### PR TITLE
ci(cli): run CLI unit tests in `ut-runtime-1gpu`

### DIFF
--- a/test/ci/ut/ut-runtime-1gpu.yaml
+++ b/test/ci/ut/ut-runtime-1gpu.yaml
@@ -20,5 +20,6 @@ install:
 ut:
   commands:
     - python3 test/runtime/run_ci_suite.py --device cuda --suite runtime-1gpu --timeout-per-file ${CI_TIMEOUT_PER_FILE:-1800}
+    - python3 -m pytest test/cli -v
 report:
   github_step_summary: true

--- a/test/cli/test_argsplit.py
+++ b/test/cli/test_argsplit.py
@@ -38,7 +38,7 @@ def test_orchestrator_only_flags_are_consumed():
 
 def test_orchestrator_default_timeouts():
     r = _split([])
-    assert r.opts.engine_startup_timeout == 600
+    assert r.opts.engine_startup_timeout == 1800
     assert r.opts.gateway_startup_timeout == 60
     assert r.opts.drain_timeout == 30
 


### PR DESCRIPTION
## Summary

- Fold `python3 -m pytest test/cli -v` into the existing `ut-runtime-1gpu` task so the CLI orchestrator surface (argv splitter, banner, log prefix, proc helpers, dispatch) is exercised on every per-commit run alongside the runtime suite — no new workflow, no duplicate install path.
- Why piggyback on a GPU runner instead of `ubuntu-latest`: `_engine_recognized_flags()` lazy-imports `ServerArgs`, which transitively pulls `triton`, `flashinfer-python`, and `tokenspeed_kernel`. Those need a CUDA build at install time, so a CPU-only runner can't even finish `install_deps.sh`. The existing 1-gpu runner already has the full stack staged.
- Fix `test_orchestrator_default_timeouts` along the way. The orchestrator default was bumped from 600s to 1800s in #105 but the assertion was left at 600; refresh it so the suite is green when the task runs.

## Test plan

- [x] `pre-commit run --all-files`
- [x] `pytest test/cli -v` locally — 57 passed, 1 skipped (the SMG integration test gracefully `importorskip`s `smg` / `smg_grpc_proto`, which are not installed in the dev env).
- [ ] `ut-runtime-1gpu / b200-1gpu` runs the CLI block via the per-commit trigger on this PR; merge gated on it being green.