### PR TITLE
perf: optimize qwen3.5 runtime prepare cost

### DIFF
--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -599,6 +599,7 @@ class CudaGraphWrapper:
                 seq_lens,
                 req_to_page=req_to_page,
                 forward_mode=ctx.forward_mode,
+                num_padding=padded_bs - bs if padded_bs != bs else 0,
                 **mamba_kwargs,
             )
 

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -487,7 +487,7 @@ class MambaAttnBackend(AttentionBackend):
     ):
         num_padding = kwargs.get("num_padding", 0)
         mamba_pool_indices = kwargs.get("mamba_pool_indices")
-        
+
         real_bs = bs - num_padding
         req_pool_indices = req_pool_indices[:bs]
         if mamba_pool_indices is not None:

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -506,15 +506,17 @@ class MambaAttnBackend(AttentionBackend):
             self.state_indices_list[bs - 1][real_bs:].fill_(self.pad_slot_id)
 
         if num_padding == 0:
-            need_copy = self._qsl_dirty[bs - 1] or self._qsl_last_mode[bs - 1] != forward_mode
+            need_copy = (
+                self._qsl_dirty[bs - 1] or self._qsl_last_mode[bs - 1] != forward_mode
+            )
             if need_copy:
                 if forward_mode.is_decode_or_idle():
                     self.query_start_loc_list[bs - 1].copy_(
-                        self.cached_cuda_graph_decode_query_start_loc[:bs + 1]
+                        self.cached_cuda_graph_decode_query_start_loc[: bs + 1]
                     )
                 elif forward_mode.is_target_verify() or forward_mode.is_draft_extend():
                     self.query_start_loc_list[bs - 1].copy_(
-                        self.cached_cuda_graph_verify_query_start_loc[:bs + 1]
+                        self.cached_cuda_graph_verify_query_start_loc[: bs + 1]
                     )
                 self._qsl_dirty[bs - 1] = False
                 self._qsl_last_mode[bs - 1] = forward_mode
@@ -534,61 +536,12 @@ class MambaAttnBackend(AttentionBackend):
             else:
                 raise ValueError(f"Invalid forward mode: {forward_mode=}")
             self._qsl_dirty[bs - 1] = True
-            self._qsl_last_mode[bs - 1] = forward_mode 
-        
-        self.forward_metadata = MambaForwardMetadata(
-            query_start_loc=self.query_start_loc_list[bs - 1],
-            mamba_cache_indices=self.state_indices_list[bs - 1],
-        )
-        
-        """req_pool_indices = req_pool_indices[:bs]
-        seq_lens_cpu = seq_lens[:bs].cpu()
-        num_padding = torch.count_nonzero(
-            seq_lens_cpu == self.get_cuda_graph_seq_len_fill_value()
-        )
-        req_pool_indices[bs - num_padding :] = 0
-        mamba_pool_indices = kwargs.get("mamba_pool_indices")
-        if mamba_pool_indices is not None:
-            mamba_pool_indices = mamba_pool_indices[:bs]
-            mamba_pool_indices[bs - num_padding :] = 0
-            mamba_indices = self.pool.get_mamba_indices(mamba_pool_indices)
-        else:
-            mamba_indices = self.pool.get_mamba_indices(req_pool_indices)
-        mamba_indices[bs - num_padding :] = -1
-        self.state_indices_list[bs - 1][: len(mamba_indices)].copy_(mamba_indices)
-
-        if forward_mode.is_decode_or_idle():
-            if num_padding == 0:
-                self.query_start_loc_list[bs - 1].copy_(
-                    self.cached_cuda_graph_decode_query_start_loc[: bs + 1]
-                )
-            else:
-                self.query_start_loc_list[bs - 1][: bs - num_padding].copy_(
-                    self.cached_cuda_graph_decode_query_start_loc[: bs - num_padding]
-                )
-                self.query_start_loc_list[bs - 1][bs - num_padding :].copy_(
-                    bs - num_padding
-                )
-        elif forward_mode.is_target_verify() or forward_mode.is_draft_extend():
-            if num_padding == 0:
-                self.query_start_loc_list[bs - 1].copy_(
-                    self.cached_cuda_graph_verify_query_start_loc[: bs + 1]
-                )
-            else:
-                self.query_start_loc_list[bs - 1][: bs - num_padding].copy_(
-                    self.cached_cuda_graph_verify_query_start_loc[: bs - num_padding]
-                )
-                self.query_start_loc_list[bs - 1][bs - num_padding :].copy_(
-                    (bs - num_padding) * self.speculative_num_draft_tokens
-                )
-        else:
-            raise ValueError(f"Invalid forward mode: {forward_mode=}")
+            self._qsl_last_mode[bs - 1] = forward_mode
 
         self.forward_metadata = MambaForwardMetadata(
             query_start_loc=self.query_start_loc_list[bs - 1],
             mamba_cache_indices=self.state_indices_list[bs - 1],
         )
-        """
 
     def get_cuda_graph_seq_len_fill_value(self):
         return 1

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -440,6 +440,8 @@ class MambaAttnBackend(AttentionBackend):
                 dtype=torch.int32,
                 device=self.device,
             )
