### PR TITLE
deps(kernel): pin triton to 3.7.10.post20260505

### DIFF
--- a/tokenspeed-kernel/python/requirements/common.txt
+++ b/tokenspeed-kernel/python/requirements/common.txt
@@ -2,7 +2,7 @@ apache-tvm-ffi>=0.1.5
 numpy
 packaging
 PyYAML>=6.0
-tokenspeed-proton>=3.7.10.post20260505
-tokenspeed-triton>=3.7.10.post20260505
+tokenspeed-proton==3.7.10.post20260505
+tokenspeed-triton==3.7.10.post20260505
 wheel
 psutil

--- a/tokenspeed-mla/pyproject.toml
+++ b/tokenspeed-mla/pyproject.toml
@@ -12,7 +12,7 @@ license = { file = "LICENSE" }
 dependencies = [
     "apache-tvm-ffi>=0.1.5",
     "nvidia-cutlass-dsl",
-    "tokenspeed-triton>=3.7.10.post20260505",
+    "tokenspeed-triton==3.7.10.post20260505",
     "torch",
 ]
 


### PR DESCRIPTION
New release seems having correctness issues for AMD. While debugging it, pin to the old version.