### PR TITLE
chore(license): use LightSeek header on sleep/wake files

### DIFF
--- a/python/tokenspeed/runtime/engine/memory_occupation.py
+++ b/python/tokenspeed/runtime/engine/memory_occupation.py
@@ -1,4 +1,23 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 """GPU-memory data plane for sleep/wake (release/resume_memory_occupation).
 
 Pairs with the control-plane :class:`PauseController`. A *release* pauses and

--- a/test/runtime/test_sleep_wakeup_gpu.py
+++ b/test/runtime/test_sleep_wakeup_gpu.py
@@ -1,4 +1,23 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 """GPU integration cases for the Sleep/Wake Up API (release/resume_memory_occupation).
 
 Run on a CUDA box with torch_memory_saver installed and a small model. Not part

--- a/test/runtime/test_sleep_wakeup_v4_gpu.py
+++ b/test/runtime/test_sleep_wakeup_v4_gpu.py
@@ -1,4 +1,23 @@
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 """Full DeepSeek-V4 sleep/wake integration test (DP4), exercising the V4 KV pool
 region wrapping AND the DP idle-forward gate.
 


### PR DESCRIPTION
## Summary

The three files added by the Sleep/Wake Up API PR (#393) shipped with an SPDX-only license header (`# SPDX-License-Identifier: Apache-2.0`) instead of the project-standard **LightSeek Foundation MIT block** used by the other ~270 Python files in the repo. This swaps them to the canonical header.

Files updated (comment-only, no functional change):
- `python/tokenspeed/runtime/engine/memory_occupation.py`
- `test/runtime/test_sleep_wakeup_gpu.py`
- `test/runtime/test_sleep_wakeup_v4_gpu.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)