### PR TITLE
perf(gdn): fuse causal_conv1d and QKV split for GDN prefill

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -30,6 +30,7 @@ from tokenspeed_kernel.ops.attention.flashinfer import (
     gated_delta_rule as gdn_flashinfer,
 )
 from tokenspeed_kernel.ops.attention.triton.gdn_qkv_split import (
+    causal_conv1d_qkv_split_gdn_prefill,
     fused_qkv_split_gdn_prefill,
 )
 
@@ -988,6 +989,11 @@ class MambaAttnBackend(AttentionBackend):
         query_start_loc = self.forward_metadata.query_start_loc
         cache_indices = self.forward_metadata.mamba_cache_indices
 
+        key_split_dim = key_dim // attn_tp_size
+        value_split_dim = value_dim // attn_tp_size
+        num_heads = key_split_dim // head_k_dim
+        num_value_heads = value_split_dim // head_v_dim
+
         if is_target_verify:
             draft_token_num = kwargs.get(
                 "draft_token_num", self.speculative_num_draft_tokens
@@ -1012,6 +1018,15 @@ class MambaAttnBackend(AttentionBackend):
             )
             # needn't contiguous here.
             mixed_qkv = mixed_qkv_processed.transpose(1, 2).view(seq_len, -1)
+            query, key, value = fused_qkv_split_gdn_prefill(
+                mixed_qkv,
+                num_q_heads=num_heads,
+                num_k_heads=num_heads,
+                num_v_heads=num_value_heads,
+                head_q=head_k_dim,
+                head_k=head_k_dim,
+                head_v=head_v_dim,
+            )
         else:
             conv_states, ssm_states = self.pool.get_mamba_params(layer_id)
             extend_prefix_lens = kwargs.get("extend_prefix_lens")
@@ -1037,33 +1052,45 @@ class MambaAttnBackend(AttentionBackend):
                 conv_states[self.forward_metadata.track_ssm_h_dst] = mixed_qkv_t[
                     :, self.forward_metadata.track_conv_indices
                 ].transpose(0, 1)
