### PR TITLE
chore: cleanup noqa

### DIFF
--- a/python/tokenspeed/runtime/cache/prefix_cache.py
+++ b/python/tokenspeed/runtime/cache/prefix_cache.py
@@ -644,17 +644,3 @@ class PrefixCache(BasePrefixCache):
                 continue
             block_hash = hash(tuple(page_tokens))
             self.kv_event_queue.append(BlockRemoved(block_hashes=[block_hash]))
-
-
-if __name__ == "__main__":
-    params = CacheInitParams(
-        req_to_token_pool=None, token_to_kv_pool_allocator=None, disable=False
-    )
-    tree = PrefixCache(params=params)
-    tree.insert([(1, 2), (3, 4)], [torch.tensor([1, 2]), torch.tensor([3, 4])])
-    tree.insert(
-        [(1, 2), (3, 4), (5, 6)],
-        [torch.tensor([1, 2]), torch.tensor([6, 5]), torch.tensor([7, 8])],
-    )
-    tree.pretty_print()
-    print(tree.match_prefix([(1, 2), (3, 4)]))

--- a/python/tokenspeed/runtime/distributed/utils.py
+++ b/python/tokenspeed/runtime/distributed/utils.py
@@ -163,7 +163,7 @@ class StatelessProcessGroup:
         used for exchanging metadata. With this function, process A and process B
         can call `StatelessProcessGroup.create` to form a group, and then process A, B,
         C, and D can call `StatelessProcessGroup.create` to form another group.
-        """  # noqa
+        """
         store = TCPStore(
             host_name=host,
             port=port,

--- a/python/tokenspeed/runtime/layers/attention/linear/causal_conv1d.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/causal_conv1d.py
@@ -118,7 +118,7 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     else:
         # cache_idx
         conv_state_batch_coord = idx_seq
-    if USE_PAD_SLOT:  # noqa
+    if USE_PAD_SLOT:
         if conv_state_batch_coord == pad_slot_id:
             # not processing as this is not the actual sequence
             return
@@ -716,7 +716,7 @@ def _causal_conv1d_update_kernel(
         ).to(tl.int64)
     else:
         conv_state_batch_coord = idx_seq
-    if USE_PAD_SLOT:  # noqa
+    if USE_PAD_SLOT:
         if conv_state_batch_coord == pad_slot_id:
             # not processing as this is not the actual sequence
             return

--- a/python/tokenspeed/runtime/layers/rotary_embedding.py
+++ b/python/tokenspeed/runtime/layers/rotary_embedding.py
@@ -231,7 +231,7 @@ class LinearScalingRotaryEmbedding(RotaryEmbedding):
     ) -> None:
         if isinstance(scaling_factors, float):
             scaling_factors = [scaling_factors]
-        self.scaling_factors: List[float] = scaling_factors  # noqa
+        self.scaling_factors: List[float] = scaling_factors
         super().__init__(
             head_size, rotary_dim, max_position_embeddings, base, is_neox_style, dtype
         )

--- a/python/tokenspeed/runtime/model_loader/loader.py
+++ b/python/tokenspeed/runtime/model_loader/loader.py
@@ -214,7 +214,6 @@ class DefaultModelLoader(BaseModelLoader):
         if envs.TOKENSPEED_USE_MODELSCOPE.is_set():
             # download model from ModelScope hub,
             # lazy import so that modelscope is not required for normal use.
-            # pylint: disable=C.
             from modelscope.hub.snapshot_download import snapshot_download
 
             if not os.path.exists(model):

--- a/python/tokenspeed/runtime/model_loader/weight_utils.py
+++ b/python/tokenspeed/runtime/model_loader/weight_utils.py
@@ -67,7 +67,7 @@ def enable_hf_transfer():
     if "HF_HUB_ENABLE_HF_TRANSFER" not in os.environ:
         try:
             # enable hf hub transfer if available
-            import hf_transfer  # type: ignore # noqa
+            import hf_transfer  # type: ignore
 
             huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER = True
         except ImportError:


### PR DESCRIPTION
Cleanup of stale bare `# noqa` markers under `python/tokenspeed/runtime/`.