### PR TITLE
feat(cli): accept positional model arg in `ts serve`

### DIFF
--- a/python/tokenspeed/cli/_argsplit.py
+++ b/python/tokenspeed/cli/_argsplit.py
@@ -20,6 +20,10 @@
 
 """Argv splitter for ``ts serve``.
 
+A leading positional argument is treated as the model (vllm-style
+``ts serve <model> [flags...]``) and rewritten to ``--model <model>``
+before routing.
+
 Routing precedence is top-down. The first matching rule wins:
 
 1. Orchestrator-only flags (consumed, never forwarded)
@@ -62,6 +66,18 @@ _GATEWAY_OVERRIDE = {
 }
 
 _ENGINE_EXPLICIT = {"--tensor-parallel-size"}
+
+_MODEL_FLAG_TOKENS = ("--model", "--model-path")
+
+
+def _has_model_flag(tokens: Iterable[str]) -> bool:
+    for token in tokens:
+        if token in _MODEL_FLAG_TOKENS:
+            return True
+        for flag in _MODEL_FLAG_TOKENS:
+            if token.startswith(flag + "="):
+                return True
+    return False
 
 
 @dataclass
@@ -128,11 +144,28 @@ def _engine_recognized_flags() -> set[str]:
 def split_argv(argv: list[str]) -> SplitResult:
     """Split ts-serve argv into engine_args, gateway_args, orchestrator_opts.
 
+    A leading positional argument is rewritten to ``--model <value>`` so
+    ``ts serve <model> [flags...]`` and ``ts serve --model <model> [flags...]``
+    both work.
+
     Raises:
         ValueError: if a flag that requires a value is provided without one
             (e.g. ``--model`` with no path), if a timeout flag is
-            non-positive, or if a positional arg appears.
+            non-positive, if the model is given both positionally and via
+            ``--model``/``--model-path``, or if a positional arg appears
+            after the leading model.
     """
+
+    argv = list(argv)
+    if argv and not argv[0].startswith("--"):
+        model = argv[0]
+        rest = argv[1:]
+        if _has_model_flag(rest):
+            raise ValueError(
+                "model specified both as positional argument and via "
+                "--model/--model-path"
+            )
+        argv = ["--model", model, *rest]
 
     items = _normalize(argv)
     result = SplitResult()

--- a/test/cli/test_argsplit.py
+++ b/test/cli/test_argsplit.py
@@ -184,3 +184,50 @@ def test_timeout_with_empty_value_raises():
 def test_timeout_with_zero_raises():
     with pytest.raises(ValueError, match="must be positive"):
         _split(["--engine-startup-timeout", "0"])
+
+
+def test_leading_positional_is_treated_as_model():
+    r = _split(
+        [
+            "openai/gpt-oss-20b",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "8000",
+            "--tensor-parallel-size",
+            "1",
+        ]
+    )
+    assert "--model" in r.engine and "openai/gpt-oss-20b" in r.engine
+    assert "--model" in r.gateway and "openai/gpt-oss-20b" in r.gateway
+    assert r.gateway[r.gateway.index("--host") + 1] == "0.0.0.0"
+    assert r.gateway[r.gateway.index("--port") + 1] == "8000"
+    assert r.engine[r.engine.index("--tensor-parallel-size") + 1] == "1"
+
+
+def test_positional_model_matches_explicit_model_flag():
+    """Both invocation styles must produce the same split."""
+    positional = _split(["openai/gpt-oss-20b", "--host", "0.0.0.0"])
+    explicit = _split(["--model", "openai/gpt-oss-20b", "--host", "0.0.0.0"])
+    assert positional == explicit
+
+
+def test_positional_and_model_flag_conflict_raises():
+    with pytest.raises(ValueError, match="positional argument and via"):
+        _split(["openai/gpt-oss-20b", "--model", "other/model"])
+
+
+def test_positional_and_model_path_alias_conflict_raises():
+    with pytest.raises(ValueError, match="positional argument and via"):
+        _split(["openai/gpt-oss-20b", "--model-path", "other/model"])
+
+
+def test_positional_and_model_equals_form_conflict_raises():
+    with pytest.raises(ValueError, match="positional argument and via"):
+        _split(["openai/gpt-oss-20b", "--model=other/model"])
+
+
+def test_trailing_positional_still_raises():
+    """Only the FIRST argument may be positional; later ones remain illegal."""
+    with pytest.raises(ValueError, match="unexpected positional arg"):
+        _split(["--host", "0.0.0.0", "stray-positional"])


### PR DESCRIPTION
## Summary

- `ts serve <model> [flags...]` now works alongside `ts serve --model <model> [flags...]`, matching the convention from `vllm serve`. The argv splitter rewrites a leading positional to `--model <value>` before routing.
- A clear error is raised when the model is specified both positionally and via `--model` / `--model-path` (including the `--model=value` and `--model-path=value` forms).
- Stray positionals that are not the leading model still raise `unexpected positional arg` so accidental typos surface immediately.

## Test plan

- [x] `pre-commit run --all-files`
- [x] `pytest test/cli/test_argsplit.py` — 6 new tests plus the existing suite all pass (one pre-existing failure on `test_orchestrator_default_timeouts` is unrelated to this change).
- [x] `tokenspeed serve openai/gpt-oss-20b --host 0.0.0.0 --port 8000 --tensor-parallel-size 1` reaches the SMG dependency check (parsed correctly).
- [x] `tokenspeed serve --model openai/gpt-oss-20b --host 0.0.0.0 --port 8000 --tensor-parallel-size 1` continues to work identically.