### PR TITLE
Make dtype-role filtering explicit

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/benchmark/cli.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/benchmark/cli.py
@@ -100,6 +100,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Benchmark dtype",
     )
     parser.add_argument(
+        "--dtype-role",
+        required=True,
+        help="Tensor role whose storage dtype is selected by --dtype",
+    )
+    parser.add_argument(
         "--shapes",
         help="JSON object or list of shape objects override",
     )
@@ -178,13 +183,17 @@ def main(argv: list[str] | None = None) -> int:
     runner = BenchmarkRunner(config)
 
     if args.kernel_name is not None:
-        results = runner.benchmark_kernel(args.kernel_name, shapes=shapes, dtype=dtype)
+        results = runner.benchmark_kernel(
+            args.kernel_name, shapes=shapes, dtype=dtype, dtype_role=args.dtype_role
+        )
     elif op_filter is not None:
         assert op_filter is not None
         family, mode = op_filter
-        results = runner.benchmark_op(family, mode, shapes=shapes, dtype=dtype)
+        results = runner.benchmark_op(
+            family, mode, shapes=shapes, dtype=dtype, dtype_role=args.dtype_role
+        )
     else:
-        results = runner.benchmark_all(dtype=dtype)
+        results = runner.benchmark_all(dtype=dtype, dtype_role=args.dtype_role)
 
     print(format_report(results))
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/benchmark/runner.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/benchmark/runner.py
@@ -24,7 +24,7 @@ import math
 import time
 from contextlib import nullcontext
 from datetime import datetime, timezone
-from typing import Any, Callable
+from typing import Any, Callable, Iterable
 
 import torch
 from tokenspeed_kernel.benchmark.config import BenchmarkConfig
@@ -135,11 +135,12 @@ class BenchmarkRunner:
         kernel: Callable[..., Any],
         shape: dict[str, Any],
         dtype: torch.dtype,
+        dtype_role: str | Iterable[str],
     ) -> BenchmarkResult | None:
         if not spec_matches_shape_traits(spec, shape):
             return None
 
-        signature = spec.format_signature_for_primary_storage_dtype(dtype)
+        signature = spec.format_signature_for_storage_dtype(dtype, dtype_role)
         if signature is None:
             return None
 
@@ -191,6 +192,7 @@ class BenchmarkRunner:
                 kernel,
                 shape,
                 dtype,
+                dtype_role,
                 generator,
             )
 
@@ -223,13 +225,14 @@ class BenchmarkRunner:
         kernel: Callable[..., Any],
         shape: dict[str, Any],
         dtype: torch.dtype,
+        dtype_role: str | Iterable[str],
         generator: Any,
     ) -> tuple[bool | None, float | None, float | None]:
         if spec.solution == "reference":
             return None, None, None
 
         registry = KernelRegistry.get()
-        signature = spec.format_signature_for_primary_storage_dtype(dtype)
+        signature = spec.format_signature_for_storage_dtype(dtype, dtype_role)
         if signature is None:
             return None, None, None
 
@@ -287,6 +290,7 @@ class BenchmarkRunner:
         *,
         shapes: list[dict[str, Any]] | None = None,
         dtype: torch.dtype = torch.bfloat16,
+        dtype_role: str | Iterable[str],
     ) -> list[BenchmarkResult]:
         """Benchmark a single kernel across shapes."""
         registry = KernelRegistry.get()
@@ -294,9 +298,10 @@ class BenchmarkRunner:
         if spec is None:
             raise ValueError(f"Kernel {kernel_name!r} is not registered")
 
-        if spec.format_signature_for_primary_storage_dtype(dtype) is None:
+        if spec.format_signature_for_storage_dtype(dtype, dtype_role) is None:
             raise ValueError(
-                f"Kernel {kernel_name!r} does not support primary storage dtype={dtype}"
+                f"Kernel {kernel_name!r} does not support storage dtype={dtype} "
+                f"on dtype role(s) {dtype_role}"
             )
 
         platform = current_platform()
@@ -318,6 +323,7 @@ class BenchmarkRunner:
                 kernel,
                 shape,
                 dtype,
+                dtype_role,
             )
             if result is not None:
                 results.append(result)
@@ -329,12 +335,14 @@ class BenchmarkRunner:
         *,
         shapes: list[dict[str, Any]] | None = None,
         dtype: torch.dtype = torch.bfloat16,
