### PR TITLE
Fix tokenspeed proton import

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/_triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/_triton.py
@@ -29,17 +29,9 @@ import importlib.util
 import sys
 
 import tokenspeed_triton as triton
+import tokenspeed_triton.profiler as proton
 from tokenspeed_triton import language as tl
-
-try:
-    import tokenspeed_proton as proton
-except ImportError:
-    proton = None
-
-try:
-    from tokenspeed_triton.tools.tensor_descriptor import TensorDescriptor
-except ImportError:
-    TensorDescriptor = None
+from tokenspeed_triton.tools.tensor_descriptor import TensorDescriptor
 
 __all__ = [
     "TensorDescriptor",


### PR DESCRIPTION
## Summary

`tokenspeed-proton` installs into `tokenspeed_triton`. Change to import proton from `tokenspeed_triton` instead of `tokenspeed_proton`.

## Test Plan

```
import tokenspeed_triton.profiler as proton
```
