### PR TITLE
feat(moe): add trtllm mxint4 (INT4 W4A16 group-32) MoE path for Kimi-K2.x

### DIFF
--- a/python/tokenspeed/runtime/layers/moe/expert.py
+++ b/python/tokenspeed/runtime/layers/moe/expert.py
@@ -146,7 +146,7 @@ class MoELayer(torch.nn.Module):
             prefix=self.prefix,
             ignored_layers=quant_config.ignored_layers,
         ):
-            self._quant_kind = quant_config.get_name()
+            self._quant_kind = quant_config.moe_weight_dtype()
 
         fp8_scale_block_shape = None
         internal_activation_dtype = "input"

--- a/python/tokenspeed/runtime/layers/moe/weights/__init__.py
+++ b/python/tokenspeed/runtime/layers/moe/weights/__init__.py
@@ -25,6 +25,7 @@ from tokenspeed.runtime.layers.moe.weights.mxfp4 import (
     create_mxfp4_fp8_input_scales,
     create_mxfp4_weight_pair,
 )
+from tokenspeed.runtime.layers.moe.weights.mxint4 import create_mxint4_weight_pair
 from tokenspeed.runtime.layers.moe.weights.nvfp4 import create_nvfp4_weight_pair
 from tokenspeed.runtime.layers.moe.weights.unquant import create_dense_weight_pair
 
