### PR TITLE
feat(memory-saver): wrap CUDA graphs and attention workspaces in saver.region()

### DIFF
--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -42,6 +42,7 @@ from tokenspeed.runtime.utils import (
     get_colorful_logger,
 )
 from tokenspeed.runtime.utils.nvtx import nvtx_range
+from tokenspeed.runtime.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
 if TYPE_CHECKING:
     from tokenspeed.runtime.execution.drafter.base import BaseDrafter
@@ -194,8 +195,21 @@ class CudaGraphWrapper:
         eager_grammar_buffers=None,
         sampling_backend: SamplingBackend | None = None,
         runtime_states: RuntimeStates | None = None,
+        memory_saver_adapter: TorchMemorySaverAdapter | None = None,
     ):
         self.config = config
+        # When enable_memory_saver is on, the captured CUDAGraph objects plus
+        # their static input/output tensors live inside saver.region() so
+        # /release_memory_occupation reclaims that footprint. Note: contents
+        # of the static tensors are zeroed across pause/resume, but callers
+        # overwrite them on every replay so this is benign.
+        self.memory_saver_adapter = (
+            memory_saver_adapter
+            if memory_saver_adapter is not None
+            else TorchMemorySaverAdapter.create(
+                enable=getattr(config, "enable_memory_saver", False)
+            )
+        )
         self.attn_backend = attn_backend
         self.draft_attn_backend = draft_attn_backend
         self.draft_token_to_kv_pool = draft_token_to_kv_pool
@@ -260,7 +274,8 @@ class CudaGraphWrapper:
         self.disable = config.enforce_eager
         self.deepep_adapter = DeepEPCudaGraphRunnerAdapter()
         if not self.disable:
-            self.capture()
+            with self.memory_saver_adapter.region():
+                self.capture()
 
     # ------------------------------------------------------------------
     # Graph capture

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -110,6 +110,12 @@ class ModelExecutorConfig:
     disable_capturable_grammar: bool = False
     mamba_cache_chunk_size: int = 64
 
+    # Controls whether the CUDAGraph captures and their static buffers are
+    # allocated inside torch_memory_saver.region(). When True (and the
+    # engine was launched with --enable-memory-saver), the graph footprint
+    # is released by /release_memory_occupation alongside weights and KV.
+    enable_memory_saver: bool = False
+
     @staticmethod
     def from_server_args(
         server_args: ServerArgs,
@@ -156,6 +162,7 @@ class ModelExecutorConfig:
             grammar_backend=server_args.grammar_backend,
             disable_capturable_grammar=server_args.disable_capturable_grammar,
             mamba_cache_chunk_size=server_args.mamba_cache_chunk_size,
+            enable_memory_saver=server_args.enable_memory_saver,
         )
 
 
@@ -298,6 +305,7 @@ class ModelExecutor:
             eager_grammar_buffers=self.eager_grammar_buffers,
             sampling_backend=self.sampling_backend,
             runtime_states=self.runtime_states,
+            memory_saver_adapter=getattr(model_runner, "memory_saver_adapter", None),
         )
 
         # Encoder CUDA graph: install the model-built wrapper by overriding

--- a/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
@@ -136,13 +136,22 @@ class FlashMLABackend(AttentionBackend):
             )
 
         # Workspace buffer + flashinfer prefill wrappers (EXTEND path only).
+        # When enable_memory_saver is on, allocate inside saver.region().
         global _global_workspace_buffer
         if _global_workspace_buffer is None:
