### PR TITLE
deps: bump tokenspeed-trtllm-kernel to 1.3.0rc15.post20260522+full

### DIFF
--- a/tokenspeed-kernel/python/requirements/cuda-thirdparty.txt
+++ b/tokenspeed-kernel/python/requirements/cuda-thirdparty.txt
@@ -7,4 +7,4 @@ tokenspeed-fast-hadamard-transform==1.1.0.post20251110
 tokenspeed-fa3==3.0.0.post20260408
 tokenspeed-fa4==4.0.0.post20260510
 tokenspeed-triton-kernels==1.0.0.post20260510
-tokenspeed-trtllm-kernel==1.2.1.post20260427
+tokenspeed-trtllm-kernel==1.3.0rc15.post20260522+full

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/trtllm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/trtllm/__init__.py
@@ -72,7 +72,10 @@ if platform.is_nvidia:
         def dsv3_fused_a_gemm(mat_a: torch.Tensor, mat_b: torch.Tensor) -> torch.Tensor:
             return torch.ops.trtllm.dsv3_fused_a_gemm_op(mat_a, mat_b, None, None)
 
-        # FP8 blockwise matmul helper.
+        # FP8 blockwise matmul helper. trtllm v1.3+ dropped the alpha and
+        # out_dtype parameters; the kernel hardcodes alpha=1.0 and selects
+        # the output dtype internally (bf16 on Blackwell). We cast to the
+        # caller's requested dtype if it differs.
         def fp8_blockwise_scaled_mm(
             mat_a: torch.Tensor,
             mat_b: torch.Tensor,
@@ -80,10 +83,10 @@ if platform.is_nvidia:
             scales_b: torch.Tensor,
             out_dtype: torch.dtype,
         ) -> torch.Tensor:
-            alpha = torch.tensor(1.0, dtype=torch.float32, device=mat_a.device)
-            return torch.ops.trtllm.fp8_block_scaling_gemm_impl(
-                mat_a, mat_b, alpha, scales_a, scales_b, out_dtype
+            result = torch.ops.trtllm.fp8_block_scaling_gemm_impl(
+                mat_a, mat_b, scales_a, scales_b
             )
+            return result if result.dtype == out_dtype else result.to(out_dtype)
 
         def per_token_group_quant_8bit(
             x: torch.Tensor,


### PR DESCRIPTION
## Summary
- Bump pin from `tokenspeed-trtllm-kernel==1.2.1.post20260427` (lite) → `==1.3.0rc15.post20260522+full` (full). Aligns with NVIDIA's official TensorRT-LLM v1.3.0rc15 release.
- Fix `fp8_blockwise_scaled_mm` wrapper: upstream `trtllm::fp8_block_scaling_gemm_impl` dropped `alpha` + `out_dtype` (now hardcoded inside kernel, dtype derived). Wrapper now uses the 4-arg form + post-cast.
- Other 7 wrappers match rc15 schemas unchanged.

## Upstream blockers found + addressed (in tokenspeed-trtllm-kernel)
- rc15 requires PTX ISA 9.1 (`cvt.e4m3x2.bf16x2` in `moeAlltoAllKernels.cu`). CUDA 13.0 ptxas rejects. Toolchain bumped to CUDA 13.1 (matches `nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc15`).
- `kernelParams.h` deleted upstream → struct moved to `trtllmGen_fmha_export/KernelParams.h`. Ported FMHA stride override + K/V pointer fallback to new locations.
- `TllmGenFmhaRunner` constructor split `dtypeKv` → `dtypeK`/`dtypeV`. `fmhaRunnerOp.cpp` wrapper updated.
- `nlohmann/json` now a hard dep (`FmhaOptions::toJson`). Added to BUILD_OPS_ONLY's FetchContent + include_directories.

Sister branches:
- `lightseekorg/tokenspeed-trtllm-kernel@upgrade/v1.3.0rc15` (patches + Dockerfile)
- `lightseekorg/tokenspeed-third-party@ci/trtllm-v1.3.0rc15` (workflow CUDA 13.1 + lite disabled)

Wheel built by workflow run #26304084690 (build steps green; release-publish step failed on GH_TOKEN scope — wheels available as artifacts).

## Test plan
- [ ] `ut-tokenspeed-kernel` matrix green on h100/b200/b300/gb200 (mi355 should skip cleanly — trtllm is nvidia-only)
- [ ] `test_numerics.py` covers 7 trtllm-backed registrations (3 gemm + 1 moe + 3 quantize) — must stay green
- [ ] Verify the wheel actually installs in CI (release-publish on lightseek-bot/tmp is currently blocked on token scope)