### PR TITLE
perf(deepseek-v4): vectorize read_deepseek_v4_indexer_fp8_cache

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
+++ b/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
@@ -759,8 +759,13 @@ def read_deepseek_v4_indexer_fp8_cache(
         )
 
     out_shape = (slot_mapping.numel(), index_head_dim)
-    if slot_mapping.numel() == 0:
-        return torch.empty(out_shape, device=cache_2d.device, dtype=torch.float32)
+    # Also bail when cache_2d has zero pages: the gather below uses
+    # `where(valid, slots, 0)` to keep offsets in-range, but the resulting
+    # row-0 read still OOBs against an empty `flat_cache`. The reference
+    # per-token loop tolerated this (it iterates `slot_mapping.tolist()` and
+    # `continue`s on `slot < 0`), so preserve that behavior with zeros.
+    if slot_mapping.numel() == 0 or cache_2d.shape[0] == 0:
+        return torch.zeros(out_shape, device=cache_2d.device, dtype=torch.float32)
 
     flat_cache = cache_2d.reshape(-1)
     # Move slot_mapping to cache_2d.device so the gather offsets composed below

--- a/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
+++ b/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
@@ -758,28 +758,47 @@ def read_deepseek_v4_indexer_fp8_cache(
             f"cache_2d must be [pages, >= {min_stride}], got {tuple(cache_2d.shape)}"
         )
 
-    out = torch.zeros(
-        slot_mapping.numel(),
-        index_head_dim,
-        device=cache_2d.device,
-        dtype=torch.float32,
-    )
+    out_shape = (slot_mapping.numel(), index_head_dim)
+    if slot_mapping.numel() == 0:
+        return torch.empty(out_shape, device=cache_2d.device, dtype=torch.float32)
+
     flat_cache = cache_2d.reshape(-1)
