### PR TITLE
refactor: forward mode consolidation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,4 @@
 # CLAUDE.md
 
 @AGENTS.md
+@AGENTS.local.md

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -792,7 +792,6 @@ class EventLoop:
         forward_mode = ForwardMode.from_num_extends(
             forward_op.num_extends(),
             len(forward_op.request_ids),
-            has_drafter=self.server_args.speculative_algorithm is not None,
         )
         self.request_handler._profile_batch_predicate(forward_mode)
 
@@ -869,7 +868,6 @@ class EventLoop:
             forward_mode = ForwardMode.from_num_extends(
                 forward_op.num_extends(),
                 batch_size,
-                has_drafter=self.server_args.speculative_algorithm is not None,
             )
 
         self._dp_local_info[0, 0] = num_tokens
@@ -886,13 +884,7 @@ class EventLoop:
         any_rank_has_work = max(global_num_tokens) > 0
         need_idle_forward = num_tokens == 0 and any_rank_has_work
         all_decode_or_idle = all(
-            mode
-            in (
-                int(ForwardMode.DECODE),
-                int(ForwardMode.IDLE),
-                int(ForwardMode.TARGET_VERIFY),
-            )
-            for mode in global_forward_mode
+            ForwardMode(mode).is_decode_or_idle() for mode in global_forward_mode
         )
         return DpForwardMetadata(
             global_num_tokens=global_num_tokens,

--- a/python/tokenspeed/runtime/engine/request_handler.py
+++ b/python/tokenspeed/runtime/engine/request_handler.py
@@ -418,7 +418,7 @@ class RequestHandler:
                 Not needed for step-count-based profiling.
         """
         if self.profile_by_stage and forward_mode is not None:
-            if forward_mode.is_extend():
+            if forward_mode.is_extend_or_mixed():
                 if self.profiler_prefill_ct == 0:
                     self.start_profile(forward_mode)
                 self.profiler_prefill_ct += 1

--- a/python/tokenspeed/runtime/engine/schedule_batch.py
+++ b/python/tokenspeed/runtime/engine/schedule_batch.py
@@ -225,7 +225,9 @@ class ScheduleBatch(DisaggregationDecodeScheduler):
                 logger.debug("[evict] out_cache_loc=%r after evict", out_cache_loc)
 
             if out_cache_loc is None:
-                phase_str = "Prefill" if self.forward_mode.is_extend() else "Decode"
+                phase_str = (
+                    "Prefill" if self.forward_mode.is_extend_or_mixed() else "Decode"
+                )
                 logger.error(
                     "%s out of memory. Try to lower your batch size.\nTry to allocate %s tokens.\nAvailable tokens: %s\n",
                     phase_str,

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -296,18 +296,13 @@ class CudaGraphWrapper:
     def _capture_one(self, bs: int):
         graph = torch.cuda.CUDAGraph()
 
-        capture_forward_mode = (
-            ForwardMode.TARGET_VERIFY
-            if self.drafter is not None
-            else ForwardMode.DECODE
-        )
         ctx = ForwardContext(
             attn_backend=self.attn_backend,
             token_to_kv_pool=self.token_to_kv_pool,
             bs=bs,
             num_extends=0,
             input_num_tokens=bs * self.max_tokens_per_req,
-            forward_mode=capture_forward_mode,
+            forward_mode=ForwardMode.DECODE,
             capture_hidden_mode=(
                 CaptureHiddenMode.FULL
                 if self.drafter is not None
@@ -463,7 +458,7 @@ class CudaGraphWrapper:
             bs * self.max_tokens_per_req,
             self.input_buffers.req_pool_indices_buf[:bs],
             self.input_buffers.seq_lens_buf[:bs],
-            ForwardMode.DECODE if self.drafter is None else ForwardMode.TARGET_VERIFY,
+            ForwardMode.DECODE,
             **capture_kwargs,
         )
         if self.draft_attn_backend is not None:
@@ -487,7 +482,7 @@ class CudaGraphWrapper:
                 bs * self.max_tokens_per_req,
                 self.input_buffers.req_pool_indices_buf[:bs],
                 self.input_buffers.seq_lens_buf[:bs],
-                ForwardMode.DRAFT_EXTEND,
+                ForwardMode.DECODE,
                 **draft_kwargs,
             )
 
@@ -597,13 +592,12 @@ class CudaGraphWrapper:
             **kwargs,
         )
         if self.draft_attn_backend is not None:
-            # DRAFT_EXTEND covers step 0 + N-1 decode steps (drafter syncs per step).
             self.draft_attn_backend.init_forward_metadata_replay_cuda_graph(
                 padded_bs,
                 req_pool_indices,
                 seq_lens,
                 req_to_page=self.drafter.req_to_page,
-                forward_mode=ForwardMode.DRAFT_EXTEND,
+                forward_mode=ForwardMode.DECODE,
                 **kwargs,
             )
 
@@ -628,14 +622,10 @@ class CudaGraphWrapper:
             **kwargs,
         )
         if self.draft_attn_backend is not None:
-            if forward_mode.is_extend():
-                # Initial prefill: draft step 0 uses EXTEND (regular prefill)
-                # kernel with the caller's prefix kwargs. Step 0 and the
-                # subsequent decode steps have structurally different
-                # metadata, so populate each slot with its own init call.
-                #
-                # Note: drops the pre-refactor subtraction of
-                # `extend_prefix_lens` from `seq_lens` for the draft init.
+            if forward_mode.is_extend_or_mixed():
+                # Step 0 uses the caller's prefix kwargs; subsequent decode
+                # steps use one-token-per-request metadata. Populate each
+                # slot with its own init call.
                 self.draft_attn_backend.init_forward_metadata(
                     padded_bs,
                     padded_bs * self.max_tokens_per_req,
@@ -654,18 +644,13 @@ class CudaGraphWrapper:
                     forward_mode=ForwardMode.DECODE,
                 )
             else:
-                # TARGET_VERIFY / DECODE caller: DRAFT_EXTEND is the "prepare
-                # full drafter pass" signal. The backend populates whichever
-                # slots it needs for step 0 + N-1 decode steps — a single
-                # slot (trtllm_mla) or both prefill and decode slots
-                # (trtllm_mha compound init).
                 self.draft_attn_backend.init_forward_metadata(
                     padded_bs,
                     padded_bs * self.max_tokens_per_req,
                     req_pool_indices,
                     seq_lens,
                     req_to_page=self.drafter.req_to_page,
-                    forward_mode=ForwardMode.DRAFT_EXTEND,
+                    forward_mode=ForwardMode.DECODE,
                 )
 
     def _global_graph_bs(self, ctx: ForwardContext) -> int | None:
@@ -677,7 +662,7 @@ class CudaGraphWrapper:
     def _can_use_graph(self, bs: int, ctx: ForwardContext) -> bool:
         if self.disable:
             return False
-        if not (ctx.forward_mode.is_decode() or ctx.forward_mode.is_target_verify()):
+        if not ctx.forward_mode.is_decode():
             return False
         if self.dp_size > 1:
             if not ctx.all_decode_or_idle:
@@ -861,7 +846,7 @@ class CudaGraphWrapper:
         # Update mamba/GDN state after speculative verify
         if (
             self.drafter is not None
-            and ctx.forward_mode.is_target_verify()
+            and ctx.forward_mode.is_decode()
             and hasattr(self.attn_backend, "update_mamba_state_after_mtp_verify")
         ):
             accept_lengths = result[1]

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -585,6 +585,7 @@ class CudaGraphWrapper:
             kwargs["actual_bs"] = actual_bs
         self.attn_backend.init_forward_metadata_replay_cuda_graph(
             padded_bs,
+            padded_bs * self.max_tokens_per_req,
             req_pool_indices,
             seq_lens,
             req_to_page=req_to_page,
@@ -594,6 +595,7 @@ class CudaGraphWrapper:
         if self.draft_attn_backend is not None:
             self.draft_attn_backend.init_forward_metadata_replay_cuda_graph(
                 padded_bs,
+                padded_bs * self.max_tokens_per_req,
                 req_pool_indices,
                 seq_lens,
                 req_to_page=self.drafter.req_to_page,

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -622,6 +622,29 @@ class CudaGraphWrapper:
             **kwargs,
         )
         if self.draft_attn_backend is not None:
+            # The drafter's decode kernel reads ``seq_lens`` from the metadata
+            # via aliasing:
+            #   - Writer: ``Eagle._run_multi_step_decode`` mutates
+            #     ``draft_seq_lens_buf`` in place between draft steps
+            #     (eagle.py: ``torch.add(cache_start, 1, out=draft_seq_lens)``
+            #     and ``draft_seq_lens.add_(1)`` inside the per-step loop).
+            #   - Reader: each backend's ``forward_decode`` passes
+            #     ``metadata.<seq_lens field>`` to its decode kernel; that
+            #     field is a slice view of ``draft_seq_lens_buf`` written
+            #     here (``cache_seqlens_int32=seq_lens[:bs]`` /
+            #     ``seq_lens_k=seq_lens[:bs]``).
+            # So the kernel sees the value the drafter just wrote, without
+            # rebuilding metadata per step.
+            # The EXTEND-mode prefill init still uses the controller's
+            # ``seq_lens`` because that path computes ``cu_seqlens_k`` from it
+            # eagerly (cumsum at init time), not via aliasing.
+            #
+            # TODO: relying on aliasing for correctness is fragile — a stray
+            # copy or a misrouted buffer silently produces wrong outputs.
+            # Move to an explicit per-call ``seq_lens`` contract
+            # so each kernel invocation carries its own value rather than
+            # reading through a tensor registered at init.
+            draft_seq_lens = self.drafter.draft_seq_lens_buf[:padded_bs]
             if forward_mode.is_extend_or_mixed():
                 # Step 0 uses the caller's prefix kwargs; subsequent decode
                 # steps use one-token-per-request metadata. Populate each
@@ -639,7 +662,7 @@ class CudaGraphWrapper:
                     padded_bs,
                     padded_bs,
                     req_pool_indices,
-                    seq_lens,
+                    draft_seq_lens,
                     req_to_page=self.drafter.req_to_page,
                     forward_mode=ForwardMode.DECODE,
                 )
@@ -648,7 +671,7 @@ class CudaGraphWrapper:
                     padded_bs,
                     padded_bs * self.max_tokens_per_req,
                     req_pool_indices,
-                    seq_lens,
+                    draft_seq_lens,
                     req_to_page=self.drafter.req_to_page,
                     forward_mode=ForwardMode.DECODE,
                 )

--- a/python/tokenspeed/runtime/execution/drafter/eagle.py
+++ b/python/tokenspeed/runtime/execution/drafter/eagle.py
@@ -150,10 +150,7 @@ class Eagle(BaseDrafter):
         input_num_tokens: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Returns (input_ids, unpadded_input_lengths) for the first draft step."""
-        # Only pure EXTEND (prefill) uses shifted_prefill_ids. TARGET_VERIFY
-        # and DRAFT_EXTEND use base_model_output + accept_lengths.
-        if forward_mode == ForwardMode.EXTEND:
-
+        if forward_mode.is_extend():
             input_ids = self.input_buffers.shifted_prefill_ids_buf[
                 :input_num_tokens
             ].clone()
@@ -165,8 +162,8 @@ class Eagle(BaseDrafter):
             input_ids[req_boundaries] = torch.where(
                 needs_fill, draft_input.base_model_output[:bs], boundary_ids
             )
-        else:
 
+        else:
             input_ids = draft_input.base_model_output
             unpadded_input_lengths = draft_input.accept_lengths
 
@@ -185,15 +182,10 @@ class Eagle(BaseDrafter):
         input_ids, unpadded_input_lengths = self._get_first_step_input(
             forward_mode, draft_input, bs, draft_input.input_num_tokens
         )
-
-        # The drafter's first step uses DRAFT_EXTEND when base model did
-        # TARGET_VERIFY, or EXTEND when base model did EXTEND (prefill).
-        if forward_mode.is_target_verify():
-            draft_first_mode = ForwardMode.DRAFT_EXTEND
-        else:
-            draft_first_mode = forward_mode
-
-        is_decode_like = draft_first_mode.is_draft_extend()
+        padded_static_len, last_index_offsets = -1, None
+        if forward_mode.is_decode():
+            padded_static_len = self.spec_num_tokens
+            last_index_offsets = self.last_index_offsets_buf[:bs]
 
         # make a ctx every time model runner forward
         first_step_ctx = ForwardContext(
@@ -203,12 +195,10 @@ class Eagle(BaseDrafter):
             bs=bs,
             num_extends=0,
             input_num_tokens=draft_input.input_num_tokens,
-            forward_mode=draft_first_mode,
+            forward_mode=forward_mode,
             capture_hidden_mode=CaptureHiddenMode.LAST,
-            padded_static_len=self.spec_num_tokens if is_decode_like else -1,
-            last_index_offsets=(
-                self.last_index_offsets_buf[:bs] if is_decode_like else None
-            ),
+            padded_static_len=padded_static_len,
+            last_index_offsets=last_index_offsets,
             keep_full_logits=False,
             global_num_tokens=draft_input.global_num_tokens,
             global_bs=draft_input.global_bs,
@@ -235,10 +225,9 @@ class Eagle(BaseDrafter):
     ) -> None:
 
         req_pool_indices = self.input_buffers.req_pool_indices_buf[:bs]
-        # Step 1's new write position. TARGET_VERIFY uses vc+accept_length
-        # (vc+N would shift rotary past the rejected tail); EXTEND uses
-        # vc+input_lengths (= seq_lens_buf).
-        if draft_input.forward_mode.is_target_verify():
+        # Step 1's write position uses vc+accept_length under DECODE so the
+        # rotary advance doesn't shift past the rejected tail.
+        if draft_input.forward_mode.is_decode():
             cache_start = (
                 self.runtime_states.valid_cache_lengths.index_select(
                     0, req_pool_indices
@@ -324,10 +313,7 @@ class Eagle(BaseDrafter):
         base_ctx: ForwardContext,
     ) -> torch.Tensor | None:
 
-        if not (
-            base_ctx.forward_mode.is_decode()
-            or base_ctx.forward_mode.is_target_verify()
-        ):
+        if not base_ctx.forward_mode.is_decode():
             return None
 
         return self.input_buffers.input_ids_buf[: base_ctx.input_num_tokens].reshape(
@@ -351,7 +337,7 @@ class Eagle(BaseDrafter):
         )
 
         # Last verified id per request → next_tokens[:, 0].
-        if draft_input.forward_mode == ForwardMode.EXTEND:
+        if draft_input.forward_mode.is_extend():
             next_tokens[:, 0] = draft_input.base_model_output[:bs]
         else:
             indices = self.last_index_offsets_buf[:bs] + draft_input.accept_lengths

--- a/python/tokenspeed/runtime/execution/forward_batch_info.py
+++ b/python/tokenspeed/runtime/execution/forward_batch_info.py
@@ -30,27 +30,18 @@ import triton.language as tl
 
 
 class ForwardMode(IntEnum):
-    # Extend a sequence. The KV cache of the beginning part of the sequence is already computed (e.g., system prompt).
+    # Extend a sequence. The KV cache of the beginning part of the sequence
+    # is already computed (e.g., system prompt).
     EXTEND = auto()
-    # Decode one token.
+    # Decode one or more tokens per request.
     DECODE = auto()
-    # Contains both EXTEND and DECODE when doing chunked prefill.
+    # Contains both EXTEND and DECODE tokens in one batch.
     MIXED = auto()
-    # No sequence to forward. For data parallel attention, some workers will be IDLE if no sequence are allocated.
+    # No sequence to forward; used for data parallel attention idle ranks.
     IDLE = auto()
 
-    # Used in speculative decoding: verify a batch in the target model.
-    TARGET_VERIFY = auto()
-    # Used in speculative decoding: extend a batch in the draft model.
-    DRAFT_EXTEND = auto()
-
     def is_extend(self):
-        return (
-            self == ForwardMode.EXTEND
-            or self == ForwardMode.MIXED
-            or self == ForwardMode.DRAFT_EXTEND
-            or self == self.TARGET_VERIFY
-        )
+        return self == ForwardMode.EXTEND
 
     def is_decode(self):
         return self == ForwardMode.DECODE
@@ -61,27 +52,20 @@ class ForwardMode(IntEnum):
     def is_idle(self):
         return self == ForwardMode.IDLE
 
-    def is_target_verify(self):
-        return self == ForwardMode.TARGET_VERIFY
-
-    def is_draft_extend(self):
-        return self == ForwardMode.DRAFT_EXTEND
+    def is_extend_or_mixed(self):
+        return self == ForwardMode.EXTEND or self == ForwardMode.MIXED
 
     def is_decode_or_idle(self):
         return self == ForwardMode.DECODE or self == ForwardMode.IDLE
 
     @staticmethod
-    def from_num_extends(
-        num_extends: int,
-        batch_size: int,
-        *,
-        has_drafter: bool = False,
-    ) -> "ForwardMode":
+    def from_num_extends(num_extends: int, batch_size: int) -> "ForwardMode":
         if batch_size <= 0:
             return ForwardMode.IDLE
-        if num_extends > 0:
+        elif num_extends > 0:
             return ForwardMode.MIXED if num_extends < batch_size else ForwardMode.EXTEND
-        return ForwardMode.TARGET_VERIFY if has_drafter else ForwardMode.DECODE
+        else:
+            return ForwardMode.DECODE
 
 
 class CaptureHiddenMode(IntEnum):

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -354,10 +354,7 @@ class ModelExecutor:
         ctx: ForwardContext,
         candidates,
     ):
-        if self.drafter is not None and (
-            ctx.forward_mode == ForwardMode.DECODE
-            or ctx.forward_mode == ForwardMode.TARGET_VERIFY
-        ):
+        if self.drafter is not None and ctx.forward_mode.is_decode():
             return self.sampling_backend.verify(
                 logits_output, sampling_info, candidates
             )
@@ -376,9 +373,7 @@ class ModelExecutor:
         # attention/MoE. Rejoined at wait_bitmask() before apply_mask.
         if self.capturable_grammar is not None:
             n = self.capturable_grammar.max_tokens_per_req
-            is_spec_verify = n > 1 and (
-                ctx.forward_mode.is_target_verify() or ctx.forward_mode.is_decode()
-            )
+            is_spec_verify = n > 1 and ctx.forward_mode.is_decode()
             slice_ = (
                 self.input_buffers.input_ids_buf[: bs * n] if is_spec_verify else None
             )
@@ -634,11 +629,6 @@ class ModelExecutor:
         ranks do. The MoE all-to-all is a collective that requires ALL
         ranks to participate.
         """
-        graph_forward_mode = (
-            ForwardMode.TARGET_VERIFY
-            if self.drafter is not None
-            else ForwardMode.DECODE
-        )
         ctx = ForwardContext(
             attn_backend=self.attn_backend,
             token_to_kv_pool=self.token_to_kv_pool,
@@ -646,7 +636,7 @@ class ModelExecutor:
             bs=0,
             num_extends=0,
             input_num_tokens=0,
-            forward_mode=graph_forward_mode,
+            forward_mode=ForwardMode.DECODE,
             global_num_tokens=global_num_tokens,
             global_bs=global_bs,
             all_decode_or_idle=all_decode_or_idle,
@@ -830,11 +820,7 @@ class ModelExecutor:
             )
 
             bs = len(forward_op.request_ids)
-            forward_mode = ForwardMode.from_num_extends(
-                num_extends,
-                bs,
-                has_drafter=self.drafter is not None,
-            )
+            forward_mode = ForwardMode.from_num_extends(num_extends, bs)
 
             if self.runtime_states.mamba_pool is not None and (
                 num_extends > 0 or has_retract
@@ -874,8 +860,7 @@ class ModelExecutor:
                         else CaptureHiddenMode.NULL
                     ),
                     padded_static_len=-1,
-                    keep_full_logits=forward_mode.is_decode_or_idle()
-                    or forward_mode.is_target_verify(),
+                    keep_full_logits=forward_mode.is_decode_or_idle(),
                 )
                 if self.config.data_parallel_size > 1:
                     if dp_global_num_tokens is None:

--- a/python/tokenspeed/runtime/layers/attention/backends/base.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/base.py
@@ -81,6 +81,7 @@ class AttentionBackend(ABC):
     def init_forward_metadata_replay_cuda_graph(
         self,
         bs: int,
+        num_tokens: int,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode = None,

--- a/python/tokenspeed/runtime/layers/attention/backends/base.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/base.py
@@ -42,6 +42,7 @@ class AttentionBackend(ABC):
         self.num_kv_heads = max(config.num_kv_heads // config.attn_tp_size, 1)
         self.dtype = config.dtype
         self.head_dim = config.head_dim
+        self.is_draft = config.is_draft
 
     @property
     def support_kv_cache_prewrite(self) -> bool:

--- a/python/tokenspeed/runtime/layers/attention/backends/base.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/base.py
@@ -120,6 +120,7 @@ class AttentionBackend(ABC):
         out_cache_loc: torch.Tensor,
         token_to_kv_pool: BaseTokenToKVPool,
         forward_mode: ForwardMode,
+        bs: int,
         save_kv_cache: bool = True,
         **kwargs,
     ):
@@ -132,6 +133,7 @@ class AttentionBackend(ABC):
                 layer,
                 out_cache_loc,
                 token_to_kv_pool,
+                bs,
                 save_kv_cache=save_kv_cache,
                 **kwargs,
             )
@@ -150,6 +152,7 @@ class AttentionBackend(ABC):
                 layer,
                 out_cache_loc,
                 token_to_kv_pool,
+                bs,
                 save_kv_cache=save_kv_cache,
                 forward_mode=forward_mode,
                 **kwargs,
@@ -171,6 +174,7 @@ class AttentionBackend(ABC):
         layer: PagedAttention,
         out_cache_loc: torch.Tensor,
         token_to_kv_pool: BaseTokenToKVPool,
+        bs: int,
         save_kv_cache: bool = True,
         **kwargs,
     ):
@@ -185,6 +189,7 @@ class AttentionBackend(ABC):
         layer: PagedAttention,
         out_cache_loc: torch.Tensor,
         token_to_kv_pool: BaseTokenToKVPool,
+        bs: int,
         save_kv_cache: bool = True,
         **kwargs,
     ):

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -1519,6 +1519,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
     def init_forward_metadata_replay_cuda_graph(
         self,
         bs: int,
+        num_tokens: int,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode = None,

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -389,7 +389,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         )
         if forward_mode is not None and forward_mode.is_mixed():
             num_prefill_reqs = max(0, min(num_extends, bs))
-        elif forward_mode is not None and forward_mode.is_extend():
+        elif forward_mode is not None and forward_mode.is_extend_or_mixed():
             num_prefill_reqs = bs
         else:
             num_prefill_reqs = 0
@@ -1093,8 +1093,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         }
         req_count = max(0, req_end - req_start)
         token_count = max(0, token_end - token_start)
-        num_prefill_reqs = req_count if forward_mode.is_extend() else 0
-        num_prefill_tokens = token_count if forward_mode.is_extend() else 0
+        num_prefill_reqs = req_count if forward_mode.is_extend_or_mixed() else 0
+        num_prefill_tokens = token_count if forward_mode.is_extend_or_mixed() else 0
         return DeepseekV4ForwardMetadata(
             page_size=metadata.page_size,
             req_pool_indices=metadata.req_pool_indices[req_start:req_end],
@@ -1167,7 +1167,10 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         metadata = self.forward_metadata
         if metadata is None:
             raise RuntimeError("DeepSeek V4 prefill requires forward metadata")
-        if metadata.forward_mode is None or not metadata.forward_mode.is_extend():
+        if (
+            metadata.forward_mode is None
+            or not metadata.forward_mode.is_extend_or_mixed()
+        ):
             raise RuntimeError(
                 "forward_deepseek_v4_prefill only supports extend/prefill modes"
             )
@@ -1232,7 +1235,10 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         metadata = self.forward_metadata
         if metadata is None:
             raise RuntimeError("DeepSeek V4 prefill requires forward metadata")
-        if metadata.forward_mode is None or not metadata.forward_mode.is_extend():
+        if (
+            metadata.forward_mode is None
+            or not metadata.forward_mode.is_extend_or_mixed()
+        ):
             raise RuntimeError(
                 "forward_deepseek_v4_prefill only supports extend/prefill modes"
             )

--- a/python/tokenspeed/runtime/layers/attention/backends/flash_attention.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/flash_attention.py
@@ -211,8 +211,8 @@ class FlashAttentionBackend(AttentionBackend):
             - It will spawn num_steps FlashAttentionBackend for the draft worker
 
     Note about CUDA Graph:
-    - We only support CUDA Graph for Decode (Normal Decode and Draft Decode) and Target Verify.
-    - We don't support CUDA Graph for Extend and Draft Extend.
+    - We only support CUDA Graph for decode (any q_len; q_len > 1 uses the prefill slot).
+    - We don't support CUDA Graph for extend.
     - When server init, init_cuda_graph_state will be called first and then init_cuda_graph_capture will be called.
     - For each forward batch, init_replay_cuda_graph will be called first and then replay the graph.
     """
@@ -220,10 +220,9 @@ class FlashAttentionBackend(AttentionBackend):
     def __init__(self, config: MHAConfig):
         super().__init__(config)
 
-        # Pattern A: separate prefill/decode metadata slots so a compound
-        # DRAFT_EXTEND capture can populate both once (step 0 = prefill,
-        # steps 1..N-1 = decode) and the captured graph reads from fixed
-        # addresses.
+        # Separate prefill/decode metadata slots so the drafter can use
+        # the prefill slot for its first multi-token step after verify
+        # and the decode slot for the single-token follow-up steps.
         self.forward_prefill_metadata: FlashAttentionMetadata = None
         self.forward_decode_metadata: FlashAttentionMetadata = None
         # extra metadata for handling speculative decoding topk > 1, extended draft decode and verify
@@ -404,13 +403,23 @@ class FlashAttentionBackend(AttentionBackend):
 
         assert req_to_page is not None, "req_to_page must be provided"
 
+        spec_num_tokens = num_tokens // bs if bs > 0 else 1
+        is_target_verify = (
+            forward_mode.is_decode_or_idle()
+            and not self.is_draft
+            and spec_num_tokens > 1
+        )
+        is_draft_extend = (
+            forward_mode.is_decode_or_idle() and self.is_draft and spec_num_tokens > 1
+        )
+
         # Use max_context_len as worst-case max_seq_len_k — avoids GPU sync (.item()).
         # The actual per-request lengths are in cache_seqlens_int32.
         page_table = build_page_table(
             req_pool_indices, req_to_page, self.page_size, max_context_len
         )
 
-        if forward_mode.is_decode_or_idle():
+        if forward_mode.is_decode_or_idle() and spec_num_tokens == 1:
             # Draft Decode
             if spec_info is not None:
                 if self.topk <= 1:
@@ -472,7 +481,7 @@ class FlashAttentionBackend(AttentionBackend):
                 cache_seqlens_int32=metadata.cache_seqlens_int32,
                 page_table=page_table,
             )
