### PR TITLE
test(agentic): add EvalScope trie benchmark protocol

### DIFF
--- a/test/agentic_benchmark/evalscope_trie/README.md
+++ b/test/agentic_benchmark/evalscope_trie/README.md
@@ -1,0 +1,117 @@
+# EvalScope Trie Agentic Benchmark Protocol
+
+This directory contains backend-neutral tooling for running EvalScope trie
+agentic workloads against an already-running OpenAI-compatible serving endpoint.
+It is intended for TokenSpeed/TRT-LLM/VLLM cross-stack comparisons where server
+launch, model placement, and backend-specific flags are controlled separately.
+
+## Scope
+
+The protocol fixes the client-side benchmark shape and metric definitions:
+
+- workload: EvalScope `trie_agentic_coding`, `trie_code_qa`, or
+  `trie_office_work`
+- endpoint: OpenAI-compatible `/v1/chat/completions` or `/v1/completions`
+- generation: streaming, multi-turn, `max_tokens=500`, greedy temperature
+- warmup: one small sanity warmup and one high-concurrency warmup
+- formal sweep: fixed request counts per concurrency
+- output: CSV rows plus a throughput-vs-per-user-speed SVG
+
+The server process is not launched by this protocol. Start TokenSpeed, TRT-LLM,
+or another backend first, wait until it is healthy, then run the protocol against
+that endpoint.
+
+Backend-specific launch flags, model sharding, KV cache sizing, and profiler
+wrapping remain outside this directory. Record those settings next to each run so
+TokenSpeed and reference-backend results can be compared with the same client
+workload but their own serving commands.
+
+## Why This Exists
+
+Earlier agentic scripts in this repository were tied to a specific backend and
+the SWE-Smith dataset. For V4-Pro work, this protocol makes the client side
+identical when comparing TokenSpeed and a reference backend:
+
+- same trie workload file
+- same request parameters and request count per concurrency
+- same prompt serialization
+- same warmup sequence
+- same temperature, streaming, and `ignore_eos` settings
+- same metric formulas
+
+This keeps perf discussions focused on serving/runtime behavior instead of
+benchmark harness drift.
+
+## Run
+
+Start a server separately, then run:
+
+```bash
+cd test/agentic_benchmark/evalscope_trie
+
+MODEL=DeepSeek-V4-Pro \
+API_URL=http://127.0.0.1:8000/v1/chat/completions \
+TOKENIZER_PATH=/path/to/tokenizer \
+DATASET=trie_agentic_coding \
+DATASET_PATH=/path/to/agentic_coding_8k.jsonl \
+NUM_GPUS=8 \
+./run_evalscope_trie_sweep.sh
+```
+
+The default sweep is:
+
+```text
+warmup 1: parallel=2, number=2
+warmup 2: parallel=8, number=16
+formal:  parallel=1/2/4/8, number=8/16/32/64
+```
+
+Override with environment variables:
+
+```bash
+FORMAL_PARALLELS="1 2 4 8 16" \
+FORMAL_NUMBERS="8 16 32 64 128" \
+./run_evalscope_trie_sweep.sh
+```
+
+## Prompt Serialization
+
+DeepSeek-V4-Pro model snapshots may not include a usable chat template. When a
+backend cannot accept `/v1/chat/completions` with templated messages, use a plain
+prompt path consistently across all compared stacks:
+
+```bash
+API_URL=http://127.0.0.1:8001/v1/completions \
+TOKENIZE_PROMPT=1 \
+./run_evalscope_trie_sweep.sh
+```
+
+Only compare TokenSpeed and reference results if both sides use the same prompt
+serialization, tokenizer path, and temperature/sampling settings.
+
+## Collect Existing Results
+
+```bash
+python3 collect_outputs.py outputs/<timestamp> \
+  --num-gpus 8 \
+  --csv sweep.csv \
+  --svg sweep.svg
+```
+
+The collector reads each `parallel_<P>_number_<N>` directory emitted by
+EvalScope and computes:
+
+- `steady_completion_tok_s`: `workload_throughput.json`, row
+  `Completion tok/s`, field `steady_state`
+- `completion_tps_per_user`: `steady_completion_tok_s / parallel`
+- `output_token_min_per_gpu`: `steady_completion_tok_s * 60 / num_gpus`
+- `decoded_tok_iter` and `spec_accept_rate`: `benchmark_summary.json`
+- `success`: `Success Requests / Total Requests`
+
+The SVG uses the same axes used in the V4-Pro comparison discussions:
+
+- X axis: `completion_tps_per_user`
+- Y axis: `output_token_min_per_gpu`
+
+Treat the CSV as the source of truth. The SVG is a convenience view for quickly
+checking the throughput/per-user-speed tradeoff.

