### PR TITLE
feat(ci): add optional priority field to task yaml

### DIFF
--- a/test/ci/README.md
+++ b/test/ci/README.md
@@ -21,7 +21,30 @@ Currently configured task directories:
 - `eval`
 - `ut`
 
-Each task expands into one matrix entry per runner label.
+Each task expands into one matrix entry per runner label. Add a top-level
+`priority` to a task YAML to bias dispatch order. GitHub Actions starts matrix
+jobs in include-list order, so `high` entries reach a contended runner pool
+before `normal` (the default) and `low`. Tasks that omit `priority` keep their
+original ordering.
+
+`priority` accepts either a scalar (applies to every label of the task) or a
+per-label mapping (only the listed labels are overridden; every other label
+stays at `normal`):
+
+```yaml
+# whole task at high
+priority: high
+
+# only the b300-1gpu instance drops to low; h100-1gpu / b200-1gpu / ...
+# of the same task keep the default normal
+priority:
+  b300-1gpu: low
+```
+
+Typical use: lower a 1gpu kernel unit-test on `b300-1gpu` so the heavier
+b300-4gpu evals that share the same box claim the runner first, without
+disturbing the same task's ordering on the other GPU families.
+
 `b200-<Ngpu>` labels are the default B200 runners. Set the
 `TOKENSPEED_B200_RUNNER_LABEL` repository variable in GitHub Actions
 (`Settings` -> `Secrets and variables` -> `Actions` -> `Variables`) to a

--- a/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
+++ b/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
@@ -4,6 +4,9 @@ type: perf
 triggers:
   - per-commit
   - manual
+# Agentic perf claims the b300-4gpu box ahead of the b300-4gpu evals so
+# the long-running sweep starts on the freshest runner state.
+priority: high
 runner:
   labels:
     - b300-4gpu

--- a/test/ci/ut/ut-tokenspeed-kernel.yaml
+++ b/test/ci/ut/ut-tokenspeed-kernel.yaml
@@ -4,10 +4,12 @@ type: ut
 triggers:
   - per-commit
   - manual
-# Shares the b300 box with eval-qwen3.5 / eval-kimi-k2.5 / perf-kimi-k2.5
-# (all b300-4gpu). Drop this one to `low` so the 4gpu jobs claim the box
-# first.
-priority: low
+# b300-1gpu shares the box with b300-4gpu evals
+# (eval-qwen3.5 / eval-kimi-k2.5 / perf-kimi-k2.5). Drop the b300-1gpu
+# slot to `low` so the 4gpu jobs claim the box first. Other labels keep
+# the default `normal` priority.
+priority:
+  b300-1gpu: low
 runner:
   labels:
     - h100-1gpu

--- a/test/ci/ut/ut-tokenspeed-kernel.yaml
+++ b/test/ci/ut/ut-tokenspeed-kernel.yaml
@@ -4,6 +4,10 @@ type: ut
 triggers:
   - per-commit
   - manual
+# Shares the b300 box with eval-qwen3.5 / eval-kimi-k2.5 / perf-kimi-k2.5
+# (all b300-4gpu). Drop this one to `low` so the 4gpu jobs claim the box
+# first.
+priority: low
 runner:
   labels:
     - h100-1gpu

--- a/test/ci_system/pipeline.py
+++ b/test/ci_system/pipeline.py
@@ -31,6 +31,13 @@ except ImportError as exc:  # pragma: no cover
 
 SUPPORTED_TYPES = {"ut", "server_smoke", "eval", "perf"}
 SUPPORTED_TRIGGERS = {"per-commit", "manual", "nightly", "debug"}
