### PR TITLE
Fix(spec decode): catch up trim bug

### DIFF
--- a/python/tokenspeed/runtime/execution/drafter/eagle.py
+++ b/python/tokenspeed/runtime/execution/drafter/eagle.py
@@ -222,14 +222,6 @@ class Eagle(BaseDrafter):
 
         draft_first_step_reduce = forward_mode.is_decode()
 
-        if draft_first_step_reduce and self.attn_backend.support_kv_cache_prewrite:
-            # Trim seq_lens by rejected-draft count so the sliced decode
-            # query does not attend to dead positions.
-            correction = (self.spec_num_tokens - draft_input.accept_lengths).to(
-                self.draft_seq_lens_buf.dtype
-            )
-            self.draft_seq_lens_buf[:bs].sub_(correction)
-
         ctx = ForwardContext(
             attn_backend=self.attn_backend,
             token_to_kv_pool=self.token_to_kv_pool,

--- a/python/tokenspeed/runtime/execution/drafter/eagle.py
+++ b/python/tokenspeed/runtime/execution/drafter/eagle.py
@@ -36,6 +36,7 @@ from tokenspeed.runtime.execution.forward_batch_info import (
     CaptureHiddenMode,
     ForwardMode,
 )
+from tokenspeed.runtime.models.base import BaseCausalLM
 from tokenspeed.runtime.multimodal.inputs import maybe_substitute_mm_pad
 from tokenspeed.runtime.utils import get_colorful_logger
 from tokenspeed.runtime.utils.nvtx import nvtx_range
@@ -226,6 +227,20 @@ class Eagle(BaseDrafter):
         )
         input_ids = maybe_substitute_mm_pad(input_ids, self.mm_pad_substitute_id)
         draft_first_step_reduce = forward_mode.is_decode()
+
+        # TODO: remove the isinstance/flag gate together with pre_attention_trim
+        # once Qwen NextN and DeepSeek V3 NextN also pre-slice q.
+        draft_model = self.draft_model_runner.model
+        if (
+            draft_first_step_reduce
+            and self.attn_backend.support_kv_cache_prewrite
+            and isinstance(draft_model, BaseCausalLM)
+            and draft_model.pre_attention_trim
+        ):
+            correction = (self.spec_num_tokens - draft_input.accept_lengths).to(
+                self.draft_seq_lens_buf.dtype
+            )
+            self.draft_seq_lens_buf[:bs].sub_(correction)
 
         draft_first_mode = (
             ForwardMode.DRAFT_EXTEND

--- a/python/tokenspeed/runtime/models/base/causal_lm.py
+++ b/python/tokenspeed/runtime/models/base/causal_lm.py
@@ -44,6 +44,10 @@ class BaseCausalLM(nn.Module):
 
     model_cls: type[BaseTransformerModel]
 
+    # TODO: temporary; remove in the follow-up refactoring that extends
+    # pre-attn q-slice to Qwen NextN and DeepSeek V3 NextN.
+    pre_attention_trim: bool = False
+
     def __init__(
         self,
         config: PretrainedConfig,

--- a/python/tokenspeed/runtime/models/llama_eagle3.py
+++ b/python/tokenspeed/runtime/models/llama_eagle3.py
@@ -35,7 +35,6 @@ from transformers import LlamaConfig
 from tokenspeed.runtime.configs.utils import get_rope_theta
 from tokenspeed.runtime.distributed.mapping import Mapping
 from tokenspeed.runtime.execution.context import ForwardContext
-from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.activation import SiluAndMul
 from tokenspeed.runtime.layers.common import concat
 from tokenspeed.runtime.layers.layernorm import RMSNorm
@@ -187,37 +186,22 @@ class LlamaAttention(nn.Module):
                 output_q_rope=q_rope,
                 enable_pdl=pdl_enabled(),
             )
-            if ctx.draft_first_step_reduce:
-                # KV already written via fused_set_kv_buffer_arg above; slice Q
-                # to one query per request and route attn as decode.
-                q_rope = q_rope.index_select(0, ctx.gather_ids)
-                attn_output = ctx.attn_backend.forward(
-                    q_rope,
-                    None,
-                    None,
-                    self.attn,
-                    out_cache_loc,
-                    ctx.token_to_kv_pool,
-                    ForwardMode.DECODE,
-                    ctx.bs,
-                    save_kv_cache=False,
-                )
-            else:
-                attn_output = self.attn(
-                    q_rope,
-                    None,
-                    None,
-                    save_kv_cache=False,
-                    ctx=ctx,
-                    out_cache_loc=out_cache_loc,
-                )
+            attn_output = self.attn(
+                q_rope,
+                None,
+                None,
+                save_kv_cache=False,
+                ctx=ctx,
+                out_cache_loc=out_cache_loc,
+            )
         else:
             q, k = self.rotary_emb(positions, q, k)
             attn_output = self.attn(q, k, v, ctx=ctx, out_cache_loc=out_cache_loc)
-            if ctx.draft_first_step_reduce:
-                # KV written by self.attn above; slice attn_output so o_proj
-                # and the rest of the layer only run on the live rows.
-                attn_output = attn_output.index_select(0, ctx.gather_ids)
+
+        if ctx.draft_first_step_reduce:
+            # KV written above; slice attn_output so o_proj and the rest of
+            # the layer only run on the live rows.
+            attn_output = attn_output.index_select(0, ctx.gather_ids)
 
         output, _ = self.o_proj(attn_output)
         return output

--- a/python/tokenspeed/runtime/models/llama_eagle3.py
+++ b/python/tokenspeed/runtime/models/llama_eagle3.py
@@ -35,6 +35,7 @@ from transformers import LlamaConfig
 from tokenspeed.runtime.configs.utils import get_rope_theta
 from tokenspeed.runtime.distributed.mapping import Mapping
 from tokenspeed.runtime.execution.context import ForwardContext
+from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.activation import SiluAndMul
 from tokenspeed.runtime.layers.common import concat
 from tokenspeed.runtime.layers.layernorm import RMSNorm
@@ -186,22 +187,37 @@ class LlamaAttention(nn.Module):
                 output_q_rope=q_rope,
                 enable_pdl=pdl_enabled(),
             )