+        self._qsl_dirty = [False] * max_num_tokens
+        self._qsl_last_mode = [None] * max_num_tokens
 
     def init_forward_metadata_capture_cuda_graph(
         self,
@@ -467,6 +469,8 @@ class MambaAttnBackend(AttentionBackend):
         else:
             mamba_indices = self.pool.get_mamba_indices(req_pool_indices[:bs])
         self.state_indices_list[bs - 1][: len(mamba_indices)].copy_(mamba_indices)
+        self._qsl_dirty[bs - 1] = False
+        self._qsl_last_mode[bs - 1] = forward_mode
         self.forward_metadata = MambaForwardMetadata(
             query_start_loc=self.query_start_loc_list[bs - 1],
             mamba_cache_indices=self.state_indices_list[bs - 1],
@@ -481,7 +485,63 @@ class MambaAttnBackend(AttentionBackend):
         req_to_page: torch.Tensor = None,
         **kwargs,
     ):
-        req_pool_indices = req_pool_indices[:bs]
+        mamba_pool_indices = kwargs.get("mamba_pool_indices")
+        if mamba_pool_indices is not None:
+            real_bs = len(mamba_pool_indices)
+            num_padding = bs - real_bs
+            mamba_indices = self.pool.get_mamba_indices(mamba_pool_indices[:real_bs])
+        else:
+            seq_lens_cpu = seq_lens[:bs].cpu()
+            num_padding = torch.count_nonzero(
+                seq_lens_cpu == self.get_cuda_graph_seq_len_fill_value()
+            ).item()
+            req_pool_indices = req_pool_indices[:bs]
+            real_bs = bs - num_padding
+            req_pool_indices[real_bs:] = 0
+            mamba_indices = self.pool.get_mamba_indices(req_pool_indices[:real_bs])
+
+        assert len(mamba_indices) == real_bs
+        self.state_indices_list[bs - 1][:real_bs].copy_(mamba_indices)
+        if real_bs < bs:
+            self.state_indices_list[bs - 1][real_bs:].fill_(self.pad_slot_id)
+
+        if num_padding == 0:
+            need_copy = self._qsl_dirty[bs - 1] or self._qsl_last_mode[bs - 1] != forward_mode
+            if need_copy:
+                if forward_mode.is_decode_or_idle():
+                    self.query_start_loc_list[bs - 1].copy_(
+                        self.cached_cuda_graph_decode_query_start_loc[:bs + 1]
+                    )
+                elif forward_mode.is_target_verify() or forward_mode.is_draft_extend():
+                    self.query_start_loc_list[bs - 1].copy_(
+                        self.cached_cuda_graph_verify_query_start_loc[:bs + 1]
+                    )
+                self._qsl_dirty[bs - 1] = False
+                self._qsl_last_mode[bs - 1] = forward_mode
+        else:
+            if forward_mode.is_decode_or_idle():
+                self.query_start_loc_list[bs - 1][:real_bs].copy_(
+                    self.cached_cuda_graph_decode_query_start_loc[:real_bs]
+                )
+                self.query_start_loc_list[bs - 1][real_bs:].fill_(real_bs)
+            elif forward_mode.is_target_verify() or forward_mode.is_draft_extend():
+                self.query_start_loc_list[bs - 1][:real_bs].copy_(
+                    self.cached_cuda_graph_verify_query_start_loc[:real_bs]
+                )
+                self.query_start_loc_list[bs - 1][real_bs:].fill_(
+                    real_bs * self.speculative_num_draft_tokens
+                )
+            else:
+                raise ValueError(f"Invalid forward mode: {forward_mode=}")
+            self._qsl_dirty[bs - 1] = True
+            self._qsl_last_mode[bs - 1] = forward_mode 
+        
+        self.forward_metadata = MambaForwardMetadata(
+            query_start_loc=self.query_start_loc_list[bs - 1],
+            mamba_cache_indices=self.state_indices_list[bs - 1],
+        )
+        
+        """req_pool_indices = req_pool_indices[:bs]
         seq_lens_cpu = seq_lens[:bs].cpu()
         num_padding = torch.count_nonzero(
             seq_lens_cpu == self.get_cuda_graph_seq_len_fill_value()
@@ -528,6 +588,7 @@ class MambaAttnBackend(AttentionBackend):
             query_start_loc=self.query_start_loc_list[bs - 1],
             mamba_cache_indices=self.state_indices_list[bs - 1],
         )
+        """
 
     def get_cuda_graph_seq_len_fill_value(self):
         return 1

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -485,24 +485,18 @@ class MambaAttnBackend(AttentionBackend):
         req_to_page: torch.Tensor = None,
         **kwargs,
     ):
+        num_padding = kwargs.get("num_padding", 0)
         mamba_pool_indices = kwargs.get("mamba_pool_indices")
+        
+        real_bs = bs - num_padding
+        req_pool_indices = req_pool_indices[:bs]
         if mamba_pool_indices is not None:
-            real_bs = len(mamba_pool_indices)
-            num_padding = bs - real_bs
             mamba_indices = self.pool.get_mamba_indices(mamba_pool_indices[:real_bs])
         else:
-            seq_lens_cpu = seq_lens[:bs].cpu()
-            num_padding = torch.count_nonzero(
-                seq_lens_cpu == self.get_cuda_graph_seq_len_fill_value()
-            ).item()
-            req_pool_indices = req_pool_indices[:bs]
-            real_bs = bs - num_padding
-            req_pool_indices[real_bs:] = 0
             mamba_indices = self.pool.get_mamba_indices(req_pool_indices[:real_bs])
 
-        assert len(mamba_indices) == real_bs
         self.state_indices_list[bs - 1][:real_bs].copy_(mamba_indices)
-        if real_bs < bs:
+        if num_padding > 0:
             self.state_indices_list[bs - 1][real_bs:].fill_(self.pad_slot_id)
 
         if num_padding == 0:

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -39,13 +39,12 @@ from tokenspeed.runtime.configs.model_config import AttentionArch
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
-from tokenspeed.runtime.layers.attention.registry import register_backend
 from tokenspeed.runtime.layers.attention.kv_cache.trtllm_fp8_kv_kernel import (
     fused_fp8_set_kv_buffer,
 )
+from tokenspeed.runtime.layers.attention.registry import register_backend
 from tokenspeed.runtime.layers.common import fp8_cast_contiguous
 from tokenspeed.runtime.utils import get_colorful_logger
-
 
 if TYPE_CHECKING:
     from tokenspeed.runtime.layers.paged_attention import PagedAttention
@@ -205,7 +204,11 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         return bmm1_scale, bmm2_scale
 
     def _should_use_fused_fp8_path(self, save_kv_cache: bool, k) -> bool:
-        return save_kv_cache and k is not None and self.kv_cache_dtype == torch.float8_e4m3fn
+        return (
+            save_kv_cache
+            and k is not None
+            and self.kv_cache_dtype == torch.float8_e4m3fn
+        )
 
     # ------------------------------------------------------------------
     # Forward

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -40,8 +40,12 @@ from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 from tokenspeed.runtime.layers.attention.registry import register_backend
+from tokenspeed.runtime.layers.attention.kv_cache.trtllm_fp8_kv_kernel import (
+    fused_fp8_set_kv_buffer,
+)
 from tokenspeed.runtime.layers.common import fp8_cast_contiguous
 from tokenspeed.runtime.utils import get_colorful_logger
