### PR TITLE
ci(pipeline): pkill `smg::router` in stale-process cleanup

### DIFF
--- a/test/ci_system/pipeline.py
+++ b/test/ci_system/pipeline.py
@@ -35,6 +35,10 @@ B200_RUNNER_LABEL_ENV = "TOKENSPEED_B200_RUNNER_LABEL"
 STALE_PROCESS_PATTERNS = [
     r"ts serve",
     r"python.*-m\s+smg(\s|\.launch|$)",
+    # smg's launch_router rewrites its cmdline to `smg::router` via
+    # setproctitle, so the python pattern above stops matching once
+    # the router is fully up.
+    r"smg::",
     r"smg_grpc_servicer\.tokenspeed",
     r"run_ci_suite",
 ]

--- a/test/ci_system/test_pipeline.py
+++ b/test/ci_system/test_pipeline.py
@@ -1,10 +1,40 @@
+import re
+
 import pytest
 from pipeline import (
+    STALE_PROCESS_PATTERNS,
     build_step_summary_lines,
     check_perf_reference,
     extract_evalscope_score,
     extract_perf_summary_rows,
 )
+
+
+def test_stale_process_patterns_match_smg_router_proctitle():
+    """`smg launch` rewrites its cmdline to `smg::router` via setproctitle;
+    the cleanup list must still match after that, otherwise stale routers
+    survive between runs and the next run hits port-bind conflicts."""
+    sample_cmdlines = [
+        "smg::router",
+        "smg::router --worker-urls grpc://127.0.0.1:1234",
+    ]
+    for cmdline in sample_cmdlines:
+        assert any(
+            re.search(pat, cmdline) for pat in STALE_PROCESS_PATTERNS
+        ), f"no STALE_PROCESS_PATTERNS entry matched cmdline: {cmdline!r}"
+
+
+def test_stale_process_patterns_match_existing_targets():
+    cmdlines = [
+        "/usr/bin/python /usr/local/bin/ts serve --model foo",
+        "/usr/bin/python -m smg launch --worker-urls grpc://127.0.0.1:1234",
+        "/usr/bin/python -m smg_grpc_servicer.tokenspeed --host 127.0.0.1",
+        "/usr/bin/python /repo/test/runtime/run_ci_suite.py --device cuda",
+    ]
+    for cmdline in cmdlines:
+        assert any(
+            re.search(pat, cmdline) for pat in STALE_PROCESS_PATTERNS
+        ), f"no STALE_PROCESS_PATTERNS entry matched cmdline: {cmdline!r}"
 
 
 def test_extract_evalscope_score_from_pipe_table():


### PR DESCRIPTION
## Summary

smg's [\`launch_router.py:32\`](https://github.com/lightseekorg/smg/blob/tokenspeed-smg/bindings/python/src/smg/launch_router.py#L32) rewrites the router's cmdline to \`smg::router\` via \`setproctitle\`. Once that runs, the existing \`r"python.*-m\s+smg(\s|\.launch|$)"\` entry in \`STALE_PROCESS_PATTERNS\` no longer matches, so a crashed-or-stuck router from a previous run survives the per-job cleanup. The next run's \`smg launch\` then fails to bind sockets — most visibly the metrics port — and the worker registration ends without ever firing the tokenizer-registration job, which downstream surfaces as \`tokenizer_not_found\` on the first eval request.

Adds \`r"smg::"\` to \`STALE_PROCESS_PATTERNS\` (covers \`smg::router\` plus any future \`smg::*\` subsystems) and pin-down tests for both the new pattern and the existing entries.

## Test plan

- [x] \`pre-commit run --files test/ci_system/pipeline.py test/ci_system/test_pipeline.py\`
- [x] \`cd test/ci_system && pytest test_pipeline.py::test_stale_process_patterns_match_smg_router_proctitle test_pipeline.py::test_stale_process_patterns_match_existing_targets -v\` — 2 passed.