-            attn_output = self.attn(
-                q_rope,
-                None,
-                None,
-                save_kv_cache=False,
-                ctx=ctx,
-                out_cache_loc=out_cache_loc,
-            )
+            if ctx.draft_first_step_reduce:
+                # KV already written via fused_set_kv_buffer_arg above; slice Q
+                # to one query per request and route attn as decode.
+                q_rope = q_rope.index_select(0, ctx.gather_ids)
+                attn_output = ctx.attn_backend.forward(
+                    q_rope,
+                    None,
+                    None,
+                    self.attn,
+                    out_cache_loc,
+                    ctx.token_to_kv_pool,
+                    ForwardMode.DECODE,
+                    ctx.bs,
+                    save_kv_cache=False,
+                )
+            else:
+                attn_output = self.attn(
+                    q_rope,
+                    None,
+                    None,
+                    save_kv_cache=False,
+                    ctx=ctx,
+                    out_cache_loc=out_cache_loc,
+                )
         else:
             q, k = self.rotary_emb(positions, q, k)
             attn_output = self.attn(q, k, v, ctx=ctx, out_cache_loc=out_cache_loc)
-
-        if ctx.draft_first_step_reduce:
-            # KV written above; slice attn_output so o_proj and the rest of
-            # the layer only run on the live rows.
-            attn_output = attn_output.index_select(0, ctx.gather_ids)
+            if ctx.draft_first_step_reduce:
+                # KV written by self.attn above; slice attn_output so o_proj
+                # and the rest of the layer only run on the live rows.
+                attn_output = attn_output.index_select(0, ctx.gather_ids)
 
         output, _ = self.o_proj(attn_output)
         return output
@@ -566,6 +582,11 @@ class Eagle3LlamaModel(BaseTransformerModel):
 class LlamaForCausalLMEagle3(BaseCausalLM):
 
     model_cls = Eagle3LlamaModel
+
+    # Eagle3 catch-up pre-slices q to active row before attn; trim must pair.
+    # TODO: remove together with the base flag once Qwen NextN / DeepSeek V3
+    # NextN also pre-slice.
+    pre_attention_trim: bool = True
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary

fix #217 that broke spec-decode catch-up on Qwen NextN and DeepSeek V3 NextN:
- catch-up `seq_lens` trim in `drafter/eagle.py`
- Llama Eagle3 pre-attention q-slice (dispatch B) in `llama_eagle3.py`

The trim assumed q was sliced to 1 row before the kernel. Llama Eagle3 had the matching q-slice; Qwen NextN and DeepSeek V3 NextN didn't — trim alone left `q_len > cache_seqlens`, giving negative kernel positions, all-masked softmax, NaN, and `accept_rate=0`. 

Solution is to add a temp flag: pre_attention_trim. 

NOTICE: this flag would be removed in the future refactor PR once adding pre_attention_trim feature to both Qwen NextN and DeepSeek V3 NextN.

## Test Plan

- Qwen3.5-35B-A3B-NVFP4 + MTP local serve: no NaN in catch-up attention output, `accept_rate > 0` restored.
- Llama Eagle3 (MiniMax-M2.5-NVFP4 target + thoughtworks/MiniMax-M2.5-Eagle3 draft): serves without regression.