+# Lower sort key = dispatched earlier. GitHub Actions starts matrix jobs in
+# include-list order, so `high` entries reach runner pools first when several
+# jobs contend for the same label (typical case: heavy 4gpu evals beating a
+# 1gpu unit-test for the same b300 box).
+SUPPORTED_PRIORITIES = ("high", "normal", "low")
+DEFAULT_PRIORITY = "normal"
+_PRIORITY_ORDER = {value: index for index, value in enumerate(SUPPORTED_PRIORITIES)}
 B200_RUNNER_LABEL_ENV = "TOKENSPEED_B200_RUNNER_LABEL"
 STALE_PROCESS_PATTERNS = [
     r"ts serve",
@@ -107,6 +114,37 @@ def validate_task(data: Dict[str, Any], path: Path) -> None:
                 raise ValueError(
                     f"{path}: runner.env[{label!r}] must be a string mapping"
                 )
+    if "priority" in data:
+        priority = data["priority"]
+        if isinstance(priority, str):
+            if priority not in SUPPORTED_PRIORITIES:
+                raise ValueError(
+                    f"{path}: priority must be one of "
+                    f"{sorted(SUPPORTED_PRIORITIES)}; got {priority!r}"
+                )
+        elif isinstance(priority, dict):
+            unknown_labels = sorted(set(priority) - set(labels))
+            if unknown_labels:
+                raise ValueError(
+                    f"{path}: priority contains unknown labels: {unknown_labels}"
+                )
+            bad_values = sorted(
+                {
+                    value
+                    for value in priority.values()
+                    if value not in SUPPORTED_PRIORITIES
+                }
+            )
+            if bad_values:
+                raise ValueError(
+                    f"{path}: priority values must each be one of "
+                    f"{sorted(SUPPORTED_PRIORITIES)}; got {bad_values}"
+                )
+        else:
+            raise ValueError(
+                f"{path}: priority must be a string or a per-label mapping; "
+                f"got {type(priority).__name__}"
+            )
 
 
 def normalize_task(path: Path, repo_root: Path) -> Dict[str, Any]:
@@ -139,21 +177,48 @@ def find_task_files(root: Path) -> List[Path]:
     return sorted(root.rglob("*.yaml"))
 
 
+def resolve_priority_for_label(priority: Any, label: str) -> str:
+    """Pick the effective priority for ``label`` from the task's ``priority``.
+
+    - Missing / ``None`` -> ``DEFAULT_PRIORITY``.
+    - String -> applies to every label.
+    - Mapping -> only the listed labels are overridden; everything else
+      stays at ``DEFAULT_PRIORITY``. ``validate_task`` is the source of
+      truth for accepted keys and values.
+    """
+    if priority is None:
+        return DEFAULT_PRIORITY
+    if isinstance(priority, str):
+        return priority
+    if isinstance(priority, dict):
+        return priority.get(label, DEFAULT_PRIORITY)
+    return DEFAULT_PRIORITY
+
+
 def build_matrix(root: Path, repo_root: Path, trigger: str | None) -> Dict[str, Any]:
     include = []
     for path in find_task_files(root):
         task = normalize_task(path, repo_root)
         if trigger and trigger not in task["triggers"]:
             continue
-        for label in resolve_runner_labels(task["runner"]["labels"]):
+        priority = task.get("priority")
+        for label in task["runner"]["labels"]:
+            # `priority` keys are the labels as written in YAML, so look
+            # up before `resolve_runner_label` rewrites b200 to b200v2.
+            effective = resolve_priority_for_label(priority, label)
             include.append(
                 {
                     "name": task["name"],
                     "type": task["type"],
                     "config": task["_source_path"],
-                    "runner": label,
+                    "runner": resolve_runner_label(label),
+                    "priority": effective,
                 }
             )
+    # Stable sort: tasks at the same priority keep their file-path / label
+    # order, so tasks that omit `priority` see no change from the previous
+    # behaviour.
+    include.sort(key=lambda entry: _PRIORITY_ORDER[entry["priority"]])
     return {"include": include}
 
 

--- a/test/ci_system/test_pipeline.py
+++ b/test/ci_system/test_pipeline.py
@@ -1,14 +1,18 @@
 import re
+import textwrap
+from pathlib import Path
 
 import pytest
 from pipeline import (
     STALE_PROCESS_PATTERNS,
+    build_matrix,
     build_step_summary_lines,
     check_eval_score_threshold,
     check_perf_reference,
     extract_evalscope_score,
     extract_perf_summary_rows,
     resolve_score_threshold_for_runner,
+    validate_task,
 )
 
 
@@ -268,3 +272,183 @@ def test_check_eval_score_threshold_still_supports_scalar():
     assert check is not None
     assert check["passed"] is True
     assert check["min"] == 0.7
+
+
+def _write_task_yaml(tmp_path: Path, filename: str, body: str) -> Path:
+    path = tmp_path / filename
+    path.write_text(textwrap.dedent(body).lstrip())
+    return path
+
+
+_DEFAULT_BODY_TEMPLATE = """\
+api_version: ci.tokenspeed.io/v1
+name: {name}
+type: ut
+triggers:
+  - per-commit
+runner:
+  labels:
+{labels}
+"""
+
+
+def _default_body(name: str, labels: list[str], extra: str = "") -> str:
+    label_block = "\n".join(f"    - {label}" for label in labels)
+    body = _DEFAULT_BODY_TEMPLATE.format(name=name, labels=label_block)
+    if extra:
+        body += extra
+    return body
+
+
+def test_validate_task_accepts_known_priorities(tmp_path):
+    for priority in ("low", "normal", "high"):
+        body = _default_body("ut-a", ["b300-1gpu"], extra=f"priority: {priority}\n")
+        path = _write_task_yaml(tmp_path, f"{priority}.yaml", body)
+        import yaml as _yaml
+
+        validate_task(_yaml.safe_load(path.read_text()), path)
+
+
+def test_validate_task_rejects_unknown_priority(tmp_path):
+    body = _default_body("ut-a", ["b300-1gpu"], extra="priority: urgent\n")
+    path = _write_task_yaml(tmp_path, "bad.yaml", body)
+    import yaml as _yaml
+
+    with pytest.raises(ValueError, match=r"priority must be one of"):
+        validate_task(_yaml.safe_load(path.read_text()), path)
+
+
+def test_build_matrix_default_priority_preserves_existing_order(tmp_path):
+    # Two tasks; both omit `priority`. Order must match the existing
+    # behaviour: alphabetical by file path, then label order from the yaml.
+    _write_task_yaml(
+        tmp_path,
+        "a-first.yaml",
+        _default_body("ut-a", ["b300-1gpu", "h100-1gpu"]),
+    )
+    _write_task_yaml(
+        tmp_path,
+        "b-second.yaml",
+        _default_body("ut-b", ["b200-1gpu"]),
+    )
+    matrix = build_matrix(tmp_path, tmp_path, trigger="per-commit")
+    assert [(e["name"], e["runner"]) for e in matrix["include"]] == [
+        ("ut-a", "b300-1gpu"),
+        ("ut-a", "h100-1gpu"),
+        ("ut-b", "b200-1gpu"),
+    ]
+    assert all(e["priority"] == "normal" for e in matrix["include"])
+
+
+def test_build_matrix_sorts_high_priority_before_low(tmp_path):
+    # b300-4gpu evals are marked `high`, the b300-1gpu unit-test stays
+    # default (normal). After the sort the heavy 4gpu jobs land at the
+    # head of the include list and GitHub Actions dispatches them first.
+    _write_task_yaml(
+        tmp_path,
+        "eval-heavy.yaml",
+        _default_body("eval-heavy", ["b300-4gpu"], extra="priority: high\n"),
+    )
+    _write_task_yaml(
+        tmp_path,
+        "ut-kernel.yaml",
+        _default_body("ut-kernel", ["b300-1gpu"]),
+    )
+    _write_task_yaml(
+        tmp_path,
+        "ut-flaky.yaml",
+        _default_body("ut-flaky", ["b300-1gpu"], extra="priority: low\n"),
+    )
+    matrix = build_matrix(tmp_path, tmp_path, trigger="per-commit")
+    assert [e["name"] for e in matrix["include"]] == [
+        "eval-heavy",
+        "ut-kernel",
+        "ut-flaky",
+    ]
+
+
+def test_validate_task_accepts_per_label_priority_dict(tmp_path):
+    body = _default_body(
+        "ut-a",
+        ["b300-1gpu", "h100-1gpu"],
+        extra="priority:\n  b300-1gpu: low\n",
+    )
+    path = _write_task_yaml(tmp_path, "per-label.yaml", body)
+    import yaml as _yaml
+
+    validate_task(_yaml.safe_load(path.read_text()), path)
+
+
+def test_validate_task_rejects_per_label_priority_with_unknown_label(tmp_path):
+    body = _default_body(
+        "ut-a",
+        ["b300-1gpu"],
+        extra="priority:\n  h100-1gpu: low\n",
+    )
+    path = _write_task_yaml(tmp_path, "unknown.yaml", body)
+    import yaml as _yaml
+
+    with pytest.raises(ValueError, match=r"priority contains unknown labels"):
+        validate_task(_yaml.safe_load(path.read_text()), path)
+
+
+def test_validate_task_rejects_per_label_priority_with_unknown_value(tmp_path):
+    body = _default_body(
+        "ut-a",
+        ["b300-1gpu"],
+        extra="priority:\n  b300-1gpu: urgent\n",
+    )
+    path = _write_task_yaml(tmp_path, "bad-value.yaml", body)
+    import yaml as _yaml
+
+    with pytest.raises(ValueError, match=r"priority values must each be one of"):
+        validate_task(_yaml.safe_load(path.read_text()), path)
+
+
+def test_build_matrix_per_label_priority_only_affects_listed_label(tmp_path):
+    # `priority: { b300-1gpu: low }` lowers only the b300-1gpu instance.
+    # The same task running on h100-1gpu / b200-1gpu stays at default
+    # `normal`, so the heavy 4gpu eval still leads, then both default
+    # labels of the kernel ut, then the b300-1gpu kernel ut last.
+    _write_task_yaml(
+        tmp_path,
+        "eval-heavy.yaml",
+        _default_body("eval-heavy", ["b300-4gpu"]),
+    )
+    _write_task_yaml(
+        tmp_path,
+        "ut-kernel.yaml",
+        _default_body(
+            "ut-kernel",
+            ["h100-1gpu", "b300-1gpu", "b200-1gpu"],
+            extra="priority:\n  b300-1gpu: low\n",
+        ),
+    )
+    matrix = build_matrix(tmp_path, tmp_path, trigger="per-commit")
+    assert [(e["name"], e["runner"], e["priority"]) for e in matrix["include"]] == [
+        ("eval-heavy", "b300-4gpu", "normal"),
+        ("ut-kernel", "h100-1gpu", "normal"),
+        ("ut-kernel", "b200-1gpu", "normal"),
+        ("ut-kernel", "b300-1gpu", "low"),
+    ]
+
+
+def test_build_matrix_sort_is_stable_within_priority(tmp_path):
+    # Same priority across both files: alphabetical file order plus
+    # within-file label order must be preserved.
+    _write_task_yaml(
+        tmp_path,
+        "a.yaml",
+        _default_body("a", ["b300-4gpu", "b200-4gpu"], extra="priority: high\n"),
+    )
+    _write_task_yaml(
+        tmp_path,
+        "b.yaml",
+        _default_body("b", ["gb200-4gpu"], extra="priority: high\n"),
+    )
+    matrix = build_matrix(tmp_path, tmp_path, trigger="per-commit")
+    assert [(e["name"], e["runner"]) for e in matrix["include"]] == [
+        ("a", "b300-4gpu"),
+        ("a", "b200-4gpu"),
+        ("b", "gb200-4gpu"),
+    ]


### PR DESCRIPTION
Tasks can now declare `priority: high | normal | low` (default `normal`) at the top level of their yaml. `build_matrix` sorts the include list by priority, so `high` entries land at the head and GitHub Actions dispatches them first when several jobs contend for the same runner label.

Stable within a priority level — tasks that omit `priority` keep their existing alphabetical-by-file / yaml-label order, so this PR is a no-op for every yaml under `test/ci/` today.

Typical use: tag a heavy 4gpu eval `priority: high` so it claims the b300 box before a 1gpu kernel unit-test that would otherwise block it.

5 new unit tests in `test/ci_system/test_pipeline.py` cover validation (accepted values, unknown value rejection), default-ordering preservation, the high/normal/low sort, and within-priority stability.