### PR TITLE
Fix EP8 DP/TP RSAG init and empty LM head

### DIFF
--- a/python/tokenspeed/runtime/distributed/comm_backend/auto.py
+++ b/python/tokenspeed/runtime/distributed/comm_backend/auto.py
@@ -88,6 +88,11 @@ class AutoBackend(CommBackend):
     ) -> torch.Tensor:
         return self._rsag.token_reduce_scatter(tensor, group, scattered_num_tokens)
 
+    def precreate_token_rsag_state(
+        self, group: Group, hidden_size: int, max_num_tokens: int
+    ) -> None:
+        self._rsag.precreate_state(group, hidden_size, max_num_tokens)
+
     # ---- Public CommBackend interface ----
 
     def all_reduce(self, tensor: torch.Tensor, group: Group, op=None) -> torch.Tensor:

--- a/python/tokenspeed/runtime/distributed/comm_backend/triton_rsag.py
+++ b/python/tokenspeed/runtime/distributed/comm_backend/triton_rsag.py
@@ -55,12 +55,15 @@ class TritonRSAGBackend:
         # (group_tuple, hidden_size) -> Triton RS/AG state
         self._instances = {}
 
-    def _get_or_create(self, group: Group, hidden_size: int):
+    def _get_or_create(
+        self, group: Group, hidden_size: int, max_num_tokens: int | None = None
+    ):
         key = (group, hidden_size)
         if key in self._instances:
             return self._instances[key]
 
-        max_num_tokens = self._get_max_num_gathered_tokens()
+        if max_num_tokens is None:
+            max_num_tokens = self._get_max_num_gathered_tokens()
         state = create_state(
             group=pg_manager.get_process_group("nccl", group),
             rank_in_group=group.index(dist.get_rank()),
@@ -69,6 +72,11 @@ class TritonRSAGBackend:
         )
         self._instances[key] = state
         return state
+
+    def precreate_state(
+        self, group: Group, hidden_size: int, max_num_tokens: int
+    ) -> None:
+        self._get_or_create(group, hidden_size, max_num_tokens=max_num_tokens)
 
     def all_gather(
         self,

--- a/python/tokenspeed/runtime/execution/distributed_initializer.py
+++ b/python/tokenspeed/runtime/execution/distributed_initializer.py
@@ -22,10 +22,12 @@ from dataclasses import dataclass
 
 import torch
 
+from tokenspeed.runtime.distributed.comm_backend import get_global_backend
 from tokenspeed.runtime.distributed.process_group_manager import (
     process_group_manager as pg_manager,
 )
 from tokenspeed.runtime.utils import (
+    ceil_div,
     get_available_gpu_memory,
     get_colorful_logger,
 )
@@ -161,6 +163,8 @@ class DistributedInitializer:
         pg_manager.init_process_group(config.mapping.dense.tp_group)
         pg_manager.init_process_group(config.mapping.moe.tp_ep_group)
 
+        DistributedInitializer._precreate_dense_rsag_state(config)
+
         logger.info(
             "Init comm buff end. Avail mem=%.4f GB",
             get_available_gpu_memory(config.device, config.gpu_id),
@@ -191,3 +195,37 @@ class DistributedInitializer:
                 )
 
         return min_per_gpu_memory
+
+    @staticmethod
+    def _precreate_dense_rsag_state(config: DistributedConfig) -> None:
+        mapping = config.mapping
+        if mapping is None or config.device != "cuda":
+            return
+        if not mapping.attn.has_dp or not mapping.dense.has_tp:
+            return
+        if mapping.dense.tp_size <= mapping.attn.tp_size:
+            return
+        if config.hidden_size <= 0 or config.max_num_tokens <= 0:
+            return
+
+        max_scattered_num_tokens = ceil_div(config.max_num_tokens, mapping.attn.tp_size)
+        max_gathered_num_tokens = max_scattered_num_tokens * max(
+            mapping.attn.tp_size,
+            mapping.dense.tp_size,
+            mapping.moe.tp_ep_size,
+        )
+        logger.info(
+            "Precreating dense RSAG state. group=%s hidden_size=%s "
+            "max_num_tokens=%s",
+            mapping.dense.tp_group,
+            config.hidden_size,
+            max_gathered_num_tokens,
+        )
+        backend = get_global_backend()
+        precreate = getattr(backend, "precreate_token_rsag_state", None)
+        if precreate is not None:
+            precreate(
+                mapping.dense.tp_group,
+                hidden_size=config.hidden_size,
+                max_num_tokens=max_gathered_num_tokens,
+            )

--- a/python/tokenspeed/runtime/layers/logits_processor.py
+++ b/python/tokenspeed/runtime/layers/logits_processor.py
@@ -501,8 +501,19 @@ class LogitsProcessor(nn.Module):
                 hidden_states, plan
             )
 
