### PR TITLE
fix(deepseek-v4): refine cache sizing and shared expert comm

### DIFF
--- a/python/tokenspeed/runtime/configs/paged_cache_spec.py
+++ b/python/tokenspeed/runtime/configs/paged_cache_spec.py
@@ -84,10 +84,16 @@ def compute_paged_cache_group_page_counts(
                     f"PagedCacheGroupSpec {spec.group_id}: sliding group missing "
                     "positive sliding_window_tokens"
                 )
-            per_req_tokens = min(window - 1 + max_scheduled_tokens, max_context_len)
-            per_req_pages = ceil_div(per_req_tokens, raw_per_page) + 1
+            resident_tokens_per_req = min(max(window - 1, 0), max_context_len)
+            resident_pages = max_live_requests * ceil_div(
+                resident_tokens_per_req, raw_per_page
+            )
+            scheduled_tokens = min(max_scheduled_tokens, max_total_tokens)
+            scheduled_pages = ceil_div(scheduled_tokens, raw_per_page)
             total = (
-                max_live_requests * per_req_pages
+                resident_pages
+                + scheduled_pages
+                + max_live_requests
                 + _PAGED_CACHE_GROUP_DUMMY_PAGES
                 + safety_margin
             )

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
@@ -14,7 +14,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from fractions import Fraction
+from typing import Any, Sequence
 
 import numpy as np
 import torch
