### PR TITLE
perf(kernel): optimize mha sliding window prefill kernel

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_prefill_fp16_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_prefill_fp16_gfx950.py
@@ -56,7 +56,6 @@ class AttentionConfig:
     BATCH_SIZE: gl.constexpr
     HAS_SINK: gl.constexpr
     HAS_LSE: gl.constexpr
-    IS_SLIDING: gl.constexpr
     WINDOW_LEFT: gl.constexpr
     NUM_XCDS: gl.constexpr
     NUM_BLOCKS: gl.constexpr
@@ -87,7 +86,6 @@ class AttentionConfig:
         BATCH_SIZE,
         HAS_SINK,
         HAS_LSE,
-        IS_SLIDING,
         WINDOW_LEFT,
         q_strides,
         k_strides,
@@ -95,10 +93,6 @@ class AttentionConfig:
     ):
         assert HEAD_DIM == 64
         assert NUM_WARPS == 4
-        if IS_SLIDING:
-            assert WINDOW_LEFT >= 0
-        else:
-            assert WINDOW_LEFT == -1
 
         qk_layout = gl.amd.AMDMFMALayout(
             version=4,
@@ -130,7 +124,6 @@ class AttentionConfig:
         self.BATCH_SIZE = gl.constexpr(BATCH_SIZE)
         self.HAS_SINK = gl.constexpr(HAS_SINK)
         self.HAS_LSE = gl.constexpr(HAS_LSE)
-        self.IS_SLIDING = gl.constexpr(IS_SLIDING)
         self.WINDOW_LEFT = gl.constexpr(WINDOW_LEFT)
         self.NUM_XCDS = gl.constexpr(8)
         self.NUM_BLOCKS = gl.constexpr(512)
@@ -669,7 +662,7 @@ def process_single_attention_tile(
     valid = mask_offs_m[:, None] < program.seq_len
     valid &= mask_offs_n[None, :] < program.seq_len
     valid &= mask_offs_n[None, :] <= mask_offs_m[:, None]
-    if cfg.IS_SLIDING:
+    if cfg.WINDOW_LEFT >= 0:
         valid &= mask_offs_m[:, None] <= mask_offs_n[None, :] + cfg.WINDOW_LEFT
 
     qk = gl.where(valid, qk, -1.0e20)
@@ -708,7 +701,7 @@ def process_attention_tile(
     q = program.load_q()
     m_i, l_i, acc, sink_log2 = program.init_attention_state()
 
-    if cfg.IS_SLIDING:
+    if cfg.WINDOW_LEFT >= 0:
         kv_start = program.q_start - cfg.WINDOW_LEFT
         kv_start = gl.where(kv_start > 0, (kv_start // cfg.BLOCK_N) * cfg.BLOCK_N, 0)
         num_kv_tiles: gl.constexpr = (
@@ -835,7 +828,6 @@ def _mha_prefill_fp16(
     max_seqlen_q,
     HAS_SINK: gl.constexpr,
     HAS_LSE: gl.constexpr,
-    IS_SLIDING: gl.constexpr,
     WINDOW_LEFT: gl.constexpr,
 ):
     cfg = AttentionConfig(
@@ -849,7 +841,6 @@ def _mha_prefill_fp16(
         BATCH_SIZE,
         HAS_SINK,
         HAS_LSE,
-        IS_SLIDING,
         WINDOW_LEFT,
         InputStrides(Q_STRIDE_T, Q_STRIDE_H, Q_STRIDE_D),
         InputStrides(K_STRIDE_T, K_STRIDE_H, K_STRIDE_D),
@@ -922,7 +913,6 @@ def _mha_prefill_sliding_fp16(
     max_seqlen_q,
     HAS_SINK: gl.constexpr,
     HAS_LSE: gl.constexpr,
-    IS_SLIDING: gl.constexpr,
     WINDOW_LEFT: gl.constexpr,
 ):
     cfg = AttentionConfig(
@@ -936,7 +926,6 @@ def _mha_prefill_sliding_fp16(
         BATCH_SIZE,
         HAS_SINK,
         HAS_LSE,
-        IS_SLIDING,
         WINDOW_LEFT,
         InputStrides(Q_STRIDE_T, Q_STRIDE_H, Q_STRIDE_D),
         InputStrides(K_STRIDE_T, K_STRIDE_H, K_STRIDE_D),
@@ -983,7 +972,6 @@ class LaunchConfig(NamedTuple):
     num_warps: int
     batch_size: int
     max_seqlen: int
-    is_sliding: bool
     window_left: int
     grid: tuple[int, ...]
 
@@ -1003,8 +991,7 @@ def get_config(
     block_n = 64
     num_warps = 4
     batch_size = cu_seqlens_q.numel() - 1
-    is_sliding = window_left >= 0
-    window_left = window_left if is_sliding else -1
+    window_left = window_left if window_left >= 0 else -1
     sm_scale = (1.0 / math.sqrt(head_dim)) * _INV_LN2_VALUE
     return LaunchConfig(
         n_heads=n_heads,
@@ -1016,7 +1003,6 @@ def get_config(
         num_warps=num_warps,
         batch_size=batch_size,
         max_seqlen=max_seqlen,
-        is_sliding=is_sliding,
         window_left=window_left,
         grid=(512,),
     )
@@ -1053,7 +1039,7 @@ def gluon_mha_prefill_fp16_gfx950(
     sink_arg = sinks if sinks is not None else q
     lse_arg = lse if lse is not None else q
 
-    kernel = _mha_prefill_sliding_fp16 if config.is_sliding else _mha_prefill_fp16
+    kernel = _mha_prefill_sliding_fp16 if config.window_left >= 0 else _mha_prefill_fp16
     kernel[config.grid](
         q,
         k,
@@ -1082,7 +1068,6 @@ def gluon_mha_prefill_fp16_gfx950(
         config.max_seqlen,
         has_sink,
         has_lse,
-        config.is_sliding,
         config.window_left,
         num_warps=config.num_warps,
     )

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_prefill_fp16_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_prefill_fp16_gfx950.py
@@ -357,22 +357,25 @@ class AttentionProgram:
     @gluon.jit
     def softmax(self, qk, m_i, l_i, acc):
         cfg = self.cfg
-        HAS_INVALID: gl.constexpr = cfg.WINDOW_LEFT >= 0 and not cfg.HAS_SINK
-        row_max = max(qk, 1)
-        m_new = maximum(m_i, row_max)
-        m_new_scaled = m_new * cfg.SM_SCALE
         # In sliding window case, some rows can see fully masked tiles before
         # any valid KV. Guard the online softmax state so `-inf - -inf` does not
         # produce NaNs. This does not happen when having sink, because m_i
         # is initialized to sink value instead of -inf.
+        HAS_INVALID: gl.constexpr = cfg.WINDOW_LEFT >= 0 and not cfg.HAS_SINK
+
+        row_max = max(qk, 1)
+        m_new = maximum(m_i, row_max)
+        m_new_scaled = m_new * cfg.SM_SCALE
         if HAS_INVALID:
             invalid = m_new == -float("inf")
             m_new_scaled = gl.where(invalid, 0.0, m_new_scaled)
+
         qk_shifted = qk * cfg.SM_SCALE - m_new_scaled[:, None]
         p = gl.exp2(qk_shifted)
         m_diff = m_i * cfg.SM_SCALE - m_new_scaled
         if HAS_INVALID:
             m_diff = gl.where(invalid, 0.0, m_diff)
+
         alpha = gl.exp2(m_diff)
         l_ij = gl.sum(p, axis=1)
         l_i = l_i * alpha + l_ij

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_prefill_fp16_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_prefill_fp16_gfx950.py
@@ -385,19 +385,6 @@ class AttentionProgram:
         return p, m_new, l_i, acc
 
     @gluon.jit
-    def apply_sliding_mask(self, qk, offs_n):
-        cfg = self.cfg
-        offs_m = self.q_start + gl.arange(
-            0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.qk_layout)
-        )
-        kv = gl.convert_layout(offs_n, gl.SliceLayout(0, cfg.qk_layout))
-        valid = offs_m[:, None] < self.seq_len
-        valid &= kv[None, :] < self.seq_len
-        valid &= kv[None, :] <= offs_m[:, None]
-        valid &= offs_m[:, None] <= kv[None, :] + cfg.WINDOW_LEFT
-        return gl.where(valid, qk, -float("inf"))
-
-    @gluon.jit
     def apply_sinks(self, l_i, m_i, sink_log2):
         cfg = self.cfg
         if cfg.HAS_SINK:
@@ -797,24 +784,38 @@ def process_sliding_attention_tile(
     num_kv_tiles: gl.constexpr = (
         cfg.BLOCK_M + cfg.WINDOW_LEFT + cfg.BLOCK_N - 1
     ) // cfg.BLOCK_N
+    offs_m = program.q_start + gl.arange(
+        0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.qk_layout)
+    )
+    mask_n = kv_start + gl.arange(
+        0, cfg.BLOCK_N, layout=gl.SliceLayout(0, cfg.qk_layout)
+    )
+    mask_diff = offs_m[:, None] - mask_n[None, :]
 
-    for _ in range(0, num_kv_tiles):
+    for _ in gl.static_range(num_kv_tiles):
         k_offsets, offs_n = program.make_k_offsets(kv_start)
         v_offsets = program.make_v_offsets(kv_start)
         mask = offs_n[:, None] < program.seq_len
         program.issue_load_k(k_offsets, k_smem, mask=mask)
         program.issue_load_v(v_offsets, v_smem, mask=mask, other=0.0)
 
+        valid = mask_diff.to(gl.uint32) <= cfg.WINDOW_LEFT
+        if kv_start + cfg.BLOCK_N > program.seq_len:
+            valid &= mask_n[None, :] < program.seq_len
+
         async_copy.wait_group(1)
         k = program.shared_load_k(k_smem)
         qk = program.compute_qk(q, k)
-        qk = program.apply_sliding_mask(qk, offs_n)
+        qk = gl.where(valid, qk, -float("inf"))
         p, m_i, l_i, acc = program.softmax(qk, m_i, l_i, acc)
 
         async_copy.wait_group(0)
         v = program.shared_load_v(v_smem)
         acc = program.compute_pv(p, v, acc)
         kv_start = kv_start + cfg.BLOCK_N
+
+        mask_n = mask_n + cfg.BLOCK_N
+        mask_diff = mask_diff - cfg.BLOCK_N
 
     l_i = program.apply_sinks(l_i, m_i, sink_log2)
     program.store_lse(l_i, m_i)

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_prefill_fp16_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_prefill_fp16_gfx950.py
@@ -355,20 +355,6 @@ class AttentionProgram:
         return m_i, l_i, acc, sink_log2
 
     @gluon.jit
-    def apply_sliding_mask(self, qk, offs_n):
-        cfg = self.cfg
-        offs_m = self.q_start + gl.arange(
-            0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.qk_layout)
-        )
-        kv = gl.convert_layout(offs_n, gl.SliceLayout(0, cfg.qk_layout))
-        valid = offs_m[:, None] < self.seq_len
-        valid &= kv[None, :] < self.seq_len
-        valid &= kv[None, :] <= offs_m[:, None]
-        valid &= offs_m[:, None] <= kv[None, :] + cfg.WINDOW_LEFT
-        qk = gl.where(valid, qk, -float("inf"))
-        return qk
-
-    @gluon.jit
     def softmax(self, qk, m_i, l_i, acc):
         cfg = self.cfg
         row_max = max(qk, 1)
@@ -381,6 +367,34 @@ class AttentionProgram:
         l_ij = gl.sum(p, axis=1)
         l_i = l_i * alpha + l_ij
         acc = acc * alpha[:, None]
+        p = p.to(self.q_ptr.dtype.element_ty)
+        p = gl.convert_layout(p, cfg.p_layout)
+        return p, m_new, l_i, acc
+
+    @gluon.jit
+    def softmax_masked(self, qk, valid, m_i, l_i, acc):
+        cfg = self.cfg
+        qk = gl.where(valid, qk, -float("inf"))
+        row_max = max(qk, 1)
+        row_max_is_neg_inf = row_max == -float("inf")
+        m_new = gl.where(row_max_is_neg_inf, m_i, maximum(m_i, row_max))
+        m_new_scaled = m_new * cfg.SM_SCALE
+        m_new_scaled_safe = gl.where(row_max_is_neg_inf, 0.0, m_new_scaled)
+        p = gl.where(
+            valid, gl.exp2(qk * cfg.SM_SCALE - m_new_scaled_safe[:, None]), 0.0
+        )
+
+        same_state = m_i == m_new
+        m_i_scaled_safe = gl.where(same_state, 0.0, m_i * cfg.SM_SCALE)
+        m_new_scaled_for_alpha = gl.where(same_state, 0.0, m_new_scaled)
+        alpha = gl.where(
+            same_state,
+            1.0,
+            gl.exp2(m_i_scaled_safe - m_new_scaled_for_alpha),
+        )
+        l_i = l_i * alpha + gl.sum(p, axis=1)
+        acc = acc * alpha[:, None]
+
         p = p.to(self.q_ptr.dtype.element_ty)
         p = gl.convert_layout(p, cfg.p_layout)
         return p, m_new, l_i, acc
@@ -701,89 +715,115 @@ def process_attention_tile(
     q = program.load_q()
     m_i, l_i, acc, sink_log2 = program.init_attention_state()
 
-    if cfg.WINDOW_LEFT >= 0:
-        kv_start = program.q_start - cfg.WINDOW_LEFT
-        kv_start = gl.where(kv_start > 0, (kv_start // cfg.BLOCK_N) * cfg.BLOCK_N, 0)
-        num_kv_tiles: gl.constexpr = (
-            cfg.BLOCK_M + cfg.WINDOW_LEFT + cfg.BLOCK_N - 1
-        ) // cfg.BLOCK_N
-        for _ in range(0, num_kv_tiles):
-            k_offsets, offs_n = program.make_k_offsets(kv_start)
-            v_offsets = program.make_v_offsets(kv_start)
-            mask = offs_n[:, None] < program.seq_len
-            program.issue_load_k(k_offsets, k_smem, mask=mask)
-            program.issue_load_v(v_offsets, v_smem, mask=mask, other=0.0)
+    main_end = program.q_start // cfg.BLOCK_N
+    base_k_offsets, base_offs_n = program.make_k_offsets(0)
+    base_v_offsets = program.make_v_offsets(0)
 
-            async_copy.wait_group(1)
-            k = program.shared_load_k(k_smem)
-            qk = program.compute_qk(q, k)
-            qk = program.apply_sliding_mask(qk, offs_n)
-            p, m_i, l_i, acc = program.softmax(qk, m_i, l_i, acc)
+    k_offsets = base_k_offsets
+    v_offsets = base_v_offsets
+    offs_n = base_offs_n
 
-            async_copy.wait_group(0)
-            v = program.shared_load_v(v_smem)
-            acc = program.compute_pv(p, v, acc)
-            kv_start = kv_start + cfg.BLOCK_N
-    else:
-        main_end = program.q_start // cfg.BLOCK_N
-        base_k_offsets, base_offs_n = program.make_k_offsets(0)
-        base_v_offsets = program.make_v_offsets(0)
-
-        k_offsets = base_k_offsets
-        v_offsets = base_v_offsets
-        offs_n = base_offs_n
-
-        for _ in range(0, main_end):
-            program.issue_load_k(k_offsets, k_smem)
-            program.issue_load_v(v_offsets, v_smem)
-
-            async_copy.wait_group(1)
-            k = program.shared_load_k(k_smem)
-            qk = program.compute_qk(q, k)
-            p, m_i, l_i, acc = program.softmax(qk, m_i, l_i, acc)
-
-            async_copy.wait_group(0)
-            v = program.shared_load_v(v_smem)
-            acc = program.compute_pv(p, v, acc)
-
-            k_offsets = program.update_k_offsets(k_offsets)
-            v_offsets = program.update_v_offsets(v_offsets)
-            offs_n = offs_n + cfg.BLOCK_N
-
-        # The main loop handles prefix tiles; the two boundary tiles are causal.
-        boundary_start = main_end * cfg.BLOCK_N
-        k_offsets, offs_n = program.make_k_offsets(boundary_start)
-        v_offsets = program.make_v_offsets(boundary_start)
-        mask = offs_n[:, None] < program.seq_len
-        program.issue_load_k(k_offsets, k_smem, mask=mask, other=0.0)
-        program.issue_load_v(v_offsets, v_smem, mask=mask, other=0.0)
+    for _ in range(0, main_end):
+        program.issue_load_k(k_offsets, k_smem)
+        program.issue_load_v(v_offsets, v_smem)
 
         async_copy.wait_group(1)
         k = program.shared_load_k(k_smem)
         qk = program.compute_qk(q, k)
-        qk = gl.where(boundary_mask0, qk, -float("inf"))
         p, m_i, l_i, acc = program.softmax(qk, m_i, l_i, acc)
 
         async_copy.wait_group(0)
         v = program.shared_load_v(v_smem)
         acc = program.compute_pv(p, v, acc)
 
-        boundary_start = boundary_start + cfg.BLOCK_N
-        k_offsets, offs_n = program.make_k_offsets(boundary_start)
-        v_offsets = program.make_v_offsets(boundary_start)
+        k_offsets = program.update_k_offsets(k_offsets)
+        v_offsets = program.update_v_offsets(v_offsets)
+        offs_n = offs_n + cfg.BLOCK_N
+
+    # The main loop handles prefix tiles; the two boundary tiles are causal.
+    boundary_start = main_end * cfg.BLOCK_N
+    k_offsets, offs_n = program.make_k_offsets(boundary_start)
+    v_offsets = program.make_v_offsets(boundary_start)
+    mask = offs_n[:, None] < program.seq_len
+    program.issue_load_k(k_offsets, k_smem, mask=mask, other=0.0)
+    program.issue_load_v(v_offsets, v_smem, mask=mask, other=0.0)
+
+    async_copy.wait_group(1)
+    k = program.shared_load_k(k_smem)
+    qk = program.compute_qk(q, k)
+    qk = gl.where(boundary_mask0, qk, -float("inf"))
+    p, m_i, l_i, acc = program.softmax(qk, m_i, l_i, acc)
+
+    async_copy.wait_group(0)
+    v = program.shared_load_v(v_smem)
+    acc = program.compute_pv(p, v, acc)
+
+    boundary_start = boundary_start + cfg.BLOCK_N
+    k_offsets, offs_n = program.make_k_offsets(boundary_start)
+    v_offsets = program.make_v_offsets(boundary_start)
+    mask = offs_n[:, None] < program.seq_len
+    program.issue_load_k(k_offsets, k_smem, mask=mask, other=0.0)
+    program.issue_load_v(v_offsets, v_smem, mask=mask, other=0.0)
+
+    async_copy.wait_group(1)
+    k = program.shared_load_k(k_smem)
+    qk = program.compute_qk(q, k)
+    qk = gl.where(boundary_mask1, qk, -float("inf"))
+    p, m_i, l_i, acc = program.softmax(qk, m_i, l_i, acc)
+
+    async_copy.wait_group(0)
+    v = program.shared_load_v(v_smem)
+    acc = program.compute_pv(p, v, acc)
+
+    l_i = program.apply_sinks(l_i, m_i, sink_log2)
+    program.store_lse(l_i, m_i)
+    denom = gl.where(l_i > 0.0, l_i, 1.0)
+    recip_denom = 1.0 / denom
+    output = acc * recip_denom[:, None]
+    output = gl.convert_layout(output, cfg.store_layout)
+    program.store_output(output)
+
+
+@gluon.jit
+def process_sliding_attention_tile(
+    program: AttentionProgram,
+    k_smem: gl.shared_memory_descriptor,
+    v_smem: gl.shared_memory_descriptor,
+):
+    cfg = program.cfg
+    q = program.load_q()
+    m_i, l_i, acc, sink_log2 = program.init_attention_state()
+
+    offs_m = program.q_start + gl.arange(
+        0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.qk_layout)
+    )
+    kv_start = program.q_start - cfg.WINDOW_LEFT
+    kv_start = gl.where(kv_start > 0, (kv_start // cfg.BLOCK_N) * cfg.BLOCK_N, 0)
+    num_kv_tiles: gl.constexpr = (
+        cfg.BLOCK_M + cfg.WINDOW_LEFT + cfg.BLOCK_N - 1
+    ) // cfg.BLOCK_N
+
+    for _ in range(0, num_kv_tiles):
+        k_offsets, offs_n = program.make_k_offsets(kv_start)
+        v_offsets = program.make_v_offsets(kv_start)
         mask = offs_n[:, None] < program.seq_len
-        program.issue_load_k(k_offsets, k_smem, mask=mask, other=0.0)
+        program.issue_load_k(k_offsets, k_smem, mask=mask)
         program.issue_load_v(v_offsets, v_smem, mask=mask, other=0.0)
 
         async_copy.wait_group(1)
         k = program.shared_load_k(k_smem)
         qk = program.compute_qk(q, k)
-        qk = gl.where(boundary_mask1, qk, -float("inf"))
-        p, m_i, l_i, acc = program.softmax(qk, m_i, l_i, acc)
+        kv = gl.convert_layout(offs_n, gl.SliceLayout(0, cfg.qk_layout))
+        valid = offs_m[:, None] < program.seq_len
+        valid &= kv[None, :] < program.seq_len
+        valid &= kv[None, :] <= offs_m[:, None]
+        valid &= offs_m[:, None] <= kv[None, :] + cfg.WINDOW_LEFT
+        p, m_i, l_i, acc = program.softmax_masked(qk, valid, m_i, l_i, acc)
 
         async_copy.wait_group(0)
         v = program.shared_load_v(v_smem)
         acc = program.compute_pv(p, v, acc)
+        kv_start = kv_start + cfg.BLOCK_N
 
     l_i = program.apply_sinks(l_i, m_i, sink_log2)
     program.store_lse(l_i, m_i)
@@ -841,7 +881,7 @@ def _mha_prefill_fp16(
         BATCH_SIZE,
         HAS_SINK,
         HAS_LSE,
-        WINDOW_LEFT,
+        -1,
         InputStrides(Q_STRIDE_T, Q_STRIDE_H, Q_STRIDE_D),
         InputStrides(K_STRIDE_T, K_STRIDE_H, K_STRIDE_D),
         InputStrides(V_STRIDE_T, V_STRIDE_H, V_STRIDE_D),
@@ -958,7 +998,7 @@ def _mha_prefill_sliding_fp16(
                 if program.q_start == 0:
                     process_single_attention_tile(program, k_smem, v_smem)
             else:
-                process_attention_tile(program, k_smem, v_smem)
+                process_sliding_attention_tile(program, k_smem, v_smem)
         scheduler = scheduler.advance()
 
 

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_prefill_fp16_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_prefill_fp16_gfx950.py
@@ -357,12 +357,22 @@ class AttentionProgram:
     @gluon.jit
     def softmax(self, qk, m_i, l_i, acc):
         cfg = self.cfg
+        HAS_INVALID: gl.constexpr = cfg.WINDOW_LEFT >= 0 and not cfg.HAS_SINK
         row_max = max(qk, 1)
         m_new = maximum(m_i, row_max)
         m_new_scaled = m_new * cfg.SM_SCALE
+        # In sliding window case, some rows can see fully masked tiles before
+        # any valid KV. Guard the online softmax state so `-inf - -inf` does not
+        # produce NaNs. This does not happen when having sink, because m_i
+        # is initialized to sink value instead of -inf.
+        if HAS_INVALID:
+            invalid = m_new == -float("inf")
+            m_new_scaled = gl.where(invalid, 0.0, m_new_scaled)
         qk_shifted = qk * cfg.SM_SCALE - m_new_scaled[:, None]
         p = gl.exp2(qk_shifted)
         m_diff = m_i * cfg.SM_SCALE - m_new_scaled
+        if HAS_INVALID:
+            m_diff = gl.where(invalid, 0.0, m_diff)
         alpha = gl.exp2(m_diff)
         l_ij = gl.sum(p, axis=1)
         l_i = l_i * alpha + l_ij
@@ -372,32 +382,17 @@ class AttentionProgram:
         return p, m_new, l_i, acc
 
     @gluon.jit
-    def softmax_masked(self, qk, valid, m_i, l_i, acc):
+    def apply_sliding_mask(self, qk, offs_n):
         cfg = self.cfg
-        qk = gl.where(valid, qk, -float("inf"))
-        row_max = max(qk, 1)
-        row_max_is_neg_inf = row_max == -float("inf")
-        m_new = gl.where(row_max_is_neg_inf, m_i, maximum(m_i, row_max))
-        m_new_scaled = m_new * cfg.SM_SCALE
-        m_new_scaled_safe = gl.where(row_max_is_neg_inf, 0.0, m_new_scaled)
-        p = gl.where(
-            valid, gl.exp2(qk * cfg.SM_SCALE - m_new_scaled_safe[:, None]), 0.0
+        offs_m = self.q_start + gl.arange(
+            0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.qk_layout)
         )
-
-        same_state = m_i == m_new
-        m_i_scaled_safe = gl.where(same_state, 0.0, m_i * cfg.SM_SCALE)
-        m_new_scaled_for_alpha = gl.where(same_state, 0.0, m_new_scaled)
-        alpha = gl.where(
-            same_state,
-            1.0,
-            gl.exp2(m_i_scaled_safe - m_new_scaled_for_alpha),
-        )
-        l_i = l_i * alpha + gl.sum(p, axis=1)
-        acc = acc * alpha[:, None]
-
-        p = p.to(self.q_ptr.dtype.element_ty)
-        p = gl.convert_layout(p, cfg.p_layout)
-        return p, m_new, l_i, acc
+        kv = gl.convert_layout(offs_n, gl.SliceLayout(0, cfg.qk_layout))
+        valid = offs_m[:, None] < self.seq_len
+        valid &= kv[None, :] < self.seq_len
+        valid &= kv[None, :] <= offs_m[:, None]
+        valid &= offs_m[:, None] <= kv[None, :] + cfg.WINDOW_LEFT
+        return gl.where(valid, qk, -float("inf"))
 
     @gluon.jit
     def apply_sinks(self, l_i, m_i, sink_log2):
@@ -794,9 +789,6 @@ def process_sliding_attention_tile(
     q = program.load_q()
     m_i, l_i, acc, sink_log2 = program.init_attention_state()
 
-    offs_m = program.q_start + gl.arange(
-        0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.qk_layout)
-    )
     kv_start = program.q_start - cfg.WINDOW_LEFT
     kv_start = gl.where(kv_start > 0, (kv_start // cfg.BLOCK_N) * cfg.BLOCK_N, 0)
     num_kv_tiles: gl.constexpr = (
@@ -813,12 +805,8 @@ def process_sliding_attention_tile(
         async_copy.wait_group(1)
         k = program.shared_load_k(k_smem)
         qk = program.compute_qk(q, k)
-        kv = gl.convert_layout(offs_n, gl.SliceLayout(0, cfg.qk_layout))
-        valid = offs_m[:, None] < program.seq_len
-        valid &= kv[None, :] < program.seq_len
-        valid &= kv[None, :] <= offs_m[:, None]
-        valid &= offs_m[:, None] <= kv[None, :] + cfg.WINDOW_LEFT
-        p, m_i, l_i, acc = program.softmax_masked(qk, valid, m_i, l_i, acc)
+        qk = program.apply_sliding_mask(qk, offs_n)
+        p, m_i, l_i, acc = program.softmax(qk, m_i, l_i, acc)
 
         async_copy.wait_group(0)
         v = program.shared_load_v(v_smem)

--- a/tokenspeed-kernel/test/ops/test_attention.py
+++ b/tokenspeed-kernel/test/ops/test_attention.py
@@ -47,16 +47,20 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.mark.parametrize(
     "dtype,head_dim,num_q_heads,num_kv_heads",
-    [(torch.bfloat16, 128, 8, 2)],
+    [(torch.bfloat16, 64, 8, 2)],
 )
+@pytest.mark.parametrize("has_sink", [False, True], ids=["no-sink", "sink"])
+@pytest.mark.parametrize("is_sliding", [False, True], ids=["full", "sliding"])
 def test_mha_prefill(
     device: str,
     dtype: torch.dtype,
     head_dim: int,
     num_q_heads: int,
     num_kv_heads: int,
+    has_sink: bool,
+    is_sliding: bool,
 ) -> None:
-    seqlens_list = [17, 9, 12]
+    seqlens_list = [851, 914, 1053]
     max_seqlen = max(seqlens_list)
     cu_seqlens_cpu = [0]
     for seqlen in seqlens_list:
@@ -68,6 +72,12 @@ def test_mha_prefill(
     q = torch.randn(total_tokens, num_q_heads, head_dim, device=device, dtype=dtype)
     k = torch.randn(total_tokens, num_kv_heads, head_dim, device=device, dtype=dtype)
     v = torch.randn(total_tokens, num_kv_heads, head_dim, device=device, dtype=dtype)
+    sinks = (
+        torch.randn(num_q_heads, device=device, dtype=torch.float32)
+        if has_sink
+        else None
+    )
+    window_left = 127 if is_sliding else -1
 
     out = mha_prefill(
         q=q,
@@ -76,9 +86,12 @@ def test_mha_prefill(
         cu_seqlens=cu_seqlens,
         cu_seqlens_cpu=cu_seqlens_cpu,
         max_seqlen=max_seqlen,
+        window_left=window_left,
+        sinks=sinks,
     )
 
     assert out.shape == q.shape
+    assert not torch.isnan(out).any()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Optimized the sliding window mask compute.
- Fix a NaN issue for slinding window prefill w/o sink.

## Test Plan

For batch size 1

| seqlen | q_heads | kv_heads | head_size | previous | now | improvement |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 1024 | 64 | 8 | 64 | 20.83 us | 17.81 us | 16.97% |
| 2048 | 64 | 8 | 64 | 31.83 us | 27.12 us | 17.36% |
| 4096 | 64 | 8 | 64 | 58.64 us | 48.49 us | 20.93% |
| 8192 | 64 | 8 | 64 | 116.43 us | 94.14 us | 23.68% |

**NOTE**: The current persistent loop has severe sgpr spill (106 + 148 spill). but looks like its performance impact is small. non-persistent version can save ~100 sgpr but still much slower. so I will keep the current persistent loop.
