### PR TITLE
Sanitize Qwen3.5 rope parameters

### DIFF
--- a/python/tokenspeed/runtime/configs/qwen3_5_config.py
+++ b/python/tokenspeed/runtime/configs/qwen3_5_config.py
@@ -25,6 +25,18 @@ from transformers import PretrainedConfig
 from tokenspeed.runtime.configs.qwen3_5_text_base_config import Qwen3_5BaseTextConfig
 from tokenspeed.runtime.configs.qwen3_vision_config import Qwen3VLVisionConfig
 
+_MROPE_EXTENSION_KEYS = frozenset({"mrope_section", "mrope_interleaved"})
+
+
+def _to_transformers_rope_parameters(rope_config):
+    if not isinstance(rope_config, dict):
+        return rope_config
+    return {
+        key: value
+        for key, value in rope_config.items()
+        if key not in _MROPE_EXTENSION_KEYS
+    }
+
 
 class Qwen3_5VisionConfig(Qwen3VLVisionConfig):
     model_type = "qwen3_5"
@@ -41,16 +53,14 @@ class Qwen3_5TextConfig(Qwen3_5BaseTextConfig):
     ):
         # HF Qwen3.5 checkpoints may provide RoPE settings under rope_parameters.
         # Normalize it before parent init so downstream code sees the expected values.
-        rope_parameters = kwargs.pop("rope_parameters", None)
-        if kwargs.get("rope_scaling") is None and rope_parameters is not None:
-            kwargs["rope_scaling"] = rope_parameters
+        full_rope_parameters = kwargs.get("rope_parameters")
+        if full_rope_parameters is not None:
+            kwargs["rope_parameters"] = _to_transformers_rope_parameters(
+                full_rope_parameters
+            )
 
         super().__init__(**kwargs)
-        if self.rope_scaling is None:
-            self.rope_scaling = rope_parameters or {}
-
-        # Keep both names for compatibility with model code paths that read either.
-        self.rope_parameters = rope_parameters or self.rope_scaling
+        self._tokenspeed_rope_parameters = full_rope_parameters or self.rope_parameters
 
 
 class Qwen3_5Config(PretrainedConfig):

--- a/python/tokenspeed/runtime/configs/qwen3_5_text_base_config.py
+++ b/python/tokenspeed/runtime/configs/qwen3_5_text_base_config.py
@@ -90,7 +90,7 @@ class Qwen3_5BaseTextConfig(PretrainedConfig):
             Whether the model's input and output word embeddings should be tied.
         rope_theta (`float`, *optional*, defaults to 10000.0):
             The base period of the RoPE embeddings.
-        rope_scaling (`Dict`, *optional*):
+        rope_parameters (`Dict`, *optional*):
             Dictionary containing the scaling configuration for the RoPE embeddings.  if you apply new rope type
             and you expect the model to work on longer `max_position_embeddings`, we recommend you to update this value
             accordingly.
@@ -201,7 +201,7 @@ class Qwen3_5BaseTextConfig(PretrainedConfig):
         use_cache=True,
         tie_word_embeddings=False,
         rope_theta=10000.0,
-        rope_scaling=None,
+        rope_parameters=None,
         partial_rotary_factor=0.25,
         attention_bias=False,
         attention_dropout=0.0,
@@ -236,7 +236,7 @@ class Qwen3_5BaseTextConfig(PretrainedConfig):
         self.rms_norm_eps = rms_norm_eps
         self.use_cache = use_cache
         self.rope_theta = rope_theta
-        self.rope_scaling = rope_scaling
+        self.rope_parameters = rope_parameters
         self.partial_rotary_factor = partial_rotary_factor
         self.attention_bias = attention_bias
         self.attention_dropout = attention_dropout

--- a/python/tokenspeed/runtime/configs/utils.py
+++ b/python/tokenspeed/runtime/configs/utils.py
@@ -43,6 +43,15 @@ def get_rope_theta(config, default: float = 10000.0) -> float:
     return default
 
 
