### PR TITLE
feat(cli): disable smg circuit breaker and retries by default

### DIFF
--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -47,6 +47,13 @@ logger = logging.getLogger(__name__)
 DEFAULT_GATEWAY_HOST = "0.0.0.0"
 DEFAULT_GATEWAY_PORT = 8000
 DEFAULT_REASONING_PARSER = "none"
+# smg reliability knobs we always want disabled when launched under
+# ts serve. These are tokenspeed-internal defaults: not surfaced via
+# the ts CLI, not routed through split_argv.
+_DEFAULT_SMG_DISABLE_FLAGS = (
+    "--disable-circuit-breaker",
+    "--disable-retries",
+)
 
 
 def _check_serve_extra_installed() -> None:
@@ -103,9 +110,19 @@ def _gateway_args_with_default_reasoning_parser(gateway_args: list[str]) -> list
     return [*gateway_args, "--reasoning-parser", DEFAULT_REASONING_PARSER]
 
 
+def _gateway_args_with_smg_disable_defaults(gateway_args: list[str]) -> list[str]:
+    """Append the smg reliability-disable switches if they are not already there."""
+    result = list(gateway_args)
+    for flag in _DEFAULT_SMG_DISABLE_FLAGS:
+        if flag not in result:
+            result.append(flag)
+    return result
+
+
 def _gateway_args_with_defaults(gateway_args: list[str]) -> list[str]:
     gateway_args = _gateway_args_with_default_port(gateway_args)
-    return _gateway_args_with_default_reasoning_parser(gateway_args)
+    gateway_args = _gateway_args_with_default_reasoning_parser(gateway_args)
+    return _gateway_args_with_smg_disable_defaults(gateway_args)
 
 
 async def _stream_to(proc, tag: str) -> None:

--- a/test/cli/test_serve_smg_unit.py
+++ b/test/cli/test_serve_smg_unit.py
@@ -35,9 +35,11 @@ sys.path.insert(0, os.path.join(REPO_ROOT, "python"))
 
 from tokenspeed.cli._argsplit import OrchestratorOpts
 from tokenspeed.cli.serve_smg import (
+    _DEFAULT_SMG_DISABLE_FLAGS,
     _gateway_args_with_default_port,
     _gateway_args_with_default_reasoning_parser,
     _gateway_args_with_defaults,
+    _gateway_args_with_smg_disable_defaults,
     _user_host_port_from_gateway_args,
     run_smg,
 )
@@ -94,7 +96,39 @@ def test_gateway_args_defaults_include_port_and_reasoning_parser():
         "8000",
         "--reasoning-parser",
         "none",
+        "--disable-circuit-breaker",
+        "--disable-retries",
     ]
+
+
+def test_smg_disable_flags_appended_when_absent():
+    gateway_args = _gateway_args_with_smg_disable_defaults(["--model", "/tmp/x"])
+
+    assert gateway_args == [
+        "--model",
+        "/tmp/x",
+        "--disable-circuit-breaker",
+        "--disable-retries",
+    ]
+
+
+def test_smg_disable_flags_not_duplicated():
+    """Idempotent: passing the flag explicitly must not double it up for smg's argparse."""
+    gateway_args = _gateway_args_with_smg_disable_defaults(
+        ["--disable-circuit-breaker"]
+    )
+
+    assert gateway_args == [
+        "--disable-circuit-breaker",
+        "--disable-retries",
+    ]
+
+
+def test_smg_disable_flag_set_covers_both():
+    assert _DEFAULT_SMG_DISABLE_FLAGS == (
+        "--disable-circuit-breaker",
+        "--disable-retries",
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `ts serve` always passes `--disable-circuit-breaker` and `--disable-retries` to the smg gateway at startup. Flag names per the smg [reliability-controls](https://lightseek.org/smg/getting-started/reliability-controls/) reference; my earlier draft used the wrong `--router-disable-*` form, which smg's argparse rejected (`unrecognized arguments`).
- Both flags are tokenspeed-internal defaults: not surfaced through the user-facing CLI, not registered in `_argsplit.py`, and not documented as configurable. They are injected at `_gateway_args_with_defaults` time, after the user's argv is already split.
- The injector is idempotent — if a user happens to pass the same flag explicitly it is not duplicated, so smg's argparse will not error on a repeat token.

## Test plan

- [x] `pre-commit run --all-files`
- [x] `pytest test/cli/test_serve_smg_unit.py -v` — 16 passed locally (flags appended when absent, no-op when present, defaults helper emits the four expected tokens in order).