### PR TITLE
perf(sampling): opt-in fast verify path for topk=1 chain spec

### DIFF
--- a/python/tokenspeed/runtime/sampling/backends/flashinfer.py
+++ b/python/tokenspeed/runtime/sampling/backends/flashinfer.py
@@ -62,11 +62,12 @@ if TYPE_CHECKING:
 # Opt-in env gate, read once at import time. spawn-launched TP workers inherit
 # os.environ via Python's cached dict (independent of setproctitle clobber on
 # /proc/<pid>/environ), so setting TOKENSPEED_SPEC_FAST_CHAIN_SAMPLING=1 before
-# launch propagates to all workers. When enabled, verify() switches to the same
-# top_k_top_p_sampling_from_logits(joint) kernel as plain decode plus a
-# token-equality verify (verify_chain_greedy), trading the sequential
-# top_k_renorm + top_p_renorm + chain_speculative_sampling_target_only chain
-# for one fused-sample + one constant-time verify. See verify() docstring.
+# launch propagates to all workers. When enabled, verify() replaces the
+# sequential top_k_renorm + top_p_renorm + chain_speculative_sampling_target_only
+# chain with top_k_top_p_sampling_from_logits(top_k_first) + a token-equality
+# verify (verify_chain_greedy). Matches stock TRTLLM 1.3.0rc14's verify
+# sampling and is bit-equivalent to the original filter semantics.
+# See verify() docstring.
 _FAST_CHAIN_ENABLED = os.environ.get("TOKENSPEED_SPEC_FAST_CHAIN_SAMPLING", "0") == "1"
 
 
@@ -329,13 +330,14 @@ class FlashInferSamplingBackend(SamplingBackend):
 
         elif _FAST_CHAIN_ENABLED and sampling_info.vocab_mask is None:
 
-            # Fast chain-spec path: mirror plain decode's joint kernel + a
-            # token-equality verify instead of the sequential renorm chain.
+            # Fast chain-spec path: collapse the sequential renorm chain into
+            # one fused-sample kernel + a token-equality verify.
             #
             #   draft is already argmax-greedy on the caller side (chain-spec
             #   topk=1), so:
             #     1. sample one target token per chain position via flashinfer
-            #        top_k_top_p_sampling_from_logits(filter_apply_order="joint")
+            #        top_k_top_p_sampling_from_logits(
+            #            filter_apply_order="top_k_first")
             #     2. verify by token-equality vs draft candidates using the
             #        same verify_chain_greedy kernel the greedy path runs
             #     3. bonus token at the first mismatched position is the
@@ -346,14 +348,12 @@ class FlashInferSamplingBackend(SamplingBackend):
             # with a single fused sample kernel + a constant-time compare.
             #
             # Numerical semantics:
-            #   This path uses joint top-k / top-p filtering on the *original*
-            #   distribution (same as plain decode), while the sequential
-            #   path applies top-p in the *top-k-renormalized* distribution.
-            #   Both are unbiased rejection samplers on a chain-spec draft
-            #   point mass, just with slightly different filter boundaries
-            #   (~5% TV in typical top_k=50/top_p=0.95 configs). Enabling this
-            #   path brings verify in line with plain decode's filter
-            #   semantics.
+            #   filter_apply_order="top_k_first" applies top-k then top-p on
+            #   the top-k-renormalized distribution -- bit-equivalent to the
+            #   sequential top_k_renorm_prob -> top_p_renorm_prob chain it
+            #   replaces. This also matches stock TRTLLM 1.3.0rc14's verify
+            #   sampling
+            #   (tensorrt_llm/_torch/pyexecutor/sampling_utils_flashinfer.py).
             #
             # vocab_mask fallback: grammar masks are per-draft-position, and
             # plain decode applies them via apply_vocab_mask to a [bs, V]
@@ -378,7 +378,7 @@ class FlashInferSamplingBackend(SamplingBackend):
                 scaled_logits,
                 top_ks,
                 top_ps,
-                filter_apply_order="joint",
+                filter_apply_order="top_k_first",
                 check_nan=check_nan,
                 deterministic=True,
             )

