### PR TITLE
fix: check mixed batch in mha backend based on forward mode

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mha.py
@@ -130,7 +130,7 @@ class MHAAttnBackend(AttentionBackend):
         extend_prefix_lens_cpu: torch.Tensor,
         **kwargs,
     ):
-        assert bs == num_extends, "mha backend does not support mixed batch"
+        assert not forward_mode.is_mixed(), "mha backend does not support mixed batch"
 
         seq_lens = seq_lens[:bs]
         page_table = build_page_table(


### PR DESCRIPTION
## Summary

The current mha backend has not added support for mixed batch. The previous gating is based on `num_extends` which is not safe for decode batch without cuda graph capture. Change to use forward mode.

## Test Plan

<!-- How was this validated? -->
