### PR TITLE
feat(mla): support custom tree masks in decode

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
@@ -433,6 +433,7 @@ class CuteDSLMLABackend(AttentionBackend):
         token_to_kv_pool,
         bs: int,
         save_kv_cache: bool = True,
+        spec_info=None,
         **kwargs,
     ) -> torch.Tensor:
         # q is whole Q [T, H, head_dim]; k is whole latent [T, 1, head_dim].
@@ -478,6 +479,16 @@ class CuteDSLMLABackend(AttentionBackend):
             query.device, layer.tp_q_head_num, self.kv_lora_rank, query.shape[1]
         )
 
+        custom_mask = kwargs.get("custom_mask")
+        cmask_off = kwargs.get("cmask_off")
+        if spec_info is not None:
+            if custom_mask is None:
+                custom_mask = getattr(spec_info, "custom_mask", None)
+            if cmask_off is None:
+                cmask_off = getattr(spec_info, "cmask_off", None)
+                if cmask_off is None:
+                    cmask_off = getattr(spec_info, "custom_mask_offsets", None)
+
         raw_out = tokenspeed_mla_decode(
             query=query,
             kv_cache=kv_cache,
@@ -489,6 +500,8 @@ class CuteDSLMLABackend(AttentionBackend):
             max_seq_len=metadata.max_seq_len_k,
             softmax_scale=softmax_scale,
             enable_pdl=pdl_enabled(),
+            custom_mask=custom_mask,
+            cmask_off=cmask_off,
         )
 
         return raw_out.view(-1, layer.tp_q_head_num * layer.v_head_dim)

--- a/tokenspeed-mla/python/tokenspeed_mla/mla_decode.py
+++ b/tokenspeed-mla/python/tokenspeed_mla/mla_decode.py
@@ -47,6 +47,39 @@ from tokenspeed_mla.utils import (
 )
 
 
