### PR TITLE
fix(vlm): clamp gpu_memory_utilization conditionally and add --language-model-only

### DIFF
--- a/python/tokenspeed/runtime/configs/model_config.py
+++ b/python/tokenspeed/runtime/configs/model_config.py
@@ -158,6 +158,8 @@ class ModelConfig:
         self.is_multimodal_gen = is_multimodal_gen_model(self.hf_config.architectures)
         self.is_image_gen = is_image_gen_model(self.hf_config.architectures)
         self.is_audio_model = is_audio_model(self.hf_config.architectures)
+
+        self.mm_attention_backend = getattr(server_args, "mm_attention_backend", None)
         self.dtype = _get_and_verify_dtype(self.hf_text_config, dtype)
 
         # Derive context length

--- a/python/tokenspeed/runtime/configs/model_config.py
+++ b/python/tokenspeed/runtime/configs/model_config.py
@@ -160,7 +160,9 @@ class ModelConfig:
         self.is_audio_model = is_audio_model(self.hf_config.architectures)
 
         language_model_only = bool(getattr(server_args, "language_model_only", False))
-        if language_model_only:
+        # Target-only flag; never apply to draft / auxiliary checkpoints.
+        apply_language_model_only = language_model_only and not is_draft_worker
+        if apply_language_model_only:
             if not self.is_multimodal:
                 raise ValueError(
                     "--language-model-only requires a multimodal model checkpoint."
@@ -170,17 +172,21 @@ class ModelConfig:
                 "be skipped; requests with multimodal inputs will be rejected."
             )
         # ``is_multimodal`` is the architectural fact; this is the runtime gate.
-        self.is_multimodal_active = self.is_multimodal and not language_model_only
-        self.mm_attention_backend = getattr(server_args, "mm_attention_backend", None)
+        self.is_multimodal_active = self.is_multimodal and not apply_language_model_only
         # Cap gpu_memory_utilization for VLMs in mm mode — the vision encoder
         # needs headroom that the global default doesn't account for.
-        if self.is_multimodal_active and server_args.gpu_memory_utilization > 0.9:
+        if (
+            self.is_multimodal_active
+            and getattr(server_args, "_gpu_memory_utilization_defaulted", False)
+            and server_args.gpu_memory_utilization > 0.9
+        ):
             logger.info(
                 "Clamping gpu_memory_utilization %.2f -> 0.9 to leave headroom "
                 "for the vision encoder.",
                 server_args.gpu_memory_utilization,
             )
             server_args.gpu_memory_utilization = 0.9
+        self.mm_attention_backend = getattr(server_args, "mm_attention_backend", None)
         self.dtype = _get_and_verify_dtype(self.hf_text_config, dtype)
 
         # Derive context length

--- a/python/tokenspeed/runtime/configs/model_config.py
+++ b/python/tokenspeed/runtime/configs/model_config.py
@@ -159,7 +159,28 @@ class ModelConfig:
         self.is_image_gen = is_image_gen_model(self.hf_config.architectures)
         self.is_audio_model = is_audio_model(self.hf_config.architectures)
 
+        language_model_only = bool(getattr(server_args, "language_model_only", False))
+        if language_model_only:
+            if not self.is_multimodal:
+                raise ValueError(
+                    "--language-model-only requires a multimodal model checkpoint."
+                )
+            logger.info(
+                "Running in language-model-only mode: vision/audio encoders will "
+                "be skipped; requests with multimodal inputs will be rejected."
+            )
+        # ``is_multimodal`` is the architectural fact; this is the runtime gate.
+        self.is_multimodal_active = self.is_multimodal and not language_model_only
         self.mm_attention_backend = getattr(server_args, "mm_attention_backend", None)
