### PR TITLE
Avoid clearing FlashInfer cache in PR CI

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -134,7 +134,6 @@ jobs:
 
       - name: Install CI task
         run: |
-          rm -rf /home/runner/.cache/flashinfer || true
           cd "${{ env.WORK_DIR }}"
           mkdir -p .ci-artifacts
           python3 test/ci_system/pipeline.py execute \


### PR DESCRIPTION
## Summary
- stop deleting the shared FlashInfer cache before CI install
- rely on runner cache ownership/permission repair instead of forcing a rebuild on every run

## Test
- Parsed .github/workflows/pr-test.yml with PyYAML