### PR TITLE
Enable FA4 prefill head dim 256

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flash_attn/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flash_attn/__init__.py
@@ -56,9 +56,11 @@ if (
     except ImportError:
         pass
 
-    # FA4 on Blackwell supports head_dim in [8, 128] divisible by 8
-    # (and (192, 128) for DeepSeek MLA, not applicable here).
-    _FA4_BLACKWELL_HEAD_DIMS = frozenset(range(8, 129, 8))
+    # FA4 on Blackwell supports prefill head_dim in [8, 256] divisible by 8
+    # (and (192, 128) for DeepSeek MLA, not applicable here). The current
+    # decode path passes seqused_k and remains limited to <=128 by upstream FA4.
+    _FA4_BLACKWELL_PREFILL_HEAD_DIMS = frozenset(range(8, 257, 8))
+    _FA4_BLACKWELL_DECODE_HEAD_DIMS = frozenset(range(8, 129, 8))
 
     @register_kernel(
         "attention",
@@ -72,7 +74,7 @@ if (
         dtypes={torch.float16, torch.bfloat16},
         priority=Priority.SPECIALIZED + 3,
         traits={
-            "head_dim": _FA4_BLACKWELL_HEAD_DIMS,
+            "head_dim": _FA4_BLACKWELL_PREFILL_HEAD_DIMS,
             "sliding_window": frozenset({False}),
             "support_sinks": frozenset({False}),
             "return_lse": frozenset({False}),
@@ -124,7 +126,7 @@ if (
         dtypes={torch.float16, torch.bfloat16},
         priority=Priority.SPECIALIZED + 3,
         traits={
-            "head_dim": _FA4_BLACKWELL_HEAD_DIMS,
+            "head_dim": _FA4_BLACKWELL_DECODE_HEAD_DIMS,
             "query_len": frozenset({1}),
             "sliding_window": frozenset({False}),
             "support_sinks": frozenset({False}),

--- a/tokenspeed-kernel/test/thirdparty/test_fa4.py
+++ b/tokenspeed-kernel/test/thirdparty/test_fa4.py
@@ -20,15 +20,19 @@
 
 from __future__ import annotations
 
+import importlib
 import math
 
 import pytest
+import tokenspeed_kernel.ops.attention.flash_attn as flash_attn_module
 import torch
 from tokenspeed_kernel.ops.attention.flash_attn import (
     flash_attn_func,
     flash_attn_varlen_func,
 )
 from tokenspeed_kernel.platform import ArchVersion, current_platform
+from tokenspeed_kernel.registry import KernelRegistry
+from tokenspeed_kernel.selection import select_kernel
 
 platform = current_platform()
 torch.manual_seed(42)
@@ -41,7 +45,7 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.mark.parametrize(
     "dtype,head_dim,num_q_heads,num_kv_heads",
-    [(torch.bfloat16, 128, 8, 2)],
+    [(torch.bfloat16, 128, 8, 2), (torch.bfloat16, 256, 8, 2)],
 )
 def test_mha(
     device: str,
@@ -77,7 +81,7 @@ def test_mha(
 
 @pytest.mark.parametrize(
     "dtype,head_dim,num_q_heads,num_kv_heads",
-    [(torch.bfloat16, 128, 8, 2)],
+    [(torch.bfloat16, 128, 8, 2), (torch.bfloat16, 256, 8, 2)],
 )
 def test_mha_ragged(
     device: str,
@@ -270,3 +274,38 @@ def test_mha_ragged_with_paged_kvcache(
 
     assert out.shape == q.shape
     assert lse is None
+
+
+def _reload_fa4_registry_entries() -> None:
+    KernelRegistry.reset()
+    importlib.reload(flash_attn_module)
+
+
+def test_fa4_prefill_selection_accepts_head_dim_256() -> None:
+    _reload_fa4_registry_entries()
+    registry = KernelRegistry.get()
+    spec = registry.get_by_name("fa4_mha_prefill")
+    assert spec is not None
+    assert spec.solution == "fa4"
+    assert 256 in spec.traits["head_dim"]
+
+    selected = select_kernel(
+        "attention",
+        "mha_prefill",
+        torch.bfloat16,
+        traits={
+            "head_dim": 256,
+            "sliding_window": False,
+            "support_sinks": False,
+            "return_lse": False,
+            "support_logit_cap": False,
+        },
+    )
+    assert selected.name == "fa4_mha_prefill"
+
+
+def test_fa4_decode_selection_keeps_head_dim_256_disabled() -> None:
+    _reload_fa4_registry_entries()
+    spec = KernelRegistry.get().get_by_name("fa4_mha_decode_with_kvcache")
+    assert spec is not None
+    assert 256 not in spec.traits["head_dim"]


### PR DESCRIPTION
## Summary
- widen FA4 prefill kernel selection to include head_dim=256 on Blackwell
- keep FA4 decode-with-kvcache at <=128 because the current FA4 hd256 dedicated kernel does not support seqused_k
- add FA4 smoke and selection coverage for head_dim=256

## Tests
- `python3 -m pip install --upgrade tokenspeed-fa4` (installed tokenspeed-fa4==4.0.0.post20260510)
- `python3 -m pytest tokenspeed-kernel/test/thirdparty/test_fa4.py -q` (8 passed)
- `python3 -m ruff check tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flash_attn/__init__.py tokenspeed-kernel/test/thirdparty/test_fa4.py`
- `python3 -m py_compile tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flash_attn/__init__.py tokenspeed-kernel/test/thirdparty/test_fa4.py`