### PR TITLE
chore(ci): drop `--stream` and generation-config from gpt-oss gpqa eval

### DIFF
--- a/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
+++ b/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
@@ -49,8 +49,6 @@ eval:
     --api-key EMPTY_TOKEN
     --datasets gpqa_diamond
     --eval-batch-size 16
-    --stream
-    --generation-config '{"do_sample":false,"temperature":0.0,"max_tokens":65536}'
 report:
   github_step_summary: true
 score_threshold: 0.7


### PR DESCRIPTION
## Summary

- Remove the trailing `--stream` and `--generation-config '{"do_sample":false,"temperature":0.0,"max_tokens":65536}'` lines from `test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml`. The eval now falls back to evalscope's own defaults for those knobs.

## Test plan

- [x] `pre-commit run --files test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml`
- [ ] `eval-gpt-oss-120b-mxfp4-gpqa-diamond` per-commit task runs on this PR — score still meeting the existing `score_threshold: 0.7` bar is the merge gate.