### PR TITLE
Add AMD Gluon sampling argmax

### DIFF
--- a/.skills/optimize-amd-gpu-kernel.md
+++ b/.skills/optimize-amd-gpu-kernel.md
@@ -1,0 +1,79 @@
+---
+name: optimize-amd-gpu-kernel
+description: Optimizing kernel performance on AMD Instinct MI GPUs.
+---
+
+## General Methodology
+
+* Understand the problem: check whether compute-, memory-, or latency-bound,
+  and approach accordingly.
+* Profile, focus on the top bottleneck; iterate in such loop.
+* Use Gluon for explicit low-level controls.
+* Pay attention to both `ttg` level and `llvm` level opportunities and balances.
+* Fine to tune configuration parameters but don't solely focus on it and don't
+  overdo it. Prefer to avoid complicated switch cases to overfit different
+  problem sizes.
+
+## Profiling Tools
+
+* Use Proton for high-level TFLOp/s or TB/s calculation; check in code changes
+  for `triton.jit`/`gluon.git` `repr` for reuse.
+* Use `rocprofv3` in ROCm to understand low-level internals like counters.
+* Proton also supports fine-grained profiling with `scope` APIs and
+  instrumentation mode.
+
+## Problem Approaches
+
+### General optimizations
+
+Applicable to various problems:
+
+* Prefer to launch enough workgroups to fill the GPU.
+* Ensure proper software pipelining to break dependencies in the same loop
+  iteration.
+* Prefer coaleased async global memory load/store.
+* If indexing range allows, prefer buffer load/store intrinsics in Gluon to
+  avoid out-of-bound branches and overheads.
+* Avoid shared memory bank conflict if possible. Use padding instead of
+  swizzling.
+
+### Compute bound problems
+
+The key is to keep issuing MFMA instructions preferrably every cyle, and
+avoid exposed memory instruction latencies. Generally two approaches:
+
+* Use 4 waves per workgroup, and perform fine-grained per-instruction level
+  interleaving in the same wave on one SIMD. Typically needs controlling
+  LLVM knobs; can use `HIPOptions.llvm_fn_attrs`.
+* Use 8 waves per workgroup, and perform course-grained multi-instruction
+  level interleaving across 2 waves on the same SIMD, to make sure those
+  two waves "ping-pong" among each other to overlap. Available via the
+  `amd.warp_pipeline_stage` API.
+
+Search and read AMD ISA docs and Triton codebase and examples to get
+inspiration.
+
+* If high VGPR pressure, consider slice along M/N in the hot loop and
+  interleave to retire certain slices of loaded values earlier.
+
+### Memory bound problems
+
+The key is to saturate GPU memory bandwidth with enough inflight memory
+instructions, and avoid exposed compute instruction cycles.
+
+* Prefetch using async load with higher number of shared memory buffers.
+* Use cache modifiers like `".cg"`, `".wt"`, etc. to control whether to
+  cache at certain levels.
+
+### Latency bound problems
+
+* Fuse multiple small kernels into one kernel when possible.
+
+### Small problem sizes
+
+* Perform split-k style optimization and launch second reduction kernel to
+  see if beneficial.
+
+### Expensive epilogue
+
+* Perform persistent kernrel style optimization to see if benefical.

--- a/.skills/optimize-amd-gpu-kernel.md
+++ b/.skills/optimize-amd-gpu-kernel.md
@@ -31,7 +31,7 @@ Applicable to various problems:
 * Prefer to launch enough workgroups to fill the GPU.
 * Ensure proper software pipelining to break dependencies in the same loop
   iteration.
-* Prefer coaleased async global memory load/store.
+* Prefer coaleased and vectorized async global memory load/store.
 * If indexing range allows, prefer buffer load/store intrinsics in Gluon to
   avoid out-of-bound branches and overheads.
 * Avoid shared memory bank conflict if possible. Use padding instead of

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,4 @@ Inside the root tokenspeed-kernel/ directory:
   new work should consolidate toward these backend choices.
 * Files under `ops/` should follow `<family>/<solution>` structure, like
   `gemm/trtllm.py` or `attention/triton/`.
+* When defining new public APIs, explain arguments and returns in docstring.

--- a/python/tokenspeed/runtime/execution/drafter/eagle.py
+++ b/python/tokenspeed/runtime/execution/drafter/eagle.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import torch
-from tokenspeed_kernel.ops.sampling.cute_dsl import argmax as cute_argmax
+from tokenspeed_kernel.ops.sampling import argmax as sampling_argmax
 from typing_extensions import override
 
 from tokenspeed.runtime.execution.cache_loc_kernel import (
@@ -352,7 +352,7 @@ class Eagle(BaseDrafter):
                 )
 
             with nvtx_range("draft_sample", color="yellow"):
-                draft_ids = cute_argmax(logits_output.next_token_logits)
+                draft_ids = sampling_argmax(logits_output.next_token_logits)
                 draft_ids.clamp_(min=0)
                 # Column 0 holds last_verified_ids; drafter writes step `i` into column `i + 1`.
                 next_tokens[:, i + 1] = self._map_hot(draft_ids)
@@ -422,7 +422,7 @@ class Eagle(BaseDrafter):
         # down to `[bs, ...]`, so logits/hidden_states arrive here already aligned to one row per request.
         logits_output = self._run_first_step(bs, draft_input)
 
-        draft_ids = cute_argmax(logits_output.next_token_logits)
+        draft_ids = sampling_argmax(logits_output.next_token_logits)
         draft_ids.clamp_(min=0)
         next_tokens[:, 1] = self._map_hot(draft_ids)
 

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -499,7 +499,7 @@ class ModelExecutor:
 
         # Single choke point for every (sample/verify) x (greedy/flashinfer)
         # path: NaN logits (e.g. DP dummy/warmup batches over uninitialized KV)
-        # make cute_argmax emit the -1 sentinel. Left unclamped, that -1 poisons
+        # make sampling argmax emit the -1 sentinel. Left unclamped, that -1 poisons
         # both consumers below -- it flows into output_ids -> detokenizer (the
         # HF Rust tokenizer raises OverflowError on a negative id and kills the
         # engine) and, via the drafter, back into future_input_map as the next

--- a/python/tokenspeed/runtime/sampling/backends/flashinfer.py
+++ b/python/tokenspeed/runtime/sampling/backends/flashinfer.py
@@ -23,13 +23,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
+from tokenspeed_kernel.ops.sampling import argmax as sampling_argmax
 from tokenspeed_kernel.ops.sampling.cuda import (
     chain_speculative_sampling_target_only,
     fused_topk_topp_prepare,
     fused_topk_topp_renorm,
     verify_chain_greedy,
 )
