### PR TITLE
perf(qwen3.5): reduce prefill memcpy sync and mamba update overhead

### DIFF
--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -502,6 +502,47 @@ class ModelExecutor:
         self.num_generated_tokens += int(results.output_lengths.sum().item())
         self.num_decode_steps += bs
 
+    @staticmethod
+    @torch.compile(dynamic=True)
+    def _compute_mtp_snapshot_indices(
+        valid_cache_lengths: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        accept_lengths: torch.Tensor,
+        output_indices: torch.Tensor,
+        track_indices: torch.Tensor,
+        sentinel: torch.Tensor,
+        page_size: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Fused elementwise pipeline computing snapshot src/dst for MTP.
+
+        All operations are batched and fused by torch.compile into a single
+        Triton kernel (plus the two gathers), eliminating the ~14 individual
+        elementwise kernel launches of the eager implementation.
+        """
+        new_cl = valid_cache_lengths[req_pool_indices]
+        old_cl = new_cl - accept_lengths.to(new_cl.dtype)
+        first_boundary = ((old_cl // page_size) + 1) * page_size
+
+        step_raw = first_boundary - old_cl - 1
+        max_col = output_indices.shape[1] - 1
+        step = step_raw.clamp(min=0, max=max_col).to(torch.int64)
+
+        bs = req_pool_indices.shape[0]
+        req_range = torch.arange(bs, device=req_pool_indices.device)
+        src_raw = output_indices[req_range, step].to(torch.int64)
+        dst_raw = track_indices.to(torch.int64)
+
+        invalid = (
+            (first_boundary > new_cl)
+            | (dst_raw < 0)
+            | (src_raw < 0)
+            | (src_raw == dst_raw)
+            | (step_raw < 0)
+        )
+        src = torch.where(invalid, sentinel, src_raw)
+        dst = torch.where(invalid, sentinel, dst_raw)
+        return src, dst
+
     def _snapshot_mamba_checkpoints(
         self,
         accept_lengths: torch.Tensor,
@@ -549,27 +590,15 @@ class ModelExecutor:
             if output_indices is None:
                 return
 
-            new_cl = self.runtime_states.valid_cache_lengths[req_pool_indices]
-            old_cl = new_cl - accept_lengths[:bs].to(device=dev, dtype=new_cl.dtype)
-            first_boundary = ((old_cl // page_size) + 1) * page_size
-
-            step_raw = first_boundary - old_cl - 1
-            max_col = output_indices.shape[1] - 1
-            step = step_raw.clamp(min=0, max=max_col).to(torch.int64)
-
-            req_range = torch.arange(bs, device=dev)
-            src_raw = output_indices[req_range, step].to(torch.int64)
-            dst_raw = track_indices.to(device=dev, dtype=torch.int64)
-
-            invalid = (
-                (first_boundary > new_cl)
-                | (dst_raw < 0)
-                | (src_raw < 0)
-                | (src_raw == dst_raw)
-                | (step_raw < 0)
+            src, dst = self._compute_mtp_snapshot_indices(
+                self.runtime_states.valid_cache_lengths,
+                req_pool_indices,
+                accept_lengths[:bs].to(device=dev),
+                output_indices,
+                track_indices,
+                sentinel,
+                page_size,
             )
-            src = torch.where(invalid, sentinel, src_raw)
-            dst = torch.where(invalid, sentinel, dst_raw)
 
             self.runtime_states.snapshot_mamba_checkpoints(
                 src,

--- a/python/tokenspeed/runtime/execution/runtime_states.py
+++ b/python/tokenspeed/runtime/execution/runtime_states.py
@@ -22,7 +22,8 @@
 import torch
 
 from tokenspeed.runtime.layers.attention.linear.mamba_state_scatter_triton import (
-    fused_mamba_state_snapshot,
+    fused_mamba_state_copy,
+    fused_mamba_state_zero,
 )
 from tokenspeed.runtime.utils import get_colorful_logger
 
@@ -84,23 +85,19 @@ class RuntimeStates:
             return
         if mamba_cow_src_indices is None:
             return
-        valid_mask = mamba_cow_src_indices[:bs] != -1
-        if not valid_mask.any():
-            return
-        if (mamba_pool_indices[:bs][valid_mask] == -1).any():
-            raise RuntimeError(
-                f"mamba_pool_indices contains -1 for requests needing COW copy: "
-                f"mamba_pool_indices={mamba_pool_indices[:bs].tolist()}, "
-                f"mamba_cow_src_indices={mamba_cow_src_indices[:bs].tolist()}"
-            )
-        src_indices = mamba_cow_src_indices[:bs][valid_mask].long()
-        dst_indices = mamba_pool_indices[:bs][valid_mask].long()
-        self.mamba_pool.conv_state[:, dst_indices] = self.mamba_pool.conv_state[
-            :, src_indices
-        ]
-        self.mamba_pool.ssm_state[:, dst_indices] = self.mamba_pool.ssm_state[
-            :, src_indices
-        ]
+        src_indices = mamba_cow_src_indices[:bs].long()
+        dst_indices = mamba_pool_indices[:bs].long()
+        # page_size=0 disables page-boundary filtering
+        fused_mamba_state_copy(
+            self.mamba_pool.conv_state,
+            src_indices,
+            dst_indices,
+        )
+        fused_mamba_state_copy(
+            self.mamba_pool.ssm_state,
+            src_indices,
+            dst_indices,
+        )
 
     def snapshot_mamba_checkpoints(
         self,
@@ -117,14 +114,14 @@ class RuntimeStates:
         """
         if self.mamba_pool is None or num_valid == 0:
             return
-        fused_mamba_state_snapshot(
+        fused_mamba_state_copy(
             self.mamba_pool.conv_state,
             src_indices,
             dst_indices,
             cache_lengths=cache_lengths,
             page_size=page_size,
         )
-        fused_mamba_state_snapshot(
+        fused_mamba_state_copy(
             self.mamba_pool.ssm_state,
             src_indices,
             dst_indices,
@@ -142,7 +139,9 @@ class RuntimeStates:
         """Clear Mamba states for newly allocated slots without prefix state."""
         if self.mamba_pool is None:
             return
-        valid_pool = mamba_pool_indices[:bs] != -1
+        pool_indices = mamba_pool_indices[:bs]
+        # Compute condition mask purely on GPU (no sync)
+        valid_pool = pool_indices != -1
         no_cow = (
             (mamba_cow_src_indices[:bs] == -1)
             if mamba_cow_src_indices is not None
@@ -154,8 +153,6 @@ class RuntimeStates:
             else torch.ones(bs, dtype=torch.bool, device=mamba_pool_indices.device)
         )
         zero_mask = valid_pool & no_cow & no_prefix
-        if not zero_mask.any():
-            return
-        indices = mamba_pool_indices[:bs][zero_mask].long()
-        self.mamba_pool.conv_state[:, indices] = 0
-        self.mamba_pool.ssm_state[:, indices] = 0
+        indices = torch.where(zero_mask, pool_indices, -1).long()
+        fused_mamba_state_zero(self.mamba_pool.conv_state, indices)
+        fused_mamba_state_zero(self.mamba_pool.ssm_state, indices)

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -55,6 +55,7 @@ class MambaForwardMetadata:
     mamba_output_indices: Optional[torch.Tensor] = None
     mamba_req_pool_indices: Optional[torch.Tensor] = None
     extend_prefix_lens: Optional[torch.Tensor] = None
+    extend_seq_lens_cpu: Optional[torch.Tensor] = None
     # Pre-computed src/dst indices for extracting Mamba prefix-cache snapshots.
     track_ssm_h_src: Optional[torch.Tensor] = None
     track_ssm_h_dst: Optional[torch.Tensor] = None
@@ -351,6 +352,7 @@ class MambaAttnBackend(AttentionBackend):
         )
 
         mamba_output_indices = None
+        extend_seq_lens_cpu = None
         if is_target_verify:
             draft_token_num = int(
                 kwargs.get("tokens_per_req", self.speculative_num_draft_tokens)
@@ -391,6 +393,9 @@ class MambaAttnBackend(AttentionBackend):
                     )
                     query_start_loc[:bs] = extend_start_loc
                     query_start_loc[bs] = extend_start_loc[-1] + extend_seq_lens[-1]
+                    extend_seq_lens_cpu = extend_seq_lens[:bs].to(
+                        device="cpu", dtype=torch.int32
+                    )
                 else:
                     extend_prefix_lens = kwargs.get("extend_prefix_lens")
                     if extend_prefix_lens is not None:
@@ -404,6 +409,7 @@ class MambaAttnBackend(AttentionBackend):
                         bs + 1, dtype=torch.int32, device=self.device
                     )
                     torch.cumsum(extend_lens, dim=0, out=query_start_loc[1:])
+                    extend_seq_lens_cpu = extend_lens.to(device="cpu")
         else:
             raise ValueError(f"Invalid forward mode: {forward_mode=}")
 
@@ -478,6 +484,7 @@ class MambaAttnBackend(AttentionBackend):
             mamba_output_indices=mamba_output_indices,
             mamba_req_pool_indices=req_pool_indices[:bs],
             extend_prefix_lens=kwargs.get("extend_prefix_lens"),
+            extend_seq_lens_cpu=extend_seq_lens_cpu,
             track_ssm_h_src=track_ssm_h_src,
             track_ssm_h_dst=track_ssm_h_dst,
             track_conv_indices=track_conv_indices,
@@ -905,6 +912,8 @@ class MambaAttnBackend(AttentionBackend):
             if extend_prefix_lens is None:
                 extend_prefix_lens = self.forward_metadata.extend_prefix_lens
             extend_seq_lens_cpu = kwargs.get("extend_seq_lens_cpu")
+            if extend_seq_lens_cpu is None:
+                extend_seq_lens_cpu = self.forward_metadata.extend_seq_lens_cpu
             has_initial_states = (
                 extend_prefix_lens > 0 if extend_prefix_lens is not None else None
             )

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -206,11 +206,7 @@ class SimpleMambaPool:
             steps = torch.arange(
                 draft_token_num - 1, dtype=torch.int32, device=working.device
             )
-            draft = (
-                draft_base
-                + req[:, None] * draft_slots_per_req
-                + steps[None, :]
-            )
+            draft = draft_base + req[:, None] * draft_slots_per_req + steps[None, :]
             output_indices[:, 1:] = torch.where(
                 valid[:, None] & (req >= 0)[:, None],
                 draft,

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -443,10 +443,6 @@ class MambaAttnBackend(AttentionBackend):
                     & (branch_lens < extend_lens)
                 )
                 track_mask = branch_inside & ((branch_lens % FLA_CHUNK_SIZE) == 0)
-                if (branch_inside & ~track_mask).any():
-                    raise RuntimeError(
-                        "Mamba branching seqlen must be aligned to FLA chunk size"
-                    )
 
                 page_size = getattr(self.pool, "page_size", 1)
                 final_lens = prefix + extend_lens

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -41,6 +41,7 @@ from tokenspeed.runtime.layers.attention.linear.fused_sigmoid_gating_recurrent i
     fused_sigmoid_gating_delta_rule_update,
 )
 from tokenspeed.runtime.layers.attention.linear.gdn import fused_gdn_gating
+from tokenspeed.runtime.layers.attention.linear.index import set_total_chunks_hint
 
 if TYPE_CHECKING:
     from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
@@ -410,6 +411,7 @@ class MambaAttnBackend(AttentionBackend):
                     )
                     torch.cumsum(extend_lens, dim=0, out=query_start_loc[1:])
                     extend_seq_lens_cpu = extend_lens.to(device="cpu")
