### PR TITLE
ci(gpt-oss): replace throughput to output throughput

### DIFF
--- a/test/random_benchmark/tokenspeed/collect_outputs.py
+++ b/test/random_benchmark/tokenspeed/collect_outputs.py
@@ -10,7 +10,7 @@ COLUMNS = [
     "config",
     "Conc.",
     "Latency (tps/user)",
-    "Throughput (tps/gpu)",
+    "Output Throughput (tps/gpu)",
     "Approx Cache Hit",
     "Decoded Tok/Iter",
 ]
@@ -49,6 +49,15 @@ def _float(summary: dict, key: str) -> float:
         return 0.0
 
 
+def _output_tps(summary: dict) -> float:
+    output_tps = _float(summary, "Output Throughput (tok/s)")
+    if output_tps:
+        return output_tps
+    return _float(summary, "Req Throughput (req/s)") * _float(
+        summary, "Avg Output Tokens"
+    )
+
+
 def collect(sweep_dir: Path, num_gpus: int):
     rows = []
     for summary_path in sorted(sweep_dir.rglob("benchmark_summary.json")):
@@ -63,7 +72,7 @@ def collect(sweep_dir: Path, num_gpus: int):
 
         tpot_ms = _float(summary, "TPOT (ms)")
         tps_user = 1000.0 / tpot_ms if tpot_ms else 0.0
-        total_tps = _float(summary, "Total Throughput (tok/s)")
+        output_tps = _output_tps(summary)
         cache_hit = _float(summary, "KV Cache Hit Rate (%)")
         decoded_per_iter = _float(summary, "Decoded Tok/Iter") or _float(
             summary, "Avg Decoded Tokens/Iter"
@@ -74,7 +83,7 @@ def collect(sweep_dir: Path, num_gpus: int):
                 "config": config,
                 "Conc.": int(_float(summary, "Concurrency")),
                 "Latency (tps/user)": round(tps_user, 2),
-                "Throughput (tps/gpu)": round(total_tps / num_gpus, 2),
+                "Output Throughput (tps/gpu)": round(output_tps / num_gpus, 2),
                 "Approx Cache Hit": round(cache_hit, 2),
                 "Decoded Tok/Iter": round(decoded_per_iter, 4),
             }

--- a/test/random_benchmark/tokenspeed/collect_outputs.py
+++ b/test/random_benchmark/tokenspeed/collect_outputs.py
@@ -49,15 +49,6 @@ def _float(summary: dict, key: str) -> float:
         return 0.0
 
 
-def _output_tps(summary: dict) -> float:
-    output_tps = _float(summary, "Output Throughput (tok/s)")
-    if output_tps:
-        return output_tps
-    return _float(summary, "Req Throughput (req/s)") * _float(
-        summary, "Avg Output Tokens"
-    )
-
-
 def collect(sweep_dir: Path, num_gpus: int):
     rows = []
     for summary_path in sorted(sweep_dir.rglob("benchmark_summary.json")):
@@ -72,7 +63,7 @@ def collect(sweep_dir: Path, num_gpus: int):
 
         tpot_ms = _float(summary, "TPOT (ms)")
         tps_user = 1000.0 / tpot_ms if tpot_ms else 0.0
-        output_tps = _output_tps(summary)
+        output_tps = _float(summary, "Output Throughput (tok/s)")
         cache_hit = _float(summary, "KV Cache Hit Rate (%)")
         decoded_per_iter = _float(summary, "Decoded Tok/Iter") or _float(
             summary, "Avg Decoded Tokens/Iter"


### PR DESCRIPTION
This pull request updates the data extraction logic in the `collect_outputs.py` script to use "Output Throughput" instead of the previous "Throughput" metric