### PR TITLE
chore(logging): suppress noisy third-party server-launch warnings

### DIFF
--- a/python/tokenspeed/_logging.py
+++ b/python/tokenspeed/_logging.py
@@ -85,10 +85,43 @@ def _suppress_flash_attn_jit_cache_debug_log():
         handler.setLevel(logging.WARNING)
 
 
+def _suppress_misc_runtime_warnings():
+    # tvm-ffi: every tilelang import re-warns about subclass fields that
+    # shadow ancestor fields. Emitted via PyErr_WarnEx from
+    # tvm_ffi/registry.py.
+    warnings.filterwarnings(
+        "ignore",
+        message=r"Field .* duplicates an ancestor field.*",
+        category=UserWarning,
+    )
+    # torch: HF tokenizer / dataset paths convert non-writable numpy
+    # arrays. Self-rate-limited but each TP rank still emits it once.
+    warnings.filterwarnings(
+        "ignore",
+        message=r"The given NumPy array is not writable.*",
+        category=UserWarning,
+    )
+    # torch.distributed.barrier: device_id is set later in our init
+    # path, but barrier() runs first and nags every rank.
+    warnings.filterwarnings(
+        "ignore",
+        message=r"barrier\(\): using the device under current context\..*",
+        category=UserWarning,
+    )
+    # transformers: some chat templates only ship a slow tokenizer; the
+    # nag offers no actionable advice.
+    warnings.filterwarnings(
+        "ignore",
+        message=r"Using a slow tokenizer\..*",
+        category=UserWarning,
+    )
+
+
 def suppress_noisy_third_party_logs():
     os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
     os.environ.setdefault("TLLM_LOG_LEVEL", "WARNING")
     _suppress_cutlass_dsl_warnings()