+_DUMMY_TREE_MASK_CACHE: dict[tuple[str, int], tuple[torch.Tensor, torch.Tensor]] = {}
+_ZERO_CMASK_OFF_CACHE: dict[str, torch.Tensor] = {}
+
+
+def _get_dummy_tree_mask_tensors(
+    device: torch.device, batch_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Persistent placeholders for the FP8 tree-mask kernel ABI.
+
+    In non-tree mode the tree branch is compiled out and these tensors are not
+    read. They still need stable device addresses, and cmask_off must carry the
+    runtime batch shape expected by the FFI call.
+    """
+
+    key = (str(device), int(batch_size))
+    cached = _DUMMY_TREE_MASK_CACHE.get(key)
+    if cached is None:
+        cached = (
+            torch.empty(1, dtype=torch.int8, device=device),
+            torch.empty(batch_size, dtype=torch.int32, device=device),
+        )
+        _DUMMY_TREE_MASK_CACHE[key] = cached
+    return cached
+
+
+def _get_zero_cmask_off_tensor(device: torch.device) -> torch.Tensor:
+    cached = _ZERO_CMASK_OFF_CACHE.get(str(device))
+    if cached is None:
+        cached = torch.zeros(1, dtype=torch.int32, device=device)
+        _ZERO_CMASK_OFF_CACHE[str(device)] = cached
+    return cached
+
+
 @functools.cache
 def _get_split_kv_and_workspace_size(
     B: int,
@@ -129,12 +162,14 @@ def _get_compiled_mla_kernel(
     causal_mask: bool = True,
     num_heads: int = 128,
     seq_len_q: int = 1,
+    tree_mask_mode: bool = False,
     use_pdl: bool = False,
 ) -> Callable:
     """Compile and cache an MLA decode kernel.
 
     Returns a callable that accepts (q_latent, q_rope, c_latent, c_rope,
-    page_table, o, lse (None to skip), workspace, split_kv_scalar, cache_seqs,
+    page_table, [custom_mask, cmask_off, custom_mask_len for FP8], o,
+    lse (None to skip), workspace, split_kv_scalar, cache_seqs,
     block_split_kvs, softmax_scale_scalar, output_scale_scalar).
 
     All scalar arguments must be pre-wrapped as Int32/Float32.
@@ -174,6 +209,7 @@ def _get_compiled_mla_kernel(
         kernel_kwargs["is_causal"] = causal_mask
         kernel_kwargs["num_heads"] = num_heads
         kernel_kwargs["seq_len_q"] = seq_len_q
+        kernel_kwargs["tree_mask_mode"] = tree_mask_mode
     kernel_obj = KernelClass(**kernel_kwargs)
 
     # All dimensions as sym_int — this matches the original kernel's use of
@@ -233,6 +269,20 @@ def _get_compiled_mla_kernel(
         stride_order=(1, 0),
         assumed_align=4,
     )
+    if is_fp8:
+        # Flattened per-request tree mask, int8 view of bool values
+        # (nonzero=attend). cmask_off[b] points to request b's row-major
+        # [seq_len_q x K_b] block inside custom_mask.
+        custom_mask_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int8,
+            (cute.sym_int(),),
+            assumed_align=1,
+        )
+        cmask_off_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (sym_batch,),
+            assumed_align=4,
+        )
     # o: [batch_size, seq_len_q, num_heads, latent_dim] — contiguous
     o_fake = cute.runtime.make_fake_compact_tensor(
         cutlass_out_dtype,
@@ -268,23 +318,33 @@ def _get_compiled_mla_kernel(
 
     stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
-    compiled_kernel = cute.compile(
+    compile_args = [
         kernel_obj,
         q_latent_fake,
         q_rope_fake,
         c_latent_fake,
         c_rope_fake,
         page_table_fake,
-        o_fake,
-        None,  # lse (disabled)
-        workspace_fake,
-        Int32(1),  # split_kv placeholder
-        cache_seqs_fake,
-        block_split_kvs_fake,
-        Float32(1.0),  # softmax_scale placeholder
-        Float32(1.0),  # output_scale placeholder
-        stream_fake,
-        use_pdl,
+    ]
+    if is_fp8:
+        compile_args.extend([custom_mask_fake, cmask_off_fake, Int32(1)])
+    compile_args.extend(
+        [
+            o_fake,
+            None,  # lse (disabled)
+            workspace_fake,
+            Int32(1),  # split_kv placeholder
+            cache_seqs_fake,
+            block_split_kvs_fake,
+            Float32(1.0),  # softmax_scale placeholder
+            Float32(1.0),  # output_scale placeholder
+            stream_fake,
+            use_pdl,
+        ]
+    )
+
+    compiled_kernel = cute.compile(
+        *compile_args,
         options="--enable-tvm-ffi --opt-level 2",
     )
 
@@ -306,6 +366,8 @@ def tokenspeed_mla_decode(
     is_var_seq: bool = True,
     causal_mask: bool = True,
     enable_pdl: bool = False,
+    custom_mask: Optional[torch.Tensor] = None,
+    cmask_off: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """CuTe DSL MLA decode kernel for Blackwell SM100.
 
@@ -351,6 +413,15 @@ def tokenspeed_mla_decode(
         underlying CuTe DSL decode kernel. Tokenspeed callers wire this from
         ``pdl_enabled()`` so ``--disable-pdl`` propagates through to the
         kernel binary; ``use_pdl`` is part of the kernel cache key.
+    custom_mask : Optional[torch.Tensor]
+        Optional flattened FP8 tree attention mask. The mask is per request,
+        row-major [q_len x K_b], concatenated over the batch, with nonzero
+        values indicating that a query token can attend to a KV column. History
+        columns are normally all True and the last q_len columns carry the tree
+        ancestry. Supported on the FP8 kernel path.
+    cmask_off : Optional[torch.Tensor]
+        Optional int32 [B] base offsets into custom_mask. CUDA graph callers
+        should pass this explicitly for B > 1 to avoid deriving a fresh tensor.
 
     Returns
     -------
@@ -386,6 +457,44 @@ def tokenspeed_mla_decode(
 
     # Page table: [B, max_pages]: passed directly, kernel reinterprets.
     page_table_k = block_tables
+
+    # cache_seqs: per-batch sequence lengths (skip .to() if already int32)
+    cache_seqs = seq_lens if seq_lens.dtype == torch.int32 else seq_lens.to(torch.int32)
+
+    tree_mask_mode = custom_mask is not None
+    if tree_mask_mode:
+        if q_dtype != torch.float8_e4m3fn:
+            raise ValueError("custom_mask is currently supported only for FP8 MLA decode")
+        if custom_mask.device != query.device:
+            raise ValueError("custom_mask must be on the same device as query")
+        if custom_mask.dtype not in (torch.bool, torch.int8):
+            raise ValueError(
+                f"custom_mask must be torch.bool or torch.int8, got {custom_mask.dtype}"
+            )
+        if not custom_mask.is_contiguous():
+            raise ValueError("custom_mask must be contiguous")
+        cmask_k = custom_mask.view(torch.int8).view(-1)
+        if cmask_k.numel() == 0:
+            raise ValueError("custom_mask must not be empty")
+        if cmask_off is not None:
+            if cmask_off.device != query.device:
+                raise ValueError("cmask_off must be on the same device as query")
+            if cmask_off.dtype != torch.int32:
+                raise ValueError(f"cmask_off must be torch.int32, got {cmask_off.dtype}")
+            if not cmask_off.is_contiguous():
+                raise ValueError("cmask_off must be contiguous")
+            if cmask_off.numel() != B:
+                raise ValueError(
+                    f"cmask_off must have {B} entries, got {cmask_off.numel()}"
+                )
+            cmask_off_k = cmask_off
+        elif B == 1:
+            cmask_off_k = _get_zero_cmask_off_tensor(query.device)
+        else:
+            excl = torch.cumsum(cache_seqs, dim=0, dtype=torch.int32) - cache_seqs
+            cmask_off_k = (q_len * excl).to(torch.int32)
+    elif q_dtype == torch.float8_e4m3fn:
+        cmask_k, cmask_off_k = _get_dummy_tree_mask_tensors(query.device, B)
 
     # Runtime validation (int comparisons only, negligible overhead)
     if max_seq_len <= 0:
@@ -430,9 +539,6 @@ def tokenspeed_mla_decode(
             (B, q_len, H, kv_lora_rank), dtype=out_dtype, device=query.device
         )
 
-    # cache_seqs: per-batch sequence lengths (skip .to() if already int32)
-    cache_seqs = seq_lens if seq_lens.dtype == torch.int32 else seq_lens.to(torch.int32)
-
     is_var_split_kv = False
     block_split_kvs = None
     skip_correction_threshold = 0.0
@@ -470,6 +576,7 @@ def tokenspeed_mla_decode(
         causal_mask=causal_mask,
         num_heads=H,
         seq_len_q=q_len,
+        tree_mask_mode=tree_mask_mode,
         use_pdl=enable_pdl,
     )
 
@@ -480,21 +587,41 @@ def tokenspeed_mla_decode(
     import tvm_ffi
 
     with tvm_ffi.use_torch_stream():
-        compiled_kernel(
-            q_latent_k,
-            q_rope_k,
-            c_latent_k,
-            c_rope_k,
-            page_table_k,
-            o_k,
-            None,  # lse (disabled)
-            workspace_bytes,
-            Int32(split_kv),
-            cache_seqs,
-            block_split_kvs,
-            Float32(softmax_scale),
-            Float32(output_scale),
-        )
+        if q_dtype == torch.float8_e4m3fn:
+            compiled_kernel(
+                q_latent_k,
+                q_rope_k,
+                c_latent_k,
+                c_rope_k,
+                page_table_k,
+                cmask_k,
+                cmask_off_k,
+                Int32(cmask_k.numel()),
+                o_k,
+                None,  # lse (disabled)
+                workspace_bytes,
+                Int32(split_kv),
+                cache_seqs,
+                block_split_kvs,
+                Float32(softmax_scale),
+                Float32(output_scale),
+            )
+        else:
+            compiled_kernel(
+                q_latent_k,
+                q_rope_k,
+                c_latent_k,
+                c_rope_k,
+                page_table_k,
+                o_k,
+                None,  # lse (disabled)
+                workspace_bytes,
+                Int32(split_kv),
+                cache_seqs,
+                block_split_kvs,
+                Float32(softmax_scale),
+                Float32(output_scale),
+            )
 
     # If out was provided, kernel already wrote into it — return directly.
     if out is not None:

--- a/tokenspeed-mla/python/tokenspeed_mla/mla_decode_fp8.py
+++ b/tokenspeed-mla/python/tokenspeed_mla/mla_decode_fp8.py
@@ -173,6 +173,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         is_causal: bool = False,
         num_heads: int = 128,
         seq_len_q: int = 1,
+        tree_mask_mode: bool = False,
     ):
         """Initializes the configuration for a Blackwell Multi-Head Latent Attention (MLA) kernel.
 
@@ -218,6 +219,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         # row r → (q_tok_in_group = r // num_heads, head = r % num_heads).
         self.num_heads = num_heads
         self.seq_len_q = seq_len_q
+        # In tree-mask mode, the causal tail predicate is replaced by a direct
+        # lookup into a flattened per-request mask supplied by the caller.
+        self.tree_mask_mode = tree_mask_mode
         self.cluster_shape_mnk = (2, 1, 1)
         self.use_2cta_instrs = True
         # When using 2 CTAs with m=128: warps 0-1 handle accumulation for first half [0, n/2),
@@ -323,6 +327,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         c_latent: cute.Tensor,
         c_rope: cute.Tensor,
         page_table: cute.Tensor,
+        custom_mask: cute.Tensor,
+        cmask_off: cute.Tensor,
+        custom_mask_len: cutlass.Int32,
         o: cute.Tensor,
         lse: Optional[cute.Tensor],
         workspace: cute.Tensor,
@@ -354,6 +361,12 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         :type c_rope: cute.Tensor
         :param page_table: The page table tensor with shape [batch_size, page_count] (contiguous)
         :type page_table: cute.Tensor
+        :param custom_mask: Flattened per-request tree mask, int8/bool values where nonzero means attend
+        :type custom_mask: cute.Tensor
+        :param cmask_off: Per-request int32 base offsets into custom_mask
+        :type cmask_off: cute.Tensor
+        :param custom_mask_len: Number of flattened int8 entries in custom_mask
+        :type custom_mask_len: cutlass.Int32
         :param o: The output tensor with shape [batch_size, seq_len_q, num_head, latent_dim] (contiguous)
         :type o: cute.Tensor
         :param lse: The LSE tensor with shape [batch_size, seq_len_q, num_head] (contiguous)
@@ -818,6 +831,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             tma_atom_c_latent_transpose,
             tma_tensor_c_latent_transpose,
             page_table,
+            custom_mask,
+            cmask_off,
+            custom_mask_len,
             o,
             lse if not self.skip_lse else None,
             acc_o,
@@ -923,6 +939,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         tma_atom_c_latent_transpose: Optional[cute.CopyAtom],
         mCLT: cute.Tensor,
         mPT: cute.Tensor,
+        mCmask: cute.Tensor,
+        mCmaskOff: cute.Tensor,
+        custom_mask_len: cutlass.Int32,
         mO: Optional[cute.Tensor],
         mLSE: Optional[cute.Tensor],
         mAccO: Optional[cute.Tensor],
@@ -1400,6 +1419,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         mAccO=mAccO,
                         mO=mO,
                         K=cache_seqs[blk_coord[2]],
+                        cmask=mCmask,
+                        cmask_off=mCmaskOff,
+                        cmask_len=custom_mask_len,
                         L=mCL.shape[1],
                         tmem_ptr=tmem_ptr,
                         tidx=tidx,
@@ -2413,12 +2435,12 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         correction_factor = self.acc_dtype(1)
         common_params.p_cor_pipeline.producer_acquire(p_cor_producer_state)
 
-        # Number of tiles from the global-K end that may contain causal-masked
-        # positions. For causal, min k_bound = K - (S_q-1), which can span up
-        # to ceil((S_q-1)/tile_N)+1 tiles (tile-boundary-crossing case).
-        # Non-causal only needs the final K-bound tile.
+        # Number of tiles from the global-K end that may contain masked
+        # positions. Causal and tree masks both touch the last S_q KV columns,
+        # which can span up to ceil((S_q-1)/tile_N)+1 tiles in boundary cases.
+        # Non-causal dense attention only needs the final K-bound tile.
         tile_n = self.mma_qk_tiler[1]
-        if cutlass.const_expr(self.is_causal):
+        if cutlass.const_expr(self.is_causal or self.tree_mask_mode):
             mask_tile_count = (self.seq_len_q - 1 + tile_n - 1) // tile_n + 1
         else:
             mask_tile_count = 1
@@ -2755,7 +2777,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             mma_s_consumer_state.advance()
             for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
                 if apply_mask:
-                    if cutlass.const_expr(self.is_causal):
+                    if cutlass.const_expr(self.tree_mask_mode):
                         if cutlass.const_expr(self.fold_sq_factor > 1):
                             q_tok = (
                                 common_params.blk_coord[1] * self.fold_sq_factor
@@ -2767,17 +2789,63 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                             )
                         else:
                             q_tok = common_params.blk_coord[1]
-                        k_bound = common_params.K - (self.seq_len_q - 1) + q_tok
-                    else:
-                        k_bound = common_params.K
-                    tTR_rAcc[i] = (
-                        tTR_rAcc[i]
-                        if cute.elem_less(
-                            tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index,
-                            k_bound,
+                        kcol = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
+                        # custom_mask is row-major [seq_len_q x K] per request
+                        # (nonzero=attend). Padding columns and malformed
+                        # offsets must not drive an out-of-bounds mask read.
+                        within_kv = cute.elem_less(kcol, common_params.K)
+                        kcol_in = (
+                            kcol
+                            if within_kv
+                            else cutlass.Int32(common_params.K - 1)
                         )
-                        else self.acc_dtype(-1.0e6)
-                    )
+                        cm_idx = (
+                            common_params.cmask_off[common_params.blk_coord[2]]
+                            + q_tok * common_params.K
+                            + kcol_in
+                        )
+                        if within_kv:
+                            if cute.elem_less(cutlass.Int32(-1), cm_idx):
+                                if cute.elem_less(cm_idx, common_params.cmask_len):
+                                    cm_keep = cute.elem_less(
+                                        cutlass.Int32(0),
+                                        cutlass.Int32(common_params.cmask[cm_idx]),
+                                    )
+                                    tTR_rAcc[i] = (
+                                        tTR_rAcc[i]
+                                        if cm_keep
+                                        else self.acc_dtype(-1.0e6)
+                                    )
+                                else:
+                                    tTR_rAcc[i] = self.acc_dtype(-1.0e6)
+                            else:
+                                tTR_rAcc[i] = self.acc_dtype(-1.0e6)
+                        else:
+                            tTR_rAcc[i] = self.acc_dtype(-1.0e6)
+                    else:
+                        if cutlass.const_expr(self.is_causal):
+                            if cutlass.const_expr(self.fold_sq_factor > 1):
+                                q_tok = (
+                                    common_params.blk_coord[1] * self.fold_sq_factor
+                                    + (
+                                        tTR_tS[i][0]
+                                        + common_params.blk_coord[0] * cta_m_rows
+                                    )
+                                    // self.num_heads
+                                )
+                            else:
+                                q_tok = common_params.blk_coord[1]
+                            k_bound = common_params.K - (self.seq_len_q - 1) + q_tok
+                        else:
+                            k_bound = common_params.K
+                        tTR_rAcc[i] = (
+                            tTR_rAcc[i]
+                            if cute.elem_less(
+                                tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index,
+                                k_bound,
+                            )
+                            else self.acc_dtype(-1.0e6)
+                        )
             # reduction for row_max
             row_max_new = tTR_rAcc.load().reduce(cute.ReductionOp.MAX, row_max_new, 0)
         elif cutlass.const_expr(arch >= Arch.sm_103 and arch <= Arch.sm_103f):
@@ -2808,7 +2876,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             tTR_rAcc = cute.make_tensor(tTR_rAcc_red.iterator, tTR_rAcc.layout)
             if apply_mask:
                 for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
-                    if cutlass.const_expr(self.is_causal):
+                    if cutlass.const_expr(self.tree_mask_mode):
                         if cutlass.const_expr(self.fold_sq_factor > 1):
                             q_tok = (
                                 common_params.blk_coord[1] * self.fold_sq_factor
@@ -2820,20 +2888,66 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                             )
                         else:
                             q_tok = common_params.blk_coord[1]
-                        # effective K(row) = K - (S_q - 1) + q_tok; equivalent to
-                        # K - (S_q - 1 - q_tok), written to avoid Python int/CuTe
-                        # Int32 __rsub__ quirks when self.seq_len_q==1.
-                        k_bound = common_params.K - (self.seq_len_q - 1) + q_tok
-                    else:
-                        k_bound = common_params.K
-                    tTR_rAcc[i] = (
-                        tTR_rAcc[i]
-                        if cute.elem_less(
-                            tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index,
-                            k_bound,
+                        kcol = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
+                        # custom_mask is row-major [seq_len_q x K] per request
+                        # (nonzero=attend). Padding columns and malformed
+                        # offsets must not drive an out-of-bounds mask read.
+                        within_kv = cute.elem_less(kcol, common_params.K)
+                        kcol_in = (
+                            kcol
+                            if within_kv
+                            else cutlass.Int32(common_params.K - 1)
                         )
-                        else self.acc_dtype(-1.0e6)
-                    )
+                        cm_idx = (
+                            common_params.cmask_off[common_params.blk_coord[2]]
+                            + q_tok * common_params.K
+                            + kcol_in
+                        )
+                        if within_kv:
+                            if cute.elem_less(cutlass.Int32(-1), cm_idx):
+                                if cute.elem_less(cm_idx, common_params.cmask_len):
+                                    cm_keep = cute.elem_less(
+                                        cutlass.Int32(0),
+                                        cutlass.Int32(common_params.cmask[cm_idx]),
+                                    )
+                                    tTR_rAcc[i] = (
+                                        tTR_rAcc[i]
+                                        if cm_keep
+                                        else self.acc_dtype(-1.0e6)
+                                    )
+                                else:
+                                    tTR_rAcc[i] = self.acc_dtype(-1.0e6)
+                            else:
+                                tTR_rAcc[i] = self.acc_dtype(-1.0e6)
+                        else:
+                            tTR_rAcc[i] = self.acc_dtype(-1.0e6)
+                    else:
+                        if cutlass.const_expr(self.is_causal):
+                            if cutlass.const_expr(self.fold_sq_factor > 1):
+                                q_tok = (
+                                    common_params.blk_coord[1] * self.fold_sq_factor
+                                    + (
+                                        tTR_tS[i][0]
+                                        + common_params.blk_coord[0] * cta_m_rows
+                                    )
+                                    // self.num_heads
+                                )
+                            else:
+                                q_tok = common_params.blk_coord[1]
+                            # effective K(row) = K - (S_q - 1) + q_tok; equivalent to
+                            # K - (S_q - 1 - q_tok), written to avoid Python int/CuTe
+                            # Int32 __rsub__ quirks when self.seq_len_q==1.
+                            k_bound = common_params.K - (self.seq_len_q - 1) + q_tok
+                        else:
+                            k_bound = common_params.K
+                        tTR_rAcc[i] = (
+                            tTR_rAcc[i]
+                            if cute.elem_less(
+                                tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index,
+                                k_bound,
+                            )
+                            else self.acc_dtype(-1.0e6)
+                        )
                 # reduction for row_max after manual masking
                 row_max_new = tTR_rAcc.load().reduce(
                     cute.ReductionOp.MAX, row_max_new, 0
@@ -4162,6 +4276,14 @@ def run(
     workspace, workspace_torch = create_workspace(
         num_heads_eff, seq_len_q_eff, latent_dim, batch_size, split_kv, acc_dtype
     )
+    dummy_custom_mask_torch = torch.empty(1, dtype=torch.int8, device="cuda")
+    dummy_custom_mask = from_dlpack(
+        dummy_custom_mask_torch, assumed_align=1
+    ).mark_layout_dynamic()
+    dummy_cmask_off_torch = torch.zeros(batch_size, dtype=torch.int32, device="cuda")
+    dummy_cmask_off = from_dlpack(
+        dummy_cmask_off_torch, assumed_align=16
+    ).mark_layout_dynamic()
 
     mla = BlackwellMultiHeadLatentAttentionForwardFP8(
         acc_dtype,
@@ -4193,6 +4315,9 @@ def run(
         c_latent,
         c_rope,
         page_table,
+        dummy_custom_mask,
+        dummy_cmask_off,
+        cutlass.Int32(1),
         o,
         lse,
         workspace,
@@ -4306,6 +4431,9 @@ def run(
             c_latent,
             c_rope,
             page_table,
+            dummy_custom_mask,
+            dummy_cmask_off,
+            cutlass.Int32(1),
             o,
             lse,
             workspace,
@@ -4444,6 +4572,9 @@ def run(
             c_latent,
             c_rope,
             page_table,
+            dummy_custom_mask,
+            dummy_cmask_off,
+            cutlass.Int32(1),
             o,
             lse,
             workspace,

--- a/tokenspeed-mla/test/microbench_tree_decode.py
+++ b/tokenspeed-mla/test/microbench_tree_decode.py
@@ -1,0 +1,244 @@
+# Copyright (c) 2026 LightSeek Foundation
+
+"""Manual GB200 correctness/perf harness for FP8 MLA tree-mask decode.
+
+This is intentionally not a default pytest: it compiles and runs the Blackwell
+CuTe MLA kernel. It validates the optional custom_mask path against an
+independent absorbed-MLA PyTorch reference and includes non-tile-aligned K plus
+batched offsets.
+
+Example:
+    python tokenspeed-mla/test/microbench_tree_decode.py --iters 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+
+import torch
+from tokenspeed_mla import tokenspeed_mla_decode
+
+
+DEV = "cuda"
+FP8 = torch.float8_e4m3fn
+KV_LORA = 512
+ROPE = 64
+D_QK = KV_LORA + ROPE
+H = 128
+PAGE = 64
+
+
+def build_inputs(batch: int, q_len: int, seq_k: int, seed: int):
+    generator = torch.Generator(device=DEV).manual_seed(seed)
+    query = (
+        torch.randn(batch, q_len, H, D_QK, device=DEV, generator=generator) * 0.3
+    ).to(FP8)
+    pages_per_request = (seq_k + PAGE - 1) // PAGE
+    page_count = pages_per_request * batch
+    kv_cache = (
+        torch.randn(page_count, PAGE, D_QK, device=DEV, generator=generator) * 0.3
+    ).to(FP8)
+    block_tables = torch.arange(page_count, device=DEV, dtype=torch.int32).view(
+        batch, pages_per_request
+    )
+    seq_lens = torch.full((batch,), seq_k, device=DEV, dtype=torch.int32)
+    workspace = torch.empty(1 << 29, dtype=torch.int8, device=DEV)
+    return query, kv_cache, block_tables, seq_lens, workspace
+
+
+def chain_ancestor(batch: int, q_len: int) -> torch.Tensor:
+    ancestor = torch.tril(torch.ones(q_len, q_len, dtype=torch.bool))
+    return ancestor.unsqueeze(0).expand(batch, q_len, q_len).contiguous()
+
+
+def random_tree_ancestor(batch: int, q_len: int, seed: int) -> torch.Tensor:
+    generator = torch.Generator().manual_seed(seed)
+    ancestor = torch.zeros(batch, q_len, q_len, dtype=torch.bool)
+    for b in range(batch):
+        parent = [-1]
+        for i in range(1, q_len):
+            parent.append(int(torch.randint(0, i, (1,), generator=generator)))
+        for qi in range(q_len):
+            j = qi
+            while j != -1:
+                ancestor[b, qi, j] = True
+                j = parent[j]
+    return ancestor
+
+
+def build_custom_mask(ancestor: torch.Tensor, seq_lens: torch.Tensor):
+    batch, q_len, _ = ancestor.shape
+    offsets = torch.empty(batch, dtype=torch.int32, device=DEV)
+    parts = []
+    offset = 0
+    for b in range(batch):
+        K = int(seq_lens[b])
+        hist = K - q_len
+        mask = torch.zeros(q_len, K, dtype=torch.bool, device=DEV)
+        mask[:, :hist] = True
+        mask[:, hist:K] = ancestor[b].to(DEV)
+        offsets[b] = offset
+        parts.append(mask.reshape(-1))
+        offset += q_len * K
+    return torch.cat(parts).contiguous(), offsets
+
+
+def call_kernel(
+    query,
+    kv_cache,
+    block_tables,
+    seq_lens,
+    workspace,
+    seq_k,
+    *,
+    causal,
+    custom_mask=None,
+    cmask_off=None,
+):
+    return tokenspeed_mla_decode(
+        query=query,
+        kv_cache=kv_cache,
+        workspace_buffer=workspace,
+        kv_lora_rank=KV_LORA,
+        qk_rope_head_dim=ROPE,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        max_seq_len=seq_k,
+        softmax_scale=1.0 / math.sqrt(D_QK),
+        causal_mask=causal,
+        custom_mask=custom_mask,
+        cmask_off=cmask_off,
+    )
+
+
+def absorbed_ref(query, kv_cache, block_tables, seq_lens, ancestor):
+    batch, q_len = query.shape[:2]
+    scale = 1.0 / math.sqrt(D_QK)
+    out = torch.zeros(batch, q_len, H, KV_LORA, device=DEV, dtype=torch.float32)
+    qf = query.float()
+    for b in range(batch):
+        K = int(seq_lens[b])
+        hist = K - q_len
+        kv = kv_cache[block_tables[b]].reshape(-1, D_QK).float()[:K]
+        for qi in range(q_len):
+            valid = torch.zeros(K, dtype=torch.bool, device=DEV)
+            valid[:hist] = True
+            valid[hist:K] = ancestor[b, qi].to(DEV)
+            scores = (qf[b, qi] @ kv.t()) * scale
+            probs = torch.softmax(
+                scores.masked_fill(~valid.view(1, -1), float("-inf")), dim=-1
+            )
+            out[b, qi] = probs @ kv[:, :KV_LORA]
+    return out
+
+
+def measure_ms(fn, warmup: int, iters: int):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters
+
+
+def parse_cases(raw: str):
+    cases = []
+    for case in raw.split(";"):
+        if not case.strip():
+            continue
+        batch, q_len, seq_k = [int(part.strip()) for part in case.split(",")]
+        if batch <= 0 or q_len <= 0 or seq_k < q_len:
+            raise ValueError(f"invalid case {case!r}")
+        cases.append((batch, q_len, seq_k))
+    return cases
+
+
+def run_case(batch: int, q_len: int, seq_k: int, args) -> bool:
+    query, kv_cache, block_tables, seq_lens, workspace = build_inputs(
+        batch, q_len, seq_k, seed=batch * 1000 + q_len * 100 + seq_k
+    )
+    passed = True
+    for name, ancestor_cpu in (
+        ("chain", chain_ancestor(batch, q_len)),
+        ("random", random_tree_ancestor(batch, q_len, seed=seq_k)),
+    ):
+        custom_mask, cmask_off = build_custom_mask(ancestor_cpu, seq_lens)
+        actual = call_kernel(
+            query,
+            kv_cache,
+            block_tables,
+            seq_lens,
+            workspace,
+            seq_k,
+            causal=False,
+            custom_mask=custom_mask,
+            cmask_off=cmask_off,
+        ).float()
+        expected = absorbed_ref(query, kv_cache, block_tables, seq_lens, ancestor_cpu)
+        max_abs = (actual - expected).abs().max().item()
+        ok = max_abs < args.tolerance
+        print(
+            f"[B={batch} q={q_len} K={seq_k}] {name} tree vs ref "
+            f"max_abs={max_abs:.3e} {'OK' if ok else 'FAIL'}"
+        )
+        passed = passed and ok
+
+    if args.iters > 0:
+        random_mask, random_off = build_custom_mask(
+            random_tree_ancestor(batch, q_len, seed=seq_k), seq_lens
+        )
+        causal_ms = measure_ms(
+            lambda: call_kernel(
+                query, kv_cache, block_tables, seq_lens, workspace, seq_k, causal=True
+            ),
+            args.warmup,
+            args.iters,
+        )
+        tree_ms = measure_ms(
+            lambda: call_kernel(
+                query,
+                kv_cache,
+                block_tables,
+                seq_lens,
+                workspace,
+                seq_k,
+                causal=False,
+                custom_mask=random_mask,
+                cmask_off=random_off,
+            ),
+            args.warmup,
+            args.iters,
+        )
+        print(f"            timing causal={causal_ms:.4f} ms tree={tree_ms:.4f} ms")
+
+    return passed
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument(
+        "--cases",
+        default="1,4,256;1,8,250;1,8,300;1,16,250;2,8,250",
+        help="Semicolon-separated B,q_len,seq_k cases.",
+    )
+    parser.add_argument("--iters", type=int, default=0)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--tolerance", type=float, default=0.2)
+    args = parser.parse_args()
+
+    torch.cuda.set_device(args.device)
+    all_passed = True
+    for batch, q_len, seq_k in parse_cases(args.cases):
+        all_passed = run_case(batch, q_len, seq_k, args) and all_passed
+    raise SystemExit(0 if all_passed else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tokenspeed-mla/test/test_tree_mask_decode.py
+++ b/tokenspeed-mla/test/test_tree_mask_decode.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 LightSeek Foundation
+
+from __future__ import annotations
+
+import torch
+
+
+def build_ancestor_mask(parent: list[int]) -> torch.Tensor:
+    """ancestor[qi, j] is True iff new-token j is on qi's ancestry path."""
+
+    q_len = len(parent)
+    ancestor = torch.zeros(q_len, q_len, dtype=torch.bool)
+    for qi in range(q_len):
+        j = qi
+        seen = 0
+        while j != -1:
+            ancestor[qi, j] = True
+            j = parent[j]
+            seen += 1
+            assert seen <= q_len, f"cycle in parent array: {parent}"
+    return ancestor
+
+
+def chain_parent(q_len: int) -> list[int]:
+    return [i - 1 for i in range(q_len)]
+
+
+def build_custom_mask(
+    ancestor: torch.Tensor, seq_lens: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Flatten per-request [q_len x K_b] masks and return int32 offsets.
+
+    History columns are fully visible. The last q_len columns carry the
+    tree-ancestor mask for the drafted tokens.
+    """
+
+    batch, q_len, q_len_2 = ancestor.shape
+    assert q_len == q_len_2
+    offsets = torch.empty(batch, dtype=torch.int32)
+    flat_masks = []
+    offset = 0
+    for b in range(batch):
+        offsets[b] = offset
+        K = int(seq_lens[b])
+        hist = K - q_len
+        assert hist >= 0
+        mask = torch.zeros(q_len, K, dtype=torch.bool)
+        mask[:, :hist] = True
+        mask[:, hist:K] = ancestor[b]
+        flat_masks.append(mask.reshape(-1))
+        offset += q_len * K
+    return torch.cat(flat_masks).contiguous(), offsets
+
+
+def test_chain_tree_mask_matches_causal_layout():
+    for q_len in (1, 2, 4, 8, 16):
+        ancestor = build_ancestor_mask(chain_parent(q_len))
+        causal = torch.tril(torch.ones(q_len, q_len, dtype=torch.bool))
+        assert torch.equal(ancestor, causal)
+
+
+def test_custom_mask_layout_and_offsets_for_variable_batch():
+    ancestor = torch.stack(
+        [
+            build_ancestor_mask([-1, 0, 0, 2]),
+            build_ancestor_mask([-1, 0, 1, 1]),
+        ]
+    )
+    seq_lens = torch.tensor([10, 13], dtype=torch.int32)
+
+    custom_mask, offsets = build_custom_mask(ancestor, seq_lens)
+
+    assert offsets.tolist() == [0, 40]
+    first = custom_mask[offsets[0] : offsets[1]].view(4, 10)
+    second = custom_mask[offsets[1] :].view(4, 13)
+
+    assert first[3].tolist() == [True] * 6 + [True, False, True, True]
+    assert second[2].tolist() == [True] * 9 + [True, True, True, False]
+
+
+def test_custom_mask_rejects_cycles_in_tree_parent():
+    try:
+        build_ancestor_mask([1, 0])
+    except AssertionError as exc:
+        assert "cycle" in str(exc)
+    else:
+        raise AssertionError("expected cycle detection to fail")


### PR DESCRIPTION
## Summary

Adds optional FP8 custom tree-mask support to TokenSpeed MLA decode. The new path lets callers provide a flattened per-request `custom_mask` plus `cmask_off` offsets so tree-style speculative verification can use the TokenSpeed MLA kernel instead of falling back to dense/causal-only behavior.

What changed:
- Add `custom_mask` / `cmask_off` kwargs to `tokenspeed_mla_decode`.
- Extend the FP8 CuTe MLA decode ABI with mask pointer, offset pointer, and mask length.
- Apply the custom mask in the softmax tail region, including folded `S_q` handling and non-tile-aligned K.
- Keep FP16/BF16 on the old call signature and keep FP8 non-tree behavior on stable dummy mask tensors.
- Forward mask kwargs through the runtime `tokenspeed_mla` attention backend.
- Add a CPU mask-layout oracle and a manual GB200 kernel-vs-reference harness.

## Validation

- Extracted from GB200 Kimi EAGLE tree validation work. The TokenSpeed MLA tree-mask path was deployed in the integrated inference stack and exercised through server startup and decode serving without runtime errors or crashes.
- The included `tokenspeed-mla/test/microbench_tree_decode.py` harness provides a reproducible GB200 check against an independent absorbed-MLA PyTorch reference, including non-tile-aligned K and batched mask-offset cases.
- Static checks:
  - `python3 -m py_compile tokenspeed-mla/python/tokenspeed_mla/mla_decode.py tokenspeed-mla/python/tokenspeed_mla/mla_decode_fp8.py python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py tokenspeed-mla/test/test_tree_mask_decode.py tokenspeed-mla/test/microbench_tree_decode.py`
  - `git diff --check`

## Review

Reviewed with an external collaborative code reviewer before pushing. Initial findings were fixed:
- Added kernel-side bounds guarding with `custom_mask_len` to prevent malformed offsets from causing out-of-bounds mask reads.
- Forwarded `custom_mask` / `cmask_off` through the runtime TokenSpeed MLA backend.

Second review returned `LGTM`.