--- a/python/tokenspeed/runtime/sampling/backends/flashinfer.py
+++ b/python/tokenspeed/runtime/sampling/backends/flashinfer.py
@@ -20,6 +20,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 import torch
@@ -56,6 +57,17 @@ if TYPE_CHECKING:
     from tokenspeed.runtime.layers.logits_processor import LogitsProcessorOutput
     from tokenspeed.runtime.sampling.sampling_batch_info import SamplingBatchInfo
     from tokenspeed.runtime.sampling.sampling_params import SamplingParams
+
+
+# Opt-in env gate, read once at import time. spawn-launched TP workers inherit
+# os.environ via Python's cached dict (independent of setproctitle clobber on
+# /proc/<pid>/environ), so setting TOKENSPEED_SPEC_FAST_CHAIN_SAMPLING=1 before
+# launch propagates to all workers. When enabled, verify() switches to the same
+# top_k_top_p_sampling_from_logits(joint) kernel as plain decode plus a
+# token-equality verify (verify_chain_greedy), trading the sequential
+# top_k_renorm + top_p_renorm + chain_speculative_sampling_target_only chain
+# for one fused-sample + one constant-time verify. See verify() docstring.
+_FAST_CHAIN_ENABLED = os.environ.get("TOKENSPEED_SPEC_FAST_CHAIN_SAMPLING", "0") == "1"
 
 
 class FlashInferSamplingBackend(SamplingBackend):
@@ -312,6 +324,74 @@ class FlashInferSamplingBackend(SamplingBackend):
                 target_predict=target_predict,
                 batch_size=bs,
                 num_draft_tokens=num_tokens_per_req,
+                enable_pdl=pdl_enabled(),
+            )
+
+        elif _FAST_CHAIN_ENABLED and sampling_info.vocab_mask is None:
+
+            # Fast chain-spec path: mirror plain decode's joint kernel + a
+            # token-equality verify instead of the sequential renorm chain.
+            #
+            #   draft is already argmax-greedy on the caller side (chain-spec
+            #   topk=1), so:
+            #     1. sample one target token per chain position via flashinfer
+            #        top_k_top_p_sampling_from_logits(filter_apply_order="joint")
+            #     2. verify by token-equality vs draft candidates using the
+            #        same verify_chain_greedy kernel the greedy path runs
+            #     3. bonus token at the first mismatched position is the
+            #        sampled target there
+            #
+            # Skips full-vocab top_k_renorm + top_p_renorm (~2.7 ms/iter on
+            # vocab=200K) and the rejection-sampling kernel, replacing them
+            # with a single fused sample kernel + a constant-time compare.
+            #
+            # Numerical semantics:
+            #   This path uses joint top-k / top-p filtering on the *original*
+            #   distribution (same as plain decode), while the sequential
+            #   path applies top-p in the *top-k-renormalized* distribution.
+            #   Both are unbiased rejection samplers on a chain-spec draft
+            #   point mass, just with slightly different filter boundaries
+            #   (~5% TV in typical top_k=50/top_p=0.95 configs). Enabling this
+            #   path brings verify in line with plain decode's filter
+            #   semantics.
+            #
+            # vocab_mask fallback: grammar masks are per-draft-position, and
+            # plain decode applies them via apply_vocab_mask to a [bs, V]
+            # tensor while spec verify expects [bs*n, V]. The original
+            # sequential path handles this correctly via the renorm chain.
+            # We keep the original path for grammar-masked rows for safety.
+            n = num_tokens_per_req
+            temperatures, top_ks, top_ps, _, _, _ = gather_and_expand_scalars(
+                sampling_info.req_pool_indices,
+                temperature=self._temperature_pool,
+                top_k=self._top_k_pool,
+                top_p=self._top_p_pool,
+                n=n,
+                enable_pdl=pdl_enabled(),
+            )
+
+            check_nan = self.config.enable_nan_detection and crash_on_warnings()
+            scaled_logits = logits_output.next_token_logits.div_(
+                temperatures.view(-1, 1)
+            )
+            sampled = top_k_top_p_sampling_from_logits(
+                scaled_logits,
+                top_ks,
+                top_ps,
+                filter_apply_order="joint",
+                check_nan=check_nan,
+                deterministic=True,
+            )
+            target_predict = sampled.view(bs, n).to(torch.int64)
+
+            verify_chain_greedy(
+                predicts=predict,
+                accept_index=accept_index,
+                accept_token_num=accept_length,
+                candidates=candidates,
+                target_predict=target_predict,
+                batch_size=bs,
+                num_draft_tokens=n,
                 enable_pdl=pdl_enabled(),
             )
 

