### PR TITLE
perf(K2.5): optimize top_k_renorm_prob + top_p_renorm_prob

### DIFF
--- a/python/tokenspeed/runtime/sampling/backends/flashinfer.py
+++ b/python/tokenspeed/runtime/sampling/backends/flashinfer.py
@@ -25,13 +25,13 @@ from typing import TYPE_CHECKING
 import torch
 from tokenspeed_kernel.ops.sampling.cuda import (
     chain_speculative_sampling_target_only,
+    fused_topk_topp_prepare,
+    fused_topk_topp_renorm,
     verify_chain_greedy,
 )
 from tokenspeed_kernel.ops.sampling.flashinfer import (
     softmax,
-    top_k_renorm_prob,
     top_k_top_p_sampling_from_logits,
-    top_p_renorm_prob,
 )
 from tokenspeed_kernel.ops.sampling.triton import gather_and_expand_scalars
 from tokenspeed_kernel.torch_compile import get_compiler_backend
@@ -76,6 +76,10 @@ class FlashInferSamplingBackend(SamplingBackend):
         super().__init__(config)
         self._init_shared_buffers(config)
         self._init_pool_scalars(config)
+        # Pre-create the side stream used by fused_topk_topp_renorm. Must
+        # happen before any CUDA graph capture — cudaStreamCreate is illegal
+        # inside capture, and verify() runs from the captured graph.
+        fused_topk_topp_prepare(config.device)
 
     def _init_pool_scalars(self, config: SamplingBackendConfig) -> None:
         # Capture warm-up reads row 0 with req_pool_indices zeroed, so row 0
@@ -334,10 +338,10 @@ class FlashInferSamplingBackend(SamplingBackend):
                 temperature=temperatures,
                 enable_pdl=pdl_enabled(),
             )