+def get_rope_parameters(config):
+    """Return TokenSpeed's full RoPE config, including private extensions."""
+    return (
+        getattr(config, "_tokenspeed_rope_parameters", None)
+        or getattr(config, "rope_parameters", None)
+        or {}
+    )
+
+
 def _compute_default_rope_parameters(
     config: PretrainedConfig | None = None,
     device: "torch.device | None" = None,

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -28,6 +28,7 @@ import torch
 from tokenspeed_kernel.platform import current_platform
 
 from tokenspeed.runtime.configs.model_config import ModelConfig
+from tokenspeed.runtime.configs.utils import get_rope_parameters
 from tokenspeed.runtime.engine.scheduler_utils import (
     paged_cache_block_table_base_offsets_from_forward_op,
     paged_cache_block_tables_from_forward_op,
@@ -147,10 +148,8 @@ class ModelExecutorConfig:
             if server_args.speculative_algorithm
             else 1
         )
-        rope_scaling = getattr(
-            model_config.hf_text_config, "rope_parameters", None
-        ) or getattr(model_config.hf_text_config, "rope_scaling", {})
-        model_is_mrope = bool(rope_scaling and "mrope_section" in rope_scaling)
+        rope_parameters = get_rope_parameters(model_config.hf_text_config)
+        model_is_mrope = bool(rope_parameters and "mrope_section" in rope_parameters)
 
         return ModelExecutorConfig(
             max_req_pool_size=max_req_pool_size,

--- a/python/tokenspeed/runtime/models/qwen3_5.py
+++ b/python/tokenspeed/runtime/models/qwen3_5.py
@@ -40,6 +40,7 @@ from tokenspeed.runtime.configs.qwen3_5_config import (
     Qwen3_5Config,
     Qwen3_5TextConfig,
 )
+from tokenspeed.runtime.configs.utils import get_rope_parameters
 
 # Distributed
 from tokenspeed.runtime.distributed.comm_manager import CommManager
@@ -591,10 +592,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         self.scaling = self.head_dim**-0.5
         self.max_position_embeddings = getattr(config, "max_position_embeddings", 8192)
 
-        if hasattr(config, "rope_parameters"):
-            self.rope_scaling = getattr(config, "rope_parameters", None)
-        else:
-            self.rope_scaling = getattr(config, "rope_scaling", None)
+        self.rope_scaling = get_rope_parameters(config)
 
         self.rope_theta = self.rope_scaling.get("rope_theta", 10000)
         self.partial_rotary_factor = self.rope_scaling.get("partial_rotary_factor", 1.0)
@@ -1160,9 +1158,7 @@ class Qwen3_5ForConditionalGeneration(BaseCausalLM):
             prefix=prefix,
         )
 
-        rope_config = getattr(self.config, "rope_parameters", None) or getattr(
-            self.config, "rope_scaling", {}
-        )
+        rope_config = get_rope_parameters(self.config)
         self.is_mrope_enabled = "mrope_section" in rope_config
         self.is_multimodal_active = is_multimodal_active
         if not self.is_multimodal_active:

--- a/test/runtime/test_resolve_architecture.py
+++ b/test/runtime/test_resolve_architecture.py
@@ -19,6 +19,8 @@ register_cuda_ci(est_time=5, suite="runtime-1gpu")
 
 from tokenspeed.runtime.configs import Qwen3_5MoeConfig  # noqa: E402
 from tokenspeed.runtime.configs.model_config import get_hf_text_config  # noqa: E402
+from tokenspeed.runtime.configs.qwen3_5_config import Qwen3_5MoeTextConfig  # noqa: E402
+from tokenspeed.runtime.configs.utils import get_rope_parameters  # noqa: E402
 from tokenspeed.runtime.utils.hf_transformers_utils import (
     _materialize_architectures,
 )
@@ -66,6 +68,23 @@ class Qwen3_5ConfigTests(unittest.TestCase):
             config.num_attention_heads,
             config.text_config.num_attention_heads,
         )
+
+    def test_mrope_extensions_do_not_leak_to_transformers_rope_validation(
+        self,
+    ) -> None:
+        rope_parameters = {
+            "rope_type": "default",
+            "mrope_section": [16, 24, 24],
+            "mrope_interleaved": True,
+        }
+
+        with self.assertNoLogs("transformers", level="WARNING"):
+            config = Qwen3_5MoeTextConfig(rope_parameters=rope_parameters)
+
+        self.assertEqual(config.rope_parameters["rope_type"], "default")
+        self.assertNotIn("mrope_section", config.rope_parameters)
+        self.assertNotIn("mrope_interleaved", config.rope_parameters)
+        self.assertEqual(get_rope_parameters(config), rope_parameters)
 
 
 class ConfigDtypeTests(unittest.TestCase):


### PR DESCRIPTION
Transformers 5 validates `rope_parameters` and warns when TokenSpeed-only MRoPE extension keys are present. Keep the public config limited to transformers-recognized keys while storing the full MRoPE configuration on a private TokenSpeed field for runtime use.