### PR TITLE
chore(logits): drop prefill gather_ids fallback in LogitsProcessor

### DIFF
--- a/python/tokenspeed/runtime/execution/drafter/eagle.py
+++ b/python/tokenspeed/runtime/execution/drafter/eagle.py
@@ -126,13 +126,6 @@ class Eagle(BaseDrafter):
             device=self.device,
         )
 
-        # Per-request input length is always 1 in multi-step decode (one token per request).
-        self.draft_input_lengths_buf = torch.ones(
-            (self.input_buffers.max_bs,),
-            dtype=torch.int32,
-            device=self.device,
-        )
-
         # Precomputed `arange(max_bs) * spec_num_tokens - 1`
         # gather_ids = gather_ids_offsets + accept_lengths
         self.padded_gather_ids_offsets_buf = (
@@ -311,7 +304,6 @@ class Eagle(BaseDrafter):
         draft_seq_lens = self.draft_seq_lens_buf[:bs]
         torch.add(cache_start, 1, out=draft_seq_lens)
 
-        input_lengths = self.draft_input_lengths_buf[:bs]
         positions = cache_start.clone()
 
         for i in range(1, self.spec_num_steps):

--- a/python/tokenspeed/runtime/execution/drafter/eagle.py
+++ b/python/tokenspeed/runtime/execution/drafter/eagle.py
@@ -222,7 +222,7 @@ class Eagle(BaseDrafter):
         buffers = self.input_buffers
         forward_mode = draft_input.forward_mode
 
-        input_ids, unpadded_input_lengths, gather_ids = self._get_first_step_input(
+        input_ids, _, gather_ids = self._get_first_step_input(
             draft_input, bs, draft_input.input_num_tokens
         )
         input_ids = maybe_substitute_mm_pad(input_ids, self.mm_pad_substitute_id)
@@ -269,7 +269,6 @@ class Eagle(BaseDrafter):
             input_ids=input_ids,
             positions=buffers.positions_buf[: draft_input.input_num_tokens],
             out_cache_loc=buffers.out_cache_loc_buf[: draft_input.input_num_tokens],
-            input_lengths=unpadded_input_lengths,  # Used in logits processor
             captured_hidden_states=draft_input.base_out_hidden_states,
             spec_step_idx=0,
         )
@@ -356,7 +355,6 @@ class Eagle(BaseDrafter):
                     input_ids=self._map_hot(draft_ids),
                     positions=positions,
                     out_cache_loc=out_cache_loc,
-                    input_lengths=input_lengths,
                     captured_hidden_states=logits_output.hidden_states,
                     spec_step_idx=i,
                 )

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -390,7 +390,6 @@ class ModelExecutor:
             self.input_buffers.input_ids_buf[: ctx.input_num_tokens],
             positions,
             self.input_buffers.out_cache_loc_buf[: ctx.input_num_tokens],
-            self.input_buffers.input_lengths_buf[:bs],
             req_pool_indices=req_pool_indices,
             seq_lens=self.input_buffers.seq_lens_buf[:bs],
             extend_prefix_lens=self.input_buffers.extend_prefix_lens_buf[
@@ -932,7 +931,6 @@ class ModelExecutor:
             input_ids=empty,
             positions=empty,
             out_cache_loc=empty,
-            input_lengths=empty,
         )
 
         # If a drafter is active, its model also has MoE layers that issue
@@ -960,7 +958,6 @@ class ModelExecutor:
                     input_ids=empty,
                     positions=empty,
                     out_cache_loc=empty,
-                    input_lengths=empty,
                     spec_step_idx=step_idx,
                 )
 

--- a/python/tokenspeed/runtime/execution/model_runner.py
+++ b/python/tokenspeed/runtime/execution/model_runner.py
@@ -132,7 +132,6 @@ class ModelRunner:
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         out_cache_loc: torch.Tensor,
-        input_lengths: torch.Tensor,
         req_pool_indices: torch.Tensor | None = None,
         seq_lens: torch.Tensor | None = None,
         extend_prefix_lens: torch.Tensor | None = None,
@@ -163,6 +162,5 @@ class ModelRunner:
             input_ids,
             positions,
             out_cache_loc,
