### PR TITLE
fix: detect GPU arch automatically for kernel building

### DIFF
--- a/tokenspeed-kernel/python/setup.py
+++ b/tokenspeed-kernel/python/setup.py
@@ -453,6 +453,30 @@ class CudaKernelBuilder:
             archs.add(self._normalize_cuda_arch(direct))
             return archs
 
+        # Try detecting from the NVIDIA driver.
+        if not archs:
+            try:
+                caps = (
+                    subprocess.check_output(
+                        [
+                            "nvidia-smi",
+                            "--query-gpu=compute_cap",
+                            "--format=csv,noheader",
+                        ],
+                        text=True,
+                        stderr=subprocess.DEVNULL,
+                    )
+                    .strip()
+                    .splitlines()
+                )
+                for cap in caps:
+                    cap = cap.strip()
+                    if cap:
+                        archs.add(self._normalize_cuda_arch(cap + "a"))
+            except (OSError, subprocess.CalledProcessError):
+                pass
+
+        # Fallback: Blackwell
         if not archs:
             archs.add("100a")
         return archs

--- a/tokenspeed-kernel/python/setup.py
+++ b/tokenspeed-kernel/python/setup.py
@@ -472,7 +472,7 @@ class CudaKernelBuilder:
                 for cap in caps:
                     cap = cap.strip()
                     if cap:
-                        archs.add(self._normalize_cuda_arch(cap + "a"))
+                        archs.add(self._normalize_cuda_arch(cap))
             except (OSError, subprocess.CalledProcessError):
                 pass
 


### PR DESCRIPTION
## Summary

Detect GPU architecture automatically while building `tokenspeed-kernel`.

## Test Plan

1. (Old flow) Built kernel on GH200, however sm100a is not comptible by default, so I get `[ts] RuntimeError: Check failed: (status == cudaSuccess) is false: BatchQKApplyRotaryPosIdsCosSinCacheEnhanced failed with error code no kernel image is available for execution on the device` while running gpt-oss-20b.
2. (New flow) Clear packages, cache and re-run `pip install -e tokenspeed-kernel/python/ --no-build-isolation`. The GPU architecture is automatically detected without setting `FLASHINFER_CUDA_ARCH_LIST` or `TOKENSPEED_CUDA_ARCH` (which also fixes the issue).