### PR TITLE
Add small-M Gluon warp-decode MoE path for GPT-OSS

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
@@ -4630,19 +4630,36 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
             router_logits, top_k, router_logits.dtype
         )
 
-    # Current GPT-OSS path uses FP8 E4M3 activations with per-tensor scale.
-    from tokenspeed_kernel import quantize_fp8
-
+    fp8_dtype = (
+        getattr(
+            getattr(getattr(w13_precision_config, "flex_ctx", None), "lhs_data", None),
+            "dtype",
+            None,
+        )
+        or torch.float8_e4m3fn
+    )
+    fuse_input_quant = os.environ.get(
+        "TOKENSPEED_MOE_GLUON_FUSE_INPUT_QUANT", "0"
+    ).strip().lower() in {"1", "true", "yes", "on"}
     if hidden_states.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz):
         x_fp8 = hidden_states
+        quantize_x = False
+    elif fuse_input_quant:
+        # Experimental: quantize BF16/FP16 input tiles to FP8 in-register in
+        # stage1.  Currently slower than the standalone quantize_fp8 launch.
+        x_fp8 = hidden_states
+        quantize_x = True
     else:
+        from tokenspeed_kernel import quantize_fp8
+
         x_fp8 = quantize_fp8(hidden_states, scale=w13_act_scale, solution="triton")
+        quantize_x = False
     # Pass FP8 tensors directly to Gluon.  ``view(torch.uint8)`` materializes a
     # copy for float8 tensors on this stack and dominates small-M latency.
     x_u8 = x_fp8
 
     inter = torch.empty(
-        (n_tokens * top_k, I), dtype=x_fp8.dtype, device=hidden_states.device
+        (n_tokens * top_k, I), dtype=fp8_dtype, device=hidden_states.device
     )
     out_dtype = getattr(w2_precision_config, "out_dtype", None) or torch.bfloat16
     out = torch.empty((n_tokens, N), dtype=out_dtype, device=hidden_states.device)
@@ -4695,6 +4712,7 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
             BLOCK_K=BLOCK_K,
             BLOCK_N=S1_BLOCK_N,
             M_DUP=S1_M_DUP,
+            QUANTIZE_X=quantize_x,
             HAS_BIAS=w13_bias is not None,
             SWIGLU_ALPHA=float(swiglu_alpha),
             SWIGLU_LIMIT=float(swiglu_limit),
@@ -4730,6 +4748,7 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
             BLOCK_K=BLOCK_K,
             BLOCK_N=S1_BLOCK_N,
             M_DUP=S1_M_DUP,
+            QUANTIZE_X=quantize_x,
             HAS_BIAS=w13_bias is not None,
             SWIGLU_ALPHA=float(swiglu_alpha),
             SWIGLU_LIMIT=float(swiglu_limit),
@@ -5378,6 +5397,7 @@ def _warp_decode_topk_stage1_fp8_mxfp4_kernel(
     BLOCK_K: gl.constexpr,
     BLOCK_N: gl.constexpr,
     M_DUP: gl.constexpr,
+    QUANTIZE_X: gl.constexpr,
     HAS_BIAS: gl.constexpr,
     SWIGLU_ALPHA: gl.constexpr,
     SWIGLU_LIMIT: gl.constexpr,
@@ -5476,6 +5496,9 @@ def _warp_decode_topk_stage1_fp8_mxfp4_kernel(
                     mask=k_elem < D,
                     other=0.0,
                 )
+                if QUANTIZE_X:
+                    x_scale_tile = gl.load(x_global_scale_ptr).to(gl.float32)
+                    a = (a.to(gl.float32) / x_scale_tile).to(gl.float8e4nv)
                 b_g = gl.load(
                     w_base
                     + k_pack.to(gl.int64) * stride_wk
@@ -5608,6 +5631,7 @@ def _warp_decode_stage1_fp8_mxfp4_kernel(
     BLOCK_K: gl.constexpr,
     BLOCK_N: gl.constexpr,
     M_DUP: gl.constexpr,
+    QUANTIZE_X: gl.constexpr,
     HAS_BIAS: gl.constexpr,
     SWIGLU_ALPHA: gl.constexpr,
     SWIGLU_LIMIT: gl.constexpr,
@@ -5672,6 +5696,9 @@ def _warp_decode_stage1_fp8_mxfp4_kernel(
                     mask=k_elem < D,
                     other=0.0,
                 )
+                if QUANTIZE_X:
+                    x_scale_tile = gl.load(x_global_scale_ptr).to(gl.float32)
+                    a = (a.to(gl.float32) / x_scale_tile).to(gl.float8e4nv)
                 a_scale = gl.full(
                     (M_DUP, BLOCK_K_SCALE), 127, gl.uint8, layout=a_scale_layout
                 )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
@@ -4550,6 +4550,166 @@ def _gluon_mxfp_ragged_matmul(
     return
 
 
+def _direct_raw_weight_for_warp_decode(w):
+    """Return raw (E, K_packed, N) storage for direct warp-decode kernels."""
+    if isinstance(w, torch.Tensor):
+        return w
+    if isinstance(w, Tensor):
+        return w.storage.data
+    return w
+
+
+def _gluon_mxfp4_fp8_warp_decode_moe(
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor,
+    w13_weight,
+    w2_weight,
+    *,
+    w13_bias=None,
+    w2_bias=None,
+    w13_precision_config=None,
+    w2_precision_config=None,
+    w13_act_scale: torch.Tensor,
+    w2_act_scale: torch.Tensor,
+    top_k: int,
+    swiglu_alpha: float = 1.702,
+    swiglu_limit: float = 7.0,
+) -> torch.Tensor | None:
+    """Small-M direct warp-decode MoE for GPT-OSS FP8 x MXFP4 path."""
+    if hidden_states.ndim != 2 or router_logits.ndim != 2:
+        return None
+    n_tokens = int(router_logits.shape[0])
+    if n_tokens > SMALLM_MAX_M:
+        return None
+    if not gluon_route_supported(router_logits, top_k, router_logits.dtype):
+        return None
+    if w13_precision_config is None or w2_precision_config is None:
+        return None
+
+    w13_raw = _direct_raw_weight_for_warp_decode(w13_weight)
+    w2_raw = _direct_raw_weight_for_warp_decode(w2_weight)
+    w13_scale = _extract_gluon_raw_s(getattr(w13_precision_config, "b_mx_scale", None))
+    w2_scale = _extract_gluon_raw_s(getattr(w2_precision_config, "b_mx_scale", None))
+    if not all(
+        isinstance(t, torch.Tensor) for t in (w13_raw, w2_raw, w13_scale, w2_scale)
+    ):
+        return None
+    if w13_raw.ndim != 3 or w2_raw.ndim != 3:
+        return None
+    if w13_raw.dtype != torch.uint8 or w2_raw.dtype != torch.uint8:
+        return None
+    if w13_scale.dtype != torch.uint8 or w2_scale.dtype != torch.uint8:
+        return None
+
+    D = int(hidden_states.shape[1])
+    if int(w13_raw.shape[1]) * 2 != D:
+        return None
+    two_i = int(w13_raw.shape[2])
+    if two_i % 2 != 0:
+        return None
+    I = two_i // 2
+    if int(w2_raw.shape[1]) * 2 != I:
+        return None
+    N = int(w2_raw.shape[2])
+
+    # Direct kernels consume dense top-k rather than ragged metadata.
+    topk_ids, topk_weights = _direct_topk_small_m(
+        router_logits, top_k, router_logits.dtype
+    )
+
+    # Current GPT-OSS path uses FP8 E4M3 activations with per-tensor scale.
+    from tokenspeed_kernel import quantize_fp8
+
+    if hidden_states.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz):
+        x_fp8 = hidden_states
+    else:
+        x_fp8 = quantize_fp8(hidden_states, scale=w13_act_scale, solution="triton")
+    x_u8 = x_fp8.view(torch.uint8) if x_fp8.dtype != torch.uint8 else x_fp8
+
+    inter = torch.empty(
+        (n_tokens * top_k, I), dtype=x_fp8.dtype, device=hidden_states.device
+    )
+    out_dtype = getattr(w2_precision_config, "out_dtype", None) or torch.bfloat16
+    out = torch.empty((n_tokens, N), dtype=out_dtype, device=hidden_states.device)
+
+    dummy_bias = _make_dummy(hidden_states.device, torch.float32, 1)
+    b13 = w13_bias if w13_bias is not None else dummy_bias
+    b2 = w2_bias if w2_bias is not None else dummy_bias
+
+    BLOCK_K = 128
+    BLOCK_N = 16
+    M_DUP = 16
+    s1_grid = (n_tokens * top_k * ((I + BLOCK_N - 1) // BLOCK_N),)
+    _warp_decode_stage1_fp8_mxfp4_kernel[s1_grid](
+        x_u8,
+        w13_raw,
+        w13_scale,
+        topk_ids,
+        inter,
+        n_tokens,
+        D,
+        I,
+        top_k,
+        x_u8.stride(0),
+        x_u8.stride(1),
+        w13_raw.stride(0),
+        w13_raw.stride(-2),
+        w13_raw.stride(-1),
+        w13_scale.stride(0),
+        w13_scale.stride(-2),
+        w13_scale.stride(-1),
+        inter.stride(0),
+        inter.stride(1),
+        w13_act_scale,
+        w2_act_scale,
+        b13,
+        D_PACKED=D // 2,
+        TOPK=top_k,
+        BLOCK_K=BLOCK_K,
+        BLOCK_N=BLOCK_N,
+        M_DUP=M_DUP,
+        HAS_BIAS=w13_bias is not None,
+        SWIGLU_ALPHA=float(swiglu_alpha),
+        SWIGLU_LIMIT=float(swiglu_limit),
+        num_warps=1,
+    )
+
+    s2_grid = (n_tokens * ((N + BLOCK_N - 1) // BLOCK_N),)
+    inter_u8 = inter.view(torch.uint8) if inter.dtype != torch.uint8 else inter
+    _warp_decode_stage2_fp8_mxfp4_kernel[s2_grid](
+        inter_u8,
+        w2_raw,
+        w2_scale,
+        topk_ids,
+        topk_weights,
+        out,
+        n_tokens,
+        N,
+        I,
+        top_k,
+        inter_u8.stride(0),
+        inter_u8.stride(1),
+        w2_raw.stride(0),
+        w2_raw.stride(-2),
+        w2_raw.stride(-1),
+        w2_scale.stride(0),
+        w2_scale.stride(-2),
+        w2_scale.stride(-1),
+        out.stride(0),
+        out.stride(1),
+        w2_act_scale,
+        b2,
+        I_PACKED=I // 2,
+        TOPK=top_k,
+        BLOCK_K=BLOCK_K,
+        BLOCK_N=BLOCK_N,
+        M_DUP=M_DUP,
+        HAS_BIAS=w2_bias is not None,
+        num_warps=1,
+    )
+    return out
+
+
 _GLUON_FUSED_SIGNATURES = frozenset(
     {
         format_signature(
@@ -4638,13 +4798,63 @@ def _gluon_mxfp_fused_moe(
 
     n_tokens = router_logits.shape[0]
 
+    if os.environ.get("TOKENSPEED_MOE_GLUON_WARP_DECODE", "0").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        try:
+            warp_out = _gluon_mxfp4_fp8_warp_decode_moe(
+                hidden_states,
+                router_logits,
+                w13_weight,
+                w2_weight,
+                w13_bias=w13_bias,
+                w2_bias=w2_bias,
+                w13_precision_config=w13_precision_config,
+                w2_precision_config=w2_precision_config,
+                w13_act_scale=w13_act_scale,
+                w2_act_scale=w2_act_scale,
+                top_k=top_k,
+                swiglu_alpha=swiglu_alpha,
+                swiglu_limit=swiglu_limit,
+            )
+            if warp_out is not None:
+                return warp_out
+        except Exception as exc:  # noqa: BLE001
+            import logging
+            import traceback
+
+            logger = logging.getLogger("tokenspeed_kernel.ops.moe.gluon")
+            logger.warning(
+                "warp-decode small-M path falling back: %s: %s",
+                type(exc).__name__,
+                exc,
+            )
+            logger.warning(
+                "  full chain:\n%s",
+                "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+            )
+
+    # Decode-small GPT-OSS routing is launch-overhead dominated.  Prefer the
+    # single-kernel Gluon route for the M<=16 single-block-collapse regime;
+    # fall back to the generic Triton route for larger/unsupported shapes.
+    route_expected_kernel = (
+        "gluon_decode_routing_gfx950"
+        if (
+            n_tokens <= SMALLM_MAX_M
+            and gluon_route_supported(router_logits, top_k, router_logits.dtype)
+        )
+        else "triton_kernels_routing"
+    )
     ragged_metadata, gather_indx, scatter_indx, gate_scal = moe_route(
         router_logits,
         top_k,
         sm_first=False,
         dtype=router_logits.dtype,
         traits={"output_type": "ragged_metadata"},
-        expected_kernel_name="triton_kernels_routing",
+        expected_kernel_name=route_expected_kernel,
     )
 
     act = FusedActivation(
@@ -4978,6 +5188,429 @@ def _fused_route_small_m(
 # ===========================================================================
 def _route_next_pow2(x: int) -> int:
     return 1 << (max(1, x) - 1).bit_length()
+
+
+@gluon.jit
+def _direct_topk_small_m_kernel(
+    Logits,
+    TopkIds,
+    TopkWeights,
+    stride_lm,
+    stride_im,
+    stride_wm,
+    M: gl.constexpr,
+    E: gl.constexpr,
+    TOPK: gl.constexpr,
+    MP: gl.constexpr,
+    GP: gl.constexpr,
+    EP: gl.constexpr,
+    TKP: gl.constexpr,
+    X_DTYPE: gl.constexpr,
+    NW_C: gl.constexpr,
+):
+    """Small-M direct top-k output for warp-decode kernels.
+
+    This reuses the same in-kernel top-k/softmax implementation as the fused
+    routing path, but stores dense token-major ``topk_ids`` and ``topk_weights``
+    instead of ragged metadata.
+    """
+    LG: gl.constexpr = gl.BlockedLayout([1], [64], [NW_C], [0])
+    LT: gl.constexpr = gl.BlockedLayout([1, 1], [1, 64], [NW_C, 1], [1, 0])
+    g = gl.arange(0, GP, layout=LG)
+    gmask = g < (M * TOPK)
+    tok = (g // TOPK).to(gl.int32)
+    slot = (g % TOPK).to(gl.int32)
+    idx, vals = _fused_topk(
+        Logits,
+        stride_lm,
+        gmask,
+        tok,
+        slot,
+        M,
+        E,
+        TOPK,
+        MP,
+        EP,
+        GP,
+        TKP,
+        X_DTYPE,
+        LG,
+        LT,
+    )
+    gl.store(TopkIds + tok * stride_im + slot, idx, mask=gmask)
+    gl.store(TopkWeights + tok * stride_wm + slot, vals, mask=gmask)
+
+
+def _direct_topk_small_m(
+    logits: torch.Tensor, topk: int, dtype: torch.dtype | None = None
+):
+    """Return dense ``(topk_ids, topk_weights)`` for small-M warp decode."""
+    if dtype is None:
+        dtype = logits.dtype
+    M, E = logits.shape
+    if M > SMALLM_MAX_M:
+        raise ValueError(f"_direct_topk_small_m requires M <= {SMALLM_MAX_M}; got {M}")
+    if not gluon_route_supported(logits, topk, dtype):
+        raise ValueError("_direct_topk_small_m received unsupported logits/topk/dtype")
+    logits = logits.contiguous()
+    ids = torch.empty((M, topk), dtype=torch.int32, device=logits.device)
+    weights = torch.empty((M, topk), dtype=dtype, device=logits.device)
+    G = M * topk
+    nw = 1 if M <= 2 else 4
+    _direct_topk_small_m_kernel[(1,)](
+        logits,
+        ids,
+        weights,
+        logits.stride(0),
+        ids.stride(0),
+        weights.stride(0),
+        M=M,
+        E=E,
+        TOPK=topk,
+        MP=_route_next_pow2(M),
+        GP=_route_next_pow2(G),
+        EP=_route_next_pow2(E),
+        TKP=_route_next_pow2(topk),
+        X_DTYPE=_ROUTE_GL_DTYPE[dtype],
+        NW_C=nw,
+        num_warps=nw,
+    )
+    return ids, weights
+
+
+@gluon.jit
+def _warp_decode_stage1_fp8_mxfp4_kernel(
+    X,
+    W,
+    WScale,
+    TopkIds,
+    Y,
+    M,
+    D,
+    I,
+    TOPK_RUNTIME,
+    stride_xm,
+    stride_xk,
+    stride_we,
+    stride_wk,
+    stride_wn,
+    stride_wse,
+    stride_wsk,
+    stride_wsn,
+    stride_ym,
+    stride_yn,
+    x_global_scale_ptr,
+    out_quant_scale_ptr,
+    w13_bias,
+    D_PACKED: gl.constexpr,
+    TOPK: gl.constexpr,
+    BLOCK_K: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    M_DUP: gl.constexpr,
+    HAS_BIAS: gl.constexpr,
+    SWIGLU_ALPHA: gl.constexpr,
+    SWIGLU_LIMIT: gl.constexpr,
+):
+    """Direct top-k stage1: FP8 hidden x MXFP4 W13 -> FP8 intermediate."""
+    BLOCK_K_PACKED: gl.constexpr = BLOCK_K // 2
+    BLOCK_K_SCALE: gl.constexpr = BLOCK_K // 32
+    pid = gl.program_id(axis=0)
+    num_pid_n = gl.cdiv(I, BLOCK_N)
+    pid_ts = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    token = pid_ts // TOPK_RUNTIME
+    slot = pid_ts % TOPK_RUNTIME
+
+    mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
+        version=4, instr_shape=[16, 16, 128], transposed=True, warps_per_cta=[1, 1]
+    )
+    dot_a_layout: gl.constexpr = gl.DotOperandLayout(
+        operand_index=0, parent=mfma_layout, k_width=16
+    )
+    dot_b_layout: gl.constexpr = gl.DotOperandLayout(
+        operand_index=1, parent=mfma_layout, k_width=16
+    )
+    a_scale_layout: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
+        dot_a_layout, [M_DUP, BLOCK_K_SCALE]
+    )
+    b_scale_layout: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
+        dot_b_layout, [BLOCK_N, BLOCK_K_SCALE]
+    )
+
+    am = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, dot_a_layout))[:, None]
+    ak = gl.arange(0, BLOCK_K, layout=gl.SliceLayout(0, dot_a_layout))[None, :]
+    bk = gl.arange(0, BLOCK_K_PACKED, layout=gl.SliceLayout(1, dot_b_layout))[:, None]
+    bn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, dot_b_layout))[None, :]
+    n_gate = pid_n * BLOCK_N + bn
+    n_up = I + n_gate
+
+    asm = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, a_scale_layout))[:, None]
+    ask = gl.arange(0, BLOCK_K_SCALE, layout=gl.SliceLayout(0, a_scale_layout))[None, :]
+    bsn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(1, b_scale_layout))[:, None]
+    bsk = gl.arange(0, BLOCK_K_SCALE, layout=gl.SliceLayout(0, b_scale_layout))[None, :]
+    n_gate_s = pid_n * BLOCK_N + bsn
+    n_up_s = I + n_gate_s
+
+    acc_g = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
+    acc_u = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
+    if token < M:
+        expert = gl.load(
+            TopkIds + token * TOPK_RUNTIME + slot, mask=token < M, other=-1
+        )
+        if expert >= 0:
+            w_base = W + expert.to(gl.int64) * stride_we
+            ws_base = WScale + expert.to(gl.int64) * stride_wse
+            for kt in range(gl.cdiv(D, BLOCK_K)):
+                k_elem = kt * BLOCK_K + ak
+                k_pack = kt * BLOCK_K_PACKED + bk
+                a = gl.load(
+                    X
+                    + token.to(gl.int64) * stride_xm
+                    + k_elem.to(gl.int64) * stride_xk
+                    + am.to(gl.int64) * 0,
+                    mask=k_elem < D,
+                    other=0.0,
+                )
+                a_scale = gl.full(
+                    (M_DUP, BLOCK_K_SCALE), 127, gl.uint8, layout=a_scale_layout
+                )
+                b_g = gl.load(
+                    w_base
+                    + k_pack.to(gl.int64) * stride_wk
+                    + n_gate.to(gl.int64) * stride_wn,
+                    mask=(k_pack < D_PACKED) & (n_gate < I),
+                    other=0,
+                )
+                b_u = gl.load(
+                    w_base
+                    + k_pack.to(gl.int64) * stride_wk
+                    + n_up.to(gl.int64) * stride_wn,
+                    mask=(k_pack < D_PACKED) & (n_gate < I),
+                    other=0,
+                )
+                sg = kt * BLOCK_K_SCALE + bsk
+                # CDNA4 scale swizzle: storage shape (..., K_SCALE_PAD*32, N_PAD/32).
+                row_g = n_gate_s.to(gl.uint32)
+                lin_g = (
+                    (sg // 8) * 128
+                    + (sg % 4) * 32
+                    + (row_g % 16) * 4
+                    + ((sg % 8) // 4) * 2
+                    + ((row_g % 32) // 16)
+                )
+                off_g = (row_g // 32).to(gl.int64) * stride_wsn + lin_g.to(
+                    gl.int64
+                ) * stride_wsk
+                row_u = n_up_s.to(gl.uint32)
+                lin_u = (
+                    (sg // 8) * 128
+                    + (sg % 4) * 32
+                    + (row_u % 16) * 4
+                    + ((sg % 8) // 4) * 2
+                    + ((row_u % 32) // 16)
+                )
+                off_u = (row_u // 32).to(gl.int64) * stride_wsn + lin_u.to(
+                    gl.int64
+                ) * stride_wsk
+                s_g = gl.load(
+                    ws_base + off_g, mask=(sg < (D // 32)) & (n_gate_s < I), other=0
+                )
+                s_u = gl.load(
+                    ws_base + off_u, mask=(sg < (D // 32)) & (n_gate_s < I), other=0
+                )
+                acc_g = gl.amd.cdna4.mfma_scaled(
+                    a=a,
+                    a_scale=a_scale,
+                    a_format="e4m3",
+                    b=b_g,
+                    b_scale=s_g,
+                    b_format="e2m1",
+                    acc=acc_g,
+                )
+                acc_u = gl.amd.cdna4.mfma_scaled(
+                    a=a,
+                    a_scale=a_scale,
+                    a_format="e4m3",
+                    b=b_u,
+                    b_scale=s_u,
+                    b_format="e2m1",
+                    acc=acc_u,
+                )
+    x_scale = gl.load(x_global_scale_ptr).to(gl.float32)
+    acc_g = acc_g * x_scale
+    acc_u = acc_u * x_scale
+    if HAS_BIAS:
+        bg = gl.load(
+            w13_bias + expert.to(gl.int64) * (2 * I) + n_gate,
+            mask=(token < M) & (n_gate < I),
+            other=0.0,
+        ).to(gl.float32)
+        bu = gl.load(
+            w13_bias + expert.to(gl.int64) * (2 * I) + n_up,
+            mask=(token < M) & (n_gate < I),
+            other=0.0,
+        ).to(gl.float32)
+        acc_g += bg
+        acc_u += bu
+    if SWIGLU_LIMIT > 0.0:
+        acc_g = gl.minimum(acc_g, SWIGLU_LIMIT)
+        acc_u = gl.clamp(acc_u, -SWIGLU_LIMIT, SWIGLU_LIMIT)
+    out_scale = gl.load(out_quant_scale_ptr).to(gl.float32)
+    out = ((acc_g / (1.0 + gl.exp(-SWIGLU_ALPHA * acc_g))) * (acc_u + 1.0)) / out_scale
+    sm = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, mfma_layout))[:, None]
+    sn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout))[None, :]
+    col = pid_n * BLOCK_N + sn
+    gl.store(
+        Y
+        + pid_ts.to(gl.int64) * stride_ym
+        + col.to(gl.int64) * stride_yn
+        + sm.to(gl.int64) * 0,
+        out.to(Y.dtype.element_ty),
+        mask=(token < M) & (sm == 0) & (col < I),
+    )
+
+
+@gluon.jit
+def _warp_decode_stage2_fp8_mxfp4_kernel(
+    X,
+    W,
+    WScale,
+    TopkIds,
+    TopkWeights,
+    Out,
+    M,
+    N,
+    I,
+    TOPK_RUNTIME,
+    stride_xm,
+    stride_xk,
+    stride_we,
+    stride_wk,
+    stride_wn,
+    stride_wse,
+    stride_wsk,
+    stride_wsn,
+    stride_om,
+    stride_on,
+    x_global_scale_ptr,
+    w2_bias,
+    I_PACKED: gl.constexpr,
+    TOPK: gl.constexpr,
+    BLOCK_K: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    M_DUP: gl.constexpr,
+    HAS_BIAS: gl.constexpr,
+):
+    """Direct top-k stage2: FP8 intermediate x MXFP4 W2 -> BF16 output."""
+    BLOCK_K_PACKED: gl.constexpr = BLOCK_K // 2
+    BLOCK_K_SCALE: gl.constexpr = BLOCK_K // 32
+    pid = gl.program_id(axis=0)
+    pid_token = pid // gl.cdiv(N, BLOCK_N)
+    pid_n = pid % gl.cdiv(N, BLOCK_N)
+    mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
+        version=4, instr_shape=[16, 16, 128], transposed=True, warps_per_cta=[1, 1]
+    )
+    dot_a_layout: gl.constexpr = gl.DotOperandLayout(
+        operand_index=0, parent=mfma_layout, k_width=16
+    )
+    dot_b_layout: gl.constexpr = gl.DotOperandLayout(
+        operand_index=1, parent=mfma_layout, k_width=16
+    )
+    a_scale_layout: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
+        dot_a_layout, [M_DUP, BLOCK_K_SCALE]
+    )
+    b_scale_layout: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
+        dot_b_layout, [BLOCK_N, BLOCK_K_SCALE]
+    )
+    am = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, dot_a_layout))[:, None]
+    ak = gl.arange(0, BLOCK_K, layout=gl.SliceLayout(0, dot_a_layout))[None, :]
+    bk = gl.arange(0, BLOCK_K_PACKED, layout=gl.SliceLayout(1, dot_b_layout))[:, None]
+    bn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, dot_b_layout))[None, :]
+    bsn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(1, b_scale_layout))[:, None]
+    bsk = gl.arange(0, BLOCK_K_SCALE, layout=gl.SliceLayout(0, b_scale_layout))[None, :]
+    n_cols = pid_n * BLOCK_N + bn
+    n_cols_s = pid_n * BLOCK_N + bsn
+    acc_total = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
+    if pid_token < M:
+        for slot in gl.static_range(0, TOPK):
+            expert = gl.load(
+                TopkIds + pid_token * TOPK_RUNTIME + slot, mask=pid_token < M, other=-1
+            )
+            gate = gl.load(
+                TopkWeights + pid_token * TOPK_RUNTIME + slot,
+                mask=pid_token < M,
+                other=0.0,
+            ).to(gl.float32)
+            if expert >= 0:
+                row = pid_token * TOPK_RUNTIME + slot
+                w_base = W + expert.to(gl.int64) * stride_we
+                ws_base = WScale + expert.to(gl.int64) * stride_wse
+                acc = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
+                for kt in range(gl.cdiv(I, BLOCK_K)):
+                    k_elem = kt * BLOCK_K + ak
+                    k_pack = kt * BLOCK_K_PACKED + bk
+                    a = gl.load(
+                        X
+                        + row.to(gl.int64) * stride_xm
+                        + k_elem.to(gl.int64) * stride_xk
+                        + am.to(gl.int64) * 0,
+                        mask=k_elem < I,
+                        other=0.0,
+                    )
+                    a_scale = gl.full(
+                        (M_DUP, BLOCK_K_SCALE), 127, gl.uint8, layout=a_scale_layout
+                    )
+                    b = gl.load(
+                        w_base
+                        + k_pack.to(gl.int64) * stride_wk
+                        + n_cols.to(gl.int64) * stride_wn,
+                        mask=(k_pack < I_PACKED) & (n_cols < N),
+                        other=0,
+                    )
+                    sk = kt * BLOCK_K_SCALE + bsk
+                    row_s = n_cols_s.to(gl.uint32)
+                    lin_s = (
+                        (sk // 8) * 128
+                        + (sk % 4) * 32
+                        + (row_s % 16) * 4
+                        + ((sk % 8) // 4) * 2
+                        + ((row_s % 32) // 16)
+                    )
+                    off_s = (row_s // 32).to(gl.int64) * stride_wsn + lin_s.to(
+                        gl.int64
+                    ) * stride_wsk
+                    s = gl.load(
+                        ws_base + off_s, mask=(sk < (I // 32)) & (n_cols_s < N), other=0
+                    )
+                    acc = gl.amd.cdna4.mfma_scaled(
+                        a=a,
+                        a_scale=a_scale,
+                        a_format="e4m3",
+                        b=b,
+                        b_scale=s,
+                        b_format="e2m1",
+                        acc=acc,
+                    )
+                acc = acc * gl.load(x_global_scale_ptr).to(gl.float32)
+                if HAS_BIAS:
+                    bias = gl.load(
+                        w2_bias + expert.to(gl.int64) * N + n_cols,
+                        mask=n_cols < N,
+                        other=0.0,
+                    ).to(gl.float32)
+                    acc += bias
+                acc_total += gate * acc
+    sm = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, mfma_layout))[:, None]
+    sn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout))[None, :]
+    col = pid_n * BLOCK_N + sn
+    gl.store(
+        Out
+        + pid_token.to(gl.int64) * stride_om
+        + col.to(gl.int64) * stride_on
+        + sm.to(gl.int64) * 0,
+        acc_total.to(Out.dtype.element_ty),
+        mask=(pid_token < M) & (sm == 0) & (col < N),
+    )
 
 
 def _route_small_m(logits, topk, dtype):

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
@@ -5541,18 +5541,21 @@ def _warp_decode_topk_stage1_fp8_mxfp4_kernel(
         acc_g = acc_g * x_scale
         acc_u = acc_u * x_scale
         if HAS_BIAS:
+            bias_n = pid_n * BLOCK_N + gl.arange(
+                0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout)
+            )
             bg = gl.load(
-                w13_bias + expert.to(gl.int64) * (2 * I) + n_gate,
-                mask=(token < M) & (n_gate < I),
+                w13_bias + expert.to(gl.int64) * (2 * I) + bias_n,
+                mask=(token < M) & (bias_n < I),
                 other=0.0,
             ).to(gl.float32)
             bu = gl.load(
-                w13_bias + expert.to(gl.int64) * (2 * I) + n_up,
-                mask=(token < M) & (n_gate < I),
+                w13_bias + expert.to(gl.int64) * (2 * I) + I + bias_n,
+                mask=(token < M) & (bias_n < I),
                 other=0.0,
             ).to(gl.float32)
-            acc_g += bg
-            acc_u += bu
+            acc_g = acc_g + bg[None, :]
+            acc_u = acc_u + bu[None, :]
         if SWIGLU_LIMIT > 0.0:
             acc_g = gl.minimum(acc_g, SWIGLU_LIMIT)
             acc_u = gl.clamp(acc_u, -SWIGLU_LIMIT, SWIGLU_LIMIT)
@@ -5736,18 +5739,21 @@ def _warp_decode_stage1_fp8_mxfp4_kernel(
     acc_g = acc_g * x_scale
     acc_u = acc_u * x_scale
     if HAS_BIAS:
+        bias_n = pid_n * BLOCK_N + gl.arange(
+            0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout)
+        )
         bg = gl.load(
-            w13_bias + expert.to(gl.int64) * (2 * I) + n_gate,
-            mask=(token < M) & (n_gate < I),
+            w13_bias + expert.to(gl.int64) * (2 * I) + bias_n,
+            mask=(token < M) & (bias_n < I),
             other=0.0,
         ).to(gl.float32)
         bu = gl.load(
-            w13_bias + expert.to(gl.int64) * (2 * I) + n_up,
-            mask=(token < M) & (n_gate < I),
+            w13_bias + expert.to(gl.int64) * (2 * I) + I + bias_n,
+            mask=(token < M) & (bias_n < I),
             other=0.0,
         ).to(gl.float32)
-        acc_g += bg
-        acc_u += bu
+        acc_g = acc_g + bg[None, :]
+        acc_u = acc_u + bu[None, :]
     if SWIGLU_LIMIT > 0.0:
         acc_g = gl.minimum(acc_g, SWIGLU_LIMIT)
         acc_u = gl.clamp(acc_u, -SWIGLU_LIMIT, SWIGLU_LIMIT)
@@ -5889,12 +5895,15 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
                     )
                 acc = acc * gl.load(x_global_scale_ptr).to(gl.float32)
                 if HAS_BIAS:
+                    bias_n = pid_n * BLOCK_N + gl.arange(
+                        0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout)
+                    )
                     bias = gl.load(
-                        w2_bias + expert.to(gl.int64) * N + n_cols,
-                        mask=n_cols < N,
+                        w2_bias + expert.to(gl.int64) * N + bias_n,
+                        mask=bias_n < N,
                         other=0.0,
                     ).to(gl.float32)
-                    acc += bias
+                    acc = acc + bias[None, :]
                 acc_total += gate * acc
     sm = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, mfma_layout))[:, None]
     sn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout))[None, :]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
