### PR TITLE
fix(runtime): widen BF16 CUTLASS MoE autotune range

### DIFF
--- a/python/tokenspeed/runtime/layers/moe/backends/unquantized/flashinfer_cutlass.py
+++ b/python/tokenspeed/runtime/layers/moe/backends/unquantized/flashinfer_cutlass.py
@@ -101,7 +101,7 @@ class Bf16FlashinferCutlassBackend(MoEBackend):
             ep_rank=self.spec.ep_rank,
             tp_size=self._tp_size,
             tp_rank=self._tp_rank,
-            tune_max_num_tokens=next_power_of_2(x.shape[0]),
+            tune_max_num_tokens=max(8192, next_power_of_2(x.shape[0])),
             activation_type=ActivationType.Swiglu,
             dtype=x.dtype,
             features={"pre_routed"},


### PR DESCRIPTION
## Summary
- Tune BF16 FlashInfer CUTLASS MoE with at least 8192 tokens on the first autotune pass.
- Avoid small CUDA graph capture batches limiting the tuned config range and causing larger decode batches to fall back to untuned CUTLASS tactics.

## Why
The previous code used `next_power_of_2(x.shape[0])` for `tune_max_num_tokens`. When the first BF16 CUTLASS MoE call happens during CUDA graph capture with a small batch, the autotuned range can be too small for later c16/c32 decode workloads. Those larger token counts then miss the tuned config and fall back to `tactic=-1`, which is the performance cliff observed on Qwen3.6-35B-A3B BF16.

This keeps the existing default backend behavior intact and only widens the BF16 CUTLASS tuning range.

## Validation
- `python3 -m py_compile python/tokenspeed/runtime/layers/moe/backends/unquantized/flashinfer_cutlass.py`
- `git diff --check`
- `uvx pre-commit run --files python/tokenspeed/runtime/layers/moe/backends/unquantized/flashinfer_cutlass.py`
- Direct Engine benchmark on Qwen3.6-35B-A3B BF16, TP=2, H100, 1024 input / 256 output:
  - patched `flashinfer_cutlass`: c16 TPOT 8.46 ms, 1892 tok/s; c32 TPOT 10.17 ms, 3146 tok/s
  - `triton`: c16 TPOT 9.26 ms, 1728 tok/s; c32 TPOT 12.31 ms, 2600 tok/s
- Patched CUTLASS run had no `No tuned config covers` / `tactic=-1` fallback logs.