### PR TITLE
perf(kvcache): add DMA backend for layerwise H2D transfer

### DIFF
--- a/python/tokenspeed/runtime/cache/executor/host_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/host_executor.py
@@ -192,6 +192,8 @@ class HostExecutor:
         self.io_backend = io_backend
         self.layer_num = layer_num
         self.device = device_pool.device
+        # Host pool decides where indices live; mirror it for _move_indices.
+        self.idx_device = host_pool.idx_device
 
         # Optional draft model pools (share the same page mapping as base model)
         self.draft_device_pool = draft_device_pool
@@ -227,9 +229,8 @@ class HostExecutor:
                 self.completed_writebacks = completed_writebacks
             completed_writebacks.append(op_id)
             return
-        device_indices = page_ids_to_token_indices(
-            src_pages, self.page_size, str(self.device)
-        )
+        # Both on host; _move_indices async-moves to idx_device.
+        device_indices = page_ids_to_token_indices(src_pages, self.page_size, "cpu")
         host_indices = page_ids_to_token_indices(dst_pages, self.page_size, "cpu")
         self.write_queue.append(
             _TransferOp(host_indices, device_indices, op_id, is_retract)
@@ -240,9 +241,7 @@ class HostExecutor:
         if not src_pages:
             return
         host_indices = page_ids_to_token_indices(src_pages, self.page_size, "cpu")
-        device_indices = page_ids_to_token_indices(
-            dst_pages, self.page_size, str(self.device)
-        )
+        device_indices = page_ids_to_token_indices(dst_pages, self.page_size, "cpu")
         self.load_queue.append(_TransferOp(host_indices, device_indices, op_id))
 
     def flush(self) -> None:
@@ -370,12 +369,13 @@ class HostExecutor:
         host_indices = op.host_indices
         device_indices = op.device_indices
         if self.io_backend == "kernel":
-            if not host_indices.is_cuda:
-                host_indices = host_indices.to(self.device, non_blocking=True)
+            if host_indices.device != self.idx_device:
+                host_indices = host_indices.to(self.idx_device, non_blocking=True)
+            if device_indices.device != self.idx_device:
+                device_indices = device_indices.to(self.idx_device, non_blocking=True)
             return host_indices, device_indices
         elif self.io_backend == "direct":
             if host_pool.layout == "layer_first":
-                device_indices = device_indices.cpu()
                 host_indices, idx = host_indices.sort()
                 return host_indices, device_indices.index_select(0, idx)
         raise ValueError(f"Unsupported io_backend={self.io_backend}")

--- a/python/tokenspeed/runtime/cache/executor/host_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/host_executor.py
@@ -55,6 +55,23 @@ def _new_cache_stream(priority: int | None = None):
         return device_module.Stream()
 
 
+def _run_per_layer_loadback(
+    host_pool,
+    device_pool,
+    host_indices: torch.Tensor,
+    device_indices: torch.Tensor,
+    io_backend: str,
+    layer_num: int,
+    producer_event,
+) -> None:
+    for layer_index in range(layer_num):
+        host_pool.load_to_device_per_layer(
+            device_pool, host_indices, device_indices, layer_index, io_backend
+        )
+        if producer_event is not None:
+            producer_event.complete(layer_index)
+
+
 def page_ids_to_token_indices(
     page_ids: list[int],
     page_size: int,
@@ -329,25 +346,26 @@ class HostExecutor:
 
         with device_module.stream(self.load_stream):
             producer_event.start_event.wait(self.load_stream)
-            for layer_index in range(self.layer_num):
-                self.host_pool.load_to_device_per_layer(
-                    self.device_pool,
-                    host_indices.to(torch.int64),
-                    device_indices.to(torch.int64),
-                    layer_index,
-                    self.io_backend,
-                )
-                producer_event.complete(layer_index)
+            _run_per_layer_loadback(
+                self.host_pool,
+                self.device_pool,
+                host_indices.to(torch.int64),
+                device_indices.to(torch.int64),
+                self.io_backend,
+                self.layer_num,
+                producer_event,
+            )
             # Draft layers follow base layers in the same load stream.
             if self.draft_host_pool is not None:
-                for layer_index in range(self.draft_layer_num):
-                    self.draft_host_pool.load_to_device_per_layer(
-                        self.draft_device_pool,
-                        draft_host_indices.to(torch.int64),
-                        draft_device_indices.to(torch.int64),
-                        layer_index,
-                        self.io_backend,
-                    )
+                _run_per_layer_loadback(
+                    self.draft_host_pool,
+                    self.draft_device_pool,
+                    draft_host_indices.to(torch.int64),
+                    draft_device_indices.to(torch.int64),
+                    self.io_backend,
+                    self.draft_layer_num,
+                    producer_event=None,
+                )
                 if draft_host_indices.is_cuda:
                     draft_host_indices.record_stream(self.load_stream)
                 if draft_device_indices.is_cuda:

--- a/python/tokenspeed/runtime/cache/executor/host_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/host_executor.py
@@ -192,8 +192,6 @@ class HostExecutor:
         self.io_backend = io_backend
         self.layer_num = layer_num
         self.device = device_pool.device
-        # Host pool decides where indices live; mirror it for _move_indices.
-        self.idx_device = host_pool.idx_device
 
         # Optional draft model pools (share the same page mapping as base model)
         self.draft_device_pool = draft_device_pool
@@ -369,10 +367,11 @@ class HostExecutor:
         host_indices = op.host_indices
         device_indices = op.device_indices
         if self.io_backend == "kernel":
-            if host_indices.device != self.idx_device:
-                host_indices = host_indices.to(self.idx_device, non_blocking=True)
-            if device_indices.device != self.idx_device:
-                device_indices = device_indices.to(self.idx_device, non_blocking=True)
+            idx_device = host_pool.idx_device
+            if host_indices.device != idx_device:
+                host_indices = host_indices.to(idx_device, non_blocking=True)
+            if device_indices.device != idx_device:
+                device_indices = device_indices.to(idx_device, non_blocking=True)
             return host_indices, device_indices
         elif self.io_backend == "direct":
             if host_pool.layout == "layer_first":

--- a/python/tokenspeed/runtime/cache/kv_cache_host.py
+++ b/python/tokenspeed/runtime/cache/kv_cache_host.py
@@ -52,7 +52,8 @@ if _is_nvidia:
         transfer_kv_per_layer_pf_lf,
         transfer_kv_per_layer_ph_lf,
     )
-from tokenspeed_kernel.ops.kvcache.triton import (
+from tokenspeed_kernel.ops.kvcache import (
+    loadback_indices_device,
     transfer_kv_all_layer,
     transfer_kv_per_layer,
 )
@@ -85,6 +86,9 @@ class HostKVCache(abc.ABC):
         self.page_size = page_size
         self.layout = layout
         self.device = device
+        # Where this pool's transfer ops want index tensors. DMA-eligible
+        # subclasses override; default is the GPU device for CUDA kernels.
+        self.idx_device = device_pool.device
 
         self.dtype = device_pool.store_dtype
         self.size_per_token = self.get_size_per_token()
@@ -255,6 +259,10 @@ class MHATokenToKVPoolHost(HostKVCache):
             dtype=torch.uint64,
             device=self.device_pool.device,
         )
+        # Only layer_first routes through the kvcacheio dispatcher (DMA or
+        # Triton); other layouts use CUDA-only Triton kernels directly.
+        if self.layout == "layer_first":
+            self.idx_device = loadback_indices_device(self.device_pool.device)
 
     def get_size_per_token(self):
         self.head_num = self.device_pool.head_num
@@ -375,10 +383,10 @@ class MHATokenToKVPoolHost(HostKVCache):
         if io_backend == "kernel":
             if self.layout == "layer_first":
                 transfer_kv_all_layer(
-                    src_k_layers=device_pool.k_data_ptrs,
-                    dst_k_layers=self.k_data_ptrs,
-                    src_v_layers=device_pool.v_data_ptrs,
-                    dst_v_layers=self.v_data_ptrs,
+                    src_k_layers=device_pool.k_buffer,
+                    dst_k_layers=self.k_data_refs,
+                    src_v_layers=device_pool.v_buffer,
+                    dst_v_layers=self.v_data_refs,
                     src_indices=device_indices,
                     dst_indices=host_indices,
                     item_size=self.token_stride_size,

--- a/python/tokenspeed/runtime/cache/kv_cache_host.py
+++ b/python/tokenspeed/runtime/cache/kv_cache_host.py
@@ -326,6 +326,7 @@ class MHATokenToKVPoolHost(HostKVCache):
                     src_indices=host_indices,
                     dst_indices=device_indices,
                     item_size=self.token_stride_size,
+                    page_size=self.page_size,
                 )
             elif self.layout == "page_first":
                 transfer_kv_per_layer_pf_lf(
@@ -391,6 +392,7 @@ class MHATokenToKVPoolHost(HostKVCache):
                     dst_indices=host_indices,
                     item_size=self.token_stride_size,
                     num_layers=self.layer_num,
+                    page_size=self.page_size,
                 )
             elif self.layout == "page_first":
                 transfer_kv_all_layer_lf_pf(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/__init__.py
@@ -69,11 +69,17 @@ def transfer_kv_per_layer(
     src_indices: torch.Tensor,
     dst_indices: torch.Tensor,
     item_size: int,
+    page_size: int = 1,
 ) -> None:
-    """One-layer KV transfer; routes to DMA or Triton based on backend."""
+    """One-layer KV transfer; routes to DMA or Triton based on backend.
+
+    ``page_size`` lets the DMA path coalesce contiguous slots into one
+    descriptor per page (k descriptors instead of k*page_size). Triton
+    ignores it — its kernel is already per-slot.
+    """
     if select_backend() == "dma":
         _dma.transfer_kv_per_layer(
-            src_k, dst_k, src_v, dst_v, src_indices, dst_indices, item_size
+            src_k, dst_k, src_v, dst_v, src_indices, dst_indices, item_size, page_size
         )
         return
     _triton.transfer_kv_per_layer(
@@ -106,12 +112,15 @@ def transfer_kv_all_layer(
     dst_indices: torch.Tensor,
     item_size: int,
     num_layers: int,
+    page_size: int = 1,
 ) -> None:
     """All-layer KV transfer; routes to DMA or Triton based on backend.
 
     ``src_*_layers`` / ``dst_*_layers`` are lists of per-layer Tensors
-    (e.g. the pool's ``k_buffer`` / ``k_data_refs``). DMA reads
-    ``.data_ptr()`` host-side; Triton uses a cached uint64 CUDA tensor.
+    (e.g. the pool's ``k_buffer`` / ``k_data_refs``). ``page_size``
+    lets the DMA path coalesce contiguous slots into one descriptor per
+    page; pass ``self.page_size`` from the engine when indices are
+    page-aligned (the usual case for loadback / writeback).
     """
     if select_backend() == "dma":
         _dma.transfer_kv_all_layer(
@@ -123,6 +132,7 @@ def transfer_kv_all_layer(
             dst_indices,
             item_size,
             num_layers,
+            page_size,
         )
         return
     gpu = src_indices.device

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/__init__.py
@@ -18,4 +18,129 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""KV cache kernel entry points."""
+"""Unified KV cache transfer entrypoints.
+
+Public functions ``transfer_kv_per_layer`` and ``transfer_kv_all_layer``
+auto-select between the DMA backend (``cuMemcpyBatchAsync`` via
+``ops/kvcache/dma.py``, NVIDIA + CUDA 12.8+; copies run on GPU copy
+engines, no SM contention) and the Triton backend
+(``ops/kvcache/triton.py``, SM-using). The engine queries
+``loadback_indices_device`` to learn where to place index tensors for
+the active backend. Override with
+``TOKENSPEED_KVCACHEIO_BACKEND={auto,dma,triton}``.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+
+import torch
+from tokenspeed_kernel.ops.kvcache import dma as _dma
+from tokenspeed_kernel.ops.kvcache import triton as _triton
+from tokenspeed_kernel.platform import current_platform
+
+_OVERRIDE_ENV = "TOKENSPEED_KVCACHEIO_BACKEND"
+
+
+@lru_cache(maxsize=1)
+def select_backend() -> str:
+    """Return ``'dma'`` or ``'triton'`` for the current platform/env."""
+    override = os.environ.get(_OVERRIDE_ENV, "auto").lower()
+    if override in ("dma", "triton"):
+        return override
+    if current_platform().is_nvidia and _dma.is_available():
+        return "dma"
+    return "triton"
+
+
+def loadback_indices_device(default_device: torch.device) -> torch.device:
+    """Where the engine should keep loadback index tensors."""
+    if select_backend() == "dma":
+        return torch.device("cpu")
+    return default_device
+
+
+def transfer_kv_per_layer(
+    src_k: torch.Tensor,
+    dst_k: torch.Tensor,
+    src_v: torch.Tensor,
+    dst_v: torch.Tensor,
+    src_indices: torch.Tensor,
+    dst_indices: torch.Tensor,
+    item_size: int,
+) -> None:
+    """One-layer KV transfer; routes to DMA or Triton based on backend."""
+    if select_backend() == "dma":
+        _dma.transfer_kv_per_layer(
+            src_k, dst_k, src_v, dst_v, src_indices, dst_indices, item_size
+        )
+        return
+    _triton.transfer_kv_per_layer(
+        src_k, dst_k, src_v, dst_v, src_indices, dst_indices, item_size
+    )
+
+
+_ptr_tensor_cache: dict = {}
+
+
+def _layers_to_ptr_tensor(layers: list, device: torch.device) -> torch.Tensor:
+    # Pool-owned layer lists live for the process lifetime, so id() is stable.
+    key = (id(layers), device)
+    cached = _ptr_tensor_cache.get(key)
+    if cached is not None:
+        return cached
+    ptrs = torch.tensor(
+        [t.data_ptr() for t in layers], dtype=torch.uint64, device=device
+    )
+    _ptr_tensor_cache[key] = ptrs
+    return ptrs
+
+
+def transfer_kv_all_layer(
+    src_k_layers: list,
+    dst_k_layers: list,
+    src_v_layers: list,
+    dst_v_layers: list,
+    src_indices: torch.Tensor,
+    dst_indices: torch.Tensor,
+    item_size: int,
+    num_layers: int,
+) -> None:
+    """All-layer KV transfer; routes to DMA or Triton based on backend.
+
+    ``src_*_layers`` / ``dst_*_layers`` are lists of per-layer Tensors
+    (e.g. the pool's ``k_buffer`` / ``k_data_refs``). DMA reads
+    ``.data_ptr()`` host-side; Triton uses a cached uint64 CUDA tensor.
+    """
+    if select_backend() == "dma":
+        _dma.transfer_kv_all_layer(
+            src_k_layers,
+            dst_k_layers,
+            src_v_layers,
+            dst_v_layers,
+            src_indices,
+            dst_indices,
+            item_size,
+            num_layers,
+        )
+        return
+    gpu = src_indices.device
+    _triton.transfer_kv_all_layer(
+        _layers_to_ptr_tensor(src_k_layers, gpu),
+        _layers_to_ptr_tensor(dst_k_layers, gpu),
+        _layers_to_ptr_tensor(src_v_layers, gpu),
+        _layers_to_ptr_tensor(dst_v_layers, gpu),
+        src_indices,
+        dst_indices,
+        item_size,
+        num_layers,
+    )
+
+
+__all__ = [
+    "select_backend",
+    "loadback_indices_device",
+    "transfer_kv_per_layer",
+    "transfer_kv_all_layer",
+]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/dma.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/dma.py
@@ -48,21 +48,30 @@ def transfer_kv_per_layer(
     src_indices: torch.Tensor,
     dst_indices: torch.Tensor,
     item_size: int,
+    page_size: int = 1,
 ) -> None:
-    """One-layer KV transfer via ``cuMemcpyBatchAsync`` (one descriptor per slot)."""
+    """One-layer KV transfer via ``cuMemcpyBatchAsync``.
+
+    With ``page_size > 1`` indices must be page-aligned and we coalesce
+    contiguous slots into one descriptor per page (e.g. 100 page descriptors
+    instead of 3200 slot descriptors for a 100-page transfer).
+    """
     if src_indices.numel() == 0:
         return
     assert (
         not src_indices.is_cuda and not dst_indices.is_cuda
     ), "DMA backend requires CPU index tensors"
+    src_off, dst_off, block_bytes = _coalesce_to_pages(
+        src_indices, dst_indices, item_size, page_size
+    )
     batch_async_load_kv_pages(
         host_k_layers=[src_k],
         host_v_layers=[src_v],
         device_k_layers=[dst_k],
         device_v_layers=[dst_v],
-        src_page_token_offsets=src_indices,
-        dst_page_token_offsets=dst_indices,
-        page_bytes=item_size,
+        src_page_token_offsets=src_off,
+        dst_page_token_offsets=dst_off,
+        page_bytes=block_bytes,
         token_stride_bytes=item_size,
         stream=torch.cuda.current_stream(),
     )
@@ -77,8 +86,12 @@ def transfer_kv_all_layer(
     dst_indices: torch.Tensor,
     item_size: int,
     num_layers: int,
+    page_size: int = 1,
 ) -> None:
-    """All-layer KV transfer via ``cuMemcpyBatchAsync``; layer args are tensor lists."""
+    """All-layer KV transfer via ``cuMemcpyBatchAsync``.
+
+    See :func:`transfer_kv_per_layer` for the ``page_size`` semantics.
+    """
     if src_indices.numel() == 0:
         return
     assert (
@@ -91,14 +104,33 @@ def transfer_kv_all_layer(
         == len(dst_v_layers)
         == num_layers
     )
+    src_off, dst_off, block_bytes = _coalesce_to_pages(
+        src_indices, dst_indices, item_size, page_size
+    )
     batch_async_load_kv_pages(
         host_k_layers=src_k_layers,
         host_v_layers=src_v_layers,
         device_k_layers=dst_k_layers,
         device_v_layers=dst_v_layers,
-        src_page_token_offsets=src_indices,
-        dst_page_token_offsets=dst_indices,
-        page_bytes=item_size,
+        src_page_token_offsets=src_off,
+        dst_page_token_offsets=dst_off,
+        page_bytes=block_bytes,
         token_stride_bytes=item_size,
         stream=torch.cuda.current_stream(),
+    )
+
+
+def _coalesce_to_pages(
+    src_indices: torch.Tensor,
+    dst_indices: torch.Tensor,
+    item_size: int,
+    page_size: int,
+):
+    """Stride down to one descriptor per page when indices are page-aligned."""
+    if page_size <= 1:
+        return src_indices, dst_indices, item_size
+    return (
+        src_indices.view(-1, page_size)[:, 0],
+        dst_indices.view(-1, page_size)[:, 0],
+        page_size * item_size,
     )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/dma.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/dma.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""DMA solution for KV cache transfers via ``cuMemcpyBatchAsync``.
+
+Same per-layer / all-layer function signatures as the Triton solution in
+``triton.py`` so the dispatcher in ``__init__.py`` can swap backends
+transparently. Copies run on the GPU's copy engines, leaving SMs / L2
+free for concurrent compute. This module never calls ``.cpu()`` /
+``.detach()`` / ``.cuda()`` on its inputs — the engine is responsible
+for placing indices on host (a misplaced input raises rather than
+syncing silently).
+"""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel.thirdparty.cuda.dma_kvcacheio import (
+    batch_async_load_kv_pages,
+    is_available,
+)
+
+__all__ = ["is_available", "transfer_kv_per_layer", "transfer_kv_all_layer"]
+
+
+def transfer_kv_per_layer(
+    src_k: torch.Tensor,
+    dst_k: torch.Tensor,
+    src_v: torch.Tensor,
+    dst_v: torch.Tensor,
+    src_indices: torch.Tensor,
+    dst_indices: torch.Tensor,
+    item_size: int,
+) -> None:
+    """One-layer KV transfer via ``cuMemcpyBatchAsync`` (one descriptor per slot)."""
+    if src_indices.numel() == 0:
+        return
+    assert (
+        not src_indices.is_cuda and not dst_indices.is_cuda
+    ), "DMA backend requires CPU index tensors"
+    batch_async_load_kv_pages(
+        host_k_layers=[src_k],
+        host_v_layers=[src_v],
+        device_k_layers=[dst_k],
+        device_v_layers=[dst_v],
+        src_page_token_offsets=src_indices,
+        dst_page_token_offsets=dst_indices,
+        page_bytes=item_size,
+        token_stride_bytes=item_size,
+        stream=torch.cuda.current_stream(),
+    )
+
+
+def transfer_kv_all_layer(
+    src_k_layers: list,
+    dst_k_layers: list,
+    src_v_layers: list,
+    dst_v_layers: list,
+    src_indices: torch.Tensor,
+    dst_indices: torch.Tensor,
+    item_size: int,
+    num_layers: int,
+) -> None:
+    """All-layer KV transfer via ``cuMemcpyBatchAsync``; layer args are tensor lists."""
+    if src_indices.numel() == 0:
+        return
+    assert (
+        not src_indices.is_cuda and not dst_indices.is_cuda
+    ), "DMA backend requires CPU index tensors"
+    assert (
+        len(src_k_layers)
+        == len(dst_k_layers)
+        == len(src_v_layers)
+        == len(dst_v_layers)
+        == num_layers
+    )
+    batch_async_load_kv_pages(
+        host_k_layers=src_k_layers,
+        host_v_layers=src_v_layers,
+        device_k_layers=dst_k_layers,
+        device_v_layers=dst_v_layers,
+        src_page_token_offsets=src_indices,
+        dst_page_token_offsets=dst_indices,
+        page_bytes=item_size,
+        token_stride_bytes=item_size,
+        stream=torch.cuda.current_stream(),
+    )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/dma_kvcacheio.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/dma_kvcacheio.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""DMA batched memcpy for KV cache transfers via ``cuMemcpyBatchAsync``.
+
+One driver call dispatches all (K/V × layer × page) copies onto the
+GPU's copy engines, so the transfer does not consume SMs or L2 and
+cannot slow concurrent compute (allreduce, MoE bmm). Requires CUDA
+12.8+ (the v13 entry point dropped the failIdx out-param; we go through
+``cuda.bindings.driver`` so the binding picks the right ABI).
+``cuMemcpyBatchAsync`` rejects the legacy NULL stream, so callers must
+issue on an explicit stream.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+from tokenspeed_kernel.platform import current_platform
+
+_driver = None
+_attrs_singleton = None
+_resolve_attempted = False
+
+
+def _try_resolve():
+    global _driver, _attrs_singleton, _resolve_attempted
+    if _resolve_attempted:
+        return _driver
+    _resolve_attempted = True
+    if not current_platform().is_nvidia:
+        return None
+    try:
+        from cuda.bindings import driver as drv
+
+        attrs = drv.CUmemcpyAttributes()
+        attrs.srcAccessOrder = (
+            drv.CUmemcpySrcAccessOrder.CU_MEMCPY_SRC_ACCESS_ORDER_STREAM
+        )
+        _driver = drv
+        _attrs_singleton = attrs
+    except Exception:
+        _driver = None
+    return _driver
+
+
+def is_available() -> bool:
+    """True iff ``cuMemcpyBatchAsync`` is resolvable on the current platform."""
+    return _try_resolve() is not None
+
+
+def batch_async_load_kv_pages(
+    host_k_layers: list,
+    host_v_layers: list,
+    device_k_layers: list,
+    device_v_layers: list,
+    src_page_token_offsets: torch.Tensor,
+    dst_page_token_offsets: torch.Tensor,
+    page_bytes: int,
+    token_stride_bytes: int,
+    stream: torch.cuda.Stream,
+) -> None:
+    """Single ``cuMemcpyBatchAsync`` call for all (K/V × layer × page) blocks.
+
+    ``*_page_token_offsets`` are 1-D CPU int tensors of per-block source /
+    destination token offsets; each block copies ``page_bytes`` bytes at
+    offset ``offset * token_stride_bytes`` from the per-layer base
+    pointer. The layer-list arguments are read host-side via
+    ``Tensor.data_ptr()`` — no syncs.
+    """
+    drv = _try_resolve()
+    if drv is None:
+        raise RuntimeError("cuMemcpyBatchAsync not available; install cuda-python")
+
+    n_pages = int(src_page_token_offsets.numel())
+    if n_pages == 0:
+        return
+    assert int(dst_page_token_offsets.numel()) == n_pages
+    n_layers = len(host_k_layers)
+    assert (
+        n_layers == len(host_v_layers) == len(device_k_layers) == len(device_v_layers)
+    )
+    assert src_page_token_offsets.is_cpu and dst_page_token_offsets.is_cpu
+
+    src_off_np = src_page_token_offsets.numpy().astype(np.uint64, copy=False)
+    dst_off_np = dst_page_token_offsets.numpy().astype(np.uint64, copy=False)
+    stride = np.uint64(token_stride_bytes)
+    src_byte_off = src_off_np * stride
+    dst_byte_off = dst_off_np * stride
+
+    src_k_bases = np.fromiter(
+        (t.data_ptr() for t in host_k_layers), dtype=np.uint64, count=n_layers
+    )
+    src_v_bases = np.fromiter(
+        (t.data_ptr() for t in host_v_layers), dtype=np.uint64, count=n_layers
+    )
+    dst_k_bases = np.fromiter(
+        (t.data_ptr() for t in device_k_layers), dtype=np.uint64, count=n_layers
+    )
+    dst_v_bases = np.fromiter(
+        (t.data_ptr() for t in device_v_layers), dtype=np.uint64, count=n_layers
+    )
+
+    src_k = (src_k_bases[:, None] + src_byte_off[None, :]).ravel()
+    src_v = (src_v_bases[:, None] + src_byte_off[None, :]).ravel()
+    dst_k = (dst_k_bases[:, None] + dst_byte_off[None, :]).ravel()
+    dst_v = (dst_v_bases[:, None] + dst_byte_off[None, :]).ravel()
+
+    src_all = np.concatenate([src_k, src_v])
+    dst_all = np.concatenate([dst_k, dst_v])
+    sz_all = np.full(src_all.shape[0], page_bytes, dtype=np.uint64)
+    total = int(src_all.shape[0])
+
+    src_list = [drv.CUdeviceptr(int(p)) for p in src_all]
+    dst_list = [drv.CUdeviceptr(int(p)) for p in dst_all]
+    sz_list = [int(s) for s in sz_all]
+
+    (err,) = drv.cuMemcpyBatchAsync(
+        dst_list,
+        src_list,
+        sz_list,
+        total,
+        [_attrs_singleton],
+        [0],
+        1,
+        stream.cuda_stream,
+    )
+    if err != drv.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(
+            f"cuMemcpyBatchAsync failed: err={err} "
+            f"total={total} n_layers={n_layers} n_pages={n_pages}"
+        )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/dma_kvcacheio.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/dma_kvcacheio.py
@@ -23,46 +23,83 @@
 One driver call dispatches all (K/V × layer × page) copies onto the
 GPU's copy engines, so the transfer does not consume SMs or L2 and
 cannot slow concurrent compute (allreduce, MoE bmm). Requires CUDA
-12.8+ (the v13 entry point dropped the failIdx out-param; we go through
-``cuda.bindings.driver`` so the binding picks the right ABI).
-``cuMemcpyBatchAsync`` rejects the legacy NULL stream, so callers must
-issue on an explicit stream.
+12.8+; ``cuda-python`` is used to look the symbol up at module load,
+then the hot-path call is a raw ``ctypes`` thunk that takes numpy
+data pointers directly — avoiding ~10µs/descriptor of Python wrapper
+cost we'd otherwise pay constructing ``CUdeviceptr`` objects.
+``cuMemcpyBatchAsync`` rejects the legacy NULL stream, so callers
+must issue on an explicit stream.
 """
 
 from __future__ import annotations
+
+import ctypes
 
 import numpy as np
 import torch
 from tokenspeed_kernel.platform import current_platform
 
-_driver = None
+
+class _CUmemLocation(ctypes.Structure):
+    _fields_ = [("type", ctypes.c_uint), ("id", ctypes.c_int)]
+
+
+class _CUmemcpyAttributes(ctypes.Structure):
+    _fields_ = [
+        ("srcAccessOrder", ctypes.c_uint),
+        ("srcLocHint", _CUmemLocation),
+        ("dstLocHint", _CUmemLocation),
+        ("flags", ctypes.c_uint),
+    ]
+
+
+# CUresult cuMemcpyBatchAsync(
+#     CUdeviceptr *dsts, CUdeviceptr *srcs, size_t *sizes, size_t count,
+#     CUmemcpyAttributes *attrs, size_t *attrsIdxs, size_t numAttrs,
+#     CUstream hStream
+# );  -- v13 ABI; v12 had an extra failIdx out-param before hStream.
+_BATCH_FN_TYPE = ctypes.CFUNCTYPE(
+    ctypes.c_uint,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_size_t,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_size_t,
+    ctypes.c_void_p,
+)
+
+_batch_fn = None
 _attrs_singleton = None
+_attrs_idxs_np = np.zeros(1, dtype=np.uint64)
 _resolve_attempted = False
 
 
 def _try_resolve():
-    global _driver, _attrs_singleton, _resolve_attempted
+    global _batch_fn, _attrs_singleton, _resolve_attempted
     if _resolve_attempted:
-        return _driver
+        return _batch_fn
     _resolve_attempted = True
     if not current_platform().is_nvidia:
         return None
     try:
         from cuda.bindings import driver as drv
 
-        attrs = drv.CUmemcpyAttributes()
-        attrs.srcAccessOrder = (
-            drv.CUmemcpySrcAccessOrder.CU_MEMCPY_SRC_ACCESS_ORDER_STREAM
-        )
-        _driver = drv
-        _attrs_singleton = attrs
+        err, ver = drv.cuDriverGetVersion()
+        if err != drv.CUresult.CUDA_SUCCESS:
+            return None
+        err, ptr, _ = drv.cuGetProcAddress(b"cuMemcpyBatchAsync", ver, 0)
+        if err != drv.CUresult.CUDA_SUCCESS or not ptr:
+            return None
+        _batch_fn = _BATCH_FN_TYPE(ptr)
+        _attrs_singleton = _CUmemcpyAttributes(srcAccessOrder=1)  # STREAM
     except Exception:
-        _driver = None
-    return _driver
+        _batch_fn = None
+    return _batch_fn
 
 
 def is_available() -> bool:
-    """True iff ``cuMemcpyBatchAsync`` is resolvable on the current platform."""
     return _try_resolve() is not None
 
 
@@ -79,14 +116,12 @@ def batch_async_load_kv_pages(
 ) -> None:
     """Single ``cuMemcpyBatchAsync`` call for all (K/V × layer × page) blocks.
 
-    ``*_page_token_offsets`` are 1-D CPU int tensors of per-block source /
-    destination token offsets; each block copies ``page_bytes`` bytes at
-    offset ``offset * token_stride_bytes`` from the per-layer base
-    pointer. The layer-list arguments are read host-side via
-    ``Tensor.data_ptr()`` — no syncs.
+    Descriptors live entirely in three numpy uint64 arrays passed by their
+    raw memory pointer — no per-descriptor Python work. Hot-path cost is
+    dominated by the driver dispatch.
     """
-    drv = _try_resolve()
-    if drv is None:
+    fn = _try_resolve()
+    if fn is None:
         raise RuntimeError("cuMemcpyBatchAsync not available; install cuda-python")
 
     n_pages = int(src_page_token_offsets.numel())
@@ -99,11 +134,11 @@ def batch_async_load_kv_pages(
     )
     assert src_page_token_offsets.is_cpu and dst_page_token_offsets.is_cpu
 
-    src_off_np = src_page_token_offsets.numpy().astype(np.uint64, copy=False)
-    dst_off_np = dst_page_token_offsets.numpy().astype(np.uint64, copy=False)
+    src_off = src_page_token_offsets.numpy().astype(np.uint64, copy=False)
+    dst_off = dst_page_token_offsets.numpy().astype(np.uint64, copy=False)
     stride = np.uint64(token_stride_bytes)
-    src_byte_off = src_off_np * stride
-    dst_byte_off = dst_off_np * stride
+    src_byte_off = src_off * stride
+    dst_byte_off = dst_off * stride
 
     src_k_bases = np.fromiter(
         (t.data_ptr() for t in host_k_layers), dtype=np.uint64, count=n_layers
@@ -123,27 +158,24 @@ def batch_async_load_kv_pages(
     dst_k = (dst_k_bases[:, None] + dst_byte_off[None, :]).ravel()
     dst_v = (dst_v_bases[:, None] + dst_byte_off[None, :]).ravel()
 
-    src_all = np.concatenate([src_k, src_v])
-    dst_all = np.concatenate([dst_k, dst_v])
-    sz_all = np.full(src_all.shape[0], page_bytes, dtype=np.uint64)
-    total = int(src_all.shape[0])
+    # Single uint64 arrays for dst/src/size; ascontiguousarray so .ctypes.data
+    # is a stable pointer the driver can read directly.
+    dst_all = np.ascontiguousarray(np.concatenate([dst_k, dst_v]), dtype=np.uint64)
+    src_all = np.ascontiguousarray(np.concatenate([src_k, src_v]), dtype=np.uint64)
+    sz_all = np.full(dst_all.size, page_bytes, dtype=np.uint64)
 
-    src_list = [drv.CUdeviceptr(int(p)) for p in src_all]
-    dst_list = [drv.CUdeviceptr(int(p)) for p in dst_all]
-    sz_list = [int(s) for s in sz_all]
-
-    (err,) = drv.cuMemcpyBatchAsync(
-        dst_list,
-        src_list,
-        sz_list,
-        total,
-        [_attrs_singleton],
-        [0],
-        1,
-        stream.cuda_stream,
+    err = fn(
+        dst_all.ctypes.data,
+        src_all.ctypes.data,
+        sz_all.ctypes.data,
+        ctypes.c_size_t(dst_all.size),
+        ctypes.addressof(_attrs_singleton),
+        _attrs_idxs_np.ctypes.data,
+        ctypes.c_size_t(1),
+        ctypes.c_void_p(stream.cuda_stream),
     )
-    if err != drv.CUresult.CUDA_SUCCESS:
+    if err != 0:
         raise RuntimeError(
             f"cuMemcpyBatchAsync failed: err={err} "
-            f"total={total} n_layers={n_layers} n_pages={n_pages}"
+            f"total={dst_all.size} n_layers={n_layers} n_pages={n_pages}"
         )


### PR DESCRIPTION
## Summary

The triton kernel for per layer kv transfer will compete sm with model forward:
<img width="2910" height="570" alt="image" src="https://github.com/user-attachments/assets/8a1ba575-aa69-4189-8385-abd970c61cb7" />
which should be 109us without contention.

Switch to DMA only copy: todo: image.


## Test Plan

<!-- How was this validated? -->
