### PR TITLE
fix(kernel): tile merge_state over heads to avoid >1024 block

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/merge_state.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/merge_state.cu
@@ -38,17 +38,23 @@ __global__ void MergeStateKernel(DTypeIn* v_a, float* s_a, DTypeIn* v_b, float* 
 
   uint32_t tx = threadIdx.x, ty = threadIdx.y;
   uint32_t pos = blockIdx.x;
-  uint32_t head_idx = ty;
+  // heads are tiled over gridDim.y to keep blockDim <= 1024.
+  uint32_t head_idx = blockIdx.y * blockDim.y + ty;
+  // masked lanes skip load/store but still reach __syncwarp below.
+  bool valid = head_idx < num_heads;
 
 #if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   asm volatile("griddepcontrol.wait;");
 #endif
   // Load phase: snapshot every aliasable input into registers before any store fires.
-  float s_a_val = s_a[pos * num_heads + head_idx] * lse_scale_log2;
-  float s_b_val = s_b[pos * num_heads + head_idx] * lse_scale_log2;
+  float s_a_val = 0.f, s_b_val = 0.f;
   vec_t<float, kVecSize> v_a_vec, v_b_vec, v_merged_vec;
-  v_a_vec.cast_load(v_a + (pos * num_heads + head_idx) * HeadDim + tx * kVecSize);
-  v_b_vec.cast_load(v_b + (pos * num_heads + head_idx) * HeadDim + tx * kVecSize);
+  if (valid) {
+    s_a_val = s_a[pos * num_heads + head_idx] * lse_scale_log2;
+    s_b_val = s_b[pos * num_heads + head_idx] * lse_scale_log2;
+    v_a_vec.cast_load(v_a + (pos * num_heads + head_idx) * HeadDim + tx * kVecSize);
+    v_b_vec.cast_load(v_b + (pos * num_heads + head_idx) * HeadDim + tx * kVecSize);
+  }
 
   // Compute phase: register-only.
   float s_max = max(s_a_val, s_b_val);
@@ -62,7 +68,9 @@ __global__ void MergeStateKernel(DTypeIn* v_a, float* s_a, DTypeIn* v_b, float* 
   }
 
   // v_merged store: per-lane disjoint slice, no cross-lane ordering needed.
-  v_merged_vec.cast_store(v_merged + (pos * num_heads + head_idx) * HeadDim + tx * kVecSize);
+  if (valid) {
+    v_merged_vec.cast_store(v_merged + (pos * num_heads + head_idx) * HeadDim + tx * kVecSize);
+  }
 
   // s_merged store: kBdx lanes share one slot. Sync so every lane's s_a load
   // is complete before the writer fires, then a single lane writes.
@@ -71,7 +79,7 @@ __global__ void MergeStateKernel(DTypeIn* v_a, float* s_a, DTypeIn* v_b, float* 
   } else {
     __syncthreads();
   }
-  if (tx == 0) {
+  if (valid && tx == 0) {
     s_merged[pos * num_heads + head_idx] =
         (math::ptx_log2(s_a_val + s_b_val) + s_max) * lse_scale_inv;
   }
@@ -93,8 +101,11 @@ cudaError_t MergeState(DTypeIn* v_a, float* s_a, DTypeIn* v_b, float* s_b, DType
   DISPATCH_HEAD_DIM(head_dim, HeadDim, {
     constexpr size_t kVecSize = std::max(16U / sizeof(DTypeIn), HeadDim / 32U);
     constexpr size_t kBdx = HeadDim / kVecSize;
-    uint32_t bdy = num_heads;
-    dim3 nblks(seq_len);
+    // cap block y so kBdx * bdy <= 1024; tile remaining heads over grid y.
+    constexpr uint32_t kMaxBdy = 1024U / static_cast<uint32_t>(kBdx);
+    uint32_t bdy = std::min(num_heads, kMaxBdy);
+    uint32_t grid_y = (num_heads + bdy - 1) / bdy;
+    dim3 nblks(seq_len, grid_y);
     dim3 nthrs(static_cast<uint32_t>(kBdx), bdy);
     auto kernel = MergeStateKernel<HeadDim, DTypeIn, DTypeO>;
 

--- a/tokenspeed-kernel/test/thirdparty/test_merge_state.py
+++ b/tokenspeed-kernel/test/thirdparty/test_merge_state.py
@@ -96,6 +96,30 @@ SHAPES = [
 ]
 
 
+# Head counts that overflow the old single-block layout (kBdx * num_heads must
+# stay <= 1024). For D=128 bf16, kBdx=16 so H>64 used to fail at launch; the
+# non-multiples also exercise the grid-y tail mask.
+LARGE_HEAD_SHAPES = [
+    (256, 65, 128),
+    (256, 128, 128),
+    (64, 200, 128),
+    (128, 128, 256),
+]
+
+
+@pytest.mark.parametrize("T,H,D", LARGE_HEAD_SHAPES)
+def test_large_num_heads(device: str, T: int, H: int, D: int) -> None:
+    """num_heads beyond kBdx*H<=1024 must tile over grid-y, not fail at launch."""
+    v_a, s_a, v_b, s_b = _make_inputs(T, H, D, device, torch.bfloat16)
+
+    v_out, s_out = merge_state(v_a, s_a, v_b, s_b)
+    torch.cuda.synchronize()
+
+    v_ref, s_ref = _reference_merge(v_a, s_a, v_b, s_b, LSE_LN)
+    assert torch.allclose(v_out.float(), v_ref.float(), atol=5e-2, rtol=1e-2)
+    assert torch.allclose(s_out, s_ref, atol=1e-4, rtol=1e-5)
+
+
 @pytest.mark.parametrize("T,H,D", SHAPES)
 @pytest.mark.parametrize("v_dtype", [torch.bfloat16, torch.float16])
 def test_natural_log_default(


### PR DESCRIPTION
## Problem
mha_merge_state CUDA kernel fails at launch when `num_heads` is large. The launcher uses `(kBdx, num_heads)` threads per block; when kBdx*num_heads > 1024 the launch returns "invalid argument". For head_dim=128 bf16 kBdx=16, so any num_heads > 64 fails.

## Fix
Tile num_heads over gridDim.y and cap block-y at 1024/kBdx. head_idx becomes `blockIdx.y*blockDim.y+ty`. Lanes past num_heads skip their load/store but still hit `__syncwarp`, keeping the warp barrier valid.

## Test
`test_large_num_heads` covers H in {65,128,200} and head_dim {128,256}, including non-multiples that exercise the grid-y tail mask. 33 passed.