### PR TITLE
Remove redundant eval reasoning parser none

### DIFF
--- a/test/ci/eval/kimi-k2.5-nvfp4-evalscope-aime25.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-evalscope-aime25.yaml
@@ -19,7 +19,6 @@ server:
     --tp 4
     --max-model-len 80000
     --trust-remote-code
-    --reasoning-parser none
     --attention-backend tokenspeed_mla
     --moe-backend flashinfer_trtllm
     --quantization nvfp4

--- a/test/ci/eval/qwen3.5-397b-a17b-nvfp4-evalscope-aime25.yaml
+++ b/test/ci/eval/qwen3.5-397b-a17b-nvfp4-evalscope-aime25.yaml
@@ -19,7 +19,6 @@ server:
     --tp 4
     --max-model-len 80000
     --trust-remote-code
-    --reasoning-parser none
     --attention-backend trtllm
     --moe-backend flashinfer_trtllm
     --quantization nvfp4


### PR DESCRIPTION
## Summary
- Remove explicit `--reasoning-parser none` from eval CI configs now that `ts serve` defaults the SMG reasoning parser to `none`.
- Keep eval configs with non-`none` reasoning parsers unchanged.

## Validation
- `rg -n -- "--reasoning-parser none|none|None" test/ci/eval` returns no matches.
- `pre-commit run --files test/ci/eval/qwen3.5-397b-a17b-nvfp4-evalscope-aime25.yaml test/ci/eval/kimi-k2.5-nvfp4-evalscope-aime25.yaml`
- `python3 test/ci_system/pipeline.py scan --root test/ci --trigger per-commit`
- `git diff --check`