+        dtype_role: str | Iterable[str],
     ) -> list[BenchmarkResult]:
         with self._profiling_context(default_output=f"bench_{kernel_name}"):
             return self._benchmark_kernel_impl(
                 kernel_name,
                 shapes=shapes,
                 dtype=dtype,
+                dtype_role=dtype_role,
             )
 
     def _benchmark_op_impl(
@@ -344,6 +352,7 @@ class BenchmarkRunner:
         *,
         shapes: list[dict[str, Any]] | None = None,
         dtype: torch.dtype = torch.bfloat16,
+        dtype_role: str | Iterable[str],
     ) -> list[BenchmarkResult]:
         """Benchmark all implementations of an op."""
         registry = KernelRegistry.get()
@@ -355,13 +364,15 @@ class BenchmarkRunner:
                 op_mode,
                 platform=platform,
             )
-            if spec.format_signature_for_primary_storage_dtype(dtype) is not None
+            if spec.format_signatures_for_storage_dtype(dtype, dtype_role)
         ]
 
         results: list[BenchmarkResult] = []
         for spec in sorted(specs, key=lambda item: (item.solution, item.name)):
             results.extend(
-                self._benchmark_kernel_impl(spec.name, shapes=shapes, dtype=dtype)
+                self._benchmark_kernel_impl(
+                    spec.name, shapes=shapes, dtype=dtype, dtype_role=dtype_role
+                )
             )
         return results
 
@@ -372,6 +383,7 @@ class BenchmarkRunner:
         *,
         shapes: list[dict[str, Any]] | None = None,
         dtype: torch.dtype = torch.bfloat16,
+        dtype_role: str | Iterable[str],
     ) -> list[BenchmarkResult]:
         with self._profiling_context(default_output=f"bench_{op_family}_{op_mode}"):
             return self._benchmark_op_impl(
@@ -379,19 +391,23 @@ class BenchmarkRunner:
                 op_mode,
                 shapes=shapes,
                 dtype=dtype,
+                dtype_role=dtype_role,
             )
 
     def _benchmark_all_impl(
         self,
         *,
         dtype: torch.dtype = torch.bfloat16,
+        dtype_role: str | Iterable[str],
     ) -> list[BenchmarkResult]:
         """Benchmark all registered kernels on this platform."""
         registry = KernelRegistry.get()
         results: list[BenchmarkResult] = []
         for family, mode in sorted(registry.list_operators()):
             try:
-                op_results = self._benchmark_op_impl(family, mode, dtype=dtype)
+                op_results = self._benchmark_op_impl(
+                    family, mode, dtype=dtype, dtype_role=dtype_role
+                )
             except KeyError:
                 continue
             if op_results:
@@ -402,6 +418,7 @@ class BenchmarkRunner:
         self,
         *,
         dtype: torch.dtype = torch.bfloat16,
+        dtype_role: str | Iterable[str],
     ) -> list[BenchmarkResult]:
         with self._profiling_context(default_output="bench_all"):
-            return self._benchmark_all_impl(dtype=dtype)
+            return self._benchmark_all_impl(dtype=dtype, dtype_role=dtype_role)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/numerics/cli.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/numerics/cli.py
@@ -64,6 +64,7 @@ def _iter_candidate_specs(
     kernel_name: str | None,
     op_filter: tuple[str, str] | None,
     dtype_filter: torch.dtype | None,
+    dtype_role: str,
 ) -> list[KernelSpec]:
     if kernel_name is not None:
         spec = registry.get_by_name(kernel_name)
