### PR TITLE
perf: default TF32 on for FP32 cuBLAS (router GEMMs)

### DIFF
--- a/python/tokenspeed/runtime/entrypoints/engine.py
+++ b/python/tokenspeed/runtime/entrypoints/engine.py
@@ -481,6 +481,11 @@ def _set_envs_and_config(server_args: ServerArgs):
     os.environ["TORCH_NCCL_AVOID_RECORD_STREAMS"] = "1"
     os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "4"
     os.environ["CUDA_MODULE_LOADING"] = "AUTO"
+    if not server_args.disable_tf32:
+        # Force TF32 on for cuBLAS/cuDNN matmuls. setdefault so a user's
+        # explicit env wins; --disable-tf32 is the documented opt-out.
+        os.environ.setdefault("NVIDIA_TF32_OVERRIDE", "1")
+        os.environ.setdefault("TORCH_ALLOW_TF32_CUBLAS_OVERRIDE", "1")
 
     # Set prometheus env vars
     if server_args.enable_metrics:

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -223,6 +223,7 @@ class ServerArgs:
     enable_symm_mem: bool = False
     disable_custom_all_reduce: bool = False
     disable_overlap_schedule: bool = False
+    disable_tf32: bool = False
     force_deterministic_rsag: bool = False
     disable_sampling_tp_sync: bool = False
     low_latency_max_num_tokens_per_gpu: int = 256
@@ -1398,6 +1399,12 @@ class ServerArgs:
             "--disable-overlap-schedule",
             action="store_true",
             help="Disable the overlap scheduler, which overlaps the CPU scheduler with GPU model worker.",
+        )
+        parser.add_argument(
+            "--disable-tf32",
+            action="store_true",
+            help="Disable forcing TF32 on for cuBLAS/cuDNN. By default the server sets "
+            "NVIDIA_TF32_OVERRIDE=1 and TORCH_ALLOW_TF32_CUBLAS_OVERRIDE=1.",
         )
         parser.add_argument(
             "--max-cudagraph-capture-size",


### PR DESCRIPTION
## Summary

Default-set `NVIDIA_TF32_OVERRIDE=1` and `TORCH_ALLOW_TF32_CUBLAS_OVERRIDE=1` in the engine launch path, with `--disable-tf32` as the opt-out.

The change only affects kernels that run in FP32 on cuBLAS/cuDNN pick up TF32 tensor cores.

## Test Plan

<!-- How was this validated? -->
