### PR TITLE
Clean up stale server startup references

### DIFF
--- a/test/runtime/models/test_gpt_oss.py
+++ b/test/runtime/models/test_gpt_oss.py
@@ -51,7 +51,7 @@ def _next_dist_port() -> int:
 # ── Server lifecycle ─────────────────────────────────────────────────
 
 
-def _api_server(port: int, extra_args=()) -> subprocess.Popen:
+def _serve_server(port: int, extra_args=()) -> subprocess.Popen:
     cmd = [
         sys.executable,
         "-m",
@@ -197,7 +197,7 @@ class TestGptOss(unittest.TestCase):
 
     def _run_quality_checks(self, case: MeshCase):
         port = _next_server_port()
-        proc = _api_server(port, case.extra_args)
+        proc = _serve_server(port, case.extra_args)
         try:
             if not _wait_for_server(port):
                 self.fail(f"[{case.name}] Server did not start within {TIMEOUT}s")

--- a/test/runtime/models/test_kimi_models.py
+++ b/test/runtime/models/test_kimi_models.py
@@ -50,7 +50,7 @@ def _next_server_port() -> int:
 # ── Server lifecycle ─────────────────────────────────────────────────
 
 
-def _api_server(port: int, extra_args=()) -> subprocess.Popen:
+def _serve_server(port: int, extra_args=()) -> subprocess.Popen:
     cmd = [
         sys.executable,
         "-m",
@@ -215,7 +215,7 @@ class TestKimiK25(unittest.TestCase):
 
     def _run_quality_checks(self, case: MeshCase):
         port = _next_server_port()
-        proc = _api_server(port, case.extra_args)
+        proc = _serve_server(port, case.extra_args)
         try:
             if not _wait_for_server(port):
                 self.fail(f"[{case.name}] Server did not start within {TIMEOUT}s")

--- a/test/runtime/models/test_llama_models.py
+++ b/test/runtime/models/test_llama_models.py
@@ -57,7 +57,7 @@ def _next_server_port() -> int:
 # ── Server lifecycle ─────────────────────────────────────────────────
 
 
-def _api_server(port: int, extra_args=()) -> subprocess.Popen:
+def _serve_server(port: int, extra_args=()) -> subprocess.Popen:
     # Use ``python -m tokenspeed.cli serve`` instead of the ``ts`` console
     # script — the CI runner doesn't always have the entrypoint on PATH
     # (e.g. when tests are executed against a source tree rather than a
@@ -184,7 +184,7 @@ class TestLlamaDense(unittest.TestCase):
 
     def _run_quality_checks(self, extra_args=()):
         port = _next_server_port()
-        proc = _api_server(port, extra_args)
+        proc = _serve_server(port, extra_args)
         try:
             if not _wait_for_server(port):
                 self.fail(f"Server did not start within {TIMEOUT}s")

--- a/test/runtime/models/test_minimax_models.py
+++ b/test/runtime/models/test_minimax_models.py
@@ -32,7 +32,7 @@ from test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     is_in_ci,
     kill_process_tree,
-    popen_api_server,
+    popen_serve_server,
     run_evalscope,
 )
 
@@ -185,7 +185,7 @@ class TestMiniMaxGSM8K(unittest.TestCase):
     def setUpClass(cls):
         cls.model = "MiniMaxAI/MiniMax-M2.5"
         cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.process = popen_api_server(
+        cls.process = popen_serve_server(
             cls.model,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,

--- a/test/runtime/models/test_mm25_perf.py
+++ b/test/runtime/models/test_mm25_perf.py
@@ -194,7 +194,7 @@ def _next_port() -> int:
 # ── Server lifecycle ─────────────────────────────────────────────────
 
 
-def _api_server(port: int, extra_args=()) -> subprocess.Popen:
+def _serve_server(port: int, extra_args=()) -> subprocess.Popen:
     # Use `python -m tokenspeed.cli serve` rather than the `ts` console
     # script so we don't depend on PATH setup in the CI runner.
     cmd = [
@@ -382,7 +382,7 @@ class TestMiniMaxM25Perf(unittest.TestCase):
 
     def _with_server(self, extra_args, fn, launch_timeout=SERVER_LAUNCH_TIMEOUT):
         port = _next_port()
-        proc = _api_server(port, extra_args)
+        proc = _serve_server(port, extra_args)
         try:
             if not _wait_for_server(port, timeout=launch_timeout):
                 self.fail(

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -56,7 +56,7 @@ def auto_config_device() -> str:
     return get_device()
 
 
-def _api_server_process(
+def _serve_process(
     command: List[str],
     env: dict,
     return_stdout_stderr: Optional[tuple],
@@ -131,7 +131,7 @@ def _wait_for_server_health(
     return False, "Server failed to start within the timeout period"
 
 
-def popen_api_server(
+def popen_serve_server(
     model: str,
     base_url: str,
     timeout: float,
@@ -140,8 +140,6 @@ def popen_api_server(
     env: Optional[dict] = None,
     return_stdout_stderr: Optional[tuple] = None,
     device: str = "auto",
-    pd_separated: bool = False,
-    num_replicas: Optional[int] = None,
 ):
     other_args = other_args or []
 
@@ -160,39 +158,24 @@ def popen_api_server(
     _, host, port = base_url.split(":")
     host = host[2:]
 
-    use_mixed_pd_engine = not pd_separated and num_replicas is not None
-    if pd_separated or use_mixed_pd_engine:
-        command = [
-            "python3",
-            "-m",
-            "tokenspeed.launch_pd_server",
-            "--model",
-            model,
-            *[str(x) for x in other_args],
-        ]
-    else:
-        command = [
-            "tokenspeed",
-            "serve",
-            "--model",
-            model,
-            *[str(x) for x in other_args],
-        ]
-
-    if pd_separated or use_mixed_pd_engine:
-        command.extend(["--lb-host", host, "--lb-port", port])
-    else:
-        command.extend(["--host", host, "--port", port])
-
-    if use_mixed_pd_engine:
-        command.extend(["--mixed", "--num-replicas", str(num_replicas)])
+    command = [
+        "tokenspeed",
+        "serve",
+        "--model",
+        model,
+        *[str(x) for x in other_args],
+        "--host",
+        host,
+        "--port",
+        port,
+    ]
 
     if api_key:
         command += ["--api-key", api_key]
 
     print(f"command={shlex.join(command)}")
 
-    process = _api_server_process(command, env, return_stdout_stderr)
+    process = _serve_process(command, env, return_stdout_stderr)
     success, error_msg = _wait_for_server_health(process, base_url, api_key, timeout)
 
     if success:


### PR DESCRIPTION
## Summary
- Remove the stale `tokenspeed.launch_pd_server` path from the shared test server launcher.
- Rename remaining test helpers from `api_server` to `serve_server` to match the current `tokenspeed serve` startup path.

## Validation
- `rg -n -- "api_server|launch_pd_server|python -m tokenspeed\\.runtime|python3 -m tokenspeed\\.runtime|runtime\\.entrypoints\\.api|vllm\\.entrypoints|sglang\\.launch" test python docs` returns no matches.
- `python3 -m compileall -q test/test_utils.py test/runtime/models/test_minimax_models.py test/runtime/models/test_gpt_oss.py test/runtime/models/test_kimi_models.py test/runtime/models/test_llama_models.py test/runtime/models/test_mm25_perf.py`
- `pre-commit run --files test/test_utils.py test/runtime/models/test_minimax_models.py test/runtime/models/test_gpt_oss.py test/runtime/models/test_kimi_models.py test/runtime/models/test_llama_models.py test/runtime/models/test_mm25_perf.py`
- `git diff --check`