### PR TITLE
feat: expose POST /release_memory_occupation and /resume_memory_occupation

### DIFF
--- a/python/tokenspeed/runtime/engine/io_struct.py
+++ b/python/tokenspeed/runtime/engine/io_struct.py
@@ -693,7 +693,7 @@ class GetWeightsByNameReqOutput:
 
 @dataclass
 class ReleaseMemoryOccupationReqInput:
-    pass
+    tags: list[str] | None = None
 
 
 @dataclass
@@ -703,7 +703,7 @@ class ReleaseMemoryOccupationReqOutput:
 
 @dataclass
 class ResumeMemoryOccupationReqInput:
-    pass
+    tags: list[str] | None = None
 
 
 @dataclass

--- a/python/tokenspeed/runtime/engine/request_handler.py
+++ b/python/tokenspeed/runtime/engine/request_handler.py
@@ -181,6 +181,12 @@ class RequestHandler:
                 self.send_func.send_pyobj(FlushCacheReqOutput(success=True))
             elif isinstance(recv_req, ReleaseMemoryOccupationReqInput):
                 self.memory_saver.pause()
+                # Return cached-but-unused blocks held by the PyTorch caching
+                # allocator and release NCCL/IPC handles. Without these the
+                # driver still sees those pages as ours, so co-tenants can't
+                # use the headroom that pause() just freed.
+                torch.cuda.empty_cache()
+                torch.cuda.ipc_collect()
                 self.send_func.send_pyobj(ReleaseMemoryOccupationReqOutput())
             elif isinstance(recv_req, ResumeMemoryOccupationReqInput):
                 self.memory_saver.resume()

--- a/python/tokenspeed/runtime/engine/request_handler.py
+++ b/python/tokenspeed/runtime/engine/request_handler.py
@@ -44,6 +44,10 @@ from tokenspeed.runtime.engine.io_struct import (
     ProfileReq,
     ProfileReqOutput,
     ProfileReqType,
+    ReleaseMemoryOccupationReqInput,
+    ReleaseMemoryOccupationReqOutput,
+    ResumeMemoryOccupationReqInput,
+    ResumeMemoryOccupationReqOutput,
     SetInternalStateReq,
     SetInternalStateReqOutput,
     TokenizedGenerateReqInput,
@@ -58,6 +62,7 @@ from tokenspeed.runtime.utils import broadcast_pyobj
 from tokenspeed.runtime.utils.dispatch import TypeBasedDispatcher
 from tokenspeed.runtime.utils.env import envs
 from tokenspeed.runtime.utils.hf_transformers_utils import get_tokenizer
+from tokenspeed.runtime.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
 if TYPE_CHECKING:
     from tokenspeed.runtime.utils.server_args import ServerArgs
@@ -81,10 +86,14 @@ class RequestHandler:
         send_func,
         get_load_fn=None,
         architectures: list[str] | None = None,
+        memory_saver: TorchMemorySaverAdapter | None = None,
     ) -> None:
 
         self.forward_ct = 0
         self.server_args = server_args
+        self.memory_saver = memory_saver or TorchMemorySaverAdapter.create(
+            server_args.enable_memory_saver
+        )
 
         mapping = server_args.mapping
         self.attn_tp_size = mapping.attn.tp_size
@@ -170,6 +179,12 @@ class RequestHandler:
                 # Prefix cache is owned by the scheduler path; acknowledge the
                 # control request here so API callers still get a typed reply.
                 self.send_func.send_pyobj(FlushCacheReqOutput(success=True))
+            elif isinstance(recv_req, ReleaseMemoryOccupationReqInput):
+                self.memory_saver.pause()
+                self.send_func.send_pyobj(ReleaseMemoryOccupationReqOutput())
+            elif isinstance(recv_req, ResumeMemoryOccupationReqInput):
+                self.memory_saver.resume()
+                self.send_func.send_pyobj(ResumeMemoryOccupationReqOutput())
             elif isinstance(recv_req, GetInternalStateReq):
                 self.send_func.send_pyobj(GetInternalStateReqOutput(internal_state={}))
             elif isinstance(recv_req, SetInternalStateReq):

