### PR TITLE
ci: use default mha and moe backend for gpt-oss ci

### DIFF
--- a/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
+++ b/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
@@ -10,11 +10,8 @@ runner:
     - amd-mi35x-2gpu-test
   env:
     b200-2gpu:
-      GPT_OSS_EVAL_ATTENTION_BACKEND: trtllm
-      GPT_OSS_EVAL_MOE_BACKEND: flashinfer_trtllm
       GPT_OSS_EVAL_MODEL: openai/gpt-oss-120b
     amd-mi35x-2gpu-test:
-      GPT_OSS_EVAL_DISABLE_KVSTORE: "1"
       GPT_OSS_EVAL_DISABLE_PREFIX_CACHING: "1"
       GPT_OSS_EVAL_MODEL: amd/gpt-oss-120b-w-mxfp4-a-fp8
 env:
@@ -30,9 +27,6 @@ server:
     --max-model-len 80000
     --trust-remote-code
     --reasoning-parser base
-    ${GPT_OSS_EVAL_ATTENTION_BACKEND:+--attention-backend ${GPT_OSS_EVAL_ATTENTION_BACKEND}}
-    ${GPT_OSS_EVAL_MOE_BACKEND:+--moe-backend ${GPT_OSS_EVAL_MOE_BACKEND}}
-    ${GPT_OSS_EVAL_DISABLE_KVSTORE:+--disable-kvstore}
     ${GPT_OSS_EVAL_DISABLE_PREFIX_CACHING:+--no-enable-prefix-caching}
     --enable-cache-report
     --host 127.0.0.1

--- a/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
+++ b/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
@@ -12,6 +12,7 @@ runner:
     b200-2gpu:
       GPT_OSS_EVAL_MODEL: openai/gpt-oss-120b
     amd-mi35x-2gpu-test:
+      GPT_OSS_EVAL_DISABLE_KVSTORE: "1"
       GPT_OSS_EVAL_DISABLE_PREFIX_CACHING: "1"
       GPT_OSS_EVAL_MODEL: amd/gpt-oss-120b-w-mxfp4-a-fp8
 env:
@@ -27,6 +28,7 @@ server:
     --max-model-len 80000
     --trust-remote-code
     --reasoning-parser base
+    ${GPT_OSS_EVAL_DISABLE_KVSTORE:+--disable-kvstore}
     ${GPT_OSS_EVAL_DISABLE_PREFIX_CACHING:+--no-enable-prefix-caching}
     --enable-cache-report
     --host 127.0.0.1


### PR DESCRIPTION
## Summary

After #465, #445, and #374, the default mha backend and moe backend should route to the same kernel for gpt-oss on B200. Use the PR to test it.

