### PR TITLE
Use FlashInfer wheel index for JIT cache

### DIFF
--- a/.github/workflows/update-tokenspeed-kernel-flashinfer.yml
+++ b/.github/workflows/update-tokenspeed-kernel-flashinfer.yml
@@ -52,12 +52,7 @@ jobs:
           replacements = [
               (r"flashinfer-python==[^\n]+", f"flashinfer-python=={version}"),
               (r"flashinfer-cubin==[^\n]+", f"flashinfer-cubin=={version}"),
-              (
-                  r"https://github\.com/flashinfer-ai/flashinfer/releases/download/"
-                  r"v[^/]+/flashinfer_jit_cache-[^+]+",
-                  "https://github.com/flashinfer-ai/flashinfer/releases/download/"
-                  f"v{version}/flashinfer_jit_cache-{version}",
-              ),
+              (r"flashinfer-jit-cache==[^ ;\n]+", f"flashinfer-jit-cache=={version}+cu130"),
           ]
           for pattern, replacement in replacements:
               text = re.sub(pattern, replacement, text)

--- a/tokenspeed-kernel/python/requirements/cuda.txt
+++ b/tokenspeed-kernel/python/requirements/cuda.txt
@@ -3,6 +3,6 @@ nvidia-cutlass-dsl
 torch==2.11.0
 flashinfer-python==0.6.11
 flashinfer-cubin==0.6.11
-flashinfer_jit_cache @ https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.11/flashinfer_jit_cache-0.6.11+cu130-cp39-abi3-manylinux_2_28_x86_64.whl ; platform_machine == "x86_64"
-flashinfer_jit_cache @ https://github.com/flashinfer-ai/flashinfer/releases/download/v0.6.11/flashinfer_jit_cache-0.6.11+cu130-cp39-abi3-manylinux_2_28_aarch64.whl ; platform_machine == "aarch64"
+--extra-index-url https://flashinfer.ai/whl/cu130
+flashinfer-jit-cache==0.6.11+cu130 ; platform_machine == "x86_64" or platform_machine == "aarch64"
 nvidia-ml-py==13.580.82


### PR DESCRIPTION
## Summary
- install flashinfer-jit-cache through the official FlashInfer cu130 wheel index
- avoid hand-written GitHub release direct URLs for the huge JIT cache wheel
- update the FlashInfer dependency update workflow to maintain the indexed requirement

## Validation
- python3 -m pip install --dry-run --no-deps --extra-index-url https://flashinfer.ai/whl/cu130 "flashinfer-jit-cache==0.6.11+cu130 ; platform_machine == \\\"x86_64\\\" or platform_machine == \\\"aarch64\\\""
- pre-commit run --files tokenspeed-kernel/python/requirements/cuda.txt .github/workflows/update-tokenspeed-kernel-flashinfer.yml