+    _suppress_misc_runtime_warnings()
 
     for logger_name in (
         "transformers",

--- a/python/tokenspeed/_logging.py
+++ b/python/tokenspeed/_logging.py
@@ -201,18 +201,25 @@ def _install_tvm_ffi_cerr_filter() -> None:
 
     _stderr_filter_installed = True
 
-    threading.Thread(
+    reader_thread = threading.Thread(
         target=_stderr_filter_reader,
         args=(read_fd, saved_stderr_fd),
         name="tokenspeed-stderr-filter",
         daemon=True,
-    ).start()
+    )
+    reader_thread.start()
 
     def _restore() -> None:
+        # Closing the pipe write end (via dup2 onto FD 2) signals EOF to the
+        # reader, which then drains any buffered bytes in its `finally` block.
+        # Join with a bounded timeout so a fail-fast process still surfaces
+        # the diagnostics written to stderr just before exit, without blocking
+        # interpreter shutdown if the reader is stuck.
         try:
             os.dup2(saved_stderr_fd, 2)
         except OSError:
             pass
+        reader_thread.join(timeout=1.0)
 
     atexit.register(_restore)
 

--- a/python/tokenspeed/_logging.py
+++ b/python/tokenspeed/_logging.py
@@ -18,8 +18,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import atexit
 import logging
 import os
+import re
+import threading
 import warnings
 from importlib import import_module
 
@@ -87,8 +90,9 @@ def _suppress_flash_attn_jit_cache_debug_log():
 
 def _suppress_misc_runtime_warnings():
     # tvm-ffi: every tilelang import re-warns about subclass fields that
-    # shadow ancestor fields. Emitted via PyErr_WarnEx from
-    # tvm_ffi/registry.py.
+    # shadow ancestor fields. The Python path (PyErr_WarnEx from
+    # tvm_ffi/registry.py) is muted here; the sibling C++ std::cerr path
+    # from libtvm_ffi.so::object.cc is handled by the FD 2 line filter.
     warnings.filterwarnings(
         "ignore",
         message=r"Field .* duplicates an ancestor field.*",
@@ -117,11 +121,108 @@ def _suppress_misc_runtime_warnings():
     )
 
 
+_TVM_FFI_CERR_PATTERN = re.compile(
+    r'\[WARNING\] Field ".*?" in type ".*?" duplicates an ancestor field'
+)
+
+_stderr_filter_installed = False
+
+
+def _stderr_line_should_drop(line: bytes) -> bool:
+    try:
+        text = line.decode("utf-8", errors="replace")
+    except Exception:
+        return False
+    return _TVM_FFI_CERR_PATTERN.search(text) is not None
+
+
+def _stderr_filter_reader(read_fd: int, forward_fd: int) -> None:
+    buf = b""
+    try:
+        with os.fdopen(read_fd, "rb", buffering=0) as pipe:
+            while True:
+                chunk = pipe.read(4096)
+                if not chunk:
+                    break
+                buf += chunk
+                while True:
+                    idx = buf.find(b"\n")
+                    if idx == -1:
+                        break
+                    line, buf = buf[: idx + 1], buf[idx + 1 :]
+                    if _stderr_line_should_drop(line):
+                        continue
+                    try:
+                        os.write(forward_fd, line)
+                    except OSError:
+                        pass
+    except Exception:
+        pass
+    finally:
+        if buf and not _stderr_line_should_drop(buf):
+            try:
+                os.write(forward_fd, buf)
+            except OSError:
+                pass
+
+
+def _install_tvm_ffi_cerr_filter() -> None:
+    # tvm-ffi's libtvm_ffi.so::object.cc emits "[WARNING] Field ... duplicates
+    # an ancestor field ..." directly to std::cerr (FD 2), bypassing Python's
+    # warnings system. Splice a line-filter onto FD 2 so these lines are
+    # dropped before reaching the inherited stderr.
+    global _stderr_filter_installed
+    if _stderr_filter_installed:
+        return
+
+    try:
+        saved_stderr_fd = os.dup(2)
+    except OSError:
+        return
+
+    try:
+        read_fd, write_fd = os.pipe()
+    except OSError:
+        os.close(saved_stderr_fd)
+        return
+
+    try:
+        os.dup2(write_fd, 2)
+    except OSError:
+        os.close(saved_stderr_fd)
+        os.close(read_fd)
+        os.close(write_fd)
+        return
+    finally:
+        try:
+            os.close(write_fd)
+        except OSError:
+            pass
+
+    _stderr_filter_installed = True
+
+    threading.Thread(
+        target=_stderr_filter_reader,
+        args=(read_fd, saved_stderr_fd),
+        name="tokenspeed-stderr-filter",
+        daemon=True,
+    ).start()
+
+    def _restore() -> None:
+        try:
+            os.dup2(saved_stderr_fd, 2)
+        except OSError:
+            pass
+
+    atexit.register(_restore)
+
+
 def suppress_noisy_third_party_logs():
     os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
     os.environ.setdefault("TLLM_LOG_LEVEL", "WARNING")
     _suppress_cutlass_dsl_warnings()
     _suppress_misc_runtime_warnings()
+    _install_tvm_ffi_cerr_filter()
 
     for logger_name in (
         "transformers",

--- a/python/tokenspeed/runtime/entrypoints/engine.py
+++ b/python/tokenspeed/runtime/entrypoints/engine.py
@@ -435,7 +435,6 @@ def _set_envs_and_config(server_args: ServerArgs):
     os.environ["NCCL_CUMEM_ENABLE"] = str(int(server_args.enable_symm_mem))
     if not server_args.enable_symm_mem:
         os.environ["NCCL_NVLS_ENABLE"] = str(int(server_args.enable_nccl_nvls))
-    os.environ["TORCH_NCCL_AVOID_RECORD_STREAMS"] = "1"
     os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "4"
     os.environ["CUDA_MODULE_LOADING"] = "AUTO"
     if not server_args.disable_tf32:


### PR DESCRIPTION
Drops four noisy `UserWarning` patterns and the matching C++ `std::cerr` line that fire on every worker subprocess, plus the now-deprecated `TORCH_NCCL_AVOID_RECORD_STREAMS=1` env-var that produces a c10d deprecation warning on every rank.

Python-side filters (`warnings.filterwarnings` in `suppress_noisy_third_party_logs`):

- `tvm-ffi`: `Field 'X' in 'Y' duplicates an ancestor field.` — PyErr_WarnEx from `tvm_ffi/registry.py`, triggered by tilelang's subclass field registrations.
- `torch`: `The given NumPy array is not writable.` — HF tokenizer / dataset paths.
- `torch.distributed`: `barrier(): using the device under current context.` — fires before our group has a `device_id`.
- `transformers`: `Using a slow tokenizer.` — some chat templates have no fast variant.

C++ side filter (FD 2 line splice in `_install_tvm_ffi_cerr_filter`):

- `tvm-ffi`: `[WARNING] Field "X" in type "Y" duplicates an ancestor field in "Z"` — written directly to `std::cerr` from `libtvm_ffi.so::object.cc`, bypassing Python's warnings system. Under TP, per-rank writes interleave at the character level producing garbled lines; the filter splices a small reader thread between FD 2 and the inherited stderr so this exact pattern is dropped before reaching the log, while everything else is forwarded verbatim.

Also drops `os.environ["TORCH_NCCL_AVOID_RECORD_STREAMS"] = "1"` in `_set_envs_and_config`. PyTorch's default already matches; setting it just trips c10d's deprecation warning every rank.