-        elif forward_mode.is_target_verify():
+        elif is_target_verify:
             if self.topk <= 1:
                 # seq_lens = valid_cache_lengths + speculative_num_draft_tokens
                 # (the controller writes the post-write cache length); the
@@ -563,7 +572,7 @@ class FlashAttentionBackend(AttentionBackend):
                         metadata, metadata_expand
                     )
 
-        elif forward_mode.is_extend():
+        elif forward_mode.is_extend_or_mixed() or is_draft_extend:
             metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
             metadata.max_seq_len_k = max_context_len
             metadata.page_table = page_table
@@ -583,10 +592,7 @@ class FlashAttentionBackend(AttentionBackend):
                 metadata.cu_seqlens_q = torch.nn.functional.pad(
                     torch.cumsum(extend_seq_lens, dim=0, dtype=torch.int32), (1, 0)
                 )
-            elif (
-                forward_mode == ForwardMode.DRAFT_EXTEND
-                and kwargs.get("extend_seq_lens") is not None
-            ):
+            elif is_draft_extend and kwargs.get("extend_seq_lens") is not None:
                 metadata.max_seq_len_q = num_tokens
                 metadata.cu_seqlens_q = torch.nn.functional.pad(
                     torch.cumsum(kwargs["extend_seq_lens"], dim=0, dtype=torch.int32),
@@ -602,7 +608,7 @@ class FlashAttentionBackend(AttentionBackend):
                 )
 
             # Setup local attention if enabled
-            if forward_mode == ForwardMode.EXTEND:
+            if forward_mode.is_extend():
                 self._init_local_attn_metadata(
                     metadata,
                     device,
@@ -611,12 +617,11 @@ class FlashAttentionBackend(AttentionBackend):
                     page_table=page_table,
                 )
 
-        # Route to prefill/decode slot. DRAFT_EXTEND is compound: step 0
-        # uses the prefill slot (multi-token query), steps 1..N-1 use the
-        # decode slot (single-token query, advanced per step).
-        if forward_mode.is_decode_or_idle():
+        # Route to prefill/decode slot. Drafter's first multi-token step uses
+        # the prefill slot; follow-up single-token steps use the decode slot.
+        if forward_mode.is_decode_or_idle() and spec_num_tokens == 1:
             self.forward_decode_metadata = metadata
-        elif forward_mode == ForwardMode.DRAFT_EXTEND:
+        elif is_draft_extend:
             self.forward_prefill_metadata = metadata
             decode_metadata = FlashAttentionMetadata()
             decode_metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
@@ -641,6 +646,7 @@ class FlashAttentionBackend(AttentionBackend):
         layer: PagedAttention,
         out_cache_loc: torch.Tensor,
         token_to_kv_pool,
+        bs: int,
         save_kv_cache: bool = True,
         # For multi-head latent attention
         q_rope: torch.Tensor | None = None,
@@ -648,7 +654,6 @@ class FlashAttentionBackend(AttentionBackend):
         sinks: torch.Tensor | None = None,
         forward_mode: ForwardMode = None,
         spec_info=None,
-        batch_size: int = None,
         **kwargs,
     ):
         if k is not None:
@@ -671,6 +676,20 @@ class FlashAttentionBackend(AttentionBackend):
         # Use precomputed metadata across all layers
         metadata = self.forward_prefill_metadata
 
+        spec_num_tokens = q.shape[0] // bs if bs > 0 else 1
+        is_target_verify = (
+            forward_mode is not None
+            and forward_mode.is_decode_or_idle()
+            and not self.is_draft
+            and spec_num_tokens > 1
+        )
+        is_draft_extend = (
+            forward_mode is not None
+            and forward_mode.is_decode_or_idle()
+            and self.is_draft
+            and spec_num_tokens > 1
+        )
+
         # Calculate window size
         is_swa = (
             layer.sliding_window_size is not None and layer.sliding_window_size > -1
@@ -683,8 +702,7 @@ class FlashAttentionBackend(AttentionBackend):
             and self.fa_impl_ver != 4
         ):
             if layer.k_scale is not None:
-                bs_for_descale = batch_size if batch_size is not None else q.shape[0]
-                descale_shape = (bs_for_descale, layer.tp_k_head_num)
+                descale_shape = (q.shape[0], layer.tp_k_head_num)
                 k_descale = layer.k_scale.expand(descale_shape)
                 v_descale = layer.v_scale.expand(descale_shape)
             q = q.to(self.kv_cache_dtype)
@@ -698,12 +716,7 @@ class FlashAttentionBackend(AttentionBackend):
             and (hasattr(layer, "use_irope") and layer.use_irope)
         )
 
-        use_cascade_attn = (
-            forward_mode is not None
-            and forward_mode.is_target_verify()
-            and self.topk > 1
-            and not is_swa
-        )
+        use_cascade_attn = is_target_verify and self.topk > 1 and not is_swa
 
         # Only pass ``ver`` when talking to a non-default FlashAttention
         # interface version.
@@ -807,9 +820,8 @@ class FlashAttentionBackend(AttentionBackend):
 
             if (
                 attn_attend_prefix_cache is not None
-                and forward_mode is not None
-                and not forward_mode.is_target_verify()
-                and not forward_mode.is_draft_extend()
+                and not is_target_verify
+                and not is_draft_extend
             ):
                 # Do multi-head attention with chunked prefix cache
                 if attn_attend_prefix_cache:
@@ -943,16 +955,36 @@ class FlashAttentionBackend(AttentionBackend):
         layer: PagedAttention,
         out_cache_loc: torch.Tensor,
         token_to_kv_pool,
+        bs: int,
         save_kv_cache: bool = True,
         # For multi-head latent attention
         q_rope: torch.Tensor | None = None,
         k_rope: torch.Tensor | None = None,
         sinks: torch.Tensor | None = None,
-        forward_mode: ForwardMode = None,
         spec_info=None,
-        batch_size: int = None,
         **kwargs,
     ) -> torch.Tensor:
+        # Multi-token decode (target verify or drafter's first post-verify
+        # step) reuses the multi-token prefill path.
+        spec_num_tokens = q.shape[0] // bs if bs > 0 else 1
+        if spec_num_tokens > 1:
+            return self.forward_extend(
+                q,
+                k,
+                v,
+                layer,
+                out_cache_loc,
+                token_to_kv_pool,
+                bs,
+                save_kv_cache=save_kv_cache,
+                q_rope=q_rope,
+                k_rope=k_rope,
+                sinks=sinks,
+                forward_mode=ForwardMode.DECODE,
+                spec_info=spec_info,
+                **kwargs,
+            )
+
         assert self.fa_impl_ver in [3], "Only FA3 support decoding"
         if k is not None:
             assert v is not None
@@ -1002,8 +1034,7 @@ class FlashAttentionBackend(AttentionBackend):
         k_descale, v_descale = None, None
         if self.kv_cache_dtype_str != "auto" and layer.head_dim <= 256:
             if layer.k_scale is not None:
-                bs_for_descale = batch_size if batch_size is not None else q.shape[0]
-                descale_shape = (bs_for_descale, layer.tp_k_head_num)
+                descale_shape = (q.shape[0], layer.tp_k_head_num)
                 k_descale = layer.k_scale.expand(descale_shape)
                 v_descale = layer.v_scale.expand(descale_shape)
             q = q.to(self.kv_cache_dtype)
@@ -1416,7 +1447,17 @@ class FlashAttentionBackend(AttentionBackend):
         metadata_expand = FlashAttentionMetadata()
 
         device = seq_lens.device
-        if forward_mode.is_decode_or_idle():
+        spec_num_tokens = num_tokens // bs if bs > 0 else 1
+        is_target_verify = (
+            forward_mode.is_decode_or_idle()
+            and not self.is_draft
+            and spec_num_tokens > 1
+        )
+        is_draft_extend = (
+            forward_mode.is_decode_or_idle() and self.is_draft and spec_num_tokens > 1
+        )
+
+        if forward_mode.is_decode_or_idle() and spec_num_tokens == 1:
             if spec_info is not None:
                 # Draft Decode
                 if self.topk <= 1:
@@ -1481,10 +1522,10 @@ class FlashAttentionBackend(AttentionBackend):
                 if self.attention_chunk_size is not None:
                     self._update_local_attn_metadata_for_capture(metadata, batch_size)
 
-        elif forward_mode.is_target_verify():
+        elif is_target_verify:
             if self.topk <= 1:
                 # cache_seqlens aliases seq_lens_buf (= valid_cache_lengths
