### PR TITLE
Add Kimi K2.5 agentic perf CI task

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -25,6 +25,15 @@ on:
       - "test/**"
       - ".github/workflows/pr-test.yml"
   workflow_dispatch:
+    inputs:
+      trigger:
+        description: "CI task trigger to run"
+        required: false
+        default: manual
+        type: choice
+        options:
+          - manual
+          - debug
 
 env:
   PIP_BREAK_SYSTEM_PACKAGES: 1
@@ -75,7 +84,10 @@ jobs:
         id: scan
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TRIGGER=manual
+            TRIGGER="${{ github.event.inputs.trigger }}"
+            if [ -z "$TRIGGER" ]; then
+              TRIGGER=manual
+            fi
           else
             TRIGGER=per-commit
           fi

--- a/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
+++ b/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
@@ -1,7 +1,6 @@
 api_version: ci.tokenspeed.io/v1
 name: perf-kimi-k2.5-nvfp4-agentic
 type: perf
-  - debug
 runner:
   labels:
     - b200-4gpu

--- a/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
+++ b/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
@@ -17,13 +17,24 @@ server:
     --attn-tp-size 4
     --moe-tp-size 4
     --max-model-len 80000
+    --max-num-seqs 16
     --max-prefill-tokens 8192
     --chunked-prefill-size 8192
+    --gpu-memory-utilization 0.95
+    --disable-cuda-graph-padding
     --trust-remote-code
     --attention-backend tokenspeed_mla
     --moe-backend flashinfer_trtllm
     --quantization nvfp4
     --kv-cache-dtype fp8
+    --speculative-algorithm EAGLE3
+    --speculative-draft-model-path lightseekorg/kimi-k2.5-eagle3-mla
+    --speculative-num-steps 3
+    --speculative-eagle-topk 1
+    --speculative-num-draft-tokens 4
+    --speculative-draft-model-quantization unquant
+    --drafter-attention-backend tokenspeed_mla
+    --enable-cache-report
     --weight-loader-prefetch-checkpoints
     --host 127.0.0.1
   ready:

--- a/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
+++ b/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
@@ -52,9 +52,23 @@ perf:
   command: >-
     REPO_ROOT=$PWD &&
     OUTPUTS_DIR=/tmp/tokenspeed-agentic-perf &&
-    trap 'rm -rf "$OUTPUTS_DIR"' EXIT &&
-    rm -rf "$OUTPUTS_DIR" &&
+    WARMUP_DIR=/tmp/tokenspeed-agentic-warmup &&
+    trap 'rm -rf "$OUTPUTS_DIR" "$WARMUP_DIR"' EXIT &&
+    rm -rf "$OUTPUTS_DIR" "$WARMUP_DIR" &&
     cd /tmp &&
+    /tmp/evalscope-perf/bin/evalscope perf
+    --model nvidia/Kimi-K2.5-NVFP4
+    --url http://localhost:8000/v1/chat/completions
+    --api openai
+    --dataset swe_smith
+    --dataset-path agentic_dataset.json
+    --max-tokens 500
+    --multi-turn
+    --number 2
+    --parallel 2
+    --dataset-offset 68
+    --outputs-dir "$WARMUP_DIR"
+    --extra-args '{"ignore_eos": true}' &&
     set +e &&
     /tmp/evalscope-perf/bin/evalscope perf
     --model nvidia/Kimi-K2.5-NVFP4

