### PR TITLE
perf(gdn): remove gdn prefill unnecessary h_state copy

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -626,11 +626,8 @@ class MambaAttnBackend(AttentionBackend):
         mamba_track_indices: torch.Tensor,
         extend_seq_lens: torch.Tensor,
     ):
-        """Compute src/dst indices for extracting intermediate SSM states.
-
-        Indexes directly into the raw flashinfer checkpoint buffer (convention B:
-        ckpts[k] = state after processing chunk k = FLA h[k+1]).
-        """
+        """Compute src/dst indices for extracting intermediate SSM states."""
+        # flashinfer ckpts[k] = state after processing chunk k = FLA h[k+1]
         num_fi_ckpts = extend_seq_lens // FLA_CHUNK_SIZE
         offset = torch.zeros_like(num_fi_ckpts)
         offset[1:] = torch.cumsum(num_fi_ckpts[:-1], dim=0)
@@ -639,7 +636,7 @@ class MambaAttnBackend(AttentionBackend):
         offset_m = offset[track_mask]
         dst_m = mamba_track_indices[track_mask]
 
-        # We want FLA h[lens//C] = flashinfer ckpts[lens//C - 1].
+        # FLA h[lens//C] = flashinfer ckpts[lens//C - 1].
         # track_mask guarantees lens_m >= FLA_CHUNK_SIZE so lens_m // C >= 1.
         track_ssm_h_src = offset_m + (lens_m // FLA_CHUNK_SIZE - 1)
         track_ssm_h_dst = dst_m
@@ -1120,7 +1117,7 @@ class MambaAttnBackend(AttentionBackend):
                     )
                 self._gdn_fastpath_checked = True
             if need_h_track:
