### PR TITLE
feat(kernel): add quantization kernel api

### DIFF
--- a/python/tokenspeed/runtime/layers/dense/unquant.py
+++ b/python/tokenspeed/runtime/layers/dense/unquant.py
@@ -66,5 +66,4 @@ class UnquantizedLinearMethod(LinearMethodBase):
             x,
             layer.weight,
             bias=bias,
-            expected_kernel_name="torch_mm",
         )

--- a/python/tokenspeed/runtime/layers/moe/backends/mxfp4/triton_kernel.py
+++ b/python/tokenspeed/runtime/layers/moe/backends/mxfp4/triton_kernel.py
@@ -42,14 +42,6 @@ _is_hopper = current_platform().is_hopper
 _is_amd = current_platform().is_amd
 
 
-def _quantize_to_fp8(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
-    fp8 = current_platform().fp8e4m3fn
-    inv_scale = (1.0 / scale.to(torch.float32)).reshape(())
-    return (
-        (x.to(torch.float32) * inv_scale).clamp_(min=fp8.min, max=fp8.max).to(fp8.dtype)
-    )
-
-
 def swizzle_mxfp4(quant_tensor, scale, num_warps):
     """Weight swizzle for mxfp4 MoE, used for OAI mxfp4 kernel."""
     from tokenspeed_kernel.ops.moe.triton_kernels import (
@@ -290,7 +282,11 @@ class Mxfp4TritonKernelBackend(MoEBackend):
         )
 
         if self._is_w4a8_fp8:
-            gemm1_input = _quantize_to_fp8(hidden_states, layer.w13_act_scale)
+            gemm1_input = tokenspeed_kernel.quantize_fp8(
+                hidden_states,
+                scale=layer.w13_act_scale,
+                solution="triton",
+            )
         else:
             gemm1_input = hidden_states
 
@@ -310,7 +306,11 @@ class Mxfp4TritonKernelBackend(MoEBackend):
         )
 
         if self._is_w4a8_fp8:
-            gemm2_input = _quantize_to_fp8(intermediate_cache, layer.w2_act_scale)
+            gemm2_input = tokenspeed_kernel.quantize_fp8(
+                intermediate_cache,
+                scale=layer.w2_act_scale,
+                solution="triton",
+            )
         else:
             gemm2_input = intermediate_cache
 

--- a/python/tokenspeed/runtime/layers/moe/backends/mxfp4/triton_kernel.py
+++ b/python/tokenspeed/runtime/layers/moe/backends/mxfp4/triton_kernel.py
@@ -37,7 +37,6 @@ from tokenspeed.runtime.layers.moe.topk import TopKOutputFormat
 from tokenspeed.runtime.layers.quantization import Mxfp4Config
 from tokenspeed.runtime.layers.quantization.utils import should_ignore_quant_layer
 
-_is_nvidia = current_platform().is_nvidia
 _is_blackwell = current_platform().is_blackwell
 _is_hopper = current_platform().is_hopper
 _is_amd = current_platform().is_amd

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -36,8 +36,8 @@ from tokenspeed_kernel.ops.gemm.nvfp4_gemm_swiglu_nvfp4_quant import (
 )
 from tokenspeed_kernel.ops.gemm.trtllm import dsv3_fused_a_gemm
 from tokenspeed_kernel.ops.moe.cuda import moe_finalize_fuse_shared
-from tokenspeed_kernel.ops.quantization import fp8_quantize
 from tokenspeed_kernel.ops.quantization.flashinfer import fp4_quantize
+from tokenspeed_kernel.ops.quantization.triton import fp8_quantize
 from tokenspeed_kernel.ops.routing.cuda import dsv3_router_gemm
 from tokenspeed_kernel.platform import current_platform
 from tokenspeed_kernel.thirdparty.cuda.merge_state import merge_state

--- a/tokenspeed-kernel/python/tokenspeed_kernel/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/__init__.py
@@ -37,17 +37,33 @@ from tokenspeed_kernel.ops.moe import (
     moe_fused,
     moe_route,
 )
+from tokenspeed_kernel.ops.quantization import (
+    quantize_fp8,
+    quantize_fp8_with_scale,
+    quantize_mxfp4,
+    quantize_mxfp8,
+    quantize_nvfp4,
+)
 
 __all__ = [
+    # gemm
     "mm",
+    # moe
     "moe_route",
     "moe_dispatch",
     "moe_experts",
     "moe_combine",
     "moe_fused",
+    # attention
     "mha_prefill",
     "mha_extend_with_kvcache",
     "mha_decode_with_kvcache",
     "mha_merge_state",
     "mha_decode_scheduler_metadata",
+    # quantization
+    "quantize_fp8",
+    "quantize_fp8_with_scale",
+    "quantize_mxfp8",
+    "quantize_nvfp4",
+    "quantize_mxfp4",
 ]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/__init__.py
