### PR TITLE
ci(perf-qwen3.5-agentic): route to gb200-4gpu-perf runner

### DIFF
--- a/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic.yaml
+++ b/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic.yaml
@@ -6,7 +6,7 @@ triggers:
   - manual
 runner:
   labels:
-    - gb200-4gpu
+    - gb200-4gpu-perf
 env:
   CI: "true"
 install:


### PR DESCRIPTION
Switches the qwen3.5 agentic perf task from the shared `gb200-4gpu` pool to the dedicated `gb200-4gpu-perf` pool so the multi-turn sweep doesn't contend with other gb200-4gpu jobs and runs on a node tuned for perf measurements.