### PR TITLE
Add --model-path alias for --model

### DIFF
--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -651,6 +651,7 @@ class ServerArgs:
         )
         parser.add_argument(
             "--model",
+            "--model-path",
             metavar="MODEL",
             type=str,
             default=None,
@@ -1722,7 +1723,7 @@ class ServerArgs:
         if args.model is None:
             raise ValueError(
                 "Model is required. Provide it as a positional argument "
-                "(e.g., `tokenspeed serve <model>`) or via --model."
+                "(e.g., `tokenspeed serve <model>`) or via --model/--model-path."
             )
 
         # --tensor-parallel-size → --attn-tp-size

--- a/test/runtime/test_server_args_attention_backends.py
+++ b/test/runtime/test_server_args_attention_backends.py
@@ -82,6 +82,14 @@ class TestAttentionBackendChoices(unittest.TestCase):
         args = prepare_server_args(["--model", "x"])
         self.assertTrue(args.enable_inline_detokenizer)
 
+    def test_model_path_alias_sets_model(self):
+        args = self._build_parser().parse_args(["--model-path", "x"])
+        self.assertEqual(args.model, "x")
+
+    def test_prepare_server_args_accepts_model_path_alias(self):
+        args = prepare_server_args(["--model-path", "x"])
+        self.assertEqual(args.model, "x")
+
     def test_defaults_to_mha_for_mha(self):
         self.assertEqual(registry._get_default_backend_name(AttentionArch.MHA), "mha")
 


### PR DESCRIPTION
## Summary
- add `--model-path` as an alias for the existing `--model` argument
- update missing-model guidance to mention both flags
- add regression coverage for parser and `prepare_server_args`

## Tests
- `python3 -m pytest test/runtime/test_server_args_attention_backends.py -q` (13 passed)
- `python3 -m py_compile python/tokenspeed/runtime/utils/server_args.py test/runtime/test_server_args_attention_backends.py`
- `python3 -m ruff check --select F821 python/tokenspeed/runtime/utils/server_args.py test/runtime/test_server_args_attention_backends.py`
- `pre-commit run --all-files`