### PR TITLE
Fix: fix a hang bug in tp server.

### DIFF
--- a/tokenspeed-scheduler/csrc/resource/allocator/mamba_chunk_allocator.cpp
+++ b/tokenspeed-scheduler/csrc/resource/allocator/mamba_chunk_allocator.cpp
@@ -28,9 +28,8 @@ MambaSlot::MambaSlot(std::int32_t index, MambaChunkAllocator* allocator)
       }) {}
 
 MambaChunkAllocator::MambaChunkAllocator(std::int32_t num_slots) : total_slots_{num_slots} {
-    free_list_.reserve(num_slots);
-    for (std::int32_t i = num_slots - 1; i >= 0; --i) {
-        free_list_.push_back(i);
+    for (std::int32_t i = 0; i < num_slots; ++i) {
+        free_list_.push(i);
     }
 }
 
@@ -38,13 +37,13 @@ std::optional<MambaSlot> MambaChunkAllocator::Allocate() {
     if (free_list_.empty()) {
         return std::nullopt;
     }
-    std::int32_t index = free_list_.back();
-    free_list_.pop_back();
+    std::int32_t index = free_list_.top();
+    free_list_.pop();
     return MambaSlot{index, this};
 }
 
 void MambaChunkAllocator::Free(std::int32_t index) {
-    free_list_.push_back(index);
+    free_list_.push(index);
 }
 
 MambaSlot::~MambaSlot() {

--- a/tokenspeed-scheduler/csrc/resource/allocator/mamba_chunk_allocator.h
+++ b/tokenspeed-scheduler/csrc/resource/allocator/mamba_chunk_allocator.h
@@ -21,7 +21,9 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <optional>
+#include <queue>
 #include <vector>
 
 #include "resource/radix_tree/mamba_slot.h"
@@ -39,7 +41,14 @@ public:
     std::int32_t TotalSlots() const { return total_slots_; }
 
 private:
-    std::vector<std::int32_t> free_list_;
+    // Min-heap of free indices: Allocate() always returns the smallest free
+    // index, so allocation results are independent of the order in which
+    // Free() is called. This is required for TP rank determinism — slot
+    // releases may fire from async transfer-completion callbacks whose
+    // ordering differs per rank, but the resulting allocator state must be
+    // identical across ranks (the C++ scheduler is mirrored).
+    std::priority_queue<std::int32_t, std::vector<std::int32_t>, std::greater<std::int32_t>>
+        free_list_;
     std::int32_t total_slots_;
 };
 

--- a/tokenspeed-scheduler/csrc/resource/allocator/mamba_chunk_allocator.h
+++ b/tokenspeed-scheduler/csrc/resource/allocator/mamba_chunk_allocator.h
@@ -47,8 +47,7 @@ private:
     // releases may fire from async transfer-completion callbacks whose
     // ordering differs per rank, but the resulting allocator state must be
     // identical across ranks (the C++ scheduler is mirrored).
-    std::priority_queue<std::int32_t, std::vector<std::int32_t>, std::greater<std::int32_t>>
-        free_list_;
+    std::priority_queue<std::int32_t, std::vector<std::int32_t>, std::greater<std::int32_t>> free_list_;
     std::int32_t total_slots_;
 };
 