+        # Cap gpu_memory_utilization for VLMs in mm mode — the vision encoder
+        # needs headroom that the global default doesn't account for.
+        if self.is_multimodal_active and server_args.gpu_memory_utilization > 0.9:
+            logger.info(
+                "Clamping gpu_memory_utilization %.2f -> 0.9 to leave headroom "
+                "for the vision encoder.",
+                server_args.gpu_memory_utilization,
+            )
+            server_args.gpu_memory_utilization = 0.9
         self.dtype = _get_and_verify_dtype(self.hf_text_config, dtype)
 
         # Derive context length

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -641,7 +641,7 @@ class EventLoop:
                 )
 
     def _get_multimodal_context_for_forward(self, forward_op):
-        if not self.model_config.is_multimodal:
+        if not self.model_config.is_multimodal_active:
             return None
 
         num_extends = forward_op.num_extends()

--- a/python/tokenspeed/runtime/engine/input_processor.py
+++ b/python/tokenspeed/runtime/engine/input_processor.py
@@ -144,7 +144,7 @@ class InputProcessor:
             # VisionEmbedder can plan vision-token scatter ranges from each
             # item's offsets — the bare placeholder token alone would not
             # encode per-item uniqueness needed by the radix prefix layer.
-            if not self.engine.model_config.is_multimodal:
+            if not self.engine.model_config.is_multimodal_active:
                 raise ValueError(
                     "precomputed_multimodal_inputs is provided for a text-only model."
                 )

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -50,7 +50,7 @@ from tokenspeed.runtime.sampling.backends.base import SamplingBackend
 from tokenspeed.runtime.sampling.sampling_batch_info import SamplingBatchInfo
 from tokenspeed.runtime.utils import get_colorful_logger, set_random_seed
 from tokenspeed.runtime.utils.common import maybe_inference_mode
-from tokenspeed.runtime.utils.env import envs, get_global_server_args
+from tokenspeed.runtime.utils.env import envs
 from tokenspeed.runtime.utils.nvtx import nvtx_range
 from tokenspeed.runtime.utils.server_args import ServerArgs
 
@@ -309,7 +309,7 @@ class ModelExecutor:
         if (
             hasattr(_mm_model, "make_encoder_cudagraph_wrapper")
             and envs.TOKENSPEED_MM_ENABLE_ENCODER_CUDA_GRAPH.get()
-            and get_global_server_args().mm_attention_backend != "flashinfer_cudnn"
+            and self.model_runner.server_args.mm_attention_backend != "flashinfer_cudnn"
         ):
             self.encoder_graph_wrapper = _mm_model.make_encoder_cudagraph_wrapper(
                 _mm_model.mapping

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -308,6 +308,7 @@ class ModelExecutor:
         _mm_model = self.model_runner.model
         if (
             hasattr(_mm_model, "make_encoder_cudagraph_wrapper")
+            and getattr(_mm_model, "is_multimodal_active", True)
             and envs.TOKENSPEED_MM_ENABLE_ENCODER_CUDA_GRAPH.get()
             and self.model_runner.server_args.mm_attention_backend != "flashinfer_cudnn"
         ):

--- a/python/tokenspeed/runtime/layers/attention/mm_encoder_attention.py
+++ b/python/tokenspeed/runtime/layers/attention/mm_encoder_attention.py
@@ -50,7 +50,6 @@ from tokenspeed.runtime.layers.linear import (
 from tokenspeed.runtime.layers.quantization import QuantizationConfig
 from tokenspeed.runtime.layers.rotary_embedding import apply_rotary_pos_emb_native
 from tokenspeed.runtime.utils import add_prefix, round_up
-from tokenspeed.runtime.utils.env import envs, get_global_server_args
 
 logger = logging.getLogger(__name__)
 
@@ -350,6 +349,7 @@ class VisionAttention(nn.Module):
             [torch.Tensor, torch.Tensor, Any, Any], Tuple[torch.Tensor, torch.Tensor]
         ] = None,
         workspace_buffer: Optional[torch.Tensor] = None,
+        mm_attention_backend: str | None = None,
     ):
         super().__init__()
         self.vision = mapping.vision
