### PR TITLE
perf: limit grid for per-layer h2d copy

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
@@ -22,9 +22,13 @@
 
 from __future__ import annotations
 
+import os
+
 import torch
 from tokenspeed_kernel._triton import tl, triton
 from tokenspeed_kernel.platform import current_platform
+
+_PER_LAYER_GRID_CAP = int(os.environ.get("TOKENSPEED_KV_GRID_CAP", "64"))
 
 _is_nvidia = current_platform().is_nvidia
 
@@ -32,6 +36,34 @@ __all__ = [
     "transfer_kv_all_layer",
     "transfer_kv_per_layer",
 ]
+
+
+@triton.jit
+def _kv_transfer_per_layer_capped_kernel(
+    k_cache_dst_ptr,
+    v_cache_dst_ptr,
+    indices_dst_ptr,
+    k_cache_src_ptr,
+    v_cache_src_ptr,
+    indices_src_ptr,
+    kv_cache_src_stride,
+    kv_cache_dst_stride,
+    length,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Grid-capped variant: each program strides over multiple indices."""
+    pid = tl.program_id(0)
+    nprog = tl.num_programs(0)
+    offs = tl.arange(0, BLOCK_SIZE)
+    for i in range(pid, length, nprog):
+        pos_src = tl.load(indices_src_ptr + i).to(tl.int64)
+        pos_dst = tl.load(indices_dst_ptr + i).to(tl.int64)
+        src_offset = pos_src * kv_cache_src_stride
+        dst_offset = pos_dst * kv_cache_dst_stride
+        k_src = tl.load(k_cache_src_ptr + src_offset + offs)
+        tl.store(k_cache_dst_ptr + dst_offset + offs, k_src)
+        v_src = tl.load(v_cache_src_ptr + src_offset + offs)
+        tl.store(v_cache_dst_ptr + dst_offset + offs, v_src)
 
 
 @triton.jit
@@ -297,6 +329,22 @@ def transfer_kv_per_layer(
 
     # BLOCK_SIZE is in elements, must be power of two and cover element_dim
     block_size = _next_power_of_two(element_dim)
+
+    cap = _PER_LAYER_GRID_CAP
+    if cap > 0 and length > cap:
+        _kv_transfer_per_layer_capped_kernel[(cap,)](
+            k_cache_dst_flat,
+            v_cache_dst_flat,
+            dst_indices,
+            k_cache_src_flat,
+            v_cache_src_flat,
+            src_indices,
+            kv_cache_src_stride,
+            kv_cache_dst_stride,
+            length,
+            BLOCK_SIZE=block_size,
+        )
+        return
 
     grid = (length,)
     _kv_transfer_per_layer_kernel[grid](


### PR DESCRIPTION
## Summary

The triton kernel for per layer kv transfer will compete sm with model forward (especially moe kernel):
<img width="2910" height="570" alt="image" src="https://github.com/user-attachments/assets/121ce8f7-18b5-4721-9aa1-89de976cbcad" />

after the fix:
<img width="3246" height="760" alt="image" src="https://github.com/user-attachments/assets/2698ba24-71b6-408a-9952-8953db427a55" />

currently only cap the grid size to 64 for better copy perf.

standalone test, grid size 64 could saturate copy bandwidth:
```
  Standalone microbench (B200, length=32 K × 2 KB/slot = 134 MB K+V, contention = autotuned trtllm_bf16_moe H=7168 I=2048 E=32 K=8 T=4096)                                            
    
  ┌─────────────────┬───────────┬───────────┬──────────────────────┬────────────────────────────────┐                                                                                 
  │      grid       │ Copy time │  Copy BW  │ MoE under contention │ MoE slowdown vs solo (3.19 ms) │
  ├─────────────────┼───────────┼───────────┼──────────────────────┼────────────────────────────────┤                                                                                 
  │ uncapped (32 K) │   2.64 ms │ 50.9 GB/s │              5.18 ms │                          1.63× │
  ├─────────────────┼───────────┼───────────┼──────────────────────┼────────────────────────────────┤
  │              32 │   4.03 ms │ 33.3 GB/s │              3.19 ms │                          1.01× │                                                                                 
  ├─────────────────┼───────────┼───────────┼──────────────────────┼────────────────────────────────┤                                                                                 
  │              48 │   3.05 ms │ 44.0 GB/s │              3.38 ms │                          1.06× │                                                                                 
  ├─────────────────┼───────────┼───────────┼──────────────────────┼────────────────────────────────┤                                                                                 
  │              64 │   2.69 ms │ 48.7 GB/s │              3.66 ms │                          1.13× │
  ├─────────────────┼───────────┼───────────┼──────────────────────┼────────────────────────────────┤                                                                                 
  │              96 │   2.66 ms │ 50.5 GB/s │              4.19 ms │                          1.31× │
  ├─────────────────┼───────────┼───────────┼──────────────────────┼────────────────────────────────┤                                                                                 
  │             148 │   2.64 ms │ 50.8 GB/s │              5.18 ms │                          1.62× │
  └─────────────────┴───────────┴───────────┴──────────────────────┴────────────────────────────────┘
```

```
  End-to-end nsys A/B/C (B200, mm25 FP4 + EAGLE3, TP=2, KVStore enabled, 80-prefix forced-eviction workload, 30 s GPU trace each)                                                     
                                           
  ┌─────────────────────┬─────────────────────┬─────────────────────┬───────────────────┬────────────────────┐                                                                        
  │       Config        │ Per-layer copy avg  │ Per-layer instances │ MoE FP4 GEMM avg  │ MoE GEMM instances │
  ├─────────────────────┼─────────────────────┼─────────────────────┼───────────────────┼────────────────────┤                                                                        
  │ Baseline (uncapped) │             1666 us │                 504 │          178.4 us │             25,943 │
  ├─────────────────────┼─────────────────────┼─────────────────────┼───────────────────┼────────────────────┤
  │ cap=48              │     2596 us (+56 %) │                 504 │ 172.6 us (-3.3 %) │             27,857 │                                                                        
  ├─────────────────────┼─────────────────────┼─────────────────────┼───────────────────┼────────────────────┤                                                                        
  │ cap=64              │ 1661 us (≈baseline) │                 756 │ 164.4 us (-7.8 %) │             27,480 │                                                                        
  └─────────────────────┴─────────────────────┴─────────────────────┴───────────────────┴────────────────────┘
```

cap 64 is good for the current impl. We shall consider writing better kernels with limited grid size next.


## Test Plan

<!-- How was this validated? -->
