### PR TITLE
Use transformers dtype config field

### DIFF
--- a/python/tokenspeed/runtime/configs/model_config.py
+++ b/python/tokenspeed/runtime/configs/model_config.py
@@ -455,9 +455,10 @@ def get_hf_text_config(config: PretrainedConfig):
     if class_name.startswith("Llava") and class_name.endswith("ForCausalLM"):
         # We support non-hf version of llava models, so we do not want to
         # read the wrong values from the unused default text_config.
-        #  We set `torch_dtype` of config to `torch.float16` for the weights, as
-        # `torch.float16` is default used for image features in `python/tokenspeed/runtime/models/llava.py`.
-        setattr(config, "torch_dtype", torch.float16)
+        # We set `dtype` of config to `torch.float16` for the weights, as
+        # `torch.float16` is default used for image features in
+        # `python/tokenspeed/runtime/models/llava.py`.
+        config.dtype = torch.float16
         return config
 
     if hasattr(config, "text_config"):
@@ -483,9 +484,8 @@ def _get_and_verify_dtype(
     config: PretrainedConfig,
     dtype: str | torch.dtype,
 ) -> torch.dtype:
-    #  getattr(config, "torch_dtype", torch.float32) is not correct
-    # because config.torch_dtype can be None.
-    config_dtype = getattr(config, "torch_dtype", None)
+    # config.dtype can be missing or None.
+    config_dtype = getattr(config, "dtype", None)
     if config_dtype is None:
         config_dtype = torch.bfloat16
 

--- a/python/tokenspeed/runtime/models/gpt_oss.py
+++ b/python/tokenspeed/runtime/models/gpt_oss.py
@@ -358,7 +358,7 @@ class GptOssSparseMoeBlock(nn.Module):
             bias=True,
             quant_config=None,
             prefix=add_prefix("gate", prefix),
-            params_dtype=config.torch_dtype,
+            params_dtype=config.dtype,
         )
 
         self.topk = TopK(
@@ -495,7 +495,7 @@ class GptOssDecoderLayer(CompiledMoEDecoderLayer):
             prefix=add_prefix("self_attn", prefix),
             sliding_window_size=self.sliding_window_size,
             layer_type=config.layer_types[self.layer_id],
-            params_dtype=config.torch_dtype,
+            params_dtype=config.dtype,
         )
 
     def resolve_mlp(self, prefix: str) -> nn.Module:

--- a/python/tokenspeed/runtime/models/qwen3_5.py
+++ b/python/tokenspeed/runtime/models/qwen3_5.py
@@ -61,7 +61,7 @@ from tokenspeed.runtime.layers.linear import (
     QKVParallelLinear,
     RowParallelLinear,
 )
-from tokenspeed.runtime.layers.logits_processor import LogitsMetadata, LogitsProcessor
+from tokenspeed.runtime.layers.logits_processor import LogitsMetadata
 from tokenspeed.runtime.layers.moe import (
     ExpertCheckpointSchema,
     build_moe_checkpoint_loader,
@@ -105,7 +105,6 @@ from tokenspeed.runtime.utils import (
     make_layers,
     set_weight_attrs,
 )
-from tokenspeed.runtime.utils.cuda_stream import StreamFork
 
 logger = logging.getLogger(__name__)
 
@@ -225,7 +224,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             group_size=None,
             norm_before_gate=True,
             device=torch.get_device_module().current_device(),
-            dtype=config.torch_dtype,
+            dtype=config.dtype,
         )
 
         # Output projection

--- a/python/tokenspeed/runtime/utils/hf_transformers_utils.py
+++ b/python/tokenspeed/runtime/utils/hf_transformers_utils.py
@@ -95,9 +95,10 @@ def get_hf_text_config(config: PretrainedConfig):
     if class_name.startswith("Llava") and class_name.endswith("ForCausalLM"):
         # We support non-hf version of llava models, so we do not want to
         # read the wrong values from the unused default text_config.
