### PR TITLE
perf(K2.5): support deterministic topk and remove maybe_broadcast

### DIFF
--- a/python/tokenspeed/runtime/sampling/backends/flashinfer.py
+++ b/python/tokenspeed/runtime/sampling/backends/flashinfer.py
@@ -381,7 +381,10 @@ class FlashInferSamplingBackend(SamplingBackend):
         # Load-bearing: flashinfer top_k_renorm_prob has no is_deterministic
         # knob and produces non-bit-identical results across ranks (sub-ulp
         # FP accumulation order).
-        self.maybe_broadcast(predict, accept_index, accept_length)
+        # For fused top-k + top-p, the results are bit-identical across ranks.
+        # So we don't need to broadcast the results.
+        if not _FUSED_TOPK_TOPP_AVAILABLE:
+            self.maybe_broadcast(predict, accept_index, accept_length)
 
         if self.config.enable_output_logprobs:
 

--- a/python/tokenspeed/runtime/sampling/backends/flashinfer_full.py
+++ b/python/tokenspeed/runtime/sampling/backends/flashinfer_full.py
@@ -332,7 +332,10 @@ class FlashInferFullSamplingBackend(FlashInferSamplingBackend):
         sampled = batch_next_token_ids.to(torch.int32)
 
         # TP-rank sync BEFORE _accumulate_counts so per-rank counts stay aligned.
-        self.maybe_broadcast(sampled)
+        # For fused top-k + top-p, the results are bit-identical across ranks.
+        # So we don't need to broadcast the results.
+        if not _FUSED_TOPK_TOPP_AVAILABLE:
+            self.maybe_broadcast(sampled)
 
         if raw_logprobs is not None:
 
@@ -445,7 +448,10 @@ class FlashInferFullSamplingBackend(FlashInferSamplingBackend):
         accept_length += 1
 
         # TP-rank sync BEFORE _accumulate_counts so per-rank counts stay aligned.