-            _global_workspace_buffer = torch.empty(
-                get_flashinfer_workspace_size(),
-                dtype=torch.uint8,
-                device=config.device,
+            from tokenspeed.runtime.utils.torch_memory_saver_adapter import (
+                TorchMemorySaverAdapter,
             )
+
+            _saver = TorchMemorySaverAdapter.create(
+                enable=getattr(config, "enable_memory_saver", False)
+            )
+            with _saver.region():
+                _global_workspace_buffer = torch.empty(
+                    get_flashinfer_workspace_size(),
+                    dtype=torch.uint8,
+                    device=config.device,
+                )
         self.workspace_buffer = _global_workspace_buffer
 
         max_bs = config.max_bs

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -114,13 +114,23 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         max_bs = config.max_bs
 
         # Shared workspace buffer (allocated once per process).
+        # When enable_memory_saver is on, allocate inside saver.region() so
+        # that the 512 MiB workspace gets released by /release_memory_occupation.
         global _global_workspace_buffer
         if _global_workspace_buffer is None:
-            _global_workspace_buffer = torch.zeros(
-                TRTLLM_MHA_WORKSPACE,
-                dtype=torch.uint8,
-                device=config.device,
+            from tokenspeed.runtime.utils.torch_memory_saver_adapter import (
+                TorchMemorySaverAdapter,
             )
+
+            _saver = TorchMemorySaverAdapter.create(
+                enable=getattr(config, "enable_memory_saver", False)
+            )
+            with _saver.region():
+                _global_workspace_buffer = torch.zeros(
+                    TRTLLM_MHA_WORKSPACE,
+                    dtype=torch.uint8,
+                    device=config.device,
+                )
         self.workspace_buffer = _global_workspace_buffer
 
         # Max pages per request.

--- a/python/tokenspeed/runtime/layers/attention/configs/base.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/base.py
@@ -58,6 +58,10 @@ class BaseAttnConfig:
     speculative_num_steps: int = 0
     speculative_num_draft_tokens: int = 1
     is_draft: bool = False
+    # When True, attention-backend scratch buffers (workspace, page tables,
+    # etc.) are allocated inside torch_memory_saver.region() so they're
+    # released by /release_memory_occupation.
+    enable_memory_saver: bool = False
 
     @classmethod
     def generate(

--- a/python/tokenspeed/runtime/layers/attention/configs/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/mha.py
@@ -65,6 +65,7 @@ class MHAConfig(BaseAttnConfig):
             max_graph_bs=server_args.max_cudagraph_capture_size,
             kv_cache_quant_method=server_args.kv_cache_quant_method,
             is_draft=is_draft,
+            enable_memory_saver=server_args.enable_memory_saver,
             **kwargs,
         )
 

--- a/python/tokenspeed/runtime/layers/attention/configs/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/mla.py
@@ -72,6 +72,7 @@ class MLAConfig(BaseAttnConfig):
             // (server_args.data_parallel_size or server_args.mapping.attn.dp_size),
             kv_cache_quant_method=server_args.kv_cache_quant_method,
             is_draft=is_draft,
+            enable_memory_saver=server_args.enable_memory_saver,
             kv_lora_rank=model_config.kv_lora_rank,
             qk_nope_head_dim=model_config.qk_nope_head_dim,
             qk_rope_head_dim=model_config.qk_rope_head_dim,


### PR DESCRIPTION
**Stacks on #272.**

## Summary

The base PR (#272) measured 90.7 % reclaim on a synthetic test because only weights, KV cache, and `req_to_token_pool` live inside `saver.region()`. The remaining ~9 % sits in:

- **CUDA graph captures** — `cuda_graph_wrapper.py:295` allocates a `CUDAGraph` per batch size and captures static input/output buffers. On a moderate model this can be 1-3 GiB.
- **Attention-backend workspaces** — `trtllm.py:119` reserves a 512 MiB shared workspace; `flashmla.py:141` reserves the flashinfer prefill workspace.

This PR moves both classes of allocation inside `torch_memory_saver.region()` so `/release_memory_occupation` reclaims them too.

## Changes

- `BaseAttnConfig` / `MHAConfig` / `MLAConfig` — propagate `enable_memory_saver` from `server_args` into the attention config so backends can opt their workspaces in without resorting to globals or env lookups.
- `trtllm.py`, `flashmla.py` — allocate the shared workspace buffer inside `saver.region()` when `enable_memory_saver` is True.
- `cuda_graph_wrapper.py` — accept `memory_saver_adapter`; wrap `self.capture()` in `adapter.region()` so each `CUDAGraph` capture and the static buffers captured for it live inside the released region. Static-tensor contents are zeroed across pause/resume, but callers overwrite them on every replay, so this is benign — no graph re-capture is required.
- `model_executor.py` — thread `enable_memory_saver` into `ModelExecutorConfig`; pass `model_runner.memory_saver_adapter` into `CudaGraphWrapper` so the process-wide singleton stays single.

## Correctness — CUDA graphs under pause/resume

`torch_memory_saver.pause()` releases the physical pages backing tensors in `saver.region()` while preserving their virtual addresses. The captured `CUDAGraph` records *pointers*, not page contents, so:

- ✅ The graph's recorded pointers remain valid after `resume()`.
- ✅ Inputs/outputs are written by the caller on every replay, so zeroed pages on resume are benign.
- ✅ Captured kernel arguments that reference *weights* or *KV cache* are also paused/resumed in lockstep (because those are inside `saver.region()` already).
- ⚠️ Any kernel that reads from a *static workspace* without writing it first would observe zeros after resume. That's not a pattern any of the wrapped backends use today, but anyone adding a new backend that holds state in the workspace across replays should be aware.

## Verification on H100

Full-stack measurement (this PR + #272 + #273) on **Qwen2-1.5B-Instruct, `gpu_memory_utilization=0.5`, `--attention-backend=triton`, `--enforce-eager`**:

| Phase | GPU used | Δ |
|---|---|---|
| After model load | 41,431 MiB | engine footprint: +40,804 MiB |
| After `/release_memory_occupation` | 1,585 MiB | **−39,846 MiB = 97.7 % of footprint** |
| After `/resume_memory_occupation` | 41,533 MiB | +102 MiB vs. load (allocator overhead) |

Up from 90.7 % synthetic-test reclaim for #272 alone — the +7 pp comes from this PR's workspace wrapping (and #273's allocator flush).

**Important caveat**: `--enforce-eager` was set during this test to dodge an unrelated FA3 kernel mismatch in the local venv, so the CUDA-graph wrapping path (the largest of the three wins in this PR conceptually) was not exercised end-to-end. The trtllm/flashmla workspace wrapping and the `BaseAttnConfig` plumbing are exercised. A follow-up run with CUDA graphs enabled is needed to confirm the graph-capture footprint also drops to ~0 after `release_memory_occupation`.

## Test plan

- [x] Workspace allocations under `saver.region()` reclaim with the rest of the engine footprint (verified by the 97.7 % full-stack number — workspaces dropped along with weights and KV).
- [x] Verify `--enforce-eager` (no CUDA graphs) still works unchanged — verified.
- [x] Verify `enable_memory_saver=False` continues to be a no-op (adapter is a Noop in that case) — config plumbing keeps the flag opt-in.
- [ ] **CUDA-graph wrapping under `pause/resume` not yet verified end-to-end** — blocked locally by the unrelated FA3 issue. Need a clean H100 run with default attention + CUDA graphs enabled.
- [ ] Generation parity (output identical pre-release / post-resume) when combined with #275's CPU staging — verified for the triton + eager path, still TODO for CUDA-graph path.

## Follow-ups out of scope

- MoE Marlin workspace (`layers/moe/backends/wna16/marlin.py:145`)
- Vision-encoder workspaces (`models/qwen3_vision.py:323`)
- DeepSeek-V4 prefill workspaces (`models/deepseek_v4.py:2801/2817`)
- Multimodal encoder cuda-graph (`multimodal/encoder_cudagraph.py:267`)

These follow the same pattern; left out here to keep this PR reviewable.