### PR TITLE
Refine third-party attribution notices

### DIFF
--- a/python/THIRDPARTYNOTICES
+++ b/python/THIRDPARTYNOTICES
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 Portions of this project are based on or inspired by designs and code from the following projects:
 
 Notice for NVIDIA/TensorRT-LLM

--- a/python/tokenspeed/runtime/configs/qwen3_5_text_base_config.py
+++ b/python/tokenspeed/runtime/configs/qwen3_5_text_base_config.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/distributed/device_communicators/pynccl.py
+++ b/python/tokenspeed/runtime/distributed/device_communicators/pynccl.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/distributed/device_communicators/utils.py
+++ b/python/tokenspeed/runtime/distributed/device_communicators/utils.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/distributed/utils.py
+++ b/python/tokenspeed/runtime/distributed/utils.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/engine/aio_rwlock.py
+++ b/python/tokenspeed/runtime/engine/aio_rwlock.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/trtllm_fp8_kv_kernel.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/trtllm_fp8_kv_kernel.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 """
 Fused FP8 quantization + paged KV cache write kernel for TRTLLM MHA backend.
 

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/utils.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/utils.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/layers/attention/linear/causal_conv1d.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/causal_conv1d.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/layers/attention/linear/chunk_o.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/chunk_o.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Adapted from fla-org/flash-linear-attention
 # This file has been modified for this repository.
 # License: https://github.com/fla-org/flash-linear-attention/blob/main/LICENSE

--- a/python/tokenspeed/runtime/layers/attention/linear/chunk_scaled_dot_kkt.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/chunk_scaled_dot_kkt.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Adapted from fla-org/flash-linear-attention
 # This file has been modified for this repository.
 # License: https://github.com/fla-org/flash-linear-attention/blob/main/LICENSE

--- a/python/tokenspeed/runtime/layers/attention/linear/cumsum.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/cumsum.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Adapted from fla-org/flash-linear-attention
 # This file has been modified for this repository.
 # License: https://github.com/fla-org/flash-linear-attention/blob/main/LICENSE

--- a/python/tokenspeed/runtime/layers/attention/linear/fused_sigmoid_gating_recurrent.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/fused_sigmoid_gating_recurrent.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Adapted from fla-org/flash-linear-attention
 # This file has been modified for this repository.
 # License: https://github.com/fla-org/flash-linear-attention/blob/main/LICENSE

--- a/python/tokenspeed/runtime/layers/attention/linear/l2norm.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/l2norm.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Adapted from fla-org/flash-linear-attention
 # This file has been modified for this repository.
 # License: https://github.com/fla-org/flash-linear-attention/blob/main/LICENSE

--- a/python/tokenspeed/runtime/layers/attention/linear/layernorm_gated.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/layernorm_gated.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/layers/attention/linear/op.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/op.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/layers/attention/linear/solve_tril.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/solve_tril.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Adapted from fla-org/flash-linear-attention
 # This file has been modified for this repository.
 # License: https://github.com/fla-org/flash-linear-attention/blob/main/LICENSE

--- a/python/tokenspeed/runtime/layers/attention/linear/utils.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/utils.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/layers/attention/linear/wy_fast.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/wy_fast.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Adapted from fla-org/flash-linear-attention
 # This file has been modified for this repository.
 # License: https://github.com/fla-org/flash-linear-attention/blob/main/LICENSE

--- a/python/tokenspeed/runtime/layers/dense/fp8.py
+++ b/python/tokenspeed/runtime/layers/dense/fp8.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/layers/linear.py
+++ b/python/tokenspeed/runtime/layers/linear.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/layers/parameter.py
+++ b/python/tokenspeed/runtime/layers/parameter.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/tokenspeed/runtime/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/layers/quantization/compressed_tensors/scalar_type.py
+++ b/python/tokenspeed/runtime/layers/quantization/compressed_tensors/scalar_type.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/layers/quantization/compressed_tensors/schemes/compressed_tensors_scheme.py
+++ b/python/tokenspeed/runtime/layers/quantization/compressed_tensors/schemes/compressed_tensors_scheme.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
+++ b/python/tokenspeed/runtime/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/layers/vocab_parallel_embedding.py
+++ b/python/tokenspeed/runtime/layers/vocab_parallel_embedding.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/moe/distribution_recorder.py
+++ b/python/tokenspeed/runtime/moe/distribution_recorder.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/python/tokenspeed/runtime/moe/eplb_algorithms/deepseek.py
+++ b/python/tokenspeed/runtime/moe/eplb_algorithms/deepseek.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/test/ci_system/ci_utils.py
+++ b/test/ci_system/ci_utils.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 import logging
 import os
 import re

--- a/test/runners.py
+++ b/test/runners.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/test/runtime/cache/storage/mooncake_store/test_mooncake_store.py
+++ b/test/runtime/cache/storage/mooncake_store/test_mooncake_store.py
@@ -1,3 +1,9 @@
+# Adapted from meituan-longcat/SGLang-FluentLLM.
+# This file has been modified for this repository.
+# This file may incorporate material from ModelTC/lightllm,
+# vllm-project/vllm, and sgl-project/sglang, as identified in
+# python/THIRDPARTYNOTICES.
+
 # Copyright (c) 2026 LightSeek Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
This change refines third-party attribution notices across selected files and package-level metadata.

It improves attribution clarity for selected adapted runtime and test files by adding the FluentLLM attribution header and keeping it aligned with the existing repository-level acknowledgements and THIRDPARTYNOTICES.

This change does not modify runtime behavior.