### PR TITLE
perf(K2.5): Optimize lm_head

### DIFF
--- a/python/tokenspeed/runtime/layers/logits_processor.py
+++ b/python/tokenspeed/runtime/layers/logits_processor.py
@@ -122,6 +122,51 @@ class LogitsMetadata:
         )
 
 
+_FUSED_LM_HEAD_GEMM = None
+
+
+def _get_fused_lm_head_gemm():
+    """Lazily import the fused lm_head GEMM kernel.
+
+    The kernel is only present when tokenspeed-kernel was built with a
+    compatible nvcc. Cache a sentinel when unavailable so we fall back
+    to ``torch.matmul`` silently on subsequent calls.
+    """
+    global _FUSED_LM_HEAD_GEMM
+    if _FUSED_LM_HEAD_GEMM is not None:
+        return _FUSED_LM_HEAD_GEMM
+    try:
+        from tokenspeed_kernel.thirdparty.cuda.lm_head_gemm import (
+            lm_head_gemm,
+            should_use_fused,
+        )
+
+        _FUSED_LM_HEAD_GEMM = (should_use_fused, lm_head_gemm)
+    except Exception:
+        _FUSED_LM_HEAD_GEMM = (None, None)
+    return _FUSED_LM_HEAD_GEMM
+
+
+def _lm_head_matmul(hidden_states: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    """Compute ``hidden_states @ weight.T``.
+
+    Routes to the fused ``lm_head_gemm`` when the shape matches a compiled
+    template and the bench-driven perf gate accepts (``should_use_fused``).
+    Otherwise falls back to ``torch.matmul``.
+
+    Only enabled for Kimi (``model_type == "kimi_k2"``) at the call site —
+    on DSv3 the fused kernel's PDL launch surface caused a downstream EAGLE3
+    spec decode AR regression that we have not characterised end-to-end; on
+    Kimi the perf win is the largest and the regression has not been
+    reproduced, so we gate the fused path to Kimi only.
+    """
+    cast_hidden = hidden_states.to(weight.dtype)
+    should_use_fused, lm_head_gemm = _get_fused_lm_head_gemm()
+    if should_use_fused is not None and should_use_fused(cast_hidden, weight):
+        return lm_head_gemm(cast_hidden, weight, enable_pdl=True)
+    return torch.matmul(cast_hidden, weight.T)
+
+
 class LogitsProcessor(nn.Module):
     def __init__(
         self,
@@ -153,6 +198,9 @@ class LogitsProcessor(nn.Module):
             and self.final_logit_softcapping < 0
         ):
             self.final_logit_softcapping = None
+
+        # Gate the fused lm_head GEMM to Kimi only. See ``_lm_head_matmul``.
+        self._use_fused_lm_head = getattr(self.config, "model_type", None) == "kimi_k2"
 
     def forward(
         self,
@@ -359,9 +407,12 @@ class LogitsProcessor(nn.Module):
         guarantee the given hidden_states follow this constraint.
         """
         if hasattr(lm_head, "weight"):
-            logits = torch.matmul(
-                hidden_states.to(lm_head.weight.dtype), lm_head.weight.T
-            )
+            if self._use_fused_lm_head:
+                logits = _lm_head_matmul(hidden_states, lm_head.weight)
+            else:
+                logits = torch.matmul(
+                    hidden_states.to(lm_head.weight.dtype), lm_head.weight.T
+                )
         else:
             # GGUF models
             logits = lm_head.linear_method.apply(lm_head, hidden_states, embedding_bias)

--- a/tokenspeed-kernel/python/setup.py
+++ b/tokenspeed-kernel/python/setup.py
@@ -396,6 +396,14 @@ KERNEL_GROUPS = [
         [],
     ),
     (
+        "lm_head_gemm",
+        [
+            CUDA_CSRC_DIR / "lm_head_gemm.cu",
+            CUDA_CSRC_DIR / "lm_head_gemm_binding.cu",
+        ],
+        [],
+    ),
+    (
         "trtllm_comm",
         [
             CUDA_CSRC_DIR / "trtllm_allreduce.cu",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/lm_head_gemm.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/lm_head_gemm.cu
@@ -1,0 +1,871 @@
+/*
+ * Copyright (c) 2019-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2021, NAVER Corp.  Authored by CLOVA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported from TensorRT-LLM
+ *   cpp/tensorrt_llm/kernels/dsv3MinLatencyKernels/dsv3FusedAGemm.cu
+ * Standalone, dependency-free version for use as the lm_head GEMM in
+ * tokenspeed (M=num_tokens<=16, K=hidden, N=vocab/sharded_vocab).
+ */
+
+#include <cassert>
+#include <cstdio>
+#include <cstdint>
+#include <algorithm>
+
+#include "cuda.h"
+#include "cuda_bf16.h"
+#include "cuda_runtime.h"
+
+namespace tokenspeed {
+namespace lm_head_gemm {
+
+using bf16_t = __nv_bfloat16;
+
+__device__ inline void hmma_16_8_16_f32acc_bf16ab(
+    float (&d_reg)[4], const bf16_t (&a_reg)[8], const bf16_t (&b_reg)[4], float const (&c_reg)[4])
+{
+    uint32_t a0 = *reinterpret_cast<uint32_t const*>(a_reg + 0);
+    uint32_t a1 = *reinterpret_cast<uint32_t const*>(a_reg + 2);
+    uint32_t a2 = *reinterpret_cast<uint32_t const*>(a_reg + 4);
+    uint32_t a3 = *reinterpret_cast<uint32_t const*>(a_reg + 6);
+    uint32_t b0 = *reinterpret_cast<uint32_t const*>(b_reg + 0);
+    uint32_t b1 = *reinterpret_cast<uint32_t const*>(b_reg + 2);
+    asm volatile(
+        "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+        "{%0,  %1,  %2,  %3},"
+        "{%4,  %5,  %6,  %7},"
+        "{%8,  %9},"
+        "{%10, %11, %12, %13};\n"
+        : "=f"(d_reg[0]), "=f"(d_reg[1]), "=f"(d_reg[2]), "=f"(d_reg[3])
+        : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "f"(d_reg[0]), "f"(d_reg[1]), "f"(d_reg[2]),
+        "f"(d_reg[3]));
+}
+
+extern "C"
+{
+    __device__ uint32_t __nvvm_get_smem_pointer(void*);
+}
+
+__device__ inline void ldgsts_128(void const* gPtr, void* sPtr, uint32_t pred)
+{
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+    if (pred)
+    {
+        uint32_t smemPtrAsUint32 = __nvvm_get_smem_pointer(sPtr);
+        asm volatile("cp.async.cg.shared.global.L2::128B [%0], [%1], %2;\n" ::"r"(smemPtrAsUint32), "l"(gPtr), "n"(16));
+    }
+#endif
+}
+
+__device__ inline void ldsm_x4(void* smem_ptr, uint32_t* reg_ptr)
+{
+    asm volatile("ldmatrix.sync.aligned.x4.m8n8.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                 : "=r"(reg_ptr[0]), "=r"(reg_ptr[1]), "=r"(reg_ptr[2]), "=r"(reg_ptr[3])
+                 : "r"(__nvvm_get_smem_pointer(smem_ptr)));
+}
+
+template <class Type>
+__device__ inline int apply_swizzle_343_on_elem_row_col(int row_idx_, int col_idx_)
+{
+    uint32_t row_idx = *reinterpret_cast<uint32_t*>(&row_idx_);
+    uint32_t col_idx = *reinterpret_cast<uint32_t*>(&col_idx_);
+    row_idx = row_idx % 8;
+    row_idx = row_idx * (16 / sizeof(Type));
+    col_idx = col_idx ^ row_idx;
+    return *reinterpret_cast<int*>(&col_idx);
+}
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+__device__ inline void initialize_barrier(uint64_t* smem_barrier, int thread_count = 1)
+{
+    uint32_t smem_int_ptr = __nvvm_get_smem_pointer(smem_barrier);
+    asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" ::"r"(smem_int_ptr), "r"(thread_count));
+}
+
+__device__ inline void wait_barrier(uint64_t* smem_barrier, int phase_bit)
+{
+    uint32_t smem_int_ptr = __nvvm_get_smem_pointer(smem_barrier);
+    asm volatile(
+        "{\n"
+        ".reg .pred                P1;\n"
+        "LAB_WAIT:\n"
+        "mbarrier.try_wait.parity.shared::cta.b64 P1, [%0], %1;\n"
+        "@P1                       bra DONE;\n"
+        "bra                   LAB_WAIT;\n"
+        "DONE:\n"
+        "}\n" ::"r"(smem_int_ptr),
+        "r"(phase_bit));
+}
+
+__device__ inline bool try_wait_barrier(uint64_t* smem_ptr, int phase_bit)
+{
+    uint32_t wait_complete;
+    uint32_t smem_int_ptr = __nvvm_get_smem_pointer(smem_ptr);
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1; \n\t"
+        "mbarrier.try_wait.parity.shared::cta.b64 P1, [%1], %2; \n\t"
+        "selp.b32 %0, 1, 0, P1; \n\t"
+        "}"
+        : "=r"(wait_complete)
+        : "r"(smem_int_ptr), "r"(phase_bit));
+    return static_cast<bool>(wait_complete);
+}
+
+__device__ inline void arrive_barrier(uint64_t* smem_barrier)
+{
+    uint32_t smem_int_ptr = __nvvm_get_smem_pointer(smem_barrier);
+    asm volatile(
+        "{\n"
+        ".reg .b64 state; \n"
+        "mbarrier.arrive.shared::cta.b64   state, [%0];\n"
+        "}\n" ::"r"(smem_int_ptr));
+}
+
+__device__ inline void ldgsts_arrive(uint64_t* smem_barrier)
+{
+    uint32_t smem_int_ptr = __nvvm_get_smem_pointer(smem_barrier);
+    asm volatile("cp.async.mbarrier.arrive.noinc.shared.b64 [%0];" : : "r"(smem_int_ptr));
+}
+#endif
+
+template <int gemm_k, int tile_m, int tile_k, int stage_cnt>
+struct GmemLoaderA
+{
+    static constexpr int elem_bytes = 2;
+    static constexpr int vec_bytes = 16;
+    static constexpr int vec_elems = vec_bytes / elem_bytes;
+    static constexpr int thread_cnt = 64;
+    static_assert((tile_m * tile_k) % (vec_elems * thread_cnt) == 0);
+    static constexpr int a_inst_cnt_per_iter = (tile_m * tile_k) / (vec_elems * thread_cnt);
+    static_assert(gemm_k % tile_k == 0);
+    static constexpr int k_iter_cnt = gemm_k / tile_k;
+
+    static constexpr int mma_warp_cnt = 4;
+    static constexpr int per_mma_warp_k = tile_k / mma_warp_cnt;
+    static constexpr int k_each_chunk = gemm_k / mma_warp_cnt;
+
+private:
+    __device__ int k_project(int tile_k_idx)
+    {
+        return (tile_k_idx / per_mma_warp_k * k_each_chunk) + (tile_k_idx % per_mma_warp_k);
+    }
+
+public:
+    __device__ GmemLoaderA(bf16_t const* gmem_a_local_, bf16_t* smem_a_, uint64_t* smem_barrier_)
+        : gmem_a(gmem_a_local_)
+        , smem_a(smem_a_)
+        , smem_barrier(smem_barrier_)
+        , local_tid(threadIdx.x % thread_cnt)
+    {
+    }
+
+    __device__ void prepare()
+    {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+#pragma unroll
+        for (int i = 0; i < a_inst_cnt_per_iter; i++)
+        {
+            int linear_idx = local_tid * vec_elems + i * thread_cnt * vec_elems;
+            int m_idx = linear_idx / tile_k;
+            int k_idx = linear_idx % tile_k;
+            k_idx = apply_swizzle_343_on_elem_row_col<bf16_t>(m_idx, k_idx);
+            a_smem_offsets[i] = m_idx * tile_k + k_idx;
+        }
+#endif
+    }
+
+    __device__ void issue_mainloop()
+    {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+#pragma unroll 1
+        for (int loop_idx = 0; loop_idx < k_iter_cnt; loop_idx++)
+        {
+            if (need_wait)
+            {
+                wait_barrier(smem_barrier + 1 + stage_idx * 2, phase_bit);
+            }
+            int next_stage_idx = stage_idx + 1;
+            int next_phase_bit = next_stage_idx == stage_cnt ? phase_bit ^ 1 : phase_bit;
+            next_stage_idx = next_stage_idx == stage_cnt ? 0 : next_stage_idx;
+            if (loop_idx != k_iter_cnt - 1)
+            {
+                need_wait = !try_wait_barrier(smem_barrier + 1 + next_stage_idx * 2, next_phase_bit);
+            }
+
+#pragma unroll
+            for (int i = 0; i < a_inst_cnt_per_iter; i++)
+            {
+                int smem_offset = a_smem_offsets[i];
+                bf16_t* smem_ptr_this_iter = smem_a + stage_idx * tile_m * tile_k + smem_offset;
+                int linear_idx = local_tid * vec_elems + i * thread_cnt * vec_elems;
+                int m_idx = linear_idx / tile_k;
+                int k_idx = linear_idx % tile_k;
+                int gmem_offset = m_idx * gemm_k + k_project(k_idx);
+                bf16_t const* gmem_ptr_this_iter = gmem_a + gmem_offset;
+                ldgsts_128(gmem_ptr_this_iter, smem_ptr_this_iter, true);
+            }
+            ldgsts_arrive(smem_barrier + stage_idx * 2);
+
+            stage_idx = next_stage_idx;
+            phase_bit = next_phase_bit;
+            gmem_a += per_mma_warp_k;
+        }
+#endif
+    }
+
+    bf16_t const* gmem_a;
+    bf16_t* smem_a;
+    uint64_t* smem_barrier;
+    int local_tid;
+    int stage_idx = 0;
+    int phase_bit = 1;
+    bool need_wait = true;
+
+    int a_smem_offsets[a_inst_cnt_per_iter];
+};
+
+template <int gemm_k, int tile_n, int tile_k, int stage_cnt>
+struct GmemLoaderB
+{
+    static constexpr int elem_bytes = 2;
+    static constexpr int vec_bytes = 16;
+    static constexpr int vec_elems = vec_bytes / elem_bytes;
+    static constexpr int thread_cnt = 64;
+    static_assert((tile_n * tile_k) % (vec_elems * thread_cnt) == 0);
+    static constexpr int b_inst_cnt_per_iter = (tile_n * tile_k) / (vec_elems * thread_cnt);
+    static_assert(gemm_k % tile_k == 0);
+    static constexpr int k_iter_cnt = gemm_k / tile_k;
+
+    static constexpr int mma_warp_cnt = 4;
+    static constexpr int per_mma_warp_k = tile_k / mma_warp_cnt;
+    static constexpr int k_each_chunk = gemm_k / mma_warp_cnt;
+
+private:
+    __device__ int k_project(int tile_k_idx)
+    {
+        return (tile_k_idx / per_mma_warp_k * k_each_chunk) + (tile_k_idx % per_mma_warp_k);
+    }
+
+public:
+    __device__ GmemLoaderB(bf16_t const* gmem_b_local_, bf16_t* smem_b_, uint64_t* smem_barrier_, int gemm_n_)
+        : gmem_b(gmem_b_local_)
+        , smem_b(smem_b_)
+        , smem_barrier(smem_barrier_)
+        , gemm_n(gemm_n_)
+        , local_tid(threadIdx.x % thread_cnt)
+    {
+    }
+
+    __device__ void prepare()
+    {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+#pragma unroll
+        for (int i = 0; i < b_inst_cnt_per_iter; i++)
+        {
+            int linear_idx = local_tid * vec_elems + i * thread_cnt * vec_elems;
+            int n_idx = linear_idx / tile_k;
+            int k_idx = linear_idx % tile_k;
+            k_idx = apply_swizzle_343_on_elem_row_col<bf16_t>(n_idx, k_idx);
+            b_smem_offsets[i] = n_idx * tile_k + k_idx;
+            preds[i] = n_idx < gemm_n;
+        }
+#endif
+    }
+
+    __device__ void issue_mainloop()
+    {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+        cudaGridDependencySynchronize();
+#pragma unroll 1
+        for (int loop_idx = 0; loop_idx < k_iter_cnt; loop_idx++)
+        {
+            if (need_wait)
+            {
+                wait_barrier(smem_barrier + 1 + stage_idx * 2, phase_bit);
+            }
+            int next_stage_idx = stage_idx + 1;
+            int next_phase_bit = next_stage_idx == stage_cnt ? phase_bit ^ 1 : phase_bit;
+            next_stage_idx = next_stage_idx == stage_cnt ? 0 : next_stage_idx;
+            if (loop_idx != k_iter_cnt - 1)
+            {
+                need_wait = !try_wait_barrier(smem_barrier + 1 + next_stage_idx * 2, next_phase_bit);
+            }
+#pragma unroll
+            for (int i = 0; i < b_inst_cnt_per_iter; i++)
+            {
+                int smem_offset = b_smem_offsets[i];
+                bf16_t* smem_ptr_this_iter = smem_b + stage_idx * tile_n * tile_k + smem_offset;
+                int linear_idx = local_tid * vec_elems + i * thread_cnt * vec_elems;
+                int n_idx = linear_idx / tile_k;
+                int k_idx = linear_idx % tile_k;
+                int gmem_offset = n_idx * gemm_k + k_project(k_idx);
+                bf16_t const* gmem_ptr_this_iter = gmem_b + gmem_offset;
+                ldgsts_128(gmem_ptr_this_iter, smem_ptr_this_iter, preds[i]);
+            }
+            ldgsts_arrive(smem_barrier + stage_idx * 2);
+
+            stage_idx = next_stage_idx;
+            phase_bit = next_phase_bit;
+            gmem_b += per_mma_warp_k;
+        }
+#endif
+    }
+
+    bf16_t const* gmem_b;
+    bf16_t* smem_b;
+    uint64_t* smem_barrier;
+    int gemm_n;
+    int local_tid;
+    int stage_idx = 0;
+    int phase_bit = 1;
+    bool need_wait = true;
+
+    int b_smem_offsets[b_inst_cnt_per_iter];
+    uint32_t preds[b_inst_cnt_per_iter];
+};
+
+template <int gemm_m, int gemm_k, int tile_m, int tile_n, int tile_k, int stage_cnt>
+struct MmaComputer
+{
+    static constexpr int elem_bytes = 2;
+    static constexpr int thread_cnt = 128;
+    static_assert(gemm_k % tile_k == 0);
+    static_assert(tile_k % (thread_cnt / 32) == 0);
+    static constexpr int per_warp_tile_k = tile_k / (thread_cnt / 32);
+    static constexpr int k_iter_cnt = gemm_k / tile_k;
+    static constexpr int k_phase_cnt = per_warp_tile_k / 16;
+    static constexpr int m_iter_cnt = (tile_m + 15) / 16;
+    static constexpr int n_iter_cnt = (tile_n + 7) / 8;
+    static_assert(m_iter_cnt == 1);
+    static_assert(n_iter_cnt == 1 || n_iter_cnt == 2);
+
+    __device__ MmaComputer(
+        bf16_t* gmem_c_local_, bf16_t* smem_a_, bf16_t* smem_b_, uint64_t* smem_barrier_, int warp_idx_, int gemm_n_)
+        : gmem_c(gmem_c_local_)
+        , smem_a(smem_a_)
+        , smem_b(smem_b_)
+        , smem_barrier(smem_barrier_)
+        , warp_idx(warp_idx_ - (thread_cnt / 32))
+        , gemm_n(gemm_n_)
+    {
+    }
+
+private:
+    __device__ constexpr int internal_b_atom_func(int tid)
+    {
+        if constexpr (tile_n < 8)
+        {
+            return (tid % tile_n) + ((tid % 8) / tile_n * 0) + tid / 8 * 8 * tile_n;
+        }
+        else
+        {
+            return (tid % 8) + ((tid % 32) / 8 * (tile_n * 8));
+        }
+    }
+
+public:
+    __device__ void prepare()
+    {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+#pragma unroll
+        for (int i = 0; i < k_phase_cnt; i++)
+        {
+            int linear_idx = (lane_idx % 16) + (lane_idx / 16) * 128 + i * 256;
+            int m_idx = linear_idx % tile_m;
+            int k_idx = linear_idx / tile_m + warp_k_offset_in_tile_k;
+            k_idx = apply_swizzle_343_on_elem_row_col<bf16_t>(m_idx, k_idx);
+            a_smem_offsets[0][i] = m_idx * tile_k + k_idx;
+        }
+#pragma unroll
+        for (int n_iter_idx = 0; n_iter_idx < n_iter_cnt; n_iter_idx++)
+        {
+#pragma unroll
+            for (int i = 0; i < k_phase_cnt; i += 2)
+            {
+                int linear_idx = internal_b_atom_func(lane_idx) + i * tile_n * 16 + n_iter_idx * 8;
+                int n_idx = linear_idx % tile_n;
+                int k_idx = linear_idx / tile_n + warp_k_offset_in_tile_k;
+                k_idx = apply_swizzle_343_on_elem_row_col<bf16_t>(n_idx, k_idx);
+                b_smem_offsets[n_iter_idx][i] = n_idx * tile_k + k_idx;
+            }
+        }
+#endif
+    }
+
+    __device__ void issue_mainloop()
+    {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+#pragma unroll 1
+        for (int loop_idx = 0; loop_idx < k_iter_cnt; loop_idx++)
+        {
+            wait_barrier(smem_barrier + 0 + stage_idx * 2, phase_bit);
+
+#pragma unroll
+            for (int i = 0; i < k_phase_cnt; i++)
+            {
+                int smem_offset = a_smem_offsets[0][i];
+                bf16_t* smem_ptr_this_iter = smem_a + stage_idx * tile_m * tile_k + smem_offset;
+                ldsm_x4(smem_ptr_this_iter, reinterpret_cast<uint32_t*>(a_reg[0][i]));
+            }
+
+#pragma unroll
+            for (int n_iter_idx = 0; n_iter_idx < n_iter_cnt; n_iter_idx++)
+            {
+#pragma unroll
+                for (int i = 0; i < k_phase_cnt; i += 2)
+                {
+                    int smem_offset = b_smem_offsets[n_iter_idx][i];
+                    bf16_t* smem_ptr_this_iter = smem_b + stage_idx * tile_n * tile_k + smem_offset;
+                    ldsm_x4(smem_ptr_this_iter, reinterpret_cast<uint32_t*>(b_reg[n_iter_idx][i]));
+                }
+            }
+
+#pragma unroll
+            for (int k_iter_idx = 0; k_iter_idx < k_phase_cnt; k_iter_idx++)
+            {
+#pragma unroll
+                for (int n_iter_idx = 0; n_iter_idx < n_iter_cnt; n_iter_idx++)
+                {
+                    hmma_16_8_16_f32acc_bf16ab(acc_reg[0][n_iter_idx], a_reg[0][k_iter_idx],
+                        b_reg[n_iter_idx][k_iter_idx], acc_reg[0][n_iter_idx]);
+                }
+            }
+            arrive_barrier(smem_barrier + 1 + stage_idx * 2);
+            stage_idx += 1;
+            phase_bit = stage_idx == stage_cnt ? phase_bit ^ 1 : phase_bit;
+            stage_idx = stage_idx == stage_cnt ? 0 : stage_idx;
+        }
+#endif
+    }
+
+    __device__ void epi()
+    {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+        asm volatile("bar.sync %0, %1;" : : "r"(1), "r"(thread_cnt));
+        constexpr int thread_m = 2;
+        constexpr int thread_n = 2 * n_iter_cnt;
+        constexpr int cta_mma_n = n_iter_cnt * 8;
+        float acc_reg_reorg[thread_m][thread_n];
+
+        for (int i = 0; i < thread_m; i++)
+        {
+            for (int j = 0; j < thread_n; j++)
+            {
+                acc_reg_reorg[i][j] = acc_reg[0][j / 2][(j % 2) + (i * 2)];
+            }
+        }
+
+        float* smem_c = reinterpret_cast<float*>(smem_a);
+        auto smem_c_index_func = [&](int m_idx, int n_idx)
+        {
+            int group_rows = 32 / cta_mma_n;
+            int group_cnt = 2;
+            return (m_idx % group_rows * cta_mma_n) + (m_idx / group_rows * (32 + group_cnt)) + n_idx;
+        };
+        constexpr int cosize_smem_c = ((tile_m * cta_mma_n) / 32) * (32 + 2);
+
+#pragma unroll
+        for (int m_idx_thread = 0; m_idx_thread < thread_m; m_idx_thread++)
+        {
+#pragma unroll
+            for (int n_idx_thread = 0; n_idx_thread < thread_n; n_idx_thread++)
+            {
+                int m_idx = (lane_idx / 4) + m_idx_thread * 8;
+                int n_idx = ((lane_idx % 4) * 2) + (n_idx_thread % 2) + (n_idx_thread / 2) * 8;
+                smem_c[cosize_smem_c * warp_idx + smem_c_index_func(m_idx, n_idx)]
+                    = acc_reg_reorg[m_idx_thread][n_idx_thread];
+            }
+        }
+        asm volatile("bar.sync %0, %1;" : : "r"(1), "r"(thread_cnt));
+
+        if (warp_idx == 0)
+        {
+            constexpr int final_acc_reg_cnt = (tile_m * tile_n + 31) / 32;
+            float acc_final[final_acc_reg_cnt]{};
+
+#pragma unroll
+            for (int reg_idx = 0; reg_idx < final_acc_reg_cnt; reg_idx++)
+            {
+                int linear_idx = reg_idx * 32 + lane_idx;
+                int m_idx = linear_idx % tile_m;
+                int n_idx = linear_idx / tile_m;
+                acc_final[reg_idx] += smem_c[smem_c_index_func(m_idx, n_idx) + 0 * cosize_smem_c]
+                    + smem_c[smem_c_index_func(m_idx, n_idx) + 1 * cosize_smem_c]
+                    + smem_c[smem_c_index_func(m_idx, n_idx) + 2 * cosize_smem_c]
+                    + smem_c[smem_c_index_func(m_idx, n_idx) + 3 * cosize_smem_c];
+            }
+
+#pragma unroll
+            for (int reg_idx = 0; reg_idx < final_acc_reg_cnt; reg_idx++)
+            {
+                int linear_idx = reg_idx * 32 + lane_idx;
+                int m_idx = linear_idx % tile_m;
+                int n_idx = linear_idx / tile_m;
+                if (m_idx < tile_m && n_idx < gemm_n)
+                {
+                    gmem_c[n_idx * gemm_m + m_idx] = acc_final[reg_idx];
+                }
+            }
+        }
+#endif
+    }
+
+    bf16_t* gmem_c;
+    bf16_t* smem_a;
+    bf16_t* smem_b;
+    uint64_t* smem_barrier;
+    int warp_idx;
+    int gemm_n;
+    int stage_idx = 0;
+    int phase_bit = 0;
+    int lane_idx = threadIdx.x % 32;
+    int warp_k_offset_in_tile_k = warp_idx * per_warp_tile_k;
+
+    int a_smem_offsets[m_iter_cnt][k_phase_cnt];
+    int b_smem_offsets[n_iter_cnt][k_phase_cnt];
+
+    bf16_t a_reg[m_iter_cnt][k_phase_cnt][8];
+    bf16_t b_reg[n_iter_cnt][k_phase_cnt][4];
+    float acc_reg[m_iter_cnt][n_iter_cnt][4]{};
+};
+
+// AB-swapped kernel: shapes are k-major, k-major, m-major.
+// __launch_bounds__(256, 2) targets 2 resident CTAs/SM at 96 KB smem each.
+template <int gemm_m, int gemm_k, int tile_m, int tile_n, int tile_k, int stage_cnt>
+__global__ __launch_bounds__(256, 2) void fused_a_gemm_kernel(
+    bf16_t* output, bf16_t const* mat_a, bf16_t const* mat_b, int gemm_n)
+{
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+    constexpr int load_thread_cnt = 128;
+    constexpr int compute_thread_cnt = 128;
+    constexpr int thread_cnt = load_thread_cnt + compute_thread_cnt;
+    (void) thread_cnt;
+    static_assert(gemm_m % 16 == 0);
+    static_assert(gemm_k % tile_k == 0);
+    static_assert(gemm_m % tile_m == 0);
+    static_assert(tile_k == 128 || tile_k == 256 || tile_k == 512 || tile_k == 1024);
+    static_assert(tile_m == 16);
+    constexpr int g2s_vec_bytes = 16;
+    constexpr int a_elem_bytes = 2;
+    constexpr int b_elem_bytes = 2;
+    static_assert((tile_m * a_elem_bytes + tile_n * b_elem_bytes) * tile_k * stage_cnt <= 225 * 1024);
+    static_assert((tile_m * tile_k * a_elem_bytes) % (load_thread_cnt * g2s_vec_bytes) == 0);
+    static_assert((tile_n * tile_k * b_elem_bytes) % (load_thread_cnt * g2s_vec_bytes) == 0);
+
+    extern __shared__ char smem[];
+    uint64_t* smem_barrier = reinterpret_cast<uint64_t*>(smem);
+    bf16_t* smem_a = reinterpret_cast<bf16_t*>(smem + (stage_cnt * 8 * 2 + 1024) / 1024 * 1024);
+    bf16_t* smem_b = smem_a + tile_m * tile_k * stage_cnt;
+
+    int cta_m_idx = tile_m * blockIdx.x;
+    int cta_n_idx = tile_n * blockIdx.y;
+    bf16_t const* gmem_a_local = mat_a + cta_m_idx * gemm_k;
+    bf16_t const* gmem_b_local = mat_b + cta_n_idx * gemm_k;
+    bf16_t* gmem_c_local = output + cta_n_idx * gemm_m + cta_m_idx;
+
+    int warp_idx = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+
+    if (warp_idx == 4)
+    {
+        for (int i = 0; i < stage_cnt; i++)
+        {
+            initialize_barrier(smem_barrier + i * 2 + 0, load_thread_cnt);
+            initialize_barrier(smem_barrier + i * 2 + 1, compute_thread_cnt);
+        }
+    }
+    __syncthreads();
+    cudaGridDependencySynchronize();
+    cudaTriggerProgrammaticLaunchCompletion();
+
+    if (warp_idx < 2)
+    {
+        GmemLoaderA<gemm_k, tile_m, tile_k, stage_cnt> a_loader(gmem_a_local, smem_a, smem_barrier);
+        a_loader.prepare();
+        a_loader.issue_mainloop();
+    }
+    else if (warp_idx < 4)
+    {
+        GmemLoaderB<gemm_k, tile_n, tile_k, stage_cnt> b_loader(gmem_b_local, smem_b, smem_barrier, gemm_n);
+        b_loader.prepare();
+        b_loader.issue_mainloop();
+    }
+    else
+    {
+        MmaComputer<gemm_m, gemm_k, tile_m, tile_n, tile_k, stage_cnt> mma_computer(
+            gmem_c_local, smem_a, smem_b, smem_barrier, warp_idx, gemm_n);
+        mma_computer.prepare();
+        mma_computer.issue_mainloop();
+        mma_computer.epi();
+    }
+#endif
+}
+
+// Persistent variant: grid is (num_persistent_ctas, 1, 1) where
+// num_persistent_ctas == num_sms * 2. Each CTA loops over its assigned
+// (cta_m_idx, cta_n_idx) tiles. This gives perfect wave packing for any
+// cta_count, lets the activation A stay in L2 across the persistent tile
+// loop, and removes per-tile launch overhead.
+template <int gemm_m, int gemm_k, int tile_m, int tile_n, int tile_k, int stage_cnt>
+__global__ __launch_bounds__(256, 2) void fused_a_gemm_kernel_persistent(
+    bf16_t* output, bf16_t const* mat_a, bf16_t const* mat_b, int gemm_n,
+    int cta_m_cnt, int cta_n_cnt)
+{
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+    constexpr int load_thread_cnt = 128;
+    constexpr int compute_thread_cnt = 128;
+
+    extern __shared__ char smem[];
+    uint64_t* smem_barrier = reinterpret_cast<uint64_t*>(smem);
+    bf16_t* smem_a = reinterpret_cast<bf16_t*>(smem + (stage_cnt * 8 * 2 + 1024) / 1024 * 1024);
+    bf16_t* smem_b = smem_a + tile_m * tile_k * stage_cnt;
+
+    int warp_idx = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    int total_tiles = cta_m_cnt * cta_n_cnt;
+    int num_persistent = gridDim.x;
+
+    // PDL: the grid sync / trigger run once at the start. Per-tile work then
+    // happens without additional grid sync.
+    cudaGridDependencySynchronize();
+    cudaTriggerProgrammaticLaunchCompletion();
+
+    for (int tile_id = blockIdx.x; tile_id < total_tiles; tile_id += num_persistent)
+    {
+        // Walk N-tiles (token dimension, usually 1) before M-tiles so the
+        // activation A's K-stripe stays hot in L2 between consecutive
+        // iterations sharing the same cta_n_idx.
+        int cta_n_idx_idx = tile_id % cta_n_cnt;
+        int cta_m_idx_idx = tile_id / cta_n_cnt;
+        int cta_m_idx = tile_m * cta_m_idx_idx;
+        int cta_n_idx = tile_n * cta_n_idx_idx;
+
+        bf16_t const* gmem_a_local = mat_a + cta_m_idx * gemm_k;
+        bf16_t const* gmem_b_local = mat_b + cta_n_idx * gemm_k;
+        bf16_t* gmem_c_local = output + cta_n_idx * gemm_m + cta_m_idx;
+
+        // Re-initialize barriers each tile: re-init resets phase to 0 and
+        // refills the expected-arrive count, so the loaders/computer can
+        // start cleanly with their initial phase_bit values without having
+        // to track the running parity across the previous tile.
+        if (warp_idx == 4)
+        {
+            for (int i = 0; i < stage_cnt; i++)
+            {
+                initialize_barrier(smem_barrier + i * 2 + 0, load_thread_cnt);
+                initialize_barrier(smem_barrier + i * 2 + 1, compute_thread_cnt);
+            }
+        }
+        __syncthreads();
+
+        if (warp_idx < 2)
+        {
+            GmemLoaderA<gemm_k, tile_m, tile_k, stage_cnt> a_loader(gmem_a_local, smem_a, smem_barrier);
+            a_loader.prepare();
+            a_loader.issue_mainloop();
+        }
+        else if (warp_idx < 4)
+        {
+            GmemLoaderB<gemm_k, tile_n, tile_k, stage_cnt> b_loader(gmem_b_local, smem_b, smem_barrier, gemm_n);
+            b_loader.prepare();
+            b_loader.issue_mainloop();
+        }
+        else
+        {
+            MmaComputer<gemm_m, gemm_k, tile_m, tile_n, tile_k, stage_cnt> mma_computer(
+                gmem_c_local, smem_a, smem_b, smem_barrier, warp_idx, gemm_n);
+            mma_computer.prepare();
+            mma_computer.issue_mainloop();
+            mma_computer.epi();
+        }
+
+        // All warps must exit before the next tile re-initializes barriers
+        // (and the loaders start writing into smem_a / smem_b again).
+        __syncthreads();
+    }
+#endif
+}
+
+// Single B200 retune config: 96 KB smem/CTA, 2 CTAs/SM, 8 stages tile_n=8 /
+// 6 stages tile_n=16. Two grid strategies share this config:
+//
+//   - static grid (`fused_a_gemm_kernel`):       grid = (cta_m_cnt, cta_n_cnt).
+//     Best when cta_m_cnt is comfortably more than num_sms*2 (>= ~8 tiles per
+//     persistent CTA), so the partial-wave tax is small.
+//
+//   - persistent grid (`fused_a_gemm_kernel_persistent`): grid = (num_sms*2, 1)
+//     with each CTA looping over its tiles. Best when wave count is small
+//     (small N) AND batch is small enough that the per-tile re-init +
+//     __syncthreads cost stays below the wave-packing benefit.
+//
+// `should_use_persistent` encodes the bench-tuned threshold from
+// `tmp/opt_lm_head/integrate_and_replace.md` §5.
+
+template <typename T, int kHdIn, int kHdOut, int kTileN>
+void invokeFusedAGemm(T* output, T const* mat_a, T const* mat_b, int num_tokens,
+                      bool persistent, bool enable_pdl, cudaStream_t stream)
+{
+    constexpr int gemm_m = kHdOut;
+    int const gemm_n = num_tokens;
+    constexpr int gemm_k = kHdIn;
+    std::swap(mat_a, mat_b);
+    constexpr int tile_m = 16;
+    constexpr int tile_n = kTileN;
+    constexpr int tile_k = std::max(256, 1024 / tile_n);
+    // Single B200-tuned config: 96 KB / CTA, 2 CTAs/SM. tile_n=8 → 8 stages,
+    // tile_n=16 → 6 stages. Hardcoded in __launch_bounds__ on the kernels.
+    constexpr int smem_budget_kb = 96;
+    constexpr int max_stage_cnt = 1024 * smem_budget_kb / ((tile_m + tile_n) * tile_k * sizeof(bf16_t));
+    constexpr int k_iter_cnt = gemm_k / tile_k;
+    constexpr int stage_cnt = k_iter_cnt > max_stage_cnt ? max_stage_cnt : k_iter_cnt;
+    int cta_m_cnt = gemm_m / tile_m;
+    int cta_n_cnt = (gemm_n + tile_n - 1) / tile_n;
+    constexpr int barrier_bytes = (stage_cnt * 16 + 1023) / 1024 * 1024;
+    constexpr int smem_bytes = ((tile_m * 2 + tile_n * 2) * tile_k * stage_cnt + barrier_bytes + 1023) / 1024 * 1024;
+
+    dim3 grid;
+    if (persistent)
+    {
+        int num_sms = 0;
+        cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, 0);
+        int total_tiles = cta_m_cnt * cta_n_cnt;
+        int desired = num_sms * 2;  // 2 CTAs/SM (matches __launch_bounds__)
+        grid = dim3(desired < total_tiles ? desired : total_tiles, 1, 1);
+    }
+    else
+    {
+        grid = dim3(cta_m_cnt, cta_n_cnt, 1);
+    }
+
+    cudaLaunchConfig_t config;
+    config.gridDim = grid;
+    config.blockDim = dim3(256);
+    config.dynamicSmemBytes = smem_bytes;
+    config.stream = stream;
+    cudaLaunchAttribute attrs[1];
+    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attrs[0].val.programmaticStreamSerializationAllowed = enable_pdl ? 1 : 0;
+    config.numAttrs = 1;
+    config.attrs = attrs;
+
+    auto launch_with_smem = [&](auto kernel, auto&&... extra_args) -> cudaError_t {
+        if (smem_bytes >= (48 * 1024))
+        {
+            cudaError_t err = cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_bytes);
+            if (err != cudaSuccess) return err;
+        }
+        return cudaLaunchKernelEx(&config, kernel, output, mat_a, mat_b, gemm_n,
+                                   std::forward<decltype(extra_args)>(extra_args)...);
+    };
+
+    cudaError_t err = persistent
+        ? launch_with_smem(fused_a_gemm_kernel_persistent<gemm_m, gemm_k, tile_m, tile_n, tile_k, stage_cnt>,
+                           cta_m_cnt, cta_n_cnt)
+        : launch_with_smem(fused_a_gemm_kernel<gemm_m, gemm_k, tile_m, tile_n, tile_k, stage_cnt>);
+    if (err != cudaSuccess)
+    {
+        fprintf(stderr, "lm_head_gemm: launch failed: %s\n", cudaGetErrorString(err));
+    }
+}
+
+// ============================================================================
+// Explicit instantiations. Shape convention:
+//   mat_a (act):    bf16 [num_tokens, kHdIn]   row-major
+//   mat_b (weight): bf16 [kHdOut,   kHdIn]     row-major
+//   output:         bf16 [num_tokens, kHdOut]  row-major
+// kHdIn=7168 (DSv3, K2.5 hidden); kTileN ∈ {8, 16}.
+// ============================================================================
+#define INSTANTIATE(K, N, TN) \
+    template void invokeFusedAGemm<bf16_t, K, N, TN>(bf16_t*, bf16_t const*, bf16_t const*, int, bool, bool, cudaStream_t);
+
+#define INSTANTIATE_TILE_N(K, N) \
+    INSTANTIATE(K, N, 8)         \
+    INSTANTIATE(K, N, 16)
+
+// DSv3 (V=129280): TP=8 -> 16160; TP=4 -> 32320; no-TP -> 129280.
+// Note: at N=16160 our kernel ties or slightly loses to cuBLAS's bf16 hmma
+// (the partial-wave tax dominates at only 3.4 waves on B200), but we still
+// compile the instantiation so callers can opt in for head-to-head bench
+// or future tuning. The default routing in production should still pick
+// torch.matmul for this shape.
+INSTANTIATE_TILE_N(7168, 16160)
+INSTANTIATE_TILE_N(7168, 32320)
+INSTANTIATE_TILE_N(7168, 129280)
+// K2.5 (V=163840): TP=8 -> 20480; TP=4 -> 40960; no-TP -> 163840.
+INSTANTIATE_TILE_N(7168, 20480)
+INSTANTIATE_TILE_N(7168, 40960)
+INSTANTIATE_TILE_N(7168, 163840)
+
+#undef INSTANTIATE
+#undef INSTANTIATE_TILE_N
+
+// ============================================================================
+// Runtime dispatcher.
+// ============================================================================
+
+// Persistent-CTA grid is the bench-winner when:
+//   1. batch (num_tokens) is small, so the persistent loop's per-tile sync
+//      overhead is short relative to the per-tile compute, AND
+//   2. tile count is small relative to num_sms*2, so the static grid would
+//      otherwise leave a large partial-wave tax.
+// Threshold tuned in `tmp/opt_lm_head/integrate_and_replace.md` §5.
+inline bool should_use_persistent(int num_tokens, int hd_out)
+{
+    if (num_tokens > 4) return false;
+    int num_sms = 0;
+    cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, 0);
+    int num_tiles = (hd_out + 15) / 16;
+    // tiles_per_persistent_CTA = num_tiles / (num_sms * 2). Keep it <= 7.5
+    // (i.e. 2 * num_tiles <= 15 * num_sms).
+    return 2 * num_tiles <= 15 * num_sms;
+}
+
+template <int K, int N>
+bool launch_for_n(__nv_bfloat16* output, __nv_bfloat16 const* mat_a, __nv_bfloat16 const* mat_b,
+                  int num_tokens, int tile_n, bool enable_pdl, cudaStream_t stream)
+{
+    bool persistent = should_use_persistent(num_tokens, N);
+    if (tile_n == 8)
+    {
+        invokeFusedAGemm<__nv_bfloat16, K, N, 8>(output, mat_a, mat_b, num_tokens, persistent, enable_pdl, stream);
+        return true;
+    }
+    if (tile_n == 16)
+    {
+        invokeFusedAGemm<__nv_bfloat16, K, N, 16>(output, mat_a, mat_b, num_tokens, persistent, enable_pdl, stream);
+        return true;
+    }
+    return false;
+}
+
+bool launch_lm_head_gemm(__nv_bfloat16* output, __nv_bfloat16 const* mat_a, __nv_bfloat16 const* mat_b,
+                         int num_tokens, int hd_in, int hd_out, int tile_n,
+                         bool enable_pdl, cudaStream_t stream)
+{
+    if (hd_in != 7168) return false;
+    switch (hd_out)
+    {
+    case 16160:  return launch_for_n<7168, 16160>(output, mat_a, mat_b, num_tokens, tile_n, enable_pdl, stream);
+    case 32320:  return launch_for_n<7168, 32320>(output, mat_a, mat_b, num_tokens, tile_n, enable_pdl, stream);
+    case 129280: return launch_for_n<7168, 129280>(output, mat_a, mat_b, num_tokens, tile_n, enable_pdl, stream);
+    case 20480:  return launch_for_n<7168, 20480>(output, mat_a, mat_b, num_tokens, tile_n, enable_pdl, stream);
+    case 40960:  return launch_for_n<7168, 40960>(output, mat_a, mat_b, num_tokens, tile_n, enable_pdl, stream);
+    case 163840: return launch_for_n<7168, 163840>(output, mat_a, mat_b, num_tokens, tile_n, enable_pdl, stream);
+    default:     return false;
+    }
+}
+
+}  // namespace lm_head_gemm
+}  // namespace tokenspeed

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/lm_head_gemm_binding.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/lm_head_gemm_binding.cu
@@ -1,0 +1,53 @@
+#include "tvm_ffi_utils.h"
+
+#include <cuda_bf16.h>
+
+namespace tokenspeed { namespace lm_head_gemm {
+bool launch_lm_head_gemm(__nv_bfloat16* output, __nv_bfloat16 const* mat_a, __nv_bfloat16 const* mat_b,
+                         int num_tokens, int hd_in, int hd_out, int tile_n,
+                         bool enable_pdl, cudaStream_t stream);
+} }
+
+// Signature:
+//   output:  bf16 [num_tokens, hd_out]  row-major, contiguous
+//   mat_a:   bf16 [num_tokens, hd_in]   row-major, contiguous
+//   mat_b:   bf16 [hd_out,   hd_in]     row-major, contiguous
+//   tile_n:  8 or 16 (batch-per-CTA). Caller picks based on num_tokens.
+//   enable_pdl: programmatic dependent launch flag.
+//
+// Persistent-CTA vs static-grid is decided internally by the launcher
+// based on (num_tokens, hd_out) and the device's SM count.
+//
+// Supported (hd_in, hd_out) pairs are fixed at compile time; caller must
+// check `lm_head_gemm_supported` first and fall back to torch.matmul if
+// the shape is unsupported.
+void lm_head_gemm(TensorView output, TensorView mat_a, TensorView mat_b, int64_t tile_n,
+                  bool enable_pdl) {
+  CHECK_INPUT(output);
+  CHECK_INPUT(mat_a);
+  CHECK_INPUT(mat_b);
+  CHECK_INPUT_TYPE(output, dl_bfloat16);
+  CHECK_INPUT_TYPE(mat_a, dl_bfloat16);
+  CHECK_INPUT_TYPE(mat_b, dl_bfloat16);
+  TVM_FFI_ICHECK_EQ(output.ndim(), 2) << "output must be 2D";
+  TVM_FFI_ICHECK_EQ(mat_a.ndim(), 2) << "mat_a must be 2D";
+  TVM_FFI_ICHECK_EQ(mat_b.ndim(), 2) << "mat_b must be 2D";
+  int64_t num_tokens = mat_a.size(0);
+  int64_t hd_in = mat_a.size(1);
+  int64_t hd_out = mat_b.size(0);
+  TVM_FFI_ICHECK_EQ(mat_b.size(1), hd_in) << "mat_b.size(1) must equal mat_a.size(1)";
+  TVM_FFI_ICHECK_EQ(output.size(0), num_tokens) << "output.size(0) must equal mat_a.size(0)";
+  TVM_FFI_ICHECK_EQ(output.size(1), hd_out) << "output.size(1) must equal mat_b.size(0)";
+
+  cudaStream_t stream = get_stream(output.device());
+  bool ok = tokenspeed::lm_head_gemm::launch_lm_head_gemm(
+      reinterpret_cast<__nv_bfloat16*>(output.data_ptr()),
+      reinterpret_cast<__nv_bfloat16 const*>(mat_a.data_ptr()),
+      reinterpret_cast<__nv_bfloat16 const*>(mat_b.data_ptr()),
+      static_cast<int>(num_tokens), static_cast<int>(hd_in), static_cast<int>(hd_out),
+      static_cast<int>(tile_n), enable_pdl, stream);
+  TVM_FFI_ICHECK(ok) << "lm_head_gemm: unsupported (hd_in,hd_out,tile_n)=(" << hd_in << "," << hd_out
+                     << "," << tile_n << ")";
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(lm_head_gemm, lm_head_gemm);

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/lm_head_gemm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/lm_head_gemm.py
@@ -1,0 +1,187 @@
+"""lm_head GEMM kernel wrapper (ported from TRT-LLM invokeFusedAGemm).
+
+Computes:
+    out = hidden_states @ weight.T
+
+where:
+    hidden_states: bf16 CUDA tensor [num_tokens, hidden_dim]
+    weight:        bf16 CUDA tensor [vocab_shard, hidden_dim]   (row-major, contiguous)
+    out:           bf16 CUDA tensor [num_tokens, vocab_shard]
+
+Pipeline config (B200-tuned): 96 KB smem/CTA, 2 CTAs/SM, 8 stages
+(tile_n=8) / 6 stages (tile_n=16). The launcher picks a static or
+persistent-CTA grid internally based on num_tokens and hd_out — see
+``should_use_persistent`` in ``csrc/lm_head_gemm.cu``.
+
+Two gating helpers for callers:
+
+  - ``is_supported(h, w)``: shape/dtype/CC compatibility — does the .so
+    have a template instantiation that can run? Used by benchmark harnesses
+    to enumerate what's compiled.
+
+  - ``should_use_fused(h, w)``: bench-driven routing — does the fused
+    kernel actually beat ``torch.matmul`` on this (M, N) pair? Production
+    callers (``logits_processor.py``) should use this and fall back to
+    ``torch.matmul`` when it returns False.
+
+The bench thresholds in ``_FUSED_MAX_TOKENS`` come from the M=1..16 sweep
+in ``tmp/opt_lm_head/integrate_and_replace.md`` §13. Re-run the sweep and
+update this table when the kernel or HW changes.
+"""
+
+from __future__ import annotations
+
+import functools
+from pathlib import Path
+
+import torch
+import tvm_ffi
+
+
+def _objs_dir() -> Path:
+    return Path(__file__).resolve().parent / "objs"
+
+
+# (hidden_dim, vocab_shard) pairs that have explicit template instantiations
+# compiled into the shared library. Keep in sync with INSTANTIATE_TILE_N in
+# csrc/lm_head_gemm.cu.
+_SUPPORTED_SHAPES: frozenset[tuple[int, int]] = frozenset(
+    {
+        # DSv3 (vocab=129280)
+        (7168, 16160),  # DSv3 TP=8
+        (7168, 32320),  # DSv3 TP=4
+        (7168, 129280),  # DSv3 no-TP
+        # Kimi K2.5 (vocab=163840)
+        (7168, 20480),  # K2.5 TP=8
+        (7168, 40960),  # K2.5 TP=4
+        (7168, 163840),  # K2.5 no-TP
+    }
+)
+
+
+# Per-(hidden_dim, vocab_shard), the largest num_tokens for which the fused
+# kernel beats torch.matmul on B200 (sm_100). 0 / absent → never beats torch
+# on this shape, fall back unconditionally. From M=1..16 sweep, see
+# tmp/opt_lm_head/integrate_and_replace.md §13.
+_FUSED_MAX_TOKENS: dict[tuple[int, int], int] = {
+    # DSv3 (vocab=129280)
+    (
+        7168,
+        16160,
+    ): 0,  # cuBLAS hmma already at peak at small N; ours ties at M=1, loses M>=2.
+    (7168, 32320): 8,  # ours wins / ties M=1..8 by 2-5%; M>=9 loses up to 3%.
+    (7168, 129280): 4,  # ours wins / ties M=1..4 (within 2%); M>=5 loses 2-10%.
+    # Kimi K2.5 (vocab=163840)
+    (7168, 20480): 16,  # ours wins / ties every M=1..16 by 0-7%.
+    (
+        7168,
+        40960,
+    ): 8,  # ours wins M=1..8 by 5-9%; M=9..15 loses 4-6% (M=16 a tiny win, treat as loss).
+    (7168, 163840): 16,  # ours wins every M=1..16 by 4-16%.
+}
+
+
+@functools.cache
+def _load_module():
+    so_path = _objs_dir() / "lm_head_gemm" / "lm_head_gemm.so"
+    if not so_path.exists():
+        raise RuntimeError(
+            f"tokenspeed_kernel lm_head_gemm library not found at {so_path}. "
+            "Run `pip install -e tokenspeed-kernel/python/` to build."
+        )
+    return tvm_ffi.load_module(str(so_path))
+
+
+def is_supported(
+    hidden_states: torch.Tensor,
+    weight: torch.Tensor,
+    num_tokens_max: int = 16,
+) -> bool:
+    """Return True if this lm_head shape can run through the fused kernel.
+
+    Capability gate (does the .so have it?), independent of perf:
+      * bf16 only
+      * M = num_tokens <= num_tokens_max (default 16)
+      * (K, N) = (hidden_dim, vocab_shard) matches a compiled instantiation
+      * CC >= 9.0 (Hopper or newer; uses HMMA + cp.async + mbarrier + PDL)
+    """
+    if hidden_states.dtype != torch.bfloat16 or weight.dtype != torch.bfloat16:
+        return False
+    if hidden_states.device.type != "cuda" or weight.device.type != "cuda":
+        return False
+    if hidden_states.dim() != 2 or weight.dim() != 2:
+        return False
+    num_tokens, hd_in = hidden_states.shape
+    hd_out, hd_in_w = weight.shape
+    if hd_in != hd_in_w or num_tokens > num_tokens_max:
+        return False
+    if (hd_in, hd_out) not in _SUPPORTED_SHAPES:
+        return False
+    major, _ = torch.cuda.get_device_capability(hidden_states.device)
+    if major < 9:
+        return False
+    return True
+
+
+def should_use_fused(
+    hidden_states: torch.Tensor,
+    weight: torch.Tensor,
+) -> bool:
+    """Return True if the fused kernel beats torch.matmul on this shape.
+
+    Combines the capability gate (``is_supported``) with the bench-derived
+    perf gate (``_FUSED_MAX_TOKENS``). Production callers should use this —
+    it returns False even for compiled shapes when torch.matmul wins (e.g.
+    DSv3 TP=8 N=16160, where cuBLAS bf16 hmma is already at peak).
+    """
+    if not is_supported(hidden_states, weight):
+        return False
+    if not hidden_states.is_contiguous() or not weight.is_contiguous():
+        return False
+    num_tokens = hidden_states.shape[0]
+    hd_in = hidden_states.shape[1]
+    hd_out = weight.shape[0]
+    cap = _FUSED_MAX_TOKENS.get((hd_in, hd_out), 0)
+    return num_tokens <= cap
+
+
+def lm_head_gemm(
+    hidden_states: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+    enable_pdl: bool = False,
+) -> torch.Tensor:
+    """Fused bf16 GEMM for lm_head / router-like projections.
+
+    Args:
+        hidden_states: ``[num_tokens, hidden_dim]`` bf16 contiguous CUDA tensor.
+        weight:        ``[vocab_shard, hidden_dim]`` bf16 contiguous CUDA tensor
+                       (i.e. the raw ``lm_head.weight``; no explicit transpose).
+        out:           optional pre-allocated output ``[num_tokens, vocab_shard]``.
+        enable_pdl:    whether to request Programmatic Dependent Launch.
+
+    Returns:
+        bf16 CUDA tensor ``[num_tokens, vocab_shard]``.
+    """
+    assert hidden_states.is_contiguous(), "hidden_states must be contiguous"
+    assert weight.is_contiguous(), "weight must be contiguous"
+    num_tokens, _ = hidden_states.shape
+    hd_out = weight.shape[0]
+    if out is None:
+        out = torch.empty(
+            (num_tokens, hd_out),
+            device=hidden_states.device,
+            dtype=torch.bfloat16,
+        )
+    else:
+        assert out.is_contiguous()
+        assert out.shape == (num_tokens, hd_out)
+        assert out.dtype == torch.bfloat16
+    # tile_n=8 is the minimum-latency config for M<=8; tile_n=16 amortizes
+    # the store/epilogue when M>8.
+    tile_n = 8 if num_tokens <= 8 else 16
+    _load_module().lm_head_gemm(
+        out, hidden_states, weight, int(tile_n), bool(enable_pdl)
+    )
+    return out


### PR DESCRIPTION
## Summary

Optimize `lm_head` for low_latency.

- Before: 94.072 us
<img width="453" height="169" alt="image" src="https://github.com/user-attachments/assets/d2ed8de0-a0cd-4be4-859a-5c08bf582b84" />

aime25 accuracy
```
+-----------------+-----------+----------+----------+-------+---------+---------+
| Model           | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+=================+===========+==========+==========+=======+=========+=========+
| Kimi-K2.5-NVFP4 | aime25    | mean_acc | default  |    30 |  0.9667 | default |
+-----------------+-----------+----------+----------+-------+---------+---------+ 
```


- After: 87.008 us (1.08x)
<img width="612" height="146" alt="image" src="https://github.com/user-attachments/assets/770ddcaf-4076-477c-9eb1-717a9ff13106" />

aime25 accuracy
```
+-----------------+-----------+----------+----------+-------+---------+---------+
| Model           | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+=================+===========+==========+==========+=======+=========+=========+
| Kimi-K2.5-NVFP4 | aime25    | mean_acc | default  |    30 |       1 | default |
+-----------------+-----------+----------+----------+-------+---------+---------+ 
```


## Test Plan

<!-- How was this validated? -->