-                # + speculative_num_draft_tokens for TARGET_VERIFY); the
+                # + speculative_num_draft_tokens for the verify call); the
                 # controller has already written the right values.
                 metadata.cache_seqlens_int32 = self.target_verify_metadata[
                     "cache_seqlens"
@@ -1551,11 +1592,10 @@ class FlashAttentionBackend(AttentionBackend):
                     self.target_verify_metadata_topk_swa[bs] = metadata_swa
                     metadata.swa_spec_metadata = metadata_swa
 
-        elif forward_mode.is_draft_extend():
-            # Compound DRAFT_EXTEND: step 0 uses prefill slot (multi-token
-            # query over spec_num_tokens), steps 1..N-1 use decode slot
-            # (single-token query). Both slots' cache_seqlens alias
-            # seq_lens_buf — controller-written, no copy.
+        elif is_draft_extend:
+            # Drafter's first multi-token step uses the prefill slot;
+            # follow-up single-token steps use the decode slot. Both slots'
+            # cache_seqlens alias seq_lens_buf — controller-written, no copy.
             metadata.cache_seqlens_int32 = self.draft_extend_metadata["cache_seqlens"][
                 :bs
             ]
@@ -1590,12 +1630,12 @@ class FlashAttentionBackend(AttentionBackend):
             ][:bs, :]
             self.decode_cuda_graph_metadata[bs] = decode_metadata
 
-        # Route to prefill/decode slots. DRAFT_EXTEND populates both.
-        if forward_mode.is_decode_or_idle():
+        # Route to prefill/decode slots. Drafter's compound case populates both.
+        if forward_mode.is_decode_or_idle() and spec_num_tokens == 1:
             self.forward_decode_metadata = metadata
-        elif forward_mode.is_target_verify():
+        elif is_target_verify:
             self.forward_prefill_metadata = metadata
-        elif forward_mode.is_draft_extend():
+        elif is_draft_extend:
             self.forward_prefill_metadata = metadata
             self.forward_decode_metadata = decode_metadata
         self.forward_metadata_spec_decode_expand = metadata_expand
@@ -1609,6 +1649,7 @@ class FlashAttentionBackend(AttentionBackend):
         req_to_page: torch.Tensor = None,
         spec_info: EagleDraftInput | None = None,
         out_cache_loc: torch.Tensor | None = None,
+        **kwargs,
     ):
         """Initialize forward metadata for replaying CUDA graph."""
         seq_lens = seq_lens[:bs]
@@ -1620,40 +1661,42 @@ class FlashAttentionBackend(AttentionBackend):
         assert req_to_page is not None, "req_to_page must be provided"
         max_context_len = self.max_context_len
 
-        if forward_mode.is_decode_or_idle():
+        # The wrapper always passes forward_mode=DECODE at replay (cuda
+        # graph only runs in decode), so dispatch by (self.is_draft, dict
+        # membership) instead. Captures populate disjoint dicts per phase.
+        is_target_verify = not self.is_draft and (
+            bs in self.target_verify_metadata
+            or bs in self.target_verify_metadata_topk_normal
+        )
+        is_draft_extend = self.is_draft and bs in self.draft_extend_metadata
 
-            if spec_info is not None:
-                # Draft Decode — cache_seqlens aliases seq_lens_buf.
-                if self.topk <= 1:
-                    metadata = self.decode_cuda_graph_metadata[bs]
-                    metadata.max_seq_len_k = max_context_len
-                    update_page_table_inplace(
-                        metadata.page_table,
-                        req_pool_indices,
-                        req_to_page,
-                        self.page_size,
-                        max_context_len,
-                    )
+        if (
+            forward_mode.is_decode_or_idle()
+            and not is_target_verify
+            and not is_draft_extend
+        ):
 
-                else:
-                    metadata = self.draft_decode_metadata_topk_normal[bs]
-                    metadata.max_seq_len_k = max_context_len
-                    update_page_table_inplace(
-                        metadata.page_table,
-                        req_pool_indices,
-                        req_to_page,
-                        self.page_size,
-                        max_context_len,
-                    )
+            if spec_info is not None and self.topk > 1:
+                # Draft Decode topk > 1 — cache_seqlens aliases seq_lens_buf.
+                metadata = self.draft_decode_metadata_topk_normal[bs]
+                metadata.max_seq_len_k = max_context_len
+                update_page_table_inplace(
+                    metadata.page_table,
+                    req_pool_indices,
+                    req_to_page,
+                    self.page_size,
+                    max_context_len,
+                )
 
-                    metadata_expand = self.draft_decode_metadata_topk_expand[bs]
-                    decode_length = self.speculative_step_id + 1
-                    cache_loc = out_cache_loc.view(-1, self.speculative_num_steps)
-                    metadata_expand.page_table[: cache_loc.shape[0]].copy_(
-                        cache_loc[:, :decode_length]
-                    )
+                metadata_expand = self.draft_decode_metadata_topk_expand[bs]
+                decode_length = self.speculative_step_id + 1
+                cache_loc = out_cache_loc.view(-1, self.speculative_num_steps)
+                metadata_expand.page_table[: cache_loc.shape[0]].copy_(
+                    cache_loc[:, :decode_length]
+                )
             else:
-                # Normal Decode — cache_seqlens aliases seq_lens_buf.
+                # Normal Decode (or drafter follow-up single-token decode,
+                # topk <= 1) — cache_seqlens aliases seq_lens_buf.
                 metadata = self.decode_cuda_graph_metadata[bs]
                 metadata.max_seq_len_k = max_context_len
                 update_page_table_inplace(
@@ -1669,7 +1712,7 @@ class FlashAttentionBackend(AttentionBackend):
                     metadata,
                     bs,
                 )
-        elif forward_mode.is_target_verify():
+        elif is_target_verify:
             if self.topk <= 1:
                 # cache_seqlens aliases seq_lens_buf; the controller already
                 # wrote vc + speculative_num_draft_tokens via fill_input_buffers.
@@ -1747,8 +1790,8 @@ class FlashAttentionBackend(AttentionBackend):
                         metadata, metadata_expand, metadata_swa
                     )
 
-        elif forward_mode.is_draft_extend():
-            # Compound DRAFT_EXTEND: refresh both prefill slot (step 0,
+        elif is_draft_extend:
+            # Drafter's compound case: refresh both prefill slot (step 0,
             # multi-token query) and decode slot (steps 1..N-1, single
             # token query). cache_seqlens aliases seq_lens_buf.
             metadata = self.draft_extend_metadata[bs]
@@ -1771,12 +1814,16 @@ class FlashAttentionBackend(AttentionBackend):
                 max_context_len,
             )
 
-        # Route to prefill/decode slots. DRAFT_EXTEND populates both.
-        if forward_mode.is_decode_or_idle():
+        # Route to prefill/decode slots. Drafter's compound case populates both.
+        if (
+            forward_mode.is_decode_or_idle()
+            and not is_target_verify
+            and not is_draft_extend
+        ):
             self.forward_decode_metadata = metadata
-        elif forward_mode.is_target_verify():
+        elif is_target_verify:
             self.forward_prefill_metadata = metadata
-        elif forward_mode.is_draft_extend():
+        elif is_draft_extend:
             self.forward_prefill_metadata = metadata
             self.forward_decode_metadata = decode_metadata
         self.forward_metadata_spec_decode_expand = metadata_expand

--- a/python/tokenspeed/runtime/layers/attention/backends/flash_attention.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/flash_attention.py
@@ -1643,6 +1643,7 @@ class FlashAttentionBackend(AttentionBackend):
     def init_forward_metadata_replay_cuda_graph(
         self,
         bs: int,
+        num_tokens: int,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode = None,
@@ -1661,14 +1662,15 @@ class FlashAttentionBackend(AttentionBackend):
         assert req_to_page is not None, "req_to_page must be provided"
         max_context_len = self.max_context_len
 
-        # The wrapper always passes forward_mode=DECODE at replay (cuda
-        # graph only runs in decode), so dispatch by (self.is_draft, dict
-        # membership) instead. Captures populate disjoint dicts per phase.
-        is_target_verify = not self.is_draft and (
-            bs in self.target_verify_metadata
-            or bs in self.target_verify_metadata_topk_normal
+        spec_num_tokens = num_tokens // bs if bs > 0 else 1
+        is_target_verify = (
+            forward_mode.is_decode_or_idle()
+            and not self.is_draft
+            and spec_num_tokens > 1
         )
-        is_draft_extend = self.is_draft and bs in self.draft_extend_metadata
+        is_draft_extend = (
+            forward_mode.is_decode_or_idle() and self.is_draft and spec_num_tokens > 1
+        )
 
         if (
             forward_mode.is_decode_or_idle()

--- a/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
@@ -104,8 +104,8 @@ _global_workspace_buffer = None
 class FlashMLABackend(AttentionBackend):
     """FlashMLA attention backend for TokenSpeed scheduling.
 
-    Uses the FlashMLA kernel for DECODE, TARGET_VERIFY, and DRAFT_EXTEND;
-    uses FlashInfer's MLA prefill wrappers for the EXTEND path.
+    Uses the FlashMLA kernel for decode (any q_len); uses FlashInfer's MLA
+    prefill wrappers for the EXTEND path.
     """
 
     def __init__(self, config: MLAConfig):
@@ -197,7 +197,17 @@ class FlashMLABackend(AttentionBackend):
         else:
             block_table = None
 
-        if forward_mode.is_decode_or_idle():
+        spec_num_tokens = num_tokens // bs if bs > 0 else 1
+        is_target_verify = (
+            forward_mode.is_decode_or_idle()
+            and not self.is_draft
+            and spec_num_tokens > 1
+        )
+        is_draft_extend = (
+            forward_mode.is_decode_or_idle() and self.is_draft and spec_num_tokens > 1
+        )
+
+        if forward_mode.is_decode_or_idle() and spec_num_tokens == 1:
             mla_metadata, num_splits = get_mla_metadata(
                 seq_lens.to(torch.int32),
                 self.num_q_heads,
@@ -208,7 +218,7 @@ class FlashMLABackend(AttentionBackend):
                 num_splits,
                 block_table,
             )
-        elif forward_mode.is_target_verify() or forward_mode.is_draft_extend():
+        elif is_target_verify or is_draft_extend:
             seq_lens = seq_lens + self.draft_token_num
             mla_metadata, num_splits = get_mla_metadata(
                 seq_lens.to(torch.int32),
@@ -287,7 +297,7 @@ class FlashMLABackend(AttentionBackend):
             )
 
     # ------------------------------------------------------------------
-    # CUDA graph (DECODE / TARGET_VERIFY / DRAFT_EXTEND only)
+    # CUDA graph (decode only, any q_len)
     # ------------------------------------------------------------------
 
     def init_cuda_graph_state(self, max_bs: int, seq_lens_buf: torch.Tensor):
@@ -334,7 +344,17 @@ class FlashMLABackend(AttentionBackend):
         forward_mode: ForwardMode,
     ):
         block_table = self.cuda_graph_kv_indices[:bs]
-        if forward_mode.is_decode_or_idle():
+        spec_num_tokens = num_tokens // bs if bs > 0 else 1
+        is_target_verify = (
+            forward_mode.is_decode_or_idle()
+            and not self.is_draft
+            and spec_num_tokens > 1
+        )
+        is_draft_extend = (
+            forward_mode.is_decode_or_idle() and self.is_draft and spec_num_tokens > 1
+        )
+
+        if forward_mode.is_decode_or_idle() and spec_num_tokens == 1:
             mla_metadata, num_splits = get_mla_metadata(
                 seq_lens.to(torch.int32),
                 self.num_q_heads,
@@ -348,7 +368,7 @@ class FlashMLABackend(AttentionBackend):
                 self.cuda_graph_num_splits[: bs + 1],
                 self.cuda_graph_kv_indices[:bs, :],
             )
-        elif forward_mode.is_target_verify() or forward_mode.is_draft_extend():
+        elif is_target_verify or is_draft_extend:
             seq_lens = seq_lens + self.draft_token_num
             mla_metadata, num_splits = get_mla_metadata(
                 seq_lens.to(torch.int32),
@@ -369,12 +389,16 @@ class FlashMLABackend(AttentionBackend):
     def init_forward_metadata_replay_cuda_graph(
         self,
         bs: int,
+        num_tokens: int,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode = None,
         req_to_page: torch.Tensor = None,
         **kwargs,
     ):
+        if forward_mode is None or not forward_mode.is_decode_or_idle():
+            raise RuntimeError(f"Not supported forward mode: {forward_mode}")
+
         req_pool_indices = req_pool_indices[:bs]
         if req_to_page is not None:
             block_table = req_to_page[req_pool_indices]
@@ -382,35 +406,32 @@ class FlashMLABackend(AttentionBackend):
             block_table = self.cuda_graph_kv_indices[:bs]
         seq_lens = seq_lens[:bs]
 
-        if forward_mode is not None and forward_mode.is_decode_or_idle():
+        spec_num_tokens = num_tokens // bs if bs > 0 else 1
+        is_target_verify = not self.is_draft and spec_num_tokens > 1
+        is_draft_extend = self.is_draft and spec_num_tokens > 1
+
+        if spec_num_tokens == 1:
             mla_metadata, num_splits = get_mla_metadata(
                 seq_lens.to(torch.int32),
                 self.num_q_heads,
                 1,
             )
-            self.cuda_graph_mla_metadata.copy_(mla_metadata)
-            self.cuda_graph_num_splits[: bs + 1].copy_(num_splits)
-            self.cuda_graph_kv_indices[:bs].copy_(block_table)
-            self.forward_metadata.flashmla_metadata = self.cuda_graph_mla_metadata
-            self.forward_metadata.num_splits = self.cuda_graph_num_splits[: bs + 1]
-            self.forward_metadata.block_table = self.cuda_graph_kv_indices[:bs]
-        elif forward_mode is not None and (
-            forward_mode.is_target_verify() or forward_mode.is_draft_extend()
-        ):
+        elif is_target_verify or is_draft_extend:
             seq_lens = seq_lens + self.draft_token_num
             mla_metadata, num_splits = get_mla_metadata(
                 seq_lens.to(torch.int32),
                 self.draft_token_num * self.num_q_heads,
                 1,
             )
-            self.cuda_graph_mla_metadata.copy_(mla_metadata)
-            self.cuda_graph_num_splits[: bs + 1].copy_(num_splits)
-            self.cuda_graph_kv_indices[:bs].copy_(block_table)
-            self.forward_metadata.flashmla_metadata = self.cuda_graph_mla_metadata
-            self.forward_metadata.num_splits = self.cuda_graph_num_splits[: bs + 1]
-            self.forward_metadata.block_table = self.cuda_graph_kv_indices[:bs]
         else:
             raise RuntimeError(f"Not supported forward mode: {forward_mode}")
+
+        self.cuda_graph_mla_metadata.copy_(mla_metadata)
+        self.cuda_graph_num_splits[: bs + 1].copy_(num_splits)
+        self.cuda_graph_kv_indices[:bs].copy_(block_table)
+        self.forward_metadata.flashmla_metadata = self.cuda_graph_mla_metadata
+        self.forward_metadata.num_splits = self.cuda_graph_num_splits[: bs + 1]
+        self.forward_metadata.block_table = self.cuda_graph_kv_indices[:bs]
 
     def get_cuda_graph_seq_len_fill_value(self):
         return 1
@@ -427,12 +448,27 @@ class FlashMLABackend(AttentionBackend):
         layer: PagedAttention,
         out_cache_loc: torch.Tensor,
         token_to_kv_pool,
+        bs: int,
         save_kv_cache: bool = True,
         seq_lens: torch.Tensor | None = None,
         forward_mode: ForwardMode | None = None,
         **kwargs,
     ):
-        if forward_mode is None or forward_mode == ForwardMode.EXTEND:
+        spec_num_tokens = q.shape[0] // bs if bs > 0 else 1
+        is_target_verify = (
+            forward_mode is not None
+            and forward_mode.is_decode_or_idle()
+            and not self.is_draft
+            and spec_num_tokens > 1
+        )
+        is_draft_extend = (
+            forward_mode is not None
+            and forward_mode.is_decode_or_idle()
+            and self.is_draft
+            and spec_num_tokens > 1
+        )
+
+        if forward_mode is None or forward_mode.is_extend():
             # Prefill: dispatch to ragged (MHA-style) or absorbed (MQA) path.
             if self.forward_metadata.use_ragged:
                 return self._forward_normal_extend(q, k, v, layer, save_kv_cache)
@@ -447,7 +483,7 @@ class FlashMLABackend(AttentionBackend):
                     save_kv_cache,
                 )
 
-        assert forward_mode.is_target_verify() or forward_mode.is_draft_extend()
+        assert is_target_verify or is_draft_extend
         if k is not None:
             assert v is not None
             if save_kv_cache:
@@ -455,7 +491,7 @@ class FlashMLABackend(AttentionBackend):
 
         bs = (
             q.shape[0]
-            if forward_mode.is_draft_extend()
+            if is_draft_extend
             else self.forward_metadata.block_table.shape[0]
         )
         k_cache = token_to_kv_pool.get_key_buffer(layer.layer_id)
@@ -522,10 +558,29 @@ class FlashMLABackend(AttentionBackend):
         layer: PagedAttention,
         out_cache_loc: torch.Tensor,
         token_to_kv_pool,
+        bs: int,
         save_kv_cache: bool = True,
         seq_lens: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor:
+        # Multi-token decode (target verify or drafter compound) reuses
+        # the multi-token kernel path in forward_extend.
+        spec_num_tokens = q.shape[0] // bs if bs > 0 else 1
+        if spec_num_tokens > 1:
+            return self.forward_extend(
+                q,
+                k,
+                v,
+                layer,
+                out_cache_loc,
+                token_to_kv_pool,
+                bs,
+                save_kv_cache=save_kv_cache,
+                seq_lens=seq_lens,
+                forward_mode=ForwardMode.DECODE,
+                **kwargs,
+            )
+
         if k is not None:
             assert v is not None
             if save_kv_cache:

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -245,12 +245,22 @@ class MambaAttnBackend(AttentionBackend):
         else:
             mamba_cache_indices = self.pool.get_mamba_indices(req_pool_indices[:bs])
 
-        if forward_mode.is_decode_or_idle():
+        spec_num_tokens = num_tokens // bs if bs > 0 else 1
+        is_target_verify = (
+            forward_mode.is_decode_or_idle()
+            and not self.is_draft
+            and spec_num_tokens > 1
+        )
+        is_draft_extend = (
+            forward_mode.is_decode_or_idle() and self.is_draft and spec_num_tokens > 1
+        )
+
+        if forward_mode.is_decode_or_idle() and spec_num_tokens == 1:
             query_start_loc = torch.arange(
                 0, bs + 1, dtype=torch.int32, device=self.device
             )
-        elif forward_mode.is_extend():
-            if forward_mode.is_target_verify() or forward_mode.is_draft_extend():
+        elif forward_mode.is_extend_or_mixed() or is_target_verify or is_draft_extend:
+            if is_target_verify or is_draft_extend:
                 tokens_per_req = kwargs.get(
                     "tokens_per_req", self.speculative_num_draft_tokens
                 )
@@ -291,7 +301,9 @@ class MambaAttnBackend(AttentionBackend):
         track_conv_indices = None
         track_ssm_final_src = None
         track_ssm_final_dst = None
-        if forward_mode.is_extend() and not forward_mode.is_target_verify():
+        if (
+            forward_mode.is_extend_or_mixed() or is_draft_extend
+        ) and not is_target_verify:
             mamba_branching_seqlens = kwargs.get("mamba_branching_seqlens")
             extend_prefix_lens_kw = kwargs.get("extend_prefix_lens")
             mamba_track_pool_indices = kwargs.get("mamba_track_pool_indices")
@@ -450,11 +462,21 @@ class MambaAttnBackend(AttentionBackend):
         forward_mode: ForwardMode,
         **kwargs,
     ):