-            input_lengths,
             **kwargs,
         )

--- a/python/tokenspeed/runtime/layers/logits_processor.py
+++ b/python/tokenspeed/runtime/layers/logits_processor.py
@@ -85,7 +85,6 @@ class LogitsMetadata:
     extend_return_logprob: bool = False
     extend_return_top_logprob: bool = False
     extend_token_ids_logprob: bool = False
-    extend_seq_lens: torch.Tensor | None = None
     extend_seq_lens_cpu: list[int] | None = None
     extend_logprob_start_lens_cpu: list[int] | None = None
     extend_logprob_pruned_lens_cpu: list[int] | None = None
@@ -113,16 +112,11 @@ class LogitsMetadata:
     global_num_tokens_for_logprob_gpu: torch.Tensor | None = None
 
     @classmethod
-    def from_forward_context(
-        cls,
-        ctx: ForwardContext,
-        input_lengths: torch.Tensor,
-    ):
+    def from_forward_context(cls, ctx: ForwardContext):
         return cls(
             forward_mode=ctx.forward_mode,
             capture_hidden_mode=ctx.capture_hidden_mode,
             gather_ids=ctx.gather_ids,
-            extend_seq_lens=input_lengths,
         )
 
 
@@ -252,13 +246,10 @@ class LogitsProcessor(nn.Module):
                     pruned_states = hidden_states[gather_ids]
                     if aux_hidden_states is not None:
                         aux_pruned_states = [h[gather_ids] for h in aux_hidden_states]
-            elif logits_metadata.forward_mode.is_extend_or_mixed():
-                # Fallback for prefill callers that do not precompute gather_ids.
-                last_index = torch.cumsum(logits_metadata.extend_seq_lens, dim=0) - 1
-                pruned_states = hidden_states[last_index]
-                if aux_hidden_states is not None:
-                    aux_pruned_states = [h[last_index] for h in aux_hidden_states]
             else:
+                assert (
+                    not logits_metadata.forward_mode.is_extend_or_mixed()
+                ), "EXTEND/MIXED forward must set gather_ids on ForwardContext"
                 pruned_states = hidden_states
                 if aux_hidden_states is not None:
                     aux_pruned_states = list(aux_hidden_states)

--- a/python/tokenspeed/runtime/models/base/causal_lm.py
+++ b/python/tokenspeed/runtime/models/base/causal_lm.py
@@ -145,7 +145,6 @@ class BaseCausalLM(nn.Module):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         out_cache_loc: torch.Tensor,
-        input_lengths: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
 
@@ -158,7 +157,7 @@ class BaseCausalLM(nn.Module):
             out_cache_loc,
             **model_kwargs,
         )
-        logits_metadata = LogitsMetadata.from_forward_context(ctx, input_lengths)
+        logits_metadata = LogitsMetadata.from_forward_context(ctx)
 
         return self.logits_processor(
             input_ids,

--- a/python/tokenspeed/runtime/models/deepseek_nextn.py
+++ b/python/tokenspeed/runtime/models/deepseek_nextn.py
@@ -215,7 +215,6 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         out_cache_loc: torch.Tensor,
-        input_lengths: torch.Tensor,
         captured_hidden_states: torch.Tensor | None = None,
     ) -> torch.Tensor:
         hidden_states, _ = self.model(
@@ -225,7 +224,7 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
             out_cache_loc,
             captured_hidden_states=captured_hidden_states,
         )
-        logits_metadata = LogitsMetadata.from_forward_context(ctx, input_lengths)
+        logits_metadata = LogitsMetadata.from_forward_context(ctx)
         return self.logits_processor(
             input_ids, hidden_states, self.lm_head, logits_metadata
         )

--- a/python/tokenspeed/runtime/models/deepseek_v4_mtp.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_mtp.py
@@ -327,7 +327,6 @@ class DeepseekV4ForCausalLMNextN(nn.Module):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         out_cache_loc: torch.Tensor,
-        input_lengths: torch.Tensor,
         input_embeds: Optional[torch.Tensor] = None,
         captured_hidden_states: Optional[torch.Tensor] = None,
         spec_step_idx: int = 0,