@@ -74,6 +75,15 @@ def create_layer_weights(
         create_mxfp4_weight_pair(spec, layer, with_bias=with_bias, solution=solution)
         if quant_config.is_w4a8_fp8:
             create_mxfp4_fp8_input_scales(layer, spec.num_local_experts)
+        return
+
+    if quant_kind == "mxint4":
+        weight_quant = quant_config.target_scheme_map["Linear"]["weights"]
+        create_mxint4_weight_pair(
+            spec,
+            layer,
+            group_size=weight_quant.group_size,
+        )
         return
 
     raise RuntimeError(f"Unsupported MoE quant kind: {quant_kind}")

--- a/python/tokenspeed/runtime/layers/moe/weights/mxint4.py
+++ b/python/tokenspeed/runtime/layers/moe/weights/mxint4.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from tokenspeed.runtime.layers.moe.types import MoELayerSpec
+from tokenspeed.runtime.layers.moe.weights.loaders import (
+    make_group_scale_loader,
+    make_weight_loader,
+)
+from tokenspeed.runtime.utils import set_weight_attrs
+
+# Eight INT4 values per int32 word (32 // 4); the kernel and its repack are
+# INT4-only, so this is a constant, not a config knob.
+_PACKED_FACTOR = 8
+
+
+def _ignore_weight_loader(param, loaded_weight, **kwargs) -> None:
+    """No-op loader for checkpoint metadata tensors the kernel does not use."""
+    del param, loaded_weight, kwargs
+
+
+def create_mxint4_weight_pair(
+    spec: MoELayerSpec,
+    layer: nn.Module,
+    *,
+    group_size: int,
+) -> None:
+    """Register per-expert INT4 pack-quantized weights with bf16 group scales.
+
+    Tensors keep the natural ``[out, in // _PACKED_FACTOR]`` checkpoint layout
+    (gate/up fused along the output dim), so the shared MoE checkpoint loaders
+    fill them without transposition; the trtllm process-weights kernel rewrites
+    them into the kernel layout afterwards. Eight INT4 values are packed per
+    ``int32`` word, while scales hold one ``bfloat16`` value per ``group_size``
+    input elements.
+    """
+    ispp = spec.intermediate_size // spec.tp_size
+
+    # Fused gate_up_proj (column parallel): [2 * intermediate, hidden // pack].
+    w13_weight_packed = torch.nn.Parameter(
+        torch.empty(
+            spec.num_local_experts,
+            2 * ispp,
+            spec.hidden_size // _PACKED_FACTOR,
+            dtype=torch.int32,
+        ),
+        requires_grad=False,
+    )
+    # down_proj (row parallel): [hidden, intermediate // pack].
+    w2_weight_packed = torch.nn.Parameter(
+        torch.empty(
+            spec.num_local_experts,
+            spec.hidden_size,
+            ispp // _PACKED_FACTOR,
+            dtype=torch.int32,
+        ),
+        requires_grad=False,
+    )
+    layer.register_parameter("w13_weight_packed", w13_weight_packed)
+    layer.register_parameter("w2_weight_packed", w2_weight_packed)
+
+    # Per-group bf16 scales: one scale per ``group_size`` input elements.
+    w13_weight_scale = torch.nn.Parameter(
+        torch.ones(
+            spec.num_local_experts,
+            2 * ispp,
+            spec.hidden_size // group_size,
+            dtype=torch.bfloat16,
+        ),
+        requires_grad=False,
+    )
+    w2_weight_scale = torch.nn.Parameter(
+        torch.ones(
+            spec.num_local_experts,
+            spec.hidden_size,
+            ispp // group_size,
+            dtype=torch.bfloat16,
+        ),
+        requires_grad=False,
+    )
+    layer.register_parameter("w13_weight_scale", w13_weight_scale)
+    layer.register_parameter("w2_weight_scale", w2_weight_scale)
+
+    weight_loader = make_weight_loader(spec)
+    scale_loader = make_group_scale_loader(spec)
+    set_weight_attrs(w13_weight_packed, {"weight_loader": weight_loader})
+    set_weight_attrs(w2_weight_packed, {"weight_loader": weight_loader})
+    set_weight_attrs(w13_weight_scale, {"weight_loader": scale_loader})
+    set_weight_attrs(w2_weight_scale, {"weight_loader": scale_loader})
+
+    # compressed-tensors ships a per-proj ``weight_shape`` metadata tensor the
+    # kernel ignores. Register absorbers so the loader has a target (it raises
+    # on a matched expert tensor with no parameter); dropped in process_weights.
+    for shape_name in ("w13_weight_shape", "w2_weight_shape"):
+        shape_param = torch.nn.Parameter(
+            torch.empty(spec.num_local_experts, 2, dtype=torch.int32),
+            requires_grad=False,
+        )
+        layer.register_parameter(shape_name, shape_param)
+        set_weight_attrs(shape_param, {"weight_loader": _ignore_weight_loader})
+
+
+__all__ = ["create_mxint4_weight_pair"]

--- a/python/tokenspeed/runtime/layers/quantization/base_config.py
+++ b/python/tokenspeed/runtime/layers/quantization/base_config.py
@@ -64,6 +64,16 @@ class QuantizationConfig(ABC):
         """Name of the quantization method."""
         raise NotImplementedError
 
+    def moe_weight_dtype(self) -> str:
+        """Logical MoE weight dtype fed to ``moe_plan`` as the ``weight_dtype`` trait.
+
+        Must name a concrete dtype the kernels register against (``fp8``,
+        ``nvfp4``, ``mxfp4``), not the quant method. Configs whose name already
+        is the dtype need no override; container formats (compressed-tensors)
+        resolve it from the parsed scheme.
+        """
+        return self.get_name()
+
     @abstractmethod
     def get_supported_act_dtypes(self) -> list[torch.dtype]:
         """List of supported activation dtypes."""

--- a/python/tokenspeed/runtime/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/tokenspeed/runtime/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -124,6 +124,27 @@ class CompressedTensorsConfig(QuantizationConfig):
     def get_name(self) -> str:
         return "compressed_tensors"
 
+    def moe_weight_dtype(self) -> str:
+        # Container format: resolve the routed-expert scheme to a concrete MoE
+        # kernel dtype. Only INT4 group-32 symmetric pack-quantized weights
+        # (Kimi-K2.5 / K2.6 / K2.7, weight-only + bf16 group scales) are wired.
+        weight_quant = self.target_scheme_map["Linear"].get("weights")
+        input_quant = self.target_scheme_map["Linear"].get("input_activations")
+        if (
+            weight_quant is not None
+            and self._is_wNa16_group_channel(weight_quant, input_quant)
+            and weight_quant.type == QuantizationType.INT
+            and weight_quant.num_bits == 4
+            and weight_quant.strategy == QuantizationStrategy.GROUP.value
+            and weight_quant.group_size == 32
+            and not weight_quant.actorder
+        ):
+            return "mxint4"
+        raise ValueError(
+            f"unsupported compressed-tensors MoE scheme for kernel selection: "
+            f"{weight_quant}"
+        )
+
     def get_scaled_act_names(self) -> list[str]:
         return []
 

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -1486,11 +1486,13 @@ class DeepseekV3ForCausalLM(BaseCausalLM):
                     "q_a_proj" in name or "kv_a_proj_with_mqa" in name
                 ):
                     quant_block_size = 1
