### PR TITLE
ci(perf): add Qwen3.5-NVFP4 agentic perf on b200-8gpu

### DIFF
--- a/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic-b200-8gpu.yaml
+++ b/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic-b200-8gpu.yaml
@@ -1,0 +1,93 @@
+api_version: ci.tokenspeed.io/v1
+name: perf-qwen3.5-397b-a17b-nvfp4-agentic-b200-8gpu
+type: perf
+triggers:
+  - per-commit
+  - manual
+runner:
+  labels:
+    - b200-8gpu
+env:
+  CI: "true"
+install:
+  - bash test/ci_system/install_deps.sh
+server:
+  command: >-
+    ts serve
+    --model nvidia/Qwen3.5-397B-A17B-NVFP4
+    --attn-tp-size 8
+    --moe-tp-size 8
+    --gpu-memory-utilization 0.6
+    --max-num-seqs 128
+    --mamba-ssm-dtype float32
+    --moe-backend flashinfer_trtllm
+    --trust-remote-code
+    --attention-backend trtllm
+    --chunked-prefill-size 2048
+    --quantization nvfp4
+    --kv-cache-dtype fp8
+    --kvstore-ratio 0.5
+    --speculative-algorithm MTP
+    --speculative-num-steps 3
+    --host 127.0.0.1
+    --port 8000
+  ready:
+    url: http://127.0.0.1:8000/readiness
+    timeout: 1800
+    interval: 10
+perf:
+  install:
+    - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]'
+    - >-
+      test -f /tmp/agentic_dataset.json ||
+      curl -fL
+      https://huggingface.co/datasets/lightseekorg/agentic-dataset/resolve/main/agentic_dataset.json
+      -o /tmp/agentic_dataset.json
+  command: >-
+    REPO_ROOT=$PWD &&
+    OUTPUTS_DIR=/tmp/tokenspeed-agentic-perf &&
+    WARMUP_DIR=/tmp/tokenspeed-agentic-warmup &&
+    trap 'rm -rf "$OUTPUTS_DIR" "$WARMUP_DIR"' EXIT &&
+    rm -rf "$OUTPUTS_DIR" "$WARMUP_DIR" &&
+    cd /tmp &&
+    /tmp/evalscope-perf/bin/evalscope perf
+    --model nvidia/Qwen3.5-397B-A17B-NVFP4
+    --url http://localhost:8000/v1/chat/completions
+    --api openai
+    --dataset swe_smith
+    --dataset-path agentic_dataset.json
+    --max-tokens 500
+    --multi-turn
+    --number 2
+    --parallel 1
+    --dataset-offset 68
+    --outputs-dir "$WARMUP_DIR"
+    --extra-args '{"ignore_eos": true}' &&
+    set +e &&
+    /tmp/evalscope-perf/bin/evalscope perf
+    --model nvidia/Qwen3.5-397B-A17B-NVFP4
+    --url http://localhost:8000/v1/chat/completions
+    --api openai
+    --dataset swe_smith
+    --dataset-path agentic_dataset.json
+    --max-tokens 500
+    --multi-turn
+    --number 2
+    --parallel 1
+    --outputs-dir "$OUTPUTS_DIR"
+    --extra-args '{"ignore_eos": true}'
+    --no-timestamp;
+    PERF_STATUS=$?;
+    if [ -d "$OUTPUTS_DIR/Qwen3.5-397B-A17B-NVFP4" ]; then
+    mv "$OUTPUTS_DIR/Qwen3.5-397B-A17B-NVFP4" "$OUTPUTS_DIR/Qwen3.5-397B-A17B-NVFP4_attn_tp8";
+    fi;
+    python3 "$REPO_ROOT/test/agentic_benchmark/tokenspeed/collect_outputs.py" "$OUTPUTS_DIR";
+    PARSE_STATUS=$?;
+    if [ "$PERF_STATUS" -ne 0 ]; then exit "$PERF_STATUS"; fi;
+    exit "$PARSE_STATUS"
+report:
+  github_step_summary: true
+perf_threshold: 0.9
+# Values are [Latency (tps/user), Throughput (tps/gpu)]; gate fails any conc whose actual falls below ref * perf_threshold.
+perf_reference:
+  1: [580, 4500]


### PR DESCRIPTION
Adds a `b200-8gpu` agentic perf task mirroring the existing `gb200-4gpu` `perf-qwen3.5-397b-a17b-nvfp4-agentic` task. Server is launched with TP=8, `--gpu-memory-utilization 0.6`, `--max-num-seqs 128`, `--chunked-prefill-size 2048`, `--kvstore-ratio 0.5`, and explicit MTP draft args; evalscope runs the same warmup + 4-conc sweep as the gb200 task.

No `perf_threshold` / `perf_reference` yet — populate once the first runs establish a baseline.