--- a/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
+++ b/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
@@ -1,0 +1,70 @@
+api_version: ci.tokenspeed.io/v1
+name: perf-kimi-k2.5-nvfp4-agentic
+type: perf
+triggers:
+  - debug
+runner:
+  labels:
+    - b200-4gpu
+env:
+  CI: "true"
+install:
+  - bash test/ci_system/install_deps.sh
+server:
+  command: >-
+    python3 -m tokenspeed.api_server
+    --model nvidia/Kimi-K2.5-NVFP4
+    --attn-tp-size 4
+    --moe-tp-size 4
+    --max-model-len 80000
+    --max-prefill-tokens 8192
+    --chunked-prefill-size 8192
+    --trust-remote-code
+    --attention-backend tokenspeed_mla
+    --moe-backend flashinfer_trtllm
+    --quantization nvfp4
+    --kv-cache-dtype fp8
+    --weight-loader-prefetch-checkpoints
+    --host 127.0.0.1
+  ready:
+    url: http://127.0.0.1:8000/health
+    timeout: 1800
+    interval: 10
+perf:
+  install:
+    - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]'
+    - >-
+      test -f /tmp/agentic_dataset.json ||
+      curl -fL
+      https://huggingface.co/datasets/lightseekorg/agentic-dataset/resolve/main/agentic_dataset.json
+      -o /tmp/agentic_dataset.json
+  command: >-
+    REPO_ROOT=$PWD &&
+    OUTPUTS_DIR=/tmp/tokenspeed-agentic-perf &&
+    trap 'rm -rf "$OUTPUTS_DIR"' EXIT &&
+    rm -rf "$OUTPUTS_DIR" &&
+    cd /tmp &&
+    set +e &&
+    /tmp/evalscope-perf/bin/evalscope perf
+    --model nvidia/Kimi-K2.5-NVFP4
+    --url http://localhost:8000/v1/chat/completions
+    --api openai
+    --dataset swe_smith
+    --dataset-path agentic_dataset.json
+    --max-tokens 500
+    --multi-turn
+    --number 4 8 8 16 32
+    --parallel 1 2 4 8 16
+    --outputs-dir "$OUTPUTS_DIR"
+    --extra-args '{"ignore_eos": true}'
+    --no-timestamp;
+    PERF_STATUS=$?;
+    if [ -d "$OUTPUTS_DIR/Kimi-K2.5-NVFP4" ]; then
+    mv "$OUTPUTS_DIR/Kimi-K2.5-NVFP4" "$OUTPUTS_DIR/Kimi-K2.5-NVFP4_attn_tp4";
+    fi;
+    python3 "$REPO_ROOT/test/agentic_benchmark/tokenspeed/collect_outputs.py" "$OUTPUTS_DIR";
+    PARSE_STATUS=$?;
+    if [ "$PERF_STATUS" -ne 0 ]; then exit "$PERF_STATUS"; fi;
+    exit "$PARSE_STATUS"
+report:
+  github_step_summary: true

--- a/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
+++ b/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
@@ -1,7 +1,6 @@
 api_version: ci.tokenspeed.io/v1
 name: perf-kimi-k2.5-nvfp4-agentic
 type: perf
-triggers:
   - debug
 runner:
   labels:

--- a/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
+++ b/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
@@ -93,3 +93,11 @@ perf:
     exit "$PARSE_STATUS"
 report:
   github_step_summary: true
+perf_threshold: 0.9
+# Values are [Latency (tps/user), Throughput (tps/gpu)]; gate fails any conc whose actual falls below ref * perf_threshold.
+perf_reference:
+  1:  [367.65, 8742.12]
+  2:  [284.90, 13280.12]
+  4:  [182.48, 17276.27]
+  8:  [112.49, 20944.40]
+  16: [67.61,  25181.19]

--- a/test/ci_system/pipeline.py
+++ b/test/ci_system/pipeline.py
@@ -861,6 +861,16 @@ def build_step_summary_lines(result: Dict[str, Any]) -> List[str]:
             f"- Eval score: `{check['score']:g}` "
             f"(threshold `{check['threshold']}`, {status})"
         )
