### PR TITLE
Use CUDA routing gemm for LongCat

### DIFF
--- a/python/tokenspeed/runtime/models/longcat_flash.py
+++ b/python/tokenspeed/runtime/models/longcat_flash.py
@@ -21,7 +21,6 @@
 from __future__ import annotations
 
 from collections.abc import Iterable as _Iterable
-from typing import Any as _Any
 
 import torch
 import torch.nn as nn
@@ -29,7 +28,7 @@ import torch.nn.functional as _F
 from tokenspeed_kernel.ops.moe.cuda import (
     moe_finalize_fuse_shared as _moe_finalize_fuse_shared,
 )
-from tokenspeed_kernel.ops.routing.trtllm import dsv3_router_gemm as _dsv3_router_gemm
+from tokenspeed_kernel.ops.routing.cuda import dsv3_router_gemm as _dsv3_router_gemm
 from tokenspeed_kernel.platform import current_platform as _current_platform
 from transformers import PretrainedConfig as _PretrainedConfig
 
@@ -82,6 +81,7 @@ from tokenspeed.runtime.moe.expert_location import (
 )
 from tokenspeed.runtime.utils import LazyValue, add_prefix, get_colorful_logger
 from tokenspeed.runtime.utils.cuda_stream import StreamFork as _StreamFork
+from tokenspeed.runtime.utils.env import global_server_args_dict
 from tokenspeed.runtime.utils.pdl import pdl_enabled as _pdl_enabled
 
 _longcat_logger = get_colorful_logger(__name__)


### PR DESCRIPTION
## Summary
- Switch LongCat router GEMM import from tokenspeed_kernel.ops.routing.trtllm to tokenspeed_kernel.ops.routing.cuda.
- Fix touched-file lint by importing global_server_args_dict and removing an unused typing import.

## Test
- git diff --check
- python3 -m ruff check python/tokenspeed/runtime/models/longcat_flash.py