-        if forward_mode.is_decode_or_idle():
+        spec_num_tokens = num_tokens // bs if bs > 0 else 1
+        is_target_verify = (
+            forward_mode.is_decode_or_idle()
+            and not self.is_draft
+            and spec_num_tokens > 1
+        )
+        is_draft_extend = (
+            forward_mode.is_decode_or_idle() and self.is_draft and spec_num_tokens > 1
+        )
+
+        if forward_mode.is_decode_or_idle() and spec_num_tokens == 1:
             self.query_start_loc_list[bs - 1].copy_(
                 self.cached_cuda_graph_decode_query_start_loc[: bs + 1]
             )
-        elif forward_mode.is_target_verify() or forward_mode.is_draft_extend():
+        elif is_target_verify or is_draft_extend:
             self.query_start_loc_list[bs - 1].copy_(
                 self.cached_cuda_graph_verify_query_start_loc[: bs + 1]
             )
@@ -468,7 +490,7 @@ class MambaAttnBackend(AttentionBackend):
             mamba_indices = self.pool.get_mamba_indices(req_pool_indices[:bs])
         self.state_indices_list[bs - 1][: len(mamba_indices)].copy_(mamba_indices)
         self._qsl_dirty[bs - 1] = False
-        self._qsl_last_mode[bs - 1] = forward_mode
+        self._qsl_last_mode[bs - 1] = (forward_mode, spec_num_tokens > 1)
         self.forward_metadata = MambaForwardMetadata(
             query_start_loc=self.query_start_loc_list[bs - 1],
             mamba_cache_indices=self.state_indices_list[bs - 1],
@@ -477,6 +499,7 @@ class MambaAttnBackend(AttentionBackend):
     def init_forward_metadata_replay_cuda_graph(
         self,
         bs: int,
+        num_tokens: int,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode = None,
@@ -497,28 +520,43 @@ class MambaAttnBackend(AttentionBackend):
         if num_padding > 0:
             self.state_indices_list[bs - 1][real_bs:].fill_(self.pad_slot_id)
 
+        spec_num_tokens = num_tokens // bs if bs > 0 else 1
+        is_target_verify = (
+            forward_mode is not None
+            and forward_mode.is_decode_or_idle()
+            and not self.is_draft
+            and spec_num_tokens > 1
+        )
+        is_draft_extend = (
+            forward_mode is not None
+            and forward_mode.is_decode_or_idle()
+            and self.is_draft
+            and spec_num_tokens > 1
+        )
+
         if num_padding == 0:
-            need_copy = (
-                self._qsl_dirty[bs - 1] or self._qsl_last_mode[bs - 1] != forward_mode
+            need_copy = self._qsl_dirty[bs - 1] or self._qsl_last_mode[bs - 1] != (
+                forward_mode,
+                spec_num_tokens > 1,
             )
             if need_copy:
-                if forward_mode.is_decode_or_idle():
+                if forward_mode.is_decode_or_idle() and spec_num_tokens == 1:
                     self.query_start_loc_list[bs - 1].copy_(
                         self.cached_cuda_graph_decode_query_start_loc[: bs + 1]
                     )
-                elif forward_mode.is_target_verify() or forward_mode.is_draft_extend():
+                elif is_target_verify or is_draft_extend:
                     self.query_start_loc_list[bs - 1].copy_(
                         self.cached_cuda_graph_verify_query_start_loc[: bs + 1]
                     )
                 self._qsl_dirty[bs - 1] = False
-                self._qsl_last_mode[bs - 1] = forward_mode
+                self._qsl_last_mode[bs - 1] = (forward_mode, spec_num_tokens > 1)
         else:
-            if forward_mode.is_decode_or_idle():
+            if forward_mode.is_decode_or_idle() and spec_num_tokens == 1:
                 self.query_start_loc_list[bs - 1][:real_bs].copy_(
                     self.cached_cuda_graph_decode_query_start_loc[:real_bs]
                 )
                 self.query_start_loc_list[bs - 1][real_bs:].fill_(real_bs)
-            elif forward_mode.is_target_verify() or forward_mode.is_draft_extend():
+            elif is_target_verify or is_draft_extend:
                 self.query_start_loc_list[bs - 1][:real_bs].copy_(
                     self.cached_cuda_graph_verify_query_start_loc[:real_bs]
                 )
@@ -528,7 +566,7 @@ class MambaAttnBackend(AttentionBackend):
             else:
                 raise ValueError(f"Invalid forward mode: {forward_mode=}")
             self._qsl_dirty[bs - 1] = True
-            self._qsl_last_mode[bs - 1] = forward_mode
+            self._qsl_last_mode[bs - 1] = (forward_mode, spec_num_tokens > 1)
 
         self.forward_metadata = MambaForwardMetadata(
             query_start_loc=self.query_start_loc_list[bs - 1],
@@ -548,9 +586,28 @@ class MambaAttnBackend(AttentionBackend):
         layer: PagedAttention,
         out_cache_loc: torch.Tensor,
         token_to_kv_pool,
+        bs: int,
         save_kv_cache: bool = True,
         **kwargs,
     ):
+        # Multi-token decode (target verify or drafter compound) reuses
+        # the multi-token kernel path in forward_extend. `q` is None for
+        # hybrid linear-attn layers; the token count comes from mixed_qkv.
+        spec_num_tokens = kwargs["mixed_qkv"].shape[0] // bs if bs > 0 else 1
+        if spec_num_tokens > 1:
+            return self.forward_extend(
+                q,
+                k,
+                v,
+                layer,
+                out_cache_loc,
+                token_to_kv_pool,
+                bs,
+                forward_mode=ForwardMode.DECODE,
+                save_kv_cache=save_kv_cache,
+                **kwargs,
+            )
+
         mixed_qkv = kwargs["mixed_qkv"]
         conv_weights = kwargs["conv_weights"]
         bias = kwargs["bias"]
@@ -619,6 +676,7 @@ class MambaAttnBackend(AttentionBackend):
         layer: PagedAttention,
         out_cache_loc: torch.Tensor,
         token_to_kv_pool,
+        bs: int,
         forward_mode: ForwardMode,
         save_kv_cache: bool = True,
         **kwargs,
@@ -639,7 +697,15 @@ class MambaAttnBackend(AttentionBackend):
         layer_id = kwargs["layer_id"]
         seq_len = kwargs["seq_len"]
 
-        is_target_verify = forward_mode.is_target_verify()
+        # `q` is None for hybrid linear-attn layers; the token count comes
+        # from seq_len carried in kwargs.
+        spec_num_tokens = seq_len // bs if bs > 0 else 1
+        is_target_verify = (
+            forward_mode is not None
+            and forward_mode.is_decode_or_idle()
+            and not self.is_draft
+            and spec_num_tokens > 1
+        )
 
         query_start_loc = self.forward_metadata.query_start_loc
         cache_indices = self.forward_metadata.mamba_cache_indices
@@ -902,7 +968,8 @@ class HybridLinearAttnBackend(AttentionBackend):
         layer: PagedAttention,
         out_cache_loc,
         token_to_kv_pool,
-        forward_mode: ForwardMode = None,
+        forward_mode: ForwardMode,
+        bs: int,
         save_kv_cache: bool = True,
         **kwargs,
     ):
@@ -915,6 +982,7 @@ class HybridLinearAttnBackend(AttentionBackend):
                 out_cache_loc,
                 token_to_kv_pool,
                 forward_mode,
+                bs,
                 save_kv_cache,
                 **kwargs,
             )
@@ -935,12 +1003,11 @@ class HybridLinearAttnBackend(AttentionBackend):
                 layer,
                 out_cache_loc,
                 token_to_kv_pool,
+                bs,
                 save_kv_cache=save_kv_cache,
                 **kwargs,
             )
         else:
-            if backend is self.linear_attn_backend and forward_mode.is_target_verify():
-                kwargs["is_target_verify"] = True
             step_counter = getattr(self, "step_counter", None)
             if (
                 not forward_mode.is_idle()
@@ -955,6 +1022,7 @@ class HybridLinearAttnBackend(AttentionBackend):
                 layer,
                 out_cache_loc,
                 token_to_kv_pool,
+                bs,
                 save_kv_cache=save_kv_cache,
                 forward_mode=forward_mode,
                 **kwargs,
@@ -967,16 +1035,20 @@ class HybridLinearAttnBackend(AttentionBackend):
                 step_counter.record_cache()
             return ret
 
-    def forward_decode(self, q, k, v, layer, out_cache_loc, token_to_kv_pool, **kwargs):
+    def forward_decode(
+        self, q, k, v, layer, out_cache_loc, token_to_kv_pool, bs, **kwargs
+    ):
         layer_id = layer.layer_id if layer else kwargs["layer_id"]
         return self._backend_for_layer(layer_id).forward_decode(
-            q, k, v, layer, out_cache_loc, token_to_kv_pool, **kwargs
+            q, k, v, layer, out_cache_loc, token_to_kv_pool, bs, **kwargs
         )
 
-    def forward_extend(self, q, k, v, layer, out_cache_loc, token_to_kv_pool, **kwargs):
+    def forward_extend(
+        self, q, k, v, layer, out_cache_loc, token_to_kv_pool, bs, **kwargs
+    ):
         layer_id = layer.layer_id if layer else kwargs["layer_id"]
         return self._backend_for_layer(layer_id).forward_extend(
-            q, k, v, layer, out_cache_loc, token_to_kv_pool, **kwargs
+            q, k, v, layer, out_cache_loc, token_to_kv_pool, bs, **kwargs
         )
 
     def update_mamba_state_after_mtp_verify(self, accepted_length, model):

--- a/python/tokenspeed/runtime/layers/attention/backends/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mha.py
@@ -102,55 +102,56 @@ class MHAAttnBackend(AttentionBackend):
             self.max_context_len,
         )
 
