### PR TITLE
fix(cache): emit AllBlocksCleared on reset only, not every match_prefix

### DIFF
--- a/python/tokenspeed/runtime/cache/prefix_cache.py
+++ b/python/tokenspeed/runtime/cache/prefix_cache.py
@@ -186,6 +186,9 @@ class PrefixCache(BasePrefixCache):
         self.protected_size_ = 0
         self.evictable_leaves: set[TreeNode] = set()
 
+        if self.enable_kv_cache_events and KV_EVENTS_AVAILABLE:
+            self.kv_event_queue.append(AllBlocksCleared())
+
     def match_prefix(self, key: list, **kwargs) -> MatchResult:
         """Find the matching prefix from the prefix tree.
         Args:
@@ -198,9 +201,6 @@ class PrefixCache(BasePrefixCache):
             than the last node's value.
         """
 
-        # Emit AllBlocksCleared event when cache is reset
-        if self.enable_kv_cache_events and KV_EVENTS_AVAILABLE:
-            self.kv_event_queue.append(AllBlocksCleared())
         if self.disable or len(key) == 0:
             return self._empty_match_result()
 


### PR DESCRIPTION
## Summary

`AllBlocksCleared` KV cache event was being emitted on every `match_prefix()` call instead of on actual cache resets. `match_prefix` is a read-only lookup invoked on every decode step, so subscribers got phantom "cache cleared" events constantly.

Trigger:
- `--enable-kv-cache-events` is on
- A subscriber consumes KV cache events (Prometheus / dashboard)

Symptom: real `BlockRemoved` events get drowned out by phantom `AllBlocksCleared` spam. Model output is unaffected; observability breaks.

Fix: move the 2-line emit from `match_prefix()` into `reset()`, where the existing comment already said it belongs (`# Emit AllBlocksCleared event when cache is reset`).

## Test Plan

No automated test — the diff is a 3-line move within `prefix_cache.py` with no behavior change for users not using KV cache events.

Manual verification: enable `--enable-kv-cache-events`, send requests, inspect the event stream. Before: `AllBlocksCleared` emitted per decode step. After: only on actual cache reset.
