### PR TITLE
Fix DeepSeek V3 tokenizer and fp8 KV guard

### DIFF
--- a/python/tokenspeed/runtime/execution/weight_loader.py
+++ b/python/tokenspeed/runtime/execution/weight_loader.py
@@ -34,6 +34,13 @@ from tokenspeed.runtime.utils.torch_memory_saver_adapter import TorchMemorySaver
 
 logger = get_colorful_logger(__name__)
 
+_DEEPSEEK_V3_ARCHITECTURES = frozenset(
+    {
+        "DeepseekV3ForCausalLM",
+        "DeepseekV3ForCausalLMNextN",
+    }
+)
+
 
 class WeightLoader:
     """Handles model weight loading from disk.
@@ -41,6 +48,35 @@ class WeightLoader:
     This class is stateless and does not modify external state.
     It returns LoadedModel with all necessary information.
     """
+
+    @staticmethod
+    def _validate_fp8_kv_cache_args(
+        model_config: ModelConfig,
+        server_args: ServerArgs,
+    ) -> None:
+        if server_args.kv_cache_dtype != "fp8_e4m3":
+            return
+
+        architectures = getattr(
+            getattr(model_config, "hf_config", None),
+            "architectures",
+            None,
+        )
+        is_deepseek_v3 = bool(
+            architectures
+            and any(arch in _DEEPSEEK_V3_ARCHITECTURES for arch in architectures)
+        )
+        if (
+            is_deepseek_v3
+            and server_args.attention_backend == "tokenspeed_mla"
+            and server_args.quantization_param_path is None
+        ):
+            raise RuntimeError(
+                "DeepSeek V3 with tokenspeed_mla requires FP8 MLA KV-cache "
+                "scaling factors when --kv-cache-dtype fp8_e4m3 is used. Pass "
+                "--quantization-param-path with KV-cache scales, or use an "
+                "attention backend that supports an unquantized KV cache."
+            )
 
     @staticmethod
     def load_model(
@@ -72,6 +108,7 @@ class WeightLoader:
             torch.set_num_threads(1)
 
         set_cuda_arch()
+        WeightLoader._validate_fp8_kv_cache_args(model_config, server_args)
 
         # Create load config
         load_config = LoadConfig(

--- a/python/tokenspeed/runtime/utils/hf_transformers_utils.py
+++ b/python/tokenspeed/runtime/utils/hf_transformers_utils.py
@@ -277,6 +277,8 @@ _FAST_LLAMA_TOKENIZER = "hf-internal-testing/llama-tokenizer"
 # verbatim tokenizer path must stay architecture-gated.
 _VERBATIM_TOKENIZER_ARCHITECTURES: frozenset = frozenset(
     {
+        "DeepseekV3ForCausalLM",
+        "DeepseekV3ForCausalLMNextN",
         "MiniMaxM2ForCausalLM",
     }
 )

--- a/test/runtime/test_hf_transformers_utils.py
+++ b/test/runtime/test_hf_transformers_utils.py
@@ -1,0 +1,75 @@
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+from tokenizers import Tokenizer
+from tokenizers.decoders import ByteLevel as ByteLevelDecoder
+from tokenizers.models import BPE
+from tokenizers.pre_tokenizers import ByteLevel
+
+# CI Registration (parsed via AST, runtime no-op)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, suite="runtime-1gpu")
+
+from tokenspeed.runtime.utils.hf_transformers_utils import get_tokenizer  # noqa: E402
+
+
+class TestHfTransformersUtils(unittest.TestCase):
+    def _write_deepseek_v3_like_tokenizer(self, model_dir: str) -> list[int]:
+        vocab = {
+            "MLA": 0,
+            "Ġattention": 1,
+            ",": 2,
+            "Ġor": 3,
+            "Ġmore": 4,
+            "Ġspecifically": 5,
+            ".ĊĊ": 6,
+            "<｜begin▁of▁sentence｜>": 7,
+            "<｜end▁of▁sentence｜>": 8,
+        }
+        tokenizer = Tokenizer(BPE(vocab=vocab, merges=[], unk_token=None))
+        tokenizer.pre_tokenizer = ByteLevel(add_prefix_space=False)
+        tokenizer.decoder = ByteLevelDecoder()
+        tokenizer.save(os.path.join(model_dir, "tokenizer.json"))
+
+        tokenizer_config = {
+            "tokenizer_class": "LlamaTokenizerFast",
+            "legacy": True,
+            "clean_up_tokenization_spaces": False,
+            "bos_token": "<｜begin▁of▁sentence｜>",
+            "eos_token": "<｜end▁of▁sentence｜>",
+            "pad_token": "<｜end▁of▁sentence｜>",
+            "unk_token": None,
+        }
+        with open(os.path.join(model_dir, "tokenizer_config.json"), "w", encoding="utf-8") as f:
+            json.dump(tokenizer_config, f)
+
+        return [0, 1, 2, 3, 4, 5, 6]
+
+    def test_deepseek_v3_uses_verbatim_fast_tokenizer(self):
+        with tempfile.TemporaryDirectory() as model_dir:
+            token_ids = self._write_deepseek_v3_like_tokenizer(model_dir)
+
+            for architecture in (
+                "DeepseekV3ForCausalLM",
+                "DeepseekV3ForCausalLMNextN",
+            ):
+                with self.subTest(architecture=architecture):
+                    tokenizer = get_tokenizer(
+                        model_dir,
+                        trust_remote_code=True,
+                        architectures=[architecture],
+                    )
+
+                    self.assertEqual(
+                        tokenizer.decode(token_ids),
+                        "MLA attention, or more specifically.\n\n",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/runtime/test_weight_loader_prefetch.py
+++ b/test/runtime/test_weight_loader_prefetch.py
@@ -1,7 +1,9 @@
 import argparse
+import contextlib
 import os
 import sys
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 # CI Registration (parsed via AST, runtime no-op)
@@ -11,8 +13,15 @@ from ci_system.ci_register import register_cuda_ci
 register_cuda_ci(est_time=10, suite="runtime-1gpu")
 
 from tokenspeed.runtime.configs.load_config import LoadConfig
+from tokenspeed.runtime.execution.weight_loader import WeightLoader
 from tokenspeed.runtime.model_loader import weight_utils
 from tokenspeed.runtime.utils.server_args import ServerArgs
+
+
+class _NullMemorySaverAdapter:
+    @contextlib.contextmanager
+    def region(self):
+        yield
 
 
 class TestWeightLoaderPrefetch(unittest.TestCase):
@@ -60,6 +69,86 @@ class TestWeightLoaderPrefetch(unittest.TestCase):
 
         self.assertFalse(thread.is_alive())
         self.assertEqual(sorted(seen), [files[1], files[4]])
+
+    def test_tokenspeed_mla_fp8_kv_requires_scaling_factors(self):
+        server_args = SimpleNamespace(
+            load_format="auto",
+            download_dir=None,
+            ext_yaml=None,
+            weight_loader_prefetch_checkpoints=False,
+            weight_loader_prefetch_num_threads=4,
+            kv_cache_dtype="fp8_e4m3",
+            quantization_param_path=None,
+            attention_backend="tokenspeed_mla",
+        )
+        model_config = SimpleNamespace(
+            dtype="bfloat16",
+            hf_config=SimpleNamespace(architectures=["DeepseekV3ForCausalLM"]),
+        )
+
+        with (
+            mock.patch(
+                "tokenspeed.runtime.execution.weight_loader.set_cuda_arch",
+            ),
+            mock.patch(
+                "tokenspeed.runtime.execution.weight_loader.get_available_gpu_memory",
+                return_value=0,
+            ),
+            mock.patch(
+                "tokenspeed.runtime.execution.weight_loader.get_model",
+            ) as get_model,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "DeepSeek V3"):
+                WeightLoader.load_model(
+                    model_config=model_config,
+                    server_args=server_args,
+                    device="cpu",
+                    gpu_id=0,
+                    memory_saver_adapter=_NullMemorySaverAdapter(),
+                )
+
+        get_model.assert_not_called()
+
+    def test_fp8_kv_scale_guard_is_deepseek_v3_specific(self):
+        server_args = SimpleNamespace(
+            load_format="auto",
+            download_dir=None,
+            ext_yaml=None,
+            weight_loader_prefetch_checkpoints=False,
+            weight_loader_prefetch_num_threads=4,
+            kv_cache_dtype="fp8_e4m3",
+            quantization_param_path=None,
+            attention_backend="tokenspeed_mla",
+        )
+        model_config = SimpleNamespace(
+            dtype="bfloat16",
+            hf_config=SimpleNamespace(architectures=["KimiK2ForCausalLM"]),
+        )
+        model = object()
+
+        with (
+            mock.patch(
+                "tokenspeed.runtime.execution.weight_loader.set_cuda_arch",
+            ),
+            mock.patch(
+                "tokenspeed.runtime.execution.weight_loader.get_available_gpu_memory",
+                return_value=0,
+            ),
+            mock.patch(
+                "tokenspeed.runtime.execution.weight_loader.get_model",
+                return_value=model,
+            ) as get_model,
+        ):
+            loaded = WeightLoader.load_model(
+                model_config=model_config,
+                server_args=server_args,
+                device="cuda",
+                gpu_id=0,
+                memory_saver_adapter=_NullMemorySaverAdapter(),
+            )
+
+        self.assertIs(loaded, model)
+        get_model.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fix two DeepSeek V3/V3.1 serving failure modes found while testing DeepSeek-V3.1-Terminus with the `tokenspeed_mla` backend.

First, DeepSeek V3-family tokenizer configs can advertise `LlamaTokenizerFast` even though the model ships a byte-level BPE `tokenizer.json`. Loading through `AutoTokenizer` can decode byte-level markers literally, producing output like `Ġattention` and `ĊĊ`. This PR routes DeepSeek V3 architectures through the verbatim fast-tokenizer path so decoding matches the tokenizer JSON.

Second, DeepSeek V3 with `tokenspeed_mla` and `--kv-cache-dtype fp8_e4m3` requires KV-cache scaling factors. Without them, the server can start but produce corrupted text. This PR adds an early validation error when that unsafe configuration is used without `--quantization-param-path`.

## Test Plan

Validated with focused regression tests:

```bash
source .venv/bin/activate
pytest -q test/runtime/test_hf_transformers_utils.py test/runtime/test_weight_loader_prefetch.py
