### PR TITLE
decoder_layer: Python 3.10 compat (replace PEP 695 generics with TypeVar/Generic)

### DIFF
--- a/python/tokenspeed/runtime/models/base/decoder_layer.py
+++ b/python/tokenspeed/runtime/models/base/decoder_layer.py
@@ -26,7 +26,7 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, Tuple
+from typing import Generic, List, Optional, Tuple, TypeVar
 
 import torch
 from torch import nn
@@ -62,7 +62,10 @@ def _default_compute_output_placement(
     return Partial(group) if has_parallel else None
 
 
-class BaseDecoderLayer[C: PretrainedConfig](nn.Module):
+_C = TypeVar("_C", bound=PretrainedConfig)
+
+
+class BaseDecoderLayer(nn.Module, Generic[_C]):
     """Default decoder layer using CommManager for communication.
 
     Subclasses override ``resolve_attn()`` and ``resolve_mlp()``.
@@ -70,7 +73,7 @@ class BaseDecoderLayer[C: PretrainedConfig](nn.Module):
 
     def __init__(
         self,
-        config: C,
+        config: _C,
         layer_id: int,
         mapping: Mapping,
         quant_config: Q | None = None,
@@ -231,7 +234,7 @@ class BaseMoEDecoderLayer(BaseDecoderLayer):
         return True
 
 
-class CompiledDecoderLayer[C: PretrainedConfig](nn.Module):
+class CompiledDecoderLayer(nn.Module, Generic[_C]):
     """Compiler-driven decoder layer (opt-in).
 
     Instead of CommManager, the forward delegates to a
@@ -240,7 +243,7 @@ class CompiledDecoderLayer[C: PretrainedConfig](nn.Module):
 
     def __init__(
         self,
-        config: C,
+        config: _C,
         layer_id: int,
         mapping: Mapping,
         quant_config: Q | None = None,


### PR DESCRIPTION
## Summary

Replace the two PEP 695 generic class declarations (`class Foo[C: PretrainedConfig]`) in `decoder_layer.py` with the equivalent `typing.TypeVar` + `typing.Generic` form. Lets the codebase import on Python 3.10 without changing behavior on Python 3.12+.

## Why

PEP 695 class generic syntax requires Python 3.12+. The current state of the AMD ROCm Python toolchain that pairs with `tokenspeed-kernel`'s `requirements/rocm.txt` (`torch==2.11.0+rocm7.2`) only ships cp310 wheels on `download.pytorch.org/whl/rocm7.2` — there is no cp312 wheel as of this PR. The official sglang-rocm container shipping that toolchain (`lmsysorg/sglang-rocm:v0.5.11-rocm720-mi35x-20260505`) is on Python 3.10.

Net result: AMD MI300 / MI350 / MI355X users currently can't `import tokenspeed` at all — `python3 -m tokenspeed.api_server` errors with `SyntaxError` on `decoder_layer.py` at import time, before any platform-detection code can run.

The two affected classes are the only PEP 695 generics in the codebase (verified via `grep -rE '^[[:space:]]*class [A-Za-z_][A-Za-z0-9_]*\['` over `python/` and `tokenspeed-kernel/python/`).

## What this changes

- `from typing import ...` adds `Generic`, `TypeVar`
- `class BaseDecoderLayer[C: PretrainedConfig](nn.Module)` → `_C = TypeVar("_C", bound=PretrainedConfig)` + `class BaseDecoderLayer(nn.Module, Generic[_C])`
- `class CompiledDecoderLayer[C: PretrainedConfig](nn.Module)` → `class CompiledDecoderLayer(nn.Module, Generic[_C])` (reuses the module-level `_C`)
- `config: C` → `config: _C` in the corresponding `__init__` signatures

No semantic change. `TypeVar(..., bound=...)` + `Generic[T]` is the documented PEP 484 equivalent of `class Foo[T: Bound]` on 3.12+, and is supported back to Python 3.7.

## Validation

Tested end-to-end on AMD Instinct MI355X (`gfx950 / CDNA4`) inside the `lmsysorg/sglang-rocm:v0.5.11-rocm720-mi35x-20260505` container (Python 3.10.12, torch 2.11.0+rocm7.2):

- Before: `SyntaxError` on `decoder_layer.py:65` at `import tokenspeed`.
- After: `python3 -m tokenspeed.api_server --model openai/gpt-oss-120b --tp 1 --attention-backend mha --moe-backend triton_kernel ...` boots cleanly, serves real generations, end-to-end.

Pre-commit (`pre-commit run --files python/tokenspeed/runtime/models/base/decoder_layer.py`) is green: isort, black, ast, eof, trailing-whitespace all pass.

## Test plan

- [ ] CI passes (lint + tests)
- [ ] On NVIDIA: confirm no regression — type checker still sees BaseDecoderLayer/CompiledDecoderLayer as generic over PretrainedConfig subclasses
- [ ] On AMD ROCm container: confirm `import tokenspeed` succeeds where it previously raised SyntaxError

🤖 Generated with [Claude Code](https://claude.com/claude-code)