### PR TITLE
Fix Qwen3 FP8 MoE activation scale layout

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton.py
@@ -20,9 +20,7 @@
 
 from __future__ import annotations
 
-import functools
 import os
-from functools import partial
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
@@ -739,6 +737,39 @@ def fused_moe_kernel(
     tl.store(c_ptrs, accumulator, mask=c_mask)
 
 
+def _normalize_fp8_group_scale_layout(
+    A: torch.Tensor,
+    A_scale: torch.Tensor,
+    expected_scale_k: int,
+) -> torch.Tensor:
+    """Return FP8 activation scales as [M, num_k_groups].
+
+    The NVIDIA fast path in ``per_token_group_quant_fp8`` can return TRT-LLM
+    scales as a flattened buffer with M padded to a multiple of 4. The MoE
+    Triton kernel consumes row-major scales with no padded rows.
+    """
+    if A_scale.shape[-1] == expected_scale_k:
+        return A_scale
+
+    if A_scale.ndim == 1:
+        m = A.shape[-2]
+        aligned_m = triton.cdiv(m, 4) * 4
+        valid_numel = expected_scale_k * aligned_m
+        if A_scale.numel() < valid_numel:
+            return A_scale
+        return (
+            A_scale[:valid_numel]
+            .view(expected_scale_k, aligned_m)[:, :m]
+            .T.contiguous()
+        )
+
+    # Some helpers return [num_k_groups, M]; convert to [M, num_k_groups].
+    if A_scale.shape[0] == expected_scale_k:
+        return A_scale.transpose(0, 1).contiguous()
+
+    return A_scale
+
+
 @register_kernel(
     "moe",
     "experts",
@@ -793,15 +824,8 @@ def invoke_fused_moe_kernel(
             assert len(block_shape) == 2
             block_n, block_k = block_shape[0], block_shape[1]
             A, A_scale = per_token_group_quant_fp8(A, block_k)
-            # TRT-LLM's per-token group quantization helper returns scales in
-            # column-major layout [num_groups, num_tokens], while this MoE
-            # kernel consumes [num_tokens, num_groups].
             expected_scale_k = triton.cdiv(A.shape[-1], block_k)
-            if (
-                A_scale.shape[-1] != expected_scale_k
-                and A_scale.shape[0] == expected_scale_k
-            ):
-                A_scale = A_scale.transpose(0, 1).contiguous()
+            A_scale = _normalize_fp8_group_scale_layout(A, A_scale, expected_scale_k)
             assert triton.cdiv(A.shape[-1], block_k) == A_scale.shape[-1]
             assert triton.cdiv(B.shape[-2], block_n) == B_scale.shape[-2]
             assert triton.cdiv(B.shape[-1], block_k) == B_scale.shape[-1]
@@ -812,10 +836,11 @@ def invoke_fused_moe_kernel(
         assert A_scale is None
         assert B_scale is None
 
-    grid = lambda META: (
-        triton.cdiv(sorted_token_ids.shape[0], META["BLOCK_SIZE_M"])
-        * triton.cdiv(B.shape[1], META["BLOCK_SIZE_N"]),
-    )
+    def grid(META):
+        return (
+            triton.cdiv(sorted_token_ids.shape[0], META["BLOCK_SIZE_M"])
+            * triton.cdiv(B.shape[1], META["BLOCK_SIZE_N"]),
+        )
 
     K = B.shape[2] - padded_size
     even_Ks = K % config["BLOCK_SIZE_K"] == 0

--- a/tokenspeed-kernel/test/ops/test_moe_triton.py
+++ b/tokenspeed-kernel/test/ops/test_moe_triton.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from tokenspeed_kernel.ops.gemm.fp8_utils import (
+    _per_token_group_quant_8bit_raw,
+    per_token_group_quant_fp8,
+)
+from tokenspeed_kernel.ops.moe.triton import _normalize_fp8_group_scale_layout
+
+
+def test_normalize_fp8_group_scale_layout_handles_trtllm_flattened_scales():
+    A = torch.empty((3, 2048))
+    expected_scale_k = 16
+    padded = torch.arange(expected_scale_k * 4, dtype=torch.float32)
+
+    scales = _normalize_fp8_group_scale_layout(A, padded, expected_scale_k)
+
+    assert scales.shape == (3, expected_scale_k)
+    torch.testing.assert_close(scales, padded.view(expected_scale_k, 4)[:, :3].T)
+
+
+def test_normalize_fp8_group_scale_layout_handles_total_count_padding():
+    A = torch.empty((2, 768))
+    expected_scale_k = 6
+    padded = torch.arange(32, dtype=torch.float32)
+
+    scales = _normalize_fp8_group_scale_layout(A, padded, expected_scale_k)
+
+    assert scales.shape == (2, expected_scale_k)
+    torch.testing.assert_close(
+        scales,
+        padded[: expected_scale_k * 4].view(expected_scale_k, 4)[:, :2].T,
+    )
+
+
+def test_normalize_fp8_group_scale_layout_transposes_column_major_scales():
+    A = torch.empty((5, 2048))
+    expected_scale_k = 16
+    column_major = torch.arange(5 * expected_scale_k, dtype=torch.float32).view(
+        expected_scale_k, 5
+    )
+
+    scales = _normalize_fp8_group_scale_layout(A, column_major, expected_scale_k)
+
+    assert scales.shape == (5, expected_scale_k)
+    torch.testing.assert_close(scales, column_major.T.contiguous())
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_normalize_fp8_group_scale_layout_matches_raw_row_major_quantizer():
+    for m, k in ((2, 768), (5, 768), (27, 768), (5, 2048)):
+        x = torch.randn((m, k), device="cuda", dtype=torch.bfloat16)
+        _, trtllm_scales = per_token_group_quant_fp8(x, 128)
+        _, raw_scales = _per_token_group_quant_8bit_raw(
+            x,
+            128,
+            dtype=torch.float8_e4m3fn,
+            column_major_scales=False,
+        )
+
+        normalized = _normalize_fp8_group_scale_layout(
+            x,
+            trtllm_scales,
+            expected_scale_k=k // 128,
+        )
+
+        torch.testing.assert_close(normalized, raw_scales)


### PR DESCRIPTION
## Summary
- normalize TRT-LLM FP8 group quantization scales before the Triton MoE kernel consumes them
- handle flattened group-major scales with M padded to a multiple of 4
- add regression coverage that compares the normalized TRT-LLM scale layout against the raw row-major quantizer

## Validation
- `pytest tokenspeed-kernel/test/ops/test_moe_triton.py -q`
- `ruff check tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton.py tokenspeed-kernel/test/ops/test_moe_triton.py`
- `pre-commit run --all-files`
- manual smoke: `Qwen/Qwen3-30B-A3B-Instruct-2507-FP8`, TP=1, Triton MoE, prompt `What is 2+2? Reply with just the number.` returned `4`
- manual smoke: `Qwen/Qwen3.6-35B-A3B-FP8`, TP=1, Triton MoE, same prompt returned `4`
- manual smoke: `Qwen/Qwen3.6-35B-A3B-FP8`, TP=2, Triton MoE, same prompt returned `4`
- manual smoke: `Qwen/Qwen3.6-35B-A3B-FP8`, EP=2 with forced Triton MoE (`world_size=2`, MoE `tp=1`, `ep=2`), same prompt returned `4`

## Notes
- `Qwen/Qwen3.6-35B-A3B-FP8` with `moe_backend=auto` selected the FlashInfer/Cutlass FP8 EP backend and failed in the external DeepGEMM/CUTLASS cubin loader. Forcing `moe_backend=triton` passed the EP smoke test above.
