### PR TITLE
feat(mla): default prefill backend to binary, bump to 0.1.3

### DIFF
--- a/tokenspeed-mla/README.md
+++ b/tokenspeed-mla/README.md
@@ -136,8 +136,8 @@ Input/output dtype behavior:
 
 Backend selection:
 
-- Default: CuTe DSL JIT (`TOKENSPEED_MLA_PREFILL_BACKEND=cutedsl`)
-- Optional: binary AOT (`TOKENSPEED_MLA_PREFILL_BACKEND=binary`)
+- Default: binary AOT (`TOKENSPEED_MLA_PREFILL_BACKEND=binary`)
+- Optional: CuTe DSL JIT (`TOKENSPEED_MLA_PREFILL_BACKEND=cutedsl`)
 - Binary `.so` path override: `TOKENSPEED_MLA_FMHA_BINARY_SO`
 - Availability probe API: `has_binary_prefill()`
 

--- a/tokenspeed-mla/pyproject.toml
+++ b/tokenspeed-mla/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tokenspeed-mla"
-version = "0.1.2"
+version = "0.1.3"
 description = "Speed-of-light TokenSpeed MLA kernels for Blackwell SM100 and SM103."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tokenspeed-mla/python/tokenspeed_mla/mla_prefill.py
+++ b/tokenspeed-mla/python/tokenspeed_mla/mla_prefill.py
@@ -50,9 +50,9 @@ from tokenspeed_mla.utils import torch_to_cutlass_dtype
 
 logger = logging.getLogger(__name__)
 
-# Backend selection via env var. Values: "cutedsl" (default) or "binary" (AOT SO).
+# Backend selection via env var. Values: "binary" (default, AOT SO) or "cutedsl".
 _PREFILL_BACKEND_ENV = os.environ.get(
-    "TOKENSPEED_MLA_PREFILL_BACKEND", "cutedsl"
+    "TOKENSPEED_MLA_PREFILL_BACKEND", "binary"
 ).lower()
 
 


### PR DESCRIPTION
Switch the default `TOKENSPEED_MLA_PREFILL_BACKEND` to `binary` (AOT SO), with `cutedsl` remaining available as an opt-in. README updated accordingly. Bump `tokenspeed-mla` to `0.1.3`.
