### PR TITLE
perf(cache): keep page-id tensors on GPU through free_group_end

### DIFF
--- a/python/tokenspeed/runtime/cache/allocator.py
+++ b/python/tokenspeed/runtime/cache/allocator.py
@@ -125,7 +125,7 @@ class KVAllocator:
         page_ids_to_free = self.req_to_page[
             req_pool_index, full_page_num : full_page_num + page_num_to_free
         ]
-        self.need_to_free.append(page_ids_to_free.cpu())
+        self.need_to_free.append(page_ids_to_free)
 
     def free_req_cache(self, req_pool_index: int, alloced_len: int):
         """Release all pages of the request when prefix cache is not used."""
@@ -133,7 +133,7 @@ class KVAllocator:
         if alloced_page_num == 0:
             return
         page_ids_to_free = self.req_to_page[req_pool_index, :alloced_page_num]
-        self.need_to_free.append(page_ids_to_free.cpu())
+        self.need_to_free.append(page_ids_to_free)
 
     def free_with_diff(self, new_prefix_page_ids, old_page_ids):
         # New KV pages come from the prefix tree and are already cached, so only
@@ -146,7 +146,7 @@ class KVAllocator:
             logger.debug(
                 "[DebugTrace] free_with_diff free page=%s", old_page_ids[diff].tolist()
             )
-            self.need_to_free.append(old_page_ids[diff].cpu())
+            self.need_to_free.append(old_page_ids[diff])
         else:
             logger.debug(
                 "[DebugTrace] free_with_diff: no pages to free, all pages are cached"
@@ -154,7 +154,7 @@ class KVAllocator:
         return diff
 
     def append_to_later_free(self, page_ids: torch.Tensor) -> None:
-        self.need_to_free.append(page_ids.cpu())
+        self.need_to_free.append(page_ids)
 
     def free(self, req_pool_index: int, indices=None) -> None:
         if self.is_not_in_free_group:
@@ -184,15 +184,13 @@ class KVAllocator:
                 "[DebugTrace] free_group_end pages_need_to_free=%s",
                 pages_need_to_free.tolist(),
             )
-            token_level_offsets = torch.arange(self.page_size)
+            token_level_offsets = torch.arange(self.page_size, device=self.device)
             slots_to_free = (
-                (pages_need_to_free[:, None] * self.page_size + token_level_offsets)
-                .flatten()
-                .to(self.device)
-            )
+                pages_need_to_free[:, None] * self.page_size + token_level_offsets
+            ).flatten()
             writted_positions = slots_to_free[self.token_slot_refs[slots_to_free] >= 1]
             self.token_slot_refs[writted_positions] += -1
-            self.free_slots = torch.concat([self.free_slots] + self.need_to_free)
+            self.free_slots = torch.concat([self.free_slots, pages_need_to_free.cpu()])
             self.need_to_free = []
 
     def clear(self) -> None:

--- a/test/runtime/cache/test_kv_allocator.py
+++ b/test/runtime/cache/test_kv_allocator.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tokenspeed.runtime.cache.allocator import KVAllocator
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="cuda required")
+def test_free_group_end_returns_freed_pages_to_free_slots():
+    """free_extra_pages_not_cached + free_group_end should push the freed
+    page ids back onto free_slots and decrement token_slot_refs."""
+    page_size = 4
+    max_pages = 8
+    total_slots = max_pages * page_size
+
+    allocator = KVAllocator(
+        size=total_slots,
+        device="cuda",
+        max_batch_size=2,
+        max_context_len=total_slots,
+        page_size=page_size,
+    )
+
+    # Assign known pages [1, 5, 6] to request 0
+    allocator.req_to_page[0, :3] = torch.tensor(
+        [1, 5, 6], dtype=torch.int32, device="cuda"
+    )
+    for page in (1, 5, 6):
+        allocator.token_slot_refs[page * page_size : (page + 1) * page_size] = 1
+
+    initial_free_count = allocator.free_slots.numel()
+
+    # alloced_len=12 covers 3 pages; real_seq_len=4 keeps 1 -> free pages [5, 6]
+    allocator.free_extra_pages_not_cached(
+        req_pool_index=0, real_seq_len=page_size, alloced_len=3 * page_size
+    )
+    allocator.free_group_end()
+
+    assert allocator.free_slots.numel() == initial_free_count + 2
+    freed_pages = set(allocator.free_slots[initial_free_count:].tolist())
+    assert freed_pages == {5, 6}
+    for page in (5, 6):
+        slot_refs = allocator.token_slot_refs[page * page_size : (page + 1) * page_size]
+        assert (slot_refs == 0).all()


### PR DESCRIPTION
## Summary

`KVAllocator` queued every per-request free as a `.cpu()`-copied tensor and ran the page-to-slot expansion through a `.to(self.device)` round-trip. This is 1 D2H sync per `free_*` call plus 1 H2D sync per `free_group_end()`. For batches with many concurrent request completions this dominates the free path.

Keep queued page-id tensors on GPU, compute `slots_to_free` directly on the device, and pay one D2H only at the end where `free_slots` (CPU arange) gets extended.

Microbench on B200 with N requests finishing in one batch step (each calling `free_extra_pages_not_cached(pages_per_req)` then `free_group_end()`), 500 iters:

| batch | pages/req | before (µs) | after (µs) | speedup |
|-------|-----------|-------------|------------|---------|
|    16 |        32 |         315 |        117 |   2.70x |
|    32 |        16 |        1972 |        778 |   2.54x |
|    64 |         8 |        5743 |       1198 |   4.80x |
|   128 |         4 |       10126 |       1995 |   5.08x |
|   256 |         2 |       19510 |       3183 |   6.13x |

## Test Plan

```
pytest test/runtime/cache/test_kv_allocator.py
```