+        empty_hidden = hidden_states.shape[0] == 0
+        if empty_hidden and (self.skip_all_gather or self.tp_size == 1):
+            vocab_size = int(self.config.vocab_size)
+            if hasattr(lm_head, "weight"):
+                dtype = lm_head.weight.dtype
+                device = lm_head.weight.device
+            else:
+                dtype = hidden_states.dtype
+                device = hidden_states.device
+            return torch.empty((0, vocab_size), dtype=dtype, device=device)
+
         if hasattr(lm_head, "weight"):
-            if self._use_fused_lm_head:
+            if self._use_fused_lm_head and not empty_hidden:
                 logits = _lm_head_matmul(hidden_states, lm_head.weight)
             else:
                 logits = torch.matmul(

--- a/test/runtime/distributed/test_comm_ops.py
+++ b/test/runtime/distributed/test_comm_ops.py
@@ -346,6 +346,125 @@ class TestFusionParams:
         assert params.norm_weight is weight
 
 
+class _FakeTokenBackend:
+
+    def __init__(self, name):
+        self.name = name
+        self.calls = []
+
+    def token_all_gather(self, tensor, group, scattered_num_tokens):
+        self.calls.append(("token_all_gather", group, scattered_num_tokens))
+        return f"{self.name}:token_all_gather"
+
+    def token_reduce_scatter(self, tensor, group, scattered_num_tokens):
+        self.calls.append(("token_reduce_scatter", group, scattered_num_tokens))
+        return f"{self.name}:token_reduce_scatter"
+
+    def precreate_state(self, group, hidden_size, max_num_tokens):
+        self.calls.append(("precreate_state", group, hidden_size, max_num_tokens))
+
+
+class TestAutoBackendRsagPrecreate:
+
+    def test_precreate_token_rsag_state_delegates_to_rsag(self):
+        from tokenspeed.runtime.distributed.comm_backend.auto import AutoBackend
+
+        backend = AutoBackend()
+        backend._rsag = _FakeTokenBackend("rsag")
+
+        backend.precreate_token_rsag_state((0, 1, 2, 3), 128, 1024)
+
+        assert backend._rsag.calls == [("precreate_state", (0, 1, 2, 3), 128, 1024)]
+
+    def test_dense_rsag_precreate_only_for_attention_dp_supergroup(self, monkeypatch):
+        from tokenspeed.runtime.distributed.mapping import Mapping
+        from tokenspeed.runtime.execution.distributed_initializer import (
+            DistributedConfig,
+            DistributedInitializer,
+        )
+
+        calls = []
+
+        class FakeBackend:
+            def precreate_token_rsag_state(self, group, hidden_size, max_num_tokens):
+                calls.append((group, hidden_size, max_num_tokens))
+
+        monkeypatch.setattr(
+            "tokenspeed.runtime.execution.distributed_initializer.get_global_backend",
+            lambda: FakeBackend(),
+        )
+        mapping = Mapping(
+            rank=0,
+            world_size=8,
+            attn_tp_size=4,
+            attn_dp_size=2,
+            dense_tp_size=8,
+            moe_ep_size=8,
+        )
+        config = DistributedConfig(
+            device="cuda",
+            gpu_id=0,
+            world_size=8,
+            global_rank=0,
+            local_rank=0,
+            attn_tp_rank=0,
+            attn_tp_size=4,
+            dp_size=2,
+            dense_tp_size=8,
+            moe_ep_size=8,
+            moe_ep_rank=0,
+            nccl_port=12345,
+            hidden_size=7168,
+            max_num_tokens=8192,
+            mapping=mapping,
+        )
+
+        DistributedInitializer._precreate_dense_rsag_state(config)
+
+        assert calls == [(mapping.dense.tp_group, 7168, 16384)]
+
+    def test_dense_rsag_precreate_skips_without_attention_dp(self, monkeypatch):
+        from tokenspeed.runtime.distributed.mapping import Mapping
+        from tokenspeed.runtime.execution.distributed_initializer import (
+            DistributedConfig,
+            DistributedInitializer,
+        )
+
+        calls = []
+        monkeypatch.setattr(
+            "tokenspeed.runtime.execution.distributed_initializer.get_global_backend",
+            lambda: calls.append("called"),
+        )
+
+        mapping = Mapping(
+            rank=0,
+            world_size=4,
+            attn_tp_size=4,
+            dense_tp_size=4,
+            moe_ep_size=4,
+        )
+        config = DistributedConfig(
+            device="cuda",
+            gpu_id=0,
+            world_size=4,
+            global_rank=0,
+            local_rank=0,
+            attn_tp_rank=0,
+            attn_tp_size=4,
+            dp_size=1,
+            dense_tp_size=4,
+            moe_ep_size=4,
+            moe_ep_rank=0,
+            nccl_port=12345,
+            hidden_size=7168,
+            max_num_tokens=8192,
+            mapping=mapping,
+        )
+        DistributedInitializer._precreate_dense_rsag_state(config)
+
+        assert calls == []
+
+
 # ---------------------------------------------------------------------------
 # Multi-GPU test classes
 # ---------------------------------------------------------------------------

--- a/test/runtime/test_logits_processor.py
+++ b/test/runtime/test_logits_processor.py
@@ -90,6 +90,57 @@ def test_tp_logits_all_gather_handles_zero_rows(monkeypatch):
     assert tuple(output.next_token_logits.shape) == (0, 6)
 
 
+def test_empty_dp_local_hidden_returns_empty_logits_without_lm_head_launch(
+    monkeypatch,
+):
+    processor = LogitsProcessor(
+        SimpleNamespace(vocab_size=7, model_type="kimi_k2"),
+        skip_all_gather=True,
+        tp_rank=0,
+        tp_size=4,
+        tp_group=(0, 1, 2, 3),
+    )
+    hidden_states = torch.empty((0, 3), dtype=torch.float32)
+    lm_head = SimpleNamespace(weight=torch.empty((11, 3), dtype=torch.bfloat16))
+
+    def fail_on_fused_lookup():
+        raise AssertionError("empty local hidden must not launch fused lm_head")
+
+    monkeypatch.setattr(
+        logits_processor_module,
+        "_get_fused_lm_head_gemm",
+        fail_on_fused_lookup,
+    )
+
+    logits = processor._get_logits(
+        hidden_states,
+        lm_head,
+        LogitsMetadata(forward_mode=ForwardMode.DECODE),
+    )
+
+    assert logits.shape == (0, 7)
+    assert logits.dtype == torch.bfloat16
+
+
+def test_empty_hidden_single_tp_returns_empty_logits():
+    processor = LogitsProcessor(
+        SimpleNamespace(vocab_size=7, model_type="unit_test"),
+        tp_rank=0,
+        tp_size=1,
+    )
+    hidden_states = torch.empty((0, 3), dtype=torch.float32)
+    lm_head = SimpleNamespace(weight=torch.empty((11, 3), dtype=torch.float16))
+
+    logits = processor._get_logits(
+        hidden_states,
+        lm_head,
+        LogitsMetadata(forward_mode=ForwardMode.DECODE),
+    )
+
+    assert logits.shape == (0, 7)
+    assert logits.dtype == torch.float16
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_fused_softcap_handles_large_logits_without_nan():
     cap = 30.0


### PR DESCRIPTION
## Summary

This PR narrows the EP8/DP2/TP4 fix to two concrete runtime issues:

- Precreate the dense TP TritonRSAG state during distributed initialization for attention-DP + dense-supergroup topologies. This avoids divergent first-use ordering of RSAG state creation across ranks before the hidden/logits boundary is reached.
- Treat an empty local hidden batch as valid at the LM-head boundary. When DP attention leaves a rank with zero local tokens, the logits processor now returns an empty logits tensor for local-logits/single-TP paths instead of launching the Kimi fused LM-head kernel.

Follow-up work is intentionally left out of this PR: global-to-local `gather_ids` layout handling, sampler output merge semantics, output logprobs with local logits, and EAGLE3/NextN hidden-capture merging.

## Test Plan

- `.venv/bin/python -m pytest test/runtime/distributed/test_comm_ops.py::TestAutoBackendRsagPrecreate test/runtime/test_logits_processor.py -q`
- `.venv/bin/pre-commit run --all-files`

Additional manual validation from the investigation:

- Direct EP8/DP2/TP4 engine smoke passed with the RSAG precreate fix.
- Kimi-K2.5 NVFP4 AIME benchmark passed with score above threshold.