-        if forward_mode.is_decode_or_idle():
-            self.forward_decode_metadata = MHAMetadata(
+        if forward_mode.is_extend_or_mixed():
+            if extend_prefix_lens is None:
+                extend_seq_lens = seq_lens
+            else:
+                assert (
+                    extend_prefix_lens.dtype == torch.int32
+                ), f"extend_prefix_lens must be int32, got {extend_prefix_lens.dtype}"
+                extend_seq_lens = seq_lens - extend_prefix_lens[:bs]
+
+            extend_seq_lens_cpu = kwargs.get("extend_seq_lens_cpu")
+            assert (
+                extend_seq_lens_cpu is not None
+            ), "mha extend requires extend_seq_lens_cpu"
+            max_seq_len_q = int(extend_seq_lens_cpu[:bs].max().item())
+
+            self.forward_prefill_metadata = MHAMetadata(
                 cache_seqlens_int32=seq_lens,
+                cu_seqlens_q=self._make_cu_seqlens(extend_seq_lens),
                 page_table=page_table,
+                max_seq_len_q=max_seq_len_q,
                 max_seq_len_k=self.max_context_len,
             )
             return
 
-        if forward_mode.is_target_verify() or forward_mode.is_draft_extend():
-            tokens_per_req = num_tokens // bs if bs > 0 else 1
+        spec_num_tokens = num_tokens // bs if bs > 0 else 1
+        if spec_num_tokens > 1:
             self.forward_prefill_metadata = MHAMetadata(
                 cache_seqlens_int32=seq_lens,
                 cu_seqlens_q=self._make_uniform_cu_seqlens(
                     bs,
-                    tokens_per_req,
+                    spec_num_tokens,
                     seq_lens.device,
                 ),
                 page_table=page_table,
-                max_seq_len_q=tokens_per_req,
+                max_seq_len_q=spec_num_tokens,
                 max_seq_len_k=self.max_context_len,
             )
+            if self.is_draft:
+                # Drafter follow-up single-token steps after the first.
+                self.forward_decode_metadata = MHAMetadata(
+                    cache_seqlens_int32=seq_lens.clone(),
+                    page_table=page_table,
+                    max_seq_len_k=self.max_context_len,
+                )
+        else:
             self.forward_decode_metadata = MHAMetadata(
-                cache_seqlens_int32=seq_lens.clone(),
+                cache_seqlens_int32=seq_lens,
                 page_table=page_table,
                 max_seq_len_k=self.max_context_len,
             )
-            return
-
-        if extend_prefix_lens is None:
-            extend_seq_lens = seq_lens
-        else:
-            assert (
-                extend_prefix_lens.dtype == torch.int32
-            ), f"extend_prefix_lens must be int32, got {extend_prefix_lens.dtype}"
-            extend_seq_lens = seq_lens - extend_prefix_lens[:bs]
-
-        extend_seq_lens_cpu = kwargs.get("extend_seq_lens_cpu")
-        assert (
-            extend_seq_lens_cpu is not None
-        ), "mha extend requires extend_seq_lens_cpu"
-        max_seq_len_q = int(extend_seq_lens_cpu[:bs].max().item())
-
-        self.forward_prefill_metadata = MHAMetadata(
-            cache_seqlens_int32=seq_lens,
-            cu_seqlens_q=self._make_cu_seqlens(extend_seq_lens),
-            page_table=page_table,
-            max_seq_len_q=max_seq_len_q,
-            max_seq_len_k=self.max_context_len,
-        )
 
     def init_cuda_graph_state(self, max_bs: int, seq_lens_buf: torch.Tensor):
         assert (
@@ -177,59 +178,43 @@ class MHAAttnBackend(AttentionBackend):
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode,
     ):
-        if forward_mode.is_decode():
-            cache_seqlens = self.cuda_graph_cache_seqlens[:bs]
-            metadata = MHAMetadata(
-                cache_seqlens_int32=cache_seqlens,
-                page_table=self.cuda_graph_page_table[:bs, :],
-                max_seq_len_k=self.max_context_len,
-            )
-            self.cuda_graph_decode_metadata[bs] = metadata
-            self.forward_decode_metadata = metadata
-        elif forward_mode.is_target_verify():
-            spec_num_tokens = num_tokens // bs if bs > 0 else 1
-            cache_seqlens = self.cuda_graph_cache_seqlens[:bs]
-            metadata = MHAMetadata(
-                cache_seqlens_int32=cache_seqlens,
-                cu_seqlens_q=self._make_uniform_cu_seqlens(
-                    bs,
-                    spec_num_tokens,
-                    self.device,
-                ),
-                page_table=self.cuda_graph_page_table[:bs, :],
-                max_seq_len_q=spec_num_tokens,
-                max_seq_len_k=self.max_context_len,
-            )
-            self.cuda_graph_prefill_metadata[bs] = metadata
-            self.forward_prefill_metadata = metadata
-        elif forward_mode.is_draft_extend():
-            spec_num_tokens = num_tokens // bs if bs > 0 else 1
-            cache_seqlens = self.cuda_graph_cache_seqlens[:bs]
-            metadata = MHAMetadata(
-                cache_seqlens_int32=cache_seqlens,
-                cu_seqlens_q=self._make_uniform_cu_seqlens(
-                    bs,
-                    spec_num_tokens,
-                    self.device,
-                ),
-                page_table=self.cuda_graph_page_table[:bs, :],
-                max_seq_len_q=spec_num_tokens,
-                max_seq_len_k=self.max_context_len,
-            )
-            self.cuda_graph_prefill_metadata[bs] = metadata
-            self.forward_prefill_metadata = metadata
-
-            metadata = MHAMetadata(
-                cache_seqlens_int32=cache_seqlens,
-                page_table=self.cuda_graph_page_table[:bs, :],
-                max_seq_len_k=self.max_context_len,
-            )
-            self.cuda_graph_decode_metadata[bs] = metadata
-            self.forward_decode_metadata = metadata
-        else:
+        if forward_mode.is_extend_or_mixed():
             raise NotImplementedError(
                 f"mha CUDA graph capture not supported for {forward_mode}"
             )
+
+        cache_seqlens = self.cuda_graph_cache_seqlens[:bs]
+        spec_num_tokens = num_tokens // bs if bs > 0 else 1
+        if spec_num_tokens > 1:
+            metadata = MHAMetadata(
+                cache_seqlens_int32=cache_seqlens,
+                cu_seqlens_q=self._make_uniform_cu_seqlens(
+                    bs,
+                    spec_num_tokens,
+                    self.device,
+                ),
+                page_table=self.cuda_graph_page_table[:bs, :],
+                max_seq_len_q=spec_num_tokens,
+                max_seq_len_k=self.max_context_len,
+            )
+            self.cuda_graph_prefill_metadata[bs] = metadata
+            self.forward_prefill_metadata = metadata
+            if self.is_draft:
+                metadata = MHAMetadata(
+                    cache_seqlens_int32=cache_seqlens,
+                    page_table=self.cuda_graph_page_table[:bs, :],
+                    max_seq_len_k=self.max_context_len,
+                )
+                self.cuda_graph_decode_metadata[bs] = metadata
+                self.forward_decode_metadata = metadata
+        else:
+            metadata = MHAMetadata(
+                cache_seqlens_int32=cache_seqlens,
+                page_table=self.cuda_graph_page_table[:bs, :],
+                max_seq_len_k=self.max_context_len,
+            )
+            self.cuda_graph_decode_metadata[bs] = metadata
+            self.forward_decode_metadata = metadata
 
     def init_forward_metadata_replay_cuda_graph(
         self,
@@ -246,17 +231,15 @@ class MHAAttnBackend(AttentionBackend):
                 req_to_page[req_pool_indices[:bs], : self.max_num_pages]
             )
 
-        if forward_mode.is_decode():
-            self.forward_decode_metadata = self.cuda_graph_decode_metadata[bs]
-        elif forward_mode.is_target_verify():
-            self.forward_prefill_metadata = self.cuda_graph_prefill_metadata[bs]
-        elif forward_mode.is_draft_extend():
-            self.forward_prefill_metadata = self.cuda_graph_prefill_metadata[bs]
-            self.forward_decode_metadata = self.cuda_graph_decode_metadata[bs]
-        else:
+        if forward_mode.is_extend_or_mixed():
             raise NotImplementedError(
                 f"mha CUDA graph replay not supported for {forward_mode}"
             )
+
+        if bs in self.cuda_graph_prefill_metadata:
+            self.forward_prefill_metadata = self.cuda_graph_prefill_metadata[bs]
+        if bs in self.cuda_graph_decode_metadata:
+            self.forward_decode_metadata = self.cuda_graph_decode_metadata[bs]
 
     def forward_decode(
         self,
@@ -266,11 +249,28 @@ class MHAAttnBackend(AttentionBackend):
         layer: PagedAttention,
         out_cache_loc: torch.Tensor,
         token_to_kv_pool,
+        bs: int,
         save_kv_cache: bool = False,
         **kwargs,
     ) -> torch.Tensor:
         if layer.qk_head_dim != layer.v_head_dim:
             raise NotImplementedError("mha backend requires qk_head_dim == v_head_dim")
+
+        # Multi-token decode (q_len > 1) reuses the prefill kernel via the
+        # uniform-stride prefill slot; plain decode uses the single-token slot.
+        spec_num_tokens = q.shape[0] // bs if bs > 0 else 1
+        if spec_num_tokens > 1:
+            return self.forward_extend(
+                q,
+                k,
+                v,
+                layer,
+                out_cache_loc,
+                token_to_kv_pool,
+                bs,
+                save_kv_cache=save_kv_cache,
+                **kwargs,
+            )
 
         if save_kv_cache and k is not None:
             token_to_kv_pool.set_kv_buffer(
@@ -312,7 +312,7 @@ class MHAAttnBackend(AttentionBackend):
         layer: PagedAttention,
         out_cache_loc: torch.Tensor,
         token_to_kv_pool,
-        forward_mode: ForwardMode,
+        bs: int,
         save_kv_cache: bool = False,
         **kwargs,
     ) -> torch.Tensor:

--- a/python/tokenspeed/runtime/layers/attention/backends/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mha.py
@@ -219,6 +219,7 @@ class MHAAttnBackend(AttentionBackend):
     def init_forward_metadata_replay_cuda_graph(
         self,
         bs: int,
+        num_tokens: int,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode,

--- a/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
@@ -369,6 +369,7 @@ class CuteDSLMLABackend(AttentionBackend):
     def init_forward_metadata_replay_cuda_graph(
         self,
         bs: int,
+        num_tokens: int,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode = None,

--- a/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
@@ -222,15 +222,7 @@ class CuteDSLMLABackend(AttentionBackend):
         spec_info=None,
         **kwargs,
     ):
-        if (
-            forward_mode.is_decode_or_idle()
-            or forward_mode.is_target_verify()
-            or forward_mode.is_draft_extend()
-        ):
-            self._init_decode_metadata(
-                bs, req_pool_indices, seq_lens, forward_mode, req_to_page, spec_info
-            )
-        else:
+        if forward_mode.is_extend_or_mixed():
             self._init_prefill_metadata(
                 seq_lens,
                 req_pool_indices=req_pool_indices,
@@ -239,6 +231,10 @@ class CuteDSLMLABackend(AttentionBackend):
                 extend_prefix_lens_cpu=kwargs.pop("extend_prefix_lens_cpu"),
                 extend_seq_lens=kwargs.pop("extend_seq_lens"),
                 extend_seq_lens_cpu=kwargs.pop("extend_seq_lens_cpu"),
+            )
+        else:
+            self._init_decode_metadata(
+                bs, req_pool_indices, seq_lens, forward_mode, req_to_page, spec_info
             )
 
     def _init_decode_metadata(
@@ -353,11 +349,7 @@ class CuteDSLMLABackend(AttentionBackend):
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode,
     ):
-        if (
-            not forward_mode.is_decode_or_idle()
-            and not forward_mode.is_target_verify()
-            and not forward_mode.is_draft_extend()
-        ):
+        if forward_mode.is_extend_or_mixed():
             raise NotImplementedError(
                 f"tokenspeed_mla CUDA graph capture not supported for {forward_mode}"
             )
@@ -383,11 +375,7 @@ class CuteDSLMLABackend(AttentionBackend):
         req_to_page: torch.Tensor = None,
         **kwargs,
     ):
-        if forward_mode is not None and (
-            not forward_mode.is_decode_or_idle()
-            and not forward_mode.is_target_verify()
-            and not forward_mode.is_draft_extend()
-        ):
+        if forward_mode is not None and forward_mode.is_extend_or_mixed():
             raise NotImplementedError(
                 f"tokenspeed_mla CUDA graph replay not supported for {forward_mode}"
             )
@@ -420,6 +408,7 @@ class CuteDSLMLABackend(AttentionBackend):
         layer: PagedAttention,
         out_cache_loc: torch.Tensor,
         token_to_kv_pool,
+        bs: int,
         save_kv_cache: bool = True,
         **kwargs,
     ) -> torch.Tensor:
@@ -433,8 +422,8 @@ class CuteDSLMLABackend(AttentionBackend):
                 k[..., self.kv_lora_rank :],
             )
 
-        # Prepare query: [T, 1, H, head_dim]
-        query = q.view(-1, layer.tp_q_head_num, layer.head_dim).unsqueeze(1)
+        spec_num_tokens = q.shape[0] // bs if bs > 0 else 1
+        query = q.view(bs, spec_num_tokens, layer.tp_q_head_num, layer.head_dim)
 
         softmax_scale = layer.scaling
         if self.data_type == torch.float8_e4m3fn:
@@ -483,55 +472,6 @@ class CuteDSLMLABackend(AttentionBackend):
 
     # ---- Forward: Extend/Prefill ----
 
