### PR TITLE
platform: hardcode MI300/MI350 LDS size; probe /sys/class/kfd for xGMI topology

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/platform.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/platform.py
@@ -414,7 +414,9 @@ def _detect_rocm_platform() -> PlatformInfo:
         memory_bandwidth=_estimate_amd_bandwidth(props),
         sm_count=props.multi_processor_count,
         max_threads_per_sm=getattr(props, "max_threads_per_multi_processor", 0),
-        max_shared_memory_per_sm=getattr(props, "max_shared_memory_per_block", 0),
+        max_shared_memory_per_sm={"gfx942": 64 * 1024, "gfx950": 64 * 1024}.get(
+            arch, getattr(props, "max_shared_memory_per_block", 0)
+        ),
         sm_features=sm_features,
         runtime_features=runtime_features,
         interconnect=_detect_rocm_interconnect(),
@@ -500,6 +502,31 @@ def _detect_rocm_interconnect() -> InterconnectInfo | None:
         device_count = torch.cuda.device_count()
         if device_count <= 1:
             return InterconnectInfo(topology="single_gpu")
+        # Probe /sys/class/kfd for xGMI links (HSA_IOLINK_TYPE_XGMI = 11).
+        try:
+            import os as _os
+
+            kfd_root = "/sys/class/kfd/kfd/topology/nodes"
+            xgmi_count = 0
+            for node in _os.listdir(kfd_root):
+                links_dir = _os.path.join(kfd_root, node, "io_links")
+                if not _os.path.isdir(links_dir):
+                    continue
+                for link in _os.listdir(links_dir):
+                    pf = _os.path.join(links_dir, link, "properties")
+                    try:
+                        with open(pf) as f:
+                            for line in f:
+                                if line.startswith("type ") and line.split()[1] == "11":
+                                    xgmi_count += 1
+                    except OSError:
+                        continue
+            if xgmi_count > 0:
+                full = device_count * (device_count - 1)
+                topo = "xgmi_full" if xgmi_count >= full else "xgmi_pairs"
+                return InterconnectInfo(topology=topo)
+        except Exception:
+            pass
         return InterconnectInfo(topology="pcie")
     except Exception:
         return None


### PR DESCRIPTION
## Summary

Two AMD-specific gaps in `_detect_rocm_platform()` / `_detect_rocm_interconnect()`:

1. **`max_shared_memory_per_sm` is reported as 0 on AMD** because `torch.cuda.get_device_properties(...).max_shared_memory_per_block` returns `0` on the ROCm side of PyTorch. MI300 and MI350 both have 64 KiB of LDS per CU. This PR hardcodes those known values for `gfx942` (MI300, CDNA3) and `gfx950` (MI350/MI355, CDNA4); other archs fall back to the existing `getattr`.

2. **`_detect_rocm_interconnect()` blindly returns `"pcie"`** for any multi-GPU AMD system, even though MI300+ servers are xGMI-connected. This PR probes `/sys/class/kfd/kfd/topology/nodes/*/io_links/*/properties` for `HSA_IOLINK_TYPE_XGMI` (= 11) and reports `"xgmi_full"` / `"xgmi_pairs"` accordingly. Falls back to `"pcie"` if the topology probe fails.

Both fields are consumed by downstream gates (LDS-budget guards, all-reduce shape selection, etc.). On MI355X the wrong values silently bias those gates against the AMD path.

## Validation

### MI355X (mia1-p01-g06)
| | before | after |
|---|---|---|
| `max_shared_memory_per_sm` | `0` | `65536` |
| `interconnect.topology` | `"pcie"` | `"xgmi_full"` |

### B200 (Shadeform)
- `vendor='nvidia', device='NVIDIA B200', is_blackwell=True, interconnect.topology='nvlink_full'`
- Identical to baseline. The CUDA detection path is intentionally not modified.

## Note on a sibling NVIDIA bug

The same `max_shared_memory_per_sm=0` issue also affects the NVIDIA path (`_detect_cuda_platform()` returns 0 on B200 via the same attribute). That fix needs SM-version-keyed values (sm_80 = 164 KiB, sm_90 = 228 KiB, sm_100 = 228 KiB, ...) and is intentionally left to a follow-up — this PR is scoped to AMD to keep the diff and review scope tight. Happy to spin a follow-up PR for the CUDA path if useful.

## Test plan

- [ ] CI passes (lint + tests)
- [ ] On AMD MI300/MI350: `current_platform().max_shared_memory_per_sm` returns 65536 (was 0)
- [ ] On AMD multi-GPU: `current_platform().interconnect.topology` returns `xgmi_*` (was `pcie`)
- [ ] On NVIDIA: confirm no regression — CUDA path is byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)