### PR TITLE
perf: default turn on tokenizer cache.

### DIFF
--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -123,6 +123,38 @@ def _gateway_args_with_smg_disable_defaults(gateway_args: list[str]) -> list[str
     return result
 
 
+_TOKENIZER_CACHE_FLAGS = (
+    "--tokenizer-cache-enable-l0",
+    "--tokenizer-cache-enable-l1",
+)
+
+
+def _gateway_args_with_default_tokenizer_cache(gateway_args: list[str]) -> list[str]:
+    """Default smg tokenizer caches (L0 + L1) ON for gateway-fronted launches.
+
+    For agentic / chat-completions traffic with a shared system prompt + history,
+    L1 prefix-caching at special-token boundaries cuts TTFT by ~30% (verified
+    end-to-end on mm25). smg's own clap defaults leave both layers OFF.
+
+    Opt-out: operators can pass ``--no-tokenizer-cache-enable-l0`` and/or
+    ``--no-tokenizer-cache-enable-l1`` to ``ts serve``. The ``--no-`` form is
+    intercepted here (smg's clap doesn't accept it natively) and prevents the
+    positive injection for that layer.
+    """
+    result = list(gateway_args)
+    for flag in _TOKENIZER_CACHE_FLAGS:
+        no_flag = "--no-" + flag[2:]
+        if no_flag in result:
+            # Operator opted out: strip the --no- marker (smg rejects it)
+            # and skip the positive injection for this layer.
+            while no_flag in result:
+                result.remove(no_flag)
+            continue
+        if flag not in result:
+            result.append(flag)
+    return result
+
+
 def _gateway_args_with_default_log_level(gateway_args: list[str]) -> list[str]:
     if "--log-level" in gateway_args:
         return gateway_args
@@ -190,6 +222,7 @@ def _gateway_args_with_defaults(gateway_args: list[str]) -> list[str]:
     gateway_args = _gateway_args_with_default_port(gateway_args)
     gateway_args = _gateway_args_with_default_reasoning_parser(gateway_args)
     gateway_args = _gateway_args_with_smg_disable_defaults(gateway_args)
+    gateway_args = _gateway_args_with_default_tokenizer_cache(gateway_args)
     gateway_args = _gateway_args_with_default_log_level(gateway_args)
     return _gateway_args_with_default_prometheus_port(gateway_args)
 

--- a/test/cli/test_serve_smg_unit.py
+++ b/test/cli/test_serve_smg_unit.py
@@ -102,6 +102,8 @@ def test_gateway_args_defaults_include_port_and_reasoning_parser():
         "none",
         "--disable-circuit-breaker",
         "--disable-retries",
+        "--tokenizer-cache-enable-l0",
+        "--tokenizer-cache-enable-l1",
         "--log-level",
         "warn",
         "--prometheus-port",


### PR DESCRIPTION
## Summary

default on unless set `--no-tokenizer-cache-enable-l0 --no-tokenizer-cache-enable-l1`

## Test Plan

```
  Workload: /v1/chat/completions, 120 requests at concurrency 30. System message = 100K-char shared prefix (≈20K tokens), user message = unique ~200-char suffix per request,
  max_tokens=64. mm25 FP4 + EAGLE3, TP=2, KVStore on. TTFT = time from POST to first SSE byte.

  ┌─────────────────────┬────────────────────┬──────────────┬─────────┐
  │       Metric        │ Stock (caches off) │ With L0 + L1 │    Δ    │
  ├─────────────────────┼────────────────────┼──────────────┼─────────┤
  │ TTFT p50            │           378.7 ms │     249.5 ms │ −34.1 % │
  ├─────────────────────┼────────────────────┼──────────────┼─────────┤
  │ TTFT p90            │           433.5 ms │     335.6 ms │ −22.6 % │
  ├─────────────────────┼────────────────────┼──────────────┼─────────┤
  │ TTFT p99            │           436.2 ms │     339.6 ms │ −22.1 % │
  ├─────────────────────┼────────────────────┼──────────────┼─────────┤
  │ TTFT mean           │           361.1 ms │     263.3 ms │ −27.1 % │
  ├─────────────────────┼────────────────────┼──────────────┼─────────┤
  │ TTFT min            │           172.0 ms │     141.3 ms │ −17.8 % │
  ├─────────────────────┼────────────────────┼──────────────┼─────────┤
  │ TTFT max            │           466.4 ms │     379.8 ms │ −18.6 % │
  ├─────────────────────┼────────────────────┼──────────────┼─────────┤
  │ Successful requests │          120 / 120 │    120 / 120 │       — │
  └─────────────────────┴────────────────────┴──────────────┴─────────┘
```