### PR TITLE
Perf[Qwen3.5]: some kernel fuse optimizations.

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -888,10 +888,9 @@ class MambaAttnBackend(AttentionBackend):
             batch_size = seq_len // draft_token_num
             # shouldn't use contiguous here, because causal_conv1d_update
             # support input non-contiguous
-            mixed_qkv_reshaped = (
-                mixed_qkv.view(batch_size, draft_token_num, -1)
-                .transpose(1, 2)
-            )
+            mixed_qkv_reshaped = mixed_qkv.view(
+                batch_size, draft_token_num, -1
+            ).transpose(1, 2)
             mixed_qkv_processed = causal_conv1d_update(
                 mixed_qkv_reshaped,
                 conv_states,
@@ -902,9 +901,7 @@ class MambaAttnBackend(AttentionBackend):
                 output_state_indices=output_indices[:batch_size],
             )
             # needn't contiguous here.
-            mixed_qkv = (
-                mixed_qkv_processed.transpose(1, 2).view(seq_len, -1)
-            )
+            mixed_qkv = mixed_qkv_processed.transpose(1, 2).view(seq_len, -1)
         else:
             conv_states, ssm_states = self.pool.get_mamba_params(layer_id)
             extend_prefix_lens = kwargs.get("extend_prefix_lens")

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -886,10 +886,11 @@ class MambaAttnBackend(AttentionBackend):
             output_indices = self.forward_metadata.mamba_output_indices
 
             batch_size = seq_len // draft_token_num
+            # shouldn't use contiguous here, because causal_conv1d_update
+            # support input non-contiguous
             mixed_qkv_reshaped = (
                 mixed_qkv.view(batch_size, draft_token_num, -1)
                 .transpose(1, 2)
-                .contiguous()
             )
             mixed_qkv_processed = causal_conv1d_update(
                 mixed_qkv_reshaped,
@@ -900,8 +901,9 @@ class MambaAttnBackend(AttentionBackend):
                 conv_state_indices=cache_indices[:batch_size],
                 output_state_indices=output_indices[:batch_size],
             )
+            # needn't contiguous here.
             mixed_qkv = (
-                mixed_qkv_processed.transpose(1, 2).contiguous().view(seq_len, -1)
+                mixed_qkv_processed.transpose(1, 2).view(seq_len, -1)
             )
         else:
             conv_states, ssm_states = self.pool.get_mamba_params(layer_id)

--- a/python/tokenspeed/runtime/models/qwen3_5.py
+++ b/python/tokenspeed/runtime/models/qwen3_5.py
@@ -31,7 +31,10 @@ import torch.nn as nn
 import triton
 import triton.language as tl
 from tokenspeed_kernel.ops.activation.triton import sigmoid_mul
