### PR TITLE
[WIP] feat: add DeepSeek V4 L2 KV offload

### DIFF
--- a/docs/design/deepseek-v4-l2-kv-offload.md
+++ b/docs/design/deepseek-v4-l2-kv-offload.md
@@ -1,0 +1,712 @@
+# DeepSeek V4 L2 KV Cache Offload Design
+
+Status: design and implementation plan for `feat/ds-v4-l2-offload`.
+
+This document designs host-side CPU L2 offload for DeepSeek V4 KV cache.
+It is intentionally scoped to L2 host memory. L3 storage, cross-node cache
+transport, and new third-party runtime dependencies are out of scope.
+
+## Goals
+
+1. Support DeepSeek V4 when KVStore is enabled internally
+   (`ServerArgs.enable_kvstore`) without falling back to token-indexed
+   `get_cpu_copy` / `load_cpu_copy` paths. Do not add a new CLI flag: the
+   user-facing switch today is `--disable-kvstore`, while KVStore defaults on
+   for non-decode instances unless disabled.
+2. Preserve the existing overlap scheduling contract: scheduler cache loadback
+   must not add a global GPU sync, and layer execution should only wait for the
+   loaded layer that it actually consumes.
+3. Offload the complete V4 paged cache state:
+   - SWA KV sliding-window cache.
+   - Compressed full-history KV cache.
+   - Compressor state sliding-window cache.
+   - CSA indexer KV cache that shares compressed-KV page ids.
+   - CSA indexer compressor state sliding-window cache.
+4. Maximize PCIe utilization by using page-level, batched, pinned host-memory
+   transfers on independent D2H and H2D streams.
+5. Keep runtime dependency boundaries unchanged. This implementation should not
+   add new runtime dependencies or new transfer kernels.
+
+The first production slice must support both history-family prefix reuse and
+terminal state prefix reuse. The replay semantics should match the existing
+device paged-cache replay path: host hits are first materialized back into
+device paged-cache pages, then the normal V4 forward path consumes device
+block tables and base logical-page offsets.
+
+## First Principles
+
+The design follows a few hard constraints instead of optimizing for abstraction
+generality:
+
+1. Cache correctness is ownership plus visibility. A cache page is reusable only
+   when the scheduler can prove which memory tier owns it and that the async
+   transfer that produced it has completed on every rank.
+2. Model code consumes device cache only. Host cache is a storage tier, not a
+   second attention backend. Therefore host hits must become device pages before
+   `FlatForwardOperation` is built.
+3. The scheduler owns cache identity and lifetime. Python runtime code owns
+   bytes and streams. Do not let runtime copy code decide prefix-cache validity.
+4. The transfer unit is a V4 paged-cache group page, not a token span and not
+   the ordinary KV page.
+5. Keep the first implementation simple: use pinned/registered host tensors and
+   batched DMA-style copies. Do not introduce a custom transfer kernel in this
+   implementation.
+6. Synchronization must be local to the data dependency. No scheduler-wide
+   loadback barrier, no global `torch.cuda.synchronize()`, and no stream wait
+   beyond the producing/consuming copy and layer events.
+
+## Current Code Facts
+
+DeepSeek V4 does not use the ordinary single KV page table.
+`DeepseekV4TokenToKVPool` owns several per-group paged buffers. The legacy
+token-indexed `get_cpu_copy` / `load_cpu_copy` APIs remain unsupported because
+compressed-MQA and indexer buffers are page-shaped and cannot be copied by
+token-indexed MHA/MLA logic. L2 support must therefore go through the
+group-paged host-pool path described below.
+
+The scheduler already has most of the device-side V4 model:
+
+- `PagedCacheGroupSpec` describes group id, rows per page, entry stride,
+  retention, sliding window, and history/state family.
+- `PagedCacheSnapshot` records per-group device page ownership plus cursor and
+  completeness metadata.
+- `HybridPrefixCache` can attach, import, and commit device-side V4 paged cache
+  snapshots.
+- `FlatForwardOperation` already carries `paged_cache_block_tables` and compact
+  logical-page base offsets to Python.
+
+The missing part is host residency for these group pages:
+
+- `TreeNode` currently has ordinary `DeviceResource`, ordinary `HostResource`,
+  Mamba device/host slots, and one `PagedCacheSnapshot`. That paged snapshot is
+  effectively device-side today.
+- `MatchResult::PagedCache` is a single hit structure. It does not distinguish
+  device pages from host pages.
+- `HybridPrefixCache::augmentMatchPagedCache` matches and imports device
+  paged-cache snapshots; `AcquireForRequest` expects page ids it can use as
+  device pages.
+- `CacheKind` currently distinguishes only `kv` and `mamba`.
+- `HostExecutor` is built around one `CachePool.page_size()` per kind. V4 group
+  pages have different byte sizes, so they should not be forced through the
+  existing kind/page-size path.
+- `MemoryExecutor` only creates MHA/MLA host KV pools plus the optional Mamba L2
+  pool.
+
+## Reference Patterns
+
+### Current Mamba L2
+
+The Mamba L2 path is the closest in-tree pattern:
+
+- Scheduler distinguishes device and host Mamba state.
+- Host memory is a dedicated layer-first pool.
+- Writeback is all-layer D2H.
+- Loadback is per-layer H2D.
+- `LayerDoneCounter` is used by the model path to wait only when a layer reads
+  restored state.
+
+This is the correct synchronization shape for V4. The main difference is that
+V4 has multiple independent paged groups and some logical groups map to more
+than one physical tensor.
+
+### vLLM CPU offload
+
+The local vLLM implementation reinforces several points that should carry over:
+
+- Scheduler-side state should manage cache identity, readiness, eviction, and
+  store/load preparation. Worker/runtime code should only execute transfer
+  specs.
+- Transfers should operate on canonical block/page descriptors rather than
+  model-specific token ranges.
+- Worker-side code canonicalizes model-specific KV layouts into raw
+  `[num_blocks, page_bytes]` tensors and data refs. TokenSpeed should do the
+  same for V4 group buffers instead of starting with a model-specific transfer
+  kernel.
+- Pinned or host-registered memory plus batched pointer descriptors are the
+  right first primitive. GPU-to-CPU is mostly DMA bandwidth bound, while
+  CPU-to-GPU uses the same batched-copy path in this implementation.
+- Store completion makes host cache visible. In-flight store blocks must be
+  pinned or otherwise protected so allocator reuse cannot race with async D2H.
+- DeepSeek-style hybrid groups need alignment filtering for sliding-window
+  groups: SWA pages that can never be used by a later full-history-aligned hit
+  should not be eagerly stored.
+
+TokenSpeed should not import vLLM code. The useful part is the separation of
+policy metadata from transfer execution, the canonical raw-block descriptor
+model, and the completion-before-visible rule.
+
+## DeepSeek V4 Cache Groups
+
+The L2 unit is a V4 paged-cache group page, not an ordinary KV token page.
+
+| Group | Family | Retention | Device buffers | L2 copy payload |
+| --- | --- | --- | --- | --- |
+| `v4.swa_kv` | state | sliding window | `swa_kv_buffer[layer]` | one uint8 SWA page per layer |
+| `v4.c{r}a.compressor_state` | state | sliding window | `compressor_state_buffer[layer]` for ratio `r` | one fp32 state page for each layer using ratio `r` |
+| `v4.c{r}a.compressed_kv` | history | full history | `compressed_kv_buffer[layer]` for ratio `r` | one uint8 compressed page for each layer using ratio `r` |
+| `v4.c4a.compressed_kv` | history | full history | `compressed_kv_buffer[layer]` and `indexer_kv_buffer[layer]` for ratio 4 | both tensors must be copied under the same logical page id |
+| `v4.c4a.indexer_compressor_state` | state | sliding window | `indexer_state_buffer[layer]` for ratio 4 | one fp32 indexer-state page for each ratio-4 layer |
+
+The ratio-4 indexer KV cache is the easiest place to corrupt correctness:
+it has no separate page table. A transfer for `v4.c4a.compressed_kv` must copy
+both compressed KV and indexer KV payloads for the same page id.
+
+## High-Level Flow
+
+```
+request finishes, retracts, or device cache pressure rises
+        |
+        v
+scheduler allocates host pages for every V4 group in the committed snapshot
+        |
+        v
+tree node owns a pending host paged-cache snapshot
+        |
+        v
+HostExecutor write stream copies device group pages to host group pages
+        |
+        v
+WriteBackDoneEvent promotes pending host snapshot after all-rank ack
+        |
+        v
+later request matches host pages when device pages are absent or shorter
+        |
+        v
+scheduler allocates device pages and emits paged-cache LoadBackOp
+        |
+        v
+forward op is built from destination device pages, never host page ids
+        |
+        v
+HostExecutor load stream copies host group pages back per layer
+        |
+        v
+V4 buffer getters wait through LayerDoneCounter before each layer reads cache
+```
+
+## Scheduler Design
+
+### Typed paged-cache transfer operations
+
+Do not encode V4 groups as more `CacheKind` enum values, and do not force V4
+through the existing `CachePool.page_size()` path. The group ids are already
+strings in scheduler configs and forward operations, and each V4 group has its
+own page id space and page byte size.
+
+Add a typed transfer payload beside ordinary `TransferPair`:
+
+```cpp
+struct PagedCacheTransferPair {
+    std::string group_id;
+    std::vector<std::int32_t> src_pages;
+    std::vector<std::int32_t> dst_pages;
+};
+```
+
+Then extend `WriteBackOperation`, `LoadBackOperation`, `FlatWriteBackOperation`,
+and `FlatLoadBackOperation` with:
+
+```cpp
+std::vector<std::vector<PagedCacheTransferPair>> paged_cache_transfers;
+```
+
+The outer vector is indexed by op id in the same order as `op_ids`. This keeps
+op-level grouping explicit and avoids adding parallel maps whose keys must be
+kept aligned by convention. Python bindings can expose the typed object or a
+plain list of `(group_id, src_pages, dst_pages)` tuples per op.
+
+Keep the current `src_pages`, `dst_pages`, and `src_pages_by_kind` fields
+unchanged for MHA/MLA/Mamba compatibility. V4 runtime code should consume only
+`paged_cache_transfers`; legacy KV runtime code should ignore it.
+
+This is the minimal ABI change that preserves the existing kind-pool model while
+making V4 group identity explicit.
+
+### Host paged-cache allocators
+
+Add host-side paged group allocators mirroring device paged group allocators.
+Each group must have its own host page id space.
+
+Host page counts must be computed from V4 group bytes, not from a single
+ordinary `num_host_pages` value:
+
+1. Runtime computes per-group `bytes_per_page` from the V4 layout and layer
+   ratios.
+2. If `--kvstore-size` is set, distribute the byte budget across groups in
+   proportion to desired resident device bytes, then divide by each group page
+   size.
+3. Otherwise use `ceil(device_group_pages * --kvstore-ratio)` per group.
+4. Send the per-group host page counts into scheduler config.
+
+State groups need enough host pages for trailing-window snapshots. History
+groups need enough pages for full-history prefix reuse. These capacities should
+be logged per group at startup because a single aggregate count is misleading.
+
+Concretely, add a scheduler config field parallel to `paged_cache_groups`, for
+example:
+
+```cpp
+std::map<std::string, std::int32_t> paged_cache_host_group_pages;
+```
+
+Python `scheduler_utils.make_config(...)` should populate it from
+`DeepseekV4TokenToKVPoolHost`. The existing scalar `num_host_pages` remains for
+ordinary KV host pages and must not be interpreted as V4 host group capacity.
+For V4, runtime should still provide a token-page shadow capacity through
+`num_host_pages` so the scheduler can attach `HostResource` locks to tree nodes
+that own visible host paged snapshots. These shadow pages do not allocate
+runtime KV host tensors and are not copied by `HostExecutor`; they exist only
+to reuse the existing HostNodeRef pin/eviction machinery for in-flight H2D
+sources and D2H destinations. Real V4 host capacity is solely the per-group
+`paged_cache_host_group_pages` map.
+
+### Tree-node residency model
+
+The tree needs separate device, visible host, and pending host paged-cache
+residency. The current single `PagedCacheSnapshot` can become the device
+snapshot, but host pages must not be stored in the same field because
+`AcquireForRequest` treats matched page ids as device pages.
+
+Conceptually:
+
+```cpp
+class TreeNode {
+    std::optional<PagedCacheSnapshot> paged_cache_device_snapshot_;
+    std::optional<PagedCacheSnapshot> paged_cache_host_snapshot_;
+    std::optional<PagedCacheSnapshot> paged_cache_pending_host_snapshot_;
+};
+```
+
+All snapshots must preserve:
+
+- `prefix_len_tokens`.
+- Per-group page ids.
+- Per-group base logical page.
+- Raw token cursor.
+- Complete history/state family metadata.
+
+The state transitions are:
+
+1. `CommitChunk` or state checkpoint produces a device snapshot under the
+   existing accepted-token boundary.
+2. Host writeback allocation creates `paged_cache_pending_host_snapshot_` with
+   host page ids. Pending snapshots are not visible to prefix matching.
+3. `WriteBackOperation` pins the source device snapshot and copies device pages
+   into pending host pages.
+4. `WriteBackDoneEvent` promotes pending host to visible host only after all
+   ranks report success.
+5. On failure, pending host pages are released and no visible host metadata is
+   changed.
+6. Device demotion may detach `paged_cache_device_snapshot_` only when no live
+   request or in-flight writeback pins it. It must not detach the visible host
+   snapshot.
+
+The implementation can hide these fields behind a small `PagedCacheResidency`
+helper if that keeps `TreeNode` cleaner, but the semantics above should remain
+explicit.
+
+### Matching and loadback
+
+Extend `HybridPrefixCache::augmentMatchPagedCache` so it can return both:
+
+- best device paged-cache hit, directly usable by a forward op;
+- best host paged-cache hit, usable after LoadBack.
+
+The match rules are identical for device and host snapshots:
+
+- History-family groups must be complete at the history alignment boundary.
+- State-family groups can be restored only when their trailing-window state is
+  complete for the selected node.
+- Transport-only continuation state requires exact terminal continuation; if it
+  is missing, cap the hit instead of silently reusing partial state.
+
+For DeepSeek V4, Python only passes history-family groups in the prefix-cache
+required group set. C++ derives the state-family groups from the registered
+allocators: page-aligned state groups may contribute to intermediate snapshots,
+while all state groups are also eligible for exact terminal continuation
+snapshots.
+
+The first implementation should support both match intents:
+
+- `MatchIntent::PrefixReuse`: import complete history-family groups. If the
+  selected replay point also has a complete terminal continuation snapshot,
+  import its state-family groups as well; otherwise cap the hit to history-only
+  replay instead of importing partial state.
+- `MatchIntent::StateRecovery`: require exact terminal state completeness for
+  SWA, compressor state, and indexer state. If exact terminal state is absent,
+  cap the hit just as the device replay path does.
+
+When host is deeper than device, the scheduler allocates device pages per group,
+emits a paged-cache `LoadBackOperation`, and constructs the forward operation
+with the destination device pages. The host snapshot is a source only; the
+forward operation must never contain host page ids.
+
+The replay sequence is therefore:
+
+1. Match host snapshot and compute usable prefix/state length.
+2. Allocate fresh device paged-cache pages for every imported group.
+3. Build `(host_page -> device_page)` transfers per group.
+4. Attach or import the destination device snapshot for the request.
+5. Populate `FlatForwardOperation.paged_cache_block_tables` from destination
+   device pages.
+6. Submit H2D loadback before model execution.
+7. Let V4 layer getters wait only for their producer layer event.
+
+Loadback does not need a scheduler completion event. It is synchronized by
+layer counters in the runtime, matching the current Mamba path.
+
+### Writeback and demotion
+
+Writeback should be generated when a committed V4 snapshot becomes worth
+preserving on host:
+
+- request finish;
+- retract/preempt path;
+- device residency demotion when host cache is enabled and pressure requires it.
+
+For every selected node:
+
+1. Read the already committed device `PagedCacheSnapshot`; do not infer pages
+   from request token length.
+2. Allocate host pages for each group and build a pending host snapshot.
+3. Emit `PagedCacheTransferPair` for each group.
+4. Keep the device snapshot pinned while the writeback is in flight.
+5. On all-rank success, promote pending host to visible host.
+6. If the host copy is complete and the device snapshot is no longer pinned by
+   live requests, demote only the device snapshot.
+
+On failed writeback, release the newly allocated host pages and keep scheduler
+metadata unchanged.
+
+This mirrors the vLLM completion-before-visible rule while staying inside
+TokenSpeed's existing event-state model.
+
+Visible host paged snapshots must be attached only to tree nodes that also have
+a scheduler `HostResource`. That resource is a shadow token-page lock for V4:
+it protects host paged pages from reuse while H2D loadback is in flight, and
+ordinary host-resource eviction releases the attached V4 host snapshot.
+
+### Accepted-token boundary
+
+For V4 MTP, only accepted target tokens may become globally reusable cache.
+Group pages that contain rejected verify-tail or draft-only state must remain
+request-local. The L2 writeback path must consume the same committed snapshot
+boundary as prefix-cache publish. It must not copy raw working buffers by
+request token length.
+
+## Runtime Design
+
+### Host pool
+
+Add a DeepSeek V4 host pool, for example:
+
+```python
+class DeepseekV4TokenToKVPoolHost:
+    def __init__(device_pool, host_ratio, host_size_gb, host_group_page_counts):
+        ...
+```
+
+The host layout should mirror V4 device group buffers:
+
+- `swa_kv_buffer[layer]`: `[host_swa_pages, swa_block_bytes]`, `uint8`, CPU.
+- `compressed_kv_buffer[layer]`: `[host_compressed_pages, compressed_page_bytes]`,
+  `uint8`, CPU.
+- `compressor_state_buffer[layer]`: `[host_state_pages, rows_per_page, state_width * 2]`,
+  `float32`, CPU.
+- `indexer_kv_buffer[layer]`: `[host_compressed_pages, indexer_page_bytes]`,
+  `uint8`, CPU, sharing the compressed group page count.
+- `indexer_state_buffer[layer]`: `[host_indexer_state_pages, rows_per_page, state_width * 2]`,
+  `float32`, CPU.
+
+Allocate CPU tensors normally, then register them through
+`current_platform().register_host_tensor_for_gpu_access`. This keeps the runtime
+inside existing platform abstractions and avoids a direct CUDA dependency.
+
+This implementation supports `layer_first` host layout only. It is the natural
+layout for per-layer loadback and matches the current V4 device buffer
+organization. `page_first` and L3-oriented contiguous page blobs are not in this
+scope.
+
+The host pool also reports a token-page shadow `page_num` derived from
+history-family host group capacity. This value is only scheduler metadata for
+`HostResource` locks; it does not create ordinary KV host buffers and must not
+be used as V4 group capacity.
+
+### Transfer pool
+
+Add a V4 transfer pool beside `KVCachePool` and `MambaCachePool`, but do not
+force it through the existing single-page-size `CachePool` shape. It should
+consume the typed `PagedCacheTransferPair` list and use group ids to build raw
+copy descriptors.
+
+```python
+class DeepseekV4CachePool:
+    supports_layerwise_loadback = True
+    def writeback_paged(transfers: list[PagedCacheTransferPair]): ...
+    def loadback_paged(
+        transfers: list[PagedCacheTransferPair],
+        layer_idx: int,
+    ): ...
+```
+
+`MemoryExecutor.submit` should route `paged_cache_transfers` to this pool when
+the device pool is `DeepseekV4TokenToKVPool`.
+
+The existing `CachePool.kind` protocol is keyed by `CacheKind`, which is too
+narrow for V4 group ids. Keep the old protocol for legacy pools and add an
+explicit V4 path in `HostExecutor` or a small sibling executor for paged-cache
+groups. That is less magical than pretending V4 is just another `kv` pool.
+
+### Copy implementation
+
+The first implementation should copy with canonical raw block descriptors:
+
+```python
+@dataclass
+class PagedCacheTensorRef:
+    group_id: str
+    layer_id: int
+    device_tensor: torch.Tensor  # viewed as [device_pages, page_bytes]
+    host_tensor: torch.Tensor    # viewed as [host_pages, page_bytes]
+    page_bytes: int
+```
+
+For each `PagedCacheTransferPair`, expand `(group_id, src_pages, dst_pages)` to
+one or more `PagedCacheTensorRef` copy descriptors. This mirrors vLLM's raw
+`[num_blocks, page_bytes]` canonicalization and keeps model-specific layout
+knowledge in one V4 host-pool module.
+
+The V4 group-to-buffer mapping is:
+
+- `v4.swa_kv`: copy `swa_kv_buffer[layer]`.
+- `v4.c{r}a.compressor_state`: copy `compressor_state_buffer[layer]` where
+  layer ratio is `r`.
+- `v4.c{r}a.compressed_kv`: copy `compressed_kv_buffer[layer]` where layer
+  ratio is `r`.
+- `v4.c4a.compressed_kv`: additionally copy `indexer_kv_buffer[layer]`.
+- `v4.c4a.indexer_compressor_state`: copy `indexer_state_buffer[layer]`.
+
+Use the existing runtime streams:
+
+- D2H writeback expands all layers for the selected group pages and submits one
+  merged batch on `write_stream`.
+- H2D loadback expands one layer at a time across all selected groups and
+  records the layer completion after that layer's batch completes.
+
+The initial backend should be a batched copy implementation over registered
+host memory. Prefer existing platform copy helpers or a small runtime wrapper
+around the same primitive shape as vLLM's `cuMemcpyBatchAsync` /
+`hipMemcpyBatchAsync` path. A new paged-copy kernel is not part of this design
+or implementation plan.
+
+CUDA D2H should prefer driver DMA / copy-engine behavior for large pages.
+H2D uses the same batched-copy implementation for now; no Triton/CuteDSL copy
+kernel is planned in this scope.
+
+### Layer synchronization
+
+Register a `LayerDoneCounter` on `DeepseekV4TokenToKVPool`. All V4 buffer
+accessors that can read restored pages must wait:
+
+- `get_swa_kv_buffer`
+- `get_compressed_kv_buffer_2d`
+- `get_compressor_state_buffer`
+- `get_indexer_kv_buffer_2d`
+- `get_indexer_state_buffer`
+- `get_key_buffer`, `get_value_buffer`, and `get_kv_buffer` through the SWA
+  getter
+
+Use one counter for the whole V4 pool. The load stream should mark a layer done
+only after every group payload for that layer has been copied. This avoids a
+partial restore where attention sees compressed KV but the indexer still sees
+stale state.
+
+Do not call `torch.cuda.synchronize()` in the offload path. The existing
+`LayerDoneCounter.update_producer()` may apply bounded backpressure when the
+producer ring is reused; that is acceptable because it is not a scheduler-wide
+loadback barrier and happens only when outstanding loadbacks exceed the counter
+ring.
+
+### Stream ordering
+
+The intended ordering is:
+
+- D2H writeback stream waits once on the current compute stream before reading
+  live device cache pages.
+- H2D loadback stream is submitted before forward execution.
+- Compute stream waits only when a V4 layer getter consumes a loaded layer.
+- Writeback is throttled behind loadback when both queues are non-empty, as
+  `HostExecutor.flush` already does.
+
+This preserves overlap scheduling:
+
+- lower model layers can execute while upper-layer H2D loadback is still in
+  flight;
+- D2H writeback can proceed after the producing compute stream reaches the
+  recorded point;
+- scheduler does not block on loadback completion;
+- bounded producer-ring backpressure is allowed when outstanding loadbacks
+  exceed available layer-event slots;
+- only writeback completion changes host residency metadata.
+
+## Implementation Plan
+
+This section is the scope for the implementation that follows this design. It
+does not include transfer-kernel tuning, L3 storage, page-first host layout, or
+new KVStore CLI flags.
+
+### 1. Scheduler Residency And Transfer Metadata
+
+Files likely touched:
+
+- `tokenspeed-scheduler/csrc/scheduler/operations/cache.h`
+- `tokenspeed-scheduler/bindings/python_module.cpp`
+- `tokenspeed-scheduler/csrc/resource/radix_tree/*`
+- `tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/*`
+- `tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp`
+- `tokenspeed-scheduler/csrc/fsm/forward_events.cpp`
+- `tokenspeed-scheduler/tests/cpp/*`
+
+Tasks:
+
+1. Add typed paged-cache transfer specs to cache ops and Python bindings.
+2. Add host paged-cache group allocators and config plumbing.
+3. Add device, visible-host, and pending-host paged-cache residency to tree
+   nodes or a `PagedCacheResidency` helper.
+4. Extend V4 paged-cache matching to report device and host hits for both
+   history-family prefix reuse and exact terminal state recovery.
+5. Generate LoadBackOp and WriteBackOp with per-group page ids.
+6. Attach host snapshots only after all-rank writeback completion.
+7. Add only the necessary C++ tests for the new scheduler contract:
+   - typed paged transfer fields survive flattening and Python binding shape;
+   - pending host snapshot is not matchable before writeback ack, then becomes
+     matchable after ack;
+   - host V4 hit allocates destination device group pages and forward metadata
+     uses those device pages, not host page ids;
+   - terminal state recovery from host succeeds when all state-family groups are
+     complete and caps the hit when a required state group is missing;
+   - ratio-4 compressed group transfer keeps compressed KV and indexer KV tied
+     to the same logical page id.
+   Do not add broad ordinary KV/Mamba regression tests unless the implementation
+   changes their existing cache-op behavior.
+
+### 2. Runtime Host Pool And L2 Transfer
+
+Files likely touched:
+
+- `python/tokenspeed/runtime/cache/executor/memory_executor.py`
+- `python/tokenspeed/runtime/cache/executor/host_executor.py`
+- `python/tokenspeed/runtime/cache/transfer/pool.py`
+- `python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py`
+- new `python/tokenspeed/runtime/cache/deepseek_v4_cache_host.py`
+- new `python/tokenspeed/runtime/cache/transfer/deepseek_v4_pool.py`
+- `python/tokenspeed/runtime/engine/event_loop.py`
+- `python/tokenspeed/runtime/engine/scheduler_utils.py`
+
+Tasks:
+
+1. Build `DeepseekV4TokenToKVPoolHost` with registered host tensors.
+2. Build `DeepseekV4CachePool` with canonical raw block descriptors and route
+   typed paged transfers through `MemoryExecutor`.
+3. Pass host paged group counts into scheduler config.
+4. Flip `DeepseekV4TokenToKVPool.supports_hierarchical_kv_cache` only when the
+   host pool path is implemented.
+5. Register and consume `LayerDoneCounter` in all V4 cache getters.
+6. Implement D2H and H2D with the batched-copy path over registered host memory.
+   Do not add a custom transfer kernel.
+7. Add only the necessary Python unit tests for runtime transfer/load:
+   - host page-count and tensor shape computation for V4 groups;
+   - canonical descriptor expansion for SWA, compressed KV, compressor state,
+     and ratio-4 indexer payloads;
+   - batched copy dispatch receives the expected descriptors for D2H and H2D;
+   - layerwise loadback marks a layer complete only after all required V4 group
+     descriptors for that layer are submitted.
+   Avoid testing the copy backend implementation itself with synthetic bandwidth
+   cases; integration validation is enough for transfer timing in this scope.
+
+### 3. Integration, Docs, And Validation
+
+Files likely touched:
+
+- `docs/serving/deepseek-v4.md`
+- scheduler/runtime metrics files
+
+Tasks:
+
+1. Document when DeepSeek V4 is supported under the existing KVStore behavior
+   and recommend `--kvstore-size` / `--kvstore-ratio` sizing. Do not introduce
+   a redundant affirmative enable CLI flag; users opt out with
+   `--disable-kvstore`.
+2. Add minimal logs and metrics required to validate the implementation:
+   - host pages total/free per V4 group;
+   - D2H/H2D pages and bytes per group;
+   - loadback queue time and transfer time if available from the copy helper;
+   - prefix hit tokens from device versus host;
+   - hit caps due to missing state groups.
+3. Validate functional correctness with GPU prefix cache reset followed by host
+   cache hit.
+4. Validate terminal state recovery from host and history-family prefix reuse
+   from host.
+5. Validate mixed prefill/decode does not introduce scheduler-wide loadback
+   waits.
+
+## Correctness Invariants
+
+1. A V4 host snapshot is visible to prefix matching only after all group pages
+   in that snapshot are written successfully.
+2. Pending host snapshots never participate in matching.
+3. A host hit must be replayed into destination device pages before
+   `FlatForwardOperation` is built. Forward ops never contain host page ids.
+4. A V4 forward operation may use loaded device pages only after the matching
+   layer's loadback event is complete.
+5. `v4.c4a.compressed_kv` host/device page ids cover both compressed KV and
+   indexer KV payloads.
+6. History groups and state groups are matched with the same completeness rules
+   on host and device.
+7. Terminal state recovery requires exact state-family completeness; otherwise
+   the match must cap rather than reuse partial state.
+8. L2 writeback copies committed cache snapshots, not raw request-local working
+   ranges.
+9. No offload path may call `torch.cuda.synchronize()` or force a scheduler-wide
+   loadback completion barrier.
+10. All ranks must generate equivalent cache op ids and host snapshot attachment
+   decisions; writeback success is committed only after rank agreement.
+
+## Performance Notes
+
+- Use pinned or CUDA-registered host tensors. Pageable host memory should be
+  treated as a correctness fallback only.
+- Start with batched DMA-style copies over canonical raw page tensors. A custom
+  copy kernel is not part of the first implementation.
+- Prefer larger merged descriptor batches for D2H; the transfer is bandwidth
+  bound and should use copy-engine DMA when page payloads are large.
+- Preserve per-layer H2D completion so the first layers can run while later
+  layers are still loading.
+- Keep writeback lower priority than loadback. A host cache hit that is needed
+  for the next forward has higher latency impact than preserving additional
+  evictable pages.
+- Skip storing sliding-window V4 pages that cannot serve a later replay hit
+  because they are outside the history alignment segment. This mirrors the
+  vLLM DeepSeek V4 MLA/SWA alignment optimization and avoids wasting host
+  bandwidth on dead SWA pages.
+- Compact and sort page ids inside a transfer group when doing so does not
+  change logical mapping. This improves descriptor locality for the batched
+  copy submission.
+- Track bytes per group. State groups can have tiny pages and may be dominated
+  by launch overhead; compressed/history groups should dominate bandwidth.
+
+## Risks
+
+- Treating all V4 groups as one page id space will silently corrupt cache.
+- Forgetting the ratio-4 indexer KV payload will produce sparse-indexer errors
+  even when compressed attention appears to work.
+- Allowing host matches without complete state groups can skip tokens whose
+  compressor or SWA state was never restored.
+- Promoting a pending host snapshot before all-rank writeback ack can make
+  prefix matching observe bytes that are not actually present on every rank.
+- Adding scheduler wait-for-loadback events would break the intended overlap
+  model and can regress mixed batches.
+- Host memory sizing by token count will be inaccurate because V4 group page
+  byte sizes differ by ratio and by state/history type.
+- MTP requires accepted-token publish discipline; draft or rejected pages must
+  not enter shared L2.

--- a/docs/serving/deepseek-v4.md
+++ b/docs/serving/deepseek-v4.md
@@ -18,8 +18,7 @@ CUDA_VISIBLE_DEVICES=0,1,2,3 tokenspeed serve deepseek-ai/DeepSeek-V4-Flash \
     --max-total-tokens 16384 \
     --chunked-prefill-size 8192 \
     --enable-mixed-batch \
-    --gpu-memory-utilization 0.9 \
-    --disable-kvstore
+    --gpu-memory-utilization 0.9
 ```
 
 ## Required flags
@@ -54,6 +53,35 @@ also be bumped to 256.)
   workspace (`0` lets the kernel pick).
 - `--deepseek-v4-indexer-prefill-max-logits-mb N`: caps the FP4 indexer
   prefill logits buffer in MB (default 512).
+
+## KVStore L2 host cache
+
+DeepSeek V4 supports KVStore L2 host offload through the existing KVStore
+switches. KVStore is enabled by default for non-decode instances unless
+`--disable-kvstore` is passed; do not add or use a separate `--enable-kvstore`
+flag.
+
+The V4 L2 path stores complete group-paged cache snapshots on host memory:
+SWA KV, compressed full-history KV, compressor state, CSA indexer KV, and CSA
+indexer compressor state. Host hits are loaded back into destination device
+group pages before forward execution, so model code still consumes device
+cache only. Loadback is synchronized per layer through the V4 cache pool's
+layer transfer counter; the scheduler does not wait for a global loadback
+barrier.
+
+Sizing is per V4 paged-cache group because the group page byte sizes differ:
+
+- `--kvstore-ratio R`: allocates `ceil(device_group_pages * R)` host pages per
+  V4 group.
+- `--kvstore-size N`: uses an aggregate host-memory budget in GB and distributes
+  it across V4 groups in proportion to resident device bytes.
+
+The scheduler also creates lightweight shadow host token pages for V4 tree-node
+pinning and eviction. They are metadata only; ordinary KV host buffers are not
+allocated or copied for DeepSeek V4.
+
+L3 storage backends are not part of the DeepSeek V4 path in this implementation.
+Do not combine V4 L2 with `--kvstore-storage-backend`.
 
 ## MTP speculative decoding
 
@@ -103,6 +131,11 @@ that is the supported phase-1 boundary. State-family reuse remains conservative:
 if SWA, compressed KV, compressor state, or CSA indexer state cannot be restored
 from a complete accepted snapshot, the request should fall back to recomputing
 that state rather than treating the speculative tail as reusable prefix state.
+
+V4 prefix caching can reuse both full-history group pages and exact terminal
+state snapshots. For MTP, only accepted target tokens may be published to shared
+device or host snapshots; rejected verify-tail and draft-only state must remain
+request-local.
 
 SWA cache insert slot mappings are validated against the current SWA group cache
 capacity before invoking fused cache writers. Multi-step MTP can carry padded or

--- a/python/tokenspeed/runtime/cache/deepseek_v4_cache_host.py
+++ b/python/tokenspeed/runtime/cache/deepseek_v4_cache_host.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import math
+import threading
+from functools import wraps
+from typing import Optional
+
+import psutil
+import torch
+from tokenspeed_kernel.platform import current_platform
+
+from tokenspeed.runtime.configs.deepseek_v4_cache_spec import (
+    V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
+    V4_SWA_KV_GROUP_ID,
+    v4_compressed_kv_group_id,
+    v4_compressor_state_group_id,
+)
+from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
+    DeepseekV4TokenToKVPool,
+    _deepseek_v4_cache_group_page_bytes,
+)
+from tokenspeed.runtime.utils import get_colorful_logger
+
+logger = get_colorful_logger(__name__)
+
+
+def synchronized(func):
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        with self.lock:
+            return func(self, *args, **kwargs)
+
+    return wrapper
+
+
+def _allocate_host_group_pages(
+    *,
+    device_counts: dict[str, int],
+    page_bytes: dict[str, int],
+    host_ratio: float,
+    host_size_gb: int,
+) -> dict[str, int]:
+    active_groups = [
+        group_id
+        for group_id, bytes_per_page in page_bytes.items()
+        if bytes_per_page > 0 and int(device_counts.get(group_id, 0)) > 0
+    ]
+    if not active_groups:
+        return {}
+
+    if host_size_gb <= 0:
+        return {
+            group_id: max(2, int(math.ceil(device_counts[group_id] * host_ratio)))
+            for group_id in active_groups
+        }
+
+    budget_bytes = int(host_size_gb * 1e9)
+    min_pages_per_group = 2  # page 0 is the dummy page; keep one usable page.
+    min_bytes = sum(
+        min_pages_per_group * page_bytes[group_id] for group_id in active_groups
+    )
+    if budget_bytes < min_bytes:
+        raise ValueError(
+            "DeepSeek V4 KVStore host budget is too small to allocate one usable "
+            "page plus the dummy page per group: "
+            f"budget={budget_bytes} bytes minimum={min_bytes} bytes"
+        )
+
+    counts = {group_id: min_pages_per_group for group_id in active_groups}
+    remaining_budget = budget_bytes - min_bytes
+    desired_bytes = {
+        group_id: int(device_counts[group_id]) * int(page_bytes[group_id])
+        for group_id in active_groups
+    }
+    total_desired = max(sum(desired_bytes.values()), 1)
+    for group_id in active_groups:
+        extra_budget = remaining_budget * desired_bytes[group_id] // total_desired
+        counts[group_id] += extra_budget // int(page_bytes[group_id])
+    return counts
+
+
+class DeepseekV4TokenToKVPoolHost:
+    """Registered host mirror for DeepSeek V4 paged-cache groups."""
+
+    def __init__(
+        self,
+        device_pool: DeepseekV4TokenToKVPool,
+        host_to_device_ratio: float,
+        host_size_gb: int,
+        layout: str = "layer_first",
+        device: str = "cpu",
+        register_host: bool = True,
+    ) -> None:
+        if layout != "layer_first":
+            raise ValueError("DeepSeek V4 KVStore host pool only supports layer_first")
+        if host_to_device_ratio <= 0 and host_size_gb <= 0:
+            raise ValueError("host_to_device_ratio must be positive")
+
+        self.device_pool = device_pool
+        self.layout = layout
+        self.device = device
+        self.layer_num = int(device_pool.layer_num)
+        self.lock = threading.RLock()
+
+        self.paged_cache_group_page_bytes = _deepseek_v4_cache_group_page_bytes(
+            device_pool.layout,
+            device_pool.paged_cache_group_specs,
+            self.layer_num,
+        )
+        self.paged_cache_group_page_counts = _allocate_host_group_pages(
+            device_counts=device_pool.paged_cache_group_page_counts,
+            page_bytes=self.paged_cache_group_page_bytes,
+            host_ratio=float(host_to_device_ratio),
+            host_size_gb=int(host_size_gb),
+        )
+        self._shadow_page_num = self._compute_shadow_page_num(device_pool)
+        self.total_bytes = int(
+            sum(
+                self.paged_cache_group_page_counts[group_id]
+                * self.paged_cache_group_page_bytes[group_id]
+                for group_id in self.paged_cache_group_page_counts
+            )
+        )
+        self._check_host_memory(self.total_bytes)
+
+        def alloc_like_group(
+            source: torch.Tensor | None,
+            group_id: str,
+        ) -> torch.Tensor | None:
+            if source is None:
+                return None
+            pages = int(self.paged_cache_group_page_counts[group_id])
+            use_pin_memory = bool(
+                device == "cpu" and not register_host and torch.cuda.is_available()
+            )
+            tensor = torch.empty(
+                (pages, *source.shape[1:]),
+                dtype=source.dtype,
+                device=device,
+                pin_memory=use_pin_memory,
+            )
+            if register_host:
+                current_platform().register_host_tensor_for_gpu_access(tensor)
+            return tensor
+
+        self.swa_kv_buffer = [
+            alloc_like_group(buf, V4_SWA_KV_GROUP_ID)
+            for buf in device_pool.swa_kv_buffer
+        ]
+        self.compressed_kv_buffer: list[torch.Tensor | None] = []
+        self.compressor_state_buffer: list[torch.Tensor | None] = []
+        self.indexer_kv_buffer: list[torch.Tensor | None] = []
+        self.indexer_state_buffer: list[torch.Tensor | None] = []
+
+        for layer_id, ratio in enumerate(device_pool.layout.layer_ratio):
+            compressed_group_id = v4_compressed_kv_group_id(ratio)
+            state_group_id = v4_compressor_state_group_id(ratio)
+            self.compressed_kv_buffer.append(
+                alloc_like_group(
+                    device_pool.compressed_kv_buffer[layer_id],
+                    compressed_group_id,
+                )
+                if ratio > 1
+                else None
+            )
+            self.compressor_state_buffer.append(
+                alloc_like_group(
+                    device_pool.compressor_state_buffer[layer_id],
+                    state_group_id,
+                )
+                if ratio > 1
+                else None
+            )
+            self.indexer_kv_buffer.append(
+                alloc_like_group(
+                    device_pool.indexer_kv_buffer[layer_id],
+                    compressed_group_id,
+                )
+                if ratio == 4
+                else None
+            )
+            self.indexer_state_buffer.append(
+                alloc_like_group(
+                    device_pool.indexer_state_buffer[layer_id],
+                    V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
+                )
+                if ratio == 4
+                else None
+            )
+
+        self.clear()
+        logger.info(
+            "Allocating %.2f GB host memory for DeepSeek V4 KVStore. "
+            "group_pages=%s group_page_bytes=%s shadow_page_num=%s layout=%s",
+            self.total_bytes / 1e9,
+            self.paged_cache_group_page_counts,
+            self.paged_cache_group_page_bytes,
+            self._shadow_page_num,
+            self.layout,
+        )
+
+    def _compute_shadow_page_num(self, device_pool: DeepseekV4TokenToKVPool) -> int:
+        """Token-page capacity used only for scheduler HostResource pinning."""
+        usable_token_pages_by_history_group: list[int] = []
+        token_page_size = max(1, int(device_pool.page_size))
+        for spec in device_pool.paged_cache_group_specs:
+            if getattr(spec, "family", "history") != "history":
+                continue
+            group_pages = int(self.paged_cache_group_page_counts.get(spec.group_id, 0))
+            usable_group_pages = max(0, group_pages - 1)  # page 0 is the dummy page.
+            raw_tokens = (
+                usable_group_pages
+                * int(spec.rows_per_page)
+                * int(spec.entry_stride_tokens)
+            )
+            usable_token_pages_by_history_group.append(
+                int(math.ceil(raw_tokens / token_page_size))
+            )
+        if not usable_token_pages_by_history_group:
+            return 0
+        usable_token_pages = min(usable_token_pages_by_history_group)
+        return usable_token_pages + 1 if usable_token_pages > 0 else 0
+
+    @staticmethod
+    def _check_host_memory(requested_bytes: int) -> None:
+        host_mem = psutil.virtual_memory()
+        ten_gb = 10 * (1024**3)
+        available_bytes = host_mem.available - ten_gb
+        if available_bytes <= 0:
+            available_bytes = host_mem.available
+        if requested_bytes > available_bytes:
+            raise ValueError(
+                "Not enough host memory available for DeepSeek V4 KVStore. "
+                f"Requesting {requested_bytes / 1e9:.2f} GB but only have "
+                f"{available_bytes / 1e9:.2f} GB free. Please reduce kvstore size."
+            )
+
+    @property
+    def page_num(self) -> int:
+        return self._shadow_page_num
+
+    @synchronized
+    def clear(self) -> None:
+        self.free_pages_by_group = {
+            group_id: torch.arange(1, count, dtype=torch.int64)
+            for group_id, count in self.paged_cache_group_page_counts.items()
+        }
+
+    def available_size(self, group_id: str | None = None) -> int:
+        if group_id is None:
+            return sum(len(pages) for pages in self.free_pages_by_group.values())
+        return len(self.free_pages_by_group[str(group_id)])
+
+    @synchronized
+    def alloc(self, group_id: str, need_pages: int) -> Optional[torch.Tensor]:
+        group_id = str(group_id)
+        if need_pages <= 0:
+            return torch.empty((0,), dtype=torch.int64)
+        free_pages = self.free_pages_by_group[group_id]
+        if need_pages > len(free_pages):
+            logger.warning(
+                "[deepseek_v4_l2] alloc FAILED group=%s n=%s remain=%s",
+                group_id,
+                need_pages,
+                len(free_pages),
+            )
+            return None
+        selected = free_pages[:need_pages]
+        self.free_pages_by_group[group_id] = free_pages[need_pages:]
+        return selected
+
+    @synchronized
+    def free(self, group_id: str, pages: torch.Tensor) -> int:
+        group_id = str(group_id)
+        max_pages = int(self.paged_cache_group_page_counts[group_id])
+        page_ids = {
+            int(page)
+            for page in pages.to(dtype=torch.int64, device="cpu").reshape(-1).tolist()
+            if 0 < int(page) < max_pages
+        }
+        if not page_ids:
+            return 0
+        existing_ids = set(
+            int(page) for page in self.free_pages_by_group[group_id].tolist()
+        )
+        new_pages = [page for page in sorted(page_ids) if page not in existing_ids]
+        if not new_pages:
+            return 0
+        pages = torch.tensor(new_pages, dtype=torch.int64)
+        self.free_pages_by_group[group_id] = torch.cat(
+            [self.free_pages_by_group[group_id], pages]
+        )
+        return len(new_pages)

--- a/python/tokenspeed/runtime/cache/executor/host_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/host_executor.py
@@ -30,7 +30,13 @@ from tokenspeed_scheduler import Cache
 
 from tokenspeed.runtime.cache.transfer.kv_pool import KVCachePool
 from tokenspeed.runtime.cache.transfer.pool import CachePool
-from tokenspeed.runtime.cache.transfer.types import CacheKind, Location, TransferUnit
+from tokenspeed.runtime.cache.transfer.types import (
+    PAGED_CACHE_KIND,
+    CacheKind,
+    Location,
+    PagedCacheTransferUnit,
+    TransferUnit,
+)
 from tokenspeed.runtime.execution.cuda_graph_wrapper import get_is_capture_mode
 from tokenspeed.runtime.utils import get_colorful_logger, get_device_module
 
@@ -117,32 +123,45 @@ class HostExecutor:
         draft_host_pool=None,
         draft_layer_num: int = 0,
         pools: list[CachePool] | None = None,
+        paged_pool=None,
     ):
         self.io_backend = io_backend
         if pools is None:
-            if (
-                page_size is None
-                or device_pool is None
-                or host_pool is None
-                or layer_num is None
-            ):
-                raise ValueError("HostExecutor requires either pools or KV pool inputs")
-            pools = [
-                KVCachePool(
-                    device_pool=device_pool,
-                    host_pool=host_pool,
-                    io_backend=io_backend,
-                    layer_num=layer_num,
-                    draft_device_pool=draft_device_pool,
-                    draft_host_pool=draft_host_pool,
-                    draft_layer_num=draft_layer_num,
-                )
-            ]
-        if not pools:
+            has_kv_inputs = (
+                page_size is not None
+                and device_pool is not None
+                and host_pool is not None
+                and layer_num is not None
+            )
+            if not has_kv_inputs:
+                if paged_pool is None:
+                    raise ValueError(
+                        "HostExecutor requires either pools, KV pool inputs, "
+                        "or a paged_pool"
+                    )
+                pools = []
+            else:
+                pools = [
+                    KVCachePool(
+                        device_pool=device_pool,
+                        host_pool=host_pool,
+                        io_backend=io_backend,
+                        layer_num=layer_num,
+                        draft_device_pool=draft_device_pool,
+                        draft_host_pool=draft_host_pool,
+                        draft_layer_num=draft_layer_num,
+                    )
+                ]
+        if not pools and paged_pool is None:
             raise ValueError("HostExecutor requires at least one cache pool")
 
         self.pools = {CacheKind(pool.kind): pool for pool in pools}
-        self.device = next(iter(self.pools.values())).device
+        self.paged_pool = paged_pool
+        self.device = (
+            next(iter(self.pools.values())).device
+            if self.pools
+            else self.paged_pool.device
+        )
 
         write_priority, load_priority = _cache_stream_priorities()
         self.write_stream = _new_cache_stream(write_priority)
@@ -155,6 +174,8 @@ class HostExecutor:
         self.load_queues: dict[CacheKind, list[TransferUnit]] = {
             kind: [] for kind in self.pools
         }
+        self.paged_write_queue: list[PagedCacheTransferUnit] = []
+        self.paged_load_queue: list[PagedCacheTransferUnit] = []
 
         self.ack_write_queue: list[_Ack] = []
         self.ack_load_queue: list[_Ack] = []
@@ -163,9 +184,13 @@ class HostExecutor:
         self._counters = {
             kind: pool.get_layer_done_counter() for kind, pool in self.pools.items()
         }
+        self._paged_counter = (
+            paged_pool.get_layer_done_counter() if paged_pool is not None else None
+        )
         self._producer_map: dict[CacheKind, OrderedDict[int, int]] = {
             kind: OrderedDict() for kind in self.pools
         }
+        self._paged_producer_map: OrderedDict[int, int] = OrderedDict()
         self._producer_map_limit = 1024
 
     def enqueue_writeback(
@@ -240,10 +265,45 @@ class HostExecutor:
             )
         )
 
-    def flush(self) -> None:
-        throttle_writeback = self._has_work(self.load_queues) and not any(
-            unit.is_retract for units in self.write_queues.values() for unit in units
+    def enqueue_paged_cache_writeback(
+        self,
+        op_id: int,
+        transfers: list,
+        is_retract: bool = False,
+    ) -> None:
+        if self.paged_pool is None:
+            if transfers:
+                raise ValueError("paged-cache writeback requires a paged_pool")
+            self.completed_writebacks.append(op_id)
+            return
+        if not transfers:
+            self.completed_writebacks.append(op_id)
+            return
+        self.paged_write_queue.append(
+            PagedCacheTransferUnit(
+                op_id=int(op_id),
+                transfers=list(transfers),
+                is_retract=is_retract,
+            )
         )
+
+    def enqueue_paged_cache_loadback(self, op_id: int, transfers: list) -> None:
+        if self.paged_pool is None:
+            if transfers:
+                raise ValueError("paged-cache loadback requires a paged_pool")
+            return
+        if not transfers:
+            return
+        self.paged_load_queue.append(
+            PagedCacheTransferUnit(op_id=int(op_id), transfers=list(transfers))
+        )
+
+    def flush(self) -> None:
+        has_load_work = self._has_work(self.load_queues) or bool(self.paged_load_queue)
+        has_retract_writeback = any(
+            unit.is_retract for units in self.write_queues.values() for unit in units
+        ) or any(unit.is_retract for unit in self.paged_write_queue)
+        throttle_writeback = has_load_work and not has_retract_writeback
         writeback_block_quota = (
             CONCURRENT_WRITEBACK_BLOCK_QUOTA if throttle_writeback else None
         )
@@ -256,7 +316,7 @@ class HostExecutor:
             self._writeback_block_quota = previous_writeback_block_quota
 
     def _start_writing(self) -> None:
-        if not self._has_work(self.write_queues):
+        if not self._has_work(self.write_queues) and not self.paged_write_queue:
             return
 
         start_event = device_module.Event()
@@ -278,13 +338,23 @@ class HostExecutor:
                 self._record_if_cuda(src_indices, self.write_stream)
                 self._record_if_cuda(dst_indices, self.write_stream)
                 op_ids.extend(unit.op_id for unit in units)
+            if self.paged_write_queue:
+                assert self.paged_pool is not None
+                transfers = [
+                    transfer
+                    for unit in self.paged_write_queue
+                    for transfer in unit.transfers
+                ]
+                self.paged_pool.writeback_paged(transfers)
+                op_ids.extend(unit.op_id for unit in self.paged_write_queue)
             finish_event.record()
 
         self._clear_queues(self.write_queues)
+        self.paged_write_queue.clear()
         self.ack_write_queue.append(_Ack(finish_event, _ordered_unique(op_ids)))
 
     def _start_loading(self) -> None:
-        if not self._has_work(self.load_queues):
+        if not self._has_work(self.load_queues) and not self.paged_load_queue:
             return
         assert (
             not get_is_capture_mode()
@@ -338,7 +408,30 @@ class HostExecutor:
                 while len(producer_map) > self._producer_map_limit:
                     producer_map.popitem(last=False)
 
+            if self.paged_load_queue:
+                assert self.paged_pool is not None
+                assert self._paged_counter is not None
+                producer_id = self._paged_counter.update_producer()
+                producer_event = self._paged_counter.events[producer_id]
+                producer_event.start_event.record()
+                producer_event.start_event.wait(self.load_stream)
+                transfers = [
+                    transfer
+                    for unit in self.paged_load_queue
+                    for transfer in unit.transfers
+                ]
+                for layer_index in range(self.paged_pool.num_layers()):
+                    self.paged_pool.loadback_paged(transfers, layer_index)
+                    producer_event.complete(layer_index)
+                op_ids = _ordered_unique(unit.op_id for unit in self.paged_load_queue)
+                self.ack_load_queue.append(_Ack(producer_event.finish_event, op_ids))
+                for op_id in op_ids:
+                    self._paged_producer_map[op_id] = producer_id
+                while len(self._paged_producer_map) > self._producer_map_limit:
+                    self._paged_producer_map.popitem(last=False)
+
         self._clear_queues(self.load_queues)
+        self.paged_load_queue.clear()
 
     @staticmethod
     def _has_work(queues: dict[CacheKind, list[TransferUnit]]) -> bool:
@@ -479,6 +572,8 @@ class HostExecutor:
             kind = CacheKind.KV
             op_id = int(kind_or_op_id)
         else:
+            if self._is_paged_kind(kind_or_op_id):
+                return self._paged_producer_map.pop(int(op_id), None)
             kind = CacheKind(kind_or_op_id)
         return self._producer_map[kind].pop(int(op_id), None)
 
@@ -491,8 +586,17 @@ class HostExecutor:
             kind = CacheKind.KV
             producer_index = kind_or_producer_index
         else:
+            if self._is_paged_kind(kind_or_producer_index):
+                assert self._paged_counter is not None
+                self._paged_counter.set_consumer(producer_index)
+                return
             kind = CacheKind(kind_or_producer_index)
         self._counters[kind].set_consumer(producer_index)
+
+    def _is_paged_kind(self, kind: CacheKind | str | int | Iterable[int]) -> bool:
+        if self.paged_pool is None:
+            return False
+        return str(kind) == PAGED_CACHE_KIND
 
     def shutdown(self) -> None:
         self.write_stream.synchronize()
@@ -501,15 +605,24 @@ class HostExecutor:
             shutdown = getattr(pool, "shutdown", None)
             if shutdown is not None:
                 shutdown()
+        if self.paged_pool is not None:
+            shutdown = getattr(self.paged_pool, "shutdown", None)
+            if shutdown is not None:
+                shutdown()
 
     def reset(self) -> None:
         self.write_stream.synchronize()
         self.load_stream.synchronize()
         self._clear_queues(self.write_queues)
         self._clear_queues(self.load_queues)
+        self.paged_write_queue.clear()
+        self.paged_load_queue.clear()
         self.ack_write_queue.clear()
         self.ack_load_queue.clear()
         for producer_map in self._producer_map.values():
             producer_map.clear()
+        self._paged_producer_map.clear()
         for counter in self._counters.values():
             counter.reset()
+        if self._paged_counter is not None:
+            self._paged_counter.reset()

--- a/python/tokenspeed/runtime/cache/executor/host_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/host_executor.py
@@ -22,6 +22,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections import OrderedDict
 from typing import Iterable, NamedTuple
 
@@ -63,6 +64,15 @@ def _new_cache_stream(priority: int | None = None):
         return device_module.Stream(priority=priority)
     except (RuntimeError, TypeError):
         return device_module.Stream()
+
+
+def _new_timing_event_if_debug():
+    if not logger.isEnabledFor(logging.DEBUG):
+        return None
+    try:
+        return device_module.Event(enable_timing=True)
+    except TypeError:
+        return None
 
 
 def page_ids_to_token_indices(
@@ -109,6 +119,8 @@ def _ordered_unique(values: Iterable[int]) -> list[int]:
 class _Ack(NamedTuple):
     finish_event: object  # device_module.Event
     op_ids: list[int]
+    timing_start_event: object | None = None  # device_module.Event
+    timing_finish_event: object | None = None  # device_module.Event
 
 
 class HostExecutor:
@@ -370,6 +382,10 @@ class HostExecutor:
                 producer_event = counter.events[producer_id]
                 producer_event.start_event.record()
                 producer_event.start_event.wait(self.load_stream)
+                timing_start_event = _new_timing_event_if_debug()
+                timing_finish_event = _new_timing_event_if_debug()
+                if timing_start_event is not None:
+                    timing_start_event.record()
 
                 unit = self._merge_units(units)
                 src_indices, dst_indices = self._prepare_indices(unit, pool)
@@ -399,9 +415,18 @@ class HostExecutor:
                     self._record_if_cuda(cow_src_indices, self.load_stream)
                 if cow_dst_indices is not None:
                     self._record_if_cuda(cow_dst_indices, self.load_stream)
+                if timing_finish_event is not None:
+                    timing_finish_event.record()
 
                 op_ids = _ordered_unique(unit.op_id for unit in units)
-                self.ack_load_queue.append(_Ack(producer_event.finish_event, op_ids))
+                self.ack_load_queue.append(
+                    _Ack(
+                        producer_event.finish_event,
+                        op_ids,
+                        timing_start_event,
+                        timing_finish_event,
+                    )
+                )
                 producer_map = self._producer_map[kind]
                 for op_id in op_ids:
                     producer_map[op_id] = producer_id
@@ -415,6 +440,10 @@ class HostExecutor:
                 producer_event = self._paged_counter.events[producer_id]
                 producer_event.start_event.record()
                 producer_event.start_event.wait(self.load_stream)
+                timing_start_event = _new_timing_event_if_debug()
+                timing_finish_event = _new_timing_event_if_debug()
+                if timing_start_event is not None:
+                    timing_start_event.record()
                 transfers = [
                     transfer
                     for unit in self.paged_load_queue
@@ -423,8 +452,17 @@ class HostExecutor:
                 for layer_index in range(self.paged_pool.num_layers()):
                     self.paged_pool.loadback_paged(transfers, layer_index)
                     producer_event.complete(layer_index)
+                if timing_finish_event is not None:
+                    timing_finish_event.record()
                 op_ids = _ordered_unique(unit.op_id for unit in self.paged_load_queue)
-                self.ack_load_queue.append(_Ack(producer_event.finish_event, op_ids))
+                self.ack_load_queue.append(
+                    _Ack(
+                        producer_event.finish_event,
+                        op_ids,
+                        timing_start_event,
+                        timing_finish_event,
+                    )
+                )
                 for op_id in op_ids:
                     self._paged_producer_map[op_id] = producer_id
                 while len(self._paged_producer_map) > self._producer_map_limit:
@@ -562,6 +600,29 @@ class HostExecutor:
         for ack in self.ack_load_queue:
             if not ack.finish_event.query():
                 remaining.append(ack)
+            else:
+                elapsed_ms = None
+                if (
+                    ack.timing_start_event is not None
+                    and ack.timing_finish_event is not None
+                ):
+                    try:
+                        elapsed_ms = ack.timing_start_event.elapsed_time(
+                            ack.timing_finish_event
+                        )
+                    except (AttributeError, RuntimeError, ValueError):
+                        elapsed_ms = None
+                if elapsed_ms is None:
+                    logger.debug(
+                        "[cache_op] loadback done op_ids=%s elapsed_ms=N/A",
+                        ack.op_ids,
+                    )
+                else:
+                    logger.debug(
+                        "[cache_op] loadback done op_ids=%s elapsed_ms=%.3f",
+                        ack.op_ids,
+                        elapsed_ms,
+                    )
         self.ack_load_queue[:] = remaining
         return results
 

--- a/python/tokenspeed/runtime/cache/executor/memory_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/memory_executor.py
@@ -54,6 +54,7 @@ from tokenspeed.runtime.cache.mamba_cache_host import MambaPoolHost
 from tokenspeed.runtime.cache.transfer.deepseek_v4_pool import (
     DeepseekV4CachePool,
     _count_page_spans,
+    _count_src_dst_spans,
     _ordered_page_pairs,
 )
 from tokenspeed.runtime.cache.transfer.kv_pool import KVCachePool
@@ -294,24 +295,39 @@ class MemoryExecutor:
     @staticmethod
     def _paged_transfer_summary(
         transfers: list,
-    ) -> tuple[int, int, int, list[str], list[str]]:
+    ) -> tuple[int, int, int, int, int, list[str], list[str], list[str], list[str]]:
         group_pages: dict[str, int] = {}
         group_spans: dict[str, int] = {}
+        group_src_spans: dict[str, int] = {}
+        group_dst_spans: dict[str, int] = {}
         for transfer in transfers:
             group_id = str(getattr(transfer, "group_id", "unknown"))
             src_pages = getattr(transfer, "src_pages", [])
             dst_pages = getattr(transfer, "dst_pages", [])
             page_pairs = _ordered_page_pairs(src_pages, dst_pages)
+            src_spans, dst_spans = _count_src_dst_spans(page_pairs)
             group_pages[group_id] = group_pages.get(group_id, 0) + len(page_pairs)
             group_spans[group_id] = group_spans.get(group_id, 0) + _count_page_spans(
                 page_pairs
             )
+            group_src_spans[group_id] = group_src_spans.get(group_id, 0) + src_spans
+            group_dst_spans[group_id] = group_dst_spans.get(group_id, 0) + dst_spans
         return (
             len(group_pages),
             sum(group_pages.values()),
             sum(group_spans.values()),
+            sum(group_src_spans.values()),
+            sum(group_dst_spans.values()),
             [f"{group_id}:{pages}" for group_id, pages in sorted(group_pages.items())],
             [f"{group_id}:{spans}" for group_id, spans in sorted(group_spans.items())],
+            [
+                f"{group_id}:{spans}"
+                for group_id, spans in sorted(group_src_spans.items())
+            ],
+            [
+                f"{group_id}:{spans}"
+                for group_id, spans in sorted(group_dst_spans.items())
+            ],
         )
 
     def set_mamba_layerwise_cow(
@@ -381,20 +397,30 @@ class MemoryExecutor:
                             group_count,
                             page_count,
                             span_count,
+                            src_span_count,
+                            dst_span_count,
                             group_pages,
                             group_spans,
+                            group_src_spans,
+                            group_dst_spans,
                         ) = self._paged_transfer_summary(paged_transfers)
                         logger.debug(
                             "[cache_op][paged_l2] writeback schedule "
                             "op_id=%s groups=%s pages=%s spans=%s "
-                            "group_pages=%s group_spans=%s "
+                            "src_spans=%s dst_spans=%s group_pages=%s "
+                            "group_spans=%s group_src_spans=%s "
+                            "group_dst_spans=%s "
                             "is_retract=%s",
                             op_id,
                             group_count,
                             page_count,
                             span_count,
+                            src_span_count,
+                            dst_span_count,
                             group_pages,
                             group_spans,
+                            group_src_spans,
+                            group_dst_spans,
                             is_retract,
                         )
                     self.host_exec.enqueue_paged_cache_writeback(
@@ -456,19 +482,29 @@ class MemoryExecutor:
                             group_count,
                             page_count,
                             span_count,
+                            src_span_count,
+                            dst_span_count,
                             group_pages,
                             group_spans,
+                            group_src_spans,
+                            group_dst_spans,
                         ) = self._paged_transfer_summary(paged_transfers)
                         logger.debug(
                             "[cache_op][paged_l2] loadback schedule "
                             "op_id=%s groups=%s pages=%s spans=%s "
-                            "group_pages=%s group_spans=%s",
+                            "src_spans=%s dst_spans=%s group_pages=%s "
+                            "group_spans=%s group_src_spans=%s "
+                            "group_dst_spans=%s",
                             op_id,
                             group_count,
                             page_count,
                             span_count,
+                            src_span_count,
+                            dst_span_count,
                             group_pages,
                             group_spans,
+                            group_src_spans,
+                            group_dst_spans,
                         )
                     self.host_exec.enqueue_paged_cache_loadback(
                         op_id,

--- a/python/tokenspeed/runtime/cache/executor/memory_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/memory_executor.py
@@ -51,7 +51,11 @@ from tokenspeed.runtime.cache.kv_cache_host import (
     MLATokenToKVPoolHost,
 )
 from tokenspeed.runtime.cache.mamba_cache_host import MambaPoolHost
-from tokenspeed.runtime.cache.transfer.deepseek_v4_pool import DeepseekV4CachePool
+from tokenspeed.runtime.cache.transfer.deepseek_v4_pool import (
+    DeepseekV4CachePool,
+    _count_page_spans,
+    _ordered_page_pairs,
+)
 from tokenspeed.runtime.cache.transfer.kv_pool import KVCachePool
 from tokenspeed.runtime.cache.transfer.mamba_pool import MambaCachePool
 from tokenspeed.runtime.cache.transfer.types import CacheKind
@@ -288,21 +292,26 @@ class MemoryExecutor:
         return groups
 
     @staticmethod
-    def _paged_transfer_summary(transfers: list) -> tuple[int, int, list[str]]:
+    def _paged_transfer_summary(
+        transfers: list,
+    ) -> tuple[int, int, int, list[str], list[str]]:
         group_pages: dict[str, int] = {}
+        group_spans: dict[str, int] = {}
         for transfer in transfers:
             group_id = str(getattr(transfer, "group_id", "unknown"))
             src_pages = getattr(transfer, "src_pages", [])
             dst_pages = getattr(transfer, "dst_pages", [])
-            page_pairs = {
-                (int(src_page), int(dst_page))
-                for src_page, dst_page in zip(src_pages, dst_pages)
-            }
+            page_pairs = _ordered_page_pairs(src_pages, dst_pages)
             group_pages[group_id] = group_pages.get(group_id, 0) + len(page_pairs)
+            group_spans[group_id] = group_spans.get(group_id, 0) + _count_page_spans(
+                page_pairs
+            )
         return (
             len(group_pages),
             sum(group_pages.values()),
+            sum(group_spans.values()),
             [f"{group_id}:{pages}" for group_id, pages in sorted(group_pages.items())],
+            [f"{group_id}:{spans}" for group_id, spans in sorted(group_spans.items())],
         )
 
     def set_mamba_layerwise_cow(
@@ -368,17 +377,24 @@ class MemoryExecutor:
                 )
                 if paged_transfers:
                     if logger.isEnabledFor(logging.DEBUG):
-                        group_count, page_count, group_pages = (
-                            self._paged_transfer_summary(paged_transfers)
-                        )
+                        (
+                            group_count,
+                            page_count,
+                            span_count,
+                            group_pages,
+                            group_spans,
+                        ) = self._paged_transfer_summary(paged_transfers)
                         logger.debug(
                             "[cache_op][paged_l2] writeback schedule "
-                            "op_id=%s groups=%s pages=%s group_pages=%s "
+                            "op_id=%s groups=%s pages=%s spans=%s "
+                            "group_pages=%s group_spans=%s "
                             "is_retract=%s",
                             op_id,
                             group_count,
                             page_count,
+                            span_count,
                             group_pages,
+                            group_spans,
                             is_retract,
                         )
                     self.host_exec.enqueue_paged_cache_writeback(
@@ -436,16 +452,23 @@ class MemoryExecutor:
                 )
                 if paged_transfers:
                     if logger.isEnabledFor(logging.DEBUG):
-                        group_count, page_count, group_pages = (
-                            self._paged_transfer_summary(paged_transfers)
-                        )
+                        (
+                            group_count,
+                            page_count,
+                            span_count,
+                            group_pages,
+                            group_spans,
+                        ) = self._paged_transfer_summary(paged_transfers)
                         logger.debug(
                             "[cache_op][paged_l2] loadback schedule "
-                            "op_id=%s groups=%s pages=%s group_pages=%s",
+                            "op_id=%s groups=%s pages=%s spans=%s "
+                            "group_pages=%s group_spans=%s",
                             op_id,
                             group_count,
                             page_count,
+                            span_count,
                             group_pages,
+                            group_spans,
                         )
                     self.host_exec.enqueue_paged_cache_loadback(
                         op_id,

--- a/python/tokenspeed/runtime/cache/executor/memory_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/memory_executor.py
@@ -40,6 +40,9 @@ except (ImportError, AttributeError):
 
 from tokenspeed_scheduler import Cache
 
+from tokenspeed.runtime.cache.deepseek_v4_cache_host import (
+    DeepseekV4TokenToKVPoolHost,
+)
 from tokenspeed.runtime.cache.executor.host_executor import HostExecutor
 from tokenspeed.runtime.cache.executor.storage_executor import StorageExecutor
 from tokenspeed.runtime.cache.kv_cache_host import (
@@ -47,9 +50,13 @@ from tokenspeed.runtime.cache.kv_cache_host import (
     MLATokenToKVPoolHost,
 )
 from tokenspeed.runtime.cache.mamba_cache_host import MambaPoolHost
+from tokenspeed.runtime.cache.transfer.deepseek_v4_pool import DeepseekV4CachePool
 from tokenspeed.runtime.cache.transfer.kv_pool import KVCachePool
 from tokenspeed.runtime.cache.transfer.mamba_pool import MambaCachePool
 from tokenspeed.runtime.cache.transfer.types import CacheKind
+from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
+    DeepseekV4TokenToKVPool,
+)
 from tokenspeed.runtime.layers.attention.kv_cache.mha import MHATokenToKVPool
 from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
 from tokenspeed.runtime.utils import get_colorful_logger
@@ -103,7 +110,26 @@ class MemoryExecutor:
         ):
             actual_pool = device_pool.inner
 
-        if isinstance(actual_pool, _mha_types):
+        self.paged_cache_pool = None
+        actual_draft_pool = None
+        if isinstance(actual_pool, DeepseekV4TokenToKVPool):
+            if config.storage_backend is not None:
+                raise NotImplementedError(
+                    "DeepSeek V4 KVStore currently supports L2 host memory only; "
+                    "L3 storage backends are out of scope."
+                )
+            self.host_pool = DeepseekV4TokenToKVPoolHost(
+                actual_pool,
+                config.host_ratio,
+                config.host_size_gb,
+                config.host_layout,
+            )
+            self.paged_cache_pool = DeepseekV4CachePool(
+                device_pool=actual_pool,
+                host_pool=self.host_pool,
+                io_backend=config.io_backend,
+            )
+        elif isinstance(actual_pool, _mha_types):
             self.host_pool = MHATokenToKVPoolHost(
                 actual_pool,
                 config.host_ratio,
@@ -121,14 +147,14 @@ class MemoryExecutor:
             )
         else:
             raise ValueError(
-                f"host_pool only supports MHA and MLA, got {type(actual_pool)} "
-                f"from module {type(actual_pool).__module__}"
+                "host_pool only supports MHA, MLA, and DeepSeek V4, "
+                f"got {type(actual_pool)} from module {type(actual_pool).__module__}"
             )
 
         # Draft model L2 cache: draft shares the same page mapping as the base
         # model, so its host pool must hold exactly the same number of tokens.
         # Pass host_size_tokens directly to bypass ratio/GB recalculation.
-        if draft_device_pool is not None:
+        if draft_device_pool is not None and self.paged_cache_pool is None:
             actual_draft_pool = draft_device_pool
             if hasattr(draft_device_pool, "inner") and not isinstance(
                 draft_device_pool, (*_mha_types, *_mla_types)
@@ -176,7 +202,8 @@ class MemoryExecutor:
         pools = None
         self.mamba_host_pool = None
         if (
-            config.enable_mamba_l2
+            self.paged_cache_pool is None
+            and config.enable_mamba_l2
             and mamba_pool is not None
             and config.mamba_l2_host_slots > 0
         ):
@@ -213,7 +240,13 @@ class MemoryExecutor:
                 config.host_layout,
             )
 
-        if pools is not None:
+        if self.paged_cache_pool is not None:
+            self.host_exec = HostExecutor(
+                pools=pools or [],
+                paged_pool=self.paged_cache_pool,
+                io_backend=config.io_backend,
+            )
+        elif pools is not None:
             self.host_exec = HostExecutor(pools=pools, io_backend=config.io_backend)
         else:
             self.host_exec = HostExecutor(
@@ -277,9 +310,14 @@ class MemoryExecutor:
                 len(op.dst_pages),
             )
             groups = self._page_groups_by_kind(op)
+            paged_transfers_by_op = getattr(op, "paged_cache_transfers", [])
+            is_retract_flags = getattr(op, "is_retract", [])
             for i in range(len(op.op_ids)):
                 op_id = op.op_ids[i]
-                is_retract = bool(getattr(op, "is_retract", [False])[i])
+                is_retract = (
+                    bool(is_retract_flags[i]) if i < len(is_retract_flags) else False
+                )
+                submitted = False
                 for kind, (src_groups, dst_groups) in groups.items():
                     if kind not in self.host_exec.pools:
                         continue
@@ -305,7 +343,18 @@ class MemoryExecutor:
                         is_retract=is_retract,
                         kind=kind,
                     )
-                if all(
+                    submitted = True
+                paged_transfers = (
+                    paged_transfers_by_op[i] if i < len(paged_transfers_by_op) else []
+                )
+                if paged_transfers:
+                    self.host_exec.enqueue_paged_cache_writeback(
+                        op_id,
+                        paged_transfers,
+                        is_retract=is_retract,
+                    )
+                    submitted = True
+                if not submitted and all(
                     i >= len(src_groups) or not src_groups[i]
                     for kind, (src_groups, _) in groups.items()
                     if kind in self.host_exec.pools
@@ -319,6 +368,7 @@ class MemoryExecutor:
                 len(op.dst_pages),
             )
             groups = self._page_groups_by_kind(op)
+            paged_transfers_by_op = getattr(op, "paged_cache_transfers", [])
             for i in range(len(op.op_ids)):
                 op_id = op.op_ids[i]
                 for kind, (src_groups, dst_groups) in groups.items():
@@ -347,6 +397,14 @@ class MemoryExecutor:
                         )
                     self.host_exec.enqueue_loadback(
                         op_id, src_pages, dst_pages, kind=kind, **loadback_kwargs
+                    )
+                paged_transfers = (
+                    paged_transfers_by_op[i] if i < len(paged_transfers_by_op) else []
+                )
+                if paged_transfers:
+                    self.host_exec.enqueue_paged_cache_loadback(
+                        op_id,
+                        paged_transfers,
                     )
 
         elif isinstance(op, Cache.PrefetchOp):

--- a/python/tokenspeed/runtime/cache/executor/memory_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/memory_executor.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 """Top-level memory executor that coordinates host and storage executors."""
 
+import logging
 from dataclasses import dataclass
 from typing import Iterable, Optional
 
@@ -286,6 +287,24 @@ class MemoryExecutor:
             groups[kind] = (src_pages, dst_pages)
         return groups
 
+    @staticmethod
+    def _paged_transfer_summary(transfers: list) -> tuple[int, int, list[str]]:
+        group_pages: dict[str, int] = {}
+        for transfer in transfers:
+            group_id = str(getattr(transfer, "group_id", "unknown"))
+            src_pages = getattr(transfer, "src_pages", [])
+            dst_pages = getattr(transfer, "dst_pages", [])
+            page_pairs = {
+                (int(src_page), int(dst_page))
+                for src_page, dst_page in zip(src_pages, dst_pages)
+            }
+            group_pages[group_id] = group_pages.get(group_id, 0) + len(page_pairs)
+        return (
+            len(group_pages),
+            sum(group_pages.values()),
+            [f"{group_id}:{pages}" for group_id, pages in sorted(group_pages.items())],
+        )
+
     def set_mamba_layerwise_cow(
         self, cow_dst_pages_by_src: dict[int, list[int]] | None
     ) -> None:
@@ -348,6 +367,20 @@ class MemoryExecutor:
                     paged_transfers_by_op[i] if i < len(paged_transfers_by_op) else []
                 )
                 if paged_transfers:
+                    if logger.isEnabledFor(logging.DEBUG):
+                        group_count, page_count, group_pages = (
+                            self._paged_transfer_summary(paged_transfers)
+                        )
+                        logger.debug(
+                            "[cache_op][paged_l2] writeback schedule "
+                            "op_id=%s groups=%s pages=%s group_pages=%s "
+                            "is_retract=%s",
+                            op_id,
+                            group_count,
+                            page_count,
+                            group_pages,
+                            is_retract,
+                        )
                     self.host_exec.enqueue_paged_cache_writeback(
                         op_id,
                         paged_transfers,
@@ -402,6 +435,18 @@ class MemoryExecutor:
                     paged_transfers_by_op[i] if i < len(paged_transfers_by_op) else []
                 )
                 if paged_transfers:
+                    if logger.isEnabledFor(logging.DEBUG):
+                        group_count, page_count, group_pages = (
+                            self._paged_transfer_summary(paged_transfers)
+                        )
+                        logger.debug(
+                            "[cache_op][paged_l2] loadback schedule "
+                            "op_id=%s groups=%s pages=%s group_pages=%s",
+                            op_id,
+                            group_count,
+                            page_count,
+                            group_pages,
+                        )
                     self.host_exec.enqueue_paged_cache_loadback(
                         op_id,
                         paged_transfers,

--- a/python/tokenspeed/runtime/cache/kvstore_controller.py
+++ b/python/tokenspeed/runtime/cache/kvstore_controller.py
@@ -57,7 +57,12 @@ class LayerDoneCounter:
         self.producer_index = -1
         self.consumer_indices: tuple[int, ...] = ()
         self._debug_wait_records: list[tuple[int, int, object, object]] = []
-        self._debug_sample_layers = {0, max(0, num_layers // 2), max(0, num_layers - 1)}
+        self._debug_sample_layers = {
+            0,
+            min(3, max(0, num_layers - 1)),
+            max(0, num_layers // 2),
+            max(0, num_layers - 1),
+        }
         self._debug_record_limit = 96
 
     def update_producer(self):

--- a/python/tokenspeed/runtime/cache/kvstore_controller.py
+++ b/python/tokenspeed/runtime/cache/kvstore_controller.py
@@ -20,6 +20,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Iterable
 
 from tokenspeed.runtime.utils import get_colorful_logger, get_device_module
@@ -55,6 +56,9 @@ class LayerDoneCounter:
         self.events = [LayerLoadingEvent(num_layers) for _ in range(self.num_counters)]
         self.producer_index = -1
         self.consumer_indices: tuple[int, ...] = ()
+        self._debug_wait_records: list[tuple[int, int, object, object]] = []
+        self._debug_sample_layers = {0, max(0, num_layers // 2), max(0, num_layers - 1)}
+        self._debug_record_limit = 96
 
     def update_producer(self):
         next_index = (self.producer_index + 1) % self.num_counters
@@ -76,9 +80,54 @@ class LayerDoneCounter:
     def wait_until(self, threshold: int):
         if not self.consumer_indices:
             return
+        record_wait = (
+            logger.isEnabledFor(logging.DEBUG)
+            and threshold in self._debug_sample_layers
+            and len(self._debug_wait_records) < self._debug_record_limit
+        )
         for consumer_index in self.consumer_indices:
-            self.events[consumer_index].wait(threshold)
+            if record_wait:
+                start_event = device_module.Event(enable_timing=True)
+                end_event = device_module.Event(enable_timing=True)
+                start_event.record()
+                self.events[consumer_index].wait(threshold)
+                end_event.record()
+                self._debug_wait_records.append(
+                    (consumer_index, threshold, start_event, end_event)
+                )
+            else:
+                self.events[consumer_index].wait(threshold)
+
+    def consume_debug_wait_records(self, sync: bool = False):
+        records = []
+        pending = 0
+        for (
+            consumer_index,
+            layer_index,
+            start_event,
+            end_event,
+        ) in self._debug_wait_records:
+            if sync:
+                end_event.synchronize()
+            if not end_event.query():
+                pending += 1
+                continue
+            try:
+                elapsed_ms = start_event.elapsed_time(end_event)
+            except (AttributeError, RuntimeError, ValueError):
+                pending += 1
+                continue
+            records.append(
+                {
+                    "producer": consumer_index,
+                    "layer": layer_index,
+                    "wait_ms": round(float(elapsed_ms), 3),
+                }
+            )
+        self._debug_wait_records.clear()
+        return records, pending
 
     def reset(self):
         self.producer_index = -1
         self.consumer_indices = ()
+        self._debug_wait_records.clear()

--- a/python/tokenspeed/runtime/cache/transfer/__init__.py
+++ b/python/tokenspeed/runtime/cache/transfer/__init__.py
@@ -2,8 +2,10 @@ from tokenspeed.runtime.cache.transfer.kv_pool import KVCachePool
 from tokenspeed.runtime.cache.transfer.mamba_pool import MambaCachePool
 from tokenspeed.runtime.cache.transfer.pool import CachePool
 from tokenspeed.runtime.cache.transfer.types import (
+    PAGED_CACHE_KIND,
     CacheKind,
     Location,
+    PagedCacheTransferUnit,
     TransferBatch,
     TransferUnit,
 )
@@ -14,6 +16,8 @@ __all__ = [
     "KVCachePool",
     "Location",
     "MambaCachePool",
+    "PAGED_CACHE_KIND",
+    "PagedCacheTransferUnit",
     "TransferBatch",
     "TransferUnit",
 ]

--- a/python/tokenspeed/runtime/cache/transfer/deepseek_v4_pool.py
+++ b/python/tokenspeed/runtime/cache/transfer/deepseek_v4_pool.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import torch
+from tokenspeed_kernel.ops.kvcache.cuda import transfer_kv_direct
+
+from tokenspeed.runtime.cache.deepseek_v4_cache_host import (
+    DeepseekV4TokenToKVPoolHost,
+)
+from tokenspeed.runtime.cache.kvstore_controller import LayerDoneCounter
+from tokenspeed.runtime.cache.transfer.types import PAGED_CACHE_KIND
+from tokenspeed.runtime.configs.deepseek_v4_cache_spec import (
+    V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
+    V4_SWA_KV_GROUP_ID,
+    parse_v4_compressor_state_group_id,
+)
+from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
+    DeepseekV4TokenToKVPool,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PagedCacheTensorRef:
+    group_id: str
+    layer_id: int
+    device_tensor: torch.Tensor
+    host_tensor: torch.Tensor
+    page_bytes: int
+
+
+def _parse_v4_compressed_kv_group_id(group_id: str) -> int | None:
+    prefix = "v4.c"
+    suffix = "a.compressed_kv"
+    if not group_id.startswith(prefix) or not group_id.endswith(suffix):
+        return None
+    try:
+        return int(group_id[len(prefix) : -len(suffix)])
+    except ValueError:
+        return None
+
+
+def _ordered_page_pairs(src_pages: Iterable[int], dst_pages: Iterable[int]):
+    seen = set()
+    pairs = []
+    for src_page, dst_page in zip(src_pages, dst_pages):
+        pair = (int(src_page), int(dst_page))
+        if pair in seen:
+            continue
+        seen.add(pair)
+        pairs.append(pair)
+    pairs.sort()
+    return pairs
+
+
+class DeepseekV4CachePool:
+    """Group-paged DeepSeek V4 L2 transfer pool.
+
+    This pool deliberately does not implement the CacheKind protocol. It is
+    driven by typed paged-cache transfers whose group ids carry the page space.
+    """
+
+    kind = PAGED_CACHE_KIND
+
+    def __init__(
+        self,
+        device_pool: DeepseekV4TokenToKVPool,
+        host_pool: DeepseekV4TokenToKVPoolHost,
+        io_backend: str,
+    ) -> None:
+        if io_backend not in ("kernel", "direct"):
+            raise ValueError(
+                f"Unsupported DeepSeek V4 paged-cache io_backend={io_backend}"
+            )
+        self.device_pool = device_pool
+        self.host_pool = host_pool
+        self.io_backend = io_backend
+        self._counter = LayerDoneCounter(self.num_layers())
+        device_pool.register_layer_transfer_counter(self._counter)
+        self._transfer_stats: dict[str, dict[str, dict[str, int]]] = {
+            "D2H": {},
+            "H2D": {},
+        }
+
+    @property
+    def device(self):
+        return self.device_pool.device
+
+    @property
+    def host_layout(self) -> str:
+        return self.host_pool.layout
+
+    def num_layers(self) -> int:
+        return int(self.device_pool.layer_num)
+
+    def supports_layerwise_loadback(self) -> bool:
+        return True
+
+    def get_layer_done_counter(self) -> LayerDoneCounter:
+        return self._counter
+
+    def get_transfer_stats(self) -> dict[str, dict[str, dict[str, int]]]:
+        return {
+            direction: {group_id: dict(values) for group_id, values in groups.items()}
+            for direction, groups in self._transfer_stats.items()
+        }
+
+    def reset_transfer_stats(self) -> None:
+        for groups in self._transfer_stats.values():
+            groups.clear()
+
+    def local_layer_idx(self, global_layer_id: int) -> int:
+        return global_layer_id
+
+    def tensor_refs_for_group(
+        self,
+        group_id: str,
+        layer_idx: int | None = None,
+    ) -> list[PagedCacheTensorRef]:
+        group_id = str(group_id)
+        layer_ids = (
+            range(self.num_layers())
+            if layer_idx is None
+            else range(layer_idx, layer_idx + 1)
+        )
+        refs: list[PagedCacheTensorRef] = []
+        for layer_id in layer_ids:
+            ratio = int(self.device_pool.layout.layer_ratio[layer_id])
+            if group_id == V4_SWA_KV_GROUP_ID:
+                refs.append(
+                    self._ref(
+                        group_id,
+                        layer_id,
+                        self.device_pool.swa_kv_buffer[layer_id],
+                        self.host_pool.swa_kv_buffer[layer_id],
+                    )
+                )
+                continue
+
+            state_ratio = parse_v4_compressor_state_group_id(group_id)
+            if state_ratio is not None:
+                if ratio == state_ratio:
+                    refs.append(
+                        self._ref(
+                            group_id,
+                            layer_id,
+                            self.device_pool.compressor_state_buffer[layer_id],
+                            self.host_pool.compressor_state_buffer[layer_id],
+                        )
+                    )
+                continue
+
+            compressed_ratio = _parse_v4_compressed_kv_group_id(group_id)
+            if compressed_ratio is not None:
+                if ratio == compressed_ratio:
+                    refs.append(
+                        self._ref(
+                            group_id,
+                            layer_id,
+                            self.device_pool.compressed_kv_buffer[layer_id],
+                            self.host_pool.compressed_kv_buffer[layer_id],
+                        )
+                    )
+                    if ratio == 4:
+                        refs.append(
+                            self._ref(
+                                group_id,
+                                layer_id,
+                                self.device_pool.indexer_kv_buffer[layer_id],
+                                self.host_pool.indexer_kv_buffer[layer_id],
+                            )
+                        )
+                continue
+
+            if group_id == V4_INDEXER_COMPRESSOR_STATE_GROUP_ID:
+                if ratio == 4:
+                    refs.append(
+                        self._ref(
+                            group_id,
+                            layer_id,
+                            self.device_pool.indexer_state_buffer[layer_id],
+                            self.host_pool.indexer_state_buffer[layer_id],
+                        )
+                    )
+                continue
+
+            raise KeyError(f"unknown DeepSeek V4 paged-cache group {group_id!r}")
+        return refs
+
+    @staticmethod
+    def _ref(
+        group_id: str,
+        layer_id: int,
+        device_tensor: torch.Tensor | None,
+        host_tensor: torch.Tensor | None,
+    ) -> PagedCacheTensorRef:
+        if device_tensor is None or host_tensor is None:
+            raise ValueError(
+                f"DeepSeek V4 group {group_id!r} has no tensor for layer {layer_id}"
+            )
+        return PagedCacheTensorRef(
+            group_id=group_id,
+            layer_id=layer_id,
+            device_tensor=device_tensor,
+            host_tensor=host_tensor,
+            page_bytes=int(device_tensor[0].nbytes),
+        )
+
+    def writeback_paged(self, transfers: list) -> None:
+        self._copy_paged(transfers, host_to_device=False, layer_idx=None)
+
+    def loadback_paged(self, transfers: list, layer_idx: int) -> None:
+        self._copy_paged(transfers, host_to_device=True, layer_idx=layer_idx)
+
+    def _copy_paged(
+        self,
+        transfers: list,
+        *,
+        host_to_device: bool,
+        layer_idx: int | None,
+    ) -> None:
+        for transfer in transfers:
+            src_pages = list(getattr(transfer, "src_pages"))
+            dst_pages = list(getattr(transfer, "dst_pages"))
+            if len(src_pages) != len(dst_pages):
+                raise ValueError(
+                    "DeepSeek V4 paged transfer page count mismatch for "
+                    f"group={transfer.group_id!r}: {len(src_pages)} src vs "
+                    f"{len(dst_pages)} dst"
+                )
+            pairs = _ordered_page_pairs(src_pages, dst_pages)
+            if not pairs:
+                continue
+            ordered_src = torch.tensor(
+                [src for src, _ in pairs], dtype=torch.int64, device="cpu"
+            )
+            ordered_dst = torch.tensor(
+                [dst for _, dst in pairs], dtype=torch.int64, device="cpu"
+            )
+            refs = self.tensor_refs_for_group(transfer.group_id, layer_idx=layer_idx)
+            if not refs:
+                continue
+            direction = "H2D" if host_to_device else "D2H"
+            transfer_bytes = len(pairs) * sum(ref.page_bytes for ref in refs)
+            if host_to_device:
+                src_layers = [ref.host_tensor for ref in refs]
+                dst_layers = [ref.device_tensor for ref in refs]
+            else:
+                src_layers = [ref.device_tensor for ref in refs]
+                dst_layers = [ref.host_tensor for ref in refs]
+            transfer_kv_direct(
+                src_layers=src_layers,
+                dst_layers=dst_layers,
+                src_indices=ordered_src,
+                dst_indices=ordered_dst,
+                page_size=1,
+            )
+            self._record_transfer_stats(
+                direction,
+                str(transfer.group_id),
+                pages=len(pairs),
+                transfer_bytes=transfer_bytes,
+            )
+
+    def _record_transfer_stats(
+        self,
+        direction: str,
+        group_id: str,
+        *,
+        pages: int,
+        transfer_bytes: int,
+    ) -> None:
+        stats = self._transfer_stats[direction].setdefault(
+            group_id,
+            {"calls": 0, "pages": 0, "bytes": 0},
+        )
+        stats["calls"] += 1
+        stats["pages"] += int(pages)
+        stats["bytes"] += int(transfer_bytes)

--- a/python/tokenspeed/runtime/cache/transfer/deepseek_v4_pool.py
+++ b/python/tokenspeed/runtime/cache/transfer/deepseek_v4_pool.py
@@ -81,6 +81,19 @@ def _count_page_spans(pairs: Iterable[PagePair]) -> int:
     return spans
 
 
+def _count_src_dst_spans(pairs: Iterable[PagePair]) -> tuple[int, int]:
+    src_spans = 0
+    dst_spans = 0
+    prev_pair: PagePair | None = None
+    for src_page, dst_page in pairs:
+        if prev_pair is None or src_page != prev_pair[0] + 1:
+            src_spans += 1
+        if prev_pair is None or dst_page != prev_pair[1] + 1:
+            dst_spans += 1
+        prev_pair = (src_page, dst_page)
+    return src_spans, dst_spans
+
+
 class DeepseekV4CachePool:
     """Group-paged DeepSeek V4 L2 transfer pool.
 

--- a/python/tokenspeed/runtime/cache/transfer/deepseek_v4_pool.py
+++ b/python/tokenspeed/runtime/cache/transfer/deepseek_v4_pool.py
@@ -30,6 +30,9 @@ class PagedCacheTensorRef:
     page_bytes: int
 
 
+PagePair = tuple[int, int]
+
+
 def _parse_v4_compressed_kv_group_id(group_id: str) -> int | None:
     prefix = "v4.c"
     suffix = "a.compressed_kv"
@@ -41,17 +44,41 @@ def _parse_v4_compressed_kv_group_id(group_id: str) -> int | None:
         return None
 
 
-def _ordered_page_pairs(src_pages: Iterable[int], dst_pages: Iterable[int]):
+def _page_pair_span_key(pair: PagePair) -> tuple[int, int, int]:
+    src_page, dst_page = pair
+    return (dst_page - src_page, src_page, dst_page)
+
+
+def _ordered_page_pairs(
+    src_pages: Iterable[int],
+    dst_pages: Iterable[int],
+) -> list[PagePair]:
     seen = set()
-    pairs = []
+    pairs: list[PagePair] = []
     for src_page, dst_page in zip(src_pages, dst_pages):
         pair = (int(src_page), int(dst_page))
         if pair in seen:
             continue
         seen.add(pair)
         pairs.append(pair)
-    pairs.sort()
+    # transfer_kv_direct coalesces adjacent pairs only when both page ids
+    # advance by one, which means all pairs in a coalescible span share dst-src.
+    pairs.sort(key=_page_pair_span_key)
     return pairs
+
+
+def _count_page_spans(pairs: Iterable[PagePair]) -> int:
+    spans = 0
+    prev_pair: PagePair | None = None
+    for src_page, dst_page in pairs:
+        if (
+            prev_pair is None
+            or src_page != prev_pair[0] + 1
+            or dst_page != prev_pair[1] + 1
+        ):
+            spans += 1
+        prev_pair = (src_page, dst_page)
+    return spans
 
 
 class DeepseekV4CachePool:

--- a/python/tokenspeed/runtime/cache/transfer/types.py
+++ b/python/tokenspeed/runtime/cache/transfer/types.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 import torch
+
+PAGED_CACHE_KIND = "paged_cache"
 
 
 class CacheKind(str, Enum):
@@ -38,3 +41,10 @@ class TransferUnit:
 class TransferBatch:
     units: list[TransferUnit]
     op_ids: list[int]
+
+
+@dataclass(slots=True)
+class PagedCacheTransferUnit:
+    op_id: int
+    transfers: list[Any]
+    is_retract: bool = False

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 
 import faulthandler
+import logging
 import signal
 import time
 from collections import OrderedDict
@@ -1157,11 +1158,13 @@ class EventLoop:
         self._dp_local_info[0, 0] = num_tokens
         self._dp_local_info[0, 1] = batch_size
         self._dp_local_info[0, 2] = int(forward_mode)
+        sync_tic = time.perf_counter()
         dist.all_gather_into_tensor(
             self._dp_global_info,
             self._dp_local_info,
             group=self.world_cpu_group,
         )
+        sync_elapsed_ms = (time.perf_counter() - sync_tic) * 1000
         global_num_tokens = self._dp_global_info[:, 0].tolist()
         global_batch_size = self._dp_global_info[:, 1].tolist()
         global_forward_mode = self._dp_global_info[:, 2].tolist()
@@ -1176,6 +1179,25 @@ class EventLoop:
             )
             for mode in global_forward_mode
         )
+        if logger.isEnabledFor(logging.DEBUG) and sync_elapsed_ms >= 20.0:
+            logger.debug(
+                "[Scheduler][forward][dp_sync] elapsed_ms=%.3f "
+                "global_rank=%s dp_rank=%s local_tokens=%s local_batch=%s "
+                "local_mode=%s global_num_tokens=%s global_batch_size=%s "
+                "global_forward_mode=%s need_idle_forward=%s "
+                "all_decode_or_idle=%s",
+                sync_elapsed_ms,
+                self.global_rank,
+                self.dp_rank,
+                num_tokens,
+                batch_size,
+                int(forward_mode),
+                global_num_tokens,
+                global_batch_size,
+                global_forward_mode,
+                need_idle_forward,
+                all_decode_or_idle,
+            )
         return DpForwardMetadata(
             global_num_tokens=global_num_tokens,
             global_batch_size=global_batch_size,

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -35,7 +35,7 @@ from tokenspeed.runtime.cache.executor.memory_executor import (
     MemoryExecutor,
     MemoryExecutorConfig,
 )
-from tokenspeed.runtime.cache.transfer.types import CacheKind
+from tokenspeed.runtime.cache.transfer.types import PAGED_CACHE_KIND, CacheKind
 from tokenspeed.runtime.configs.model_config import ModelConfig
 from tokenspeed.runtime.distributed.process_group_manager import (
     process_group_manager as pg_manager,
@@ -51,7 +51,7 @@ from tokenspeed.runtime.engine.scheduler_utils import (
     cache_sync_debug_enabled,
     make_config,
     pool_to_paged_cache_groups,
-    pool_to_prefix_cache_adjunct_spec,
+    pool_to_prefix_cache_adjunct_spec_if_enabled,
     pop_common_cache_event_payloads,
     should_use_overlap_schedule,
 )
@@ -95,6 +95,14 @@ from tokenspeed.runtime.utils.process import register_usr_signal
 from tokenspeed.runtime.utils.server_args import PortArgs, ServerArgs
 
 logger = get_colorful_logger(__name__)
+
+
+def _paged_cache_host_group_pages_for_scheduler(
+    enable_kvstore: bool, host_pool
+) -> dict:
+    if not enable_kvstore:
+        return {}
+    return dict(getattr(host_pool, "paged_cache_group_page_counts", {}))
 
 
 def calc_l3_query_hashes(scheduler, tokens: list[int]) -> list[str]:
@@ -267,6 +275,7 @@ class EventLoop:
             mamba_l2_layout=server_args.mamba_l2_layout,
             mamba_l2_io_backend=server_args.mamba_l2_io_backend,
         )
+        paged_cache_host_group_pages = {}
         if not token_to_kv_pool.supports_hierarchical_kv_cache:
             if server_args.enable_kvstore:
                 raise NotImplementedError(
@@ -284,7 +293,10 @@ class EventLoop:
                 draft_device_pool=draft_token_to_kv_pool,
                 mamba_pool=mamba_pool,
             )
-            num_host_pages = self.memory_executor.host_pool.page_num
+            num_host_pages = int(getattr(self.memory_executor.host_pool, "page_num", 0))
+            paged_cache_host_group_pages = _paged_cache_host_group_pages_for_scheduler(
+                server_args.enable_kvstore, self.memory_executor.host_pool
+            )
 
         # For DP attention, max_batch_size must be per-rank to avoid
         # req_pool_allocator overflow.  The C++ scheduler allocates
@@ -303,13 +315,14 @@ class EventLoop:
                 f"(ratio={server_args.mamba_full_memory_ratio})."
             )
 
-        # Adjunct enabled only when pool opts in AND prefix-caching switch is on.
+        # Adjunct enabled only when pool opts in and host-side kvstore is active.
         paged_cache_groups = pool_to_paged_cache_groups(token_to_kv_pool)
         self._paged_cache_groups = paged_cache_groups
-        prefix_cache_adjunct = None
-        required_groups = token_to_kv_pool.prefix_cache_required_group_ids
-        if required_groups is not None and server_args.enable_prefix_caching:
-            prefix_cache_adjunct = pool_to_prefix_cache_adjunct_spec(required_groups)
+        prefix_cache_adjunct = pool_to_prefix_cache_adjunct_spec_if_enabled(
+            token_to_kv_pool.prefix_cache_required_group_ids,
+            enable_prefix_caching=server_args.enable_prefix_caching,
+            enable_kvstore=server_args.enable_kvstore,
+        )
         scheduler_cfg = make_config(
             num_device_pages=self.max_total_num_tokens // server_args.block_size,
             max_scheduled_tokens=server_args.chunked_prefill_size,
@@ -333,6 +346,7 @@ class EventLoop:
             enable_mamba_l2=server_args.enable_mamba_l2,
             mamba_l2_host_slots=mamba_l2_host_slots,
             paged_cache_groups=paged_cache_groups,
+            paged_cache_host_group_pages=paged_cache_host_group_pages,
             enable_mixed_prefill_decode=server_args.enable_mixed_batch,
             prefix_cache_adjunct=prefix_cache_adjunct,
         )
@@ -341,7 +355,8 @@ class EventLoop:
             "max_scheduled_tokens=%s decode_input_tokens=%s disable_l2_cache=%s "
             "max_batch_size=%s (global max_num_seqs=%s, dp_size=%s) "
             "mamba_pool_total_chunks=%s enable_mamba=%s "
-            "disable_prefix_cache=%s paged_cache_groups=%s",
+            "disable_prefix_cache=%s paged_cache_groups=%s "
+            "paged_cache_host_group_pages=%s",
             scheduler_cfg.page_size,
             scheduler_cfg.num_device_pages,
             scheduler_cfg.max_scheduled_tokens,
@@ -354,9 +369,9 @@ class EventLoop:
             has_mamba,
             scheduler_cfg.disable_prefix_cache,
             [group.group_id for group in paged_cache_groups],
+            paged_cache_host_group_pages,
         )
         self.scheduler = Scheduler(scheduler_cfg)
-        token_to_kv_pool.bind_paged_cache_scheduler(self.scheduler)
         if attn_tp_rank == 0:
             self.kv_event_publisher = EventPublisherFactory.create(
                 server_args.kv_events_config,
@@ -745,9 +760,12 @@ class EventLoop:
         consumer_indices_by_kind: dict[CacheKind, list[int]] = {
             kind: [] for kind in available_pools
         }
+        consumer_indices_by_paged_cache: list[int] = []
+        has_paged_pool = getattr(host_exec, "paged_pool", None) is not None
         for cache_op in execution_plan.cache:
             if isinstance(cache_op, Cache.LoadBackOp):
-                for op_id in cache_op.op_ids:
+                paged_transfers_by_op = getattr(cache_op, "paged_cache_transfers", [])
+                for i, op_id in enumerate(cache_op.op_ids):
                     for kind in consumer_indices_by_kind:
                         producer_idx = self.memory_executor.get_producer_index(
                             kind, op_id
@@ -757,9 +775,33 @@ class EventLoop:
                             and producer_idx not in consumer_indices_by_kind[kind]
                         ):
                             consumer_indices_by_kind[kind].append(producer_idx)
+                    paged_transfers = (
+                        paged_transfers_by_op[i]
+                        if i < len(paged_transfers_by_op)
+                        else []
+                    )
+                    if has_paged_pool and paged_transfers:
+                        producer_idx = self.memory_executor.get_producer_index(
+                            PAGED_CACHE_KIND,
+                            op_id,
+                        )
+                        if (
+                            producer_idx is not None
+                            and producer_idx not in consumer_indices_by_paged_cache
+                        ):
+                            consumer_indices_by_paged_cache.append(producer_idx)
         for kind, consumer_indices in consumer_indices_by_kind.items():
             self.memory_executor.set_consumer(
                 kind, consumer_indices if consumer_indices else -1
+            )
+        if has_paged_pool:
+            self.memory_executor.set_consumer(
+                PAGED_CACHE_KIND,
+                (
+                    consumer_indices_by_paged_cache
+                    if consumer_indices_by_paged_cache
+                    else -1
+                ),
             )
 
     def _flush_mamba_retract_states(self, forward_op) -> None:

--- a/python/tokenspeed/runtime/engine/scheduler_utils.py
+++ b/python/tokenspeed/runtime/engine/scheduler_utils.py
@@ -70,6 +70,7 @@ def make_config(
     enable_mamba_l2: bool = False,
     mamba_l2_host_slots: int = 0,
     paged_cache_groups: Sequence["PagedCacheGroupConfig"] | None = None,
+    paged_cache_host_group_pages: Mapping[str, int] | None = None,
     enable_mixed_prefill_decode: bool = False,
     prefix_cache_adjunct: "PrefixCacheAdjunctSpec | None" = None,
 ) -> SchedulerConfig:
@@ -103,6 +104,11 @@ def make_config(
     cfg.enable_mixed_prefill_decode = enable_mixed_prefill_decode
     if paged_cache_groups:
         cfg.paged_cache_groups = list(paged_cache_groups)
+    if paged_cache_host_group_pages:
+        cfg.paged_cache_host_group_pages = {
+            str(group_id): int(page_count)
+            for group_id, page_count in paged_cache_host_group_pages.items()
+        }
     # Opt-in; unset means paged-cache groups are transport-only.
     if prefix_cache_adjunct is not None:
         cfg.prefix_cache_adjunct = prefix_cache_adjunct
@@ -161,6 +167,23 @@ def pool_to_prefix_cache_adjunct_spec(
     spec = PrefixCacheAdjunctSpec()
     spec.required_groups = [str(gid) for gid in required_group_ids]
     return spec
+
+
+def pool_to_prefix_cache_adjunct_spec_if_enabled(
+    required_group_ids: Sequence[str] | None,
+    *,
+    enable_prefix_caching: bool,
+    enable_kvstore: bool,
+) -> "PrefixCacheAdjunctSpec | None":
+    """Build a prefix adjunct only when host-side KV store is enabled.
+
+    Paged-cache groups are still needed without kvstore because they provide
+    model block tables. The prefix adjunct is the extra prefix-reuse layer; keep
+    it disabled with ``--disable-kvstore`` so that path matches origin/main.
+    """
+    if required_group_ids is None or not enable_prefix_caching or not enable_kvstore:
+        return None
+    return pool_to_prefix_cache_adjunct_spec(required_group_ids)
 
 
 def should_use_overlap_schedule(

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -20,6 +20,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -68,6 +69,7 @@ if TYPE_CHECKING:
 logger = get_colorful_logger(__name__)
 
 _DRAFTER_MAPPING = {"EAGLE3": Eagle, "MTP": Eagle}
+SLOW_PREFILL_LOG_THRESHOLD_MS = 1000.0
 
 
 def _draft_idle_global_num_tokens_for_step(
@@ -99,6 +101,8 @@ class ModelExecutorConfig:
     device: str
     gpu_id: int
     global_rank: int
+    attn_dp_rank: int
+    attn_tp_rank: int
     num_total_pages: int
     decode_log_interval: int
     cudagraph_capture_sizes: list[int] | None
@@ -160,6 +164,8 @@ class ModelExecutorConfig:
             device=server_args.device,
             gpu_id=gpu_id,
             global_rank=global_rank,
+            attn_dp_rank=server_args.mapping.attn.dp_rank,
+            attn_tp_rank=server_args.mapping.attn.tp_rank,
             num_total_pages=num_total_pages,
             decode_log_interval=server_args.decode_log_interval,
             cudagraph_capture_sizes=server_args.cudagraph_capture_sizes,
@@ -585,6 +591,12 @@ class ModelExecutor:
             runtime.min_bs,
         )
 
+    def _consume_layerwise_wait_debug(self, sync: bool = False):
+        counter = getattr(self.token_to_kv_pool, "layer_transfer_counter", None)
+        if counter is None or not hasattr(counter, "consume_debug_wait_records"):
+            return [], 0
+        return counter.consume_debug_wait_records(sync=sync)
+
     @maybe_inference_mode()
     def _forward_step(
         self,
@@ -917,6 +929,11 @@ class ModelExecutor:
                 num_queue_reqs,
             )
 
+        forward_tic = (
+            time.perf_counter()
+            if not is_decode and logger.isEnabledFor(logging.DEBUG)
+            else None
+        )
         result = self.execute_forward_op(
             forward_op,
             sampling_params_list,
@@ -927,6 +944,57 @@ class ModelExecutor:
             multimodal_context=multimodal_context,
             capture_next_input_ids=capture_next_input_ids,
         )
+        if forward_tic is not None:
+            forward_elapsed_ms = (time.perf_counter() - forward_tic) * 1000
+            if self.config.global_rank == 0:
+                logger.debug(
+                    "[Scheduler][forward] prefill done elapsed_ms=%.3f "
+                    "num_extends=%s batch=%s input_lengths=%s prefix_lens=%s "
+                    "request_ids=%s",
+                    forward_elapsed_ms,
+                    num_extends,
+                    bs,
+                    forward_op.input_lengths,
+                    forward_op.extend_prefix_lens,
+                    forward_op.request_ids,
+                )
+            if forward_elapsed_ms >= SLOW_PREFILL_LOG_THRESHOLD_MS:
+                logger.debug(
+                    "[Scheduler][forward][slow] prefill elapsed_ms=%.3f "
+                    "global_rank=%s attn_dp_rank=%s attn_tp_rank=%s "
+                    "num_extends=%s batch=%s input_lengths=%s prefix_lens=%s "
+                    "request_ids=%s dp_global_num_tokens=%s dp_global_bs=%s "
+                    "dp_all_decode_or_idle=%s",
+                    forward_elapsed_ms,
+                    self.config.global_rank,
+                    self.config.attn_dp_rank,
+                    self.config.attn_tp_rank,
+                    num_extends,
+                    bs,
+                    forward_op.input_lengths,
+                    forward_op.extend_prefix_lens,
+                    forward_op.request_ids,
+                    dp_global_num_tokens,
+                    dp_global_bs,
+                    dp_all_decode_or_idle,
+                )
+                layer_wait_samples, pending_layer_waits = (
+                    self._consume_layerwise_wait_debug(sync=True)
+                )
+                phase_wall_ms = getattr(self, "_last_forward_phase_wall_ms", {})
+                if phase_wall_ms or layer_wait_samples or pending_layer_waits:
+                    logger.debug(
+                        "[Scheduler][forward][slow_detail] "
+                        "global_rank=%s request_ids=%s phase_wall_ms=%s "
+                        "layer_wait_samples=%s pending_layer_waits=%s",
+                        self.config.global_rank,
+                        forward_op.request_ids,
+                        phase_wall_ms,
+                        layer_wait_samples,
+                        pending_layer_waits,
+                    )
+            else:
+                self._consume_layerwise_wait_debug(sync=False)
 
         if is_decode and (
             self.config.global_rank == 0
@@ -1282,7 +1350,19 @@ class ModelExecutor:
         total_tokens = sum(forward_op.input_lengths)
         self._active_multimodal_context = multimodal_context
         self._active_positions_override = None
+        phase_timing_enabled = logger.isEnabledFor(logging.DEBUG) and num_extends > 0
+        phase_wall_ms: dict[str, float] = {}
 
+        def phase_start():
+            return time.perf_counter() if phase_timing_enabled else None
+
+        def phase_done(name: str, tic) -> None:
+            if tic is None:
+                return
+            elapsed_ms = (time.perf_counter() - tic) * 1000
+            phase_wall_ms[name] = round(phase_wall_ms.get(name, 0.0) + elapsed_ms, 3)
+
+        tic = phase_start()
         with nvtx_range("pre_fill_setup", color="orange"):
             has_retract = num_extends <= 0 and any(
                 x != -1 for x in getattr(forward_op, "hist_token_lens", [])
@@ -1293,14 +1373,18 @@ class ModelExecutor:
             # complete before reading them.
             torch.cuda.current_stream().wait_stream(self.execution_stream)
             self.execution_stream.wait_stream(torch.cuda.current_stream())
+        phase_done("pre_fill_setup", tic)
         with torch.cuda.stream(self.execution_stream):
             bs = len(forward_op.request_ids)
+            tic = phase_start()
             decode_input_ids = self.input_buffers.fill_input_buffers(
                 forward_op=forward_op,
                 runtime_states=self.runtime_states,
                 req_to_page=self.req_to_page,
                 total_tokens=total_tokens,
             )
+            phase_done("fill_input_buffers", tic)
+            tic = phase_start()
             skipped_layerwise_cow_mask = self._skip_completed_layerwise_mamba_cow(
                 forward_op, bs
             )
@@ -1309,7 +1393,9 @@ class ModelExecutor:
                 multimodal_context=multimodal_context,
                 total_tokens=total_tokens,
             )
+            phase_done("input_postprocess", tic)
 
+            tic = phase_start()
             forward_mode = ForwardMode.from_num_extends(
                 num_extends,
                 bs,
@@ -1351,6 +1437,7 @@ class ModelExecutor:
                             self.input_buffers.req_pool_indices_buf[:bs][retract_mask],
                             mamba_pool_indices[:bs][retract_mask],
                         )
+            phase_done("mamba_state_ops", tic)
 
             grammar_completion = None
 
@@ -1360,6 +1447,7 @@ class ModelExecutor:
                 output_lengths = torch.zeros(bs, dtype=torch.int32, device=self.device)
                 output_logprobs = None
             else:
+                tic = phase_start()
                 gather_ids = None
                 if num_extends > 0:
                     num_decodes = bs - num_extends
@@ -1421,6 +1509,8 @@ class ModelExecutor:
                     ctx.global_num_tokens = dp_global_num_tokens
                     ctx.global_bs = dp_global_bs
                     ctx.all_decode_or_idle = dp_all_decode_or_idle
+                phase_done("forward_context", tic)
+                tic = phase_start()
                 with nvtx_range("sampling_prep", color="yellow"):
                     sampling_info = self._build_sampling_info(bs, sampling_params_list)
                     grammar_completion = setup_grammar_step(
@@ -1447,11 +1537,13 @@ class ModelExecutor:
                         sampling_params_list=sampling_params_list,
                         num_tokens_per_req=self.config.output_length,
                     )
+                phase_done("sampling_prep", tic)
 
                 with nvtx_range(
                     f"forward_step ext={num_extends} dec={bs - num_extends}",
                     color="blue",
                 ):
+                    tic = phase_start()
                     mamba_kwargs = (
                         {
                             "mamba_pool_indices": self.input_buffers.mamba_pool_indices_buf[
@@ -1470,6 +1562,8 @@ class ModelExecutor:
                         if self.input_buffers.has_mamba
                         else {}
                     )
+                    phase_done("mamba_kwargs", tic)
+                    tic = phase_start()
                     paged_cache_block_tables = paged_cache_block_tables_from_forward_op(
                         forward_op,
                         device=self.device,
@@ -1483,7 +1577,9 @@ class ModelExecutor:
                         device=self.device,
                         num_reqs=bs,
                     )
+                    phase_done("paged_cache_tables", tic)
                     self._log_dp_sampling_route(bs, ctx)
+                    tic = phase_start()
                     output_tokens, output_lengths, output_logprobs = self.forward_step(
                         bs=bs,
                         ctx=ctx,
@@ -1508,8 +1604,10 @@ class ModelExecutor:
                         ),
                         **mamba_kwargs,
                     )
+                    phase_done("forward_step", tic)
 
                 # Update runtime state on execution_stream (NOT in the CUDA graph).
+                tic = phase_start()
                 self._update_runtime_state(
                     req_pool_indices=self.input_buffers.req_pool_indices_buf[:bs],
                     output_tokens=output_tokens,
@@ -1522,7 +1620,9 @@ class ModelExecutor:
                     bs,
                     num_extends,
                 )
+                phase_done("runtime_state_update", tic)
 
+            tic = phase_start()
             with nvtx_range("output_d2h", color="green"):
                 next_input_ids = None
                 if (
@@ -1566,7 +1666,9 @@ class ModelExecutor:
 
                 copy_event = torch.cuda.Event()
                 copy_event.record()
+            phase_done("output_d2h", tic)
 
+        self._last_forward_phase_wall_ms = phase_wall_ms
         return ModelExecutionResult(
             output_tokens=output_tokens,
             output_lengths=output_lengths,

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -979,7 +979,6 @@ class ModelExecutor:
                     gen_throughput,
                     num_queue_reqs,
                 )
-            self.token_to_kv_pool.maybe_log_paged_cache_group_pages()
             self.num_generated_tokens = 0
             self.num_decode_steps = 0
             self.last_decode_stats_tic = now

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -596,9 +596,33 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             extend_seq_lens_cpu,
             extend_prefix_lens_cpu,
         )
+        has_explicit_num_tokens = num_tokens_arg is not None or isinstance(
+            positions, torch.Tensor
+        )
+        metadata_num_tokens = num_tokens
+        if (
+            not has_explicit_num_tokens
+            and query_lens_cpu is not None
+            and query_lens_cpu.numel() >= bs
+        ):
+            metadata_num_tokens = sum(int(x) for x in query_lens_cpu[:bs].tolist())
+        elif (
+            not has_explicit_num_tokens
+            and forward_mode is not None
+            and forward_mode.is_extend_or_mixed()
+        ):
+            raise RuntimeError(
+                "DeepSeek V4 prefill metadata requires CPU query lens to size "
+                "token metadata without synchronizing GPU"
+            )
         seq_lens_cpu = None
-        if extend_prefix_lens_cpu is not None and query_lens_cpu is not None:
-            seq_lens_cpu = seq_lens[:bs].to(dtype=torch.int32, device="cpu")
+        seq_lens_cpu_covers_batch = False
+        if (
+            num_prefill_reqs > 0
+            and extend_prefix_lens_cpu is not None
+            and query_lens_cpu is not None
+        ):
+            seq_lens_cpu = torch.zeros(bs, dtype=torch.int32, device="cpu")
             prefix_count = min(
                 int(extend_prefix_lens_cpu.numel()),
                 (
@@ -615,22 +639,36 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                     )
                     + query_lens_cpu[:prefix_count]
                 )
+            seq_lens_cpu_covers_batch = prefix_count == bs
+        elif (
+            num_prefill_reqs > 0
+            and extend_seq_lens_cpu is not None
+            and forward_mode is not None
+            and forward_mode.is_mixed()
+        ):
+            seq_lens_cpu = torch.zeros(bs, dtype=torch.int32, device="cpu")
+            seq_lens_cpu[:num_prefill_reqs] = extend_seq_lens_cpu[:num_prefill_reqs].to(
+                dtype=torch.int32, device="cpu"
+            )
+            seq_lens_cpu_covers_batch = num_prefill_reqs == bs
         elif extend_seq_lens_cpu is not None and forward_mode is not None:
             if forward_mode.is_extend():
                 seq_lens_cpu = extend_seq_lens_cpu[:bs].to(
                     dtype=torch.int32,
                     device="cpu",
                 )
-            elif forward_mode.is_mixed():
-                seq_lens_cpu = seq_lens[:bs].to(dtype=torch.int32, device="cpu")
-        max_seq_len = int(seq_lens.max().item()) if bs else 0
-        if forward_mode is not None and (
-            forward_mode.is_extend()
-            or forward_mode.is_target_verify()
-            or forward_mode.is_draft_extend()
-        ):
-            max_seq_len += max(self.speculative_num_steps - 1, 0)
-        max_pages = (max_seq_len + self.page_size - 1) // self.page_size
+                seq_lens_cpu_covers_batch = True
+        if bs and seq_lens_cpu_covers_batch and seq_lens_cpu is not None:
+            max_seq_len = max(int(x) for x in seq_lens_cpu[:bs].tolist())
+            if forward_mode is not None and (
+                forward_mode.is_extend()
+                or forward_mode.is_target_verify()
+                or forward_mode.is_draft_extend()
+            ):
+                max_seq_len += max(self.speculative_num_steps - 1, 0)
+            max_pages = (max_seq_len + self.page_size - 1) // self.page_size
+        else:
+            max_pages = self.max_num_pages if bs else 0
         if req_to_page is None:
             block_table = torch.zeros(
                 (bs, max(max_pages, 1)),
@@ -666,10 +704,28 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             base_offsets_on_device,
         )
         req_ids = torch.arange(bs, device=device, dtype=torch.int32)
-        token_to_req = torch.repeat_interleave(req_ids, query_lens.clamp_min(0))
-        num_prefill_tokens = (
-            int(query_lens[:num_prefill_reqs].sum().item()) if num_prefill_reqs else 0
+        token_to_req = torch.repeat_interleave(
+            req_ids,
+            query_lens.clamp_min(0),
+            output_size=metadata_num_tokens,
         )
+        if num_prefill_reqs == 0:
+            num_prefill_tokens = 0
+        elif query_lens_cpu is not None and query_lens_cpu.numel() >= num_prefill_reqs:
+            num_prefill_tokens = sum(
+                int(x) for x in query_lens_cpu[:num_prefill_reqs].tolist()
+            )
+        elif forward_mode is not None and forward_mode.is_mixed():
+            num_prefill_tokens = max(
+                0, metadata_num_tokens - max(0, bs - num_prefill_reqs)
+            )
+        elif forward_mode is not None and forward_mode.is_extend():
+            num_prefill_tokens = metadata_num_tokens
+        else:
+            raise RuntimeError(
+                "DeepSeek V4 prefill metadata requires CPU query lens to avoid "
+                "synchronizing GPU"
+            )
         query_start_loc = torch.nn.functional.pad(
             torch.cumsum(query_lens.to(torch.int32), dim=0, dtype=torch.int32),
             (1, 0),
@@ -1200,15 +1256,39 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         if cache_metadata.swa_block_table is None:
             raise RuntimeError("DeepSeek V4 missing paged-cache block table for SWA KV")
         swa_block_table = cache_metadata.swa_block_table
-        max_gather_len = int(gather_lens.max().item()) if num_reqs else 1
         compressed_lens = (
             torch.div(metadata.seq_lens, compress_ratio, rounding_mode="floor")
             if compress_ratio > 1
             else torch.zeros_like(metadata.seq_lens)
         )
-        compressed_base = (
-            int(compressed_lens.max().item()) if compress_ratio > 1 and num_reqs else 0
-        )
+        max_gather_len = 1
+        compressed_base = 0
+        if num_reqs:
+            seq_lens_cpu = metadata.seq_lens_cpu
+            query_lens_cpu = metadata.query_lens_cpu
+            if (
+                seq_lens_cpu is None
+                or query_lens_cpu is None
+                or seq_lens_cpu.device.type != "cpu"
+                or query_lens_cpu.device.type != "cpu"
+                or seq_lens_cpu.numel() < num_reqs
+                or query_lens_cpu.numel() < num_reqs
+            ):
+                raise RuntimeError(
+                    "DeepSeek V4 prefill requires CPU seq/query lens to size "
+                    "workspace without synchronizing GPU"
+                )
+            seq_lens_list = seq_lens_cpu[:num_reqs].tolist()
+            query_lens_list = query_lens_cpu[:num_reqs].tolist()
+            window_prefix_len = max(window_size - 1, 0)
+            max_gather_len = max(
+                int(query_len) + min(int(seq_len) - int(query_len), window_prefix_len)
+                for seq_len, query_len in zip(seq_lens_list, query_lens_list)
+            )
+            if compress_ratio > 1:
+                compressed_base = max(
+                    int(seq_len) // compress_ratio for seq_len in seq_lens_list
+                )
         workspace_width = max(1, compressed_base + max_gather_len)
         kv_workspace = self._get_prefill_workspace(
             num_reqs=num_reqs,
@@ -1499,9 +1579,19 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             total_ms = (time.perf_counter() - total_tic) * 1000
             if total_ms >= SLOW_DEEPSEEK_V4_ATTN_LOG_THRESHOLD_MS:
                 try:
-                    max_seq_len = int(metadata.seq_lens.max().item())
-                    max_query_len = int(metadata.query_lens.max().item())
-                    max_lens = int(lens.max().item())
+                    max_seq_len = (
+                        max(int(x) for x in metadata.seq_lens_cpu.tolist())
+                        if metadata.seq_lens_cpu is not None
+                        and metadata.seq_lens_cpu.numel() > 0
+                        else -1
+                    )
+                    max_query_len = (
+                        max(int(x) for x in metadata.query_lens_cpu.tolist())
+                        if metadata.query_lens_cpu is not None
+                        and metadata.query_lens_cpu.numel() > 0
+                        else -1
+                    )
+                    max_lens = int(indices.shape[-1])
                 except Exception:
                     max_seq_len = -1
                     max_query_len = -1
@@ -1585,10 +1675,19 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                 topk_indices=topk_indices,
             )
 
-        token_offsets = [
-            int(x)
-            for x in metadata.query_start_loc[: num_reqs + 1].detach().cpu().tolist()
-        ]
+        query_lens_cpu = metadata.query_lens_cpu
+        if (
+            query_lens_cpu is None
+            or query_lens_cpu.device.type != "cpu"
+            or query_lens_cpu.numel() < num_reqs
+        ):
+            raise RuntimeError(
+                "DeepSeek V4 chunked prefill requires CPU query lens to avoid "
+                "synchronizing GPU query offsets"
+            )
+        token_offsets = [0]
+        for query_len in query_lens_cpu[:num_reqs].tolist():
+            token_offsets.append(token_offsets[-1] + max(0, int(query_len)))
         out = q.new_empty((q.shape[0], num_local_heads, head_dim))
         saved_metadata = self.forward_metadata
         try:

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -13,6 +13,8 @@
 
 from __future__ import annotations
 
+import logging
+import time
 from typing import Optional
 
 import torch
@@ -55,8 +57,12 @@ from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
     _split_paged_cache_block_tables_into_v4_metadata,
 )
 from tokenspeed.runtime.layers.attention.registry import register_backend
+from tokenspeed.runtime.utils import get_colorful_logger
 from tokenspeed.runtime.utils.env import global_server_args_dict
 from tokenspeed.runtime.utils.nvtx import nvtx_range
+
+logger = get_colorful_logger(__name__)
+SLOW_DEEPSEEK_V4_ATTN_LOG_THRESHOLD_MS = 250.0
 
 DEEPSEEK_V4_DEFAULT_PREFILL_CHUNK_SIZE = 4
 
@@ -1441,6 +1447,20 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                 "Build/install `tokenspeed-kernel/python` with FlashMLA."
             )
 
+        timing_enabled = logger.isEnabledFor(logging.DEBUG)
+        total_tic = time.perf_counter() if timing_enabled else None
+        phase_wall_ms: dict[str, float] = {}
+
+        def phase_start():
+            return time.perf_counter() if timing_enabled else None
+
+        def phase_done(name: str, tic) -> None:
+            if tic is None:
+                return
+            elapsed_ms = (time.perf_counter() - tic) * 1000
+            phase_wall_ms[name] = round(phase_wall_ms.get(name, 0.0) + elapsed_ms, 3)
+
+        tic = phase_start()
         with nvtx_range(f"attn_{kind}_prefill_pad_q"):
             if q.shape[1] == padded_heads:
                 q_padded = q.contiguous()
@@ -1451,6 +1471,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                     device=q.device,
                 )
                 q_padded[:, : q.shape[1]].copy_(q)
+        phase_done("pad_q", tic)
+        tic = phase_start()
         with nvtx_range(f"attn_{kind}_prefill_workspace"):
             kv_workspace, indices, lens = self._prefill_workspace(
                 positions=positions,
@@ -1461,6 +1483,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                 head_dim=head_dim,
                 topk_indices=topk_indices,
             )
+        phase_done("workspace", tic)
+        tic = phase_start()
         with nvtx_range(f"attn_{kind}_prefill_flashmla"):
             out, _, _ = flash_mla_sparse_fwd(
                 q=q_padded,
@@ -1470,6 +1494,36 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                 attn_sink=attn_sink,
                 topk_length=lens,
             )
+        phase_done("flashmla", tic)
+        if timing_enabled and total_tic is not None:
+            total_ms = (time.perf_counter() - total_tic) * 1000
+            if total_ms >= SLOW_DEEPSEEK_V4_ATTN_LOG_THRESHOLD_MS:
+                try:
+                    max_seq_len = int(metadata.seq_lens.max().item())
+                    max_query_len = int(metadata.query_lens.max().item())
+                    max_lens = int(lens.max().item())
+                except Exception:
+                    max_seq_len = -1
+                    max_query_len = -1
+                    max_lens = -1
+                logger.debug(
+                    "[DeepSeekV4][slow_attn_prefill] layer=%s kind=%s "
+                    "ratio=%s total_ms=%.3f phase_wall_ms=%s tokens=%s "
+                    "reqs=%s max_seq_len=%s max_query_len=%s max_lens=%s "
+                    "workspace_shape=%s indices_shape=%s",
+                    layer_id,
+                    kind,
+                    compress_ratio,
+                    total_ms,
+                    phase_wall_ms,
+                    q.shape[0],
+                    int(metadata.num_prefill_reqs or metadata.seq_lens.numel()),
+                    max_seq_len,
+                    max_query_len,
+                    max_lens,
+                    tuple(kv_workspace.shape),
+                    tuple(indices.shape),
+                )
         return out[:, :num_local_heads]
 
     def forward_deepseek_v4_prefill(

--- a/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
+++ b/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
@@ -837,6 +837,7 @@ def deepseek_v4_hca_compress_kv_cache_insert(
     kv_cache_block_size: int,
     compress_ratio: int = 128,
     block_table_base_offsets: torch.Tensor | None = None,
+    compact_rows: int | None = None,
 ) -> None:
     """Compress HCA state, normalize/RoPE/FP8-quantize, and insert KV cache.
 
@@ -899,6 +900,7 @@ def deepseek_v4_hca_compress_kv_cache_insert(
         compress_ratio=compress_ratio,
         overlap=False,
         block_table_base_offsets=block_table_base_offsets,
+        compact_rows=compact_rows,
     )
 
 
@@ -917,6 +919,7 @@ def deepseek_v4_csa_compress_kv_cache_insert(
     kv_cache_block_size: int,
     compress_ratio: int = 4,
     block_table_base_offsets: torch.Tensor | None = None,
+    compact_rows: int | None = None,
 ) -> None:
     """Compress CSA state and insert one `fp8_ds_mla` row per 4 tokens.
 
@@ -929,6 +932,7 @@ def deepseek_v4_csa_compress_kv_cache_insert(
         raise ValueError(
             f"CSA cache insert requires compress_ratio=4, got {compress_ratio}"
         )
+    del compact_rows
     if state_cache.dim() != 3:
         raise ValueError(f"state_cache must be 3D, got {tuple(state_cache.shape)}")
     state_width = state_cache.shape[-1] // 2

--- a/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
+++ b/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
@@ -53,6 +53,9 @@ from tokenspeed_kernel.ops.attention.triton.deepseek_v4 import (
     deepseek_v4_fused_sparse_compress_cache_insert as _triton_fused_sparse_compress_cache_insert,
 )
 from tokenspeed_kernel.ops.attention.triton.deepseek_v4 import (
+    deepseek_v4_hca_tiled_compress_cache_insert as _triton_hca_tiled_compress_cache_insert,
+)
+from tokenspeed_kernel.ops.attention.triton.deepseek_v4 import (
     deepseek_v4_paged_compressed_slot_mapping,
 )
 from tokenspeed_kernel.ops.attention.triton.deepseek_v4 import (
@@ -833,10 +836,12 @@ def deepseek_v4_hca_compress_kv_cache_insert(
     rms_norm_eps: float,
     cos_sin_cache: torch.Tensor,
     kv_cache_2d: torch.Tensor,
-    kv_slot_mapping: torch.Tensor,
+    kv_slot_mapping: torch.Tensor | None,
     kv_cache_block_size: int,
     compress_ratio: int = 128,
     block_table_base_offsets: torch.Tensor | None = None,
+    kv_block_table: torch.Tensor | None = None,
+    kv_block_table_base_offsets: torch.Tensor | None = None,
     compact_rows: int | None = None,
 ) -> None:
     """Compress HCA state, normalize/RoPE/FP8-quantize, and insert KV cache.
@@ -875,14 +880,43 @@ def deepseek_v4_hca_compress_kv_cache_insert(
     num_actual = min(
         compressor_slot_mapping.numel(),
         positions.numel(),
-        kv_slot_mapping.numel(),
     )
+    if kv_slot_mapping is not None:
+        num_actual = min(num_actual, kv_slot_mapping.numel())
     if num_actual == 0:
         return
     if not state_cache.is_cuda:
         raise ValueError(
             "deepseek_v4_hca_compress_kv_cache_insert only supports CUDA tensors."
         )
+    if kv_slot_mapping is None and kv_block_table is None:
+        raise ValueError("HCA cache insert requires kv_slot_mapping or kv_block_table")
+
+    use_tiled_insert = (
+        compact_rows is not None and not torch.cuda.is_current_stream_capturing()
+    )
+    if use_tiled_insert:
+        _triton_hca_tiled_compress_cache_insert(
+            state_cache=state_cache,
+            token_to_req_indices=token_to_req_indices,
+            positions=positions,
+            compressor_slot_mapping=compressor_slot_mapping,
+            state_block_table=block_table,
+            compressor_block_size=compressor_block_size,
+            rms_norm_weight=rms_norm_weight,
+            rms_norm_eps=rms_norm_eps,
+            cos_sin_cache=cos_sin_cache,
+            kv_cache_2d=kv_cache_2d,
+            kv_slot_mapping=kv_slot_mapping,
+            kv_cache_block_size=kv_cache_block_size,
+            block_table_base_offsets=block_table_base_offsets,
+            kv_block_table=kv_block_table,
+            kv_block_table_base_offsets=kv_block_table_base_offsets,
+            compact_rows=compact_rows,
+        )
+        return
+    if kv_slot_mapping is None:
+        raise RuntimeError("HCA fused fallback requires a dense kv_slot_mapping")
 
     _triton_fused_sparse_compress_cache_insert(
         state_cache=state_cache,

--- a/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
+++ b/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
@@ -53,6 +53,9 @@ from tokenspeed_kernel.ops.attention.triton.deepseek_v4 import (
     deepseek_v4_fused_sparse_compress_cache_insert as _triton_fused_sparse_compress_cache_insert,
 )
 from tokenspeed_kernel.ops.attention.triton.deepseek_v4 import (
+    deepseek_v4_paged_compressed_slot_mapping,
+)
+from tokenspeed_kernel.ops.attention.triton.deepseek_v4 import (
     deepseek_v4_save_compressor_state as _triton_save_compressor_state,
 )
 from tokenspeed_kernel.ops.attention.triton.deepseek_v4 import (

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
@@ -85,13 +85,6 @@ class BaseTokenToKVPool:
     def set_token_slot_refs(self, token_slot_refs: torch.Tensor):
         self.token_slot_refs = token_slot_refs
 
-    def bind_paged_cache_scheduler(self, scheduler: object) -> None:
-        """Optional hook for model-specific paged-cache diagnostics."""
-        return None
-
-    def maybe_log_paged_cache_group_pages(self) -> None:
-        return None
-
     def get_key_buffer(self, layer_id: int) -> torch.Tensor:
         raise NotImplementedError()
 

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
@@ -13,7 +13,6 @@
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass, field
 from fractions import Fraction
 from typing import Any, Iterable, Optional, Sequence
@@ -755,7 +754,7 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
     group rather than owning a separate group of its own.
     """
 
-    supports_hierarchical_kv_cache = False
+    supports_hierarchical_kv_cache = True
 
     def __init__(
         self,
@@ -801,12 +800,6 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
         self._paged_cache_group_specs_by_id = {
             spec.group_id: spec for spec in self.paged_cache_group_specs
         }
-        self._paged_cache_scheduler: object | None = None
-        self._paged_cache_state_group_ids = tuple(
-            str(spec.group_id)
-            for spec in self.paged_cache_group_specs
-            if spec.family == "state"
-        )
         self.paged_cache_group_page_counts = compute_paged_cache_group_page_counts(
             self.paged_cache_group_specs,
             max_live_requests=max_batch_size,
@@ -967,36 +960,22 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
             if spec.family == "history"
         )
 
-    def bind_paged_cache_scheduler(self, scheduler: object) -> None:
-        self._paged_cache_scheduler = scheduler
-
-    def maybe_log_paged_cache_group_pages(self) -> None:
-        scheduler = self._paged_cache_scheduler
-        if self.rank != 0 or scheduler is None or not self._paged_cache_state_group_ids:
-            return
-        if not logger.isEnabledFor(logging.DEBUG):
-            return
-
-        parts = []
-        for group_id in self._paged_cache_state_group_ids:
-            total = scheduler.paged_cache_group_total_pages(group_id)
-            available = scheduler.paged_cache_group_available_pages(group_id)
-            failed = scheduler.paged_cache_group_failed_alloc_count(group_id)
-            parts.append(
-                f"{group_id}: used={total - available}/{total}, "
-                f"available={available}, failed_alloc={failed}"
-            )
-        logger.debug("DeepSeek V4 paged-cache state group pages. %s", "; ".join(parts))
-
     def _require(
         self, buffers: list[torch.Tensor | None], layer_id: int, name: str
     ) -> torch.Tensor:
+        self._wait_for_layer_loadback(layer_id)
         buf = buffers[layer_id]
         if buf is None:
             raise ValueError(f"DeepSeek V4 layer {layer_id} has no {name} cache")
         return buf
 
+    def _wait_for_layer_loadback(self, layer_id: int) -> None:
+        counter = self.layer_transfer_counter
+        if counter is not None:
+            counter.wait_until(layer_id)
+
     def get_swa_kv_buffer(self, layer_id: int) -> torch.Tensor:
+        self._wait_for_layer_loadback(layer_id)
         return self.swa_kv_buffer[layer_id]
 
     def get_compressed_kv_buffer_2d(self, layer_id: int) -> torch.Tensor:
@@ -1237,13 +1216,13 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
     def get_cpu_copy(self, token_indices: list[int]) -> list[torch.Tensor]:
         del token_indices
         raise NotImplementedError(
-            "DeepSeek V4 KV cache offload is not implemented; the compressed-MQA "
-            "and indexer buffers are page-shaped and require page-aware indexing."
+            "DeepSeek V4 does not support legacy token-indexed KV cache offload; "
+            "use the group-paged L2 KVStore path instead."
         )
 
     def load_cpu_copy(self, kv_cache_cpu, token_indices: list[int]) -> None:
         del kv_cache_cpu, token_indices
         raise NotImplementedError(
-            "DeepSeek V4 KV cache reload is not implemented; the compressed-MQA "
-            "and indexer buffers are page-shaped and require page-aware indexing."
+            "DeepSeek V4 does not support legacy token-indexed KV cache reload; "
+            "use the group-paged L2 KVStore path instead."
         )

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
@@ -40,6 +40,7 @@ from tokenspeed.runtime.configs.paged_cache_spec import (
 )
 from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (
     deepseek_v4_compressed_slot_mapping,
+    deepseek_v4_paged_compressed_slot_mapping,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.base import BaseTokenToKVPool
 from tokenspeed.runtime.utils import get_colorful_logger
@@ -672,6 +673,26 @@ class DeepseekV4CacheMetadata:
                 is_valid_token=is_valid_token,
             )
             return mapping[: positions.numel()]
+        if block_table is not self.block_table:
+            base_offsets = self.paged_cache_block_table_base_offsets.get(
+                v4_compressed_kv_group_id(compress_ratio)
+            )
+            if (
+                positions.is_cuda
+                and token_to_req_indices.is_cuda
+                and block_table.is_cuda
+                and (base_offsets is None or base_offsets.is_cuda)
+            ):
+                mapping = deepseek_v4_paged_compressed_slot_mapping(
+                    positions=positions,
+                    token_to_req_indices=token_to_req_indices,
+                    block_table=block_table,
+                    block_size=kv_cache_block_size,
+                    compress_ratio=compress_ratio,
+                    base_offsets=base_offsets,
+                )
+                return _mask_invalid_graph_tokens(mapping, is_valid_token)
+
         compressed_pos = torch.div(
             positions.to(torch.int64), compress_ratio, rounding_mode="floor"
         )

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -27,8 +27,10 @@ until the HCA/CSA cache kernels are wired into TokenSpeed.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
+import time
 from dataclasses import dataclass
 from typing import Any, Iterable, Optional, Tuple
 
@@ -146,6 +148,7 @@ _platform = current_platform()
 
 
 logger = get_colorful_logger(__name__)
+SLOW_DEEPSEEK_V4_LAYER_LOG_THRESHOLD_MS = 500.0
 
 
 def _deepseek_v4_metadata_matches_tokens(metadata, num_tokens: int) -> bool:
@@ -3907,6 +3910,23 @@ class DeepseekV4DecoderLayer(nn.Module):
         swa_slot_mapping: torch.Tensor | None = None,
         compressor_slot_cache: dict | None = None,
     ) -> torch.Tensor:
+        timing_enabled = (
+            logger.isEnabledFor(logging.DEBUG)
+            and ctx.forward_mode is not None
+            and ctx.forward_mode.is_extend_or_mixed()
+        )
+        layer_tic = time.perf_counter() if timing_enabled else None
+        phase_wall_ms: dict[str, float] = {}
+
+        def phase_start():
+            return time.perf_counter() if timing_enabled else None
+
+        def phase_done(name: str, tic) -> None:
+            if tic is None:
+                return
+            elapsed_ms = (time.perf_counter() - tic) * 1000
+            phase_wall_ms[name] = round(phase_wall_ms.get(name, 0.0) + elapsed_ms, 3)
+
         residual = hidden_states
         with nvtx_range("hc_attn_pre"):
             hidden_states, post, comb = mhc_pre(
@@ -3920,6 +3940,7 @@ class DeepseekV4DecoderLayer(nn.Module):
             )
         with nvtx_range("attn_norm"):
             hidden_states = self.attn_norm(hidden_states)
+        tic = phase_start()
         with nvtx_range("attn_total"):
             hidden_states = self.attn(
                 positions,
@@ -3929,6 +3950,7 @@ class DeepseekV4DecoderLayer(nn.Module):
                 swa_slot_mapping,
                 compressor_slot_cache,
             )
+        phase_done("attn_total", tic)
         with nvtx_range("hc_attn_post"):
             hidden_states = mhc_post(hidden_states, residual, post, comb)
 
@@ -3953,15 +3975,22 @@ class DeepseekV4DecoderLayer(nn.Module):
             max_num_tokens_per_gpu = max(token_counts) if token_counts else 0
         else:
             token_counts = None
+            tic = phase_start()
             with nvtx_range("pre_mlp_comm"):
                 hidden_states = self.comm_manager.pre_mlp_comm(hidden_states, ctx)
+            phase_done("pre_mlp_comm", tic)
             if self.ffn.gate.is_hash_moe:
+                tic = phase_start()
                 with nvtx_range("pre_mlp_input_ids_comm"):
                     ffn_input_ids = self._pre_mlp_input_ids_comm(input_ids, ctx)
+                phase_done("pre_mlp_input_ids_comm", tic)
+            tic = phase_start()
             with nvtx_range("moe_get_num_tokens"):
                 num_global_tokens, max_num_tokens_per_gpu = (
                     self.comm_manager.get_num_tokens(ctx)
                 )
+            phase_done("moe_get_num_tokens", tic)
+        tic = phase_start()
         with nvtx_range("ffn_total"):
             hidden_states = self.ffn(
                 hidden_states,
@@ -3971,13 +4000,35 @@ class DeepseekV4DecoderLayer(nn.Module):
                 ctx=ctx if use_mega_moe else None,
                 comm_manager=self.comm_manager if use_mega_moe else None,
             )
+        phase_done("ffn_total", tic)
         if not use_mega_moe:
+            tic = phase_start()
             with nvtx_range("post_mlp_comm"):
                 hidden_states, _ = self.comm_manager.post_mlp_comm(
                     hidden_states, None, ctx
                 )
+            phase_done("post_mlp_comm", tic)
         with nvtx_range("hc_ffn_post"):
             hidden_states = mhc_post(hidden_states, residual, post, comb)
+        if timing_enabled and layer_tic is not None:
+            total_ms = (time.perf_counter() - layer_tic) * 1000
+            if total_ms >= SLOW_DEEPSEEK_V4_LAYER_LOG_THRESHOLD_MS:
+                logger.debug(
+                    "[DeepSeekV4][slow_layer] layer=%s total_ms=%.3f "
+                    "phase_wall_ms=%s input_tokens=%s num_extends=%s "
+                    "global_num_tokens=%s global_bs=%s use_mega_moe=%s "
+                    "token_counts=%s max_tokens_per_gpu=%s",
+                    self.layer_id,
+                    total_ms,
+                    phase_wall_ms,
+                    ctx.input_num_tokens,
+                    ctx.num_extends,
+                    getattr(ctx, "global_num_tokens", None),
+                    getattr(ctx, "global_bs", None),
+                    use_mega_moe,
+                    token_counts,
+                    max_num_tokens_per_gpu,
+                )
         return hidden_states
 
 

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -529,7 +529,12 @@ def _deepseek_v4_gather_paged_indexer_mxfp4_cache(
         cache_2d.shape[1] // block_size
     )
     if out is None:
-        total_rows = int(cu_seq_lens[-1].item()) if cu_seq_lens.numel() else 0
+        if cu_seq_lens.is_cuda:
+            raise RuntimeError(
+                "DeepSeek V4 paged MXFP4 gather requires a pre-sized workspace "
+                "to avoid synchronizing CUDA sequence lengths"
+            )
+        total_rows = int(cu_seq_lens[-1].tolist()) if cu_seq_lens.numel() else 0
         values = torch.empty(
             (total_rows, value_bytes),
             dtype=torch.uint8,
@@ -772,6 +777,23 @@ def _deepseek_v4_indexer_prefill_max_logits_bytes(
     return max(1, int(max_logits_mb) * 1024 * 1024)
 
 
+def _deepseek_v4_cpu_int_list(
+    tensor: torch.Tensor,
+    name: str,
+    *,
+    start: Optional[int] = None,
+    end: Optional[int] = None,
+) -> list[int]:
+    if tensor.device.type != "cpu":
+        raise RuntimeError(f"DeepSeek V4 {name} must stay on CPU to avoid GPU sync")
+    view = tensor.detach()
+    if start is not None or end is not None:
+        view = view[slice(start, end)]
+    if view.dtype != torch.int64:
+        view = view.to(torch.int64)
+    return [int(x) for x in view.reshape(-1).tolist()]
+
+
 def _deepseek_v4_indexer_prefill_workspace_size(
     seq_lens_cpu: torch.Tensor,
     workspace_size: Optional[int] = None,
@@ -781,7 +803,8 @@ def _deepseek_v4_indexer_prefill_workspace_size(
     context_len = global_server_args_dict.get("max_model_len")
     if isinstance(context_len, int) and context_len > 0:
         return context_len * 40
-    max_seq_len = int(seq_lens_cpu.max().item()) if seq_lens_cpu.numel() else 1
+    seq_lens = _deepseek_v4_cpu_int_list(seq_lens_cpu, "prefill seq_lens_cpu")
+    max_seq_len = max(seq_lens) if seq_lens else 1
     return max(1, max_seq_len) * 40
 
 
@@ -800,23 +823,23 @@ def _deepseek_v4_indexer_prefill_request_chunks(
     if num_tokens == 0:
         return []
 
-    seq_lens = seq_lens_cpu.detach().cpu().to(torch.int64)
-    query_lens = query_lens_cpu.detach().cpu().to(torch.int64)
-    if seq_lens.numel() != query_lens.numel():
+    seq_lens_list = _deepseek_v4_cpu_int_list(seq_lens_cpu, "prefill seq_lens_cpu")
+    query_lens_list = _deepseek_v4_cpu_int_list(
+        query_lens_cpu,
+        "prefill query_lens_cpu",
+    )
+    if len(seq_lens_list) != len(query_lens_list):
         return []
 
-    query_lens_list = [max(0, int(x)) for x in query_lens.tolist()]
+    seq_lens_list = [max(0, int(x)) for x in seq_lens_list]
+    query_lens_list = [max(0, int(x)) for x in query_lens_list]
     if sum(query_lens_list) != num_tokens:
         return []
 
-    compressed_seq_lens = torch.div(
-        seq_lens,
-        max(1, int(compress_ratio)),
-        rounding_mode="floor",
-    )
-    compressed_seq_lens_list = [max(0, int(x)) for x in compressed_seq_lens.tolist()]
+    ratio = max(1, int(compress_ratio))
+    compressed_seq_lens_list = [seq_len // ratio for seq_len in seq_lens_list]
     workspace_rows = _deepseek_v4_indexer_prefill_workspace_size(
-        seq_lens,
+        seq_lens_cpu,
         workspace_size,
     )
     max_logits_elems = (
@@ -910,11 +933,17 @@ def _deepseek_v4_indexer_prefill_request_gather_plan(
         empty_i64 = torch.empty(0, dtype=torch.int64, device=device)
         return empty_i64, empty_i32, empty_i32, empty_i32, 0
 
-    seq_lens_list = (
-        seq_lens_cpu.detach().cpu().to(torch.int64)[req_start:req_end].tolist()
+    seq_lens_list = _deepseek_v4_cpu_int_list(
+        seq_lens_cpu,
+        "prefill seq_lens_cpu",
+        start=req_start,
+        end=req_end,
     )
-    query_lens_list = (
-        query_lens_cpu.detach().cpu().to(torch.int64)[req_start:req_end].tolist()
+    query_lens_list = _deepseek_v4_cpu_int_list(
+        query_lens_cpu,
+        "prefill query_lens_cpu",
+        start=req_start,
+        end=req_end,
     )
     if len(seq_lens_list) != len(query_lens_list):
         empty_i32 = torch.empty(0, dtype=torch.int32, device=device)
@@ -990,7 +1019,12 @@ def _deepseek_v4_indexer_prefill_chunk_total_rows(
     req_end: int,
 ) -> int:
     ratio = max(1, int(compress_ratio))
-    seq_lens = seq_lens_cpu.detach().cpu().to(torch.int64)[req_start:req_end].tolist()
+    seq_lens = _deepseek_v4_cpu_int_list(
+        seq_lens_cpu,
+        "prefill seq_lens_cpu",
+        start=req_start,
+        end=req_end,
+    )
     return sum(max(0, int(seq_len)) // ratio for seq_len in seq_lens)
 
 
@@ -1448,10 +1482,16 @@ def _deepseek_v4_indexer_topk_from_cache_deepgemm_decode(
         context_lens = decode_context_lens
         block_tables = decode_block_table
         max_len = (
-            int(decode_max_context_len)
-            if decode_max_context_len is not None
-            else int(context_lens.max().item())
+            int(decode_max_context_len) if decode_max_context_len is not None else None
         )
+        if max_len is None:
+            if context_lens.is_cuda:
+                raise RuntimeError(
+                    "DeepSeek V4 decode indexer requires decode_max_context_len "
+                    "to avoid synchronizing CUDA context lengths"
+                )
+            context_lens_list = context_lens.reshape(-1).tolist()
+            max_len = max(int(x) for x in context_lens_list) if context_lens_list else 0
     else:
         decode_plan = _deepseek_v4_indexer_decode_plan(
             positions=positions,

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -174,6 +174,53 @@ def _deepseek_v4_phase_done(
     phase_wall_ms[name] = round(phase_wall_ms.get(name, 0.0) + elapsed_ms, 3)
 
 
+def _deepseek_v4_cuda_event_start(
+    enabled: bool,
+    device: torch.device | None,
+) -> tuple[torch.cuda.Event, torch.cuda.Event] | None:
+    if not enabled or device is None or device.type != "cuda":
+        return None
+    try:
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record(torch.cuda.current_stream(device))
+        return start, end
+    except (RuntimeError, ValueError):
+        return None
+
+
+def _deepseek_v4_cuda_event_done(
+    events: list[tuple[str, torch.cuda.Event, torch.cuda.Event]],
+    name: str,
+    event_pair: tuple[torch.cuda.Event, torch.cuda.Event] | None,
+    device: torch.device | None,
+) -> None:
+    if event_pair is None or device is None or device.type != "cuda":
+        return
+    _, end = event_pair
+    try:
+        end.record(torch.cuda.current_stream(device))
+    except (RuntimeError, ValueError):
+        return
+    events.append((name, event_pair[0], end))
+
+
+def _deepseek_v4_cuda_events_read(
+    events: list[tuple[str, torch.cuda.Event, torch.cuda.Event]],
+) -> tuple[dict[str, float], int]:
+    elapsed: dict[str, float] = {}
+    pending = 0
+    for name, start, end in events:
+        try:
+            if not end.query():
+                pending += 1
+                continue
+            elapsed[name] = round(float(start.elapsed_time(end)), 3)
+        except (RuntimeError, ValueError):
+            pending += 1
+    return elapsed, pending
+
+
 def _deepseek_v4_metadata_matches_tokens(metadata, num_tokens: int) -> bool:
     return (
         metadata is not None
@@ -196,6 +243,37 @@ def _deepseek_v4_indexer_token_split(
     ):
         return 0, int(total_tokens)
     return int(total_tokens), 0
+
+
+def _deepseek_v4_prefill_boundary_rows(
+    metadata,
+    compress_ratio: int,
+) -> int | None:
+    seq_lens_cpu = getattr(metadata, "seq_lens_cpu", None)
+    query_lens_cpu = getattr(metadata, "query_lens_cpu", None)
+    num_prefill_reqs = int(getattr(metadata, "num_prefill_reqs", 0) or 0)
+    if seq_lens_cpu is None or query_lens_cpu is None or num_prefill_reqs <= 0:
+        return None
+    seq_lens = _deepseek_v4_cpu_int_list(
+        seq_lens_cpu,
+        "prefill seq_lens_cpu",
+        start=0,
+        end=num_prefill_reqs,
+    )
+    query_lens = _deepseek_v4_cpu_int_list(
+        query_lens_cpu,
+        "prefill query_lens_cpu",
+        start=0,
+        end=num_prefill_reqs,
+    )
+    rows = 0
+    ratio = max(1, int(compress_ratio))
+    for seq_len, query_len in zip(seq_lens, query_lens):
+        seq_len = max(0, int(seq_len))
+        query_len = max(0, int(query_len))
+        prefix_len = max(0, seq_len - query_len)
+        rows += seq_len // ratio - prefix_len // ratio
+    return max(0, rows)
 
 
 def _deepseek_v4_forward_metadata(ctx: ForwardContext):
@@ -1059,10 +1137,15 @@ def _deepseek_v4_indexer_prefill_metadata(
     compress_ratio: int,
     num_prefill_tokens: int,
 ) -> DeepseekV4IndexerPrefillMetadata:
+    timing_enabled = logger.isEnabledFor(logging.DEBUG)
+    total_tic = _deepseek_v4_phase_start(timing_enabled)
+    phase_wall_ms: dict[str, float] = {}
+    cuda_events: list[tuple[str, torch.cuda.Event, torch.cuda.Event]] = []
     device = block_table.device
     if num_prefill_tokens <= 0:
         return DeepseekV4IndexerPrefillMetadata.empty(device)
 
+    tic = _deepseek_v4_phase_start(timing_enabled)
     seq_lens_cpu = getattr(metadata, "seq_lens_cpu", None)
     query_lens_cpu = getattr(metadata, "query_lens_cpu", None)
     num_prefill_reqs = int(getattr(metadata, "num_prefill_reqs", 0) or 0)
@@ -1083,6 +1166,7 @@ def _deepseek_v4_indexer_prefill_metadata(
         compress_ratio=compress_ratio,
         num_tokens=num_prefill_tokens,
     )
+    _deepseek_v4_phase_done(phase_wall_ms, "cpu_lens_chunks", tic)
     if not chunks:
         out = DeepseekV4IndexerPrefillMetadata.empty(device)
         cache[cache_key] = out
@@ -1097,7 +1181,9 @@ def _deepseek_v4_indexer_prefill_metadata(
     slot_offset = 0
     cu_seq_offset = 0
     row_offset = 0
+    cuda_tensor_elems = 0
     for chunk in chunks:
+        tic = _deepseek_v4_phase_start(timing_enabled)
         slots, cu_seqlen_k_start, cu_seqlen_k_end, seq_lens_k, max_seqlen_k = (
             _deepseek_v4_indexer_prefill_request_gather_plan(
                 seq_lens_cpu=seq_lens_cpu,
@@ -1118,6 +1204,9 @@ def _deepseek_v4_indexer_prefill_metadata(
             req_start=chunk.req_start,
             req_end=chunk.req_end,
         )
+        _deepseek_v4_phase_done(phase_wall_ms, "per_chunk_plan", tic)
+        tic = _deepseek_v4_phase_start(timing_enabled)
+        cuda_pair = _deepseek_v4_cuda_event_start(timing_enabled, device)
         compressed_lens = torch.div(
             seq_lens_cpu[chunk.req_start : chunk.req_end].to(
                 dtype=torch.int32,
@@ -1133,6 +1222,20 @@ def _deepseek_v4_indexer_prefill_metadata(
         )
         cu_seq_lens[:1] = 0
         torch.cumsum(compressed_lens, dim=0, out=cu_seq_lens[1:])
+        cuda_tensor_elems += (
+            compressed_lens.numel()
+            + cu_seq_lens.numel()
+            + cu_seqlen_k_start.numel()
+            + cu_seqlen_k_end.numel()
+            + seq_lens_k.numel()
+        )
+        _deepseek_v4_cuda_event_done(
+            cuda_events,
+            "cuda_tensor_build",
+            cuda_pair,
+            device,
+        )
+        _deepseek_v4_phase_done(phase_wall_ms, "cuda_tensor_build", tic)
         slot_end = slot_offset + slot_count
         cu_seq_end = cu_seq_offset + cu_seq_lens.numel()
         row_end = row_offset + seq_lens_k.numel()
@@ -1162,6 +1265,8 @@ def _deepseek_v4_indexer_prefill_metadata(
         cu_seq_offset = cu_seq_end
         row_offset = row_end
 
+    tic = _deepseek_v4_phase_start(timing_enabled)
+    cuda_pair = _deepseek_v4_cuda_event_start(timing_enabled, device)
     out = DeepseekV4IndexerPrefillMetadata(
         chunks=tuple(chunk_plans),
         chunk_specs=torch.tensor(
@@ -1220,7 +1325,36 @@ def _deepseek_v4_indexer_prefill_metadata(
             else torch.empty(0, dtype=torch.int32, device=device)
         ),
     )
+    _deepseek_v4_cuda_event_done(cuda_events, "cat_pack", cuda_pair, device)
+    _deepseek_v4_phase_done(phase_wall_ms, "cat_pack", tic)
+    tic = _deepseek_v4_phase_start(timing_enabled)
     cache[cache_key] = out
+    _deepseek_v4_phase_done(phase_wall_ms, "cache_put", tic)
+    if timing_enabled and total_tic is not None:
+        total_ms = (time.perf_counter() - total_tic) * 1000
+        if total_ms >= SLOW_DEEPSEEK_V4_LAYER_LOG_THRESHOLD_MS:
+            phase_cuda_ms, pending_cuda_events = _deepseek_v4_cuda_events_read(
+                cuda_events
+            )
+            logger.debug(
+                "[DeepSeekV4][slow_indexer_prefill_metadata] total_ms=%.3f "
+                "phase_wall_ms=%s phase_cuda_ms=%s pending_cuda_events=%s "
+                "cache_hit=false cache_key=%s num_prefill_reqs=%s "
+                "num_prefill_tokens=%s chunks=%s max_gather_rows=%s "
+                "sum_gather_rows=%s cuda_tensor_elems=%s device=%s build_slots=false",
+                total_ms,
+                phase_wall_ms,
+                phase_cuda_ms,
+                pending_cuda_events,
+                cache_key,
+                num_prefill_reqs,
+                num_prefill_tokens,
+                len(chunk_plans),
+                out.max_gather_rows(),
+                sum(max(0, chunk.slot_end - chunk.slot_start) for chunk in chunk_plans),
+                cuda_tensor_elems,
+                device,
+            )
     return out
 
 
@@ -2893,7 +3027,25 @@ class DeepseekV4Compressor(nn.Module):
             if not write_compressed_cache
             else f"compressor_c{self.compress_ratio}"
         )
+        timing_enabled = _deepseek_v4_timing_enabled(ctx)
+        total_tic = _deepseek_v4_phase_start(timing_enabled)
+        phase_wall_ms: dict[str, float] = {}
+        cuda_events: list[tuple[str, torch.cuda.Event, torch.cuda.Event]] = []
+        decode_tokens = (
+            metadata.decode_token_count()
+            if hasattr(metadata, "decode_token_count")
+            else 0
+        )
+        hca_boundary_rows = (
+            _deepseek_v4_prefill_boundary_rows(metadata, self.compress_ratio)
+            if write_compressed_cache
+            and self.compress_ratio == 128
+            and not self.overlap
+            and decode_tokens == 0
+            else None
+        )
         if kv_score is None:
+            tic = _deepseek_v4_phase_start(timing_enabled)
             with nvtx_range(f"{profile_prefix}_dequant_weight"):
                 weight_shape = (
                     self.fused_wkv_wgate.output_size_per_partition,
@@ -2906,9 +3058,12 @@ class DeepseekV4Compressor(nn.Module):
                 kv_score = _deepseek_v4_bf16_linear_fp32(hidden_states, weight)
                 if kv_score is None:
                     kv_score = torch.matmul(hidden_states.float(), weight.float().T)
+            _deepseek_v4_phase_done(phase_wall_ms, "compute_kv_score", tic)
         kv, score = kv_score.split([self.coff * self.head_dim] * 2, dim=-1)
         if state_cache is None:
+            tic = _deepseek_v4_phase_start(timing_enabled)
             state_cache = pool.get_compressor_state_buffer(layer_index)
+            _deepseek_v4_phase_done(phase_wall_ms, "get_state_buffer", tic)
         cache_metadata = metadata.cache
         # State/compressed slot mappings are per-step metadata. Reuse them across
         # layers when the cache group shape is identical; the indexer-compressor
@@ -2934,10 +3089,12 @@ class DeepseekV4Compressor(nn.Module):
             if getattr(metadata, "is_valid_token", None) is not None
             else None
         )
+        state_slot_cache_hit = state_slot_mapping is not None
         if state_slot_mapping is None:
             state_hit = (
                 memo.get(("state", self.compress_ratio)) if memo is not None else None
             )
+            state_slot_cache_hit = state_hit is not None
             if state_hit is not None:
                 state_slot_mapping, state_block_table = state_hit
             else:
@@ -2962,6 +3119,8 @@ class DeepseekV4Compressor(nn.Module):
                         state_slot_mapping,
                         state_block_table,
                     )
+        tic = _deepseek_v4_phase_start(timing_enabled)
+        cuda_pair = _deepseek_v4_cuda_event_start(timing_enabled, positions.device)
         with nvtx_range(f"{profile_prefix}_save_state"):
             save_deepseek_v4_compressor_state(
                 kv=kv,
@@ -2973,7 +3132,37 @@ class DeepseekV4Compressor(nn.Module):
                 block_size=state_block_size,
                 compress_ratio=self.compress_ratio,
             )
+        _deepseek_v4_cuda_event_done(
+            cuda_events, "save_state", cuda_pair, positions.device
+        )
+        _deepseek_v4_phase_done(phase_wall_ms, "save_state", tic)
         if not write_compressed_cache:
+            if timing_enabled and total_tic is not None:
+                total_ms = (time.perf_counter() - total_tic) * 1000
+                if total_ms >= SLOW_DEEPSEEK_V4_LAYER_LOG_THRESHOLD_MS:
+                    phase_cuda_ms, pending_cuda_events = _deepseek_v4_cuda_events_read(
+                        cuda_events
+                    )
+                    logger.debug(
+                        "[DeepSeekV4][slow_compressor] layer=%s ratio=%s "
+                        "write_compressed_cache=%s total_ms=%.3f phase_wall_ms=%s "
+                        "phase_cuda_ms=%s pending_cuda_events=%s input_tokens=%s "
+                        "decode_tokens=%s hca_boundary_rows=%s compact_rows=%s "
+                        "state_slot_cache_hit=%s compressed_slot_cache_hit=%s",
+                        layer_index,
+                        self.compress_ratio,
+                        write_compressed_cache,
+                        total_ms,
+                        phase_wall_ms,
+                        phase_cuda_ms,
+                        pending_cuda_events,
+                        positions.numel(),
+                        decode_tokens,
+                        hca_boundary_rows,
+                        None,
+                        state_slot_cache_hit,
+                        None,
+                    )
             return kv, score
 
         kv_cache_block_size = pool.get_compressed_block_size(layer_index)
@@ -2985,9 +3174,11 @@ class DeepseekV4Compressor(nn.Module):
             use_decode_cache,
         )
         compressed_hit = memo.get(compressed_key) if memo is not None else None
+        compressed_slot_cache_hit = compressed_hit is not None
         if compressed_hit is not None:
             compressed_slots = compressed_hit
         else:
+            tic = _deepseek_v4_phase_start(timing_enabled)
             with nvtx_range(f"{profile_prefix}_compressed_slot_mapping"):
                 compressed_slots = cache_metadata.compressed_slot_mapping(
                     positions,
@@ -3003,11 +3194,22 @@ class DeepseekV4Compressor(nn.Module):
                 )
             if memo is not None:
                 memo[compressed_key] = compressed_slots
+            _deepseek_v4_phase_done(phase_wall_ms, "compressed_slot_mapping", tic)
+        tic = _deepseek_v4_phase_start(timing_enabled)
+        kv_cache_2d = pool.get_compressed_kv_buffer_2d(layer_index)
+        _deepseek_v4_phase_done(phase_wall_ms, "get_compressed_kv_buffer", tic)
+        tic = _deepseek_v4_phase_start(timing_enabled)
+        cuda_pair = _deepseek_v4_cuda_event_start(timing_enabled, positions.device)
         with nvtx_range(f"{profile_prefix}_cache_insert"):
             insert = (
                 deepseek_v4_csa_compress_kv_cache_insert
                 if self.compress_ratio == 4
                 else deepseek_v4_hca_compress_kv_cache_insert
+            )
+            compact_rows = (
+                hca_boundary_rows
+                if self.compress_ratio == 128 and hca_boundary_rows is not None
+                else None
             )
             insert(
                 state_cache=state_cache,
@@ -3020,11 +3222,44 @@ class DeepseekV4Compressor(nn.Module):
                 rms_norm_weight=self.norm.weight,
                 rms_norm_eps=self.norm.variance_epsilon,
                 cos_sin_cache=cos_sin_cache,
-                kv_cache_2d=pool.get_compressed_kv_buffer_2d(layer_index),
+                kv_cache_2d=kv_cache_2d,
                 kv_slot_mapping=compressed_slots,
                 kv_cache_block_size=kv_cache_block_size,
                 compress_ratio=self.compress_ratio,
+                compact_rows=compact_rows,
             )
+        _deepseek_v4_cuda_event_done(
+            cuda_events, "cache_insert", cuda_pair, positions.device
+        )
+        _deepseek_v4_phase_done(phase_wall_ms, "cache_insert", tic)
+        if timing_enabled and total_tic is not None:
+            total_ms = (time.perf_counter() - total_tic) * 1000
+            if total_ms >= SLOW_DEEPSEEK_V4_LAYER_LOG_THRESHOLD_MS:
+                phase_cuda_ms, pending_cuda_events = _deepseek_v4_cuda_events_read(
+                    cuda_events
+                )
+                logger.debug(
+                    "[DeepSeekV4][slow_compressor] layer=%s ratio=%s "
+                    "write_compressed_cache=%s total_ms=%.3f phase_wall_ms=%s "
+                    "phase_cuda_ms=%s pending_cuda_events=%s input_tokens=%s "
+                    "decode_tokens=%s hca_boundary_rows=%s compact_rows=%s "
+                    "state_slot_cache_hit=%s compressed_slot_cache_hit=%s "
+                    "use_decode_cache=%s",
+                    layer_index,
+                    self.compress_ratio,
+                    write_compressed_cache,
+                    total_ms,
+                    phase_wall_ms,
+                    phase_cuda_ms,
+                    pending_cuda_events,
+                    positions.numel(),
+                    decode_tokens,
+                    hca_boundary_rows,
+                    compact_rows,
+                    state_slot_cache_hit,
+                    compressed_slot_cache_hit,
+                    use_decode_cache,
+                )
         return kv, score
 
 
@@ -3824,6 +4059,7 @@ class DeepseekV4Attention(nn.Module):
         timing_enabled = _deepseek_v4_timing_enabled(ctx)
         total_tic = _deepseek_v4_phase_start(timing_enabled)
         phase_wall_ms: dict[str, float] = {}
+        cuda_events: list[tuple[str, torch.cuda.Event, torch.cuda.Event]] = []
 
         # --- Phase 1: pre-compute input GEMMs in parallel ---
         # Q/KV projection on main stream; compressor GEMM(s) on aux stream.
@@ -3920,6 +4156,7 @@ class DeepseekV4Attention(nn.Module):
             )
 
             tic = _deepseek_v4_phase_start(timing_enabled)
+            cuda_pair = _deepseek_v4_cuda_event_start(timing_enabled, positions.device)
             with self.stream_fork.scope(
                 enable=self.stream_fork.aux_stream is not None
             ) as fork:
@@ -3944,9 +4181,16 @@ class DeepseekV4Attention(nn.Module):
                 inner_tic = _deepseek_v4_phase_start(timing_enabled)
                 run_compressor()
                 _deepseek_v4_phase_done(phase_wall_ms, "compressor", inner_tic)
+            _deepseek_v4_cuda_event_done(
+                cuda_events,
+                "indexer_stream_scope",
+                cuda_pair,
+                positions.device,
+            )
             _deepseek_v4_phase_done(phase_wall_ms, "indexer_stream_scope", tic)
         elif self.compressor is not None:
             tic = _deepseek_v4_phase_start(timing_enabled)
+            cuda_pair = _deepseek_v4_cuda_event_start(timing_enabled, positions.device)
             with self.stream_fork.scope(
                 enable=self.stream_fork.aux_stream is not None
             ) as fork:
@@ -3957,6 +4201,12 @@ class DeepseekV4Attention(nn.Module):
                 with fork.branch():
                     insert_swa_cache()
                 _deepseek_v4_phase_done(phase_wall_ms, "insert_swa_cache", inner_tic)
+            _deepseek_v4_cuda_event_done(
+                cuda_events,
+                "compressor_stream_scope",
+                cuda_pair,
+                positions.device,
+            )
             _deepseek_v4_phase_done(phase_wall_ms, "compressor_stream_scope", tic)
         else:
             tic = _deepseek_v4_phase_start(timing_enabled)
@@ -4035,11 +4285,14 @@ class DeepseekV4Attention(nn.Module):
         if timing_enabled and total_tic is not None:
             total_ms = (time.perf_counter() - total_tic) * 1000
             if total_ms >= SLOW_DEEPSEEK_V4_LAYER_LOG_THRESHOLD_MS:
+                phase_cuda_ms, pending_cuda_events = _deepseek_v4_cuda_events_read(
+                    cuda_events
+                )
                 logger.debug(
                     "[DeepSeekV4][slow_attn] layer=%s cache_layer=%s kind=%s "
                     "total_ms=%.3f phase_wall_ms=%s input_tokens=%s "
                     "num_prefill_tokens=%s num_decode_tokens=%s num_extends=%s "
-                    "forward_mode=%s",
+                    "forward_mode=%s phase_cuda_ms=%s pending_cuda_events=%s",
                     self.layer_index,
                     self.cache_layer_index,
                     self.attention_kind,
@@ -4050,6 +4303,8 @@ class DeepseekV4Attention(nn.Module):
                     metadata.decode_token_count(),
                     ctx.num_extends,
                     forward_mode,
+                    phase_cuda_ms,
+                    pending_cuda_events,
                 )
         return out
 

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -2910,9 +2910,9 @@ class DeepseekV4Compressor(nn.Module):
         if state_cache is None:
             state_cache = pool.get_compressor_state_buffer(layer_index)
         cache_metadata = metadata.cache
-        # state/compressed slot mappings depend only on (per-step state, ratio), so reuse
-        # them across layers of the same ratio within a step. Attn-compressor path only:
-        # the indexer-compressor passes an explicit state_block_table and is excluded.
+        # State/compressed slot mappings are per-step metadata. Reuse them across
+        # layers when the cache group shape is identical; the indexer-compressor
+        # passes an explicit state_block_table and is excluded from the state memo.
         memo = compressor_slot_cache if state_block_table is None else None
         if state_block_table is None:
             state_block_table = cache_metadata.compressor_state_block_tables.get(
@@ -2977,9 +2977,14 @@ class DeepseekV4Compressor(nn.Module):
             return kv, score
 
         kv_cache_block_size = pool.get_compressed_block_size(layer_index)
-        compressed_hit = (
-            memo.get(("compressed", self.compress_ratio)) if memo is not None else None
+        use_decode_cache = ctx.forward_mode is not None and ctx.forward_mode.is_decode()
+        compressed_key = (
+            "compressed",
+            self.compress_ratio,
+            kv_cache_block_size,
+            use_decode_cache,
         )
+        compressed_hit = memo.get(compressed_key) if memo is not None else None
         if compressed_hit is not None:
             compressed_slots = compressed_hit
         else:
@@ -2993,13 +2998,11 @@ class DeepseekV4Compressor(nn.Module):
                     query_start_loc=metadata.query_start_loc,
                     seq_lens=metadata.seq_lens,
                     kv_cache_block_size=kv_cache_block_size,
-                    use_decode_cache=(
-                        ctx.forward_mode is not None and ctx.forward_mode.is_decode()
-                    ),
+                    use_decode_cache=use_decode_cache,
                     is_valid_token=valid_token,
                 )
             if memo is not None:
-                memo[("compressed", self.compress_ratio)] = compressed_slots
+                memo[compressed_key] = compressed_slots
         with nvtx_range(f"{profile_prefix}_cache_insert"):
             insert = (
                 deepseek_v4_csa_compress_kv_cache_insert
@@ -3463,18 +3466,35 @@ class DeepseekV4Indexer(nn.Module):
                 self.compress_ratio,
                 indexer_block_size,
             )
-            compressed_slots = cache_metadata.compressed_slot_mapping(
-                positions,
-                self.compress_ratio,
-                token_to_req_indices=metadata.token_to_req_indices[: positions.numel()],
-                query_start_loc=metadata.query_start_loc,
-                seq_lens=metadata.seq_lens,
-                kv_cache_block_size=indexer_block_size,
-                use_decode_cache=(
-                    ctx.forward_mode is not None and ctx.forward_mode.is_decode()
-                ),
-                is_valid_token=valid_token,
+            use_decode_cache = (
+                ctx.forward_mode is not None and ctx.forward_mode.is_decode()
             )
+            compressed_key = (
+                "compressed",
+                self.compress_ratio,
+                indexer_block_size,
+                use_decode_cache,
+            )
+            compressed_slots = (
+                compressor_slot_cache.get(compressed_key)
+                if compressor_slot_cache is not None
+                else None
+            )
+            if compressed_slots is None:
+                compressed_slots = cache_metadata.compressed_slot_mapping(
+                    positions,
+                    self.compress_ratio,
+                    token_to_req_indices=metadata.token_to_req_indices[
+                        : positions.numel()
+                    ],
+                    query_start_loc=metadata.query_start_loc,
+                    seq_lens=metadata.seq_lens,
+                    kv_cache_block_size=indexer_block_size,
+                    use_decode_cache=use_decode_cache,
+                    is_valid_token=valid_token,
+                )
+                if compressor_slot_cache is not None:
+                    compressor_slot_cache[compressed_key] = compressed_slots
         _deepseek_v4_phase_done(phase_wall_ms, "indexer_compressed_slot_mapping", tic)
         tic = _deepseek_v4_phase_start(timing_enabled)
         with nvtx_range("indexer_cache_insert"):
@@ -4332,9 +4352,8 @@ class DeepseekV4Model(nn.Module):
             positions,
             out_cache_loc,
         )
-        # Per-(step, ratio) compressor slot mappings are identical across layers of the
-        # same ratio; memoize within the step (filled lazily by the first compressor of
-        # each ratio, reused by the rest).
+        # Per-step cache slot mappings are identical across layers when their
+        # cache group shape matches; fill lazily and reuse within the step.
         compressor_slot_cache: dict = {}
         for layer in self.layers:
             hidden_states = layer(

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -276,6 +276,22 @@ def _deepseek_v4_prefill_boundary_rows(
     return max(0, rows)
 
 
+def _deepseek_v4_hca_compact_row_bound(
+    prefill_rows: int | None,
+    decode_tokens: int,
+    include_decode_tokens: bool,
+) -> int | None:
+    if prefill_rows is None:
+        return None
+    compact_rows = prefill_rows
+    if include_decode_tokens:
+        # Decode tokens may contain at most one HCA boundary row each. Use this
+        # as a compact-buffer upper bound; the kernel still filters exact
+        # boundary positions before materializing rows.
+        compact_rows += max(0, int(decode_tokens))
+    return compact_rows
+
+
 def _deepseek_v4_forward_metadata(ctx: ForwardContext):
     metadata = getattr(ctx.attn_backend, "forward_metadata", None)
     if ctx.forward_mode == ForwardMode.EXTEND:
@@ -3036,14 +3052,18 @@ class DeepseekV4Compressor(nn.Module):
             if hasattr(metadata, "decode_token_count")
             else 0
         )
-        hca_boundary_rows = (
-            _deepseek_v4_prefill_boundary_rows(metadata, self.compress_ratio)
-            if write_compressed_cache
-            and self.compress_ratio == 128
-            and not self.overlap
-            and decode_tokens == 0
-            else None
-        )
+        hca_boundary_rows: int | None = None
+        hca_compact_rows: int | None = None
+        if write_compressed_cache and self.compress_ratio == 128 and not self.overlap:
+            hca_boundary_rows = _deepseek_v4_prefill_boundary_rows(
+                metadata,
+                self.compress_ratio,
+            )
+            hca_compact_rows = _deepseek_v4_hca_compact_row_bound(
+                hca_boundary_rows,
+                decode_tokens,
+                ctx.forward_mode is not None and ctx.forward_mode.is_mixed(),
+            )
         if kv_score is None:
             tic = _deepseek_v4_phase_start(timing_enabled)
             with nvtx_range(f"{profile_prefix}_dequant_weight"):
@@ -3167,67 +3187,104 @@ class DeepseekV4Compressor(nn.Module):
 
         kv_cache_block_size = pool.get_compressed_block_size(layer_index)
         use_decode_cache = ctx.forward_mode is not None and ctx.forward_mode.is_decode()
-        compressed_key = (
-            "compressed",
-            self.compress_ratio,
-            kv_cache_block_size,
-            use_decode_cache,
+        hca_direct_slots = (
+            self.compress_ratio == 128
+            and hca_boundary_rows is not None
+            and decode_tokens == 0
         )
-        compressed_hit = memo.get(compressed_key) if memo is not None else None
-        compressed_slot_cache_hit = compressed_hit is not None
-        if compressed_hit is not None:
-            compressed_slots = compressed_hit
-        else:
-            tic = _deepseek_v4_phase_start(timing_enabled)
-            with nvtx_range(f"{profile_prefix}_compressed_slot_mapping"):
-                compressed_slots = cache_metadata.compressed_slot_mapping(
-                    positions,
-                    self.compress_ratio,
-                    token_to_req_indices=metadata.token_to_req_indices[
-                        : positions.numel()
-                    ],
-                    query_start_loc=metadata.query_start_loc,
-                    seq_lens=metadata.seq_lens,
-                    kv_cache_block_size=kv_cache_block_size,
-                    use_decode_cache=use_decode_cache,
-                    is_valid_token=valid_token,
+        compressed_slots: torch.Tensor | None = None
+        compressed_slot_cache_hit = False
+        compressed_kv_block_table: torch.Tensor | None = None
+        compressed_kv_base_offsets: torch.Tensor | None = None
+        if hca_direct_slots:
+            compressed_kv_block_table = cache_metadata.compressed_block_table(
+                self.compress_ratio,
+                kv_cache_block_size,
+            )
+            compressed_kv_base_offsets = (
+                cache_metadata.paged_cache_block_table_base_offsets.get(
+                    v4_compressed_kv_group_id(self.compress_ratio)
                 )
-            if memo is not None:
-                memo[compressed_key] = compressed_slots
-            _deepseek_v4_phase_done(phase_wall_ms, "compressed_slot_mapping", tic)
+            )
+        else:
+            compressed_key = (
+                "compressed",
+                self.compress_ratio,
+                kv_cache_block_size,
+                use_decode_cache,
+            )
+            compressed_hit = memo.get(compressed_key) if memo is not None else None
+            compressed_slot_cache_hit = compressed_hit is not None
+            if compressed_hit is not None:
+                compressed_slots = compressed_hit
+            else:
+                tic = _deepseek_v4_phase_start(timing_enabled)
+                with nvtx_range(f"{profile_prefix}_compressed_slot_mapping"):
+                    compressed_slots = cache_metadata.compressed_slot_mapping(
+                        positions,
+                        self.compress_ratio,
+                        token_to_req_indices=metadata.token_to_req_indices[
+                            : positions.numel()
+                        ],
+                        query_start_loc=metadata.query_start_loc,
+                        seq_lens=metadata.seq_lens,
+                        kv_cache_block_size=kv_cache_block_size,
+                        use_decode_cache=use_decode_cache,
+                        is_valid_token=valid_token,
+                    )
+                if memo is not None:
+                    memo[compressed_key] = compressed_slots
+                _deepseek_v4_phase_done(phase_wall_ms, "compressed_slot_mapping", tic)
         tic = _deepseek_v4_phase_start(timing_enabled)
         kv_cache_2d = pool.get_compressed_kv_buffer_2d(layer_index)
         _deepseek_v4_phase_done(phase_wall_ms, "get_compressed_kv_buffer", tic)
         tic = _deepseek_v4_phase_start(timing_enabled)
         cuda_pair = _deepseek_v4_cuda_event_start(timing_enabled, positions.device)
         with nvtx_range(f"{profile_prefix}_cache_insert"):
-            insert = (
-                deepseek_v4_csa_compress_kv_cache_insert
-                if self.compress_ratio == 4
-                else deepseek_v4_hca_compress_kv_cache_insert
-            )
-            compact_rows = (
-                hca_boundary_rows
-                if self.compress_ratio == 128 and hca_boundary_rows is not None
-                else None
-            )
-            insert(
-                state_cache=state_cache,
-                token_to_req_indices=metadata.token_to_req_indices[: positions.numel()],
-                positions=positions,
-                compressor_slot_mapping=state_slot_mapping,
-                block_table=state_block_table,
-                block_table_base_offsets=state_base_logical_page,
-                compressor_block_size=state_block_size,
-                rms_norm_weight=self.norm.weight,
-                rms_norm_eps=self.norm.variance_epsilon,
-                cos_sin_cache=cos_sin_cache,
-                kv_cache_2d=kv_cache_2d,
-                kv_slot_mapping=compressed_slots,
-                kv_cache_block_size=kv_cache_block_size,
-                compress_ratio=self.compress_ratio,
-                compact_rows=compact_rows,
-            )
+            compact_rows = hca_compact_rows
+            if self.compress_ratio == 128:
+                deepseek_v4_hca_compress_kv_cache_insert(
+                    state_cache=state_cache,
+                    token_to_req_indices=metadata.token_to_req_indices[
+                        : positions.numel()
+                    ],
+                    positions=positions,
+                    compressor_slot_mapping=state_slot_mapping,
+                    block_table=state_block_table,
+                    block_table_base_offsets=state_base_logical_page,
+                    compressor_block_size=state_block_size,
+                    rms_norm_weight=self.norm.weight,
+                    rms_norm_eps=self.norm.variance_epsilon,
+                    cos_sin_cache=cos_sin_cache,
+                    kv_cache_2d=kv_cache_2d,
+                    kv_slot_mapping=compressed_slots,
+                    kv_cache_block_size=kv_cache_block_size,
+                    compress_ratio=self.compress_ratio,
+                    kv_block_table=compressed_kv_block_table,
+                    kv_block_table_base_offsets=compressed_kv_base_offsets,
+                    compact_rows=compact_rows,
+                )
+            else:
+                assert compressed_slots is not None
+                deepseek_v4_csa_compress_kv_cache_insert(
+                    state_cache=state_cache,
+                    token_to_req_indices=metadata.token_to_req_indices[
+                        : positions.numel()
+                    ],
+                    positions=positions,
+                    compressor_slot_mapping=state_slot_mapping,
+                    block_table=state_block_table,
+                    block_table_base_offsets=state_base_logical_page,
+                    compressor_block_size=state_block_size,
+                    rms_norm_weight=self.norm.weight,
+                    rms_norm_eps=self.norm.variance_epsilon,
+                    cos_sin_cache=cos_sin_cache,
+                    kv_cache_2d=kv_cache_2d,
+                    kv_slot_mapping=compressed_slots,
+                    kv_cache_block_size=kv_cache_block_size,
+                    compress_ratio=self.compress_ratio,
+                    compact_rows=compact_rows,
+                )
         _deepseek_v4_cuda_event_done(
             cuda_events, "cache_insert", cuda_pair, positions.device
         )

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -151,6 +151,29 @@ logger = get_colorful_logger(__name__)
 SLOW_DEEPSEEK_V4_LAYER_LOG_THRESHOLD_MS = 500.0
 
 
+def _deepseek_v4_timing_enabled(ctx: ForwardContext | None = None) -> bool:
+    if not logger.isEnabledFor(logging.DEBUG):
+        return False
+    if ctx is None:
+        return True
+    return ctx.forward_mode is not None and ctx.forward_mode.is_extend_or_mixed()
+
+
+def _deepseek_v4_phase_start(enabled: bool) -> float | None:
+    return time.perf_counter() if enabled else None
+
+
+def _deepseek_v4_phase_done(
+    phase_wall_ms: dict[str, float],
+    name: str,
+    tic: float | None,
+) -> None:
+    if tic is None:
+        return
+    elapsed_ms = (time.perf_counter() - tic) * 1000
+    phase_wall_ms[name] = round(phase_wall_ms.get(name, 0.0) + elapsed_ms, 3)
+
+
 def _deepseek_v4_metadata_matches_tokens(metadata, num_tokens: int) -> bool:
     return (
         metadata is not None
@@ -1393,6 +1416,9 @@ def _deepseek_v4_indexer_topk_prefill_deepgemm(
     if not _deepseek_v4_deepgemm_fp4_indexer_available(q_values):
         raise RuntimeError("DeepSeek V4 sparse indexer requires DeepGEMM FP4 support")
 
+    timing_enabled = _deepseek_v4_timing_enabled()
+    total_tic = _deepseek_v4_phase_start(timing_enabled)
+    phase_wall_ms: dict[str, float] = {}
     num_tokens = q_values.shape[0]
     if num_tokens == 0:
         return (
@@ -1414,7 +1440,9 @@ def _deepseek_v4_indexer_topk_prefill_deepgemm(
             gathered_k,
         )
 
+    reused_gather = gathered_k is not None
     if gathered_k is None:
+        tic = _deepseek_v4_phase_start(timing_enabled)
         with nvtx_range("indexer_topk_prefill_gather_paged_mxfp4"):
             gathered_k = _deepseek_v4_gather_paged_indexer_mxfp4_cache(
                 cache_2d,
@@ -1423,8 +1451,10 @@ def _deepseek_v4_indexer_topk_prefill_deepgemm(
                 cache_block_size,
                 out=gather_workspace,
             )
+        _deepseek_v4_phase_done(phase_wall_ms, "gather_paged_mxfp4", tic)
     k_values, k_scales = gathered_k
 
+    tic = _deepseek_v4_phase_start(timing_enabled)
     with nvtx_range("indexer_topk_prefill_deepgemm_logits"):
         logits = deep_gemm.fp8_fp4_mqa_logits(
             q=(q_values.contiguous().view(torch.int8), q_scales.contiguous()),
@@ -1436,17 +1466,39 @@ def _deepseek_v4_indexer_topk_prefill_deepgemm(
             max_seqlen_k=max_len,
             logits_dtype=torch.float32,
         )
+    _deepseek_v4_phase_done(phase_wall_ms, "deepgemm_logits", tic)
 
+    tic = _deepseek_v4_phase_start(timing_enabled)
     with nvtx_range("indexer_topk_prefill_select"):
-        return (
-            _deepseek_v4_indexer_topk_from_logits(
-                logits,
-                row_lens,
-                topk_tokens,
-                use_prefill_topk_op=use_prefill_topk_op,
-            ),
-            gathered_k,
+        topk = _deepseek_v4_indexer_topk_from_logits(
+            logits,
+            row_lens,
+            topk_tokens,
+            use_prefill_topk_op=use_prefill_topk_op,
         )
+    _deepseek_v4_phase_done(phase_wall_ms, "topk_select", tic)
+
+    if timing_enabled and total_tic is not None:
+        total_ms = (time.perf_counter() - total_tic) * 1000
+        if total_ms >= SLOW_DEEPSEEK_V4_LAYER_LOG_THRESHOLD_MS:
+            logger.debug(
+                "[DeepSeekV4][slow_indexer_prefill_chunk] total_ms=%.3f "
+                "phase_wall_ms=%s num_tokens=%s max_len=%s topk_tokens=%s "
+                "gather_rows=%s reused_gather=%s workspace_rows=%s",
+                total_ms,
+                phase_wall_ms,
+                num_tokens,
+                max_len,
+                topk_tokens,
+                int(k_values.shape[0]),
+                reused_gather,
+                (
+                    int(gather_workspace[0].shape[0])
+                    if gather_workspace is not None
+                    else 0
+                ),
+            )
+    return topk, gathered_k
 
 
 def _deepseek_v4_indexer_topk_from_cache_deepgemm_decode(
@@ -3136,6 +3188,7 @@ class DeepseekV4Indexer(nn.Module):
         indexer_cache: torch.Tensor,
         indexer_block_size: int,
         cos_sin_cache: torch.Tensor,
+        layer_index: int,
     ) -> torch.Tensor:
         if not self.use_fp4_cache:
             raise RuntimeError(
@@ -3158,11 +3211,19 @@ class DeepseekV4Indexer(nn.Module):
             total_tokens,
         )
 
+        timing_enabled = _deepseek_v4_timing_enabled(ctx)
+        total_tic = _deepseek_v4_phase_start(timing_enabled)
+        phase_wall_ms: dict[str, float] = {}
+        tic = _deepseek_v4_phase_start(timing_enabled)
         with nvtx_range("indexer_wq_b"):
             index_q, _ = self.wq_b(qr)
             index_q = index_q.view(-1, self.n_head, self.head_dim)
+        _deepseek_v4_phase_done(phase_wall_ms, "wq_b", tic)
+        tic = _deepseek_v4_phase_start(timing_enabled)
         with nvtx_range("indexer_weights_proj"):
             weights, _ = self.weights_proj(hidden_states)
+        _deepseek_v4_phase_done(phase_wall_ms, "weights_proj", tic)
+        tic = _deepseek_v4_phase_start(timing_enabled)
         with nvtx_range("indexer_prepare_mxfp4"):
             packed_index_q, packed_weights = deepseek_v4_prepare_indexer_q_mxfp4(
                 index_q=index_q,
@@ -3172,6 +3233,7 @@ class DeepseekV4Indexer(nn.Module):
                 softmax_scale=self.softmax_scale,
                 head_scale=self.n_head**-0.5,
             )
+        _deepseek_v4_phase_done(phase_wall_ms, "prepare_mxfp4", tic)
 
         packed_indexer_available = _deepseek_v4_deepgemm_fp4_indexer_available(
             packed_index_q[0]
@@ -3196,6 +3258,7 @@ class DeepseekV4Indexer(nn.Module):
             self.compress_ratio,
             indexer_block_size,
         )
+        tic = _deepseek_v4_phase_start(timing_enabled)
         prefill_metadata = _deepseek_v4_indexer_prefill_metadata(
             metadata=metadata,
             block_table=indexer_block_table,
@@ -3203,6 +3266,7 @@ class DeepseekV4Indexer(nn.Module):
             compress_ratio=self.compress_ratio,
             num_prefill_tokens=num_prefill_tokens,
         )
+        _deepseek_v4_phase_done(phase_wall_ms, "prefill_metadata", tic)
 
         decode_schedule_metadata = None
         decode_plan = None
@@ -3215,6 +3279,7 @@ class DeepseekV4Indexer(nn.Module):
                 if getattr(metadata, "is_valid_token", None) is not None
                 else None
             )
+            tic = _deepseek_v4_phase_start(timing_enabled)
             decode_plan = _deepseek_v4_indexer_decode_plan(
                 positions=decode_positions,
                 token_to_req_indices=metadata.token_to_req_indices[
@@ -3233,6 +3298,7 @@ class DeepseekV4Indexer(nn.Module):
                 metadata=metadata,
                 context_lens=decode_plan.context_lens,
             )
+            _deepseek_v4_phase_done(phase_wall_ms, "decode_metadata", tic)
         indexer_metadata = DeepseekV4SparseIndexerMetadata(
             batch_metadata=DeepseekV4IndexerBatchMetadata(
                 positions=positions,
@@ -3246,11 +3312,14 @@ class DeepseekV4Indexer(nn.Module):
             decode_plan=decode_plan,
             decode_schedule_metadata=decode_schedule_metadata,
         )
+        tic = _deepseek_v4_phase_start(timing_enabled)
         prefill_gather_values, prefill_gather_scales = self._prefill_gather_workspace(
             prefill_metadata.max_gather_rows(),
             positions.device,
         )
+        _deepseek_v4_phase_done(phase_wall_ms, "prefill_gather_workspace", tic)
 
+        tic = _deepseek_v4_phase_start(timing_enabled)
         topk_out = (
             self.topk_buffer.get(total_tokens, positions.device)
             if self.topk_buffer is not None
@@ -3260,7 +3329,7 @@ class DeepseekV4Indexer(nn.Module):
                 dtype=torch.int32,
             )
         )[:total_tokens]
-        return _deepseek_v4_sparse_attn_indexer(
+        topk = _deepseek_v4_sparse_attn_indexer(
             indexer_metadata=indexer_metadata,
             indexer_cache=indexer_cache,
             indexer_block_table=indexer_block_table,
@@ -3275,6 +3344,26 @@ class DeepseekV4Indexer(nn.Module):
             persistent_topk_workspace=self._persistent_topk_workspace,
             topk_tokens=self.topk_tokens,
         )
+        _deepseek_v4_phase_done(phase_wall_ms, "sparse_attn_indexer_op", tic)
+        if timing_enabled and total_tic is not None:
+            total_ms = (time.perf_counter() - total_tic) * 1000
+            if total_ms >= SLOW_DEEPSEEK_V4_LAYER_LOG_THRESHOLD_MS:
+                logger.debug(
+                    "[DeepSeekV4][slow_indexer_custom] layer=%s total_ms=%.3f "
+                    "phase_wall_ms=%s total_tokens=%s num_prefill_tokens=%s "
+                    "num_decode_tokens=%s prefill_chunks=%s max_gather_rows=%s "
+                    "topk_tokens=%s",
+                    layer_index,
+                    total_ms,
+                    phase_wall_ms,
+                    total_tokens,
+                    num_prefill_tokens,
+                    num_decode_tokens,
+                    len(prefill_metadata.chunks),
+                    prefill_metadata.max_gather_rows(),
+                    self.topk_tokens,
+                )
+        return topk
 
     def forward(
         self,
@@ -3299,6 +3388,9 @@ class DeepseekV4Indexer(nn.Module):
             if getattr(metadata, "is_valid_token", None) is not None
             else None
         )
+        timing_enabled = _deepseek_v4_timing_enabled(ctx)
+        total_tic = _deepseek_v4_phase_start(timing_enabled)
+        phase_wall_ms: dict[str, float] = {}
         idx_hit = (
             compressor_slot_cache.get("indexer_state")
             if compressor_slot_cache is not None
@@ -3322,6 +3414,7 @@ class DeepseekV4Indexer(nn.Module):
                     "compressor state"
                 )
             indexer_state_block_size = pool.get_indexer_state_block_size(layer_index)
+            tic = _deepseek_v4_phase_start(timing_enabled)
             indexer_state_slot_mapping = _group_slot_mapping_from_raw(
                 positions,
                 metadata.token_to_req_indices[: positions.numel()],
@@ -3333,6 +3426,11 @@ class DeepseekV4Indexer(nn.Module):
                 indexer_state_slot_mapping,
                 valid_token,
             )
+            _deepseek_v4_phase_done(
+                phase_wall_ms,
+                "indexer_state_slot_mapping",
+                tic,
+            )
             if compressor_slot_cache is not None:
                 compressor_slot_cache["indexer_state"] = (
                     indexer_state_slot_mapping,
@@ -3340,6 +3438,7 @@ class DeepseekV4Indexer(nn.Module):
                     indexer_state_block_size,
                     indexer_state_base_logical_page,
                 )
+        tic = _deepseek_v4_phase_start(timing_enabled)
         with nvtx_range("indexer_compressor_total"):
             self.compressor(
                 hidden_states=hidden_states,
@@ -3356,6 +3455,8 @@ class DeepseekV4Indexer(nn.Module):
                 write_compressed_cache=False,
                 kv_score=indexer_compressor_kv_score,
             )
+        _deepseek_v4_phase_done(phase_wall_ms, "indexer_compressor_total", tic)
+        tic = _deepseek_v4_phase_start(timing_enabled)
         with nvtx_range("indexer_compressed_slot_mapping"):
             indexer_block_size = pool.get_indexer_block_size(layer_index)
             indexer_block_table = cache_metadata.compressed_block_table(
@@ -3374,6 +3475,8 @@ class DeepseekV4Indexer(nn.Module):
                 ),
                 is_valid_token=valid_token,
             )
+        _deepseek_v4_phase_done(phase_wall_ms, "indexer_compressed_slot_mapping", tic)
+        tic = _deepseek_v4_phase_start(timing_enabled)
         with nvtx_range("indexer_cache_insert"):
             deepseek_v4_csa_indexer_cache_insert(
                 state_cache=indexer_state,
@@ -3392,7 +3495,9 @@ class DeepseekV4Indexer(nn.Module):
                 use_fp4_cache=self.use_fp4_cache,
                 compress_ratio=self.compress_ratio,
             )
-        return self._forward_sparse_indexer_custom_op(
+        _deepseek_v4_phase_done(phase_wall_ms, "indexer_cache_insert", tic)
+        tic = _deepseek_v4_phase_start(timing_enabled)
+        topk = self._forward_sparse_indexer_custom_op(
             hidden_states=hidden_states,
             qr=qr,
             positions=positions,
@@ -3401,7 +3506,25 @@ class DeepseekV4Indexer(nn.Module):
             indexer_cache=pool.get_indexer_kv_buffer_2d(layer_index),
             indexer_block_size=indexer_block_size,
             cos_sin_cache=cos_sin_cache,
+            layer_index=layer_index,
         )
+        _deepseek_v4_phase_done(phase_wall_ms, "indexer_sparse_custom_op", tic)
+        if timing_enabled and total_tic is not None:
+            total_ms = (time.perf_counter() - total_tic) * 1000
+            if total_ms >= SLOW_DEEPSEEK_V4_LAYER_LOG_THRESHOLD_MS:
+                logger.debug(
+                    "[DeepSeekV4][slow_indexer_forward] layer=%s total_ms=%.3f "
+                    "phase_wall_ms=%s input_tokens=%s num_extends=%s "
+                    "compress_ratio=%s use_fp4_cache=%s",
+                    layer_index,
+                    total_ms,
+                    phase_wall_ms,
+                    positions.numel(),
+                    ctx.num_extends,
+                    self.compress_ratio,
+                    self.use_fp4_cache,
+                )
+        return topk
 
 
 class DeepseekV4Attention(nn.Module):
@@ -3678,6 +3801,10 @@ class DeepseekV4Attention(nn.Module):
         if metadata is None:
             raise RuntimeError("DeepSeek V4 attention requires forward metadata")
 
+        timing_enabled = _deepseek_v4_timing_enabled(ctx)
+        total_tic = _deepseek_v4_phase_start(timing_enabled)
+        phase_wall_ms: dict[str, float] = {}
+
         # --- Phase 1: pre-compute input GEMMs in parallel ---
         # Q/KV projection on main stream; compressor GEMM(s) on aux stream.
         # After this phase, each compressor's forward() receives its
@@ -3685,6 +3812,7 @@ class DeepseekV4Attention(nn.Module):
         # shared-weight dependency that prevents safe multi-stream overlap.
         compressor_kv_score: torch.Tensor | None = None
         indexer_compressor_kv_score: torch.Tensor | None = None
+        tic = _deepseek_v4_phase_start(timing_enabled)
         with self.stream_fork.scope(
             enable=self.stream_fork.aux_stream is not None
         ) as fork:
@@ -3701,13 +3829,20 @@ class DeepseekV4Attention(nn.Module):
                         indexer_compressor_kv_score = (
                             self.indexer.compressor.compute_kv_score(hidden_states)
                         )
+        _deepseek_v4_phase_done(
+            phase_wall_ms,
+            "project_q_kv_and_compressor_gemm",
+            tic,
+        )
 
         if swa_slot_mapping is None:
+            tic = _deepseek_v4_phase_start(timing_enabled)
             swa_slot_mapping = _deepseek_v4_swa_slot_mapping(
                 ctx,
                 positions,
                 out_cache_loc,
             )
+            _deepseek_v4_phase_done(phase_wall_ms, "swa_slot_mapping", tic)
 
         def insert_swa_cache() -> None:
             with nvtx_range(f"{profile_prefix}_insert_swa_cache"):
@@ -3748,6 +3883,7 @@ class DeepseekV4Attention(nn.Module):
         topk_indices = None
         if self.indexer is not None:
             assert self.compressor is not None
+            tic = _deepseek_v4_phase_start(timing_enabled)
             with nvtx_range(f"{profile_prefix}_indexer_prepare_decode_metadata"):
                 self.indexer.prepare_decode_metadata(
                     positions=positions,
@@ -3757,10 +3893,17 @@ class DeepseekV4Attention(nn.Module):
                         self.cache_layer_index
                     ),
                 )
+            _deepseek_v4_phase_done(
+                phase_wall_ms,
+                "indexer_prepare_decode_metadata",
+                tic,
+            )
 
+            tic = _deepseek_v4_phase_start(timing_enabled)
             with self.stream_fork.scope(
                 enable=self.stream_fork.aux_stream is not None
             ) as fork:
+                inner_tic = _deepseek_v4_phase_start(timing_enabled)
                 with nvtx_range(f"{profile_prefix}_indexer"):
                     topk_indices = self.indexer(
                         hidden_states=hidden_states,
@@ -3773,22 +3916,37 @@ class DeepseekV4Attention(nn.Module):
                         compressor_slot_cache=compressor_slot_cache,
                         indexer_compressor_kv_score=indexer_compressor_kv_score,
                     )
+                _deepseek_v4_phase_done(phase_wall_ms, "indexer", inner_tic)
+                inner_tic = _deepseek_v4_phase_start(timing_enabled)
                 with fork.branch():
                     insert_swa_cache()
+                _deepseek_v4_phase_done(phase_wall_ms, "insert_swa_cache", inner_tic)
+                inner_tic = _deepseek_v4_phase_start(timing_enabled)
                 run_compressor()
+                _deepseek_v4_phase_done(phase_wall_ms, "compressor", inner_tic)
+            _deepseek_v4_phase_done(phase_wall_ms, "indexer_stream_scope", tic)
         elif self.compressor is not None:
+            tic = _deepseek_v4_phase_start(timing_enabled)
             with self.stream_fork.scope(
                 enable=self.stream_fork.aux_stream is not None
             ) as fork:
+                inner_tic = _deepseek_v4_phase_start(timing_enabled)
                 run_compressor()
+                _deepseek_v4_phase_done(phase_wall_ms, "compressor", inner_tic)
+                inner_tic = _deepseek_v4_phase_start(timing_enabled)
                 with fork.branch():
                     insert_swa_cache()
+                _deepseek_v4_phase_done(phase_wall_ms, "insert_swa_cache", inner_tic)
+            _deepseek_v4_phase_done(phase_wall_ms, "compressor_stream_scope", tic)
         else:
+            tic = _deepseek_v4_phase_start(timing_enabled)
             insert_swa_cache()
+            _deepseek_v4_phase_done(phase_wall_ms, "insert_swa_cache", tic)
         forward_mode = ctx.forward_mode
         if forward_mode is None:
             raise RuntimeError("DeepSeek V4 attention requires forward mode")
         if forward_mode.is_mixed():
+            tic = _deepseek_v4_phase_start(timing_enabled)
             with nvtx_range(f"{profile_prefix}_mixed_backend"):
                 attn_output = ctx.attn_backend.forward_deepseek_v4_mixed(
                     q=q,
@@ -3805,7 +3963,9 @@ class DeepseekV4Attention(nn.Module):
                     attn_sink=self.attn_sink,
                     topk_indices=topk_indices,
                 )
+            _deepseek_v4_phase_done(phase_wall_ms, "mixed_backend", tic)
         elif forward_mode.is_decode() or forward_mode.is_speculative():
+            tic = _deepseek_v4_phase_start(timing_enabled)
             with nvtx_range(f"{profile_prefix}_decode_backend"):
                 attn_output = ctx.attn_backend.forward_deepseek_v4_decode(
                     q=q,
@@ -3822,7 +3982,9 @@ class DeepseekV4Attention(nn.Module):
                     attn_sink=self.attn_sink,
                     topk_indices=topk_indices,
                 )
+            _deepseek_v4_phase_done(phase_wall_ms, "decode_backend", tic)
         elif forward_mode.is_extend_or_mixed():
+            tic = _deepseek_v4_phase_start(timing_enabled)
             with nvtx_range(f"{profile_prefix}_prefill_backend"):
                 attn_output = ctx.attn_backend.forward_deepseek_v4_prefill(
                     q=q,
@@ -3839,14 +4001,37 @@ class DeepseekV4Attention(nn.Module):
                     attn_sink=self.attn_sink,
                     topk_indices=topk_indices,
                 )
+            _deepseek_v4_phase_done(phase_wall_ms, "prefill_backend", tic)
         else:
             raise RuntimeError(f"Unsupported DeepSeek V4 forward mode: {forward_mode}")
+        tic = _deepseek_v4_phase_start(timing_enabled)
         with nvtx_range(f"{profile_prefix}_output_proj"):
-            return self._project_attention_output(
+            out = self._project_attention_output(
                 attn_output,
                 positions,
                 cos_sin_cache,
             )
+        _deepseek_v4_phase_done(phase_wall_ms, "output_proj", tic)
+        if timing_enabled and total_tic is not None:
+            total_ms = (time.perf_counter() - total_tic) * 1000
+            if total_ms >= SLOW_DEEPSEEK_V4_LAYER_LOG_THRESHOLD_MS:
+                logger.debug(
+                    "[DeepSeekV4][slow_attn] layer=%s cache_layer=%s kind=%s "
+                    "total_ms=%.3f phase_wall_ms=%s input_tokens=%s "
+                    "num_prefill_tokens=%s num_decode_tokens=%s num_extends=%s "
+                    "forward_mode=%s",
+                    self.layer_index,
+                    self.cache_layer_index,
+                    self.attention_kind,
+                    total_ms,
+                    phase_wall_ms,
+                    positions.numel(),
+                    getattr(metadata, "num_prefill_tokens", None),
+                    metadata.decode_token_count(),
+                    ctx.num_extends,
+                    forward_mode,
+                )
+        return out
 
 
 class DeepseekV4DecoderLayer(nn.Module):

--- a/test/runtime/cache/test_deepseek_v4_l2_offload.py
+++ b/test/runtime/cache/test_deepseek_v4_l2_offload.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+
+def test_deepseek_v4_disable_kvstore_hides_host_groups_from_scheduler():
+    from tokenspeed.runtime.engine.event_loop import (
+        _paged_cache_host_group_pages_for_scheduler,
+    )
+
+    host_pool = SimpleNamespace(paged_cache_group_page_counts={"v4.swa_kv": 1})
+
+    assert _paged_cache_host_group_pages_for_scheduler(False, host_pool) == {}
+    assert _paged_cache_host_group_pages_for_scheduler(True, host_pool) == {
+        "v4.swa_kv": 1
+    }
+
+
+def _make_v4_pool():
+    from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
+        DeepseekV4TokenToKVPool,
+        deepseek_v4_cache_layout_from_config,
+    )
+
+    hf_config = SimpleNamespace(
+        compress_ratios=(1, 4, 128),
+        head_dim=512,
+        qk_rope_head_dim=64,
+        index_head_dim=128,
+        sliding_window=128,
+    )
+    layout = deepseek_v4_cache_layout_from_config(
+        hf_config,
+        page_size=64,
+        use_fp4_indexer_cache=True,
+    )
+    pool = DeepseekV4TokenToKVPool(
+        size=512,
+        model_dtype=torch.bfloat16,
+        layout=layout,
+        layer_num=3,
+        device="cpu",
+        enable_memory_saver=False,
+        max_batch_size=2,
+        max_context_len=512,
+        page_size=64,
+        rank=0,
+        hf_config=hf_config,
+        max_scheduled_tokens=64,
+    )
+    return pool
+
+
+def _make_host_pool(device_pool, ratio: float = 1.5):
+    from tokenspeed.runtime.cache.deepseek_v4_cache_host import (
+        DeepseekV4TokenToKVPoolHost,
+    )
+
+    return DeepseekV4TokenToKVPoolHost(
+        device_pool,
+        host_to_device_ratio=ratio,
+        host_size_gb=0,
+        register_host=False,
+    )
+
+
+def test_deepseek_v4_host_pool_shapes_and_group_counts():
+    device_pool = _make_v4_pool()
+    host_pool = _make_host_pool(device_pool, ratio=1.5)
+
+    for group_id, device_pages in device_pool.paged_cache_group_page_counts.items():
+        assert host_pool.paged_cache_group_page_counts[group_id] >= device_pages
+
+    assert (
+        host_pool.swa_kv_buffer[0].shape[1:] == device_pool.swa_kv_buffer[0].shape[1:]
+    )
+    assert host_pool.compressed_kv_buffer[1].shape[1:] == (
+        device_pool.compressed_kv_buffer[1].shape[1:]
+    )
+    assert host_pool.indexer_kv_buffer[1].shape[0] == (
+        host_pool.compressed_kv_buffer[1].shape[0]
+    )
+    assert host_pool.indexer_state_buffer[1].shape[1:] == (
+        device_pool.indexer_state_buffer[1].shape[1:]
+    )
+    assert host_pool.page_num > 0
+    assert host_pool.total_bytes > 0
+
+
+def test_deepseek_v4_host_group_page_sizing_keeps_one_usable_page_per_group():
+    from tokenspeed.runtime.cache.deepseek_v4_cache_host import (
+        _allocate_host_group_pages,
+    )
+
+    ratio_counts = _allocate_host_group_pages(
+        device_counts={"a": 3, "b": 1},
+        page_bytes={"a": 100, "b": 200},
+        host_ratio=0.1,
+        host_size_gb=0,
+    )
+    assert ratio_counts == {"a": 2, "b": 2}
+
+    size_counts = _allocate_host_group_pages(
+        device_counts={"a": 3, "b": 1},
+        page_bytes={"a": 100, "b": 200},
+        host_ratio=1.0,
+        host_size_gb=1,
+    )
+    assert size_counts["a"] >= 2
+    assert size_counts["b"] >= 2
+
+
+def test_deepseek_v4_host_pool_reserves_dummy_page_zero():
+    device_pool = _make_v4_pool()
+    host_pool = _make_host_pool(device_pool)
+    group_id = "v4.swa_kv"
+    group_pages = host_pool.paged_cache_group_page_counts[group_id]
+
+    assert host_pool.available_size(group_id) == group_pages - 1
+    allocated = host_pool.alloc(group_id, min(2, group_pages - 1))
+    assert allocated is not None
+    assert 0 not in allocated.tolist()
+
+    assert host_pool.free(group_id, torch.tensor([0], dtype=torch.int64)) == 0
+    assert 0 not in host_pool.free_pages_by_group[group_id].tolist()
+
+
+def test_deepseek_v4_host_pool_free_rejects_duplicates_and_out_of_range_pages():
+    device_pool = _make_v4_pool()
+    host_pool = _make_host_pool(device_pool)
+    group_id = "v4.swa_kv"
+    group_pages = host_pool.paged_cache_group_page_counts[group_id]
+
+    allocated = host_pool.alloc(group_id, 1)
+    assert allocated is not None
+    page = int(allocated[0])
+    available_after_alloc = host_pool.available_size(group_id)
+
+    assert (
+        host_pool.free(
+            group_id,
+            torch.tensor([page, page, 0, group_pages], dtype=torch.int64),
+        )
+        == 1
+    )
+    assert host_pool.available_size(group_id) == available_after_alloc + 1
+    assert host_pool.free(group_id, torch.tensor(page, dtype=torch.int64)) == 0
+    free_ids = host_pool.free_pages_by_group[group_id].tolist()
+    assert free_ids.count(page) == 1
+    assert group_pages not in free_ids
+
+
+def test_deepseek_v4_shadow_capacity_uses_complete_history_limit():
+    device_pool = _make_v4_pool()
+    host_pool = _make_host_pool(device_pool)
+    host_pool.paged_cache_group_page_counts.update(
+        {
+            "v4.c4a.compressed_kv": 2,
+            "v4.c128a.compressed_kv": 32,
+        }
+    )
+
+    expected_usable_pages = min(
+        (
+            (host_pool.paged_cache_group_page_counts[spec.group_id] - 1)
+            * spec.rows_per_page
+            * spec.entry_stride_tokens
+            + device_pool.page_size
+            - 1
+        )
+        // device_pool.page_size
+        for spec in device_pool.paged_cache_group_specs
+        if spec.family == "history"
+    )
+
+    assert host_pool._compute_shadow_page_num(device_pool) == expected_usable_pages + 1
+
+
+def test_deepseek_v4_descriptor_expansion_ties_ratio4_indexer_to_compressed_group():
+    from tokenspeed.runtime.cache.transfer.deepseek_v4_pool import DeepseekV4CachePool
+
+    device_pool = _make_v4_pool()
+    host_pool = _make_host_pool(device_pool)
+    transfer_pool = DeepseekV4CachePool(device_pool, host_pool, io_backend="direct")
+
+    swa_refs = transfer_pool.tensor_refs_for_group("v4.swa_kv")
+    assert [ref.layer_id for ref in swa_refs] == [0, 1, 2]
+
+    c4_refs = transfer_pool.tensor_refs_for_group(
+        "v4.c4a.compressed_kv",
+        layer_idx=1,
+    )
+    assert len(c4_refs) == 2
+    assert c4_refs[0].device_tensor is device_pool.compressed_kv_buffer[1]
+    assert c4_refs[0].host_tensor is host_pool.compressed_kv_buffer[1]
+    assert c4_refs[1].device_tensor is device_pool.indexer_kv_buffer[1]
+    assert c4_refs[1].host_tensor is host_pool.indexer_kv_buffer[1]
+    assert all(ref.page_bytes == ref.device_tensor[0].nbytes for ref in c4_refs)
+
+
+def test_deepseek_v4_descriptor_expansion_maps_state_groups_to_state_buffers():
+    from tokenspeed.runtime.cache.transfer.deepseek_v4_pool import DeepseekV4CachePool
+
+    device_pool = _make_v4_pool()
+    host_pool = _make_host_pool(device_pool)
+    transfer_pool = DeepseekV4CachePool(device_pool, host_pool, io_backend="direct")
+
+    c4_state_refs = transfer_pool.tensor_refs_for_group(
+        "v4.c4a.compressor_state",
+        layer_idx=1,
+    )
+    assert len(c4_state_refs) == 1
+    assert c4_state_refs[0].device_tensor is device_pool.compressor_state_buffer[1]
+    assert c4_state_refs[0].host_tensor is host_pool.compressor_state_buffer[1]
+
+    c128_state_refs = transfer_pool.tensor_refs_for_group(
+        "v4.c128a.compressor_state",
+        layer_idx=2,
+    )
+    assert len(c128_state_refs) == 1
+    assert c128_state_refs[0].device_tensor is device_pool.compressor_state_buffer[2]
+    assert c128_state_refs[0].host_tensor is host_pool.compressor_state_buffer[2]
+
+    indexer_state_refs = transfer_pool.tensor_refs_for_group(
+        "v4.c4a.indexer_compressor_state",
+        layer_idx=1,
+    )
+    assert len(indexer_state_refs) == 1
+    assert indexer_state_refs[0].device_tensor is device_pool.indexer_state_buffer[1]
+    assert indexer_state_refs[0].host_tensor is host_pool.indexer_state_buffer[1]
+
+
+def test_deepseek_v4_paged_pool_dispatches_direct_page_copies(monkeypatch):
+    from tokenspeed.runtime.cache.transfer import deepseek_v4_pool
+    from tokenspeed.runtime.cache.transfer.deepseek_v4_pool import DeepseekV4CachePool
+
+    device_pool = _make_v4_pool()
+    host_pool = _make_host_pool(device_pool)
+    transfer_pool = DeepseekV4CachePool(device_pool, host_pool, io_backend="kernel")
+
+    calls = []
+
+    def fake_transfer_kv_direct(
+        *,
+        src_layers,
+        dst_layers,
+        src_indices,
+        dst_indices,
+        page_size,
+    ):
+        calls.append(
+            (
+                src_layers,
+                dst_layers,
+                src_indices.tolist(),
+                dst_indices.tolist(),
+                page_size,
+            )
+        )
+
+    monkeypatch.setattr(
+        deepseek_v4_pool,
+        "transfer_kv_direct",
+        fake_transfer_kv_direct,
+    )
+    transfer = SimpleNamespace(
+        group_id="v4.c4a.compressed_kv",
+        src_pages=[3, 1, 3],
+        dst_pages=[9, 7, 9],
+    )
+
+    transfer_pool.writeback_paged([transfer])
+
+    assert len(calls) == 1
+    src_layers, dst_layers, src_indices, dst_indices, page_size = calls[0]
+    assert src_indices == [1, 3]
+    assert dst_indices == [7, 9]
+    assert page_size == 1
+    assert src_layers[0] is device_pool.compressed_kv_buffer[1]
+    assert src_layers[1] is device_pool.indexer_kv_buffer[1]
+    assert dst_layers[0] is host_pool.compressed_kv_buffer[1]
+    assert dst_layers[1] is host_pool.indexer_kv_buffer[1]
+    c4_bytes = (
+        device_pool.compressed_kv_buffer[1][0].nbytes
+        + device_pool.indexer_kv_buffer[1][0].nbytes
+    )
+    assert transfer_pool.get_transfer_stats()["D2H"]["v4.c4a.compressed_kv"] == {
+        "calls": 1,
+        "pages": 2,
+        "bytes": 2 * c4_bytes,
+    }
+
+    calls.clear()
+    transfer_pool.loadback_paged([transfer], layer_idx=1)
+
+    assert len(calls) == 1
+    src_layers, dst_layers, src_indices, dst_indices, page_size = calls[0]
+    assert src_layers[0] is host_pool.compressed_kv_buffer[1]
+    assert src_layers[1] is host_pool.indexer_kv_buffer[1]
+    assert dst_layers[0] is device_pool.compressed_kv_buffer[1]
+    assert dst_layers[1] is device_pool.indexer_kv_buffer[1]
+    assert src_indices == [1, 3]
+    assert dst_indices == [7, 9]
+    assert page_size == 1
+    assert transfer_pool.get_transfer_stats()["H2D"]["v4.c4a.compressed_kv"] == {
+        "calls": 1,
+        "pages": 2,
+        "bytes": 2 * c4_bytes,
+    }
+    transfer_pool.reset_transfer_stats()
+    assert transfer_pool.get_transfer_stats() == {"D2H": {}, "H2D": {}}
+
+    def failing_transfer_kv_direct(**kwargs):
+        del kwargs
+        raise RuntimeError("copy submission failed")
+
+    monkeypatch.setattr(
+        deepseek_v4_pool,
+        "transfer_kv_direct",
+        failing_transfer_kv_direct,
+    )
+    try:
+        transfer_pool.writeback_paged([transfer])
+    except RuntimeError as exc:
+        assert "copy submission failed" in str(exc)
+    else:
+        raise AssertionError("expected transfer failure")
+    assert transfer_pool.get_transfer_stats() == {"D2H": {}, "H2D": {}}
+
+
+def test_deepseek_v4_layer_getters_wait_on_registered_counter():
+    device_pool = _make_v4_pool()
+    waits = []
+
+    class FakeCounter:
+        def wait_until(self, layer_id: int):
+            waits.append(layer_id)
+
+    device_pool.register_layer_transfer_counter(FakeCounter())
+
+    device_pool.get_swa_kv_buffer(0)
+    device_pool.get_compressed_kv_buffer_2d(1)
+    device_pool.get_compressor_state_buffer(1)
+    device_pool.get_indexer_kv_buffer_2d(1)
+    device_pool.get_indexer_state_buffer(1)
+    device_pool.get_kv_buffer(2)
+
+    assert waits == [0, 1, 1, 1, 1, 2]
+
+
+def test_scheduler_config_accepts_paged_cache_host_group_pages():
+    from tokenspeed.runtime.engine.scheduler_utils import make_config
+
+    cfg = make_config(
+        num_device_pages=8,
+        max_scheduled_tokens=4,
+        max_batch_size=2,
+        page_size=64,
+        num_host_pages=0,
+        disable_l2_cache=False,
+        enable_l3_storage=False,
+        prefetch_threshold=4,
+        role="null",
+        paged_cache_host_group_pages={"v4.swa_kv": 17},
+    )
+
+    assert cfg.paged_cache_host_group_pages == {"v4.swa_kv": 17}

--- a/test/runtime/cache/test_transfer_host_executor.py
+++ b/test/runtime/cache/test_transfer_host_executor.py
@@ -5,7 +5,12 @@ from contextlib import nullcontext
 import pytest
 import torch
 
-from tokenspeed.runtime.cache.transfer.types import CacheKind, Location, TransferUnit
+from tokenspeed.runtime.cache.transfer.types import (
+    PAGED_CACHE_KIND,
+    CacheKind,
+    Location,
+    TransferUnit,
+)
 
 
 class FakeEvent:
@@ -107,6 +112,29 @@ class FakePool:
         self.writebacks.clear()
         self.loadbacks.clear()
         self.counter.reset()
+
+
+class FakePagedPool:
+    kind = PAGED_CACHE_KIND
+
+    def __init__(self, num_layers: int):
+        self._num_layers = num_layers
+        self.device = torch.device("cpu")
+        self.counter = FakeCounter(num_layers)
+        self.writebacks = []
+        self.loadbacks = []
+
+    def num_layers(self):
+        return self._num_layers
+
+    def get_layer_done_counter(self):
+        return self.counter
+
+    def writeback_paged(self, transfers):
+        self.writebacks.append(list(transfers))
+
+    def loadback_paged(self, transfers, layer_idx: int):
+        self.loadbacks.append((layer_idx, list(transfers)))
 
 
 def _patch_host_executor_device(monkeypatch):
@@ -227,6 +255,46 @@ def test_host_executor_loadback_uses_independent_layer_counters(monkeypatch):
     assert kv_pool.counter.consumer == [0]
 
 
+def test_host_executor_paged_cache_loadback_marks_layers_and_producer(monkeypatch):
+    HostExecutor = _patch_host_executor_device(monkeypatch)
+    paged_pool = FakePagedPool(num_layers=3)
+    executor = HostExecutor(pools=[], paged_pool=paged_pool, io_backend="kernel")
+    transfer = object()
+
+    executor.enqueue_paged_cache_loadback(33, [transfer])
+    executor.flush()
+
+    assert paged_pool.loadbacks == [
+        (0, [transfer]),
+        (1, [transfer]),
+        (2, [transfer]),
+    ]
+    assert all(event.recorded for event in paged_pool.counter.events[0].load_events)
+    assert executor.get_producer_index(PAGED_CACHE_KIND, 33) == 0
+    executor.set_consumer(PAGED_CACHE_KIND, [0])
+    assert paged_pool.counter.consumer == [0]
+    assert executor.drain() == []
+
+
+def test_cache_event_payloads_commit_only_common_ops_and_and_success():
+    from tokenspeed.runtime.engine.scheduler_utils import (
+        pop_common_cache_event_payloads,
+    )
+
+    rank0 = [
+        {"kind": "WriteBackDoneEvent", "op_id": 3, "success": True},
+        {"kind": "WriteBackDoneEvent", "op_id": 5, "success": True},
+    ]
+    rank1 = [
+        {"kind": "WriteBackDoneEvent", "op_id": 3, "success": False},
+    ]
+
+    ready = pop_common_cache_event_payloads([rank0, rank1])
+
+    assert ready == [{"kind": "WriteBackDoneEvent", "op_id": 3, "success": False}]
+    assert pop_common_cache_event_payloads([rank0, []]) == []
+
+
 def test_memory_executor_submit_dispatches_flat_op_by_cache_kind(monkeypatch):
     import tokenspeed.runtime.cache.executor.memory_executor as memory_executor
 
@@ -296,6 +364,69 @@ def test_memory_executor_submit_dispatches_flat_op_by_cache_kind(monkeypatch):
         (CacheKind.KV, 9, [10], [20]),
         (CacheKind.MAMBA, 9, [30], [40]),
     ]
+
+
+def test_memory_executor_submit_dispatches_paged_cache_transfers(monkeypatch):
+    import tokenspeed.runtime.cache.executor.memory_executor as memory_executor
+
+    class FakeCache:
+        class WriteBackOp:
+            pass
+
+        class LoadBackOp:
+            pass
+
+        class PrefetchOp:
+            pass
+
+        class BackUpOp:
+            pass
+
+    class FakeHostExec:
+        def __init__(self):
+            self.pools = {}
+            self.completed_writebacks = []
+            self.paged_writebacks = []
+            self.paged_loadbacks = []
+
+        def enqueue_paged_cache_writeback(self, op_id, transfers, is_retract=False):
+            self.paged_writebacks.append((op_id, transfers, is_retract))
+
+        def enqueue_paged_cache_loadback(self, op_id, transfers):
+            self.paged_loadbacks.append((op_id, transfers))
+
+        def flush(self):
+            pass
+
+    monkeypatch.setattr(memory_executor, "Cache", FakeCache)
+    executor = object.__new__(memory_executor.MemoryExecutor)
+    executor.host_exec = FakeHostExec()
+    executor.storage_exec = None
+
+    transfer = object()
+    wb = FakeCache.WriteBackOp()
+    wb.op_ids = [7]
+    wb.src_pages = [[]]
+    wb.dst_pages = [[]]
+    wb.src_pages_by_kind = {"kv": [[]], "mamba": [[]]}
+    wb.dst_pages_by_kind = {"kv": [[]], "mamba": [[]]}
+    wb.paged_cache_transfers = [[transfer]]
+    wb.is_retract = [True]
+    executor.submit(wb)
+
+    assert executor.host_exec.paged_writebacks == [(7, [transfer], True)]
+    assert executor.host_exec.completed_writebacks == []
+
+    lb = FakeCache.LoadBackOp()
+    lb.op_ids = [9]
+    lb.src_pages = [[]]
+    lb.dst_pages = [[]]
+    lb.src_pages_by_kind = {"kv": [[]], "mamba": [[]]}
+    lb.dst_pages_by_kind = {"kv": [[]], "mamba": [[]]}
+    lb.paged_cache_transfers = [[transfer]]
+    executor.submit(lb)
+
+    assert executor.host_exec.paged_loadbacks == [(9, [transfer])]
 
 
 def test_memory_executor_submit_plan_keeps_generic_submit_signature(monkeypatch):

--- a/test/runtime/test_deepseek_v4_attention_ops.py
+++ b/test/runtime/test_deepseek_v4_attention_ops.py
@@ -36,6 +36,7 @@ from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (
     deepseek_v4_decode_swa_indices_and_lens,
     deepseek_v4_dequantize_and_gather_k_cache,
     deepseek_v4_hca_compress_kv_cache_insert,
+    deepseek_v4_paged_compressed_slot_mapping,
     deepseek_v4_prepare_indexer_q_mxfp4,
     dequantize_deepseek_v4_fp8_ds_mla_cache,
     fused_qnorm_rope_kv_insert,
@@ -1663,6 +1664,57 @@ class DeepseekV4AttentionOpsTest(unittest.TestCase):
             )
         )
         self.assertTrue(torch.equal(out[5:].cpu(), torch.full((3,), -1)))
+
+    def test_paged_compressed_slot_mapping_matches_reference(self):
+        device = torch.device("cuda")
+        positions = torch.tensor(
+            [3, 4, 7, 8, 11, 15, 16],
+            device=device,
+            dtype=torch.int64,
+        )
+        req_indices = torch.tensor(
+            [0, 0, 0, 1, 1, 1, 1],
+            device=device,
+            dtype=torch.int32,
+        )
+        block_table = torch.tensor(
+            [
+                [10, 11, -1],
+                [20, 21, 22],
+            ],
+            device=device,
+            dtype=torch.int32,
+        )
+        base_offsets = torch.tensor([0, 1], device=device, dtype=torch.int32)
+
+        actual = deepseek_v4_paged_compressed_slot_mapping(
+            positions=positions,
+            token_to_req_indices=req_indices,
+            block_table=block_table,
+            block_size=2,
+            compress_ratio=4,
+            base_offsets=base_offsets,
+        )
+        torch.cuda.synchronize()
+
+        expected = []
+        for pos, req in zip(positions.cpu().tolist(), req_indices.cpu().tolist()):
+            if (pos + 1) % 4 != 0:
+                expected.append(-1)
+                continue
+            compressed_pos = pos // 4
+            page = compressed_pos // 2 - int(base_offsets.cpu()[req])
+            offset = compressed_pos % 2
+            if page < 0 or page >= block_table.shape[1]:
+                expected.append(-1)
+                continue
+            page_id = int(block_table.cpu()[req, page])
+            expected.append(page_id * 2 + offset if page_id >= 0 else -1)
+
+        torch.testing.assert_close(
+            actual.cpu(),
+            torch.tensor(expected, dtype=torch.int64),
+        )
 
     def test_sparse_prefill_dequantize_and_gather_matches_reference(self):
         torch.manual_seed(9234)

--- a/test/runtime/test_deepseek_v4_attention_ops.py
+++ b/test/runtime/test_deepseek_v4_attention_ops.py
@@ -598,6 +598,7 @@ class DeepseekV4AttentionOpsTest(unittest.TestCase):
             dtype=torch.uint8,
         )
         compact_cache = torch.zeros_like(cache)
+        direct_compact_cache = torch.zeros_like(cache)
 
         deepseek_v4_hca_compress_kv_cache_insert(
             state_cache=state_cache,
@@ -630,6 +631,23 @@ class DeepseekV4AttentionOpsTest(unittest.TestCase):
             compress_ratio=compress_ratio,
             compact_rows=1,
         )
+        deepseek_v4_hca_compress_kv_cache_insert(
+            state_cache=state_cache,
+            token_to_req_indices=token_to_req_indices,
+            positions=positions,
+            compressor_slot_mapping=state_slots,
+            block_table=block_table,
+            compressor_block_size=state_block_size,
+            rms_norm_weight=rms_weight,
+            rms_norm_eps=eps,
+            cos_sin_cache=cos_sin,
+            kv_cache_2d=direct_compact_cache,
+            kv_slot_mapping=None,
+            kv_cache_block_size=kv_cache_block_size,
+            compress_ratio=compress_ratio,
+            kv_block_table=block_table,
+            compact_rows=1,
+        )
 
         weights = torch.softmax(score.float() + ape, dim=0)
         compressed = torch.sum(kv.float() * weights, dim=0)
@@ -646,7 +664,7 @@ class DeepseekV4AttentionOpsTest(unittest.TestCase):
             .view(torch.uint8)
         )
 
-        for tested_cache in (cache, compact_cache):
+        for tested_cache in (cache, compact_cache, direct_compact_cache):
             flat_cache = tested_cache.view(-1)
             scale_base = kv_cache_block_size * SWA_TOKEN_STRIDE
             for qblock in range(7):

--- a/test/runtime/test_deepseek_v4_attention_ops.py
+++ b/test/runtime/test_deepseek_v4_attention_ops.py
@@ -597,6 +597,7 @@ class DeepseekV4AttentionOpsTest(unittest.TestCase):
             device=device,
             dtype=torch.uint8,
         )
+        compact_cache = torch.zeros_like(cache)
 
         deepseek_v4_hca_compress_kv_cache_insert(
             state_cache=state_cache,
@@ -612,6 +613,22 @@ class DeepseekV4AttentionOpsTest(unittest.TestCase):
             kv_slot_mapping=kv_slots,
             kv_cache_block_size=kv_cache_block_size,
             compress_ratio=compress_ratio,
+        )
+        deepseek_v4_hca_compress_kv_cache_insert(
+            state_cache=state_cache,
+            token_to_req_indices=token_to_req_indices,
+            positions=positions,
+            compressor_slot_mapping=state_slots,
+            block_table=block_table,
+            compressor_block_size=state_block_size,
+            rms_norm_weight=rms_weight,
+            rms_norm_eps=eps,
+            cos_sin_cache=cos_sin,
+            kv_cache_2d=compact_cache,
+            kv_slot_mapping=kv_slots,
+            kv_cache_block_size=kv_cache_block_size,
+            compress_ratio=compress_ratio,
+            compact_rows=1,
         )
 
         weights = torch.softmax(score.float() + ape, dim=0)
@@ -629,31 +646,32 @@ class DeepseekV4AttentionOpsTest(unittest.TestCase):
             .view(torch.uint8)
         )
 
-        flat_cache = cache.view(-1)
-        scale_base = kv_cache_block_size * SWA_TOKEN_STRIDE
-        for qblock in range(7):
-            start = qblock * 64
-            expected_bytes, expected_scale = _fp8_bytes_and_scale(
-                quant_input[start : start + 64]
-            )
+        for tested_cache in (cache, compact_cache):
+            flat_cache = tested_cache.view(-1)
+            scale_base = kv_cache_block_size * SWA_TOKEN_STRIDE
+            for qblock in range(7):
+                start = qblock * 64
+                expected_bytes, expected_scale = _fp8_bytes_and_scale(
+                    quant_input[start : start + 64]
+                )
+                torch.testing.assert_close(
+                    flat_cache[start : start + 64].cpu(),
+                    expected_bytes.cpu(),
+                    atol=0,
+                    rtol=0,
+                )
+                self.assertEqual(int(flat_cache[scale_base + qblock]), expected_scale)
+            self.assertEqual(int(flat_cache[scale_base + 7]), 0)
             torch.testing.assert_close(
-                flat_cache[start : start + 64].cpu(),
-                expected_bytes.cpu(),
+                flat_cache[NOPE_DIM:SWA_TOKEN_STRIDE].cpu(),
+                expected_rope.cpu(),
                 atol=0,
                 rtol=0,
             )
-            self.assertEqual(int(flat_cache[scale_base + qblock]), expected_scale)
-        self.assertEqual(int(flat_cache[scale_base + 7]), 0)
-        torch.testing.assert_close(
-            flat_cache[NOPE_DIM:SWA_TOKEN_STRIDE].cpu(),
-            expected_rope.cpu(),
-            atol=0,
-            rtol=0,
-        )
-        self.assertEqual(
-            int(flat_cache[SWA_TOKEN_STRIDE : 2 * SWA_TOKEN_STRIDE].sum()),
-            0,
-        )
+            self.assertEqual(
+                int(flat_cache[SWA_TOKEN_STRIDE : 2 * SWA_TOKEN_STRIDE].sum()),
+                0,
+            )
 
     def test_csa_compressor_state_insert_matches_reference(self):
         torch.manual_seed(5678)

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -2109,7 +2109,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertTrue(
             torch.equal(
                 metadata.seq_lens_cpu,
-                torch.tensor([5, 9, 12], dtype=torch.int32),
+                torch.tensor([5, 0, 0], dtype=torch.int32),
             )
         )
         self.assertTrue(
@@ -2157,6 +2157,41 @@ class TestDeepseekV4Config(unittest.TestCase):
             torch.equal(decode.query_lens_cpu, torch.tensor([1, 1], dtype=torch.int32))
         )
 
+    def test_deepseek_v4_extend_metadata_sizes_tokens_from_cpu_lens(self):
+        backend = DeepseekV4AttentionBackend(
+            SimpleNamespace(
+                page_size=64,
+                device="cpu",
+                num_attention_heads=8,
+                num_kv_heads=1,
+                attn_tp_size=1,
+                dtype=torch.bfloat16,
+                is_draft=False,
+                speculative_num_draft_tokens=1,
+                head_dim=576,
+                context_len=256,
+            )
+        )
+        backend.init_forward_metadata(
+            bs=1,
+            req_pool_indices=torch.tensor([0], dtype=torch.int32),
+            seq_lens=torch.tensor([5], dtype=torch.int32),
+            forward_mode=ForwardMode.EXTEND,
+            req_to_page=torch.tensor([[10]], dtype=torch.int32),
+            extend_seq_lens_cpu=torch.tensor([5], dtype=torch.int32),
+        )
+
+        metadata = backend.forward_metadata
+        self.assertIsNotNone(metadata)
+        self.assertEqual(metadata.token_to_req_indices.numel(), 5)
+        self.assertEqual(metadata.num_prefill_tokens, 5)
+        self.assertTrue(
+            torch.equal(
+                metadata.token_to_req_indices,
+                torch.tensor([0, 0, 0, 0, 0], dtype=torch.int32),
+            )
+        )
+
     def test_deepseek_v4_mixed_metadata_accepts_prefill_prefix_lens_only(self):
         backend = DeepseekV4AttentionBackend(
             SimpleNamespace(
@@ -2192,7 +2227,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertTrue(
             torch.equal(
                 metadata.seq_lens_cpu,
-                torch.tensor([5, 9, 12, 6], dtype=torch.int32),
+                torch.tensor([5, 9, 12, 0], dtype=torch.int32),
             )
         )
         self.assertTrue(
@@ -2389,6 +2424,73 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertIs(backend.forward_metadata, mixed_metadata)
         self.assertTrue(torch.equal(out[:3], torch.ones((3, 1, 2))))
         self.assertTrue(torch.equal(out[3:], torch.full((2, 1, 2), 2.0)))
+
+    def test_deepseek_v4_chunked_prefill_uses_cpu_query_lens_offsets(self):
+        backend = DeepseekV4AttentionBackend(
+            SimpleNamespace(
+                page_size=64,
+                device="cpu",
+                num_attention_heads=8,
+                num_kv_heads=1,
+                attn_tp_size=1,
+                dtype=torch.bfloat16,
+                is_draft=False,
+                speculative_num_draft_tokens=1,
+                head_dim=576,
+                context_len=256,
+                deepseek_v4_prefill_chunk_size=2,
+            )
+        )
+        backend.init_forward_metadata(
+            bs=3,
+            req_pool_indices=torch.tensor([0, 1, 2], dtype=torch.int32),
+            seq_lens=torch.tensor([2, 3, 1], dtype=torch.int32),
+            forward_mode=ForwardMode.EXTEND,
+            req_to_page=torch.tensor([[10], [20], [30]], dtype=torch.int32),
+            extend_seq_lens_cpu=torch.tensor([2, 3, 1], dtype=torch.int32),
+        )
+        calls = []
+
+        def fake_prefill_chunk(**kwargs):
+            metadata = backend.forward_metadata
+            q = kwargs["q"]
+            calls.append(
+                (
+                    q.shape[0],
+                    kwargs["positions"].tolist(),
+                    metadata.req_pool_indices.tolist(),
+                    metadata.token_to_req_indices.tolist(),
+                    metadata.query_lens_cpu.tolist(),
+                )
+            )
+            return q.new_full((q.shape[0], 1, 2), float(len(calls)))
+
+        backend._forward_deepseek_v4_prefill_chunk = fake_prefill_chunk
+        out = backend.forward_deepseek_v4_prefill(
+            q=torch.zeros((6, 1, 2), dtype=torch.float32),
+            positions=torch.arange(6, dtype=torch.int64),
+            token_to_kv_pool=SimpleNamespace(),
+            layer_id=0,
+            kind="mla",
+            compress_ratio=4,
+            num_local_heads=1,
+            padded_heads=1,
+            head_dim=2,
+            window_size=4,
+            softmax_scale=1.0,
+            attn_sink=torch.zeros(1),
+            topk_indices=None,
+        )
+
+        self.assertEqual(
+            calls,
+            [
+                (5, [0, 1, 2, 3, 4], [0, 1], [0, 0, 1, 1, 1], [2, 3]),
+                (1, [5], [2], [0], [1]),
+            ],
+        )
+        self.assertTrue(torch.equal(out[:5], torch.ones((5, 1, 2))))
+        self.assertTrue(torch.equal(out[5:], torch.full((1, 1, 2), 2.0)))
 
     def test_deepseek_v4_spec_metadata_requires_uniform_pack(self):
         backend = DeepseekV4AttentionBackend(

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -93,6 +93,7 @@ from tokenspeed.runtime.models.deepseek_v4 import (
     DeepseekV4MoEGate,
     _deepseek_v4_forward_metadata,
     _deepseek_v4_fused_select_experts,
+    _deepseek_v4_hca_compact_row_bound,
     _deepseek_v4_indexer_decode_max_len,
     _deepseek_v4_indexer_decode_plan,
     _deepseek_v4_indexer_prefill_max_logits_bytes,
@@ -317,6 +318,32 @@ class TestDeepseekV4Config(unittest.TestCase):
                 has_drafter=True, use_target_verify=True
             ),
             ForwardMode.TARGET_VERIFY,
+        )
+
+    def test_deepseek_v4_hca_compact_row_bound_includes_mixed_decode_tokens(self):
+        self.assertEqual(
+            _deepseek_v4_hca_compact_row_bound(
+                prefill_rows=3,
+                decode_tokens=0,
+                include_decode_tokens=False,
+            ),
+            3,
+        )
+        self.assertEqual(
+            _deepseek_v4_hca_compact_row_bound(
+                prefill_rows=3,
+                decode_tokens=2,
+                include_decode_tokens=True,
+            ),
+            5,
+        )
+        self.assertEqual(
+            _deepseek_v4_hca_compact_row_bound(
+                prefill_rows=None,
+                decode_tokens=1,
+                include_decode_tokens=True,
+            ),
+            None,
         )
 
     def test_model_runner_forwards_supported_spec_step_idx(self):

--- a/test/runtime/test_v4_prefix_cache_metadata.py
+++ b/test/runtime/test_v4_prefix_cache_metadata.py
@@ -158,5 +158,38 @@ class TestV4PrefixCacheMetadata(unittest.TestCase):
         self.assertEqual(fh_base, 0)
 
 
+class TestV4PrefixCacheAdjunctGate(unittest.TestCase):
+
+    def test_disable_kvstore_keeps_paged_groups_transport_only(self) -> None:
+        from tokenspeed.runtime.engine.scheduler_utils import (
+            pool_to_prefix_cache_adjunct_spec_if_enabled,
+        )
+
+        required = ("fh", "swa")
+
+        self.assertIsNone(
+            pool_to_prefix_cache_adjunct_spec_if_enabled(
+                required,
+                enable_prefix_caching=True,
+                enable_kvstore=False,
+            )
+        )
+        self.assertIsNone(
+            pool_to_prefix_cache_adjunct_spec_if_enabled(
+                required,
+                enable_prefix_caching=False,
+                enable_kvstore=True,
+            )
+        )
+
+        adjunct = pool_to_prefix_cache_adjunct_spec_if_enabled(
+            required,
+            enable_prefix_caching=True,
+            enable_kvstore=True,
+        )
+        self.assertIsNotNone(adjunct)
+        self.assertEqual(adjunct.required_groups, ["fh", "swa"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/runtime/test_v4_sliding_window_groups_smoke.py
+++ b/test/runtime/test_v4_sliding_window_groups_smoke.py
@@ -19,7 +19,6 @@ import pathlib
 import sys
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
 
 import torch
 
@@ -102,9 +101,6 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
             self.assertLess(n, bound, spec.group_id)
 
     def test_deepseek_v4_pool_exposes_scheduler_cache_groups(self):
-        from tokenspeed.runtime.layers.attention.kv_cache import (
-            deepseek_v4 as deepseek_v4_kv,
-        )
         from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
             DeepseekV4TokenToKVPool,
             deepseek_v4_cache_layout_from_config,
@@ -148,7 +144,7 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
             pool.paged_cache_group_page_counts["v4.c4a.compressed_kv"], 1
         )
         self.assertFalse(hasattr(pool, "prefix_cache_state_policy"))
-        self.assertFalse(pool.supports_hierarchical_kv_cache)
+        self.assertTrue(pool.supports_hierarchical_kv_cache)
         self.assertEqual(
             pool.prefix_cache_required_group_ids,
             (
@@ -156,31 +152,6 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
                 "v4.c128a.compressed_kv",
             ),
         )
-
-        class FakePagedCacheScheduler:
-            @staticmethod
-            def paged_cache_group_total_pages(group_id: str) -> int:
-                return 11
-
-            @staticmethod
-            def paged_cache_group_available_pages(group_id: str) -> int:
-                return 4
-
-            @staticmethod
-            def paged_cache_group_failed_alloc_count(group_id: str) -> int:
-                return 2
-
-        pool.bind_paged_cache_scheduler(FakePagedCacheScheduler())
-        with (
-            patch.object(deepseek_v4_kv.logger, "isEnabledFor", return_value=True),
-            patch.object(deepseek_v4_kv.logger, "debug") as log_debug,
-        ):
-            pool.maybe_log_paged_cache_group_pages()
-        log_debug.assert_called_once()
-        logged_groups = log_debug.call_args.args[1]
-        self.assertIn("v4.swa_kv: used=7/11", logged_groups)
-        self.assertIn("v4.c4a.indexer_compressor_state", logged_groups)
-        self.assertIn("failed_alloc=2", logged_groups)
 
     def test_deepseek_v4_capacity_profile_matches_pool_buffers(self):
         from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/deepseek_v4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/deepseek_v4.py
@@ -253,6 +253,7 @@ def deepseek_v4_fused_indexer_q_rope_hadamard_mxfp4(
 
 @triton.jit
 def _deepseek_v4_fused_sparse_compress_cache_kernel(
+    token_indices_ptr,
     state_cache_ptr,
     state_cache_stride0,
     state_cache_stride1,
@@ -282,8 +283,15 @@ def _deepseek_v4_fused_sparse_compress_cache_kernel(
     TOKEN_STRIDE: tl.constexpr,
     SCALE_DIM: tl.constexpr,
     KV_BLOCK_STRIDE: tl.constexpr,
+    USE_COMPACT: tl.constexpr,
 ):
-    token_idx = tl.program_id(0)
+    row_idx = tl.program_id(0)
+    if USE_COMPACT:
+        token_idx = tl.load(token_indices_ptr + row_idx)
+        if token_idx < 0:
+            return
+    else:
+        token_idx = row_idx
 
     state_slot = tl.load(slot_mapping_ptr + token_idx)
     if state_slot < 0:
@@ -399,6 +407,27 @@ def _deepseek_v4_fused_sparse_compress_cache_kernel(
     )
 
 
+@triton.jit
+def _deepseek_v4_compact_hca_boundary_tokens_kernel(
+    positions_ptr,
+    state_slot_mapping_ptr,
+    kv_slot_mapping_ptr,
+    token_indices_ptr,
+    count_ptr,
+    COMPRESS_RATIO: tl.constexpr,
+    MAX_ROWS: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    position = tl.load(positions_ptr + token_idx)
+    state_slot = tl.load(state_slot_mapping_ptr + token_idx)
+    kv_slot = tl.load(kv_slot_mapping_ptr + token_idx)
+    keep = (state_slot >= 0) & (kv_slot >= 0) & ((position + 1) % COMPRESS_RATIO == 0)
+    if keep:
+        row = tl.atomic_add(count_ptr, 1, sem="relaxed")
+        if row < MAX_ROWS:
+            tl.store(token_indices_ptr + row, token_idx)
+
+
 def deepseek_v4_fused_sparse_compress_cache_insert(
     *,
     state_cache: torch.Tensor,
@@ -416,6 +445,7 @@ def deepseek_v4_fused_sparse_compress_cache_insert(
     compress_ratio: int,
     overlap: bool,
     block_table_base_offsets: torch.Tensor | None = None,
+    compact_rows: int | None = None,
 ) -> None:
     num_actual = min(
         compressor_slot_mapping.numel(),
@@ -424,7 +454,39 @@ def deepseek_v4_fused_sparse_compress_cache_insert(
     )
     if num_actual == 0:
         return
-    _deepseek_v4_fused_sparse_compress_cache_kernel[(num_actual,)](
+    use_compact = (
+        compact_rows is not None
+        and int(compact_rows) >= 0
+        and int(compact_rows) < num_actual
+    )
+    if use_compact:
+        max_rows = int(compact_rows)
+        if max_rows == 0:
+            return
+        token_indices = torch.empty(
+            (max_rows,),
+            device=positions.device,
+            dtype=torch.int32,
+        )
+        token_indices.fill_(-1)
+        compact_count = torch.empty((1,), device=positions.device, dtype=torch.int32)
+        compact_count.zero_()
+        _deepseek_v4_compact_hca_boundary_tokens_kernel[(num_actual,)](
+            positions[:num_actual],
+            compressor_slot_mapping[:num_actual],
+            kv_slot_mapping[:num_actual],
+            token_indices,
+            compact_count,
+            COMPRESS_RATIO=compress_ratio,
+            MAX_ROWS=max_rows,
+            num_warps=4,
+        )
+        grid = max_rows
+    else:
+        token_indices = None
+        grid = num_actual
+    _deepseek_v4_fused_sparse_compress_cache_kernel[(grid,)](
+        token_indices,
         state_cache,
         state_cache.stride(0),
         state_cache.stride(1),
@@ -458,6 +520,7 @@ def deepseek_v4_fused_sparse_compress_cache_insert(
         TOKEN_STRIDE=DEEPSEEK_V4_SWA_TOKEN_STRIDE,
         SCALE_DIM=DEEPSEEK_V4_SWA_SCALE_DIM,
         KV_BLOCK_STRIDE=kv_cache_2d.stride(0),
+        USE_COMPACT=use_compact,
         num_warps=4,
     )
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/deepseek_v4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/deepseek_v4.py
@@ -43,6 +43,7 @@ __all__ = [
     "deepseek_v4_combine_dense_swa_indices",
     "deepseek_v4_combine_topk_swa_indices",
     "deepseek_v4_compressed_slot_mapping",
+    "deepseek_v4_paged_compressed_slot_mapping",
     "deepseek_v4_compute_global_topk_indices_and_lens",
     "deepseek_v4_decode_swa_indices_and_lens",
     "deepseek_v4_dequantize_and_gather_k_cache",
@@ -1683,6 +1684,96 @@ def deepseek_v4_compressed_slot_mapping(
         compress_ratio=compress_ratio,
         pad_id=-1,
         candidate_block=1024,
+    )
+    return slot_mapping
+
+
+@triton.jit(do_not_specialize=["num_tokens"])
+def _deepseek_v4_paged_compressed_slot_mapping_kernel(
+    slot_mapping_ptr,
+    positions_ptr,
+    req_indices_ptr,
+    block_table_ptr,
+    block_table_base_offsets_ptr,
+    block_table_stride,
+    block_table_rows: tl.constexpr,
+    block_table_cols: tl.constexpr,
+    num_tokens,
+    block_size: tl.constexpr,
+    compress_ratio: tl.constexpr,
+    pad_id: tl.constexpr,
+    has_base_offsets: tl.constexpr,
+    candidate_block: tl.constexpr,
+):
+    block_id = tl.program_id(0)
+    offsets = block_id * candidate_block + tl.arange(0, candidate_block)
+    mask = offsets < num_tokens
+
+    req_idx = tl.load(req_indices_ptr + offsets, mask=mask, other=-1).to(tl.int64)
+    positions = tl.load(positions_ptr + offsets, mask=mask, other=-1).to(tl.int64)
+    valid_req = (req_idx >= 0) & (req_idx < block_table_rows)
+    valid_boundary = ((positions + 1) % compress_ratio) == 0
+
+    compressed_pos = positions // compress_ratio
+    page_indices = compressed_pos // block_size
+    if has_base_offsets:
+        safe_req_for_base = tl.maximum(tl.minimum(req_idx, block_table_rows - 1), 0)
+        base_offsets = tl.load(
+            block_table_base_offsets_ptr + safe_req_for_base,
+            mask=mask & valid_req,
+            other=0,
+        ).to(tl.int64)
+        page_indices = page_indices - base_offsets
+
+    valid_page = (page_indices >= 0) & (page_indices < block_table_cols)
+    safe_req = tl.maximum(tl.minimum(req_idx, block_table_rows - 1), 0)
+    safe_page = tl.maximum(tl.minimum(page_indices, block_table_cols - 1), 0)
+    valid = mask & valid_req & valid_page & valid_boundary
+    page_ids = tl.load(
+        block_table_ptr + safe_req * block_table_stride + safe_page,
+        mask=valid,
+        other=-1,
+    ).to(tl.int64)
+    valid = valid & (page_ids >= 0)
+    slots = page_ids * block_size + (compressed_pos % block_size)
+    values = tl.where(valid, slots, pad_id)
+    tl.store(slot_mapping_ptr + offsets, values, mask=mask)
+
+
+def deepseek_v4_paged_compressed_slot_mapping(
+    *,
+    positions: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    compress_ratio: int,
+    base_offsets: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Build compressed KV slot mapping for paged DeepSeek V4 cache groups."""
+
+    num_tokens = positions.numel()
+    if out is None:
+        out = torch.empty(num_tokens, dtype=torch.int64, device=positions.device)
+    slot_mapping = out[:num_tokens]
+    if num_tokens == 0:
+        return slot_mapping
+
+    _deepseek_v4_paged_compressed_slot_mapping_kernel[(triton.cdiv(num_tokens, 256),)](
+        slot_mapping,
+        positions,
+        token_to_req_indices[:num_tokens],
+        block_table,
+        base_offsets,
+        block_table.stride(0),
+        block_table.shape[0],
+        block_table.shape[1],
+        num_tokens,
+        block_size=block_size,
+        compress_ratio=compress_ratio,
+        pad_id=-1,
+        has_base_offsets=base_offsets is not None,
+        candidate_block=256,
     )
     return slot_mapping
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/deepseek_v4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/deepseek_v4.py
@@ -51,6 +51,7 @@ __all__ = [
     "deepseek_v4_fused_indexer_q_rope_hadamard_mxfp4",
     "deepseek_v4_fused_sparse_compress_cache_insert",
     "deepseek_v4_gather_indexer_mxfp4_cache",
+    "deepseek_v4_hca_tiled_compress_cache_insert",
     "deepseek_v4_indexer_decode_metadata_compute",
     "deepseek_v4_save_compressor_state",
     "write_deepseek_v4_indexer_mxfp4_cache_cuda",
@@ -426,6 +427,410 @@ def _deepseek_v4_compact_hca_boundary_tokens_kernel(
         row = tl.atomic_add(count_ptr, 1, sem="relaxed")
         if row < MAX_ROWS:
             tl.store(token_indices_ptr + row, token_idx)
+
+
+@triton.jit
+def _deepseek_v4_compact_hca_boundary_slots_kernel(
+    positions_ptr,
+    token_to_req_indices_ptr,
+    state_slot_mapping_ptr,
+    kv_slot_mapping_ptr,
+    kv_block_table_ptr,
+    kv_block_table_base_offsets_ptr,
+    token_indices_ptr,
+    compact_kv_slots_ptr,
+    count_ptr,
+    kv_block_table_stride,
+    kv_block_table_rows: tl.constexpr,
+    kv_block_table_cols: tl.constexpr,
+    kv_cache_block_size,
+    COMPRESS_RATIO: tl.constexpr,
+    MAX_ROWS: tl.constexpr,
+    USE_KV_SLOT_MAPPING: tl.constexpr,
+    HAS_KV_BASE_OFFSETS: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    position = tl.load(positions_ptr + token_idx)
+    state_slot = tl.load(state_slot_mapping_ptr + token_idx)
+    boundary = ((position + 1) % COMPRESS_RATIO) == 0
+    keep = (state_slot >= 0) & boundary
+
+    if USE_KV_SLOT_MAPPING:
+        kv_slot = tl.load(kv_slot_mapping_ptr + token_idx)
+        keep = keep & (kv_slot >= 0)
+    else:
+        req_idx = tl.load(token_to_req_indices_ptr + token_idx).to(tl.int64)
+        valid_req = (req_idx >= 0) & (req_idx < kv_block_table_rows)
+        compressed_pos = position // COMPRESS_RATIO
+        page_index = compressed_pos // kv_cache_block_size
+        if HAS_KV_BASE_OFFSETS:
+            safe_req_for_base = tl.maximum(
+                tl.minimum(req_idx, kv_block_table_rows - 1), 0
+            )
+            base_offset = tl.load(
+                kv_block_table_base_offsets_ptr + safe_req_for_base,
+                mask=valid_req,
+                other=0,
+            ).to(tl.int64)
+            page_index = page_index - base_offset
+        valid_page = (page_index >= 0) & (page_index < kv_block_table_cols)
+        safe_req = tl.maximum(tl.minimum(req_idx, kv_block_table_rows - 1), 0)
+        safe_page = tl.maximum(tl.minimum(page_index, kv_block_table_cols - 1), 0)
+        page_id = tl.load(
+            kv_block_table_ptr + safe_req * kv_block_table_stride + safe_page,
+            mask=valid_req & valid_page,
+            other=-1,
+        ).to(tl.int64)
+        keep = keep & valid_req & valid_page & (page_id >= 0)
+        kv_slot = page_id * kv_cache_block_size + (compressed_pos % kv_cache_block_size)
+
+    if keep:
+        row = tl.atomic_add(count_ptr, 1, sem="relaxed")
+        if row < MAX_ROWS:
+            tl.store(token_indices_ptr + row, token_idx)
+            tl.store(compact_kv_slots_ptr + row, kv_slot)
+
+
+@triton.jit
+def _deepseek_v4_hca_tiled_compress_stage1_kernel(
+    token_indices_ptr,
+    state_cache_ptr,
+    state_cache_stride0,
+    state_cache_stride1,
+    token_to_req_indices_ptr,
+    positions_ptr,
+    slot_mapping_ptr,
+    block_table_ptr,
+    block_table_base_offsets_ptr,
+    block_table_stride,
+    block_table_width: tl.constexpr,
+    state_block_size,
+    tmp_ptr,
+    partial_sumsq_ptr,
+    HEAD_SIZE: tl.constexpr,
+    STATE_WIDTH: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    BLOCK_DIM: tl.constexpr,
+    N_DIM_BLOCKS: tl.constexpr,
+    USE_COMPACT: tl.constexpr,
+    HAS_BASE_OFFSETS: tl.constexpr,
+):
+    row_idx = tl.program_id(0)
+    dim_block = tl.program_id(1)
+    if USE_COMPACT:
+        token_idx = tl.load(token_indices_ptr + row_idx)
+        if token_idx < 0:
+            return
+    else:
+        token_idx = row_idx
+
+    state_slot = tl.load(slot_mapping_ptr + token_idx)
+    if state_slot < 0:
+        return
+
+    position = tl.load(positions_ptr + token_idx)
+    if (position + 1) % COMPRESS_RATIO != 0:
+        return
+
+    req_idx = tl.load(token_to_req_indices_ptr + token_idx)
+    if HAS_BASE_OFFSETS:
+        base_logical_page = tl.load(block_table_base_offsets_ptr + req_idx)
+    else:
+        base_logical_page = tl.full((), 0, tl.int32)
+
+    tokens = tl.arange(0, COMPRESS_RATIO)
+    pos = position - COMPRESS_RATIO + 1 + tokens
+    valid_pos = pos >= 0
+    table_idx = pos // state_block_size - base_logical_page
+    valid_pos = valid_pos & (table_idx >= 0) & (table_idx < block_table_width)
+    block_numbers = tl.load(
+        block_table_ptr + req_idx * block_table_stride + table_idx,
+        mask=valid_pos,
+        other=-1,
+    ).to(tl.int64)
+    pos_in_block = pos % state_block_size
+
+    dim_offsets = dim_block * BLOCK_DIM + tl.arange(0, BLOCK_DIM)
+    dim_mask = dim_offsets < HEAD_SIZE
+    row_base = (
+        state_cache_ptr
+        + block_numbers[:, None] * state_cache_stride0
+        + pos_in_block[:, None] * state_cache_stride1
+    )
+    combined_mask = (
+        valid_pos[:, None] & (block_numbers[:, None] >= 0) & dim_mask[None, :]
+    )
+    score = tl.load(
+        row_base + STATE_WIDTH + dim_offsets[None, :],
+        mask=combined_mask,
+        other=float("-inf"),
+    )
+    score = tl.softmax(score, dim=0)
+    kv = tl.load(
+        row_base + dim_offsets[None, :],
+        mask=combined_mask,
+        other=0.0,
+    )
+    compressed = tl.sum(kv * score, axis=0)
+    tl.store(
+        tmp_ptr + row_idx * HEAD_SIZE + dim_offsets,
+        compressed,
+        mask=dim_mask,
+    )
+    partial = tl.sum(compressed * compressed, axis=0)
+    tl.store(partial_sumsq_ptr + row_idx * N_DIM_BLOCKS + dim_block, partial)
+
+
+@triton.jit
+def _deepseek_v4_hca_tiled_compress_stage2_kernel(
+    token_indices_ptr,
+    compact_kv_slots_ptr,
+    token_to_req_indices_ptr,
+    positions_ptr,
+    slot_mapping_ptr,
+    kv_slot_mapping_ptr,
+    tmp_ptr,
+    partial_sumsq_ptr,
+    rms_norm_weight_ptr,
+    rms_norm_eps,
+    cos_sin_cache_ptr,
+    cos_sin_stride,
+    k_cache_ptr,
+    kv_cache_block_size,
+    HEAD_SIZE: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    ROPE_HEAD_DIM: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    QUANT_BLOCK: tl.constexpr,
+    BLOCK_DIM: tl.constexpr,
+    N_DIM_BLOCKS: tl.constexpr,
+    TOKEN_STRIDE: tl.constexpr,
+    SCALE_DIM: tl.constexpr,
+    KV_BLOCK_STRIDE: tl.constexpr,
+    USE_COMPACT: tl.constexpr,
+):
+    row_idx = tl.program_id(0)
+    dim_block = tl.program_id(1)
+    if USE_COMPACT:
+        token_idx = tl.load(token_indices_ptr + row_idx)
+        kv_slot = tl.load(compact_kv_slots_ptr + row_idx)
+        if (token_idx < 0) | (kv_slot < 0):
+            return
+    else:
+        token_idx = row_idx
+        kv_slot = tl.load(kv_slot_mapping_ptr + token_idx)
+        if kv_slot < 0:
+            return
+
+    state_slot = tl.load(slot_mapping_ptr + token_idx)
+    if state_slot < 0:
+        return
+
+    position = tl.load(positions_ptr + token_idx)
+    if (position + 1) % COMPRESS_RATIO != 0:
+        return
+
+    sum_offsets = tl.arange(0, N_DIM_BLOCKS)
+    sumsq = tl.load(partial_sumsq_ptr + row_idx * N_DIM_BLOCKS + sum_offsets)
+    inv_rms = tl.rsqrt(tl.sum(sumsq, axis=0) / HEAD_SIZE + rms_norm_eps)
+
+    dim_offsets = dim_block * BLOCK_DIM + tl.arange(0, BLOCK_DIM)
+    dim_mask = dim_offsets < HEAD_SIZE
+    compressed = tl.load(
+        tmp_ptr + row_idx * HEAD_SIZE + dim_offsets,
+        mask=dim_mask,
+        other=0.0,
+    )
+    rms_w = tl.load(rms_norm_weight_ptr + dim_offsets, mask=dim_mask, other=0.0)
+    normed = compressed * inv_rms * rms_w
+
+    kv_block = kv_slot // kv_cache_block_size
+    kv_pos = kv_slot % kv_cache_block_size
+    cache_block_ptr = k_cache_ptr + kv_block.to(tl.int64) * KV_BLOCK_STRIDE
+    fp8_ptr = cache_block_ptr + kv_pos * TOKEN_STRIDE
+    scale_ptr = (
+        cache_block_ptr + kv_cache_block_size * TOKEN_STRIDE + kv_pos * SCALE_DIM
+    )
+
+    NOPE_HEAD_DIM: tl.constexpr = HEAD_SIZE - ROPE_HEAD_DIM
+    N_NOPE_BLOCKS: tl.constexpr = NOPE_HEAD_DIM // QUANT_BLOCK
+    INV_FP8_MAX: tl.constexpr = 1.0 / FP8_MAX
+
+    if dim_block < N_NOPE_BLOCKS:
+        quant_input = normed.to(tl.bfloat16).to(tl.float32)
+        block_absmax = tl.max(tl.abs(quant_input), axis=0)
+        block_absmax = tl.maximum(block_absmax, 1.0e-4)
+        exponent = tl.ceil(tl.log2(block_absmax * INV_FP8_MAX))
+        inv_scale = tl.exp2(-exponent)
+        x_scaled = quant_input * inv_scale
+        x_fp8 = tl.clamp(x_scaled, -FP8_MAX, FP8_MAX).to(tl.float8e4nv)
+        x_uint8 = x_fp8.to(tl.uint8, bitcast=True)
+        tl.store(fp8_ptr + dim_offsets, x_uint8, mask=dim_offsets < NOPE_HEAD_DIM)
+        encoded = tl.maximum(tl.minimum(exponent + 127.0, 255.0), 0.0)
+        tl.store(scale_ptr + dim_block, encoded.to(tl.uint8))
+    else:
+        tl.store(scale_ptr + N_NOPE_BLOCKS, tl.zeros((), dtype=tl.uint8))
+        NUM_PAIRS: tl.constexpr = BLOCK_DIM // 2
+        HALF_ROPE: tl.constexpr = ROPE_HEAD_DIM // 2
+        pair_2d = tl.reshape(normed, (NUM_PAIRS, 2))
+        even, odd = tl.split(pair_2d)
+        pair_idx = tl.arange(0, NUM_PAIRS)
+        compressed_pos = (position // COMPRESS_RATIO) * COMPRESS_RATIO
+        cs_base = cos_sin_cache_ptr + compressed_pos * cos_sin_stride
+        rope_mask = pair_idx < HALF_ROPE
+        cos_v = tl.load(cs_base + pair_idx, mask=rope_mask, other=1.0)
+        sin_v = tl.load(cs_base + HALF_ROPE + pair_idx, mask=rope_mask, other=0.0)
+        new_even = even * cos_v - odd * sin_v
+        new_odd = odd * cos_v + even * sin_v
+        rotated = tl.interleave(new_even, new_odd)
+        rope_ptr = (fp8_ptr + NOPE_HEAD_DIM).to(tl.pointer_type(tl.bfloat16))
+        rope_offsets = dim_offsets - NOPE_HEAD_DIM
+        tl.store(
+            rope_ptr + rope_offsets,
+            rotated.to(tl.bfloat16),
+            mask=(dim_offsets >= NOPE_HEAD_DIM) & dim_mask,
+        )
+
+
+def deepseek_v4_hca_tiled_compress_cache_insert(
+    *,
+    state_cache: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    positions: torch.Tensor,
+    compressor_slot_mapping: torch.Tensor,
+    state_block_table: torch.Tensor,
+    compressor_block_size: int,
+    rms_norm_weight: torch.Tensor,
+    rms_norm_eps: float,
+    cos_sin_cache: torch.Tensor,
+    kv_cache_2d: torch.Tensor,
+    kv_slot_mapping: torch.Tensor | None,
+    kv_cache_block_size: int,
+    block_table_base_offsets: torch.Tensor | None = None,
+    kv_block_table: torch.Tensor | None = None,
+    kv_block_table_base_offsets: torch.Tensor | None = None,
+    compact_rows: int | None = None,
+) -> None:
+    num_actual = min(compressor_slot_mapping.numel(), positions.numel())
+    if kv_slot_mapping is not None:
+        num_actual = min(num_actual, kv_slot_mapping.numel())
+    if num_actual == 0:
+        return
+    use_compact = (
+        compact_rows is not None
+        and int(compact_rows) >= 0
+        and int(compact_rows) < num_actual
+    )
+    if use_compact:
+        rows = int(compact_rows)
+        if rows == 0:
+            return
+        token_indices = torch.empty((rows,), device=positions.device, dtype=torch.int32)
+        token_indices.fill_(-1)
+        compact_kv_slots = torch.empty(
+            (rows,), device=positions.device, dtype=torch.int64
+        )
+        compact_kv_slots.fill_(-1)
+        compact_count = torch.empty((1,), device=positions.device, dtype=torch.int32)
+        compact_count.zero_()
+        use_kv_slot_mapping = kv_slot_mapping is not None
+        if not use_kv_slot_mapping and kv_block_table is None:
+            raise ValueError(
+                "HCA compact insert requires kv_slot_mapping or kv_block_table"
+            )
+        kv_table = kv_block_table if kv_block_table is not None else state_block_table
+        _deepseek_v4_compact_hca_boundary_slots_kernel[(num_actual,)](
+            positions[:num_actual],
+            token_to_req_indices[:num_actual],
+            compressor_slot_mapping[:num_actual],
+            kv_slot_mapping[:num_actual] if kv_slot_mapping is not None else None,
+            kv_table,
+            (
+                kv_block_table_base_offsets.to(torch.int32)
+                if kv_block_table_base_offsets is not None
+                else None
+            ),
+            token_indices,
+            compact_kv_slots,
+            compact_count,
+            kv_table.stride(0),
+            kv_table.shape[0],
+            kv_table.shape[-1],
+            kv_cache_block_size,
+            COMPRESS_RATIO=128,
+            MAX_ROWS=rows,
+            USE_KV_SLOT_MAPPING=use_kv_slot_mapping,
+            HAS_KV_BASE_OFFSETS=kv_block_table_base_offsets is not None,
+            num_warps=4,
+        )
+    else:
+        rows = num_actual
+        token_indices = None
+        compact_kv_slots = None
+        if kv_slot_mapping is None:
+            raise ValueError("HCA dense insert requires kv_slot_mapping")
+
+    tmp = torch.empty(
+        (rows, DEEPSEEK_V4_HEAD_DIM), device=positions.device, dtype=torch.float32
+    )
+    partial_sumsq = torch.empty((rows, 8), device=positions.device, dtype=torch.float32)
+    use_compact_const = token_indices is not None
+    _deepseek_v4_hca_tiled_compress_stage1_kernel[(rows, 8)](
+        token_indices,
+        state_cache,
+        state_cache.stride(0),
+        state_cache.stride(1),
+        token_to_req_indices[:num_actual],
+        positions[:num_actual],
+        compressor_slot_mapping[:num_actual],
+        state_block_table,
+        (
+            block_table_base_offsets.to(torch.int32)
+            if block_table_base_offsets is not None
+            else None
+        ),
+        state_block_table.stride(0),
+        state_block_table.shape[-1],
+        compressor_block_size,
+        tmp,
+        partial_sumsq,
+        HEAD_SIZE=DEEPSEEK_V4_HEAD_DIM,
+        STATE_WIDTH=state_cache.shape[-1] // 2,
+        COMPRESS_RATIO=128,
+        BLOCK_DIM=64,
+        N_DIM_BLOCKS=8,
+        USE_COMPACT=use_compact_const,
+        HAS_BASE_OFFSETS=block_table_base_offsets is not None,
+        num_warps=4,
+    )
+    _deepseek_v4_hca_tiled_compress_stage2_kernel[(rows, 8)](
+        token_indices,
+        compact_kv_slots,
+        token_to_req_indices[:num_actual],
+        positions[:num_actual],
+        compressor_slot_mapping[:num_actual],
+        kv_slot_mapping[:num_actual] if kv_slot_mapping is not None else None,
+        tmp,
+        partial_sumsq,
+        rms_norm_weight,
+        rms_norm_eps,
+        cos_sin_cache,
+        cos_sin_cache.stride(0),
+        kv_cache_2d,
+        kv_cache_block_size,
+        HEAD_SIZE=DEEPSEEK_V4_HEAD_DIM,
+        COMPRESS_RATIO=128,
+        ROPE_HEAD_DIM=DEEPSEEK_V4_ROPE_DIM,
+        FP8_MAX=DEEPSEEK_V4_FP8_MAX,
+        QUANT_BLOCK=DEEPSEEK_V4_FP8_QUANT_BLOCK,
+        BLOCK_DIM=64,
+        N_DIM_BLOCKS=8,
+        TOKEN_STRIDE=DEEPSEEK_V4_SWA_TOKEN_STRIDE,
+        SCALE_DIM=DEEPSEEK_V4_SWA_SCALE_DIM,
+        KV_BLOCK_STRIDE=kv_cache_2d.stride(0),
+        USE_COMPACT=use_compact_const,
+        num_warps=4,
+    )
 
 
 def deepseek_v4_fused_sparse_compress_cache_insert(

--- a/tokenspeed-scheduler/CMakeLists.txt
+++ b/tokenspeed-scheduler/CMakeLists.txt
@@ -116,6 +116,7 @@ if(TOKENSPEED_SCHEDULER_BUILD_TESTS)
         tests/cpp/test_paged_cache_attach_loop.cpp
         tests/cpp/test_paged_cache_eviction.cpp
         tests/cpp/test_paged_cache_family_split.cpp
+        tests/cpp/test_paged_cache_l2_offload.cpp
         tests/cpp/test_paged_cache_prefix_hit_commit.cpp
         tests/cpp/test_paged_cache_replay.cpp
         tests/cpp/test_retract_abort_pages.cpp

--- a/tokenspeed-scheduler/bindings/python_module.cpp
+++ b/tokenspeed-scheduler/bindings/python_module.cpp
@@ -230,6 +230,7 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
             "num_host_pages", [](const tokenspeed::SchedulerConfig& c) { return c.host_allocator.total_pages; },
             [](tokenspeed::SchedulerConfig& c, std::int32_t v) { c.host_allocator.total_pages = v; })
         .def_rw("paged_cache_groups", &tokenspeed::SchedulerConfig::paged_cache_groups)
+        .def_rw("paged_cache_host_group_pages", &tokenspeed::SchedulerConfig::paged_cache_host_group_pages)
         .def_rw("prefix_cache_adjunct", &tokenspeed::SchedulerConfig::prefix_cache_adjunct)
         .def_rw("disable_l2_cache", &tokenspeed::SchedulerConfig::disable_l2_cache)
         .def_rw("enable_l3_storage", &tokenspeed::SchedulerConfig::enable_l3_storage)
@@ -353,6 +354,11 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .value("KV", tokenspeed::CacheKind::kKV)
         .value("MAMBA", tokenspeed::CacheKind::kMamba);
 
+    nb::class_<tokenspeed::PagedCacheTransferPair>(cache, "PagedCacheTransferPair")
+        .def_ro("group_id", &tokenspeed::PagedCacheTransferPair::group_id)
+        .def_ro("src_pages", &tokenspeed::PagedCacheTransferPair::src_pages)
+        .def_ro("dst_pages", &tokenspeed::PagedCacheTransferPair::dst_pages);
+
     auto prefetch_op = nb::class_<tokenspeed::PrefetchOperation>(cache, "PrefetchOp");
     BindCacheCommonFields<tokenspeed::PrefetchOperation>(prefetch_op);
     prefetch_op.def(nb::init<>())
@@ -368,7 +374,8 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .def_ro("src_pages", &tokenspeed::FlatLoadBackOperation::src_pages)
         .def_ro("dst_pages", &tokenspeed::FlatLoadBackOperation::dst_pages)
         .def_ro("src_pages_by_kind", &tokenspeed::FlatLoadBackOperation::src_pages_by_kind)
-        .def_ro("dst_pages_by_kind", &tokenspeed::FlatLoadBackOperation::dst_pages_by_kind);
+        .def_ro("dst_pages_by_kind", &tokenspeed::FlatLoadBackOperation::dst_pages_by_kind)
+        .def_ro("paged_cache_transfers", &tokenspeed::FlatLoadBackOperation::paged_cache_transfers);
 
     nb::class_<tokenspeed::FlatWriteBackOperation>(cache, "WriteBackOp")
         .def_ro("op_ids", &tokenspeed::FlatWriteBackOperation::op_ids)
@@ -376,6 +383,7 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .def_ro("dst_pages", &tokenspeed::FlatWriteBackOperation::dst_pages)
         .def_ro("src_pages_by_kind", &tokenspeed::FlatWriteBackOperation::src_pages_by_kind)
         .def_ro("dst_pages_by_kind", &tokenspeed::FlatWriteBackOperation::dst_pages_by_kind)
+        .def_ro("paged_cache_transfers", &tokenspeed::FlatWriteBackOperation::paged_cache_transfers)
         .def_ro("is_retract", &tokenspeed::FlatWriteBackOperation::is_retract);
 
     auto collect_forward = [](const tokenspeed::ExecutionPlan& plan) -> nb::list {
@@ -434,6 +442,12 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .def("paged_cache_group_available_pages", &tokenspeed::Scheduler::PagedCacheGroupAvailablePages,
              nb::arg("group_id"))
         .def("paged_cache_group_failed_alloc_count", &tokenspeed::Scheduler::PagedCacheGroupFailedAllocCount,
+             nb::arg("group_id"))
+        .def("paged_cache_host_group_total_pages", &tokenspeed::Scheduler::PagedCacheHostGroupTotalPages,
+             nb::arg("group_id"))
+        .def("paged_cache_host_group_available_pages", &tokenspeed::Scheduler::PagedCacheHostGroupAvailablePages,
+             nb::arg("group_id"))
+        .def("paged_cache_host_group_failed_alloc_count", &tokenspeed::Scheduler::PagedCacheHostGroupFailedAllocCount,
              nb::arg("group_id"))
         .def("get_request_paged_cache_page_ids", &tokenspeed::Scheduler::GetRequestPagedCachePageIds,
              nb::arg("request_id"), nb::arg("group_id"))

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
@@ -76,12 +76,35 @@ std::vector<tokenspeed::TreeNode*> MambaNodesForTransferPairs(const std::vector<
     return nodes;
 }
 
+std::vector<tokenspeed::TreeNode*> PagedCacheSnapshotNodesForWriteBack(tokenspeed::TreeNode* last_node) {
+    std::vector<tokenspeed::TreeNode*> nodes;
+    for (tokenspeed::TreeNode* node : tokenspeed::LeafToRoot(last_node)) {
+        if (node == nullptr) continue;
+        if (node->HasPagedCacheSnapshot() && !node->HasPagedCacheHostSnapshot() &&
+            !node->HasPagedCachePendingHostSnapshot()) {
+            nodes.push_back(node);
+        }
+    }
+    return nodes;
+}
+
 void DemoteWrittenBackDevice(tokenspeed::KVPrefixCache* kv_prefix_cache,
                              tokenspeed::HybridPrefixCache* hybrid_prefix_cache, tokenspeed::TreeNode* device_node) {
     if (kv_prefix_cache == nullptr || device_node == nullptr) return;
     kv_prefix_cache->ReleaseDeviceResourcesPresentOnHost(device_node, [hybrid_prefix_cache](tokenspeed::TreeNode* n) {
         if (hybrid_prefix_cache != nullptr) {
             hybrid_prefix_cache->OnKVDeviceDemote(n);
+        }
+    });
+}
+
+void ReleaseFailedHostWriteBack(tokenspeed::KVPrefixCache* kv_prefix_cache,
+                                tokenspeed::HybridPrefixCache* hybrid_prefix_cache,
+                                const std::vector<tokenspeed::TreeNode*>& host_writeback_nodes) {
+    if (kv_prefix_cache == nullptr || host_writeback_nodes.empty()) return;
+    kv_prefix_cache->ReleaseHostResources(host_writeback_nodes, [hybrid_prefix_cache](tokenspeed::TreeNode* n) {
+        if (hybrid_prefix_cache != nullptr) {
+            hybrid_prefix_cache->OnKVHostEvict(n);
         }
     });
 }
@@ -175,10 +198,13 @@ std::variant<PrefillDone, Prefilling> SchedulePrefillFirstChunkEvent::operator()
 
     TokenContainer* token_container = state.GetTokenContainer();
 
-    std::int32_t max_matched_pages =
-        disable_l2_cache_ ? match_result_.device.DepthInPage()
-                          : std::max(match_result_.device.DepthInPage(), match_result_.host.DepthInPage());
-    std::int32_t window_begin = max_matched_pages * state.GetPageSize();
+    std::int32_t window_begin = matched_prefix_len_tokens_;
+    if (window_begin < 0) {
+        const std::int32_t max_matched_pages =
+            disable_l2_cache_ ? match_result_.device.DepthInPage()
+                              : std::max(match_result_.device.DepthInPage(), match_result_.host.DepthInPage());
+        window_begin = max_matched_pages * state.GetPageSize();
+    }
     TokenContainer::Window window{.begin = window_begin, .size = tokens_this_round_};
 
     bool is_last_chunk = (window.begin + window.size) == token_container->PrefillSize();
@@ -398,14 +424,24 @@ std::variant<Draining, Finished> FinishEvent::apply(ForwardStateT&& state) {
 
         auto pages_to_transfer = BuildWriteBackPairs(write_diff);
         std::vector<TreeNode*> mamba_writeback_nodes;
+        std::vector<PagedCacheTransferPair> paged_cache_writeback_transfers;
+        std::vector<TreeNode*> paged_cache_writeback_nodes;
         if (hybrid_prefix_cache_ != nullptr) {
             auto mamba_pairs = hybrid_prefix_cache_->PrepareMambaHostWriteBack(write_diff);
             mamba_writeback_nodes = MambaNodesForTransferPairs(write_diff, mamba_pairs);
             pages_to_transfer.insert(pages_to_transfer.end(), std::make_move_iterator(mamba_pairs.begin()),
                                      std::make_move_iterator(mamba_pairs.end()));
+            paged_cache_writeback_nodes = PagedCacheSnapshotNodesForWriteBack(match.device.last_node);
+            paged_cache_writeback_transfers =
+                hybrid_prefix_cache_->PreparePagedCacheHostWriteBack(paged_cache_writeback_nodes);
         }
-        return Draining{std::move(pages_to_transfer), std::move(device_node_ref), std::move(host_node_ref),
-                        std::move(mamba_writeback_nodes)};
+        return Draining{std::move(pages_to_transfer),
+                        std::move(device_node_ref),
+                        std::move(host_node_ref),
+                        std::move(write_diff),
+                        std::move(mamba_writeback_nodes),
+                        std::move(paged_cache_writeback_transfers),
+                        std::move(paged_cache_writeback_nodes)};
     }
     return Finished{};
 }
@@ -433,8 +469,11 @@ WritingBack FinishEvent::operator()(Retracting&& state) {
 WritingBack CommitDrainingEvent::operator()(Draining&& state) {
     auto device_node_ref = std::move(state).TakeDeviceNodeRef();
     auto host_node_ref = std::move(state).TakeHostNodeRef();
+    auto host_writeback_nodes = std::move(state).TakeHostWriteBackNodes();
     auto mamba_writeback_nodes = std::move(state).TakeMambaWriteBackNodes();
-    return WritingBack{std::move(device_node_ref), std::move(host_node_ref), std::move(mamba_writeback_nodes)};
+    auto paged_cache_writeback_nodes = std::move(state).TakePagedCacheWriteBackNodes();
+    return WritingBack{std::move(device_node_ref), std::move(host_node_ref), std::move(host_writeback_nodes),
+                       std::move(mamba_writeback_nodes), std::move(paged_cache_writeback_nodes)};
 }
 
 // WritingBack → Finished
@@ -443,11 +482,18 @@ WritingBack CommitDrainingEvent::operator()(Draining&& state) {
 Finished WriteBackDoneEvent::operator()(WritingBack&& state) {
     TreeNode* device_node = state.DeviceNode();
     if (hybrid_prefix_cache_ != nullptr) {
-        hybrid_prefix_cache_->OnMambaHostWriteBackDone(state.MambaWriteBackNodes());
+        hybrid_prefix_cache_->OnMambaHostWriteBackDone(state.MambaWriteBackNodes(), success_);
+        hybrid_prefix_cache_->OnPagedCacheHostWriteBackDone(state.PagedCacheWriteBackNodes(), success_);
+    }
+    if (!success_) {
+        state.DropHostNodeRef();
+        ReleaseFailedHostWriteBack(kv_prefix_cache_, hybrid_prefix_cache_, state.HostWriteBackNodes());
     }
     state.DropDeviceNodeRef();
-    DemoteWrittenBackDevice(kv_prefix_cache_, hybrid_prefix_cache_, device_node);
-    if (hybrid_prefix_cache_ != nullptr) {
+    if (success_) {
+        DemoteWrittenBackDevice(kv_prefix_cache_, hybrid_prefix_cache_, device_node);
+    }
+    if (success_ && hybrid_prefix_cache_ != nullptr) {
         hybrid_prefix_cache_->DemoteIdleMambaDeviceCopiesPresentOnHost();
     }
     return Finished{};
@@ -458,11 +504,18 @@ Retracted WriteBackDoneEvent::operator()(Retracting&& state) {
     std::int32_t page_size = state.GetPageSize();
     TreeNode* device_node = state.DeviceNode();
     if (hybrid_prefix_cache_ != nullptr) {
-        hybrid_prefix_cache_->OnMambaHostWriteBackDone(state.MambaWriteBackNodes());
+        hybrid_prefix_cache_->OnMambaHostWriteBackDone(state.MambaWriteBackNodes(), success_);
+        hybrid_prefix_cache_->OnPagedCacheHostWriteBackDone(state.PagedCacheWriteBackNodes(), success_);
+    }
+    if (!success_) {
+        state.DropHostNodeRef();
+        ReleaseFailedHostWriteBack(kv_prefix_cache_, hybrid_prefix_cache_, state.HostWriteBackNodes());
     }
     state.DropDeviceNodeRef();
-    DemoteWrittenBackDevice(kv_prefix_cache_, hybrid_prefix_cache_, device_node);
-    if (hybrid_prefix_cache_ != nullptr) {
+    if (success_) {
+        DemoteWrittenBackDevice(kv_prefix_cache_, hybrid_prefix_cache_, device_node);
+    }
+    if (success_ && hybrid_prefix_cache_ != nullptr) {
         hybrid_prefix_cache_->DemoteIdleMambaDeviceCopiesPresentOnHost();
     }
     auto host_ref = std::move(static_cast<WritingBack&&>(state)).TakeHostNodeRef();
@@ -518,7 +571,10 @@ Retracting ScheduleRetractEvent::applyRetract(ForwardStateT&& state) {
     std::unique_ptr<DeviceNodeRef> device_node_ref = nullptr;
     std::unique_ptr<HostNodeRef> host_node_ref = nullptr;
     std::vector<Retracting::PagePair> pages_to_transfer;
+    std::vector<TreeNode*> host_writeback_nodes;
     std::vector<TreeNode*> mamba_writeback_nodes;
+    std::vector<PagedCacheTransferPair> paged_cache_writeback_transfers;
+    std::vector<TreeNode*> paged_cache_writeback_nodes;
 
     if (match_result_.device.DepthInPage() > match_result_.host.DepthInPage()) {
         std::vector<TreeNode*> write_diff = match_result_.NodesWithout<ResourceType::Host>();
@@ -526,12 +582,16 @@ Retracting ScheduleRetractEvent::applyRetract(ForwardStateT&& state) {
         if (!kv_prefix_cache_->AllocateResourceOfType<ResourceType::Host>(write_diff)) {
             throw std::logic_error("ScheduleRetractEvent: failed to allocate host pages for device cache writeback");
         }
+        host_writeback_nodes = write_diff;
         pages_to_transfer = BuildWriteBackPairs(write_diff);
         if (hybrid_prefix_cache_ != nullptr) {
             auto mamba_pairs = hybrid_prefix_cache_->PrepareMambaHostWriteBack(write_diff);
             mamba_writeback_nodes = MambaNodesForTransferPairs(write_diff, mamba_pairs);
             pages_to_transfer.insert(pages_to_transfer.end(), std::make_move_iterator(mamba_pairs.begin()),
                                      std::make_move_iterator(mamba_pairs.end()));
+            paged_cache_writeback_nodes = PagedCacheSnapshotNodesForWriteBack(match_result_.device.last_node);
+            paged_cache_writeback_transfers =
+                hybrid_prefix_cache_->PreparePagedCacheHostWriteBack(paged_cache_writeback_nodes);
         }
         host_node_ref = std::make_unique<HostNodeRef>(match_result_.device.last_node);
     } else {
@@ -568,7 +628,10 @@ Retracting ScheduleRetractEvent::applyRetract(ForwardStateT&& state) {
                       std::move(local_allocator),
                       std::move(pages_to_transfer),
                       std::move(mamba_writeback_nodes),
-                      std::move(local_mamba_allocator)};
+                      std::move(local_mamba_allocator),
+                      std::move(paged_cache_writeback_transfers),
+                      std::move(paged_cache_writeback_nodes),
+                      std::move(host_writeback_nodes)};
 }
 
 Retracting ScheduleRetractEvent::operator()(Decoding&& state) {

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.h
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.h
@@ -67,7 +67,9 @@ struct SchedulePrefillFirstChunkEvent : InvalidTransitionHandler<SchedulePrefill
                                    bool disable_l2_cache, std::vector<TreeNode*> loadback_diff,
                                    HybridPrefixCache* hybrid_prefix_cache = nullptr,
                                    MambaChunkAllocator* mamba_allocator = nullptr,
-                                   std::vector<TreeNode*> mamba_loadback_nodes = {})
+                                   std::vector<TreeNode*> mamba_loadback_nodes = {},
+                                   std::vector<PagedCacheTransferPair> paged_cache_loadback_transfers = {},
+                                   std::int32_t matched_prefix_len_tokens = -1)
         : tokens_this_round_(tokens_this_round),
           decode_input_tokens_(decode_input_tokens),
           device_allocator_(device_allocator),
@@ -77,6 +79,8 @@ struct SchedulePrefillFirstChunkEvent : InvalidTransitionHandler<SchedulePrefill
           disable_l2_cache_{disable_l2_cache},
           loadback_diff_(std::move(loadback_diff)),
           mamba_loadback_nodes_(std::move(mamba_loadback_nodes)),
+          paged_cache_loadback_transfers_(std::move(paged_cache_loadback_transfers)),
+          matched_prefix_len_tokens_(matched_prefix_len_tokens),
           kv_prefix_cache_(kv_prefix_cache),
           hybrid_prefix_cache_(hybrid_prefix_cache),
           mamba_allocator_(mamba_allocator) {}
@@ -88,6 +92,9 @@ struct SchedulePrefillFirstChunkEvent : InvalidTransitionHandler<SchedulePrefill
 
     const std::vector<TreeNode*>& GetLoadbackDiff() const { return loadback_diff_; }
     const std::vector<TreeNode*>& GetMambaLoadbackNodes() const { return mamba_loadback_nodes_; }
+    const std::vector<PagedCacheTransferPair>& GetPagedCacheLoadbackTransfers() const {
+        return paged_cache_loadback_transfers_;
+    }
 
 private:
     std::int32_t tokens_this_round_{};
@@ -99,6 +106,8 @@ private:
     bool disable_l2_cache_{};
     std::vector<TreeNode*> loadback_diff_;
     std::vector<TreeNode*> mamba_loadback_nodes_;
+    std::vector<PagedCacheTransferPair> paged_cache_loadback_transfers_;
+    std::int32_t matched_prefix_len_tokens_{-1};
     KVPrefixCache* kv_prefix_cache_;
     HybridPrefixCache* hybrid_prefix_cache_{};
     MambaChunkAllocator* mamba_allocator_{};
@@ -143,7 +152,8 @@ struct ScheduleDecodeFromRetractedEvent : InvalidTransitionHandler<ScheduleDecod
                                      ReqPoolAllocator* req_pool_allocator, KVPrefixCache* kv_prefix_cache,
                                      MatchResult match_result, std::vector<TreeNode*> loadback_diff,
                                      MambaChunkAllocator* mamba_allocator = nullptr,
-                                     std::vector<TreeNode*> mamba_loadback_nodes = {})
+                                     std::vector<TreeNode*> mamba_loadback_nodes = {},
+                                     std::vector<PagedCacheTransferPair> paged_cache_loadback_transfers = {})
         : decode_input_tokens_(decode_input_tokens),
           device_allocator_(device_allocator),
           req_pool_allocator_(req_pool_allocator),
@@ -151,6 +161,7 @@ struct ScheduleDecodeFromRetractedEvent : InvalidTransitionHandler<ScheduleDecod
           match_result_(std::move(match_result)),
           loadback_diff_(std::move(loadback_diff)),
           mamba_loadback_nodes_(std::move(mamba_loadback_nodes)),
+          paged_cache_loadback_transfers_(std::move(paged_cache_loadback_transfers)),
           mamba_allocator_(mamba_allocator) {}
 
     Decoding operator()(Retracted&& state);
@@ -159,6 +170,9 @@ struct ScheduleDecodeFromRetractedEvent : InvalidTransitionHandler<ScheduleDecod
 
     const std::vector<TreeNode*>& GetLoadbackDiff() const { return loadback_diff_; }
     const std::vector<TreeNode*>& GetMambaLoadbackNodes() const { return mamba_loadback_nodes_; }
+    const std::vector<PagedCacheTransferPair>& GetPagedCacheLoadbackTransfers() const {
+        return paged_cache_loadback_transfers_;
+    }
 
 private:
     std::int32_t decode_input_tokens_{};
@@ -168,6 +182,7 @@ private:
     MatchResult match_result_{};
     std::vector<TreeNode*> loadback_diff_;
     std::vector<TreeNode*> mamba_loadback_nodes_;
+    std::vector<PagedCacheTransferPair> paged_cache_loadback_transfers_;
     MambaChunkAllocator* mamba_allocator_{};
 };
 
@@ -256,8 +271,8 @@ struct CommitDrainingEvent : InvalidTransitionHandler<CommitDrainingEvent> {
 //                          device_node_ref drops (frees GPU pages), host_node_ref moves into Retracted.
 struct WriteBackDoneEvent : InvalidTransitionHandler<WriteBackDoneEvent> {
     explicit WriteBackDoneEvent(KVPrefixCache* kv_prefix_cache = nullptr,
-                                HybridPrefixCache* hybrid_prefix_cache = nullptr)
-        : kv_prefix_cache_(kv_prefix_cache), hybrid_prefix_cache_(hybrid_prefix_cache) {}
+                                HybridPrefixCache* hybrid_prefix_cache = nullptr, bool success = true)
+        : kv_prefix_cache_(kv_prefix_cache), hybrid_prefix_cache_(hybrid_prefix_cache), success_(success) {}
 
     using InvalidTransitionHandler<WriteBackDoneEvent>::operator();
     Finished operator()(WritingBack&& state);
@@ -266,6 +281,7 @@ struct WriteBackDoneEvent : InvalidTransitionHandler<WriteBackDoneEvent> {
 private:
     KVPrefixCache* kv_prefix_cache_{};
     HybridPrefixCache* hybrid_prefix_cache_{};
+    bool success_{true};
 };
 
 struct UpdateReserveNumTokensEvent : InvalidTransitionHandler<UpdateReserveNumTokensEvent> {

--- a/tokenspeed-scheduler/csrc/fsm/forward_states.h
+++ b/tokenspeed-scheduler/csrc/fsm/forward_states.h
@@ -287,11 +287,17 @@ struct Draining {
     // split-safe: it never needs to re-walk the radix tree.
     using PagePair = TransferPair;
     Draining(std::vector<PagePair> pages_to_transfer, std::unique_ptr<DeviceNodeRef>&& device_node_ref,
-             std::unique_ptr<HostNodeRef>&& host_node_ref, std::vector<TreeNode*> mamba_writeback_nodes = {})
+             std::unique_ptr<HostNodeRef>&& host_node_ref, std::vector<TreeNode*> host_writeback_nodes = {},
+             std::vector<TreeNode*> mamba_writeback_nodes = {},
+             std::vector<PagedCacheTransferPair> paged_cache_writeback_transfers = {},
+             std::vector<TreeNode*> paged_cache_writeback_nodes = {})
         : pages_to_transfer_(std::move(pages_to_transfer)),
           device_node_ref_(std::move(device_node_ref)),
           host_node_ref_(std::move(host_node_ref)),
-          mamba_writeback_nodes_(std::move(mamba_writeback_nodes)) {}
+          host_writeback_nodes_(std::move(host_writeback_nodes)),
+          mamba_writeback_nodes_(std::move(mamba_writeback_nodes)),
+          paged_cache_writeback_transfers_(std::move(paged_cache_writeback_transfers)),
+          paged_cache_writeback_nodes_(std::move(paged_cache_writeback_nodes)) {}
 
 public:
     // Transfer pairs that must be copied Device→Host.
@@ -299,13 +305,22 @@ public:
 
     std::unique_ptr<DeviceNodeRef> TakeDeviceNodeRef() && { return std::move(device_node_ref_); }
     std::unique_ptr<HostNodeRef> TakeHostNodeRef() && { return std::move(host_node_ref_); }
+    std::vector<TreeNode*> TakeHostWriteBackNodes() && { return std::move(host_writeback_nodes_); }
     std::vector<TreeNode*> TakeMambaWriteBackNodes() && { return std::move(mamba_writeback_nodes_); }
+    const std::vector<PagedCacheTransferPair>& GetPagedCacheWriteBackTransfers() const {
+        return paged_cache_writeback_transfers_;
+    }
+    const std::vector<TreeNode*>& PagedCacheWriteBackNodes() const { return paged_cache_writeback_nodes_; }
+    std::vector<TreeNode*> TakePagedCacheWriteBackNodes() && { return std::move(paged_cache_writeback_nodes_); }
 
 private:
     std::vector<PagePair> pages_to_transfer_;         // concrete mixed-kind pairs to copy
     std::unique_ptr<DeviceNodeRef> device_node_ref_;  // keeps matched Device node alive until WritingBack
     std::unique_ptr<HostNodeRef> host_node_ref_;      // keeps pre-allocated Host node alive until WritingBack
+    std::vector<TreeNode*> host_writeback_nodes_;     // exact KV host resources newly allocated by this op
     std::vector<TreeNode*> mamba_writeback_nodes_;    // exact Mamba nodes covered by this writeback op
+    std::vector<PagedCacheTransferPair> paged_cache_writeback_transfers_;
+    std::vector<TreeNode*> paged_cache_writeback_nodes_;
 };
 
 // WritingBack OP has been generated, executing offload.
@@ -313,23 +328,31 @@ private:
 // async Device→Host transfer is in flight.
 struct WritingBack {
     WritingBack(std::unique_ptr<DeviceNodeRef>&& device_node_ref, std::unique_ptr<HostNodeRef>&& host_node_ref,
-                std::vector<TreeNode*> mamba_writeback_nodes = {})
+                std::vector<TreeNode*> host_writeback_nodes = {}, std::vector<TreeNode*> mamba_writeback_nodes = {},
+                std::vector<TreeNode*> paged_cache_writeback_nodes = {})
         : device_node_ref_(std::move(device_node_ref)),
           host_node_ref_(std::move(host_node_ref)),
-          mamba_writeback_nodes_(std::move(mamba_writeback_nodes)) {}
+          host_writeback_nodes_(std::move(host_writeback_nodes)),
+          mamba_writeback_nodes_(std::move(mamba_writeback_nodes)),
+          paged_cache_writeback_nodes_(std::move(paged_cache_writeback_nodes)) {}
 
     WritingBack(WritingBack&&) noexcept = default;
     WritingBack& operator=(WritingBack&&) noexcept = default;
 
     std::unique_ptr<HostNodeRef> TakeHostNodeRef() && { return std::move(host_node_ref_); }
     TreeNode* DeviceNode() const { return device_node_ref_ ? device_node_ref_->Node() : nullptr; }
+    const std::vector<TreeNode*>& HostWriteBackNodes() const { return host_writeback_nodes_; }
     const std::vector<TreeNode*>& MambaWriteBackNodes() const { return mamba_writeback_nodes_; }
+    const std::vector<TreeNode*>& PagedCacheWriteBackNodes() const { return paged_cache_writeback_nodes_; }
     void DropDeviceNodeRef() { device_node_ref_.reset(); }
+    void DropHostNodeRef() { host_node_ref_.reset(); }
 
 private:
     std::unique_ptr<DeviceNodeRef> device_node_ref_;  // released after WriteBackDone
     std::unique_ptr<HostNodeRef> host_node_ref_;      // released after WriteBackDone
+    std::vector<TreeNode*> host_writeback_nodes_;     // newly attached KV host resources
     std::vector<TreeNode*> mamba_writeback_nodes_;    // pending host Mamba slots published by this op ack
+    std::vector<TreeNode*> paged_cache_writeback_nodes_;
 };
 
 // Need to hold local_kv_allocator(has tail page info), and token container for recovery
@@ -339,13 +362,18 @@ struct Retracting : public WritingBack {
     Retracting(TokenContainer* token_container, std::int32_t page_size, std::unique_ptr<HostNodeRef>&& host_node_ref,
                std::unique_ptr<DeviceNodeRef>&& device_node_ref, std::unique_ptr<LocalKVAllocator>&& local_kv_allocator,
                std::vector<PagePair> pages_to_transfer, std::vector<TreeNode*> mamba_writeback_nodes = {},
-               std::unique_ptr<LocalMambaAllocator>&& local_mamba_allocator = nullptr)
-        : WritingBack(std::move(device_node_ref), std::move(host_node_ref), std::move(mamba_writeback_nodes)),
+               std::unique_ptr<LocalMambaAllocator>&& local_mamba_allocator = nullptr,
+               std::vector<PagedCacheTransferPair> paged_cache_writeback_transfers = {},
+               std::vector<TreeNode*> paged_cache_writeback_nodes = {},
+               std::vector<TreeNode*> host_writeback_nodes = {})
+        : WritingBack(std::move(device_node_ref), std::move(host_node_ref), std::move(host_writeback_nodes),
+                      std::move(mamba_writeback_nodes), std::move(paged_cache_writeback_nodes)),
           token_container_{token_container},
           page_size_{page_size},
           local_kv_allocator_(std::move(local_kv_allocator)),
           pages_to_transfer_(std::move(pages_to_transfer)),
-          local_mamba_allocator_(std::move(local_mamba_allocator)) {}
+          local_mamba_allocator_(std::move(local_mamba_allocator)),
+          paged_cache_writeback_transfers_(std::move(paged_cache_writeback_transfers)) {}
 
     Retracting(Retracting&&) noexcept = default;
     Retracting& operator=(Retracting&&) noexcept = default;
@@ -357,6 +385,9 @@ struct Retracting : public WritingBack {
 
     // (device_page, host_page) pairs to transfer, captured at ScheduleRetractEvent time.
     const std::vector<PagePair>& GetPagesToTransfer() const { return pages_to_transfer_; }
+    const std::vector<PagedCacheTransferPair>& GetPagedCacheWriteBackTransfers() const {
+        return paged_cache_writeback_transfers_;
+    }
     void ExtendResultTokens(const std::vector<std::int32_t> result_tokens) { token_container_->Extend(result_tokens); }
 
     // Returns only the pages held by the local KV allocator (tail page after retraction insert).
@@ -370,6 +401,7 @@ private:
     std::unique_ptr<LocalKVAllocator> local_kv_allocator_{};
     std::vector<PagePair> pages_to_transfer_{};
     std::unique_ptr<LocalMambaAllocator> local_mamba_allocator_{};
+    std::vector<PagedCacheTransferPair> paged_cache_writeback_transfers_{};
 };
 
 struct Retracted {

--- a/tokenspeed-scheduler/csrc/resource/allocator/paged_cache_group.cpp
+++ b/tokenspeed-scheduler/csrc/resource/allocator/paged_cache_group.cpp
@@ -416,7 +416,9 @@ void PagedCacheGroupTable::ImportPrefixOwned(OwnedPages pages, std::int32_t base
     owned_pages_ = std::move(pages);
     base_logical_page_ = base_logical_page;
     raw_token_cursor_ = raw_tokens_covered;
-    committed_prefix_len_tokens_ = raw_tokens_covered;
+    committed_prefix_len_tokens_ = allocator_->Config().family == PagedCacheGroupFamily::History
+                                       ? base_logical_page_ * raw_per_page
+                                       : raw_tokens_covered;
     RefreshPageIdsView();
 }
 

--- a/tokenspeed-scheduler/csrc/resource/allocator/paged_cache_group.cpp
+++ b/tokenspeed-scheduler/csrc/resource/allocator/paged_cache_group.cpp
@@ -383,6 +383,43 @@ void PagedCacheGroupTable::ImportPrefixBorrowed(std::vector<std::int32_t> ids, s
     RefreshPageIdsView();
 }
 
+void PagedCacheGroupTable::ImportPrefixOwned(OwnedPages pages, std::int32_t base_logical_page,
+                                             std::int32_t raw_tokens_covered) {
+    if (allocator_ == nullptr) {
+        throw std::logic_error("PagedCacheGroupTable::ImportPrefixOwned: no allocator bound");
+    }
+    if (!(borrowed_page_ids_.empty() && owned_pages_.Empty() && raw_token_cursor_ == 0 && base_logical_page_ == 0 &&
+          committed_prefix_len_tokens_ == 0)) {
+        throw std::logic_error("PagedCacheGroupTable::ImportPrefixOwned: only legal on a fresh-empty table");
+    }
+    if (base_logical_page < 0) {
+        throw std::invalid_argument("PagedCacheGroupTable::ImportPrefixOwned: base_logical_page must be >= 0");
+    }
+    if (raw_tokens_covered < 0) {
+        throw std::invalid_argument("PagedCacheGroupTable::ImportPrefixOwned: raw_tokens_covered must be >= 0");
+    }
+    const std::int32_t raw_per_page = allocator_->Config().RawTokensPerPage();
+    if (raw_per_page <= 0) {
+        throw std::logic_error("PagedCacheGroupTable::ImportPrefixOwned: invalid group config");
+    }
+    if (raw_tokens_covered % raw_per_page != 0) {
+        throw std::invalid_argument("PagedCacheGroupTable::ImportPrefixOwned: raw_tokens_covered must be page-aligned");
+    }
+    if (!pages.Empty()) {
+        const std::int32_t covered_pages = raw_tokens_covered / raw_per_page;
+        if (base_logical_page + pages.Size() != covered_pages) {
+            throw std::invalid_argument(
+                "PagedCacheGroupTable::ImportPrefixOwned: page ids do not end at covered raw "
+                "token cursor");
+        }
+    }
+    owned_pages_ = std::move(pages);
+    base_logical_page_ = base_logical_page;
+    raw_token_cursor_ = raw_tokens_covered;
+    committed_prefix_len_tokens_ = raw_tokens_covered;
+    RefreshPageIdsView();
+}
+
 std::vector<std::int32_t> PagedCacheGroupTable::ReleaseSkipped(std::int32_t window_lower_bound) {
     if (allocator_ == nullptr || window_lower_bound <= 0) {
         return {};

--- a/tokenspeed-scheduler/csrc/resource/allocator/paged_cache_group.h
+++ b/tokenspeed-scheduler/csrc/resource/allocator/paged_cache_group.h
@@ -155,8 +155,10 @@ public:
                               std::int32_t raw_tokens_covered);
 
     // Adopt owned device pages that were freshly materialized from host L2.
-    // Legal only on a fresh-empty table. The table owns these pages and can
-    // later commit them into device snapshots or release them with the request.
+    // Legal only on a fresh-empty table. History-family pages remain
+    // uncommitted so CommitChunk can publish them into device snapshots before
+    // extending the chain; State-family pages represent terminal state already
+    // covered by the host hit.
     void ImportPrefixOwned(OwnedPages pages, std::int32_t base_logical_page, std::int32_t raw_tokens_covered);
 
     // Sliding-only: drop front pages strictly below `window_lower_bound`.

--- a/tokenspeed-scheduler/csrc/resource/allocator/paged_cache_group.h
+++ b/tokenspeed-scheduler/csrc/resource/allocator/paged_cache_group.h
@@ -30,6 +30,8 @@
 
 namespace tokenspeed {
 
+class HybridPrefixCache;
+
 // Positive-only ceiling division; returns 0 for non-positive numerators.
 // Lives here because paged-cache admission/table math is its only caller.
 inline std::int32_t CeilDivPositive(std::int32_t numer, std::int32_t denom) {
@@ -88,6 +90,7 @@ public:
 
 private:
     friend class PagedCacheGroupTable;
+    friend class HybridPrefixCache;
 
     // Empty OwnedPages on insufficient capacity (bumps failed_alloc_count_).
     OwnedPages AcquireOwned(std::int32_t num_pages);
@@ -150,6 +153,11 @@ public:
     // Throws std::logic_error if called after Acquire/Import/Commit.
     void ImportPrefixBorrowed(std::vector<std::int32_t> ids, std::int32_t base_logical_page,
                               std::int32_t raw_tokens_covered);
+
+    // Adopt owned device pages that were freshly materialized from host L2.
+    // Legal only on a fresh-empty table. The table owns these pages and can
+    // later commit them into device snapshots or release them with the request.
+    void ImportPrefixOwned(OwnedPages pages, std::int32_t base_logical_page, std::int32_t raw_tokens_covered);
 
     // Sliding-only: drop front pages strictly below `window_lower_bound`.
     // On an empty table, advances base_logical_page_ so first allocation starts

--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
@@ -37,6 +37,7 @@
 #include <iterator>
 #include <numeric>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
 namespace tokenspeed {
@@ -1722,37 +1723,63 @@ void HybridPrefixCache::CommitChunk(const std::string& request_id, TreeNode* ter
         if (attach_node == nullptr) break;
 
         bool preflight_ok = true;
+        const char* preflight_fail_reason = "unknown";
+        std::string preflight_fail_group;
+        std::int32_t fail_raw_per_page = -1;
+        std::int32_t fail_committed = -1;
+        std::int32_t fail_raw_cursor = -1;
+        std::int32_t fail_base = -1;
+        std::int32_t fail_borrowed = -1;
+        std::int32_t fail_owned = -1;
+        std::int32_t fail_committed_page = -1;
+        std::int32_t fail_owned_base_page = -1;
+        std::int32_t fail_pages_to_commit = -1;
+
+        auto mark_preflight_failure = [&](const char* reason, const std::string& gid,
+                                          const PagedCacheGroupTable* table = nullptr, std::int32_t raw_per_page = -1) {
+            preflight_ok = false;
+            preflight_fail_reason = reason;
+            preflight_fail_group = gid;
+            fail_raw_per_page = raw_per_page;
+            if (table == nullptr) return;
+            fail_committed = table->CommittedPrefixLenTokens();
+            fail_raw_cursor = table->RawTokenCursor();
+            fail_base = table->BaseLogicalPage();
+            fail_borrowed = table->BorrowedPagesCount();
+            fail_owned = table->OwnedPagesCount();
+        };
+
         for (const auto& gid : required_groups) {
             auto t_it = tables.find(gid);
             if (t_it == tables.end()) {
-                preflight_ok = false;
+                mark_preflight_failure("missing_table", gid);
                 break;
             }
             const auto& table = t_it->second;
             const std::int32_t raw_per_page = table.RawTokensPerPage();
             if (raw_per_page <= 0) {
-                preflight_ok = false;
+                mark_preflight_failure("invalid_raw_per_page", gid, &table, raw_per_page);
                 break;
             }
             if (table.CommittedPrefixLenTokens() % raw_per_page != 0) {
-                preflight_ok = false;
+                mark_preflight_failure("committed_unaligned", gid, &table, raw_per_page);
                 break;
             }
             if (target % raw_per_page != 0) {
-                preflight_ok = false;
+                mark_preflight_failure("target_unaligned", gid, &table, raw_per_page);
                 break;
             }
             if (target <= table.CommittedPrefixLenTokens()) {
-                preflight_ok = false;
+                mark_preflight_failure("target_not_advanced", gid, &table, raw_per_page);
                 break;
             }
             if (target > table.RawTokenCursor()) {
-                preflight_ok = false;
+                mark_preflight_failure("target_exceeds_raw_cursor", gid, &table, raw_per_page);
                 break;
             }
             auto group_alloc_it = paged_cache_allocators_.find(gid);
             if (group_alloc_it == paged_cache_allocators_.end() || group_alloc_it->second == nullptr) {
-                preflight_ok = false;
+                mark_preflight_failure("missing_allocator", gid, &table, raw_per_page);
                 break;
             }
             const auto& cfg = group_alloc_it->second->Config();
@@ -1760,17 +1787,30 @@ void HybridPrefixCache::CommitChunk(const std::string& request_id, TreeNode* ter
                 const std::int32_t committed_page = table.CommittedPrefixLenTokens() / raw_per_page;
                 const std::int32_t owned_base_page = table.BaseLogicalPage() + table.BorrowedPagesCount();
                 const std::int32_t pages_to_commit = (target - table.CommittedPrefixLenTokens()) / raw_per_page;
-                if (owned_base_page != committed_page || pages_to_commit > table.OwnedPagesCount()) {
-                    preflight_ok = false;
+                if (owned_base_page != committed_page) {
+                    mark_preflight_failure("history_owned_base_mismatch", gid, &table, raw_per_page);
+                    fail_committed_page = committed_page;
+                    fail_owned_base_page = owned_base_page;
+                    fail_pages_to_commit = pages_to_commit;
+                    break;
+                }
+                if (pages_to_commit > table.OwnedPagesCount()) {
+                    mark_preflight_failure("history_owned_pages_short", gid, &table, raw_per_page);
+                    fail_committed_page = committed_page;
+                    fail_owned_base_page = owned_base_page;
+                    fail_pages_to_commit = pages_to_commit;
                     break;
                 }
             }
         }
         if (!preflight_ok) {
             spdlog::warn(
-                "[HybridPrefixCache] CommitChunk: preflight failed for request {} at target "
-                "depth {}; leaving prior commits intact",
-                request_id, target);
+                "[HybridPrefixCache] CommitChunk: preflight failed request={} target={} chunk_depth={} lcm={} "
+                "reason={} group={} committed={} raw_cursor={} raw_per_page={} base={} borrowed={} owned={} "
+                "committed_page={} owned_base_page={} pages_to_commit={}; leaving prior commits intact",
+                request_id, target, chunk_depth, lcm, preflight_fail_reason, preflight_fail_group, fail_committed,
+                fail_raw_cursor, fail_raw_per_page, fail_base, fail_borrowed, fail_owned, fail_committed_page,
+                fail_owned_base_page, fail_pages_to_commit);
             break;
         }
 

--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <numeric>
 #include <stdexcept>
 #include <utility>
@@ -51,7 +52,7 @@ HybridPrefixCache::HybridPrefixCache(KVPrefixCache& kv_prefix_cache, MambaChunkA
 MatchResult HybridPrefixCache::Match(const token_vec_t& token_ids, MatchIntent intent) {
     auto match = kv_prefix_cache_.Match(token_ids, intent);
     augmentMatch(match);
-    augmentMatchPagedCache(match);
+    augmentMatchPagedCache(match, intent);
     return match;
 }
 
@@ -59,7 +60,7 @@ MatchResult HybridPrefixCache::Match(const std::vector<std::span<const std::int3
                                      MatchIntent intent) {
     auto match = kv_prefix_cache_.Match(token_pages, intent);
     augmentMatch(match);
-    augmentMatchPagedCache(match);
+    augmentMatchPagedCache(match, intent);
     return match;
 }
 
@@ -396,10 +397,26 @@ bool HybridPrefixCache::AttachPagedCacheSnapshotToNode(TreeNode* node, std::uniq
     return true;
 }
 
+bool HybridPrefixCache::AttachPagedCacheHostSnapshotToNode(TreeNode* node,
+                                                           std::unique_ptr<PagedCacheSnapshot> snapshot) {
+    if (node == nullptr || snapshot == nullptr) return false;
+    if (!node->OnHost()) return false;
+    RefreshPagedCacheSnapshotCompleteness(*snapshot);
+    node->AttachPagedCacheHostSnapshot(std::move(snapshot));
+    paged_cache_host_snapshot_nodes_.insert(node);
+    return true;
+}
+
 std::unique_ptr<PagedCacheSnapshot> HybridPrefixCache::DetachPagedCacheSnapshotFromNode(TreeNode* node) {
     if (node == nullptr) return nullptr;
     paged_cache_snapshot_nodes_.erase(node);
     return node->DetachPagedCacheSnapshot();
+}
+
+std::unique_ptr<PagedCacheSnapshot> HybridPrefixCache::DetachPagedCacheHostSnapshotFromNode(TreeNode* node) {
+    if (node == nullptr) return nullptr;
+    paged_cache_host_snapshot_nodes_.erase(node);
+    return node->DetachPagedCacheHostSnapshot();
 }
 
 void HybridPrefixCache::OnKVEvict(TreeNode* node) {
@@ -450,7 +467,14 @@ void HybridPrefixCache::OnNodeDestroyed(TreeNode* node) {
 }
 
 void HybridPrefixCache::OnKVHostEvict(TreeNode* node) {
-    if (node == nullptr || mamba_host_allocator_ == nullptr) return;
+    if (node == nullptr) return;
+    if (node->HasPagedCacheHostSnapshot()) {
+        DetachPagedCacheHostSnapshotFromNode(node);
+    }
+    if (node->HasPagedCachePendingHostSnapshot()) {
+        node->DetachPagedCachePendingHostSnapshot();
+    }
+    if (mamba_host_allocator_ == nullptr) return;
     pending_mamba_host_writebacks_.erase(node);
     if (node->HasMambaOnHost()) {
         node->DetachMambaHost();
@@ -485,17 +509,17 @@ void HybridPrefixCache::DemoteIdleMambaDeviceCopiesPresentOnHost() {
     }
 }
 
-void HybridPrefixCache::OnMambaHostWriteBackDone(TreeNode* last_node) {
+void HybridPrefixCache::OnMambaHostWriteBackDone(TreeNode* last_node, bool success) {
     if (last_node == nullptr) return;
     std::vector<TreeNode*> nodes;
     for (TreeNode* node : LeafToRoot(last_node)) {
         if (node == nullptr || !node->OnHost()) break;
         nodes.push_back(node);
     }
-    OnMambaHostWriteBackDone(nodes);
+    OnMambaHostWriteBackDone(nodes, success);
 }
 
-void HybridPrefixCache::OnMambaHostWriteBackDone(const std::vector<TreeNode*>& nodes) {
+void HybridPrefixCache::OnMambaHostWriteBackDone(const std::vector<TreeNode*>& nodes, bool success) {
     if (mamba_allocator_ == nullptr || mamba_host_allocator_ == nullptr) return;
 
     std::int32_t attached = 0;
@@ -504,6 +528,10 @@ void HybridPrefixCache::OnMambaHostWriteBackDone(const std::vector<TreeNode*>& n
         if (node == nullptr || !node->OnHost()) continue;
         auto pending = pending_mamba_host_writebacks_.find(node);
         if (pending != pending_mamba_host_writebacks_.end()) {
+            if (!success) {
+                pending_mamba_host_writebacks_.erase(pending);
+                continue;
+            }
             node->AttachMambaHost(std::move(pending->second));
             pending_mamba_host_writebacks_.erase(pending);
             mamba_host_nodes_.insert(node);
@@ -518,11 +546,17 @@ void HybridPrefixCache::OnMambaHostWriteBackDone(const std::vector<TreeNode*>& n
         spdlog::debug("[HybridPrefixCache][mamba_l2] host writeback done attach_count={} completed_nodes={}", attached,
                       completed);
     }
-    DemoteIdleMambaDeviceCopiesPresentOnHost();
+    if (success) {
+        DemoteIdleMambaDeviceCopiesPresentOnHost();
+    }
 }
 
 void HybridPrefixCache::OnKVDeviceDemote(TreeNode* node) {
-    if (node == nullptr || mamba_allocator_ == nullptr) return;
+    if (node == nullptr) return;
+    if (node->HasPagedCacheSnapshot() && node->HasPagedCacheHostSnapshot()) {
+        DetachPagedCacheSnapshotFromNode(node);
+    }
+    if (mamba_allocator_ == nullptr) return;
     if (node->HasMamba() && node->HasMambaOnHost()) {
         mamba_eviction_manager_.UntrackNode(node);
         node->DetachMamba();
@@ -546,6 +580,29 @@ void HybridPrefixCache::RegisterPagedCacheGroup(std::unique_ptr<PagedCacheGroupA
         throw std::invalid_argument("HybridPrefixCache::RegisterPagedCacheGroup: duplicate group_id: " + gid);
     }
     paged_cache_allocators_.emplace(std::move(gid), std::move(allocator));
+}
+
+void HybridPrefixCache::RegisterPagedCacheHostGroup(std::unique_ptr<PagedCacheGroupAllocator> allocator) {
+    if (allocator == nullptr) {
+        throw std::invalid_argument("HybridPrefixCache::RegisterPagedCacheHostGroup: null allocator");
+    }
+    const std::string gid = allocator->Config().group_id;
+    if (paged_cache_host_allocators_.find(gid) != paged_cache_host_allocators_.end()) {
+        throw std::invalid_argument("HybridPrefixCache::RegisterPagedCacheHostGroup: duplicate group_id: " + gid);
+    }
+    auto device_it = paged_cache_allocators_.find(gid);
+    if (device_it == paged_cache_allocators_.end() || device_it->second == nullptr) {
+        throw std::invalid_argument("HybridPrefixCache::RegisterPagedCacheHostGroup: device group missing: " + gid);
+    }
+    const auto& host_cfg = allocator->Config();
+    const auto& device_cfg = device_it->second->Config();
+    if (host_cfg.rows_per_page != device_cfg.rows_per_page ||
+        host_cfg.entry_stride_tokens != device_cfg.entry_stride_tokens || host_cfg.retention != device_cfg.retention ||
+        host_cfg.sliding_window_tokens != device_cfg.sliding_window_tokens || host_cfg.family != device_cfg.family) {
+        throw std::invalid_argument("HybridPrefixCache::RegisterPagedCacheHostGroup: host/device config mismatch for " +
+                                    gid);
+    }
+    paged_cache_host_allocators_.emplace(gid, std::move(allocator));
 }
 
 void HybridPrefixCache::EnablePagedCacheAdjunct(
@@ -658,6 +715,19 @@ TreeNode* CapNodeToDepth(TreeNode* from, std::int32_t depth) {
     return node;
 }
 
+enum class PagedCacheResidency { kDevice, kHost };
+
+const PagedCacheSnapshot* GetPagedCacheSnapshotForResidency(TreeNode* node, PagedCacheResidency residency) {
+    if (node == nullptr) return nullptr;
+    switch (residency) {
+        case PagedCacheResidency::kDevice:
+            return node->GetPagedCacheSnapshot();
+        case PagedCacheResidency::kHost:
+            return node->GetPagedCacheHostSnapshot();
+    }
+    return nullptr;
+}
+
 // Ancestor path (excluding root), reversed so element 0 is closest to root.
 std::vector<TreeNode*> CollectAncestorPathRootToLeaf(TreeNode* from) {
     std::vector<TreeNode*> path;
@@ -669,11 +739,11 @@ std::vector<TreeNode*> CollectAncestorPathRootToLeaf(TreeNode* from) {
 }
 
 void AssemblePagedCacheGroupPages(MatchResult::PagedCache& out, const std::string& gid,
-                                  std::span<TreeNode* const> chain, bool is_sliding) {
+                                  std::span<TreeNode* const> chain, bool is_sliding, PagedCacheResidency residency) {
     std::vector<std::int32_t> page_ids;
     std::int32_t base_logical_page = 0;
     if (!chain.empty()) {
-        const PagedCacheSnapshot* earliest_snap = chain.front()->GetPagedCacheSnapshot();
+        const PagedCacheSnapshot* earliest_snap = GetPagedCacheSnapshotForResidency(chain.front(), residency);
         if (earliest_snap != nullptr && is_sliding) {
             auto git = earliest_snap->groups.find(gid);
             if (git != earliest_snap->groups.end()) {
@@ -681,7 +751,7 @@ void AssemblePagedCacheGroupPages(MatchResult::PagedCache& out, const std::strin
             }
         }
         for (TreeNode* anc : chain) {
-            const PagedCacheSnapshot* snap = anc->GetPagedCacheSnapshot();
+            const PagedCacheSnapshot* snap = GetPagedCacheSnapshotForResidency(anc, residency);
             if (snap == nullptr) continue;
             auto git = snap->groups.find(gid);
             if (git == snap->groups.end()) continue;
@@ -709,7 +779,8 @@ bool ImportPagedCacheGroupSnapshot(MatchResult::PagedCache& out, const std::stri
 bool AssemblePagedCacheStateGroupPagesToTarget(MatchResult::PagedCache& out, const std::string& gid,
                                                std::span<TreeNode* const> chain,
                                                const PagedCacheGroupAllocator& allocator,
-                                               std::int32_t target_raw_tokens, std::int32_t retained_tokens) {
+                                               std::int32_t target_raw_tokens, std::int32_t retained_tokens,
+                                               PagedCacheResidency residency) {
     const std::int32_t raw_per_page = allocator.Config().RawTokensPerPage();
     if (raw_per_page <= 0 || target_raw_tokens <= 0 || target_raw_tokens % raw_per_page != 0) return false;
     if (retained_tokens <= 0 || retained_tokens % raw_per_page != 0) return false;
@@ -724,7 +795,7 @@ bool AssemblePagedCacheStateGroupPagesToTarget(MatchResult::PagedCache& out, con
     bool started = false;
 
     for (TreeNode* anc : chain) {
-        const PagedCacheSnapshot* snap = anc != nullptr ? anc->GetPagedCacheSnapshot() : nullptr;
+        const PagedCacheSnapshot* snap = GetPagedCacheSnapshotForResidency(anc, residency);
         if (snap == nullptr) continue;
         auto git = snap->groups.find(gid);
         if (git == snap->groups.end()) continue;
@@ -763,151 +834,207 @@ bool AssemblePagedCacheStateGroupPagesToTarget(MatchResult::PagedCache& out, con
 
 }  // namespace
 
-void HybridPrefixCache::augmentMatchPagedCache(MatchResult& match) const {
+void HybridPrefixCache::augmentMatchPagedCache(MatchResult& match, MatchIntent intent) const {
     if (!HasPagedCacheAdjunct()) return;
-    if (match.device.last_node == nullptr) return;
+    TreeNode* token_terminal = match.token_terminal != nullptr ? match.token_terminal : match.device.last_node;
+    if (token_terminal == nullptr) return;
 
     const std::int32_t align = paged_cache_history_alignment_tokens_;
 
     auto cap_to_root = [&]() {
-        TreeNode* root = RootOf(match.device.last_node);
+        TreeNode* root = RootOf(token_terminal);
         match.device.last_node = root;
         match.host.last_node = RootOf(match.host.last_node);
         match.paged_cache = MatchResult::PagedCache{};
+        match.paged_cache_host = MatchResult::PagedCache{};
     };
 
-    std::vector<TreeNode*> path = CollectAncestorPathRootToLeaf(match.device.last_node);
+    auto build_hit = [&](PagedCacheResidency residency) -> MatchResult::PagedCache {
+        MatchResult::PagedCache hit{};
+        std::vector<TreeNode*> path = CollectAncestorPathRootToLeaf(token_terminal);
 
-    TreeNode* deepest_history = nullptr;
-    std::vector<TreeNode*> history_chain;
-    std::int32_t expected_depth = align;
-    for (TreeNode* n : path) {
-        const std::int32_t d = static_cast<std::int32_t>(n->DepthInTokens());
-        if (d < expected_depth) continue;
-        if (d > expected_depth) break;
-        const auto* snap = n->GetPagedCacheSnapshot();
-        if (snap == nullptr) break;
-        if (!snap->IsCompleteFor(PagedCacheGroupFamily::History)) break;
-        deepest_history = n;
-        history_chain.push_back(n);
-        expected_depth += align;
-    }
-    if (deepest_history == nullptr) {
-        cap_to_root();
-        return;
-    }
+        TreeNode* deepest_history = nullptr;
+        std::vector<TreeNode*> history_chain;
+        std::int32_t expected_depth = align;
+        for (TreeNode* n : path) {
+            const std::int32_t d = static_cast<std::int32_t>(n->DepthInTokens());
+            if (d < expected_depth) continue;
+            if (d > expected_depth) break;
+            const auto* snap = GetPagedCacheSnapshotForResidency(n, residency);
+            if (snap == nullptr) break;
+            if (!snap->IsCompleteFor(PagedCacheGroupFamily::History)) break;
+            deepest_history = n;
+            history_chain.push_back(n);
+            expected_depth += align;
+        }
+        if (deepest_history == nullptr) {
+            return hit;
+        }
 
-    match.paged_cache.per_group_page_ids.clear();
-    match.paged_cache.per_group_base_logical_page.clear();
-    match.paged_cache.history_hit_tokens = static_cast<std::int32_t>(deepest_history->DepthInTokens());
+        hit.history_hit_tokens = static_cast<std::int32_t>(deepest_history->DepthInTokens());
 
-    const std::int32_t history_hit = match.paged_cache.history_hit_tokens;
-    if (!paged_cache_continuation_state_groups_.empty()) {
-        const auto* terminal_snap = deepest_history->GetPagedCacheSnapshot();
-        if (terminal_snap != nullptr && terminal_snap->continuation_state_complete &&
-            terminal_snap->prefix_len_tokens == history_hit) {
+        const std::int32_t history_hit = hit.history_hit_tokens;
+        if (intent == MatchIntent::StateRecovery) {
+            const std::int32_t terminal_depth = static_cast<std::int32_t>(token_terminal->DepthInTokens());
+            const auto* terminal_snap = GetPagedCacheSnapshotForResidency(token_terminal, residency);
+            const bool terminal_state_complete =
+                paged_cache_continuation_state_groups_.empty() ||
+                (terminal_snap != nullptr && terminal_snap->continuation_state_complete);
+            if (deepest_history != token_terminal || terminal_snap == nullptr ||
+                terminal_snap->prefix_len_tokens != terminal_depth || !terminal_state_complete) {
+                return MatchResult::PagedCache{};
+            }
+
             MatchResult::PagedCache terminal_hit{};
-            terminal_hit.last_node = deepest_history;
-            terminal_hit.prefix_len_tokens = history_hit;
-            terminal_hit.history_hit_tokens = history_hit;
+            terminal_hit.last_node = token_terminal;
+            terminal_hit.prefix_len_tokens = terminal_depth;
+            terminal_hit.history_hit_tokens = terminal_depth;
 
             const std::span<TreeNode* const> history_span{history_chain};
             for (const auto& gid : paged_cache_history_groups_) {
                 const bool is_sliding =
                     paged_cache_sliding_window_per_group_.find(gid) != paged_cache_sliding_window_per_group_.end();
-                AssemblePagedCacheGroupPages(terminal_hit, gid, history_span, is_sliding);
+                AssemblePagedCacheGroupPages(terminal_hit, gid, history_span, is_sliding, residency);
             }
 
-            bool continuation_ok = true;
             for (const auto& gid : paged_cache_continuation_state_groups_) {
                 auto alloc_it = paged_cache_allocators_.find(gid);
                 if (alloc_it == paged_cache_allocators_.end()) {
-                    continuation_ok = false;
-                    break;
+                    return MatchResult::PagedCache{};
                 }
                 const std::int32_t retained_tokens = alloc_it->second->Config().sliding_window_tokens.value_or(0);
                 if (!AssemblePagedCacheStateGroupPagesToTarget(terminal_hit, gid, history_span, *alloc_it->second,
-                                                               history_hit, retained_tokens)) {
-                    continuation_ok = false;
-                    break;
+                                                               terminal_depth, retained_tokens, residency)) {
+                    return MatchResult::PagedCache{};
                 }
             }
-            if (continuation_ok) {
-                match.paged_cache = std::move(terminal_hit);
-                match.device.last_node = deepest_history;
-                match.host.last_node = CapNodeToDepth(match.host.last_node, history_hit);
-                return;
-            }
+            return terminal_hit;
         }
-    }
 
-    const bool has_transport_only_state =
-        paged_cache_continuation_state_group_set_.size() != paged_cache_state_group_set_.size();
-    if (has_transport_only_state) {
-        cap_to_root();
-        return;
-    }
+        if (!paged_cache_continuation_state_groups_.empty()) {
+            const auto* terminal_snap = GetPagedCacheSnapshotForResidency(deepest_history, residency);
+            if (terminal_snap != nullptr && terminal_snap->continuation_state_complete &&
+                terminal_snap->prefix_len_tokens == history_hit) {
+                MatchResult::PagedCache terminal_hit{};
+                terminal_hit.last_node = deepest_history;
+                terminal_hit.prefix_len_tokens = history_hit;
+                terminal_hit.history_hit_tokens = history_hit;
 
-    std::int32_t worst_window = 0;
-    for (const auto& gid : paged_cache_state_groups_) {
-        auto it = paged_cache_sliding_window_per_group_.find(gid);
-        if (it != paged_cache_sliding_window_per_group_.end()) {
-            worst_window = std::max(worst_window, it->second);
-        }
-    }
-    const std::int32_t segments_needed = worst_window > 0 ? (worst_window + align - 1) / align : 1;
+                const std::span<TreeNode* const> history_span{history_chain};
+                for (const auto& gid : paged_cache_history_groups_) {
+                    const bool is_sliding =
+                        paged_cache_sliding_window_per_group_.find(gid) != paged_cache_sliding_window_per_group_.end();
+                    AssemblePagedCacheGroupPages(terminal_hit, gid, history_span, is_sliding, residency);
+                }
 
-    TreeNode* usable_node = nullptr;
-    if (paged_cache_state_groups_.empty()) {
-        usable_node = deepest_history;
-    } else {
-        for (std::int32_t end_idx = static_cast<std::int32_t>(history_chain.size()) - 1; end_idx >= 0; --end_idx) {
-            const std::int32_t start_idx = std::max(0, end_idx - segments_needed + 1);
-            bool ok = true;
-            for (std::int32_t i = start_idx; i <= end_idx; ++i) {
-                const auto* snap = history_chain[i]->GetPagedCacheSnapshot();
-                if (snap == nullptr || !snap->IsCompleteFor(PagedCacheGroupFamily::State)) {
-                    ok = false;
-                    break;
+                bool continuation_ok = true;
+                for (const auto& gid : paged_cache_continuation_state_groups_) {
+                    auto alloc_it = paged_cache_allocators_.find(gid);
+                    if (alloc_it == paged_cache_allocators_.end()) {
+                        continuation_ok = false;
+                        break;
+                    }
+                    const std::int32_t retained_tokens = alloc_it->second->Config().sliding_window_tokens.value_or(0);
+                    if (!AssemblePagedCacheStateGroupPagesToTarget(terminal_hit, gid, history_span, *alloc_it->second,
+                                                                   history_hit, retained_tokens, residency)) {
+                        continuation_ok = false;
+                        break;
+                    }
+                }
+                if (continuation_ok) {
+                    return terminal_hit;
                 }
             }
-            if (ok) {
-                usable_node = history_chain[end_idx];
-                break;
-            }
         }
-    }
-    if (usable_node == nullptr) {
-        cap_to_root();
-        return;
-    }
 
-    const std::int32_t usable = static_cast<std::int32_t>(usable_node->DepthInTokens());
-    while (!history_chain.empty() && static_cast<std::int32_t>(history_chain.back()->DepthInTokens()) > usable) {
-        history_chain.pop_back();
-    }
+        const bool has_transport_only_state =
+            paged_cache_continuation_state_group_set_.size() != paged_cache_state_group_set_.size();
+        if (has_transport_only_state) {
+            return MatchResult::PagedCache{};
+        }
 
-    match.paged_cache.last_node = usable_node;
-    match.paged_cache.prefix_len_tokens = usable;
-
-    const std::span<TreeNode* const> history_span{history_chain};
-    for (const auto& gid : paged_cache_history_groups_) {
-        const bool is_sliding =
-            paged_cache_sliding_window_per_group_.find(gid) != paged_cache_sliding_window_per_group_.end();
-        AssemblePagedCacheGroupPages(match.paged_cache, gid, history_span, is_sliding);
-    }
-    if (!paged_cache_state_groups_.empty()) {
-        const std::size_t take = std::min<std::size_t>(history_chain.size(), static_cast<std::size_t>(segments_needed));
-        const std::span<TreeNode* const> state_span = history_span.last(take);
+        std::int32_t worst_window = 0;
         for (const auto& gid : paged_cache_state_groups_) {
+            auto it = paged_cache_sliding_window_per_group_.find(gid);
+            if (it != paged_cache_sliding_window_per_group_.end()) {
+                worst_window = std::max(worst_window, it->second);
+            }
+        }
+        const std::int32_t segments_needed = worst_window > 0 ? (worst_window + align - 1) / align : 1;
+
+        TreeNode* usable_node = nullptr;
+        if (paged_cache_state_groups_.empty()) {
+            usable_node = deepest_history;
+        } else {
+            for (std::int32_t end_idx = static_cast<std::int32_t>(history_chain.size()) - 1; end_idx >= 0; --end_idx) {
+                const std::int32_t start_idx = std::max(0, end_idx - segments_needed + 1);
+                bool ok = true;
+                for (std::int32_t i = start_idx; i <= end_idx; ++i) {
+                    const auto* snap = GetPagedCacheSnapshotForResidency(history_chain[i], residency);
+                    if (snap == nullptr || !snap->IsCompleteFor(PagedCacheGroupFamily::State)) {
+                        ok = false;
+                        break;
+                    }
+                }
+                if (ok) {
+                    usable_node = history_chain[end_idx];
+                    break;
+                }
+            }
+        }
+        if (usable_node == nullptr) {
+            return MatchResult::PagedCache{};
+        }
+
+        const std::int32_t usable = static_cast<std::int32_t>(usable_node->DepthInTokens());
+        while (!history_chain.empty() && static_cast<std::int32_t>(history_chain.back()->DepthInTokens()) > usable) {
+            history_chain.pop_back();
+        }
+
+        hit.last_node = usable_node;
+        hit.prefix_len_tokens = usable;
+
+        const std::span<TreeNode* const> history_span{history_chain};
+        for (const auto& gid : paged_cache_history_groups_) {
             const bool is_sliding =
                 paged_cache_sliding_window_per_group_.find(gid) != paged_cache_sliding_window_per_group_.end();
-            AssemblePagedCacheGroupPages(match.paged_cache, gid, state_span, is_sliding);
+            AssemblePagedCacheGroupPages(hit, gid, history_span, is_sliding, residency);
         }
+        if (!paged_cache_state_groups_.empty()) {
+            const std::size_t take =
+                std::min<std::size_t>(history_chain.size(), static_cast<std::size_t>(segments_needed));
+            const std::span<TreeNode* const> state_span = history_span.last(take);
+            for (const auto& gid : paged_cache_state_groups_) {
+                const bool is_sliding =
+                    paged_cache_sliding_window_per_group_.find(gid) != paged_cache_sliding_window_per_group_.end();
+                AssemblePagedCacheGroupPages(hit, gid, state_span, is_sliding, residency);
+            }
+        }
+        return hit;
+    };
+
+    match.paged_cache = build_hit(PagedCacheResidency::kDevice);
+    match.paged_cache_host = build_hit(PagedCacheResidency::kHost);
+
+    const bool has_device_hit = match.paged_cache.last_node != nullptr && match.paged_cache.prefix_len_tokens > 0;
+    const bool has_host_hit =
+        match.paged_cache_host.last_node != nullptr && match.paged_cache_host.prefix_len_tokens > 0;
+    if (!has_device_hit && !has_host_hit) {
+        cap_to_root();
+        return;
     }
 
-    match.device.last_node = usable_node;
+    TreeNode* root = RootOf(token_terminal);
+    if (has_device_hit) {
+        match.device.last_node = match.paged_cache.last_node;
+    } else {
+        match.device.last_node = root;
+    }
+    const std::int32_t usable = std::max(match.paged_cache.prefix_len_tokens, match.paged_cache_host.prefix_len_tokens);
     match.host.last_node = CapNodeToDepth(match.host.last_node, usable);
+    if (match.host.last_node == nullptr) {
+        match.host.last_node = RootOf(token_terminal);
+    }
 }
 
 std::vector<std::string> HybridPrefixCache::PagedCacheGroupIds() const {
@@ -939,6 +1066,30 @@ std::int64_t HybridPrefixCache::PagedCacheGroupFailedAllocCount(const std::strin
     auto it = paged_cache_allocators_.find(group_id);
     if (it == paged_cache_allocators_.end()) {
         throw std::out_of_range("HybridPrefixCache::PagedCacheGroupFailedAllocCount: group_id not configured");
+    }
+    return it->second->FailedAllocCount();
+}
+
+std::int32_t HybridPrefixCache::PagedCacheHostGroupTotalPages(const std::string& group_id) const {
+    auto it = paged_cache_host_allocators_.find(group_id);
+    if (it == paged_cache_host_allocators_.end()) {
+        throw std::out_of_range("HybridPrefixCache::PagedCacheHostGroupTotalPages: group_id not configured");
+    }
+    return it->second->TotalPages();
+}
+
+std::int32_t HybridPrefixCache::PagedCacheHostGroupAvailablePages(const std::string& group_id) const {
+    auto it = paged_cache_host_allocators_.find(group_id);
+    if (it == paged_cache_host_allocators_.end()) {
+        throw std::out_of_range("HybridPrefixCache::PagedCacheHostGroupAvailablePages: group_id not configured");
+    }
+    return it->second->AvailablePages();
+}
+
+std::int64_t HybridPrefixCache::PagedCacheHostGroupFailedAllocCount(const std::string& group_id) const {
+    auto it = paged_cache_host_allocators_.find(group_id);
+    if (it == paged_cache_host_allocators_.end()) {
+        throw std::out_of_range("HybridPrefixCache::PagedCacheHostGroupFailedAllocCount: group_id not configured");
     }
     return it->second->FailedAllocCount();
 }
@@ -1039,6 +1190,122 @@ void HybridPrefixCache::RewindRequest(const std::string& request_id, std::int32_
     }
     for (auto& [_, table] : it->second) {
         table.RewindTail(accepted_raw_tokens);
+    }
+}
+
+std::vector<PagedCacheTransferPair> HybridPrefixCache::PreparePagedCacheDeviceLoadBack(
+    const std::string& request_id, const MatchResult::PagedCache& host_hit) {
+    std::vector<PagedCacheTransferPair> transfers;
+    if (!HasPagedCacheHostAdjunct() || host_hit.last_node == nullptr || host_hit.prefix_len_tokens <= 0) {
+        return transfers;
+    }
+    auto& tables = request_paged_cache_tables_[request_id];
+    if (!tables.empty()) {
+        throw std::logic_error("HybridPrefixCache::PreparePagedCacheDeviceLoadBack: request already has tables");
+    }
+
+    for (const auto& [gid, host_pages] : host_hit.per_group_page_ids) {
+        if (host_pages.empty()) continue;
+        auto device_alloc_it = paged_cache_allocators_.find(gid);
+        if (device_alloc_it == paged_cache_allocators_.end() || device_alloc_it->second == nullptr) {
+            ReleaseRequest(request_id);
+            return {};
+        }
+        OwnedPages device_pages = device_alloc_it->second->AcquireOwned(static_cast<std::int32_t>(host_pages.size()));
+        if (device_pages.Size() != static_cast<std::int32_t>(host_pages.size())) {
+            ReleaseRequest(request_id);
+            return {};
+        }
+        std::int32_t base_logical_page = 0;
+        auto base_it = host_hit.per_group_base_logical_page.find(gid);
+        if (base_it != host_hit.per_group_base_logical_page.end()) {
+            base_logical_page = base_it->second;
+        }
+
+        PagedCacheTransferPair transfer{gid, host_pages, device_pages.Ids()};
+        auto [table_it, inserted] = tables.emplace(gid, PagedCacheGroupTable(device_alloc_it->second.get()));
+        if (!inserted) {
+            ReleaseRequest(request_id);
+            throw std::logic_error("HybridPrefixCache::PreparePagedCacheDeviceLoadBack: duplicate table for group " +
+                                   gid);
+        }
+        table_it->second.ImportPrefixOwned(std::move(device_pages), base_logical_page, host_hit.prefix_len_tokens);
+        transfers.push_back(std::move(transfer));
+    }
+    if (transfers.empty()) {
+        ReleaseRequest(request_id);
+    }
+    return transfers;
+}
+
+std::vector<PagedCacheTransferPair> HybridPrefixCache::PreparePagedCacheHostWriteBack(
+    const std::vector<TreeNode*>& nodes) {
+    std::vector<PagedCacheTransferPair> transfers;
+    if (!HasPagedCacheHostAdjunct()) return transfers;
+
+    for (TreeNode* node : nodes) {
+        if (node == nullptr || !node->HasPagedCacheSnapshot() || node->HasPagedCacheHostSnapshot() ||
+            node->HasPagedCachePendingHostSnapshot() || !node->OnHost()) {
+            continue;
+        }
+        const PagedCacheSnapshot* device_snapshot = node->GetPagedCacheSnapshot();
+        if (device_snapshot == nullptr || device_snapshot->groups.empty()) continue;
+
+        auto pending = std::make_unique<PagedCacheSnapshot>();
+        pending->prefix_len_tokens = device_snapshot->prefix_len_tokens;
+        std::vector<PagedCacheTransferPair> node_transfers;
+        bool ok = true;
+        for (const auto& [gid, device_group] : device_snapshot->groups) {
+            auto host_alloc_it = paged_cache_host_allocators_.find(gid);
+            if (host_alloc_it == paged_cache_host_allocators_.end() || host_alloc_it->second == nullptr) {
+                ok = false;
+                break;
+            }
+            const auto& src_ids = device_group.pages.Ids();
+            if (src_ids.empty()) continue;
+            OwnedPages host_pages = host_alloc_it->second->AcquireOwned(static_cast<std::int32_t>(src_ids.size()));
+            while (host_pages.Size() != static_cast<std::int32_t>(src_ids.size()) && tryPrunePagedCacheHostSnapshot()) {
+                host_pages = host_alloc_it->second->AcquireOwned(static_cast<std::int32_t>(src_ids.size()));
+            }
+            if (host_pages.Size() != static_cast<std::int32_t>(src_ids.size())) {
+                ok = false;
+                break;
+            }
+
+            PagedCacheGroupSnapshot host_group{};
+            host_group.pages = std::move(host_pages);
+            host_group.base_logical_page = device_group.base_logical_page;
+            host_group.raw_token_cursor = device_group.raw_token_cursor;
+            host_group.sliding = device_group.sliding;
+
+            node_transfers.push_back(PagedCacheTransferPair{gid, src_ids, host_group.pages.Ids()});
+            pending->groups.emplace(gid, std::move(host_group));
+        }
+        if (!ok || pending->groups.empty()) {
+            continue;
+        }
+        RefreshPagedCacheSnapshotCompleteness(*pending);
+        node->AttachPagedCachePendingHostSnapshot(std::move(pending));
+        transfers.insert(transfers.end(), std::make_move_iterator(node_transfers.begin()),
+                         std::make_move_iterator(node_transfers.end()));
+    }
+
+    return transfers;
+}
+
+void HybridPrefixCache::OnPagedCacheHostWriteBackDone(const std::vector<TreeNode*>& nodes, bool success) {
+    if (!HasPagedCacheHostAdjunct()) return;
+
+    for (TreeNode* node : nodes) {
+        if (node == nullptr || !node->HasPagedCachePendingHostSnapshot()) continue;
+        if (!success) {
+            node->DetachPagedCachePendingHostSnapshot();
+            continue;
+        }
+        node->PromotePagedCachePendingHostSnapshot();
+        if (node->HasPagedCacheHostSnapshot()) {
+            paged_cache_host_snapshot_nodes_.insert(node);
+        }
     }
 }
 
@@ -1352,6 +1619,60 @@ bool HybridPrefixCache::tryPrunePagedCacheSnapshot(AdmissionFailureKind kind) {
     return false;
 }
 
+bool HybridPrefixCache::tryPrunePagedCacheHostSnapshot() {
+    if (!HasPagedCacheHostAdjunct()) return false;
+
+    auto is_pinned = [](TreeNode* node) {
+        for (TreeNode* cur = node; cur != nullptr && !cur->IsRoot(); cur = cur->Parent()) {
+            if (!cur->OnHost()) return true;
+            if (cur->Host().RefCount() > 0) return true;
+        }
+        return false;
+    };
+
+    std::vector<TreeNode*> candidates;
+    candidates.reserve(paged_cache_host_snapshot_nodes_.size());
+    for (TreeNode* node : paged_cache_host_snapshot_nodes_) {
+        if (node == nullptr || !node->HasPagedCacheHostSnapshot()) continue;
+        candidates.push_back(node);
+    }
+    std::sort(candidates.begin(), candidates.end(), [](TreeNode* a, TreeNode* b) {
+        if (a->Time() != b->Time()) return a->Time() < b->Time();
+        return a->DepthInTokens() > b->DepthInTokens();
+    });
+
+    TreeNode* victim = nullptr;
+    for (TreeNode* node : candidates) {
+        if (is_pinned(node)) continue;
+        victim = node;
+        break;
+    }
+    if (victim == nullptr) return false;
+
+    const std::size_t victim_depth = victim->DepthInTokens();
+    auto primary = DetachPagedCacheHostSnapshotFromNode(victim);
+    (void)primary;
+
+    std::vector<TreeNode*> descendants;
+    for (TreeNode* node : paged_cache_host_snapshot_nodes_) {
+        if (node == nullptr || node == victim) continue;
+        if (!node->HasPagedCacheHostSnapshot()) continue;
+        if (node->DepthInTokens() <= victim_depth) continue;
+        for (TreeNode* cur = node->Parent(); cur != nullptr && !cur->IsRoot(); cur = cur->Parent()) {
+            if (cur == victim) {
+                descendants.push_back(node);
+                break;
+            }
+        }
+    }
+    for (TreeNode* descendant : descendants) {
+        if (is_pinned(descendant)) continue;
+        auto cascaded = DetachPagedCacheHostSnapshotFromNode(descendant);
+        (void)cascaded;
+    }
+    return true;
+}
+
 bool HybridPrefixCache::AdmitChunk(const std::string& request_id, std::int32_t first_raw_position_of_op,
                                    std::int32_t target_raw_tokens_exclusive,
                                    std::map<std::string, std::int32_t>& simulated_free,
@@ -1385,8 +1706,9 @@ void HybridPrefixCache::CommitChunk(const std::string& request_id, TreeNode* ter
     if (lcm <= 0) return;
     const auto& required_groups = paged_cache_required_groups_;
     if (required_groups.empty()) return;
+    const auto& canonical_groups = paged_cache_history_groups_.empty() ? required_groups : paged_cache_history_groups_;
 
-    auto canonical_it = tables.find(required_groups.front());
+    auto canonical_it = tables.find(canonical_groups.front());
     if (canonical_it == tables.end()) return;
     std::int32_t last_committed = canonical_it->second.CommittedPrefixLenTokens();
 

--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.h
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.h
@@ -65,21 +65,23 @@ public:
     std::vector<TransferPair> PrepareMambaDeviceLoadBack(const std::vector<TreeNode*>& nodes);
     void OnKVHostEvict(TreeNode* node);
     void OnKVDeviceDemote(TreeNode* node);
-    void OnMambaHostWriteBackDone(TreeNode* last_node);
-    void OnMambaHostWriteBackDone(const std::vector<TreeNode*>& nodes);
+    void OnMambaHostWriteBackDone(TreeNode* last_node, bool success = true);
+    void OnMambaHostWriteBackDone(const std::vector<TreeNode*>& nodes, bool success = true);
     void DemoteIdleMambaDeviceCopiesPresentOnHost();
 
     // Takes ownership. Duplicate group_id throws std::invalid_argument.
     void RegisterPagedCacheGroup(std::unique_ptr<PagedCacheGroupAllocator> allocator);
+    void RegisterPagedCacheHostGroup(std::unique_ptr<PagedCacheGroupAllocator> allocator);
 
-    // History alignment is the LCM of RawTokensPerPage() over the History-family
-    // groups; state groups only need the trailing window. Sliding groups must
-    // have a window entry; full-history groups must not.
+    // History alignment is the LCM of RawTokensPerPage() over the required
+    // History-family groups. Continuation state groups only need their trailing
+    // window and are intentionally outside prefix-reuse admission.
     void EnablePagedCacheAdjunct(std::vector<std::string> required_groups,
                                  std::unordered_map<std::string, std::int32_t> sliding_window_per_group);
 
     bool HasMambaAdjunct() const { return mamba_allocator_ != nullptr; }
     bool HasPagedCacheAdjunct() const { return paged_cache_history_alignment_tokens_ > 0; }
+    bool HasPagedCacheHostAdjunct() const { return !paged_cache_host_allocators_.empty(); }
     std::int32_t PagedCacheHistoryAlignmentTokens() const { return paged_cache_history_alignment_tokens_; }
     const std::vector<std::string>& PagedCacheRequiredGroups() const { return paged_cache_required_groups_; }
 
@@ -88,6 +90,9 @@ public:
     std::int32_t PagedCacheGroupTotalPages(const std::string& group_id) const;
     std::int32_t PagedCacheGroupAvailablePages(const std::string& group_id) const;
     std::int64_t PagedCacheGroupFailedAllocCount(const std::string& group_id) const;
+    std::int32_t PagedCacheHostGroupTotalPages(const std::string& group_id) const;
+    std::int32_t PagedCacheHostGroupAvailablePages(const std::string& group_id) const;
+    std::int64_t PagedCacheHostGroupFailedAllocCount(const std::string& group_id) const;
 
     // Per-request introspection: unknown group_id throws; unknown request_id returns empty.
     std::vector<std::int32_t> GetRequestPagedCachePageIds(const std::string& request_id,
@@ -111,6 +116,16 @@ public:
 
     // Reclaim request-local paged-cache tail slots beyond the accepted token length.
     void RewindRequest(const std::string& request_id, std::int32_t accepted_raw_tokens);
+
+    // Allocate request-local device pages for a host paged-cache hit and import
+    // them as owned prefix pages. Returns the HOST->DEVICE transfer specs.
+    std::vector<PagedCacheTransferPair> PreparePagedCacheDeviceLoadBack(const std::string& request_id,
+                                                                        const MatchResult::PagedCache& host_hit);
+
+    // Allocate pending host snapshots from device snapshots. Host metadata is
+    // invisible to Match() until OnPagedCacheHostWriteBackDone(..., true).
+    std::vector<PagedCacheTransferPair> PreparePagedCacheHostWriteBack(const std::vector<TreeNode*>& nodes);
+    void OnPagedCacheHostWriteBackDone(const std::vector<TreeNode*>& nodes, bool success = true);
 
     // Fill op.paged_cache_pages / op.paged_cache_page_base_offsets from the tables.
     void PopulateOp(ForwardOperationBase& op_base) const;
@@ -136,9 +151,11 @@ public:
     // null (defensive no-op). Accepts partial snapshots; the per-policy
     // "snapshot must be full" invariant is enforced upstream by CommitChunk.
     bool AttachPagedCacheSnapshotToNode(TreeNode* node, std::unique_ptr<PagedCacheSnapshot> snapshot);
+    bool AttachPagedCacheHostSnapshotToNode(TreeNode* node, std::unique_ptr<PagedCacheSnapshot> snapshot);
 
     // Drops `node` from the membership set, then detaches and returns the snapshot.
     std::unique_ptr<PagedCacheSnapshot> DetachPagedCacheSnapshotFromNode(TreeNode* node);
+    std::unique_ptr<PagedCacheSnapshot> DetachPagedCacheHostSnapshotFromNode(TreeNode* node);
 
     // Callback from KV prefix-cache eviction.
     void OnKVEvict(TreeNode* node);
@@ -189,11 +206,12 @@ private:
                                             std::int32_t target);
 
     void augmentMatch(MatchResult& match) const;
-    void augmentMatchPagedCache(MatchResult& match) const;
+    void augmentMatchPagedCache(MatchResult& match, MatchIntent intent) const;
 
     // Detach oldest evictable snapshot to free pool pages. State-only path is
     // used only on kStateStarved; history/both go to full cascade.
     bool tryPrunePagedCacheSnapshot(AdmissionFailureKind kind);
+    bool tryPrunePagedCacheHostSnapshot();
 
     bool admitPagedCacheChunk(const std::string& request_id, std::int32_t first_raw_position_of_op,
                               std::int32_t target_raw_tokens_exclusive,
@@ -225,6 +243,7 @@ private:
 
     // `paged_cache_history_alignment_tokens_ == 0` means adjunct disabled; tables still work.
     std::map<std::string, std::unique_ptr<PagedCacheGroupAllocator>> paged_cache_allocators_;
+    std::map<std::string, std::unique_ptr<PagedCacheGroupAllocator>> paged_cache_host_allocators_;
     std::unordered_map<std::string, std::map<std::string, PagedCacheGroupTable>> request_paged_cache_tables_;
     std::int32_t paged_cache_history_alignment_tokens_{0};
     std::vector<std::string> paged_cache_required_groups_;
@@ -240,6 +259,7 @@ private:
 
     // TODO(snapshot-lru-perf): O(N log N) per prune; swap in LRU index if profiling shows it matters.
     std::unordered_set<TreeNode*> paged_cache_snapshot_nodes_;
+    std::unordered_set<TreeNode*> paged_cache_host_snapshot_nodes_;
 };
 
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/csrc/resource/kv_prefix_cache/kv_prefix_cache.cpp
+++ b/tokenspeed-scheduler/csrc/resource/kv_prefix_cache/kv_prefix_cache.cpp
@@ -191,6 +191,7 @@ MatchResult KVPrefixCache::RootMatch() const {
     TreeNode* root = tree_.Root();
     const std::int32_t page_size = tree_.PageSize();
     return MatchResult{
+        .token_terminal = root,
         .device = {.last_node = root, .page_size = page_size},
         .host = {.last_node = root, .page_size = page_size},
     };
@@ -381,6 +382,42 @@ std::vector<TreeNode*> KVPrefixCache::ReleaseDeviceResourcesPresentOnHost(TreeNo
         }
         released.push_back(node);
         device_.UpdateLeaves(node->Parent());
+    }
+    return released;
+}
+
+std::vector<TreeNode*> KVPrefixCache::ReleaseHostResources(const std::vector<TreeNode*>& nodes,
+                                                           std::function<void(TreeNode*)> on_release) {
+    std::vector<TreeNode*> candidates;
+    candidates.reserve(nodes.size());
+    std::unordered_set<TreeNode*> seen;
+    for (TreeNode* node : nodes) {
+        if (node == nullptr || node->IsRoot() || !node->OnHost()) {
+            continue;
+        }
+        if (seen.insert(node).second) {
+            candidates.push_back(node);
+        }
+    }
+
+    std::sort(candidates.begin(), candidates.end(),
+              [](const TreeNode* lhs, const TreeNode* rhs) { return lhs->DepthInTokens() > rhs->DepthInTokens(); });
+
+    std::vector<TreeNode*> released;
+    for (TreeNode* node : candidates) {
+        if (node == nullptr || !node->OnHost() || node->Host().RefCount() != 0) {
+            continue;
+        }
+        if (on_release) {
+            on_release(node);
+        }
+        host_.RemoveLeaf(node);
+        auto detached = node->DetachResource<ResourceType::Host>();
+        if (detached == nullptr) {
+            continue;
+        }
+        released.push_back(node);
+        host_.UpdateLeaves(node->Parent());
     }
     return released;
 }

--- a/tokenspeed-scheduler/csrc/resource/kv_prefix_cache/kv_prefix_cache.h
+++ b/tokenspeed-scheduler/csrc/resource/kv_prefix_cache/kv_prefix_cache.h
@@ -68,6 +68,8 @@ public:
 
     std::vector<TreeNode*> ReleaseDeviceResourcesPresentOnHost(TreeNode* last_node,
                                                                std::function<void(TreeNode*)> on_release = {});
+    std::vector<TreeNode*> ReleaseHostResources(const std::vector<TreeNode*>& nodes,
+                                                std::function<void(TreeNode*)> on_release = {});
 
     void EnqueueTransfer(TreeNode* last_node);
 

--- a/tokenspeed-scheduler/csrc/resource/radix_tree/radix_tree.cpp
+++ b/tokenspeed-scheduler/csrc/resource/radix_tree/radix_tree.cpp
@@ -78,7 +78,9 @@ SplitResult RadixTree::splitChild(TreeNode* parent, const token_vec_t& child_key
 TreeNode* RadixTree::PruneEmptyByNode(TreeNode* node) {
     TreeNode* current = node;
     while (current != nullptr && !current->IsRoot()) {
-        if (current->NumChildren() != 0 || current->OnDevice() || current->OnHost()) {
+        if (current->NumChildren() != 0 || current->OnDevice() || current->OnHost() ||
+            current->HasPagedCacheSnapshot() || current->HasPagedCacheHostSnapshot() ||
+            current->HasPagedCachePendingHostSnapshot()) {
             break;
         }
 
@@ -117,7 +119,8 @@ TreeNode* RadixTree::SplitAt(TreeNode* descendant, std::int32_t depth_in_tokens)
         }
         if (depth_in_tokens > parent_depth && depth_in_tokens < this_depth) {
             // Refuse to split a snapshot-bearing node (would dangle borrowed ids).
-            if (current->HasPagedCacheSnapshot()) {
+            if (current->HasPagedCacheSnapshot() || current->HasPagedCacheHostSnapshot() ||
+                current->HasPagedCachePendingHostSnapshot()) {
                 return nullptr;
             }
             TreeNode* parent = current->Parent();
@@ -140,6 +143,7 @@ WalkResult RadixTree::WalkDownUtilMismatch(token_slice aligned_tokens, TreeNode:
         .remaining_tokens = aligned_tokens,
         .match =
             {
+                .token_terminal = current,
                 .device = {.last_node = current},
                 .host = {.last_node = current},
             },
@@ -174,7 +178,8 @@ WalkResult RadixTree::WalkDownUtilMismatch(token_slice aligned_tokens, TreeNode:
         }
         if (matched_num_pages != static_cast<std::int32_t>(child->Tokens().size() / page_size_)) {
             // Refuse to split a snapshot-bearing node; borrowed ids rely on it.
-            if (child->HasPagedCacheSnapshot()) {
+            if (child->HasPagedCacheSnapshot() || child->HasPagedCacheHostSnapshot() ||
+                child->HasPagedCachePendingHostSnapshot()) {
                 break;
             }
             SplitResult split = splitChild(current, walk_key_cache, matched_num_pages);
@@ -188,6 +193,7 @@ WalkResult RadixTree::WalkDownUtilMismatch(token_slice aligned_tokens, TreeNode:
 
         current = child;
         result.terminal = child;
+        result.match.token_terminal = child;
         result.remaining_tokens = result.remaining_tokens.subspan(matched_num_pages * page_size_);
     }
 

--- a/tokenspeed-scheduler/csrc/resource/radix_tree/tree_node.cpp
+++ b/tokenspeed-scheduler/csrc/resource/radix_tree/tree_node.cpp
@@ -99,7 +99,8 @@ void TreeNode::SplitSelfInto(TreeNode& prefix, std::size_t prefix_pages, std::in
     // Mamba stays in suffix.
     // Invariant: snapshot-bearing nodes are never split (RadixTree refuses).
     // A split here would dangle borrowed ids in active requests.
-    _assert(paged_cache_snapshot_ == nullptr,
+    _assert(paged_cache_snapshot_ == nullptr && paged_cache_host_snapshot_ == nullptr &&
+                paged_cache_pending_host_snapshot_ == nullptr,
             "TreeNode::SplitSelfInto called on a node with an attached paged-cache snapshot; "
             "splitting would invalidate borrowed page id references in active requests");
 }
@@ -110,6 +111,29 @@ void TreeNode::AttachPagedCacheSnapshot(std::unique_ptr<PagedCacheSnapshot> snap
 
 std::unique_ptr<PagedCacheSnapshot> TreeNode::DetachPagedCacheSnapshot() {
     return std::move(paged_cache_snapshot_);
+}
+
+void TreeNode::AttachPagedCacheHostSnapshot(std::unique_ptr<PagedCacheSnapshot> snapshot) {
+    paged_cache_host_snapshot_ = std::move(snapshot);
+}
+
+std::unique_ptr<PagedCacheSnapshot> TreeNode::DetachPagedCacheHostSnapshot() {
+    return std::move(paged_cache_host_snapshot_);
+}
+
+void TreeNode::AttachPagedCachePendingHostSnapshot(std::unique_ptr<PagedCacheSnapshot> snapshot) {
+    paged_cache_pending_host_snapshot_ = std::move(snapshot);
+}
+
+std::unique_ptr<PagedCacheSnapshot> TreeNode::DetachPagedCachePendingHostSnapshot() {
+    return std::move(paged_cache_pending_host_snapshot_);
+}
+
+void TreeNode::PromotePagedCachePendingHostSnapshot() {
+    if (paged_cache_pending_host_snapshot_ == nullptr) {
+        return;
+    }
+    paged_cache_host_snapshot_ = std::move(paged_cache_pending_host_snapshot_);
 }
 
 void TreeNode::SetPersisted(bool persisted) {

--- a/tokenspeed-scheduler/csrc/resource/radix_tree/tree_node.h
+++ b/tokenspeed-scheduler/csrc/resource/radix_tree/tree_node.h
@@ -122,6 +122,9 @@ public:
     // snapshot itself (see `PagedCacheSnapshot::IsCompleteFor`).
     bool HasPagedCacheSnapshot() const { return paged_cache_snapshot_ != nullptr; }
     const PagedCacheSnapshot* GetPagedCacheSnapshot() const { return paged_cache_snapshot_.get(); }
+    bool HasPagedCacheHostSnapshot() const { return paged_cache_host_snapshot_ != nullptr; }
+    bool HasPagedCachePendingHostSnapshot() const { return paged_cache_pending_host_snapshot_ != nullptr; }
+    const PagedCacheSnapshot* GetPagedCacheHostSnapshot() const { return paged_cache_host_snapshot_.get(); }
 
     std::optional<cache_op_id> CacheOpId() const;
 
@@ -141,6 +144,12 @@ private:
     void AttachPagedCacheSnapshot(std::unique_ptr<PagedCacheSnapshot> snapshot);
     std::unique_ptr<PagedCacheSnapshot> DetachPagedCacheSnapshot();
     PagedCacheSnapshot* GetPagedCacheSnapshotMut() { return paged_cache_snapshot_.get(); }
+    void AttachPagedCacheHostSnapshot(std::unique_ptr<PagedCacheSnapshot> snapshot);
+    std::unique_ptr<PagedCacheSnapshot> DetachPagedCacheHostSnapshot();
+    void AttachPagedCachePendingHostSnapshot(std::unique_ptr<PagedCacheSnapshot> snapshot);
+    std::unique_ptr<PagedCacheSnapshot> DetachPagedCachePendingHostSnapshot();
+    void PromotePagedCachePendingHostSnapshot();
+    PagedCacheSnapshot* GetPagedCacheHostSnapshotMut() { return paged_cache_host_snapshot_.get(); }
 
 private:
     TreeNode* parent_{};
@@ -157,6 +166,8 @@ private:
     std::unique_ptr<MambaSlot> mamba_slot_{};
     std::unique_ptr<MambaSlot> mamba_host_slot_{};
     std::unique_ptr<PagedCacheSnapshot> paged_cache_snapshot_{};
+    std::unique_ptr<PagedCacheSnapshot> paged_cache_host_snapshot_{};
+    std::unique_ptr<PagedCacheSnapshot> paged_cache_pending_host_snapshot_{};
 
     static std::atomic<seq_id_t> next_seq_id_;
 };

--- a/tokenspeed-scheduler/csrc/resource/types.h
+++ b/tokenspeed-scheduler/csrc/resource/types.h
@@ -52,6 +52,9 @@ using DeviceNodeRef = NodeRef<ResourceType::Device>;
 using HostNodeRef = NodeRef<ResourceType::Host>;
 
 struct MatchResult {
+    // Deepest token-radix node reached before tier-specific resource capping.
+    TreeNode* token_terminal{nullptr};
+
     struct Device {
         TreeNode* last_node;
         std::int32_t page_size{0};
@@ -85,6 +88,9 @@ struct MatchResult {
         std::map<std::string, std::vector<std::int32_t>> per_group_page_ids;
         std::map<std::string, std::int32_t> per_group_base_logical_page;
     } paged_cache;
+    // Host-tier paged-cache hit. These page ids are host page ids and must be
+    // materialized into device pages before a forward op is built.
+    PagedCache paged_cache_host;
 };
 
 struct InsertResult {
@@ -108,6 +114,7 @@ struct CacheOpSpec {
     std::string request_id;
     TreeNode* last_node{nullptr};
     std::vector<TreeNode*> nodes;
+    std::vector<TreeNode*> paged_cache_nodes;
 
     CacheOpSpec();
     ~CacheOpSpec();

--- a/tokenspeed-scheduler/csrc/scheduler/operations/cache.h
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/cache.h
@@ -90,9 +90,20 @@ struct TransferPairHash {
     }
 };
 
+struct PagedCacheTransferPair {
+    std::string group_id;
+    std::vector<std::int32_t> src_pages;
+    std::vector<std::int32_t> dst_pages;
+
+    bool operator==(const PagedCacheTransferPair& other) const {
+        return group_id == other.group_id && src_pages == other.src_pages && dst_pages == other.dst_pages;
+    }
+};
+
 struct WriteBackOperation {
     cache_op_id op_id{0};
-    std::vector<TransferPair> transfers;  // DEVICE→HOST by cache kind.
+    std::vector<TransferPair> transfers;                        // DEVICE→HOST by cache kind.
+    std::vector<PagedCacheTransferPair> paged_cache_transfers;  // DEVICE→HOST by paged-cache group.
     bool is_retract{false};
 
     WriteBackOperation() = default;
@@ -101,6 +112,12 @@ struct WriteBackOperation {
         : op_id{op_id}, transfers{ToTransferPairs(CacheKind::kKV, pages_to_transfer)}, is_retract{is_retract} {}
     WriteBackOperation(cache_op_id op_id, std::vector<TransferPair> transfers, bool is_retract = false)
         : op_id{op_id}, transfers{std::move(transfers)}, is_retract{is_retract} {}
+    WriteBackOperation(cache_op_id op_id, std::vector<TransferPair> transfers,
+                       std::vector<PagedCacheTransferPair> paged_cache_transfers, bool is_retract = false)
+        : op_id{op_id},
+          transfers{std::move(transfers)},
+          paged_cache_transfers{std::move(paged_cache_transfers)},
+          is_retract{is_retract} {}
 };
 
 struct FlatWriteBackOperation {
@@ -111,6 +128,8 @@ struct FlatWriteBackOperation {
     // Generic view keyed by CacheKindName(kind), currently "kv" and "mamba".
     std::map<std::string, std::vector<std::vector<std::int32_t>>> src_pages_by_kind;
     std::map<std::string, std::vector<std::vector<std::int32_t>>> dst_pages_by_kind;
+    // Indexed by op_ids; each item preserves the op's paged-cache group transfer specs.
+    std::vector<std::vector<PagedCacheTransferPair>> paged_cache_transfers;
     std::vector<bool> is_retract;
 
     explicit FlatWriteBackOperation(const std::vector<WriteBackOperation>& ops) {
@@ -140,6 +159,7 @@ struct FlatWriteBackOperation {
             for (auto& [kind, pages] : dst_this_op) {
                 dst_pages_by_kind[kind].push_back(std::move(pages));
             }
+            paged_cache_transfers.push_back(op.paged_cache_transfers);
             is_retract.push_back(op.is_retract);
         }
     }
@@ -147,13 +167,17 @@ struct FlatWriteBackOperation {
 
 struct LoadBackOperation {
     cache_op_id op_id{0};
-    std::vector<TransferPair> transfers;  // HOST→DEVICE by cache kind.
+    std::vector<TransferPair> transfers;                        // HOST→DEVICE by cache kind.
+    std::vector<PagedCacheTransferPair> paged_cache_transfers;  // HOST→DEVICE by paged-cache group.
 
     LoadBackOperation() = default;
     LoadBackOperation(cache_op_id op_id, std::vector<std::tuple<std::int32_t, std::int32_t>> pages_to_transfer)
         : op_id{op_id}, transfers{ToTransferPairs(CacheKind::kKV, pages_to_transfer)} {}
     LoadBackOperation(cache_op_id op_id, std::vector<TransferPair> transfers)
         : op_id{op_id}, transfers{std::move(transfers)} {}
+    LoadBackOperation(cache_op_id op_id, std::vector<TransferPair> transfers,
+                      std::vector<PagedCacheTransferPair> paged_cache_transfers)
+        : op_id{op_id}, transfers{std::move(transfers)}, paged_cache_transfers{std::move(paged_cache_transfers)} {}
 };
 
 struct FlatLoadBackOperation {
@@ -164,6 +188,8 @@ struct FlatLoadBackOperation {
     // Generic view keyed by CacheKindName(kind), currently "kv" and "mamba".
     std::map<std::string, std::vector<std::vector<std::int32_t>>> src_pages_by_kind;
     std::map<std::string, std::vector<std::vector<std::int32_t>>> dst_pages_by_kind;
+    // Indexed by op_ids; each item preserves the op's paged-cache group transfer specs.
+    std::vector<std::vector<PagedCacheTransferPair>> paged_cache_transfers;
 
     explicit FlatLoadBackOperation(const std::vector<LoadBackOperation>& ops) {
         std::unordered_set<TransferPair, TransferPairHash> seen;
@@ -192,6 +218,7 @@ struct FlatLoadBackOperation {
             for (auto& [kind, pages] : dst_this_op) {
                 dst_pages_by_kind[kind].push_back(std::move(pages));
             }
+            paged_cache_transfers.push_back(op.paged_cache_transfers);
         }
     }
 };

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -87,17 +87,29 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
     std::int32_t unscheduled = 0;
     std::vector<TreeNode*> loadback_diff;
     std::vector<TreeNode*> mamba_loadback_nodes;
+    std::vector<PagedCacheTransferPair> paged_cache_loadback_transfers;
 
     const std::int32_t device_matched = match_result.device.DepthInPage();
     const std::int32_t host_matched = match_result.host.DepthInPage();
+    const bool has_paged_cache = hybrid_prefix_cache_ && hybrid_prefix_cache_->HasPagedCacheAdjunct();
+    const std::int32_t paged_device_matched = match_result.paged_cache.prefix_len_tokens;
+    const std::int32_t paged_host_matched = disable_l2_cache ? 0 : match_result.paged_cache_host.prefix_len_tokens;
+    const bool use_paged_host_hit = has_paged_cache && paged_host_matched > paged_device_matched;
+    std::int32_t matched_prefix_len_tokens = 0;
     if (disable_l2_cache) {
-        unscheduled = request->PrefillSize() - device_matched * config_.page_size;
+        matched_prefix_len_tokens = device_matched * config_.page_size;
+        unscheduled = request->PrefillSize() - matched_prefix_len_tokens;
     } else {
         loadback_diff = match_result.NodesWithout<ResourceType::Device>();
         if (host_matched > device_matched) {
             loadback_tokens = config_.page_size * (host_matched - device_matched);
         }
-        unscheduled = request->PrefillSize() - std::max(device_matched, host_matched) * config_.page_size;
+        matched_prefix_len_tokens = has_paged_cache ? std::max(paged_device_matched, paged_host_matched)
+                                                    : std::max(device_matched, host_matched) * config_.page_size;
+        unscheduled = request->PrefillSize() - matched_prefix_len_tokens;
+    }
+    if (unscheduled < 0) {
+        unscheduled = 0;
     }
 
     std::int32_t tokens_this_round = std::min(remaining, unscheduled);
@@ -134,11 +146,22 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
         return {};
     }
 
-    const std::int32_t first_pos = request->PrefillSize() - unscheduled;
+    const std::int32_t first_pos =
+        disable_l2_cache ? request->PrefillSize() - unscheduled : matched_prefix_len_tokens;
     const std::int32_t target = first_pos + tokens_this_round;
+    const MatchResult::PagedCache empty_paged_hit{};
+    const MatchResult::PagedCache& paged_hit_for_admission =
+        use_paged_host_hit ? empty_paged_hit : match_result.paged_cache;
     if (hybrid_prefix_cache_ &&
-        !hybrid_prefix_cache_->AdmitChunk(request->Id(), first_pos, target, simulated_free, match_result.paged_cache)) {
+        !hybrid_prefix_cache_->AdmitChunk(request->Id(), first_pos, target, simulated_free, paged_hit_for_admission)) {
         return {};
+    }
+    if (use_paged_host_hit) {
+        paged_cache_loadback_transfers =
+            hybrid_prefix_cache_->PreparePagedCacheDeviceLoadBack(request->Id(), match_result.paged_cache_host);
+        if (paged_cache_loadback_transfers.empty()) {
+            return {};
+        }
     }
     if (needs_mamba_loadback) {
         hybrid_prefix_cache_->PrepareMambaDeviceLoadBack(mamba_loadback_nodes);
@@ -165,6 +188,8 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
         hybrid_prefix_cache_ ? &*hybrid_prefix_cache_ : nullptr,
         mamba_allocator_ ? &*mamba_allocator_ : nullptr,
         std::move(mamba_loadback_nodes),
+        std::move(paged_cache_loadback_transfers),
+        matched_prefix_len_tokens,
     };
 }
 
@@ -231,6 +256,12 @@ std::optional<fsm::ScheduleDecodeFromRetractedEvent> Scheduler::scheduleDecodeFr
             : kv_prefix_cache_.Match(request->GetFullPagedTokens(true), MatchIntent::StateRecovery);
     std::vector<TreeNode*> loadback_diff = match_result.NodesWithout<ResourceType::Device>();
     std::vector<TreeNode*> mamba_loadback_nodes;
+    std::vector<PagedCacheTransferPair> paged_cache_loadback_transfers;
+    const bool has_paged_cache = hybrid_prefix_cache_ && hybrid_prefix_cache_->HasPagedCacheAdjunct();
+    const std::int32_t paged_device_matched = match_result.paged_cache.prefix_len_tokens;
+    const std::int32_t paged_host_matched =
+        config_.disable_l2_cache ? 0 : match_result.paged_cache_host.prefix_len_tokens;
+    const bool use_paged_host_hit = has_paged_cache && paged_host_matched > paged_device_matched;
     TreeNode* mamba_recovery_node = nullptr;
     bool needs_mamba_loadback = false;
     if (hybrid_prefix_cache_ && mamba_allocator_) {
@@ -280,9 +311,20 @@ std::optional<fsm::ScheduleDecodeFromRetractedEvent> Scheduler::scheduleDecodeFr
     }
 
     const std::int32_t target = request->TokenSize();
+    const MatchResult::PagedCache empty_paged_hit{};
+    const MatchResult::PagedCache& paged_hit_for_admission =
+        use_paged_host_hit ? empty_paged_hit : match_result.paged_cache;
     if (hybrid_prefix_cache_ && !hybrid_prefix_cache_->AdmitChunkFromRetracted(request->Id(), target, simulated_free,
-                                                                               match_result.paged_cache)) {
+                                                                               paged_hit_for_admission)) {
         return {};
+    }
+    if (use_paged_host_hit) {
+        hybrid_prefix_cache_->ReleaseRequest(request->Id());
+        paged_cache_loadback_transfers =
+            hybrid_prefix_cache_->PreparePagedCacheDeviceLoadBack(request->Id(), match_result.paged_cache_host);
+        if (paged_cache_loadback_transfers.empty()) {
+            return {};
+        }
     }
     if (needs_mamba_loadback) {
         hybrid_prefix_cache_->PrepareMambaDeviceLoadBack(mamba_loadback_nodes);
@@ -300,6 +342,7 @@ std::optional<fsm::ScheduleDecodeFromRetractedEvent> Scheduler::scheduleDecodeFr
         loadback_diff,
         mamba_allocator_ ? &*mamba_allocator_ : nullptr,
         std::move(mamba_loadback_nodes),
+        std::move(paged_cache_loadback_transfers),
     };
 }
 
@@ -339,6 +382,7 @@ std::optional<fsm::ScheduleRetractEvent> Scheduler::scheduleRetract(Request* req
 }
 
 LoadBackOperation GenerateLoadBackOp(const std::vector<TreeNode*>& diff, const std::vector<TreeNode*>& mamba_nodes,
+                                     const std::vector<PagedCacheTransferPair>& paged_cache_transfers,
                                      cache_op_id op_id) {
     std::vector<TransferPair> transfers;
 
@@ -354,7 +398,9 @@ LoadBackOperation GenerateLoadBackOp(const std::vector<TreeNode*>& diff, const s
             transfers.push_back(TransferPair{CacheKind::kMamba, node->MambaHostSlotIndex(), node->MambaSlotIndex()});
         }
     }
-    return LoadBackOperation{op_id, std::move(transfers)};
+    return LoadBackOperation{
+        op_id, std::move(transfers),
+        std::vector<PagedCacheTransferPair>(paged_cache_transfers.begin(), paged_cache_transfers.end())};
 }
 
 std::optional<WriteBackOperation> Scheduler::applyEventAndGenerateOp(Request* request,
@@ -363,7 +409,8 @@ std::optional<WriteBackOperation> Scheduler::applyEventAndGenerateOp(Request* re
     request->Apply(std::move(event));
 
     const auto& pages_to_transfer = request->GetPagesToTransfer<fsm::Retracting>();
-    if (pages_to_transfer.empty()) {
+    const auto& paged_cache_transfers = request->GetPagedCacheWriteBackTransfers<fsm::Retracting>();
+    if (pages_to_transfer.empty() && paged_cache_transfers.empty()) {
         // No copy needed; advance Retracting to Retracted without an op_id.
         request->Apply(
             fsm::WriteBackDoneEvent{&kv_prefix_cache_, hybrid_prefix_cache_ ? &*hybrid_prefix_cache_ : nullptr});
@@ -373,9 +420,11 @@ std::optional<WriteBackOperation> Scheduler::applyEventAndGenerateOp(Request* re
     cache_op_id op_id = kv_prefix_cache_.AllocateCacheOpId();
     CacheOpSpec spec;
     spec.request_id = request->Id();
+    spec.paged_cache_nodes = request->GetPagedCacheWriteBackNodes<fsm::Retracting>();
     cache_op_tracker_[op_id] = std::move(spec);
-    return WriteBackOperation{op_id, std::vector<TransferPair>(pages_to_transfer.begin(), pages_to_transfer.end()),
-                              true};
+    return WriteBackOperation{
+        op_id, std::vector<TransferPair>(pages_to_transfer.begin(), pages_to_transfer.end()),
+        std::vector<PagedCacheTransferPair>(paged_cache_transfers.begin(), paged_cache_transfers.end()), true};
 }
 
 std::optional<WriteBackOperation> Scheduler::newRetractOperation(Request* retract_request) {
@@ -510,6 +559,7 @@ DecodeOperation Scheduler::applyEventAndGenerateOp(Request* request, fsm::Schedu
 DecodeOperation Scheduler::applyEventAndGenerateOp(Request* request, fsm::ScheduleDecodeFromRetractedEvent event) {
     const std::int32_t mamba_cow_src_index = event.GetMatchResult().mamba_cow_src_index;
     auto paged_cache_hit = event.GetMatchResult().paged_cache;
+    const bool has_paged_cache_loadback = !event.GetPagedCacheLoadbackTransfers().empty();
     request->Apply(std::move(event));
     if (!request->Is<fsm::Decoding>()) {
         throw std::logic_error(
@@ -539,7 +589,9 @@ DecodeOperation Scheduler::applyEventAndGenerateOp(Request* request, fsm::Schedu
     }
 
     if (hybrid_prefix_cache_) {
-        hybrid_prefix_cache_->ReleaseRequest(op.request_id);
+        if (!has_paged_cache_loadback) {
+            hybrid_prefix_cache_->ReleaseRequest(op.request_id);
+        }
         hybrid_prefix_cache_->AcquireForRequest(op.request_id, 0, request->TokenSize(), paged_cache_hit);
         hybrid_prefix_cache_->PopulateOp(op);
     }
@@ -601,11 +653,15 @@ Scheduler::newForwardOperation(std::vector<Request*> candidates) {
                                                     config_.disable_l2_cache, simulated_free)) {
                 std::vector<TreeNode*> loadback_diff = ev->GetLoadbackDiff();
                 std::vector<TreeNode*> mamba_loadback_nodes = ev->GetMambaLoadbackNodes();
+                std::vector<PagedCacheTransferPair> paged_cache_loadback_transfers =
+                    ev->GetPagedCacheLoadbackTransfers();
                 push_op(applyEventAndGenerateOp(request, std::move(*ev)), true);
                 // will be empty when disable_l2_cache
-                if (!loadback_diff.empty() || !mamba_loadback_nodes.empty()) {
+                if (!loadback_diff.empty() || !mamba_loadback_nodes.empty() ||
+                    !paged_cache_loadback_transfers.empty()) {
                     cache_op_id op_id = kv_prefix_cache_.AllocateCacheOpId();
-                    loadback_ops.push_back(GenerateLoadBackOp(loadback_diff, mamba_loadback_nodes, op_id));
+                    loadback_ops.push_back(
+                        GenerateLoadBackOp(loadback_diff, mamba_loadback_nodes, paged_cache_loadback_transfers, op_id));
                 }
             }
         } else if (request->Is<fsm::PrefillDone>() || (request->Is<fsm::Decoding>() && config_.role != Role::kP)) {
@@ -623,10 +679,14 @@ Scheduler::newForwardOperation(std::vector<Request*> candidates) {
             if (auto ev = scheduleDecodeFromRetracted(request, simulated_free)) {
                 std::vector<TreeNode*> loadback_diff = ev->GetLoadbackDiff();
                 std::vector<TreeNode*> mamba_loadback_nodes = ev->GetMambaLoadbackNodes();
+                std::vector<PagedCacheTransferPair> paged_cache_loadback_transfers =
+                    ev->GetPagedCacheLoadbackTransfers();
                 push_op(applyEventAndGenerateOp(request, std::move(*ev)));
-                if (!loadback_diff.empty() || !mamba_loadback_nodes.empty()) {
+                if (!loadback_diff.empty() || !mamba_loadback_nodes.empty() ||
+                    !paged_cache_loadback_transfers.empty()) {
                     cache_op_id op_id = kv_prefix_cache_.AllocateCacheOpId();
-                    loadback_ops.push_back(GenerateLoadBackOp(loadback_diff, mamba_loadback_nodes, op_id));
+                    loadback_ops.push_back(
+                        GenerateLoadBackOp(loadback_diff, mamba_loadback_nodes, paged_cache_loadback_transfers, op_id));
                 }
             }
         }

--- a/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
@@ -155,9 +155,13 @@ void Scheduler::handleEvent(const cache::WriteBackDone& event) {
 
     if (!spec.request_id.empty()) {
         if (auto* req = find_request(spec.request_id)) {
-            req->Apply(
-                fsm::WriteBackDoneEvent{&kv_prefix_cache_, hybrid_prefix_cache_ ? &*hybrid_prefix_cache_ : nullptr});
+            req->Apply(fsm::WriteBackDoneEvent{&kv_prefix_cache_,
+                                               hybrid_prefix_cache_ ? &*hybrid_prefix_cache_ : nullptr, event.success});
+            return;
         }
+    }
+    if (hybrid_prefix_cache_ && !spec.paged_cache_nodes.empty()) {
+        hybrid_prefix_cache_->OnPagedCacheHostWriteBackDone(spec.paged_cache_nodes, event.success);
     }
 }
 

--- a/tokenspeed-scheduler/csrc/scheduler/request.h
+++ b/tokenspeed-scheduler/csrc/scheduler/request.h
@@ -271,6 +271,36 @@ public:
             state_);
     }
 
+    template <typename S>
+        requires(std::same_as<S, fsm::Draining> || std::same_as<S, fsm::Retracting>)
+    const std::vector<PagedCacheTransferPair>& GetPagedCacheWriteBackTransfers() const {
+        return std::visit(Overloaded{
+            []<typename T>(const T& s) -> const std::vector<PagedCacheTransferPair>&
+                requires(std::same_as<T, S>)
+            { return s.GetPagedCacheWriteBackTransfers(); },
+            [this](const auto&) -> const std::vector<PagedCacheTransferPair>& {
+                throw std::logic_error("Request::GetPagedCacheWriteBackTransfers: expected state=" +
+                                       std::string(detail::TypeName<S>()) + "; got state=" + StateName());
+            },
+            },
+            state_);
+    }
+
+    template <typename S>
+        requires(std::same_as<S, fsm::Draining> || std::same_as<S, fsm::Retracting>)
+    const std::vector<TreeNode*>& GetPagedCacheWriteBackNodes() const {
+        return std::visit(Overloaded{
+            []<typename T>(const T& s) -> const std::vector<TreeNode*>&
+                requires(std::same_as<T, S>)
+            { return s.PagedCacheWriteBackNodes(); },
+            [this](const auto&) -> const std::vector<TreeNode*>& {
+                throw std::logic_error("Request::GetPagedCacheWriteBackNodes: expected state=" +
+                                       std::string(detail::TypeName<S>()) + "; got state=" + StateName());
+            },
+            },
+            state_);
+    }
+
 private:
     std::string id_;
     TokenContainer token_container_;

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -104,6 +104,25 @@ Scheduler::Scheduler(SchedulerConfig config)
             copy.Validate();
             hybrid_prefix_cache_->RegisterPagedCacheGroup(std::make_unique<PagedCacheGroupAllocator>(std::move(copy)));
         }
+        std::unordered_set<std::string> registered_paged_group_ids;
+        for (const auto& cfg : config_.paged_cache_groups) {
+            registered_paged_group_ids.insert(cfg.group_id);
+            auto host_it = config_.paged_cache_host_group_pages.find(cfg.group_id);
+            if (host_it == config_.paged_cache_host_group_pages.end() || host_it->second <= 0) {
+                continue;
+            }
+            PagedCacheGroupConfig host_copy = cfg;
+            host_copy.total_pages = host_it->second;
+            host_copy.Validate();
+            hybrid_prefix_cache_->RegisterPagedCacheHostGroup(
+                std::make_unique<PagedCacheGroupAllocator>(std::move(host_copy)));
+        }
+        for (const auto& [gid, _] : config_.paged_cache_host_group_pages) {
+            if (registered_paged_group_ids.find(gid) == registered_paged_group_ids.end()) {
+                throw std::invalid_argument("Scheduler: paged_cache_host_group_pages references unknown group_id '" +
+                                            gid + "'");
+            }
+        }
 
         if (has_prefix_cache_adjunct) {
             const auto& spec = *config_.prefix_cache_adjunct;
@@ -218,6 +237,10 @@ std::size_t Scheduler::AvailableKvPages() const {
     return device_allocator_.AvailablePages();
 }
 
+std::size_t Scheduler::AvailableHostKvPages() const {
+    return host_allocator_.AvailablePages();
+}
+
 std::size_t Scheduler::ActiveKvPages() const {
     std::unordered_set<std::int32_t> active_pages;
     for (const auto& [_, req] : requests_) {
@@ -256,6 +279,27 @@ std::int64_t Scheduler::PagedCacheGroupFailedAllocCount(const std::string& group
     return hybrid_prefix_cache_->PagedCacheGroupFailedAllocCount(group_id);
 }
 
+std::int32_t Scheduler::PagedCacheHostGroupTotalPages(const std::string& group_id) const {
+    if (!hybrid_prefix_cache_) {
+        throw std::out_of_range("Scheduler::PagedCacheHostGroupTotalPages: group_id not configured");
+    }
+    return hybrid_prefix_cache_->PagedCacheHostGroupTotalPages(group_id);
+}
+
+std::int32_t Scheduler::PagedCacheHostGroupAvailablePages(const std::string& group_id) const {
+    if (!hybrid_prefix_cache_) {
+        throw std::out_of_range("Scheduler::PagedCacheHostGroupAvailablePages: group_id not configured");
+    }
+    return hybrid_prefix_cache_->PagedCacheHostGroupAvailablePages(group_id);
+}
+
+std::int64_t Scheduler::PagedCacheHostGroupFailedAllocCount(const std::string& group_id) const {
+    if (!hybrid_prefix_cache_) {
+        throw std::out_of_range("Scheduler::PagedCacheHostGroupFailedAllocCount: group_id not configured");
+    }
+    return hybrid_prefix_cache_->PagedCacheHostGroupFailedAllocCount(group_id);
+}
+
 std::vector<std::int32_t> Scheduler::GetRequestPagedCachePageIds(const std::string& request_id,
                                                                  const std::string& group_id) const {
     if (!hybrid_prefix_cache_) {
@@ -289,14 +333,17 @@ std::vector<WriteBackOperation> Scheduler::newWriteBackOperation(
     for (auto& [id, req] : requests) {
         if (!req->Is<fsm::Draining>()) continue;
         const auto& pages_to_transfer = req->GetPagesToTransfer<fsm::Draining>();
+        const auto& paged_cache_transfers = req->GetPagedCacheWriteBackTransfers<fsm::Draining>();
 
-        if (!pages_to_transfer.empty()) {
+        if (!pages_to_transfer.empty() || !paged_cache_transfers.empty()) {
             cache_op_id op_id = kv_prefix_cache_.AllocateCacheOpId();
             CacheOpSpec spec;
             spec.request_id = id;
+            spec.paged_cache_nodes = req->GetPagedCacheWriteBackNodes<fsm::Draining>();
             cache_op_tracker_[op_id] = std::move(spec);
             ops.push_back(WriteBackOperation{
-                op_id, std::vector<TransferPair>(pages_to_transfer.begin(), pages_to_transfer.end())});
+                op_id, std::vector<TransferPair>(pages_to_transfer.begin(), pages_to_transfer.end()),
+                std::vector<PagedCacheTransferPair>(paged_cache_transfers.begin(), paged_cache_transfers.end())});
             req->Apply(fsm::CommitDrainingEvent{});
         } else {
             req->Apply(fsm::AbortEvent{});

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.h
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.h
@@ -65,6 +65,7 @@ public:
     std::size_t DecodingSize() const;
     std::size_t RetractedSize() const;
     std::size_t AvailableKvPages() const;
+    std::size_t AvailableHostKvPages() const;
     std::size_t ActiveKvPages() const;
     std::size_t PrefillSize() const;
     std::int32_t GetRequestTokenSize(const std::string& id) const;
@@ -72,6 +73,9 @@ public:
     std::int32_t PagedCacheGroupTotalPages(const std::string& group_id) const;
     std::int32_t PagedCacheGroupAvailablePages(const std::string& group_id) const;
     std::int64_t PagedCacheGroupFailedAllocCount(const std::string& group_id) const;
+    std::int32_t PagedCacheHostGroupTotalPages(const std::string& group_id) const;
+    std::int32_t PagedCacheHostGroupAvailablePages(const std::string& group_id) const;
+    std::int64_t PagedCacheHostGroupFailedAllocCount(const std::string& group_id) const;
     std::vector<std::int32_t> GetRequestPagedCachePageIds(const std::string& request_id,
                                                           const std::string& group_id) const;
     // Compact-view base logical-page offset; 0 for full-history / unseen.

--- a/tokenspeed-scheduler/csrc/scheduler/types.h
+++ b/tokenspeed-scheduler/csrc/scheduler/types.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <optional>
+#include <map>
 #include <unordered_map>
 #include <variant>
 #include <cstdint>
@@ -84,6 +85,7 @@ struct SchedulerConfig {
     } device_allocator;
 
     std::vector<PagedCacheGroupConfig> paged_cache_groups{};
+    std::map<std::string, std::int32_t> paged_cache_host_group_pages{};
 
     // Unset means paged-cache groups are transport-only.
     std::optional<PrefixCacheAdjunctSpec> prefix_cache_adjunct{};

--- a/tokenspeed-scheduler/tests/cpp/test_cache_operation_kinds.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_operation_kinds.cpp
@@ -25,6 +25,32 @@ TEST(CacheOperationKindTest, FlatWriteBackBucketsTransfersByKind) {
     EXPECT_EQ(flat.dst_pages_by_kind.at("mamba")[0], std::vector<std::int32_t>({22, 23}));
 }
 
+TEST(CacheOperationKindTest, FlatWriteBackPreservesPagedCacheTransfersByOp) {
+    WriteBackOperation first;
+    first.op_id = 7;
+    first.paged_cache_transfers = {
+        PagedCacheTransferPair{"v4.c4a.compressed_kv", {1, 2}, {101, 102}},
+        PagedCacheTransferPair{"v4.swa_kv", {3}, {103}},
+    };
+    WriteBackOperation second;
+    second.op_id = 8;
+    second.paged_cache_transfers = {
+        PagedCacheTransferPair{"v4.c128a.compressed_kv", {4}, {104}},
+    };
+
+    FlatWriteBackOperation flat({first, second});
+
+    ASSERT_EQ(flat.op_ids, std::vector<cache_op_id>({7, 8}));
+    ASSERT_EQ(flat.paged_cache_transfers.size(), 2u);
+    ASSERT_EQ(flat.paged_cache_transfers[0].size(), 2u);
+    EXPECT_EQ(flat.paged_cache_transfers[0][0].group_id, "v4.c4a.compressed_kv");
+    EXPECT_EQ(flat.paged_cache_transfers[0][0].src_pages, std::vector<std::int32_t>({1, 2}));
+    EXPECT_EQ(flat.paged_cache_transfers[0][0].dst_pages, std::vector<std::int32_t>({101, 102}));
+    EXPECT_EQ(flat.paged_cache_transfers[0][1].group_id, "v4.swa_kv");
+    ASSERT_EQ(flat.paged_cache_transfers[1].size(), 1u);
+    EXPECT_EQ(flat.paged_cache_transfers[1][0].group_id, "v4.c128a.compressed_kv");
+}
+
 TEST(CacheOperationKindTest, FlatLoadBackBucketsTransfersByKind) {
     LoadBackOperation op;
     op.op_id = 9;
@@ -42,6 +68,25 @@ TEST(CacheOperationKindTest, FlatLoadBackBucketsTransfersByKind) {
     EXPECT_EQ(flat.dst_pages_by_kind.at("kv")[0], std::vector<std::int32_t>({20}));
     EXPECT_EQ(flat.src_pages_by_kind.at("mamba")[0], std::vector<std::int32_t>({30}));
     EXPECT_EQ(flat.dst_pages_by_kind.at("mamba")[0], std::vector<std::int32_t>({40}));
+}
+
+TEST(CacheOperationKindTest, FlatLoadBackPreservesPagedCacheTransfersByOp) {
+    LoadBackOperation op;
+    op.op_id = 9;
+    op.paged_cache_transfers = {
+        PagedCacheTransferPair{"v4.c4a.compressed_kv", {101, 102}, {1, 2}},
+        PagedCacheTransferPair{"v4.c4a.indexer_compressor_state", {103}, {3}},
+    };
+
+    FlatLoadBackOperation flat({op});
+
+    ASSERT_EQ(flat.op_ids, std::vector<cache_op_id>({9}));
+    ASSERT_EQ(flat.paged_cache_transfers.size(), 1u);
+    ASSERT_EQ(flat.paged_cache_transfers[0].size(), 2u);
+    EXPECT_EQ(flat.paged_cache_transfers[0][0].group_id, "v4.c4a.compressed_kv");
+    EXPECT_EQ(flat.paged_cache_transfers[0][0].src_pages, std::vector<std::int32_t>({101, 102}));
+    EXPECT_EQ(flat.paged_cache_transfers[0][0].dst_pages, std::vector<std::int32_t>({1, 2}));
+    EXPECT_EQ(flat.paged_cache_transfers[0][1].group_id, "v4.c4a.indexer_compressor_state");
 }
 
 }  // namespace tokenspeed::test

--- a/tokenspeed-scheduler/tests/cpp/test_paged_cache_l2_offload.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_paged_cache_l2_offload.cpp
@@ -1,0 +1,436 @@
+// Copyright (c) 2026 LightSeek Foundation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "paged_cache_test_fixture.h"
+#include "integration_test_helper.h"
+#include "resource/radix_tree/tree_resource.h"
+#include "scheduler/operations/forward.h"
+
+#include <map>
+#include <set>
+
+namespace tokenspeed::test {
+
+class PagedCacheL2OffloadTest : public PagedCacheSmallFixture {
+protected:
+    void SetUp() override {
+        PagedCacheSmallFixture::SetUp();
+
+        auto fh_host_cfg = MakeGroupConfig("fh", kSmallFixtureParams.fh_rows_per_page, kSmallFixtureParams.fh_stride,
+                                           PagedCacheGroupConfig::Retention::FullHistory, /*window=*/0,
+                                           PagedCacheGroupFamily::History);
+        fh_host_cfg.total_pages = 3;
+        auto swa_host_cfg = MakeGroupConfig(
+            "swa", kSmallFixtureParams.swa_rows_per_page, kSmallFixtureParams.swa_stride,
+            PagedCacheGroupConfig::Retention::SlidingWindow, kSlidingWindow, PagedCacheGroupFamily::State);
+        swa_host_cfg.total_pages = 3;
+        auto fh_host = std::make_unique<PagedCacheGroupAllocator>(std::move(fh_host_cfg));
+        auto swa_host = std::make_unique<PagedCacheGroupAllocator>(std::move(swa_host_cfg));
+        hybrid_->RegisterPagedCacheHostGroup(std::move(fh_host));
+        hybrid_->RegisterPagedCacheHostGroup(std::move(swa_host));
+    }
+
+    TreeNode* SeedCompleteDeviceSnapshot() {
+        TreeNode* terminal = InsertDevicePages(/*num_pages=*/2, /*token_start=*/1);
+        EXPECT_NE(terminal, nullptr);
+        hybrid_->AttachPagedCacheSnapshotToNode(terminal, MakeCompleteSnapshot(kLcm));
+        return terminal;
+    }
+
+    TreeNode* SeedCompleteDeviceSnapshot(token_t token_start) {
+        TreeNode* terminal = InsertDevicePages(/*num_pages=*/2, token_start);
+        EXPECT_NE(terminal, nullptr);
+        hybrid_->AttachPagedCacheSnapshotToNode(terminal, MakeCompleteSnapshot(kLcm));
+        return terminal;
+    }
+
+    void AttachHostResource(TreeNode* node) {
+        ASSERT_NE(node, nullptr);
+        node->AttachResource<ResourceType::Host>(std::make_unique<NodeResource<ResourceType::Host>>(OwnedPages{}));
+    }
+};
+
+class PagedCacheL2SchedulerTest : public SchedulerTestSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        auto cfg = SchedulerTestSuite::MakeConfig();
+        cfg.page_size = kSmallFixtureParams.page_size;
+        cfg.device_allocator.total_pages = 32;
+        cfg.host_allocator.total_pages = 32;
+        cfg.max_scheduled_tokens = 64;
+        cfg.max_batch_size = 8;
+        cfg.enable_l3_storage = false;
+        cfg.disable_l2_cache = false;
+
+        cfg.paged_cache_groups = {
+            MakeSchedulerGroup("fh", kSmallFixtureParams.fh_rows_per_page, kSmallFixtureParams.fh_stride,
+                               PagedCacheGroupConfig::Retention::FullHistory, /*window=*/0,
+                               PagedCacheGroupFamily::History),
+            MakeSchedulerGroup("swa", kSmallFixtureParams.swa_rows_per_page, kSmallFixtureParams.swa_stride,
+                               PagedCacheGroupConfig::Retention::SlidingWindow,
+                               kSmallFixtureParams.sliding_window_tokens, PagedCacheGroupFamily::State),
+        };
+        cfg.paged_cache_host_group_pages = {{"fh", 16}, {"swa", 16}};
+        PrefixCacheAdjunctSpec adjunct;
+        adjunct.required_groups = {"fh", "swa"};
+        cfg.prefix_cache_adjunct = adjunct;
+        return cfg;
+    }
+
+    static PagedCacheGroupConfig MakeSchedulerGroup(std::string group_id, std::int32_t rows_per_page,
+                                                    std::int32_t stride, PagedCacheGroupConfig::Retention retention,
+                                                    std::int32_t window, PagedCacheGroupFamily family) {
+        PagedCacheGroupConfig cfg{};
+        cfg.group_id = std::move(group_id);
+        cfg.rows_per_page = rows_per_page;
+        cfg.entry_stride_tokens = stride;
+        cfg.total_pages = 16;
+        cfg.retention = retention;
+        if (retention == PagedCacheGroupConfig::Retention::SlidingWindow) {
+            cfg.sliding_window_tokens = window;
+        }
+        cfg.family = family;
+        return cfg;
+    }
+
+    void BringToDecoding(const std::string& id, token_t start = 1) {
+        Submit(MakeRequestSpec(id, /*num_pages=*/2, start));
+        PlanOnce();
+        SendForwardDone(id, {42});
+        PlanOnce();
+    }
+
+    static const FlatWriteBackOperation* GetWriteBack(const ExecutionPlan& plan) {
+        for (const auto& op : plan.Operations()) {
+            if (auto* cache_op = std::get_if<CacheOperation>(&op)) {
+                if (auto* wb = std::get_if<FlatWriteBackOperation>(cache_op)) {
+                    return wb;
+                }
+            }
+        }
+        return nullptr;
+    }
+
+    static const FlatLoadBackOperation* GetLoadBack(const ExecutionPlan& plan) {
+        for (const auto& op : plan.Operations()) {
+            if (auto* cache_op = std::get_if<CacheOperation>(&op)) {
+                if (auto* lb = std::get_if<FlatLoadBackOperation>(cache_op)) {
+                    return lb;
+                }
+            }
+        }
+        return nullptr;
+    }
+
+    static const FlatForwardOperation* GetForward(const ExecutionPlan& plan) {
+        for (const auto& op : plan.Operations()) {
+            if (auto* fwd = std::get_if<FlatForwardOperation>(&op)) {
+                return fwd;
+            }
+        }
+        return nullptr;
+    }
+
+    static std::map<std::string, std::int32_t> UniqueDstPagesByGroup(const FlatWriteBackOperation& writeback) {
+        std::map<std::string, std::set<std::int32_t>> pages_by_group;
+        for (const auto& transfers : writeback.paged_cache_transfers) {
+            for (const auto& transfer : transfers) {
+                auto& pages = pages_by_group[transfer.group_id];
+                pages.insert(transfer.dst_pages.begin(), transfer.dst_pages.end());
+            }
+        }
+        std::map<std::string, std::int32_t> counts;
+        for (const auto& [group_id, pages] : pages_by_group) {
+            counts[group_id] = static_cast<std::int32_t>(pages.size());
+        }
+        return counts;
+    }
+
+    static std::int32_t UniqueKvDstPages(const FlatWriteBackOperation& writeback) {
+        std::set<std::int32_t> pages;
+        for (const auto& op_pages : writeback.dst_pages) {
+            pages.insert(op_pages.begin(), op_pages.end());
+        }
+        return static_cast<std::int32_t>(pages.size());
+    }
+};
+
+TEST_F(PagedCacheL2OffloadTest, PendingHostSnapshotInvisibleUntilWriteBackAck) {
+    TreeNode* terminal = SeedCompleteDeviceSnapshot();
+    ASSERT_NE(terminal, nullptr);
+    AttachHostResource(terminal);
+    const auto tokens = MakeAlignedTokens(/*num_pages=*/2, kPageSize, /*start=*/1);
+
+    auto transfers = hybrid_->PreparePagedCacheHostWriteBack({terminal});
+    ASSERT_EQ(transfers.size(), 2u);
+    EXPECT_TRUE(terminal->HasPagedCachePendingHostSnapshot());
+    EXPECT_FALSE(terminal->HasPagedCacheHostSnapshot());
+
+    auto pending_match = hybrid_->Match(tokens);
+    EXPECT_EQ(pending_match.paged_cache_host.last_node, nullptr);
+    EXPECT_EQ(pending_match.paged_cache_host.prefix_len_tokens, 0);
+
+    hybrid_->OnPagedCacheHostWriteBackDone({terminal}, /*success=*/true);
+    EXPECT_FALSE(terminal->HasPagedCachePendingHostSnapshot());
+    ASSERT_TRUE(terminal->HasPagedCacheHostSnapshot());
+
+    auto visible_match = hybrid_->Match(tokens);
+    ASSERT_NE(visible_match.paged_cache_host.last_node, nullptr);
+    EXPECT_EQ(visible_match.paged_cache_host.last_node, terminal);
+    EXPECT_EQ(visible_match.paged_cache_host.prefix_len_tokens, kLcm);
+}
+
+TEST_F(PagedCacheL2OffloadTest, FailedHostWriteBackReleasesPendingSnapshotWithoutPublishing) {
+    TreeNode* terminal = SeedCompleteDeviceSnapshot();
+    ASSERT_NE(terminal, nullptr);
+    AttachHostResource(terminal);
+    const auto tokens = MakeAlignedTokens(/*num_pages=*/2, kPageSize, /*start=*/1);
+    const std::int32_t fh_before = hybrid_->PagedCacheHostGroupAvailablePages("fh");
+    const std::int32_t swa_before = hybrid_->PagedCacheHostGroupAvailablePages("swa");
+
+    auto transfers = hybrid_->PreparePagedCacheHostWriteBack({terminal});
+    ASSERT_FALSE(transfers.empty());
+    ASSERT_TRUE(terminal->HasPagedCachePendingHostSnapshot());
+    ASSERT_LT(hybrid_->PagedCacheHostGroupAvailablePages("fh"), fh_before);
+    ASSERT_LT(hybrid_->PagedCacheHostGroupAvailablePages("swa"), swa_before);
+
+    hybrid_->OnPagedCacheHostWriteBackDone({terminal}, /*success=*/false);
+
+    EXPECT_FALSE(terminal->HasPagedCachePendingHostSnapshot());
+    EXPECT_FALSE(terminal->HasPagedCacheHostSnapshot());
+    EXPECT_TRUE(terminal->HasPagedCacheSnapshot());
+    EXPECT_EQ(hybrid_->PagedCacheHostGroupAvailablePages("fh"), fh_before);
+    EXPECT_EQ(hybrid_->PagedCacheHostGroupAvailablePages("swa"), swa_before);
+    auto match = hybrid_->Match(tokens);
+    EXPECT_EQ(match.paged_cache_host.last_node, nullptr);
+    EXPECT_EQ(match.paged_cache_host.prefix_len_tokens, 0);
+}
+
+TEST_F(PagedCacheL2OffloadTest, HostHitMaterializesDeviceDestinationPagesForForwardMetadata) {
+    TreeNode* terminal = SeedCompleteDeviceSnapshot();
+    ASSERT_NE(terminal, nullptr);
+    AttachHostResource(terminal);
+    auto writeback = hybrid_->PreparePagedCacheHostWriteBack({terminal});
+    ASSERT_FALSE(writeback.empty());
+    hybrid_->OnPagedCacheHostWriteBackDone({terminal}, /*success=*/true);
+    auto detached_device = hybrid_->DetachPagedCacheSnapshotFromNode(terminal);
+    ASSERT_NE(detached_device, nullptr);
+
+    const auto tokens = MakeAlignedTokens(/*num_pages=*/2, kPageSize, /*start=*/1);
+    auto match = hybrid_->Match(tokens);
+    ASSERT_EQ(match.paged_cache.last_node, nullptr);
+    ASSERT_NE(match.paged_cache_host.last_node, nullptr);
+
+    auto loadback = hybrid_->PreparePagedCacheDeviceLoadBack("r-load", match.paged_cache_host);
+    ASSERT_EQ(loadback.size(), 2u);
+
+    PrefillOperation op{{
+        .request_id = "r-load",
+        .request_pool_index = 0,
+        .input_length = 0,
+        .occupied_pages = {},
+        .begin = 0,
+        .size = 0,
+        .prefill_length = kLcm,
+    }};
+    hybrid_->AcquireForRequest("r-load", /*first_raw_position_of_op=*/0, /*target_raw_tokens_exclusive=*/kLcm);
+    hybrid_->PopulateOp(op);
+
+    for (const auto& transfer : loadback) {
+        auto pages_it = op.paged_cache_pages.find(transfer.group_id);
+        ASSERT_NE(pages_it, op.paged_cache_pages.end()) << transfer.group_id;
+        EXPECT_EQ(pages_it->second, transfer.dst_pages) << transfer.group_id;
+    }
+
+    hybrid_->ReleaseRequest("r-load");
+}
+
+TEST_F(PagedCacheL2OffloadTest, HostStateRecoveryRequiresExactTerminalStateCompleteness) {
+    TreeNode* terminal = SeedCompleteDeviceSnapshot();
+    ASSERT_NE(terminal, nullptr);
+    AttachHostResource(terminal);
+    auto writeback = hybrid_->PreparePagedCacheHostWriteBack({terminal});
+    ASSERT_FALSE(writeback.empty());
+    hybrid_->OnPagedCacheHostWriteBackDone({terminal}, /*success=*/true);
+    auto detached_device = hybrid_->DetachPagedCacheSnapshotFromNode(terminal);
+    ASSERT_NE(detached_device, nullptr);
+
+    const auto tokens = MakeAlignedTokens(/*num_pages=*/2, kPageSize, /*start=*/1);
+    auto match = hybrid_->Match(tokens, MatchIntent::StateRecovery);
+
+    ASSERT_EQ(match.paged_cache.last_node, nullptr);
+    ASSERT_NE(match.paged_cache_host.last_node, nullptr);
+    EXPECT_EQ(match.paged_cache_host.last_node, terminal);
+    EXPECT_EQ(match.paged_cache_host.prefix_len_tokens, kLcm);
+}
+
+TEST_F(PagedCacheL2OffloadTest, HostStateRecoveryCapsWhenTerminalStateGroupMissing) {
+    TreeNode* terminal = SeedCompleteDeviceSnapshot();
+    ASSERT_NE(terminal, nullptr);
+    AttachHostResource(terminal);
+    auto writeback = hybrid_->PreparePagedCacheHostWriteBack({terminal});
+    ASSERT_FALSE(writeback.empty());
+    hybrid_->OnPagedCacheHostWriteBackDone({terminal}, /*success=*/true);
+    auto detached_device = hybrid_->DetachPagedCacheSnapshotFromNode(terminal);
+    ASSERT_NE(detached_device, nullptr);
+
+    auto host_snapshot = hybrid_->DetachPagedCacheHostSnapshotFromNode(terminal);
+    ASSERT_NE(host_snapshot, nullptr);
+    host_snapshot->groups.erase("swa");
+    ASSERT_TRUE(hybrid_->AttachPagedCacheHostSnapshotToNode(terminal, std::move(host_snapshot)));
+
+    const auto tokens = MakeAlignedTokens(/*num_pages=*/2, kPageSize, /*start=*/1);
+    auto match = hybrid_->Match(tokens, MatchIntent::StateRecovery);
+
+    EXPECT_EQ(match.paged_cache.last_node, nullptr);
+    EXPECT_EQ(match.paged_cache_host.last_node, nullptr);
+    ASSERT_NE(match.device.last_node, nullptr);
+    EXPECT_TRUE(match.device.last_node->IsRoot());
+    ASSERT_NE(match.host.last_node, nullptr);
+    EXPECT_TRUE(match.host.last_node->IsRoot());
+}
+
+TEST_F(PagedCacheL2OffloadTest, KVHostEvictReleasesPagedCacheHostSnapshotPages) {
+    TreeNode* terminal = SeedCompleteDeviceSnapshot();
+    ASSERT_NE(terminal, nullptr);
+    AttachHostResource(terminal);
+    auto writeback = hybrid_->PreparePagedCacheHostWriteBack({terminal});
+    ASSERT_FALSE(writeback.empty());
+    hybrid_->OnPagedCacheHostWriteBackDone({terminal}, /*success=*/true);
+    ASSERT_TRUE(terminal->HasPagedCacheHostSnapshot());
+    EXPECT_EQ(hybrid_->PagedCacheHostGroupAvailablePages("fh"), 1);
+    EXPECT_EQ(hybrid_->PagedCacheHostGroupAvailablePages("swa"), 0);
+
+    hybrid_->OnKVHostEvict(terminal);
+
+    EXPECT_FALSE(terminal->HasPagedCacheHostSnapshot());
+    EXPECT_EQ(hybrid_->PagedCacheHostGroupAvailablePages("fh"), 2);
+    EXPECT_EQ(hybrid_->PagedCacheHostGroupAvailablePages("swa"), 2);
+}
+
+TEST_F(PagedCacheL2OffloadTest, HostWriteBackPrunesOnlyUnpinnedPagedCacheHostSnapshots) {
+    TreeNode* pinned = SeedCompleteDeviceSnapshot(/*token_start=*/1);
+    ASSERT_NE(pinned, nullptr);
+    AttachHostResource(pinned);
+    auto first_writeback = hybrid_->PreparePagedCacheHostWriteBack({pinned});
+    ASSERT_FALSE(first_writeback.empty());
+    hybrid_->OnPagedCacheHostWriteBackDone({pinned}, /*success=*/true);
+    ASSERT_TRUE(pinned->HasPagedCacheHostSnapshot());
+
+    TreeNode* next = SeedCompleteDeviceSnapshot(/*token_start=*/101);
+    ASSERT_NE(next, nullptr);
+    AttachHostResource(next);
+    {
+        HostNodeRef lock(pinned);
+        auto blocked = hybrid_->PreparePagedCacheHostWriteBack({next});
+        EXPECT_TRUE(blocked.empty());
+        EXPECT_TRUE(pinned->HasPagedCacheHostSnapshot());
+        EXPECT_FALSE(next->HasPagedCachePendingHostSnapshot());
+    }
+
+    auto writeback = hybrid_->PreparePagedCacheHostWriteBack({next});
+    ASSERT_FALSE(writeback.empty());
+    EXPECT_FALSE(pinned->HasPagedCacheHostSnapshot());
+    EXPECT_TRUE(next->HasPagedCachePendingHostSnapshot());
+}
+
+TEST_F(PagedCacheL2SchedulerTest, WriteBackAckDemotesDeviceSnapshotAndNextHitLoadsFromHost) {
+    const auto request_tokens = MakeAlignedTokens(/*num_pages=*/3, kSmallFixtureParams.page_size, /*start=*/1);
+    BringToDecoding("r1");
+    SendFinish("r1");
+
+    auto writeback_plan = PlanOnce();
+    const auto* writeback = GetWriteBack(writeback_plan);
+    ASSERT_NE(writeback, nullptr);
+    ASSERT_EQ(writeback->op_ids.size(), 1u);
+    ASSERT_EQ(writeback->paged_cache_transfers.size(), 1u);
+    ASSERT_FALSE(writeback->paged_cache_transfers[0].empty());
+
+    SendWriteBackDone(writeback->op_ids[0]);
+    PlanOnce();
+    EXPECT_EQ(scheduler_->PagedCacheGroupAvailablePages("fh"), 15);
+    EXPECT_EQ(scheduler_->PagedCacheGroupAvailablePages("swa"), 15);
+    EXPECT_EQ(scheduler_->PagedCacheHostGroupTotalPages("fh"), 16);
+    EXPECT_EQ(scheduler_->PagedCacheHostGroupTotalPages("swa"), 16);
+    const std::int32_t fh_host_after_writeback = scheduler_->PagedCacheHostGroupAvailablePages("fh");
+    const std::int32_t swa_host_after_writeback = scheduler_->PagedCacheHostGroupAvailablePages("swa");
+    EXPECT_LT(fh_host_after_writeback, scheduler_->PagedCacheHostGroupTotalPages("fh"));
+    EXPECT_LT(swa_host_after_writeback, scheduler_->PagedCacheHostGroupTotalPages("swa"));
+
+    Submit(RequestSpec{
+        .request_id = "r2",
+        .tokens = request_tokens,
+    });
+    auto loadback_plan = PlanOnce();
+    const auto* loadback = GetLoadBack(loadback_plan);
+    ASSERT_NE(loadback, nullptr);
+    ASSERT_EQ(loadback->paged_cache_transfers.size(), 1u);
+    ASSERT_FALSE(loadback->paged_cache_transfers[0].empty());
+
+    std::set<std::string> groups;
+    for (const auto& transfer : loadback->paged_cache_transfers[0]) {
+        groups.insert(transfer.group_id);
+        EXPECT_EQ(transfer.src_pages.size(), transfer.dst_pages.size());
+        EXPECT_FALSE(transfer.src_pages.empty());
+    }
+    EXPECT_EQ(groups, (std::set<std::string>{"fh", "swa"}));
+    EXPECT_EQ(scheduler_->PagedCacheHostGroupAvailablePages("fh"), fh_host_after_writeback);
+    EXPECT_EQ(scheduler_->PagedCacheHostGroupAvailablePages("swa"), swa_host_after_writeback);
+}
+
+TEST_F(PagedCacheL2SchedulerTest, FailedWriteBackDoesNotPublishHostSnapshotOrDemoteDeviceSnapshot) {
+    const auto request_tokens = MakeAlignedTokens(/*num_pages=*/3, kSmallFixtureParams.page_size, /*start=*/1);
+    BringToDecoding("r1");
+    SendFinish("r1");
+
+    auto writeback_plan = PlanOnce();
+    const auto* writeback = GetWriteBack(writeback_plan);
+    ASSERT_NE(writeback, nullptr);
+    ASSERT_EQ(writeback->op_ids.size(), 1u);
+    ASSERT_EQ(writeback->paged_cache_transfers.size(), 1u);
+    ASSERT_FALSE(writeback->paged_cache_transfers[0].empty());
+    const auto transferred_host_pages = UniqueDstPagesByGroup(*writeback);
+    const std::int32_t transferred_kv_host_pages = UniqueKvDstPages(*writeback);
+    const std::size_t kv_host_before_ack = scheduler_->AvailableHostKvPages();
+    const std::int32_t fh_host_before_ack = scheduler_->PagedCacheHostGroupAvailablePages("fh");
+    const std::int32_t swa_host_before_ack = scheduler_->PagedCacheHostGroupAvailablePages("swa");
+    ASSERT_GT(transferred_kv_host_pages, 0);
+    ASSERT_GT(transferred_host_pages.at("fh"), 0);
+    ASSERT_GT(transferred_host_pages.at("swa"), 0);
+
+    SendWriteBackDone(writeback->op_ids[0], /*success=*/false);
+    PlanOnce();
+
+    EXPECT_EQ(scheduler_->AvailableHostKvPages(), kv_host_before_ack + transferred_kv_host_pages);
+    EXPECT_EQ(scheduler_->PagedCacheHostGroupAvailablePages("fh"),
+              fh_host_before_ack + transferred_host_pages.at("fh"));
+    EXPECT_EQ(scheduler_->PagedCacheHostGroupAvailablePages("swa"),
+              swa_host_before_ack + transferred_host_pages.at("swa"));
+
+    Submit(RequestSpec{
+        .request_id = "r2",
+        .tokens = request_tokens,
+    });
+    auto reuse_plan = PlanOnce();
+    EXPECT_EQ(GetLoadBack(reuse_plan), nullptr);
+    ASSERT_NE(GetForward(reuse_plan), nullptr);
+}
+
+}  // namespace tokenspeed::test

--- a/tokenspeed-scheduler/tests/cpp/test_paged_cache_l2_offload.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_paged_cache_l2_offload.cpp
@@ -89,7 +89,7 @@ protected:
         };
         cfg.paged_cache_host_group_pages = {{"fh", 16}, {"swa", 16}};
         PrefixCacheAdjunctSpec adjunct;
-        adjunct.required_groups = {"fh", "swa"};
+        adjunct.required_groups = {"fh"};
         cfg.prefix_cache_adjunct = adjunct;
         return cfg;
     }
@@ -170,6 +170,70 @@ protected:
         }
         return static_cast<std::int32_t>(pages.size());
     }
+};
+
+class PagedCacheHistoryOnlyL2OffloadTest : public ::testing::Test {
+protected:
+    static constexpr std::int32_t kPageSize = 2;
+    static constexpr std::int32_t kLcm = 4;
+
+    void SetUp() override {
+        device_alloc_ = std::make_unique<PageAllocator>(kPageSize, /*total_pages=*/64);
+        kv_cache_ = std::make_unique<KVPrefixCache>(device_alloc_.get(), /*host=*/nullptr);
+
+        auto history_cfg = MakeHistoryGroup(/*total_pages=*/32);
+        auto history_owner = std::make_unique<PagedCacheGroupAllocator>(history_cfg);
+        history_alloc_ = history_owner.get();
+        hybrid_ = std::make_unique<HybridPrefixCache>(*kv_cache_, /*mamba=*/nullptr, /*mamba_chunk_size=*/0);
+        hybrid_->RegisterPagedCacheGroup(std::move(history_owner));
+
+        auto host_history_cfg = MakeHistoryGroup(/*total_pages=*/32);
+        auto host_history = std::make_unique<PagedCacheGroupAllocator>(host_history_cfg);
+        hybrid_->RegisterPagedCacheHostGroup(std::move(host_history));
+        hybrid_->EnablePagedCacheAdjunct({"fh"}, {});
+        kv_cache_->GetDeviceManager().SetEvictionCallback([this](TreeNode* node) { hybrid_->OnKVEvict(node); });
+    }
+
+    TreeNode* InsertDeviceTokens(std::int32_t num_pages, token_t token_start = 1) {
+        auto tokens = MakeAlignedTokens(num_pages, kPageSize, token_start);
+        OwnedPages pages = device_alloc_->Allocate(num_pages);
+        auto inserted =
+            kv_cache_->Insert<ResourceType::Device>(tokens, /*prefix_pages=*/{}, std::move(pages), /*page_hashes=*/{});
+        return inserted.last_node;
+    }
+
+    std::unique_ptr<PagedCacheSnapshot> MakeHistorySnapshot(std::int32_t prefix_len_tokens) {
+        PagedCacheGroupTable table{history_alloc_};
+        table.Acquire(prefix_len_tokens);
+        auto committed = table.CommitHistoryToSnapshot(prefix_len_tokens);
+
+        PagedCacheGroupSnapshot group{};
+        group.pages = std::move(committed.pages);
+        group.base_logical_page = committed.segment_base_logical_page;
+        group.raw_token_cursor = prefix_len_tokens;
+        group.sliding = false;
+
+        auto snapshot = std::make_unique<PagedCacheSnapshot>();
+        snapshot->prefix_len_tokens = prefix_len_tokens;
+        snapshot->groups.emplace("fh", std::move(group));
+        return snapshot;
+    }
+
+    static PagedCacheGroupConfig MakeHistoryGroup(std::int32_t total_pages) {
+        PagedCacheGroupConfig cfg{};
+        cfg.group_id = "fh";
+        cfg.rows_per_page = 4;
+        cfg.entry_stride_tokens = 1;
+        cfg.total_pages = total_pages;
+        cfg.retention = PagedCacheGroupConfig::Retention::FullHistory;
+        cfg.family = PagedCacheGroupFamily::History;
+        return cfg;
+    }
+
+    std::unique_ptr<PageAllocator> device_alloc_;
+    std::unique_ptr<KVPrefixCache> kv_cache_;
+    PagedCacheGroupAllocator* history_alloc_{nullptr};
+    std::unique_ptr<HybridPrefixCache> hybrid_;
 };
 
 TEST_F(PagedCacheL2OffloadTest, PendingHostSnapshotInvisibleUntilWriteBackAck) {
@@ -260,6 +324,40 @@ TEST_F(PagedCacheL2OffloadTest, HostHitMaterializesDeviceDestinationPagesForForw
     }
 
     hybrid_->ReleaseRequest("r-load");
+}
+
+TEST_F(PagedCacheHistoryOnlyL2OffloadTest, HostLoadedHistoryPrefixCanPublishContinuationSnapshot) {
+    TreeNode* prefix = InsertDeviceTokens(/*num_pages=*/2);
+    ASSERT_NE(prefix, nullptr);
+    ASSERT_TRUE(hybrid_->AttachPagedCacheSnapshotToNode(prefix, MakeHistorySnapshot(kLcm)));
+    prefix->AttachResource<ResourceType::Host>(std::make_unique<NodeResource<ResourceType::Host>>(OwnedPages{}));
+
+    auto writeback = hybrid_->PreparePagedCacheHostWriteBack({prefix});
+    ASSERT_EQ(writeback.size(), 1u);
+    hybrid_->OnPagedCacheHostWriteBackDone({prefix}, /*success=*/true);
+    auto detached_device = hybrid_->DetachPagedCacheSnapshotFromNode(prefix);
+    ASSERT_NE(detached_device, nullptr);
+
+    auto host_match = hybrid_->Match(MakeAlignedTokens(/*num_pages=*/2, kPageSize, /*start=*/1));
+    ASSERT_EQ(host_match.paged_cache.last_node, nullptr);
+    ASSERT_NE(host_match.paged_cache_host.last_node, nullptr);
+    EXPECT_EQ(host_match.paged_cache_host.prefix_len_tokens, kLcm);
+
+    auto loadback = hybrid_->PreparePagedCacheDeviceLoadBack("r-load", host_match.paged_cache_host);
+    ASSERT_EQ(loadback.size(), 1u);
+
+    TreeNode* extended = InsertDeviceTokens(/*num_pages=*/4);
+    ASSERT_NE(extended, nullptr);
+    hybrid_->AcquireForRequest("r-load", /*first_raw_position_of_op=*/kLcm,
+                               /*target_raw_tokens_exclusive=*/2 * kLcm);
+    hybrid_->CommitChunk("r-load", extended);
+
+    ASSERT_TRUE(extended->HasPagedCacheSnapshot());
+    auto device_match = hybrid_->Match(MakeAlignedTokens(/*num_pages=*/4, kPageSize, /*start=*/1));
+    ASSERT_NE(device_match.paged_cache.last_node, nullptr);
+    EXPECT_EQ(device_match.paged_cache.prefix_len_tokens, 2 * kLcm);
+    ASSERT_EQ(device_match.paged_cache.per_group_page_ids.count("fh"), 1u);
+    EXPECT_EQ(device_match.paged_cache.per_group_page_ids.at("fh").size(), 2u);
 }
 
 TEST_F(PagedCacheL2OffloadTest, HostStateRecoveryRequiresExactTerminalStateCompleteness) {


### PR DESCRIPTION
## Summary

Add DeepSeek V4 L2 KV cache offload/transfer support, implements host-side CPU KVStore support for DeepSeek V4. KVStore remains enabled by default and can still be disabled with the existing `--disable-kvstore`.

Main changes:

- Add DeepSeek V4 host cache pools for SWA KV, compressed KV, compressor state, ratio-4 indexer KV, and indexer compressor state.
- Add a typed paged-cache transfer path so V4 group pages are not forced through token-indexed MHA/MLA KV cache APIs.
- Extend scheduler hybrid prefix cache with device, pending-host, and visible-host paged-cache residency.
- Support history-family prefix reuse and exact terminal state recovery from host L2.
- Materialize host hits back into destination device pages before building forward ops.
- Add layerwise loadback synchronization via `LayerDoneCounter`, preserving overlap scheduling and avoiding scheduler-wide loadback waits.
- Document the DeepSeek V4 L2 design and serving behavior.

## Testing


Validation in remote serving:
- DeepSeek V4 with `--disable-kvstore`
- DeepSeek V4 with default KVStore enabled