@@ -357,7 +356,7 @@ class DeepseekV4ForCausalLMNextN(nn.Module):
             mtp_hidden_states,
             spec_step_idx,
         )
-        logits_metadata = LogitsMetadata.from_forward_context(ctx, input_lengths)
+        logits_metadata = LogitsMetadata.from_forward_context(ctx)
         return self.logits_processor(
             input_ids,
             logits_hidden_states,

--- a/python/tokenspeed/runtime/models/extensible.py
+++ b/python/tokenspeed/runtime/models/extensible.py
@@ -75,10 +75,9 @@ class OutputProcessorBase(nn.Module):
         input_ids: Tensor,
         positions: Tensor,
         ctx: ForwardContext,
-        input_lengths: Tensor,
         output_hidden_states: Tensor,
     ) -> LogitsProcessorOutput:
-        logits_metadata = LogitsMetadata.from_forward_context(ctx, input_lengths)
+        logits_metadata = LogitsMetadata.from_forward_context(ctx)
         return self.base_lm.logits_processor(
             input_ids,
             output_hidden_states,
@@ -165,7 +164,6 @@ class ExtensibleLM(nn.Module):
         input_ids: Tensor,
         positions: Tensor,
         out_cache_loc: Tensor,
-        input_lengths: Tensor,
         input_embeds: Tensor = None,
     ) -> LogitsProcessorOutput:
         # input processor: get input hidden states
@@ -184,7 +182,7 @@ class ExtensibleLM(nn.Module):
 
         # output processor: lm hidden states to logits
         logits_output: LogitsProcessorOutput = self.output_processor(
-            input_ids, positions, ctx, input_lengths, out_hidden_states
+            input_ids, positions, ctx, out_hidden_states
         )
         self.step += 1
         return logits_output

--- a/python/tokenspeed/runtime/models/kimi_k25.py
+++ b/python/tokenspeed/runtime/models/kimi_k25.py
@@ -870,7 +870,6 @@ class KimiK25ForConditionalGeneration(nn.Module):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         out_cache_loc: torch.Tensor,
-        input_lengths: torch.Tensor,
         **kwargs,
     ):
         if self.language_model is None:
@@ -897,7 +896,6 @@ class KimiK25ForConditionalGeneration(nn.Module):
             input_ids,
             positions,
             out_cache_loc,
-            input_lengths,
             **kwargs,
         )
 

--- a/python/tokenspeed/runtime/models/qwen3_5.py
+++ b/python/tokenspeed/runtime/models/qwen3_5.py
@@ -1249,7 +1249,6 @@ class Qwen3_5ForConditionalGeneration(BaseCausalLM):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         out_cache_loc: torch.Tensor,
-        input_lengths: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
         multimodal_context = kwargs.pop("multimodal_context", None)
@@ -1263,7 +1262,6 @@ class Qwen3_5ForConditionalGeneration(BaseCausalLM):
                 input_ids,
                 positions,
                 out_cache_loc,
-                input_lengths,
                 **kwargs,
             )
 
@@ -1286,7 +1284,7 @@ class Qwen3_5ForConditionalGeneration(BaseCausalLM):
             input_embeds=input_embeds,
             **model_kwargs,
         )
-        logits_metadata = LogitsMetadata.from_forward_context(ctx, input_lengths)
+        logits_metadata = LogitsMetadata.from_forward_context(ctx)
         return self.logits_processor(
             input_ids,
             hidden_states,

--- a/python/tokenspeed/runtime/models/qwen3_5_nextn.py
+++ b/python/tokenspeed/runtime/models/qwen3_5_nextn.py
@@ -135,7 +135,6 @@ class Qwen3_5ForConditionalGenerationNextN(nn.Module):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         out_cache_loc: torch.Tensor,
-        input_lengths: torch.Tensor,
         input_embeds: torch.Tensor | None = None,
         captured_hidden_states: torch.Tensor | None = None,
         **kwargs,
@@ -170,7 +169,7 @@ class Qwen3_5ForConditionalGenerationNextN(nn.Module):
             input_embeds=hidden_states,
         )
 