--- a/tokenspeed-kernel/test/ops/test_fast_chain_sampling.py
+++ b/tokenspeed-kernel/test/ops/test_fast_chain_sampling.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Statistical correctness for the opt-in fast chain-spec sampling path.
+
+The runtime opt-in (TOKENSPEED_SPEC_FAST_CHAIN_SAMPLING=1, see
+`tokenspeed/runtime/sampling/backends/flashinfer.py`) replaces the sequential
+
+    top_k_renorm_prob -> top_p_renorm_prob -> chain_speculative_sampling_target_only
+
+verify chain with
+
+    top_k_top_p_sampling_from_logits(filter_apply_order="joint") -> verify_chain_greedy
+
+These three properties must hold (the third one is the explicit caveat):
+
+1. The fast path's empirical output matches the joint-filter analytic
+   reference within statistical noise (joint-mode top-k AND top-p computed
+   on the original distribution).
+2. The original sequential path's empirical output matches the sequential
+   analytic reference within statistical noise (top-k renormalize then top-p
+   on renormalized distribution).
+3. The two filter modes are *not* identical -- in typical configs they
+   differ by a small but non-zero total variation distance (~5%). The fast
+   path therefore aligns verify with plain-decode's filter semantics rather
+   than preserving bit-distribution-equivalence with the sequential path.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from tokenspeed_kernel.ops.sampling.cuda import (
+    chain_speculative_sampling_target_only,
+    verify_chain_greedy,
+)
+from tokenspeed_kernel.ops.sampling.flashinfer import (
+    top_k_renorm_prob,
+    top_k_top_p_sampling_from_logits,
+    top_p_renorm_prob,
+)
+
+# Small enough to run in a few seconds on a single GPU.
+_VOCAB = 1024
+_TOP_K = 50
+_TOP_P = 0.95
+_BATCH = 4096
+_NUM_CHUNKS = 64  # → 262,144 trials per path
+_MODE_NOISE_FLOOR = 0.02
+_JOINT_VS_SEQUENTIAL_MAX_TV = 0.10
+
+
+def _total_variation(p: torch.Tensor, q: torch.Tensor) -> float:
+    return 0.5 * (p - q).abs().sum().item()
+
+
+def _sequential_filter_reference(
+    probs: torch.Tensor, top_k: int, top_p: float
+) -> torch.Tensor:
+    """Sequential top_k_renorm then top_p_renorm (the original spec verify)."""
+    top_k_t = torch.tensor([top_k], dtype=torch.int32, device=probs.device)
+    top_p_t = torch.tensor([top_p], dtype=torch.float32, device=probs.device)
+    ref = top_k_renorm_prob(probs.unsqueeze(0), top_k_t)
+    ref = top_p_renorm_prob(ref, top_p_t, is_deterministic=True)
+    return ref[0]
+
+
+def _joint_filter_reference(
+    probs: torch.Tensor, top_k: int, top_p: float
+) -> torch.Tensor:
+    """flashinfer joint mode: top-k AND top-p judged on the *original* distribution."""
+    vocab = probs.size(0)
+    sorted_probs, sorted_idx = torch.sort(probs, descending=True)
+    cumsum = torch.cumsum(sorted_probs, dim=0)
+    in_top_p = cumsum <= top_p
+    # Include the first token that crosses top_p so retained mass >= top_p
+    # (matches the flashinfer convention).
+    last_in = int(in_top_p.sum().item())
+    if last_in < vocab:
+        in_top_p[last_in] = True
+    in_top_k = torch.arange(vocab, device=probs.device) < top_k
+    joint_mask = in_top_k & in_top_p
+    kept_sorted = torch.where(joint_mask, sorted_probs, torch.zeros_like(sorted_probs))
+    kept_sorted = kept_sorted / kept_sorted.sum()
+    ref = torch.zeros(vocab, device=probs.device)
+    ref[sorted_idx] = kept_sorted
+    return ref
+
+
+def _accumulate(samples: torch.Tensor, counts: torch.Tensor) -> None:
+    ones = torch.ones_like(samples, dtype=torch.float32)
+    counts.scatter_add_(0, samples.long(), ones)
+
+
+@pytest.fixture
+def setup(device: str):
+    """Single fixed target distribution + batched expanded scalars."""
+    torch.manual_seed(0)
+    logits = torch.randn(1, _VOCAB, device=device) * 2.5
+    target_probs_raw = torch.softmax(logits, dim=-1).contiguous()
+    ref_seq = _sequential_filter_reference(target_probs_raw[0], _TOP_K, _TOP_P)
+    ref_joint = _joint_filter_reference(target_probs_raw[0], _TOP_K, _TOP_P)
+    draft_token = int(ref_seq.argmax().item())
+    target_probs_raw_bs = target_probs_raw.expand(_BATCH, -1).contiguous()
+    top_k_t_bs = torch.full((_BATCH,), _TOP_K, dtype=torch.int32, device=device)
+    top_p_t_bs = torch.full((_BATCH,), _TOP_P, dtype=torch.float32, device=device)
+    return {
+        "device": device,
+        "target_probs_raw": target_probs_raw,
+        "target_probs_raw_bs": target_probs_raw_bs,
+        "top_k_t_bs": top_k_t_bs,
+        "top_p_t_bs": top_p_t_bs,
+        "ref_seq": ref_seq,
+        "ref_joint": ref_joint,
+        "draft_token": draft_token,
+    }
+
+
+def _fast_path_step(setup_dict) -> torch.Tensor:
+    """One BATCH-sized call of joint-mode sampling, matching the runtime
+    fast path. Returns shape [BATCH] sampled tokens.
+
+    The runtime path pre-scales logits by temperature before sampling; for
+    this test we work directly from the raw probs and a temperature of 1.0,
+    so we pass log(probs) -- top_k_top_p_sampling_from_logits applies its
+    own softmax internally.
+    """
+    logits = setup_dict["target_probs_raw_bs"].log()
+    return top_k_top_p_sampling_from_logits(
+        logits,
+        setup_dict["top_k_t_bs"],
+        setup_dict["top_p_t_bs"],
+        filter_apply_order="joint",
+        deterministic=True,
+    )
+
+
+def _sequential_path_step(setup_dict) -> torch.Tensor:
+    """One BATCH-sized call of the original sequential chain-spec verify on a
+    2-position linear chain. Each batch row is an independent trial.
+
+    Returns shape [BATCH] -- the token chosen at chain position 0, which is
+    the only relevant output for distribution comparison.
+    """
+    device = setup_dict["device"]
+    bs = _BATCH
+    num_draft_tokens = 2  # 1 chain candidate + 1 bonus slot
+
+    target_probs_filtered = top_k_renorm_prob(
+        setup_dict["target_probs_raw_bs"], setup_dict["top_k_t_bs"]
+    )
+    target_probs_filtered = top_p_renorm_prob(
+        target_probs_filtered, setup_dict["top_p_t_bs"], is_deterministic=True
+    )
+    target_3d = (
+        target_probs_filtered.unsqueeze(1)
+        .expand(bs, num_draft_tokens, _VOCAB)
+        .contiguous()
+    )
+
+    candidates = torch.empty((bs, num_draft_tokens), dtype=torch.int64, device=device)
+    candidates[:, 0] = setup_dict["draft_token"]
+    candidates[:, 1] = 0
+
+    predicts = torch.full(
+        (bs * num_draft_tokens,), -1, dtype=torch.int32, device=device
+    )
+    accept_index = torch.full(
+        (bs, num_draft_tokens), -1, dtype=torch.int32, device=device
+    )
+    accept_token_num = torch.zeros(bs, dtype=torch.int32, device=device)
+    coins = torch.rand((bs, num_draft_tokens), dtype=torch.float32, device=device)
+    coins_final = torch.rand((bs,), dtype=torch.float32, device=device)
+
+    chain_speculative_sampling_target_only(
+        predicts=predicts,
+        accept_index=accept_index,
+        accept_token_num=accept_token_num,
+        candidates=candidates,
+        uniform_samples=coins,
+        uniform_samples_for_final_sampling=coins_final,
+        target_probs=target_3d,
+        draft_probs=None,
+        threshold_single=1.0,
+        threshold_acc=1.0,
+        deterministic=True,
+    )
+    return predicts.view(bs, num_draft_tokens)[:, 0]
+
+
+def _empirical_dist(sampler, setup_dict) -> torch.Tensor:
+    counts = torch.zeros(_VOCAB, device=setup_dict["device"])
+    for _ in range(_NUM_CHUNKS):
+        _accumulate(sampler(setup_dict), counts)
+    return counts / counts.sum()
+
+
+@pytest.mark.gpu
+def test_fast_path_matches_joint_filter_reference(setup) -> None:
+    """fast path's empirical output ≈ joint-filter analytic reference."""
+    torch.manual_seed(1)
+    emp = _empirical_dist(_fast_path_step, setup)
+    tv = _total_variation(emp, setup["ref_joint"])
+    assert (
+        tv < _MODE_NOISE_FLOOR
+    ), f"fast path deviates from joint-filter reference: TV={tv:.4f}"
+
+
+@pytest.mark.gpu
+def test_sequential_path_matches_sequential_filter_reference(setup) -> None:
+    """sequential path's empirical output ≈ sequential-filter analytic reference."""
+    torch.manual_seed(2)
+    emp = _empirical_dist(_sequential_path_step, setup)
+    tv = _total_variation(emp, setup["ref_seq"])
+    assert (
+        tv < _MODE_NOISE_FLOOR
+    ), f"sequential path deviates from sequential-filter reference: TV={tv:.4f}"
+
+
+@pytest.mark.gpu
+def test_joint_vs_sequential_filter_gap_is_bounded_and_nonzero(setup) -> None:
+    """The two filter modes are NOT identical (documented semantic shift).
+
+    Assert TV is bounded by JOINT_VS_SEQUENTIAL_MAX_TV in this config and is
+    strictly non-zero. Catches both regressions (gap blew up) and accidental
+    semantic convergence (gap collapsed to zero, suggesting tests aren't
+    exercising both filter modes anymore).
+    """
+    tv = _total_variation(setup["ref_seq"], setup["ref_joint"])
+    assert tv < _JOINT_VS_SEQUENTIAL_MAX_TV, (
+        f"joint vs sequential filter gap unexpectedly large: TV={tv:.4f} "
+        f"(typical ~0.05 for top_k=50/top_p=0.95)"
+    )
+    assert tv > 0.0, (
+        "joint and sequential filter references are identical -- are the "
+        "filter modes truly distinct in this config?"
+    )

