### PR TITLE
Move nvtx dependency to tokenspeed-kernel

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,7 +45,6 @@ dependencies = [
     "msgspec",
     "ninja",
     "numpy",
-    "nvtx",
     "openai==2.33.0",
     "openai-harmony",
     "orjson",

--- a/python/tokenspeed/runtime/utils/nvtx.py
+++ b/python/tokenspeed/runtime/utils/nvtx.py
@@ -37,10 +37,16 @@ from __future__ import annotations
 
 import functools
 
-import nvtx
-from nvtx.colors import _NVTX_COLORS
+from tokenspeed_kernel.platform import current_platform
 
 from tokenspeed.runtime.utils.env import envs
+
+if current_platform().is_nvidia:
+    import nvtx
+    from nvtx.colors import _NVTX_COLORS
+else:
+    nvtx = None
+    _NVTX_COLORS = ()
 
 NVTX_DOMAIN: str = "tokenspeed"
 
@@ -49,12 +55,13 @@ NVTX_DOMAIN: str = "tokenspeed"
 # rather than crashing the server.
 _VALID_COLORS = frozenset(c for c in _NVTX_COLORS if c is not None)
 
-_enabled: bool = envs.TOKENSPEED_NVTX.get()
+_nvtx_available = nvtx is not None
+_enabled: bool = _nvtx_available and envs.TOKENSPEED_NVTX.get()
 
 
 def set_nvtx_enabled(enabled: bool) -> None:
     global _enabled
-    _enabled = enabled
+    _enabled = _nvtx_available and enabled
 
 
 class _Range:

--- a/tokenspeed-kernel/python/requirements/cuda.txt
+++ b/tokenspeed-kernel/python/requirements/cuda.txt
@@ -6,3 +6,4 @@ flashinfer-cubin==0.6.11
 --extra-index-url https://flashinfer.ai/whl/cu130
 flashinfer-jit-cache==0.6.11+cu130 ; platform_machine == "x86_64" or platform_machine == "aarch64"
 nvidia-ml-py==13.580.82
+nvtx


### PR DESCRIPTION
## Summary
- remove nvtx from the tokenspeed runtime package dependencies
- add nvtx to tokenspeed-kernel CUDA requirements
- guard the runtime NVTX wrapper with tokenspeed_kernel.platform.current_platform().is_nvidia before importing nvtx

## Validation
- python3 -m py_compile python/tokenspeed/runtime/utils/nvtx.py
- pre-commit run --files python/pyproject.toml tokenspeed-kernel/python/requirements/cuda.txt python/tokenspeed/runtime/utils/nvtx.py