### PR TITLE
fix: trtllm allreduce hang

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/include/flashinfer/comm/trtllm_allgather_fusion.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/include/flashinfer/comm/trtllm_allgather_fusion.cuh
@@ -365,9 +365,6 @@ __global__ __launch_bounds__(264, 1) void allgather_fusion_kernel_oneshot_lampor
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaGridDependencySynchronize();
-  if constexpr (!TriggerCompletionAtEnd) {
-    cudaTriggerProgrammaticLaunchCompletion();
-  }
 #endif
 
   flashinfer::trtllm_reducescatter_fusion::RLamportComm<NRanks> comm(params.workspace, params.rank);
@@ -386,15 +383,16 @@ __global__ __launch_bounds__(264, 1) void allgather_fusion_kernel_oneshot_lampor
 
 #pragma unroll
       for (int r = 0; r < NRanks; ++r) {
-        val.store(reinterpret_cast<T*>(comm.data_bufs[r]) + idx * VEC_SIZE);
+        val.store_global_release(reinterpret_cast<T*>(comm.data_bufs[r]) + idx * VEC_SIZE);
       }
     }
   }
+  __threadfence_system();
   for (int idx = access_id; idx < clear_access; idx += access_stride) {
-    // Clear comm buffer that previous kernel used
-    clear_vec.store(reinterpret_cast<T*>(comm.clear_buf) + idx * VEC_SIZE);
+    // Clear the Lamport slot used by the previous Lamport launch.
+    clear_vec.store_global_release(reinterpret_cast<T*>(comm.clear_buf) + idx * VEC_SIZE);
   }
-  __syncthreads();
+  __threadfence_system();
 
   AllGatherFusedOp<Pattern, T> fused_op(params);
 
@@ -402,8 +400,8 @@ __global__ __launch_bounds__(264, 1) void allgather_fusion_kernel_oneshot_lampor
     vec_t<T, VEC_SIZE> val;
     bool done = false;
     while (!done) {
-      val.load_global_volatile(reinterpret_cast<T*>(comm.data_bufs[params.rank]) +
-                               idx * VEC_SIZE);
+      val.load_global_acquire(reinterpret_cast<T*>(comm.data_bufs[params.rank]) +
+                              idx * VEC_SIZE);
       done = !flashinfer::trtllm_reducescatter_fusion::utils::has_neg_zero(val);
     }
 
@@ -414,9 +412,7 @@ __global__ __launch_bounds__(264, 1) void allgather_fusion_kernel_oneshot_lampor
   comm.update(params.size);
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  if constexpr (TriggerCompletionAtEnd) {
-    cudaTriggerProgrammaticLaunchCompletion();
-  }
+  cudaTriggerProgrammaticLaunchCompletion();
 #endif
 }
 
@@ -434,9 +430,6 @@ __global__ void allgather_fusion_kernel_twoshot_sync(
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaGridDependencySynchronize();
-  if constexpr (!TriggerCompletionAtEnd) {
-    cudaTriggerProgrammaticLaunchCompletion();
-  }
 #endif
 
   flashinfer::trtllm_reducescatter_fusion::RSyncComm<NRanks> comm(params.workspace);
@@ -445,8 +438,10 @@ __global__ void allgather_fusion_kernel_twoshot_sync(
   int my_access_count = my_token_num * params.hidden_dim / VEC_SIZE;
 
   for (int idx = access_id; idx < my_access_count; idx += access_stride) {
-    reinterpret_cast<float4*>(comm.comm_bufs[params.rank])[idx] =
-        reinterpret_cast<float4*>(params.allgather_in)[idx];
+    vec_t<T, VEC_SIZE> val;
+    val.load(reinterpret_cast<T*>(params.allgather_in) + idx * VEC_SIZE);
+    val.store_global_release(reinterpret_cast<T*>(comm.comm_bufs[params.rank]) +
+                             idx * VEC_SIZE);
   }
 
   flashinfer::trtllm_reducescatter_fusion::RBarrier<NRanks> barrier(params.rank, comm);
@@ -476,16 +471,15 @@ __global__ void allgather_fusion_kernel_twoshot_sync(
     int local_idx = idx - owner_start_access;
 
     vec_t<T, VEC_SIZE> val;
-    val.load(reinterpret_cast<T*>(comm.comm_bufs[owner_rank]) + local_idx * VEC_SIZE);
+    val.load_global_acquire(reinterpret_cast<T*>(comm.comm_bufs[owner_rank]) +
+                            local_idx * VEC_SIZE);
     fused_op(val, idx);
   }
 
   comm.update(barrier.m_flag_value);
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  if constexpr (TriggerCompletionAtEnd) {
-    cudaTriggerProgrammaticLaunchCompletion();
-  }
+  cudaTriggerProgrammaticLaunchCompletion();
 #endif
 }
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
@@ -55,6 +55,16 @@ static constexpr int kBarrierFlagCount = 256;
 
 }  // namespace details
 
