### PR TITLE
Make tokenspeed-kernel imports lazy

### DIFF
--- a/tokenspeed-kernel/README.md
+++ b/tokenspeed-kernel/README.md
@@ -9,7 +9,9 @@ performant kernels for multi-silicon AI inference. It features:
 * A minimal list of curated dependencies for fast iteration
 
 TokenSpeed-kernel is pip-installable on its own and can be directly used by
-others.
+others. Importing `tokenspeed_kernel` and its public op packages is intentionally
+lightweight: built-in backend modules are loaded lazily on first API use or by
+calling `tokenspeed_kernel.registry.load_builtin_kernels()`.
 
 ## Design Goals
 

--- a/tokenspeed-kernel/README.md
+++ b/tokenspeed-kernel/README.md
@@ -9,9 +9,9 @@ performant kernels for multi-silicon AI inference. It features:
 * A minimal list of curated dependencies for fast iteration
 
 TokenSpeed-kernel is pip-installable on its own and can be directly used by
-others. Importing `tokenspeed_kernel` and its public op packages is intentionally
-lightweight: built-in backend modules are loaded lazily on first API use or by
-calling `tokenspeed_kernel.registry.load_builtin_kernels()`.
+others. Importing `tokenspeed_kernel` exposes the public op wrappers without
+loading built-in backend modules. Backend modules are loaded lazily on first API
+use or by calling `tokenspeed_kernel.registry.load_builtin_kernels()`.
 
 ## Design Goals
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/__init__.py
@@ -18,52 +18,100 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from tokenspeed_kernel.profiling import bootstrap_profiling_from_env
+from __future__ import annotations
 
-bootstrap_profiling_from_env()
+import importlib
+import os
+from collections.abc import Callable
+from typing import Any
 
