### PR TITLE
fix scheduler req pool move assignment leak

### DIFF
--- a/tokenspeed-scheduler/CMakeLists.txt
+++ b/tokenspeed-scheduler/CMakeLists.txt
@@ -111,6 +111,7 @@ if(TOKENSPEED_SCHEDULER_BUILD_TESTS)
         tests/cpp/test_prefetch.cpp
         tests/cpp/test_owned_pages.cpp
         tests/cpp/test_retract_abort_pages.cpp
+        tests/cpp/test_req_pool_allocator.cpp
         tests/cpp/test_mamba_slot.cpp
         tests/cpp/test_mamba_eviction.cpp
         tests/cpp/test_mamba_cache.cpp

--- a/tokenspeed-scheduler/csrc/resource/allocator/req_pool_allocator.cpp
+++ b/tokenspeed-scheduler/csrc/resource/allocator/req_pool_allocator.cpp
@@ -33,6 +33,9 @@ ReqPoolIndex::ReqPoolIndex(ReqPoolIndex&& other) noexcept : slot_(other.slot_), 
 
 ReqPoolIndex& ReqPoolIndex::operator=(ReqPoolIndex&& other) noexcept {
     if (this != &other) {
+        if (allocator_) {
+            allocator_->deAllocate(slot_);
+        }
         slot_ = other.slot_;
         allocator_ = other.allocator_;
         other.slot_ = -1;

--- a/tokenspeed-scheduler/tests/cpp/test_req_pool_allocator.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_req_pool_allocator.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 LightSeek Foundation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <utility>
+
+#include "resource/allocator/req_pool_allocator.h"
+
+namespace tokenspeed::test {
+
+TEST(ReqPoolAllocatorTest, RAIIReleasesSlotOnDestruction) {
+    ReqPoolAllocator allocator(1);
+    {
+        auto index = allocator.Allocate();
+        EXPECT_TRUE(index.valid());
+        EXPECT_EQ(allocator.AvailableSlots(), 0);
+    }
+    EXPECT_EQ(allocator.AvailableSlots(), 1);
+}
+
+TEST(ReqPoolAllocatorTest, MoveAssignmentReleasesPreviouslyOwnedSlot) {
+    ReqPoolAllocator allocator(2);
+    {
+        auto dst = allocator.Allocate();
+        auto src = allocator.Allocate();
+        ASSERT_EQ(allocator.AvailableSlots(), 0);
+
+        dst = std::move(src);
+
+        EXPECT_TRUE(dst.valid());
+        EXPECT_FALSE(src.valid());
+        EXPECT_EQ(allocator.AvailableSlots(), 1);
+    }
+    EXPECT_EQ(allocator.AvailableSlots(), 2);
+}
+
+}  // namespace tokenspeed::test


### PR DESCRIPTION
## Summary

Fix `ReqPoolIndex` move assignment to release the slot currently owned by the destination before taking ownership from the source.

`ReqPoolIndex` is an RAII handle: its destructor returns the held slot to `ReqPoolAllocator`. The previous move-assignment operator overwrote `slot_` and `allocator_` directly, so assigning into an already-valid `ReqPoolIndex` leaked the destination's old slot.

## Tests

- `./tokenspeed-scheduler/build-test/tokenspeed_scheduler_tests --gtest_filter='ReqPoolAllocatorTest.*'`