-
-            mixed_qkv = causal_conv1d_fn(
-                mixed_qkv_t,
-                conv_weights,
-                bias,
-                activation=activation,
-                conv_states=conv_states,
-                has_initial_state=has_initial_states,
-                cache_indices=cache_indices,
-                query_start_loc=query_start_loc,
-                seq_lens_cpu=extend_seq_lens_cpu,
-            ).transpose(0, 1)[:seq_len]
-
-        key_split_dim = key_dim // attn_tp_size
-        value_split_dim = value_dim // attn_tp_size
-        num_heads = key_split_dim // head_k_dim
-        num_value_heads = value_split_dim // head_v_dim
-
-        query, key, value = fused_qkv_split_gdn_prefill(
-            mixed_qkv,
-            num_q_heads=num_heads,
-            num_k_heads=num_heads,
-            num_v_heads=num_value_heads,
-            head_q=head_k_dim,
-            head_k=head_k_dim,
-            head_v=head_v_dim,
-        )
+                mixed_qkv = causal_conv1d_fn(
+                    mixed_qkv_t,
+                    conv_weights,
+                    bias,
+                    activation=activation,
+                    conv_states=conv_states,
+                    has_initial_state=has_initial_states,
+                    cache_indices=cache_indices,
+                    query_start_loc=query_start_loc,
+                    seq_lens_cpu=extend_seq_lens_cpu,
+                ).transpose(0, 1)[:seq_len]
+                query, key, value = fused_qkv_split_gdn_prefill(
+                    mixed_qkv,
+                    num_q_heads=num_heads,
+                    num_k_heads=num_heads,
+                    num_v_heads=num_value_heads,
+                    head_q=head_k_dim,
+                    head_k=head_k_dim,
+                    head_v=head_v_dim,
+                )
+            else:
+                query, key, value = causal_conv1d_qkv_split_gdn_prefill(
+                    mixed_qkv_t,
+                    conv_weights,
+                    bias,
+                    conv_states,
+                    query_start_loc,
+                    extend_seq_lens_cpu,
+                    num_q_heads=num_heads,
+                    num_k_heads=num_heads,
+                    num_v_heads=num_value_heads,
+                    head_q=head_k_dim,
+                    head_k=head_k_dim,
+                    head_v=head_v_dim,
+                    total_seq_len=seq_len,
+                    cache_indices=cache_indices,
+                    has_initial_state=has_initial_states,
+                    activation=activation,
+                )
 
         if is_target_verify:
             draft_token_num = kwargs.get(

--- a/test/runtime/benchmark/bench_causal_conv1d_qkv_split.py
+++ b/test/runtime/benchmark/bench_causal_conv1d_qkv_split.py
@@ -1,0 +1,216 @@
+"""Benchmark: causal_conv1d + fused_qkv_split (sequential) vs each kernel alone.
+
+Goal: measure what fraction of the sequential pipeline the QKV split (b0)
+occupies. If split contributes a meaningful fraction (>~20%) at large T,
+a fused kernel that eliminates the conv_out staging buffer would be worth
+building.
+
+Run:
+  python/.venv/bin/python test/runtime/benchmark/bench_causal_conv1d_qkv_split.py
+
+Config matches Qwen3.5 GDN prefill (nq=nk=nv=16, h=128, width=4, silu).
+"""
+
+from __future__ import annotations
+
+import sys
+
+import torch
+import triton
+
+sys.path.insert(
+    0,
+    "python",
+)
+sys.path.insert(
+    0,
+    "tokenspeed-kernel/python",
+)
+
+from tokenspeed.runtime.layers.attention.linear.causal_conv1d import (
+    causal_conv1d_fn,
+)
+from tokenspeed_kernel.ops.attention.triton.gdn_qkv_split import (
+    fused_qkv_split_gdn_prefill,
+)
+
+DEVICE = torch.device("cuda")
+DTYPE = torch.bfloat16
+
+# Qwen3.5 GDN config (single-GPU, no TP)
+NQ = NK = NV = 16
+HEAD_DIM = 128
+CONV_DIM = (NQ + NK + NV) * HEAD_DIM  # 3072 for Qwen3.5
+CONV_WIDTH = 4  # kernel width (3 state tokens + 1)
+
+WARMUP = 50
+REPEAT = 200
+
+
+def _make_conv_inputs(seq_len: int):
+    """Single-sequence prefill inputs for causal_conv1d_fn."""
+    # x: (dim, seq_len) channel-last → stride(0)=1, stride(1)=dim
+    x = torch.randn(CONV_DIM, seq_len, dtype=DTYPE, device=DEVICE)
+    x = x.as_strided(x.shape, (1, CONV_DIM))  # channel-last
+
+    weight = torch.randn(CONV_DIM, CONV_WIDTH, dtype=DTYPE, device=DEVICE)
+
+    num_cache_lines = 1
+    conv_states = torch.zeros(
+        num_cache_lines, CONV_DIM, CONV_WIDTH - 1, dtype=DTYPE, device=DEVICE
+    )
+    cache_indices = torch.tensor([0], dtype=torch.int32, device=DEVICE)
+    has_initial_state = torch.zeros(1, dtype=torch.bool, device=DEVICE)
+    query_start_loc = torch.tensor([0, seq_len], dtype=torch.int32, device=DEVICE)
+
+    return x, weight, conv_states, cache_indices, has_initial_state, query_start_loc
+
+
+def bench_conv1d(seq_len: int) -> float:
+    x, weight, conv_states, cache_indices, has_initial_state, query_start_loc = (
+        _make_conv_inputs(seq_len)
+    )
+
+    def fn():
+        causal_conv1d_fn(
+            x,
+            weight,
+            None,
+            conv_states,
+            query_start_loc,
+            cache_indices=cache_indices,
+            has_initial_state=has_initial_state,
+            activation="silu",
+        )
+
+    return triton.testing.do_bench(fn, warmup=WARMUP, rep=REPEAT, return_mode="median")
+
+
+def bench_split(seq_len: int) -> float:
+    mixed_qkv = torch.randn(seq_len, CONV_DIM, dtype=DTYPE, device=DEVICE)
+
+    def fn():
+        fused_qkv_split_gdn_prefill(
+            mixed_qkv,
+            num_q_heads=NQ,
+            num_k_heads=NK,
+            num_v_heads=NV,
+            head_q=HEAD_DIM,
+            head_k=HEAD_DIM,
+            head_v=HEAD_DIM,
+        )
+
+    return triton.testing.do_bench(fn, warmup=WARMUP, rep=REPEAT, return_mode="median")
+
+
+def bench_sequential(seq_len: int) -> float:
+    """Measure conv1d + split back-to-back (as in current hybrid_linear_attn.py)."""
+    x, weight, conv_states, cache_indices, has_initial_state, query_start_loc = (
+        _make_conv_inputs(seq_len)
+    )
+
+    def fn():
+        conv_out = causal_conv1d_fn(
+            x,
+            weight,
+            None,
+            conv_states,
+            query_start_loc,
+            cache_indices=cache_indices,
+            has_initial_state=has_initial_state,
+            activation="silu",
+        )
+        # replicate hybrid_linear_attn.py:1044 post-processing
+        mixed_qkv = conv_out.transpose(0, 1)[:seq_len].contiguous()
+        fused_qkv_split_gdn_prefill(
+            mixed_qkv,
+            num_q_heads=NQ,
+            num_k_heads=NK,
+            num_v_heads=NV,
+            head_q=HEAD_DIM,
+            head_k=HEAD_DIM,
+            head_v=HEAD_DIM,
+        )
+
+    return triton.testing.do_bench(fn, warmup=WARMUP, rep=REPEAT, return_mode="median")
+
+
+def bench_fused(seq_len: int) -> float:
+    """Measure fused causal_conv1d + QKV split in one kernel."""
+    import sys
+
+    sys.path.insert(0, "tokenspeed-kernel/python")
+    from tokenspeed_kernel.ops.attention.triton.gdn_qkv_split import (
+        causal_conv1d_qkv_split_gdn_prefill,
+    )
+
+    x, weight, conv_states, cache_indices, has_initial_state, query_start_loc = (
+        _make_conv_inputs(seq_len)
+    )
+    seq_lens_cpu = [seq_len]
+
+    def fn():
+        causal_conv1d_qkv_split_gdn_prefill(
+            x,
+            weight,
+            None,
+            conv_states,
+            query_start_loc,
+            seq_lens_cpu,
+            num_q_heads=NQ,
+            num_k_heads=NK,
+            num_v_heads=NV,
+            head_q=HEAD_DIM,
+            head_k=HEAD_DIM,
+            head_v=HEAD_DIM,
+            total_seq_len=seq_len,
+            cache_indices=cache_indices,
+            has_initial_state=has_initial_state,
+            activation="silu",
+        )
+
+    return triton.testing.do_bench(fn, warmup=WARMUP, rep=REPEAT, return_mode="median")
+
+
+def main():
+    if not torch.cuda.is_available():
+        print("CUDA not available")
+        return
+
+    props = torch.cuda.get_device_properties(0)
+    l2_mb = props.L2_cache_size / (1024**2)
+    sm = f"{props.major}{props.minor}"
+    print(f"GPU: {props.name}  L2: {l2_mb:.0f} MB  sm_{sm}")
+    print(f"dtype={DTYPE}  conv_dim={CONV_DIM}  nq={NQ} nk={NK} nv={NV} h={HEAD_DIM}")
+    print()
+
+    header = (
+        f"{'T':>6}  {'conv1d':>9}  {'split(b0)':>9}  {'seq(c+s)':>9}"
+        f"  {'fused':>9}  {'gain%':>7}  {'conv_out':>9}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for seq_len in [512, 2048, 4096, 8192, 16384]:
+        conv_out_mb = CONV_DIM * seq_len * 2 // (1024**2)
+
+        t_conv = bench_conv1d(seq_len)
+        t_split = bench_split(seq_len)
+        t_seq = bench_sequential(seq_len)
+        t_fused = bench_fused(seq_len)
+
+        gain_pct = (t_seq - t_fused) / t_seq * 100
+
+        print(
+            f"{seq_len:>6}  {t_conv*1e3:>7.1f}µs  {t_split*1e3:>7.1f}µs"
+            f"  {t_seq*1e3:>7.1f}µs  {t_fused*1e3:>7.1f}µs"
+            f"  {gain_pct:>6.1f}%  {conv_out_mb:>7d}MB"
+        )
+
+    print()
+    print("gain% = (seq - fused) / seq  (positive = fused faster)")
+    print(f"L2 capacity: {l2_mb:.0f} MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/runtime/layers/test_causal_conv1d_qkv_split_fused.py
+++ b/test/runtime/layers/test_causal_conv1d_qkv_split_fused.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Correctness tests for fused causal_conv1d + QKV split kernel."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from tokenspeed_kernel.ops.attention.triton.gdn_qkv_split import (
+    causal_conv1d_qkv_split_gdn_prefill,
+    fused_qkv_split_gdn_prefill,
+)
+
+from tokenspeed.runtime.layers.attention.linear.causal_conv1d import (
+    causal_conv1d_fn,
+)
+
+NQ = NK = NV = 16
+HEAD_DIM = 128
+CONV_DIM = (NQ + NK + NV) * HEAD_DIM  # 6144
+CONV_WIDTH = 4
+
+# (seq_lens_list, description)
+SEQ_CONFIGS = [
+    ([512], "single_seq_512"),
+    ([2048], "single_seq_2048"),
+    ([8192], "single_seq_8192"),
+    ([256, 512], "varlen_2seq"),
+    ([128, 256, 512], "varlen_3seq"),
+]
+
+
+def _make_inputs(seq_lens: list[int], dtype: torch.dtype, with_initial_state: bool = False):
+    total_tokens = sum(seq_lens)
+    batch = len(seq_lens)
+
+    x = torch.randn(CONV_DIM, total_tokens, dtype=dtype, device="cuda")
+    x = x.as_strided(x.shape, (1, CONV_DIM))  # channel-last
+
+    weight = torch.randn(CONV_DIM, CONV_WIDTH, dtype=dtype, device="cuda")
+
+    conv_states = torch.zeros(batch, CONV_DIM, CONV_WIDTH - 1, dtype=dtype, device="cuda")
+    cache_indices = torch.arange(batch, dtype=torch.int32, device="cuda")
+    has_initial_state = torch.zeros(batch, dtype=torch.bool, device="cuda")
+    if with_initial_state:
+        has_initial_state[:] = True
+        conv_states.uniform_(-0.1, 0.1)
+
+    offsets = [0] + list(torch.tensor(seq_lens).cumsum(0).tolist())
+    query_start_loc = torch.tensor(offsets, dtype=torch.int32, device="cuda")
+    seq_lens_cpu = seq_lens
+
+    return x, weight, conv_states, cache_indices, has_initial_state, query_start_loc, seq_lens_cpu
+
+
+def _run_reference(x, weight, conv_states, cache_indices, has_initial_state,
+                   query_start_loc, seq_lens_cpu, total_seq_len, dtype):
+    """Reference: causal_conv1d_fn + fused_qkv_split_gdn_prefill (2 kernels)."""
+    # conv_states is mutated in-place; clone so both paths see the same initial state
+    conv_states_ref = conv_states.clone()
+    mixed_qkv = causal_conv1d_fn(
+        x,
+        weight,
+        None,
+        conv_states_ref,
+        query_start_loc,
+        cache_indices=cache_indices,
+        has_initial_state=has_initial_state,
+        activation="silu",
+        seq_lens_cpu=seq_lens_cpu,
+    ).transpose(0, 1)[:total_seq_len]
+
+    return fused_qkv_split_gdn_prefill(
+        mixed_qkv,
+        num_q_heads=NQ,
+        num_k_heads=NK,
+        num_v_heads=NV,
+        head_q=HEAD_DIM,
+        head_k=HEAD_DIM,
+        head_v=HEAD_DIM,
+    )
+
+
+def _run_fused(x, weight, conv_states, cache_indices, has_initial_state,
+               query_start_loc, seq_lens_cpu, total_seq_len, dtype):
+    conv_states_fused = conv_states.clone()
+    return causal_conv1d_qkv_split_gdn_prefill(
+        x,
+        weight,
+        None,
+        conv_states_fused,
+        query_start_loc,
+        seq_lens_cpu,
+        num_q_heads=NQ,
+        num_k_heads=NK,
+        num_v_heads=NV,
+        head_q=HEAD_DIM,
+        head_k=HEAD_DIM,
+        head_v=HEAD_DIM,
+        total_seq_len=total_seq_len,
+        cache_indices=cache_indices,
+        has_initial_state=has_initial_state,
+        activation="silu",
+    )
+
+
+@pytest.mark.parametrize("seq_lens,_desc", SEQ_CONFIGS)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("with_initial_state", [False, True])
+def test_qkv_correctness(seq_lens, _desc, dtype, with_initial_state):
+    torch.manual_seed(0)
+    total = sum(seq_lens)
+    x, weight, conv_states, cache_indices, has_initial_state, query_start_loc, seq_lens_cpu = (
+        _make_inputs(seq_lens, dtype, with_initial_state)
+    )
+
+    q_ref, k_ref, v_ref = _run_reference(
+        x, weight, conv_states, cache_indices, has_initial_state,
+        query_start_loc, seq_lens_cpu, total, dtype,
+    )
+    q, k, v = _run_fused(
+        x, weight, conv_states, cache_indices, has_initial_state,
+        query_start_loc, seq_lens_cpu, total, dtype,
+    )
+
+    tol = dict(atol=1e-3, rtol=1e-3)
+    assert q.shape == q_ref.shape, f"Q shape mismatch: {q.shape} vs {q_ref.shape}"
+    assert k.shape == k_ref.shape
+    assert v.shape == v_ref.shape
+    assert torch.allclose(q, q_ref, **tol), f"Q max diff {(q - q_ref).abs().max():.2e}"
+    assert torch.allclose(k, k_ref, **tol), f"K max diff {(k - k_ref).abs().max():.2e}"
+    assert torch.allclose(v, v_ref, **tol), f"V max diff {(v - v_ref).abs().max():.2e}"
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_conv_state_update(dtype):
+    """conv_states must be updated identically by both paths."""
+    torch.manual_seed(1)
+    seq_lens = [512]
+    total = sum(seq_lens)
+    x, weight, conv_states, cache_indices, has_initial_state, query_start_loc, seq_lens_cpu = (
+        _make_inputs(seq_lens, dtype, with_initial_state=False)
+    )
+
+    conv_states_ref = conv_states.clone()
+    conv_states_fused = conv_states.clone()
+
+    causal_conv1d_fn(
+        x, weight, None, conv_states_ref, query_start_loc,
+        cache_indices=cache_indices, has_initial_state=has_initial_state,
+        activation="silu", seq_lens_cpu=seq_lens_cpu,
+    )
+    causal_conv1d_qkv_split_gdn_prefill(
+        x, weight, None, conv_states_fused, query_start_loc, seq_lens_cpu,
+        NQ, NK, NV, HEAD_DIM, HEAD_DIM, HEAD_DIM,
+        total_seq_len=total,
+        cache_indices=cache_indices,
+        has_initial_state=has_initial_state,
+        activation="silu",
+    )
+
+    assert torch.allclose(conv_states_ref, conv_states_fused, atol=1e-3, rtol=1e-3), (
+        f"conv_states diverged: max diff {(conv_states_ref - conv_states_fused).abs().max():.2e}"
+    )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/gdn_qkv_split.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/gdn_qkv_split.py
@@ -20,8 +20,14 @@
 
 from __future__ import annotations
 
+import numpy as np
 import torch
 from tokenspeed_kernel._triton import tl, triton
+
+_PAD_SLOT_ID = -1
+_CONV1D_BLOCK_M = 8
+_CONV1D_BLOCK_N = 256
+
 
 
 def _autotune_configs():
@@ -212,5 +218,435 @@ def fused_qkv_split_gdn_prefill(
         head_v,
         qkv_dim,
         BLOCK_SIZE=block_size,
+    )
+    return q, k, v
+
+
+# ---------------------------------------------------------------------------
+# Fused causal_conv1d + QKV split
+# ---------------------------------------------------------------------------
+# Kernel body mirrors _causal_conv1d_fwd_kernel from causal_conv1d.py.
+# Only the output write is changed: instead of a single merged buffer,
+# each program routes to q_ptr / k_ptr / v_ptr based on its channel block.
+# BLOCK_N=256 divides Q_DIM / K_DIM / V_DIM exactly for all Qwen3.5 configs,
+# so every program falls cleanly into one output region.
+
+
+@triton.jit()
+def _causal_conv1d_qkv_split_fwd_kernel(
+    x_ptr,
+    w_ptr,
+    bias_ptr,
+    initial_states_ptr,
+    cache_indices_ptr,
+    has_initial_states_ptr,
+    query_start_loc_ptr,
+    batch_ptr,
+    token_chunk_offset_ptr,
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    batch: tl.int32,
+    dim: tl.constexpr,
+    seqlen: tl.int32,
+    num_cache_lines: tl.constexpr,
+    Q_DIM: tl.constexpr,
+    K_DIM: tl.constexpr,
+    V_DIM: tl.constexpr,
+    stride_x_seq: tl.constexpr,
+    stride_x_dim: tl.constexpr,
+    stride_x_token: tl.constexpr,
+    stride_w_dim: tl.constexpr,
+    stride_w_width: tl.constexpr,
+    stride_istate_seq: tl.constexpr,
+    stride_istate_dim: tl.constexpr,
+    stride_istate_token: tl.constexpr,
+    pad_slot_id: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+    KERNEL_WIDTH: tl.constexpr,
+    SILU_ACTIVATION: tl.constexpr,
+    HAS_INITIAL_STATES: tl.constexpr,
+    HAS_CACHE: tl.constexpr,
+    IS_CONTINUOUS_BATCHING: tl.constexpr,
+    USE_PAD_SLOT: tl.constexpr,
+    NP2_STATELEN: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    conv_states_ptr = initial_states_ptr
+    conv_state_indices_ptr = cache_indices_ptr
+    stride_conv_state_seq = stride_istate_seq
+    stride_conv_state_dim = stride_istate_dim
+    stride_conv_state_tok = stride_istate_token
+    state_len = KERNEL_WIDTH - 1
+
+    idx_seq = tl.load(batch_ptr + tl.program_id(0))
+    chunk_offset = tl.load(token_chunk_offset_ptr + tl.program_id(0))
+
+    pid_n = tl.program_id(1)
+    idx_feats = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    if idx_seq == pad_slot_id:
+        return
+
+    sequence_start_index = tl.load(query_start_loc_ptr + idx_seq)
+    sequence_end_index = tl.load(query_start_loc_ptr + idx_seq + 1)
+    seqlen = sequence_end_index - sequence_start_index
+
+    token_offset = BLOCK_M * chunk_offset
+    segment_len = min(BLOCK_M, seqlen - token_offset)
+
+    x_base = x_ptr + sequence_start_index * stride_x_token + idx_feats * stride_x_dim
+
+    if IS_CONTINUOUS_BATCHING:
+        conv_state_batch_coord = tl.load(conv_state_indices_ptr + idx_seq).to(tl.int64)
+    else:
+        conv_state_batch_coord = idx_seq
+    if USE_PAD_SLOT:
+        if conv_state_batch_coord == pad_slot_id:
+            return
+    conv_states_base = (
+        conv_states_ptr
+        + (conv_state_batch_coord * stride_conv_state_seq)
+        + (idx_feats * stride_conv_state_dim)
+    )
+
+    w_base = w_ptr + (idx_feats * stride_w_dim)
+
+    if chunk_offset == 0:
+        load_init_state = False
+        if HAS_INITIAL_STATES:
+            load_init_state = tl.load(has_initial_states_ptr + idx_seq).to(tl.int1)
+        if load_init_state:
+            prior_tokens = conv_states_base + (state_len - 1) * stride_conv_state_tok
+            mask_w = idx_feats < dim
+            if KERNEL_WIDTH == 2:
+                conv_states_ptrs = prior_tokens
+                col0 = tl.load(conv_states_ptrs, mask_w, 0.0)
+            if KERNEL_WIDTH == 3:
+                conv_states_ptrs = prior_tokens
+                col1 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                conv_states_ptrs = prior_tokens - 1 * stride_conv_state_tok
+                col0 = tl.load(conv_states_ptrs, mask_w, 0.0)
+            if KERNEL_WIDTH == 4:
+                conv_states_ptrs = prior_tokens
+                col2 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                conv_states_ptrs = prior_tokens - 1 * stride_conv_state_tok
+                col1 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                conv_states_ptrs = prior_tokens - 2 * stride_conv_state_tok
+                col0 = tl.load(conv_states_ptrs, mask_w, 0.0)
+            if KERNEL_WIDTH == 5:
+                conv_states_ptrs = prior_tokens
+                col3 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                conv_states_ptrs = prior_tokens - 1 * stride_conv_state_tok
+                col2 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                conv_states_ptrs = prior_tokens - 2 * stride_conv_state_tok
+                col1 = tl.load(conv_states_ptrs, mask_w, 0.0)
+                conv_states_ptrs = prior_tokens - 3 * stride_conv_state_tok
+                col0 = tl.load(conv_states_ptrs, mask_w, 0.0)
+        else:
+            if KERNEL_WIDTH >= 2:
+                col0 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+            if KERNEL_WIDTH >= 3:
+                col1 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+            if KERNEL_WIDTH >= 4:
+                col2 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+            if KERNEL_WIDTH >= 5:
+                col3 = tl.zeros((BLOCK_N,), dtype=x_ptr.dtype.element_ty)
+
+        if state_len <= seqlen:
+            idx_tokens_last = (seqlen - state_len) + tl.arange(0, NP2_STATELEN)
+            x_ptrs = (
+                x_ptr
+                + ((sequence_start_index + idx_tokens_last) * stride_x_token)[:, None]
+                + (idx_feats * stride_x_dim)[None, :]
+            )
+            mask_x = (
+                (idx_tokens_last >= 0)[:, None]
+                & (idx_tokens_last < seqlen)[:, None]
+                & (idx_feats < dim)[None, :]
+            )
+            new_conv_state = tl.load(x_ptrs, mask_x, 0.0)
+            idx_tokens_conv = tl.arange(0, NP2_STATELEN)
+            conv_states_ptrs_target = (
+                conv_states_base[None, :]
+                + (idx_tokens_conv * stride_conv_state_tok)[:, None]
+            )
+            mask = (idx_tokens_conv < state_len)[:, None] & (idx_feats < dim)[None, :]
+            tl.debug_barrier()
+            tl.store(conv_states_ptrs_target, new_conv_state, mask)
+        else:
+            if load_init_state:
+                idx_tokens_conv = tl.arange(0, NP2_STATELEN)
+                conv_states_ptrs_source = (
+                    conv_states_ptr
+                    + (conv_state_batch_coord * stride_conv_state_seq)
+                    + (idx_feats * stride_conv_state_dim)[None, :]
+                    + ((idx_tokens_conv + seqlen) * stride_conv_state_tok)[:, None]
+                )
+                mask = (
+                    (conv_state_batch_coord < num_cache_lines)
+                    & ((idx_tokens_conv + seqlen) < state_len)[:, None]
+                    & (idx_feats < dim)[None, :]
+                )
+                conv_state = tl.load(conv_states_ptrs_source, mask, other=0.0)
+                VAL = state_len - seqlen
+                x_ptrs = (
+                    x_base[None, :]
+                    + ((idx_tokens_conv - VAL) * stride_x_token)[:, None]
+                )
+                mask_x = (
+                    (idx_tokens_conv - VAL >= 0)[:, None]
+                    & (idx_tokens_conv - VAL < seqlen)[:, None]
+                    & (idx_feats < dim)[None, :]
+                )
+                loaded_x = tl.load(x_ptrs, mask_x, 0.0)
+                tl.debug_barrier()
+                new_conv_state = tl.where(mask, conv_state, loaded_x)
+                conv_states_ptrs_target = (
+                    conv_states_base
+                    + (idx_tokens_conv * stride_conv_state_tok)[:, None]
+                )
+                mask = (idx_tokens_conv < state_len)[:, None] & (idx_feats < dim)[None, :]
+                tl.store(conv_states_ptrs_target, new_conv_state, mask)
+            else:
+                idx_tokens_conv = tl.arange(0, NP2_STATELEN)
+                VAL = state_len - seqlen
+                x_ptrs = (
+                    x_base[None, :]
+                    + ((idx_tokens_conv - VAL) * stride_x_token)[:, None]
+                )
+                mask_x = (
+                    (idx_tokens_conv - VAL >= 0)[:, None]
+                    & (idx_tokens_conv - VAL < seqlen)[:, None]
+                    & (idx_feats < dim)[None, :]
+                )
+                new_conv_state = tl.load(x_ptrs, mask_x, 0.0)
+                conv_states_ptrs_target = (
+                    conv_states_base
+                    + (idx_tokens_conv * stride_conv_state_tok)[:, None]
+                )
+                mask = (idx_tokens_conv < state_len)[:, None] & (idx_feats < dim)[None, :]
+                tl.store(conv_states_ptrs_target, new_conv_state, mask)
+    else:
+        load_init_state = True
+        prior_tokens = x_base + (token_offset - 1) * stride_x_token
+        mask_w = idx_feats < dim
+        if KERNEL_WIDTH == 2:
+            conv_states_ptrs = prior_tokens
+            col0 = tl.load(conv_states_ptrs, mask_w, 0.0, cache_modifier=".ca")
+        if KERNEL_WIDTH == 3:
+            conv_states_ptrs = prior_tokens
+            col1 = tl.load(conv_states_ptrs, mask_w, 0.0, cache_modifier=".ca")
+            conv_states_ptrs = prior_tokens - 1 * stride_x_token
+            col0 = tl.load(conv_states_ptrs, mask_w, 0.0, cache_modifier=".ca")
+        if KERNEL_WIDTH == 4:
+            conv_states_ptrs = prior_tokens
+            col2 = tl.load(conv_states_ptrs, mask_w, 0.0, cache_modifier=".ca")
+            conv_states_ptrs = prior_tokens - 1 * stride_x_token
+            col1 = tl.load(conv_states_ptrs, mask_w, 0.0, cache_modifier=".ca")
+            conv_states_ptrs = prior_tokens - 2 * stride_x_token
+            col0 = tl.load(conv_states_ptrs, mask_w, 0.0, cache_modifier=".ca")
+        if KERNEL_WIDTH == 5:
+            conv_states_ptrs = prior_tokens
+            col3 = tl.load(conv_states_ptrs, mask_w, 0.0, cache_modifier=".ca")  # noqa: F841
+            conv_states_ptrs = prior_tokens - 1 * stride_x_token
+            col2 = tl.load(conv_states_ptrs, mask_w, 0.0, cache_modifier=".ca")
+            conv_states_ptrs = prior_tokens - 2 * stride_x_token
+            col1 = tl.load(conv_states_ptrs, mask_w, 0.0, cache_modifier=".ca")
+            conv_states_ptrs = prior_tokens - 3 * stride_x_token
+            col0 = tl.load(conv_states_ptrs, mask_w, 0.0, cache_modifier=".ca")
+
+    if HAS_BIAS:
+        bias = bias_ptr + idx_feats
+        mask_bias = idx_feats < dim
+        acc_preload = tl.load(bias, mask=mask_bias, other=0.0).to(tl.float32)
+    else:
+        acc_preload = tl.zeros((BLOCK_N,), dtype=tl.float32)
+
+    x_base_1d = x_base + token_offset * stride_x_token
+
+    mask_w = idx_feats < dim
+    if KERNEL_WIDTH >= 2:
+        w_ptrs = w_base + (0 * stride_w_width)
+        w_col0 = tl.load(w_ptrs, mask_w, other=0.0)
+        w_ptrs = w_base + (1 * stride_w_width)
+        w_col1 = tl.load(w_ptrs, mask_w, other=0.0)
+    if KERNEL_WIDTH >= 3:
+        w_ptrs = w_base + (2 * stride_w_width)
+        w_col2 = tl.load(w_ptrs, mask_w, other=0.0)
+    if KERNEL_WIDTH >= 4:
+        w_ptrs = w_base + (3 * stride_w_width)
+        w_col3 = tl.load(w_ptrs, mask_w, other=0.0)
+
+    mask_x_1d = idx_feats < dim
+    for idx_token in range(segment_len):
+        acc = acc_preload
+
+        matrix_w = w_col0
+        matrix_x = col0
+        for j in tl.static_range(KERNEL_WIDTH):
+            if KERNEL_WIDTH == 2:
+                if j == 1:
+                    matrix_w = w_col1
+                    x_ptrs_1d = x_base_1d + idx_token * stride_x_token
+                    matrix_x = tl.load(x_ptrs_1d, mask=mask_x_1d)
+            elif KERNEL_WIDTH == 3:
+                if j == 1:
+                    matrix_w = w_col1
+                    matrix_x = col1
+                elif j == 2:
+                    matrix_w = w_col2
+                    x_ptrs_1d = x_base_1d + idx_token * stride_x_token
+                    matrix_x = tl.load(x_ptrs_1d, mask=mask_x_1d)
+            elif KERNEL_WIDTH == 4:
+                if j == 1:
+                    matrix_w = w_col1
+                    matrix_x = col1
+                elif j == 2:
+                    matrix_w = w_col2
+                    matrix_x = col2
+                elif j == 3:
+                    matrix_w = w_col3
+                    x_ptrs_1d = x_base_1d + idx_token * stride_x_token
+                    matrix_x = tl.load(x_ptrs_1d, mask=mask_x_1d)
+
+            acc += matrix_x * matrix_w
+
+        if KERNEL_WIDTH == 2:
+            col0 = matrix_x
+        elif KERNEL_WIDTH == 3:
+            col0 = col1
+            col1 = matrix_x
+        elif KERNEL_WIDTH == 4:
+            col0 = col1
+            col1 = col2
+            col2 = matrix_x
+
+        if SILU_ACTIVATION:
+            acc = acc / (1 + tl.exp(-acc))
+
+        mask_1d = (idx_token < segment_len) & (idx_feats < dim)
+        g = sequence_start_index + token_offset + idx_token
+        if pid_n < Q_DIM // BLOCK_N:
+            o_ptrs = q_ptr + g * Q_DIM + idx_feats
+        elif pid_n < (Q_DIM + K_DIM) // BLOCK_N:
+            o_ptrs = k_ptr + g * K_DIM + (idx_feats - Q_DIM)
+        else:
+            o_ptrs = v_ptr + g * V_DIM + (idx_feats - Q_DIM - K_DIM)
+        tl.store(o_ptrs, acc, mask=mask_1d)
+
+
+def causal_conv1d_qkv_split_gdn_prefill(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    conv_states: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    seq_lens_cpu,
+    num_q_heads: int,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_q: int,
+    head_k: int,
+    head_v: int,
+    total_seq_len: int,
+    cache_indices: torch.Tensor | None = None,
+    has_initial_state: torch.Tensor | None = None,
+    activation: str | None = "silu",
+    pad_slot_id: int = _PAD_SLOT_ID,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused causal_conv1d + QKV split for GDN prefill.
+
+    Replaces the two-kernel sequence (causal_conv1d_fn → fused_qkv_split_gdn_prefill)
+    with a single launch, eliminating the intermediate conv_out staging buffer.
+
+    Args:
+        x: (dim, cu_seq_len), channel-last (stride(0)=1).
+        weight: (dim, conv_width).
+        total_seq_len: actual token count to allocate; caller may pass seq_len
+            to avoid over-allocation when cu_seq_len includes padding.
+    Returns:
+        (q, k, v) each shaped (1, total_seq_len, H, D).
+    """
+    Q_DIM = num_q_heads * head_q
+    K_DIM = num_k_heads * head_k
+    V_DIM = num_v_heads * head_v
+    dim, cu_seqlen = x.shape
+    _, width = weight.shape
+    state_len = width - 1
+    np2_statelen = triton.next_power_of_2(state_len)
+    padded_batch = query_start_loc.size(0) - 1
+
+    q = torch.empty((1, total_seq_len, num_q_heads, head_q), dtype=x.dtype, device=x.device)
+    k = torch.empty((1, total_seq_len, num_k_heads, head_k), dtype=x.dtype, device=x.device)
+    v = torch.empty((1, total_seq_len, num_v_heads, head_v), dtype=x.dtype, device=x.device)
+
+    num_cache_lines = 0
+    stride_istate_seq = stride_istate_dim = stride_istate_token = 0
+    if conv_states is not None:
+        num_cache_lines = conv_states.size(0)
+        stride_istate_seq = conv_states.stride(0)
+        stride_istate_dim = conv_states.stride(1)
+        stride_istate_token = conv_states.stride(2)
+
+    seqlens_np = np.asarray(seq_lens_cpu)
+    nums = (seqlens_np + _CONV1D_BLOCK_M - 1) // _CONV1D_BLOCK_M
+    tot = int(nums.sum())
+    if tot == 0:
+        return q, k, v
+
+    mlist = np.repeat(np.arange(len(nums)), nums)
+    offsetlist = np.arange(tot) - np.repeat(np.cumsum(nums) - nums, nums)
+    combined = np.stack([mlist, offsetlist]).astype(np.int32, copy=False)
+    combined_cpu = torch.from_numpy(combined).pin_memory()
+
+    batch_ptr = torch.full((tot + 1,), pad_slot_id, dtype=torch.int32, device=x.device)
+    token_chunk_offset_ptr = torch.full((tot + 1,), pad_slot_id, dtype=torch.int32, device=x.device)
+    batch_ptr[:tot].copy_(combined_cpu[0], non_blocking=True)
+    token_chunk_offset_ptr[:tot].copy_(combined_cpu[1], non_blocking=True)
+
+    grid = (tot, triton.cdiv(dim, _CONV1D_BLOCK_N))
+
+    _causal_conv1d_qkv_split_fwd_kernel[grid](
+        x,
+        weight,
+        bias,
+        conv_states,
+        cache_indices,
+        has_initial_state,
+        query_start_loc,
+        batch_ptr,
+        token_chunk_offset_ptr,
+        q,
+        k,
+        v,
+        padded_batch,
+        dim,
+        cu_seqlen,
+        num_cache_lines,
+        Q_DIM,
+        K_DIM,
+        V_DIM,
+        0,
+        x.stride(0),
+        x.stride(1),
+        weight.stride(0),
+        weight.stride(1),
+        stride_istate_seq,
+        stride_istate_dim,
+        stride_istate_token,
+        pad_slot_id,
+        HAS_BIAS=bias is not None,
+        KERNEL_WIDTH=width,
+        SILU_ACTIVATION=activation in ("silu", "swish"),
+        HAS_INITIAL_STATES=has_initial_state is not None,
+        HAS_CACHE=conv_states is not None,
+        IS_CONTINUOUS_BATCHING=cache_indices is not None,
+        USE_PAD_SLOT=pad_slot_id is not None,
+        NP2_STATELEN=np2_statelen,
+        BLOCK_M=_CONV1D_BLOCK_M,
+        BLOCK_N=_CONV1D_BLOCK_N,
+        num_stages=2,
     )
     return q, k, v

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/gdn_qkv_split.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/gdn_qkv_split.py
@@ -572,6 +572,11 @@ def causal_conv1d_qkv_split_gdn_prefill(
     Q_DIM = num_q_heads * head_q
     K_DIM = num_k_heads * head_k
     V_DIM = num_v_heads * head_v
+    if Q_DIM % _CONV1D_BLOCK_N or K_DIM % _CONV1D_BLOCK_N or V_DIM % _CONV1D_BLOCK_N:
+        raise ValueError(
+            f"Q/K/V dims ({Q_DIM}/{K_DIM}/{V_DIM}) must each be divisible by "
+            f"BLOCK_N={_CONV1D_BLOCK_N}; use the two-kernel path for other shapes."
+        )
     dim, cu_seqlen = x.shape
     _, width = weight.shape
     state_len = width - 1


### PR DESCRIPTION
### What this does

In the GDN prefill path, `causal_conv1d_fn` writes its output to a staging buffer (`conv_out`, bf16, shape `[conv_dim, T]`), and then `fused_qkv_split_gdn_prefill` reads that buffer to produce Q, K, V. This PR replaces those two kernel calls with a single Triton kernel that writes directly into Q/K/V, skipping the intermediate buffer entirely.

The staging buffer grows with sequence length at T=8192 it is 96 MB, which is 76% of B200's L2 (126 MB). At that size the split kernel cannot reuse L2-cached data from the conv kernel, so there is a real DRAM round-trip cost.

### Changes

- `gdn_qkv_split.py`: added `_causal_conv1d_qkv_split_fwd_kernel` and `causal_conv1d_qkv_split_gdn_prefill`. The kernel body is almost identical to `_causal_conv1d_fwd_kernel`, only the store path changes (three output pointers instead of one).
- `hybrid_linear_attn.py`: routes `need_h_track=False` prefill through the fused call. `need_h_track=True` keeps the original two-call path unchanged.

The Q/K/V boundary alignment is clean because Q_DIM = K_DIM = V_DIM = 2048, all exact multiples of BLOCK_N=256, so each Triton program falls entirely within one output region.

### Perf (B200, bf16, single-seq)

```
     T    sequential      fused    gain
   512      128.4µs     79.1µs   +38%
  2048      131.6µs     70.8µs   +46%
  4096      150.4µs     74.9µs   +50%
  8192      203.8µs    126.7µs   +38%
 16384      324.6µs    204.8µs   +37%
```

### Tests

Added `test/runtime/layers/test_causal_conv1d_qkv_split_fused.py`: 22 tests covering varlen, initial conv state, bf16/fp16. All pass. Conv state update is also verified to be identical between the two paths.