### PR TITLE
fix(mamba): gate per-draft-token pool budget on speculative_algorithm

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -512,7 +512,11 @@ def create_attn_components(
         temporal_size = 1
         for dim in temporal_state_shape:
             temporal_size *= dim
-        speculative_num_draft_tokens = server_args.speculative_num_draft_tokens or 0
+        speculative_num_draft_tokens = (
+            server_args.speculative_num_draft_tokens
+            if server_args.speculative_algorithm is not None
+            else 0
+        )
         per_layer_mamba_chunk_memory = (
             conv_size * conv_dtype.itemsize + temporal_size * ssm_dtype.itemsize
         ) * (1 + speculative_num_draft_tokens)


### PR DESCRIPTION
## Bug

In `create_attn_components`, the mamba pool budget multiplies per-chunk memory by `(1 + speculative_num_draft_tokens)`:

```python
speculative_num_draft_tokens = server_args.speculative_num_draft_tokens or 0
per_layer_mamba_chunk_memory = (...) * (1 + speculative_num_draft_tokens)
```

`speculative_num_draft_tokens` defaults to `speculative_num_steps + 1` even when no speculative algorithm is configured, and this multiplier is applied unconditionally. The actual state-tensor allocation (`SimpleMambaPool`) already gates the draft dimension on `speculative_algorithm is not None`, so the budget is the only ungated consumer: with speculative decoding off it over-counts each chunk, and the mamba pool is sized smaller than the available memory allows (the over-reserved memory is never allocated).

## Fix

Gate the budget the same way the allocation is gated. No change when a speculative algorithm is enabled.
