### PR TITLE
Resolve platform-specific MLA binary objects

### DIFF
--- a/tokenspeed-mla/python/tokenspeed_mla/fmha_binary.py
+++ b/tokenspeed-mla/python/tokenspeed_mla/fmha_binary.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import functools
 import logging
 import os
+import platform
 from pathlib import Path
 
 import torch
@@ -78,7 +79,12 @@ def _resolve_so_path() -> Path:
     if env:
         return Path(env)
     props = torch.cuda.get_device_properties(torch.cuda.current_device())
-    arch = f"sm_{props.major}{props.minor}a"
+    machine = platform.machine().lower()
+    if machine == "amd64":
+        machine = "x86_64"
+    elif machine == "arm64":
+        machine = "aarch64"
+    arch = f"sm_{props.major}{props.minor}a_{machine}"
     name = f"cute_dsl_fmha_fp8_e4m3_to_bf16_hd192_{arch}.so"
     return _objs_dir() / name
 


### PR DESCRIPTION
## Summary

- Resolve `tokenspeed_mla` binary FMHA shared objects with the platform suffix used by packaged files.
- Normalize `amd64` to `x86_64` and `arm64` to `aarch64` for local machine names.

## Validation

- Ran `pre-commit run --files tokenspeed-mla/python/tokenspeed_mla/fmha_binary.py`.
- Ran `git diff --check`.
- Verified on x86_64 B200 that the resolver finds `cute_dsl_fmha_fp8_e4m3_to_bf16_hd192_sm_100a_x86_64.so`, `cute.runtime.load_module` returns `ExternalBinaryModule`, and `has_binary_prefill()` returns `True`.