### PR TITLE
fix(server-args): restrict --speculative-eagle-topk to 1

### DIFF
--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -1391,7 +1391,7 @@ class ServerArgs:
             "--speculative-eagle-topk",
             type=int,
             help="The number of tokens sampled from the draft model in each speculative step.",
-            choices=[1, 2, 4, 8],
+            choices=[1],
             default=ServerArgs.speculative_eagle_topk,
         )
         parser.add_argument(

--- a/test/runtime/test_cli_config_compat.py
+++ b/test/runtime/test_cli_config_compat.py
@@ -481,31 +481,28 @@ class TestCLIConfigCompat(unittest.TestCase):
         self.assertEqual(sa.speculative_num_steps, 1)
         self.assertEqual(sa.speculative_num_draft_tokens, 2)
 
-    def test_speculative_eagle_topk_gt_1_rejected(self):
+    def test_speculative_eagle_topk_cli_rejects_non_1(self):
+        # Only chain spec (topk=1) is wired end-to-end; the CLI choices
+        # set is the gate, so non-1 values must fail at parse time.
+        with self.assertRaises(SystemExit):
+            self._parse_args(["--model", "test/model", "--speculative-eagle-topk", "4"])
+
+    def test_speculative_eagle_topk_runtime_rejects_non_1_when_spec_on(self):
+        # ServerArgs can be built programmatically (e.g. by smg_grpc_servicer),
+        # bypassing argparse — keep the resolve-time defensive check covered.
         args = self._parse_args(
             [
                 "--model",
                 "test/model",
                 "--speculative-algorithm",
                 "EAGLE3",
-                "--speculative-eagle-topk",
-                "4",
             ]
         )
         sa = self._from_cli_args_no_init(args)
+        sa.speculative_eagle_topk = 4
         sa.resolve_basic_defaults()
         with self.assertRaisesRegex(ValueError, "speculative_eagle_topk"):
             sa.resolve_speculative_decoding()
-
-    def test_speculative_eagle_topk_gt_1_allowed_when_spec_off(self):
-        # topk is only consumed by the spec path, so don't reject when SD is off.
-        args = self._parse_args(
-            ["--model", "test/model", "--speculative-eagle-topk", "4"]
-        )
-        sa = self._from_cli_args_no_init(args)
-        sa.resolve_basic_defaults()
-        sa.resolve_speculative_decoding()
-        self.assertIsNone(sa.speculative_algorithm)
 
     # ---- Full server command example ----
 


### PR DESCRIPTION
## Summary

`--speculative-eagle-topk` advertises `choices=[1, 2, 4, 8]` but only `1` is actually supported end-to-end. `ServerArgs.resolve_speculative_decoding` already raises at startup if `speculative_algorithm` is set and topk != 1:

```python
if self.speculative_algorithm is not None and self.speculative_eagle_topk != 1:
    raise ValueError(
        "speculative_eagle_topk > 1 (tree spec) is not currently "
        f"supported: {self.speculative_eagle_topk=}. Only chain spec "
        "(topk=1) is wired end-to-end."
    )
```

So accepting `2`, `4`, `8` from the CLI only delays the failure — it lands as a startup `ValueError` instead of a clean argparse rejection. Drop the unsupported candidates so the CLI says "no" up front:

```diff
-    choices=[1, 2, 4, 8],
+    choices=[1],
```

The runtime check in `resolve_speculative_decoding` stays as defensive depth for callers that build `ServerArgs` programmatically (e.g. `smg_grpc_servicer`).

## Test plan

- [x] Updated `test/runtime/test_cli_config_compat.py`:
  - `test_speculative_eagle_topk_cli_rejects_non_1` — `parser.parse_args(["--speculative-eagle-topk", "4"])` raises `SystemExit` (argparse choices).
  - `test_speculative_eagle_topk_runtime_rejects_non_1_when_spec_on` — programmatic `sa.speculative_eagle_topk = 4` with `EAGLE3` set still raises the `ValueError` from `resolve_speculative_decoding`, keeping the defensive path covered.
- [x] Both pass locally with the on-branch source forced in `sys.path` (the venv's editable install of `tokenspeed` points at a different repo, so plain `pytest` would have hit the stale module — irrelevant under CI's fresh install).
- [x] Grep across `python/`, `test/`, `docs/` for any in-tree caller passing `--speculative-eagle-topk 2`/`4`/`8`; none — the only README reference is `--speculative-eagle-topk 1`.
