### PR TITLE
Support EvalScope box table score parsing

### DIFF
--- a/test/ci_system/pipeline.py
+++ b/test/ci_system/pipeline.py
@@ -570,9 +570,10 @@ def extract_evalscope_score(report_table: str) -> float | None:
 
     for line in report_table.splitlines():
         stripped = line.strip()
-        if not stripped.startswith("|"):
+        if not stripped.startswith(("|", "│")):
             continue
-        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        separator = "│" if stripped.startswith("│") else "|"
+        cells = [cell.strip() for cell in stripped.strip(separator).split(separator)]
         if not cells:
             continue
         if any(set(cell) <= {"=", "-"} for cell in cells if cell):

--- a/test/ci_system/test_pipeline.py
+++ b/test/ci_system/test_pipeline.py
@@ -1,0 +1,23 @@
+from pipeline import extract_evalscope_score
+
+
+def test_extract_evalscope_score_from_pipe_table():
+    report_table = """
+| Model           | Dataset | Metric   | Subset  | Num | Score  | Cat.0   |
+|-----------------|---------|----------|---------|-----|--------|---------|
+| Kimi-K2.5-NVFP4 | aime25  | mean_acc | default | 30  | 0.9667 | default |
+"""
+
+    assert extract_evalscope_score(report_table) == 0.9667
+
+
+def test_extract_evalscope_score_from_box_table():
+    report_table = """
+┌─────────────────┬───────────┬──────────┬──────────┬───────┬─────────┬─────────┐
+│ Model           │ Dataset   │ Metric   │ Subset   │   Num │   Score │ Cat.0   │
+├─────────────────┼───────────┼──────────┼──────────┼───────┼─────────┼─────────┤
+│ Kimi-K2.5-NVFP4 │ aime25    │ mean_acc │ default  │    30 │  0.9667 │ default │
+└─────────────────┴───────────┴──────────┴──────────┴───────┴─────────┴─────────┘
+"""
+
+    assert extract_evalscope_score(report_table) == 0.9667


### PR DESCRIPTION
## Summary
- Support EvalScope overall report tables rendered with box-drawing separators.
- Keep compatibility with the previous pipe table format.
- Add focused parser tests for both formats.

## Test
- git diff --check
- python3 -m ruff check test/ci_system/pipeline.py test/ci_system/test_pipeline.py
- python3 -m pytest test/ci_system/test_pipeline.py