+__device__ __forceinline__ int ld_global_acquire_sys(int* addr) {
+  int val;
+  asm volatile("ld.global.acquire.sys.b32 %0, [%1];" : "=r"(val) : "l"(addr));
+  return val;
+}
+
+__device__ __forceinline__ void st_global_release_sys(int* addr, int val) {
+  asm volatile("st.global.release.sys.b32 [%1], %0;" ::"r"(val), "l"(addr));
+}
+
 namespace maths {
 // // ============================== Cast ==============================
 template <typename T_OUT, typename T_IN>
@@ -808,23 +818,24 @@ struct SyncComm {
   __device__ __forceinline__ SyncComm(void** workspace) {
     counter_ptr = &reinterpret_cast<int*>(workspace[NRanks * 3])[0];
     flag_ptr = &reinterpret_cast<int*>(workspace[NRanks * 3])[1];
-    flag_value = *flag_ptr;
+    flag_value = ld_global_acquire_sys(flag_ptr);
     for (int r = 0; r < NRanks; ++r) {
       comm_bufs[r] = workspace[r];
       barrier_flags[r] = workspace[NRanks + r];
     }
-    __syncthreads();
-    if (threadIdx.x == 0) {
-      atomicAdd(counter_ptr, 1);
-    }
   }
 
   __device__ __forceinline__ void update(int new_flag_value) {
+    __syncthreads();
+    __threadfence_system();
+    if (threadIdx.x == 0) {
+      atomicAdd(counter_ptr, 1);
+    }
     if (blockIdx.x == 0 && threadIdx.x == 0) {
-      while (*reinterpret_cast<int volatile*>(counter_ptr) != gridDim.x) {
+      while (ld_global_acquire_sys(counter_ptr) != gridDim.x) {
       }
-      *flag_ptr = new_flag_value;
-      *counter_ptr = 0;
+      st_global_release_sys(counter_ptr, 0);
+      st_global_release_sys(flag_ptr, new_flag_value);
     }
   }
 
@@ -838,32 +849,37 @@ struct SyncComm {
 template <int NRanks>
 struct LamportComm {
   __device__ __forceinline__ LamportComm(void** workspace, int rank) {
-    counter_ptr = &reinterpret_cast<int*>(workspace[NRanks * 3])[0];
+    // Lamport one-shot and two-shot sync launches can be adjacent in captured
+    // graphs. Keep their CTA-completion counters separate.
+    counter_ptr = &reinterpret_cast<int*>(workspace[NRanks * 3])[5];
     flag_ptr = &reinterpret_cast<int*>(workspace[NRanks * 3])[2];
     clear_ptr = &reinterpret_cast<int*>(workspace[NRanks * 3])[4];
-    flag_value = *flag_ptr;
-    int comm_size = reinterpret_cast<int*>(workspace[NRanks * 3])[3];
-    clear_size = *clear_ptr;
-    int data_offset = flag_value % 3;
+    flag_value = ld_global_acquire_sys(flag_ptr);
+    int comm_size = ld_global_acquire_sys(&reinterpret_cast<int*>(workspace[NRanks * 3])[3]);
+    data_offset = flag_value % 3;
     int clear_offset = (flag_value + 2) % 3;
+    clear_size = ld_global_acquire_sys(clear_ptr);
     for (int r = 0; r < NRanks; ++r) {
       data_bufs[r] = reinterpret_cast<uint8_t*>(workspace[2 * NRanks + r]) +
                      static_cast<int64_t>(data_offset) * comm_size;
     }
     clear_buf = reinterpret_cast<uint8_t*>(workspace[2 * NRanks + rank]) + clear_offset * comm_size;
-    __syncthreads();
-    if (threadIdx.x == 0) {
-      atomicAdd(counter_ptr, 1);
-    }
   }
 
   __device__ __forceinline__ void update(int new_clear_size) {
+    __syncthreads();
+    __threadfence_system();
+    if (threadIdx.x == 0) {
+      atomicAdd(counter_ptr, 1);
+    }
     if (blockIdx.x == 0 && threadIdx.x == 0) {
-      while (*reinterpret_cast<int volatile*>(counter_ptr) != gridDim.x) {
+      while (ld_global_acquire_sys(counter_ptr) != gridDim.x) {
       }
-      *flag_ptr = (flag_value + 1) % 3;
-      *clear_ptr = new_clear_size;
-      *counter_ptr = 0;
+      // The generation flag is the publication point for the next launch. Reset
+      // the CTA counter and publish the next clear size before advancing it.
+      st_global_release_sys(counter_ptr, 0);
+      st_global_release_sys(clear_ptr, clear_size > new_clear_size ? clear_size : new_clear_size);
+      st_global_release_sys(flag_ptr, (flag_value + 1) % 3);
     }
   }
 
@@ -874,6 +890,7 @@ struct LamportComm {
   uint8_t* clear_buf;
   int clear_size;
   int flag_value;
+  int data_offset;
 };
 
 template <int NRanks>
@@ -892,6 +909,7 @@ class Barrier {
 
   __device__ __forceinline__ void sync() {
     __syncthreads();
+    __threadfence_system();
     if (threadIdx.x < NRanks) {
       m_flag_value = next_flag(m_flag_value);
       // To avoid the ABA problem, we need to synchronize the correct flag value to all
@@ -1303,14 +1321,11 @@ __global__ void allreduce_fusion_kernel_oneshot_lamport(
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaGridDependencySynchronize();
 #endif
-  // Load upstream-produced inputs only after gridDepSync, but before releasing
-  // PDL dependents that may reuse those producer buffers.
+  // Load upstream-produced inputs only after gridDepSync.
   fused_op.load_upstream_inputs();
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  if constexpr (!TriggerCompletionAtEnd) {
-    cudaTriggerProgrammaticLaunchCompletion();
-  }
-#endif
+  // This kernel reuses a shared Lamport workspace generation and CTA counter.
+  // Releasing PDL dependents before comm.update() lets a later fusion launch
+  // enter the same generation while this launch is still using it.
   LamportComm<NRanks> comm(params.workspace, params.rank);
   int clear_access = comm.clear_size / VEC_SIZE;
   for (int idx = access_id, tidx = token_id; idx < tot_access;
@@ -1328,14 +1343,16 @@ __global__ void allreduce_fusion_kernel_oneshot_lamport(
 #pragma unroll
     for (int r = 0; r < NRanks; ++r) {
       // Push data to other ranks
-      val.store(reinterpret_cast<T*>(comm.data_bufs[r]) +
-                (params.rank * tot_access + idx) * VEC_SIZE);
+      val.store_global_release(reinterpret_cast<T*>(comm.data_bufs[r]) +
+                               (params.rank * tot_access + idx) * VEC_SIZE);
     }
   }
+  __threadfence_system();
   for (int idx = access_id; idx < clear_access; idx += access_stride) {
-    // Clear comm buffer that previous kernel used
-    clear_vec.store(reinterpret_cast<T*>(comm.clear_buf) + idx * VEC_SIZE);
+    // Clear the Lamport slot used by the previous Lamport launch.
+    clear_vec.store_global_release(reinterpret_cast<T*>(comm.clear_buf) + idx * VEC_SIZE);
   }
+  __threadfence_system();
   for (int idx = access_id, tidx = token_id; idx < tot_access;
        idx += access_stride, tidx += token_stride) {
     fused_op.update(idx, res_add_before_reduce);
@@ -1347,8 +1364,8 @@ __global__ void allreduce_fusion_kernel_oneshot_lamport(
 #pragma unroll
       for (int r = 0; r < NRanks; ++r) {
         // LDG.128 from local rank
-        vals[r].load_global_volatile(reinterpret_cast<T*>(comm.data_bufs[params.rank]) +
-                                     (r * tot_access + idx) * VEC_SIZE);
+        vals[r].load_global_acquire(reinterpret_cast<T*>(comm.data_bufs[params.rank]) +
+                                    (r * tot_access + idx) * VEC_SIZE);
         done &= !has_neg_zero<T, VEC_SIZE>(vals[r]);
       }
     }
@@ -1368,9 +1385,7 @@ __global__ void allreduce_fusion_kernel_oneshot_lamport(
   comm.update(params.size * NRanks);
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-  if constexpr (TriggerCompletionAtEnd) {
-    cudaTriggerProgrammaticLaunchCompletion();
-  }
+  cudaTriggerProgrammaticLaunchCompletion();
 #endif
 }
 
@@ -1398,8 +1413,10 @@ __global__ void allreduce_fusion_kernel_twoshot_sync(AllReduceFusionParams<T> pa
     int comm_access_id = access_id + begin_tokens[r] * params.hidden_dim / VEC_SIZE;
     int comm_tot_access = (begin_tokens[r] + token_num_per_ranks[r]) * params.hidden_dim / VEC_SIZE;
     for (int idx = comm_access_id; idx < comm_tot_access; idx += access_stride) {
-      reinterpret_cast<float4*>(comm.comm_bufs[params.rank])[idx] =
-          reinterpret_cast<float4*>(params.allreduce_in)[idx];
+      vec_t<T, VEC_SIZE> val;
+      val.load(reinterpret_cast<T*>(params.allreduce_in) + idx * VEC_SIZE);
+      val.store_global_release(reinterpret_cast<T*>(comm.comm_bufs[params.rank]) +
+                               idx * VEC_SIZE);
     }
   }
   Barrier<NRanks> barrier(params.rank, comm);
@@ -1411,12 +1428,13 @@ __global__ void allreduce_fusion_kernel_twoshot_sync(AllReduceFusionParams<T> pa
     vec_t<T, VEC_SIZE> vals[NRanks];
 #pragma unroll
     for (int r = 0; r < NRanks; ++r) {
-      vals[r].load(reinterpret_cast<T*>(comm.comm_bufs[r]) + idx * VEC_SIZE);
+      vals[r].load_global_acquire(reinterpret_cast<T*>(comm.comm_bufs[r]) + idx * VEC_SIZE);
     }
     vec_t<T, VEC_SIZE> sum_val = allreduce_sum<T, VEC_SIZE, NRanks, Fp32Acc>(vals);
 #pragma unroll
     for (int r = 0; r < NRanks; ++r) {
-      sum_val.store(reinterpret_cast<T*>(comm.comm_bufs[r]) + (tot_access + idx) * VEC_SIZE);
+      sum_val.store_global_release(reinterpret_cast<T*>(comm.comm_bufs[r]) +
+                                   (tot_access + idx) * VEC_SIZE);
     }
   }
   barrier.sync();
@@ -1429,8 +1447,8 @@ __global__ void allreduce_fusion_kernel_twoshot_sync(AllReduceFusionParams<T> pa
          idx += access_stride, tidx += token_stride) {
       fused_op.update(idx, false);
       vec_t<T, VEC_SIZE> sum_val;
-      sum_val.load(reinterpret_cast<T*>(comm.comm_bufs[params.rank]) +
-                   (tot_access + idx) * VEC_SIZE);
+      sum_val.load_global_acquire(reinterpret_cast<T*>(comm.comm_bufs[params.rank]) +
+                                  (tot_access + idx) * VEC_SIZE);
       fused_op(sum_val, tidx, false, false, true, idx, idx);
     }
   }

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/include/flashinfer/comm/trtllm_reducescatter_fusion.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/include/flashinfer/comm/trtllm_reducescatter_fusion.cuh
@@ -55,6 +55,16 @@ static constexpr int kBarrierFlagCount = 256;
 
 }  // namespace details
 
+__device__ __forceinline__ int ld_global_acquire_sys(int* addr) {
+  int val;
+  asm volatile("ld.global.acquire.sys.b32 %0, [%1];" : "=r"(val) : "l"(addr));
+  return val;
+}
+
+__device__ __forceinline__ void st_global_release_sys(int* addr, int val) {
+  asm volatile("st.global.release.sys.b32 [%1], %0;" ::"r"(val), "l"(addr));
+}
+
 enum class ReduceScatterFusionPattern : int {
   kReduceScatter = 0,
   kRSResidualRMSNorm = 1,
@@ -157,23 +167,24 @@ struct RSyncComm {
   __device__ __forceinline__ RSyncComm(void** workspace) {
     counter_ptr = &reinterpret_cast<int*>(workspace[NRanks * 3])[0];
     flag_ptr = &reinterpret_cast<int*>(workspace[NRanks * 3])[1];
-    flag_value = *flag_ptr;
+    flag_value = ld_global_acquire_sys(flag_ptr);
     for (int r = 0; r < NRanks; ++r) {
       comm_bufs[r] = workspace[r];
       barrier_flags[r] = workspace[NRanks + r];
     }
-    __syncthreads();
-    if (threadIdx.x == 0) {
-      atomicAdd(counter_ptr, 1);
-    }
   }
 
   __device__ __forceinline__ void update(int new_flag_value) {
+    __syncthreads();
+    __threadfence_system();
+    if (threadIdx.x == 0) {
+      atomicAdd(counter_ptr, 1);
+    }
     if (blockIdx.x == 0 && threadIdx.x == 0) {
-      while (*reinterpret_cast<int volatile*>(counter_ptr) != gridDim.x) {
+      while (ld_global_acquire_sys(counter_ptr) != gridDim.x) {
       }
-      *flag_ptr = new_flag_value;
-      *counter_ptr = 0;
+      st_global_release_sys(counter_ptr, 0);
+      st_global_release_sys(flag_ptr, new_flag_value);
     }
   }
 
@@ -187,32 +198,35 @@ struct RSyncComm {
 template <int NRanks>
 struct RLamportComm {
   __device__ __forceinline__ RLamportComm(void** workspace, int rank) {
-    counter_ptr = &reinterpret_cast<int*>(workspace[NRanks * 3])[0];
+    // Lamport one-shot and two-shot sync launches can be adjacent in captured
+    // graphs. Keep their CTA-completion counters separate.
+    counter_ptr = &reinterpret_cast<int*>(workspace[NRanks * 3])[5];
     flag_ptr = &reinterpret_cast<int*>(workspace[NRanks * 3])[2];
     clear_ptr = &reinterpret_cast<int*>(workspace[NRanks * 3])[4];
-    flag_value = *flag_ptr;
-    int comm_size = reinterpret_cast<int*>(workspace[NRanks * 3])[3];
-    clear_size = *clear_ptr;
-    int data_offset = flag_value % 3;
+    flag_value = ld_global_acquire_sys(flag_ptr);
+    int comm_size = ld_global_acquire_sys(&reinterpret_cast<int*>(workspace[NRanks * 3])[3]);
+    data_offset = flag_value % 3;
     int clear_offset = (flag_value + 2) % 3;
+    clear_size = ld_global_acquire_sys(clear_ptr);
     for (int r = 0; r < NRanks; ++r) {
       data_bufs[r] = reinterpret_cast<uint8_t*>(workspace[2 * NRanks + r]) +
                      static_cast<int64_t>(data_offset) * comm_size;
     }
     clear_buf = reinterpret_cast<uint8_t*>(workspace[2 * NRanks + rank]) + clear_offset * comm_size;
-    __syncthreads();
-    if (threadIdx.x == 0) {
-      atomicAdd(counter_ptr, 1);
-    }
   }
 
   __device__ __forceinline__ void update(int new_clear_size) {
+    __syncthreads();
+    __threadfence_system();
+    if (threadIdx.x == 0) {
+      atomicAdd(counter_ptr, 1);
+    }
     if (blockIdx.x == 0 && threadIdx.x == 0) {
-      while (*reinterpret_cast<int volatile*>(counter_ptr) != gridDim.x) {
+      while (ld_global_acquire_sys(counter_ptr) != gridDim.x) {
       }
-      *flag_ptr = (flag_value + 1) % 3;
-      *clear_ptr = new_clear_size;
-      *counter_ptr = 0;
+      st_global_release_sys(counter_ptr, 0);
+      st_global_release_sys(clear_ptr, clear_size > new_clear_size ? clear_size : new_clear_size);
+      st_global_release_sys(flag_ptr, (flag_value + 1) % 3);
     }
   }
 
@@ -223,6 +237,7 @@ struct RLamportComm {
   uint8_t* clear_buf;
   int clear_size;
   int flag_value;
+  int data_offset;
 };
 
 template <int NRanks>
@@ -241,6 +256,7 @@ class RBarrier {
 
   __device__ __forceinline__ void sync() {
     __syncthreads();
+    __threadfence_system();
     if (threadIdx.x < NRanks) {
       m_flag_value = next_flag(m_flag_value);
       for (int flag_idx = blockIdx.x; flag_idx < details::kBarrierFlagCount;
@@ -1047,9 +1063,6 @@ __global__ void reducescatter_fusion_kernel_oneshot_lamport(ReduceScatterFusionP
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaGridDependencySynchronize();
-  if constexpr (!TriggerCompletionAtEnd) {
-    cudaTriggerProgrammaticLaunchCompletion();
-  }
 #endif
   RLamportComm<NRanks> comm(params.workspace, params.rank);
   int clear_access = comm.clear_size / VEC_SIZE;
@@ -1072,47 +1085,48 @@ __global__ void reducescatter_fusion_kernel_oneshot_lamport(ReduceScatterFusionP
         target_rank = remaining_tokens + (current_token_idx - threshold) / tokens_per_rank;
       }
     }
-    val.store(reinterpret_cast<T*>(comm.data_bufs[target_rank]) +
-              (params.rank * tot_access + idx) * VEC_SIZE);
+    val.store_global_release(reinterpret_cast<T*>(comm.data_bufs[target_rank]) +
+                             (params.rank * tot_access + idx) * VEC_SIZE);
   }
+  __threadfence_system();
 
-    for (int idx = access_id; idx < clear_access; idx += access_stride) {
-      clear_vec.store(reinterpret_cast<T*>(comm.clear_buf) + idx * VEC_SIZE);
-    }
+  for (int idx = access_id; idx < clear_access; idx += access_stride) {
+    // Clear the Lamport slot used by the previous Lamport launch.
+    clear_vec.store_global_release(reinterpret_cast<T*>(comm.clear_buf) + idx * VEC_SIZE);
+  }
+  __threadfence_system();
 
-    int start_idx = start_token_idx * access_per_token;
-    int end_idx = start_idx + token_count_this_rank * access_per_token;
+  int start_idx = start_token_idx * access_per_token;
+  int end_idx = start_idx + token_count_this_rank * access_per_token;
 
-    // idx:输入数据的全局地址(从所有 rank 的view获取); out_idx:输出地址
-    for (int idx = access_id + start_idx, out_idx = access_id; idx < end_idx;
-        idx += access_stride, out_idx += access_stride) {
-      ReduceScatterFusedOp<Pattern, T> fused_op(params, out_idx, access_id_in_token, token_count_this_rank);
-      fused_op.update(out_idx);
-      vec_t<T, VEC_SIZE> vals[NRanks];
-      bool done = false;
+  // idx:输入数据的全局地址(从所有 rank 的view获取); out_idx:输出地址
+  for (int idx = access_id + start_idx, out_idx = access_id; idx < end_idx;
+       idx += access_stride, out_idx += access_stride) {
+    ReduceScatterFusedOp<Pattern, T> fused_op(params, out_idx, access_id_in_token, token_count_this_rank);
+    fused_op.update(out_idx);
+    vec_t<T, VEC_SIZE> vals[NRanks];
+    bool done = false;
 
-      while (!done) {
-        done = true;
-  #pragma unroll
-        for (int r = 0; r < NRanks; ++r) {
-          vals[r].load_global_volatile(reinterpret_cast<T*>(comm.data_bufs[params.rank]) +
-                                      (r * tot_access + idx) * VEC_SIZE);
-          done &= !utils::has_neg_zero(vals[r]);
-        }
+    while (!done) {
+      done = true;
+#pragma unroll
+      for (int r = 0; r < NRanks; ++r) {
+        vals[r].load_global_acquire(reinterpret_cast<T*>(comm.data_bufs[params.rank]) +
+                                    (r * tot_access + idx) * VEC_SIZE);
+        done &= !utils::has_neg_zero(vals[r]);
       }
-
-      vec_t<T, VEC_SIZE> sum_val = reducescatter_sum<T, VEC_SIZE, NRanks, Fp32Acc>(vals);
-      int token_id_local = out_idx / (params.hidden_dim / VEC_SIZE);
-      fused_op(sum_val, token_id_local);
     }
 
-    comm.update(params.size * NRanks);
-
-  #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-    if constexpr (TriggerCompletionAtEnd) {
-      cudaTriggerProgrammaticLaunchCompletion();
+    vec_t<T, VEC_SIZE> sum_val = reducescatter_sum<T, VEC_SIZE, NRanks, Fp32Acc>(vals);
+    int token_id_local = out_idx / (params.hidden_dim / VEC_SIZE);
+    fused_op(sum_val, token_id_local);
     }
-  #endif
+
+  comm.update(params.size * NRanks);
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  cudaTriggerProgrammaticLaunchCompletion();
+#endif
 }
 
 template <ReduceScatterFusionPattern Pattern, typename T, int NRanks, bool Fp32Acc,
@@ -1147,8 +1161,10 @@ __global__ void reducescatter_fusion_kernel_twoshot_sync(
     int comm_access_id = access_id + begin_tokens[r] * params.hidden_dim / VEC_SIZE;
     int comm_tot_access = (begin_tokens[r] + token_num_per_ranks[r]) * params.hidden_dim / VEC_SIZE;
     for (int idx = comm_access_id; idx < comm_tot_access; idx += access_stride) {
-      reinterpret_cast<float4*>(comm.comm_bufs[params.rank])[idx] =
-          reinterpret_cast<float4*>(params.reducescatter_in)[idx];
+      vec_t<T, VEC_SIZE> val;
+      val.load(reinterpret_cast<T*>(params.reducescatter_in) + idx * VEC_SIZE);
+      val.store_global_release(reinterpret_cast<T*>(comm.comm_bufs[params.rank]) +
+                               idx * VEC_SIZE);
     }
   }
 
@@ -1164,12 +1180,13 @@ __global__ void reducescatter_fusion_kernel_twoshot_sync(
     vec_t<T, VEC_SIZE> vals[NRanks];
 #pragma unroll
     for (int r = 0; r < NRanks; ++r) {
-      vals[r].load(reinterpret_cast<T*>(comm.comm_bufs[r]) + idx * VEC_SIZE);
+      vals[r].load_global_acquire(reinterpret_cast<T*>(comm.comm_bufs[r]) + idx * VEC_SIZE);
     }
     vec_t<T, VEC_SIZE> sum_val = reducescatter_sum<T, VEC_SIZE, NRanks, Fp32Acc>(vals);
 #pragma unroll
     for (int r = 0; r < NRanks; ++r) {
-      sum_val.store(reinterpret_cast<T*>(comm.comm_bufs[r]) + (tot_access + idx) * VEC_SIZE);
+      sum_val.store_global_release(reinterpret_cast<T*>(comm.comm_bufs[r]) +
+                                   (tot_access + idx) * VEC_SIZE);
     }
   }
 
@@ -1180,8 +1197,8 @@ __global__ void reducescatter_fusion_kernel_twoshot_sync(
        idx += access_stride, out_idx += access_stride) {
     fused_op.update(out_idx);
     vec_t<T, VEC_SIZE> sum_val;
-    sum_val.load(reinterpret_cast<T*>(comm.comm_bufs[params.rank]) +
-                 (tot_access + idx) * VEC_SIZE);
+    sum_val.load_global_acquire(reinterpret_cast<T*>(comm.comm_bufs[params.rank]) +
+                                (tot_access + idx) * VEC_SIZE);
     // out_idx is already relative to this rank's output, so token_id_local should be in [0, token_num/world_size)
     int token_id_local = out_idx / (params.hidden_dim / VEC_SIZE);
     fused_op(sum_val, token_id_local);

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/trtllm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/trtllm.py
@@ -209,9 +209,11 @@ def _create_ipc_workspace(
         for rank in range(tp_size):
             workspace.append(ipc_handle[rank])
 
-    # Allocate and initialize flags: [0, 0, 0, lamport_comm_size, 0]
-    flag_ptr = cudart.cudaMalloc(5 * 4)
-    cudart.cudaMemset(flag_ptr, 0, 5 * 4)
+    # Allocate and initialize flags:
+    # [sync_counter, sync_flag, lamport_flag, lamport_comm_size,
+    #  lamport_clear_size, lamport_counter]
+    flag_ptr = cudart.cudaMalloc(6 * 4)
+    cudart.cudaMemset(flag_ptr, 0, 6 * 4)
     lamport_comm_size_bytes = lamport_comm_size.to_bytes(4, byteorder="little")
     cudart.cudaMemcpy(
         c_void_p(flag_ptr.value + 3 * 4), cast(lamport_comm_size_bytes, c_void_p), 4

--- a/tokenspeed-kernel/test/thirdparty/test_trtllm_comm.py
+++ b/tokenspeed-kernel/test/thirdparty/test_trtllm_comm.py
@@ -126,7 +126,7 @@ def _worker_allreduce(rank, world_size, port, results):
         import tokenspeed_kernel.thirdparty.cuda.trtllm as tk_comm
 
         hidden_dim = 4096
-        max_token_num = 128
+        max_token_num = 192
         eps = 1e-6
         dtype = torch.bfloat16
 
@@ -137,7 +137,25 @@ def _worker_allreduce(rank, world_size, port, results):
         )
 
         all_ok = True
-        for token_num in [1, 8, 16, 64]:
+        # Alternate one-shot and two-shot launches to exercise generation
+        # rotation, clear-size changes, and shared counter reset ordering.
+        token_cases = [
+            (1, True),
+            (64, True),
+            (129, False),
+            (8, True),
+            (160, False),
+            (128, True),
+            (2, True),
+            (192, False),
+            (16, True),
+            (127, True),
+            (136, False),
+            (4, True),
+            (64, True),
+            (1, True),
+        ]
+        for token_num, use_oneshot in token_cases:
             torch.manual_seed(42 + rank)
             ar_in = torch.randn(token_num, hidden_dim, dtype=dtype, device=device)
             res_in = torch.randn(token_num, hidden_dim, dtype=dtype, device=device)
@@ -168,7 +186,7 @@ def _worker_allreduce(rank, world_size, port, results):
                 trigger_completion_at_end=False,
                 fp32_acc=False,
                 pattern_code=tk_comm.AllReduceFusionPattern.kARResidualRMSNorm,
-                use_oneshot=True,
+                use_oneshot=use_oneshot,
                 allreduce_out=None,
                 residual_in=res_in,
                 residual_out=tk_res,
@@ -192,7 +210,7 @@ def _worker_allreduce(rank, world_size, port, results):
                 max_diff_r = (tk_res - ref_res).abs().max().item()
                 max_diff_n = (tk_norm - ref_norm).abs().max().item()
                 print(
-                    f"  allreduce tok={token_num}: {status}"
+                    f"  allreduce tok={token_num} oneshot={use_oneshot}: {status}"
                     f" (res_maxdiff={max_diff_r:.4f}, norm_maxdiff={max_diff_n:.4f})"
                 )
                 if not (res_close and norm_close):


### PR DESCRIPTION
## Summary                                                                      
                                                                                
Fix a silent cross-rank deadlock in the TRT-LLM all-reduce fusion communication kernels.                                                                        

Under Kimi-K2 NVFP4 TP8 with EAGLE3 speculative decode, the trtllm AR-fusion path could hang under load: all GPUs stayed pegged at 100%, scheduler output stopped, some ranks spun while others blocked in `cudaEventSynchronize`, and no CUDA/NCCL error was reported. The NCCL fallback path survived, so the issue was localized to the custom fusion kernels. 

## Root Cause

The fusion kernels were missing a complete system-scope publication protocol across all paths:

- Lamport one-shot payload writes were published to peer buffers without system-scope release ordering, while peers consumed them with volatile/global loads that did not provide matching acquire semantics.
- The two-shot path had the same ordering gap around `comm_bufs` payload writes, barrier flags, and peer reads.
- Lamport one-shot and two-shot sync reused the same CTA-completion counter in the shared workspace. With captured graphs, PDL, batch-size changes, and oneshot/twoshot transitions, this allowed control bookkeeping to desynchronize across launches. 
- Programmatic launch completion could be triggered before the kernel had completed the workspace generation update, allowing a dependent launch to observe stale or partially published state.

These could leave ranks disagreeing about which generation/flag/payload was current, producing a silent distributed spin instead of a reported failure.