-from tokenspeed_kernel.ops.layernorm.triton import qk_rmsnorm
+from tokenspeed_kernel.ops.layernorm.triton import (
+    fused_qk_rmsnorm_rope_gate,
+    qk_rmsnorm,
+)
 
 # Configs
 from tokenspeed.runtime.configs.qwen3_5_config import (
@@ -43,7 +46,6 @@ from tokenspeed.runtime.configs.qwen3_5_config import (
 from tokenspeed.runtime.distributed.comm_manager import CommManager
 from tokenspeed.runtime.distributed.mapping import Mapping
 from tokenspeed.runtime.execution.context import ForwardContext
-from tokenspeed.runtime.execution.cuda_graph_wrapper import get_is_capture_mode
 
 # Layers - Attention
 from tokenspeed.runtime.layers.attention.linear.layernorm_gated import (
@@ -108,7 +110,6 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         mapping: Mapping,
         layer_id: int,
         quant_config: QuantizationConfig | None = None,
-        alt_stream: torch.cuda.Stream | None = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -124,7 +125,6 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         self.head_v_dim = config.linear_value_head_dim
         self.key_dim = self.head_k_dim * self.num_k_heads
         self.value_dim = self.head_v_dim * self.num_v_heads
-        self.stream_fork = StreamFork(alt_stream)
 
         self.conv_kernel_size = config.linear_conv_kernel_dim
         self.layer_id = layer_id
@@ -145,33 +145,30 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         )
         self.conv1d.weight.data = self.conv1d.weight.data.unsqueeze(1)
 
-        self.in_proj_qkvz = MergedColumnParallelLinear(
+        self.in_proj_qkvzba = MergedColumnParallelLinear(
             input_size=self.hidden_size,
-            output_sizes=[self.key_dim, self.key_dim, self.value_dim, self.value_dim],
+            output_sizes=[
+                self.key_dim,
+                self.key_dim,
+                self.value_dim,
+                self.value_dim,
+                self.num_v_heads,
+                self.num_v_heads,
+            ],
             bias=False,
             quant_config=quant_config,
             tp_rank=self.attn_tp_rank,
             tp_size=self.attn_tp_size,
             tp_group=self.attn_tp_group,
-            prefix=add_prefix("in_proj_qkvz", prefix),
+            prefix=add_prefix("in_proj_qkvzba", prefix),
         )
-
-        self.in_proj_ba = MergedColumnParallelLinear(
-            input_size=self.hidden_size,
-            output_sizes=[self.num_v_heads, self.num_v_heads],
-            bias=False,
-            quant_config=quant_config,
-            tp_rank=self.attn_tp_rank,
-            tp_size=self.attn_tp_size,
-            tp_group=self.attn_tp_group,
-            prefix=add_prefix("in_proj_ba", prefix),
-        )
+        self._qkvz_dim = (self.key_dim * 2 + self.value_dim * 2) // self.attn_tp_size
+        self._ba_dim = (self.num_v_heads * 2) // self.attn_tp_size
 
         # Override weight loaders for packed checkpoint format.
         # Important: for FP8, this must cover not only `.weight` but also
         # `weight_scale_inv` / `weight_scale` / `input_scale` if present.
-        self._bind_packed_weight_loaders(self.in_proj_qkvz)
-        self._bind_packed_weight_loaders(self.in_proj_ba)
+        self._bind_packed_weight_loaders(self.in_proj_qkvzba)
 
         # Conv1d weight loader setup
         query_key_settings = (self.key_dim, 0, False)
@@ -294,8 +291,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
     @classmethod
     def _make_packed_weight_loader(cls, module, original_weight_loader):
         """Wrap the param's original loader so split checkpoints:
-          - in_proj_qkv + in_proj_z -> merged in_proj_qkvz
-          - in_proj_b + in_proj_a   -> merged in_proj_ba
+          - in_proj_qkv + in_proj_z + in_proj_b + in_proj_a -> merged in_proj_qkvzba
         can load correctly for both normal and FP8 params.
         """
 
@@ -355,15 +351,10 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         return query, key, value, z, b, a
 
     def _forward_input_proj(self, hidden_states: torch.Tensor):
-        DUAL_STREAM_TOKEN_THRESHOLD = 1024
-
-        seq_len, _ = hidden_states.shape
-        with self.stream_fork.scope(
-            enable=get_is_capture_mode() and seq_len < DUAL_STREAM_TOKEN_THRESHOLD
-        ) as fork:
-            projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
-            with fork.branch():
-                projected_states_ba, _ = self.in_proj_ba(hidden_states)
+        projected_all, _ = self.in_proj_qkvzba(hidden_states)
+        projected_states_qkvz, projected_states_ba = projected_all.split(
+            [self._qkvz_dim, self._ba_dim], dim=-1
+        )
         return projected_states_qkvz, projected_states_ba
 
     def forward(
@@ -459,7 +450,7 @@ class Qwen3_5LinearDecoderLayer(nn.Module):
             else quant_config
         )
         self.linear_attn = Qwen3_5GatedDeltaNet(
-            config, mapping, layer_id, linear_attn_quant_config, alt_stream, prefix
+            config, mapping, layer_id, linear_attn_quant_config, prefix=prefix
         )
 
         #  Determine the MLP type based on the model type
@@ -726,18 +717,24 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
             q_gate, k, v = qkv.split(
                 [self.q_size * 2, self.kv_size, self.kv_size], dim=-1
             )
-            orig_shape = q_gate.shape[:-1]
-            q_gate = q_gate.view(*orig_shape, self.num_heads, -1)
-            q, gate = torch.chunk(q_gate, 2, dim=-1)
-            q = q.reshape(*orig_shape, -1)
-            # gate stays as the [..., num_heads, head_dim] strided view from
-            # chunk; sigmoid_mul reads it directly so the contiguous reshape
-            # is folded into the fused write.
+            q, k, gate = fused_qk_rmsnorm_rope_gate(
+                q_gate,
+                k,
+                self.q_norm.gemma_weight,
+                self.k_norm.gemma_weight,
+                self.rotary_emb.cos_sin_cache,
+                positions,
+                self.q_norm.variance_epsilon,
+                self.num_heads,
+                self.num_kv_heads,
+                self.head_dim,
+                self.rotary_emb.rotary_dim,
+            )
         else:
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+            q, k = self._apply_qk_norm(q, k)
+            q, k = self.rotary_emb(positions, q, k)
 
-        q, k = self._apply_qk_norm(q, k)
-        q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v, ctx, out_cache_loc)
 
         if self.attn_output_gate:
@@ -933,10 +930,14 @@ class Qwen3_5ForCausalLM(nn.Module):
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
             # GDN (GatedDeltaNet) linear attention projections
-            ("in_proj_qkvz.", "in_proj_qkv.", (0, 1, 2)),
-            ("in_proj_qkvz.", "in_proj_z.", 3),
-            ("in_proj_ba.", "in_proj_b.", 0),
-            ("in_proj_ba.", "in_proj_a.", 1),
+            # Split checkpoint format (separate qkv/z/b/a files)
+            ("in_proj_qkvzba.", "in_proj_qkv.", (0, 1, 2)),
+            ("in_proj_qkvzba.", "in_proj_z.", 3),
+            ("in_proj_qkvzba.", "in_proj_b.", 4),
+            ("in_proj_qkvzba.", "in_proj_a.", 5),
+            # Pre-packed checkpoint format (already merged qkvz and ba)
+            ("in_proj_qkvzba.", "in_proj_qkvz.", (0, 1, 2, 3)),
+            ("in_proj_qkvzba.", "in_proj_ba.", (4, 5)),
         ]
 
         loaded_params: set[str] = set()
@@ -1006,10 +1007,14 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
             # GDN (GatedDeltaNet) linear attention projections
-            ("in_proj_qkvz.", "in_proj_qkv.", (0, 1, 2)),
-            ("in_proj_qkvz.", "in_proj_z.", 3),
-            ("in_proj_ba.", "in_proj_b.", 0),
-            ("in_proj_ba.", "in_proj_a.", 1),
+            # Split checkpoint format (separate qkv/z/b/a files)
+            ("in_proj_qkvzba.", "in_proj_qkv.", (0, 1, 2)),
+            ("in_proj_qkvzba.", "in_proj_z.", 3),
+            ("in_proj_qkvzba.", "in_proj_b.", 4),
+            ("in_proj_qkvzba.", "in_proj_a.", 5),
+            # Pre-packed checkpoint format (already merged qkvz and ba)
+            ("in_proj_qkvzba.", "in_proj_qkvz.", (0, 1, 2, 3)),
+            ("in_proj_qkvzba.", "in_proj_ba.", (4, 5)),
         ]
 
         # Skip loading extra parameters for GPTQ/nvfp4 models.
