### PR TITLE
Revert "Update tokenspeed-kernel MLA to 0.1.4 (#215)"

### DIFF
--- a/tokenspeed-kernel/python/requirements/cuda-thirdparty.txt
+++ b/tokenspeed-kernel/python/requirements/cuda-thirdparty.txt
@@ -2,7 +2,7 @@ tokenspeed-deepep==1.2.1.post20251110
 tokenspeed-deepgemm==2.5.0.post20260424
 tilelang==0.1.9
 tokenspeed-flashmla==1.0.0.post20260429
-tokenspeed-mla==0.1.4
+tokenspeed-mla==0.1.3
 tokenspeed-fast-hadamard-transform==1.1.0.post20251110
 tokenspeed-fa3==3.0.0.post20260408
 tokenspeed-fa4==4.0.0.post20260510


### PR DESCRIPTION
Revert https://github.com/lightseekorg/tokenspeed/commit/a4df8b66593f023285324f68223b757442b98387 — bring `tokenspeed-kernel`'s `tokenspeed-mla` pin back to `0.1.3`.