### PR TITLE
[AMD] Add eval ci and fix kv store addr on mi355

### DIFF
--- a/python/tokenspeed/runtime/cache/kv_cache_host.py
+++ b/python/tokenspeed/runtime/cache/kv_cache_host.py
@@ -226,7 +226,7 @@ class MHATokenToKVPoolHost(HostKVCache):
         host_size: int,
         page_size: int,
         layout: str,
-        pin_memory: bool = True,
+        pin_memory: bool = _is_nvidia,
         device: str = "cpu",
         host_size_tokens: int = 0,
     ):
@@ -549,7 +549,7 @@ class MLATokenToKVPoolHost(HostKVCache):
         host_size: int,
         page_size: int,
         layout: str,
-        pin_memory: bool = True,
+        pin_memory: bool = _is_nvidia,
         device: str = "cpu",
         host_size_tokens: int = 0,
     ):

--- a/python/tokenspeed/runtime/cache/kv_cache_host.py
+++ b/python/tokenspeed/runtime/cache/kv_cache_host.py
@@ -51,7 +51,6 @@ from tokenspeed_kernel.ops.kvcache.triton import (
     transfer_kv_per_layer,
 )
 
-SUPPORT_PIN_MEMORY = True
 MLA_KVSTORE_LOADBACK_BLOCK_QUOTA = 16
 MLA_KVSTORE_WRITEBACK_BLOCK_QUOTA = 16
 
@@ -73,14 +72,12 @@ class HostKVCache(abc.ABC):
         host_size: int,
         page_size: int,
         layout: str,
-        pin_memory: bool,
         device: str,
         host_size_tokens: int = 0,
     ):
         self.device_pool = device_pool
         self.page_size = page_size
         self.layout = layout
-        self.pin_memory = pin_memory and SUPPORT_PIN_MEMORY
         self.device = device
 
         self.dtype = device_pool.store_dtype
@@ -226,7 +223,6 @@ class MHATokenToKVPoolHost(HostKVCache):
         host_size: int,
         page_size: int,
         layout: str,
-        pin_memory: bool = _is_nvidia,
         device: str = "cpu",
         host_size_tokens: int = 0,
     ):
@@ -236,20 +232,20 @@ class MHATokenToKVPoolHost(HostKVCache):
             host_size,
             page_size,
             layout,
-            pin_memory,
             device,
             host_size_tokens=host_size_tokens,
         )
         self.element_dim = self.device_pool.head_num * self.device_pool.head_dim
         self.k_data_refs = [self.k_buffer[i] for i in range(self.layer_num)]
         self.v_data_refs = [self.v_buffer[i] for i in range(self.layer_num)]
+        platform = current_platform()
         self.k_data_ptrs = torch.tensor(
-            [x.data_ptr() for x in self.k_data_refs],
+            [platform.device_visible_data_ptr(x) for x in self.k_data_refs],
             dtype=torch.uint64,
             device=self.device_pool.device,
         )
         self.v_data_ptrs = torch.tensor(
-            [x.data_ptr() for x in self.v_data_refs],
+            [platform.device_visible_data_ptr(x) for x in self.v_data_refs],
             dtype=torch.uint64,
             device=self.device_pool.device,
         )
@@ -287,10 +283,7 @@ class MHATokenToKVPoolHost(HostKVCache):
             dtype=self.dtype,
             device=self.device,
         )
-        if self.pin_memory:
-            torch.cuda.cudart().cudaHostRegister(
-                buffer.data_ptr(), buffer.numel() * buffer.element_size(), 0
-            )
+        current_platform().register_host_tensor_for_gpu_access(buffer)
         return buffer
 
     @property
@@ -446,7 +439,7 @@ class MHATokenToKVPoolHost(HostKVCache):
             (2, self.layer_num, self.page_size, self.head_num, self.head_dim),
             dtype=self.dtype,
             device=self.device,
-            pin_memory=self.pin_memory,
+            pin_memory=True,
         ).flatten()
 
     def set_from_flat_data_page(self, index: int, data_page: torch.Tensor) -> None:
