### PR TITLE
Suppress TensorRT-LLM INFO startup logs

### DIFF
--- a/python/tokenspeed/_logging.py
+++ b/python/tokenspeed/_logging.py
@@ -87,6 +87,7 @@ def _suppress_flash_attn_jit_cache_debug_log():
 
 def suppress_noisy_third_party_logs():
     os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+    os.environ.setdefault("TLLM_LOG_LEVEL", "WARNING")
     _suppress_cutlass_dsl_warnings()
 
     for logger_name in (


### PR DESCRIPTION
## Summary
- set the TensorRT-LLM logger level to WARNING during TokenSpeed runtime startup
- use TensorRT-LLM's supported TLLM_LOG_LEVEL environment knob instead of filtering stdout

## Validation
- pre-commit run --files python/tokenspeed/_logging.py
- verified startup with python3 -m tokenspeed.api_server --model nvidia/Kimi-K2.5-NVFP4 --attn-tp-size 4 --moe-tp-size 4 --max-model-len 80000 --trust-remote-code --attention-backend tokenspeed_mla --moe-backend flashinfer_trtllm --quantization nvfp4 --kv-cache-dtype fp8 --weight-loader-prefetch-checkpoints --speculative-algorithm EAGLE3 --speculative-draft-model-path lightseekorg/kimi-k2.5-eagle3 --speculative-num-steps 1 --drafter-attention-backend trtllm --enable-cache-report --host 127.0.0.1; startup reached CuteDSL compilation, CUDA graph capture, and TRT-LLM fusion workspace initialization without the repeated [TensorRT-LLM][INFO] Set logger level to INFO lines