@@ -83,7 +84,7 @@ def _iter_candidate_specs(
         specs = [
             s
             for s in specs
-            if s.format_signature_for_primary_storage_dtype(dtype_filter) is not None
+            if s.format_signatures_for_storage_dtype(dtype_filter, dtype_role)
         ]
 
     specs.sort(key=lambda s: (s.family, s.mode, s.name))
@@ -93,10 +94,11 @@ def _iter_candidate_specs(
 def _iter_dtypes(
     spec: KernelSpec,
     dtype_filter: torch.dtype | None,
+    dtype_role: str,
 ) -> Iterable[torch.dtype]:
     if dtype_filter is not None:
         return (dtype_filter,)
-    return sorted(spec.primary_storage_dtypes(), key=str)
+    return sorted(spec.storage_dtypes_for_role(dtype_role), key=str)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -107,6 +109,11 @@ def main(argv: list[str] | None = None) -> int:
         "--dtype",
         choices=sorted(_DTYPE_SELECTIONS),
         help="Filter by dtype selection",
+    )
+    parser.add_argument(
+        "--dtype-role",
+        required=True,
+        help="Tensor role whose storage dtype is selected by --dtype",
     )
     parser.add_argument(
         "--shapes",
@@ -126,6 +133,7 @@ def main(argv: list[str] | None = None) -> int:
         kernel_name=args.kernel_name,
         op_filter=op_filter,
         dtype_filter=dtype_filter,
+        dtype_role=args.dtype_role,
     )
 
     if not specs:
@@ -136,13 +144,14 @@ def main(argv: list[str] | None = None) -> int:
     failing = False
     ran = False
     for spec in specs:
-        for dtype in _iter_dtypes(spec, dtype_filter):
+        for dtype in _iter_dtypes(spec, dtype_filter, args.dtype_role):
             ran = True
             try:
                 results = verify_kernel(
                     spec.name,
                     shapes=shapes,
                     dtype=dtype,
+                    dtype_role=args.dtype_role,
                     verbose=False,
                 )
             except Exception as exc:

--- a/tokenspeed-kernel/python/tokenspeed_kernel/numerics/verify.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/numerics/verify.py
@@ -20,7 +20,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Iterable
 
 import torch
 from tokenspeed_kernel.numerics.comparison import (
@@ -66,17 +66,6 @@ def _as_tolerance_fn(override: ToleranceOverride | None) -> ToleranceFn | None:
     )
 
 
-def _format_signatures_for_primary_storage_dtype(
-    spec: KernelSpec,
-    dtype: torch.dtype,
-) -> tuple[FormatSignature, ...]:
-    return tuple(
-        signature
-        for signature in sorted(spec.format_signatures, key=str)
-        if signature.primary_storage_dtype() == dtype
-    )
-
-
 def _compatible_reference_for_signature(
     registry: KernelRegistry,
     spec: KernelSpec,
@@ -100,8 +89,9 @@ def _verification_signature_and_reference(
     registry: KernelRegistry,
     spec: KernelSpec,
     dtype: torch.dtype,
+    dtype_role: str | Iterable[str],
 ) -> tuple[FormatSignature | None, KernelSpec | None]:
-    signatures = _format_signatures_for_primary_storage_dtype(spec, dtype)
+    signatures = spec.format_signatures_for_storage_dtype(dtype, dtype_role)
     for signature in signatures:
         ref_spec = _compatible_reference_for_signature(registry, spec, signature)
         if ref_spec is not None:
@@ -114,6 +104,7 @@ def verify_kernel(
     *,
     shapes: list[dict[str, Any]] | None = None,
     dtype: torch.dtype = torch.bfloat16,
+    dtype_role: str | Iterable[str],
     tolerance: ToleranceOverride | None = None,
     verbose: bool = False,
     device: str | None = None,
@@ -130,10 +121,13 @@ def verify_kernel(
     if kernel is None:
         raise ValueError(f"Kernel implementation for {kernel_name!r} is missing")
 
-    signature, ref_spec = _verification_signature_and_reference(registry, spec, dtype)
+    signature, ref_spec = _verification_signature_and_reference(
+        registry, spec, dtype, dtype_role
+    )
     if signature is None:
         raise ValueError(
-            f"Kernel {kernel_name!r} does not support primary storage dtype={dtype}"
+            f"Kernel {kernel_name!r} does not support storage dtype={dtype} "
+            f"on dtype filter role(s) {dtype_role}"
         )
     if ref_spec is None:
         raise ValueError(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/__init__.py
@@ -260,7 +260,7 @@ def mm(
     signature = _gemm_format_signature(
         A, B, A_scales, B_scales, out_dtype, quant, block_size
     )
-    select_dtype = signature.primary_storage_dtype() or A.dtype
+    select_dtype = signature.storage_dtype_for("a") or A.dtype
 
     kernel = select_kernel(
         "gemm",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/registry.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/registry.py
@@ -24,7 +24,7 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import IntEnum
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 if TYPE_CHECKING:
     import torch
@@ -44,6 +44,16 @@ __all__ = [
     "register_kernel",
     "describe_kernel",
 ]
+
+
+def _normalize_roles(roles: str | Iterable[str]) -> tuple[str, ...]:
+    if isinstance(roles, str):
+        role_names = (roles,)
+    else:
+        role_names = tuple(roles)
+    if not role_names:
+        raise ValueError("at least one dtype filter role is required")
+    return role_names
 
 
 # Hard upper bound on priority values; selection scoring clamps to this range.
@@ -162,22 +172,55 @@ class KernelSpec:
     def supports_format_signature(self, format_signature: FormatSignature) -> bool:
         return format_signature in self.format_signatures
 
-    def format_signature_for_primary_storage_dtype(
+    def format_signatures_for_storage_dtype(
         self,
-        primary_storage_dtype: torch.dtype,
-    ) -> FormatSignature | None:
-        """Return the first signature matching a dtype-oriented filter."""
-        for signature in sorted(self.format_signatures, key=str):
-            if signature.primary_storage_dtype() == primary_storage_dtype:
-                return signature
-        return None
+        storage_dtype: torch.dtype,
+        roles: str | Iterable[str],
+    ) -> tuple[FormatSignature, ...]:
+        """Return signatures whose selected role has storage_dtype.
 
-    def primary_storage_dtypes(self) -> frozenset[torch.dtype]:
+        ``roles`` is explicit because the meaningful dtype role is an operator
+        property, not a property of ``FormatSignature`` itself. Multiple roles
+        are treated as alternatives, which is useful for operators whose dtype
+        filter role depends on the concrete signature.
+        """
+        role_names = _normalize_roles(roles)
+        return tuple(
+            signature
+            for signature in sorted(self.format_signatures, key=str)
+            if any(
+                signature.storage_dtype_for(role) == storage_dtype
+                for role in role_names
+            )
+        )
+
+    def format_signature_for_storage_dtype(
+        self,
+        storage_dtype: torch.dtype,
+        roles: str | Iterable[str],
+    ) -> FormatSignature | None:
+        """Return the single matching signature, or raise if ambiguous."""
+        matches = self.format_signatures_for_storage_dtype(storage_dtype, roles)
+        if len(matches) > 1:
+            role_list = ", ".join(_normalize_roles(roles)) or "none"
+            raise ValueError(
+                f"Kernel {self.name!r} has multiple format signatures for "
+                f"storage dtype={storage_dtype} on role(s) {role_list}; "
+                "use a full format signature"
+            )
+        return matches[0] if matches else None
+
+    def storage_dtypes_for_role(
+        self,
+        roles: str | Iterable[str],
+    ) -> frozenset[torch.dtype]:
+        role_names = _normalize_roles(roles)
         return frozenset(
             dtype
             for dtype in (
-                signature.primary_storage_dtype()
+                signature.storage_dtype_for(role)
                 for signature in self.format_signatures
+                for role in role_names
             )
             if dtype is not None
         )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/signature.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/signature.py
@@ -151,27 +151,12 @@ class FormatSignature:
                 return tensor_format
         return None
 
-    def primary_storage_dtype(self) -> torch.dtype | None:
-        """Return the dtype used by dtype-oriented tooling and filters.
-
-        The registry and selection path use the full signature. This helper is
-        only for compatibility with user-facing commands that still ask for a
-        single dtype filter, such as numerics and benchmark CLIs.
-        """
-        preferred_roles = (
-            "q",
-            "a",
-            "x",
-            "input",
-            "logits",
-            "out_a",
-            "hidden",
-        )
-        for role in preferred_roles:
-            tensor_format = self.format_for(role)
-            if tensor_format is not None:
-                return tensor_format.storage_dtype
-        return self.roles[0][1].storage_dtype if self.roles else None
+    def storage_dtype_for(self, role: str) -> torch.dtype | None:
+        """Return the main tensor storage dtype for role, or None if absent."""
+        tensor_format = self.format_for(role)
+        if tensor_format is None:
+            return None
+        return tensor_format.storage_dtype
 
     def __str__(self) -> str:
         return (

--- a/tokenspeed-kernel/test/conftest.py
+++ b/tokenspeed-kernel/test/conftest.py
@@ -45,12 +45,13 @@ from utils import make_sample_specs
 
 
 @pytest.fixture
-def require() -> Callable[[str, str, str, torch.dtype], None]:
+def require() -> Callable[[str, str, str, torch.dtype, str], None]:
     def _require(
         family: str,
         mode: str,
         solution: str,
         dtype: torch.dtype,
+        dtype_role: str,
     ) -> None:
         from tokenspeed_kernel.platform import current_platform
 
@@ -62,7 +63,7 @@ def require() -> Callable[[str, str, str, torch.dtype], None]:
                 platform=current_platform(),
                 solution=solution,
             )
-            if spec.format_signature_for_primary_storage_dtype(dtype) is not None
+            if spec.format_signatures_for_storage_dtype(dtype, dtype_role)
         ]
         if not specs:
             pytest.skip(f"{family}.{mode} solution {solution!r} is not registered")

--- a/tokenspeed-kernel/test/ops/test_embedding.py
+++ b/tokenspeed-kernel/test/ops/test_embedding.py
@@ -39,7 +39,7 @@ def test_rope_neox_full_bf16(
     rotary_dim = 128
     max_position = 1024
     dtype = torch.bfloat16
-    require("embedding", "rope", solution, dtype)
+    require("embedding", "rope", solution, dtype, "query")
 
     inv_freq = 1.0 / (
         10000.0
@@ -106,7 +106,7 @@ def test_rope_gptj_full_bf16(
     rotary_dim = 64
     max_position = 512
     dtype = torch.bfloat16
-    require("embedding", "rope", solution, dtype)
+    require("embedding", "rope", solution, dtype, "query")
 
     inv_freq = 1.0 / (
         10000.0
@@ -173,7 +173,7 @@ def test_rope_neox_partial_bf16(
     rotary_dim = 64
     max_position = 256
     dtype = torch.bfloat16
-    require("embedding", "rope", solution, dtype)
+    require("embedding", "rope", solution, dtype, "query")
 
     inv_freq = 1.0 / (
         10000.0
@@ -251,7 +251,7 @@ def test_rope_single_token(
     rotary_dim = 128
     max_position = 64
     dtype = torch.bfloat16
-    require("embedding", "rope", solution, dtype)
+    require("embedding", "rope", solution, dtype, "query")
 
     inv_freq = 1.0 / (
         10000.0
@@ -312,7 +312,7 @@ def test_rope_fused_set_kv_buffer(
     max_position = 512
     cache_size = 32
     dtype = torch.bfloat16
-    require("embedding", "rope", solution, dtype)
+    require("embedding", "rope", solution, dtype, "query")
 
     inv_freq = 1.0 / (
         10000.0

--- a/tokenspeed-kernel/test/ops/test_quantization.py
+++ b/tokenspeed-kernel/test/ops/test_quantization.py
@@ -55,7 +55,7 @@ def test_quantize_fp8_pure_cast_bf16(
 ) -> None:
     torch.manual_seed(0)
     dtype = torch.bfloat16
-    require("quantization", "fp8", solution, dtype)
+    require("quantization", "fp8", solution, dtype, "x")
 
     x = torch.randn(shape, device=device, dtype=dtype) * 50
     fp8 = current_platform().fp8e4m3fn
@@ -77,7 +77,7 @@ def test_quantize_fp8_strided_slice(
 ) -> None:
     torch.manual_seed(1)
     dtype = torch.bfloat16
-    require("quantization", "fp8", solution, dtype)
+    require("quantization", "fp8", solution, dtype, "x")
 
     s, h, qk_nope, v_head = 4096, 16, 128, 128
     kv = torch.randn(s, h, qk_nope + v_head, device=device, dtype=dtype) * 50
@@ -103,7 +103,7 @@ def test_quantize_fp8_scale_float(
 ) -> None:
     torch.manual_seed(2)
     dtype = torch.bfloat16
-    require("quantization", "fp8", solution, dtype)
+    require("quantization", "fp8", solution, dtype, "x")
 
     x = torch.randn(2048, 512, device=device, dtype=dtype) * 100
     fp8 = current_platform().fp8e4m3fn
@@ -126,7 +126,7 @@ def test_quantize_fp8_scale_tensor(
 ) -> None:
     torch.manual_seed(3)
     dtype = torch.bfloat16
-    require("quantization", "fp8", solution, dtype)
+    require("quantization", "fp8", solution, dtype, "x")
 
     x = torch.randn(8, 2880, device=device, dtype=dtype) * 100
     scale = torch.tensor([0.125], device=device, dtype=torch.float32)
@@ -152,7 +152,7 @@ def test_quantize_fp8_with_scale_tensor_and_token(
 ) -> None:
     torch.manual_seed(4)
     dtype = torch.bfloat16
-    require("quantization", "fp8_with_scale", solution, dtype)
+    require("quantization", "fp8_with_scale", solution, dtype, "x")
 
     x = torch.randn(16, 128, device=device, dtype=dtype) * 10
     fp8 = current_platform().fp8e4m3fn
@@ -181,7 +181,7 @@ def test_quantize_fp8_with_scale_token_group(
 ) -> None:
     torch.manual_seed(5)
     dtype = torch.bfloat16
-    require("quantization", "fp8_with_scale", solution, dtype)
+    require("quantization", "fp8_with_scale", solution, dtype, "x")
 
     x = torch.randn(16, 256, device=device, dtype=dtype) * 10
     fp8 = current_platform().fp8e4m3fn
@@ -208,7 +208,7 @@ def test_quantize_mxfp8_shape_and_scale(
 ) -> None:
     torch.manual_seed(6)
     dtype = torch.bfloat16
-    require("quantization", "mxfp8", solution, dtype)
+    require("quantization", "mxfp8", solution, dtype, "x")
 
     x = torch.randn(17, 2880, device=device, dtype=dtype)
     out, scale = quantize_mxfp8(x, solution=solution)
@@ -227,7 +227,7 @@ def test_quantize_nvfp4_shape_and_scale(
 ) -> None:
     torch.manual_seed(7)
     dtype = torch.bfloat16
-    require("quantization", "nvfp4", solution, dtype)
+    require("quantization", "nvfp4", solution, dtype, "x")
 
     x = torch.randn(16, 256, device=device, dtype=dtype)
     out, scale = quantize_nvfp4(

--- a/tokenspeed-kernel/test/test_benchmark.py
+++ b/tokenspeed-kernel/test/test_benchmark.py
@@ -105,6 +105,7 @@ def test_benchmark_kernel_returns_result(setup_gemm_case):
         "test_gemm_fast",
         shapes=_TEST_SHAPES,
         dtype=torch.float32,
+        dtype_role="a",
     )
 
     assert len(results) == 1
@@ -129,6 +130,7 @@ def test_benchmark_kernel_supports_cpu_wall_time(setup_gemm_case):
         "test_gemm_fast",
         shapes=_TEST_SHAPES,
         dtype=torch.float32,
+        dtype_role="a",
     )
 
     assert len(results) == 1
@@ -151,6 +153,7 @@ def test_benchmark_kernel_can_disable_verification(setup_gemm_case):
         "test_gemm_fast",
         shapes=_TEST_SHAPES,
         dtype=torch.float32,
+        dtype_role="a",
     )
 
     assert len(results) == 1
@@ -172,6 +175,7 @@ def test_benchmark_op_includes_reference(setup_gemm_case):
         "mm",
         shapes=_TEST_SHAPES,
         dtype=torch.float32,
+        dtype_role="a",
     )
 
     names = {result.kernel_name for result in results}
@@ -190,6 +194,7 @@ def test_report_format_contains_expected_columns(setup_gemm_case):
         "mm",
         shapes=_TEST_SHAPES,
         dtype=torch.float32,
+        dtype_role="a",
     )
     report = format_report(results)
 
@@ -212,6 +217,7 @@ def test_export_import_roundtrip(tmp_path, setup_gemm_case):
         "mm",
         shapes=_TEST_SHAPES,
         dtype=torch.float32,
+        dtype_role="a",
     )
 
     export_path = tmp_path / "bench_results.json"
@@ -329,6 +335,7 @@ def test_benchmark_kernel_uses_profiling_context_when_enabled(
         "test_gemm_fast",
         shapes=_TEST_SHAPES,
         dtype=torch.float32,
+        dtype_role="a",
     )
 
     assert len(results) == 1
@@ -370,6 +377,7 @@ def test_benchmark_op_profiles_once_when_enabled(setup_gemm_case, monkeypatch):
         "mm",
         shapes=_TEST_SHAPES,
         dtype=torch.float32,
+        dtype_role="a",
     )
 
     assert {result.kernel_name for result in results} == {
@@ -419,6 +427,7 @@ def test_benchmark_kernel_uses_explicit_proton_config(setup_gemm_case, monkeypat
         "test_gemm_fast",
         shapes=_TEST_SHAPES,
         dtype=torch.float32,
+        dtype_role="a",
     )
 
     assert len(configs) == 1
@@ -450,7 +459,7 @@ def test_benchmark_cli_proton_flag_sets_profile_mode(monkeypatch):
     monkeypatch.setattr(benchmark_cli, "load_builtin_kernels", lambda: None)
     monkeypatch.setattr(benchmark_cli, "format_report", lambda _results: "ok")
 
-    rc = benchmark_cli.main(["--op", "gemm.mm", "--proton"])
+    rc = benchmark_cli.main(["--op", "gemm.mm", "--dtype-role", "a", "--proton"])
 
     assert rc == 0
     assert _FakeRunner.last_config is not None
@@ -488,6 +497,8 @@ def test_benchmark_cli_builds_proton_config_from_flags(monkeypatch):
         [
             "--op",
             "gemm.mm",
+            "--dtype-role",
+            "a",
             "--proton-output",
             "bench_cli",
             "--proton-data",

--- a/tokenspeed-kernel/test/test_numerics.py
+++ b/tokenspeed-kernel/test/test_numerics.py
@@ -153,7 +153,7 @@ def test_verification_uses_signature_with_compatible_reference(fresh_registry) -
     registry.register(test_spec, lambda **_kwargs: None)
 
     signature, reference = _verification_signature_and_reference(
-        registry, test_spec, _fp8_dtype
+        registry, test_spec, _fp8_dtype, "a"
     )
 
     assert signature == tensor_signature
@@ -162,7 +162,7 @@ def test_verification_uses_signature_with_compatible_reference(fresh_registry) -
 
 class TestNumericsVerification:
     def _get_verifiable_specs(
-        dtype: torch.dtype, family: str | None = None
+        dtype: torch.dtype, dtype_role: str, family: str | None = None
     ) -> list[KernelSpec]:
         load_builtin_kernels()
         registry = KernelRegistry.get()
@@ -177,7 +177,7 @@ class TestNumericsVerification:
             dtype_specs = [
                 s
                 for s in op_specs
-                if s.format_signature_for_primary_storage_dtype(dtype) is not None
+                if s.format_signatures_for_storage_dtype(dtype, dtype_role)
             ]
             has_reference = any(s.solution == "reference" for s in dtype_specs)
             if not has_reference:
@@ -193,12 +193,14 @@ class TestNumericsVerification:
         specs.sort(key=lambda s: (s.family, s.mode, s.name))
         return specs
 
-    def _verify(self, spec: KernelSpec, dtype: torch.dtype) -> None:
+    def _verify(self, spec: KernelSpec, dtype: torch.dtype, dtype_role: str) -> None:
         if not torch.cuda.is_available():
             pytest.skip("CUDA is required for numerics verification")
 
         try:
-            results = verify_kernel(spec.name, dtype=dtype, verbose=False)
+            results = verify_kernel(
+                spec.name, dtype=dtype, dtype_role=dtype_role, verbose=False
+            )
         except Exception as exc:
             pytest.fail(
                 f"Kernel {spec.name} raised an exception during verification: {exc}"
@@ -213,32 +215,32 @@ class TestNumericsVerification:
 
     @pytest.mark.parametrize(
         "spec",
-        _get_verifiable_specs(_fp8_dtype, family="gemm"),
+        _get_verifiable_specs(_fp8_dtype, "a", family="gemm"),
         ids=lambda s: f"{s.family}.{s.mode}:{s.name}",
     )
     def test_gemm_fp8(self, spec: KernelSpec):
-        self._verify(spec, _fp8_dtype)
+        self._verify(spec, _fp8_dtype, "a")
 
     @pytest.mark.parametrize(
         "spec",
-        _get_verifiable_specs(torch.bfloat16, family="gemm"),
+        _get_verifiable_specs(torch.bfloat16, "a", family="gemm"),
         ids=lambda s: f"{s.family}.{s.mode}:{s.name}",
     )
     def test_gemm_bf16(self, spec: KernelSpec):
-        self._verify(spec, torch.bfloat16)
+        self._verify(spec, torch.bfloat16, "a")
 
     @pytest.mark.parametrize(
         "spec",
-        _get_verifiable_specs(torch.bfloat16, family="quantize"),
+        _get_verifiable_specs(torch.bfloat16, "x", family="quantize"),
         ids=lambda s: f"{s.family}.{s.mode}:{s.name}",
     )
     def test_quantize_bf16(self, spec: KernelSpec):
-        self._verify(spec, torch.bfloat16)
+        self._verify(spec, torch.bfloat16, "x")
 
     @pytest.mark.parametrize(
         "spec",
-        _get_verifiable_specs(torch.int32, family="moe"),
+        _get_verifiable_specs(torch.int32, "indices", family="moe"),
         ids=lambda s: f"{s.family}.{s.mode}:{s.name}",
     )
     def test_moe_int32(self, spec: KernelSpec):
-        self._verify(spec, torch.int32)
+        self._verify(spec, torch.int32, "indices")

--- a/tokenspeed-kernel/test/test_registry.py
+++ b/tokenspeed-kernel/test/test_registry.py
@@ -121,6 +121,54 @@ class TestKernelSpec:
         with pytest.raises(ValueError, match="requires scale"):
             tensor_format("scaled-fp8", torch.float8_e4m3fn)
 
+    def test_format_signature_storage_dtype_for_role(self):
+        signature = format_signature(
+            a=dense_tensor_format(torch.bfloat16),
+            b=dense_tensor_format(torch.float16),
+        )
+
+        assert signature.storage_dtype_for("a") == torch.bfloat16
+        assert signature.storage_dtype_for("b") == torch.float16
+        assert signature.storage_dtype_for("missing") is None
+
+    def test_format_signatures_for_storage_dtype_uses_explicit_roles(self):
+        mxfp4_scale = ScaleFormat(
+            storage_dtype=torch.uint8,
+            granularity="block",
+            block_shape=(32,),
+        )
+        nvfp4_scale = ScaleFormat(
+            storage_dtype=torch.float32,
+            granularity="block",
+            dynamic_block_shape=True,
+        )
+        bf16_mxfp4 = format_signature(
+            x=dense_tensor_format(torch.bfloat16),
+            weight=tensor_format("mxfp4", torch.uint8, scale=mxfp4_scale),
+        )
+        bf16_nvfp4 = format_signature(
+            x=dense_tensor_format(torch.bfloat16),
+            weight=tensor_format("nvfp4", torch.uint8, scale=nvfp4_scale),
+        )
+        fp16_mxfp4 = format_signature(
+            x=dense_tensor_format(torch.float16),
+            weight=tensor_format("mxfp4", torch.uint8, scale=mxfp4_scale),
+        )
+        spec = KernelSpec(
+            name="moe_fused",
+            family="moe",
+            mode="fused",
+            format_signatures=frozenset({bf16_mxfp4, bf16_nvfp4, fp16_mxfp4}),
+        )
+
+        matches = spec.format_signatures_for_storage_dtype(torch.bfloat16, "x")
+
+        assert set(matches) == {bf16_mxfp4, bf16_nvfp4}
+        assert spec.storage_dtypes_for_role("x") == {torch.bfloat16, torch.float16}
+        assert spec.format_signature_for_storage_dtype(torch.float16, "x") == fp16_mxfp4
+        with pytest.raises(ValueError, match="multiple format signatures"):
+            spec.format_signature_for_storage_dtype(torch.bfloat16, "x")
+
     def test_equality(self):
         spec1 = KernelSpec(name="k1", family="attention", mode="decode")
         spec2 = KernelSpec(name="k1", family="attention", mode="decode")

--- a/tokenspeed-kernel/test/test_runtime_callsite_selection.py
+++ b/tokenspeed-kernel/test/test_runtime_callsite_selection.py
@@ -302,10 +302,32 @@ _DTYPE_PREFERENCE = [
 ]
 
 
+def _all_storage_dtypes(spec) -> frozenset[torch.dtype]:
+    return frozenset(
+        tensor_format.storage_dtype
+        for signature in spec.format_signatures
+        for _role, tensor_format in signature.roles
+    )
+
+
+def _format_signature_for_any_role(spec, dtype: torch.dtype) -> FormatSignature | None:
+    matches = tuple(
+        signature
+        for signature in sorted(spec.format_signatures, key=str)
+        if any(
+            tensor_format.storage_dtype == dtype
+            for _role, tensor_format in signature.roles
+        )
+    )
+    if len(matches) > 1:
+        pytest.skip(f"Kernel {spec.name!r} has multiple signatures for {dtype}")
+    return matches[0] if matches else None
+
+
 def _infer_dtype(expected_name: str) -> torch.dtype:
     spec = KernelRegistry.get().get_by_name(expected_name)
     if spec is not None:
-        storage_dtypes = spec.primary_storage_dtypes()
+        storage_dtypes = _all_storage_dtypes(spec)
         for dt in _DTYPE_PREFERENCE:
             if dt in storage_dtypes:
                 return dt
@@ -323,7 +345,7 @@ def _infer_format_signature(
 ) -> FormatSignature:
     if family == "moe" and mode == "fused":
         return _moe_pkg._moe_fused_format_signature(dtype, weight_format or "bf16")
-    signature = spec.format_signature_for_primary_storage_dtype(dtype)
+    signature = _format_signature_for_any_role(spec, dtype)
     if signature is None:
         pytest.skip(f"Kernel {spec.name!r} has no signature for {dtype}")
     return signature

--- a/tokenspeed-kernel/test/thirdparty/test_fa4.py
+++ b/tokenspeed-kernel/test/thirdparty/test_fa4.py
@@ -383,7 +383,7 @@ def test_fa4_prefill_selection_accepts_head_dim_256() -> None:
     assert spec.solution == "fa4"
     assert 256 in spec.traits["head_dim"]
 
-    signature = spec.format_signature_for_primary_storage_dtype(torch.bfloat16)
+    signature = spec.format_signature_for_storage_dtype(torch.bfloat16, "q")
     assert signature is not None
 
     selected = select_kernel(


### PR DESCRIPTION
After making various op's format signature explicit in order
to support mixed precision and different format types, we
need to update various cli tools to avoid anchoring on an
explicit primary dtype; rather we need to make the dtype-role
filtering explicit.

Remove the registry-level primary storage dtype heuristic and
require dtype-oriented callers to pass the operand role they
mean to filter on.

Add role-aware storage dtype helpers for format signatures,
wire benchmark and numerics tooling through explicit dtype_role
arguments, and update tests to cover mixed signatures and
ambiguous role matches.