-    def forward_extend(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        layer: PagedAttention,
-        out_cache_loc: torch.Tensor,
-        token_to_kv_pool,
-        save_kv_cache: bool = True,
-        forward_mode: ForwardMode = None,
-        **kwargs,
-    ):
-        if forward_mode is not None and forward_mode.is_target_verify():
-            return self._forward_target_verify(
-                q,
-                k,
-                v,
-                layer,
-                out_cache_loc,
-                token_to_kv_pool,
-                save_kv_cache,
-            )
-
-        # draft_extend: few tokens per request. Route through _forward_target_verify
-        # so q is reshaped as [bs, num_draft_tokens, H, D] to match page_table batch
-        # dim; forward_decode's `.unsqueeze(1)` path assumes a single token per row
-        # and breaks the tokenspeed_mla_decode shape-consistency check.
-        if forward_mode is not None and forward_mode.is_draft_extend():
-            return self._forward_target_verify(
-                q,
-                k,
-                v,
-                layer,
-                out_cache_loc,
-                token_to_kv_pool,
-                save_kv_cache,
-            )
-
-        # Regular prefill: use CuteDSL FMHA kernel
-        return self._forward_cutedsl_prefill(
-            q,
-            k,
-            v,
-            layer,
-            out_cache_loc,
-            token_to_kv_pool,
-            save_kv_cache,
-        )
-
     def forward_extend_chunked(
         self,
         q: torch.Tensor,
@@ -564,6 +504,10 @@ class CuteDSLMLABackend(AttentionBackend):
             k = k.to(torch.float8_e4m3fn)
             v = v.to(torch.float8_e4m3fn)
 
+        if not CuteDSLMLABackend._logged_prefill:
+            logger.info("CuteDSL MLA prefill kernel invoked (tokenspeed_mla_prefill)")
+            CuteDSLMLABackend._logged_prefill = True
+
         result = tokenspeed_mla_prefill(
             query=q,
             key=k,
@@ -589,118 +533,6 @@ class CuteDSLMLABackend(AttentionBackend):
             out = out.to(self.q_data_type)
 
         return out, lse
-
-    def _forward_target_verify(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        layer: PagedAttention,
-        out_cache_loc: torch.Tensor,
-        token_to_kv_pool,
-        save_kv_cache: bool = True,
-    ) -> torch.Tensor:
-        """Handle target_verify: multi-token query against paged KV (context + draft)."""
-        # q is whole Q [T, H, head_dim]; k is whole latent [T, 1, head_dim].
-        if save_kv_cache:
-            assert k is not None
-            token_to_kv_pool.set_mla_kv_buffer(
-                layer,
-                out_cache_loc,
-                k[..., : self.kv_lora_rank],
-                k[..., self.kv_lora_rank :],
-            )
-
-        bs = self.forward_decode_metadata.seq_lens_k.shape[0]
-        query = q.to(self.data_type).view(bs, -1, layer.tp_q_head_num, layer.head_dim)
-
-        # KV cache: 3D for CuteDSL
-        k_cache = token_to_kv_pool.get_key_buffer(layer.layer_id)
-        if self.data_type != k_cache.dtype:
-            k_cache = k_cache.to(self.data_type)
-        kv_cache = k_cache.view(-1, self.page_size, self.kv_cache_dim)
-
-        if self.data_type == torch.float8_e4m3fn:
-            k_scale = (
-                layer.k_scale_float
-                if getattr(layer, "k_scale_float", None) is not None
-                else 1.0
-            )
-        else:
-            k_scale = 1.0
-        softmax_scale = k_scale * layer.scaling
-
-        metadata = self.forward_decode_metadata
-        max_seq_len = metadata.max_seq_len_k
-
-        self.cutedsl_workspace = get_cutedsl_workspace_buffer(
-            query.device, layer.tp_q_head_num, self.kv_lora_rank, query.shape[1]
-        )
-
-        raw_out = tokenspeed_mla_decode(
-            query=query,
-            kv_cache=kv_cache,
-            workspace_buffer=self.cutedsl_workspace,
-            kv_lora_rank=self.kv_lora_rank,
-            qk_rope_head_dim=self.qk_rope_head_dim,
-            block_tables=metadata.block_kv_indices,
-            seq_lens=metadata.seq_lens_k,
-            max_seq_len=max_seq_len,
-            softmax_scale=softmax_scale,
-            enable_pdl=pdl_enabled(),
-        )
-
-        return raw_out.view(-1, layer.tp_q_head_num * layer.v_head_dim)
-
-    def _forward_cutedsl_prefill(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        layer: PagedAttention,
-        out_cache_loc: torch.Tensor,
-        token_to_kv_pool,
-        save_kv_cache: bool = True,
-    ):
-        """MLA prefill using CuteDSL FMHA kernel.
-
-        q is whole Q [T, H, head_dim]; k is whole latent [T, 1, head_dim].
-        Currently unreachable (the live non-absorb prefill path goes through
-        `forward_normal_chunked_kv_core` → `forward_extend_chunked`, not this
-        entry point), but the KV write uses the MLA-correct API so it stays honest.
-        """
-        if not CuteDSLMLABackend._logged_prefill:
-            logger.info("CuteDSL MLA prefill kernel invoked (tokenspeed_mla_prefill)")
-            CuteDSLMLABackend._logged_prefill = True
-
-        if save_kv_cache:
-            token_to_kv_pool.set_mla_kv_buffer(
-                layer,
-                out_cache_loc,
-                k[..., : self.kv_lora_rank],
-                k[..., self.kv_lora_rank :],
-            )
-
-        q = q.view(-1, layer.tp_q_head_num, layer.head_dim)
-        k = k.view(-1, layer.tp_k_head_num, layer.head_dim)
-        v = v.view(-1, layer.tp_k_head_num, layer.v_head_dim)
-
-        metadata = self.forward_prefill_metadata
-
-        out = tokenspeed_mla_prefill(
-            query=q,
-            key=k,
-            value=v,
-            seq_lens=metadata.seq_lens,
-            cum_seq_lens=metadata.cum_seq_lens,
-            max_seq_len=metadata.max_seq_len,
-            batch_size=metadata.seq_lens.shape[0],
-            softmax_scale=layer.scaling,
-            is_causal=True,
-            enable_pdl=pdl_enabled(),
-        )
-
-        return out.view(-1, layer.tp_q_head_num * layer.v_head_dim)
 
 
 register_backend("tokenspeed_mla", {AttentionArch.MLA}, CuteDSLMLABackend)

--- a/python/tokenspeed/runtime/layers/attention/backends/triton.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/triton.py
@@ -200,7 +200,17 @@ class TritonAttnBackend(AttentionBackend):
         window_kv_indices = None
         window_num_kv_splits = None
 
-        if forward_mode.is_decode_or_idle():
+        spec_num_tokens = num_tokens // bs if bs > 0 else 1
+        is_target_verify = (
+            forward_mode.is_decode_or_idle()
+            and not self.is_draft
+            and spec_num_tokens > 1
+        )
+        is_draft_extend = (
+            forward_mode.is_decode_or_idle() and self.is_draft and spec_num_tokens > 1
+        )
+
+        if forward_mode.is_decode_or_idle() and spec_num_tokens == 1:
             if spec_info is None:
                 torch.cumsum(seq_lens, dim=0, out=kv_indptr[1 : bs + 1])
                 kv_indptr = kv_indptr[: bs + 1]
@@ -259,7 +269,7 @@ class TritonAttnBackend(AttentionBackend):
             custom_mask = None
             mask_indptr = None
             max_extend_len = None
-        elif forward_mode.is_target_verify():
+        elif is_target_verify:
             bs = len(req_pool_indices)
             qo_indptr = torch.arange(
                 0,
@@ -307,7 +317,7 @@ class TritonAttnBackend(AttentionBackend):
             attn_logits = None
             attn_lse = None
 
-        elif forward_mode.is_draft_extend():
+        elif is_draft_extend:
             kv_indices, kv_indptr, qo_indptr, custom_mask = (
                 spec_info.generate_attn_arg_prefill(
                     req_pool_indices,
@@ -452,7 +462,17 @@ class TritonAttnBackend(AttentionBackend):
         window_kv_indices = None
         window_num_kv_splits = None
 
-        if forward_mode.is_decode_or_idle():
+        spec_num_tokens = num_tokens // bs if bs > 0 else 1
+        is_target_verify = (
+            forward_mode.is_decode_or_idle()
+            and not self.is_draft
+            and spec_num_tokens > 1
+        )
+        is_draft_extend = (
+            forward_mode.is_decode_or_idle() and self.is_draft and spec_num_tokens > 1
+        )
+
+        if forward_mode.is_decode_or_idle() and spec_num_tokens == 1:
             if spec_info is None:
                 kv_indptr = self.kv_indptr
                 torch.cumsum(seq_lens, dim=0, out=kv_indptr[1 : bs + 1])
@@ -495,7 +515,7 @@ class TritonAttnBackend(AttentionBackend):
             qo_indptr = None
             custom_mask = None
             mask_indptr = None
-        elif forward_mode.is_target_verify():
+        elif is_target_verify:
             qo_indptr = self.qo_indptr[: bs + 1]
             qo_indptr[: bs + 1] = torch.arange(
                 0,
@@ -542,7 +562,7 @@ class TritonAttnBackend(AttentionBackend):
             num_kv_splits = None
             attn_logits = None
             attn_lse = None
-        elif forward_mode.is_draft_extend():
+        elif is_draft_extend:
             num_tokens_per_bs = self.speculative_num_steps + 1
             qo_indptr = self.qo_indptr[: bs + 1]
             qo_indptr[: bs + 1] = torch.arange(
@@ -593,15 +613,27 @@ class TritonAttnBackend(AttentionBackend):
     def init_forward_metadata_replay_cuda_graph(
         self,
         bs: int,
+        num_tokens: int,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode = None,
         req_to_page: torch.Tensor = None,
         spec_info: EagleDraftInput | None = None,
+        **kwargs,
     ):
         _req_to_token = self.req_to_page
 
-        if forward_mode.is_decode_or_idle():
+        spec_num_tokens = num_tokens // bs if bs > 0 else 1
+        is_target_verify = (
+            forward_mode.is_decode_or_idle()
+            and not self.is_draft
+            and spec_num_tokens > 1
+        )
+        is_draft_extend = (
+            forward_mode.is_decode_or_idle() and self.is_draft and spec_num_tokens > 1
+        )
+
+        if forward_mode.is_decode_or_idle() and spec_num_tokens == 1:
             # Update kv_indptr, kv_indices
             kv_indptr = self.kv_indptr
             kv_indices = self.cuda_graph_kv_indices
@@ -645,7 +677,7 @@ class TritonAttnBackend(AttentionBackend):
                 num_token = spec_info.kv_indptr.shape[0] - 1
             self.get_num_kv_splits(num_kv_splits[:num_token], seq_lens[:bs])
 
-        elif forward_mode.is_target_verify():
+        elif is_target_verify:
             # Update qo_indptr, kv_indptr, kv_indices, custom_mask, mask_indptr
             bs = len(req_pool_indices)
             qo_indptr = self.qo_indptr[: bs + 1]
@@ -686,7 +718,7 @@ class TritonAttnBackend(AttentionBackend):
             seq_mask_len = self.num_draft_tokens * (seq_lens + self.num_draft_tokens)
             mask_indptr = self.mask_indptr[: bs + 1]
             torch.cumsum(seq_mask_len, dim=0, out=mask_indptr[1 : bs + 1])
-        elif forward_mode.is_draft_extend():
+        elif is_draft_extend:
             seq_lens = seq_lens[:bs]
             accept_lens = spec_info.accept_length[:bs]
             qo_indptr = self.qo_indptr[: bs + 1]
@@ -719,6 +751,7 @@ class TritonAttnBackend(AttentionBackend):
         layer: PagedAttention,
         out_cache_loc: torch.Tensor,
         token_to_kv_pool,
+        bs: int,
         save_kv_cache: bool = True,
         **kwargs,
     ):
@@ -772,9 +805,26 @@ class TritonAttnBackend(AttentionBackend):
         layer: PagedAttention,
         out_cache_loc: torch.Tensor,
         token_to_kv_pool,
+        bs: int,
         save_kv_cache: bool = True,
         **kwargs,
     ):
+        # Multi-token decode (target verify or drafter compound) reuses
+        # the multi-token kernel path in forward_extend.
+        spec_num_tokens = q.shape[0] // bs if bs > 0 else 1
+        if spec_num_tokens > 1:
+            return self.forward_extend(
+                q,
+                k,
+                v,
+                layer,
+                out_cache_loc,
+                token_to_kv_pool,
+                bs,
+                save_kv_cache=save_kv_cache,
+                **kwargs,
+            )
+
         # During torch.compile, there is a bug in rotary_emb that causes the
         # output value to have a 3D tensor shape. This reshapes the output correctly.
         q = q.reshape(-1, layer.tp_q_head_num * layer.qk_head_dim)

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -564,6 +564,7 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
     def init_forward_metadata_replay_cuda_graph(
         self,
         bs: int,
+        num_tokens: int,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode,

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -214,17 +214,9 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
     # Forward
     # ------------------------------------------------------------------
 
-    def forward_decode(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        layer: PagedAttention,
-        out_cache_loc: torch.Tensor,
-        token_to_kv_pool,
-        save_kv_cache: bool = True,
-        **kwargs,
-    ) -> torch.Tensor:
+    def _save_kv_and_prepare_q(
+        self, q, k, v, layer, out_cache_loc, token_to_kv_pool, save_kv_cache
+    ):
         if self._should_use_fused_fp8_path(save_kv_cache, k):
             k_cache, v_cache = token_to_kv_pool.get_kv_buffer(layer.layer_id)
             fused_fp8_set_kv_buffer(
@@ -247,8 +239,23 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         else:
             q = q.contiguous()
 
-        q = q.view(-1, layer.tp_q_head_num, layer.head_dim)
+        return q.view(-1, layer.tp_q_head_num, layer.head_dim)
 
+    def forward_decode(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: PagedAttention,
+        out_cache_loc: torch.Tensor,
+        token_to_kv_pool,
+        bs: int,
+        save_kv_cache: bool = True,
+        **kwargs,
+    ) -> torch.Tensor:
+        q = self._save_kv_and_prepare_q(
+            q, k, v, layer, out_cache_loc, token_to_kv_pool, save_kv_cache
+        )
         k_cache, v_cache = self._get_kv_cache_permuted(layer, token_to_kv_pool)
         bmm1_scale, bmm2_scale = self._compute_scales(layer)
 
@@ -256,7 +263,15 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         if attention_sink is not None:
             attention_sink = attention_sink.float()
 
-        metadata = self.forward_decode_metadata
+        # Multi-token decode (q_len > 1) reads the prefill slot's
+        # uniform-stride metadata; plain decode reads the single-token slot.
+        spec_num_tokens = q.shape[0] // bs if bs > 0 else 1
+        metadata = (
+            self.forward_prefill_metadata
+            if spec_num_tokens > 1
+            else self.forward_decode_metadata
+        )
+
         o = trtllm_batch_decode_with_kv_cache(
             query=q,
             kv_cache=(k_cache, v_cache),
@@ -269,6 +284,7 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
             window_left=layer.sliding_window_size,
             sinks=attention_sink,
             out_dtype=self.dtype,
+            q_len_per_req=metadata.max_seq_len_q,
         )
         return o.view(-1, layer.tp_q_head_num * layer.head_dim)
 
@@ -280,34 +296,13 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         layer: PagedAttention,
         out_cache_loc: torch.Tensor,
         token_to_kv_pool,
-        forward_mode: ForwardMode,
+        bs: int,
         save_kv_cache: bool = True,
         **kwargs,
     ) -> torch.Tensor:
-        if self._should_use_fused_fp8_path(save_kv_cache, k):
-            k_cache, v_cache = token_to_kv_pool.get_kv_buffer(layer.layer_id)
-            fused_fp8_set_kv_buffer(
-                k=k.view(-1, layer.tp_k_head_num, layer.head_dim),
-                v=v.view(-1, layer.tp_k_head_num, layer.head_dim),
-                k_cache=k_cache,
-                v_cache=v_cache,
-                cache_loc=out_cache_loc,
-                k_scale=layer.k_scale,
-                v_scale=layer.v_scale,
-                page_size=self.page_size,
-            )
-        elif save_kv_cache and k is not None:
-            token_to_kv_pool.set_kv_buffer(
-                layer, out_cache_loc, k, v, layer.k_scale, layer.v_scale
-            )
-
-        if self.kv_cache_dtype == torch.float8_e4m3fn:
-            q = fp8_cast_contiguous(q)
-        else:
-            q = q.contiguous()
-
-        q = q.view(-1, layer.tp_q_head_num, layer.head_dim)
-
+        q = self._save_kv_and_prepare_q(
+            q, k, v, layer, out_cache_loc, token_to_kv_pool, save_kv_cache
+        )
         k_cache, v_cache = self._get_kv_cache_permuted(layer, token_to_kv_pool)
         bmm1_scale, bmm2_scale = self._compute_scales(layer)
 
@@ -315,52 +310,24 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         if attention_sink is not None:
             attention_sink = attention_sink.float()
 
-        # target_verify and draft_extend both produce uniform spec-length
-        # query batches (init_forward_metadata calls _init_target_verify_metadata
-        # for both), so route both through the latency-tagged decode kernel.
-        use_decode_kernel = (
-            forward_mode.is_target_verify() or forward_mode.is_draft_extend()
-        )
-
         metadata = self.forward_prefill_metadata
-
-        if use_decode_kernel:
-
-            o = trtllm_batch_decode_with_kv_cache(
-                query=q,
-                kv_cache=(k_cache, v_cache),
-                workspace_buffer=self.workspace_buffer,
-                block_tables=metadata.page_table,
-                seq_lens=metadata.cache_seqlens_int32,
-                max_seq_len=self.max_context_len,
-                bmm1_scale=bmm1_scale,
-                bmm2_scale=bmm2_scale,
-                window_left=layer.sliding_window_size,
-                sinks=attention_sink,
-                out_dtype=self.dtype,
-                q_len_per_req=metadata.max_seq_len_q,
-            )
-
-        else:
-
-            o = trtllm_batch_context_with_kv_cache(
-                query=q,
-                kv_cache=(k_cache, v_cache),
-                workspace_buffer=self.workspace_buffer,
-                block_tables=metadata.page_table,
-                seq_lens=metadata.cache_seqlens_int32,
-                max_q_len=metadata.max_seq_len_q,
-                max_kv_len=self.max_context_len,
-                bmm1_scale=bmm1_scale,
-                bmm2_scale=bmm2_scale,
-                batch_size=metadata.cu_seqlens_q.shape[0] - 1,
-                cum_seq_lens_q=metadata.cu_seqlens_q,
-                cum_seq_lens_kv=metadata.cu_seqlens_k,
-                window_left=layer.sliding_window_size,
-                sinks=attention_sink,
-                out_dtype=self.dtype,
-            )
-
+        o = trtllm_batch_context_with_kv_cache(
+            query=q,
+            kv_cache=(k_cache, v_cache),
+            workspace_buffer=self.workspace_buffer,
+            block_tables=metadata.page_table,
+            seq_lens=metadata.cache_seqlens_int32,
+            max_q_len=metadata.max_seq_len_q,
+            max_kv_len=self.max_context_len,
+            bmm1_scale=bmm1_scale,
+            bmm2_scale=bmm2_scale,
+            batch_size=metadata.cu_seqlens_q.shape[0] - 1,
+            cum_seq_lens_q=metadata.cu_seqlens_q,
+            cum_seq_lens_kv=metadata.cu_seqlens_k,
+            window_left=layer.sliding_window_size,
+            sinks=attention_sink,
+            out_dtype=self.dtype,
+        )
         return o.view(-1, layer.tp_q_head_num * layer.head_dim)
 
     # ------------------------------------------------------------------
@@ -383,23 +350,7 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         use_cuda_graph: bool = False,
         **kwargs,
     ):
-        if forward_mode.is_decode():
-            self._init_decode_metadata(bs, req_pool_indices, seq_lens, req_to_page)
-        elif forward_mode.is_target_verify():
-            spec_num_tokens = num_tokens // bs if bs > 0 else 1
-            self._init_target_verify_metadata(
-                bs, spec_num_tokens, req_pool_indices, seq_lens, req_to_page
-            )
-        elif forward_mode.is_draft_extend():
-            # Compound: draft's step 0 uses prefill kernel (multi-token),
-            # steps 1..N-1 use decode kernel (single-token). Populate both
-            # slots in one call.
-            spec_num_tokens = num_tokens // bs if bs > 0 else 1
-            self._init_target_verify_metadata(
-                bs, spec_num_tokens, req_pool_indices, seq_lens, req_to_page
-            )
-            self._init_decode_metadata(bs, req_pool_indices, seq_lens, req_to_page)
-        elif forward_mode.is_extend():
+        if forward_mode.is_extend_or_mixed():
             self._init_extend_metadata(
                 bs,
                 req_pool_indices,
@@ -410,8 +361,18 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
                 extend_prefix_lens_cpu=extend_prefix_lens_cpu,
                 extend_seq_lens_cpu=extend_seq_lens_cpu,
             )
+            return
+
+        spec_num_tokens = num_tokens // bs if bs > 0 else 1
+        if spec_num_tokens > 1:
+            self._init_multi_token_metadata(
+                bs, spec_num_tokens, req_pool_indices, seq_lens, req_to_page
+            )
+            if self.is_draft:
+                # Drafter's N-1 single-token steps after the first.
+                self._init_decode_metadata(bs, req_pool_indices, seq_lens, req_to_page)
         else:
-            raise NotImplementedError(f"Unsupported forward mode: {forward_mode}")
+            self._init_decode_metadata(bs, req_pool_indices, seq_lens, req_to_page)
 
     def _init_decode_metadata(
         self,
@@ -436,7 +397,7 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
             ),
         )
 
-    def _init_target_verify_metadata(
+    def _init_multi_token_metadata(
         self,
         bs: int,
         spec_num_tokens: int,
@@ -444,8 +405,9 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         seq_lens: torch.Tensor,
         req_to_page: torch.Tensor,
     ):
-        """Prefill slot for TARGET_VERIFY / DRAFT_EXTEND. Routes through the
-        decode kernel (q_len_per_req), which doesn't read cu_seqlens_k."""
+        """Prefill-slot metadata for multi-token decode (uniform q_len per
+        request). Routes through the decode kernel via q_len_per_req; the
+        kernel doesn't read cu_seqlens_k."""
         assert (
             seq_lens.dtype == torch.int32
         ), f"seq_lens must be int32, got {seq_lens.dtype}"
@@ -554,20 +516,18 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode,
     ):
-        if forward_mode.is_decode():
-            self._init_decode_metadata_capture(bs, seq_lens)
-        elif forward_mode.is_target_verify():
-            spec_num_tokens = num_tokens // bs if bs > 0 else 1
-            self._init_target_verify_metadata_capture(bs, spec_num_tokens, seq_lens)
-        elif forward_mode.is_draft_extend():
-            # Compound: capture both prefill (step 0) and decode (steps 1..N-1).
-            spec_num_tokens = num_tokens // bs if bs > 0 else 1
-            self._init_target_verify_metadata_capture(bs, spec_num_tokens, seq_lens)
-            self._init_decode_metadata_capture(bs, seq_lens)
-        else:
+        if forward_mode.is_extend_or_mixed():
             raise NotImplementedError(
                 f"trtllm CUDA graph capture not supported for {forward_mode}"
             )
+
+        spec_num_tokens = num_tokens // bs if bs > 0 else 1
+        if spec_num_tokens > 1:
+            self._init_multi_token_metadata_capture(bs, spec_num_tokens, seq_lens)
+            if self.is_draft:
+                self._init_decode_metadata_capture(bs, seq_lens)
+        else:
+            self._init_decode_metadata_capture(bs, seq_lens)
 
     def _init_decode_metadata_capture(self, bs: int, seq_lens: torch.Tensor):
         # cache_seqlens aliases seq_lens_buf (set in init_cuda_graph_state).
@@ -581,7 +541,7 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         self.cuda_graph_decode_metadata[bs] = metadata
         self.forward_decode_metadata = metadata
 
-    def _init_target_verify_metadata_capture(
+    def _init_multi_token_metadata_capture(
         self, bs: int, spec_num_tokens: int, seq_lens: torch.Tensor
     ):
         # cache_seqlens aliases seq_lens_buf; routes through the decode kernel.
@@ -610,6 +570,11 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         req_to_page: torch.Tensor = None,
         **kwargs,
     ):
+        if forward_mode.is_extend_or_mixed():
+            raise NotImplementedError(
+                f"trtllm CUDA graph replay not supported for {forward_mode}"
+            )
+
         # cache_seqlens aliases seq_lens_buf; only page_table needs refresh.
         if req_to_page is not None:
             torch.index_select(
@@ -619,23 +584,10 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
                 out=self.cuda_graph_page_table[:bs, : self.max_num_pages],
             )
 
-        if forward_mode.is_decode():
-            self._init_decode_metadata_replay(bs)
-        elif forward_mode.is_target_verify():
-            self._init_target_verify_metadata_replay(bs)
-        elif forward_mode.is_draft_extend():
-            self._init_target_verify_metadata_replay(bs)
-            self._init_decode_metadata_replay(bs)
-        else:
-            raise NotImplementedError(
-                f"trtllm CUDA graph replay not supported for {forward_mode}"
-            )
-
-    def _init_decode_metadata_replay(self, bs: int):
-        self.forward_decode_metadata = self.cuda_graph_decode_metadata[bs]
-
-    def _init_target_verify_metadata_replay(self, bs: int):
-        self.forward_prefill_metadata = self.cuda_graph_prefill_metadata[bs]
+        if bs in self.cuda_graph_prefill_metadata:
+            self.forward_prefill_metadata = self.cuda_graph_prefill_metadata[bs]
+        if bs in self.cuda_graph_decode_metadata:
+            self.forward_decode_metadata = self.cuda_graph_decode_metadata[bs]
 
 
 register_backend("trtllm", {AttentionArch.MHA}, TRTLLMMHAAttnBackend)

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
@@ -188,22 +188,7 @@ class TRTLLMMLABackend(AttentionBackend):
         spec_info=None,
         **kwargs,
     ):
-        use_decode_path = (
-            forward_mode.is_decode_or_idle()
-            or forward_mode.is_target_verify()
-            or forward_mode.is_draft_extend()
-        )
-        # Eagle drafter may call with forward_mode=EXTEND but without the
-        # prefill-specific kwargs (extend_prefix_lens, etc.).  Fall back to
-        # the decode metadata path for those calls.
-        if not use_decode_path and "extend_prefix_lens" not in kwargs:
-            use_decode_path = True
-
-        if use_decode_path:
-            self._init_decode_metadata(
-                bs, req_pool_indices, seq_lens, forward_mode, req_to_page, spec_info
-            )
-        else:
+        if forward_mode.is_extend_or_mixed():
             self._init_prefill_metadata(
                 seq_lens,
                 req_pool_indices=req_pool_indices,
@@ -212,6 +197,10 @@ class TRTLLMMLABackend(AttentionBackend):
                 extend_prefix_lens_cpu=kwargs.pop("extend_prefix_lens_cpu"),
                 extend_seq_lens=kwargs.pop("extend_seq_lens"),
                 extend_seq_lens_cpu=kwargs.pop("extend_seq_lens_cpu"),
+            )
+        else:
+            self._init_decode_metadata(
+                bs, req_pool_indices, seq_lens, forward_mode, req_to_page, spec_info
             )
 
     def _init_decode_metadata(
@@ -325,11 +314,7 @@ class TRTLLMMLABackend(AttentionBackend):
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode,
     ):
-        if (
-            not forward_mode.is_decode_or_idle()
-            and not forward_mode.is_target_verify()
-            and not forward_mode.is_draft_extend()
-        ):
+        if forward_mode.is_extend_or_mixed():
             raise NotImplementedError(
                 f"trtllm_mla CUDA graph capture not supported for {forward_mode}"
             )
@@ -357,11 +342,7 @@ class TRTLLMMLABackend(AttentionBackend):
         req_to_page: torch.Tensor = None,
         **kwargs,
     ):
-        if forward_mode is not None and (
-            not forward_mode.is_decode_or_idle()
-            and not forward_mode.is_target_verify()
-            and not forward_mode.is_draft_extend()
-        ):
+        if forward_mode is not None and forward_mode.is_extend_or_mixed():
             raise NotImplementedError(
                 f"trtllm_mla CUDA graph replay not supported for {forward_mode}"
             )
@@ -394,6 +375,7 @@ class TRTLLMMLABackend(AttentionBackend):
         layer: PagedAttention,
         out_cache_loc: torch.Tensor,
         token_to_kv_pool,
+        bs: int,
         save_kv_cache: bool = True,
         **kwargs,
     ) -> torch.Tensor:
@@ -407,10 +389,29 @@ class TRTLLMMLABackend(AttentionBackend):
                 k[..., self.kv_lora_rank :],
             )
 
