### PR TITLE
Remove forced NCCL record stream override

### DIFF
--- a/python/tokenspeed/runtime/entrypoints/engine.py
+++ b/python/tokenspeed/runtime/entrypoints/engine.py
@@ -451,7 +451,6 @@ def _set_envs_and_config(server_args: ServerArgs):
     os.environ["NCCL_CUMEM_ENABLE"] = str(int(server_args.enable_symm_mem))
     if not server_args.enable_symm_mem:
         os.environ["NCCL_NVLS_ENABLE"] = str(int(server_args.enable_nccl_nvls))
-    os.environ["TORCH_NCCL_AVOID_RECORD_STREAMS"] = "1"
     os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "4"
     os.environ["CUDA_MODULE_LOADING"] = "AUTO"
     if not server_args.disable_tf32:


### PR DESCRIPTION
Stop forcing `TORCH_NCCL_AVOID_RECORD_STREAMS=1` at engine startup so deployments can rely on their runtime environment for this NCCL behavior.

Validation: `python3 -m py_compile python/tokenspeed/runtime/entrypoints/engine.py`.