### PR TITLE
[AMD] warp_decode improvements

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
@@ -4539,51 +4539,28 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
     # X is stored as raw i8 in LDS and bitcast to e4m3 in mfma_scaled; pass the
     # uint8 view (an fp8 LDS buffer fails to lower).
     x_uint8 = x_fp8.view(torch.uint8)
+    # fmt: off
     _warp_decode_topk_stage1_coop_kernel[coop_grid](
-        x_uint8,
-        router_logits_c,
-        w13_raw,
-        w13_scale,
-        topk_ids,
-        topk_weights,
-        inter,
-        n_tokens,
-        n_experts,
-        D,
-        I,
-        x_uint8.stride(0),
-        x_uint8.stride(1),
-        router_logits_c.stride(0),
-        topk_ids.stride(0),
-        topk_weights.stride(0),
-        w13_raw.stride(0),
-        w13_raw.stride(-2),
-        w13_raw.stride(-1),
-        w13_scale.stride(0),
-        w13_scale.stride(-2),
-        w13_scale.stride(-1),
-        inter.stride(0),
-        inter.stride(1),
-        w13_act_scale,
-        w2_act_scale,
-        b13,
-        D_PACKED=D // 2,
-        TOPK=top_k,
+        x_uint8, router_logits_c, w13_raw, w13_scale, topk_ids, topk_weights, inter,
+        n_tokens, n_experts, D, I,
+        x_uint8.stride(0), x_uint8.stride(1),
+        router_logits_c.stride(0), topk_ids.stride(0), topk_weights.stride(0),
+        w13_raw.stride(0), w13_raw.stride(-2), w13_raw.stride(-1),
+        w13_scale.stride(0), w13_scale.stride(-2), w13_scale.stride(-1),
+        inter.stride(0), inter.stride(1),
+        w13_act_scale, w2_act_scale, b13,
+        D_PACKED=D // 2, TOPK=top_k,
         # EP/TKP: padded widths of the [tokens, experts] logits tile and the
         # top-k selection tile; >= 64*num_warps keeps the blocked layout valid.
-        EP=max(_route_next_pow2(n_experts), 64 * COOP_NUM_WARPS),
-        TKP=64 * COOP_NUM_WARPS,
+        EP=max(_route_next_pow2(n_experts), 64 * COOP_NUM_WARPS), TKP=64 * COOP_NUM_WARPS,
         X_DTYPE=_ROUTE_GL_DTYPE[router_logits.dtype],
-        BLOCK_K=COOP_BLOCK_K,
-        BLOCK_N=COOP_BLOCK_N,
-        BLOCK_M=16,
-        NUM_BUFFERS=COOP_NUM_BUFFERS,
-        NUM_WARPS=COOP_NUM_WARPS,
+        BLOCK_K=COOP_BLOCK_K, BLOCK_N=COOP_BLOCK_N, BLOCK_M=16,
+        NUM_BUFFERS=COOP_NUM_BUFFERS, NUM_WARPS=COOP_NUM_WARPS,
         HAS_BIAS=w13_bias is not None,
-        SWIGLU_ALPHA=float(swiglu_alpha),
-        SWIGLU_LIMIT=float(swiglu_limit),
+        SWIGLU_ALPHA=float(swiglu_alpha), SWIGLU_LIMIT=float(swiglu_limit),
         num_warps=COOP_NUM_WARPS,
     )
+    # fmt: on
 
     n_tiles2 = (N + S2_BLOCK_N - 1) // S2_BLOCK_N
     if s2_split_k > 1:
@@ -4601,55 +4578,32 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         s2_stride_on = out.stride(1)
         s2_stride_ok = 0
         s2_grid = (n_tokens * n_tiles2,)
+    # fmt: off
     _warp_decode_stage2_fp8_mxfp4_kernel[s2_grid](
-        inter,
-        w2_raw,
-        w2_scale,
-        topk_ids,
-        topk_weights,
-        s2_dst,
-        n_tokens,
-        N,
-        I,
-        inter.stride(0),
-        inter.stride(1),
-        w2_raw.stride(0),
-        w2_raw.stride(-2),
-        w2_raw.stride(-1),
-        w2_scale.stride(0),
-        w2_scale.stride(-2),
-        w2_scale.stride(-1),
-        s2_stride_om,
-        s2_stride_on,
-        s2_stride_ok,
-        w2_act_scale,
-        b2,
-        I_PACKED=I // 2,
-        TOPK=top_k,
-        BLOCK_K=BLOCK_K,
-        BLOCK_N=S2_BLOCK_N,
-        M_DUP=S2_M_DUP,
-        HAS_BIAS=w2_bias is not None,
-        SPLIT_K=s2_split_k,
+        inter, w2_raw, w2_scale, topk_ids, topk_weights, s2_dst,
+        n_tokens, N, I,
+        inter.stride(0), inter.stride(1),
+        w2_raw.stride(0), w2_raw.stride(-2), w2_raw.stride(-1),
+        w2_scale.stride(0), w2_scale.stride(-2), w2_scale.stride(-1),
+        s2_stride_om, s2_stride_on, s2_stride_ok,
+        w2_act_scale, b2,
+        I_PACKED=I // 2, TOPK=top_k,
+        BLOCK_K=BLOCK_K, BLOCK_N=S2_BLOCK_N, M_DUP=S2_M_DUP,
+        HAS_BIAS=w2_bias is not None, SPLIT_K=s2_split_k,
         num_warps=1,
     )
