### PR TITLE
fix(deepseek): guard missing quant weight_block_size

### DIFF
--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -1460,11 +1460,11 @@ class DeepseekV3ForCausalLM(BaseCausalLM):
                     "q_a_proj" in name or "kv_a_proj_with_mqa" in name
                 ):
                     quant_block_size = 1
-                    if (
-                        self.quant_config is not None
-                        and self.quant_config.weight_block_size is not None
-                    ):
-                        quant_block_size = self.quant_config.weight_block_size[0]
+                    weight_block_size = getattr(
+                        self.quant_config, "weight_block_size", None
+                    )
+                    if weight_block_size is not None:
+                        quant_block_size = weight_block_size[0]
                     begin_size_mp = {
                         "q_a_proj": 0,
                         "kv_a_proj_with_mqa": self.config.q_lora_rank,


### PR DESCRIPTION
## Summary

- use `getattr(..., "weight_block_size", None)` before reading `quant_config.weight_block_size`
- keep the existing default `quant_block_size = 1` behavior when the quant config does not expose that attribute

## Motivation

Some quantization config implementations do not define `weight_block_size`. The current DeepSeek/Kimi loader path assumes the attribute exists before indexing it, which can fail during NVFP4 model loading.

## Validation

- `python3 -m compileall -q python/tokenspeed/runtime/models/deepseek_v3.py`
- Hit and validated locally while bringing up Kimi K2.6 NVFP4 under TokenSpeed