+    if result.get("perf_reference_check"):
+        check = result["perf_reference_check"]
+        status = "pass" if check["passed"] else "fail"
+        lines.append(
+            f"- Perf reference: `{status}` "
+            f"(threshold `{check['threshold']:g}`, "
+            f"{len(check['checks'])} concurrency levels)"
+        )
+        if not check["passed"]:
+            lines.extend([f"  - {failure}" for failure in check["failures"]])
     if result.get("eval_accept_rate"):
         accept_rate = result["eval_accept_rate"]
         lines.append(

--- a/test/ci_system/pipeline.py
+++ b/test/ci_system/pipeline.py
@@ -28,7 +28,7 @@ except ImportError as exc:  # pragma: no cover
 
 
 SUPPORTED_TYPES = {"ut", "server_smoke", "eval", "perf"}
-SUPPORTED_TRIGGERS = {"per-commit", "manual", "nightly"}
+SUPPORTED_TRIGGERS = {"per-commit", "manual", "nightly", "debug"}
 B200_RUNNER_LABEL_ENV = "TOKENSPEED_B200_RUNNER_LABEL"
 STALE_PROCESS_PATTERNS = [
     r"python.*tokenspeed\.api_server",

--- a/test/ci_system/pipeline.py
+++ b/test/ci_system/pipeline.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import argparse
 import ast
+import csv
 import glob
+import io
 import json
 import os
 import re
@@ -554,6 +556,10 @@ def summarize_command_output(command: str, output: str) -> Dict[str, Any]:
     if evalscope_perf_table:
         result["evalscope_perf_table"] = evalscope_perf_table
 
+    perf_summary_rows = extract_perf_summary_rows(output)
+    if perf_summary_rows:
+        result["perf_summary_rows"] = perf_summary_rows
+
     return result
 
 
@@ -687,6 +693,114 @@ def check_eval_score_threshold(
         "max": max_score,
         "passed": passed,
         "threshold": threshold_text,
+    }
+
+
+PERF_CSV_HEADER = (
+    "config,Conc.,Latency (tps/user),Throughput (tps/gpu),"
+    "Approx Cache Hit,Decoded Tok/Iter"
+)
+PERF_REFERENCE_METRICS = ("Latency (tps/user)", "Throughput (tps/gpu)")
+
+
+def extract_perf_summary_rows(output: str) -> List[Dict[str, str]] | None:
+    idx = output.find(PERF_CSV_HEADER)
+    if idx < 0:
+        return None
+    block = output[idx:]
+    lines: List[str] = []
+    for raw in block.splitlines():
+        line = clean_log_line(raw)
+        if not line.strip():
+            if lines:
+                break
+            continue
+        if lines and re.match(r"^\d{4}-\d{2}-\d{2} .* - .* - ", line):
+            break
+        lines.append(line)
+    if len(lines) < 2:
+        return None
+    return list(csv.DictReader(io.StringIO("\n".join(lines))))
+
+
+def check_perf_reference(
+    task: Dict[str, Any],
+    command_results: List[Dict[str, Any]],
+    stages_run: List[str],
+) -> Dict[str, Any] | None:
+    reference = task.get("perf_reference")
+    if reference is None:
+        print("[perf-ref] no perf_reference configured", flush=True)
+        return None
+    if "perf" not in stages_run:
+        print(
+            "[perf-ref] perf_reference configured but perf stage was not "
+            f"executed; stages={stages_run}",
+            flush=True,
+        )
+        return None
+    if not isinstance(reference, dict) or not reference:
+        raise ValueError("perf_reference must be a non-empty dict")
+
+    threshold = float(task.get("perf_threshold", 0.9))
+
+    rows: List[Dict[str, str]] | None = None
+    for result in command_results:
+        if "perf_summary_rows" in result:
+            rows = result["perf_summary_rows"]
+    if not rows:
+        print("[perf-ref] no perf summary rows found in command output", flush=True)
+        raise ValueError(
+            "perf_reference is configured but no perf summary rows were found"
+        )
+
+    failures: List[str] = []
+    checks: List[Dict[str, Any]] = []
+    for conc_key, ref_pair in reference.items():
+        try:
+            conc = int(conc_key)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"perf_reference key must be an int concurrency: got {conc_key!r}"
+            ) from exc
+        if not isinstance(ref_pair, list) or len(ref_pair) != 2:
+            raise ValueError(
+                f"perf_reference[{conc_key}] must be [tps_user, tps_gpu]; "
+                f"got {ref_pair!r}"
+            )
+        match = next((r for r in rows if int(r["Conc."]) == conc), None)
+        if match is None:
+            failures.append(f"conc={conc}: no matching row in perf summary")
+            continue
+        entry: Dict[str, Any] = {"conc": conc}
+        for metric, ref in zip(PERF_REFERENCE_METRICS, ref_pair):
+            ref_v = float(ref)
+            actual = float(match[metric])
+            floor = ref_v * threshold
+            passed_metric = actual >= floor
+            entry[metric] = {
+                "actual": actual,
+                "ref": ref_v,
+                "floor": floor,
+                "passed": passed_metric,
+            }
+            if not passed_metric:
+                failures.append(
+                    f"conc={conc}: {metric} {actual:g} < {floor:g} "
+                    f"({threshold * 100:g}% of {ref_v:g})"
+                )
+        checks.append(entry)
+
+    passed = not failures
+    status = "passed" if passed else "failed"
+    print(f"[perf-ref] threshold={threshold:g}, status={status}", flush=True)
+    for line in failures:
+        print(f"[perf-ref]   {line}", flush=True)
+    return {
+        "passed": passed,
+        "threshold": threshold,
+        "checks": checks,
+        "failures": failures,
     }
 
 
@@ -1073,6 +1187,12 @@ def execute_task(
                 f"eval score {eval_score_check['score']:g} does not satisfy "
                 f"threshold {eval_score_check['threshold']}"
             )
+        perf_reference_check = check_perf_reference(task, command_results, stages_run)
+        if perf_reference_check is not None and not perf_reference_check["passed"]:
+            raise RuntimeError(
+                "perf_reference check failed: "
+                + "; ".join(perf_reference_check["failures"])
+            )
 
         result = {
             "ok": True,
@@ -1085,6 +1205,8 @@ def execute_task(
         }
         if eval_score_check is not None:
             result["eval_score_check"] = eval_score_check
+        if perf_reference_check is not None:
+            result["perf_reference_check"] = perf_reference_check
         if eval_accept_rate is not None:
             result["eval_accept_rate"] = eval_accept_rate
         if task.get("report", {}).get("github_step_summary"):

--- a/test/ci_system/test_pipeline.py
+++ b/test/ci_system/test_pipeline.py
@@ -1,5 +1,6 @@
 import pytest
 from pipeline import (
+    build_step_summary_lines,
     check_perf_reference,
     extract_evalscope_score,
     extract_perf_summary_rows,
@@ -112,3 +113,50 @@ def test_check_perf_reference_raises_on_malformed_pair():
     task = {"perf_reference": {16: [40.0]}}
     with pytest.raises(ValueError, match=r"\[tps_user, tps_gpu\]"):
         check_perf_reference(task, _command_results_with(rows), ["perf"])
+
+
+def _base_result(**extras):
+    base = {
+        "ok": True,
+        "task": "perf-task",
+        "runner": "b200-4gpu",
+        "executed_stages": ["server", "perf.install", "perf"],
+        "targets": {},
+        "command_results": [],
+    }
+    base.update(extras)
+    return base
+
+
+def test_step_summary_includes_perf_reference_pass():
+    rows = extract_perf_summary_rows(PERF_CSV_FIXTURE)
+    task = {
+        "perf_threshold": 0.9,
+        "perf_reference": {16: [33.0, 26000.0]},
+    }
+    check = check_perf_reference(task, _command_results_with(rows), ["perf"])
+    summary = "\n".join(
+        build_step_summary_lines(_base_result(perf_reference_check=check))
+    )
+    assert "- Perf reference: `pass`" in summary
+    assert "threshold `0.9`" in summary
+    assert "1 concurrency levels" in summary
+
+
+def test_step_summary_includes_perf_reference_failures():
+    rows = extract_perf_summary_rows(PERF_CSV_FIXTURE)
+    task = {
+        "perf_threshold": 0.9,
+        "perf_reference": {16: [40.0, 26000.0]},
+    }
+    check = check_perf_reference(task, _command_results_with(rows), ["perf"])
+    summary = "\n".join(
+        build_step_summary_lines(_base_result(perf_reference_check=check))
+    )
+    assert "- Perf reference: `fail`" in summary
+    assert "Latency (tps/user)" in summary
+
+
+def test_step_summary_omits_perf_reference_when_unconfigured():
+    summary = "\n".join(build_step_summary_lines(_base_result()))
+    assert "Perf reference" not in summary

--- a/test/ci_system/test_pipeline.py
+++ b/test/ci_system/test_pipeline.py
@@ -1,4 +1,9 @@
-from pipeline import extract_evalscope_score
+import pytest
+from pipeline import (
+    check_perf_reference,
+    extract_evalscope_score,
+    extract_perf_summary_rows,
+)
 
 
 def test_extract_evalscope_score_from_pipe_table():
@@ -21,3 +26,89 @@ def test_extract_evalscope_score_from_box_table():
 """
 
     assert extract_evalscope_score(report_table) == 0.9667
+
+
+PERF_CSV_FIXTURE = """\
+some unrelated log line
+config,Conc.,Latency (tps/user),Throughput (tps/gpu),Approx Cache Hit,Decoded Tok/Iter
+attn_tp4_moe_tp4,1,40.0,2500.0,82.5,3.1
+attn_tp4_moe_tp4,2,38.0,4500.0,82.5,3.1
+attn_tp4_moe_tp4,4,35.0,8000.0,82.5,3.1
+attn_tp4_moe_tp4,8,32.0,14000.0,82.5,3.1
+attn_tp4_moe_tp4,16,30.0,24000.0,82.5,3.1
+
+2026-05-08 12:00:00 - root - INFO - done
+"""
+
+
+def test_extract_perf_summary_rows_parses_csv_block():
+    rows = extract_perf_summary_rows(PERF_CSV_FIXTURE)
+    assert rows is not None
+    assert len(rows) == 5
+    assert rows[0]["Conc."] == "1"
+    assert rows[-1]["Latency (tps/user)"] == "30.0"
+    assert rows[-1]["Throughput (tps/gpu)"] == "24000.0"
+
+
+def test_extract_perf_summary_rows_returns_none_when_missing():
+    assert extract_perf_summary_rows("nothing relevant here") is None
+
+
+def _command_results_with(rows):
+    return [{"perf_summary_rows": rows}]
+
+
+def test_check_perf_reference_passes_when_actual_meets_floor():
+    rows = extract_perf_summary_rows(PERF_CSV_FIXTURE)
+    task = {
+        "perf_threshold": 0.9,
+        "perf_reference": {16: [33.0, 26000.0]},
+    }
+    result = check_perf_reference(task, _command_results_with(rows), ["perf"])
+    assert result is not None
+    assert result["passed"] is True
+    assert result["failures"] == []
+
+
+def test_check_perf_reference_fails_when_metric_below_floor():
+    rows = extract_perf_summary_rows(PERF_CSV_FIXTURE)
+    task = {
+        "perf_threshold": 0.9,
+        "perf_reference": {16: [40.0, 26000.0]},
+    }
+    result = check_perf_reference(task, _command_results_with(rows), ["perf"])
+    assert result is not None
+    assert result["passed"] is False
+    assert any("Latency (tps/user)" in f for f in result["failures"])
+
+
+def test_check_perf_reference_reports_missing_row():
+    rows = extract_perf_summary_rows(PERF_CSV_FIXTURE)
+    task = {"perf_reference": {64: [10.0, 100.0]}}
+    result = check_perf_reference(task, _command_results_with(rows), ["perf"])
+    assert result is not None
+    assert result["passed"] is False
+    assert any("no matching row" in f for f in result["failures"])
+
+
+def test_check_perf_reference_skips_when_perf_stage_not_run():
+    rows = extract_perf_summary_rows(PERF_CSV_FIXTURE)
+    task = {"perf_reference": {16: [40.0, 26000.0]}}
+    assert check_perf_reference(task, _command_results_with(rows), ["server"]) is None
+
+
+def test_check_perf_reference_returns_none_when_unconfigured():
+    assert check_perf_reference({}, [], ["perf"]) is None
+
+
+def test_check_perf_reference_raises_when_no_rows_found():
+    task = {"perf_reference": {16: [40.0, 26000.0]}}
+    with pytest.raises(ValueError, match="no perf summary rows"):
+        check_perf_reference(task, [], ["perf"])
+
+
+def test_check_perf_reference_raises_on_malformed_pair():
+    rows = extract_perf_summary_rows(PERF_CSV_FIXTURE)
+    task = {"perf_reference": {16: [40.0]}}
+    with pytest.raises(ValueError, match=r"\[tps_user, tps_gpu\]"):
+        check_perf_reference(task, _command_results_with(rows), ["perf"])


### PR DESCRIPTION
## Summary
- Add a Kimi K2.5 NVFP4 EvalScope perf task for the SWE-smith agentic dataset.
- Download the dataset to /tmp/agentic_dataset.json only when it is missing.
- Add a workflow_dispatch trigger selector and keep the new task behind agentic-perf-debug so it does not run by default on per-commit/manual scans.

## Test
- git diff --check
- python3 -m ruff check test/ci_system/pipeline.py
- python3 test/ci_system/pipeline.py scan --root test/ci --trigger agentic-perf-debug
- python3 test/ci_system/pipeline.py scan --root test/ci --trigger manual
- python3 test/ci_system/pipeline.py scan --root test/ci --trigger per-commit
- python3 test/ci_system/pipeline.py execute --config test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml --runner b200-4gpu --work-dir . --print-plan --dry-run