### PR TITLE
Suppress FlashAttention JIT cache debug logs

### DIFF
--- a/python/tokenspeed/__init__.py
+++ b/python/tokenspeed/__init__.py
@@ -18,30 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import importlib
-import logging
-
 from tokenspeed._logging import suppress_noisy_third_party_logs
 
 _suppress_noisy_third_party_logs = suppress_noisy_third_party_logs
 
-
-def _suppress_flash_attn_jit_cache_debug_log():
-    module_name = "flash_attn.cute.cache_utils"
-    previous_disable_level = logging.root.manager.disable
-    logging.disable(logging.INFO)
-    try:
-        importlib.import_module(module_name)
-    except ImportError:
-        return
-    finally:
-        logging.disable(previous_disable_level)
-
-    logger_obj = logging.getLogger(module_name)
-    logger_obj.setLevel(logging.WARNING)
-    for handler in logger_obj.handlers:
-        handler.setLevel(logging.WARNING)
-
-
 _suppress_noisy_third_party_logs()
-_suppress_flash_attn_jit_cache_debug_log()

--- a/test/runtime/test_logging.py
+++ b/test/runtime/test_logging.py
@@ -18,46 +18,36 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import contextlib
+import io
 import logging
-import os
+import unittest
 from importlib import import_module
 
-
-def _suppress_flash_attn_jit_cache_debug_log():
-    logger_name = "flash_attn.cute.cache_utils"
-    previous_disable_level = logging.root.manager.disable
-    logging.disable(logging.INFO)
-    try:
-        import_module(logger_name)
-    except ImportError:
-        return
-    finally:
-        logging.disable(previous_disable_level)
-
-    logger = logging.getLogger(logger_name)
-    logger.setLevel(logging.WARNING)
-    for handler in logger.handlers:
-        handler.setLevel(logging.WARNING)
+from tokenspeed._logging import suppress_noisy_third_party_logs
 
 
-def suppress_noisy_third_party_logs():
-    os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+class TestThirdPartyLogging(unittest.TestCase):
+    def test_flash_attn_jit_cache_debug_log_is_suppressed(self):
+        try:
+            cache_utils = import_module("flash_attn.cute.cache_utils")
+        except ImportError:
+            self.skipTest("flash_attn.cute.cache_utils is unavailable")
 
-    for logger_name in (
-        "transformers",
-        "huggingface_hub",
-        "huggingface_hub.file_download",
-        "httpx",
-        "httpcore",
-        "flash_attn.cute.cache_utils",
-    ):
-        logging.getLogger(logger_name).setLevel(logging.WARNING)
+        logging.basicConfig(level=logging.DEBUG, force=True)
+        suppress_noisy_third_party_logs()
 
-    _suppress_flash_attn_jit_cache_debug_log()
+        logger = logging.getLogger("flash_attn.cute.cache_utils")
+        self.assertGreaterEqual(logger.getEffectiveLevel(), logging.WARNING)
+        for handler in logger.handlers:
+            self.assertGreaterEqual(handler.level, logging.WARNING)
 
-    try:
-        from huggingface_hub.utils import disable_progress_bars
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            cache_utils.get_jit_cache()
 
-        disable_progress_bars()
-    except Exception:
-        pass
+        self.assertNotIn("Persistent cache disabled", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- suppress the FlashAttention/CuteDSL JIT cache logger through TokenSpeed's shared noisy-log filtering
- remove the duplicate package-level suppression helper from tokenspeed.__init__
- add a regression test for the "Persistent cache disabled, using in-memory JIT cache" message

## Validation
- python3 -m unittest test.runtime.test_logging
- python3 -c "import logging; logging.basicConfig(level=logging.DEBUG, force=True); import tokenspeed; from flash_attn.cute import cache_utils; cache_utils.get_jit_cache(); print('done')"
- pre-commit run --files python/tokenspeed/__init__.py python/tokenspeed/_logging.py test/runtime/test_logging.py