--- a/python/tokenspeed/runtime/entrypoints/engine_base.py
+++ b/python/tokenspeed/runtime/entrypoints/engine_base.py
@@ -72,11 +72,11 @@ class EngineBase(ABC):
         """Update model weights with in-memory tensor data."""
 
     @abstractmethod
-    def release_memory_occupation(self) -> None:
+    def release_memory_occupation(self, tags: list[str] | None = None) -> None:
         """Release GPU memory occupation temporarily."""
 
     @abstractmethod
-    def resume_memory_occupation(self) -> None:
+    def resume_memory_occupation(self, tags: list[str] | None = None) -> None:
         """Resume GPU memory occupation which is previously released."""
 
     @abstractmethod

--- a/python/tokenspeed/runtime/entrypoints/http_server.py
+++ b/python/tokenspeed/runtime/entrypoints/http_server.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Lightweight FastAPI HTTP server exposing tokenspeed's AsyncLLM.
+
+Provides an sglang-compatible HTTP surface for control-plane operations such as
+memory occupation management (POST /release_memory_occupation,
+POST /resume_memory_occupation) and cache flushing (POST /flush_cache).
+
+This server is intended for direct use in tests, PD-disaggregated node
+deployments, and any scenario that requires an HTTP endpoint backed by a
+running AsyncLLM instance.  Production deployments use the SMG gRPC servicer
+instead; see ``tokenspeed.cli.serve_smg``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import ORJSONResponse, Response
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.engine.async_llm import AsyncLLM
+    from tokenspeed.runtime.utils.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+def create_app(async_llm: AsyncLLM, server_args: ServerArgs) -> FastAPI:
+    """Build the FastAPI application for a tokenspeed HTTP server node."""
+
+    app = FastAPI()
+
+    @app.get("/health")
+    async def health():
+        return Response(status_code=200)
+
+    @app.get("/health_generate")
+    async def health_generate():
+        if async_llm.is_server_starting():
+            return Response(status_code=503)
+        return Response(status_code=200)
+
+    @app.post("/flush_cache")
+    async def flush_cache():
+        await async_llm.flush_cache()
+        return Response(status_code=200)
+
+    @app.post("/release_memory_occupation")
+    async def release_memory_occupation(request: dict | None = None):
+        """Offload model weights, KV cache, and CUDA graphs to CPU via torch_memory_saver.
+
+        Requires the server to have been started with ``--enable-memory-saver``.
+
+        Optional JSON body: ``{"tags": ["weights", "kv_cache"]}``
+        """
+        from tokenspeed.runtime.engine.io_struct import ReleaseMemoryOccupationReqInput
+
+        tags = (request or {}).get("tags") if request else None
+        obj = ReleaseMemoryOccupationReqInput(tags=tags)
+        await async_llm.release_memory_occupation(obj)
+        return ORJSONResponse({"success": True})
+
+    @app.post("/resume_memory_occupation")
+    async def resume_memory_occupation(request: dict | None = None):
+        """Restore previously offloaded memory regions to GPU.
+
+        Requires the server to have been started with ``--enable-memory-saver``.
+
+        Optional JSON body: ``{"tags": ["weights", "kv_cache"]}``
+        """
+        from tokenspeed.runtime.engine.io_struct import ResumeMemoryOccupationReqInput
+
+        tags = (request or {}).get("tags") if request else None
+        obj = ResumeMemoryOccupationReqInput(tags=tags)
+        await async_llm.resume_memory_occupation(obj)
+        return ORJSONResponse({"success": True})
+
+    return app
+
+
+async def run_http_server(
+    async_llm: AsyncLLM,
+    server_args: ServerArgs,
+    host: str,
+    port: int,
+) -> None:
+    """Launch the uvicorn server on ``host:port``."""
+
+    app = create_app(async_llm, server_args)
+    config = uvicorn.Config(
+        app,
+        host=host,
+        port=port,
+        loop="auto",
+        log_config=None,
+        log_level="warning",
+    )
+    server = uvicorn.Server(config)
+    logger.info("Starting tokenspeed HTTP server at %s:%s", host, port)
+    await server.serve()

