### PR TITLE
ci: test in-tree tokenspeed-mla when its sources change

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -67,6 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.scan.outputs.matrix }}
+      install_tokenspeed_mla_from_source: ${{ steps.detect_mla.outputs.changed }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -96,6 +97,41 @@ jobs:
           MATRIX=$(python3 test/ci_system/pipeline.py scan --root test/ci --trigger "$TRIGGER")
           echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
 
+      # Compute this once on the hosted runner (where `gh` is pre-installed)
+      # and propagate the result to every matrix job via job output. The
+      # downstream unit-test job reads it as an env var and `install_deps.sh`
+      # gates its in-tree `tokenspeed-mla` reinstall on it. Without this
+      # detection, CI would always exercise the pinned PyPI wheel and edits
+      # under `tokenspeed-mla/` would be silently uncovered.
+      - name: Detect tokenspeed-mla source changes
+        id: detect_mla
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          case "${{ github.event_name }}" in
+            pull_request)
+              files=$(gh api \
+                "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+                --paginate -q '.[].filename')
+              ;;
+            push)
+              files=$(gh api \
+                "/repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.event.after }}" \
+                -q '.files[].filename')
+              ;;
+            *)
+              files=""
+              ;;
+          esac
+          if printf '%s\n' "$files" | grep -q '^tokenspeed-mla/'; then
+            echo "tokenspeed-mla touched by this run; in-tree source will be installed."
+            echo "changed=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "tokenspeed-mla untouched; keeping pinned PyPI wheel."
+            echo "changed=0" >> "$GITHUB_OUTPUT"
+          fi
+
   unit-test:
     needs: scan
     if: |
@@ -114,6 +150,11 @@ jobs:
     name: ${{ matrix.name }} / ${{ matrix.runner }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
+    env:
+      # When the scan job determined that this run touched `tokenspeed-mla/`,
+      # `install_deps.sh` will reinstall the in-tree source on top of the
+      # pinned PyPI wheel. See the matching detect step in the `scan` job.
+      INSTALL_TOKENSPEED_MLA_FROM_SOURCE: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -142,48 +183,6 @@ jobs:
       # `tokenspeed-kernel/python/requirements/cuda-thirdparty.txt`, not
       # the code on the PR/branch. When the diff doesn't touch
       # `tokenspeed-mla/` we keep using the pinned PyPI wheel.
-      - name: Detect tokenspeed-mla source changes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          # Use curl + python3 instead of `gh api`: the self-hosted GPU
-          # runners (b200 / b300 / h100 / gb200 / MI355) don't ship the
-          # gh CLI, so `gh: command not found` would silently leave the
-          # env var unset and skip the source override on every host.
-          case "${{ github.event_name }}" in
-            pull_request)
-              url="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=100"
-              ;;
-            push)
-              url="https://api.github.com/repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.event.after }}"
-              ;;
-            *)
-              echo "Unhandled event_name '${{ github.event_name }}'; assuming no tokenspeed-mla change."
-              exit 0
-              ;;
-          esac
-          changed=$(curl -sSL --fail \
-              -H "Authorization: Bearer $GH_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              "$url" \
-            | python3 -c '
-          import json, sys
-          d = json.load(sys.stdin)
-          files = d["files"] if isinstance(d, dict) and "files" in d else d
-          for f in files:
-              print(f["filename"])
-          ' \
-            | grep '^tokenspeed-mla/' || true)
-          if [ -n "$changed" ]; then
-            echo "tokenspeed-mla touched by this run; will reinstall from source"
-            echo "$changed"
-            echo "INSTALL_TOKENSPEED_MLA_FROM_SOURCE=1" >> "$GITHUB_ENV"
-          else
-            echo "tokenspeed-mla not touched; keeping pinned PyPI wheel."
-          fi
-
       - name: Install CI task
         run: |
           cd "${{ env.WORK_DIR }}"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -11,6 +11,7 @@ on:
       - "python/pyproject.toml"
       - "python/tokenspeed/**"
       - "tokenspeed-kernel/**"
+      - "tokenspeed-mla/**"
       - "tokenspeed-scheduler/**"
       - "test/**"
       - ".github/workflows/pr-test.yml"
@@ -21,6 +22,7 @@ on:
       - "python/pyproject.toml"
       - "python/tokenspeed/**"
       - "tokenspeed-kernel/**"
+      - "tokenspeed-mla/**"
       - "tokenspeed-scheduler/**"
       - "test/**"
       - ".github/workflows/pr-test.yml"
@@ -131,6 +133,39 @@ jobs:
             sleep 10
           done
           exit 1
+
+      # When the diff touches `tokenspeed-mla/`, ask install_deps.sh to
+      # rebuild + install that package from the in-tree source after the
+      # pinned PyPI wheel has been installed (transitively via
+      # tokenspeed-kernel). Without this, CI keeps testing whichever
+      # `tokenspeed-mla` version is pinned in
+      # `tokenspeed-kernel/python/requirements/cuda-thirdparty.txt`, not
+      # the code on the PR/branch. When the diff doesn't touch
+      # `tokenspeed-mla/` we keep using the pinned PyPI wheel.
+      - name: Detect tokenspeed-mla source changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          changed=""
+          case "${{ github.event_name }}" in
+            pull_request)
+              changed=$(gh api \
+                "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+                --paginate -q '.[].filename' \
+                | grep '^tokenspeed-mla/' || true)
+              ;;
+            push)
+              changed=$(gh api \
+                "/repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.event.after }}" \
+                -q '.files[].filename' \
+                | grep '^tokenspeed-mla/' || true)
+              ;;
+          esac
+          if [ -n "$changed" ]; then
+            echo "tokenspeed-mla touched by this run; will reinstall from source"
+            echo "INSTALL_TOKENSPEED_MLA_FROM_SOURCE=1" >> "$GITHUB_ENV"
+          fi
 
       - name: Install CI task
         run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -147,24 +147,41 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          changed=""