--- a/tokenspeed-kernel/test/ops/test_fast_chain_sampling.py
+++ b/tokenspeed-kernel/test/ops/test_fast_chain_sampling.py
@@ -27,20 +27,18 @@ The runtime opt-in (TOKENSPEED_SPEC_FAST_CHAIN_SAMPLING=1, see
 
 verify chain with
 
-    top_k_top_p_sampling_from_logits(filter_apply_order="joint") -> verify_chain_greedy
+    top_k_top_p_sampling_from_logits(filter_apply_order="top_k_first")
+    -> verify_chain_greedy
 
-These three properties must hold (the third one is the explicit caveat):
+These two properties must hold:
 
-1. The fast path's empirical output matches the joint-filter analytic
-   reference within statistical noise (joint-mode top-k AND top-p computed
-   on the original distribution).
-2. The original sequential path's empirical output matches the sequential
-   analytic reference within statistical noise (top-k renormalize then top-p
-   on renormalized distribution).
-3. The two filter modes are *not* identical -- in typical configs they
-   differ by a small but non-zero total variation distance (~5%). The fast
-   path therefore aligns verify with plain-decode's filter semantics rather
-   than preserving bit-distribution-equivalence with the sequential path.
+1. The fast path's empirical output matches the sequential-filter analytic
+   reference within statistical noise. flashinfer's "top_k_first" mode
+   applies top-p on the top-k-renormalized distribution, which is
+   distributionally equivalent to the sequential top_k_renorm_prob ->
+   top_p_renorm_prob chain it replaces.
+2. The original sequential path's empirical output also matches the
+   sequential-filter analytic reference, validating the test setup.
 """
 
 from __future__ import annotations
@@ -64,7 +62,6 @@ _TOP_P = 0.95
 _BATCH = 4096
 _NUM_CHUNKS = 64  # → 262,144 trials per path
 _MODE_NOISE_FLOOR = 0.02
-_JOINT_VS_SEQUENTIAL_MAX_TV = 0.10
 
 
 def _total_variation(p: torch.Tensor, q: torch.Tensor) -> float:
@@ -82,28 +79,6 @@ def _sequential_filter_reference(
     return ref[0]
 
 
-def _joint_filter_reference(
-    probs: torch.Tensor, top_k: int, top_p: float
-) -> torch.Tensor:
-    """flashinfer joint mode: top-k AND top-p judged on the *original* distribution."""
-    vocab = probs.size(0)
-    sorted_probs, sorted_idx = torch.sort(probs, descending=True)
-    cumsum = torch.cumsum(sorted_probs, dim=0)
-    in_top_p = cumsum <= top_p
-    # Include the first token that crosses top_p so retained mass >= top_p
-    # (matches the flashinfer convention).
-    last_in = int(in_top_p.sum().item())
-    if last_in < vocab:
-        in_top_p[last_in] = True
-    in_top_k = torch.arange(vocab, device=probs.device) < top_k
-    joint_mask = in_top_k & in_top_p
-    kept_sorted = torch.where(joint_mask, sorted_probs, torch.zeros_like(sorted_probs))
-    kept_sorted = kept_sorted / kept_sorted.sum()
-    ref = torch.zeros(vocab, device=probs.device)
-    ref[sorted_idx] = kept_sorted
-    return ref
-
-
 def _accumulate(samples: torch.Tensor, counts: torch.Tensor) -> None:
     ones = torch.ones_like(samples, dtype=torch.float32)
     counts.scatter_add_(0, samples.long(), ones)
@@ -116,7 +91,6 @@ def setup(device: str):
     logits = torch.randn(1, _VOCAB, device=device) * 2.5
     target_probs_raw = torch.softmax(logits, dim=-1).contiguous()
     ref_seq = _sequential_filter_reference(target_probs_raw[0], _TOP_K, _TOP_P)
-    ref_joint = _joint_filter_reference(target_probs_raw[0], _TOP_K, _TOP_P)
     draft_token = int(ref_seq.argmax().item())
     target_probs_raw_bs = target_probs_raw.expand(_BATCH, -1).contiguous()
     top_k_t_bs = torch.full((_BATCH,), _TOP_K, dtype=torch.int32, device=device)
@@ -128,13 +102,12 @@ def setup(device: str):
         "top_k_t_bs": top_k_t_bs,
         "top_p_t_bs": top_p_t_bs,
         "ref_seq": ref_seq,
-        "ref_joint": ref_joint,
         "draft_token": draft_token,
     }
 
 
 def _fast_path_step(setup_dict) -> torch.Tensor:
-    """One BATCH-sized call of joint-mode sampling, matching the runtime
+    """One BATCH-sized call of top_k_first-mode sampling, matching the runtime
     fast path. Returns shape [BATCH] sampled tokens.
 
     The runtime path pre-scales logits by temperature before sampling; for
@@ -147,7 +120,7 @@ def _fast_path_step(setup_dict) -> torch.Tensor:
         logits,
         setup_dict["top_k_t_bs"],
         setup_dict["top_p_t_bs"],
-        filter_apply_order="joint",
+        filter_apply_order="top_k_first",
         deterministic=True,
     )
 
@@ -213,14 +186,14 @@ def _empirical_dist(sampler, setup_dict) -> torch.Tensor:
 
 
 @pytest.mark.gpu
-def test_fast_path_matches_joint_filter_reference(setup) -> None:
-    """fast path's empirical output ≈ joint-filter analytic reference."""
+def test_fast_path_matches_sequential_filter_reference(setup) -> None:
+    """fast path's empirical output ≈ sequential-filter analytic reference."""
     torch.manual_seed(1)
     emp = _empirical_dist(_fast_path_step, setup)
-    tv = _total_variation(emp, setup["ref_joint"])
+    tv = _total_variation(emp, setup["ref_seq"])
     assert (
         tv < _MODE_NOISE_FLOOR
-    ), f"fast path deviates from joint-filter reference: TV={tv:.4f}"
+    ), f"fast path deviates from sequential-filter reference: TV={tv:.4f}"
 
 
 @pytest.mark.gpu