-from tokenspeed_kernel.ops.sampling.cute_dsl import argmax as cute_argmax
 from tokenspeed_kernel.ops.sampling.flashinfer import (
     softmax,
     top_k_renorm_prob,
@@ -244,7 +244,7 @@ class FlashInferSamplingBackend(SamplingBackend):
 
         if sampling_info.is_all_greedy:
 
-            batch_next_token_ids = cute_argmax(logits)
+            batch_next_token_ids = sampling_argmax(logits)
 
         else:
 
@@ -322,7 +322,7 @@ class FlashInferSamplingBackend(SamplingBackend):
 
         if sampling_info.is_all_greedy:
 
-            target_predict = cute_argmax(logits).reshape(bs, num_tokens_per_req)
+            target_predict = sampling_argmax(logits).reshape(bs, num_tokens_per_req)
 
             verify_chain_greedy(
                 predicts=predict,

--- a/python/tokenspeed/runtime/sampling/backends/greedy.py
+++ b/python/tokenspeed/runtime/sampling/backends/greedy.py
@@ -23,10 +23,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import torch
+from tokenspeed_kernel.ops.sampling import argmax as sampling_argmax
 from tokenspeed_kernel.ops.sampling.cuda import (
     verify_chain_greedy as _verify_chain_greedy_cuda,
 )
-from tokenspeed_kernel.ops.sampling.cute_dsl import argmax as cute_argmax
 from tokenspeed_kernel.registry import error_fn
 
 from tokenspeed.runtime.sampling.backends.base import (
@@ -182,7 +182,7 @@ class GreedySamplingBackend(SamplingBackend):
                 logits=logits, vocab_mask=sampling_info.vocab_mask
             )
         bs = logits.shape[0]
-        tokens = cute_argmax(logits, out=self._sample_token_buf[:bs])
+        tokens = sampling_argmax(logits, out=self._sample_token_buf[:bs])
 
         if self.config.enable_output_logprobs:
             logits_output.next_token_logprobs = gather_token_logprobs_torch(
@@ -221,7 +221,7 @@ class GreedySamplingBackend(SamplingBackend):
                 logits=logits,
                 vocab_mask=sampling_info.vocab_mask,
             )
-        target_predict = cute_argmax(logits).reshape(bs, num_tokens_per_req)
+        target_predict = sampling_argmax(logits).reshape(bs, num_tokens_per_req)
 
         _verify_chain_greedy(
             predicts=predict,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/__init__.py
@@ -44,6 +44,7 @@ from tokenspeed_kernel.ops.quantization import (
     quantize_mxfp8,
     quantize_nvfp4,
 )
+from tokenspeed_kernel.ops.sampling import argmax
 
 __all__ = [
     # gemm
@@ -66,4 +67,6 @@ __all__ = [
     "quantize_mxfp8",
     "quantize_nvfp4",
     "quantize_mxfp4",
+    # sampling
+    "argmax",
 ]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/__init__.py
@@ -19,3 +19,94 @@
 # SOFTWARE.
 
 """Sampling kernel entry points."""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
+from tokenspeed_kernel.selection import NoKernelFoundError, select_kernel
+from tokenspeed_kernel.signature import dense_tensor_format, format_signature
+
+__all__ = ["argmax"]
+
+_SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+_SUPPORTED_OUT_DTYPES = (torch.int32, torch.int64)
+
+
+def _validate_argmax_out(logits: torch.Tensor, out: torch.Tensor) -> None:
+    if out.shape != (logits.shape[0],):
+        raise ValueError(
+            f"out must have shape (M,)={(logits.shape[0],)}, got {tuple(out.shape)}"
+        )
+    if out.dtype not in _SUPPORTED_OUT_DTYPES:
+        raise ValueError(f"out must be int32 or int64; got {out.dtype}")
+    if out.device != logits.device:
+        raise ValueError("out must be on the same device as logits")
+
+
+def _argmax_torch_fallback(
+    logits: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if out is not None:
+        _validate_argmax_out(logits, out)
+    result = torch.argmax(logits, dim=-1)
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
+
+
+def argmax(
+    logits: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+    solution: str | None = None,
+    override: str | None = None,
+) -> torch.Tensor:
+    """Return row-wise argmax indices over the last logits dimension.
+
+    Args:
+        logits: Input logits with shape ``(M, N)``. The argmax is taken
+            over the last dimension.
+        out: Optional output buffer with shape ``(M,)`` and dtype int32 or
+            int64 on the same device as ``logits``.
+        solution: Optional kernel solution to force through normal selection.
+        override: Optional exact kernel-name or solution override.
+
+    Returns:
+        A tensor containing argmax indices for each row of ``logits``.
+    """
+    if logits.dim() != 2 or not logits.is_cuda or logits.dtype not in _SUPPORTED_DTYPES:
+        return _argmax_torch_fallback(logits, out=out)
+
+    signature = format_signature(logits=dense_tensor_format(logits.dtype))
+    try:
+        kernel = select_kernel(
+            "sampling",
+            "argmax",
+            signature,
+            solution=solution,
+            override=override,
+        )
+    except NoKernelFoundError:
+        return _argmax_torch_fallback(logits, out=out)
+
+    shape_params = {
+        "M": logits.shape[0],
+        "N": logits.shape[1],
+        "has_out": out is not None,
+    }
+    ShapeCapture.get().record(
+        "sampling", "argmax", kernel.name, logits.dtype, shape_params
+    )
+    with kernel_scope(
+        "sampling", "argmax", logits.dtype, kernel_name=kernel.name, **shape_params
+    ):
+        return kernel(logits, out=out)
+
+
+# Backend registration (side-effect imports).
+import tokenspeed_kernel.ops.sampling.cute_dsl  # noqa: E402,F401
+import tokenspeed_kernel.ops.sampling.gluon  # noqa: E402,F401

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/__init__.py
@@ -75,6 +75,13 @@ def argmax(
         solution: Optional kernel solution to force through normal selection.
         override: Optional exact kernel-name or solution override.
 
+    NaN handling:
+        Kernel-backed sampling paths treat NaNs as invalid candidates.
+        Rows with at least one non-NaN value return the index of the
+        maximum non-NaN value, with ties broken toward the lowest index.
+        Rows with no valid non-NaN values return the ``-1`` sentinel.
+        Unsupported inputs fall back to ``torch.argmax`` semantics.
+
     Returns:
         A tensor containing argmax indices for each row of ``logits``.
     """

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
@@ -21,8 +21,8 @@
 """CuTe DSL based sampling kernels.
 
 Wraps the upstream CuTe DSL ``ArgmaxKernel`` (derived from the Quack library and
-ported through TensorRT-LLM) so the runtime can call it without touching the
-third-party module directly.
+ported through TensorRT-LLM) so the sampling public API can register it
+without touching the third-party module directly.
 
 Exports two entry points:
 
@@ -40,22 +40,25 @@ Exports two entry points:
 Platform support:
 
 The CuTe DSL kernel ships only for NVIDIA Hopper/Blackwell (sm_90..<sm_120).
-On every other target — AMD ROCm, CPU-only, unsupported SM, missing
-``nvidia-cutlass-dsl`` — the public ``argmax`` / ``argmax_pair`` names are
-bound at import time to pure-torch fallback implementations, so callers don't
-need to test for kernel availability. The cute-DSL imports are gated behind
-``_ARCH_SUPPORTED`` and never executed on non-NVIDIA hosts.
+The common ``tokenspeed_kernel.ops.sampling.argmax`` API selects this
+registered solution on NVIDIA.
 """
 
 from __future__ import annotations
 
 import torch
-from tokenspeed_kernel.platform import current_platform
-from tokenspeed_kernel.registry import error_fn
+from tokenspeed_kernel.platform import (
+    ArchVersion,
+    CapabilityRequirement,
+    current_platform,
+)
+from tokenspeed_kernel.registry import Priority, error_fn, register_kernel
+from tokenspeed_kernel.signature import format_signatures
 
 __all__ = [
     "argmax",
     "argmax_pair",
+    "cute_dsl_argmax",
     "is_available",
 ]
 
@@ -151,7 +154,7 @@ if _ARCH_SUPPORTED and _has_cluster_launch_support():
 
 
 def is_available() -> bool:
-    """Whether the CuTe DSL argmax kernel can run on the current platform."""
+    """Whether the CuTe DSL argmax kernel can run on this platform."""
     return _CUTE_AVAILABLE
 
 
@@ -283,6 +286,28 @@ def _argmax_pair_torch_fallback(
     return out
 
 
+def _register_cute_argmax(fn):
+    if not _CUTE_AVAILABLE:
+        return fn
+    return register_kernel(
+        "sampling",
+        "argmax",
+        name="cute_dsl_argmax",
+        solution="cute_dsl",
+        capability=CapabilityRequirement(
+            min_arch_version=ArchVersion(9, 0),
+            max_arch_version=ArchVersion(11, 9),
+            vendors=frozenset({"nvidia"}),
+        ),
+        signatures=format_signatures(
+            "logits", "dense", {torch.float16, torch.bfloat16, torch.float32}
+        ),
+        priority=Priority.SPECIALIZED,
+        tags={"latency", "determinism"},
+    )(fn)
+
+
+@_register_cute_argmax
 def _argmax_cute(
     logits: torch.Tensor,
     *,
@@ -353,10 +378,10 @@ def _argmax_pair_cute(
     return out
 
 
-# Public API binding. On NVIDIA + cute-DSL-installed hosts the fast path is
-# selected; everywhere else the public names refer to pure-torch
-# implementations so callers don't need to test for availability. Mirrors the
-# pattern used in ``tokenspeed_kernel.ops.sampling.cuda``.
+cute_dsl_argmax = _argmax_cute
+
+# Direct CuTe DSL module API. The common runtime-facing API lives in
+# tokenspeed_kernel.ops.sampling and selects among registered solutions.
 if _CUTE_AVAILABLE:
     argmax = _argmax_cute
     argmax_pair = _argmax_pair_cute

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/__init__.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Gluon sampling kernels."""
+
+from __future__ import annotations
+
+from tokenspeed_kernel.ops.sampling.gluon.argmax_gfx950 import (
+    gluon_argmax_gfx950,
+)
+
+__all__ = ["gluon_argmax_gfx950"]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/argmax_gfx950.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/argmax_gfx950.py
@@ -1,0 +1,297 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Gluon argmax kernels optimized for AMD GFX950 sampling."""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel._triton import gl, gluon, triton
+from tokenspeed_kernel.platform import ArchVersion, CapabilityRequirement
+from tokenspeed_kernel.registry import Priority, register_kernel
+from tokenspeed_kernel.signature import format_signatures
+
+__all__ = [
+    "argmax",
+    "argmax_pair",
+    "gluon_argmax_gfx950",
+]
+
+cdna4 = gl.amd.cdna4
+
+_SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+_SUPPORTED_OUT_DTYPES = (torch.int32, torch.int64)
+_MIN_GLUON_VOCAB_SIZE = 4096
+_scratch_cache: dict[
+    tuple[int, int, int], tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+] = {}
+
+
+@gluon.jit
+def _argmax_combine(value1, index1, value2, index2):
+    take1 = (value1 > value2) | ((value1 == value2) & (index1 < index2))
+    value = gl.where(take1, value1, value2)
+    index = gl.where(take1, index1, index2)
+    return value, index
+
+
+@gluon.constexpr_function
+def _argmax_layout(BLOCK: gl.constexpr, NUM_WARPS: gl.constexpr):
+    return gl.BlockedLayout([1], [64], [NUM_WARPS], [0])
+
+
+@gluon.jit
+def _argmax_tile(
+    logits, row, start, stride_m: gl.constexpr, N: gl.constexpr, BLOCK: gl.constexpr
+):
+    offs = gl.arange(0, BLOCK, layout=_argmax_layout(BLOCK, gl.num_warps()))
+    cols = start + offs
+    mask = cols < N
+    vals = cdna4.buffer_load(
+        logits,
+        row * stride_m + cols,
+        mask=mask,
+        other=-float("inf"),
+    ).to(gl.float32)
+    indices = gl.where(mask, cols.to(gl.int32), 2147483647)
+    return gl.reduce((vals, indices), axis=0, combine_fn=_argmax_combine)
+
+
+@gluon.jit
+def _argmax_one_stage_kernel(
+    logits,
+    out,
+    stride_m: gl.constexpr,
+    out_stride: gl.constexpr,
+    N: gl.constexpr,
+    BLOCK: gl.constexpr,
+):
+    row = gl.program_id(0)
+    best_val = gl.full((), -float("inf"), gl.float32)
+    best_idx = gl.full((), 2147483647, gl.int32)
+
+    for start in range(0, N, BLOCK):
+        tile_val, tile_idx = _argmax_tile(logits, row, start, stride_m, N, BLOCK)
+        best_val, best_idx = _argmax_combine(best_val, best_idx, tile_val, tile_idx)
+
+    gl.store(out + row * out_stride, best_idx.to(out.dtype.element_ty))
+
+
+@gluon.jit
+def _argmax_split_atomic_kernel(
+    logits,
+    partial_values,
+    partial_indices,
+    counters,
+    out,
+    stride_m: gl.constexpr,
+    out_stride: gl.constexpr,
+    N: gl.constexpr,
+    NUM_SPLITS: gl.constexpr,
+    BLOCK: gl.constexpr,
+    REDUCE_BLOCK: gl.constexpr,
+):
+    row = gl.program_id(0)
+    split = gl.program_id(1)
+    tile_val, tile_idx = _argmax_tile(logits, row, split * BLOCK, stride_m, N, BLOCK)
+    partial_offset = row * NUM_SPLITS + split
+    gl.store(partial_values + partial_offset, tile_val)
+    gl.store(partial_indices + partial_offset, tile_idx)
+
+    old = gl.atomic_add(counters + row, 1, sem="acq_rel", scope="gpu")
+    if old == NUM_SPLITS - 1:
+        offs = gl.arange(
+            0, REDUCE_BLOCK, layout=_argmax_layout(REDUCE_BLOCK, gl.num_warps())
+        )
+        mask = offs < NUM_SPLITS
+        base = row * NUM_SPLITS + offs
+        vals = gl.load(
+            partial_values + base, mask=mask, other=-float("inf"), volatile=True
+        )
+        indices = gl.load(partial_indices + base, mask=mask, other=2147483647)
+        _, best_idx = gl.reduce((vals, indices), axis=0, combine_fn=_argmax_combine)
+        gl.store(out + row * out_stride, best_idx.to(out.dtype.element_ty))
+        gl.store(counters + row, 0)
+
+
+def _validate_argmax_out(logits: torch.Tensor, out: torch.Tensor) -> None:
+    if out.shape != (logits.shape[0],):
+        raise ValueError(
+            f"out must have shape (M,)={(logits.shape[0],)}, got {tuple(out.shape)}"
+        )
+    if out.dtype not in _SUPPORTED_OUT_DTYPES:
+        raise ValueError(f"out must be int32 or int64; got {out.dtype}")
+    if out.device != logits.device:
+        raise ValueError("out must be on the same device as logits")
+
+
+def _validate_argmax_pair_out(logits: torch.Tensor, out: torch.Tensor) -> None:
+    shape = (logits.shape[0], 2)
+    if out.shape != shape:
+        raise ValueError(f"out must have shape (M, 2)={shape}, got {tuple(out.shape)}")
+    if out.dtype != torch.float32 or out.device != logits.device:
+        raise ValueError("out must be float32 on the same device as logits")
+
+
+def _argmax_torch_fallback(
+    logits: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if out is not None:
+        _validate_argmax_out(logits, out)
+    result = torch.argmax(logits, dim=-1)
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
+
+
+def _argmax_pair_torch_fallback(
+    logits: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if logits.dim() != 2:
+        raise ValueError(f"argmax_pair expects 2D input, got {logits.dim()}D")
+    if out is None:
+        out = torch.empty(
+            (logits.shape[0], 2), dtype=torch.float32, device=logits.device
+        )
+    else:
+        _validate_argmax_pair_out(logits, out)
+    max_vals, max_indices = torch.max(logits, dim=-1, keepdim=True)
+    out[:, 0:1].copy_(max_vals.to(torch.float32))
+    out[:, 1:2].copy_(max_indices.to(torch.float32))
+    return out
+
+
+def _supports_gluon(logits: torch.Tensor) -> bool:
+    if logits.dim() != 2 or not logits.is_cuda:
+        return False
+    if logits.dtype not in _SUPPORTED_DTYPES:
+        return False
+    if logits.shape[1] < _MIN_GLUON_VOCAB_SIZE:
+        return False
+    if logits.stride(1) != 1:
+        return False
+    return True
+
+
+def _get_atomic_scratch(
+    M: int, num_splits: int, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    device_index = device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    key = (device_index, M, num_splits)
+    scratch = _scratch_cache.get(key)
+    if scratch is None:
+        partial_values = torch.empty(
+            (M, num_splits), dtype=torch.float32, device=device
+        )
+        partial_indices = torch.empty((M, num_splits), dtype=torch.int32, device=device)
+        counters = torch.zeros((M,), dtype=torch.int32, device=device)
+        scratch = (partial_values, partial_indices, counters)
+        _scratch_cache[key] = scratch
+    return scratch
+
+
+def _select_config(M: int, N: int) -> tuple[int, int, bool]:
+    """Return Gluon launch config for ``M x N`` logits.
+
+    Returns ``(block, num_warps, use_split_atomic)``: the tile width,
+    wave grouping, and whether to use the split-tile atomic reduction path.
+    """
+    if M <= 32:
+        return 16384, 4, True
+    if M <= 64:
+        block = 32768 if N >= 180000 else 16384
+        return block, 4, True
+    return 8192, 4, False
+
+
+@register_kernel(
+    "sampling",
+    "argmax",
+    name="gluon_argmax_gfx950",
+    solution="gluon",
+    capability=CapabilityRequirement(
+        min_arch_version=ArchVersion(9, 5),
+        max_arch_version=ArchVersion(9, 5),
+        vendors=frozenset({"amd"}),
+    ),
+    signatures=format_signatures("logits", "dense", set(_SUPPORTED_DTYPES)),
+    priority=Priority.SPECIALIZED,
+    tags={"latency", "determinism"},
+)
+def gluon_argmax_gfx950(
+    logits: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if out is not None:
+        _validate_argmax_out(logits, out)
+
+    if not _supports_gluon(logits):
+        return _argmax_torch_fallback(logits, out=out)
+
+    M, N = logits.shape
+    if out is None:
+        out = torch.empty((M,), dtype=torch.int64, device=logits.device)
+    if M == 0:
+        return out
+
+    block, num_warps, use_split = _select_config(M, N)
+    if use_split:
+        num_splits = triton.cdiv(N, block)
+        split_block = triton.next_power_of_2(num_splits)
+        partial_values, partial_indices, counters = _get_atomic_scratch(
+            M, num_splits, logits.device
+        )
+        _argmax_split_atomic_kernel[(M, num_splits)](
+            logits,
+            partial_values,
+            partial_indices,
+            counters,
+            out,
+            stride_m=logits.stride(0),
+            out_stride=out.stride(0),
+            N=N,
+            NUM_SPLITS=num_splits,
+            BLOCK=block,
+            REDUCE_BLOCK=split_block,
+            num_warps=num_warps,
+        )
+    else:
+        _argmax_one_stage_kernel[(M,)](
+            logits,
+            out,
+            stride_m=logits.stride(0),
+            out_stride=out.stride(0),
+            N=N,
+            BLOCK=block,
+            num_warps=num_warps,
+        )
+    return out
+
+
+argmax = gluon_argmax_gfx950
+argmax_pair = _argmax_pair_torch_fallback

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/argmax_gfx950.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/argmax_gfx950.py
@@ -106,7 +106,7 @@ def _argmax_one_stage_kernel(
 
 
 @gluon.jit
-def _argmax_split_atomic_kernel(
+def _argmax_split_atomic_fixed_block_size_kernel(
     logits,
     partial_values,
     partial_indices,
@@ -170,7 +170,7 @@ def _argmax_tile_chunk(
 
 
 @gluon.jit
-def _argmax_split_chunk_atomic_kernel(
+def _argmax_split_atomic_fixed_split_count_kernel(
     logits,
     partial_values,
     partial_indices,
@@ -349,7 +349,7 @@ def gluon_argmax_gfx950(
         partial_values, partial_indices, counters = _get_atomic_scratch(
             M, num_splits, logits.device
         )
-        _argmax_split_chunk_atomic_kernel[(M, num_splits)](
+        _argmax_split_atomic_fixed_split_count_kernel[(M, num_splits)](
             logits,
             partial_values,
             partial_indices,
@@ -371,7 +371,7 @@ def gluon_argmax_gfx950(
         partial_values, partial_indices, counters = _get_atomic_scratch(
             M, num_splits, logits.device
         )
-        _argmax_split_atomic_kernel[(M, num_splits)](
+        _argmax_split_atomic_fixed_block_size_kernel[(M, num_splits)](
             logits,
             partial_values,
             partial_indices,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/argmax_gfx950.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/argmax_gfx950.py
@@ -60,7 +60,7 @@ def _argmax_layout(
 
 
 @gluon.jit
-def _argmax_tile(
+def _argmax_fixed_block_size_tile(
     logits,
     row,
     start,
@@ -97,7 +97,7 @@ def _argmax_one_stage_kernel(
     best_idx = gl.full((), 2147483647, gl.int32)
 
     for start in range(0, N, BLOCK):
-        tile_val, tile_idx = _argmax_tile(
+        tile_val, tile_idx = _argmax_fixed_block_size_tile(
             logits, row, start, stride_m, N, BLOCK, LOAD_ELEMS
         )
         best_val, best_idx = _argmax_combine(best_val, best_idx, tile_val, tile_idx)
@@ -122,7 +122,7 @@ def _argmax_split_atomic_fixed_block_size_kernel(
 ):
     row = gl.program_id(0)
     split = gl.program_id(1)
-    tile_val, tile_idx = _argmax_tile(
+    tile_val, tile_idx = _argmax_fixed_block_size_tile(
         logits, row, split * BLOCK, stride_m, N, BLOCK, LOAD_ELEMS
     )
     partial_offset = row * NUM_SPLITS + split
@@ -146,7 +146,7 @@ def _argmax_split_atomic_fixed_block_size_kernel(
 
 
 @gluon.jit
-def _argmax_tile_chunk(
+def _argmax_fixed_split_count_tile(
     logits,
     row,
     start,
@@ -187,7 +187,7 @@ def _argmax_split_atomic_fixed_split_count_kernel(
 ):
     row = gl.program_id(0)
     split = gl.program_id(1)
-    tile_val, tile_idx = _argmax_tile_chunk(
+    tile_val, tile_idx = _argmax_fixed_split_count_tile(
         logits, row, split * CHUNK_SIZE, stride_m, N, CHUNK_SIZE, BLOCK, LOAD_ELEMS
     )
     partial_offset = row * NUM_SPLITS + split
@@ -294,18 +294,24 @@ def _load_elements_per_thread(dtype: torch.dtype) -> int:
     return 128 // torch.finfo(dtype).bits
 
 
-def _select_config(M: int, N: int) -> tuple[int, int, bool]:
+def _select_config(M: int, N: int) -> tuple[int, int, bool, int | None]:
     """Return Gluon launch config for ``M x N`` logits.
 
-    Returns ``(block, num_warps, use_split_atomic)``: the tile width,
-    wave grouping, and whether to use the split-tile atomic reduction path.
+    Returns ``(block_size, num_warps, use_split_atomic, fixed_split_count)``:
+    the physical tile width, wave grouping, whether to use a split-atomic
+    path, and an optional fixed split count. When ``fixed_split_count`` is
+    set, ``block`` is the power-of-two tile width for each derived chunk.
     """
+    if M <= 4 and N >= 65536:
+        num_splits = 32 if M == 1 else 16
+        block = triton.next_power_of_2(triton.cdiv(N, num_splits))
+        return block, 4, True, num_splits
     if M <= 32:
-        return 16384, 4, True
+        return 16384, 4, True, None
     if M <= 64:
         block = 32768 if N >= 180000 else 16384
-        return block, 4, True
-    return 8192, 4, False
+        return block, 4, True, None
+    return 8192, 4, False, None
 
 
 @register_kernel(
@@ -339,13 +345,11 @@ def gluon_argmax_gfx950(
     if M == 0:
         return out
 
-    block, num_warps, use_split = _select_config(M, N)
+    block, num_warps, use_split, fixed_split_count = _select_config(M, N)
     load_elems = _load_elements_per_thread(logits.dtype)
-    # Extra row splits help M=1/4 occupancy; too many lose to atomic overhead.
-    if (M == 1 or M == 4) and N >= 65536:
-        num_splits = 32 if M == 1 else 16
+    if fixed_split_count is not None:
+        num_splits = fixed_split_count
         chunk_size = triton.cdiv(N, num_splits)
-        fixed_block = triton.next_power_of_2(chunk_size)
         partial_values, partial_indices, counters = _get_atomic_scratch(
             M, num_splits, logits.device
         )
@@ -359,7 +363,7 @@ def gluon_argmax_gfx950(
             out_stride=out.stride(0),
             N=N,
             CHUNK_SIZE=chunk_size,
-            BLOCK=fixed_block,
+            BLOCK=block,
             NUM_SPLITS=num_splits,
             REDUCE_BLOCK=num_splits,
             LOAD_ELEMS=load_elems,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/argmax_gfx950.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/argmax_gfx950.py
@@ -52,6 +52,11 @@ def _argmax_combine(value1, index1, value2, index2):
     return value, index
 
 
+@gluon.jit
+def _normalize_argmax_sentinel(value, index):
+    return gl.where((index == 2147483647) | (value != value), -1, index)
+
+
 @gluon.constexpr_function
 def _argmax_layout(
     BLOCK: gl.constexpr, NUM_WARPS: gl.constexpr, LOAD_ELEMS: gl.constexpr
@@ -68,6 +73,7 @@ def _argmax_fixed_block_size_tile(
     N: gl.constexpr,
     BLOCK: gl.constexpr,
     LOAD_ELEMS: gl.constexpr,
+    SANITIZE_NAN: gl.constexpr,
 ):
     offs = gl.arange(0, BLOCK, layout=_argmax_layout(BLOCK, gl.num_warps(), LOAD_ELEMS))
     cols = start + offs
@@ -78,6 +84,9 @@ def _argmax_fixed_block_size_tile(
         mask=mask,
         other=-float("inf"),
     ).to(gl.float32)
+    if SANITIZE_NAN:
+        mask = mask & (vals == vals)
+        vals = gl.where(mask, vals, -float("inf"))
     indices = gl.where(mask, cols.to(gl.int32), 2147483647)
     return gl.reduce((vals, indices), axis=0, combine_fn=_argmax_combine)
 
@@ -98,10 +107,11 @@ def _argmax_one_stage_kernel(
 
     for start in range(0, N, BLOCK):
         tile_val, tile_idx = _argmax_fixed_block_size_tile(
-            logits, row, start, stride_m, N, BLOCK, LOAD_ELEMS
+            logits, row, start, stride_m, N, BLOCK, LOAD_ELEMS, False
         )
         best_val, best_idx = _argmax_combine(best_val, best_idx, tile_val, tile_idx)
 
+    best_idx = _normalize_argmax_sentinel(best_val, best_idx)
     gl.store(out + row * out_stride, best_idx.to(out.dtype.element_ty))
 
 
@@ -123,7 +133,7 @@ def _argmax_split_atomic_fixed_block_size_kernel(
     row = gl.program_id(0)
     split = gl.program_id(1)
     tile_val, tile_idx = _argmax_fixed_block_size_tile(
-        logits, row, split * BLOCK, stride_m, N, BLOCK, LOAD_ELEMS
+        logits, row, split * BLOCK, stride_m, N, BLOCK, LOAD_ELEMS, True
     )
     partial_offset = row * NUM_SPLITS + split
     gl.store(partial_values + partial_offset, tile_val)
@@ -140,7 +150,10 @@ def _argmax_split_atomic_fixed_block_size_kernel(
             partial_values + base, mask=mask, other=-float("inf"), volatile=True
         )
         indices = gl.load(partial_indices + base, mask=mask, other=2147483647)
-        _, best_idx = gl.reduce((vals, indices), axis=0, combine_fn=_argmax_combine)
+        best_val, best_idx = gl.reduce(
+            (vals, indices), axis=0, combine_fn=_argmax_combine
+        )
+        best_idx = _normalize_argmax_sentinel(best_val, best_idx)
         gl.store(out + row * out_stride, best_idx.to(out.dtype.element_ty))
         gl.store(counters + row, 0)
 
@@ -165,6 +178,8 @@ def _argmax_fixed_split_count_tile(
         mask=mask,
         other=-float("inf"),
     ).to(gl.float32)
+    mask = mask & (vals == vals)
+    vals = gl.where(mask, vals, -float("inf"))
     indices = gl.where(mask, cols.to(gl.int32), 2147483647)
     return gl.reduce((vals, indices), axis=0, combine_fn=_argmax_combine)
 
@@ -202,7 +217,10 @@ def _argmax_split_atomic_fixed_split_count_kernel(
         base = row * NUM_SPLITS + offs
         vals = gl.load(partial_values + base, volatile=True)
         indices = gl.load(partial_indices + base)
-        _, best_idx = gl.reduce((vals, indices), axis=0, combine_fn=_argmax_combine)
+        best_val, best_idx = gl.reduce(
+            (vals, indices), axis=0, combine_fn=_argmax_combine
+        )
+        best_idx = _normalize_argmax_sentinel(best_val, best_idx)
         gl.store(out + row * out_stride, best_idx.to(out.dtype.element_ty))
         gl.store(counters + row, 0)
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/argmax_gfx950.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/argmax_gfx950.py
@@ -145,6 +145,68 @@ def _argmax_split_atomic_kernel(
         gl.store(counters + row, 0)
 
 
+@gluon.jit
+def _argmax_tile_chunk(
+    logits,
+    row,
+    start,
+    stride_m: gl.constexpr,
+    N: gl.constexpr,
+    CHUNK_SIZE: gl.constexpr,
+    BLOCK: gl.constexpr,
+    LOAD_ELEMS: gl.constexpr,
+):
+    offs = gl.arange(0, BLOCK, layout=_argmax_layout(BLOCK, gl.num_warps(), LOAD_ELEMS))
+    cols = start + offs
+    mask = (offs < CHUNK_SIZE) & (cols < N)
+    vals = cdna4.buffer_load(
+        logits,
+        row * stride_m + cols,
+        mask=mask,
+        other=-float("inf"),
+    ).to(gl.float32)
+    indices = gl.where(mask, cols.to(gl.int32), 2147483647)
+    return gl.reduce((vals, indices), axis=0, combine_fn=_argmax_combine)
+
+
+@gluon.jit
+def _argmax_split_chunk_atomic_kernel(
+    logits,
+    partial_values,
+    partial_indices,
+    counters,
+    out,
+    stride_m: gl.constexpr,
+    out_stride: gl.constexpr,
+    N: gl.constexpr,
+    CHUNK_SIZE: gl.constexpr,
+    BLOCK: gl.constexpr,
+    NUM_SPLITS: gl.constexpr,
+    REDUCE_BLOCK: gl.constexpr,
+    LOAD_ELEMS: gl.constexpr,
+):
+    row = gl.program_id(0)
+    split = gl.program_id(1)
+    tile_val, tile_idx = _argmax_tile_chunk(
+        logits, row, split * CHUNK_SIZE, stride_m, N, CHUNK_SIZE, BLOCK, LOAD_ELEMS
+    )
+    partial_offset = row * NUM_SPLITS + split
+    gl.store(partial_values + partial_offset, tile_val)
+    gl.store(partial_indices + partial_offset, tile_idx)
+
+    old = gl.atomic_add(counters + row, 1, sem="acq_rel", scope="gpu")
+    if old == NUM_SPLITS - 1:
+        offs = gl.arange(
+            0, REDUCE_BLOCK, layout=_argmax_layout(REDUCE_BLOCK, gl.num_warps(), 1)
+        )
+        base = row * NUM_SPLITS + offs
+        vals = gl.load(partial_values + base, volatile=True)
+        indices = gl.load(partial_indices + base)
+        _, best_idx = gl.reduce((vals, indices), axis=0, combine_fn=_argmax_combine)
+        gl.store(out + row * out_stride, best_idx.to(out.dtype.element_ty))
+        gl.store(counters + row, 0)
+
+
 def _validate_argmax_out(logits: torch.Tensor, out: torch.Tensor) -> None:
     if out.shape != (logits.shape[0],):
         raise ValueError(
@@ -279,7 +341,31 @@ def gluon_argmax_gfx950(
 
     block, num_warps, use_split = _select_config(M, N)
     load_elems = _load_elements_per_thread(logits.dtype)
-    if use_split:
+    # Extra row splits help M=1/4 occupancy; too many lose to atomic overhead.
+    if (M == 1 or M == 4) and N >= 65536:
+        num_splits = 32 if M == 1 else 16
+        chunk_size = triton.cdiv(N, num_splits)
+        fixed_block = triton.next_power_of_2(chunk_size)
+        partial_values, partial_indices, counters = _get_atomic_scratch(
+            M, num_splits, logits.device
+        )
+        _argmax_split_chunk_atomic_kernel[(M, num_splits)](
+            logits,
+            partial_values,
+            partial_indices,
+            counters,
+            out,
+            stride_m=logits.stride(0),
+            out_stride=out.stride(0),
+            N=N,
+            CHUNK_SIZE=chunk_size,
+            BLOCK=fixed_block,
+            NUM_SPLITS=num_splits,
+            REDUCE_BLOCK=num_splits,
+            LOAD_ELEMS=load_elems,
+            num_warps=num_warps,
+        )
+    elif use_split:
         num_splits = triton.cdiv(N, block)
         split_block = triton.next_power_of_2(num_splits)
         partial_values, partial_indices, counters = _get_atomic_scratch(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/argmax_gfx950.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/argmax_gfx950.py
@@ -39,6 +39,7 @@ cdna4 = gl.amd.cdna4
 _SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
 _SUPPORTED_OUT_DTYPES = (torch.int32, torch.int64)
 _MIN_GLUON_VOCAB_SIZE = 4096
+_INT32_MAX = gl.constexpr(2**31 - 1)
 _scratch_cache: dict[
     tuple[int, int, int], tuple[torch.Tensor, torch.Tensor, torch.Tensor]
 ] = {}
@@ -54,7 +55,7 @@ def _argmax_combine(value1, index1, value2, index2):
 
 @gluon.jit
 def _normalize_argmax_sentinel(value, index):
-    return gl.where((index == 2147483647) | (value != value), -1, index)
+    return gl.where((index == _INT32_MAX) | (value != value), -1, index)
 
 
 @gluon.constexpr_function
@@ -87,7 +88,7 @@ def _argmax_fixed_block_size_tile(
     if SANITIZE_NAN:
         mask = mask & (vals == vals)
         vals = gl.where(mask, vals, -float("inf"))
-    indices = gl.where(mask, cols.to(gl.int32), 2147483647)
+    indices = gl.where(mask, cols.to(gl.int32), _INT32_MAX)
     return gl.reduce((vals, indices), axis=0, combine_fn=_argmax_combine)
 
 
@@ -103,7 +104,7 @@ def _argmax_one_stage_kernel(
 ):
     row = gl.program_id(0)
     best_val = gl.full((), -float("inf"), gl.float32)
-    best_idx = gl.full((), 2147483647, gl.int32)
+    best_idx = gl.full((), _INT32_MAX, gl.int32)
 
     for start in range(0, N, BLOCK):
         tile_val, tile_idx = _argmax_fixed_block_size_tile(
@@ -149,7 +150,7 @@ def _argmax_split_atomic_fixed_block_size_kernel(
         vals = gl.load(
             partial_values + base, mask=mask, other=-float("inf"), volatile=True
         )
-        indices = gl.load(partial_indices + base, mask=mask, other=2147483647)
+        indices = gl.load(partial_indices + base, mask=mask, other=_INT32_MAX)
         best_val, best_idx = gl.reduce(
             (vals, indices), axis=0, combine_fn=_argmax_combine
         )
@@ -180,7 +181,7 @@ def _argmax_fixed_split_count_tile(
     ).to(gl.float32)
     mask = mask & (vals == vals)
     vals = gl.where(mask, vals, -float("inf"))
-    indices = gl.where(mask, cols.to(gl.int32), 2147483647)
+    indices = gl.where(mask, cols.to(gl.int32), _INT32_MAX)
     return gl.reduce((vals, indices), axis=0, combine_fn=_argmax_combine)
 
 
@@ -292,10 +293,7 @@ def _supports_gluon(logits: torch.Tensor) -> bool:
 def _get_atomic_scratch(
     M: int, num_splits: int, device: torch.device
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    device_index = device.index
-    if device_index is None:
-        device_index = torch.cuda.current_device()
-    key = (device_index, M, num_splits)
+    key = (device.index, M, num_splits)
     scratch = _scratch_cache.get(key)
     if scratch is None:
         partial_values = torch.empty(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/argmax_gfx950.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/argmax_gfx950.py
@@ -53,15 +53,23 @@ def _argmax_combine(value1, index1, value2, index2):
 
 
 @gluon.constexpr_function
-def _argmax_layout(BLOCK: gl.constexpr, NUM_WARPS: gl.constexpr):
-    return gl.BlockedLayout([1], [64], [NUM_WARPS], [0])
+def _argmax_layout(
+    BLOCK: gl.constexpr, NUM_WARPS: gl.constexpr, LOAD_ELEMS: gl.constexpr
+):
+    return gl.BlockedLayout([LOAD_ELEMS], [64], [NUM_WARPS], [0])
 
 
 @gluon.jit
 def _argmax_tile(
-    logits, row, start, stride_m: gl.constexpr, N: gl.constexpr, BLOCK: gl.constexpr
+    logits,
+    row,
+    start,
+    stride_m: gl.constexpr,
+    N: gl.constexpr,
+    BLOCK: gl.constexpr,
+    LOAD_ELEMS: gl.constexpr,
 ):
-    offs = gl.arange(0, BLOCK, layout=_argmax_layout(BLOCK, gl.num_warps()))
+    offs = gl.arange(0, BLOCK, layout=_argmax_layout(BLOCK, gl.num_warps(), LOAD_ELEMS))
     cols = start + offs
     mask = cols < N
     vals = cdna4.buffer_load(
@@ -82,13 +90,16 @@ def _argmax_one_stage_kernel(
     out_stride: gl.constexpr,
     N: gl.constexpr,
     BLOCK: gl.constexpr,
+    LOAD_ELEMS: gl.constexpr,
 ):
     row = gl.program_id(0)
     best_val = gl.full((), -float("inf"), gl.float32)
     best_idx = gl.full((), 2147483647, gl.int32)
 
     for start in range(0, N, BLOCK):
-        tile_val, tile_idx = _argmax_tile(logits, row, start, stride_m, N, BLOCK)
+        tile_val, tile_idx = _argmax_tile(
+            logits, row, start, stride_m, N, BLOCK, LOAD_ELEMS
+        )
         best_val, best_idx = _argmax_combine(best_val, best_idx, tile_val, tile_idx)
 
     gl.store(out + row * out_stride, best_idx.to(out.dtype.element_ty))
@@ -107,10 +118,13 @@ def _argmax_split_atomic_kernel(
     NUM_SPLITS: gl.constexpr,
     BLOCK: gl.constexpr,
     REDUCE_BLOCK: gl.constexpr,
+    LOAD_ELEMS: gl.constexpr,
 ):
     row = gl.program_id(0)
     split = gl.program_id(1)
-    tile_val, tile_idx = _argmax_tile(logits, row, split * BLOCK, stride_m, N, BLOCK)
+    tile_val, tile_idx = _argmax_tile(
+        logits, row, split * BLOCK, stride_m, N, BLOCK, LOAD_ELEMS
+    )
     partial_offset = row * NUM_SPLITS + split
     gl.store(partial_values + partial_offset, tile_val)
     gl.store(partial_indices + partial_offset, tile_idx)
@@ -118,7 +132,7 @@ def _argmax_split_atomic_kernel(
     old = gl.atomic_add(counters + row, 1, sem="acq_rel", scope="gpu")
     if old == NUM_SPLITS - 1:
         offs = gl.arange(
-            0, REDUCE_BLOCK, layout=_argmax_layout(REDUCE_BLOCK, gl.num_warps())
+            0, REDUCE_BLOCK, layout=_argmax_layout(REDUCE_BLOCK, gl.num_warps(), 1)
         )
         mask = offs < NUM_SPLITS
         base = row * NUM_SPLITS + offs
@@ -214,6 +228,10 @@ def _get_atomic_scratch(
     return scratch
 
 
+def _load_elements_per_thread(dtype: torch.dtype) -> int:
+    return 128 // torch.finfo(dtype).bits
+
+
 def _select_config(M: int, N: int) -> tuple[int, int, bool]:
     """Return Gluon launch config for ``M x N`` logits.
 
@@ -260,6 +278,7 @@ def gluon_argmax_gfx950(
         return out
 
     block, num_warps, use_split = _select_config(M, N)
+    load_elems = _load_elements_per_thread(logits.dtype)
     if use_split:
         num_splits = triton.cdiv(N, block)
         split_block = triton.next_power_of_2(num_splits)
@@ -278,6 +297,7 @@ def gluon_argmax_gfx950(
             NUM_SPLITS=num_splits,
             BLOCK=block,
             REDUCE_BLOCK=split_block,
+            LOAD_ELEMS=load_elems,
             num_warps=num_warps,
         )
     else:
@@ -288,6 +308,7 @@ def gluon_argmax_gfx950(
             out_stride=out.stride(0),
             N=N,
             BLOCK=block,
+            LOAD_ELEMS=load_elems,
             num_warps=num_warps,
         )
     return out

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/argmax_gfx950.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/gluon/argmax_gfx950.py
@@ -107,7 +107,7 @@ def _argmax_one_stage_kernel(
 
     for start in range(0, N, BLOCK):
         tile_val, tile_idx = _argmax_fixed_block_size_tile(
-            logits, row, start, stride_m, N, BLOCK, LOAD_ELEMS, False
+            logits, row, start, stride_m, N, BLOCK, LOAD_ELEMS, True
         )
         best_val, best_idx = _argmax_combine(best_val, best_idx, tile_val, tile_idx)
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/registry.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/registry.py
@@ -455,6 +455,7 @@ def load_builtin_kernels() -> None:
     import tokenspeed_kernel.ops.gemm  # noqa: F401
     import tokenspeed_kernel.ops.moe  # noqa: F401
     import tokenspeed_kernel.ops.quantization  # noqa: F401
+    import tokenspeed_kernel.ops.sampling  # noqa: F401
 
 
 def error_fn(*args, **kwargs):

--- a/tokenspeed-kernel/test/ops/test_sampling_cute_dsl.py
+++ b/tokenspeed-kernel/test/ops/test_sampling_cute_dsl.py
@@ -470,7 +470,7 @@ def test_greedy_sample_pattern_under_cuda_graph():
 
 # ---------------------------------------------------------------------------
 # Pure-torch fallback on hosts without the CuTe DSL kernel — exercises the
-# code path AMD ROCm / CPU-only / sm_80 / sm_120+ / missing-nvidia-cutlass-dsl
+# code path CPU-only / sm_80 / sm_120+ / missing-nvidia-cutlass-dsl
 # would take. Selected at import time via the module-level dispatch in
 # cute_dsl.py; we reach it here by calling the underscore-prefixed
 # implementation directly so the test runs regardless of the host hardware.
@@ -509,9 +509,7 @@ def test_argmax_pair_torch_fallback_on_cpu_tensor():
 
 
 def test_public_binding_dispatch_matches_arch():
-    """Public ``argmax`` / ``argmax_pair`` names are bound at import time:
-    NVIDIA hosts with cute available → cute fast path; everyone else → torch
-    fallback. This test pins that contract."""
+    """The CuTe module owns only the NVIDIA CuTe direct API."""
     if cute_dsl.is_available():
         assert cute_dsl.argmax is cute_dsl._argmax_cute
         assert cute_dsl.argmax_pair is cute_dsl._argmax_pair_cute

--- a/tokenspeed-kernel/test/ops/test_sampling_gluon.py
+++ b/tokenspeed-kernel/test/ops/test_sampling_gluon.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import pytest
+import torch
+from tokenspeed_kernel.ops.sampling.gluon import argmax_gfx950 as gluon
+from tokenspeed_kernel.platform import current_platform
+
+MODEL_VOCABS = {
+    "deepseek_v4": 129280,
+    "qwen3_5": 151936,
+    "minimax_m2": 200064,
+}
+
+
+def _is_gfx950() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    try:
+        platform = current_platform()
+    except Exception:
+        return False
+    return platform.is_cdna4
+
+
+pytestmark = pytest.mark.skipif(
+    not _is_gfx950(), reason="AMD GFX950 is required for Gluon argmax tests"
+)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_argmax_matches_torch_for_dtypes(dtype):
+    torch.manual_seed(0xA950)
+    x = torch.randn(8, 4096, device="cuda", dtype=dtype)
+    out = gluon.argmax(x)
+    torch.testing.assert_close(out, torch.argmax(x, dim=-1), atol=0, rtol=0)
+
+
+@pytest.mark.parametrize(
+    "M,N",
+    [
+        (1, MODEL_VOCABS["deepseek_v4"]),
+        (16, MODEL_VOCABS["qwen3_5"]),
+        (64, MODEL_VOCABS["minimax_m2"]),
+        (128, MODEL_VOCABS["qwen3_5"]),
+    ],
+)
+def test_argmax_matches_torch_for_model_shapes(M, N):
+    torch.manual_seed(M ^ N)
+    x = 0.1 * torch.randn(M, N, device="cuda", dtype=torch.float32)
+    out = gluon.argmax(x)
+    torch.testing.assert_close(out, torch.argmax(x, dim=-1), atol=0, rtol=0)
+
+
+def test_argmax_returns_first_index_on_ties():
+    M, N = 4, 4096
+    x = torch.full((M, N), -100.0, device="cuda", dtype=torch.float32)
+    plant_positions = [
+        [0, 7, 9],
+        [3, 4],
+        [128, 1024, 2048],
+        [N - 1, 17],
+    ]
+    for row, positions in enumerate(plant_positions):
+        for pos in positions:
+            x[row, pos] = 0.0
+    torch.testing.assert_close(gluon.argmax(x), torch.argmax(x, dim=-1), atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("out_dtype", [torch.int32, torch.int64])
+def test_argmax_writes_into_strided_caller_buffer(out_dtype):
+    M, N = 8, 4096
+    x = torch.randn(M, N, device="cuda", dtype=torch.float32)
+    storage = torch.empty(M * 2, device="cuda", dtype=out_dtype)
+    out = storage[::2]
+    returned = gluon.argmax(x, out=out)
+    assert returned.data_ptr() == out.data_ptr()
+    torch.testing.assert_close(out.long(), torch.argmax(x, dim=-1), atol=0, rtol=0)
+
+
+def test_argmax_out_buffer_under_cuda_graph():
+    M, N = 16, MODEL_VOCABS["deepseek_v4"]
+    torch.manual_seed(M ^ N ^ 0xC0DE)
+    x = 0.1 * torch.randn(M, N, device="cuda", dtype=torch.float32)
+    out = torch.empty(M, dtype=torch.int32, device="cuda")
+
+    gluon.argmax(x, out=out)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        gluon.argmax(x, out=out)
+
+    new_x = 0.1 * torch.randn_like(x)
+    x.copy_(new_x)
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out.long(), torch.argmax(x, dim=-1), atol=0, rtol=0)

--- a/tokenspeed-kernel/test/ops/test_sampling_gluon.py
+++ b/tokenspeed-kernel/test/ops/test_sampling_gluon.py
@@ -74,6 +74,36 @@ def test_argmax_matches_torch_for_model_shapes(M, N):
     torch.testing.assert_close(out, torch.argmax(x, dim=-1), atol=0, rtol=0)
 
 
+@pytest.mark.parametrize(
+    "M,N,dtype",
+    [
+        (1, MODEL_VOCABS["deepseek_v4"], torch.float32),
+        (4, MODEL_VOCABS["deepseek_v4"], torch.float32),
+        (8, MODEL_VOCABS["deepseek_v4"], torch.float16),
+        (128, MODEL_VOCABS["deepseek_v4"], torch.bfloat16),
+    ],
+)
+def test_argmax_all_nan_rows_return_sentinel(M, N, dtype):
+    x = torch.full((M, N), float("nan"), device="cuda", dtype=dtype)
+    out = gluon.argmax(x)
+    expected = torch.full((M,), -1, device="cuda", dtype=out.dtype)
+    torch.testing.assert_close(out, expected, atol=0, rtol=0)
+
+
+def test_argmax_split_path_ignores_nan_but_preserves_valid_negative_infinity():
+    M, N = 4, MODEL_VOCABS["deepseek_v4"]
+    x = torch.full((M, N), float("nan"), device="cuda", dtype=torch.float32)
+    x[0, 123] = 0.5
+    x[0, 456] = 1.0
+    x[1].fill_(-float("inf"))
+    x[2, 7] = 3.0
+    x[2, 5] = 3.0
+
+    out = gluon.argmax(x)
+    expected = torch.tensor([456, 0, 5, -1], device="cuda", dtype=out.dtype)
+    torch.testing.assert_close(out, expected, atol=0, rtol=0)
+
+
 def test_argmax_returns_first_index_on_ties():
     M, N = 4, 4096
     x = torch.full((M, N), -100.0, device="cuda", dtype=torch.float32)

--- a/tokenspeed-kernel/test/ops/test_sampling_gluon.py
+++ b/tokenspeed-kernel/test/ops/test_sampling_gluon.py
@@ -59,6 +59,8 @@ def test_argmax_matches_torch_for_dtypes(dtype):
     "M,N",
     [
         (1, MODEL_VOCABS["deepseek_v4"]),
+        (2, MODEL_VOCABS["deepseek_v4"]),
+        (3, MODEL_VOCABS["deepseek_v4"]),
         (4, MODEL_VOCABS["deepseek_v4"]),
         (16, MODEL_VOCABS["qwen3_5"]),
         (64, MODEL_VOCABS["minimax_m2"]),

--- a/tokenspeed-kernel/test/ops/test_sampling_gluon.py
+++ b/tokenspeed-kernel/test/ops/test_sampling_gluon.py
@@ -59,6 +59,7 @@ def test_argmax_matches_torch_for_dtypes(dtype):
     "M,N",
     [
         (1, MODEL_VOCABS["deepseek_v4"]),
+        (4, MODEL_VOCABS["deepseek_v4"]),
         (16, MODEL_VOCABS["qwen3_5"]),
         (64, MODEL_VOCABS["minimax_m2"]),
         (128, MODEL_VOCABS["qwen3_5"]),

--- a/tokenspeed-kernel/test/ops/test_sampling_gluon.py
+++ b/tokenspeed-kernel/test/ops/test_sampling_gluon.py
@@ -90,8 +90,9 @@ def test_argmax_all_nan_rows_return_sentinel(M, N, dtype):
     torch.testing.assert_close(out, expected, atol=0, rtol=0)
 
 
-def test_argmax_split_path_ignores_nan_but_preserves_valid_negative_infinity():
-    M, N = 4, MODEL_VOCABS["deepseek_v4"]
+@pytest.mark.parametrize("M", [4, 128])
+def test_argmax_ignores_nan_but_preserves_valid_negative_infinity(M):
+    N = MODEL_VOCABS["deepseek_v4"]
     x = torch.full((M, N), float("nan"), device="cuda", dtype=torch.float32)
     x[0, 123] = 0.5
     x[0, 456] = 1.0
@@ -100,7 +101,8 @@ def test_argmax_split_path_ignores_nan_but_preserves_valid_negative_infinity():
     x[2, 5] = 3.0
 
     out = gluon.argmax(x)
-    expected = torch.tensor([456, 0, 5, -1], device="cuda", dtype=out.dtype)
+    expected = torch.full((M,), -1, device="cuda", dtype=out.dtype)
+    expected[:3] = torch.tensor([456, 0, 5], device="cuda", dtype=out.dtype)
     torch.testing.assert_close(out, expected, atol=0, rtol=0)
 
 

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -50,6 +50,10 @@ import tokenspeed_kernel.ops.moe.flashinfer as _moe_flashinfer
 import tokenspeed_kernel.ops.moe.triton as _moe_triton
 import tokenspeed_kernel.ops.moe.triton_kernels as _moe_triton_kernels
 import tokenspeed_kernel.ops.moe.trtllm as _moe_trtllm
+import tokenspeed_kernel.ops.sampling as _sampling_pkg
+import tokenspeed_kernel.ops.sampling.cute_dsl as _sampling_cute_dsl
+import tokenspeed_kernel.ops.sampling.gluon as _sampling_gluon
+import tokenspeed_kernel.ops.sampling.gluon.argmax_gfx950 as _sampling_gluon_argmax
 import torch
 from tokenspeed_kernel.platform import ArchVersion, Platform, PlatformInfo
 from tokenspeed_kernel.registry import KernelRegistry
@@ -81,6 +85,11 @@ _RELOAD_MODULES = [
     _moe_triton_kernels,
     _moe_trtllm,
     _moe_pkg,
+    # Sampling registration modules.
+    _sampling_cute_dsl,
+    _sampling_gluon_argmax,
+    _sampling_gluon,
+    _sampling_pkg,
     # Top-level public API re-exports.
     tokenspeed_kernel,
 ]
@@ -122,6 +131,10 @@ def _is_blackwell_plus(platform: PlatformInfo) -> bool:
 
 def _is_nvidia(platform: PlatformInfo) -> bool:
     return platform.is_nvidia
+
+
+def _is_nvidia_with_cute_dsl(platform: PlatformInfo) -> bool:
+    return platform.is_nvidia and _sampling_cute_dsl.is_available()
 
 
 def _is_cdna4(platform: PlatformInfo) -> bool:
@@ -330,6 +343,11 @@ def _attention_merge_state() -> object:
     lse_a = torch.empty((4, 16), dtype=torch.float32)
     lse_b = torch.empty((4, 16), dtype=torch.float32)
     return tokenspeed_kernel.mha_merge_state(out_a, lse_a, out_b, lse_b)
+
+
+def _sampling_argmax() -> object:
+    logits = torch.empty((4, 4096), dtype=torch.float32, device="cuda")
+    return tokenspeed_kernel.argmax(logits)
 
 
 def _moe_route_grouped_topk() -> object:
@@ -645,6 +663,23 @@ _CASES = [
         "cublaslt_mm_nvfp4",
         _mm_nvfp4,
     ),
+    # Sampling API x architecture golden cases.
+    _case(
+        _is_nvidia_with_cute_dsl,
+        "nvidia-cutedsl",
+        "sampling",
+        "argmax",
+        "cute_dsl_argmax",
+        _sampling_argmax,
+    ),
+    _case(
+        _is_cdna4,
+        "cdna4",
+        "sampling",
+        "argmax",
+        "gluon_argmax_gfx950",
+        _sampling_argmax,
+    ),
     # MoE API x architecture golden cases.
     _case(
         _is_supported_gpu,
@@ -803,6 +838,15 @@ def selected_kernel_spy(monkeypatch):
                 lse = torch.empty(q.shape[:-1], dtype=torch.float32, device=q.device)
                 return torch.empty_like(q), lse
             return torch.empty_like(q)
+
+        if case.family == "sampling":
+            (logits,) = args[:1]
+            out = kwargs.get("out")
+            if out is not None:
+                return out
+            return torch.empty(
+                (logits.shape[0],), dtype=torch.int64, device=logits.device
+            )
 
         return None
 


### PR DESCRIPTION
Adding Gluon argmax kernels for AMD gfx950. Measured with

- Input shape: (M, N)
- Argmax dimension: N, the vocab dimension
- Dtypes: float32, float16, bfloat16
- M cases: 1, 2, 3, 4, 8, 16, 32, 64, 128
- Timing: triton do_bench(..., warmup=25, rep=100, quantiles=[0.5]) for both gluon and torch
- Table values are speedup: torch_us / gluon_us, so higher is better.

Overall geomean speedup across all 150 cases: 2.33x.
Detailed per model, average over precisions.

| Model | M=1 | M=2 | M=3 | M=4 | M=8 | M=16 | M=32 | M=64 | M=128 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| deepseek_v4 [vocab=129280] | 7.395x | 7.072x | 6.687x | 6.643x | 5.530x | 4.687x | 3.715x | 2.708x | 1.577x |
| qwen3_5 [vocab=151936] | 2.252x | 2.256x | 2.226x | 2.279x | 2.139x | 2.301x | 1.961x | 1.532x | 1.629x |
| kimi_k2_5 [vocab=163840] | 2.243x | 2.300x | 2.282x | 2.314x | 2.097x | 2.297x | 1.991x | 1.430x | 1.611x |
| minimax_m2 [vocab=200064] | 2.136x | 2.057x | 2.038x | 2.107x | 2.124x | 2.167x | 1.722x | 1.585x | 1.255x |
| gpt_oss [vocab=201088] | 2.126x | 2.071x | 2.046x | 2.114x | 2.122x | 2.158x | 1.728x | 1.578x | 1.312x |