+
 
 if TYPE_CHECKING:
     from tokenspeed.runtime.layers.paged_attention import PagedAttention
@@ -200,6 +204,9 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         bmm2_scale = 1.0
         return bmm1_scale, bmm2_scale
 
+    def _should_use_fused_fp8_path(self, save_kv_cache: bool, k) -> bool:
+        return save_kv_cache and k is not None and self.kv_cache_dtype == torch.float8_e4m3fn
+
     # ------------------------------------------------------------------
     # Forward
     # ------------------------------------------------------------------
@@ -215,7 +222,19 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         save_kv_cache: bool = True,
         **kwargs,
     ) -> torch.Tensor:
-        if save_kv_cache and k is not None:
+        if self._should_use_fused_fp8_path(save_kv_cache, k):
+            k_cache, v_cache = token_to_kv_pool.get_kv_buffer(layer.layer_id)
+            fused_fp8_set_kv_buffer(
+                k=k.view(-1, layer.tp_k_head_num, layer.head_dim),
+                v=v.view(-1, layer.tp_k_head_num, layer.head_dim),
+                k_cache=k_cache,
+                v_cache=v_cache,
+                cache_loc=out_cache_loc,
+                k_scale=layer.k_scale,
+                v_scale=layer.v_scale,
+                page_size=self.page_size,
+            )
+        else save_kv_cache and k is not None:
             token_to_kv_pool.set_kv_buffer(
                 layer, out_cache_loc, k, v, layer.k_scale, layer.v_scale
             )
@@ -262,8 +281,19 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         save_kv_cache: bool = True,
         **kwargs,
     ) -> torch.Tensor:
-
-        if save_kv_cache and k is not None:
+        if self._should_use_fused_fp8_path(save_kv_cache, k):
+            k_cache, v_cache = token_to_kv_pool.get_kv_buffer(layer.layer_id)
+            fused_fp8_set_kv_buffer(
+                k=k.view(-1, layer.tp_k_head_num, layer.head_dim),
+                v=v.view(-1, layer.tp_k_head_num, layer.head_dim),
+                k_cache=k_cache,
+                v_cache=v_cache,
+                cache_loc=out_cache_loc,
+                k_scale=layer.k_scale,
+                v_scale=layer.v_scale,
+                page_size=self.page_size,
+            )
+        else save_kv_cache and k is not None:
             token_to_kv_pool.set_kv_buffer(
                 layer, out_cache_loc, k, v, layer.k_scale, layer.v_scale
             )

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -234,7 +234,7 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
                 v_scale=layer.v_scale,
                 page_size=self.page_size,
             )
-        else save_kv_cache and k is not None:
+        elif save_kv_cache and k is not None:
             token_to_kv_pool.set_kv_buffer(
                 layer, out_cache_loc, k, v, layer.k_scale, layer.v_scale
             )
@@ -293,7 +293,7 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
                 v_scale=layer.v_scale,
                 page_size=self.page_size,
             )