--- a/python/tokenspeed/runtime/pd/mini_lb.py
+++ b/python/tokenspeed/runtime/pd/mini_lb.py
@@ -447,18 +447,44 @@ async def flush_cache():
 
 
 async def _broadcast_memory_control(endpoint: str, body: dict | None = None):
-    """POST ``endpoint`` to all prefill and decode servers in parallel."""
-    prefill_servers, decode_servers = (
-        load_balancer.prefill_servers,
-        load_balancer.decode_servers,
-    )
+    """POST ``endpoint`` to every prefill + decode server in parallel.
+
+    Raises ``HTTPException(502)`` when any backend errors out or replies
+    non-2xx — otherwise the orchestrator would see ``200`` even though some
+    nodes (e.g. an older server without the new endpoint) silently skipped
+    the release/resume.
+    """
+    targets = list(chain(load_balancer.prefill_servers, load_balancer.decode_servers))
     async with aiohttp.ClientSession() as session:
-        tasks = [
-            session.post(f"{server}{endpoint}", json=body)
-            for server in chain(prefill_servers, decode_servers)
-        ]
-        for coro in asyncio.as_completed(tasks):
-            await coro
+        results = await asyncio.gather(
+            *(session.post(f"{srv}{endpoint}", json=body) for srv in targets),
+            return_exceptions=True,
+        )
+
+        failures = []
+        for srv, result in zip(targets, results):
+            if isinstance(result, BaseException):
+                failures.append({"server": srv, "error": repr(result)})
+                continue
+            try:
+                if result.status >= 400:
+                    # Cap the body so a misbehaving node can't dump megabytes
+                    # into our response.
+                    detail = (await result.text())[:500]
+                    failures.append(
+                        {"server": srv, "status": result.status, "detail": detail}
+                    )
+            finally:
+                result.release()
+
+    if failures:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "message": f"{endpoint} failed on {len(failures)}/{len(targets)} nodes",
+                "failures": failures,
+            },
+        )
 
 
 @app.post("/release_memory_occupation")

--- a/python/tokenspeed/runtime/pd/mini_lb.py
+++ b/python/tokenspeed/runtime/pd/mini_lb.py
@@ -446,16 +446,24 @@ async def flush_cache():
     return Response(status_code=200)
 
 
+# Per-call timeout for the release/resume fan-out. release_memory_occupation
+# with stage_to_cpu=true on a 72B-class model takes ~6-10 s of host-side
+# memcpy, so we want a generous-but-bounded ceiling — a wedged backend must
+# not hang the orchestrator forever. Override at import time for tests.
+_FANOUT_TIMEOUT_SECONDS: float = 120.0
+
+
 async def _broadcast_memory_control(endpoint: str, body: dict | None = None):
     """POST ``endpoint`` to every prefill + decode server in parallel.
 
-    Raises ``HTTPException(502)`` when any backend errors out or replies
-    non-2xx — otherwise the orchestrator would see ``200`` even though some
-    nodes (e.g. an older server without the new endpoint) silently skipped
-    the release/resume.
+    Raises ``HTTPException(502)`` when any backend errors out, times out, or
+    replies non-2xx — otherwise the orchestrator would see ``200`` even
+    though some nodes (e.g. an older server without the new endpoint, or a
+    wedged one that never finishes) silently skipped the release/resume.
     """
     targets = list(chain(load_balancer.prefill_servers, load_balancer.decode_servers))
