### PR TITLE
fix(env): add missing runtime packages to PACKAGE_LIST

### DIFF
--- a/python/tokenspeed/env.py
+++ b/python/tokenspeed/env.py
@@ -72,6 +72,9 @@ PACKAGE_LIST = [
     "requests",
     "setproctitle",
     "tiktoken",
+    "tokenspeed-smg",
+    "tokenspeed-smg-grpc-proto",
+    "tokenspeed-smg-grpc-servicer",
     "torch",
     "torchvision",
     "tqdm",
@@ -79,6 +82,7 @@ PACKAGE_LIST = [
     "uv",
     "uvicorn",
     "uvloop",
+    "viztracer",
     "xgrammar",
 ]
 


### PR DESCRIPTION
## Summary

`tokenspeed env` reports versions for packages in `PACKAGE_LIST`, but four
`pyproject.toml` runtime dependencies were missing from the list:

- `tokenspeed-smg`
- `tokenspeed-smg-grpc-proto`
- `tokenspeed-smg-grpc-servicer`
- `viztracer`

The smg packages are date-pinned (e.g., `1.4.1.post20260519`), so knowing
their exact installed version matters when triaging serving-layer issues.

## Test Plan

- `tokenspeed env` now includes the four packages in its output.
- No behavior change for any other code path.