-        else save_kv_cache and k is not None:
+        elif save_kv_cache and k is not None:
             token_to_kv_pool.set_kv_buffer(
                 layer, out_cache_loc, k, v, layer.k_scale, layer.v_scale
             )

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/trtllm_fp8_kv_kernel.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/trtllm_fp8_kv_kernel.py
@@ -1,0 +1,504 @@
+"""
+Fused FP8 quantization + paged KV cache write kernel for TRTLLM MHA backend.
+
+This kernel fuses the following operations:
+1. FP8 quantization of K and V tensors (from BF16/FP16 to FP8)
+2. Per-token or per-page scale computation
+3. Writing quantized K/V to paged KV cache layout
+
+Performance benefits:
+- Eliminates intermediate FP8 tensors in memory
+- Reduces kernel launch overhead
+- Better memory bandwidth utilization
+"""
+
+import logging
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def _process_kv_tensor(
+    token_id,
+    head_block_id,
+    page_id,
+    page_offset,
+    input_ptr,
+    cache_ptr,
+    inv_scale,
+    use_provided_scale: tl.constexpr,
+    num_kv_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    input_stride_token: tl.constexpr,
+    input_stride_head: tl.constexpr,
+    input_stride_dim: tl.constexpr,
+    cache_stride_page: tl.constexpr,
+    cache_stride_offset: tl.constexpr,
+    cache_stride_head: tl.constexpr,
+    cache_stride_dim: tl.constexpr,
+    BLOCK_HEAD: tl.constexpr,
+    BLOCK_DIM: tl.constexpr,
+):
+    """Process a block of heads for a single K or V tensor."""
+    head_idx = head_block_id * BLOCK_HEAD
+    num_heads_in_block = min(BLOCK_HEAD, num_kv_heads - head_idx)
+
+    for dim_idx in range(0, head_dim, BLOCK_DIM):
+        num_dims_in_block = min(BLOCK_DIM, head_dim - dim_idx)
+
+        head_offsets = head_idx + tl.arange(0, BLOCK_HEAD)
+        dim_offsets = dim_idx + tl.arange(0, BLOCK_DIM)
+
+        head_mask = head_offsets < (head_idx + num_heads_in_block)
+        dim_mask = dim_offsets < (dim_idx + num_dims_in_block)
+
+        # Load from input using 3D strides
+        input_offsets = (
+            token_id * input_stride_token
+            + head_offsets[:, None] * input_stride_head
+            + dim_offsets[None, :] * input_stride_dim
+        )
+        mask = head_mask[:, None] & dim_mask[None, :]
+
+        block = tl.load(input_ptr + input_offsets, mask=mask, other=0.0)
+
+        # Quantize to FP8
+        if use_provided_scale:
+            block_fp8 = (block * inv_scale).to(tl.float8e4nv)
+        else:
+            block_fp8 = block.to(tl.float8e4nv)
+
+        # Write to cache at [page_id, page_offset, head, dim]
+        cache_offsets = (
+            page_id * cache_stride_page
+            + page_offset * cache_stride_offset
+            + head_offsets[:, None] * cache_stride_head
+            + dim_offsets[None, :] * cache_stride_dim
+        )
+
+        tl.store(cache_ptr + cache_offsets, block_fp8, mask=mask)
+
+
+@triton.jit
+def _fused_fp8_set_kv_buffer_kernel(
+    # Input tensors (post-RoPE K and V in FP16/BF16)
+    k_ptr,  # [num_tokens, num_kv_heads, head_dim]
+    v_ptr,  # [num_tokens, num_kv_heads, head_dim]
+    # Output KV cache buffers (FP8 paged layout)
+    k_cache_ptr,  # [total_slots, num_kv_heads, head_dim]
+    v_cache_ptr,  # [total_slots, num_kv_heads, head_dim]
+    # Cache location indices
+    cache_loc_ptr,  # [num_tokens] -> token to cache location mapping
+    # Pointers to scalar inverse scales (computed on GPU in wrapper)
+    inv_k_scale_ptr,  # pointer to 0-D tensor on GPU
+    inv_v_scale_ptr,  # pointer to 0-D tensor on GPU
+    use_provided_scale: tl.constexpr,  # whether to use provided scale
+    # Tensor dimensions
+    num_kv_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    page_size: tl.constexpr,
+    # Strides for K input [num_tokens, num_kv_heads, head_dim]
+    k_stride_token: tl.constexpr,
+    k_stride_head: tl.constexpr,
+    k_stride_dim: tl.constexpr,
+    # Strides for K cache [total_slots, num_kv_heads, head_dim] (logically paged)
+    k_cache_stride_page: tl.constexpr,
+    k_cache_stride_offset: tl.constexpr,
+    k_cache_stride_head: tl.constexpr,
+    k_cache_stride_dim: tl.constexpr,
+    # Strides for V input [num_tokens, num_kv_heads, head_dim]
+    v_stride_token: tl.constexpr,
+    v_stride_head: tl.constexpr,
+    v_stride_dim: tl.constexpr,
+    # Strides for V cache [total_slots, num_kv_heads, head_dim] (logically paged)
+    v_cache_stride_page: tl.constexpr,
+    v_cache_stride_offset: tl.constexpr,
+    v_cache_stride_head: tl.constexpr,
+    v_cache_stride_dim: tl.constexpr,
+    # Block sizes
+    BLOCK_HEAD: tl.constexpr,  # Number of heads per block
+    BLOCK_DIM: tl.constexpr,  # Head dimension block size
+):
+    """
+    Fused FP8 quantization + paged KV cache write kernel.
+
+    Each program processes one token-head_block-kv combination, quantizing and writing
+    to the appropriate page in the KV cache.
+
+    Grid: (num_tokens, num_head_blocks, 2) where dim2: 0=K, 1=V
+    """
+    # Get program IDs
+    token_id = tl.program_id(0)
+    head_block_id = tl.program_id(1)
+    kv_idx = tl.program_id(2)  # 0 for K, 1 for V
+
+    # Get cache location for this token
+    cache_loc = tl.load(cache_loc_ptr + token_id)
+
+    # Compute page_id and offset within page
+    page_id = cache_loc // page_size
+    page_offset = cache_loc % page_size
+
+    # Select K or V based on kv_idx
+    if kv_idx == 0:
+        # Process K tensor
+        if use_provided_scale:
+            inv_scale = tl.load(inv_k_scale_ptr)
+        else:
+            inv_scale = 1.0
+        _process_kv_tensor(
+            token_id,
+            head_block_id,
+            page_id,
+            page_offset,
+            k_ptr,
+            k_cache_ptr,
+            inv_scale,
+            use_provided_scale,
+            num_kv_heads,
+            head_dim,
+            k_stride_token,
+            k_stride_head,
+            k_stride_dim,
+            k_cache_stride_page,
+            k_cache_stride_offset,
+            k_cache_stride_head,
+            k_cache_stride_dim,
+            BLOCK_HEAD,
+            BLOCK_DIM,
+        )
+    else:
+        # Process V tensor
+        if use_provided_scale:
+            inv_scale = tl.load(inv_v_scale_ptr)
+        else:
+            inv_scale = 1.0
+        _process_kv_tensor(
+            token_id,
+            head_block_id,
+            page_id,
+            page_offset,
+            v_ptr,
+            v_cache_ptr,
+            inv_scale,
+            use_provided_scale,
+            num_kv_heads,
+            head_dim,
+            v_stride_token,
+            v_stride_head,
+            v_stride_dim,
+            v_cache_stride_page,
+            v_cache_stride_offset,
+            v_cache_stride_head,
+            v_cache_stride_dim,
+            BLOCK_HEAD,
+            BLOCK_DIM,
+        )
+
+
+def fused_fp8_set_kv_buffer(
+    k: torch.Tensor,  # [num_tokens, num_kv_heads, head_dim] or [num_tokens, num_kv_heads * head_dim]
+    v: torch.Tensor,  # [num_tokens, num_kv_heads, head_dim] or [num_tokens, num_kv_heads * head_dim]
+    k_cache: torch.Tensor,  # [total_slots, num_kv_heads, head_dim] or [num_pages, page_size, num_kv_heads, head_dim]
+    v_cache: torch.Tensor,  # [total_slots, num_kv_heads, head_dim] or [num_pages, page_size, num_kv_heads, head_dim]
+    cache_loc: torch.Tensor,  # [num_tokens], dtype=int32
+    k_scale: Optional[
+        float
+    ] = None,  # Scalar scale (matching original set_kv_buffer signature)
+    v_scale: Optional[float] = None,
+    page_size: int = 16,
+    use_triton: bool = True,  # Whether to use Triton kernel (set to False to force naive fallback)
+) -> None:
+    """
+    Python wrapper for the fused FP8 quantization + paged KV cache write kernel.
+
+    This function replicates the exact behavior of the original set_kv_buffer but with
+    a fused kernel that combines FP8 quantization and cache write.
+
+    Args:
+        k: Key tensor after RoPE, can be 2D or 3D
+        v: Value tensor, can be 2D or 3D
+        k_cache: Paged K cache buffer in FP8
+        v_cache: Paged V cache buffer in FP8
+        cache_loc: Cache location for each token, shape [num_tokens]
+        k_scale: Optional scalar scale for K (matching original set_kv_buffer)
+        v_scale: Optional scalar scale for V (matching original set_kv_buffer)
+        page_size: Number of tokens per page
+        use_triton: Whether to use optimized Triton kernel
+    """
+    num_tokens = k.shape[0]
+
+    # Step 1: Infer num_kv_heads and head_dim from cache shape
+    if k_cache.ndim == 3:
+        # 3D cache layout: [total_slots, num_kv_heads, head_dim]
+        total_slots, num_kv_heads, head_dim = k_cache.shape
+        assert (
+            total_slots % page_size == 0
+        ), f"total_slots ({total_slots}) must be divisible by page_size ({page_size})"
+        num_pages = total_slots // page_size
+    elif k_cache.ndim == 4:
+        # 4D cache layout: [num_pages, page_size, num_kv_heads, head_dim]
+        num_pages, ps, num_kv_heads, head_dim = k_cache.shape
+        assert (
+            ps == page_size
+        ), f"page_size mismatch: cache has {ps}, expected {page_size}"
+        total_slots = num_pages * page_size
+    else:
+        raise ValueError(f"Unsupported k_cache.ndim={k_cache.ndim}, expected 3 or 4")
+
+    # Step 2: Validate k, v shapes and normalize
+    # Store original 3D shape for Triton path
+    k_3d = None
+    v_3d = None
+
+    if k.ndim == 3:
+        # Input is [num_tokens, num_kv_heads, head_dim]
+        assert (
+            k.shape[1] == num_kv_heads
+        ), f"num_kv_heads mismatch: k.shape[1]={k.shape[1]} vs cache={num_kv_heads}"
+        assert (
+            k.shape[2] == head_dim
+        ), f"head_dim mismatch: k.shape[2]={k.shape[2]} vs cache={head_dim}"
+        assert v.shape[1] == num_kv_heads and v.shape[2] == head_dim, "v shape mismatch"
+
+        # Keep 3D for Triton kernel
+        k_3d = k
+        v_3d = v
+        # Create 2D view for naive fallback (will be used only if use_triton=False)
+        k_2d = k.reshape(num_tokens, num_kv_heads * head_dim)
+        v_2d = v.reshape(num_tokens, num_kv_heads * head_dim)
+    elif k.ndim == 2:
+        # Input is already [num_tokens, num_kv_heads * head_dim]
+        assert (
+            k.shape[1] == num_kv_heads * head_dim
+        ), f"k.shape[1]={k.shape[1]} != {num_kv_heads * head_dim}"
+        assert (
+            v.shape[1] == num_kv_heads * head_dim
+        ), f"v.shape[1]={v.shape[1]} != {num_kv_heads * head_dim}"
+
+        # Create 3D view for Triton kernel
+        k_3d = k.view(num_tokens, num_kv_heads, head_dim)
+        v_3d = v.view(num_tokens, num_kv_heads, head_dim)
+        # Keep 2D for naive
+        k_2d = k
+        v_2d = v
+    else:
+        raise ValueError(f"Unsupported k.ndim={k.ndim}, expected 2 or 3")
+
+    # Step 3: Compute cache strides based on layout
+    if k_cache.ndim == 3:
+        # 3D cache: [total_slots, num_kv_heads, head_dim]
+        stride_slot = k_cache.stride(0)
+        stride_head = k_cache.stride(1)
+        stride_dim = k_cache.stride(2)
+
+        k_cache_stride_page = stride_slot * page_size
+        k_cache_stride_offset = stride_slot
+        k_cache_stride_head = stride_head
+        k_cache_stride_dim = stride_dim
+
+        v_stride_slot = v_cache.stride(0)
+        v_stride_head = v_cache.stride(1)
+        v_stride_dim = v_cache.stride(2)
+
+        v_cache_stride_page = v_stride_slot * page_size
+        v_cache_stride_offset = v_stride_slot
+        v_cache_stride_head = v_stride_head
+        v_cache_stride_dim = v_stride_dim
+    else:
+        # 4D cache: [num_pages, page_size, num_kv_heads, head_dim]
+        k_cache_stride_page = k_cache.stride(0)
+        k_cache_stride_offset = k_cache.stride(1)
+        k_cache_stride_head = k_cache.stride(2)
+        k_cache_stride_dim = k_cache.stride(3)
+
+        v_cache_stride_page = v_cache.stride(0)
+        v_cache_stride_offset = v_cache.stride(1)
+        v_cache_stride_head = v_cache.stride(2)
+        v_cache_stride_dim = v_cache.stride(3)
+
+    # Decide whether to use provided scale
+    use_provided_scale = k_scale is not None and v_scale is not None
+
+    if use_triton and num_tokens > 0:
+        # Use optimized Triton kernel
+        # Compute input strides for 3D k, v: [num_tokens, num_kv_heads, head_dim]
+        k_stride_token = k_3d.stride(0)
+        k_stride_head = k_3d.stride(1)
+        k_stride_dim = k_3d.stride(2)
+
+        v_stride_token = v_3d.stride(0)
+        v_stride_head = v_3d.stride(1)
+        v_stride_dim = v_3d.stride(2)
+
+        # Block sizes for tiling (tunable)
+        BLOCK_HEAD = min(num_kv_heads, 8)  # Process up to 8 heads at once
+        BLOCK_DIM = min(head_dim, 128)  # Process up to 128 dims at once
+
+        # Compute number of head blocks
+        num_head_blocks = (num_kv_heads + BLOCK_HEAD - 1) // BLOCK_HEAD
+
+        # Grid: (num_tokens, num_head_blocks, 2)
+        # - dim 0: tokens
+        # - dim 1: head blocks
+        # - dim 2: K/V (0=K, 1=V)
+        grid = (num_tokens, num_head_blocks, 2)
+
+        device = k_3d.device
+
+        def _to_tensor_scale(scale):
+            """Convert scale to 0-D CUDA tensor (accepts Python float or Tensor)."""
+            if isinstance(scale, torch.Tensor):
+                return scale.to(device=device, dtype=torch.float32)
+            else:
+                # Python float / np scalar
+                return torch.tensor(float(scale), device=device, dtype=torch.float32)
+
+        # Compute inverse scales on GPU to avoid GPU→CPU sync in CUDA graph capture.
+        # Previously we used float(k_scale) which triggers synchronization and fails
+        # during CUDA graph capture with cudaErrorStreamCaptureUnsupported.
+        if use_provided_scale:
+            k_scale_tensor = _to_tensor_scale(k_scale)
+            v_scale_tensor = _to_tensor_scale(v_scale)
+
+            # Pure GPU scalar operation, safe for CUDA graph
+            inv_k_scale = (1.0 / k_scale_tensor).to(device=device, dtype=torch.float32)
+            inv_v_scale = (1.0 / v_scale_tensor).to(device=device, dtype=torch.float32)
+
+            inv_k_scale_ptr = inv_k_scale
+            inv_v_scale_ptr = inv_v_scale
+        else:
+            # When use_provided_scale=False, kernel uses constant 1.0 for inv_scale.
+            # Triton will optimize away the tl.load() calls via constant folding.
+            # We pass dummy pointers (k_3d) which won't be accessed in the kernel.
+            # This avoids creating new GPU tensors during CUDA graph capture.
+            inv_k_scale_ptr = k_3d
+            inv_v_scale_ptr = k_3d
+
+        # Launch Triton kernel
+        _fused_fp8_set_kv_buffer_kernel[grid](
+            k_3d,
+            v_3d,
+            k_cache,
+            v_cache,
+            cache_loc,
+            inv_k_scale_ptr,
+            inv_v_scale_ptr,
+            use_provided_scale,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            k_stride_token,
+            k_stride_head,
+            k_stride_dim,
+            k_cache_stride_page,
+            k_cache_stride_offset,
+            k_cache_stride_head,
+            k_cache_stride_dim,
+            v_stride_token,
+            v_stride_head,
+            v_stride_dim,
+            v_cache_stride_page,
+            v_cache_stride_offset,
+            v_cache_stride_head,
+            v_cache_stride_dim,
+            BLOCK_HEAD=BLOCK_HEAD,
+            BLOCK_DIM=BLOCK_DIM,
+        )
+    else:
+        # Fallback to naive implementation
+        _naive_fp8_set_kv_buffer(
+            k_2d, v_2d, k_cache, v_cache, cache_loc, k_scale, v_scale, page_size
+        )
+
+
+def _naive_fp8_set_kv_buffer(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    cache_loc: torch.Tensor,
+    k_scale: Optional[float],
+    v_scale: Optional[float],
+    page_size: int,
+) -> None:
+    """
+    Naive fallback implementation that mimics the original set_kv_buffer logic.
+
+    This directly replicates the behavior of MHATokenToKVPool.set_kv_buffer:
+    1. Apply scale (if k.dtype != cache.dtype and scale is provided)
+    2. Convert to FP8
+    3. Write to cache at cache_loc
+
+    Args:
+        k: [num_tokens, num_kv_heads * head_dim], already reshaped to 2D
+        v: [num_tokens, num_kv_heads * head_dim], already reshaped to 2D
+        k_cache: [total_slots, num_kv_heads, head_dim] or [num_pages, page_size, num_kv_heads, head_dim]
+        v_cache: Same shape as k_cache
+        cache_loc: [num_tokens]
+        k_scale: Optional scale for K
+        v_scale: Optional scale for V
+        page_size: Tokens per page
+    """
+    num_tokens = k.shape[0]
+
+    # Infer dimensions from cache
+    if k_cache.ndim == 3:
+        num_kv_heads = k_cache.shape[1]
+        head_dim = k_cache.shape[2]
+    elif k_cache.ndim == 4:
+        num_kv_heads = k_cache.shape[2]
+        head_dim = k_cache.shape[3]
+    else:
+        raise ValueError(f"Unsupported k_cache.ndim={k_cache.ndim}")
+
+    # Determine target dtype and storage dtype
+    # See: python/sglang/srt/mem_cache/memory_pool.py:445-449
+    store_dtype = k_cache.dtype
+    if store_dtype == torch.uint8:
+        # Cache is stored as uint8 for FP8 (due to index_put limitation)
+        dtype = torch.float8_e4m3fn  # Logical dtype
+    else:
+        dtype = store_dtype  # Cache dtype is the logical dtype
+
+    # Replicate the original set_kv_buffer behavior
+    # See: python/sglang/srt/mem_cache/memory_pool.py:777-799
+    if k.dtype != dtype:
+        # Need quantization - clone first to avoid modifying input
+        k = k.clone()
+        v = v.clone()
+
+        if k_scale is not None:
+            k.div_(k_scale)  # In-place division
+        if v_scale is not None:
+            v.div_(v_scale)  # In-place division
+
+        k = k.to(dtype)
+        v = v.to(dtype)
+
+    # View FP8 as uint8 if needed (for index_put compatibility)
+    if store_dtype == torch.uint8 and dtype in (torch.float8_e5m2, torch.float8_e4m3fn):
+        k = k.view(torch.uint8)
+        v = v.view(torch.uint8)
+
+    # Reshape from [T, H*D] to [T, H, D]
+    k = k.view(num_tokens, num_kv_heads, head_dim)
+    v = v.view(num_tokens, num_kv_heads, head_dim)
+
+    # Write to cache using advanced indexing (same as original)
+    if k_cache.ndim == 3:
+        # 3D cache: [total_slots, H, D]
+        k_cache[cache_loc] = k
+        v_cache[cache_loc] = v
+    else:
+        # 4D cache: [num_pages, page_size, H, D]
+        # Decompose loc into page_id and page_offset (vectorized)
+        page_ids = cache_loc // page_size
+        page_offsets = cache_loc % page_size
+        k_cache[page_ids, page_offsets] = k
+        v_cache[page_ids, page_offsets] = v