@@ -232,23 +205,3 @@ def test_sequential_path_matches_sequential_filter_reference(setup) -> None:
     assert (
         tv < _MODE_NOISE_FLOOR
     ), f"sequential path deviates from sequential-filter reference: TV={tv:.4f}"
-
-
-@pytest.mark.gpu
-def test_joint_vs_sequential_filter_gap_is_bounded_and_nonzero(setup) -> None:
-    """The two filter modes are NOT identical (documented semantic shift).
-
-    Assert TV is bounded by JOINT_VS_SEQUENTIAL_MAX_TV in this config and is
-    strictly non-zero. Catches both regressions (gap blew up) and accidental
-    semantic convergence (gap collapsed to zero, suggesting tests aren't
-    exercising both filter modes anymore).
-    """
-    tv = _total_variation(setup["ref_seq"], setup["ref_joint"])
-    assert tv < _JOINT_VS_SEQUENTIAL_MAX_TV, (
-        f"joint vs sequential filter gap unexpectedly large: TV={tv:.4f} "
-        f"(typical ~0.05 for top_k=50/top_p=0.95)"
-    )
-    assert tv > 0.0, (
-        "joint and sequential filter references are identical -- are the "
-        "filter modes truly distinct in this config?"
-    )


### PR DESCRIPTION
## Summary

