### PR TITLE
fix(ci): scope stale-process cleanup to our own pgid on b200/b300

### DIFF
--- a/test/ci_system/pipeline.py
+++ b/test/ci_system/pipeline.py
@@ -47,7 +47,7 @@ STALE_PROCESS_PATTERNS = [
 # physical host share the network namespace and process table, so
 # the cmdline-pattern fallback above would TERM/KILL peer jobs'
 # smg / engine / ts serve processes alongside our own.
-PGM_RUNNER_PREFIXES = ("b200-", "b300-", "gb200-", "gb300-")
+PGM_RUNNER_PREFIXES = ("b200-", "b300-", "gb200-")
 RUNNER_SM_PREFIXES = (
     (("h100", "h200"), "sm90"),
     (("b200", "gb200"), "sm100"),
@@ -352,8 +352,8 @@ def setup_runner(
         return local_env, pgm
 
     if runner_uses_pgm(runner):
-        # b200 / b300 / gb300: scope stale-process cleanup to our own
-        # pgid. The broad cmdline-pattern fallback would kill any
+        # b200 / b300: scope stale-process cleanup to our own pgid.
+        # The broad cmdline-pattern fallback would kill any
         # concurrently-running peer job's smg / engine / ts serve
         # processes on the same physical host.
         pgm = make_manager()

--- a/test/ci_system/pipeline.py
+++ b/test/ci_system/pipeline.py
@@ -42,6 +42,12 @@ STALE_PROCESS_PATTERNS = [
     r"smg_grpc_servicer\.tokenspeed",
     r"run_ci_suite",
 ]
+# Bare-metal pools whose stale-process cleanup must be scoped to our
+# own pgid via ProcessGroupManager. Concurrent jobs on the same
+# physical host share the network namespace and process table, so
+# the cmdline-pattern fallback above would TERM/KILL peer jobs'
+# smg / engine / ts serve processes alongside our own.
+PGM_RUNNER_PREFIXES = ("b200-", "b300-", "gb200-", "gb300-")
 RUNNER_SM_PREFIXES = (
     (("h100", "h200"), "sm90"),
     (("b200", "gb200"), "sm100"),
@@ -53,6 +59,10 @@ AMD_RUNNER_PREFIXES = ("linux-mi355",)
 
 def is_amd_runner(runner: str) -> bool:
     return runner.startswith(AMD_RUNNER_PREFIXES)
+
+
+def runner_uses_pgm(runner: str) -> bool:
+    return runner.startswith(PGM_RUNNER_PREFIXES)
 
 
 def load_yaml(path: Path) -> Dict[str, Any]:
@@ -341,7 +351,17 @@ def setup_runner(
         )
         return local_env, pgm
 
-    kill_stale_processes(local_env, cwd, dry_run)
+    if runner_uses_pgm(runner):
+        # b200 / b300 / gb300: scope stale-process cleanup to our own
+        # pgid. The broad cmdline-pattern fallback would kill any
+        # concurrently-running peer job's smg / engine / ts serve
+        # processes on the same physical host.
+        pgm = make_manager()
+        local_env["CI_RUNNER_ID"] = pgm.runner_id
+        print(f"[pgm] runner={runner} runner_id={pgm.runner_id}", flush=True)
+        pgm.cleanup_stale(dry_run=dry_run)
+    else:
+        kill_stale_processes(local_env, cwd, dry_run)
     shell_run("sudo apt-get update -q", env=local_env, cwd=cwd, dry_run=dry_run)
     shell_run(
         "sudo apt-get install -y ninja-build",

--- a/test/ci_system/test_pipeline.py
+++ b/test/ci_system/test_pipeline.py
@@ -46,7 +46,6 @@ def test_stale_process_patterns_match_existing_targets():
         ("b200-4gpu", True),
         ("b300-4gpu", True),
         ("gb200-1gpu", True),
-        ("gb300-4gpu", True),
         ("h100-1gpu", False),
         ("h200-1gpu", False),
         ("linux-mi355-2gpu-lightseek", False),
@@ -54,8 +53,8 @@ def test_stale_process_patterns_match_existing_targets():
     ],
 )
 def test_runner_uses_pgm_covers_bare_metal_blackwell(runner, expected):
-    """Self-hosted Blackwell pools (b200/b300/gb200/gb300) share the
-    host's network namespace and process table — they need pgid-scoped
+    """Self-hosted Blackwell pools (b200/b300/gb200) share the host's
+    network namespace and process table — they need pgid-scoped
     cleanup so concurrent jobs on the same physical runner don't pkill
     each other's smg / engine / ts serve processes via the broad
     cmdline-pattern fallback."""

--- a/test/ci_system/test_pipeline.py
+++ b/test/ci_system/test_pipeline.py
@@ -2,11 +2,13 @@ import re
 
 import pytest
 from pipeline import (
+    PGM_RUNNER_PREFIXES,
     STALE_PROCESS_PATTERNS,
     build_step_summary_lines,
     check_perf_reference,
     extract_evalscope_score,
     extract_perf_summary_rows,
+    runner_uses_pgm,
 )
 
 
@@ -35,6 +37,36 @@ def test_stale_process_patterns_match_existing_targets():
         assert any(
             re.search(pat, cmdline) for pat in STALE_PROCESS_PATTERNS
         ), f"no STALE_PROCESS_PATTERNS entry matched cmdline: {cmdline!r}"
+
+
+@pytest.mark.parametrize(
+    "runner,expected",
+    [
+        ("b200-1gpu", True),
+        ("b200-4gpu", True),
+        ("b300-4gpu", True),
+        ("gb200-1gpu", True),
+        ("gb300-4gpu", True),
+        ("h100-1gpu", False),
+        ("h200-1gpu", False),
+        ("linux-mi355-2gpu-lightseek", False),
+        ("ubuntu-latest", False),
+    ],
+)
+def test_runner_uses_pgm_covers_bare_metal_blackwell(runner, expected):
+    """Self-hosted Blackwell pools (b200/b300/gb200/gb300) share the
+    host's network namespace and process table — they need pgid-scoped
+    cleanup so concurrent jobs on the same physical runner don't pkill
+    each other's smg / engine / ts serve processes via the broad
+    cmdline-pattern fallback."""
+    assert runner_uses_pgm(runner) is expected
+
+
+def test_pgm_runner_prefixes_are_kebab_terminated():
+    """Trailing dash prevents `gb200` from accidentally matching a
+    future `gb2000-*` runner label, etc."""
+    for prefix in PGM_RUNNER_PREFIXES:
+        assert prefix.endswith("-"), prefix
 
 
 def test_extract_evalscope_score_from_pipe_table():


### PR DESCRIPTION
## Summary

The b300 `eval-qwen3.5-397b-a17b-nvfp4-aime25` job keeps failing with `tokenizer_not_found` after the engine + gateway come up cleanly (most recent run: https://github.com/lightseekorg/tokenspeed/actions/runs/25886853551/job/76080751529). Tracing the symptom back through `test/ci_system/pipeline.py` surfaces a different root cause than the metrics-port collision PR #151 tried to fix.

`setup_runner` for non-`gb200` self-hosted runners runs `kill_stale_processes`, which iterates `STALE_PROCESS_PATTERNS` and shells out to:

```
pkill -TERM -f "ts serve"
pkill -TERM -f "python.*-m\s+smg(\s|\.launch|$)"
pkill -TERM -f "smg::"
pkill -TERM -f "smg_grpc_servicer\.tokenspeed"
pkill -TERM -f "run_ci_suite"
```

`pkill -f` matches against the entire `/proc/<pid>/cmdline` regex and kills every match owned by the current uid — there is no per-job scoping. The b200 / b300 pool is a set of self-hosted bare-metal runners (`pr-test.yml` has no `container:` block) where multiple GitHub-runner agents can be registered on the same physical host. When a second job lands on a host that's already running an eval, its `setup_runner` step TERM/KILLs the first job's smg router, gRPC servicer, and `ts serve` wrapper as "stale". The first job then continues, but the engine has been killed underneath the gateway — `evalscope` posts to `/v1/chat/completions`, smg can't find the tokenizer for the dead worker, and the failure surfaces as `tokenizer_not_found` HTTP 500.

`gb200-*` doesn't have this problem because it already goes through `ProcessGroupManager`: `cleanup_stale()` reads `/tmp/ci-pgid/<runner_id>.pgid` (keyed on `RUNNER_NAME`) and only `killpg`s the pgid owned by this specific runner's previous run. Extending that same scoping to b200 / b300 is the actual fix.

This PR:

- Adds `PGM_RUNNER_PREFIXES = ("b200-", "b300-", "gb200-")` and a `runner_uses_pgm()` helper so the eligible labels live in one place.
- Adds a second branch in `setup_runner` for `b200-*` / `b300-*` that calls `pgm.cleanup_stale()` instead of falling through to the broad `kill_stale_processes()`. The rest of the legacy bare-metal setup (apt-get, ninja-build, cuSparseLt, libcuda lookup) is preserved.
- The `gb200-*` branch is left untouched: it owns a separate per-runner venv / HOME layout that doesn't apply elsewhere.
- `h100-*`, `h200-*`, and the AMD `linux-mi355-*` labels keep the cmdline-pattern fallback because they don't currently run a pgm-tracked agent layout.

Downstream of `setup_runner`, returning a non-`None` `pgm` is already enough to flip stage commands from `start_server` / `shell_run` to `pgm.start` / `pgm.run`, and the `finally` block in `run_task` invokes `pgm.terminate_all()` (pgid-scoped) instead of `stop_server()` / `kill_stale_processes()`. No further wiring needed.

## Test plan

- [x] `cd test/ci_system && python3 -m pytest test_pipeline.py -x -q` — 25 passed locally, including the new parametrized coverage for b200 / b300 / gb200 (pgm path) and h100 / h200 / AMD / ubuntu-latest (legacy path).
- [ ] Re-run the failing matrix entry on the merged main and confirm that two concurrent b300 jobs landing on the same physical host no longer pkill each other's `smg::router` / `ts serve` mid-run.
