### PR TITLE
perf(kernel): optimize Qwen vision QKV rotary layout

### DIFF
--- a/python/tokenspeed/_logging.py
+++ b/python/tokenspeed/_logging.py
@@ -74,7 +74,7 @@ def _suppress_flash_attn_jit_cache_debug_log():
     logging.disable(logging.INFO)
     try:
         import_module(logger_name)
-    except ImportError:
+    except Exception:
         return
     finally:
         logging.disable(previous_disable_level)

--- a/python/tokenspeed/runtime/layers/attention/mm_encoder_attention.py
+++ b/python/tokenspeed/runtime/layers/attention/mm_encoder_attention.py
@@ -64,7 +64,10 @@ if _is_nvidia:
     )
 
 from tokenspeed_kernel.ops.attention.triton.context import context_attention_fwd
-from tokenspeed_kernel.ops.attention.triton.qkv_rotary import packed_qkv_complex_rotary
+from tokenspeed_kernel.ops.attention.triton.qkv_rotary import (
+    packed_qkv_complex_rotary,
+    packed_qkv_neox_rotary,
+)
 
 # CUDA-graph bucketing for the cuDNN vision prefill backend: batch and max
 # seqlen are quantized so a small set of captured graphs covers the request
@@ -382,6 +385,11 @@ class VisionAttention(nn.Module):
             self._backend_fn is vision_attn_fa4
             and self.position_embedding_mode == "complex_rope"
         )
+        self._use_packed_qkv_rotary = (
+            self._backend_fn is vision_attn_fa4
+            and self.customized_position_embedding_applier is None
+        )
+        self._copy_v_after_packed_qkv_rotary = False
         self._workspace_buffer = workspace_buffer
 
         self.qkv_proj = QKVParallelLinear(
@@ -437,13 +445,34 @@ class VisionAttention(nn.Module):
         )
 
         qkv, _ = self.qkv_proj(x)
-        cos = None
-        sin = None
 
+        use_packed_qkv_rotary = (
+            self._use_packed_qkv_rotary
+            and position_embeddings is None
+            and rotary_pos_emb_cos is not None
+            and rotary_pos_emb_sin is not None
+        )
         use_packed_qkv_complex_rotary = (
             self._use_packed_qkv_complex_rotary and position_embeddings is not None
         )
-        if use_packed_qkv_complex_rotary:
+        cos = rotary_pos_emb_cos if use_packed_qkv_rotary else None
+        sin = rotary_pos_emb_sin if use_packed_qkv_rotary else None
+
+        if use_packed_qkv_rotary:
+            if cos.size(-1) * 2 == self.head_size:
+                cos = torch.cat([cos, cos], dim=-1)
+                sin = torch.cat([sin, sin], dim=-1)
+            q, k, v = packed_qkv_neox_rotary(
+                qkv,
+                self.q_size,
+                self.kv_size,
+                head,
+                self.head_size,
+                cos,
+                sin,
+                copy_v=self._copy_v_after_packed_qkv_rotary,
+            )
+        elif use_packed_qkv_complex_rotary:
             q, k, v = packed_qkv_complex_rotary(
                 qkv,
                 self.q_size,
@@ -451,26 +480,35 @@ class VisionAttention(nn.Module):
                 head,
                 self.head_size,
                 position_embeddings,
+                copy_v=self._copy_v_after_packed_qkv_rotary,
             )
         else:
             q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
-            q = q.reshape(bsz * s, head, -1).contiguous()
-            k = k.reshape(bsz * s, kv_head, -1).contiguous()
-            v = v.reshape(bsz * s, kv_head, -1).contiguous()
+            q = q.reshape(bsz * s, head, -1)
+            k = k.reshape(bsz * s, kv_head, -1)
+            v = v.reshape(bsz * s, kv_head, -1)
 
-        if not use_packed_qkv_complex_rotary and position_embeddings is not None:
-            if self.customized_position_embedding_applier is not None:
-                q, k = self.customized_position_embedding_applier(
-                    q, k, position_embeddings, x_shape
-                )
-            else:
-                cos, sin = position_embeddings
-        elif rotary_pos_emb_cos is not None and rotary_pos_emb_sin is not None:
-            cos = rotary_pos_emb_cos
-            sin = rotary_pos_emb_sin
+            cos = None
+            sin = None
 
