### PR TITLE
Fix agentic perf CI triggers

### DIFF
--- a/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
+++ b/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
@@ -1,6 +1,9 @@
 api_version: ci.tokenspeed.io/v1
 name: perf-kimi-k2.5-nvfp4-agentic
 type: perf
+triggers:
+  - per-commit
+  - manual
 runner:
   labels:
     - b200-4gpu


### PR DESCRIPTION
## Summary
- Add the missing per-commit and manual triggers to the Kimi K2.5 NVFP4 agentic perf CI task.

## Verification
- python3 test/ci_system/pipeline.py scan --root test/ci --trigger per-commit
- python3 test/ci_system/pipeline.py scan --root test/ci --trigger manual
- pre-commit run --all-files