@@ -4612,10 +4612,22 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         return None
     N = int(w2_raw.shape[2])
 
-    # Direct kernels consume dense top-k rather than ragged metadata.
-    topk_ids, topk_weights = _direct_topk_small_m(
-        router_logits, top_k, router_logits.dtype
-    )
+    fuse_topk_stage1 = os.environ.get(
+        "TOKENSPEED_MOE_GLUON_FUSE_TOPK_STAGE1", "0"
+    ).strip().lower() in {"1", "true", "yes", "on"}
+    if fuse_topk_stage1:
+        router_logits_c = router_logits.contiguous()
+        topk_ids = torch.empty(
+            (n_tokens, top_k), dtype=torch.int32, device=router_logits.device
+        )
+        topk_weights = torch.empty(
+            (n_tokens, top_k), dtype=router_logits.dtype, device=router_logits.device
+        )
+    else:
+        # Direct kernels consume dense top-k rather than ragged metadata.
+        topk_ids, topk_weights = _direct_topk_small_m(
+            router_logits, top_k, router_logits.dtype
+        )
 
     # Current GPT-OSS path uses FP8 E4M3 activations with per-tensor scale.
     from tokenspeed_kernel import quantize_fp8
@@ -4639,40 +4651,85 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
     BLOCK_K = 128
     BLOCK_N = 16
     M_DUP = 16
