### PR TITLE
fix: Avoid large FP32 init for skipped MLA ref checks

### DIFF
--- a/tokenspeed-mla/python/tokenspeed_mla/fmha.py
+++ b/tokenspeed-mla/python/tokenspeed_mla/fmha.py
@@ -3018,6 +3018,16 @@ def run(
         use_random_int=True,
         zero_out=False,
     ):
+        if skip_ref_check and math.prod(shape) > 2**31 - 1:
+            if dtype in {cutlass.Float8E4M3FN, cutlass.Float8E5M2}:
+                torch_dtype = torch.int8
+            else:
+                torch_dtype = cutlass_torch.dtype(dtype)
+            torch_tensor = torch.zeros(*shape, dtype=torch_dtype, device="cuda")
+            cute_tensor = from_dlpack(torch_tensor, assumed_align=16)
+            cute_tensor.element_type = dtype
+            return None, cute_tensor, torch_tensor
+
         # Random int initialization can ensure the refcheck is stable
         # via different problem shapes & random seeds.
         # However, gaussian initialization can ensure the performance measurement is


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->
fix https://github.com/lightseekorg/tokenspeed/issues/11

For very large benchmark tensors, `fmha.py` still created FP32 temporary tensors and converted them to FP8 via
`cute.testing.convert`, even though reference checking was skipped. The documented B=4, KV=80K prefill case can exceed 32-bit
element counts during this initialization path and hit an XID 31 / illegal memory access on B200.

This change skips the FP32 init/convert path for large tensors in `skip_ref_check` mode and directly allocates the target
CUDA tensor used by the benchmark.

## Test Plan

<!-- How was this validated? -->
