### PR TITLE
ci: install smg deps from whl index

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -74,15 +74,6 @@ dependencies = [
     "viztracer",
 ]
 
-[project.optional-dependencies]
-# Install: pip install 'tokenspeed[serve]' --extra-index-url https://lightseek.org/whl/cu130/
-# Bump all three .devN versions together — proto / RuntimeType must stay in sync.
-serve = [
-    "smg==1.4.2.dev15",
-    "smg-grpc-servicer==0.5.3.dev15",
-    "smg-grpc-proto==0.4.8.dev15",
-]
-
 [project.scripts]
 tokenspeed = "tokenspeed.cli:main"
 ts = "tokenspeed.cli:main"

--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -54,8 +54,8 @@ def _check_serve_extra_installed() -> None:
         missing.append("smg-grpc-servicer")
     if missing:
         sys.stderr.write(
-            "ts serve requires the [serve] extra:\n\n"
-            "    pip install 'tokenspeed[serve]' \\\n"
+            "ts serve requires SMG packages:\n\n"
+            "    pip install smg smg-grpc-servicer smg-grpc-proto \\\n"
             "        --extra-index-url https://lightseek.org/whl/cu130/\n\n"
             "Swap the index for other variants:\n"
             "    https://lightseek.org/whl/cu129/      (CUDA 12.9)\n"

--- a/test/ci_system/install_deps.sh
+++ b/test/ci_system/install_deps.sh
@@ -106,6 +106,8 @@ pip_install_with_retry pip3 install tokenspeed-scheduler/
 # Step 5: Install TokenSpeed
 # ============================================================
 echo "=== Step 5: Install TokenSpeed ==="
+pip_install_with_retry pip3 install smg smg-grpc-servicer smg-grpc-proto \
+    --extra-index-url https://lightseek.org/whl/cu130
 pip_install_with_retry pip3 install -e "./python[cuda_${SM}]" \
     --extra-index-url https://download.pytorch.org/whl/cu${CUINDEX}
 

--- a/test/ci_system/install_deps_rocm.sh
+++ b/test/ci_system/install_deps_rocm.sh
@@ -36,6 +36,8 @@ pip3 install cmake ninja
 pip3 install tokenspeed-scheduler/
 
 echo "=== Step 5: Install TokenSpeed ==="
+pip3 install smg smg-grpc-servicer smg-grpc-proto \
+    --extra-index-url https://lightseek.org/whl/cu130
 pip3 install -e ./python --no-build-isolation \
     --extra-index-url "${ROCM_INDEX}"
 

--- a/test/ci_system/install_deps_rocm.sh
+++ b/test/ci_system/install_deps_rocm.sh
@@ -37,7 +37,7 @@ pip3 install tokenspeed-scheduler/
 
 echo "=== Step 5: Install TokenSpeed ==="
 pip3 install smg smg-grpc-servicer smg-grpc-proto \
-    --extra-index-url https://lightseek.org/whl/cu130
+    --extra-index-url https://lightseek.org/whl/rocm72
 pip3 install -e ./python --no-build-isolation \
     --extra-index-url "${ROCM_INDEX}"
 


### PR DESCRIPTION
## Summary
- install smg, smg-grpc-servicer, and smg-grpc-proto explicitly in CI install deps from https://lightseek.org/whl/cu130
- remove the tokenspeed serve optional dependency group and pinned SMG deps from pyproject
- update the ts serve missing-dependency hint to install the SMG packages directly

## Testing
- git diff --check
- python3 -m py_compile python/tokenspeed/cli/serve_smg.py
- parsed python/pyproject.toml with tomllib