### PR TITLE
fix(cli): pin smg prometheus port to 8413 by default

### DIFF
--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -51,6 +51,7 @@ DEFAULT_GATEWAY_HOST = "0.0.0.0"
 DEFAULT_GATEWAY_PORT = 8000
 DEFAULT_REASONING_PARSER = "none"
 DEFAULT_SMG_LOG_LEVEL = "warn"
+DEFAULT_SMG_PROMETHEUS_PORT = 8413
 # smg reliability knobs we always want disabled when launched under
 # ts serve. These are tokenspeed-internal defaults: not surfaced via
 # the ts CLI, not routed through split_argv.
@@ -128,6 +129,22 @@ def _gateway_args_with_default_log_level(gateway_args: list[str]) -> list[str]:
     return [*gateway_args, "--log-level", DEFAULT_SMG_LOG_LEVEL]
 
 
+def _gateway_args_with_default_prometheus_port(gateway_args: list[str]) -> list[str]:
+    """Pin the smg Prometheus exporter to ``DEFAULT_SMG_PROMETHEUS_PORT``.
+
+    smg's own default (``29000``) collides easily when multiple ``ts serve``
+    instances share a host or when a previous run hasn't released the
+    port yet — the gateway then exits early and the tokenizer
+    registration job never runs, surfacing later as
+    ``tokenizer_not_found`` on the first request. Pinning a tokenspeed-
+    specific default keeps the port stable for our deployments while
+    still allowing an explicit override.
+    """
+    if "--prometheus-port" in gateway_args:
+        return gateway_args
+    return [*gateway_args, "--prometheus-port", str(DEFAULT_SMG_PROMETHEUS_PORT)]
+
+
 def _user_model_id(gateway_args: list[str]) -> str | None:
     """Return the value of ``--model`` from a split gateway argv, or ``None``."""
     try:
@@ -173,7 +190,8 @@ def _gateway_args_with_defaults(gateway_args: list[str]) -> list[str]:
     gateway_args = _gateway_args_with_default_port(gateway_args)
     gateway_args = _gateway_args_with_default_reasoning_parser(gateway_args)
     gateway_args = _gateway_args_with_smg_disable_defaults(gateway_args)
-    return _gateway_args_with_default_log_level(gateway_args)
+    gateway_args = _gateway_args_with_default_log_level(gateway_args)
+    return _gateway_args_with_default_prometheus_port(gateway_args)
 
 
 def _overwrite_sampling_backend(engine_args: list[str]) -> list[str]:

--- a/test/cli/test_serve_smg_unit.py
+++ b/test/cli/test_serve_smg_unit.py
@@ -38,6 +38,7 @@ from tokenspeed.cli.serve_smg import (
     _DEFAULT_SMG_DISABLE_FLAGS,
     _gateway_args_with_default_log_level,
     _gateway_args_with_default_port,
+    _gateway_args_with_default_prometheus_port,
     _gateway_args_with_default_reasoning_parser,
     _gateway_args_with_defaults,
     _gateway_args_with_smg_disable_defaults,
@@ -103,6 +104,8 @@ def test_gateway_args_defaults_include_port_and_reasoning_parser():
         "--disable-retries",
         "--log-level",
         "warn",
+        "--prometheus-port",
+        "8413",
     ]
 
 
@@ -116,6 +119,20 @@ def test_gateway_args_preserve_user_log_level():
     gateway_args = _gateway_args_with_default_log_level(["--log-level", "debug"])
 
     assert gateway_args == ["--log-level", "debug"]
+
+
+def test_gateway_args_default_prometheus_port_is_8413():
+    gateway_args = _gateway_args_with_default_prometheus_port(["--model", "/tmp/x"])
+
+    assert gateway_args == ["--model", "/tmp/x", "--prometheus-port", "8413"]
+
+
+def test_gateway_args_preserve_user_prometheus_port():
+    gateway_args = _gateway_args_with_default_prometheus_port(
+        ["--prometheus-port", "29000"]
+    )
+
+    assert gateway_args == ["--prometheus-port", "29000"]
 
 
 def test_smg_disable_flags_appended_when_absent():


### PR DESCRIPTION
## Summary

\`smg\`'s built-in default for \`--prometheus-port\` is \`29000\` (see [smg `router_args.py`](https://github.com/lightseekorg/smg/blob/tokenspeed-smg/bindings/python/src/smg/router_args.py#L543-L547)). On a single host that hosts more than one \`ts serve\` (or where a previous run hasn't released the port yet), the gateway can't bind the metrics exporter and exits early. The worker still finishes registering on the gRPC side, but the tokenizer-registration job that runs in the gateway's lifecycle never executes — the first eval request surfaces it later as \`tokenizer_not_found\` (HTTP 500). Keyang traced the recent b300 flake to this exact path.

Inject \`--prometheus-port 8413\` from \`_gateway_args_with_defaults\` when the operator hasn't already passed one. Same idempotent pattern as \`--port\`, \`--reasoning-parser\`, \`--log-level\`. Explicit overrides win:

```bash
ts serve ... --prometheus-port 29000   # operator-chosen port still applied
```

## Test plan

- [x] \`pre-commit run --files python/tokenspeed/cli/serve_smg.py test/cli/test_serve_smg_unit.py\`
- [x] \`pytest test/cli/test_serve_smg_unit.py -v\` — 27 passed locally. Two new cases cover \`_gateway_args_with_default_prometheus_port\` (default injected when absent, user value preserved when set); the combined-defaults helper now emits \`--prometheus-port 8413\` after \`--log-level warn\`.