-        # Prepare query: [bs, 1, H, head_dim]
-        query = q.view(-1, layer.tp_q_head_num, layer.head_dim).unsqueeze(1)
+        metadata = self.forward_decode_metadata
+        spec_num_tokens = q.shape[0] // bs if bs > 0 else 1
 
-        bmm1_scale = layer.scaling
+        if spec_num_tokens > 1 and self.is_draft:
+            # First draft step catching up its KV after verify: one query entry per token;
+            # per-token seq_lens advance by 1 so each successive token sees its own KV write.
+            query = q.view(-1, layer.tp_q_head_num, layer.head_dim).unsqueeze(1)
+            block_tables = metadata.block_kv_indices.repeat_interleave(
+                spec_num_tokens, dim=0
+            )
+            base_lens = metadata.seq_lens_k.repeat_interleave(spec_num_tokens)
+            offsets = torch.arange(
+                spec_num_tokens, device=base_lens.device, dtype=base_lens.dtype
+            ).repeat(bs)
+            seq_lens = base_lens + offsets
+            max_seq_len = metadata.max_seq_len_k + spec_num_tokens
+        else:
+            # Plain decode (q_len=1) or bs-grouped multi-token decode.
+            query = q.view(bs, -1, layer.tp_q_head_num, layer.head_dim)
+            block_tables = metadata.block_kv_indices
+            seq_lens = metadata.seq_lens_k
+            max_seq_len = metadata.max_seq_len_k
+
         if self.data_type == torch.float8_e4m3fn:
             query = query.to(self.data_type)
             k_scale = (
@@ -419,14 +420,13 @@ class TRTLLMMLABackend(AttentionBackend):
                 else 1.0
             )
             bmm1_scale = k_scale * layer.scaling
+        else:
+            bmm1_scale = layer.scaling
 
-        # Prepare KV cache: [num_pages, 1, page_size, kv_cache_dim]
         k_cache = token_to_kv_pool.get_key_buffer(layer.layer_id)
         if self.data_type != k_cache.dtype:
             k_cache = k_cache.to(self.data_type)
         kv_cache = k_cache.view(-1, self.page_size, self.kv_cache_dim).unsqueeze(1)
-
-        metadata = self.forward_decode_metadata
 
         raw_out = trtllm_batch_decode_with_kv_cache_mla(
             query=query,
@@ -435,58 +435,13 @@ class TRTLLMMLABackend(AttentionBackend):
             qk_nope_head_dim=self.qk_nope_head_dim,
             kv_lora_rank=self.kv_lora_rank,
             qk_rope_head_dim=self.qk_rope_head_dim,
-            block_tables=metadata.block_kv_indices,
-            seq_lens=metadata.seq_lens_k,
-            max_seq_len=metadata.max_seq_len_k,
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            max_seq_len=max_seq_len,
             bmm1_scale=bmm1_scale,
         )
 
         return raw_out.view(-1, layer.tp_q_head_num * layer.v_head_dim)
-
-    # ---- Forward: Extend/Prefill ----
-
-    def forward_extend(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        layer: PagedAttention,
-        out_cache_loc: torch.Tensor,
-        token_to_kv_pool,
-        save_kv_cache: bool = True,
-        forward_mode: ForwardMode = None,
-        **kwargs,
-    ):
-        if forward_mode is not None and forward_mode.is_target_verify():
-            return self._forward_target_verify(
-                q,
-                k,
-                v,
-                layer,
-                out_cache_loc,
-                token_to_kv_pool,
-                save_kv_cache,
-            )
-
-        # draft_extend: few tokens per request, use decode kernel.
-        # Unlike plain decode (1 token per request), draft_extend may have
-        # multiple tokens per request.  Expand per-request metadata so the
-        # decode kernel sees one entry per token.
-        if forward_mode is not None and forward_mode.is_draft_extend():
-            return self._forward_draft_extend(
-                q,
-                k,
-                v,
-                layer,
-                out_cache_loc,
-                token_to_kv_pool,
-                save_kv_cache,
-            )
-
-        # Regular prefill uses the ragged attention path.
-        return self._forward_trtllm_prefill(
-            q, k, v, layer, out_cache_loc, token_to_kv_pool, save_kv_cache
-        )
 
     def forward_extend_chunked(
         self,
@@ -557,223 +512,6 @@ class TRTLLMMLABackend(AttentionBackend):
         if isinstance(result, tuple):
             return result[0], result[1]
         return result, None
-
-    def _forward_target_verify(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        layer: PagedAttention,
-        out_cache_loc: torch.Tensor,
-        token_to_kv_pool,
-        save_kv_cache: bool = True,
-    ) -> torch.Tensor:
-        """Handle target_verify: multi-token query against paged KV (context + draft)."""
-        # q is whole Q [T, H, head_dim]; k is whole latent [T, 1, head_dim].
-        if save_kv_cache:
-            assert k is not None
-            token_to_kv_pool.set_mla_kv_buffer(
-                layer,
-                out_cache_loc,
-                k[..., : self.kv_lora_rank],
-                k[..., self.kv_lora_rank :],
-            )
-
-        # Reshape to [bs, q_len, H, head_dim] and cast to KV cache dtype (fp8).
-        # The kernel for tileSizeQ > 1 is only compiled for FP8+FP8; for single-
-        # token decode (tileSizeQ=1) BF16 query works, but not for multi-token verify.
-        bs = self.forward_decode_metadata.seq_lens_k.shape[0]
-        query = q.to(self.data_type).view(bs, -1, layer.tp_q_head_num, layer.head_dim)
-
-        # KV cache: [num_pages, 1, page_size, kv_cache_dim]
-        k_cache = token_to_kv_pool.get_key_buffer(layer.layer_id)
-        if self.data_type != k_cache.dtype:
-            k_cache = k_cache.to(self.data_type)
-        kv_cache = k_cache.view(-1, self.page_size, self.kv_cache_dim).unsqueeze(1)
-
-        # bmm1_scale = q_scale * k_scale * softmax_scale
-        if self.data_type == torch.float8_e4m3fn:
-            k_scale = (
-                layer.k_scale_float
-                if getattr(layer, "k_scale_float", None) is not None
-                else 1.0
-            )
-        else:
-            k_scale = 1.0
-        bmm1_scale = k_scale * layer.scaling
-
-        metadata = self.forward_decode_metadata
-        # max_seq_len must cover context + draft tokens
-        max_seq_len = metadata.max_seq_len_k
-
-        raw_out = trtllm_batch_decode_with_kv_cache_mla(
-            query=query,
-            kv_cache=kv_cache,
-            workspace_buffer=self.trtllm_workspace,
-            qk_nope_head_dim=self.qk_nope_head_dim,
-            kv_lora_rank=self.kv_lora_rank,
-            qk_rope_head_dim=self.qk_rope_head_dim,
-            block_tables=metadata.block_kv_indices,
-            seq_lens=metadata.seq_lens_k,
-            max_seq_len=max_seq_len,
-            bmm1_scale=bmm1_scale,
-        )
-
-        return raw_out.view(-1, layer.tp_q_head_num * layer.v_head_dim)
-
-    def _forward_draft_extend(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        layer: PagedAttention,
-        out_cache_loc: torch.Tensor,
-        token_to_kv_pool,
-        save_kv_cache: bool = True,
-    ) -> torch.Tensor:
-        """Handle DRAFT_EXTEND: multiple query tokens per request.
-
-        The fused MLA decode kernel expects one entry per query token.
-        We expand the per-request metadata (block tables, seq_lens) so
-        that each token gets its own entry, with seq_lens incremented
-        for successive tokens within the same request (causal masking).
-        """
-        # q is whole Q [T, H, head_dim]; k is whole latent [T, 1, head_dim].
-        if save_kv_cache:
-            assert k is not None
-            token_to_kv_pool.set_mla_kv_buffer(
-                layer,
-                out_cache_loc,
-                k[..., : self.kv_lora_rank],
-                k[..., self.kv_lora_rank :],
-            )
-
-        num_tokens = q.shape[0]
-        metadata = self.forward_decode_metadata
-        bs = metadata.block_kv_indices.shape[0]  # number of requests
-        tokens_per_req = num_tokens // bs if bs > 0 else num_tokens
-
-        # Prepare query: [num_tokens, 1, H, head_dim]
-        query = (
-            q.to(self.data_type)
-            .view(-1, layer.tp_q_head_num, layer.head_dim)
-            .unsqueeze(1)
-        )
-
-        # bmm1_scale
-        if self.data_type == torch.float8_e4m3fn:
-            k_scale = (
-                layer.k_scale_float
-                if getattr(layer, "k_scale_float", None) is not None
-                else 1.0
-            )
-        else:
-            k_scale = 1.0
-        bmm1_scale = k_scale * layer.scaling
-
-        # Prepare KV cache
-        k_cache = token_to_kv_pool.get_key_buffer(layer.layer_id)
-        if self.data_type != k_cache.dtype:
-            k_cache = k_cache.to(self.data_type)
-        kv_cache = k_cache.view(-1, self.page_size, self.kv_cache_dim).unsqueeze(1)
-
-        if tokens_per_req <= 1:
-            # Single token per request — same as normal decode
-            block_tables = metadata.block_kv_indices
-            seq_lens = metadata.seq_lens_k
-        else:
-            # Expand: repeat each request's block table for its tokens
-            block_tables = metadata.block_kv_indices.repeat_interleave(
-                tokens_per_req, dim=0
-            )
-            # Each successive token within a request sees one more KV entry
-            base_lens = metadata.seq_lens_k.repeat_interleave(tokens_per_req)
-            offsets = torch.arange(
-                tokens_per_req, device=base_lens.device, dtype=base_lens.dtype
-            ).repeat(bs)
-            seq_lens = base_lens + offsets
-
-        raw_out = trtllm_batch_decode_with_kv_cache_mla(
-            query=query,
-            kv_cache=kv_cache,
-            workspace_buffer=self.trtllm_workspace,
-            qk_nope_head_dim=self.qk_nope_head_dim,
-            kv_lora_rank=self.kv_lora_rank,
-            qk_rope_head_dim=self.qk_rope_head_dim,
-            block_tables=block_tables,
-            seq_lens=seq_lens,
-            max_seq_len=metadata.max_seq_len_k + tokens_per_req,
-            bmm1_scale=bmm1_scale,
-        )
-
-        return raw_out.view(-1, layer.tp_q_head_num * layer.v_head_dim)
-
-    def _forward_trtllm_prefill(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        layer: PagedAttention,
-        out_cache_loc: torch.Tensor,
-        token_to_kv_pool,
-        save_kv_cache: bool = True,
-    ):
-        # MLA prefill via the ragged kernel.
-        # q is whole Q [T, H, head_dim]; k is whole latent [T, 1, head_dim].
-        # This helper is currently unreachable (the live non-absorb prefill path
-        # goes through `forward_normal_chunked_kv_core` → `forward_extend_chunked`,
-        # not this entry point), but the KV write uses the MLA-correct API so it
-        # stays honest.
-        if save_kv_cache:
-            token_to_kv_pool.set_mla_kv_buffer(
-                layer,
-                out_cache_loc,
-                k[..., : self.kv_lora_rank],
-                k[..., self.kv_lora_rank :],
-            )
-
-        q = q.view(-1, layer.tp_q_head_num, layer.head_dim)
-        k = k.view(-1, layer.tp_k_head_num, layer.head_dim)
-        v = v.view(-1, layer.tp_k_head_num, layer.v_head_dim)
-
-        metadata = self.forward_prefill_metadata
-        bmm1_scale = layer.scaling
-
-        out = torch.zeros(
-            q.shape[0],
-            q.shape[1],
-            v.shape[2],
-            device=q.device,
-            dtype=self.q_data_type,
-        )
-
-        result = trtllm_ragged_attention_deepseek(
-            query=q,
-            key=k,
-            value=v,
-            workspace_buffer=self.trtllm_workspace,
-            seq_lens=metadata.seq_lens,
-            max_q_len=metadata.max_seq_len,
-            max_kv_len=metadata.max_seq_len,
-            bmm1_scale=bmm1_scale,
-            bmm2_scale=1.0,
-            o_sf_scale=-1.0,
-            batch_size=metadata.seq_lens.shape[0],
-            window_left=-1,
-            cum_seq_lens_q=metadata.cum_seq_lens,
-            cum_seq_lens_kv=metadata.cum_seq_lens,
-            enable_pdl=pdl_enabled(),
-            is_causal=True,
-            return_lse=False,
-            out=out,
-        )
-
-        if isinstance(result, tuple):
-            out = result[0]
-        else:
-            out = result
-
-        return out.view(-1, layer.tp_q_head_num * layer.v_head_dim)
 
 
 register_backend("trtllm_mla", {AttentionArch.MLA}, TRTLLMMLABackend)

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
@@ -336,6 +336,7 @@ class TRTLLMMLABackend(AttentionBackend):
     def init_forward_metadata_replay_cuda_graph(
         self,
         bs: int,
+        num_tokens: int,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode = None,

--- a/python/tokenspeed/runtime/layers/attention/configs/base.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/base.py
@@ -57,6 +57,7 @@ class BaseAttnConfig:
     kv_cache_quant_method: str
     speculative_num_steps: int = 0
     speculative_num_draft_tokens: int = 0
+    is_draft: bool = False
 
     @classmethod
     def generate(

--- a/python/tokenspeed/runtime/layers/attention/configs/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/mha.py
@@ -60,6 +60,7 @@ class MHAConfig(BaseAttnConfig):
             kv_cache_quant_method=server_args.kv_cache_quant_method,
             speculative_num_steps=server_args.speculative_num_steps,
             speculative_num_draft_tokens=server_args.speculative_num_draft_tokens,
+            is_draft=is_draft,
         )
 
     def cache_cell_size(self) -> int:

--- a/python/tokenspeed/runtime/layers/attention/configs/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/mla.py
@@ -67,6 +67,7 @@ class MLAConfig(BaseAttnConfig):
             kv_cache_quant_method=server_args.kv_cache_quant_method,
             speculative_num_steps=server_args.speculative_num_steps,
             speculative_num_draft_tokens=server_args.speculative_num_draft_tokens,
+            is_draft=is_draft,
             kv_lora_rank=model_config.kv_lora_rank,
             qk_nope_head_dim=model_config.qk_nope_head_dim,
             qk_rope_head_dim=model_config.qk_rope_head_dim,

--- a/python/tokenspeed/runtime/layers/logits_processor.py
+++ b/python/tokenspeed/runtime/layers/logits_processor.py
@@ -212,32 +212,32 @@ class LogitsProcessor(nn.Module):
         aux_hidden_states: torch.Tensor | None = None,
     ) -> LogitsProcessorOutput:
         # Get the last hidden states and last logits for the next token prediction
-        if (
-            logits_metadata.forward_mode.is_decode_or_idle()
-            or logits_metadata.forward_mode.is_target_verify()
-        ):
-            pruned_states = hidden_states
-            if aux_hidden_states is not None:
-                aux_pruned_states = [hidden for hidden in aux_hidden_states]
-            sample_indices = None
-            input_logprob_indices = None
-        elif (
-            logits_metadata.forward_mode.is_extend()
-            and not logits_metadata.extend_return_logprob
-        ):
-            # Prefill without input logprobs.
-            if logits_metadata.padded_static_len < 0:
+        if not logits_metadata.extend_return_logprob:
+            if logits_metadata.forward_mode.is_extend_or_mixed():
+                # Prefill: last token of each request via cumulative seq lens.
                 last_index = torch.cumsum(logits_metadata.extend_seq_lens, dim=0) - 1
-            else:
-                # If padding_static length is 5 and extended_seq_lens is [2, 3],
-                # then our batch looks like [t00, t01, p, p, p, t10, t11, t12, p, p]
-                # and this retrieves t01 and t12, which are the valid last tokens
+                pruned_states = hidden_states[last_index]
+                if aux_hidden_states is not None:
+                    aux_pruned_states = [
+                        hidden[last_index] for hidden in aux_hidden_states
+                    ]
+            elif logits_metadata.padded_static_len > 0:
+                # Padded per-request layout: pick the last valid token per
+                # request using the precomputed offsets.
                 last_index = (
                     logits_metadata.last_index_offsets + logits_metadata.extend_seq_lens
                 )
-            pruned_states = hidden_states[last_index]
-            if aux_hidden_states is not None:
-                aux_pruned_states = [hidden[last_index] for hidden in aux_hidden_states]
+                pruned_states = hidden_states[last_index]
+                if aux_hidden_states is not None:
+                    aux_pruned_states = [
+                        hidden[last_index] for hidden in aux_hidden_states
+                    ]
+            else:
+                # One row per request already — no indexing needed.
+                pruned_states = hidden_states
+                if aux_hidden_states is not None:
+                    aux_pruned_states = [hidden for hidden in aux_hidden_states]
+
             sample_indices = None
             input_logprob_indices = None
         else:

--- a/python/tokenspeed/runtime/layers/paged_attention.py
+++ b/python/tokenspeed/runtime/layers/paged_attention.py
@@ -84,6 +84,7 @@ class PagedAttention(nn.Module):
             out_cache_loc,
             ctx.token_to_kv_pool,
             ctx.forward_mode,
+            ctx.bs,
             save_kv_cache,
             **kwargs,
         )

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -613,25 +613,17 @@ class DeepseekV3AttentionMLA(nn.Module):
 
     def no_absorb(self, ctx: ForwardContext) -> bool:
         if self.attention_backend in self._MLA_KERNEL_BACKENDS:
