### PR TITLE
feat(cli): print TokenSpeed banner on `ts serve` startup

### DIFF
--- a/python/tokenspeed/cli/_logo.py
+++ b/python/tokenspeed/cli/_logo.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Startup banner for ``ts serve``: ``Token`` in bright black, ``Speed`` in blue."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import IO
+
+from tokenspeed.version import __version__
+
+_TOKEN_LINES = (
+    "████████  ██████  ██   ██ ███████ ███    ██ ",
+    "   ██    ██    ██ ██  ██  ██      ████   ██ ",
+    "   ██    ██    ██ █████   █████   ██ ██  ██ ",
+    "   ██    ██    ██ ██  ██  ██      ██  ██ ██ ",
+    "   ██     ██████  ██   ██ ███████ ██   ████ ",
+)
+
+_SPEED_LINES = (
+    "███████ ██████  ███████ ███████ ██████  ",
+    "██      ██   ██ ██      ██      ██   ██ ",
+    "███████ ██████  █████   █████   ██   ██ ",
+    "     ██ ██      ██      ██      ██   ██ ",
+    "███████ ██      ███████ ███████ ██████  ",
+)
+
+_TOKEN_STYLE = "\033[90m"  # bright black (grey).
+_SPEED_STYLE = "\033[94m"  # bright blue.
+_RESET = "\033[0m"
+
+_TAGLINE = "Tokens at the speed of light"
+_DISABLE_ENV = "TOKENSPEED_DISABLE_LOGO"
+# Visible width of one banner row: len(token) + " " + len(speed).
+_BANNER_WIDTH = len(_TOKEN_LINES[0]) + 1 + len(_SPEED_LINES[0])
+
+
+def _is_disabled() -> bool:
+    value = os.environ.get(_DISABLE_ENV, "").strip().lower()
+    return value not in ("", "0", "false", "no")
+
+
+def _stream_supports_color(stream: IO[str]) -> bool:
+    isatty = getattr(stream, "isatty", None)
+    if not callable(isatty):
+        return False
+    try:
+        return bool(isatty())
+    except ValueError:
+        return False
+
+
+def render_logo(version: str = __version__, *, color: bool = True) -> str:
+    """Return the multi-line banner. Trailing newline included."""
+    if color:
+        token_open, speed_open, close = _TOKEN_STYLE, _SPEED_STYLE, _RESET
+    else:
+        token_open = speed_open = close = ""
+
+    rows = [
+        f"{token_open}{token}{close} {speed_open}{speed}{close}"
+        for token, speed in zip(_TOKEN_LINES, _SPEED_LINES)
+    ]
+    footer = f"{_TAGLINE} · v{version}"
+    pad = max(0, (_BANNER_WIDTH - len(footer)) // 2)
+    rows.append(" " * pad + footer)
+    return "\n".join(rows) + "\n"
+
+
+def print_logo(version: str = __version__, *, stream: IO[str] | None = None) -> None:
+    """Write the banner to ``stream`` (default stderr).
+
+    No-op when ``TOKENSPEED_DISABLE_LOGO`` is truthy. ANSI colors are emitted
+    only when the target stream is a TTY.
+    """
+    if _is_disabled():
+        return
+    if stream is None:
+        stream = sys.stderr
+    stream.write(render_logo(version, color=_stream_supports_color(stream)))
+    stream.flush()

--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -30,6 +30,7 @@ import signal
 import sys
 
 from tokenspeed.cli._argsplit import OrchestratorOpts, split_argv
+from tokenspeed.cli._logo import print_logo
 from tokenspeed.cli._logprefix import ENGINE_TAG, GATEWAY_TAG, tag_stream
 from tokenspeed.cli._proc import (
     spawn_engine,
@@ -283,6 +284,8 @@ def run_smg_from_args(args: argparse.Namespace, raw_argv: list[str]) -> None:
         setproctitle.setproctitle("ts-serve")
     except ImportError:
         pass
+
+    print_logo()
 
     _check_serve_extra_installed()
     split = split_argv(raw_argv)

--- a/test/cli/test_logo.py
+++ b/test/cli/test_logo.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Unit tests for the ``ts serve`` startup banner."""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(REPO_ROOT, "python"))
+
+from tokenspeed.cli._logo import (
+    _RESET,
+    _SPEED_STYLE,
+    _TOKEN_STYLE,
+    print_logo,
+    render_logo,
+)
+
+
+class _TTYBuffer(io.StringIO):
+    def isatty(self) -> bool:  # noqa: D401 - trivial
+        return True
+
+
+def test_render_logo_colored_wraps_token_in_grey_and_speed_in_blue():
+    out = render_logo("9.9.9", color=True)
+
+    body_rows = out.splitlines()[:-1]
+    assert len(body_rows) == 5
+    for row in body_rows:
+        assert row.startswith(_TOKEN_STYLE)
+        assert _SPEED_STYLE in row
+        assert row.endswith(_RESET)
+        # Token segment must close before the speed one opens.
+        assert row.index(_RESET) < row.index(_SPEED_STYLE)
+
+    assert "Tokens at the speed of light · v9.9.9" in out
+    assert out.endswith("\n")
+
+
+def test_render_logo_monochrome_omits_escape_codes():
+    out = render_logo("0.0.0", color=False)
+
+    assert "\033[" not in out
+    assert "Tokens at the speed of light · v0.0.0" in out
+
+
+def test_print_logo_writes_to_stream_with_color_on_tty(monkeypatch):
+    monkeypatch.delenv("TOKENSPEED_DISABLE_LOGO", raising=False)
+    buf = _TTYBuffer()
+
+    print_logo("1.2.3", stream=buf)
+
+    assert _TOKEN_STYLE in buf.getvalue()
+    assert _SPEED_STYLE in buf.getvalue()
+    assert "Tokens at the speed of light · v1.2.3" in buf.getvalue()
+
+
+def test_print_logo_omits_color_on_non_tty(monkeypatch):
+    monkeypatch.delenv("TOKENSPEED_DISABLE_LOGO", raising=False)
+    buf = io.StringIO()  # isatty() -> False by default
+
+    print_logo("1.2.3", stream=buf)
+
+    assert "\033[" not in buf.getvalue()
+    assert "Tokens at the speed of light · v1.2.3" in buf.getvalue()
+
+
+def test_print_logo_disabled_via_env(monkeypatch):
+    buf = _TTYBuffer()
+    monkeypatch.setenv("TOKENSPEED_DISABLE_LOGO", "1")
+
+    print_logo("1.2.3", stream=buf)
+
+    assert buf.getvalue() == ""
+
+
+def test_print_logo_zero_value_is_not_disabled(monkeypatch):
+    # "0" / "false" / "" must NOT count as "disabled" — only truthy strings.
+    buf = _TTYBuffer()
+    monkeypatch.setenv("TOKENSPEED_DISABLE_LOGO", "0")
+
+    print_logo("1.2.3", stream=buf)
+
+    assert "Tokens at the speed of light · v1.2.3" in buf.getvalue()


### PR DESCRIPTION
## Summary

- Render a TokenSpeed startup banner from `ts serve` ahead of dependency checks, so users get a visual confirmation of the product and version on launch.
- ``Token`` is bright black (`\033[90m`) and ``Speed`` is bright blue (`\033[94m`), mirroring the marketing banner under `assets/banner/tokenspeed-banner.png`. Tagline `Tokens at the speed of light · v<version>` is centered underneath, with the version pulled from `tokenspeed.version.__version__`.
- ANSI colors are emitted only when the target stream is a TTY; the banner can be fully suppressed via `TOKENSPEED_DISABLE_LOGO=1`.

## Preview

```
████████  ██████  ██   ██ ███████ ███    ██   ███████ ██████  ███████ ███████ ██████
   ██    ██    ██ ██  ██  ██      ████   ██   ██      ██   ██ ██      ██      ██   ██
   ██    ██    ██ █████   █████   ██ ██  ██   ███████ ██████  █████   █████   ██   ██
   ██    ██    ██ ██  ██  ██      ██  ██ ██        ██ ██      ██      ██      ██   ██
   ██     ██████  ██   ██ ███████ ██   ████   ███████ ██      ███████ ███████ ██████
                        Tokens at the speed of light · v0.1.0
```

## Test plan

- [x] `pre-commit run --all-files`
- [x] `pytest test/cli/test_logo.py` — 6/6 pass (color/monochrome rendering, TTY detection, `TOKENSPEED_DISABLE_LOGO` switch)
- [x] `pytest test/cli/test_serve_smg_unit.py` — existing serve-orchestrator tests still pass with the banner wired into `run_smg_from_args`
- [x] Manually invoked `tokenspeed serve openai/gpt-oss-20b --host 0.0.0.0 --port 8000 --tensor-parallel-size 1` and confirmed the banner renders before the SMG dependency check runs.