### PR TITLE
fix(vlm): concat per-item grids in compute_mrope_positions

### DIFF
--- a/python/tokenspeed/runtime/multimodal/mrope.py
+++ b/python/tokenspeed/runtime/multimodal/mrope.py
@@ -56,13 +56,18 @@ def compute_mrope_positions(hf_config, input_ids, mm_items):
     if not any(arch in _MROPE_ARCHITECTURES for arch in architectures):
         return None, None
 
-    image_grid_thw = None
-    video_grid_thw = None
-    for item in mm_items:
-        if "image_grid_thw" in item.model_specific_data:
-            image_grid_thw = item.model_specific_data["image_grid_thw"]
-        if "video_grid_thw" in item.model_specific_data:
-            video_grid_thw = item.model_specific_data["video_grid_thw"]
+    image_grids = [
+        item.model_specific_data["image_grid_thw"]
+        for item in mm_items
+        if "image_grid_thw" in item.model_specific_data
+    ]
+    video_grids = [
+        item.model_specific_data["video_grid_thw"]
+        for item in mm_items
+        if "video_grid_thw" in item.model_specific_data
+    ]
+    image_grid_thw = torch.cat(image_grids, dim=0) if image_grids else None
+    video_grid_thw = torch.cat(video_grids, dim=0) if video_grids else None
 
     input_ids_tensor = torch.tensor(input_ids, dtype=torch.long).unsqueeze(0)
     mrope_positions, mrope_position_delta = MRotaryEmbedding.get_rope_index(

--- a/tokenspeed-kernel/python/requirements/cuda-thirdparty.txt
+++ b/tokenspeed-kernel/python/requirements/cuda-thirdparty.txt
@@ -6,5 +6,6 @@ tokenspeed-mla==0.1.7
 tokenspeed-fast-hadamard-transform==1.1.0.post20251110
 tokenspeed-fa3==3.0.0.post20260408
 tokenspeed-fa4==4.0.0.post20260524
+nvidia-cutlass-dsl==4.5.2
 tokenspeed-triton-kernels==1.0.0.post20260510
 tokenspeed-trtllm-kernel==1.2.1.post20260427


### PR DESCRIPTION
## Summary
Requests with ≥2 images crash with `IndexError` in M-RoPE position computation.

## Root cause
The smg gateway switched to an **itemized** multimodal ABI — each image is now its own item with its own grid:

```
flat (before):     1 item  → image_grid_thw [N, 3]
itemized (after):  N items → image_grid_thw [1, 3] each
```

`compute_mrope_positions` still assumed the flat layout: it overwrote `image_grid_thw` per item instead of concatenating, keeping only the last image's `[1, 3]` → `IndexError` for any request with ≥2 images.

## Fix
Concatenate the per-item image/video grids into `[N, 3]`.

## Validation
Qwen3.5-397B, 8 images/request: errored before, all pass after. MRoPE VLMs only; non-MRoPE (e.g. Kimi-K2.5) early-return, unaffected.
