### PR TITLE
Remove default eval prefill args

### DIFF
--- a/test/ci/eval/qwen3.5-397b-a17b-nvfp4-evalscope-aime25.yaml
+++ b/test/ci/eval/qwen3.5-397b-a17b-nvfp4-evalscope-aime25.yaml
@@ -19,8 +19,6 @@ server:
     --attn-tp-size 4
     --moe-tp-size 4
     --max-model-len 80000
-    --max-prefill-tokens 8192
-    --chunked-prefill-size 8192
     --trust-remote-code
     --attention-backend trtllm
     --moe-backend flashinfer_trtllm


### PR DESCRIPTION
## Summary
- remove explicit default prefill token args from the Qwen eval CI command
- verify no test/ci/eval yaml still sets --max-prefill-tokens 8192 or --chunked-prefill-size 8192

## Validation
- pre-commit run --files test/ci/eval/qwen3.5-397b-a17b-nvfp4-evalscope-aime25.yaml