### PR TITLE
Default MLA prefill backend to binary

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
@@ -34,12 +34,19 @@ from typing import TYPE_CHECKING
 
 import torch
 import triton
+
+# isort: off
+# env must be imported before tokenspeed_kernel so MLA prefill defaults reach
+# tokenspeed_mla.mla_prefill before its backend is resolved.
+from tokenspeed.runtime.utils.env import global_server_args_dict
 from tokenspeed_kernel.ops.attention.tokenspeed_mla import (
     get_num_sm,
     tokenspeed_mla_decode,
     tokenspeed_mla_prefill,
     warmup_compile_prefill,
 )
+
+# isort: on
 
 from tokenspeed.runtime.configs.model_config import AttentionArch
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
@@ -53,7 +60,6 @@ from tokenspeed.runtime.layers.attention.chunk import (
 )
 from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.registry import register_backend
-from tokenspeed.runtime.utils.env import global_server_args_dict
 from tokenspeed.runtime.utils.pdl import pdl_enabled
 
 if TYPE_CHECKING:

--- a/python/tokenspeed/runtime/utils/env.py
+++ b/python/tokenspeed/runtime/utils/env.py
@@ -278,6 +278,7 @@ class Envs:
     TOKENSPEED_HOST_IP = EnvStr("")
     TOKENSPEED_LOGGING_CONFIG_PATH = EnvStr(None)
     TOKENSPEED_MAMBA_SSM_DTYPE = EnvStr("float32")
+    TOKENSPEED_MLA_PREFILL_BACKEND = EnvStr("binary")
     TOKENSPEED_MODEL_REDIRECT_PATH = EnvStr(None)
     TOKENSPEED_MOE_PADDING = EnvBool(False)
     TOKENSPEED_MOE_CONFIG_DIR = EnvStr(None)
@@ -289,3 +290,13 @@ class Envs:
 
 
 envs = Envs()
+
+
+def _apply_process_env_defaults():
+    os.environ.setdefault(
+        envs.TOKENSPEED_MLA_PREFILL_BACKEND.name,
+        envs.TOKENSPEED_MLA_PREFILL_BACKEND.default,
+    )
+
+
+_apply_process_env_defaults()

--- a/test/runtime/test_env.py
+++ b/test/runtime/test_env.py
@@ -1,0 +1,34 @@
+import importlib
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(REPO_ROOT, "python"))
+
+# CI Registration (parsed via AST, runtime no-op)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=5, suite="runtime-1gpu")
+
+
+def test_mla_prefill_backend_defaults_to_binary(monkeypatch):
+    monkeypatch.delenv("TOKENSPEED_MLA_PREFILL_BACKEND", raising=False)
+
+    import tokenspeed.runtime.utils.env as env_module
+
+    env_module = importlib.reload(env_module)
+
+    assert os.environ["TOKENSPEED_MLA_PREFILL_BACKEND"] == "binary"
+    assert env_module.envs.TOKENSPEED_MLA_PREFILL_BACKEND.get() == "binary"
+
+
+def test_mla_prefill_backend_preserves_user_env(monkeypatch):
+    monkeypatch.setenv("TOKENSPEED_MLA_PREFILL_BACKEND", "cutedsl")
+
+    import tokenspeed.runtime.utils.env as env_module
+
+    env_module = importlib.reload(env_module)
+
+    assert os.environ["TOKENSPEED_MLA_PREFILL_BACKEND"] == "cutedsl"
+    assert env_module.envs.TOKENSPEED_MLA_PREFILL_BACKEND.get() == "cutedsl"


### PR DESCRIPTION
## Summary
- Add `TOKENSPEED_MLA_PREFILL_BACKEND` to runtime env defaults with `binary` as the default.
- Apply the runtime env default before importing the tokenspeed MLA kernel backend so the kernel import path observes the binary default.
- Add env tests covering the default and preserving explicit user overrides.

## Validation
- `python3 -m pytest test/runtime/test_env.py -q`
- `pre-commit run --files python/tokenspeed/runtime/utils/env.py python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py test/runtime/test_env.py`
- `git diff --check`