### PR TITLE
ci: pin smg install deps

### DIFF
--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -55,7 +55,10 @@ def _check_serve_extra_installed() -> None:
     if missing:
         sys.stderr.write(
             "ts serve requires SMG packages:\n\n"
-            "    pip install smg smg-grpc-servicer smg-grpc-proto \\\n"
+            "    pip install \\\n"
+            "        'smg==1.4.2.dev15' \\\n"
+            "        'smg-grpc-servicer==0.5.3.dev15' \\\n"
+            "        'smg-grpc-proto==0.4.8.dev15' \\\n"
             "        --extra-index-url https://lightseek.org/whl/cu130/\n\n"
             "Swap the index for other variants:\n"
             "    https://lightseek.org/whl/cu129/      (CUDA 12.9)\n"

--- a/test/ci_system/install_deps.sh
+++ b/test/ci_system/install_deps.sh
@@ -106,7 +106,10 @@ pip_install_with_retry pip3 install tokenspeed-scheduler/
 # Step 5: Install TokenSpeed
 # ============================================================
 echo "=== Step 5: Install TokenSpeed ==="
-pip_install_with_retry pip3 install smg smg-grpc-servicer smg-grpc-proto \
+pip_install_with_retry pip3 install \
+    "smg==1.4.2.dev15" \
+    "smg-grpc-servicer==0.5.3.dev15" \
+    "smg-grpc-proto==0.4.8.dev15" \
     --extra-index-url https://lightseek.org/whl/cu130
 pip_install_with_retry pip3 install -e "./python[cuda_${SM}]" \
     --extra-index-url https://download.pytorch.org/whl/cu${CUINDEX}

--- a/test/ci_system/install_deps_rocm.sh
+++ b/test/ci_system/install_deps_rocm.sh
@@ -36,8 +36,11 @@ pip3 install cmake ninja
 pip3 install tokenspeed-scheduler/
 
 echo "=== Step 5: Install TokenSpeed ==="
-pip3 install smg smg-grpc-servicer smg-grpc-proto \
-    --extra-index-url https://lightseek.org/whl/rocm72
+pip3 install \
+    "smg==1.4.2.dev15" \
+    "smg-grpc-servicer==0.5.3.dev15" \
+    "smg-grpc-proto==0.4.8.dev15" \
+    --extra-index-url https://lightseek.org/whl/rocm7.2
 pip3 install -e ./python --no-build-isolation \
     --extra-index-url "${ROCM_INDEX}"
 


### PR DESCRIPTION
## Summary
- pin CI-installed SMG packages to smg==1.4.2.dev15, smg-grpc-servicer==0.5.3.dev15, and smg-grpc-proto==0.4.8.dev15
- keep CUDA installs on https://lightseek.org/whl/cu130
- fix the ROCm SMG wheel index from rocm72 to https://lightseek.org/whl/rocm7.2
- update the ts serve missing-dependency hint with the same pinned versions

## Testing
- git diff --check
- python3 -m py_compile python/tokenspeed/cli/serve_smg.py