@@ -370,9 +370,7 @@ class VisionAttention(nn.Module):
         self.customized_position_embedding_applier = (
             customized_position_embedding_applier
         )
-        self._backend_fn = _resolve_backend(
-            get_global_server_args().mm_attention_backend
-        )
+        self._backend_fn = _resolve_backend(mm_attention_backend)
         self._workspace_buffer = workspace_buffer
 
         self.qkv_proj = QKVParallelLinear(

--- a/python/tokenspeed/runtime/model_loader/loader.py
+++ b/python/tokenspeed/runtime/model_loader/loader.py
@@ -149,6 +149,7 @@ def _initialize_model(
     # Only VLM wrappers accept these kwargs.
     extra_kwargs: dict = {}
     if model_config.is_multimodal:
+        extra_kwargs["is_multimodal_active"] = model_config.is_multimodal_active
         extra_kwargs["mm_attention_backend"] = model_config.mm_attention_backend
     return model_class(
         config=model_config.hf_config,

--- a/python/tokenspeed/runtime/model_loader/loader.py
+++ b/python/tokenspeed/runtime/model_loader/loader.py
@@ -146,10 +146,15 @@ def _initialize_model(
     model_class, _ = get_model_architecture(model_config)
     quant_config = _get_quantization_config(model_config, load_config)
     mapping = model_config.mapping
+    # Only VLM wrappers accept these kwargs.
+    extra_kwargs: dict = {}
+    if model_config.is_multimodal:
+        extra_kwargs["mm_attention_backend"] = model_config.mm_attention_backend
     return model_class(
         config=model_config.hf_config,
         mapping=mapping,
         quant_config=quant_config,
+        **extra_kwargs,
     )
 
 

--- a/python/tokenspeed/runtime/models/kimi_k25.py
+++ b/python/tokenspeed/runtime/models/kimi_k25.py
@@ -210,6 +210,7 @@ class MoonViTEncoderLayer(nn.Module):
         attn_bias: bool = False,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        mm_attention_backend: str | None = None,
     ):
         super().__init__()
         self.num_heads = num_heads
@@ -234,6 +235,7 @@ class MoonViTEncoderLayer(nn.Module):
             prefix=add_prefix("attn", prefix),
             customized_position_embedding_applier=apply_rope,
             mapping=mapping,
+            mm_attention_backend=mm_attention_backend,
         )
 
     def forward(
@@ -623,6 +625,7 @@ class MoonViT3dPretrainedModel(nn.Module):
         *inputs,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        mm_attention_backend: str | None = None,
         **kwargs,
     ):
         super().__init__()
@@ -649,6 +652,7 @@ class MoonViT3dPretrainedModel(nn.Module):
                 "activation": PytorchGELUTanh(),
                 "attn_bias": True,
                 "mapping": mapping,
+                "mm_attention_backend": mm_attention_backend,
             },
             video_attn_type=config.video_attn_type,
             quant_config=quant_config,
@@ -724,6 +728,7 @@ class KimiK25ForConditionalGeneration(nn.Module):
         mapping: Mapping,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        mm_attention_backend: str | None = None,
         **kwargs,  # fix init_tts argument error
     ) -> None:
         super().__init__()
@@ -737,6 +742,7 @@ class KimiK25ForConditionalGeneration(nn.Module):
             ),
             prefix="vision_tower",
             mapping=mapping,
+            mm_attention_backend=mm_attention_backend,
         )
         self.mm_projector = K2VLMultiModalProjector(config.vision_config)
 

--- a/python/tokenspeed/runtime/models/kimi_k25.py
+++ b/python/tokenspeed/runtime/models/kimi_k25.py
@@ -728,6 +728,7 @@ class KimiK25ForConditionalGeneration(nn.Module):
         mapping: Mapping,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        is_multimodal_active: bool = True,
         mm_attention_backend: str | None = None,
         **kwargs,  # fix init_tts argument error
     ) -> None:
@@ -735,16 +736,21 @@ class KimiK25ForConditionalGeneration(nn.Module):
         self.config = config
         self.mapping = mapping
         self.quant_config = quant_config
-        self.vision_tower = MoonViT3dPretrainedModel(
-            config.vision_config,
-            quant_config=(
-                quant_config if isinstance(quant_config, ModelSlimConfig) else None
-            ),
-            prefix="vision_tower",
-            mapping=mapping,
-            mm_attention_backend=mm_attention_backend,
-        )
-        self.mm_projector = K2VLMultiModalProjector(config.vision_config)
+        self.is_multimodal_active = is_multimodal_active
+        if not self.is_multimodal_active:
+            self.vision_tower = None
+            self.mm_projector = None
+        else:
+            self.vision_tower = MoonViT3dPretrainedModel(
+                config.vision_config,
+                quant_config=(
+                    quant_config if isinstance(quant_config, ModelSlimConfig) else None
+                ),
+                prefix="vision_tower",
+                mapping=mapping,
+                mm_attention_backend=mm_attention_backend,
+            )
+            self.mm_projector = K2VLMultiModalProjector(config.vision_config)
 
         self.language_model = None
         if not getattr(config, "encoder_only", False):
@@ -759,16 +765,22 @@ class KimiK25ForConditionalGeneration(nn.Module):
                 ),
             )
 
-        # Match vision-tower / mm-projector dtype to language-model dtype;
-        # the vision tower defaults to float32 while the LM may be bf16 / fp8.
-        if self.language_model is not None and hasattr(self.language_model, "dtype"):
-            target_dtype = self.language_model.dtype
-            self.vision_tower = self.vision_tower.to(dtype=target_dtype)
-            self.mm_projector = self.mm_projector.to(dtype=target_dtype)
+        if self.is_multimodal_active:
+            # Match vision-tower / mm-projector dtype to language-model dtype;
+            # the vision tower defaults to float32 while the LM may be bf16 / fp8.
+            if self.language_model is not None and hasattr(
+                self.language_model, "dtype"
+            ):
+                target_dtype = self.language_model.dtype
+                self.vision_tower = self.vision_tower.to(dtype=target_dtype)
+                self.mm_projector = self.mm_projector.to(dtype=target_dtype)
 