--- a/python/tokenspeed/runtime/models/qwen3_5.py
+++ b/python/tokenspeed/runtime/models/qwen3_5.py
@@ -826,24 +826,14 @@ class Qwen3_5ForCausalLM(nn.Module):
         alt_stream = torch.cuda.Stream()
 
         # Embedding layer
-        if self.mapping.attn.has_dp:
-            self.embed_tokens = VocabParallelEmbedding(
-                config.vocab_size,
-                config.hidden_size,
-                org_num_embeddings=config.vocab_size,
-                tp_rank=self.mapping.attn.tp_rank,
-                tp_size=self.mapping.attn.tp_size,
-                tp_group=self.mapping.attn.tp_group,
-            )
-        else:
-            self.embed_tokens = VocabParallelEmbedding(
-                config.vocab_size,
-                config.hidden_size,
-                org_num_embeddings=config.vocab_size,
-                tp_rank=self.mapping.attn.tp_rank,
-                tp_size=self.mapping.attn.tp_size,
-                tp_group=self.mapping.attn.tp_group,
-            )
+        self.embed_tokens = VocabParallelEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            org_num_embeddings=config.vocab_size,
+            tp_rank=self.mapping.attn.tp_rank,
+            tp_size=self.mapping.attn.tp_size,
+            tp_group=self.mapping.attn.tp_group,
+        )
 
         # Decoder layers
         def get_layer(idx: int, prefix: str):

