### PR TITLE
fix(deepseek-v4): corrected profiling to estimate cache capacity. 

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
@@ -128,6 +128,142 @@ class DeepseekV4CacheLayout:
         return cell_size
 
 
+def _estimate_deepseek_v4_cache_bytes(
+    *,
+    layout: DeepseekV4CacheLayout,
+    hf_config: Any,
+    layer_num: int,
+    max_total_tokens: int,
+    max_live_requests: int,
+    max_scheduled_tokens: int,
+    max_context_len: int,
+) -> int:
+    """Estimate bytes allocated by DeepseekV4TokenToKVPool for a token budget."""
+    if layer_num > len(layout.layer_ratio):
+        raise ValueError(
+            "DeepSeek V4 cache layout has fewer layer ratios "
+            f"({len(layout.layer_ratio)}) than requested layers ({layer_num})"
+        )
+    if max_total_tokens < 0:
+        raise ValueError(f"max_total_tokens must be >= 0, got {max_total_tokens}")
+
+    specs = tuple(build_v4_cache_specs(hf_config, layer_ratio=layout.layer_ratio))
+    counts = compute_paged_cache_group_page_counts(
+        specs,
+        max_live_requests=max_live_requests,
+        max_scheduled_tokens=max(0, int(max_scheduled_tokens)),
+        max_total_tokens=max_total_tokens,
+        max_context_len=max_context_len,
+    )
+    group_rows = {spec.group_id: int(spec.rows_per_page) for spec in specs}
+
+    fp32_size = torch._utils._element_size(torch.float32)
+    total = 0
+    swa_pages = int(counts[V4_SWA_KV_GROUP_ID])
+    swa_block_bytes = layout.swa_block_bytes(
+        group_rows.get(V4_SWA_KV_GROUP_ID, V4_KERNEL_BLOCK_ROWS)
+    )
+
+    for layer_id, ratio in enumerate(layout.layer_ratio[:layer_num]):
+        total += swa_pages * swa_block_bytes
+        if ratio <= 1:
+            continue
+
+        compressed_pages = int(counts[v4_compressed_kv_group_id(ratio)])
+        compressed_block_size = layout.storage_block_size(ratio)
+        total += compressed_pages * layout.swa_block_bytes(compressed_block_size)
+
+        state_pages = int(counts[v4_compressor_state_group_id(ratio)])
+        state_block_size = group_rows.get(
+            v4_compressor_state_group_id(ratio), layout.page_size
+        )
+        total += (
+            state_pages
+            * state_block_size
+            * layout.state_width(layer_id)
+            * 2
+            * fp32_size
+        )
+
+        if ratio == 4:
+            indexer_block_size = max(V4_KERNEL_BLOCK_ROWS, compressed_block_size)
+            total += compressed_pages * indexer_block_size * layout.indexer_row_bytes
+
+            indexer_state_pages = int(counts[V4_INDEXER_COMPRESSOR_STATE_GROUP_ID])
+            indexer_state_block_size = group_rows.get(
+                V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
+                layout.compressor_state_block_size(ratio),
+            )
+            total += (
+                indexer_state_pages
+                * indexer_state_block_size
+                * layout.state_width(layer_id, indexer=True)
+                * 2
+                * fp32_size
+            )
+
+    return int(total)
+
+
+def profile_deepseek_v4_max_num_pages(
+    *,
+    layout: DeepseekV4CacheLayout,
+    hf_config: Any,
+    layer_num: int,
+    max_live_requests: int,
+    max_scheduled_tokens: int,
+    max_context_len: int,
+    available_cache_memory_bytes: int,
+    draft_cache_cell_size: int = 0,
+) -> int:
+    """Return the largest scheduler page budget that fits V4 grouped caches."""
+    page_size = int(layout.page_size)
+    if page_size <= 0:
+        raise ValueError(f"page_size must be positive, got {page_size}")
+    if available_cache_memory_bytes <= 0:
+        return 0
+    if draft_cache_cell_size < 0:
+        raise ValueError(
+            f"draft_cache_cell_size must be >= 0, got {draft_cache_cell_size}"
+        )
+
+    def _bytes_for_pages(num_pages: int) -> int:
+        num_tokens = int(num_pages) * page_size
+        return (
+            _estimate_deepseek_v4_cache_bytes(
+                layout=layout,
+                hf_config=hf_config,
+                layer_num=layer_num,
+                max_total_tokens=num_tokens,
+                max_live_requests=max_live_requests,
+                max_scheduled_tokens=max_scheduled_tokens,
+                max_context_len=max_context_len,
+            )
+            + num_tokens * draft_cache_cell_size
+        )
+
+    if _bytes_for_pages(1) > available_cache_memory_bytes:
+        return 0
+
+    if not any(int(ratio) > 1 for ratio in layout.layer_ratio[:layer_num]):
+        return max(
+            1,
+            (int(max_live_requests) * int(max_context_len) + page_size - 1)
+            // page_size,
+        )
+    high = 1
+    while _bytes_for_pages(high) <= available_cache_memory_bytes:
+        high *= 2
+    low = high // 2
+    while low + 1 < high:
+        mid = (low + high) // 2
+        if _bytes_for_pages(mid) <= available_cache_memory_bytes:
+            low = mid
+        else:
+            high = mid
+    return int(low)
+
+
 def _split_paged_cache_block_tables_into_v4_metadata(
     paged_cache_block_tables: dict[str, torch.Tensor],
     paged_cache_block_table_base_offsets: dict[str, torch.Tensor] | None = None,

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -31,6 +31,7 @@ from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.kv_cache.base import BaseTokenToKVPool
 from tokenspeed.runtime.layers.attention.utils import (
+    profile_available_cache_memory_bytes,
     profile_cache_budget,
     profile_max_num_pages,
 )
@@ -359,7 +360,6 @@ def create_attn_components(
                 server_args, model_config.hf_config
             ),
         )
