### PR TITLE
ci(pr-test): pass HF_TOKEN to unit-test jobs

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -155,6 +155,12 @@ jobs:
       # `install_deps.sh` will reinstall the in-tree source on top of the
       # pinned PyPI wheel. See the matching detect step in the `scan` job.
       INSTALL_TOKENSPEED_MLA_FROM_SOURCE: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
+      # Authenticate Hugging Face Hub downloads so checkpoint pulls during
+      # `ts serve` startup are not throttled by the anonymous rate limit. The
+      # 600s per-file `runtime-1gpu` timeout is otherwise exceeded on cold
+      # runners (e.g. `linux-mi355-1gpu-lightseek` loading
+      # `openai/gpt-oss-120b` + EAGLE3 draft).
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Anonymous Hugging Face Hub downloads during `ts serve` startup get throttled, intermittently exceeding the 600s `runtime-1gpu` per-file timeout on cold runners (`linux-mi355-1gpu-lightseek` loading `openai/gpt-oss-120b` + EAGLE3 draft is the most frequent victim, but the unauthenticated warning shows on every runner).

Wires the repo's `HF_TOKEN` secret through to the `unit-test` job env. `pipeline.py` already forwards the parent process environment to all `ts serve` subprocesses, so no further plumbing is required.