### PR TITLE
feat(cli): default smg gateway log level to warn

### DIFF
--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -47,6 +47,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_GATEWAY_HOST = "0.0.0.0"
 DEFAULT_GATEWAY_PORT = 8000
 DEFAULT_REASONING_PARSER = "none"
+DEFAULT_SMG_LOG_LEVEL = "warn"
 # smg reliability knobs we always want disabled when launched under
 # ts serve. These are tokenspeed-internal defaults: not surfaced via
 # the ts CLI, not routed through split_argv.
@@ -119,10 +120,17 @@ def _gateway_args_with_smg_disable_defaults(gateway_args: list[str]) -> list[str
     return result
 
 
+def _gateway_args_with_default_log_level(gateway_args: list[str]) -> list[str]:
+    if "--log-level" in gateway_args:
+        return gateway_args
+    return [*gateway_args, "--log-level", DEFAULT_SMG_LOG_LEVEL]
+
+
 def _gateway_args_with_defaults(gateway_args: list[str]) -> list[str]:
     gateway_args = _gateway_args_with_default_port(gateway_args)
     gateway_args = _gateway_args_with_default_reasoning_parser(gateway_args)
-    return _gateway_args_with_smg_disable_defaults(gateway_args)
+    gateway_args = _gateway_args_with_smg_disable_defaults(gateway_args)
+    return _gateway_args_with_default_log_level(gateway_args)
 
 
 async def _stream_to(proc, tag: str) -> None:

--- a/test/cli/test_serve_smg_unit.py
+++ b/test/cli/test_serve_smg_unit.py
@@ -36,6 +36,7 @@ sys.path.insert(0, os.path.join(REPO_ROOT, "python"))
 from tokenspeed.cli._argsplit import OrchestratorOpts
 from tokenspeed.cli.serve_smg import (
     _DEFAULT_SMG_DISABLE_FLAGS,
+    _gateway_args_with_default_log_level,
     _gateway_args_with_default_port,
     _gateway_args_with_default_reasoning_parser,
     _gateway_args_with_defaults,
@@ -98,7 +99,21 @@ def test_gateway_args_defaults_include_port_and_reasoning_parser():
         "none",
         "--disable-circuit-breaker",
         "--disable-retries",
+        "--log-level",
+        "warn",
     ]
+
+
+def test_gateway_args_default_log_level_is_warn():
+    gateway_args = _gateway_args_with_default_log_level(["--model", "/tmp/x"])
+
+    assert gateway_args == ["--model", "/tmp/x", "--log-level", "warn"]
+
+
+def test_gateway_args_preserve_user_log_level():
+    gateway_args = _gateway_args_with_default_log_level(["--log-level", "debug"])
+
+    assert gateway_args == ["--log-level", "debug"]
 
 
 def test_smg_disable_flags_appended_when_absent():


### PR DESCRIPTION
## Summary

- `ts serve` now passes `--log-level warn` to the smg gateway at startup. smg's own default is `info`, which produces per-request log lines; bumping the floor to `warn` keeps important state transitions and errors visible while quieting the steady stream.
- The injector follows the existing port / reasoning-parser pattern: it only adds the flag when the user has not supplied their own `--log-level`, so `ts serve --log-level debug ...` still works for ad-hoc debugging.
- Choices come from [smg's reliability/logging docs](https://lightseek.org/smg/getting-started/reliability-controls/) and `RouterArgs.add_cli_args` (`debug` / `info` / `warn` / `error`).

## Test plan

- [x] `pre-commit run --all-files`
- [x] `pytest test/cli/test_serve_smg_unit.py -v` — 18 passed locally (2 new cases: default injected when absent, user value preserved; combined-defaults helper now emits `--log-level warn` after the disable flags).