### PR TITLE
feat: add DeepSeek V4 parser support

### DIFF
--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -109,9 +109,10 @@ about.
 | `--tool-call-parser` | Parser for OpenAI-compatible tool-call payloads (handled by the smg gateway). |
 | `--enable-custom-logit-processor` | Allow custom logit processors. Keep disabled unless the deployment needs it. |
 
-Common reasoning parser values include `kimi_k25`, `base`, `qwen3`, and
-`deepseek_r1`. Common tool-call parser values include `kimik2`, `qwen`, `json`,
-and `passthrough`. The parser names are validated by the SMG gateway, so use
+Common reasoning parser values include `kimi_k25`, `base`, `qwen3`,
+`deepseek_r1`, and `deepseek_v31`. Common tool-call parser values include
+`kimik2`, `qwen`, `deepseek_v4`, `json`, and `passthrough`. The parser names
+are validated by the SMG gateway, so use
 the values accepted by the bundled `tokenspeed-smg` package.
 
 ## Speculative Decoding

--- a/docs/serving/deepseek-v4.md
+++ b/docs/serving/deepseek-v4.md
@@ -33,6 +33,12 @@ CUDA_VISIBLE_DEVICES=0,1,2,3 tokenspeed serve deepseek-ai/DeepSeek-V4-Flash \
 | `--enable-mixed-batch` | Enables mixed prefill/decode scheduling for V4 sparse attention. It is off by default globally because other backend paths do not all support mixed batches yet. |
 | `--trust-remote-code` | The HF config uses model-class architectures registered via remote code. |
 
