### PR TITLE
fix: NAN error in dp case cause of dummy input/data

### DIFF
--- a/python/tokenspeed/runtime/execution/drafter/eagle.py
+++ b/python/tokenspeed/runtime/execution/drafter/eagle.py
@@ -355,6 +355,7 @@ class Eagle(BaseDrafter):
 
             with nvtx_range("draft_sample", color="yellow"):
                 draft_ids = cute_argmax(logits_output.next_token_logits)
+                draft_ids.clamp_(min=0)
                 # Column 0 holds last_verified_ids; drafter writes step `i` into column `i + 1`.
                 next_tokens[:, i + 1] = self._map_hot(draft_ids)
                 if i + 1 < self.spec_num_steps:
@@ -424,6 +425,7 @@ class Eagle(BaseDrafter):
         logits_output = self._run_first_step(bs, draft_input)
 
         draft_ids = cute_argmax(logits_output.next_token_logits)
+        draft_ids.clamp_(min=0)
         next_tokens[:, 1] = self._map_hot(draft_ids)
 
         if self.spec_num_steps <= 1:

--- a/python/tokenspeed/runtime/execution/input_buffer.py
+++ b/python/tokenspeed/runtime/execution/input_buffer.py
@@ -401,4 +401,7 @@ class InputBuffers:
             self.mrope_positions_buf[:, :total_tokens].zero_()
         if batch_size > 0:
             self.req_pool_indices_buf[:batch_size].fill_(0)
-            self.seq_lens_buf[:batch_size].fill_(1)
+            # seq_lens must be >= spec_num_tokens so the drafter's prewrite
+            # correction never goes negative.
+            num_tokens_per_req = total_tokens // batch_size if batch_size > 0 else 1
+            self.seq_lens_buf[:batch_size].fill_(max(num_tokens_per_req, 1))

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -309,6 +309,11 @@ class ModelExecutor:
             runtime_states=self.runtime_states,
         )
 
+        # CUDA graph warmup runs the drafter with dummy data whose
+        # uninitialized KV cache produces NaN → argmax sentinel -1.
+        # Clear the residue so pool slots reused by real requests start clean.
+        self.runtime_states.future_input_map.zero_()
+
         # Encoder CUDA graph: install the model-built wrapper by overriding
         # ``image_encoder``. Vision-encoder analogue of ``forward_step``'s
         # ``CudaGraphWrapper``.

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -477,6 +477,18 @@ class ModelExecutor:
             logits_output, sampling_info, ctx, candidates
         )
 
+        # Single choke point for every (sample/verify) x (greedy/flashinfer)
+        # path: NaN logits (e.g. DP dummy/warmup batches over uninitialized KV)
+        # make cute_argmax emit the -1 sentinel. Left unclamped, that -1 poisons
+        # both consumers below -- it flows into output_ids -> detokenizer (the
+        # HF Rust tokenizer raises OverflowError on a negative id and kills the
+        # engine) and, via the drafter, back into future_input_map as the next
+        # round's input_ids (negative embedding index -> garbage / CUDA illegal
+        # access). Clamp in place (this runs inside the CUDA graph) so grammar,
+        # drafter, and the return value all observe clean ids. Mirror of the
+        # draft-side draft_ids.clamp_(min=0) guard.
+        output_tokens.clamp_(min=0)
+
         # Fork sampler-output D2H onto the grammar side stream so the
         # next step's build hostfunc can advance the matcher.
         if self.capturable_grammar is not None:


### PR DESCRIPTION
## Summary

Fixes NAN propagation in data parallel (DP) mode caused by dummy data in two scenarios:

1. CUDA graph warmup — startup capture uses dummy data whose uninitialized KV cache produces NaN; the NaN residue persists in future_input_map and corrupts real requests when pool slots are reused.
2. Idle rank forward — at runtime, DP ranks with no real work call fill_dummy_decode_buffers to participate in NCCL collectives (e.g. MoE all-to-all). The dummy data similarly produces NaN logits, and an undersized seq_lens causes the drafter's prewrite correction to go negative.

Both paths share the same failure chain: dummy data → NaN logits → argmax returns sentinel -1 → negative index propagates into token buffers → NAN errors in downstream computation.

Changes

- eagle.py: Clamp draft_ids to min=0 after cute_argmax to prevent negative indices from NaN logits propagating into token selection
- input_buffer.py: Fill seq_lens_buf with num_tokens_per_req instead of hardcoded 1, ensuring the drafter's prewrite correction never goes negative during both warmup and idle forward
- model_executor.py: Zero out future_input_map after CUDA graph warmup to clear NaN residue so reused pool slots start clean

<!-- What changed and why? -->

## Test Plan
 - [x] Run DP inference (multi-GPU) with Eagle speculative decoding and verify no NAN errors
 - [x] Verify idle ranks participate correctly in NCCL collectives without NAN propagation
 - [x] Verify single-GPU inference remains unaffected
<!-- How was this validated? -->