-        #  We set `torch_dtype` of config to `torch.float16` for the weights, as
-        # `torch.float16` is default used for image features in `python/tokenspeed/runtime/models/llava.py`.
-        setattr(config, "torch_dtype", torch.float16)
+        # We set `dtype` of config to `torch.float16` for the weights, as
+        # `torch.float16` is default used for image features in
+        # `python/tokenspeed/runtime/models/llava.py`.
+        config.dtype = torch.float16
         return config
 
     text_config = None
@@ -113,11 +114,7 @@ def get_hf_text_config(config: PretrainedConfig):
         # qwen2.5 omni
         thinker_config = config.thinker_config
         if hasattr(thinker_config, "text_config"):
-            setattr(
-                thinker_config.text_config,
-                "torch_dtype",
-                getattr(thinker_config, "torch_dtype", None),
-            )
+            thinker_config.text_config.dtype = thinker_config.dtype
             text_config = thinker_config.text_config
         else:
             text_config = thinker_config

--- a/test/runtime/test_resolve_architecture.py
+++ b/test/runtime/test_resolve_architecture.py
@@ -3,9 +3,14 @@
 ``_materialize_architectures`` (pin the raw config.json value back onto
 the live config when ``from_pretrained`` lost it)."""
 
+# ruff: noqa: E402
+
 import os
 import sys
 import unittest
+
+import torch
+from transformers import PretrainedConfig
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from ci_system.ci_register import register_cuda_ci  # noqa: E402
@@ -14,8 +19,13 @@ register_cuda_ci(est_time=5, suite="runtime-1gpu")
 
 from tokenspeed.runtime.configs import Qwen3_5MoeConfig  # noqa: E402
 from tokenspeed.runtime.configs.model_config import get_hf_text_config  # noqa: E402
-from tokenspeed.runtime.utils.hf_transformers_utils import (  # noqa: E402
+from tokenspeed.runtime.utils.hf_transformers_utils import (
     _materialize_architectures,
+)
+from tokenspeed.runtime.utils.hf_transformers_utils import (  # noqa: E402
+    get_hf_text_config as get_runtime_hf_text_config,
+)
+from tokenspeed.runtime.utils.hf_transformers_utils import (
     resolve_architecture,
 )
 
@@ -56,6 +66,17 @@ class Qwen3_5ConfigTests(unittest.TestCase):
             config.num_attention_heads,
             config.text_config.num_attention_heads,
         )
+
+
+class ConfigDtypeTests(unittest.TestCase):
+    def test_llava_dtype_override_does_not_use_deprecated_field(self) -> None:
+        helpers = (get_hf_text_config, get_runtime_hf_text_config)
+
+        with self.assertNoLogs("transformers", level="WARNING"):
+            for helper in helpers:
+                config = PretrainedConfig(architectures=["LlavaForCausalLM"])
+                self.assertIs(helper(config), config)
+                self.assertIs(config.dtype, torch.float16)
 
 
 class MaterializeArchitecturesTests(unittest.TestCase):


### PR DESCRIPTION
Transformers 5 emits a deprecation warning when runtime config paths read or write `torch_dtype`. Use the new `dtype` field directly in config handling and model initialization so startup logs stay clean while matching the pinned transformers API.

Validation:
- `pre-commit run --all-files`
- `ruff check python/tokenspeed/runtime/utils/hf_transformers_utils.py python/tokenspeed/runtime/configs/model_config.py python/tokenspeed/runtime/models/qwen3_5.py python/tokenspeed/runtime/models/gpt_oss.py test/runtime/test_resolve_architecture.py`
- `python3 -m py_compile python/tokenspeed/runtime/utils/hf_transformers_utils.py python/tokenspeed/runtime/configs/model_config.py python/tokenspeed/runtime/models/qwen3_5.py python/tokenspeed/runtime/models/gpt_oss.py test/runtime/test_resolve_architecture.py`
- `python3 -m unittest test.runtime.test_resolve_architecture -v`