+          # Use curl + python3 instead of `gh api`: the self-hosted GPU
+          # runners (b200 / b300 / h100 / gb200 / MI355) don't ship the
+          # gh CLI, so `gh: command not found` would silently leave the
+          # env var unset and skip the source override on every host.
           case "${{ github.event_name }}" in
             pull_request)
-              changed=$(gh api \
-                "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-                --paginate -q '.[].filename' \
-                | grep '^tokenspeed-mla/' || true)
+              url="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files?per_page=100"
               ;;
             push)
-              changed=$(gh api \
-                "/repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.event.after }}" \
-                -q '.files[].filename' \
-                | grep '^tokenspeed-mla/' || true)
+              url="https://api.github.com/repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.event.after }}"
+              ;;
+            *)
+              echo "Unhandled event_name '${{ github.event_name }}'; assuming no tokenspeed-mla change."
+              exit 0
               ;;
           esac
+          changed=$(curl -sSL --fail \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$url" \
+            | python3 -c '
+          import json, sys
+          d = json.load(sys.stdin)
+          files = d["files"] if isinstance(d, dict) and "files" in d else d
+          for f in files:
+              print(f["filename"])
+          ' \
+            | grep '^tokenspeed-mla/' || true)
           if [ -n "$changed" ]; then
             echo "tokenspeed-mla touched by this run; will reinstall from source"
+            echo "$changed"
             echo "INSTALL_TOKENSPEED_MLA_FROM_SOURCE=1" >> "$GITHUB_ENV"
+          else
+            echo "tokenspeed-mla not touched; keeping pinned PyPI wheel."
           fi
 
       - name: Install CI task

--- a/test/ci_system/install_deps.sh
+++ b/test/ci_system/install_deps.sh
@@ -113,9 +113,23 @@ pip_install_with_retry pip3 install -e "./python[cuda_${SM}]" \
     --extra-index-url https://download.pytorch.org/whl/cu${CUINDEX}
 
 # ============================================================
-# Step 6: Fix Triton ptxas (CUDA 13+ only)
+# Step 6: Optionally override tokenspeed-mla with in-tree source
 # ============================================================
-echo "=== Step 6: Fix Triton ptxas ==="
+# Set by `.github/workflows/pr-test.yml` when the diff touches
+# `tokenspeed-mla/`. Without this override CI exercises whichever
+# `tokenspeed-mla` version is pinned in
+# `tokenspeed-kernel/python/requirements/cuda-thirdparty.txt` and the
+# in-tree change is silently ignored.
+if [ "${INSTALL_TOKENSPEED_MLA_FROM_SOURCE:-0}" = "1" ]; then
+    echo "=== Step 6: Reinstall tokenspeed-mla from in-tree source ==="
+    pip_install_with_retry pip3 install --break-system-packages \
+        --force-reinstall --no-deps "${WORKSPACE}/tokenspeed-mla"
+fi
+
+# ============================================================
+# Step 7: Fix Triton ptxas (CUDA 13+ only)
+# ============================================================
+echo "=== Step 7: Fix Triton ptxas ==="
 if [ "${CUDA_VERSION%%.*}" = "13" ]; then
     TRITON_BIN="/usr/local/lib/python3.12/dist-packages/triton/backends/nvidia/bin"
     if [ -d "${TRITON_BIN}" ]; then

--- a/tokenspeed-mla/README.md
+++ b/tokenspeed-mla/README.md
@@ -210,3 +210,4 @@ out, lse = tokenspeed_mla_prefill(
     enable_pdl=False,
 )
 ```
+<!-- ci: verify in-tree source install on tokenspeed-mla diff -->

--- a/tokenspeed-mla/README.md
+++ b/tokenspeed-mla/README.md
@@ -210,4 +210,3 @@ out, lse = tokenspeed_mla_prefill(
     enable_pdl=False,
 )
 ```
-<!-- ci: verify in-tree source install on tokenspeed-mla diff -->


### PR DESCRIPTION
## Summary

PR Test currently exercises whichever `tokenspeed-mla` version is pinned in `tokenspeed-kernel/python/requirements/cuda-thirdparty.txt`, so a PR that only edits files under `tokenspeed-mla/` is invisible to CI — the workflow's `paths:` filter doesn't list the directory, and `install_deps.sh` never reinstalls `tokenspeed-mla` from the working tree after the pinned PyPI wheel lands.

Plumb both ends:

- `pr-test.yml`: add `tokenspeed-mla/**` to the `push` / `pull_request` path filters so edits there trigger the suite.
- `pr-test.yml`: add a `Detect tokenspeed-mla source changes` step that queries the GitHub API for files touched by this run (`/pulls/N/files` for PRs, `/compare/before...after` for pushes); when any path under `tokenspeed-mla/` shows up, export `INSTALL_TOKENSPEED_MLA_FROM_SOURCE=1` into the job env.
- `install_deps.sh`: after the existing editable `tokenspeed` install (which transitively brings in the pinned `tokenspeed-mla` wheel), gate a `pip install --force-reinstall --no-deps ${WORKSPACE}/tokenspeed-mla` on that env var so the in-tree source overrides the wheel.

When the env var is unset, behavior is unchanged — PRs that don't touch `tokenspeed-mla/` keep using the pinned PyPI version.

## Test plan

- [ ] After merge, a PR touching only a file under `tokenspeed-mla/` triggers PR Test, the `Detect tokenspeed-mla source changes` step exports the env var, and `install_deps.sh` logs `=== Step 6: Reinstall tokenspeed-mla from in-tree source ===`.
- [ ] A PR not touching `tokenspeed-mla/` (e.g. a `python/tokenspeed/**` change) still triggers PR Test, the detect step finds no matches, and `install_deps.sh` keeps the pinned wheel.
