### PR TITLE
Default prefill token budgets to 8k

### DIFF
--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -52,8 +52,8 @@ For a compact compatibility table, see
 | `--max-model-len` | Maximum sequence length. If omitted, TokenSpeed uses the model config. |
 | `--gpu-memory-utilization` | Fraction of GPU memory used for model weights and KV cache. Lower it to leave headroom. |
 | `--max-num-seqs` | Maximum number of active sequences the scheduler may process concurrently. |
-| `--chunked-prefill-size` | Token budget the scheduler may issue in one iteration. Set `-1` to disable chunked prefill. |
-| `--max-prefill-tokens` | Prefill token budget used when chunked prefill is disabled. |
+| `--chunked-prefill-size` | Token budget the scheduler may issue in one iteration. Defaults to `8192`. Set `-1` to disable chunked prefill. |
+| `--max-prefill-tokens` | Prefill token budget used when chunked prefill is disabled. Defaults to `8192`. |
 | `--max-total-tokens` | Override the automatically calculated token pool size. |
 | `--block-size` | KV cache block size. |
 | `--enable-prefix-caching` / `--no-enable-prefix-caching` | Enable or disable prefix cache reuse. |

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -92,7 +92,7 @@ class ServerArgs:
     max_num_seqs: int | None = None
     max_total_tokens: int | None = None
     chunked_prefill_size: int | None = None
-    max_prefill_tokens: int = 16384
+    max_prefill_tokens: int = 8192
     block_size: int = 64
     # special kv cache
     mamba_ssm_dtype: str = "float32"
@@ -365,14 +365,9 @@ class ServerArgs:
             else:
                 self.gpu_memory_utilization = 0.88
 
-        # Set the chunked prefill token budget, which depends on GPU memory.
+        # Set the chunked prefill token budget.
         if self.chunked_prefill_size is None:
-            if gpu_mem is not None and gpu_mem < 25_000:
-                self.chunked_prefill_size = 2048
-            elif gpu_mem is not None and gpu_mem < 100_000:
-                self.chunked_prefill_size = 8192
-            else:
-                self.chunked_prefill_size = 16384
+            self.chunked_prefill_size = 8192
 
         # Set CUDA graph max capture size.
         if self.max_cudagraph_capture_size is None:

--- a/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
+++ b/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
@@ -26,8 +26,6 @@ server:
     --attn-tp-size 2
     --moe-tp-size 2
     --max-model-len 80000
-    --max-prefill-tokens 8192
-    --chunked-prefill-size 8192
     --trust-remote-code
     --reasoning-parser gpt-oss
     ${GPT_OSS_EVAL_ATTENTION_BACKEND:+--attention-backend ${GPT_OSS_EVAL_ATTENTION_BACKEND}}

--- a/test/ci/eval/kimi-k2.5-nvfp4-evalscope-aime25.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-evalscope-aime25.yaml
@@ -19,8 +19,6 @@ server:
     --attn-tp-size 4
     --moe-tp-size 4
     --max-model-len 80000
-    --max-prefill-tokens 8192
-    --chunked-prefill-size 8192
     --trust-remote-code
     --attention-backend tokenspeed_mla
     --moe-backend flashinfer_trtllm

--- a/test/ci/eval/kimi-k2.5-nvfp4-evalscope-gpqa-diamond.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-evalscope-gpqa-diamond.yaml
@@ -18,8 +18,6 @@ server:
     --attn-tp-size 4
     --moe-tp-size 4
     --max-model-len 80000
-    --max-prefill-tokens 8192
-    --chunked-prefill-size 8192
     --trust-remote-code
     --attention-backend tokenspeed_mla
     --moe-backend flashinfer_trtllm

--- a/test/ci/eval/kimi-k2.5-nvfp4-evalscope-gsm8k.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-evalscope-gsm8k.yaml
@@ -18,8 +18,6 @@ server:
     --attn-tp-size 4
     --moe-tp-size 4
     --max-model-len 80000
-    --max-prefill-tokens 8192
-    --chunked-prefill-size 8192
     --trust-remote-code
     --attention-backend tokenspeed_mla
     --moe-backend flashinfer_trtllm

