### PR TITLE
Remove runtime cutlass DSL dependency

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,7 +45,6 @@ dependencies = [
     "msgspec",
     "ninja",
     "numpy",
-    "nvidia-cutlass-dsl",
     "nvtx",
     "openai==2.33.0",
     "openai-harmony",


### PR DESCRIPTION
## Summary
- remove nvidia-cutlass-dsl from the tokenspeed runtime package dependencies
- keep the dependency in tokenspeed-kernel CUDA requirements, where it is needed
- leave python/tokenspeed/env.py unchanged for environment reporting

## Validation
- pre-commit run --files python/pyproject.toml