### PR TITLE
fix(thirdparty/triton_kernels): tolerate upstream module rename

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton_kernels/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton_kernels/__init__.py
@@ -20,14 +20,31 @@
 
 from tokenspeed_kernel._triton import redirect_triton_to_tokenspeed_triton
 
+# Different upstream triton_kernels versions ship different submodule names
+# (older releases used ``matmul`` / ``matmul_details``; newer ones rename
+# them to ``matmul_ogs`` / ``matmul_ogs_details``). Wrap each pre-import in
+# try/except so an installed-version mismatch doesn't break the whole
+# import chain — call sites in tokenspeed_kernel.ops already guard their
+# actual usages with ImportError fallbacks.
 with redirect_triton_to_tokenspeed_triton():
     import triton_kernels  # noqa: F401
-    import triton_kernels.matmul  # noqa: F401
-    import triton_kernels.matmul_details  # noqa: F401
-    import triton_kernels.matmul_details.opt_flags  # noqa: F401
-    import triton_kernels.numerics  # noqa: F401
-    import triton_kernels.swiglu  # noqa: F401
-    import triton_kernels.tensor  # noqa: F401
-    import triton_kernels.tensor_details  # noqa: F401
-    import triton_kernels.tensor_details.layout  # noqa: F401
-    import triton_kernels.topk  # noqa: F401
+
+    for _mod in (
+        "triton_kernels.matmul",
+        "triton_kernels.matmul_details",
+        "triton_kernels.matmul_details.opt_flags",
+        "triton_kernels.matmul_ogs",
+        "triton_kernels.matmul_ogs_details",
+        "triton_kernels.matmul_ogs_details.opt_flags",
+        "triton_kernels.numerics",
+        "triton_kernels.swiglu",
+        "triton_kernels.tensor",
+        "triton_kernels.tensor_details",
+        "triton_kernels.tensor_details.layout",
+        "triton_kernels.topk",
+    ):
+        try:
+            __import__(_mod)
+        except ImportError:
+            pass
+    del _mod


### PR DESCRIPTION
## Summary

`tokenspeed_kernel/thirdparty/triton_kernels/__init__.py` pre-imports a list of `triton_kernels` submodules under the redirected-triton context. The pre-imports were unconditional, so any naming difference between the locally-installed `triton_kernels` and the names hard-coded here broke every downstream `tokenspeed.runtime` import with:

```
ModuleNotFoundError: No module named 'triton_kernels.matmul'
```

Upstream `openai/triton`'s `triton_kernels` renamed `matmul` → `matmul_ogs` (and `matmul_details` → `matmul_ogs_details`) at some point between 0.x and 1.x. PyPI's `triton_kernels==0.1.0` already has the new layout; older builds shipped through other channels still have the old layout.

Real call sites in `tokenspeed_kernel/ops/moe/triton_kernels.py` already guard their actual usages with `try/except ImportError`, so the only thing actually broken was the eager pre-import.

## Change

Wrap each `__import__` individually. List both naming conventions so either flavour of the installed package works.

## Test plan

- [ ] `python -c "from tokenspeed.runtime.entrypoints.engine import Engine"` succeeds against the new layout (`triton_kernels==0.1.0` PyPI build, has `matmul_ogs`). ✅ verified locally.
- [ ] Same against an older install that still has `matmul` (will still work via the first half of the alternation list).
- [ ] MoE path that depends on `triton_kernels.matmul_ogs` is unaffected (no behaviour change to call sites, only to the pre-import shim).

## Related

Encountered while verifying #272 / #273 / #274 / #275 end-to-end on H100.