+                set_total_chunks_hint(extend_seq_lens_cpu)
         else:
             raise ValueError(f"Invalid forward mode: {forward_mode=}")
 

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -180,6 +180,43 @@ class SimpleMambaPool:
         """Return mamba cache indices directly (allocated by C++ scheduler)."""
         return mamba_pool_indices.to(torch.int32)
 
+    @staticmethod
+    @torch.compile(dynamic=True)
+    def _build_mtp_output_indices_kernel(
+        output_indices: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        working_indices: torch.Tensor,
+        draft_base: int,
+        draft_slots_per_req: int,
+        draft_token_num: int,
+    ) -> None:
+        """Fused fill of MTP target-verify output index table.
+
+        Inductor fuses the working-column write and the draft-grid write into
+        as few elementwise kernels as possible.  The host-side early returns
+        (draft_token_num<=0, ``out is None``) are kept in the wrapper.
+        """
+        bs = working_indices.shape[0]
+        working = working_indices.to(torch.int32)
+        valid = working >= 0
+        output_indices[:, 0] = torch.where(valid, working, -1)
+
+        if draft_token_num > 1 and draft_slots_per_req > 0:
+            req = req_pool_indices[:bs].to(torch.int32)
+            steps = torch.arange(
+                draft_token_num - 1, dtype=torch.int32, device=working.device
+            )
+            draft = (
+                draft_base
+                + req[:, None] * draft_slots_per_req
+                + steps[None, :]
+            )
+            output_indices[:, 1:] = torch.where(
+                valid[:, None] & (req >= 0)[:, None],
+                draft,
+                -1,
+            )
+
     def get_mtp_output_indices(
         self,
         req_pool_indices: torch.Tensor,
@@ -202,26 +239,60 @@ class SimpleMambaPool:
         if draft_token_num <= 0:
             return output_indices
 
-        working = working_indices.to(torch.int32)
-        valid = working >= 0
-        output_indices[:, 0] = torch.where(valid, working, -1)
-
-        if draft_token_num > 1 and self.draft_slots_per_req > 0:
-            req = req_pool_indices[:bs].to(torch.int32)
-            steps = torch.arange(
-                draft_token_num - 1, dtype=torch.int32, device=working.device
-            )
-            draft = (
-                self.draft_base
-                + req[:, None] * self.draft_slots_per_req
-                + steps[None, :]
-            )
-            output_indices[:, 1:] = torch.where(
-                valid[:, None] & (req >= 0)[:, None],
-                draft,
-                -1,
-            )
+        self._build_mtp_output_indices_kernel(
+            output_indices,
+            req_pool_indices,
+            working_indices,
+            self.draft_base,
+            self.draft_slots_per_req,
+            draft_token_num,
+        )
         return output_indices
+
+    @staticmethod
+    @torch.compile(dynamic=True)
+    def _get_current_input_indices_kernel(
+        req_pool_indices: torch.Tensor,
+        working_indices: torch.Tensor,
+        current_input_indices_buf: torch.Tensor,
+        current_input_size: int,
+    ) -> torch.Tensor:
+        """Fused gather + masked-where for the no-COW path."""
+        n = working_indices.shape[0]
+        req = req_pool_indices[:n].to(torch.int32)
+        working = working_indices.to(torch.int32)
+        valid = (working >= 0) & (req >= 0)
+        safe = req.clamp(0, current_input_size - 1).to(torch.int64)
+        stored = current_input_indices_buf[safe]
+        current = torch.where(valid & (stored >= 0), stored, working)
+        current = torch.where(valid, current, torch.full_like(current, -1))
+        return current
+
+    @staticmethod
+    @torch.compile(dynamic=True)
+    def _get_current_input_indices_with_cow_kernel(
+        req_pool_indices: torch.Tensor,
+        working_indices: torch.Tensor,
+        cow_src_indices: torch.Tensor,
+        current_input_indices_buf: torch.Tensor,
+        current_input_size: int,
+    ) -> torch.Tensor:
+        """Fused gather + masked-where for the COW path."""
+        n = working_indices.shape[0]
+        req = req_pool_indices[:n].to(torch.int32)
+        working = working_indices.to(torch.int32)
+        cow = cow_src_indices[:n].to(torch.int32)
+        valid = (working >= 0) & (req >= 0)
+        safe = req.clamp(0, current_input_size - 1).to(torch.int64)
+        stored = current_input_indices_buf[safe]
+        current = torch.where(valid & (stored >= 0), stored, working)
+        current = torch.where(valid, current, torch.full_like(current, -1))
+        current = torch.where(
+            (cow >= 0) & valid & (current == working),
+            cow,
+            current,
+        )
+        return current
 
     def get_current_input_indices(
         self,
@@ -230,24 +301,20 @@ class SimpleMambaPool:
         cow_src_indices: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Return the row each request should read at the start of target verify."""
-        req_pool_indices = req_pool_indices[: working_indices.shape[0]].to(torch.int32)
-        working_indices = working_indices.to(torch.int32)
-        # Only keep >= 0 checks; upper bounds are guaranteed by the scheduler.
-        valid = (working_indices >= 0) & (req_pool_indices >= 0)
-        safe_req_indices = req_pool_indices.clamp(0, self.current_input_size - 1).long()
-        stored = self.current_input_indices[safe_req_indices]
-        current = torch.where(valid & (stored >= 0), stored, working_indices)
-        current = torch.where(valid, current, torch.full_like(current, -1))
-        if cow_src_indices is not None:
-            cow_src_indices = cow_src_indices[: working_indices.shape[0]].to(
-                torch.int32
+        if cow_src_indices is None:
+            return self._get_current_input_indices_kernel(
+                req_pool_indices,
+                working_indices,
+                self.current_input_indices,
+                self.current_input_size,
             )
-            current = torch.where(
-                (cow_src_indices >= 0) & valid & (current == working_indices),
-                cow_src_indices,
-                current,
-            )
-        return current
+        return self._get_current_input_indices_with_cow_kernel(
+            req_pool_indices,
+            working_indices,
+            cow_src_indices,
+            self.current_input_indices,
+            self.current_input_size,
+        )
 
     def reset_current_inputs(
         self, req_pool_indices: torch.Tensor, working_indices: torch.Tensor
@@ -257,6 +324,28 @@ class SimpleMambaPool:
         working_indices = working_indices.to(torch.int32)
         self.current_input_indices[req_pool_indices.long()] = working_indices
 
+    @staticmethod
+    @torch.compile(dynamic=True)
+    def _update_current_inputs_after_verify_kernel(
+        req_pool_indices: torch.Tensor,
+        output_indices: torch.Tensor,
+        accepted_lengths: torch.Tensor,
+        current_input_indices: torch.Tensor,
+        max_col: int,
+    ) -> None:
+        """Fused gather-scatter for the after-verify input pointer update.
+
+        Inductor fuses clamp/arange/sub/dtype-convert into a single elementwise
+        kernel; the gather and the in-place scatter on ``current_input_indices``
+        each remain a single kernel.  All tensors stay on GPU; no host sync.
+        """
+        n = accepted_lengths.shape[0]
+        req = req_pool_indices[:n].to(torch.int64)
+        idx = (accepted_lengths.clamp(min=1, max=max_col) - 1).to(torch.int64)
+        rows = torch.arange(n, device=accepted_lengths.device, dtype=torch.int64)
+        selected = output_indices[rows, idx].to(torch.int32)
+        current_input_indices[req] = selected
+
     def update_current_inputs_after_verify(
         self,
         req_pool_indices: torch.Tensor,
@@ -265,14 +354,13 @@ class SimpleMambaPool:
     ) -> None:
         if output_indices is None or output_indices.numel() == 0:
             return
-        n = accepted_lengths.shape[0]
-        req_pool_indices = req_pool_indices[:n].to(torch.int32)
-        accepted_lengths = accepted_lengths.clamp(
-            min=1, max=output_indices.shape[1]
-        ).to(torch.int32)
-        rows = torch.arange(n, device=accepted_lengths.device, dtype=torch.long)
-        selected = output_indices[rows, (accepted_lengths - 1).long()].to(torch.int32)
-        self.current_input_indices[req_pool_indices.long()] = selected
+        self._update_current_inputs_after_verify_kernel(
+            req_pool_indices,
+            output_indices,
+            accepted_lengths,
+            self.current_input_indices,
+            output_indices.shape[1],
+        )
 
     def get_mamba_params(self, layer_id: int):
         """Return per-layer cache slices."""

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -41,7 +41,10 @@ from tokenspeed.runtime.layers.attention.linear.fused_sigmoid_gating_recurrent i
     fused_sigmoid_gating_delta_rule_update,
 )
 from tokenspeed.runtime.layers.attention.linear.gdn import fused_gdn_gating
-from tokenspeed.runtime.layers.attention.linear.index import set_total_chunks_hint
+from tokenspeed.runtime.layers.attention.linear.index import (
+    set_total_chunks_hint,
+    set_total_chunks_hint_uniform,
+)
 
 if TYPE_CHECKING:
     from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
@@ -469,6 +472,7 @@ class MambaAttnBackend(AttentionBackend):
                     dtype=torch.int32,
                     device=self.device,
                 )
+                set_total_chunks_hint_uniform(bs, tokens_per_req, query_start_loc)
             else:
                 extend_start_loc = kwargs.get("extend_start_loc")
                 extend_seq_lens = kwargs.get("extend_seq_lens")
@@ -495,7 +499,7 @@ class MambaAttnBackend(AttentionBackend):
                     )
                     torch.cumsum(extend_lens, dim=0, out=query_start_loc[1:])
                     extend_seq_lens_cpu = extend_lens.to(device="cpu")
-                set_total_chunks_hint(extend_seq_lens_cpu)
+                set_total_chunks_hint(extend_seq_lens_cpu, query_start_loc)
         else:
             raise ValueError(f"Invalid forward mode: {forward_mode=}")
 

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -638,12 +638,12 @@ register_backend("trtllm", {AttentionArch.MHA}, TRTLLMMHAAttnBackend)
 
 @triton.jit
 def _gather_page_table_with_padding_kernel(
-    req_to_page_ptr,        # [req_pool_size+1, src_stride0] int32
-    req_pool_indices_ptr,   # [bs] int32 or int64
-    seq_lens_ptr,           # [bs] int32 — KV length per req
-    out_ptr,                # [max_bs, max_num_pages] int32
-    src_stride0,            # row stride of req_to_page
-    out_stride0,            # row stride of cuda_graph_page_table
+    req_to_page_ptr,  # [req_pool_size+1, src_stride0] int32
+    req_pool_indices_ptr,  # [bs] int32 or int64
+    seq_lens_ptr,  # [bs] int32 — KV length per req
+    out_ptr,  # [max_bs, max_num_pages] int32
+    src_stride0,  # row stride of req_to_page
+    out_stride0,  # row stride of cuda_graph_page_table
     max_num_pages: tl.constexpr,
     page_size: tl.constexpr,
     dummy_slot: tl.constexpr,

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import torch
+import triton
+import triton.language as tl
 from tokenspeed_kernel.ops.attention.flashinfer import (
     trtllm_batch_context_with_kv_cache,
     trtllm_batch_decode_with_kv_cache,
@@ -562,6 +564,37 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         self.cuda_graph_prefill_metadata[bs] = metadata
         self.forward_prefill_metadata = metadata
 
+    def _replay_gather_page_table(
+        self,
+        bs: int,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        req_to_page: torch.Tensor,
+    ) -> None:
+        """Refresh cuda_graph_page_table[:bs] for the current replay step.
+
+        Replaces torch.index_select(req_to_page, 0, req_pool_indices, out=...).
+        The Triton kernel (1) skips reading padding columns of req_to_page
+        (cache-miss bound under large max_num_pages) and (2) overwrites stale
+        page IDs left in padding columns by previous replays where bs or
+        seq_lens were larger — keeping cuda_graph_page_table consistent.
+        """
+        BLOCK_COLS = 128
+        grid = (bs, triton.cdiv(self.max_num_pages, BLOCK_COLS))
+        _gather_page_table_with_padding_kernel[grid](
+            req_to_page,
+            req_pool_indices,
+            seq_lens,
+            self.cuda_graph_page_table,
+            req_to_page.stride(0),
+            self.cuda_graph_page_table.stride(0),
+            self.max_num_pages,
+            self.page_size,
+            0,  # dummy_slot — must match cuda_graph_page_table init (zeros)
+            BLOCK_COLS=BLOCK_COLS,
+            num_warps=4,
+        )
+
     def init_forward_metadata_replay_cuda_graph(
         self,
         bs: int,
@@ -578,12 +611,7 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
 
         # cache_seqlens aliases seq_lens_buf; only page_table needs refresh.
         if req_to_page is not None:
-            torch.index_select(
-                req_to_page[:, : self.max_num_pages],
-                0,
-                req_pool_indices[:bs],
-                out=self.cuda_graph_page_table[:bs, : self.max_num_pages],
-            )
+            self._replay_gather_page_table(bs, req_pool_indices, seq_lens, req_to_page)
 
         if bs in self.cuda_graph_prefill_metadata:
             self.forward_prefill_metadata = self.cuda_graph_prefill_metadata[bs]
@@ -592,3 +620,50 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
 
 
 register_backend("trtllm", {AttentionArch.MHA}, TRTLLMMHAAttnBackend)
+
+
+# ---------------------------------------------------------------------------
+# Triton kernel for cuda graph page table gather (replay path)
+# ---------------------------------------------------------------------------
+# Replaces torch.index_select(req_to_page, 0, req_pool_indices, out=...) which
+# launches an ATen indexSelectSmallIndex kernel that (a) reads every column of
+# the source row including padding (max_num_pages can be ~2048 for 128K context)
+# and (b) suffers cache misses on the small-index gather pattern.
+#
+# This kernel only loads the actual valid pages (ceil(seq_len / page_size))
+# and writes dummy_slot to padding columns, which both shrinks total reads
+# (often by 10-100x) and overwrites any stale page IDs left from previous
+# replays where bs or seq_lens were larger.
+
+
+@triton.jit
+def _gather_page_table_with_padding_kernel(
+    req_to_page_ptr,        # [req_pool_size+1, src_stride0] int32
+    req_pool_indices_ptr,   # [bs] int32 or int64
+    seq_lens_ptr,           # [bs] int32 — KV length per req
+    out_ptr,                # [max_bs, max_num_pages] int32
+    src_stride0,            # row stride of req_to_page
+    out_stride0,            # row stride of cuda_graph_page_table
+    max_num_pages: tl.constexpr,
+    page_size: tl.constexpr,
+    dummy_slot: tl.constexpr,
+    BLOCK_COLS: tl.constexpr,
+):
+    pid_row = tl.program_id(0)
+    pid_col = tl.program_id(1)
+
+    # Per-row valid page count = ceil(seq_len / page_size).
+    sl = tl.load(seq_lens_ptr + pid_row).to(tl.int32)
+    n_pages = (sl + page_size - 1) // page_size
+
+    col_offsets = pid_col * BLOCK_COLS + tl.arange(0, BLOCK_COLS)
+    in_bounds = col_offsets < max_num_pages
+    valid = col_offsets < n_pages
+
+    # Gather source row; out-of-range cols (padding) get dummy_slot via `other`.
+    req_idx = tl.load(req_pool_indices_ptr + pid_row).to(tl.int64)
+    src_addr = req_to_page_ptr + req_idx * src_stride0 + col_offsets
+    gathered = tl.load(src_addr, mask=valid & in_bounds, other=dummy_slot)
+
+    out_addr = out_ptr + pid_row * out_stride0 + col_offsets
+    tl.store(out_addr, gathered, mask=in_bounds)

--- a/python/tokenspeed/runtime/layers/attention/linear/causal_conv1d.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/causal_conv1d.py
@@ -542,32 +542,25 @@ def causal_conv1d_fn(
     if metadata is None:
 
         def num_program(META, seqlens):
-            tot = 0
+            nums = -(-seqlens // META["BLOCK_M"])  # ceil-div, numpy array
+            tot = int(nums.sum())
 
-            mlist = []
-            offsetlist = []  # type: ignore
-
-            nums = -(-seqlens // META["BLOCK_M"])
-
-            tot = nums.sum().item()
             mlist = np.repeat(np.arange(len(nums)), nums)
-            for idx, num in enumerate(nums):
-                offsetlist.extend(
-                    range(num)
-                )  # chunk-idx if a sequence is split into multiple chunks
+            # offsetlist[i] = local chunk index within its sequence
+            offsetlist = np.arange(tot) - np.repeat(np.cumsum(nums) - nums, nums)
+            mlist_len = mlist.shape[0]
 
-            if META["batch_ptr"].nelement() < len(mlist):
-                newlen = len(mlist) + 1
+            if META["batch_ptr"].nelement() < mlist_len:
+                newlen = mlist_len + 1
                 META["batch_ptr"].resize_(newlen).fill_(PAD_SLOT_ID)
                 META["token_chunk_offset_ptr"].resize_(newlen).fill_(PAD_SLOT_ID)
 
-            if META["batch_ptr"].nelement() >= len(mlist):
-                META["batch_ptr"][0 : len(mlist)].copy_(
-                    torch.from_numpy(np.array(mlist))
-                )
-                META["token_chunk_offset_ptr"][0 : len(mlist)].copy_(
-                    torch.from_numpy(np.array(offsetlist))
-                )
+            combined_np = np.stack([mlist, offsetlist]).astype(np.int32, copy=False)
+            combined_cpu = torch.from_numpy(combined_np).pin_memory()
+            META["batch_ptr"][:mlist_len].copy_(combined_cpu[0], non_blocking=True)
+            META["token_chunk_offset_ptr"][:mlist_len].copy_(
+                combined_cpu[1], non_blocking=True
+            )
 
             META["batch_ptr"] = META["batch_ptr"].to(META["x_ptr"].device)
             META["token_chunk_offset_ptr"] = META["token_chunk_offset_ptr"].to(

--- a/python/tokenspeed/runtime/layers/attention/linear/causal_conv1d.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/causal_conv1d.py
@@ -465,7 +465,11 @@ def causal_conv1d_fn(
         batch_ptr = metadata.batch_ptr
         token_chunk_offset_ptr = metadata.token_chunk_offset_ptr
     else:
-        seqlens = np.diff(query_start_loc.to("cpu"))
+        seq_lens_cpu = kwargs.get("seq_lens_cpu")
+        if seq_lens_cpu is not None:
+            seqlens = np.asarray(seq_lens_cpu)
+        else:
+            seqlens = np.diff(query_start_loc.to("cpu"))
         args = seqlens
         MAX_NUM_PROGRAMS = 1024
 

--- a/python/tokenspeed/runtime/layers/attention/linear/index.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/index.py
@@ -68,6 +68,9 @@ def prepare_chunk_indices(
 def prepare_chunk_offsets(
     cu_seqlens: torch.LongTensor, chunk_size: int
 ) -> torch.LongTensor:
-    return torch.cat(
-        [cu_seqlens.new_tensor([0]), triton.cdiv(prepare_lens(cu_seqlens), chunk_size)]
-    ).cumsum(-1)
+    nums = triton.cdiv(prepare_lens(cu_seqlens), chunk_size)
+    offsets = torch.zeros(
+        nums.shape[0] + 1, dtype=nums.dtype, device=nums.device
+    )
+    torch.cumsum(nums, dim=0, out=offsets[1:])
+    return offsets

--- a/python/tokenspeed/runtime/layers/attention/linear/index.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/index.py
@@ -26,9 +26,8 @@ import triton
 
 from tokenspeed.runtime.layers.attention.linear.utils import tensor_cache
 
-# Pre-computed total chunk counts. Keyed by (chunk_size, id(cu_seqlens)) so a
-# hint produced for one batch can never be reused by a later unrelated call
-# that happens to use the same chunk_size
+# Pre-computed total chunk counts. Keyed by (chunk_size, id(cu_seqlens)) and
+# cleared at the start of every set_*() call. 
 _total_chunks_hint: dict[tuple[int, int], int] = {}
 
 
@@ -41,6 +40,7 @@ def set_total_chunks_hint(
     cu_seqlens tensor (by id), avoiding cross-batch hint pollution."""
     lens = np.asarray(seq_lens_cpu, dtype=np.int64)
     key_id = id(cu_seqlens)
+    _total_chunks_hint.clear()
     for cs in chunk_sizes:
         _total_chunks_hint[(cs, key_id)] = int(np.sum(-(-lens // cs)))
 
@@ -54,6 +54,7 @@ def set_total_chunks_hint_uniform(
     """Fast path for spec verify / draft-extend where every sequence has the
     same length (tokens_per_seq). Avoids allocating a per-seq numpy array."""
     key_id = id(cu_seqlens)
+    _total_chunks_hint.clear()
     for cs in chunk_sizes:
         _total_chunks_hint[(cs, key_id)] = bs * (-(-tokens_per_seq // cs))
 

--- a/python/tokenspeed/runtime/layers/attention/linear/index.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/index.py
@@ -27,7 +27,7 @@ import triton
 from tokenspeed.runtime.layers.attention.linear.utils import tensor_cache
 
 # Pre-computed total chunk counts. Keyed by (chunk_size, id(cu_seqlens)) and
-# cleared at the start of every set_*() call. 
+# cleared at the start of every set_*() call.
 _total_chunks_hint: dict[tuple[int, int], int] = {}
 
 

--- a/python/tokenspeed/runtime/layers/attention/linear/index.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/index.py
@@ -20,10 +20,25 @@
 
 # -*- coding: utf-8 -*-
 
+import numpy as np
 import torch
 import triton
 
 from tokenspeed.runtime.layers.attention.linear.utils import tensor_cache
+
+# Pre-computed total chunk counts keyed by chunk_size.
+_total_chunks_hint: dict[int, int] = {}
+
+
+def set_total_chunks_hint(
+    seq_lens_cpu,
+    chunk_sizes: tuple[int, ...] = (16, 64),
+) -> None:
+    """Pre-compute total chunk counts on CPU
+    """
+    lens = np.asarray(seq_lens_cpu, dtype=np.int64)
+    for cs in chunk_sizes:
+        _total_chunks_hint[cs] = int(np.sum(-(-lens // cs)))
 
 
 @tensor_cache
@@ -40,8 +55,9 @@ def prepare_chunk_indices(
         nums.shape[0] + 1, dtype=nums.dtype, device=nums.device
     )
     torch.cumsum(nums, dim=0, out=offsets[1:])
-    total = offsets[-1]
-    total_int = total.item()
+    total_int = _total_chunks_hint.pop(chunk_size, None)
+    if total_int is None:
+        total_int = offsets[-1].item()
     chunk_global = torch.arange(total_int, device=nums.device)
     seq_ids = torch.searchsorted(offsets[1:], chunk_global, right=True)
     local_indices = chunk_global - offsets[seq_ids]

--- a/python/tokenspeed/runtime/layers/attention/linear/index.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/index.py
@@ -34,8 +34,7 @@ def set_total_chunks_hint(
     seq_lens_cpu,
     chunk_sizes: tuple[int, ...] = (16, 64),
 ) -> None:
-    """Pre-compute total chunk counts on CPU
-    """
+    """Pre-compute total chunk counts on CPU"""
     lens = np.asarray(seq_lens_cpu, dtype=np.int64)
     for cs in chunk_sizes:
         _total_chunks_hint[cs] = int(np.sum(-(-lens // cs)))
@@ -51,9 +50,7 @@ def prepare_chunk_indices(
     cu_seqlens: torch.LongTensor, chunk_size: int
 ) -> torch.LongTensor:
     nums = triton.cdiv(prepare_lens(cu_seqlens), chunk_size)
-    offsets = torch.zeros(
-        nums.shape[0] + 1, dtype=nums.dtype, device=nums.device
-    )
+    offsets = torch.zeros(nums.shape[0] + 1, dtype=nums.dtype, device=nums.device)
     torch.cumsum(nums, dim=0, out=offsets[1:])
     total_int = _total_chunks_hint.pop(chunk_size, None)
     if total_int is None:
@@ -69,8 +66,6 @@ def prepare_chunk_offsets(
     cu_seqlens: torch.LongTensor, chunk_size: int
 ) -> torch.LongTensor:
     nums = triton.cdiv(prepare_lens(cu_seqlens), chunk_size)
-    offsets = torch.zeros(
-        nums.shape[0] + 1, dtype=nums.dtype, device=nums.device
-    )
+    offsets = torch.zeros(nums.shape[0] + 1, dtype=nums.dtype, device=nums.device)
     torch.cumsum(nums, dim=0, out=offsets[1:])
     return offsets

--- a/python/tokenspeed/runtime/layers/attention/linear/index.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/index.py
@@ -26,18 +26,36 @@ import triton
 
 from tokenspeed.runtime.layers.attention.linear.utils import tensor_cache
 
-# Pre-computed total chunk counts keyed by chunk_size.
-_total_chunks_hint: dict[int, int] = {}
+# Pre-computed total chunk counts. Keyed by (chunk_size, id(cu_seqlens)) so a
+# hint produced for one batch can never be reused by a later unrelated call
+# that happens to use the same chunk_size
+_total_chunks_hint: dict[tuple[int, int], int] = {}
 
 
 def set_total_chunks_hint(
     seq_lens_cpu,
+    cu_seqlens: torch.Tensor,
     chunk_sizes: tuple[int, ...] = (16, 64),
 ) -> None:
-    """Pre-compute total chunk counts on CPU"""
+    """Pre-compute total chunk counts on CPU and bind them to a specific
+    cu_seqlens tensor (by id), avoiding cross-batch hint pollution."""
     lens = np.asarray(seq_lens_cpu, dtype=np.int64)
+    key_id = id(cu_seqlens)
     for cs in chunk_sizes:
-        _total_chunks_hint[cs] = int(np.sum(-(-lens // cs)))
+        _total_chunks_hint[(cs, key_id)] = int(np.sum(-(-lens // cs)))
+
+
+def set_total_chunks_hint_uniform(
+    bs: int,
+    tokens_per_seq: int,
+    cu_seqlens: torch.Tensor,
+    chunk_sizes: tuple[int, ...] = (16, 64),
+) -> None:
+    """Fast path for spec verify / draft-extend where every sequence has the
+    same length (tokens_per_seq). Avoids allocating a per-seq numpy array."""
+    key_id = id(cu_seqlens)
+    for cs in chunk_sizes:
+        _total_chunks_hint[(cs, key_id)] = bs * (-(-tokens_per_seq // cs))
 
 
 @tensor_cache
@@ -52,7 +70,7 @@ def prepare_chunk_indices(
     nums = triton.cdiv(prepare_lens(cu_seqlens), chunk_size)
     offsets = torch.zeros(nums.shape[0] + 1, dtype=nums.dtype, device=nums.device)
     torch.cumsum(nums, dim=0, out=offsets[1:])
-    total_int = _total_chunks_hint.pop(chunk_size, None)
+    total_int = _total_chunks_hint.pop((chunk_size, id(cu_seqlens)), None)
     if total_int is None:
         total_int = offsets[-1].item()
     chunk_global = torch.arange(total_int, device=nums.device)

--- a/python/tokenspeed/runtime/layers/attention/linear/index.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/index.py
@@ -35,13 +35,17 @@ def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
 def prepare_chunk_indices(
     cu_seqlens: torch.LongTensor, chunk_size: int
 ) -> torch.LongTensor:
-    indices = torch.cat(
-        [
-            torch.arange(n)
-            for n in triton.cdiv(prepare_lens(cu_seqlens), chunk_size).tolist()
-        ]
+    nums = triton.cdiv(prepare_lens(cu_seqlens), chunk_size)
+    offsets = torch.zeros(
+        nums.shape[0] + 1, dtype=nums.dtype, device=nums.device
     )
-    return torch.stack([indices.eq(0).cumsum(0) - 1, indices], 1).to(cu_seqlens)
+    torch.cumsum(nums, dim=0, out=offsets[1:])
+    total = offsets[-1]
+    total_int = total.item()
+    chunk_global = torch.arange(total_int, device=nums.device)
+    seq_ids = torch.searchsorted(offsets[1:], chunk_global, right=True)
+    local_indices = chunk_global - offsets[seq_ids]
+    return torch.stack([seq_ids, local_indices], 1).to(cu_seqlens)
 
 
 @tensor_cache

--- a/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
@@ -168,7 +168,7 @@ def _mamba_state_snapshot_kernel(
         tl.store(pool_ptr + dst_offset + offsets, data, mask=mask)
 
 
-def fused_mamba_state_snapshot(
+def fused_mamba_state_copy(
     pool: torch.Tensor,  # [num_layers, pool_size, *state_shape]
     src_indices: torch.Tensor,  # [num_valid]
     dst_indices: torch.Tensor,  # [num_valid]
@@ -176,18 +176,21 @@ def fused_mamba_state_snapshot(
     page_size: int = 0,  # 0 means no page filtering
 ):
     """
-    Snapshot mamba states: pool[:, dst_indices[i], :] = pool[:, src_indices[i], :]
+    Copy mamba states: pool[:, dst_indices[i], :] = pool[:, src_indices[i], :]
 
-    Specialized for checkpoint snapshot with page-boundary filtering.
-    When page_size > 0 and cache_lengths is provided, skips entries where
-    cache_lengths[i] % page_size != 0 (all done inside a single kernel).
+    Handles both COW copy and checkpoint snapshot. Invalid indices (< 0 or
+    >= pool_size) are skipped inside the kernel. When page_size > 0 and
+    cache_lengths is provided, also skips entries where
+    cache_lengths[i] % page_size != 0.
 
     Args:
         pool: State tensor [num_layers, pool_size, *state_shape], must be contiguous.
         src_indices: Source slot indices [num_valid], int32 or int64.
         dst_indices: Destination slot indices [num_valid], int32 or int64.
         cache_lengths: Per-entry cache lengths for page-boundary filtering.
-        page_size: Page size for filtering; 0 disables.
+        page_size: When > 0, only copy entries where cache_lengths[i] is
+            aligned to page_size. Set to 0 to disable filtering (used by 
+            COW copy where all valid entries must be copied).
     """
     num_valid = src_indices.shape[0]
     if num_valid == 0:
@@ -233,6 +236,91 @@ def fused_mamba_state_snapshot(
         dst_indices,
         cache_lengths,
         page_size,
+        elem_per_entry,
+        layer_stride,
+        req_stride,
+        pool_size,
+        BLOCK_SIZE=BLOCK_SIZE,
+        num_warps=8,
+    )
+
+
+@triton.jit
+def _mamba_state_zero_kernel(
+    pool_ptr,
+    indices_ptr,  # [bs] — indices to zero; negative values are skipped
+    elem_per_entry: tl.constexpr,
+    layer_stride,
+    req_stride,
+    pool_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """
+    Zero kernel: pool[:, indices[i], :] = 0
+    Skips entries where indices[i] < 0 or indices[i] >= pool_size.
+
+    Grid: (bs, num_layers) — loops over elem_per_entry internally.
+    """
+    pid_req = tl.program_id(0)
+    pid_layer = tl.program_id(1).to(tl.int64)
+
+    idx = tl.load(indices_ptr + pid_req).to(tl.int64)
+
+    # Skip invalid entries (negative sentinel from torch.where)
+    if (idx < 0) | (idx >= pool_size):
+        return
+
+    dst_offset = pid_layer * layer_stride + idx * req_stride
+
+    zero_val = tl.zeros([BLOCK_SIZE], dtype=pool_ptr.dtype.element_ty)
+    for start in tl.static_range(0, elem_per_entry, BLOCK_SIZE):
+        offsets = start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < elem_per_entry
+        tl.store(pool_ptr + dst_offset + offsets, zero_val, mask=mask)
+
+
+def fused_mamba_state_zero(
+    pool: torch.Tensor,  # [num_layers, pool_size, *state_shape]
+    indices: torch.Tensor,  # [bs] — slots to zero; negative values skipped inside kernel
+):
+    """
+    Zero mamba states: pool[:, indices[i], :] = 0 for valid indices.
+
+    Invalid indices (< 0) are skipped inside the kernel, avoiding any
+    CPU-GPU synchronization from boolean indexing or .any() checks.
+
+    Args:
+        pool: State tensor [num_layers, pool_size, *state_shape], must be contiguous.
+        indices: Slot indices [bs], int64. Negative values are treated as invalid
+            and skipped (no-op).
+    """
+    bs = indices.shape[0]
+    if bs == 0:
+        return
+
+    if not pool.is_cuda:
+        raise ValueError("fused_mamba_state_zero only supports CUDA tensors.")
+    if not pool.is_contiguous():
+        raise ValueError("pool tensor must be contiguous")
+    if pool.ndim < 2:
+        raise ValueError(f"pool must be at least 2D, got {pool.ndim}D")
+
+    num_layers = pool.shape[0]
+    pool_size = pool.shape[1]
+    elem_per_entry = pool.numel() // (num_layers * pool_size)
+
+    layer_stride = pool.stride(0)
+    req_stride = pool.stride(1)
+
+    if not indices.is_contiguous():
+        indices = indices.contiguous()
+
+    BLOCK_SIZE = 8192
+    grid = (bs, num_layers)
+
+    _mamba_state_zero_kernel[grid](
+        pool,
+        indices,
         elem_per_entry,
         layer_stride,
         req_stride,

--- a/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
@@ -189,7 +189,7 @@ def fused_mamba_state_copy(
         dst_indices: Destination slot indices [num_valid], int32 or int64.
         cache_lengths: Per-entry cache lengths for page-boundary filtering.
         page_size: When > 0, only copy entries where cache_lengths[i] is
-            aligned to page_size. Set to 0 to disable filtering (used by 
+            aligned to page_size. Set to 0 to disable filtering (used by
             COW copy where all valid entries must be copied).
     """
     num_valid = src_indices.shape[0]

--- a/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic.yaml
+++ b/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic.yaml
@@ -92,7 +92,7 @@ report:
 perf_threshold: 0.9
 # Values are [Latency (tps/user), Throughput (tps/gpu)]; gate fails any conc whose actual falls below ref * perf_threshold.
 perf_reference:
-  1:  [440, 9300]
-  2:  [340, 14500]
-  4:  [250, 21000]
-  8:  [149, 27000]
+  1:  [530, 11600]
+  2:  [440, 17800]
+  4:  [270, 24400]
+  8:  [160, 31600]


### PR DESCRIPTION
## Summary

A series of small optimizations on the GDN (linear-attention / Mamba) prefill hot path: remove host↔device syncs, fuse element-wise ops, and trim memory traffic.

- **Eliminate CPU↔GPU sync** on the prefill scheduling path: drop per-iter `.item()` / `.tolist()` / `.any()` host pulls; replace with pinned-CPU mirrors or move the work fully on-device. Page-aligned filtering for the Mamba snapshot is pushed down into a Triton kernel so the host no longer participates.
- **Fuse element-wise ops with `@torch.compile(dynamic=True)`** on two hot paths (MTP snapshot index computation and Mamba MTP-verify state-pointer updates), collapsing dozens of tiny CUDA launches into a handful of Inductor-generated Triton kernels.
- **TRT-LLM page-table replay**: replace the ATen `indexSelectSmallIndex` call with a dedicated Triton kernel that skips reading padding columns of the source table and overwrites stale page IDs left from previous replays.
- `lint & format`.

## Test Plan
- [x] Run Qwen3.5 MoE decode + prefill e2e to confirm no numerical regression
- [x] No accuracy drift on standard eval set.
