### PR TITLE
fix(kernel): import FA4 CUTE on Blackwell+

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -65,9 +65,9 @@ dependencies = [
     "setproctitle",
     "tiktoken",
     "tokenspeed-mooncake>=0.3.11.post20260527",
-    "tokenspeed-smg==1.5.0.post20260617",
-    "tokenspeed-smg-grpc-proto==0.4.10.post20260617",
-    "tokenspeed-smg-grpc-servicer==0.5.6.post20260617",
+    "tokenspeed-smg==1.5.0.post20260618",
+    "tokenspeed-smg-grpc-proto==0.4.10.post20260618",
+    "tokenspeed-smg-grpc-servicer==0.5.6.post20260618",
     "torch==2.11.0",
     # Tag-capable sleep/wake allocator (region(tag, enable_cpu_backup)/pause/
     # resume). Bundles cu12/cu13 binaries; import-guarded so it's a no-op unless

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flash_attn/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flash_attn/__init__.py
@@ -48,20 +48,17 @@ platform = current_platform()
 # ------------------------------------------------------------------------------
 
 
-# FA4 CUTE kernels currently support SM 10.0 (B100/B200/GB200) variants only.
-# B300/GB300 (SM 10.3 / sm_103) is not yet supported by flash-attn — its CUTE
-# arch enum value falls outside the [sm_100, sm_110f] range checked in
-# FlashAttentionForwardSm100, causing an AssertionError at call time.
-if (
-    platform.is_nvidia
-    and platform.is_blackwell
-    and platform.arch_version == ArchVersion(10, 0)
-):
+if platform.is_blackwell_plus:
     from flash_attn.cute import (
         flash_attn_func,
         flash_attn_varlen_func,
     )
 
+if (
+    platform.is_nvidia
+    and platform.is_blackwell
+    and platform.arch_version == ArchVersion(10, 0)
+):
     # FA4 on Blackwell supports prefill head_dim in [8, 256] divisible by 8,
     # but the 256-wide MHA path mishandles non-contiguous V split views, so we
     # restrict it to <256 for now until that is resolved.


### PR DESCRIPTION
## Summary

better integrated version of #473, makes FA4 CUTE direct functions available on blackwell+ without changing our registered FA4 MHA kernel selection

## Test Plan

<!-- How was this validated? -->