-                core_attn_out, last_recurrent_state, fi_checkpoints, _ = (
+                core_attn_out, last_recurrent_state, fi_h_checkpoints, _ = (
                     gdn_flashinfer.gdn_chunk_prefill(
                         l2norm_fwd(query),
                         l2norm_fwd(key),
@@ -1148,7 +1145,7 @@ class MambaAttnBackend(AttentionBackend):
             ssm_states[cache_indices] = last_recurrent_state
 
             if need_h_track:
-                ssm_states[self.forward_metadata.track_ssm_h_dst] = fi_checkpoints[
+                ssm_states[self.forward_metadata.track_ssm_h_dst] = fi_h_checkpoints[
                     self.forward_metadata.track_ssm_h_src
                 ].to(ssm_states.dtype, copy=False)
 

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -625,19 +625,20 @@ class MambaAttnBackend(AttentionBackend):
     ):
         """Compute src/dst indices for extracting intermediate SSM states.
 
-        Matching conv windows are gathered separately from packed pre-conv inputs.
+        Indexes directly into the raw flashinfer checkpoint buffer (convention B:
+        ckpts[k] = state after processing chunk k = FLA h[k+1]).
         """
-        num_h_states = (extend_seq_lens - 1) // FLA_CHUNK_SIZE + 1
-        offset = torch.zeros_like(num_h_states)
-        offset[1:] = torch.cumsum(num_h_states[:-1], dim=0)
+        num_fi_ckpts = extend_seq_lens // FLA_CHUNK_SIZE
+        offset = torch.zeros_like(num_fi_ckpts)
+        offset[1:] = torch.cumsum(num_fi_ckpts[:-1], dim=0)
 
         lens_m = track_lens[track_mask]
         offset_m = offset[track_mask]
-        dst_m = mamba_track_indices[track_mask]  # write to TRACKING slots
+        dst_m = mamba_track_indices[track_mask]
 
-        # h[i] is the state before chunk i, so an aligned lens maps directly to
-        # lens // FLA_CHUNK_SIZE.
-        track_ssm_h_src = offset_m + (lens_m // FLA_CHUNK_SIZE)
+        # We want FLA h[lens//C] = flashinfer ckpts[lens//C - 1].
+        # track_mask guarantees lens_m >= FLA_CHUNK_SIZE so lens_m // C >= 1.
+        track_ssm_h_src = offset_m + (lens_m // FLA_CHUNK_SIZE - 1)
         track_ssm_h_dst = dst_m
 
         return (
@@ -1115,13 +1116,8 @@ class MambaAttnBackend(AttentionBackend):
                         f"sm100_available={gdn_flashinfer.is_available()}."
                     )
                 self._gdn_fastpath_checked = True
-            # sm100 fast-path for both code paths. q/k l2norm here since the
-            # kernel ignores its own flag; the wrapper handles the
-            # gate/beta/state conventions and, when output_h=True, returns a
-            # drop-in replacement for FLA's intermediate-h tensor so the
-            # downstream track_ssm_h_src indexing is identical.
             if need_h_track:
-                core_attn_out, last_recurrent_state, h = (
+                core_attn_out, last_recurrent_state, fi_checkpoints, _ = (
                     gdn_flashinfer.gdn_chunk_prefill(
                         l2norm_fwd(query),
                         l2norm_fwd(key),
@@ -1149,11 +1145,7 @@ class MambaAttnBackend(AttentionBackend):
             ssm_states[cache_indices] = last_recurrent_state
 
             if need_h_track:
-                if h is None:
-                    raise RuntimeError(
-                        "Missing intermediate mamba states for branching track"
-                    )
-                ssm_states[self.forward_metadata.track_ssm_h_dst] = h.squeeze(0)[
+                ssm_states[self.forward_metadata.track_ssm_h_dst] = fi_checkpoints[
                     self.forward_metadata.track_ssm_h_src
                 ].to(ssm_states.dtype, copy=False)
 

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -626,7 +626,10 @@ class MambaAttnBackend(AttentionBackend):
         mamba_track_indices: torch.Tensor,
         extend_seq_lens: torch.Tensor,
     ):
-        """Compute src/dst indices for extracting intermediate SSM states."""
+        """Compute src/dst indices for extracting intermediate SSM states.
+
+        Matching conv windows are gathered separately from packed pre-conv inputs.
+        """
         # flashinfer ckpts[k] = state after processing chunk k = FLA h[k+1]
         num_fi_ckpts = extend_seq_lens // FLA_CHUNK_SIZE
         offset = torch.zeros_like(num_fi_ckpts)

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -51,6 +51,9 @@ from tokenspeed.runtime.layers.attention.linear.index import (
     set_total_chunks_hint_uniform,
 )
 from tokenspeed.runtime.layers.attention.linear.l2norm import l2norm_fwd
+from tokenspeed.runtime.layers.attention.linear.mamba_state_scatter_triton import (
+    fused_mamba_state_copy,
+)
 
 if TYPE_CHECKING:
     from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
@@ -1150,12 +1153,16 @@ class MambaAttnBackend(AttentionBackend):
                 ].to(ssm_states.dtype, copy=False)
 
             if need_final_track:
-                conv_states[self.forward_metadata.track_ssm_final_dst] = conv_states[
-                    self.forward_metadata.track_ssm_final_src
-                ]
-                ssm_states[self.forward_metadata.track_ssm_final_dst] = ssm_states[
-                    self.forward_metadata.track_ssm_final_src
-                ]
+                fused_mamba_state_copy(
+                    conv_states,
+                    self.forward_metadata.track_ssm_final_src,
+                    self.forward_metadata.track_ssm_final_dst,
+                )
+                fused_mamba_state_copy(
+                    ssm_states,
+                    self.forward_metadata.track_ssm_final_src,
+                    self.forward_metadata.track_ssm_final_dst,
+                )
 
         return core_attn_out
 

--- a/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
@@ -169,7 +169,7 @@ def _mamba_state_snapshot_kernel(
 
 
 def fused_mamba_state_copy(
-    pool: torch.Tensor,  # [num_layers, pool_size, *state_shape]
+    pool: torch.Tensor,  # [num_layers, pool_size, *state_shape] or [pool_size, *state_shape]
     src_indices: torch.Tensor,  # [num_valid]
     dst_indices: torch.Tensor,  # [num_valid]
     cache_lengths: torch.Tensor | None = None,  # [num_valid], for page filter
@@ -183,8 +183,14 @@ def fused_mamba_state_copy(
     cache_lengths is provided, also skips entries where
     cache_lengths[i] % page_size != 0.
 
+    Supports both 3D pool tensors ``[num_layers, pool_size, *state_shape]``
+    and 2D per-layer slices ``[pool_size, *state_shape]`` (which may be
+    non-contiguous views into a larger cache).  For 2D inputs the kernel
+    is launched with ``num_layers=1``.
+
     Args:
-        pool: State tensor [num_layers, pool_size, *state_shape], must be contiguous.
+        pool: State tensor, either 3D [num_layers, pool_size, *state_shape]
+            or 2D [pool_size, *state_shape].
         src_indices: Source slot indices [num_valid], int32 or int64.
         dst_indices: Destination slot indices [num_valid], int32 or int64.
         cache_lengths: Per-entry cache lengths for page-boundary filtering.
@@ -198,8 +204,6 @@ def fused_mamba_state_copy(
 
     if not pool.is_cuda:
         raise ValueError("fused_mamba_state_copy only supports CUDA tensors.")
-    if not pool.is_contiguous():
-        raise ValueError("pool tensor must be contiguous")
     if pool.ndim < 2:
         raise ValueError(f"pool must be at least 2D, got {pool.ndim}D")
     if src_indices.shape[0] != dst_indices.shape[0]:
@@ -207,19 +211,25 @@ def fused_mamba_state_copy(
             f"indices length mismatch: {src_indices.shape[0]} vs {dst_indices.shape[0]}"
         )
 
-    num_layers = pool.shape[0]
-    pool_size = pool.shape[1]
-
-    # Elements per (layer, slot) entry
-    elem_per_entry = pool.numel() // (num_layers * pool_size)
-
-    layer_stride = pool.stride(0)
-    req_stride = pool.stride(1)
+    if pool.ndim == 2:
+        num_layers = 1
+        pool_size = pool.shape[0]
+        elem_per_entry = pool.numel() // pool_size
+        layer_stride = 0  # unused when num_layers=1 (pid_layer is always 0)
+        req_stride = pool.stride(0)
+    else:
+        num_layers = pool.shape[0]
+        pool_size = pool.shape[1]
+        elem_per_entry = pool.numel() // (num_layers * pool_size)
+        layer_stride = pool.stride(0)
+        req_stride = pool.stride(1)
 
     if not src_indices.is_contiguous():
-        raise ValueError("src_indices must be contiguous")
+        src_indices = src_indices.contiguous()
     if not dst_indices.is_contiguous():
-        raise ValueError("dst_indices must be contiguous")
+        dst_indices = dst_indices.contiguous()
+    src_indices = src_indices.to(torch.int32)
+    dst_indices = dst_indices.to(torch.int32)
 
     if page_size > 0 and cache_lengths is not None:
         cache_lengths = cache_lengths.to(torch.int32)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flashinfer/gated_delta_rule.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flashinfer/gated_delta_rule.py
@@ -110,23 +110,18 @@ def gdn_chunk_prefill(
     Default returns ``(out, final_state)`` matching the FLA layout:
     out [B, T, Hv, D] in q.dtype, final_state [N, H, K, V].
 
-    When ``output_h=True`` returns ``(out, final_state, h)`` where ``h`` is a
-    drop-in replacement for FLA's ``output_h=True`` tensor:
-    shape ``[1, total_chunks, H, K, V]`` in q.dtype, with per-sequence layout
-    ``[h_init_i, h_after_chunk_0_i, ...]`` of ``ceil(L_i / CHUNK_SIZE)``
-    entries (= ``L_i // CHUNK_SIZE`` when ``L_i`` is chunk-aligned, otherwise
-    one more). Index convention matches FLA's: ``h[offset_i + lens // CHUNK]``
-    is the state right *before* chunk ``lens // CHUNK`` for seq ``i`` (so
-    chunk-0's slot holds that seq's initial state, and ``h[-1]`` of a
-    non-aligned seq is the state right before its trailing partial chunk).
+    When ``output_h=True`` returns
+    ``(out, final_state, fi_checkpoints, checkpoint_cu_starts)`` where:
+    - ``fi_checkpoints``: raw flashinfer checkpoint buffer in FLA state layout
+      ``[total_fi_ckpts, H, K, V]`` (float32). Checkpoint ``k`` within a
+      sequence is the state *after* processing chunk ``k`` (= FLA ``h[k+1]``).
+      Per-sequence count is ``L_i // CHUNK_SIZE``.
+    - ``checkpoint_cu_starts``: int64 tensor of length ``N+1`` giving the
+      cumulative start offset of each sequence's checkpoints in
+      ``fi_checkpoints``.
 
-    flashinfer natively emits only post-chunk states (``L_i // CHUNK`` of
-    them, *including* the post-last one which equals ``final_state[i]`` on
-    chunk-aligned seqs). To match FLA we (a) splice ``initial_state[i]`` into
-    the front of each seq's slice and (b) drop flashinfer's last checkpoint
-    on chunk-aligned seqs (FLA does not include the final-state slot in h).
-    This keeps the caller's index math (``track_ssm_h_src``) identical to the
-    FLA path.
+    The caller indexes directly with flashinfer-native offsets rather than
+    rebuilding the FLA h tensor.
     """
     batched = q.dim() == 4
     q3 = q.squeeze(0) if batched else q
@@ -152,17 +147,12 @@ def gdn_chunk_prefill(
         H_state = fi_initial_state.shape[1]
         D_state = fi_initial_state.shape[-1]
         state_checkpoints = torch.empty(
-            total_ckpts_fi,
-            H_state,
-            D_state,
-            D_state,
-            device=fi_initial_state.device,
-            dtype=torch.float32,
+            total_ckpts_fi, H_state, D_state, D_state,
+            device=fi_initial_state.device, dtype=torch.float32,
         )
         checkpoint_cu_starts = torch.zeros(
             per_seq_ckpts_fi.numel() + 1,
-            device=fi_initial_state.device,
-            dtype=torch.int64,
+            device=fi_initial_state.device, dtype=torch.int64,
         )
         checkpoint_cu_starts[1:] = torch.cumsum(per_seq_ckpts_fi, dim=0)
 
@@ -192,41 +182,8 @@ def gdn_chunk_prefill(
     if not output_h:
         return out, final_state_fla
 
-    # Build the FLA-equivalent h: per seq -> [init, ckpt_0, ..., ckpt_{n_fla-2}].
-    fi_ckpts_fla = state_checkpoints.transpose(-1, -2)  # [total_fi, H, K, V]
-    per_seq_lens_cpu = per_seq_lens.cpu()
-    per_seq_ckpts_fi_cpu = per_seq_lens_cpu // CHUNK_SIZE
-    per_seq_fla_counts_cpu = (per_seq_lens_cpu + CHUNK_SIZE - 1) // CHUNK_SIZE
-    n_seq = per_seq_fla_counts_cpu.numel()
-    total_fla = int(per_seq_fla_counts_cpu.sum().item())
-    H_state = fi_initial_state.shape[1]
-    D_state = fi_initial_state.shape[-1]
-    h_fla = torch.empty(
-        total_fla,
-        H_state,
-        D_state,
-        D_state,
-        device=fi_initial_state.device,
-        dtype=torch.float32,
-    )
-    init_fla = initial_state.float()
-    fla_off = 0
-    fi_off = 0
-    for i in range(n_seq):
-        n_fla = int(per_seq_fla_counts_cpu[i].item())
-        n_fi = int(per_seq_ckpts_fi_cpu[i].item())
-        if n_fla == 0:
-            continue
-        # Slot 0: initial state.
-        h_fla[fla_off] = init_fla[i]
-        # Remaining (n_fla - 1) slots: the first (n_fla - 1) flashinfer
-        # checkpoints (drops final-state-equivalent ckpt on aligned seqs).
-        n_take = n_fla - 1
-        if n_take > 0:
-            h_fla[fla_off + 1 : fla_off + 1 + n_take] = fi_ckpts_fla[
-                fi_off : fi_off + n_take
-            ]
-        fla_off += n_fla
-        fi_off += n_fi
-
-    return out, final_state_fla, h_fla.to(q.dtype).unsqueeze(0)
+    # Return raw flashinfer checkpoints in FLA state layout [total_fi, H, K, V].
+    # The caller indexes directly using flashinfer-native offsets, avoiding the
+    # expensive per-seq loop that used to splice initial_state into slot 0.
+    fi_ckpts_fla = state_checkpoints.transpose(-1, -2)
+    return out, final_state_fla, fi_ckpts_fla, checkpoint_cu_starts

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flashinfer/gated_delta_rule.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flashinfer/gated_delta_rule.py
@@ -142,19 +142,25 @@ def gdn_chunk_prefill(
     per_seq_lens = None
     if output_h:
         per_seq_lens = (cu_seqlens[1:] - cu_seqlens[:-1]).to(torch.int64)
-        per_seq_ckpts_fi = per_seq_lens // CHUNK_SIZE
-        total_ckpts_fi = int(per_seq_ckpts_fi.sum().item())
+        # flashinfer-native checkpoint count: only full chunks emit a checkpoint.
+        per_seq_h_ckpts = per_seq_lens // CHUNK_SIZE
+        total_h_ckpts = int(per_seq_h_ckpts.sum().item())
         H_state = fi_initial_state.shape[1]
         D_state = fi_initial_state.shape[-1]
         state_checkpoints = torch.empty(
-            total_ckpts_fi, H_state, D_state, D_state,
-            device=fi_initial_state.device, dtype=torch.float32,
+            total_h_ckpts,
+            H_state,
+            D_state,
+            D_state,
+            device=fi_initial_state.device,
+            dtype=torch.float32,
         )
         checkpoint_cu_starts = torch.zeros(
-            per_seq_ckpts_fi.numel() + 1,
-            device=fi_initial_state.device, dtype=torch.int64,
+            per_seq_h_ckpts.numel() + 1,
+            device=fi_initial_state.device,
+            dtype=torch.int64,
         )
-        checkpoint_cu_starts[1:] = torch.cumsum(per_seq_ckpts_fi, dim=0)
+        checkpoint_cu_starts[1:] = torch.cumsum(per_seq_h_ckpts, dim=0)
 
     out, final_state = _chunk_gated_delta_rule(
         q3.contiguous(),
@@ -163,11 +169,8 @@ def gdn_chunk_prefill(
         g=torch.exp(g2).float().contiguous(),
         beta=beta2.float().contiguous(),
         scale=scale,
-        # flashinfer requires fp32 state; runtime ssm dtype may be bf16.
         initial_state=fi_initial_state,
         output_final_state=True,
-        # flashinfer casts cu_seqlens per path internally (int32 for sm100), so
-        # pass it through rather than forcing a dtype.
         cu_seqlens=cu_seqlens,
         state_checkpoints=state_checkpoints,
         checkpoint_cu_starts=checkpoint_cu_starts,
@@ -183,7 +186,6 @@ def gdn_chunk_prefill(
         return out, final_state_fla
 
     # Return raw flashinfer checkpoints in FLA state layout [total_fi, H, K, V].
-    # The caller indexes directly using flashinfer-native offsets, avoiding the
-    # expensive per-seq loop that used to splice initial_state into slot 0.
-    fi_ckpts_fla = state_checkpoints.transpose(-1, -2)
-    return out, final_state_fla, fi_ckpts_fla, checkpoint_cu_starts
+    # The caller indexes directly using flashinfer-native offsets
+    h_ckpts_fla = state_checkpoints.transpose(-1, -2)
+    return out, final_state_fla, h_ckpts_fla, checkpoint_cu_starts


### PR DESCRIPTION
## Summary
Remove the previous redundant h-state conversion when persisting intermediate SSM states into the tracking pool (h-track and final-track) on the flashinfer GDN prefill fast-path. Instead of rebuilding an FLA-style h tensor from flashinfer's checkpoints, the tracking now indexes the native checkpoint buffer directly.

**Approach**:
- Reuse flashinfer's native checkpoints; drop the FLA-h rebuild: The prefill wrapper no longer runs a host-side per-sequence loop that splices the initial state into slot 0 and drops the trailing checkpoint to fabricate an FLA-style h tensor. It now returns the raw checkpoint buffer plus cumulative start offsets (checkpoint_cu_starts), and the caller indexes with flashinfer-native offsets. This removes a full-state allocation/copy and a host loop that incurred .item() syncs.
- Adjust index math to the new convention: Track indices now address the raw checkpoint buffer directly. The per-request entry count changes from `ceil(L/C)` to `L//C`, and the source index is shifted by -1 accordingly `(FLA h[m] = ckpts[m-1])`.
- Use a fused kernel for final-track copies: The final-state movement of conv_states/ssm_states switches from per-tensor index-copy to a fused Triton kernel, which is also extended to support 2D non-contiguous per-layer views, relax the contiguity requirement, and cast indices to int32 automatically.

## Test Plan
<!-- How was this validated? -->