--- a/test/agentic_benchmark/evalscope_trie/collect_outputs.py
+++ b/test/agentic_benchmark/evalscope_trie/collect_outputs.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Collect EvalScope trie perf outputs into CSV and a simple Pareto SVG."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import re
+import sqlite3
+import xml.sax.saxutils as sx
+from pathlib import Path
+from typing import Any
+
+CSV_COLUMNS = [
+    "phase",
+    "model",
+    "parallel",
+    "number",
+    "success",
+    "total_requests",
+    "success_requests",
+    "failed_requests",
+    "steady_completion_tok_s",
+    "completion_tps_per_user",
+    "output_token_min_per_gpu",
+    "avg_latency_s",
+    "avg_ttft_s",
+    "avg_tpot_s",
+    "avg_input_tokens",
+    "avg_output_tokens",
+    "avg_turns",
+    "cache_hit_pct",
+    "first_turn_ttft_s",
+    "subsequent_turn_ttft_s",
+    "decoded_tok_iter",
+    "spec_accept_rate",
+    "trace_count",
+    "run_dir",
+]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    with path.open() as f:
+        return json.load(f)
+
+
+def safe_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def ms_to_s(value: Any) -> float | None:
+    value = safe_float(value)
+    return value / 1000.0 if value is not None else None
+
+
+def workload_rows(path: Path) -> dict[str, dict[str, Any]]:
+    data = load_json(path)
+    return {row.get("metric", ""): row for row in data.get("rows", [])}
+
+
+def db_counts(db_path: Path) -> tuple[int | None, int | None]:
+    if not db_path.exists():
+        return None, None
+    with sqlite3.connect(db_path) as con:
+        total = con.execute("select count(*) from result").fetchone()[0]
+        success = con.execute("select count(*) from result where success=1").fetchone()[
+            0
+        ]
+    return total, success
+
+
+def parse_parallel_number(run_dir: Path) -> tuple[int, int]:
+    match = re.match(r"parallel_(\d+)_number_(\d+)$", run_dir.name)
+    if not match:
+        raise ValueError(f"Cannot parse parallel/number from {run_dir}")
+    return int(match.group(1)), int(match.group(2))
+
+
+def infer_phase_and_model(root: Path, run_dir: Path) -> tuple[str, str]:
+    rel = run_dir.relative_to(root)
+    parts = rel.parts
+    phase = parts[0] if len(parts) >= 3 else "unknown"
+    model = parts[-2] if len(parts) >= 2 else "unknown"
+    return phase, model
+
+
+def parse_run(root: Path, run_dir: Path, num_gpus: int) -> dict[str, Any]:
+    summary = load_json(run_dir / "benchmark_summary.json")
+    trace_summary = load_json(run_dir / "trace_summary.json")
+    rows = workload_rows(run_dir / "workload_throughput.json")
+    parallel, number = parse_parallel_number(run_dir)
+    phase, model = infer_phase_and_model(root, run_dir)
+    db_total, db_success = db_counts(run_dir / "benchmark_data.db")
+
+    def wl(metric: str, field: str) -> float | None:
+        return safe_float(rows.get(metric, {}).get(field))
+
+    total = int(summary.get("Total Requests") or db_total or 0)
+    success = int(summary.get("Success Requests") or db_success or 0)
+    failed = int(summary.get("Failed Requests") or max(total - success, 0))
+    steady_completion = wl("Completion tok/s", "steady_state")
+    completion_tps_user = (
+        steady_completion / parallel
+        if steady_completion is not None and parallel
+        else None
+    )
+    output_token_min_gpu = (
+        steady_completion * 60.0 / num_gpus
+        if steady_completion is not None and num_gpus
+        else None
+    )
+
+    return {
+        "phase": phase,
+        "model": model,
+        "parallel": parallel,
+        "number": number,
+        "success": f"{success}/{total}" if total else "",
+        "total_requests": total,
+        "success_requests": success,
+        "failed_requests": failed,
+        "steady_completion_tok_s": steady_completion,
+        "completion_tps_per_user": completion_tps_user,
+        "output_token_min_per_gpu": output_token_min_gpu,
+        "avg_latency_s": safe_float(summary.get("Avg Latency (s)")),
+        "avg_ttft_s": ms_to_s(summary.get("TTFT (ms)")),
+        "avg_tpot_s": ms_to_s(summary.get("TPOT (ms)")),
+        "avg_input_tokens": safe_float(summary.get("Avg Input Tokens")),
+        "avg_output_tokens": safe_float(summary.get("Avg Output Tokens")),
+        "avg_turns": safe_float(summary.get("Avg Turns/Request")),
+        "cache_hit_pct": safe_float(summary.get("KV Cache Hit Rate (%)")),
+        "first_turn_ttft_s": ms_to_s(summary.get("First-Turn TTFT (ms)")),
+        "subsequent_turn_ttft_s": ms_to_s(summary.get("Subsequent-Turn TTFT (ms)")),
+        "decoded_tok_iter": safe_float(summary.get("Decoded Tok/Iter")),
+        "spec_accept_rate": safe_float(summary.get("Spec. Accept Rate")),
+        "trace_count": trace_summary.get("n_traces"),
+        "run_dir": str(run_dir),
+    }
+
+
+def collect(root: Path, num_gpus: int) -> list[dict[str, Any]]:
+    rows = []
+    for run_dir in sorted(root.glob("**/parallel_*_number_*")):
+        if (run_dir / "benchmark_summary.json").exists():
+            rows.append(parse_run(root, run_dir, num_gpus))
+    rows.sort(key=lambda r: (r["phase"] != "sweep", r["parallel"], r["number"]))
+    return rows
+
+
+def write_csv(rows: list[dict[str, Any]], path: Path) -> None:
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def finite(values: list[float | None]) -> list[float]:
+    return [
+        value
+        for value in values
+        if value is not None and not math.isnan(value) and not math.isinf(value)
+    ]
+
+
+def scale(value: float, lo: float, hi: float, out_lo: float, out_hi: float) -> float:
+    if hi <= lo:
+        return (out_lo + out_hi) / 2
+    return out_lo + (value - lo) * (out_hi - out_lo) / (hi - lo)
+
+
+def write_svg(rows: list[dict[str, Any]], path: Path, title: str) -> None:
+    points = [
+        row
+        for row in rows
+        if row["phase"] == "sweep"
+        and row["completion_tps_per_user"] is not None
+        and row["output_token_min_per_gpu"] is not None
+    ]
+    if not points:
+        return
+
+    width, height = 1120, 720
+    left, right, top, bottom = 95, 55, 86, 96
+    xs = finite([row["completion_tps_per_user"] for row in points])
+    ys = finite([row["output_token_min_per_gpu"] for row in points])
+    x_min, x_max = min(xs) * 0.88, max(xs) * 1.08
+    y_min, y_max = 0.0, max(ys) * 1.15
+
+    def x_px(v: float) -> float:
+        return scale(v, x_min, x_max, left, width - right)
+
+    def y_px(v: float) -> float:
+        return scale(v, y_min, y_max, height - bottom, top)
+
+    ordered = sorted(points, key=lambda row: row["parallel"])
+    line_path = " ".join(
+        ("M" if idx == 0 else "L")
+        + f"{x_px(row['completion_tps_per_user']):.1f},"
+        + f"{y_px(row['output_token_min_per_gpu']):.1f}"
+        for idx, row in enumerate(ordered)
+    )
+
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
+        "<style>",
+        "text{font-family:Arial,Helvetica,sans-serif;fill:#333}",
+        ".grid{stroke:#ddd;stroke-width:1}",
+        ".axis{stroke:#555;stroke-width:1.5}",
+        ".line{fill:none;stroke:#8e24aa;stroke-width:3}",
+        ".pt{fill:#8e24aa;stroke:white;stroke-width:2}",
+        "</style>",
+        '<rect width="100%" height="100%" fill="white"/>',
+        f'<text x="560" y="36" text-anchor="middle" font-size="24" font-weight="700">{sx.escape(title)}</text>',
+        '<text x="560" y="64" text-anchor="middle" font-size="14">EvalScope trie workload, formal sweep only</text>',
+    ]
+    for idx in range(7):
+        x = left + (width - left - right) * idx / 6
+        value = x_min + (x_max - x_min) * idx / 6
+        svg.append(
+            f'<line class="grid" x1="{x:.1f}" y1="{top}" x2="{x:.1f}" y2="{height-bottom}"/>'
+        )
+        svg.append(
+            f'<text x="{x:.1f}" y="{height-bottom+28}" text-anchor="middle" font-size="12">{value:.0f}</text>'
+        )
+    for idx in range(7):
+        y = height - bottom - (height - top - bottom) * idx / 6
+        value = y_min + (y_max - y_min) * idx / 6
+        svg.append(
+            f'<line class="grid" x1="{left}" y1="{y:.1f}" x2="{width-right}" y2="{y:.1f}"/>'
+        )
+        svg.append(
+            f'<text x="{left-12}" y="{y+4:.1f}" text-anchor="end" font-size="12">{value:.0f}</text>'
+        )
+    svg.append(
+        f'<line class="axis" x1="{left}" y1="{height-bottom}" x2="{width-right}" y2="{height-bottom}"/>'
+    )
+    svg.append(
+        f'<line class="axis" x1="{left}" y1="{top}" x2="{left}" y2="{height-bottom}"/>'
+    )
+    svg.append(f'<path class="line" d="{line_path}"/>')
+    for row in ordered:
+        x = x_px(row["completion_tps_per_user"])
+        y = y_px(row["output_token_min_per_gpu"])
+        failed = int(row.get("failed_requests") or 0)
+        label = f"p={row['parallel']} n={row['number']}"
+        if failed:
+            label += f" ({failed} failed)"
+        svg.append(f'<circle class="pt" cx="{x:.1f}" cy="{y:.1f}" r="6"/>')
+        svg.append(
+            f'<text x="{x+8:.1f}" y="{y-8:.1f}" font-size="12">{sx.escape(label)}</text>'
+        )
+    svg.append(
+        f'<text x="{(left + width - right) / 2:.1f}" y="{height-34}" text-anchor="middle" font-size="15">Completion TPS/user = steady completion tok/s / parallel</text>'
+    )
+    svg.append(
+        f'<text transform="translate(28,{(top + height - bottom) / 2:.1f}) rotate(-90)" text-anchor="middle" font-size="15">Output Token/Min/GPU = steady completion tok/s * 60 / num_gpus</text>'
+    )
+    svg.append("</svg>")
+    path.write_text("\n".join(svg))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output_dir", type=Path, help="EvalScope sweep output root")
+    parser.add_argument("--num-gpus", type=int, default=8)
+    parser.add_argument("--csv", type=Path, default=None)
+    parser.add_argument("--svg", type=Path, default=None)
+    parser.add_argument(
+        "--title",
+        default="Agentic Trie Performance",
+        help="SVG chart title",
+    )
+    args = parser.parse_args()
+
+    rows = collect(args.output_dir, args.num_gpus)
+    csv_path = args.csv or args.output_dir / "sweep.csv"
+    svg_path = args.svg or args.output_dir / "sweep.svg"
+    write_csv(rows, csv_path)
+    write_svg(rows, svg_path, args.title)
+    print(f"rows={len(rows)}")
+    print(f"csv={csv_path}")
+    print(f"svg={svg_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/agentic_benchmark/evalscope_trie/run_evalscope_trie_sweep.sh
+++ b/test/agentic_benchmark/evalscope_trie/run_evalscope_trie_sweep.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+MODEL=${MODEL:-DeepSeek-V4-Pro}
+API_URL=${API_URL:-http://127.0.0.1:8000/v1/chat/completions}
+API=${API:-openai}
+API_KEY=${API_KEY:-EMPTY}
+TOKENIZER_PATH=${TOKENIZER_PATH:-}
+
+DATASET=${DATASET:-trie_agentic_coding}
+DATASET_PATH=${DATASET_PATH:-}
+MAX_TOKENS=${MAX_TOKENS:-500}
+EXTRA_ARGS=${EXTRA_ARGS:-'{"ignore_eos": true, "temperature": 0.0}'}
+
+NUM_GPUS=${NUM_GPUS:-8}
+OUTPUT_DIR=${OUTPUT_DIR:-"$SCRIPT_DIR/outputs/$(date +%Y%m%d_%H%M%S)"}
+EVALSCOPE_VENV=${EVALSCOPE_VENV:-"$OUTPUT_DIR/.evalscope-venv"}
+EVALSCOPE_BIN=${EVALSCOPE_BIN:-"$EVALSCOPE_VENV/bin/evalscope"}
+
+WARMUP1_PARALLEL=${WARMUP1_PARALLEL:-2}
+WARMUP1_NUMBER=${WARMUP1_NUMBER:-2}
+WARMUP2_PARALLEL=${WARMUP2_PARALLEL:-8}
+WARMUP2_NUMBER=${WARMUP2_NUMBER:-16}
+FORMAL_PARALLELS=${FORMAL_PARALLELS:-"1 2 4 8"}
+FORMAL_NUMBERS=${FORMAL_NUMBERS:-"8 16 32 64"}
+
+STREAM=${STREAM:-1}
+TOKENIZE_PROMPT=${TOKENIZE_PROMPT:-0}
+NO_TEST_CONNECTION=${NO_TEST_CONNECTION:-1}
+HEALTH_URL=${HEALTH_URL:-}
+
+log() {
+  printf '[%s] %s\n' "$(date '+%F %T %Z')" "$*" >&2
+}
+
+usage() {
+  cat <<'EOF'
+Run EvalScope trie agentic perf against an already-running server.
+
+Required:
+  DATASET_PATH=/path/to/trie/workloads/agentic_coding_8k.jsonl
+
+Common overrides:
+  MODEL=DeepSeek-V4-Pro
+  API_URL=http://127.0.0.1:8000/v1/chat/completions
+  TOKENIZER_PATH=/path/to/tokenizer
+  OUTPUT_DIR=/path/to/output
+  FORMAL_PARALLELS="1 2 4 8"
+  FORMAL_NUMBERS="8 16 32 64"
+  TOKENIZE_PROMPT=1  # useful with /v1/completions plain-prompt replay
+EOF
+}
+
+require_dataset() {
+  if [[ -z "$DATASET_PATH" ]]; then
+    usage >&2
+    exit 2
+  fi
+  if [[ ! -f "$DATASET_PATH" ]]; then
+    echo "DATASET_PATH does not exist: $DATASET_PATH" >&2
+    exit 2
+  fi
+}
+
+ensure_evalscope() {
+  if [[ -x "$EVALSCOPE_BIN" ]]; then
+    return
+  fi
+  log "installing evalscope[perf] into $EVALSCOPE_VENV"
+  if command -v uv >/dev/null 2>&1; then
+    uv venv --seed --clear "$EVALSCOPE_VENV"
+    uv pip install --python "$EVALSCOPE_VENV/bin/python" "evalscope[perf]"
+  elif python3 -m uv --version >/dev/null 2>&1; then
+    python3 -m uv venv --seed --clear "$EVALSCOPE_VENV"
+    python3 -m uv pip install --python "$EVALSCOPE_VENV/bin/python" "evalscope[perf]"
+  else
+    python3 -m venv --clear "$EVALSCOPE_VENV"
+    "$EVALSCOPE_VENV/bin/python" -m pip install --upgrade pip
+    "$EVALSCOPE_VENV/bin/python" -m pip install "evalscope[perf]"
+  fi
+}
+
+wait_for_health() {
+  if [[ -z "$HEALTH_URL" ]]; then
+    return
+  fi
+  log "waiting for health endpoint: $HEALTH_URL"
+  for _ in {1..120}; do
+    if curl --max-time 10 -fsS "$HEALTH_URL" >/dev/null; then
+      log "server is healthy"
+      return
+    fi
+    sleep 5
+  done
+  echo "Timed out waiting for $HEALTH_URL" >&2
+  exit 1
+}
+
+check_pair_counts() {
+  local numbers=$1
+  local parallels=$2
+  local n_count p_count
+  read -r -a n_count <<< "$numbers"
+  read -r -a p_count <<< "$parallels"
+  if [[ ${#n_count[@]} -ne ${#p_count[@]} ]]; then
+    echo "number/parallel list lengths differ: '$numbers' vs '$parallels'" >&2
+    exit 2
+  fi
+}
+
+run_evalscope() {
+  local label=$1
+  local numbers=$2
+  local parallels=$3
+  local out_dir="$OUTPUT_DIR/$label"
+  local log_file="$OUTPUT_DIR/${label}.log"
+  local number_args parallel_args cmd
+
+  check_pair_counts "$numbers" "$parallels"
+  read -r -a number_args <<< "$numbers"
+  read -r -a parallel_args <<< "$parallels"
+
+  rm -rf "$out_dir"
+  mkdir -p "$out_dir"
+
+  cmd=(
+    "$EVALSCOPE_BIN" perf
+    --model "$MODEL"
+    --url "$API_URL"
+    --api "$API"
+    --api-key "$API_KEY"
+    --dataset "$DATASET"
+    --dataset-path "$DATASET_PATH"
+    --max-tokens "$MAX_TOKENS"
+    --multi-turn
+    --number "${number_args[@]}"
+    --parallel "${parallel_args[@]}"
+    --extra-args "$EXTRA_ARGS"
+    --no-timestamp
+    --outputs-dir "$out_dir"
+  )
+
+  if [[ -n "$TOKENIZER_PATH" ]]; then
+    cmd+=(--tokenizer-path "$TOKENIZER_PATH")
+  fi
+  if [[ "$STREAM" == "1" ]]; then
+    cmd+=(--stream)
+  fi
+  if [[ "$TOKENIZE_PROMPT" == "1" ]]; then
+    cmd+=(--tokenize-prompt)
+  fi
+  if [[ "$NO_TEST_CONNECTION" == "1" ]]; then
+    cmd+=(--no-test-connection)
+  fi
+
+  log "running $label: numbers=[$numbers], parallels=[$parallels], out=$out_dir"
+  "${cmd[@]}" 2>&1 | tee "$log_file"
+}
+
+collect_results() {
+  local csv="$OUTPUT_DIR/sweep.csv"
+  local svg="$OUTPUT_DIR/sweep.svg"
+  log "collecting results into $csv and $svg"
+  python3 "$SCRIPT_DIR/collect_outputs.py" "$OUTPUT_DIR" \
+    --num-gpus "$NUM_GPUS" \
+    --csv "$csv" \
+    --svg "$svg"
+}
+
+main() {
+  require_dataset
+  mkdir -p "$OUTPUT_DIR"
+  log "output_dir=$OUTPUT_DIR"
+  log "model=$MODEL api_url=$API_URL dataset=$DATASET dataset_path=$DATASET_PATH"
+  ensure_evalscope
+  wait_for_health
+  run_evalscope "warmup_p${WARMUP1_PARALLEL}_n${WARMUP1_NUMBER}" "$WARMUP1_NUMBER" "$WARMUP1_PARALLEL"
+  run_evalscope "warmup_p${WARMUP2_PARALLEL}_n${WARMUP2_NUMBER}" "$WARMUP2_NUMBER" "$WARMUP2_PARALLEL"
+  run_evalscope "sweep" "$FORMAL_NUMBERS" "$FORMAL_PARALLELS"
+  collect_results
+  log "done"
+}
+
+main "$@"

--- a/test/agentic_benchmark/test_evalscope_trie_collect_outputs.py
+++ b/test/agentic_benchmark/test_evalscope_trie_collect_outputs.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+
+
+def load_collector():
+    path = Path(__file__).resolve().parent / "evalscope_trie" / "collect_outputs.py"
+    spec = importlib.util.spec_from_file_location("evalscope_trie_collect", path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_json(path: Path, data: dict):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+def write_db(path: Path):
+    con = sqlite3.connect(path)
+    try:
+        con.execute("create table result(success integer)")
+        con.executemany("insert into result(success) values (?)", [(1,), (1,), (0,)])
+        con.commit()
+    finally:
+        con.close()
+
+
+def test_collect_outputs_computes_jiying_style_axes(tmp_path):
+    collector = load_collector()
+    run_dir = tmp_path / "sweep" / "DeepSeek-V4-Pro" / "parallel_4_number_32"
+    write_json(
+        run_dir / "benchmark_summary.json",
+        {
+            "Concurrency": 4,
+            "Total Requests": 3,
+            "Success Requests": 2,
+            "Failed Requests": 1,
+            "Avg Latency (s)": 1.5,
+            "TTFT (ms)": 250.0,
+            "TPOT (ms)": 6.0,
+            "Avg Input Tokens": 1000,
+            "Avg Output Tokens": 200,
+            "Avg Turns/Request": 3,
+            "KV Cache Hit Rate (%)": 91.5,
+            "First-Turn TTFT (ms)": 500.0,
+            "Subsequent-Turn TTFT (ms)": 200.0,
+            "Decoded Tok/Iter": 3.2,
+            "Spec. Accept Rate": 0.71,
+        },
+    )
+    write_json(
+        run_dir / "workload_throughput.json",
+        {"rows": [{"metric": "Completion tok/s", "steady_state": 320.0}]},
+    )
+    write_json(run_dir / "trace_summary.json", {"n_traces": 32})
+    write_db(run_dir / "benchmark_data.db")
+
+    rows = collector.collect(tmp_path, num_gpus=8)
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["phase"] == "sweep"
+    assert row["model"] == "DeepSeek-V4-Pro"
+    assert row["parallel"] == 4
+    assert row["number"] == 32
+    assert row["success"] == "2/3"
+    assert row["steady_completion_tok_s"] == 320.0
+    assert row["completion_tps_per_user"] == 80.0
+    assert row["output_token_min_per_gpu"] == 2400.0
+    assert row["avg_ttft_s"] == 0.25
+    assert row["first_turn_ttft_s"] == 0.5
+    assert row["decoded_tok_iter"] == 3.2
+    assert row["spec_accept_rate"] == 0.71


### PR DESCRIPTION
## Summary

This draft adds a reusable EvalScope trie benchmark protocol/tooling path for agentic serving comparisons.

The protocol is based on Jiying Dong's EvalScope trie workflow and the follow-up discussion around warmup, formal sweep sizing, prompt serialization, and metric alignment. The goal is to make TRTLLM and TokenSpeed runs use the same workload, request parameters, warmup protocol, prompt serialization, and metric definitions before we compare V4-Pro agentic serving results.

## What changed

- Add `test/agentic_benchmark/evalscope_trie/run_evalscope_trie_sweep.sh`:
  - runs two warmup passes
  - runs a formal parallel sweep
  - supports chat-completions and plain completions/tokenized-prompt mode
- Add `collect_outputs.py`:
  - collects EvalScope output into a CSV
  - computes `Completion TPS/user`
  - computes `Output Token/Min/GPU`
  - emits a throughput-vs-per-user-speed SVG curve
- Add README with the agreed benchmark protocol, metric definitions, and V4-Pro tokenizer/chat-template caveat.
- Add a focused unit test for the collector.

## Scope

This PR does not launch or configure the server. TokenSpeed, TRTLLM, or another backend should be started separately, and backend-specific launch flags should be recorded next to each benchmark run.

## Test Plan

- `pre-commit run --all-files`
- `python -m pytest test/agentic_benchmark/test_evalscope_trie_collect_outputs.py -q`
- Python compile / shell syntax checks for the new scripts

## Notes

Opening as draft first so Jiying can review whether the protocol attribution and default settings match the workflow she proposed before this is marked ready for review.

