### PR TITLE
test: use mi350 platform to mean both mi350x/mi355x

### DIFF
--- a/tokenspeed-kernel/test/conftest.py
+++ b/tokenspeed-kernel/test/conftest.py
@@ -117,11 +117,11 @@ def mi300_platform() -> PlatformInfo:
 
 
 @pytest.fixture
-def mi355_platform() -> PlatformInfo:
+def mi350_platform() -> PlatformInfo:
     return PlatformInfo(
         vendor="amd",
         arch_version=ArchVersion(9, 5),
-        device_name="AMD Instinct MI355X",
+        device_name="AMD Instinct MI350X/MI355X",
         device_count=8,
         total_memory=288 * (1024**3),
         memory_bandwidth=8000.0,

--- a/tokenspeed-kernel/test/test_callsite_selection.py
+++ b/tokenspeed-kernel/test/test_callsite_selection.py
@@ -322,7 +322,11 @@ def _site_id(site: CallSite) -> str:
 )
 @pytest.mark.parametrize(
     "platform_name",
-    ["h100_platform", "b200_platform"],
+    [
+        "h100_platform",
+        "b200_platform",
+        "mi350_platform",
+    ],
 )
 def test_kernel_selection(site, platform_name, request):
     platform = request.getfixturevalue(platform_name)

--- a/tokenspeed-kernel/test/test_registry.py
+++ b/tokenspeed-kernel/test/test_registry.py
@@ -140,7 +140,7 @@ class TestRegistryQueries:
             assert "paged" in s.features
 
     def test_filter_by_platform(
-        self, sample_specs, h100_platform, mi300_platform, mi355_platform
+        self, sample_specs, h100_platform, mi300_platform, mi350_platform
     ):
         reg = KernelRegistry.get()
         register_all_samples(reg, sample_specs)
@@ -159,13 +159,13 @@ class TestRegistryQueries:
         assert "flashinfer_decode" not in amd_names
         assert "aiter_decode" in amd_names
 
-        mi355_kernels = reg.get_for_operator(
-            "attention", "decode", platform=mi355_platform
+        mi350_kernels = reg.get_for_operator(
+            "attention", "decode", platform=mi350_platform
         )
-        mi355_names = {s.name for s in mi355_kernels}
-        assert "flashinfer_decode" not in mi355_names
-        assert "aiter_decode" in mi355_names
-        assert "triton_decode" in mi355_names
+        mi350_names = {s.name for s in mi350_kernels}
+        assert "flashinfer_decode" not in mi350_names
+        assert "aiter_decode" in mi350_names
+        assert "triton_decode" in mi350_names
 
     def test_filter_by_dtype(self, sample_specs):
         reg = KernelRegistry.get()

--- a/tokenspeed-kernel/test/test_selection.py
+++ b/tokenspeed-kernel/test/test_selection.py
@@ -687,7 +687,7 @@ class TestSelectKernel:
         )
         assert impl() == "aiter_decode"
 
-    def test_amd_mi355_platform_selects_aiter(self, sample_specs, mi355_platform):
+    def test_amd_mi350_platform_selects_aiter(self, sample_specs, mi350_platform):
         reg = KernelRegistry.get()
         register_all_samples(reg, sample_specs)
 
@@ -695,7 +695,7 @@ class TestSelectKernel:
             "attention",
             "decode",
             torch.bfloat16,
-            platform=mi355_platform,
+            platform=mi350_platform,
         )
         assert impl() == "aiter_decode"
 


### PR DESCRIPTION
Along the way, also enable test_callsite_selection for mi350 platform.