-        self.maybe_broadcast(predict, accept_index, accept_length)
+        # For fused top-k + top-p, the results are bit-identical across ranks.
+        # So we don't need to broadcast the results.
+        if not _FUSED_TOPK_TOPP_AVAILABLE:
+            self.maybe_broadcast(predict, accept_index, accept_length)
 
         # Accumulate accepted tokens into counts. accept_index is [bs, N]
         # with -1 in unused slots; clamp to a safe index and mask with a

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/fused_topk_topp.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/fused_topk_topp.cu
@@ -339,21 +339,21 @@ __launch_bounds__(BLOCK_SIZE) __global__ void applyKernel(
     const int32_t k_raw = top_ks[b];
     const float p = top_ps[b];
 
-    // (value, index) pair sort, 6-bit radix groups → 6 passes for the 32-bit
-    // float key (vs 11 passes for the 64-bit packed key). The original uint64
-    // packed-key version is retained as a dummy union member so the kernel's
-    // static smem footprint stays at the level that locks SM occupancy to
-    // 1 block/SM (preserves mode 3.2's V-scan HBM bandwidth).
-    using BlockRadixSort = cub::BlockRadixSort<float, BLOCK_SIZE, ITEMS_PER_THREAD, int32_t,
-                                                /*RADIX_BITS=*/6>;
-    using BlockRadixSortLarge = cub::BlockRadixSort<uint64_t, BLOCK_SIZE, ITEMS_PER_THREAD,
-                                                     cub::NullType, /*RADIX_BITS=*/6>;
+    // Packed (val ↓, idx ↑) uint64 sort. Upper 32 bits = twiddle_in(val, false)
+    // so ascending uint order == descending val order; lower 32 bits = idx so
+    // ties on val break by smaller idx first. This makes the sort tie-break
+    // deterministic (matches baseline `is_deterministic=True`), independent
+    // of how air_topk_stable's strictly-greater branch happened to order tied
+    // items via atomicAdd. The smem footprint matches what the dummy uint64
+    // pad used to provide, so SM occupancy is unchanged (still 1 block/SM,
+    // which mode 3.2's V-scan needs to keep HBM bandwidth).
+    using BlockRadixSort = cub::BlockRadixSort<uint64_t, BLOCK_SIZE, ITEMS_PER_THREAD,
+                                                cub::NullType, /*RADIX_BITS=*/6>;
     using BlockScan = cub::BlockScan<float, BLOCK_SIZE>;
     using BlockReduce = cub::BlockReduce<float, BLOCK_SIZE>;
 
     __shared__ union {
         typename BlockRadixSort::TempStorage sort;
-        typename BlockRadixSortLarge::TempStorage sort_pad;  // smem occupancy pad.
         typename BlockScan::TempStorage scan;
         typename BlockReduce::TempStorage reduce;
     } temp_storage;
@@ -368,34 +368,42 @@ __launch_bounds__(BLOCK_SIZE) __global__ void applyKernel(
         __shared__ int s_cutoff_j;
         __shared__ float s_inv_factor;
 
-        // (value, index) sort descending: ties on the float key are broken by
-        // whatever cub's radix produces — for softmax-shaped distributions tie
-        // collisions on 32-bit floats are essentially never seen, so this still
-        // matches the baseline within fp32 ulp.
-        float t_vals[ITEMS_PER_THREAD];
-        int32_t t_idxs[ITEMS_PER_THREAD];
-
+        // Build packed keys, sort ascending → descending val, ascending idx on ties.
+        uint64_t t_keys[ITEMS_PER_THREAD];
         const int row_base = b * max_k;
 #pragma unroll
         for (int i = 0; i < ITEMS_PER_THREAD; ++i) {
             const int pos = threadIdx.x * ITEMS_PER_THREAD + i;
+            float val;
+            int32_t idx;
             if (pos < max_k) {
-                t_vals[i] = top_k_vals[row_base + pos];
-                t_idxs[i] = top_k_idx[row_base + pos];
+                val = top_k_vals[row_base + pos];
+                idx = top_k_idx[row_base + pos];
             } else {
-                t_vals[i] = -FLT_MAX;
-                t_idxs[i] = INT32_MAX;
+                val = -FLT_MAX;
+                idx = INT32_MAX;
             }
+            uint32_t v_bits = nv::air_topk_stable::twiddle_in<float>(val, /*select_min=*/false);
+            t_keys[i] = (static_cast<uint64_t>(v_bits) << 32) | static_cast<uint32_t>(idx);
         }
 
-        BlockRadixSort(temp_storage.sort).SortDescending(t_vals, t_idxs);
+        BlockRadixSort(temp_storage.sort).Sort(t_keys);
         __syncthreads();
 
+        // Unpack into thread-local t_vals (for the upcoming BlockScan) and
+        // mirror to smem so the scatter step can read by sorted position.
+        float t_vals[ITEMS_PER_THREAD];
 #pragma unroll
         for (int i = 0; i < ITEMS_PER_THREAD; ++i) {
+            const uint64_t key = t_keys[i];
+            const uint32_t v_bits = static_cast<uint32_t>(key >> 32);
+            const int32_t idx = static_cast<int32_t>(static_cast<uint32_t>(key));
+            const float val =
+                nv::air_topk_stable::twiddle_out<float>(v_bits, /*select_min=*/false);
+            t_vals[i] = val;
             const int pos = threadIdx.x * ITEMS_PER_THREAD + i;
-            s_vals[pos] = t_vals[i];
-            s_idx[pos] = t_idxs[i];
+            s_vals[pos] = val;
+            s_idx[pos] = idx;
         }
 
         float t_scan[ITEMS_PER_THREAD];


### PR DESCRIPTION
## Summary
Related Work: [perf(K2.5): optimize top_k_renorm_prob + top_p_renorm_prob](https://github.com/lightseekorg/tokenspeed/pull/184)

### What this PR does:
1) Support deterministic topk.
Sort the key and index as a single combined unit. If the values ​​are identical, sort by index in ascending order. This ensures that Top-K and Top-P sampling are deterministic.

2) Remove maybe_broadcast if we use `fused_topk_topp_renorm`.
Once Top-K and Top-P sampling are deterministic, we can save one broadcast operation, as the computed results are identical across all ranks.

### Timeline
- before
<img width="1064" height="265" alt="image" src="https://github.com/user-attachments/assets/8008709c-5000-4e69-bfc8-cf2e69b84227" />


- after
<img width="707" height="241" alt="image" src="https://github.com/user-attachments/assets/8249470e-d2c2-4ce9-9796-411aa4f0ac91" />


## Test Plan

<!-- How was this validated? -->