--- a/python/tokenspeed/runtime/models/qwen3_5.py
+++ b/python/tokenspeed/runtime/models/qwen3_5.py
@@ -877,9 +877,14 @@ class Qwen3_5ForCausalLM(nn.Module):
     ) -> tuple[torch.Tensor, None]:
         # Initialize hidden states
         if input_embeds is None:
-            hidden_states = self.embed_tokens(input_ids, reduce_results=False)
-            # Use zeros residual so the first layer do fused allreduce+residual+norm path.
-            residual = torch.zeros_like(hidden_states)
+            # Only skip embedding allreduce when the first layer's fused
+            # allreduce+residual+norm will handle it
+            if self.layers[0].comm_manager.should_fuse(input_ids.shape[0]):
+                hidden_states = self.embed_tokens(input_ids, reduce_results=False)
+                residual = torch.zeros_like(hidden_states)
+            else:
+                hidden_states = self.embed_tokens(input_ids)
+                residual = None
         else:
             hidden_states = input_embeds
             residual = None

--- a/python/tokenspeed/runtime/models/qwen3_5.py
+++ b/python/tokenspeed/runtime/models/qwen3_5.py
@@ -890,7 +890,8 @@ class Qwen3_5ForCausalLM(nn.Module):
             hidden_states = self.embed_tokens(input_ids)
         else:
             hidden_states = input_embeds