--- a/tokenspeed-scheduler/csrc/resource/allocator/mamba_host_allocator.cpp
+++ b/tokenspeed-scheduler/csrc/resource/allocator/mamba_host_allocator.cpp
@@ -25,10 +25,9 @@
 namespace tokenspeed {
 
 MambaHostAllocator::MambaHostAllocator(std::int32_t num_slots) : total_slots_{num_slots} {
-    free_list_.reserve(num_slots);
     released_idx_queue_.reserve(num_slots);
-    for (std::int32_t i = num_slots - 1; i >= 0; --i) {
-        free_list_.push_back(i);
+    for (std::int32_t i = 0; i < num_slots; ++i) {
+        free_list_.push(i);
     }
 }
 
@@ -36,8 +35,8 @@ std::optional<MambaSlot> MambaHostAllocator::Allocate() {
     if (free_list_.empty()) {
         return std::nullopt;
     }
-    std::int32_t index = free_list_.back();
-    free_list_.pop_back();
+    std::int32_t index = free_list_.top();
+    free_list_.pop();
     return MambaSlot{index, [this](std::int32_t i) { Free(i); }};
 }
 
@@ -45,7 +44,7 @@ void MambaHostAllocator::Free(std::int32_t index) {
     if (index < 0 || index >= total_slots_) {
         return;
     }
-    free_list_.push_back(index);
+    free_list_.push(index);
     released_idx_queue_.push_back(index);
 }
 
@@ -53,6 +52,10 @@ std::vector<std::int32_t> MambaHostAllocator::DrainReleased(std::size_t max) {
     std::size_t n = std::min(max, released_idx_queue_.size());
     std::vector<std::int32_t> released(released_idx_queue_.begin(), released_idx_queue_.begin() + n);
     released_idx_queue_.erase(released_idx_queue_.begin(), released_idx_queue_.begin() + n);
+    // Sort so the drained set is order-independent across TP ranks (Free()
+    // callbacks may fire in different orders per rank). Consumers only need
+    // the SET of released indices.
+    std::sort(released.begin(), released.end());
     return released;
 }
 

--- a/tokenspeed-scheduler/csrc/resource/allocator/mamba_host_allocator.h
+++ b/tokenspeed-scheduler/csrc/resource/allocator/mamba_host_allocator.h
@@ -22,7 +22,9 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <optional>
+#include <queue>
 #include <vector>
 
 #include "resource/radix_tree/mamba_slot.h"
@@ -41,7 +43,13 @@ public:
     std::int32_t TotalSlots() const { return total_slots_; }
 
 private:
-    std::vector<std::int32_t> free_list_;
+    // See mamba_chunk_allocator.h for the rationale: min-heap free list keeps
+    // Allocate() output independent of Free() ordering so TP ranks stay in sync
+    // even when slot-release callbacks fire at different times per rank.
+    std::priority_queue<std::int32_t, std::vector<std::int32_t>, std::greater<std::int32_t>>
+        free_list_;
+    // DrainReleased() sorts before returning, so insertion order here doesn't
+    // affect cross-rank determinism.
     std::vector<std::int32_t> released_idx_queue_;
     std::int32_t total_slots_;
 };

--- a/tokenspeed-scheduler/csrc/resource/allocator/mamba_host_allocator.h
+++ b/tokenspeed-scheduler/csrc/resource/allocator/mamba_host_allocator.h
@@ -46,8 +46,7 @@ private:
     // See mamba_chunk_allocator.h for the rationale: min-heap free list keeps
     // Allocate() output independent of Free() ordering so TP ranks stay in sync
     // even when slot-release callbacks fire at different times per rank.
-    std::priority_queue<std::int32_t, std::vector<std::int32_t>, std::greater<std::int32_t>>
-        free_list_;
+    std::priority_queue<std::int32_t, std::vector<std::int32_t>, std::greater<std::int32_t>> free_list_;
     // DrainReleased() sorts before returning, so insertion order here doesn't
     // affect cross-rank determinism.
     std::vector<std::int32_t> released_idx_queue_;

--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/mamba_eviction_manager.cpp
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/mamba_eviction_manager.cpp
@@ -64,7 +64,20 @@ void MambaEvictionManager::UpdateLeaf(TreeNode* node) {
 }
 
 std::int32_t MambaEvictionManager::Evict(std::int32_t num_slots, TreeNode* protected_node) {
-    auto older = [](const TreeNode* a, const TreeNode* b) { return a->Time() > b->Time(); };
+    // TP-determinism: ties on Time() must resolve identically across ranks.
+    // mamba_leaves_ is unordered_set<TreeNode*> whose iteration order is
+    // pointer-hash-randomized per-process, so the priority_queue's push order
+    // (and thus internal heap structure for tied elements) diverges across
+    // ranks. Comparing only on Time() leaves ties resolved by heap order →
+    // different ranks evict different leaves on Time ties → cascading parent
+    // re-insertions cause mamba_leaves_ membership to permanently diverge,
+    // eventually wedging the next NCCL collective.
+    // SeqId() is assigned monotonically at TreeNode construction; all ranks
+    // construct nodes in the same order, so SeqId() is identical across ranks.
+    auto older = [](const TreeNode* a, const TreeNode* b) {
+        if (a->Time() != b->Time()) return a->Time() > b->Time();
+        return a->SeqId() > b->SeqId();
+    };
     std::priority_queue<TreeNode*, std::vector<TreeNode*>, decltype(older)> candidates(older);
 
     for (TreeNode* n : mamba_leaves_) {

--- a/tokenspeed-scheduler/csrc/resource/kv_prefix_cache/eviction.h
+++ b/tokenspeed-scheduler/csrc/resource/kv_prefix_cache/eviction.h
@@ -77,7 +77,7 @@ void ResourceManager<RType>::removeLeaf(TreeNode* node) {
 
     auto it = node_time_.find(node);
     if (it != node_time_.end()) {
-        lru_leaves_.erase({it->second, node});
+        lru_leaves_.erase({it->second, node->SeqId(), node});
         node_time_.erase(it);
         if (HasResource<RType>(node)) {
             GetResource<RType>(node).ClearEvictableNotifier();
@@ -99,7 +99,7 @@ void ResourceManager<RType>::updateLeaf(TreeNode* node) {
 
     if (IsLeaf<RType>(node)) {
         auto ts = node->Time();
-        lru_leaves_.insert({ts, node});
+        lru_leaves_.insert({ts, node->SeqId(), node});
         node_time_[node] = ts;
         // When the last lock on this node is released, OnNodeEvictable refreshes
         // the LRU sort key so Touch() calls made while locked are reflected.
@@ -129,8 +129,8 @@ std::vector<TreeNode*> ResourceManager<RType>::Evict(std::int32_t num_pages) {
     std::int32_t evicted = 0;
     while (evicted < num_pages && !lru_leaves_.empty()) {
         auto it = lru_leaves_.begin();  // oldest (LRU) first
-        TreeNode* leaf = it->second;
-        timestamp_t ts = it->first;
+        timestamp_t ts = std::get<0>(*it);
+        TreeNode* leaf = std::get<2>(*it);
         lru_leaves_.erase(it);
         node_time_.erase(leaf);
 
@@ -165,7 +165,7 @@ std::vector<TreeNode*> ResourceManager<RType>::Evict(std::int32_t num_pages) {
     // the node was locked is reflected in LRU order immediately.
     for (auto& [ts, node] : deferred_locked) {
         auto current_ts = node->Time();
-        lru_leaves_.insert({current_ts, node});
+        lru_leaves_.insert({current_ts, node->SeqId(), node});
         node_time_[node] = current_ts;
         GetResource<RType>(node).BindEvictableNotifier(this, node);
     }

--- a/tokenspeed-scheduler/csrc/resource/radix_tree/tree_node.cpp
+++ b/tokenspeed-scheduler/csrc/resource/radix_tree/tree_node.cpp
@@ -29,8 +29,12 @@
 #include "resource/types.h"
 namespace tokenspeed {
 
+std::atomic<TreeNode::seq_id_t> TreeNode::next_seq_id_{0};
+
 TreeNode::TreeNode(token_vec_t tokens, timestamp_t access_time)
-    : tokens_{std::move(tokens)}, last_access_time_{access_time} {}
+    : tokens_{std::move(tokens)},
+      last_access_time_{access_time},
+      seq_id_{next_seq_id_.fetch_add(1, std::memory_order_relaxed)} {}
 
 void TreeNode::AddChild(const token_vec_t& key, std::unique_ptr<TreeNode>&& child) {
     if (child == nullptr) [[unlikely]] {

--- a/tokenspeed-scheduler/csrc/resource/radix_tree/tree_node.h
+++ b/tokenspeed-scheduler/csrc/resource/radix_tree/tree_node.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -53,6 +54,11 @@ class TreeNode {
 public:
     using children_map_t = std::unordered_map<token_vec_t, std::unique_ptr<TreeNode>, TokenVecHash>;
     using timestamp_t = std::chrono::steady_clock::time_point;
+    // Monotonically increasing identifier assigned at construction. Used as a
+    // deterministic tiebreaker in eviction orderings whose primary key (Time())
+    // can repeat. Pointer values are not usable as a tiebreaker because they
+    // are randomized per-process and would diverge across TP ranks.
+    using seq_id_t = std::int64_t;
 
     explicit TreeNode(token_vec_t tokens = {}, timestamp_t access_time = std::chrono::steady_clock::now());
     ~TreeNode() = default;
@@ -77,6 +83,7 @@ public:
     const std::size_t NumChildren() const { return children_.size(); }
     const children_map_t& Children() const { return children_; }
     timestamp_t Time() const { return last_access_time_; }
+    seq_id_t SeqId() const { return seq_id_; }
 
     template <ResourceType RType>
     void AttachResource(std::unique_ptr<NodeResource<RType>>&& resource) {
@@ -143,12 +150,15 @@ private:
     std::vector<std::string> page_hashes_{};
     std::vector<std::uint64_t> block_hashes_{};
     timestamp_t last_access_time_{std::chrono::steady_clock::now()};
+    seq_id_t seq_id_{};
     bool storage_persisted_{false};
     std::unique_ptr<DeviceResource> device_resource_{};
     std::unique_ptr<HostResource> host_resource_{};
     std::unique_ptr<MambaSlot> mamba_slot_{};
     std::unique_ptr<MambaSlot> mamba_host_slot_{};
     std::unique_ptr<PagedCacheSnapshot> paged_cache_snapshot_{};
+
+    static std::atomic<seq_id_t> next_seq_id_;
 };
 
 template <ResourceType RType>

--- a/tokenspeed-scheduler/csrc/resource/radix_tree/tree_resource.h
+++ b/tokenspeed-scheduler/csrc/resource/radix_tree/tree_resource.h
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <functional>
 #include <set>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -119,7 +120,7 @@ public:
     // O(N) scan — locked leaves are in lru_leaves_ but not evictable.
     std::int32_t EvictablePagesNum() const {
         std::int32_t total = 0;
-        for (const auto& [ts, node] : lru_leaves_) {
+        for (const auto& [ts, sid, node] : lru_leaves_) {
             const auto& res = GetResource<RType>(node);
             if (res.IsEvictable()) {
                 total += res.NumPages();
@@ -135,7 +136,13 @@ private:
     PageAllocator* allocator_;
     // Leaf nodes sorted by last-access time (oldest first = LRU eviction order).
     // node_time_ holds each node's sort key for O(1) keyed removal.
-    std::set<std::pair<timestamp_t, TreeNode*>> lru_leaves_;
+    // Tuple key: (Time, SeqId, TreeNode*). SeqId is the deterministic
+    // tiebreaker — pointer values would diverge across TP ranks (per-process
+    // ASLR), causing different ranks to evict different leaves on Time ties
+    // and eventually wedging the next NCCL collective. Stored as std::int64_t
+    // (not TreeNode::seq_id_t) to keep the include cycle broken — tree_node.h
+    // pulls in this header for NodeResource.
+    std::set<std::tuple<timestamp_t, std::int64_t, TreeNode*>> lru_leaves_;
     std::unordered_map<TreeNode*, timestamp_t> node_time_;
     EvictionCallback eviction_callback_{};
 };

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -565,11 +565,10 @@ Scheduler::newForwardOperation(std::vector<Request*> candidates) {
     // and — when token_budget / page / mamba-slot constraints are tight — picks
     // a different subset to schedule. That made forward_op None on some ranks
     // and non-None on others, deadlocking the next NCCL collective.
-    std::sort(candidates.begin(), candidates.end(),
-              [&](const auto& a, const auto& b) {
-                  int pa = priority(a), pb = priority(b);
-                  return pa != pb ? pa < pb : a->Id() < b->Id();
-              });
+    std::sort(candidates.begin(), candidates.end(), [&](const auto& a, const auto& b) {
+        int pa = priority(a), pb = priority(b);
+        return pa != pb ? pa < pb : a->Id() < b->Id();
+    });
 
     std::vector<ForwardOperation> ops;
     std::int32_t token_budget = config_.max_scheduled_tokens;

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -558,8 +558,18 @@ Scheduler::newForwardOperation(std::vector<Request*> candidates) {
         if (req->Is<fsm::Retracted>()) return 4;
         return 9;
     };
+    // TP-determinism: tie-break on Request::Id() so the relative order within a
+    // priority class is identical across ranks. requests_ is an unordered_map
+    // keyed by string id; libstdc++ randomizes string hashing per process, so
+    // without the tiebreaker each rank visits candidates in a different order
+    // and — when token_budget / page / mamba-slot constraints are tight — picks
+    // a different subset to schedule. That made forward_op None on some ranks
+    // and non-None on others, deadlocking the next NCCL collective.
     std::sort(candidates.begin(), candidates.end(),
-              [&](const auto& a, const auto& b) { return priority(a) < priority(b); });
+              [&](const auto& a, const auto& b) {
+                  int pa = priority(a), pb = priority(b);
+                  return pa != pb ? pa < pb : a->Id() < b->Id();
+              });
 
     std::vector<ForwardOperation> ops;
     std::int32_t token_budget = config_.max_scheduled_tokens;

--- a/tokenspeed-scheduler/tests/cpp/test_eviction_lru.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_eviction_lru.cpp
@@ -199,15 +199,13 @@ TEST(EvictionLRUDeterminism, EvictionDeterministicOnTimeTies) {
 
     auto t1 = MakeAlignedTokens(1, kPageSize, 1);
     auto first = std::make_unique<TreeNode>(t1, ts);
-    first->AttachResource<ResourceType::Device>(
-        std::make_unique<DeviceResource>(alloc.Allocate(1)));
+    first->AttachResource<ResourceType::Device>(std::make_unique<DeviceResource>(alloc.Allocate(1)));
     TreeNode* first_raw = first.get();
     root.AddChild(t1, std::move(first));
 
     auto t2 = MakeAlignedTokens(1, kPageSize, 5);
     auto second = std::make_unique<TreeNode>(t2, ts);
-    second->AttachResource<ResourceType::Device>(
-        std::make_unique<DeviceResource>(alloc.Allocate(1)));
+    second->AttachResource<ResourceType::Device>(std::make_unique<DeviceResource>(alloc.Allocate(1)));
     TreeNode* second_raw = second.get();
     root.AddChild(t2, std::move(second));
 

--- a/tokenspeed-scheduler/tests/cpp/test_eviction_lru.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_eviction_lru.cpp
@@ -26,6 +26,7 @@
 
 #include "unit_test_helper.h"
 #include "resource/allocator/page_allocator.h"
+#include "resource/kv_prefix_cache/eviction.h"
 #include "resource/kv_prefix_cache/kv_prefix_cache.h"
 #include "resource/radix_tree/tree_node.h"
 #include "resource/types.h"
@@ -179,6 +180,48 @@ TEST_F(EvictionLRUTest, EvictablePagesNumExcludesLockedLeaves) {
     // Release lock — node becomes evictable again via OnNodeEvictable callback.
     ref = DeviceNodeRef(nullptr);
     EXPECT_EQ(cache_->GetDeviceManager().EvictablePagesNum(), 3);
+}
+
+// ---------------------------------------------------------------------------
+// TP-determinism: when two leaves share Time(), the LRU set must break ties
+// on SeqId (not on pointer value, which is ASLR-randomized per process).
+// Without this, different TP ranks evict different leaves on Time ties and
+// the next NCCL collective deadlocks on a shape mismatch.
+// ---------------------------------------------------------------------------
+
+TEST(EvictionLRUDeterminism, EvictionDeterministicOnTimeTies) {
+    constexpr int32_t kPageSize = 4;
+    constexpr int32_t kTotalPages = 32;
+    PageAllocator alloc(kPageSize, kTotalPages);
+
+    auto ts = std::chrono::steady_clock::now();
+    TreeNode root;
+
+    auto t1 = MakeAlignedTokens(1, kPageSize, 1);
+    auto first = std::make_unique<TreeNode>(t1, ts);
+    first->AttachResource<ResourceType::Device>(
+        std::make_unique<DeviceResource>(alloc.Allocate(1)));
+    TreeNode* first_raw = first.get();
+    root.AddChild(t1, std::move(first));
+
+    auto t2 = MakeAlignedTokens(1, kPageSize, 5);
+    auto second = std::make_unique<TreeNode>(t2, ts);
+    second->AttachResource<ResourceType::Device>(
+        std::make_unique<DeviceResource>(alloc.Allocate(1)));
+    TreeNode* second_raw = second.get();
+    root.AddChild(t2, std::move(second));
+
+    ASSERT_EQ(first_raw->Time(), second_raw->Time());
+    ASSERT_LT(first_raw->SeqId(), second_raw->SeqId());
+
+    DeviceManager mgr(&alloc);
+    mgr.UpdateLeaves(first_raw);
+    mgr.UpdateLeaves(second_raw);
+
+    auto evicted = mgr.Evict(1);
+    ASSERT_EQ(evicted.size(), 1u);
+    // Smaller SeqId is older — must be evicted first under SeqId tiebreak.
+    EXPECT_EQ(evicted.front(), first_raw);
 }
 
 }  // namespace tokenspeed::test

--- a/tokenspeed-scheduler/tests/cpp/test_mamba_eviction.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_mamba_eviction.cpp
@@ -134,8 +134,7 @@ TEST_F(MambaEvictionTest, EvictDeterministicOnTimeTies) {
 
     auto t1 = token_vec_t{1, 2};
     auto first = std::make_unique<TreeNode>(t1, ts);
-    first->AttachResource<ResourceType::Device>(
-        std::make_unique<DeviceResource>(page_alloc_->Allocate(1)));
+    first->AttachResource<ResourceType::Device>(std::make_unique<DeviceResource>(page_alloc_->Allocate(1)));
     auto slot1 = mamba_alloc_->Allocate();
     ASSERT_TRUE(slot1.has_value());
     first->AttachMamba(std::make_unique<MambaSlot>(std::move(*slot1)));
@@ -145,8 +144,7 @@ TEST_F(MambaEvictionTest, EvictDeterministicOnTimeTies) {
 
     auto t2 = token_vec_t{3, 4};
     auto second = std::make_unique<TreeNode>(t2, ts);
-    second->AttachResource<ResourceType::Device>(
-        std::make_unique<DeviceResource>(page_alloc_->Allocate(1)));
+    second->AttachResource<ResourceType::Device>(std::make_unique<DeviceResource>(page_alloc_->Allocate(1)));
     auto slot2 = mamba_alloc_->Allocate();
     ASSERT_TRUE(slot2.has_value());
     second->AttachMamba(std::make_unique<MambaSlot>(std::move(*slot2)));

--- a/tokenspeed-scheduler/tests/cpp/test_mamba_eviction.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_mamba_eviction.cpp
@@ -122,4 +122,54 @@ TEST_F(MambaEvictionTest, LeafPromotion) {
     EXPECT_FALSE(a->HasMamba());
 }
 
+// ---------------------------------------------------------------------------
+// TP-determinism: on Time() ties, smaller-SeqId leaf must be evicted first
+// regardless of pointer ordering. Guards against pointer-randomized
+// unordered_set iteration causing different TP ranks to evict different
+// leaves and wedging the next NCCL collective.
+// ---------------------------------------------------------------------------
+
+TEST_F(MambaEvictionTest, EvictDeterministicOnTimeTies) {
+    auto ts = std::chrono::steady_clock::now();
+
+    auto t1 = token_vec_t{1, 2};
+    auto first = std::make_unique<TreeNode>(t1, ts);
+    first->AttachResource<ResourceType::Device>(
+        std::make_unique<DeviceResource>(page_alloc_->Allocate(1)));
+    auto slot1 = mamba_alloc_->Allocate();
+    ASSERT_TRUE(slot1.has_value());
+    first->AttachMamba(std::make_unique<MambaSlot>(std::move(*slot1)));
+    TreeNode* first_raw = first.get();
+    root_.AddChild(t1, std::move(first));
+    eviction_->TrackNode(first_raw);
+
+    auto t2 = token_vec_t{3, 4};
+    auto second = std::make_unique<TreeNode>(t2, ts);
+    second->AttachResource<ResourceType::Device>(
+        std::make_unique<DeviceResource>(page_alloc_->Allocate(1)));
+    auto slot2 = mamba_alloc_->Allocate();
+    ASSERT_TRUE(slot2.has_value());
+    second->AttachMamba(std::make_unique<MambaSlot>(std::move(*slot2)));
+    TreeNode* second_raw = second.get();
+    root_.AddChild(t2, std::move(second));
+    eviction_->TrackNode(second_raw);
+
+    ASSERT_EQ(first_raw->Time(), second_raw->Time());
+    ASSERT_LT(first_raw->SeqId(), second_raw->SeqId());
+
+    std::int32_t freed = eviction_->Evict(1);
+    EXPECT_EQ(freed, 1);
+    // Older-by-SeqId is evicted first; tie-breaker must be deterministic.
+    EXPECT_FALSE(first_raw->HasMamba());
+    EXPECT_TRUE(second_raw->HasMamba());
+}
+
+TEST(TreeNodeSeqId, IsMonotonicAcrossConstruction) {
+    TreeNode a;
+    TreeNode b;
+    TreeNode c;
+    EXPECT_LT(a.SeqId(), b.SeqId());
+    EXPECT_LT(b.SeqId(), c.SeqId());
+}
+
 }  // namespace tokenspeed::test

--- a/tokenspeed-scheduler/tests/cpp/test_mamba_slot.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_mamba_slot.cpp
@@ -52,6 +52,34 @@ TEST(MambaChunkAllocatorTest, ExhaustedPoolReturnsNullopt) {
     EXPECT_FALSE(s2.has_value());
 }
 
+TEST(MambaChunkAllocatorTest, AllocateReturnsSmallestFreeIndexRegardlessOfFreeOrder) {
+    // TP-determinism invariant: the index returned by Allocate() must depend
+    // only on the SET of free indices, not on the order in which Free() was
+    // called. Replays the same Free sequence in two different orders and
+    // expects the same Allocate result.
+    MambaChunkAllocator allocator_a(8);
+    MambaChunkAllocator allocator_b(8);
+    // Drain both pools.
+    std::vector<std::optional<MambaSlot>> slots_a, slots_b;
+    for (int i = 0; i < 8; ++i) {
+        slots_a.push_back(allocator_a.Allocate());
+        slots_b.push_back(allocator_b.Allocate());
+    }
+    // Free the same set of indices in opposite orders.
+    slots_a[3].reset();
+    slots_a[6].reset();
+    slots_a[1].reset();
+    slots_b[1].reset();
+    slots_b[6].reset();
+    slots_b[3].reset();
+    auto next_a = allocator_a.Allocate();
+    auto next_b = allocator_b.Allocate();
+    ASSERT_TRUE(next_a.has_value());
+    ASSERT_TRUE(next_b.has_value());
+    EXPECT_EQ(next_a->Index(), next_b->Index());
+    EXPECT_EQ(next_a->Index(), 1);  // smallest free index after freeing {1,3,6}
+}
+
 TEST(MambaHostAllocatorTest, AllocateFreeAndDrainReleased) {
     tokenspeed::MambaHostAllocator allocator(3);
     auto slot = allocator.Allocate();
@@ -65,6 +93,49 @@ TEST(MambaHostAllocatorTest, AllocateFreeAndDrainReleased) {
     ASSERT_EQ(released.size(), 1);
     EXPECT_EQ(released[0], idx);
     EXPECT_TRUE(allocator.DrainReleased().empty());
+}
+
+TEST(MambaHostAllocatorTest, AllocateReturnsSmallestFreeIndexRegardlessOfFreeOrder) {
+    // Mirror of the MambaChunkAllocator determinism test for the host pool.
+    tokenspeed::MambaHostAllocator allocator_a(8);
+    tokenspeed::MambaHostAllocator allocator_b(8);
+    std::vector<std::optional<tokenspeed::MambaSlot>> slots_a, slots_b;
+    for (int i = 0; i < 8; ++i) {
+        slots_a.push_back(allocator_a.Allocate());
+        slots_b.push_back(allocator_b.Allocate());
+    }
+    slots_a[5].reset();
+    slots_a[2].reset();
+    slots_a[7].reset();
+    slots_b[7].reset();
+    slots_b[2].reset();
+    slots_b[5].reset();
+    auto next_a = allocator_a.Allocate();
+    auto next_b = allocator_b.Allocate();
+    ASSERT_TRUE(next_a.has_value());
+    ASSERT_TRUE(next_b.has_value());
+    EXPECT_EQ(next_a->Index(), next_b->Index());
+    EXPECT_EQ(next_a->Index(), 2);
+}
+
+TEST(MambaHostAllocatorTest, DrainReleasedReturnsSortedRegardlessOfFreeOrder) {
+    // The drain output must be order-independent across TP ranks too — the
+    // consumer treats it as a SET of released indices.
+    tokenspeed::MambaHostAllocator allocator(8);
+    std::vector<std::optional<tokenspeed::MambaSlot>> slots;
+    for (int i = 0; i < 8; ++i) {
+        slots.push_back(allocator.Allocate());
+    }
+    slots[5].reset();
+    slots[1].reset();
+    slots[7].reset();
+    slots[3].reset();
+    auto released = allocator.DrainReleased();
+    ASSERT_EQ(released.size(), 4);
+    EXPECT_EQ(released[0], 1);
+    EXPECT_EQ(released[1], 3);
+    EXPECT_EQ(released[2], 5);
+    EXPECT_EQ(released[3], 7);
 }
 
 TEST(MambaSlotTest, CustomReleaserRunsOnDestruction) {

--- a/tokenspeed-scheduler/tests/cpp/test_scheduler_plan.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_scheduler_plan.cpp
@@ -146,4 +146,66 @@ TEST_F(DisablePrefixCacheTestSuite, PrefetchNotGeneratedForStorageHit) {
     EXPECT_TRUE(ExtractCacheOpsOfKind<PrefetchOperation>(plan).empty());
 }
 
+class StableCandidateOrderingSuite : public SchedulerTestSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        auto cfg = SchedulerTestSuite::MakeConfig();
+        // Force the candidates loop to break after exactly one push so the
+        // tiebreaker decides which request wins.
+        cfg.max_batch_size = 1;
+        return cfg;
+    }
+};
+
+TEST_F(StableCandidateOrderingSuite, NewForwardOperationTieBreaksOnRequestId) {
+    // TP-determinism regression: requests_ is unordered_map<string, ...> so
+    // candidates are visited in per-process random order. Without an Id()
+    // tiebreaker in newForwardOperation's sort, each rank picks a different
+    // request when the loop budget admits only a subset — making forward_op
+    // None on some ranks and non-None on others, which deadlocks NCCL.
+    Submit(MakeRequestSpec("r_ccc", 2, 300));
+    Submit(MakeRequestSpec("r_aaa", 2, 100));
+    Submit(MakeRequestSpec("r_bbb", 2, 200));
+    auto plan = PlanOnce();
+    std::vector<std::string> ids;
+    for (const auto& op : plan.Operations()) {
+        if (auto* fwd = std::get_if<FlatForwardOperation>(&op)) {
+            ids = fwd->request_ids;
+        }
+    }
+    ASSERT_EQ(ids.size(), 1u);
+    EXPECT_EQ(ids[0], "r_aaa");
+}
+
+TEST_F(StableCandidateOrderingSuite, ForwardOpIsInsertionOrderIndependent) {
+    // Mirror of the above using two scheduler instances fed the same request
+    // set in opposite submit orders. The chosen forward request must depend
+    // only on the SET of request ids, not the submission sequence.
+    Submit(MakeRequestSpec("r_ccc", 2, 300));
+    Submit(MakeRequestSpec("r_aaa", 2, 100));
+    Submit(MakeRequestSpec("r_bbb", 2, 200));
+    auto plan_a = PlanOnce();
+    std::vector<std::string> ids_a;
+    for (const auto& op : plan_a.Operations()) {
+        if (auto* fwd = std::get_if<FlatForwardOperation>(&op)) {
+            ids_a = fwd->request_ids;
+        }
+    }
+
+    scheduler_ = std::make_unique<Scheduler>(config_);
+    Submit(MakeRequestSpec("r_bbb", 2, 200));
+    Submit(MakeRequestSpec("r_ccc", 2, 300));
+    Submit(MakeRequestSpec("r_aaa", 2, 100));
+    auto plan_b = PlanOnce();
+    std::vector<std::string> ids_b;
+    for (const auto& op : plan_b.Operations()) {
+        if (auto* fwd = std::get_if<FlatForwardOperation>(&op)) {
+            ids_b = fwd->request_ids;
+        }
+    }
+
+    ASSERT_FALSE(ids_a.empty());
+    EXPECT_EQ(ids_a, ids_b);
+}
+
 }  // namespace tokenspeed::test


### PR DESCRIPTION

## Summary
The mirrored C++ scheduler relies on every TP rank producing byte-identical plans. We observed a TP=4 hang where one rank scheduled a prefill on a given iteration while peers did not — the next NCCL collective then deadlocked on a shape mismatch. Trace logs showed mamba_leaves_ / lru_leaves_ membership drifting apart across ranks over hours of serving.

  **Root cause:** 
three eviction call sites tiebroke on values that are non-deterministic across processes (ASLR-randomized pointer hashes / unordered_set iteration / unordered_map<string> iteration). Whenever the primary key (TreeNode::Time(), a steady_clock timestamp that frequently ties for batch-inserted nodes) was equal, each rank picked a different victim. Divergence then compounded as cascading parent re-insertions further perturbed each rank's state.

 ### What changed

  **TreeNode gains a monotonic SeqId**
  - std::atomic<int64_t>, incremented on construction. All ranks construct the same nodes in the same order, so SeqId is identical across ranks. Overflow-safe in practice (~290k years at 1M nodes/sec). 
  
  **Three eviction tiebreakers fixed**


 Site   | Before  |  After   
------ | ------- | -----
MambaEvictionManager::Evict priority_queue   | compares on Time() only   | (Time, SeqId) 
ResourceManager<RType>::lru_leaves_   | set<pair<timestamp_t, TreeNode*>> | set<tuple<timestamp_t, int64_t, TreeNode*>>
Scheduler::newForwardOperation candidate sort |  priority class only | (priority, Request::Id())

  **Bundled determinism fixes in the same eviction stack (caught while investigating; they interact)**
  - MambaChunkAllocator / MambaHostAllocator free_list switched to a min-heap → Allocate() output depends only on the set of free indices, not on async Free() callback ordering.
  - MambaHostAllocator::DrainReleased() sorts its output (the consumer treats it as a set).

  Test plan

  - [x] New gtests specifically targeting the failure mode — two nodes with identical Time() constructed in opposite orders evict the same one across runs:
    - MambaEvictionTest.EvictDeterministicOnTimeTies
    - EvictionLRUDeterminism.EvictionDeterministicOnTimeTies
    - TreeNodeSeqId.IsMonotonicAcrossConstruction
    - MambaChunkAllocatorTest.AllocateReturnsSmallestFreeIndexRegardlessOfFreeOrder
    - MambaHostAllocatorTest.AllocateReturnsSmallestFreeIndexRegardlessOfFreeOrder
    - MambaHostAllocatorTest.DrainReleasedReturnsSortedRegardlessOfFreeOrder
    - StableCandidateOrderingSuite.NewForwardOperationTieBreaksOnRequestId
    - StableCandidateOrderingSuite.ForwardOpIsInsertionOrderIndependent
  - [x] Full suite: 175/175 gtests pass (was 172 + 3 new in this PR — the bundled fixes added their tests in earlier patches).
  - [x] TP=4 long-running serving smoke test — confirm the original hang reproducer no longer wedges after >30 min.
  - [x] Check no perf regression in qwen3.5-397B bench (the eviction path now does one extra int64_t compare on ties; expected to be in the noise).
<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
