### PR TITLE
fix(scheduler): release paged-cache snapshots in ~HybridPrefixCache to avoid teardown use-after-free

### DIFF
--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
@@ -48,6 +48,17 @@ HybridPrefixCache::HybridPrefixCache(KVPrefixCache& kv_prefix_cache, MambaChunkA
       mamba_eviction_manager_{mamba_allocator},
       mamba_cache_chunk_size_{mamba_cache_chunk_size} {}
 
+HybridPrefixCache::~HybridPrefixCache() {
+    // Snapshots on KVPrefixCache's tree nodes hold OwnedPages borrowed from
+    // paged_cache_allocators_, but Scheduler destroys this object before
+    // KVPrefixCache. Release them now so the pages return to still-live
+    // allocators instead of deallocating into a freed allocator during
+    // ~KVPrefixCache (heap-use-after-free).
+    while (!paged_cache_snapshot_nodes_.empty()) {
+        DetachPagedCacheSnapshotFromNode(*paged_cache_snapshot_nodes_.begin());
+    }
+}
+
 MatchResult HybridPrefixCache::Match(const token_vec_t& token_ids, MatchIntent intent) {
     auto match = kv_prefix_cache_.Match(token_ids, intent);
     augmentMatch(match);

--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.h
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.h
@@ -51,6 +51,10 @@ public:
     HybridPrefixCache(KVPrefixCache& prefix_cache, MambaChunkAllocator* allocator, std::int32_t mamba_cache_chunk_size,
                       MambaHostAllocator* mamba_host_allocator = nullptr);
 
+    // Detaches any paged-cache snapshots still on tree nodes before the
+    // PagedCacheGroupAllocator members they borrow from are destroyed.
+    ~HybridPrefixCache();
+
     MatchResult Match(const token_vec_t& token_ids, MatchIntent intent = MatchIntent::PrefixReuse);
     MatchResult Match(const std::vector<std::span<const std::int32_t>>& token_pages,
                       MatchIntent intent = MatchIntent::PrefixReuse);

--- a/tokenspeed-scheduler/tests/cpp/test_paged_cache_family_split.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_paged_cache_family_split.cpp
@@ -117,4 +117,25 @@ TEST_F(PagedCacheFamilySplitTest, StateDetachDoesNotBreakHistoryChain) {
     EXPECT_EQ(match.paged_cache.prefix_len_tokens, 768);
 }
 
+// Regression: ~HybridPrefixCache must drop snapshots still on tree nodes before
+// its allocators die. The nodes outlive hybrid_ (Scheduler order), so otherwise
+// their OwnedPages deallocate into a freed allocator at teardown (UAF under ASan).
+TEST_F(PagedCacheFamilySplitTest, DestructorReleasesAttachedSnapshots) {
+    const std::int32_t num_pages = 768 / kPageSize;
+    TreeNode* terminal = InsertDevicePages(num_pages, /*token_start=*/1);
+    ASSERT_NE(terminal, nullptr);
+
+    TreeNode* n256 = kv_cache_->GetRadixTree().SplitAt(terminal, 256);
+    ASSERT_NE(n256, nullptr);
+    hybrid_->AttachPagedCacheSnapshotToNode(n256, MakeCompleteSnapshot(256));
+    ASSERT_TRUE(n256->HasPagedCacheSnapshot());
+
+    // Destroy the hybrid cache first, mirroring Scheduler teardown order.
+    hybrid_.reset();
+
+    // The destructor detached the snapshot while its allocator was still alive;
+    // n256 (owned by kv_cache_) outlives hybrid_ and now carries no snapshot.
+    EXPECT_FALSE(n256->HasPagedCacheSnapshot());
+}
+
 }  // namespace tokenspeed::test


### PR DESCRIPTION

## Summary

- Fixes a heap-use-after-free at scheduler teardown: `PagedCacheSnapshot`s attached to `TreeNode`s in `KVPrefixCache` hold `OwnedPages` that borrow from `PagedCacheGroupAllocator`s owned by `HybridPrefixCache`, but `Scheduler` destroys `HybridPrefixCache` first, so `~KVPrefixCache` later deallocates page ids into a freed allocator.
- Adds a `~HybridPrefixCache` destructor that detaches every still-attached snapshot (via `paged_cache_snapshot_nodes_`) before its allocators are destroyed, returning the pages to still-live allocators.
- Adds a deterministic regression test.

## Root Cause

`Scheduler` declares `kv_prefix_cache_` before `hybrid_prefix_cache_`, so member destruction order tears down `HybridPrefixCache` (and its `paged_cache_allocators_`) first, then `KVPrefixCache`:

```
freed by  ~HybridPrefixCache -> ~map<string, unique_ptr<PagedCacheGroupAllocator>>
used  by  ~KVPrefixCache -> ~RadixTree -> ~TreeNode -> ~PagedCacheSnapshot
                         -> ~PagedCacheGroupSnapshot -> ~OwnedPages
                         -> PageAllocator::Deallocate()   // heap-use-after-free
```

Whenever a paged-cache deployment still has prefix snapshots attached to the radix tree at exit, the snapshot `OwnedPages` deallocate into an allocator that was already freed. `request_paged_cache_tables_` does not have this problem: it is declared after `paged_cache_allocators_` and so is destroyed first. The mamba slot path is also unaffected, since the mamba allocators are `Scheduler` members declared before `kv_prefix_cache_`.

#357 fixed the analogous dangling-pointer problem on the prune path (its destroy callback drops dying nodes from these adjunct sets, including `paged_cache_snapshot_nodes_`). The teardown path addressed here is a separate gap: at shutdown the snapshots are released by `~KVPrefixCache` rather than `PruneEmptyByNode`, after `HybridPrefixCache` and its allocators are already gone.

## Test Plan

Built and run on a single host under AddressSanitizer over the full scheduler C++ test suite (`tokenspeed_scheduler_tests`).

- Before (fix reverted): ASan reports `heap-use-after-free` in `PageAllocator::Deallocate` during `PagedCacheTestFixtureT` teardown.
- After: full suite is ASan-clean, 185 tests pass (184 existing + 1 new).

The new test `PagedCacheFamilySplitTest.DestructorReleasesAttachedSnapshots` attaches a snapshot, destroys the hybrid cache first, and asserts the node no longer carries a snapshot. With the fix reverted it reproduces the use-after-free under ASan and fails in a normal build; the scheduler CI runs Release without ASan, so this deterministic guard is needed.

<details>
<summary>ASan report (before fix)</summary>

```
==ERROR: AddressSanitizer: heap-use-after-free ... READ of size 8
  #2 PageAllocator::Deallocate(...) page_allocator.cpp:66
  #3 OwnedPages::~OwnedPages() owned_pages.cpp:32
  #4 PagedCacheGroupSnapshot::~PagedCacheGroupSnapshot() paged_cache_snapshot.h:30
  ...
  #14 PagedCacheSnapshot::~PagedCacheSnapshot()
  #17 TreeNode::~TreeNode()
  #31 RadixTree::~RadixTree()
  #32 KVPrefixCache::~KVPrefixCache()
freed by thread T0 here:
  #1 ~unique_ptr<PagedCacheGroupAllocator>()
  #12 HybridPrefixCache::~HybridPrefixCache() hybrid_prefix_cache.h:48
```
</details>
