### PR TITLE
Fix FlashInfer update workflow branch push

### DIFF
--- a/.github/workflows/update-tokenspeed-kernel-flashinfer.yml
+++ b/.github/workflows/update-tokenspeed-kernel-flashinfer.yml
@@ -68,9 +68,14 @@ jobs:
 
       - name: Create pull request
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.LIGHTSEEK_BOT_TOKEN }}
           VERSION: ${{ steps.update.outputs.version }}
         run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "LIGHTSEEK_BOT_TOKEN is required because this repository does not allow GITHUB_TOKEN to create pull requests." >&2
+            exit 1
+          fi
+
           if git diff --quiet; then
             echo "FlashInfer is already at $VERSION."
             exit 0
@@ -80,27 +85,26 @@ jobs:
           git checkout -b "$branch"
           git add tokenspeed-kernel/python/requirements/cuda.txt
           git commit -s -m "Update tokenspeed-kernel FlashInfer to ${VERSION}"
-          git push --force-with-lease origin "$branch"
+          git push --force origin "HEAD:refs/heads/${branch}"
 
-          body="$(cat <<EOF
+          cat > pr-body.md <<EOF
           ## Summary
           - update tokenspeed-kernel FlashInfer dependencies to ${VERSION}
 
           ## Tests
           - Not run (dependency-only workflow update)
           EOF
-          )"
 
           if gh pr view "$branch" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh pr edit "$branch" \
               --repo "$GITHUB_REPOSITORY" \
               --title "Update tokenspeed-kernel FlashInfer to ${VERSION}" \
-              --body "$body"
+              --body-file pr-body.md
           else
             gh pr create \
               --repo "$GITHUB_REPOSITORY" \
               --base main \
               --head "$branch" \
               --title "Update tokenspeed-kernel FlashInfer to ${VERSION}" \
-              --body "$body"
+              --body-file pr-body.md
           fi


### PR DESCRIPTION
## Summary
- use LIGHTSEEK_BOT_TOKEN for FlashInfer update PR create/edit
- force-push the managed bot update branch directly to avoid stale lease failures when the branch already exists
- write the generated PR body to a file before passing it to gh

## Tests
- pre-commit run --files .github/workflows/update-tokenspeed-kernel-flashinfer.yml
- YAML parse check