### PR TITLE
fix(attention): limit decode scheduler metadata to FA3

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mha.py
@@ -651,10 +651,11 @@ class MHAAttnBackend(AttentionBackend):
     ) -> torch.Tensor | None:
         """Pre-compute FA3 decode scheduler metadata once per step.
 
-        Returns ``None`` when the active backend does not consume pre-computed
-        scheduler metadata (only FA3 on Hopper does); the kernel then falls
-        back to its internal prepare_varlen_num_blocks launch.
+        Other MHA solutions do not accept this FA3-specific metadata, so the
+        runtime leaves it unset unless the selected kernel solution is FA3.
         """
+        if self.kernel_solution != "fa3":
+            return None
         return mha_decode_scheduler_metadata(
             batch_size=bs,
             max_seqlen_q=1,
@@ -665,7 +666,7 @@ class MHAAttnBackend(AttentionBackend):
             cache_seqlens=seq_lens,
             qkv_dtype=self.qkv_dtype,
             page_size=self.page_size,
-            causal=True,
+            causal=False,
         )
 
 

--- a/test/runtime/test_server_args_attention_backends.py
+++ b/test/runtime/test_server_args_attention_backends.py
@@ -21,6 +21,8 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
+import torch
+
 from tokenspeed.runtime.configs.model_config import AttentionArch
 from tokenspeed.runtime.layers.attention import registry
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
@@ -138,6 +140,45 @@ class TestAttentionBackendChoices(unittest.TestCase):
 
         self.assertEqual(config.speculative_num_steps, 3)
         self.assertEqual(config.speculative_num_draft_tokens, 4)
+
+    def test_mha_scheduler_metadata_is_fa3_only_and_noncausal(self):
+        from tokenspeed.runtime.layers.attention.backends import mha
+
+        base_kwargs = dict(
+            device="cpu",
+            num_attention_heads=16,
+            num_kv_heads=8,
+            head_dim=128,
+            attn_tp_size=4,
+            dtype=torch.bfloat16,
+            kv_cache_dtype=torch.bfloat16,
+            page_size=64,
+            context_len=4096,
+            max_bs=8,
+            max_graph_bs=4,
+            kv_cache_quant_method="none",
+        )
+        seq_lens = torch.ones((2,), dtype=torch.int32)
+
+        for backend_name in ("mha", "fa4", "triton", "flashinfer"):
+            backend = mha.MHAAttnBackend(
+                MHAConfig(backend_name=backend_name, **base_kwargs)
+            )
+            with mock.patch.object(mha, "mha_decode_scheduler_metadata") as mocked:
+                self.assertIsNone(
+                    backend._maybe_compute_scheduler_metadata(2, seq_lens)
+                )
+                mocked.assert_not_called()
+
+        marker = torch.empty((1,), dtype=torch.int32)
+        fa3_backend = mha.MHAAttnBackend(MHAConfig(backend_name="fa3", **base_kwargs))
+        with mock.patch.object(
+            mha, "mha_decode_scheduler_metadata", return_value=marker
+        ) as mocked:
+            self.assertIs(
+                fa3_backend._maybe_compute_scheduler_metadata(2, seq_lens), marker
+            )
+            self.assertFalse(mocked.call_args.kwargs["causal"])
 
 
 if __name__ == "__main__":

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flash_attn/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flash_attn/__init__.py
@@ -407,14 +407,9 @@ def mha_decode_scheduler_metadata(
     cache_seqlens: torch.Tensor,
     qkv_dtype: torch.dtype,
     page_size: int,
-    causal: bool = True,
+    causal: bool = False,
 ) -> torch.Tensor | None:
-    """Pre-compute decode scheduler metadata once per scheduler step.
-
-    Only the FA3 decode kernel consumes pre-computed scheduler metadata; on
-    every other backend the kernel computes it internally and this helper
-    returns ``None`` so callers can pass through unconditionally.
-    """
+    """Pre-compute FA3 decode scheduler metadata once per scheduler step."""
     if get_scheduler_metadata is error_fn:
         return None
     return get_scheduler_metadata(

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -324,6 +324,34 @@ def _attention_decode() -> object:
     )
 
 
+def test_mha_decode_scheduler_metadata_defaults_to_noncausal(monkeypatch) -> None:
+    marker = torch.empty((1,), dtype=torch.int32)
+    call_kwargs = {}
+
+    def fake_get_scheduler_metadata(**kwargs):
+        call_kwargs.update(kwargs)
+        return marker
+
+    monkeypatch.setattr(
+        _attention_flash_attn, "get_scheduler_metadata", fake_get_scheduler_metadata
+    )
+
+    result = _attention_flash_attn.mha_decode_scheduler_metadata(
+        batch_size=2,
+        max_seqlen_q=1,
+        max_seqlen_k=128,
+        num_heads_q=16,
+        num_heads_kv=8,
+        headdim=64,
+        cache_seqlens=torch.tensor([64, 128], dtype=torch.int32),
+        qkv_dtype=torch.bfloat16,
+        page_size=64,
+    )
+
+    assert result is marker
+    assert call_kwargs["causal"] is False
+
+
 def _attention_merge_state() -> object:
     out_a = torch.empty((4, 16, 64), dtype=torch.bfloat16)
     out_b = torch.empty((4, 16, 64), dtype=torch.bfloat16)


### PR DESCRIPTION
## Summary
- only compute MHA decode scheduler metadata when the selected kernel solution is FA3
- use non-causal scheduler metadata for FA3 decode
- add regression coverage for runtime backend gating and the kernel helper default

## Validation
- `pre-commit run --all-files`
- `python -m pytest test/runtime/test_server_args_attention_backends.py::TestAttentionBackendChoices::test_mha_scheduler_metadata_is_fa3_only_and_noncausal -q`
- `python -m pytest tokenspeed-kernel/test/test_kernel_api_selection.py::test_mha_decode_scheduler_metadata_defaults_to_noncausal -q`

## MiniMax control check
After opening this PR, I also tested clean `origin/main` (`25429a5c`) without this change using `MiniMaxAI/MiniMax-M2.5`, `world_size=8`, `ep_size=8`, and `TOKENSPEED_MINIMAX_AR_USE_TRITON=1`. Both `attention_backend=triton` and `attention_backend=fa3` generated text successfully.

So this PR should not be presented as required to make MiniMax-M2.5 run on current main. It is a generic MHA decode metadata contract cleanup with targeted regression coverage.