### PR TITLE
feat(memory-saver): optional CPU staging for round-trip weight preservation

### DIFF
--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -372,6 +372,15 @@ class EventLoop:
             ),
         )
 
+        from tokenspeed.runtime.engine.memory_occupation_manager import (
+            MemoryOccupationManager,
+        )
+
+        memory_occupation_manager = MemoryOccupationManager(
+            memory_saver=target.memory_saver_adapter,
+            model_runner=target,
+            draft_model_runner=draft,
+        )
         self.request_handler = RequestHandler(
             server_args=self.server_args,
             hf_eos_token_id=self.model_config.hf_eos_token_id,
@@ -381,6 +390,8 @@ class EventLoop:
             send_func=self.send_to_tokenizer,
             get_load_fn=self._get_load,
             architectures=self.model_config.hf_config.architectures,
+            memory_saver=target.memory_saver_adapter,
+            memory_occupation_manager=memory_occupation_manager,
         )
 
         self.output_processor = OutputProcesser(

--- a/python/tokenspeed/runtime/engine/io_struct.py
+++ b/python/tokenspeed/runtime/engine/io_struct.py
@@ -694,6 +694,10 @@ class GetWeightsByNameReqOutput:
 @dataclass
 class ReleaseMemoryOccupationReqInput:
     tags: list[str] | None = None
+    # When True, copy model parameters and buffers into pinned host RAM
+    # before pause() so /resume_memory_occupation can restore them without
+    # re-reading the checkpoint from disk.
+    stage_to_cpu: bool = False
 
 
 @dataclass

--- a/python/tokenspeed/runtime/engine/memory_occupation_manager.py
+++ b/python/tokenspeed/runtime/engine/memory_occupation_manager.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""CPU-staged release/resume for torch_memory_saver-managed regions.
+
+`torch_memory_saver.pause()` releases the physical GPU pages backing tensors
+allocated in `saver.region()` and preserves their virtual addresses. It does
+**not** copy data to host RAM, so the next `resume()` returns memory with
+zeroed contents — callers either accept that (scratch buffers, KV cache) or
+reload from disk (weights).
+
+For the RLHF train↔serve handoff case it's cheaper to stage weights to host
+RAM on release and copy them back on resume than to re-read tens-of-GiB
+checkpoints from disk on every cycle. This module implements that pattern:
+
+  - On `release(stage_to_cpu=True)`:
+      1. Copy every model parameter into a pre-allocated pinned host buffer.
+      2. Call `saver.pause()` to release the GPU pages.
+  - On `resume()`:
+      1. Call `saver.resume()` so the same virtual addresses are backed again.
+      2. Copy each parameter back from the pinned host buffer.
+
+Trade-off: host RAM holds a full duplicate of the model weights for the
+duration of the release. For Qwen2-72B in bf16 that's ~145 GiB of host RAM
+during the offload window. The release side becomes the bottleneck on the
+HtoD path (PCIe Gen4 x16 ≈ 25 GiB/s, NVLink-attached host even faster).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.execution.model_runner import ModelRunner
+    from tokenspeed.runtime.utils.torch_memory_saver_adapter import (
+        TorchMemorySaverAdapter,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class MemoryOccupationManager:
+    """Coordinates torch_memory_saver pause/resume with optional CPU staging."""
+
+    def __init__(
+        self,
+        memory_saver: TorchMemorySaverAdapter,
+        model_runner: ModelRunner | None,
+        draft_model_runner: ModelRunner | None = None,
+        use_pinned_host: bool = True,
+    ) -> None:
+        self.memory_saver = memory_saver
+        self.model_runner = model_runner
+        self.draft_model_runner = draft_model_runner
+        self.use_pinned_host = use_pinned_host
+        # name -> CPU tensor snapshot. Populated on release(stage_to_cpu=True),
+        # consumed and cleared on resume().
+        self._staged: dict[str, torch.Tensor] = {}
+
+    # ------------------------------------------------------------------
+    # release
+    # ------------------------------------------------------------------
+
+    def release(
+        self, *, stage_to_cpu: bool = False, tags: list[str] | None = None
+    ) -> None:
+        """Release GPU memory; optionally stage model weights to host RAM first."""
+        if stage_to_cpu:
+            self._stage_to_cpu()
+        self.memory_saver.pause()
+        # Surrender allocator-cached and IPC pages to the driver as well.
+        torch.cuda.empty_cache()
+        torch.cuda.ipc_collect()
+
+    def resume(self, *, tags: list[str] | None = None) -> None:
+        """Reacquire GPU memory; restore staged weights if any are pending."""
+        self.memory_saver.resume()
+        if self._staged:
+            self._restore_from_cpu()
+
+    # ------------------------------------------------------------------
+    # internal: CPU staging
+    # ------------------------------------------------------------------
+
+    def _iter_runners(self):
+        for runner in (self.model_runner, self.draft_model_runner):
+            if runner is not None and getattr(runner, "model", None) is not None:
+                yield runner
+
+    def _stage_to_cpu(self) -> None:
+        """Copy every model parameter into a pinned host buffer.
+
+        Reuses existing snapshot buffers when present (same shape/dtype) so a
+        repeated release→resume→release cycle doesn't reallocate host RAM.
+        """
+        for runner in self._iter_runners():
+            model = runner.model
+            prefix = "model" if runner is self.model_runner else "draft"
+            for name, param in model.named_parameters():
+                key = f"{prefix}::{name}"
+                src = param.detach()
+                snap = self._staged.get(key)
+                if snap is None or snap.shape != src.shape or snap.dtype != src.dtype:
+                    snap = torch.empty(
+                        src.shape,
+                        dtype=src.dtype,
+                        device="cpu",
+                        pin_memory=self.use_pinned_host and torch.cuda.is_available(),
+                    )
+                    self._staged[key] = snap
+                snap.copy_(src, non_blocking=True)
+            # Also stage buffers (norm running stats, embeddings stored as
+            # buffers, etc.) so resume reconstructs the full forward state.
+            for name, buf in model.named_buffers():
+                key = f"{prefix}::buffer::{name}"
+                src = buf.detach()
+                snap = self._staged.get(key)
+                if snap is None or snap.shape != src.shape or snap.dtype != src.dtype:
+                    snap = torch.empty(
+                        src.shape,
+                        dtype=src.dtype,
+                        device="cpu",
+                        pin_memory=self.use_pinned_host and torch.cuda.is_available(),
+                    )
+                    self._staged[key] = snap
+                snap.copy_(src, non_blocking=True)
+        torch.cuda.synchronize()
+        logger.info("Staged %d tensors to host RAM ahead of pause()", len(self._staged))
+
+    def _restore_from_cpu(self) -> None:
+        """Copy staged host-side tensors back into the original GPU buffers.
+
+        The GPU buffers are at the same virtual addresses as before pause();
+        their contents are zeroed at this point. ``param.data.copy_()`` writes
+        through to those same pages, preserving every captured CUDAGraph
+        argument pointer.
+        """
+        with torch.no_grad():
+            for runner in self._iter_runners():
+                model = runner.model
+                prefix = "model" if runner is self.model_runner else "draft"
+                for name, param in model.named_parameters():
+                    key = f"{prefix}::{name}"
+                    snap = self._staged.get(key)
+                    if snap is not None:
+                        param.data.copy_(snap, non_blocking=True)
+                for name, buf in model.named_buffers():
+                    key = f"{prefix}::buffer::{name}"
+                    snap = self._staged.get(key)
+                    if snap is not None:
+                        buf.data.copy_(snap, non_blocking=True)
+        torch.cuda.synchronize()
+        logger.info(
+            "Restored %d tensors from host RAM after resume()", len(self._staged)
+        )
+        # Drop the snapshots so subsequent resumes without a staging release
+        # don't accidentally clobber freshly loaded weights.
+        self._staged.clear()

--- a/python/tokenspeed/runtime/engine/request_handler.py
+++ b/python/tokenspeed/runtime/engine/request_handler.py
@@ -52,6 +52,7 @@ from tokenspeed.runtime.engine.io_struct import (
     SetInternalStateReqOutput,
     TokenizedGenerateReqInput,
 )
+from tokenspeed.runtime.engine.memory_occupation_manager import MemoryOccupationManager
 from tokenspeed.runtime.engine.request_types import FINISH_ABORT
 from tokenspeed.runtime.engine.scheduler_utils import make_spec
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
@@ -87,12 +88,24 @@ class RequestHandler:
         get_load_fn=None,
         architectures: list[str] | None = None,
         memory_saver: TorchMemorySaverAdapter | None = None,
+        memory_occupation_manager: MemoryOccupationManager | None = None,
     ) -> None:
 
         self.forward_ct = 0
         self.server_args = server_args
         self.memory_saver = memory_saver or TorchMemorySaverAdapter.create(
             server_args.enable_memory_saver
+        )
+        # Falls back to a manager without a model reference, which means
+        # stage_to_cpu=True silently degrades to a plain pause (no staging,
+        # no error). The event loop is expected to supply a real manager
+        # with model_runner attached.
+        self.memory_occupation_manager = (
+            memory_occupation_manager
+            if memory_occupation_manager is not None
+            else MemoryOccupationManager(
+                memory_saver=self.memory_saver, model_runner=None
+            )
         )
 
         mapping = server_args.mapping
@@ -180,10 +193,13 @@ class RequestHandler:
                 # control request here so API callers still get a typed reply.
                 self.send_func.send_pyobj(FlushCacheReqOutput(success=True))
             elif isinstance(recv_req, ReleaseMemoryOccupationReqInput):
-                self.memory_saver.pause()
+                self.memory_occupation_manager.release(
+                    stage_to_cpu=recv_req.stage_to_cpu,
+                    tags=recv_req.tags,
+                )
                 self.send_func.send_pyobj(ReleaseMemoryOccupationReqOutput())
             elif isinstance(recv_req, ResumeMemoryOccupationReqInput):
-                self.memory_saver.resume()
+                self.memory_occupation_manager.resume(tags=recv_req.tags)
                 self.send_func.send_pyobj(ResumeMemoryOccupationReqOutput())
             elif isinstance(recv_req, GetInternalStateReq):
                 self.send_func.send_pyobj(GetInternalStateReqOutput(internal_state={}))

--- a/python/tokenspeed/runtime/entrypoints/http_server.py
+++ b/python/tokenspeed/runtime/entrypoints/http_server.py
@@ -69,16 +69,24 @@ def create_app(async_llm: AsyncLLM, server_args: ServerArgs) -> FastAPI:
 
     @app.post("/release_memory_occupation")
     async def release_memory_occupation(request: dict | None = None):
-        """Offload model weights, KV cache, and CUDA graphs to CPU via torch_memory_saver.
+        """Release GPU memory occupied by tensors inside torch_memory_saver regions.
 
         Requires the server to have been started with ``--enable-memory-saver``.
 
-        Optional JSON body: ``{"tags": ["weights", "kv_cache"]}``
+        Optional JSON body:
+          - ``tags``: subset of regions to release (currently no-op; future use)
+          - ``stage_to_cpu``: when True, copy model parameters + buffers to
+            pinned host RAM before release so /resume_memory_occupation can
+            restore them without re-reading the checkpoint from disk. Costs
+            ~model_size bytes of host RAM for the duration of the release.
         """
         from tokenspeed.runtime.engine.io_struct import ReleaseMemoryOccupationReqInput
 
-        tags = (request or {}).get("tags") if request else None
-        obj = ReleaseMemoryOccupationReqInput(tags=tags)
+        body = request or {}
+        obj = ReleaseMemoryOccupationReqInput(
+            tags=body.get("tags"),
+            stage_to_cpu=bool(body.get("stage_to_cpu", False)),
+        )
         await async_llm.release_memory_occupation(obj)
         return ORJSONResponse({"success": True})
 


### PR DESCRIPTION
**Stacks on #272.**

## Summary

#272's `/release_memory_occupation` truthfully releases GPU memory but the contents are gone — `torch_memory_saver.pause()` preserves virtual addresses only, not data. `/resume_memory_occupation` gets zeroed pages back, so any caller that wants the model to work after a release/resume cycle has to re-read the checkpoint from disk. For RLHF train↔serve handoff and similar "pause inference, return GPU, resume inference" flows that's tens of GiB of disk I/O on every cycle.

This PR adds an **opt-in** CPU staging step:

```
POST /release_memory_occupation
{"stage_to_cpu": true}
```

- Before `saver.pause()`, copy every param and buffer of the (target and draft) model into a pre-allocated pinned host buffer.
- After `saver.resume()`, copy them back into the original GPU virtual addresses (so any CUDAGraph captures keep their argument pointers valid).

## Changes

- **New** `tokenspeed/runtime/engine/memory_occupation_manager.py` — `MemoryOccupationManager` class. Owns the pinned host buffers, drives `saver.pause()`/`resume()`, and reuses staging buffers across cycles so a steady-state RLHF loop doesn't reallocate ~145 GiB of pinned host RAM every iteration.
- `io_struct.py` — add `stage_to_cpu: bool = False` to `ReleaseMemoryOccupationReqInput`.
- `request_handler.py` — replace direct `memory_saver` calls with the manager so the staging path runs in the scheduler process where `model_runner.model` is live.
- `event_loop.py` — construct the manager with the real target + draft `model_runner` and pass it into `RequestHandler`.
- `http_server.py` — parse `stage_to_cpu` from the JSON body.

## Verification on H100 — **round-trip correctness PASS**

Measured on **Qwen2-1.5B-Instruct, `gpu_memory_utilization=0.5`, `--attention-backend=triton`, `--enforce-eager`**:

| Phase | GPU used | Δ |
|---|---|---|
| After model load | 41,431 MiB | engine footprint: +40,804 MiB |
| After `release(stage_to_cpu=true)` | 1,593 MiB | **−39,838 MiB = 97.6 % of footprint** |
| After `resume()` (restores from CPU) | 41,541 MiB | +110 MiB vs. load |

| Latency | Value |
|---|---|
| Release (incl. staging) | **1.70 s** |
| Resume (incl. restore) | **0.08 s** |

Generation parity:

| Phase | Prompt → Output |
|---|---|
| Pre-release | `"The capital of France is"` → `" ______.\nA. Paris\nB."` |
| Post-resume | `"The capital of France is"` → `" ______.\nA. Paris\nB."` |

**`Outputs match: True`** — round-trip preservation works end-to-end.

For Qwen2-1.5B (~3 GiB bf16 weights), the 1.7 s release latency is dominated by the DtoH memcpy of weights into pinned host RAM. Extrapolating to Qwen2-72B (~145 GiB) at PCIe Gen4 x16 (~25 GiB/s pinned): release ≈ 6-8 s; resume ≈ 6-8 s. Compared to ~60-180 s to re-read a 145 GiB checkpoint from network storage, that's a ~10-20× speedup for the train↔serve handoff path.

## Trade-offs

- **Host RAM**: holds ~sizeof(model) for the duration of the release. For a 72B bf16 model that's ~145 GiB of pinned host RAM.
- **Release latency**: with staging, ~1.7 s for a 1.5B model; without, 23 ms. Resume latency goes from 18 ms to 80 ms.
- **Scope**: stages model parameters + buffers only. KV cache and `req_to_token_pool` are scratch — the engine flushes outstanding requests before any reasonable use of this endpoint, so there's nothing in them worth preserving.
- **Tag-based staging**: not yet implemented. The `tags` field is plumbed but unused; a future PR can use it to stage only a subset (e.g. weights but not KV).

## Test plan

- [x] Round-trip correctness: release with `stage_to_cpu=true`, resume, run inference; outputs match the pre-release run.
- [x] Measure release time / resume time with and without staging on a representative model.
- [x] Verify `stage_to_cpu=false` continues to behave as #272 — release returns zeroed pages, caller must reload weights.
- [ ] Cycle test: 5x release→resume in a loop, host RAM usage stable (no leak from staging buffer reallocation).
- [ ] Verify with CUDA graphs enabled (blocked locally by the unrelated FA3 issue; see #276 / #277).

## Env caveats during testing (unrelated to this PR)

- #276 fixes a `scheduler_metadata` kwarg leak in `MHAAttnBackend` that breaks `--attention-backend=triton` / `fa4` / `flashinfer`.
- #277 fixes an `import triton_kernels.matmul` failure caused by upstream module renames.

## Open questions

- Do we want a config knob for `pin_memory` (currently default-on)? On hosts without enough pinned-RAM budget, unpinned staging works at ~6-8 GiB/s vs. ~25 GiB/s pinned.
- Should the staging buffer live on a separate NUMA node when available? Out of scope here.