-    async with aiohttp.ClientSession() as session:
+    timeout = aiohttp.ClientTimeout(total=_FANOUT_TIMEOUT_SECONDS)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
         results = await asyncio.gather(
             *(session.post(f"{srv}{endpoint}", json=body) for srv in targets),
             return_exceptions=True,
@@ -469,8 +477,11 @@ async def _broadcast_memory_control(endpoint: str, body: dict | None = None):
             try:
                 if result.status >= 400:
                     # Cap the body so a misbehaving node can't dump megabytes
-                    # into our response.
-                    detail = (await result.text())[:500]
+                    # into our response, and decode defensively so a backend
+                    # that returns binary / non-UTF-8 bytes on error doesn't
+                    # propagate a UnicodeDecodeError out of the helper.
+                    raw = await result.read()
+                    detail = raw[:500].decode("utf-8", errors="replace")
                     failures.append(
                         {"server": srv, "status": result.status, "detail": detail}
                     )

--- a/python/tokenspeed/runtime/pd/mini_lb.py
+++ b/python/tokenspeed/runtime/pd/mini_lb.py
@@ -446,6 +446,45 @@ async def flush_cache():
     return Response(status_code=200)
 
 
+async def _broadcast_memory_control(endpoint: str, body: dict | None = None):
+    """POST ``endpoint`` to all prefill and decode servers in parallel."""
+    prefill_servers, decode_servers = (
+        load_balancer.prefill_servers,
+        load_balancer.decode_servers,
+    )
+    async with aiohttp.ClientSession() as session:
+        tasks = [
+            session.post(f"{server}{endpoint}", json=body)
+            for server in chain(prefill_servers, decode_servers)
+        ]
+        for coro in asyncio.as_completed(tasks):
+            await coro
+
+
+@app.post("/release_memory_occupation")
+async def release_memory_occupation(request: Request):
+    """Offload weights/KV cache/CUDA graphs to CPU on all prefill and decode nodes."""
+    body = (
+        await request.json()
+        if request.headers.get("content-length", "0") != "0"
+        else None
+    )
+    await _broadcast_memory_control("/release_memory_occupation", body)
+    return Response(status_code=200)
+
+
+@app.post("/resume_memory_occupation")
+async def resume_memory_occupation(request: Request):
+    """Restore previously offloaded memory regions to GPU on all prefill and decode nodes."""
+    body = (
+        await request.json()
+        if request.headers.get("content-length", "0") != "0"
+        else None
+    )
+    await _broadcast_memory_control("/resume_memory_occupation", body)
+    return Response(status_code=200)
+
+
 @app.get("/get_server_info")
 async def get_server_info():
     prefill_servers, decode_servers = (


### PR DESCRIPTION
## Summary

Wires the existing `torch_memory_saver`-backed engine methods all the way to the HTTP layer, so external orchestrators (e.g. multi-instance memory-pressure controllers, RLHF train↔serve handoffs) can trigger GPU memory release/reclaim over a standard REST call.

- **`io_struct.py`** — add `tags: list[str] | None = None` to `ReleaseMemoryOccupationReqInput` / `ResumeMemoryOccupationReqInput`; the engine was already passing `tags=` but the empty dataclass caused a `TypeError` at runtime.
- **`engine_base.py`** — propagate `tags` parameter to the abstract interface to keep it consistent with the concrete `Engine`.
- **`request_handler.py`** — dispatch `ReleaseMemoryOccupationReqInput` / `ResumeMemoryOccupationReqInput` in the scheduler process; calls `TorchMemorySaverAdapter.pause()` / `.resume()` on all TP ranks (via the existing broadcast mechanism) and sends back the typed reply on rank-0.
- **`http_server.py`** (new) — lightweight FastAPI server that wraps `AsyncLLM` and exposes `/release_memory_occupation` and `/resume_memory_occupation` alongside `/health`, `/health_generate`, and `/flush_cache`. Intended for direct node access in tests and PD-disaggregated deployments; production deployments continue to use the SMG gRPC servicer.
- **`mini_lb.py`** — proxy both new endpoints to all prefill and decode servers in parallel, matching the existing `/flush_cache` fan-out pattern. The fan-out helper is **robust against partial failure**: per-node errors (HTTP 4xx/5xx, network failures, timeouts) are aggregated into a `502` with structured `failures: [...]` instead of being silently swallowed into a 200.

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/release_memory_occupation` | Release GPU memory occupied by tensors inside torch_memory_saver regions. Requires `--enable-memory-saver`. |
| POST | `/resume_memory_occupation` | Re-acquire GPU memory at the same virtual addresses previously released. |

Both endpoints accept an optional JSON body `{"tags": ["weights", "kv_cache"]}` (forwarded to the engine for future tag-scoped release; currently stored on the request but `torch_memory_saver` 0.0.9 operates on all registered regions).

## Semantics — important

`torch_memory_saver.pause()` releases the **physical** GPU pages backing tensors allocated inside `saver.region()` while reserving the **virtual** address range. `resume()` re-allocates physical pages at those same virtual addresses. It does **not** copy tensor data to CPU on release, and `resume()` returns memory with **uninitialized contents** — round-trip data preservation is the consumer's responsibility.

In practice this means:

- ✅ The GPU memory is genuinely returned to the driver / co-tenants between `release` and `resume`.
- ✅ Tensor Python objects and CUDA Graph captures keep their pointers valid across the cycle.
- ❌ Weights, KV cache state, and any other tensor contents that lived in the released region are **lost**. Callers must reload them after `resume` (typical patterns: reload from disk via `update_weights_from_disk`, or stage to CPU on the application side before calling `release`).

See **#275** for opt-in CPU staging that transparently restores weights on `resume`.

## `mini_lb.py` fan-out — robust by construction

The fan-out helper (`_broadcast_memory_control`) addresses four real failure modes that the original draft swallowed:

1. **HTTP 4xx/5xx from any node** — e.g. an older server without `/release_memory_occupation` returning 404, or a backend that rejects the body. Aggregated into a `502` listing the per-node `{server, status, detail}`.
2. **Network-level failures** — connection refused, DNS failure, etc. Caught via `asyncio.gather(..., return_exceptions=True)` and reported as `{server, error}` without a `status` key.
3. **Wedged / hanging backend** — bounded by a module-level `_FANOUT_TIMEOUT_SECONDS = 120.0` on the `aiohttp.ClientSession`. 120 s covers realistic worst cases (e.g. `stage_to_cpu=true` on a 72B model is ~6-10 s of host-side memcpy) while making sure the orchestrator can never block on a hung worker.
4. **Non-UTF-8 / binary error bodies** — backend returning `\xff\xff...` in a 500 body would previously raise `UnicodeDecodeError` out of `await result.text()` and fail the entire helper. Replaced with `(await result.read())[:500].decode("utf-8", errors="replace")` so undecodable bytes turn into U+FFFD markers and the read is bounded at 500 bytes regardless of body size.

Successful runs still return `200`; only partial / total failure raises `502`.

## Verification on H100

Measured on H100 (80 GB HBM3, GPU 0) with **Qwen2-1.5B-Instruct, `gpu_memory_utilization=0.5`, `--attention-backend=triton`, `--enforce-eager`**.

| Phase | GPU used | Δ |
|---|---|---|
| Baseline (no engine) | 627 MiB | — |
| After model load | 41,431 MiB | **engine footprint: +40,804 MiB** |
| After `/release_memory_occupation` | 1,585 MiB | **−39,846 MiB = 97.7 %** of footprint |
| After `/resume_memory_occupation` | 41,533 MiB | +102 MiB vs. load (allocator overhead) |

| Latency | Value |
|---|---|
| Release | 23 ms |
| Resume | 18 ms |

The 97.7 % reclaim ratio is the **full-stack** measurement (this PR + #273 empty_cache/ipc_collect + #274 workspaces). The standalone-PR figure from synthetic testing was 90.7 %; the extra ~7 pp comes from the stacked improvements.

A round-trip generation parity check (output before release vs. output after resume) **passes** when combined with #275's `stage_to_cpu=true` flow. Without staging, weights are zeroed after resume (as documented above) and the engine produces garbage until weights are reloaded by other means.

Env caveats during testing (pre-existing, unrelated to this PR — fixes opened separately):
- #276 fixes a `scheduler_metadata` kwarg leak in `MHAAttnBackend` that breaks `--attention-backend=triton` / `fa4` / `flashinfer`.
- #277 fixes an `import triton_kernels.matmul` failure caused by upstream module renames.
- Set `FLASHINFER_DISABLE_VERSION_CHECK=1` and `LD_PRELOAD=$(pwd)/.venv/.../torch_memory_saver_hook_mode_preload_cu13.abi3.so` to launch the test process.

## `mini_lb.py` fan-out — verification

End-to-end test (`/tmp/test_mini_lb_fanout.py`) spins up real `aiohttp.web` backends on dynamic ports and drives the LB via FastAPI `TestClient`. All 12 scenarios pass:

| # | Scenario | Outcome |
|---|---|---|
| 1 | 1 good + 1 returning 500 + 1 returning 404 | `502` with both failing servers itemised |
| 2 | All backends return 200 | `200` |
| 3 | `/resume_memory_occupation` with one bad backend | `502` with the bad server |
| 4 | Backend returns 8 KiB error body | `detail` capped at exactly 500 B |
| 5 | Dead port (connection refused) | `502` with `error:` (no `status:`) |
| 6 | Every backend returns 500 (no successes) | `502` with `2/2 nodes` in message |
| 7 | `{stage_to_cpu, tags}` body forwarded verbatim | body received intact by every backend |
| 8 | No request body sent | backends see no body, fan-out still completes |
| 9 | Backend returns 202 (other 2xx) | treated as success → `200` |
| 10 | Empty `decode_servers` and empty everything | `200` (no-op fan-out) |
| 11 | Backend hangs (`await asyncio.sleep(60)`), helper timeout 1.5 s | returned in **1.50 s** with timeout reported; the parallel good backend still succeeded |
| 12 | Backend returns 500 with raw `\xff\xfe\xfd\xfc` bytes | `502` with `len(detail)=128`, U+FFFD replacement marker present, no UnicodeDecodeError |

## Test plan

- [x] Engine import path: `from tokenspeed.runtime.entrypoints.engine import Engine` (verified after env fixes).
- [x] `Engine(enable_memory_saver=True)` startup completes; baseline → after-load GPU memory matches `gpu_memory_utilization`.
- [x] `engine.release_memory_occupation()` returns; GPU memory drops by ~97 % of engine footprint.
- [x] `engine.resume_memory_occupation()` returns; GPU memory restored.
- [x] Regression: `Engine.release_memory_occupation(tags=["weights"])` no longer raises `TypeError`.
- [x] `mini_lb.py` fan-out propagates per-node failures (HTTP 4xx/5xx, connection refused, all-fail, body forwarding, 2xx variants, empty configs, hung backend timeout, binary error body) — see the 12-scenario table above.

## Notes / follow-ups

- The SMG gRPC servicer does not yet expose these methods; adding gRPC methods to `smg_grpc_proto` and `smg_grpc_servicer` is left as follow-up work so the endpoints become reachable through the production `ts serve` path.
- `tags` filtering (releasing only a subset of registered regions) is not yet implemented in `torch_memory_saver`; the field is plumbed through for forward-compatibility.
- CPU staging for transparent round-trip weight preservation is in #275.
- `_FANOUT_TIMEOUT_SECONDS` is currently a module-level constant (120 s). If real deployments need per-call tuning we can promote it to a server arg or query parameter.