### PR TITLE
fix(kernel): drop Triton vendored CUDA include path from nvcc -I

### DIFF
--- a/tokenspeed-kernel/python/setup.py
+++ b/tokenspeed-kernel/python/setup.py
@@ -520,13 +520,6 @@ class CudaKernelBuilder:
                     _add_dir(candidate)
                 if (candidate / "cccl").exists():
                     _add_dir(candidate / "cccl")
-            for rel in (
-                "tokenspeed_triton/backends/nvidia/include",
-                "triton/backends/nvidia/include",
-            ):
-                candidate = base_path / rel
-                if (candidate / "cuda_runtime.h").exists():
-                    _add_dir(candidate)
 
         try:
             tvm_ffi = importlib.import_module("tvm_ffi")


### PR DESCRIPTION
`_resolve_include_dirs` folds `tokenspeed_triton/backends/nvidia/include` and `triton/backends/nvidia/include` into nvcc's `-I`. Those bundles ship a CUDA-12-era `crt/host_runtime.h` whose `__cudaLaunch` is a 1-arg macro; nvcc 13.0's generated stubs call it with 2 args. On hosts where the system CUDA's `crt/host_runtime.h` isn't on nvcc's implicit search path (e.g. apt-installed CUDA 13 SDK behind a `/usr/local/cuda` symlink, observed in smg CI), the build dies with `error: macro "__cudaLaunch" passed 2 arguments, but takes just 1`. `CUDA_HOME/include` and the `nvidia/cu*/include` block already cover what nvcc needs, so drop the Triton block.

Verified inline-patched in lightseekorg/smg#1515 — once that CI is green the same change is safe to merge here.