### PR TITLE
chore(mla): default prefill backend back to cutedsl

### DIFF
--- a/tokenspeed-mla/README.md
+++ b/tokenspeed-mla/README.md
@@ -136,8 +136,8 @@ Input/output dtype behavior:
 
 Backend selection:
 
-- Default: binary AOT (`TOKENSPEED_MLA_PREFILL_BACKEND=binary`)
-- Optional: CuTe DSL JIT (`TOKENSPEED_MLA_PREFILL_BACKEND=cutedsl`)
+- Default: CuTe DSL JIT (`TOKENSPEED_MLA_PREFILL_BACKEND=cutedsl`)
+- Optional: binary AOT (`TOKENSPEED_MLA_PREFILL_BACKEND=binary`)
 - Binary `.so` path override: `TOKENSPEED_MLA_FMHA_BINARY_SO`
 - Availability probe API: `has_binary_prefill()`
 

--- a/tokenspeed-mla/pyproject.toml
+++ b/tokenspeed-mla/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tokenspeed-mla"
-version = "0.1.3"
+version = "0.1.4"
 description = "Speed-of-light TokenSpeed MLA kernels for Blackwell SM100 and SM103."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tokenspeed-mla/pyproject.toml
+++ b/tokenspeed-mla/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tokenspeed-mla"
-version = "0.1.4"
+version = "0.1.3"
 description = "Speed-of-light TokenSpeed MLA kernels for Blackwell SM100 and SM103."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tokenspeed-mla/python/tokenspeed_mla/mla_prefill.py
+++ b/tokenspeed-mla/python/tokenspeed_mla/mla_prefill.py
@@ -50,9 +50,9 @@ from tokenspeed_mla.utils import torch_to_cutlass_dtype
 
 logger = logging.getLogger(__name__)
 
-# Backend selection via env var. Values: "binary" (default, AOT SO) or "cutedsl".
+# Backend selection via env var. Values: "cutedsl" (default) or "binary" (AOT SO).
 _PREFILL_BACKEND_ENV = os.environ.get(
-    "TOKENSPEED_MLA_PREFILL_BACKEND", "binary"
+    "TOKENSPEED_MLA_PREFILL_BACKEND", "cutedsl"
 ).lower()
 
 


### PR DESCRIPTION
Revert the prefill backend default from `binary` (set in #180) back to `cutedsl`. After recent optimization the CuTe DSL JIT backend already delivers very strong performance, so there's no longer a need to expose users to the AOT-binary fallback by default; the binary path stays available as an opt-in via `TOKENSPEED_MLA_PREFILL_BACKEND=binary`. README updated to match.
