### PR TITLE
Use packaged tokenspeed-triton-kernels dependency

### DIFF
--- a/tokenspeed-kernel/python/requirements/cuda-thirdparty.txt
+++ b/tokenspeed-kernel/python/requirements/cuda-thirdparty.txt
@@ -6,5 +6,5 @@ tokenspeed-mla==0.1.1
 tokenspeed-fast-hadamard-transform==1.1.0.post20251110
 tokenspeed-fa3==3.0.0.post20260408
 tokenspeed-fa4==4.0.0.post20260510
-triton_kernels @ git+https://github.com/triton-lang/triton.git@4790c35390e62830fed7210d69f5988accf8aeda#subdirectory=python/triton_kernels
+tokenspeed-triton-kernels==1.0.0.post20260510
 tokenspeed-trtllm-kernel==1.2.1.post20260427

--- a/tokenspeed-kernel/python/requirements/rocm-thirdparty.txt
+++ b/tokenspeed-kernel/python/requirements/rocm-thirdparty.txt
@@ -1,2 +1,2 @@
-triton_kernels @ git+https://github.com/triton-lang/triton.git@4790c35390e62830fed7210d69f5988accf8aeda#subdirectory=python/triton_kernels
+tokenspeed-triton-kernels==1.0.0.post20260510
 iris @ git+https://github.com/ROCm/iris.git@9459a5e95d01ac50bd072b9c6c498a5c8f96af16


### PR DESCRIPTION
## Summary
- replace upstream triton_kernels git dependency with tokenspeed-triton-kernels==1.0.0.post20260510
- update both CUDA and ROCm third-party requirement files

## Testing
- Not run; requirements-only change