+## Parser defaults
+
+`tokenspeed serve deepseek-ai/DeepSeek-V4-Flash` automatically selects
+`--reasoning-parser deepseek_v31` and `--tool-call-parser deepseek_v4`.
+Pass explicit parser flags to override these defaults.
+
 ## Block size
 
 V4 uses `block_size=256` (`block_size / compress_ratio` cleanly divides the

--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -25,10 +25,12 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import logging
 import os
 import signal
 import sys
+from pathlib import Path
 
 from tokenspeed.cli._argsplit import OrchestratorOpts, split_argv
 from tokenspeed.cli._logo import print_logo
@@ -48,6 +50,8 @@ logger = logging.getLogger(__name__)
 DEFAULT_GATEWAY_HOST = "0.0.0.0"
 DEFAULT_GATEWAY_PORT = 8000
 DEFAULT_REASONING_PARSER = "none"
+DEEPSEEK_V4_REASONING_PARSER = "deepseek_v31"
+DEEPSEEK_V4_TOOL_CALL_PARSER = "deepseek_v4"
 DEFAULT_SMG_LOG_LEVEL = "warn"
 DEFAULT_SMG_PROMETHEUS_PORT = 8413
 # smg reliability knobs we always want disabled when launched under
@@ -184,6 +188,58 @@ def _user_model_id(gateway_args: list[str]) -> str | None:
     if idx + 1 >= len(gateway_args):
         return None
     return gateway_args[idx + 1]
+
+
+def _is_deepseek_v4_model(model_id: str | None) -> bool:
+    if not model_id:
+        return False
+
+    normalized = model_id.lower().replace("_", "-")
+    compact = normalized.replace("-", "")
+    if "deepseek-v4" in normalized or "deepseekv4" in compact:
+        return True
+
+    config_path = Path(model_id) / "config.json"
+    if not config_path.is_file():
+        return False
+    try:
+        with config_path.open() as f:
+            config = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(config, dict):
+        return False
+    architectures = config.get("architectures") or []
+    return (
+        config.get("model_type") == "deepseek_v4"
+        or "DeepseekV4ForCausalLM" in architectures
+    )
+
+
+def _args_with_default_model_parsers(
+    engine_args: list[str], gateway_args: list[str]
+) -> tuple[list[str], list[str]]:
+    """Apply model-family parser defaults before smg gateway defaults.
+
+    Reasoning parser defaults must be visible to both processes: smg extracts
+    reasoning_content after generation, while the engine uses the same parser
+    name to defer json_schema grammars past the reasoning channel.
+    """
+    model_id = _user_model_id(gateway_args) or _user_model_id(engine_args)
+    if not _is_deepseek_v4_model(model_id):
+        return engine_args, gateway_args
+
+    engine_result = list(engine_args)
+    gateway_result = list(gateway_args)
+    if (
+        "--reasoning-parser" not in engine_result
+        and "--reasoning-parser" not in gateway_result
+    ):
+        engine_result.extend(["--reasoning-parser", DEEPSEEK_V4_REASONING_PARSER])
+        gateway_result.extend(["--reasoning-parser", DEEPSEEK_V4_REASONING_PARSER])
+    if "--tool-call-parser" not in gateway_result:
+        gateway_result.extend(["--tool-call-parser", DEEPSEEK_V4_TOOL_CALL_PARSER])
+    return engine_result, gateway_result
 
 
 def _prewarm_hf_tokenizer(model_id: str) -> None:
@@ -406,8 +462,10 @@ def run_smg_from_args(args: argparse.Namespace, raw_argv: list[str]) -> None:
 
     _check_serve_extra_installed()
     split = split_argv(raw_argv)
-    engine_args = split.engine
-    gateway_args = _gateway_args_with_defaults(split.gateway)
+    engine_args, gateway_args = _args_with_default_model_parsers(
+        split.engine, split.gateway
+    )
+    gateway_args = _gateway_args_with_defaults(gateway_args)
     user_host, user_port = _user_host_port_from_gateway_args(gateway_args)
 
     model_id = _user_model_id(gateway_args)

--- a/python/tokenspeed/runtime/grammar/reasoning_structural_tag.py
+++ b/python/tokenspeed/runtime/grammar/reasoning_structural_tag.py
@@ -55,6 +55,7 @@ from typing import Any
 # json_schema for that family.
 _REASONING_PARSER_TO_XGRAMMAR_MODEL: dict[str, str] = {
     "deepseek_r1": "deepseek_r1",
+    "deepseek_v31": "deepseek_v3_2",
     "kimi": "kimi",
     "kimi_k25": "kimi",
     "minimax": "minimax",

--- a/test/cli/test_serve_smg_unit.py
+++ b/test/cli/test_serve_smg_unit.py
@@ -23,6 +23,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import signal
 import sys
@@ -36,12 +37,17 @@ sys.path.insert(0, os.path.join(REPO_ROOT, "python"))
 from tokenspeed.cli._argsplit import OrchestratorOpts
 from tokenspeed.cli.serve_smg import (
     _DEFAULT_SMG_DISABLE_FLAGS,
+    DEEPSEEK_V4_REASONING_PARSER,
+    DEEPSEEK_V4_TOOL_CALL_PARSER,
+    DEFAULT_REASONING_PARSER,
+    _args_with_default_model_parsers,
     _gateway_args_with_default_log_level,
     _gateway_args_with_default_port,
     _gateway_args_with_default_prometheus_port,
     _gateway_args_with_default_reasoning_parser,
     _gateway_args_with_defaults,
     _gateway_args_with_smg_disable_defaults,
+    _is_deepseek_v4_model,
     _prewarm_hf_tokenizer,
     _user_host_port_from_gateway_args,
     _user_model_id,
@@ -180,6 +186,113 @@ def test_user_model_id_returns_none_when_absent():
 
 def test_user_model_id_returns_none_when_model_lacks_value():
     assert _user_model_id(["--model"]) is None
+
+
+def test_deepseek_v4_model_id_gets_default_parsers():
+    model = "deepseek-ai/DeepSeek-V4-Flash"
+
+    engine_args, gateway_args = _args_with_default_model_parsers(
+        ["--model", model],
+        ["--model", model],
+    )
+
+    assert engine_args == [
+        "--model",
+        model,
+        "--reasoning-parser",
+        DEEPSEEK_V4_REASONING_PARSER,
+    ]
+    assert gateway_args == [
+        "--model",
+        model,
+        "--reasoning-parser",
+        DEEPSEEK_V4_REASONING_PARSER,
+        "--tool-call-parser",
+        DEEPSEEK_V4_TOOL_CALL_PARSER,
+    ]
+
+
+def test_deepseek_v4_parser_defaults_preserve_explicit_user_values():
+    model = "deepseek-ai/DeepSeek-V4-Flash"
+
+    engine_args, gateway_args = _args_with_default_model_parsers(
+        ["--model", model, "--reasoning-parser", "none"],
+        [
+            "--model",
+            model,
+            "--reasoning-parser",
+            "none",
+            "--tool-call-parser",
+            "json",
+        ],
+    )
+
+    assert engine_args == ["--model", model, "--reasoning-parser", "none"]
+    assert gateway_args == [
+        "--model",
+        model,
+        "--reasoning-parser",
+        "none",
+        "--tool-call-parser",
+        "json",
+    ]
+
+
+def test_deepseek_v4_parser_defaults_fill_missing_parser_only():
+    model = "deepseek-ai/DeepSeek-V4-Flash"
+
+    engine_args, gateway_args = _args_with_default_model_parsers(
+        ["--model", model, "--reasoning-parser", "none"],
+        ["--model", model, "--reasoning-parser", "none"],
+    )
+    assert engine_args == ["--model", model, "--reasoning-parser", "none"]
+    assert gateway_args == [
+        "--model",
+        model,
+        "--reasoning-parser",
+        "none",
+        "--tool-call-parser",
+        DEEPSEEK_V4_TOOL_CALL_PARSER,
+    ]
+
+    engine_args, gateway_args = _args_with_default_model_parsers(
+        ["--model", model],
+        ["--model", model, "--tool-call-parser", "json"],
+    )
+    assert engine_args == [
+        "--model",
+        model,
+        "--reasoning-parser",
+        DEEPSEEK_V4_REASONING_PARSER,
+    ]
+    assert gateway_args == [
+        "--model",
+        model,
+        "--tool-call-parser",
+        "json",
+        "--reasoning-parser",
+        DEEPSEEK_V4_REASONING_PARSER,
+    ]
+
+
+def test_deepseek_v4_default_reasoning_parser_survives_gateway_defaults():
+    model = "deepseek-ai/DeepSeek-V4-Flash"
+
+    _, gateway_args = _args_with_default_model_parsers(
+        ["--model", model],
+        ["--model", model],
+    )
+    gateway_args = _gateway_args_with_defaults(gateway_args)
+
+    idx = gateway_args.index("--reasoning-parser")
+    assert gateway_args[idx + 1] == DEEPSEEK_V4_REASONING_PARSER
+    assert DEFAULT_REASONING_PARSER not in gateway_args
+
+
+def test_local_deepseek_v4_config_is_detected(tmp_path):
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "deepseek_v4"}))
+
+    assert _is_deepseek_v4_model(str(tmp_path))
 
 
 def test_prewarm_skips_local_path(tmp_path):