-                    if (
-                        self.quant_config is not None
-                        and self.quant_config.weight_block_size is not None
-                    ):
-                        quant_block_size = self.quant_config.weight_block_size[0]
+                    # ``weight_block_size`` exists only on block-FP8 configs;
+                    # elsewhere (e.g. compressed-tensors INT4) q/kv_a_proj is unquantized.
+                    weight_block_size = getattr(
+                        self.quant_config, "weight_block_size", None
+                    )
+                    if self.quant_config is not None and weight_block_size is not None:
+                        quant_block_size = weight_block_size[0]
                     begin_size_mp = {
                         "q_a_proj": 0,
                         "kv_a_proj_with_mqa": self.config.q_lora_rank,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/__init__.py
@@ -23,6 +23,7 @@ import tokenspeed_kernel.ops.moe.flashinfer.cutlass_fp8  # noqa: F401
 import tokenspeed_kernel.ops.moe.flashinfer.cutlass_nvfp4  # noqa: F401
 import tokenspeed_kernel.ops.moe.flashinfer.cutlass_unquant  # noqa: F401
 import tokenspeed_kernel.ops.moe.flashinfer.trtllm_mxfp4  # noqa: F401
+import tokenspeed_kernel.ops.moe.flashinfer.trtllm_mxint4  # noqa: F401
 import tokenspeed_kernel.ops.moe.flashinfer.trtllm_nvfp4  # noqa: F401
 import tokenspeed_kernel.ops.moe.flashinfer.trtllm_unquant  # noqa: F401
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_mxint4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_mxint4.py
@@ -1,0 +1,295 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Weight-only INT4 group-32 MoE using the fused FlashInfer block-scale kernel.
+
+Serves ``compressed-tensors`` ``pack-quantized`` checkpoints whose routed
+experts are INT4 with a group size of 32 and ``bfloat16`` group scales (e.g.
+Kimi-K2.5 / K2.6 / K2.7). Blackwell-only, weight-only (activations stay
+``bfloat16``, no activation quant); routing runs inside the kernel from raw logits.
+
+The checkpoint stores ``weight_packed`` as ``int32`` (eight INT4 per word,
+``+8`` zero-point) with per-group ``bfloat16`` scales; the kernel wants signed
+``uint8`` weights (two INT4 per byte) in ``BlockMajorK`` layout with
+permuted/interleaved scales. process_weights repacks them once.
+"""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel.platform import (
+    ArchVersion,
+    CapabilityRequirement,
+    current_platform,
+)
+from tokenspeed_kernel.registry import Priority, register_kernel
+from tokenspeed_kernel.signature import format_signature, format_signatures
+
+platform = current_platform()
+next_power_of_2 = lambda value: 1 if value <= 1 else 1 << (value - 1).bit_length()
+
+# FlashInfer's block-scale MoE kernel is tiled with a fixed 128-row epilogue and
+# a 128-element K block; the weight/scale permutations are computed against
+# these constants.
+_EPILOGUE_TILE_M = 128
+_BLOCK_K = 128
+
+
+if platform.is_nvidia:
+    from flashinfer import block_scale_interleave
+    from flashinfer.fused_moe.core import (
+        _maybe_get_cached_w3_w1_permute_indices,
+        convert_to_block_layout,
+        get_w2_permute_indices_with_cache,
+        trtllm_mxint4_block_scale_moe,
+    )
+
+    def _repack_int4(packed: torch.Tensor) -> torch.Tensor:
+        """Convert one expert's ``int32`` ``(w/s)+8`` words to ``uint8`` ``(w/s)``.
+
+        The checkpoint packs eight unsigned 4-bit values per ``int32`` with the
+        ``+8`` zero-point convention; the kernel wants signed two's-complement
+        INT4, two per byte, so the offset is removed and the nibbles re-packed.
+        """
+        assert packed.dim() == 2 and packed.dtype == torch.int32
+        shifts = torch.arange(0, 32, 4, dtype=torch.int32, device=packed.device)
+        nibbles = (packed.unsqueeze(2) >> shifts) & 0x0F
+        nibbles = (nibbles - 8).to(torch.int8).reshape(packed.shape[0], -1, 2)
+        out = (nibbles[..., 0] & 0x0F) | ((nibbles[..., 1] & 0x0F) << 4)
+        return out.to(torch.uint8)
+
+    def _prepare_mxint4_weights_for_kernel(
+        w13_weight_packed: torch.Tensor,
+        w2_weight_packed: torch.Tensor,
+        w13_weight_scale: torch.Tensor,
+        w2_weight_scale: torch.Tensor,
+        num_experts: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Repack + permute + block-layout every expert into the kernel format."""
+        cache: dict = {}
+        w13_weights_shuffled = []
+        w13_scales_shuffled = []
+        w2_weights_shuffled = []
+        w2_scales_shuffled = []
+
+        for i in range(num_experts):
+            gemm1_weight = _repack_int4(w13_weight_packed[i])
+            gemm2_weight = _repack_int4(w2_weight_packed[i])
+
+            # gate_up (gemm1): permute rows for the transposed-MMA epilogue, then
+            # interleave the group scales the same way.
+            perm = _maybe_get_cached_w3_w1_permute_indices(
+                cache, gemm1_weight, _EPILOGUE_TILE_M
+            )
+            w13_weights_shuffled.append(
+                gemm1_weight[perm.to(gemm1_weight.device)].contiguous()
+            )
+            perm_sf = _maybe_get_cached_w3_w1_permute_indices(
+                cache,
+                w13_weight_scale[i].to(torch.bfloat16),
+                _EPILOGUE_TILE_M,
+                num_elts_per_sf=32,
+            )
+            w13_scales_shuffled.append(
+                block_scale_interleave(
+                    w13_weight_scale[i]
+                    .to(torch.bfloat16)[perm_sf.to(w13_weight_scale.device)]
+                    .contiguous()
+                )
+            )
+
+            # down (gemm2): same treatment with the w2 permutation helper.
+            perm2 = get_w2_permute_indices_with_cache(
+                cache, gemm2_weight, _EPILOGUE_TILE_M
+            )
+            w2_weights_shuffled.append(
+                gemm2_weight[perm2.to(gemm2_weight.device)].contiguous()
+            )
+            perm2_sf = get_w2_permute_indices_with_cache(
+                cache,
+                w2_weight_scale[i].to(torch.bfloat16),
+                _EPILOGUE_TILE_M,
+                num_elts_per_sf=16,
+            )
+            w2_scales_shuffled.append(
+                block_scale_interleave(
+                    w2_weight_scale[i]
+                    .to(torch.bfloat16)[perm2_sf.to(w2_weight_scale.device)]
+                    .contiguous()
+                )
+            )
+
+        w13_weights = torch.stack(
+            [
+                convert_to_block_layout(w.view(torch.uint8), _BLOCK_K)
+                for w in w13_weights_shuffled
+            ]
+        )
+        w2_weights = torch.stack(
+            [
+                convert_to_block_layout(w.view(torch.uint8), _BLOCK_K)
+                for w in w2_weights_shuffled
+            ]
+        )
+        w13_scales = torch.stack(w13_scales_shuffled)
+        w2_scales = torch.stack(w2_scales_shuffled)
+        return w13_weights, w13_scales, w2_weights, w2_scales
+
+    @register_kernel(
+        "moe",
+        "process_weights",
+        name="flashinfer_trtllm_mxint4_moe_process_weights",
+        solution="flashinfer_trtllm",
+        capability=CapabilityRequirement(
+            vendors=frozenset({"nvidia"}),
+            min_arch_version=ArchVersion(10, 0),
+            max_arch_version=ArchVersion(10, 3),
+        ),
+        signatures=frozenset({format_signature()}),
+        traits={"weight_dtype": frozenset({"mxint4"})},
+        priority=Priority.SPECIALIZED,
+    )
+    def flashinfer_trtllm_mxint4_moe_process_weights(plan: dict, w: torch.nn.Module):
+        num_experts = w.w13_weight_packed.shape[0]
+
+        # Swap [W1(Gate), W3(Up)] -> [W3(Up), W1(Gate)]. The flashinfer fused
+        # gated-act epilogue expects the up-proj rows first; the shared loader
+        # fills the natural [gate|up] order, so swap the two w13 halves (weight +
+        # group scale) here, mirroring the nvfp4 path (trtllm_nvfp4.py:73-88).
+        # Without this every expert computes silu(W_up x) * (W_gate x) instead of
+        # silu(W_gate x) * (W_up x).
+        half_w = w.w13_weight_packed.shape[1] // 2
+        w1_weight = w.w13_weight_packed.data[:, :half_w, :].clone()
+        w.w13_weight_packed.data[:, :half_w, :] = w.w13_weight_packed.data[
+            :, half_w:, :
+        ]
+        w.w13_weight_packed.data[:, half_w:, :] = w1_weight
+        del w1_weight
+
+        half_s = w.w13_weight_scale.shape[1] // 2
+        w1_scale = w.w13_weight_scale.data[:, :half_s, :].clone()
+        w.w13_weight_scale.data[:, :half_s, :] = w.w13_weight_scale.data[:, half_s:, :]
+        w.w13_weight_scale.data[:, half_s:, :] = w1_scale
+        del w1_scale
+
+        w13_weights, w13_scales, w2_weights, w2_scales = (
+            _prepare_mxint4_weights_for_kernel(
+                w.w13_weight_packed.data,
+                w.w2_weight_packed.data,
+                w.w13_weight_scale.data,
+                w.w2_weight_scale.data,
+                num_experts=num_experts,
+            )
+        )
+        w.w13_weight_packed = torch.nn.Parameter(w13_weights, requires_grad=False)
+        w.w2_weight_packed = torch.nn.Parameter(w2_weights, requires_grad=False)
+        w.w13_weight_scale = torch.nn.Parameter(w13_scales, requires_grad=False)
+        w.w2_weight_scale = torch.nn.Parameter(w2_scales, requires_grad=False)
+
+        # Drop the unused compressed-tensors ``weight_shape`` metadata absorbed
+        # during loading.
+        for shape_name in ("w13_weight_shape", "w2_weight_shape"):
+            if hasattr(w, shape_name):
+                delattr(w, shape_name)
+
+        # The kernel reads the routing bias in bfloat16. _correction_bias is a
+        # registered nn.Parameter on the layer, so mutate its data in place;
+        # rebinding the attribute to a plain Tensor would raise.
+        correction_bias = getattr(w, "_correction_bias", None)
+        if correction_bias is not None and correction_bias.dtype != torch.bfloat16:
+            correction_bias.data = correction_bias.data.to(torch.bfloat16)
+        return None
+
+    @register_kernel(
+        "moe",
+        "apply",
+        name="flashinfer_trtllm_mxint4_moe_apply",
+        solution="flashinfer_trtllm",
+        capability=CapabilityRequirement(
+            vendors=frozenset({"nvidia"}),
+            min_arch_version=ArchVersion(10, 0),
+            max_arch_version=ArchVersion(10, 3),
+        ),
+        signatures=format_signatures(
+            "x",
+            "dense",
+            {torch.float16, torch.bfloat16},
+        ),
+        traits={
+            "weight_dtype": frozenset({"mxint4"}),
+            "activation": frozenset({"silu", "swiglu"}),
+            "routing_mode": frozenset({"kernel_routing"}),
+            "supports_deferred_finalize": frozenset({False}),
+            "supports_ep": frozenset({True}),
+            "supports_all_to_all_ep": frozenset({False}),
+            # w2 stores two INT4 per byte, so its packed K dim is ispp // 2 and
+            # the 128-element block layout needs ispp divisible by 256.
+            "ispp_alignment": frozenset({256}),
+            "internal_activation_dtype": frozenset({"input"}),
+        },
+        priority=Priority.SPECIALIZED,
+    )
+    def flashinfer_trtllm_mxint4_moe_apply(
+        plan: dict,
+        x: torch.Tensor,
+        w: torch.nn.Module,
+        router_logits: torch.Tensor,
+        topk_weights: torch.Tensor | None = None,
+        topk_ids: torch.Tensor | None = None,
+        num_tokens_global: int | None = None,
+        max_num_tokens_per_gpu: int | None = None,
+        do_finalize: bool = True,
+        enable_pdl: bool = False,
+    ):
+        # Idle DP ranks / dummy warmup issue a 0-token forward; the fused kernel
+        # divides by token count on the host and SIGFPEs on empty input. This
+        # path is do_finalize-only, and x is already [0, hidden].
+        if x.shape[0] == 0:
+            return x
+
+        # DeepSeekV3 / MiniMax2 routing reads the logits in float32; the layer
+        # records the right dtype for its routing method.
+        routing_logits = router_logits.to(
+            getattr(w, "_routing_logits_dtype", torch.float32)
+        )
+        local_experts = w.num_local_experts
+        result = trtllm_mxint4_block_scale_moe(
+            routing_logits=routing_logits,
+            routing_bias=getattr(w, "_correction_bias", None),
+            hidden_states=x,
+            gemm1_weights=w.w13_weight_packed,
+            gemm1_weights_scale=w.w13_weight_scale,
+            gemm1_alpha=None,
+            gemm1_beta=None,
+            gemm1_clamp_limit=None,
+            gemm2_weights=w.w2_weight_packed,
+            gemm2_weights_scale=w.w2_weight_scale,
+            num_experts=w.num_experts,
+            top_k=w.top_k,
+            n_group=w._n_group,
+            topk_group=w._topk_group,
+            intermediate_size=w.intermediate_size // w.tp_size,
+            local_expert_offset=w.ep_rank * local_experts,
+            local_num_experts=local_experts,
+            routed_scaling_factor=w._routed_scaling_factor,
+            routing_method_type=w._routing_method_type,
+            tune_max_num_tokens=next_power_of_2(x.shape[0]),
+        )
+        return result[0]


### PR DESCRIPTION
## Summary
Kimi-K2.x is released by the model vendor in INT4 (compressed-tensors W4A16, group-size 32, symmetric) — that INT4 checkpoint is the model's native, as-shipped precision, not a downstream post-training quantization. This PR adds a weight-only INT4 MoE path so we serve the vendor's own checkpoint directly on Blackwell (via flashinfer `trtllm_mxint4_block_scale_moe`), instead of relying on a separately post-training-quantized NVFP4 variant. Only the routed experts are quantized (attn / shared / dense / lm_head / vision stay bf16).

## What changed
- **quant seam** (`quantization/base_config.py`, `compressed_tensors.py`): new `moe_weight_dtype()` (default = quant method name; compressed_tensors maps an INT4 / 4-bit / group-32 / symmetric W4A16 group scheme to `"mxint4"`). Decouples the quant method from the MoE weight dtype; `moe/expert.py` dispatches on the latter.
- **kernel** (`tokenspeed-kernel/.../ops/moe/flashinfer/trtllm_mxint4.py`, new): registers the MoE `process_weights` + `apply` kernels for the `mxint4` weight dtype. `process_weights` repacks the int4 words, applies the kernel permute + block-scale interleave, and swaps the w13 gate/up halves into the `[Up, Gate]` order the fused gated-act epilogue expects (same layout step as the nvfp4 trtllm path). `apply` is pure weight-only with a zero-token guard.
- **weights** (`moe/weights/mxint4.py`, new; `weights/__init__.py`): builds the int32 packed weight + bf16 group-scale params and dispatches them.
- **loader guard** (`models/deepseek_v3.py`): guard the fp8-only `weight_block_size` access so compressed-tensors checkpoints load.

## Accuracy (Kimi-K2.5, TP4, B200, via `ts serve`, greedy)
| benchmark | NVFP4 | INT4 (this PR) |
|---|---|---|
| OCRBench (1000) | 0.906 | 0.909 |
| AIME 2025 (30) | 28/30 | 28/30 |

Serving the vendor's native INT4 matches the post-training NVFP4 variant: no accuracy regression.

## Notes
- Blackwell-only (kernel capability sm_100-10.3); the trait match excludes it elsewhere.
- Outputs verified numerically coherent end-to-end before the accuracy runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
