### PR TITLE
fix(cli): prewarm HF tokenizer cache before launching smg gateway

### DIFF
--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import os
 import signal
 import sys
 
@@ -125,6 +126,47 @@ def _gateway_args_with_default_log_level(gateway_args: list[str]) -> list[str]:
     if "--log-level" in gateway_args:
         return gateway_args
     return [*gateway_args, "--log-level", DEFAULT_SMG_LOG_LEVEL]
+
+
+def _user_model_id(gateway_args: list[str]) -> str | None:
+    """Return the value of ``--model`` from a split gateway argv, or ``None``."""
+    try:
+        idx = gateway_args.index("--model")
+    except ValueError:
+        return None
+    if idx + 1 >= len(gateway_args):
+        return None
+    return gateway_args[idx + 1]
+
+
+def _prewarm_hf_tokenizer(model_id: str) -> None:
+    """Download tokenizer artifacts to the HF cache before the gateway boots.
+
+    smg fires its ``AddTokenizer`` job asynchronously after the engine
+    reports SERVING. On fast runners (e.g. b300) the first eval request
+    can race that fetch and fail with ``tokenizer_not_found``. Pulling
+    tokenizer files into the HF cache up front keeps the registration
+    fast regardless of engine startup speed.
+    """
+    if not model_id or os.path.isdir(model_id):
+        return
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError:
+        return
+    try:
+        snapshot_download(
+            repo_id=model_id,
+            allow_patterns=[
+                "tokenizer*",
+                "special_tokens_map*",
+                "vocab*",
+                "merges*",
+                "*.json",
+            ],
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("HF tokenizer prewarm failed for %s: %s", model_id, exc)
 
 
 def _gateway_args_with_defaults(gateway_args: list[str]) -> list[str]:
@@ -341,6 +383,10 @@ def run_smg_from_args(args: argparse.Namespace, raw_argv: list[str]) -> None:
     engine_args = _overwrite_sampling_backend(split.engine)
     gateway_args = _gateway_args_with_defaults(split.gateway)
     user_host, user_port = _user_host_port_from_gateway_args(gateway_args)
+
+    model_id = _user_model_id(gateway_args)
+    if model_id is not None:
+        _prewarm_hf_tokenizer(model_id)
     rc = asyncio.run(
         run_smg(
             engine_args=engine_args,

--- a/test/cli/test_serve_smg_unit.py
+++ b/test/cli/test_serve_smg_unit.py
@@ -41,7 +41,9 @@ from tokenspeed.cli.serve_smg import (
     _gateway_args_with_default_reasoning_parser,
     _gateway_args_with_defaults,
     _gateway_args_with_smg_disable_defaults,
+    _prewarm_hf_tokenizer,
     _user_host_port_from_gateway_args,
+    _user_model_id,
     run_smg,
 )
 
@@ -144,6 +146,56 @@ def test_smg_disable_flag_set_covers_both():
         "--disable-circuit-breaker",
         "--disable-retries",
     )
+
+
+def test_user_model_id_extracts_value():
+    assert (
+        _user_model_id(["--model", "nvidia/Qwen3.5-397B-A17B-NVFP4", "--port", "8000"])
+        == "nvidia/Qwen3.5-397B-A17B-NVFP4"
+    )
+
+
+def test_user_model_id_returns_none_when_absent():
+    assert _user_model_id(["--port", "8000"]) is None
+
+
+def test_user_model_id_returns_none_when_model_lacks_value():
+    assert _user_model_id(["--model"]) is None
+
+
+def test_prewarm_skips_local_path(tmp_path):
+    with patch(
+        "huggingface_hub.snapshot_download", side_effect=AssertionError("must not call")
+    ) as sd:
+        _prewarm_hf_tokenizer(str(tmp_path))
+    sd.assert_not_called()
+
+
+def test_prewarm_skips_empty():
+    with patch("huggingface_hub.snapshot_download") as sd:
+        _prewarm_hf_tokenizer("")
+    sd.assert_not_called()
+
+
+def test_prewarm_fetches_tokenizer_artifacts_for_hf_id():
+    with patch("huggingface_hub.snapshot_download") as sd:
+        _prewarm_hf_tokenizer("nvidia/Qwen3.5-397B-A17B-NVFP4")
+    sd.assert_called_once()
+    _, kwargs = sd.call_args
+    assert kwargs["repo_id"] == "nvidia/Qwen3.5-397B-A17B-NVFP4"
+    # Patterns must include tokenizer.json and the surrounding JSON configs;
+    # avoid pulling weight files (no `*.safetensors` etc.).
+    patterns = set(kwargs["allow_patterns"])
+    assert "tokenizer*" in patterns
+    assert "*.json" in patterns
+
+
+def test_prewarm_swallows_download_errors():
+    with patch(
+        "huggingface_hub.snapshot_download", side_effect=RuntimeError("HF down")
+    ):
+        # Must not raise — smg's own retry path is the fallback.
+        _prewarm_hf_tokenizer("nvidia/Qwen3.5-397B-A17B-NVFP4")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

\`smg\` fires its \`AddTokenizer\` job asynchronously once the engine reports SERVING. On fast runners (e.g. b300) the engine finishes loading weights before that fetch lands, so the first eval request races the registration and the gateway answers \`tokenizer_not_found\` (HTTP 500). Same eval config on b200 only succeeds because its slower engine warm-up gives the async fetch enough runway. Reproducer (failing): [eval-qwen3.5-397b-a17b-nvfp4-aime25 / b300-4gpu](https://github.com/lightseekorg/tokenspeed/actions/runs/25852380610/job/75961843081).

The fix pulls tokenizer artifacts into the local HF cache from \`ts serve\` itself before the gateway boots:

- \`_user_model_id\` extracts the user's \`--model\` value from the split gateway argv (None for missing flag / trailing bare flag).
- \`_prewarm_hf_tokenizer\` calls \`huggingface_hub.snapshot_download(repo_id=..., allow_patterns=["tokenizer*", "special_tokens_map*", "vocab*", "merges*", "*.json"])\`. Patterns are tokenizer / config-only — no \`*.safetensors\`, so weight files keep flowing through the engine's own loader. Local paths skip, missing \`huggingface_hub\` skips, download exceptions log + swallow so smg's own retry path stays the fallback.

By the time smg's tokenizer-registration job runs, the artifacts are already on disk; registration completes immediately regardless of how fast the engine reaches SERVING.

## Test plan

- [x] \`pre-commit run --files python/tokenspeed/cli/serve_smg.py test/cli/test_serve_smg_unit.py\`
- [x] \`pytest test/cli/test_serve_smg_unit.py -v\` — 25 passed locally. 6 new cases cover: \`_user_model_id\` extract / missing flag / trailing bare flag, and \`_prewarm_hf_tokenizer\` local-path skip / empty skip / HF id snapshot-download invocation pattern / swallowed download error.
- [ ] \`eval-qwen3.5-397b-a17b-nvfp4-aime25 / b300-4gpu\` (the original failure) re-runs green on this PR.