### PR TITLE
perf[Qwen3.5]: fuse small kernels in MoE block.

### DIFF
--- a/python/tokenspeed/runtime/models/qwen3_5_moe.py
+++ b/python/tokenspeed/runtime/models/qwen3_5_moe.py
@@ -24,7 +24,7 @@
 from __future__ import annotations
 
 import torch
-import torch.nn.functional as F
+from tokenspeed_kernel.ops.activation.triton import fused_gate_sigmoid_mul_add
 from torch import nn
 
 from tokenspeed.runtime.configs.qwen3_5_text_base_config import Qwen3_5BaseTextConfig
@@ -263,14 +263,6 @@ class Qwen3_5MoeSparseMoeBlock(nn.Module):
             with fork.branch():
                 if self.shared_expert is not None:
                     shared_output = self.shared_expert(hidden_states)
-                    if (
-                        hidden_states.shape[0] > 0
-                        and self.shared_expert_gate is not None
-                    ):
-                        shared_output = (
-                            F.sigmoid(self.shared_expert_gate(hidden_states))
-                            * shared_output
-                        )
 
             if hidden_states.shape[0] > 0:
                 topk_output = self.topk(hidden_states, router_logits)
@@ -289,7 +281,15 @@ class Qwen3_5MoeSparseMoeBlock(nn.Module):
             )
 
         if shared_output is not None:
-            final_hidden_states = final_hidden_states + shared_output
+            if self.shared_expert_gate is not None and hidden_states.shape[0] > 0:
+                fused_gate_sigmoid_mul_add(
+                    hidden_states,
+                    self.shared_expert_gate.weight.squeeze(0),
+                    shared_output,
+                    final_hidden_states,
+                )
+            else:
+                final_hidden_states = final_hidden_states + shared_output
 
         # Reduce-scatter / all-reduce expert output back to local token count
         final_hidden_states, _ = self.comm_manager.post_mlp_fused(
@@ -316,10 +316,6 @@ class Qwen3_5MoeSparseMoeBlock(nn.Module):
         shared_output = None
         if self.shared_expert is not None:
             shared_output = self.shared_expert(hidden_states)
-            if hidden_states.shape[0] > 0 and self.shared_expert_gate is not None:
-                shared_output = (
-                    F.sigmoid(self.shared_expert_gate(hidden_states)) * shared_output
-                )
             if self.mapping.dense.has_tp:
                 from tokenspeed.runtime.distributed.comm_ops import all_reduce
 
@@ -348,6 +344,14 @@ class Qwen3_5MoeSparseMoeBlock(nn.Module):
         )
 
         if shared_output is not None:
-            final_hidden_states = final_hidden_states + shared_output
+            if self.shared_expert_gate is not None and hidden_states.shape[0] > 0:
+                fused_gate_sigmoid_mul_add(
+                    hidden_states,
+                    self.shared_expert_gate.weight.squeeze(0),
+                    shared_output,
+                    final_hidden_states,
+                )
+            else:
+                final_hidden_states = final_hidden_states + shared_output
 
         return final_hidden_states.view(num_tokens, hidden_dim)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/activation/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/activation/triton.py
@@ -25,7 +25,108 @@ from __future__ import annotations
 import torch
 from tokenspeed_kernel._triton import tl, triton
 
