### PR TITLE
Fix sampling backend default on non-NVIDIA platforms

### DIFF
--- a/python/tokenspeed/runtime/sampling/registry.py
+++ b/python/tokenspeed/runtime/sampling/registry.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from tokenspeed_kernel.platform import current_platform
+
 from tokenspeed.runtime.sampling.backends.base import (
     DEFAULT_RANDOM_SEED,
     SamplingBackend,
@@ -33,7 +35,16 @@ if TYPE_CHECKING:
 
 
 _BACKEND_REGISTRY: dict[str, type[SamplingBackend]] = {}
-_DEFAULT_BACKEND = "flashinfer"
+
+
+def _get_default_backend_name() -> str:
+    if current_platform().is_nvidia:
+        return "flashinfer"
+    return "greedy"
+
+
+def _resolve_backend_name(server_args: ServerArgs) -> str:
+    return server_args.sampling_backend or _get_default_backend_name()
 
 
 def register_backend(name: str, cls: type[SamplingBackend]) -> None:
@@ -58,7 +69,7 @@ def create_sampling_backend(
     )
     from tokenspeed.runtime.sampling.backends import greedy as _g  # noqa: F401
 
-    name = server_args.sampling_backend or _DEFAULT_BACKEND
+    name = _resolve_backend_name(server_args)
     if name not in _BACKEND_REGISTRY:
         raise ValueError(
             f"Unknown sampling backend: {name!r}. "

--- a/test/runtime/test_sampling_backend_registry.py
+++ b/test/runtime/test_sampling_backend_registry.py
@@ -1,0 +1,38 @@
+"""Regression tests for sampling backend registry defaults."""
+
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+# CI Registration (parsed via AST, runtime no-op)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=10, suite="runtime-1gpu")
+
+from tokenspeed.runtime.sampling import registry  # noqa: E402
+
+
+class TestSamplingBackendRegistryDefaults(unittest.TestCase):
+    def test_unresolved_default_uses_flashinfer_on_nvidia(self):
+        platform = SimpleNamespace(is_nvidia=True)
+        server_args = SimpleNamespace(sampling_backend=None)
+
+        with mock.patch.object(registry, "current_platform", return_value=platform):
+            self.assertEqual(registry._resolve_backend_name(server_args), "flashinfer")
+
+    def test_unresolved_default_uses_greedy_on_non_nvidia(self):
+        platform = SimpleNamespace(is_nvidia=False)
+        server_args = SimpleNamespace(sampling_backend=None)
+
+        with mock.patch.object(registry, "current_platform", return_value=platform):
+            self.assertEqual(registry._resolve_backend_name(server_args), "greedy")
+
+    def test_explicit_backend_is_preserved(self):
+        platform = SimpleNamespace(is_nvidia=False)
+        server_args = SimpleNamespace(sampling_backend="flashinfer")
+
+        with mock.patch.object(registry, "current_platform", return_value=platform):
+            self.assertEqual(registry._resolve_backend_name(server_args), "flashinfer")


### PR DESCRIPTION
## Summary
- make sampling registry fallback match ServerArgs platform-aware default
- keep flashinfer as the implicit default only on NVIDIA; use greedy on non-NVIDIA/AMD
- add a regression test for unresolved sampling backend defaults and explicit backend preservation

## Root cause
ServerArgs.resolve_kernel_backends() already defaults AMD/non-NVIDIA to greedy, but the lower-level sampling registry had its own hard-coded fallback of flashinfer when server_args.sampling_backend was still None. Any path that constructs the backend from an unresolved or partially reconstructed ServerArgs can therefore select flashinfer on AMD even though FlashInfer sampling kernels are NVIDIA-only.

The AMD eval job linked in run 25830917431 was canceled before it reached server/eval, so its artifact does not contain a sampling traceback. The code root cause is this inconsistent fallback; it was latent from the initial registry implementation and became easier to hit after the flashinfer sampling optimization work expanded that backend path.

## Test
- env PYTHONPATH=/home/runner/tokenspeed-amd-sampling/python:/home/runner/tokenspeed-amd-sampling/tokenspeed-kernel/python python3 -m pytest test/runtime/test_sampling_backend_registry.py test/runtime/test_server_args_attention_backends.py
- pre-commit run --files python/tokenspeed/runtime/sampling/registry.py test/runtime/test_sampling_backend_registry.py