-        # image_encoder may be swapped to a cudagraph wrapper by ModelExecutor.
-        self.vision_embedder = VisionEmbedder()
-        self.image_encoder = self.get_image_feature
+            # image_encoder may be swapped to a cudagraph wrapper by ModelExecutor.
+            self.vision_embedder = VisionEmbedder()
+            self.image_encoder = self.get_image_feature
+        else:
+            self.vision_embedder = None
+            self.image_encoder = None
 
     def get_image_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
         """Eager image encode via the same ``pre_encode`` / ``forward_blocks``
@@ -913,7 +925,9 @@ class KimiK25ForConditionalGeneration(nn.Module):
                 name = name.replace("language_model.", "")
                 language_weights.append((name, loaded_weight))
 
-        if not getattr(self.config, "language_only", False):
+        if self.is_multimodal_active and not getattr(
+            self.config, "language_only", False
+        ):
             vision_state_dict = dict(vision_weights)
             params_dict = dict(self.named_parameters(remove_duplicate=False))
             for name, loaded_weight in vision_state_dict.items():

--- a/python/tokenspeed/runtime/models/qwen3_5.py
+++ b/python/tokenspeed/runtime/models/qwen3_5.py
@@ -1123,6 +1123,7 @@ class Qwen3_5ForConditionalGeneration(BaseCausalLM):
         mapping: Mapping,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        mm_attention_backend: str | None = None,
     ):
         super().__init__(
             config=config.text_config,
@@ -1141,6 +1142,7 @@ class Qwen3_5ForConditionalGeneration(BaseCausalLM):
             norm_eps=getattr(config, "rms_norm_eps", 1e-6),
             prefix=add_prefix("model.visual", prefix),
             mapping=mapping,
+            mm_attention_backend=mm_attention_backend,
         )
         self.deepstack_visual_indexes = self.visual.deepstack_visual_indexes
         self.num_deepstack_embeddings = len(self.deepstack_visual_indexes)
@@ -1366,12 +1368,14 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5ForConditionalGeneration):
         mapping: Mapping,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        mm_attention_backend: str | None = None,
     ) -> None:
         super().__init__(
             config=config,
             mapping=mapping,
             quant_config=quant_config,
             prefix=prefix,
+            mm_attention_backend=mm_attention_backend,
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):

--- a/python/tokenspeed/runtime/models/qwen3_5.py
+++ b/python/tokenspeed/runtime/models/qwen3_5.py
@@ -1123,6 +1123,7 @@ class Qwen3_5ForConditionalGeneration(BaseCausalLM):
         mapping: Mapping,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        is_multimodal_active: bool = True,
         mm_attention_backend: str | None = None,
     ):
         super().__init__(
@@ -1136,20 +1137,29 @@ class Qwen3_5ForConditionalGeneration(BaseCausalLM):
             self.config, "rope_scaling", {}
         )
         self.is_mrope_enabled = "mrope_section" in rope_config
-        self.visual = Qwen3VLMoeVisionModel(
-            config.vision_config,
-            quant_config=None,
-            norm_eps=getattr(config, "rms_norm_eps", 1e-6),
-            prefix=add_prefix("model.visual", prefix),
-            mapping=mapping,
-            mm_attention_backend=mm_attention_backend,
-        )
-        self.deepstack_visual_indexes = self.visual.deepstack_visual_indexes
-        self.num_deepstack_embeddings = len(self.deepstack_visual_indexes)
-        # image_encoder may be swapped to a cudagraph wrapper by ModelExecutor.
-        self.vision_embedder = VisionEmbedder()
-        self.image_encoder = self.get_image_feature
-        self.video_encoder = self.get_video_feature
+        self.is_multimodal_active = is_multimodal_active
+        if not self.is_multimodal_active:
+            self.visual = None
+            self.deepstack_visual_indexes = []
+            self.num_deepstack_embeddings = 0
+            self.vision_embedder = None
+            self.image_encoder = None
+            self.video_encoder = None
+        else:
+            self.visual = Qwen3VLMoeVisionModel(
+                config.vision_config,
+                quant_config=None,
+                norm_eps=getattr(config, "rms_norm_eps", 1e-6),
+                prefix=add_prefix("model.visual", prefix),
+                mapping=mapping,
+                mm_attention_backend=mm_attention_backend,
+            )
+            self.deepstack_visual_indexes = self.visual.deepstack_visual_indexes
+            self.num_deepstack_embeddings = len(self.deepstack_visual_indexes)
+            # image_encoder may be swapped to a cudagraph wrapper by ModelExecutor.
+            self.vision_embedder = VisionEmbedder()
+            self.image_encoder = self.get_image_feature
+            self.video_encoder = self.get_video_feature
 
     def separate_deepstack_embeds(self, embedding: torch.Tensor):
         assert embedding.shape[-1] % (1 + self.num_deepstack_embeddings) == 0, (
@@ -1317,6 +1327,8 @@ class Qwen3_5ForConditionalGeneration(BaseCausalLM):
                 continue
             if "mtp" in name:
                 continue
+            if not self.is_multimodal_active and "visual" in name:
+                continue
             if "language_model" in name:
                 name = name.replace(r"model.language_model.", r"model.")
             if ".self_attn." in name:
@@ -1368,6 +1380,7 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5ForConditionalGeneration):
         mapping: Mapping,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        is_multimodal_active: bool = True,
         mm_attention_backend: str | None = None,
     ) -> None:
         super().__init__(
@@ -1375,6 +1388,7 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5ForConditionalGeneration):
             mapping=mapping,
             quant_config=quant_config,
             prefix=prefix,
+            is_multimodal_active=is_multimodal_active,
             mm_attention_backend=mm_attention_backend,
         )
 
@@ -1432,6 +1446,8 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5ForConditionalGeneration):
             if "rotary_emb.inv_freq" in name:
                 continue
             if "mtp" in name:
+                continue
+            if not self.is_multimodal_active and "visual" in name:
                 continue
             if "language_model" in name:
                 name = name.replace(r"model.language_model.", r"model.")

--- a/python/tokenspeed/runtime/models/qwen3_vision.py
+++ b/python/tokenspeed/runtime/models/qwen3_vision.py
@@ -46,7 +46,6 @@ from tokenspeed.runtime.layers.quantization.base_config import QuantizationConfi
 from tokenspeed.runtime.layers.rotary_embedding import get_rope
 from tokenspeed.runtime.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from tokenspeed.runtime.utils import add_prefix
-from tokenspeed.runtime.utils.env import get_global_server_args
 
 
 @lru_cache(maxsize=1024)
@@ -159,6 +158,7 @@ class Qwen3VLVisionBlock(nn.Module):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         workspace_buffer: torch.Tensor | None = None,
+        mm_attention_backend: str | None = None,
     ) -> None:
         super().__init__()
         if norm_layer is None:
@@ -175,6 +175,7 @@ class Qwen3VLVisionBlock(nn.Module):
             prefix=add_prefix("attn", prefix),
             workspace_buffer=workspace_buffer,
             mapping=mapping,
+            mm_attention_backend=mm_attention_backend,
         )
         self.mlp = Qwen3VLVisionMLP(
             dim,
@@ -283,9 +284,11 @@ class Qwen3VLMoeVisionModel(nn.Module):
         norm_eps: float = 1e-6,
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
+        mm_attention_backend: str | None = None,
     ) -> None:
         super().__init__()
         vision = mapping.vision
+        self.mm_attention_backend = mm_attention_backend
         self.hidden_size = vision_config.hidden_size
         self.num_heads = vision_config.num_heads
         self.num_position_embeddings = vision_config.num_position_embeddings
@@ -315,7 +318,7 @@ class Qwen3VLMoeVisionModel(nn.Module):
         )
 
         workspace_buffer = None
-        if get_global_server_args().mm_attention_backend == "flashinfer_cudnn":
+        if self.mm_attention_backend == "flashinfer_cudnn":
             if torch.cuda.is_available():
                 ws_device = torch.device("cuda", torch.cuda.current_device())
             else:
@@ -339,6 +342,7 @@ class Qwen3VLMoeVisionModel(nn.Module):
                     prefix=add_prefix(f"blocks.{layer_idx}", prefix),
                     workspace_buffer=workspace_buffer,
                     mapping=mapping,
+                    mm_attention_backend=mm_attention_backend,
                 )
                 for layer_idx in range(vision_config.depth)
             ]
@@ -567,7 +571,7 @@ class Qwen3VLMoeVisionModel(nn.Module):
         real_seq_lens = token_cu_seqlens[1:] - token_cu_seqlens[:-1]
         real_max_seqlen = int(real_seq_lens.max()) if real_seq_lens.size > 0 else 0
 
-        if get_global_server_args().mm_attention_backend == "flashinfer_cudnn":
+        if self.mm_attention_backend == "flashinfer_cudnn":
             # (B_padded,) token lengths
             seq_lens_padded = self.compute_cudnn_sequence_lengths_padded(
                 token_cu_seqlens

--- a/python/tokenspeed/runtime/utils/env.py
+++ b/python/tokenspeed/runtime/utils/env.py
@@ -21,13 +21,10 @@
 import os
 import warnings
 from contextlib import contextmanager
-from types import SimpleNamespace
 from typing import Any
 
 from tokenspeed.runtime.utils.pdl import pdl_enabled
 from tokenspeed.runtime.utils.server_args import ServerArgs
-
-global_server_args: ServerArgs | None = None
 
 global_server_args_dict: dict = {
     "attention_backend": ServerArgs.attention_backend,
@@ -73,8 +70,6 @@ global_server_args_dict: dict = {
 
 
 def global_server_args_dict_update(server_args: ServerArgs):
-    global global_server_args
-    global_server_args = server_args
     global_server_args_dict.update(
         {
             "attention_backend": server_args.attention_backend,
@@ -119,18 +114,6 @@ def global_server_args_dict_update(server_args: ServerArgs):
         }
     )
     pdl_enabled.cache_clear()
-
-
-def get_global_server_args():
-    if global_server_args is not None:
-        return global_server_args
-
-    defaults = dict(global_server_args_dict)
-    defaults.setdefault("mm_attention_backend", None)
-    defaults.setdefault("skip_tokenizer_init", False)
-    defaults.setdefault("chunked_prefill_size", None)
-    defaults.setdefault("tp_size", 1)
-    return SimpleNamespace(**defaults)
 
 
 class EnvField:

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -356,6 +356,7 @@ class ServerArgs:
             gpu_mem = None
 
         # Set GPU memory utilization, which depends on the tensor parallelism size.
+        self._gpu_memory_utilization_defaulted = False
         if self.gpu_memory_utilization is None:
             if self.mapping.world_size >= 16:
                 self.gpu_memory_utilization = 0.79
@@ -367,6 +368,7 @@ class ServerArgs:
                 self.gpu_memory_utilization = 0.87
             else:
                 self.gpu_memory_utilization = 0.88
+            self._gpu_memory_utilization_defaulted = True
 
         # Set the chunked prefill token budget.
         if self.chunked_prefill_size is None:

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -77,6 +77,7 @@ class ServerArgs:
     device: str = "cuda"
     served_model_name: str | None = None
     revision: str | None = None
+    language_model_only: bool = False
 
     # Port for the HTTP server
     host: str = "127.0.0.1"
@@ -696,6 +697,13 @@ class ServerArgs:
             action=argparse.BooleanOptionalAction,
             default=ServerArgs.skip_tokenizer_init,
             help="If set, skip init tokenizer and pass input_ids in generate request",
+        )
+        parser.add_argument(
+            "--language-model-only",
+            action="store_true",
+            default=ServerArgs.language_model_only,
+            help="Skip vision/audio encoders on a multimodal checkpoint and "
+            "run text-only. Multimodal requests are rejected.",
         )
         parser.add_argument("--ext-yaml", type=str, default=None)
         parser.add_argument(


### PR DESCRIPTION
## Summary

Two related changes:

1. **Conditional `gpu_memory_utilization` clamp** — clamped to 0.9 only when multimodal is active (decided in `ModelConfig`). The tp=4 default stays at 0.95 so text-only deployments are not penalized; VLM tp=4 still gets the 0.9 headroom.
2. **`--language-model-only`** — new flag to run a VLM checkpoint text-only on the same engine. Vision/audio encoders are skipped entirely: `vision_tower` / `visual` / `mm_projector` / `vision_embedder` / `image_encoder` stay `None`; vision weights are skipped during `load_weights`; encoder CUDA graph wrapper is not installed; precomputed-mm requests are rejected with a clear error.

## Behavior matrix

| Mode | tp=4 `gpu_memory_utilization` |
|------|--------------------------------|
| text-only checkpoint | 0.95 (default) |
| VLM checkpoint | 0.95 → clamped to 0.9 |
| VLM + `--language-model-only` | 0.95 (no clamp; no vision encoder) |

## Test plan

- [ ] CI on Kimi-K2.5 VLM at tp=4 — no OOM, parity
- [ ] CI on Qwen3.5-VL at tp=4 — same
- [ ] Manual: VLM checkpoint with `--language-model-only` — text inference works, image requests rejected
- [ ] Manual: text-only checkpoint at tp=4 — `gpu_memory_utilization` stays at 0.95