### PR TITLE
fix(deepseek-v4): defer mega-MoE warmup and fix MoE TP weight loading

### DIFF
--- a/python/tokenspeed/runtime/layers/moe/backends/base.py
+++ b/python/tokenspeed/runtime/layers/moe/backends/base.py
@@ -112,6 +112,7 @@ class MoEBackend(ABC):
             is_bias=is_bias,
             use_presharded_weights=use_presharded_weights,
             do_transpose=do_transpose,
+            tp_size=self.spec.tp_size,
         )
 
     def _make_group_scale_loader(self, *, do_transpose: bool = False) -> Callable:

--- a/python/tokenspeed/runtime/layers/moe/backends/weight_loaders.py
+++ b/python/tokenspeed/runtime/layers/moe/backends/weight_loaders.py
@@ -45,6 +45,7 @@ def _load_w13(
     use_presharded_weights: bool,
     do_transpose: bool,
     load_up_proj_weight_first: bool,
+    tp_size: int = 1,
 ):
     # Index the loaded weight for tp sharding.
     # gate_up_proj: "MergedColumnParallel", so tp sharding on output_dim
@@ -75,15 +76,23 @@ def _load_w13(
 
     if not use_presharded_weights:
         if not is_bias and do_transpose:
-            # do not transpose for bias
             loaded_weight = loaded_weight.transpose(-2, -1)
-        loaded_weight = loaded_weight.narrow(
-            shard_dim, shard_size * tp_rank, shard_size
-        )
+        if tp_size > 1:
+            # Derive the unpadded shard size from the checkpoint tensor.
+            # expert_data may be Blackwell-padded; checkpoint is not.
+            load_shard = loaded_weight.shape[shard_dim] // tp_size
+            loaded_weight = loaded_weight.narrow(
+                shard_dim, load_shard * tp_rank, load_shard
+            )
+        else:
+            loaded_weight = loaded_weight.narrow(
+                shard_dim, shard_size * tp_rank, shard_size
+            )
 
     expert_data = expert_data.narrow(shard_dim, start, shard_size)
-    loaded_weight = _preserve_e8m0_bytes_for_uint8_param(expert_data, loaded_weight)
-    expert_data.copy_(loaded_weight)
+    dst = expert_data.narrow(shard_dim, 0, loaded_weight.shape[shard_dim])
+    loaded_weight = _preserve_e8m0_bytes_for_uint8_param(dst, loaded_weight)
+    dst.copy_(loaded_weight)
 
 
 def _load_w2(
@@ -95,6 +104,7 @@ def _load_w2(
     is_bias: bool,
     use_presharded_weights: bool,
     do_transpose: bool,
+    tp_size: int = 1,
 ):
     if not isinstance(expert_data, torch.Tensor) or not isinstance(
         loaded_weight, torch.Tensor
@@ -118,15 +128,19 @@ def _load_w2(
 
     if not use_presharded_weights:
         if not is_bias and do_transpose:
-            # do not transpose for bias
             loaded_weight = loaded_weight.transpose(-2, -1)
+        if tp_size > 1:
+            load_shard = loaded_weight.shape[shard_dim] // tp_size
+        else:
+            load_shard = shard_size
         loaded_weight = loaded_weight.narrow(
-            shard_dim, shard_size * tp_rank, shard_size
+            shard_dim, load_shard * tp_rank, load_shard
         )
 
     # w2, down_proj: Load into only logical weight of w2.
-    loaded_weight = _preserve_e8m0_bytes_for_uint8_param(expert_data, loaded_weight)
-    expert_data.copy_(loaded_weight)
+    dst = expert_data.narrow(shard_dim, 0, loaded_weight.shape[shard_dim])
+    loaded_weight = _preserve_e8m0_bytes_for_uint8_param(dst, loaded_weight)
+    dst.copy_(loaded_weight)
 
 
 def get_shard_dim(param, shard_id, do_transpose):
@@ -150,6 +164,7 @@ def load_model_weight(
     is_bias: bool,
     use_presharded_weights: bool,
     do_transpose: bool,
+    tp_size: int = 1,
 ):
     expert_data = param.data[local_expert_id]
     shard_dim = get_shard_dim(param, shard_id, do_transpose)
@@ -170,6 +185,7 @@ def load_model_weight(
         is_bias,
         use_presharded_weights,
         do_transpose,
+        tp_size=tp_size,
     )
 
 

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -2243,17 +2243,19 @@ class DeepseekV4MegaMoEExperts(nn.Module):
             (1, DEEPSEEK_V4_MXFP4_BLOCK_SIZE),
             self.num_local_experts,
         )
-        self._transformed_l1_weights, self._transformed_l2_weights = (
-            deep_gemm.transform_weights_for_mega_moe(
-                (self.w13_weight.data.view(torch.int8).contiguous(), w13_scale),
-                (self.w2_weight.data.view(torch.int8).contiguous(), w2_scale),
-            )
+        l1, l2 = deep_gemm.transform_weights_for_mega_moe(
+            (self.w13_weight.data.view(torch.int8).contiguous(), w13_scale),
+            (self.w2_weight.data.view(torch.int8).contiguous(), w2_scale),
         )
+        # L2 data tensor may alias the input .contiguous() buffer — clone
+        # to break the reference so the original weight storage can be freed.
+        self._transformed_l1_weights = l1
+        self._transformed_l2_weights = (l2[0].clone(), l2[1])
 
-        self.w13_weight = None
-        self.w13_weight_scale = None
-        self.w2_weight = None
-        self.w2_weight_scale = None
+        del self.w13_weight
+        del self.w13_weight_scale
+        del self.w2_weight
+        del self.w2_weight_scale
 
     def get_symm_buffer(self):
         if deep_gemm is None:
@@ -4117,7 +4119,9 @@ class DeepseekV4ForCausalLM(BaseCausalLM):
                     continue
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
+        del params_dict, moe_loader
         self.post_load_weights()
+        self.warmup_mega_moe()
 
     def post_load_weights(self):
         mega_moe_experts: list[DeepseekV4MegaMoEExperts] = []
@@ -4129,18 +4133,25 @@ class DeepseekV4ForCausalLM(BaseCausalLM):
                 mega_moe_experts.append(module)
             elif isinstance(module, MoELayer):
                 module.process_weights_after_loading(module)
-        # Pre-compile the DeepGEMM mega-MoE tiles now so DeepGEMM never JITs on
-        # the serving hot path: a cold mid-serving compile stalls one EP rank
-        # past the NVLink barrier's 30 s timeout and aborts the job. Tiles are
-        # cached by GEMM shape + token count (not by layer), so warming one
-        # experts module covers every layer. Opt out with
-        # TOKENSPEED_DISABLE_MEGA_MOE_WARMUP=1.
-        if (
-            mega_moe_experts
-            and os.environ.get("TOKENSPEED_DISABLE_MEGA_MOE_WARMUP") != "1"
-        ):
-            logger.info("Pre-compiling DeepGEMM mega-MoE kernel variants...")
-            mega_moe_experts[0].warmup_jit_variants()
+
+    def warmup_mega_moe(self) -> None:
+        """Pre-compile DeepGEMM mega-MoE tiles.
+
+        Called after post_load_weights (not inside it) so that
+        finalize_weights temporaries have been freed by GC and there is
+        enough GPU memory for the symmetric buffer allocation.
+        """
+        if os.environ.get("TOKENSPEED_DISABLE_MEGA_MOE_WARMUP") == "1":
+            return
+        import gc
+
+        gc.collect()
+        torch.cuda.empty_cache()
+        for module in self.modules():
+            if isinstance(module, DeepseekV4MegaMoEExperts):
+                logger.info("Pre-compiling DeepGEMM mega-MoE kernel variants...")
+                module.warmup_jit_variants()
+                return
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):


### PR DESCRIPTION
## Summary

Three independent fixes for DeepSeek V4 MoE memory and weight loading:

1. **Defer mega-MoE warmup** — `finalize_weights` transforms MoE weights in-place, but `params_dict` in `load_weights` held references to the original parameters, preventing GC from reclaiming them. 61 layers of original weights (~60 GiB on V4-Pro) accumulated, leaving insufficient memory for the symmetric buffer. Fix: `del params_dict` before `post_load_weights`, move warmup to `warmup_mega_moe()` called after `post_load_weights` with explicit `gc.collect + empty_cache`.

2. **Clone L2 transformed weights** — `transform_weights_for_mega_moe` returns L2 data as-is (not copied), so `_transformed_l2_weights[0]` may share storage with the input `.contiguous()` buffer. Clone breaks the reference so `del self.w2_weight` can free the original storage.

3. **Fix MoE FP4 weight loader for TP** — `expert_data` may be Blackwell-padded (`round_up(384, 256) = 512`), but `loaded_weight` from checkpoint is unpadded (384). The TP narrow used `expert_data.shape` to compute shard offset, overshooting on the unpadded checkpoint tensor. Fix: derive shard size from `loaded_weight.shape // tp_size`, narrow padded destination to match source size.

## Test plan

- [x] V4-Pro TP=8 EP=8 mega_moe: GSM8K 0.96, trie 2/2 traces (deferred warmup)
- [x] V4-Pro DP=8 EP=8 mega_moe: trie 1/1 trace (del params_dict fix)
- [x] V4-Pro dense-tp-size=1: serve starts (previously OOM)
- [x] V4-Pro MoE TP=8 (flashinfer): GSM8K 0.92, trie 2/2 traces (weight loader fix)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)