@@ -34,6 +35,7 @@ from tokenspeed.runtime.configs.deepseek_v4_cache_spec import (
     v4_compressor_state_group_id,
 )
 from tokenspeed.runtime.configs.paged_cache_spec import (
+    PagedCacheGroupSpec,
     compute_paged_cache_group_page_counts,
 )
 from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (
@@ -41,6 +43,7 @@ from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (
 )
 from tokenspeed.runtime.layers.attention.kv_cache.base import BaseTokenToKVPool
 from tokenspeed.runtime.utils import get_colorful_logger
+from tokenspeed.runtime.utils.common import ceil_div
 
 logger = get_colorful_logger(__name__)
 
@@ -133,6 +136,59 @@ class DeepseekV4CacheLayout:
         return cell_size
 
 
+def _deepseek_v4_cache_group_page_bytes(
+    layout: DeepseekV4CacheLayout,
+    specs: Sequence[PagedCacheGroupSpec],
+    layer_num: int,
+) -> dict[str, int]:
+    if layer_num > len(layout.layer_ratio):
+        raise ValueError(
+            "DeepSeek V4 cache layout has fewer layer ratios "
+            f"({len(layout.layer_ratio)}) than requested layers ({layer_num})"
+        )
+
+    group_rows = {spec.group_id: int(spec.rows_per_page) for spec in specs}
+    page_bytes = {spec.group_id: 0 for spec in specs}
+    fp32_size = torch._utils._element_size(torch.float32)
+
+    swa_block_bytes = layout.swa_block_bytes(
+        group_rows.get(V4_SWA_KV_GROUP_ID, V4_KERNEL_BLOCK_ROWS)
+    )
+    for layer_id, ratio in enumerate(layout.layer_ratio[:layer_num]):
+        page_bytes[V4_SWA_KV_GROUP_ID] += swa_block_bytes
+        if ratio <= 1:
+            continue
+
+        compressed_group_id = v4_compressed_kv_group_id(ratio)
+        compressed_block_size = layout.storage_block_size(ratio)
+        page_bytes[compressed_group_id] += layout.swa_block_bytes(compressed_block_size)
+
+        state_group_id = v4_compressor_state_group_id(ratio)
+        state_block_size = group_rows.get(state_group_id, layout.page_size)
+        page_bytes[state_group_id] += (
+            state_block_size * layout.state_width(layer_id) * 2 * fp32_size
+        )
+
+        if ratio == 4:
+            indexer_block_size = max(V4_KERNEL_BLOCK_ROWS, compressed_block_size)
+            page_bytes[compressed_group_id] += (
+                indexer_block_size * layout.indexer_row_bytes
+            )
+
+            indexer_state_block_size = group_rows.get(
+                V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
+                layout.compressor_state_block_size(ratio),
+            )
+            page_bytes[V4_INDEXER_COMPRESSOR_STATE_GROUP_ID] += (
+                indexer_state_block_size
+                * layout.state_width(layer_id, indexer=True)
+                * 2
+                * fp32_size
+            )
+
+    return page_bytes
+
+
 def _estimate_deepseek_v4_cache_bytes(
     *,
     layout: DeepseekV4CacheLayout,
@@ -153,6 +209,7 @@ def _estimate_deepseek_v4_cache_bytes(
         raise ValueError(f"max_total_tokens must be >= 0, got {max_total_tokens}")
 
     specs = tuple(build_v4_cache_specs(hf_config, layer_ratio=layout.layer_ratio))
+    page_bytes = _deepseek_v4_cache_group_page_bytes(layout, specs, layer_num)
     counts = compute_paged_cache_group_page_counts(
         specs,
         max_live_requests=max_live_requests,
@@ -160,54 +217,12 @@ def _estimate_deepseek_v4_cache_bytes(
         max_total_tokens=max_total_tokens,
         max_context_len=max_context_len,
     )
-    group_rows = {spec.group_id: int(spec.rows_per_page) for spec in specs}
-
-    fp32_size = torch._utils._element_size(torch.float32)
-    total = 0
-    swa_pages = int(counts[V4_SWA_KV_GROUP_ID])
-    swa_block_bytes = layout.swa_block_bytes(
-        group_rows.get(V4_SWA_KV_GROUP_ID, V4_KERNEL_BLOCK_ROWS)
+    return int(
+        sum(
+            int(counts[gid]) * bytes_per_page
+            for gid, bytes_per_page in page_bytes.items()
+        )
     )
-
-    for layer_id, ratio in enumerate(layout.layer_ratio[:layer_num]):
-        total += swa_pages * swa_block_bytes
-        if ratio <= 1:
-            continue
-
-        compressed_pages = int(counts[v4_compressed_kv_group_id(ratio)])
-        compressed_block_size = layout.storage_block_size(ratio)
-        total += compressed_pages * layout.swa_block_bytes(compressed_block_size)
-
-        state_pages = int(counts[v4_compressor_state_group_id(ratio)])
-        state_block_size = group_rows.get(
-            v4_compressor_state_group_id(ratio), layout.page_size
-        )
-        total += (
-            state_pages
-            * state_block_size
-            * layout.state_width(layer_id)
-            * 2
-            * fp32_size
-        )
-
-        if ratio == 4:
-            indexer_block_size = max(V4_KERNEL_BLOCK_ROWS, compressed_block_size)
-            total += compressed_pages * indexer_block_size * layout.indexer_row_bytes
-
-            indexer_state_pages = int(counts[V4_INDEXER_COMPRESSOR_STATE_GROUP_ID])
-            indexer_state_block_size = group_rows.get(
-                V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
-                layout.compressor_state_block_size(ratio),
-            )
-            total += (
-                indexer_state_pages
-                * indexer_state_block_size
-                * layout.state_width(layer_id, indexer=True)
-                * 2
-                * fp32_size
-            )
-
-    return int(total)
 
 
 def profile_deepseek_v4_max_num_pages(
@@ -232,20 +247,27 @@ def profile_deepseek_v4_max_num_pages(
             f"draft_cache_cell_size must be >= 0, got {draft_cache_cell_size}"
         )
 
+    draft_cache_cell_size = int(draft_cache_cell_size)
+    max_live_requests = int(max_live_requests)
+    max_scheduled_tokens = max(0, int(max_scheduled_tokens))
+    max_context_len = int(max_context_len)
+    specs = tuple(build_v4_cache_specs(hf_config, layer_ratio=layout.layer_ratio))
+    page_bytes = _deepseek_v4_cache_group_page_bytes(layout, specs, layer_num)
+
     def _bytes_for_pages(num_pages: int) -> int:
         num_tokens = int(num_pages) * page_size
-        return (
-            _estimate_deepseek_v4_cache_bytes(
-                layout=layout,
-                hf_config=hf_config,
-                layer_num=layer_num,
-                max_total_tokens=num_tokens,
-                max_live_requests=max_live_requests,
-                max_scheduled_tokens=max_scheduled_tokens,
-                max_context_len=max_context_len,
-            )
-            + num_tokens * draft_cache_cell_size
+        counts = compute_paged_cache_group_page_counts(
+            specs,
+            max_live_requests=max_live_requests,
+            max_scheduled_tokens=max_scheduled_tokens,
+            max_total_tokens=num_tokens,
+            max_context_len=max_context_len,
         )
+        cache_bytes = sum(
+            int(counts[gid]) * bytes_per_page
+            for gid, bytes_per_page in page_bytes.items()
+        )
+        return int(cache_bytes + num_tokens * draft_cache_cell_size)
 
     if _bytes_for_pages(1) > available_cache_memory_bytes:
         return 0
@@ -256,17 +278,66 @@ def profile_deepseek_v4_max_num_pages(
             (int(max_live_requests) * int(max_context_len) + page_size - 1)
             // page_size,
         )
-    high = 1
-    while _bytes_for_pages(high) <= available_cache_memory_bytes:
-        high *= 2
-    low = high // 2
-    while low + 1 < high:
-        mid = (low + high) // 2
-        if _bytes_for_pages(mid) <= available_cache_memory_bytes:
-            low = mid
-        else:
-            high = mid
-    return int(low)
+
+    # Fixed bytes cover resident sliding windows, request fragments, and dummy
+    # pages. Variable bytes are piecewise linear before and after the global
+    # scheduled-token write budget is capped.
+    fixed_counts = compute_paged_cache_group_page_counts(
+        specs,
+        max_live_requests=max_live_requests,
+        max_scheduled_tokens=max_scheduled_tokens,
+        max_total_tokens=0,
+        max_context_len=max_context_len,
+    )
+    fixed_bytes = sum(
+        int(fixed_counts[gid]) * bytes_per_page
+        for gid, bytes_per_page in page_bytes.items()
+    )
+    full_history_slope = Fraction(page_size * draft_cache_cell_size, 1)
+    scheduled_slope = Fraction(0, 1)
+    scheduled_cap_bytes = 0
+    for spec in specs:
+        bytes_per_page = page_bytes[spec.group_id]
+        if bytes_per_page == 0:
+            continue
+        raw_per_page = int(spec.rows_per_page) * int(spec.entry_stride_tokens)
+        if spec.retention == "full_history":
+            full_history_slope += Fraction(page_size * bytes_per_page, raw_per_page)
+        elif spec.retention == "sliding_window":
+            scheduled_slope += Fraction(page_size * bytes_per_page, raw_per_page)
+            scheduled_cap_bytes += (
+                ceil_div(max_scheduled_tokens, raw_per_page) * bytes_per_page
+            )
+
+    def _pages_from_budget(extra_bytes: int, slope: Fraction) -> int:
+        if extra_bytes <= 0 or slope <= 0:
+            return 0
+        return int(extra_bytes * slope.denominator // slope.numerator)
+
+    cap_pages = ceil_div(max_scheduled_tokens, page_size)
+    candidate = 0
+    pre_cap_slope = full_history_slope + scheduled_slope
+    if cap_pages > 0:
+        pre_cap_pages = _pages_from_budget(
+            available_cache_memory_bytes - fixed_bytes,
+            pre_cap_slope,
+        )
+        candidate = min(pre_cap_pages, cap_pages - 1)
+
+    post_cap_fixed_bytes = fixed_bytes + scheduled_cap_bytes
+    post_cap_pages = _pages_from_budget(
+        available_cache_memory_bytes - post_cap_fixed_bytes,
+        full_history_slope,
+    )
+    if post_cap_pages >= cap_pages:
+        candidate = max(candidate, post_cap_pages)
+    candidate = max(1, candidate)
+
+    while candidate > 0 and _bytes_for_pages(candidate) > available_cache_memory_bytes:
+        candidate -= 1
+    while _bytes_for_pages(candidate + 1) <= available_cache_memory_bytes:
+        candidate += 1
+    return int(candidate)
 
 
 def _split_paged_cache_block_tables_into_v4_metadata(

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -82,11 +82,7 @@ from tokenspeed.runtime.configs.deepseek_v4_cache_spec import (
 )
 from tokenspeed.runtime.distributed import Mapping
 from tokenspeed.runtime.distributed.comm_manager import CommManager
-from tokenspeed.runtime.distributed.comm_ops import (
-    all_reduce,
-    token_all_gather,
-    token_reduce_scatter,
-)
+from tokenspeed.runtime.distributed.comm_ops import all_reduce
 from tokenspeed.runtime.distributed.process_group_manager import (
     process_group_manager as pg_manager,
 )
@@ -3388,22 +3384,29 @@ class DeepseekV4MoE(nn.Module):
         return StandardTopKOutput(topk_weights, topk_ids, router_scores)
 
     def _forward_shared_experts(
-        self, hidden_states: torch.Tensor | None
+        self,
+        hidden_states: torch.Tensor,
+        ctx: ForwardContext | None = None,
+        comm_manager: CommManager | None = None,
     ) -> torch.Tensor | None:
-        if (
-            self.n_shared_experts is None
-            or hidden_states is None
-            or hidden_states.shape[0] == 0
-        ):
+        if self.shared_experts is None:
+            return None
+        if comm_manager is not None:
+            hidden_states = comm_manager.pre_dense_comm(hidden_states, ctx)
+        if hidden_states.shape[0] == 0:
             return None
         with nvtx_range("moe_shared_experts"):
-            return self.shared_experts(hidden_states)
+            shared = self.shared_experts(hidden_states)
+        if comm_manager is not None:
+            shared, _ = comm_manager.post_dense_comm(shared, None, ctx)
+        return shared
 
     def forward_mega_moe(
         self,
         hidden_states: torch.Tensor,
         input_ids: torch.Tensor,
-        shared_scattered_num_tokens: list[int] | None,
+        ctx: ForwardContext,
+        comm_manager: CommManager,
     ) -> torch.Tensor:
         if hidden_states.shape[0] == 0:
             topk_weights = hidden_states.new_empty(
@@ -3420,35 +3423,6 @@ class DeepseekV4MoE(nn.Module):
                     hidden_states, input_ids
                 )
 
-        shared_input = None
-        shared_token_counts = None
-        if self.n_shared_experts is not None:
-            if self.shared_experts.tp_size > 1:
-                if shared_scattered_num_tokens is None:
-                    raise ValueError(
-                        "DeepSeek V4 shared expert dense TP requires token counts."
-                    )
-                shared_token_counts = [
-                    int(count) for count in shared_scattered_num_tokens
-                ]
-                if len(shared_token_counts) != self.shared_experts.tp_size:
-                    raise ValueError(
-                        "DeepSeek V4 shared expert token count length must match "
-                        "the dense TP size."
-                    )
-                if sum(shared_token_counts) > 0:
-                    with nvtx_range("moe_shared_all_gather"):
-                        shared_input = token_all_gather(
-                            hidden_states,
-                            rank=self.shared_experts.tp_rank,
-                            group=self.shared_experts.tp_group,
-                            scattered_num_tokens=shared_token_counts,
-                        )
-                else:
-                    shared_token_counts = None
-            else:
-                shared_input = hidden_states
-
         shared = None
         with self.stream_fork.scope(enable=get_is_capture_mode()) as fork:
             with nvtx_range("moe_mega_experts"):
@@ -3463,15 +3437,10 @@ class DeepseekV4MoE(nn.Module):
                     activation_clamp=getattr(self.config, "swiglu_limit", None),
                 )
             with fork.branch():
-                shared = self._forward_shared_experts(shared_input)
-
-        if shared is not None and shared_token_counts is not None:
-            with nvtx_range("moe_shared_reduce_scatter"):
-                shared = token_reduce_scatter(
-                    shared,
-                    rank=self.shared_experts.tp_rank,
-                    group=self.shared_experts.tp_group,
-                    scattered_num_tokens=shared_token_counts,
+                shared = self._forward_shared_experts(
+                    hidden_states,
+                    ctx=ctx,
+                    comm_manager=comm_manager,
                 )
         return routed + shared if shared is not None else routed
 
@@ -3513,11 +3482,15 @@ class DeepseekV4MoE(nn.Module):
         input_ids: torch.Tensor,
         num_global_tokens: int,
         max_num_tokens_per_gpu: int,
-        shared_scattered_num_tokens: list[int] | None = None,
+        ctx: ForwardContext | None = None,
+        comm_manager: CommManager | None = None,
     ) -> torch.Tensor:
         if self.use_mega_moe:
             return self.forward_mega_moe(
-                hidden_states, input_ids, shared_scattered_num_tokens
+                hidden_states,
+                input_ids,
+                ctx,
+                comm_manager,
             )
         return self.forward_normal(
             hidden_states, input_ids, num_global_tokens, max_num_tokens_per_gpu
@@ -5444,18 +5417,10 @@ class DeepseekV4DecoderLayer(nn.Module):
             hidden_states = self.ffn_norm(hidden_states)
         ffn_input_ids = input_ids
         use_mega_moe = getattr(self.ffn, "use_mega_moe", False)
-        shared_scattered_num_tokens = None
         if use_mega_moe:
             token_counts = self.comm_manager.moe_tp_ep_group_scattered_num_tokens(ctx)
             num_global_tokens = sum(token_counts)
             max_num_tokens_per_gpu = max(token_counts) if token_counts else 0
-            if (
-                self.ffn.shared_experts is not None
-                and self.ffn.shared_experts.tp_size > 1
-            ):
-                shared_scattered_num_tokens = (
-                    self.comm_manager.dense_tp_group_scattered_num_tokens(ctx)
-                )
         else:
             token_counts = None
             with nvtx_range("pre_mlp_comm"):
@@ -5473,7 +5438,8 @@ class DeepseekV4DecoderLayer(nn.Module):
                 ffn_input_ids,
                 num_global_tokens,
                 max_num_tokens_per_gpu,
-                shared_scattered_num_tokens=shared_scattered_num_tokens,
+                ctx=ctx if use_mega_moe else None,
+                comm_manager=self.comm_manager if use_mega_moe else None,
             )
         if not use_mega_moe:
             with nvtx_range("post_mlp_comm"):

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -324,34 +324,36 @@ class TestDeepseekV4Config(unittest.TestCase):
         moe = self._make_fake_mega_deepseek_v4_moe(
             hidden_states, input_ids, SharedExperts(), calls
         )
+        ctx = object()
 
-        with (
-            patch.object(
-                deepseek_v4_model,
-                "token_all_gather",
-                side_effect=AssertionError("shared expert should not use MoE RSAG"),
-            ),
-            patch.object(
-                deepseek_v4_model,
-                "token_reduce_scatter",
-                side_effect=AssertionError("shared expert should not use MoE RSAG"),
-            ),
-        ):
-            actual = DeepseekV4MoE.forward(
-                moe,
-                hidden_states,
-                input_ids,
-                num_global_tokens=2,
-                max_num_tokens_per_gpu=2,
-            )
+        class FakeCommManager:
+            def pre_dense_comm(self, states, actual_ctx):
+                test_case.assertIs(actual_ctx, ctx)
+                return states
+
+            def post_dense_comm(self, states, residual, actual_ctx):
+                test_case.assertIs(actual_ctx, ctx)
+                return states, residual
+
+        actual = DeepseekV4MoE.forward(
+            moe,
+            hidden_states,
+            input_ids,
+            num_global_tokens=2,
+            max_num_tokens_per_gpu=2,
+            ctx=ctx,
+            comm_manager=FakeCommManager(),
+        )
 
         self.assertEqual(calls, ["select", "routed", "shared"])
         self.assertTrue(torch.equal(actual, hidden_states + 1 + hidden_states + 3))
 
-    def test_deepseek_v4_mega_moe_shared_rsag_uses_dense_tp_group(self):
+    def test_deepseek_v4_mega_moe_shared_uses_comm_manager(self):
         calls = []
         hidden_states = torch.ones(2, 3)
         input_ids = torch.arange(2)
+        ctx = object()
+        test_case = self
 
         class SharedExperts:
             tp_rank = 1
@@ -360,6 +362,7 @@ class TestDeepseekV4Config(unittest.TestCase):
 
             def __call__(self, states):
                 calls.append("shared")
+                test_case.assertTrue(torch.equal(states, hidden_states + 2))
                 return states + 3
 
         moe = self._make_fake_mega_deepseek_v4_moe(
@@ -367,41 +370,32 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
         comm_calls = []
 
-        def fake_all_gather(states, *, rank, group, scattered_num_tokens):
-            comm_calls.append(("all_gather", rank, group, scattered_num_tokens))
-            return states
+        class FakeCommManager:
+            def pre_dense_comm(self, states, actual_ctx):
+                comm_calls.append(("pre", actual_ctx))
+                test_case.assertIs(actual_ctx, ctx)
+                test_case.assertIs(states, hidden_states)
+                return states + 2
 
-        def fake_reduce_scatter(states, *, rank, group, scattered_num_tokens):
-            comm_calls.append(("reduce_scatter", rank, group, scattered_num_tokens))
-            return states
+            def post_dense_comm(self, states, residual, actual_ctx):
+                comm_calls.append(("post", actual_ctx))
+                test_case.assertIsNone(residual)
+                test_case.assertIs(actual_ctx, ctx)
+                test_case.assertTrue(torch.equal(states, hidden_states + 5))
+                return states - 2, residual
 
-        with (
-            patch.object(
-                deepseek_v4_model, "token_all_gather", side_effect=fake_all_gather
-            ),
-            patch.object(
-                deepseek_v4_model,
-                "token_reduce_scatter",
-                side_effect=fake_reduce_scatter,
-            ),
-        ):
-            actual = DeepseekV4MoE.forward(
-                moe,
-                hidden_states,
-                input_ids,
-                num_global_tokens=2,
-                max_num_tokens_per_gpu=2,
-                shared_scattered_num_tokens=[1, 1],
-            )
+        actual = DeepseekV4MoE.forward(
+            moe,
+            hidden_states,
+            input_ids,
+            num_global_tokens=2,
+            max_num_tokens_per_gpu=2,
+            ctx=ctx,
+            comm_manager=FakeCommManager(),
+        )
 
         self.assertEqual(calls, ["select", "routed", "shared"])
-        self.assertEqual(
-            comm_calls,
-            [
-                ("all_gather", 1, (2, 3), [1, 1]),
-                ("reduce_scatter", 1, (2, 3), [1, 1]),
-            ],
-        )
+        self.assertEqual(comm_calls, [("pre", ctx), ("post", ctx)])
         self.assertTrue(torch.equal(actual, hidden_states + 1 + hidden_states + 3))
 
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")

--- a/test/runtime/test_v4_sliding_window_groups_smoke.py
+++ b/test/runtime/test_v4_sliding_window_groups_smoke.py
@@ -48,9 +48,38 @@ _v4 = _load(
 
 build_v4_cache_specs = _v4.build_v4_cache_specs
 compute_paged_cache_group_page_counts = _generic.compute_paged_cache_group_page_counts
+PagedCacheGroupSpec = _generic.PagedCacheGroupSpec
 
 
 class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
+    def test_sliding_window_scheduled_tokens_are_global_and_capped(self):
+        specs = [
+            PagedCacheGroupSpec(
+                group_id="sliding",
+                retention="sliding_window",
+                rows_per_page=4,
+                entry_stride_tokens=1,
+                sliding_window_tokens=8,
+            )
+        ]
+
+        counts = compute_paged_cache_group_page_counts(
+            specs,
+            max_live_requests=10,
+            max_scheduled_tokens=100,
+            max_total_tokens=20,
+            max_context_len=4096,
+        )
+
+        resident_pages = 10 * math.ceil(7 / 4)
+        scheduled_pages = math.ceil(20 / 4)
+        request_fragment_pages = 10
+        dummy_pages = 1
+        self.assertEqual(
+            counts["sliding"],
+            resident_pages + scheduled_pages + request_fragment_pages + dummy_pages,
+        )
+
     def test_page_counts_positive_finite_and_under_total_times_live(self):
         inputs = dict(
             max_live_requests=32,
@@ -80,6 +109,7 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
         hf_config = SimpleNamespace(
             compress_ratios=(1, 4, 128),
             head_dim=512,
+            qk_rope_head_dim=64,
             index_head_dim=128,
             sliding_window=128,
         )
@@ -124,6 +154,7 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
         hf_config = SimpleNamespace(
             compress_ratios=(1, 4, 128),
             head_dim=512,
+            qk_rope_head_dim=64,
             index_head_dim=128,
             sliding_window=128,
         )
@@ -182,6 +213,38 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
 
         legacy_pages = current_bytes // (layout.cache_cell_size(3) * layout.page_size)
         self.assertLess(legacy_pages, target_pages)
+
+    def test_deepseek_v4_profile_does_not_multiply_scheduled_tokens_by_requests(self):
+        from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
+            deepseek_v4_cache_layout_from_config,
+            profile_deepseek_v4_max_num_pages,
+        )
+
+        hf_config = SimpleNamespace(
+            compress_ratios=tuple([1, 1] + [4, 128] * 20 + [4, 1]),
+            head_dim=512,
+            qk_rope_head_dim=64,
+            index_head_dim=128,
+            sliding_window=128,
+        )
+        layout = deepseek_v4_cache_layout_from_config(
+            hf_config,
+            page_size=256,
+            use_fp4_indexer_cache=True,
+        )
+
+        self.assertGreater(
+            profile_deepseek_v4_max_num_pages(
+                layout=layout,
+                hf_config=hf_config,
+                layer_num=43,
+                max_live_requests=160,
+                max_scheduled_tokens=8192,
+                max_context_len=4096,
+                available_cache_memory_bytes=80 * (1 << 30),
+            ),
+            0,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fix DeepSeek V4 grouped cache sizing by separating resident sliding-window pages from the global scheduled-token write budget.
- Reuse `CommManager` dense communication for MegaMoE shared experts instead of local shared-expert collectives.
- Add regression coverage for sliding-window group page counts, V4 cache profiling, and shared-expert communication.

## Validation
- `git diff --check origin/main...HEAD`
- `FLASHINFER_DISABLE_VERSION_CHECK=1 python3 -m pytest test/runtime/test_v4_sliding_window_groups_smoke.py test/runtime/test_deepseek_v4_config.py::TestDeepseekV4Config::test_deepseek_v4_mega_moe_dense_tp_one_skips_shared_rsag test/runtime/test_deepseek_v4_config.py::TestDeepseekV4Config::test_deepseek_v4_mega_moe_shared_uses_comm_manager test/runtime/test_deepseek_v4_config.py::TestDeepseekV4Config::test_deepseek_v4_moe_stream_fork_fallback_order` (`8 passed`)
- DeepSeek V4 GSM8K 5-shot, limit 50, attention TP2 / dense TP1 / EP2: `exact_match=0.96 ± 0.028` for both strict and flexible extraction.