### PR TITLE
feat(memory-saver): flush PyTorch alloc cache and IPC handles after pause

### DIFF
--- a/python/tokenspeed/runtime/engine/request_handler.py
+++ b/python/tokenspeed/runtime/engine/request_handler.py
@@ -181,6 +181,12 @@ class RequestHandler:
                 self.send_func.send_pyobj(FlushCacheReqOutput(success=True))
             elif isinstance(recv_req, ReleaseMemoryOccupationReqInput):
                 self.memory_saver.pause()
+                # Return cached-but-unused blocks held by the PyTorch caching
+                # allocator and release NCCL/IPC handles. Without these the
+                # driver still sees those pages as ours, so co-tenants can't
+                # use the headroom that pause() just freed.
+                torch.cuda.empty_cache()
+                torch.cuda.ipc_collect()
                 self.send_func.send_pyobj(ReleaseMemoryOccupationReqOutput())
             elif isinstance(recv_req, ResumeMemoryOccupationReqInput):
                 self.memory_saver.resume()


### PR DESCRIPTION
**Stacks on #272.**

## Summary

`torch_memory_saver.pause()` releases the physical pages backing tensors in `saver.region()`, but PyTorch's caching allocator still holds onto its own free pool and any NCCL/IPC handles outside that region. From the driver's perspective those pages are still ours, so co-tenants can't use the headroom `pause()` just freed.

This adds a `torch.cuda.empty_cache()` + `torch.cuda.ipc_collect()` immediately after `pause()` in the scheduler-side handler, so the bytes are actually surrendered to the driver pool.

## Verification on H100

Combined with #272 alone the synthetic measurement was 90.7 % reclaim of engine footprint. With this PR + #274 stacked on #272, the **full-stack reclaim on a real engine (Qwen2-1.5B, 40,804 MiB footprint, `--enforce-eager`)** is **97.7 %** — see #272 description for the per-phase table.

Isolated contribution of *this* PR can't be precisely separated from #274 in the stacked test (both ran together). What can be said:

- Without `empty_cache()` after `pause()`, the PyTorch caching allocator continues to hold the freed blocks. On a steady-state engine that's typically a few hundred MiB; right after a burst that ended in `free → realloc`, it can be > 1 GiB.
- `ipc_collect()` adds a small but non-zero amount (NCCL collectives, P2P buffers).
- Release latency stays at 23 ms — `empty_cache()` is essentially free at pause time.

## Test plan

- [x] Capture `nvidia-smi memory.used` delta with the `empty_cache` call across `/release_memory_occupation` — confirmed in the H100 E2E run.
- [x] Verify no perf regression on `/resume_memory_occupation` (allocator will rebuild the cache lazily on next forward) — resume latency stayed at 18 ms.
- [ ] Single-process A/B test isolating just `empty_cache`'s contribution (low priority; #274 is the bigger win in the stack).