Opt-in optimization for **chain-spec (`eagle_topk = 1`) only**. In this configuration the draft is always argmax-greedy, so the verify pass can collapse the sequential renorm chain into a single fused-sample kernel followed by a constant-time token-equality verify.

Today the spec verify path goes through

```
softmax → top_k_renorm_prob → top_p_renorm_prob → chain_speculative_sampling_target_only
```

which scans full vocab twice at the renorm steps. For vocab≈200K (M2.5/MiniMax) this dominates verify sampling cost.

This PR adds an opt-in branch in `verify()` under `TOKENSPEED_SPEC_FAST_CHAIN_SAMPLING=1` that, in the topk=1 chain-spec case:

1. Samples one target token per chain position via `top_k_top_p_sampling_from_logits(filter_apply_order="top_k_first")` — the same flashinfer API and filter mode that stock TRTLLM 1.3.0rc14 uses for verify
2. Verifies by token-equality against the (already argmax-greedy) draft candidates using the existing `verify_chain_greedy` kernel (same kernel the greedy branch already uses)
3. Bonus token at first mismatch = the sampled target there

## Scope and applicability

Only applies when **all** of the following hold:
- `speculative_eagle_topk == 1` (chain spec) — tree spec topk>1 keeps the generic rejection kernel
- non-greedy sampling — greedy path is already on the fast `verify_chain_greedy` kernel
- no grammar mask — per-position bitmasks need the renorm chain (auto-fallback)
- request param hint matches the narrow scope this backend supports (no min_p, no penalties, no logit_bias)