-            # MLA kernel backends: Do not absorb when enabling ragged prefill
-            # Target verify and draft extend have few tokens, go through absorb.
+            # MLA kernel backends: do not absorb when ragged prefill is enabled.
             return (
                 not global_server_args_dict["mla_disable_ragged"]
-                and ctx.forward_mode.is_extend()
-                and not ctx.forward_mode.is_target_verify()
-                and not ctx.forward_mode.is_draft_extend()
+                and ctx.forward_mode.is_extend_or_mixed()
                 and ctx.padded_static_len == -1
             )
         else:
-            # Triton: Use normal computation for pure prefill and use weight absorption otherwise.
-            # Note: extend_prefix_lens_cpu not available in ForwardContext, so we skip the
-            # "no prefix cache" check. This is conservative — always absorb for Triton.
-            return (
-                ctx.forward_mode.is_extend()
-                and not ctx.forward_mode.is_target_verify()
-                and not ctx.forward_mode.is_draft_extend()
-                and ctx.padded_static_len == -1
-            )
+            # Triton: skip absorption on pure prefill, absorb otherwise.
+            # `extend_prefix_lens_cpu` is not on ForwardContext, so the
+            # "no prefix cache" guard is conservative — always absorb.
+            return ctx.forward_mode.is_extend_or_mixed() and ctx.padded_static_len == -1
 
     def forward(
         self,

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -5485,7 +5485,7 @@ class DeepseekV4Attention(nn.Module):
         elif (
             backend_prefill is not None
             and ctx.forward_mode is not None
-            and ctx.forward_mode.is_extend()
+            and ctx.forward_mode.is_extend_or_mixed()
         ):
             with deepseek_v4_profile_scope(f"{profile_prefix}_prefill_backend"):
                 attn_output = backend_prefill(

--- a/python/tokenspeed/runtime/models/qwen3_5.py
+++ b/python/tokenspeed/runtime/models/qwen3_5.py
@@ -420,6 +420,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             out_cache_loc=None,
             token_to_kv_pool=ctx.token_to_kv_pool,
             forward_mode=ctx.forward_mode,
+            bs=ctx.bs,
             **kwargs,
         )
 

--- a/test/agentic_benchmark/tokenspeed/agentic_bench.sh
+++ b/test/agentic_benchmark/tokenspeed/agentic_bench.sh
@@ -42,7 +42,7 @@ launch_server() {
 wait_for_ready() {
     local TIMEOUT=600
     local START=$SECONDS
-    until curl -sf -o /dev/null http://localhost:8000/readiness; do
+    until curl -sf -o /dev/null http://127.0.0.1:8000/readiness; do
         if ! kill -0 "$SERVER_PID" 2>/dev/null; then
             echo "Server died early. Last log lines:" >&2
             tail -100 "$SERVER_LOG" >&2
@@ -79,7 +79,7 @@ wait_for_port_free() {
     local port=${1:-8000}
     local timeout=${2:-90}
     local start=$SECONDS
-    while ! python3 -c "import socket; s=socket.socket(); s.bind(('localhost', $port)); s.close()" 2>/dev/null; do
+    while ! python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1', $port)); s.close()" 2>/dev/null; do
         if (( SECONDS - start > timeout )); then
             echo "Port ${port} still in use after ${timeout}s" >&2
             return 1
@@ -109,7 +109,7 @@ for CONFIG in "${CONFIGS[@]}"; do
     echo "Warmup..."
     evalscope perf \
         --model nvidia/Kimi-K2.5-NVFP4 \
-        --url http://localhost:8000/v1/chat/completions \
+        --url http://127.0.0.1:8000/v1/chat/completions \
         --api openai \
         --dataset swe_smith \
         --dataset-path agentic_dataset.json \
@@ -124,7 +124,7 @@ for CONFIG in "${CONFIGS[@]}"; do
     echo "Benchmark..."
     evalscope perf \
         --model nvidia/Kimi-K2.5-NVFP4 \
-        --url http://localhost:8000/v1/chat/completions \
+        --url http://127.0.0.1:8000/v1/chat/completions \
         --api openai \
         --dataset swe_smith \
         --dataset-path agentic_dataset.json \

--- a/test/agentic_benchmark/tokenspeed/configs/attn_dp8_moe_ep8.sh
+++ b/test/agentic_benchmark/tokenspeed/configs/attn_dp8_moe_ep8.sh
@@ -25,6 +25,6 @@ exec ts serve \
     --speculative-draft-model-quantization unquant \
     --drafter-attention-backend trtllm_mla \
     --enable-cache-report \
-    --host localhost \
+    --host 127.0.0.1 \
     --port 8000 \
-    --dist-init-addr localhost:4000
+    --dist-init-addr 127.0.0.1:4000

--- a/test/agentic_benchmark/tokenspeed/configs/attn_dp8_moe_tp8.sh
+++ b/test/agentic_benchmark/tokenspeed/configs/attn_dp8_moe_tp8.sh
@@ -25,6 +25,6 @@ exec ts serve \
     --speculative-draft-model-quantization unquant \
     --drafter-attention-backend trtllm_mla \
     --enable-cache-report \
-    --host localhost \
+    --host 127.0.0.1 \
     --port 8000 \
-    --dist-init-addr localhost:4000
+    --dist-init-addr 127.0.0.1:4000

--- a/test/agentic_benchmark/tokenspeed/configs/attn_tp4_moe_ep4.sh
+++ b/test/agentic_benchmark/tokenspeed/configs/attn_tp4_moe_ep4.sh
@@ -25,5 +25,5 @@ exec ts serve \
     --speculative-draft-model-quantization unquant \
     --drafter-attention-backend tokenspeed_mla \
     --enable-cache-report \
-    --host localhost \
+    --host 127.0.0.1 \
     --port 8000

--- a/test/agentic_benchmark/tokenspeed/configs/attn_tp4_moe_tp4.sh
+++ b/test/agentic_benchmark/tokenspeed/configs/attn_tp4_moe_tp4.sh
@@ -25,5 +25,5 @@ exec ts serve \
     --speculative-draft-model-quantization unquant \
     --drafter-attention-backend tokenspeed_mla \
     --enable-cache-report \
-    --host localhost \
+    --host 127.0.0.1 \
     --port 8000

--- a/test/agentic_benchmark/tokenspeed/configs/attn_tp8_moe_ep8.sh
+++ b/test/agentic_benchmark/tokenspeed/configs/attn_tp8_moe_ep8.sh
@@ -25,5 +25,5 @@ exec ts serve \
     --speculative-draft-model-quantization unquant \
     --drafter-attention-backend tokenspeed_mla \
     --enable-cache-report \
-    --host localhost \
+    --host 127.0.0.1 \
     --port 8000

--- a/test/agentic_benchmark/tokenspeed/configs/attn_tp8_moe_tp8.sh
+++ b/test/agentic_benchmark/tokenspeed/configs/attn_tp8_moe_tp8.sh
@@ -25,5 +25,5 @@ exec ts serve \
     --speculative-draft-model-quantization unquant \
     --drafter-attention-backend tokenspeed_mla \
     --enable-cache-report \
-    --host localhost \
+    --host 127.0.0.1 \
     --port 8000

--- a/test/agentic_benchmark/trtllm/agentic_bench.sh
+++ b/test/agentic_benchmark/trtllm/agentic_bench.sh
@@ -45,7 +45,7 @@ launch_server() {
         --enable_chunked_prefill \
         --trust_remote_code \
         --config "${SCRIPT_DIR}/configs/${config}.yaml" \
-        --host localhost \
+        --host 127.0.0.1 \
         --port 8001 \
         > "$SERVER_LOG" 2>&1 &
     SERVER_PID=$!
@@ -54,7 +54,7 @@ launch_server() {
 wait_for_ready() {
     local TIMEOUT=600
     local START=$SECONDS
-    until curl -sf -o /dev/null http://localhost:8001/health; do
+    until curl -sf -o /dev/null http://127.0.0.1:8001/health; do
         if ! kill -0 "$SERVER_PID" 2>/dev/null; then
             echo "Server died early. Last log lines:" >&2
             tail -100 "$SERVER_LOG" >&2
@@ -91,7 +91,7 @@ wait_for_port_free() {
     local port=${1:-8001}
     local timeout=${2:-90}
     local start=$SECONDS
-    while ! python3 -c "import socket; s=socket.socket(); s.bind(('localhost', $port)); s.close()" 2>/dev/null; do
+    while ! python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1', $port)); s.close()" 2>/dev/null; do
         if (( SECONDS - start > timeout )); then
             echo "Port ${port} still in use after ${timeout}s" >&2
             return 1
@@ -121,7 +121,7 @@ for CONFIG in "${CONFIGS[@]}"; do
     echo "Warmup..."
     evalscope perf \
         --model nvidia/Kimi-K2.5-NVFP4 \
-        --url http://localhost:8001/v1/chat/completions \
+        --url http://127.0.0.1:8001/v1/chat/completions \
         --api openai \
         --dataset swe_smith \
         --dataset-path agentic_dataset.json \
@@ -136,7 +136,7 @@ for CONFIG in "${CONFIGS[@]}"; do
     echo "Benchmark..."
     evalscope perf \
         --model nvidia/Kimi-K2.5-NVFP4 \
-        --url http://localhost:8001/v1/chat/completions \
+        --url http://127.0.0.1:8001/v1/chat/completions \
         --api openai \
         --dataset swe_smith \
         --dataset-path agentic_dataset.json \

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -94,12 +94,14 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertTrue(ForwardMode.MIXED.is_mixed())
         self.assertFalse(ForwardMode.EXTEND.is_mixed())
         self.assertFalse(ForwardMode.DECODE.is_mixed())
+        self.assertTrue(ForwardMode.EXTEND.is_extend_or_mixed())
+        self.assertTrue(ForwardMode.MIXED.is_extend_or_mixed())
+        self.assertFalse(ForwardMode.DECODE.is_extend_or_mixed())
+        self.assertTrue(ForwardMode.DECODE.is_decode_or_idle())
+        self.assertTrue(ForwardMode.IDLE.is_decode_or_idle())
+        self.assertFalse(ForwardMode.EXTEND.is_decode_or_idle())
         self.assertEqual(ForwardMode.from_num_extends(0, 0), ForwardMode.IDLE)
         self.assertEqual(ForwardMode.from_num_extends(0, 2), ForwardMode.DECODE)
-        self.assertEqual(
-            ForwardMode.from_num_extends(0, 2, has_drafter=True),
-            ForwardMode.TARGET_VERIFY,
-        )
         self.assertEqual(ForwardMode.from_num_extends(2, 2), ForwardMode.EXTEND)
         self.assertEqual(ForwardMode.from_num_extends(1, 2), ForwardMode.MIXED)
 
@@ -127,6 +129,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         wrapper = object.__new__(CudaGraphWrapper)
         wrapper.attn_backend = FakeBackend()
         wrapper.draft_attn_backend = None
+        wrapper.max_tokens_per_req = 1
 
         wrapper._init_replay_metadata(
             padded_bs=4,
@@ -140,6 +143,8 @@ class TestDeepseekV4Config(unittest.TestCase):
             },
         )
 
+        # num_tokens = padded_bs * max_tokens_per_req is passed as 2nd positional.
+        self.assertEqual(captured["args"][1], 4)
         self.assertEqual(captured["kwargs"]["actual_bs"], 0)
         self.assertEqual(
             captured["kwargs"]["paged_cache_block_tables"]["v4.swa"].shape,
@@ -751,6 +756,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_kv_heads=1,
                 attn_tp_size=1,
                 dtype=torch.bfloat16,
+                is_draft=False,
                 head_dim=512,
                 context_len=4096,
             )
@@ -784,6 +790,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_kv_heads=1,
                 attn_tp_size=1,
                 dtype=torch.bfloat16,
+                is_draft=False,
                 head_dim=512,
                 context_len=4096,
             )
@@ -823,6 +830,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_kv_heads=1,
                 attn_tp_size=1,
                 dtype=torch.bfloat16,
+                is_draft=False,
                 head_dim=512,
                 context_len=4096,
             )
@@ -863,6 +871,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_kv_heads=1,
                 attn_tp_size=1,
                 dtype=torch.bfloat16,
+                is_draft=False,
                 head_dim=512,
                 context_len=4096,
             )
@@ -928,6 +937,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_kv_heads=1,
                 attn_tp_size=1,
                 dtype=torch.bfloat16,
+                is_draft=False,
                 head_dim=512,
                 context_len=4096,
             )
@@ -1127,6 +1137,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_kv_heads=1,
                 attn_tp_size=1,
                 dtype=torch.bfloat16,
+                is_draft=False,
                 head_dim=576,
                 context_len=256,
             )
@@ -1212,6 +1223,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_kv_heads=1,
                 attn_tp_size=1,
                 dtype=torch.bfloat16,
+                is_draft=False,
                 head_dim=576,
                 context_len=256,
             )
@@ -1256,6 +1268,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_kv_heads=1,
                 attn_tp_size=1,
                 dtype=torch.bfloat16,
+                is_draft=False,
                 head_dim=576,
                 context_len=256,
             )
@@ -1349,6 +1362,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_kv_heads=1,
                 attn_tp_size=1,
                 dtype=torch.bfloat16,
+                is_draft=False,
                 head_dim=512,
                 context_len=128,
             )
@@ -1434,6 +1448,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_kv_heads=1,
                 attn_tp_size=1,
                 dtype=torch.bfloat16,
+                is_draft=False,
                 head_dim=512,
                 context_len=128,
             )
@@ -1494,6 +1509,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_kv_heads=1,
                 attn_tp_size=1,
                 dtype=torch.bfloat16,
+                is_draft=False,
                 head_dim=512,
                 context_len=1024,
             )
@@ -1617,6 +1633,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_kv_heads=1,
                 attn_tp_size=1,
                 dtype=torch.bfloat16,
+                is_draft=False,
                 head_dim=512,
                 context_len=128,
             )
@@ -1680,6 +1697,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_kv_heads=1,
                 attn_tp_size=1,
                 dtype=torch.bfloat16,
+                is_draft=False,
                 head_dim=512,
                 context_len=128,
             )

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -1695,6 +1695,7 @@ class TestDeepseekV4Config(unittest.TestCase):
 
         backend.init_forward_metadata_replay_cuda_graph(
             bs=4,
+            num_tokens=4,
             actual_bs=2,
             req_pool_indices=torch.arange(4, dtype=torch.int32),
             seq_lens=torch.tensor([70, 3, 1, 1], dtype=torch.int32),


### PR DESCRIPTION
## Summary

  This is a prerequisite for a large-scale enabledment of mixed prefill&decode batching.

  Collapse `ForwardMode.TARGET_VERIFY` and `ForwardMode.DRAFT_EXTEND` into `DECODE`. Backends now dispatch on `config.is_draft` + `spec_num_tokens = num_tokens // bs` instead of separate enum values — `TARGET_VERIFY` is `not is_draft and spec_num_tokens > 1`, `DRAFT_EXTEND` is `is_draft and spec_num_tokens > 1`. The enum keeps only `EXTEND`, `DECODE`, `MIXED`, `IDLE`.

  ### Why

  The old enum split a single concept (decode with variable q_len) across three values and required the controller to know about drafter state to pick the right one. The new split is local to each backend, and drafter vs. target is already a static property of the backend's config.

  ### Changes

  - `ForwardMode`: remove `TARGET_VERIFY` / `DRAFT_EXTEND`; drop `has_drafter` from `from_num_extends`; add `is_extend_or_mixed()` helper.
  - `BaseAttnConfig.is_draft: bool` (defaults to `False`); `AttentionBackend.__init__` reads it.
  - `init_forward_metadata_replay_cuda_graph` signature: `num_tokens` becomes the 2nd positional, so backends can compute `spec_num_tokens` without mode-specific signals.
  - `CudaGraphWrapper`: capture/replay always uses `ForwardMode.DECODE`; passes `padded_bs * max_tokens_per_req` as `num_tokens` for target and drafter alike.
  - All 10 attention backends migrated (flash_attention, flashmla, trtllm, trtllm_mla, mha, triton, tokenspeed_mla, deepseek_v4, hybrid_linear_attn, base) using consistent local-predicate renames. `trtllm_mla` / `tokenspeed_mla`: drop `forward_extend` — old verify/draft-extend paths now route through `forward_decode` based on `spec_num_tokens > 1`.
  - `Eagle` drafter, `LogitsProcessor`, `EventLoop`, `ModelExecutor`: drop mode-specific branches in favor of `is_decode()` / `is_extend_or_mixed()`.