@@ -1146,10 +1151,14 @@ class Qwen3_5ForConditionalGeneration(BaseCausalLM):
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
             # GDN (GatedDeltaNet) linear attention projections
-            ("in_proj_qkvz.", "in_proj_qkv.", (0, 1, 2)),
-            ("in_proj_qkvz.", "in_proj_z.", 3),
-            ("in_proj_ba.", "in_proj_b.", 0),
-            ("in_proj_ba.", "in_proj_a.", 1),
+            # Split checkpoint format (separate qkv/z/b/a files)
+            ("in_proj_qkvzba.", "in_proj_qkv.", (0, 1, 2)),
+            ("in_proj_qkvzba.", "in_proj_z.", 3),
+            ("in_proj_qkvzba.", "in_proj_b.", 4),
+            ("in_proj_qkvzba.", "in_proj_a.", 5),
+            # Pre-packed checkpoint format (already merged qkvz and ba)
+            ("in_proj_qkvzba.", "in_proj_qkvz.", (0, 1, 2, 3)),
+            ("in_proj_qkvzba.", "in_proj_ba.", (4, 5)),
         ]
 
         loaded_params: set[str] = set()
@@ -1223,10 +1232,14 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5ForConditionalGeneration):
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
             # GDN (GatedDeltaNet) linear attention projections