For any other configuration, `verify()` falls through to the existing sequential path with no behavior change.

## Measured impact (M2.5plus-fp4 NVFP4, TP=2 B200, vocab=200054, c=32 / 200 reqs)

### Sampling kernel level (per verify, inside captured CUDA graph)

Captured via `nsys profile --cuda-graph-trace=node` at typical full batch (gridX=128):

| Path | breakdown | total µs/verify |
|------|-----------|----------------:|
| Sequential (baseline) | OnlineSoftmax 89 + RadixTopKRenormProb 165 + AirTopPRenormRadix×3 410 + AirTopPRenormApply 191 + AirTopPInit 2 + ChainSpecSampling 84 | **~941** |
| **Fast (this PR)** | RadixTopKMaskLogits + TopPSamplingFromProb + VerifyChainGreedy (fused dispatch) | **~55–90** |
| Speedup | | **~10–17×** |

The fast-path range covers small-batch (~55 µs, well-sampled at gridX=4) up to extrapolated full-batch (~90 µs). nsys event buffers overflow aggressively at full batch with `--cuda-graph-trace=node`, so the precise full-batch number for top_k_first is bracketed by the joint-mode capture at the same gridX (~85 µs sample + ~2 µs verify) and the +6–19% micro-bench delta between the two filter modes.