-        residual = None
+        # Pre-alloc zeros for residual
+        residual = torch.zeros_like(hidden_states)
 
         # Pass through decoder layers
         for layer_idx in range(len(self.layers)):

--- a/python/tokenspeed/runtime/models/qwen3_5.py
+++ b/python/tokenspeed/runtime/models/qwen3_5.py
@@ -887,7 +887,7 @@ class Qwen3_5ForCausalLM(nn.Module):
     ) -> tuple[torch.Tensor, None]:
         # Initialize hidden states
         if input_embeds is None:
-            hidden_states = self.embed_tokens(input_ids)
+            hidden_states = self.embed_tokens(input_ids, reduce_results=False)
         else:
             hidden_states = input_embeds
         # Pre-alloc zeros for residual

--- a/python/tokenspeed/runtime/models/qwen3_5.py
+++ b/python/tokenspeed/runtime/models/qwen3_5.py
@@ -878,10 +878,11 @@ class Qwen3_5ForCausalLM(nn.Module):
         # Initialize hidden states
         if input_embeds is None:
             hidden_states = self.embed_tokens(input_ids, reduce_results=False)
+            # Use zeros residual so the first layer do fused allreduce+residual+norm path.
+            residual = torch.zeros_like(hidden_states)
         else:
             hidden_states = input_embeds
-        # Pre-alloc zeros for residual
-        residual = torch.zeros_like(hidden_states)
+            residual = None
 
         # Pass through decoder layers
         for layer_idx in range(len(self.layers)):

--- a/python/tokenspeed/runtime/sampling/backends/flashinfer.py
+++ b/python/tokenspeed/runtime/sampling/backends/flashinfer.py
@@ -104,6 +104,8 @@ class FlashInferSamplingBackend(SamplingBackend):
         # gives per-step uniqueness independent of the torch.Generator.
         self._generator_per_slot: list[torch.Generator | None] = [None] * pool_rows
         self._generator_per_slot[0] = self._capture_gen
+        self._cpu_generator_per_slot: list[torch.Generator | None] = [None] * pool_rows
+        self._cpu_generator_per_slot[0] = self._capture_gen
 
     def _reset_slot(self, pool_idx: int, sp: SamplingParams) -> None:
         self._temperature_pool[pool_idx].fill_(float(sp.temperature))
@@ -114,6 +116,10 @@ class FlashInferSamplingBackend(SamplingBackend):
         gen = torch.Generator(device=self.config.device)
         gen.manual_seed(int(sp.seed))
         self._generator_per_slot[pool_idx] = gen
+        
+        cpu_gen = torch.Generator(device="cpu")
+        cpu_gen.manual_seed(int(sp.seed))
+        self._cpu_generator_per_slot[pool_idx] = cpu_gen
 
     def _init_shared_buffers(self, config: SamplingBackendConfig) -> None:
 
@@ -127,6 +133,11 @@ class FlashInferSamplingBackend(SamplingBackend):
         self._final_coins_buf = torch.zeros(
             (config.max_bs,), dtype=torch.float32, device=config.device
         )
+
+        self._cpu_coins_buf = torch.empty(
+            config.max_bs, config.max_draft_tokens_per_req, dtype=torch.float32, pin_memory=True
+        )
+        self._cpu_final_coins_buf = torch.empty(config.max_bs, dtype=torch.float32, pin_memory=True)
 
         # Stub generator used during CUDA-graph capture/warm-up (no requests yet).
         self._capture_gen = torch.Generator(device=config.device)
