### PR TITLE
[Bugfix] fix miss help command

### DIFF
--- a/python/tokenspeed/cli/__main__.py
+++ b/python/tokenspeed/cli/__main__.py
@@ -60,6 +60,7 @@ def main() -> None:
     # don't register the engine's ServerArgs on this parser.
     serve_parser = subparsers.add_parser(
         "serve",
+        add_help=False,
         help="Launch the TokenSpeed inference server.",
     )
     serve_parser.set_defaults(func=_serve)

--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -42,6 +42,7 @@ from tokenspeed.cli._proc import (
     wait_grpc_serving,
     wait_http_ready,
 )
+from tokenspeed.runtime.utils import configure_logger
 from tokenspeed.runtime.utils.network import get_free_port
 from tokenspeed.runtime.utils.process import kill_process_tree
 
@@ -53,6 +54,7 @@ DEFAULT_REASONING_PARSER = "passthrough"
 DEEPSEEK_V4_REASONING_PARSER = "deepseek_v31"
 DEEPSEEK_V4_TOOL_CALL_PARSER = "deepseek_v4"
 DEFAULT_SMG_LOG_LEVEL = "warn"
+DEFAULT_TS_SERVE_LOG_LEVEL = "INFO"
 DEFAULT_SMG_PROMETHEUS_PORT = 8413
 # smg reliability knobs we always want disabled when launched under
 # ts serve. These are tokenspeed-internal defaults: not surfaced via
@@ -61,6 +63,63 @@ _DEFAULT_SMG_DISABLE_FLAGS = (
     "--disable-circuit-breaker",
     "--disable-retries",
 )
