### PR TITLE
fix(runtime bug): MoE collective sizing and aux hidden capture under heterogeneous TP

### DIFF
--- a/python/tokenspeed/runtime/distributed/comm_manager.py
+++ b/python/tokenspeed/runtime/distributed/comm_manager.py
@@ -97,7 +97,9 @@ class CommManager:
         global_counts = (
             ctx.global_bs if ctx.draft_first_step_reduce else ctx.global_num_tokens
         )
-        if global_counts is not None:
+        # Without DP, all ranks share the batch and the scattered table needs
+        # no global metadata, so the lookup below stays valid.
+        if global_counts is not None or not self.mapping.attn.has_dp:
             # After post_attn_comm reduce-scatter, each rank holds its
             # scattered share of its attn dp group's tokens, not the raw
             # global count; MoE collectives must size from those rows.
@@ -106,6 +108,8 @@ class CommManager:
                 scattered[self.mapping.attn.scatter_index(rank)]
                 for rank in self.mapping.moe.tp_ep_group
             ]
+        # With DP but no gathered metadata, other dp groups' counts are
+        # unknown; only the local rank's contribution can be reported.
         num_tokens = ctx.bs if ctx.draft_first_step_reduce else ctx.input_num_tokens
         result = [0] * tp_ep_size
         result[self.mapping.moe.tp_ep_rank] = num_tokens

--- a/python/tokenspeed/runtime/distributed/comm_manager.py
+++ b/python/tokenspeed/runtime/distributed/comm_manager.py
@@ -138,6 +138,24 @@ class CommManager:
             scattered_num_tokens=self.attn_tp_group_scattered_num_tokens(ctx),
         )
 
+    def gather_residual(self, residual: torch.Tensor, ctx: ForwardContext):
+        """All-gather a residual left scattered by the previous layer's RSAG
+        path (e.g. for aux hidden capture); no-op when rows are already full.
+
+        Mirrors the pre_attn_comm gather conditions.
+        """
+        if self.layer_id == 0:
+            return residual
+        if not self.mapping.has_attn_tp:
+            return residual
+        if self.use_all_reduce(self.prev_is_moe):
+            return residual
+        return token_all_gather(
+            residual,
+            group=self.mapping.attn.tp_group,
+            scattered_num_tokens=self.attn_tp_group_scattered_num_tokens(ctx),
+        )
+
     def post_attn_comm(
         self, hidden_states: torch.Tensor, residual: torch.Tensor, ctx: ForwardContext
     ):

--- a/python/tokenspeed/runtime/distributed/comm_manager.py
+++ b/python/tokenspeed/runtime/distributed/comm_manager.py
@@ -68,7 +68,11 @@ class CommManager:
         if global_counts is not None:
             scattered = []
             for attn_dp_rank in range(self.mapping.attn.dp_size):
-                num_tokens = global_counts[attn_dp_rank * self.mapping.attn.tp_size]
+                # global_counts is indexed by global rank with dp stride
+                # tp_size * cp_size; cp peers report the same count.
+                num_tokens = global_counts[
+                    attn_dp_rank * self.mapping.attn.tp_size * self.mapping.attn.cp_size
+                ]
                 scattered.extend(
                     self._scatter_count(num_tokens, self.mapping.attn.tp_size)
                 )
@@ -94,8 +98,14 @@ class CommManager:
             ctx.global_bs if ctx.draft_first_step_reduce else ctx.global_num_tokens
         )
         if global_counts is not None:
-            start = self.mapping.moe.dp_rank * tp_ep_size
-            return list(global_counts[start : start + tp_ep_size])
+            # After post_attn_comm reduce-scatter, each rank holds its
+            # scattered share of its attn dp group's tokens, not the raw
+            # global count; MoE collectives must size from those rows.
+            scattered = self.scattered_num_tokens(ctx)
+            return [
+                scattered[self.mapping.attn.scatter_index(rank)]
+                for rank in self.mapping.moe.tp_ep_group
+            ]
         num_tokens = ctx.bs if ctx.draft_first_step_reduce else ctx.input_num_tokens
         result = [0] * tp_ep_size
         result[self.mapping.moe.tp_ep_rank] = num_tokens