@@ -152,6 +163,7 @@ class FlashInferSamplingBackend(SamplingBackend):
             (config.max_bs,), dtype=torch.int32, device=config.device
         )
 
+    @torch.compile(dynamic=True, backend=get_compiler_backend())
     def _prepare_step_hook(
         self,
         num_tokens_per_req: int,
@@ -172,17 +184,21 @@ class FlashInferSamplingBackend(SamplingBackend):
             self._coins_buf[:bs, :n].uniform_(lo, 1.0, generator=self._capture_gen)
             self._final_coins_buf[:bs].uniform_(lo, 1.0, generator=self._capture_gen)
             return
+            
+        cpu_coins = self._cpu_coins_buf[:bs, :n]
+        cpu_final = self._cpu_final_coins_buf[:bs]
 
         for i, pool_idx in enumerate(request_pool_indices):
-            gen = self._generator_per_slot[pool_idx]
-            if gen is None:
-                # No _reset_slot has run for this slot yet — fall back to
-                # the stub generator. Should not happen in well-formed runs
-                # because prepare_step's flip detection runs _reset_slot
-                # before this hook.
-                gen = self._capture_gen
-            self._coins_buf[i, :n].uniform_(lo, 1.0, generator=gen)
-            self._final_coins_buf[i : i + 1].uniform_(lo, 1.0, generator=gen)
+            # No _reset_slot has run for this slot yet — fall back to
+            # the stub generator. Should not happen in well-formed runs
+            # because prepare_step's flip detection runs _reset_slot
+            # before this hook.
+            gen = self._cpu_generator_per_slot[pool_idx] or self._capture_gen
+            cpu_coins[i, :n].uniform_(lo, 1.0, generator=gen)
+            cpu_final[i].uniform_(lo, 1.0, generator=gen)
+
+        self._coins_buf[:bs, :n].copy_(cpu_coins, non_blocking=True)
+        self._final_coins_buf[:bs].copy_(cpu_final, non_blocking=True)
 
     @torch.compile(dynamic=True, backend=get_compiler_backend())
     def _gather_scalars(

--- a/python/tokenspeed/runtime/sampling/backends/flashinfer.py
+++ b/python/tokenspeed/runtime/sampling/backends/flashinfer.py
@@ -116,7 +116,7 @@ class FlashInferSamplingBackend(SamplingBackend):
         gen = torch.Generator(device=self.config.device)
         gen.manual_seed(int(sp.seed))
         self._generator_per_slot[pool_idx] = gen
-        
+
         cpu_gen = torch.Generator(device="cpu")
         cpu_gen.manual_seed(int(sp.seed))
         self._cpu_generator_per_slot[pool_idx] = cpu_gen
@@ -135,9 +135,14 @@ class FlashInferSamplingBackend(SamplingBackend):
         )
 
         self._cpu_coins_buf = torch.empty(
-            config.max_bs, config.max_draft_tokens_per_req, dtype=torch.float32, pin_memory=True
+            config.max_bs,
+            config.max_draft_tokens_per_req,
+            dtype=torch.float32,
+            pin_memory=True,
         )
-        self._cpu_final_coins_buf = torch.empty(config.max_bs, dtype=torch.float32, pin_memory=True)
+        self._cpu_final_coins_buf = torch.empty(
+            config.max_bs, dtype=torch.float32, pin_memory=True
+        )
 
         # Stub generator used during CUDA-graph capture/warm-up (no requests yet).
         self._capture_gen = torch.Generator(device=config.device)
@@ -184,7 +189,7 @@ class FlashInferSamplingBackend(SamplingBackend):
             self._coins_buf[:bs, :n].uniform_(lo, 1.0, generator=self._capture_gen)
             self._final_coins_buf[:bs].uniform_(lo, 1.0, generator=self._capture_gen)
             return
-            
+
         cpu_coins = self._cpu_coins_buf[:bs, :n]
         cpu_final = self._cpu_final_coins_buf[:bs]
 


### PR DESCRIPTION
## Summary
Reduce unnecessary GPU kernel launches, DtoD memcpy, and redundant communication during forward preparation.

### Changes

**1. Delay embedding allreduce to first-layer fused norm** (`qwen3_5.py`)
- Skip embedding allreduce when `should_fuse()` is true; the first decoder layer's fused allreduce+residual+rmsnorm handles it instead.
- Fall back to embedding-internal allreduce when fused path is unavailable.

**2. Reduce CUDA graph replay memcpy** (`hybrid_linear_attn.py`)
- Add `_qsl_dirty` + `_qsl_last_mode` tracking to skip redundant `query_start_loc` DtoD copy when content is unchanged.
- Use `mamba_pool_indices` length to infer `num_padding`, avoiding `seq_lens.cpu()` D2H sync.

**3. Fused FP8 KV buffer kernel** (`trtllm_fp8_kv_kernel.py`)
- New Triton kernel to fuse FP8 quantized KV cache write into a single launch.

**4. CPU-side coins buffer fill** (`flashinfer.py`)
- Move speculative decoding coins buffer fill to CPU, reducing GPU kernel launches.
<!-- What changed and why? -->

## Test Plan

### Accuracy (AIME25)

- **MTP enabled**
  <img width="1168" height="142" alt="aime25-mtp" src="https://github.com/user-attachments/assets/73398d72-6190-46a4-8951-9b65b3421e63" />

- **MTP disabled**
  <img width="1172" height="142" alt="image" src="https://github.com/user-attachments/assets/ddb13cab-8ae5-4097-9885-8fddfb2c4885" />

### Performance

Qwen3.5-397B-NVFP4 GB200 TP4, bs=64, input 1024 / output 4096, greedy sampler

| Config | Before (6fa49b3) | After | Speedup |
|--------|:-:|:-:|:-:|
| MTP enabled | 6061 tok/s | 6422 tok/s | +6% |
| MTP disabled | 3275 tok/s | 3438 tok/s | +5% |
<!-- How was this validated? -->
