### PR TITLE
perf(K2.5): integrate cutedsl argmax

### DIFF
--- a/python/tokenspeed/runtime/execution/drafter/eagle.py
+++ b/python/tokenspeed/runtime/execution/drafter/eagle.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import torch
+from tokenspeed_kernel.ops.sampling.cute_dsl import argmax as cute_argmax
 from typing_extensions import override
 
 from tokenspeed.runtime.execution.cache_loc_kernel import (
@@ -296,7 +297,7 @@ class Eagle(BaseDrafter):
                 )
 
             with nvtx_range("draft_sample", color="yellow"):
-                draft_ids = torch.argmax(logits_output.next_token_logits, dim=-1)
+                draft_ids = cute_argmax(logits_output.next_token_logits)
                 # Column 0 holds last_verified_ids; drafter writes step `i` into column `i + 1`.
                 next_tokens[:, i + 1] = self._map_hot(draft_ids)
                 if i + 1 < self.spec_num_steps:
@@ -353,7 +354,7 @@ class Eagle(BaseDrafter):
         # arrive here already aligned to one row per request.
         logits_output = self._run_first_step(bs, draft_input)
 
-        draft_ids = torch.argmax(logits_output.next_token_logits, dim=-1)
+        draft_ids = cute_argmax(logits_output.next_token_logits)
         next_tokens[:, 1] = self._map_hot(draft_ids)
 
         # Draft step 2+ (multi-step decode).

--- a/python/tokenspeed/runtime/sampling/backends/flashinfer.py
+++ b/python/tokenspeed/runtime/sampling/backends/flashinfer.py
@@ -29,6 +29,7 @@ from tokenspeed_kernel.ops.sampling.cuda import (
     fused_topk_topp_renorm,
     verify_chain_greedy,
 )
