### PR TITLE
fix(deepseek-v4): correct admission over-credit for state-family paged-cache groups

### DIFF
--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
@@ -811,6 +811,8 @@ HybridPrefixCache::PagedCacheGroupAdmission HybridPrefixCache::checkPagedCacheGr
         std::int32_t borrowed_in_table = 0;
         std::int32_t owned_in_table = 0;
         std::int32_t already_released = 0;
+        std::int32_t committed_prefix = 0;
+        std::int32_t raw_cursor = 0;
         bool table_exists = false;
         if (req_it != request_paged_cache_tables_.end()) {
             auto t_it = req_it->second.find(gid);
@@ -821,6 +823,8 @@ HybridPrefixCache::PagedCacheGroupAdmission HybridPrefixCache::checkPagedCacheGr
                 borrowed_in_table = t_it->second.BorrowedPagesCount();
                 owned_in_table = t_it->second.OwnedPagesCount();
                 already_released = t_it->second.ReleasedPagesCount();
+                committed_prefix = t_it->second.CommittedPrefixLenTokens();
+                raw_cursor = t_it->second.RawTokenCursor();
             }
         }
 
@@ -852,6 +856,25 @@ HybridPrefixCache::PagedCacheGroupAdmission HybridPrefixCache::checkPagedCacheGr
             releasable_owned = releasable_total - std::min(releasable_total, borrowed_present_total);
             if (table_exists) {
                 releasable_owned = std::min(releasable_owned, owned_in_table);
+            }
+
+            // State-family: CommitChunk converts ALL owned→borrowed before
+            // ReleaseSkipped runs, so owned pages do NOT return to the pool
+            // via release.  The only pool credit is from CheckpointStateToSnapshot's
+            // stale-owned drop (pages below live_lower at the first commit step).
+            const std::int32_t lcm = paged_cache_history_alignment_tokens_;
+            if (cfg.family == PagedCacheGroupFamily::State && table_exists &&
+                lcm > 0 && committed_prefix + lcm <= raw_cursor) {
+                const std::int32_t commit_target = committed_prefix + lcm;
+                const std::int32_t live_lower_raw = std::max(0, commit_target - *cfg.sliding_window_tokens);
+                const std::int32_t live_lower_page = live_lower_raw / raw_per_page;
+                std::int32_t base = already_released;
+                if (live_lower_page > base) {
+                    base += std::min(live_lower_page - base, borrowed_in_table);
+                }
+                releasable_owned = (live_lower_page > base)
+                                       ? std::min(live_lower_page - base, owned_in_table)
+                                       : 0;
             }
         }
 

--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
@@ -863,8 +863,8 @@ HybridPrefixCache::PagedCacheGroupAdmission HybridPrefixCache::checkPagedCacheGr
             // via release.  The only pool credit is from CheckpointStateToSnapshot's
             // stale-owned drop (pages below live_lower at the first commit step).
             const std::int32_t lcm = paged_cache_history_alignment_tokens_;
-            if (cfg.family == PagedCacheGroupFamily::State && table_exists &&
-                lcm > 0 && committed_prefix + lcm <= raw_cursor) {
+            if (cfg.family == PagedCacheGroupFamily::State && table_exists && lcm > 0 &&
+                committed_prefix + lcm <= raw_cursor) {
                 const std::int32_t commit_target = committed_prefix + lcm;
                 const std::int32_t live_lower_raw = std::max(0, commit_target - *cfg.sliding_window_tokens);
                 const std::int32_t live_lower_page = live_lower_raw / raw_per_page;
@@ -872,9 +872,7 @@ HybridPrefixCache::PagedCacheGroupAdmission HybridPrefixCache::checkPagedCacheGr
                 if (live_lower_page > base) {
                     base += std::min(live_lower_page - base, borrowed_in_table);
                 }
-                releasable_owned = (live_lower_page > base)
-                                       ? std::min(live_lower_page - base, owned_in_table)
-                                       : 0;
+                releasable_owned = (live_lower_page > base) ? std::min(live_lower_page - base, owned_in_table) : 0;
             }
         }
 


### PR DESCRIPTION
## Summary

- Fix pool exhaustion crash in DeepSeek-V4-Flash caused by `checkPagedCacheGroupAdmission` over-crediting `releasable_owned` for state-family paged-cache groups (e.g. `v4.c4a.compressor_state`)
- The admission check assumed owned pages below the sliding window would be freed to pool by `ReleaseSkipped`, but `CommitChunk` converts all owned→borrowed via `CheckpointStateToSnapshot` before `ReleaseSkipped` runs — so those pages never return to the pool
- The over-credited `simulated_free` prevented the pruning loop in `admitPagedCacheChunk` from triggering, causing snapshot pages to accumulate until pool exhaustion
- Fix: for state-family groups with pending commits, compute the exact stale-owned drop from `CheckpointStateToSnapshot`'s first commit step (the only step that produces pool credit). When no commits are pending, the original calculation is correct and unchanged

## Test plan

- [x] GSM8K 5-shot 50-sample eval with `max_total_tokens=16384` (the crash-triggering setting): exact_match=0.96
- [x] High-concurrency stress test: 64/64 requests passed (8/16/32/8 concurrent waves)
- [x] Server log: zero errors during eval and stress test

🤖 Generated with [Claude Code](https://claude.com/claude-code)