### PR TITLE
fix(kernel): register FA4 for SM 10.x and 11.x

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flash_attn/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flash_attn/__init__.py
@@ -48,15 +48,7 @@ platform = current_platform()
 # ------------------------------------------------------------------------------
 
 
-# FA4 CUTE kernels currently support SM 10.0 (B100/B200/GB200) variants only.
-# B300/GB300 (SM 10.3 / sm_103) is not yet supported by flash-attn — its CUTE
-# arch enum value falls outside the [sm_100, sm_110f] range checked in
-# FlashAttentionForwardSm100, causing an AssertionError at call time.
-if (
-    platform.is_nvidia
-    and platform.is_blackwell
-    and platform.arch_version == ArchVersion(10, 0)
-):
+if platform.is_blackwell_plus:
     from flash_attn.cute import (
         flash_attn_func,
         flash_attn_varlen_func,


### PR DESCRIPTION
## Summary

Register FA4 CUTE kernels for NVIDIA SM 10.x and 11.x architectures instead of only SM 10.0.

[PR #5](https://github.com/lightseekorg/tokenspeed/pull/5) skips B300/GB300 (sm_103) FA4 registration because flash-attn CUTE did not support that arch at the time - since then, there have been SM 10.x / 11.x support added in [flash-attn PR #2572](https://github.com/Dao-AILab/flash-attention/pull/2572), [flash-attn PR #2589](https://github.com/Dao-AILab/flash-attention/pull/2589), and [flash-attn PR #2590](https://github.com/Dao-AILab/flash-attention/pull/2590).

## Test Plan

confirmed on b300