### PR TITLE
Fix GPT-OSS MXFP4 scale dtype

### DIFF
--- a/python/tokenspeed/runtime/layers/moe/backends/mxfp4/triton_kernel.py
+++ b/python/tokenspeed/runtime/layers/moe/backends/mxfp4/triton_kernel.py
@@ -43,13 +43,6 @@ _is_amd = current_platform().is_amd
 _CDNA4MXScaleLayout = None
 
 
-def _mxfp4_scale_for_layout(scale: torch.Tensor):
-    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
-    if e8m0_dtype is not None and scale.dtype == e8m0_dtype:
-        return scale.view(torch.uint8)
-    return scale
-
-
 if _is_amd:
     import math
 
@@ -157,7 +150,6 @@ def swizzle_mxfp4(quant_tensor, scale, num_warps):
     if _is_amd and issubclass(scale_layout, layout.CDNA4MXScaleLayout):
         # A patch for an issue in scale preshuffling on CDNA4
         scale_layout = _CDNA4MXScaleLayout
-    scale = _mxfp4_scale_for_layout(scale)
     scale = convert_layout(wrap_torch_tensor(scale), scale_layout, **scale_layout_opts)
     return quant_tensor, InFlexData(), scale
 

--- a/python/tokenspeed/runtime/layers/moe/backends/mxfp4/weights.py
+++ b/python/tokenspeed/runtime/layers/moe/backends/mxfp4/weights.py
@@ -26,7 +26,6 @@ from torch import nn
 from tokenspeed.runtime.layers.moe.backends.base import MoEBackend
 
 MXFP4_BLOCK = 32
-MXFP4_SCALE_DTYPE = getattr(torch, "float8_e8m0fnu", torch.uint8)
 
 
 def create_mxfp4_weights(
@@ -56,7 +55,7 @@ def create_mxfp4_weights(
             num_local_experts,
             2 * ispp_padded,
             hidden_size_padded // MXFP4_BLOCK,
-            dtype=MXFP4_SCALE_DTYPE,
+            dtype=torch.uint8,
         ),
         requires_grad=False,
     )
@@ -79,7 +78,7 @@ def create_mxfp4_weights(
             num_local_experts,
             hidden_size_padded,
             ispp_padded // MXFP4_BLOCK,
-            dtype=MXFP4_SCALE_DTYPE,
+            dtype=torch.uint8,
         ),
         requires_grad=False,
     )
@@ -108,4 +107,4 @@ def create_mxfp4_weights(
         set_weight_attrs(w2_weight_bias, {"weight_loader": weight_loader})
 
 
-__all__ = ["MXFP4_BLOCK", "MXFP4_SCALE_DTYPE", "create_mxfp4_weights"]
+__all__ = ["MXFP4_BLOCK", "create_mxfp4_weights"]

--- a/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
+++ b/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
@@ -54,3 +54,4 @@ eval:
     --generation-config '{"do_sample":false,"temperature":0.0,"max_tokens":65536}'
 report:
   github_step_summary: true
+score_threshold: 0.7

--- a/test/runtime/test_mxfp4_weights.py
+++ b/test/runtime/test_mxfp4_weights.py
@@ -1,0 +1,43 @@
+"""Regression tests for shared MXFP4 MoE weight allocation."""
+
+import os
+import sys
+import unittest
+
+# CI Registration (parsed via AST, runtime no-op)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, suite="runtime-1gpu")
+
+import torch
+from torch import nn
+
+from tokenspeed.runtime.layers.moe.backends.mxfp4.weights import create_mxfp4_weights
+
+
+class _Backend:
+    def _make_weight_loader(self):
+        def _weight_loader(*args, **kwargs):
+            del args, kwargs
+
+        return _weight_loader
+
+
+class TestMxfp4Weights(unittest.TestCase):
+    def test_scale_weights_store_checkpoint_bytes(self):
+        layer = nn.Module()
+        create_mxfp4_weights(
+            _Backend(),
+            layer,
+            num_local_experts=2,
+            hidden_size_padded=64,
+            ispp_padded=96,
+        )
+
+        self.assertEqual(layer.w13_weight_scale.dtype, torch.uint8)
+        self.assertEqual(layer.w2_weight_scale.dtype, torch.uint8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Keep shared MXFP4 MoE scale parameters as checkpoint bytes (torch.uint8) to avoid corrupting GPT-OSS MXFP4 scales during weight loading.
- Remove the unnecessary float8 scale conversion from the shared MXFP4 Triton swizzle path.
- Add a regression test for MXFP4 scale dtype allocation.
- Add a 0.7 score threshold for the GPT-OSS GPQA-Diamond eval CI.

## Verification
- python3 -m unittest test.runtime.test_mxfp4_weights
- python3 test/ci_system/pipeline.py scan --root test/ci --trigger per-commit
- pre-commit run --all-files