### PR TITLE
Suppress noisy CUTLASS DSL warnings

### DIFF
--- a/python/tokenspeed/_logging.py
+++ b/python/tokenspeed/_logging.py
@@ -20,7 +20,52 @@
 
 import logging
 import os
+import warnings
 from importlib import import_module
+
+_original_showwarning = warnings.showwarning
+
+_CUTLASS_POINTER_WARNING = "Use explicit `struct.scalar.ptr` for pointer instead."
+_CUTLASS_NAMED_BARRIER_WARNING = (
+    "NamedBarrier wait also arrives on the barrier. "
+    "Routing call to NamedBarrier.arrive_and_wait()."
+)
+
+
+def _is_noisy_cutlass_dsl_warning(message, category) -> bool:
+    message_text = str(message)
+    return (
+        issubclass(category, DeprecationWarning)
+        and message_text == _CUTLASS_POINTER_WARNING
+    ) or (
+        issubclass(category, UserWarning)
+        and message_text == _CUTLASS_NAMED_BARRIER_WARNING
+    )
+
+
+def _showwarning(message, category, filename, lineno, file=None, line=None):
+    if _is_noisy_cutlass_dsl_warning(message, category):
+        return
+    _original_showwarning(message, category, filename, lineno, file=file, line=line)
+
+
+def _suppress_cutlass_dsl_warnings():
+    if warnings.showwarning is not _showwarning:
+        warnings.showwarning = _showwarning
+
+    warnings.filterwarnings(
+        "ignore",
+        message=r"Use explicit `struct\.scalar\.ptr` for pointer instead\.",
+        category=DeprecationWarning,
+    )
+    warnings.filterwarnings(
+        "ignore",
+        message=(
+            r"NamedBarrier wait also arrives on the barrier\. "
+            r"Routing call to NamedBarrier\.arrive_and_wait\(\)\."
+        ),
+        category=UserWarning,
+    )
 
 
 def _suppress_flash_attn_jit_cache_debug_log():
@@ -42,6 +87,7 @@ def _suppress_flash_attn_jit_cache_debug_log():
 
 def suppress_noisy_third_party_logs():
     os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+    _suppress_cutlass_dsl_warnings()
 
     for logger_name in (
         "transformers",


### PR DESCRIPTION
## Summary
- suppress known noisy CUTLASS DSL startup warnings from pointer deprecation and NamedBarrier wait routing
- keep the change in the TokenSpeed runtime startup path without modifying tokenspeed-kernel
- preserve unrelated Python warnings while filtering only the exact noisy CUTLASS DSL warning messages

## Validation
- pre-commit run --files python/tokenspeed/_logging.py
- verified targeted warning suppression locally: CUTLASS DSL warnings are filtered and unrelated warnings still print
- verified startup with python3 -m tokenspeed.api_server --model nvidia/Kimi-K2.5-NVFP4 --attn-tp-size 4 --moe-tp-size 4 --max-model-len 80000 --trust-remote-code --attention-backend tokenspeed_mla --moe-backend flashinfer_trtllm --quantization nvfp4 --kv-cache-dtype fp8 --weight-loader-prefetch-checkpoints --speculative-algorithm EAGLE3 --speculative-draft-model-path lightseekorg/kimi-k2.5-eagle3 --speculative-num-steps 1 --drafter-attention-backend trtllm --enable-cache-report --host 127.0.0.1; startup reached CuteDSL FMHA compilation and CUDA graph capture without the suppressed CUTLASS DSL warnings