### PR TITLE
perf(K2.5): Tune num_tokens for router_gemm and fused_a_gemm

### DIFF
--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -419,7 +419,7 @@ class DeepseekV3FusedQkvAProjWithMqa(ReplicatedLinear):
     ) -> torch.Tensor:
         if (
             self.use_min_latency
-            and 0 < x.size(0) <= 16
+            and x.size(0) > 0
             and block_scale is None
             and (output_dtype is None or output_dtype == torch.bfloat16)
         ):

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/dsv3_router_gemm.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/dsv3_router_gemm.cu
@@ -148,7 +148,7 @@ void dsv3_router_gemm(TensorView output, TensorView mat_a, TensorView mat_b, boo
 
   cudaStream_t stream = get_stream(device);
 
-  bool use_custom_kernel = (num_tokens >= 1 && num_tokens <= 16);
+  bool use_custom_kernel = (num_tokens >= 1 && num_tokens <= 8);
   bool supported_experts = (num_experts == 256 || num_experts == 384 || num_experts == 768);
   bool supported_hidden = (hidden_dim == 3072 || hidden_dim == 6144 || hidden_dim == 7168);
 


### PR DESCRIPTION
## Summary

This PR adjusts the token threshold for router_gemm and fused_a_gemm.

## Test Plan

<!-- How was this validated? -->
