### PR TITLE
feat (L3 KVStore): prefetch and backup support

### DIFF
--- a/python/tokenspeed/runtime/engine/scheduler_utils.py
+++ b/python/tokenspeed/runtime/engine/scheduler_utils.py
@@ -40,6 +40,7 @@ from tokenspeed_scheduler import (
 _CACHE_EVENT_TYPES = {
     "WriteBackDoneEvent": Cache.WriteBackDoneEvent,
     "PrefetchDoneEvent": Cache.PrefetchDoneEvent,
+    "BackUpDoneEvent": Cache.BackUpDoneEvent,
 }
 _TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
 

--- a/python/tokenspeed/runtime/engine/scheduler_utils.py
+++ b/python/tokenspeed/runtime/engine/scheduler_utils.py
@@ -195,12 +195,15 @@ def cache_event_to_payload(event) -> dict:
     kind = type(event).__name__
     if kind not in _CACHE_EVENT_TYPES:
         raise ValueError(f"Unsupported cache event type: {kind}")
-    return {
+    payload = {
         "kind": kind,
         "op_id": int(event.op_id),
         "success": bool(event.success),
         "request_id": getattr(event, "request_id", ""),
     }
+    if hasattr(event, "completed_pages"):
+        payload["completed_pages"] = int(event.completed_pages)
+    return payload
 
 
 def cache_event_from_payload(payload: dict):
@@ -213,6 +216,8 @@ def cache_event_from_payload(payload: dict):
     request_id = payload.get("request_id", "")
     if request_id:
         event.request_id = request_id
+    if "completed_pages" in payload and hasattr(event, "completed_pages"):
+        event.completed_pages = int(payload["completed_pages"])
     return event
 
 

--- a/tokenspeed-scheduler/bindings/python_module.cpp
+++ b/tokenspeed-scheduler/bindings/python_module.cpp
@@ -287,6 +287,11 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .def_rw("op_id", &tokenspeed::cache::WriteBackDone::op_id)
         .def_rw("success", &tokenspeed::cache::WriteBackDone::success);
 
+    nb::class_<tokenspeed::cache::BackUpDone>(cache, "BackUpDoneEvent")
+        .def(nb::init<>())
+        .def_rw("op_id", &tokenspeed::cache::BackUpDone::op_id)
+        .def_rw("success", &tokenspeed::cache::BackUpDone::success);
+
     nb::class_<tokenspeed::pd::BootstrappedEvent>(pd, "BootstrappedEvent")
         .def(nb::init<std::string>(), nb::arg("request_id"))
         .def_ro("request_id", &tokenspeed::pd::BootstrappedEvent::request_id);

--- a/tokenspeed-scheduler/csrc/fsm/cache_events.cpp
+++ b/tokenspeed-scheduler/csrc/fsm/cache_events.cpp
@@ -34,7 +34,7 @@ namespace tokenspeed::fsm {
 
 State SchedulePrefetchEvent::operator()(Submitted&& state) {
     return Prefetching{state.GetTokenContainer(), state.GetPageSize(), host_allocator_->Allocate(num_pages_to_fetch_),
-                       std::move(host_node_ref_)};
+                       std::move(host_node_ref_), prefetch_start_page_};
 }
 
 State PrefetchDoneEvent::operator()(Prefetching&& state) {

--- a/tokenspeed-scheduler/csrc/fsm/cache_events.cpp
+++ b/tokenspeed-scheduler/csrc/fsm/cache_events.cpp
@@ -34,7 +34,7 @@ namespace tokenspeed::fsm {
 
 State SchedulePrefetchEvent::operator()(Submitted&& state) {
     return Prefetching{state.GetTokenContainer(), state.GetPageSize(), host_allocator_->Allocate(num_pages_to_fetch_),
-                       std::make_unique<HostNodeRef>(host_match_node_)};
+                       std::move(host_node_ref_)};
 }
 
 State PrefetchDoneEvent::operator()(Prefetching&& state) {

--- a/tokenspeed-scheduler/csrc/fsm/cache_events.h
+++ b/tokenspeed-scheduler/csrc/fsm/cache_events.h
@@ -43,9 +43,11 @@ struct SchedulePrefetchEvent : InvalidTransitionHandler<SchedulePrefetchEvent> {
     using InvalidTransitionHandler<SchedulePrefetchEvent>::operator();
 
     SchedulePrefetchEvent() = default;
-    SchedulePrefetchEvent(std::int32_t num_pages_to_fetch, std::vector<std::string> rolling_page_hashes,
-                          PageAllocator* host_allocator, std::unique_ptr<HostNodeRef> host_node_ref)
+    SchedulePrefetchEvent(std::int32_t num_pages_to_fetch, std::int32_t prefetch_start_page,
+                          std::vector<std::string> rolling_page_hashes, PageAllocator* host_allocator,
+                          std::unique_ptr<HostNodeRef> host_node_ref)
         : num_pages_to_fetch_{num_pages_to_fetch},
+          prefetch_start_page_{prefetch_start_page},
           rolling_page_hashes_{std::move(rolling_page_hashes)},
           host_allocator_{host_allocator},
           host_node_ref_{std::move(host_node_ref)} {}
@@ -56,6 +58,7 @@ struct SchedulePrefetchEvent : InvalidTransitionHandler<SchedulePrefetchEvent> {
 
 private:
     std::int32_t num_pages_to_fetch_{};
+    std::int32_t prefetch_start_page_{};
     PageAllocator* host_allocator_{};
     std::unique_ptr<HostNodeRef> host_node_ref_;
     std::vector<std::string> rolling_page_hashes_;

--- a/tokenspeed-scheduler/csrc/fsm/cache_events.h
+++ b/tokenspeed-scheduler/csrc/fsm/cache_events.h
@@ -21,18 +21,18 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "fsm/base_event.h"
 #include "fsm/states.h"
+#include "resource/radix_tree/tree_node.h"
 
 namespace tokenspeed {
 
 class PageAllocator;
-class TreeNode;
-
 namespace fsm {
 
 struct Aborting;
@@ -44,11 +44,11 @@ struct SchedulePrefetchEvent : InvalidTransitionHandler<SchedulePrefetchEvent> {
 
     SchedulePrefetchEvent() = default;
     SchedulePrefetchEvent(std::int32_t num_pages_to_fetch, std::vector<std::string> rolling_page_hashes,
-                          PageAllocator* host_allocator, TreeNode* host_match_node)
+                          PageAllocator* host_allocator, std::unique_ptr<HostNodeRef> host_node_ref)
         : num_pages_to_fetch_{num_pages_to_fetch},
           rolling_page_hashes_{std::move(rolling_page_hashes)},
           host_allocator_{host_allocator},
-          host_match_node_{host_match_node} {}
+          host_node_ref_{std::move(host_node_ref)} {}
 
     State operator()(Submitted&& state);
 
@@ -57,7 +57,7 @@ struct SchedulePrefetchEvent : InvalidTransitionHandler<SchedulePrefetchEvent> {
 private:
     std::int32_t num_pages_to_fetch_{};
     PageAllocator* host_allocator_{};
-    TreeNode* host_match_node_{};
+    std::unique_ptr<HostNodeRef> host_node_ref_;
     std::vector<std::string> rolling_page_hashes_;
 };
 

--- a/tokenspeed-scheduler/csrc/fsm/cache_states.h
+++ b/tokenspeed-scheduler/csrc/fsm/cache_states.h
@@ -32,11 +32,12 @@ namespace tokenspeed::fsm {
 
 struct Prefetching {
     Prefetching(TokenContainer* token_container, std::int32_t page_size, OwnedPages host_pages,
-                std::unique_ptr<HostNodeRef>&& host_lock)
+                std::unique_ptr<HostNodeRef>&& host_lock, std::int32_t prefetch_start_page)
         : token_container_{token_container},
           page_size_{page_size},
           host_pages_{std::move(host_pages)},
-          host_lock_{std::move(host_lock)} {}
+          host_lock_{std::move(host_lock)},
+          prefetch_start_page_{prefetch_start_page} {}
 
     ~Prefetching() = default;
 
@@ -53,12 +54,14 @@ struct Prefetching {
     OwnedPages TakeHostPages() && { return std::move(host_pages_); }
 
     TreeNode* GetHostLockNode() const { return host_lock_ ? host_lock_->Node() : nullptr; }
+    std::int32_t GetPrefetchStartPage() const { return prefetch_start_page_; }
 
 private:
     TokenContainer* token_container_{};
     std::int32_t page_size_{};
     OwnedPages host_pages_;
     std::unique_ptr<HostNodeRef> host_lock_;
+    std::int32_t prefetch_start_page_{};
 };
 
 struct PrefetchDone {

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
@@ -133,8 +133,9 @@ void InsertHybridCache(HybridPrefixCache* hybrid_cache,
     device_node_ref = std::make_unique<DeviceNodeRef>(insert_result.last_node);
 }
 
-// Submitted -> PrefillDone / Prefilling
-std::variant<PrefillDone, Prefilling> SchedulePrefillFirstChunkEvent::operator()(Submitted&& state) {
+// Submitted / PrefetchDone -> PrefillDone / Prefilling
+template <typename StateT>
+std::variant<PrefillDone, Prefilling> SchedulePrefillFirstChunkEvent::applyFirstChunk(StateT&& state) {
     // Lock node
     std::unique_ptr<HostNodeRef> host_node_ref{nullptr};
     std::unique_ptr<DeviceNodeRef> device_node_ref{nullptr};
@@ -198,6 +199,14 @@ std::variant<PrefillDone, Prefilling> SchedulePrefillFirstChunkEvent::operator()
                           window,
                           std::move(local_mamba_allocator)};
     }
+}
+
+std::variant<PrefillDone, Prefilling> SchedulePrefillFirstChunkEvent::operator()(Submitted&& state) {
+    return applyFirstChunk(std::move(state));
+}
+
+std::variant<PrefillDone, Prefilling> SchedulePrefillFirstChunkEvent::operator()(PrefetchDone&& state) {
+    return applyFirstChunk(std::move(state));
 }
 
 // Prefilling -> Prefilling / PrefillDone

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.h
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.h
@@ -82,6 +82,7 @@ struct SchedulePrefillFirstChunkEvent : InvalidTransitionHandler<SchedulePrefill
 
     // Returns PrefillDone (single-chunk or last chunk) or Prefilling (more chunks remain).
     std::variant<PrefillDone, Prefilling> operator()(Submitted&& state);
+    std::variant<PrefillDone, Prefilling> operator()(PrefetchDone&& state);
 
     const MatchResult GetMatchResult() const { return match_result_; }
 
@@ -89,6 +90,9 @@ struct SchedulePrefillFirstChunkEvent : InvalidTransitionHandler<SchedulePrefill
     const std::vector<TreeNode*>& GetMambaLoadbackNodes() const { return mamba_loadback_nodes_; }
 
 private:
+    template <typename StateT>
+    std::variant<PrefillDone, Prefilling> applyFirstChunk(StateT&& state);
+
     std::int32_t tokens_this_round_{};
     std::int32_t decode_input_tokens_{};
     PageAllocator* device_allocator_{};

--- a/tokenspeed-scheduler/csrc/fsm/forward_states.h
+++ b/tokenspeed-scheduler/csrc/fsm/forward_states.h
@@ -297,6 +297,8 @@ public:
     // Transfer pairs that must be copied Device→Host.
     const std::vector<PagePair>& GetPagesToTransfer() const { return pages_to_transfer_; }
 
+    TreeNode* HostNode() const { return host_node_ref_ ? host_node_ref_->Node() : nullptr; }
+
     std::unique_ptr<DeviceNodeRef> TakeDeviceNodeRef() && { return std::move(device_node_ref_); }
     std::unique_ptr<HostNodeRef> TakeHostNodeRef() && { return std::move(host_node_ref_); }
     std::vector<TreeNode*> TakeMambaWriteBackNodes() && { return std::move(mamba_writeback_nodes_); }

--- a/tokenspeed-scheduler/csrc/resource/types.h
+++ b/tokenspeed-scheduler/csrc/resource/types.h
@@ -110,6 +110,9 @@ struct CacheOpSpec {
     std::string request_id;
     TreeNode* last_node{nullptr};
     std::vector<TreeNode*> nodes;
+    // L3 backup: captured at WriteBackOp creation, consumed at WriteBackDone to emit BackUpOp.
+    std::vector<std::int32_t> backup_host_pages;
+    std::vector<std::string> backup_rolling_hashes;
 
     CacheOpSpec();
     ~CacheOpSpec();

--- a/tokenspeed-scheduler/csrc/resource/types.h
+++ b/tokenspeed-scheduler/csrc/resource/types.h
@@ -113,6 +113,7 @@ struct CacheOpSpec {
     // L3 backup: captured at WriteBackOp creation, consumed at WriteBackDone to emit BackUpOp.
     std::vector<std::int32_t> backup_host_pages;
     std::vector<std::string> backup_rolling_hashes;
+    TreeNode* backup_host_node{nullptr};
 
     CacheOpSpec();
     ~CacheOpSpec();

--- a/tokenspeed-scheduler/csrc/scheduler/operations/cache.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/cache.cpp
@@ -30,6 +30,7 @@
 #include "fsm/cache_events.h"
 #include "fsm/forward_states.h"
 #include "resource/kv_prefix_cache/kv_prefix_cache.h"
+#include "resource/radix_tree/tree_node.h"
 #include "resource/types.h"
 #include "scheduler/request.h"
 #include "scheduler/request_spec.h"
@@ -46,6 +47,10 @@ std::optional<fsm::SchedulePrefetchEvent> Scheduler::schedulePrefetch(Request* r
     }
 
     const std::int32_t num_pages_to_fetch = storage.hit_pages;
+
+    // Lock the matched host node BEFORE eviction so it cannot be evicted.
+    auto host_node_ref = std::make_unique<HostNodeRef>(match.host.last_node);
+
     if (!kv_prefix_cache_.EnsureCapacityByEvict<ResourceType::Host>(num_pages_to_fetch)) {
         return {};
     }
@@ -53,7 +58,7 @@ std::optional<fsm::SchedulePrefetchEvent> Scheduler::schedulePrefetch(Request* r
     std::vector<std::string> hashes(storage.rolling_hashes.begin(),
                                     storage.rolling_hashes.begin() + num_pages_to_fetch);
 
-    return fsm::SchedulePrefetchEvent{num_pages_to_fetch, std::move(hashes), &host_allocator_, match.host.last_node};
+    return fsm::SchedulePrefetchEvent{num_pages_to_fetch, std::move(hashes), &host_allocator_, std::move(host_node_ref)};
 }
 
 PrefetchOperation Scheduler::applyEventAndGenerateOp(Request* request, fsm::SchedulePrefetchEvent event) {

--- a/tokenspeed-scheduler/csrc/scheduler/operations/cache.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/cache.cpp
@@ -47,6 +47,10 @@ std::optional<fsm::SchedulePrefetchEvent> Scheduler::schedulePrefetch(Request* r
     }
 
     const std::int32_t num_pages_to_fetch = storage.hit_pages;
+    if (static_cast<std::int32_t>(storage.rolling_hashes.size()) < num_pages_to_fetch) {
+        return {};
+    }
+    const std::int32_t prefetch_start_page = match.host.DepthInPage();
 
     // Lock the matched host node BEFORE eviction so it cannot be evicted.
     auto host_node_ref = std::make_unique<HostNodeRef>(match.host.last_node);
@@ -58,7 +62,8 @@ std::optional<fsm::SchedulePrefetchEvent> Scheduler::schedulePrefetch(Request* r
     std::vector<std::string> hashes(storage.rolling_hashes.begin(),
                                     storage.rolling_hashes.begin() + num_pages_to_fetch);
 
-    return fsm::SchedulePrefetchEvent{num_pages_to_fetch, std::move(hashes), &host_allocator_, std::move(host_node_ref)};
+    return fsm::SchedulePrefetchEvent{num_pages_to_fetch, prefetch_start_page, std::move(hashes), &host_allocator_,
+                                      std::move(host_node_ref)};
 }
 
 PrefetchOperation Scheduler::applyEventAndGenerateOp(Request* request, fsm::SchedulePrefetchEvent event) {

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -550,7 +550,7 @@ std::tuple<std::vector<ForwardOperation>, std::variant<std::vector<LoadBackOpera
 Scheduler::newForwardOperation(std::vector<Request*> candidates) {
     auto priority = [&](const Request* req) -> int {
         if (req->Is<fsm::Prefilling>()) return 1;
-        if (req->Is<fsm::Submitted>()) return 2;
+        if (req->Is<fsm::Submitted>() || req->Is<fsm::PrefetchDone>()) return 2;
         if (req->Is<fsm::Decoding>() || req->Is<fsm::PrefillDone>()) {
             // Decode-first if mixed-batch is enabled; prefill-first otherwise.
             return config_.enable_mixed_prefill_decode ? 0 : 3;
@@ -594,18 +594,30 @@ Scheduler::newForwardOperation(std::vector<Request*> candidates) {
                 push_op(applyEventAndGenerateOp(request, *ev));
             }
         } else if (request->Is<fsm::Submitted>() || request->Is<fsm::PrefetchDone>()) {
-            // PrefetchDone: host cache populated; treat same as Submitted for forward scheduling.
-            std::int32_t decode_input_tokens = config_.role == Role::kP ? 0 : config_.decode_input_tokens;
-
-            if (auto ev = schedulePrefillFirstChunk(request, token_budget, decode_input_tokens,
-                                                    config_.disable_l2_cache, simulated_free)) {
-                std::vector<TreeNode*> loadback_diff = ev->GetLoadbackDiff();
-                std::vector<TreeNode*> mamba_loadback_nodes = ev->GetMambaLoadbackNodes();
-                push_op(applyEventAndGenerateOp(request, std::move(*ev)), true);
-                // will be empty when disable_l2_cache
-                if (!loadback_diff.empty() || !mamba_loadback_nodes.empty()) {
-                    cache_op_id op_id = kv_prefix_cache_.AllocateCacheOpId();
-                    loadback_ops.push_back(GenerateLoadBackOp(loadback_diff, mamba_loadback_nodes, op_id));
+            // L3 prefetch path: for Submitted requests with enough L3 hits,
+            // start an async L3→Host transfer before entering prefill.
+            bool prefetch_scheduled = false;
+            if (request->Is<fsm::Submitted>()) {
+                auto token_pages = request->GetFullPagedTokens(true);
+                MatchResult match = hybrid_prefix_cache_ ? hybrid_prefix_cache_->Match(token_pages)
+                                                         : kv_prefix_cache_.Match(token_pages);
+                if (auto prefetch_ev = schedulePrefetch(request, match)) {
+                    pending_prefetch_ops_.push_back(applyEventAndGenerateOp(request, std::move(*prefetch_ev)));
+                    prefetch_scheduled = true;
+                }
+            }
+            // PrefetchDone or Submitted without L3 hit: proceed to prefill.
+            if (!prefetch_scheduled) {
+                std::int32_t decode_input_tokens = config_.role == Role::kP ? 0 : config_.decode_input_tokens;
+                if (auto ev = schedulePrefillFirstChunk(request, token_budget, decode_input_tokens,
+                                                        config_.disable_l2_cache, simulated_free)) {
+                    std::vector<TreeNode*> loadback_diff = ev->GetLoadbackDiff();
+                    std::vector<TreeNode*> mamba_loadback_nodes = ev->GetMambaLoadbackNodes();
+                    push_op(applyEventAndGenerateOp(request, std::move(*ev)), true);
+                    if (!loadback_diff.empty() || !mamba_loadback_nodes.empty()) {
+                        cache_op_id op_id = kv_prefix_cache_.AllocateCacheOpId();
+                        loadback_ops.push_back(GenerateLoadBackOp(loadback_diff, mamba_loadback_nodes, op_id));
+                    }
                 }
             }
         } else if (request->Is<fsm::PrefillDone>() || (request->Is<fsm::Decoding>() && config_.role != Role::kP)) {

--- a/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
@@ -152,12 +152,25 @@ void Scheduler::handleEvent(const cache::WriteBackDone& event) {
     auto now = std::chrono::steady_clock::now();
     for (TreeNode* n : spec.nodes) n->Touch(now);
 
+    // Generate L3 backup from the pages just written to host (fire-and-forget).
+    if (config_.enable_l3_storage && !spec.backup_host_pages.empty()) {
+        BackUpOperation backup_op;
+        backup_op.op_id = kv_prefix_cache_.AllocateCacheOpId();
+        backup_op.src_pages = std::move(spec.backup_host_pages);
+        backup_op.rolling_page_hashes = std::move(spec.backup_rolling_hashes);
+        pending_backup_ops_.push_back(std::move(backup_op));
+    }
+
     if (!spec.request_id.empty()) {
         if (auto* req = find_request(spec.request_id)) {
             req->Apply(
                 fsm::WriteBackDoneEvent{&kv_prefix_cache_, hybrid_prefix_cache_ ? &*hybrid_prefix_cache_ : nullptr});
         }
     }
+}
+
+void Scheduler::handleEvent(const cache::BackUpDone& event) {
+    // Reserved for future use (e.g. marking tree nodes as persisted).
 }
 
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include <algorithm>
 #include <stdexcept>
 
 #include "resource/allocator/owned_pages.h"
@@ -59,12 +60,17 @@ void Scheduler::handleEvent(const cache::PrefetchDone& event) {
         OwnedPages host_owned = req->TakeHostPages();
         std::int32_t total_host = host_owned.Size();
 
+        const std::int32_t prefetch_start_page = req->GetPrefetchStartPage();
+        const std::int32_t suffix_pages =
+            std::max<std::int32_t>(0, static_cast<std::int32_t>(token_pages.size()) - prefetch_start_page);
+        TreeNode* start_node = req->GetHostLockNode();
+
         std::int32_t n = std::min(event.completed_pages, total_host);
-        std::int32_t n_tokens = std::min(n, static_cast<std::int32_t>(token_pages.size()));
+        std::int32_t n_tokens = std::min(n, suffix_pages);
 
         if (n_tokens > 0) {
-            std::vector<std::span<const std::int32_t>> insert_token_pages(token_pages.begin(),
-                                                                          token_pages.begin() + n_tokens);
+            auto insert_begin = token_pages.begin() + prefetch_start_page;
+            std::vector<std::span<const std::int32_t>> insert_token_pages(insert_begin, insert_begin + n_tokens);
 
             // Storage hashes for L3 backup (optional).
             const auto& storage = req->GetStorageInfo();
@@ -79,7 +85,8 @@ void Scheduler::handleEvent(const cache::PrefetchDone& event) {
             OwnedPages insert_pages = host_owned.TakeFirst(n_tokens);
 
             auto insert_result = kv_prefix_cache_.Insert<ResourceType::Host>(insert_token_pages, {},
-                                                                             std::move(insert_pages), page_hashes);
+                                                                             std::move(insert_pages), page_hashes,
+                                                                             start_node);
             completed = n;
             inserted = insert_result.inserted_num_pages;
         }
@@ -165,6 +172,9 @@ void Scheduler::handleEvent(const cache::WriteBackDone& event) {
         backup_op.op_id = kv_prefix_cache_.AllocateCacheOpId();
         backup_op.src_pages = std::move(spec.backup_host_pages);
         backup_op.rolling_page_hashes = std::move(spec.backup_rolling_hashes);
+        if (spec.backup_host_node != nullptr) {
+            pending_backup_host_refs_[backup_op.op_id] = std::make_unique<HostNodeRef>(spec.backup_host_node);
+        }
         pending_backup_ops_.push_back(std::move(backup_op));
     }
 
@@ -177,7 +187,7 @@ void Scheduler::handleEvent(const cache::WriteBackDone& event) {
 }
 
 void Scheduler::handleEvent(const cache::BackUpDone& event) {
-    // Reserved for future use (e.g. marking tree nodes as persisted).
+    pending_backup_host_refs_.erase(event.op_id);
 }
 
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
@@ -52,15 +52,19 @@ void Scheduler::handleEvent(const cache::PrefetchDone& event) {
         // Insert completed host pages into the KVPrefixCache so that future Match() calls
         // see them in the host side and can generate LoadBack ops.
         auto token_pages = req->GetFullPagedTokens(false);
-        auto all_host_pages = req->GetHostPageIds();
 
-        std::int32_t n = std::min(event.completed_pages, static_cast<std::int32_t>(all_host_pages.size()));
+        // Move host page ownership out of the Prefetching state so we can pass
+        // proper OwnedPages to Insert. The subsequent FSM transition will see
+        // empty pages and skip its cleanup (all handled here).
+        OwnedPages host_owned = req->TakeHostPages();
+        std::int32_t total_host = host_owned.Size();
+
+        std::int32_t n = std::min(event.completed_pages, total_host);
         std::int32_t n_tokens = std::min(n, static_cast<std::int32_t>(token_pages.size()));
 
         if (n_tokens > 0) {
             std::vector<std::span<const std::int32_t>> insert_token_pages(token_pages.begin(),
                                                                           token_pages.begin() + n_tokens);
-            std::vector<std::int32_t> insert_pages(all_host_pages.begin(), all_host_pages.begin() + n);
 
             // Storage hashes for L3 backup (optional).
             const auto& storage = req->GetStorageInfo();
@@ -70,13 +74,16 @@ void Scheduler::handleEvent(const cache::PrefetchDone& event) {
                 page_hashes.assign(storage.rolling_hashes.begin(), storage.rolling_hashes.begin() + nh);
             }
 
-            // Insert into host side; InsertHost returns how many were actually inserted
-            // (0 for pages that already existed — "overlapping").
-            auto insert_result = kv_prefix_cache_.Insert<ResourceType::Host>(insert_token_pages, insert_pages,
-                                                                             OwnedPages{}, page_hashes);
+            // Take the first n_tokens pages as allocator_pages for Insert;
+            // remaining uncompleted pages are freed when host_owned goes out of scope.
+            OwnedPages insert_pages = host_owned.TakeFirst(n_tokens);
+
+            auto insert_result = kv_prefix_cache_.Insert<ResourceType::Host>(insert_token_pages, {},
+                                                                             std::move(insert_pages), page_hashes);
             completed = n;
             inserted = insert_result.inserted_num_pages;
         }
+        // host_owned destructor frees any uncompleted pages back to the host allocator.
     }
 
     fsm::PrefetchDoneEvent fsm_event{completed, inserted};

--- a/tokenspeed-scheduler/csrc/scheduler/outside_events/cache.h
+++ b/tokenspeed-scheduler/csrc/scheduler/outside_events/cache.h
@@ -38,7 +38,12 @@ struct WriteBackDone {
     bool success;
 };
 
+struct BackUpDone {
+    cache_op_id op_id{};
+    bool success;
+};
+
 };  // namespace cache
 
-using CacheEvent = std::variant<cache::WriteBackDone, cache::PrefetchDone>;
+using CacheEvent = std::variant<cache::WriteBackDone, cache::PrefetchDone, cache::BackUpDone>;
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/csrc/scheduler/request.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/request.cpp
@@ -72,4 +72,12 @@ OwnedPages Request::TakeHostPages() {
     return std::move(*s).TakeHostPages();
 }
 
+std::int32_t Request::GetPrefetchStartPage() const {
+    auto* s = std::get_if<fsm::Prefetching>(&state_);
+    if (s == nullptr) {
+        throw std::logic_error("Request::GetPrefetchStartPage: expected state=Prefetching; got state=" + StateName());
+    }
+    return s->GetPrefetchStartPage();
+}
+
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/csrc/scheduler/request.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/request.cpp
@@ -64,4 +64,12 @@ std::vector<std::int32_t> Request::GetHostPageIds() const {
     return s->GetHostPageIds();
 }
 
+OwnedPages Request::TakeHostPages() {
+    auto* s = std::get_if<fsm::Prefetching>(&state_);
+    if (s == nullptr) {
+        throw std::logic_error("Request::TakeHostPages: expected state=Prefetching; got state=" + StateName());
+    }
+    return std::move(*s).TakeHostPages();
+}
+
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/csrc/scheduler/request.h
+++ b/tokenspeed-scheduler/csrc/scheduler/request.h
@@ -271,6 +271,16 @@ public:
             state_);
     }
 
+    template <typename S>
+        requires(std::same_as<S, fsm::Draining>)
+    TreeNode* GetHostNode() const {
+        return std::visit(Overloaded{
+            [](const fsm::Draining& s) -> TreeNode* { return s.HostNode(); },
+            [](const auto&) -> TreeNode* { return nullptr; },
+            },
+            state_);
+    }
+
 private:
     std::string id_;
     TokenContainer token_container_;

--- a/tokenspeed-scheduler/csrc/scheduler/request.h
+++ b/tokenspeed-scheduler/csrc/scheduler/request.h
@@ -86,6 +86,10 @@ public:
     // Returns the host pages allocated in Prefetching state (only valid when Is<Prefetching>()).
     std::vector<std::int32_t> GetHostPageIds() const;
 
+    // Moves host page ownership out of the Prefetching state (only valid when Is<Prefetching>()).
+    // After this call the Prefetching state's host_pages_ is empty.
+    OwnedPages TakeHostPages();
+
     const StorageInfo& GetStorageInfo() const { return storage_info_; }
 
     std::vector<std::span<const std::int32_t>> GetFullPagedTokens(bool except_last) const {

--- a/tokenspeed-scheduler/csrc/scheduler/request.h
+++ b/tokenspeed-scheduler/csrc/scheduler/request.h
@@ -89,6 +89,7 @@ public:
     // Moves host page ownership out of the Prefetching state (only valid when Is<Prefetching>()).
     // After this call the Prefetching state's host_pages_ is empty.
     OwnedPages TakeHostPages();
+    std::int32_t GetPrefetchStartPage() const;
 
     const StorageInfo& GetStorageInfo() const { return storage_info_; }
 

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -43,6 +43,7 @@
 #include "fsm/forward_events.h"
 #include "fsm/forward_states.h"
 #include "resource/kv_prefix_cache/kv_prefix_cache.h"
+#include "resource/radix_tree/node_range.h"
 #include "resource/radix_tree/radix_tree.h"
 #include "resource/radix_tree/tree_node.h"
 #include "scheduler/execution_event.h"
@@ -288,6 +289,30 @@ std::vector<WriteBackOperation> Scheduler::newWriteBackOperation(
             cache_op_id op_id = kv_prefix_cache_.AllocateCacheOpId();
             CacheOpSpec spec;
             spec.request_id = id;
+            // Capture L3 backup metadata while the host node-ref is still alive.
+            // write_diff pages correspond to the tail of the full root→leaf hash path.
+            if (config_.enable_l3_storage) {
+                TreeNode* host_node = req->GetHostNode<fsm::Draining>();
+                if (host_node) {
+                    std::vector<std::string> all_hashes;
+                    for (TreeNode* n : RootToLeaf(host_node)) {
+                        const auto& h = n->PageHashes();
+                        all_hashes.insert(all_hashes.end(), h.begin(), h.end());
+                    }
+                    std::int32_t n_kv_pairs = 0;
+                    for (const auto& p : pages_to_transfer) {
+                        if (p.kind == CacheKind::kKV) n_kv_pairs++;
+                    }
+                    if (n_kv_pairs > 0 && static_cast<std::int32_t>(all_hashes.size()) >= n_kv_pairs) {
+                        spec.backup_rolling_hashes.assign(all_hashes.end() - n_kv_pairs, all_hashes.end());
+                        for (const auto& p : pages_to_transfer) {
+                            if (p.kind == CacheKind::kKV) {
+                                spec.backup_host_pages.push_back(p.dst);
+                            }
+                        }
+                    }
+                }
+            }
             cache_op_tracker_[op_id] = std::move(spec);
             ops.push_back(WriteBackOperation{
                 op_id, std::vector<TransferPair>(pages_to_transfer.begin(), pages_to_transfer.end())});
@@ -338,6 +363,15 @@ ExecutionPlan Scheduler::NextExecutionPlan() {
             plan.With(CacheOperation{FlatLoadBackOperation{*lb}});
         }
     }
+    // Emit L3 storage ops (prefetch from newForwardOperation, backup from WriteBackDone handler).
+    for (auto& op : pending_prefetch_ops_) {
+        plan.With(CacheOperation{std::move(op)});
+    }
+    pending_prefetch_ops_.clear();
+    for (auto& op : pending_backup_ops_) {
+        plan.With(CacheOperation{std::move(op)});
+    }
+    pending_backup_ops_.clear();
     if (std::getenv("DEBUG_MEM")) {
         check_device_mem();
     }

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -290,12 +290,12 @@ std::vector<WriteBackOperation> Scheduler::newWriteBackOperation(
             CacheOpSpec spec;
             spec.request_id = id;
             // Capture L3 backup metadata while the host node-ref is still alive.
-            // write_diff pages correspond to the tail of the full root→leaf hash path.
+            // Collect hashes in leaf-to-root order to match pages_to_transfer ordering.
             if (config_.enable_l3_storage) {
                 TreeNode* host_node = req->GetHostNode<fsm::Draining>();
                 if (host_node) {
                     std::vector<std::string> all_hashes;
-                    for (TreeNode* n : RootToLeaf(host_node)) {
+                    for (TreeNode* n : LeafToRoot(host_node)) {
                         const auto& h = n->PageHashes();
                         all_hashes.insert(all_hashes.end(), h.begin(), h.end());
                     }
@@ -304,7 +304,7 @@ std::vector<WriteBackOperation> Scheduler::newWriteBackOperation(
                         if (p.kind == CacheKind::kKV) n_kv_pairs++;
                     }
                     if (n_kv_pairs > 0 && static_cast<std::int32_t>(all_hashes.size()) >= n_kv_pairs) {
-                        spec.backup_rolling_hashes.assign(all_hashes.end() - n_kv_pairs, all_hashes.end());
+                        spec.backup_rolling_hashes.assign(all_hashes.begin(), all_hashes.begin() + n_kv_pairs);
                         for (const auto& p : pages_to_transfer) {
                             if (p.kind == CacheKind::kKV) {
                                 spec.backup_host_pages.push_back(p.dst);

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -305,6 +305,7 @@ std::vector<WriteBackOperation> Scheduler::newWriteBackOperation(
                     }
                     if (n_kv_pairs > 0 && static_cast<std::int32_t>(all_hashes.size()) >= n_kv_pairs) {
                         spec.backup_rolling_hashes.assign(all_hashes.begin(), all_hashes.begin() + n_kv_pairs);
+                        spec.backup_host_node = host_node;
                         for (const auto& p : pages_to_transfer) {
                             if (p.kind == CacheKind::kKV) {
                                 spec.backup_host_pages.push_back(p.dst);

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.h
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.h
@@ -147,6 +147,7 @@ private:
     // L3 ops produced during scheduling / event handling, drained in NextExecutionPlan().
     std::vector<PrefetchOperation> pending_prefetch_ops_;
     std::vector<BackUpOperation> pending_backup_ops_;
+    std::unordered_map<cache_op_id, std::unique_ptr<HostNodeRef>> pending_backup_host_refs_;
     // Stats
     SchedulerStats stats_;
 };

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.h
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.h
@@ -112,6 +112,7 @@ private:
 private:
     void handleEvent(const cache::PrefetchDone& event);
     void handleEvent(const cache::WriteBackDone& event);
+    void handleEvent(const cache::BackUpDone& event);
     void handleEvent(const pd::BootstrappedEvent& event);
     void handleEvent(const pd::FailedEvent& event);
     void handleEvent(const pd::SucceededEvent& event);
@@ -143,6 +144,9 @@ private:
     std::unordered_map<std::string, std::unique_ptr<Request>> requests_;
     std::unordered_map<cache_op_id, CacheOpSpec> cache_op_tracker_;
     std::vector<KvCacheEvent> kv_events_;
+    // L3 ops produced during scheduling / event handling, drained in NextExecutionPlan().
+    std::vector<PrefetchOperation> pending_prefetch_ops_;
+    std::vector<BackUpOperation> pending_backup_ops_;
     // Stats
     SchedulerStats stats_;
 };

--- a/tokenspeed-scheduler/tests/cpp/integration_test_helper.h
+++ b/tokenspeed-scheduler/tests/cpp/integration_test_helper.h
@@ -113,6 +113,27 @@ protected:
         scheduler_->Advance(std::move(event));
     }
 
+    void SendPrefetchDone(cache_op_id op_id, const std::string& request_id, std::int32_t completed_pages,
+                          bool success = true) {
+        ExecutionEvent event;
+        event.With(CacheEvent{cache::PrefetchDone{
+            .success = success,
+            .op_id = op_id,
+            .request_id = request_id,
+            .completed_pages = completed_pages,
+        }});
+        scheduler_->Advance(std::move(event));
+    }
+
+    void SendBackUpDone(cache_op_id op_id, bool success = true) {
+        ExecutionEvent event;
+        event.With(CacheEvent{cache::BackUpDone{
+            .op_id = op_id,
+            .success = success,
+        }});
+        scheduler_->Advance(std::move(event));
+    }
+
     // Send ExtendResult (new decode tokens) to the scheduler.
     void SendForwardDone(const std::string& request_id, const std::vector<std::int32_t>& tokens) {
         ExecutionEvent event;

--- a/tokenspeed-scheduler/tests/cpp/test_prefetch.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_prefetch.cpp
@@ -42,11 +42,54 @@ protected:
         return nullptr;
     }
 
+    static const BackUpOperation* GetBackup(const ExecutionPlan& plan) {
+        for (const auto& op : plan.Operations()) {
+            if (auto* cop = std::get_if<CacheOperation>(&op)) {
+                if (auto* backup = std::get_if<BackUpOperation>(cop)) return backup;
+            }
+        }
+        return nullptr;
+    }
+
+    static const FlatWriteBackOperation* GetWriteBack(const ExecutionPlan& plan) {
+        for (const auto& op : plan.Operations()) {
+            if (auto* cop = std::get_if<CacheOperation>(&op)) {
+                if (auto* wb = std::get_if<FlatWriteBackOperation>(cop)) return wb;
+            }
+        }
+        return nullptr;
+    }
+
     static const FlatForwardOperation* GetForwardOp(const ExecutionPlan& plan) {
         for (const auto& op : plan.Operations()) {
             if (auto* f = std::get_if<FlatForwardOperation>(&op)) return f;
         }
         return nullptr;
+    }
+
+    void BringToDecoding(const RequestSpec& spec) {
+        Submit(spec);
+        PlanOnce();
+        SendForwardDone(spec.request_id, {42});
+        PlanOnce();
+    }
+
+    cache_op_id MaterializeHostPrefix(const RequestSpec& spec) {
+        BringToDecoding(spec);
+        SendFinish(spec.request_id);
+        auto writeback_plan = PlanOnce();
+        const auto* wb = GetWriteBack(writeback_plan);
+        if (wb == nullptr || wb->op_ids.empty()) {
+            ADD_FAILURE() << "expected writeback for " << spec.request_id;
+            return 0;
+        }
+        SendWriteBackDone(wb->op_ids[0]);
+        auto backup_plan = PlanOnce();
+        const auto* backup = GetBackup(backup_plan);
+        if (backup == nullptr) {
+            return 0;
+        }
+        return backup->op_id;
     }
 };
 
@@ -84,6 +127,62 @@ TEST_F(PrefetchTestSuite, NoPrefetch_BelowThreshold) {
     auto plan = PlanOnce();
     const auto* pf = GetPrefetch(plan);
     EXPECT_EQ(pf, nullptr);
+}
+
+TEST_F(PrefetchTestSuite, PrefetchDone_InsertsSuffixAfterHostMatchedPrefix) {
+    RequestSpec prefix;
+    prefix.request_id = "prefix";
+    prefix.tokens = {1, 2};
+    cache_op_id backup_id = MaterializeHostPrefix(prefix);
+    if (backup_id != 0) {
+        SendBackUpDone(backup_id);
+    }
+
+    RequestSpec spec;
+    spec.request_id = "r2";
+    spec.tokens = {1, 2, 3, 4, 5, 6, 7, 8};
+    spec.rolling_hashes = {"h34", "h56", "h78"};
+    spec.storage_hit_pages = 3;
+    Submit(spec);
+
+    auto prefetch_plan = PlanOnce();
+    const auto* pf = GetPrefetch(prefetch_plan);
+    ASSERT_NE(pf, nullptr);
+    ASSERT_EQ(pf->rolling_page_hashes.size(), 3u);
+    SendPrefetchDone(pf->op_id, "r2", /*completed_pages=*/3);
+
+    auto forward_plan = PlanOnce();
+    const auto* fwd = GetForwardOp(forward_plan);
+    ASSERT_NE(fwd, nullptr);
+    ASSERT_EQ(fwd->request_ids.size(), 1u);
+    EXPECT_EQ(fwd->request_ids[0], "r2");
+    ASSERT_EQ(fwd->extend_prefix_lens.size(), 1u);
+    EXPECT_EQ(fwd->extend_prefix_lens[0], 8);
+    ASSERT_EQ(fwd->input_lengths.size(), 1u);
+    EXPECT_EQ(fwd->input_lengths[0], 0);
+}
+
+TEST_F(PrefetchTestSuite, BackupPinsHostPagesUntilBackUpDone) {
+    auto cfg = MakeConfig();
+    cfg.host_allocator.total_pages = 2;
+    cfg.prefetch_threshold = 0;
+    scheduler_ = std::make_unique<Scheduler>(cfg);
+
+    RequestSpec written;
+    written.request_id = "written";
+    written.tokens = {1, 2, 3, 4};
+    cache_op_id backup_id = MaterializeHostPrefix(written);
+    ASSERT_NE(backup_id, 0u);
+
+    Submit(MakePrefetchableSpec("blocked", /*num_pages=*/2, /*storage_hit_pages=*/2, /*start=*/100));
+    auto blocked_plan = PlanOnce();
+    EXPECT_EQ(GetPrefetch(blocked_plan), nullptr);
+
+    SendBackUpDone(backup_id);
+
+    Submit(MakePrefetchableSpec("released", /*num_pages=*/2, /*storage_hit_pages=*/2, /*start=*/200));
+    auto released_plan = PlanOnce();
+    EXPECT_NE(GetPrefetch(released_plan), nullptr);
 }
 
 }  // namespace tokenspeed::test


### PR DESCRIPTION
## Summary

### Prefetch (L3 → Host)

On request submission, query Mooncake for existing KV pages. If hits exceed prefetch_threshold, take an async prefetch path (Submitted → Prefetching → PrefetchDone → Prefilling) instead of direct prefill. Completed pages are inserted into the radix tree's host layer with proper OwnedPages ownership transfer.

### Backup (Host → L3)

On WriteBackDone, emit a fire-and-forget BackUpOperation to persist host pages to Mooncake. Backup metadata is captured at WriteBackOperation creation time while the Draining state's host node-ref is still alive.

### Key changes

- FSM: Add SchedulePrefillFirstChunkEvent::operator()(PrefetchDone&&) via templated applyFirstChunk<StateT>() so prefetch-completed requests can enter prefill.
- forward.cpp: Attempt schedulePrefetch for Submitted requests before falling through to prefill. Treat PrefetchDone with same scheduling priority.
- outside_event_handler.cpp: Transfer host page ownership via OwnedPages into Insert<Host>(); RAII-free uncompleted pages. Add WriteBackDone hook to emit BackUpOperation.
- scheduler.cpp: Capture L3 backup metadata (rolling hashes, host page IDs) in CacheOpSpec during newWriteBackOperation. Drain pending_prefetch_ops_ and pending_backup_ops_ in NextExecutionPlan().

## Test Plan

- Served kimi-k2.5 with Mooncake KVStore enabled in dev container
- Sent a long-generation request (long prompt, max_tokens=262144), then sent multiple different requests to fill device/host cache and force eviction of the first request's KV pages to L3
- Re-sent the same first request; verified L3 prefetch path activated (KV pages fetched back from Mooncake → host → device) and output matched the original response
- Confirmed L3 fetch via Mooncake `batch_get_into` logs (439 tokens prompt, 439/64 = 6, 6 * TP4 = 24):
```
Mooncake log:
 | Requests (Success/Total): PutStart=4/4, PutEnd=4/4, PutRevoke=0/0, Get=4/4, Exist=4/4, Del=0/0, DelAll=0/0, Ping=2228/2228, CopyStart=0/0, CopyEnd=0/0, CopyRevoke=0/0, MoveStart=0/0, MoveEnd=0/0, MoveRevoke=0/0, EvictDiskReplica=0/0 | Batch Requests (Req=Success/PartialSuccess/Total, Item=Success/Total): PutStart:(Req=14/0/51, Item=1369/5238), PutEnd:(Req=14/0/14, Item=1369/1369), PutRevoke:(Req=0/0/0, Item=0/0), Get:(Req=4/0/4, Item=24/24), ExistKey:(Req=64/0/64, Item=5524/5524), QueryIp:(Req=0/0/0, Item=0/0), Clear:(Req=0/0/0, Item=0/0), CreateMoveTask:(Req=0/0), CreateCopyTask:(Req=0/0), QueryTask=(Req=0/0), FetchTasks=(Req=2228/2228), MarkTaskToComplete= (Req=0/0),  | Eviction: Success/Attempts=0/0, keys=0, size=0 B | Discard: Released/Total=0/0, StagingSize=0 B | Snapshots: Success=0, Fail=0}, ha={HA Metrics Summary: last_seq=0, applied_seq=0, lag=0, pending=0, mutation_queue=0, batch_commits=0, sync_commits=0, skipped=0, checksum_fail=0, etcd_fail=0, watch_disconn=0, state=0}

ts log:
[ts] I0528 04:36:33.135007 2732203 real_client.cpp:3556] Time taken for batch_get_into: 9814us, read store: 0us, with memory key count: 6, offload key count: 0
[ts] I0528 04:36:33.135859 2732205 real_client.cpp:3556] Time taken for batch_get_into: 10103us, read store: 0us, with memory key count: 6, offload key count: 0
[ts] I0528 04:36:33.136945 2732206 real_client.cpp:3556] Time taken for batch_get_into: 11312us, read store: 0us, with memory key count: 6, offload key count: 0
[ts] I0528 04:36:33.147481 2732204 real_client.cpp:3556] Time taken for batch_get_into: 22004us, read store: 0us, with memory key count: 6, offload key count: 0
```