### PR TITLE
docs: add Qwen3 and DeepSeek V3/V3.1 model recipes

### DIFF
--- a/docs/recipes/models.md
+++ b/docs/recipes/models.md
@@ -64,6 +64,62 @@ tokenspeed serve openai/gpt-oss-120b \
   --port 8000
 ```
 
+## DeepSeek V3 / V3.1
+
+DeepSeek V3 and V3.1 models use MLA attention and MoE architecture. They
+require `--trust-remote-code` and benefit from expert parallelism.
+
+### DeepSeek-V3-0324 (FP8)
+
+```bash
+tokenspeed serve deepseek-ai/DeepSeek-V3-0324   --served-model-name deepseek-v3   --trust-remote-code   --tensor-parallel-size 4   --enable-expert-parallel   --max-model-len 131072   --kv-cache-dtype fp8   --chunked-prefill-size 8192   --max-num-seqs 256   --attention-backend trtllm_mla   --moe-backend flashinfer_trtllm   --reasoning-parser deepseekv3   --tool-call-parser deepseekv3   --host 0.0.0.0   --port 8000
+```
+
+### DeepSeek-V3.1 (latest)
+
+V3.1 uses the same architecture as V3 with updated weights and improved
+tool-call formatting.
+
+```bash
+tokenspeed serve deepseek-ai/DeepSeek-V3.1   --served-model-name deepseek-v3.1   --trust-remote-code   --tensor-parallel-size 4   --enable-expert-parallel   --max-model-len 131072   --kv-cache-dtype fp8   --chunked-prefill-size 8192   --max-num-seqs 256   --attention-backend trtllm_mla   --moe-backend flashinfer_trtllm   --reasoning-parser deepseekv31   --tool-call-parser deepseekv31   --host 0.0.0.0   --port 8000
+```
+
+## Qwen3 / Qwen3.5
+
+Qwen3 models support thinking mode (reasoning) and tool calling. Use
+`--reasoning-parser qwen3` for thinking mode and `--tool-call-parser qwen3`
+for function calling.
+
+### Qwen3-8B (single GPU)
+
+```bash
+tokenspeed serve Qwen/Qwen3-8B   --served-model-name qwen3-8b   --tensor-parallel-size 1   --max-model-len 131072   --chunked-prefill-size 8192   --reasoning-parser qwen3   --tool-call-parser qwen3   --host 0.0.0.0   --port 8000
+```
+
+### Qwen3-30B-A3B (MoE, multi-GPU)
+
+Qwen3 MoE models benefit from expert parallelism for better throughput.
+
+```bash
+tokenspeed serve Qwen/Qwen3-30B-A3B   --served-model-name qwen3-30b-a3b   --tensor-parallel-size 2   --enable-expert-parallel   --max-model-len 131072   --kv-cache-dtype fp8   --chunked-prefill-size 8192   --max-num-seqs 256   --reasoning-parser qwen3   --tool-call-parser qwen3   --host 0.0.0.0   --port 8000
+```
+
+### Qwen3-Coder-30B-A3B (code generation)
+
+Qwen3-Coder uses a different tool-call format optimized for code generation.
+
+```bash
+tokenspeed serve Qwen/Qwen3-Coder-30B-A3B   --served-model-name qwen3-coder-30b   --tensor-parallel-size 2   --enable-expert-parallel   --max-model-len 262144   --kv-cache-dtype fp8   --chunked-prefill-size 8192   --max-num-seqs 128   --reasoning-parser qwen3   --tool-call-parser qwen3_coder   --host 0.0.0.0   --port 8000
+```
+
+### Qwen3.5-27B (latest generation)
+
+Qwen3.5 models use the same parser configuration as Qwen3.
+
+```bash
+tokenspeed serve Qwen/Qwen3.5-27B   --served-model-name qwen3.5-27b   --tensor-parallel-size 2   --max-model-len 131072   --kv-cache-dtype fp8   --chunked-prefill-size 8192   --max-num-seqs 256   --reasoning-parser qwen3   --tool-call-parser qwen3.5   --host 0.0.0.0   --port 8000
+```
+
 ## Tuning Order
 
 1. Set model ID, trust policy, tokenizer mode, and served model name.


### PR DESCRIPTION
## Summary

Add model recipes for Qwen3, Qwen3 MoE, Qwen3-Coder, Qwen3.5, DeepSeek V3, and DeepSeek V3.1 to the documentation.

## Changes

### New Model Recipes

**Qwen3 Family:**
- Qwen3-8B (single GPU, dense model)
- Qwen3-30B-A3B (MoE, multi-GPU with expert parallelism)
- Qwen3-Coder-30B-A3B (code generation with specialized tool-call parser)
- Qwen3.5-27B (latest generation)

**DeepSeek Family:**
- DeepSeek-V3-0324 (MLA attention, MoE)
- DeepSeek-V3.1 (latest with improved tool-call formatting)

### Key Configuration Details

Each recipe includes:
- Correct `--reasoning-parser` for thinking mode support
- Correct `--tool-call-parser` for function calling
- Appropriate parallelism settings (tensor/expert)
- KV cache dtype recommendations
- Scheduler budget tuning

### Parser Mappings

| Model | reasoning-parser | tool-call-parser |
|-------|-----------------|------------------|
| Qwen3 | `qwen3` | `qwen3` |
| Qwen3-Coder | `qwen3` | `qwen3_coder` |
| Qwen3.5 | `qwen3` | `qwen3.5` |
| DeepSeek V3 | `deepseekv3` | `deepseekv3` |
| DeepSeek V3.1 | `deepseekv31` | `deepseekv31` |

## Why This Matters

The documentation currently only covers Kimi and GPT-OSS models. Adding Qwen3 and DeepSeek recipes:
1. Covers the most popular open-source LLM families
2. Shows proper MLA attention configuration for DeepSeek
3. Demonstrates MoE expert parallelism setup
4. Provides correct parser settings for thinking mode and tool calling

## Test Plan

- Documentation-only change
- Recipes follow the existing format
- Parser names verified against source code (`function_call_parser.py`)

---

*AI assistance used: Claude (Anthropic) for documentation analysis. All changes reviewed and verified by the author.*