### PR TITLE
perf: optimize mamba prefix cache performance

### DIFF
--- a/python/tokenspeed/runtime/execution/input_buffer.py
+++ b/python/tokenspeed/runtime/execution/input_buffer.py
@@ -97,6 +97,19 @@ class InputBuffers:
         self.extend_seq_lens_cpu = torch.zeros(
             max_bs, dtype=torch.int32, pin_memory=True
         )
+        if has_mamba:
+            self._mamba_pool_indices_cpu = torch.full(
+                (max_bs,), -1, dtype=torch.int32, pin_memory=True
+            )
+            self._mamba_cow_src_indices_cpu = torch.full(
+                (max_bs,), -1, dtype=torch.int32, pin_memory=True
+            )
+            self._mamba_branching_seqlens_cpu = torch.full(
+                (max_bs,), -1, dtype=torch.int32, pin_memory=True
+            )
+            self._mamba_track_pool_indices_cpu = torch.full(
+                (max_bs,), -1, dtype=torch.int32, pin_memory=True
+            )
 
     @nvtx_range("input_prep_fill", color="cyan")
     def fill_input_buffers(
@@ -234,23 +247,30 @@ class InputBuffers:
             and hasattr(forward_op, "mamba_pool_indices")
             and forward_op.mamba_pool_indices
         ):
