### PR TITLE
Fix gfx950 Gluon MoE preshuffled W2 OOB accesses

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
@@ -4087,9 +4087,16 @@ def _pipelined_moe_tile_compute(
 
     if HAS_BIAS:
         bias_offs = off_n + gl.arange(0, BLOCK_N, gl.SliceLayout(0, cfg.acc_layout))
-        bias_mask = bias_offs < N
+        if Y_N_CONST and not DO_SWIGLU:
+            BIAS_N: gl.constexpr = Y_N_CONST
+            bias_mask = bias_offs < BIAS_N
+        else:
+            bias_mask = bias_offs < N
+        # Masked lanes still need in-bounds addresses; W2 preshuffle can
+        # tile over padded physical N while bias remains logical N.
+        bias_offs_safe = gl.where(bias_mask, bias_offs, gl.zeros_like(bias_offs))
         bias = gl.load(
-            bias_ptr + expert_id * stride_be + bias_offs,
+            bias_ptr + expert_id * stride_be + bias_offs_safe,
             mask=bias_mask,
             other=0.0,
         )
@@ -4134,21 +4141,23 @@ def _pipelined_moe_tile_compute(
         ACTUAL_N: gl.constexpr = (N_LIMIT // 2) if DO_SWIGLU else N_LIMIT
     else:
         actual_n = (N // 2) if DO_SWIGLU else N
+    if Y_N_CONST or N_LIMIT:
+        n_in_bounds = offs_y_n < ACTUAL_N
+    else:
+        n_in_bounds = offs_y_n < actual_n
+    # Clamp masked-off N lanes before pointer arithmetic; masked GPU
+    # memory ops may still fault on OOB addresses.
+    offs_y_n_safe = gl.where(n_in_bounds, offs_y_n, gl.zeros_like(offs_y_n))
     if HAS_SCATTER:
         rows_y = gl.load(scatter_idx_ptr + offs_y_m_safe, mask=y_m_in_bounds, other=M)
-        if Y_N_CONST or N_LIMIT:
-            mask_y = (rows_y[:, None] < M) & (offs_y_n[None, :] < ACTUAL_N)
-        else:
-            mask_y = (rows_y[:, None] < M) & (offs_y_n[None, :] < actual_n)
-        rows_y_safe = gl.where(y_m_in_bounds, rows_y, gl.zeros_like(rows_y))
-        y_offs = rows_y_safe[:, None] * stride_ym + offs_y_n[None, :] * stride_yn
+        rows_y_in_bounds = rows_y < M
+        mask_y = rows_y_in_bounds[:, None] & n_in_bounds[None, :]
+        rows_y_safe = gl.where(rows_y_in_bounds, rows_y, gl.zeros_like(rows_y))
+        y_offs = rows_y_safe[:, None] * stride_ym + offs_y_n_safe[None, :] * stride_yn
     else:
-        if Y_N_CONST or N_LIMIT:
-            mask_y = (offs_y_m[:, None] < m_limit) & (offs_y_n[None, :] < ACTUAL_N)
-        else:
-            mask_y = (offs_y_m[:, None] < m_limit) & (offs_y_n[None, :] < actual_n)
+        mask_y = y_m_in_bounds[:, None] & n_in_bounds[None, :]
         offs_y_m_2d_safe = offs_y_m_safe[:, None]
-        y_offs = offs_y_m_2d_safe * stride_ym + offs_y_n[None, :] * stride_yn
+        y_offs = offs_y_m_2d_safe * stride_ym + offs_y_n_safe[None, :] * stride_yn
 
     gl.store(y_ptr + y_offs, out, mask=mask_y)
 
@@ -7220,19 +7229,22 @@ def _warp_decode_stage2_reduce(
     pid_n = pid % num_n
     LAYOUT: gl.constexpr = gl.BlockedLayout([4], [64], [1], [0])
     n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=LAYOUT)
-    bound = (pid_m < M) & (n < N)
+    n_in_bounds = n < N
+    # Tail lanes are masked, but keep their addresses in-bounds for AMD/HIP.
+    n_safe = gl.where(n_in_bounds, n, gl.zeros_like(n))
+    bound = (pid_m < M) & n_in_bounds
     acc = gl.zeros([BLOCK_N], gl.float32, layout=LAYOUT)
     for k in gl.static_range(SPLIT_K):
         acc += gl.load(
             Partial
             + k * stride_pk
             + pid_m.to(gl.int64) * stride_pm
-            + n.to(gl.int64) * stride_pn,
+            + n_safe.to(gl.int64) * stride_pn,
             mask=bound,
             other=0.0,
         )
     gl.store(
-        Out + pid_m.to(gl.int64) * stride_om + n.to(gl.int64) * stride_on,
+        Out + pid_m.to(gl.int64) * stride_om + n_safe.to(gl.int64) * stride_on,
         acc.to(Out.dtype.element_ty),
         mask=bound,
     )

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
@@ -4150,7 +4150,7 @@ def _pipelined_moe_tile_compute(
     offs_y_n_safe = gl.where(n_in_bounds, offs_y_n, gl.zeros_like(offs_y_n))
     if HAS_SCATTER:
         rows_y = gl.load(scatter_idx_ptr + offs_y_m_safe, mask=y_m_in_bounds, other=M)
-        rows_y_in_bounds = rows_y < M
+        rows_y_in_bounds = y_m_in_bounds & (rows_y < M)
         mask_y = rows_y_in_bounds[:, None] & n_in_bounds[None, :]
         rows_y_safe = gl.where(rows_y_in_bounds, rows_y, gl.zeros_like(rows_y))
         y_offs = rows_y_safe[:, None] * stride_ym + offs_y_n_safe[None, :] * stride_yn
@@ -7229,22 +7229,19 @@ def _warp_decode_stage2_reduce(
     pid_n = pid % num_n
     LAYOUT: gl.constexpr = gl.BlockedLayout([4], [64], [1], [0])
     n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=LAYOUT)
-    n_in_bounds = n < N
-    # Tail lanes are masked, but keep their addresses in-bounds for AMD/HIP.
-    n_safe = gl.where(n_in_bounds, n, gl.zeros_like(n))
-    bound = (pid_m < M) & n_in_bounds
+    bound = (pid_m < M) & (n < N)
     acc = gl.zeros([BLOCK_N], gl.float32, layout=LAYOUT)
     for k in gl.static_range(SPLIT_K):
         acc += gl.load(
             Partial
             + k * stride_pk
             + pid_m.to(gl.int64) * stride_pm
-            + n_safe.to(gl.int64) * stride_pn,
+            + n.to(gl.int64) * stride_pn,
             mask=bound,
             other=0.0,
         )
     gl.store(
-        Out + pid_m.to(gl.int64) * stride_om + n_safe.to(gl.int64) * stride_on,
+        Out + pid_m.to(gl.int64) * stride_om + n.to(gl.int64) * stride_on,
         acc.to(Out.dtype.element_ty),
         mask=bound,
     )

--- a/tokenspeed-kernel/test/ops/moe/test_gluon_moe_gemm_gfx950.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gluon_moe_gemm_gfx950.py
@@ -398,10 +398,7 @@ def _make_preprocessed_weights(
         w13_weight=layer.w13_weight_triton_tensor,
         w2_weight=layer.w2_weight_triton_tensor,
         w13_bias=layer.w13_weight_bias,
-        # W2 preshuffle pads output N before the Gluon-specific shuffle.
-        # Keep combine bias out of this test so the same Triton reference is
-        # valid for both padded-preshuffle and unpadded LDS paths.
-        w2_bias=None,
+        w2_bias=layer.w2_weight_bias,
         w13_precision_config=layer.w13_precision_config,
         w2_precision_config=layer.w2_precision_config,
         w13_act_scale=layer.w13_act_scale,
@@ -416,6 +413,16 @@ def mxfp4_weights() -> Mxfp4WeightVariants:
         nonpreshuffled=_make_preprocessed_weights(raw_weights, preshuffle=False),
         preshuffled=_make_preprocessed_weights(raw_weights, preshuffle=True),
     )
+
+
+def test_gluon_preshuffle_keeps_w2_bias_logical_n(
+    mxfp4_weights: Mxfp4WeightVariants,
+) -> None:
+    w2_raw = gluon_moe._extract_gluon_raw_w(mxfp4_weights.preshuffled.w2_weight)
+    assert mxfp4_weights.preshuffled.w2_bias is not None
+    assert getattr(w2_raw, "original_n") == HIDDEN_SIZE
+    assert w2_raw.shape[-1] > HIDDEN_SIZE
+    assert mxfp4_weights.preshuffled.w2_bias.shape[-1] == HIDDEN_SIZE
 
 
 def _make_hidden_and_router(num_tokens: int) -> tuple[torch.Tensor, torch.Tensor]:


### PR DESCRIPTION
Preshuffled W2 pads the physical N dimension while combine outputs keep the logical N width. The Gluon epilogue masked logical-N tail lanes but still formed bias/store/reduce addresses with the padded N coordinates, which can fault on AMD even when the lanes are masked off.

Clamp masked-off N lanes before address formation and pad W2 bias together with W2 weight/scale during Gluon preprocessing. Keep the gfx950 preshuffle tests running with W2 bias enabled and assert the padded bias columns are zero.