@@ -512,3 +625,43 @@ def test_run_smg_from_args_sets_process_title(monkeypatch):
     except SystemExit:
         pass
     assert captured.get("title") == "ts-serve"
+
+
+def test_run_smg_from_args_applies_deepseek_v4_parser_defaults(monkeypatch):
+    captured = {}
+
+    async def fake_run_smg(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr("tokenspeed.cli.serve_smg.print_logo", lambda: None)
+    monkeypatch.setattr(
+        "tokenspeed.cli.serve_smg._check_serve_extra_installed", lambda: None
+    )
+    monkeypatch.setattr(
+        "tokenspeed.cli.serve_smg._prewarm_hf_tokenizer", lambda _: None
+    )
+    monkeypatch.setattr("tokenspeed.cli.serve_smg.run_smg", fake_run_smg)
+
+    from argparse import Namespace
+
+    from tokenspeed.cli.serve_smg import run_smg_from_args
+
+    with pytest.raises(SystemExit) as exc:
+        run_smg_from_args(Namespace(), ["deepseek-ai/DeepSeek-V4-Flash"])
+
+    assert exc.value.code == 0
+    assert captured["engine_args"] == [
+        "--model",
+        "deepseek-ai/DeepSeek-V4-Flash",
+        "--reasoning-parser",
+        DEEPSEEK_V4_REASONING_PARSER,
+    ]
+    assert captured["gateway_args"][:6] == [
+        "--model",
+        "deepseek-ai/DeepSeek-V4-Flash",
+        "--reasoning-parser",
+        DEEPSEEK_V4_REASONING_PARSER,
+        "--tool-call-parser",
+        DEEPSEEK_V4_TOOL_CALL_PARSER,
+    ]

--- a/test/cli/test_smg_parser_availability.py
+++ b/test/cli/test_smg_parser_availability.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+pytest.importorskip("smg")
+
+
+def test_smg_exposes_deepseek_v4_parsers():
+    proc = subprocess.run(
+        [sys.executable, "-m", "smg", "launch", "--help"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    assert "deepseek_v31" in proc.stdout
+    assert "deepseek_v4" in proc.stdout

--- a/test/runtime/test_reasoning_structural_tag.py
+++ b/test/runtime/test_reasoning_structural_tag.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tokenspeed.runtime.grammar.reasoning_structural_tag import (
+    structural_tag_for_reasoning_json_schema,
+)
+
+pytest.importorskip("xgrammar")
+
+
+def test_deepseek_v31_reasoning_parser_wraps_json_schema_after_thinking():
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
+    }
+
+    structural_tag = structural_tag_for_reasoning_json_schema("deepseek_v31", schema)
+
+    assert structural_tag is not None
+    payload = json.loads(structural_tag)
+    elements = payload["format"]["elements"]
+    assert payload["type"] == "structural_tag"
+    assert payload["format"]["type"] == "sequence"
+    assert elements[0]["type"] == "tag"
+    assert elements[0]["begin"] == "<think>"
+    assert elements[0]["end"] == "</think>"
+    assert elements[-1]["type"] == "json_schema"
+    assert elements[-1]["json_schema"] == schema


### PR DESCRIPTION
## Summary
- Default `ts serve` for DeepSeek V4 to SMG parser names `deepseek_v31` and `deepseek_v4`, while preserving explicit user parser flags.
- Map `deepseek_v31` to the engine-side xgrammar `deepseek_v3_2` structural tag so JSON schema constraints apply after reasoning.
- Add parser availability, CLI defaulting, and structural tag tests; document the DeepSeek V4 parser defaults.

## Validation
- `pre-commit run --all-files`
- `FLASHINFER_DISABLE_VERSION_CHECK=1 python3 -m pytest test/cli/test_smg_parser_availability.py test/cli/test_argsplit.py test/runtime/test_reasoning_structural_tag.py -q`
- `FLASHINFER_DISABLE_VERSION_CHECK=1 python3 -m pytest test/cli/test_serve_smg_unit.py -q -k "deepseek_v4 or run_smg_from_args_applies_deepseek_v4_parser_defaults or gateway_args_default_reasoning_parser_is_none or gateway_args_preserve_user_reasoning_parser or gateway_args_defaults_include_port_and_reasoning_parser"`