### PR TITLE
Remove FlashInfer JIT cache requirement

### DIFF
--- a/.github/workflows/update-tokenspeed-kernel-flashinfer.yml
+++ b/.github/workflows/update-tokenspeed-kernel-flashinfer.yml
@@ -52,7 +52,6 @@ jobs:
           replacements = [
               (r"flashinfer-python==[^\n]+", f"flashinfer-python=={version}"),
               (r"flashinfer-cubin==[^\n]+", f"flashinfer-cubin=={version}"),
-              (r"flashinfer-jit-cache==[^ ;\n]+", f"flashinfer-jit-cache=={version}+cu130"),
           ]
           for pattern, replacement in replacements:
               text = re.sub(pattern, replacement, text)

--- a/tokenspeed-kernel/python/requirements/cuda.txt
+++ b/tokenspeed-kernel/python/requirements/cuda.txt
@@ -3,7 +3,5 @@ nvidia-cutlass-dsl
 torch==2.11.0
 flashinfer-python==0.6.11
 flashinfer-cubin==0.6.11
---extra-index-url https://flashinfer.ai/whl/cu130
-flashinfer-jit-cache==0.6.11+cu130 ; platform_machine == "x86_64" or platform_machine == "aarch64"
 nvidia-ml-py==13.580.82
 nvtx


### PR DESCRIPTION
## Summary
- remove the FlashInfer extra index from tokenspeed-kernel CUDA requirements
- remove flashinfer-jit-cache from tokenspeed-kernel CUDA requirements because runner images preinstall it
- stop the FlashInfer dependency update workflow from trying to update the removed jit-cache line

## Testing
- git grep found no remaining flashinfer-jit-cache or flashinfer.ai/whl references