### PR TITLE
fix(mha): don't compute FA3 scheduler metadata for non-FA3 backends

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mha.py
@@ -212,6 +212,11 @@ class MHAAttnBackend(AttentionBackend):
         scheduler metadata (only FA3 on Hopper does); the kernel then falls
         back to its internal prepare_varlen_num_blocks launch.
         """
+        # Only FA3 consumes the pre-computed metadata; triton/fa4/flashinfer
+        # reject it as an unknown kwarg. ``None`` solution means auto-select,
+        # which may land on FA3, so we still compute in that case.
+        if self.kernel_solution not in (None, "fa3"):
+            return None
         return mha_decode_scheduler_metadata(
             batch_size=bs,
             max_seqlen_q=1,


### PR DESCRIPTION
## Summary

`MHAAttnBackend._maybe_compute_scheduler_metadata`'s docstring says it returns `None` when the active backend doesn't consume pre-computed scheduler metadata, but the implementation unconditionally calls `mha_decode_scheduler_metadata` and returns its result. Downstream in `forward_decode`, the non-None tensor gets passed to the selected kernel — and triton / fa4 / flashinfer reject the unknown `scheduler_metadata` kwarg:

```
TypeError: triton_mha_decode_with_kvcache() got an unexpected keyword
argument 'scheduler_metadata'
```

Guard the call so the docstring matches the behaviour: skip the compute (and therefore the downstream kwarg) when `kernel_solution` is anything other than `"fa3"` or `None` (None == auto-select, may land on FA3).

## Repro

```
python -m tokenspeed.cli serve <any-MHA-model> --attention-backend=triton
# first decode forward TypeErrors as above
```

## Test plan

- [ ] `--attention-backend=triton` end-to-end inference on Hopper (Qwen2-1.5B-Instruct) — confirmed locally; produces correct output.
- [ ] `--attention-backend=fa3` continues to consume the pre-computed metadata as before.
- [ ] `--attention-backend=mha` (auto) continues to compute it (auto-select may still land on FA3).
- [ ] `--attention-backend=fa4` / `flashinfer` no longer trip the TypeError.

## Related

Encountered while verifying #272 / #273 / #274 / #275 end-to-end on H100.