### PR TITLE
docs: update parser launch examples

### DIFF
--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -109,7 +109,10 @@ about.
 | `--tool-call-parser` | Parser for OpenAI-compatible tool-call payloads (handled by the smg gateway). |
 | `--enable-custom-logit-processor` | Allow custom logit processors. Keep disabled unless the deployment needs it. |
 
-Common parser values include `kimi_k2` and `gpt-oss`.
+Common reasoning parser values include `kimi_k25`, `base`, `qwen3`, and
+`deepseek_r1`. Common tool-call parser values include `kimik2`, `qwen`, `json`,
+and `passthrough`. The parser names are validated by the SMG gateway, so use
+the values accepted by the bundled `tokenspeed-smg` package.
 
 ## Speculative Decoding
 

--- a/docs/guides/launching.md
+++ b/docs/guides/launching.md
@@ -31,8 +31,8 @@ tokenspeed serve nvidia/Kimi-K2.5-NVFP4 \
   --max-num-seqs 256 \
   --attention-backend trtllm_mla \
   --moe-backend flashinfer_trtllm \
-  --reasoning-parser kimi_k2 \
-  --tool-call-parser kimi_k2
+  --reasoning-parser kimi_k25 \
+  --tool-call-parser kimik2
 ```
 
 ## Launch Checklist

--- a/docs/recipes/models.md
+++ b/docs/recipes/models.md
@@ -24,8 +24,8 @@ tokenspeed serve nvidia/Kimi-K2.5-NVFP4 \
   --max-num-seqs 256 \
   --attention-backend trtllm_mla \
   --moe-backend flashinfer_trtllm \
-  --reasoning-parser kimi_k2 \
-  --tool-call-parser kimi_k2 \
+  --reasoning-parser kimi_k25 \
+  --tool-call-parser kimik2 \
   --host 0.0.0.0 \
   --port 8000
 ```
@@ -44,8 +44,7 @@ tokenspeed serve openai/gpt-oss-20b \
   --tensor-parallel-size 1 \
   --max-model-len 131072 \
   --chunked-prefill-size 8192 \
-  --reasoning-parser gpt-oss \
-  --tool-call-parser gpt-oss \
+  --reasoning-parser base \
   --host 0.0.0.0 \
   --port 8000
 ```
@@ -58,8 +57,7 @@ tokenspeed serve openai/gpt-oss-120b \
   --kv-cache-dtype fp8 \
   --chunked-prefill-size 8192 \
   --max-num-seqs 256 \
-  --reasoning-parser gpt-oss \
-  --tool-call-parser gpt-oss \
+  --reasoning-parser base \
   --host 0.0.0.0 \
   --port 8000
 ```

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -1312,7 +1312,7 @@ class ServerArgs:
             type=str,
             default=ServerArgs.reasoning_parser,
             help=(
-                "Reasoning parser name (e.g. 'minimax', 'gpt-oss'). "
+                "Reasoning parser name (e.g. 'minimax', 'kimi_k25'). "
                 "Used to defer json_schema grammars past the model's "
                 "reasoning channel."
             ),


### PR DESCRIPTION
## Summary

I noticed the Kimi and GPT-OSS launch docs were using parser names that the bundled SMG gateway does not accept. With the documented Kimi values, startup fails during SMG argument validation even after the TokenSpeed engine finishes warmup, so I updated the docs to use the accepted parser names: `kimi_k25` / `kimik2` for Kimi, and `base` for the GPT-OSS reasoning parser used by the existing CI recipe.

I also updated the server argument help text so it no longer lists `gpt-oss` as an example reasoning parser.

## Currently accepted SMG parser choices

Reasoning parsers:

```text
base
cohere_cmd
deepseek_r1
deepseek_v31
glm45
kimi
kimi_k25
kimi_thinking
minimax
nano_v3
none
qwen3
qwen3_thinking
step3
```

Tool-call parsers:

```text
cohere
deepseek
deepseek31
deepseek32
deepseek_v4
glm45_moe
glm47_moe
json
kimik2
llama
minimax_m2
mistral
passthrough
pythonic
qwen
qwen_coder
qwen_xml
step3
```

## Test Plan

I hit this startup failure when using the documented Kimi parser values:

```text
[smg] __main__.py: error: argument --reasoning-parser: invalid choice: 'kimi_k2' (choose from 'base', 'cohere_cmd', 'deepseek_r1', 'deepseek_v31', 'glm45', 'kimi', 'kimi_k25', 'kimi_thinking', 'minimax', 'nano_v3', 'none', 'qwen3', 'qwen3_thinking', 'step3')
startup failed: smg subprocess exited with rc=2 during startup; see [smg] log lines above for the cause
```

After changing the launch command to use `--reasoning-parser kimi_k25` and `--tool-call-parser kimik2`, the SMG parser validation issue is gone and the server can continue past gateway startup.