### PR TITLE
ci(eval): set kimi-k2.5 ocr-bench score_threshold to 0.9

### DIFF
--- a/test/ci/eval/kimi-k2.5-nvfp4-evalscope-ocr-bench.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-evalscope-ocr-bench.yaml
@@ -46,3 +46,4 @@ eval:
     --eval-batch-size 16
 report:
   github_step_summary: true
+score_threshold: 0.9

--- a/test/ci_system/pipeline.py
+++ b/test/ci_system/pipeline.py
@@ -652,7 +652,7 @@ def extract_evalscope_score(report_table: str) -> float | None:
         cells = [cell.strip() for cell in stripped.strip(separator).split(separator)]
         if not cells:
             continue
-        if any(set(cell) <= {"=", "-"} for cell in cells if cell):
+        if all(set(cell) <= {"=", "-"} for cell in cells if cell):
             continue
         normalized = [cell.lower() for cell in cells]
         if "score" in normalized:


### PR DESCRIPTION
## Summary

Follow-up to #253:

- Set kimi-k2.5 ocr-bench `score_threshold` to 0.9.
- Fix the evalscope score extractor: the `any` separator filter was skipping the OCRBench OVERALL row (Cat.0 is `-`), so CI read 0.49 instead of 0.903.

## Test plan

- [x] Local repro of the CI config, 20 OCRBench passes: mean 0.9076, std 0.0027, min 0.904, max 0.915 — all 20/20 above 0.9
- [ ] CI `eval-kimi-k2.5-nvfp4-ocr-bench` passes on the new threshold