@@ -549,7 +542,6 @@ class MLATokenToKVPoolHost(HostKVCache):
         host_size: int,
         page_size: int,
         layout: str,
-        pin_memory: bool = _is_nvidia,
         device: str = "cpu",
         host_size_tokens: int = 0,
     ):
@@ -559,13 +551,13 @@ class MLATokenToKVPoolHost(HostKVCache):
             host_size,
             page_size,
             layout,
-            pin_memory,
             device,
             host_size_tokens=host_size_tokens,
         )
         self.data_refs = [self.kv_buffer[i] for i in range(self.layer_num)]
+        platform = current_platform()
         self.data_ptrs = torch.tensor(
-            [x.data_ptr() for x in self.data_refs],
+            [platform.device_visible_data_ptr(x) for x in self.data_refs],
             dtype=torch.uint64,
             device=self.device_pool.device,
         )
@@ -611,10 +603,7 @@ class MLATokenToKVPoolHost(HostKVCache):
             dtype=self.dtype,
             device=self.device,
         )
-        if self.pin_memory:
-            torch.cuda.cudart().cudaHostRegister(
-                buffer.data_ptr(), buffer.numel() * buffer.element_size(), 0
-            )
+        current_platform().register_host_tensor_for_gpu_access(buffer)
         return buffer
 
     def load_to_device_per_layer(
@@ -726,7 +715,7 @@ class MLATokenToKVPoolHost(HostKVCache):
             ),
             dtype=self.dtype,
             device=self.device,
-            pin_memory=self.pin_memory,
+            pin_memory=True,
         ).flatten()
 
     def set_from_flat_data_page(self, index: int, data_page: torch.Tensor) -> None:

