### PR TITLE
chore(qwen3.5): adjust qwen perf tps threshold

### DIFF
--- a/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic.yaml
+++ b/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic.yaml
@@ -93,6 +93,6 @@ perf_threshold: 0.9
 # Values are [Latency (tps/user), Throughput (tps/gpu)]; gate fails any conc whose actual falls below ref * perf_threshold.
 perf_reference:
   1:  [530, 11600]
-  2:  [440, 17800]
+  2:  [420, 17800]
   4:  [270, 24400]
   8:  [160, 31600]


### PR DESCRIPTION
## Summary
Adjust latency threshold from 440 -> 420 tps at concurrency=2
<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