-    s1_grid = (n_tokens * top_k * ((I + BLOCK_N - 1) // BLOCK_N),)
-    _warp_decode_stage1_fp8_mxfp4_kernel[s1_grid](
-        x_u8,
-        w13_raw,
-        w13_scale,
-        topk_ids,
-        inter,
-        n_tokens,
-        D,
-        I,
-        top_k,
-        x_u8.stride(0),
-        x_u8.stride(1),
-        w13_raw.stride(0),
-        w13_raw.stride(-2),
-        w13_raw.stride(-1),
-        w13_scale.stride(0),
-        w13_scale.stride(-2),
-        w13_scale.stride(-1),
-        inter.stride(0),
-        inter.stride(1),
-        w13_act_scale,
-        w2_act_scale,
-        b13,
-        D_PACKED=D // 2,
-        TOPK=top_k,
-        BLOCK_K=BLOCK_K,
-        BLOCK_N=BLOCK_N,
-        M_DUP=M_DUP,
-        HAS_BIAS=w13_bias is not None,
-        SWIGLU_ALPHA=float(swiglu_alpha),
-        SWIGLU_LIMIT=float(swiglu_limit),
-        num_warps=1,
-    )
+    if fuse_topk_stage1:
+        s1_grid = (n_tokens * ((I + BLOCK_N - 1) // BLOCK_N),)
+        _warp_decode_topk_stage1_fp8_mxfp4_kernel[s1_grid](
+            x_u8,
+            router_logits_c,
+            w13_raw,
+            w13_scale,
+            topk_ids,
+            topk_weights,
+            inter,
+            n_tokens,
+            int(router_logits.shape[1]),
+            D,
+            I,
+            top_k,
+            x_u8.stride(0),
+            x_u8.stride(1),
+            router_logits_c.stride(0),
+            topk_ids.stride(0),
+            topk_weights.stride(0),
+            w13_raw.stride(0),
+            w13_raw.stride(-2),
+            w13_raw.stride(-1),
+            w13_scale.stride(0),
+            w13_scale.stride(-2),
+            w13_scale.stride(-1),
+            inter.stride(0),
+            inter.stride(1),
+            w13_act_scale,
+            w2_act_scale,
+            b13,
+            D_PACKED=D // 2,
+            TOPK=top_k,
+            EP=_route_next_pow2(int(router_logits.shape[1])),
+            TKP=_route_next_pow2(top_k),
+            X_DTYPE=_ROUTE_GL_DTYPE[router_logits.dtype],
+            BLOCK_K=BLOCK_K,
+            BLOCK_N=BLOCK_N,
+            M_DUP=M_DUP,
+            HAS_BIAS=w13_bias is not None,
+            SWIGLU_ALPHA=float(swiglu_alpha),
+            SWIGLU_LIMIT=float(swiglu_limit),
+            num_warps=1,
+        )
+    else:
+        s1_grid = (n_tokens * top_k * ((I + BLOCK_N - 1) // BLOCK_N),)
+        _warp_decode_stage1_fp8_mxfp4_kernel[s1_grid](
+            x_u8,
+            w13_raw,
+            w13_scale,
+            topk_ids,
+            inter,
+            n_tokens,
+            D,
+            I,
+            top_k,
+            x_u8.stride(0),
+            x_u8.stride(1),
+            w13_raw.stride(0),
+            w13_raw.stride(-2),
+            w13_raw.stride(-1),
+            w13_scale.stride(0),
+            w13_scale.stride(-2),
+            w13_scale.stride(-1),
+            inter.stride(0),
+            inter.stride(1),
+            w13_act_scale,
+            w2_act_scale,
+            b13,
+            D_PACKED=D // 2,
+            TOPK=top_k,
+            BLOCK_K=BLOCK_K,
+            BLOCK_N=BLOCK_N,
+            M_DUP=M_DUP,
+            HAS_BIAS=w13_bias is not None,
+            SWIGLU_ALPHA=float(swiglu_alpha),
+            SWIGLU_LIMIT=float(swiglu_limit),
+            num_warps=1,
+        )
 
     s2_grid = (n_tokens * ((N + BLOCK_N - 1) // BLOCK_N),)
     inter_u8 = inter.view(torch.uint8) if inter.dtype != torch.uint8 else inter
@@ -5276,6 +5333,240 @@ def _direct_topk_small_m(
         num_warps=nw,
     )
     return ids, weights
+
+
+@gluon.jit
+def _warp_decode_topk_stage1_fp8_mxfp4_kernel(
+    X,
+    Logits,
+    W,
+    WScale,
+    TopkIdsOut,
+    TopkWeightsOut,
+    Y,
+    M,
+    E,
+    D,
+    I,
+    TOPK_RUNTIME,
+    stride_xm,
+    stride_xk,
+    stride_lm,
+    stride_tim,
+    stride_twm,
+    stride_we,
+    stride_wk,
+    stride_wn,
+    stride_wse,
+    stride_wsk,
+    stride_wsn,
+    stride_ym,
+    stride_yn,
+    x_global_scale_ptr,
+    out_quant_scale_ptr,
+    w13_bias,
+    D_PACKED: gl.constexpr,
+    TOPK: gl.constexpr,
+    EP: gl.constexpr,
+    TKP: gl.constexpr,
+    X_DTYPE: gl.constexpr,
+    BLOCK_K: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    M_DUP: gl.constexpr,
+    HAS_BIAS: gl.constexpr,
+    SWIGLU_ALPHA: gl.constexpr,
+    SWIGLU_LIMIT: gl.constexpr,
+):
+    """Fused dense top-k + direct top-k stage1 for small-M warp decode."""
+    BLOCK_K_PACKED: gl.constexpr = BLOCK_K // 2
+    BLOCK_K_SCALE: gl.constexpr = BLOCK_K // 32
+    pid = gl.program_id(axis=0)
+    num_pid_n = gl.cdiv(I, BLOCK_N)
+    token = pid // num_pid_n
+    pid_n = pid % num_pid_n
+
+    # ---- direct top-k for this token (duplicated per N tile to save a launch) ----
+    LE: gl.constexpr = gl.BlockedLayout([1], [64], [1], [0])
+    LT: gl.constexpr = gl.BlockedLayout([1], [64], [1], [0])
+    e = gl.arange(0, EP, layout=LE)
+    emask = e < E
+    cur = gl.load(
+        Logits + token.to(gl.int64) * stride_lm + e,
+        mask=(token < M) & emask,
+        other=float("-inf"),
+    ).to(gl.float32)
+    t = gl.arange(0, TKP, layout=LT)
+    val_t = gl.full([TKP], -1e30, gl.float32, layout=LT)
+    idx_t = gl.zeros([TKP], gl.int32, layout=LT)
+    big = gl.full([EP], E, gl.int32, layout=LE)
+    for r in gl.static_range(TOPK):
+        vmax = gl.max(cur, axis=0)
+        ismax = (cur == vmax) & emask
+        amax = gl.min(gl.where(ismax, e, big), axis=0)
+        sel = t == r
+        val_t = gl.where(sel, vmax, val_t)
+        idx_t = gl.where(sel, amax, idx_t)
+        cur = gl.where(e == amax, float("-inf"), cur)
+    rmax = gl.max(val_t, axis=0)
+    num = gl.exp(val_t - rmax)
+    den = gl.sum(num, axis=0)
+    gate_t = gl.fdiv(num, den)
+    if pid_n == 0:
+        gl.store(
+            TopkIdsOut + token.to(gl.int64) * stride_tim + t,
+            idx_t,
+            mask=(token < M) & (t < TOPK_RUNTIME),
+        )
+        gl.store(
+            TopkWeightsOut + token.to(gl.int64) * stride_twm + t,
+            gate_t.to(TopkWeightsOut.dtype.element_ty),
+            mask=(token < M) & (t < TOPK_RUNTIME),
+        )
+
+    mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
+        version=4, instr_shape=[16, 16, 128], transposed=True, warps_per_cta=[1, 1]
+    )
+    dot_a_layout: gl.constexpr = gl.DotOperandLayout(
+        operand_index=0, parent=mfma_layout, k_width=16
+    )
+    dot_b_layout: gl.constexpr = gl.DotOperandLayout(
+        operand_index=1, parent=mfma_layout, k_width=16
+    )
+    a_scale_layout: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
+        dot_a_layout, [M_DUP, BLOCK_K_SCALE]
+    )
+    b_scale_layout: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
+        dot_b_layout, [BLOCK_N, BLOCK_K_SCALE]
+    )
+    am = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, dot_a_layout))[:, None]
+    ak = gl.arange(0, BLOCK_K, layout=gl.SliceLayout(0, dot_a_layout))[None, :]
+    bk = gl.arange(0, BLOCK_K_PACKED, layout=gl.SliceLayout(1, dot_b_layout))[:, None]
+    bn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, dot_b_layout))[None, :]
+    n_gate = pid_n * BLOCK_N + bn
+    n_up = I + n_gate
+    bsn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(1, b_scale_layout))[:, None]
+    bsk = gl.arange(0, BLOCK_K_SCALE, layout=gl.SliceLayout(0, b_scale_layout))[None, :]
+    n_gate_s = pid_n * BLOCK_N + bsn
+    n_up_s = I + n_gate_s
+    a_scale = gl.full((M_DUP, BLOCK_K_SCALE), 127, gl.uint8, layout=a_scale_layout)
+
+    for slot in gl.static_range(TOPK):
+        slot_sel = t == slot
+        expert = gl.sum(
+            gl.where(slot_sel, idx_t, gl.zeros([TKP], gl.int32, layout=LT)), axis=0
+        )
+        acc_g = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
+        acc_u = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
+        if (token < M) & (slot < TOPK_RUNTIME) & (expert >= 0):
+            w_base = W + expert.to(gl.int64) * stride_we
+            ws_base = WScale + expert.to(gl.int64) * stride_wse
+            for kt in range(gl.cdiv(D, BLOCK_K)):
+                k_elem = kt * BLOCK_K + ak
+                k_pack = kt * BLOCK_K_PACKED + bk
+                a = gl.load(
+                    X
+                    + token.to(gl.int64) * stride_xm
+                    + k_elem.to(gl.int64) * stride_xk
+                    + am.to(gl.int64) * 0,
+                    mask=k_elem < D,
+                    other=0.0,
+                )
+                b_g = gl.load(
+                    w_base
+                    + k_pack.to(gl.int64) * stride_wk
+                    + n_gate.to(gl.int64) * stride_wn,
+                    mask=(k_pack < D_PACKED) & (n_gate < I),
+                    other=0,
+                )
+                b_u = gl.load(
+                    w_base
+                    + k_pack.to(gl.int64) * stride_wk
+                    + n_up.to(gl.int64) * stride_wn,
+                    mask=(k_pack < D_PACKED) & (n_gate < I),
+                    other=0,
+                )
+                sg = kt * BLOCK_K_SCALE + bsk
+                row_g = n_gate_s.to(gl.uint32)
+                lin_g = (
+                    (sg // 8) * 128
+                    + (sg % 4) * 32
+                    + (row_g % 16) * 4
+                    + ((sg % 8) // 4) * 2
+                    + ((row_g % 32) // 16)
+                )
+                off_g = (row_g // 32).to(gl.int64) * stride_wsn + lin_g.to(
+                    gl.int64
+                ) * stride_wsk
+                row_u = n_up_s.to(gl.uint32)
+                lin_u = (
+                    (sg // 8) * 128
+                    + (sg % 4) * 32
+                    + (row_u % 16) * 4
+                    + ((sg % 8) // 4) * 2
+                    + ((row_u % 32) // 16)
+                )
+                off_u = (row_u // 32).to(gl.int64) * stride_wsn + lin_u.to(
+                    gl.int64
+                ) * stride_wsk
+                s_g = gl.load(
+                    ws_base + off_g, mask=(sg < (D // 32)) & (n_gate_s < I), other=0
+                )
+                s_u = gl.load(
+                    ws_base + off_u, mask=(sg < (D // 32)) & (n_gate_s < I), other=0
+                )
+                acc_g = gl.amd.cdna4.mfma_scaled(
+                    a=a,
+                    a_scale=a_scale,
+                    a_format="e4m3",
+                    b=b_g,
+                    b_scale=s_g,
+                    b_format="e2m1",
+                    acc=acc_g,
+                )
+                acc_u = gl.amd.cdna4.mfma_scaled(
+                    a=a,
+                    a_scale=a_scale,
+                    a_format="e4m3",
+                    b=b_u,
+                    b_scale=s_u,
+                    b_format="e2m1",
+                    acc=acc_u,
+                )
+        x_scale = gl.load(x_global_scale_ptr).to(gl.float32)
+        acc_g = acc_g * x_scale
+        acc_u = acc_u * x_scale
+        if HAS_BIAS:
+            bg = gl.load(
+                w13_bias + expert.to(gl.int64) * (2 * I) + n_gate,
+                mask=(token < M) & (n_gate < I),
+                other=0.0,
+            ).to(gl.float32)
+            bu = gl.load(
+                w13_bias + expert.to(gl.int64) * (2 * I) + n_up,
+                mask=(token < M) & (n_gate < I),
+                other=0.0,
+            ).to(gl.float32)
+            acc_g += bg
+            acc_u += bu
+        if SWIGLU_LIMIT > 0.0:
+            acc_g = gl.minimum(acc_g, SWIGLU_LIMIT)
+            acc_u = gl.clamp(acc_u, -SWIGLU_LIMIT, SWIGLU_LIMIT)
+        out_scale = gl.load(out_quant_scale_ptr).to(gl.float32)
+        out = (
+            (acc_g / (1.0 + gl.exp(-SWIGLU_ALPHA * acc_g))) * (acc_u + 1.0)
+        ) / out_scale
+        sm = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, mfma_layout))[:, None]
+        sn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout))[None, :]
+        col = pid_n * BLOCK_N + sn
+        row = token * TOPK_RUNTIME + slot
+        gl.store(
+            Y
+            + row.to(gl.int64) * stride_ym
+            + col.to(gl.int64) * stride_yn
+            + sm.to(gl.int64) * 0,
+            out.to(Y.dtype.element_ty),
+            mask=(token < M) & (sm == 0) & (col < I),
+        )
 
 
 @gluon.jit

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
@@ -4873,8 +4873,15 @@ def _gluon_mxfp_fused_moe(
 
     n_tokens = router_logits.shape[0]
 
+    # Warp-decode small-M MoE is the default on gfx950: it is the fastest path
+    # for the M<=16 decode regime and self-guards (returns None) for any shape
+    # it does not cover. Mirrors the other gluon moe kernels' opt-out switch:
+    # TOKENSPEED_MOE_GLUON_WARP_DECODE=0 (or the master TOKENSPEED_MOE_GLUON=0)
+    # disables it and falls back to the generic gluon/triton route.
     warp_decode_enabled = (
-        os.environ.get("TOKENSPEED_MOE_GLUON_WARP_DECODE", "0").strip().lower()
+        not _GLUON_DISABLED_ENV
+        and current_platform().is_cdna4
+        and os.environ.get("TOKENSPEED_MOE_GLUON_WARP_DECODE", "1").strip().lower()
         not in _GLUON_DISABLE_VALUES
     )
     if warp_decode_enabled:
@@ -4897,9 +4904,9 @@ def _gluon_mxfp_fused_moe(
             if warp_out is not None:
                 return warp_out
         except Exception as exc:  # noqa: BLE001
-            # Warp-decode is bring-up only: on a compile/launch failure for this
-            # shape, log once and fall back to the generic route. exc_info defers
-            # traceback formatting so it is skipped when WARNING is filtered out.
+            # On a compile/launch failure for this shape, log once and fall back
+            # to the generic gluon/triton route. exc_info defers traceback
+            # formatting so it is skipped when WARNING is filtered out.
             import logging
 
             logging.getLogger("tokenspeed_kernel.ops.moe.gluon").warning(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
@@ -4612,9 +4612,10 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         return None
     N = int(w2_raw.shape[2])
 
-    fuse_topk_stage1 = os.environ.get(
-        "TOKENSPEED_MOE_GLUON_FUSE_TOPK_STAGE1", "0"
-    ).strip().lower() in {"1", "true", "yes", "on"}
+    fuse_topk_stage1 = (
+        os.environ.get("TOKENSPEED_MOE_GLUON_FUSE_TOPK_STAGE1", "1").strip().lower()
+        not in _GLUON_DISABLE_VALUES
+    )
     if fuse_topk_stage1:
         router_logits_c = router_logits.contiguous()
         topk_ids = torch.empty(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
@@ -4652,10 +4652,12 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
     b2 = w2_bias if w2_bias is not None else dummy_bias
 
     BLOCK_K = 128
-    BLOCK_N = 16
-    M_DUP = 16
+    S1_BLOCK_N = 8 if n_tokens <= 4 else 16
+    S1_M_DUP = 8 if n_tokens <= 4 else 16
+    S2_BLOCK_N = 8 if n_tokens <= 1 else 16
+    S2_M_DUP = 4
     if fuse_topk_stage1:
-        s1_grid = (n_tokens * ((I + BLOCK_N - 1) // BLOCK_N),)
+        s1_grid = (n_tokens * ((I + S1_BLOCK_N - 1) // S1_BLOCK_N),)
         _warp_decode_topk_stage1_fp8_mxfp4_kernel[s1_grid](
             x_u8,
             router_logits_c,
@@ -4691,15 +4693,15 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
             TKP=_route_next_pow2(top_k),
             X_DTYPE=_ROUTE_GL_DTYPE[router_logits.dtype],
             BLOCK_K=BLOCK_K,
-            BLOCK_N=BLOCK_N,
-            M_DUP=M_DUP,
+            BLOCK_N=S1_BLOCK_N,
+            M_DUP=S1_M_DUP,
             HAS_BIAS=w13_bias is not None,
             SWIGLU_ALPHA=float(swiglu_alpha),
             SWIGLU_LIMIT=float(swiglu_limit),
             num_warps=1,
         )
     else:
-        s1_grid = (n_tokens * top_k * ((I + BLOCK_N - 1) // BLOCK_N),)
+        s1_grid = (n_tokens * top_k * ((I + S1_BLOCK_N - 1) // S1_BLOCK_N),)
         _warp_decode_stage1_fp8_mxfp4_kernel[s1_grid](
             x_u8,
             w13_raw,
@@ -4726,15 +4728,15 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
             D_PACKED=D // 2,
             TOPK=top_k,
             BLOCK_K=BLOCK_K,
-            BLOCK_N=BLOCK_N,
-            M_DUP=M_DUP,
+            BLOCK_N=S1_BLOCK_N,
+            M_DUP=S1_M_DUP,
             HAS_BIAS=w13_bias is not None,
             SWIGLU_ALPHA=float(swiglu_alpha),
             SWIGLU_LIMIT=float(swiglu_limit),
             num_warps=1,
         )
 
-    s2_grid = (n_tokens * ((N + BLOCK_N - 1) // BLOCK_N),)
+    s2_grid = (n_tokens * ((N + S2_BLOCK_N - 1) // S2_BLOCK_N),)
     inter_u8 = inter
     _warp_decode_stage2_fp8_mxfp4_kernel[s2_grid](
         inter_u8,
@@ -4762,8 +4764,8 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         I_PACKED=I // 2,
         TOPK=top_k,
         BLOCK_K=BLOCK_K,
-        BLOCK_N=BLOCK_N,
-        M_DUP=M_DUP,
+        BLOCK_N=S2_BLOCK_N,
+        M_DUP=S2_M_DUP,
         HAS_BIAS=w2_bias is not None,
         num_warps=1,
     )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
@@ -70,6 +70,9 @@ _GLUON_DISABLED_ENV = (
     os.environ.get("TOKENSPEED_MOE_GLUON", "").strip().lower() in _GLUON_DISABLE_VALUES
 )
 
+# Stage2 split-K factor (applied across the whole small-M decode path).
+_WARP_DECODE_S2_SPLIT_K = 4
+
 
 def _as_int32(t):
     if t is None or t.dtype == torch.int32:
@@ -4688,14 +4691,30 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         num_warps=1,
     )
 
-    s2_grid = (n_tokens * ((N + S2_BLOCK_N - 1) // S2_BLOCK_N),)
+    n_tiles2 = (N + S2_BLOCK_N - 1) // S2_BLOCK_N
+    s2_split_k = _WARP_DECODE_S2_SPLIT_K
+    if s2_split_k > 1:
+        out_partial = torch.empty(
+            (s2_split_k, n_tokens, N), dtype=torch.float32, device=hidden_states.device
+        )
+        s2_dst = out_partial
+        s2_stride_om = out_partial.stride(1)
+        s2_stride_on = out_partial.stride(2)
+        s2_stride_ok = out_partial.stride(0)
+        s2_grid = (n_tokens * n_tiles2 * s2_split_k,)
+    else:
+        s2_dst = out
+        s2_stride_om = out.stride(0)
+        s2_stride_on = out.stride(1)
+        s2_stride_ok = 0
+        s2_grid = (n_tokens * n_tiles2,)
     _warp_decode_stage2_fp8_mxfp4_kernel[s2_grid](
         inter,
         w2_raw,
         w2_scale,
         topk_ids,
         topk_weights,
-        out,
+        s2_dst,
         n_tokens,
         N,
         I,
@@ -4707,8 +4726,9 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         w2_scale.stride(0),
         w2_scale.stride(-2),
         w2_scale.stride(-1),
-        out.stride(0),
-        out.stride(1),
+        s2_stride_om,
+        s2_stride_on,
+        s2_stride_ok,
         w2_act_scale,
         b2,
         I_PACKED=I // 2,
@@ -4717,8 +4737,26 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         BLOCK_N=S2_BLOCK_N,
         M_DUP=S2_M_DUP,
         HAS_BIAS=w2_bias is not None,
+        SPLIT_K=s2_split_k,
         num_warps=1,
     )
+    if s2_split_k > 1:
+        R_BLOCK_N = 256
+        r_grid = (n_tokens * ((N + R_BLOCK_N - 1) // R_BLOCK_N),)
+        _warp_decode_stage2_reduce[r_grid](
+            out_partial,
+            out,
+            n_tokens,
+            N,
+            out_partial.stride(0),
+            out_partial.stride(1),
+            out_partial.stride(2),
+            out.stride(0),
+            out.stride(1),
+            SPLIT_K=s2_split_k,
+            BLOCK_N=R_BLOCK_N,
+            num_warps=1,
+        )
     return out
 
 
@@ -5547,6 +5585,7 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
     stride_wsn,
     stride_om,
     stride_on,
+    stride_ok,
     x_global_scale_ptr,
     w2_bias,
     I_PACKED: gl.constexpr,
@@ -5555,13 +5594,32 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
     BLOCK_N: gl.constexpr,
     M_DUP: gl.constexpr,
     HAS_BIAS: gl.constexpr,
+    SPLIT_K: gl.constexpr,
 ):
-    """Direct top-k stage2: FP8 intermediate x MXFP4 W2 -> BF16 output."""
+    """Direct top-k stage2: FP8 intermediate x MXFP4 W2 -> BF16 output.
+
+    With SPLIT_K > 1 the K (intermediate) reduction is partitioned across
+    SPLIT_K CTAs per output tile; each writes an fp32 partial into slice
+    ``pid_k`` of the destination, reduced by ``_warp_decode_stage2_reduce``.
+    Bias is added only by the first slice so it is not counted SPLIT_K times.
+    """
     BLOCK_K_PACKED: gl.constexpr = BLOCK_K // 2
     BLOCK_K_SCALE: gl.constexpr = BLOCK_K // 32
     pid = gl.program_id(axis=0)
-    pid_token = pid // gl.cdiv(N, BLOCK_N)
-    pid_n = pid % gl.cdiv(N, BLOCK_N)
+    num_n = gl.cdiv(N, BLOCK_N)
+    if SPLIT_K == 1:
+        pid_k = 0
+        pid_token = pid // num_n
+        pid_n = pid % num_n
+    else:
+        per_k = M * num_n
+        pid_k = pid // per_k
+        rem = pid % per_k
+        pid_token = rem // num_n
+        pid_n = rem % num_n
+    num_kt = gl.cdiv(I, BLOCK_K)
+    kt_per = gl.cdiv(num_kt, SPLIT_K)
+    kt_start = pid_k * kt_per
     _layouts: gl.constexpr = _warp_decode_mfma_layouts(M_DUP, BLOCK_N, BLOCK_K_SCALE)
     mfma_layout: gl.constexpr = _layouts[0]
     dot_a_layout: gl.constexpr = _layouts[1]
@@ -5592,7 +5650,7 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
                 w_base = W + expert.to(gl.int64) * stride_we
                 ws_base = WScale + expert.to(gl.int64) * stride_wse
                 acc = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
-                for kt in range(gl.cdiv(I, BLOCK_K)):
+                for kt in range(kt_start, kt_start + kt_per):
                     k_elem = kt * BLOCK_K + ak
                     k_pack = kt * BLOCK_K_PACKED + bk
                     a = gl.load(
@@ -5633,20 +5691,68 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
                         0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout)
                     )
                     w2_base = w2_bias + expert.to(gl.int64) * N
+                    if SPLIT_K == 1:
+                        bias_bound = bias_n < N
+                    else:
+                        bias_bound = (bias_n < N) & (pid_k == 0)
                     acc = _add_expert_bias(
-                        acc, w2_base, bias_n, bias_n < N, mfma_layout
+                        acc, w2_base, bias_n, bias_bound, mfma_layout
                     )
                 acc_total += gate * acc
     sm = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, mfma_layout))[:, None]
     sn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout))[None, :]
     col = pid_n * BLOCK_N + sn
-    gl.store(
+    out_base = (
         Out
         + pid_token.to(gl.int64) * stride_om
         + col.to(gl.int64) * stride_on
-        + sm.to(gl.int64) * 0,
+        + sm.to(gl.int64) * 0
+    )
+    if SPLIT_K > 1:
+        out_base = out_base + pid_k.to(gl.int64) * stride_ok
+    gl.store(
+        out_base,
         acc_total.to(Out.dtype.element_ty),
         mask=(pid_token < M) & (sm == 0) & (col < N),
+    )
+
+
+@gluon.jit
+def _warp_decode_stage2_reduce(
+    Partial,
+    Out,
+    M,
+    N,
+    stride_pk,
+    stride_pm,
+    stride_pn,
+    stride_om,
+    stride_on,
+    SPLIT_K: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+):
+    """Sum the SPLIT_K stage2 partials into the bf16 output in one launch."""
+    pid = gl.program_id(axis=0)
+    num_n = gl.cdiv(N, BLOCK_N)
+    pid_m = pid // num_n
+    pid_n = pid % num_n
+    LAYOUT: gl.constexpr = gl.BlockedLayout([4], [64], [1], [0])
+    n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=LAYOUT)
+    bound = (pid_m < M) & (n < N)
+    acc = gl.zeros([BLOCK_N], gl.float32, layout=LAYOUT)
+    for k in gl.static_range(SPLIT_K):
+        acc += gl.load(
+            Partial
+            + k * stride_pk
+            + pid_m.to(gl.int64) * stride_pm
+            + n.to(gl.int64) * stride_pn,
+            mask=bound,
+            other=0.0,
+        )
+    gl.store(
+        Out + pid_m.to(gl.int64) * stride_om + n.to(gl.int64) * stride_on,
+        acc.to(Out.dtype.element_ty),
+        mask=bound,
     )
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
@@ -4605,22 +4605,14 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         return None
     N = int(w2_raw.shape[2])
 
-    # Fused top-k stage1 is the default warp-decode path; the non-fused path is
-    # kept as a fallback below and removed in a follow-up.
-    fuse_topk_stage1 = True
-    if fuse_topk_stage1:
-        router_logits_c = router_logits.contiguous()
-        topk_ids = torch.empty(
-            (n_tokens, top_k), dtype=torch.int32, device=router_logits.device
-        )
-        topk_weights = torch.empty(
-            (n_tokens, top_k), dtype=router_logits.dtype, device=router_logits.device
-        )
-    else:
-        # Direct kernels consume dense top-k rather than ragged metadata.
-        topk_ids, topk_weights = _direct_topk_small_m(
-            router_logits, top_k, router_logits.dtype
-        )
+    # Stage1 computes the dense top-k inside the kernel; allocate its outputs.
+    router_logits_c = router_logits.contiguous()
+    topk_ids = torch.empty(
+        (n_tokens, top_k), dtype=torch.int32, device=router_logits.device
+    )
+    topk_weights = torch.empty(
+        (n_tokens, top_k), dtype=router_logits.dtype, device=router_logits.device
+    )
 
     fp8_dtype = (
         getattr(
@@ -4670,85 +4662,49 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
     S1_M_DUP = 8 if n_tokens <= 4 else 16
     S2_BLOCK_N = 8 if n_tokens <= 1 else 16
     S2_M_DUP = 4
-    if fuse_topk_stage1:
-        s1_grid = (n_tokens * ((I + S1_BLOCK_N - 1) // S1_BLOCK_N),)
-        _warp_decode_topk_stage1_fp8_mxfp4_kernel[s1_grid](
-            x_fp8,
-            router_logits_c,
-            w13_raw,
-            w13_scale,
-            topk_ids,
-            topk_weights,
-            inter,
-            n_tokens,
-            n_experts,
-            D,
-            I,
-            x_fp8.stride(0),
-            x_fp8.stride(1),
-            router_logits_c.stride(0),
-            topk_ids.stride(0),
-            topk_weights.stride(0),
-            w13_raw.stride(0),
-            w13_raw.stride(-2),
-            w13_raw.stride(-1),
-            w13_scale.stride(0),
-            w13_scale.stride(-2),
-            w13_scale.stride(-1),
-            inter.stride(0),
-            inter.stride(1),
-            w13_act_scale,
-            w2_act_scale,
-            b13,
-            D_PACKED=D // 2,
-            TOPK=top_k,
-            EP=_route_next_pow2(n_experts),
-            TKP=_route_next_pow2(top_k),
-            X_DTYPE=_ROUTE_GL_DTYPE[router_logits.dtype],
-            BLOCK_K=BLOCK_K,
-            BLOCK_N=S1_BLOCK_N,
-            M_DUP=S1_M_DUP,
-            QUANTIZE_X=quantize_x,
-            HAS_BIAS=w13_bias is not None,
-            SWIGLU_ALPHA=float(swiglu_alpha),
-            SWIGLU_LIMIT=float(swiglu_limit),
-            num_warps=1,
-        )
-    else:
-        s1_grid = (n_tokens * top_k * ((I + S1_BLOCK_N - 1) // S1_BLOCK_N),)
-        _warp_decode_stage1_fp8_mxfp4_kernel[s1_grid](
-            x_fp8,
-            w13_raw,
-            w13_scale,
-            topk_ids,
-            inter,
-            n_tokens,
-            D,
-            I,
-            x_fp8.stride(0),
-            x_fp8.stride(1),
-            w13_raw.stride(0),
-            w13_raw.stride(-2),
-            w13_raw.stride(-1),
-            w13_scale.stride(0),
-            w13_scale.stride(-2),
-            w13_scale.stride(-1),
-            inter.stride(0),
-            inter.stride(1),
-            w13_act_scale,
-            w2_act_scale,
-            b13,
-            D_PACKED=D // 2,
-            TOPK=top_k,
-            BLOCK_K=BLOCK_K,
-            BLOCK_N=S1_BLOCK_N,
-            M_DUP=S1_M_DUP,
-            QUANTIZE_X=quantize_x,
-            HAS_BIAS=w13_bias is not None,
-            SWIGLU_ALPHA=float(swiglu_alpha),
-            SWIGLU_LIMIT=float(swiglu_limit),
-            num_warps=1,
-        )
+    s1_grid = (n_tokens * ((I + S1_BLOCK_N - 1) // S1_BLOCK_N),)
+    _warp_decode_topk_stage1_fp8_mxfp4_kernel[s1_grid](
+        x_fp8,
+        router_logits_c,
+        w13_raw,
+        w13_scale,
+        topk_ids,
+        topk_weights,
+        inter,
+        n_tokens,
+        n_experts,
+        D,
+        I,
+        x_fp8.stride(0),
+        x_fp8.stride(1),
+        router_logits_c.stride(0),
+        topk_ids.stride(0),
+        topk_weights.stride(0),
+        w13_raw.stride(0),
+        w13_raw.stride(-2),
+        w13_raw.stride(-1),
+        w13_scale.stride(0),
+        w13_scale.stride(-2),
+        w13_scale.stride(-1),
+        inter.stride(0),
+        inter.stride(1),
+        w13_act_scale,
+        w2_act_scale,
+        b13,
+        D_PACKED=D // 2,
+        TOPK=top_k,
+        EP=_route_next_pow2(n_experts),
+        TKP=_route_next_pow2(top_k),
+        X_DTYPE=_ROUTE_GL_DTYPE[router_logits.dtype],
+        BLOCK_K=BLOCK_K,
+        BLOCK_N=S1_BLOCK_N,
+        M_DUP=S1_M_DUP,
+        QUANTIZE_X=quantize_x,
+        HAS_BIAS=w13_bias is not None,
+        SWIGLU_ALPHA=float(swiglu_alpha),
+        SWIGLU_LIMIT=float(swiglu_limit),
+        num_warps=1,
+    )
 
     s2_grid = (n_tokens * ((N + S2_BLOCK_N - 1) // S2_BLOCK_N),)
     _warp_decode_stage2_fp8_mxfp4_kernel[s2_grid](
@@ -5263,94 +5219,6 @@ def _route_next_pow2(x: int) -> int:
 
 
 @gluon.jit
-def _direct_topk_small_m_kernel(
-    Logits,
-    TopkIds,
-    TopkWeights,
-    stride_lm,
-    stride_im,
-    stride_wm,
-    M: gl.constexpr,
-    E: gl.constexpr,
-    TOPK: gl.constexpr,
-    MP: gl.constexpr,
-    GP: gl.constexpr,
-    EP: gl.constexpr,
-    TKP: gl.constexpr,
-    X_DTYPE: gl.constexpr,
-    NW_C: gl.constexpr,
-):
-    """Small-M direct top-k output for warp-decode kernels.
-
-    This reuses the same in-kernel top-k/softmax implementation as the fused
-    routing path, but stores dense token-major ``topk_ids`` and ``topk_weights``
-    instead of ragged metadata.
-    """
-    LG: gl.constexpr = gl.BlockedLayout([1], [64], [NW_C], [0])
-    LT: gl.constexpr = gl.BlockedLayout([1, 1], [1, 64], [NW_C, 1], [1, 0])
-    g = gl.arange(0, GP, layout=LG)
-    gmask = g < (M * TOPK)
-    tok = (g // TOPK).to(gl.int32)
-    slot = (g % TOPK).to(gl.int32)
-    idx, vals = _fused_topk(
-        Logits,
-        stride_lm,
-        gmask,
-        tok,
-        slot,
-        M,
-        E,
-        TOPK,
-        MP,
-        EP,
-        GP,
-        TKP,
-        X_DTYPE,
-        LG,
-        LT,
-    )
-    gl.store(TopkIds + tok * stride_im + slot, idx, mask=gmask)
-    gl.store(TopkWeights + tok * stride_wm + slot, vals, mask=gmask)
-
-
-def _direct_topk_small_m(
-    logits: torch.Tensor, topk: int, dtype: torch.dtype | None = None
-):
-    """Return dense ``(topk_ids, topk_weights)`` for small-M warp decode."""
-    if dtype is None:
-        dtype = logits.dtype
-    M, E = logits.shape
-    if M > SMALLM_MAX_M:
-        raise ValueError(f"_direct_topk_small_m requires M <= {SMALLM_MAX_M}; got {M}")
-    if not gluon_route_supported(logits, topk, dtype):
-        raise ValueError("_direct_topk_small_m received unsupported logits/topk/dtype")
-    logits = logits.contiguous()
-    ids = torch.empty((M, topk), dtype=torch.int32, device=logits.device)
-    weights = torch.empty((M, topk), dtype=dtype, device=logits.device)
-    G = M * topk
-    nw = 1 if M <= 2 else 4
-    _direct_topk_small_m_kernel[(1,)](
-        logits,
-        ids,
-        weights,
-        logits.stride(0),
-        ids.stride(0),
-        weights.stride(0),
-        M=M,
-        E=E,
-        TOPK=topk,
-        MP=_route_next_pow2(M),
-        GP=_route_next_pow2(G),
-        EP=_route_next_pow2(E),
-        TKP=_route_next_pow2(topk),
-        X_DTYPE=_ROUTE_GL_DTYPE[dtype],
-        NW_C=nw,
-        num_warps=nw,
-    )
-    return ids, weights
-
-
-@gluon.jit
 def _add_expert_bias(acc, bias_base, col, bound, mfma_layout: gl.constexpr):
     """Broadcast-add a per-expert column bias into an MFMA accumulator.
 
@@ -5680,84 +5548,6 @@ def _warp_decode_topk_stage1_fp8_mxfp4_kernel(
             SWIGLU_ALPHA,
             SWIGLU_LIMIT,
         )
-
-
-@gluon.jit
-def _warp_decode_stage1_fp8_mxfp4_kernel(
-    X,
-    W,
-    WScale,
-    TopkIds,
-    Y,
-    M,
-    D,
-    I,
-    stride_xm,
-    stride_xk,
-    stride_we,
-    stride_wk,
-    stride_wn,
-    stride_wse,
-    stride_wsk,
-    stride_wsn,
-    stride_ym,
-    stride_yn,
-    x_global_scale_ptr,
-    out_quant_scale_ptr,
-    w13_bias,
-    D_PACKED: gl.constexpr,
-    TOPK: gl.constexpr,
-    BLOCK_K: gl.constexpr,
-    BLOCK_N: gl.constexpr,
-    M_DUP: gl.constexpr,
-    QUANTIZE_X: gl.constexpr,
-    HAS_BIAS: gl.constexpr,
-    SWIGLU_ALPHA: gl.constexpr,
-    SWIGLU_LIMIT: gl.constexpr,
-):
-    """Direct top-k stage1: FP8 hidden x MXFP4 W13 -> FP8 intermediate."""
-    pid = gl.program_id(axis=0)
-    num_pid_n = gl.cdiv(I, BLOCK_N)
-    pid_ts = pid // num_pid_n
-    pid_n = pid % num_pid_n
-    token = pid_ts // TOPK
-    slot = pid_ts % TOPK
-    expert = gl.load(TopkIds + token * TOPK + slot, mask=token < M, other=-1)
-    _warp_decode_stage1_compute(
-        token,
-        slot,
-        expert,
-        pid_n,
-        X,
-        W,
-        WScale,
-        Y,
-        M,
-        D,
-        I,
-        stride_xm,
-        stride_xk,
-        stride_we,
-        stride_wk,
-        stride_wn,
-        stride_wse,
-        stride_wsk,
-        stride_wsn,
-        stride_ym,
-        stride_yn,
-        x_global_scale_ptr,
-        out_quant_scale_ptr,
-        w13_bias,
-        D_PACKED,
-        TOPK,
-        BLOCK_K,
-        BLOCK_N,
-        M_DUP,
-        QUANTIZE_X,
-        HAS_BIAS,
-        SWIGLU_ALPHA,
-        SWIGLU_LIMIT,
-    )
 
 
 @gluon.jit

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
@@ -5554,6 +5554,8 @@ def _warp_decode_topk_stage1_fp8_mxfp4_kernel(
                 mask=(token < M) & (bias_n < I),
                 other=0.0,
             ).to(gl.float32)
+            bg = gl.convert_layout(bg, gl.SliceLayout(0, mfma_layout))
+            bu = gl.convert_layout(bu, gl.SliceLayout(0, mfma_layout))
             acc_g = acc_g + bg[None, :]
             acc_u = acc_u + bu[None, :]
         if SWIGLU_LIMIT > 0.0:
@@ -5752,6 +5754,8 @@ def _warp_decode_stage1_fp8_mxfp4_kernel(
             mask=(token < M) & (bias_n < I),
             other=0.0,
         ).to(gl.float32)
+        bg = gl.convert_layout(bg, gl.SliceLayout(0, mfma_layout))
+        bu = gl.convert_layout(bu, gl.SliceLayout(0, mfma_layout))
         acc_g = acc_g + bg[None, :]
         acc_u = acc_u + bu[None, :]
     if SWIGLU_LIMIT > 0.0:
@@ -5903,6 +5907,7 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
                         mask=bias_n < N,
                         other=0.0,
                     ).to(gl.float32)
+                    bias = gl.convert_layout(bias, gl.SliceLayout(0, mfma_layout))
                     acc = acc + bias[None, :]
                 acc_total += gate * acc
     sm = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, mfma_layout))[:, None]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
@@ -4550,15 +4550,6 @@ def _gluon_mxfp_ragged_matmul(
     return
 
 
-def _direct_raw_weight_for_warp_decode(w):
-    """Return raw (E, K_packed, N) storage for direct warp-decode kernels."""
-    if isinstance(w, torch.Tensor):
-        return w
-    if isinstance(w, Tensor):
-        return w.storage.data
-    return w
-
-
 def _gluon_mxfp4_fp8_warp_decode_moe(
     hidden_states: torch.Tensor,
     router_logits: torch.Tensor,
@@ -4579,6 +4570,7 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
     if hidden_states.ndim != 2 or router_logits.ndim != 2:
         return None
     n_tokens = int(router_logits.shape[0])
+    n_experts = int(router_logits.shape[1])
     if n_tokens > SMALLM_MAX_M:
         return None
     if not gluon_route_supported(router_logits, top_k, router_logits.dtype):
@@ -4586,8 +4578,9 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
     if w13_precision_config is None or w2_precision_config is None:
         return None
 
-    w13_raw = _direct_raw_weight_for_warp_decode(w13_weight)
-    w2_raw = _direct_raw_weight_for_warp_decode(w2_weight)
+    # Both weights and scales unwrap to their raw uint8 storage the same way.
+    w13_raw = _extract_gluon_raw_s(w13_weight)
+    w2_raw = _extract_gluon_raw_s(w2_weight)
     w13_scale = _extract_gluon_raw_s(getattr(w13_precision_config, "b_mx_scale", None))
     w2_scale = _extract_gluon_raw_s(getattr(w2_precision_config, "b_mx_scale", None))
     if not all(
@@ -4656,7 +4649,6 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         quantize_x = False
     # Pass FP8 tensors directly to Gluon.  ``view(torch.uint8)`` materializes a
     # copy for float8 tensors on this stack and dominates small-M latency.
-    x_u8 = x_fp8
 
     inter = torch.empty(
         (n_tokens * top_k, I), dtype=fp8_dtype, device=hidden_states.device
@@ -4664,7 +4656,13 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
     out_dtype = getattr(w2_precision_config, "out_dtype", None) or torch.bfloat16
     out = torch.empty((n_tokens, N), dtype=out_dtype, device=hidden_states.device)
 
-    dummy_bias = _make_dummy(hidden_states.device, torch.float32, 1)
+    # The kernels only read the bias pointer when HAS_BIAS; allocate the
+    # placeholder solely for the absent ones.
+    dummy_bias = (
+        _make_dummy(hidden_states.device, torch.float32, 1)
+        if (w13_bias is None or w2_bias is None)
+        else None
+    )
     b13 = w13_bias if w13_bias is not None else dummy_bias
     b2 = w2_bias if w2_bias is not None else dummy_bias
 
@@ -4676,7 +4674,7 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
     if fuse_topk_stage1:
         s1_grid = (n_tokens * ((I + S1_BLOCK_N - 1) // S1_BLOCK_N),)
         _warp_decode_topk_stage1_fp8_mxfp4_kernel[s1_grid](
-            x_u8,
+            x_fp8,
             router_logits_c,
             w13_raw,
             w13_scale,
@@ -4684,12 +4682,11 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
             topk_weights,
             inter,
             n_tokens,
-            int(router_logits.shape[1]),
+            n_experts,
             D,
             I,
-            top_k,
-            x_u8.stride(0),
-            x_u8.stride(1),
+            x_fp8.stride(0),
+            x_fp8.stride(1),
             router_logits_c.stride(0),
             topk_ids.stride(0),
             topk_weights.stride(0),
@@ -4706,7 +4703,7 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
             b13,
             D_PACKED=D // 2,
             TOPK=top_k,
-            EP=_route_next_pow2(int(router_logits.shape[1])),
+            EP=_route_next_pow2(n_experts),
             TKP=_route_next_pow2(top_k),
             X_DTYPE=_ROUTE_GL_DTYPE[router_logits.dtype],
             BLOCK_K=BLOCK_K,
@@ -4721,7 +4718,7 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
     else:
         s1_grid = (n_tokens * top_k * ((I + S1_BLOCK_N - 1) // S1_BLOCK_N),)
         _warp_decode_stage1_fp8_mxfp4_kernel[s1_grid](
-            x_u8,
+            x_fp8,
             w13_raw,
             w13_scale,
             topk_ids,
@@ -4729,9 +4726,8 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
             n_tokens,
             D,
             I,
-            top_k,
-            x_u8.stride(0),
-            x_u8.stride(1),
+            x_fp8.stride(0),
+            x_fp8.stride(1),
             w13_raw.stride(0),
             w13_raw.stride(-2),
             w13_raw.stride(-1),
@@ -4756,9 +4752,8 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         )
 
     s2_grid = (n_tokens * ((N + S2_BLOCK_N - 1) // S2_BLOCK_N),)
-    inter_u8 = inter
     _warp_decode_stage2_fp8_mxfp4_kernel[s2_grid](
-        inter_u8,
+        inter,
         w2_raw,
         w2_scale,
         topk_ids,
@@ -4767,9 +4762,8 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         n_tokens,
         N,
         I,
-        top_k,
-        inter_u8.stride(0),
-        inter_u8.stride(1),
+        inter.stride(0),
+        inter.stride(1),
         w2_raw.stride(0),
         w2_raw.stride(-2),
         w2_raw.stride(-1),
@@ -4879,12 +4873,11 @@ def _gluon_mxfp_fused_moe(
 
     n_tokens = router_logits.shape[0]
 
-    if os.environ.get("TOKENSPEED_MOE_GLUON_WARP_DECODE", "0").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }:
+    warp_decode_enabled = (
+        os.environ.get("TOKENSPEED_MOE_GLUON_WARP_DECODE", "0").strip().lower()
+        not in _GLUON_DISABLE_VALUES
+    )
+    if warp_decode_enabled:
         try:
             warp_out = _gluon_mxfp4_fp8_warp_decode_moe(
                 hidden_states,
@@ -4904,18 +4897,16 @@ def _gluon_mxfp_fused_moe(
             if warp_out is not None:
                 return warp_out
         except Exception as exc:  # noqa: BLE001
+            # Warp-decode is bring-up only: on a compile/launch failure for this
+            # shape, log once and fall back to the generic route. exc_info defers
+            # traceback formatting so it is skipped when WARNING is filtered out.
             import logging
-            import traceback
 
-            logger = logging.getLogger("tokenspeed_kernel.ops.moe.gluon")
-            logger.warning(
+            logging.getLogger("tokenspeed_kernel.ops.moe.gluon").warning(
                 "warp-decode small-M path falling back: %s: %s",
                 type(exc).__name__,
                 exc,
-            )
-            logger.warning(
-                "  full chain:\n%s",
-                "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+                exc_info=exc,
             )
 
     # Decode-small GPT-OSS routing is launch-overhead dominated.  Prefer the
@@ -5360,6 +5351,210 @@ def _direct_topk_small_m(
 
 
 @gluon.jit
+def _add_expert_bias(acc, bias_base, col, bound, mfma_layout: gl.constexpr):
+    """Broadcast-add a per-expert column bias into an MFMA accumulator.
+
+    The bias is loaded along N then converted into the accumulator's column
+    slice layout, which keeps the broadcast-add convert-compatible with acc.
+    """
+    b = gl.load(bias_base + col, mask=bound, other=0.0).to(gl.float32)
+    b = gl.convert_layout(b, gl.SliceLayout(0, mfma_layout))
+    return acc + b[None, :]
+
+
+@gluon.constexpr_function
+def _warp_decode_mfma_layouts(m_dup, block_n, block_k_scale):
+    """MFMA + dot-operand + e8m0 scale layouts shared by the warp-decode kernels.
+
+    get_mfma_layout is not reused: it asserts num_warps in (4, 8), whereas warp
+    decode runs a single warp ([1, 1] warps_per_cta).
+    """
+    mfma = gl.amd.AMDMFMALayout(
+        version=4, instr_shape=[16, 16, 128], transposed=True, warps_per_cta=[1, 1]
+    )
+    dot_a = gl.DotOperandLayout(operand_index=0, parent=mfma, k_width=16)
+    dot_b = gl.DotOperandLayout(operand_index=1, parent=mfma, k_width=16)
+    a_scale = gl.amd.cdna4.get_mfma_scale_layout(dot_a, [m_dup, block_k_scale])
+    b_scale = gl.amd.cdna4.get_mfma_scale_layout(dot_b, [block_n, block_k_scale])
+    return mfma, dot_a, dot_b, a_scale, b_scale
+
+
+@gluon.jit
+def _mxfp4_scale_offset(n_idx, k_scale_idx, stride_wsk, stride_wsn):
+    """Byte offset into a CDNA4-swizzled MXFP4 scale tensor.
+
+    Storage is (..., K_SCALE_PAD*32, N_PAD/32); the swizzle packs the 32-wide N
+    block and the K-scale position into one linear axis.
+    """
+    row = n_idx.to(gl.uint32)
+    lin = (
+        (k_scale_idx // 8) * 128
+        + (k_scale_idx % 4) * 32
+        + (row % 16) * 4
+        + ((k_scale_idx % 8) // 4) * 2
+        + ((row % 32) // 16)
+    )
+    return (row // 32).to(gl.int64) * stride_wsn + lin.to(gl.int64) * stride_wsk
+
+
+@gluon.jit
+def _swiglu_gate_up(gate, linear, alpha: gl.constexpr, limit: gl.constexpr):
+    """SwiGLU on separate gate/up MFMA accumulators (pre-split form)."""
+    if limit > 0.0:
+        gate = gl.minimum(gate, limit)
+        linear = gl.clamp(linear, -limit, limit)
+    return (gate / (1.0 + gl.exp(-alpha * gate))) * (linear + 1.0)
+
+
+@gluon.jit
+def _warp_decode_stage1_compute(
+    token,
+    slot,
+    expert,
+    pid_n,
+    X,
+    W,
+    WScale,
+    Y,
+    M,
+    D,
+    I,
+    stride_xm,
+    stride_xk,
+    stride_we,
+    stride_wk,
+    stride_wn,
+    stride_wse,
+    stride_wsk,
+    stride_wsn,
+    stride_ym,
+    stride_yn,
+    x_global_scale_ptr,
+    out_quant_scale_ptr,
+    w13_bias,
+    D_PACKED: gl.constexpr,
+    TOPK: gl.constexpr,
+    BLOCK_K: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    M_DUP: gl.constexpr,
+    QUANTIZE_X: gl.constexpr,
+    HAS_BIAS: gl.constexpr,
+    SWIGLU_ALPHA: gl.constexpr,
+    SWIGLU_LIMIT: gl.constexpr,
+):
+    """Gate/up MFMA + bias + SwiGLU + store for one (token, slot, expert).
+
+    Shared by the fused and direct-topk stage1 kernels, which differ only in how
+    they select ``expert`` and map the program id.
+    """
+    BLOCK_K_PACKED: gl.constexpr = BLOCK_K // 2
+    BLOCK_K_SCALE: gl.constexpr = BLOCK_K // 32
+    _layouts: gl.constexpr = _warp_decode_mfma_layouts(M_DUP, BLOCK_N, BLOCK_K_SCALE)
+    mfma_layout: gl.constexpr = _layouts[0]
+    dot_a_layout: gl.constexpr = _layouts[1]
+    dot_b_layout: gl.constexpr = _layouts[2]
+    a_scale_layout: gl.constexpr = _layouts[3]
+    b_scale_layout: gl.constexpr = _layouts[4]
+    am = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, dot_a_layout))[:, None]
+    ak = gl.arange(0, BLOCK_K, layout=gl.SliceLayout(0, dot_a_layout))[None, :]
+    bk = gl.arange(0, BLOCK_K_PACKED, layout=gl.SliceLayout(1, dot_b_layout))[:, None]
+    bn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, dot_b_layout))[None, :]
+    n_gate = pid_n * BLOCK_N + bn
+    n_up = I + n_gate
+    bsn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(1, b_scale_layout))[:, None]
+    bsk = gl.arange(0, BLOCK_K_SCALE, layout=gl.SliceLayout(0, b_scale_layout))[None, :]
+    n_gate_s = pid_n * BLOCK_N + bsn
+    n_up_s = I + n_gate_s
+    a_scale = gl.full((M_DUP, BLOCK_K_SCALE), 127, gl.uint8, layout=a_scale_layout)
+
+    acc_g = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
+    acc_u = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
+    if (token < M) & (expert >= 0):
+        w_base = W + expert.to(gl.int64) * stride_we
+        ws_base = WScale + expert.to(gl.int64) * stride_wse
+        for kt in range(gl.cdiv(D, BLOCK_K)):
+            k_elem = kt * BLOCK_K + ak
+            k_pack = kt * BLOCK_K_PACKED + bk
+            a = gl.load(
+                X
+                + token.to(gl.int64) * stride_xm
+                + k_elem.to(gl.int64) * stride_xk
+                + am.to(gl.int64) * 0,
+                mask=k_elem < D,
+                other=0.0,
+            )
+            if QUANTIZE_X:
+                x_scale_tile = gl.load(x_global_scale_ptr).to(gl.float32)
+                a = (a.to(gl.float32) / x_scale_tile).to(gl.float8e4nv)
+            b_g = gl.load(
+                w_base
+                + k_pack.to(gl.int64) * stride_wk
+                + n_gate.to(gl.int64) * stride_wn,
+                mask=(k_pack < D_PACKED) & (n_gate < I),
+                other=0,
+            )
+            b_u = gl.load(
+                w_base
+                + k_pack.to(gl.int64) * stride_wk
+                + n_up.to(gl.int64) * stride_wn,
+                mask=(k_pack < D_PACKED) & (n_gate < I),
+                other=0,
+            )
+            sg = kt * BLOCK_K_SCALE + bsk
+            off_g = _mxfp4_scale_offset(n_gate_s, sg, stride_wsk, stride_wsn)
+            off_u = _mxfp4_scale_offset(n_up_s, sg, stride_wsk, stride_wsn)
+            s_g = gl.load(
+                ws_base + off_g, mask=(sg < (D // 32)) & (n_gate_s < I), other=0
+            )
+            s_u = gl.load(
+                ws_base + off_u, mask=(sg < (D // 32)) & (n_gate_s < I), other=0
+            )
+            acc_g = gl.amd.cdna4.mfma_scaled(
+                a=a,
+                a_scale=a_scale,
+                a_format="e4m3",
+                b=b_g,
+                b_scale=s_g,
+                b_format="e2m1",
+                acc=acc_g,
+            )
+            acc_u = gl.amd.cdna4.mfma_scaled(
+                a=a,
+                a_scale=a_scale,
+                a_format="e4m3",
+                b=b_u,
+                b_scale=s_u,
+                b_format="e2m1",
+                acc=acc_u,
+            )
+    x_scale = gl.load(x_global_scale_ptr).to(gl.float32)
+    acc_g = acc_g * x_scale
+    acc_u = acc_u * x_scale
+    if HAS_BIAS:
+        bias_n = pid_n * BLOCK_N + gl.arange(
+            0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout)
+        )
+        w13_base = w13_bias + expert.to(gl.int64) * (2 * I)
+        bound = (token < M) & (bias_n < I)
+        acc_g = _add_expert_bias(acc_g, w13_base, bias_n, bound, mfma_layout)
+        acc_u = _add_expert_bias(acc_u, w13_base + I, bias_n, bound, mfma_layout)
+    out_scale = gl.load(out_quant_scale_ptr).to(gl.float32)
+    out = _swiglu_gate_up(acc_g, acc_u, SWIGLU_ALPHA, SWIGLU_LIMIT) / out_scale
+    sm = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, mfma_layout))[:, None]
+    sn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout))[None, :]
+    col = pid_n * BLOCK_N + sn
+    row = token * TOPK + slot
+    gl.store(
+        Y
+        + row.to(gl.int64) * stride_ym
+        + col.to(gl.int64) * stride_yn
+        + sm.to(gl.int64) * 0,
+        out.to(Y.dtype.element_ty),
+        mask=(token < M) & (sm == 0) & (col < I),
+    )
+
+
+@gluon.jit
 def _warp_decode_topk_stage1_fp8_mxfp4_kernel(
     X,
     Logits,
@@ -5372,7 +5567,6 @@ def _warp_decode_topk_stage1_fp8_mxfp4_kernel(
     E,
     D,
     I,
-    TOPK_RUNTIME,
     stride_xm,
     stride_xk,
     stride_lm,
@@ -5403,8 +5597,6 @@ def _warp_decode_topk_stage1_fp8_mxfp4_kernel(
     SWIGLU_LIMIT: gl.constexpr,
 ):
     """Fused dense top-k + direct top-k stage1 for small-M warp decode."""
-    BLOCK_K_PACKED: gl.constexpr = BLOCK_K // 2
-    BLOCK_K_SCALE: gl.constexpr = BLOCK_K // 32
     pid = gl.program_id(axis=0)
     num_pid_n = gl.cdiv(I, BLOCK_N)
     token = pid // num_pid_n
@@ -5440,165 +5632,53 @@ def _warp_decode_topk_stage1_fp8_mxfp4_kernel(
         gl.store(
             TopkIdsOut + token.to(gl.int64) * stride_tim + t,
             idx_t,
-            mask=(token < M) & (t < TOPK_RUNTIME),
+            mask=(token < M) & (t < TOPK),
         )
         gl.store(
             TopkWeightsOut + token.to(gl.int64) * stride_twm + t,
             gate_t.to(TopkWeightsOut.dtype.element_ty),
-            mask=(token < M) & (t < TOPK_RUNTIME),
+            mask=(token < M) & (t < TOPK),
         )
-
-    mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
-        version=4, instr_shape=[16, 16, 128], transposed=True, warps_per_cta=[1, 1]
-    )
-    dot_a_layout: gl.constexpr = gl.DotOperandLayout(
-        operand_index=0, parent=mfma_layout, k_width=16
-    )
-    dot_b_layout: gl.constexpr = gl.DotOperandLayout(
-        operand_index=1, parent=mfma_layout, k_width=16
-    )
-    a_scale_layout: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
-        dot_a_layout, [M_DUP, BLOCK_K_SCALE]
-    )
-    b_scale_layout: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
-        dot_b_layout, [BLOCK_N, BLOCK_K_SCALE]
-    )
-    am = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, dot_a_layout))[:, None]
-    ak = gl.arange(0, BLOCK_K, layout=gl.SliceLayout(0, dot_a_layout))[None, :]
-    bk = gl.arange(0, BLOCK_K_PACKED, layout=gl.SliceLayout(1, dot_b_layout))[:, None]
-    bn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, dot_b_layout))[None, :]
-    n_gate = pid_n * BLOCK_N + bn
-    n_up = I + n_gate
-    bsn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(1, b_scale_layout))[:, None]
-    bsk = gl.arange(0, BLOCK_K_SCALE, layout=gl.SliceLayout(0, b_scale_layout))[None, :]
-    n_gate_s = pid_n * BLOCK_N + bsn
-    n_up_s = I + n_gate_s
-    a_scale = gl.full((M_DUP, BLOCK_K_SCALE), 127, gl.uint8, layout=a_scale_layout)
 
     for slot in gl.static_range(TOPK):
         slot_sel = t == slot
         expert = gl.sum(
             gl.where(slot_sel, idx_t, gl.zeros([TKP], gl.int32, layout=LT)), axis=0
         )
-        acc_g = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
-        acc_u = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
-        if (token < M) & (slot < TOPK_RUNTIME) & (expert >= 0):
-            w_base = W + expert.to(gl.int64) * stride_we
-            ws_base = WScale + expert.to(gl.int64) * stride_wse
-            for kt in range(gl.cdiv(D, BLOCK_K)):
-                k_elem = kt * BLOCK_K + ak
-                k_pack = kt * BLOCK_K_PACKED + bk
-                a = gl.load(
-                    X
-                    + token.to(gl.int64) * stride_xm
-                    + k_elem.to(gl.int64) * stride_xk
-                    + am.to(gl.int64) * 0,
-                    mask=k_elem < D,
-                    other=0.0,
-                )
-                if QUANTIZE_X:
-                    x_scale_tile = gl.load(x_global_scale_ptr).to(gl.float32)
-                    a = (a.to(gl.float32) / x_scale_tile).to(gl.float8e4nv)
-                b_g = gl.load(
-                    w_base
-                    + k_pack.to(gl.int64) * stride_wk
-                    + n_gate.to(gl.int64) * stride_wn,
-                    mask=(k_pack < D_PACKED) & (n_gate < I),
-                    other=0,
-                )
-                b_u = gl.load(
-                    w_base
-                    + k_pack.to(gl.int64) * stride_wk
-                    + n_up.to(gl.int64) * stride_wn,
-                    mask=(k_pack < D_PACKED) & (n_gate < I),
-                    other=0,
-                )
-                sg = kt * BLOCK_K_SCALE + bsk
-                row_g = n_gate_s.to(gl.uint32)
-                lin_g = (
-                    (sg // 8) * 128
-                    + (sg % 4) * 32
-                    + (row_g % 16) * 4
-                    + ((sg % 8) // 4) * 2
-                    + ((row_g % 32) // 16)
-                )
-                off_g = (row_g // 32).to(gl.int64) * stride_wsn + lin_g.to(
-                    gl.int64
-                ) * stride_wsk
-                row_u = n_up_s.to(gl.uint32)
-                lin_u = (
-                    (sg // 8) * 128
-                    + (sg % 4) * 32
-                    + (row_u % 16) * 4
-                    + ((sg % 8) // 4) * 2
-                    + ((row_u % 32) // 16)
-                )
-                off_u = (row_u // 32).to(gl.int64) * stride_wsn + lin_u.to(
-                    gl.int64
-                ) * stride_wsk
-                s_g = gl.load(
-                    ws_base + off_g, mask=(sg < (D // 32)) & (n_gate_s < I), other=0
-                )
-                s_u = gl.load(
-                    ws_base + off_u, mask=(sg < (D // 32)) & (n_gate_s < I), other=0
-                )
-                acc_g = gl.amd.cdna4.mfma_scaled(
-                    a=a,
-                    a_scale=a_scale,
-                    a_format="e4m3",
-                    b=b_g,
-                    b_scale=s_g,
-                    b_format="e2m1",
-                    acc=acc_g,
-                )
-                acc_u = gl.amd.cdna4.mfma_scaled(
-                    a=a,
-                    a_scale=a_scale,
-                    a_format="e4m3",
-                    b=b_u,
-                    b_scale=s_u,
-                    b_format="e2m1",
-                    acc=acc_u,
-                )
-        x_scale = gl.load(x_global_scale_ptr).to(gl.float32)
-        acc_g = acc_g * x_scale
-        acc_u = acc_u * x_scale
-        if HAS_BIAS:
-            bias_n = pid_n * BLOCK_N + gl.arange(
-                0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout)
-            )
-            bg = gl.load(
-                w13_bias + expert.to(gl.int64) * (2 * I) + bias_n,
-                mask=(token < M) & (bias_n < I),
-                other=0.0,
-            ).to(gl.float32)
-            bu = gl.load(
-                w13_bias + expert.to(gl.int64) * (2 * I) + I + bias_n,
-                mask=(token < M) & (bias_n < I),
-                other=0.0,
-            ).to(gl.float32)
-            bg = gl.convert_layout(bg, gl.SliceLayout(0, mfma_layout))
-            bu = gl.convert_layout(bu, gl.SliceLayout(0, mfma_layout))
-            acc_g = acc_g + bg[None, :]
-            acc_u = acc_u + bu[None, :]
-        if SWIGLU_LIMIT > 0.0:
-            acc_g = gl.minimum(acc_g, SWIGLU_LIMIT)
-            acc_u = gl.clamp(acc_u, -SWIGLU_LIMIT, SWIGLU_LIMIT)
-        out_scale = gl.load(out_quant_scale_ptr).to(gl.float32)
-        out = (
-            (acc_g / (1.0 + gl.exp(-SWIGLU_ALPHA * acc_g))) * (acc_u + 1.0)
-        ) / out_scale
-        sm = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, mfma_layout))[:, None]
-        sn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout))[None, :]
-        col = pid_n * BLOCK_N + sn
-        row = token * TOPK_RUNTIME + slot
-        gl.store(
-            Y
-            + row.to(gl.int64) * stride_ym
-            + col.to(gl.int64) * stride_yn
-            + sm.to(gl.int64) * 0,
-            out.to(Y.dtype.element_ty),
-            mask=(token < M) & (sm == 0) & (col < I),
+        _warp_decode_stage1_compute(
+            token,
+            slot,
+            expert,
+            pid_n,
+            X,
+            W,
+            WScale,
+            Y,
+            M,
+            D,
+            I,
+            stride_xm,
+            stride_xk,
+            stride_we,
+            stride_wk,
+            stride_wn,
+            stride_wse,
+            stride_wsk,
+            stride_wsn,
+            stride_ym,
+            stride_yn,
+            x_global_scale_ptr,
+            out_quant_scale_ptr,
+            w13_bias,
+            D_PACKED,
+            TOPK,
+            BLOCK_K,
+            BLOCK_N,
+            M_DUP,
+            QUANTIZE_X,
+            HAS_BIAS,
+            SWIGLU_ALPHA,
+            SWIGLU_LIMIT,
         )
 
 
@@ -5612,7 +5692,6 @@ def _warp_decode_stage1_fp8_mxfp4_kernel(
     M,
     D,
     I,
-    TOPK_RUNTIME,
     stride_xm,
     stride_xk,
     stride_we,
@@ -5637,169 +5716,47 @@ def _warp_decode_stage1_fp8_mxfp4_kernel(
     SWIGLU_LIMIT: gl.constexpr,
 ):
     """Direct top-k stage1: FP8 hidden x MXFP4 W13 -> FP8 intermediate."""
-    BLOCK_K_PACKED: gl.constexpr = BLOCK_K // 2
-    BLOCK_K_SCALE: gl.constexpr = BLOCK_K // 32
     pid = gl.program_id(axis=0)
     num_pid_n = gl.cdiv(I, BLOCK_N)
     pid_ts = pid // num_pid_n
     pid_n = pid % num_pid_n
-    token = pid_ts // TOPK_RUNTIME
-    slot = pid_ts % TOPK_RUNTIME
-
-    mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
-        version=4, instr_shape=[16, 16, 128], transposed=True, warps_per_cta=[1, 1]
-    )
-    dot_a_layout: gl.constexpr = gl.DotOperandLayout(
-        operand_index=0, parent=mfma_layout, k_width=16
-    )
-    dot_b_layout: gl.constexpr = gl.DotOperandLayout(
-        operand_index=1, parent=mfma_layout, k_width=16
-    )
-    a_scale_layout: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
-        dot_a_layout, [M_DUP, BLOCK_K_SCALE]
-    )
-    b_scale_layout: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
-        dot_b_layout, [BLOCK_N, BLOCK_K_SCALE]
-    )
-
-    am = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, dot_a_layout))[:, None]
-    ak = gl.arange(0, BLOCK_K, layout=gl.SliceLayout(0, dot_a_layout))[None, :]
-    bk = gl.arange(0, BLOCK_K_PACKED, layout=gl.SliceLayout(1, dot_b_layout))[:, None]
-    bn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, dot_b_layout))[None, :]
-    n_gate = pid_n * BLOCK_N + bn
-    n_up = I + n_gate
-
-    asm = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, a_scale_layout))[:, None]
-    ask = gl.arange(0, BLOCK_K_SCALE, layout=gl.SliceLayout(0, a_scale_layout))[None, :]
-    bsn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(1, b_scale_layout))[:, None]
-    bsk = gl.arange(0, BLOCK_K_SCALE, layout=gl.SliceLayout(0, b_scale_layout))[None, :]
-    n_gate_s = pid_n * BLOCK_N + bsn
-    n_up_s = I + n_gate_s
-
-    acc_g = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
-    acc_u = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
-    if token < M:
-        expert = gl.load(
-            TopkIds + token * TOPK_RUNTIME + slot, mask=token < M, other=-1
-        )
-        if expert >= 0:
-            w_base = W + expert.to(gl.int64) * stride_we
-            ws_base = WScale + expert.to(gl.int64) * stride_wse
-            for kt in range(gl.cdiv(D, BLOCK_K)):
-                k_elem = kt * BLOCK_K + ak
-                k_pack = kt * BLOCK_K_PACKED + bk
-                a = gl.load(
-                    X
-                    + token.to(gl.int64) * stride_xm
-                    + k_elem.to(gl.int64) * stride_xk
-                    + am.to(gl.int64) * 0,
-                    mask=k_elem < D,
-                    other=0.0,
-                )
-                if QUANTIZE_X:
-                    x_scale_tile = gl.load(x_global_scale_ptr).to(gl.float32)
-                    a = (a.to(gl.float32) / x_scale_tile).to(gl.float8e4nv)
-                a_scale = gl.full(
-                    (M_DUP, BLOCK_K_SCALE), 127, gl.uint8, layout=a_scale_layout
-                )
-                b_g = gl.load(
-                    w_base
-                    + k_pack.to(gl.int64) * stride_wk
-                    + n_gate.to(gl.int64) * stride_wn,
-                    mask=(k_pack < D_PACKED) & (n_gate < I),
-                    other=0,
-                )
-                b_u = gl.load(
-                    w_base
-                    + k_pack.to(gl.int64) * stride_wk
-                    + n_up.to(gl.int64) * stride_wn,
-                    mask=(k_pack < D_PACKED) & (n_gate < I),
-                    other=0,
-                )
-                sg = kt * BLOCK_K_SCALE + bsk
-                # CDNA4 scale swizzle: storage shape (..., K_SCALE_PAD*32, N_PAD/32).
-                row_g = n_gate_s.to(gl.uint32)
-                lin_g = (
-                    (sg // 8) * 128
-                    + (sg % 4) * 32
-                    + (row_g % 16) * 4
-                    + ((sg % 8) // 4) * 2
-                    + ((row_g % 32) // 16)
-                )
-                off_g = (row_g // 32).to(gl.int64) * stride_wsn + lin_g.to(
-                    gl.int64
-                ) * stride_wsk
-                row_u = n_up_s.to(gl.uint32)
-                lin_u = (
-                    (sg // 8) * 128
-                    + (sg % 4) * 32
-                    + (row_u % 16) * 4
-                    + ((sg % 8) // 4) * 2
-                    + ((row_u % 32) // 16)
-                )
-                off_u = (row_u // 32).to(gl.int64) * stride_wsn + lin_u.to(
-                    gl.int64
-                ) * stride_wsk
-                s_g = gl.load(
-                    ws_base + off_g, mask=(sg < (D // 32)) & (n_gate_s < I), other=0
-                )
-                s_u = gl.load(
-                    ws_base + off_u, mask=(sg < (D // 32)) & (n_gate_s < I), other=0
-                )
-                acc_g = gl.amd.cdna4.mfma_scaled(
-                    a=a,
-                    a_scale=a_scale,
-                    a_format="e4m3",
-                    b=b_g,
-                    b_scale=s_g,
-                    b_format="e2m1",
-                    acc=acc_g,
-                )
-                acc_u = gl.amd.cdna4.mfma_scaled(
-                    a=a,
-                    a_scale=a_scale,
-                    a_format="e4m3",
-                    b=b_u,
-                    b_scale=s_u,
-                    b_format="e2m1",
-                    acc=acc_u,
-                )
-    x_scale = gl.load(x_global_scale_ptr).to(gl.float32)
-    acc_g = acc_g * x_scale
-    acc_u = acc_u * x_scale
-    if HAS_BIAS:
-        bias_n = pid_n * BLOCK_N + gl.arange(
-            0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout)
-        )
-        bg = gl.load(
-            w13_bias + expert.to(gl.int64) * (2 * I) + bias_n,
-            mask=(token < M) & (bias_n < I),
-            other=0.0,
-        ).to(gl.float32)
-        bu = gl.load(
-            w13_bias + expert.to(gl.int64) * (2 * I) + I + bias_n,
-            mask=(token < M) & (bias_n < I),
-            other=0.0,
-        ).to(gl.float32)
-        bg = gl.convert_layout(bg, gl.SliceLayout(0, mfma_layout))
-        bu = gl.convert_layout(bu, gl.SliceLayout(0, mfma_layout))
-        acc_g = acc_g + bg[None, :]
-        acc_u = acc_u + bu[None, :]
-    if SWIGLU_LIMIT > 0.0:
-        acc_g = gl.minimum(acc_g, SWIGLU_LIMIT)
-        acc_u = gl.clamp(acc_u, -SWIGLU_LIMIT, SWIGLU_LIMIT)
-    out_scale = gl.load(out_quant_scale_ptr).to(gl.float32)
-    out = ((acc_g / (1.0 + gl.exp(-SWIGLU_ALPHA * acc_g))) * (acc_u + 1.0)) / out_scale
-    sm = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, mfma_layout))[:, None]
-    sn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout))[None, :]
-    col = pid_n * BLOCK_N + sn
-    gl.store(
-        Y
-        + pid_ts.to(gl.int64) * stride_ym
-        + col.to(gl.int64) * stride_yn
-        + sm.to(gl.int64) * 0,
-        out.to(Y.dtype.element_ty),
-        mask=(token < M) & (sm == 0) & (col < I),
+    token = pid_ts // TOPK
+    slot = pid_ts % TOPK
+    expert = gl.load(TopkIds + token * TOPK + slot, mask=token < M, other=-1)
+    _warp_decode_stage1_compute(
+        token,
+        slot,
+        expert,
+        pid_n,
+        X,
+        W,
+        WScale,
+        Y,
+        M,
+        D,
+        I,
+        stride_xm,
+        stride_xk,
+        stride_we,
+        stride_wk,
+        stride_wn,
+        stride_wse,
+        stride_wsk,
+        stride_wsn,
+        stride_ym,
+        stride_yn,
+        x_global_scale_ptr,
+        out_quant_scale_ptr,
+        w13_bias,
+        D_PACKED,
+        TOPK,
+        BLOCK_K,
+        BLOCK_N,
+        M_DUP,
+        QUANTIZE_X,
+        HAS_BIAS,
+        SWIGLU_ALPHA,
+        SWIGLU_LIMIT,
     )
 
 
@@ -5814,7 +5771,6 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
     M,
     N,
     I,
-    TOPK_RUNTIME,
     stride_xm,
     stride_xk,
     stride_we,
@@ -5840,21 +5796,12 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
     pid = gl.program_id(axis=0)
     pid_token = pid // gl.cdiv(N, BLOCK_N)
     pid_n = pid % gl.cdiv(N, BLOCK_N)
-    mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
-        version=4, instr_shape=[16, 16, 128], transposed=True, warps_per_cta=[1, 1]
-    )
-    dot_a_layout: gl.constexpr = gl.DotOperandLayout(
-        operand_index=0, parent=mfma_layout, k_width=16
-    )
-    dot_b_layout: gl.constexpr = gl.DotOperandLayout(
-        operand_index=1, parent=mfma_layout, k_width=16
-    )
-    a_scale_layout: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
-        dot_a_layout, [M_DUP, BLOCK_K_SCALE]
-    )
-    b_scale_layout: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
-        dot_b_layout, [BLOCK_N, BLOCK_K_SCALE]
-    )
+    _layouts: gl.constexpr = _warp_decode_mfma_layouts(M_DUP, BLOCK_N, BLOCK_K_SCALE)
+    mfma_layout: gl.constexpr = _layouts[0]
+    dot_a_layout: gl.constexpr = _layouts[1]
+    dot_b_layout: gl.constexpr = _layouts[2]
+    a_scale_layout: gl.constexpr = _layouts[3]
+    b_scale_layout: gl.constexpr = _layouts[4]
     am = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, dot_a_layout))[:, None]
     ak = gl.arange(0, BLOCK_K, layout=gl.SliceLayout(0, dot_a_layout))[None, :]
     bk = gl.arange(0, BLOCK_K_PACKED, layout=gl.SliceLayout(1, dot_b_layout))[:, None]
@@ -5867,15 +5814,15 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
     if pid_token < M:
         for slot in gl.static_range(0, TOPK):
             expert = gl.load(
-                TopkIds + pid_token * TOPK_RUNTIME + slot, mask=pid_token < M, other=-1
+                TopkIds + pid_token * TOPK + slot, mask=pid_token < M, other=-1
             )
             gate = gl.load(
-                TopkWeights + pid_token * TOPK_RUNTIME + slot,
+                TopkWeights + pid_token * TOPK + slot,
                 mask=pid_token < M,
                 other=0.0,
             ).to(gl.float32)
             if expert >= 0:
-                row = pid_token * TOPK_RUNTIME + slot
+                row = pid_token * TOPK + slot
                 w_base = W + expert.to(gl.int64) * stride_we
                 ws_base = WScale + expert.to(gl.int64) * stride_wse
                 acc = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
@@ -5901,17 +5848,7 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
                         other=0,
                     )
                     sk = kt * BLOCK_K_SCALE + bsk
-                    row_s = n_cols_s.to(gl.uint32)
-                    lin_s = (
-                        (sk // 8) * 128
-                        + (sk % 4) * 32
-                        + (row_s % 16) * 4
-                        + ((sk % 8) // 4) * 2
-                        + ((row_s % 32) // 16)
-                    )
-                    off_s = (row_s // 32).to(gl.int64) * stride_wsn + lin_s.to(
-                        gl.int64
-                    ) * stride_wsk
+                    off_s = _mxfp4_scale_offset(n_cols_s, sk, stride_wsk, stride_wsn)
                     s = gl.load(
                         ws_base + off_s, mask=(sk < (I // 32)) & (n_cols_s < N), other=0
                     )
@@ -5929,13 +5866,10 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
                     bias_n = pid_n * BLOCK_N + gl.arange(
                         0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout)
                     )
-                    bias = gl.load(
-                        w2_bias + expert.to(gl.int64) * N + bias_n,
-                        mask=bias_n < N,
-                        other=0.0,
-                    ).to(gl.float32)
-                    bias = gl.convert_layout(bias, gl.SliceLayout(0, mfma_layout))
-                    acc = acc + bias[None, :]
+                    w2_base = w2_bias + expert.to(gl.int64) * N
+                    acc = _add_expert_bias(
+                        acc, w2_base, bias_n, bias_n < N, mfma_layout
+                    )
                 acc_total += gate * acc
     sm = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, mfma_layout))[:, None]
     sn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout))[None, :]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
@@ -4614,35 +4614,18 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         (n_tokens, top_k), dtype=router_logits.dtype, device=router_logits.device
     )
 
-    fp8_dtype = (
-        getattr(
-            getattr(getattr(w13_precision_config, "flex_ctx", None), "lhs_data", None),
-            "dtype",
-            None,
-        )
-        or torch.float8_e4m3fn
-    )
-    fuse_input_quant = os.environ.get(
-        "TOKENSPEED_MOE_GLUON_FUSE_INPUT_QUANT", "0"
-    ).strip().lower() in {"1", "true", "yes", "on"}
+    # Current GPT-OSS path uses FP8 E4M3 activations with per-tensor scale.
+    from tokenspeed_kernel import quantize_fp8
+
     if hidden_states.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz):
         x_fp8 = hidden_states
-        quantize_x = False
-    elif fuse_input_quant:
-        # Experimental: quantize BF16/FP16 input tiles to FP8 in-register in
-        # stage1.  Currently slower than the standalone quantize_fp8 launch.
-        x_fp8 = hidden_states
-        quantize_x = True
     else:
-        from tokenspeed_kernel import quantize_fp8
-
         x_fp8 = quantize_fp8(hidden_states, scale=w13_act_scale, solution="triton")
-        quantize_x = False
-    # Pass FP8 tensors directly to Gluon.  ``view(torch.uint8)`` materializes a
+    # Pass the FP8 tensor straight to Gluon.  ``view(torch.uint8)`` materializes a
     # copy for float8 tensors on this stack and dominates small-M latency.
 
     inter = torch.empty(
-        (n_tokens * top_k, I), dtype=fp8_dtype, device=hidden_states.device
+        (n_tokens * top_k, I), dtype=x_fp8.dtype, device=hidden_states.device
     )
     out_dtype = getattr(w2_precision_config, "out_dtype", None) or torch.bfloat16
     out = torch.empty((n_tokens, N), dtype=out_dtype, device=hidden_states.device)
@@ -4699,7 +4682,6 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         BLOCK_K=BLOCK_K,
         BLOCK_N=S1_BLOCK_N,
         M_DUP=S1_M_DUP,
-        QUANTIZE_X=quantize_x,
         HAS_BIAS=w13_bias is not None,
         SWIGLU_ALPHA=float(swiglu_alpha),
         SWIGLU_LIMIT=float(swiglu_limit),
@@ -5305,7 +5287,6 @@ def _warp_decode_stage1_compute(
     BLOCK_K: gl.constexpr,
     BLOCK_N: gl.constexpr,
     M_DUP: gl.constexpr,
-    QUANTIZE_X: gl.constexpr,
     HAS_BIAS: gl.constexpr,
     SWIGLU_ALPHA: gl.constexpr,
     SWIGLU_LIMIT: gl.constexpr,
@@ -5351,9 +5332,6 @@ def _warp_decode_stage1_compute(
                 mask=k_elem < D,
                 other=0.0,
             )
-            if QUANTIZE_X:
-                x_scale_tile = gl.load(x_global_scale_ptr).to(gl.float32)
-                a = (a.to(gl.float32) / x_scale_tile).to(gl.float8e4nv)
             b_g = gl.load(
                 w_base
                 + k_pack.to(gl.int64) * stride_wk
@@ -5459,7 +5437,6 @@ def _warp_decode_topk_stage1_fp8_mxfp4_kernel(
     BLOCK_K: gl.constexpr,
     BLOCK_N: gl.constexpr,
     M_DUP: gl.constexpr,
-    QUANTIZE_X: gl.constexpr,
     HAS_BIAS: gl.constexpr,
     SWIGLU_ALPHA: gl.constexpr,
     SWIGLU_LIMIT: gl.constexpr,
@@ -5543,7 +5520,6 @@ def _warp_decode_topk_stage1_fp8_mxfp4_kernel(
             BLOCK_K,
             BLOCK_N,
             M_DUP,
-            QUANTIZE_X,
             HAS_BIAS,
             SWIGLU_ALPHA,
             SWIGLU_LIMIT,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
@@ -4637,7 +4637,9 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         x_fp8 = hidden_states
     else:
         x_fp8 = quantize_fp8(hidden_states, scale=w13_act_scale, solution="triton")
-    x_u8 = x_fp8.view(torch.uint8) if x_fp8.dtype != torch.uint8 else x_fp8
+    # Pass FP8 tensors directly to Gluon.  ``view(torch.uint8)`` materializes a
+    # copy for float8 tensors on this stack and dominates small-M latency.
+    x_u8 = x_fp8
 
     inter = torch.empty(
         (n_tokens * top_k, I), dtype=x_fp8.dtype, device=hidden_states.device
@@ -4733,7 +4735,7 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         )
 
     s2_grid = (n_tokens * ((N + BLOCK_N - 1) // BLOCK_N),)
-    inter_u8 = inter.view(torch.uint8) if inter.dtype != torch.uint8 else inter
+    inter_u8 = inter
     _warp_decode_stage2_fp8_mxfp4_kernel[s2_grid](
         inter_u8,
         w2_raw,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon.py
@@ -4605,10 +4605,9 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         return None
     N = int(w2_raw.shape[2])
 
-    fuse_topk_stage1 = (
-        os.environ.get("TOKENSPEED_MOE_GLUON_FUSE_TOPK_STAGE1", "1").strip().lower()
-        not in _GLUON_DISABLE_VALUES
-    )
+    # Fused top-k stage1 is the default warp-decode path; the non-fused path is
+    # kept as a fallback below and removed in a follow-up.
+    fuse_topk_stage1 = True
     if fuse_topk_stage1:
         router_logits_c = router_logits.contiguous()
         topk_ids = torch.empty(
@@ -4873,17 +4872,11 @@ def _gluon_mxfp_fused_moe(
 
     n_tokens = router_logits.shape[0]
 
-    # Warp-decode small-M MoE is the default on gfx950: it is the fastest path
-    # for the M<=16 decode regime and self-guards (returns None) for any shape
-    # it does not cover. Mirrors the other gluon moe kernels' opt-out switch:
-    # TOKENSPEED_MOE_GLUON_WARP_DECODE=0 (or the master TOKENSPEED_MOE_GLUON=0)
-    # disables it and falls back to the generic gluon/triton route.
-    warp_decode_enabled = (
-        not _GLUON_DISABLED_ENV
-        and current_platform().is_cdna4
-        and os.environ.get("TOKENSPEED_MOE_GLUON_WARP_DECODE", "1").strip().lower()
-        not in _GLUON_DISABLE_VALUES
-    )
+    # Warp-decode small-M MoE is the fastest path for the M<=16 decode regime
+    # and is the default on gfx950. It self-guards (returns None) for any shape
+    # it does not cover, and the master TOKENSPEED_MOE_GLUON=0 switch disables
+    # the whole gluon family (this path included), falling back to triton.
+    warp_decode_enabled = not _GLUON_DISABLED_ENV and current_platform().is_cdna4
     if warp_decode_enabled:
         try:
             warp_out = _gluon_mxfp4_fp8_warp_decode_moe(

--- a/tokenspeed-kernel/test/ops/test_moe_gluon_warp_decode.py
+++ b/tokenspeed-kernel/test/ops/test_moe_gluon_warp_decode.py
@@ -14,8 +14,22 @@ from tokenspeed_kernel.platform import current_platform
 
 # Standard OCP MXFP4 (E2M1) value table; index is the 4-bit code.
 _E2M1_VALUES = [
-    0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
-    -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,
+    -0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
 ]
 
 _FP8_DTYPE = torch.float8_e4m3fn
@@ -58,7 +72,9 @@ def _build_case(
     s13 = torch.full((E, 2 * I, D // 32), 127, device=device, dtype=torch.uint8)
     s2 = torch.full((E, D, I // 32), 127, device=device, dtype=torch.uint8)
     w13_bias = (
-        torch.randn((E, 2 * I), device=device, dtype=torch.float32) if use_bias else None
+        torch.randn((E, 2 * I), device=device, dtype=torch.float32)
+        if use_bias
+        else None
     )
     w2_bias = (
         torch.randn((E, D), device=device, dtype=torch.float32) if use_bias else None
@@ -85,11 +101,24 @@ def _build_case(
         out_dtype=torch.bfloat16,
     )
     return {
-        "M": M, "E": E, "D": D, "I": I, "topk": topk, "use_bias": use_bias,
-        "hidden": hidden, "router": router,
-        "w13": w13, "w2": w2, "w13_bias": w13_bias, "w2_bias": w2_bias,
-        "wt13": wt13, "wt2": wt2, "pc1": pc1, "pc2": pc2,
-        "scale1": scale1, "scale2": scale2,
+        "M": M,
+        "E": E,
+        "D": D,
+        "I": I,
+        "topk": topk,
+        "use_bias": use_bias,
+        "hidden": hidden,
+        "router": router,
+        "w13": w13,
+        "w2": w2,
+        "w13_bias": w13_bias,
+        "w2_bias": w2_bias,
+        "wt13": wt13,
+        "wt2": wt2,
+        "pc1": pc1,
+        "pc2": pc2,
+        "scale1": scale1,
+        "scale2": scale2,
     }
 
 

--- a/tokenspeed-kernel/test/ops/test_moe_gluon_warp_decode.py
+++ b/tokenspeed-kernel/test/ops/test_moe_gluon_warp_decode.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 LightSeek Foundation
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tokenspeed_kernel.ops.moe.gluon import (
+    _direct_topk_small_m,
+    _gluon_mxfp4_fp8_warp_decode_moe,
+)
+from tokenspeed_kernel.ops.moe.triton_kernels import FlexCtx, InFlexData, PrecisionConfig
+from tokenspeed_kernel.platform import current_platform
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA/HIP required")
+@pytest.mark.skipif(not current_platform().is_cdna4, reason="Gluon warp-decode helpers are gfx950-only")
+@pytest.mark.parametrize("M", [1, 4, 8, 16])
+@pytest.mark.parametrize("E", [16, 128])
+@pytest.mark.parametrize("topk", [1, 4])
+def test_direct_topk_small_m_matches_selected_softmax(M: int, E: int, topk: int):
+    torch.manual_seed(M * 1000 + E * 10 + topk)
+    logits = torch.randn((M, E), device="cuda", dtype=torch.float32)
+
+    ids, weights = _direct_topk_small_m(logits, topk)
+    torch.cuda.synchronize()
+
+    ref_vals, ref_ids = torch.topk(logits, topk, dim=-1)
+    ref_weights = torch.softmax(ref_vals, dim=-1)
+
+    assert torch.equal(ids, ref_ids.to(torch.int32))
+    torch.testing.assert_close(weights, ref_weights, rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA/HIP required")
+@pytest.mark.skipif(not current_platform().is_cdna4, reason="Gluon warp-decode helpers are gfx950-only")
+def test_direct_topk_small_m_rejects_large_m():
+    logits = torch.randn((17, 16), device="cuda", dtype=torch.float32)
+    with pytest.raises(ValueError, match="requires M <="):
+        _direct_topk_small_m(logits, 4)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA/HIP required")
+@pytest.mark.skipif(not current_platform().is_cdna4, reason="Gluon warp-decode helpers are gfx950-only")
+def test_fp8_mxfp4_warp_decode_moe_matches_torch_reference():
+    pytest.importorskip("aiter")
+    from aiter.utility.fp4_utils import mxfp4_to_f32
+    from tokenspeed.runtime.layers.moe.backends.mxfp4.triton_kernel import swizzle_mxfp4
+
+    torch.manual_seed(123)
+    M, E, D, I, topk = 2, 4, 128, 128, 2
+    device = "cuda"
+    hidden = torch.randn((M, D), device=device, dtype=torch.bfloat16)
+    router = torch.randn((M, E), device=device, dtype=torch.float32)
+    w13 = torch.randint(0, 256, (E, 2 * I, D // 2), device=device, dtype=torch.uint8)
+    w2 = torch.randint(0, 256, (E, D, I // 2), device=device, dtype=torch.uint8)
+    s13 = torch.full((E, 2 * I, D // 32), 127, device=device, dtype=torch.uint8)
+    s2 = torch.full((E, D, I // 32), 127, device=device, dtype=torch.uint8)
+    wt13, flex13, st13 = swizzle_mxfp4(w13, s13, 8)
+    wt2, flex2, st2 = swizzle_mxfp4(w2, s2, 8)
+    scale1 = torch.ones((1,), device=device, dtype=torch.float32)
+    scale2 = torch.ones((1,), device=device, dtype=torch.float32)
+    fp8_dtype = torch.float8_e4m3fn
+    pc1 = PrecisionConfig(
+        flex_ctx=FlexCtx(lhs_data=InFlexData(dtype=fp8_dtype, scale=scale1), rhs_data=flex13),
+        b_mx_scale=st13,
+        b_microblock_size=32,
+        out_dtype=torch.bfloat16,
+    )
+    pc2 = PrecisionConfig(
+        flex_ctx=FlexCtx(lhs_data=InFlexData(dtype=fp8_dtype, scale=scale2), rhs_data=flex2),
+        b_mx_scale=st2,
+        b_microblock_size=32,
+        out_dtype=torch.bfloat16,
+    )
+
+    out = _gluon_mxfp4_fp8_warp_decode_moe(
+        hidden,
+        router,
+        wt13,
+        wt2,
+        w13_precision_config=pc1,
+        w2_precision_config=pc2,
+        w13_act_scale=scale1,
+        w2_act_scale=scale2,
+        top_k=topk,
+    )
+    assert out is not None
+    torch.cuda.synchronize()
+
+    topk_vals, topk_ids = torch.topk(router, topk, dim=-1)
+    topk_weights = torch.softmax(topk_vals, dim=-1)
+    hidden_fp8 = hidden.to(fp8_dtype).to(torch.float32)
+    w13_f = mxfp4_to_f32(w13)
+    w2_f = mxfp4_to_f32(w2)
+    ref = torch.zeros((M, D), device=device, dtype=torch.float32)
+    for m in range(M):
+        for slot in range(topk):
+            expert = int(topk_ids[m, slot])
+            gate_up = hidden_fp8[m : m + 1] @ w13_f[expert].T
+            gate = torch.minimum(gate_up[:, :I], torch.tensor(7.0, device=device))
+            linear = torch.clamp(gate_up[:, I:], -7.0, 7.0)
+            inter = (gate / (1.0 + torch.exp(-1.702 * gate))) * (linear + 1.0)
+            inter_fp8 = inter.to(fp8_dtype).to(torch.float32)
+            ref[m] += topk_weights[m, slot] * (inter_fp8 @ w2_f[expert].T).squeeze(0)
+    torch.testing.assert_close(out.float(), ref.to(torch.bfloat16).float(), rtol=5e-2, atol=2.0)

--- a/tokenspeed-kernel/test/ops/test_moe_gluon_warp_decode.py
+++ b/tokenspeed-kernel/test/ops/test_moe_gluon_warp_decode.py
@@ -4,47 +4,13 @@ from __future__ import annotations
 
 import pytest
 import torch
-from tokenspeed_kernel.ops.moe.gluon import (
-    _direct_topk_small_m,
-    _gluon_mxfp4_fp8_warp_decode_moe,
-)
+from tokenspeed_kernel.ops.moe.gluon import _gluon_mxfp4_fp8_warp_decode_moe
 from tokenspeed_kernel.ops.moe.triton_kernels import (
     FlexCtx,
     InFlexData,
     PrecisionConfig,
 )
 from tokenspeed_kernel.platform import current_platform
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA/HIP required")
-@pytest.mark.skipif(
-    not current_platform().is_cdna4, reason="Gluon warp-decode helpers are gfx950-only"
-)
-@pytest.mark.parametrize("M", [1, 4, 8, 16])
-@pytest.mark.parametrize("E", [16, 128])
-@pytest.mark.parametrize("topk", [1, 4])
-def test_direct_topk_small_m_matches_selected_softmax(M: int, E: int, topk: int):
-    torch.manual_seed(M * 1000 + E * 10 + topk)
-    logits = torch.randn((M, E), device="cuda", dtype=torch.float32)
-
-    ids, weights = _direct_topk_small_m(logits, topk)
-    torch.cuda.synchronize()
-
-    ref_vals, ref_ids = torch.topk(logits, topk, dim=-1)
-    ref_weights = torch.softmax(ref_vals, dim=-1)
-
-    assert torch.equal(ids, ref_ids.to(torch.int32))
-    torch.testing.assert_close(weights, ref_weights, rtol=1e-6, atol=1e-6)
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA/HIP required")
-@pytest.mark.skipif(
-    not current_platform().is_cdna4, reason="Gluon warp-decode helpers are gfx950-only"
-)
-def test_direct_topk_small_m_rejects_large_m():
-    logits = torch.randn((17, 16), device="cuda", dtype=torch.float32)
-    with pytest.raises(ValueError, match="requires M <="):
-        _direct_topk_small_m(logits, 4)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA/HIP required")

--- a/tokenspeed-kernel/test/ops/test_moe_gluon_warp_decode.py
+++ b/tokenspeed-kernel/test/ops/test_moe_gluon_warp_decode.py
@@ -51,7 +51,8 @@ def test_direct_topk_small_m_rejects_large_m():
 @pytest.mark.skipif(
     not current_platform().is_cdna4, reason="Gluon warp-decode helpers are gfx950-only"
 )
-def test_fp8_mxfp4_warp_decode_moe_matches_torch_reference():
+@pytest.mark.parametrize("use_bias", [False, True])
+def test_fp8_mxfp4_warp_decode_moe_matches_torch_reference(use_bias: bool):
     pytest.importorskip("aiter")
     from aiter.utility.fp4_utils import mxfp4_to_f32
 
@@ -66,6 +67,9 @@ def test_fp8_mxfp4_warp_decode_moe_matches_torch_reference():
     w2 = torch.randint(0, 256, (E, D, I // 2), device=device, dtype=torch.uint8)
     s13 = torch.full((E, 2 * I, D // 32), 127, device=device, dtype=torch.uint8)
     s2 = torch.full((E, D, I // 32), 127, device=device, dtype=torch.uint8)
+    # N (w2 output dim) equals D for this square config.
+    w13_bias = torch.randn((E, 2 * I), device=device, dtype=torch.float32) if use_bias else None
+    w2_bias = torch.randn((E, D), device=device, dtype=torch.float32) if use_bias else None
     wt13, flex13, st13 = swizzle_mxfp4(w13, s13, 8)
     wt2, flex2, st2 = swizzle_mxfp4(w2, s2, 8)
     scale1 = torch.ones((1,), device=device, dtype=torch.float32)
@@ -93,6 +97,8 @@ def test_fp8_mxfp4_warp_decode_moe_matches_torch_reference():
         router,
         wt13,
         wt2,
+        w13_bias=w13_bias,
+        w2_bias=w2_bias,
         w13_precision_config=pc1,
         w2_precision_config=pc2,
         w13_act_scale=scale1,
@@ -112,11 +118,17 @@ def test_fp8_mxfp4_warp_decode_moe_matches_torch_reference():
         for slot in range(topk):
             expert = int(topk_ids[m, slot])
             gate_up = hidden_fp8[m : m + 1] @ w13_f[expert].T
+            if use_bias:
+                # Bias is added before the swiglu clamp, matching the kernel.
+                gate_up = gate_up + w13_bias[expert][None, :]
             gate = torch.minimum(gate_up[:, :I], torch.tensor(7.0, device=device))
             linear = torch.clamp(gate_up[:, I:], -7.0, 7.0)
             inter = (gate / (1.0 + torch.exp(-1.702 * gate))) * (linear + 1.0)
             inter_fp8 = inter.to(fp8_dtype).to(torch.float32)
-            ref[m] += topk_weights[m, slot] * (inter_fp8 @ w2_f[expert].T).squeeze(0)
+            second = inter_fp8 @ w2_f[expert].T
+            if use_bias:
+                second = second + w2_bias[expert][None, :]
+            ref[m] += topk_weights[m, slot] * second.squeeze(0)
     torch.testing.assert_close(
         out.float(), ref.to(torch.bfloat16).float(), rtol=5e-2, atol=2.0
     )

--- a/tokenspeed-kernel/test/ops/test_moe_gluon_warp_decode.py
+++ b/tokenspeed-kernel/test/ops/test_moe_gluon_warp_decode.py
@@ -12,38 +12,65 @@ from tokenspeed_kernel.ops.moe.triton_kernels import (
 )
 from tokenspeed_kernel.platform import current_platform
 
+# Standard OCP MXFP4 (E2M1) value table; index is the 4-bit code.
+_E2M1_VALUES = [
+    0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+    -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
+]
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA/HIP required")
-@pytest.mark.skipif(
-    not current_platform().is_cdna4, reason="Gluon warp-decode helpers are gfx950-only"
-)
-@pytest.mark.parametrize("use_bias", [False, True])
-def test_fp8_mxfp4_warp_decode_moe_matches_torch_reference(use_bias: bool):
-    pytest.importorskip("aiter")
-    from aiter.utility.fp4_utils import mxfp4_to_f32
+_FP8_DTYPE = torch.float8_e4m3fn
 
+
+def _mxfp4_dequant(packed: torch.Tensor) -> torch.Tensor:
+    """Decode packed MXFP4 (two e2m1 codes per byte) to float32.
+
+    Replaces aiter.utility.fp4_utils.mxfp4_to_f32 so the test carries no
+    aiter dependency. The low nibble is the even element along the unpacked
+    axis, the high nibble the odd element. Input (..., K // 2) uint8 maps to
+    output (..., K) float32. All weight microscales in these cases are e8m0
+    code 127, i.e. a unit scale, so no scale factor is applied here.
+    """
+    lut = torch.tensor(_E2M1_VALUES, device=packed.device, dtype=torch.float32)
+    lo = lut[(packed & 0x0F).long()]
+    hi = lut[(packed >> 4).long()]
+    return torch.stack((lo, hi), dim=-1).reshape(*packed.shape[:-1], -1)
+
+
+def _build_case(
+    *,
+    M: int,
+    E: int,
+    D: int,
+    I: int,
+    topk: int,
+    use_bias: bool,
+    device: str = "cuda",
+    seed: int = 123,
+) -> dict:
+    """Construct kernel inputs plus the raw weights kept for the reference."""
     from tokenspeed.runtime.layers.moe.backends.mxfp4.triton_kernel import swizzle_mxfp4
 
-    torch.manual_seed(123)
-    M, E, D, I, topk = 2, 4, 128, 128, 2
-    device = "cuda"
+    torch.manual_seed(seed)
     hidden = torch.randn((M, D), device=device, dtype=torch.bfloat16)
     router = torch.randn((M, E), device=device, dtype=torch.float32)
     w13 = torch.randint(0, 256, (E, 2 * I, D // 2), device=device, dtype=torch.uint8)
     w2 = torch.randint(0, 256, (E, D, I // 2), device=device, dtype=torch.uint8)
     s13 = torch.full((E, 2 * I, D // 32), 127, device=device, dtype=torch.uint8)
     s2 = torch.full((E, D, I // 32), 127, device=device, dtype=torch.uint8)
-    # N (w2 output dim) equals D for this square config.
-    w13_bias = torch.randn((E, 2 * I), device=device, dtype=torch.float32) if use_bias else None
-    w2_bias = torch.randn((E, D), device=device, dtype=torch.float32) if use_bias else None
+    w13_bias = (
+        torch.randn((E, 2 * I), device=device, dtype=torch.float32) if use_bias else None
+    )
+    w2_bias = (
+        torch.randn((E, D), device=device, dtype=torch.float32) if use_bias else None
+    )
+
     wt13, flex13, st13 = swizzle_mxfp4(w13, s13, 8)
     wt2, flex2, st2 = swizzle_mxfp4(w2, s2, 8)
     scale1 = torch.ones((1,), device=device, dtype=torch.float32)
     scale2 = torch.ones((1,), device=device, dtype=torch.float32)
-    fp8_dtype = torch.float8_e4m3fn
     pc1 = PrecisionConfig(
         flex_ctx=FlexCtx(
-            lhs_data=InFlexData(dtype=fp8_dtype, scale=scale1), rhs_data=flex13
+            lhs_data=InFlexData(dtype=_FP8_DTYPE, scale=scale1), rhs_data=flex13
         ),
         b_mx_scale=st13,
         b_microblock_size=32,
@@ -51,50 +78,134 @@ def test_fp8_mxfp4_warp_decode_moe_matches_torch_reference(use_bias: bool):
     )
     pc2 = PrecisionConfig(
         flex_ctx=FlexCtx(
-            lhs_data=InFlexData(dtype=fp8_dtype, scale=scale2), rhs_data=flex2
+            lhs_data=InFlexData(dtype=_FP8_DTYPE, scale=scale2), rhs_data=flex2
         ),
         b_mx_scale=st2,
         b_microblock_size=32,
         out_dtype=torch.bfloat16,
     )
+    return {
+        "M": M, "E": E, "D": D, "I": I, "topk": topk, "use_bias": use_bias,
+        "hidden": hidden, "router": router,
+        "w13": w13, "w2": w2, "w13_bias": w13_bias, "w2_bias": w2_bias,
+        "wt13": wt13, "wt2": wt2, "pc1": pc1, "pc2": pc2,
+        "scale1": scale1, "scale2": scale2,
+    }
 
-    out = _gluon_mxfp4_fp8_warp_decode_moe(
-        hidden,
-        router,
-        wt13,
-        wt2,
-        w13_bias=w13_bias,
-        w2_bias=w2_bias,
-        w13_precision_config=pc1,
-        w2_precision_config=pc2,
-        w13_act_scale=scale1,
-        w2_act_scale=scale2,
-        top_k=topk,
+
+def _run_kernel(case: dict) -> torch.Tensor:
+    return _gluon_mxfp4_fp8_warp_decode_moe(
+        case["hidden"],
+        case["router"],
+        case["wt13"],
+        case["wt2"],
+        w13_bias=case["w13_bias"],
+        w2_bias=case["w2_bias"],
+        w13_precision_config=case["pc1"],
+        w2_precision_config=case["pc2"],
+        w13_act_scale=case["scale1"],
+        w2_act_scale=case["scale2"],
+        top_k=case["topk"],
     )
-    assert out is not None
-    torch.cuda.synchronize()
+
+
+def _reference(case: dict) -> torch.Tensor:
+    """Pure-torch decode-MoE matching the warp kernel's swiglu + fp8 rounding."""
+    M, D, I, topk = case["M"], case["D"], case["I"], case["topk"]
+    device = case["hidden"].device
+    use_bias = case["use_bias"]
+    router, w13, w2 = case["router"], case["w13"], case["w2"]
+    w13_bias, w2_bias = case["w13_bias"], case["w2_bias"]
 
     topk_vals, topk_ids = torch.topk(router, topk, dim=-1)
     topk_weights = torch.softmax(topk_vals, dim=-1)
-    hidden_fp8 = hidden.to(fp8_dtype).to(torch.float32)
-    w13_f = mxfp4_to_f32(w13)
-    w2_f = mxfp4_to_f32(w2)
+    hidden_fp8 = case["hidden"].to(_FP8_DTYPE).to(torch.float32)
+    seven = torch.tensor(7.0, device=device)
+
+    # Dequant only the experts that are actually routed to, keeping memory
+    # bounded for the larger decode shapes.
+    deq_cache: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
+
+    def _expert_weights(expert: int) -> tuple[torch.Tensor, torch.Tensor]:
+        if expert not in deq_cache:
+            deq_cache[expert] = (
+                _mxfp4_dequant(w13[expert]),
+                _mxfp4_dequant(w2[expert]),
+            )
+        return deq_cache[expert]
+
     ref = torch.zeros((M, D), device=device, dtype=torch.float32)
     for m in range(M):
         for slot in range(topk):
             expert = int(topk_ids[m, slot])
-            gate_up = hidden_fp8[m : m + 1] @ w13_f[expert].T
+            w13_f, w2_f = _expert_weights(expert)
+            gate_up = hidden_fp8[m : m + 1] @ w13_f.T
             if use_bias:
-                # Bias is added before the swiglu clamp, matching the kernel.
                 gate_up = gate_up + w13_bias[expert][None, :]
-            gate = torch.minimum(gate_up[:, :I], torch.tensor(7.0, device=device))
+            gate = torch.minimum(gate_up[:, :I], seven)
             linear = torch.clamp(gate_up[:, I:], -7.0, 7.0)
             inter = (gate / (1.0 + torch.exp(-1.702 * gate))) * (linear + 1.0)
-            inter_fp8 = inter.to(fp8_dtype).to(torch.float32)
-            second = inter_fp8 @ w2_f[expert].T
+            inter_fp8 = inter.to(_FP8_DTYPE).to(torch.float32)
+            second = inter_fp8 @ w2_f.T
             if use_bias:
                 second = second + w2_bias[expert][None, :]
             ref[m] += topk_weights[m, slot] * second.squeeze(0)
+    return ref
+
+
+def _p50_latency_ms(case: dict, *, warmup: int = 20, iters: int = 100) -> float:
+    for _ in range(warmup):
+        _run_kernel(case)
+    torch.cuda.synchronize()
+    starts = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    ends = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    for i in range(iters):
+        starts[i].record()
+        _run_kernel(case)
+        ends[i].record()
+    torch.cuda.synchronize()
+    samples = sorted(s.elapsed_time(e) for s, e in zip(starts, ends))
+    return samples[len(samples) // 2]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA/HIP required")
+@pytest.mark.skipif(
+    not current_platform().is_cdna4, reason="Gluon warp-decode helpers are gfx950-only"
+)
+@pytest.mark.parametrize("use_bias", [False, True])
+def test_fp8_mxfp4_warp_decode_moe_matches_torch_reference(use_bias: bool):
+    case = _build_case(M=2, E=4, D=128, I=128, topk=2, use_bias=use_bias)
+    out = _run_kernel(case)
+    assert out is not None
+    torch.cuda.synchronize()
+    ref = _reference(case)
     torch.testing.assert_close(
         out.float(), ref.to(torch.bfloat16).float(), rtol=5e-2, atol=2.0
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA/HIP required")
+@pytest.mark.skipif(
+    not current_platform().is_cdna4, reason="Gluon warp-decode helpers are gfx950-only"
+)
+@pytest.mark.parametrize("M", [1, 2, 4, 8, 16])
+def test_fp8_mxfp4_warp_decode_moe_decode_perf(M: int):
+    """Decode-shape (gpt-oss-120B MoE) perf with a correctness gate.
+
+    Validates against the torch reference, then reports p50 kernel latency
+    measured with CUDA events. Run with ``-s`` to see the latency line.
+    """
+    case = _build_case(M=M, E=128, D=2880, I=2880, topk=4, use_bias=True)
+    out = _run_kernel(case)
+    assert out is not None
+    torch.cuda.synchronize()
+    ref = _reference(case)
+    torch.testing.assert_close(
+        out.float(), ref.to(torch.bfloat16).float(), rtol=5e-2, atol=2.0
+    )
+    p50_ms = _p50_latency_ms(case)
+    assert p50_ms > 0.0
+    print(
+        f"\n[warp-decode MoE] M={M} E=128 D=2880 I=2880 topk=4: "
+        f"p50={p50_ms * 1e3:.1f} us"
     )

--- a/tokenspeed-kernel/test/ops/test_moe_gluon_warp_decode.py
+++ b/tokenspeed-kernel/test/ops/test_moe_gluon_warp_decode.py
@@ -153,59 +153,21 @@ def _reference(case: dict) -> torch.Tensor:
     return ref
 
 
-def _p50_latency_ms(case: dict, *, warmup: int = 20, iters: int = 100) -> float:
-    for _ in range(warmup):
-        _run_kernel(case)
-    torch.cuda.synchronize()
-    starts = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
-    ends = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
-    for i in range(iters):
-        starts[i].record()
-        _run_kernel(case)
-        ends[i].record()
-    torch.cuda.synchronize()
-    samples = sorted(s.elapsed_time(e) for s, e in zip(starts, ends))
-    return samples[len(samples) // 2]
-
-
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA/HIP required")
 @pytest.mark.skipif(
     not current_platform().is_cdna4, reason="Gluon warp-decode helpers are gfx950-only"
 )
 @pytest.mark.parametrize("use_bias", [False, True])
-def test_fp8_mxfp4_warp_decode_moe_matches_torch_reference(use_bias: bool):
-    case = _build_case(M=2, E=4, D=128, I=128, topk=2, use_bias=use_bias)
-    out = _run_kernel(case)
-    assert out is not None
-    torch.cuda.synchronize()
-    ref = _reference(case)
-    torch.testing.assert_close(
-        out.float(), ref.to(torch.bfloat16).float(), rtol=5e-2, atol=2.0
-    )
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA/HIP required")
-@pytest.mark.skipif(
-    not current_platform().is_cdna4, reason="Gluon warp-decode helpers are gfx950-only"
-)
 @pytest.mark.parametrize("M", [1, 2, 4, 8, 16])
-def test_fp8_mxfp4_warp_decode_moe_decode_perf(M: int):
-    """Decode-shape (gpt-oss-120B MoE) perf with a correctness gate.
-
-    Validates against the torch reference, then reports p50 kernel latency
-    measured with CUDA events. Run with ``-s`` to see the latency line.
-    """
-    case = _build_case(M=M, E=128, D=2880, I=2880, topk=4, use_bias=True)
+def test_fp8_mxfp4_warp_decode_moe(M: int, use_bias: bool):
+    # I = 256 > BLOCK_K (128) so stage2 split-K partitions the reduction across
+    # real K slices. M sweeps the supported decode range (up to SMALLM_MAX_M=16)
+    # and its tiling transitions (stage2 at M>1, stage1 at M>4).
+    case = _build_case(M=M, E=4, D=256, I=256, topk=2, use_bias=use_bias)
     out = _run_kernel(case)
     assert out is not None
     torch.cuda.synchronize()
     ref = _reference(case)
     torch.testing.assert_close(
         out.float(), ref.to(torch.bfloat16).float(), rtol=5e-2, atol=2.0
-    )
-    p50_ms = _p50_latency_ms(case)
-    assert p50_ms > 0.0
-    print(
-        f"\n[warp-decode MoE] M={M} E=128 D=2880 I=2880 topk=4: "
-        f"p50={p50_ms * 1e3:.1f} us"
     )

--- a/tokenspeed-kernel/test/ops/test_moe_gluon_warp_decode.py
+++ b/tokenspeed-kernel/test/ops/test_moe_gluon_warp_decode.py
@@ -4,17 +4,22 @@ from __future__ import annotations
 
 import pytest
 import torch
-
 from tokenspeed_kernel.ops.moe.gluon import (
     _direct_topk_small_m,
     _gluon_mxfp4_fp8_warp_decode_moe,
 )
-from tokenspeed_kernel.ops.moe.triton_kernels import FlexCtx, InFlexData, PrecisionConfig
+from tokenspeed_kernel.ops.moe.triton_kernels import (
+    FlexCtx,
+    InFlexData,
+    PrecisionConfig,
+)
 from tokenspeed_kernel.platform import current_platform
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA/HIP required")
-@pytest.mark.skipif(not current_platform().is_cdna4, reason="Gluon warp-decode helpers are gfx950-only")
+@pytest.mark.skipif(
+    not current_platform().is_cdna4, reason="Gluon warp-decode helpers are gfx950-only"
+)
 @pytest.mark.parametrize("M", [1, 4, 8, 16])
 @pytest.mark.parametrize("E", [16, 128])
 @pytest.mark.parametrize("topk", [1, 4])
@@ -33,7 +38,9 @@ def test_direct_topk_small_m_matches_selected_softmax(M: int, E: int, topk: int)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA/HIP required")
-@pytest.mark.skipif(not current_platform().is_cdna4, reason="Gluon warp-decode helpers are gfx950-only")
+@pytest.mark.skipif(
+    not current_platform().is_cdna4, reason="Gluon warp-decode helpers are gfx950-only"
+)
 def test_direct_topk_small_m_rejects_large_m():
     logits = torch.randn((17, 16), device="cuda", dtype=torch.float32)
     with pytest.raises(ValueError, match="requires M <="):
@@ -41,10 +48,13 @@ def test_direct_topk_small_m_rejects_large_m():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA/HIP required")
-@pytest.mark.skipif(not current_platform().is_cdna4, reason="Gluon warp-decode helpers are gfx950-only")
+@pytest.mark.skipif(
+    not current_platform().is_cdna4, reason="Gluon warp-decode helpers are gfx950-only"
+)
 def test_fp8_mxfp4_warp_decode_moe_matches_torch_reference():
     pytest.importorskip("aiter")
     from aiter.utility.fp4_utils import mxfp4_to_f32
+
     from tokenspeed.runtime.layers.moe.backends.mxfp4.triton_kernel import swizzle_mxfp4
 
     torch.manual_seed(123)
@@ -62,13 +72,17 @@ def test_fp8_mxfp4_warp_decode_moe_matches_torch_reference():
     scale2 = torch.ones((1,), device=device, dtype=torch.float32)
     fp8_dtype = torch.float8_e4m3fn
     pc1 = PrecisionConfig(
-        flex_ctx=FlexCtx(lhs_data=InFlexData(dtype=fp8_dtype, scale=scale1), rhs_data=flex13),
+        flex_ctx=FlexCtx(
+            lhs_data=InFlexData(dtype=fp8_dtype, scale=scale1), rhs_data=flex13
+        ),
         b_mx_scale=st13,
         b_microblock_size=32,
         out_dtype=torch.bfloat16,
     )
     pc2 = PrecisionConfig(
-        flex_ctx=FlexCtx(lhs_data=InFlexData(dtype=fp8_dtype, scale=scale2), rhs_data=flex2),
+        flex_ctx=FlexCtx(
+            lhs_data=InFlexData(dtype=fp8_dtype, scale=scale2), rhs_data=flex2
+        ),
         b_mx_scale=st2,
         b_microblock_size=32,
         out_dtype=torch.bfloat16,
@@ -103,4 +117,6 @@ def test_fp8_mxfp4_warp_decode_moe_matches_torch_reference():
             inter = (gate / (1.0 + torch.exp(-1.702 * gate))) * (linear + 1.0)
             inter_fp8 = inter.to(fp8_dtype).to(torch.float32)
             ref[m] += topk_weights[m, slot] * (inter_fp8 @ w2_f[expert].T).squeeze(0)
-    torch.testing.assert_close(out.float(), ref.to(torch.bfloat16).float(), rtol=5e-2, atol=2.0)
+    torch.testing.assert_close(
+        out.float(), ref.to(torch.bfloat16).float(), rtol=5e-2, atol=2.0
+    )


### PR DESCRIPTION
## Summary

This PR adds a Gluon warp-decode MoE path for GPT-OSS-style FP8 activation + MXFP4 weight inference on gfx950 (CDNA4) as described by [Warp-decode blog post by Cursor](https://cursor.com/blog/warp-decode).

The new path targets small decode batches (M <= 16) and avoids the expert-centric routing/GEMM/combine pipeline. Instead it computes dense top-k routing and runs direct token/top-k kernels.

The new flow is:
```python
  # old path
  ragged_metadata, gather, scatter, gate = route(router_logits)
  intermediate = grouped_expert_gemm(hidden, w13, gather, ragged_metadata)
  out = grouped_expert_gemm_and_combine(intermediate, w2, scatter, gate)

  # new warp-decode path
  topk_ids, topk_weights, intermediate = topk_plus_stage1(hidden, router_logits, w13)
  out = direct_stage2(intermediate, w2, topk_ids, topk_weights)
```

The stage1 kernel fuses dense top-k selection with the gate/up projection and SwiGLU activation. The stage2 kernel loops over each token's top-k experts internally and writes the final output directly, avoiding scatter/reduce metadata.

Since the MFMA intrinsic works on 16-row tiles, the direct decode kernels duplicate the single logical token row across the hardware M dimension and only store row 0.

## Test Plan

- `tokenspeed-kernel/test/ops/test_moe_gluon_warp_decode.py::test_fp8_mxfp4_warp_decode_moe` compares the full warp-decode path against a pure-torch reference.

```bash
  pytest tokenspeed-kernel/test/ops/test_moe_gluon_warp_decode.py -q
  # 10 passed
```

## Perf Run for GPT-OSS on GFX950

    Full-run benchmark summary
    ----------------------------------------------------------------------
                                  main (f132793)   branch (47fbdca, warp+splitK)
    Benchmark duration (s)              88.59            68.08
    Output token throughput            184.95           240.64
    Total token throughput            1664.55          2165.79
    Mean latency (ms)                44242.90         33991.67
    Mean TTFT (ms)                     505.18           502.01

   Branch is ~23% lower wall-clock and ~30% higher decode throughput at conc=8 in eager mode. 