+
+
+def print_serve_help() -> None:
+    """Render a complete ``ts serve`` help text.
+
+    We keep the top-level ``tokenspeed`` argparse parser intentionally slim and
+    route unknown ``serve`` flags into ``split_argv``. This helper exposes the
+    full engine CLI surface (``ServerArgs``) plus orchestrator/gateway options.
+    """
+    from tokenspeed.runtime.utils.server_args import ServerArgs
+
+    parser = argparse.ArgumentParser(
+        prog="tokenspeed serve",
+        description=("Launch TokenSpeed through the TokenSpeed engine.\n\n"),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+
+    orch = parser.add_argument_group("orchestrator options")
+    orch.add_argument(
+        "--engine-startup-timeout",
+        type=int,
+        metavar="SECONDS",
+        default=1800,
+        help="Max wait for engine gRPC readiness (default: 1800)",
+    )
+    orch.add_argument(
+        "--gateway-startup-timeout",
+        type=int,
+        metavar="SECONDS",
+        default=60,
+        help="Max wait for gateway HTTP readiness (default: 60)",
+    )
+    orch.add_argument(
+        "--drain-timeout",
+        type=int,
+        metavar="SECONDS",
+        default=30,
+        help="Grace period for shutdown before SIGKILL (default: 30)",
+    )
+    orch.add_argument(
+        "--control-port",
+        type=int,
+        metavar="PORT",
+        default=None,
+        help="Optional control HTTP port",
+    )
+
+    ServerArgs.add_cli_args(parser)
+
+    parser.epilog = (
+        "Routing notes:\n"
+        "  --model / --reasoning-parser are fanned out to engine + gateway.\n"
+        "  --host / --port are treated as gateway-facing in smg mode.\n"
+        "  --chat-template / --tool-call-parser are gateway-only overrides.\n"
+        "  Unknown flags fall through to smg gateway launch arguments."
+    )
+    parser.print_help()
 
 
 def _check_serve_extra_installed() -> None:
@@ -177,6 +236,18 @@ def _gateway_args_with_default_prometheus_port(gateway_args: list[str]) -> list[
     if "--prometheus-port" in gateway_args:
         return gateway_args
     return [*gateway_args, "--prometheus-port", str(DEFAULT_SMG_PROMETHEUS_PORT)]
+
+
+def _configure_cli_logging() -> None:
+    root_logger = logging.getLogger()
+    if root_logger.handlers:
+        return
+
+    configure_logger(
+        argparse.Namespace(
+            log_level=os.environ.get("TS_SERVE_LOG_LEVEL", DEFAULT_TS_SERVE_LOG_LEVEL)
+        )
+    )
 
 
 def _user_model_id(gateway_args: list[str]) -> str | None:
@@ -514,6 +585,10 @@ async def run_smg(
 
 def run_smg_from_args(args: argparse.Namespace, raw_argv: list[str]) -> None:
     """Entry point called from cli/__main__.py for ``ts serve``."""
+    if "-h" in raw_argv or "--help" in raw_argv:
+        print_serve_help()
+        sys.exit(0)
+
     try:
         import setproctitle
 
@@ -523,6 +598,7 @@ def run_smg_from_args(args: argparse.Namespace, raw_argv: list[str]) -> None:
 
     print_logo()
 
+    _configure_cli_logging()
     _check_serve_extra_installed()
     split = split_argv(raw_argv)
     engine_args, gateway_args = _args_with_default_model_parsers(


### PR DESCRIPTION
## Summary

Current exec `ts serve -h` command not efficient help function.

```
$ tokenspeed serve -h
usage: tokenspeed serve [-h]

options:
  -h, --help  show this help message and exit
(tokenspeed) root@lrf-dev-gpu-0:~# tokenspeed serve -h
usage: tokenspeed serve [-h]

options:
  -h, --help  show this help message and exit
```

## Test Plan

```
$ tokenspeed serve -h
usage: tokenspeed serve [-h] [--engine-startup-timeout SECONDS] [--gateway-startup-timeout SECONDS]
                        [--drain-timeout SECONDS] [--control-port PORT] [--model MODEL] [--tokenizer TOKENIZER]
                        [--host HOST] [--port PORT] [--tokenizer-mode {auto,slow,deepseek_v4}]
                        [--skip-tokenizer-init | --no-skip-tokenizer-init] [--language-model-only] [--ext-yaml EXT_YAML]
                        [--load-format {auto,pt,safetensors,npcache,dummy,extensible}]
                        [--trust-remote-code | --no-trust-remote-code] [--dtype {auto,half,float16,bfloat16,float,float32}]
                        [--kv-cache-dtype {auto,fp8,fp8_e4m3}] [--kv-cache-quant-method {none,per_token_head}]
                        [--quantization {fp8,nvfp4,w8a8_fp8,compressed-tensors}]
                        [--quantization-param-path QUANTIZATION_PARAM_PATH] [--max-model-len MAX_MODEL_LEN]
                        [--device {cuda}] [--served-model-name SERVED_MODEL_NAME] [--revision REVISION]
                        [--gpu-memory-utilization GPU_MEMORY_UTILIZATION] [--max-num-seqs MAX_NUM_SEQS]
                        [--max-total-tokens MAX_TOTAL_TOKENS] [--chunked-prefill-size CHUNKED_PREFILL_SIZE]
                        [--enable-mixed-batch] [--block-size BLOCK_SIZE] [--disable-kvstore]
                        [--kvstore-ratio KVSTORE_RATIO] [--kvstore-size KVSTORE_SIZE]
                        [--kvstore-io-backend {direct,kernel}] [--kvstore-mem-layout {layer_first,page_first,page_head}]
                        [--kvstore-storage-backend {mooncake}]
                        [--kvstore-storage-backend-extra-config KVSTORE_STORAGE_BACKEND_EXTRA_CONFIG]
                        [--enable-mla-l1-5-cache] [--mamba-ssm-dtype {float32,bfloat16}]
                        [--mamba-track-interval MAMBA_TRACK_INTERVAL] [--max-mamba-cache-size MAX_MAMBA_CACHE_SIZE]
                        [--mamba-full-memory-ratio MAMBA_FULL_MEMORY_RATIO] [--enable-mamba-l2]
                        [--mamba-l2-host-slots MAMBA_L2_HOST_SLOTS] [--mamba-l2-ratio MAMBA_L2_RATIO]
                        [--mamba-l2-layout {layer_first}] [--mamba-l2-io-backend {direct,kernel}]
                        [--mamba-l2-host-gb MAMBA_L2_HOST_GB] [--max-prefill-tokens MAX_PREFILL_TOKENS]
                        [--stream-interval STREAM_INTERVAL] [--stream-output] [--seed SEED]
                        [--distributed-timeout-seconds DISTRIBUTED_TIMEOUT_SECONDS] [--download-dir DOWNLOAD_DIR]
                        [--base-gpu-id BASE_GPU_ID] [--gpu-id-step GPU_ID_STEP] [--log-level LOG_LEVEL]
                        [--log-level-http LOG_LEVEL_HTTP] [--enable-log-requests | --no-enable-log-requests]
                        [--log-requests-level {0,1,2}] [--enable-metrics] [--metrics-reporters {prometheus}]
                        [--app-key APP_KEY] [--decode-log-interval DECODE_LOG_INTERVAL] [--api-key API_KEY]
                        [--enable-cache-report] [--kv-events-config KV_EVENTS_CONFIG]
                        [--data-parallel-size DATA_PARALLEL_SIZE]
                        [--load-balance-method {round_robin,shortest_queue,minimum_cache_usage}]
                        [--load-watch-interval LOAD_WATCH_INTERVAL] [--expert-parallel-size EXPERT_PARALLEL_SIZE]
                        [--init-expert-location INIT_EXPERT_LOCATION] [--ep-num-redundant-experts EP_NUM_REDUNDANT_EXPERTS]
                        [--ep-dispatch-algorithm EP_DISPATCH_ALGORITHM] [--eplb-algorithm EPLB_ALGORITHM]
                        [--expert-distribution-recorder-mode EXPERT_DISTRIBUTION_RECORDER_MODE]
                        [--expert-distribution-recorder-buffer-size EXPERT_DISTRIBUTION_RECORDER_BUFFER_SIZE]
                        [--enable-expert-distribution-metrics] [--enable-eplb] [--moe-backend MOE_BACKEND]
                        [--draft-moe-backend DRAFT_MOE_BACKEND] [--flashinfer-mxfp4-moe-precision {default,bf16}]
                        [--all2all-backend ALL2ALL_BACKEND] [--deepep-mode {normal,low_latency,auto}]
                        [--disable-flashinfer-cutlass-moe-fp4-allgather] [--dist-init-addr DIST_INIT_ADDR]
                        [--nnodes NNODES] [--node-rank NODE_RANK] [--hf-overrides HF_OVERRIDES]
                        [--preferred-sampling-params PREFERRED_SAMPLING_PARAMS]
                        [--attention-backend {mha,fa3,fa4,triton,flashinfer,trtllm,trtllm_mla,flashmla,tokenspeed_mla,hybrid_linear_attn}]
                        [--drafter-attention-backend {mha,fa3,fa4,triton,flashinfer,trtllm,trtllm_mla,flashmla,tokenspeed_mla,hybrid_linear_attn}]
                        [--mha-extend-mode {paged,ragged}] [--sampling-backend {greedy,flashinfer,flashinfer_full}]
                        [--attention-use-fp4-indexer-cache [ATTENTION_USE_FP4_INDEXER_CACHE]]
                        [--attention-config.use-trtllm-ragged-deepseek-prefill [USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL]]
                        [--deepseek-v4-mega-moe-max-num-tokens DEEPSEEK_V4_MEGA_MOE_MAX_NUM_TOKENS]
                        [--deepseek-v4-indexer-prefill-max-logits-mb DEEPSEEK_V4_INDEXER_PREFILL_MAX_LOGITS_MB]
                        [--deepseek-v4-prefill-chunk-size DEEPSEEK_V4_PREFILL_CHUNK_SIZE]
                        [--grammar-backend {xgrammar,none}] [--reasoning-parser REASONING_PARSER]
                        [--grammar-compile-timeout-secs GRAMMAR_COMPILE_TIMEOUT_SECS]
                        [--grammar-compile-max-retries GRAMMAR_COMPILE_MAX_RETRIES] [--disable-any-whitespace]
                        [--disable-capturable-grammar] [--mla-disable-ragged] [--draft-model-path-use-base]
                        [--speculative-config SPECULATIVE_CONFIG] [--speculative-algorithm {EAGLE3,MTP}]
                        [--speculative-draft-model-path SPECULATIVE_DRAFT_MODEL_PATH]
                        [--speculative-draft-model-quantization SPECULATIVE_DRAFT_MODEL_QUANTIZATION]
                        [--speculative-num-steps SPECULATIVE_NUM_STEPS] [--speculative-eagle-topk {1}]
                        [--speculative-num-draft-tokens SPECULATIVE_NUM_DRAFT_TOKENS] [--enable-output-logprobs]
                        [--eagle3-layers-to-capture EAGLE3_LAYERS_TO_CAPTURE] [--disable-pdl]
                        [--enable-prefix-caching | --no-enable-prefix-caching] [--enforce-eager]
                        [--disable-cuda-graph-padding] [--enable-cudagraph-gc] [--enable-nccl-nvls] [--enable-symm-mem]
                        [--disable-custom-all-reduce] [--disable-overlap-schedule] [--disable-tf32]
                        [--max-cudagraph-capture-size MAX_CUDAGRAPH_CAPTURE_SIZE]
                        [--cudagraph-capture-sizes CUDAGRAPH_CAPTURE_SIZE [CUDAGRAPH_CAPTURE_SIZE ...]]
                        [--disable-prefill-graph] [--prefill-graph-max-tokens PREFILL_GRAPH_MAX_TOKENS]
                        [--enable-nan-detection] [--enable-nvtx] [--enable-p2p-check] [--triton-attention-reduce-in-fp32]
                        [--delete-ckpt-after-loading] [--weight-loader-prefetch-checkpoints]
                        [--weight-loader-prefetch-num-threads WEIGHT_LOADER_PREFETCH_NUM_THREADS] [--enable-memory-saver]
                        [--enable-custom-logit-processor] [--skip-server-warmup] [--warmups WARMUPS]
                        [--tensor-parallel-size TENSOR_PARALLEL_SIZE] [--enable-expert-parallel]
                        [--attn-tp-size ATTN_TP_SIZE] [--dense-tp-size DENSE_TP_SIZE] [--moe-tp-size MOE_TP_SIZE]
                        [--nprocs-per-node NPROCS_PER_NODE] [--world-size WORLD_SIZE] [--force-deterministic-rsag]
                        [--disable-sampling-tp-sync]
                        [--low-latency-max-num-tokens-per-gpu LOW_LATENCY_MAX_NUM_TOKENS_PER_GPU]
                        [--mla-chunk-multiplier MLA_CHUNK_MULTIPLIER]
                        [--mm-attention-backend {fa3,fa4,triton_attn,flashinfer_cudnn}]
                        [--disaggregation-mode {null,prefill,decode}]
                        [--comm-fusion-max-num-tokens COMM_FUSION_MAX_NUM_TOKENS] [--enable-allreduce-fusion]
                        [--disaggregation-bootstrap-port DISAGGREGATION_BOOTSTRAP_PORT]
                        [--disaggregation-transfer-backend {mooncake,mooncake_async}]
                        [--disaggregation-ib-device DISAGGREGATION_IB_DEVICE]
                        [--disaggregation-layerwise-interval DISAGGREGATION_LAYERWISE_INTERVAL] [--pdlb-url PDLB_URL]
                        [model]

Launch TokenSpeed through the TokenSpeed engine.

positional arguments:
  model                 The model name or path (positional argument). Equivalent to --model.

options:
  -h, --help            show this help message and exit
  --model MODEL, --model-path MODEL
                        The path of the model weights. This can be a local folder or a Hugging Face repo ID.
  --tokenizer TOKENIZER
                        The path of the tokenizer.
  --host HOST           The host of the server.
  --port PORT           The port of the server.
  --tokenizer-mode {auto,slow,deepseek_v4}
                        Tokenizer mode. 'auto' will use the fast tokenizer and model-specific tokenizer hooks if available, 'slow' will always use the slow tokenizer.
  --skip-tokenizer-init, --no-skip-tokenizer-init
                        If set, skip init tokenizer and pass input_ids in generate request
  --language-model-only
                        Skip vision/audio encoders on a multimodal checkpoint and run text-only. Multimodal requests are rejected.
  --ext-yaml EXT_YAML
  --load-format {auto,pt,safetensors,npcache,dummy,extensible}
                        The format of the model weights to load. "auto" will try to load the weights in the safetensors format and fall back to the pytorch bin format if safetensors format is not available. "pt" will load the weights in the pytorch bin format. "safetensors" will load the weights in the safetensors format. "npcache" will load the weights in pytorch format and store a numpy cache to speed up the loading. "dummy" will initialize the weights with random values.
  --trust-remote-code, --no-trust-remote-code
                        Whether or not to allow for custom models defined on the Hub in their own modeling files.
  --dtype {auto,half,float16,bfloat16,float,float32}
                        Data type for model weights and activations.
                        
                        * "auto" will use FP16 precision for FP32 and FP16 models, and BF16 precision for BF16 models.
                        * "half" for FP16. Recommended for AWQ quantization.
                        * "float16" is the same as "half".
                        * "bfloat16" for a balance between precision and range.
                        * "float" is shorthand for FP32 precision.
                        * "float32" for FP32 precision.
  --kv-cache-dtype {auto,fp8,fp8_e4m3}
                        Data type for kv cache storage. "auto" will use model data type. "fp8" is an alias for "fp8_e4m3".
  --kv-cache-quant-method {none,per_token_head}
                        kv cache quant method
  --quantization {fp8,nvfp4,w8a8_fp8,compressed-tensors}
                        The quantization method.
  --quantization-param-path QUANTIZATION_PARAM_PATH
                        Path to the JSON file containing the KV cache scaling factors. This should generally be supplied, when KV cache dtype is FP8. Otherwise, KV cache scaling factors default to 1.0, which may cause accuracy issues. 
  --max-model-len MAX_MODEL_LEN
                        The model's maximum context length. Defaults to None (will use the value from the model's config.json instead).
  --device {cuda}       The device type.
  --served-model-name SERVED_MODEL_NAME
                        Override the model name returned by the v1/models endpoint in OpenAI API server.
  --revision REVISION   The specific model version to use. It can be a branch name, a tag name, or a commit id. If unspecified, will use the default version.
  --gpu-memory-utilization GPU_MEMORY_UTILIZATION
                        The fraction of GPU memory to use for model weights and KV cache. Use a smaller value if you see out-of-memory errors.
  --max-num-seqs MAX_NUM_SEQS
                        Maximum number of sequences to process concurrently.
  --max-total-tokens MAX_TOTAL_TOKENS
                        The maximum number of tokens in the memory pool. If not specified, it will be automatically calculated based on the memory usage fraction. This overrides the automatically calculated token pool size.
  --chunked-prefill-size CHUNKED_PREFILL_SIZE
                        Maximum number of tokens the scheduler may issue in a single iteration. Setting this to -1 disables chunked prefill.
  --enable-mixed-batch  Allow the scheduler to issue prefill and decode requests in the same iteration.
  --block-size BLOCK_SIZE
  --disable-kvstore     Disable KVStore
  --kvstore-ratio KVSTORE_RATIO
                        The ratio of the size of the KVStore host memory pool to the size of the device pool.
  --kvstore-size KVSTORE_SIZE
                        The size of the KVStore host memory pool in gigabytes, which will override kvstore_ratio if set.
  --kvstore-io-backend {direct,kernel}
                        The IO backend for KVStore transfer between CPU and GPU.
  --kvstore-mem-layout {layer_first,page_first,page_head}
                        The layout of the KVStore host memory pool.
  --kvstore-storage-backend {mooncake}
                        The storage backend for KVStore. Built-in backends: mooncake. For dynamic backend, use --kvstore-storage-backend-extra-config to specify: backend_name (custom name), module_path (Python module path), class_name (backend class name).
  --kvstore-storage-backend-extra-config KVSTORE_STORAGE_BACKEND_EXTRA_CONFIG
                        A dictionary in JSON string format containing extra configuration for the storage backend.
  --enable-mla-l1-5-cache
                        Enable MLA L1.5 cache in disaggregation paths.
  --mamba-ssm-dtype {float32,bfloat16}
                        It is used to tune mamba ssm dtype
  --mamba-track-interval MAMBA_TRACK_INTERVAL
                        The interval to track the mamba state during decode.
  --max-mamba-cache-size MAX_MAMBA_CACHE_SIZE
                        The maximum number of Mamba cache chunks. If unset, the pool size is profiled from available memory.
  --mamba-full-memory-ratio MAMBA_FULL_MEMORY_RATIO
                        Memory ratio used to split cache budget between Mamba state chunks and full-attention KV cache.
  --enable-mamba-l2     Enable host-memory L2 cache for Mamba state slots.
  --mamba-l2-host-slots MAMBA_L2_HOST_SLOTS
                        Number of host Mamba L2 slots. If 0, derive from --mamba-l2-host-gb or --mamba-l2-ratio.
  --mamba-l2-ratio MAMBA_L2_RATIO
                        Mamba host L2 slot ratio relative to device Mamba slots when host slots are not explicit.
  --mamba-l2-layout {layer_first}
                        Mamba host L2 memory layout.
  --mamba-l2-io-backend {direct,kernel}
                        IO backend for Mamba L2 host/device transfers.
  --mamba-l2-host-gb MAMBA_L2_HOST_GB
                        Mamba L2 host memory budget in GiB. Overrides --mamba-l2-ratio when host slots are not explicit.
  --max-prefill-tokens MAX_PREFILL_TOKENS
                        Maximum prefill-token budget used when chunked prefill is disabled. Per-iteration scheduling is controlled by --chunked-prefill-size.
  --stream-interval STREAM_INTERVAL
                        The interval (or buffer size) for streaming in terms of the token length. A smaller value makes streaming smoother, while a larger value makes the throughput higher
  --stream-output       Whether to output as a sequence of disjoint segments.
  --seed SEED           The random seed.
  --distributed-timeout-seconds DISTRIBUTED_TIMEOUT_SECONDS
                        Set timeout for torch.distributed initialization.
  --download-dir DOWNLOAD_DIR
                        Model download directory for huggingface.
  --base-gpu-id BASE_GPU_ID
                        The base GPU ID to start allocating GPUs from. Useful when running multiple instances on the same machine.
  --gpu-id-step GPU_ID_STEP
                        The delta between consecutive GPU IDs that are used. For example, setting it to 2 will use GPU 0,2,4,...
  --log-level LOG_LEVEL
                        The logging level of all loggers.
  --log-level-http LOG_LEVEL_HTTP
                        The logging level of HTTP server. If not set, reuse --log-level by default.
  --enable-log-requests, --no-enable-log-requests
                        Log metadata, inputs, outputs of all requests. The verbosity is decided by --log-requests-level
  --log-requests-level {0,1,2}
                        0: Log metadata. 1. Log metadata and partial input/output. 2. Log every input/output.
  --enable-metrics      Enable log metrics.
  --metrics-reporters {prometheus}
                        Select metrics reporter(can be specified multiple times)
  --app-key APP_KEY     Set app key of the server
  --decode-log-interval DECODE_LOG_INTERVAL
                        The log interval of decode batch.
  --api-key API_KEY     Set API key of the server. It is also used in the OpenAI API compatible server.
  --enable-cache-report
                        Return number of cached tokens in usage.prompt_tokens_details for each openai request.
  --kv-events-config KV_EVENTS_CONFIG
                        JSON KV cache event publisher config. Set 'enable_kv_cache_events': true and publisher 'zmq' to publish device prefix-cache mutations.
  --data-parallel-size DATA_PARALLEL_SIZE
                        The data parallelism size. If not set, inferred from world_size and attn_tp_size.
  --load-balance-method {round_robin,shortest_queue,minimum_cache_usage}
                        The load balancing strategy for data parallelism.
  --load-watch-interval LOAD_WATCH_INTERVAL
                        The interval of load watching in seconds.
  --expert-parallel-size EXPERT_PARALLEL_SIZE, --ep-size EXPERT_PARALLEL_SIZE
                        The expert parallelism size.
  --init-expert-location INIT_EXPERT_LOCATION
                        Initial location of EP experts.
  --ep-num-redundant-experts EP_NUM_REDUNDANT_EXPERTS
                        Allocate this number of redundant experts in expert parallel.
  --ep-dispatch-algorithm EP_DISPATCH_ALGORITHM
                        The algorithm to choose ranks for redundant experts in expert parallel.
  --eplb-algorithm EPLB_ALGORITHM
                        Chosen EPLB algorithm
  --expert-distribution-recorder-mode EXPERT_DISTRIBUTION_RECORDER_MODE
                        Mode of expert distribution recorder.
  --expert-distribution-recorder-buffer-size EXPERT_DISTRIBUTION_RECORDER_BUFFER_SIZE
                        Circular buffer size of expert distribution recorder. Set to -1 to denote infinite buffer.
  --enable-expert-distribution-metrics
                        Enable logging metrics for expert balancedness
  --enable-eplb         Enable EPLB algorithm
  --moe-backend MOE_BACKEND
                        MoE runner backend: auto, triton, triton_kernel, flashinfer_mxfp4, marlin, etc.
  --draft-moe-backend DRAFT_MOE_BACKEND
                        MoE runner backend for the draft model in speculative decoding. If not set, defaults to --moe-backend.
  --flashinfer-mxfp4-moe-precision {default,bf16}
                        Computation precision of flashinfer mxfp4 moe.
  --all2all-backend ALL2ALL_BACKEND
                        MoE all-to-all backend: none, deepep, etc.
  --deepep-mode {normal,low_latency,auto}
                        Select the mode when enable DeepEP MoE, could be `normal`, `low_latency` or `auto`. Default is `auto`, which means `low_latency` for decode batch and `normal` for prefill batch.
  --disable-flashinfer-cutlass-moe-fp4-allgather
                        Disable flashinfer cutlass MoE FP4 allgather.
  --dist-init-addr DIST_INIT_ADDR
                        The host address for initializing distributed backend (e.g., `192.168.0.2:25000`).
  --nnodes NNODES       The number of nodes.
  --node-rank NODE_RANK
                        The node rank.
  --hf-overrides HF_OVERRIDES
                        A dictionary in JSON string format used to override default model configurations.
  --preferred-sampling-params PREFERRED_SAMPLING_PARAMS
                        json-formatted sampling settings that will be returned in /get_model_info
  --attention-backend {mha,fa3,fa4,triton,flashinfer,trtllm,trtllm_mla,flashmla,tokenspeed_mla,hybrid_linear_attn}
                        Choose the kernels for attention layers.
  --drafter-attention-backend {mha,fa3,fa4,triton,flashinfer,trtllm,trtllm_mla,flashmla,tokenspeed_mla,hybrid_linear_attn}
                        Attention backend for drafter model in speculative decoding. If not specified, uses the same backend as the main model (attention_backend).
  --mha-extend-mode {paged,ragged}
                        MHA extend strategy for prefix-cache/chunked-prefill batches. 'paged' uses one paged KV-cache attention kernel over full visible KV; 'ragged' uses ragged current-chunk prefill plus paged cached-prefix attention and merges with mha_merge_state.
  --sampling-backend {greedy,flashinfer,flashinfer_full}
                        Sampling backend. When unspecified, defaults to 'flashinfer' on NVIDIA and 'greedy' elsewhere. 'greedy': argmax + verify_chain_greedy, zero sampling-param plumbing. 'flashinfer': temperature/top_k/top_p via fused softmax + top_k_top_p_sampling_from_probs; min_p and penalties silently ignored. 'flashinfer_full': adds min_p plus frequency/presence/repetition penalties and logit_bias via the softmax+renorm+min_p kernel sequence. Allocates a counts[max_req_pool_size, vocab_size] int32 buffer (substantial memory). Both 'flashinfer' and 'flashinfer_full' require top_k < 128 (fused kernel limit) or -1.
  --attention-use-fp4-indexer-cache [ATTENTION_USE_FP4_INDEXER_CACHE], --attention-config.use-fp4-indexer-cache [ATTENTION_USE_FP4_INDEXER_CACHE], --attention_config.use_fp4_indexer_cache [ATTENTION_USE_FP4_INDEXER_CACHE]
                        Use the MXFP4 sparse attention indexer cache layout.
  --attention-config.use-trtllm-ragged-deepseek-prefill [USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL], --attention-config.use_trtllm_ragged_deepseek_prefill [USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL], --attention_config.use_trtllm_ragged_deepseek_prefill [USE_TRTLLM_RAGGED_DEEPSEEK_PREFILL]
                        Use ragged prefill for DeepSeek MLA attention.
  --deepseek-v4-mega-moe-max-num-tokens DEEPSEEK_V4_MEGA_MOE_MAX_NUM_TOKENS
                        DeepSeek V4 MegaMoE staging-buffer cap on tokens per forward (0 = derive from chunked-prefill / cuda-graph budgets).
  --deepseek-v4-indexer-prefill-max-logits-mb DEEPSEEK_V4_INDEXER_PREFILL_MAX_LOGITS_MB
                        DeepSeek V4 sparse indexer prefill workspace cap (MiB) for the softplus_sqrt logits buffer.
  --deepseek-v4-prefill-chunk-size DEEPSEEK_V4_PREFILL_CHUNK_SIZE
                        Maximum number of requests per DeepSeek V4 FlashMLA prefill chunk.
  --grammar-backend {xgrammar,none}
                        Grammar backend. 'none' disables grammar-guided decoding entirely 
  --reasoning-parser REASONING_PARSER
                        Reasoning parser name (e.g. 'minimax', 'kimi_k25'). Used to defer json_schema grammars past the model's reasoning channel.
  --grammar-compile-timeout-secs GRAMMAR_COMPILE_TIMEOUT_SECS
                        Per-compile wallclock budget before the request is aborted.
  --grammar-compile-max-retries GRAMMAR_COMPILE_MAX_RETRIES
                        Compile timeouts allowed before a grammar key is permanently rejected.
  --disable-any-whitespace
                        Compile xgrammar JSON grammars in tight mode (no arbitrary whitespace between tokens). Mitigates models that wedge into endless whitespace until length cutoff. xgrammar only.
  --disable-capturable-grammar
                        Force the synchronous eager grammar fallback even on CUDA. For parity-testing the captured-grammar path: output should match; throughput will be lower (sync stall every step).
  --mla-disable-ragged  Disable the ragged prefill wrapper on MLA kernel backends during EXTEND.
  --draft-model-path-use-base
                        The path of the draft model weights use the path of the base model
  --speculative-config SPECULATIVE_CONFIG, --speculative_config SPECULATIVE_CONFIG
                        JSON speculative decoding configuration. Supported keys are method, model, and num_speculative_tokens.
  --speculative-algorithm {EAGLE3,MTP}
                        Speculative algorithm.
  --speculative-draft-model-path SPECULATIVE_DRAFT_MODEL_PATH
                        The path of the draft model weights. This can be a local folder or a Hugging Face repo ID.
  --speculative-draft-model-quantization SPECULATIVE_DRAFT_MODEL_QUANTIZATION
                        Quantization method for the draft model. Defaults to 'unquant'.
  --speculative-num-steps SPECULATIVE_NUM_STEPS
                        The number of steps sampled from draft model in Speculative Decoding.
  --speculative-eagle-topk {1}
                        The number of tokens sampled from the draft model in each speculative step.
  --speculative-num-draft-tokens SPECULATIVE_NUM_DRAFT_TOKENS
                        The number of tokens sampled from the draft model in Speculative Decoding.
  --enable-output-logprobs
                        Enable per-token sampled-token logprobs. OFF by default; enabling extends the captured CUDA-graph footprint. Requests asking for logprobs on a server without this flag receive empty logprobs.
  --eagle3-layers-to-capture EAGLE3_LAYERS_TO_CAPTURE
                        The layers of Eagle3 to capture.
  --disable-pdl         Disable PDL launch.
  --enable-prefix-caching
                        Enable prefix caching.
  --no-enable-prefix-caching
                        Disable prefix caching.
  --enforce-eager       Disable CUDA graph.
  --disable-cuda-graph-padding
                        Disable cuda graph when padding is needed. Still uses cuda graph when padding is not needed.
  --enable-cudagraph-gc
                        Enable garbage collection during CUDA graph capture. If disabled (default), GC is frozen during capture to speed up the process.
  --enable-nccl-nvls    Enable NCCL NVLS for prefill heavy requests when available.
  --enable-symm-mem     Enable NCCL symmetric memory for fast collectives.
  --disable-custom-all-reduce
                        Disable the custom all-reduce kernel and fall back to NCCL.
  --disable-overlap-schedule
                        Disable the overlap scheduler, which overlaps the CPU scheduler with GPU model worker.
  --disable-tf32        Disable forcing TF32 on for cuBLAS/cuDNN. By default the server sets NVIDIA_TF32_OVERRIDE=1 and TORCH_ALLOW_TF32_CUBLAS_OVERRIDE=1.
  --max-cudagraph-capture-size MAX_CUDAGRAPH_CAPTURE_SIZE
                        Set the maximum batch size for CUDA graph capture.
  --cudagraph-capture-sizes CUDAGRAPH_CAPTURE_SIZE [CUDAGRAPH_CAPTURE_SIZE ...]
                        Set the list of batch sizes for CUDA graph capture.
  --disable-prefill-graph
                        Disable cuda graph for prefill.
  --prefill-graph-max-tokens PREFILL_GRAPH_MAX_TOKENS
                        Max query tokens to capture when enable prefill graph
  --enable-nan-detection
                        Enable the NaN detection for debugging purposes.
  --enable-nvtx         Emit NVTX ranges around input_prep / target_forward / sampling / drafter stages for nsys profiling. Off by default (true no-op — no NVTX calls are made). Also enabled by TOKENSPEED_NVTX=1.
  --enable-p2p-check    Enable the full GPU P2P access check, otherwise trust the driver's P2P report.
  --triton-attention-reduce-in-fp32
                        Cast the intermediate attention results to fp32 to avoid possible crashes related to fp16.This only affects Triton attention kernels.
  --delete-ckpt-after-loading
                        Delete the model checkpoint after loading the model.
  --weight-loader-prefetch-checkpoints
                        Prefetch safetensors checkpoint shards into OS page cache before loading. Local ranks split the shard list to reduce repeated reads from shared filesystems.
  --weight-loader-prefetch-num-threads WEIGHT_LOADER_PREFETCH_NUM_THREADS
                        Number of background threads per rank for checkpoint prefetching.
  --enable-memory-saver
                        Allow saving memory using release_memory_occupation and resume_memory_occupation
  --enable-custom-logit-processor
                        Enable users to pass custom logit processors to the server (disabled by default for security)
  --skip-server-warmup  If set, skip warmup.
  --warmups WARMUPS     Specify custom warmup functions (csv) to run before server starts eg. --warmups=warmup_name1,warmup_name2 will run the functions `warmup_name1` and `warmup_name2` specified in warmup.py before the server starts listening for requests
  --tensor-parallel-size TENSOR_PARALLEL_SIZE, --tp TENSOR_PARALLEL_SIZE
                        Sets tensor parallelism size uniformly (equivalent to --attn-tp-size). Cannot be used together with --attn-tp-size.
  --enable-expert-parallel
                        Enable expert parallelism by automatically setting ep_size to world_size.
  --attn-tp-size ATTN_TP_SIZE
                        Specify tp size for attn part
  --dense-tp-size DENSE_TP_SIZE
                        Specify tp size for dense part, default equals nprocs-per-node, if non dp_attn && combine_dense mode, this parameter will be overridden by attn_tp_size
  --moe-tp-size MOE_TP_SIZE
                        Specify tp size for MoE part, default equals nprocs-per-node, if non dp_attn && combine_dense mode, this parameter will be overridden by attn_tp_size
  --nprocs-per-node NPROCS_PER_NODE
                        Number of processes to start per node
  --world-size WORLD_SIZE
                        Total number of processes across all nodes.
  --force-deterministic-rsag
                        Enable force deterministic rsag.
  --disable-sampling-tp-sync
                        Skip broadcasting sampler outputs across the attention TP group. Only safe when the sampling kernels are deterministic.
  --low-latency-max-num-tokens-per-gpu LOW_LATENCY_MAX_NUM_TOKENS_PER_GPU
                        Low latency max num tokens per gpu
  --mla-chunk-multiplier MLA_CHUNK_MULTIPLIER
                        Per-iter MLA chunked-prefill chunk capacity multiplier; the actual capacity is chunked_prefill_size * mla_chunk_multiplier.
  --mm-attention-backend {fa3,fa4,triton_attn,flashinfer_cudnn}
                        Set multimodal attention backend.
  --disaggregation-mode {null,prefill,decode}
                        Only used for PD disaggregation. "prefill" for prefill-only server, and "decode" for decode-only server. If not specified, it is not PD disaggregated
  --comm-fusion-max-num-tokens COMM_FUSION_MAX_NUM_TOKENS
                        Max num tokens for communication fusion workspace
  --enable-allreduce-fusion
                        Enable allreduce fusion for improved decode performance. Auto-enabled on supported single-node TP configurations.
  --disaggregation-bootstrap-port DISAGGREGATION_BOOTSTRAP_PORT
                        Bootstrap server port on the prefill server. Default is 8998.
  --disaggregation-transfer-backend {mooncake,mooncake_async}
                        The backend for disaggregation transfer. Default is mooncake.
  --disaggregation-ib-device DISAGGREGATION_IB_DEVICE
                        The InfiniBand devices for disaggregation transfer, accepts single device (e.g., --disaggregation-ib-device mlx5_0) or multiple comma-separated devices (e.g., --disaggregation-ib-device mlx5_0,mlx5_1). Default is None, which triggers automatic device detection when mooncake backend is enabled.
  --disaggregation-layerwise-interval DISAGGREGATION_LAYERWISE_INTERVAL
                        The interval of layerwise transfer for disaggregation. Default is 1.
  --pdlb-url PDLB_URL   The URL of the PD disaggregation load balancer. If set, the prefill/decode server will register with the load balancer.

orchestrator options:
  --engine-startup-timeout SECONDS
                        Max wait for engine gRPC readiness (default: 1800)
  --gateway-startup-timeout SECONDS
                        Max wait for gateway HTTP readiness (default: 60)
  --drain-timeout SECONDS
                        Grace period for shutdown before SIGKILL (default: 30)
  --control-port PORT   Optional control HTTP port

Routing notes:
  --model / --reasoning-parser are fanned out to engine + gateway.
  --host / --port are treated as gateway-facing in smg mode.
  --chat-template / --tool-call-parser are gateway-only overrides.
  Unknown flags fall through to smg gateway launch arguments.
```

<!-- How was this validated? -->
