### PR TITLE
Skip FA4 registration on B300 (SM 10.3)

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flash_attn/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flash_attn/__init__.py
@@ -38,7 +38,15 @@ platform = current_platform()
 # ------------------------------------------------------------------------------
 
 
-if platform.is_nvidia and platform.is_blackwell:
+# FA4 CUTE kernels currently support SM 10.0 (B100/B200/GB200) variants only.
+# B300/GB300 (SM 10.3 / sm_103) is not yet supported by flash-attn — its CUTE
+# arch enum value falls outside the [sm_100, sm_110f] range checked in
+# FlashAttentionForwardSm100, causing an AssertionError at call time.
+if (
+    platform.is_nvidia
+    and platform.is_blackwell
+    and platform.arch_version == ArchVersion(10, 0)
+):
     try:
         from flash_attn.cute import (
             flash_attn_func,

--- a/tokenspeed-kernel/test/thirdparty/test_fa4.py
+++ b/tokenspeed-kernel/test/thirdparty/test_fa4.py
@@ -28,14 +28,14 @@ from tokenspeed_kernel.ops.attention.flash_attn import (
     flash_attn_func,
     flash_attn_varlen_func,
 )
-from tokenspeed_kernel.platform import current_platform
+from tokenspeed_kernel.platform import ArchVersion, current_platform
 
 platform = current_platform()
 torch.manual_seed(42)
 
 pytestmark = pytest.mark.skipif(
-    not platform.is_blackwell,
-    reason="FA4 smoke tests require Blackwell GPU.",
+    not (platform.is_blackwell and platform.arch_version == ArchVersion(10, 0)),
+    reason="FA4 smoke tests require SM 10.0 Blackwell GPU (B100/B200/GB200).",
 )
 
 


### PR DESCRIPTION
FA4's CUTE kernels only support SM 10.0 variants (B100/B200/GB200). On B300/GB300 (SM 10.3 / sm_103), the arch enum falls outside the [sm_100, sm_110f] range checked in FlashAttentionForwardSm100, causing an AssertionError at call time. Restrict registration to ArchVersion(10, 0) so B300 falls back to other available kernels.
