### PR TITLE
docs: fix mla_l1_5_args docstring and mini_lb module description

### DIFF
--- a/python/tokenspeed/runtime/pd/mini_lb.py
+++ b/python/tokenspeed/runtime/pd/mini_lb.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Minimal HTTP load balancer for prefill and decode servers used in tests."""
+"""Minimal HTTP load balancer for routing requests between prefill and decode servers."""
 
 import asyncio
 import contextlib

--- a/python/tokenspeed/runtime/pd/mooncake/sender.py
+++ b/python/tokenspeed/runtime/pd/mooncake/sender.py
@@ -71,9 +71,10 @@ class MooncakeKVSender:
     ):
         """
         Send the kv cache at the given kv indices to the decoder server
-        mla_l1_5_args: optional (page_transfer_mask, page_local_indices)
+        mla_l1_5_args: optional PageTransferMetadata dataclass with fields:
+            indices_are_local: whether page_local_indices are already in local address space
             page_transfer_mask: boolean mask to select decode pages that will receive data from this prefill rank
-            page_local_indices: remapped local page indices that this prefill rank will send
+            page_local_indices: remapped local page indices that this prefill rank will send (optional)
         bootstrap_token: first output token produced by prefill (shipped via ZMQ status msg).
         """
         index_slice = slice(self.curr_idx, self.curr_idx + len(kv_indices))


### PR DESCRIPTION
## Doc/Code Alignment Fix

Found two documentation mismatches between docstrings and the actual implementation.

### Changes

1. `python/tokenspeed/runtime/pd/mooncake/sender.py:74`
   - **Before:** `mla_l1_5_args: optional (page_transfer_mask, page_local_indices)` — describes a plain tuple
   - **After:** correctly documents it as a `PageTransferMetadata` dataclass, adds the missing `indices_are_local` field, and marks `page_local_indices` as optional (matching the dataclass definition)

2. `python/tokenspeed/runtime/pd/mini_lb.py:21`
   - **Before:** `"""Minimal HTTP load balancer for prefill and decode servers used in tests."""`
   - **After:** removes the misleading "used in tests" — `MiniLoadBalancer` is a production PD serving component, not test-only

### Verification

| Check | Result |
|-------|--------|
| Logic change | ✅ None — docstrings only |