-            target_probs = top_k_renorm_prob(target_probs, top_ks)
-            target_probs = top_p_renorm_prob(
-                target_probs, top_ps, is_deterministic=True
-            )
+            # Fused replacement for the back-to-back top_k_renorm_prob +
+            # top_p_renorm_prob(is_deterministic=True) pair. Sentinel K = 1<<30
+            # in top_ks routes per-row through the radix top-p only path.
+            target_probs = fused_topk_topp_renorm(target_probs, top_ks, top_ps)
             target_probs = target_probs.reshape(bs, n, -1)
 
             chain_speculative_sampling_target_only(

--- a/python/tokenspeed/runtime/sampling/backends/flashinfer.py
+++ b/python/tokenspeed/runtime/sampling/backends/flashinfer.py
@@ -31,10 +31,19 @@ from tokenspeed_kernel.ops.sampling.cuda import (
 )
 from tokenspeed_kernel.ops.sampling.flashinfer import (
     softmax,
+    top_k_renorm_prob,
     top_k_top_p_sampling_from_logits,
+    top_p_renorm_prob,
 )
 from tokenspeed_kernel.ops.sampling.triton import gather_and_expand_scalars
+from tokenspeed_kernel.platform import current_platform
 from tokenspeed_kernel.torch_compile import get_compiler_backend
+
+# Resolved once at import: the fused top-k + top-p kernel is NVIDIA-only.
+# On non-NVIDIA platforms (e.g. ROCm) we fall back to the back-to-back
+# flashinfer renorm calls. Defining this at module scope keeps the hot path
+# branch-free in the captured graph.
+_FUSED_TOPK_TOPP_AVAILABLE = current_platform().is_nvidia
 
 from tokenspeed.runtime.sampling.backends.base import (
     SPECULATIVE_ACCEPT_THRESHOLD_ACC,
@@ -338,10 +347,17 @@ class FlashInferSamplingBackend(SamplingBackend):
                 temperature=temperatures,
                 enable_pdl=pdl_enabled(),
             )
-            # Fused replacement for the back-to-back top_k_renorm_prob +
-            # top_p_renorm_prob(is_deterministic=True) pair. Sentinel K = 1<<30
-            # in top_ks routes per-row through the radix top-p only path.
-            target_probs = fused_topk_topp_renorm(target_probs, top_ks, top_ps)
+            if _FUSED_TOPK_TOPP_AVAILABLE:
+                # Fused replacement for the back-to-back top_k_renorm_prob +
+                # top_p_renorm_prob(is_deterministic=True) pair. Sentinel
+                # K = 1<<30 in top_ks routes per-row through the radix top-p
+                # only path.
+                target_probs = fused_topk_topp_renorm(target_probs, top_ks, top_ps)
+            else:
+                target_probs = top_k_renorm_prob(target_probs, top_ks)
+                target_probs = top_p_renorm_prob(
+                    target_probs, top_ps, is_deterministic=True
+                )
             target_probs = target_probs.reshape(bs, n, -1)
 
             chain_speculative_sampling_target_only(

--- a/python/tokenspeed/runtime/sampling/backends/flashinfer_full.py
+++ b/python/tokenspeed/runtime/sampling/backends/flashinfer_full.py
@@ -23,12 +23,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
-from tokenspeed_kernel.ops.sampling.cuda import chain_speculative_sampling_target_only
+from tokenspeed_kernel.ops.sampling.cuda import (
+    chain_speculative_sampling_target_only,
+    fused_topk_topp_renorm,
+)
 from tokenspeed_kernel.ops.sampling.flashinfer import (
     min_p_sampling_from_probs,
     softmax,
-    top_k_renorm_prob,
-    top_p_renorm_prob,
 )
 from tokenspeed_kernel.ops.sampling.triton import (
     gather_and_expand_scalars,
@@ -304,8 +305,11 @@ class FlashInferFullSamplingBackend(FlashInferSamplingBackend):
         probs = softmax(
             logits, temperature=temperatures.view(-1, 1), enable_pdl=pdl_enabled()
         )
-        probs = top_k_renorm_prob(probs, top_ks)
-        probs = top_p_renorm_prob(probs, top_ps, is_deterministic=True)
+
+        # Fused replacement for the back-to-back top_k_renorm_prob +
+        # top_p_renorm_prob(is_deterministic=True) pair. Sentinel K = 1<<30
+        # in top_ks routes per-row through the radix top-p only path.
+        probs = fused_topk_topp_renorm(probs, top_ks, top_ps)
 
         batch_next_token_ids = min_p_sampling_from_probs(
             probs,
@@ -394,8 +398,10 @@ class FlashInferFullSamplingBackend(FlashInferSamplingBackend):
         target_probs = softmax(
             logits, temperature=temperatures.view(-1, 1), enable_pdl=pdl_enabled()
         )
-        target_probs = top_k_renorm_prob(target_probs, top_ks)
-        target_probs = top_p_renorm_prob(target_probs, top_ps, is_deterministic=True)
+        # Fused replacement for the back-to-back top_k_renorm_prob +
+        # top_p_renorm_prob(is_deterministic=True) pair. Sentinel K = 1<<30
+        # in top_ks routes per-row through the radix top-p only path.
+        target_probs = fused_topk_topp_renorm(target_probs, top_ks, top_ps)
 
         target_probs = min_p_renorm_prob(target_probs, min_ps, enable_pdl=pdl_enabled())
 

--- a/python/tokenspeed/runtime/sampling/backends/flashinfer_full.py
+++ b/python/tokenspeed/runtime/sampling/backends/flashinfer_full.py
@@ -30,6 +30,8 @@ from tokenspeed_kernel.ops.sampling.cuda import (
 from tokenspeed_kernel.ops.sampling.flashinfer import (
     min_p_sampling_from_probs,
     softmax,
+    top_k_renorm_prob,
+    top_p_renorm_prob,
 )
 from tokenspeed_kernel.ops.sampling.triton import (
     gather_and_expand_scalars,
@@ -42,7 +44,10 @@ from tokenspeed.runtime.sampling.backends.base import (
     SPECULATIVE_ACCEPT_THRESHOLD_SINGLE,
     SamplingBackendConfig,
 )
-from tokenspeed.runtime.sampling.backends.flashinfer import FlashInferSamplingBackend
+from tokenspeed.runtime.sampling.backends.flashinfer import (
+    _FUSED_TOPK_TOPP_AVAILABLE,
+    FlashInferSamplingBackend,
+)
 from tokenspeed.runtime.sampling.registry import register_backend
 from tokenspeed.runtime.sampling.utils import nan_guard_logits
 from tokenspeed.runtime.utils.nvtx import nvtx_range
@@ -306,10 +311,15 @@ class FlashInferFullSamplingBackend(FlashInferSamplingBackend):
             logits, temperature=temperatures.view(-1, 1), enable_pdl=pdl_enabled()
         )
 
-        # Fused replacement for the back-to-back top_k_renorm_prob +
-        # top_p_renorm_prob(is_deterministic=True) pair. Sentinel K = 1<<30
-        # in top_ks routes per-row through the radix top-p only path.
-        probs = fused_topk_topp_renorm(probs, top_ks, top_ps)
+        if _FUSED_TOPK_TOPP_AVAILABLE:
+            # Fused replacement for the back-to-back top_k_renorm_prob +
+            # top_p_renorm_prob(is_deterministic=True) pair. Sentinel
+            # K = 1<<30 in top_ks routes per-row through the radix top-p
+            # only path.
+            probs = fused_topk_topp_renorm(probs, top_ks, top_ps)
+        else:
+            probs = top_k_renorm_prob(probs, top_ks)
+            probs = top_p_renorm_prob(probs, top_ps, is_deterministic=True)
 
         batch_next_token_ids = min_p_sampling_from_probs(
             probs,
@@ -398,10 +408,17 @@ class FlashInferFullSamplingBackend(FlashInferSamplingBackend):
         target_probs = softmax(
             logits, temperature=temperatures.view(-1, 1), enable_pdl=pdl_enabled()
         )
-        # Fused replacement for the back-to-back top_k_renorm_prob +
-        # top_p_renorm_prob(is_deterministic=True) pair. Sentinel K = 1<<30
-        # in top_ks routes per-row through the radix top-p only path.
-        target_probs = fused_topk_topp_renorm(target_probs, top_ks, top_ps)
+        if _FUSED_TOPK_TOPP_AVAILABLE:
+            # Fused replacement for the back-to-back top_k_renorm_prob +
+            # top_p_renorm_prob(is_deterministic=True) pair. Sentinel
+            # K = 1<<30 in top_ks routes per-row through the radix top-p
+            # only path.
+            target_probs = fused_topk_topp_renorm(target_probs, top_ks, top_ps)
+        else:
+            target_probs = top_k_renorm_prob(target_probs, top_ks)
+            target_probs = top_p_renorm_prob(
+                target_probs, top_ps, is_deterministic=True
+            )
 
         target_probs = min_p_renorm_prob(target_probs, min_ps, enable_pdl=pdl_enabled())
 

--- a/python/tokenspeed/runtime/sampling/sampling_params.py
+++ b/python/tokenspeed/runtime/sampling/sampling_params.py
@@ -30,6 +30,12 @@ _SAMPLING_EPS = 1e-6
 # unchanged to top_k kernels that expect a positive cutoff.
 _TOP_K_DISABLED = 1 << 30
 
+# Upper bound the fused top-k + top-p kernel sorts in its on-chip top-K
+# branch. Requests with a finite top_k above this would silently fall through
+# to the top-p-only branch, so reject them at request time. Must stay in sync
+# with K_TOPK_MAX in fused_topk_topp.h.
+_TOP_K_FUSED_MAX = 128
+
 
 class SamplingParams:
     """
@@ -120,6 +126,11 @@ class SamplingParams:
         if self.top_k < -1 or self.top_k == 0:
             raise ValueError(
                 f"top_k must be -1 (disable), or at least 1, " f"got {self.top_k}."
+            )
+        if self.top_k != _TOP_K_DISABLED and self.top_k >= _TOP_K_FUSED_MAX:
+            raise ValueError(
+                f"top_k must be < {_TOP_K_FUSED_MAX} (fused kernel limit) "
+                f"or -1 (disable), got {self.top_k}."
             )
         if not -2.0 <= self.frequency_penalty <= 2.0:
             raise ValueError(

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -1254,7 +1254,8 @@ class ServerArgs:
             "min_p and penalties silently ignored. "
             "'flashinfer_full': adds min_p plus frequency/presence/repetition penalties and logit_bias "
             "via the softmax+renorm+min_p kernel sequence. "
-            "Allocates a counts[max_req_pool_size, vocab_size] int32 buffer (substantial memory).",
+            "Allocates a counts[max_req_pool_size, vocab_size] int32 buffer (substantial memory). "
+            "Both 'flashinfer' and 'flashinfer_full' require top_k < 128 (fused kernel limit) or -1.",
         )
         parser.add_argument(
             "--attention-use-fp4-indexer-cache",

--- a/tokenspeed-kernel/python/setup.py
+++ b/tokenspeed-kernel/python/setup.py
@@ -348,6 +348,18 @@ KERNEL_GROUPS = [
         [],
     ),
     (
+        "fused_topk_topp",
+        [
+            CUDA_CSRC_DIR / "fused_topk_topp" / "fused_topk_topp.cu",
+            CUDA_CSRC_DIR / "fused_topk_topp" / "fused_topk_topp_binding.cu",
+        ],
+        [],
+        # Match the standalone build's flags. --use_fast_math + relaxed-constexpr
+        # are mostly redundant with the global -DFLASHINFER_ENABLE_* set, but
+        # --expt-extended-lambda is required by air_topk_stable.cuh's CUB usage.
+        ["-O3", "--use_fast_math", "--expt-extended-lambda"],
+    ),
+    (
         "rmsnorm_fused_parallel",
         [
             CUDA_CSRC_DIR / "rmsnorm_fused_parallel.cu",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cuda.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cuda.py
@@ -21,7 +21,11 @@ from tokenspeed_kernel.platform import current_platform
 from tokenspeed_kernel.registry import error_fn
 
 chain_speculative_sampling_target_only = error_fn
-fused_topk_topp_prepare = error_fn
+# Prepare is a side-stream registration helper. On non-NVIDIA the fused
+# kernel doesn't exist, so callers should never reach the renorm path —
+# but prepare gets called unconditionally from FlashInfer backends'
+# __init__, so we keep it as a silent no-op rather than error_fn.
+fused_topk_topp_prepare = lambda *_args, **_kwargs: None  # noqa: E731
 fused_topk_topp_renorm = error_fn
 fused_topk_topp_workspace_size = error_fn
 verify_chain_greedy = error_fn

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cuda.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cuda.py
@@ -21,6 +21,9 @@ from tokenspeed_kernel.platform import current_platform
 from tokenspeed_kernel.registry import error_fn
 
 chain_speculative_sampling_target_only = error_fn
+fused_topk_topp_prepare = error_fn
+fused_topk_topp_renorm = error_fn
+fused_topk_topp_workspace_size = error_fn
 verify_chain_greedy = error_fn
 
 if current_platform().is_nvidia:
@@ -32,4 +35,21 @@ if current_platform().is_nvidia:
     except ImportError:
         pass
 
-__all__ = ["chain_speculative_sampling_target_only", "verify_chain_greedy"]
+    try:
+        from tokenspeed_kernel.thirdparty.cuda.fused_topk_topp import (
+            fused_topk_topp_renorm,
+            fused_topk_topp_workspace_size,
+        )
+        from tokenspeed_kernel.thirdparty.cuda.fused_topk_topp import (
+            prepare_for_device as fused_topk_topp_prepare,
+        )
+    except ImportError:
+        pass
+
+__all__ = [
+    "chain_speculative_sampling_target_only",
+    "fused_topk_topp_prepare",
+    "fused_topk_topp_renorm",
+    "fused_topk_topp_workspace_size",
+    "verify_chain_greedy",
+]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/__init__.py
@@ -26,6 +26,13 @@ from tokenspeed_kernel.thirdparty.cuda.activation import (
 )
 from tokenspeed_kernel.thirdparty.cuda.dsv3_gemm import dsv3_router_gemm
 from tokenspeed_kernel.thirdparty.cuda.fp32_router_gemm import fp32_router_gemm
+from tokenspeed_kernel.thirdparty.cuda.fused_topk_topp import (
+    fused_topk_topp_renorm,
+    fused_topk_topp_workspace_size,
+)
+from tokenspeed_kernel.thirdparty.cuda.fused_topk_topp import (
+    prepare_for_device as fused_topk_topp_prepare,
+)
 from tokenspeed_kernel.thirdparty.cuda.marlin import gptq_marlin_repack
 from tokenspeed_kernel.thirdparty.cuda.moe import moe_finalize_fuse_shared
 from tokenspeed_kernel.thirdparty.cuda.rmsnorm import rmsnorm_fused_parallel
@@ -45,6 +52,9 @@ __all__ = [
     "chain_speculative_sampling_target_only",
     "dsv3_router_gemm",
     "fp32_router_gemm",
+    "fused_topk_topp_prepare",
+    "fused_topk_topp_renorm",
+    "fused_topk_topp_workspace_size",
     "gptq_marlin_repack",
     "hash_softplus_sqrt_topk_flash",
     "moe_finalize_fuse_shared",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/air_top_p.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/air_top_p.cuh
@@ -1,3 +1,23 @@
+// Copyright (c) 2026 LightSeek Foundation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 // Standalone deterministic AIR Top-P radix algorithm.
 //
 // Derived from flashinfer/data/include/flashinfer/air_top_p.cuh (Apache 2.0,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/air_top_p.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/air_top_p.cuh
@@ -1,0 +1,562 @@
+// Standalone deterministic AIR Top-P radix algorithm.
+//
+// Derived from flashinfer/data/include/flashinfer/air_top_p.cuh (Apache 2.0,
+// FlashInfer team, 2026), which in turn ports TensorRT-LLM's AIR Top-P kernel.
+//
+// Adaptations for the fused top-k + top-p kernel here:
+//   * Per-row skip — when counter->len is initialized to 0 (set by our fused
+//     init kernel for rows whose top_k <= MAX_K), every radix pass exits
+//     immediately. Output threshold is then unused by the apply kernel.
+//   * Threshold is left in counter->kthValueBits (no built-in apply kernel).
+//   * Counter holds per-row total_sum so the apply kernel can renormalize.
+
+#ifndef AIR_TOP_P_CUH_
+#define AIR_TOP_P_CUH_
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+#include <cub/cub.cuh>
+#include <cuda/atomic>
+#include <cuda_runtime.h>
+
+#include "nv_util.h"
+
+namespace air_top_p {
+
+using IdxT = int;
+using AccT = float;
+
+static constexpr int BITS_PER_PASS = 11;
+static constexpr int NUM_BUCKETS = 1 << BITS_PER_PASS;
+static constexpr int BLOCK_SIZE = 512;
+using WideT = float4;
+
+template <typename T>
+static constexpr int NUM_PASSES = (sizeof(T) * 8 + BITS_PER_PASS - 1) / BITS_PER_PASS;
+
+// Deterministic: 64-bit mantissa-only accumulator (radix exponent class is
+// fixed per bucket because all values in a bucket share their top BITS_PER_PASS
+// MSBs — so summing the mantissas plus tracking the count is enough to
+// reconstruct an exact float per bucket regardless of summation order).
+template <typename T>
+using HisT = uint64_t;
+
+template <typename T>
+struct alignas(128) Counter {
+    T const* in;
+    IdxT oriLen;
+    AccT sum;          // remaining sum budget at current refinement level
+    IdxT len;          // candidates count in current refinement level
+    float p;           // top_p threshold; 0 means "skip this row"
+    AccT totalSum;     // total sum of the row (after pass 0)
+    IdxT previousLen;
+    typename cub::Traits<T>::UnsignedBits kthValueBits;
+    alignas(128) IdxT filterCnt;
+    alignas(128) uint32_t finishedBlockCnt;
+};
+
+template <typename IntType>
+constexpr __host__ __device__ IntType ceilDiv(IntType a, IntType b) {
+    return (a + b - 1) / b;
+}
+
+template <typename IntType>
+constexpr __host__ __device__ IntType alignTo(IntType a, IntType b) {
+    return ceilDiv(a, b) * b;
+}
+
+template <typename T>
+__device__ int constexpr calcStartBit(int pass) {
+    int startBit = static_cast<int>(sizeof(T) * 8) - (pass + 1) * BITS_PER_PASS;
+    return startBit < 0 ? 0 : startBit;
+}
+
+template <typename T>
+__device__ uint32_t constexpr calcMask(int pass) {
+    int numBits = calcStartBit<T>(pass - 1) - calcStartBit<T>(pass);
+    return (1 << numBits) - 1;
+}
+
+template <typename T>
+__device__ typename cub::Traits<T>::UnsignedBits twiddleIn(T key, bool selectMin) {
+    auto bits = reinterpret_cast<typename cub::Traits<T>::UnsignedBits&>(key);
+    bits = cub::Traits<T>::TwiddleIn(bits);
+    if (!selectMin) bits = ~bits;
+    return bits;
+}
+
+template <typename T>
+__device__ T twiddleOut(typename cub::Traits<T>::UnsignedBits bits, bool selectMin) {
+    if (!selectMin) bits = ~bits;
+    bits = cub::Traits<T>::TwiddleOut(bits);
+    return reinterpret_cast<T&>(bits);
+}
+
+template <typename T>
+__device__ int calcBucket(T x, int startBit, uint32_t mask) {
+    return (twiddleIn(x, false) >> startBit) & mask;
+}
+
+template <typename T>
+__host__ __device__ IdxT calcBufLen(IdxT len) {
+    IdxT constexpr ratio = 2 + sizeof(IdxT) * 2 / sizeof(T);
+    IdxT bufLen = len / (ratio * 8);
+    bufLen = alignTo(bufLen, 256);
+    return bufLen;
+}
+
+template <typename T>
+__host__ __device__ void setBufPointers(T const* in, T* buf1, T* buf2, int pass, T const*& inBuf,
+                                        T*& outBuf) {
+    if (pass == 0) {
+        inBuf = in;
+        outBuf = nullptr;
+    } else if (pass == 1) {
+        inBuf = in;
+        outBuf = buf1;
+    } else if (pass % 2 == 0) {
+        inBuf = buf1;
+        outBuf = buf2;
+    } else {
+        inBuf = buf2;
+        outBuf = buf1;
+    }
+}
+
+__device__ inline uint32_t calcMantissa(float value) {
+    union { uint32_t bits; float value; } u;
+    u.value = value;
+    constexpr uint32_t numMantissa = 23;
+    return u.bits & ((1u << numMantissa) - 1);
+}
+
+__device__ inline uint32_t calcExponent(float value) {
+    union { uint32_t bits; float value; } u;
+    u.value = value;
+    constexpr uint32_t numMantissa = 23;
+    return u.bits & ~((1u << numMantissa) - 1);
+}
+
+// Reconstruct sum-of-floats from {count, common exponent, accumulated mantissa
+// bits}. The common exponent comes from the bucket's bit pattern; count adds
+// in the implicit leading 1 bit each value has; bitSum stacks all mantissas.
+__device__ inline float calcFloatValue(uint32_t count, uint32_t exponent, uint64_t bitSum) {
+    constexpr uint32_t numTotalBits = 64;
+    constexpr uint32_t numMantissa = 23;
+    uint64_t extraInMantissa = (bitSum >> numMantissa);
+    extraInMantissa = (exponent == 0) ? extraInMantissa : extraInMantissa + count;
+    uint32_t numExtra = numTotalBits - __clzll(extraInMantissa);
+    int numNorm = (exponent == 0) ? 0 : -1;
+    exponent = exponent + ((numExtra + numNorm) << numMantissa);
+    uint32_t mantissa;
+    if (extraInMantissa != 0) {
+        int numMove = numMantissa - (numExtra - 1);
+        uint32_t mask = (1u << (numExtra - 1)) - 1;
+        extraInMantissa = extraInMantissa & mask;
+        if (numMove > 0) {
+            extraInMantissa = extraInMantissa << numMove;
+            mask = (1u << numMantissa) - 1;
+            mantissa = ((bitSum & mask) >> (numExtra - 1)) | extraInMantissa;
+        } else {
+            mantissa = extraInMantissa >> (-1 * numMove);
+        }
+    } else {
+        mantissa = bitSum;
+    }
+    uint32_t bitFloat = exponent | mantissa;
+    return reinterpret_cast<float&>(bitFloat);
+}
+
+template <typename T, typename HisT_>
+__device__ constexpr void histAtomicAdd(HisT_* dst, T value) {
+    uint32_t m = calcMantissa(value);
+    atomicAdd(reinterpret_cast<unsigned long long*>(dst), static_cast<uint64_t>(m));
+}
+
+template <typename T, typename Func>
+__device__ void vectorizedProcess(size_t threadRank, size_t numThreads, T const* in, IdxT len,
+                                  Func f) {
+    if constexpr (sizeof(T) >= sizeof(WideT)) {
+        for (IdxT i = threadRank; i < len; i += numThreads) f(in[i], i);
+    } else {
+        static_assert(sizeof(WideT) % sizeof(T) == 0);
+        constexpr int itemsPerScalar = sizeof(WideT) / sizeof(T);
+        union { WideT scalar; T array[itemsPerScalar]; } wide;
+        int skipCnt =
+            (reinterpret_cast<size_t>(in) % sizeof(WideT))
+                ? ((sizeof(WideT) - reinterpret_cast<size_t>(in) % sizeof(WideT)) / sizeof(T))
+                : 0;
+        if (skipCnt > len) skipCnt = len;
+        WideT const* inCast = reinterpret_cast<WideT const*>(in + skipCnt);
+        IdxT const lenCast = (len - skipCnt) / itemsPerScalar;
+        for (IdxT i = threadRank; i < lenCast; i += numThreads) {
+            wide.scalar = inCast[i];
+            IdxT const real_i = skipCnt + i * itemsPerScalar;
+#pragma unroll
+            for (int j = 0; j < itemsPerScalar; ++j) f(wide.array[j], real_i + j);
+        }
+        if (static_cast<IdxT>(threadRank) < skipCnt) {
+            f(in[threadRank], static_cast<IdxT>(threadRank));
+        }
+        IdxT const remain_i = skipCnt + lenCast * itemsPerScalar + threadRank;
+        if (remain_i < len) f(in[remain_i], remain_i);
+    }
+}
+
+template <typename T, typename HisT_>
+__device__ __forceinline__ void filterAndHistogram(T const* inBuf, T* outBuf, int previousLen,
+                                                   Counter<T>* counter, HisT_* histogram,
+                                                   IdxT* countHistogram, HisT_* histogramSmem,
+                                                   IdxT* countHistogramSmem, int pass) {
+    for (IdxT i = threadIdx.x; i < NUM_BUCKETS; i += blockDim.x) {
+        histogramSmem[i] = 0;
+        countHistogramSmem[i] = 0;
+    }
+    __syncthreads();
+    int const startBit = calcStartBit<T>(pass);
+    uint32_t const mask = calcMask<T>(pass);
+    if (pass == 0) {
+        auto f = [startBit, mask, histogramSmem, countHistogramSmem](T value, IdxT) {
+            int bucket = calcBucket<T>(value, startBit, mask);
+            histAtomicAdd<T>(histogramSmem + bucket, value);
+            atomicAdd(countHistogramSmem + bucket, static_cast<IdxT>(1));
+        };
+        vectorizedProcess<T>(static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x,
+                             static_cast<size_t>(blockDim.x) * gridDim.x, inBuf, previousLen, f);
+    } else {
+        IdxT* pFilterCnt = &counter->filterCnt;
+        auto const kthValueBits = counter->kthValueBits;
+        int const previousStartBit = calcStartBit<T>(pass - 1);
+        auto f = [outBuf, startBit, mask, previousStartBit, kthValueBits, pFilterCnt, histogramSmem,
+                  countHistogramSmem](T value, IdxT) {
+            auto const previousBits =
+                (twiddleIn(value, false) >> previousStartBit) << previousStartBit;
+            if (previousBits == kthValueBits) {
+                if (outBuf) {
+                    IdxT pos = atomicAdd(pFilterCnt, static_cast<IdxT>(1));
+                    outBuf[pos] = value;
+                }
+                int bucket = calcBucket<T>(value, startBit, mask);
+                histAtomicAdd<T>(histogramSmem + bucket, value);
+                atomicAdd(countHistogramSmem + bucket, static_cast<IdxT>(1));
+            }
+        };
+        vectorizedProcess<T>(static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x,
+                             static_cast<size_t>(blockDim.x) * gridDim.x, inBuf, previousLen, f);
+    }
+    __syncthreads();
+    for (int i = threadIdx.x; i < NUM_BUCKETS; i += blockDim.x) {
+        if (histogramSmem[i] != 0) {
+            atomicAdd(reinterpret_cast<unsigned long long*>(histogram + i),
+                      static_cast<unsigned long long>(histogramSmem[i]));
+        }
+        if (countHistogramSmem[i] != 0) atomicAdd(countHistogram + i, countHistogramSmem[i]);
+    }
+}
+
+template <typename T>
+__global__ void AirTopPRadixKernel(Counter<T>* counters, HisT<T>* histograms,
+                                   IdxT* countHistograms, int const pass, T* buf1, T* buf2) {
+    using HisT_ = HisT<T>;
+    int const batchId = blockIdx.y;
+    auto counter = counters + batchId;
+    AccT currentSum;
+    IdxT previousLen, currentLen;
+    if (pass == 0) {
+        currentSum = 0;
+        previousLen = counter->len;
+        currentLen = counter->len;
+    } else {
+        currentSum = counter->sum;
+        currentLen = counter->len;
+        previousLen = counter->previousLen;
+    }
+    if (currentLen == 0) return;
+    IdxT const bufLen = calcBufLen<T>(counter->oriLen);
+    T const* inBuf = nullptr;
+    T* outBuf = nullptr;
+    setBufPointers(counter->in, buf1 + bufLen * batchId, buf2 + bufLen * batchId, pass, inBuf,
+                   outBuf);
+    if (pass == 0 || pass == 1 || previousLen > bufLen) {
+        inBuf = counter->in;
+        previousLen = counter->oriLen;
+    }
+    if (pass == 0 || currentLen > bufLen) {
+        outBuf = nullptr;
+    }
+    auto histogram = histograms + batchId * NUM_BUCKETS;
+    auto countHistogram = countHistograms + batchId * NUM_BUCKETS;
+    __shared__ HisT_ histogramSmem[NUM_BUCKETS];
+    __shared__ IdxT countHistogramSmem[NUM_BUCKETS];
+    filterAndHistogram<T, HisT_>(inBuf, outBuf, previousLen, counter, histogram, countHistogram,
+                                 histogramSmem, countHistogramSmem, pass);
+    __syncthreads();
+    __threadfence();
+    bool isLastBlock = false;
+    if (threadIdx.x == 0) {
+        uint32_t finished = atomicInc(&counter->finishedBlockCnt, gridDim.x - 1);
+        isLastBlock = (finished == (gridDim.x - 1));
+    }
+    if (__syncthreads_or(isLastBlock)) {
+        AccT* histValueSmem = reinterpret_cast<AccT*>(histogramSmem);
+        for (int i = threadIdx.x; i < NUM_BUCKETS; i += blockDim.x) {
+            uint64_t value = static_cast<uint64_t>(histogram[i]);
+            IdxT count = countHistogram[i];
+            if (count != 0) {
+                uint32_t sb = calcStartBit<T>(pass);
+                uint32_t bv = counter->kthValueBits;
+                if (pass == 0) bv = i << sb;
+                histValueSmem[i] = calcFloatValue(static_cast<uint32_t>(count),
+                                                  calcExponent(twiddleOut<T>(bv, false)), value);
+            } else {
+                histValueSmem[i] = 0.0f;
+            }
+        }
+        __syncthreads();
+        constexpr int WARP_SIZE = 32;
+        constexpr int WARP_COUNT = NUM_BUCKETS / WARP_SIZE;
+        namespace cg = cooperative_groups;
+        cg::thread_block block = cg::this_thread_block();
+        cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
+        AccT* histPtr = histValueSmem;
+        __shared__ AccT warpSum[WARP_COUNT];
+        __shared__ cuda::atomic<AccT, cuda::thread_scope_block> blockSum;
+        for (int i = threadIdx.x; i < NUM_BUCKETS; i += BLOCK_SIZE) {
+            reduce_store_async(warp, warpSum + i / WARP_SIZE, histPtr[i], cg::plus<float>{});
+        }
+        __syncthreads();
+        if (threadIdx.x < WARP_SIZE) {
+            reduce_store_async(warp, blockSum, warpSum[threadIdx.x], cg::plus<float>{});
+            reduce_update_async(warp, blockSum, warpSum[threadIdx.x + WARP_SIZE],
+                                cg::plus<float>{});
+        }
+        __syncthreads();
+        if (pass == 0 && threadIdx.x == 0) {
+            counter->totalSum = blockSum.load();
+        }
+        if (pass == 0) currentSum = blockSum.load() * counter->p;
+        if (threadIdx.x == 0) {
+            AccT prev = 0;
+            int targetStep = 0;
+            for (int i = 0; i < WARP_COUNT; i++) {
+                if (warpSum[i]) {
+                    targetStep = i;
+                    if ((prev + warpSum[i]) >= currentSum) break;
+                    prev += warpSum[i];
+                }
+            }
+            int targetIdx = 0;
+            for (int i = targetStep * WARP_SIZE; i < NUM_BUCKETS; i++) {
+                if (countHistogram[i]) {
+                    targetIdx = i;
+                    if ((prev + histPtr[i]) >= currentSum) break;
+                    prev += histPtr[i];
+                }
+            }
+            counter->sum = currentSum - prev;
+            counter->len = countHistogram[targetIdx];
+            typename cub::Traits<T>::UnsignedBits bucket = targetIdx;
+            counter->kthValueBits |= bucket << calcStartBit<T>(pass);
+        }
+        __syncthreads();
+        if (pass != NUM_PASSES<T> - 1) {
+            for (int i = threadIdx.x; i < NUM_BUCKETS; i += blockDim.x) {
+                histogram[i] = 0;
+                countHistogram[i] = 0;
+            }
+        }
+        if (threadIdx.x == 0) {
+            counter->previousLen = currentLen;
+            counter->filterCnt = 0;
+        }
+    }
+}
+
+// Per-row init. Sets counter->len to oriLen (vocab size) only when this row is
+// in top-p mode (top_k > maxTopK); otherwise len stays 0 so every radix pass
+// short-circuits via the `if (currentLen == 0) return;` check.
+template <typename T>
+__global__ void AirTopPInitKernel(Counter<T>* counters, int len, T const* in,
+                                  float const* top_p_arr, int32_t const* top_k_arr,
+                                  int32_t maxTopK, HisT<T>* histograms,
+                                  IdxT* countHistograms) {
+    int const batchIdx = blockIdx.x;
+    Counter<T>* counter = counters + batchIdx;
+    int32_t k = top_k_arr[batchIdx];
+    float p = top_p_arr[batchIdx];
+    bool active = (k > maxTopK);
+    if (threadIdx.x == 0) {
+        counter->in = in + batchIdx * len;
+        counter->oriLen = len;
+        counter->len = active ? len : 0;
+        counter->previousLen = len;
+        counter->p = active ? p : 0.0f;
+        counter->totalSum = 0.0f;
+        counter->sum = 0;
+        counter->kthValueBits = 0;
+        counter->finishedBlockCnt = 0;
+        counter->filterCnt = 0;
+    }
+    HisT<T>* hist = histograms + batchIdx * NUM_BUCKETS;
+    IdxT* cntHist = countHistograms + batchIdx * NUM_BUCKETS;
+    for (int i = threadIdx.x; i < NUM_BUCKETS; i += blockDim.x) {
+        hist[i] = 0;
+        cntHist[i] = 0;
+    }
+}
+
+template <typename T>
+uint32_t CalcAirTopPBlockNum(int batchSize, int len, int smCnt) {
+    constexpr int VECTORIZED_READ_SIZE = 16;
+    int activeBlocks;
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(&activeBlocks, AirTopPRadixKernel<T>, BLOCK_SIZE,
+                                                  0);
+    activeBlocks *= smCnt;
+    IdxT bestNumBlocks = 0;
+    float bestTailWavePenalty = 1.0f;
+    IdxT const maxNumBlocks =
+        ceilDiv<IdxT>(len, VECTORIZED_READ_SIZE / (int)sizeof(T) * BLOCK_SIZE);
+    for (int numWaves = 1;; ++numWaves) {
+        IdxT numBlocks = std::min(
+            maxNumBlocks, static_cast<IdxT>(std::max(numWaves * activeBlocks / batchSize, 1)));
+        IdxT itemsPerThread = ceilDiv<IdxT>(len, numBlocks * BLOCK_SIZE);
+        itemsPerThread = alignTo<IdxT>(itemsPerThread, VECTORIZED_READ_SIZE / (int)sizeof(T));
+        numBlocks = ceilDiv<IdxT>(len, itemsPerThread * BLOCK_SIZE);
+        float actualNumWaves = static_cast<float>(numBlocks) * batchSize / activeBlocks;
+        float tailWavePenalty = (ceilf(actualNumWaves) - actualNumWaves) / ceilf(actualNumWaves);
+        if (tailWavePenalty < 0.15f) {
+            bestNumBlocks = numBlocks;
+            break;
+        } else if (tailWavePenalty < bestTailWavePenalty) {
+            bestNumBlocks = numBlocks;
+            bestTailWavePenalty = tailWavePenalty;
+        }
+        if (numBlocks == maxNumBlocks) break;
+    }
+    return bestNumBlocks;
+}
+
+template <typename T>
+size_t getWorkspaceBytes(int batchSize, int vocabSize) {
+    auto align256 = [](size_t x) { return ((x + 255) / 256) * 256; };
+    IdxT const bufLen = calcBufLen<T>(vocabSize);
+    size_t countersSize = align256(sizeof(Counter<T>) * batchSize);
+    size_t histSize = align256(sizeof(HisT<T>) * NUM_BUCKETS * batchSize);
+    size_t countHistSize = align256(sizeof(IdxT) * NUM_BUCKETS * batchSize);
+    size_t bufSize = align256(sizeof(T) * bufLen * batchSize);
+    return countersSize + histSize + countHistSize + 2 * bufSize + 256;
+}
+
+// Resolve the workspace pointers and return them via the out-args. The caller
+// is responsible for zeroing the counters/histograms/countHistograms (the
+// unified init kernel does this so we can skip the separate AirTopPInitKernel).
+template <typename T>
+void resolveWorkspace(int batchSize, int vocabSize, void* workspace,
+                      Counter<T>*& outCounters,
+                      HisT<T>*& outHistograms,
+                      IdxT*& outCountHistograms,
+                      T*& outBuf1,
+                      T*& outBuf2) {
+    auto align256 = [](size_t x) { return ((x + 255) / 256) * 256; };
+    IdxT const bufLen = calcBufLen<T>(vocabSize);
+    size_t countersSize = align256(sizeof(Counter<T>) * batchSize);
+    size_t histSize = align256(sizeof(HisT<T>) * NUM_BUCKETS * batchSize);
+    size_t countHistSize = align256(sizeof(IdxT) * NUM_BUCKETS * batchSize);
+    size_t bufSize = align256(sizeof(T) * bufLen * batchSize);
+
+    uint8_t* ws = static_cast<uint8_t*>(workspace);
+    outCounters = reinterpret_cast<Counter<T>*>(ws);
+    outHistograms = reinterpret_cast<HisT<T>*>(ws + countersSize);
+    outCountHistograms = reinterpret_cast<IdxT*>(ws + countersSize + histSize);
+    outBuf1 = reinterpret_cast<T*>(ws + countersSize + histSize + countHistSize);
+    outBuf2 = reinterpret_cast<T*>(ws + countersSize + histSize + countHistSize + bufSize);
+}
+
+// Run just the 3 radix passes. Counters/histograms must already be initialized
+// (e.g. by the fused kernel's unifiedInitKernel).
+template <typename T>
+void launchRadixOnly(Counter<T>* counters, HisT<T>* histograms, IdxT* countHistograms,
+                     T* buf1, T* buf2, int batchSize, int vocabSize,
+                     cudaStream_t stream) {
+    auto launchPDL = [&](auto kernel, dim3 grid, dim3 block, size_t smem, auto... args) {
+        cudaLaunchAttribute attr[1];
+        attr[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+        attr[0].val.programmaticStreamSerializationAllowed = 1;
+        cudaLaunchConfig_t config{};
+        config.gridDim = grid;
+        config.blockDim = block;
+        config.dynamicSmemBytes = smem;
+        config.stream = stream;
+        config.attrs = attr;
+        config.numAttrs = 1;
+        cudaLaunchKernelEx(&config, kernel, args...);
+    };
+
+    int dev = 0, smCnt = 0;
+    cudaGetDevice(&dev);
+    cudaDeviceGetAttribute(&smCnt, cudaDevAttrMultiProcessorCount, dev);
+    uint32_t blockNum = CalcAirTopPBlockNum<T>(batchSize, vocabSize, smCnt);
+    dim3 grid(blockNum, batchSize);
+    constexpr int numPasses = NUM_PASSES<T>;
+    for (int pass = 0; pass < numPasses; ++pass) {
+        launchPDL(AirTopPRadixKernel<T>, grid, dim3(BLOCK_SIZE), 0, counters, histograms,
+                  countHistograms, pass, buf1, buf2);
+    }
+}
+
+template <typename T>
+void launch(T const* probs, float const* topPArr, int32_t const* topKArr, int32_t maxTopK,
+            int batchSize, int vocabSize, void* workspace, Counter<T>*& outCounters,
+            cudaStream_t stream) {
+    auto align256 = [](size_t x) { return ((x + 255) / 256) * 256; };
+    IdxT const bufLen = calcBufLen<T>(vocabSize);
+    size_t countersSize = align256(sizeof(Counter<T>) * batchSize);
+    size_t histSize = align256(sizeof(HisT<T>) * NUM_BUCKETS * batchSize);
+    size_t countHistSize = align256(sizeof(IdxT) * NUM_BUCKETS * batchSize);
+    size_t bufSize = align256(sizeof(T) * bufLen * batchSize);
+
+    uint8_t* ws = static_cast<uint8_t*>(workspace);
+    Counter<T>* counters = reinterpret_cast<Counter<T>*>(ws);
+    HisT<T>* histograms = reinterpret_cast<HisT<T>*>(ws + countersSize);
+    IdxT* countHistograms = reinterpret_cast<IdxT*>(ws + countersSize + histSize);
+    T* buf1 = reinterpret_cast<T*>(ws + countersSize + histSize + countHistSize);
+    T* buf2 = reinterpret_cast<T*>(ws + countersSize + histSize + countHistSize + bufSize);
+
+    outCounters = counters;
+
+    auto launchPDL = [&](auto kernel, dim3 grid, dim3 block, size_t smem, auto... args) {
+        cudaLaunchAttribute attr[1];
+        attr[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+        attr[0].val.programmaticStreamSerializationAllowed = 1;
+        cudaLaunchConfig_t config{};
+        config.gridDim = grid;
+        config.blockDim = block;
+        config.dynamicSmemBytes = smem;
+        config.stream = stream;
+        config.attrs = attr;
+        config.numAttrs = 1;
+        cudaLaunchKernelEx(&config, kernel, args...);
+    };
+
+    launchPDL(AirTopPInitKernel<T>, dim3(batchSize), dim3(256), 0, counters, vocabSize, probs,
+              topPArr, topKArr, maxTopK, histograms, countHistograms);
+
+    int dev = 0, smCnt = 0;
+    cudaGetDevice(&dev);
+    cudaDeviceGetAttribute(&smCnt, cudaDevAttrMultiProcessorCount, dev);
+    uint32_t blockNum = CalcAirTopPBlockNum<T>(batchSize, vocabSize, smCnt);
+    dim3 grid(blockNum, batchSize);
+    constexpr int numPasses = NUM_PASSES<T>;
+    for (int pass = 0; pass < numPasses; ++pass) {
+        launchPDL(AirTopPRadixKernel<T>, grid, dim3(BLOCK_SIZE), 0, counters, histograms,
+                  countHistograms, pass, buf1, buf2);
+    }
+}
+
+}  // namespace air_top_p
+
+#endif  // AIR_TOP_P_CUH_

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/air_topk_stable.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/air_topk_stable.cuh
@@ -1,0 +1,1236 @@
+#ifndef AIR_TOPK_STABLE_CUH_
+#define AIR_TOPK_STABLE_CUH_
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <vector>
+
+#include <cuda/atomic>
+#include <cuda_runtime.h>
+
+#include <cub/cub.cuh>
+
+#include "nv_util.h"
+
+namespace nv {
+
+namespace air_topk_stable {
+using WideT = float4;
+constexpr int VECTORIZED_READ_SIZE = 16;
+constexpr int WARP_SIZE = 32;
+constexpr unsigned FULL_WARP_MASK = 0xffffffff;
+
+#ifdef __CUDA_ARCH__
+using ::atomicAdd;
+inline __device__ size_t atomicAdd(size_t* address, size_t value) {
+    static_assert(sizeof(size_t) == sizeof(unsigned long long int));
+    return atomicAdd(
+        reinterpret_cast<unsigned long long int*>(address),
+        static_cast<unsigned long long int>(value));
+}
+#endif
+
+template<int BitsPerPass>
+__host__ __device__ constexpr int calc_num_buckets() {
+    return 1 << BitsPerPass;
+}
+
+template<typename IntType>
+constexpr __host__ __device__ IntType ceildiv(IntType a, IntType b) {
+    return (a + b - 1) / b;
+}
+
+template<typename IntType>
+constexpr __host__ __device__ IntType alignTo(IntType a, IntType b) {
+    return ceildiv(a, b) * b;
+}
+
+template<typename T, int BitsPerPass>
+__host__ __device__ constexpr int calc_num_passes() {
+    return ceildiv<int>(static_cast<int>(sizeof(T) * 8), BitsPerPass);
+}
+
+__host__ __device__ inline int round_up(int num, int round_value) {
+    return ((num - 1) / round_value + 1) * round_value;
+}
+
+template<typename T, int BitsPerPass>
+__device__ constexpr int calc_start_bit(int pass) {
+    int start_bit = static_cast<int>(sizeof(T) * 8) - (pass + 1) * BitsPerPass;
+    if (start_bit < 0) {
+        start_bit = 0;
+    }
+    return start_bit;
+}
+
+template<typename T, int BitsPerPass>
+__device__ constexpr unsigned calc_mask(int pass) {
+    static_assert(BitsPerPass <= 31);
+    int num_bits =
+        calc_start_bit<T, BitsPerPass>(pass - 1) - calc_start_bit<T, BitsPerPass>(pass);
+    return (1U << num_bits) - 1U;
+}
+
+template<typename T>
+__device__ typename cub::Traits<T>::UnsignedBits twiddle_in(T key, bool select_min) {
+    auto bits = reinterpret_cast<typename cub::Traits<T>::UnsignedBits&>(key);
+    bits = cub::Traits<T>::TwiddleIn(bits);
+    if (!select_min) {
+        bits = ~bits;
+    }
+    return bits;
+}
+
+template<typename T>
+__device__ T twiddle_out(typename cub::Traits<T>::UnsignedBits bits, bool select_min) {
+    if (!select_min) {
+        bits = ~bits;
+    }
+    bits = cub::Traits<T>::TwiddleOut(bits);
+    return reinterpret_cast<T&>(bits);
+}
+
+template<typename T, int BitsPerPass>
+__device__ int calc_bucket(T x, int start_bit, unsigned mask, bool select_min) {
+    static_assert(BitsPerPass <= sizeof(int) * 8 - 1,
+                  "BitsPerPass is too large that the result type could not be int");
+    return static_cast<int>((twiddle_in(x, select_min) >> start_bit) & mask);
+}
+
+template<typename I>
+constexpr inline std::enable_if_t<std::is_integral<I>::value, bool> is_a_power_of_two(
+    I val) noexcept {
+    return ((val - 1) & val) == 0;
+}
+
+template<typename T, typename IdxT, typename RATIO_T = float>
+__host__ __device__ IdxT calc_buf_len(IdxT len) {
+    constexpr RATIO_T ratio = 2 + sizeof(IdxT) * 2 / sizeof(T);
+    IdxT buf_len = len / (ratio * 8);
+    static_assert(is_a_power_of_two(sizeof(T)));
+    static_assert(is_a_power_of_two(sizeof(IdxT)));
+    constexpr IdxT aligned = 256 / std::min(sizeof(T), sizeof(IdxT));
+    buf_len = buf_len & (~(aligned - 1));
+    return buf_len;
+}
+
+template<typename T, typename idxT, typename Func>
+__device__ void vectorized_process(
+    size_t thread_rank, size_t num_threads, const T* in, idxT len, Func f) {
+    if constexpr (sizeof(T) >= sizeof(WideT)) {
+        for (idxT i = thread_rank; i < len; i += num_threads) {
+            f(in[i], i);
+        }
+    }
+    else {
+        static_assert(sizeof(WideT) % sizeof(T) == 0);
+        constexpr int items_per_scalar = static_cast<int>(sizeof(WideT) / sizeof(T));
+        union {
+            WideT scalar;
+            T array[items_per_scalar];
+        } wide;
+
+        int skip_cnt =
+            (reinterpret_cast<size_t>(in) % sizeof(WideT))
+                ? static_cast<int>((sizeof(WideT) - reinterpret_cast<size_t>(in) % sizeof(WideT))
+                                     / sizeof(T))
+                : 0;
+        if (skip_cnt > len) {
+            skip_cnt = static_cast<int>(len);
+        }
+        const WideT* in_cast = reinterpret_cast<const WideT*>(in + skip_cnt);
+        const idxT len_cast = (len - skip_cnt) / items_per_scalar;
+
+        for (idxT i = thread_rank; i < len_cast; i += num_threads) {
+            wide.scalar = in_cast[i];
+            const idxT real_i = skip_cnt + i * items_per_scalar;
+#pragma unroll
+            for (int j = 0; j < items_per_scalar; ++j) {
+                f(wide.array[j], real_i + j);
+            }
+        }
+
+        static_assert(WARP_SIZE >= items_per_scalar);
+        if (thread_rank < static_cast<size_t>(skip_cnt)) {
+            f(in[thread_rank], static_cast<idxT>(thread_rank));
+        }
+        const idxT remain_i = skip_cnt + len_cast * items_per_scalar + static_cast<idxT>(thread_rank);
+        if (remain_i < len) {
+            f(in[remain_i], remain_i);
+        }
+    }
+}
+
+template<typename T, typename idxT, typename Func>
+__device__ void vectorized_process(const T* in, idxT len, Func f, int sync_width) {
+    const idxT stride = blockDim.x * gridDim.x;
+    const idxT tid = blockIdx.x * blockDim.x + threadIdx.x;
+    if constexpr (sizeof(T) >= sizeof(WideT)) {
+        for (idxT i = tid; i < len; i += stride) {
+            f(in[i], i, true);
+        }
+    }
+    else {
+        static_assert(sizeof(WideT) % sizeof(T) == 0);
+        constexpr int items_per_scalar = static_cast<int>(sizeof(WideT) / sizeof(T));
+        union {
+            WideT scalar;
+            T array[items_per_scalar];
+        } wide;
+
+        int skip_cnt =
+            (reinterpret_cast<size_t>(in) % sizeof(WideT))
+                ? static_cast<int>((sizeof(WideT) - reinterpret_cast<size_t>(in) % sizeof(WideT))
+                                     / sizeof(T))
+                : 0;
+        if (skip_cnt > len) {
+            skip_cnt = static_cast<int>(len);
+        }
+        const WideT* in_cast = reinterpret_cast<const WideT*>(in + skip_cnt);
+        const idxT len_cast = (len - skip_cnt) / items_per_scalar;
+
+        const idxT len_cast_for_sync = ((len_cast - 1) / sync_width + 1) * sync_width;
+        for (idxT i = tid; i < len_cast_for_sync; i += stride) {
+            bool valid = i < len_cast;
+            if (valid) {
+                wide.scalar = in_cast[i];
+            }
+            const idxT real_i = skip_cnt + i * items_per_scalar;
+#pragma unroll
+            for (int j = 0; j < items_per_scalar; ++j) {
+                f(wide.array[j], real_i + j, valid);
+            }
+        }
+
+        static_assert(WARP_SIZE >= items_per_scalar);
+        if (tid < sync_width) {
+            bool valid = tid < static_cast<unsigned>(skip_cnt);
+            T value = valid ? in[tid] : T();
+            f(value, static_cast<idxT>(tid), valid);
+
+            const idxT remain_i = skip_cnt + len_cast * items_per_scalar + tid;
+            valid = remain_i < len;
+            value = valid ? in[remain_i] : T();
+            f(value, remain_i, valid);
+        }
+    }
+}
+
+template<typename T, typename IdxT>
+struct alignas(128) Counter {
+    IdxT k;
+    IdxT len;
+    IdxT previous_len;
+    typename cub::Traits<T>::UnsignedBits kth_value_bits;
+    // Per-row short-circuit flag: when set to non-zero, radix_kernel and
+    // last_filter_kernel return immediately without doing any work for this
+    // row. Lets callers (e.g. fused top-k + top-p) skip top-k for rows where
+    // top_k is effectively "no cap" (mode 3.2). Zero by default — memset of
+    // the workspace leaves this off, so existing callers see no behavior
+    // change.
+    int skip;
+    alignas(128) IdxT filter_cnt;
+    alignas(128) unsigned int finished_block_cnt;
+    alignas(128) IdxT out_cnt;
+    alignas(128) IdxT out_back_cnt;
+};
+
+template<typename T, typename IdxT, int BitsPerPass>
+__device__ void filter_and_histogram(const T* in_buf,
+                                     const IdxT* in_idx_buf,
+                                     T* out_buf,
+                                     IdxT* out_idx_buf,
+                                     T* out,
+                                     IdxT* out_idx,
+                                     IdxT previous_len,
+                                     Counter<T, IdxT>* counter,
+                                     IdxT* histogram,
+                                     bool select_min,
+                                     int pass,
+                                     bool early_stop) {
+    constexpr int num_buckets = calc_num_buckets<BitsPerPass>();
+    __shared__ IdxT histogram_smem[num_buckets];
+    for (IdxT i = threadIdx.x; i < num_buckets; i += blockDim.x) {
+        histogram_smem[i] = 0;
+    }
+    __syncthreads();
+
+    const int start_bit = calc_start_bit<T, BitsPerPass>(pass);
+    const unsigned mask = calc_mask<T, BitsPerPass>(pass);
+
+    if (pass == 0) {
+        auto f = [select_min, start_bit, mask](T value, IdxT) {
+            int bucket = calc_bucket<T, BitsPerPass>(value, start_bit, mask, select_min);
+            atomicAdd(histogram_smem + bucket, static_cast<IdxT>(1));
+        };
+        vectorized_process(static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x,
+                           static_cast<size_t>(blockDim.x) * gridDim.x,
+                           in_buf,
+                           previous_len,
+                           f);
+    }
+    else {
+        IdxT* p_filter_cnt = &counter->filter_cnt;
+        IdxT* p_out_cnt = &counter->out_cnt;
+        const auto kth_value_bits = counter->kth_value_bits;
+        const int previous_start_bit = calc_start_bit<T, BitsPerPass>(pass - 1);
+
+        auto f = [in_idx_buf,
+                  out_buf,
+                  out_idx_buf,
+                  out,
+                  out_idx,
+                  select_min,
+                  start_bit,
+                  mask,
+                  previous_start_bit,
+                  kth_value_bits,
+                  p_filter_cnt,
+                  p_out_cnt,
+                  early_stop](T value, IdxT i) {
+            const auto previous_bits =
+                (twiddle_in(value, select_min) >> previous_start_bit)
+                << previous_start_bit;
+            if (previous_bits == kth_value_bits) {
+                if (early_stop) {
+                    IdxT pos = atomicAdd(p_out_cnt, static_cast<IdxT>(1));
+                    out[pos] = value;
+                    out_idx[pos] = in_idx_buf ? in_idx_buf[i] : i;
+                }
+                else {
+                    if (out_buf) {
+                        IdxT pos = atomicAdd(p_filter_cnt, static_cast<IdxT>(1));
+                        out_buf[pos] = value;
+                        out_idx_buf[pos] = in_idx_buf ? in_idx_buf[i] : i;
+                    }
+
+                    int bucket =
+                        calc_bucket<T, BitsPerPass>(value, start_bit, mask, select_min);
+                    atomicAdd(histogram_smem + bucket, static_cast<IdxT>(1));
+                }
+            }
+            else if ((out_buf || early_stop) && previous_bits < kth_value_bits) {
+                IdxT pos = atomicAdd(p_out_cnt, static_cast<IdxT>(1));
+                out[pos] = value;
+                out_idx[pos] = in_idx_buf ? in_idx_buf[i] : i;
+            }
+        };
+        vectorized_process(static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x,
+                           static_cast<size_t>(blockDim.x) * gridDim.x,
+                           in_buf,
+                           previous_len,
+                           f);
+    }
+    if (early_stop) {
+        return;
+    }
+    __syncthreads();
+
+    for (int i = threadIdx.x; i < num_buckets; i += blockDim.x) {
+        if (histogram_smem[i] != 0) {
+            atomicAdd(histogram + i, histogram_smem[i]);
+        }
+    }
+}
+
+template<typename IdxT, int BitsPerPass, int BlockSize>
+__device__ void scan(IdxT* histogram) {
+    constexpr int num_buckets = calc_num_buckets<BitsPerPass>();
+    if constexpr (num_buckets >= BlockSize) {
+        static_assert(num_buckets % BlockSize == 0);
+        constexpr int items_per_thread = num_buckets / BlockSize;
+        typedef cub::
+            BlockLoad<IdxT, BlockSize, items_per_thread, cub::BLOCK_LOAD_TRANSPOSE>
+                BlockLoad;
+        typedef cub::
+            BlockStore<IdxT, BlockSize, items_per_thread, cub::BLOCK_STORE_TRANSPOSE>
+                BlockStore;
+        typedef cub::BlockScan<IdxT, BlockSize> BlockScan;
+
+        __shared__ union {
+            typename BlockLoad::TempStorage load;
+            typename BlockScan::TempStorage scan;
+            typename BlockStore::TempStorage store;
+        } temp_storage;
+        IdxT thread_data[items_per_thread];
+
+        BlockLoad(temp_storage.load).Load(histogram, thread_data);
+        __syncthreads();
+
+        BlockScan(temp_storage.scan).InclusiveSum(thread_data, thread_data);
+        __syncthreads();
+
+        BlockStore(temp_storage.store).Store(histogram, thread_data);
+    }
+    else {
+        typedef cub::BlockScan<IdxT, BlockSize> BlockScan;
+        __shared__ typename BlockScan::TempStorage temp_storage;
+
+        IdxT thread_data = 0;
+        if (threadIdx.x < static_cast<unsigned>(num_buckets)) {
+            thread_data = histogram[threadIdx.x];
+        }
+
+        BlockScan(temp_storage).InclusiveSum(thread_data, thread_data);
+        __syncthreads();
+
+        if (threadIdx.x < static_cast<unsigned>(num_buckets)) {
+            histogram[threadIdx.x] = thread_data;
+        }
+    }
+}
+
+template<typename T, typename IdxT, int BitsPerPass>
+__device__ void choose_bucket(Counter<T, IdxT>* counter,
+                              const IdxT* histogram,
+                              const IdxT k,
+                              const int pass) {
+    constexpr int num_buckets = calc_num_buckets<BitsPerPass>();
+    for (int i = threadIdx.x; i < num_buckets; i += blockDim.x) {
+        IdxT prev = (i == 0) ? 0 : histogram[i - 1];
+        IdxT cur = histogram[i];
+
+        if (prev < k && cur >= k) {
+            counter->k = k - prev;
+            counter->len = cur - prev;
+            typename cub::Traits<T>::UnsignedBits bucket = static_cast<typename cub::Traits<T>::UnsignedBits>(i);
+            int start_bit = calc_start_bit<T, BitsPerPass>(pass);
+            counter->kth_value_bits |= bucket << start_bit;
+        }
+    }
+}
+
+template<typename T,
+         typename IdxT,
+         int BitsPerPass,
+         bool prioritize_smaller_indice = false>
+__device__ void last_filter(const T* in_buf,
+                            const IdxT* in_idx_buf,
+                            T* out,
+                            IdxT* out_idx,
+                            IdxT current_len,
+                            IdxT k,
+                            Counter<T, IdxT>* counter,
+                            const bool select_min,
+                            const int pass) {
+    const auto kth_value_bits = counter->kth_value_bits;
+    const int start_bit = calc_start_bit<T, BitsPerPass>(pass);
+
+    const IdxT num_of_kth_needed = counter->k;
+    IdxT* p_out_cnt = &counter->out_cnt;
+    IdxT* p_out_back_cnt = &counter->out_back_cnt;
+    IdxT* p_equal = out_idx + k - num_of_kth_needed;
+    for (IdxT i = threadIdx.x; i < current_len; i += blockDim.x) {
+        const T value = in_buf[i];
+        const auto bits = (twiddle_in(value, select_min) >> start_bit) << start_bit;
+        if (bits < kth_value_bits) {
+            IdxT pos = atomicAdd(p_out_cnt, static_cast<IdxT>(1));
+            out[pos] = value;
+            out_idx[pos] = in_idx_buf ? in_idx_buf[i] : i;
+        }
+        else if (bits == kth_value_bits) {
+            IdxT new_idx = in_idx_buf ? in_idx_buf[i] : i;
+            IdxT back_pos = atomicAdd(p_out_back_cnt, static_cast<IdxT>(1));
+            if (back_pos < num_of_kth_needed) {
+                IdxT pos = k - 1 - back_pos;
+                out[pos] = value;
+                if constexpr (!prioritize_smaller_indice) {
+                    out_idx[pos] = new_idx;
+                }
+            }
+            if constexpr (prioritize_smaller_indice) {
+                if (new_idx < p_equal[num_of_kth_needed - 1]) {
+                    for (int j = 0; j < num_of_kth_needed; j++) {
+                        IdxT pre_idx = atomicMin(&p_equal[j], new_idx);
+                        if (pre_idx > new_idx) {
+                            new_idx = pre_idx;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+template<typename T,
+         typename IdxT,
+         int BitsPerPass,
+         bool prioritize_smaller_indice = false>
+__global__ void last_filter_kernel(const T* in,
+                                   const IdxT* in_idx,
+                                   const T* in_buf,
+                                   const IdxT* in_idx_buf,
+                                   T* out,
+                                   IdxT* out_idx,
+                                   IdxT len,
+                                   IdxT k,
+                                   Counter<T, IdxT>* counters,
+                                   const bool select_min) {
+    const size_t batch_id = blockIdx.y;
+
+    Counter<T, IdxT>* counter = counters + batch_id;
+    if (counter->skip) {
+        return;
+    }
+    IdxT previous_len = counter->previous_len;
+    if (previous_len == 0) {
+        return;
+    }
+    const IdxT buf_len = calc_buf_len<T>(len);
+    if (previous_len > buf_len || in_buf == in) {
+        in_buf = in + batch_id * len;
+        in_idx_buf = in_idx ? (in_idx + batch_id * len) : nullptr;
+        previous_len = len;
+    }
+    else {
+        in_buf += batch_id * buf_len;
+        in_idx_buf += batch_id * buf_len;
+    }
+    out += batch_id * k;
+    out_idx += batch_id * k;
+
+    constexpr int pass = calc_num_passes<T, BitsPerPass>() - 1;
+    constexpr int start_bit = calc_start_bit<T, BitsPerPass>(pass);
+
+    const auto kth_value_bits = counter->kth_value_bits;
+    const IdxT num_of_kth_needed = counter->k;
+    IdxT* p_out_cnt = &counter->out_cnt;
+    IdxT* p_out_back_cnt = &counter->out_back_cnt;
+    IdxT* p_equal = out_idx + k - num_of_kth_needed;
+    auto f = [k,
+              select_min,
+              kth_value_bits,
+              num_of_kth_needed,
+              p_out_cnt,
+              p_out_back_cnt,
+              in_idx_buf,
+              out,
+              out_idx,
+              p_equal](T value, IdxT i) {
+        const auto bits = (twiddle_in(value, select_min) >> start_bit) << start_bit;
+        if (bits < kth_value_bits) {
+            IdxT pos = atomicAdd(p_out_cnt, static_cast<IdxT>(1));
+            out[pos] = value;
+            out_idx[pos] = in_idx_buf ? in_idx_buf[i] : i;
+        }
+        else if (bits == kth_value_bits) {
+            IdxT new_idx = in_idx_buf ? in_idx_buf[i] : i;
+            IdxT back_pos = atomicAdd(p_out_back_cnt, static_cast<IdxT>(1));
+            if (back_pos < num_of_kth_needed) {
+                IdxT pos = k - 1 - back_pos;
+                out[pos] = value;
+                if constexpr (!prioritize_smaller_indice) {
+                    out_idx[pos] = new_idx;
+                }
+            }
+            if constexpr (prioritize_smaller_indice) {
+                if (new_idx < p_equal[num_of_kth_needed - 1]) {
+                    for (int j = 0; j < num_of_kth_needed; j++) {
+                        IdxT pre_idx = atomicMin(&p_equal[j], new_idx);
+                        if (pre_idx > new_idx) {
+                            new_idx = pre_idx;
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    vectorized_process(static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x,
+                       static_cast<size_t>(blockDim.x) * gridDim.x,
+                       in_buf,
+                       previous_len,
+                       f);
+}
+
+template<typename T,
+         typename IdxT,
+         int BitsPerPass,
+         int BlockSize,
+         bool fused_last_filter,
+         bool prioritize_smaller_indice = false>
+__global__ void radix_kernel(const T* in,
+                             const IdxT* in_idx,
+                             const T* in_buf,
+                             const IdxT* in_idx_buf,
+                             T* out_buf,
+                             IdxT* out_idx_buf,
+                             T* out,
+                             IdxT* out_idx,
+                             Counter<T, IdxT>* counters,
+                             IdxT* histograms,
+                             const IdxT len,
+                             const IdxT k,
+                             const bool select_min,
+                             const int pass) {
+    const size_t batch_id = blockIdx.y;
+    auto counter = counters + batch_id;
+    if (counter->skip) {
+        return;
+    }
+    IdxT current_k;
+    IdxT previous_len;
+    IdxT current_len;
+    if (pass == 0) {
+        current_k = k;
+        previous_len = len;
+        current_len = len;
+    }
+    else {
+        current_k = counter->k;
+        current_len = counter->len;
+        previous_len = counter->previous_len;
+    }
+    if (current_len == 0) {
+        return;
+    }
+
+    const bool early_stop = (current_len == current_k);
+    const IdxT buf_len = calc_buf_len<T>(len);
+
+    if (pass == 0 || pass == 1 || previous_len > buf_len) {
+        in_buf = in + batch_id * len;
+        in_idx_buf = in_idx ? (in_idx + batch_id * len) : nullptr;
+        previous_len = len;
+    }
+    else {
+        in_buf += batch_id * buf_len;
+        in_idx_buf += batch_id * buf_len;
+    }
+    if (pass == 0 || current_len > buf_len) {
+        out_buf = nullptr;
+        out_idx_buf = nullptr;
+    }
+    else {
+        out_buf += batch_id * buf_len;
+        out_idx_buf += batch_id * buf_len;
+    }
+    out += batch_id * k;
+    out_idx += batch_id * k;
+
+    constexpr int num_buckets = calc_num_buckets<BitsPerPass>();
+    auto histogram = histograms + batch_id * num_buckets;
+
+    filter_and_histogram<T, IdxT, BitsPerPass>(in_buf,
+                                               in_idx_buf,
+                                               out_buf,
+                                               out_idx_buf,
+                                               out,
+                                               out_idx,
+                                               previous_len,
+                                               counter,
+                                               histogram,
+                                               select_min,
+                                               pass,
+                                               early_stop);
+    __threadfence();
+
+    bool isLastBlock = false;
+    if (threadIdx.x == 0) {
+        unsigned int finished = atomicInc(&counter->finished_block_cnt, gridDim.x - 1);
+        isLastBlock = (finished == (gridDim.x - 1U));
+    }
+
+    if (__syncthreads_or(isLastBlock)) {
+        if (early_stop) {
+            if (threadIdx.x == 0) {
+                counter->previous_len = 0;
+                counter->len = 0;
+            }
+            return;
+        }
+
+        scan<IdxT, BitsPerPass, BlockSize>(histogram);
+        __syncthreads();
+        choose_bucket<T, IdxT, BitsPerPass>(counter, histogram, current_k, pass);
+        __syncthreads();
+
+        constexpr int num_passes = calc_num_passes<T, BitsPerPass>();
+        if (pass != num_passes - 1) {
+            for (int i = threadIdx.x; i < num_buckets; i += blockDim.x) {
+                histogram[i] = 0;
+            }
+        }
+        if (threadIdx.x == 0) {
+            counter->previous_len = current_len;
+            counter->filter_cnt = 0;
+        }
+
+        if (pass == num_passes - 1) {
+            volatile const IdxT num_of_kth_needed = counter->k;
+            for (IdxT i = threadIdx.x; i < num_of_kth_needed; i += blockDim.x) {
+                out_idx[k - num_of_kth_needed + i] =
+                    cuda::std::numeric_limits<IdxT>::max();
+            }
+            __syncthreads();
+            if constexpr (fused_last_filter) {
+                last_filter<T, IdxT, BitsPerPass, prioritize_smaller_indice>(
+                    out_buf ? out_buf : in_buf,
+                    out_idx_buf ? out_idx_buf : in_idx_buf,
+                    out,
+                    out_idx,
+                    out_buf ? current_len : len,
+                    k,
+                    counter,
+                    select_min,
+                    pass);
+            }
+        }
+    }
+}
+
+template<typename T, typename IdxT, int BitsPerPass, int BlockSize>
+unsigned calc_grid_dim(int batch_size, IdxT len, int sm_cnt) {
+    static_assert(VECTORIZED_READ_SIZE / sizeof(T) >= 1);
+
+    int active_blocks = 0;
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &active_blocks,
+        radix_kernel<T, IdxT, BitsPerPass, BlockSize, false, true>,
+        BlockSize,
+        0);
+    active_blocks *= sm_cnt;
+
+    IdxT best_num_blocks = 0;
+    float best_tail_wave_penalty = 1.0f;
+    const IdxT max_num_blocks =
+        ceildiv<IdxT>(len, VECTORIZED_READ_SIZE / sizeof(T) * BlockSize);
+    for (int num_waves = 1;; ++num_waves) {
+        IdxT num_blocks = std::min(
+            max_num_blocks,
+            static_cast<IdxT>(std::max(num_waves * active_blocks / batch_size, 1)));
+        IdxT items_per_thread = ceildiv<IdxT>(len, num_blocks * BlockSize);
+        items_per_thread =
+            alignTo<IdxT>(items_per_thread, VECTORIZED_READ_SIZE / sizeof(T));
+        num_blocks = ceildiv<IdxT>(len, items_per_thread * BlockSize);
+        float actual_num_waves =
+            static_cast<float>(num_blocks) * batch_size / active_blocks;
+        float tail_wave_penalty =
+            (ceilf(actual_num_waves) - actual_num_waves) / ceilf(actual_num_waves);
+
+        if (tail_wave_penalty < 0.15f) {
+            best_num_blocks = num_blocks;
+            break;
+        }
+        else if (tail_wave_penalty < best_tail_wave_penalty) {
+            best_num_blocks = num_blocks;
+            best_tail_wave_penalty = tail_wave_penalty;
+        }
+
+        if (num_blocks == max_num_blocks) {
+            break;
+        }
+    }
+    return static_cast<unsigned>(best_num_blocks);
+}
+
+template<typename T, typename IdxT>
+__host__ __device__ void set_buf_pointers(const T* in,
+                                          const IdxT* in_idx,
+                                          T* buf1,
+                                          IdxT* idx_buf1,
+                                          T* buf2,
+                                          IdxT* idx_buf2,
+                                          int pass,
+                                          const T*& in_buf,
+                                          const IdxT*& in_idx_buf,
+                                          T*& out_buf,
+                                          IdxT*& out_idx_buf) {
+    if (pass == 0) {
+        in_buf = in;
+        in_idx_buf = nullptr;
+        out_buf = nullptr;
+        out_idx_buf = nullptr;
+    }
+    else if (pass == 1) {
+        in_buf = in;
+        in_idx_buf = in_idx;
+        out_buf = buf1;
+        out_idx_buf = idx_buf1;
+    }
+    else if (pass % 2 == 0) {
+        in_buf = buf1;
+        in_idx_buf = idx_buf1;
+        out_buf = buf2;
+        out_idx_buf = idx_buf2;
+    }
+    else {
+        in_buf = buf2;
+        in_idx_buf = idx_buf2;
+        out_buf = buf1;
+        out_idx_buf = idx_buf1;
+    }
+}
+
+template<typename T, typename IdxT>
+__device__ void set_buf_pointers(const T* in,
+                                 const IdxT* in_idx,
+                                 char* bufs,
+                                 IdxT buf_len,
+                                 int pass,
+                                 const T*& in_buf,
+                                 const IdxT*& in_idx_buf,
+                                 T*& out_buf,
+                                 IdxT*& out_idx_buf) {
+    if (pass == 0) {
+        in_buf = in;
+        in_idx_buf = nullptr;
+        out_buf = nullptr;
+        out_idx_buf = nullptr;
+    }
+    else if (pass == 1) {
+        in_buf = in;
+        in_idx_buf = in_idx;
+        out_buf = reinterpret_cast<T*>(bufs);
+        out_idx_buf = reinterpret_cast<IdxT*>(bufs + sizeof(T) * 2 * buf_len);
+    }
+    else if (pass % 2 == 0) {
+        in_buf = reinterpret_cast<T*>(bufs);
+        in_idx_buf = reinterpret_cast<IdxT*>(bufs + sizeof(T) * 2 * buf_len);
+        out_buf = const_cast<T*>(in_buf + buf_len);
+        out_idx_buf = const_cast<IdxT*>(in_idx_buf + buf_len);
+    }
+    else {
+        out_buf = reinterpret_cast<T*>(bufs);
+        out_idx_buf = reinterpret_cast<IdxT*>(bufs + sizeof(T) * 2 * buf_len);
+        in_buf = out_buf + buf_len;
+        in_idx_buf = out_idx_buf + buf_len;
+    }
+}
+
+template<typename T, typename IdxT, int BitsPerPass>
+__device__ void filter_and_histogram_for_one_block(const T* in_buf,
+                                                   const IdxT* in_idx_buf,
+                                                   T* out_buf,
+                                                   IdxT* out_idx_buf,
+                                                   T* out,
+                                                   IdxT* out_idx,
+                                                   const IdxT previous_len,
+                                                   Counter<T, IdxT>* counter,
+                                                   IdxT* histogram,
+                                                   bool select_min,
+                                                   int pass) {
+    constexpr int num_buckets = calc_num_buckets<BitsPerPass>();
+    for (int i = threadIdx.x; i < num_buckets; i += blockDim.x) {
+        histogram[i] = 0;
+    }
+    IdxT* p_filter_cnt = &counter->filter_cnt;
+    if (threadIdx.x == 0) {
+        *p_filter_cnt = 0;
+    }
+    __syncthreads();
+
+    const int start_bit = calc_start_bit<T, BitsPerPass>(pass);
+    const unsigned mask = calc_mask<T, BitsPerPass>(pass);
+
+    if (pass == 0) {
+        auto f = [histogram, select_min, start_bit, mask](T value, IdxT) {
+            int bucket = calc_bucket<T, BitsPerPass>(value, start_bit, mask, select_min);
+            atomicAdd(histogram + bucket, static_cast<IdxT>(1));
+        };
+        vectorized_process(threadIdx.x, blockDim.x, in_buf, previous_len, f);
+    }
+    else if (!out_buf) {
+        const auto kth_value_bits = counter->kth_value_bits;
+        const int previous_start_bit = calc_start_bit<T, BitsPerPass>(pass - 1);
+
+        for (IdxT i = threadIdx.x; i < previous_len; i += blockDim.x) {
+            const T value = in_buf[i];
+            const auto previous_bits =
+                (twiddle_in(value, select_min) >> previous_start_bit)
+                << previous_start_bit;
+            if (previous_bits == kth_value_bits) {
+                int bucket =
+                    calc_bucket<T, BitsPerPass>(value, start_bit, mask, select_min);
+                atomicAdd(histogram + bucket, static_cast<IdxT>(1));
+            }
+        }
+    }
+    else {
+        IdxT* p_out_cnt = &counter->out_cnt;
+        const auto kth_value_bits = counter->kth_value_bits;
+        const int previous_start_bit = calc_start_bit<T, BitsPerPass>(pass - 1);
+
+        for (IdxT i = threadIdx.x; i < previous_len; i += blockDim.x) {
+            const T value = in_buf[i];
+            const auto previous_bits =
+                (twiddle_in(value, select_min) >> previous_start_bit)
+                << previous_start_bit;
+            if (previous_bits == kth_value_bits) {
+#if CUDART_VERSION < 12000
+                volatile
+#endif
+                    IdxT pos = atomicAdd(p_filter_cnt, static_cast<IdxT>(1));
+                out_buf[pos] = value;
+                out_idx_buf[pos] = in_idx_buf ? in_idx_buf[i] : i;
+
+                int bucket =
+                    calc_bucket<T, BitsPerPass>(value, start_bit, mask, select_min);
+                atomicAdd(histogram + bucket, static_cast<IdxT>(1));
+            }
+            else if (previous_bits < kth_value_bits) {
+                IdxT pos = atomicAdd(p_out_cnt, static_cast<IdxT>(1));
+                out[pos] = value;
+                out_idx[pos] = in_idx_buf ? in_idx_buf[i] : i;
+            }
+        }
+    }
+}
+
+template<typename T,
+         typename IdxT,
+         int BitsPerPass,
+         int BlockSize,
+         bool prioritize_smaller_indice = false>
+__global__ void radix_topk_one_block_kernel(const T* in,
+                                            const IdxT* in_idx,
+                                            const IdxT len,
+                                            const IdxT k,
+                                            T* out,
+                                            IdxT* out_idx,
+                                            const bool select_min,
+                                            char* bufs) {
+    constexpr int num_buckets = calc_num_buckets<BitsPerPass>();
+    __shared__ Counter<T, IdxT> counter;
+    __shared__ IdxT histogram[num_buckets];
+
+    if (threadIdx.x == 0) {
+        counter.k = k;
+        counter.len = len;
+        counter.previous_len = len;
+        counter.kth_value_bits = 0;
+        counter.out_cnt = 0;
+        counter.out_back_cnt = 0;
+    }
+    __syncthreads();
+
+    const size_t batch_id = blockIdx.x;
+    in += batch_id * len;
+    if (in_idx) {
+        in_idx += batch_id * len;
+    }
+
+    out += batch_id * k;
+    out_idx += batch_id * k;
+    const IdxT buf_len = calc_buf_len<T, IdxT, unsigned>(len);
+    bufs += batch_id * buf_len * 2 * (sizeof(T) + sizeof(IdxT));
+
+    constexpr int num_passes = calc_num_passes<T, BitsPerPass>();
+    for (int pass = 0; pass < num_passes; ++pass) {
+        const T* in_buf = nullptr;
+        const IdxT* in_idx_buf = nullptr;
+        T* out_buf = nullptr;
+        IdxT* out_idx_buf = nullptr;
+        set_buf_pointers(
+            in, in_idx, bufs, buf_len, pass, in_buf, in_idx_buf, out_buf, out_idx_buf);
+
+        const IdxT current_len = counter.len;
+        const IdxT current_k = counter.k;
+        IdxT previous_len = counter.previous_len;
+        if (previous_len > buf_len) {
+            in_buf = in;
+            in_idx_buf = in_idx;
+            previous_len = len;
+        }
+        if (current_len > buf_len) {
+            out_buf = nullptr;
+            out_idx_buf = nullptr;
+        }
+
+        filter_and_histogram_for_one_block<T, IdxT, BitsPerPass>(
+            in_buf,
+            in_idx_buf,
+            out_buf,
+            out_idx_buf,
+            out,
+            out_idx,
+            previous_len,
+            &counter,
+            histogram,
+            select_min,
+            pass);
+        __syncthreads();
+
+        scan<IdxT, BitsPerPass, BlockSize>(histogram);
+        __syncthreads();
+
+        choose_bucket<T, IdxT, BitsPerPass>(&counter, histogram, current_k, pass);
+        if (threadIdx.x == 0) {
+            counter.previous_len = current_len;
+        }
+        __syncthreads();
+
+        if ((pass == num_passes - 1)) {
+            if constexpr (prioritize_smaller_indice) {
+                const IdxT num_of_kth_needed = counter.k;
+                for (IdxT i = threadIdx.x; i < num_of_kth_needed; i += blockDim.x) {
+                    out_idx[k - num_of_kth_needed + i] =
+                        cuda::std::numeric_limits<IdxT>::max();
+                }
+                __syncthreads();
+            }
+            last_filter<T, IdxT, BitsPerPass, prioritize_smaller_indice>(
+                out_buf ? out_buf : in,
+                out_buf ? out_idx_buf : in_idx,
+                out,
+                out_idx,
+                out_buf ? current_len : len,
+                k,
+                &counter,
+                select_min,
+                pass);
+            break;
+        }
+        else if (counter.len == counter.k) {
+            last_filter<T, IdxT, BitsPerPass, false>(out_buf ? out_buf : in,
+                                                     out_buf ? out_idx_buf : in_idx,
+                                                     out,
+                                                     out_idx,
+                                                     out_buf ? current_len : len,
+                                                     k,
+                                                     &counter,
+                                                     select_min,
+                                                     pass);
+            break;
+        }
+    }
+}
+
+}  // namespace air_topk_stable
+
+template<typename T, typename IdxT, int BitsPerPass, int BlockSize>
+void standalone_stable_radix_topk_(void* buf,
+                                   size_t& buf_size,
+                                   const T* in,
+                                   const IdxT* in_idx,
+                                   int batch_size,
+                                   IdxT len,
+                                   IdxT k,
+                                   T* out,
+                                   IdxT* out_idx,
+                                   bool select_min,
+                                   bool fused_last_filter,
+                                   unsigned grid_dim,
+                                   cudaStream_t stream) {
+    static_assert(air_topk_stable::calc_num_passes<T, BitsPerPass>() > 1);
+    constexpr int num_buckets = air_topk_stable::calc_num_buckets<BitsPerPass>();
+
+    air_topk_stable::Counter<T, IdxT>* counters = nullptr;
+    IdxT* histograms = nullptr;
+    T* buf1 = nullptr;
+    IdxT* idx_buf1 = nullptr;
+    T* buf2 = nullptr;
+    IdxT* idx_buf2 = nullptr;
+
+    {
+        IdxT len_candidates = air_topk_stable::calc_buf_len<T>(len);
+
+        std::vector<size_t> sizes = {sizeof(*counters) * static_cast<size_t>(batch_size),
+                                     sizeof(*histograms) * static_cast<size_t>(num_buckets)
+                                         * static_cast<size_t>(batch_size),
+                                     sizeof(*buf1) * static_cast<size_t>(len_candidates)
+                                         * static_cast<size_t>(batch_size),
+                                     sizeof(*idx_buf1) * static_cast<size_t>(len_candidates)
+                                         * static_cast<size_t>(batch_size),
+                                     sizeof(*buf2) * static_cast<size_t>(len_candidates)
+                                         * static_cast<size_t>(batch_size),
+                                     sizeof(*idx_buf2) * static_cast<size_t>(len_candidates)
+                                         * static_cast<size_t>(batch_size)};
+        size_t total_size = calc_aligned_size(sizes);
+        if (!buf) {
+            buf_size = total_size;
+            return;
+        }
+
+        std::vector<void*> aligned_pointers = calc_aligned_pointers(buf, sizes);
+        counters = static_cast<decltype(counters)>(aligned_pointers[0]);
+        histograms = static_cast<decltype(histograms)>(aligned_pointers[1]);
+        buf1 = static_cast<decltype(buf1)>(aligned_pointers[2]);
+        idx_buf1 = static_cast<decltype(idx_buf1)>(aligned_pointers[3]);
+        buf2 = static_cast<decltype(buf2)>(aligned_pointers[4]);
+        idx_buf2 = static_cast<decltype(idx_buf2)>(aligned_pointers[5]);
+
+        cudaMemsetAsync(buf,
+                        0,
+                        static_cast<char*>(aligned_pointers[2])
+                            - static_cast<char*>(aligned_pointers[0]),
+                        stream);
+    }
+
+    const T* in_buf = nullptr;
+    const IdxT* in_idx_buf = nullptr;
+    T* out_buf = nullptr;
+    IdxT* out_idx_buf = nullptr;
+
+    dim3 blocks(grid_dim, static_cast<unsigned>(batch_size));
+
+    constexpr int num_passes = air_topk_stable::calc_num_passes<T, BitsPerPass>();
+
+    auto kernel =
+        air_topk_stable::radix_kernel<T, IdxT, BitsPerPass, BlockSize, false, true>;
+
+    for (int pass = 0; pass < num_passes; ++pass) {
+        air_topk_stable::set_buf_pointers(in,
+                                          in_idx,
+                                          buf1,
+                                          idx_buf1,
+                                          buf2,
+                                          idx_buf2,
+                                          pass,
+                                          in_buf,
+                                          in_idx_buf,
+                                          out_buf,
+                                          out_idx_buf);
+
+        if (fused_last_filter && pass == num_passes - 1) {
+            kernel = air_topk_stable::
+                radix_kernel<T, IdxT, BitsPerPass, BlockSize, true, true>;
+        }
+
+        kernel<<<blocks, BlockSize, 0, stream>>>(in,
+                                                 in_idx,
+                                                 in_buf,
+                                                 in_idx_buf,
+                                                 out_buf,
+                                                 out_idx_buf,
+                                                 out,
+                                                 out_idx,
+                                                 counters,
+                                                 histograms,
+                                                 len,
+                                                 k,
+                                                 select_min,
+                                                 pass);
+    }
+
+    if (!fused_last_filter) {
+        air_topk_stable::last_filter_kernel<T, IdxT, BitsPerPass, true>
+            <<<blocks, BlockSize, 0, stream>>>(in,
+                                               in_idx,
+                                               out_buf,
+                                               out_idx_buf,
+                                               out,
+                                               out_idx,
+                                               len,
+                                               k,
+                                               counters,
+                                               select_min);
+    }
+}
+
+template<typename T, typename IdxT, int BitsPerPass, int BlockSize>
+void standalone_stable_radix_topk_one_block_(void* buf,
+                                             size_t& buf_size,
+                                             const T* in,
+                                             const IdxT* in_idx,
+                                             int batch_size,
+                                             IdxT len,
+                                             IdxT k,
+                                             T* out,
+                                             IdxT* out_idx,
+                                             bool select_min,
+                                             cudaStream_t stream) {
+    static_assert(air_topk_stable::calc_num_passes<T, BitsPerPass>() > 1);
+
+    char* bufs = nullptr;
+    const IdxT buf_len = air_topk_stable::calc_buf_len<T, IdxT, unsigned>(len);
+
+    {
+        std::vector<size_t> sizes = {
+            static_cast<size_t>(buf_len) * 2 * (sizeof(T) + sizeof(IdxT))
+            * static_cast<size_t>(batch_size)};
+        size_t total_size = calc_aligned_size(sizes);
+
+        if (!buf) {
+            buf_size = total_size;
+            return;
+        }
+
+        std::vector<void*> aligned_pointers = calc_aligned_pointers(buf, sizes);
+        bufs = static_cast<decltype(bufs)>(aligned_pointers[0]);
+    }
+
+    air_topk_stable::radix_topk_one_block_kernel<T, IdxT, BitsPerPass, BlockSize, true>
+        <<<batch_size, BlockSize, 0, stream>>>(
+            in, in_idx, len, k, out, out_idx, select_min, bufs);
+}
+
+template<typename T, typename idxT>
+void standalone_stable_radix_11bits(void* buf,
+                                    size_t& buf_size,
+                                    const T* in,
+                                    int batch_size,
+                                    idxT len,
+                                    idxT k,
+                                    T* out,
+                                    idxT* out_idx,
+                                    bool greater,
+                                    cudaStream_t stream = 0) {
+    constexpr int block_dim = 512;
+    constexpr bool fused_last_filter = false;
+
+    if (len <= static_cast<idxT>(block_dim) * 32) {
+        standalone_stable_radix_topk_one_block_<T, idxT, 11, block_dim>(
+            buf,
+            buf_size,
+            in,
+            static_cast<idxT*>(nullptr),
+            batch_size,
+            len,
+            k,
+            out,
+            out_idx,
+            !greater,
+            stream);
+    }
+    else {
+        int sm_cnt = 0;
+        {
+            int dev = 0;
+            TOPK_CUDA_CHECK(cudaGetDevice(&dev));
+            TOPK_CUDA_CHECK(
+                cudaDeviceGetAttribute(&sm_cnt, cudaDevAttrMultiProcessorCount, dev));
+        }
+        unsigned grid_dim = air_topk_stable::calc_grid_dim<T, idxT, 11, block_dim>(
+            batch_size, len, sm_cnt);
+
+        if (grid_dim == 1U) {
+            standalone_stable_radix_topk_one_block_<T, idxT, 11, block_dim>(
+                buf,
+                buf_size,
+                in,
+                static_cast<idxT*>(nullptr),
+                batch_size,
+                len,
+                k,
+                out,
+                out_idx,
+                !greater,
+                stream);
+        }
+        else {
+            standalone_stable_radix_topk_<T, idxT, 11, block_dim>(
+                buf,
+                buf_size,
+                in,
+                static_cast<idxT*>(nullptr),
+                batch_size,
+                len,
+                k,
+                out,
+                out_idx,
+                !greater,
+                fused_last_filter,
+                grid_dim,
+                stream);
+        }
+    }
+}
+
+}  // namespace nv
+
+#endif  // AIR_TOPK_STABLE_CUH_

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/air_topk_stable.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/air_topk_stable.cuh
@@ -1,3 +1,23 @@
+// Copyright (c) 2026 LightSeek Foundation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 #ifndef AIR_TOPK_STABLE_CUH_
 #define AIR_TOPK_STABLE_CUH_
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/fused_topk_topp.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/fused_topk_topp.cu
@@ -1,0 +1,600 @@
+// Fused TopK + TopP renorm. Picks one of three branches per row, but launches
+// the same kernels every call so the host-side path is deterministic and
+// CUDA-graph capturable. Per-row dispatch happens inside the apply kernel via
+// topKs[row].
+
+#include <cuda_runtime.h>
+#include <cub/cub.cuh>
+#include <cfloat>
+#include <climits>
+#include <cstdint>
+#include <vector>
+
+#include "air_top_p.cuh"
+#include "air_topk_stable.cuh"
+#include "fused_topk_topp.h"
+
+namespace fused_topk_topp {
+
+// PDL helper. B200 (sm_100) supports cudaLaunchAttributeProgrammaticStream
+// Serialization — the next kernel can run its prologue (allocate resources,
+// fetch args) in parallel with the previous kernel's epilogue. Saves a
+// fraction of each launch's overhead. Used for every kernel in this pipeline.
+template <typename KernelFunc, typename... Args>
+static inline void launchPDL(KernelFunc kernel, dim3 grid, dim3 block, size_t smem,
+                             cudaStream_t stream, Args... args) {
+    cudaLaunchAttribute attr[1];
+    attr[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attr[0].val.programmaticStreamSerializationAllowed = 1;
+    cudaLaunchConfig_t config{};
+    config.gridDim = grid;
+    config.blockDim = block;
+    config.dynamicSmemBytes = smem;
+    config.stream = stream;
+    config.attrs = attr;
+    config.numAttrs = 1;
+    cudaLaunchKernelEx(&config, kernel, args...);
+}
+
+// Per-row init: mark `counter.skip = 1` for rows whose top_k exceeds the
+// MAX_K bound (mode 3.2). The radix kernels in air_topk_stable.cuh check this
+// flag at the top and return immediately, so the entire stage 1 pipeline does
+// no HBM read or histogram work for those rows.
+template <typename T, typename IdxT>
+__global__ void initTopKSkipKernel(nv::air_topk_stable::Counter<T, IdxT>* counters,
+                                   int batch_size,
+                                   int32_t const* __restrict__ top_k_arr,
+                                   int max_topk) {
+    int b = blockIdx.x * blockDim.x + threadIdx.x;
+    if (b >= batch_size) return;
+    counters[b].skip = (top_k_arr[b] > max_topk) ? 1 : 0;
+}
+
+// Unified per-row init kernel: combines the topk-stage skip-flag setter, the
+// topk workspace zero-fill, and the topp-stage init kernel into a single
+// launch. Saves 2 kernel launches plus a cudaMemsetAsync.
+//
+// Block layout: dim3(batch_size) × dim3(256). Each block handles one row.
+template <typename T, typename IdxT, int NUM_TOPP_BUCKETS, int TOPK_NUM_BUCKETS>
+__launch_bounds__(256) __global__ void unifiedInitKernel(
+    nv::air_topk_stable::Counter<T, IdxT>* topk_counters,
+    IdxT* topk_histograms,
+    air_top_p::Counter<T>* topp_counters,
+    air_top_p::HisT<T>* topp_histograms,
+    air_top_p::IdxT* topp_count_histograms,
+    int batch_size,
+    int vocab_size,
+    T const* __restrict__ probs,
+    float const* __restrict__ top_p_arr,
+    int32_t const* __restrict__ top_k_arr,
+    int32_t max_topk) {
+    int const b = blockIdx.x;
+    if (b >= batch_size) return;
+    int32_t const k = top_k_arr[b];
+    float const p = top_p_arr[b];
+    bool const topp_active = (k > max_topk);
+
+    // Set topk counter fields (thread 0). The radix kernels reset most fields
+    // themselves between passes — only `skip` matters for short-circuiting.
+    if (threadIdx.x == 0) {
+        auto* tkc = topk_counters + b;
+        tkc->k = 0;
+        tkc->len = 0;
+        tkc->previous_len = 0;
+        tkc->kth_value_bits = 0;
+        tkc->skip = topp_active ? 1 : 0;
+        tkc->filter_cnt = 0;
+        tkc->out_cnt = 0;
+        tkc->out_back_cnt = 0;
+        tkc->finished_block_cnt = 0;
+    }
+
+    // Set topp counter fields (thread 0).
+    if (threadIdx.x == 0) {
+        auto* tpc = topp_counters + b;
+        tpc->in = probs + static_cast<size_t>(b) * vocab_size;
+        tpc->oriLen = vocab_size;
+        tpc->len = topp_active ? vocab_size : 0;
+        tpc->previousLen = vocab_size;
+        tpc->p = topp_active ? p : 0.0f;
+        tpc->totalSum = 0.0f;
+        tpc->sum = 0;
+        tpc->kthValueBits = 0;
+        tpc->finishedBlockCnt = 0;
+        tpc->filterCnt = 0;
+    }
+
+    // Zero topk histograms (per row).
+    IdxT* tk_hist = topk_histograms + static_cast<size_t>(b) * TOPK_NUM_BUCKETS;
+    for (int i = threadIdx.x; i < TOPK_NUM_BUCKETS; i += blockDim.x) {
+        tk_hist[i] = 0;
+    }
+
+    // Zero topp histograms (per row).
+    air_top_p::HisT<T>* tp_hist =
+        topp_histograms + static_cast<size_t>(b) * NUM_TOPP_BUCKETS;
+    air_top_p::IdxT* tp_cnt_hist =
+        topp_count_histograms + static_cast<size_t>(b) * NUM_TOPP_BUCKETS;
+    for (int i = threadIdx.x; i < NUM_TOPP_BUCKETS; i += blockDim.x) {
+        tp_hist[i] = 0;
+        tp_cnt_hist[i] = 0;
+    }
+}
+
+// Compute workspace pointers for the air_topk multi-block path.
+template <typename T, typename IdxT, int BitsPerPass>
+static void airTopKResolveWorkspace(void* buf, IdxT len, int batch_size,
+                                    nv::air_topk_stable::Counter<T, IdxT>*& counters,
+                                    IdxT*& histograms, T*& buf1, IdxT*& idx_buf1,
+                                    T*& buf2, IdxT*& idx_buf2) {
+    using Counter = nv::air_topk_stable::Counter<T, IdxT>;
+    constexpr int num_buckets = nv::air_topk_stable::calc_num_buckets<BitsPerPass>();
+    IdxT const len_candidates = nv::air_topk_stable::calc_buf_len<T>(len);
+    std::vector<size_t> sizes = {
+        sizeof(Counter) * static_cast<size_t>(batch_size),
+        sizeof(IdxT) * static_cast<size_t>(num_buckets) * static_cast<size_t>(batch_size),
+        sizeof(T) * static_cast<size_t>(len_candidates) * static_cast<size_t>(batch_size),
+        sizeof(IdxT) * static_cast<size_t>(len_candidates) * static_cast<size_t>(batch_size),
+        sizeof(T) * static_cast<size_t>(len_candidates) * static_cast<size_t>(batch_size),
+        sizeof(IdxT) * static_cast<size_t>(len_candidates) * static_cast<size_t>(batch_size),
+    };
+    auto ptrs = nv::calc_aligned_pointers(buf, sizes);
+    counters = static_cast<Counter*>(ptrs[0]);
+    histograms = static_cast<IdxT*>(ptrs[1]);
+    buf1 = static_cast<T*>(ptrs[2]);
+    idx_buf1 = static_cast<IdxT*>(ptrs[3]);
+    buf2 = static_cast<T*>(ptrs[4]);
+    idx_buf2 = static_cast<IdxT*>(ptrs[5]);
+}
+
+// Multi-block radix top-K launcher that mirrors air_topk_stable::
+// standalone_stable_radix_topk_ but inserts initTopKSkipKernel between the
+// workspace memset and the first radix pass. We can't use the cuVS standalone
+// directly because it does the memset internally and gives no hook between
+// memset and pass 0; replicating its ~30 lines of host-side logic is the
+// simplest way to slot the init kernel in.
+template <typename T, typename IdxT, int BitsPerPass, int BlockSize>
+static void airTopKMultiBlockWithSkip(void* buf, size_t& buf_size, T const* in, int batch_size,
+                                      IdxT len, IdxT k, T* out, IdxT* out_idx,
+                                      bool select_min, bool fused_last_filter, unsigned grid_dim,
+                                      int32_t const* top_k_arr, int max_topk,
+                                      cudaStream_t stream, bool skip_init = false) {
+    static_assert(nv::air_topk_stable::calc_num_passes<T, BitsPerPass>() > 1);
+    constexpr int num_buckets = nv::air_topk_stable::calc_num_buckets<BitsPerPass>();
+
+    using Counter = nv::air_topk_stable::Counter<T, IdxT>;
+
+    IdxT const len_candidates = nv::air_topk_stable::calc_buf_len<T>(len);
+    std::vector<size_t> sizes = {
+        sizeof(Counter) * static_cast<size_t>(batch_size),
+        sizeof(IdxT) * static_cast<size_t>(num_buckets) * static_cast<size_t>(batch_size),
+        sizeof(T) * static_cast<size_t>(len_candidates) * static_cast<size_t>(batch_size),
+        sizeof(IdxT) * static_cast<size_t>(len_candidates) * static_cast<size_t>(batch_size),
+        sizeof(T) * static_cast<size_t>(len_candidates) * static_cast<size_t>(batch_size),
+        sizeof(IdxT) * static_cast<size_t>(len_candidates) * static_cast<size_t>(batch_size),
+    };
+    size_t const total_size = nv::calc_aligned_size(sizes);
+    if (!buf) {
+        buf_size = total_size;
+        return;
+    }
+
+    auto ptrs = nv::calc_aligned_pointers(buf, sizes);
+    auto* counters = static_cast<Counter*>(ptrs[0]);
+    auto* histograms = static_cast<IdxT*>(ptrs[1]);
+    T* buf1 = static_cast<T*>(ptrs[2]);
+    IdxT* idx_buf1 = static_cast<IdxT*>(ptrs[3]);
+    T* buf2 = static_cast<T*>(ptrs[4]);
+    IdxT* idx_buf2 = static_cast<IdxT*>(ptrs[5]);
+
+    if (!skip_init) {
+        // Zero counters + histograms (skip flag included → defaults to "no skip").
+        cudaMemsetAsync(buf, 0,
+                        static_cast<char*>(ptrs[2]) - static_cast<char*>(ptrs[0]), stream);
+
+        // Mark skip rows. Optional: when top_k_arr is null we keep the
+        // memset-default of "no skip" for every row (equivalent to standalone).
+        if (top_k_arr) {
+            int threads = 128;
+            int blocks = (batch_size + threads - 1) / threads;
+            launchPDL(initTopKSkipKernel<T, IdxT>, dim3(blocks), dim3(threads), 0, stream,
+                      counters, batch_size, top_k_arr, max_topk);
+        }
+    }
+
+    // Radix passes. Same dispatch as standalone_stable_radix_topk_.
+    T const* in_buf = nullptr;
+    IdxT const* in_idx_buf = nullptr;
+    T* out_buf = nullptr;
+    IdxT* out_idx_buf = nullptr;
+    dim3 blocks(grid_dim, static_cast<unsigned>(batch_size));
+    // Pass 2 (the last pass) reads only the small per-row survivors buffer,
+    // so multi-block doesn't help — each row's last block ends up doing all
+    // the histogram scan + bucket select + last-filter work anyway. Drop to
+    // grid_dim=1 for pass 2 to skip the inter-block atomic and synchronization
+    // overhead in the existing radix_kernel.
+    dim3 last_pass_blocks(1U, static_cast<unsigned>(batch_size));
+    constexpr int num_passes = nv::air_topk_stable::calc_num_passes<T, BitsPerPass>();
+
+    auto kernel =
+        nv::air_topk_stable::radix_kernel<T, IdxT, BitsPerPass, BlockSize, false, true>;
+
+    for (int pass = 0; pass < num_passes; ++pass) {
+        nv::air_topk_stable::set_buf_pointers(in, static_cast<IdxT const*>(nullptr), buf1,
+                                              idx_buf1, buf2, idx_buf2, pass, in_buf,
+                                              in_idx_buf, out_buf, out_idx_buf);
+        if (fused_last_filter && pass == num_passes - 1) {
+            kernel = nv::air_topk_stable::
+                radix_kernel<T, IdxT, BitsPerPass, BlockSize, true, true>;
+        }
+        dim3 pass_blocks = (pass == num_passes - 1) ? last_pass_blocks : blocks;
+        launchPDL(kernel, pass_blocks, dim3(BlockSize), 0, stream, in,
+                  static_cast<IdxT const*>(nullptr), in_buf, in_idx_buf, out_buf, out_idx_buf,
+                  out, out_idx, counters, histograms, len, k, select_min, pass);
+    }
+
+    if (!fused_last_filter) {
+        launchPDL(nv::air_topk_stable::last_filter_kernel<T, IdxT, BitsPerPass, true>, blocks,
+                  dim3(BlockSize), 0, stream, in, static_cast<IdxT const*>(nullptr), out_buf,
+                  out_idx_buf, out, out_idx, len, k, counters, select_min);
+    }
+}
+
+// air_topk wrapper that always uses fused_last_filter=true and prioritizes
+// smaller indices on ties (matches baseline's deterministic top-k semantics).
+// Always goes through the multi-block path so the workspace layout is
+// predictable (the unified init kernel writes to a fixed multi-block layout
+// regardless of V). For production V=163840 multi-block is always optimal;
+// for small V (sanity check), multi-block with grid_dim=1 is correct.
+template <typename T, typename IdxT>
+static void air_topk_11bits_fused_last(void* buf, size_t& buf_size, T const* in, int batch_size,
+                                       IdxT len, IdxT k, T* out, IdxT* out_idx,
+                                       int32_t const* top_k_arr, int max_topk,
+                                       cudaStream_t stream, bool skip_init = false) {
+    constexpr int block_dim = 512;
+    constexpr int BitsPerPass = 11;
+    constexpr bool greater = true;     // largest values
+    constexpr bool fused_last_filter = true;
+
+    int sm_cnt = 0, dev = 0;
+    if (buf) {
+        cudaGetDevice(&dev);
+        cudaDeviceGetAttribute(&sm_cnt, cudaDevAttrMultiProcessorCount, dev);
+    } else {
+        // Use a representative SM count for workspace sizing query.
+        sm_cnt = 132;
+    }
+    unsigned grid_dim =
+        nv::air_topk_stable::calc_grid_dim<T, IdxT, BitsPerPass, block_dim>(batch_size, len,
+                                                                            sm_cnt);
+    if (grid_dim == 0U) grid_dim = 1U;
+    airTopKMultiBlockWithSkip<T, IdxT, BitsPerPass, block_dim>(
+        buf, buf_size, in, batch_size, len, k, out, out_idx,
+        !greater, fused_last_filter, grid_dim, top_k_arr, max_topk, stream, skip_init);
+}
+
+static size_t airTopKWorkspaceBytes(int batchSize, int vocabSize) {
+    size_t ws = 0;
+    air_topk_11bits_fused_last<float, int32_t>(nullptr, ws, nullptr, batchSize, vocabSize,
+                                              K_TOPK_MAX, nullptr, nullptr,
+                                              /*top_k_arr=*/nullptr,
+                                              /*max_topk=*/K_TOPK_MAX, 0);
+    return ws;
+}
+
+// Workspace layout (all 256B-aligned):
+//   [airTopkWS] [topKVals: bs*K_TOPK_MAX float] [topKIdx: bs*K_TOPK_MAX int32]
+//   [airTopPWS] (includes its own counters + histograms + buf1 + buf2)
+size_t getWorkspaceSize(SizeType32 batchSize, SizeType32 vocabSize) {
+    std::vector<size_t> sizes = {
+        airTopKWorkspaceBytes(batchSize, vocabSize),
+        sizeof(float) * static_cast<size_t>(batchSize) * K_TOPK_MAX,
+        sizeof(int32_t) * static_cast<size_t>(batchSize) * K_TOPK_MAX,
+        air_top_p::getWorkspaceBytes<float>(batchSize, vocabSize),
+    };
+    return nv::calc_aligned_size(sizes);
+}
+
+// Per-row apply kernel — branches on top_k[row]:
+//   K_eff <= MAX_K → mode 3.1 / 3.3: sort the K top values, find min(K, P)
+//     cutoff, scatter renormalized values into outProbs[row].
+//   K_eff >  MAX_K → mode 3.2: use the top-p threshold left in the
+//     air_top_p counter, scan the row, renormalize, write outProbs[row].
+//
+// outProbs is pre-zeroed by an asynchronous memset on a side stream — both
+// branches write only the kept positions.
+template <int BLOCK_SIZE, int ITEMS_PER_THREAD>
+__launch_bounds__(BLOCK_SIZE) __global__ void applyKernel(
+    float const* __restrict__ probs,
+    float const* __restrict__ top_k_vals,
+    int32_t const* __restrict__ top_k_idx,
+    int32_t const* __restrict__ top_ks,
+    float const* __restrict__ top_ps,
+    air_top_p::Counter<float>* __restrict__ topp_counters,
+    float* __restrict__ out_probs,
+    int32_t vocab_size,
+    int32_t max_k) {
+    constexpr int MAX_K = BLOCK_SIZE * ITEMS_PER_THREAD;
+    const int b = blockIdx.x;
+    const int32_t k_raw = top_ks[b];
+    const float p = top_ps[b];
+
+    // (value, index) pair sort, 6-bit radix groups → 6 passes for the 32-bit
+    // float key (vs 11 passes for the 64-bit packed key). The original uint64
+    // packed-key version is retained as a dummy union member so the kernel's
+    // static smem footprint stays at the level that locks SM occupancy to
+    // 1 block/SM (preserves mode 3.2's V-scan HBM bandwidth).
+    using BlockRadixSort = cub::BlockRadixSort<float, BLOCK_SIZE, ITEMS_PER_THREAD, int32_t,
+                                                /*RADIX_BITS=*/6>;
+    using BlockRadixSortLarge = cub::BlockRadixSort<uint64_t, BLOCK_SIZE, ITEMS_PER_THREAD,
+                                                     cub::NullType, /*RADIX_BITS=*/6>;
+    using BlockScan = cub::BlockScan<float, BLOCK_SIZE>;
+    using BlockReduce = cub::BlockReduce<float, BLOCK_SIZE>;
+
+    __shared__ union {
+        typename BlockRadixSort::TempStorage sort;
+        typename BlockRadixSortLarge::TempStorage sort_pad;  // smem occupancy pad.
+        typename BlockScan::TempStorage scan;
+        typename BlockReduce::TempStorage reduce;
+    } temp_storage;
+
+    if (k_raw <= max_k) {
+        // ── Mode 3.1 / 3.3: top-K (post-process for top-P) ──────────────────
+        const int k = max(1, min(k_raw, max_k));
+
+        __shared__ float s_vals[MAX_K];
+        __shared__ int32_t s_idx[MAX_K];
+        __shared__ float s_cumsum[MAX_K];
+        __shared__ int s_cutoff_j;
+        __shared__ float s_inv_factor;
+
+        // (value, index) sort descending: ties on the float key are broken by
+        // whatever cub's radix produces — for softmax-shaped distributions tie
+        // collisions on 32-bit floats are essentially never seen, so this still
+        // matches the baseline within fp32 ulp.
+        float t_vals[ITEMS_PER_THREAD];
+        int32_t t_idxs[ITEMS_PER_THREAD];
+
+        const int row_base = b * max_k;
+#pragma unroll
+        for (int i = 0; i < ITEMS_PER_THREAD; ++i) {
+            const int pos = threadIdx.x * ITEMS_PER_THREAD + i;
+            if (pos < max_k) {
+                t_vals[i] = top_k_vals[row_base + pos];
+                t_idxs[i] = top_k_idx[row_base + pos];
+            } else {
+                t_vals[i] = -FLT_MAX;
+                t_idxs[i] = INT32_MAX;
+            }
+        }
+
+        BlockRadixSort(temp_storage.sort).SortDescending(t_vals, t_idxs);
+        __syncthreads();
+
+#pragma unroll
+        for (int i = 0; i < ITEMS_PER_THREAD; ++i) {
+            const int pos = threadIdx.x * ITEMS_PER_THREAD + i;
+            s_vals[pos] = t_vals[i];
+            s_idx[pos] = t_idxs[i];
+        }
+
+        float t_scan[ITEMS_PER_THREAD];
+#pragma unroll
+        for (int i = 0; i < ITEMS_PER_THREAD; ++i) {
+            const int pos = threadIdx.x * ITEMS_PER_THREAD + i;
+            t_scan[i] = (pos < k) ? t_vals[i] : 0.0f;
+        }
+        __syncthreads();
+        BlockScan(temp_storage.scan).InclusiveSum(t_scan, t_scan);
+        __syncthreads();
+
+#pragma unroll
+        for (int i = 0; i < ITEMS_PER_THREAD; ++i) {
+            const int pos = threadIdx.x * ITEMS_PER_THREAD + i;
+            s_cumsum[pos] = t_scan[i];
+        }
+        __syncthreads();
+
+        if (threadIdx.x == 0) {
+            const float sum_topk = s_cumsum[k - 1];
+            const float threshold = p * sum_topk;
+            int j = k - 1;
+            for (int i = 0; i < k; ++i) {
+                if (s_cumsum[i] >= threshold) {
+                    j = i;
+                    break;
+                }
+            }
+            s_cutoff_j = j;
+            const float denom = s_cumsum[j];
+            s_inv_factor = (denom > 1e-30f) ? 1.0f / denom : 0.0f;
+        }
+        __syncthreads();
+
+        const int cutoff = s_cutoff_j;
+        const float inv = s_inv_factor;
+        float* out_row = out_probs + b * vocab_size;
+        for (int i = threadIdx.x; i <= cutoff; i += BLOCK_SIZE) {
+            const int idx = s_idx[i];
+            out_row[idx] = s_vals[i] * inv;
+        }
+    } else {
+        // ── Mode 3.2: top-P only (radix top-p threshold) ────────────────────
+        // Vectorized V-scan with float4: each thread reads/writes 16B per
+        // iteration, 4× fewer transactions than scalar. Row base is always
+        // 16B-aligned (PyTorch tensors are 256B-aligned). The tail (vocab_size
+        // not divisible by 4) is handled by a scalar epilogue.
+        const float threshold =
+            air_top_p::twiddleOut<float>(topp_counters[b].kthValueBits, false);
+
+        float const* in_row = probs + b * vocab_size;
+        float* out_row = out_probs + b * vocab_size;
+        const int vec_count = vocab_size / 4;            // # of float4 lanes
+        const int vec_tail_start = vec_count * 4;        // start of scalar tail
+
+        float4 const* in_row_v = reinterpret_cast<float4 const*>(in_row);
+
+        // Pass 1: sum of kept values.
+        float thread_sum = 0.0f;
+        for (int i = threadIdx.x; i < vec_count; i += BLOCK_SIZE) {
+            float4 v4 = in_row_v[i];
+            if (v4.x >= threshold) thread_sum += v4.x;
+            if (v4.y >= threshold) thread_sum += v4.y;
+            if (v4.z >= threshold) thread_sum += v4.z;
+            if (v4.w >= threshold) thread_sum += v4.w;
+        }
+        for (int i = vec_tail_start + threadIdx.x; i < vocab_size; i += BLOCK_SIZE) {
+            float v = in_row[i];
+            if (v >= threshold) thread_sum += v;
+        }
+        float row_sum = BlockReduce(temp_storage.reduce).Sum(thread_sum);
+
+        __shared__ float s_inv;
+        if (threadIdx.x == 0) {
+            s_inv = (row_sum > 1e-30f) ? (1.0f / row_sum) : 0.0f;
+        }
+        __syncthreads();
+        const float inv = s_inv;
+
+        // Pass 2: mask + renorm. Non-kept positions stay 0 (set by memset
+        // on the side stream and joined into this stream before this kernel).
+        float4* out_row_v = reinterpret_cast<float4*>(out_row);
+        for (int i = threadIdx.x; i < vec_count; i += BLOCK_SIZE) {
+            float4 v4 = in_row_v[i];
+            float4 o4;
+            o4.x = (v4.x >= threshold) ? v4.x * inv : 0.0f;
+            o4.y = (v4.y >= threshold) ? v4.y * inv : 0.0f;
+            o4.z = (v4.z >= threshold) ? v4.z * inv : 0.0f;
+            o4.w = (v4.w >= threshold) ? v4.w * inv : 0.0f;
+            // Only write the float4 if at least one lane is non-zero — keeps
+            // the write traffic ≈ kept positions × 4B in the common sharp-
+            // distribution case (most float4s have all 4 lanes below
+            // threshold and stay at their memset-0 value).
+            if (o4.x != 0.0f || o4.y != 0.0f || o4.z != 0.0f || o4.w != 0.0f) {
+                out_row_v[i] = o4;
+            }
+        }
+        for (int i = vec_tail_start + threadIdx.x; i < vocab_size; i += BLOCK_SIZE) {
+            float v = in_row[i];
+            if (v >= threshold) out_row[i] = v * inv;
+        }
+        (void)p;  // unused in this branch
+    }
+}
+
+void invokeFusedTopKTopP(float const* probs, SizeType32 const* topKs, float const* topPs,
+                        float* outProbs, void* workspace, SizeType32 batchSize,
+                        SizeType32 vocabSize, cudaStream_t mainStream,
+                        cudaStream_t memsetStream) {
+    // ── Workspace partitioning ──────────────────────────────────────────────
+    size_t airTopkWS = airTopKWorkspaceBytes(batchSize, vocabSize);
+    std::vector<size_t> sizes = {
+        airTopkWS,
+        sizeof(float) * static_cast<size_t>(batchSize) * K_TOPK_MAX,
+        sizeof(int32_t) * static_cast<size_t>(batchSize) * K_TOPK_MAX,
+        air_top_p::getWorkspaceBytes<float>(batchSize, vocabSize),
+    };
+    auto ptrs = nv::calc_aligned_pointers(workspace, sizes);
+    void* topkWS = ptrs[0];
+    float* topKVals = static_cast<float*>(ptrs[1]);
+    int32_t* topKIdx = static_cast<int32_t*>(ptrs[2]);
+    void* toppWS = ptrs[3];
+
+    // ── Stage 0a: pull the side stream into any in-flight CUDA-graph capture
+    //              BEFORE the first side-stream op. A capture only includes
+    //              work issued on streams already joined to the capture; if we
+    //              memset outProbs on a still-unjoined side stream, the memset
+    //              runs eagerly at capture time and never replays — leaving
+    //              outProbs polluted with the previous replay's kept-positions
+    //              on every subsequent replay. The fork-event also gives the
+    //              side stream a happens-after on whatever was queued on the
+    //              main stream up to this point (the apply kernel from the
+    //              previous call, if any) so its memset doesn't race a stale
+    //              reader.
+    const cudaStream_t msStream = memsetStream ? memsetStream : mainStream;
+    const bool sideStreamActive = memsetStream && memsetStream != mainStream;
+    if (sideStreamActive) {
+        cudaEvent_t forkEvent;
+        cudaEventCreateWithFlags(&forkEvent, cudaEventDisableTiming);
+        cudaEventRecord(forkEvent, mainStream);
+        cudaStreamWaitEvent(msStream, forkEvent, 0);
+        cudaEventDestroy(forkEvent);
+    }
+
+    // ── Stage 0b: zero-fill outProbs on side stream (overlaps with stage 1) ─
+    cudaMemsetAsync(outProbs, 0,
+                    sizeof(float) * static_cast<size_t>(batchSize) * vocabSize, msStream);
+
+    // ── Stage 1a: unified init kernel — sets up topk skip flags, topp counter
+    //              fields, and zeros both stages' histograms in one launch.
+    constexpr int TOPK_NUM_BUCKETS = nv::air_topk_stable::calc_num_buckets<11>();  // 2048
+
+    nv::air_topk_stable::Counter<float, int32_t>* topkCounters = nullptr;
+    int32_t* topkHistograms = nullptr;
+    float* topkBuf1 = nullptr;
+    int32_t* topkIdxBuf1 = nullptr;
+    float* topkBuf2 = nullptr;
+    int32_t* topkIdxBuf2 = nullptr;
+    airTopKResolveWorkspace<float, int32_t, 11>(topkWS, vocabSize, batchSize, topkCounters,
+                                                topkHistograms, topkBuf1, topkIdxBuf1,
+                                                topkBuf2, topkIdxBuf2);
+
+    air_top_p::Counter<float>* toppCounters = nullptr;
+    air_top_p::HisT<float>* toppHistograms = nullptr;
+    air_top_p::IdxT* toppCountHistograms = nullptr;
+    float* toppBuf1 = nullptr;
+    float* toppBuf2 = nullptr;
+    air_top_p::resolveWorkspace<float>(batchSize, vocabSize, toppWS, toppCounters,
+                                       toppHistograms, toppCountHistograms, toppBuf1, toppBuf2);
+
+    launchPDL(unifiedInitKernel<float, int32_t, air_top_p::NUM_BUCKETS, TOPK_NUM_BUCKETS>,
+              dim3(batchSize), dim3(256), 0, mainStream,
+              topkCounters, topkHistograms,
+              toppCounters, toppHistograms, toppCountHistograms,
+              batchSize, vocabSize, probs, topPs, topKs, K_TOPK_MAX);
+
+    // ── Stage 2 on side stream (parallel with stage 1 on main) ──────────────
+    // Run the topp radix on the side stream so it overlaps with the topk
+    // radix on the main stream. After both finish, the apply kernel runs on
+    // the main stream after a stream-event sync. The side stream has to wait
+    // for `unifiedInitKernel` to finish (it sets up the topp counters), so
+    // we record an event on main here and gate the side stream on it.
+    if (sideStreamActive) {
+        cudaEvent_t initEvent;
+        cudaEventCreateWithFlags(&initEvent, cudaEventDisableTiming);
+        cudaEventRecord(initEvent, mainStream);
+        cudaStreamWaitEvent(msStream, initEvent, 0);
+        cudaEventDestroy(initEvent);
+    }
+    air_top_p::launchRadixOnly<float>(toppCounters, toppHistograms, toppCountHistograms,
+                                     toppBuf1, toppBuf2, batchSize, vocabSize, msStream);
+
+    // ── Stage 1b: deterministic radix top-K on main stream ──────────────────
+    // K is pinned to K_TOPK_MAX so the grid configuration is fixed regardless
+    // of the per-row top_k values. Per-row short-circuit: rows in mode 3.2
+    // (k_user > K_TOPK_MAX) get counter.skip=1 from the unified init, so
+    // every block of that grid column returns immediately — no HBM read, no
+    // histogram work.
+    air_topk_11bits_fused_last<float, int32_t>(topkWS, airTopkWS, probs, batchSize, vocabSize,
+                                              K_TOPK_MAX, topKVals, topKIdx,
+                                              topKs, K_TOPK_MAX, mainStream,
+                                              /*skip_init=*/true);
+
+    // ── Sync side stream (memset + topp radix) onto main before apply ───────
+    if (sideStreamActive) {
+        cudaEvent_t evt;
+        cudaEventCreateWithFlags(&evt, cudaEventDisableTiming);
+        cudaEventRecord(evt, msStream);
+        cudaStreamWaitEvent(mainStream, evt, 0);
+        cudaEventDestroy(evt);
+    }
+
+    // ── Stage 3: per-row apply. BLOCK=128, ITEMS=1 → MAX_K=128 sort window,
+    //            and 128 threads handle V=160k via stride loops in the top-p
+    //            branch (block reduce sized for 128).
+    launchPDL(applyKernel<128, 1>, dim3(batchSize), dim3(128), 0, mainStream,
+              probs, topKVals, topKIdx, topKs, topPs, toppCounters, outProbs, vocabSize,
+              K_TOPK_MAX);
+}
+
+}  // namespace fused_topk_topp

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/fused_topk_topp.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/fused_topk_topp.cu
@@ -1,3 +1,23 @@
+// Copyright (c) 2026 LightSeek Foundation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 // Fused TopK + TopP renorm. Picks one of three branches per row, but launches
 // the same kernels every call so the host-side path is deterministic and
 // CUDA-graph capturable. Per-row dispatch happens inside the apply kernel via

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/fused_topk_topp.h
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/fused_topk_topp.h
@@ -1,3 +1,23 @@
+// Copyright (c) 2026 LightSeek Foundation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 #ifndef TOKENSPEED_FUSED_TOPK_TOPP_H_
 #define TOKENSPEED_FUSED_TOPK_TOPP_H_
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/fused_topk_topp.h
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/fused_topk_topp.h
@@ -1,0 +1,39 @@
+#ifndef TOKENSPEED_FUSED_TOPK_TOPP_H_
+#define TOKENSPEED_FUSED_TOPK_TOPP_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <cuda_runtime.h>
+
+namespace fused_topk_topp {
+
+using SizeType32 = int32_t;
+
+constexpr int K_TOPK_MAX = 128;
+
+// One workspace covers both pipelines + intermediate top-K results.
+size_t getWorkspaceSize(SizeType32 batchSize, SizeType32 vocabSize);
+
+// Renorm-only fused kernel.
+//
+// Inputs (all on device):
+//   probs[bs, V]   — already softmax'd probabilities.
+//   topKs[bs]      — int32, per-row K. K_TOPK_MAX is hard upper bound for the
+//                    top-k path; K >= V (e.g. (1<<30)) routes the row through
+//                    the radix top-p path.
+//   topPs[bs]      — float, per-row P in (0, 1].
+//
+// Output:
+//   outProbs[bs, V] — same shape as probs; non-selected positions are 0; kept
+//                     positions are renormalized so the row sums to 1.
+//
+// CUDA-graph safe: every kernel launch has fixed grid/block; per-row mode is
+// resolved by the kernels themselves via topKs[row].
+void invokeFusedTopKTopP(float const* probs, SizeType32 const* topKs, float const* topPs,
+                        float* outProbs, void* workspace, SizeType32 batchSize,
+                        SizeType32 vocabSize, cudaStream_t mainStream,
+                        cudaStream_t memsetStream);
+
+}  // namespace fused_topk_topp
+
+#endif  // TOKENSPEED_FUSED_TOPK_TOPP_H_

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/fused_topk_topp_binding.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/fused_topk_topp_binding.cu
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 LightSeek Foundation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED.
+
+#include "tvm_ffi_utils.h"
+#include "fused_topk_topp.h"
+
+void fused_topk_topp_renorm(
+    TensorView probs,
+    TensorView top_ks,
+    TensorView top_ps,
+    TensorView out,
+    TensorView workspace,
+    int64_t side_stream_handle
+) {
+  CHECK_INPUT(probs);
+  CHECK_INPUT(top_ks);
+  CHECK_INPUT(top_ps);
+  CHECK_INPUT(out);
+  CHECK_INPUT(workspace);
+  CHECK_DEVICE(probs, out);
+  CHECK_DEVICE(probs, top_ks);
+  CHECK_DEVICE(probs, top_ps);
+  CHECK_DEVICE(probs, workspace);
+  CHECK_DIM(2, probs);
+  CHECK_DIM(2, out);
+  CHECK_DIM(1, top_ks);
+  CHECK_DIM(1, top_ps);
+  CHECK_DIM(1, workspace);
+  CHECK_INPUT_TYPE(probs, dl_float32);
+  CHECK_INPUT_TYPE(top_ks, dl_int32);
+  CHECK_INPUT_TYPE(top_ps, dl_float32);
+  CHECK_INPUT_TYPE(out, dl_float32);
+  CHECK_INPUT_TYPE(workspace, dl_uint8);
+
+  int bs = static_cast<int>(probs.size(0));
+  int V = static_cast<int>(probs.size(1));
+  TVM_FFI_ICHECK_EQ(top_ks.size(0), bs);
+  TVM_FFI_ICHECK_EQ(top_ps.size(0), bs);
+  TVM_FFI_ICHECK_EQ(out.size(0), bs);
+  TVM_FFI_ICHECK_EQ(out.size(1), V);
+
+  size_t needed = fused_topk_topp::getWorkspaceSize(bs, V);
+  TVM_FFI_ICHECK_GE(static_cast<size_t>(workspace.size(0)), needed)
+      << "fused_topk_topp_renorm workspace too small: have "
+      << workspace.size(0) << " bytes, need " << needed;
+
+  cudaStream_t mainStream = get_stream(probs.device());
+  cudaStream_t sideStream = reinterpret_cast<cudaStream_t>(side_stream_handle);
+  // Treat self-handle (== mainStream) and null as "no side stream"; invokeFused
+  // checks that internally too, but normalize here so the bench fast-paths.
+  if (sideStream == mainStream) {
+    sideStream = nullptr;
+  }
+
+  // The host caller is responsible for keeping `sideStream` alive across this
+  // call (typically a long-lived per-device stream cached in Python). Gating
+  // events are created inline below; they're captured into any in-flight CUDA
+  // graph as fork/join nodes and replayed each iteration. Stream creation
+  // itself is illegal during capture, which is why we accept the handle from
+  // Python rather than lazy-init it here.
+  fused_topk_topp::invokeFusedTopKTopP(
+      static_cast<float const*>(probs.data_ptr()),
+      static_cast<int32_t const*>(top_ks.data_ptr()),
+      static_cast<float const*>(top_ps.data_ptr()),
+      static_cast<float*>(out.data_ptr()),
+      workspace.data_ptr(),
+      bs,
+      V,
+      mainStream,
+      sideStream);
+}
+
+int64_t fused_topk_topp_workspace_size(int64_t bs, int64_t V) {
+  return static_cast<int64_t>(
+      fused_topk_topp::getWorkspaceSize(
+          static_cast<int32_t>(bs), static_cast<int32_t>(V)));
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(fused_topk_topp_renorm, fused_topk_topp_renorm);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(fused_topk_topp_workspace_size,
+                              fused_topk_topp_workspace_size);

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/nv_util.h
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/nv_util.h
@@ -1,0 +1,97 @@
+#ifndef NV_UTIL_H_
+#define NV_UTIL_H_
+#include <cassert>
+#include <chrono>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "cuda_runtime_api.h"
+
+
+#define TOPK_CUDA_CHECK(val) \
+    { nv::cuda_check_((val), __FILE__, __LINE__); }
+#define TOPK_CUDA_CHECK_LAST_ERROR() \
+    { nv::cuda_check_last_error_(__FILE__, __LINE__); }
+
+
+namespace nv {
+
+constexpr unsigned FULL_WARP_MASK = 0xffffffff;
+constexpr int WARP_SIZE = 32;
+
+
+class CudaException : public std::runtime_error {
+public:
+    explicit CudaException(const std::string& what) : runtime_error(what) {}
+};
+
+inline void cuda_check_(cudaError_t val, const char* file, int line) {
+    if (val != cudaSuccess) {
+        throw CudaException(std::string(file) + ":" + std::to_string(line)
+                            + ": CUDA error " + std::to_string(val) + ": "
+                            + cudaGetErrorString(val));
+    }
+}
+
+inline void cuda_check_last_error_(const char* file, int line) {
+    cudaDeviceSynchronize();
+    cudaError_t err = cudaPeekAtLastError();
+    cuda_check_(err, file, line);
+}
+
+
+
+
+class Timer {
+public:
+    Timer() { reset(); }
+    void reset() { start_time_ = std::chrono::steady_clock::now(); }
+    float elapsed_ms() {
+        auto end_time = std::chrono::steady_clock::now();
+        auto dur = std::chrono::duration_cast<std::chrono::duration<float, std::milli>>(
+            end_time - start_time_);
+        return dur.count();
+    }
+
+private:
+    std::chrono::steady_clock::time_point start_time_;
+};
+
+
+inline size_t calc_aligned_size(const std::vector<size_t>& sizes) {
+    const size_t ALIGN_BYTES = 256;
+    const size_t ALIGN_MASK = ~(ALIGN_BYTES - 1);
+    size_t total = 0;
+    for (auto sz : sizes) {
+        total += (sz + ALIGN_BYTES - 1) & ALIGN_MASK;
+    }
+    return total + ALIGN_BYTES - 1;
+}
+
+inline std::vector<void*> calc_aligned_pointers(const void* p,
+                                                const std::vector<size_t>& sizes) {
+    const size_t ALIGN_BYTES = 256;
+    const size_t ALIGN_MASK = ~(ALIGN_BYTES - 1);
+
+    char* ptr = reinterpret_cast<char*>((reinterpret_cast<size_t>(p) + ALIGN_BYTES - 1)
+                                        & ALIGN_MASK);
+
+    std::vector<void*> aligned_pointers;
+    aligned_pointers.reserve(sizes.size());
+    for (auto sz : sizes) {
+        aligned_pointers.push_back(ptr);
+        ptr += (sz + ALIGN_BYTES - 1) & ALIGN_MASK;
+    }
+
+    return aligned_pointers;
+}
+
+
+
+
+
+}  // namespace nv
+#endif

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/nv_util.h
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/nv_util.h
@@ -1,3 +1,23 @@
+// Copyright (c) 2026 LightSeek Foundation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 #ifndef NV_UTIL_H_
 #define NV_UTIL_H_
 #include <cassert>

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/fused_topk_topp.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/fused_topk_topp.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Fused TopK + TopP renormalization kernel wrapper.
+
+Matches the result of flashinfer's ``top_k_renorm_prob`` followed by
+``top_p_renorm_prob(..., is_deterministic=True)`` in one launch sequence.
+"""
+
+import functools
+from pathlib import Path
+
+import torch
+
+
+@functools.cache
+def _load_fused_topk_topp_module():
+    import tvm_ffi
+
+    objs_dir = Path(__file__).parent / "objs" / "fused_topk_topp"
+    so_path = objs_dir / "fused_topk_topp.so"
+    if not so_path.exists():
+        raise RuntimeError(
+            f"tokenspeed_kernel fused_topk_topp library not found at {so_path}. "
+            "Run: pip install -e tokenspeed_kernel/python/"
+        )
+    return tvm_ffi.load_module(str(so_path))
+
+
+# Persistent per-device side streams used to overlap the top-p radix with the
+# top-k radix on the main stream. Streams must be pre-created OUTSIDE CUDA
+# graph capture (cudaStreamCreate is illegal inside capture), so callers that
+# replay the kernel from a captured graph have to register them up front via
+# ``prepare_for_device`` — typically from the sampling backend's ``__init__``.
+_side_streams: dict[torch.device, torch.cuda.Stream] = {}
+
+
+def prepare_for_device(device: torch.device | str | int) -> None:
+    """Pre-create the side stream used by ``fused_topk_topp_renorm`` for the
+    given device. Idempotent. Must be called before the first invocation that
+    happens inside a CUDA graph capture region, so the stream handle is stable
+    across the captured replays.
+    """
+    device = torch.device(device)
+    if device.type != "cuda":
+        return
+    if device not in _side_streams:
+        _side_streams[device] = torch.cuda.Stream(device=device)
+
+
+def _get_side_stream_handle(device: torch.device) -> int:
+    """Return the raw ``cudaStream_t`` (as int64) for the device's side stream,
+    creating it if we're not currently inside a capture region. Returns 0 to
+    signal "no side stream" if we'd have to create one inside capture."""
+    stream = _side_streams.get(device)
+    if stream is not None:
+        return int(stream.cuda_stream)
+    if torch.cuda.is_current_stream_capturing():
+        return 0
+    prepare_for_device(device)
+    return int(_side_streams[device].cuda_stream)
+
+
+def fused_topk_topp_workspace_size(batch_size: int, vocab_size: int) -> int:
+    """Workspace size (in bytes) required by ``fused_topk_topp_renorm``."""
+    return int(
+        _load_fused_topk_topp_module().fused_topk_topp_workspace_size(
+            int(batch_size), int(vocab_size)
+        )
+    )
+
+
+def fused_topk_topp_renorm(
+    probs: torch.Tensor,
+    top_ks: torch.Tensor,
+    top_ps: torch.Tensor,
+    workspace: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Fused TopK + TopP renormalization.
+
+    Args:
+        probs:  ``[bs, V]`` float32, softmax'd probabilities.
+        top_ks: ``[bs]`` int32. K in ``[1, V)`` plus the sentinel ``K = 1 << 30``
+                which routes the row through the radix top-p path.
+        top_ps: ``[bs]`` float32. P in ``(0, 1]``.
+        workspace: optional pre-allocated uint8 scratch buffer; if omitted, a
+                   fresh one is allocated via the CUDA caching allocator.
+        out: optional pre-allocated ``[bs, V]`` float32 output; if omitted, a
+             fresh one is allocated.
+
+    Returns:
+        ``[bs, V]`` float32. Non-kept positions are 0; kept positions are
+        renormalized so each row sums to 1.
+    """
+    if out is None:
+        out = torch.empty_like(probs)
+    if workspace is None:
+        ws_bytes = fused_topk_topp_workspace_size(probs.size(0), probs.size(1))
+        workspace = torch.empty(ws_bytes, dtype=torch.uint8, device=probs.device)
+    side_handle = _get_side_stream_handle(probs.device)
+    _load_fused_topk_topp_module().fused_topk_topp_renorm(
+        probs, top_ks, top_ps, out, workspace, side_handle
+    )
+    return out

--- a/tokenspeed-kernel/test/ops/test_sampling.py
+++ b/tokenspeed-kernel/test/ops/test_sampling.py
@@ -219,6 +219,8 @@ def _ref_topk_topp(
 def test_fused_topk_topp_matches_pipeline(
     device: str, ks: list[int], ps: list[float], tag: str
 ) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA GPU is required for fused_topk_topp_renorm test")
     torch.manual_seed(0)
     bs, V = len(ks), 8192
     logits = torch.randn(bs, V, device=device, dtype=torch.float32) * 3.0
@@ -248,6 +250,9 @@ def test_fused_topk_topp_matches_pipeline(
 def test_fused_topk_topp_workspace_size_grows_with_batch(device: str) -> None:
     """Workspace size must grow monotonically with batch and vocab so callers
     can pre-allocate a buffer sized for ``max_bs × vocab``."""
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA GPU is required for fused_topk_topp_workspace_size test")
     V = 8192
     small = fused_topk_topp_workspace_size(1, V)
     large = fused_topk_topp_workspace_size(64, V)
@@ -259,6 +264,9 @@ def test_fused_topk_topp_external_workspace(device: str) -> None:
     """Pre-allocated workspace path must produce the same result as the
     auto-allocated one, so the runtime can hoist the alloc out of the hot
     path."""
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA GPU is required for fused_topk_topp_external_workspace test")
     torch.manual_seed(1)
     bs, V = 4, 8192
     probs = torch.softmax(

--- a/tokenspeed-kernel/test/ops/test_sampling.py
+++ b/tokenspeed-kernel/test/ops/test_sampling.py
@@ -30,9 +30,18 @@ from tokenspeed_kernel.ops.sampling.triton import (
     gather_and_expand_scalars,
     min_p_renorm_prob,
 )
+from tokenspeed_kernel.platform import current_platform
 
 # Sentinel matching tokenspeed.runtime.sampling.sampling_params._TOP_K_DISABLED.
 _TOP_K_DISABLED = 1 << 30
+
+# The fused top-k + top-p kernel ships only as a CUDA build; on ROCm the
+# Python entry point resolves to a RuntimeError stub. Gate the tests instead
+# of failing loudly on AMD CI.
+requires_nvidia = pytest.mark.skipif(
+    not current_platform().is_nvidia,
+    reason="fused_topk_topp kernel is NVIDIA-only",
+)
 
 
 def _make_pools(pool_rows: int, device: str):
@@ -191,6 +200,7 @@ def _ref_topk_topp(
     return out
 
 
+@requires_nvidia
 @pytest.mark.parametrize(
     "ks,ps,tag",
     [
@@ -247,6 +257,7 @@ def test_fused_topk_topp_matches_pipeline(
     torch.testing.assert_close(ours, ref, atol=1e-5, rtol=1e-4)
 
 
+@requires_nvidia
 def test_fused_topk_topp_workspace_size_grows_with_batch(device: str) -> None:
     """Workspace size must grow monotonically with batch and vocab so callers
     can pre-allocate a buffer sized for ``max_bs × vocab``."""
@@ -260,6 +271,7 @@ def test_fused_topk_topp_workspace_size_grows_with_batch(device: str) -> None:
     assert large > small
 
 
+@requires_nvidia
 def test_fused_topk_topp_external_workspace(device: str) -> None:
     """Pre-allocated workspace path must produce the same result as the
     auto-allocated one, so the runtime can hoist the alloc out of the hot

--- a/tokenspeed-kernel/test/ops/test_sampling.py
+++ b/tokenspeed-kernel/test/ops/test_sampling.py
@@ -22,10 +22,17 @@ from __future__ import annotations
 
 import pytest
 import torch
+from tokenspeed_kernel.ops.sampling.cuda import (
+    fused_topk_topp_renorm,
+    fused_topk_topp_workspace_size,
+)
 from tokenspeed_kernel.ops.sampling.triton import (
     gather_and_expand_scalars,
     min_p_renorm_prob,
 )
+
+# Sentinel matching tokenspeed.runtime.sampling.sampling_params._TOP_K_DISABLED.
+_TOP_K_DISABLED = 1 << 30
 
 
 def _make_pools(pool_rows: int, device: str):
@@ -150,6 +157,124 @@ def test_gather_min_p_only(device: str) -> None:
     assert offsets is None
     assert min_ps is not None
     torch.testing.assert_close(min_ps, _reference(index, min_p_p, 4))
+
+
+def _ref_topk_topp(
+    probs: torch.Tensor, top_ks: torch.Tensor, top_ps: torch.Tensor
+) -> torch.Tensor:
+    """Pure-torch baseline mirroring flashinfer's ``top_k_renorm_prob`` followed
+    by ``top_p_renorm_prob(is_deterministic=True)``. K >= V is treated as no
+    top-k cutoff (matches both the flashinfer clamp and the K = 1<<30 sentinel).
+    """
+    bs, V = probs.shape
+    out = probs.clone()
+    for i in range(bs):
+        k = min(int(top_ks[i].item()), V)
+        if k < V:
+            kth = torch.topk(out[i], k, sorted=False).values.min()
+            out[i] = torch.where(out[i] >= kth, out[i], torch.zeros_like(out[i]))
+            s = out[i].sum()
+            if s > 0:
+                out[i] = out[i] / s
+        sorted_vals, _ = torch.sort(out[i], descending=True)
+        cs = torch.cumsum(sorted_vals, 0)
+        p = float(top_ps[i].item())
+        # Smallest prefix with cumulative mass >= p. Clamp to V to absorb
+        # fp32 rounding when p = 1.0 (cumsum's last value can fall a ulp
+        # short of 1.0 and would otherwise push keep past the end).
+        keep = min((cs < p).sum().item() + 1, V)
+        thresh = sorted_vals[keep - 1]
+        out[i] = torch.where(out[i] >= thresh, out[i], torch.zeros_like(out[i]))
+        s = out[i].sum()
+        if s > 0:
+            out[i] = out[i] / s
+    return out
+
+
+@pytest.mark.parametrize(
+    "ks,ps,tag",
+    [
+        # Mode 3.1: top-K only (P=1.0).
+        ([1, 16, 64, 128, 1, 64, 16, 128], [1.0] * 8, "topk-only"),
+        # Mode 3.2: top-P only (K sentinel → radix path).
+        (
+            [_TOP_K_DISABLED] * 8,
+            [0.5, 0.7, 0.9, 0.95, 0.99, 0.5, 0.9, 0.8],
+            "topp-only",
+        ),
+        # Mode 3.3: top-K + top-P together.
+        (
+            [64, 64, 32, 128, 16, 8, 64, 128],
+            [0.9, 0.5, 0.8, 0.7, 0.95, 0.6, 0.9, 0.99],
+            "topk+topp",
+        ),
+        # Mixed batch: different rows take different paths in one launch.
+        (
+            [64, _TOP_K_DISABLED, 1, 128, 32, _TOP_K_DISABLED, 16, 8],
+            [0.9, 0.9, 1.0, 0.7, 0.95, 0.5, 0.8, 0.99],
+            "mixed",
+        ),
+    ],
+)
+def test_fused_topk_topp_matches_pipeline(
+    device: str, ks: list[int], ps: list[float], tag: str
+) -> None:
+    torch.manual_seed(0)
+    bs, V = len(ks), 8192
+    logits = torch.randn(bs, V, device=device, dtype=torch.float32) * 3.0
+    probs = torch.softmax(logits, dim=-1)
+    top_ks = torch.tensor(ks, dtype=torch.int32, device=device)
+    top_ps = torch.tensor(ps, dtype=torch.float32, device=device)
+
+    ref = _ref_topk_topp(probs, top_ks, top_ps)
+    ours = fused_topk_topp_renorm(probs.clone(), top_ks, top_ps)
+
+    # Each kept row should renormalize to 1 within fp32 ulp tolerance.
+    torch.testing.assert_close(
+        ours.sum(dim=-1), torch.ones(bs, device=device), atol=1e-5, rtol=1e-5
+    )
+    # The fused kernel must produce the same kept set on every row. Allow
+    # a single position of disagreement to absorb ties at the top-p cutoff
+    # (cumulative-sum rounding can include/exclude the boundary by 1 entry).
+    pos_ref = ref > 0
+    pos_ours = ours > 0
+    pos_diff = (pos_ref != pos_ours).sum(dim=-1).max().item()
+    assert pos_diff <= 1, f"[{tag}] kept-position mismatch up to {pos_diff} per row"
+    # Renormalized values: sub-ulp accumulation order differs by row scale,
+    # so 1e-5 is the right tolerance (matches the per-row sum bound).
+    torch.testing.assert_close(ours, ref, atol=1e-5, rtol=1e-4)
+
+
+def test_fused_topk_topp_workspace_size_grows_with_batch(device: str) -> None:
+    """Workspace size must grow monotonically with batch and vocab so callers
+    can pre-allocate a buffer sized for ``max_bs × vocab``."""
+    V = 8192
+    small = fused_topk_topp_workspace_size(1, V)
+    large = fused_topk_topp_workspace_size(64, V)
+    assert small > 0
+    assert large > small
+
+
+def test_fused_topk_topp_external_workspace(device: str) -> None:
+    """Pre-allocated workspace path must produce the same result as the
+    auto-allocated one, so the runtime can hoist the alloc out of the hot
+    path."""
+    torch.manual_seed(1)
+    bs, V = 4, 8192
+    probs = torch.softmax(
+        torch.randn(bs, V, device=device, dtype=torch.float32) * 2.5, dim=-1
+    )
+    top_ks = torch.tensor(
+        [32, _TOP_K_DISABLED, 64, 128], dtype=torch.int32, device=device
+    )
+    top_ps = torch.tensor([0.9, 0.85, 0.95, 0.8], dtype=torch.float32, device=device)
+
+    auto = fused_topk_topp_renorm(probs, top_ks, top_ps)
+    ws = torch.empty(
+        fused_topk_topp_workspace_size(bs, V), dtype=torch.uint8, device=device
+    )
+    manual = fused_topk_topp_renorm(probs, top_ks, top_ps, workspace=ws)
+    torch.testing.assert_close(auto, manual, atol=0.0, rtol=0.0)
 
 
 def test_gather_empty_batch(device: str) -> None:


### PR DESCRIPTION
## Summary

Optimize the implementation of `top_k_renorm_prob` and `top_p_renorm_prob`.

### Implement details
- Design dedicated short-circuiting mechanisms for topk-only mode and topp-only mode, respectively. And also support topk+topp mode.
- Compatible with CUDA Graphs. 
- Dual streams are utilized to achieve overlap.

```
side stream                  main stream
─────────────                ────────────
cudaMemsetAsync(out,0)       unifiedInitKernel
wait_event(main.init done)
air_top_p::launchRadixOnly:
  AirTopPRadixKernel pass 0
  AirTopPRadixKernel pass 1   air_topk multi-block:
  AirTopPRadixKernel pass 2     radix pass 0 (grid_dim, bs)
                                 radix pass 1 (grid_dim, bs)
                                 radix pass 2 (1, bs)
wait_event(side done)
                              applyKernel<128,1>
```


### Performance
#### Kernel benchmark:
```
Results table  (B200, V=163840, warmup=50, reps=500)

+--------------------------------------+--------------------+--------------------+----------+-------+
| Case                                 |  baseline μs (med) |      ours μs (med) |  speedup |   det |
+--------------------------------------+--------------------+--------------------+----------+-------+
|── Mode 3.1: top-K only (P=1.0) ─────────────────────────────────────────────────────────────────|
| 3.1_topk_only_bs1_k1                 |   148.22 ( 148.00) |    45.50 (  45.54) |   × 3.26 |     ✓ |
| 3.1_topk_only_bs1_k2                 |   147.55 ( 147.97) |    44.13 (  43.78) |   × 3.34 |     ✓ |
| 3.1_topk_only_bs1_k4                 |   147.29 ( 147.90) |    46.20 (  43.52) |   × 3.19 |     ✓ |
| 3.1_topk_only_bs1_k8                 |   147.73 ( 147.97) |    42.91 (  42.53) |   × 3.44 |     ✓ |
| 3.1_topk_only_bs1_k16                |   150.25 ( 150.05) |    44.19 (  43.81) |   × 3.40 |     ✓ |
| 3.1_topk_only_bs1_k32                |   149.98 ( 150.02) |    33.86 (  34.14) |   × 4.43 |     ✓ |
| 3.1_topk_only_bs1_k64                |   148.88 ( 148.13) |    35.12 (  34.46) |   × 4.24 |     ✓ |
| 3.1_topk_only_bs1_k128               |   150.14 ( 150.02) |    37.02 (  36.45) |   × 4.06 |     ✓ |
| 3.1_topk_only_bs2_k1                 |   152.11 ( 152.10) |    33.70 (  34.14) |   × 4.51 |     ✓ |
| 3.1_topk_only_bs2_k2                 |   149.29 ( 149.89) |    33.58 (  34.11) |   × 4.45 |     ✓ |
| 3.1_topk_only_bs2_k4                 |   150.30 ( 150.08) |    34.21 (  34.27) |   × 4.39 |     ✓ |
| 3.1_topk_only_bs2_k8                 |   376.54 ( 377.18) |    34.35 (  34.30) |   ×10.96 |     ✓ |
| 3.1_topk_only_bs2_k16                |   153.28 ( 154.02) |    34.43 (  34.30) |   × 4.45 |     ✓ |
| 3.1_topk_only_bs2_k32                |   151.28 ( 151.81) |    34.83 (  34.34) |   × 4.34 |     ✓ |
| 3.1_topk_only_bs2_k64                |   151.75 ( 152.03) |    36.39 (  36.38) |   × 4.17 |     ✓ |
| 3.1_topk_only_bs2_k128               |   153.76 ( 154.08) |    38.83 (  38.46) |   × 3.96 |     ✓ |
| 3.1_topk_only_bs4_k1                 |   158.30 ( 158.21) |    35.04 (  34.43) |   × 4.52 |     ✓ |
| 3.1_topk_only_bs4_k2                 |   157.87 ( 158.18) |    35.03 (  34.43) |   × 4.51 |     ✓ |
| 3.1_topk_only_bs4_k4                 |   156.55 ( 156.19) |    35.76 (  36.22) |   × 4.38 |     ✓ |
| 3.1_topk_only_bs4_k8                 |   387.36 ( 383.52) |    35.70 (  36.13) |   ×10.85 |     ✓ |
| 3.1_topk_only_bs4_k16                |   158.19 ( 158.21) |    35.83 (  36.26) |   × 4.42 |     ✓ |
| 3.1_topk_only_bs4_k32                |   158.51 ( 158.24) |    36.56 (  36.38) |   × 4.34 |     ✓ |
| 3.1_topk_only_bs4_k64                |   158.26 ( 158.21) |    37.77 (  38.30) |   × 4.19 |     ✓ |
| 3.1_topk_only_bs4_k128               |   158.26 ( 158.21) |    53.10 (  40.42) |   × 2.98 |     ✓ |
| 3.1_topk_only_bs8_k1                 |   176.82 ( 176.67) |    38.01 (  38.34) |   × 4.65 |     ✓ |
| 3.1_topk_only_bs8_k2                 |   174.84 ( 174.62) |    38.18 (  38.40) |   × 4.58 |     ✓ |
| 3.1_topk_only_bs8_k4                 |   174.75 ( 174.62) |    38.36 (  38.40) |   × 4.56 |     ✓ |
| 3.1_topk_only_bs8_k8                 |   446.97 ( 461.34) |    38.50 (  38.43) |   ×11.61 |     ✓ |
| 3.1_topk_only_bs8_k16                |   175.04 ( 174.62) |    38.53 (  38.43) |   × 4.54 |     ✓ |
| 3.1_topk_only_bs8_k32                |   429.00 ( 428.51) |    41.78 (  38.56) |   ×10.27 |     ✓ |
| 3.1_topk_only_bs8_k64                |   177.74 ( 176.67) |    52.54 (  40.48) |   × 3.38 |     ✓ |
| 3.1_topk_only_bs8_k128               |   175.45 ( 174.72) |    43.15 (  42.56) |   × 4.07 |     ✓ |
| 3.1_topk_only_bs16_k1                |   189.14 ( 188.96) |    63.97 (  40.45) |   × 2.96 |     ✓ |
| 3.1_topk_only_bs16_k2                |   186.88 ( 186.88) |    40.81 (  40.48) |   × 4.58 |     ✓ |
| 3.1_topk_only_bs16_k4                |   267.02 ( 187.20) |    40.93 (  40.51) |   × 6.52 |     ✓ |
| 3.1_topk_only_bs16_k8                |   447.35 ( 447.10) |    40.89 (  40.51) |   ×10.94 |     ✓ |
| 3.1_topk_only_bs16_k16               |   444.44 ( 432.70) |    40.87 (  40.51) |   ×10.87 |     ✓ |
| 3.1_topk_only_bs16_k32               |   446.47 ( 442.78) |    41.69 (  42.21) |   ×10.71 |     ✓ |
| 3.1_topk_only_bs16_k64               |   299.02 ( 191.07) |    44.96 (  42.56) |   × 6.65 |     ✓ |
| 3.1_topk_only_bs16_k128              |   429.54 ( 428.70) |    69.84 (  44.67) |   × 6.15 |     ✓ |
| 3.1_topk_only_bs32_k1                |   230.25 ( 229.92) |    45.30 (  44.61) |   × 5.08 |     ✓ |
| 3.1_topk_only_bs32_k2                |   230.81 ( 230.21) |    45.29 (  44.61) |   × 5.10 |     ✓ |
| 3.1_topk_only_bs32_k4                |   510.49 ( 504.77) |    45.21 (  44.61) |   ×11.29 |     ✓ |
| 3.1_topk_only_bs32_k8                |   608.30 ( 596.61) |    58.40 (  44.61) |   ×10.42 |     ✓ |
| 3.1_topk_only_bs32_k16               |   592.79 ( 592.38) |    45.29 (  44.61) |   ×13.09 |     ✓ |
| 3.1_topk_only_bs32_k32               |   629.06 ( 635.20) |    46.05 (  46.43) |   ×13.66 |     ✓ |
| 3.1_topk_only_bs32_k64               |   593.84 ( 596.64) |    83.81 (  46.66) |   × 7.09 |     ✓ |
| 3.1_topk_only_bs32_k128              |   634.13 ( 637.38) |    49.83 (  48.80) |   ×12.73 |     ✓ |
| 3.1_topk_only_bs64_k1                |   349.56 ( 349.70) |    55.97 (  54.82) |   × 6.25 |     ✓ |
| 3.1_topk_only_bs64_k2                |   353.70 ( 352.90) |    59.11 (  55.04) |   × 5.98 |     ✓ |
| 3.1_topk_only_bs64_k4                |   712.23 ( 701.06) |    59.63 (  56.77) |   ×11.94 |     ✓ |
| 3.1_topk_only_bs64_k8                |   780.42 ( 780.64) |    60.56 (  54.88) |   ×12.89 |     ✓ |
| 3.1_topk_only_bs64_k16               |   789.23 ( 788.74) |    57.01 (  56.00) |   ×13.84 |     ✓ |
| 3.1_topk_only_bs64_k32               |   794.34 ( 794.18) |    62.54 (  57.95) |   ×12.70 |     ✓ |
| 3.1_topk_only_bs64_k64               |   864.33 ( 864.74) |    58.87 (  56.86) |   ×14.68 |     ✓ |
| 3.1_topk_only_bs64_k128              |   824.77 ( 792.99) |    60.89 (  59.04) |   ×13.55 |     ✓ |
|   ↳ group geomean / arithmetic mean  |   326.08           |    45.01           |   × 6.07 |       |
|── Mode 3.2: top-P only (K=1<<30) ───────────────────────────────────────────────────────────────|
| 3.2_topp_only_bs1_p0.5               |   119.82 ( 119.33) |   102.34 (  71.36) |   × 1.17 |     ✓ |
| 3.2_topp_only_bs1_p0.9               |   119.36 ( 119.33) |    76.38 (  75.36) |   × 1.56 |     ✓ |
| 3.2_topp_only_bs1_p0.95              |   121.36 ( 121.34) |    76.94 (  75.39) |   × 1.58 |     ✓ |
| 3.2_topp_only_bs2_p0.5               |   124.32 ( 123.65) |    78.66 (  77.47) |   × 1.58 |     ✓ |
| 3.2_topp_only_bs2_p0.9               |   122.84 ( 123.36) |    80.28 (  79.46) |   × 1.53 |     ✓ |
| 3.2_topp_only_bs2_p0.95              |   127.87 ( 127.55) |    83.33 (  83.26) |   × 1.53 |     ✓ |
| 3.2_topp_only_bs4_p0.5               |   131.73 ( 131.62) |    83.66 (  83.46) |   × 1.57 |     ✓ |
| 3.2_topp_only_bs4_p0.9               |   133.09 ( 133.60) |    87.95 (  87.58) |   × 1.51 |     ✓ |
| 3.2_topp_only_bs4_p0.95              |   134.02 ( 133.70) |    89.12 (  89.44) |   × 1.50 |     ✓ |
| 3.2_topp_only_bs8_p0.5               |   148.46 ( 148.03) |    91.93 (  91.65) |   × 1.61 |     ✓ |
| 3.2_topp_only_bs8_p0.9               |   148.25 ( 148.00) |    94.74 (  93.86) |   × 1.56 |     ✓ |
| 3.2_topp_only_bs8_p0.95              |   152.17 ( 152.10) |    97.96 (  97.79) |   × 1.55 |     ✓ |
| 3.2_topp_only_bs16_p0.5              |   160.14 ( 160.22) |   100.89 (  99.90) |   × 1.59 |     ✓ |
| 3.2_topp_only_bs16_p0.9              |   161.87 ( 162.27) |   104.55 ( 103.97) |   × 1.55 |     ✓ |
| 3.2_topp_only_bs16_p0.95             |   164.51 ( 164.38) |   107.87 ( 107.97) |   × 1.53 |     ✓ |
| 3.2_topp_only_bs32_p0.5              |   198.70 ( 199.14) |   134.19 ( 134.56) |   × 1.48 |     ✓ |
| 3.2_topp_only_bs32_p0.9              |   202.92 ( 203.26) |   141.14 ( 140.80) |   × 1.44 |     ✓ |
| 3.2_topp_only_bs32_p0.95             |   206.57 ( 207.30) |   145.25 ( 144.90) |   × 1.42 |     ✓ |
| 3.2_topp_only_bs64_p0.5              |   281.98 ( 281.31) |   196.70 ( 196.13) |   × 1.43 |     ✓ |
| 3.2_topp_only_bs64_p0.9              |   278.33 ( 278.98) |   203.66 ( 204.19) |   × 1.37 |     ✓ |
| 3.2_topp_only_bs64_p0.95             |   290.14 ( 289.47) |   209.83 ( 210.27) |   × 1.38 |     ✓ |
|   ↳ group geomean / arithmetic mean  |   168.02           |   113.68           |   × 1.49 |       |
|── Mode 3.3: top-K + top-P ──────────────────────────────────────────────────────────────────────|
| 3.3_topkp_bs1_k64_p0.5               |   149.86 ( 150.02) |    33.34 (  33.22) |   × 4.50 |     ✓ |
| 3.3_topkp_bs1_k64_p0.9               |   146.21 ( 145.95) |    34.02 (  34.21) |   × 4.30 |     ✓ |
| 3.3_topkp_bs1_k128_p0.8              |   146.96 ( 146.91) |    34.96 (  34.40) |   × 4.20 |     ✓ |
| 3.3_topkp_bs1_k128_p0.9              |   147.67 ( 147.97) |    35.94 (  36.03) |   × 4.11 |     ✓ |
| 3.3_topkp_bs2_k64_p0.5               |   152.39 ( 152.13) |    34.31 (  34.27) |   × 4.44 |     ✓ |
| 3.3_topkp_bs2_k64_p0.9               |   148.39 ( 148.00) |    35.76 (  36.29) |   × 4.15 |     ✓ |
| 3.3_topkp_bs2_k128_p0.8              |   153.18 ( 153.95) |    36.39 (  36.38) |   × 4.21 |     ✓ |
| 3.3_topkp_bs2_k128_p0.9              |   150.61 ( 150.08) |    37.17 (  36.45) |   × 4.05 |     ✓ |
| 3.3_topkp_bs4_k64_p0.5               |   157.87 ( 158.18) |    35.71 (  36.22) |   × 4.42 |     ✓ |
| 3.3_topkp_bs4_k64_p0.9               |   158.04 ( 158.21) |    37.22 (  36.51) |   × 4.25 |     ✓ |
| 3.3_topkp_bs4_k128_p0.8              |   158.25 ( 158.21) |    37.88 (  38.34) |   × 4.18 |     ✓ |
| 3.3_topkp_bs4_k128_p0.9              |   157.71 ( 158.18) |    38.76 (  38.43) |   × 4.07 |     ✓ |
| 3.3_topkp_bs8_k64_p0.5               |   175.35 ( 174.69) |    38.43 (  38.43) |   × 4.56 |     ✓ |
| 3.3_topkp_bs8_k64_p0.9               |   177.22 ( 176.74) |    40.01 (  40.38) |   × 4.43 |     ✓ |
| 3.3_topkp_bs8_k128_p0.8              |   175.46 ( 174.69) |    40.89 (  40.51) |   × 4.29 |     ✓ |
| 3.3_topkp_bs8_k128_p0.9              |   174.92 ( 174.62) |    41.87 (  42.37) |   × 4.18 |     ✓ |
| 3.3_topkp_bs16_k64_p0.5              |   189.55 ( 189.02) |    40.82 (  40.51) |   × 4.64 |     ✓ |
| 3.3_topkp_bs16_k64_p0.9              |   191.06 ( 190.98) |    42.45 (  42.50) |   × 4.50 |     ✓ |
| 3.3_topkp_bs16_k128_p0.8             |   189.09 ( 188.96) |    43.12 (  42.56) |   × 4.39 |     ✓ |
| 3.3_topkp_bs16_k128_p0.9             |   189.82 ( 189.60) |    43.99 (  44.45) |   × 4.32 |     ✓ |
| 3.3_topkp_bs32_k64_p0.5              |   231.68 ( 231.94) |    45.35 (  44.64) |   × 5.11 |     ✓ |
| 3.3_topkp_bs32_k64_p0.9              |   233.12 ( 233.92) |    46.81 (  46.62) |   × 4.98 |     ✓ |
| 3.3_topkp_bs32_k128_p0.8             |   232.12 ( 232.00) |    47.77 (  46.75) |   × 4.86 |     ✓ |
| 3.3_topkp_bs32_k128_p0.9             |   233.38 ( 233.95) |    48.89 (  48.67) |   × 4.77 |     ✓ |
| 3.3_topkp_bs64_k64_p0.5              |   352.91 ( 352.80) |    56.66 (  55.87) |   × 6.23 |     ✓ |
| 3.3_topkp_bs64_k64_p0.9              |   354.69 ( 354.82) |    58.12 (  56.93) |   × 6.10 |     ✓ |
| 3.3_topkp_bs64_k128_p0.8             |   353.35 ( 352.90) |    58.96 (  58.78) |   × 5.99 |     ✓ |
| 3.3_topkp_bs64_k128_p0.9             |   354.65 ( 354.82) |    60.44 (  58.94) |   × 5.87 |     ✓ |
|   ↳ group geomean / arithmetic mean  |   201.27           |    42.36           |   × 4.61 |       |
|── Mixed batch (per-row mode) ───────────────────────────────────────────────────────────────────|
| mixed_bs8                            |   177.80 ( 176.86) |    92.19 (  91.71) |   × 1.93 |     ✓ |
| mixed_bs32                           |   238.46 ( 238.14) |   138.96 ( 138.75) |   × 1.72 |     ✓ |
| mixed_bs128                          |   581.56 ( 582.08) |   333.10 ( 320.96) |   × 1.75 |     ✓ |
|   ↳ group geomean / arithmetic mean  |   332.61           |   188.09           |   × 1.79 |       |
+--------------------------------------+--------------------+--------------------+----------+-------+
| Overall geomean (n=108)              |                    |                    |   × 4.16 |       |
+--------------------------------------+--------------------+--------------------+----------+-------+
```


#### End2end timeline comparison
- before opt: ~140us
<img width="891" height="132" alt="image" src="https://github.com/user-attachments/assets/a9446910-6cbb-460f-a9c3-456134478562" />

- after opt: ~32.5 us (4.338x, num_tokens = 4)
<img width="732" height="157" alt="image" src="https://github.com/user-attachments/assets/0b47534a-97c5-4822-a04d-a48aa09934ce" />

### Accuracy
```
aime25 report table:                                                                                                                                      
+-----------------+-----------+----------+----------+-------+---------+---------+                                                                                                                                                                                                                                   
| Model           | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |                                                                                                                                                                                                                                   
+=================+===========+==========+==========+=======+=========+=========+                                                                                                                                                                                                                                   
| Kimi-K2.5-NVFP4 | aime25    | mean_acc | default  |    30 |  0.9667 | default |                                                                                                                                                                                                                                   
+-----------------+-----------+----------+----------+-------+---------+---------+  
```




## Test Plan
```
cd /tokenspeed/tokenspeed-kernel
/usr/bin/python3 -m pytest test/ops/test_sampling.py -v
```


