### PR TITLE
fix(runtime): use scattered token counts for MoE RSAG

### DIFF
--- a/python/tokenspeed/runtime/distributed/comm_manager.py
+++ b/python/tokenspeed/runtime/distributed/comm_manager.py
@@ -94,8 +94,17 @@ class CommManager:
             ctx.global_bs if ctx.draft_first_step_reduce else ctx.global_num_tokens
         )
         if global_counts is not None:
-            start = self.mapping.moe.dp_rank * tp_ep_size
-            return list(global_counts[start : start + tp_ep_size])
+            scattered = self.scattered_num_tokens(ctx)
+            result = []
+            for rank in self.mapping.moe.tp_ep_group:
+                attn_dp_rank = rank // (
+                    self.mapping.attn.tp_size * self.mapping.attn.cp_size
+                )
+                attn_tp_rank = rank % self.mapping.attn.tp_size
+                result.append(
+                    scattered[attn_dp_rank * self.mapping.attn.tp_size + attn_tp_rank]
+                )
+            return result
         num_tokens = ctx.bs if ctx.draft_first_step_reduce else ctx.input_num_tokens
         result = [0] * tp_ep_size
         result[self.mapping.moe.tp_ep_rank] = num_tokens

--- a/test/runtime/distributed/test_draft_moe_capture_global_bs.py
+++ b/test/runtime/distributed/test_draft_moe_capture_global_bs.py
@@ -124,6 +124,58 @@ def test_capture_matches_replay_all_ranks(rank: int):
     assert scattered == [bs] * 4
 
 
+@pytest.mark.parametrize("rank", [0, 1, 2, 3])
+def test_moe_tp_ep_counts_use_post_attention_scattered_rows(rank: int):
+    """When attention TP and MoE TP differ, MoE all-gather sees the rows left
+    after attention reduce-scatter, not the original per-rank token counts."""
+    mapping = Mapping(
+        rank=rank,
+        world_size=4,
+        attn_tp_size=2,
+        attn_dp_size=2,
+        dense_tp_size=4,
+        moe_tp_size=4,
+    )
+    cm = CommManager(mapping=mapping, layer_id=0, is_moe=True, prev_is_moe=True)
+    ctx = ForwardContext(
+        attn_backend=None,
+        token_to_kv_pool=None,
+        bs=4,
+        num_extends=0,
+        input_num_tokens=4,
+        forward_mode=ForwardMode.DECODE,
+        draft_first_step_reduce=False,
+        global_num_tokens=[4, 4, 4, 4],
+    )
+
+    assert cm.moe_tp_ep_group_scattered_num_tokens(ctx) == [2, 2, 2, 2]
+
+
+@pytest.mark.parametrize("rank", [0, 1, 2, 3])
+def test_moe_tp_ep_counts_account_for_attention_cp_ranks(rank: int):
+    mapping = Mapping(
+        rank=rank,
+        world_size=4,
+        attn_tp_size=1,
+        attn_cp_size=4,
+        dense_tp_size=4,
+        moe_tp_size=4,
+    )
+    cm = CommManager(mapping=mapping, layer_id=0, is_moe=True, prev_is_moe=True)
+    ctx = ForwardContext(
+        attn_backend=None,
+        token_to_kv_pool=None,
+        bs=4,
+        num_extends=0,
+        input_num_tokens=4,
+        forward_mode=ForwardMode.DECODE,
+        draft_first_step_reduce=False,
+        global_num_tokens=[4, 4, 4, 4],
+    )
+
+    assert cm.moe_tp_ep_group_scattered_num_tokens(ctx) == [4, 4, 4, 4]
+
+
 def test_capture_one_sets_global_bs(monkeypatch):
     """Guards the fix at its source: CudaGraphWrapper._capture_one must set
     ctx.global_bs (not leave it None) for DP, matching how global_num_tokens is


### PR DESCRIPTION
## Summary

Fixes #405.

When attention TP and MoE TP differ, `post_attn_comm` reduce-scatters hidden states across the attention TP group before `pre_moe_comm`. The MoE token-aware all-gather must therefore size its per-rank rows from the post-attention scattered layout, not from the original per-rank `global_num_tokens`.

This changes `moe_tp_ep_group_scattered_num_tokens` to reuse the already-computed attention-scattered counts and select the ranks in the current MoE `tp_ep_group`.

## Test Plan

- Added a CPU-only regression for the token-count invariant from #405.
- Added a CPU-only regression for attention CP ranks in MoE groups, covering Codex review feedback.
- Ran the regression locally with lightweight stubs for unavailable GPU/runtime packages: `14 passed, 1 deselected`.
- Ran mapping tests locally with the same stubs: `71 passed`.
- `python -m py_compile python/tokenspeed/runtime/distributed/comm_manager.py test/runtime/distributed/test_draft_moe_capture_global_bs.py`
- `git diff --check`
- `pre-commit run --all-files`