@@ -95,13 +95,7 @@ def quantize_fp8_with_scale(
     # quantization options
     granularity: Literal["tensor", "token", "token_group"] = "tensor",
     group_size: int | None = None,
-    num_token_padding: int | None = None,
-    scale_dtype: torch.dtype = torch.float32,
-    scale_layout: Literal[
-        "row_major", "column_major", "tma_aligned", "linear"
-    ] = "row_major",
     scale_encoding: Literal["float32", "ue8m0", "packed_ue8m0"] = "float32",
-    eps: float = 1.0e-10,
     # kernel options
     enable_pdl: bool = False,
     # dispatch options
@@ -121,13 +115,8 @@ def quantize_fp8_with_scale(
             token_group.
         group_size: Number of contiguous values per scale group along the last
             dimension. Required for token_group granularity.
-        num_token_padding: Optional output row padding for GEMM/MoE kernels.
-        scale_dtype: Requested scale dtype for token_group granularity.
-        scale_layout: Scale memory layout for token_group granularity, such as
-            row_major, column_major, tma_aligned, or linear.
         scale_encoding: Scale encoding for token_group granularity, such as
             float32, ue8m0, or packed_ue8m0.
-        eps: Minimum value used by dynamic token_group scale computation.
         enable_pdl: Whether to request Programmatic Dependent Launch support.
         override: Optional exact kernel name or solution override.
         solution: Optional registered solution to select.
@@ -138,6 +127,9 @@ def quantize_fp8_with_scale(
     The expected scale shapes are [1] for tensor granularity, [M, 1] for token
     granularity, and [M, ceil(K / group_size)] or a backend-specific layout for
     token_group granularity, where M = x.reshape(-1, x.shape[-1]).shape[0].
+    Returned scales use float32 dtype for scale_encoding="float32" and a
+    backend-specific encoded integer dtype for non-float encodings such as
+    "ue8m0".
     """
 
     if granularity not in {"tensor", "token", "token_group"}:
@@ -147,11 +139,11 @@ def quantize_fp8_with_scale(
             raise ValueError(
                 f"token_group granularity requires positive group_size, got {group_size}"
             )
+        granularity_trait = f"token_group_{group_size}"
+    else:
+        granularity_trait = granularity
     traits = {
-        "granularity": granularity,
-        "group_size": group_size,
-        "scale_dtype": scale_dtype,
-        "scale_layout": scale_layout,
+        "granularity": granularity_trait,
         "scale_encoding": scale_encoding,
     }
     kernel = select_kernel(
@@ -164,10 +156,8 @@ def quantize_fp8_with_scale(
     )
     shape_params = {
         "shape": tuple(x.shape),
-        "granularity": granularity,
+        "granularity": granularity_trait,
         "group_size": group_size,
-        "scale_dtype": str(scale_dtype),
-        "scale_layout": scale_layout,
         "scale_encoding": scale_encoding,
     }
     ShapeCapture.get().record(
@@ -183,21 +173,14 @@ def quantize_fp8_with_scale(
         return kernel(
             x,
             granularity=granularity,
-            num_token_padding=num_token_padding,
             group_size=group_size,
-            scale_dtype=scale_dtype,
-            scale_layout=scale_layout,
             scale_encoding=scale_encoding,
-            eps=eps,
             enable_pdl=enable_pdl,
         )
 
 
 def quantize_mxfp8(
     x: torch.Tensor,
-    # quantization options
-    alignment: int = 32,
-    scale_layout: Literal["linear", "128x4", "8x4"] = "linear",
     # kernel options
     enable_pdl: bool = False,
     # dispatch options
@@ -207,14 +190,10 @@ def quantize_mxfp8(
     """Quantize x to MXFP8 format.
 
     MXFP8 uses FP8 data plus encoded vector scales, commonly one scale per 32
-    values along the last dimension.  Backends may pad the last dimension to
-    alignment and may return a flat encoded scale buffer whose layout is
-    specified by scale_layout.
+    values along the last dimension.
 
     Args:
         x: Input tensor.
-        alignment: Last-dimension alignment requested from the backend.
-        scale_layout: Scale-factor layout, such as linear, 128x4, or 8x4.
         enable_pdl: Whether to request Programmatic Dependent Launch support.
         override: Optional exact kernel name or solution override.
         solution: Optional registered solution to select.
@@ -224,13 +203,7 @@ def quantize_mxfp8(
 
     """
 
-    if alignment <= 0:
-        raise ValueError(f"alignment must be positive, got {alignment}")
-    traits = {
-        "alignment": alignment,
-        "scale_layout": scale_layout,
-        "scale_encoding": "mxfp8",
-    }
+    traits = {}
     kernel = select_kernel(
         "quantization",
         "mxfp8",
@@ -241,8 +214,6 @@ def quantize_mxfp8(
     )
     shape_params = {
         "shape": tuple(x.shape),
-        "alignment": alignment,
-        "scale_layout": scale_layout,
     }
     ShapeCapture.get().record(
         "quantization", "mxfp8", kernel.name, x.dtype, shape_params
@@ -252,64 +223,46 @@ def quantize_mxfp8(
     ):
         return kernel(
             x,
-            alignment=alignment,
-            scale_layout=scale_layout,
             enable_pdl=enable_pdl,
         )
 
 
 def quantize_nvfp4(
     x: torch.Tensor,
+    scale: float | torch.Tensor | None = None,
     # quantization options
-    global_scale: float | None = None,
-    scale_size: int = 16,
-    scale_layout: Literal["linear", "128x4", "8x4"] = "128x4",
-    per_token_activation: bool = False,
-    expanded_idx_to_permuted_idx: torch.Tensor | None = None,
+    scale_layout: Literal["linear", "swizzled"] = "swizzled",
     # kernel options
     enable_pdl: bool = False,
     # dispatch options
     override: str | None = None,
     solution: str | None = None,
-) -> (
-    tuple[torch.Tensor, torch.Tensor] | tuple[torch.Tensor, torch.Tensor, torch.Tensor]
-):
+) -> tuple[torch.Tensor, torch.Tensor]:
     """Quantize x to packed NVFP4.
 
-    NVFP4 uses packed E2M1x2 data with one E4M3 scale factor per scale_size
-    values, usually scale_size=16. The quantized output is usually shaped
-    [M, K/2].
+    NVFP4 uses packed E2M1x2 data with one E4M3 scale factor per 16 values.
+    The quantized output is usually shaped [M, K/2].
 
-    global_scale is the actual global scale. Backend adapters should handle any
+    scale is the actual input scale. Backend adapters should handle any
     backend-specific inverse-scale convention internally.
 
     Args:
         x: Input tensor.
-        global_scale: Optional scalar global scale.
-        scale_size: Number of values per scale-factor vector.
-        scale_layout: Scale-factor layout, such as linear, 128x4, or 8x4.
-        per_token_activation: Whether the backend should also produce per-token
-            activation scales.
-        expanded_idx_to_permuted_idx: Optional row remapping for per-token
-            activation quantization.
+        scale: Optional scalar input scale.
+        scale_layout: Scale-factor layout. "linear" returns unswizzled scales;
+            "swizzled" requests the backend-specific layout used by FP4 GEMM.
         enable_pdl: Whether to request Programmatic Dependent Launch support.
         override: Optional exact kernel name or solution override.
         solution: Optional registered solution to select.
 
     Returns:
-        Tuple of packed NVFP4 tensor and scale-factor tensor. Backends that
-        support per-token activation scales may return a third tensor.
+        Tuple of packed NVFP4 tensor and scale-factor tensor.
 
     """
 
-    if scale_size <= 0:
-        raise ValueError(f"scale_size must be positive, got {scale_size}")
-
     traits = {
-        "scale_size": scale_size,
         "scale_layout": scale_layout,
-        "has_global_scale": global_scale is not None,
-        "per_token_activation": per_token_activation,
+        "has_scale": scale is not None,
     }
     kernel = select_kernel(
         "quantization",
@@ -321,10 +274,8 @@ def quantize_nvfp4(
     )
     shape_params = {
         "shape": tuple(x.shape),
-        "scale_size": scale_size,
         "scale_layout": scale_layout,
-        "has_global_scale": global_scale is not None,
-        "per_token_activation": per_token_activation,
+        "has_scale": scale is not None,
     }
     ShapeCapture.get().record(
         "quantization", "nvfp4", kernel.name, x.dtype, shape_params
@@ -334,11 +285,8 @@ def quantize_nvfp4(
     ):
         return kernel(
             x,
-            global_scale=global_scale,
-            scale_size=scale_size,
+            scale=scale,
             scale_layout=scale_layout,
-            per_token_activation=per_token_activation,
-            expanded_idx_to_permuted_idx=expanded_idx_to_permuted_idx,
             enable_pdl=enable_pdl,
         )
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/__init__.py
@@ -23,18 +23,17 @@ from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
 from tokenspeed_kernel.selection import select_kernel
 
 __all__ = [
-    "quantize_fp8_static",
-    "quantize_fp8_dynamic",
+    "quantize_fp8",
+    "quantize_fp8_with_scale",
     "quantize_mxfp8",
     "quantize_nvfp4",
     "quantize_mxfp4",
 ]
 
 
-def quantize_fp8_static(
+def quantize_fp8(
     x: torch.Tensor,
-    scale: float | None = None,
-    out: torch.Tensor | None = None,
+    scale: float | torch.Tensor | None = None,
     # kernel options
     enable_pdl: bool = False,
     # dispatch options
@@ -50,19 +49,18 @@ def quantize_fp8_static(
 
     Args:
         x: Input tensor.
-        scale: Optional scalar scale. If provided, the backend computes
-            x / scale before casting. If omitted, the backend performs a pure
-            FP8 cast.
-        out: Optional pre-allocated FP8 output tensor.
+        scale: Optional scalar scale, as a Python value or scalar tensor. If
+            provided, the backend computes x / scale before casting. If omitted,
+            the backend performs a pure FP8 cast.
         enable_pdl: Whether to request Programmatic Dependent Launch support.
         override: Optional exact kernel name or solution override.
         solution: Optional registered solution to select.
 
     Returns:
-        Quantized FP8 tensor with the same shape as x, unless out is provided.
+        Quantized FP8 tensor with the same shape as x.
 
-    Scalar scales are Python values. Non-scalar scales belong in dynamic
-    quantization APIs and should be on-device tensors.
+    Non-scalar scales belong in dynamic quantization APIs and should be
+    on-device tensors.
 
     """
 
@@ -71,7 +69,7 @@ def quantize_fp8_static(
     }
     kernel = select_kernel(
         "quantization",
-        "fp8_static",
+        "fp8",
         x.dtype,
         traits=traits,
         solution=solution,
@@ -81,24 +79,19 @@ def quantize_fp8_static(
         "shape": tuple(x.shape),
         "has_scale": scale is not None,
     }
-    ShapeCapture.get().record(
-        "quantization", "fp8_static", kernel.name, x.dtype, shape_params
-    )
+    ShapeCapture.get().record("quantization", "fp8", kernel.name, x.dtype, shape_params)
     with kernel_scope(
-        "quantization", "fp8_static", x.dtype, kernel_name=kernel.name, **shape_params
+        "quantization", "fp8", x.dtype, kernel_name=kernel.name, **shape_params
     ):
         return kernel(
             x,
             scale=scale,
-            out=out,
             enable_pdl=enable_pdl,
         )
 
 
-def quantize_fp8_dynamic(
+def quantize_fp8_with_scale(
     x: torch.Tensor,
-    out: torch.Tensor | None = None,
-    out_scale: torch.Tensor | None = None,
     # quantization options
     granularity: Literal["tensor", "token", "token_group"] = "tensor",
     group_size: int | None = None,
@@ -124,8 +117,6 @@ def quantize_fp8_dynamic(
 
     Args:
         x: Input tensor.
-        out: Optional pre-allocated FP8 output tensor.
-        out_scale: Optional pre-allocated scale tensor.
         granularity: Scale granularity. Supported values are tensor, token, and
             token_group.
         group_size: Number of contiguous values per scale group along the last
@@ -165,7 +156,7 @@ def quantize_fp8_dynamic(
     }
     kernel = select_kernel(
         "quantization",
-        "fp8_dynamic",
+        "fp8_with_scale",
         x.dtype,
         traits=traits,
         solution=solution,
@@ -180,16 +171,18 @@ def quantize_fp8_dynamic(
         "scale_encoding": scale_encoding,
     }
     ShapeCapture.get().record(
-        "quantization", "fp8_dynamic", kernel.name, x.dtype, shape_params
+        "quantization", "fp8_with_scale", kernel.name, x.dtype, shape_params
     )
     with kernel_scope(
-        "quantization", "fp8_dynamic", x.dtype, kernel_name=kernel.name, **shape_params
+        "quantization",
+        "fp8_with_scale",
+        x.dtype,
+        kernel_name=kernel.name,
+        **shape_params,
     ):
         return kernel(
             x,
             granularity=granularity,
-            out=out,
-            out_scale=out_scale,
             num_token_padding=num_token_padding,
             group_size=group_size,
             scale_dtype=scale_dtype,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/__init__.py
@@ -14,3 +14,416 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
+from tokenspeed_kernel.selection import select_kernel
+
+__all__ = [
+    "quantize_fp8_static",
+    "quantize_fp8_dynamic",
+    "quantize_mxfp8",
+    "quantize_nvfp4",
+    "quantize_mxfp4",
+]
+
+
+def quantize_fp8_static(
+    x: torch.Tensor,
+    scale: float | None = None,
+    out: torch.Tensor | None = None,
+    # kernel options
+    enable_pdl: bool = False,
+    # dispatch options
+    override: str | None = None,
+    solution: str | None = None,
+) -> torch.Tensor:
+    """Quantize x to same-shape FP8 with an optional scalar scale.
+
+    This API covers static activation-scale cases such as GPT-OSS MXFP4 MoE
+    W4A8 input quantization and plain FP8 casts. If scale is provided, it is
+    the actual quantization scale, so the backend computes x / scale before
+    casting. If scale is omitted, the backend performs a pure FP8 cast.
+
+    Args:
+        x: Input tensor.
+        scale: Optional scalar scale. If provided, the backend computes
+            x / scale before casting. If omitted, the backend performs a pure
+            FP8 cast.
+        out: Optional pre-allocated FP8 output tensor.
+        enable_pdl: Whether to request Programmatic Dependent Launch support.
+        override: Optional exact kernel name or solution override.
+        solution: Optional registered solution to select.
+
+    Returns:
+        Quantized FP8 tensor with the same shape as x, unless out is provided.
+
+    Scalar scales are Python values. Non-scalar scales belong in dynamic
+    quantization APIs and should be on-device tensors.
+
+    """
+
+    traits = {
+        "has_scale": scale is not None,
+    }
+    kernel = select_kernel(
+        "quantization",
+        "fp8_static",
+        x.dtype,
+        traits=traits,
+        solution=solution,
+        override=override,
+    )
+    shape_params = {
+        "shape": tuple(x.shape),
+        "has_scale": scale is not None,
+    }
+    ShapeCapture.get().record(
+        "quantization", "fp8_static", kernel.name, x.dtype, shape_params
+    )
+    with kernel_scope(
+        "quantization", "fp8_static", x.dtype, kernel_name=kernel.name, **shape_params
+    ):
+        return kernel(
+            x,
+            scale=scale,
+            out=out,
+            enable_pdl=enable_pdl,
+        )
+
+
+def quantize_fp8_dynamic(
+    x: torch.Tensor,
+    out: torch.Tensor | None = None,
+    out_scale: torch.Tensor | None = None,
+    # quantization options
+    granularity: Literal["tensor", "token", "token_group"] = "tensor",
+    group_size: int | None = None,
+    num_token_padding: int | None = None,
+    scale_dtype: torch.dtype = torch.float32,
+    scale_layout: Literal[
+        "row_major", "column_major", "tma_aligned", "linear"
+    ] = "row_major",
+    scale_encoding: Literal["float32", "ue8m0", "packed_ue8m0"] = "float32",
+    eps: float = 1.0e-10,
+    # kernel options
+    enable_pdl: bool = False,
+    # dispatch options
+    override: str | None = None,
+    solution: str | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize x to FP8 while dynamically computing scales.
+
+    Use granularity="tensor" for one scale over the whole tensor,
+    granularity="token" for one scale per row/token, and
+    granularity="token_group" for one scale per row/token and contiguous group
+    along the last dimension.
+
+    Args:
+        x: Input tensor.
+        out: Optional pre-allocated FP8 output tensor.
+        out_scale: Optional pre-allocated scale tensor.
+        granularity: Scale granularity. Supported values are tensor, token, and
+            token_group.
+        group_size: Number of contiguous values per scale group along the last
+            dimension. Required for token_group granularity.
+        num_token_padding: Optional output row padding for GEMM/MoE kernels.
+        scale_dtype: Requested scale dtype for token_group granularity.
+        scale_layout: Scale memory layout for token_group granularity, such as
+            row_major, column_major, tma_aligned, or linear.
+        scale_encoding: Scale encoding for token_group granularity, such as
+            float32, ue8m0, or packed_ue8m0.
+        eps: Minimum value used by dynamic token_group scale computation.
+        enable_pdl: Whether to request Programmatic Dependent Launch support.
+        override: Optional exact kernel name or solution override.
+        solution: Optional registered solution to select.
+
+    Returns:
+        Tuple of quantized FP8 tensor and scale tensor.
+
+    The expected scale shapes are [1] for tensor granularity, [M, 1] for token
+    granularity, and [M, ceil(K / group_size)] or a backend-specific layout for
+    token_group granularity, where M = x.reshape(-1, x.shape[-1]).shape[0].
+    """
+
+    if granularity not in {"tensor", "token", "token_group"}:
+        raise ValueError(f"unsupported FP8 dynamic granularity: {granularity!r}")
+    if granularity == "token_group":
+        if group_size is None or group_size <= 0:
+            raise ValueError(
+                f"token_group granularity requires positive group_size, got {group_size}"
+            )
+    traits = {
+        "granularity": granularity,
+        "group_size": group_size,
+        "scale_dtype": scale_dtype,
+        "scale_layout": scale_layout,
+        "scale_encoding": scale_encoding,
+    }
+    kernel = select_kernel(
+        "quantization",
+        "fp8_dynamic",
+        x.dtype,
+        traits=traits,
+        solution=solution,
+        override=override,
+    )
+    shape_params = {
+        "shape": tuple(x.shape),
+        "granularity": granularity,
+        "group_size": group_size,
+        "scale_dtype": str(scale_dtype),
+        "scale_layout": scale_layout,
+        "scale_encoding": scale_encoding,
+    }
+    ShapeCapture.get().record(
+        "quantization", "fp8_dynamic", kernel.name, x.dtype, shape_params
+    )
+    with kernel_scope(
+        "quantization", "fp8_dynamic", x.dtype, kernel_name=kernel.name, **shape_params
+    ):
+        return kernel(
+            x,
+            granularity=granularity,
+            out=out,
+            out_scale=out_scale,
+            num_token_padding=num_token_padding,
+            group_size=group_size,
+            scale_dtype=scale_dtype,
+            scale_layout=scale_layout,
+            scale_encoding=scale_encoding,
+            eps=eps,
+            enable_pdl=enable_pdl,
+        )
+
+
+def quantize_mxfp8(
+    x: torch.Tensor,
+    # quantization options
+    alignment: int = 32,
+    scale_layout: Literal["linear", "128x4", "8x4"] = "linear",
+    # kernel options
+    enable_pdl: bool = False,
+    # dispatch options
+    override: str | None = None,
+    solution: str | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize x to MXFP8 format.
+
+    MXFP8 uses FP8 data plus encoded vector scales, commonly one scale per 32
+    values along the last dimension.  Backends may pad the last dimension to
+    alignment and may return a flat encoded scale buffer whose layout is
+    specified by scale_layout.
+
+    Args:
+        x: Input tensor.
+        alignment: Last-dimension alignment requested from the backend.
+        scale_layout: Scale-factor layout, such as linear, 128x4, or 8x4.
+        enable_pdl: Whether to request Programmatic Dependent Launch support.
+        override: Optional exact kernel name or solution override.
+        solution: Optional registered solution to select.
+
+    Returns:
+        Tuple of quantized MXFP8 tensor and encoded scale tensor.
+
+    """
+
+    if alignment <= 0:
+        raise ValueError(f"alignment must be positive, got {alignment}")
+    traits = {
+        "alignment": alignment,
+        "scale_layout": scale_layout,
+        "scale_encoding": "mxfp8",
+    }
+    kernel = select_kernel(
+        "quantization",
+        "mxfp8",
+        x.dtype,
+        traits=traits,
+        solution=solution,
+        override=override,
+    )
+    shape_params = {
+        "shape": tuple(x.shape),
+        "alignment": alignment,
+        "scale_layout": scale_layout,
+    }
+    ShapeCapture.get().record(
+        "quantization", "mxfp8", kernel.name, x.dtype, shape_params
+    )
+    with kernel_scope(
+        "quantization", "mxfp8", x.dtype, kernel_name=kernel.name, **shape_params
+    ):
+        return kernel(
+            x,
+            alignment=alignment,
+            scale_layout=scale_layout,
+            enable_pdl=enable_pdl,
+        )
+
+
+def quantize_nvfp4(
+    x: torch.Tensor,
+    # quantization options
+    global_scale: float | None = None,
+    scale_size: int = 16,
+    scale_layout: Literal["linear", "128x4", "8x4"] = "128x4",
+    per_token_activation: bool = False,
+    expanded_idx_to_permuted_idx: torch.Tensor | None = None,
+    # kernel options
+    enable_pdl: bool = False,
+    # dispatch options
+    override: str | None = None,
+    solution: str | None = None,
+) -> (
+    tuple[torch.Tensor, torch.Tensor] | tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+):
+    """Quantize x to packed NVFP4.
+
+    NVFP4 uses packed E2M1x2 data with one E4M3 scale factor per scale_size
+    values, usually scale_size=16. The quantized output is usually shaped
+    [M, K/2].
+
+    global_scale is the actual global scale. Backend adapters should handle any
+    backend-specific inverse-scale convention internally.
+
+    Args:
+        x: Input tensor.
+        global_scale: Optional scalar global scale.
+        scale_size: Number of values per scale-factor vector.
+        scale_layout: Scale-factor layout, such as linear, 128x4, or 8x4.
+        per_token_activation: Whether the backend should also produce per-token
+            activation scales.
+        expanded_idx_to_permuted_idx: Optional row remapping for per-token
+            activation quantization.
+        enable_pdl: Whether to request Programmatic Dependent Launch support.
+        override: Optional exact kernel name or solution override.
+        solution: Optional registered solution to select.
+
+    Returns:
+        Tuple of packed NVFP4 tensor and scale-factor tensor. Backends that
+        support per-token activation scales may return a third tensor.
+
+    """
+
+    if scale_size <= 0:
+        raise ValueError(f"scale_size must be positive, got {scale_size}")
+
+    traits = {
+        "scale_size": scale_size,
+        "scale_layout": scale_layout,
+        "has_global_scale": global_scale is not None,
+        "per_token_activation": per_token_activation,
+    }
+    kernel = select_kernel(
+        "quantization",
+        "nvfp4",
+        x.dtype,
+        traits=traits,
+        solution=solution,
+        override=override,
+    )
+    shape_params = {
+        "shape": tuple(x.shape),
+        "scale_size": scale_size,
+        "scale_layout": scale_layout,
+        "has_global_scale": global_scale is not None,
+        "per_token_activation": per_token_activation,
+    }
+    ShapeCapture.get().record(
+        "quantization", "nvfp4", kernel.name, x.dtype, shape_params
+    )
+    with kernel_scope(
+        "quantization", "nvfp4", x.dtype, kernel_name=kernel.name, **shape_params
+    ):
+        return kernel(
+            x,
+            global_scale=global_scale,
+            scale_size=scale_size,
+            scale_layout=scale_layout,
+            per_token_activation=per_token_activation,
+            expanded_idx_to_permuted_idx=expanded_idx_to_permuted_idx,
+            enable_pdl=enable_pdl,
+        )
+
+
+def quantize_mxfp4(
+    x: torch.Tensor,
+    # quantization options
+    global_scale: float | None = None,
+    scale_size: int = 32,
+    scale_layout: Literal["linear", "128x4", "8x4"] = "128x4",
+    # kernel options
+    enable_pdl: bool = False,
+    # dispatch options
+    override: str | None = None,
+    solution: str | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize x to packed MXFP4.
+
+    MXFP4 uses packed E2M1x2 data with one UE8M0 scale factor per scale_size
+    values, usually scale_size=32. The quantized output is usually shaped
+    [M, K/2].
+
+    global_scale is optional because some backends compute the global scale
+    internally from the input. If provided, it is the actual global scale.
+
+    Args:
+        x: Input tensor.
+        global_scale: Optional scalar global scale.
+        scale_size: Number of values per scale-factor vector.
+        scale_layout: Scale-factor layout, such as linear, 128x4, or 8x4.
+        enable_pdl: Whether to request Programmatic Dependent Launch support.
+        override: Optional exact kernel name or solution override.
+        solution: Optional registered solution to select.
+
+    Returns:
+        Tuple of packed MXFP4 tensor and scale-factor tensor.
+
+    """
+
+    if scale_size <= 0:
+        raise ValueError(f"scale_size must be positive, got {scale_size}")
+
+    traits = {
+        "scale_size": scale_size,
+        "scale_layout": scale_layout,
+        "has_global_scale": global_scale is not None,
+        "scale_encoding": "ue8m0",
+    }
+    kernel = select_kernel(
+        "quantization",
+        "mxfp4",
+        x.dtype,
+        traits=traits,
+        solution=solution,
+        override=override,
+    )
+    shape_params = {
+        "shape": tuple(x.shape),
+        "scale_size": scale_size,
+        "scale_layout": scale_layout,
+        "has_global_scale": global_scale is not None,
+    }
+    ShapeCapture.get().record(
+        "quantization", "mxfp4", kernel.name, x.dtype, shape_params
+    )
+    with kernel_scope(
+        "quantization", "mxfp4", x.dtype, kernel_name=kernel.name, **shape_params
+    ):
+        return kernel(
+            x,
+            global_scale=global_scale,
+            scale_size=scale_size,
+            scale_layout=scale_layout,
+            enable_pdl=enable_pdl,
+        )
+
+
+# Backend registration (side-effect imports).
+import tokenspeed_kernel.ops.quantization.flashinfer  # noqa: E402,F401
+import tokenspeed_kernel.ops.quantization.triton  # noqa: E402,F401
+import tokenspeed_kernel.ops.quantization.trtllm  # noqa: E402,F401

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/__init__.py
@@ -14,12 +14,3 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-"""Quantization kernel entry points."""
-
-# Backend registration (side-effect imports — decorators fire at module load)
-import tokenspeed_kernel.numerics.reference.quantize  # noqa: F401
-import tokenspeed_kernel.ops.quantization.trtllm  # noqa: F401
-from tokenspeed_kernel.ops.quantization.triton import fp8_quantize
-
-__all__ = ["fp8_quantize"]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/flashinfer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/flashinfer.py
@@ -17,7 +17,11 @@
 from __future__ import annotations
 
 import torch
-from tokenspeed_kernel.platform import current_platform
+from tokenspeed_kernel.platform import (
+    ArchVersion,
+    CapabilityRequirement,
+    current_platform,
+)
 from tokenspeed_kernel.registry import Priority, error_fn, register_kernel
 
 platform = current_platform()
@@ -30,11 +34,7 @@ nvfp4_block_scale_interleave = error_fn
 fp8_blockscale_quantize_runner_sm90 = error_fn
 
 if platform.is_nvidia:
-    from flashinfer import (
-        fp4_quantize,
-        mxfp8_quantize,
-        nvfp4_block_scale_interleave,
-    )
+    from flashinfer import mxfp8_quantize
 
     if platform.is_hopper:
         from flashinfer.gemm.gemm_base import (
@@ -56,11 +56,22 @@ if platform.is_nvidia:
     ) -> tuple[torch.Tensor, torch.Tensor]:
         return mxfp8_quantize(x, False)
 
+
+if platform.is_nvidia and platform.is_blackwell:
+    from flashinfer import (
+        fp4_quantize,
+        nvfp4_block_scale_interleave,
+    )
+
     @register_kernel(
         "quantization",
         "nvfp4",
         name="flashinfer_quantize_nvfp4",
         solution="flashinfer",
+        capability=CapabilityRequirement(
+            min_arch_version=ArchVersion(10, 0),
+            vendors=frozenset({"nvidia"}),
+        ),
         dtypes={torch.bfloat16, torch.float16},
         traits={
             "has_scale": frozenset({True}),

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/flashinfer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/flashinfer.py
@@ -47,19 +47,14 @@ if platform.is_nvidia:
         name="flashinfer_quantize_mxfp8",
         solution="flashinfer",
         dtypes={torch.bfloat16, torch.float16},
-        traits={
-            "scale_layout": frozenset({"linear"}),
-            "scale_encoding": frozenset({"mxfp8"}),
-        },
+        traits={},
         priority=Priority.PERFORMANT,
     )
     def flashinfer_quantize_mxfp8(
         x: torch.Tensor,
-        alignment: int = 32,
-        scale_layout: str = "linear",
         enable_pdl: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        return mxfp8_quantize(x, False, alignment=alignment)
+        return mxfp8_quantize(x, False)
 
     @register_kernel(
         "quantization",
@@ -68,32 +63,24 @@ if platform.is_nvidia:
         solution="flashinfer",
         dtypes={torch.bfloat16, torch.float16},
         traits={
-            "scale_size": frozenset({16}),
-            "has_global_scale": frozenset({True}),
-            "per_token_activation": frozenset({False}),
+            "has_scale": frozenset({True}),
         },
         priority=Priority.PERFORMANT,
     )
     def flashinfer_quantize_nvfp4(
         x: torch.Tensor,
-        global_scale: float | torch.Tensor | None = None,
-        scale_size: int = 16,
-        scale_layout: str = "128x4",
-        per_token_activation: bool = False,
-        expanded_idx_to_permuted_idx: torch.Tensor | None = None,
+        scale: float | torch.Tensor | None = None,
+        scale_layout: str = "swizzled",
         enable_pdl: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if expanded_idx_to_permuted_idx is not None:
-            raise ValueError("flashinfer nvfp4 does not support row remapping")
-
         # The public quantization API uses the actual scale; FlashInfer's FP4
         # helper expects the inverse scale used before packing.
-        global_scale_inv = 1.0 / global_scale
+        scale_inv = 1.0 / scale
         return fp4_quantize(
             x,
-            global_scale=global_scale_inv,
-            sf_vec_size=scale_size,
-            is_sf_swizzled_layout=scale_layout != "linear",
+            global_scale=scale_inv,
+            sf_vec_size=16,
+            is_sf_swizzled_layout=scale_layout == "swizzled",
             enable_pdl=enable_pdl,
         )
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/flashinfer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/flashinfer.py
@@ -23,6 +23,8 @@ import torch
 from tokenspeed_kernel.platform import current_platform
 from tokenspeed_kernel.registry import Priority, error_fn, register_kernel
 
+platform = current_platform()
+
 fp4_quantize = error_fn
 flashinfer_quantize_mxfp8 = error_fn
 flashinfer_quantize_nvfp4 = error_fn
@@ -30,26 +32,17 @@ mxfp8_quantize = error_fn
 nvfp4_block_scale_interleave = error_fn
 fp8_blockscale_quantize_runner_sm90 = error_fn
 
-if current_platform().is_nvidia:
-    try:
-        from flashinfer import (
-            fp4_quantize,
-            mxfp8_quantize,
-            nvfp4_block_scale_interleave,
-        )
-    except ImportError:
-        pass
+if platform.is_nvidia:
+    from flashinfer import (
+        fp4_quantize,
+        mxfp8_quantize,
+        nvfp4_block_scale_interleave,
+    )
 
-if current_platform().is_hopper:
-    try:
+    if platform.is_hopper:
         from flashinfer.gemm.gemm_base import (
             get_fp8_blockscale_gemm_runner_sm90 as fp8_blockscale_quantize_runner_sm90,
         )
-    except ImportError:
-        pass
-
-
-if mxfp8_quantize is not error_fn:
 
     @register_kernel(
         "quantization",
@@ -71,9 +64,6 @@ if mxfp8_quantize is not error_fn:
         enable_pdl: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         return mxfp8_quantize(x, False, alignment=alignment)
-
-
-if fp4_quantize is not error_fn:
 
     @register_kernel(
         "quantization",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/flashinfer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/flashinfer.py
@@ -14,9 +14,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-"""FlashInfer quantization kernels."""
-
 from __future__ import annotations
 
 import torch

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/flashinfer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/flashinfer.py
@@ -17,10 +17,15 @@
 
 """FlashInfer quantization kernels."""
 
+from __future__ import annotations
+
+import torch
 from tokenspeed_kernel.platform import current_platform
-from tokenspeed_kernel.registry import error_fn
+from tokenspeed_kernel.registry import Priority, error_fn, register_kernel
 
 fp4_quantize = error_fn
+flashinfer_quantize_mxfp8 = error_fn
+flashinfer_quantize_nvfp4 = error_fn
 mxfp8_quantize = error_fn
 nvfp4_block_scale_interleave = error_fn
 fp8_blockscale_quantize_runner_sm90 = error_fn
@@ -42,6 +47,70 @@ if current_platform().is_hopper:
         )
     except ImportError:
         pass
+
+
+if mxfp8_quantize is not error_fn:
+
+    @register_kernel(
+        "quantization",
+        "mxfp8",
+        name="flashinfer_quantize_mxfp8",
+        solution="flashinfer",
+        dtypes={torch.bfloat16, torch.float16},
+        traits={
+            "scale_layout": frozenset({"linear"}),
+            "scale_encoding": frozenset({"mxfp8"}),
+        },
+        priority=Priority.SPECIALIZED,
+        tags={"throughput"},
+    )
+    def flashinfer_quantize_mxfp8(
+        x: torch.Tensor,
+        alignment: int = 32,
+        scale_layout: str = "linear",
+        enable_pdl: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return mxfp8_quantize(x, False, alignment=alignment)
+
+
+if fp4_quantize is not error_fn:
+
+    @register_kernel(
+        "quantization",
+        "nvfp4",
+        name="flashinfer_quantize_nvfp4",
+        solution="flashinfer",
+        dtypes={torch.bfloat16, torch.float16},
+        traits={
+            "scale_size": frozenset({16}),
+            "has_global_scale": frozenset({True}),
+            "per_token_activation": frozenset({False}),
+        },
+        priority=Priority.SPECIALIZED,
+        tags={"throughput"},
+    )
+    def flashinfer_quantize_nvfp4(
+        x: torch.Tensor,
+        global_scale: float | torch.Tensor | None = None,
+        scale_size: int = 16,
+        scale_layout: str = "128x4",
+        per_token_activation: bool = False,
+        expanded_idx_to_permuted_idx: torch.Tensor | None = None,
+        enable_pdl: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if expanded_idx_to_permuted_idx is not None:
+            raise ValueError("flashinfer nvfp4 does not support row remapping")
+
+        # The public quantization API uses the actual scale; FlashInfer's FP4
+        # helper expects the inverse scale used before packing.
+        global_scale_inv = 1.0 / global_scale
+        return fp4_quantize(
+            x,
+            global_scale=global_scale_inv,
+            sf_vec_size=scale_size,
+            is_sf_swizzled_layout=scale_layout != "linear",
+            enable_pdl=enable_pdl,
+        )
 
 
 __all__ = [

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/flashinfer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/flashinfer.py
@@ -51,8 +51,7 @@ if platform.is_nvidia:
             "scale_layout": frozenset({"linear"}),
             "scale_encoding": frozenset({"mxfp8"}),
         },
-        priority=Priority.SPECIALIZED,
-        tags={"throughput"},
+        priority=Priority.PERFORMANT,
     )
     def flashinfer_quantize_mxfp8(
         x: torch.Tensor,
@@ -73,8 +72,7 @@ if platform.is_nvidia:
             "has_global_scale": frozenset({True}),
             "per_token_activation": frozenset({False}),
         },
-        priority=Priority.SPECIALIZED,
-        tags={"throughput"},
+        priority=Priority.PERFORMANT,
     )
     def flashinfer_quantize_nvfp4(
         x: torch.Tensor,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/triton.py
@@ -193,8 +193,7 @@ def fp8_quantize(
     solution="triton",
     dtypes={torch.bfloat16, torch.float16},
     traits={"has_scale": frozenset({True, False})},
-    priority=Priority.PERFORMANT,
-    tags={"throughput"},
+    priority=Priority.PORTABLE,
 )
 def triton_quantize_fp8(
     x: torch.Tensor,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/triton.py
@@ -14,16 +14,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-"""Triton FP8 quantize / cast kernel.
-
-Drop-in replacement for ``x.to(torch.float8_e4m3fn)`` (or ``e5m2``) with
-optional per-tensor scale. Designed for the per-layer cast call sites in MLA
-prefill (deepseek_v3.py:1001/1005), where torch's default cast under-saturates
-HBM and the existing ``static_quant_fp8`` kernel is even slower because of its
-contiguous-input requirement and one-row-per-program tiling.
-"""
-
 from typing import Optional
 
 import torch

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/triton.py
@@ -28,25 +28,30 @@ from typing import Optional
 
 import torch
 from tokenspeed_kernel._triton import tl, triton
+from tokenspeed_kernel.registry import Priority, register_kernel
 
 
 @triton.jit
 def _fp8_quantize_kernel(
     x_ptr,
     out_ptr,
-    scale_inv,
+    scale,
     M,
     x_row_stride,
     out_row_stride,
     N: tl.constexpr,
+    BLOCK_N: tl.constexpr,
     FP8_DTYPE: tl.constexpr,
     BLOCK_M: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    HAS_SCALE_TENSOR: tl.constexpr,
     ENABLE_PDL: tl.constexpr,
 ):
     pid = tl.program_id(0)
     m_idx = pid * BLOCK_M + tl.arange(0, BLOCK_M)
     m_mask = m_idx < M
-    n_idx = tl.arange(0, N)
+    n_idx = tl.arange(0, BLOCK_N)
+    n_mask = n_idx < N
 
     # PDL: wait for the producer kernel (e.g., kv_b_proj GEMM) to drain before
     # we read its output. No-op when disabled.
@@ -54,12 +59,18 @@ def _fp8_quantize_kernel(
         tl.extra.cuda.gdc_wait()
 
     x_off = m_idx[:, None] * x_row_stride + n_idx[None, :]
-    x = tl.load(x_ptr + x_off, mask=m_mask[:, None])
+    mask = m_mask[:, None] & n_mask[None, :]
+    x = tl.load(x_ptr + x_off, mask=mask, other=0.0)
 
-    x_fp8 = (x.to(tl.float32) * scale_inv).to(FP8_DTYPE)
+    x = x.to(tl.float32)
+    if HAS_SCALE:
+        if HAS_SCALE_TENSOR:
+            scale = tl.load(scale)
+        x = x / scale
+    x_fp8 = x.to(FP8_DTYPE)
 
     out_off = m_idx[:, None] * out_row_stride + n_idx[None, :]
-    tl.store(out_ptr + out_off, x_fp8, mask=m_mask[:, None])
+    tl.store(out_ptr + out_off, x_fp8, mask=mask)
 
     # PDL: signal that dependents (e.g., FMHA) can begin their preamble.
     if ENABLE_PDL:
@@ -95,22 +106,22 @@ def _flatten_to_2d(x: torch.Tensor):
 
 def fp8_quantize(
     x: torch.Tensor,
-    scale_inv: float = 1.0,
+    scale: float | torch.Tensor | None = None,
     out: Optional[torch.Tensor] = None,
     fp8_dtype: torch.dtype = torch.float8_e4m3fn,
     enable_pdl: bool = False,
 ) -> torch.Tensor:
     """Cast a BF16/FP16 tensor to FP8 with an optional per-tensor scale.
 
-    Computes ``out = saturate((x * scale_inv) -> fp8)`` element-wise. When
-    ``scale_inv == 1.0`` the multiply is dropped at compile time (pure cast).
+    Computes ``out = saturate((x / scale) -> fp8)`` element-wise when scale is
+    provided. When scale is omitted, this is a pure FP8 cast.
 
     Args:
         x: BF16 or FP16 tensor. Must have stride(-1) == 1; leading dims must
            pack uniformly onto the row stride (true for contiguous tensors and
            for last-dim slice views like ``kv[..., qk_nope:]``).
-        scale_inv: scalar multiplier applied before the cast (i.e. ``1/scale``).
-           Passed as a plain kernel arg — no GMEM load.
+        scale: optional scalar divisor applied before the cast. Python values
+           are passed as plain kernel args; scalar tensors are loaded on device.
         out: optional pre-allocated FP8 output. Same shape as ``x``. If not
            provided, allocated as contiguous.
         fp8_dtype: ``torch.float8_e4m3fn`` (default) or ``torch.float8_e5m2``.
@@ -125,6 +136,11 @@ def fp8_quantize(
         torch.float16,
     ), f"fp8_quantize input must be bf16/fp16, got {x.dtype}"
     assert fp8_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+    has_scale = scale is not None
+    has_scale_tensor = isinstance(scale, torch.Tensor)
+    if has_scale_tensor:
+        assert scale.numel() == 1, "scale tensor must be scalar"
+        scale = scale.contiguous()
 
     M, N, x_row_stride = _flatten_to_2d(x)
 
@@ -136,6 +152,7 @@ def fp8_quantize(
     assert out_M == M
 
     fp8_dtype_const = tl.float8e4nv if fp8_dtype is torch.float8_e4m3fn else tl.float8e5
+    block_n = triton.next_power_of_2(N)
 
     # Block-size heuristic — picked from per-shape best configs in an
     # nsys-driven sweep on B200 (kv_a [s,512] and v [s,h,128] for K2.5).
@@ -161,16 +178,42 @@ def fp8_quantize(
     _fp8_quantize_kernel[grid](
         x,
         out,
-        scale_inv,
+        1.0 if scale is None else scale,
         M,
         x_row_stride,
         out_row_stride,
         N=N,
+        BLOCK_N=block_n,
         FP8_DTYPE=fp8_dtype_const,
         BLOCK_M=block_m,
+        HAS_SCALE=has_scale,
+        HAS_SCALE_TENSOR=has_scale_tensor,
         ENABLE_PDL=enable_pdl,
         num_warps=num_warps,
         num_stages=num_stages,
         **extra_kwargs,
     )
     return out
+
+
+@register_kernel(
+    "quantization",
+    "fp8",
+    name="triton_quantize_fp8",
+    solution="triton",
+    dtypes={torch.bfloat16, torch.float16},
+    traits={"has_scale": frozenset({True, False})},
+    priority=Priority.PERFORMANT,
+    tags={"throughput"},
+)
+def triton_quantize_fp8(
+    x: torch.Tensor,
+    scale: float | torch.Tensor | None = None,
+    enable_pdl: bool = False,
+) -> torch.Tensor:
+    return fp8_quantize(x, scale=scale, enable_pdl=enable_pdl)
+
+
+__all__ = [
+    "fp8_quantize",
+]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/triton.py
@@ -66,7 +66,7 @@ def _fp8_quantize_kernel(
     if HAS_SCALE:
         if HAS_SCALE_TENSOR:
             scale = tl.load(scale)
-        x = x / scale
+        x = x * (1.0 / scale)
     x_fp8 = x.to(FP8_DTYPE)
 
     out_off = m_idx[:, None] * out_row_stride + n_idx[None, :]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
@@ -86,9 +86,9 @@ if platform.is_nvidia:
                 scale = torch.empty(1, dtype=torch.float32, device=x.device)
                 _trtllm_per_tensor_quant_fp8(x, q, scale)
             else:
-                scale_shape = (*x.shape[:-1], 1)
-                scale = torch.empty(scale_shape, dtype=torch.float32, device=x.device)
+                scale = torch.empty(x.shape[:-1], dtype=torch.float32, device=x.device)
                 _trtllm_per_token_quant_fp8(x, q, scale)
+                scale = scale.unsqueeze(-1)
             return q, scale
 
         if granularity == "token_group":

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
@@ -18,21 +18,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""TRT-LLM fp8 quantize kernels exposed via the numerics registry.
+"""TRT-LLM fp8 quantize helpers.
 
-We pair these against torch reference implementations so per-SM accuracy gets
-exercised on every CI run. Each registered impl returns ``qweight.float()`` —
-the fp8 quantized values cast back to fp32 for comparison. We deliberately
-skip comparing the scale tensor: its memory layout (1D vs 2D, padded vs
-contiguous) differs between SM90 and SM100 in trtllm; the qweight values
-already prove the per-group statistics + rounding agree.
+Each helper returns ``qweight.float()`` so callers can compare quantized values
+without depending on TRT-LLM's scale tensor layout.
 """
 
 from __future__ import annotations
 
 import torch
-from tokenspeed_kernel.platform import ArchVersion, CapabilityRequirement, Platform
-from tokenspeed_kernel.registry import register_kernel
+from tokenspeed_kernel.platform import Platform
 from tokenspeed_kernel.thirdparty.trtllm import (
     per_tensor_quant_fp8 as _trtllm_per_tensor_quant_fp8,
 )
@@ -46,40 +41,11 @@ from tokenspeed_kernel.thirdparty.trtllm import (
 _FP8_DTYPE = Platform.get().fp8e4m3fn.dtype
 
 
-@register_kernel(
-    "quantize",
-    "fp8_token_group_128",
-    name="trtllm_fp8_token_group_128",
-    solution="trtllm",
-    capability=CapabilityRequirement(
-        min_arch_version=ArchVersion(9, 0),
-        vendors=frozenset({"nvidia"}),
-    ),
-    # The trtllm op asserts bf16-only input.
-    dtypes={torch.bfloat16},
-    traits={},
-    priority=12,
-    tags={"latency"},
-)
 def trtllm_fp8_token_group_128(x: torch.Tensor) -> torch.Tensor:
     qweight, _scale = _trtllm_per_token_group_quant_8bit(x, group_size=128)
     return qweight.float()
 
 
-@register_kernel(
-    "quantize",
-    "fp8_token",
-    name="trtllm_fp8_token",
-    solution="trtllm",
-    capability=CapabilityRequirement(
-        min_arch_version=ArchVersion(9, 0),
-        vendors=frozenset({"nvidia"}),
-    ),
-    dtypes={torch.bfloat16, torch.float16},
-    traits={},
-    priority=12,
-    tags={"latency"},
-)
 def trtllm_fp8_token(x: torch.Tensor) -> torch.Tensor:
     output = torch.empty_like(x, dtype=_FP8_DTYPE)
     scale = torch.empty(x.size(0), dtype=torch.float32, device=x.device)
@@ -87,20 +53,6 @@ def trtllm_fp8_token(x: torch.Tensor) -> torch.Tensor:
     return output.float()
 
 
-@register_kernel(
-    "quantize",
-    "fp8_tensor",
-    name="trtllm_fp8_tensor",
-    solution="trtllm",
-    capability=CapabilityRequirement(
-        min_arch_version=ArchVersion(9, 0),
-        vendors=frozenset({"nvidia"}),
-    ),
-    dtypes={torch.bfloat16, torch.float16},
-    traits={},
-    priority=12,
-    tags={"latency"},
-)
 def trtllm_fp8_tensor(x: torch.Tensor) -> torch.Tensor:
     output = torch.empty_like(x, dtype=_FP8_DTYPE)
     scale = torch.zeros(1, dtype=torch.float32, device=x.device)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
@@ -65,10 +65,7 @@ if platform.is_nvidia:
         solution="trtllm",
         dtypes={torch.bfloat16, torch.float16},
         traits={
-            "granularity": frozenset({"tensor", "token", "token_group"}),
-            "group_size": frozenset({None, 128}),
-            "scale_layout": frozenset({"row_major", "linear"}),
-            "scale_dtype": frozenset({torch.float32}),
+            "granularity": frozenset({"tensor", "token", "token_group_128"}),
             "scale_encoding": frozenset({"float32", "ue8m0"}),
         },
         priority=Priority.PERFORMANT,
@@ -77,16 +74,9 @@ if platform.is_nvidia:
         x: torch.Tensor,
         granularity: str = "tensor",
         group_size: int | None = None,
-        num_token_padding: int | None = None,
-        scale_dtype: torch.dtype = torch.float32,
-        scale_layout: str = "row_major",
         scale_encoding: str = "float32",
-        eps: float = 1.0e-10,
         enable_pdl: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if num_token_padding is not None:
-            raise ValueError("TRT-LLM FP8 quantization does not support row padding")
-
         if granularity in {"tensor", "token"}:
             if scale_encoding != "float32":
                 raise ValueError(f"TRT-LLM {granularity} FP8 requires float32 scales")

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
@@ -27,7 +27,7 @@ without depending on TRT-LLM's scale tensor layout.
 from __future__ import annotations
 
 import torch
-from tokenspeed_kernel.platform import Platform, current_platform
+from tokenspeed_kernel.platform import current_platform
 from tokenspeed_kernel.registry import Priority, error_fn, register_kernel
 
 platform = current_platform()
@@ -35,6 +35,10 @@ platform = current_platform()
 _trtllm_per_tensor_quant_fp8 = error_fn
 _trtllm_per_token_group_quant_8bit = error_fn
 _trtllm_per_token_quant_fp8 = error_fn
+trtllm_fp8_token_group_128 = error_fn
+trtllm_fp8_token = error_fn
+trtllm_fp8_tensor = error_fn
+trtllm_quantize_fp8_with_scale = error_fn
 
 if platform.is_nvidia:
     from tokenspeed_kernel.thirdparty.trtllm import (
@@ -47,30 +51,23 @@ if platform.is_nvidia:
         per_token_quant_fp8 as _trtllm_per_token_quant_fp8,
     )
 
-_FP8_DTYPE = Platform.get().fp8e4m3fn.dtype
-trtllm_quantize_fp8_with_scale = error_fn
+    _FP8_DTYPE = platform.fp8e4m3fn.dtype
 
+    def trtllm_fp8_token_group_128(x: torch.Tensor) -> torch.Tensor:
+        qweight, _scale = _trtllm_per_token_group_quant_8bit(x, group_size=128)
+        return qweight.float()
 
-def trtllm_fp8_token_group_128(x: torch.Tensor) -> torch.Tensor:
-    qweight, _scale = _trtllm_per_token_group_quant_8bit(x, group_size=128)
-    return qweight.float()
+    def trtllm_fp8_token(x: torch.Tensor) -> torch.Tensor:
+        output = torch.empty_like(x, dtype=_FP8_DTYPE)
+        scale = torch.empty(x.size(0), dtype=torch.float32, device=x.device)
+        _trtllm_per_token_quant_fp8(x, output, scale)
+        return output.float()
 
-
-def trtllm_fp8_token(x: torch.Tensor) -> torch.Tensor:
-    output = torch.empty_like(x, dtype=_FP8_DTYPE)
-    scale = torch.empty(x.size(0), dtype=torch.float32, device=x.device)
-    _trtllm_per_token_quant_fp8(x, output, scale)
-    return output.float()
-
-
-def trtllm_fp8_tensor(x: torch.Tensor) -> torch.Tensor:
-    output = torch.empty_like(x, dtype=_FP8_DTYPE)
-    scale = torch.zeros(1, dtype=torch.float32, device=x.device)
-    _trtllm_per_tensor_quant_fp8(x, output, scale)
-    return output.float()
-
-
-if platform.is_nvidia:
+    def trtllm_fp8_tensor(x: torch.Tensor) -> torch.Tensor:
+        output = torch.empty_like(x, dtype=_FP8_DTYPE)
+        scale = torch.zeros(1, dtype=torch.float32, device=x.device)
+        _trtllm_per_tensor_quant_fp8(x, output, scale)
+        return output.float()
 
     @register_kernel(
         "quantization",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
@@ -32,13 +32,9 @@ from tokenspeed_kernel.registry import Priority, error_fn, register_kernel
 
 platform = current_platform()
 
-_trtllm_per_tensor_quant_fp8 = error_fn
-_trtllm_per_token_group_quant_8bit = error_fn
-_trtllm_per_token_quant_fp8 = error_fn
 trtllm_fp8_token_group_128 = error_fn
 trtllm_fp8_token = error_fn
 trtllm_fp8_tensor = error_fn
-trtllm_quantize_fp8_with_scale = error_fn
 
 if platform.is_nvidia:
     from tokenspeed_kernel.thirdparty.trtllm import (

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
@@ -17,13 +17,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-"""TRT-LLM fp8 quantize helpers.
-
-Each helper returns ``qweight.float()`` so callers can compare quantized values
-without depending on TRT-LLM's scale tensor layout.
-"""
-
 from __future__ import annotations
 
 import torch

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import torch
 from tokenspeed_kernel.platform import Platform
+from tokenspeed_kernel.registry import Priority, error_fn, register_kernel
 from tokenspeed_kernel.thirdparty.trtllm import (
     per_tensor_quant_fp8 as _trtllm_per_tensor_quant_fp8,
 )
@@ -39,6 +40,7 @@ from tokenspeed_kernel.thirdparty.trtllm import (
 )
 
 _FP8_DTYPE = Platform.get().fp8e4m3fn.dtype
+trtllm_quantize_fp8_with_scale = error_fn
 
 
 def trtllm_fp8_token_group_128(x: torch.Tensor) -> torch.Tensor:
@@ -58,3 +60,70 @@ def trtllm_fp8_tensor(x: torch.Tensor) -> torch.Tensor:
     scale = torch.zeros(1, dtype=torch.float32, device=x.device)
     _trtllm_per_tensor_quant_fp8(x, output, scale)
     return output.float()
+
+
+if (
+    _trtllm_per_tensor_quant_fp8 is not error_fn
+    and _trtllm_per_token_quant_fp8 is not error_fn
+    and _trtllm_per_token_group_quant_8bit is not error_fn
+):
+
+    @register_kernel(
+        "quantization",
+        "fp8_with_scale",
+        name="trtllm_quantize_fp8_with_scale",
+        solution="trtllm",
+        dtypes={torch.bfloat16, torch.float16},
+        traits={
+            "granularity": frozenset({"tensor", "token", "token_group"}),
+            "group_size": frozenset({None, 128}),
+            "scale_layout": frozenset({"row_major", "linear"}),
+            "scale_dtype": frozenset({torch.float32}),
+            "scale_encoding": frozenset({"float32", "ue8m0"}),
+        },
+        priority=Priority.PERFORMANT,
+        tags={"throughput"},
+    )
+    def trtllm_quantize_fp8_with_scale(
+        x: torch.Tensor,
+        granularity: str = "tensor",
+        group_size: int | None = None,
+        num_token_padding: int | None = None,
+        scale_dtype: torch.dtype = torch.float32,
+        scale_layout: str = "row_major",
+        scale_encoding: str = "float32",
+        eps: float = 1.0e-10,
+        enable_pdl: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if num_token_padding is not None:
+            raise ValueError("TRT-LLM FP8 quantization does not support row padding")
+
+        if granularity in {"tensor", "token"}:
+            if scale_encoding != "float32":
+                raise ValueError(f"TRT-LLM {granularity} FP8 requires float32 scales")
+
+            q = torch.empty_like(x, dtype=_FP8_DTYPE)
+            if granularity == "tensor":
+                scale = torch.empty(1, dtype=torch.float32, device=x.device)
+                _trtllm_per_tensor_quant_fp8(x, q, scale)
+            else:
+                scale_shape = (*x.shape[:-1], 1)
+                scale = torch.empty(scale_shape, dtype=torch.float32, device=x.device)
+                _trtllm_per_token_quant_fp8(x, q, scale)
+            return q, scale
+
+        if granularity == "token_group":
+            return _trtllm_per_token_group_quant_8bit(
+                x,
+                group_size=group_size,
+                use_ue8m0=scale_encoding == "ue8m0",
+            )
+
+        raise ValueError(f"unsupported TRT-LLM FP8 granularity: {granularity!r}")
+
+
+__all__ = [
+    "trtllm_fp8_token_group_128",
+    "trtllm_fp8_token",
+    "trtllm_fp8_tensor",
+]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
@@ -27,17 +27,25 @@ without depending on TRT-LLM's scale tensor layout.
 from __future__ import annotations
 
 import torch
-from tokenspeed_kernel.platform import Platform
+from tokenspeed_kernel.platform import Platform, current_platform
 from tokenspeed_kernel.registry import Priority, error_fn, register_kernel
-from tokenspeed_kernel.thirdparty.trtllm import (
-    per_tensor_quant_fp8 as _trtllm_per_tensor_quant_fp8,
-)
-from tokenspeed_kernel.thirdparty.trtllm import (
-    per_token_group_quant_8bit as _trtllm_per_token_group_quant_8bit,
-)
-from tokenspeed_kernel.thirdparty.trtllm import (
-    per_token_quant_fp8 as _trtllm_per_token_quant_fp8,
-)
+
+platform = current_platform()
+
+_trtllm_per_tensor_quant_fp8 = error_fn
+_trtllm_per_token_group_quant_8bit = error_fn
+_trtllm_per_token_quant_fp8 = error_fn
+
+if platform.is_nvidia:
+    from tokenspeed_kernel.thirdparty.trtllm import (
+        per_tensor_quant_fp8 as _trtllm_per_tensor_quant_fp8,
+    )
+    from tokenspeed_kernel.thirdparty.trtllm import (
+        per_token_group_quant_8bit as _trtllm_per_token_group_quant_8bit,
+    )
+    from tokenspeed_kernel.thirdparty.trtllm import (
+        per_token_quant_fp8 as _trtllm_per_token_quant_fp8,
+    )
 
 _FP8_DTYPE = Platform.get().fp8e4m3fn.dtype
 trtllm_quantize_fp8_with_scale = error_fn
@@ -62,11 +70,7 @@ def trtllm_fp8_tensor(x: torch.Tensor) -> torch.Tensor:
     return output.float()
 
 
-if (
-    _trtllm_per_tensor_quant_fp8 is not error_fn
-    and _trtllm_per_token_quant_fp8 is not error_fn
-    and _trtllm_per_token_group_quant_8bit is not error_fn
-):
+if platform.is_nvidia:
 
     @register_kernel(
         "quantization",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
@@ -72,7 +72,6 @@ if platform.is_nvidia:
             "scale_encoding": frozenset({"float32", "ue8m0"}),
         },
         priority=Priority.PERFORMANT,
-        tags={"throughput"},
     )
     def trtllm_quantize_fp8_with_scale(
         x: torch.Tensor,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/registry.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/registry.py
@@ -382,7 +382,7 @@ def load_builtin_kernels() -> None:
     import tokenspeed_kernel.ops.embedding  # noqa: F401
     import tokenspeed_kernel.ops.gemm  # noqa: F401
     import tokenspeed_kernel.ops.moe  # noqa: F401
-    import tokenspeed_kernel.ops.quantization  # noqa: F401
+    import tokenspeed_kernel.ops.quantization.triton  # noqa: F401
 
 
 def error_fn(*args, **kwargs):

--- a/tokenspeed-kernel/python/tokenspeed_kernel/registry.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/registry.py
@@ -382,7 +382,7 @@ def load_builtin_kernels() -> None:
     import tokenspeed_kernel.ops.embedding  # noqa: F401
     import tokenspeed_kernel.ops.gemm  # noqa: F401
     import tokenspeed_kernel.ops.moe  # noqa: F401
-    import tokenspeed_kernel.ops.quantization.triton  # noqa: F401
+    import tokenspeed_kernel.ops.quantization  # noqa: F401
 
 
 def error_fn(*args, **kwargs):

--- a/tokenspeed-kernel/test/conftest.py
+++ b/tokenspeed-kernel/test/conftest.py
@@ -45,7 +45,7 @@ from utils import make_sample_specs
 
 
 @pytest.fixture
-def require_registered_solution() -> Callable[[str, str, str, torch.dtype], None]:
+def require() -> Callable[[str, str, str, torch.dtype], None]:
     def _require(
         family: str,
         mode: str,

--- a/tokenspeed-kernel/test/conftest.py
+++ b/tokenspeed-kernel/test/conftest.py
@@ -21,9 +21,11 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
+import torch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "python"))
@@ -40,6 +42,29 @@ from tokenspeed_kernel.selection import (
     clear_config_overrides,
 )
 from utils import make_sample_specs
+
+
+@pytest.fixture
+def require_registered_solution() -> Callable[[str, str, str, torch.dtype], None]:
+    def _require(
+        family: str,
+        mode: str,
+        solution: str,
+        dtype: torch.dtype,
+    ) -> None:
+        from tokenspeed_kernel.platform import current_platform
+
+        specs = KernelRegistry.get().get_for_operator(
+            family,
+            mode,
+            platform=current_platform(),
+            dtype=dtype,
+            solution=solution,
+        )
+        if not specs:
+            pytest.skip(f"{family}.{mode} solution {solution!r} is not registered")
+
+    return _require
 
 
 @pytest.fixture

--- a/tokenspeed-kernel/test/ops/test_embedding.py
+++ b/tokenspeed-kernel/test/ops/test_embedding.py
@@ -23,24 +23,14 @@ from __future__ import annotations
 import pytest
 import torch
 from tokenspeed_kernel.ops.embedding import FusedSetKVBufferArg, apply_rope
-from tokenspeed_kernel.platform import current_platform
-from tokenspeed_kernel.registry import KernelRegistry
-
-
-def _skip_if_solution_unregistered(solution: str, dtype: torch.dtype) -> None:
-    specs = KernelRegistry.get().get_for_operator(
-        "embedding",
-        "rope",
-        platform=current_platform(),
-        dtype=dtype,
-        solution=solution,
-    )
-    if not specs:
-        pytest.skip(f"embedding.rope solution {solution!r} is not registered")
 
 
 @pytest.mark.parametrize("solution", ["triton", "cuda"])
-def test_rope_neox_full_bf16(device: str, solution: str) -> None:
+def test_rope_neox_full_bf16(
+    device: str,
+    solution: str,
+    require_registered_solution,
+) -> None:
     torch.manual_seed(0)
     num_tokens = 17
     num_q_heads = 8
@@ -49,7 +39,7 @@ def test_rope_neox_full_bf16(device: str, solution: str) -> None:
     rotary_dim = 128
     max_position = 1024
     dtype = torch.bfloat16
-    _skip_if_solution_unregistered(solution, dtype)
+    require_registered_solution("embedding", "rope", solution, dtype)
 
     inv_freq = 1.0 / (
         10000.0
@@ -103,7 +93,11 @@ def test_rope_neox_full_bf16(device: str, solution: str) -> None:
 
 
 @pytest.mark.parametrize("solution", ["triton", "cuda"])
-def test_rope_gptj_full_bf16(device: str, solution: str) -> None:
+def test_rope_gptj_full_bf16(
+    device: str,
+    solution: str,
+    require_registered_solution,
+) -> None:
     torch.manual_seed(1)
     num_tokens = 9
     num_q_heads = 4
@@ -112,7 +106,7 @@ def test_rope_gptj_full_bf16(device: str, solution: str) -> None:
     rotary_dim = 64
     max_position = 512
     dtype = torch.bfloat16
-    _skip_if_solution_unregistered(solution, dtype)
+    require_registered_solution("embedding", "rope", solution, dtype)
 
     inv_freq = 1.0 / (
         10000.0
@@ -166,7 +160,11 @@ def test_rope_gptj_full_bf16(device: str, solution: str) -> None:
 
 
 @pytest.mark.parametrize("solution", ["triton", "cuda"])
-def test_rope_neox_partial_bf16(device: str, solution: str) -> None:
+def test_rope_neox_partial_bf16(
+    device: str,
+    solution: str,
+    require_registered_solution,
+) -> None:
     torch.manual_seed(2)
     num_tokens = 5
     num_q_heads = 4
@@ -175,7 +173,7 @@ def test_rope_neox_partial_bf16(device: str, solution: str) -> None:
     rotary_dim = 64
     max_position = 256
     dtype = torch.bfloat16
-    _skip_if_solution_unregistered(solution, dtype)
+    require_registered_solution("embedding", "rope", solution, dtype)
 
     inv_freq = 1.0 / (
         10000.0
@@ -239,7 +237,11 @@ def test_rope_neox_partial_bf16(device: str, solution: str) -> None:
 
 
 @pytest.mark.parametrize("solution", ["triton", "cuda"])
-def test_rope_single_token(device: str, solution: str) -> None:
+def test_rope_single_token(
+    device: str,
+    solution: str,
+    require_registered_solution,
+) -> None:
     """Edge case: num_tokens == 1 (decode step)."""
     torch.manual_seed(4)
     num_tokens = 1
@@ -249,7 +251,7 @@ def test_rope_single_token(device: str, solution: str) -> None:
     rotary_dim = 128
     max_position = 64
     dtype = torch.bfloat16
-    _skip_if_solution_unregistered(solution, dtype)
+    require_registered_solution("embedding", "rope", solution, dtype)
 
     inv_freq = 1.0 / (
         10000.0
@@ -296,7 +298,11 @@ def test_rope_single_token(device: str, solution: str) -> None:
 
 
 @pytest.mark.parametrize("solution", ["triton", "cuda"])
-def test_rope_fused_set_kv_buffer(device: str, solution: str) -> None:
+def test_rope_fused_set_kv_buffer(
+    device: str,
+    solution: str,
+    require_registered_solution,
+) -> None:
     torch.manual_seed(5)
     num_tokens = 13
     num_q_heads = 4
@@ -306,7 +312,7 @@ def test_rope_fused_set_kv_buffer(device: str, solution: str) -> None:
     max_position = 512
     cache_size = 32
     dtype = torch.bfloat16
-    _skip_if_solution_unregistered(solution, dtype)
+    require_registered_solution("embedding", "rope", solution, dtype)
 
     inv_freq = 1.0 / (
         10000.0

--- a/tokenspeed-kernel/test/ops/test_embedding.py
+++ b/tokenspeed-kernel/test/ops/test_embedding.py
@@ -29,7 +29,7 @@ from tokenspeed_kernel.ops.embedding import FusedSetKVBufferArg, apply_rope
 def test_rope_neox_full_bf16(
     device: str,
     solution: str,
-    require_registered_solution,
+    require,
 ) -> None:
     torch.manual_seed(0)
     num_tokens = 17
@@ -39,7 +39,7 @@ def test_rope_neox_full_bf16(
     rotary_dim = 128
     max_position = 1024
     dtype = torch.bfloat16
-    require_registered_solution("embedding", "rope", solution, dtype)
+    require("embedding", "rope", solution, dtype)
 
     inv_freq = 1.0 / (
         10000.0
@@ -96,7 +96,7 @@ def test_rope_neox_full_bf16(
 def test_rope_gptj_full_bf16(
     device: str,
     solution: str,
-    require_registered_solution,
+    require,
 ) -> None:
     torch.manual_seed(1)
     num_tokens = 9
@@ -106,7 +106,7 @@ def test_rope_gptj_full_bf16(
     rotary_dim = 64
     max_position = 512
     dtype = torch.bfloat16
-    require_registered_solution("embedding", "rope", solution, dtype)
+    require("embedding", "rope", solution, dtype)
 
     inv_freq = 1.0 / (
         10000.0
@@ -163,7 +163,7 @@ def test_rope_gptj_full_bf16(
 def test_rope_neox_partial_bf16(
     device: str,
     solution: str,
-    require_registered_solution,
+    require,
 ) -> None:
     torch.manual_seed(2)
     num_tokens = 5
@@ -173,7 +173,7 @@ def test_rope_neox_partial_bf16(
     rotary_dim = 64
     max_position = 256
     dtype = torch.bfloat16
-    require_registered_solution("embedding", "rope", solution, dtype)
+    require("embedding", "rope", solution, dtype)
 
     inv_freq = 1.0 / (
         10000.0
@@ -240,7 +240,7 @@ def test_rope_neox_partial_bf16(
 def test_rope_single_token(
     device: str,
     solution: str,
-    require_registered_solution,
+    require,
 ) -> None:
     """Edge case: num_tokens == 1 (decode step)."""
     torch.manual_seed(4)
@@ -251,7 +251,7 @@ def test_rope_single_token(
     rotary_dim = 128
     max_position = 64
     dtype = torch.bfloat16
-    require_registered_solution("embedding", "rope", solution, dtype)
+    require("embedding", "rope", solution, dtype)
 
     inv_freq = 1.0 / (
         10000.0
@@ -301,7 +301,7 @@ def test_rope_single_token(
 def test_rope_fused_set_kv_buffer(
     device: str,
     solution: str,
-    require_registered_solution,
+    require,
 ) -> None:
     torch.manual_seed(5)
     num_tokens = 13
@@ -312,7 +312,7 @@ def test_rope_fused_set_kv_buffer(
     max_position = 512
     cache_size = 32
     dtype = torch.bfloat16
-    require_registered_solution("embedding", "rope", solution, dtype)
+    require("embedding", "rope", solution, dtype)
 
     inv_freq = 1.0 / (
         10000.0

--- a/tokenspeed-kernel/test/ops/test_quantization.py
+++ b/tokenspeed-kernel/test/ops/test_quantization.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import pytest
 import torch
-from tokenspeed_kernel.ops.quantization import fp8_quantize
+from tokenspeed_kernel.ops.quantization.triton import fp8_quantize
 
 FP8_E4M3_MAX = 448.0
 

--- a/tokenspeed-kernel/test/ops/test_quantization.py
+++ b/tokenspeed-kernel/test/ops/test_quantization.py
@@ -22,108 +22,216 @@ from __future__ import annotations
 
 import pytest
 import torch
-from tokenspeed_kernel import quantize_fp8
-from tokenspeed_kernel.ops.quantization.triton import fp8_quantize
+from tokenspeed_kernel import (
+    quantize_fp8,
+    quantize_fp8_with_scale,
+    quantize_mxfp8,
+    quantize_nvfp4,
+)
+from tokenspeed_kernel.platform import current_platform
+from tokenspeed_kernel.registry import KernelRegistry
 
-FP8_E4M3_MAX = 448.0
+
+def _skip_if_solution_unregistered(
+    mode: str,
+    solution: str,
+    dtype: torch.dtype,
+) -> None:
+    specs = KernelRegistry.get().get_for_operator(
+        "quantization",
+        mode,
+        platform=current_platform(),
+        dtype=dtype,
+        solution=solution,
+    )
+    if not specs:
+        pytest.skip(f"quantization.{mode} solution {solution!r} is not registered")
 
 
 def _bitwise_equal(a: torch.Tensor, b: torch.Tensor) -> bool:
     return torch.equal(a.view(torch.uint8), b.view(torch.uint8))
 
 
-def test_pure_cast_contig_bf16(device: str) -> None:
+@pytest.mark.parametrize("solution", ["triton"])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 2880),
+        (8, 2880),
+        (33, 2880),
+        (4, 4096),
+        (2, 1),
+        (3, 513),
+    ],
+)
+def test_quantize_fp8_pure_cast_bf16(
+    device: str,
+    solution: str,
+    shape: tuple[int, ...],
+) -> None:
     torch.manual_seed(0)
-    x = torch.randn(2048, 512, device=device, dtype=torch.bfloat16) * 50
-    ref = x.to(torch.float8_e4m3fn)
-    out = fp8_quantize(x)
+    dtype = torch.bfloat16
+    _skip_if_solution_unregistered("fp8", solution, dtype)
+
+    x = torch.randn(shape, device=device, dtype=dtype) * 50
+    fp8 = current_platform().fp8e4m3fn
+    ref = x.to(fp8.dtype)
+
+    out = quantize_fp8(x, solution=solution)
     torch.cuda.synchronize()
-    assert out.shape == ref.shape and out.dtype == ref.dtype
+
+    assert out.shape == ref.shape
+    assert out.dtype == ref.dtype
     assert _bitwise_equal(out, ref)
 
 
-def test_pure_cast_strided_v_slice(device: str) -> None:
-    """v = kv[..., qk_nope:] — the deepseek_v3.py call site shape."""
-    torch.manual_seed(0)
+@pytest.mark.parametrize("solution", ["triton"])
+def test_quantize_fp8_strided_slice(device: str, solution: str) -> None:
+    torch.manual_seed(1)
+    dtype = torch.bfloat16
+    _skip_if_solution_unregistered("fp8", solution, dtype)
+
     s, h, qk_nope, v_head = 4096, 16, 128, 128
-    kv = torch.randn(s, h, qk_nope + v_head, device=device, dtype=torch.bfloat16) * 50
+    kv = torch.randn(s, h, qk_nope + v_head, device=device, dtype=dtype) * 50
     v = kv[..., qk_nope:]
-    assert not v.is_contiguous(), "v must be a strided slice for this test"
-    ref = v.to(torch.float8_e4m3fn)
-    out = fp8_quantize(v)
+    assert not v.is_contiguous()
+
+    fp8 = current_platform().fp8e4m3fn
+    ref = v.to(fp8.dtype)
+
+    out = quantize_fp8(v, solution=solution)
     torch.cuda.synchronize()
+
     assert _bitwise_equal(out, ref)
 
 
-def test_pure_cast_1d(device: str) -> None:
-    torch.manual_seed(0)
-    x = torch.randn(1024, device=device, dtype=torch.bfloat16) * 50
-    ref = x.to(torch.float8_e4m3fn)
-    out = fp8_quantize(x)
-    torch.cuda.synchronize()
-    assert _bitwise_equal(out, ref)
-
-
-def test_pure_cast_fp16(device: str) -> None:
-    torch.manual_seed(0)
-    x = torch.randn(1024, 512, device=device, dtype=torch.float16) * 50
-    ref = x.to(torch.float8_e4m3fn)
-    out = fp8_quantize(x)
-    torch.cuda.synchronize()
-    assert _bitwise_equal(out, ref)
-
-
-def test_pure_cast_e5m2(device: str) -> None:
-    torch.manual_seed(0)
-    x = torch.randn(1024, 512, device=device, dtype=torch.bfloat16) * 50
-    ref = x.to(torch.float8_e5m2)
-    out = fp8_quantize(x, fp8_dtype=torch.float8_e5m2)
-    torch.cuda.synchronize()
-    assert out.dtype == torch.float8_e5m2
-    assert _bitwise_equal(out, ref)
-
-
+@pytest.mark.parametrize("solution", ["triton"])
 @pytest.mark.parametrize("scale", [2.0, 0.5, 7.5])
-def test_scaled_cast_matches_reference(device: str, scale: float) -> None:
-    """Scaled path matches the runtime reciprocal-multiply quantization recipe."""
-    torch.manual_seed(0)
-    x = torch.randn(2048, 512, device=device, dtype=torch.bfloat16) * 100
+def test_quantize_fp8_scale_float(
+    device: str,
+    solution: str,
+    scale: float,
+) -> None:
+    torch.manual_seed(2)
+    dtype = torch.bfloat16
+    _skip_if_solution_unregistered("fp8", solution, dtype)
+
+    x = torch.randn(2048, 512, device=device, dtype=dtype) * 100
+    fp8 = current_platform().fp8e4m3fn
     inv_scale = 1.0 / scale
     ref = (
-        (x.to(torch.float32) * inv_scale)
-        .clamp(-FP8_E4M3_MAX, FP8_E4M3_MAX)
-        .to(torch.float8_e4m3fn)
+        (x.to(torch.float32) * inv_scale).clamp(min=fp8.min, max=fp8.max).to(fp8.dtype)
     )
-    out = fp8_quantize(x, scale=scale)
+
+    out = quantize_fp8(x, scale=scale, solution=solution)
     torch.cuda.synchronize()
+
     assert _bitwise_equal(out, ref)
 
 
-def test_registered_quantize_fp8_matches_reference(device: str) -> None:
-    torch.manual_seed(0)
-    x = torch.randn(8, 2880, device=device, dtype=torch.bfloat16) * 100
+@pytest.mark.parametrize("solution", ["triton"])
+def test_quantize_fp8_scale_tensor(device: str, solution: str) -> None:
+    torch.manual_seed(3)
+    dtype = torch.bfloat16
+    _skip_if_solution_unregistered("fp8", solution, dtype)
+
+    x = torch.randn(8, 2880, device=device, dtype=dtype) * 100
     scale = torch.tensor([0.125], device=device, dtype=torch.float32)
+    fp8 = current_platform().fp8e4m3fn
     inv_scale = (1.0 / scale.to(torch.float32)).reshape(())
     ref = (
-        (x.to(torch.float32) * inv_scale)
-        .clamp(-FP8_E4M3_MAX, FP8_E4M3_MAX)
-        .to(torch.float8_e4m3fn)
+        (x.to(torch.float32) * inv_scale).clamp(min=fp8.min, max=fp8.max).to(fp8.dtype)
     )
-    out = quantize_fp8(x, scale=scale, solution="triton")
+
+    out = quantize_fp8(x, scale=scale, solution=solution)
     torch.cuda.synchronize()
+
     assert _bitwise_equal(out, ref)
 
 
-def test_rejects_unsupported_dtype(device: str) -> None:
-    x = torch.randn(64, 128, device=device, dtype=torch.float32)
-    with pytest.raises(AssertionError):
-        fp8_quantize(x)
+@pytest.mark.parametrize("solution", ["trtllm"])
+@pytest.mark.parametrize("granularity", ["tensor", "token"])
+def test_quantize_fp8_with_scale_tensor_and_token(
+    device: str,
+    solution: str,
+    granularity: str,
+) -> None:
+    torch.manual_seed(4)
+    dtype = torch.bfloat16
+    _skip_if_solution_unregistered("fp8_with_scale", solution, dtype)
+
+    x = torch.randn(16, 128, device=device, dtype=dtype) * 10
+    fp8 = current_platform().fp8e4m3fn
+
+    out, scale = quantize_fp8_with_scale(
+        x,
+        granularity=granularity,
+        solution=solution,
+    )
+    torch.cuda.synchronize()
+
+    assert out.shape == x.shape
+    assert out.dtype == fp8.dtype
+    assert scale.dtype == torch.float32
+    if granularity == "tensor":
+        assert scale.shape == (1,)
+    else:
+        assert scale.shape == (x.shape[0], 1)
 
 
-def test_rejects_non_stride1_inner(device: str) -> None:
-    """fp8_quantize requires stride(-1) == 1; reject otherwise."""
-    x = torch.randn(64, 128, device=device, dtype=torch.bfloat16)
-    transposed = x.t()  # stride(-1) = 128, stride(-2) = 1
-    assert transposed.stride(-1) != 1
-    with pytest.raises(AssertionError):
-        fp8_quantize(transposed)
+@pytest.mark.parametrize("solution", ["trtllm"])
+def test_quantize_fp8_with_scale_token_group(device: str, solution: str) -> None:
+    torch.manual_seed(5)
+    dtype = torch.bfloat16
+    _skip_if_solution_unregistered("fp8_with_scale", solution, dtype)
+
+    x = torch.randn(16, 256, device=device, dtype=dtype) * 10
+    fp8 = current_platform().fp8e4m3fn
+
+    out, scale = quantize_fp8_with_scale(
+        x,
+        granularity="token_group",
+        group_size=128,
+        solution=solution,
+    )
+    torch.cuda.synchronize()
+
+    assert out.shape == x.shape
+    assert out.dtype == fp8.dtype
+    assert scale.dtype == torch.float32
+    assert scale.numel() > 0
+
+
+@pytest.mark.parametrize("solution", ["flashinfer"])
+def test_quantize_mxfp8_shape_and_scale(device: str, solution: str) -> None:
+    torch.manual_seed(6)
+    dtype = torch.bfloat16
+    _skip_if_solution_unregistered("mxfp8", solution, dtype)
+
+    x = torch.randn(17, 2880, device=device, dtype=dtype)
+    out, scale = quantize_mxfp8(x, alignment=4096, solution=solution)
+    torch.cuda.synchronize()
+
+    assert out.shape[:-1] == x.shape[:-1]
+    assert out.shape[-1] == 4096
+    assert scale.numel() > 0
+
+
+@pytest.mark.parametrize("solution", ["flashinfer"])
+def test_quantize_nvfp4_shape_and_scale(device: str, solution: str) -> None:
+    torch.manual_seed(7)
+    dtype = torch.bfloat16
+    _skip_if_solution_unregistered("nvfp4", solution, dtype)
+
+    x = torch.randn(16, 256, device=device, dtype=dtype)
+    out, scale = quantize_nvfp4(
+        x,
+        global_scale=torch.tensor([0.125], device=device, dtype=torch.float32),
+        scale_size=16,
+        solution=solution,
+    )
+    torch.cuda.synchronize()
+
+    assert out.shape[:-1] == x.shape[:-1]
+    assert out.shape[-1] == x.shape[-1] // 2
+    assert scale.numel() > 0

--- a/tokenspeed-kernel/test/ops/test_quantization.py
+++ b/tokenspeed-kernel/test/ops/test_quantization.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import pytest
 import torch
+from tokenspeed_kernel import quantize_fp8
 from tokenspeed_kernel.ops.quantization.triton import fp8_quantize
 
 FP8_E4M3_MAX = 448.0
@@ -82,30 +83,35 @@ def test_pure_cast_e5m2(device: str) -> None:
     assert _bitwise_equal(out, ref)
 
 
-@pytest.mark.parametrize("scale_inv", [0.5, 2.0, 1.0 / 7.5])
-def test_scaled_cast_matches_reference(device: str, scale_inv: float) -> None:
-    """Scaled path: out = saturate((x * scale_inv) -> fp8). Compare bitwise to
-    the same recipe applied in eager torch."""
+@pytest.mark.parametrize("scale", [2.0, 0.5, 7.5])
+def test_scaled_cast_matches_reference(device: str, scale: float) -> None:
+    """Scaled path matches the runtime reciprocal-multiply quantization recipe."""
     torch.manual_seed(0)
     x = torch.randn(2048, 512, device=device, dtype=torch.bfloat16) * 100
+    inv_scale = 1.0 / scale
     ref = (
-        (x.to(torch.float32) * scale_inv)
+        (x.to(torch.float32) * inv_scale)
         .clamp(-FP8_E4M3_MAX, FP8_E4M3_MAX)
         .to(torch.float8_e4m3fn)
     )
-    out = fp8_quantize(x, scale_inv=scale_inv)
+    out = fp8_quantize(x, scale=scale)
     torch.cuda.synchronize()
     assert _bitwise_equal(out, ref)
 
 
-def test_preallocated_output(device: str) -> None:
+def test_registered_quantize_fp8_matches_reference(device: str) -> None:
     torch.manual_seed(0)
-    x = torch.randn(1024, 512, device=device, dtype=torch.bfloat16) * 50
-    out = torch.empty_like(x, dtype=torch.float8_e4m3fn)
-    ret = fp8_quantize(x, out=out)
+    x = torch.randn(8, 2880, device=device, dtype=torch.bfloat16) * 100
+    scale = torch.tensor([0.125], device=device, dtype=torch.float32)
+    inv_scale = (1.0 / scale.to(torch.float32)).reshape(())
+    ref = (
+        (x.to(torch.float32) * inv_scale)
+        .clamp(-FP8_E4M3_MAX, FP8_E4M3_MAX)
+        .to(torch.float8_e4m3fn)
+    )
+    out = quantize_fp8(x, scale=scale, solution="triton")
     torch.cuda.synchronize()
-    assert ret.data_ptr() == out.data_ptr()
-    assert _bitwise_equal(out, x.to(torch.float8_e4m3fn))
+    assert _bitwise_equal(out, ref)
 
 
 def test_rejects_unsupported_dtype(device: str) -> None:

--- a/tokenspeed-kernel/test/ops/test_quantization.py
+++ b/tokenspeed-kernel/test/ops/test_quantization.py
@@ -29,23 +29,6 @@ from tokenspeed_kernel import (
     quantize_nvfp4,
 )
 from tokenspeed_kernel.platform import current_platform
-from tokenspeed_kernel.registry import KernelRegistry
-
-
-def _skip_if_solution_unregistered(
-    mode: str,
-    solution: str,
-    dtype: torch.dtype,
-) -> None:
-    specs = KernelRegistry.get().get_for_operator(
-        "quantization",
-        mode,
-        platform=current_platform(),
-        dtype=dtype,
-        solution=solution,
-    )
-    if not specs:
-        pytest.skip(f"quantization.{mode} solution {solution!r} is not registered")
 
 
 def _bitwise_equal(a: torch.Tensor, b: torch.Tensor) -> bool:
@@ -68,10 +51,11 @@ def test_quantize_fp8_pure_cast_bf16(
     device: str,
     solution: str,
     shape: tuple[int, ...],
+    require_registered_solution,
 ) -> None:
     torch.manual_seed(0)
     dtype = torch.bfloat16
-    _skip_if_solution_unregistered("fp8", solution, dtype)
+    require_registered_solution("quantization", "fp8", solution, dtype)
 
     x = torch.randn(shape, device=device, dtype=dtype) * 50
     fp8 = current_platform().fp8e4m3fn
@@ -86,10 +70,14 @@ def test_quantize_fp8_pure_cast_bf16(
 
 
 @pytest.mark.parametrize("solution", ["triton"])
-def test_quantize_fp8_strided_slice(device: str, solution: str) -> None:
+def test_quantize_fp8_strided_slice(
+    device: str,
+    solution: str,
+    require_registered_solution,
+) -> None:
     torch.manual_seed(1)
     dtype = torch.bfloat16
-    _skip_if_solution_unregistered("fp8", solution, dtype)
+    require_registered_solution("quantization", "fp8", solution, dtype)
 
     s, h, qk_nope, v_head = 4096, 16, 128, 128
     kv = torch.randn(s, h, qk_nope + v_head, device=device, dtype=dtype) * 50
@@ -111,10 +99,11 @@ def test_quantize_fp8_scale_float(
     device: str,
     solution: str,
     scale: float,
+    require_registered_solution,
 ) -> None:
     torch.manual_seed(2)
     dtype = torch.bfloat16
-    _skip_if_solution_unregistered("fp8", solution, dtype)
+    require_registered_solution("quantization", "fp8", solution, dtype)
 
     x = torch.randn(2048, 512, device=device, dtype=dtype) * 100
     fp8 = current_platform().fp8e4m3fn
@@ -130,10 +119,14 @@ def test_quantize_fp8_scale_float(
 
 
 @pytest.mark.parametrize("solution", ["triton"])
-def test_quantize_fp8_scale_tensor(device: str, solution: str) -> None:
+def test_quantize_fp8_scale_tensor(
+    device: str,
+    solution: str,
+    require_registered_solution,
+) -> None:
     torch.manual_seed(3)
     dtype = torch.bfloat16
-    _skip_if_solution_unregistered("fp8", solution, dtype)
+    require_registered_solution("quantization", "fp8", solution, dtype)
 
     x = torch.randn(8, 2880, device=device, dtype=dtype) * 100
     scale = torch.tensor([0.125], device=device, dtype=torch.float32)
@@ -155,10 +148,11 @@ def test_quantize_fp8_with_scale_tensor_and_token(
     device: str,
     solution: str,
     granularity: str,
+    require_registered_solution,
 ) -> None:
     torch.manual_seed(4)
     dtype = torch.bfloat16
-    _skip_if_solution_unregistered("fp8_with_scale", solution, dtype)
+    require_registered_solution("quantization", "fp8_with_scale", solution, dtype)
 
     x = torch.randn(16, 128, device=device, dtype=dtype) * 10
     fp8 = current_platform().fp8e4m3fn
@@ -180,10 +174,14 @@ def test_quantize_fp8_with_scale_tensor_and_token(
 
 
 @pytest.mark.parametrize("solution", ["trtllm"])
-def test_quantize_fp8_with_scale_token_group(device: str, solution: str) -> None:
+def test_quantize_fp8_with_scale_token_group(
+    device: str,
+    solution: str,
+    require_registered_solution,
+) -> None:
     torch.manual_seed(5)
     dtype = torch.bfloat16
-    _skip_if_solution_unregistered("fp8_with_scale", solution, dtype)
+    require_registered_solution("quantization", "fp8_with_scale", solution, dtype)
 
     x = torch.randn(16, 256, device=device, dtype=dtype) * 10
     fp8 = current_platform().fp8e4m3fn
@@ -203,10 +201,14 @@ def test_quantize_fp8_with_scale_token_group(device: str, solution: str) -> None
 
 
 @pytest.mark.parametrize("solution", ["flashinfer"])
-def test_quantize_mxfp8_shape_and_scale(device: str, solution: str) -> None:
+def test_quantize_mxfp8_shape_and_scale(
+    device: str,
+    solution: str,
+    require_registered_solution,
+) -> None:
     torch.manual_seed(6)
     dtype = torch.bfloat16
-    _skip_if_solution_unregistered("mxfp8", solution, dtype)
+    require_registered_solution("quantization", "mxfp8", solution, dtype)
 
     x = torch.randn(17, 2880, device=device, dtype=dtype)
     out, scale = quantize_mxfp8(x, alignment=4096, solution=solution)
@@ -218,10 +220,14 @@ def test_quantize_mxfp8_shape_and_scale(device: str, solution: str) -> None:
 
 
 @pytest.mark.parametrize("solution", ["flashinfer"])
-def test_quantize_nvfp4_shape_and_scale(device: str, solution: str) -> None:
+def test_quantize_nvfp4_shape_and_scale(
+    device: str,
+    solution: str,
+    require_registered_solution,
+) -> None:
     torch.manual_seed(7)
     dtype = torch.bfloat16
-    _skip_if_solution_unregistered("nvfp4", solution, dtype)
+    require_registered_solution("quantization", "nvfp4", solution, dtype)
 
     x = torch.randn(16, 256, device=device, dtype=dtype)
     out, scale = quantize_nvfp4(

--- a/tokenspeed-kernel/test/ops/test_quantization.py
+++ b/tokenspeed-kernel/test/ops/test_quantization.py
@@ -51,11 +51,11 @@ def test_quantize_fp8_pure_cast_bf16(
     device: str,
     solution: str,
     shape: tuple[int, ...],
-    require_registered_solution,
+    require,
 ) -> None:
     torch.manual_seed(0)
     dtype = torch.bfloat16
-    require_registered_solution("quantization", "fp8", solution, dtype)
+    require("quantization", "fp8", solution, dtype)
 
     x = torch.randn(shape, device=device, dtype=dtype) * 50
     fp8 = current_platform().fp8e4m3fn
@@ -73,11 +73,11 @@ def test_quantize_fp8_pure_cast_bf16(
 def test_quantize_fp8_strided_slice(
     device: str,
     solution: str,
-    require_registered_solution,
+    require,
 ) -> None:
     torch.manual_seed(1)
     dtype = torch.bfloat16
-    require_registered_solution("quantization", "fp8", solution, dtype)
+    require("quantization", "fp8", solution, dtype)
 
     s, h, qk_nope, v_head = 4096, 16, 128, 128
     kv = torch.randn(s, h, qk_nope + v_head, device=device, dtype=dtype) * 50
@@ -99,11 +99,11 @@ def test_quantize_fp8_scale_float(
     device: str,
     solution: str,
     scale: float,
-    require_registered_solution,
+    require,
 ) -> None:
     torch.manual_seed(2)
     dtype = torch.bfloat16
-    require_registered_solution("quantization", "fp8", solution, dtype)
+    require("quantization", "fp8", solution, dtype)
 
     x = torch.randn(2048, 512, device=device, dtype=dtype) * 100
     fp8 = current_platform().fp8e4m3fn
@@ -122,11 +122,11 @@ def test_quantize_fp8_scale_float(
 def test_quantize_fp8_scale_tensor(
     device: str,
     solution: str,
-    require_registered_solution,
+    require,
 ) -> None:
     torch.manual_seed(3)
     dtype = torch.bfloat16
-    require_registered_solution("quantization", "fp8", solution, dtype)
+    require("quantization", "fp8", solution, dtype)
 
     x = torch.randn(8, 2880, device=device, dtype=dtype) * 100
     scale = torch.tensor([0.125], device=device, dtype=torch.float32)
@@ -148,11 +148,11 @@ def test_quantize_fp8_with_scale_tensor_and_token(
     device: str,
     solution: str,
     granularity: str,
-    require_registered_solution,
+    require,
 ) -> None:
     torch.manual_seed(4)
     dtype = torch.bfloat16
-    require_registered_solution("quantization", "fp8_with_scale", solution, dtype)
+    require("quantization", "fp8_with_scale", solution, dtype)
 
     x = torch.randn(16, 128, device=device, dtype=dtype) * 10
     fp8 = current_platform().fp8e4m3fn
@@ -177,11 +177,11 @@ def test_quantize_fp8_with_scale_tensor_and_token(
 def test_quantize_fp8_with_scale_token_group(
     device: str,
     solution: str,
-    require_registered_solution,
+    require,
 ) -> None:
     torch.manual_seed(5)
     dtype = torch.bfloat16
-    require_registered_solution("quantization", "fp8_with_scale", solution, dtype)
+    require("quantization", "fp8_with_scale", solution, dtype)
 
     x = torch.randn(16, 256, device=device, dtype=dtype) * 10
     fp8 = current_platform().fp8e4m3fn
@@ -204,11 +204,11 @@ def test_quantize_fp8_with_scale_token_group(
 def test_quantize_mxfp8_shape_and_scale(
     device: str,
     solution: str,
-    require_registered_solution,
+    require,
 ) -> None:
     torch.manual_seed(6)
     dtype = torch.bfloat16
-    require_registered_solution("quantization", "mxfp8", solution, dtype)
+    require("quantization", "mxfp8", solution, dtype)
 
     x = torch.randn(17, 2880, device=device, dtype=dtype)
     out, scale = quantize_mxfp8(x, alignment=4096, solution=solution)
@@ -223,11 +223,11 @@ def test_quantize_mxfp8_shape_and_scale(
 def test_quantize_nvfp4_shape_and_scale(
     device: str,
     solution: str,
-    require_registered_solution,
+    require,
 ) -> None:
     torch.manual_seed(7)
     dtype = torch.bfloat16
-    require_registered_solution("quantization", "nvfp4", solution, dtype)
+    require("quantization", "nvfp4", solution, dtype)
 
     x = torch.randn(16, 256, device=device, dtype=dtype)
     out, scale = quantize_nvfp4(

--- a/tokenspeed-kernel/test/ops/test_quantization.py
+++ b/tokenspeed-kernel/test/ops/test_quantization.py
@@ -211,11 +211,11 @@ def test_quantize_mxfp8_shape_and_scale(
     require("quantization", "mxfp8", solution, dtype)
 
     x = torch.randn(17, 2880, device=device, dtype=dtype)
-    out, scale = quantize_mxfp8(x, alignment=4096, solution=solution)
+    out, scale = quantize_mxfp8(x, solution=solution)
     torch.cuda.synchronize()
 
     assert out.shape[:-1] == x.shape[:-1]
-    assert out.shape[-1] == 4096
+    assert out.shape[-1] >= x.shape[-1]
     assert scale.numel() > 0
 
 
@@ -232,8 +232,7 @@ def test_quantize_nvfp4_shape_and_scale(
     x = torch.randn(16, 256, device=device, dtype=dtype)
     out, scale = quantize_nvfp4(
         x,
-        global_scale=torch.tensor([0.125], device=device, dtype=torch.float32),
-        scale_size=16,
+        scale=torch.tensor([0.125], device=device, dtype=torch.float32),
         solution=solution,
     )
     torch.cuda.synchronize()


### PR DESCRIPTION
## Summary

Add shared quantization api for fp8 | fp8 with scale | mxfp8 | mxfp4 | nvfp4, backed by trtllm/flashinfer/triton kernels. Replace the torch impl of quant in runtime.

## Test Plan

Test on H100/B200/MI355.

```sh
pytest tokenspeed-kernel/test/ops/test_quantization.py"
```