-            ("in_proj_qkvz.", "in_proj_qkv.", (0, 1, 2)),
-            ("in_proj_qkvz.", "in_proj_z.", 3),
-            ("in_proj_ba.", "in_proj_b.", 0),
-            ("in_proj_ba.", "in_proj_a.", 1),
+            # Split checkpoint format (separate qkv/z/b/a files)
+            ("in_proj_qkvzba.", "in_proj_qkv.", (0, 1, 2)),
+            ("in_proj_qkvzba.", "in_proj_z.", 3),
+            ("in_proj_qkvzba.", "in_proj_b.", 4),
+            ("in_proj_qkvzba.", "in_proj_a.", 5),
+            # Pre-packed checkpoint format (already merged qkvz and ba)
+            ("in_proj_qkvzba.", "in_proj_qkvz.", (0, 1, 2, 3)),
+            ("in_proj_qkvzba.", "in_proj_ba.", (4, 5)),
         ]
 
         ignore_suffixes = (
@@ -1335,6 +1348,8 @@ def fused_qkvzba_split_reshape_cat_contiguous_kernel(
     a,
     mixed_qkvz,
     mixed_ba,
+    stride_qkvz,
+    stride_ba,
     NUM_HEADS_QK: tl.constexpr,
     NUM_HEADS_V: tl.constexpr,
     HEAD_QK: tl.constexpr,
@@ -1344,23 +1359,21 @@ def fused_qkvzba_split_reshape_cat_contiguous_kernel(
 
     V_PER_GROUP: tl.constexpr = NUM_HEADS_V // NUM_HEADS_QK
 
-    # ── Input dimensions (contiguous layout) ──
+    # ── Input dimensions ──
     TOTAL_Q: tl.constexpr = NUM_HEADS_QK * HEAD_QK
     TOTAL_K: tl.constexpr = NUM_HEADS_QK * HEAD_QK
     TOTAL_V: tl.constexpr = NUM_HEADS_V * HEAD_V
-    TOTAL_QKVZ: tl.constexpr = TOTAL_Q + TOTAL_K + TOTAL_V + TOTAL_V
-    TOTAL_BA: tl.constexpr = NUM_HEADS_V * 2
 
     # ── Output dimensions ──
     QKV_DIM_T: tl.constexpr = TOTAL_Q + TOTAL_K + TOTAL_V
 
-    # ── Read from contiguous input ──
+    # ── Read from input (supports non-contiguous stride) ──
     # q for head group i_qk: in the all_q region, offset i_qk * HEAD_QK
-    blk_q_ptr = mixed_qkvz + i_bs * TOTAL_QKVZ + i_qk * HEAD_QK + tl.arange(0, HEAD_QK)
+    blk_q_ptr = mixed_qkvz + i_bs * stride_qkvz + i_qk * HEAD_QK + tl.arange(0, HEAD_QK)
     # k for head group i_qk: in the all_k region
     blk_k_ptr = (
         mixed_qkvz
-        + i_bs * TOTAL_QKVZ
+        + i_bs * stride_qkvz
         + TOTAL_Q
         + i_qk * HEAD_QK
         + tl.arange(0, HEAD_QK)
@@ -1368,7 +1381,7 @@ def fused_qkvzba_split_reshape_cat_contiguous_kernel(
     # v for head group i_qk: in the all_v region
     blk_v_ptr = (
         mixed_qkvz
-        + i_bs * TOTAL_QKVZ
+        + i_bs * stride_qkvz
         + TOTAL_Q
         + TOTAL_K
         + i_qk * V_PER_GROUP * HEAD_V
@@ -1377,7 +1390,7 @@ def fused_qkvzba_split_reshape_cat_contiguous_kernel(
     # z for head group i_qk: in the all_z region
     blk_z_ptr = (
         mixed_qkvz
-        + i_bs * TOTAL_QKVZ
+        + i_bs * stride_qkvz
         + TOTAL_Q
         + TOTAL_K
         + TOTAL_V
@@ -1413,14 +1426,14 @@ def fused_qkvzba_split_reshape_cat_contiguous_kernel(
     tl.store(blk_v_st_ptr, tl.load(blk_v_ptr))
     tl.store(blk_z_st_ptr, tl.load(blk_z_ptr))
 
-    # ── b and a from contiguous [all_b | all_a] ──
+    # ── b and a ──
     for i in tl.static_range(V_PER_GROUP):
-        blk_b_ptr = mixed_ba + i_bs * TOTAL_BA + i_qk * V_PER_GROUP + i
+        blk_b_ptr = mixed_ba + i_bs * stride_ba + i_qk * V_PER_GROUP + i
         blk_b_st_ptr = b + i_bs * NUM_HEADS_V + i_qk * V_PER_GROUP + i
         tl.store(blk_b_st_ptr, tl.load(blk_b_ptr))
 
     for i in tl.static_range(V_PER_GROUP):
-        blk_a_ptr = mixed_ba + i_bs * TOTAL_BA + NUM_HEADS_V + i_qk * V_PER_GROUP + i
+        blk_a_ptr = mixed_ba + i_bs * stride_ba + NUM_HEADS_V + i_qk * V_PER_GROUP + i
         blk_a_st_ptr = a + i_bs * NUM_HEADS_V + i_qk * V_PER_GROUP + i
         tl.store(blk_a_st_ptr, tl.load(blk_a_ptr))
 
@@ -1433,13 +1446,13 @@ def fused_qkvzba_split_reshape_cat_contiguous(
     head_qk,
     head_v,
 ):
-    """Fused split/reshape/cat for CONTIGUOUS input format (Qwen3.5).
+    """Fused split/reshape/cat for Qwen3.5. Supports non-contiguous inputs.
 
-    Input layout:
+    Input layout (per row):
         mixed_qkvz: [all_q | all_k | all_v | all_z]
         mixed_ba:   [all_b | all_a]
 
-    Output layout (same as fused_qkvzba_split_reshape_cat):
+    Output layout:
         mixed_qkv: [all_q | all_k | all_v]  (z stripped)
         z: [num_v_heads, head_v]
         b: [num_v_heads]
@@ -1471,6 +1484,8 @@ def fused_qkvzba_split_reshape_cat_contiguous(
         a,
         mixed_qkvz,
         mixed_ba,
+        mixed_qkvz.stride(0),
+        mixed_ba.stride(0),
         num_heads_qk,
         num_heads_v,
         head_qk,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/layernorm/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/layernorm/triton.py
@@ -197,4 +197,207 @@ def qk_rmsnorm(
     return q_out, k_out
 
 
-__all__ = ["rmsnorm", "qk_rmsnorm"]
+@triton.jit
+def _fused_qk_rmsnorm_rope_gate_kernel(
+    q_gate_ptr,
+    k_ptr,
+    q_out_ptr,
+    k_out_ptr,
+    gate_out_ptr,
+    q_weight_ptr,
+    k_weight_ptr,
+    cos_sin_cache_ptr,
+    positions_ptr,
+    q_gate_stride_t,
+    k_stride_t,
+    q_out_stride_t,
+    k_out_stride_t,
+    gate_out_stride_t,
+    cache_stride_p,
+    num_q_heads: tl.constexpr,
+    num_kv_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    rotary_dim: tl.constexpr,
+    half_rotary: tl.constexpr,
+    eps: tl.constexpr,
+    INPUT_DTYPE: tl.constexpr,
+    HEAD_BLOCK: tl.constexpr,
+    ROT_HALF_BLOCK: tl.constexpr,
+    HAS_PASS: tl.constexpr,
+):
+    token = tl.program_id(0)
+    head = tl.program_id(1)
+    is_k = head >= num_q_heads
+    local_head = tl.where(is_k, head - num_q_heads, head)
+
+    if is_k:
+        in_base = k_ptr + token * k_stride_t + local_head * head_dim
+        w_ptr = k_weight_ptr
+        out_base = k_out_ptr + token * k_out_stride_t + local_head * head_dim
+    else:
+        in_base = q_gate_ptr + token * q_gate_stride_t + local_head * 2 * head_dim
+        w_ptr = q_weight_ptr
+        out_base = q_out_ptr + token * q_out_stride_t + local_head * head_dim
+
+    # --- RMSNorm: variance over the full head_dim ---
+    head_offs = tl.arange(0, HEAD_BLOCK)
+    head_mask = head_offs < head_dim
+    x = tl.load(in_base + head_offs, mask=head_mask, other=0.0).to(tl.float32)
+    var = tl.sum(x * x, axis=0) / head_dim
+    inv_rms = tl.rsqrt(var + eps)
+    w = tl.load(w_ptr + head_offs, mask=head_mask, other=0.0).to(tl.float32)
+    # Round-trip through INPUT_DTYPE so the RoPE input matches the bf16-storage
+    # behavior of the unfused (qk_rmsnorm → memory → apply_rope) reference path.
+    x_norm = (x * inv_rms * w).to(INPUT_DTYPE).to(tl.float32)
+
+    # --- Pass-through tail [rotary_dim, head_dim): RMSNorm-only, no rotation ---
+    # The rotary head [0, rotary_dim) will be overwritten by the RoPE store below.
+    if HAS_PASS:
+        pass_mask = head_mask & (head_offs >= rotary_dim)
+        tl.store(out_base + head_offs, x_norm, mask=pass_mask)
+
+    # --- Partial RoPE on the first rotary_dim elements ---
+    # Triton lacks easy sub-vector slicing of x_norm, so we recompute the
+    # normalized rotary halves on a smaller block (next_pow2(half_rotary)).
+    # The extra ~rotary_dim element reload hits L1, so the cost is negligible.
+    rot_offs = tl.arange(0, ROT_HALF_BLOCK)
+    rot_mask = rot_offs < half_rotary
+    x_rot1 = tl.load(in_base + rot_offs, mask=rot_mask, other=0.0).to(tl.float32)
+    x_rot2 = tl.load(
+        in_base + half_rotary + rot_offs, mask=rot_mask, other=0.0
+    ).to(tl.float32)
+    w_rot1 = tl.load(w_ptr + rot_offs, mask=rot_mask, other=0.0).to(tl.float32)
+    w_rot2 = tl.load(
+        w_ptr + half_rotary + rot_offs, mask=rot_mask, other=0.0
+    ).to(tl.float32)
+    x_rot1 = (x_rot1 * inv_rms * w_rot1).to(INPUT_DTYPE).to(tl.float32)
+    x_rot2 = (x_rot2 * inv_rms * w_rot2).to(INPUT_DTYPE).to(tl.float32)
+
+    # Always use int64 for position to avoid overflow in address computation.
+    pos = tl.load(positions_ptr + token).to(tl.int64)
+    cache_offset = pos * cache_stride_p
+    cos = tl.load(
+        cos_sin_cache_ptr + cache_offset + rot_offs, mask=rot_mask, other=0.0
+    ).to(tl.float32)
+    sin = tl.load(
+        cos_sin_cache_ptr + cache_offset + half_rotary + rot_offs,
+        mask=rot_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    o1 = x_rot1 * cos - x_rot2 * sin
+    o2 = x_rot2 * cos + x_rot1 * sin
+    tl.store(out_base + rot_offs, o1, mask=rot_mask)
+    tl.store(out_base + half_rotary + rot_offs, o2, mask=rot_mask)
+
+    # --- Gate copy (q heads only, verbatim) ---
+    if not is_k:
+        gate_in_base = in_base + head_dim
+        gate_out_base = (
+            gate_out_ptr + token * gate_out_stride_t + local_head * head_dim
+        )
+        g = tl.load(gate_in_base + head_offs, mask=head_mask, other=0.0)
+        tl.store(gate_out_base + head_offs, g, mask=head_mask)
+
+
+def fused_qk_rmsnorm_rope_gate(
+    q_gate: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    eps: float,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    rotary_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused split + QK-RMSNorm + (partial) RoPE + gate copy for Qwen3.5 attn.
+
+    Replaces 4 kernel launches (2 contiguous copies + qk_rmsnorm + RoPE)
+    with a single triton kernel.  Supports partial RoPE: only the first
+    ``rotary_dim`` elements of each head are rotated; the remaining
+    ``head_dim - rotary_dim`` elements pass through after RMSNorm only.
+    Qwen3.5 uses ``partial_rotary_factor=0.25``, so ``rotary_dim = head_dim // 4``.
+
+    Args:
+        q_gate: (n_tokens, num_q_heads * 2 * head_dim) — per head: [q|gate]
+        k: (n_tokens, num_kv_heads * head_dim)
+        q_weight: (head_dim,) GemmaRMSNorm weight (already +1)
+        k_weight: (head_dim,) GemmaRMSNorm weight (already +1)
+        cos_sin_cache: (max_pos, rotary_dim) packed [cos|sin], float32
+        positions: (n_tokens,) int32 or int64
+        eps: RMSNorm epsilon
+        num_q_heads: number of Q heads (after TP split)
+        num_kv_heads: number of KV heads (after TP split)
+        head_dim: per-head dimension
+        rotary_dim: rotary dimension; must be even and <= head_dim
+
+    Returns:
+        (q_out, k_out, gate_out) — all contiguous (n_tokens, heads * head_dim)
+    """
+    if rotary_dim <= 0 or rotary_dim > head_dim or rotary_dim % 2 != 0:
+        raise ValueError(
+            f"rotary_dim must be a positive even integer <= head_dim, "
+            f"got rotary_dim={rotary_dim}, head_dim={head_dim}"
+        )
+
+    n_tokens = q_gate.shape[0]
+    if n_tokens == 0:
+        q_out = torch.empty(
+            (0, num_q_heads * head_dim), dtype=q_gate.dtype, device=q_gate.device
+        )
+        k_out = torch.empty(
+            (0, num_kv_heads * head_dim), dtype=k.dtype, device=k.device
+        )
+        gate_out = torch.empty_like(q_out)
+        return q_out, k_out, gate_out
+
+    q_out = torch.empty(
+        (n_tokens, num_q_heads * head_dim), dtype=q_gate.dtype, device=q_gate.device
+    )
+    k_out = torch.empty(
+        (n_tokens, num_kv_heads * head_dim), dtype=k.dtype, device=k.device
+    )
+    gate_out = torch.empty_like(q_out)
+
+    half_rotary = rotary_dim // 2
+    head_block = triton.next_power_of_2(head_dim)
+    rot_half_block = triton.next_power_of_2(half_rotary)
+    num_warps = max(1, head_block // 64)
+
+    grid = (n_tokens, num_q_heads + num_kv_heads)
+    _fused_qk_rmsnorm_rope_gate_kernel[grid](
+        q_gate,
+        k,
+        q_out,
+        k_out,
+        gate_out,
+        q_weight,
+        k_weight,
+        cos_sin_cache,
+        positions,
+        q_gate.stride(0),
+        k.stride(0),
+        q_out.stride(0),
+        k_out.stride(0),
+        gate_out.stride(0),
+        cos_sin_cache.stride(0),
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+        rotary_dim,
+        half_rotary,
+        eps,
+        INPUT_DTYPE=tl.bfloat16 if q_gate.dtype == torch.bfloat16 else tl.float16,
+        HEAD_BLOCK=head_block,
+        ROT_HALF_BLOCK=rot_half_block,
+        HAS_PASS=rotary_dim < head_dim,
+        num_warps=num_warps,
+        num_stages=2,
+    )
+    return q_out, k_out, gate_out
+
+
+__all__ = ["rmsnorm", "qk_rmsnorm", "fused_qk_rmsnorm_rope_gate"]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/layernorm/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/layernorm/triton.py
@@ -263,13 +263,13 @@ def _fused_qk_rmsnorm_rope_gate_kernel(
     rot_offs = tl.arange(0, ROT_HALF_BLOCK)
     rot_mask = rot_offs < half_rotary
     x_rot1 = tl.load(in_base + rot_offs, mask=rot_mask, other=0.0).to(tl.float32)
-    x_rot2 = tl.load(
-        in_base + half_rotary + rot_offs, mask=rot_mask, other=0.0
-    ).to(tl.float32)
+    x_rot2 = tl.load(in_base + half_rotary + rot_offs, mask=rot_mask, other=0.0).to(
+        tl.float32
+    )
     w_rot1 = tl.load(w_ptr + rot_offs, mask=rot_mask, other=0.0).to(tl.float32)
-    w_rot2 = tl.load(
-        w_ptr + half_rotary + rot_offs, mask=rot_mask, other=0.0
-    ).to(tl.float32)
+    w_rot2 = tl.load(w_ptr + half_rotary + rot_offs, mask=rot_mask, other=0.0).to(
+        tl.float32
+    )
     x_rot1 = (x_rot1 * inv_rms * w_rot1).to(INPUT_DTYPE).to(tl.float32)
     x_rot2 = (x_rot2 * inv_rms * w_rot2).to(INPUT_DTYPE).to(tl.float32)
 
@@ -293,9 +293,7 @@ def _fused_qk_rmsnorm_rope_gate_kernel(
     # --- Gate copy (q heads only, verbatim) ---
     if not is_k:
         gate_in_base = in_base + head_dim
-        gate_out_base = (
-            gate_out_ptr + token * gate_out_stride_t + local_head * head_dim
-        )
+        gate_out_base = gate_out_ptr + token * gate_out_stride_t + local_head * head_dim
         g = tl.load(gate_in_base + head_offs, mask=head_mask, other=0.0)
         tl.store(gate_out_base + head_offs, g, mask=head_mask)
 

--- a/tokenspeed-kernel/test/ops/test_layernorm.py
+++ b/tokenspeed-kernel/test/ops/test_layernorm.py
@@ -189,7 +189,9 @@ def _ref_qk_rmsnorm_rope_gate(
     # 3. Partial RoPE on the first rotary_dim elements of each head.
     half_rotary = rotary_dim // 2
     cos = cos_sin_cache[positions, :half_rotary].unsqueeze(1).to(torch.float32)
-    sin = cos_sin_cache[positions, half_rotary:rotary_dim].unsqueeze(1).to(torch.float32)
+    sin = (
+        cos_sin_cache[positions, half_rotary:rotary_dim].unsqueeze(1).to(torch.float32)
+    )
 
     def _apply_partial_rope(x: torch.Tensor, num_heads: int) -> torch.Tensor:
         x_h = x.reshape(n_tokens, num_heads, head_dim).to(torch.float32)

--- a/tokenspeed-kernel/test/ops/test_layernorm.py
+++ b/tokenspeed-kernel/test/ops/test_layernorm.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import pytest
 import torch
-from tokenspeed_kernel.ops.layernorm.triton import qk_rmsnorm, rmsnorm
+from tokenspeed_kernel.ops.layernorm.triton import (
+    fused_qk_rmsnorm_rope_gate,
+    qk_rmsnorm,
+    rmsnorm,
+)
 from tokenspeed_kernel.platform import current_platform
 
 platform = current_platform()
@@ -126,6 +130,224 @@ def test_qk_rmsnorm_gemma_weight_strided_qkv_split(device: str) -> None:
     torch.testing.assert_close(
         k_out, _gemma_ref(k, k_weight, head_dim, eps, dtype), atol=2e-2, rtol=2e-2
     )
+
+
+def _build_rope_cache(
+    rotary_dim: int, max_pos: int, base: float, device: str
+) -> torch.Tensor:
+    """Mirror tokenspeed.runtime.layers.rotary_embedding._compute_cos_sin_cache."""
+    inv_freq = 1.0 / (
+        base
+        ** (
+            torch.arange(0, rotary_dim, 2, dtype=torch.float, device=device)
+            / rotary_dim
+        )
+    )
+    t = torch.arange(max_pos, dtype=torch.float, device=device)
+    freqs = torch.einsum("i,j -> ij", t, inv_freq)
+    # Per-position layout: [cos(rotary_dim/2), sin(rotary_dim/2)] — total rotary_dim.
+    return torch.cat((freqs.cos(), freqs.sin()), dim=-1).contiguous()
+
+
+def _ref_qk_rmsnorm_rope_gate(
+    q_gate: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    eps: float,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    rotary_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pure-PyTorch reference matching unfused (split → qk_rmsnorm → apply_rope).
+
+    Mirrors the bf16 round-trips at the same boundaries as the production path:
+      1. GemmaRMSNorm computes fp32 then stores bf16  (qk_rmsnorm output)
+      2. RoPE reads bf16, computes fp32, stores bf16  (apply_rope_with_cos_sin_cache_inplace)
+    """
+    dtype = q_gate.dtype
+    n_tokens = q_gate.shape[0]
+
+    # 1. Split q_gate into q and gate per head.
+    q_gate_3d = q_gate.view(n_tokens, num_q_heads, 2 * head_dim)
+    q, gate = torch.chunk(q_gate_3d, 2, dim=-1)
+    q = q.reshape(n_tokens, num_q_heads * head_dim).contiguous()
+    gate = gate.reshape(n_tokens, num_q_heads * head_dim).contiguous()
+
+    # 2. GemmaRMSNorm over the full head_dim, with weight already +1.
+    def _rmsnorm(x: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
+        x_h = x.reshape(-1, head_dim).to(torch.float32)
+        var = x_h.pow(2).mean(dim=-1, keepdim=True)
+        return (x_h * torch.rsqrt(var + eps) * w).to(dtype).view(x.shape)
+
+    q_normed = _rmsnorm(q, q_weight)
+    k_normed = _rmsnorm(k, k_weight)
+
+    # 3. Partial RoPE on the first rotary_dim elements of each head.
+    half_rotary = rotary_dim // 2
+    cos = cos_sin_cache[positions, :half_rotary].unsqueeze(1).to(torch.float32)
+    sin = cos_sin_cache[positions, half_rotary:rotary_dim].unsqueeze(1).to(torch.float32)
+
+    def _apply_partial_rope(x: torch.Tensor, num_heads: int) -> torch.Tensor:
+        x_h = x.reshape(n_tokens, num_heads, head_dim).to(torch.float32)
+        x1 = x_h[..., :half_rotary]
+        x2 = x_h[..., half_rotary:rotary_dim]
+        o1 = x1 * cos - x2 * sin
+        o2 = x2 * cos + x1 * sin
+        out = x_h.clone()
+        out[..., :half_rotary] = o1
+        out[..., half_rotary:rotary_dim] = o2
+        return out.reshape(n_tokens, num_heads * head_dim).to(dtype)
+
+    q_out = _apply_partial_rope(q_normed, num_q_heads)
+    k_out = _apply_partial_rope(k_normed, num_kv_heads)
+    return q_out, k_out, gate
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "num_q_heads,num_kv_heads,head_dim,rotary_dim",
+    # Qwen3.5 production: head_dim=256, partial_rotary_factor=0.25 → rotary_dim=64.
+    # Other rows pin down full RoPE and an aggressive partial setting.
+    [
+        (16, 2, 256, 64),
+        (16, 2, 256, 256),
+        (32, 8, 128, 128),
+        (28, 4, 128, 32),
+    ],
+)
+def test_fused_qk_rmsnorm_rope_gate_matches_reference(
+    dtype: torch.dtype,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    rotary_dim: int,
+    device: str,
+) -> None:
+    """Fused kernel must match the unfused (qk_rmsnorm + apply_rope + gate split) path.
+
+    Regression test: an earlier version of the fused kernel hard-coded
+    ``rotary_dim == head_dim`` and silently corrupted both q/k and the
+    cos/sin cache reads on Qwen3.5 (rotary_dim=64, head_dim=256), tanking
+    the MTP speculative-decode acceptance rate.
+    """
+    num_tokens = 23
+    eps = 1e-6
+    max_pos = 1024
+
+    q_gate = torch.randn(
+        num_tokens, num_q_heads * 2 * head_dim, device=device, dtype=dtype
+    )
+    k = torch.randn(num_tokens, num_kv_heads * head_dim, device=device, dtype=dtype)
+    q_weight = torch.randn(head_dim, device=device, dtype=torch.float32) * 0.1
+    k_weight = torch.randn(head_dim, device=device, dtype=torch.float32) * 0.1
+    q_gemma_weight = q_weight + 1.0
+    k_gemma_weight = k_weight + 1.0
+    cos_sin_cache = _build_rope_cache(rotary_dim, max_pos, base=10000.0, device=device)
+    positions = torch.randint(
+        0, max_pos, (num_tokens,), device=device, dtype=torch.int64
+    )
+
+    q_out, k_out, gate_out = fused_qk_rmsnorm_rope_gate(
+        q_gate,
+        k,
+        q_gemma_weight,
+        k_gemma_weight,
+        cos_sin_cache,
+        positions,
+        eps,
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+        rotary_dim,
+    )
+
+    q_ref, k_ref, gate_ref = _ref_qk_rmsnorm_rope_gate(
+        q_gate,
+        k,
+        q_gemma_weight,
+        k_gemma_weight,
+        cos_sin_cache,
+        positions,
+        eps,
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+        rotary_dim,
+    )
+
+    torch.testing.assert_close(q_out, q_ref, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(k_out, k_ref, atol=2e-2, rtol=2e-2)
+    # Gate is a verbatim copy of the second-half slice of q_gate.
+    torch.testing.assert_close(gate_out, gate_ref, atol=0, rtol=0)
+
+
+def test_fused_qk_rmsnorm_rope_gate_empty(device: str) -> None:
+    """Zero-token batch returns correctly shaped empty tensors without launching."""
+    head_dim, rotary_dim = 256, 64
+    num_q_heads, num_kv_heads = 4, 1
+    q_gate = torch.empty(
+        0, num_q_heads * 2 * head_dim, device=device, dtype=torch.bfloat16
+    )
+    k = torch.empty(0, num_kv_heads * head_dim, device=device, dtype=torch.bfloat16)
+    weight = torch.ones(head_dim, device=device, dtype=torch.float32)
+    cos_sin_cache = _build_rope_cache(rotary_dim, 16, base=10000.0, device=device)
+    positions = torch.empty(0, device=device, dtype=torch.int64)
+
+    q_out, k_out, gate_out = fused_qk_rmsnorm_rope_gate(
+        q_gate,
+        k,
+        weight,
+        weight,
+        cos_sin_cache,
+        positions,
+        1e-6,
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+        rotary_dim,
+    )
+    assert q_out.shape == (0, num_q_heads * head_dim)
+    assert k_out.shape == (0, num_kv_heads * head_dim)
+    assert gate_out.shape == (0, num_q_heads * head_dim)
+
+
+@pytest.mark.parametrize("bad_rotary_dim", [0, -2, 65, 33])
+def test_fused_qk_rmsnorm_rope_gate_rejects_invalid_rotary_dim(
+    bad_rotary_dim: int, device: str
+) -> None:
+    """rotary_dim must be a positive even integer <= head_dim."""
+    head_dim = 64
+    num_q_heads, num_kv_heads, n = 2, 1, 3
+    q_gate = torch.randn(
+        n, num_q_heads * 2 * head_dim, device=device, dtype=torch.bfloat16
+    )
+    k = torch.randn(n, num_kv_heads * head_dim, device=device, dtype=torch.bfloat16)
+    weight = torch.ones(head_dim, device=device, dtype=torch.float32)
+    cos_sin_cache = _build_rope_cache(
+        max(2, bad_rotary_dim if bad_rotary_dim > 0 else 2),
+        16,
+        base=10000.0,
+        device=device,
+    )
+    positions = torch.zeros(n, device=device, dtype=torch.int64)
+    with pytest.raises(ValueError, match="rotary_dim"):
+        fused_qk_rmsnorm_rope_gate(
+            q_gate,
+            k,
+            weight,
+            weight,
+            cos_sin_cache,
+            positions,
+            1e-6,
+            num_q_heads,
+            num_kv_heads,
+            head_dim,
+            bad_rotary_dim,
+        )
 
 
 def test_rmsnorm_inplace(device: str) -> None:


### PR DESCRIPTION
## Summary

- Add a new fused Triton kernel fused_qk_rmsnorm_rope_gate that combines split + QK-RMSNorm + partial RoPE + gate copy into one kernel launch (replaces 4 separate kernel launches in the attention layer).

before  |  after
----- | ------
<img width="1282" height="410" alt="image" src="https://github.com/user-attachments/assets/055a3028-353e-456b-a72e-da0e5d2bc8ba" />  | <img width="1468" height="674" alt="image" src="https://github.com/user-attachments/assets/017a13e5-ad30-4da8-926d-b09f1b813a3c" />

- Fuse in_proj_qkvz and in_proj_ba into a single GEMM (in_proj_qkvzba) in Qwen3.5 GatedDeltaNet, eliminating one GEMM launch and the dual-stream scheduling overhead (StreamFork removed).
- Remove unnecessary .contiguous() calls in the Mamba decode path — causal_conv1d_update already supports non-contiguous inputs, saving two extra memory copies.

 before | opt
---- | ----
<img width="1622" height="606" alt="image" src="https://github.com/user-attachments/assets/a6ff649a-d1c9-4f0c-bbbe-1b92c7c9899f" /> |  <img width="1218" height="602" alt="image" src="https://github.com/user-attachments/assets/8d18edb4-181a-4089-b16b-cae8158f1b4c" />

- Update weight loading mappings across all 4 model classes (Qwen3_5ForCausalLM, Qwen3_5MoeForCausalLM, Qwen3_5ForConditionalGeneration, Qwen3_5MoeForConditionalGeneration) to support both split checkpoint format and pre-packed checkpoint format for the new merged projection.
- Fix fused_qkvzba_split_reshape_cat_contiguous_kernel to use explicit strides instead of assuming contiguous layout, enabling it to work with the fused GEMM output directly.

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