-        profile_cache_cell_size = deepseek_v4_layout.cache_cell_size(num_layers)
 
     hf_config = getattr(model_config, "hf_config", None)
     text_config = getattr(hf_config, "text_config", hf_config) if hf_config else None
@@ -387,7 +387,48 @@ def create_attn_components(
         ),
     )
 
-    if has_mamba and server_args.max_mamba_cache_size is not None:
+    if is_deepseek_v4_model:
+        from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
+            profile_deepseek_v4_max_num_pages,
+        )
+
+        draft_cache_cell_size = 0
+        if draft_attn_config is not None:
+            draft_cache_cell_size = (
+                draft_attn_config.cache_cell_size()
+                * draft_model_config.num_attention_layers
+            )
+        max_total_num_pages = profile_deepseek_v4_max_num_pages(
+            layout=deepseek_v4_layout,
+            hf_config=model_config.hf_config,
+            layer_num=num_layers,
+            max_live_requests=config.max_bs,
+            max_scheduled_tokens=server_args.chunked_prefill_size,
+            max_context_len=config.context_len,
+            available_cache_memory_bytes=profile_available_cache_memory_bytes(
+                attn_config=config,
+                gpu_id=gpu_id,
+                tp_size=server_args.mapping.world_size,
+                gpu_memory_utilization=server_args.gpu_memory_utilization,
+                total_gpu_memory=gpu_memory,
+                world_group=server_args.mapping.world_group,
+            ),
+            draft_cache_cell_size=draft_cache_cell_size,
+        )
+        logger.info(
+            "DeepSeek V4 grouped KV profile: max_live_requests=%s "
+            "(attn config max_bs=%s, attn_dp_size=%s), max_total_num_pages=%s",
+            config.max_bs,
+            config.max_bs,
+            server_args.mapping.attn.dp_size,
+            max_total_num_pages,
+        )
+        max_num_tokens = _resolve_max_num_tokens(
+            max_total_num_pages,
+            server_args.block_size,
+            server_args.max_total_tokens,
+        )
+    elif has_mamba and server_args.max_mamba_cache_size is not None:
         mamba_pool_total_chunks = server_args.max_mamba_cache_size
         max_total_num_pages = profile_max_num_pages(
             **_profile_kwargs,

--- a/python/tokenspeed/runtime/layers/attention/utils.py
+++ b/python/tokenspeed/runtime/layers/attention/utils.py
@@ -116,13 +116,30 @@ def token_indices_from_pages(
 
 # --- Page-based memory profiling ---
 
-from typing import Optional, Tuple
 
-from tokenspeed.runtime.distributed.process_group_manager import (
-    process_group_manager as pg_manager,
-)
-from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
-from tokenspeed.runtime.utils import get_available_gpu_memory
+def profile_available_cache_memory_bytes(
+    attn_config: BaseAttnConfig,
+    gpu_id: int,
+    tp_size: int,
+    gpu_memory_utilization: float,
+    total_gpu_memory: int,
+    world_group=None,
+) -> int:
+    cpu_group = (
+        pg_manager.get_process_group("gloo", world_group)
+        if world_group is not None
+        else None
+    )
+    available_gpu_memory = get_available_gpu_memory(
+        attn_config.device,
+        gpu_id,
+        distributed=tp_size > 1,
+        cpu_group=cpu_group,
+    )
+    cache_memory = available_gpu_memory - total_gpu_memory * (
+        1 - gpu_memory_utilization
+    )
+    return int(cache_memory * (1 << 30))
 
 
 def profile_max_num_pages(
@@ -138,19 +155,14 @@ def profile_max_num_pages(
     draft_num_attention_layers: int | None = None,
     cache_cell_size: int | None = None,
 ):
-    cpu_group = (
-        pg_manager.get_process_group("gloo", world_group)
-        if world_group is not None
-        else None
-    )
-    available_gpu_memory = get_available_gpu_memory(
-        attn_config.device,
+    cache_memory = profile_available_cache_memory_bytes(
+        attn_config,
         gpu_id,
-        distributed=tp_size > 1,
-        cpu_group=cpu_group,
+        tp_size,
+        gpu_memory_utilization,
+        total_gpu_memory,
+        world_group,
     )
-
-    rest_memory = available_gpu_memory - total_gpu_memory * (1 - gpu_memory_utilization)
     if cache_cell_size is None:
         cell_size = attn_config.cache_cell_size() * num_attention_layers
     else:
@@ -159,7 +171,7 @@ def profile_max_num_pages(
         cell_size += draft_attn_config.cache_cell_size() * draft_num_attention_layers
     if cell_size <= 0:
         raise ValueError(f"KV cache cell size must be positive, got {cell_size}")
-    max_num_token = int(rest_memory * (1 << 30) // cell_size)
+    max_num_token = cache_memory // cell_size
     max_num_pages = (max_num_token + page_size - 1) // page_size
     return max_num_pages
 
@@ -175,32 +187,26 @@ def profile_cache_budget(
     mamba_memory_per_chunk: int,
     mamba_ratio: float,
     world_group=None,
-    draft_attn_config: Optional[BaseAttnConfig] = None,
-    draft_num_attention_layers: Optional[int] = None,
-) -> Tuple[int, int]:
+    draft_attn_config: BaseAttnConfig | None = None,
+    draft_num_attention_layers: int | None = None,
+) -> tuple[int, int]:
     """Profile GPU memory and split between KV pages and mamba chunks.
 
     Returns:
         (kv_max_num_pages, mamba_pool_total_chunks)
     """
-    cpu_group = (
-        pg_manager.get_process_group("gloo", world_group)
-        if world_group is not None
-        else None
-    )
-    available_gpu_memory = get_available_gpu_memory(
-        attn_config.device,
+    total_cache_memory = profile_available_cache_memory_bytes(
+        attn_config,
         gpu_id,
-        distributed=tp_size > 1,
-        cpu_group=cpu_group,
+        tp_size,
+        mem_fraction_static,
+        total_gpu_memory,
+        world_group,
     )
-
-    rest_memory = available_gpu_memory - total_gpu_memory * (1 - mem_fraction_static)
     cell_size = attn_config.cache_cell_size() * num_attention_layers
     if draft_attn_config is not None:
         cell_size += draft_attn_config.cache_cell_size() * draft_num_attention_layers
 
-    total_cache_memory = rest_memory * (1 << 30)
     kv_memory = int(total_cache_memory / (1 + mamba_ratio))
     mamba_memory = total_cache_memory - kv_memory
 

--- a/test/runtime/test_v4_sliding_window_groups_smoke.py
+++ b/test/runtime/test_v4_sliding_window_groups_smoke.py
@@ -114,6 +114,75 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
             pool.paged_cache_group_page_counts["v4.c4a.compressed_kv"], 1
         )
 
+    def test_deepseek_v4_capacity_profile_matches_pool_buffers(self):
+        from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
+            DeepseekV4TokenToKVPool,
+            deepseek_v4_cache_layout_from_config,
+            profile_deepseek_v4_max_num_pages,
+        )
+
+        hf_config = SimpleNamespace(
+            compress_ratios=(1, 4, 128),
+            head_dim=512,
+            index_head_dim=128,
+            sliding_window=128,
+        )
+        layout = deepseek_v4_cache_layout_from_config(
+            hf_config,
+            page_size=64,
+            use_fp4_indexer_cache=True,
+        )
+
+        def make_pool(num_pages: int) -> DeepseekV4TokenToKVPool:
+            return DeepseekV4TokenToKVPool(
+                size=num_pages * layout.page_size,
+                model_dtype=torch.bfloat16,
+                layout=layout,
+                layer_num=3,
+                device="cpu",
+                enable_memory_saver=False,
+                max_batch_size=2,
+                max_context_len=1024,
+                page_size=layout.page_size,
+                rank=0,
+                hf_config=hf_config,
+                max_scheduled_tokens=1,
+            )
+
+        def buffer_bytes(pool: DeepseekV4TokenToKVPool) -> int:
+            tensors = []
+            tensors.extend(pool.swa_kv_buffer)
+            tensors.extend(pool.compressed_kv_buffer)
+            tensors.extend(pool.compressor_state_buffer)
+            tensors.extend(pool.indexer_kv_buffer)
+            tensors.extend(pool.indexer_state_buffer)
+            return sum(
+                tensor.numel() * tensor.element_size()
+                for tensor in tensors
+                if tensor is not None
+            )
+
+        target_pages = 8
+        current_bytes = buffer_bytes(make_pool(target_pages))
+        next_bytes = buffer_bytes(make_pool(target_pages + 1))
+
+        self.assertGreater(next_bytes, current_bytes)
+        self.assertEqual(
+            profile_deepseek_v4_max_num_pages(
+                layout=layout,
+                hf_config=hf_config,
+                layer_num=3,
+                max_live_requests=2,
+                max_scheduled_tokens=1,
+                max_context_len=1024,
+                available_cache_memory_bytes=current_bytes,
+            ),
+            target_pages,
+        )
+
+        legacy_pages = current_bytes // (layout.cache_cell_size(3) * layout.page_size)
+        self.assertLess(legacy_pages, target_pages)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fix DeepSeek V4 KV capacity profiling to estimate memory from the actual grouped/sliding `DeepseekV4TokenToKVPool` allocation model instead of the legacy per-token full-cache cost. 
This aligns the scheduler logical page budget with real V4 cache layout while keeping the existing paged-cache group sizing formula unchanged.

## Test Plan

  - python3 -m py_compile ... for touched runtime/test files
  - git diff --check HEAD~1 HEAD
  - Runtime A/B startup validation on DeepSeek-V4-Flash DP=4: fixed branch starts successfully and reports a much larger **num_device_pages** than main branch, avoiding premature logical page budget exhaustion.
