### PR TITLE
fix(deps): pin flashinfer-jit-cache==0.6.11 in cuda requirements

### DIFF
--- a/.github/workflows/update-tokenspeed-kernel-flashinfer.yml
+++ b/.github/workflows/update-tokenspeed-kernel-flashinfer.yml
@@ -52,6 +52,7 @@ jobs:
           replacements = [
               (r"flashinfer-python==[^\n]+", f"flashinfer-python=={version}"),
               (r"flashinfer-cubin==[^\n]+", f"flashinfer-cubin=={version}"),
+              (r"flashinfer-jit-cache==[^\n]+", f"flashinfer-jit-cache=={version}"),
           ]
           for pattern, replacement in replacements:
               text = re.sub(pattern, replacement, text)

--- a/test/ci_system/install_deps.sh
+++ b/test/ci_system/install_deps.sh
@@ -91,7 +91,10 @@ python3 -m pip install --upgrade pip setuptools wheel
 # ============================================================
 echo "=== Step 3: Install tokenspeed-kernel ==="
 cd ${WORKSPACE}
-export PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cu${CUINDEX}"
+# Two extra index URLs:
+#   - download.pytorch.org for torch
+#   - flashinfer.ai/whl/cu*/ for flashinfer-jit-cache (not on PyPI)
+export PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cu${CUINDEX} https://flashinfer.ai/whl/cu${CUINDEX}"
 TOKENSPEED_KERNEL_BACKEND=cuda FLASHINFER_CUDA_ARCH_LIST="${FI_ARCH}" \
 pip_install_with_retry pip3 install tokenspeed-kernel/python/ --no-build-isolation -v
 

--- a/tokenspeed-kernel/python/requirements/cuda.txt
+++ b/tokenspeed-kernel/python/requirements/cuda.txt
@@ -3,5 +3,8 @@ nvidia-cutlass-dsl
 torch==2.11.0
 flashinfer-python==0.6.11
 flashinfer-cubin==0.6.11
+# flashinfer-jit-cache lives on flashinfer.ai/whl/cuXXX/ (not PyPI); see
+# install_deps.sh for the --extra-index-url that makes this resolvable.
+flashinfer-jit-cache==0.6.11
 nvidia-ml-py==13.580.82
 nvtx


### PR DESCRIPTION
## Summary

`flashinfer-jit-cache` was missing from `cuda.txt` requirements and had drifted to `0.6.9+cu130` while `flashinfer-python` was at `0.6.11`. This version mismatch caused MiniMax-M2.7 (and likely other models) to be completely unserviceable on H100 (SM90).

**Root cause**: `flashinfer/jit/env.py` raises `RuntimeError` at import time when the jit-cache and python package versions don't match. When bypassed with `FLASHINFER_DISABLE_VERSION_CHECK=1`, the stale 0.6.9 precompiled kernels cause async CUDA errors, illegal memory accesses, and missing SM90 CUBINs throughout the serving stack.

**Fix**: add `flashinfer-jit-cache==0.6.11` to `cuda.txt` so it's pinned alongside `flashinfer-python` and `flashinfer-cubin`.

## Test plan

Verified MiniMaxAI/MiniMax-M2.7 FP8 TP4 on H100×4 with `flashinfer-jit-cache==0.6.11+cu130`:

| Batch | Throughput |
|---|---|
| BS=1 | 107 tok/s |
| BS=4 | 395 tok/s |
| BS=16 | 1,304 tok/s |
| BS=32 | 2,260 tok/s |

All batch sizes work without crashes or code changes.