--- a/test/ci/eval/kimi-k2.5-nvfp4-evalscope-mmlu-pro.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-evalscope-mmlu-pro.yaml
@@ -18,8 +18,6 @@ server:
     --attn-tp-size 4
     --moe-tp-size 4
     --max-model-len 80000
-    --max-prefill-tokens 8192
-    --chunked-prefill-size 8192
     --trust-remote-code
     --attention-backend tokenspeed_mla
     --moe-backend flashinfer_trtllm

--- a/test/ci/eval/kimi-k2.5-nvfp4-evalscope-mmlu.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-evalscope-mmlu.yaml
@@ -18,8 +18,6 @@ server:
     --attn-tp-size 4
     --moe-tp-size 4
     --max-model-len 80000
-    --max-prefill-tokens 8192
-    --chunked-prefill-size 8192
     --trust-remote-code
     --attention-backend tokenspeed_mla
     --moe-backend flashinfer_trtllm

--- a/test/ci/eval/minimax-m2.7-nvfp4-evalscope-aime25.yaml
+++ b/test/ci/eval/minimax-m2.7-nvfp4-evalscope-aime25.yaml
@@ -18,8 +18,6 @@ server:
     --attn-tp-size 2
     --moe-tp-size 2
     --max-model-len 80000
-    --max-prefill-tokens 8192
-    --chunked-prefill-size 8192
     --trust-remote-code
     --reasoning-parser minimax
     --attention-backend trtllm

--- a/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
+++ b/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
@@ -19,8 +19,6 @@ server:
     --moe-tp-size 4
     --max-model-len 80000
     --max-num-seqs 16
-    --max-prefill-tokens 8192
-    --chunked-prefill-size 8192
     --gpu-memory-utilization 0.95
     --disable-cuda-graph-padding
     --trust-remote-code

--- a/test/runtime/test_cli_config_compat.py
+++ b/test/runtime/test_cli_config_compat.py
@@ -17,6 +17,7 @@ import argparse
 import contextlib
 import io
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from tokenspeed.runtime.utils.server_args import ServerArgs
@@ -138,6 +139,23 @@ class TestCLIConfigCompat(unittest.TestCase):
             ["--model", "test/model", "--chunked-prefill-size", "2048"]
         )
         self.assertEqual(args.chunked_prefill_size, 2048)
+
+    def test_prefill_token_defaults(self):
+        args = self._parse_args(["--model", "test/model"])
+        self.assertEqual(args.max_prefill_tokens, 8192)
+        self.assertIsNone(args.chunked_prefill_size)
+
+        sa = self._from_cli_args_no_init(args)
+        sa.mapping = SimpleNamespace(world_size=1)
+        platform = SimpleNamespace(is_amd=False, is_nvidia=False)
+        with patch(
+            "tokenspeed.runtime.utils.server_args.current_platform",
+            return_value=platform,
+        ):
+            sa.resolve_memory_and_scheduling()
+
+        self.assertEqual(sa.max_prefill_tokens, 8192)
+        self.assertEqual(sa.chunked_prefill_size, 8192)
 
     def test_distributed_timeout_seconds_arg(self):
         args = self._parse_args(


### PR DESCRIPTION
## Summary
- default max_prefill_tokens to 8192
- resolve unspecified chunked_prefill_size to 8192 instead of GPU-memory buckets
- remove redundant 8192 prefill flags from CI eval/perf YAML commands
- document both defaults and add a regression test

## Validation
- python3 -m unittest test.runtime.test_cli_config_compat.TestCLIConfigCompat.test_prefill_token_defaults
- pre-commit run --files python/tokenspeed/runtime/utils/server_args.py test/runtime/test_cli_config_compat.py docs/configuration/server.md test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml test/ci/eval/kimi-k2.5-nvfp4-evalscope-aime25.yaml test/ci/eval/kimi-k2.5-nvfp4-evalscope-gpqa-diamond.yaml test/ci/eval/kimi-k2.5-nvfp4-evalscope-gsm8k.yaml test/ci/eval/kimi-k2.5-nvfp4-evalscope-mmlu-pro.yaml test/ci/eval/kimi-k2.5-nvfp4-evalscope-mmlu.yaml test/ci/eval/minimax-m2.7-nvfp4-evalscope-aime25.yaml test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml