### PR TITLE
[fix] Correct gfx950 LDS size to 160 KB

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/platform.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/platform.py
@@ -431,7 +431,7 @@ def _detect_rocm_platform() -> PlatformInfo:
         memory_bandwidth=_estimate_amd_bandwidth(props),
         sm_count=props.multi_processor_count,
         max_threads_per_sm=getattr(props, "max_threads_per_multi_processor", 0),
-        max_shared_memory_per_sm={"gfx942": 64 * 1024, "gfx950": 64 * 1024}.get(
+        max_shared_memory_per_sm={"gfx942": 64 * 1024, "gfx950": 160 * 1024}.get(
             arch, getattr(props, "max_shared_memory_per_block", 0)
         ),
         sm_features=sm_features,


### PR DESCRIPTION
## Summary
- `_detect_rocm_platform` reported `max_shared_memory_per_sm = 64 KB` for `gfx950`, but MI350X/MI355X (CDNA4) actually has 160 KB of LDS per CU.
- Updated the lookup so `gfx950` returns `160 * 1024`. `gfx942` (MI300, 64 KB) is unchanged.

## Verification
On an MI355X box:
- `hipGetDeviceProperties` → `sharedMemPerMultiprocessor = 163840`
- `rocminfo` → `Segment: GROUP, Size: 160 KB`
- Cross-checked against AMD's [amdgpu kernel optimization guide](https://github.com/nod-ai/amd-shark-ai/blob/main/docs/amdgpu_kernel_optimization_guide.md#mi355x): "The LDS in the MI350X/MI355X (CDNA4) is 160KB."
<img width="2233" height="914" alt="image" src="https://github.com/user-attachments/assets/912ba67a-327a-4d06-817d-7839d73456ce" />