### PR TITLE
Default SMG reasoning parser to none

### DIFF
--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -45,6 +45,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_GATEWAY_HOST = "0.0.0.0"
 DEFAULT_GATEWAY_PORT = 8000
+DEFAULT_REASONING_PARSER = "none"
 
 
 def _check_serve_extra_installed() -> None:
@@ -93,6 +94,17 @@ def _gateway_args_with_default_port(gateway_args: list[str]) -> list[str]:
     if "--port" in gateway_args:
         return gateway_args
     return [*gateway_args, "--port", str(DEFAULT_GATEWAY_PORT)]
+
+
+def _gateway_args_with_default_reasoning_parser(gateway_args: list[str]) -> list[str]:
+    if "--reasoning-parser" in gateway_args:
+        return gateway_args
+    return [*gateway_args, "--reasoning-parser", DEFAULT_REASONING_PARSER]
+
+
+def _gateway_args_with_defaults(gateway_args: list[str]) -> list[str]:
+    gateway_args = _gateway_args_with_default_port(gateway_args)
+    return _gateway_args_with_default_reasoning_parser(gateway_args)
 
 
 async def _stream_to(proc, tag: str) -> None:
@@ -274,7 +286,7 @@ def run_smg_from_args(args: argparse.Namespace, raw_argv: list[str]) -> None:
 
     _check_serve_extra_installed()
     split = split_argv(raw_argv)
-    gateway_args = _gateway_args_with_default_port(split.gateway)
+    gateway_args = _gateway_args_with_defaults(split.gateway)
     user_host, user_port = _user_host_port_from_gateway_args(gateway_args)
     rc = asyncio.run(
         run_smg(

--- a/test/cli/test_serve_smg_unit.py
+++ b/test/cli/test_serve_smg_unit.py
@@ -36,6 +36,8 @@ sys.path.insert(0, os.path.join(REPO_ROOT, "python"))
 from tokenspeed.cli._argsplit import OrchestratorOpts
 from tokenspeed.cli.serve_smg import (
     _gateway_args_with_default_port,
+    _gateway_args_with_default_reasoning_parser,
+    _gateway_args_with_defaults,
     _user_host_port_from_gateway_args,
     run_smg,
 )
@@ -66,6 +68,33 @@ def test_gateway_args_preserve_user_port():
 
     assert gateway_args == ["--port", "8413"]
     assert _user_host_port_from_gateway_args(gateway_args) == ("0.0.0.0", 8413)
+
+
+def test_gateway_args_default_reasoning_parser_is_none():
+    gateway_args = _gateway_args_with_default_reasoning_parser(["--model", "/tmp/x"])
+
+    assert gateway_args == ["--model", "/tmp/x", "--reasoning-parser", "none"]
+
+
+def test_gateway_args_preserve_user_reasoning_parser():
+    gateway_args = _gateway_args_with_default_reasoning_parser(
+        ["--reasoning-parser", "qwen3"]
+    )
+
+    assert gateway_args == ["--reasoning-parser", "qwen3"]
+
+
+def test_gateway_args_defaults_include_port_and_reasoning_parser():
+    gateway_args = _gateway_args_with_defaults(["--model", "/tmp/x"])
+
+    assert gateway_args == [
+        "--model",
+        "/tmp/x",
+        "--port",
+        "8000",
+        "--reasoning-parser",
+        "none",
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Default `ts serve` SMG gateway args to `--reasoning-parser none` when the user does not specify a reasoning parser.
- Preserve explicit user-provided `--reasoning-parser` values.
- Add unit coverage for the default and explicit parser behavior.

## Validation
- `pytest test/cli/test_serve_smg_unit.py`
- `pre-commit run --files python/tokenspeed/cli/serve_smg.py test/cli/test_serve_smg_unit.py`
- `git diff --check`