### PR TITLE
fix(qwen3): plumb tensor-parallel info through MLP layers

### DIFF
--- a/python/tokenspeed/runtime/models/qwen3.py
+++ b/python/tokenspeed/runtime/models/qwen3.py
@@ -61,6 +61,9 @@ class Qwen3MLP(nn.Module):
         intermediate_size: int,
         hidden_act: str,
         quant_config: QuantizationConfig | None = None,
+        tp_rank: int | None = None,
+        tp_size: int | None = None,
+        tp_group: tuple[int, ...] | None = None,
     ) -> None:
         super().__init__()
         self.gate_up_proj = MergedColumnParallelLinear(
@@ -68,6 +71,9 @@ class Qwen3MLP(nn.Module):
             [intermediate_size] * 2,
             bias=False,
             quant_config=quant_config,
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+            tp_group=tp_group,
         )
         self.down_proj = RowParallelLinear(
             intermediate_size,
@@ -75,6 +81,9 @@ class Qwen3MLP(nn.Module):
             bias=False,
             quant_config=quant_config,
             reduce_results=False,
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+            tp_group=tp_group,
         )
         if hidden_act != "silu":
             raise ValueError(
@@ -253,6 +262,9 @@ class Qwen3DecoderLayer(nn.Module):
             intermediate_size=config.intermediate_size,
             hidden_act=config.hidden_act,
             quant_config=quant_config,
+            tp_rank=self.mapping.dense.tp_rank,
+            tp_size=self.mapping.dense.tp_size,
+            tp_group=self.mapping.dense.tp_group,
         )
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = RMSNorm(
@@ -280,7 +292,7 @@ class Qwen3DecoderLayer(nn.Module):
             )
             hidden_states, residual = self.input_layernorm(hidden_states, residual)
         else:
-            hidden_states, residual, _ = (
+            hidden_states, residual, *_ = (
                 self.input_layernorm.forward_with_allreduce_fusion(
                     self.mapping.dense.tp_rank,
                     self.mapping.dense.tp_group,
@@ -306,7 +318,7 @@ class Qwen3DecoderLayer(nn.Module):
                 hidden_states, residual
             )
         else:
-            hidden_states, residual, _ = (
+            hidden_states, residual, *_ = (
                 self.post_attention_layernorm.forward_with_allreduce_fusion(
                     self.mapping.attn.tp_rank,
                     self.mapping.attn.tp_group,
@@ -387,7 +399,7 @@ class Qwen3Model(nn.Module):
             )
             hidden_states, _ = self.norm(hidden_states, residual)
         else:
-            hidden_states, _, _ = self.norm.forward_with_allreduce_fusion(
+            hidden_states, *_ = self.norm.forward_with_allreduce_fusion(
                 self.mapping.dense.tp_rank,
                 self.mapping.dense.tp_group,
                 hidden_states,


### PR DESCRIPTION
## Summary

Dense Qwen3 was silently broken at TP>1: `Qwen3MLP` constructed `MergedColumnParallelLinear` (gate_up_proj) and `RowParallelLinear` (down_proj) without passing `tp_rank`/`tp_size`/`tp_group`, so `ColumnParallelLinear.__init__` defaulted them to `tp_size=1` and each rank materialised the **entire** MLP locally. The next decoder layer's `input_layernorm.forward_with_allreduce_fusion` then allreduced the already-full MLP output as if it were a per-rank partial sum, doubling its contribution to the residual stream every layer. The effect compounded and produced garbage at TP>1.

This PR plumbs `mapping.dense.tp_rank/tp_size/tp_group` from `Qwen3DecoderLayer` into `Qwen3MLP`, which forwards them to both projection layers.

Also fixes the 3-tuple unpacking of `forward_with_allreduce_fusion`: the fused `trtllm_allreduce_residual_rmsnorm` kernel returns a 4-tuple `(norm_out, residual_out, scale_out, partial_norm_out)`, and the previous `hidden_states, residual, _ =` form tripped `ValueError: too many values to unpack` once `len(group) > 1` activated the fused path. Switched to `*_` to match `base/comm_ops.py` and `llama_eagle3.py`.

## Reproduction

The bug is undetected because no model in the repo is end-to-end tested at TP>1 (the only `tp_size=_AVAILABLE_GPUS` cases are `gpt-oss-120b` and `Qwen3.5-35B-A3B`, both `min_gpu_memory_gb=150` / `blackwell_only=True`, almost never exercised).

Reproduced cleanly on `Qwen/Qwen3-0.6B`, TP=2, 2× H100, BF16, 3 prompts × 32 decode tokens. Per-token chosen-token logprob comparison vs HF scoring the same sequence:

| Metric | TP=2 before | TP=2 after | TP=1 reference |
|---|---|---|---|
| mean abs Δlog p | **~1.15 nats** | **~0.025 nats** | ~0.027 nats |
| K3 KL estimator | **~0.93 nats/token** | **~6e-4 nats/token** | ~7e-4 nats/token |

Generated text before (sample): `' to share this sunny day with my dog, Bella, Bella, Bella, Bella, Bella, Bella, ...'` — degenerate.
After: `' to go to the park. I have a dog named Max. Max is a very friendly dog. ...'` — coherent, matches TP=1.

## Localization

I traced layer-by-layer (hidden_states/residual mean/std) on TP=1 and TP=2 with the same prompt. Layer 0 outputs match between TP=1 and TP=2 (BF16 noise). Divergence first appears at layer 1's residual stream (TP=2 ~1.5× TP=1's residual norm), pointing at the layer-0→layer-1 transition where the MLP output gets allreduced into the residual. Inspection of `Qwen3MLP` then revealed the missing TP plumbing.

## Test plan

- [x] Pre-commit passes.
- [x] Qwen3-0.6B TP=1: unchanged (~5e-4 K3 nats/token, BF16 noise floor).
- [x] Qwen3-0.6B TP=2: now ~6e-4 K3 nats/token (was ~0.93).
- [ ] Larger Qwen3 dense models at TP=4/8 (not run locally).

## Caveats

- The `*_` unpack-fix part is unconditionally correct; the TP-plumbing part assumes `mapping.dense.tp_*` is the right group for MLP (Qwen3 asserts `attn.tp_size == dense.tp_size`, so this matches the existing all-reduce sites in this file).
- I did not change `Qwen3DecoderLayer`'s comment about not using `CommManager`; the structural choice is preserved.