### PR TITLE
Align speculative config token steps

### DIFF
--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -338,7 +338,7 @@ class ServerArgs:
 
             num_speculative_tokens = config.get("num_speculative_tokens")
             if num_speculative_tokens is not None:
-                self.speculative_num_draft_tokens = int(num_speculative_tokens)
+                self.speculative_num_steps = int(num_speculative_tokens)
 
         if self.speculative_num_draft_tokens is None:
             self.speculative_num_draft_tokens = self.speculative_num_steps + 1

--- a/test/runtime/test_cli_config_compat.py
+++ b/test/runtime/test_cli_config_compat.py
@@ -301,7 +301,58 @@ class TestCLIConfigCompat(unittest.TestCase):
         sa.resolve_basic_defaults()
         self.assertEqual(sa.speculative_algorithm, "MTP")
         self.assertEqual(sa.speculative_draft_model_path, "draft/model")
-        self.assertEqual(sa.speculative_num_draft_tokens, 3)
+        self.assertEqual(sa.speculative_num_steps, 3)
+        self.assertEqual(sa.speculative_num_draft_tokens, 4)
+
+    def test_speculative_config_matches_explicit_eagle3_args(self):
+        draft_model = "lightseekorg/kimi-k2.5-eagle3-mla"
+
+        config_args = self._parse_args(
+            [
+                "--model",
+                "test/model",
+                "--speculative-config",
+                (
+                    f'{{"model":"{draft_model}",'
+                    '"method":"eagle3",'
+                    '"num_speculative_tokens":1}'
+                ),
+            ]
+        )
+        explicit_args = self._parse_args(
+            [
+                "--model",
+                "test/model",
+                "--speculative-algorithm",
+                "EAGLE3",
+                "--speculative-draft-model-path",
+                draft_model,
+                "--speculative-num-steps",
+                "1",
+            ]
+        )
+
+        config_server_args = self._from_cli_args_no_init(config_args)
+        explicit_server_args = self._from_cli_args_no_init(explicit_args)
+        config_server_args.resolve_basic_defaults()
+        explicit_server_args.resolve_basic_defaults()
+
+        self.assertEqual(
+            config_server_args.speculative_algorithm,
+            explicit_server_args.speculative_algorithm,
+        )
+        self.assertEqual(
+            config_server_args.speculative_draft_model_path,
+            explicit_server_args.speculative_draft_model_path,
+        )
+        self.assertEqual(
+            config_server_args.speculative_num_steps,
+            explicit_server_args.speculative_num_steps,
+        )
+        self.assertEqual(
+            config_server_args.speculative_num_draft_tokens,
+            explicit_server_args.speculative_num_draft_tokens,
+        )
 
     def test_speculative_config_must_be_json_object(self):
         args = self._parse_args(["--model", "test/model", "--speculative-config", "[]"])


### PR DESCRIPTION
## Summary
- map speculative_config num_speculative_tokens to speculative_num_steps
- keep speculative_num_draft_tokens derived as speculative_num_steps + 1 by default
- add a regression test that verifies speculative_config is equivalent to explicit EAGLE3 CLI flags

## Validation
- python3 -m unittest test.runtime.test_cli_config_compat.TestCLIConfigCompat.test_vllm_recipe_speculative_config_arg test.runtime.test_cli_config_compat.TestCLIConfigCompat.test_speculative_config_matches_explicit_eagle3_args test.runtime.test_cli_config_compat.TestCLIConfigCompat.test_speculative_draft_tokens_default_to_steps_plus_one
- pre-commit run --files python/tokenspeed/runtime/utils/server_args.py test/runtime/test_cli_config_compat.py