### PR TITLE
fix(moe): fix divide zero bug and guard nvfp4 flashinfer forward on empty input

### DIFF
--- a/python/tokenspeed/runtime/layers/moe/backends/nvfp4/flashinfer_trtllm.py
+++ b/python/tokenspeed/runtime/layers/moe/backends/nvfp4/flashinfer_trtllm.py
@@ -286,10 +286,24 @@ class Nvfp4FlashinferTrtllmBackend(MoEBackend):
         do_finalize: bool = True,
     ) -> torch.Tensor:
         del num_global_tokens, max_num_tokens_per_gpu
-        from tokenspeed_kernel.ops.quantization.flashinfer import fp4_quantize
 
         x = hidden_states
         num_tokens = x.shape[0]
+        # Idle DP ranks run a dummy forward with 0 tokens. The fused
+        # kernel divides by the token count on the host and SIGFPEs on
+        # empty input, so skip the experts entirely.
+        if num_tokens == 0:
+            if do_finalize:
+                return x
+            return (
+                x,
+                x.new_empty((0, self.spec.top_k), dtype=torch.bfloat16),
+                # moe_finalize_fuse_shared expects a 1-D
+                # [num_tokens * top_k] permute map.
+                x.new_empty((0,), dtype=torch.int32),
+            )
+
+        from tokenspeed_kernel.ops.quantization.flashinfer import fp4_quantize
 
         # Quantize input to FP4 using the fused-kernel scale layout.
         hs_fp4, hs_scale = fp4_quantize(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/moe.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/moe.py
@@ -104,6 +104,10 @@ def moe_finalize_fuse_shared(
     out = torch.empty(
         num_tokens, hidden_dim, dtype=torch.bfloat16, device=gemm2_out.device
     )
+    # Idle DP ranks may finalize 0 tokens; the kernel launch cannot take
+    # an empty grid, so return the empty output directly.
+    if num_tokens == 0:
+        return out
     # The C++ side uses numel()==0 to mean "no shared bias"; pass an empty
     # placeholder when the caller didn't provide one. Avoids optional-tensor
     # plumbing through tvm_ffi.


### PR DESCRIPTION
## Summary

`Nvfp4FlashinferTrtllmBackend.forward` has had no empty-input guard since
the initial release. With DP attention (`data-parallel-size > 1`), when one
DP group runs a prefill, the other group executes an eager idle forward
with a 0-token dummy input. The idle forward skips attention but still
calls the MoE experts; with NVFP4 quantization the backend feeds the empty
tensor straight into `fp4_quantize` + the fused FlashInfer MoE kernel,
whose launcher does a host-side integer division by the token count
(`trtllm_fused_moe_kernel_launcher.cu`) and crashes the whole process with
SIGFPE — no Python traceback.

Pure-DP (attn-tp=1) configs never hit this because the cross-group MoE
all-gather always feeds idle ranks at least one row; it surfaces with
hybrid attn-tp×dp topologies where the MoE group is congruent with the
attn-tp group (all-reduce path), e.g. MiniMax-M2.5 NVFP4 with
attn-tp=2 × dp=2 × moe-tp=2.

## Fix

Early-return on `hidden_states.shape[0] == 0` before quantization,
mirroring the guard the unquantized FlashInfer TRT-LLM backend already
has. Both return shapes are covered:

- `do_finalize=True`: return the input unchanged.
- `do_finalize=False` (deferred-finalize path used by DeepSeek/LongCat,
  which explicitly allows 0-token flows via `empty_topk_output`): return
  an empty `(gemm2_out, expert_weights, expanded_idx)` triple with the
  dtypes of the normal path (bf16 weights, int32 indices).