### PR TITLE
Default SMG serve port to 8000

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "pybind11",
     "pydantic",
     "py-spy",
+    "pytest-asyncio",
     "python-multipart",
     "pyzmq",
     "requests",

--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -43,6 +43,9 @@ from tokenspeed.runtime.utils.process import kill_process_tree
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_GATEWAY_HOST = "0.0.0.0"
+DEFAULT_GATEWAY_PORT = 8000
+
 
 def _check_serve_extra_installed() -> None:
     import importlib.util
@@ -71,12 +74,12 @@ def _check_serve_extra_installed() -> None:
 def _user_host_port_from_gateway_args(gateway_args: list[str]) -> tuple[str, int]:
     """Pull --host / --port out of the gateway-bound argv.
 
-    Defaults match smg's clap (host=0.0.0.0, port=30000). The argv MUST
+    Defaults match TokenSpeed's public serving endpoint. The argv MUST
     be in canonical ``[--flag, value, ...]`` form as produced by
     ``split_argv``; equals-form (``--port=8000``) is not handled here.
     """
-    host = "0.0.0.0"
-    port = 30000
+    host = DEFAULT_GATEWAY_HOST
+    port = DEFAULT_GATEWAY_PORT
     it = iter(gateway_args)
     for token in it:
         if token == "--host":
@@ -84,6 +87,12 @@ def _user_host_port_from_gateway_args(gateway_args: list[str]) -> tuple[str, int
         elif token == "--port":
             port = int(next(it))
     return host, port
+
+
+def _gateway_args_with_default_port(gateway_args: list[str]) -> list[str]:
+    if "--port" in gateway_args:
+        return gateway_args
+    return [*gateway_args, "--port", str(DEFAULT_GATEWAY_PORT)]
 
 
 async def _stream_to(proc, tag: str) -> None:
@@ -265,11 +274,12 @@ def run_smg_from_args(args: argparse.Namespace, raw_argv: list[str]) -> None:
 
     _check_serve_extra_installed()
     split = split_argv(raw_argv)
-    user_host, user_port = _user_host_port_from_gateway_args(split.gateway)
+    gateway_args = _gateway_args_with_default_port(split.gateway)
+    user_host, user_port = _user_host_port_from_gateway_args(gateway_args)
     rc = asyncio.run(
         run_smg(
             engine_args=split.engine,
-            gateway_args=split.gateway,
+            gateway_args=gateway_args,
             opts=split.opts,
             user_host=user_host,
             user_port=user_port,

--- a/test/cli/test_serve_smg_unit.py
+++ b/test/cli/test_serve_smg_unit.py
@@ -23,14 +23,22 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import signal
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(REPO_ROOT, "python"))
+
 from tokenspeed.cli._argsplit import OrchestratorOpts
-from tokenspeed.cli.serve_smg import run_smg
+from tokenspeed.cli.serve_smg import (
+    _gateway_args_with_default_port,
+    _user_host_port_from_gateway_args,
+    run_smg,
+)
 
 
 def _make_proc(returncode: int | None = None) -> MagicMock:
@@ -44,6 +52,20 @@ def _make_proc(returncode: int | None = None) -> MagicMock:
     proc.kill = MagicMock()
     proc.wait = AsyncMock(return_value=returncode if returncode is not None else 0)
     return proc
+
+
+def test_gateway_args_default_port_is_8000():
+    gateway_args = _gateway_args_with_default_port(["--model", "/tmp/x"])
+
+    assert gateway_args == ["--model", "/tmp/x", "--port", "8000"]
+    assert _user_host_port_from_gateway_args(gateway_args) == ("0.0.0.0", 8000)
+
+
+def test_gateway_args_preserve_user_port():
+    gateway_args = _gateway_args_with_default_port(["--port", "8413"])
+
+    assert gateway_args == ["--port", "8413"]
+    assert _user_host_port_from_gateway_args(gateway_args) == ("0.0.0.0", 8413)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Restore the default `ts serve` public port to 8000 when the user does not pass `--port`.
- TokenSpeed's initial release defaulted to port 8000, matching vLLM; the SMG integration PR unintentionally changed the effective default to SMG's 30000.
- Pass the default port through to `smg launch` so the readiness probe and gateway listener agree.
- Add unit coverage for the default port and preserving an explicit user port, make the unit test load the current checkout before any installed TokenSpeed package, and include `pytest-asyncio` in default dependencies for the existing async tests.

## Validation
- `pytest test/cli/test_serve_smg_unit.py`
- `pre-commit run --files python/pyproject.toml python/tokenspeed/cli/serve_smg.py test/cli/test_serve_smg_unit.py`
- `git diff --check`