-        logits_metadata = LogitsMetadata.from_forward_context(ctx, input_lengths)
+        logits_metadata = LogitsMetadata.from_forward_context(ctx)
         return self.logits_processor(
             input_ids, hidden_states, self.lm_head, logits_metadata
         )

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -330,7 +330,6 @@ class TestDeepseekV4Config(unittest.TestCase):
                 input_ids,
                 positions,
                 out_cache_loc,
-                input_lengths,
                 spec_step_idx=0,
             ):
                 self.received_spec_step_idx = spec_step_idx
@@ -349,7 +348,6 @@ class TestDeepseekV4Config(unittest.TestCase):
             input_ids=empty,
             positions=empty,
             out_cache_loc=empty,
-            input_lengths=empty,
             spec_step_idx=2,
         )
 
@@ -364,7 +362,6 @@ class TestDeepseekV4Config(unittest.TestCase):
                 input_ids,
                 positions,
                 out_cache_loc,
-                input_lengths,
             ):
                 return "ok"
 
@@ -381,7 +378,6 @@ class TestDeepseekV4Config(unittest.TestCase):
             input_ids=empty,
             positions=empty,
             out_cache_loc=empty,
-            input_lengths=empty,
             spec_step_idx=2,
         )
 
@@ -398,7 +394,6 @@ class TestDeepseekV4Config(unittest.TestCase):
                 input_ids,
                 positions,
                 out_cache_loc,
-                input_lengths,
                 **kwargs,
             ):
                 self.received_kwargs = kwargs
@@ -417,7 +412,6 @@ class TestDeepseekV4Config(unittest.TestCase):
             input_ids=empty,
             positions=empty,
             out_cache_loc=empty,
-            input_lengths=empty,
             spec_step_idx=2,
         )
 

--- a/test/runtime/test_logits_processor.py
+++ b/test/runtime/test_logits_processor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import sys
-from types import SimpleNamespace
 
 # CI Registration (parsed via AST, runtime no-op)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -15,44 +14,7 @@ register_cuda_ci(est_time=90, suite="runtime-1gpu")
 import pytest
 import torch
 
-from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
-from tokenspeed.runtime.layers.logits_processor import (
-    LogitsMetadata,
-    LogitsProcessor,
-    fused_softcap,
-)
-
-
-@pytest.mark.parametrize("forward_mode", [ForwardMode.EXTEND, ForwardMode.MIXED])
-def test_logits_processor_extend_without_gather_ids_uses_request_last_tokens(
-    forward_mode,
-):
-    processor = LogitsProcessor(config=SimpleNamespace(model_type="test", vocab_size=3))
-    hidden_states = torch.tensor(
-        [
-            [1.0, 0.0, 0.0],
-            [2.0, 0.0, 0.0],
-            [0.0, 3.0, 0.0],
-            [0.0, 4.0, 0.0],
-            [0.0, 5.0, 0.0],
-        ],
-        dtype=torch.float32,
-    )
-    lm_head = SimpleNamespace(weight=torch.eye(3, dtype=torch.float32))
-    metadata = LogitsMetadata(
-        forward_mode=forward_mode,
-        gather_ids=None,
-        extend_seq_lens=torch.tensor([2, 3], dtype=torch.int32),
-    )
-
-    out = processor(
-        input_ids=None,
-        hidden_states=hidden_states,
-        lm_head=lm_head,
-        logits_metadata=metadata,
-    )
-
-    torch.testing.assert_close(out.next_token_logits, hidden_states[[1, 4]])
+from tokenspeed.runtime.layers.logits_processor import fused_softcap
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")


### PR DESCRIPTION
### Summary
Remove the legacy prefill gather fallback in LogitsProcessor: when gather_ids was missing on EXTEND/MIXED, it used cumsum(extend_seq_lens) - 1 to pick last-token rows. Production already sets gather_ids in model_executor (prefill/MIXED) and eagle (draft first step), so that path was unused.

Delete LogitsMetadata.extend_seq_lens (tensor) and stop passing input_lengths into model forward / from_forward_context only for logits wiring.
Assert if EXTEND/MIXED reach LogitsProcessor without gather_ids.
Keep the gather_ids is None → use full hidden_states path for decode / TARGET_VERIFY / DP idle.