### PR TITLE
perf(sampling): fuse min-p renorm in flashinfer full backend

### DIFF
--- a/python/tokenspeed/runtime/sampling/backends/flashinfer_full.py
+++ b/python/tokenspeed/runtime/sampling/backends/flashinfer_full.py
@@ -30,7 +30,10 @@ from tokenspeed_kernel.ops.sampling.flashinfer import (
     top_k_renorm_prob,
     top_p_renorm_prob,
 )
-from tokenspeed_kernel.ops.sampling.triton import gather_and_expand_scalars
+from tokenspeed_kernel.ops.sampling.triton import (
+    gather_and_expand_scalars,
+    min_p_renorm_prob,
+)
 from tokenspeed_kernel.torch_compile import get_compiler_backend
 
 from tokenspeed.runtime.sampling.backends.base import (
@@ -394,18 +397,7 @@ class FlashInferFullSamplingBackend(FlashInferSamplingBackend):
         target_probs = top_k_renorm_prob(target_probs, top_ks)
         target_probs = top_p_renorm_prob(target_probs, top_ps, is_deterministic=True)
 
-        # min_p renorm open-coded: zero probs below `min_p * max_prob` per
-        # row, then renormalize. The chain-speculative-sampling kernel has no
-        # min_p knob, and flashinfer exposes no `min_p_renorm_prob`.
-        max_probs = target_probs.max(dim=-1, keepdim=True).values
-
-        target_probs = torch.where(
-            target_probs >= min_ps.view(-1, 1) * max_probs,
-            target_probs,
-            torch.zeros_like(target_probs),
-        )
-
-        target_probs.div_(target_probs.sum(dim=-1, keepdim=True))
+        target_probs = min_p_renorm_prob(target_probs, min_ps, enable_pdl=pdl_enabled())
 
         target_probs = target_probs.reshape(bs, num_tokens_per_req, -1)
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/triton.py
@@ -18,14 +18,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Triton fused sampling-scalar gather + broadcast kernel."""
+"""Triton sampling helper kernels."""
 
 from __future__ import annotations
 
 import torch
 from tokenspeed_kernel._triton import tl, triton
 
-__all__ = ["gather_and_expand_scalars"]
+__all__ = ["gather_and_expand_scalars", "min_p_renorm_prob"]
 
 
 @triton.jit
@@ -179,3 +179,105 @@ def gather_and_expand_scalars(
     )
 
     return out_temperature, out_top_k, out_top_p, out_min_p, out_seed, out_offsets
+
+
+@triton.jit
+def _min_p_renorm_prob_kernel(
+    probs_ptr,
+    min_p_ptr,
+    out_ptr,
+    vocab_size: tl.constexpr,
+    probs_row_stride: tl.constexpr,
+    out_row_stride: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
+):
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
+    row = tl.program_id(0)
+    offs = tl.arange(0, BLOCK_SIZE)
+    probs_row = probs_ptr + row * probs_row_stride
+    out_row = out_ptr + row * out_row_stride
+
+    max_prob = tl.full((), 0.0, tl.float32)
+    for start in tl.range(0, vocab_size, BLOCK_SIZE, num_stages=3):
+        cols = start + offs
+        mask = cols < vocab_size
+        vals = tl.load(probs_row + cols, mask=mask, other=0.0).to(tl.float32)
+        max_prob = tl.maximum(max_prob, tl.max(tl.where(mask, vals, 0.0), axis=0))
+
+    threshold = max_prob * tl.load(min_p_ptr + row).to(tl.float32)
+    denom = tl.full((), 0.0, tl.float32)
+    for start in tl.range(0, vocab_size, BLOCK_SIZE, num_stages=3):
+        cols = start + offs
+        mask = cols < vocab_size
+        vals = tl.load(probs_row + cols, mask=mask, other=0.0).to(tl.float32)
+        keep = mask & (vals >= threshold)
+        denom += tl.sum(tl.where(keep, vals, 0.0), axis=0)
+
+    inv_denom = 1.0 / tl.maximum(denom, 1.0e-20)
+    for start in tl.range(0, vocab_size, BLOCK_SIZE, num_stages=3):
+        cols = start + offs
+        mask = cols < vocab_size
+        vals = tl.load(probs_row + cols, mask=mask, other=0.0).to(tl.float32)
+        keep = mask & (vals >= threshold)
+        out = tl.where(keep, vals * inv_denom, 0.0)
+        tl.store(out_row + cols, out, mask=mask)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
+
+def min_p_renorm_prob(
+    probs: torch.Tensor,
+    min_p: torch.Tensor,
+    *,
+    enable_pdl: bool = False,
+) -> torch.Tensor:
+    """Renormalize probabilities after applying a per-row min-p cutoff.
+
+    For each row, this computes ``threshold = min_p[row] * max(probs[row])``,
+    zeros probabilities below the threshold, and renormalizes the surviving
+    probabilities so the row sums to one.
+    """
+    if probs.ndim != 2:
+        raise ValueError(f"min_p_renorm_prob expects 2D probs, got {probs.ndim}D")
+    if min_p.ndim != 1:
+        raise ValueError(f"min_p_renorm_prob expects 1D min_p, got {min_p.ndim}D")
+    if min_p.shape[0] != probs.shape[0]:
+        raise ValueError(
+            "min_p length must match probs rows, "
+            f"got {min_p.shape[0]} and {probs.shape[0]}"
+        )
+    if probs.device.type != "cuda" or min_p.device.type != "cuda":
+        raise ValueError("min_p_renorm_prob requires CUDA tensors")
+    if probs.stride(-1) != 1:
+        raise ValueError(
+            f"min_p_renorm_prob requires stride-1 vocab dimension, got stride={probs.stride()}"
+        )
+    if not min_p.is_contiguous():
+        min_p = min_p.contiguous()
+
+    out = torch.empty_like(probs)
+    rows, vocab_size = probs.shape
+    if rows == 0:
+        return out
+
+    block_size = min(4096, triton.next_power_of_2(vocab_size))
+    num_warps = 4 if block_size <= 1024 else 8
+    extra_kwargs = {"launch_pdl": True} if enable_pdl else {}
+    _min_p_renorm_prob_kernel[(rows,)](
+        probs,
+        min_p,
+        out,
+        vocab_size=vocab_size,
+        probs_row_stride=probs.stride(0),
+        out_row_stride=out.stride(0),
+        BLOCK_SIZE=block_size,
+        ENABLE_PDL=enable_pdl,
+        num_warps=num_warps,
+        num_stages=3,
+        **extra_kwargs,
+    )
+    return out

--- a/tokenspeed-kernel/test/ops/test_sampling.py
+++ b/tokenspeed-kernel/test/ops/test_sampling.py
@@ -22,7 +22,10 @@ from __future__ import annotations
 
 import pytest
 import torch
-from tokenspeed_kernel.ops.sampling.triton import gather_and_expand_scalars
+from tokenspeed_kernel.ops.sampling.triton import (
+    gather_and_expand_scalars,
+    min_p_renorm_prob,
+)
 
 
 def _make_pools(pool_rows: int, device: str):
@@ -39,6 +42,16 @@ def _reference(index, pool, n: int):
     """index_select + repeat_interleave reference."""
     idx = index.long()
     return pool.index_select(0, idx).repeat_interleave(n, dim=0)
+
+
+def _min_p_reference(probs: torch.Tensor, min_p: torch.Tensor) -> torch.Tensor:
+    max_probs = probs.max(dim=-1, keepdim=True).values
+    out = torch.where(
+        probs >= min_p.to(probs.dtype).view(-1, 1) * max_probs,
+        probs,
+        torch.zeros_like(probs),
+    )
+    return out / out.sum(dim=-1, keepdim=True)
 
 
 @pytest.mark.parametrize("bs", [1, 4, 7])
@@ -163,3 +176,40 @@ def test_gather_empty_batch(device: str) -> None:
     assert min_ps.numel() == 0
     assert seeds.numel() == 0
     assert offsets.numel() == 0
+
+
+@pytest.mark.parametrize("rows", [1, 3, 5])
+@pytest.mark.parametrize("vocab_size", [17, 257, 1025])
+def test_min_p_renorm_prob(rows: int, vocab_size: int, device: str) -> None:
+    torch.manual_seed(rows * 1000 + vocab_size)
+    probs = torch.rand((rows, vocab_size), device=device, dtype=torch.float32)
+    probs = probs / probs.sum(dim=-1, keepdim=True)
+    min_p = torch.linspace(0.0, 0.2, rows, device=device, dtype=torch.float32)
+
+    out = min_p_renorm_prob(probs, min_p)
+    ref = _min_p_reference(probs, min_p)
+
+    torch.testing.assert_close(out, ref, rtol=1e-5, atol=1e-6)
+    torch.testing.assert_close(out.sum(dim=-1), torch.ones(rows, device=device))
+
+
+def test_min_p_renorm_prob_bf16_min_p(device: str) -> None:
+    torch.manual_seed(0)
+    probs = torch.rand((4, 513), device=device, dtype=torch.float32)
+    probs = probs / probs.sum(dim=-1, keepdim=True)
+    min_p = torch.tensor([0.0, 0.01, 0.05, 0.2], device=device, dtype=torch.bfloat16)
+
+    out = min_p_renorm_prob(probs, min_p)
+    ref = _min_p_reference(probs, min_p)
+
+    torch.testing.assert_close(out, ref, rtol=1e-5, atol=1e-6)
+
+
+def test_min_p_renorm_prob_empty_batch(device: str) -> None:
+    probs = torch.empty((0, 32), device=device, dtype=torch.float32)
+    min_p = torch.empty((0,), device=device, dtype=torch.float32)
+
+    out = min_p_renorm_prob(probs, min_p)
+
+    assert out.shape == probs.shape
+    assert out.dtype == probs.dtype


### PR DESCRIPTION
## Summary

- Add a Triton helper for min-p probability renormalization.
- Use it in the `flashinfer_full` sampling backend.
- This replaces the PyTorch `max -> where -> sum -> div` sequence.

## Test Plan

- `python -m pytest tokenspeed-kernel/test/ops/test_sampling.py -q`
- H100 microbenchmark for min-p renorm, `vocab_size=151936`, `min_p=0.05`,
  with `enable_pdl=True`:
- The same benchmark with `min_p=0.0` also showed no regression.

| rows | baseline | Triton helper | speedup |
| ---: | ---: | ---: | ---: |
| 16 | 0.0748 ms | 0.0442 ms | 1.69x |
| 64 | 0.1801 ms | 0.0738 ms | 2.44x |
| 128 | 0.3316 ms | 0.1112 ms | 2.98x |