### PR TITLE
feat(qwen3): add Qwen3 MoE causal LM support

### DIFF
--- a/docs/recipes/models.md
+++ b/docs/recipes/models.md
@@ -33,6 +33,24 @@ tokenspeed serve nvidia/Kimi-K2.5-NVFP4 \
 For K2.6, keep the same parameter shape and change the checkpoint and parser
 only if the model card requires a different value.
 
+## Qwen3 Dense / Qwen3 30B-A3B
+
+Qwen2, dense Qwen3, and Qwen3 MoE checkpoints use different architecture names.
+For Qwen3 30B-A3B, the Hugging Face config advertises `qwen3_moe` and
+`Qwen3MoeForCausalLM`, so launch it as a MoE model.
+
+```bash
+tokenspeed serve Qwen/Qwen3-30B-A3B \
+  --served-model-name qwen3-30b-a3b \
+  --tensor-parallel-size 2 \
+  --enable-expert-parallel \
+  --moe-backend flashinfer_cutlass \
+  --max-model-len 40960 \
+  --reasoning-parser qwen3 \
+  --host 0.0.0.0 \
+  --port 8000
+```
+
 ## GPT-OSS 20B / 120B
 
 Small GPT-OSS launches can start simple. Large GPT-OSS launches usually tune

--- a/python/tokenspeed/runtime/configs/qwen3_moe_config.py
+++ b/python/tokenspeed/runtime/configs/qwen3_moe_config.py
@@ -18,23 +18,39 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Runtime configuration exports."""
+"""Qwen3 MoE model configuration definitions."""
 
-from tokenspeed.runtime.configs.deepseek_v4_config import DeepseekV4Config
-from tokenspeed.runtime.configs.kimi_k2_config import KimiK2Config
-from tokenspeed.runtime.configs.minimax_m2_config import MiniMaxM2Config
-from tokenspeed.runtime.configs.qwen2_config import Qwen2Config
-from tokenspeed.runtime.configs.qwen3_5_config import Qwen3_5Config, Qwen3_5MoeConfig
 from tokenspeed.runtime.configs.qwen3_config import Qwen3Config
-from tokenspeed.runtime.configs.qwen3_moe_config import Qwen3MoeConfig
 
-__all__ = [
-    "DeepseekV4Config",
-    "Qwen2Config",
-    "Qwen3Config",
-    "Qwen3MoeConfig",
-    "Qwen3_5Config",
-    "Qwen3_5MoeConfig",
-    "MiniMaxM2Config",
-    "KimiK2Config",
-]
+
+class Qwen3MoeConfig(Qwen3Config):
+    """Configuration for Qwen3 MoE causal LMs such as Qwen3-30B-A3B."""
+
+    model_type = "qwen3_moe"
+
+    def __init__(
+        self,
+        decoder_sparse_step=1,
+        moe_intermediate_size=768,
+        shared_expert_intermediate_size=0,
+        num_experts_per_tok=8,
+        num_experts=128,
+        norm_topk_prob=True,
+        output_router_logits=False,
+        router_aux_loss_coef=0.001,
+        mlp_only_layers=None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.decoder_sparse_step = decoder_sparse_step
+        self.moe_intermediate_size = moe_intermediate_size
+        self.shared_expert_intermediate_size = shared_expert_intermediate_size
+        self.num_experts_per_tok = num_experts_per_tok
+        self.num_experts = num_experts
+        self.norm_topk_prob = norm_topk_prob
+        self.output_router_logits = output_router_logits
+        self.router_aux_loss_coef = router_aux_loss_coef
+        self.mlp_only_layers = [] if mlp_only_layers is None else mlp_only_layers
+
+
+__all__ = ["Qwen3MoeConfig"]

--- a/python/tokenspeed/runtime/models/qwen3_moe.py
+++ b/python/tokenspeed/runtime/models/qwen3_moe.py
@@ -298,6 +298,8 @@ class Qwen3MoeForCausalLM(Qwen3ForCausalLM):
                     continue
                 if name.endswith(ignore_suffixes) and name not in params_dict:
                     continue
+                if name not in params_dict:
+                    continue
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)

--- a/python/tokenspeed/runtime/models/qwen3_moe.py
+++ b/python/tokenspeed/runtime/models/qwen3_moe.py
@@ -190,9 +190,10 @@ class Qwen3MoeModel(Qwen3Model):
                 cos_sin=None,
             )
 
-        hidden_states = layer.comm_manager.final_norm(
-            hidden_states, residual, ctx, self.norm
-        )
+        if not ctx.forward_mode.is_idle():
+            hidden_states = layer.comm_manager.final_norm(
+                hidden_states, residual, ctx, self.norm
+            )
         return hidden_states, None
 
 

--- a/python/tokenspeed/runtime/models/qwen3_moe.py
+++ b/python/tokenspeed/runtime/models/qwen3_moe.py
@@ -1,0 +1,306 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Inference-only Qwen3 MoE model compatible with HuggingFace weights."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import torch
+from torch import nn
+
+from tokenspeed.runtime.configs.qwen3_moe_config import Qwen3MoeConfig
+from tokenspeed.runtime.distributed.comm_manager import CommManager
+from tokenspeed.runtime.distributed.mapping import Mapping
+from tokenspeed.runtime.execution.context import ForwardContext
+from tokenspeed.runtime.layers.moe.checkpoint import (
+    ExpertCheckpointSchema,
+    build_moe_checkpoint_loader,
+)
+from tokenspeed.runtime.layers.quantization.base_config import QuantizationConfig
+from tokenspeed.runtime.layers.utils import get_layer_id
+from tokenspeed.runtime.model_loader.weight_utils import default_weight_loader
+from tokenspeed.runtime.models.qwen3 import (
+    Qwen3DecoderLayer,
+    Qwen3ForCausalLM,
+    Qwen3MLP,
+    Qwen3Model,
+)
+from tokenspeed.runtime.models.qwen3_5_moe import (
+    Qwen3_5MoeMLP,
+    Qwen3_5MoeSparseMoeBlock,
+    _is_moe_layer,
+)
+from tokenspeed.runtime.utils import add_prefix
+
+
+class Qwen3MoeDecoderLayer(Qwen3DecoderLayer):
+    def __init__(
+        self,
+        config: Qwen3MoeConfig,
+        mapping: Mapping,
+        layer_id: int = 0,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(
+            config=config,
+            mapping=mapping,
+            layer_id=layer_id,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+        if _is_moe_layer(layer_id, config):
+            self.mlp = Qwen3_5MoeSparseMoeBlock(
+                config=config,
+                mapping=self.mapping,
+                quant_config=quant_config,
+                layer_index=layer_id,
+                prefix=add_prefix("mlp", prefix),
+            )
+        elif isinstance(self.mlp, Qwen3MLP):
+            self.mlp = Qwen3_5MoeMLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                hidden_act=config.hidden_act,
+                mapping=self.mapping,
+                quant_config=quant_config,
+                reduce_results=False,
+                prefix=add_prefix("mlp", prefix),
+            )
+        is_moe = isinstance(self.mlp, Qwen3_5MoeSparseMoeBlock)
+        self.comm_manager = CommManager(
+            mapping=self.mapping,
+            layer_id=layer_id,
+            is_moe=is_moe,
+            prev_is_moe=_is_moe_layer(layer_id - 1, config),
+            input_layernorm=self.input_layernorm,
+            post_attn_layernorm=self.post_attention_layernorm,
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        ctx: ForwardContext,
+        out_cache_loc: torch.Tensor,
+        residual: torch.Tensor | None,
+        cos_sin: tuple[torch.Tensor, torch.Tensor] | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if not ctx.forward_mode.is_idle():
+            hidden_states, residual = self.comm_manager.input_reduce_norm(
+                hidden_states, residual
+            )
+            hidden_states = self.comm_manager.pre_attn_comm(hidden_states, ctx)
+            hidden_states = self.self_attn(
+                positions=positions,
+                hidden_states=hidden_states,
+                ctx=ctx,
+                out_cache_loc=out_cache_loc,
+                cos_sin=cos_sin,
+            )
+            hidden_states, residual = self.comm_manager.post_attn_reduce_norm(
+                hidden_states, residual, ctx
+            )
+
+        hidden_states, residual = self.forward_mlp(hidden_states, residual, ctx)
+        return hidden_states, residual
+
+    def forward_mlp(
+        self,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor,
+        ctx: ForwardContext,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if isinstance(self.mlp, Qwen3_5MoeSparseMoeBlock):
+            num_global_tokens, max_num_tokens_per_gpu = (
+                self.mlp.comm_manager.get_num_tokens(ctx)
+            )
+            hidden_states = self.mlp(
+                hidden_states,
+                num_global_tokens,
+                max_num_tokens_per_gpu,
+                ctx,
+            )
+            return hidden_states, residual
+
+        hidden_states = self.comm_manager.pre_mlp_comm(hidden_states, ctx)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states, residual = self.comm_manager.post_mlp_fused(
+            hidden_states, residual, ctx
+        )
+        return hidden_states, residual
+
+
+class Qwen3MoeModel(Qwen3Model):
+    def __init__(
+        self,
+        config: Qwen3MoeConfig,
+        mapping: Mapping,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(
+            config=config,
+            mapping=mapping,
+            quant_config=quant_config,
+            prefix=prefix,
+            decoder_layer_type=Qwen3MoeDecoderLayer,
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        ctx: ForwardContext,
+        out_cache_loc: torch.Tensor,
+        input_embeds: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, None]:
+        if input_embeds is None:
+            hidden_states = self.embed_tokens(input_ids)
+        else:
+            hidden_states = input_embeds
+        residual = None
+
+        for layer in self.layers:
+            hidden_states, residual = layer(
+                positions,
+                hidden_states,
+                ctx,
+                out_cache_loc,
+                residual,
+                cos_sin=None,
+            )
+
+        hidden_states = layer.comm_manager.final_norm(
+            hidden_states, residual, ctx, self.norm
+        )
+        return hidden_states, None
+
+
+class Qwen3MoeForCausalLM(Qwen3ForCausalLM):
+    model_cls = Qwen3MoeModel
+
+    default_bitsandbytes_target_modules = [
+        ".gate_proj.",
+        ".down_proj.",
+        ".up_proj.",
+        ".q_proj.",
+        ".k_proj.",
+        ".v_proj.",
+        ".o_proj.",
+    ]
+    bitsandbytes_stacked_params_mapping = {
+        "q_proj": ("qkv_proj", 0),
+        "k_proj": ("qkv_proj", 1),
+        "v_proj": ("qkv_proj", 2),
+        "gate_proj": ("gate_up_proj", 0),
+        "up_proj": ("gate_up_proj", 1),
+    }
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        stacked_params_mapping = [
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        ignore_suffixes = (
+            ".bias",
+            "_bias",
+            ".k_scale",
+            "_k_scale",
+            ".v_scale",
+            "_v_scale",
+            ".weight_scale",
+            "_weight_scale",
+            ".input_scale",
+            "_input_scale",
+        )
+
+        params_dict = dict(self.named_parameters(remove_duplicate=False))
+        moe_loader = build_moe_checkpoint_loader(
+            params_dict=params_dict,
+            expert_schema=ExpertCheckpointSchema(
+                gate_proj_name="gate_proj",
+                down_proj_name="down_proj",
+                up_proj_name="up_proj",
+            ),
+            fused_schema=ExpertCheckpointSchema(
+                gate_up_fused_name="gate_up_proj",
+                down_proj_name="down_proj",
+            ),
+            num_experts=self.config.num_experts,
+            ep_rank=self.mapping.moe.ep_rank,
+            ep_size=self.mapping.moe.ep_size,
+        )
+
+        for name, loaded_weight in weights:
+            if "Embedding" in self.config.name_or_path:
+                name = add_prefix(name, "model")
+            layer_id = get_layer_id(name)
+            if (
+                layer_id is not None
+                and hasattr(self.model, "start_layer")
+                and (
+                    layer_id < self.model.start_layer
+                    or layer_id >= self.model.end_layer
+                )
+            ):
+                continue
+            if "rotary_emb.inv_freq" in name or "projector" in name:
+                continue
+            if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
+                continue
+            if self.config.tie_word_embeddings and "lm_head.weight" in name:
+                continue
+            if name.startswith("model.vision_tower") and name not in params_dict:
+                continue
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                if "mlp.experts" in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                if name.endswith(ignore_suffixes) and name not in params_dict:
+                    continue
+                if name not in params_dict:
+                    continue
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                if name.endswith((".bias", "_bias")) and name not in params_dict:
+                    continue
+                if moe_loader.matches(name):
+                    moe_loader.load(name, loaded_weight)
+                    continue
+                if name.endswith(ignore_suffixes) and name not in params_dict:
+                    continue
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+
+
+EntryClass = Qwen3MoeForCausalLM

--- a/python/tokenspeed/runtime/utils/hf_transformers_utils.py
+++ b/python/tokenspeed/runtime/utils/hf_transformers_utils.py
@@ -51,12 +51,14 @@ from tokenspeed.runtime.configs import (
     Qwen3_5Config,
     Qwen3_5MoeConfig,
     Qwen3Config,
+    Qwen3MoeConfig,
 )
 from tokenspeed.runtime.utils import lru_cache_frozenset
 
 _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = {
     Qwen2Config.model_type: Qwen2Config,
     Qwen3Config.model_type: Qwen3Config,
+    Qwen3MoeConfig.model_type: Qwen3MoeConfig,
     DeepseekV4Config.model_type: DeepseekV4Config,
     Qwen3_5Config.model_type: Qwen3_5Config,
     Qwen3_5MoeConfig.model_type: Qwen3_5MoeConfig,

--- a/test/runtime/models/test_qwen3_moe_models.py
+++ b/test/runtime/models/test_qwen3_moe_models.py
@@ -16,7 +16,7 @@ def _tiny_qwen3_moe_config() -> Qwen3MoeConfig:
         hidden_size=16,
         intermediate_size=32,
         num_hidden_layers=2,
-        num_attention_heads=2,
+        num_attention_heads=4,
         num_key_value_heads=1,
         head_dim=8,
         max_position_embeddings=128,
@@ -28,6 +28,12 @@ def _tiny_qwen3_moe_config() -> Qwen3MoeConfig:
 
 def _single_rank_mapping() -> Mapping:
     mapping = Mapping(rank=0, world_size=1)
+    global_server_args_dict["mapping"] = mapping
+    return mapping
+
+
+def _ep_rank_mapping(rank: int) -> Mapping:
+    mapping = Mapping(rank=rank, world_size=4, moe_ep_size=4)
     global_server_args_dict["mapping"] = mapping
     return mapping
 
@@ -135,6 +141,31 @@ class TestQwen3MoeConfig(unittest.TestCase):
         w2 = params["model.layers.0.mlp.experts.w2_weight"]
         self.assertEqual(w13[0, :8].mean().item(), 1.0)
         self.assertEqual(w13[0, 8:].mean().item(), 11.0)
+        self.assertEqual(w2[0].mean().item(), 21.0)
+
+    def test_skips_nonlocal_expert_weights_under_expert_parallelism(self):
+        from tokenspeed.runtime.models.qwen3_moe import Qwen3MoeForCausalLM
+
+        model = Qwen3MoeForCausalLM(
+            _tiny_qwen3_moe_config(),
+            mapping=_ep_rank_mapping(rank=0),
+        )
+        model.load_weights(
+            [
+                (
+                    "model.layers.0.mlp.experts.0.down_proj.weight",
+                    torch.full((16, 8), 21.0),
+                ),
+                (
+                    "model.layers.0.mlp.experts.3.down_proj.weight",
+                    torch.full((16, 8), 24.0),
+                ),
+            ]
+        )
+
+        params = dict(model.named_parameters())
+        w2 = params["model.layers.0.mlp.experts.w2_weight"]
+        self.assertEqual(w2.shape[0], 1)
         self.assertEqual(w2[0].mean().item(), 21.0)
 
 

--- a/test/runtime/models/test_qwen3_moe_models.py
+++ b/test/runtime/models/test_qwen3_moe_models.py
@@ -2,9 +2,12 @@ import json
 import unittest
 
 import torch
+from torch import nn
 
 from tokenspeed.runtime.configs.qwen3_moe_config import Qwen3MoeConfig
 from tokenspeed.runtime.distributed.mapping import Mapping
+from tokenspeed.runtime.execution.context import ForwardContext
+from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.utils.env import global_server_args_dict
 from tokenspeed.runtime.utils.hf_transformers_utils import _CONFIG_REGISTRY, get_config
 
@@ -167,6 +170,53 @@ class TestQwen3MoeConfig(unittest.TestCase):
         w2 = params["model.layers.0.mlp.experts.w2_weight"]
         self.assertEqual(w2.shape[0], 1)
         self.assertEqual(w2[0].mean().item(), 21.0)
+
+    def test_idle_forward_skips_final_norm(self):
+        from tokenspeed.runtime.models.qwen3_moe import Qwen3MoeForCausalLM
+
+        class FailingCommManager:
+            def final_norm(self, *args, **kwargs):
+                raise AssertionError("final_norm should not run for idle forwards")
+
+        class IdleLayer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.comm_manager = FailingCommManager()
+
+            def forward(
+                self,
+                positions,
+                hidden_states,
+                ctx,
+                out_cache_loc,
+                residual,
+                cos_sin=None,
+            ):
+                return hidden_states, residual
+
+        model = Qwen3MoeForCausalLM(
+            _tiny_qwen3_moe_config(),
+            mapping=_single_rank_mapping(),
+        )
+        model.model.layers = nn.ModuleList([IdleLayer()])
+        ctx = ForwardContext(
+            attn_backend=None,
+            token_to_kv_pool=None,
+            bs=0,
+            num_extends=0,
+            input_num_tokens=0,
+            forward_mode=ForwardMode.IDLE,
+        )
+
+        hidden_states, residual = model.model(
+            input_ids=torch.empty(0, dtype=torch.long),
+            positions=torch.empty(0, dtype=torch.long),
+            ctx=ctx,
+            out_cache_loc=torch.empty(0, dtype=torch.long),
+        )
+
+        self.assertEqual(hidden_states.shape, (0, 16))
+        self.assertIsNone(residual)
 
 
 if __name__ == "__main__":

--- a/test/runtime/models/test_qwen3_moe_models.py
+++ b/test/runtime/models/test_qwen3_moe_models.py
@@ -1,0 +1,142 @@
+import json
+import unittest
+
+import torch
+
+from tokenspeed.runtime.configs.qwen3_moe_config import Qwen3MoeConfig
+from tokenspeed.runtime.distributed.mapping import Mapping
+from tokenspeed.runtime.utils.env import global_server_args_dict
+from tokenspeed.runtime.utils.hf_transformers_utils import _CONFIG_REGISTRY, get_config
+
+
+def _tiny_qwen3_moe_config() -> Qwen3MoeConfig:
+    return Qwen3MoeConfig(
+        architectures=["Qwen3MoeForCausalLM"],
+        vocab_size=64,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        max_position_embeddings=128,
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=8,
+    )
+
+
+def _single_rank_mapping() -> Mapping:
+    mapping = Mapping(rank=0, world_size=1)
+    global_server_args_dict["mapping"] = mapping
+    return mapping
+
+
+class TestQwen3MoeConfig(unittest.TestCase):
+    def test_config_registry(self):
+        self.assertEqual(Qwen3MoeConfig.model_type, "qwen3_moe")
+        self.assertIs(_CONFIG_REGISTRY["qwen3_moe"], Qwen3MoeConfig)
+
+    def test_get_config_loads_qwen3_30b_a3b_shape(self):
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.json"
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "architectures": ["Qwen3MoeForCausalLM"],
+                        "attention_bias": False,
+                        "head_dim": 128,
+                        "hidden_act": "silu",
+                        "hidden_size": 2048,
+                        "intermediate_size": 6144,
+                        "max_position_embeddings": 40960,
+                        "max_window_layers": 48,
+                        "mlp_only_layers": [],
+                        "model_type": "qwen3_moe",
+                        "moe_intermediate_size": 768,
+                        "norm_topk_prob": True,
+                        "num_attention_heads": 32,
+                        "num_experts": 128,
+                        "num_experts_per_tok": 8,
+                        "num_hidden_layers": 48,
+                        "num_key_value_heads": 4,
+                        "rope_theta": 1000000.0,
+                        "sliding_window": None,
+                        "tie_word_embeddings": False,
+                        "use_sliding_window": False,
+                        "vocab_size": 151936,
+                    }
+                )
+            )
+
+            config = get_config(tmpdir, trust_remote_code=False)
+
+        self.assertIsInstance(config, Qwen3MoeConfig)
+        self.assertEqual(config.architectures, ["Qwen3MoeForCausalLM"])
+        self.assertEqual(config.num_experts, 128)
+        self.assertEqual(config.num_experts_per_tok, 8)
+        self.assertEqual(config.moe_intermediate_size, 768)
+
+    def test_model_registry_resolves_qwen3_moe(self):
+        from tokenspeed.runtime.models.qwen3_moe import Qwen3MoeForCausalLM
+        from tokenspeed.runtime.models.registry import ModelRegistry
+
+        cls, arch = ModelRegistry.resolve_model_cls(["Qwen3MoeForCausalLM"])
+        self.assertIs(cls, Qwen3MoeForCausalLM)
+        self.assertEqual(arch, "Qwen3MoeForCausalLM")
+
+    def test_constructs_sparse_moe_layers_with_comm_manager(self):
+        from tokenspeed.runtime.models.qwen3_5_moe import Qwen3_5MoeSparseMoeBlock
+        from tokenspeed.runtime.models.qwen3_moe import Qwen3MoeForCausalLM
+
+        model = Qwen3MoeForCausalLM(
+            _tiny_qwen3_moe_config(),
+            mapping=_single_rank_mapping(),
+        )
+
+        self.assertIsInstance(model.model.layers[0].mlp, Qwen3_5MoeSparseMoeBlock)
+        self.assertTrue(model.model.layers[0].comm_manager.is_moe)
+        self.assertFalse(model.model.layers[0].comm_manager.prev_is_moe)
+        self.assertTrue(model.model.layers[1].comm_manager.prev_is_moe)
+
+    def test_loads_unfused_expert_weights_into_moe_layer(self):
+        from tokenspeed.runtime.models.qwen3_moe import Qwen3MoeForCausalLM
+
+        model = Qwen3MoeForCausalLM(
+            _tiny_qwen3_moe_config(),
+            mapping=_single_rank_mapping(),
+        )
+        weights = []
+        for expert_id in range(4):
+            weights.extend(
+                [
+                    (
+                        f"model.layers.0.mlp.experts.{expert_id}.gate_proj.weight",
+                        torch.full((8, 16), 1.0 + expert_id),
+                    ),
+                    (
+                        f"model.layers.0.mlp.experts.{expert_id}.up_proj.weight",
+                        torch.full((8, 16), 11.0 + expert_id),
+                    ),
+                    (
+                        f"model.layers.0.mlp.experts.{expert_id}.down_proj.weight",
+                        torch.full((16, 8), 21.0 + expert_id),
+                    ),
+                ]
+            )
+
+        model.load_weights(weights)
+
+        params = dict(model.named_parameters())
+        w13 = params["model.layers.0.mlp.experts.w13_weight"]
+        w2 = params["model.layers.0.mlp.experts.w2_weight"]
+        self.assertEqual(w13[0, :8].mean().item(), 1.0)
+        self.assertEqual(w13[0, 8:].mean().item(), 11.0)
+        self.assertEqual(w2[0].mean().item(), 21.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `qwen3_moe` config registration for Qwen3 MoE checkpoints such as Qwen/Qwen3-30B-A3B
- add `Qwen3MoeForCausalLM` runtime support using Qwen3 attention with `CommManager`-driven MoE communication and the existing MoE checkpoint loader
- document a Qwen3 30B-A3B launch recipe and add config/registry/MoE construction/weight-loader tests

## Tests
- `pre-commit run --all-files`
- `python -m pytest test/runtime/models/test_qwen3_moe_models.py -q`