### PR TITLE
Add AMD Kimi MXFP4 CI job

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mla.py
@@ -307,12 +307,20 @@ class MLAAttnBackend(AttentionBackend):
             page_table = metadata.page_table[num_extends:].repeat_interleave(
                 q_len_per_req, dim=0
             )
-            base_lens = metadata.seq_lens[num_extends:].repeat_interleave(q_len_per_req)
+            cache_seqlens = metadata.seq_lens[num_extends:].repeat_interleave(
+                q_len_per_req
+            )
+            # Draft catch-up starts from the current draft KV length; target
+            # verify starts from the final target KV length and backs up.
+            offset_start = 0 if self.is_draft else 1 - q_len_per_req
             offsets = torch.arange(
-                q_len_per_req, device=base_lens.device, dtype=base_lens.dtype
+                offset_start,
+                offset_start + q_len_per_req,
+                device=cache_seqlens.device,
+                dtype=cache_seqlens.dtype,
             ).repeat(bs)
-            cache_seqlens = base_lens + offsets
-            max_seqlen_k = self.max_context_len + q_len_per_req
+            cache_seqlens = cache_seqlens + offsets
+            max_seqlen_k = self.max_context_len
         else:
             query = q.view(bs, -1, layer.tp_q_head_num, layer.head_dim)
             page_table = metadata.page_table[num_extends:]

--- a/test/ci/eval/kimi-k2.5-mxfp4-evalscope-aime25-amd.yaml
+++ b/test/ci/eval/kimi-k2.5-mxfp4-evalscope-aime25-amd.yaml
@@ -1,0 +1,54 @@
+api_version: ci.tokenspeed.io/v1
+name: eval-kimi-k2.5-mxfp4-aime25-amd
+type: eval
+triggers:
+  - per-commit
+  - manual
+runner:
+  labels:
+    - amd-mi35x-4gpu-test
+env:
+  CI: "true"
+install:
+  - bash test/ci_system/install_deps_rocm.sh
+server:
+  command: >-
+    ts serve
+    --model amd/Kimi-K2.5-MXFP4
+    --host 127.0.0.1
+    --port 8000
+    --world-size 4
+    --max-model-len 80000
+    --max-num-seqs 16
+    --trust-remote-code
+    --quantization mxfp4
+    --speculative-algorithm EAGLE3
+    --speculative-draft-model-path lightseekorg/kimi-k2.5-eagle3
+    --speculative-num-steps 1
+    --speculative-eagle-topk 1
+    --speculative-num-draft-tokens 2
+    --speculative-draft-model-quantization unquant
+    --sampling-backend greedy
+    --disable-kvstore
+    --kvstore-ratio 0.0
+    --enable-cache-report
+  ready:
+    url: http://127.0.0.1:8000/readiness
+    timeout: 1800
+    interval: 10
+eval:
+  install:
+    - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]'
+  command: >-
+    /tmp/evalscope-perf/bin/evalscope eval
+    --model amd/Kimi-K2.5-MXFP4
+    --api-url http://127.0.0.1:8000/v1
+    --api-key EMPTY_TOKEN
+    --datasets aime25
+    --limit 4
+    --eval-batch-size 4
+    --stream
+    --generation-config '{"do_sample":false,"temperature":0.0,"max_tokens":8192}'
+report:
+  github_step_summary: true
+score_threshold: 0.75

--- a/test/runtime/layers/test_mla_verify_metadata.py
+++ b/test/runtime/layers/test_mla_verify_metadata.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from tokenspeed.runtime.layers.attention.backends import mla as mla_backend
+
+
+def _run_mla_decode(monkeypatch, *, is_draft: bool) -> torch.Tensor:
+    captured = {}
+
+    def fake_mla_decode_with_kvcache(**kwargs):
+        captured["cache_seqlens"] = kwargs["cache_seqlens"]
+        return torch.zeros(4, 1, 1, 4)
+
+    monkeypatch.setattr(
+        mla_backend, "mla_decode_with_kvcache", fake_mla_decode_with_kvcache
+    )
+
+    backend = object.__new__(mla_backend.MLAAttnBackend)
+    backend.forward_decode_metadata = SimpleNamespace(
+        num_extends=0,
+        page_table=torch.zeros(2, 1, dtype=torch.int32),
+        seq_lens=torch.tensor([64, 128], dtype=torch.int32),
+    )
+    backend.is_draft = is_draft
+    backend.max_context_len = 256
+    backend.page_size = 16
+    backend.kv_lora_rank = 2
+    backend.qk_nope_head_dim = 2
+    backend.qk_rope_head_dim = 2
+    backend.kv_cache_dim = 4
+    backend.data_type = torch.float32
+    backend.kernel_solution = "default"
+
+    layer = SimpleNamespace(
+        tp_q_head_num=1,
+        head_dim=4,
+        v_head_dim=4,
+        scaling=1.0,
+        logit_cap=0.0,
+        k_scale_float=None,
+        layer_id=0,
+    )
+    token_to_kv_pool = SimpleNamespace(
+        get_key_buffer=lambda layer_id: torch.zeros(16, 4)
+    )
+
+    backend.forward_decode(
+        q=torch.zeros(4, 4),
+        k=None,
+        v=None,
+        layer=layer,
+        out_cache_loc=torch.empty(0, dtype=torch.int32),
+        token_to_kv_pool=token_to_kv_pool,
+        bs=2,
+        save_kv_cache=False,
+    )
+    return captured["cache_seqlens"]
+
+
+def test_target_verify_cache_seqlens_count_back_from_final_lengths(monkeypatch):
+    cache_seqlens = _run_mla_decode(monkeypatch, is_draft=False)
+
+    assert cache_seqlens.tolist() == [63, 64, 127, 128]
+
+
+def test_draft_cache_seqlens_count_forward_from_base_lengths(monkeypatch):
+    cache_seqlens = _run_mla_decode(monkeypatch, is_draft=True)
+
+    assert cache_seqlens.tolist() == [64, 65, 128, 129]


### PR DESCRIPTION
This also fixes MLA cache length metadata for speculative multi-token decode. During target verification, Kimi verifies multiple draft tokens through its MLA attention backend, regardless of which draft model proposed them. The per-token `cache_seqlens` need to count backward from the final verified sequence length; for MLA draft catch-up they count forward from the current draft KV length. The added test covers both cases.