--- a/python/tokenspeed/runtime/distributed/mapping.py
+++ b/python/tokenspeed/runtime/distributed/mapping.py
@@ -185,6 +185,15 @@ class AttentionLayerMapping(MappingBase):
             self.rank, self.dp_size, stride=self.tp_size * self.cp_size
         )
 
+    def scatter_index(self, rank: int) -> int:
+        """Index of ``rank`` in a dp-major/tp-minor scattered token count
+        table; cp peers share their dp group's tp split."""
+        tp_rank = _make_parallelism_rank(rank, self.tp_size, stride=1)
+        dp_rank = _make_parallelism_rank(
+            rank, self.dp_size, stride=self.tp_size * self.cp_size
+        )
+        return dp_rank * self.tp_size + tp_rank
+
 
 class MoeLayerMapping(MappingBase):
     def __init__(

--- a/python/tokenspeed/runtime/models/base/comm_ops.py
+++ b/python/tokenspeed/runtime/models/base/comm_ops.py
@@ -81,7 +81,9 @@ def _group_scattered_num_tokens(
         return _scattered_num_tokens_all(ctx, mapping)[start:end]
     elif group_type == ParallelGroup.MOE_TP_EP:
         tp_ep_size = mapping.moe.tp_ep_size
-        if ctx.global_num_tokens is not None:
+        # Without DP, all ranks share the batch and the scattered table needs
+        # no global metadata, so the lookup below stays valid.
+        if ctx.global_num_tokens is not None or not mapping.attn.has_dp:
             # After the attention reduce-scatter, each rank holds its
             # scattered share of its attn dp group's tokens, not the raw
             # global count; MoE collectives must size from those rows.
@@ -90,6 +92,8 @@ def _group_scattered_num_tokens(
                 scattered[mapping.attn.scatter_index(rank)]
                 for rank in mapping.moe.tp_ep_group
             ]
+        # With DP but no gathered metadata, other dp groups' counts are
+        # unknown; only the local rank's contribution can be reported.
         result = [0] * tp_ep_size
         result[mapping.moe.tp_ep_rank] = ctx.input_num_tokens
         return result

--- a/python/tokenspeed/runtime/models/base/comm_ops.py
+++ b/python/tokenspeed/runtime/models/base/comm_ops.py
@@ -56,7 +56,11 @@ def _scattered_num_tokens_all(ctx: ForwardContext, mapping: Mapping) -> List[int
     if ctx.global_num_tokens is not None:
         scattered: List[int] = []
         for attn_dp_rank in range(mapping.attn.dp_size):
-            num_tokens = ctx.global_num_tokens[attn_dp_rank * mapping.attn.tp_size]
+            # global_num_tokens is indexed by global rank with dp stride
+            # tp_size * cp_size; cp peers report the same count.
+            num_tokens = ctx.global_num_tokens[
+                attn_dp_rank * mapping.attn.tp_size * mapping.attn.cp_size
+            ]
             scattered.extend(_scatter_count(num_tokens, mapping.attn.tp_size))
         return scattered
     return _scatter_count(ctx.input_num_tokens, mapping.attn.tp_size)
@@ -78,8 +82,14 @@ def _group_scattered_num_tokens(
     elif group_type == ParallelGroup.MOE_TP_EP:
         tp_ep_size = mapping.moe.tp_ep_size
         if ctx.global_num_tokens is not None:
-            start = mapping.moe.dp_rank * tp_ep_size
-            return list(ctx.global_num_tokens[start : start + tp_ep_size])
+            # After the attention reduce-scatter, each rank holds its
+            # scattered share of its attn dp group's tokens, not the raw
+            # global count; MoE collectives must size from those rows.
+            scattered = _scattered_num_tokens_all(ctx, mapping)
+            return [
+                scattered[mapping.attn.scatter_index(rank)]
+                for rank in mapping.moe.tp_ep_group
+            ]
         result = [0] * tp_ep_size
         result[mapping.moe.tp_ep_rank] = ctx.input_num_tokens
         return result

--- a/python/tokenspeed/runtime/models/base/decoder_layer.py
+++ b/python/tokenspeed/runtime/models/base/decoder_layer.py
@@ -135,8 +135,12 @@ class BaseDecoderLayer(nn.Module, Generic[_C]):
         )
 
         if aux_hidden_states is not None:
-
-            aux_hidden_states.append(residual.clone())
+            # Under RSAG the residual entering this layer is reduce-scattered
+            # across the attn TP group; aux consumers (e.g. the EAGLE3
+            # drafter) expect full rows, so gather before capturing.
+            aux_hidden_states.append(
+                self.comm_manager.gather_residual(residual, ctx).clone()
+            )
 
         hidden_states = self.comm_manager.pre_attn_comm(hidden_states, ctx)
 

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -1291,8 +1291,15 @@ class DeepseekV3Model(nn.Module):
         aux_hidden_states = [] if self.layers_to_capture else None
         for i in range(len(self.layers)):
             if aux_hidden_states is not None and i in self.layers_to_capture:
-                aux_hidden_states.append(
+                # Under RSAG the inter-layer hidden/residual are reduce-
+                # scattered across the attn TP group; aux consumers (e.g. the
+                # EAGLE3 drafter) expect full rows, so gather before capturing.
+                aux = (
                     hidden_states + residual if residual is not None else hidden_states
+                )
+                gathered = self.layers[i].comm_manager.gather_residual(aux, ctx)
+                aux_hidden_states.append(
+                    gathered if gathered is aux else gathered.clone()
                 )
             with get_global_expert_distribution_recorder().with_current_layer(i):
                 layer = self.layers[i]


### PR DESCRIPTION
## Summary

This PR fixes three bugs on the heterogeneous-TP (RSAG) path, where attention TP differs from MoE TP/EP: each fix unmasked the next one along the same forward chain.

### 1. MoE collective sizing under DP (#405)

- **Condition:** attn TP > 1 with DP (e.g. attn tp2 × dp2 + moe tp4).
- **Bug:** `post_attn_comm` reduce-scatters hidden states across the attention
  TP group, but MoE collectives sized each rank from raw `global_num_tokens`
  entries instead of its post-attention scattered rows →
  `hidden_states.shape=(2, H) | local_num_tokens=4` assert at CUDA graph
  capture.
- **Fix:** size MoE all-gather / reduce-scatter from the scattered-count table
  via the new `AttentionLayerMapping.scatter_index`. The table builders also
  read each DP group's count at stride `tp_size * cp_size` (was `tp_size`),
  matching the global-rank layout of `global_num_tokens`. Applied to both
  `CommManager` and the compiled-layer mirror in `models/base/comm_ops.py`.

### 2. MoE collective sizing without DP

- **Condition:** no DP (`global_num_tokens` is None) + heterogeneous TP
  (e.g. attn tp4 + moe tp2).
- **Bug:** the code never took the `global_counts is not None` branch and fell
  through to the one-hot fallback (`[N, 0]` on rank 0 vs `[0, N]` on rank 1),
  giving each rank of the same MoE group a different layout for the same
  collective → same class of shape mismatch as #405.
- **Fix:** without DP all ranks share the batch, so the scattered table needs
  no global metadata; route this case through the same `scatter_index` lookup.
  The one-hot fallback remains only for DP-without-metadata, which cannot
  occur in production.

### 3. EAGLE3/deepseekV3 aux hidden capture

- **Condition:** RSAG path + EAGLE3/deepseekV3 (aux hidden capture enabled).
- **Bug:** the aux hidden capture (`BaseDecoderLayer.forward_attn`, and the
  deepseek_v3 layer loop) cloned the residual before the pre-attention
  all-gather, so the drafter received per-rank fragments and failed when
  concatenating them with full-row token embeddings
  (`torch.cat: expected size 4 but got size 2`). Previously unreachable —
  the same topology crashed earlier at bug 1.
- **Fix:** new `CommManager.gather_residual` (gather conditions mirror
  `pre_attn_comm`), called at both capture sites. No-op for pure-DP and
  uniform-TP topologies, so existing configs are unaffected.
