### PR TITLE
fix(server-args): bump tp4 gpu_memory_utilization to 0.95

### DIFF
--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -355,7 +355,7 @@ class ServerArgs:
             elif self.mapping.world_size >= 8:
                 self.gpu_memory_utilization = 0.81
             elif self.mapping.world_size >= 4:
-                self.gpu_memory_utilization = 0.85
+                self.gpu_memory_utilization = 0.95
             elif self.mapping.world_size >= 2:
                 self.gpu_memory_utilization = 0.87
             else:


### PR DESCRIPTION
Bump the default `gpu_memory_utilization` for `world_size >= 4` (tp4) from 0.85 to 0.95. Other tiers unchanged.
