### PR TITLE
fix(cudagraph): seed warmup seq_lens to q_len to avoid NAN

### DIFF
--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -416,6 +416,9 @@ class CudaGraphWrapper:
                 self.sampling_backend.prepare_capture(
                     bs=bs, num_tokens_per_req=self.max_tokens_per_req
                 )
+            # Keep warmup seq_lens >= q_len_per_req so no query row gets an
+            # empty causal span; a stale seq_len of 1 overflows to non-finite KV.
+            self.input_buffers.seq_lens_buf[:bs].fill_(self.max_tokens_per_req)
             self._init_capture_metadata(bs)
             run_once()
 


### PR DESCRIPTION
## Summary：

CUDA-graph capture runs warmup forwards without refreshing InputBuffers.seq_lens_buf, so they execute against the torch.ones init value (seq_len=1). Under spec-decode the verify forward has q_len_per_req = spec_num_tokens (e.g. 4), and the end-aligned decode kernel maps query row i to KV position seq_len - q_len + i. With seq_len=1 < q_len=4 the leading query rows get an empty causal span; the attention-sink fallback keeps them finite but produces large activations that accumulate across layers and overflow bf16 to ±inf, writing non-finite KV into the dummy slot.

Fix: seed seq_lens_buf[:bs] to max_tokens_per_req (= q_len_per_req) before each warmup forward, the minimal value that gives every query row a non-empty causal span. No effect on non-spec runs (max_tokens_per_req == 1).