+    # fmt: on
     if s2_split_k > 1:
         R_BLOCK_N = 256
         r_grid = (n_tokens * ((N + R_BLOCK_N - 1) // R_BLOCK_N),)
+        # fmt: off
         _warp_decode_stage2_reduce[r_grid](
-            out_partial,
-            out,
-            n_tokens,
-            N,
-            out_partial.stride(0),
-            out_partial.stride(1),
-            out_partial.stride(2),
-            out.stride(0),
-            out.stride(1),
-            SPLIT_K=s2_split_k,
-            BLOCK_N=R_BLOCK_N,
-            num_warps=1,
+            out_partial, out, n_tokens, N,
+            out_partial.stride(0), out_partial.stride(1), out_partial.stride(2),
+            out.stride(0), out.stride(1),
+            SPLIT_K=s2_split_k, BLOCK_N=R_BLOCK_N, num_warps=1,
         )
+        # fmt: on
     return out
 
 
@@ -5383,41 +5337,21 @@ def _warp_decode_topk_stage1_coop_kernel(
     expert = gl.sum(
         gl.where(slot_sel, idx_t, gl.zeros([TKP], gl.int32, layout=LT)), axis=0
     )
+    # Grouped by role: coords / tensors / shapes / strides / scalars / constexpr.
+    # fmt: off
     _warp_decode_stage1_coop_compute(
-        token,
-        slot,
-        expert,
-        pid_n,
-        X,
-        W,
-        WScale,
-        Y,
-        M,
-        D,
-        I,
-        stride_xm,
-        stride_xk,
-        stride_we,
-        stride_wk,
-        stride_wn,
-        stride_wse,
-        stride_wsk,
-        stride_wsn,
-        stride_ym,
-        stride_yn,
-        x_global_scale_ptr,
-        out_quant_scale_ptr,
-        w13_bias,
-        TOPK,
-        BLOCK_M,
-        BLOCK_N,
-        BLOCK_K,
-        NUM_BUFFERS,
-        NUM_WARPS,
-        HAS_BIAS,
-        SWIGLU_ALPHA,
-        SWIGLU_LIMIT,
+        token, slot, expert, pid_n,
+        X, W, WScale, Y,
+        M, D, I,
+        stride_xm, stride_xk,
+        stride_we, stride_wk, stride_wn,
+        stride_wse, stride_wsk, stride_wsn,
+        stride_ym, stride_yn,
+        x_global_scale_ptr, out_quant_scale_ptr, w13_bias,
+        TOPK, BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, NUM_WARPS,
+        HAS_BIAS, SWIGLU_ALPHA, SWIGLU_LIMIT,
     )
+    # fmt: on
 
 
 @gluon.jit
@@ -5497,50 +5431,20 @@ def _warp_decode_stage2_load_pair(
     I_PACKED: gl.constexpr,
 ):
     """Load the even (kt) and odd (kt+1) K-tiles of one pipeline step."""
+    # fmt: off
     a_even, b_even, s_even = _warp_decode_stage2_load_tile(
-        kt,
-        ak,
-        bk,
-        bsk,
-        am,
-        X,
-        W,
-        WScale,
-        x_row_off,
-        w_n_off,
-        ws_expert_off,
-        scale_row_off,
-        stride_xk,
-        stride_wk,
-        stride_wsk,
-        I,
-        BLOCK_K,
-        BLOCK_K_PACKED,
-        BLOCK_K_SCALE,
-        I_PACKED,
+        kt, ak, bk, bsk, am, X, W, WScale,
+        x_row_off, w_n_off, ws_expert_off, scale_row_off,
+        stride_xk, stride_wk, stride_wsk, I,
+        BLOCK_K, BLOCK_K_PACKED, BLOCK_K_SCALE, I_PACKED,
     )
     a_odd, b_odd, s_odd = _warp_decode_stage2_load_tile(
-        kt + 1,
-        ak,
-        bk,
-        bsk,
-        am,
-        X,
-        W,
-        WScale,
-        x_row_off,
-        w_n_off,
-        ws_expert_off,
-        scale_row_off,
-        stride_xk,
-        stride_wk,
-        stride_wsk,
-        I,
-        BLOCK_K,
-        BLOCK_K_PACKED,
-        BLOCK_K_SCALE,
-        I_PACKED,
+        kt + 1, ak, bk, bsk, am, X, W, WScale,
+        x_row_off, w_n_off, ws_expert_off, scale_row_off,
+        stride_xk, stride_wk, stride_wsk, I,
+        BLOCK_K, BLOCK_K_PACKED, BLOCK_K_SCALE, I_PACKED,
     )
+    # fmt: on
     return a_even, b_even, s_even, a_odd, b_odd, s_odd
 
 
@@ -5549,24 +5453,16 @@ def _warp_decode_stage2_mfma_pair(
     acc, a_even, b_even, s_even, a_odd, b_odd, s_odd, a_scale
 ):
     """Accumulate the scaled-MFMA of one even+odd K-tile pair (fp8 x mxfp4)."""
+    # fmt: off
     acc = gl.amd.cdna4.mfma_scaled(
-        a=a_even,
-        a_scale=a_scale,
-        a_format="e4m3",
-        b=b_even,
-        b_scale=s_even,
-        b_format="e2m1",
-        acc=acc,
+        a=a_even, a_scale=a_scale, a_format="e4m3",
+        b=b_even, b_scale=s_even, b_format="e2m1", acc=acc,
     )
     acc = gl.amd.cdna4.mfma_scaled(
-        a=a_odd,
-        a_scale=a_scale,
-        a_format="e4m3",
-        b=b_odd,
-        b_scale=s_odd,
-        b_format="e2m1",
-        acc=acc,
+        a=a_odd, a_scale=a_scale, a_format="e4m3",
+        b=b_odd, b_scale=s_odd, b_format="e2m1", acc=acc,
     )
+    # fmt: on
     return acc
 
 
@@ -5675,71 +5571,29 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
                 # prefetch the first pair, then each iteration loads the next pair
                 # before MFMA-ing the current one (prefetch depth 2).
                 main_kt = main_end - kt_start
+                # fmt: off
                 if main_kt > 0:
-                    a_even, b_even, s_even, a_odd, b_odd, s_odd = (
-                        _warp_decode_stage2_load_pair(
-                            kt_start,
-                            ak,
-                            bk,
-                            bsk,
-                            am,
-                            X,
-                            W,
-                            WScale,
-                            x_row_off,
-                            w_n_off,
-                            ws_expert_off,
-                            scale_row_off,
-                            stride_xk,
-                            stride_wk,
-                            stride_wsk,
-                            I,
-                            BLOCK_K,
-                            BLOCK_K_PACKED,
-                            BLOCK_K_SCALE,
-                            I_PACKED,
-                        )
+                    (a_even, b_even, s_even,
+                     a_odd, b_odd, s_odd) = _warp_decode_stage2_load_pair(
+                        kt_start, ak, bk, bsk, am, X, W, WScale,
+                        x_row_off, w_n_off, ws_expert_off, scale_row_off,
+                        stride_xk, stride_wk, stride_wsk, I,
+                        BLOCK_K, BLOCK_K_PACKED, BLOCK_K_SCALE, I_PACKED,
                     )
                     for kt in range(kt_start, main_end - 2, 2):
-                        (
-                            nxt_a_even,
-                            nxt_b_even,
-                            nxt_s_even,
-                            nxt_a_odd,
-                            nxt_b_odd,
-                            nxt_s_odd,
-                        ) = _warp_decode_stage2_load_pair(
-                            kt + 2,
-                            ak,
-                            bk,
-                            bsk,
-                            am,
-                            X,
-                            W,
-                            WScale,
-                            x_row_off,
-                            w_n_off,
-                            ws_expert_off,
-                            scale_row_off,
-                            stride_xk,
-                            stride_wk,
-                            stride_wsk,
-                            I,
-                            BLOCK_K,
-                            BLOCK_K_PACKED,
-                            BLOCK_K_SCALE,
-                            I_PACKED,
+                        (nxt_a_even, nxt_b_even, nxt_s_even,
+                         nxt_a_odd, nxt_b_odd, nxt_s_odd) = _warp_decode_stage2_load_pair(
+                            kt + 2, ak, bk, bsk, am, X, W, WScale,
+                            x_row_off, w_n_off, ws_expert_off, scale_row_off,
+                            stride_xk, stride_wk, stride_wsk, I,
+                            BLOCK_K, BLOCK_K_PACKED, BLOCK_K_SCALE, I_PACKED,
                         )
                         acc = _warp_decode_stage2_mfma_pair(
                             acc, a_even, b_even, s_even, a_odd, b_odd, s_odd, a_scale
                         )
                         a_even, b_even, s_even, a_odd, b_odd, s_odd = (
-                            nxt_a_even,
-                            nxt_b_even,
-                            nxt_s_even,
-                            nxt_a_odd,
-                            nxt_b_odd,
-                            nxt_s_odd,
+                            nxt_a_even, nxt_b_even, nxt_s_even,
+                            nxt_a_odd, nxt_b_odd, nxt_s_odd,
                         )
                     # Epilogue: MFMA the final prefetched pair.
                     acc = _warp_decode_stage2_mfma_pair(
@@ -5748,37 +5602,17 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
                 # Masked remainder: leftover odd/partial K-tile(s) in this split.
                 for kt in range(main_end, kt_stop):
                     a_t, b_t, s_t = _warp_decode_stage2_load_tile(
-                        kt,
-                        ak,
-                        bk,
-                        bsk,
-                        am,
-                        X,
-                        W,
-                        WScale,
-                        x_row_off,
-                        w_n_off,
-                        ws_expert_off,
-                        scale_row_off,
-                        stride_xk,
-                        stride_wk,
-                        stride_wsk,
-                        I,
-                        BLOCK_K,
-                        BLOCK_K_PACKED,
-                        BLOCK_K_SCALE,
-                        I_PACKED,
+                        kt, ak, bk, bsk, am, X, W, WScale,
+                        x_row_off, w_n_off, ws_expert_off, scale_row_off,
+                        stride_xk, stride_wk, stride_wsk, I,
+                        BLOCK_K, BLOCK_K_PACKED, BLOCK_K_SCALE, I_PACKED,
                         MASK_TAIL=True,
                     )
                     acc = gl.amd.cdna4.mfma_scaled(
-                        a=a_t,
-                        a_scale=a_scale,
-                        a_format="e4m3",
-                        b=b_t,
-                        b_scale=s_t,
-                        b_format="e2m1",
-                        acc=acc,
+                        a=a_t, a_scale=a_scale, a_format="e4m3",
+                        b=b_t, b_scale=s_t, b_format="e2m1", acc=acc,
                     )
+                # fmt: on
                 acc = acc * gl.load(x_global_scale_ptr).to(gl.float32)
                 if HAS_BIAS:
                     bias_n = pid_n * BLOCK_N + gl.arange(

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
@@ -34,10 +34,6 @@ from tokenspeed_kernel_amd.ops.moe.utils import (
     topk,
 )
 
-# Stage2 split-K factor (applied across the whole small-M decode path).
-_WARP_DECODE_S2_SPLIT_K = 4
-
-
 def _as_int32(t):
     if t is None or t.dtype == torch.int32:
         return t
@@ -4503,9 +4499,6 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
     # Pass the FP8 tensor straight to Gluon.  ``view(torch.uint8)`` materializes a
     # copy for float8 tensors on this stack and dominates small-M latency.
 
-    inter = torch.empty(
-        (n_tokens * top_k, I), dtype=x_fp8.dtype, device=hidden_states.device
-    )
     out_dtype = getattr(w2_precision_config, "out_dtype", None) or torch.bfloat16
     out = torch.empty((n_tokens, N), dtype=out_dtype, device=hidden_states.device)
 
@@ -4520,13 +4513,33 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
     b2 = w2_bias if w2_bias is not None else dummy_bias
 
     BLOCK_K = 128
-    S1_BLOCK_N = 8 if n_tokens <= 4 else 16
-    S1_M_DUP = 8 if n_tokens <= 4 else 16
-    S2_BLOCK_N = 8 if n_tokens <= 1 else 16
+    S2_BLOCK_N = 32 if n_tokens >= 16 else (8 if n_tokens <= 1 else 16)
     S2_M_DUP = 4
-    s1_grid = (n_tokens * ((I + S1_BLOCK_N - 1) // S1_BLOCK_N),)
-    _warp_decode_topk_stage1_fp8_mxfp4_kernel[s1_grid](
-        x_fp8,
+    # Tuned stage2 K=I split factor by batch size (8/4 raise small-M occupancy, off for M>=5).
+    if n_tokens <= 2:
+        s2_split_k = 8
+    elif n_tokens <= 4:
+        s2_split_k = 4
+    else:
+        s2_split_k = 1
+
+    inter = torch.empty(
+        (n_tokens * top_k, I), dtype=x_fp8.dtype, device=hidden_states.device
+    )
+    # Cooperative-LDS, num_warps=4, software-pipelined stage1 -- the small-M
+    # decode path (this wrapper is only entered for n_tokens <= SMALLM_MAX_M).
+    # BLOCK_N=64 maximizes CTAs/CU (the kernel is occupancy-bound); BLOCK_K=256
+    # is the MX-scale-swizzle minimum; NUM_BUFFERS=3 is the LDS pipeline depth.
+    COOP_NUM_WARPS = 4
+    COOP_BLOCK_N = 64
+    COOP_BLOCK_K = 256
+    COOP_NUM_BUFFERS = 3
+    coop_grid = (n_tokens * ((2 * I + COOP_BLOCK_N - 1) // COOP_BLOCK_N) * top_k,)
+    # X is stored as raw i8 in LDS and bitcast to e4m3 in mfma_scaled; pass the
+    # uint8 view (an fp8 LDS buffer fails to lower).
+    x_uint8 = x_fp8.view(torch.uint8)
+    _warp_decode_topk_stage1_coop_kernel[coop_grid](
+        x_uint8,
         router_logits_c,
         w13_raw,
         w13_scale,
@@ -4537,8 +4550,8 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         n_experts,
         D,
         I,
-        x_fp8.stride(0),
-        x_fp8.stride(1),
+        x_uint8.stride(0),
+        x_uint8.stride(1),
         router_logits_c.stride(0),
         topk_ids.stride(0),
         topk_weights.stride(0),
@@ -4555,20 +4568,23 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         b13,
         D_PACKED=D // 2,
         TOPK=top_k,
-        EP=_route_next_pow2(n_experts),
-        TKP=_route_next_pow2(top_k),
+        # EP/TKP: padded widths of the [tokens, experts] logits tile and the
+        # top-k selection tile; >= 64*num_warps keeps the blocked layout valid.
+        EP=max(_route_next_pow2(n_experts), 64 * COOP_NUM_WARPS),
+        TKP=64 * COOP_NUM_WARPS,
         X_DTYPE=_ROUTE_GL_DTYPE[router_logits.dtype],
-        BLOCK_K=BLOCK_K,
-        BLOCK_N=S1_BLOCK_N,
-        M_DUP=S1_M_DUP,
+        BLOCK_K=COOP_BLOCK_K,
+        BLOCK_N=COOP_BLOCK_N,
+        BLOCK_M=16,
+        NUM_BUFFERS=COOP_NUM_BUFFERS,
+        NUM_WARPS=COOP_NUM_WARPS,
         HAS_BIAS=w13_bias is not None,
         SWIGLU_ALPHA=float(swiglu_alpha),
         SWIGLU_LIMIT=float(swiglu_limit),
-        num_warps=1,
+        num_warps=COOP_NUM_WARPS,
     )
 
     n_tiles2 = (N + S2_BLOCK_N - 1) // S2_BLOCK_N
-    s2_split_k = _WARP_DECODE_S2_SPLIT_K
     if s2_split_k > 1:
         out_partial = torch.empty(
             (s2_split_k, n_tokens, N), dtype=torch.float32, device=hidden_states.device
@@ -5052,9 +5068,11 @@ def _mxfp4_scale_offset(n_idx, k_scale_idx, stride_wsk, stride_wsn):
     block and the K-scale position into one linear axis.
     """
     row = n_idx.to(gl.uint32)
+    # CDNA4 e8m0 swizzle: K-scale group stride 256, (k%4) stride 64. Using
+    # 128/32 would alias K-scale offsets with the N-part (wrong scale read).
     lin = (
-        (k_scale_idx // 8) * 128
-        + (k_scale_idx % 4) * 32
+        (k_scale_idx // 8) * 256
+        + (k_scale_idx % 4) * 64
         + (row % 16) * 4
         + ((k_scale_idx % 8) // 4) * 2
         + ((row % 32) // 16)
@@ -5068,11 +5086,12 @@ def _swiglu_gate_up(gate, linear, alpha: gl.constexpr, limit: gl.constexpr):
     if limit > 0.0:
         gate = gl.minimum(gate, limit)
         linear = gl.clamp(linear, -limit, limit)
-    return (gate / (1.0 + gl.exp(-alpha * gate))) * (linear + 1.0)
+    sigmoid = 1.0 / (1.0 + gl.exp(-alpha * gate))
+    return (gate * sigmoid) * (linear + 1.0)
 
 
 @gluon.jit
-def _warp_decode_stage1_compute(
+def _warp_decode_stage1_coop_compute(
     token,
     slot,
     expert,
@@ -5097,126 +5116,176 @@ def _warp_decode_stage1_compute(
     x_global_scale_ptr,
     out_quant_scale_ptr,
     w13_bias,
-    D_PACKED: gl.constexpr,
     TOPK: gl.constexpr,
-    BLOCK_K: gl.constexpr,
+    BLOCK_M: gl.constexpr,
     BLOCK_N: gl.constexpr,
-    M_DUP: gl.constexpr,
+    BLOCK_K: gl.constexpr,
+    NUM_BUFFERS: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
     HAS_BIAS: gl.constexpr,
     SWIGLU_ALPHA: gl.constexpr,
     SWIGLU_LIMIT: gl.constexpr,
 ):
-    """Gate/up MFMA + bias + SwiGLU + store for one (token, slot, expert).
-
-    Shared by the fused and direct-topk stage1 kernels, which differ only in how
-    they select ``expert`` and map the program id.
+    """Cooperative gate_up GEMM + bias + SwiGLU + fp8-quant + store for one
+    (token, slot, expert).  N runs over the INTERLEAVED gate_up rows (2*I);
+    ``_swiglu_reduce`` splits even=gate / odd=up.  Mirrors the plain path of
+    ``_pipelined_moe_tile_compute`` (W_TRANSPOSE=False, SCALE_VIA_LDS w-scale,
+    per-tensor x scale) but specialized to a single decode token (row 0 of the
+    BLOCK_M tile).
     """
-    BLOCK_K_PACKED: gl.constexpr = BLOCK_K // 2
-    BLOCK_K_SCALE: gl.constexpr = BLOCK_K // 32
-    _layouts: gl.constexpr = _warp_decode_mfma_layouts(M_DUP, BLOCK_N, BLOCK_K_SCALE)
-    mfma_layout: gl.constexpr = _layouts[0]
-    dot_a_layout: gl.constexpr = _layouts[1]
-    dot_b_layout: gl.constexpr = _layouts[2]
-    a_scale_layout: gl.constexpr = _layouts[3]
-    b_scale_layout: gl.constexpr = _layouts[4]
-    am = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, dot_a_layout))[:, None]
-    ak = gl.arange(0, BLOCK_K, layout=gl.SliceLayout(0, dot_a_layout))[None, :]
-    bk = gl.arange(0, BLOCK_K_PACKED, layout=gl.SliceLayout(1, dot_b_layout))[:, None]
-    bn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, dot_b_layout))[None, :]
-    n_gate = pid_n * BLOCK_N + bn
-    n_up = I + n_gate
-    bsn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(1, b_scale_layout))[:, None]
-    bsk = gl.arange(0, BLOCK_K_SCALE, layout=gl.SliceLayout(0, b_scale_layout))[None, :]
-    n_gate_s = pid_n * BLOCK_N + bsn
-    n_up_s = I + n_gate_s
-    a_scale = gl.full((M_DUP, BLOCK_K_SCALE), 127, gl.uint8, layout=a_scale_layout)
+    N = 2 * I
+    off_n = pid_n * BLOCK_N
+    # Keep base offsets int32 (buffer_load_to_shared requires int32/uint32
+    # offsets); expert * stride fits int32 for GPT-OSS shapes.
+    w_base_offset = expert * stride_we
+    ws_base_offset = expert * stride_wse
 
-    acc_g = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
-    acc_u = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
-    if (token < M) & (expert >= 0):
-        w_base = W + expert.to(gl.int64) * stride_we
-        ws_base = WScale + expert.to(gl.int64) * stride_wse
-        for kt in range(gl.cdiv(D, BLOCK_K)):
-            k_elem = kt * BLOCK_K + ak
-            k_pack = kt * BLOCK_K_PACKED + bk
-            a = gl.load(
-                X
-                + token.to(gl.int64) * stride_xm
-                + k_elem.to(gl.int64) * stride_xk
-                + am.to(gl.int64) * 0,
-                mask=k_elem < D,
-                other=0.0,
-            )
-            b_g = gl.load(
-                w_base
-                + k_pack.to(gl.int64) * stride_wk
-                + n_gate.to(gl.int64) * stride_wn,
-                mask=(k_pack < D_PACKED) & (n_gate < I),
-                other=0,
-            )
-            b_u = gl.load(
-                w_base
-                + k_pack.to(gl.int64) * stride_wk
-                + n_up.to(gl.int64) * stride_wn,
-                mask=(k_pack < D_PACKED) & (n_gate < I),
-                other=0,
-            )
-            sg = kt * BLOCK_K_SCALE + bsk
-            off_g = _mxfp4_scale_offset(n_gate_s, sg, stride_wsk, stride_wsn)
-            off_u = _mxfp4_scale_offset(n_up_s, sg, stride_wsk, stride_wsn)
-            s_g = gl.load(
-                ws_base + off_g, mask=(sg < (D // 32)) & (n_gate_s < I), other=0
-            )
-            s_u = gl.load(
-                ws_base + off_u, mask=(sg < (D // 32)) & (n_gate_s < I), other=0
-            )
-            acc_g = gl.amd.cdna4.mfma_scaled(
-                a=a,
-                a_scale=a_scale,
-                a_format="e4m3",
-                b=b_g,
-                b_scale=s_g,
-                b_format="e2m1",
-                acc=acc_g,
-            )
-            acc_u = gl.amd.cdna4.mfma_scaled(
-                a=a,
-                a_scale=a_scale,
-                a_format="e4m3",
-                b=b_u,
-                b_scale=s_u,
-                b_format="e2m1",
-                acc=acc_u,
-            )
-    x_scale = gl.load(x_global_scale_ptr).to(gl.float32)
-    acc_g = acc_g * x_scale
-    acc_u = acc_u * x_scale
-    if HAS_BIAS:
-        bias_n = pid_n * BLOCK_N + gl.arange(
-            0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout)
-        )
-        w13_base = w13_bias + expert.to(gl.int64) * (2 * I)
-        bound = (token < M) & (bias_n < I)
-        acc_g = _add_expert_bias(acc_g, w13_base, bias_n, bound, mfma_layout)
-        acc_u = _add_expert_bias(acc_u, w13_base + I, bias_n, bound, mfma_layout)
-    out_scale = gl.load(out_quant_scale_ptr).to(gl.float32)
-    out = _swiglu_gate_up(acc_g, acc_u, SWIGLU_ALPHA, SWIGLU_LIMIT) / out_scale
-    sm = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, mfma_layout))[:, None]
-    sn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout))[None, :]
-    col = pid_n * BLOCK_N + sn
-    row = token * TOPK + slot
-    gl.store(
-        Y
-        + row.to(gl.int64) * stride_ym
-        + col.to(gl.int64) * stride_yn
-        + sm.to(gl.int64) * 0,
-        out.to(Y.dtype.element_ty),
-        mask=(token < M) & (sm == 0) & (col < I),
+    cfg = MoEConfig(
+        BLOCK_M,
+        BLOCK_N,
+        BLOCK_K,
+        "e4m3",  # X format (fp8 activations)
+        "e2m1",  # W format (mxfp4 weights)
+        32,  # SCALE_BLOCK
+        NUM_BUFFERS,
+        True,  # W_TRANSPOSE (W is K-packed-contiguous: stride_wk==1)
+        False,  # WITH_X_MX_SCALE (per-tensor x scale only)
+        True,  # WITH_W_MX_SCALE (e8m0 block scales)
+        "swizzle",  # SCALE_LOAD_MODE -> SCALE_VIA_LDS unswizzle
+        gl.int32,
+        (1, 1, 1),  # NUM_SUBTILES
+        False,  # EVEN_K (D=2880 not a multiple of BLOCK_K)
+        False,  # USE_GATHER
+        NUM_WARPS,
+        W_VIA_VGPR=False,
+        W_PREFETCH=True,
     )
+
+    BLOCK_K_X: gl.constexpr = cfg.BLOCK_K // cfg.DIV_FACTOR_X
+    BLOCK_K_W: gl.constexpr = cfg.BLOCK_K // cfg.DIV_FACTOR_W
+    OUT_BLOCK_N: gl.constexpr = BLOCK_N // 2
+    W_CACHE_MODIFIER: gl.constexpr = ".cg" if BLOCK_M <= 32 else ""
+
+    X_ELEM_BITS: gl.constexpr = X.dtype.element_ty.primitive_bitwidth
+    W_ELEM_BITS: gl.constexpr = W.dtype.element_ty.primitive_bitwidth
+    LOAD_X_LAYOUT: gl.constexpr = _load_layout(
+        BLOCK_K_X, BLOCK_M, NUM_WARPS, [1, 0], X_ELEM_BITS
+    )
+    # K-contig W (W_TRANSPOSE=True): vectorise the contiguous K_packed axis
+    # (mirrors the W_TRANSPOSE branch of _pipelined_moe_tile_compute).
+    LOAD_W_LAYOUT: gl.constexpr = _load_layout(
+        BLOCK_K_W, BLOCK_N, NUM_WARPS, [1, 0], W_ELEM_BITS
+    )
+
+    offs_xm = gl.arange(0, BLOCK_M, layout=gl.SliceLayout(1, LOAD_X_LAYOUT))
+    offs_xk = gl.arange(0, BLOCK_K_X, layout=gl.SliceLayout(0, LOAD_X_LAYOUT))
+    offs_wn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(1, LOAD_W_LAYOUT))
+    offs_wk = gl.arange(0, BLOCK_K_W, layout=gl.SliceLayout(0, LOAD_W_LAYOUT))
+
+    valid = (token < M) & (expert >= 0)
+    # One decode token per CTA: row 0 of the BLOCK_M tile carries the token,
+    # the remaining rows are clamped/masked (buffer OOB -> 0 in LDS).
+    rows_m = gl.where(offs_xm == 0, token, gl.zeros_like(offs_xm))
+    mask_m = (offs_xm == 0) & valid
+    mask_n = (off_n + offs_wn) < N
+
+    k_limit_x = gl.multiple_of(D // cfg.DIV_FACTOR_X, 16)
+    k_limit_w = gl.multiple_of(D // cfg.DIV_FACTOR_W, 16)
+
+    x_desc = AsyncCopyDescriptor.initialize(
+        cfg,
+        0,
+        BLOCK_K_X,
+        X,
+        rows_m,
+        offs_xk,
+        stride_xm,
+        stride_xk,
+        mask_m[:, None],
+        k_limit_x,
+    )
+    w_desc = AsyncCopyDescriptor.initialize(
+        cfg,
+        0,
+        BLOCK_K_W,
+        W,
+        off_n + offs_wn,
+        offs_wk,
+        stride_wn,
+        stride_wk,
+        mask_n[:, None],
+        k_limit_w,
+        base_offset=w_base_offset,
+        cache_modifier=W_CACHE_MODIFIER,
+    )
+
+    # W e8m0 scales -> LDS in the post-swizzle HBM shape; issue_local_load_unswizzle
+    # reconstructs [BLOCK_N, BLOCK_K_SCALE] (the 7-D reshape/permute).
+    BLOCK_N_PS: gl.constexpr = cfg.BLOCK_N_PRESHUFFLED
+    BLOCK_K_S_PS_W: gl.constexpr = cfg.BLOCK_K_SCALE_PRESHUFFLED
+    LW_S: gl.constexpr = cfg.load_layout_w_scale
+    offs_ws_n = gl.arange(0, BLOCK_N_PS, layout=gl.SliceLayout(1, LW_S))
+    offs_ws_k = gl.arange(0, BLOCK_K_S_PS_W, layout=gl.SliceLayout(0, LW_S))
+    rows_n_scale = off_n // cfg.PRESHUFFLE_FACTOR + offs_ws_n
+    row_limit_w_s = (N + cfg.PRESHUFFLE_FACTOR - 1) // cfg.PRESHUFFLE_FACTOR
+    # Suppress the K-mask: the swizzle packs K with N; the W K-mask already
+    # zeroes the OOB product regardless of scale value.
+    k_limit_ws_load = ((D // cfg.SCALE_BLOCK + 7) // 8 * 8) * cfg.PRESHUFFLE_FACTOR
+    w_scale_desc = AsyncCopyDescriptor.initialize(
+        cfg,
+        0,
+        BLOCK_K_S_PS_W,
+        WScale,
+        rows_n_scale,
+        offs_ws_k,
+        stride_wsn,
+        stride_wsk,
+        rows_n_scale[:, None] < row_limit_w_s,
+        k_limit_ws_load,
+        base_offset=ws_base_offset,
+    )
+
+    pgm = MoEPipelinedProgram.initialize(cfg, x_desc, w_desc, 0, w_scale_desc)
+    acc = pgm.pipeline(D)
+
+    # Per-tensor activation scale.
+    x_scale = gl.load(x_global_scale_ptr).to(gl.float32)
+    acc = acc * x_scale
+
+    if HAS_BIAS:
+        # Bias is laid out [E, 2*I] (interleaved gate/up rows); add before the
+        # SwiGLU even/odd split, matching the num_warps=1 path.
+        bias_offs = off_n + gl.arange(0, BLOCK_N, gl.SliceLayout(0, cfg.acc_layout))
+        bias_mask = bias_offs < N
+        bias = gl.load(
+            w13_bias + expert.to(gl.int64) * N + bias_offs,
+            mask=bias_mask,
+            other=0.0,
+        )
+        acc = acc + bias[None, :].to(gl.float32)
+
+    out = _swiglu_reduce(acc, SWIGLU_ALPHA, SWIGLU_LIMIT, OUT_BLOCK_N, cfg.acc_layout)
+    out_inv_scale = 1.0 / gl.load(out_quant_scale_ptr).to(gl.float32)
+    out = (out * out_inv_scale).to(Y.dtype.element_ty)
+    STORE_LAYOUT: gl.constexpr = out.type.layout
+
+    offs_y_m = gl.arange(0, BLOCK_M, gl.SliceLayout(1, STORE_LAYOUT))
+    off_n_out = pid_n * OUT_BLOCK_N
+    offs_y_n = off_n_out + gl.arange(0, OUT_BLOCK_N, gl.SliceLayout(0, STORE_LAYOUT))
+    row = token * TOPK + slot
+    # Only tile-row 0 holds the token's result; all valid columns map to the
+    # single Y row (row*stride_ym).
+    y_offs = (
+        row.to(gl.int64) * stride_ym
+        + offs_y_n[None, :].to(gl.int64) * stride_yn
+        + offs_y_m[:, None].to(gl.int64) * 0
+    )
+    mask_y = (offs_y_m[:, None] == 0) & valid & (offs_y_n[None, :] < I)
+    gl.store(Y + y_offs, out, mask=mask_y)
 
 
 @gluon.jit
-def _warp_decode_topk_stage1_fp8_mxfp4_kernel(
+def _warp_decode_topk_stage1_coop_kernel(
     X,
     Logits,
     W,
@@ -5251,20 +5320,29 @@ def _warp_decode_topk_stage1_fp8_mxfp4_kernel(
     X_DTYPE: gl.constexpr,
     BLOCK_K: gl.constexpr,
     BLOCK_N: gl.constexpr,
-    M_DUP: gl.constexpr,
+    BLOCK_M: gl.constexpr,
+    NUM_BUFFERS: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
     HAS_BIAS: gl.constexpr,
     SWIGLU_ALPHA: gl.constexpr,
     SWIGLU_LIMIT: gl.constexpr,
 ):
-    """Fused dense top-k + direct top-k stage1 for small-M warp decode."""
-    pid = gl.program_id(axis=0)
-    num_pid_n = gl.cdiv(I, BLOCK_N)
-    token = pid // num_pid_n
-    pid_n = pid % num_pid_n
+    """Cooperative (multi-warp) fused dense top-k + gate_up stage1.
 
-    # ---- direct top-k for this token (duplicated per N tile to save a launch) ----
-    LE: gl.constexpr = gl.BlockedLayout([1], [64], [1], [0])
-    LT: gl.constexpr = gl.BlockedLayout([1], [64], [1], [0])
+    The slot dimension is folded into the grid -- one gate_up GEMM (one
+    MoEPipelinedProgram / LDS buffer set) per program, so LDS is not multiplied
+    by TOPK. Routing layouts span all warps (EP/TKP padded to 64*NUM_WARPS).
+    """
+    pid = gl.program_id(axis=0)
+    num_pid_n = gl.cdiv(2 * I, BLOCK_N)
+    slot = pid % TOPK
+    rest = pid // TOPK
+    pid_n = rest % num_pid_n
+    token = rest // num_pid_n
+
+    # ---- direct top-k for this token (replicated per (N tile, slot)) ----
+    LE: gl.constexpr = gl.BlockedLayout([1], [64], [NUM_WARPS], [0])
+    LT: gl.constexpr = gl.BlockedLayout([1], [64], [NUM_WARPS], [0])
     e = gl.arange(0, EP, layout=LE)
     emask = e < E
     cur = gl.load(
@@ -5288,7 +5366,7 @@ def _warp_decode_topk_stage1_fp8_mxfp4_kernel(
     num = gl.exp(val_t - rmax)
     den = gl.sum(num, axis=0)
     gate_t = gl.fdiv(num, den)
-    if pid_n == 0:
+    if (pid_n == 0) & (slot == 0):
         gl.store(
             TopkIdsOut + token.to(gl.int64) * stride_tim + t,
             idx_t,
@@ -5300,45 +5378,195 @@ def _warp_decode_topk_stage1_fp8_mxfp4_kernel(
             mask=(token < M) & (t < TOPK),
         )
 
-    for slot in gl.static_range(TOPK):
-        slot_sel = t == slot
-        expert = gl.sum(
-            gl.where(slot_sel, idx_t, gl.zeros([TKP], gl.int32, layout=LT)), axis=0
+    slot_sel = t == slot
+    expert = gl.sum(
+        gl.where(slot_sel, idx_t, gl.zeros([TKP], gl.int32, layout=LT)), axis=0
+    )
+    _warp_decode_stage1_coop_compute(
+        token,
+        slot,
+        expert,
+        pid_n,
+        X,
+        W,
+        WScale,
+        Y,
+        M,
+        D,
+        I,
+        stride_xm,
+        stride_xk,
+        stride_we,
+        stride_wk,
+        stride_wn,
+        stride_wse,
+        stride_wsk,
+        stride_wsn,
+        stride_ym,
+        stride_yn,
+        x_global_scale_ptr,
+        out_quant_scale_ptr,
+        w13_bias,
+        TOPK,
+        BLOCK_M,
+        BLOCK_N,
+        BLOCK_K,
+        NUM_BUFFERS,
+        NUM_WARPS,
+        HAS_BIAS,
+        SWIGLU_ALPHA,
+        SWIGLU_LIMIT,
+    )
+
+
+@gluon.jit
+def _warp_decode_stage2_load_tile(
+    kt,
+    ak,
+    bk,
+    bsk,
+    am,
+    X,
+    W,
+    WScale,
+    x_row_off,
+    w_n_off,
+    ws_expert_off,
+    scale_row_off,
+    stride_xk,
+    stride_wk,
+    stride_wsk,
+    I,
+    BLOCK_K: gl.constexpr,
+    BLOCK_K_PACKED: gl.constexpr,
+    BLOCK_K_SCALE: gl.constexpr,
+    I_PACKED: gl.constexpr,
+    MASK_TAIL: gl.constexpr = False,
+):
+    k_elem = kt * BLOCK_K + ak
+    k_pack = kt * BLOCK_K_PACKED + bk
+    a_off = (x_row_off + k_elem.to(gl.int64) * stride_xk + am.to(gl.int64) * 0).to(
+        gl.int32
+    )
+    b_off = (w_n_off + k_pack.to(gl.int64) * stride_wk).to(gl.int32)
+    if BLOCK_K_SCALE == 4:
+        scale_k_lin = (kt // 2) * 256 + (kt % 2) * 2 + bsk * 64
+    else:
+        sk = kt * BLOCK_K_SCALE + bsk
+        scale_k_lin = (sk // 8) * 256 + (sk % 4) * 64 + ((sk % 8) // 4) * 2
+    scale_k_off = scale_k_lin.to(gl.int64) * stride_wsk
+    s_off = (ws_expert_off + scale_row_off + scale_k_off).to(gl.int32)
+    if MASK_TAIL:
+        # Partial / odd final K-tile (K = intermediate dim I): mask out-of-range
+        # K lanes to 0 so they contribute nothing and never over-read.
+        sk_valid = (kt * BLOCK_K_SCALE + bsk) < (I // 32)
+        a = gl.amd.cdna4.buffer_load(ptr=X, offsets=a_off, mask=k_elem < I, other=0.0)
+        b = gl.amd.cdna4.buffer_load(
+            ptr=W, offsets=b_off, mask=k_pack < I_PACKED, other=0
         )
-        _warp_decode_stage1_compute(
-            token,
-            slot,
-            expert,
-            pid_n,
-            X,
-            W,
-            WScale,
-            Y,
-            M,
-            D,
-            I,
-            stride_xm,
-            stride_xk,
-            stride_we,
-            stride_wk,
-            stride_wn,
-            stride_wse,
-            stride_wsk,
-            stride_wsn,
-            stride_ym,
-            stride_yn,
-            x_global_scale_ptr,
-            out_quant_scale_ptr,
-            w13_bias,
-            D_PACKED,
-            TOPK,
-            BLOCK_K,
-            BLOCK_N,
-            M_DUP,
-            HAS_BIAS,
-            SWIGLU_ALPHA,
-            SWIGLU_LIMIT,
-        )
+        s = gl.amd.cdna4.buffer_load(ptr=WScale, offsets=s_off, mask=sk_valid, other=0)
+    else:
+        a = gl.amd.cdna4.buffer_load(ptr=X, offsets=a_off)
+        b = gl.amd.cdna4.buffer_load(ptr=W, offsets=b_off)
+        s = gl.amd.cdna4.buffer_load(ptr=WScale, offsets=s_off)
+    return a, b, s
+
+
+@gluon.jit
+def _warp_decode_stage2_load_pair(
+    kt,
+    ak,
+    bk,
+    bsk,
+    am,
+    X,
+    W,
+    WScale,
+    x_row_off,
+    w_n_off,
+    ws_expert_off,
+    scale_row_off,
+    stride_xk,
+    stride_wk,
+    stride_wsk,
+    I,
+    BLOCK_K: gl.constexpr,
+    BLOCK_K_PACKED: gl.constexpr,
+    BLOCK_K_SCALE: gl.constexpr,
+    I_PACKED: gl.constexpr,
+):
+    """Load the even (kt) and odd (kt+1) K-tiles of one pipeline step."""
+    a_even, b_even, s_even = _warp_decode_stage2_load_tile(
+        kt,
+        ak,
+        bk,
+        bsk,
+        am,
+        X,
+        W,
+        WScale,
+        x_row_off,
+        w_n_off,
+        ws_expert_off,
+        scale_row_off,
+        stride_xk,
+        stride_wk,
+        stride_wsk,
+        I,
+        BLOCK_K,
+        BLOCK_K_PACKED,
+        BLOCK_K_SCALE,
+        I_PACKED,
+    )
+    a_odd, b_odd, s_odd = _warp_decode_stage2_load_tile(
+        kt + 1,
+        ak,
+        bk,
+        bsk,
+        am,
+        X,
+        W,
+        WScale,
+        x_row_off,
+        w_n_off,
+        ws_expert_off,
+        scale_row_off,
+        stride_xk,
+        stride_wk,
+        stride_wsk,
+        I,
+        BLOCK_K,
+        BLOCK_K_PACKED,
+        BLOCK_K_SCALE,
+        I_PACKED,
+    )
+    return a_even, b_even, s_even, a_odd, b_odd, s_odd
+
+
+@gluon.jit
+def _warp_decode_stage2_mfma_pair(
+    acc, a_even, b_even, s_even, a_odd, b_odd, s_odd, a_scale
+):
+    """Accumulate the scaled-MFMA of one even+odd K-tile pair (fp8 x mxfp4)."""
+    acc = gl.amd.cdna4.mfma_scaled(
+        a=a_even,
+        a_scale=a_scale,
+        a_format="e4m3",
+        b=b_even,
+        b_scale=s_even,
+        b_format="e2m1",
+        acc=acc,
+    )
+    acc = gl.amd.cdna4.mfma_scaled(
+        a=a_odd,
+        a_scale=a_scale,
+        a_format="e4m3",
+        b=b_odd,
+        b_scale=s_odd,
+        b_format="e2m1",
+        acc=acc,
+    )
+    return acc
 
 
 @gluon.jit
@@ -5394,9 +5622,15 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
         rem = pid % per_k
         pid_token = rem // num_n
         pid_n = rem % num_n
-    num_kt = gl.cdiv(I, BLOCK_K)
-    kt_per = gl.cdiv(num_kt, SPLIT_K)
+    # Full + partial K-tile coverage (K = intermediate dim I). The old
+    # `num_kt = I // BLOCK_K` dropped the partial final tile, miscomputing any
+    # I not a multiple of BLOCK_K (GPT-OSS I=2880 lost K=2816..2879).
+    num_full = I // BLOCK_K
+    total_kt = (I + BLOCK_K - 1) // BLOCK_K
+    kt_per = (total_kt + SPLIT_K - 1) // SPLIT_K
     kt_start = pid_k * kt_per
+    kt_stop = gl.minimum(kt_start + kt_per, total_kt)
+    full_stop = gl.minimum(kt_stop, num_full)
     _layouts: gl.constexpr = _warp_decode_mfma_layouts(M_DUP, BLOCK_N, BLOCK_K_SCALE)
     mfma_layout: gl.constexpr = _layouts[0]
     dot_a_layout: gl.constexpr = _layouts[1]
@@ -5411,6 +5645,7 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
     bsk = gl.arange(0, BLOCK_K_SCALE, layout=gl.SliceLayout(0, b_scale_layout))[None, :]
     n_cols = pid_n * BLOCK_N + bn
     n_cols_s = pid_n * BLOCK_N + bsn
+    a_scale = gl.full((M_DUP, BLOCK_K_SCALE), 127, gl.uint8, layout=a_scale_layout)
     acc_total = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
     if pid_token < M:
         for slot in gl.static_range(0, TOPK):
@@ -5424,41 +5659,122 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
             ).to(gl.float32)
             if expert >= 0:
                 row = pid_token * TOPK + slot
-                w_base = W + expert.to(gl.int64) * stride_we
-                ws_base = WScale + expert.to(gl.int64) * stride_wse
+                x_row_off = row.to(gl.int64) * stride_xm
+                w_expert_off = expert.to(gl.int64) * stride_we
+                ws_expert_off = expert.to(gl.int64) * stride_wse
+                w_n_off = w_expert_off + n_cols.to(gl.int64) * stride_wn
+                scale_row = n_cols_s.to(gl.uint32)
+                scale_row_off = (scale_row // 32).to(gl.int64) * stride_wsn + (
+                    (scale_row % 16) * 4 + ((scale_row % 32) // 16)
+                ).to(gl.int64) * stride_wsk
                 acc = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
-                for kt in range(kt_start, kt_start + kt_per):
-                    k_elem = kt * BLOCK_K + ak
-                    k_pack = kt * BLOCK_K_PACKED + bk
-                    a = gl.load(
-                        X
-                        + row.to(gl.int64) * stride_xm
-                        + k_elem.to(gl.int64) * stride_xk
-                        + am.to(gl.int64) * 0,
-                        mask=k_elem < I,
-                        other=0.0,
+                main_end = kt_start + ((full_stop - kt_start) // 2) * 2
+
+                # Software-pipeline the main paired K-loop one step ahead:
+                # prefetch the first pair, then each iteration loads the next pair
+                # before MFMA-ing the current one (prefetch depth 2).
+                main_kt = main_end - kt_start
+                if main_kt > 0:
+                    a_even, b_even, s_even, a_odd, b_odd, s_odd = (
+                        _warp_decode_stage2_load_pair(
+                            kt_start,
+                            ak,
+                            bk,
+                            bsk,
+                            am,
+                            X,
+                            W,
+                            WScale,
+                            x_row_off,
+                            w_n_off,
+                            ws_expert_off,
+                            scale_row_off,
+                            stride_xk,
+                            stride_wk,
+                            stride_wsk,
+                            I,
+                            BLOCK_K,
+                            BLOCK_K_PACKED,
+                            BLOCK_K_SCALE,
+                            I_PACKED,
+                        )
                     )
-                    a_scale = gl.full(
-                        (M_DUP, BLOCK_K_SCALE), 127, gl.uint8, layout=a_scale_layout
+                    for kt in range(kt_start, main_end - 2, 2):
+                        (
+                            nxt_a_even,
+                            nxt_b_even,
+                            nxt_s_even,
+                            nxt_a_odd,
+                            nxt_b_odd,
+                            nxt_s_odd,
+                        ) = _warp_decode_stage2_load_pair(
+                            kt + 2,
+                            ak,
+                            bk,
+                            bsk,
+                            am,
+                            X,
+                            W,
+                            WScale,
+                            x_row_off,
+                            w_n_off,
+                            ws_expert_off,
+                            scale_row_off,
+                            stride_xk,
+                            stride_wk,
+                            stride_wsk,
+                            I,
+                            BLOCK_K,
+                            BLOCK_K_PACKED,
+                            BLOCK_K_SCALE,
+                            I_PACKED,
+                        )
+                        acc = _warp_decode_stage2_mfma_pair(
+                            acc, a_even, b_even, s_even, a_odd, b_odd, s_odd, a_scale
+                        )
+                        a_even, b_even, s_even, a_odd, b_odd, s_odd = (
+                            nxt_a_even,
+                            nxt_b_even,
+                            nxt_s_even,
+                            nxt_a_odd,
+                            nxt_b_odd,
+                            nxt_s_odd,
+                        )
+                    # Epilogue: MFMA the final prefetched pair.
+                    acc = _warp_decode_stage2_mfma_pair(
+                        acc, a_even, b_even, s_even, a_odd, b_odd, s_odd, a_scale
                     )
-                    b = gl.load(
-                        w_base
-                        + k_pack.to(gl.int64) * stride_wk
-                        + n_cols.to(gl.int64) * stride_wn,
-                        mask=(k_pack < I_PACKED) & (n_cols < N),
-                        other=0,
-                    )
-                    sk = kt * BLOCK_K_SCALE + bsk
-                    off_s = _mxfp4_scale_offset(n_cols_s, sk, stride_wsk, stride_wsn)
-                    s = gl.load(
-                        ws_base + off_s, mask=(sk < (I // 32)) & (n_cols_s < N), other=0
+                # Masked remainder: leftover odd/partial K-tile(s) in this split.
+                for kt in range(main_end, kt_stop):
+                    a_t, b_t, s_t = _warp_decode_stage2_load_tile(
+                        kt,
+                        ak,
+                        bk,
+                        bsk,
+                        am,
+                        X,
+                        W,
+                        WScale,
+                        x_row_off,
+                        w_n_off,
+                        ws_expert_off,
+                        scale_row_off,
+                        stride_xk,
+                        stride_wk,
+                        stride_wsk,
+                        I,
+                        BLOCK_K,
+                        BLOCK_K_PACKED,
+                        BLOCK_K_SCALE,
+                        I_PACKED,
+                        MASK_TAIL=True,
                     )
                     acc = gl.amd.cdna4.mfma_scaled(
-                        a=a,
+                        a=a_t,
                         a_scale=a_scale,
                         a_format="e4m3",
-                        b=b,
-                        b_scale=s,
+                        b=b_t,
+                        b_scale=s_t,
                         b_format="e2m1",
                         acc=acc,
                     )

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
@@ -34,6 +34,7 @@ from tokenspeed_kernel_amd.ops.moe.utils import (
     topk,
 )
 
+
 def _as_int32(t):
     if t is None or t.dtype == torch.int32:
         return t

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
@@ -105,9 +105,8 @@ if platform.is_amd:
         ),
         signatures=frozenset({format_signature()}),
         traits={"weight_dtype": frozenset({"mxfp4"})},
-        # Higher priority than triton: gfx950 warp-decode (coop stage1 + tuned
-        # split-K) now outperforms the triton MoE across the decode range.
-        priority=Priority.PORTABLE + 1,
+        # gluon is narrowly gated to gfx950
+        priority=Priority.SPECIALIZED,
     )
     def gluon_mxfp4_moe_process_weights(plan: dict, w: torch.nn.Module):
         MXFP_BLOCK_SIZE = 32
@@ -201,9 +200,8 @@ if platform.is_amd:
             "internal_activation_dtype": frozenset({"fp8"}),
             "supports_bias": frozenset({True}),
         },
-        # Higher priority than triton: gfx950 warp-decode (coop stage1 + tuned
-        # split-K) now outperforms the triton MoE across the decode range.
-        priority=Priority.PORTABLE + 1,
+        # gluon is narrowly gated to gfx950
+        priority=Priority.SPECIALIZED,
     )
     def gluon_mxfp4_moe_apply(
         plan: dict,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
@@ -105,8 +105,9 @@ if platform.is_amd:
         ),
         signatures=frozenset({format_signature()}),
         traits={"weight_dtype": frozenset({"mxfp4"})},
-        # Lower priority than the triton implementation due to performance issue
-        priority=Priority.PORTABLE - 1,
+        # Higher priority than triton: gfx950 warp-decode (coop stage1 + tuned
+        # split-K) now outperforms the triton MoE across the decode range.
+        priority=Priority.PORTABLE + 1,
     )
     def gluon_mxfp4_moe_process_weights(plan: dict, w: torch.nn.Module):
         MXFP_BLOCK_SIZE = 32
@@ -200,8 +201,9 @@ if platform.is_amd:
             "internal_activation_dtype": frozenset({"fp8"}),
             "supports_bias": frozenset({True}),
         },
-        # Lower priority than the triton implementation due to performance issue
-        priority=Priority.PORTABLE - 1,
+        # Higher priority than triton: gfx950 warp-decode (coop stage1 + tuned
+        # split-K) now outperforms the triton MoE across the decode range.
+        priority=Priority.PORTABLE + 1,
     )
     def gluon_mxfp4_moe_apply(
         plan: dict,

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -529,6 +529,22 @@ def _moe_apply_mxfp4_triton() -> object:
     return tokenspeed_kernel.moe_apply(plan, x, torch.nn.Module(), router_logits)
 
 
+def _moe_apply_mxfp4_gluon() -> object:
+    plan = tokenspeed_kernel.moe_plan(
+        "mxfp4",
+        input_dtype=torch.bfloat16,
+        activation="swiglu",
+        ispp=128,
+        internal_activation_dtype="fp8",
+        with_bias=True,
+    )
+    assert plan["apply_kernel_name"] == "gluon_mxfp4_moe_apply"
+    assert plan["process_weights_kernel_name"] == "gluon_mxfp4_moe_process_weights"
+    x = torch.empty((4, 16), dtype=torch.bfloat16)
+    router_logits = torch.empty((4, 8), dtype=torch.float32)
+    return tokenspeed_kernel.moe_apply(plan, x, torch.nn.Module(), router_logits)
+
+
 def _case(
     matches: Callable[[PlatformInfo], bool],
     arch: str,
@@ -791,8 +807,8 @@ _CASES = [
         "cdna4",
         "moe",
         "apply",
-        "triton_mxfp4_moe_apply",
-        _moe_apply_mxfp4_triton,
+        "gluon_mxfp4_moe_apply",
+        _moe_apply_mxfp4_gluon,
     ),
 ]
 


### PR DESCRIPTION
## Summary

 - Stage 1: cooperative-LDS, software-pipelined. Replaces the single-warp stage1 (num_warps=1) with a num_warps=4 kernel that streams weights/scales global->LDS through a multi-buffer async pipeline (BLOCK_N=64, BLOCK_K=256, NUM_BUFFERS=3). At M=1 the old path launched too few warps to hide w13 load latency; the coop kernel raises occupancy and was the dominant small-M cost.
 - Stage 2: per-M tuned split-K + reduce. Replaces the flat split_k=4 with a tuned selector (8 at M≤2, 4 at M≤4, 1 for M≥5) that partitions the K=I reduction across more CTAs to fix stage2's small-M occupancy starvation, and activates _warp_decode_stage2_reduce to sum the fp32 partials. Also adds a depth-2 software pipeline plus load_pair/mfma_pair helpers for the main K-loop.
 - Correctness fixes folded in (_swiglu_gate_up gate/up interleave, _mxfp4_scale_offset CDNA4 scale-swizzle, K-tail masking) so the path is bit-correct vs the Triton/torch reference.
 - Cleanup: cooperative path is the default (no env flags), dead num_warps=1 stage1 removed, single-call helpers inlined.


## Test Plan

<!-- How was this validated? -->


## Performance

 Gluon:

 ```
   Overall perf table:
     config  Conc.  Latency (tps/user)  Throughput (tps/gpu)  Approx Cache Hit  Decoded Tok/Iter
   --------  -----  ------------------  --------------------  ----------------  ----------------
   input_1k      1               300.3                587.12               0.0             1.001
   input_1k      2              273.97               1067.48               0.0            1.0169
   input_1k      4              223.21                1648.6               0.0            1.0261
   input_1k      8              162.07               2348.73               0.0            1.0487
   input_1k     16              114.68               3441.47               0.0            1.0412
   input_2k      1              298.51                872.39               0.0            1.0228
   input_2k      2              272.48                1544.9               0.0             1.001
   input_2k      4              221.73               2573.91               0.0            1.0264
   input_2k      8               160.0               3628.49               0.0              1.03
   input_2k     16              113.25               5248.15               0.0            1.0274
   input_4k      1              295.86               1432.27               0.0            1.0039
   input_4k      2              268.82               2580.33               0.0            1.0039
   input_4k      4              218.34               4164.91               0.0            1.0108
   input_4k      8              155.52               5922.84               0.0            1.0878
   input_4k     16              109.05               8249.01               0.0            1.0109
   input_8k      1              293.26               2519.18               0.0            1.0039
   input_8k      2              263.85               4475.79               0.0            1.0034
   input_8k      4              209.64               7051.41               0.0            1.0144
   input_8k      8              147.28               9807.56               0.0            1.1191
   input_8k     16                99.5              13058.89               0.0            1.0075
 ```

 Triton:

 ```
   Overall perf table:
     config  Conc.  Latency (tps/user)  Throughput (tps/gpu)  Approx Cache Hit  Decoded Tok/Iter
   --------  -----  ------------------  --------------------  ----------------  ----------------
   input_1k      1              210.53                414.14               0.0               0.0
   input_1k      2              192.68                754.46               0.0            1.0746
   input_1k      4              161.81               1225.23               0.0             1.053
   input_1k      8              130.89               1990.77               0.0            1.0574
   input_1k     16              109.77               3408.43               0.0            1.0192
   input_2k      1              208.33                 612.3               0.0               0.0
   input_2k      2              190.48               1112.45               0.0            1.0015
   input_2k      4              158.98               1851.37               0.0            1.0273
   input_2k      8              131.75               3050.67               0.0            1.0428
   input_2k     16              108.46               4977.43               0.0            1.0234
   input_4k      1              202.84                986.99               0.0            1.0039
   input_4k      2              185.53               1789.81               0.0            1.0104
   input_4k      4              156.74                3001.9               0.0            1.0109
   input_4k      8              131.75               4990.88               0.0            1.0878
   input_4k     16              106.27               7910.74               0.0            1.0052
   input_8k      1              197.63               1712.65               0.0            1.0046
   input_8k      2              182.82                3124.5               0.0            1.0119
   input_8k      4              153.14               5173.33               0.0            1.0124
   input_8k      8              124.38               8224.56               0.0            1.0102
   input_8k     16               97.85               12534.6               0.0            1.0079
 ```