-        if cos is not None and sin is not None:
+            if position_embeddings is not None:
+                if self.customized_position_embedding_applier is not None:
+                    q, k = self.customized_position_embedding_applier(
+                        q, k, position_embeddings, x_shape
+                    )
+                else:
+                    cos, sin = position_embeddings
+            elif rotary_pos_emb_cos is not None and rotary_pos_emb_sin is not None:
+                cos = rotary_pos_emb_cos
+                sin = rotary_pos_emb_sin
+
+        if (
+            not use_packed_qkv_rotary
+            and not use_packed_qkv_complex_rotary
+            and cos is not None
+            and sin is not None
+        ):
             original_shape = q.shape
 
             # [total_tokens, head, head_size]

--- a/python/tokenspeed/runtime/models/qwen3_5.py
+++ b/python/tokenspeed/runtime/models/qwen3_5.py
@@ -458,7 +458,7 @@ class Qwen3_5LinearDecoderLayer(nn.Module):
 
         linear_attn_quant_config = (
             None
-            if quant_config and quant_config.get_name() == "nvfp4"
+            if quant_config and quant_config.get_name() in ("fp8", "nvfp4")
             else quant_config
         )
         self.linear_attn = Qwen3_5GatedDeltaNet(

--- a/test/runtime/models/test_qwen35_vlm_e2e.py
+++ b/test/runtime/models/test_qwen35_vlm_e2e.py
@@ -1,0 +1,179 @@
+"""End-to-end tests for Qwen3.5 VLM image requests."""
+
+from __future__ import annotations
+
+import base64
+import io
+import os
+import subprocess
+import sys
+import time
+import unittest
+from pathlib import Path
+
+# /test on sys.path so "ci_system.ci_register" resolves from test/ci_system/.
+sys.path.insert(
+    0,
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+)
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(
+    est_time=1200,
+    suite="runtime-1gpu",
+    disabled_on_runners=["amd-*", "h100-*"],
+    disabled_on_runners_reason="Qwen3.5 FP8 VLM smoke requires NVIDIA Blackwell.",
+)
+
+MODEL = os.environ.get("QWEN35_VLM_E2E_MODEL", "Qwen/Qwen3.5-35B-A3B-FP8")
+PORT = int(os.environ.get("QWEN35_VLM_E2E_PORT", "23220"))
+LOG_DIR = Path(os.environ.get("QWEN35_VLM_E2E_LOG_DIR", ".ci-artifacts/qwen35-vlm-e2e"))
+SERVED_MODEL_NAME = "qwen35-vlm-e2e"
+SERVER_LAUNCH_TIMEOUT = 900
+REQUEST_TIMEOUT = 300
+
+
+def _image_data_url() -> str:
+    from PIL import Image
+
+    image = Image.new("RGB", (256, 256), color=(220, 20, 20))
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    encoded = base64.b64encode(buf.getvalue()).decode("ascii")
+    return f"data:image/png;base64,{encoded}"
+
+
+def _serve_server(log_path: Path) -> subprocess.Popen:
+    cmd = [
+        sys.executable,
+        "-m",
+        "tokenspeed.cli",
+        "serve",
+        "--model",
+        MODEL,
+        "--served-model-name",
+        SERVED_MODEL_NAME,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(PORT),
+        "--world-size",
+        "1",
+        "--max-model-len",
+        "8192",
+        "--max-num-seqs",
+        "1",
+        "--max-prefill-tokens",
+        "4096",
+        "--chunked-prefill-size",
+        "4096",
+        "--gpu-memory-utilization",
+        "0.85",
+        "--attention-backend",
+        "trtllm",
+        "--moe-backend",
+        "flashinfer_trtllm",
+        "--sampling-backend",
+        "flashinfer",
+        "--quantization",
+        "fp8",
+        "--mm-attention-backend",
+        "fa4",
+        "--disable-kvstore",
+        "--disable-prefill-graph",
+        "--trust-remote-code",
+    ]
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_f = log_path.open("w")
+    return subprocess.Popen(
+        cmd,
+        stdout=log_f,
+        stderr=subprocess.STDOUT,
+        env=os.environ.copy(),
+    )
+
+
+def _wait_for_server(timeout: int = SERVER_LAUNCH_TIMEOUT) -> bool:
+    import requests
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            if (
+                requests.get(
+                    f"http://127.0.0.1:{PORT}/readiness", timeout=5
+                ).status_code
+                == 200
+            ):
+                return True
+        except Exception:
+            pass
+        time.sleep(5)
+    return False
+
+
+class TestQwen35VlmE2E(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            from tokenspeed_kernel.platform import current_platform
+        except Exception as exc:  # noqa: BLE001
+            raise unittest.SkipTest(f"TokenSpeed kernel deps unavailable: {exc}")
+
+        if not current_platform().is_blackwell:
+            raise unittest.SkipTest("Qwen3.5 FP8 VLM smoke requires NVIDIA Blackwell")
+
+    def test_image_chat_completion(self):
+        import requests
+
+        log_path = LOG_DIR / "server.log"
+        proc = _serve_server(log_path)
+        try:
+            if not _wait_for_server():
+                tail = (
+                    log_path.read_text(errors="replace")[-4000:]
+                    if log_path.exists()
+                    else ""
+                )
+                self.fail(f"server did not become ready; log tail:\n{tail}")
+
+            payload = {
+                "model": SERVED_MODEL_NAME,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "Describe this image in one short sentence.",
+                            },
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": _image_data_url()},
+                            },
+                        ],
+                    }
+                ],
+                "max_tokens": 16,
+                "temperature": 0.0,
+                "stream": False,
+            }
+            resp = requests.post(
+                f"http://127.0.0.1:{PORT}/v1/chat/completions",
+                json=payload,
+                timeout=REQUEST_TIMEOUT,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            content = data["choices"][0]["message"].get("content") or ""
+            self.assertTrue(content.strip(), f"empty VLM response: {data}")
+            self.assertGreater(data.get("usage", {}).get("prompt_tokens", 0), 0)
+        finally:
+            from tokenspeed.runtime.utils.process import kill_process_tree
+
+            kill_process_tree(proc.pid)
+            time.sleep(5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/runtime/models/test_qwen35_vlm_e2e.py
+++ b/test/runtime/models/test_qwen35_vlm_e2e.py
@@ -22,7 +22,7 @@ register_cuda_ci(
     est_time=1200,
     suite="runtime-1gpu",
     disabled_on_runners=["amd-*", "h100-*"],
-    disabled_on_runners_reason="Qwen3.5 FP8 VLM smoke requires NVIDIA Blackwell.",
+    disabled_on_runners_reason="Qwen3.5 FP8 VLM requires NVIDIA Blackwell.",
 )
 
 MODEL = os.environ.get("QWEN35_VLM_E2E_MODEL", "Qwen/Qwen3.5-35B-A3B-FP8")
@@ -49,6 +49,8 @@ def _serve_server(log_path: Path) -> subprocess.Popen:
         "-m",
         "tokenspeed.cli",
         "serve",
+        "--gateway-startup-timeout",
+        "300",
         "--model",
         MODEL,
         "--served-model-name",
@@ -74,23 +76,27 @@ def _serve_server(log_path: Path) -> subprocess.Popen:
         "--moe-backend",
         "flashinfer_trtllm",
         "--sampling-backend",
-        "flashinfer",
+        "greedy",
         "--quantization",
         "fp8",
         "--mm-attention-backend",
         "fa4",
+        "--policy",
+        "random",
         "--disable-kvstore",
         "--disable-prefill-graph",
         "--trust-remote-code",
     ]
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_f = log_path.open("w")
-    return subprocess.Popen(
+    proc = subprocess.Popen(
         cmd,
         stdout=log_f,
         stderr=subprocess.STDOUT,
         env=os.environ.copy(),
     )
+    proc._log_file = log_f
+    return proc
 
 
 def _wait_for_server(timeout: int = SERVER_LAUNCH_TIMEOUT) -> bool:
@@ -121,7 +127,7 @@ class TestQwen35VlmE2E(unittest.TestCase):
             raise unittest.SkipTest(f"TokenSpeed kernel deps unavailable: {exc}")
 
         if not current_platform().is_blackwell:
-            raise unittest.SkipTest("Qwen3.5 FP8 VLM smoke requires NVIDIA Blackwell")
+            raise unittest.SkipTest("Qwen3.5 FP8 VLM requires NVIDIA Blackwell")
 
     def test_image_chat_completion(self):
         import requests
@@ -158,11 +164,18 @@ class TestQwen35VlmE2E(unittest.TestCase):
                 "temperature": 0.0,
                 "stream": False,
             }
-            resp = requests.post(
-                f"http://127.0.0.1:{PORT}/v1/chat/completions",
-                json=payload,
-                timeout=REQUEST_TIMEOUT,
-            )
+            deadline = time.time() + REQUEST_TIMEOUT
+            resp = None
+            while time.time() < deadline:
+                resp = requests.post(
+                    f"http://127.0.0.1:{PORT}/v1/chat/completions",
+                    json=payload,
+                    timeout=60,
+                )
+                if resp.status_code < 500:
+                    break
+                time.sleep(5)
+            assert resp is not None
             resp.raise_for_status()
             data = resp.json()
             content = data["choices"][0]["message"].get("content") or ""
@@ -172,6 +185,11 @@ class TestQwen35VlmE2E(unittest.TestCase):
             from tokenspeed.runtime.utils.process import kill_process_tree
 
             kill_process_tree(proc.pid)
+            try:
+                proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                pass
+            proc._log_file.close()
             time.sleep(5)
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/qkv_rotary.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/qkv_rotary.py
@@ -65,9 +65,7 @@ def _packed_qkv_complex_rotary_kernel(
     k_odd = tl.load(k_base + odd_d[None, :], mask=mask, other=0.0).to(tl.float32)
 
     freq_base = (
-        FREQS
-        + offs_t[:, None] * freqs_stride_t
-        + offs_p[None, :] * freqs_stride_pair
+        FREQS + offs_t[:, None] * freqs_stride_t + offs_p[None, :] * freqs_stride_pair
     )
     real = tl.load(freq_base, mask=mask, other=0.0).to(tl.float32)
     imag = tl.load(freq_base + freqs_stride_ri, mask=mask, other=0.0).to(tl.float32)
@@ -240,12 +238,10 @@ def _packed_qkv_neox_rotary_kernel(
     q = tl.load(q_ptr, mask=mask, other=0.0).to(tl.float32)
     k = tl.load(k_ptr, mask=mask, other=0.0).to(tl.float32)
     q_rot = (
-        tl.load(q_rot_ptr, mask=rot_mask, other=0.0).to(tl.float32)
-        * rot_sign[None, :]
+        tl.load(q_rot_ptr, mask=rot_mask, other=0.0).to(tl.float32) * rot_sign[None, :]
     )
     k_rot = (
-        tl.load(k_rot_ptr, mask=rot_mask, other=0.0).to(tl.float32)
-        * rot_sign[None, :]
+        tl.load(k_rot_ptr, mask=rot_mask, other=0.0).to(tl.float32) * rot_sign[None, :]
     )
     cos = tl.load(cos_ptr, mask=mask, other=0.0).to(tl.float32)
     sin = tl.load(sin_ptr, mask=mask, other=0.0).to(tl.float32)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/qkv_rotary.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/qkv_rotary.py
@@ -21,7 +21,6 @@
 from __future__ import annotations
 
 import torch
-
 from tokenspeed_kernel._triton import tl, triton
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/qkv_rotary.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/qkv_rotary.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 import torch
+
 from tokenspeed_kernel._triton import tl, triton
 
 
@@ -65,7 +66,9 @@ def _packed_qkv_complex_rotary_kernel(
     k_odd = tl.load(k_base + odd_d[None, :], mask=mask, other=0.0).to(tl.float32)
 
     freq_base = (
-        FREQS + offs_t[:, None] * freqs_stride_t + offs_p[None, :] * freqs_stride_pair
+        FREQS
+        + offs_t[:, None] * freqs_stride_t
+        + offs_p[None, :] * freqs_stride_pair
     )
     real = tl.load(freq_base, mask=mask, other=0.0).to(tl.float32)
     imag = tl.load(freq_base + freqs_stride_ri, mask=mask, other=0.0).to(tl.float32)
@@ -99,19 +102,28 @@ def packed_qkv_complex_rotary(
     *,
     copy_v: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Apply Kimi complex RoPE while splitting packed QKV.
+    """Apply Kimi-style complex RoPE while splitting packed QKV.
+
+    Kimi's reference path views adjacent head-dimension pairs as complex
+    numbers and multiplies them by ``freqs_cis``. This helper performs the same
+    pairwise rotation from packed QKV, materializing contiguous Q/K outputs for
+    FA4 while leaving V as a packed-QKV view by default.
 
     Args:
-        qkv: Packed QKV tensor with contiguous last dimension.
-        q_size: Packed Q width for this rank.
-        kv_size: Packed K/V width for this rank.
-        num_heads: Number of heads on this rank.
+        qkv: Packed QKV tensor shaped ``[batch, seq, q + k + v]`` or
+            ``[tokens, q + k + v]`` with contiguous last dimension.
+        q_size: Packed Q width in elements for this rank.
+        kv_size: Packed K/V width in elements for this rank.
+        num_heads: Number of Q/K/V heads on this rank.
         head_dim: Per-head dimension. Must be even.
-        freqs_cis: Complex RoPE tensor shaped ``[tokens, head_dim / 2]``.
-        copy_v: If true, materialize V; otherwise return a packed-QKV view.
+        freqs_cis: Complex tensor shaped ``[tokens, head_dim / 2]``.
+        copy_v: If true, materialize contiguous V. Otherwise return a strided
+            view into the packed input.
 
     Returns:
-        ``(q, k, v)`` shaped ``[tokens, heads, head_dim]``.
+        ``(q, k, v)`` tensors shaped ``[tokens, heads, head_dim]``. Q and K are
+        contiguous complex-RoPE outputs. V is contiguous only when
+        ``copy_v=True``.
     """
     qkv_flat = qkv.reshape(-1, qkv.shape[-1])
     total_tokens = qkv_flat.shape[0]
@@ -160,4 +172,179 @@ def packed_qkv_complex_rotary(
     return q_out, k_out, v_out
 
 
-__all__ = ["packed_qkv_complex_rotary"]
+@triton.jit
+def _packed_qkv_neox_rotary_kernel(
+    QKV,
+    COS,
+    SIN,
+    Q_OUT,
+    K_OUT,
+    V_OUT,
+    total_tokens: tl.constexpr,
+    packed_stride: tl.constexpr,
+    q_offset: tl.constexpr,
+    k_offset: tl.constexpr,
+    v_offset: tl.constexpr,
+    out_stride_t: tl.constexpr,
+    out_stride_h: tl.constexpr,
+    cos_stride_t: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    copy_v: tl.constexpr,
+    BLOCK_T: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    block_t = tl.program_id(0)
+    head = tl.program_id(1)
+
+    offs_t = block_t * BLOCK_T + tl.arange(0, BLOCK_T)
+    offs_d = tl.arange(0, BLOCK_D)
+    mask = (offs_t[:, None] < total_tokens) & (offs_d[None, :] < head_dim)
+
+    half = head_dim // 2
+    rot_d = tl.where(offs_d < half, offs_d + half, offs_d - half)
+    rot_sign = tl.where(offs_d < half, -1.0, 1.0)
+    rot_mask = (offs_t[:, None] < total_tokens) & (rot_d[None, :] < head_dim)
+
+    q_ptr = (
+        QKV
+        + offs_t[:, None] * packed_stride
+        + q_offset
+        + head * head_dim
+        + offs_d[None, :]
+    )
+    k_ptr = (
+        QKV
+        + offs_t[:, None] * packed_stride
+        + k_offset
+        + head * head_dim
+        + offs_d[None, :]
+    )
+    q_rot_ptr = (
+        QKV
+        + offs_t[:, None] * packed_stride
+        + q_offset
+        + head * head_dim
+        + rot_d[None, :]
+    )
+    k_rot_ptr = (
+        QKV
+        + offs_t[:, None] * packed_stride
+        + k_offset
+        + head * head_dim
+        + rot_d[None, :]
+    )
+
+    cos_ptr = COS + offs_t[:, None] * cos_stride_t + offs_d[None, :]
+    sin_ptr = SIN + offs_t[:, None] * cos_stride_t + offs_d[None, :]
+
+    q = tl.load(q_ptr, mask=mask, other=0.0).to(tl.float32)
+    k = tl.load(k_ptr, mask=mask, other=0.0).to(tl.float32)
+    q_rot = (
+        tl.load(q_rot_ptr, mask=rot_mask, other=0.0).to(tl.float32)
+        * rot_sign[None, :]
+    )
+    k_rot = (
+        tl.load(k_rot_ptr, mask=rot_mask, other=0.0).to(tl.float32)
+        * rot_sign[None, :]
+    )
+    cos = tl.load(cos_ptr, mask=mask, other=0.0).to(tl.float32)
+    sin = tl.load(sin_ptr, mask=mask, other=0.0).to(tl.float32)
+
+    q_out = q * cos + q_rot * sin
+    k_out = k * cos + k_rot * sin
+
+    out_ptr = offs_t[:, None] * out_stride_t + head * out_stride_h + offs_d[None, :]
+    tl.store(Q_OUT + out_ptr, q_out, mask=mask)
+    tl.store(K_OUT + out_ptr, k_out, mask=mask)
+
+    if copy_v:
+        v_ptr = (
+            QKV
+            + offs_t[:, None] * packed_stride
+            + v_offset
+            + head * head_dim
+            + offs_d[None, :]
+        )
+        v = tl.load(v_ptr, mask=mask, other=0.0)
+        tl.store(V_OUT + out_ptr, v, mask=mask)
+
+
+def packed_qkv_neox_rotary(
+    qkv: torch.Tensor,
+    q_size: int,
+    kv_size: int,
+    num_heads: int,
+    head_dim: int,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    *,
+    copy_v: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Apply NeoX rotary while splitting packed QKV for vision attention.
+
+    The helper is backend-agnostic: it prepares Q/K/V tensors from a packed QKV
+    projection. The current runtime caller uses it for the Qwen vision FA4 path.
+
+    Args:
+        qkv: Packed QKV tensor shaped ``[batch, seq, q + k + v]`` or
+            ``[tokens, q + k + v]`` with contiguous last dimension.
+        q_size: Packed Q width in elements for this rank.
+        kv_size: Packed K/V width in elements for this rank.
+        num_heads: Number of Q/K/V heads on this rank.
+        head_dim: Per-head dimension.
+        cos: Full-width rotary cos tensor shaped ``[tokens, head_dim]``.
+        sin: Full-width rotary sin tensor shaped ``[tokens, head_dim]``.
+        copy_v: If true, materialize contiguous V. Otherwise return a strided
+            view into the packed input.
+
+    Returns:
+        ``(q, k, v)`` tensors shaped ``[tokens, heads, head_dim]``. Q and K are
+        contiguous rotary outputs. V is contiguous only when ``copy_v=True``.
+    """
+    qkv_flat = qkv.reshape(-1, qkv.shape[-1])
+    total_tokens = qkv_flat.shape[0]
+    packed_stride = qkv_flat.stride(0)
+    assert q_size == num_heads * head_dim
+    assert kv_size == num_heads * head_dim
+    assert cos.shape == (total_tokens, head_dim)
+    assert sin.shape == (total_tokens, head_dim)
+
+    q_out = torch.empty(
+        (total_tokens, num_heads, head_dim), device=qkv.device, dtype=qkv.dtype
+    )
+    k_out = torch.empty_like(q_out)
+    if copy_v:
+        v_out = torch.empty_like(q_out)
+    else:
+        v_view = qkv_flat[:, q_size + kv_size : q_size + kv_size + kv_size]
+        v_out = v_view.reshape(total_tokens, num_heads, head_dim)
+
+    block_t = 16
+    block_d = triton.next_power_of_2(head_dim)
+    grid = (triton.cdiv(total_tokens, block_t), num_heads)
+    _packed_qkv_neox_rotary_kernel[grid](
+        qkv_flat,
+        cos,
+        sin,
+        q_out,
+        k_out,
+        v_out,
+        total_tokens=total_tokens,
+        packed_stride=packed_stride,
+        q_offset=0,
+        k_offset=q_size,
+        v_offset=q_size + kv_size,
+        out_stride_t=q_out.stride(0),
+        out_stride_h=q_out.stride(1),
+        cos_stride_t=cos.stride(0),
+        num_heads=num_heads,
+        head_dim=head_dim,
+        copy_v=copy_v,
+        BLOCK_T=block_t,
+        BLOCK_D=block_d,
+    )
+    return q_out, k_out, v_out
+
+
+__all__ = ["packed_qkv_complex_rotary", "packed_qkv_neox_rotary"]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_fp8.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_fp8.py
@@ -40,6 +40,7 @@ if platform.is_nvidia:
     from tokenspeed_kernel.ops.gemm.fp8_utils import per_token_group_quant_fp8
 
     _FP8_BLOCK = 128
+
     def _routing_value(w: torch.nn.Module, name: str, default):
         routing_config = getattr(w, "routing_config", {})
         if not isinstance(routing_config, dict):

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_fp8.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_fp8.py
@@ -40,8 +40,6 @@ if platform.is_nvidia:
     from tokenspeed_kernel.ops.gemm.fp8_utils import per_token_group_quant_fp8
 
     _FP8_BLOCK = 128
-    _DEEPSEEK_V3_ROUTING = int(RoutingMethodType.DeepSeekV3)
-
     def _routing_value(w: torch.nn.Module, name: str, default):
         routing_config = getattr(w, "routing_config", {})
         if not isinstance(routing_config, dict):
@@ -156,9 +154,10 @@ if platform.is_nvidia:
             if isinstance(correction_bias, torch.Tensor)
             else None
         )
-        n_group = _routing_value(w, "n_group", 0) or None
-        topk_group = _routing_value(w, "topk_group", 0) or None
+        n_group = _routing_value(w, "n_group", 0) or 1
+        topk_group = _routing_value(w, "topk_group", 0) or 1
         routed_scaling_factor = _routing_value(w, "routed_scaling_factor", None)
+        routing_method_type = _routing_value(w, "routing_method_type", 1)
 
         result = trtllm_fp8_block_scale_moe(
             routing_logits=router_logits.to(torch.float32),
@@ -177,7 +176,7 @@ if platform.is_nvidia:
             local_expert_offset=getattr(w, "ep_rank", 0) * local_experts,
             local_num_experts=local_experts,
             routed_scaling_factor=routed_scaling_factor,
-            routing_method_type=_DEEPSEEK_V3_ROUTING,
+            routing_method_type=int(routing_method_type),
             do_finalize=True,
             tune_max_num_tokens=next_power_of_2(x_fp8.shape[0]),
         )


### PR DESCRIPTION
## Summary

+7.38% average speedup for encoder

Previously, `VisionAttention.forward()` split packed QKV and forced Q, K, and V to become contiguous tensors:

```python
q = q.reshape(bsz * s, head, -1).contiguous()
k = k.reshape(bsz * s, kv_head, -1).contiguous()
v = v.reshape(bsz * s, kv_head, -1).contiguous()
```

That made three device copies per vision attention layer, qwen vision has 27 layers, so this was 81 Q/K/V layout copies per encoder forward

This pr makes two optimizations for this, first by removing the explicit Q/K/V .contiguous() copies by keeping Q/K/V as views after the packed-QKV split then adding a packed-QKV rotary triton kernel for Qwen RoPE

## Test Plan

accuracy was validated across backends;

Encoder only results:
Qwen3.5-397B-A17B-NVFP4
backend: FA4

Item 1: Remove Q/K/V `.contiguous()` materialization after packed QKV split

| | Before Avg ms | After Avg ms | Speedup |
|---|---:|---:|---:|
| grid=96,batch=32 | 760.27 | 725.83 | +4.75% |
| grid=128,batch=32 | 1709.16 | 1693.18 | +0.94% |

Item 2: Add packed-QKV + rotary Triton kernel on top of item 1

| | Before Avg ms | After Avg ms | Speedup |
|---|---:|---:|---:|
| grid=96,batch=8 | 191.99 | 177.01 | +8.46% |
| grid=96,batch=32 | 750.61 | 690.60 | +8.69% |
| grid=128,batch=8 | 438.65 | 412.62 | +6.31% |
| grid=128,batch=32 | 1769.53 | 1667.77 | +6.10% |

E2E results:
Qwen3.5-397B-A17B-NVFP4
backend: FA4
TP8
8xb300

4 images x 1024, concurrency 8

| | Before Avg | After Avg | Delta |
|---|---:|---:|---:|
| Requests/sec | 1.269 | 1.270 | +0.10% |
| Tokens/sec | 324.917 | 325.230 | +0.10% |
| p50 TTFT | 4094.646 ms | 3795.509 ms | +7.88% faster |
| p50 total latency | 6046.911 ms | 6007.632 ms | +0.65% faster |

1 image x 2048, concurrency 8

| | Before Avg | After Avg | Delta |
|---|---:|---:|---:|
| Requests/sec | 1.236 | 1.225 | -0.90% |
| Tokens/sec | 316.089 | 313.215 | -0.91% |
| p50 TTFT | 4375.853 ms | 4696.134 ms | -6.82% slower |
| p50 total latency | 6288.336 ms | 6361.221 ms | -1.15% slower |

slight regression for higher resolution image on average
