### PR TITLE
fix: fix the bug that kv cache pool size is too small.

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -134,6 +134,7 @@ jobs:
 
       - name: Install CI task
         run: |
+          rm -rf /home/runner/.cache/flashinfer || true
           cd "${{ env.WORK_DIR }}"
           mkdir -p .ci-artifacts
           python3 test/ci_system/pipeline.py execute \

--- a/python/tokenspeed/runtime/configs/model_config.py
+++ b/python/tokenspeed/runtime/configs/model_config.py
@@ -255,6 +255,10 @@ class ModelConfig:
             for arch in self.hf_config.architectures
         ):
             self.num_attention_layers = self.num_hidden_layers * 2
+        if is_draft_worker:
+            mtp_layers = getattr(self.hf_text_config, "mtp_num_hidden_layers", None)
+            if mtp_layers is not None:
+                self.num_attention_layers = mtp_layers
         self.vocab_size = self.hf_text_config.vocab_size
 
         # Verify quantization

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/trtllm_fp8_kv_kernel.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/trtllm_fp8_kv_kernel.py
@@ -144,7 +144,7 @@ def _fused_fp8_set_kv_buffer_kernel(
     kv_idx = tl.program_id(2)  # 0 for K, 1 for V
 
     # Get cache location for this token
-    cache_loc = tl.load(cache_loc_ptr + token_id)
+    cache_loc = tl.load(cache_loc_ptr + token_id).to(tl.int64)
 
     # Compute page_id and offset within page
     page_id = cache_loc // page_size

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -436,8 +436,14 @@ def create_attn_components(
         )
     elif has_mamba and server_args.max_mamba_cache_size is not None:
         mamba_pool_total_chunks = server_args.max_mamba_cache_size
+        full_attn_layer_ids = getattr(text_config, "full_attention_layer_ids", None)
+        num_kv_layers = (
+            len(full_attn_layer_ids)
+            if full_attn_layer_ids is not None
+            else num_layers - len(mamba_cache_params[4])
+        )
         max_total_num_pages = profile_max_num_pages(
-            **_profile_kwargs,
+            **{**_profile_kwargs, "num_attention_layers": num_kv_layers},
             gpu_memory_utilization=server_args.gpu_memory_utilization,
             cache_cell_size=profile_cache_cell_size,
         )
@@ -466,8 +472,14 @@ def create_attn_components(
             conv_size * conv_dtype.itemsize + temporal_size * ssm_dtype.itemsize
         ) * (1 + speculative_num_draft_tokens)
         memory_per_mamba_chunk = num_mamba_layers * per_layer_mamba_chunk_memory
+        full_attn_layer_ids = getattr(text_config, "full_attention_layer_ids", None)
+        num_kv_layers = (
+            len(full_attn_layer_ids)
+            if full_attn_layer_ids is not None
+            else num_layers - num_mamba_layers
+        )
         kv_max_num_pages, mamba_pool_total_chunks = profile_cache_budget(
-            **_profile_kwargs,
+            **{**_profile_kwargs, "num_attention_layers": num_kv_layers},
             mem_fraction_static=server_args.gpu_memory_utilization,
             mamba_memory_per_chunk=memory_per_mamba_chunk,
             mamba_ratio=server_args.mamba_full_memory_ratio,

--- a/python/tokenspeed/runtime/utils/hf_transformers_utils.py
+++ b/python/tokenspeed/runtime/utils/hf_transformers_utils.py
@@ -195,6 +195,14 @@ def get_config(
     if text_config.architectures == ["LlamaForCausalLMNextN"]:
         text_config.num_hidden_layers = 1
 
+    # For MTP NextN draft models whose text_config carries
+    # mtp_num_hidden_layers, override num_hidden_layers so that the
+    # KV-cache budget uses the draft model's actual layer count instead
+    # of the full target model's layer count.
+    mtp_layers = getattr(text_config, "mtp_num_hidden_layers", None)
+    if is_draft_worker and mtp_layers is not None:
+        text_config.num_hidden_layers = mtp_layers
+
     if model_override_args:
         text_config.update(model_override_args)
 

--- a/python/tokenspeed/runtime/utils/hf_transformers_utils.py
+++ b/python/tokenspeed/runtime/utils/hf_transformers_utils.py
@@ -195,14 +195,6 @@ def get_config(
     if text_config.architectures == ["LlamaForCausalLMNextN"]:
         text_config.num_hidden_layers = 1
 
-    # For MTP NextN draft models whose text_config carries
-    # mtp_num_hidden_layers, override num_hidden_layers so that the
-    # KV-cache budget uses the draft model's actual layer count instead
-    # of the full target model's layer count.
-    mtp_layers = getattr(text_config, "mtp_num_hidden_layers", None)
-    if is_draft_worker and mtp_layers is not None:
-        text_config.num_hidden_layers = mtp_layers
-
     if model_override_args:
         text_config.update(model_override_args)
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
@@ -62,7 +62,7 @@ def _store_kv_cache_kernel(
     is_v = tl.program_id(0)
     row = tl.program_id(1)
 
-    dst_row = tl.load(loc_ptr + row)
+    dst_row = tl.load(loc_ptr + row).to(tl.int64)
     offsets = tl.arange(0, BLOCK)
     mask = offsets < n_kv_per_token
 


### PR DESCRIPTION
## Summary

- Fix KV cache pool under-allocation for hybrid Mamba-attention models. When computing the KV cache budget for models with both Mamba and attention layers (e.g., Jamba), the profiler was using num_attention_layers from _profile_kwargs, which defaulted to the total layer count (num_layers). This caused the per-page memory estimate to be inflated by counting Mamba layers as if they needed KV cache, resulting in fewer pages being allocated than necessary. The fix computes the true number of attention-only layers — either from full_attention_layer_ids in the model config or by subtracting the Mamba layer count — and passes it explicitly to profile_max_num_pages / profile_cache_budget.
- Fix KV cache budget for MTP NextN draft models. For draft workers using MTP NextN models, num_hidden_layers in the text config could reflect the full target model rather than the draft model. This caused the cache budget to be computed for the wrong number of layers. The fix overrides num_hidden_layers with mtp_num_hidden_layers when running as a draft worker.

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
