### PR TITLE
ci: retry pip bootstrap install

### DIFF
--- a/test/ci_system/install_deps.sh
+++ b/test/ci_system/install_deps.sh
@@ -84,7 +84,7 @@ echo "FlashInfer architecture: ${FI_ARCH}"
 # ============================================================
 sudo apt install -y openmpi-bin libopenmpi-dev libssl-dev pkg-config -y
 echo "=== Step 2: Upgrade pip/setuptools/wheel ==="
-python3 -m pip install --upgrade pip setuptools wheel
+pip_install_with_retry python3 -m pip install --upgrade pip setuptools wheel
 
 # ============================================================
 # Step 3: Install tokenspeed-kernel


### PR DESCRIPTION
## Summary
- wrap the pip/setuptools/wheel bootstrap install in the existing pip retry helper
- avoid failing CI on transient package index parse errors

## Test
- bash -n test/ci_system/install_deps.sh