+from tokenspeed_kernel.ops.sampling.cute_dsl import argmax as cute_argmax
 from tokenspeed_kernel.ops.sampling.flashinfer import (
     softmax,
     top_k_renorm_prob,
@@ -241,7 +242,7 @@ class FlashInferSamplingBackend(SamplingBackend):
 
         if sampling_info.is_all_greedy:
 
-            batch_next_token_ids = torch.argmax(logits, -1)
+            batch_next_token_ids = cute_argmax(logits)
 
         else:
 
@@ -313,9 +314,9 @@ class FlashInferSamplingBackend(SamplingBackend):
 
         if sampling_info.is_all_greedy:
 
-            target_predict = torch.argmax(
-                logits_output.next_token_logits, dim=-1
-            ).reshape(bs, num_tokens_per_req)
+            target_predict = cute_argmax(logits_output.next_token_logits).reshape(
+                bs, num_tokens_per_req
+            )
 
             verify_chain_greedy(
                 predicts=predict,

--- a/python/tokenspeed/runtime/sampling/backends/greedy.py
+++ b/python/tokenspeed/runtime/sampling/backends/greedy.py
@@ -138,6 +138,13 @@ class GreedySamplingBackend(SamplingBackend):
         self._ones_buf = torch.ones(
             (config.max_bs,), dtype=torch.int32, device=config.device
         )
+        # Pre-allocated int32 buffer for ``sample``'s argmax output: lets the
+        # cute_dsl kernel write int32 token ids directly, skipping the
+        # ``.to(torch.int32)`` cast and its elementwise launch in the
+        # CUDA-graph-captured hot path.
+        self._sample_token_buf = torch.empty(
+            (config.max_bs,), dtype=torch.int32, device=config.device
+        )
         self._predict_buf = torch.zeros(
             (config.max_bs * config.max_draft_tokens_per_req,),
             dtype=torch.int32,
@@ -171,14 +178,12 @@ class GreedySamplingBackend(SamplingBackend):
             sampling_info.apply_vocab_mask(
                 logits=logits, vocab_mask=sampling_info.vocab_mask
             )
-        tokens = cute_argmax(logits).to(torch.int32)
+        bs = logits.shape[0]
+        tokens = cute_argmax(logits, out=self._sample_token_buf[:bs])
 
         if self.config.enable_output_logprobs:
 
             write_output_logprobs(logits_output, logits, tokens)
-
-        # Greedy backend allocates no sampling buffers — derive bs from logits.
-        bs = logits.shape[0]
 
         return tokens, self._ones_buf[:bs]
 

--- a/python/tokenspeed/runtime/sampling/backends/greedy.py
+++ b/python/tokenspeed/runtime/sampling/backends/greedy.py
@@ -26,6 +26,7 @@ import torch
 from tokenspeed_kernel.ops.sampling.cuda import (
     verify_chain_greedy as _verify_chain_greedy_cuda,
 )
+from tokenspeed_kernel.ops.sampling.cute_dsl import argmax as cute_argmax
 from tokenspeed_kernel.registry import error_fn
 
 from tokenspeed.runtime.sampling.backends.base import (
@@ -170,7 +171,7 @@ class GreedySamplingBackend(SamplingBackend):
             sampling_info.apply_vocab_mask(
                 logits=logits, vocab_mask=sampling_info.vocab_mask
             )
-        tokens = torch.argmax(logits, -1).to(torch.int32)
+        tokens = cute_argmax(logits).to(torch.int32)
 
         if self.config.enable_output_logprobs:
 
@@ -207,7 +208,7 @@ class GreedySamplingBackend(SamplingBackend):
                 logits=logits_output.next_token_logits,
                 vocab_mask=sampling_info.vocab_mask,
             )
-        target_predict = torch.argmax(logits_output.next_token_logits, dim=-1).reshape(
+        target_predict = cute_argmax(logits_output.next_token_logits).reshape(
             bs, num_tokens_per_req
         )
 

--- a/test/runtime/test_cute_dsl_argmax.py
+++ b/test/runtime/test_cute_dsl_argmax.py
@@ -300,6 +300,53 @@ def test_argmax_mtp_pattern():
 
 
 # ---------------------------------------------------------------------------
+# ``out=`` parameter — the kernel must honor caller-provided int32 / int64
+# buffers (used by greedy / flashinfer / eagle to skip a downstream cast).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("out_dtype", [torch.int32, torch.int64])
+def test_argmax_writes_into_caller_buffer(out_dtype):
+    """Caller-provided int32 / int64 buffer: kernel writes indices directly,
+    no post-kernel cast on the hot path."""
+    _need_cuda()
+    M, N = 8, MODEL_VOCABS["deepseek_v4"]
+    torch.manual_seed(M ^ N ^ 1)
+    x = 0.1 * torch.randn(M, N, device="cuda", dtype=torch.float32)
+    out = torch.empty(M, dtype=out_dtype, device="cuda")
+    returned = cute_argmax(x, out=out)
+    assert returned.data_ptr() == out.data_ptr()
+    assert out.dtype == out_dtype
+    ref = torch.argmax(x, dim=-1)
+    torch.testing.assert_close(out.long(), ref, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("out_dtype", [torch.int32, torch.int64])
+def test_argmax_caller_buffer_via_fallback(out_dtype):
+    """``out=`` must still receive correct indices when the wrapper takes the
+    torch.argmax fallback (small N here). Catches dtype-cast issues in the
+    fallback's ``out.copy_(result)`` path."""
+    _need_cuda()
+    M, N = 4, 257  # unaligned N forces fallback.
+    torch.manual_seed(N)
+    x = torch.randn(M, N, device="cuda", dtype=torch.float32)
+    out = torch.empty(M, dtype=out_dtype, device="cuda")
+    cute_argmax(x, out=out)
+    torch.testing.assert_close(out.long(), torch.argmax(x, dim=-1), atol=0, rtol=0)
+
+
+def test_argmax_rejects_invalid_out():
+    _need_cuda()
+    x = torch.randn(4, MODEL_VOCABS["deepseek_v4"], device="cuda", dtype=torch.float32)
+    with pytest.raises(ValueError, match="shape"):
+        cute_argmax(x, out=torch.empty(5, dtype=torch.int32, device="cuda"))
+    with pytest.raises(ValueError, match="int32 or int64"):
+        cute_argmax(x, out=torch.empty(4, dtype=torch.float32, device="cuda"))
+    with pytest.raises(ValueError, match="device"):
+        cute_argmax(x, out=torch.empty(4, dtype=torch.int32, device="cpu"))
+
+
+# ---------------------------------------------------------------------------
 # CUDA graph compatibility — the kernel must run from inside a captured graph
 # ---------------------------------------------------------------------------
 

--- a/test/runtime/test_cute_dsl_argmax.py
+++ b/test/runtime/test_cute_dsl_argmax.py
@@ -1,0 +1,361 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for the CuTe DSL argmax wrapper used by sampling/drafter code.
+
+These exercise:
+  * Parity with ``torch.argmax`` across vocab sizes used by real LLMs.
+  * Correct routing through the torch fallback for unsupported shapes/dtypes
+    (small N, unaligned N, fp16/bf16).
+  * CUDA-graph capture/replay — the kernel must stay in-place under graph
+    capture, since the sampling backends run under captured graphs.
+  * Drop-in compatibility from the runtime entrypoints used by the drafter
+    and sampling backends — verifies that the modules import successfully
+    with the cute_dsl integration in place.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+cute_dsl = pytest.importorskip("tokenspeed_kernel.ops.sampling.cute_dsl")
+cute_argmax = cute_dsl.argmax
+cute_argmax_pair = cute_dsl.argmax_pair
+
+
+# Vocab sizes for the models tokenspeed actively serves — same list as
+# ``tmp/integrate_cutedsl_argmax/bench_argmax.py::DEFAULT_N``.
+MODEL_VOCABS = {
+    "deepseek_v4": 129280,
+    "qwen3_5": 151936,
+    "kimi_k2_5": 163840,
+    "minimax_m2": 200064,
+    "gpt_oss": 201088,
+}
+
+
+def _need_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the CuTe argmax kernel")
+
+
+# ---------------------------------------------------------------------------
+# Correctness — kernel path (N >= 256, N % 32 == 0, fp32, supported SM)
+# ---------------------------------------------------------------------------
+
+
+# Speculative-decoding-style small batches × all 5 real model vocabs. Mirrors
+# ``bench_argmax.py::DEFAULT_M`` so the kernel coverage tested here matches the
+# one we benchmark.
+_KERNEL_M_VALUES = [1, 4, 16, 64, 128]
+_KERNEL_SHAPES = [(m, n) for n in MODEL_VOCABS.values() for m in _KERNEL_M_VALUES] + [
+    # Asymmetric M values to catch row-tail edge cases the powers-of-two miss.
+    (37, MODEL_VOCABS["deepseek_v4"]),
+    (199, MODEL_VOCABS["qwen3_5"]),
+]
+
+
+@pytest.mark.parametrize("M,N", _KERNEL_SHAPES)
+def test_argmax_matches_torch_for_kernel_shapes(M, N):
+    """Parity with ``torch.argmax`` across all served model vocabs."""
+    _need_cuda()
+    torch.manual_seed(M * 13 + N)
+    x = 0.1 * torch.randn(M, N, device="cuda", dtype=torch.float32)
+    out = cute_argmax(x)
+    ref = torch.argmax(x, dim=-1)
+    assert out.dtype == torch.int64
+    assert out.shape == ref.shape
+    torch.testing.assert_close(out, ref, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize(
+    "M,N",
+    [
+        (1, MODEL_VOCABS["deepseek_v4"]),
+        (16, MODEL_VOCABS["qwen3_5"]),
+        (64, MODEL_VOCABS["kimi_k2_5"]),
+        (4, MODEL_VOCABS["minimax_m2"]),
+        (32, MODEL_VOCABS["gpt_oss"]),
+    ],
+)
+def test_argmax_pair_matches_torch_max(M, N):
+    _need_cuda()
+    torch.manual_seed(M ^ N)
+    x = 0.1 * torch.randn(M, N, device="cuda", dtype=torch.float32)
+    pair = cute_argmax_pair(x)
+    ref_max, ref_idx = torch.max(x, dim=-1, keepdim=True)
+    assert pair.shape == (M, 2)
+    assert pair.dtype == torch.float32
+    torch.testing.assert_close(pair[:, 0:1], ref_max, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(pair[:, 1:2].long(), ref_idx, atol=0, rtol=0)
+
+
+def test_argmax_pair_writes_into_caller_buffer():
+    """argmax_pair must populate the caller-provided ``out`` (CUDA graph hot path)."""
+    _need_cuda()
+    M, N = 4, MODEL_VOCABS["qwen3_5"]
+    x = 0.1 * torch.randn(M, N, device="cuda", dtype=torch.float32)
+    out = torch.empty((M, 2), dtype=torch.float32, device="cuda")
+    returned = cute_argmax_pair(x, out=out)
+    assert returned.data_ptr() == out.data_ptr()
+    ref_max, ref_idx = torch.max(x, dim=-1, keepdim=True)
+    torch.testing.assert_close(out[:, 0:1], ref_max, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(out[:, 1:2].long(), ref_idx, atol=0, rtol=0)
+
+
+# ---------------------------------------------------------------------------
+# Fallback paths — these must still return correct indices
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("N", [8, 32, 64, 128, 256, 1024, 2048, 3072])
+def test_argmax_falls_back_for_small_N(N):
+    """N ≤ 3072 (incl. all multiples) hangs the kernel on B200 (see
+    ``_MIN_VOCAB_SIZE = 4096`` in cute_dsl.py). The wrapper must route every
+    such N through ``torch.argmax``."""
+    _need_cuda()
+    M = 4
+    torch.manual_seed(N)
+    x = torch.randn(M, N, device="cuda", dtype=torch.float32)
+    torch.testing.assert_close(cute_argmax(x), torch.argmax(x, dim=-1), atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("N", [257, 1023, 1025, 32001])
+def test_argmax_falls_back_for_unaligned_N(N):
+    _need_cuda()
+    M = 4
+    torch.manual_seed(N)
+    x = torch.randn(M, N, device="cuda", dtype=torch.float32)
+    torch.testing.assert_close(cute_argmax(x), torch.argmax(x, dim=-1), atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_argmax_falls_back_for_low_precision_dtypes(dtype):
+    _need_cuda()
+    x = torch.randn(8, 4096, device="cuda", dtype=dtype)
+    torch.testing.assert_close(cute_argmax(x), torch.argmax(x, dim=-1), atol=0, rtol=0)
+
+
+def test_argmax_falls_back_for_1d_input():
+    _need_cuda()
+    x = torch.randn(4096, device="cuda", dtype=torch.float32)
+    out = cute_argmax(x)
+    assert out.shape == ()
+    assert out.item() == torch.argmax(x, dim=-1).item()
+
+
+def test_argmax_falls_back_on_cpu():
+    x = torch.randn(4, 4096, dtype=torch.float32)
+    out = cute_argmax(x)
+    torch.testing.assert_close(out, torch.argmax(x, dim=-1), atol=0, rtol=0)
+
+
+def test_argmax_falls_back_when_cute_unavailable(monkeypatch):
+    """Simulate AMD ROCm / CPU-only / missing-cutlass platforms.
+
+    Forces the kernel availability flag off and verifies that both ``argmax``
+    and ``argmax_pair`` still return correct results via ``torch`` ops.
+    """
+    monkeypatch.setattr(cute_dsl, "_CUTE_AVAILABLE", False)
+    assert not cute_dsl.is_available()
+
+    if torch.cuda.is_available():
+        device = "cuda"
+    else:
+        device = "cpu"
+
+    # argmax: should match torch.argmax across kernel-eligible and ineligible shapes.
+    for shape in [
+        (4, MODEL_VOCABS["deepseek_v4"]),
+        (1, MODEL_VOCABS["gpt_oss"]),
+        (8, 257),
+    ]:
+        x = torch.randn(*shape, device=device, dtype=torch.float32)
+        torch.testing.assert_close(
+            cute_argmax(x), torch.argmax(x, dim=-1), atol=0, rtol=0
+        )
+
+    # argmax_pair: should still pack (max, idx) via torch fallback when CUDA.
+    if torch.cuda.is_available():
+        x = torch.randn(8, MODEL_VOCABS["qwen3_5"], device="cuda", dtype=torch.float32)
+        pair = cute_argmax_pair(x)
+        ref_max, ref_idx = torch.max(x, dim=-1, keepdim=True)
+        torch.testing.assert_close(pair[:, 0:1], ref_max, atol=1e-4, rtol=1e-4)
+        torch.testing.assert_close(pair[:, 1:2].long(), ref_idx, atol=0, rtol=0)
+
+
+def _fake_platform(vendor: str, major: int, minor: int):
+    from tokenspeed_kernel.platform import ArchVersion, PlatformInfo
+
+    return PlatformInfo(
+        vendor=vendor,
+        arch_version=ArchVersion(major, minor),
+        device_name=f"fake-{vendor}-{major}{minor}",
+        device_count=1,
+        total_memory=0,
+        memory_bandwidth=0.0,
+        sm_count=0,
+        max_threads_per_sm=0,
+        max_shared_memory_per_sm=0,
+    )
+
+
+def test_ts_supported_arch_gates_non_nvidia():
+    """_ts_supported_arch must return False for any non-NVIDIA platform.
+
+    Verifies the vendor gate by faking a PlatformInfo with vendor='amd'.
+    """
+    from tokenspeed_kernel.platform import Platform
+
+    real_platform = Platform.get()
+    try:
+        Platform.override(_fake_platform("amd", 9, 4))
+        assert cute_dsl._ts_supported_arch() is False
+    finally:
+        Platform.override(real_platform)
+
+
+def test_ts_supported_arch_gates_unsupported_sm():
+    """SM versions outside [9.0, 12.0) must be rejected, even on NVIDIA."""
+    from tokenspeed_kernel.platform import Platform
+
+    real_platform = Platform.get()
+    try:
+        # sm_80 (A100) — too old.
+        Platform.override(_fake_platform("nvidia", 8, 0))
+        assert cute_dsl._ts_supported_arch() is False
+
+        # sm_120 — upstream-flagged as unstable.
+        Platform.override(_fake_platform("nvidia", 12, 0))
+        assert cute_dsl._ts_supported_arch() is False
+
+        # sm_90 (Hopper) — supported.
+        Platform.override(_fake_platform("nvidia", 9, 0))
+        assert cute_dsl._ts_supported_arch() is True
+
+        # sm_100 (Blackwell) — supported.
+        Platform.override(_fake_platform("nvidia", 10, 0))
+        assert cute_dsl._ts_supported_arch() is True
+    finally:
+        Platform.override(real_platform)
+
+
+# ---------------------------------------------------------------------------
+# Special vocab patterns — ties / structured maxima
+# ---------------------------------------------------------------------------
+
+
+def test_argmax_returns_first_index_on_ties_like_torch():
+    """Tied values: torch.argmax returns the lowest index. The CuTe kernel uses
+    a redux.sync.min on candidates whose value equals the warp max, so it must
+    do the same."""
+    _need_cuda()
+    M, N = 4, MODEL_VOCABS["qwen3_5"]
+    x = torch.full((M, N), -100.0, device="cuda", dtype=torch.float32)
+    # Plant several rows where many positions hold the maximum value 0.0 at
+    # known indices — the kernel must return the first.
+    plant_positions = [
+        [0, 7, 9],
+        [3, 4],
+        [128, 1024, 65536],
+        [N - 1, 17],
+    ]
+    for row, positions in enumerate(plant_positions):
+        for pos in positions:
+            x[row, pos] = 0.0
+    out = cute_argmax(x)
+    torch.testing.assert_close(out, torch.argmax(x, dim=-1), atol=0, rtol=0)
+
+
+def test_argmax_mtp_pattern():
+    """Matches the test_argmax_mtp_case in TRT-LLM: one hot row at vocab[1].
+
+    Uses DeepSeek V4 vocab (already JIT-cached by earlier kernel-shape tests
+    within the same process) to keep this test fast — the row pattern is what's
+    being verified, not the vocab size."""
+    _need_cuda()
+    N = MODEL_VOCABS["deepseek_v4"]
+    x = torch.full((1, N), -100.0, device="cuda", dtype=torch.float32)
+    x[0, 1] = 0.0
+    out = cute_argmax(x)
+    assert out[0].item() == 1
+
+
+# ---------------------------------------------------------------------------
+# CUDA graph compatibility — the kernel must run from inside a captured graph
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "M,N",
+    [
+        (4, MODEL_VOCABS["deepseek_v4"]),
+        (16, MODEL_VOCABS["kimi_k2_5"]),
+        (64, MODEL_VOCABS["gpt_oss"]),
+    ],
+)
+def test_argmax_under_cuda_graph(M, N):
+    _need_cuda()
+    torch.manual_seed(M ^ N ^ 0xC0DE)
+    x = 0.1 * torch.randn(M, N, device="cuda", dtype=torch.float32)
+    out = torch.empty(M, dtype=torch.int64, device="cuda")
+
+    # Warmup.
+    out.copy_(cute_argmax(x))
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        out.copy_(cute_argmax(x))
+
+    # Mutate input, replay — output must reflect the new values.
+    new_x = 0.1 * torch.randn_like(x)
+    x.copy_(new_x)
+    graph.replay()
+    torch.cuda.synchronize()
+    ref = torch.argmax(x, dim=-1)
+    torch.testing.assert_close(out, ref, atol=0, rtol=0)
+
+
+# ---------------------------------------------------------------------------
+# Integration smoke — the modules that now import cute_dsl must still load
+# ---------------------------------------------------------------------------
+
+
+def test_eagle_imports_cute_argmax():
+    import importlib
+
+    mod = importlib.import_module("tokenspeed.runtime.execution.drafter.eagle")
+    assert mod.cute_argmax is cute_argmax
+
+
+def test_greedy_imports_cute_argmax():
+    import importlib
+
+    mod = importlib.import_module("tokenspeed.runtime.sampling.backends.greedy")
+    assert mod.cute_argmax is cute_argmax
+
+
+def test_flashinfer_imports_cute_argmax():
+    import importlib
+
+    mod = importlib.import_module("tokenspeed.runtime.sampling.backends.flashinfer")
+    assert mod.cute_argmax is cute_argmax

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
@@ -36,6 +36,15 @@ Exports two entry points:
   into two separate tensors; this entry point assembles them back into the
   legacy ``(M, 2)`` layout (one extra elementwise copy off the hot path). The
   runtime no longer uses this layout — kept for tests / future logprob users.
+
+Platform support:
+
+The CuTe DSL kernel ships only for NVIDIA Hopper/Blackwell (sm_90..<sm_120).
+On every other target — AMD ROCm, CPU-only, unsupported SM, missing
+``nvidia-cutlass-dsl`` — the public ``argmax`` / ``argmax_pair`` names are
+bound at import time to pure-torch fallback implementations, so callers don't
+need to test for kernel availability. The cute-DSL imports are gated behind
+``_ARCH_SUPPORTED`` and never executed on non-NVIDIA hosts.
 """
 
 from __future__ import annotations
@@ -182,63 +191,99 @@ def _invoke_kernel(
 _SUPPORTED_OUT_DTYPES = (torch.int32, torch.int64)
 
 
-def argmax(
+def _validate_argmax_out(logits: torch.Tensor, out: torch.Tensor) -> None:
+    if out.shape != (logits.shape[0],):
+        raise ValueError(
+            f"out must have shape (M,)={(logits.shape[0],)}, got {tuple(out.shape)}"
+        )
+    if out.dtype not in _SUPPORTED_OUT_DTYPES:
+        raise ValueError(f"out must be int32 or int64; got {out.dtype}")
+    if out.device != logits.device:
+        raise ValueError("out must be on the same device as logits")
+
+
+def _validate_argmax_pair_out(logits: torch.Tensor, out: torch.Tensor) -> None:
+    M = logits.shape[0]
+    if out.shape != (M, 2):
+        raise ValueError(f"out must have shape (M, 2)={M, 2}, got {tuple(out.shape)}")
+    if out.dtype != torch.float32 or out.device != logits.device:
+        raise ValueError("out must be float32 on the same device as logits")
+
+
+def _argmax_torch_fallback(
     logits: torch.Tensor,
     *,
     out: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Drop-in replacement for ``torch.argmax(logits, dim=-1)``.
+    """Pure-torch implementation of :func:`argmax`.
 
-    Returns an int64 tensor of shape ``(M,)`` by default. The CuTe DSL kernel
-    is used when ``logits`` is a 2D CUDA float32 tensor with N >= 4096 and
-    N % 32 == 0 on a supported Blackwell-class SM; otherwise this falls back
-    to ``torch.argmax`` for transparent compatibility.
-
-    The kernel writes the indices into ``out`` (or into a freshly allocated
-    int64 tensor) directly, so no post-kernel elementwise cast is launched on
-    the hot path. Callers that need int32 token ids can pass an int32 ``out``
-    to skip a downstream ``.to(torch.int32)`` cast — the kernel will write
-    int32 values straight into the buffer.
-
-    Args:
-        logits: 2D tensor of shape ``(M, N)``. Only the last dim is reduced.
-        out: Optional pre-allocated buffer of shape ``(M,)``. Must be int32
-            or int64 on the same device as ``logits``. Determines the dtype
-            of the returned tensor; defaults to int64 when omitted.
-
-    Returns:
-        Integer tensor of shape ``(M,)`` with dtype matching ``out`` (or
-        int64 when ``out`` was not supplied).
+    Selected at import time on non-NVIDIA / unsupported-SM hosts (AMD ROCm,
+    CPU-only, sm_80, sm_120+, missing ``nvidia-cutlass-dsl``). Also reached
+    per-call from the cute path when the input fails the kernel's
+    preconditions (1D / non-CUDA / fp16 / bf16 / small N / unaligned N).
     """
     if out is not None:
-        if out.shape != (logits.shape[0],):
-            raise ValueError(
-                f"out must have shape (M,)={(logits.shape[0],)}, "
-                f"got {tuple(out.shape)}"
-            )
-        if out.dtype not in _SUPPORTED_OUT_DTYPES:
-            raise ValueError(f"out must be int32 or int64; got {out.dtype}")
-        if out.device != logits.device:
-            raise ValueError("out must be on the same device as logits")
+        _validate_argmax_out(logits, out)
+    result = torch.argmax(logits, dim=-1)
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
+
+
+def _argmax_pair_torch_fallback(
+    logits: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Pure-torch implementation of :func:`argmax_pair`.
+
+    Selected at import time on non-NVIDIA / unsupported-SM hosts, and reached
+    per-call from the cute path when the input fails the kernel's
+    preconditions.
+    """
+    if logits.dim() != 2:
+        raise ValueError(f"argmax_pair expects 2D input, got {logits.dim()}D")
+    M = logits.shape[0]
+    device = logits.device
+    if out is None:
+        out = torch.empty((M, 2), dtype=torch.float32, device=device)
+    else:
+        _validate_argmax_pair_out(logits, out)
+
+    max_vals, max_indices = torch.max(logits, dim=-1, keepdim=True)
+    out[:, 0:1].copy_(max_vals.to(torch.float32))
+    out[:, 1:2].copy_(max_indices.to(torch.float32))
+    return out
+
+
+def _argmax_cute(
+    logits: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """CuTe DSL fast path for argmax.
+
+    Falls back per-call to :func:`_argmax_torch_fallback` when the input
+    isn't kernel-eligible (1D / non-CUDA / fp16 / bf16 / small N / unaligned N).
+    Only ever bound to the public ``argmax`` name on NVIDIA hosts with the
+    cute DSL Python packages available — see the module-level dispatch below.
+    """
+    if out is not None:
+        _validate_argmax_out(logits, out)
 
     if (
         logits.dim() != 2
         or not logits.is_cuda
         or not _supports_cute(logits.shape[1], logits.dtype)
     ):
-        result = torch.argmax(logits, dim=-1)
-        if out is not None:
-            out.copy_(result)
-            return out
-        return result
+        return _argmax_torch_fallback(logits, out=out)
 
     M = logits.shape[0]
     device = logits.device
-
-    if out is None:
-        out_idx = torch.empty((M,), dtype=torch.int64, device=device)
-    else:
-        out_idx = out
+    out_idx = (
+        out if out is not None else torch.empty((M,), dtype=torch.int64, device=device)
+    )
 
     # The max value is needed only inside the kernel reduction; the caller
     # never sees it. Allocate a scratch buffer so the kernel has somewhere to
@@ -248,31 +293,14 @@ def argmax(
     return out_idx
 
 
-def argmax_pair(
+def _argmax_pair_cute(
     logits: torch.Tensor,
     *,
     out: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Row-wise ``(max_value, argmax_index)`` packed as a ``(M, 2)`` float32 tensor.
-
-    The index is stored as ``float32`` — exact for any vocab below ``2**24``
-    (16,777,216), which covers every shipped LLM vocab size. This is a legacy
-    layout kept for tests / future logprob users; the runtime hot path uses
-    :func:`argmax` instead and avoids the extra packing entirely.
-
-    Args:
-        logits: 2D tensor of shape ``(M, N)`` on CUDA.
-        out: Optional pre-allocated ``(M, 2)`` float32 tensor. When supplied,
-            the kernel writes into it (useful inside CUDA graphs).
-
-    Returns:
-        ``(M, 2)`` float32 tensor: ``out[:, 0]`` is the max value,
-        ``out[:, 1]`` is the argmax index.
-    """
+    """CuTe DSL fast path for argmax_pair. Falls back per-call when needed."""
     if logits.dim() != 2:
         raise ValueError(f"argmax_pair expects 2D input, got {logits.dim()}D")
-    if not logits.is_cuda:
-        raise ValueError("argmax_pair requires a CUDA tensor")
 
     M, N = logits.shape
     device = logits.device
@@ -280,20 +308,12 @@ def argmax_pair(
     if out is None:
         out = torch.empty((M, 2), dtype=torch.float32, device=device)
     else:
-        if out.shape != (M, 2):
-            raise ValueError(
-                f"out must have shape (M, 2)={M, 2}, got {tuple(out.shape)}"
-            )
-        if out.dtype != torch.float32 or out.device != device:
-            raise ValueError("out must be float32 on the same device as logits")
+        _validate_argmax_pair_out(logits, out)
 
-    if not _supports_cute(N, logits.dtype):
-        # Fallback: emulate the same (max, idx) packing using torch ops so the
-        # downstream extraction path is uniform.
-        max_vals, max_indices = torch.max(logits, dim=-1, keepdim=True)
-        out[:, 0:1].copy_(max_vals.to(torch.float32))
-        out[:, 1:2].copy_(max_indices.to(torch.float32))
-        return out
+    if not logits.is_cuda or not _supports_cute(N, logits.dtype):
+        # Reuse the pure-torch packing path; pass our pre-allocated buffer so
+        # the caller-supplied ``out`` is honored.
+        return _argmax_pair_torch_fallback(logits, out=out)
 
     # Kernel writes into separate (M,) tensors; assemble into the legacy
     # (M, 2) layout for backward compatibility. This is off the runtime hot
@@ -306,7 +326,14 @@ def argmax_pair(
     return out
 
 
-# Expose the underlying compiled-kernel entry as the registered impl so other
-# code can probe `is _argmax_kernel_impl` style availability checks if needed.
+# Public API binding. On NVIDIA + cute-DSL-installed hosts the fast path is
+# selected; everywhere else the public names refer to pure-torch
+# implementations so callers don't need to test for availability. Mirrors the
+# pattern used in ``tokenspeed_kernel.ops.sampling.cuda``.
 if _CUTE_AVAILABLE:
+    argmax = _argmax_cute
+    argmax_pair = _argmax_pair_cute
     _argmax_kernel_impl = _invoke_kernel
+else:
+    argmax = _argmax_torch_fallback
+    argmax_pair = _argmax_pair_torch_fallback

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
@@ -26,12 +26,16 @@ third-party module directly.
 
 Exports two entry points:
 
-* :func:`argmax_pair`: row-wise ``(max_value, argmax_index)`` in a single
-  ``(M, 2)`` float32 tensor — direct passthrough to the kernel.
 * :func:`argmax`: drop-in replacement for ``torch.argmax(logits, dim=-1)``.
-  Returns int64 indices and transparently falls back to ``torch.argmax`` when
-  the CuTe DSL kernel is unavailable or its preconditions are not met
+  Returns int64 indices written by the kernel directly — no post-kernel cast
+  on the hot path. Transparently falls back to ``torch.argmax`` when the CuTe
+  DSL kernel is unavailable or its preconditions are not met
   (dtype/N/alignment/SM-version).
+* :func:`argmax_pair`: row-wise ``(max_value, argmax_index)`` packed as a
+  single ``(M, 2)`` float32 tensor. The kernel writes the max value and index
+  into two separate tensors; this entry point assembles them back into the
+  legacy ``(M, 2)`` layout (one extra elementwise copy off the hot path). The
+  runtime no longer uses this layout — kept for tests / future logprob users.
 """
 
 from __future__ import annotations
@@ -128,15 +132,133 @@ def _supports_cute(N: int, dtype: torch.dtype) -> bool:
     return True
 
 
+def _convert_to_cute(t: torch.Tensor):
+    """Wrap a torch tensor as a CuTe DSL tensor with a CUDA-graph-safe view."""
+    return from_dlpack(
+        CUDAGraphCompatibleWrapper(t.detach()), assumed_align=16
+    ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1))
+
+
+def _convert_to_cute_1d(t: torch.Tensor):
+    """1D-tensor variant of :func:`_convert_to_cute`."""
+    return from_dlpack(
+        CUDAGraphCompatibleWrapper(t.detach()), assumed_align=16
+    ).mark_compact_shape_dynamic(mode=0, stride_order=(0,))
+
+
+def _invoke_kernel(
+    logits: torch.Tensor, out_max: torch.Tensor, out_idx: torch.Tensor
+) -> None:
+    """Launch ArgmaxKernel with separate ``(M,)`` max and idx output tensors.
+
+    Caller is responsible for shape/dtype checks; this helper assumes inputs
+    are already validated by :func:`_supports_cute`.
+    """
+    dtype = torch2cute_dtype_map[logits.dtype]
+    x_tensor = _convert_to_cute(logits)
+    max_tensor = _convert_to_cute_1d(out_max)
+    idx_tensor = _convert_to_cute_1d(out_idx)
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    # Blackwell (sm_100/103) supports redux.sync.max.f32; Hopper falls back to
+    # warp shuffles.
+    p = current_platform()
+    sm = p.arch_version.major * 10 + p.arch_version.minor
+    use_redux = 100 <= sm < 120
+
+    N = logits.shape[1]
+    # Cache by index dtype too: the kernel writes the index with the output
+    # tensor's element type, so int64 vs int32 produce distinct compiled units.
+    compile_key = (dtype, N, use_redux, out_idx.dtype)
+    compiled = _compile_cache.get(compile_key)
+    if compiled is None:
+        kernel = ArgmaxKernel(dtype, N, use_redux=use_redux)
+        compiled = cute.compile(kernel, x_tensor, max_tensor, idx_tensor, stream)
+        _compile_cache[compile_key] = compiled
+
+    compiled(x_tensor, max_tensor, idx_tensor, stream)
+
+
+_SUPPORTED_OUT_DTYPES = (torch.int32, torch.int64)
+
+
+def argmax(
+    logits: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Drop-in replacement for ``torch.argmax(logits, dim=-1)``.
+
+    Returns an int64 tensor of shape ``(M,)`` by default. The CuTe DSL kernel
+    is used when ``logits`` is a 2D CUDA float32 tensor with N >= 4096 and
+    N % 32 == 0 on a supported Blackwell-class SM; otherwise this falls back
+    to ``torch.argmax`` for transparent compatibility.
+
+    The kernel writes the indices into ``out`` (or into a freshly allocated
+    int64 tensor) directly, so no post-kernel elementwise cast is launched on
+    the hot path. Callers that need int32 token ids can pass an int32 ``out``
+    to skip a downstream ``.to(torch.int32)`` cast — the kernel will write
+    int32 values straight into the buffer.
+
+    Args:
+        logits: 2D tensor of shape ``(M, N)``. Only the last dim is reduced.
+        out: Optional pre-allocated buffer of shape ``(M,)``. Must be int32
+            or int64 on the same device as ``logits``. Determines the dtype
+            of the returned tensor; defaults to int64 when omitted.
+
+    Returns:
+        Integer tensor of shape ``(M,)`` with dtype matching ``out`` (or
+        int64 when ``out`` was not supplied).
+    """
+    if out is not None:
+        if out.shape != (logits.shape[0],):
+            raise ValueError(
+                f"out must have shape (M,)={(logits.shape[0],)}, "
+                f"got {tuple(out.shape)}"
+            )
+        if out.dtype not in _SUPPORTED_OUT_DTYPES:
+            raise ValueError(f"out must be int32 or int64; got {out.dtype}")
+        if out.device != logits.device:
+            raise ValueError("out must be on the same device as logits")
+
+    if (
+        logits.dim() != 2
+        or not logits.is_cuda
+        or not _supports_cute(logits.shape[1], logits.dtype)
+    ):
+        result = torch.argmax(logits, dim=-1)
+        if out is not None:
+            out.copy_(result)
+            return out
+        return result
+
+    M = logits.shape[0]
+    device = logits.device
+
+    if out is None:
+        out_idx = torch.empty((M,), dtype=torch.int64, device=device)
+    else:
+        out_idx = out
+
+    # The max value is needed only inside the kernel reduction; the caller
+    # never sees it. Allocate a scratch buffer so the kernel has somewhere to
+    # write it.
+    scratch_max = torch.empty((M,), dtype=torch.float32, device=device)
+    _invoke_kernel(logits, scratch_max, out_idx)
+    return out_idx
+
+
 def argmax_pair(
     logits: torch.Tensor,
     *,
     out: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Row-wise ``(max_value, argmax_index)`` in a single ``(M, 2)`` float32 tensor.
+    """Row-wise ``(max_value, argmax_index)`` packed as a ``(M, 2)`` float32 tensor.
 
     The index is stored as ``float32`` — exact for any vocab below ``2**24``
-    (16,777,216), which covers every shipped LLM vocab size.
+    (16,777,216), which covers every shipped LLM vocab size. This is a legacy
+    layout kept for tests / future logprob users; the runtime hot path uses
+    :func:`argmax` instead and avoids the extra packing entirely.
 
     Args:
         logits: 2D tensor of shape ``(M, N)`` on CUDA.
@@ -153,15 +275,16 @@ def argmax_pair(
         raise ValueError("argmax_pair requires a CUDA tensor")
 
     M, N = logits.shape
+    device = logits.device
 
     if out is None:
-        out = torch.empty((M, 2), dtype=torch.float32, device=logits.device)
+        out = torch.empty((M, 2), dtype=torch.float32, device=device)
     else:
         if out.shape != (M, 2):
             raise ValueError(
                 f"out must have shape (M, 2)={M, 2}, got {tuple(out.shape)}"
             )
-        if out.dtype != torch.float32 or out.device != logits.device:
+        if out.dtype != torch.float32 or out.device != device:
             raise ValueError("out must be float32 on the same device as logits")
 
     if not _supports_cute(N, logits.dtype):
@@ -172,73 +295,18 @@ def argmax_pair(
         out[:, 1:2].copy_(max_indices.to(torch.float32))
         return out
 
-    dtype = torch2cute_dtype_map[logits.dtype]
-
-    def _convert(t: torch.Tensor):
-        return from_dlpack(
-            CUDAGraphCompatibleWrapper(t.detach()), assumed_align=16
-        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1))
-
-    x_tensor = _convert(logits)
-    out_tensor = _convert(out)
-    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-
-    # Blackwell (sm_100/103) supports redux.sync.max.f32; Hopper falls back to
-    # warp shuffles.
-    p = current_platform()
-    sm = p.arch_version.major * 10 + p.arch_version.minor
-    use_redux = 100 <= sm < 120
-
-    compile_key = (dtype, N, use_redux)
-    compiled = _compile_cache.get(compile_key)
-    if compiled is None:
-        kernel = ArgmaxKernel(dtype, N, use_redux=use_redux)
-        compiled = cute.compile(kernel, x_tensor, out_tensor, stream)
-        _compile_cache[compile_key] = compiled
-
-    compiled(x_tensor, out_tensor, stream)
+    # Kernel writes into separate (M,) tensors; assemble into the legacy
+    # (M, 2) layout for backward compatibility. This is off the runtime hot
+    # path (callers use :func:`argmax` instead), so the extra copy/cast is OK.
+    tmp_max = torch.empty((M,), dtype=torch.float32, device=device)
+    tmp_idx = torch.empty((M,), dtype=torch.int64, device=device)
+    _invoke_kernel(logits, tmp_max, tmp_idx)
+    out[:, 0].copy_(tmp_max)
+    out[:, 1].copy_(tmp_idx.to(torch.float32))
     return out
-
-
-def argmax(
-    logits: torch.Tensor,
-    *,
-    out: torch.Tensor | None = None,
-) -> torch.Tensor:
-    """Drop-in replacement for ``torch.argmax(logits, dim=-1)``.
-
-    Returns an int64 tensor of shape ``(M,)``. The CuTe DSL kernel is used
-    when ``logits`` is a 2D CUDA float32 tensor with N >= 256 and N % 32 == 0
-    on a supported Blackwell-class SM; otherwise this falls back to
-    ``torch.argmax`` for transparent compatibility.
-
-    Args:
-        logits: 2D tensor of shape ``(M, N)``. Only the last dim is reduced.
-        out: Optional pre-allocated int64 buffer of shape ``(M,)``.
-
-    Returns:
-        int64 tensor of shape ``(M,)``.
-    """
-    if (
-        logits.dim() != 2
-        or not logits.is_cuda
-        or not _supports_cute(logits.shape[1], logits.dtype)
-    ):
-        result = torch.argmax(logits, dim=-1)
-        if out is not None:
-            out.copy_(result)
-            return out
-        return result
-
-    pair = argmax_pair(logits)
-    indices = pair[:, 1].to(torch.int64)
-    if out is not None:
-        out.copy_(indices)
-        return out
-    return indices
 
 
 # Expose the underlying compiled-kernel entry as the registered impl so other
 # code can probe `is _argmax_kernel_impl` style availability checks if needed.
 if _CUTE_AVAILABLE:
-    _argmax_kernel_impl = argmax_pair
+    _argmax_kernel_impl = _invoke_kernel

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
@@ -1,0 +1,244 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""CuTe DSL based sampling kernels.
+
+Wraps the upstream CuTe DSL ``ArgmaxKernel`` (derived from the Quack library and
+ported through TensorRT-LLM) so the runtime can call it without touching the
+third-party module directly.
+
+Exports two entry points:
+
+* :func:`argmax_pair`: row-wise ``(max_value, argmax_index)`` in a single
+  ``(M, 2)`` float32 tensor — direct passthrough to the kernel.
+* :func:`argmax`: drop-in replacement for ``torch.argmax(logits, dim=-1)``.
+  Returns int64 indices and transparently falls back to ``torch.argmax`` when
+  the CuTe DSL kernel is unavailable or its preconditions are not met
+  (dtype/N/alignment/SM-version).
+"""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel.platform import current_platform
+from tokenspeed_kernel.registry import error_fn
+
+__all__ = [
+    "argmax",
+    "argmax_pair",
+    "is_available",
+]
+
+_argmax_kernel_impl = error_fn
+_compile_cache: dict[tuple, object] = {}
+
+# Minimum vocab size for the CuTe tiled kernel.
+#
+# The kernel hangs on B200 (sm_100) when ``_calculate_threads_per_row()``
+# returns 32 AND ``tiler_mn[1] == N`` (i.e. ``is_even_N`` skips ``fill_oob``).
+# Empirically that happens for N ∈ {256, 512, 1024, 2048, 3072} — every clean
+# multiple in the upstream ``128 < N <= 3072`` band. Bumping the floor above
+# 3072 sidesteps the bad band entirely; every real LLM vocab (≥ 30K) is far
+# above this, so we never lose the kernel in practice.
+_MIN_VOCAB_SIZE = 4096
+
+# The async copy requires 128-byte alignment.
+_VOCAB_SIZE_ALIGNMENT = 32
+
+
+def _ts_supported_arch() -> bool:
+    """Gate: only NVIDIA Hopper/Blackwell run the CuTe DSL kernel.
+
+    * Vendor must be NVIDIA — AMD ROCm and any future vendor get the torch
+      fallback (CuTe DSL has no ROCm backend).
+    * SM range ``[9.0, 12.0)``: ``redux.sync.max.f32`` exists from Blackwell
+      (sm_100/sm_103); we run on Hopper too via the shuffle path. ``sm_120+``
+      is excluded — upstream TRT-LLM reports CUTLASS DSL JIT instability there.
+    * If platform detection itself raises (e.g. CPU-only host with no GPU),
+      treat it as unsupported and let callers fall back transparently.
+    """
+    try:
+        p = current_platform()
+    except Exception:
+        return False
+    if not p.is_nvidia:
+        return False
+    sm = p.arch_version.major * 10 + p.arch_version.minor
+    return 90 <= sm < 120
+
+
+_ARCH_SUPPORTED = _ts_supported_arch()
+
+
+# Only import the third-party CuTe DSL module on supported NVIDIA hardware.
+# On AMD / CPU-only / unsupported SM, leave ``_CUTE_AVAILABLE = False`` so every
+# entry point in this module routes through ``torch.argmax``.
+_CUTE_AVAILABLE = False
+if _ARCH_SUPPORTED:
+    try:
+        import cuda.bindings.driver as cuda
+        import cutlass.cute as cute
+        from cutlass.cute.runtime import from_dlpack
+        from tokenspeed_kernel.thirdparty.cute_dsl.argmax import (
+            ArgmaxKernel,
+            CUDAGraphCompatibleWrapper,
+            torch2cute_dtype_map,
+        )
+
+        _CUTE_AVAILABLE = True
+    except ImportError:
+        _CUTE_AVAILABLE = False
+
+
+def is_available() -> bool:
+    """Whether the CuTe DSL argmax kernel can run on the current platform."""
+    return _CUTE_AVAILABLE
+
+
+def _supports_cute(N: int, dtype: torch.dtype) -> bool:
+    if not _CUTE_AVAILABLE:
+        return False
+    if dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        return False
+    # The current upstream wrapper only ships a float32 path. Honor that here so
+    # we don't surprise callers with reduced-precision argmax on bf16/fp16.
+    if dtype is not torch.float32:
+        return False
+    if N < _MIN_VOCAB_SIZE:
+        return False
+    if N % _VOCAB_SIZE_ALIGNMENT != 0:
+        return False
+    return True
+
+
+def argmax_pair(
+    logits: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Row-wise ``(max_value, argmax_index)`` in a single ``(M, 2)`` float32 tensor.
+
+    The index is stored as ``float32`` — exact for any vocab below ``2**24``
+    (16,777,216), which covers every shipped LLM vocab size.
+
+    Args:
+        logits: 2D tensor of shape ``(M, N)`` on CUDA.
+        out: Optional pre-allocated ``(M, 2)`` float32 tensor. When supplied,
+            the kernel writes into it (useful inside CUDA graphs).
+
+    Returns:
+        ``(M, 2)`` float32 tensor: ``out[:, 0]`` is the max value,
+        ``out[:, 1]`` is the argmax index.
+    """
+    if logits.dim() != 2:
+        raise ValueError(f"argmax_pair expects 2D input, got {logits.dim()}D")
+    if not logits.is_cuda:
+        raise ValueError("argmax_pair requires a CUDA tensor")
+
+    M, N = logits.shape
+
+    if out is None:
+        out = torch.empty((M, 2), dtype=torch.float32, device=logits.device)
+    else:
+        if out.shape != (M, 2):
+            raise ValueError(
+                f"out must have shape (M, 2)={M, 2}, got {tuple(out.shape)}"
+            )
+        if out.dtype != torch.float32 or out.device != logits.device:
+            raise ValueError("out must be float32 on the same device as logits")
+
+    if not _supports_cute(N, logits.dtype):
+        # Fallback: emulate the same (max, idx) packing using torch ops so the
+        # downstream extraction path is uniform.
+        max_vals, max_indices = torch.max(logits, dim=-1, keepdim=True)
+        out[:, 0:1].copy_(max_vals.to(torch.float32))
+        out[:, 1:2].copy_(max_indices.to(torch.float32))
+        return out
+
+    dtype = torch2cute_dtype_map[logits.dtype]
+
+    def _convert(t: torch.Tensor):
+        return from_dlpack(
+            CUDAGraphCompatibleWrapper(t.detach()), assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1))
+
+    x_tensor = _convert(logits)
+    out_tensor = _convert(out)
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    # Blackwell (sm_100/103) supports redux.sync.max.f32; Hopper falls back to
+    # warp shuffles.
+    p = current_platform()
+    sm = p.arch_version.major * 10 + p.arch_version.minor
+    use_redux = 100 <= sm < 120
+
+    compile_key = (dtype, N, use_redux)
+    compiled = _compile_cache.get(compile_key)
+    if compiled is None:
+        kernel = ArgmaxKernel(dtype, N, use_redux=use_redux)
+        compiled = cute.compile(kernel, x_tensor, out_tensor, stream)
+        _compile_cache[compile_key] = compiled
+
+    compiled(x_tensor, out_tensor, stream)
+    return out
+
+
+def argmax(
+    logits: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Drop-in replacement for ``torch.argmax(logits, dim=-1)``.
+
+    Returns an int64 tensor of shape ``(M,)``. The CuTe DSL kernel is used
+    when ``logits`` is a 2D CUDA float32 tensor with N >= 256 and N % 32 == 0
+    on a supported Blackwell-class SM; otherwise this falls back to
+    ``torch.argmax`` for transparent compatibility.
+
+    Args:
+        logits: 2D tensor of shape ``(M, N)``. Only the last dim is reduced.
+        out: Optional pre-allocated int64 buffer of shape ``(M,)``.
+
+    Returns:
+        int64 tensor of shape ``(M,)``.
+    """
+    if (
+        logits.dim() != 2
+        or not logits.is_cuda
+        or not _supports_cute(logits.shape[1], logits.dtype)
+    ):
+        result = torch.argmax(logits, dim=-1)
+        if out is not None:
+            out.copy_(result)
+            return out
+        return result
+
+    pair = argmax_pair(logits)
+    indices = pair[:, 1].to(torch.int64)
+    if out is not None:
+        out.copy_(indices)
+        return out
+    return indices
+
+
+# Expose the underlying compiled-kernel entry as the registered impl so other
+# code can probe `is _argmax_kernel_impl` style availability checks if needed.
+if _CUTE_AVAILABLE:
+    _argmax_kernel_impl = argmax_pair

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/argmax.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/argmax.py
@@ -1,0 +1,644 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, Tri Dao.
+# SPDX-FileCopyrightText: Copyright (c) 2025, Wentao Guo, Ted Zadouri, Tri Dao.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file contains code derived from the Quack library:
+# https://github.com/Dao-AILab/quack
+# Originally integrated into TensorRT-LLM:
+# https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/cute_dsl_kernels/argmax.py
+#
+# Argmax kernel using CuTe DSL.
+#
+# This module pulls in ``cuda.bindings.driver`` and ``cutlass``, which are
+# NVIDIA-only Python packages. **Do not import this module directly from the
+# runtime.** Use ``tokenspeed_kernel.ops.sampling.cute_dsl`` instead — that
+# wrapper gates on ``current_platform().is_nvidia`` before importing this file
+# and falls back to ``torch.argmax`` on every other platform.
+
+from typing import Optional, Tuple, Type
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.arch.nvvm_wrappers import FULL_MASK
+from cutlass.cute.runtime import from_dlpack
+from cutlass.cute.typing import Float32, Int, Int32
+from cutlass.cutlass_dsl import T, dsl_user_op
+
+# ============================================================================
+# Torch to CuTE dtype mapping
+# ============================================================================
+torch2cute_dtype_map = {
+    torch.float16: cutlass.Float16,
+    torch.bfloat16: cutlass.BFloat16,
+    torch.float32: cutlass.Float32,
+}
+
+
+# ============================================================================
+# CUDA Graph compatibility wrapper
+# ============================================================================
+class CUDAGraphCompatibleWrapper:
+    """Wrapper to make tensors compatible with CUDA graph capture for DLPack export."""
+
+    def __init__(self, tensor):
+        self._tensor = tensor
+
+    def __dlpack__(self, stream=None):
+        return self._tensor.__dlpack__(stream=-1)
+
+    def __dlpack_device__(self):
+        return self._tensor.__dlpack_device__()
+
+
+# ============================================================================
+# Utility functions from quack/utils.py
+# ============================================================================
+@dsl_user_op
+def elem_pointer(
+    x: cute.Tensor, coord: cute.Coord, *, loc=None, ip=None
+) -> cute.Pointer:
+    return x.iterator + cute.crd2idx(coord, x.layout, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def set_block_rank(
+    smem_ptr: cute.Pointer, peer_cta_rank_in_cluster: cute.Int32, *, loc=None, ip=None
+) -> cutlass.Int32:
+    smem_ptr_i32 = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    return cutlass.Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [smem_ptr_i32, peer_cta_rank_in_cluster.ir_value()],
+            "mapa.shared::cluster.u32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def store_shared_remote(
+    val: float | Float32 | cutlass.Int64,
+    smem_ptr: cute.Pointer,
+    mbar_ptr: cute.Pointer,
+    peer_cta_rank_in_cluster: cute.typing.Int,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
+    remote_smem_ptr_i32 = set_block_rank(
+        smem_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip
+    ).ir_value()
+    remote_mbar_ptr_i32 = set_block_rank(
+        mbar_ptr, peer_cta_rank_in_cluster, loc=loc, ip=ip
+    ).ir_value()
+    if cutlass.const_expr(isinstance(val, float)):
+        val = Float32(val)
+    assert isinstance(val, (Float32, Int32, cutlass.Int64))
+    suffix = {Float32: "f32", Int32: "s32", cutlass.Int64: "s64"}[type(val)]
+    constraint = {Float32: "f", Int32: "r", cutlass.Int64: "l"}[type(val)]
+    llvm.inline_asm(
+        None,
+        [remote_smem_ptr_i32, val.ir_value(loc=loc, ip=ip), remote_mbar_ptr_i32],
+        f"st.async.shared::cluster.mbarrier::complete_tx::bytes.{suffix} [$0], $1, [$2];",
+        f"r,{constraint},r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@cute.jit
+def predicate_k(tAcA: cute.Tensor, limit: cutlass.Int32) -> cute.Tensor:
+    tApA = cute.make_fragment(
+        cute.make_layout(
+            (
+                cute.size(tAcA, mode=[0, 1]),
+                cute.size(tAcA, mode=[1]),
+                cute.size(tAcA, mode=[2]),
+            ),
+            stride=(cute.size(tAcA, mode=[2]), 0, 1),
+        ),
+        cutlass.Boolean,
+    )
+    for rest_v in cutlass.range_constexpr(tApA.shape[0]):
+        for rest_k in cutlass.range_constexpr(tApA.shape[2]):
+            tApA[rest_v, 0, rest_k] = cute.elem_less(
+                tAcA[(0, rest_v), 0, rest_k][1], limit
+            )
+    return tApA
+
+
+@cute.jit
+def fill_oob(
+    tXsX: cute.Tensor, tXpX: Optional[cute.Tensor], fill_value: cute.Numeric
+) -> None:
+    tXrX_fill = cute.make_fragment_like(tXsX[(None, 0), None, 0])
+    tXrX_fill.fill(fill_value)
+    for rest_v in cutlass.range_constexpr(tXsX.shape[0][1]):
+        for rest_k in cutlass.range_constexpr(tXsX.shape[2]):
+            if cutlass.const_expr(tXpX is not None):
+                if not tXpX[rest_v, 0, rest_k]:
+                    cute.autovec_copy(tXrX_fill, tXsX[(None, rest_v), None, rest_k])
+            else:
+                cute.autovec_copy(tXrX_fill, tXsX[(None, rest_v), None, rest_k])
+
+
+@dsl_user_op
+def domain_offset_i64(
+    coord: cute.Coord, tensor: cute.Tensor, *, loc=None, ip=None
+) -> cute.Tensor:
+    flat_coord_i64 = tuple(cutlass.Int64(c) for c in cute.flatten(coord))
+    flat_stride = cute.flatten_to_tuple(tensor.stride)
+    offset = sum(c * s for c, s in zip(flat_coord_i64, flat_stride))
+    new_ptr = cute.make_ptr(
+        tensor.element_type,
+        tensor.iterator.toint() + offset * tensor.element_type.width // 8,
+        tensor.memspace,
+        assumed_align=tensor.iterator.max_alignment,
+    )
+    return cute.make_tensor(new_ptr, tensor.layout)
+
+
+# ============================================================================
+# Inline PTX for redux.sync operations
+# ============================================================================
+@dsl_user_op
+def ptx_redux_sync_max_f32(
+    value: Float32, mask: Int = FULL_MASK, *, loc=None, ip=None
+) -> Float32:
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [
+                Float32(value).ir_value(loc=loc, ip=ip),
+                Int32(mask).ir_value(loc=loc, ip=ip),
+            ],
+            """redux.sync.max.f32 $0, $1, $2;""",
+            "=f,f,i",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def ptx_redux_sync_min_u32(
+    value: Int32, mask: Int = FULL_MASK, *, loc=None, ip=None
+) -> Int32:
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Int32(value).ir_value(loc=loc, ip=ip),
+                Int32(mask).ir_value(loc=loc, ip=ip),
+            ],
+            """redux.sync.min.u32 $0, $1, $2;""",
+            "=r,r,i",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def ptx_select_argmax_candidate(
+    current_max: Float32, warp_max: Float32, current_argmax: Int32, *, loc=None, ip=None
+) -> Int32:
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Float32(current_max).ir_value(loc=loc, ip=ip),
+                Float32(warp_max).ir_value(loc=loc, ip=ip),
+                Int32(current_argmax).ir_value(loc=loc, ip=ip),
+            ],
+            """{
+                .reg .pred p;
+                setp.eq.f32 p, $1, $2;
+                selp.s32 $0, $3, 0xffffffff, p;
+            }""",
+            "=r,f,f,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@cute.jit
+def warp_argmax_redux(current_max: Float32, current_argmax: Int32):
+    """Redux-based warp argmax - only works on sm_100f (Blackwell)."""
+    warp_max = ptx_redux_sync_max_f32(current_max)
+    candidate_idx = ptx_select_argmax_candidate(current_max, warp_max, current_argmax)
+    winning_idx = ptx_redux_sync_min_u32(candidate_idx)
+    return warp_max, winning_idx
+
+
+@cute.jit
+def warp_reduce_argmax(current_max: Float32, current_argmax: Int32):
+    """Shuffle-based warp argmax - works on all architectures (Hopper+)."""
+    warp_max = current_max
+    warp_argmax = current_argmax
+
+    # Use butterfly shuffle pattern for warp reduction
+    for i in cutlass.range_constexpr(int(5)):  # log2(32) = 5 iterations
+        # Get values from other lanes using butterfly pattern
+        other_max = cute.arch.shuffle_sync_bfly(warp_max, offset=1 << i)
+        other_argmax = cute.arch.shuffle_sync_bfly(warp_argmax, offset=1 << i)
+
+        # Inline argmax comparison
+        if other_max > warp_max:
+            warp_max = other_max
+            warp_argmax = other_argmax
+
+    return warp_max, warp_argmax
+
+
+# ============================================================================
+# Reduction Base class
+# ============================================================================
+class ReductionBase:
+    def __init__(
+        self,
+        dtype: Type[cutlass.Numeric],
+        N: int,
+        stage: int,
+        reduction_dtype=cutlass.Float32,
+    ):
+        self.dtype = dtype
+        self.N = N
+        self.stage = stage
+        self.reduction_dtype = reduction_dtype
+
+    def _calculate_threads_per_row(self):
+        raise NotImplementedError()
+
+    def _set_cluster_n(self):
+        self.cluster_n = 1
+
+    def _get_num_threads(self):
+        return 128 if self.N <= 16384 else 256
+
+    def _get_tv_layout(self, num_copy_bits=128):
+        vecsize = num_copy_bits // self.dtype.width
+        num_threads = self._get_num_threads()
+        threads_per_row = self._calculate_threads_per_row()
+        num_blocks_N = cute.ceil_div(
+            self.N // vecsize, threads_per_row * self.cluster_n
+        )
+        cols_per_block = num_threads // threads_per_row
+        tiler_mn = (cols_per_block, vecsize * num_blocks_N * threads_per_row)
+        tv_layout = cute.make_layout(
+            ((threads_per_row, cols_per_block), (vecsize, num_blocks_N)),
+            stride=(
+                (vecsize * cols_per_block, 1),
+                (cols_per_block, cols_per_block * vecsize * threads_per_row),
+            ),
+        )
+        return tiler_mn, tv_layout
+
+    def _smem_size_in_bytes(self, tiler_mn, num_warps):
+        return (
+            cute.size_in_bytes(self.dtype, cute.make_layout(tiler_mn))
+            + self.stage
+            * num_warps
+            * self.cluster_n
+            * (self.reduction_dtype.width // 8)
+            + self.stage * (cutlass.Int64.width // 8)
+        )
+
+    def _get_reduction_buffer_layout(self, tv_layout: cute.Layout, cluster_n: int):
+        num_warps = cute.size(tv_layout, mode=[0]) // cute.arch.WARP_SIZE
+        warps_per_row = max(tv_layout.shape[0][0] // cute.arch.WARP_SIZE, 1)
+        return cute.make_ordered_layout(
+            (num_warps // warps_per_row, (warps_per_row, cluster_n), self.stage),
+            order=(1, 0, 2),
+        )
+
+    def _allocate_reduction_buffer_and_mbar(
+        self, smem: cutlass.utils.SmemAllocator, tv_layout: cute.Layout
+    ) -> Tuple[cute.Tensor, Optional[cute.Pointer]]:
+        reduction_buffer = smem.allocate_tensor(
+            self.reduction_dtype,
+            self._get_reduction_buffer_layout(tv_layout, self.cluster_n),
+            byte_alignment=4,
+        )
+        if cutlass.const_expr(self.cluster_n > 1):
+            mbar_ptr = smem.allocate_array(cutlass.Int64, num_elems=self.stage)
+        else:
+            mbar_ptr = None
+        return reduction_buffer, mbar_ptr
+
+    @cute.jit
+    def _initialize_cluster(
+        self, tidx: cutlass.Int32, mbar_ptr: cute.Pointer, num_warps: int
+    ):
+        if cutlass.const_expr(self.cluster_n > 1):
+            if tidx < self.stage:
+                cute.arch.mbarrier_init(mbar_ptr + tidx, 1)
+            cute.arch.mbarrier_init_fence()
+            cute.arch.cluster_arrive_relaxed()
+
+
+# ============================================================================
+# Argmax Kernel class
+# ============================================================================
+class ArgmaxKernel(ReductionBase):
+    def __init__(self, dtype: Type[cutlass.Numeric], N: int, use_redux: bool = False):
+        super().__init__(dtype, N, stage=1, reduction_dtype=cutlass.Float32)
+        # use_redux=True for Blackwell (sm_100f), False for Hopper (sm_90)
+        self.use_redux = use_redux
+
+    def _calculate_threads_per_row(self):
+        N = self.N
+        return (
+            8
+            if N <= 64
+            else (
+                16
+                if N <= 128
+                else (
+                    32
+                    if N <= 3072
+                    else (64 if N <= 6144 else (128 if N <= 16384 else 256))
+                )
+            )
+        )
+
+    def _set_cluster_n(self):
+        N = self.N
+        if cutlass.const_expr(self.dtype.width == 16):
+            self.cluster_n = (
+                1
+                if N <= 16 * 1024
+                else (
+                    2
+                    if N <= 32 * 1024
+                    else (4 if N <= 64 * 1024 else (8 if N <= 128 * 1024 else 16))
+                )
+            )
+        else:
+            self.cluster_n = (
+                1
+                if N <= 32 * 1024
+                else (
+                    2
+                    if N <= 64 * 1024
+                    else (4 if N <= 128 * 1024 else (8 if N <= 256 * 1024 else 16))
+                )
+            )
+
+    def _get_reduction_buffer_layout(self, tv_layout: cute.Layout, cluster_n: int):
+        num_warps = cute.size(tv_layout, mode=[0]) // cute.arch.WARP_SIZE
+        warps_per_row = max(tv_layout.shape[0][0] // cute.arch.WARP_SIZE, 1)
+        return cute.make_ordered_layout(
+            (num_warps // warps_per_row, (warps_per_row, cluster_n), self.stage, 2),
+            order=(1, 0, 2, 3),
+        )
+
+    def _smem_size_in_bytes(self, tiler_mn, num_warps):
+        return (
+            cute.size_in_bytes(self.dtype, cute.make_layout(tiler_mn))
+            + 2
+            * self.stage
+            * num_warps
+            * self.cluster_n
+            * (self.reduction_dtype.width // 8)
+            + self.stage * (cutlass.Int64.width // 8)
+        )
+
+    @cute.jit
+    def __call__(self, mX: cute.Tensor, mO: cute.Tensor, stream: cuda.CUstream):
+        self._set_cluster_n()
+        tiler_mn, tv_layout = self._get_tv_layout()
+        num_threads = cute.size(tv_layout, mode=[0])
+        num_warps = num_threads // cute.arch.WARP_SIZE
+
+        self.kernel(mX, mO, tv_layout, tiler_mn).launch(
+            grid=[cute.ceil_div(mX.shape[0], tiler_mn[0]), self.cluster_n, 1],
+            block=[num_threads, 1, 1],
+            cluster=(
+                [1, self.cluster_n, 1]
+                if cutlass.const_expr(self.cluster_n > 1)
+                else None
+            ),
+            smem=self._smem_size_in_bytes(tiler_mn, num_warps),
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        mX: cute.Tensor,
+        mO: cute.Tensor,
+        tv_layout: cute.Layout,
+        tiler_mn: cute.Shape,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bidy, bidz = cute.arch.block_idx()
+
+        if cutlass.const_expr(self.cluster_n > 1):
+            cluster_y = cute.arch.block_idx()[1]
+        else:
+            cluster_y = cutlass.const_expr(0)
+
+        shape = mX.shape
+        idX = cute.make_identity_tensor(shape)
+
+        mX, mO = [domain_offset_i64((bidx * tiler_mn[0], 0), mT) for mT in (mX, mO)]
+        gX, gO = [cute.local_tile(mT, tiler_mn, (0, cluster_y)) for mT in (mX, mO)]
+        cX = cute.local_tile(idX, tiler_mn, (bidx, cluster_y))
+
+        smem = cutlass.utils.SmemAllocator()
+        sX = smem.allocate_tensor(
+            mX.element_type,
+            cute.make_ordered_layout(tiler_mn, order=(1, 0)),
+            byte_alignment=16,
+        )
+        reduction_buffer, mbar_ptr = self._allocate_reduction_buffer_and_mbar(
+            smem, tv_layout
+        )
+
+        copy_atom_load_X = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyG2SOp(), mX.element_type, num_bits_per_copy=128
+        )
+        thr_copy_X = cute.make_tiled_copy(
+            copy_atom_load_X, tv_layout, tiler_mn
+        ).get_slice(tidx)
+
+        tXgX = thr_copy_X.partition_S(gX)
+        tXsX = thr_copy_X.partition_D(sX)
+        tXcX = thr_copy_X.partition_S(cX)[(0, None), None, None]
+
+        tvlayout_cX = cute.composition(cX, tv_layout)
+        thr_coord = (tidx, (None, None))
+        thr_cX = tvlayout_cX[thr_coord]
+
+        tXrX = cute.make_fragment_like(tXgX)
+        num_warps = cute.size(tv_layout, mode=[0]) // cute.arch.WARP_SIZE
+        self._initialize_cluster(tidx, mbar_ptr, num_warps)
+
+        is_even_N = cutlass.const_expr(shape[1] == tiler_mn[1] * self.cluster_n)
+        tXpX = (
+            predicate_k(thr_copy_X.partition_S(cX), limit=shape[1])
+            if not is_even_N
+            else None
+        )
+
+        if tXcX[0][0] < shape[0]:
+            cute.copy(copy_atom_load_X, tXgX, tXsX, pred=tXpX)
+        cute.arch.cp_async_commit_group()
+        cute.arch.cp_async_wait_group(0)
+
+        if cutlass.const_expr(not is_even_N):
+            fill_oob(tXsX, tXpX, -tXsX.element_type.inf)
+
+        cute.autovec_copy(tXsX, tXrX)
+        x = tXrX.load().to(cute.Float32)
+
+        current_max = -tXsX.element_type.inf
+        current_argmax = Int32(0xFFFFFFFF)
+
+        for i in cutlass.range_constexpr(thr_cX.shape[0]):
+            for j in cutlass.range_constexpr(thr_cX.shape[1]):
+                col_idx = thr_cX[i, j][1]
+                linear_idx = i + j * thr_cX.shape[0]
+                element_value1 = x[linear_idx]
+                if element_value1 > current_max:
+                    current_max = element_value1
+                    current_argmax = Int32(col_idx)
+
+        lane_idx, warp_idx = cute.arch.lane_idx(), cute.arch.warp_idx()
+        if cutlass.const_expr(self.use_redux):
+            warp_max, warp_argmax = warp_argmax_redux(current_max, current_argmax)
+        else:
+            warp_max, warp_argmax = warp_reduce_argmax(current_max, current_argmax)
+
+        if cutlass.const_expr(self.cluster_n == 1):
+            warps_per_row = cute.size(reduction_buffer.shape[1])
+            row_idx, col_idx = warp_idx // warps_per_row, warp_idx % warps_per_row
+
+            if lane_idx == 0:
+                reduction_buffer[row_idx, col_idx, 0, 0] = warp_max
+                reduction_buffer[row_idx, col_idx, 0, 1] = warp_argmax.to(
+                    cutlass.Float32
+                )
+
+            cute.arch.barrier()
+            block_reduce_max = -tXsX.element_type.inf
+            block_reduce_argmax = Int32(0xFFFFFFFF)
+
+            if lane_idx < warps_per_row:
+                block_reduce_max = reduction_buffer[row_idx, lane_idx, 0, 0]
+                block_reduce_argmax = reduction_buffer[row_idx, lane_idx, 0, 1].to(
+                    cutlass.Int32
+                )
+
+            if cutlass.const_expr(self.use_redux):
+                warp_max, warp_argmax = warp_argmax_redux(
+                    block_reduce_max, block_reduce_argmax
+                )
+            else:
+                warp_max, warp_argmax = warp_reduce_argmax(
+                    block_reduce_max, block_reduce_argmax
+                )
+        else:
+            cute.arch.cluster_wait()
+            warps_per_row, cluster_n = reduction_buffer.shape[1]
+            cta_rank_in_cluster = cute.arch.block_idx_in_cluster()
+            rows_per_block, (warps_per_row, cluster_n), _, _ = reduction_buffer.shape
+            row_idx, col_idx = warp_idx // warps_per_row, warp_idx % warps_per_row
+
+            if warp_idx == 0:
+                with cute.arch.elect_one():
+                    num_warps = rows_per_block * warps_per_row
+                    cute.arch.mbarrier_arrive_and_expect_tx(
+                        mbar_ptr,
+                        num_warps
+                        * cluster_n
+                        * 2
+                        * reduction_buffer.element_type.width
+                        // 8,
+                    )
+
+            if lane_idx < cluster_n:
+                store_shared_remote(
+                    warp_max,
+                    elem_pointer(
+                        reduction_buffer,
+                        (row_idx, (col_idx, cta_rank_in_cluster), 0, 0),
+                    ),
+                    mbar_ptr,
+                    peer_cta_rank_in_cluster=lane_idx,
+                )
+                store_shared_remote(
+                    warp_argmax.to(cutlass.Float32),
+                    elem_pointer(
+                        reduction_buffer,
+                        (row_idx, (col_idx, cta_rank_in_cluster), 0, 1),
+                    ),
+                    mbar_ptr,
+                    peer_cta_rank_in_cluster=lane_idx,
+                )
+
+            cute.arch.mbarrier_wait(mbar_ptr, phase=0)
+            block_reduce_val = -tXsX.element_type.inf
+            block_reduce_argmax = Int32(0xFFFFFFFF)
+            num_iter = cute.ceil_div(warps_per_row * cluster_n, cute.arch.WARP_SIZE)
+
+            for i in cutlass.range_constexpr(num_iter):
+                idx = lane_idx + i * cute.arch.WARP_SIZE
+                if idx < cute.size(reduction_buffer, mode=[1]):
+                    element_max = reduction_buffer[row_idx, idx, 0, 0]
+                    element_argmax = reduction_buffer[row_idx, idx, 0, 1].to(
+                        cutlass.Int32
+                    )
+                    if element_max > block_reduce_val:
+                        block_reduce_val = element_max
+                        block_reduce_argmax = element_argmax
+
+            if cutlass.const_expr(self.use_redux):
+                warp_max, warp_argmax = warp_argmax_redux(
+                    block_reduce_val, block_reduce_argmax
+                )
+            else:
+                warp_max, warp_argmax = warp_reduce_argmax(
+                    block_reduce_val, block_reduce_argmax
+                )
+
+        row_idx = tXcX[0][0]
+        warps_per_row = tv_layout.shape[0][0] // cute.arch.WARP_SIZE
+        local_row_idx = row_idx - (bidx * tiler_mn[0])
+        first_warp_for_row = local_row_idx * warps_per_row
+        first_thread_for_row = first_warp_for_row * cute.arch.WARP_SIZE
+
+        if (
+            tidx == first_thread_for_row
+            and row_idx < shape[0]
+            and local_row_idx >= 0
+            and local_row_idx < tiler_mn[0]
+            and (self.cluster_n == 1 or bidy == 0)
+        ):
+            mO[local_row_idx, 0] = warp_max.to(mO.element_type)
+            mO[local_row_idx, 1] = warp_argmax.to(mO.element_type)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/argmax.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/argmax.py
@@ -257,20 +257,28 @@ def warp_argmax_redux(current_max: Float32, current_argmax: Int32):
 
 @cute.jit
 def warp_reduce_argmax(current_max: Float32, current_argmax: Int32):
-    """Shuffle-based warp argmax - works on all architectures (Hopper+)."""
+    """Shuffle-based warp argmax - works on all architectures (Hopper+).
+
+    Ties are broken to the lowest index, matching ``torch.argmax``. The redux
+    path (``warp_argmax_redux``) already does this via ``redux.sync.min.u32``;
+    this path used to keep whichever side the strict ``>`` happened to retain,
+    so the tie-break-to-lowest invariant could fail on Hopper. The extra
+    ``==`` arm makes the two paths agree on Hopper and Blackwell.
+    """
     warp_max = current_max
     warp_argmax = current_argmax
 
-    # Use butterfly shuffle pattern for warp reduction
+    # Butterfly shuffle reduction.
     for i in cutlass.range_constexpr(int(5)):  # log2(32) = 5 iterations
-        # Get values from other lanes using butterfly pattern
         other_max = cute.arch.shuffle_sync_bfly(warp_max, offset=1 << i)
         other_argmax = cute.arch.shuffle_sync_bfly(warp_argmax, offset=1 << i)
 
-        # Inline argmax comparison
         if other_max > warp_max:
             warp_max = other_max
             warp_argmax = other_argmax
+        elif other_max == warp_max:
+            if other_argmax < warp_argmax:
+                warp_argmax = other_argmax
 
     return warp_max, warp_argmax
 
@@ -624,9 +632,14 @@ class ArgmaxKernel(ReductionBase):
                     element_argmax = reduction_buffer[row_idx, idx, 0, 1].to(
                         cutlass.Int32
                     )
+                    # Tie-break to the lowest index so the cluster-side
+                    # reduction agrees with torch.argmax / the redux path.
                     if element_max > block_reduce_val:
                         block_reduce_val = element_max
                         block_reduce_argmax = element_argmax
+                    elif element_max == block_reduce_val:
+                        if element_argmax < block_reduce_argmax:
+                            block_reduce_argmax = element_argmax
 
             if cutlass.const_expr(self.use_redux):
                 warp_max, warp_argmax = warp_argmax_redux(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/argmax.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/argmax.py
@@ -429,13 +429,19 @@ class ArgmaxKernel(ReductionBase):
         )
 
     @cute.jit
-    def __call__(self, mX: cute.Tensor, mO: cute.Tensor, stream: cuda.CUstream):
+    def __call__(
+        self,
+        mX: cute.Tensor,
+        mO_max: cute.Tensor,
+        mO_idx: cute.Tensor,
+        stream: cuda.CUstream,
+    ):
         self._set_cluster_n()
         tiler_mn, tv_layout = self._get_tv_layout()
         num_threads = cute.size(tv_layout, mode=[0])
         num_warps = num_threads // cute.arch.WARP_SIZE
 
-        self.kernel(mX, mO, tv_layout, tiler_mn).launch(
+        self.kernel(mX, mO_max, mO_idx, tv_layout, tiler_mn).launch(
             grid=[cute.ceil_div(mX.shape[0], tiler_mn[0]), self.cluster_n, 1],
             block=[num_threads, 1, 1],
             cluster=(
@@ -451,7 +457,8 @@ class ArgmaxKernel(ReductionBase):
     def kernel(
         self,
         mX: cute.Tensor,
-        mO: cute.Tensor,
+        mO_max: cute.Tensor,
+        mO_idx: cute.Tensor,
         tv_layout: cute.Layout,
         tiler_mn: cute.Shape,
     ):
@@ -466,8 +473,11 @@ class ArgmaxKernel(ReductionBase):
         shape = mX.shape
         idX = cute.make_identity_tensor(shape)
 
-        mX, mO = [domain_offset_i64((bidx * tiler_mn[0], 0), mT) for mT in (mX, mO)]
-        gX, gO = [cute.local_tile(mT, tiler_mn, (0, cluster_y)) for mT in (mX, mO)]
+        mX = domain_offset_i64((bidx * tiler_mn[0], 0), mX)
+        gX = cute.local_tile(mX, tiler_mn, (0, cluster_y))
+        # Each output is 1D (M,); only a row-axis offset is needed.
+        mO_max = domain_offset_i64((bidx * tiler_mn[0],), mO_max)
+        mO_idx = domain_offset_i64((bidx * tiler_mn[0],), mO_idx)
         cX = cute.local_tile(idX, tiler_mn, (bidx, cluster_y))
 
         smem = cutlass.utils.SmemAllocator()
@@ -640,5 +650,5 @@ class ArgmaxKernel(ReductionBase):
             and local_row_idx < tiler_mn[0]
             and (self.cluster_n == 1 or bidy == 0)
         ):
-            mO[local_row_idx, 0] = warp_max.to(mO.element_type)
-            mO[local_row_idx, 1] = warp_argmax.to(mO.element_type)
+            mO_max[local_row_idx] = warp_max.to(mO_max.element_type)
+            mO_idx[local_row_idx] = warp_argmax.to(mO_idx.element_type)

--- a/tokenspeed-kernel/test/ops/test_sampling_cute_dsl.py
+++ b/tokenspeed-kernel/test/ops/test_sampling_cute_dsl.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Tests for the CuTe DSL argmax wrapper used by sampling/drafter code.
+"""Tests for the CuTe DSL argmax kernel wrapper.
 
 These exercise:
   * Parity with ``torch.argmax`` across vocab sizes used by real LLMs.
@@ -26,9 +26,8 @@ These exercise:
     (small N, unaligned N, fp16/bf16).
   * CUDA-graph capture/replay — the kernel must stay in-place under graph
     capture, since the sampling backends run under captured graphs.
-  * Drop-in compatibility from the runtime entrypoints used by the drafter
-    and sampling backends — verifies that the modules import successfully
-    with the cute_dsl integration in place.
+  * Pure-torch fallback path on non-NVIDIA hosts (AMD ROCm / CPU-only /
+    sm_80 / sm_120+ / missing nvidia-cutlass-dsl).
 """
 
 from __future__ import annotations
@@ -382,27 +381,138 @@ def test_argmax_under_cuda_graph(M, N):
     torch.testing.assert_close(out, ref, atol=0, rtol=0)
 
 
+@pytest.mark.parametrize("out_dtype", [torch.int32, torch.int64])
+def test_argmax_out_buffer_under_cuda_graph(out_dtype):
+    """``cute_argmax(x, out=buf)`` must be CUDA-graph-safe — this is the
+    pattern GreedySamplingBackend uses inside the captured sampling graph.
+
+    Caller provides a pre-allocated buffer (no graph-internal allocation of
+    the output tensor); the kernel writes int32 / int64 indices straight
+    into it. Replay must observe input mutations.
+    """
+    _need_cuda()
+    M, N = 16, MODEL_VOCABS["deepseek_v4"]
+    torch.manual_seed(M ^ N ^ 0xBEEF)
+    x = 0.1 * torch.randn(M, N, device="cuda", dtype=torch.float32)
+    buf = torch.empty(M, dtype=out_dtype, device="cuda")
+
+    # Warmup so cute DSL JIT compiles outside graph capture.
+    cute_argmax(x, out=buf)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        cute_argmax(x, out=buf)
+
+    new_x = 0.1 * torch.randn_like(x)
+    x.copy_(new_x)
+    graph.replay()
+    torch.cuda.synchronize()
+    ref = torch.argmax(x, dim=-1)
+    torch.testing.assert_close(buf.long(), ref, atol=0, rtol=0)
+
+
+def test_argmax_pair_under_cuda_graph():
+    """argmax_pair with caller-provided (M, 2) f32 buffer must work inside
+    a CUDA graph. The kernel splits its output into two scratch tensors
+    internally; we verify the assembly still survives capture/replay."""
+    _need_cuda()
+    M, N = 8, MODEL_VOCABS["qwen3_5"]
+    torch.manual_seed(0xABCD)
+    x = 0.1 * torch.randn(M, N, device="cuda", dtype=torch.float32)
+    pair = torch.empty((M, 2), dtype=torch.float32, device="cuda")
+
+    cute_argmax_pair(x, out=pair)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        cute_argmax_pair(x, out=pair)
+
+    new_x = 0.1 * torch.randn_like(x)
+    x.copy_(new_x)
+    graph.replay()
+    torch.cuda.synchronize()
+    ref_max, ref_idx = torch.max(x, dim=-1, keepdim=True)
+    torch.testing.assert_close(pair[:, 0:1], ref_max, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(pair[:, 1:2].long(), ref_idx, atol=0, rtol=0)
+
+
+def test_greedy_sample_pattern_under_cuda_graph():
+    """Verbatim of GreedySamplingBackend.sample's call pattern: caller holds a
+    pre-allocated int32 buffer sized for max_bs, slices it per request, and
+    captures the slice into the graph. Replay with new logits must produce
+    new tokens."""
+    _need_cuda()
+    max_bs, bs, N = 32, 16, MODEL_VOCABS["kimi_k2_5"]
+    torch.manual_seed(0xCAFE)
+    logits = 0.1 * torch.randn(bs, N, device="cuda", dtype=torch.float32)
+    sample_token_buf = torch.empty((max_bs,), dtype=torch.int32, device="cuda")
+
+    tokens = cute_argmax(logits, out=sample_token_buf[:bs])
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        tokens = cute_argmax(logits, out=sample_token_buf[:bs])
+
+    new_logits = 0.1 * torch.randn_like(logits)
+    logits.copy_(new_logits)
+    graph.replay()
+    torch.cuda.synchronize()
+    ref = torch.argmax(logits, dim=-1).to(torch.int32)
+    torch.testing.assert_close(tokens, ref, atol=0, rtol=0)
+    # Slice view must alias the underlying buffer.
+    torch.testing.assert_close(sample_token_buf[:bs], ref, atol=0, rtol=0)
+
+
 # ---------------------------------------------------------------------------
-# Integration smoke — the modules that now import cute_dsl must still load
+# Pure-torch fallback on hosts without the CuTe DSL kernel — exercises the
+# code path AMD ROCm / CPU-only / sm_80 / sm_120+ / missing-nvidia-cutlass-dsl
+# would take. Selected at import time via the module-level dispatch in
+# cute_dsl.py; we reach it here by calling the underscore-prefixed
+# implementation directly so the test runs regardless of the host hardware.
 # ---------------------------------------------------------------------------
 
 
-def test_eagle_imports_cute_argmax():
-    import importlib
-
-    mod = importlib.import_module("tokenspeed.runtime.execution.drafter.eagle")
-    assert mod.cute_argmax is cute_argmax
-
-
-def test_greedy_imports_cute_argmax():
-    import importlib
-
-    mod = importlib.import_module("tokenspeed.runtime.sampling.backends.greedy")
-    assert mod.cute_argmax is cute_argmax
+def test_argmax_torch_fallback_on_cpu_tensor():
+    """Pure-torch fallback must handle CPU input — non-CUDA hosts route here."""
+    x = torch.randn(8, 4096, dtype=torch.float32)
+    out = cute_dsl._argmax_torch_fallback(x)
+    torch.testing.assert_close(out, torch.argmax(x, dim=-1), atol=0, rtol=0)
+    assert out.dtype == torch.int64
 
 
-def test_flashinfer_imports_cute_argmax():
-    import importlib
+def test_argmax_torch_fallback_with_int32_out():
+    x = torch.randn(8, 4096, dtype=torch.float32)
+    out = torch.empty(8, dtype=torch.int32)
+    cute_dsl._argmax_torch_fallback(x, out=out)
+    torch.testing.assert_close(out.long(), torch.argmax(x, dim=-1), atol=0, rtol=0)
 
-    mod = importlib.import_module("tokenspeed.runtime.sampling.backends.flashinfer")
-    assert mod.cute_argmax is cute_argmax
+
+def test_argmax_pair_torch_fallback_on_cpu_tensor():
+    """argmax_pair fallback must handle CPU input — AMD/CPU hosts route here.
+
+    This case was a regression in an earlier version of the wrapper that
+    short-circuited on ``not logits.is_cuda``; AMD/CPU could not even reach
+    the fallback. Keep this test to guard against that regression.
+    """
+    x = torch.randn(4, 4096, dtype=torch.float32)
+    pair = cute_dsl._argmax_pair_torch_fallback(x)
+    assert pair.shape == (4, 2)
+    assert pair.dtype == torch.float32
+    ref_max, ref_idx = torch.max(x, dim=-1, keepdim=True)
+    torch.testing.assert_close(pair[:, 0:1], ref_max, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(pair[:, 1:2].long(), ref_idx, atol=0, rtol=0)
+
+
+def test_public_binding_dispatch_matches_arch():
+    """Public ``argmax`` / ``argmax_pair`` names are bound at import time:
+    NVIDIA hosts with cute available → cute fast path; everyone else → torch
+    fallback. This test pins that contract."""
+    if cute_dsl.is_available():
+        assert cute_dsl.argmax is cute_dsl._argmax_cute
+        assert cute_dsl.argmax_pair is cute_dsl._argmax_pair_cute
+    else:
+        assert cute_dsl.argmax is cute_dsl._argmax_torch_fallback
+        assert cute_dsl.argmax_pair is cute_dsl._argmax_pair_torch_fallback


### PR DESCRIPTION
## Summary

1) Integrate high-performance argmax implementation from TRT-LLM: https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/cute_dsl_kernels/argmax.py
2) Further optimize to avoid the cast kernel.

### Performance
### Kernel benchmark
Compared with pytorch argmax, B200
```
=== Performance sweep (avg µs/call) ===
    M |        N | torch.argmax | cute argmax |  speedup
----------------------------------------------------------------
    1 |   129280 |      25.95µs |      3.93µs |    6.60x
    2 |   129280 |      25.94µs |      4.12µs |    6.30x
    4 |   129280 |      26.16µs |      4.11µs |    6.36x
    8 |   129280 |      26.15µs |      4.15µs |    6.31x
   16 |   129280 |      26.05µs |      4.17µs |    6.25x
   32 |   129280 |      25.61µs |      4.47µs |    5.74x
   64 |   129280 |      25.82µs |      7.46µs |    3.46x
  128 |   129280 |      26.09µs |     13.39µs |    1.95x
    1 |   151936 |      10.36µs |      3.23µs |    3.21x
    2 |   151936 |      10.92µs |      3.15µs |    3.47x
    4 |   151936 |      11.15µs |      3.18µs |    3.51x
    8 |   151936 |      12.11µs |      3.19µs |    3.79x
   16 |   151936 |      14.39µs |      3.92µs |    3.67x
   32 |   151936 |      16.74µs |      4.38µs |    3.82x
   64 |   151936 |      21.51µs |      7.50µs |    2.87x
  128 |   151936 |      30.77µs |     13.31µs |    2.31x
    1 |   163840 |      10.39µs |      3.00µs |    3.46x
    2 |   163840 |      10.93µs |      3.00µs |    3.64x
    4 |   163840 |      11.25µs |      3.00µs |    3.75x
    8 |   163840 |      12.35µs |      2.93µs |    4.22x
   16 |   163840 |      14.40µs |      4.04µs |    3.56x
   32 |   163840 |      18.36µs |      4.35µs |    4.22x
   64 |   163840 |      22.54µs |      7.23µs |    3.12x
  128 |   163840 |      32.87µs |     13.01µs |    2.53x
    1 |   200064 |      10.38µs |      3.68µs |    2.82x
    2 |   200064 |      10.96µs |      3.70µs |    2.96x
    4 |   200064 |      11.20µs |      3.68µs |    3.04x
    8 |   200064 |      12.36µs |      3.73µs |    3.32x
   16 |   200064 |      14.39µs |      5.16µs |    2.79x
   32 |   200064 |      18.53µs |      5.46µs |    3.39x
   64 |   200064 |      24.33µs |      9.71µs |    2.51x
  128 |   200064 |      42.98µs |     25.98µs |    1.65x
    1 |   201088 |      10.32µs |      3.70µs |    2.79x
    2 |   201088 |      10.97µs |      3.67µs |    2.99x
    4 |   201088 |      11.19µs |      3.65µs |    3.06x
    8 |   201088 |      12.33µs |      3.70µs |    3.33x
   16 |   201088 |      14.39µs |      5.14µs |    2.80x
   32 |   201088 |      18.53µs |      5.46µs |    3.40x
   64 |   201088 |      24.42µs |      9.73µs |    2.51x
  128 |   201088 |      42.13µs |     25.79µs |    1.63x
----------------------------------------------------------------
  Average over 40 (M,N) combinations: geomean = 3.38x, mean = 3.58x, min = 1.63x, max = 6.60x
```

### End2end timeline comparison
- before
<img width="1045" height="176" alt="image" src="https://github.com/user-attachments/assets/3eb32499-0a20-4f96-b020-d2629d8623c6" />

- after
<img width="1041" height="152" alt="image" src="https://github.com/user-attachments/assets/1ee8fc7f-2d24-43a3-9fcb-a5f212aa54b0" />




## Test Plan

```
/usr/bin/python3 -m pytest test/runtime/test_cute_dsl_argmax.py -v
```
