### PR TITLE
Update SMG package pins

### DIFF
--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -56,9 +56,9 @@ def _check_serve_extra_installed() -> None:
         sys.stderr.write(
             "ts serve requires SMG packages:\n\n"
             "    pip install \\\n"
-            "        'smg==1.4.2.dev15' \\\n"
-            "        'smg-grpc-servicer==0.5.3.dev15' \\\n"
-            "        'smg-grpc-proto==0.4.8.dev15' \\\n"
+            "        'smg==1.4.1.post20260512' \\\n"
+            "        'smg-grpc-servicer==0.5.2.post20260512' \\\n"
+            "        'smg-grpc-proto==0.4.7.post20260512' \\\n"
             "        --extra-index-url https://lightseek.org/whl/cu130/\n\n"
             "Swap the index for other variants:\n"
             "    https://lightseek.org/whl/cu129/      (CUDA 12.9)\n"

--- a/test/ci_system/install_deps.sh
+++ b/test/ci_system/install_deps.sh
@@ -108,12 +108,12 @@ pip_install_with_retry pip3 install tokenspeed-scheduler/
 echo "=== Step 5: Install TokenSpeed ==="
 # Pin smg / smg-grpc-servicer / smg-grpc-proto: the `tokenspeed` submodule
 # that `ts serve` imports (smg_grpc_servicer.tokenspeed.server) only exists
-# on these dev pins; later versions drop it. The three .devN versions must
-# stay in sync — the gRPC proto / runtime contract is dev-pinned.
+# on these post-release pins. The three post-date versions must stay in sync:
+# the gRPC proto / runtime contract is pinned as a set.
 pip_install_with_retry pip3 install \
-    "smg==1.4.2.dev15" \
-    "smg-grpc-servicer==0.5.3.dev15" \
-    "smg-grpc-proto==0.4.8.dev15" \
+    "smg==1.4.1.post20260512" \
+    "smg-grpc-servicer==0.5.2.post20260512" \
+    "smg-grpc-proto==0.4.7.post20260512" \
     --extra-index-url https://lightseek.org/whl/cu130
 pip_install_with_retry pip3 install -e "./python[cuda_${SM}]" \
     --extra-index-url https://download.pytorch.org/whl/cu${CUINDEX}

--- a/test/ci_system/install_deps_rocm.sh
+++ b/test/ci_system/install_deps_rocm.sh
@@ -38,13 +38,12 @@ pip3 install tokenspeed-scheduler/
 echo "=== Step 5: Install TokenSpeed ==="
 # Pin smg / smg-grpc-servicer / smg-grpc-proto: the `tokenspeed` submodule
 # that `ts serve` imports (smg_grpc_servicer.tokenspeed.server) only exists
-# on these dev pins; the stable releases on PyPI drop it. The three .devN
-# versions must stay in sync — the gRPC proto / runtime contract is
-# dev-pinned.
+# on these post-release pins. The three post-date versions must stay in sync:
+# the gRPC proto / runtime contract is pinned as a set.
 pip3 install \
-    "smg==1.4.2.dev15" \
-    "smg-grpc-servicer==0.5.3.dev15" \
-    "smg-grpc-proto==0.4.8.dev15" \
+    "smg==1.4.1.post20260512" \
+    "smg-grpc-servicer==0.5.2.post20260512" \
+    "smg-grpc-proto==0.4.7.post20260512" \
     --extra-index-url https://lightseek.org/whl/rocm7.2
 pip3 install -e ./python --no-build-isolation \
     --extra-index-url "${ROCM_INDEX}"


### PR DESCRIPTION
## Summary

- Update `ts serve` install guidance to the SMG post-release package set.
- Update CUDA and ROCm CI dependency installs to use:
  - `smg==1.4.1.post20260512`
  - `smg-grpc-proto==0.4.7.post20260512`
  - `smg-grpc-servicer==0.5.2.post20260512`
- Refresh comments to describe the post-date package set instead of the old dev pins.

## Validation

- `python3 -m py_compile python/tokenspeed/cli/serve_smg.py`
- `bash -n test/ci_system/install_deps.sh`
- `bash -n test/ci_system/install_deps_rocm.sh`