### PR TITLE
Add first-class MLA decode routing

### DIFF
--- a/tokenspeed-kernel/README.md
+++ b/tokenspeed-kernel/README.md
@@ -131,6 +131,7 @@ backends. See `tokenspeed_kernel/plugins/README.md`.
 ```python
 from tokenspeed_kernel import (
     mha_prefill, mha_prefill_with_kvcache, mha_decode_with_kvcache,
+    mla_decode_with_kvcache,
     mm,
     moe_route, moe_dispatch, moe_experts, moe_combine, moe_fused,
     ...
@@ -141,6 +142,12 @@ Using the above platform and solution-agnostic public APIs can get the most
 value out of TokenSpeed-kernel; but one can also directly call into a
 specific solution under `ops/<family>/`, or manually `select_kernel` with
 targeted filters:
+
+MLA decode has a separate public API because its query and KV cache layout are
+different from MHA/GQA decode. `mla_decode_with_kvcache` selects the best
+registered MLA backend for the current platform. This currently registers the
+TokenSpeed MLA backend for Blackwell; Hopper intentionally has no default
+native MLA backend until a dedicated Hopper implementation lands.
 
 ```python
 from tokenspeed_kernel.selection import select_kernel, kernel_override

--- a/tokenspeed-kernel/python/tokenspeed_kernel/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/__init__.py
@@ -23,6 +23,7 @@ from tokenspeed_kernel.profiling import bootstrap_profiling_from_env
 bootstrap_profiling_from_env()
 
 from tokenspeed_kernel.ops.attention import (
+    mla_decode_with_kvcache,
     mha_decode_with_kvcache,
     mha_prefill,
     mha_prefill_with_kvcache,
@@ -46,4 +47,5 @@ __all__ = [
     "mha_prefill",
     "mha_prefill_with_kvcache",
     "mha_decode_with_kvcache",
+    "mla_decode_with_kvcache",
 ]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 # Backend registration (side-effect imports)
 import tokenspeed_kernel.ops.attention.flash_attn  # noqa: F401
 import tokenspeed_kernel.ops.attention.flashinfer  # noqa: F401
+import tokenspeed_kernel.ops.attention.tokenspeed_mla  # noqa: F401
 import tokenspeed_kernel.ops.attention.triton  # noqa: F401
 import torch
 from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
@@ -34,6 +35,7 @@ __all__ = [
     "mha_prefill",
     "mha_prefill_with_kvcache",
     "mha_decode_with_kvcache",
+    "mla_decode_with_kvcache",
 ]
 
 
@@ -362,4 +364,116 @@ def mha_decode_with_kvcache(
             sinks=sinks,
             return_lse=return_lse,
             max_seqlen_k=max_seqlen_k,
+        )
+
+
+def _mla_page_size(kv_cache: torch.Tensor) -> int:
+    if kv_cache.dim() == 3:
+        return kv_cache.shape[1]
+    if kv_cache.dim() == 4 and kv_cache.shape[1] == 1:
+        return kv_cache.shape[2]
+    if kv_cache.dim() == 4 and kv_cache.shape[2] == 1:
+        return kv_cache.shape[1]
+    raise ValueError(
+        "MLA kv_cache must be [pages, page_size, dim], "
+        "[pages, 1, page_size, dim], or [pages, page_size, 1, dim]"
+    )
+
+
+def mla_decode_with_kvcache(
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    max_seq_len: int,
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+    workspace_buffer: torch.Tensor | None = None,
+    softmax_scale: float | None = None,
+    output_scale: float = 1.0,
+    out: torch.Tensor | None = None,
+    is_var_seq: bool = True,
+    causal_mask: bool = True,
+    enable_pdl: bool = False,
+    override: str | None = None,
+) -> torch.Tensor:
+    """Paged MLA decode.
+
+    Query shape is ``[batch, query_len, num_heads, head_dim]`` where
+    ``head_dim = kv_lora_rank + qk_rope_head_dim``.  KV cache is packed MLA
+    cache in one of the accepted paged layouts.
+    """
+    if query.dim() != 4:
+        raise ValueError(
+            "MLA query must be [batch, query_len, num_heads, head_dim], "
+            f"got shape {tuple(query.shape)}"
+        )
+    expected_head_dim = kv_lora_rank + qk_rope_head_dim
+    if query.shape[-1] != expected_head_dim:
+        raise ValueError(
+            f"query head_dim must be {expected_head_dim}, got {query.shape[-1]}"
+        )
+    if kv_cache.shape[-1] != expected_head_dim:
+        raise ValueError(
+            f"kv_cache last dim must be {expected_head_dim}, got {kv_cache.shape[-1]}"
+        )
+
+    page_size = _mla_page_size(kv_cache)
+    traits = {
+        "query_len": query.shape[1],
+        "num_q_heads": query.shape[2],
+        "kv_lora_rank": kv_lora_rank,
+        "qk_rope_head_dim": qk_rope_head_dim,
+        "page_size": page_size,
+    }
+    kernel = select_kernel(
+        "attention",
+        "mla_decode_with_kvcache",
+        query.dtype,
+        features=frozenset({"mla", "paged"}),
+        traits=traits,
+        override=override,
+    )
+
+    shape_params = {
+        "batch_size": query.shape[0],
+        "query_len": query.shape[1],
+        "num_pages": kv_cache.shape[0],
+        "page_size": page_size,
+        "max_pages_per_seq": block_tables.shape[1],
+        "num_q_heads": query.shape[2],
+        "kv_lora_rank": kv_lora_rank,
+        "qk_rope_head_dim": qk_rope_head_dim,
+        "max_seq_len": max_seq_len,
+    }
+    ShapeCapture.get().record(
+        "attention",
+        "mla_decode_with_kvcache",
+        kernel.name,
+        query.dtype,
+        shape_params,
+    )
+
+    with kernel_scope(
+        "attention",
+        "mla_decode_with_kvcache",
+        query.dtype,
+        kernel_name=kernel.name,
+        **shape_params,
+    ):
+        return kernel(
+            query=query,
+            kv_cache=kv_cache,
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            max_seq_len=max_seq_len,
+            kv_lora_rank=kv_lora_rank,
+            qk_rope_head_dim=qk_rope_head_dim,
+            workspace_buffer=workspace_buffer,
+            softmax_scale=softmax_scale,
+            output_scale=output_scale,
+            out=out,
+            is_var_seq=is_var_seq,
+            causal_mask=causal_mask,
+            enable_pdl=enable_pdl,
         )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/tokenspeed_mla/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/tokenspeed_mla/__init__.py
@@ -20,7 +20,13 @@
 
 """TokenSpeed MLA kernels exposed through tokenspeed-kernel."""
 
-from tokenspeed_kernel.registry import error_fn
+from __future__ import annotations
+
+import math
+
+import torch
+from tokenspeed_kernel.platform import ArchVersion, CapabilityRequirement
+from tokenspeed_kernel.registry import Priority, error_fn, register_kernel
 
 try:
     from tokenspeed_mla import (
@@ -37,10 +43,66 @@ except ImportError:
     tokenspeed_mla_prefill = error_fn
     warmup_compile_prefill = error_fn
 
+
+@register_kernel(
+    "attention",
+    "mla_decode_with_kvcache",
+    name="tokenspeed_mla_decode_with_kvcache",
+    features={"mla", "paged"},
+    solution="tokenspeed_mla",
+    capability=CapabilityRequirement(
+        min_arch_version=ArchVersion(10, 0),
+        max_arch_version=ArchVersion(10, 3),
+        vendors=frozenset({"nvidia"}),
+    ),
+    dtypes={torch.float16, torch.bfloat16, torch.float8_e4m3fn},
+    priority=Priority.SPECIALIZED + 3,
+    tags={"latency"},
+)
+def tokenspeed_mla_decode_with_kvcache(
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    max_seq_len: int,
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+    workspace_buffer: torch.Tensor | None = None,
+    softmax_scale: float | None = None,
+    output_scale: float = 1.0,
+    out: torch.Tensor | None = None,
+    is_var_seq: bool = True,
+    causal_mask: bool = True,
+    enable_pdl: bool = False,
+) -> torch.Tensor:
+    if workspace_buffer is None:
+        raise ValueError("workspace_buffer is required for TokenSpeed MLA decode")
+    return tokenspeed_mla_decode(
+        query=query,
+        kv_cache=kv_cache,
+        workspace_buffer=workspace_buffer,
+        kv_lora_rank=kv_lora_rank,
+        qk_rope_head_dim=qk_rope_head_dim,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        max_seq_len=max_seq_len,
+        softmax_scale=(
+            softmax_scale
+            if softmax_scale is not None
+            else 1.0 / math.sqrt(query.shape[-1])
+        ),
+        output_scale=output_scale,
+        out=out,
+        is_var_seq=is_var_seq,
+        causal_mask=causal_mask,
+        enable_pdl=enable_pdl,
+    )
+
 __all__ = [
     "get_num_sm",
     "mla_kv_pack_quantize_fp8",
     "tokenspeed_mla_decode",
+    "tokenspeed_mla_decode_with_kvcache",
     "tokenspeed_mla_prefill",
     "warmup_compile_prefill",
 ]

--- a/tokenspeed-kernel/test/ops/test_mla_decode_selection.py
+++ b/tokenspeed-kernel/test/ops/test_mla_decode_selection.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+import torch
+from tokenspeed_kernel.platform import Platform
+from tokenspeed_kernel.registry import KernelRegistry, KernelSpec
+from tokenspeed_kernel.selection import NoKernelFoundError, select_kernel
+
+pytestmark = pytest.mark.usefixtures("fresh_registry")
+
+_MLA_FEATURES = frozenset({"mla", "paged"})
+
+
+@pytest.fixture(autouse=True)
+def _reset_platform_after_test():
+    yield
+    Platform.reset()
+
+
+def _reload_mla_registrations(platform):
+    Platform.override(platform)
+    for module_name in (
+        "tokenspeed_kernel.ops.attention.tokenspeed_mla",
+        "tokenspeed_kernel.ops.attention",
+    ):
+        if module_name in sys.modules:
+            importlib.reload(sys.modules[module_name])
+        else:
+            importlib.import_module(module_name)
+
+
+def test_hopper_does_not_select_blackwell_mla_decode(h100_platform):
+    _reload_mla_registrations(h100_platform)
+
+    with pytest.raises(NoKernelFoundError):
+        select_kernel(
+            "attention",
+            "mla_decode_with_kvcache",
+            torch.bfloat16,
+            features=_MLA_FEATURES,
+            platform=h100_platform,
+            traits={"query_len": 1},
+        )
+
+
+def test_blackwell_selects_tokenspeed_mla_decode(b200_platform):
+    _reload_mla_registrations(b200_platform)
+
+    selected = select_kernel(
+        "attention",
+        "mla_decode_with_kvcache",
+        torch.float8_e4m3fn,
+        features=_MLA_FEATURES,
+        platform=b200_platform,
+        traits={"query_len": 1},
+    )
+
+    assert selected.name == "tokenspeed_mla_decode_with_kvcache"
+
+
+def test_ampere_has_no_mla_decode_kernel(a100_platform):
+    _reload_mla_registrations(a100_platform)
+
+    with pytest.raises(NoKernelFoundError):
+        select_kernel(
+            "attention",
+            "mla_decode_with_kvcache",
+            torch.bfloat16,
+            features=_MLA_FEATURES,
+            platform=a100_platform,
+            traits={"query_len": 1},
+        )
+
+
+def test_public_mla_decode_api_passes_mla_shaped_inputs(h100_platform):
+    _reload_mla_registrations(h100_platform)
+
+    from tokenspeed_kernel.ops.attention import mla_decode_with_kvcache
+
+    captured = {}
+    expected = torch.empty((2, 1, 4, 512), dtype=torch.bfloat16)
+
+    def _impl(**kwargs):
+        captured.update(kwargs)
+        return expected
+
+    KernelRegistry.get().register(
+        KernelSpec(
+            name="test_mla_decode",
+            family="attention",
+            mode="mla_decode_with_kvcache",
+            solution="test",
+            features=_MLA_FEATURES,
+            dtypes=frozenset({torch.bfloat16}),
+        ),
+        _impl,
+    )
+
+    query = torch.empty((2, 1, 4, 576), dtype=torch.bfloat16)
+    kv_cache = torch.empty((8, 64, 576), dtype=torch.bfloat16)
+    block_tables = torch.zeros((2, 8), dtype=torch.int32)
+    seq_lens = torch.tensor([64, 128], dtype=torch.int32)
+
+    result = mla_decode_with_kvcache(
+        query=query,
+        kv_cache=kv_cache,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        max_seq_len=128,
+        kv_lora_rank=512,
+        qk_rope_head_dim=64,
+        softmax_scale=0.07216882,
+        override="test_mla_decode",
+    )
+
+    assert result is expected
+    assert captured["query"] is query
+    assert captured["kv_cache"] is kv_cache
+    assert captured["block_tables"] is block_tables
+    assert captured["seq_lens"] is seq_lens
+    assert captured["kv_lora_rank"] == 512
+    assert captured["qk_rope_head_dim"] == 64
+    assert captured["softmax_scale"] == 0.07216882

--- a/tokenspeed-mla/bench_mla_decode.py
+++ b/tokenspeed-mla/bench_mla_decode.py
@@ -1,0 +1,927 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""MLA Decode Benchmark: TokenSpeed MLA vs FlashMLA vs FlashInfer MLA.
+
+Benchmarks MLA decode latency across multiple backends on Blackwell GPUs.
+Produces a unified comparison table (ASCII + CSV).
+
+Usage:
+    # Benchmark all available backends with default shapes
+    python bench_mla_decode.py
+
+    # Only TokenSpeed MLA
+    python bench_mla_decode.py --backends tokenspeed
+
+    # TokenSpeed vs FlashMLA
+    python bench_mla_decode.py --backends tokenspeed flash_mla
+
+    # Custom shapes
+    python bench_mla_decode.py --batch-sizes 1,4,8 --seq-lens-kv 8192,32768,81920
+
+    # FP8 input
+    python bench_mla_decode.py --dtype fp8
+
+    # Export results
+    python bench_mla_decode.py --export csv --output mla_decode_results.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import sys
+import time
+from dataclasses import dataclass
+
+import torch
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DecodeShape:
+    batch_size: int
+    seq_len_q: int
+    seq_len_kv: int
+    num_heads: int
+    qk_nope_head_dim: int
+    kv_lora_rank: int
+    qk_rope_head_dim: int
+    page_size: int
+
+
+@dataclass
+class BenchmarkResult:
+    backend: str
+    dtype: str
+    batch_size: int
+    seq_len_q: int
+    seq_len_kv: int
+    num_heads: int
+    qk_nope_head_dim: int
+    kv_lora_rank: int
+    qk_rope_head_dim: int
+    page_size: int
+    median_latency_us: float
+    p90_latency_us: float
+    p99_latency_us: float
+    min_latency_us: float
+    max_latency_us: float
+    warmup_iters: int
+    bench_iters: int
+    timestamp: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Default decode shapes
+# ---------------------------------------------------------------------------
+
+DEFAULT_DECODE_SHAPES = [
+    # (batch_size, seq_len_q, seq_len_kv, num_heads)
+    (1, 1, 8192, 16),
+    (1, 1, 32768, 16),
+    (1, 1, 81920, 16),
+    (4, 1, 8192, 16),
+    (4, 1, 32768, 16),
+    (4, 1, 81920, 16),
+    (1, 1, 8192, 32),
+    (1, 1, 32768, 32),
+    (1, 1, 81920, 32),
+    (4, 1, 8192, 32),
+    (4, 1, 32768, 32),
+    (4, 1, 81920, 32),
+    (4, 4, 81920, 16),
+    (4, 4, 81920, 32),
+    (8, 1, 81920, 16),
+    (8, 1, 81920, 32),
+    (16, 1, 81920, 16),
+    (16, 1, 81920, 32),
+]
+
+# DeepSeek V3 MLA config
+QK_NOPE_HEAD_DIM = 128
+KV_LORA_RANK = 512
+QK_ROPE_HEAD_DIM = 64
+PAGE_SIZE = 64
+
+
+# ---------------------------------------------------------------------------
+# Timing utilities
+# ---------------------------------------------------------------------------
+
+
+def benchmark_fn(fn, warmup_iters: int = 10, bench_iters: int = 50) -> list[float]:
+    """Run fn multiple times and return latencies in microseconds."""
+    # Warmup
+    for _ in range(warmup_iters):
+        fn()
+    torch.cuda.synchronize()
+
+    start_events = [torch.cuda.Event(enable_timing=True) for _ in range(bench_iters)]
+    end_events = [torch.cuda.Event(enable_timing=True) for _ in range(bench_iters)]
+
+    for i in range(bench_iters):
+        start_events[i].record()
+        fn()
+        end_events[i].record()
+
+    torch.cuda.synchronize()
+    latencies = [
+        s.elapsed_time(e) * 1000.0 for s, e in zip(start_events, end_events)  # ms -> us
+    ]
+    return sorted(latencies)
+
+
+def percentile(sorted_vals: list[float], p: float) -> float:
+    if not sorted_vals:
+        return 0.0
+    if len(sorted_vals) == 1:
+        return float(sorted_vals[0])
+    rank = (len(sorted_vals) - 1) * (p / 100.0)
+    lo = int(math.floor(rank))
+    hi = int(math.ceil(rank))
+    if lo == hi:
+        return float(sorted_vals[lo])
+    w = rank - float(lo)
+    return float(sorted_vals[lo]) * (1.0 - w) + float(sorted_vals[hi]) * w
+
+
+def make_block_tables(
+    batch_size: int,
+    num_pages_per_seq: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Create one contiguous physical page range per request."""
+    return (
+        torch.arange(
+            batch_size * num_pages_per_seq,
+            dtype=torch.int32,
+            device=device,
+        )
+        .reshape(batch_size, num_pages_per_seq)
+        .contiguous()
+    )
+
+
+def randn_tensor(
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    source_dtype = torch.bfloat16 if dtype == torch.float8_e4m3fn else dtype
+    return torch.randn(shape, dtype=source_dtype, device=device).to(dtype)
+
+
+# ---------------------------------------------------------------------------
+# Backend: TokenSpeed MLA Decode
+# ---------------------------------------------------------------------------
+
+
+def bench_tokenspeed_mla_decode(
+    shape: DecodeShape,
+    dtype: torch.dtype,
+    device: torch.device,
+    warmup_iters: int,
+    bench_iters: int,
+    softmax_scale: float,
+) -> BenchmarkResult | None:
+    try:
+        from tokenspeed_mla import get_num_sm, tokenspeed_mla_decode
+    except ImportError:
+        print("  [SKIP] tokenspeed_mla not available", flush=True)
+        return None
+
+    from tokenspeed_mla.mla_decode import _get_split_kv_and_workspace_size
+
+    B, q_len, H = shape.batch_size, shape.seq_len_q, shape.num_heads
+    kv_lora_rank = shape.kv_lora_rank
+    qk_rope_head_dim = shape.qk_rope_head_dim
+    D_qk = kv_lora_rank + qk_rope_head_dim
+    page_size = shape.page_size
+    max_seq_len = shape.seq_len_kv
+
+    q_dtype = dtype
+
+    # Allocate inputs
+    query = randn_tensor((B, q_len, H, D_qk), q_dtype, device)
+    num_pages = (max_seq_len + page_size - 1) // page_size
+    num_pages_total = B * num_pages
+    kv_cache = randn_tensor((num_pages_total, page_size, D_qk), q_dtype, device)
+    block_tables = make_block_tables(B, num_pages, device)
+    seq_lens = torch.full((B,), max_seq_len, dtype=torch.int32, device=device)
+
+    # Workspace
+    num_sms = get_num_sm(device)
+    # fold_sq logic
+    mma_m_tile = 128
+    fold_sq = H < mma_m_tile and H * q_len <= mma_m_tile
+    H_eff = H * q_len if fold_sq else H
+    q_len_eff = 1 if fold_sq else q_len
+    split_kv, workspace_size = _get_split_kv_and_workspace_size(
+        B, q_len_eff, H_eff, kv_lora_rank, num_sms
+    )
+    workspace_buffer = torch.zeros(
+        max(workspace_size, 1), dtype=torch.int8, device=device
+    )
+
+    # Warmup + JIT compile (first call triggers compile)
+    def run():
+        tokenspeed_mla_decode(
+            query=query,
+            kv_cache=kv_cache,
+            workspace_buffer=workspace_buffer,
+            kv_lora_rank=kv_lora_rank,
+            qk_rope_head_dim=qk_rope_head_dim,
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            max_seq_len=max_seq_len,
+            softmax_scale=softmax_scale,
+            enable_pdl=False,
+        )
+
+    # Extra warmup for JIT
+    print(
+        "    tokenspeed_mla: compiling (may take a while on first run)...",
+        end="",
+        flush=True,
+    )
+    run()
+    torch.cuda.synchronize()
+    print(" done", flush=True)
+
+    latencies = benchmark_fn(run, warmup_iters, bench_iters)
+
+    return BenchmarkResult(
+        backend="tokenspeed_mla",
+        dtype=str(dtype),
+        batch_size=B,
+        seq_len_q=q_len,
+        seq_len_kv=max_seq_len,
+        num_heads=H,
+        qk_nope_head_dim=shape.qk_nope_head_dim,
+        kv_lora_rank=kv_lora_rank,
+        qk_rope_head_dim=qk_rope_head_dim,
+        page_size=page_size,
+        median_latency_us=percentile(latencies, 50),
+        p90_latency_us=percentile(latencies, 90),
+        p99_latency_us=percentile(latencies, 99),
+        min_latency_us=latencies[0],
+        max_latency_us=latencies[-1],
+        warmup_iters=warmup_iters,
+        bench_iters=bench_iters,
+        timestamp=time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backend: FlashMLA
+# ---------------------------------------------------------------------------
+
+
+def bench_flash_mla_decode(
+    shape: DecodeShape,
+    dtype: torch.dtype,
+    device: torch.device,
+    warmup_iters: int,
+    bench_iters: int,
+    softmax_scale: float,
+) -> BenchmarkResult | None:
+    try:
+        from flash_mla import flash_mla_with_kvcache, get_mla_metadata
+    except ImportError:
+        print("  [SKIP] flash_mla not available", flush=True)
+        return None
+
+    B, q_len, H = shape.batch_size, shape.seq_len_q, shape.num_heads
+    kv_lora_rank = shape.kv_lora_rank
+    qk_rope_head_dim = shape.qk_rope_head_dim
+    D_qk = kv_lora_rank + qk_rope_head_dim
+    page_size = shape.page_size
+    max_seq_len = shape.seq_len_kv
+
+    # FlashMLA only supports BF16
+    if dtype != torch.bfloat16:
+        print(f"  [SKIP] flash_mla only supports bf16, got {dtype}", flush=True)
+        return None
+
+    # Allocate inputs. FlashMLA expects q as [B, q_len, H, D] and k_cache as
+    # [num_pages, page_size, 1, D].
+    query = randn_tensor((B, q_len, H, D_qk), dtype, device)
+    num_pages = (max_seq_len + page_size - 1) // page_size
+    num_pages_total = B * num_pages
+    kv_cache = randn_tensor((num_pages_total, page_size, 1, D_qk), dtype, device)
+    block_tables = make_block_tables(B, num_pages, device)
+    seq_lens = torch.full((B,), max_seq_len, dtype=torch.int32, device=device)
+
+    # FlashMLA metadata
+    cache_seqlens = seq_lens
+    tile_scheduler_metadata, num_splits = get_mla_metadata(cache_seqlens, q_len * H, 1)
+
+    def run():
+        flash_mla_with_kvcache(
+            q=query,
+            k_cache=kv_cache,
+            block_table=block_tables,
+            cache_seqlens=cache_seqlens,
+            head_dim_v=kv_lora_rank,
+            tile_scheduler_metadata=tile_scheduler_metadata,
+            num_splits=num_splits,
+            softmax_scale=softmax_scale,
+            causal=True,
+        )
+
+    print(f"    flash_mla: compiling...", end="", flush=True)
+    run()
+    torch.cuda.synchronize()
+    print(" done", flush=True)
+
+    latencies = benchmark_fn(run, warmup_iters, bench_iters)
+
+    return BenchmarkResult(
+        backend="flash_mla",
+        dtype=str(dtype),
+        batch_size=B,
+        seq_len_q=q_len,
+        seq_len_kv=max_seq_len,
+        num_heads=H,
+        qk_nope_head_dim=shape.qk_nope_head_dim,
+        kv_lora_rank=kv_lora_rank,
+        qk_rope_head_dim=qk_rope_head_dim,
+        page_size=page_size,
+        median_latency_us=percentile(latencies, 50),
+        p90_latency_us=percentile(latencies, 90),
+        p99_latency_us=percentile(latencies, 99),
+        min_latency_us=latencies[0],
+        max_latency_us=latencies[-1],
+        warmup_iters=warmup_iters,
+        bench_iters=bench_iters,
+        timestamp=time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backend: FlashInfer MLA
+# ---------------------------------------------------------------------------
+
+
+def bench_flashinfer_mla_decode(
+    shape: DecodeShape,
+    dtype: torch.dtype,
+    device: torch.device,
+    warmup_iters: int,
+    bench_iters: int,
+    softmax_scale: float,
+) -> BenchmarkResult | None:
+    try:
+        from flashinfer.mla import BatchMLAPagedAttentionWrapper
+    except ImportError:
+        print("  [SKIP] flashinfer.mla not available", flush=True)
+        return None
+
+    B, q_len, H = shape.batch_size, shape.seq_len_q, shape.num_heads
+    kv_lora_rank = shape.kv_lora_rank
+    qk_rope_head_dim = shape.qk_rope_head_dim
+    D_qk = kv_lora_rank + qk_rope_head_dim
+    page_size = shape.page_size
+    max_seq_len = shape.seq_len_kv
+
+    # FlashInfer MLA on Blackwell — check availability
+    if dtype not in (torch.bfloat16, torch.float16):
+        print(
+            f"  [SKIP] flashinfer.mla only supports bf16/fp16, got {dtype}",
+            flush=True,
+        )
+        return None
+
+    # Allocate inputs
+    query = randn_tensor((B, q_len, H, D_qk), dtype, device)
+    query_flat = query.reshape(B * q_len, H, D_qk)
+    q_nope = query_flat[..., :kv_lora_rank].contiguous()
+    q_pe = query_flat[..., kv_lora_rank:].contiguous()
+    num_pages = (max_seq_len + page_size - 1) // page_size
+    num_pages_total = B * num_pages
+    kv_cache = randn_tensor((num_pages_total, page_size, D_qk), dtype, device)
+    ckv_cache = kv_cache[:, :, :kv_lora_rank].contiguous()
+    kpe_cache = kv_cache[:, :, kv_lora_rank:].contiguous()
+    block_tables = make_block_tables(B, num_pages, device)
+    kv_indices = block_tables.reshape(-1).contiguous()
+    seq_lens = torch.full((B,), max_seq_len, dtype=torch.int32, device=device)
+    qo_indptr = torch.arange(B + 1, dtype=torch.int32, device=device) * q_len
+    kv_indptr = torch.arange(B + 1, dtype=torch.int32, device=device) * num_pages
+
+    workspace = torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device=device)
+    wrapper = BatchMLAPagedAttentionWrapper(workspace, backend="auto")
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        seq_lens,
+        H,
+        kv_lora_rank,
+        qk_rope_head_dim,
+        page_size,
+        True,
+        softmax_scale,
+        dtype,
+        dtype,
+    )
+
+    def run():
+        wrapper.run(q_nope, q_pe, ckv_cache, kpe_cache, return_lse=False)
+
+    print(f"    flashinfer_mla: compiling...", end="", flush=True)
+    run()
+    torch.cuda.synchronize()
+    print(" done", flush=True)
+
+    latencies = benchmark_fn(run, warmup_iters, bench_iters)
+
+    return BenchmarkResult(
+        backend="flashinfer_mla",
+        dtype=str(dtype),
+        batch_size=B,
+        seq_len_q=q_len,
+        seq_len_kv=max_seq_len,
+        num_heads=H,
+        qk_nope_head_dim=shape.qk_nope_head_dim,
+        kv_lora_rank=kv_lora_rank,
+        qk_rope_head_dim=qk_rope_head_dim,
+        page_size=page_size,
+        median_latency_us=percentile(latencies, 50),
+        p90_latency_us=percentile(latencies, 90),
+        p99_latency_us=percentile(latencies, 99),
+        min_latency_us=latencies[0],
+        max_latency_us=latencies[-1],
+        warmup_iters=warmup_iters,
+        bench_iters=bench_iters,
+        timestamp=time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backend: TRT-LLM Gen MLA decode (via FlashInfer wrapper)
+# ---------------------------------------------------------------------------
+
+
+def bench_trtllm_mla_decode(
+    shape: DecodeShape,
+    dtype: torch.dtype,
+    device: torch.device,
+    warmup_iters: int,
+    bench_iters: int,
+    softmax_scale: float,
+) -> BenchmarkResult | None:
+    try:
+        from flashinfer.mla import trtllm_batch_decode_with_kv_cache_mla
+    except ImportError:
+        print("  [SKIP] trtllm_mla (flashinfer.mla) not available", flush=True)
+        return None
+
+    B, q_len, H = shape.batch_size, shape.seq_len_q, shape.num_heads
+    kv_lora_rank = shape.kv_lora_rank
+    qk_rope_head_dim = shape.qk_rope_head_dim
+    D_qk = kv_lora_rank + qk_rope_head_dim
+    page_size = shape.page_size
+    max_seq_len = shape.seq_len_kv
+
+    if dtype not in (torch.bfloat16, torch.float16):
+        print(f"  [SKIP] trtllm_mla only supports bf16/fp16, got {dtype}", flush=True)
+        return None
+
+    # Allocate
+    query = randn_tensor((B, q_len, H, D_qk), dtype, device)
+    num_pages = (max_seq_len + page_size - 1) // page_size
+    num_pages_total = B * num_pages
+    kv_cache = randn_tensor((num_pages_total, 1, page_size, D_qk), dtype, device)
+    block_tables = make_block_tables(B, num_pages, device)
+    seq_lens = torch.full((B,), max_seq_len, dtype=torch.int32, device=device)
+    workspace = torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device=device)
+
+    def run():
+        trtllm_batch_decode_with_kv_cache_mla(
+            query=query,
+            kv_cache=kv_cache,
+            workspace_buffer=workspace,
+            qk_nope_head_dim=shape.qk_nope_head_dim,
+            kv_lora_rank=kv_lora_rank,
+            qk_rope_head_dim=qk_rope_head_dim,
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            max_seq_len=max_seq_len,
+            bmm1_scale=softmax_scale,
+        )
+
+    print(f"    trtllm_mla: compiling...", end="", flush=True)
+    run()
+    torch.cuda.synchronize()
+    print(" done", flush=True)
+
+    latencies = benchmark_fn(run, warmup_iters, bench_iters)
+
+    return BenchmarkResult(
+        backend="trtllm_mla",
+        dtype=str(dtype),
+        batch_size=B,
+        seq_len_q=q_len,
+        seq_len_kv=max_seq_len,
+        num_heads=H,
+        qk_nope_head_dim=shape.qk_nope_head_dim,
+        kv_lora_rank=kv_lora_rank,
+        qk_rope_head_dim=qk_rope_head_dim,
+        page_size=page_size,
+        median_latency_us=percentile(latencies, 50),
+        p90_latency_us=percentile(latencies, 90),
+        p99_latency_us=percentile(latencies, 99),
+        min_latency_us=latencies[0],
+        max_latency_us=latencies[-1],
+        warmup_iters=warmup_iters,
+        bench_iters=bench_iters,
+        timestamp=time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Table formatting
+# ---------------------------------------------------------------------------
+
+
+def format_results_table(results: list[BenchmarkResult]) -> str:
+    if not results:
+        return "No results."
+
+    # Group by shape
+    from collections import defaultdict
+
+    groups: dict[tuple, list[BenchmarkResult]] = defaultdict(list)
+    for r in results:
+        key = (r.batch_size, r.seq_len_q, r.seq_len_kv, r.num_heads)
+        groups[key].append(r)
+
+    lines: list[str] = []
+    gpu_name = torch.cuda.get_device_name(0) if torch.cuda.is_available() else "N/A"
+    dtype_str = results[0].dtype if results else "N/A"
+    cfg = results[0]
+    lines.append(f"MLA Decode Benchmark | GPU: {gpu_name} | dtype: {dtype_str}")
+    lines.append(
+        "qk_nope_head_dim="
+        f"{cfg.qk_nope_head_dim}, kv_lora_rank={cfg.kv_lora_rank}, "
+        f"qk_rope_head_dim={cfg.qk_rope_head_dim}, page_size={cfg.page_size}"
+    )
+    lines.append("")
+
+    for key in sorted(groups.keys()):
+        B, q_len, kv_len, H = key
+        group = sorted(groups[key], key=lambda r: r.median_latency_us)
+        lines.append(f"B={B}, q_len={q_len}, kv_len={kv_len}, H={H}")
+
+        header = (
+            f"{'Backend':<20} {'p50(us)':>10} {'p90(us)':>10} "
+            f"{'p99(us)':>10} {'min(us)':>10} {'max(us)':>10}"
+        )
+        lines.append(header)
+        lines.append("-" * len(header))
+
+        for r in group:
+            lines.append(
+                f"{r.backend:<20} {r.median_latency_us:>10.1f} "
+                f"{r.p90_latency_us:>10.1f} {r.p99_latency_us:>10.1f} "
+                f"{r.min_latency_us:>10.1f} {r.max_latency_us:>10.1f}"
+            )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_speedup_table(
+    results: list[BenchmarkResult],
+    baseline: str = "flash_mla",
+) -> str:
+    """Format a speedup table relative to a baseline backend."""
+    if not results:
+        return "No results."
+
+    from collections import defaultdict
+
+    groups: dict[tuple, dict[str, BenchmarkResult]] = defaultdict(dict)
+    for r in results:
+        key = (r.batch_size, r.seq_len_q, r.seq_len_kv, r.num_heads)
+        groups[key][r.backend] = r
+
+    lines: list[str] = []
+    lines.append(f"MLA Decode Speedup vs {baseline}")
+    lines.append("")
+
+    backends = sorted(set(r.backend for r in results) - {baseline})
+    header = f"{'Shape':<30}" + "".join(f" {b:>12}" for b in backends)
+    lines.append(header)
+    lines.append("-" * len(header))
+
+    for key in sorted(groups.keys()):
+        B, q_len, kv_len, H = key
+        shape_str = f"B={B},q={q_len},kv={kv_len},H={H}"
+        baseline_r = groups[key].get(baseline)
+        if baseline_r is None:
+            continue
+        row = f"{shape_str:<30}"
+        for b in backends:
+            r = groups[key].get(b)
+            if r is not None:
+                speedup = baseline_r.median_latency_us / r.median_latency_us
+                row += f" {speedup:>11.2f}x"
+            else:
+                row += f" {'N/A':>12}"
+        lines.append(row)
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+
+def export_csv(results: list[BenchmarkResult], path: str) -> None:
+    if not results:
+        return
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=list(results[0].__dataclass_fields__.keys()),
+        )
+        writer.writeheader()
+        for r in results:
+            writer.writerow(r.__dict__)
+
+
+def export_json(results: list[BenchmarkResult], path: str) -> None:
+    with open(path, "w") as f:
+        json.dump([r.__dict__ for r in results], f, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+BACKEND_REGISTRY = {
+    "tokenspeed": bench_tokenspeed_mla_decode,
+    "flash_mla": bench_flash_mla_decode,
+    "flashinfer_mla": bench_flashinfer_mla_decode,
+    "trtllm_mla": bench_trtllm_mla_decode,
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "MLA Decode Benchmark: " "TokenSpeed vs FlashMLA vs FlashInfer vs TRT-LLM"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  python bench_mla_decode.py
+  python bench_mla_decode.py --backends tokenspeed flash_mla
+  python bench_mla_decode.py --dtype fp8
+  python bench_mla_decode.py --batch-sizes 1,4,8,16 --seq-lens-kv 8192,81920
+  python bench_mla_decode.py --export csv --output results.csv
+""",
+    )
+    parser.add_argument(
+        "--backends",
+        nargs="+",
+        default=["tokenspeed", "flash_mla", "flashinfer_mla", "trtllm_mla"],
+        choices=list(BACKEND_REGISTRY.keys()),
+        help="Backends to benchmark (default: all available)",
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=["bf16", "fp16", "fp8"],
+        default="bf16",
+        help="Input dtype (default: bf16)",
+    )
+    parser.add_argument(
+        "--batch-sizes",
+        type=str,
+        default=None,
+        help="Comma-separated batch sizes (default: from standard shapes)",
+    )
+    parser.add_argument(
+        "--seq-lens-kv",
+        type=str,
+        default=None,
+        help="Comma-separated KV sequence lengths (default: from standard shapes)",
+    )
+    parser.add_argument(
+        "--num-heads",
+        type=str,
+        default=None,
+        help="Comma-separated num_heads values (default: 16,32)",
+    )
+    parser.add_argument(
+        "--qk-nope-head-dim",
+        type=int,
+        default=QK_NOPE_HEAD_DIM,
+        help=f"QK non-RoPE head dim (default: {QK_NOPE_HEAD_DIM})",
+    )
+    parser.add_argument(
+        "--kv-lora-rank",
+        type=int,
+        default=KV_LORA_RANK,
+        help=f"KV LoRA rank (default: {KV_LORA_RANK})",
+    )
+    parser.add_argument(
+        "--qk-rope-head-dim",
+        type=int,
+        default=QK_ROPE_HEAD_DIM,
+        help=f"QK RoPE head dim (default: {QK_ROPE_HEAD_DIM})",
+    )
+    parser.add_argument(
+        "--page-size",
+        type=int,
+        default=PAGE_SIZE,
+        help=f"Page size (default: {PAGE_SIZE})",
+    )
+    parser.add_argument(
+        "--warmup-iters",
+        type=int,
+        default=10,
+        help="Number of warmup iterations (default: 10)",
+    )
+    parser.add_argument(
+        "--bench-iters",
+        type=int,
+        default=50,
+        help="Number of benchmark iterations (default: 50)",
+    )
+    parser.add_argument(
+        "--export",
+        choices=["csv", "json"],
+        default=None,
+        help="Export format for results",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="mla_decode_benchmark",
+        help="Output file path (without extension for json)",
+    )
+    parser.add_argument(
+        "--speedup-baseline",
+        type=str,
+        default="flash_mla",
+        help="Baseline backend for speedup comparison (default: flash_mla)",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if not torch.cuda.is_available():
+        print("ERROR: CUDA is not available. This benchmark requires a GPU.")
+        sys.exit(1)
+
+    device = torch.device("cuda")
+    gpu_name = torch.cuda.get_device_name(0)
+    gpu_mem = torch.cuda.get_device_properties(0).total_mem / (1024**3)
+
+    dtype_map = {
+        "bf16": torch.bfloat16,
+        "fp16": torch.float16,
+        "fp8": torch.float8_e4m3fn,
+    }
+    dtype = dtype_map[args.dtype]
+    softmax_scale = 1.0 / math.sqrt(args.qk_nope_head_dim + args.qk_rope_head_dim)
+
+    # Build shapes
+    if args.batch_sizes or args.seq_lens_kv or args.num_heads:
+        batch_sizes = (
+            [int(x) for x in args.batch_sizes.split(",")]
+            if args.batch_sizes
+            else [1, 4]
+        )
+        seq_lens_kv = (
+            [int(x) for x in args.seq_lens_kv.split(",")]
+            if args.seq_lens_kv
+            else [8192, 32768, 81920]
+        )
+        num_heads_list = (
+            [int(x) for x in args.num_heads.split(",")] if args.num_heads else [16, 32]
+        )
+        shapes = []
+        for B in batch_sizes:
+            for kv_len in seq_lens_kv:
+                for H in num_heads_list:
+                    shapes.append(
+                        DecodeShape(
+                            batch_size=B,
+                            seq_len_q=1,
+                            seq_len_kv=kv_len,
+                            num_heads=H,
+                            qk_nope_head_dim=args.qk_nope_head_dim,
+                            kv_lora_rank=args.kv_lora_rank,
+                            qk_rope_head_dim=args.qk_rope_head_dim,
+                            page_size=args.page_size,
+                        )
+                    )
+    else:
+        shapes = [
+            DecodeShape(
+                batch_size=B,
+                seq_len_q=q_len,
+                seq_len_kv=kv_len,
+                num_heads=H,
+                qk_nope_head_dim=args.qk_nope_head_dim,
+                kv_lora_rank=args.kv_lora_rank,
+                qk_rope_head_dim=args.qk_rope_head_dim,
+                page_size=args.page_size,
+            )
+            for B, q_len, kv_len, H in DEFAULT_DECODE_SHAPES
+        ]
+
+    print("=" * 80)
+    print("MLA Decode Benchmark")
+    print("=" * 80)
+    print(f"GPU:       {gpu_name} ({gpu_mem:.1f} GB)")
+    print(f"dtype:     {args.dtype}")
+    print(f"Backends:  {args.backends}")
+    print(f"Shapes:    {len(shapes)} configurations")
+    print(f"Warmup:    {args.warmup_iters} iters")
+    print(f"Benchmark: {args.bench_iters} iters")
+    print(f"softmax_scale: {softmax_scale:.6f}")
+    print("=" * 80)
+
+    all_results: list[BenchmarkResult] = []
+
+    for shape in shapes:
+        print(
+            f"\n--- B={shape.batch_size}, q={shape.seq_len_q}, "
+            f"kv={shape.seq_len_kv}, H={shape.num_heads} ---"
+        )
+
+        for backend_name in args.backends:
+            bench_fn = BACKEND_REGISTRY[backend_name]
+            result = bench_fn(
+                shape=shape,
+                dtype=dtype,
+                device=device,
+                warmup_iters=args.warmup_iters,
+                bench_iters=args.bench_iters,
+                softmax_scale=softmax_scale,
+            )
+            if result is not None:
+                all_results.append(result)
+                print(
+                    f"    => p50={result.median_latency_us:.1f}us, "
+                    f"p90={result.p90_latency_us:.1f}us, "
+                    f"p99={result.p99_latency_us:.1f}us"
+                )
+
+    # Print results
+    print("\n" + "=" * 80)
+    print("RESULTS")
+    print("=" * 80)
+    print(format_results_table(all_results))
+
+    # Speedup table (if baseline exists)
+    baseline_backends = set(r.backend for r in all_results)
+    if args.speedup_baseline in baseline_backends and len(baseline_backends) > 1:
+        print("\n" + "=" * 80)
+        print(format_speedup_table(all_results, baseline=args.speedup_baseline))
+
+    # Export
+    if args.export == "csv":
+        out_path = args.output if args.output.endswith(".csv") else f"{args.output}.csv"
+        export_csv(all_results, out_path)
+        print(f"\nResults exported to {out_path}")
+    elif args.export == "json":
+        out_path = (
+            args.output if args.output.endswith(".json") else f"{args.output}.json"
+        )
+        export_json(all_results, out_path)
+        print(f"\nResults exported to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tokenspeed-mla/bench_mla_prefill.py
+++ b/tokenspeed-mla/bench_mla_prefill.py
@@ -1,0 +1,676 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""MLA Prefill Benchmark: TokenSpeed MLA vs FlashInfer.
+
+Benchmarks MLA prefill latency across backends on Blackwell GPUs.
+Matches the use cases from the TokenSpeed README:
+
+    use case 1: batch_size=1, seqlen_qo=8K,  seqlen_kv=8K
+    use case 2: batch_size=1, seqlen_qo=8K,  seqlen_kv=32K
+    use case 3: batch_size=1, seqlen_qo=8K,  seqlen_kv=64K
+    use case 4: batch_size=4, seqlen_qo=512,  seqlen_kv=80K
+    use case 5: batch_size=4, seqlen_qo=1024, seqlen_kv=80K
+
+Usage:
+    # Benchmark all available backends
+    python bench_mla_prefill.py
+
+    # Only TokenSpeed MLA
+    python bench_mla_prefill.py --backends tokenspeed
+
+    # Custom shapes
+    python bench_mla_prefill.py \
+        --batch-sizes 1,4 --seqlen-qos 8192 --seqlen-kvs 8192,32768,65536
+
+    # FP8 input
+    python bench_mla_prefill.py --dtype fp8
+
+    # Export results
+    python bench_mla_prefill.py --export csv --output mla_prefill_results.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import sys
+import time
+from dataclasses import dataclass
+
+import torch
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PrefillShape:
+    batch_size: int
+    seqlen_q: int
+    seqlen_kv: int
+    h_q: int
+    h_k: int
+    d_qk: int
+    d_v: int
+
+
+@dataclass
+class BenchmarkResult:
+    backend: str
+    dtype: str
+    batch_size: int
+    seqlen_q: int
+    seqlen_kv: int
+    h_q: int
+    h_k: int
+    d_qk: int
+    d_v: int
+    is_causal: bool
+    median_latency_us: float
+    p90_latency_us: float
+    p99_latency_us: float
+    min_latency_us: float
+    max_latency_us: float
+    warmup_iters: int
+    bench_iters: int
+    timestamp: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Default shapes (from TokenSpeed README)
+# ---------------------------------------------------------------------------
+
+# DeepSeek V3/V4 MLA config:
+# h_q=128, h_k=1, d_qk=192 (qk_nope_head_dim=128 + qk_rope_head_dim=64)
+# But prefill uses h_q > h_k with GQA-style, so h_q=128, h_k=1 for MLA
+# Actually in MLA prefill, the shapes are:
+#   Q: [sum(q_lens), h_q, d_qk]
+#   K: [sum(kv_lens), h_k, d_qk]
+#   V: [sum(kv_lens), h_k, d_v]
+# With h_q = num_heads * h_r, h_k = 1 for MLA
+# For DeepSeek V3: num_heads=128, kv_lora_rank=512, qk_rope_head_dim=64
+# So h_q=128, h_k=1, d_qk=192, d_v=128 is for the compressed MLA representation
+# But the TokenSpeed README uses h_q=128, d_qk=192 for the Q/K shapes
+
+DEFAULT_PREFILL_SHAPES = [
+    # (batch_size, seqlen_q, seqlen_kv, h_q, h_k)
+    (1, 8192, 8192, 128, 1),
+    (1, 8192, 32768, 128, 1),
+    (1, 8192, 65536, 128, 1),
+    (4, 512, 81920, 128, 1),
+    (4, 1024, 81920, 128, 1),
+]
+
+# MLA dimensions (DeepSeek V3)
+H_Q = 128
+H_K = 1
+QK_NOPE_HEAD_DIM = 128
+QK_ROPE_HEAD_DIM = 64
+D_QK = QK_NOPE_HEAD_DIM + QK_ROPE_HEAD_DIM
+D_V = 128
+
+
+# ---------------------------------------------------------------------------
+# Timing utilities (shared with decode benchmark)
+# ---------------------------------------------------------------------------
+
+
+def benchmark_fn(fn, warmup_iters: int = 10, bench_iters: int = 50) -> list[float]:
+    for _ in range(warmup_iters):
+        fn()
+    torch.cuda.synchronize()
+
+    start_events = [torch.cuda.Event(enable_timing=True) for _ in range(bench_iters)]
+    end_events = [torch.cuda.Event(enable_timing=True) for _ in range(bench_iters)]
+
+    for i in range(bench_iters):
+        start_events[i].record()
+        fn()
+        end_events[i].record()
+
+    torch.cuda.synchronize()
+    latencies = [
+        s.elapsed_time(e) * 1000.0 for s, e in zip(start_events, end_events)  # ms -> us
+    ]
+    return sorted(latencies)
+
+
+def percentile(sorted_vals: list[float], p: float) -> float:
+    if not sorted_vals:
+        return 0.0
+    if len(sorted_vals) == 1:
+        return float(sorted_vals[0])
+    rank = (len(sorted_vals) - 1) * (p / 100.0)
+    lo = int(math.floor(rank))
+    hi = int(math.ceil(rank))
+    if lo == hi:
+        return float(sorted_vals[lo])
+    w = rank - float(lo)
+    return float(sorted_vals[lo]) * (1.0 - w) + float(sorted_vals[hi]) * w
+
+
+def randn_tensor(
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    source_dtype = torch.bfloat16 if dtype == torch.float8_e4m3fn else dtype
+    return torch.randn(shape, dtype=source_dtype, device=device).to(dtype)
+
+
+# ---------------------------------------------------------------------------
+# Backend: TokenSpeed MLA Prefill
+# ---------------------------------------------------------------------------
+
+
+def bench_tokenspeed_mla_prefill(
+    shape: PrefillShape,
+    dtype: torch.dtype,
+    device: torch.device,
+    warmup_iters: int,
+    bench_iters: int,
+    softmax_scale: float,
+    is_causal: bool,
+) -> BenchmarkResult | None:
+    try:
+        from tokenspeed_mla import tokenspeed_mla_prefill
+    except ImportError:
+        print("  [SKIP] tokenspeed_mla not available", flush=True)
+        return None
+
+    B = shape.batch_size
+    total_q = B * shape.seqlen_q
+    total_kv = B * shape.seqlen_kv
+    h_q, h_k = shape.h_q, shape.h_k
+    d_qk, d_v = shape.d_qk, shape.d_v
+
+    q = randn_tensor((total_q, h_q, d_qk), dtype, device)
+    k = randn_tensor((total_kv, h_k, d_qk), dtype, device)
+    v = randn_tensor((total_kv, h_k, d_v), dtype, device)
+    seq_lens = torch.full((B,), shape.seqlen_kv, dtype=torch.int32, device=device)
+    cum_seq_lens = (
+        torch.arange(B + 1, dtype=torch.int32, device=device) * shape.seqlen_kv
+    )
+    cum_seq_lens_q = (
+        torch.arange(B + 1, dtype=torch.int32, device=device) * shape.seqlen_q
+    )
+
+    # Warmup compile
+    print(f"    tokenspeed_mla_prefill: compiling...", end="", flush=True)
+
+    def run():
+        return tokenspeed_mla_prefill(
+            query=q,
+            key=k,
+            value=v,
+            seq_lens=seq_lens,
+            cum_seq_lens=cum_seq_lens,
+            max_seq_len=shape.seqlen_kv,
+            batch_size=B,
+            softmax_scale=softmax_scale,
+            is_causal=is_causal,
+            return_lse=False,
+            cum_seq_lens_q=cum_seq_lens_q,
+            max_seq_len_q=shape.seqlen_q,
+            enable_pdl=False,
+        )
+
+    out = run()
+    torch.cuda.synchronize()
+    del out
+    print(" done", flush=True)
+
+    latencies = benchmark_fn(run, warmup_iters, bench_iters)
+
+    return BenchmarkResult(
+        backend="tokenspeed_mla",
+        dtype=str(dtype),
+        batch_size=B,
+        seqlen_q=shape.seqlen_q,
+        seqlen_kv=shape.seqlen_kv,
+        h_q=h_q,
+        h_k=h_k,
+        d_qk=d_qk,
+        d_v=d_v,
+        is_causal=is_causal,
+        median_latency_us=percentile(latencies, 50),
+        p90_latency_us=percentile(latencies, 90),
+        p99_latency_us=percentile(latencies, 99),
+        min_latency_us=latencies[0],
+        max_latency_us=latencies[-1],
+        warmup_iters=warmup_iters,
+        bench_iters=bench_iters,
+        timestamp=time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backend: FlashInfer TRT-LLM ragged attention (DeepSeek)
+# ---------------------------------------------------------------------------
+
+
+def bench_flashinfer_ragged_prefill(
+    shape: PrefillShape,
+    dtype: torch.dtype,
+    device: torch.device,
+    warmup_iters: int,
+    bench_iters: int,
+    softmax_scale: float,
+    is_causal: bool,
+) -> BenchmarkResult | None:
+    try:
+        from flashinfer.prefill import trtllm_ragged_attention_deepseek
+    except ImportError:
+        print("  [SKIP] flashinfer.prefill not available", flush=True)
+        return None
+
+    if dtype not in (torch.bfloat16, torch.float16):
+        print(
+            f"  [SKIP] flashinfer prefill only supports bf16/fp16, got {dtype}",
+            flush=True,
+        )
+        return None
+
+    B = shape.batch_size
+    total_q = B * shape.seqlen_q
+    total_kv = B * shape.seqlen_kv
+    h_q, h_k = shape.h_q, shape.h_k
+    d_qk, d_v = shape.d_qk, shape.d_v
+
+    q = randn_tensor((total_q, h_q, d_qk), dtype, device)
+    k = randn_tensor((total_kv, h_k, d_qk), dtype, device)
+    v = randn_tensor((total_kv, h_k, d_v), dtype, device)
+
+    cum_seq_lens_q = (
+        torch.arange(B + 1, dtype=torch.int32, device=device) * shape.seqlen_q
+    )
+    cum_seq_lens_kv = (
+        torch.arange(B + 1, dtype=torch.int32, device=device) * shape.seqlen_kv
+    )
+    seq_lens = torch.full((B,), shape.seqlen_kv, dtype=torch.int32, device=device)
+
+    workspace = torch.zeros(256 * 1024 * 1024, dtype=torch.uint8, device=device)
+
+    def run():
+        return trtllm_ragged_attention_deepseek(
+            query=q,
+            key=k,
+            value=v,
+            workspace_buffer=workspace,
+            seq_lens=seq_lens,
+            max_q_len=shape.seqlen_q,
+            max_kv_len=shape.seqlen_kv,
+            bmm1_scale=softmax_scale,
+            bmm2_scale=1.0,
+            o_sf_scale=-1.0,
+            batch_size=B,
+            window_left=-1,
+            cum_seq_lens_q=cum_seq_lens_q,
+            cum_seq_lens_kv=cum_seq_lens_kv,
+            enable_pdl=False,
+            is_causal=is_causal,
+            return_lse=False,
+        )
+
+    print(f"    flashinfer: compiling...", end="", flush=True)
+    run()
+    torch.cuda.synchronize()
+    print(" done", flush=True)
+
+    latencies = benchmark_fn(run, warmup_iters, bench_iters)
+
+    return BenchmarkResult(
+        backend="flashinfer",
+        dtype=str(dtype),
+        batch_size=B,
+        seqlen_q=shape.seqlen_q,
+        seqlen_kv=shape.seqlen_kv,
+        h_q=h_q,
+        h_k=h_k,
+        d_qk=d_qk,
+        d_v=d_v,
+        is_causal=is_causal,
+        median_latency_us=percentile(latencies, 50),
+        p90_latency_us=percentile(latencies, 90),
+        p99_latency_us=percentile(latencies, 99),
+        min_latency_us=latencies[0],
+        max_latency_us=latencies[-1],
+        warmup_iters=warmup_iters,
+        bench_iters=bench_iters,
+        timestamp=time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Table formatting (shared with decode benchmark)
+# ---------------------------------------------------------------------------
+
+
+def format_results_table(results: list[BenchmarkResult]) -> str:
+    if not results:
+        return "No results."
+
+    from collections import defaultdict
+
+    groups: dict[tuple, list[BenchmarkResult]] = defaultdict(list)
+    for r in results:
+        key = (r.batch_size, r.seqlen_q, r.seqlen_kv, r.h_q)
+        groups[key].append(r)
+
+    lines: list[str] = []
+    gpu_name = torch.cuda.get_device_name(0) if torch.cuda.is_available() else "N/A"
+    lines.append(f"MLA Prefill Benchmark | GPU: {gpu_name} | dtype: {results[0].dtype}")
+    lines.append(
+        f"h_q={results[0].h_q}, h_k={results[0].h_k}, "
+        f"d_qk={results[0].d_qk}, d_v={results[0].d_v}"
+    )
+    lines.append(f"causal={results[0].is_causal}")
+    lines.append("")
+
+    for key in sorted(groups.keys()):
+        B, sq, sk, hq = key
+        group = sorted(groups[key], key=lambda r: r.median_latency_us)
+        lines.append(f"B={B}, seqlen_q={sq}, seqlen_kv={sk}, h_q={hq}")
+
+        header = (
+            f"{'Backend':<25} {'p50(us)':>10} {'p90(us)':>10} "
+            f"{'p99(us)':>10} {'min(us)':>10} {'max(us)':>10}"
+        )
+        lines.append(header)
+        lines.append("-" * len(header))
+
+        for r in group:
+            lines.append(
+                f"{r.backend:<25} {r.median_latency_us:>10.1f} "
+                f"{r.p90_latency_us:>10.1f} {r.p99_latency_us:>10.1f} "
+                f"{r.min_latency_us:>10.1f} {r.max_latency_us:>10.1f}"
+            )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_speedup_table(
+    results: list[BenchmarkResult],
+    baseline: str = "flashinfer",
+) -> str:
+    if not results:
+        return "No results."
+
+    from collections import defaultdict
+
+    groups: dict[tuple, dict[str, BenchmarkResult]] = defaultdict(dict)
+    for r in results:
+        key = (r.batch_size, r.seqlen_q, r.seqlen_kv, r.h_q)
+        groups[key][r.backend] = r
+
+    lines: list[str] = []
+    lines.append(f"MLA Prefill Speedup vs {baseline}")
+    lines.append("")
+
+    backends = sorted(set(r.backend for r in results) - {baseline})
+    header = f"{'Shape':<40}" + "".join(f" {b:>12}" for b in backends)
+    lines.append(header)
+    lines.append("-" * len(header))
+
+    for key in sorted(groups.keys()):
+        B, sq, sk, hq = key
+        shape_str = f"B={B},sq={sq},sk={sk},hq={hq}"
+        baseline_r = groups[key].get(baseline)
+        if baseline_r is None:
+            continue
+        row = f"{shape_str:<40}"
+        for b in backends:
+            r = groups[key].get(b)
+            if r is not None:
+                speedup = baseline_r.median_latency_us / r.median_latency_us
+                row += f" {speedup:>11.2f}x"
+            else:
+                row += f" {'N/A':>12}"
+        lines.append(row)
+
+    return "\n".join(lines)
+
+
+def export_csv(results: list[BenchmarkResult], path: str) -> None:
+    if not results:
+        return
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=list(results[0].__dataclass_fields__.keys()),
+        )
+        writer.writeheader()
+        for r in results:
+            writer.writerow(r.__dict__)
+
+
+def export_json(results: list[BenchmarkResult], path: str) -> None:
+    with open(path, "w") as f:
+        json.dump([r.__dict__ for r in results], f, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+BACKEND_REGISTRY = {
+    "tokenspeed": bench_tokenspeed_mla_prefill,
+    "flashinfer": bench_flashinfer_ragged_prefill,
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="MLA Prefill Benchmark: TokenSpeed vs FlashInfer",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--backends",
+        nargs="+",
+        default=["tokenspeed", "flashinfer"],
+        choices=list(BACKEND_REGISTRY.keys()),
+        help="Backends to benchmark (default: all)",
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=["bf16", "fp8"],
+        default="bf16",
+        help="Input dtype (default: bf16)",
+    )
+    parser.add_argument(
+        "--batch-sizes",
+        type=str,
+        default=None,
+        help="Comma-separated batch sizes",
+    )
+    parser.add_argument(
+        "--seqlen-qos",
+        type=str,
+        default=None,
+        help="Comma-separated query sequence lengths",
+    )
+    parser.add_argument(
+        "--seqlen-kvs",
+        type=str,
+        default=None,
+        help="Comma-separated KV sequence lengths",
+    )
+    parser.add_argument(
+        "--no-causal",
+        action="store_true",
+        help="Disable causal masking (default: causal=True)",
+    )
+    parser.add_argument(
+        "--warmup-iters",
+        type=int,
+        default=5,
+        help="Warmup iterations (default: 5, prefill is expensive)",
+    )
+    parser.add_argument(
+        "--bench-iters",
+        type=int,
+        default=20,
+        help="Benchmark iterations (default: 20)",
+    )
+    parser.add_argument(
+        "--export",
+        choices=["csv", "json"],
+        default=None,
+        help="Export format",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="mla_prefill_benchmark",
+        help="Output file path",
+    )
+    parser.add_argument(
+        "--speedup-baseline",
+        type=str,
+        default="flashinfer",
+        help="Baseline backend for speedup comparison",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if not torch.cuda.is_available():
+        print("ERROR: CUDA is not available.")
+        sys.exit(1)
+
+    device = torch.device("cuda")
+    gpu_name = torch.cuda.get_device_name(0)
+    gpu_mem = torch.cuda.get_device_properties(0).total_mem / (1024**3)
+
+    dtype_map = {"bf16": torch.bfloat16, "fp8": torch.float8_e4m3fn}
+    dtype = dtype_map[args.dtype]
+    softmax_scale = 1.0 / math.sqrt(D_QK)
+    is_causal = not args.no_causal
+
+    # Build shapes
+    if args.batch_sizes or args.seqlen_qos or args.seqlen_kvs:
+        batch_sizes = (
+            [int(x) for x in args.batch_sizes.split(",")] if args.batch_sizes else [1]
+        )
+        seqlen_qos = (
+            [int(x) for x in args.seqlen_qos.split(",")] if args.seqlen_qos else [8192]
+        )
+        seqlen_kvs = (
+            [int(x) for x in args.seqlen_kvs.split(",")] if args.seqlen_kvs else [8192]
+        )
+        shapes = [
+            PrefillShape(
+                batch_size=B,
+                seqlen_q=sq,
+                seqlen_kv=sk,
+                h_q=H_Q,
+                h_k=H_K,
+                d_qk=D_QK,
+                d_v=D_V,
+            )
+            for B in batch_sizes
+            for sq in seqlen_qos
+            for sk in seqlen_kvs
+        ]
+    else:
+        shapes = [
+            PrefillShape(
+                batch_size=B,
+                seqlen_q=sq,
+                seqlen_kv=sk,
+                h_q=hq,
+                h_k=hk,
+                d_qk=D_QK,
+                d_v=D_V,
+            )
+            for B, sq, sk, hq, hk in DEFAULT_PREFILL_SHAPES
+        ]
+
+    print("=" * 80)
+    print("MLA Prefill Benchmark")
+    print("=" * 80)
+    print(f"GPU:          {gpu_name} ({gpu_mem:.1f} GB)")
+    print(f"dtype:        {args.dtype}")
+    print(f"Backends:     {args.backends}")
+    print(f"Causal:       {is_causal}")
+    print(f"Shapes:       {len(shapes)} configurations")
+    print(f"Warmup:       {args.warmup_iters} iters")
+    print(f"Benchmark:    {args.bench_iters} iters")
+    print(f"softmax_scale: {softmax_scale:.6f}")
+    print("=" * 80)
+
+    all_results: list[BenchmarkResult] = []
+
+    for shape in shapes:
+        print(
+            f"\n--- B={shape.batch_size}, sq={shape.seqlen_q}, "
+            f"sk={shape.seqlen_kv}, h_q={shape.h_q} ---"
+        )
+
+        for backend_name in args.backends:
+            bench_fn = BACKEND_REGISTRY[backend_name]
+            result = bench_fn(
+                shape=shape,
+                dtype=dtype,
+                device=device,
+                warmup_iters=args.warmup_iters,
+                bench_iters=args.bench_iters,
+                softmax_scale=softmax_scale,
+                is_causal=is_causal,
+            )
+            if result is not None:
+                all_results.append(result)
+                print(
+                    f"    => p50={result.median_latency_us:.1f}us, "
+                    f"p90={result.p90_latency_us:.1f}us, "
+                    f"p99={result.p99_latency_us:.1f}us"
+                )
+
+    print("\n" + "=" * 80)
+    print("RESULTS")
+    print("=" * 80)
+    print(format_results_table(all_results))
+
+    baseline_backends = set(r.backend for r in all_results)
+    if args.speedup_baseline in baseline_backends and len(baseline_backends) > 1:
+        print("\n" + "=" * 80)
+        print(format_speedup_table(all_results, baseline=args.speedup_baseline))
+
+    if args.export == "csv":
+        out_path = args.output if args.output.endswith(".csv") else f"{args.output}.csv"
+        export_csv(all_results, out_path)
+        print(f"\nResults exported to {out_path}")
+    elif args.export == "json":
+        out_path = (
+            args.output if args.output.endswith(".json") else f"{args.output}.json"
+        )
+        export_json(all_results, out_path)
+        print(f"\nResults exported to {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

MLA decode is currently not represented as a first-class `tokenspeed-kernel` attention operator. The existing TokenSpeed MLA decode implementation lives behind the `tokenspeed-mla` package and is Blackwell-specific, which makes platform-aware selection, shape capture, and future backend work harder to wire through the shared kernel registry.

This PR adds the registry/API foundation for MLA decode before introducing any Hopper-specific implementation. It also makes the architecture boundary explicit: Hopper must not accidentally select the Blackwell-only TokenSpeed MLA backend.

## What changed

- Add `mla_decode_with_kvcache(...)` to the public `tokenspeed_kernel` API.
- Add MLA-shaped input validation and shape capture around the new public entry point.
- Register the existing `tokenspeed_mla_decode` backend under `attention.mla_decode_with_kvcache` for NVIDIA Blackwell SM100/SM103.
- Add routing tests covering Blackwell, Hopper, and Ampere behavior.
- Document the new API and clarify that Hopper has no default native MLA backend in this PR.

## Routing behavior

After this PR:

- Blackwell SM100/SM103 selects `tokenspeed_mla_decode_with_kvcache`.
- Hopper SM90 does not select a native MLA backend yet.
- Ampere SM80 does not select an MLA backend.

This is intentional. A Hopper backend should be added separately as either an in-tree Triton MLA kernel or a future CuTe DSL implementation, then registered under the same `mla_decode_with_kvcache` operator.

## Non-goals

- This PR does not add a FlashMLA fallback.
- This PR does not add a Hopper Triton/CuTe MLA kernel.
- This PR does not change the existing Blackwell `tokenspeed-mla` kernel implementation.

## Testing

Added focused routing/API tests for the new MLA decode entry point. Also ran local syntax and registry-selection checks.