-__all__ = ["sigmoid_mul"]
+__all__ = ["fused_gate_sigmoid_mul_add", "sigmoid_mul"]
+
+
+@triton.jit
+def _fused_gate_sigmoid_mul_add_kernel(
+    hidden_states_ptr,
+    gate_weight_ptr,
+    shared_output_ptr,
+    final_ptr,
+    hidden_dim: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    token_id = tl.program_id(0).to(tl.int64)
+    row_offset = token_id * hidden_dim
+
+    # Phase 1: gate = dot(hidden_states[token_id], gate_weight)
+    # BLOCK >= hidden_dim so this loop is single-iteration (unrolled away).
+    acc = tl.zeros([BLOCK], dtype=tl.float32)
+    for k_offset in range(0, hidden_dim, BLOCK):
+        cols = k_offset + tl.arange(0, BLOCK)
+        mask = cols < hidden_dim
+        h = tl.load(hidden_states_ptr + row_offset + cols, mask=mask, other=0.0)
+        w = tl.load(gate_weight_ptr + cols, mask=mask, other=0.0)
+        acc += h.to(tl.float32) * w.to(tl.float32)
+    gate_val = tl.sigmoid(tl.sum(acc, axis=0))
+
+    # Phase 2: final[token_id] += gate_val * shared_output[token_id]
+    for n_offset in range(0, hidden_dim, BLOCK):
+        cols = n_offset + tl.arange(0, BLOCK)
+        mask = cols < hidden_dim
+        s = tl.load(shared_output_ptr + row_offset + cols, mask=mask)
+        f = tl.load(final_ptr + row_offset + cols, mask=mask)
+        out = f.to(tl.float32) + gate_val * s.to(tl.float32)
+        tl.store(final_ptr + row_offset + cols, out.to(f.dtype), mask=mask)
+
+
+def fused_gate_sigmoid_mul_add(
+    hidden_states: torch.Tensor,
+    gate_weight: torch.Tensor,
+    shared_output: torch.Tensor,
+    final_hidden_states: torch.Tensor,
+) -> torch.Tensor:
+    """Fused ``final_hidden_states += sigmoid(hidden_states @ gate_weight) * shared_output``.
+
+    Computes the gate dot-product (reduction over hidden_dim), applies sigmoid,
+    multiplies by ``shared_output``, and adds to ``final_hidden_states`` in-place.
+
+    Args:
+        hidden_states: ``[num_tokens, hidden_dim]`` contiguous input.
+        gate_weight: ``[hidden_dim]`` contiguous 1-D weight vector.
+        shared_output: ``[num_tokens, hidden_dim]`` contiguous shared expert output.
+        final_hidden_states: ``[num_tokens, hidden_dim]`` contiguous MoE output,
+            modified in-place.
+
+    Returns:
+        ``final_hidden_states`` (same storage, mutated in-place).
+    """
+    if hidden_states.ndim != 2:
+        raise ValueError(f"hidden_states must be 2D, got {hidden_states.ndim}D")
+    if not hidden_states.is_contiguous():
+        raise ValueError("hidden_states must be contiguous")
+    if gate_weight.ndim != 1:
+        raise ValueError(f"gate_weight must be 1D, got {gate_weight.ndim}D")
+    if not gate_weight.is_contiguous():
+        raise ValueError("gate_weight must be contiguous")
+    if not shared_output.is_contiguous():
+        raise ValueError("shared_output must be contiguous")
+    if not final_hidden_states.is_contiguous():
+        raise ValueError("final_hidden_states must be contiguous")
+
+    num_tokens, hidden_dim = hidden_states.shape
+    if gate_weight.shape[0] != hidden_dim:
+        raise ValueError(
+            f"gate_weight dim mismatch: expected {hidden_dim}, got {gate_weight.shape[0]}"
+        )
+    if shared_output.shape != (num_tokens, hidden_dim):
+        raise ValueError(
+            f"shared_output shape mismatch: expected {(num_tokens, hidden_dim)}, "
+            f"got {shared_output.shape}"
+        )
+    if final_hidden_states.shape != (num_tokens, hidden_dim):
+        raise ValueError(
+            f"final_hidden_states shape mismatch: expected {(num_tokens, hidden_dim)}, "
+            f"got {final_hidden_states.shape}"
+        )
+
+    if num_tokens == 0:
+        return final_hidden_states
+
+    BLOCK = triton.next_power_of_2(hidden_dim)
+    num_warps = 4 if BLOCK <= 2048 else (8 if BLOCK <= 4096 else 16)
+    grid = (num_tokens,)
+    _fused_gate_sigmoid_mul_add_kernel[grid](
+        hidden_states,
+        gate_weight,
+        shared_output,
+        final_hidden_states,
+        hidden_dim=hidden_dim,
+        BLOCK=BLOCK,
+        num_warps=num_warps,
+    )
+    return final_hidden_states
 
 
 @triton.jit

--- a/tokenspeed-kernel/test/ops/test_activation.py
+++ b/tokenspeed-kernel/test/ops/test_activation.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import pytest
 import torch
-from tokenspeed_kernel.ops.activation.triton import sigmoid_mul
+from tokenspeed_kernel.ops.activation.triton import (
+    fused_gate_sigmoid_mul_add,
+    sigmoid_mul,
+)
 from tokenspeed_kernel.platform import current_platform
 
 platform = current_platform()
@@ -108,3 +111,54 @@ def test_sigmoid_mul_rejects_4d_gate(device: str) -> None:
     gate = torch.randn(4, 2, 4, 4, device=device, dtype=torch.bfloat16)
     with pytest.raises(ValueError, match="gate must be 2D or 3D"):
         sigmoid_mul(x, gate)
+
+
+# --- fused_gate_sigmoid_mul_add tests ---
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "num_tokens,hidden_dim",
+    [(1, 3584), (1, 5120), (17, 3584), (128, 5120), (256, 3584)],
+)
+def test_fused_gate_sigmoid_mul_add_matches_eager(
+    dtype: torch.dtype, num_tokens: int, hidden_dim: int, device: str
+) -> None:
+    hidden_states = torch.randn(num_tokens, hidden_dim, device=device, dtype=dtype)
+    gate_weight = torch.randn(hidden_dim, device=device, dtype=dtype)
+    shared_output = torch.randn(num_tokens, hidden_dim, device=device, dtype=dtype)
+    final = torch.randn(num_tokens, hidden_dim, device=device, dtype=dtype)
+
+    # Eager reference
+    gate_val = (hidden_states.float() @ gate_weight.float().unsqueeze(1)).sigmoid()
+    ref = final.float() + gate_val * shared_output.float()
+    ref = ref.to(dtype)
+
+    out = fused_gate_sigmoid_mul_add(
+        hidden_states, gate_weight, shared_output.clone(), final.clone()
+    )
+
+    tol = 1e-2 if dtype == torch.bfloat16 else 5e-3
+    torch.testing.assert_close(out, ref, atol=tol, rtol=tol)
+
+
+def test_fused_gate_sigmoid_mul_add_is_inplace(device: str) -> None:
+    hidden_states = torch.randn(8, 256, device=device, dtype=torch.bfloat16)
+    gate_weight = torch.randn(256, device=device, dtype=torch.bfloat16)
+    shared_output = torch.randn(8, 256, device=device, dtype=torch.bfloat16)
+    final = torch.randn(8, 256, device=device, dtype=torch.bfloat16)
+
+    result = fused_gate_sigmoid_mul_add(
+        hidden_states, gate_weight, shared_output, final
+    )
+    assert result.data_ptr() == final.data_ptr()
+
+
+def test_fused_gate_sigmoid_mul_add_empty(device: str) -> None:
+    hidden_states = torch.empty(0, 256, device=device, dtype=torch.bfloat16)
+    gate_weight = torch.randn(256, device=device, dtype=torch.bfloat16)
+    shared_output = torch.empty(0, 256, device=device, dtype=torch.bfloat16)
+    final = torch.empty(0, 256, device=device, dtype=torch.bfloat16)
+
+    out = fused_gate_sigmoid_mul_add(hidden_states, gate_weight, shared_output, final)
+    assert out.shape == (0, 256)


### PR DESCRIPTION
## Summary

- Fuse shared expert gate (dot product) + sigmoid + multiply + residual add into a single Triton kernel (fused_gate_sigmoid_mul_add) in the Qwen3.5 MoE block, replacing 3+ separate CUDA kernel launches
- Move gate computation out of the CUDA stream fork branch and combine it with the final add after fork join, reducing memory traffic (hidden_states read once instead of twice)

  before | after
  ----- | -----
  <img width="1328" height="546" alt="image" src="https://github.com/user-attachments/assets/7153e134-8d4e-48cd-bca5-64a46cc6ad0f" /> |  <img width="1226" height="532" alt="image" src="https://github.com/user-attachments/assets/e809998d-bf0e-43ee-84df-e610a59c2b0e" />


<!-- What changed and why? -->

## Test Plan

-  [x] pytest tokenspeed-kernel/test/ops/test_activation.py -v — new tests verify fused kernel correctness (bf16/fp16, various token counts and hidden dims), in-place semantics, and empty-tensor edge case
- [x] Run Qwen3.5 MoE decode + prefill e2e to confirm no numerical regression
-  [x] Verify no performance regression in MoE layer latency (expect slight improvement from reduced kernel launch overhead)

<!-- How was this validated? -->