### End-to-end throughput (3 reps each, no nsys overhead)

| Config | avg tok/s | stddev | Δ |
|--------|----------:|-------:|--:|
| Sequential (default) | 1667 | 31 (1.9%) | — |
| **Fast (this PR)** | **1707** | 32 (1.9%) | **+2.4%** (within 1σ) |

The ≥10× kernel speedup does **not** fully translate to E2E because sampling now occupies <1% of decode iter wall in this backend — MoE + attention + allreduce dominate. The PR is most useful when:
- sampling shows up as a hotspot in profiling (e.g. larger batch or larger vocab models)
- you want to eliminate the renorm chain to simplify reasoning about decode hot path
- a future configuration shifts the bottleneck

## Numerical semantics

`filter_apply_order="top_k_first"` is **bit-equivalent in filter semantics** to the sequential `top_k_renorm_prob → top_p_renorm_prob` chain it replaces — both apply top-p on the top-k-renormalized distribution. Same prompt + sampling params produce statistically equivalent samples whether spec is on or off (empirical TV vs sequential analytic reference: **0.0040** at vocab=1024 / top_k=50 / top_p=0.95, identical noise floor to the sequential path's own 0.0035).

An earlier revision of this PR used `filter_apply_order="joint"` (top-k AND top-p applied simultaneously on the original distribution), which introduced a ~5% TV semantic shift relative to the sequential path. Profiling showed `joint` was at most ~19% faster than `top_k_first` at full-batch kernel level but the difference disappeared in E2E noise, so `top_k_first` was selected for the cleaner semantics and TRTLLM alignment.

## Prior art

The chain-spec + token-equality verify shape, the flashinfer API choice, and the `filter_apply_order="top_k_first"` selection all mirror stock TensorRT-LLM 1.3.0rc14's verify sampling (`tensorrt_llm/_torch/pyexecutor/sampling_utils_flashinfer.py`).

## CUDA graph compatibility

The fast path uses kernels (`top_k_top_p_sampling_from_logits`, `verify_chain_greedy`) that are already in-graph in this backend's `sample()` and greedy `verify()` paths. Confirmed via `nsys --cuda-graph-trace=node`: fast-path verify kernels in the benchmark trace are reported as `in_graph` (alongside eager calls from prefill sample()).

Persistent buffers (`_predict_buf`, `_accept_index_buf`, `_accept_length_buf`) are reused as in the sequential path — no per-step allocation in the hot path.

## Tests

`tokenspeed-kernel/test/ops/test_fast_chain_sampling.py` — Monte Carlo on 262,144 trials, two checks:

1. Fast path's empirical output matches the sequential-filter analytic reference within noise (`TV < 0.02`, measured 0.0040)
2. Sequential path's empirical output also matches the sequential-filter analytic reference (`TV < 0.02`, measured 0.0035) — validates the test infrastructure

Both pass.

## Opt-in / default

Default off. Read once at import time. Spawn-launched TP workers inherit `os.environ` via Python's cached dict (independent of `setproctitle`'s clobber on `/proc/<pid>/environ`), so setting `TOKENSPEED_SPEC_FAST_CHAIN_SAMPLING=1` before launching propagates to all workers.

## Test plan

- [x] Statistical correctness test (2 Monte Carlo checks, both passing at TV ≈ 0.004)
- [x] E2E benchmark, 3 reps × baseline+fast at c=32
- [x] `nsys profile --cuda-graph-trace=node` confirms in-graph kernel composition and per-verify kernel speedup
- [x] Pre-commit clean (isort, black, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
