### PR TITLE
perf(deepseek-v4): decode attention optimizations

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -1864,6 +1864,12 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             metadata_paged,
             metadata_base_offsets,
         )
+        prior_metadata = self._cuda_graph_metadata.get(bs)
+        prior_slot_mappings = (
+            prior_metadata.cache.decode_compressed_slot_mappings
+            if prior_metadata is not None
+            else {}
+        )
         cache_metadata = DeepseekV4CacheMetadata(
             page_size=self.page_size,
             block_table=self._cuda_graph_block_table[:bs, : self.max_num_pages],
@@ -1875,8 +1881,9 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             compressor_state_base_logical_pages=compressor_state_base,
             indexer_state_block_table=indexer_state_block_table,
             indexer_state_base_logical_page=indexer_state_base,
+            decode_compressed_slot_mappings=prior_slot_mappings,
         )
-        metadata = self._cuda_graph_metadata.get(bs)
+        metadata = prior_metadata
         if metadata is None:
             metadata = DeepseekV4ForwardMetadata(
                 req_pool_indices=self._cuda_graph_req_pool_indices[:bs],

--- a/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
+++ b/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
@@ -168,27 +168,6 @@ def _apply_gptj_rope_tail_rows(
     return out
 
 
-def _apply_inverse_gptj_rope_tail(
-    x: torch.Tensor,
-    positions: torch.Tensor,
-    cos_sin_cache: torch.Tensor,
-    rope_dim: int,
-) -> torch.Tensor:
-    out = x.float().clone()
-    half_rope = rope_dim // 2
-    nope_dim = x.shape[-1] - rope_dim
-    cos = cos_sin_cache[positions.long(), :half_rope].float()
-    sin = cos_sin_cache[positions.long(), half_rope:rope_dim].float()
-    even = out[..., nope_dim::2].clone()
-    odd = out[..., nope_dim + 1 :: 2].clone()
-    while cos.ndim < even.ndim:
-        cos = cos.unsqueeze(1)
-        sin = sin.unsqueeze(1)
-    out[..., nope_dim::2] = even * cos + odd * sin
-    out[..., nope_dim + 1 :: 2] = odd * cos - even * sin
-    return out
-
-
 def _fp8_e4m3_pow2_bytes(block: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     scale = max(float(block.detach().abs().max()) / DEEPSEEK_V4_FP8_MAX, 1.0e-10)
     scale = 2.0 ** math.ceil(math.log2(scale))
@@ -222,36 +201,6 @@ def _deepseek_v4_hadamard_rotate(x: torch.Tensor) -> torch.Tensor:
         scale=shape[-1] ** -0.5,
     )
     return rotated.reshape(shape)
-
-
-def deepseek_v4_inv_rope_grouped(
-    o: torch.Tensor,
-    positions: torch.Tensor,
-    cos_sin_cache: torch.Tensor,
-    n_groups: int,
-    heads_per_group: int,
-    nope_dim: int | None = None,
-    rope_dim: int | None = None,
-) -> torch.Tensor:
-    """Inverse-RoPE and group V4 attention output without FP8 activation rounding."""
-
-    if o.dim() != 3:
-        raise ValueError(f"o must be [tokens, heads, dim], got {tuple(o.shape)}")
-    if rope_dim is None:
-        rope_dim = int(cos_sin_cache.shape[-1])
-    if nope_dim is None:
-        nope_dim = int(o.shape[2]) - rope_dim
-    if o.shape[1] != n_groups * heads_per_group:
-        raise ValueError(
-            f"heads={o.shape[1]} does not match n_groups={n_groups} "
-            f"* heads_per_group={heads_per_group}"
-        )
-    if o.shape[2] != nope_dim + rope_dim:
-        raise ValueError(f"head dim must be {nope_dim + rope_dim}, got {o.shape[2]}")
-
-    inv = _apply_inverse_gptj_rope_tail(o, positions, cos_sin_cache, rope_dim)
-    grouped = inv.reshape(o.shape[0], n_groups, heads_per_group * o.shape[2])
-    return grouped.to(o.dtype)
 
 
 def dequantize_deepseek_v4_fp8_ds_mla_cache(

--- a/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
+++ b/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
@@ -47,6 +47,9 @@ from tokenspeed_kernel.ops.attention.triton.deepseek_v4 import (
     deepseek_v4_fused_indexer_q_rope_hadamard_mxfp4 as _triton_fused_indexer_q_rope_hadamard_mxfp4,
 )
 from tokenspeed_kernel.ops.attention.triton.deepseek_v4 import (
+    deepseek_v4_fused_inv_rope_fp8_quant,
+)
+from tokenspeed_kernel.ops.attention.triton.deepseek_v4 import (
     deepseek_v4_fused_sparse_compress_cache_insert as _triton_fused_sparse_compress_cache_insert,
 )
 from tokenspeed_kernel.ops.attention.triton.deepseek_v4 import (

--- a/python/tokenspeed/runtime/layers/dense/fp8.py
+++ b/python/tokenspeed/runtime/layers/dense/fp8.py
@@ -213,31 +213,27 @@ class Fp8LinearMethod(LinearMethodBase):
                 N, K = layer.weight.shape
                 block_n, block_k = self.quant_config.weight_block_size
                 if is_bmm:
-                    # Grouped (batched) projection, e.g. V4 attention wo_a whose
-                    # weight is [groups * n, K] and is consumed per group as
-                    # [n, K]. Transform each group's block scale into the
-                    # deep_gemm MN-major layout so the per-group GEMM can run
-                    # native FP8 instead of dequantizing the weight to FP32.
-                    # Keep the per-group scales as a list (not a stacked tensor):
-                    # stacking re-lays them out row-major and breaks deep_gemm's
-                    # sf.stride(-2) == 1 requirement. weight_scale_inv is left
-                    # untouched so the dequant fallback still works.
+                    # Grouped (batched) projection (V4 attention wo_a, weight
+                    # [groups * n, K], consumed per group as [n, K]). Transform
+                    # the block scale into the deep_gemm MN-major layout with the
+                    # group axis so deep_gemm.fp8_einsum("bhr,hdr->bhd") runs the
+                    # output projection as one native FP8 GEMM (no FP32 dequant).
+                    # recipe is (1, block_n, block_k) at load; the runtime einsum
+                    # uses (1, 1, block_n) on SM100.
                     g = layer.bmm_batch_size
                     n = N // g
                     if n % block_n == 0 and K % block_k == 0:
                         sf = _ceil_to_ue8m0(layer.weight_scale_inv.data).view(
                             g, n // block_n, K // block_k
                         )
-                        layer._deep_gemm_bmm_weight_scales = [
-                            _transform_sf(
-                                sf=sf[i],
-                                mn=n,
-                                k=K,
-                                recipe=(1, block_n, block_k),
-                                is_sfa=False,
-                            )
-                            for i in range(g)
-                        ]
+                        layer.weight_scale_inv.data = _transform_sf(
+                            sf=sf,
+                            mn=n,
+                            k=K,
+                            recipe=(1, block_n, block_k),
+                            num_groups=g,
+                            is_sfa=False,
+                        )
                         layer._deep_gemm_block_size = [block_n, block_k]
                         layer._use_deep_gemm_fp8 = True
                 elif N % 64 == 0 and K % 128 == 0:

--- a/python/tokenspeed/runtime/layers/dense/fp8.py
+++ b/python/tokenspeed/runtime/layers/dense/fp8.py
@@ -209,15 +209,38 @@ class Fp8LinearMethod(LinearMethodBase):
             layer._use_deep_gemm_fp8 = False
             is_bmm = getattr(layer, "is_bmm", False)
             is_ue8m0 = getattr(self.quant_config, "scale_fmt", None) == "ue8m0"
-            if (
-                _transform_sf is not None
-                and _ceil_to_ue8m0 is not None
-                and not is_bmm
-                and is_ue8m0
-            ):
+            if _transform_sf is not None and _ceil_to_ue8m0 is not None and is_ue8m0:
                 N, K = layer.weight.shape
                 block_n, block_k = self.quant_config.weight_block_size
-                if N % 64 == 0 and K % 128 == 0:
+                if is_bmm:
+                    # Grouped (batched) projection, e.g. V4 attention wo_a whose
+                    # weight is [groups * n, K] and is consumed per group as
+                    # [n, K]. Transform each group's block scale into the
+                    # deep_gemm MN-major layout so the per-group GEMM can run
+                    # native FP8 instead of dequantizing the weight to FP32.
+                    # Keep the per-group scales as a list (not a stacked tensor):
+                    # stacking re-lays them out row-major and breaks deep_gemm's
+                    # sf.stride(-2) == 1 requirement. weight_scale_inv is left
+                    # untouched so the dequant fallback still works.
+                    g = layer.bmm_batch_size
+                    n = N // g
+                    if n % block_n == 0 and K % block_k == 0:
+                        sf = _ceil_to_ue8m0(layer.weight_scale_inv.data).view(
+                            g, n // block_n, K // block_k
+                        )
+                        layer._deep_gemm_bmm_weight_scales = [
+                            _transform_sf(
+                                sf=sf[i],
+                                mn=n,
+                                k=K,
+                                recipe=(1, block_n, block_k),
+                                is_sfa=False,
+                            )
+                            for i in range(g)
+                        ]
+                        layer._deep_gemm_block_size = [block_n, block_k]
+                        layer._use_deep_gemm_fp8 = True
+                elif N % 64 == 0 and K % 128 == 0:
                     sf = _ceil_to_ue8m0(layer.weight_scale_inv.data)
                     layer.weight_scale_inv.data = _transform_sf(
                         sf=sf,
@@ -227,6 +250,17 @@ class Fp8LinearMethod(LinearMethodBase):
                         is_sfa=False,
                     )
                     layer._use_deep_gemm_fp8 = True
+            if is_bmm and not layer._use_deep_gemm_fp8:
+                # The is_bmm runtime path (DeepSeek-V4 o_proj) has no FP32
+                # fallback, so fail fast at load with a clear message instead of
+                # a cryptic AttributeError on the first forward.
+                raise RuntimeError(
+                    "is_bmm weight requires the deep_gemm FP8 block-scale path "
+                    "but it could not be prepared (deep_gemm_available="
+                    f"{_transform_sf is not None}, ue8m0={is_ue8m0}, "
+                    f"weight={tuple(layer.weight.shape)}); ensure FP8 block-quant "
+                    "ue8m0 weights with block-aligned dims and deep_gemm installed."
+                )
         else:
             layer.weight = Parameter(layer.weight.data, requires_grad=False)
 

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -43,7 +43,6 @@ try:
 except ImportError:
     deep_gemm = None  # type: ignore[assignment]
 
-import tokenspeed_kernel
 from tokenspeed_kernel.ops.attention.cuda.deepseek_v4 import (
     has_indexer_mxfp4_paged_gather,
     has_persistent_topk,
@@ -96,8 +95,8 @@ from tokenspeed.runtime.layers.attention.deepseek_v4.metadata import (
 from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (
     deepseek_v4_csa_compress_kv_cache_insert,
     deepseek_v4_csa_indexer_cache_insert,
+    deepseek_v4_fused_inv_rope_fp8_quant,
     deepseek_v4_hca_compress_kv_cache_insert,
-    deepseek_v4_inv_rope_grouped,
     deepseek_v4_prepare_indexer_q_mxfp4,
     fused_qnorm_rope_kv_insert,
     save_deepseek_v4_compressor_state,
@@ -3341,6 +3340,9 @@ class DeepseekV4Attention(nn.Module):
         )
         self.wo_a.is_bmm = True
         self.wo_a.bmm_batch_size = self.num_local_groups
+        # SM100 packs the FP8 output-proj scales as INT32 UE8M0 (fp8_einsum
+        # recipe (1,1,128)); SM90 keeps FP32 block scales (recipe (1,128,128)).
+        self._o_tma_aligned = torch.cuda.get_device_capability()[0] >= 10
         self.wo_b = RowParallelLinear(
             self.o_groups * self.o_lora_rank,
             config.hidden_size,
@@ -3440,8 +3442,12 @@ class DeepseekV4Attention(nn.Module):
         positions: torch.Tensor,
         cos_sin_cache: torch.Tensor,
     ) -> torch.Tensor:
+        # Inverse RoPE + grouped block-scaled FP8 quant in one Triton kernel,
+        # then a single native FP8 GEMM via deep_gemm.fp8_einsum -- replaces the
+        # inv-rope + per-group online-quant + GEMM chain. wo_a's block scale was
+        # transformed into the deep_gemm MN-major layout at load time.
         heads_per_group = self.num_local_heads // self.num_local_groups
-        grouped = deepseek_v4_inv_rope_grouped(
+        o_fp8, o_scale = deepseek_v4_fused_inv_rope_fp8_quant(
             attn_output,
             positions,
             cos_sin_cache,
@@ -3449,30 +3455,23 @@ class DeepseekV4Attention(nn.Module):
             heads_per_group=heads_per_group,
             nope_dim=self.nope_head_dim,
             rope_dim=self.qk_rope_head_dim,
+            tma_aligned_scales=self._o_tma_aligned,
         )
         in_dim = self.num_heads * self.head_dim // self.o_groups
-        # Native FP8 block-scale GEMM per group (deep_gemm), replacing the
-        # FP32 weight dequant + FP32 torch.bmm. wo_a's block scale was
-        # transformed into the deep_gemm layout at load time; activations
-        # are quantized online by tokenspeed_kernel.mm.
         weight = self.wo_a.weight.view(self.num_local_groups, self.o_lora_rank, in_dim)
-        scales = self.wo_a._deep_gemm_bmm_weight_scales
-        block_size = self.wo_a._deep_gemm_block_size
-        grouped = grouped.transpose(0, 1).contiguous()
-        z = torch.stack(
-            [
-                tokenspeed_kernel.mm(
-                    grouped[g],
-                    weight[g],
-                    B_scales=scales[g],
-                    out_dtype=attn_output.dtype,
-                    quant="mxfp8",
-                    block_size=block_size,
-                    override="deep_gemm_mm_fp8_blockscale",
-                )
-                for g in range(self.num_local_groups)
-            ],
-            dim=1,
+        block_n, block_k = self.wo_a._deep_gemm_block_size
+        recipe = (1, 1, block_n) if self._o_tma_aligned else (1, block_n, block_k)
+        z = torch.empty(
+            (attn_output.shape[0], self.num_local_groups, self.o_lora_rank),
+            device=attn_output.device,
+            dtype=torch.bfloat16,
+        )
+        deep_gemm.fp8_einsum(
+            "bhr,hdr->bhd",
+            (o_fp8, o_scale),
+            (weight, self.wo_a.weight_scale_inv),
+            z,
+            recipe=recipe,
         )
         out, _ = self.wo_b(z.flatten(1))
         return out

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -27,6 +27,7 @@ until the HCA/CSA cache kernels are wired into TokenSpeed.
 
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass
 from typing import Any, Iterable, Optional, Tuple
@@ -2098,6 +2099,7 @@ class DeepseekV4MegaMoEExperts(nn.Module):
         intermediate_size: int,
         mapping: Mapping,
         prefix: str,
+        swiglu_limit: float | None,
     ) -> None:
         super().__init__()
         self.prefix = prefix
@@ -2108,6 +2110,11 @@ class DeepseekV4MegaMoEExperts(nn.Module):
         self.intermediate_size = intermediate_size
         self.mapping = mapping
         self.max_num_tokens = _deepseek_v4_mega_moe_max_num_tokens()
+        # DeepGEMM bakes the activation clamp into the kernel as a compile-time
+        # template arg, so the warmup below must use the same value serving does
+        # (the caller passes it to ``forward``) for the pre-compiled tiles to
+        # match the served kernels.
+        self.swiglu_limit = swiglu_limit
 
         weight_attrs = {"weight_loader": self.weight_loader}
         self.w13_weight = nn.Parameter(
@@ -2321,6 +2328,71 @@ class DeepseekV4MegaMoEExperts(nn.Module):
         )
         return y
 
+    def warmup_jit_variants(self) -> None:
+        """Pre-compile every DeepGEMM mega-MoE tile this layer can hit at runtime.
+
+        DeepGEMM JITs ``fp8_fp4_mega_moe`` on first use and selects the tile
+        (``block_m``) from the per-rank token count -- roughly
+        ``num_tokens * num_ranks * num_topk / num_experts`` mapped to a
+        ``block_m`` bucket (DeepGEMM ``heuristics/mega_moe.hpp``). CUDA-graph
+        capture only exercises decode-sized token counts, so the larger prefill
+        tiles would otherwise JIT mid-serving -- and because the kernel arms its
+        NVLink EP barrier on the same launch, a cold compile stalls one rank
+        past DeepGEMM's 30 s barrier timeout and aborts the job.
+
+        Sweeping a few token counts that cross every ``block_m`` boundary
+        compiles each tile at startup with all EP ranks in lock-step, so serving
+        never JITs on the hot path. The kernels are cached by shape + tile (not
+        by layer or activation values), so dummy activations on one module
+        cover the whole stack.
+        """
+        if deep_gemm is None or self._transformed_l1_weights is None:
+            return
+
+        device = self._transformed_l1_weights[0].device
+        cap = self.max_num_tokens
+        # Token counts spanning the block_m buckets up to the symmetric-buffer
+        # capacity. Decode-sized tiles are also covered by CUDA-graph capture;
+        # the small counts here keep the warmup self-contained.
+        token_counts = sorted(
+            {n for n in (16, 32, 64, 128, 256, 512, 1024, 2048, 4096) if n < cap}
+            | {cap}
+        )
+
+        # The launch runs an NVLink barrier across the EP group, so every rank
+        # must enter the sweep together; align them once after weight load so a
+        # straggler cannot trip the barrier's 30 s timeout.
+        if torch.distributed.is_initialized():
+            group = pg_manager.get_process_group("nccl", self.mapping.moe.tp_ep_group)
+            torch.distributed.barrier(group=group)
+
+        for num_tokens in token_counts:
+            hidden_states = torch.randn(
+                (num_tokens, self.hidden_size),
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            topk_weights = torch.full(
+                (num_tokens, self.top_k),
+                1.0 / self.top_k,
+                dtype=torch.float32,
+                device=device,
+            )
+            topk_ids = torch.randint(
+                0,
+                self.num_experts,
+                (num_tokens, self.top_k),
+                dtype=torch.int64,
+                device=device,
+            )
+            self.forward(
+                hidden_states,
+                topk_weights,
+                topk_ids,
+                activation_clamp=self.swiglu_limit,
+            )
+        torch.cuda.synchronize()
+
 
 class DeepseekV4MoE(nn.Module):
     def __init__(
@@ -2395,6 +2467,7 @@ class DeepseekV4MoE(nn.Module):
                 intermediate_size=config.moe_intermediate_size,
                 mapping=mapping,
                 prefix=add_prefix("experts", prefix),
+                swiglu_limit=getattr(config, "swiglu_limit", None),
             )
             self.topk = None
         else:
@@ -3885,13 +3958,27 @@ class DeepseekV4ForCausalLM(BaseCausalLM):
         self.post_load_weights()
 
     def post_load_weights(self):
+        mega_moe_experts: list[DeepseekV4MegaMoEExperts] = []
         for module in self.modules():
             if isinstance(module, DeepseekV4Compressor):
                 module.process_weights_after_loading()
             elif isinstance(module, DeepseekV4MegaMoEExperts):
                 module.finalize_weights()
+                mega_moe_experts.append(module)
             elif isinstance(module, MoELayer):
                 module.process_weights_after_loading(module)
+        # Pre-compile the DeepGEMM mega-MoE tiles now so DeepGEMM never JITs on
+        # the serving hot path: a cold mid-serving compile stalls one EP rank
+        # past the NVLink barrier's 30 s timeout and aborts the job. Tiles are
+        # cached by GEMM shape + token count (not by layer), so warming one
+        # experts module covers every layer. Opt out with
+        # TOKENSPEED_DISABLE_MEGA_MOE_WARMUP=1.
+        if (
+            mega_moe_experts
+            and os.environ.get("TOKENSPEED_DISABLE_MEGA_MOE_WARMUP") != "1"
+        ):
+            logger.info("Pre-compiling DeepGEMM mega-MoE kernel variants...")
+            mega_moe_experts[0].warmup_jit_variants()
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -2704,6 +2704,7 @@ class DeepseekV4Compressor(nn.Module):
         state_block_size: int | None = None,
         state_base_logical_page: torch.Tensor | None = None,
         write_compressed_cache: bool = True,
+        compressor_slot_cache: dict | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         pool = ctx.token_to_kv_pool
         metadata = _deepseek_v4_forward_metadata(ctx)
@@ -2730,6 +2731,10 @@ class DeepseekV4Compressor(nn.Module):
         if state_cache is None:
             state_cache = pool.get_compressor_state_buffer(layer_index)
         cache_metadata = metadata.cache
+        # state/compressed slot mappings depend only on (per-step state, ratio), so reuse
+        # them across layers of the same ratio within a step. Attn-compressor path only:
+        # the indexer-compressor passes an explicit state_block_table and is excluded.
+        memo = compressor_slot_cache if state_block_table is None else None
         if state_block_table is None:
             state_block_table = cache_metadata.compressor_state_block_tables.get(
                 self.compress_ratio
@@ -2750,7 +2755,12 @@ class DeepseekV4Compressor(nn.Module):
             if getattr(metadata, "is_valid_token", None) is not None
             else None
         )
-        if state_block_table is not None:
+        state_hit = (
+            memo.get(("state", self.compress_ratio)) if memo is not None else None
+        )
+        if state_hit is not None:
+            state_slot_mapping, state_block_table = state_hit
+        elif state_block_table is not None:
             state_slot_mapping = _group_slot_mapping_from_raw(
                 positions,
                 metadata.token_to_req_indices[: positions.numel()],
@@ -2765,6 +2775,11 @@ class DeepseekV4Compressor(nn.Module):
             state_slot_mapping,
             valid_token,
         )
+        if memo is not None and state_hit is None:
+            memo[("state", self.compress_ratio)] = (
+                state_slot_mapping,
+                state_block_table,
+            )
         with nvtx_range(f"{profile_prefix}_save_state"):
             save_deepseek_v4_compressor_state(
                 kv=kv,
@@ -2780,19 +2795,29 @@ class DeepseekV4Compressor(nn.Module):
             return kv, score
 
         kv_cache_block_size = pool.get_compressed_block_size(layer_index)
-        with nvtx_range(f"{profile_prefix}_compressed_slot_mapping"):
-            compressed_slots = cache_metadata.compressed_slot_mapping(
-                positions,
-                self.compress_ratio,
-                token_to_req_indices=metadata.token_to_req_indices[: positions.numel()],
-                query_start_loc=metadata.query_start_loc,
-                seq_lens=metadata.seq_lens,
-                kv_cache_block_size=kv_cache_block_size,
-                use_decode_cache=(
-                    ctx.forward_mode is not None and ctx.forward_mode.is_decode()
-                ),
-                is_valid_token=valid_token,
-            )
+        compressed_hit = (
+            memo.get(("compressed", self.compress_ratio)) if memo is not None else None
+        )
+        if compressed_hit is not None:
+            compressed_slots = compressed_hit
+        else:
+            with nvtx_range(f"{profile_prefix}_compressed_slot_mapping"):
+                compressed_slots = cache_metadata.compressed_slot_mapping(
+                    positions,
+                    self.compress_ratio,
+                    token_to_req_indices=metadata.token_to_req_indices[
+                        : positions.numel()
+                    ],
+                    query_start_loc=metadata.query_start_loc,
+                    seq_lens=metadata.seq_lens,
+                    kv_cache_block_size=kv_cache_block_size,
+                    use_decode_cache=(
+                        ctx.forward_mode is not None and ctx.forward_mode.is_decode()
+                    ),
+                    is_valid_token=valid_token,
+                )
+            if memo is not None:
+                memo[("compressed", self.compress_ratio)] = compressed_slots
         with nvtx_range(f"{profile_prefix}_cache_insert"):
             insert = (
                 deepseek_v4_csa_compress_kv_cache_insert
@@ -3483,6 +3508,7 @@ class DeepseekV4Attention(nn.Module):
         ctx: ForwardContext,
         out_cache_loc: torch.Tensor,
         swa_slot_mapping: torch.Tensor,
+        compressor_slot_cache: dict,
     ) -> torch.Tensor:
         if hidden_states.shape[0] == 0:
             return hidden_states
@@ -3528,6 +3554,7 @@ class DeepseekV4Attention(nn.Module):
                     out_cache_loc=out_cache_loc,
                     layer_index=self.cache_layer_index,
                     cos_sin_cache=cos_sin_cache,
+                    compressor_slot_cache=compressor_slot_cache,
                 )
 
         topk_indices = None
@@ -3738,6 +3765,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         out_cache_loc: torch.Tensor,
         input_ids: torch.Tensor,
         swa_slot_mapping: torch.Tensor,
+        compressor_slot_cache: dict,
     ) -> torch.Tensor:
         residual = hidden_states
         with nvtx_range("hc_attn_pre"):
@@ -3754,7 +3782,12 @@ class DeepseekV4DecoderLayer(nn.Module):
             hidden_states = self.attn_norm(hidden_states)
         with nvtx_range("attn_total"):
             hidden_states = self.attn(
-                positions, hidden_states, ctx, out_cache_loc, swa_slot_mapping
+                positions,
+                hidden_states,
+                ctx,
+                out_cache_loc,
+                swa_slot_mapping,
+                compressor_slot_cache,
             )
         with nvtx_range("hc_attn_post"):
             hidden_states = mhc_post(hidden_states, residual, post, comb)
@@ -3898,6 +3931,10 @@ class DeepseekV4Model(nn.Module):
                 )
             else:
                 swa_slot_mapping = out_cache_loc
+        # Per-(step, ratio) compressor slot mappings are identical across layers of the
+        # same ratio; memoize within the step (filled lazily by the first compressor of
+        # each ratio, reused by the rest).
+        compressor_slot_cache: dict = {}
         for layer in self.layers:
             hidden_states = layer(
                 positions,
@@ -3906,6 +3943,7 @@ class DeepseekV4Model(nn.Module):
                 out_cache_loc,
                 input_ids,
                 swa_slot_mapping,
+                compressor_slot_cache,
             )
         aux_hidden_states = None
         if (

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -3552,7 +3552,14 @@ class DeepseekV4Attention(nn.Module):
                     )
                 with fork.branch():
                     insert_swa_cache()
-                    run_compressor()
+                # Run the attention compressor on the MAIN stream. The indexer
+                # (above, main stream) internally runs its own compressor; a
+                # second compressor concurrently on the aux stream races over
+                # shared state and intermittently faults with an illegal memory
+                # access (surfaces async in _group_slot_mapping_from_raw). Only
+                # insert_swa stays on the aux branch -- that overlap is safe and
+                # is preserved. Mirrors the elif structure below.
+                run_compressor()
         elif self.compressor is not None:
             with self.stream_fork.scope(
                 enable=self.stream_fork.aux_stream is not None

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -3559,11 +3559,13 @@ class DeepseekV4Attention(nn.Module):
         hidden_states: torch.Tensor,
         ctx: ForwardContext,
         out_cache_loc: torch.Tensor,
-        swa_slot_mapping: torch.Tensor,
-        compressor_slot_cache: dict,
+        swa_slot_mapping: torch.Tensor | None = None,
+        compressor_slot_cache: dict | None = None,
     ) -> torch.Tensor:
         if hidden_states.shape[0] == 0:
             return hidden_states
+        if compressor_slot_cache is None:
+            compressor_slot_cache = {}
         profile_prefix = f"attn_{self.attention_kind}"
         cos_sin_cache = self.rotary_emb.cos_sin_cache
         if cos_sin_cache.dtype != torch.float32:
@@ -3597,8 +3599,14 @@ class DeepseekV4Attention(nn.Module):
                             self.indexer.compressor.compute_kv_score(hidden_states)
                         )
 
-        # swa_slot_mapping is computed once per step in DeepseekV4Model.forward
-        # (it is identical across all layers) and threaded in here.
+        # When swa_slot_mapping is provided (main model path), use it directly.
+        # When None (MTP draft path), fall back to out_cache_loc.
+        # TODO: MTP draft metadata has token_to_req_indices shaped per-request
+        # (not per-token), so _group_slot_mapping_from_raw cannot compute the
+        # correct paged SWA mapping here. out_cache_loc is not ideal when paged
+        # SWA groups are active; fix once MTP metadata packs per-token indices.
+        if swa_slot_mapping is None:
+            swa_slot_mapping = out_cache_loc
 
         def insert_swa_cache() -> None:
             with nvtx_range(f"{profile_prefix}_insert_swa_cache"):
@@ -3838,8 +3846,8 @@ class DeepseekV4DecoderLayer(nn.Module):
         ctx: ForwardContext,
         out_cache_loc: torch.Tensor,
         input_ids: torch.Tensor,
-        swa_slot_mapping: torch.Tensor,
-        compressor_slot_cache: dict,
+        swa_slot_mapping: torch.Tensor | None = None,
+        compressor_slot_cache: dict | None = None,
     ) -> torch.Tensor:
         residual = hidden_states
         with nvtx_range("hc_attn_pre"):

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -43,6 +43,7 @@ try:
 except ImportError:
     deep_gemm = None  # type: ignore[assignment]
 
+import tokenspeed_kernel
 from tokenspeed_kernel.ops.attention.cuda.deepseek_v4 import (
     has_indexer_mxfp4_paged_gather,
     has_persistent_topk,
@@ -3325,9 +3326,9 @@ class DeepseekV4Attention(nn.Module):
         )
         self.kv_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
         self.fused_qkv_norm = FusedRMSNorm(self.q_norm, self.kv_norm)
-        # Fused QKV-RMSNorm is opt-in; the unfused path is the default until
-        # a wider correctness sweep confirms the fused kernel.
-        self.use_fused_qkv_rmsnorm = False
+        # Fused QKV-RMSNorm: fuses q_a/kv_a RMSNorm into one kernel instead of two
+        # sequential RMSNorm + a kv.contiguous() copy. Validated via GSM8K.
+        self.use_fused_qkv_rmsnorm = True
         self.wo_a = ColumnParallelLinear(
             self.num_heads * self.head_dim // self.o_groups,
             self.o_groups * self.o_lora_rank,
@@ -3450,15 +3451,29 @@ class DeepseekV4Attention(nn.Module):
             rope_dim=self.qk_rope_head_dim,
         )
         in_dim = self.num_heads * self.head_dim // self.o_groups
-        weight = _dequant_fp8_weight(
-            self.wo_a,
-            (self.num_local_groups, self.o_lora_rank, in_dim),
+        # Native FP8 block-scale GEMM per group (deep_gemm), replacing the
+        # FP32 weight dequant + FP32 torch.bmm. wo_a's block scale was
+        # transformed into the deep_gemm layout at load time; activations
+        # are quantized online by tokenspeed_kernel.mm.
+        weight = self.wo_a.weight.view(self.num_local_groups, self.o_lora_rank, in_dim)
+        scales = self.wo_a._deep_gemm_bmm_weight_scales
+        block_size = self.wo_a._deep_gemm_block_size
+        grouped = grouped.transpose(0, 1).contiguous()
+        z = torch.stack(
+            [
+                tokenspeed_kernel.mm(
+                    grouped[g],
+                    weight[g],
+                    B_scales=scales[g],
+                    out_dtype=attn_output.dtype,
+                    quant="mxfp8",
+                    block_size=block_size,
+                    override="deep_gemm_mm_fp8_blockscale",
+                )
+                for g in range(self.num_local_groups)
+            ],
+            dim=1,
         )
-        z = torch.bmm(
-            grouped.float().transpose(0, 1),
-            weight.transpose(1, 2),
-        ).transpose(0, 1)
-        z = z.to(attn_output.dtype).contiguous()
         out, _ = self.wo_b(z.flatten(1))
         return out
 

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -3482,6 +3482,7 @@ class DeepseekV4Attention(nn.Module):
         hidden_states: torch.Tensor,
         ctx: ForwardContext,
         out_cache_loc: torch.Tensor,
+        swa_slot_mapping: torch.Tensor,
     ) -> torch.Tensor:
         if hidden_states.shape[0] == 0:
             return hidden_states
@@ -3495,17 +3496,8 @@ class DeepseekV4Attention(nn.Module):
         metadata = ctx.attn_backend.forward_metadata
         if metadata is None:
             raise RuntimeError("DeepSeek V4 attention requires forward metadata")
-        cache_metadata = metadata.cache
-        if cache_metadata.swa_block_table is not None:
-            swa_slot_mapping = _group_slot_mapping_from_raw(
-                positions,
-                metadata.token_to_req_indices[: positions.numel()],
-                cache_metadata.swa_block_table,
-                pool.swa_block_size,
-                base_offsets=cache_metadata.swa_base_logical_page,
-            )
-        else:
-            swa_slot_mapping = out_cache_loc
+        # swa_slot_mapping is computed once per step in DeepseekV4Model.forward
+        # (it is identical across all layers) and threaded in here.
 
         def insert_swa_cache() -> None:
             with nvtx_range(f"{profile_prefix}_insert_swa_cache"):
@@ -3745,6 +3737,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         ctx: ForwardContext,
         out_cache_loc: torch.Tensor,
         input_ids: torch.Tensor,
+        swa_slot_mapping: torch.Tensor,
     ) -> torch.Tensor:
         residual = hidden_states
         with nvtx_range("hc_attn_pre"):
@@ -3760,7 +3753,9 @@ class DeepseekV4DecoderLayer(nn.Module):
         with nvtx_range("attn_norm"):
             hidden_states = self.attn_norm(hidden_states)
         with nvtx_range("attn_total"):
-            hidden_states = self.attn(positions, hidden_states, ctx, out_cache_loc)
+            hidden_states = self.attn(
+                positions, hidden_states, ctx, out_cache_loc, swa_slot_mapping
+            )
         with nvtx_range("hc_attn_post"):
             hidden_states = mhc_post(hidden_states, residual, post, comb)
 
@@ -3880,9 +3875,37 @@ class DeepseekV4Model(nn.Module):
                 hidden_states = self.embed_tokens(input_ids)
         with nvtx_range("hc_repeat"):
             hidden_states = hidden_states.unsqueeze(1).repeat(1, self.hc_mult, 1)
+        # The SWA write-slot mapping is identical across all layers, so compute
+        # it once per step here instead of recomputing it in every attention
+        # layer (DeepSeek-V3 likewise derives its slot mapping once per step).
+        # On an empty batch (e.g. the DP idle fallback) the attention layers
+        # early-return without touching metadata, so skip the metadata read here
+        # too to preserve that behavior on a fresh backend.
+        if hidden_states.shape[0] == 0:
+            swa_slot_mapping = out_cache_loc
+        else:
+            metadata = ctx.attn_backend.forward_metadata
+            if metadata is None:
+                raise RuntimeError("DeepSeek V4 attention requires forward metadata")
+            cache_metadata = metadata.cache
+            if cache_metadata.swa_block_table is not None:
+                swa_slot_mapping = _group_slot_mapping_from_raw(
+                    positions,
+                    metadata.token_to_req_indices[: positions.numel()],
+                    cache_metadata.swa_block_table,
+                    ctx.token_to_kv_pool.swa_block_size,
+                    base_offsets=cache_metadata.swa_base_logical_page,
+                )
+            else:
+                swa_slot_mapping = out_cache_loc
         for layer in self.layers:
             hidden_states = layer(
-                positions, hidden_states, ctx, out_cache_loc, input_ids
+                positions,
+                hidden_states,
+                ctx,
+                out_cache_loc,
+                input_ids,
+                swa_slot_mapping,
             )
         aux_hidden_states = None
         if (

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -2690,6 +2690,25 @@ class DeepseekV4Compressor(nn.Module):
             self.ape.data.copy_(_deepseek_v4_reorder_c4_ape_2604(self.ape.data))
         self._ape_reordered = True
 
+    def compute_kv_score(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Pre-compute the input GEMM (fused_wkv_wgate @ hidden_states).
+
+        Can be launched on an aux stream in parallel with the main Q/KV
+        projection so that ``forward()`` only needs the lightweight state
+        update + cache write phase.
+        """
+        weight_shape = (
+            self.fused_wkv_wgate.output_size_per_partition,
+            self.fused_wkv_wgate.input_size,
+        )
+        weight = self.fused_wkv_wgate.weight.view(*weight_shape)
+        if weight.dtype == torch.float8_e4m3fn:
+            weight = _dequant_fp8_weight(self.fused_wkv_wgate, weight_shape)
+        kv_score = _deepseek_v4_bf16_linear_fp32(hidden_states, weight)
+        if kv_score is None:
+            kv_score = torch.matmul(hidden_states.float(), weight.float().T)
+        return kv_score
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -2706,6 +2725,7 @@ class DeepseekV4Compressor(nn.Module):
         state_slot_mapping: torch.Tensor | None = None,
         write_compressed_cache: bool = True,
         compressor_slot_cache: dict | None = None,
+        kv_score: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         pool = ctx.token_to_kv_pool
         metadata = _deepseek_v4_forward_metadata(ctx)
@@ -2716,19 +2736,20 @@ class DeepseekV4Compressor(nn.Module):
             if not write_compressed_cache
             else f"compressor_c{self.compress_ratio}"
         )
-        with nvtx_range(f"{profile_prefix}_dequant_weight"):
-            weight_shape = (
-                self.fused_wkv_wgate.output_size_per_partition,
-                self.fused_wkv_wgate.input_size,
-            )
-            weight = self.fused_wkv_wgate.weight.view(*weight_shape)
-            if weight.dtype == torch.float8_e4m3fn:
-                weight = _dequant_fp8_weight(self.fused_wkv_wgate, weight_shape)
-        with nvtx_range(f"{profile_prefix}_matmul"):
-            kv_score = _deepseek_v4_bf16_linear_fp32(hidden_states, weight)
-            if kv_score is None:
-                kv_score = torch.matmul(hidden_states.float(), weight.float().T)
-            kv, score = kv_score.split([self.coff * self.head_dim] * 2, dim=-1)
+        if kv_score is None:
+            with nvtx_range(f"{profile_prefix}_dequant_weight"):
+                weight_shape = (
+                    self.fused_wkv_wgate.output_size_per_partition,
+                    self.fused_wkv_wgate.input_size,
+                )
+                weight = self.fused_wkv_wgate.weight.view(*weight_shape)
+                if weight.dtype == torch.float8_e4m3fn:
+                    weight = _dequant_fp8_weight(self.fused_wkv_wgate, weight_shape)
+            with nvtx_range(f"{profile_prefix}_matmul"):
+                kv_score = _deepseek_v4_bf16_linear_fp32(hidden_states, weight)
+                if kv_score is None:
+                    kv_score = torch.matmul(hidden_states.float(), weight.float().T)
+        kv, score = kv_score.split([self.coff * self.head_dim] * 2, dim=-1)
         if state_cache is None:
             state_cache = pool.get_compressor_state_buffer(layer_index)
         cache_metadata = metadata.cache
@@ -2762,26 +2783,27 @@ class DeepseekV4Compressor(nn.Module):
             )
             if state_hit is not None:
                 state_slot_mapping, state_block_table = state_hit
-            elif state_block_table is not None:
-                state_slot_mapping = _group_slot_mapping_from_raw(
-                    positions,
-                    metadata.token_to_req_indices[: positions.numel()],
-                    state_block_table,
-                    state_block_size,
-                    base_offsets=state_base_logical_page,
-                )
             else:
-                state_block_table = cache_metadata.block_table
-                state_slot_mapping = out_cache_loc
-            state_slot_mapping = _mask_invalid_graph_tokens(
-                state_slot_mapping,
-                valid_token,
-            )
-            if memo is not None and state_hit is None:
-                memo[("state", self.compress_ratio)] = (
+                if state_block_table is not None:
+                    state_slot_mapping = _group_slot_mapping_from_raw(
+                        positions,
+                        metadata.token_to_req_indices[: positions.numel()],
+                        state_block_table,
+                        state_block_size,
+                        base_offsets=state_base_logical_page,
+                    )
+                else:
+                    state_block_table = cache_metadata.block_table
+                    state_slot_mapping = out_cache_loc
+                state_slot_mapping = _mask_invalid_graph_tokens(
                     state_slot_mapping,
-                    state_block_table,
+                    valid_token,
                 )
+                if memo is not None:
+                    memo[("state", self.compress_ratio)] = (
+                        state_slot_mapping,
+                        state_block_table,
+                    )
         with nvtx_range(f"{profile_prefix}_save_state"):
             save_deepseek_v4_compressor_state(
                 kv=kv,
@@ -3158,6 +3180,7 @@ class DeepseekV4Indexer(nn.Module):
         layer_index: int,
         cos_sin_cache: torch.Tensor,
         compressor_slot_cache: dict,
+        indexer_compressor_kv_score: torch.Tensor | None = None,
     ) -> torch.Tensor:
         pool = ctx.token_to_kv_pool
         metadata = _deepseek_v4_forward_metadata(ctx)
@@ -3228,6 +3251,7 @@ class DeepseekV4Indexer(nn.Module):
                 state_base_logical_page=indexer_state_base_logical_page,
                 state_slot_mapping=indexer_state_slot_mapping,
                 write_compressed_cache=False,
+                kv_score=indexer_compressor_kv_score,
             )
         with nvtx_range("indexer_compressed_slot_mapping"):
             indexer_block_size = pool.get_indexer_block_size(layer_index)
@@ -3541,8 +3565,6 @@ class DeepseekV4Attention(nn.Module):
         if hidden_states.shape[0] == 0:
             return hidden_states
         profile_prefix = f"attn_{self.attention_kind}"
-        with nvtx_range(f"{profile_prefix}_project_q_kv"):
-            q, kv, qr = self._project_q_kv(hidden_states)
         cos_sin_cache = self.rotary_emb.cos_sin_cache
         if cos_sin_cache.dtype != torch.float32:
             cos_sin_cache = cos_sin_cache.float()
@@ -3550,6 +3572,31 @@ class DeepseekV4Attention(nn.Module):
         metadata = ctx.attn_backend.forward_metadata
         if metadata is None:
             raise RuntimeError("DeepSeek V4 attention requires forward metadata")
+
+        # --- Phase 1: pre-compute input GEMMs in parallel ---
+        # Q/KV projection on main stream; compressor GEMM(s) on aux stream.
+        # After this phase, each compressor's forward() receives its
+        # pre-computed kv_score and skips the internal GEMM, removing the
+        # shared-weight dependency that prevents safe multi-stream overlap.
+        compressor_kv_score: torch.Tensor | None = None
+        indexer_compressor_kv_score: torch.Tensor | None = None
+        with self.stream_fork.scope(
+            enable=self.stream_fork.aux_stream is not None
+        ) as fork:
+            with nvtx_range(f"{profile_prefix}_project_q_kv"):
+                q, kv, qr = self._project_q_kv(hidden_states)
+            with fork.branch():
+                if self.compressor is not None:
+                    with nvtx_range(f"{profile_prefix}_compressor_gemm"):
+                        compressor_kv_score = self.compressor.compute_kv_score(
+                            hidden_states
+                        )
+                if self.indexer is not None:
+                    with nvtx_range(f"{profile_prefix}_indexer_compressor_gemm"):
+                        indexer_compressor_kv_score = (
+                            self.indexer.compressor.compute_kv_score(hidden_states)
+                        )
+
         # swa_slot_mapping is computed once per step in DeepseekV4Model.forward
         # (it is identical across all layers) and threaded in here.
 
@@ -3583,8 +3630,12 @@ class DeepseekV4Attention(nn.Module):
                     layer_index=self.cache_layer_index,
                     cos_sin_cache=cos_sin_cache,
                     compressor_slot_cache=compressor_slot_cache,
+                    kv_score=compressor_kv_score,
                 )
 
+        # --- Phase 2: state-update + cache-write overlap ---
+        # With GEMMs already done, the remaining work per stream is lightweight
+        # state updates and paged cache writes — safe to overlap.
         topk_indices = None
         if self.indexer is not None:
             assert self.compressor is not None
@@ -3611,16 +3662,10 @@ class DeepseekV4Attention(nn.Module):
                         layer_index=self.cache_layer_index,
                         cos_sin_cache=cos_sin_cache,
                         compressor_slot_cache=compressor_slot_cache,
+                        indexer_compressor_kv_score=indexer_compressor_kv_score,
                     )
                 with fork.branch():
                     insert_swa_cache()
-                # Run the attention compressor on the MAIN stream. The indexer
-                # (above, main stream) internally runs its own compressor; a
-                # second compressor concurrently on the aux stream races over
-                # shared state and intermittently faults with an illegal memory
-                # access (surfaces async in _group_slot_mapping_from_raw). Only
-                # insert_swa stays on the aux branch -- that overlap is safe and
-                # is preserved. Mirrors the elif structure below.
                 run_compressor()
         elif self.compressor is not None:
             with self.stream_fork.scope(

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -2703,6 +2703,7 @@ class DeepseekV4Compressor(nn.Module):
         state_block_table: torch.Tensor | None = None,
         state_block_size: int | None = None,
         state_base_logical_page: torch.Tensor | None = None,
+        state_slot_mapping: torch.Tensor | None = None,
         write_compressed_cache: bool = True,
         compressor_slot_cache: dict | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -2755,31 +2756,32 @@ class DeepseekV4Compressor(nn.Module):
             if getattr(metadata, "is_valid_token", None) is not None
             else None
         )
-        state_hit = (
-            memo.get(("state", self.compress_ratio)) if memo is not None else None
-        )
-        if state_hit is not None:
-            state_slot_mapping, state_block_table = state_hit
-        elif state_block_table is not None:
-            state_slot_mapping = _group_slot_mapping_from_raw(
-                positions,
-                metadata.token_to_req_indices[: positions.numel()],
-                state_block_table,
-                state_block_size,
-                base_offsets=state_base_logical_page,
+        if state_slot_mapping is None:
+            state_hit = (
+                memo.get(("state", self.compress_ratio)) if memo is not None else None
             )
-        else:
-            state_block_table = cache_metadata.block_table
-            state_slot_mapping = out_cache_loc
-        state_slot_mapping = _mask_invalid_graph_tokens(
-            state_slot_mapping,
-            valid_token,
-        )
-        if memo is not None and state_hit is None:
-            memo[("state", self.compress_ratio)] = (
+            if state_hit is not None:
+                state_slot_mapping, state_block_table = state_hit
+            elif state_block_table is not None:
+                state_slot_mapping = _group_slot_mapping_from_raw(
+                    positions,
+                    metadata.token_to_req_indices[: positions.numel()],
+                    state_block_table,
+                    state_block_size,
+                    base_offsets=state_base_logical_page,
+                )
+            else:
+                state_block_table = cache_metadata.block_table
+                state_slot_mapping = out_cache_loc
+            state_slot_mapping = _mask_invalid_graph_tokens(
                 state_slot_mapping,
-                state_block_table,
+                valid_token,
             )
+            if memo is not None and state_hit is None:
+                memo[("state", self.compress_ratio)] = (
+                    state_slot_mapping,
+                    state_block_table,
+                )
         with nvtx_range(f"{profile_prefix}_save_state"):
             save_deepseek_v4_compressor_state(
                 kv=kv,
@@ -3155,6 +3157,7 @@ class DeepseekV4Indexer(nn.Module):
         out_cache_loc: torch.Tensor,
         layer_index: int,
         cos_sin_cache: torch.Tensor,
+        compressor_slot_cache: dict,
     ) -> torch.Tensor:
         pool = ctx.token_to_kv_pool
         metadata = _deepseek_v4_forward_metadata(ctx)
@@ -3162,31 +3165,55 @@ class DeepseekV4Indexer(nn.Module):
             raise RuntimeError("DeepSeek V4 indexer requires forward metadata")
         cache_metadata = metadata.cache
         indexer_state = pool.get_indexer_state_buffer(layer_index)
-        indexer_state_block_table = cache_metadata.indexer_state_block_table
-        indexer_state_base_logical_page = cache_metadata.indexer_state_base_logical_page
         valid_token = (
             metadata.is_valid_token[: positions.numel()]
             if getattr(metadata, "is_valid_token", None) is not None
             else None
         )
-        if indexer_state_block_table is not None:
-            indexer_state_block_size = pool.get_indexer_state_block_size(layer_index)
-            indexer_state_slot_mapping = _group_slot_mapping_from_raw(
-                positions,
-                metadata.token_to_req_indices[: positions.numel()],
+        idx_hit = (
+            compressor_slot_cache.get("indexer_state")
+            if compressor_slot_cache is not None
+            else None
+        )
+        if idx_hit is not None:
+            (
+                indexer_state_slot_mapping,
                 indexer_state_block_table,
                 indexer_state_block_size,
-                base_offsets=indexer_state_base_logical_page,
-            )
+                indexer_state_base_logical_page,
+            ) = idx_hit
         else:
-            indexer_state_block_table = cache_metadata.block_table
-            indexer_state_block_size = pool.state_block_size
-            indexer_state_slot_mapping = out_cache_loc
-            indexer_state_base_logical_page = None
-        indexer_state_slot_mapping = _mask_invalid_graph_tokens(
-            indexer_state_slot_mapping,
-            valid_token,
-        )
+            indexer_state_block_table = cache_metadata.indexer_state_block_table
+            indexer_state_base_logical_page = (
+                cache_metadata.indexer_state_base_logical_page
+            )
+            if indexer_state_block_table is not None:
+                indexer_state_block_size = pool.get_indexer_state_block_size(
+                    layer_index
+                )
+                indexer_state_slot_mapping = _group_slot_mapping_from_raw(
+                    positions,
+                    metadata.token_to_req_indices[: positions.numel()],
+                    indexer_state_block_table,
+                    indexer_state_block_size,
+                    base_offsets=indexer_state_base_logical_page,
+                )
+            else:
+                indexer_state_block_table = cache_metadata.block_table
+                indexer_state_block_size = pool.state_block_size
+                indexer_state_slot_mapping = out_cache_loc
+                indexer_state_base_logical_page = None
+            indexer_state_slot_mapping = _mask_invalid_graph_tokens(
+                indexer_state_slot_mapping,
+                valid_token,
+            )
+            if compressor_slot_cache is not None:
+                compressor_slot_cache["indexer_state"] = (
+                    indexer_state_slot_mapping,
+                    indexer_state_block_table,
+                    indexer_state_block_size,
+                    indexer_state_base_logical_page,
+                )
         with nvtx_range("indexer_compressor_total"):
             self.compressor(
                 hidden_states=hidden_states,
@@ -3199,6 +3226,7 @@ class DeepseekV4Indexer(nn.Module):
                 state_block_table=indexer_state_block_table,
                 state_block_size=indexer_state_block_size,
                 state_base_logical_page=indexer_state_base_logical_page,
+                state_slot_mapping=indexer_state_slot_mapping,
                 write_compressed_cache=False,
             )
         with nvtx_range("indexer_compressed_slot_mapping"):
@@ -3582,6 +3610,7 @@ class DeepseekV4Attention(nn.Module):
                         out_cache_loc=out_cache_loc,
                         layer_index=self.cache_layer_index,
                         cos_sin_cache=cos_sin_cache,
+                        compressor_slot_cache=compressor_slot_cache,
                     )
                 with fork.branch():
                     insert_swa_cache()

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -3681,6 +3681,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 out_cache_loc=torch.zeros(2, dtype=torch.int64),
                 layer_index=0,
                 cos_sin_cache=torch.empty((1, 1)),
+                compressor_slot_cache={},
             )
 
         self.assertEqual(captured["indexer_block_size"], 4)

--- a/test/runtime/test_deepseek_v4_mega_moe.py
+++ b/test/runtime/test_deepseek_v4_mega_moe.py
@@ -28,6 +28,7 @@ class TestDeepseekV4MegaMoE(unittest.TestCase):
             intermediate_size=128,
             mapping=None,
             prefix="layers.0.ffn.experts",
+            swiglu_limit=None,
         )
 
         w1 = torch.full((128, 64), 1, dtype=torch.uint8)
@@ -50,6 +51,22 @@ class TestDeepseekV4MegaMoE(unittest.TestCase):
         torch.testing.assert_close(experts.w13_weight_scale[1, :128], s1)
         torch.testing.assert_close(experts.w13_weight_scale[1, 128:], s3)
         torch.testing.assert_close(experts.w2_weight_scale[1], s2)
+
+    def test_init_stores_swiglu_limit(self):
+        # swiglu_limit is a DeepGEMM compile-time template arg; the experts
+        # module must carry the served value so warmup_jit_variants()
+        # pre-compiles the matching mega-MoE tiles (see deepseek_v4.py).
+        experts = DeepseekV4MegaMoEExperts(
+            num_experts=4,
+            num_local_experts=2,
+            top_k=2,
+            hidden_size=128,
+            intermediate_size=128,
+            mapping=None,
+            prefix="layers.0.ffn.experts",
+            swiglu_limit=10.0,
+        )
+        self.assertEqual(experts.swiglu_limit, 10.0)
 
 
 if __name__ == "__main__":

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/deepseek_v4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/deepseek_v4.py
@@ -1789,3 +1789,182 @@ def deepseek_v4_indexer_decode_metadata_compute(
         max_blocks=int(max_blocks),
         candidate_block=candidate_block,
     )
+
+
+# Fused inverse-RoPE + block-scaled FP8 quant for the V4 attention output
+# projection. Adapted from vllm-project/vllm
+# (models/deepseek_v4/common/ops/fused_inv_rope_fp8_quant.py). Output scale is
+# pre-transformed (MN-major TMA-aligned; INT32-packed UE8M0 on SM100, FP32 on
+# SM90) so deep_gemm.fp8_einsum can consume it without re-transforming.
+@triton.jit(do_not_specialize=["num_tokens"])
+def _deepseek_v4_fused_inv_rope_fp8_quant_per_head(
+    o_ptr,
+    positions_ptr,
+    cos_sin_cache_ptr,
+    fp8_ptr,
+    scale_ptr,
+    num_tokens,
+    heads_per_group: tl.constexpr,
+    o_stride_token,
+    o_stride_head,
+    cache_stride_pos,
+    fp8_stride_group,
+    fp8_stride_token,
+    scale_stride_group,
+    scale_stride_k,
+    fp8_max: tl.constexpr,
+    eps: tl.constexpr,
+    QUANT_GROUP_SIZE: tl.constexpr,
+    CHUNKS_PER_HEAD: tl.constexpr,
+    ROPE_START: tl.constexpr,
+    HALF_ROPE: tl.constexpr,
+    TMA_ALIGNED_SCALES: tl.constexpr,
+):
+    pid_token = tl.program_id(0).to(tl.int64)
+    pid_gh = tl.program_id(1).to(tl.int64)
+    g = pid_gh // heads_per_group
+    head_in_group = pid_gh % heads_per_group
+    global_head = pid_gh
+    qb_start = head_in_group * CHUNKS_PER_HEAD
+    if pid_token >= num_tokens:
+        # Zero-fill the TMA-aligned padding rows of the scale buffer.
+        if TMA_ALIGNED_SCALES:
+            scale_addr = (
+                scale_ptr
+                + g * scale_stride_group
+                + pid_token
+                + head_in_group * scale_stride_k
+            )
+            tl.store(scale_addr, tl.zeros((), dtype=tl.int32))
+        else:
+            block_offsets = tl.arange(0, CHUNKS_PER_HEAD)
+            qb_indices = qb_start + block_offsets
+            scale_addrs = (
+                scale_ptr
+                + g * scale_stride_group
+                + pid_token
+                + qb_indices * scale_stride_k
+            )
+            tl.store(scale_addrs, tl.zeros((CHUNKS_PER_HEAD,), dtype=tl.float32))
+        return
+    input_base = o_ptr + pid_token * o_stride_token + global_head * o_stride_head
+    HEAD_DIM: tl.constexpr = CHUNKS_PER_HEAD * QUANT_GROUP_SIZE
+    offsets = tl.arange(0, HEAD_DIM)
+    x = tl.load(input_base + offsets).to(tl.float32)
+    rope_abs_start: tl.constexpr = (CHUNKS_PER_HEAD - 1) * QUANT_GROUP_SIZE + ROPE_START
+    pos = tl.load(positions_ptr + pid_token)
+    cache_base = cos_sin_cache_ptr + pos * cache_stride_pos
+    is_rope = offsets >= rope_abs_start
+    rope_local = offsets - rope_abs_start
+    x_partner = tl.load(input_base + (offsets ^ 1), mask=is_rope, other=0.0).to(
+        tl.float32
+    )
+    cs_idx = tl.maximum(rope_local >> 1, 0)
+    cos_v = tl.load(cache_base + cs_idx, mask=is_rope, other=1.0)
+    sin_v = tl.load(cache_base + HALF_ROPE + cs_idx, mask=is_rope, other=0.0)
+    x_add = x * cos_v + x_partner * sin_v
+    x_sub = x * cos_v - x_partner * sin_v
+    is_even = (rope_local & 1) == 0
+    rotated = tl.where(is_even, x_add, x_sub)
+    x = tl.where(is_rope, rotated, x)
+    x_2d = tl.reshape(tl.abs(x), (CHUNKS_PER_HEAD, QUANT_GROUP_SIZE))
+    block_absmax = tl.maximum(tl.max(x_2d, axis=1), eps)
+    scale_raw = block_absmax * (1.0 / fp8_max)
+    scales = tl.math.exp2(tl.ceil(tl.log2(scale_raw)))
+    scales_exp = tl.reshape(
+        tl.broadcast_to(
+            tl.reshape(scales, (CHUNKS_PER_HEAD, 1)),
+            (CHUNKS_PER_HEAD, QUANT_GROUP_SIZE),
+        ),
+        (HEAD_DIM,),
+    )
+    x_quant = tl.clamp(x / scales_exp, -fp8_max, fp8_max).to(tl.float8e4nv)
+    fp8_base = (
+        fp8_ptr
+        + g * fp8_stride_group
+        + pid_token * fp8_stride_token
+        + qb_start * QUANT_GROUP_SIZE
+    )
+    tl.store(fp8_base + offsets, x_quant)
+    block_offsets = tl.arange(0, CHUNKS_PER_HEAD)
+    qb_indices = qb_start + block_offsets
+    if TMA_ALIGNED_SCALES:
+        scale_bits = scales.to(tl.int32, bitcast=True)
+        ue8m0_bytes = (scale_bits >> 23) & 0xFF
+        packed_val = tl.sum(ue8m0_bytes << (block_offsets * 8))
+        scale_addr = (
+            scale_ptr
+            + g * scale_stride_group
+            + pid_token
+            + head_in_group * scale_stride_k
+        )
+        tl.store(scale_addr, packed_val)
+    else:
+        scale_addrs = (
+            scale_ptr + g * scale_stride_group + pid_token + qb_indices * scale_stride_k
+        )
+        tl.store(scale_addrs, scales)
+
+
+def deepseek_v4_fused_inv_rope_fp8_quant(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    n_groups: int,
+    heads_per_group: int,
+    nope_dim: int = 448,
+    rope_dim: int = 64,
+    quant_group_size: int = 128,
+    tma_aligned_scales: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Inverse RoPE + grouped block-scaled FP8 quant of the attention output.
+
+    Returns (o_fp8 [T, G, D] float8_e4m3fn, o_scale [T, G, scale_inner])
+    pre-laid-out for ``deep_gemm.fp8_einsum("bhr,hdr->bhd")``.
+    """
+    num_tokens, num_heads, head_dim = o.shape
+    d = heads_per_group * head_dim
+    num_scale_blocks = d // quant_group_size
+    chunks_per_head = head_dim // quant_group_size
+    fp8_max = torch.finfo(torch.float8_e4m3fn).max
+    tma_aligned_t = ((num_tokens + 3) // 4) * 4  # get_tma_aligned_size(T, int32)
+    scale_inner = (
+        (num_scale_blocks + 3) // 4 if tma_aligned_scales else num_scale_blocks
+    )
+    fp8_buf = torch.empty(
+        (n_groups, num_tokens, d), dtype=torch.float8_e4m3fn, device=o.device
+    )
+    scale_dtype = torch.int32 if tma_aligned_scales else torch.float32
+    scale_buf = torch.empty(
+        n_groups * scale_inner * tma_aligned_t, dtype=scale_dtype, device=o.device
+    ).as_strided(
+        (n_groups, num_tokens, scale_inner),
+        (scale_inner * tma_aligned_t, 1, tma_aligned_t),
+    )
+    grid = (tma_aligned_t, n_groups * heads_per_group)
+    _deepseek_v4_fused_inv_rope_fp8_quant_per_head[grid](
+        o,
+        positions,
+        cos_sin_cache,
+        fp8_buf,
+        scale_buf,
+        num_tokens,
+        heads_per_group=heads_per_group,
+        o_stride_token=o.stride(0),
+        o_stride_head=o.stride(1),
+        cache_stride_pos=cos_sin_cache.stride(0),
+        fp8_stride_group=fp8_buf.stride(0),
+        fp8_stride_token=fp8_buf.stride(1),
+        scale_stride_group=scale_buf.stride(0),
+        scale_stride_k=scale_buf.stride(2),
+        fp8_max=fp8_max,
+        eps=1e-10,
+        QUANT_GROUP_SIZE=quant_group_size,
+        CHUNKS_PER_HEAD=chunks_per_head,
+        ROPE_START=nope_dim % quant_group_size,
+        HALF_ROPE=rope_dim // 2,
+        TMA_ALIGNED_SCALES=tma_aligned_scales,
+        num_stages=1,
+        num_warps=1,
+    )
+    return fp8_buf.transpose(0, 1), scale_buf.transpose(0, 1)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/deep_gemm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/deep_gemm/__init__.py
@@ -71,6 +71,7 @@ _prepare_deep_gemm_cuda_home()
 from deep_gemm import (
     ceil_div,
     ceil_to_ue8m0,
+    fp8_einsum,
     fp8_fp4_mega_moe,
     fp8_fp4_mqa_logits,
     fp8_fp4_paged_mqa_logits,
@@ -95,6 +96,7 @@ __all__ = [
     "fp8_fp4_mega_moe",
     "fp8_fp4_mqa_logits",
     "fp8_fp4_paged_mqa_logits",
+    "fp8_einsum",
     "fp8_gemm_nt",
     "get_num_sms",
     "get_symm_buffer_for_mega_moe",


### PR DESCRIPTION
## Summary

- **fix: pre-compile mega-MoE tiles at startup** — cold JIT compilation mid-serving stalled EP ranks past the 30s NVLink barrier, causing Xid-13. Warmup sweeps all `block_m` variants at startup.
- **fix: run compressor on main stream** — two compressor instances on different CUDA streams raced on shared state, causing intermittent async IMA. Compressor now runs serial with indexer on main stream; only SWA insert stays on aux.
- **fix: carry `decode_compressed_slot_mappings` across capture re-init** — `init_forward_metadata_capture_cuda_graph` is called twice per batch size (warmup + capture). The second call created a fresh empty dict, discarding warmup-allocated buffers. Carry the dict forward (matching the replay path).
- **perf: fuse q/kv RMSNorm + native FP8 deep_gemm BMM for o_proj** — single fused QKV-RMSNorm kernel + FP8 block-scale deep_gemm BMM per group replaces FP32 dequant + torch.bmm chain.
- **perf: single-kernel o_proj** — fused Triton kernel (inv-RoPE + grouped FP8 block-scale quant) + `deep_gemm.fp8_einsum` replaces the multi-step inv-RoPE → per-group quant → GEMM chain.
- **perf: hoist SWA slot-mapping to per-step** — SWA compressed slot-mapping computed once per decode step instead of per-layer.
- **perf: memoize compressor slot-mappings** — state and compressed slot-mappings cached in per-step memo dict for cross-layer reuse within same compress_ratio.
- **perf: dedup indexer-compressor state slot-mapping** — indexer_state mapping computed once per step via `compressor_slot_cache` and reused across layers + fed into indexer's internal compressor.
- **perf: pre-compute compressor GEMMs in parallel with Q/KV projection** — vLLM-style two-phase split: Phase 1 runs compressor `fused_wkv_wgate` matmuls on aux stream overlapped with main Q/KV projection; Phase 2 passes pre-computed `kv_score` to skip internal GEMM. Removes dead code (`deepseek_v4_inv_rope_grouped`).

## Test plan

- [x] GSM8K 5-shot 50-sample nc=8: 5 rounds (0.92, 0.98, 0.96, 0.96, 0.94), mean 0.952
- [x] Zero Xid / IMA / runtime errors across all rounds
- [x] CUDA graph capture passes (origin/main's `compressed_slot_metadata` bug fixed)
- [x] Codex code review: LGTM (2 minor issues fixed — memo double-mask, dead code removal)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)