### PR TITLE
fix(spec-decode): reject speculative_eagle_topk > 1 at startup

### DIFF
--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -517,6 +517,14 @@ class ServerArgs:
                 int(x) for x in self.eagle3_layers_to_capture.split(",")
             ]
 
+        # Hoist the PD-decode runtime assert (topk == 1) to startup.
+        if self.speculative_algorithm is not None and self.speculative_eagle_topk != 1:
+            raise ValueError(
+                "speculative_eagle_topk > 1 (tree spec) is not currently "
+                f"supported: {self.speculative_eagle_topk=}. Only chain spec "
+                "(topk=1) is wired end-to-end."
+            )
+
     def resolve_communication(self):
         # Auto-enable allreduce fusion on supported single-node TP configurations.
         platform = current_platform()

--- a/test/runtime/test_cli_config_compat.py
+++ b/test/runtime/test_cli_config_compat.py
@@ -481,6 +481,32 @@ class TestCLIConfigCompat(unittest.TestCase):
         self.assertEqual(sa.speculative_num_steps, 1)
         self.assertEqual(sa.speculative_num_draft_tokens, 2)
 
+    def test_speculative_eagle_topk_gt_1_rejected(self):
+        args = self._parse_args(
+            [
+                "--model",
+                "test/model",
+                "--speculative-algorithm",
+                "EAGLE3",
+                "--speculative-eagle-topk",
+                "4",
+            ]
+        )
+        sa = self._from_cli_args_no_init(args)
+        sa.resolve_basic_defaults()
+        with self.assertRaisesRegex(ValueError, "speculative_eagle_topk"):
+            sa.resolve_speculative_decoding()
+
+    def test_speculative_eagle_topk_gt_1_allowed_when_spec_off(self):
+        # topk is only consumed by the spec path, so don't reject when SD is off.
+        args = self._parse_args(
+            ["--model", "test/model", "--speculative-eagle-topk", "4"]
+        )
+        sa = self._from_cli_args_no_init(args)
+        sa.resolve_basic_defaults()
+        sa.resolve_speculative_decoding()
+        self.assertIsNone(sa.speculative_algorithm)
+
     # ---- Full server command example ----
 
     def test_full_server_command(self):


### PR DESCRIPTION
## Summary
`--speculative-eagle-topk` is accepted at the CLI with choices `{1, 2, 4, 8}`. However, I observed that topk > 1 does not seem to be working today:

- The EAGLE drafter uses `torch.argmax` for sampling, so only chain candidates are produced.
- In the FlashAttention backend, `self.topk` is initialized to `0` and is not updated from the config, so the `self.topk > 1` branches are not reachable.
- The PD-decode scheduler has `assert topk == 1, "Tree attention is abandoned for now"` at runtime (`disaggregation_decode_scheduler.py:151`).

This PR adds a `ValueError` in `resolve_speculative_decoding()` when `speculative_algorithm` is set and `speculative_eagle_topk != 1`. The intent is to make the same condition fail at startup, instead of failing inside the PD-decode path. When SD is off, the option is still accepted but not used, which matches the current behavior.

## Test Plan

- [x] `test/runtime/test_cli_config_compat.py::test_speculative_eagle_topk_gt_1_rejected`
- [x] `test/runtime/test_cli_config_compat.py::test_speculative_eagle_topk_gt_1_allowed_when_spec_off`
- [x] `pre-commit run` passes on the changed files.
