### PR TITLE
Update tokenspeed-fa4 dependency

### DIFF
--- a/tokenspeed-kernel/python/requirements/cuda-thirdparty.txt
+++ b/tokenspeed-kernel/python/requirements/cuda-thirdparty.txt
@@ -5,6 +5,6 @@ tokenspeed-flashmla==1.0.0.post20260429
 tokenspeed-mla==0.1.1
 tokenspeed-fast-hadamard-transform==1.1.0.post20251110
 tokenspeed-fa3==3.0.0.post20260408
-tokenspeed-fa4==4.0.0.post20251110
+tokenspeed-fa4==4.0.0.post20260510
 triton_kernels @ git+https://github.com/triton-lang/triton.git@4790c35390e62830fed7210d69f5988accf8aeda#subdirectory=python/triton_kernels
 tokenspeed-trtllm-kernel==1.2.1.post20260427


### PR DESCRIPTION
## Summary
- update tokenspeed-fa4 to 4.0.0.post20260510
- this version was built from Dao-AILab/flash-attention@09aa322287571356db9fff765e9b10f005a3e9f5

## Validation
- python3 -m pip install --dry-run --no-deps --extra-index-url https://lightseekorg.github.io/whl/cu130 tokenspeed-fa4==4.0.0.post20260510
- pre-commit run --files tokenspeed-kernel/python/requirements/cuda-thirdparty.txt