--- a/python/tokenspeed/runtime/configs/model_config.py
+++ b/python/tokenspeed/runtime/configs/model_config.py
@@ -300,6 +300,7 @@ class ModelConfig:
         optimized_quantization_methods = [
             "fp8",
             "nvfp4",
+            "mxfp4",
             "compressed_tensors",
             "compressed-tensors",
             "w8a8_fp8",

--- a/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
+++ b/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
@@ -14,7 +14,6 @@ runner:
       GPT_OSS_EVAL_MOE_BACKEND: flashinfer_mxfp4
     linux-mi355-2gpu-lightseek:
       GPT_OSS_EVAL_KVSTORE_RATIO: "0.25"
-      GPT_OSS_EVAL_MAX_TOTAL_TOKENS: "1310720"
 env:
   CI: "true"
 install:
@@ -33,7 +32,6 @@ server:
     ${GPT_OSS_EVAL_ATTENTION_BACKEND:+--attention-backend ${GPT_OSS_EVAL_ATTENTION_BACKEND}}
     ${GPT_OSS_EVAL_MOE_BACKEND:+--moe-backend ${GPT_OSS_EVAL_MOE_BACKEND}}
     ${GPT_OSS_EVAL_KVSTORE_RATIO:+--kvstore-ratio ${GPT_OSS_EVAL_KVSTORE_RATIO}}
-    ${GPT_OSS_EVAL_MAX_TOTAL_TOKENS:+--max-total-tokens ${GPT_OSS_EVAL_MAX_TOTAL_TOKENS}}
     --enable-cache-report
     --host 127.0.0.1
   ready:

--- a/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
+++ b/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
@@ -13,6 +13,7 @@ runner:
       GPT_OSS_EVAL_ATTENTION_BACKEND: trtllm
       GPT_OSS_EVAL_MOE_BACKEND: flashinfer_mxfp4
     linux-mi355-2gpu-lightseek:
+      # speed up host-side mem alloc in ci
       GPT_OSS_EVAL_KVSTORE_RATIO: "0.25"
 env:
   CI: "true"

--- a/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
+++ b/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
@@ -7,6 +7,14 @@ triggers:
 runner:
   labels:
     - b200-2gpu
+    - linux-mi355-2gpu-lightseek
+  env:
+    b200-2gpu:
+      GPT_OSS_EVAL_ATTENTION_BACKEND: trtllm
+      GPT_OSS_EVAL_MOE_BACKEND: flashinfer_mxfp4
+    linux-mi355-2gpu-lightseek:
+      GPT_OSS_EVAL_KVSTORE_RATIO: "0.25"
+      GPT_OSS_EVAL_MAX_TOTAL_TOKENS: "1310720"
 env:
   CI: "true"
 install:
@@ -22,8 +30,10 @@ server:
     --chunked-prefill-size 8192
     --trust-remote-code
     --reasoning-parser gpt-oss
-    --attention-backend trtllm
-    --moe-backend flashinfer_mxfp4
+    ${GPT_OSS_EVAL_ATTENTION_BACKEND:+--attention-backend ${GPT_OSS_EVAL_ATTENTION_BACKEND}}
+    ${GPT_OSS_EVAL_MOE_BACKEND:+--moe-backend ${GPT_OSS_EVAL_MOE_BACKEND}}
+    ${GPT_OSS_EVAL_KVSTORE_RATIO:+--kvstore-ratio ${GPT_OSS_EVAL_KVSTORE_RATIO}}
+    ${GPT_OSS_EVAL_MAX_TOTAL_TOKENS:+--max-total-tokens ${GPT_OSS_EVAL_MAX_TOTAL_TOKENS}}
     --enable-cache-report
     --host 127.0.0.1
   ready:

--- a/tokenspeed-kernel/python/requirements/common.txt
+++ b/tokenspeed-kernel/python/requirements/common.txt
@@ -1,5 +1,4 @@
 apache-tvm-ffi>=0.1.5
-nvidia-cutlass-dsl
 numpy
 packaging
 PyYAML>=6.0

--- a/tokenspeed-kernel/python/requirements/cuda.txt
+++ b/tokenspeed-kernel/python/requirements/cuda.txt
@@ -1,4 +1,5 @@
 -r common.txt
+nvidia-cutlass-dsl
 torch==2.11.0
 flashinfer-python==0.6.9
 flashinfer-cubin==0.6.9

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
@@ -264,7 +264,6 @@ def transfer_kv_per_layer(
     src_indices: torch.Tensor,
     dst_indices: torch.Tensor,
     item_size: int,
-    block_quota: int | None = None,
 ) -> None:
     """
     Transfer KV cache entries for one layer based on src/dst indices.
@@ -277,10 +276,7 @@ def transfer_kv_per_layer(
         src_indices: Source indices tensor [length]
         dst_indices: Destination indices tensor [length]
         item_size: Number of bytes per cache slot
-        block_quota: Accepted for CUDA API compatibility; unused by this Triton kernel
     """
-    del block_quota
-
     if item_size % src_k.element_size() != 0:
         raise ValueError("item_size must be divisible by the KV cache element size.")
     element_dim = item_size // src_k.element_size()
@@ -325,7 +321,6 @@ def transfer_kv_all_layer(
     dst_indices: torch.Tensor,
     item_size: int,
     num_layers: int,
-    block_quota: int | None = None,
 ) -> None:
     """
     Transfer KV cache entries for all layers based on src/dst indices.
@@ -339,10 +334,7 @@ def transfer_kv_all_layer(
         dst_indices: Destination indices tensor [length]
         item_size: Number of bytes per cache slot
         num_layers: Number of layers to copy
-        block_quota: Accepted for CUDA API compatibility; unused by this Triton kernel
     """
-    del block_quota
-
     length = src_indices.numel()
 
     if length == 0:

--- a/tokenspeed-kernel/python/tokenspeed_kernel/platform.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/platform.py
@@ -32,7 +32,7 @@ import tempfile
 from dataclasses import dataclass
 from functools import lru_cache
 from itertools import product
-from typing import Sequence
+from pathlib import Path
 
 import torch
 import torch.distributed as dist
@@ -202,6 +202,23 @@ class PlatformInfo:
             fp8_min = -fp8_max
             _fp8e4m3_dtype = Fp8E4M3FnDType(dtype=dtype, max=fp8_max, min=fp8_min)
         return _fp8e4m3_dtype
+
+    def register_host_tensor_for_gpu_access(self, tensor: torch.Tensor) -> None:
+        """Register host memory that GPU kernels will directly dereference."""
+        if tensor.device.type != "cpu" or tensor.numel() == 0:
+            return
+        status = torch.cuda.cudart().cudaHostRegister(
+            tensor.data_ptr(), tensor.numel() * tensor.element_size(), 0
+        )
+        if int(status) != 0:
+            raise RuntimeError(f"cudaHostRegister failed with {status!s}")
+
+    def device_visible_data_ptr(self, tensor: torch.Tensor) -> int:
+        """Return a pointer value that is valid to dereference from GPU kernels."""
+        ptr = tensor.data_ptr()
+        if self.is_amd and tensor.device.type == "cpu" and tensor.numel() > 0:
+            return _hip_host_get_device_pointer(ptr)
+        return ptr
 
     @property
     def generation_name(self) -> str:
@@ -644,3 +661,55 @@ def _check_symmetric_memory_available() -> bool:
 def _check_nvlink_available() -> bool:
     """Check if NVLink connectivity is available."""
     return _detect_cuda_nvlink_topology() is not None
+
+
+@lru_cache(maxsize=1)
+def _get_hip_runtime():
+    lib_name = "libamdhip64.so"
+    candidates = []
+    torch_hip_path = Path(torch.__file__).resolve().parent / "lib" / lib_name
+    if torch_hip_path.exists():
+        candidates.append(str(torch_hip_path))
+    candidates.append(lib_name)
+
+    last_error = None
+    for candidate in candidates:
+        try:
+            lib = ctypes.CDLL(candidate)
+            lib.hipHostGetDevicePointer.argtypes = [
+                ctypes.POINTER(ctypes.c_void_p),
+                ctypes.c_void_p,
+                ctypes.c_uint,
+            ]
+            lib.hipHostGetDevicePointer.restype = ctypes.c_int
+            if hasattr(lib, "hipGetErrorString"):
+                lib.hipGetErrorString.argtypes = [ctypes.c_int]
+                lib.hipGetErrorString.restype = ctypes.c_char_p
+            return lib
+        except OSError as exc:
+            last_error = exc
+
+    raise RuntimeError(f"Failed to load {lib_name}") from last_error
+
+
+def _hip_host_get_device_pointer(host_ptr: int) -> int:
+    lib = _get_hip_runtime()
+    device_ptr = ctypes.c_void_p()
+    error = lib.hipHostGetDevicePointer(
+        ctypes.byref(device_ptr), ctypes.c_void_p(host_ptr), 0
+    )
+    if error != 0:
+        error_str = f"HIP error {error}"
+        if hasattr(lib, "hipGetErrorString"):
+            raw_error_str = lib.hipGetErrorString(error)
+            if raw_error_str:
+                error_str = raw_error_str.decode()
+        raise RuntimeError(
+            "hipHostGetDevicePointer failed for registered host pointer "
+            f"0x{host_ptr:x}: {error_str}"
+        )
+    if device_ptr.value is None:
+        raise RuntimeError(
+            f"hipHostGetDevicePointer returned null for registered host pointer 0x{host_ptr:x}"
+        )
+    return device_ptr.value


### PR DESCRIPTION
## Summary

- Added MI355 coverage to test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml. And moved nvidia-cutlass-dsl out of common kernel deps to speed up ci installation.
- Fixed ROCm host KVStore pointer handling: this addresses the MI355 memory fault where Triton was dereferencing CPU VAs from GPU pointer tables. Added shared platform apis to manage host tensor.
- Cleaned up Triton KVStore API: removed unused block_quota args from tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py.

## Test Plan

Test on mi355

```sh
tokenspeed serve   --model openai/gpt-oss-120b   --host 127.0.0.1   --port 21000   --world-size 1   --max-total-tokens 65536   --enable-cache-report   --enforce-eager
tokenspeed bench   --backend tokenspeed   --host 127.0.0.1   --port 21000   --model openai/gpt-oss-120b   --dataset-name random   --random-input-len 1024   --random-output-len 1024   --random-range-ratio 0.0   --num-prompts 8   --max-concurrency 8   --request-rate inf   --seed 1
```