-from tokenspeed_kernel.ops.attention import (
-    mha_decode_scheduler_metadata,
-    mha_decode_with_kvcache,
-    mha_extend_with_kvcache,
-    mha_merge_state,
-    mha_prefill,
+# Keep these names in sync with profiling.py without importing that module here;
+# importing profiling would pull in _triton/proton during plain package import.
+_PROFILE_BOOTSTRAP_ENVS = frozenset(
+    {
+        "TOKENSPEED_KERNEL_PROFILE",
+        "TOKENSPEED_KERNEL_CAPTURE_SHAPES",
+    }
 )
-from tokenspeed_kernel.ops.gemm import mm
-from tokenspeed_kernel.ops.moe import (
-    moe_combine,
-    moe_dispatch,
-    moe_experts,
-    moe_fused,
-    moe_route,
-)
-from tokenspeed_kernel.ops.quantization import (
-    quantize_fp8,
-    quantize_fp8_with_scale,
-    quantize_mxfp4,
-    quantize_mxfp8,
-    quantize_nvfp4,
-)
-
-__all__ = [
+_PUBLIC_APIS: dict[str, tuple[str, str]] = {
     # gemm
-    "mm",
+    "mm": ("tokenspeed_kernel.ops.gemm", "mm"),
     # moe
-    "moe_route",
-    "moe_dispatch",
-    "moe_experts",
-    "moe_combine",
-    "moe_fused",
+    "moe_route": ("tokenspeed_kernel.ops.moe", "moe_route"),
+    "moe_dispatch": ("tokenspeed_kernel.ops.moe", "moe_dispatch"),
+    "moe_experts": ("tokenspeed_kernel.ops.moe", "moe_experts"),
+    "moe_combine": ("tokenspeed_kernel.ops.moe", "moe_combine"),
+    "moe_fused": ("tokenspeed_kernel.ops.moe", "moe_fused"),
     # attention
-    "mha_prefill",
-    "mha_extend_with_kvcache",
-    "mha_decode_with_kvcache",
-    "mha_merge_state",
-    "mha_decode_scheduler_metadata",
+    "mha_prefill": ("tokenspeed_kernel.ops.attention", "mha_prefill"),
+    "mha_extend_with_kvcache": (
+        "tokenspeed_kernel.ops.attention",
+        "mha_extend_with_kvcache",
+    ),
+    "mha_decode_with_kvcache": (
+        "tokenspeed_kernel.ops.attention",
+        "mha_decode_with_kvcache",
+    ),
+    "mha_merge_state": ("tokenspeed_kernel.ops.attention", "mha_merge_state"),
+    "mha_decode_scheduler_metadata": (
+        "tokenspeed_kernel.ops.attention",
+        "mha_decode_scheduler_metadata",
+    ),
     # quantization
-    "quantize_fp8",
-    "quantize_fp8_with_scale",
-    "quantize_mxfp8",
-    "quantize_nvfp4",
-    "quantize_mxfp4",
-]
+    "quantize_fp8": ("tokenspeed_kernel.ops.quantization", "quantize_fp8"),
+    "quantize_fp8_with_scale": (
+        "tokenspeed_kernel.ops.quantization",
+        "quantize_fp8_with_scale",
+    ),
+    "quantize_mxfp8": ("tokenspeed_kernel.ops.quantization", "quantize_mxfp8"),
+    "quantize_nvfp4": ("tokenspeed_kernel.ops.quantization", "quantize_nvfp4"),
+    "quantize_mxfp4": ("tokenspeed_kernel.ops.quantization", "quantize_mxfp4"),
+}
+
+__all__ = list(_PUBLIC_APIS)
+
+
+def _is_truthy(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _profiling_env_enabled() -> bool:
+    return any(_is_truthy(os.environ.get(name)) for name in _PROFILE_BOOTSTRAP_ENVS)
+
+
+def _bootstrap_profiling_if_requested() -> None:
+    if not _profiling_env_enabled():
+        return
+    from tokenspeed_kernel.profiling import bootstrap_profiling_from_env
+
+    bootstrap_profiling_from_env()
+
+
+def _resolve_public_api(name: str) -> Callable[..., Any]:
+    """Import and return the concrete implementation for a public API name."""
+    module_name, attr_name = _PUBLIC_APIS[name]
+    module = importlib.import_module(module_name)
+    return getattr(module, attr_name)
+
+
+def _make_public_api(name: str) -> Callable[..., Any]:
+    """Create a thin lazy wrapper that resolves the implementation on call."""
+
+    def public_api(*args: Any, **kwargs: Any) -> Any:
+        return _resolve_public_api(name)(*args, **kwargs)
+
+    public_api.__name__ = name
+    public_api.__qualname__ = name
+    public_api.__module__ = __name__
+    return public_api
+
+
+_bootstrap_profiling_if_requested()
+
+for _name in __all__:
+    # Publish callables without importing ops modules until the API is used.
+    globals()[_name] = _make_public_api(_name)
+
+del _name

--- a/tokenspeed-kernel/python/tokenspeed_kernel/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/__init__.py
@@ -20,98 +20,52 @@
 
 from __future__ import annotations
 
-import importlib
-import os
-from collections.abc import Callable
-from typing import Any
+from tokenspeed_kernel.profiling import bootstrap_profiling_from_env
 
-# Keep these names in sync with profiling.py without importing that module here;
-# importing profiling would pull in _triton/proton during plain package import.
-_PROFILE_BOOTSTRAP_ENVS = frozenset(
-    {
-        "TOKENSPEED_KERNEL_PROFILE",
-        "TOKENSPEED_KERNEL_CAPTURE_SHAPES",
-    }
+bootstrap_profiling_from_env()
+
+from tokenspeed_kernel.ops.attention import (
+    mha_decode_scheduler_metadata,
+    mha_decode_with_kvcache,
+    mha_extend_with_kvcache,
+    mha_merge_state,
+    mha_prefill,
 )
-_PUBLIC_APIS: dict[str, tuple[str, str]] = {
+from tokenspeed_kernel.ops.gemm import mm
+from tokenspeed_kernel.ops.moe import (
+    moe_combine,
+    moe_dispatch,
+    moe_experts,
+    moe_fused,
+    moe_route,
+)
+from tokenspeed_kernel.ops.quantization import (
+    quantize_fp8,
+    quantize_fp8_with_scale,
+    quantize_mxfp4,
+    quantize_mxfp8,
+    quantize_nvfp4,
+)
+
+__all__ = [
     # gemm
-    "mm": ("tokenspeed_kernel.ops.gemm", "mm"),
+    "mm",
     # moe
-    "moe_route": ("tokenspeed_kernel.ops.moe", "moe_route"),
-    "moe_dispatch": ("tokenspeed_kernel.ops.moe", "moe_dispatch"),
-    "moe_experts": ("tokenspeed_kernel.ops.moe", "moe_experts"),
-    "moe_combine": ("tokenspeed_kernel.ops.moe", "moe_combine"),
-    "moe_fused": ("tokenspeed_kernel.ops.moe", "moe_fused"),
+    "moe_route",
+    "moe_dispatch",
+    "moe_experts",
+    "moe_combine",
+    "moe_fused",
     # attention
-    "mha_prefill": ("tokenspeed_kernel.ops.attention", "mha_prefill"),
-    "mha_extend_with_kvcache": (
-        "tokenspeed_kernel.ops.attention",
-        "mha_extend_with_kvcache",
-    ),
-    "mha_decode_with_kvcache": (
-        "tokenspeed_kernel.ops.attention",
-        "mha_decode_with_kvcache",
-    ),
-    "mha_merge_state": ("tokenspeed_kernel.ops.attention", "mha_merge_state"),
-    "mha_decode_scheduler_metadata": (
-        "tokenspeed_kernel.ops.attention",
-        "mha_decode_scheduler_metadata",
-    ),
+    "mha_prefill",
+    "mha_extend_with_kvcache",
+    "mha_decode_with_kvcache",
+    "mha_merge_state",
+    "mha_decode_scheduler_metadata",
     # quantization
-    "quantize_fp8": ("tokenspeed_kernel.ops.quantization", "quantize_fp8"),
-    "quantize_fp8_with_scale": (
-        "tokenspeed_kernel.ops.quantization",
-        "quantize_fp8_with_scale",
-    ),
-    "quantize_mxfp8": ("tokenspeed_kernel.ops.quantization", "quantize_mxfp8"),
-    "quantize_nvfp4": ("tokenspeed_kernel.ops.quantization", "quantize_nvfp4"),
-    "quantize_mxfp4": ("tokenspeed_kernel.ops.quantization", "quantize_mxfp4"),
-}
-
-__all__ = list(_PUBLIC_APIS)
-
-
-def _is_truthy(value: str | None) -> bool:
-    if value is None:
-        return False
-    return value.strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _profiling_env_enabled() -> bool:
-    return any(_is_truthy(os.environ.get(name)) for name in _PROFILE_BOOTSTRAP_ENVS)
-
-
-def _bootstrap_profiling_if_requested() -> None:
-    if not _profiling_env_enabled():
-        return
-    from tokenspeed_kernel.profiling import bootstrap_profiling_from_env
-
-    bootstrap_profiling_from_env()
-
-
-def _resolve_public_api(name: str) -> Callable[..., Any]:
-    """Import and return the concrete implementation for a public API name."""
-    module_name, attr_name = _PUBLIC_APIS[name]
-    module = importlib.import_module(module_name)
-    return getattr(module, attr_name)
-
-
-def _make_public_api(name: str) -> Callable[..., Any]:
-    """Create a thin lazy wrapper that resolves the implementation on call."""
-
-    def public_api(*args: Any, **kwargs: Any) -> Any:
-        return _resolve_public_api(name)(*args, **kwargs)
-
-    public_api.__name__ = name
-    public_api.__qualname__ = name
-    public_api.__module__ = __name__
-    return public_api
-
-
-_bootstrap_profiling_if_requested()
-
-for _name in __all__:
-    # Publish callables without importing ops modules until the API is used.
-    globals()[_name] = _make_public_api(_name)
-
-del _name
+    "quantize_fp8",
+    "quantize_fp8_with_scale",
+    "quantize_mxfp8",
+    "quantize_nvfp4",
+    "quantize_mxfp4",
+]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/__init__.py
@@ -18,8 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from __future__ import annotations
-
 from tokenspeed_kernel.profiling import bootstrap_profiling_from_env
 
 bootstrap_profiling_from_env()

--- a/tokenspeed-kernel/python/tokenspeed_kernel/backends.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/backends.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Lazy loading for built-in kernel registration modules."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Iterable
+from threading import RLock
+
+__all__ = ["load_builtin_kernels", "reset_builtin_kernel_load_state"]
+
+
+_BUILTIN_MODULES_BY_FAMILY: dict[str, tuple[str, ...]] = {
+    "attention": (
+        "tokenspeed_kernel.ops.attention.cuda",
+        "tokenspeed_kernel.ops.attention.flash_attn",
+        "tokenspeed_kernel.ops.attention.flashinfer",
+        "tokenspeed_kernel.ops.attention.gluon",
+        "tokenspeed_kernel.ops.attention.triton",
+    ),
+    "embedding": (
+        "tokenspeed_kernel.ops.embedding.cuda",
+        "tokenspeed_kernel.ops.embedding.triton",
+    ),
+    "gemm": (
+        "tokenspeed_kernel.numerics.reference.gemm",
+        "tokenspeed_kernel.ops.gemm.deep_gemm",
+        "tokenspeed_kernel.ops.gemm.flashinfer",
+        "tokenspeed_kernel.ops.gemm.triton",
+        "tokenspeed_kernel.ops.gemm.trtllm",
+    ),
+    "moe": (
+        "tokenspeed_kernel.numerics.reference.moe",
+        "tokenspeed_kernel.ops.moe.cuda",
+        "tokenspeed_kernel.ops.moe.deepep",
+        "tokenspeed_kernel.ops.moe.flashinfer",
+        "tokenspeed_kernel.ops.moe.gluon",
+        "tokenspeed_kernel.ops.moe.triton",
+        "tokenspeed_kernel.ops.moe.triton_kernels",
+        "tokenspeed_kernel.ops.moe.trtllm",
+    ),
+    "quantization": (
+        "tokenspeed_kernel.ops.quantization.flashinfer",
+        "tokenspeed_kernel.ops.quantization.triton",
+        "tokenspeed_kernel.ops.quantization.trtllm",
+    ),
+}
+
+_LOCK = RLock()
+_LOADED_FAMILIES: set[str] = set()
+
+
+def _all_builtin_modules() -> tuple[str, ...]:
+    modules: list[str] = []
+    for family_modules in _BUILTIN_MODULES_BY_FAMILY.values():
+        modules.extend(family_modules)
+    return tuple(modules)
+
+
+def reset_builtin_kernel_load_state() -> None:
+    """Forget loaded-family state and cached registration modules."""
+
+    with _LOCK:
+        _LOADED_FAMILIES.clear()
+        builtin_modules = _all_builtin_modules()
+        for name in list(sys.modules):
+            if any(
+                name == module_name or name.startswith(module_name + ".")
+                for module_name in builtin_modules
+            ):
+                del sys.modules[name]
+
+
+def _normalize_families(families: str | Iterable[str] | None) -> tuple[str, ...]:
+    if families is None:
+        return tuple(_BUILTIN_MODULES_BY_FAMILY)
+    if isinstance(families, str):
+        return (families,)
+    return tuple(families)
+
+
+def load_builtin_kernels(families: str | Iterable[str] | None = None) -> None:
+    """Import built-in registration modules for one or more op families.
+
+    This is intentionally separate from importing public API packages. Built-in
+    modules perform platform detection and optional vendor-library imports, so
+    they are loaded only when an API call needs them or tests request them.
+    """
+
+    family_names = _normalize_families(families)
+
+    with _LOCK:
+        from tokenspeed_kernel.registry import KernelRegistry
+
+        if not KernelRegistry.get().list_kernels():
+            reset_builtin_kernel_load_state()
+
+        for family in family_names:
+            try:
+                module_names = _BUILTIN_MODULES_BY_FAMILY[family]
+            except KeyError as exc:
+                valid = ", ".join(sorted(_BUILTIN_MODULES_BY_FAMILY))
+                raise ValueError(
+                    f"unknown built-in kernel family {family!r}: {valid}"
+                ) from exc
+
+            if family in _LOADED_FAMILIES:
+                continue
+
+            for module_name in module_names:
+                importlib.import_module(module_name)
+            _LOADED_FAMILIES.add(family)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/backends.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/backends.py
@@ -99,6 +99,10 @@ def _normalize_families(families: str | Iterable[str] | None) -> tuple[str, ...]
     return tuple(families)
 
 
+def _all_families_loaded(families: tuple[str, ...]) -> bool:
+    return all(family in _LOADED_FAMILIES for family in families)
+
+
 def load_builtin_kernels(families: str | Iterable[str] | None = None) -> None:
     """Import built-in registration modules for one or more op families.
 
@@ -108,12 +112,14 @@ def load_builtin_kernels(families: str | Iterable[str] | None = None) -> None:
     """
 
     family_names = _normalize_families(families)
+    # Hot path for every op call after first use. Registry resets clear this
+    # state via reset_builtin_kernel_load_state(), so no registry scan is needed.
+    if _all_families_loaded(family_names):
+        return
 
     with _LOCK:
-        from tokenspeed_kernel.registry import KernelRegistry
-
-        if not KernelRegistry.get().list_kernels():
-            reset_builtin_kernel_load_state()
+        if _all_families_loaded(family_names):
+            return
 
         for family in family_names:
             try:

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -22,14 +22,8 @@ from __future__ import annotations
 
 import math
 
-# Backend registration (side-effect imports)
-import tokenspeed_kernel.ops.attention.cuda  # noqa: F401
-import tokenspeed_kernel.ops.attention.flash_attn  # noqa: F401
-import tokenspeed_kernel.ops.attention.flashinfer  # noqa: F401
-import tokenspeed_kernel.ops.attention.gluon  # noqa: F401
-import tokenspeed_kernel.ops.attention.triton  # noqa: F401
 import torch
-from tokenspeed_kernel.ops.attention.flash_attn import mha_decode_scheduler_metadata
+from tokenspeed_kernel.backends import load_builtin_kernels
 from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
 from tokenspeed_kernel.selection import select_kernel
 from tokenspeed_kernel.signature import dense_tensor_format, format_signature
@@ -52,6 +46,15 @@ __all__ = [
 ]
 
 LSE_LN = math.log2(math.e)
+
+
+def mha_decode_scheduler_metadata(**kwargs):
+    load_builtin_kernels("attention")
+    from tokenspeed_kernel.ops.attention.flash_attn import (
+        mha_decode_scheduler_metadata as _impl,
+    )
+
+    return _impl(**kwargs)
 
 
 def mha_prefill(
@@ -103,6 +106,7 @@ def mha_prefill(
         "return_lse": return_lse,
     }
     signature = _attention_format_signature(q=q, k=k, v=v)
+    load_builtin_kernels("attention")
     kernel = select_kernel(
         "attention",
         "mha_prefill",
@@ -206,6 +210,7 @@ def mha_extend_with_kvcache(
         "return_lse": return_lse,
     }
     signature = _attention_format_signature(q=q, k_cache=k_cache, v_cache=v_cache)
+    load_builtin_kernels("attention")
     kernel = select_kernel(
         "attention",
         "mha_extend_with_kvcache",
@@ -311,6 +316,7 @@ def mha_decode_with_kvcache(
         "return_lse": return_lse,
     }
     signature = _attention_format_signature(q=q, k_cache=k_cache, v_cache=v_cache)
+    load_builtin_kernels("attention")
     kernel = select_kernel(
         "attention",
         "mha_decode_with_kvcache",
@@ -393,6 +399,7 @@ def mha_merge_state(
         "head_dim": out_a.shape[-1],
     }
     signature = _attention_format_signature(out_a=out_a, out_b=out_b)
+    load_builtin_kernels("attention")
     kernel = select_kernel(
         "attention",
         "mha_merge_state",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/__init__.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 import torch
+from tokenspeed_kernel.backends import load_builtin_kernels
 from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
 from tokenspeed_kernel.selection import select_kernel
 from tokenspeed_kernel.signature import dense_tensor_format, format_signature
@@ -116,6 +117,7 @@ def apply_rope(
         query=dense_tensor_format(query.dtype),
         key=dense_tensor_format(key.dtype),
     )
+    load_builtin_kernels("embedding")
     kernel = select_kernel(
         "embedding",
         "rope",
@@ -171,8 +173,3 @@ def apply_rope(
 
 
 __all__ = ["FusedSetKVBufferArg", "apply_rope"]
-
-
-# Backend registration (side-effect imports).
-import tokenspeed_kernel.ops.embedding.cuda  # noqa: E402,F401
-import tokenspeed_kernel.ops.embedding.triton  # noqa: E402,F401

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/__init__.py
@@ -22,14 +22,8 @@ from __future__ import annotations
 
 import logging
 
-# Backend registration (side-effect imports)
-import tokenspeed_kernel.numerics.reference.gemm  # noqa: F401
-import tokenspeed_kernel.ops.gemm.deep_gemm  # noqa: F401
-import tokenspeed_kernel.ops.gemm.flashinfer  # noqa: F401
-import tokenspeed_kernel.ops.gemm.triton  # noqa: F401
-import tokenspeed_kernel.ops.gemm.trtllm  # noqa: F401
 import torch
-from tokenspeed_kernel.platform import Platform
+from tokenspeed_kernel.backends import load_builtin_kernels
 from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
 from tokenspeed_kernel.selection import select_kernel
 from tokenspeed_kernel.signature import (
@@ -43,8 +37,16 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["mm"]
 
-_platform = Platform.get()
-_fp8_dtype = _platform.fp8e4m3fn.dtype
+
+def _current_platform():
+    from tokenspeed_kernel.platform import Platform
+
+    return Platform.get()
+
+
+def _fp8_dtype():
+    return _current_platform().fp8e4m3fn.dtype
+
 
 # Kernels that natively fuse a bias-vector add inside their GEMM kernel.
 # For any kernel not listed here, ``mm`` applies the bias with a post-GEMM
@@ -101,7 +103,7 @@ def _gemm_format_signature(
             granularity="block",
             block_shape=tuple(block_size),
         )
-        a_storage_dtype = _fp8_dtype if A_scales is None else A.dtype
+        a_storage_dtype = _fp8_dtype() if A_scales is None else A.dtype
         return format_signature(
             a=tensor_format("mxfp8", a_storage_dtype, scale=scale),
             b=tensor_format("mxfp8", B.dtype, scale=scale),
@@ -172,7 +174,7 @@ def _online_quantize_mxfp8(
             block_k,
             column_major_scales=True,
             scale_tma_aligned=True,
-            scale_ue8m0=_platform.is_blackwell_plus,
+            scale_ue8m0=_current_platform().is_blackwell_plus,
         )
     elif kernel_name == "flashinfer_mm_fp8_blockscale":
         from tokenspeed_kernel.ops.gemm.fp8_utils import (
@@ -262,6 +264,7 @@ def mm(
     )
     select_dtype = signature.storage_dtype_for("a") or A.dtype
 
+    load_builtin_kernels("gemm")
     kernel = select_kernel(
         "gemm",
         "mm",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/__init__.py
@@ -23,16 +23,8 @@ from __future__ import annotations
 import logging
 from typing import Optional, Set
 
-# Backend registration (side-effect imports)
-import tokenspeed_kernel.numerics.reference.moe  # noqa: F401
-import tokenspeed_kernel.ops.moe.cuda  # noqa: F401
-import tokenspeed_kernel.ops.moe.deepep  # noqa: F401
-import tokenspeed_kernel.ops.moe.flashinfer  # noqa: F401
-import tokenspeed_kernel.ops.moe.gluon  # noqa: F401
-import tokenspeed_kernel.ops.moe.triton  # noqa: F401
-import tokenspeed_kernel.ops.moe.triton_kernels  # noqa: F401
-import tokenspeed_kernel.ops.moe.trtllm  # noqa: F401
 import torch
+from tokenspeed_kernel.backends import load_builtin_kernels
 from tokenspeed_kernel.ops.moe.expert_location_dispatch import (  # noqa: F401
     ExpertLocationDispatchInfo,
     topk_ids_logical_to_physical,
@@ -210,6 +202,7 @@ def moe_route(
     * ``{"grouped": True/False}``: whether grouped expert selection is used.
     """
     signature = _single_dense_tensor_format_signature("logits", dtype)
+    load_builtin_kernels("moe")
     kernel = select_kernel(
         "moe",
         "route",
@@ -235,6 +228,7 @@ def moe_dispatch(
     """
     selection_traits = traits or {"comm_strategy": "local"}
     signature = _moe_dispatch_format_signature(dtype, selection_traits)
+    load_builtin_kernels("moe")
     kernel = select_kernel(
         "moe",
         "dispatch",
@@ -275,6 +269,7 @@ def moe_experts(
         signature = _moe_fused_format_signature(
             dtype, weight_format, fp8_scale_granularity=fp8_scale_granularity
         )
+    load_builtin_kernels("moe")
     kernel = select_kernel(
         "moe",
         "experts",
@@ -296,6 +291,7 @@ def moe_combine(
 ):
     """Combine expert outputs with weighted reduction."""
     signature = _single_dense_tensor_format_signature("x", dtype)
+    load_builtin_kernels("moe")
     kernel = select_kernel(
         "moe",
         "combine",
@@ -345,6 +341,7 @@ def moe_fused(
         dtype, weight_format, fp8_scale_granularity=fp8_scale_granularity
     )
     selection_traits = dict(traits or {})
+    load_builtin_kernels("moe")
     kernel = select_kernel(
         "moe",
         "fused",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/__init__.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from typing import Literal
 
 import torch
+from tokenspeed_kernel.backends import load_builtin_kernels
 from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
 from tokenspeed_kernel.selection import select_kernel
 from tokenspeed_kernel.signature import dense_tensor_format, format_signature
@@ -69,6 +70,7 @@ def quantize_fp8(
         "has_scale": scale is not None,
     }
     signature = format_signature(x=dense_tensor_format(x.dtype))
+    load_builtin_kernels("quantization")
     kernel = select_kernel(
         "quantization",
         "fp8",
@@ -149,6 +151,7 @@ def quantize_fp8_with_scale(
         "scale_encoding": scale_encoding,
     }
     signature = format_signature(x=dense_tensor_format(x.dtype))
+    load_builtin_kernels("quantization")
     kernel = select_kernel(
         "quantization",
         "fp8_with_scale",
@@ -208,6 +211,7 @@ def quantize_mxfp8(
 
     traits = {}
     signature = format_signature(x=dense_tensor_format(x.dtype))
+    load_builtin_kernels("quantization")
     kernel = select_kernel(
         "quantization",
         "mxfp8",
@@ -269,6 +273,7 @@ def quantize_nvfp4(
         "has_scale": scale is not None,
     }
     signature = format_signature(x=dense_tensor_format(x.dtype))
+    load_builtin_kernels("quantization")
     kernel = select_kernel(
         "quantization",
         "nvfp4",
@@ -341,6 +346,7 @@ def quantize_mxfp4(
         "scale_encoding": "ue8m0",
     }
     signature = format_signature(x=dense_tensor_format(x.dtype))
+    load_builtin_kernels("quantization")
     kernel = select_kernel(
         "quantization",
         "mxfp4",
@@ -368,9 +374,3 @@ def quantize_mxfp4(
             scale_layout=scale_layout,
             enable_pdl=enable_pdl,
         )
-
-
-# Backend registration (side-effect imports).
-import tokenspeed_kernel.ops.quantization.flashinfer  # noqa: E402,F401
-import tokenspeed_kernel.ops.quantization.triton  # noqa: E402,F401
-import tokenspeed_kernel.ops.quantization.trtllm  # noqa: E402,F401

--- a/tokenspeed-kernel/python/tokenspeed_kernel/plugins/README.md
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/plugins/README.md
@@ -88,7 +88,7 @@ pip install -e ./my-kernels-plugin
 ```
 
 ```python
-import tokenspeed_kernel  # registers built-in kernels
+import tokenspeed_kernel  # noqa: F401  -- exposes public op wrappers
 from tokenspeed_kernel.plugins import discover_plugins, list_plugins
 
 discover_plugins()
@@ -103,7 +103,7 @@ entry points so plugins can override built-ins by registering at a higher
 priority.
 
 ```python
-import tokenspeed_kernel  # noqa: F401  -- optional; top-level import is lazy
+import tokenspeed_kernel  # noqa: F401  -- optional; exposes public op wrappers
 from tokenspeed_kernel.plugins import discover_plugins
 
 discover_plugins()

--- a/tokenspeed-kernel/python/tokenspeed_kernel/plugins/README.md
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/plugins/README.md
@@ -18,9 +18,9 @@ itself.
 2. Your `pyproject.toml` advertises that function under the
    `tokenspeed_kernel.plugins` entry-point group.
 3. The host application (engine, benchmark, notebook, etc.) calls
-   `tokenspeed_kernel.plugins.discover_plugins()` once at startup, after
-   built-in kernels have been imported. Discovery walks the entry-point
-   group and invokes each `register()`.
+   `tokenspeed_kernel.plugins.discover_plugins()` once at startup. Discovery
+   loads built-in kernels first, then walks the entry-point group and invokes
+   each `register()`.
 
 Loading is **fully explicit** — importing `tokenspeed_kernel` or
 `tokenspeed_kernel.plugins` does **not** trigger discovery on its own.
@@ -98,11 +98,12 @@ print(list_plugins())  # -> [PluginInfo(name='my_plugin', ...)]
 ## Host-application integration
 
 Engines and other long-running hosts should call `discover_plugins()`
-exactly once at startup, after built-in kernel modules have been imported
-(so plugins can override built-ins by registering at a higher priority).
+exactly once at startup. It loads built-in kernel modules before plugin
+entry points so plugins can override built-ins by registering at a higher
+priority.
 
 ```python
-import tokenspeed_kernel  # noqa: F401  -- registers built-ins
+import tokenspeed_kernel  # noqa: F401  -- optional; top-level import is lazy
 from tokenspeed_kernel.plugins import discover_plugins
 
 discover_plugins()
@@ -178,11 +179,10 @@ for info in list_plugins():
 
 - **No discovery call → no plugin kernels.** Forgetting to call
   `discover_plugins()` is silent.
-- **Plugin loaded before built-ins.** If you call `discover_plugins()`
-  before `import tokenspeed_kernel`, plugins that intend to override
-  built-ins will appear to win, but the built-in modules will be imported
-  later and may overwrite the plugin's slot. Always import
-  `tokenspeed_kernel` first.
+- **Manual registration before built-ins.** If you bypass
+  `discover_plugins()` and invoke a plugin `register()` directly before
+  built-ins are loaded, later built-in imports may overwrite that slot. Use
+  `discover_plugins()` for entry-point plugins so built-ins load first.
 - **Stale registry.** Calling `KernelRegistry.reset()` clears registered
   kernels but leaves `_loaded_plugins` populated; re-discovery will skip
   already-loaded plugins. Use `discover_plugins(force=True)` after a

--- a/tokenspeed-kernel/python/tokenspeed_kernel/plugins/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/plugins/__init__.py
@@ -23,7 +23,7 @@
 Third-party packages register kernel implementations via Python entry points
 in the ``tokenspeed_kernel.plugins`` group. Loading is explicit: the host
 application must call :func:`discover_plugins` (typically once at startup,
-after built-in kernels have been imported) for installed plugins to take
+which loads built-in kernels before plugins) for installed plugins to take
 effect. See ``README.md`` for details.
 """
 
@@ -35,7 +35,7 @@ import os
 import warnings
 from dataclasses import dataclass, field
 
-from tokenspeed_kernel.registry import KernelRegistry
+from tokenspeed_kernel.registry import KernelRegistry, load_builtin_kernels
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +153,9 @@ def _check_priority_collisions(
 def discover_plugins(*, force: bool = False) -> list[PluginInfo]:
     """Discover and load installed kernel plugins via entry points.
 
+    Built-in kernels are loaded before plugin entry points so plugins can
+    intentionally override built-ins by registering at a higher priority.
+
     Plugins disabled via :func:`disable_plugin` or the
     ``TOKENSPEED_KERNEL_DISABLE_PLUGINS`` env var are skipped.
 
@@ -160,6 +163,8 @@ def discover_plugins(*, force: bool = False) -> list[PluginInfo]:
     their ``register()`` is invoked again (useful for tests that reset the
     registry).
     """
+    load_builtin_kernels()
+
     disabled = _disabled_plugins | _disabled_from_env()
     registry = KernelRegistry.get()
     loaded: list[PluginInfo] = []

--- a/tokenspeed-kernel/python/tokenspeed_kernel/registry.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/registry.py
@@ -441,20 +441,10 @@ def describe_kernel(name: str) -> str:
     return "\n".join(lines)
 
 
-def load_builtin_kernels() -> None:
-    import sys
+def load_builtin_kernels(families=None) -> None:
+    from tokenspeed_kernel.backends import load_builtin_kernels as _load_builtins
 
-    if not KernelRegistry.get().list_kernels():
-        # Registry was reset; clear cached ops modules so decorators re-run.
-        for key in list(sys.modules.keys()):
-            if key.startswith("tokenspeed_kernel.ops.") or key.startswith(
-                "tokenspeed_kernel.numerics.reference."
-            ):
-                del sys.modules[key]
-    import tokenspeed_kernel.ops.embedding  # noqa: F401
-    import tokenspeed_kernel.ops.gemm  # noqa: F401
-    import tokenspeed_kernel.ops.moe  # noqa: F401
-    import tokenspeed_kernel.ops.quantization  # noqa: F401
+    _load_builtins(families)
 
 
 def error_fn(*args, **kwargs):

--- a/tokenspeed-kernel/python/tokenspeed_kernel/registry.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/registry.py
@@ -248,6 +248,11 @@ class KernelRegistry:
     def reset(cls) -> None:
         """Reset singleton (for testing)."""
         cls._instance = None
+        try:
+            from tokenspeed_kernel.backends import reset_builtin_kernel_load_state
+        except ImportError:
+            return
+        reset_builtin_kernel_load_state()
 
     # ---- Registration ----
 

--- a/tokenspeed-kernel/test/test_plugins.py
+++ b/tokenspeed-kernel/test/test_plugins.py
@@ -46,8 +46,9 @@ from tokenspeed_kernel.signature import format_signatures
 
 
 @pytest.fixture
-def fresh_plugins():
+def fresh_plugins(monkeypatch):
     """Reset registry and plugin state before/after each test."""
+    monkeypatch.setattr(plugins_mod, "load_builtin_kernels", lambda: None)
     KernelRegistry.reset()
     reset_plugins()
     yield
@@ -197,6 +198,34 @@ class TestDiscovery:
         assert info.num_kernels == 1
         assert info.kernel_names == ("alpha_kernel",)
         assert KernelRegistry.get().get_by_name("alpha_kernel") is not None
+
+    def test_discover_loads_builtins_before_plugins(
+        self, fresh_plugins, patch_entry_points, monkeypatch
+    ):
+        order: list[str] = []
+
+        def load_builtins():
+            order.append("builtins")
+
+        def register():
+            order.append("plugin")
+
+            @register_kernel(
+                "gemm",
+                "mm",
+                name="ordered_kernel",
+                solution="ordered",
+                signatures=format_signatures(("a", "b"), "dense", {torch.bfloat16}),
+            )
+            def impl():
+                return None
+
+        monkeypatch.setattr(plugins_mod, "load_builtin_kernels", load_builtins)
+        patch_entry_points([_FakeEntryPoint("ordered", register)])
+
+        discover_plugins()
+
+        assert order == ["builtins", "plugin"]
 
     def test_discover_alphabetical_order(self, fresh_plugins, patch_entry_points):
         order: list[str] = []

--- a/tokenspeed-kernel/test/test_public_api_import.py
+++ b/tokenspeed-kernel/test/test_public_api_import.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_PYTHON_DIR = Path(__file__).resolve().parent.parent / "python"
+
+
+def _run_import_check(script: str) -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = (
+        str(_PYTHON_DIR)
+        if not env.get("PYTHONPATH")
+        else f"{_PYTHON_DIR}{os.pathsep}{env['PYTHONPATH']}"
+    )
+    subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        text=True,
+        check=True,
+    )
+
+
+def test_top_level_import_does_not_load_public_ops_or_vendor_modules() -> None:
+    _run_import_check("""
+import sys
+before = set(sys.modules)
+import tokenspeed_kernel
+loaded = set(sys.modules) - before
+
+unexpected = [
+    name
+    for name in loaded
+    if name.startswith("tokenspeed_kernel.ops.")
+    or name.startswith("tokenspeed_kernel.thirdparty")
+    or name in {"flashinfer", "trtllm_kernel", "deep_gemm", "deep_ep"}
+]
+assert unexpected == [], unexpected
+assert callable(tokenspeed_kernel.mm)
+""")
+
+
+def test_public_op_imports_do_not_register_builtin_backends() -> None:
+    _run_import_check("""
+import sys
+try:
+    import torch  # noqa: F401
+except ImportError:
+    raise SystemExit(0)
+
+before = set(sys.modules)
+import tokenspeed_kernel.ops.attention
+import tokenspeed_kernel.ops.embedding
+import tokenspeed_kernel.ops.gemm
+import tokenspeed_kernel.ops.moe
+import tokenspeed_kernel.ops.quantization
+from tokenspeed_kernel.registry import KernelRegistry
+loaded = set(sys.modules) - before
+
+unexpected = [
+    name
+    for name in loaded
+    if name.startswith("tokenspeed_kernel.thirdparty")
+    or name in {"flashinfer", "trtllm_kernel", "deep_gemm", "deep_ep"}
+]
+assert unexpected == [], unexpected
+assert KernelRegistry.get().list_kernels() == []
+""")

--- a/tokenspeed-kernel/test/test_public_api_import.py
+++ b/tokenspeed-kernel/test/test_public_api_import.py
@@ -43,21 +43,56 @@ def _run_import_check(script: str) -> None:
     )
 
 
-def test_top_level_import_does_not_load_public_ops_or_vendor_modules() -> None:
+def test_top_level_import_does_not_load_builtin_backends_or_vendor_modules() -> None:
     _run_import_check("""
 import sys
 before = set(sys.modules)
 import tokenspeed_kernel
+from tokenspeed_kernel.registry import KernelRegistry
 loaded = set(sys.modules) - before
+
+backend_prefixes = (
+    "tokenspeed_kernel.numerics.reference.",
+    "tokenspeed_kernel.ops.attention.cuda",
+    "tokenspeed_kernel.ops.attention.flash_attn",
+    "tokenspeed_kernel.ops.attention.flashinfer",
+    "tokenspeed_kernel.ops.attention.gluon",
+    "tokenspeed_kernel.ops.attention.triton",
+    "tokenspeed_kernel.ops.embedding.cuda",
+    "tokenspeed_kernel.ops.embedding.triton",
+    "tokenspeed_kernel.ops.gemm.deep_gemm",
+    "tokenspeed_kernel.ops.gemm.flashinfer",
+    "tokenspeed_kernel.ops.gemm.triton",
+    "tokenspeed_kernel.ops.gemm.trtllm",
+    "tokenspeed_kernel.ops.moe.cuda",
+    "tokenspeed_kernel.ops.moe.deepep",
+    "tokenspeed_kernel.ops.moe.flashinfer",
+    "tokenspeed_kernel.ops.moe.gluon",
+    "tokenspeed_kernel.ops.moe.triton",
+    "tokenspeed_kernel.ops.moe.triton_kernels",
+    "tokenspeed_kernel.ops.moe.trtllm",
+    "tokenspeed_kernel.ops.quantization.flashinfer",
+    "tokenspeed_kernel.ops.quantization.triton",
+    "tokenspeed_kernel.ops.quantization.trtllm",
+)
+vendor_modules = {
+    "deep_ep",
+    "deep_gemm",
+    "flash_attn",
+    "flash_attn_interface",
+    "flashinfer",
+    "trtllm_kernel",
+}
 
 unexpected = [
     name
     for name in loaded
-    if name.startswith("tokenspeed_kernel.ops.")
+    if name.startswith(backend_prefixes)
     or name.startswith("tokenspeed_kernel.thirdparty")
-    or name in {"flashinfer", "trtllm_kernel", "deep_gemm", "deep_ep"}
+    or name in vendor_modules
 ]
 assert unexpected == [], unexpected
+assert KernelRegistry.get().list_kernels() == []
 assert callable(tokenspeed_kernel.mm)
 """)
 
@@ -79,11 +114,45 @@ import tokenspeed_kernel.ops.quantization
 from tokenspeed_kernel.registry import KernelRegistry
 loaded = set(sys.modules) - before
 
+backend_prefixes = (
+    "tokenspeed_kernel.numerics.reference.",
+    "tokenspeed_kernel.ops.attention.cuda",
+    "tokenspeed_kernel.ops.attention.flash_attn",
+    "tokenspeed_kernel.ops.attention.flashinfer",
+    "tokenspeed_kernel.ops.attention.gluon",
+    "tokenspeed_kernel.ops.attention.triton",
+    "tokenspeed_kernel.ops.embedding.cuda",
+    "tokenspeed_kernel.ops.embedding.triton",
+    "tokenspeed_kernel.ops.gemm.deep_gemm",
+    "tokenspeed_kernel.ops.gemm.flashinfer",
+    "tokenspeed_kernel.ops.gemm.triton",
+    "tokenspeed_kernel.ops.gemm.trtllm",
+    "tokenspeed_kernel.ops.moe.cuda",
+    "tokenspeed_kernel.ops.moe.deepep",
+    "tokenspeed_kernel.ops.moe.flashinfer",
+    "tokenspeed_kernel.ops.moe.gluon",
+    "tokenspeed_kernel.ops.moe.triton",
+    "tokenspeed_kernel.ops.moe.triton_kernels",
+    "tokenspeed_kernel.ops.moe.trtllm",
+    "tokenspeed_kernel.ops.quantization.flashinfer",
+    "tokenspeed_kernel.ops.quantization.triton",
+    "tokenspeed_kernel.ops.quantization.trtllm",
+)
+vendor_modules = {
+    "deep_ep",
+    "deep_gemm",
+    "flash_attn",
+    "flash_attn_interface",
+    "flashinfer",
+    "trtllm_kernel",
+}
+
 unexpected = [
     name
     for name in loaded
-    if name.startswith("tokenspeed_kernel.thirdparty")
-    or name in {"flashinfer", "trtllm_kernel", "deep_gemm", "deep_ep"}
+    if name.startswith(backend_prefixes)
+    or name.startswith("tokenspeed_kernel.thirdparty")
+    or name in vendor_modules
 ]
 assert unexpected == [], unexpected
 assert KernelRegistry.get().list_kernels() == []

--- a/tokenspeed-kernel/test/test_registry.py
+++ b/tokenspeed-kernel/test/test_registry.py
@@ -187,6 +187,26 @@ class TestRegistrySingleton:
         r2 = KernelRegistry.get()
         assert r1 is not r2
 
+    def test_reset_clears_builtin_load_state(self, monkeypatch):
+        from tokenspeed_kernel import backends
+
+        imported: list[str] = []
+        monkeypatch.setitem(
+            backends._BUILTIN_MODULES_BY_FAMILY,
+            "test",
+            ("test_builtin",),
+        )
+        monkeypatch.setattr(backends.importlib, "import_module", imported.append)
+        backends.reset_builtin_kernel_load_state()
+
+        backends.load_builtin_kernels("test")
+        backends.load_builtin_kernels("test")
+        assert imported == ["test_builtin"]
+
+        KernelRegistry.reset()
+        backends.load_builtin_kernels("test")
+        assert imported == ["test_builtin", "test_builtin"]
+
 
 class TestRegistryRegister:
     def test_register_and_retrieve(self):


### PR DESCRIPTION
This is a pre-step to structure kernel packages better.