### PR TITLE
[Perf] Parallelize split-k reduce in mha_decode_fp16_gfx950 kernel

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/mha_decode_fp16_gfx950.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/mha_decode_fp16_gfx950.py
@@ -118,7 +118,7 @@ class AttentionConfig:
         v_layout = gl.DotOperandLayout(1, pv_layout, k_width=4)
         load_layout = gl.BlockedLayout([1, 8], [8, 8], [1, 1], [1, 0])
         store_layout = gl.BlockedLayout([1, 8], [8, 8], [1, 1], [1, 0])
-        reduce_layout = gl.BlockedLayout([1], [64], [1], [0])
+        reduce_layout = gl.BlockedLayout([1, 1], [1, HEAD_DIM], [1, 1], [1, 0])
         k_smem_layout = gl.PaddedSharedLayout.with_identity_for(
             [[512, 8]], [BLOCK_N, HEAD_DIM], [1, 0]
         )
@@ -653,39 +653,41 @@ def _mha_decode_reduce_fp16(
     end_page = cdiv(cache_len, cfg.PAGE_SIZE)
     num_pages = end_page - first_page
     pages_per_split = cdiv(num_pages, cfg.NUM_KV_SPLITS)
-    offs_d = gl.arange(0, cfg.HEAD_DIM, layout=cfg.reduce_layout)
-    if HAS_SINK:
-        m_i = gl.load(sink_ptr + q_head).to(gl.float32) * _INV_LN2
-        l_i = gl.full((), value=1.0, dtype=gl.float32)
-    else:
-        m_i = gl.full((), value=-float("inf"), dtype=gl.float32)
-        l_i = gl.full((), value=0.0, dtype=gl.float32)
-    acc = gl.full([cfg.HEAD_DIM], value=0.0, dtype=gl.float32, layout=cfg.reduce_layout)
 
-    for split_id in range(0, cfg.NUM_KV_SPLITS):
-        split_start_page = first_page + split_id * pages_per_split
-        split_end_page = min(split_start_page + pages_per_split, end_page)
-        split_start = split_start_page * cfg.PAGE_SIZE
-        split_end = min(split_end_page * cfg.PAGE_SIZE, cache_len)
-        if split_start < split_end:
-            mid_o_base = (
-                (batch * cfg.NUM_Q_HEADS + q_head) * cfg.NUM_KV_SPLITS + split_id
-            ) * cfg.HEAD_DIM
-            mid_lse_offset = (
-                batch * cfg.NUM_Q_HEADS + q_head
-            ) * cfg.NUM_KV_SPLITS + split_id
-            part_o = cdna4.buffer_load(mid_o_ptr, mid_o_base + offs_d)
-            part_lse = gl.load(mid_lse_ptr + mid_lse_offset)
-            m_new = maximum(m_i, part_lse)
-            alpha = gl.exp2(m_i - m_new)
-            beta = gl.exp2(part_lse - m_new)
-            acc = acc * alpha + part_o * beta
-            l_i = l_i * alpha + beta
-            m_i = m_new
+    # SPLIT_TILE pads NUM_KV_SPLITS up to a power of 2.
+    SPLIT_TILE: gl.constexpr = 1 << (NUM_KV_SPLITS - 1).bit_length()
+    offs_s = gl.arange(0, SPLIT_TILE, layout=gl.SliceLayout(1, cfg.reduce_layout))
+    offs_d = gl.arange(0, cfg.HEAD_DIM, layout=gl.SliceLayout(0, cfg.reduce_layout))
+    # split_valid masks out empty splits and the power-of-2 padding tail.
+    split_start_page = first_page + offs_s * pages_per_split
+    split_end_page_raw = split_start_page + pages_per_split
+    split_end_page = gl.where(
+        split_end_page_raw < end_page, split_end_page_raw, end_page
+    )
+    split_start_tok = split_start_page * cfg.PAGE_SIZE
+    split_end_raw = split_end_page * cfg.PAGE_SIZE
+    split_end_tok = gl.where(split_end_raw < cache_len, split_end_raw, cache_len)
+    split_valid = (split_start_tok < split_end_tok) & (offs_s < cfg.NUM_KV_SPLITS)
+    # Load every split's partial output and lse.
+    base = (batch * cfg.NUM_Q_HEADS + q_head) * cfg.NUM_KV_SPLITS + offs_s
+    part_lse = gl.load(mid_lse_ptr + base, mask=split_valid, other=-float("inf"))
+    o_off = base[:, None] * cfg.HEAD_DIM + offs_d[None, :]
+    part_o = cdna4.buffer_load(mid_o_ptr, o_off, mask=split_valid[:, None], other=0.0)
+
+    # Global softmax max over all splits (folding in the sink).
+    m_i = max(part_lse, axis=0)
+    if HAS_SINK:
+        sink = gl.load(sink_ptr + q_head).to(gl.float32) * _INV_LN2
+        m_i = maximum(m_i, sink)
+    # Weighted sum of the split partials, normalized by the total softmax mass.
+    beta = gl.exp2(part_lse - m_i)
+    l_i = gl.sum(beta, axis=0)
+    if HAS_SINK:
+        l_i = l_i + gl.exp2(sink - m_i)
+    acc = gl.sum(part_o * beta[:, None], axis=0)
 
     out_base = (batch * cfg.NUM_Q_HEADS + q_head) * cfg.HEAD_DIM
-    l_i_recip = 1.0 / l_i
-    output = acc * l_i_recip
+    output = acc * (1.0 / l_i)
     output = output.to(out_ptr.dtype.element_ty)
     cdna4.buffer_store(output, out_ptr, out_base + offs_d)
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/mha_decode_fp16_gfx950.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/mha_decode_fp16_gfx950.py
@@ -118,7 +118,7 @@ class AttentionConfig:
         v_layout = gl.DotOperandLayout(1, pv_layout, k_width=4)
         load_layout = gl.BlockedLayout([1, 8], [8, 8], [1, 1], [1, 0])
         store_layout = gl.BlockedLayout([1, 8], [8, 8], [1, 1], [1, 0])
-        reduce_layout = gl.BlockedLayout([1, 1], [1, HEAD_DIM], [1, 1], [1, 0])
+        reduce_layout = gl.BlockedLayout([1, 1], [1, 64], [1, 1], [1, 0])
         k_smem_layout = gl.PaddedSharedLayout.with_identity_for(
             [[512, 8]], [BLOCK_N, HEAD_DIM], [1, 0]
         )
@@ -624,8 +624,6 @@ def _mha_decode_reduce_fp16(
     BLOCK_M: gl.constexpr,
     BLOCK_N: gl.constexpr,
     HAS_SINK: gl.constexpr,
-    IS_SLIDING: gl.constexpr,
-    WINDOW_LEFT: gl.constexpr,
 ):
     cfg = AttentionConfig(
         SM_SCALE,
@@ -637,19 +635,14 @@ def _mha_decode_reduce_fp16(
         HEAD_DIM,
         BLOCK_M,
         BLOCK_N,
-        IS_SLIDING,
-        WINDOW_LEFT,
+        False,  # IS_SLIDING
+        -1,  # WINDOW_LEFT
         InputStrides(1, 1, 1),
     )
     batch = gl.program_id(0)
     q_head = gl.program_id(1)
     cache_len = gl.load(cache_seqlens_ptr + batch)
-    if cfg.IS_SLIDING:
-        window_len = min(cache_len, cfg.WINDOW_LEFT)
-        kv_start = cache_len - window_len
-    else:
-        kv_start = cache_len - cache_len
-    first_page = kv_start // cfg.PAGE_SIZE
+    first_page = 0
     end_page = cdiv(cache_len, cfg.PAGE_SIZE)
     num_pages = end_page - first_page
     pages_per_split = cdiv(num_pages, cfg.NUM_KV_SPLITS)
@@ -918,8 +911,6 @@ def gluon_mha_decode_fp16_gfx950(
             config.block_m,
             config.block_n,
             has_sink,
-            config.is_sliding,
-            config.window_left,
             num_warps=1,
         )
     return output

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/mha_decode_fp16_gfx950.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/mha_decode_fp16_gfx950.py
@@ -707,20 +707,25 @@ def _select_num_kv_splits(
 
     Return the smaller of two candidate counts: splits_for_occupancy (enough to
     fill ~wave_target waves of CUs) and splits_for_pages (~min_pages_per_split
-    pages per split, but at least min(min_page_splits, num_pages) so a short
-    context still splits without launching empty work).
+    pages per split), with the pages candidate clamped to [min_page_splits,
+    max_page_splits] so a short context still splits without launching empty work
+    and a long one does not over-split where reduce cost outgrows the decode win.
     """
     wave_target = 2
-    min_pages_per_split = 8
+    min_pages_per_split = 2
     min_page_splits = 8
+    max_page_splits = 32
 
     base_ctas = batch * num_kv_heads * num_groups
     target_ctas = current_platform().sm_count * wave_target
     splits_for_occupancy = (target_ctas + base_ctas - 1) // base_ctas
+
     splits_for_pages = num_pages // min_pages_per_split
-    page_splits_floor = min(min_page_splits, num_pages)
-    if splits_for_pages < page_splits_floor:
-        splits_for_pages = page_splits_floor
+    min_page_splits = min(min_page_splits, num_pages)
+    if splits_for_pages < min_page_splits:
+        splits_for_pages = min_page_splits
+    if splits_for_pages > max_page_splits:
+        splits_for_pages = max_page_splits
     return min(splits_for_occupancy, splits_for_pages)
 
 


### PR DESCRIPTION
- **Parallel split-k reduce.** Replace the reduce kernel's serial online-softmax
  scan over KV splits with a single-pass parallel reduction: one program per
  `(batch, q_head)` loads every split's partials as one `[SPLIT_TILE, HEAD_DIM]`
  tile and reduces over the split axis. Removes the serial `mid_o` load wall that
  dominated the low-batch / long-context regime.
- **Retuned `num_kv_splits`.** With reduce now cheap, drop the conservative pages
  cap (`min_pages_per_split` 8→2) and add an explicit `max_page_splits = 32` so
  low-batch / long-context workloads use more mha parallelism without
  over-splitting; high-batch stays occupancy-bound (unchanged).
  
### kernel speedup (mha+ reduce, >1 is good)
| batch ＼ seqlen | 1k    | 2k    | 4k    | 8k    | 16k   |
| -------------- | ----- | ----- | ----- | ----- | ----- |
| 1              | 1.18x | 1.41x | 1.55x | 1.70x | 1.53x |
| 2              | 1.44x | 1.28x | 1.56x | 1.57x | 1.47x |
| 4              | 1.28x | 1.32x | 1.45x | 1.21x | 1.05x |
| 8              | 1.20x | 1.19x | 1.10x | 1.00x | 1.01x |
| 16             | 1.04x | 1.12x | 1.00x | 0.97x | 1.01x |

### detailed latency — `baseline total (mha+reduce) / PR total (mha+reduce)` µs
| batch ＼ seqlen | 1k | 2k | 4k | 8k | 16k |
| -------------- | -- | -- | -- | -- | --- |
| 1  | 8.7 (4.6+4.1) / 7.4 (4.5+2.9)  | 9.0 (5.5+3.5) / 6.4 (4.0+2.4)  | 13.0 (9.1+3.9) / 8.4 (4.6+3.8)  | 15.1 (8.7+6.5) / 8.9 (5.7+3.2)   | 21.0 (10.7+10.3) / 13.7 (10.4+3.2) |
| 2  | 9.1 (4.5+4.6) / 6.3 (4.0+2.3)  | 9.7 (5.6+4.2) / 7.6 (4.6+3.0)  | 13.9 (9.3+4.6) / 8.9 (5.1+3.8)  | 18.1 (11.0+7.1) / 11.5 (7.8+3.7) | 23.2 (13.0+10.2) / 15.8 (13.0+2.8) |
| 4  | 8.2 (4.0+4.1) / 6.4 (4.1+2.3)  | 11.1 (6.3+4.7) / 8.4 (5.3+3.1) | 14.6 (10.4+4.2) / 10.1 (7.4+2.7) | 18.8 (12.4+6.4) / 15.6 (12.8+2.8) | 27.2 (21.3+5.9) / 25.8 (21.9+3.9) |
| 8  | 9.5 (5.2+4.3) / 7.9 (5.2+2.7)  | 12.4 (7.8+4.6) / 10.4 (7.6+2.8) | 16.1 (12.3+3.7) / 14.7 (12.7+2.0) | 25.8 (21.9+3.9) / 25.7 (21.8+3.9) | 44.0 (39.9+4.0) / 43.7 (39.8+3.9) |
| 16 | 11.2 (7.6+3.6) / 10.8 (7.9+3.0) | 16.1 (12.7+3.4) / 14.4 (12.2+2.2) | 25.4 (21.5+3.9) / 25.5 (21.6+3.9) | 43.3 (39.3+4.0) / 44.6 (40.5+4.0) | 102.7 (97.9+4.8) / 101.8 (97.0+4.8) |
