### PR TITLE
feat(kvstore): support mamba l2 cache transfers

### DIFF
--- a/python/tokenspeed/runtime/cache/executor/host_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/host_executor.py
@@ -389,7 +389,7 @@ class HostExecutor:
         results = []
         completed_writebacks = getattr(self, "completed_writebacks", [])
         for op_id in completed_writebacks:
-            logger.info("[cache_op] writeback done op_id=%s immediate=True", op_id)
+            logger.debug("[cache_op] writeback done op_id=%s immediate=True", op_id)
             evt = Cache.WriteBackDoneEvent()
             evt.op_id = op_id
             evt.success = True
@@ -398,7 +398,7 @@ class HostExecutor:
         remaining = []
         for ack in self.ack_write_queue:
             if ack.finish_event.query():
-                logger.info(
+                logger.debug(
                     "[cache_op] writeback done op_ids=%s immediate=False", ack.op_ids
                 )
                 for op_id in ack.op_ids:

--- a/python/tokenspeed/runtime/cache/executor/host_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/host_executor.py
@@ -28,7 +28,10 @@ from typing import Iterable, NamedTuple
 import torch
 from tokenspeed_scheduler import Cache
 
-from tokenspeed.runtime.cache.kvstore_controller import LayerDoneCounter
+from tokenspeed.runtime.cache.transfer.kv_pool import KVCachePool
+from tokenspeed.runtime.cache.transfer.pool import CachePool
+from tokenspeed.runtime.cache.transfer.types import CacheKind, Location, TransferUnit
+from tokenspeed.runtime.execution.cuda_graph_wrapper import get_is_capture_mode
 from tokenspeed.runtime.utils import get_colorful_logger, get_device_module
 
 logger = get_colorful_logger(__name__)
@@ -85,116 +88,138 @@ def _dedupe_page_pairs(
     return deduped_src, deduped_dst
 
 
-class _TransferOp:
-
-    def __init__(
-        self,
-        host_indices: torch.Tensor,
-        device_indices: torch.Tensor,
-        node_id: int,
-        is_retract: bool = False,
-    ):
-        self.host_indices = host_indices
-        self.device_indices = device_indices
-        self.node_ids = [node_id]
-        self.is_retract = is_retract
-
-    @staticmethod
-    def merge(ops: list["_TransferOp"]) -> "_TransferOp":
-        assert len(ops) > 0
-        if len(ops) == 1:
-            return ops[0]
-        host_indices = torch.cat([op.host_indices for op in ops])
-        device_indices = torch.cat([op.device_indices for op in ops])
-        merged = _TransferOp(host_indices, device_indices, -1)
-        merged.node_ids = []
-        merged.is_retract = False
-        for op in ops:
-            merged.node_ids.extend(op.node_ids)
-            merged.is_retract = merged.is_retract or op.is_retract
-        return merged
+def _ordered_unique(values: Iterable[int]) -> list[int]:
+    seen = set()
+    result = []
+    for value in values:
+        value = int(value)
+        if value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
 
 
 class _Ack(NamedTuple):
     finish_event: object  # device_module.Event
-    node_ids: list[int]
+    op_ids: list[int]
 
 
 class HostExecutor:
-
     def __init__(
         self,
-        page_size: int,
-        device_pool,
-        host_pool,
-        io_backend: str,
-        layer_num: int,
+        page_size: int | None = None,
+        device_pool=None,
+        host_pool=None,
+        io_backend: str = "kernel",
+        layer_num: int | None = None,
         draft_device_pool=None,
         draft_host_pool=None,
         draft_layer_num: int = 0,
+        pools: list[CachePool] | None = None,
     ):
-        self.page_size = page_size
-        self.device_pool = device_pool
-        self.host_pool = host_pool
         self.io_backend = io_backend
-        self.layer_num = layer_num
-        self.device = device_pool.device
+        if pools is None:
+            if (
+                page_size is None
+                or device_pool is None
+                or host_pool is None
+                or layer_num is None
+            ):
+                raise ValueError("HostExecutor requires either pools or KV pool inputs")
+            pools = [
+                KVCachePool(
+                    device_pool=device_pool,
+                    host_pool=host_pool,
+                    io_backend=io_backend,
+                    layer_num=layer_num,
+                    draft_device_pool=draft_device_pool,
+                    draft_host_pool=draft_host_pool,
+                    draft_layer_num=draft_layer_num,
+                )
+            ]
+        if not pools:
+            raise ValueError("HostExecutor requires at least one cache pool")
 
-        # Optional draft model pools (share the same page mapping as base model)
-        self.draft_device_pool = draft_device_pool
-        self.draft_host_pool = draft_host_pool
-        self.draft_layer_num = draft_layer_num
+        self.pools = {CacheKind(pool.kind): pool for pool in pools}
+        self.device = next(iter(self.pools.values())).device
 
         write_priority, load_priority = _cache_stream_priorities()
         self.write_stream = _new_cache_stream(write_priority)
         self.load_stream = _new_cache_stream(load_priority)
         self._writeback_block_quota: int | None = None
 
-        self.write_queue: list[_TransferOp] = []
-        self.load_queue: list[_TransferOp] = []
+        self.write_queues: dict[CacheKind, list[TransferUnit]] = {
+            kind: [] for kind in self.pools
+        }
+        self.load_queues: dict[CacheKind, list[TransferUnit]] = {
+            kind: [] for kind in self.pools
+        }
 
         self.ack_write_queue: list[_Ack] = []
         self.ack_load_queue: list[_Ack] = []
         self.completed_writebacks: list[int] = []
 
-        self.layer_done_counter = LayerDoneCounter(layer_num)
-        device_pool.register_layer_transfer_counter(self.layer_done_counter)
-
-        self._producer_map: OrderedDict[int, int] = OrderedDict()
+        self._counters = {
+            kind: pool.get_layer_done_counter() for kind, pool in self.pools.items()
+        }
+        self._producer_map: dict[CacheKind, OrderedDict[int, int]] = {
+            kind: OrderedDict() for kind in self.pools
+        }
         self._producer_map_limit = 1024
 
     def enqueue_writeback(
-        self, op_id, src_pages, dst_pages, is_retract: bool = False
+        self,
+        op_id,
+        src_pages,
+        dst_pages,
+        is_retract: bool = False,
+        kind: CacheKind | str = CacheKind.KV,
     ) -> None:
+        kind = CacheKind(kind)
+        pool = self.pools[kind]
         src_pages, dst_pages = _dedupe_page_pairs(src_pages, dst_pages)
         if not src_pages:
-            completed_writebacks = getattr(self, "completed_writebacks", None)
-            if completed_writebacks is None:
-                completed_writebacks = []
-                self.completed_writebacks = completed_writebacks
-            completed_writebacks.append(op_id)
+            self.completed_writebacks.append(op_id)
             return
-        device_indices = page_ids_to_token_indices(
-            src_pages, self.page_size, str(self.device)
-        )
-        host_indices = page_ids_to_token_indices(dst_pages, self.page_size, "cpu")
-        self.write_queue.append(
-            _TransferOp(host_indices, device_indices, op_id, is_retract)
+        device_indices = page_ids_to_token_indices(src_pages, pool.page_size(), "cpu")
+        host_indices = page_ids_to_token_indices(dst_pages, pool.page_size(), "cpu")
+        self.write_queues[kind].append(
+            TransferUnit(
+                kind=kind,
+                src_loc=Location.DEVICE,
+                dst_loc=Location.HOST,
+                src_indices=device_indices,
+                dst_indices=host_indices,
+                op_id=op_id,
+                is_retract=is_retract,
+            )
         )
 
-    def enqueue_loadback(self, op_id, src_pages, dst_pages) -> None:
+    def enqueue_loadback(
+        self, op_id, src_pages, dst_pages, kind: CacheKind | str = CacheKind.KV
+    ) -> None:
+        kind = CacheKind(kind)
+        pool = self.pools[kind]
         src_pages, dst_pages = _dedupe_page_pairs(src_pages, dst_pages)
         if not src_pages:
             return
-        host_indices = page_ids_to_token_indices(src_pages, self.page_size, "cpu")
-        device_indices = page_ids_to_token_indices(
-            dst_pages, self.page_size, str(self.device)
+        host_indices = page_ids_to_token_indices(src_pages, pool.page_size(), "cpu")
+        device_indices = page_ids_to_token_indices(dst_pages, pool.page_size(), "cpu")
+        self.load_queues[kind].append(
+            TransferUnit(
+                kind=kind,
+                src_loc=Location.HOST,
+                dst_loc=Location.DEVICE,
+                src_indices=host_indices,
+                dst_indices=device_indices,
+                op_id=op_id,
+            )
         )
-        self.load_queue.append(_TransferOp(host_indices, device_indices, op_id))
 
     def flush(self) -> None:
-        throttle_writeback = self.load_queue and not any(
-            getattr(op, "is_retract", False) for op in self.write_queue
+        throttle_writeback = self._has_work(self.load_queues) and not any(
+            unit.is_retract for units in self.write_queues.values() for unit in units
         )
         writeback_block_quota = (
             CONCURRENT_WRITEBACK_BLOCK_QUOTA if throttle_writeback else None
@@ -207,125 +232,152 @@ class HostExecutor:
         finally:
             self._writeback_block_quota = previous_writeback_block_quota
 
-    def _start_writing(self) -> None:
-        if not self.write_queue:
-            return
+    def fence_writeback_after(self, producer_stream) -> None:
+        if producer_stream is not None:
+            self.write_stream.wait_stream(producer_stream)
 
-        op = _TransferOp.merge(self.write_queue)
-        host_indices, device_indices = self._move_indices(op, self.host_pool)
-        # Prepare draft indices outside the stream context so non_blocking H2D
-        # copies are issued on the default stream and then consumed by write_stream.
-        if self.draft_host_pool is not None:
-            draft_host_indices, draft_device_indices = self._move_indices(
-                op, self.draft_host_pool
-            )
-        else:
-            draft_host_indices = draft_device_indices = None
-        self.write_queue.clear()
+    def _start_writing(self) -> None:
+        if not self._has_work(self.write_queues):
+            return
 
         start_event = device_module.Event()
         finish_event = device_module.Event()
+        op_ids: list[int] = []
 
         start_event.record()
         with device_module.stream(self.write_stream):
             start_event.wait(self.write_stream)
-            self.host_pool.backup_from_device_all_layer(
-                self.device_pool,
-                host_indices.to(torch.int64),
-                device_indices.to(torch.int64),
-                self.io_backend,
-                block_quota=self._writeback_block_quota,
-            )
-            # Draft model shares the same page mapping; backup its KV cache too.
-            if self.draft_host_pool is not None:
-                self.draft_host_pool.backup_from_device_all_layer(
-                    self.draft_device_pool,
-                    draft_host_indices.to(torch.int64),
-                    draft_device_indices.to(torch.int64),
-                    self.io_backend,
-                    block_quota=self._writeback_block_quota,
+            for kind, units in self.write_queues.items():
+                if not units:
+                    continue
+                pool = self.pools[kind]
+                unit = self._merge_units(units)
+                src_indices, dst_indices = self._prepare_indices(unit, pool)
+                self._pool_writeback(
+                    pool, src_indices.to(torch.int64), dst_indices.to(torch.int64)
                 )
-                if draft_host_indices.is_cuda:
-                    draft_host_indices.record_stream(self.write_stream)
-                if draft_device_indices.is_cuda:
-                    draft_device_indices.record_stream(self.write_stream)
+                self._record_if_cuda(src_indices, self.write_stream)
+                self._record_if_cuda(dst_indices, self.write_stream)
+                op_ids.extend(unit.op_id for unit in units)
             finish_event.record()
-            if host_indices.is_cuda:
-                host_indices.record_stream(self.write_stream)
-            if device_indices.is_cuda:
-                device_indices.record_stream(self.write_stream)
 
-        self.ack_write_queue.append(_Ack(finish_event, op.node_ids))
+        self._clear_queues(self.write_queues)
+        self.ack_write_queue.append(_Ack(finish_event, _ordered_unique(op_ids)))
 
     def _start_loading(self) -> None:
-        if not self.load_queue:
+        if not self._has_work(self.load_queues):
             return
-
-        producer_id = self.layer_done_counter.update_producer()
-        op = _TransferOp.merge(self.load_queue)
-        host_indices, device_indices = self._move_indices(op, self.host_pool)
-        self.load_queue.clear()
-
-        producer_event = self.layer_done_counter.events[producer_id]
-        producer_event.start_event.record()
-
-        # Prepare draft indices once if draft pool is present.
-        if self.draft_host_pool is not None:
-            draft_host_indices, draft_device_indices = self._move_indices(
-                op, self.draft_host_pool
-            )
-        else:
-            draft_host_indices = draft_device_indices = None
+        assert (
+            not get_is_capture_mode()
+        ), "cache loadback must run in eager admission iter"
 
         with device_module.stream(self.load_stream):
-            producer_event.start_event.wait(self.load_stream)
-            for layer_index in range(self.layer_num):
-                self.host_pool.load_to_device_per_layer(
-                    self.device_pool,
-                    host_indices.to(torch.int64),
-                    device_indices.to(torch.int64),
-                    layer_index,
-                    self.io_backend,
-                )
-                producer_event.complete(layer_index)
-            # Draft layers follow base layers in the same load stream.
-            if self.draft_host_pool is not None:
-                for layer_index in range(self.draft_layer_num):
-                    self.draft_host_pool.load_to_device_per_layer(
-                        self.draft_device_pool,
-                        draft_host_indices.to(torch.int64),
-                        draft_device_indices.to(torch.int64),
+            for kind, units in self.load_queues.items():
+                if not units:
+                    continue
+                pool = self.pools[kind]
+                counter = self._counters[kind]
+                producer_id = counter.update_producer()
+                producer_event = counter.events[producer_id]
+                producer_event.start_event.record()
+                producer_event.start_event.wait(self.load_stream)
+
+                unit = self._merge_units(units)
+                src_indices, dst_indices = self._prepare_indices(unit, pool)
+                for layer_index in range(pool.num_layers()):
+                    pool.loadback(
+                        src_indices.to(torch.int64),
+                        dst_indices.to(torch.int64),
                         layer_index,
-                        self.io_backend,
                     )
-                if draft_host_indices.is_cuda:
-                    draft_host_indices.record_stream(self.load_stream)
-                if draft_device_indices.is_cuda:
-                    draft_device_indices.record_stream(self.load_stream)
-            if host_indices.is_cuda:
-                host_indices.record_stream(self.load_stream)
-            if device_indices.is_cuda:
-                device_indices.record_stream(self.load_stream)
+                    producer_event.complete(layer_index)
+                self._record_if_cuda(src_indices, self.load_stream)
+                self._record_if_cuda(dst_indices, self.load_stream)
 
-        self.ack_load_queue.append(_Ack(producer_event.finish_event, op.node_ids))
-        for op_id in op.node_ids:
-            self._producer_map[op_id] = producer_id
-        while len(self._producer_map) > self._producer_map_limit:
-            self._producer_map.popitem(last=False)
+                op_ids = _ordered_unique(unit.op_id for unit in units)
+                self.ack_load_queue.append(_Ack(producer_event.finish_event, op_ids))
+                producer_map = self._producer_map[kind]
+                for op_id in op_ids:
+                    producer_map[op_id] = producer_id
+                while len(producer_map) > self._producer_map_limit:
+                    producer_map.popitem(last=False)
 
-    def _move_indices(self, op: _TransferOp, host_pool):
-        host_indices = op.host_indices
-        device_indices = op.device_indices
-        if self.io_backend == "kernel":
-            if not host_indices.is_cuda:
-                host_indices = host_indices.to(self.device, non_blocking=True)
-            return host_indices, device_indices
-        elif self.io_backend == "direct":
-            if host_pool.layout == "layer_first":
+        self._clear_queues(self.load_queues)
+
+    @staticmethod
+    def _has_work(queues: dict[CacheKind, list[TransferUnit]]) -> bool:
+        return any(bool(units) for units in queues.values())
+
+    @staticmethod
+    def _clear_queues(queues: dict[CacheKind, list[TransferUnit]]) -> None:
+        for units in queues.values():
+            units.clear()
+
+    @staticmethod
+    def _merge_units(units: list[TransferUnit]) -> TransferUnit:
+        assert units
+        if len(units) == 1:
+            return units[0]
+        first = units[0]
+        return TransferUnit(
+            kind=first.kind,
+            src_loc=first.src_loc,
+            dst_loc=first.dst_loc,
+            src_indices=torch.cat([unit.src_indices for unit in units]),
+            dst_indices=torch.cat([unit.dst_indices for unit in units]),
+            op_id=-1,
+            is_retract=any(unit.is_retract for unit in units),
+        )
+
+    def _prepare_indices(
+        self, unit: TransferUnit, pool: CachePool
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if unit.src_loc == Location.HOST:
+            host_indices = unit.src_indices
+            device_indices = unit.dst_indices
+        elif unit.dst_loc == Location.HOST:
+            host_indices = unit.dst_indices
+            device_indices = unit.src_indices
+        else:
+            raise ValueError(f"unsupported transfer direction: {unit.direction}")
+
+        io_backend = getattr(pool, "io_backend", self.io_backend)
+        if io_backend == "kernel":
+            target_device = pool.device
+            if device_indices.device != target_device:
+                device_indices = device_indices.to(target_device, non_blocking=True)
+            if host_indices.device != target_device:
+                host_indices = host_indices.to(target_device, non_blocking=True)
+        elif io_backend == "direct":
+            if pool.host_layout == "layer_first":
                 device_indices = device_indices.cpu()
                 host_indices, idx = host_indices.sort()
-                return host_indices, device_indices.index_select(0, idx)
-        raise ValueError(f"Unsupported io_backend={self.io_backend}")
+                device_indices = device_indices.index_select(0, idx)
+            else:
+                raise ValueError(f"Unsupported host layout: {pool.host_layout}")
+        else:
+            raise ValueError(f"Unsupported io_backend={io_backend}")
+
+        if unit.src_loc == Location.HOST:
+            return host_indices, device_indices
+        return device_indices, host_indices
+
+    def _pool_writeback(
+        self, pool: CachePool, src_indices: torch.Tensor, dst_indices: torch.Tensor
+    ) -> None:
+        try:
+            pool.writeback(
+                src_indices, dst_indices, block_quota=self._writeback_block_quota
+            )
+        except TypeError as exc:
+            if "block_quota" not in str(exc):
+                raise
+            pool.writeback(src_indices, dst_indices)
+
+    @staticmethod
+    def _record_if_cuda(tensor: torch.Tensor, stream) -> None:
+        if tensor.is_cuda:
+            tensor.record_stream(stream)
 
     def drain(self) -> list:
         results: list = []
@@ -337,6 +389,7 @@ class HostExecutor:
         results = []
         completed_writebacks = getattr(self, "completed_writebacks", [])
         for op_id in completed_writebacks:
+            logger.info("[cache_op] writeback done op_id=%s immediate=True", op_id)
             evt = Cache.WriteBackDoneEvent()
             evt.op_id = op_id
             evt.success = True
@@ -345,7 +398,10 @@ class HostExecutor:
         remaining = []
         for ack in self.ack_write_queue:
             if ack.finish_event.query():
-                for op_id in ack.node_ids:
+                logger.info(
+                    "[cache_op] writeback done op_ids=%s immediate=False", ack.op_ids
+                )
+                for op_id in ack.op_ids:
                     evt = Cache.WriteBackDoneEvent()
                     evt.op_id = op_id
                     evt.success = True
@@ -364,22 +420,44 @@ class HostExecutor:
         self.ack_load_queue[:] = remaining
         return results
 
-    def get_producer_index(self, op_id: int) -> int | None:
-        return self._producer_map.pop(op_id, None)
+    def get_producer_index(
+        self, kind_or_op_id: CacheKind | str | int, op_id: int | None = None
+    ) -> int | None:
+        if op_id is None:
+            kind = CacheKind.KV
+            op_id = int(kind_or_op_id)
+        else:
+            kind = CacheKind(kind_or_op_id)
+        return self._producer_map[kind].pop(int(op_id), None)
 
-    def set_consumer(self, producer_index: int | Iterable[int]) -> None:
-        self.layer_done_counter.set_consumer(producer_index)
+    def set_consumer(
+        self,
+        kind_or_producer_index: CacheKind | str | int | Iterable[int],
+        producer_index: int | Iterable[int] | None = None,
+    ) -> None:
+        if producer_index is None:
+            kind = CacheKind.KV
+            producer_index = kind_or_producer_index
+        else:
+            kind = CacheKind(kind_or_producer_index)
+        self._counters[kind].set_consumer(producer_index)
 
     def shutdown(self) -> None:
         self.write_stream.synchronize()
         self.load_stream.synchronize()
+        for pool in self.pools.values():
+            shutdown = getattr(pool, "shutdown", None)
+            if shutdown is not None:
+                shutdown()
 
     def reset(self) -> None:
         self.write_stream.synchronize()
         self.load_stream.synchronize()
-        self.write_queue.clear()
-        self.load_queue.clear()
+        self._clear_queues(self.write_queues)
+        self._clear_queues(self.load_queues)
         self.ack_write_queue.clear()
         self.ack_load_queue.clear()
-        self._producer_map.clear()
-        self.layer_done_counter.reset()
+        for producer_map in self._producer_map.values():
+            producer_map.clear()
+        for counter in self._counters.values():
+            counter.reset()

--- a/python/tokenspeed/runtime/cache/executor/memory_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/memory_executor.py
@@ -203,7 +203,7 @@ class MemoryExecutor:
                     io_backend=config.mamba_l2_io_backend,
                 ),
             ]
-            logger.info(
+            logger.debug(
                 "[cache_op] MemoryExecutor init pools=%s host_pools=%s draft=%s mamba=%s io_backend=%s host_layout=%s",
                 [pool.kind.value for pool in pools],
                 [type(self.host_pool).__name__, type(self.mamba_host_pool).__name__],
@@ -280,7 +280,7 @@ class MemoryExecutor:
                     if not src_pages:
                         continue
                     if kind == CacheKind.MAMBA:
-                        logger.info(
+                        logger.debug(
                             "[cache_op][mamba_l2] writeback schedule "
                             "op_id=%s slots=%s device_slots=%s host_slots=%s "
                             "is_retract=%s",
@@ -321,7 +321,7 @@ class MemoryExecutor:
                     if not src_pages:
                         continue
                     if kind == CacheKind.MAMBA:
-                        logger.info(
+                        logger.debug(
                             "[cache_op][mamba_l2] loadback schedule "
                             "op_id=%s slots=%s host_slots=%s device_slots=%s",
                             op_id,

--- a/python/tokenspeed/runtime/cache/executor/memory_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/memory_executor.py
@@ -46,6 +46,10 @@ from tokenspeed.runtime.cache.kv_cache_host import (
     MHATokenToKVPoolHost,
     MLATokenToKVPoolHost,
 )
+from tokenspeed.runtime.cache.mamba_cache_host import MambaPoolHost
+from tokenspeed.runtime.cache.transfer.kv_pool import KVCachePool
+from tokenspeed.runtime.cache.transfer.mamba_pool import MambaCachePool
+from tokenspeed.runtime.cache.transfer.types import CacheKind
 from tokenspeed.runtime.layers.attention.kv_cache.mha import MHATokenToKVPool
 from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
 from tokenspeed.runtime.utils import get_colorful_logger
@@ -64,6 +68,10 @@ class MemoryExecutorConfig:
     storage_backend: Optional[str] = "mooncake"
     storage_backend_extra_config: Optional[str] = None
     model_name: Optional[str] = None
+    enable_mamba_l2: bool = False
+    mamba_l2_host_slots: int = 0
+    mamba_l2_layout: str = "layer_first"
+    mamba_l2_io_backend: str = "kernel"
 
 
 class MemoryExecutor:
@@ -76,6 +84,7 @@ class MemoryExecutor:
         is_dp_attention_enabled: bool,
         tp_group=None,
         draft_device_pool=None,
+        mamba_pool=None,
     ):
         self.page_size = config.page_size
 
@@ -164,18 +173,61 @@ class MemoryExecutor:
             self.draft_host_pool = None
             draft_layer_num = 0
 
-        self.host_exec = HostExecutor(
-            page_size=config.page_size,
-            device_pool=device_pool,
-            host_pool=self.host_pool,
-            io_backend=config.io_backend,
-            layer_num=actual_pool.layer_num,
-            draft_device_pool=(
-                actual_draft_pool if draft_device_pool is not None else None
-            ),
-            draft_host_pool=self.draft_host_pool,
-            draft_layer_num=draft_layer_num,
-        )
+        pools = None
+        self.mamba_host_pool = None
+        if (
+            config.enable_mamba_l2
+            and mamba_pool is not None
+            and config.mamba_l2_host_slots > 0
+        ):
+            self.mamba_host_pool = MambaPoolHost(
+                mamba_pool,
+                host_size_slots=config.mamba_l2_host_slots,
+                layout=config.mamba_l2_layout,
+            )
+            pools = [
+                KVCachePool(
+                    device_pool=device_pool,
+                    host_pool=self.host_pool,
+                    io_backend=config.io_backend,
+                    layer_num=actual_pool.layer_num,
+                    draft_device_pool=(
+                        actual_draft_pool if draft_device_pool is not None else None
+                    ),
+                    draft_host_pool=self.draft_host_pool,
+                    draft_layer_num=draft_layer_num,
+                ),
+                MambaCachePool(
+                    device_pool=mamba_pool,
+                    host_pool=self.mamba_host_pool,
+                    io_backend=config.mamba_l2_io_backend,
+                ),
+            ]
+            logger.info(
+                "[cache_op] MemoryExecutor init pools=%s host_pools=%s draft=%s mamba=%s io_backend=%s host_layout=%s",
+                [pool.kind.value for pool in pools],
+                [type(self.host_pool).__name__, type(self.mamba_host_pool).__name__],
+                self.draft_host_pool is not None,
+                True,
+                config.io_backend,
+                config.host_layout,
+            )
+
+        if pools is not None:
+            self.host_exec = HostExecutor(pools=pools, io_backend=config.io_backend)
+        else:
+            self.host_exec = HostExecutor(
+                page_size=config.page_size,
+                device_pool=device_pool,
+                host_pool=self.host_pool,
+                io_backend=config.io_backend,
+                layer_num=actual_pool.layer_num,
+                draft_device_pool=(
+                    actual_draft_pool if draft_device_pool is not None else None
+                ),
+                draft_host_pool=self.draft_host_pool,
+                draft_layer_num=draft_layer_num,
+            )
         self.storage_exec = StorageExecutor(
             page_size=config.page_size,
             device_pool=device_pool,
@@ -187,9 +239,23 @@ class MemoryExecutor:
             tp_group=tp_group,
         )
 
-    def submit_plan(self, plan) -> None:
+    @staticmethod
+    def _page_groups_by_kind(op) -> dict[CacheKind, tuple[list, list]]:
+        src_by_kind = getattr(op, "src_pages_by_kind", None)
+        dst_by_kind = getattr(op, "dst_pages_by_kind", None)
+        if src_by_kind is None or dst_by_kind is None:
+            return {CacheKind.KV: (op.src_pages, op.dst_pages)}
+        groups: dict[CacheKind, tuple[list, list]] = {}
+        for kind in CacheKind:
+            src_pages = src_by_kind.get(kind.value, [])
+            dst_pages = dst_by_kind.get(kind.value, [])
+            groups[kind] = (src_pages, dst_pages)
+        return groups
+
+    def submit_plan(self, plan, producer_stream=None) -> None:
         if plan.cache:
             logger.debug("[cache_op] submit_plan: %s cache ops", len(plan.cache))
+        self.host_exec.fence_writeback_after(producer_stream)
         for op in plan.cache:
             self.submit(op)
         self.host_exec.flush()
@@ -202,14 +268,41 @@ class MemoryExecutor:
                 len(op.src_pages),
                 len(op.dst_pages),
             )
+            groups = self._page_groups_by_kind(op)
             for i in range(len(op.op_ids)):
                 op_id = op.op_ids[i]
-                src_pages = op.src_pages[i]
-                dst_pages = op.dst_pages[i]
                 is_retract = bool(getattr(op, "is_retract", [False])[i])
-                self.host_exec.enqueue_writeback(
-                    op_id, src_pages, dst_pages, is_retract=is_retract
-                )
+                for kind, (src_groups, dst_groups) in groups.items():
+                    if kind not in self.host_exec.pools:
+                        continue
+                    src_pages = src_groups[i] if i < len(src_groups) else []
+                    dst_pages = dst_groups[i] if i < len(dst_groups) else []
+                    if not src_pages:
+                        continue
+                    if kind == CacheKind.MAMBA:
+                        logger.info(
+                            "[cache_op][mamba_l2] writeback schedule "
+                            "op_id=%s slots=%s device_slots=%s host_slots=%s "
+                            "is_retract=%s",
+                            op_id,
+                            len(src_pages),
+                            src_pages[:8],
+                            dst_pages[:8],
+                            is_retract,
+                        )
+                    self.host_exec.enqueue_writeback(
+                        op_id,
+                        src_pages,
+                        dst_pages,
+                        is_retract=is_retract,
+                        kind=kind,
+                    )
+                if all(
+                    i >= len(src_groups) or not src_groups[i]
+                    for kind, (src_groups, _) in groups.items()
+                    if kind in self.host_exec.pools
+                ):
+                    self.host_exec.completed_writebacks.append(op_id)
         elif isinstance(op, Cache.LoadBackOp):
             logger.debug(
                 "[cache_op] loadback op_id=%s src_pages=%s dst_pages=%s",
@@ -217,11 +310,29 @@ class MemoryExecutor:
                 len(op.src_pages),
                 len(op.dst_pages),
             )
+            groups = self._page_groups_by_kind(op)
             for i in range(len(op.op_ids)):
                 op_id = op.op_ids[i]
-                src_pages = op.src_pages[i]
-                dst_pages = op.dst_pages[i]
-                self.host_exec.enqueue_loadback(op_id, src_pages, dst_pages)
+                for kind, (src_groups, dst_groups) in groups.items():
+                    if kind not in self.host_exec.pools:
+                        continue
+                    src_pages = src_groups[i] if i < len(src_groups) else []
+                    dst_pages = dst_groups[i] if i < len(dst_groups) else []
+                    if not src_pages:
+                        continue
+                    if kind == CacheKind.MAMBA:
+                        logger.info(
+                            "[cache_op][mamba_l2] loadback schedule "
+                            "op_id=%s slots=%s host_slots=%s device_slots=%s",
+                            op_id,
+                            len(src_pages),
+                            src_pages[:8],
+                            dst_pages[:8],
+                        )
+                    self.host_exec.enqueue_loadback(
+                        op_id, src_pages, dst_pages, kind=kind
+                    )
+
         elif isinstance(op, Cache.PrefetchOp):
             logger.debug(
                 "[cache_op] prefetch op_id=%s dst_pages=%s", op.op_id, len(op.dst_pages)
@@ -249,11 +360,17 @@ class MemoryExecutor:
                 )
         return results
 
-    def get_producer_index(self, op_id: int) -> Optional[int]:
-        return self.host_exec.get_producer_index(op_id)
+    def get_producer_index(
+        self, kind_or_op_id: CacheKind | str | int, op_id: int | None = None
+    ) -> Optional[int]:
+        return self.host_exec.get_producer_index(kind_or_op_id, op_id)
 
-    def set_consumer(self, producer_index: int | Iterable[int]) -> None:
-        self.host_exec.set_consumer(producer_index)
+    def set_consumer(
+        self,
+        kind_or_producer_index: CacheKind | str | int | Iterable[int],
+        producer_index: int | Iterable[int] | None = None,
+    ) -> None:
+        self.host_exec.set_consumer(kind_or_producer_index, producer_index)
 
     def query_l3_pages(self, hashes: list[str]) -> int:
         return self.storage_exec.query_exists(hashes)

--- a/python/tokenspeed/runtime/cache/mamba_cache_host.py
+++ b/python/tokenspeed/runtime/cache/mamba_cache_host.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import threading
+from functools import wraps
+from typing import Optional
+
+import torch
+from tokenspeed_kernel.ops.kvcache.cuda import (
+    transfer_kv_all_layer_mla,
+    transfer_kv_direct,
+    transfer_kv_per_layer_mla,
+)
+from tokenspeed_kernel.platform import current_platform
+
+from tokenspeed.runtime.layers.attention.backends.hybrid_linear_attn import (
+    SimpleMambaPool,
+)
+from tokenspeed.runtime.utils import get_colorful_logger
+
+logger = get_colorful_logger(__name__)
+MAMBA_KVSTORE_LOADBACK_BLOCK_QUOTA = 16
+MAMBA_KVSTORE_WRITEBACK_BLOCK_QUOTA = 16
+
+
+def synchronized(func):
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        with self.lock:
+            return func(self, *args, **kwargs)
+
+    return wrapper
+
+
+class MambaPoolHost:
+    """Pinned host mirror for SimpleMambaPool conv_state and ssm_state."""
+
+    def __init__(
+        self,
+        device_pool: SimpleMambaPool,
+        host_size_slots: int,
+        layout: str = "layer_first",
+        pin_memory: bool = True,
+        device: str = "cpu",
+        register_host: bool = True,
+    ):
+        if layout != "layer_first":
+            raise ValueError("MambaPoolHost v1 only supports layer_first layout")
+        if host_size_slots <= 0:
+            raise ValueError("host_size_slots must be positive")
+        self.device_pool = device_pool
+        self.layout = layout
+        self.device = device
+        self.size = int(host_size_slots)
+        self.page_size = 1
+        self.num_layers = int(device_pool.conv_state.shape[0])
+        self.conv_shape = tuple(device_pool.conv_state.shape[2:])
+        self.ssm_shape = tuple(device_pool.ssm_state.shape[2:])
+        self.conv_dtype = device_pool.conv_state.dtype
+        self.ssm_dtype = device_pool.ssm_state.dtype
+        self.conv_item_size = device_pool.conv_state[0, 0].nbytes
+        self.ssm_item_size = device_pool.ssm_state[0, 0].nbytes
+        self.size_per_slot = self.num_layers * (
+            self.conv_item_size + self.ssm_item_size
+        )
+
+        # cudaHostRegister pins ordinary host memory for GPU-side access.
+        # Avoid allocating an already pinned tensor when we will register it,
+        # because some CUDA stacks reject double registration.
+        use_pin_memory = bool(pin_memory and device == "cpu" and not register_host)
+        self.conv_buffer = torch.empty(
+            (self.num_layers, self.size, *self.conv_shape),
+            dtype=self.conv_dtype,
+            device=device,
+            pin_memory=use_pin_memory,
+        )
+        self.ssm_buffer = torch.empty(
+            (self.num_layers, self.size, *self.ssm_shape),
+            dtype=self.ssm_dtype,
+            device=device,
+            pin_memory=use_pin_memory,
+        )
+        if register_host:
+            platform = current_platform()
+            platform.register_host_tensor_for_gpu_access(self.conv_buffer)
+            platform.register_host_tensor_for_gpu_access(self.ssm_buffer)
+
+        self.conv_data_refs = [self.conv_buffer[i] for i in range(self.num_layers)]
+        self.ssm_data_refs = [self.ssm_buffer[i] for i in range(self.num_layers)]
+        # Keep CUDA all-layer kernel pointer tables alive across async launches.
+        self._kernel_ptr_tables: dict[str, torch.Tensor] | None = None
+
+        self.lock = threading.RLock()
+        self.clear()
+        logger.info(
+            "[mamba_l2] alloc host buffer pool_type=%s size_slots=%s "
+            "size_per_slot_mb=%.2f num_mamba_layers=%s layout=%s pin_memory=%s "
+            "total_gb=%.2f",
+            type(self).__name__,
+            self.size,
+            self.size_per_slot / 1e6,
+            self.num_layers,
+            self.layout,
+            use_pin_memory,
+            self.size * self.size_per_slot / 1e9,
+        )
+
+    @synchronized
+    def clear(self) -> None:
+        self.free_slots = torch.arange(self.size, dtype=torch.int64)
+
+    def available_size(self) -> int:
+        return len(self.free_slots)
+
+    @synchronized
+    def alloc(self, need_size: int) -> Optional[torch.Tensor]:
+        if need_size <= 0:
+            return torch.empty((0,), dtype=torch.int64)
+        if need_size > self.available_size():
+            logger.warning(
+                "[mamba_l2] alloc FAILED n=%s remain=%s (will trigger eviction)",
+                need_size,
+                self.available_size(),
+            )
+            return None
+        selected = self.free_slots[:need_size]
+        self.free_slots = self.free_slots[need_size:]
+        logger.debug(
+            "[mamba_l2] alloc n=%s remain=%s", need_size, self.available_size()
+        )
+        return selected
+
+    @synchronized
+    def free(self, indices: torch.Tensor) -> int:
+        indices = indices.to(dtype=torch.int64, device="cpu")
+        self.free_slots = torch.cat([self.free_slots, indices])
+        logger.debug(
+            "[mamba_l2] free n=%s deferred=%s remain=%s",
+            len(indices),
+            False,
+            self.available_size(),
+        )
+        return len(indices)
+
+    def backup_from_device_all_layer(
+        self,
+        device_pool: SimpleMambaPool,
+        host_indices: torch.Tensor,
+        device_indices: torch.Tensor,
+        io_backend: str,
+        block_quota: Optional[int] = None,
+    ) -> None:
+        if block_quota is None:
+            block_quota = MAMBA_KVSTORE_WRITEBACK_BLOCK_QUOTA
+        if io_backend == "kernel":
+            ptrs = self._ensure_kernel_ptr_tables(device_pool)
+            transfer_kv_all_layer_mla(
+                src_layers=ptrs["device_conv"],
+                dst_layers=ptrs["host_conv"],
+                src_indices=device_indices,
+                dst_indices=host_indices,
+                item_size=self.conv_item_size,
+                num_layers=self.num_layers,
+                block_quota=block_quota,
+            )
+            transfer_kv_all_layer_mla(
+                src_layers=ptrs["device_ssm"],
+                dst_layers=ptrs["host_ssm"],
+                src_indices=device_indices,
+                dst_indices=host_indices,
+                item_size=self.ssm_item_size,
+                num_layers=self.num_layers,
+                block_quota=block_quota,
+            )
+        elif io_backend == "direct":
+            transfer_kv_direct(
+                src_layers=self._layer_refs(device_pool.conv_state)
+                + self._layer_refs(device_pool.ssm_state),
+                dst_layers=self.conv_data_refs + self.ssm_data_refs,
+                src_indices=device_indices,
+                dst_indices=host_indices,
+                page_size=self.page_size,
+            )
+        else:
+            raise ValueError(f"Unsupported IO backend: {io_backend}")
+
+    def load_to_device_per_layer(
+        self,
+        device_pool: SimpleMambaPool,
+        host_indices: torch.Tensor,
+        device_indices: torch.Tensor,
+        layer_idx: int,
+        io_backend: str = "kernel",
+    ) -> None:
+        if not 0 <= layer_idx < self.num_layers:
+            raise IndexError(f"layer_idx out of range: {layer_idx}")
+        if io_backend == "kernel":
+            transfer_kv_per_layer_mla(
+                src=self.conv_buffer[layer_idx],
+                dst=device_pool.conv_state[layer_idx],
+                src_indices=host_indices,
+                dst_indices=device_indices,
+                item_size=self.conv_item_size,
+                block_quota=MAMBA_KVSTORE_LOADBACK_BLOCK_QUOTA,
+            )
+            transfer_kv_per_layer_mla(
+                src=self.ssm_buffer[layer_idx],
+                dst=device_pool.ssm_state[layer_idx],
+                src_indices=host_indices,
+                dst_indices=device_indices,
+                item_size=self.ssm_item_size,
+                block_quota=MAMBA_KVSTORE_LOADBACK_BLOCK_QUOTA,
+            )
+        elif io_backend == "direct":
+            transfer_kv_direct(
+                src_layers=[self.conv_buffer[layer_idx], self.ssm_buffer[layer_idx]],
+                dst_layers=[
+                    device_pool.conv_state[layer_idx],
+                    device_pool.ssm_state[layer_idx],
+                ],
+                src_indices=host_indices,
+                dst_indices=device_indices,
+                page_size=self.page_size,
+            )
+        else:
+            raise ValueError(f"Unsupported IO backend: {io_backend}")
+
+    def get_hybrid_pool_buffer(self) -> list[torch.Tensor]:
+        return [self.conv_buffer, self.ssm_buffer]
+
+    @staticmethod
+    def _layer_refs(buffer: torch.Tensor) -> list[torch.Tensor]:
+        return [buffer[i] for i in range(buffer.shape[0])]
+
+    def _ensure_kernel_ptr_tables(
+        self, device_pool: SimpleMambaPool
+    ) -> dict[str, torch.Tensor]:
+        if self._kernel_ptr_tables is None:
+            self._kernel_ptr_tables = {
+                "device_conv": self._data_ptrs(
+                    device_pool.conv_state, device_pool.device
+                ),
+                "host_conv": self._data_ptrs(self.conv_buffer, device_pool.device),
+                "device_ssm": self._data_ptrs(
+                    device_pool.ssm_state, device_pool.device
+                ),
+                "host_ssm": self._data_ptrs(self.ssm_buffer, device_pool.device),
+            }
+        return self._kernel_ptr_tables
+
+    @staticmethod
+    def _data_ptrs(buffer: torch.Tensor, device) -> torch.Tensor:
+        platform = current_platform()
+        return torch.tensor(
+            [
+                platform.device_visible_data_ptr(buffer[i])
+                for i in range(buffer.shape[0])
+            ],
+            dtype=torch.uint64,
+            device=device,
+        )

--- a/python/tokenspeed/runtime/cache/transfer/__init__.py
+++ b/python/tokenspeed/runtime/cache/transfer/__init__.py
@@ -1,0 +1,19 @@
+from tokenspeed.runtime.cache.transfer.kv_pool import KVCachePool
+from tokenspeed.runtime.cache.transfer.mamba_pool import MambaCachePool
+from tokenspeed.runtime.cache.transfer.pool import CachePool
+from tokenspeed.runtime.cache.transfer.types import (
+    CacheKind,
+    Location,
+    TransferBatch,
+    TransferUnit,
+)
+
+__all__ = [
+    "CacheKind",
+    "CachePool",
+    "KVCachePool",
+    "Location",
+    "MambaCachePool",
+    "TransferBatch",
+    "TransferUnit",
+]

--- a/python/tokenspeed/runtime/cache/transfer/kv_pool.py
+++ b/python/tokenspeed/runtime/cache/transfer/kv_pool.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import torch
+
+from tokenspeed.runtime.cache.kvstore_controller import LayerDoneCounter
+from tokenspeed.runtime.cache.transfer.types import CacheKind
+
+
+class KVCachePool:
+    kind = CacheKind.KV
+
+    def __init__(
+        self,
+        device_pool,
+        host_pool,
+        io_backend: str,
+        layer_num: int,
+        draft_device_pool=None,
+        draft_host_pool=None,
+        draft_layer_num: int = 0,
+    ):
+        self.device_pool = device_pool
+        self.host_pool = host_pool
+        self.io_backend = io_backend
+        self.layer_num = layer_num
+        self.draft_device_pool = draft_device_pool
+        self.draft_host_pool = draft_host_pool
+        self.draft_layer_num = draft_layer_num
+        self._counter = LayerDoneCounter(max(layer_num, draft_layer_num, 1))
+        device_pool.register_layer_transfer_counter(self._counter)
+
+    @property
+    def device(self):
+        return self.device_pool.device
+
+    @property
+    def host_layout(self) -> str:
+        return self.host_pool.layout
+
+    def page_size(self) -> int:
+        return self.host_pool.page_size
+
+    def num_layers(self) -> int:
+        return max(self.layer_num, self.draft_layer_num)
+
+    def supports_layerwise_loadback(self) -> bool:
+        return True
+
+    def get_layer_done_counter(self) -> LayerDoneCounter:
+        return self._counter
+
+    def local_layer_idx(self, global_layer_id: int) -> int:
+        return global_layer_id
+
+    def writeback(
+        self,
+        src_indices: torch.Tensor,
+        dst_indices: torch.Tensor,
+        block_quota: int | None = None,
+    ) -> None:
+        self.host_pool.backup_from_device_all_layer(
+            self.device_pool,
+            dst_indices,
+            src_indices,
+            self.io_backend,
+            block_quota=block_quota,
+        )
+        if self.draft_host_pool is not None:
+            self.draft_host_pool.backup_from_device_all_layer(
+                self.draft_device_pool,
+                dst_indices,
+                src_indices,
+                self.io_backend,
+                block_quota=block_quota,
+            )
+
+    def loadback(
+        self, src_indices: torch.Tensor, dst_indices: torch.Tensor, layer_idx: int
+    ) -> None:
+        if layer_idx < self.layer_num:
+            self.host_pool.load_to_device_per_layer(
+                self.device_pool,
+                src_indices,
+                dst_indices,
+                layer_idx,
+                self.io_backend,
+            )
+        if self.draft_host_pool is not None and layer_idx < self.draft_layer_num:
+            self.draft_host_pool.load_to_device_per_layer(
+                self.draft_device_pool,
+                src_indices,
+                dst_indices,
+                layer_idx,
+                self.io_backend,
+            )
+
+    def alloc_host(self, n: int):
+        return self.host_pool.alloc(n)
+
+    def free_host(self, indices: torch.Tensor) -> None:
+        self.host_pool.free(indices)
+
+    def host_available(self) -> int:
+        return self.host_pool.available_size()

--- a/python/tokenspeed/runtime/cache/transfer/mamba_pool.py
+++ b/python/tokenspeed/runtime/cache/transfer/mamba_pool.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import torch
+
+from tokenspeed.runtime.cache.kvstore_controller import LayerDoneCounter
+from tokenspeed.runtime.cache.mamba_cache_host import MambaPoolHost
+from tokenspeed.runtime.cache.transfer.types import CacheKind
+from tokenspeed.runtime.layers.attention.backends.hybrid_linear_attn import (
+    SimpleMambaPool,
+)
+
+
+class MambaCachePool:
+    kind = CacheKind.MAMBA
+
+    def __init__(
+        self,
+        device_pool: SimpleMambaPool,
+        host_pool: MambaPoolHost,
+        io_backend: str,
+    ):
+        self.device_pool = device_pool
+        self.host_pool = host_pool
+        self.io_backend = io_backend
+        self._counter = LayerDoneCounter(self.num_layers())
+        device_pool.register_layer_transfer_counter(self._counter)
+
+    @property
+    def device(self):
+        return self.device_pool.device
+
+    @property
+    def host_layout(self) -> str:
+        return self.host_pool.layout
+
+    def page_size(self) -> int:
+        return 1
+
+    def num_layers(self) -> int:
+        return int(self.device_pool.conv_state.shape[0])
+
+    def supports_layerwise_loadback(self) -> bool:
+        return True
+
+    def get_layer_done_counter(self) -> LayerDoneCounter:
+        return self._counter
+
+    def local_layer_idx(self, global_layer_id: int) -> int:
+        return self.device_pool.mamba_map[global_layer_id]
+
+    def writeback(
+        self,
+        src_indices: torch.Tensor,
+        dst_indices: torch.Tensor,
+        block_quota: int | None = None,
+    ) -> None:
+        self.host_pool.backup_from_device_all_layer(
+            self.device_pool,
+            host_indices=dst_indices,
+            device_indices=src_indices,
+            io_backend=self.io_backend,
+            block_quota=block_quota,
+        )
+
+    def loadback(
+        self, src_indices: torch.Tensor, dst_indices: torch.Tensor, layer_idx: int
+    ) -> None:
+        self.host_pool.load_to_device_per_layer(
+            self.device_pool,
+            host_indices=src_indices,
+            device_indices=dst_indices,
+            layer_idx=layer_idx,
+            io_backend=self.io_backend,
+        )
+
+    def alloc_host(self, n: int):
+        return self.host_pool.alloc(n)
+
+    def free_host(self, indices: torch.Tensor) -> None:
+        self.host_pool.free(indices)
+
+    def host_available(self) -> int:
+        return self.host_pool.available_size()

--- a/python/tokenspeed/runtime/cache/transfer/pool.py
+++ b/python/tokenspeed/runtime/cache/transfer/pool.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Optional, Protocol
+
+import torch
+
+from tokenspeed.runtime.cache.transfer.types import CacheKind
+
+
+class CachePool(Protocol):
+    kind: CacheKind
+    device: torch.device | str
+    host_layout: str
+
+    def page_size(self) -> int: ...
+
+    def num_layers(self) -> int: ...
+
+    def supports_layerwise_loadback(self) -> bool: ...
+
+    def writeback(
+        self,
+        src_indices: torch.Tensor,
+        dst_indices: torch.Tensor,
+        block_quota: int | None = None,
+    ) -> None: ...
+
+    def loadback(
+        self, src_indices: torch.Tensor, dst_indices: torch.Tensor, layer_idx: int
+    ) -> None: ...
+
+    def get_layer_done_counter(self): ...
+
+    def local_layer_idx(self, global_layer_id: int) -> int: ...
+
+    def alloc_host(self, n: int) -> Optional[torch.Tensor]: ...
+
+    def free_host(self, indices: torch.Tensor) -> None: ...
+
+    def host_available(self) -> int: ...

--- a/python/tokenspeed/runtime/cache/transfer/types.py
+++ b/python/tokenspeed/runtime/cache/transfer/types.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+import torch
+
+
+class CacheKind(str, Enum):
+    KV = "kv"
+    MAMBA = "mamba"
+
+
+class Location(str, Enum):
+    DEVICE = "device"
+    HOST = "host"
+    STORAGE = "storage"
+
+
+@dataclass(slots=True)
+class TransferUnit:
+    kind: CacheKind
+    src_loc: Location
+    dst_loc: Location
+    src_indices: torch.Tensor
+    dst_indices: torch.Tensor
+    op_id: int
+    is_retract: bool = False
+
+    @property
+    def direction(self) -> tuple[Location, Location]:
+        return (self.src_loc, self.dst_loc)
+
+
+@dataclass(slots=True)
+class TransferBatch:
+    units: list[TransferUnit]
+    op_ids: list[int]

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -35,6 +35,7 @@ from tokenspeed.runtime.cache.executor.memory_executor import (
     MemoryExecutor,
     MemoryExecutorConfig,
 )
+from tokenspeed.runtime.cache.transfer.types import CacheKind
 from tokenspeed.runtime.configs.model_config import ModelConfig
 from tokenspeed.runtime.distributed.process_group_manager import (
     process_group_manager as pg_manager,
@@ -224,6 +225,26 @@ class EventLoop:
                 "KVStore L2 cache will not be used during normal execution, but it will still be used when retraction happens."
             )
 
+        mamba_l2_host_slots = 0
+        if has_mamba and server_args.enable_mamba_l2:
+            if server_args.mamba_l2_host_slots > 0:
+                mamba_l2_host_slots = server_args.mamba_l2_host_slots
+            elif server_args.mamba_l2_host_gb > 0 and mamba_pool is not None:
+                slot_bytes = int(
+                    mamba_pool.conv_state.shape[0]
+                    * (
+                        mamba_pool.conv_state[0, 0].nbytes
+                        + mamba_pool.ssm_state[0, 0].nbytes
+                    )
+                )
+                mamba_l2_host_slots = int(
+                    server_args.mamba_l2_host_gb * (1024**3) // max(slot_bytes, 1)
+                )
+            else:
+                mamba_l2_host_slots = max(
+                    int(mamba_pool_total_chunks * server_args.mamba_l2_ratio), 1
+                )
+
         mem_cfg = MemoryExecutorConfig(
             layer_num=self.model_config.num_hidden_layers,
             page_size=server_args.block_size,
@@ -234,6 +255,10 @@ class EventLoop:
             storage_backend=server_args.kvstore_storage_backend,
             storage_backend_extra_config=server_args.kvstore_storage_backend_extra_config,
             model_name=server_args.model,
+            enable_mamba_l2=server_args.enable_mamba_l2,
+            mamba_l2_host_slots=mamba_l2_host_slots,
+            mamba_l2_layout=server_args.mamba_l2_layout,
+            mamba_l2_io_backend=server_args.mamba_l2_io_backend,
         )
         is_deepseek_v4_pool = (
             type(token_to_kv_pool).__name__ == "DeepseekV4TokenToKVPool"
@@ -253,6 +278,7 @@ class EventLoop:
                 is_dp_attention_enabled=self.has_dp,
                 tp_group=self.attn_tp_cpu_group,
                 draft_device_pool=draft_token_to_kv_pool,
+                mamba_pool=mamba_pool,
             )
             num_host_pages = self.memory_executor.host_pool.page_num
 
@@ -274,6 +300,7 @@ class EventLoop:
             )
 
         # Adjunct enabled only when pool opts in AND prefix-caching switch is on.
+
         paged_cache_groups = pool_to_paged_cache_groups(token_to_kv_pool)
         prefix_cache_adjunct = None
         required_groups = token_to_kv_pool.prefix_cache_required_group_ids
@@ -299,6 +326,8 @@ class EventLoop:
             enable_mamba=has_mamba,
             mamba_cache_chunk_size=server_args.mamba_cache_chunk_size,
             mamba_pool_total_chunks=mamba_pool_total_chunks,
+            enable_mamba_l2=server_args.enable_mamba_l2,
+            mamba_l2_host_slots=mamba_l2_host_slots,
             paged_cache_groups=paged_cache_groups,
             enable_mixed_prefill_decode=server_args.enable_mixed_batch,
             prefix_cache_adjunct=prefix_cache_adjunct,
@@ -610,7 +639,9 @@ class EventLoop:
     def _submit_cache_ops(self, execution_plan) -> None:
         if self.memory_executor is None:
             return
-        self.memory_executor.submit_plan(execution_plan)
+        self.memory_executor.submit_plan(
+            execution_plan, producer_stream=self.model_executor.execution_stream
+        )
         for op in execution_plan.cache:
             if isinstance(op, (Cache.WriteBackOp, Cache.LoadBackOp)):
                 self._num_inflight_cache_ops += len(op.op_ids)
@@ -621,29 +652,44 @@ class EventLoop:
         self._setup_layerwise_loadback(execution_plan)
 
     def _setup_layerwise_loadback(self, execution_plan) -> None:
-        consumer_indices = []
+        host_exec = getattr(self.memory_executor, "host_exec", None)
+        available_pools = (
+            getattr(host_exec, "pools", {}) if host_exec is not None else {}
+        )
+        consumer_indices_by_kind: dict[CacheKind, list[int]] = {
+            kind: [] for kind in available_pools
+        }
         for cache_op in execution_plan.cache:
             if isinstance(cache_op, Cache.LoadBackOp):
                 for op_id in cache_op.op_ids:
-                    producer_idx = self.memory_executor.get_producer_index(op_id)
-                    if (
-                        producer_idx is not None
-                        and producer_idx not in consumer_indices
-                    ):
-                        consumer_indices.append(producer_idx)
-        self.memory_executor.set_consumer(consumer_indices if consumer_indices else -1)
+                    for kind in consumer_indices_by_kind:
+                        producer_idx = self.memory_executor.get_producer_index(
+                            kind, op_id
+                        )
+                        if (
+                            producer_idx is not None
+                            and producer_idx not in consumer_indices_by_kind[kind]
+                        ):
+                            consumer_indices_by_kind[kind].append(producer_idx)
+        for kind, consumer_indices in consumer_indices_by_kind.items():
+            self.memory_executor.set_consumer(
+                kind, consumer_indices if consumer_indices else -1
+            )
+        has_mamba_loadback = bool(consumer_indices_by_kind.get(CacheKind.MAMBA))
         # Fence WriteBack against this iter's ``set_kv_buffer``: the
         # scheduler can re-allocate a freed-but-not-yet-written-back slot
         # to a new prefill / decode within the same iter. ``set_kv_buffer``
         # runs before any ``wait_until`` in attention, so nothing else
         # orders writeback's reads against the new writes. Cheap when
         # write_stream is idle.
-        # LoadBack does not need fencing here: it only fires on admission
-        # iters (eager prefill), whose per-layer ``wait_until`` drains
-        # ``load_stream`` before the iter ends.
         host_exec = getattr(self.memory_executor, "host_exec", None)
         if host_exec is not None:
             self.model_executor.execution_stream.wait_stream(host_exec.write_stream)
+            if has_mamba_loadback:
+                # Mamba COW runs before the layerwise waits in mamba forward and
+                # reads the freshly loaded tree slot into the request-local
+                # working slot. Fence load_stream here so COW cannot race H->D.
+                self.model_executor.execution_stream.wait_stream(host_exec.load_stream)
 
     def _flush_mamba_retract_states(self, forward_op) -> None:
         """Copy draft->working mamba states when retract occurred (no forward scheduled)."""

--- a/python/tokenspeed/runtime/engine/scheduler_utils.py
+++ b/python/tokenspeed/runtime/engine/scheduler_utils.py
@@ -67,6 +67,8 @@ def make_config(
     enable_mamba: bool = False,
     mamba_cache_chunk_size: int = 64,
     mamba_pool_total_chunks: int = 0,
+    enable_mamba_l2: bool = False,
+    mamba_l2_host_slots: int = 0,
     paged_cache_groups: Sequence["PagedCacheGroupConfig"] | None = None,
     enable_mixed_prefill_decode: bool = False,
     prefix_cache_adjunct: "PrefixCacheAdjunctSpec | None" = None,
@@ -96,6 +98,8 @@ def make_config(
     cfg.enable_mamba = enable_mamba
     cfg.mamba_cache_chunk_size = mamba_cache_chunk_size
     cfg.mamba_pool_total_chunks = mamba_pool_total_chunks
+    cfg.enable_mamba_l2 = enable_mamba_l2
+    cfg.mamba_l2_host_slots = mamba_l2_host_slots
     cfg.enable_mixed_prefill_decode = enable_mixed_prefill_decode
     if paged_cache_groups:
         cfg.paged_cache_groups = list(paged_cache_groups)

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -169,6 +169,7 @@ class SimpleMambaPool:
         )
 
         self.mamba_cache = (self.conv_state, self.ssm_state)
+        self.layer_transfer_counter = None
 
         self.current_input_indices = torch.full(
             (self.current_input_size,), -1, dtype=torch.int32, device=device
@@ -272,13 +273,20 @@ class SimpleMambaPool:
         selected = output_indices[rows, (accepted_lengths - 1).long()].to(torch.int32)
         self.current_input_indices[req_pool_indices.long()] = selected
 
+    def register_layer_transfer_counter(self, layer_transfer_counter):
+        self.layer_transfer_counter = layer_transfer_counter
+
     def get_mamba_params(self, layer_id: int):
         """Return per-layer cache slices."""
         internal_idx = self.mamba_map[layer_id]
+        if self.layer_transfer_counter is not None:
+            self.layer_transfer_counter.wait_until(internal_idx)
         return [self.mamba_cache[i][internal_idx] for i in range(len(self.mamba_cache))]
 
     def get_mamba_params_all_layers(self):
         """Return all layers for all cache components."""
+        if self.layer_transfer_counter is not None:
+            self.layer_transfer_counter.wait_until(self.conv_state.shape[0] - 1)
         return [self.mamba_cache[i] for i in range(len(self.mamba_cache))]
 
     def get_contiguous_buf_infos(self):
@@ -415,17 +423,12 @@ class MambaAttnBackend(AttentionBackend):
         if (
             forward_mode.is_extend_or_mixed() or is_draft_extend
         ) and not is_target_verify:
-            mamba_branching_seqlens = kwargs.get("mamba_branching_seqlens")
             extend_prefix_lens_kw = kwargs.get("extend_prefix_lens")
             mamba_track_pool_indices = kwargs.get("mamba_track_pool_indices")
             if (
-                mamba_branching_seqlens is not None
-                and extend_prefix_lens_kw is not None
+                extend_prefix_lens_kw is not None
                 and mamba_track_pool_indices is not None
             ):
-                branching = mamba_branching_seqlens[:bs].to(
-                    dtype=torch.int32, device=self.device
-                )
                 prefix = extend_prefix_lens_kw[:bs].to(
                     dtype=torch.int32, device=self.device
                 )
@@ -435,24 +438,19 @@ class MambaAttnBackend(AttentionBackend):
                 extend_lens = (seq_lens[:bs] - prefix).to(torch.int32)
                 checkpoint_mask = (track_indices >= 0) & (mamba_cache_indices >= 0)
 
-                branch_lens = branching - prefix
-                branch_inside = (
-                    (branching > 0)
-                    & checkpoint_mask
-                    & (branch_lens > 0)
-                    & (branch_lens < extend_lens)
-                )
-                track_mask = branch_inside & ((branch_lens % FLA_CHUNK_SIZE) == 0)
-                if (branch_inside & ~track_mask).any():
-                    raise RuntimeError(
-                        "Mamba branching seqlen must be aligned to FLA chunk size"
-                    )
-
                 page_size = getattr(self.pool, "page_size", 1)
                 final_lens = prefix + extend_lens
+                last_inserted_lens = (final_lens // page_size) * page_size
+                track_lens = last_inserted_lens - prefix
+                track_inside = (
+                    checkpoint_mask & (track_lens > 0) & (track_lens < extend_lens)
+                )
+                track_mask = track_inside & ((track_lens % FLA_CHUNK_SIZE) == 0)
+                # C++ attaches the checkpoint slot to the last KV page inserted
+                # for this chunk. When a chunk has an intermediate branch and
+                # ends exactly on a page boundary, the final state must win.
                 final_mask = (
                     checkpoint_mask
-                    & ~branch_inside
                     & (final_lens >= page_size)
                     & ((final_lens % page_size) == 0)
                 )
@@ -465,14 +463,14 @@ class MambaAttnBackend(AttentionBackend):
                         track_ssm_h_src,
                         track_ssm_h_dst,
                     ) = self._compute_track_ssm_indices(
-                        branch_lens,
+                        track_lens,
                         track_mask,
                         track_indices,
                         seq_lens[:bs] - prefix,  # extend_seq_lens
                     )
                     track_conv_indices = self._compute_track_conv_indices(
                         query_start_loc,
-                        branch_lens,
+                        track_lens,
                         track_mask,
                     )
 
@@ -492,12 +490,12 @@ class MambaAttnBackend(AttentionBackend):
     def _compute_track_conv_indices(
         self,
         query_start_loc: torch.Tensor,
-        branch_lens: torch.Tensor,
+        track_lens: torch.Tensor,
         track_mask: torch.Tensor,
     ):
         """Compute packed input indices for conv windows at tracked boundaries."""
         conv_state_len = self.pool.conv_state.shape[-1]
-        lens_m = branch_lens[track_mask]
+        lens_m = track_lens[track_mask]
         start = query_start_loc[:-1][track_mask] + lens_m - conv_state_len
         indices = start.unsqueeze(-1) + torch.arange(
             conv_state_len,
@@ -508,7 +506,7 @@ class MambaAttnBackend(AttentionBackend):
 
     def _compute_track_ssm_indices(
         self,
-        branch_lens: torch.Tensor,
+        track_lens: torch.Tensor,
         track_mask: torch.Tensor,
         mamba_track_indices: torch.Tensor,
         extend_seq_lens: torch.Tensor,
@@ -521,7 +519,7 @@ class MambaAttnBackend(AttentionBackend):
         offset = torch.zeros_like(num_h_states)
         offset[1:] = torch.cumsum(num_h_states[:-1], dim=0)
 
-        lens_m = branch_lens[track_mask]
+        lens_m = track_lens[track_mask]
         offset_m = offset[track_mask]
         dst_m = mamba_track_indices[track_mask]  # write to TRACKING slots
 

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -95,6 +95,12 @@ class ServerArgs:
     mamba_track_interval: int = 256
     max_mamba_cache_size: int | None = None
     mamba_full_memory_ratio: float = 0.9
+    enable_mamba_l2: bool = False
+    mamba_l2_host_slots: int = 0
+    mamba_l2_ratio: float = 2.0
+    mamba_l2_layout: str = "layer_first"
+    mamba_l2_io_backend: str = "kernel"
+    mamba_l2_host_gb: int = 0
 
     # Other runtime options
     stream_interval: int = 1
@@ -922,6 +928,43 @@ class ServerArgs:
             type=float,
             default=ServerArgs.mamba_full_memory_ratio,
             help="Memory ratio used to split cache budget between Mamba state chunks and full-attention KV cache.",
+        )
+        parser.add_argument(
+            "--enable-mamba-l2",
+            action="store_true",
+            help="Enable host-memory L2 cache for Mamba state slots.",
+        )
+        parser.add_argument(
+            "--mamba-l2-host-slots",
+            type=int,
+            default=ServerArgs.mamba_l2_host_slots,
+            help="Number of host Mamba L2 slots. If 0, derive from --mamba-l2-host-gb or --mamba-l2-ratio.",
+        )
+        parser.add_argument(
+            "--mamba-l2-ratio",
+            type=float,
+            default=ServerArgs.mamba_l2_ratio,
+            help="Mamba host L2 slot ratio relative to device Mamba slots when host slots are not explicit.",
+        )
+        parser.add_argument(
+            "--mamba-l2-layout",
+            type=str,
+            choices=["layer_first"],
+            default=ServerArgs.mamba_l2_layout,
+            help="Mamba host L2 memory layout.",
+        )
+        parser.add_argument(
+            "--mamba-l2-io-backend",
+            type=str,
+            choices=["direct", "kernel"],
+            default=ServerArgs.mamba_l2_io_backend,
+            help="IO backend for Mamba L2 host/device transfers.",
+        )
+        parser.add_argument(
+            "--mamba-l2-host-gb",
+            type=int,
+            default=ServerArgs.mamba_l2_host_gb,
+            help="Mamba L2 host memory budget in GiB. Overrides --mamba-l2-ratio when host slots are not explicit.",
         )
 
         parser.add_argument(

--- a/test/runtime/cache/test_mamba_cache_host.py
+++ b/test/runtime/cache/test_mamba_cache_host.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import torch
+
+from tokenspeed.runtime.cache.mamba_cache_host import MambaPoolHost
+from tokenspeed.runtime.cache.transfer.mamba_pool import MambaCachePool
+from tokenspeed.runtime.layers.attention.backends.hybrid_linear_attn import (
+    SimpleMambaPool,
+)
+
+
+def _new_mamba_pool(size: int = 4):
+    return SimpleMambaPool(
+        size=size,
+        num_mamba_layers=2,
+        conv_state_shape=(3,),
+        temporal_state_shape=(2, 2),
+        conv_dtype=torch.float32,
+        ssm_dtype=torch.float32,
+        mamba_layer_ids=[4, 7],
+        device="cpu",
+        page_size=1,
+    )
+
+
+def test_mamba_pool_host_alloc_free_tracks_slots():
+    device_pool = _new_mamba_pool(size=3)
+    host_pool = MambaPoolHost(
+        device_pool, host_size_slots=2, pin_memory=False, register_host=False
+    )
+
+    first = host_pool.alloc(1)
+    second = host_pool.alloc(1)
+    assert first.tolist() == [0]
+    assert second.tolist() == [1]
+    assert host_pool.alloc(1) is None
+
+    host_pool.free(first)
+    assert host_pool.available_size() == 1
+    assert host_pool.alloc(1).tolist() == [0]
+
+
+class _SpyPlatform:
+    def __init__(self):
+        self.registered = []
+
+    def register_host_tensor_for_gpu_access(self, tensor):
+        self.registered.append(tensor)
+
+
+def test_mamba_pool_host_registers_unpinned_cpu_buffers(monkeypatch):
+    import tokenspeed.runtime.cache.mamba_cache_host as mamba_cache_host
+
+    device_pool = _new_mamba_pool(size=2)
+    platform = _SpyPlatform()
+    monkeypatch.setattr(mamba_cache_host, "current_platform", lambda: platform)
+
+    host_pool = MambaPoolHost(
+        device_pool, host_size_slots=2, pin_memory=True, register_host=True
+    )
+
+    assert platform.registered == [host_pool.conv_buffer, host_pool.ssm_buffer]
+    assert not host_pool.conv_buffer.is_pinned()
+    assert not host_pool.ssm_buffer.is_pinned()
+
+
+def test_mamba_pool_host_kernel_writeback_reuses_pointer_tables(monkeypatch):
+    import tokenspeed.runtime.cache.mamba_cache_host as mamba_cache_host
+
+    class PtrPlatform(_SpyPlatform):
+        def device_visible_data_ptr(self, tensor):
+            return tensor.data_ptr()
+
+    calls = []
+
+    def fake_transfer_kv_all_layer_mla(**kwargs):
+        calls.append((kwargs["src_layers"], kwargs["dst_layers"]))
+
+    monkeypatch.setattr(mamba_cache_host, "current_platform", lambda: PtrPlatform())
+    monkeypatch.setattr(
+        mamba_cache_host,
+        "transfer_kv_all_layer_mla",
+        fake_transfer_kv_all_layer_mla,
+    )
+
+    device_pool = _new_mamba_pool(size=4)
+    host_pool = MambaPoolHost(
+        device_pool, host_size_slots=4, pin_memory=False, register_host=False
+    )
+    device_indices = torch.tensor([0, 2], dtype=torch.int64)
+    host_indices = torch.tensor([1, 3], dtype=torch.int64)
+
+    for _ in range(2):
+        host_pool.backup_from_device_all_layer(
+            device_pool, host_indices, device_indices, io_backend="kernel"
+        )
+
+    ptrs = host_pool._kernel_ptr_tables
+    assert ptrs is not None
+    assert (
+        calls
+        == [
+            (ptrs["device_conv"], ptrs["host_conv"]),
+            (ptrs["device_ssm"], ptrs["host_ssm"]),
+        ]
+        * 2
+    )
+
+
+def test_mamba_pool_host_direct_roundtrip_is_layerwise():
+    device_pool = _new_mamba_pool(size=4)
+    host_pool = MambaPoolHost(
+        device_pool, host_size_slots=4, pin_memory=False, register_host=False
+    )
+    device_indices = torch.tensor([0, 2], dtype=torch.int64)
+    host_indices = torch.tensor([1, 3], dtype=torch.int64)
+
+    device_pool.conv_state[:, device_indices] = torch.arange(
+        device_pool.conv_state[:, device_indices].numel(), dtype=torch.float32
+    ).reshape_as(device_pool.conv_state[:, device_indices])
+    device_pool.ssm_state[:, device_indices] = (
+        torch.arange(
+            device_pool.ssm_state[:, device_indices].numel(), dtype=torch.float32
+        ).reshape_as(device_pool.ssm_state[:, device_indices])
+        + 1000
+    )
+    expected_conv = device_pool.conv_state[:, device_indices].clone()
+    expected_ssm = device_pool.ssm_state[:, device_indices].clone()
+
+    host_pool.backup_from_device_all_layer(
+        device_pool,
+        host_indices=host_indices,
+        device_indices=device_indices,
+        io_backend="direct",
+    )
+    device_pool.conv_state.zero_()
+    device_pool.ssm_state.zero_()
+
+    host_pool.load_to_device_per_layer(
+        device_pool,
+        host_indices=host_indices,
+        device_indices=device_indices,
+        layer_idx=0,
+        io_backend="direct",
+    )
+    assert torch.equal(device_pool.conv_state[0, device_indices], expected_conv[0])
+    assert torch.equal(device_pool.ssm_state[0, device_indices], expected_ssm[0])
+    assert torch.equal(
+        device_pool.conv_state[1, device_indices], torch.zeros_like(expected_conv[1])
+    )
+    assert torch.equal(
+        device_pool.ssm_state[1, device_indices], torch.zeros_like(expected_ssm[1])
+    )
+
+    host_pool.load_to_device_per_layer(
+        device_pool,
+        host_indices=host_indices,
+        device_indices=device_indices,
+        layer_idx=1,
+        io_backend="direct",
+    )
+    assert torch.equal(device_pool.conv_state[:, device_indices], expected_conv)
+    assert torch.equal(device_pool.ssm_state[:, device_indices], expected_ssm)
+
+
+def test_mamba_cache_pool_registers_layer_counter_and_delegates():
+    device_pool = _new_mamba_pool(size=2)
+    host_pool = MambaPoolHost(
+        device_pool, host_size_slots=2, pin_memory=False, register_host=False
+    )
+    cache_pool = MambaCachePool(device_pool, host_pool, io_backend="direct")
+
+    assert device_pool.layer_transfer_counter is cache_pool.get_layer_done_counter()
+    assert cache_pool.kind.value == "mamba"
+    assert cache_pool.page_size() == 1
+    assert cache_pool.num_layers() == 2
+    assert cache_pool.local_layer_idx(7) == 1
+
+
+class SpyCounter:
+    def __init__(self):
+        self.waited = []
+
+    def wait_until(self, layer_idx: int):
+        self.waited.append(layer_idx)
+
+
+def test_simple_mamba_pool_waits_for_local_layer_before_returning_params():
+    device_pool = _new_mamba_pool(size=2)

--- a/test/runtime/cache/test_transfer_host_executor.py
+++ b/test/runtime/cache/test_transfer_host_executor.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import pytest
+import torch
+
+from tokenspeed.runtime.cache.transfer.types import CacheKind, Location, TransferUnit
+
+
+class FakeEvent:
+    def __init__(self):
+        self.recorded = False
+
+    def record(self):
+        self.recorded = True
+
+    def wait(self, stream):
+        return None
+
+    def query(self):
+        return True
+
+    def synchronize(self):
+        self.recorded = True
+
+
+class FakeStream:
+    def synchronize(self):
+        return None
+
+
+class FakeDeviceModule:
+    Event = FakeEvent
+    Stream = FakeStream
+
+    @staticmethod
+    def stream(stream):
+        return nullcontext()
+
+    @staticmethod
+    def current_stream():
+        return FakeStream()
+
+
+class FakeLayerEvent:
+    def __init__(self, num_layers: int):
+        self.start_event = FakeEvent()
+        self.load_events = [FakeEvent() for _ in range(num_layers)]
+
+    def complete(self, layer_idx: int):
+        self.load_events[layer_idx].record()
+
+    @property
+    def finish_event(self):
+        return self.load_events[-1]
+
+
+class FakeCounter:
+    def __init__(self, num_layers: int):
+        self.events = [FakeLayerEvent(num_layers) for _ in range(3)]
+        self.producer = -1
+        self.consumer = None
+
+    def update_producer(self):
+        self.producer = (self.producer + 1) % len(self.events)
+        return self.producer
+
+    def set_consumer(self, producer_index):
+        self.consumer = producer_index
+
+    def reset(self):
+        self.producer = -1
+        self.consumer = None
+
+
+class FakePool:
+    def __init__(self, kind: CacheKind, page_size: int, num_layers: int):
+        self.kind = kind
+        self._page_size = page_size
+        self._num_layers = num_layers
+        self.device = torch.device("cpu")
+        self.host_layout = "layer_first"
+        self.writebacks: list[tuple[list[int], list[int]]] = []
+        self.loadbacks: list[tuple[int, list[int], list[int]]] = []
+        self.counter = FakeCounter(num_layers)
+
+    def page_size(self):
+        return self._page_size
+
+    def num_layers(self):
+        return self._num_layers
+
+    def supports_layerwise_loadback(self):
+        return True
+
+    def writeback(self, src_indices, dst_indices):
+        self.writebacks.append((src_indices.tolist(), dst_indices.tolist()))
+
+    def loadback(self, src_indices, dst_indices, layer_idx: int):
+        self.loadbacks.append((layer_idx, src_indices.tolist(), dst_indices.tolist()))
+
+    def get_layer_done_counter(self):
+        return self.counter
+
+    def reset(self):
+        self.writebacks.clear()
+        self.loadbacks.clear()
+        self.counter.reset()
+
+
+def _patch_host_executor_device(monkeypatch):
+    import tokenspeed.runtime.cache.executor.host_executor as host_executor
+
+    monkeypatch.setattr(host_executor, "device_module", FakeDeviceModule)
+    return host_executor.HostExecutor
+
+
+def test_transfer_unit_exposes_direction():
+    unit = TransferUnit(
+        kind=CacheKind.MAMBA,
+        src_loc=Location.DEVICE,
+        dst_loc=Location.HOST,
+        src_indices=torch.tensor([1, 2], dtype=torch.int64),
+        dst_indices=torch.tensor([3, 4], dtype=torch.int64),
+        op_id=99,
+    )
+
+    assert unit.direction == (Location.DEVICE, Location.HOST)
+
+
+def test_host_executor_keeps_page_indices_on_cpu_until_flush(monkeypatch):
+    host_executor = __import__(
+        "tokenspeed.runtime.cache.executor.host_executor",
+        fromlist=["HostExecutor"],
+    )
+    monkeypatch.setattr(host_executor, "device_module", FakeDeviceModule)
+
+    seen_devices = []
+    real_converter = host_executor.page_ids_to_token_indices
+
+    def spy_page_ids_to_token_indices(page_ids, page_size, device="cpu"):
+        seen_devices.append(device)
+        return real_converter(page_ids, page_size, device)
+
+    monkeypatch.setattr(
+        host_executor, "page_ids_to_token_indices", spy_page_ids_to_token_indices
+    )
+    executor = host_executor.HostExecutor(
+        pools=[FakePool(CacheKind.KV, page_size=4, num_layers=2)], io_backend="kernel"
+    )
+
+    executor.enqueue_writeback(1, src_pages=[2], dst_pages=[5], kind=CacheKind.KV)
+    executor.enqueue_loadback(2, src_pages=[7], dst_pages=[11], kind=CacheKind.KV)
+
+    assert seen_devices == ["cpu", "cpu", "cpu", "cpu"]
+    assert executor.write_queues[CacheKind.KV][0].src_indices.device.type == "cpu"
+    assert executor.write_queues[CacheKind.KV][0].dst_indices.device.type == "cpu"
+    assert executor.load_queues[CacheKind.KV][0].src_indices.device.type == "cpu"
+    assert executor.load_queues[CacheKind.KV][0].dst_indices.device.type == "cpu"
+
+
+def test_host_executor_batches_writeback_by_cache_kind_and_acks_once(monkeypatch):
+    HostExecutor = _patch_host_executor_device(monkeypatch)
+    kv_pool = FakePool(CacheKind.KV, page_size=4, num_layers=2)
+    mamba_pool = FakePool(CacheKind.MAMBA, page_size=1, num_layers=3)
+    executor = HostExecutor(pools=[kv_pool, mamba_pool], io_backend="kernel")
+
+    executor.enqueue_writeback(
+        7, src_pages=[2], dst_pages=[5], kind=CacheKind.KV, is_retract=True
+    )
+    executor.enqueue_writeback(
+        7, src_pages=[11], dst_pages=[13], kind=CacheKind.MAMBA, is_retract=True
+    )
+
+    executor.flush()
+
+    assert kv_pool.writebacks == [([8, 9, 10, 11], [20, 21, 22, 23])]
+    assert mamba_pool.writebacks == [([11], [13])]
+
+    results = executor.drain()
+    assert [event.op_id for event in results] == [7]
+    assert all(event.success for event in results)
+
+
+def test_host_executor_rejects_loadback_during_cuda_graph_capture(monkeypatch):
+    import tokenspeed.runtime.cache.executor.host_executor as host_executor
+
+    monkeypatch.setattr(host_executor, "device_module", FakeDeviceModule)
+    monkeypatch.setattr(host_executor, "get_is_capture_mode", lambda: True)
+    executor = host_executor.HostExecutor(
+        pools=[FakePool(CacheKind.MAMBA, page_size=1, num_layers=1)],
+        io_backend="kernel",
+    )
+
+    executor.enqueue_loadback(1, src_pages=[2], dst_pages=[3], kind=CacheKind.MAMBA)
+
+    with pytest.raises(AssertionError, match="eager admission iter"):
+        executor.flush()
+
+
+def test_host_executor_loadback_uses_independent_layer_counters(monkeypatch):
+    HostExecutor = _patch_host_executor_device(monkeypatch)
+    kv_pool = FakePool(CacheKind.KV, page_size=2, num_layers=2)
+    mamba_pool = FakePool(CacheKind.MAMBA, page_size=1, num_layers=3)
+    executor = HostExecutor(pools=[kv_pool, mamba_pool], io_backend="kernel")
+
+    executor.enqueue_loadback(10, src_pages=[4], dst_pages=[8], kind=CacheKind.KV)
+    executor.enqueue_loadback(20, src_pages=[6], dst_pages=[9], kind=CacheKind.MAMBA)
+
+    executor.flush()
+
+    assert kv_pool.loadbacks == [
+        (0, [8, 9], [16, 17]),
+        (1, [8, 9], [16, 17]),
+    ]
+    assert mamba_pool.loadbacks == [
+        (0, [6], [9]),
+        (1, [6], [9]),
+        (2, [6], [9]),
+    ]
+
+    assert executor.get_producer_index(CacheKind.KV, 10) == 0
+    assert executor.get_producer_index(CacheKind.MAMBA, 20) == 0
+    executor.set_consumer(CacheKind.KV, [0])
+    executor.set_consumer(CacheKind.MAMBA, [0])
+    assert kv_pool.counter.consumer == [0]
+
+
+def test_memory_executor_submit_dispatches_flat_op_by_cache_kind(monkeypatch):
+    import tokenspeed.runtime.cache.executor.memory_executor as memory_executor
+
+    class FakeCache:
+        class WriteBackOp:
+            pass
+
+        class LoadBackOp:
+            pass
+
+        class PrefetchOp:
+            pass
+
+        class BackUpOp:
+            pass
+
+    class FakeHostExec:
+        def __init__(self):
+            self.pools = {CacheKind.KV: object(), CacheKind.MAMBA: object()}
+            self.writebacks = []
+            self.loadbacks = []
+            self.completed_writebacks = []
+            self.order = []
+
+        def fence_writeback_after(self, producer_stream):
+            self.order.append(("fence", producer_stream))
+
+        def enqueue_writeback(
+            self, op_id, src_pages, dst_pages, is_retract=False, kind=CacheKind.KV
+        ):
+            self.order.append(("writeback", kind, op_id))
+            self.writebacks.append((kind, op_id, src_pages, dst_pages, is_retract))
+
+        def enqueue_loadback(self, op_id, src_pages, dst_pages, kind=CacheKind.KV):
+            self.order.append(("loadback", kind, op_id))
+            self.loadbacks.append((kind, op_id, src_pages, dst_pages))
+
+        def flush(self):
+            self.order.append(("flush",))
+
+    monkeypatch.setattr(memory_executor, "Cache", FakeCache)
+    executor = object.__new__(memory_executor.MemoryExecutor)
+    executor.host_exec = FakeHostExec()
+    executor.storage_exec = None
+
+    wb = FakeCache.WriteBackOp()
+    wb.op_ids = [7]
+    wb.src_pages = [[1]]
+    wb.dst_pages = [[11]]
+    wb.src_pages_by_kind = {"kv": [[1]], "mamba": [[2, 3]]}
+    wb.dst_pages_by_kind = {"kv": [[11]], "mamba": [[22, 23]]}
+    wb.is_retract = [True]
+    executor.submit(wb)
+
+    assert executor.host_exec.writebacks == [
+        (CacheKind.KV, 7, [1], [11], True),
+        (CacheKind.MAMBA, 7, [2, 3], [22, 23], True),
+    ]
+    assert executor.host_exec.completed_writebacks == []
+
+    lb = FakeCache.LoadBackOp()
+    lb.op_ids = [9]
+    lb.src_pages = [[10]]
+    lb.dst_pages = [[20]]
+    lb.src_pages_by_kind = {"kv": [[10]], "mamba": [[30]]}
+    lb.dst_pages_by_kind = {"kv": [[20]], "mamba": [[40]]}
+    executor.submit(lb)
+
+    assert executor.host_exec.loadbacks == [
+        (CacheKind.KV, 9, [10], [20]),
+        (CacheKind.MAMBA, 9, [30], [40]),
+    ]
+
+
+def test_memory_executor_submit_plan_fences_writeback_before_enqueue(monkeypatch):
+    import tokenspeed.runtime.cache.executor.memory_executor as memory_executor
+
+    class FakeCache:
+        class WriteBackOp:
+            pass
+
+        class LoadBackOp:
+            pass
+
+        class PrefetchOp:
+            pass
+
+        class BackUpOp:
+            pass
+
+    class FakeHostExec:
+        def __init__(self):
+            self.pools = {CacheKind.MAMBA: object()}
+            self.completed_writebacks = []
+            self.order = []
+
+        def fence_writeback_after(self, producer_stream):
+            self.order.append(("fence", producer_stream))
+
+        def enqueue_writeback(
+            self, op_id, src_pages, dst_pages, is_retract=False, kind=CacheKind.KV
+        ):
+            self.order.append(("writeback", kind, op_id))
+
+        def enqueue_loadback(self, op_id, src_pages, dst_pages, kind=CacheKind.KV):
+            self.order.append(("loadback", kind, op_id))
+
+        def flush(self):
+            self.order.append(("flush",))
+
+    monkeypatch.setattr(memory_executor, "Cache", FakeCache)
+    executor = object.__new__(memory_executor.MemoryExecutor)
+    executor.host_exec = FakeHostExec()
+    executor.storage_exec = None
+    producer_stream = object()
+
+    wb = FakeCache.WriteBackOp()
+    wb.op_ids = [11]
+    wb.src_pages = [[1]]
+    wb.dst_pages = [[2]]
+    wb.src_pages_by_kind = {"mamba": [[3]]}
+    wb.dst_pages_by_kind = {"mamba": [[4]]}
+    wb.is_retract = [False]
+    plan = type("Plan", (), {"cache": [wb]})()
+
+    executor.submit_plan(plan, producer_stream=producer_stream)
+
+    assert executor.host_exec.order == [
+        ("fence", producer_stream),
+        ("writeback", CacheKind.MAMBA, 11),
+        ("flush",),
+    ]

--- a/test/runtime/layers/test_mamba_checkpoint_metadata.py
+++ b/test/runtime/layers/test_mamba_checkpoint_metadata.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import torch
+
+from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
+from tokenspeed.runtime.layers.attention.backends.hybrid_linear_attn import (
+    MambaAttnBackend,
+    SimpleMambaPool,
+)
+
+
+def _new_backend(page_size: int = 64) -> MambaAttnBackend:
+    pool = SimpleMambaPool(
+        size=8,
+        num_mamba_layers=1,
+        conv_state_shape=(4,),
+        temporal_state_shape=(2, 2),
+        conv_dtype=torch.float32,
+        ssm_dtype=torch.float32,
+        mamba_layer_ids=[0],
+        device="cpu",
+        page_size=page_size,
+    )
+
+    backend = object.__new__(MambaAttnBackend)
+    backend.pool = pool
+    backend.device = "cpu"
+    backend.is_draft = False
+    backend.spec_num_tokens = 1
+    backend.speculative_num_draft_tokens = 0
+    return backend
+
+
+def test_extend_tracks_final_page_boundary_when_branch_checkpoint_is_inside():
+    backend = _new_backend(page_size=64)
+
+    backend.init_forward_metadata(
+        bs=1,
+        req_pool_indices=torch.tensor([0], dtype=torch.int32),
+        seq_lens=torch.tensor([320], dtype=torch.int32),
+        forward_mode=ForwardMode.EXTEND,
+        mamba_pool_indices=torch.tensor([2], dtype=torch.int32),
+        mamba_branching_seqlens=torch.tensor([256], dtype=torch.int32),
+        extend_prefix_lens=torch.tensor([192], dtype=torch.int32),
+        mamba_track_pool_indices=torch.tensor([5], dtype=torch.int32),
+    )
+
+    metadata = backend.forward_metadata
+
+    assert metadata.track_ssm_h_dst is None
+    assert metadata.track_ssm_final_src.tolist() == [2]
+    assert metadata.track_ssm_final_dst.tolist() == [5]
+
+
+def test_extend_tracks_only_branch_boundary_when_final_boundary_is_not_aligned():
+    backend = _new_backend(page_size=64)
+
+    backend.init_forward_metadata(
+        bs=1,
+        req_pool_indices=torch.tensor([0], dtype=torch.int32),
+        seq_lens=torch.tensor([319], dtype=torch.int32),
+        forward_mode=ForwardMode.EXTEND,
+        mamba_pool_indices=torch.tensor([2], dtype=torch.int32),
+        mamba_branching_seqlens=torch.tensor([256], dtype=torch.int32),
+        extend_prefix_lens=torch.tensor([192], dtype=torch.int32),
+        mamba_track_pool_indices=torch.tensor([5], dtype=torch.int32),
+    )
+
+    metadata = backend.forward_metadata
+
+    assert metadata.track_ssm_h_dst.tolist() == [5]
+    assert metadata.track_ssm_final_dst is None
+
+
+def test_extend_tracks_last_inserted_page_boundary_when_branch_is_earlier():
+    backend = _new_backend(page_size=64)
+
+    backend.init_forward_metadata(
+        bs=1,
+        req_pool_indices=torch.tensor([0], dtype=torch.int32),
+        seq_lens=torch.tensor([350], dtype=torch.int32),
+        forward_mode=ForwardMode.EXTEND,
+        mamba_pool_indices=torch.tensor([2], dtype=torch.int32),
+        mamba_branching_seqlens=torch.tensor([256], dtype=torch.int32),
+        extend_prefix_lens=torch.tensor([192], dtype=torch.int32),
+        mamba_track_pool_indices=torch.tensor([5], dtype=torch.int32),
+    )
+
+    metadata = backend.forward_metadata
+
+    assert metadata.track_ssm_h_src.tolist() == [2]
+    assert metadata.track_ssm_h_dst.tolist() == [5]
+    assert metadata.track_ssm_final_dst is None
+
+
+def test_extend_tracks_last_inserted_page_boundary_without_branch_hint():
+    backend = _new_backend(page_size=64)
+
+    backend.init_forward_metadata(
+        bs=1,
+        req_pool_indices=torch.tensor([0], dtype=torch.int32),
+        seq_lens=torch.tensor([350], dtype=torch.int32),
+        forward_mode=ForwardMode.EXTEND,
+        mamba_pool_indices=torch.tensor([2], dtype=torch.int32),
+        mamba_branching_seqlens=torch.tensor([-1], dtype=torch.int32),
+        extend_prefix_lens=torch.tensor([256], dtype=torch.int32),
+        mamba_track_pool_indices=torch.tensor([5], dtype=torch.int32),
+    )
+
+    metadata = backend.forward_metadata
+
+    assert metadata.track_ssm_h_src.tolist() == [1]
+
+
+def test_extend_skips_unaligned_inserted_page_boundary():
+    backend = _new_backend(page_size=64)
+
+    backend.init_forward_metadata(
+        bs=1,
+        req_pool_indices=torch.tensor([0], dtype=torch.int32),
+        seq_lens=torch.tensor([66], dtype=torch.int32),
+        forward_mode=ForwardMode.EXTEND,
+        mamba_pool_indices=torch.tensor([2], dtype=torch.int32),
+        mamba_branching_seqlens=torch.tensor([-1], dtype=torch.int32),
+        extend_prefix_lens=torch.tensor([41], dtype=torch.int32),
+        mamba_track_pool_indices=torch.tensor([5], dtype=torch.int32),
+    )
+
+    metadata = backend.forward_metadata
+
+    assert metadata.track_ssm_h_dst is None
+    assert metadata.track_ssm_final_dst is None

--- a/tokenspeed-scheduler/CMakeLists.txt
+++ b/tokenspeed-scheduler/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(tokenspeed_scheduler_core STATIC
     csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
     csrc/resource/hybrid_prefix_cache/mamba_eviction_manager.cpp
     csrc/resource/allocator/mamba_chunk_allocator.cpp
+    csrc/resource/allocator/mamba_host_allocator.cpp
     csrc/resource/allocator/local_mamba_allocator.cpp
 
     csrc/fsm/forward_events.cpp
@@ -102,6 +103,7 @@ if(TOKENSPEED_SCHEDULER_BUILD_TESTS)
         tests/cpp/test_outside_event_handler.cpp
         tests/cpp/test_write_back.cpp
         tests/cpp/test_load_back.cpp
+        tests/cpp/test_cache_operation_kinds.cpp
         tests/cpp/test_retract.cpp
         tests/cpp/test_prefix_cache_host_match.cpp
         tests/cpp/test_abort.cpp

--- a/tokenspeed-scheduler/bindings/python_module.cpp
+++ b/tokenspeed-scheduler/bindings/python_module.cpp
@@ -239,7 +239,9 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .def_rw("disable_prefix_cache", &tokenspeed::SchedulerConfig::disable_prefix_cache)
         .def_rw("enable_mamba", &tokenspeed::SchedulerConfig::enable_mamba)
         .def_rw("mamba_cache_chunk_size", &tokenspeed::SchedulerConfig::mamba_cache_chunk_size)
-        .def_rw("mamba_pool_total_chunks", &tokenspeed::SchedulerConfig::mamba_pool_total_chunks);
+        .def_rw("mamba_pool_total_chunks", &tokenspeed::SchedulerConfig::mamba_pool_total_chunks)
+        .def_rw("enable_mamba_l2", &tokenspeed::SchedulerConfig::enable_mamba_l2)
+        .def_rw("mamba_l2_host_slots", &tokenspeed::SchedulerConfig::mamba_l2_host_slots);
 
     nb::class_<tokenspeed::RequestSpec>(m, "RequestSpec")
         .def(nb::init<>())
@@ -347,6 +349,10 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .def_ro("mamba_branching_seqlens", &tokenspeed::FlatForwardOperation::mamba_branching_seqlens);
 
     // ─── CacheOperation (attached to the Cache submodule) ──────────
+    nb::enum_<tokenspeed::CacheKind>(cache, "CacheKind")
+        .value("KV", tokenspeed::CacheKind::kKV)
+        .value("MAMBA", tokenspeed::CacheKind::kMamba);
+
     auto prefetch_op = nb::class_<tokenspeed::PrefetchOperation>(cache, "PrefetchOp");
     BindCacheCommonFields<tokenspeed::PrefetchOperation>(prefetch_op);
     prefetch_op.def(nb::init<>())
@@ -360,12 +366,16 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
     nb::class_<tokenspeed::FlatLoadBackOperation>(cache, "LoadBackOp")
         .def_ro("op_ids", &tokenspeed::FlatLoadBackOperation::op_ids)
         .def_ro("src_pages", &tokenspeed::FlatLoadBackOperation::src_pages)
-        .def_ro("dst_pages", &tokenspeed::FlatLoadBackOperation::dst_pages);
+        .def_ro("dst_pages", &tokenspeed::FlatLoadBackOperation::dst_pages)
+        .def_ro("src_pages_by_kind", &tokenspeed::FlatLoadBackOperation::src_pages_by_kind)
+        .def_ro("dst_pages_by_kind", &tokenspeed::FlatLoadBackOperation::dst_pages_by_kind);
 
     nb::class_<tokenspeed::FlatWriteBackOperation>(cache, "WriteBackOp")
         .def_ro("op_ids", &tokenspeed::FlatWriteBackOperation::op_ids)
         .def_ro("src_pages", &tokenspeed::FlatWriteBackOperation::src_pages)
         .def_ro("dst_pages", &tokenspeed::FlatWriteBackOperation::dst_pages)
+        .def_ro("src_pages_by_kind", &tokenspeed::FlatWriteBackOperation::src_pages_by_kind)
+        .def_ro("dst_pages_by_kind", &tokenspeed::FlatWriteBackOperation::dst_pages_by_kind)
         .def_ro("is_retract", &tokenspeed::FlatWriteBackOperation::is_retract);
 
     auto collect_forward = [](const tokenspeed::ExecutionPlan& plan) -> nb::list {

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
@@ -45,22 +45,21 @@ namespace {
 
 // Build a flat list of (device_page, host_page) pairs from the given write_diff nodes.
 // Both Draining::PagePair and Retracting::PagePair are std::tuple<int32_t, int32_t>.
-std::vector<tokenspeed::TransferPair> BuildWriteBackPairs(
-    const std::vector<tokenspeed::TreeNode*>& write_diff) {
+std::vector<tokenspeed::TransferPair> BuildWriteBackPairs(const std::vector<tokenspeed::TreeNode*>& write_diff) {
     std::vector<tokenspeed::TransferPair> pages_to_transfer;
     for (tokenspeed::TreeNode* n : write_diff) {
         const auto& dev_pages = n->Device().Pages();
         const auto& host_pages = n->Host().Pages();
         for (std::size_t i = 0; i < dev_pages.size(); ++i) {
-            pages_to_transfer.push_back(tokenspeed::TransferPair{tokenspeed::CacheKind::kKV, dev_pages[i], host_pages[i]});
+            pages_to_transfer.push_back(
+                tokenspeed::TransferPair{tokenspeed::CacheKind::kKV, dev_pages[i], host_pages[i]});
         }
     }
     return pages_to_transfer;
 }
 
-std::vector<tokenspeed::TreeNode*> MambaNodesForTransferPairs(
-    const std::vector<tokenspeed::TreeNode*>& candidates,
-    const std::vector<tokenspeed::TransferPair>& transfers) {
+std::vector<tokenspeed::TreeNode*> MambaNodesForTransferPairs(const std::vector<tokenspeed::TreeNode*>& candidates,
+                                                              const std::vector<tokenspeed::TransferPair>& transfers) {
     std::unordered_set<std::int32_t> src_slots;
     for (const auto& transfer : transfers) {
         if (transfer.kind == tokenspeed::CacheKind::kMamba) {
@@ -78,8 +77,7 @@ std::vector<tokenspeed::TreeNode*> MambaNodesForTransferPairs(
 }
 
 void DemoteWrittenBackDevice(tokenspeed::KVPrefixCache* kv_prefix_cache,
-                             tokenspeed::HybridPrefixCache* hybrid_prefix_cache,
-                             tokenspeed::TreeNode* device_node) {
+                             tokenspeed::HybridPrefixCache* hybrid_prefix_cache, tokenspeed::TreeNode* device_node) {
     if (kv_prefix_cache == nullptr || device_node == nullptr) return;
     kv_prefix_cache->ReleaseDeviceResourcesPresentOnHost(device_node, [hybrid_prefix_cache](tokenspeed::TreeNode* n) {
         if (hybrid_prefix_cache != nullptr) {
@@ -107,8 +105,8 @@ namespace tokenspeed::fsm {
 void InsertHybridCache(HybridPrefixCache* hybrid_cache,
                        const std::vector<std::span<const std::int32_t>>& full_paged_tokens,
                        std::unique_ptr<DeviceNodeRef>& device_node_ref, LocalKVAllocator* local_kv_allocator,
-                       LocalMambaAllocator* local_mamba_allocator, std::int32_t chunk_begin,
-                       std::int32_t chunk_size, std::int32_t page_size) {
+                       LocalMambaAllocator* local_mamba_allocator, std::int32_t chunk_begin, std::int32_t chunk_size,
+                       std::int32_t page_size) {
     if (hybrid_cache == nullptr) return;
 
     std::vector<std::int32_t> prefix_pages = DevicePagesFromRoot(device_node_ref->Node());
@@ -329,7 +327,8 @@ Decoding ScheduleDecodeFromRetractedEvent::operator()(Retracted&& state) {
             throw std::logic_error("ScheduleDecodeFromRetractedEvent: failed to allocate Mamba recovery working slot");
         }
         if (!local_mamba_allocator->AllocateCheckpoint()) {
-            throw std::logic_error("ScheduleDecodeFromRetractedEvent: failed to allocate Mamba recovery checkpoint slot");
+            throw std::logic_error(
+                "ScheduleDecodeFromRetractedEvent: failed to allocate Mamba recovery checkpoint slot");
         }
     }
     auto req_pool_index = std::make_unique<ReqPoolIndex>(req_pool_allocator_->Allocate());

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <stdexcept>
 #include <tuple>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -38,22 +39,65 @@
 #include "resource/kv_prefix_cache/kv_prefix_cache.h"
 #include "resource/radix_tree/tree_node.h"
 #include "resource/types.h"
+#include "scheduler/operations/cache.h"
 
 namespace {
 
 // Build a flat list of (device_page, host_page) pairs from the given write_diff nodes.
 // Both Draining::PagePair and Retracting::PagePair are std::tuple<int32_t, int32_t>.
-std::vector<std::tuple<std::int32_t, std::int32_t>> BuildWriteBackPairs(
+std::vector<tokenspeed::TransferPair> BuildWriteBackPairs(
     const std::vector<tokenspeed::TreeNode*>& write_diff) {
-    std::vector<std::tuple<std::int32_t, std::int32_t>> pages_to_transfer;
+    std::vector<tokenspeed::TransferPair> pages_to_transfer;
     for (tokenspeed::TreeNode* n : write_diff) {
         const auto& dev_pages = n->Device().Pages();
         const auto& host_pages = n->Host().Pages();
         for (std::size_t i = 0; i < dev_pages.size(); ++i) {
-            pages_to_transfer.emplace_back(dev_pages[i], host_pages[i]);
+            pages_to_transfer.push_back(tokenspeed::TransferPair{tokenspeed::CacheKind::kKV, dev_pages[i], host_pages[i]});
         }
     }
     return pages_to_transfer;
+}
+
+std::vector<tokenspeed::TreeNode*> MambaNodesForTransferPairs(
+    const std::vector<tokenspeed::TreeNode*>& candidates,
+    const std::vector<tokenspeed::TransferPair>& transfers) {
+    std::unordered_set<std::int32_t> src_slots;
+    for (const auto& transfer : transfers) {
+        if (transfer.kind == tokenspeed::CacheKind::kMamba) {
+            src_slots.insert(transfer.src);
+        }
+    }
+    std::vector<tokenspeed::TreeNode*> nodes;
+    nodes.reserve(src_slots.size());
+    for (tokenspeed::TreeNode* node : candidates) {
+        if (node != nullptr && node->HasMamba() && src_slots.find(node->MambaSlotIndex()) != src_slots.end()) {
+            nodes.push_back(node);
+        }
+    }
+    return nodes;
+}
+
+void DemoteWrittenBackDevice(tokenspeed::KVPrefixCache* kv_prefix_cache,
+                             tokenspeed::HybridPrefixCache* hybrid_prefix_cache,
+                             tokenspeed::TreeNode* device_node) {
+    if (kv_prefix_cache == nullptr || device_node == nullptr) return;
+    kv_prefix_cache->ReleaseDeviceResourcesPresentOnHost(device_node, [hybrid_prefix_cache](tokenspeed::TreeNode* n) {
+        if (hybrid_prefix_cache != nullptr) {
+            hybrid_prefix_cache->OnKVDeviceDemote(n);
+        }
+    });
+}
+
+bool ShouldPublishMambaCheckpoint(tokenspeed::HybridPrefixCache* hybrid_cache, std::int32_t chunk_begin,
+                                  std::int32_t chunk_size, std::int32_t page_size) {
+    if (hybrid_cache == nullptr || chunk_size <= 0 || page_size <= 0) return false;
+    const std::int32_t final_len = chunk_begin + chunk_size;
+    const std::int32_t last_inserted_len = (final_len / page_size) * page_size;
+    if (last_inserted_len <= chunk_begin) return false;
+    if (last_inserted_len == final_len) return true;
+
+    const std::int32_t track_len = last_inserted_len - chunk_begin;
+    return hybrid_cache->AlignMambaCacheSeqlen(track_len) == track_len;
 }
 
 }  // namespace
@@ -63,20 +107,30 @@ namespace tokenspeed::fsm {
 void InsertHybridCache(HybridPrefixCache* hybrid_cache,
                        const std::vector<std::span<const std::int32_t>>& full_paged_tokens,
                        std::unique_ptr<DeviceNodeRef>& device_node_ref, LocalKVAllocator* local_kv_allocator,
-                       LocalMambaAllocator* local_mamba_allocator) {
+                       LocalMambaAllocator* local_mamba_allocator, std::int32_t chunk_begin,
+                       std::int32_t chunk_size, std::int32_t page_size) {
     if (hybrid_cache == nullptr) return;
 
     std::vector<std::int32_t> prefix_pages = DevicePagesFromRoot(device_node_ref->Node());
     std::int32_t new_page_count =
         static_cast<std::int32_t>(full_paged_tokens.size()) - static_cast<std::int32_t>(prefix_pages.size());
-    if (new_page_count <= 0) return;
+    if (new_page_count <= 0) {
+        if (local_mamba_allocator != nullptr && local_mamba_allocator->HasCheckpoint()) {
+            local_mamba_allocator->DetachCheckpoint();
+        }
+        return;
+    }
 
     OwnedPages pages_to_insert = local_kv_allocator->TakeFirst(new_page_count);
     auto insert_result = hybrid_cache->GetKVPrefixCache().Insert<ResourceType::Device>(full_paged_tokens, prefix_pages,
                                                                                        std::move(pages_to_insert));
 
     if (local_mamba_allocator != nullptr && local_mamba_allocator->HasCheckpoint()) {
-        hybrid_cache->InsertMamba(insert_result.last_node, local_mamba_allocator->DetachCheckpoint());
+        if (ShouldPublishMambaCheckpoint(hybrid_cache, chunk_begin, chunk_size, page_size)) {
+            hybrid_cache->InsertMamba(insert_result.last_node, local_mamba_allocator->DetachCheckpoint());
+        } else {
+            local_mamba_allocator->DetachCheckpoint();
+        }
     }
     device_node_ref = std::make_unique<DeviceNodeRef>(insert_result.last_node);
 }
@@ -107,8 +161,12 @@ std::variant<PrefillDone, Prefilling> SchedulePrefillFirstChunkEvent::operator()
     std::unique_ptr<LocalMambaAllocator> local_mamba_allocator;
     if (mamba_allocator_ != nullptr) {
         local_mamba_allocator = std::make_unique<LocalMambaAllocator>(mamba_allocator_);
-        if (!local_mamba_allocator->AllocateWorking() || !local_mamba_allocator->AllocateCheckpoint()) {
+        if (!local_mamba_allocator->AllocateWorking()) {
             local_mamba_allocator.reset();
+        } else {
+            if (!local_mamba_allocator->AllocateCheckpoint()) {
+                throw std::logic_error("SchedulePrefillFirstChunkEvent: failed to allocate Mamba checkpoint slot");
+            }
         }
     }
 
@@ -158,13 +216,15 @@ std::variant<PrefillDone, Prefilling> SchedulePrefillEvent::operator()(Prefillin
         paged_tokens.resize(end_of_window_pages);
     }
     InsertHybridCache(hybrid_prefix_cache_, paged_tokens, device_node_ref, local_kv_allocator.get(),
-                      local_mamba_allocator.get());
+                      local_mamba_allocator.get(), state.window.begin, state.window.size, state.GetPageSize());
     // Allocate KV pages for the new chunk
     local_kv_allocator->Acquire(tokens_this_round_);
 
     // Allocate fresh mamba checkpoint for this chunk.
     if (hybrid_prefix_cache_ != nullptr && local_mamba_allocator != nullptr) {
-        local_mamba_allocator->AllocateCheckpoint();
+        if (!local_mamba_allocator->AllocateCheckpoint()) {
+            throw std::logic_error("SchedulePrefillEvent: failed to allocate Mamba checkpoint slot");
+        }
     }
 
     TokenContainer::Window window{.begin = state.window.begin + state.window.size, .size = tokens_this_round_};
@@ -206,10 +266,12 @@ Decoding ScheduleDecodeEvent::operator()(PrefillDone&& state) {
         paged_tokens.resize(end_of_window_pages);
     }
     InsertHybridCache(hybrid_prefix_cache_, paged_tokens, device_node_ref, local_kv_allocator.get(),
-                      local_mamba_allocator.get());
+                      local_mamba_allocator.get(), state.window.begin, state.window.size, state.GetPageSize());
     // Allocate fresh checkpoint for decode-phase mamba state tracking
     if (hybrid_prefix_cache_ != nullptr && local_mamba_allocator != nullptr) {
-        local_mamba_allocator->AllocateCheckpoint();
+        if (!local_mamba_allocator->AllocateCheckpoint()) {
+            throw std::logic_error("ScheduleDecodeEvent: failed to allocate Mamba checkpoint slot");
+        }
     }
 
     std::int32_t reserve = state.GetReserveNumTokensInNextScheduleEvent();
@@ -263,8 +325,11 @@ Decoding ScheduleDecodeFromRetractedEvent::operator()(Retracted&& state) {
     std::unique_ptr<LocalMambaAllocator> local_mamba_allocator;
     if (mamba_allocator_ != nullptr) {
         local_mamba_allocator = std::make_unique<LocalMambaAllocator>(mamba_allocator_);
-        if (!local_mamba_allocator->AllocateWorking() || !local_mamba_allocator->AllocateCheckpoint()) {
-            throw std::logic_error("ScheduleDecodeFromRetractedEvent: failed to allocate Mamba recovery slots");
+        if (!local_mamba_allocator->AllocateWorking()) {
+            throw std::logic_error("ScheduleDecodeFromRetractedEvent: failed to allocate Mamba recovery working slot");
+        }
+        if (!local_mamba_allocator->AllocateCheckpoint()) {
+            throw std::logic_error("ScheduleDecodeFromRetractedEvent: failed to allocate Mamba recovery checkpoint slot");
         }
     }
     auto req_pool_index = std::make_unique<ReqPoolIndex>(req_pool_allocator_->Allocate());
@@ -327,7 +392,16 @@ std::variant<Draining, Finished> FinishEvent::apply(ForwardStateT&& state) {
         std::unique_ptr<DeviceNodeRef> device_node_ref = std::make_unique<DeviceNodeRef>(match.device.last_node);
         std::unique_ptr<HostNodeRef> host_node_ref = std::make_unique<HostNodeRef>(match.device.last_node);
 
-        return Draining{BuildWriteBackPairs(write_diff), std::move(device_node_ref), std::move(host_node_ref)};
+        auto pages_to_transfer = BuildWriteBackPairs(write_diff);
+        std::vector<TreeNode*> mamba_writeback_nodes;
+        if (hybrid_prefix_cache_ != nullptr) {
+            auto mamba_pairs = hybrid_prefix_cache_->PrepareMambaHostWriteBack(write_diff);
+            mamba_writeback_nodes = MambaNodesForTransferPairs(write_diff, mamba_pairs);
+            pages_to_transfer.insert(pages_to_transfer.end(), std::make_move_iterator(mamba_pairs.begin()),
+                                     std::make_move_iterator(mamba_pairs.end()));
+        }
+        return Draining{std::move(pages_to_transfer), std::move(device_node_ref), std::move(host_node_ref),
+                        std::move(mamba_writeback_nodes)};
     }
     return Finished{};
 }
@@ -355,19 +429,38 @@ WritingBack FinishEvent::operator()(Retracting&& state) {
 WritingBack CommitDrainingEvent::operator()(Draining&& state) {
     auto device_node_ref = std::move(state).TakeDeviceNodeRef();
     auto host_node_ref = std::move(state).TakeHostNodeRef();
-    return WritingBack{std::move(device_node_ref), std::move(host_node_ref)};
+    auto mamba_writeback_nodes = std::move(state).TakeMambaWriteBackNodes();
+    return WritingBack{std::move(device_node_ref), std::move(host_node_ref), std::move(mamba_writeback_nodes)};
 }
 
 // WritingBack → Finished
-// The async Device→Host transfer completed.  Dropping WritingBack releases
-// both DeviceNodeRef and HostNodeRef, making the pages evictable again.
-Finished WriteBackDoneEvent::operator()(WritingBack&& /*state*/) {
+// The async Device→Host transfer completed. Dropping the refs releases locks,
+// then written-back cache becomes host-only so the next hit must load back.
+Finished WriteBackDoneEvent::operator()(WritingBack&& state) {
+    TreeNode* device_node = state.DeviceNode();
+    if (hybrid_prefix_cache_ != nullptr) {
+        hybrid_prefix_cache_->OnMambaHostWriteBackDone(state.MambaWriteBackNodes());
+    }
+    state.DropDeviceNodeRef();
+    DemoteWrittenBackDevice(kv_prefix_cache_, hybrid_prefix_cache_, device_node);
+    if (hybrid_prefix_cache_ != nullptr) {
+        hybrid_prefix_cache_->DemoteIdleMambaDeviceCopiesPresentOnHost();
+    }
     return Finished{};
 }
 
 Retracted WriteBackDoneEvent::operator()(Retracting&& state) {
     TokenContainer* token_container = state.GetTokenContainer();
     std::int32_t page_size = state.GetPageSize();
+    TreeNode* device_node = state.DeviceNode();
+    if (hybrid_prefix_cache_ != nullptr) {
+        hybrid_prefix_cache_->OnMambaHostWriteBackDone(state.MambaWriteBackNodes());
+    }
+    state.DropDeviceNodeRef();
+    DemoteWrittenBackDevice(kv_prefix_cache_, hybrid_prefix_cache_, device_node);
+    if (hybrid_prefix_cache_ != nullptr) {
+        hybrid_prefix_cache_->DemoteIdleMambaDeviceCopiesPresentOnHost();
+    }
     auto host_ref = std::move(static_cast<WritingBack&&>(state)).TakeHostNodeRef();
     std::unique_ptr<LocalKVAllocator> local_device_allocator = std::move(state).TakeKVAllocator();
     auto local_mamba_allocator = std::move(state).TakeMambaAllocator();
@@ -421,6 +514,7 @@ Retracting ScheduleRetractEvent::applyRetract(ForwardStateT&& state) {
     std::unique_ptr<DeviceNodeRef> device_node_ref = nullptr;
     std::unique_ptr<HostNodeRef> host_node_ref = nullptr;
     std::vector<Retracting::PagePair> pages_to_transfer;
+    std::vector<TreeNode*> mamba_writeback_nodes;
 
     if (match_result_.device.DepthInPage() > match_result_.host.DepthInPage()) {
         std::vector<TreeNode*> write_diff = match_result_.NodesWithout<ResourceType::Host>();
@@ -429,6 +523,12 @@ Retracting ScheduleRetractEvent::applyRetract(ForwardStateT&& state) {
             throw std::logic_error("ScheduleRetractEvent: failed to allocate host pages for device cache writeback");
         }
         pages_to_transfer = BuildWriteBackPairs(write_diff);
+        if (hybrid_prefix_cache_ != nullptr) {
+            auto mamba_pairs = hybrid_prefix_cache_->PrepareMambaHostWriteBack(write_diff);
+            mamba_writeback_nodes = MambaNodesForTransferPairs(write_diff, mamba_pairs);
+            pages_to_transfer.insert(pages_to_transfer.end(), std::make_move_iterator(mamba_pairs.begin()),
+                                     std::make_move_iterator(mamba_pairs.end()));
+        }
         host_node_ref = std::make_unique<HostNodeRef>(match_result_.device.last_node);
     } else {
         host_node_ref = std::make_unique<HostNodeRef>(match_result_.device.last_node);
@@ -463,6 +563,7 @@ Retracting ScheduleRetractEvent::applyRetract(ForwardStateT&& state) {
                       std::move(device_node_ref),
                       std::move(local_allocator),
                       std::move(pages_to_transfer),
+                      std::move(mamba_writeback_nodes),
                       std::move(local_mamba_allocator)};
 }
 

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.h
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.h
@@ -55,7 +55,8 @@ struct Prefetching;
 void InsertHybridCache(HybridPrefixCache* hybrid_prefix_cache,
                        const std::vector<std::span<const std::int32_t>>& full_paged_tokens,
                        std::unique_ptr<DeviceNodeRef>& device_node_ref, LocalKVAllocator* local_kv_allocator,
-                       LocalMambaAllocator* local_mamba_allocator);
+                       LocalMambaAllocator* local_mamba_allocator, std::int32_t chunk_begin,
+                       std::int32_t chunk_size, std::int32_t page_size);
 
 struct SchedulePrefillFirstChunkEvent : InvalidTransitionHandler<SchedulePrefillFirstChunkEvent> {
     using InvalidTransitionHandler<SchedulePrefillFirstChunkEvent>::operator();
@@ -64,7 +65,8 @@ struct SchedulePrefillFirstChunkEvent : InvalidTransitionHandler<SchedulePrefill
                                    MatchResult match_result, Role role, KVPrefixCache* kv_prefix_cache,
                                    bool disable_l2_cache, std::vector<TreeNode*> loadback_diff,
                                    HybridPrefixCache* hybrid_prefix_cache = nullptr,
-                                   MambaChunkAllocator* mamba_allocator = nullptr)
+                                   MambaChunkAllocator* mamba_allocator = nullptr,
+                                   std::vector<TreeNode*> mamba_loadback_nodes = {})
         : tokens_this_round_(tokens_this_round),
           decode_input_tokens_(decode_input_tokens),
           device_allocator_(device_allocator),
@@ -73,6 +75,7 @@ struct SchedulePrefillFirstChunkEvent : InvalidTransitionHandler<SchedulePrefill
           role_{role},
           disable_l2_cache_{disable_l2_cache},
           loadback_diff_(std::move(loadback_diff)),
+          mamba_loadback_nodes_(std::move(mamba_loadback_nodes)),
           kv_prefix_cache_(kv_prefix_cache),
           hybrid_prefix_cache_(hybrid_prefix_cache),
           mamba_allocator_(mamba_allocator) {}
@@ -83,6 +86,7 @@ struct SchedulePrefillFirstChunkEvent : InvalidTransitionHandler<SchedulePrefill
     const MatchResult GetMatchResult() const { return match_result_; }
 
     const std::vector<TreeNode*>& GetLoadbackDiff() const { return loadback_diff_; }
+    const std::vector<TreeNode*>& GetMambaLoadbackNodes() const { return mamba_loadback_nodes_; }
 
 private:
     std::int32_t tokens_this_round_{};
@@ -93,6 +97,7 @@ private:
     const Role role_;
     bool disable_l2_cache_{};
     std::vector<TreeNode*> loadback_diff_;
+    std::vector<TreeNode*> mamba_loadback_nodes_;
     KVPrefixCache* kv_prefix_cache_;
     HybridPrefixCache* hybrid_prefix_cache_{};
     MambaChunkAllocator* mamba_allocator_{};
@@ -136,13 +141,15 @@ struct ScheduleDecodeFromRetractedEvent : InvalidTransitionHandler<ScheduleDecod
     ScheduleDecodeFromRetractedEvent(std::int32_t decode_input_tokens, PageAllocator* device_allocator,
                                      ReqPoolAllocator* req_pool_allocator, KVPrefixCache* kv_prefix_cache,
                                      MatchResult match_result, std::vector<TreeNode*> loadback_diff,
-                                     MambaChunkAllocator* mamba_allocator = nullptr)
+                                     MambaChunkAllocator* mamba_allocator = nullptr,
+                                     std::vector<TreeNode*> mamba_loadback_nodes = {})
         : decode_input_tokens_(decode_input_tokens),
           device_allocator_(device_allocator),
           req_pool_allocator_(req_pool_allocator),
           kv_prefix_cache_(kv_prefix_cache),
           match_result_(std::move(match_result)),
           loadback_diff_(std::move(loadback_diff)),
+          mamba_loadback_nodes_(std::move(mamba_loadback_nodes)),
           mamba_allocator_(mamba_allocator) {}
 
     Decoding operator()(Retracted&& state);
@@ -150,6 +157,7 @@ struct ScheduleDecodeFromRetractedEvent : InvalidTransitionHandler<ScheduleDecod
     const MatchResult& GetMatchResult() const { return match_result_; }
 
     const std::vector<TreeNode*>& GetLoadbackDiff() const { return loadback_diff_; }
+    const std::vector<TreeNode*>& GetMambaLoadbackNodes() const { return mamba_loadback_nodes_; }
 
 private:
     std::int32_t decode_input_tokens_{};
@@ -158,6 +166,7 @@ private:
     KVPrefixCache* kv_prefix_cache_{};
     MatchResult match_result_{};
     std::vector<TreeNode*> loadback_diff_;
+    std::vector<TreeNode*> mamba_loadback_nodes_;
     MambaChunkAllocator* mamba_allocator_{};
 };
 
@@ -245,9 +254,17 @@ struct CommitDrainingEvent : InvalidTransitionHandler<CommitDrainingEvent> {
 // Retracting  → Retracted: same transfer path for preempted requests;
 //                          device_node_ref drops (frees GPU pages), host_node_ref moves into Retracted.
 struct WriteBackDoneEvent : InvalidTransitionHandler<WriteBackDoneEvent> {
+    explicit WriteBackDoneEvent(KVPrefixCache* kv_prefix_cache = nullptr,
+                                HybridPrefixCache* hybrid_prefix_cache = nullptr)
+        : kv_prefix_cache_(kv_prefix_cache), hybrid_prefix_cache_(hybrid_prefix_cache) {}
+
     using InvalidTransitionHandler<WriteBackDoneEvent>::operator();
     Finished operator()(WritingBack&& state);
     Retracted operator()(Retracting&& state);
+
+private:
+    KVPrefixCache* kv_prefix_cache_{};
+    HybridPrefixCache* hybrid_prefix_cache_{};
 };
 
 struct UpdateReserveNumTokensEvent : InvalidTransitionHandler<UpdateReserveNumTokensEvent> {

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.h
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.h
@@ -55,8 +55,8 @@ struct Prefetching;
 void InsertHybridCache(HybridPrefixCache* hybrid_prefix_cache,
                        const std::vector<std::span<const std::int32_t>>& full_paged_tokens,
                        std::unique_ptr<DeviceNodeRef>& device_node_ref, LocalKVAllocator* local_kv_allocator,
-                       LocalMambaAllocator* local_mamba_allocator, std::int32_t chunk_begin,
-                       std::int32_t chunk_size, std::int32_t page_size);
+                       LocalMambaAllocator* local_mamba_allocator, std::int32_t chunk_begin, std::int32_t chunk_size,
+                       std::int32_t page_size);
 
 struct SchedulePrefillFirstChunkEvent : InvalidTransitionHandler<SchedulePrefillFirstChunkEvent> {
     using InvalidTransitionHandler<SchedulePrefillFirstChunkEvent>::operator();

--- a/tokenspeed-scheduler/csrc/fsm/forward_states.h
+++ b/tokenspeed-scheduler/csrc/fsm/forward_states.h
@@ -287,8 +287,7 @@ struct Draining {
     // split-safe: it never needs to re-walk the radix tree.
     using PagePair = TransferPair;
     Draining(std::vector<PagePair> pages_to_transfer, std::unique_ptr<DeviceNodeRef>&& device_node_ref,
-             std::unique_ptr<HostNodeRef>&& host_node_ref,
-             std::vector<TreeNode*> mamba_writeback_nodes = {})
+             std::unique_ptr<HostNodeRef>&& host_node_ref, std::vector<TreeNode*> mamba_writeback_nodes = {})
         : pages_to_transfer_(std::move(pages_to_transfer)),
           device_node_ref_(std::move(device_node_ref)),
           host_node_ref_(std::move(host_node_ref)),

--- a/tokenspeed-scheduler/csrc/fsm/forward_states.h
+++ b/tokenspeed-scheduler/csrc/fsm/forward_states.h
@@ -32,6 +32,7 @@
 #include "resource/allocator/kv_allocator.h"
 #include "resource/allocator/owned_pages.h"
 #include "resource/allocator/local_mamba_allocator.h"
+#include "scheduler/operations/cache.h"
 #include "resource/page_container.h"
 #include "resource/allocator/req_pool_allocator.h"
 #include "resource/types.h"
@@ -284,52 +285,63 @@ struct Draining {
     // can redistribute pages across new prefix/suffix nodes).
     // Storing concrete (device_page, host_page) pairs here makes newWriteBackOperation
     // split-safe: it never needs to re-walk the radix tree.
-    using PagePair = std::tuple<std::int32_t, std::int32_t>;
+    using PagePair = TransferPair;
     Draining(std::vector<PagePair> pages_to_transfer, std::unique_ptr<DeviceNodeRef>&& device_node_ref,
-             std::unique_ptr<HostNodeRef>&& host_node_ref)
+             std::unique_ptr<HostNodeRef>&& host_node_ref,
+             std::vector<TreeNode*> mamba_writeback_nodes = {})
         : pages_to_transfer_(std::move(pages_to_transfer)),
           device_node_ref_(std::move(device_node_ref)),
-          host_node_ref_(std::move(host_node_ref)) {}
+          host_node_ref_(std::move(host_node_ref)),
+          mamba_writeback_nodes_(std::move(mamba_writeback_nodes)) {}
 
 public:
-    // (device_page, host_page) pairs that must be transferred Device→Host.
+    // Transfer pairs that must be copied Device→Host.
     const std::vector<PagePair>& GetPagesToTransfer() const { return pages_to_transfer_; }
 
     std::unique_ptr<DeviceNodeRef> TakeDeviceNodeRef() && { return std::move(device_node_ref_); }
     std::unique_ptr<HostNodeRef> TakeHostNodeRef() && { return std::move(host_node_ref_); }
+    std::vector<TreeNode*> TakeMambaWriteBackNodes() && { return std::move(mamba_writeback_nodes_); }
 
 private:
-    std::vector<PagePair> pages_to_transfer_;         // concrete (dev, host) page pairs to copy
+    std::vector<PagePair> pages_to_transfer_;         // concrete mixed-kind pairs to copy
     std::unique_ptr<DeviceNodeRef> device_node_ref_;  // keeps matched Device node alive until WritingBack
     std::unique_ptr<HostNodeRef> host_node_ref_;      // keeps pre-allocated Host node alive until WritingBack
+    std::vector<TreeNode*> mamba_writeback_nodes_;    // exact Mamba nodes covered by this writeback op
 };
 
 // WritingBack OP has been generated, executing offload.
 // Holds both node refs as RAII locks so the pages are not evicted while the
 // async Device→Host transfer is in flight.
 struct WritingBack {
-    WritingBack(std::unique_ptr<DeviceNodeRef>&& device_node_ref, std::unique_ptr<HostNodeRef>&& host_node_ref)
-        : device_node_ref_(std::move(device_node_ref)), host_node_ref_(std::move(host_node_ref)) {}
+    WritingBack(std::unique_ptr<DeviceNodeRef>&& device_node_ref, std::unique_ptr<HostNodeRef>&& host_node_ref,
+                std::vector<TreeNode*> mamba_writeback_nodes = {})
+        : device_node_ref_(std::move(device_node_ref)),
+          host_node_ref_(std::move(host_node_ref)),
+          mamba_writeback_nodes_(std::move(mamba_writeback_nodes)) {}
 
     WritingBack(WritingBack&&) noexcept = default;
     WritingBack& operator=(WritingBack&&) noexcept = default;
 
     std::unique_ptr<HostNodeRef> TakeHostNodeRef() && { return std::move(host_node_ref_); }
+    TreeNode* DeviceNode() const { return device_node_ref_ ? device_node_ref_->Node() : nullptr; }
+    const std::vector<TreeNode*>& MambaWriteBackNodes() const { return mamba_writeback_nodes_; }
+    void DropDeviceNodeRef() { device_node_ref_.reset(); }
 
 private:
     std::unique_ptr<DeviceNodeRef> device_node_ref_;  // released after WriteBackDone
     std::unique_ptr<HostNodeRef> host_node_ref_;      // released after WriteBackDone
+    std::vector<TreeNode*> mamba_writeback_nodes_;    // pending host Mamba slots published by this op ack
 };
 
 // Need to hold local_kv_allocator(has tail page info), and token container for recovery
 struct Retracting : public WritingBack {
-    using PagePair = std::tuple<std::int32_t, std::int32_t>;
+    using PagePair = TransferPair;
 
     Retracting(TokenContainer* token_container, std::int32_t page_size, std::unique_ptr<HostNodeRef>&& host_node_ref,
                std::unique_ptr<DeviceNodeRef>&& device_node_ref, std::unique_ptr<LocalKVAllocator>&& local_kv_allocator,
-               std::vector<PagePair> pages_to_transfer,
+               std::vector<PagePair> pages_to_transfer, std::vector<TreeNode*> mamba_writeback_nodes = {},
                std::unique_ptr<LocalMambaAllocator>&& local_mamba_allocator = nullptr)
-        : WritingBack(std::move(device_node_ref), std::move(host_node_ref)),
+        : WritingBack(std::move(device_node_ref), std::move(host_node_ref), std::move(mamba_writeback_nodes)),
           token_container_{token_container},
           page_size_{page_size},
           local_kv_allocator_(std::move(local_kv_allocator)),

--- a/tokenspeed-scheduler/csrc/resource/allocator/mamba_host_allocator.cpp
+++ b/tokenspeed-scheduler/csrc/resource/allocator/mamba_host_allocator.cpp
@@ -18,45 +18,42 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include "resource/allocator/mamba_chunk_allocator.h"
+#include "resource/allocator/mamba_host_allocator.h"
+
+#include <algorithm>
 
 namespace tokenspeed {
 
-MambaSlot::MambaSlot(std::int32_t index, MambaChunkAllocator* allocator)
-    : MambaSlot(index, [allocator](std::int32_t i) {
-          if (allocator != nullptr) allocator->Free(i);
-      }) {}
-
-MambaChunkAllocator::MambaChunkAllocator(std::int32_t num_slots) : total_slots_{num_slots} {
+MambaHostAllocator::MambaHostAllocator(std::int32_t num_slots) : total_slots_{num_slots} {
     free_list_.reserve(num_slots);
+    released_idx_queue_.reserve(num_slots);
     for (std::int32_t i = num_slots - 1; i >= 0; --i) {
         free_list_.push_back(i);
     }
 }
 
-std::optional<MambaSlot> MambaChunkAllocator::Allocate() {
+std::optional<MambaSlot> MambaHostAllocator::Allocate() {
     if (free_list_.empty()) {
         return std::nullopt;
     }
     std::int32_t index = free_list_.back();
     free_list_.pop_back();
-    return MambaSlot{index, this};
+    return MambaSlot{index, [this](std::int32_t i) { Free(i); }};
 }
 
-void MambaChunkAllocator::Free(std::int32_t index) {
-    free_list_.push_back(index);
-}
-
-MambaSlot::~MambaSlot() {
-    release();
-}
-
-void MambaSlot::release() {
-    if (index_ >= 0 && releaser_) {
-        releaser_(index_);
-        index_ = -1;
-        releaser_ = {};
+void MambaHostAllocator::Free(std::int32_t index) {
+    if (index < 0 || index >= total_slots_) {
+        return;
     }
+    free_list_.push_back(index);
+    released_idx_queue_.push_back(index);
+}
+
+std::vector<std::int32_t> MambaHostAllocator::DrainReleased(std::size_t max) {
+    std::size_t n = std::min(max, released_idx_queue_.size());
+    std::vector<std::int32_t> released(released_idx_queue_.begin(), released_idx_queue_.begin() + n);
+    released_idx_queue_.erase(released_idx_queue_.begin(), released_idx_queue_.begin() + n);
+    return released;
 }
 
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/csrc/resource/allocator/mamba_host_allocator.h
+++ b/tokenspeed-scheduler/csrc/resource/allocator/mamba_host_allocator.h
@@ -18,45 +18,32 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include "resource/allocator/mamba_chunk_allocator.h"
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "resource/radix_tree/mamba_slot.h"
 
 namespace tokenspeed {
 
-MambaSlot::MambaSlot(std::int32_t index, MambaChunkAllocator* allocator)
-    : MambaSlot(index, [allocator](std::int32_t i) {
-          if (allocator != nullptr) allocator->Free(i);
-      }) {}
+class MambaHostAllocator {
+public:
+    explicit MambaHostAllocator(std::int32_t num_slots);
 
-MambaChunkAllocator::MambaChunkAllocator(std::int32_t num_slots) : total_slots_{num_slots} {
-    free_list_.reserve(num_slots);
-    for (std::int32_t i = num_slots - 1; i >= 0; --i) {
-        free_list_.push_back(i);
-    }
-}
+    std::optional<MambaSlot> Allocate();
+    void Free(std::int32_t index);
+    std::vector<std::int32_t> DrainReleased(std::size_t max = 1024);
 
-std::optional<MambaSlot> MambaChunkAllocator::Allocate() {
-    if (free_list_.empty()) {
-        return std::nullopt;
-    }
-    std::int32_t index = free_list_.back();
-    free_list_.pop_back();
-    return MambaSlot{index, this};
-}
+    std::int32_t AvailableSlots() const { return static_cast<std::int32_t>(free_list_.size()); }
+    std::int32_t TotalSlots() const { return total_slots_; }
 
-void MambaChunkAllocator::Free(std::int32_t index) {
-    free_list_.push_back(index);
-}
-
-MambaSlot::~MambaSlot() {
-    release();
-}
-
-void MambaSlot::release() {
-    if (index_ >= 0 && releaser_) {
-        releaser_(index_);
-        index_ = -1;
-        releaser_ = {};
-    }
-}
+private:
+    std::vector<std::int32_t> free_list_;
+    std::vector<std::int32_t> released_idx_queue_;
+    std::int32_t total_slots_;
+};
 
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
@@ -370,7 +370,7 @@ void HybridPrefixCache::OnMambaHostWriteBackDone(const std::vector<TreeNode*>& n
     }
     if (attached > 0 || completed > 0) {
         spdlog::debug("[HybridPrefixCache][mamba_l2] host writeback done attach_count={} completed_nodes={}", attached,
-                     completed);
+                      completed);
     }
     DemoteIdleMambaDeviceCopiesPresentOnHost();
 }

--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
@@ -335,7 +335,7 @@ void HybridPrefixCache::DemoteIdleMambaDeviceCopiesPresentOnHost() {
         ++demoted;
     }
     if (demoted > 0) {
-        spdlog::info("[HybridPrefixCache][mamba_l2] demoted device copies after host writeback count={}", demoted);
+        spdlog::debug("[HybridPrefixCache][mamba_l2] demoted device copies after host writeback count={}", demoted);
     }
 }
 
@@ -369,7 +369,7 @@ void HybridPrefixCache::OnMambaHostWriteBackDone(const std::vector<TreeNode*>& n
         }
     }
     if (attached > 0 || completed > 0) {
-        spdlog::info("[HybridPrefixCache][mamba_l2] host writeback done attach_count={} completed_nodes={}", attached,
+        spdlog::debug("[HybridPrefixCache][mamba_l2] host writeback done attach_count={} completed_nodes={}", attached,
                      completed);
     }
     DemoteIdleMambaDeviceCopiesPresentOnHost();

--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
@@ -20,8 +20,10 @@
 
 #include "resource/hybrid_prefix_cache/hybrid_prefix_cache.h"
 #include "resource/allocator/mamba_chunk_allocator.h"
+#include "resource/allocator/mamba_host_allocator.h"
 #include "resource/allocator/paged_cache_group.h"
 #include "resource/radix_tree/paged_cache_snapshot.h"
+#include "resource/radix_tree/node_range.h"
 #include "resource/radix_tree/radix_tree.h"
 #include "resource/radix_tree/tree_node.h"
 #include "scheduler/operations/forward.h"
@@ -39,9 +41,11 @@
 namespace tokenspeed {
 
 HybridPrefixCache::HybridPrefixCache(KVPrefixCache& kv_prefix_cache, MambaChunkAllocator* mamba_allocator,
-                                     std::int32_t mamba_cache_chunk_size)
+                                     std::int32_t mamba_cache_chunk_size,
+                                     MambaHostAllocator* mamba_host_allocator)
     : kv_prefix_cache_{kv_prefix_cache},
       mamba_allocator_{mamba_allocator},
+      mamba_host_allocator_{mamba_host_allocator},
       mamba_eviction_manager_{mamba_allocator},
       mamba_cache_chunk_size_{mamba_cache_chunk_size} {}
 
@@ -62,28 +66,74 @@ MatchResult HybridPrefixCache::Match(const std::vector<std::span<const std::int3
 
 void HybridPrefixCache::augmentMatch(MatchResult& match) const {
     if (mamba_allocator_ == nullptr) return;
-    TreeNode* kv_terminal = match.device.last_node;
-    if (kv_terminal == nullptr || kv_terminal->IsRoot()) return;
+    TreeNode* root = match.device.last_node;
+    while (root != nullptr && !root->IsRoot()) root = root->Parent();
+    if (root == nullptr) return;
 
-    TreeNode* mamba_node = FindLastMambaNode(kv_terminal);
-    if (mamba_node == nullptr) {
-        const std::int32_t kv_depth = match.device.DepthInPage();
-        const std::int32_t aligned_seqlen = AlignMambaCacheSeqlen(kv_depth * match.device.page_size);
-        if (aligned_seqlen > 0) {
-            match.mamba_branching_seqlen = aligned_seqlen;
+    // Backward-compatible path: before Mamba L2 is enabled, only device Mamba is
+    // a valid hybrid prefix source and both match tiers are truncated together.
+    if (mamba_host_allocator_ == nullptr) {
+        TreeNode* kv_terminal = match.device.last_node;
+        if (kv_terminal == nullptr || kv_terminal->IsRoot()) return;
+
+        TreeNode* mamba_node = FindLastMambaNode(kv_terminal);
+        if (mamba_node == nullptr) {
+            const std::int32_t kv_depth = match.device.DepthInPage();
+            const std::int32_t aligned_seqlen = AlignMambaCacheSeqlen(kv_depth * match.device.page_size);
+            if (aligned_seqlen > 0) {
+                match.mamba_branching_seqlen = aligned_seqlen;
+            }
+            match.device.last_node = root;
+            match.host.last_node = root;
+            return;
         }
-        TreeNode* root = kv_terminal;
-        while (!root->IsRoot()) root = root->Parent();
-        match.device.last_node = root;
-        match.host.last_node = root;
+
+        std::int32_t page_size = match.device.page_size;
+        std::int32_t kv_depth = match.device.DepthInPage();
+        std::int32_t mamba_depth = mamba_node->DepthInPage(page_size);
+        match.mamba_cow_src_index = mamba_node->MambaSlotIndex();
+        if (kv_depth > mamba_depth) {
+            const std::int32_t aligned_seqlen = AlignMambaCacheSeqlen(kv_depth * page_size);
+            if (aligned_seqlen > mamba_depth * page_size) {
+                match.mamba_branching_seqlen = aligned_seqlen;
+            }
+        }
+        match.device.last_node = mamba_node;
+        match.host.last_node = mamba_node;
         return;
     }
 
-    std::int32_t page_size = match.device.page_size;
-    std::int32_t kv_depth = match.device.DepthInPage();
-    std::int32_t mamba_depth = mamba_node->DepthInPage(page_size);
+    const std::int32_t page_size = match.device.page_size;
+    const std::int32_t kv_depth = std::max(match.device.DepthInPage(), match.host.DepthInPage());
 
-    match.mamba_cow_src_index = mamba_node->MambaSlotIndex();
+    TreeNode* device_mamba_node = FindLastMambaNode(match.device.last_node);
+    TreeNode* host_mamba_node = FindLastMambaHostNode(match.host.last_node);
+    const std::int32_t device_mamba_depth =
+        device_mamba_node == nullptr ? 0 : device_mamba_node->DepthInPage(page_size);
+    const std::int32_t host_mamba_depth = host_mamba_node == nullptr ? 0 : host_mamba_node->DepthInPage(page_size);
+    const bool prefer_host_mamba = host_mamba_depth > device_mamba_depth;
+    std::int32_t mamba_depth = 0;
+
+    if (device_mamba_node != nullptr) {
+        match.device.last_node = device_mamba_node;
+        if (!prefer_host_mamba) {
+            match.mamba_cow_src_index = device_mamba_node->MambaSlotIndex();
+        }
+        mamba_depth = std::max(mamba_depth, device_mamba_depth);
+    } else {
+        match.device.last_node = root;
+    }
+
+    if (host_mamba_node != nullptr) {
+        match.host.last_node = host_mamba_node;
+        match.mamba_host_src_index = host_mamba_node->MambaHostSlotIndex();
+        if (prefer_host_mamba) {
+            match.mamba_cow_src_index = -1;
+        }
+        mamba_depth = std::max(mamba_depth, host_mamba_depth);
+    } else {
+        match.host.last_node = root;
+    }
 
     if (kv_depth > mamba_depth) {
         const std::int32_t aligned_seqlen = AlignMambaCacheSeqlen(kv_depth * page_size);
@@ -91,9 +141,6 @@ void HybridPrefixCache::augmentMatch(MatchResult& match) const {
             match.mamba_branching_seqlen = aligned_seqlen;
         }
     }
-
-    match.device.last_node = mamba_node;
-    match.host.last_node = mamba_node;
 }
 
 std::int32_t HybridPrefixCache::AlignMambaCacheSeqlen(std::int32_t seqlen) const {
@@ -106,6 +153,83 @@ TreeNode* HybridPrefixCache::FindLastMambaNode(TreeNode* from) const {
         if (cur->HasMamba()) return cur;
     }
     return nullptr;
+}
+
+TreeNode* HybridPrefixCache::FindLastMambaHostNode(TreeNode* from) const {
+    for (TreeNode* cur = from; cur != nullptr && !cur->IsRoot(); cur = cur->Parent()) {
+        if (cur->HasMambaOnHost()) return cur;
+    }
+    return nullptr;
+}
+
+bool HybridPrefixCache::EnsureMambaHostCapacityByEvict(std::int32_t num_slots, TreeNode* protected_node) {
+    if (mamba_host_allocator_ == nullptr) return num_slots <= 0;
+    if (mamba_host_allocator_->AvailableSlots() >= num_slots) return true;
+
+    std::vector<TreeNode*> candidates;
+    candidates.reserve(mamba_host_nodes_.size());
+    for (TreeNode* node : mamba_host_nodes_) {
+        if (node == nullptr || node == protected_node || !node->HasMambaOnHost()) continue;
+        if (node->OnHost() && GetResource<ResourceType::Host>(node).RefCount() > 0) continue;
+        candidates.push_back(node);
+    }
+    std::sort(candidates.begin(), candidates.end(), [](const TreeNode* lhs, const TreeNode* rhs) {
+        return lhs->Time() < rhs->Time();
+    });
+
+    for (TreeNode* node : candidates) {
+        if (mamba_host_allocator_->AvailableSlots() >= num_slots) break;
+        node->DetachMambaHost();
+        mamba_host_nodes_.erase(node);
+    }
+    if (mamba_host_allocator_->AvailableSlots() < num_slots) {
+        spdlog::warn("[HybridPrefixCache] mamba host capacity exhausted required={} after_evict_available={}",
+                     num_slots, mamba_host_allocator_->AvailableSlots());
+    }
+    return mamba_host_allocator_->AvailableSlots() >= num_slots;
+}
+
+std::vector<TransferPair> HybridPrefixCache::PrepareMambaHostWriteBack(const std::vector<TreeNode*>& nodes) {
+    std::vector<TransferPair> transfers;
+    if (mamba_allocator_ == nullptr || mamba_host_allocator_ == nullptr) return transfers;
+
+    std::int32_t needed = 0;
+    for (TreeNode* node : nodes) {
+        if (node != nullptr && node->HasMamba() && !node->HasMambaOnHost() &&
+            pending_mamba_host_writebacks_.find(node) == pending_mamba_host_writebacks_.end()) {
+            needed++;
+        }
+    }
+    if (!EnsureMambaHostCapacityByEvict(needed)) return transfers;
+
+    for (TreeNode* node : nodes) {
+        if (node == nullptr || !node->HasMamba() || node->HasMambaOnHost()) continue;
+        if (pending_mamba_host_writebacks_.find(node) != pending_mamba_host_writebacks_.end()) continue;
+        auto slot = mamba_host_allocator_->Allocate();
+        if (!slot.has_value()) break;
+        const std::int32_t device_idx = node->MambaSlotIndex();
+        const std::int32_t host_idx = slot->Index();
+        pending_mamba_host_writebacks_.emplace(node, std::make_unique<MambaSlot>(std::move(*slot)));
+        transfers.push_back(TransferPair{CacheKind::kMamba, device_idx, host_idx});
+    }
+    return transfers;
+}
+
+std::vector<TransferPair> HybridPrefixCache::PrepareMambaDeviceLoadBack(const std::vector<TreeNode*>& nodes) {
+    std::vector<TransferPair> transfers;
+    if (mamba_allocator_ == nullptr || mamba_host_allocator_ == nullptr) return transfers;
+
+    for (TreeNode* node : nodes) {
+        if (node == nullptr || !node->HasMambaOnHost() || node->HasMamba()) continue;
+        auto slot = mamba_allocator_->Allocate();
+        if (!slot.has_value()) break;
+        const std::int32_t host_idx = node->MambaHostSlotIndex();
+        const std::int32_t device_idx = slot->Index();
+        node->AttachMamba(std::make_unique<MambaSlot>(std::move(*slot)));
+        mamba_eviction_manager_.TrackNode(node);
+        transfers.push_back(TransferPair{CacheKind::kMamba, host_idx, device_idx});
+    }
+    return transfers;
 }
 
 bool HybridPrefixCache::EnsureMambaCapacityByEvict(std::int32_t num_slots, TreeNode* protected_node) {
@@ -178,6 +302,89 @@ void HybridPrefixCache::OnKVEvict(TreeNode* node) {
     // Route through DetachPagedCacheSnapshotFromNode to keep membership set in sync.
     if (node->HasPagedCacheSnapshot()) {
         DetachPagedCacheSnapshotFromNode(node);
+    }
+}
+
+void HybridPrefixCache::OnKVHostEvict(TreeNode* node) {
+    if (node == nullptr || mamba_host_allocator_ == nullptr) return;
+    pending_mamba_host_writebacks_.erase(node);
+    if (node->HasMambaOnHost()) {
+        node->DetachMambaHost();
+        mamba_host_nodes_.erase(node);
+        mamba_host_writeback_done_nodes_.erase(node);
+    }
+}
+
+void HybridPrefixCache::DemoteIdleMambaDeviceCopiesPresentOnHost() {
+    if (mamba_allocator_ == nullptr || mamba_host_allocator_ == nullptr) return;
+
+    std::int32_t demoted = 0;
+    std::vector<TreeNode*> nodes(mamba_host_writeback_done_nodes_.begin(), mamba_host_writeback_done_nodes_.end());
+    for (TreeNode* node : nodes) {
+        if (node == nullptr || !node->HasMambaOnHost()) {
+            mamba_host_writeback_done_nodes_.erase(node);
+            continue;
+        }
+        if (!node->HasMamba()) {
+            mamba_host_writeback_done_nodes_.erase(node);
+            continue;
+        }
+        if (node->OnDevice() && node->Device().RefCount() != 0) {
+            continue;
+        }
+        OnKVDeviceDemote(node);
+        mamba_host_writeback_done_nodes_.erase(node);
+        ++demoted;
+    }
+    if (demoted > 0) {
+        spdlog::info("[HybridPrefixCache][mamba_l2] demoted device copies after host writeback count={}", demoted);
+    }
+}
+
+void HybridPrefixCache::OnMambaHostWriteBackDone(TreeNode* last_node) {
+    if (last_node == nullptr) return;
+    std::vector<TreeNode*> nodes;
+    for (TreeNode* node : LeafToRoot(last_node)) {
+        if (node == nullptr || !node->OnHost()) break;
+        nodes.push_back(node);
+    }
+    OnMambaHostWriteBackDone(nodes);
+}
+
+void HybridPrefixCache::OnMambaHostWriteBackDone(const std::vector<TreeNode*>& nodes) {
+    if (mamba_allocator_ == nullptr || mamba_host_allocator_ == nullptr) return;
+
+    std::int32_t attached = 0;
+    std::int32_t completed = 0;
+    for (TreeNode* node : nodes) {
+        if (node == nullptr || !node->OnHost()) continue;
+        auto pending = pending_mamba_host_writebacks_.find(node);
+        if (pending != pending_mamba_host_writebacks_.end()) {
+            node->AttachMambaHost(std::move(pending->second));
+            pending_mamba_host_writebacks_.erase(pending);
+            mamba_host_nodes_.insert(node);
+            ++attached;
+        }
+        if (node->HasMambaOnHost()) {
+            mamba_host_writeback_done_nodes_.insert(node);
+            ++completed;
+        }
+    }
+    if (attached > 0 || completed > 0) {
+        spdlog::info("[HybridPrefixCache][mamba_l2] host writeback done attach_count={} completed_nodes={}",
+                     attached, completed);
+    }
+    DemoteIdleMambaDeviceCopiesPresentOnHost();
+}
+
+void HybridPrefixCache::OnKVDeviceDemote(TreeNode* node) {
+    if (node == nullptr || mamba_allocator_ == nullptr) return;
+    if (node->HasMamba() && node->HasMambaOnHost()) {
+        mamba_eviction_manager_.UntrackNode(node);
+        node->DetachMamba();
+        if (node->Parent() != nullptr) {
+            mamba_eviction_manager_.UpdateLeaf(node->Parent());
+        }
     }
 }
 
@@ -550,11 +757,13 @@ void HybridPrefixCache::AcquireForRequest(const std::string& request_id, std::in
 
 void HybridPrefixCache::ReleaseRequest(const std::string& request_id) {
     auto it = request_paged_cache_tables_.find(request_id);
-    if (it == request_paged_cache_tables_.end()) return;
-    for (auto& [_, table] : it->second) {
-        table.ReleaseAll();
+    if (it != request_paged_cache_tables_.end()) {
+        for (auto& [_, table] : it->second) {
+            table.ReleaseAll();
+        }
+        request_paged_cache_tables_.erase(it);
     }
-    request_paged_cache_tables_.erase(it);
+    DemoteIdleMambaDeviceCopiesPresentOnHost();
 }
 
 void HybridPrefixCache::PopulateOp(ForwardOperationBase& op_base) const {

--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
@@ -41,8 +41,7 @@
 namespace tokenspeed {
 
 HybridPrefixCache::HybridPrefixCache(KVPrefixCache& kv_prefix_cache, MambaChunkAllocator* mamba_allocator,
-                                     std::int32_t mamba_cache_chunk_size,
-                                     MambaHostAllocator* mamba_host_allocator)
+                                     std::int32_t mamba_cache_chunk_size, MambaHostAllocator* mamba_host_allocator)
     : kv_prefix_cache_{kv_prefix_cache},
       mamba_allocator_{mamba_allocator},
       mamba_host_allocator_{mamba_host_allocator},
@@ -173,9 +172,8 @@ bool HybridPrefixCache::EnsureMambaHostCapacityByEvict(std::int32_t num_slots, T
         if (node->OnHost() && GetResource<ResourceType::Host>(node).RefCount() > 0) continue;
         candidates.push_back(node);
     }
-    std::sort(candidates.begin(), candidates.end(), [](const TreeNode* lhs, const TreeNode* rhs) {
-        return lhs->Time() < rhs->Time();
-    });
+    std::sort(candidates.begin(), candidates.end(),
+              [](const TreeNode* lhs, const TreeNode* rhs) { return lhs->Time() < rhs->Time(); });
 
     for (TreeNode* node : candidates) {
         if (mamba_host_allocator_->AvailableSlots() >= num_slots) break;
@@ -371,8 +369,8 @@ void HybridPrefixCache::OnMambaHostWriteBackDone(const std::vector<TreeNode*>& n
         }
     }
     if (attached > 0 || completed > 0) {
-        spdlog::info("[HybridPrefixCache][mamba_l2] host writeback done attach_count={} completed_nodes={}",
-                     attached, completed);
+        spdlog::info("[HybridPrefixCache][mamba_l2] host writeback done attach_count={} completed_nodes={}", attached,
+                     completed);
     }
     DemoteIdleMambaDeviceCopiesPresentOnHost();
 }

--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.h
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.h
@@ -34,18 +34,21 @@
 #include "resource/allocator/paged_cache_group.h"
 #include "resource/hybrid_prefix_cache/mamba_eviction_manager.h"
 #include "resource/radix_tree/mamba_slot.h"
+#include "scheduler/operations/cache.h"
 #include "resource/kv_prefix_cache/kv_prefix_cache.h"
 #include "resource/types.h"
 
 namespace tokenspeed {
 
 class MambaChunkAllocator;
+class MambaHostAllocator;
 class ForwardOperationBase;
 
 class HybridPrefixCache {
 public:
     // `mamba_allocator` may be null; paged-cache adjunct is enabled separately.
-    HybridPrefixCache(KVPrefixCache& prefix_cache, MambaChunkAllocator* allocator, std::int32_t mamba_cache_chunk_size);
+    HybridPrefixCache(KVPrefixCache& prefix_cache, MambaChunkAllocator* allocator, std::int32_t mamba_cache_chunk_size,
+                      MambaHostAllocator* mamba_host_allocator = nullptr);
 
     MatchResult Match(const token_vec_t& token_ids, MatchIntent intent = MatchIntent::PrefixReuse);
     MatchResult Match(const std::vector<std::span<const std::int32_t>>& token_pages,
@@ -55,6 +58,15 @@ public:
     void InsertMamba(TreeNode* terminal_node, std::unique_ptr<MambaSlot> slot);
     std::int32_t AlignMambaCacheSeqlen(std::int32_t seqlen) const;
     TreeNode* FindLastMambaNode(TreeNode* from) const;
+    TreeNode* FindLastMambaHostNode(TreeNode* from) const;
+    bool EnsureMambaHostCapacityByEvict(std::int32_t num_slots, TreeNode* protected_node = nullptr);
+    std::vector<TransferPair> PrepareMambaHostWriteBack(const std::vector<TreeNode*>& nodes);
+    std::vector<TransferPair> PrepareMambaDeviceLoadBack(const std::vector<TreeNode*>& nodes);
+    void OnKVHostEvict(TreeNode* node);
+    void OnKVDeviceDemote(TreeNode* node);
+    void OnMambaHostWriteBackDone(TreeNode* last_node);
+    void OnMambaHostWriteBackDone(const std::vector<TreeNode*>& nodes);
+    void DemoteIdleMambaDeviceCopiesPresentOnHost();
 
     // Takes ownership. Duplicate group_id throws std::invalid_argument.
     void RegisterPagedCacheGroup(std::unique_ptr<PagedCacheGroupAllocator> allocator);
@@ -184,8 +196,12 @@ private:
 
     KVPrefixCache& kv_prefix_cache_;
     MambaChunkAllocator* mamba_allocator_;
+    MambaHostAllocator* mamba_host_allocator_;
     MambaEvictionManager mamba_eviction_manager_;
     std::int32_t mamba_cache_chunk_size_;
+    std::unordered_set<TreeNode*> mamba_host_nodes_;
+    std::unordered_map<TreeNode*, std::unique_ptr<MambaSlot>> pending_mamba_host_writebacks_;
+    std::unordered_set<TreeNode*> mamba_host_writeback_done_nodes_;
 
     // `paged_cache_history_alignment_tokens_ == 0` means adjunct disabled; tables still work.
     std::map<std::string, std::unique_ptr<PagedCacheGroupAllocator>> paged_cache_allocators_;

--- a/tokenspeed-scheduler/csrc/resource/kv_prefix_cache/eviction.h
+++ b/tokenspeed-scheduler/csrc/resource/kv_prefix_cache/eviction.h
@@ -33,6 +33,16 @@
 namespace tokenspeed {
 
 template <ResourceType RType>
+inline bool HasResource(const TreeNode* node) {
+    if (node == nullptr) return false;
+    if constexpr (RType == ResourceType::Device) {
+        return node->OnDevice();
+    } else {
+        return node->OnHost();
+    }
+}
+
+template <ResourceType RType>
 inline bool HasChildWithPages(const TreeNode* node) {
     for (const auto& [_, child] : node->Children()) {
         if (child == nullptr) continue;
@@ -62,16 +72,30 @@ inline bool IsLeaf(const TreeNode* node) {
 }
 
 template <ResourceType RType>
-void ResourceManager<RType>::updateLeaf(TreeNode* node) {
+void ResourceManager<RType>::removeLeaf(TreeNode* node) {
     if (node == nullptr || node->IsRoot()) return;
 
-    // Remove stale entry (if any) using the stored sort key for O(1) erase.
     auto it = node_time_.find(node);
     if (it != node_time_.end()) {
         lru_leaves_.erase({it->second, node});
         node_time_.erase(it);
-        GetResource<RType>(node).ClearEvictableNotifier();
+        if (HasResource<RType>(node)) {
+            GetResource<RType>(node).ClearEvictableNotifier();
+        }
     }
+}
+
+template <ResourceType RType>
+void ResourceManager<RType>::RemoveLeaf(TreeNode* node) {
+    removeLeaf(node);
+}
+
+template <ResourceType RType>
+void ResourceManager<RType>::updateLeaf(TreeNode* node) {
+    if (node == nullptr || node->IsRoot()) return;
+
+    // Remove stale entry (if any) using the stored sort key for O(1) erase.
+    removeLeaf(node);
 
     if (IsLeaf<RType>(node)) {
         auto ts = node->Time();

--- a/tokenspeed-scheduler/csrc/resource/kv_prefix_cache/kv_prefix_cache.cpp
+++ b/tokenspeed-scheduler/csrc/resource/kv_prefix_cache/kv_prefix_cache.cpp
@@ -353,6 +353,38 @@ bool KVPrefixCache::EnsureCapacityByEvict(std::int32_t required_num_pages) {
     return manager.AvailablePages() >= required_num_pages;
 }
 
+std::vector<TreeNode*> KVPrefixCache::ReleaseDeviceResourcesPresentOnHost(
+    TreeNode* last_node, std::function<void(TreeNode*)> on_release) {
+    std::vector<TreeNode*> released;
+    for (TreeNode* node : LeafToRoot(last_node)) {
+        if (node == nullptr || node->IsRoot()) continue;
+        if (!node->OnDevice()) continue;
+
+        if (!node->OnHost()) {
+            break;
+        }
+        if (node->Device().RefCount() != 0) {
+            break;
+        }
+        if (on_release) {
+            on_release(node);
+        }
+        if (HasChildWithPages<ResourceType::Device>(node)) {
+            break;
+        }
+
+        device_.RemoveLeaf(node);
+        recordDeviceBlockRemoved(node);
+        auto detached = node->DetachResource<ResourceType::Device>();
+        if (detached == nullptr) {
+            break;
+        }
+        released.push_back(node);
+        device_.UpdateLeaves(node->Parent());
+    }
+    return released;
+}
+
 cache_op_id KVPrefixCache::AllocateCacheOpId() {
     return next_op_id_++;
 }

--- a/tokenspeed-scheduler/csrc/resource/kv_prefix_cache/kv_prefix_cache.cpp
+++ b/tokenspeed-scheduler/csrc/resource/kv_prefix_cache/kv_prefix_cache.cpp
@@ -353,8 +353,8 @@ bool KVPrefixCache::EnsureCapacityByEvict(std::int32_t required_num_pages) {
     return manager.AvailablePages() >= required_num_pages;
 }
 
-std::vector<TreeNode*> KVPrefixCache::ReleaseDeviceResourcesPresentOnHost(
-    TreeNode* last_node, std::function<void(TreeNode*)> on_release) {
+std::vector<TreeNode*> KVPrefixCache::ReleaseDeviceResourcesPresentOnHost(TreeNode* last_node,
+                                                                          std::function<void(TreeNode*)> on_release) {
     std::vector<TreeNode*> released;
     for (TreeNode* node : LeafToRoot(last_node)) {
         if (node == nullptr || node->IsRoot()) continue;

--- a/tokenspeed-scheduler/csrc/resource/kv_prefix_cache/kv_prefix_cache.h
+++ b/tokenspeed-scheduler/csrc/resource/kv_prefix_cache/kv_prefix_cache.h
@@ -66,6 +66,9 @@ public:
     template <ResourceType RType>
     bool EnsureCapacityByEvict(std::int32_t required_num_pages);
 
+    std::vector<TreeNode*> ReleaseDeviceResourcesPresentOnHost(
+        TreeNode* last_node, std::function<void(TreeNode*)> on_release = {});
+
     void EnqueueTransfer(TreeNode* last_node);
 
     template <ResourceType RType>
@@ -78,6 +81,7 @@ public:
 
     std::int32_t PageSize() const { return tree_.PageSize(); }
     DeviceManager& GetDeviceManager() { return device_; }
+    HostManager& GetHostManager() { return host_; }
 
     // Adjunct managers may need to materialize boundary nodes via SplitAt.
     // The tree's lifetime remains owned by this KVPrefixCache.

--- a/tokenspeed-scheduler/csrc/resource/kv_prefix_cache/kv_prefix_cache.h
+++ b/tokenspeed-scheduler/csrc/resource/kv_prefix_cache/kv_prefix_cache.h
@@ -66,8 +66,8 @@ public:
     template <ResourceType RType>
     bool EnsureCapacityByEvict(std::int32_t required_num_pages);
 
-    std::vector<TreeNode*> ReleaseDeviceResourcesPresentOnHost(
-        TreeNode* last_node, std::function<void(TreeNode*)> on_release = {});
+    std::vector<TreeNode*> ReleaseDeviceResourcesPresentOnHost(TreeNode* last_node,
+                                                               std::function<void(TreeNode*)> on_release = {});
 
     void EnqueueTransfer(TreeNode* last_node);
 

--- a/tokenspeed-scheduler/csrc/resource/radix_tree/mamba_slot.h
+++ b/tokenspeed-scheduler/csrc/resource/radix_tree/mamba_slot.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <utility>
 
 namespace tokenspeed {
@@ -29,18 +30,21 @@ class MambaChunkAllocator;
 
 class MambaSlot {
 public:
-    MambaSlot(std::int32_t index, MambaChunkAllocator* allocator) : index_{index}, allocator_{allocator} {}
+    using Releaser = std::function<void(std::int32_t)>;
+
+    MambaSlot(std::int32_t index, MambaChunkAllocator* allocator);
+    MambaSlot(std::int32_t index, Releaser releaser) : index_{index}, releaser_{std::move(releaser)} {}
 
     ~MambaSlot();
 
     MambaSlot(MambaSlot&& other) noexcept
-        : index_{std::exchange(other.index_, -1)}, allocator_{std::exchange(other.allocator_, nullptr)} {}
+        : index_{std::exchange(other.index_, -1)}, releaser_{std::move(other.releaser_)} {}
 
     MambaSlot& operator=(MambaSlot&& other) noexcept {
         if (this != &other) {
             release();
             index_ = std::exchange(other.index_, -1);
-            allocator_ = std::exchange(other.allocator_, nullptr);
+            releaser_ = std::move(other.releaser_);
         }
         return *this;
     }
@@ -54,7 +58,7 @@ private:
     void release();
 
     std::int32_t index_{-1};
-    MambaChunkAllocator* allocator_{};
+    Releaser releaser_{};
 };
 
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/csrc/resource/radix_tree/tree_node.cpp
+++ b/tokenspeed-scheduler/csrc/resource/radix_tree/tree_node.cpp
@@ -140,4 +140,9 @@ std::int32_t TreeNode::MambaSlotIndex() const {
     return mamba_slot_->Index();
 }
 
+std::int32_t TreeNode::MambaHostSlotIndex() const {
+    _assert(mamba_host_slot_ != nullptr, "MambaHostSlotIndex called on node without mamba host slot");
+    return mamba_host_slot_->Index();
+}
+
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/csrc/resource/radix_tree/tree_node.h
+++ b/tokenspeed-scheduler/csrc/resource/radix_tree/tree_node.h
@@ -103,9 +103,13 @@ public:
     const HostResource& Host() const { return *host_resource_; }
 
     bool HasMamba() const { return mamba_slot_ != nullptr; }
+    bool HasMambaOnHost() const { return mamba_host_slot_ != nullptr; }
     std::int32_t MambaSlotIndex() const;
+    std::int32_t MambaHostSlotIndex() const;
     void AttachMamba(std::unique_ptr<MambaSlot> slot) { mamba_slot_ = std::move(slot); }
+    void AttachMambaHost(std::unique_ptr<MambaSlot> slot) { mamba_host_slot_ = std::move(slot); }
     std::unique_ptr<MambaSlot> DetachMamba() { return std::move(mamba_slot_); }
+    std::unique_ptr<MambaSlot> DetachMambaHost() { return std::move(mamba_host_slot_); }
 
     // Paged-cache snapshot adjunct. Completeness is now per-family on the
     // snapshot itself (see `PagedCacheSnapshot::IsCompleteFor`).
@@ -143,6 +147,7 @@ private:
     std::unique_ptr<DeviceResource> device_resource_{};
     std::unique_ptr<HostResource> host_resource_{};
     std::unique_ptr<MambaSlot> mamba_slot_{};
+    std::unique_ptr<MambaSlot> mamba_host_slot_{};
     std::unique_ptr<PagedCacheSnapshot> paged_cache_snapshot_{};
 };
 

--- a/tokenspeed-scheduler/csrc/resource/radix_tree/tree_resource.h
+++ b/tokenspeed-scheduler/csrc/resource/radix_tree/tree_resource.h
@@ -105,6 +105,7 @@ public:
 
     void SetEvictionCallback(EvictionCallback cb) { eviction_callback_ = std::move(cb); }
 
+    void RemoveLeaf(TreeNode* node);
     void UpdateLeaves(TreeNode* node);
     std::vector<TreeNode*> Evict(std::int32_t num_pages);
     std::vector<TreeNode*> EnsureCapacity(std::int32_t required_num_pages);
@@ -128,6 +129,7 @@ public:
     }
 
 private:
+    void removeLeaf(TreeNode* node);
     void updateLeaf(TreeNode* node);
 
     PageAllocator* allocator_;

--- a/tokenspeed-scheduler/csrc/resource/types.h
+++ b/tokenspeed-scheduler/csrc/resource/types.h
@@ -70,6 +70,7 @@ struct MatchResult {
     // Mamba extension (default: no mamba cache, -1 = inactive)
     std::int32_t mamba_branching_seqlen{-1};
     std::int32_t mamba_cow_src_index{-1};
+    std::int32_t mamba_host_src_index{-1};
 
     // Paged-cache adjunct hit. Null last_node or zero prefix means no hit.
     // When hit, device/host last_node also sit at or before prefix_len_tokens.

--- a/tokenspeed-scheduler/csrc/scheduler/operations/cache.h
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/cache.h
@@ -71,8 +71,8 @@ struct TransferPair {
     }
 };
 
-inline std::vector<TransferPair> ToTransferPairs(
-    CacheKind kind, const std::vector<std::tuple<std::int32_t, std::int32_t>>& pages) {
+inline std::vector<TransferPair> ToTransferPairs(CacheKind kind,
+                                                 const std::vector<std::tuple<std::int32_t, std::int32_t>>& pages) {
     std::vector<TransferPair> transfers;
     transfers.reserve(pages.size());
     for (const auto& page : pages) {

--- a/tokenspeed-scheduler/csrc/scheduler/operations/cache.h
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/cache.h
@@ -24,6 +24,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <string>
 #include <tuple>
 #include <unordered_set>
@@ -48,39 +49,97 @@ struct PrefetchOperation : public CacheOperationBase {
 struct BackUpOperation : public CacheOperationBase {
     std::vector<std::string> rolling_page_hashes;
 };
+enum class CacheKind : std::int32_t { kKV = 0, kMamba = 1 };
+
+inline const char* CacheKindName(CacheKind kind) {
+    switch (kind) {
+        case CacheKind::kKV:
+            return "kv";
+        case CacheKind::kMamba:
+            return "mamba";
+    }
+    return "unknown";
+}
+
+struct TransferPair {
+    CacheKind kind{CacheKind::kKV};
+    std::int32_t src{-1};
+    std::int32_t dst{-1};
+
+    bool operator==(const TransferPair& other) const {
+        return kind == other.kind && src == other.src && dst == other.dst;
+    }
+};
+
+inline std::vector<TransferPair> ToTransferPairs(
+    CacheKind kind, const std::vector<std::tuple<std::int32_t, std::int32_t>>& pages) {
+    std::vector<TransferPair> transfers;
+    transfers.reserve(pages.size());
+    for (const auto& page : pages) {
+        transfers.push_back(TransferPair{kind, std::get<0>(page), std::get<1>(page)});
+    }
+    return transfers;
+}
+
+struct TransferPairHash {
+    std::size_t operator()(const TransferPair& pair) const {
+        std::size_t h0 = std::hash<std::int32_t>{}(static_cast<std::int32_t>(pair.kind));
+        std::size_t h1 = std::hash<std::int32_t>{}(pair.src);
+        std::size_t h2 = std::hash<std::int32_t>{}(pair.dst);
+        return h0 ^ (h1 << 1) ^ (h2 << 32) ^ (h2 >> 32);
+    }
+};
+
 struct WriteBackOperation {
     cache_op_id op_id{0};
-    std::vector<std::tuple<std::int32_t, std::int32_t>> pages_to_transfer;  // (src_device, dst_host)
+    std::vector<TransferPair> transfers;  // DEVICE→HOST by cache kind.
     bool is_retract{false};
+
+    WriteBackOperation() = default;
+    WriteBackOperation(cache_op_id op_id, std::vector<std::tuple<std::int32_t, std::int32_t>> pages_to_transfer,
+                       bool is_retract = false)
+        : op_id{op_id}, transfers{ToTransferPairs(CacheKind::kKV, pages_to_transfer)}, is_retract{is_retract} {}
+    WriteBackOperation(cache_op_id op_id, std::vector<TransferPair> transfers, bool is_retract = false)
+        : op_id{op_id}, transfers{std::move(transfers)}, is_retract{is_retract} {}
 };
 
 struct FlatWriteBackOperation {
     std::vector<cache_op_id> op_ids;
+    // Backward-compatible KV-only view.
     std::vector<std::vector<std::int32_t>> src_pages;
     std::vector<std::vector<std::int32_t>> dst_pages;
+    // Generic view keyed by CacheKindName(kind), currently "kv" and "mamba".
+    std::map<std::string, std::vector<std::vector<std::int32_t>>> src_pages_by_kind;
+    std::map<std::string, std::vector<std::vector<std::int32_t>>> dst_pages_by_kind;
     std::vector<bool> is_retract;
 
     explicit FlatWriteBackOperation(const std::vector<WriteBackOperation>& ops) {
-        struct PairHash {
-            std::size_t operator()(const std::tuple<std::int32_t, std::int32_t>& t) const {
-                std::size_t h1 = std::hash<std::int32_t>{}(std::get<0>(t));
-                std::size_t h2 = std::hash<std::int32_t>{}(std::get<1>(t));
-                return h1 ^ (h2 << 32) ^ (h2 >> 32);
-            }
-        };
-        std::unordered_set<std::tuple<std::int32_t, std::int32_t>, PairHash> seen;
+        std::unordered_set<TransferPair, TransferPairHash> seen;
         for (const auto& op : ops) {
-            std::vector<std::int32_t> src_pages_this_op;
-            std::vector<std::int32_t> dst_pages_this_op;
-            for (const auto& page : op.pages_to_transfer) {
-                if (seen.insert(page).second) {
-                    src_pages_this_op.push_back(std::get<0>(page));
-                    dst_pages_this_op.push_back(std::get<1>(page));
+            std::map<std::string, std::vector<std::int32_t>> src_this_op;
+            std::map<std::string, std::vector<std::int32_t>> dst_this_op;
+            src_this_op[CacheKindName(CacheKind::kKV)];
+            dst_this_op[CacheKindName(CacheKind::kKV)];
+            src_this_op[CacheKindName(CacheKind::kMamba)];
+            dst_this_op[CacheKindName(CacheKind::kMamba)];
+
+            for (const auto& transfer : op.transfers) {
+                if (seen.insert(transfer).second) {
+                    const std::string kind_name = CacheKindName(transfer.kind);
+                    src_this_op[kind_name].push_back(transfer.src);
+                    dst_this_op[kind_name].push_back(transfer.dst);
                 }
             }
+
             op_ids.push_back(op.op_id);
-            src_pages.push_back(std::move(src_pages_this_op));
-            dst_pages.push_back(std::move(dst_pages_this_op));
+            src_pages.push_back(src_this_op[CacheKindName(CacheKind::kKV)]);
+            dst_pages.push_back(dst_this_op[CacheKindName(CacheKind::kKV)]);
+            for (auto& [kind, pages] : src_this_op) {
+                src_pages_by_kind[kind].push_back(std::move(pages));
+            }
+            for (auto& [kind, pages] : dst_this_op) {
+                dst_pages_by_kind[kind].push_back(std::move(pages));
+            }
             is_retract.push_back(op.is_retract);
         }
     }
@@ -88,35 +147,51 @@ struct FlatWriteBackOperation {
 
 struct LoadBackOperation {
     cache_op_id op_id{0};
-    std::vector<std::tuple<std::int32_t, std::int32_t>> pages_to_transfer;
+    std::vector<TransferPair> transfers;  // HOST→DEVICE by cache kind.
+
+    LoadBackOperation() = default;
+    LoadBackOperation(cache_op_id op_id, std::vector<std::tuple<std::int32_t, std::int32_t>> pages_to_transfer)
+        : op_id{op_id}, transfers{ToTransferPairs(CacheKind::kKV, pages_to_transfer)} {}
+    LoadBackOperation(cache_op_id op_id, std::vector<TransferPair> transfers)
+        : op_id{op_id}, transfers{std::move(transfers)} {}
 };
 
 struct FlatLoadBackOperation {
     std::vector<cache_op_id> op_ids;
+    // Backward-compatible KV-only view.
     std::vector<std::vector<std::int32_t>> src_pages;
     std::vector<std::vector<std::int32_t>> dst_pages;
+    // Generic view keyed by CacheKindName(kind), currently "kv" and "mamba".
+    std::map<std::string, std::vector<std::vector<std::int32_t>>> src_pages_by_kind;
+    std::map<std::string, std::vector<std::vector<std::int32_t>>> dst_pages_by_kind;
 
     explicit FlatLoadBackOperation(const std::vector<LoadBackOperation>& ops) {
-        struct PairHash {
-            std::size_t operator()(const std::tuple<std::int32_t, std::int32_t>& t) const {
-                std::size_t h1 = std::hash<std::int32_t>{}(std::get<0>(t));
-                std::size_t h2 = std::hash<std::int32_t>{}(std::get<1>(t));
-                return h1 ^ (h2 << 32) ^ (h2 >> 32);
-            }
-        };
-        std::unordered_set<std::tuple<std::int32_t, std::int32_t>, PairHash> seen;
+        std::unordered_set<TransferPair, TransferPairHash> seen;
         for (const auto& op : ops) {
-            std::vector<std::int32_t> src_pages_this_op;
-            std::vector<std::int32_t> dst_pages_this_op;
-            for (const auto& page : op.pages_to_transfer) {
-                if (seen.insert(page).second) {
-                    src_pages_this_op.push_back(std::get<0>(page));
-                    dst_pages_this_op.push_back(std::get<1>(page));
+            std::map<std::string, std::vector<std::int32_t>> src_this_op;
+            std::map<std::string, std::vector<std::int32_t>> dst_this_op;
+            src_this_op[CacheKindName(CacheKind::kKV)];
+            dst_this_op[CacheKindName(CacheKind::kKV)];
+            src_this_op[CacheKindName(CacheKind::kMamba)];
+            dst_this_op[CacheKindName(CacheKind::kMamba)];
+
+            for (const auto& transfer : op.transfers) {
+                if (seen.insert(transfer).second) {
+                    const std::string kind_name = CacheKindName(transfer.kind);
+                    src_this_op[kind_name].push_back(transfer.src);
+                    dst_this_op[kind_name].push_back(transfer.dst);
                 }
             }
+
             op_ids.push_back(op.op_id);
-            src_pages.push_back(std::move(src_pages_this_op));
-            dst_pages.push_back(std::move(dst_pages_this_op));
+            src_pages.push_back(src_this_op[CacheKindName(CacheKind::kKV)]);
+            dst_pages.push_back(dst_this_op[CacheKindName(CacheKind::kKV)]);
+            for (auto& [kind, pages] : src_this_op) {
+                src_pages_by_kind[kind].push_back(std::move(pages));
+            }
+            for (auto& [kind, pages] : dst_this_op) {
+                dst_pages_by_kind[kind].push_back(std::move(pages));
+            }
         }
     }
 };

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -118,8 +118,8 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
         return {};
     }
 
-    if (hybrid_prefix_cache_ && hybrid_prefix_cache_->HasMambaAdjunct() &&
-        match_result.mamba_host_src_index >= 0 && match_result.mamba_cow_src_index < 0) {
+    if (hybrid_prefix_cache_ && hybrid_prefix_cache_->HasMambaAdjunct() && match_result.mamba_host_src_index >= 0 &&
+        match_result.mamba_cow_src_index < 0) {
         TreeNode* host_mamba_node = hybrid_prefix_cache_->FindLastMambaHostNode(match_result.host.last_node);
         if (host_mamba_node != nullptr && host_mamba_node->HasMambaOnHost() && !host_mamba_node->HasMamba()) {
             AddUniqueNode(mamba_loadback_nodes, host_mamba_node);
@@ -338,8 +338,7 @@ std::optional<fsm::ScheduleRetractEvent> Scheduler::scheduleRetract(Request* req
                                      hybrid_prefix_cache_ ? &*hybrid_prefix_cache_ : nullptr};
 }
 
-LoadBackOperation GenerateLoadBackOp(const std::vector<TreeNode*>& diff,
-                                     const std::vector<TreeNode*>& mamba_nodes,
+LoadBackOperation GenerateLoadBackOp(const std::vector<TreeNode*>& diff, const std::vector<TreeNode*>& mamba_nodes,
                                      cache_op_id op_id) {
     std::vector<TransferPair> transfers;
 
@@ -366,8 +365,8 @@ std::optional<WriteBackOperation> Scheduler::applyEventAndGenerateOp(Request* re
     const auto& pages_to_transfer = request->GetPagesToTransfer<fsm::Retracting>();
     if (pages_to_transfer.empty()) {
         // No copy needed; advance Retracting to Retracted without an op_id.
-        request->Apply(fsm::WriteBackDoneEvent{&kv_prefix_cache_,
-                                               hybrid_prefix_cache_ ? &*hybrid_prefix_cache_ : nullptr});
+        request->Apply(
+            fsm::WriteBackDoneEvent{&kv_prefix_cache_, hybrid_prefix_cache_ ? &*hybrid_prefix_cache_ : nullptr});
         return std::nullopt;
     }
     // Register op_id so WriteBackDone can route back.
@@ -375,9 +374,8 @@ std::optional<WriteBackOperation> Scheduler::applyEventAndGenerateOp(Request* re
     CacheOpSpec spec;
     spec.request_id = request->Id();
     cache_op_tracker_[op_id] = std::move(spec);
-    return WriteBackOperation{
-        op_id, std::vector<TransferPair>(pages_to_transfer.begin(), pages_to_transfer.end()),
-        true};
+    return WriteBackOperation{op_id, std::vector<TransferPair>(pages_to_transfer.begin(), pages_to_transfer.end()),
+                              true};
 }
 
 std::optional<WriteBackOperation> Scheduler::newRetractOperation(Request* retract_request) {

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -56,6 +56,27 @@
 
 namespace tokenspeed {
 
+namespace {
+
+std::int32_t CountMambaDeviceLoadBackSlots(const std::vector<TreeNode*>& nodes) {
+    std::int32_t slots = 0;
+    for (TreeNode* node : nodes) {
+        if (node != nullptr && node->HasMambaOnHost() && !node->HasMamba()) {
+            ++slots;
+        }
+    }
+    return slots;
+}
+
+void AddUniqueNode(std::vector<TreeNode*>& nodes, TreeNode* node) {
+    if (node == nullptr) return;
+    if (std::find(nodes.begin(), nodes.end(), node) == nodes.end()) {
+        nodes.push_back(node);
+    }
+}
+
+}  // namespace
+
 std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFirstChunk(
     Request* request, std::int32_t remaining, std::int32_t decode_input_tokens, bool disable_l2_cache,
     std::map<std::string, std::int32_t>& simulated_free) {
@@ -65,6 +86,7 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
     std::int32_t loadback_tokens = 0;
     std::int32_t unscheduled = 0;
     std::vector<TreeNode*> loadback_diff;
+    std::vector<TreeNode*> mamba_loadback_nodes;
 
     const std::int32_t device_matched = match_result.device.DepthInPage();
     const std::int32_t host_matched = match_result.host.DepthInPage();
@@ -97,7 +119,18 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
     }
 
     if (hybrid_prefix_cache_ && hybrid_prefix_cache_->HasMambaAdjunct() &&
-        !hybrid_prefix_cache_->EnsureMambaCapacityByEvict(2)) {
+        match_result.mamba_host_src_index >= 0 && match_result.mamba_cow_src_index < 0) {
+        TreeNode* host_mamba_node = hybrid_prefix_cache_->FindLastMambaHostNode(match_result.host.last_node);
+        if (host_mamba_node != nullptr && host_mamba_node->HasMambaOnHost() && !host_mamba_node->HasMamba()) {
+            AddUniqueNode(mamba_loadback_nodes, host_mamba_node);
+        }
+    }
+    const bool needs_mamba_loadback = !mamba_loadback_nodes.empty();
+    const std::int32_t mamba_loadback_slots_needed =
+        needs_mamba_loadback ? CountMambaDeviceLoadBackSlots(mamba_loadback_nodes) : 0;
+    const std::int32_t mamba_slots_needed = 2 + mamba_loadback_slots_needed;
+    if (hybrid_prefix_cache_ && hybrid_prefix_cache_->HasMambaAdjunct() &&
+        !hybrid_prefix_cache_->EnsureMambaCapacityByEvict(mamba_slots_needed)) {
         return {};
     }
 
@@ -105,6 +138,17 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
     const std::int32_t target = first_pos + tokens_this_round;
     if (hybrid_prefix_cache_ &&
         !hybrid_prefix_cache_->AdmitChunk(request->Id(), first_pos, target, simulated_free, match_result.paged_cache)) {
+        return {};
+    }
+    if (needs_mamba_loadback) {
+        hybrid_prefix_cache_->PrepareMambaDeviceLoadBack(mamba_loadback_nodes);
+        TreeNode* mamba_node = hybrid_prefix_cache_->FindLastMambaNode(match_result.host.last_node);
+        if (mamba_node != nullptr) {
+            match_result.mamba_cow_src_index = mamba_node->MambaSlotIndex();
+        }
+    }
+    if (hybrid_prefix_cache_ && hybrid_prefix_cache_->HasMambaAdjunct() && mamba_allocator_ &&
+        mamba_allocator_->AvailableSlots() < 1) {
         return {};
     }
 
@@ -120,6 +164,7 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
         std::move(loadback_diff),
         hybrid_prefix_cache_ ? &*hybrid_prefix_cache_ : nullptr,
         mamba_allocator_ ? &*mamba_allocator_ : nullptr,
+        std::move(mamba_loadback_nodes),
     };
 }
 
@@ -160,6 +205,12 @@ std::optional<fsm::ScheduleDecodeEvent> Scheduler::scheduleDecode(Request* reque
         return {};
     }
 
+    if (hybrid_prefix_cache_ && hybrid_prefix_cache_->HasMambaAdjunct() && mamba_allocator_ &&
+        request->Is<fsm::PrefillDone>() && request->GetLocalMambaAllocator() != nullptr &&
+        !hybrid_prefix_cache_->EnsureMambaCapacityByEvict(1)) {
+        return {};
+    }
+
     const std::int32_t first_pos = request->TokenSize();
     const std::int32_t target = first_pos + config_.decode_input_tokens;
     if (hybrid_prefix_cache_ && !hybrid_prefix_cache_->AdmitChunk(request->Id(), first_pos, target, simulated_free)) {
@@ -179,16 +230,27 @@ std::optional<fsm::ScheduleDecodeFromRetractedEvent> Scheduler::scheduleDecodeFr
             ? hybrid_prefix_cache_->Match(request->GetFullPagedTokens(true), MatchIntent::StateRecovery)
             : kv_prefix_cache_.Match(request->GetFullPagedTokens(true), MatchIntent::StateRecovery);
     std::vector<TreeNode*> loadback_diff = match_result.NodesWithout<ResourceType::Device>();
+    std::vector<TreeNode*> mamba_loadback_nodes;
     TreeNode* mamba_recovery_node = nullptr;
+    bool needs_mamba_loadback = false;
     if (hybrid_prefix_cache_ && mamba_allocator_) {
         mamba_recovery_node = hybrid_prefix_cache_->FindLastMambaNode(match_result.host.last_node);
+        if (mamba_recovery_node == nullptr) {
+            mamba_recovery_node = hybrid_prefix_cache_->FindLastMambaHostNode(match_result.host.last_node);
+            needs_mamba_loadback = mamba_recovery_node != nullptr;
+            if (needs_mamba_loadback && !mamba_recovery_node->HasMamba()) {
+                AddUniqueNode(mamba_loadback_nodes, mamba_recovery_node);
+            }
+        }
         if (mamba_recovery_node == nullptr) {
             spdlog::warn("[Scheduler] Retracted request {} lost tree-owned Mamba state, aborting request",
                          request->Id());
             request->Apply(fsm::AbortEvent{});
             return {};
         }
-        match_result.mamba_cow_src_index = mamba_recovery_node->MambaSlotIndex();
+        if (!needs_mamba_loadback) {
+            match_result.mamba_cow_src_index = mamba_recovery_node->MambaSlotIndex();
+        }
     }
 
     const std::int32_t device_matched2 = match_result.device.DepthInPage();
@@ -211,7 +273,8 @@ std::optional<fsm::ScheduleDecodeFromRetractedEvent> Scheduler::scheduleDecodeFr
         // working/checkpoint slots. Protect the source node only for this
         // allocation; retracted Mamba states are otherwise normal evictable
         // tree-owned cache entries.
-        if (!hybrid_prefix_cache_->EnsureMambaCapacityByEvict(2, mamba_recovery_node)) {
+        const std::int32_t mamba_slots_needed = 2 + CountMambaDeviceLoadBackSlots(mamba_loadback_nodes);
+        if (!hybrid_prefix_cache_->EnsureMambaCapacityByEvict(mamba_slots_needed, mamba_recovery_node)) {
             return {};
         }
     }
@@ -220,6 +283,12 @@ std::optional<fsm::ScheduleDecodeFromRetractedEvent> Scheduler::scheduleDecodeFr
     if (hybrid_prefix_cache_ && !hybrid_prefix_cache_->AdmitChunkFromRetracted(request->Id(), target, simulated_free,
                                                                                match_result.paged_cache)) {
         return {};
+    }
+    if (needs_mamba_loadback) {
+        hybrid_prefix_cache_->PrepareMambaDeviceLoadBack(mamba_loadback_nodes);
+        if (mamba_recovery_node->HasMamba()) {
+            match_result.mamba_cow_src_index = mamba_recovery_node->MambaSlotIndex();
+        }
     }
 
     return fsm::ScheduleDecodeFromRetractedEvent{
@@ -230,6 +299,7 @@ std::optional<fsm::ScheduleDecodeFromRetractedEvent> Scheduler::scheduleDecodeFr
         std::move(match_result),
         loadback_diff,
         mamba_allocator_ ? &*mamba_allocator_ : nullptr,
+        std::move(mamba_loadback_nodes),
     };
 }
 
@@ -268,17 +338,24 @@ std::optional<fsm::ScheduleRetractEvent> Scheduler::scheduleRetract(Request* req
                                      hybrid_prefix_cache_ ? &*hybrid_prefix_cache_ : nullptr};
 }
 
-LoadBackOperation GenerateLoadBackOp(const std::vector<TreeNode*>& diff, cache_op_id op_id) {
-    std::vector<std::tuple<std::int32_t, std::int32_t>> pages_to_transfer;
+LoadBackOperation GenerateLoadBackOp(const std::vector<TreeNode*>& diff,
+                                     const std::vector<TreeNode*>& mamba_nodes,
+                                     cache_op_id op_id) {
+    std::vector<TransferPair> transfers;
 
     for (TreeNode* node : diff) {
         const auto& host_pages = node->Host().Pages();
         const auto& device_pages = node->Device().Pages();
         for (std::size_t i = 0; i < host_pages.size(); ++i) {
-            pages_to_transfer.emplace_back(host_pages[i], device_pages[i]);
+            transfers.push_back(TransferPair{CacheKind::kKV, host_pages[i], device_pages[i]});
         }
     }
-    return LoadBackOperation{op_id, std::move(pages_to_transfer)};
+    for (TreeNode* node : mamba_nodes) {
+        if (node != nullptr && node->HasMambaOnHost() && node->HasMamba()) {
+            transfers.push_back(TransferPair{CacheKind::kMamba, node->MambaHostSlotIndex(), node->MambaSlotIndex()});
+        }
+    }
+    return LoadBackOperation{op_id, std::move(transfers)};
 }
 
 std::optional<WriteBackOperation> Scheduler::applyEventAndGenerateOp(Request* request,
@@ -289,7 +366,8 @@ std::optional<WriteBackOperation> Scheduler::applyEventAndGenerateOp(Request* re
     const auto& pages_to_transfer = request->GetPagesToTransfer<fsm::Retracting>();
     if (pages_to_transfer.empty()) {
         // No copy needed; advance Retracting to Retracted without an op_id.
-        request->Apply(fsm::WriteBackDoneEvent{});
+        request->Apply(fsm::WriteBackDoneEvent{&kv_prefix_cache_,
+                                               hybrid_prefix_cache_ ? &*hybrid_prefix_cache_ : nullptr});
         return std::nullopt;
     }
     // Register op_id so WriteBackDone can route back.
@@ -298,7 +376,7 @@ std::optional<WriteBackOperation> Scheduler::applyEventAndGenerateOp(Request* re
     spec.request_id = request->Id();
     cache_op_tracker_[op_id] = std::move(spec);
     return WriteBackOperation{
-        op_id, std::vector<std::tuple<std::int32_t, std::int32_t>>(pages_to_transfer.begin(), pages_to_transfer.end()),
+        op_id, std::vector<TransferPair>(pages_to_transfer.begin(), pages_to_transfer.end()),
         true};
 }
 
@@ -515,11 +593,12 @@ Scheduler::newForwardOperation(std::vector<Request*> candidates) {
             if (auto ev = schedulePrefillFirstChunk(request, token_budget, decode_input_tokens,
                                                     config_.disable_l2_cache, simulated_free)) {
                 std::vector<TreeNode*> loadback_diff = ev->GetLoadbackDiff();
+                std::vector<TreeNode*> mamba_loadback_nodes = ev->GetMambaLoadbackNodes();
                 push_op(applyEventAndGenerateOp(request, std::move(*ev)), true);
                 // will be empty when disable_l2_cache
-                if (!loadback_diff.empty()) {
+                if (!loadback_diff.empty() || !mamba_loadback_nodes.empty()) {
                     cache_op_id op_id = kv_prefix_cache_.AllocateCacheOpId();
-                    loadback_ops.push_back(GenerateLoadBackOp(loadback_diff, op_id));
+                    loadback_ops.push_back(GenerateLoadBackOp(loadback_diff, mamba_loadback_nodes, op_id));
                 }
             }
         } else if (request->Is<fsm::PrefillDone>() || (request->Is<fsm::Decoding>() && config_.role != Role::kP)) {
@@ -536,10 +615,11 @@ Scheduler::newForwardOperation(std::vector<Request*> candidates) {
 
             if (auto ev = scheduleDecodeFromRetracted(request, simulated_free)) {
                 std::vector<TreeNode*> loadback_diff = ev->GetLoadbackDiff();
+                std::vector<TreeNode*> mamba_loadback_nodes = ev->GetMambaLoadbackNodes();
                 push_op(applyEventAndGenerateOp(request, std::move(*ev)));
-                if (!loadback_diff.empty()) {
+                if (!loadback_diff.empty() || !mamba_loadback_nodes.empty()) {
                     cache_op_id op_id = kv_prefix_cache_.AllocateCacheOpId();
-                    loadback_ops.push_back(GenerateLoadBackOp(loadback_diff, op_id));
+                    loadback_ops.push_back(GenerateLoadBackOp(loadback_diff, mamba_loadback_nodes, op_id));
                 }
             }
         }

--- a/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
@@ -154,8 +154,8 @@ void Scheduler::handleEvent(const cache::WriteBackDone& event) {
 
     if (!spec.request_id.empty()) {
         if (auto* req = find_request(spec.request_id)) {
-            req->Apply(fsm::WriteBackDoneEvent{&kv_prefix_cache_,
-                                               hybrid_prefix_cache_ ? &*hybrid_prefix_cache_ : nullptr});
+            req->Apply(
+                fsm::WriteBackDoneEvent{&kv_prefix_cache_, hybrid_prefix_cache_ ? &*hybrid_prefix_cache_ : nullptr});
         }
     }
 }

--- a/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
@@ -154,7 +154,8 @@ void Scheduler::handleEvent(const cache::WriteBackDone& event) {
 
     if (!spec.request_id.empty()) {
         if (auto* req = find_request(spec.request_id)) {
-            req->Apply(fsm::WriteBackDoneEvent{});
+            req->Apply(fsm::WriteBackDoneEvent{&kv_prefix_cache_,
+                                               hybrid_prefix_cache_ ? &*hybrid_prefix_cache_ : nullptr});
         }
     }
 }

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -74,6 +74,10 @@ Scheduler::Scheduler(SchedulerConfig config)
     if (has_mamba_pool) {
         mamba_allocator_.emplace(config_.mamba_pool_total_chunks);
     }
+    const bool has_mamba_l2_pool = has_mamba_pool && config_.enable_mamba_l2 && config_.mamba_l2_host_slots > 0;
+    if (has_mamba_l2_pool) {
+        mamba_host_allocator_.emplace(config_.mamba_l2_host_slots);
+    }
 
     // Construct HybridPrefixCache when any adjunct/paged-cache feature is configured.
     // Role::kD skips Mamba but still participates in paged-cache transport.
@@ -82,9 +86,12 @@ Scheduler::Scheduler(SchedulerConfig config)
     const bool has_paged_cache_groups = !config_.paged_cache_groups.empty();
     if (has_mamba_adjunct || has_prefix_cache_adjunct || has_paged_cache_groups) {
         MambaChunkAllocator* mamba_ptr = has_mamba_adjunct ? &*mamba_allocator_ : nullptr;
-        hybrid_prefix_cache_.emplace(kv_prefix_cache_, mamba_ptr, config_.mamba_cache_chunk_size);
+        MambaHostAllocator* mamba_host_ptr = has_mamba_l2_pool ? &*mamba_host_allocator_ : nullptr;
+        hybrid_prefix_cache_.emplace(kv_prefix_cache_, mamba_ptr, config_.mamba_cache_chunk_size, mamba_host_ptr);
         kv_prefix_cache_.GetDeviceManager().SetEvictionCallback(
             [this](TreeNode* node) { hybrid_prefix_cache_->OnKVEvict(node); });
+        kv_prefix_cache_.GetHostManager().SetEvictionCallback(
+            [this](TreeNode* node) { hybrid_prefix_cache_->OnKVHostEvict(node); });
 
         for (const auto& cfg : config_.paged_cache_groups) {
             PagedCacheGroupConfig copy = cfg;
@@ -282,7 +289,7 @@ std::vector<WriteBackOperation> Scheduler::newWriteBackOperation(
             CacheOpSpec spec;
             spec.request_id = id;
             cache_op_tracker_[op_id] = std::move(spec);
-            ops.push_back(WriteBackOperation{op_id, std::vector<std::tuple<std::int32_t, std::int32_t>>(
+            ops.push_back(WriteBackOperation{op_id, std::vector<TransferPair>(
                                                         pages_to_transfer.begin(), pages_to_transfer.end())});
             req->Apply(fsm::CommitDrainingEvent{});
         } else {

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -289,8 +289,8 @@ std::vector<WriteBackOperation> Scheduler::newWriteBackOperation(
             CacheOpSpec spec;
             spec.request_id = id;
             cache_op_tracker_[op_id] = std::move(spec);
-            ops.push_back(WriteBackOperation{op_id, std::vector<TransferPair>(
-                                                        pages_to_transfer.begin(), pages_to_transfer.end())});
+            ops.push_back(WriteBackOperation{
+                op_id, std::vector<TransferPair>(pages_to_transfer.begin(), pages_to_transfer.end())});
             req->Apply(fsm::CommitDrainingEvent{});
         } else {
             req->Apply(fsm::AbortEvent{});

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.h
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.h
@@ -41,6 +41,7 @@
 #include "resource/kv_prefix_cache/kv_prefix_cache.h"
 #include "resource/allocator/req_pool_allocator.h"
 #include "resource/allocator/mamba_chunk_allocator.h"
+#include "resource/allocator/mamba_host_allocator.h"
 #include "resource/hybrid_prefix_cache/hybrid_prefix_cache.h"
 
 #include "fsm/forward_events.h"
@@ -133,6 +134,7 @@ private:
     PageAllocator device_allocator_;
     PageAllocator host_allocator_;
     std::optional<MambaChunkAllocator> mamba_allocator_{};
+    std::optional<MambaHostAllocator> mamba_host_allocator_{};
     KVPrefixCache kv_prefix_cache_;
     ReqPoolAllocator req_pool_allocator_;
     std::optional<HybridPrefixCache> hybrid_prefix_cache_{};

--- a/tokenspeed-scheduler/csrc/scheduler/types.h
+++ b/tokenspeed-scheduler/csrc/scheduler/types.h
@@ -104,6 +104,8 @@ struct SchedulerConfig {
     bool enable_mamba{false};
     std::int32_t mamba_cache_chunk_size{64};
     std::int32_t mamba_pool_total_chunks{0};
+    bool enable_mamba_l2{false};
+    std::int32_t mamba_l2_host_slots{0};
 };
 
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/tests/cpp/test_cache_operation_kinds.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_operation_kinds.cpp
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+
+#include "scheduler/operations/cache.h"
+
+namespace tokenspeed::test {
+
+TEST(CacheOperationKindTest, FlatWriteBackBucketsTransfersByKind) {
+    WriteBackOperation op;
+    op.op_id = 7;
+    op.transfers = {
+        TransferPair{CacheKind::kKV, 1, 11},
+        TransferPair{CacheKind::kMamba, 2, 22},
+        TransferPair{CacheKind::kKV, 1, 11},
+        TransferPair{CacheKind::kMamba, 3, 23},
+    };
+
+    FlatWriteBackOperation flat({op});
+
+    ASSERT_EQ(flat.op_ids, std::vector<cache_op_id>({7}));
+    EXPECT_EQ(flat.src_pages[0], std::vector<std::int32_t>({1}));
+    EXPECT_EQ(flat.dst_pages[0], std::vector<std::int32_t>({11}));
+    EXPECT_EQ(flat.src_pages_by_kind.at("kv")[0], std::vector<std::int32_t>({1}));
+    EXPECT_EQ(flat.dst_pages_by_kind.at("kv")[0], std::vector<std::int32_t>({11}));
+    EXPECT_EQ(flat.src_pages_by_kind.at("mamba")[0], std::vector<std::int32_t>({2, 3}));
+    EXPECT_EQ(flat.dst_pages_by_kind.at("mamba")[0], std::vector<std::int32_t>({22, 23}));
+}
+
+TEST(CacheOperationKindTest, FlatLoadBackBucketsTransfersByKind) {
+    LoadBackOperation op;
+    op.op_id = 9;
+    op.transfers = {
+        TransferPair{CacheKind::kKV, 10, 20},
+        TransferPair{CacheKind::kMamba, 30, 40},
+    };
+
+    FlatLoadBackOperation flat({op});
+
+    ASSERT_EQ(flat.op_ids, std::vector<cache_op_id>({9}));
+    EXPECT_EQ(flat.src_pages[0], std::vector<std::int32_t>({10}));
+    EXPECT_EQ(flat.dst_pages[0], std::vector<std::int32_t>({20}));
+    EXPECT_EQ(flat.src_pages_by_kind.at("kv")[0], std::vector<std::int32_t>({10}));
+    EXPECT_EQ(flat.dst_pages_by_kind.at("kv")[0], std::vector<std::int32_t>({20}));
+    EXPECT_EQ(flat.src_pages_by_kind.at("mamba")[0], std::vector<std::int32_t>({30}));
+    EXPECT_EQ(flat.dst_pages_by_kind.at("mamba")[0], std::vector<std::int32_t>({40}));
+}
+
+}  // namespace tokenspeed::test

--- a/tokenspeed-scheduler/tests/cpp/test_mamba_cache.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_mamba_cache.cpp
@@ -202,7 +202,6 @@ TEST_F(MambaCacheTest, KVEvictionTriggersMambaEviction) {
     EXPECT_FALSE(node->HasMamba());
 }
 
-
 class MambaL2CacheTest : public ::testing::Test {
 protected:
     static constexpr std::int32_t kPageSize = 2;
@@ -218,13 +217,13 @@ protected:
         prefix_cache_ = std::make_unique<KVPrefixCache>(device_alloc_.get(), host_alloc_.get());
         mamba_alloc_ = std::make_unique<MambaChunkAllocator>(kMambaSlots);
         mamba_host_alloc_ = std::make_unique<MambaHostAllocator>(kMambaHostSlots);
-        hybrid_prefix_cache_ = std::make_unique<HybridPrefixCache>(
-            *prefix_cache_, mamba_alloc_.get(), kMambaCacheChunkSize, mamba_host_alloc_.get());
+        hybrid_prefix_cache_ = std::make_unique<HybridPrefixCache>(*prefix_cache_, mamba_alloc_.get(),
+                                                                   kMambaCacheChunkSize, mamba_host_alloc_.get());
     }
 
     TreeNode* InsertHostKV(const token_vec_t& tokens) {
-        auto result = prefix_cache_->Insert<ResourceType::Host>(tokens, {}, host_alloc_->Allocate(
-            static_cast<std::int32_t>(tokens.size()) / kPageSize));
+        auto result = prefix_cache_->Insert<ResourceType::Host>(
+            tokens, {}, host_alloc_->Allocate(static_cast<std::int32_t>(tokens.size()) / kPageSize));
         return result.last_node;
     }
 

--- a/tokenspeed-scheduler/tests/cpp/test_mamba_cache.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_mamba_cache.cpp
@@ -20,13 +20,24 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+#include <variant>
+
+#include "core/token_container.h"
+#include "fsm/forward_events.h"
+#include "fsm/forward_states.h"
+
 #include "resource/hybrid_prefix_cache/hybrid_prefix_cache.h"
 #include "resource/allocator/mamba_chunk_allocator.h"
+#include "resource/allocator/mamba_host_allocator.h"
+#include "scheduler/operations/cache.h"
 #include "resource/radix_tree/mamba_slot.h"
 #include "resource/kv_prefix_cache/kv_prefix_cache.h"
 #include "resource/radix_tree/node_range.h"
 #include "resource/allocator/page_allocator.h"
+#include "resource/allocator/req_pool_allocator.h"
 #include "unit_test_helper.h"
+#include "scheduler/types.h"
 
 namespace tokenspeed::test {
 
@@ -189,6 +200,248 @@ TEST_F(MambaCacheTest, KVEvictionTriggersMambaEviction) {
     prefix_cache_->EnsureCapacityByEvict<ResourceType::Device>(kDevicePages);
 
     EXPECT_FALSE(node->HasMamba());
+}
+
+
+class MambaL2CacheTest : public ::testing::Test {
+protected:
+    static constexpr std::int32_t kPageSize = 2;
+    static constexpr std::int32_t kDevicePages = 32;
+    static constexpr std::int32_t kHostPages = 32;
+    static constexpr std::int32_t kMambaSlots = 8;
+    static constexpr std::int32_t kMambaHostSlots = 8;
+    static constexpr std::int32_t kMambaCacheChunkSize = 4;
+
+    void SetUp() override {
+        device_alloc_ = std::make_unique<PageAllocator>(kPageSize, kDevicePages);
+        host_alloc_ = std::make_unique<PageAllocator>(kPageSize, kHostPages);
+        prefix_cache_ = std::make_unique<KVPrefixCache>(device_alloc_.get(), host_alloc_.get());
+        mamba_alloc_ = std::make_unique<MambaChunkAllocator>(kMambaSlots);
+        mamba_host_alloc_ = std::make_unique<MambaHostAllocator>(kMambaHostSlots);
+        hybrid_prefix_cache_ = std::make_unique<HybridPrefixCache>(
+            *prefix_cache_, mamba_alloc_.get(), kMambaCacheChunkSize, mamba_host_alloc_.get());
+    }
+
+    TreeNode* InsertHostKV(const token_vec_t& tokens) {
+        auto result = prefix_cache_->Insert<ResourceType::Host>(tokens, {}, host_alloc_->Allocate(
+            static_cast<std::int32_t>(tokens.size()) / kPageSize));
+        return result.last_node;
+    }
+
+    std::unique_ptr<PageAllocator> device_alloc_;
+    std::unique_ptr<PageAllocator> host_alloc_;
+    std::unique_ptr<MambaChunkAllocator> mamba_alloc_;
+    std::unique_ptr<MambaHostAllocator> mamba_host_alloc_;
+    std::unique_ptr<KVPrefixCache> prefix_cache_;
+    std::unique_ptr<HybridPrefixCache> hybrid_prefix_cache_;
+};
+
+TEST_F(MambaL2CacheTest, HostKVRequiresHostMambaForHybridMatch) {
+    auto tokens = MakeAlignedTokens(3, kPageSize);
+    TreeNode* node = InsertHostKV(tokens);
+
+    auto device_slot = mamba_alloc_->Allocate();
+    ASSERT_TRUE(device_slot.has_value());
+    node->AttachMamba(std::make_unique<MambaSlot>(std::move(*device_slot)));
+
+    auto mismatch = hybrid_prefix_cache_->Match(tokens);
+    EXPECT_EQ(mismatch.host.DepthInPage(), 0);
+    EXPECT_EQ(mismatch.device.DepthInPage(), 0);
+
+    node->DetachMamba();
+    auto host_slot = mamba_host_alloc_->Allocate();
+    ASSERT_TRUE(host_slot.has_value());
+    const std::int32_t host_idx = host_slot->Index();
+    node->AttachMambaHost(std::make_unique<MambaSlot>(std::move(*host_slot)));
+
+    auto match = hybrid_prefix_cache_->Match(tokens);
+    EXPECT_EQ(match.host.DepthInPage(), 3);
+    EXPECT_EQ(match.device.DepthInPage(), 0);
+    EXPECT_EQ(match.mamba_host_src_index, host_idx);
+    EXPECT_EQ(match.mamba_cow_src_index, -1);
+}
+
+TEST_F(MambaL2CacheTest, DeeperHostMambaMatchTakesPriorityOverShallowDeviceMamba) {
+    auto tokens2 = MakeAlignedTokens(2, kPageSize);
+    auto device_result = prefix_cache_->Insert<ResourceType::Device>(tokens2, {}, device_alloc_->Allocate(2));
+    TreeNode* device_node = device_result.last_node;
+    auto device_slot = mamba_alloc_->Allocate();
+    ASSERT_TRUE(device_slot.has_value());
+    device_node->AttachMamba(std::make_unique<MambaSlot>(std::move(*device_slot)));
+
+    auto tokens4 = MakeAlignedTokens(4, kPageSize);
+    auto host_result = prefix_cache_->Insert<ResourceType::Host>(tokens4, {}, host_alloc_->Allocate(4));
+    TreeNode* host_node = host_result.last_node;
+    auto host_slot = mamba_host_alloc_->Allocate();
+    ASSERT_TRUE(host_slot.has_value());
+    const std::int32_t host_idx = host_slot->Index();
+    host_node->AttachMambaHost(std::make_unique<MambaSlot>(std::move(*host_slot)));
+
+    auto match = hybrid_prefix_cache_->Match(tokens4);
+
+    EXPECT_EQ(match.device.DepthInPage(), 2);
+    EXPECT_EQ(match.host.DepthInPage(), 4);
+    EXPECT_EQ(match.mamba_host_src_index, host_idx);
+    EXPECT_EQ(match.mamba_cow_src_index, -1) << "deeper host hit must trigger Mamba L2 loadback";
+}
+
+TEST_F(MambaL2CacheTest, PrefillFirstChunkRequiresCheckpointSlot) {
+    MambaChunkAllocator one_slot_mamba_alloc(1);
+    ReqPoolAllocator req_pool_alloc(1);
+    auto tokens = MakeAlignedTokens(1, kPageSize);
+    TokenContainer token_container(tokens);
+    auto match = prefix_cache_->Match(token_container.GetFullPagedTokens(kPageSize, true));
+
+    fsm::SchedulePrefillFirstChunkEvent event{
+        static_cast<std::int32_t>(tokens.size()),
+        0,
+        device_alloc_.get(),
+        &req_pool_alloc,
+        match,
+        Role::kP,
+        prefix_cache_.get(),
+        false,
+        {},
+        hybrid_prefix_cache_.get(),
+        &one_slot_mamba_alloc,
+    };
+
+    EXPECT_THROW((void)event(fsm::Submitted{&token_container, kPageSize}), std::logic_error);
+}
+
+TEST_F(MambaL2CacheTest, PrepareMambaLoadBackAllocatesDeviceSlotAndTransferPair) {
+    auto tokens = MakeAlignedTokens(2, kPageSize);
+    TreeNode* node = InsertHostKV(tokens);
+    auto host_slot = mamba_host_alloc_->Allocate();
+    ASSERT_TRUE(host_slot.has_value());
+    const std::int32_t host_idx = host_slot->Index();
+    node->AttachMambaHost(std::make_unique<MambaSlot>(std::move(*host_slot)));
+
+    auto transfers = hybrid_prefix_cache_->PrepareMambaDeviceLoadBack({node});
+
+    ASSERT_TRUE(node->HasMamba());
+    ASSERT_EQ(transfers.size(), 1u);
+    EXPECT_EQ(transfers[0].kind, CacheKind::kMamba);
+    EXPECT_EQ(transfers[0].src, host_idx);
+    EXPECT_EQ(transfers[0].dst, node->MambaSlotIndex());
+}
+
+TEST_F(MambaL2CacheTest, ExactWriteBackAckDoesNotPublishUnackedAncestor) {
+    auto tokens2 = MakeAlignedTokens(2, kPageSize);
+    auto tokens4 = MakeAlignedTokens(4, kPageSize);
+    auto result2 = prefix_cache_->Insert<ResourceType::Device>(tokens2, {}, device_alloc_->Allocate(2));
+    auto result4 = prefix_cache_->Insert<ResourceType::Device>(tokens4, {}, device_alloc_->Allocate(4));
+    TreeNode* ancestor = result2.last_node;
+    TreeNode* descendant = result4.last_node;
+    prefix_cache_->Insert<ResourceType::Host>(tokens4, {}, host_alloc_->Allocate(4));
+
+    auto ancestor_slot = mamba_alloc_->Allocate();
+    ASSERT_TRUE(ancestor_slot.has_value());
+    ancestor->AttachMamba(std::make_unique<MambaSlot>(std::move(*ancestor_slot)));
+    auto descendant_slot = mamba_alloc_->Allocate();
+    ASSERT_TRUE(descendant_slot.has_value());
+    descendant->AttachMamba(std::make_unique<MambaSlot>(std::move(*descendant_slot)));
+
+    auto ancestor_transfers = hybrid_prefix_cache_->PrepareMambaHostWriteBack({ancestor});
+    auto descendant_transfers = hybrid_prefix_cache_->PrepareMambaHostWriteBack({descendant});
+    ASSERT_EQ(ancestor_transfers.size(), 1u);
+    ASSERT_EQ(descendant_transfers.size(), 1u);
+
+    hybrid_prefix_cache_->OnMambaHostWriteBackDone(std::vector<TreeNode*>{descendant});
+
+    EXPECT_FALSE(ancestor->HasMambaOnHost())
+        << "an ack for a descendant op must not publish a different pending ancestor";
+    EXPECT_TRUE(descendant->HasMambaOnHost());
+
+    hybrid_prefix_cache_->OnMambaHostWriteBackDone(std::vector<TreeNode*>{ancestor});
+    EXPECT_TRUE(ancestor->HasMambaOnHost());
+}
+
+TEST_F(MambaL2CacheTest, PrepareMambaWriteBackPublishesHostSlotOnlyAfterAck) {
+    auto tokens = MakeAlignedTokens(2, kPageSize);
+    auto result = prefix_cache_->Insert<ResourceType::Device>(tokens, {}, device_alloc_->Allocate(2));
+    TreeNode* node = result.last_node;
+    prefix_cache_->Insert<ResourceType::Host>(tokens, {}, host_alloc_->Allocate(2));
+    auto device_slot = mamba_alloc_->Allocate();
+    ASSERT_TRUE(device_slot.has_value());
+    const std::int32_t device_idx = device_slot->Index();
+    node->AttachMamba(std::make_unique<MambaSlot>(std::move(*device_slot)));
+
+    auto transfers = hybrid_prefix_cache_->PrepareMambaHostWriteBack({node});
+
+    ASSERT_EQ(transfers.size(), 1u);
+    EXPECT_EQ(transfers[0].kind, CacheKind::kMamba);
+    EXPECT_EQ(transfers[0].src, device_idx);
+    const std::int32_t host_idx = transfers[0].dst;
+    EXPECT_FALSE(node->HasMambaOnHost()) << "host mamba must remain invisible until writeback ack";
+
+    auto pending_match = hybrid_prefix_cache_->Match(tokens);
+    EXPECT_EQ(pending_match.host.DepthInPage(), 0);
+
+    hybrid_prefix_cache_->OnMambaHostWriteBackDone(node);
+
+    ASSERT_TRUE(node->HasMambaOnHost());
+    EXPECT_EQ(node->MambaHostSlotIndex(), host_idx);
+    EXPECT_FALSE(node->HasMamba()) << "idle device mamba copy should demote once host writeback is acknowledged";
+    auto host_match = hybrid_prefix_cache_->Match(tokens);
+    EXPECT_EQ(host_match.host.DepthInPage(), 2);
+    EXPECT_EQ(host_match.mamba_host_src_index, host_idx);
+    EXPECT_EQ(host_match.mamba_cow_src_index, -1);
+}
+
+TEST_F(MambaL2CacheTest, HostWriteBackDemotesAfterDeviceRefUnlock) {
+    auto tokens = MakeAlignedTokens(2, kPageSize);
+    auto result = prefix_cache_->Insert<ResourceType::Device>(tokens, {}, device_alloc_->Allocate(2));
+    TreeNode* node = result.last_node;
+    prefix_cache_->Insert<ResourceType::Host>(tokens, {}, host_alloc_->Allocate(2));
+
+    auto device_slot = mamba_alloc_->Allocate();
+    ASSERT_TRUE(device_slot.has_value());
+    node->AttachMamba(std::make_unique<MambaSlot>(std::move(*device_slot)));
+
+    auto transfers = hybrid_prefix_cache_->PrepareMambaHostWriteBack({node});
+    ASSERT_EQ(transfers.size(), 1u);
+
+    {
+        DeviceNodeRef device_ref(node);
+        hybrid_prefix_cache_->OnMambaHostWriteBackDone(std::vector<TreeNode*>{node});
+        EXPECT_TRUE(node->HasMamba()) << "device copy must stay pinned while DeviceNodeRef is live";
+        EXPECT_TRUE(node->HasMambaOnHost());
+    }
+
+    EXPECT_TRUE(node->HasMamba()) << "device copy is still present before the post-unlock demote pass";
+
+    hybrid_prefix_cache_->DemoteIdleMambaDeviceCopiesPresentOnHost();
+
+    EXPECT_FALSE(node->HasMamba());
+    EXPECT_TRUE(node->HasMambaOnHost());
+}
+
+TEST_F(MambaL2CacheTest, WriteBackDoneDropsDeviceMambaWhenKVChildKeepsDeviceNode) {
+    auto tokens4 = MakeAlignedTokens(4, kPageSize);
+    auto result = prefix_cache_->Insert<ResourceType::Device>(tokens4, {}, device_alloc_->Allocate(4));
+    TreeNode* node = result.last_node;
+    prefix_cache_->Insert<ResourceType::Host>(tokens4, {}, host_alloc_->Allocate(4));
+
+    auto device_slot = mamba_alloc_->Allocate();
+    ASSERT_TRUE(device_slot.has_value());
+    node->AttachMamba(std::make_unique<MambaSlot>(std::move(*device_slot)));
+    auto host_slot = mamba_host_alloc_->Allocate();
+    ASSERT_TRUE(host_slot.has_value());
+    node->AttachMambaHost(std::make_unique<MambaSlot>(std::move(*host_slot)));
+
+    auto tokens5 = MakeAlignedTokens(5, kPageSize);
+    prefix_cache_->Insert<ResourceType::Device>(tokens5, DevicePagesFromRoot(node), device_alloc_->Allocate(1));
+    ASSERT_TRUE(node->OnDevice());
+    ASSERT_TRUE(node->HasMamba());
+    ASSERT_GT(node->NumChildren(), 0u);
+
+    prefix_cache_->ReleaseDeviceResourcesPresentOnHost(
+        node, [this](TreeNode* n) { hybrid_prefix_cache_->OnKVDeviceDemote(n); });
+
+    EXPECT_TRUE(node->OnDevice()) << "KV device node is kept because a child still uses the device tier";
+    EXPECT_FALSE(node->HasMamba()) << "Mamba device state must still demote to host after writeback";
+    EXPECT_TRUE(node->HasMambaOnHost());
 }
 
 }  // namespace tokenspeed::test

--- a/tokenspeed-scheduler/tests/cpp/test_mamba_integration.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_mamba_integration.cpp
@@ -152,7 +152,6 @@ TEST_F(MambaDecodeCapacityTest, PrefillDoneDecodeCapacityMissRetractsInsteadOfTh
     ASSERT_EQ(writebacks.size(), 1u);
 }
 
-
 class MambaUnalignedCheckpointTest : public SchedulerTestSuite {
 protected:
     SchedulerConfig MakeConfig() override {

--- a/tokenspeed-scheduler/tests/cpp/test_mamba_integration.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_mamba_integration.cpp
@@ -127,6 +127,189 @@ TEST_F(MambaIntegrationTest, AbortFreesMambaSlots) {
     PlanOnce();
 }
 
+class MambaDecodeCapacityTest : public SchedulerTestSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        auto cfg = SchedulerTestSuite::MakeConfig();
+        cfg.enable_mamba = true;
+        cfg.mamba_pool_total_chunks = 2;
+        cfg.max_batch_size = 1;
+        return cfg;
+    }
+};
+
+TEST_F(MambaDecodeCapacityTest, PrefillDoneDecodeCapacityMissRetractsInsteadOfThrowing) {
+    Submit(MakeRequestSpec("r1", 1));
+
+    auto prefill = PlanOnce();
+    ASSERT_FALSE(prefill.Operations().empty());
+    SendForwardDone("r1", {100});
+
+    ExecutionPlan plan;
+    EXPECT_NO_THROW(plan = PlanOnce());
+
+    auto writebacks = ExtractCacheOpsOfKind<FlatWriteBackOperation>(plan);
+    ASSERT_EQ(writebacks.size(), 1u);
+}
+
+
+class MambaUnalignedCheckpointTest : public SchedulerTestSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        auto cfg = SchedulerTestSuite::MakeConfig();
+        cfg.enable_mamba = true;
+        cfg.mamba_pool_total_chunks = 16;
+        cfg.mamba_cache_chunk_size = 4;
+        cfg.max_scheduled_tokens = 3;
+        cfg.enable_l3_storage = false;
+        return cfg;
+    }
+
+    static const FlatForwardOperation* GetForward(const ExecutionPlan& plan) {
+        for (const auto& op : plan.Operations()) {
+            if (auto* fwd = std::get_if<FlatForwardOperation>(&op)) return fwd;
+        }
+        return nullptr;
+    }
+};
+
+TEST_F(MambaUnalignedCheckpointTest, ChunkBoundaryNotAlignedToMambaChunkDoesNotPublishCheckpoint) {
+    Submit(RequestSpec{.request_id = "r1", .tokens = {1, 2, 3, 4, 5}});
+
+    auto first_chunk = PlanOnce();
+    const auto* first_forward = GetForward(first_chunk);
+    ASSERT_NE(first_forward, nullptr);
+    ASSERT_EQ(first_forward->input_lengths[0], 3);
+
+    auto second_chunk = PlanOnce();
+    const auto* second_forward = GetForward(second_chunk);
+    ASSERT_NE(second_forward, nullptr);
+
+    SendFinish("r1");
+    PlanOnce();
+
+    Submit(RequestSpec{.request_id = "r2", .tokens = {1, 2, 9}});
+    auto prefix_probe = PlanOnce();
+    const auto* probe_forward = GetForward(prefix_probe);
+    ASSERT_NE(probe_forward, nullptr);
+    ASSERT_EQ(probe_forward->request_ids.size(), 1u);
+    EXPECT_EQ(probe_forward->request_ids[0], "r2");
+    EXPECT_EQ(probe_forward->extend_prefix_lens[0], 0);
+    EXPECT_EQ(probe_forward->mamba_cow_src_indices[0], -1)
+        << "C++ must not publish a checkpoint that Python skipped at an unaligned boundary";
+}
+
+class MambaL2IntegrationTest : public SchedulerTestSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        auto cfg = SchedulerTestSuite::MakeConfig();
+        cfg.enable_mamba = true;
+        cfg.mamba_pool_total_chunks = 16;
+        cfg.enable_mamba_l2 = true;
+        cfg.mamba_l2_host_slots = 16;
+        cfg.host_allocator.total_pages = 32;
+        return cfg;
+    }
+
+    static const FlatWriteBackOperation* GetWriteBack(const ExecutionPlan& plan) {
+        for (const auto& op : plan.Operations()) {
+            if (auto* cop = std::get_if<CacheOperation>(&op)) {
+                if (auto* wb = std::get_if<FlatWriteBackOperation>(cop)) {
+                    return wb;
+                }
+            }
+        }
+        return nullptr;
+    }
+
+    static const FlatLoadBackOperation* GetLoadBack(const ExecutionPlan& plan) {
+        for (const auto& op : plan.Operations()) {
+            if (auto* cop = std::get_if<CacheOperation>(&op)) {
+                if (auto* lb = std::get_if<FlatLoadBackOperation>(cop)) {
+                    return lb;
+                }
+            }
+        }
+        return nullptr;
+    }
+};
+
+TEST_F(MambaL2IntegrationTest, FinishWriteBackCarriesMambaPair) {
+    Submit(MakeRequestSpec("r1", 2));
+    PlanOnce();
+    SendForwardDone("r1", {100});
+    PlanOnce();
+
+    SendFinish("r1");
+    auto plan = PlanOnce();
+    const auto* wb = GetWriteBack(plan);
+    ASSERT_NE(wb, nullptr);
+    ASSERT_FALSE(wb->op_ids.empty());
+    ASSERT_TRUE(wb->src_pages_by_kind.contains("mamba"));
+    bool has_mamba_pair = false;
+    for (const auto& pages : wb->src_pages_by_kind.at("mamba")) {
+        has_mamba_pair = has_mamba_pair || !pages.empty();
+    }
+    EXPECT_TRUE(has_mamba_pair);
+}
+
+TEST_F(MambaL2IntegrationTest, WriteBackDoneDemotesDeviceAndNextRequestLoadsBackMamba) {
+    Submit(MakeRequestSpec("r1", 2));
+    PlanOnce();
+    SendForwardDone("r1", {100});
+    PlanOnce();
+
+    SendFinish("r1");
+    auto writeback_plan = PlanOnce();
+    const auto* wb = GetWriteBack(writeback_plan);
+    ASSERT_NE(wb, nullptr);
+    ASSERT_FALSE(wb->op_ids.empty());
+
+    SendWriteBackDone(wb->op_ids[0]);
+    PlanOnce();
+
+    Submit(MakeRequestSpec("r2", 3));
+    auto loadback_plan = PlanOnce();
+    const auto* lb = GetLoadBack(loadback_plan);
+    ASSERT_NE(lb, nullptr) << "written-back Mamba+KV cache must be host-only and require loadback";
+    ASSERT_TRUE(lb->src_pages_by_kind.contains("kv"));
+    ASSERT_TRUE(lb->src_pages_by_kind.contains("mamba"));
+    EXPECT_FALSE(lb->src_pages_by_kind.at("mamba").empty());
+}
+
+TEST_F(MambaL2IntegrationTest, HostOnlyMambaLoadsBackAfterPinnedWriteBackReleases) {
+    Submit(RequestSpec{.request_id = "r1", .tokens = {1, 2, 3, 4}});
+    PlanOnce();
+    SendForwardDone("r1", {100});
+    PlanOnce();
+
+    SendFinish("r1");
+    auto writeback_plan = PlanOnce();
+    const auto* wb = GetWriteBack(writeback_plan);
+    ASSERT_NE(wb, nullptr);
+    ASSERT_FALSE(wb->op_ids.empty());
+
+    Submit(RequestSpec{.request_id = "child", .tokens = {1, 2, 3, 4, 5, 6}});
+    PlanOnce();
+    SendForwardDone("child", {200});
+    PlanOnce();
+
+    SendWriteBackDone(wb->op_ids[0]);
+    PlanOnce();
+
+    ExecutionEvent abort_child;
+    abort_child.With(ForwardEvent{forward::Abort{.request_id = "child"}});
+    scheduler_->Advance(std::move(abort_child));
+    PlanOnce();
+
+    Submit(RequestSpec{.request_id = "probe", .tokens = {1, 2, 3, 4, 9}});
+    auto loadback_plan = PlanOnce();
+    const auto* lb = GetLoadBack(loadback_plan);
+    ASSERT_NE(lb, nullptr) << "host-only Mamba must load back after the pinning request releases";
+    ASSERT_TRUE(lb->src_pages_by_kind.contains("mamba"));
+    EXPECT_FALSE(lb->src_pages_by_kind.at("mamba").empty());
+}
+
 class DisablePrefixCacheMambaRetractTest : public SchedulerTestSuite {
 protected:
     SchedulerConfig MakeConfig() override {

--- a/tokenspeed-scheduler/tests/cpp/test_mamba_slot.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_mamba_slot.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <numeric>
 #include "resource/allocator/mamba_chunk_allocator.h"
+#include "resource/allocator/mamba_host_allocator.h"
 #include "resource/radix_tree/mamba_slot.h"
 #include "resource/allocator/local_mamba_allocator.h"
 #include "resource/radix_tree/tree_node.h"
@@ -49,6 +50,33 @@ TEST(MambaChunkAllocatorTest, ExhaustedPoolReturnsNullopt) {
     auto s1 = allocator.Allocate();
     auto s2 = allocator.Allocate();
     EXPECT_FALSE(s2.has_value());
+}
+
+
+
+TEST(MambaHostAllocatorTest, AllocateFreeAndDrainReleased) {
+    tokenspeed::MambaHostAllocator allocator(3);
+    auto slot = allocator.Allocate();
+    ASSERT_TRUE(slot.has_value());
+    std::int32_t idx = slot->Index();
+    EXPECT_EQ(allocator.AvailableSlots(), 2);
+
+    slot.reset();
+    EXPECT_EQ(allocator.AvailableSlots(), 3);
+    auto released = allocator.DrainReleased();
+    ASSERT_EQ(released.size(), 1);
+    EXPECT_EQ(released[0], idx);
+    EXPECT_TRUE(allocator.DrainReleased().empty());
+}
+
+TEST(MambaSlotTest, CustomReleaserRunsOnDestruction) {
+    std::vector<std::int32_t> released;
+    {
+        tokenspeed::MambaSlot slot(7, [&released](std::int32_t idx) { released.push_back(idx); });
+        EXPECT_EQ(slot.Index(), 7);
+    }
+    ASSERT_EQ(released.size(), 1);
+    EXPECT_EQ(released[0], 7);
 }
 
 TEST(MambaSlotTest, RAIIFreesOnDestruction) {
@@ -114,6 +142,38 @@ TEST(TreeNodeMambaTest, DestructorFreesMambaSlot) {
         EXPECT_EQ(allocator.AvailableSlots(), 3);
     }
     EXPECT_EQ(allocator.AvailableSlots(), 4);
+}
+
+
+
+TEST(TreeNodeMambaTest, AttachAndDetachMambaHost) {
+    tokenspeed::MambaHostAllocator allocator(4);
+    tokenspeed::TreeNode node;
+
+    auto slot = allocator.Allocate();
+    ASSERT_TRUE(slot.has_value());
+    std::int32_t idx = slot->Index();
+
+    node.AttachMambaHost(std::make_unique<tokenspeed::MambaSlot>(std::move(*slot)));
+    EXPECT_TRUE(node.HasMambaOnHost());
+    EXPECT_EQ(node.MambaHostSlotIndex(), idx);
+
+    auto detached = node.DetachMambaHost();
+    EXPECT_FALSE(node.HasMambaOnHost());
+    EXPECT_EQ(detached->Index(), idx);
+    EXPECT_EQ(allocator.AvailableSlots(), 3);
+}
+
+TEST(TreeNodeMambaTest, DestructorFreesMambaHostSlot) {
+    tokenspeed::MambaHostAllocator allocator(4);
+    {
+        tokenspeed::TreeNode node;
+        auto slot = allocator.Allocate();
+        node.AttachMambaHost(std::make_unique<tokenspeed::MambaSlot>(std::move(*slot)));
+        EXPECT_EQ(allocator.AvailableSlots(), 3);
+    }
+    EXPECT_EQ(allocator.AvailableSlots(), 4);
+    EXPECT_EQ(allocator.DrainReleased().size(), 1);
 }
 
 TEST(TreeNodeMambaTest, SplitKeepsMambaOnSuffix) {

--- a/tokenspeed-scheduler/tests/cpp/test_mamba_slot.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_mamba_slot.cpp
@@ -52,8 +52,6 @@ TEST(MambaChunkAllocatorTest, ExhaustedPoolReturnsNullopt) {
     EXPECT_FALSE(s2.has_value());
 }
 
-
-
 TEST(MambaHostAllocatorTest, AllocateFreeAndDrainReleased) {
     tokenspeed::MambaHostAllocator allocator(3);
     auto slot = allocator.Allocate();
@@ -143,8 +141,6 @@ TEST(TreeNodeMambaTest, DestructorFreesMambaSlot) {
     }
     EXPECT_EQ(allocator.AvailableSlots(), 4);
 }
-
-
 
 TEST(TreeNodeMambaTest, AttachAndDetachMambaHost) {
     tokenspeed::MambaHostAllocator allocator(4);


### PR DESCRIPTION
## Summary
This PR adds L2 cache support for Mamba cache alongside the existing KV cache L2 path.

The core change is to generalize cache movement into CacheTransferUnit, which carries the cache kind (KV or Mamba) plus source and destination slots/pages. WriteBackOperation and LoadBackOperation can now carry mixed KV/Mamba transfer units without adding Mamba-specific scheduler branches everywhere.

Key behavior:

- Mamba cache can be written back from GPU to host memory.
- Mamba cache can be loaded back from host memory to GPU.
- Mamba host memory supports eviction when host Mamba slots are exhausted.
- Mamba loadback completion is synchronized through stream fence semantics, not scheduler loadback-done events.
- Prefix reuse now requires all cache types for a token prefix to exist. KV-only cache is not considered reusable when the corresponding Mamba state is missing.
- Mamba state depth is tracked explicitly so page-aligned prefix states and non-exact retraction recovery states are not confused.

Important design points:

- CacheTransferUnit avoids duplicating writeback/loadback logic for KV and Mamba.
- TreeNode tracks device/host Mamba slots and their token depth.
- FindLastMambaNode(..., require_exact_depth=true) is used for prefix cache reuse.
- Retraction recovery may use non-exact live Mamba state, but normal prefix reuse may not.
- Host-side Mamba eviction detaches only the host Mamba state; future prefix reuse still requires KV and Mamba to both be present.

## Test Plan
`ts serve \
  --model nvidia/Qwen3.5-397B-A17B-NVFP4 \
  --host 127.0.0.1 \
  --port 12346 \
  --trust-remote-code \
  --max-model-len 120000 \
  --gpu-memory-utilization 0.95 \
  --max-num-seqs 16 \
  --max-total-tokens 1000000 \
  --chunked-prefill-size 128 \
  --max-prefill-tokens 128 \
  --kv-cache-dtype fp8_e4m3 \
  --quantization nvfp4 \
  --enable-mamba-l2 \
  --mamba-l2-host-slots 512 \
  --mamba-l2-io-backend kernel \
  --enable-cache-report \
  --moe-backend flashinfer_trtllm \
  --attention-backend trtllm \
  --attn-tp-size 4`

`evalscope eval \
  --model nvidia/Qwen3.5-397B-A17B-NVFP4 \
  --api-url http://127.0.0.12346/v1 \
  --api-key EMPTY_TOKEN \
  --datasets aime25 \
  --eval-batch-size 16 \
  --generation-config '{"max_tokens":100000}'`

mamba loadback/writeback can be seen. The score is 0.9

<!-- How was this validated? -->
