### PR TITLE
Add fa4 attention backend option

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mha.py
@@ -412,3 +412,4 @@ class MHAAttnBackend(AttentionBackend):
 
 
 register_backend("mha", {AttentionArch.MHA}, MHAAttnBackend)
+register_backend("fa4", {AttentionArch.MHA}, MHAAttnBackend)

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -1200,6 +1200,7 @@ class ServerArgs:
             "triton",
             "flashmla",
             "fa3",
+            "fa4",
             "hybrid_linear_attn",
             "mha",
             "trtllm",

--- a/test/runtime/test_server_args_attention_backends.py
+++ b/test/runtime/test_server_args_attention_backends.py
@@ -45,6 +45,18 @@ class TestAttentionBackendChoices(unittest.TestCase):
         )
         self.assertEqual(args.attention_backend, "trtllm_mla")
 
+    def test_attention_backend_accepts_fa4(self):
+        args = self._build_parser().parse_args(
+            ["--model", "x", "--attention-backend", "fa4"]
+        )
+        self.assertEqual(args.attention_backend, "fa4")
+
+    def test_drafter_attention_backend_accepts_fa4(self):
+        args = self._build_parser().parse_args(
+            ["--model", "x", "--drafter-attention-backend", "fa4"]
+        )
+        self.assertEqual(args.drafter_attention_backend, "fa4")
+
     def test_drafter_attention_backend_accepts_trtllm_mla(self):
         """Regression: trtllm_mla must be accepted here too."""
         args = self._build_parser().parse_args(
@@ -77,6 +89,13 @@ class TestAttentionBackendChoices(unittest.TestCase):
 
     def test_defaults_to_mha_for_mha(self):
         self.assertEqual(registry._get_default_backend_name(AttentionArch.MHA), "mha")
+
+    def test_fa4_resolves_to_mha_backend(self):
+        from tokenspeed.runtime.layers.attention.backends.mha import MHAAttnBackend
+
+        self.assertIs(
+            registry._get_backend_cls("fa4", AttentionArch.MHA), MHAAttnBackend
+        )
 
     def test_sm90_defaults_to_flashmla_for_mla(self):
         platform = SimpleNamespace(is_blackwell=False, is_hopper=True)


### PR DESCRIPTION
## Summary
- allow `--attention-backend fa4` and `--drafter-attention-backend fa4`
- register `fa4` as an MHA runtime backend name so server args resolve past argparse
- add regression coverage for fa4 CLI choices and registry resolution

## Tests
- `python3 -m pip install --force-reinstall tokenspeed-triton-kernels==1.0.0.post20260510`
- `python3 -m pytest test/runtime/test_server_args_attention_backends.py -q` (12 passed)
- `python3 -m py_compile python/tokenspeed/runtime/utils/server_args.py python/tokenspeed/runtime/layers/attention/backends/mha.py test/runtime/test_server_args_attention_backends.py`
- `python3 -m ruff check --select F821 python/tokenspeed/runtime/utils/server_args.py python/tokenspeed/runtime/layers/attention/backends/mha.py test/runtime/test_server_args_attention_backends.py`