### PR TITLE
[Bugfix] fix smg command argument cannot be used multiple times

### DIFF
--- a/python/tokenspeed/cli/_proc.py
+++ b/python/tokenspeed/cli/_proc.py
@@ -75,8 +75,6 @@ async def spawn_gateway(
         "launch",
         "--worker-urls",
         f"grpc://{engine_host}:{engine_port}",
-        "--disable-retries",
-        "--disable-circuit-breaker",
         *args,
     ]
     logger.info("spawn gateway: %s", " ".join(cmd))

--- a/test/cli/test_proc.py
+++ b/test/cli/test_proc.py
@@ -34,28 +34,6 @@ from tokenspeed.cli._proc import (
 
 
 @pytest.mark.asyncio
-async def test_spawn_gateway_disables_retries_and_circuit_breaker(monkeypatch):
-    """Single-worker mode: retries and circuit-breaker are disabled by default."""
-
-    captured = {}
-
-    async def fake_exec(*cmd, **kwargs):
-        captured["cmd"] = cmd
-
-        class _P:
-            async def wait(self):
-                return 0
-
-        return _P()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
-    await spawn_gateway([], engine_host="127.0.0.1", engine_port=12345)
-    cmd = captured["cmd"]
-    assert "--disable-retries" in cmd
-    assert "--disable-circuit-breaker" in cmd
-
-
-@pytest.mark.asyncio
 async def test_terminate_then_kill_uses_sigterm_first_then_sigkill():
     """If the child doesn't exit within drain_timeout, we escalate to SIGKILL."""
     proc = MagicMock()


### PR DESCRIPTION
## Summary

Fix: https://github.com/lightseekorg/tokenspeed/issues/365

Because generate smg command argument `--disable-retries --disable-circuit-breaker` this part is multiple times.
```
/home/jovyan/code/tokenspeed/.venv/bin/python3 -m smg launch --worker-urls grpc://127.0.0.1:37693 --disable-retries --disable-circuit-breaker --model /new-model/gpt-oss-20b/ --log-level debug --port 8000 --reasoning-parser passthrough --disable-circuit-breaker --disable-retries --tokenizer-cache-enable-l0 --tokenizer-cache-enable-l1 --prometheus-port 8413
```

In `_gateway_args_with_smg_disable_defaults` this method will add this two default argument. 

```
_DEFAULT_SMG_DISABLE_FLAGS = (
    "--disable-circuit-breaker",
    "--disable-retries",
)
def _gateway_args_with_smg_disable_defaults(gateway_args: list[str]) -> list[str]:
    """Append the smg reliability-disable switches if they are not already there."""
    result = list(gateway_args)
    for flag in _DEFAULT_SMG_DISABLE_FLAGS:
        if flag not in result:
            result.append(flag)
    return result
```

## Test Plan

```
$ tokenspeed serve /new-model/gpt-oss-20b/ --log-level debug
```