### PR TITLE
feat(serve): default ts serve to smg passthrough routing policy

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -65,9 +65,9 @@ dependencies = [
     "setproctitle",
     "tiktoken",
     "tokenspeed-mooncake>=0.3.11.post20260527",
-    "tokenspeed-smg==1.5.0.post20260621",
-    "tokenspeed-smg-grpc-proto==0.4.10.post20260621",
-    "tokenspeed-smg-grpc-servicer==0.5.6.post20260621",
+    "tokenspeed-smg==1.5.0.post20260622",
+    "tokenspeed-smg-grpc-proto==0.4.10.post20260622",
+    "tokenspeed-smg-grpc-servicer==0.5.6.post20260622",
     "torch==2.11.0",
     # Tag-capable sleep/wake allocator (region(tag, enable_cpu_backup)/pause/
     # resume). Bundles cu12/cu13 binaries; import-guarded so it's a no-op unless

--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -54,6 +54,10 @@ DEEPSEEK_V4_REASONING_PARSER = "deepseek_v31"
 DEEPSEEK_V4_TOOL_CALL_PARSER = "deepseek_v4"
 DEFAULT_SMG_LOG_LEVEL = "warn"
 DEFAULT_SMG_PROMETHEUS_PORT = 8413
+# smg routing policy for ``ts serve``. Distinct from DEFAULT_REASONING_PARSER,
+# which happens to share the "passthrough" string but configures an unrelated
+# flag (--reasoning-parser).
+DEFAULT_SMG_POLICY = "passthrough"
 # smg reliability knobs we always want disabled when launched under
 # ts serve. These are tokenspeed-internal defaults: not surfaced via
 # the ts CLI, not routed through split_argv.
@@ -123,6 +127,30 @@ def _gateway_args_with_smg_disable_defaults(gateway_args: list[str]) -> list[str
         if flag not in result:
             result.append(flag)
     return result
+
+
+def _gateway_args_with_default_policy(gateway_args: list[str]) -> list[str]:
+    """Front smg's single backend with the ``passthrough`` routing policy.
+
+    ``ts serve`` always orchestrates exactly one engine endpoint, so smg's binary
+    default (``cache_aware``) is pure overhead here: it runs the load-aware worker
+    monitor and subscribes to the engine's KV events (``SubscribeKvEvents``).
+    Against engines that predate that RPC the subscription surfaced as
+    ``NotImplementedError: Method not implemented`` (smg#1794). The ``passthrough``
+    policy (smg#1797) forwards every request to the single healthy worker with no
+    load balancing, load monitoring, or KV-event subscription.
+
+    Default-when-unset: an explicit operator ``--policy`` is preserved.
+
+    NOTE: ``--policy`` is whitelisted by smg's clap ``value_parser`` — a gateway
+    that predates smg#1797 rejects ``passthrough`` and fails to start. This
+    injection therefore requires a bundled ``tokenspeed-smg`` that ships smg#1797;
+    the pin in ``python/pyproject.toml`` must be bumped to such a release in
+    lockstep with this default.
+    """
+    if "--policy" in gateway_args:
+        return gateway_args
+    return [*gateway_args, "--policy", DEFAULT_SMG_POLICY]
 
 
 _TOKENIZER_CACHE_FLAGS = (
@@ -276,6 +304,7 @@ def _gateway_args_with_defaults(gateway_args: list[str]) -> list[str]:
     gateway_args = _gateway_args_with_default_port(gateway_args)
     gateway_args = _gateway_args_with_default_reasoning_parser(gateway_args)
     gateway_args = _gateway_args_with_smg_disable_defaults(gateway_args)
+    gateway_args = _gateway_args_with_default_policy(gateway_args)
     gateway_args = _gateway_args_with_default_tokenizer_cache(gateway_args)
     gateway_args = _gateway_args_with_default_log_level(gateway_args)
     return _gateway_args_with_default_prometheus_port(gateway_args)

--- a/test/cli/test_serve_smg_unit.py
+++ b/test/cli/test_serve_smg_unit.py
@@ -39,9 +39,9 @@ from tokenspeed.cli.serve_smg import (
     _DEFAULT_SMG_DISABLE_FLAGS,
     DEEPSEEK_V4_REASONING_PARSER,
     DEEPSEEK_V4_TOOL_CALL_PARSER,
-    DEFAULT_REASONING_PARSER,
     _args_with_default_model_parsers,
     _gateway_args_with_default_log_level,
+    _gateway_args_with_default_policy,
     _gateway_args_with_default_port,
     _gateway_args_with_default_prometheus_port,
     _gateway_args_with_default_reasoning_parser,
@@ -96,6 +96,18 @@ def test_gateway_args_preserve_user_reasoning_parser():
     assert gateway_args == ["--reasoning-parser", "qwen3"]
 
 
+def test_gateway_args_default_policy_is_passthrough():
+    gateway_args = _gateway_args_with_default_policy(["--model", "/tmp/x"])
+
+    assert gateway_args == ["--model", "/tmp/x", "--policy", "passthrough"]
+
+
+def test_gateway_args_preserve_user_policy():
+    gateway_args = _gateway_args_with_default_policy(["--policy", "round_robin"])
+
+    assert gateway_args == ["--policy", "round_robin"]
+
+
 def test_gateway_args_defaults_include_port_and_reasoning_parser():
     gateway_args = _gateway_args_with_defaults(["--model", "/tmp/x"])
 
@@ -108,6 +120,8 @@ def test_gateway_args_defaults_include_port_and_reasoning_parser():
         "passthrough",
         "--disable-circuit-breaker",
         "--disable-retries",
+        "--policy",
+        "passthrough",
         "--tokenizer-cache-enable-l0",
         "--tokenizer-cache-enable-l1",
         "--log-level",
@@ -115,6 +129,28 @@ def test_gateway_args_defaults_include_port_and_reasoning_parser():
         "--prometheus-port",
         "8413",
     ]
+
+
+def test_gateway_args_defaults_inject_passthrough_policy():
+    """``ts serve`` fronts a single backend, so the default routing policy is
+    ``passthrough`` (no load balancing / monitoring / KV-event subscription)."""
+    gateway_args = _gateway_args_with_defaults(["--model", "/tmp/x"])
+
+    assert "--policy" in gateway_args
+    idx = gateway_args.index("--policy")
+    assert gateway_args[idx + 1] == "passthrough"
+
+
+def test_gateway_args_defaults_preserve_user_policy():
+    """An explicit operator ``--policy`` is never overridden by the default."""
+    gateway_args = _gateway_args_with_defaults(
+        ["--model", "/tmp/x", "--policy", "round_robin"]
+    )
+
+    # Exactly one --policy (default not appended on top of the explicit value).
+    assert gateway_args.count("--policy") == 1
+    idx = gateway_args.index("--policy")
+    assert gateway_args[idx + 1] == "round_robin"
 
 
 def test_gateway_args_default_log_level_is_warn():
@@ -284,9 +320,14 @@ def test_deepseek_v4_default_reasoning_parser_survives_gateway_defaults():
     )
     gateway_args = _gateway_args_with_defaults(gateway_args)
 
+    # Exactly one reasoning parser, and it is the deepseek-v4 default — the
+    # generic passthrough reasoning-parser default must not be layered on top.
+    # Check the parser slot rather than bare membership: the value "passthrough"
+    # (== DEFAULT_REASONING_PARSER) now also appears as the --policy value, which
+    # is an unrelated flag.
+    assert gateway_args.count("--reasoning-parser") == 1
     idx = gateway_args.index("--reasoning-parser")
     assert gateway_args[idx + 1] == DEEPSEEK_V4_REASONING_PARSER
-    assert DEFAULT_REASONING_PARSER not in gateway_args
 
 
 def test_local_deepseek_v4_config_is_detected(tmp_path):


### PR DESCRIPTION
## Summary

`ts serve` orchestrates exactly one engine endpoint. smg default `cache_aware` routing is unnecessary for that shape: it starts the load-aware worker monitor and subscribes to engine KV events, which can fail against engines that do not implement `SubscribeKvEvents`.

This injects `--policy passthrough` into the smg gateway argv by default while preserving any explicit operator `--policy`. `passthrough` forwards requests to the single healthy worker without load balancing, load monitoring, or KV-event subscription.

The smg dependency pins are updated in this PR to the 20260622 post-release set that contains passthrough support:

- `tokenspeed-smg==1.5.0.post20260622`
- `tokenspeed-smg-grpc-proto==0.4.10.post20260622`
- `tokenspeed-smg-grpc-servicer==0.5.6.post20260622`

## Tests

Added to `test/cli/test_serve_smg_unit.py`:

- `test_gateway_args_default_policy_is_passthrough` / `test_gateway_args_preserve_user_policy`
- `test_gateway_args_defaults_inject_passthrough_policy`
- `test_gateway_args_defaults_preserve_user_policy`
- Updated the exact-list `_gateway_args_with_defaults` assertion and the deepseek reasoning-parser test check.

Validation for the dependency bump:

- `python3 -m pip index versions tokenspeed-smg`
- `python3 -m pip index versions tokenspeed-smg-grpc-proto`
- `python3 -m pip index versions tokenspeed-smg-grpc-servicer`
- `.venv/bin/python -c "import tomllib; tomllib.load(open('python/pyproject.toml','rb')); print('toml ok')"`
- `git diff --check`
- `pre-commit run --all-files`