-            t_pool = torch.tensor(
-                forward_op.mamba_pool_indices, device="cpu", pin_memory=True
+            self._mamba_pool_indices_cpu[:batch_size].copy_(
+                torch.as_tensor(forward_op.mamba_pool_indices, dtype=torch.int32)
             )
-            t_cow = torch.tensor(
-                forward_op.mamba_cow_src_indices, device="cpu", pin_memory=True
+            self._mamba_cow_src_indices_cpu[:batch_size].copy_(
+                torch.as_tensor(forward_op.mamba_cow_src_indices, dtype=torch.int32)
             )
-            t_br = torch.tensor(
-                forward_op.mamba_branching_seqlens, device="cpu", pin_memory=True
+            self._mamba_branching_seqlens_cpu[:batch_size].copy_(
+                torch.as_tensor(forward_op.mamba_branching_seqlens, dtype=torch.int32)
             )
-            t_track = torch.tensor(
-                forward_op.mamba_track_pool_indices, device="cpu", pin_memory=True
+            self._mamba_track_pool_indices_cpu[:batch_size].copy_(
+                torch.as_tensor(forward_op.mamba_track_pool_indices, dtype=torch.int32)
             )
-            self.mamba_pool_indices_buf[:batch_size].copy_(t_pool, non_blocking=True)
-            self.mamba_cow_src_indices_buf[:batch_size].copy_(t_cow, non_blocking=True)
-            self.mamba_branching_seqlens_buf[:batch_size].copy_(t_br, non_blocking=True)
+
+            self.mamba_pool_indices_buf[:batch_size].copy_(
+                self._mamba_pool_indices_cpu[:batch_size], non_blocking=True
+            )
+            self.mamba_cow_src_indices_buf[:batch_size].copy_(
+                self._mamba_cow_src_indices_cpu[:batch_size], non_blocking=True
+            )
+            self.mamba_branching_seqlens_buf[:batch_size].copy_(
+                self._mamba_branching_seqlens_cpu[:batch_size], non_blocking=True
+            )
             self.mamba_track_pool_indices_buf[:batch_size].copy_(
-                t_track, non_blocking=True
+                self._mamba_track_pool_indices_cpu[:batch_size], non_blocking=True
             )
             if batch_size < self.mamba_pool_indices_buf.shape[0]:
                 self.mamba_pool_indices_buf[batch_size:].fill_(-1)

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -479,9 +479,7 @@ class ModelExecutor:
         if not getattr(forward_op, "mamba_pool_indices", None):
             return
 
-        # CPU-side pre-filter: only keep entries where BOTH pool and checkpoint
-        # indices are valid (!= -1).  This avoids launching expensive GPU
-        # gather/scatter kernels for the entire batch every decode step.
+        # CPU-side pre-filter
         src_list = []
         dst_list = []
         req_list = []
@@ -493,18 +491,17 @@ class ModelExecutor:
                 dst_list.append(ckpt_idx)
                 req_list.append(forward_op.request_pool_indices[i])
 
-        n = len(src_list)
-        if n == 0:
-            return  # No request needs checkpointing this step
+        num_valid = len(src_list)
+        if num_valid == 0:
+            return
 
-        # Pinned memory + non_blocking H2D (no stream sync)
         t_src = torch.tensor(src_list, dtype=torch.int64, device="cpu", pin_memory=True)
         t_dst = torch.tensor(dst_list, dtype=torch.int64, device="cpu", pin_memory=True)
         t_req = torch.tensor(req_list, dtype=torch.int64, device="cpu", pin_memory=True)
 
-        src_buf = torch.empty(n, dtype=torch.int64, device=self.device)
-        dst_buf = torch.empty(n, dtype=torch.int64, device=self.device)
-        req_buf = torch.empty(n, dtype=torch.int64, device=self.device)
+        src_buf = torch.empty(num_valid, dtype=torch.int64, device=self.device)
+        dst_buf = torch.empty(num_valid, dtype=torch.int64, device=self.device)
+        req_buf = torch.empty(num_valid, dtype=torch.int64, device=self.device)
         src_buf.copy_(t_src, non_blocking=True)
         dst_buf.copy_(t_dst, non_blocking=True)
         req_buf.copy_(t_req, non_blocking=True)
@@ -515,7 +512,7 @@ class ModelExecutor:
             dst_buf,
             cache_lengths,
             self.config.block_size,
-            n,
+            num_valid,
         )
 
     def execute_forward_op_with_log(

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -479,21 +479,25 @@ class ModelExecutor:
         if not getattr(forward_op, "mamba_pool_indices", None):
             return
         bs = len(forward_op.request_ids)
-        mamba_pool_indices = torch.tensor(
-            forward_op.mamba_pool_indices,
-            dtype=torch.int32,
-            device=self.device,
+        # Use pinned memory + non_blocking copy to avoid synchronous H2D transfer.
+        # The input_buffers will be overwritten again by fill_input_buffers later
+        # (on execution_stream which waits for default_stream), so this is safe.
+        t_pool = torch.tensor(
+            forward_op.mamba_pool_indices, dtype=torch.int32, device="cpu", pin_memory=True
         )
-        mamba_checkpoint_indices = torch.tensor(
-            forward_op.mamba_track_pool_indices,
-            dtype=torch.int32,
-            device=self.device,
+        t_track = torch.tensor(
+            forward_op.mamba_track_pool_indices, dtype=torch.int32, device="cpu", pin_memory=True
         )
-        req_pool_indices = torch.tensor(
-            forward_op.request_pool_indices,
-            dtype=torch.int64,
-            device=self.device,
+        t_req = torch.tensor(
+            forward_op.request_pool_indices, dtype=torch.int32, device="cpu", pin_memory=True
         )
+        self.input_buffers.mamba_pool_indices_buf[:bs].copy_(t_pool, non_blocking=True)
+        self.input_buffers.mamba_track_pool_indices_buf[:bs].copy_(t_track, non_blocking=True)
+        self.input_buffers.req_pool_indices_buf[:bs].copy_(t_req, non_blocking=True)
+
+        mamba_pool_indices = self.input_buffers.mamba_pool_indices_buf[:bs]
+        mamba_checkpoint_indices = self.input_buffers.mamba_track_pool_indices_buf[:bs]
+        req_pool_indices = self.input_buffers.req_pool_indices_buf[:bs].long()
         cache_lengths = self.runtime_states.valid_cache_lengths[req_pool_indices]
         self.runtime_states.snapshot_mamba_checkpoints(
             mamba_pool_indices,

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -478,33 +478,44 @@ class ModelExecutor:
             return
         if not getattr(forward_op, "mamba_pool_indices", None):
             return
-        bs = len(forward_op.request_ids)
-        # Use pinned memory + non_blocking copy to avoid synchronous H2D transfer.
-        # The input_buffers will be overwritten again by fill_input_buffers later
-        # (on execution_stream which waits for default_stream), so this is safe.
-        t_pool = torch.tensor(
-            forward_op.mamba_pool_indices, dtype=torch.int32, device="cpu", pin_memory=True
-        )
-        t_track = torch.tensor(
-            forward_op.mamba_track_pool_indices, dtype=torch.int32, device="cpu", pin_memory=True
-        )
-        t_req = torch.tensor(
-            forward_op.request_pool_indices, dtype=torch.int32, device="cpu", pin_memory=True
-        )
-        self.input_buffers.mamba_pool_indices_buf[:bs].copy_(t_pool, non_blocking=True)
-        self.input_buffers.mamba_track_pool_indices_buf[:bs].copy_(t_track, non_blocking=True)
-        self.input_buffers.req_pool_indices_buf[:bs].copy_(t_req, non_blocking=True)
 
-        mamba_pool_indices = self.input_buffers.mamba_pool_indices_buf[:bs]
-        mamba_checkpoint_indices = self.input_buffers.mamba_track_pool_indices_buf[:bs]
-        req_pool_indices = self.input_buffers.req_pool_indices_buf[:bs].long()
-        cache_lengths = self.runtime_states.valid_cache_lengths[req_pool_indices]
+        # CPU-side pre-filter: only keep entries where BOTH pool and checkpoint
+        # indices are valid (!= -1).  This avoids launching expensive GPU
+        # gather/scatter kernels for the entire batch every decode step.
+        src_list = []
+        dst_list = []
+        req_list = []
+        for i in range(len(forward_op.request_ids)):
+            pool_idx = forward_op.mamba_pool_indices[i]
+            ckpt_idx = forward_op.mamba_track_pool_indices[i]
+            if pool_idx != -1 and ckpt_idx != -1:
+                src_list.append(pool_idx)
+                dst_list.append(ckpt_idx)
+                req_list.append(forward_op.request_pool_indices[i])
+
+        n = len(src_list)
+        if n == 0:
+            return  # No request needs checkpointing this step
+
+        # Pinned memory + non_blocking H2D (no stream sync)
+        t_src = torch.tensor(src_list, dtype=torch.int64, device="cpu", pin_memory=True)
+        t_dst = torch.tensor(dst_list, dtype=torch.int64, device="cpu", pin_memory=True)
+        t_req = torch.tensor(req_list, dtype=torch.int64, device="cpu", pin_memory=True)
+
+        src_buf = torch.empty(n, dtype=torch.int64, device=self.device)
+        dst_buf = torch.empty(n, dtype=torch.int64, device=self.device)
+        req_buf = torch.empty(n, dtype=torch.int64, device=self.device)
+        src_buf.copy_(t_src, non_blocking=True)
+        dst_buf.copy_(t_dst, non_blocking=True)
+        req_buf.copy_(t_req, non_blocking=True)
+
+        cache_lengths = self.runtime_states.valid_cache_lengths[req_buf]
         self.runtime_states.snapshot_mamba_checkpoints(
-            mamba_pool_indices,
-            mamba_checkpoint_indices,
+            src_buf,
+            dst_buf,
             cache_lengths,
             self.config.block_size,
-            bs,
+            n,
         )
 
     def execute_forward_op_with_log(

--- a/python/tokenspeed/runtime/execution/runtime_states.py
+++ b/python/tokenspeed/runtime/execution/runtime_states.py
@@ -22,7 +22,7 @@
 import torch
 
 from tokenspeed.runtime.layers.attention.linear.mamba_state_scatter_triton import (
-    fused_mamba_state_copy,
+    fused_mamba_state_snapshot,
 )
 from tokenspeed.runtime.utils import get_colorful_logger
 
@@ -115,15 +115,18 @@ class RuntimeStates:
         """Copy current working Mamba states into checkpoint slots.
 
         src_indices/dst_indices are pre-filtered on CPU (only valid entries).
-        Only the page_size condition is checked on GPU.
+        The page_size condition is checked inside the Triton kernel.
         """
         if self.mamba_pool is None or num_valid == 0:
             return
-        if page_size > 0:
-            page_mask = cache_lengths[:num_valid] % page_size == 0
-            dst_indices = torch.where(page_mask, dst_indices, src_indices)
-        fused_mamba_state_copy(self.mamba_pool.conv_state, src_indices, dst_indices)
-        fused_mamba_state_copy(self.mamba_pool.ssm_state, src_indices, dst_indices)
+        fused_mamba_state_snapshot(
+            self.mamba_pool.conv_state, src_indices, dst_indices,
+            cache_lengths=cache_lengths, page_size=page_size,
+        )
+        fused_mamba_state_snapshot(
+            self.mamba_pool.ssm_state, src_indices, dst_indices,
+            cache_lengths=cache_lengths, page_size=page_size,
+        )
 
     def zero_mamba_states(
         self,

--- a/python/tokenspeed/runtime/execution/runtime_states.py
+++ b/python/tokenspeed/runtime/execution/runtime_states.py
@@ -120,12 +120,18 @@ class RuntimeStates:
         if self.mamba_pool is None or num_valid == 0:
             return
         fused_mamba_state_snapshot(
-            self.mamba_pool.conv_state, src_indices, dst_indices,
-            cache_lengths=cache_lengths, page_size=page_size,
+            self.mamba_pool.conv_state,
+            src_indices,
+            dst_indices,
+            cache_lengths=cache_lengths,
+            page_size=page_size,
         )
         fused_mamba_state_snapshot(
-            self.mamba_pool.ssm_state, src_indices, dst_indices,
-            cache_lengths=cache_lengths, page_size=page_size,
+            self.mamba_pool.ssm_state,
+            src_indices,
+            dst_indices,
+            cache_lengths=cache_lengths,
+            page_size=page_size,
         )
 
     def zero_mamba_states(

--- a/python/tokenspeed/runtime/execution/runtime_states.py
+++ b/python/tokenspeed/runtime/execution/runtime_states.py
@@ -114,18 +114,16 @@ class RuntimeStates:
         """
         if self.mamba_pool is None or n == 0:
             return
-        src = src_indices[:n]
-        dst = dst_indices[:n]
         if page_size > 0:
             # Use torch.where to keep fixed-size output (no boolean indexing sync).
             # Invalid entries become self-copy (dst = src), harmless no-op.
             page_mask = cache_lengths[:n] % page_size == 0
-            dst = torch.where(page_mask, dst, src)
-        self.mamba_pool.conv_state[:, dst] = self.mamba_pool.conv_state[
-            :, src
+            dst_indices = torch.where(page_mask, dst_indices, src_indices)
+        self.mamba_pool.conv_state[:, dst_indices] = self.mamba_pool.conv_state[
+            :, src_indices
         ]
-        self.mamba_pool.ssm_state[:, dst] = self.mamba_pool.ssm_state[
-            :, src
+        self.mamba_pool.ssm_state[:, dst_indices] = self.mamba_pool.ssm_state[
+            :, src_indices
         ]
 
     def zero_mamba_states(

--- a/python/tokenspeed/runtime/execution/runtime_states.py
+++ b/python/tokenspeed/runtime/execution/runtime_states.py
@@ -105,19 +105,19 @@ class RuntimeStates:
         dst_indices: torch.Tensor,
         cache_lengths: torch.Tensor,
         page_size: int,
-        n: int,
+        num_valid: int,
     ) -> None:
         """Copy current working Mamba states into checkpoint slots.
 
         src_indices/dst_indices are pre-filtered on CPU (only valid entries).
         Only the page_size condition is checked on GPU.
         """
-        if self.mamba_pool is None or n == 0:
+        if self.mamba_pool is None or num_valid == 0:
             return
         if page_size > 0:
             # Use torch.where to keep fixed-size output (no boolean indexing sync).
             # Invalid entries become self-copy (dst = src), harmless no-op.
-            page_mask = cache_lengths[:n] % page_size == 0
+            page_mask = cache_lengths[:num_valid] % page_size == 0
             dst_indices = torch.where(page_mask, dst_indices, src_indices)
         self.mamba_pool.conv_state[:, dst_indices] = self.mamba_pool.conv_state[
             :, src_indices

--- a/python/tokenspeed/runtime/execution/runtime_states.py
+++ b/python/tokenspeed/runtime/execution/runtime_states.py
@@ -62,7 +62,9 @@ class RuntimeStates:
     def update_valid_cache_length(
         self, req_pool_indices: torch.Tensor, increment_lengths: torch.Tensor
     ) -> None:
-        self.valid_cache_lengths[req_pool_indices] += increment_lengths
+        self.valid_cache_lengths.index_add_(
+            0, req_pool_indices.long(), increment_lengths
+        )
 
     def reset_states(
         self,

--- a/python/tokenspeed/runtime/execution/runtime_states.py
+++ b/python/tokenspeed/runtime/execution/runtime_states.py
@@ -115,10 +115,14 @@ class RuntimeStates:
         )
         if page_size > 0:
             valid_mask &= cache_lengths[:bs] % page_size == 0
-        if not valid_mask.any():
-            return
-        src_indices = mamba_pool_indices[:bs][valid_mask].long()
-        dst_indices = mamba_checkpoint_indices[:bs][valid_mask].long()
+        # Use torch.where instead of boolean indexing to avoid CPU-GPU sync.
+        # Boolean indexing calls nonzero() internally which requires reading
+        # the output size from GPU → cudaStreamSynchronize.
+        # For invalid entries we set dst = src (self-copy, no data mutation).
+        src_indices = mamba_pool_indices[:bs].clamp(min=0).long()
+        dst_indices = torch.where(
+            valid_mask, mamba_checkpoint_indices[:bs].long(), src_indices
+        )
         self.mamba_pool.conv_state[:, dst_indices] = self.mamba_pool.conv_state[
             :, src_indices
         ]

--- a/python/tokenspeed/runtime/execution/runtime_states.py
+++ b/python/tokenspeed/runtime/execution/runtime_states.py
@@ -101,33 +101,31 @@ class RuntimeStates:
 
     def snapshot_mamba_checkpoints(
         self,
-        mamba_pool_indices: torch.Tensor,
-        mamba_checkpoint_indices: torch.Tensor,
+        src_indices: torch.Tensor,
+        dst_indices: torch.Tensor,
         cache_lengths: torch.Tensor,
         page_size: int,
-        bs: int,
+        n: int,
     ) -> None:
-        """Copy current working Mamba states into checkpoint slots."""
-        if self.mamba_pool is None:
+        """Copy current working Mamba states into checkpoint slots.
+
+        src_indices/dst_indices are pre-filtered on CPU (only valid entries).
+        Only the page_size condition is checked on GPU.
+        """
+        if self.mamba_pool is None or n == 0:
             return
-        valid_mask = (mamba_pool_indices[:bs] != -1) & (
-            mamba_checkpoint_indices[:bs] != -1
-        )
+        src = src_indices[:n]
+        dst = dst_indices[:n]
         if page_size > 0:
-            valid_mask &= cache_lengths[:bs] % page_size == 0
-        # Use torch.where instead of boolean indexing to avoid CPU-GPU sync.
-        # Boolean indexing calls nonzero() internally which requires reading
-        # the output size from GPU → cudaStreamSynchronize.
-        # For invalid entries we set dst = src (self-copy, no data mutation).
-        src_indices = mamba_pool_indices[:bs].clamp(min=0).long()
-        dst_indices = torch.where(
-            valid_mask, mamba_checkpoint_indices[:bs].long(), src_indices
-        )
-        self.mamba_pool.conv_state[:, dst_indices] = self.mamba_pool.conv_state[
-            :, src_indices
+            # Use torch.where to keep fixed-size output (no boolean indexing sync).
+            # Invalid entries become self-copy (dst = src), harmless no-op.
+            page_mask = cache_lengths[:n] % page_size == 0
+            dst = torch.where(page_mask, dst, src)
+        self.mamba_pool.conv_state[:, dst] = self.mamba_pool.conv_state[
+            :, src
         ]
-        self.mamba_pool.ssm_state[:, dst_indices] = self.mamba_pool.ssm_state[
-            :, src_indices
+        self.mamba_pool.ssm_state[:, dst] = self.mamba_pool.ssm_state[
+            :, src
         ]
 
     def zero_mamba_states(

--- a/python/tokenspeed/runtime/execution/runtime_states.py
+++ b/python/tokenspeed/runtime/execution/runtime_states.py
@@ -21,6 +21,9 @@
 
 import torch
 
+from tokenspeed.runtime.layers.attention.linear.mamba_state_scatter_triton import (
+    fused_mamba_state_copy,
+)
 from tokenspeed.runtime.utils import get_colorful_logger
 
 logger = get_colorful_logger(__name__)
@@ -119,12 +122,8 @@ class RuntimeStates:
             # Invalid entries become self-copy (dst = src), harmless no-op.
             page_mask = cache_lengths[:num_valid] % page_size == 0
             dst_indices = torch.where(page_mask, dst_indices, src_indices)
-        self.mamba_pool.conv_state[:, dst_indices] = self.mamba_pool.conv_state[
-            :, src_indices
-        ]
-        self.mamba_pool.ssm_state[:, dst_indices] = self.mamba_pool.ssm_state[
-            :, src_indices
-        ]
+        fused_mamba_state_copy(self.mamba_pool.conv_state, src_indices, dst_indices)
+        fused_mamba_state_copy(self.mamba_pool.ssm_state, src_indices, dst_indices)
 
     def zero_mamba_states(
         self,

--- a/python/tokenspeed/runtime/execution/runtime_states.py
+++ b/python/tokenspeed/runtime/execution/runtime_states.py
@@ -118,8 +118,6 @@ class RuntimeStates:
         if self.mamba_pool is None or num_valid == 0:
             return
         if page_size > 0:
-            # Use torch.where to keep fixed-size output (no boolean indexing sync).
-            # Invalid entries become self-copy (dst = src), harmless no-op.
             page_mask = cache_lengths[:num_valid] % page_size == 0
             dst_indices = torch.where(page_mask, dst_indices, src_indices)
         fused_mamba_state_copy(self.mamba_pool.conv_state, src_indices, dst_indices)

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -182,9 +182,7 @@ class SimpleMambaPool:
 
     def get_mamba_indices(self, mamba_pool_indices: torch.Tensor) -> torch.Tensor:
         """Return mamba cache indices directly (allocated by C++ scheduler)."""
-        indices = mamba_pool_indices.to(torch.int32)
-        valid_mask = (indices >= 0) & (indices < self.size)
-        return torch.where(valid_mask, indices, torch.full_like(indices, -1))
+        return mamba_pool_indices.to(torch.int32)
 
     def get_mamba_params(self, layer_id: int):
         """Return per-layer cache slices."""

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -612,8 +612,11 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
     ):
         # cache_seqlens aliases seq_lens_buf; only page_table needs refresh.
         if req_to_page is not None:
-            self.cuda_graph_page_table[:bs, : self.max_num_pages].copy_(
-                req_to_page[req_pool_indices[:bs], : self.max_num_pages]
+            torch.index_select(
+                req_to_page[:, : self.max_num_pages],
+                0,
+                req_pool_indices[:bs].long(),
+                out=self.cuda_graph_page_table[:bs, : self.max_num_pages],
             )
 
         if forward_mode.is_decode():

--- a/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
@@ -116,10 +116,12 @@ def _fused_mamba_state_scatter_with_mask_kernel(
 
 
 @triton.jit
-def _mamba_state_copy_kernel(
+def _mamba_state_snapshot_kernel(
     pool_ptr,
     src_indices_ptr,  # [num_valid]
     dst_indices_ptr,  # [num_valid]
+    cache_lengths_ptr,  # [num_valid] or nullptr (0 when page_size==0)
+    page_size,  # 0 means no page filtering
     elem_per_entry: tl.constexpr,
     layer_stride,
     req_stride,
@@ -128,6 +130,7 @@ def _mamba_state_copy_kernel(
 ):
     """
     In-place copy kernel: pool[:, dst[i], :] = pool[:, src[i], :]
+    Skips copy if page_size > 0 and cache_lengths[i] % page_size != 0.
 
     Grid: (num_valid, num_layers, ceil(elem_per_entry / BLOCK_SIZE))
     """
@@ -138,8 +141,15 @@ def _mamba_state_copy_kernel(
     src_idx = tl.load(src_indices_ptr + pid_req).to(tl.int64)
     dst_idx = tl.load(dst_indices_ptr + pid_req).to(tl.int64)
 
+    # Skip self-copy (no-op)
     if src_idx == dst_idx:
         return
+
+    # Page-boundary filter: skip if not aligned
+    if page_size > 0:
+        cl = tl.load(cache_lengths_ptr + pid_req).to(tl.int64)
+        if cl % page_size != 0:
+            return
 
     # Bounds check
     if not (
@@ -158,18 +168,26 @@ def _mamba_state_copy_kernel(
     tl.store(pool_ptr + dst_offset + offsets, data, mask=mask)
 
 
-def fused_mamba_state_copy(
+def fused_mamba_state_snapshot(
     pool: torch.Tensor,  # [num_layers, pool_size, *state_shape]
     src_indices: torch.Tensor,  # [num_valid]
     dst_indices: torch.Tensor,  # [num_valid]
+    cache_lengths: torch.Tensor | None = None,  # [num_valid], for page filter
+    page_size: int = 0,  # 0 means no page filtering
 ):
     """
-    In-place state copy: pool[:, dst_indices[i], :] = pool[:, src_indices[i], :]
+    Snapshot mamba states: pool[:, dst_indices[i], :] = pool[:, src_indices[i], :]
+
+    Specialized for checkpoint snapshot with page-boundary filtering.
+    When page_size > 0 and cache_lengths is provided, skips entries where
+    cache_lengths[i] % page_size != 0 (all done inside a single kernel).
 
     Args:
         pool: State tensor [num_layers, pool_size, *state_shape], must be contiguous.
         src_indices: Source slot indices [num_valid], int32 or int64.
         dst_indices: Destination slot indices [num_valid], int32 or int64.
+        cache_lengths: Per-entry cache lengths for page-boundary filtering.
+        page_size: Page size for filtering; 0 disables.
     """
     num_valid = src_indices.shape[0]
     if num_valid == 0:
@@ -195,16 +213,26 @@ def fused_mamba_state_copy(
     layer_stride = pool.stride(0)
     req_stride = pool.stride(1)
 
-    src_indices = src_indices.to(torch.int32).contiguous()
-    dst_indices = dst_indices.to(torch.int32).contiguous()
+    if not src_indices.is_contiguous():
+        raise ValueError("src_indices must be contiguous")
+    if not dst_indices.is_contiguous():
+        raise ValueError("dst_indices must be contiguous")
+
+    if page_size > 0 and cache_lengths is not None:
+        cache_lengths = cache_lengths.to(torch.int32)
+    else:
+        cache_lengths = src_indices  # unused; kernel skips when page_size==0
+        page_size = 0
 
     BLOCK_SIZE = 1024
     grid = (num_valid, num_layers, triton.cdiv(elem_per_entry, BLOCK_SIZE))
 
-    _mamba_state_copy_kernel[grid](
+    _mamba_state_snapshot_kernel[grid](
         pool,
         src_indices,
         dst_indices,
+        cache_lengths,
+        page_size,
         elem_per_entry,
         layer_stride,
         req_stride,

--- a/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
@@ -138,6 +138,9 @@ def _mamba_state_copy_kernel(
     src_idx = tl.load(src_indices_ptr + pid_req).to(tl.int64)
     dst_idx = tl.load(dst_indices_ptr + pid_req).to(tl.int64)
 
+    if src_idx == dst_idx:
+        return
+
     # Bounds check
     if not (
         (src_idx >= 0) & (src_idx < pool_size)

--- a/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
@@ -115,6 +115,109 @@ def _fused_mamba_state_scatter_with_mask_kernel(
     tl.store(dst_ptr + dst_offset + offsets, data, mask=mask)
 
 
+@triton.jit
+def _mamba_state_copy_kernel(
+    pool_ptr,
+    src_indices_ptr,  # [num_valid]
+    dst_indices_ptr,  # [num_valid]
+    elem_per_entry: tl.constexpr,
+    layer_stride,
+    req_stride,
+    pool_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """
+    In-place copy kernel: pool[:, dst[i], :] = pool[:, src[i], :]
+
+    Grid: (num_valid, num_layers, ceil(elem_per_entry / BLOCK_SIZE))
+    """
+    pid_req = tl.program_id(0)
+    pid_layer = tl.program_id(1).to(tl.int64)
+    pid_block = tl.program_id(2).to(tl.int64)
+
+    src_idx = tl.load(src_indices_ptr + pid_req).to(tl.int64)
+    dst_idx = tl.load(dst_indices_ptr + pid_req).to(tl.int64)
+
+    # Bounds check
+    if not (
+        (src_idx >= 0) & (src_idx < pool_size)
+        & (dst_idx >= 0) & (dst_idx < pool_size)
+    ):
+        return
+
+    src_offset = pid_layer * layer_stride + src_idx * req_stride
+    dst_offset = pid_layer * layer_stride + dst_idx * req_stride
+
+    start = pid_block * BLOCK_SIZE
+    offsets = start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < elem_per_entry
+
+    data = tl.load(pool_ptr + src_offset + offsets, mask=mask)
+    tl.store(pool_ptr + dst_offset + offsets, data, mask=mask)
+
+
+def fused_mamba_state_copy(
+    pool: torch.Tensor,  # [num_layers, pool_size, *state_shape]
+    src_indices: torch.Tensor,  # [num_valid]
+    dst_indices: torch.Tensor,  # [num_valid]
+):
+    """
+    In-place state copy: pool[:, dst_indices[i], :] = pool[:, src_indices[i], :]
+
+    Replaces the expensive PyTorch advanced indexing pattern:
+        pool[:, dst] = pool[:, src]
+    which launches ~6 kernels (gather tmp buffer + scatter) with a single
+    fused Triton kernel.
+
+    Args:
+        pool: State tensor [num_layers, pool_size, *state_shape], must be contiguous.
+        src_indices: Source slot indices [num_valid], int32 or int64.
+        dst_indices: Destination slot indices [num_valid], int32 or int64.
+    """
+    num_valid = src_indices.shape[0]
+    if num_valid == 0:
+        return
+
+    if not pool.is_cuda:
+        raise ValueError("fused_mamba_state_copy only supports CUDA tensors.")
+    if not pool.is_contiguous():
+        raise ValueError("pool tensor must be contiguous")
+    if pool.ndim < 2:
+        raise ValueError(f"pool must be at least 2D, got {pool.ndim}D")
+    if src_indices.shape[0] != dst_indices.shape[0]:
+        raise ValueError(
+            f"indices length mismatch: {src_indices.shape[0]} vs {dst_indices.shape[0]}"
+        )
+
+    num_layers = pool.shape[0]
+    pool_size = pool.shape[1]
+
+    # Elements per (layer, slot) entry
+    elem_per_entry = pool.numel() // (num_layers * pool_size)
+
+    # Strides in elements
+    layer_stride = pool.stride(0)
+    req_stride = pool.stride(1)
+
+    # Ensure indices are int32 and contiguous
+    src_indices = src_indices.to(torch.int32).contiguous()
+    dst_indices = dst_indices.to(torch.int32).contiguous()
+
+    BLOCK_SIZE = 1024
+    grid = (num_valid, num_layers, triton.cdiv(elem_per_entry, BLOCK_SIZE))
+
+    _mamba_state_copy_kernel[grid](
+        pool,
+        src_indices,
+        dst_indices,
+        elem_per_entry,
+        layer_stride,
+        req_stride,
+        pool_size,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
 def fused_mamba_state_scatter_with_mask(
     dst: torch.Tensor,  # [num_layers, cache_size, *state_shape]
     src: torch.Tensor,  # [num_layers, spec_size, draft_tokens, *state_shape]

--- a/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
@@ -166,11 +166,6 @@ def fused_mamba_state_copy(
     """
     In-place state copy: pool[:, dst_indices[i], :] = pool[:, src_indices[i], :]
 
-    Replaces the expensive PyTorch advanced indexing pattern:
-        pool[:, dst] = pool[:, src]
-    which launches ~6 kernels (gather tmp buffer + scatter) with a single
-    fused Triton kernel.
-
     Args:
         pool: State tensor [num_layers, pool_size, *state_shape], must be contiguous.
         src_indices: Source slot indices [num_valid], int32 or int64.
@@ -197,11 +192,9 @@ def fused_mamba_state_copy(
     # Elements per (layer, slot) entry
     elem_per_entry = pool.numel() // (num_layers * pool_size)
 
-    # Strides in elements
     layer_stride = pool.stride(0)
     req_stride = pool.stride(1)
 
-    # Ensure indices are int32 and contiguous
     src_indices = src_indices.to(torch.int32).contiguous()
     dst_indices = dst_indices.to(torch.int32).contiguous()
 

--- a/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
@@ -143,8 +143,7 @@ def _mamba_state_copy_kernel(
 
     # Bounds check
     if not (
-        (src_idx >= 0) & (src_idx < pool_size)
-        & (dst_idx >= 0) & (dst_idx < pool_size)
+        (src_idx >= 0) & (src_idx < pool_size) & (dst_idx >= 0) & (dst_idx < pool_size)
     ):
         return
 


### PR DESCRIPTION
## Summary
Reduces the runtime overhead of `snapshot_mamba_checkpoints_for_op` which previously introduced `cudaStreamSynchronize` calls per decode step, breaking scheduler overlap.

### Changes

- **CPU-side pre-filtering** (`model_executor.py`): Filter out invalid entries (`pool_idx == -1` or `ckpt_idx == -1`) on CPU before H2D transfer. Only valid (src, dst, req) triplets are copied to GPU via pinned memory + `non_blocking`.
- **Sync-free page_size check** (`runtime_stats.py`): Replace `valid_mask.any()` (which triggers GPU→CPU sync) with `torch.where(page_mask, dst, src)` — invalid entries become self-copy, no dynamic shape, no sync.
- **Fused Triton kernel** (`mamba_state_scatter_triton.py`): Replace PyTorch advanced indexing (`pool[:, dst] = pool[:, src]`, ~6 kernels per state) with a single `fused_mamba_state_copy` Triton kernel. Kernel-side `src == dst` early-exit avoids memory traffic for filtered-out entries.
- **Pre-allocated pinned buffers** (`input_buffer.py`): Replace per-step `torch.tensor(..., pin_memory=True)` allocation with pre-allocated pinned CPU buffers reused across steps, eliminating expensive driver-level pinned memory allocation overhead.

<!-- What changed and why? -->

## Test Plan
- **MTP enabled**
<img width="1174" height="132" alt="image" src="https://github.com/user-attachments/assets/41b3cc47-1235-4570-a0fe-583585f164a8" />

- **MTP disabled**
<img width="1176" height="142" alt="image" src="https://github.com/user-attachments/assets/1b89db9b-352a-4fb5-b499-ba449e487b20" />


### Performance

Qwen3.5-397B-NVFP4 GB200 TP4, bs=64, input 1024 / output 4096, greedy sampler
Output throughput
| Config | Before (c8e7ce1) | After | Speedup |
|--------|:-:|:-:|:-:|
| MTP enabled | 6203 tok/s | 6663 tok/s | +7.4% |
| MTP disabled | 3735 tok/s | 4200 tok/s | +12.4% |
<!-- How was this validated? -->

### Timeline
before:
<img width="1672" height="228" alt="image" src="https://github.com/user-attachments/assets/a83abe19-3966-47ca-8f2d-e4f3b3e1e018" />
after:
<img width="1212" height="184" alt="image" src="https://github.com/user-attachments/assets/7bba03b6-9bb7-40f6-be6c-bf79fea825aa" />