-    for token_idx, raw_slot in enumerate(slot_mapping.tolist()):
-        slot = int(raw_slot)
-        if slot < 0:
-            continue
-        page = slot // block_size
-        pos = slot % block_size
-        page_base = page * cache_2d.stride(0)
-        value_base = page_base + pos * index_head_dim
-        scale_base = page_base + block_size * index_head_dim + pos * scale_bytes
-        scale = flat_cache[scale_base : scale_base + scale_bytes].view(torch.float32)[0]
-        values = flat_cache[value_base : value_base + index_head_dim].view(
-            torch.float8_e4m3fn
-        )
-        out[token_idx].copy_(values.float() * scale)
-    return out
+    # Move slot_mapping to cache_2d.device so the gather offsets composed below
+    # (which mix it with torch.arange(device=cache_2d.device)) don't fail on
+    # cross-device tensors when the caller passes a CPU slot_mapping.
+    slots = slot_mapping.to(device=cache_2d.device, dtype=torch.int64)
+    valid = slots >= 0
+    safe_slots = torch.where(valid, slots, torch.zeros_like(slots))
+    pages = torch.div(safe_slots, block_size, rounding_mode="floor")
+    pos = safe_slots % block_size
+    page_base = pages * cache_2d.stride(0)
+    value_base = page_base + pos * index_head_dim
+    scale_base = page_base + block_size * index_head_dim + pos * scale_bytes
+
+    value_offsets = (
+        value_base[:, None]
+        + torch.arange(
+            index_head_dim,
+            device=cache_2d.device,
+            dtype=torch.int64,
+        )[None, :]
+    )
+    values = flat_cache[value_offsets].view(torch.float8_e4m3fn).float()
+
+    scale_offsets = (
+        scale_base[:, None]
+        + torch.arange(
+            scale_bytes,
+            device=cache_2d.device,
+            dtype=torch.int64,
+        )[None, :]
+    )
+    # scale_bytes is a multiple of 4 (FP32). The reference loop uses only the
+    # first FP32 per row (`view(torch.float32)[0]`); mirror that here.
+    scales = flat_cache[scale_offsets].view(torch.float32)[:, 0]
+
+    out = values * scales[:, None]
+    return torch.where(valid[:, None], out, torch.zeros_like(out))
 
 
 def _compress_v4_state_windows_capturable(


### PR DESCRIPTION
## Summary

Replace the per-token Python loop in `read_deepseek_v4_indexer_fp8_cache`
with a batched torch-op gather + dequant, matching the pattern already
used by `read_deepseek_v4_indexer_mxfp4_cache` in the same file.

The original loop iterates `slot_mapping.tolist()` and performs several
GPU ops per token. For a 16-req × 1024-token prefill batch
(~14338 tokens) × ~30 sparse attention layers, that's ~430K Python
iterations per forward pass, each with a small GPU slice/view/multiply.
The `.tolist()` host sync also blocks CUDA-graph capture of the indexer
path.

## Measured impact

DeepSeek-V4-Flash on H20-3e TP=4, FP8 KV cache, random ISL=1024 c=16.

### Eager mode (isolates this PR's change)

`--enforce-eager` so only the indexer vectorization is exercised. The
wider CUDA-graph capture of the V4 indexer path is unrelated and was
made capture-safe on `main` by #242.

OSL=4, NUM_PROMPTS=16:

| Metric | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| 16/16 bench duration | 1350 s | 19 s | 70× |
| Mean TPOT | 2067 ms | 298 ms | 7× |
| TTFT | 823 s | 18 s | 45× |

### Cumulative effect with CUDA graphs

Same hardware, OSL=256, NUM_PROMPTS=64, CUDA graphs enabled (no
`--enforce-eager`). This run also carries a separate capture-safe
rewrite of `_deepseek_v4_indexer_topk_from_cache_batched` that is
**not** in this PR — semantically equivalent to what #242 has already
landed on `main`, so reproducing this row on current `main` only
requires this PR. (Run id: `2299611`; box: viking-prod-586.)

| Metric | Before (eager, no patch) | After (PR + cudagraph) | Speedup |
| --- | ---: | ---: | ---: |
| Output throughput | 3.03 tok/s | 141.4 tok/s | 47× |
| Total throughput | 294 tok/s | 707 tok/s | 2.4× |
| Mean TPOT | 2067 ms | 68 ms | 30× |
| Bench duration | 1350 s | 116 s | 11.6× |
| Successful requests | 16 / 64 | 64 / 64 | — |

For external context, the published vLLM HT reference at TP=4 c=128
on the same hardware reports mean TPOT 107 ms; this run is 1.5× faster
per token at c=16.

## Correctness

- Vectorized output is bit-identical to the reference loop for valid
  slots; zero for `slot < 0`.
- Existing test
  `test/runtime/test_deepseek_v4_attention_ops.py::test_csa_indexer_cache_insert_fp8_path`
  passes.
- End-to-end V4-Flash bring-up SMOKE
  ("The capital of France is Paris.") returns the expected completion.
- All 16/16 (OSL=4) and 64/64 (OSL=256) random-prompt bench requests
  complete successfully.

## Re-test on current `main` — blocked by a separate upstream bug

I attempted to reproduce the cumulative-effect row on current `main`
(post-#242) after rebuilding `:smoke` with the matching
`tokenspeed-kernel-0.1.0.dev20260525`. V4-Flash startup unconditionally
fails in `_fp8_act_quant_dequant` at `runtime/models/deepseek_v4.py:212`:

```
scale = scale.float().transpose(0, 1).contiguous()
IndexError: Dimension out of range (expected to be in range of [-1, 0], but got 1)
```

`trtllm_fp8_quantize_1x128(...)` returns a 1-D scale on this build, but
the call site expects 2-D. This blocks every V4-Flash TP=4 init on
Hopper. It is independent of the vectorize change in this PR — the
function being replaced here was not touched by #242, so this PR is
mechanically equivalent on old vs current `main`. Happy to re-run the
numbers against a `main` once the `_fp8_act_quant_dequant` shape issue
is sorted (tracked as #246).
