### PR TITLE
fix(spec): remove V4 MTP special forward modes

### DIFF
--- a/python/tokenspeed/runtime/configs/model_config.py
+++ b/python/tokenspeed/runtime/configs/model_config.py
@@ -412,7 +412,7 @@ class ModelConfig:
         else:
             self.attention_arch = AttentionArch.MHA
 
-        self.use_target_verify_forward_mode = (
+        self.use_v4_mtp_paged_metadata = (
             getattr(server_args, "speculative_algorithm", None) is not None
             and not is_draft_worker
             and attention_family is not None

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -1059,10 +1059,6 @@ class EventLoop:
         forward_mode = ForwardMode.from_num_extends(
             forward_op.num_extends(),
             len(forward_op.request_ids),
-            has_drafter=self.server_args.speculative_algorithm is not None,
-            use_target_verify=(
-                self.model_executor.config.use_target_verify_forward_mode
-            ),
         )
         self.request_handler._profile_batch_predicate(forward_mode)
 
@@ -1152,10 +1148,6 @@ class EventLoop:
             forward_mode = ForwardMode.from_num_extends(
                 forward_op.num_extends(),
                 batch_size,
-                has_drafter=self.server_args.speculative_algorithm is not None,
-                use_target_verify=(
-                    self.model_executor.config.use_target_verify_forward_mode
-                ),
             )
 
         self._dp_local_info[0, 0] = num_tokens
@@ -1176,7 +1168,6 @@ class EventLoop:
             in (
                 int(ForwardMode.DECODE),
                 int(ForwardMode.IDLE),
-                int(ForwardMode.TARGET_VERIFY),
             )
             for mode in global_forward_mode
         )

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -61,16 +61,12 @@ def get_is_capture_mode() -> bool:
     return _is_capture_mode
 
 
-def _draft_decode_forward_mode(use_draft_extend: bool) -> ForwardMode:
-    return ForwardMode.DRAFT_EXTEND if use_draft_extend else ForwardMode.DECODE
-
-
 def _should_update_mamba_state_after_mtp_verify(
     drafter, attn_backend, forward_mode: ForwardMode
 ) -> bool:
     return (
         drafter is not None
-        and (forward_mode.is_decode() or forward_mode.is_target_verify())
+        and forward_mode.is_decode()
         and hasattr(attn_backend, "update_mamba_state_after_mtp_verify")
     )
 
@@ -234,7 +230,7 @@ class CudaGraphWrapper:
         self.max_tokens_per_req = (
             config.spec_num_tokens if config.spec_algo is not None else 1
         )
-        self.use_target_verify_forward_mode = config.use_target_verify_forward_mode
+        self.use_v4_mtp_paged_metadata = config.use_v4_mtp_paged_metadata
         self.dp_size = config.data_parallel_size
         self.world_size = config.world_size
         # Backends alias their cache_seqlens buffer. Draft backend aliases
@@ -330,11 +326,7 @@ class CudaGraphWrapper:
     def _capture_one(self, bs: int):
         graph = torch.cuda.CUDAGraph()
 
-        capture_forward_mode = (
-            ForwardMode.TARGET_VERIFY
-            if self.drafter is not None and self.use_target_verify_forward_mode
-            else ForwardMode.DECODE
-        )
+        capture_forward_mode = ForwardMode.DECODE
         ctx = ForwardContext(
             attn_backend=self.attn_backend,
             token_to_kv_pool=self.token_to_kv_pool,
@@ -503,15 +495,13 @@ class CudaGraphWrapper:
             and self.attn_backend.uses_paged_cache_groups
         ):
             capture_kwargs["paged_cache_block_tables"] = paged_cache_block_tables
+            if self.drafter is not None:
+                capture_kwargs["num_tokens"] = bs * self.max_tokens_per_req
         self.attn_backend.init_forward_metadata_capture_cuda_graph(
             bs,
             self.input_buffers.req_pool_indices_buf[:bs],
             self.input_buffers.seq_lens_buf[:bs],
-            (
-                ForwardMode.TARGET_VERIFY
-                if self.drafter is not None and self.use_target_verify_forward_mode
-                else ForwardMode.DECODE
-            ),
+            ForwardMode.DECODE,
             **capture_kwargs,
         )
         if self.draft_attn_backend is not None:
@@ -528,12 +518,13 @@ class CudaGraphWrapper:
                     draft_kwargs["paged_cache_block_tables"] = (
                         draft_paged_cache_block_tables
                     )
+                    draft_kwargs["num_tokens"] = bs * self.max_tokens_per_req
             # Drafter mutates seq_lens_buf in place per step; backends alias.
             self.draft_attn_backend.init_forward_metadata_capture_cuda_graph(
                 bs,
                 self.input_buffers.req_pool_indices_buf[:bs],
                 self.input_buffers.seq_lens_buf[:bs],
-                _draft_decode_forward_mode(self.use_target_verify_forward_mode),
+                ForwardMode.DECODE,
                 **draft_kwargs,
             )
 
@@ -642,7 +633,7 @@ class CudaGraphWrapper:
                     )
         if self.attn_backend.uses_padded_decode_token_mask:
             kwargs["actual_bs"] = actual_bs
-        if target_uses_paged_groups and forward_mode.is_speculative():
+        if target_uses_paged_groups and getattr(self, "drafter", None) is not None:
             kwargs["num_tokens"] = padded_bs * self.max_tokens_per_req
         self.attn_backend.init_forward_metadata_replay_cuda_graph(
             padded_bs,
@@ -662,10 +653,8 @@ class CudaGraphWrapper:
                     )
             if getattr(self.draft_attn_backend, "uses_padded_decode_token_mask", False):
                 draft_attn_kwargs["actual_bs"] = actual_bs
-            draft_forward_mode = _draft_decode_forward_mode(
-                self.use_target_verify_forward_mode
-            )
-            if draft_uses_paged_groups and draft_forward_mode.is_speculative():
+            draft_forward_mode = ForwardMode.DECODE
+            if draft_uses_paged_groups:
                 draft_attn_kwargs["num_tokens"] = padded_bs * self.max_tokens_per_req
             self.draft_attn_backend.init_forward_metadata_replay_cuda_graph(
                 padded_bs,
@@ -690,7 +679,8 @@ class CudaGraphWrapper:
         """Eager path — allocate/refresh metadata for the upcoming forward."""
         if (
             getattr(self.attn_backend, "uses_paged_cache_groups", False)
-            and forward_mode.is_speculative()
+            and self.drafter is not None
+            and forward_mode.is_decode()
         ):
             kwargs.setdefault("num_tokens", padded_bs * self.max_tokens_per_req)
         self.attn_backend.init_forward_metadata(
@@ -726,7 +716,7 @@ class CudaGraphWrapper:
                 # metadata, then a separate decode init to prepare the draft
                 # decode metadata from that first-step state.
                 draft_prefill_seq_lens = (
-                    seq_lens if self.use_target_verify_forward_mode else draft_seq_lens
+                    seq_lens if self.use_v4_mtp_paged_metadata else draft_seq_lens
                 )
                 self.draft_attn_backend.init_forward_metadata(
                     bs=padded_bs,
@@ -737,7 +727,7 @@ class CudaGraphWrapper:
                     forward_mode=forward_mode,
                     **kwargs,
                 )
-                if self.use_target_verify_forward_mode:
+                if self.use_v4_mtp_paged_metadata:
                     self.draft_attn_backend.init_forward_metadata(
                         bs=padded_bs,
                         num_extends=0,
@@ -749,15 +739,10 @@ class CudaGraphWrapper:
                     )
             else:
                 draft_metadata_seq_lens = (
-                    seq_lens if self.use_target_verify_forward_mode else draft_seq_lens
+                    seq_lens if self.use_v4_mtp_paged_metadata else draft_seq_lens
                 )
-                draft_forward_mode = _draft_decode_forward_mode(
-                    self.use_target_verify_forward_mode
-                )
-                if (
-                    getattr(self.draft_attn_backend, "uses_paged_cache_groups", False)
-                    and draft_forward_mode.is_speculative()
-                ):
+                draft_forward_mode = ForwardMode.DECODE
+                if getattr(self.draft_attn_backend, "uses_paged_cache_groups", False):
                     draft_kwargs["num_tokens"] = padded_bs * self.max_tokens_per_req
                 self.draft_attn_backend.init_forward_metadata(
                     bs=padded_bs,
@@ -778,7 +763,7 @@ class CudaGraphWrapper:
     def _can_use_graph(self, bs: int, ctx: ForwardContext) -> bool:
         if self.disable:
             return False
-        if not (ctx.forward_mode.is_decode() or ctx.forward_mode.is_target_verify()):
+        if not ctx.forward_mode.is_decode():
             return False
         if self.dp_size > 1:
             if not ctx.all_decode_or_idle:

--- a/python/tokenspeed/runtime/execution/drafter/eagle.py
+++ b/python/tokenspeed/runtime/execution/drafter/eagle.py
@@ -243,20 +243,14 @@ class Eagle(BaseDrafter):
             draft_input, bs, draft_input.input_num_tokens
         )
         input_ids = maybe_substitute_mm_pad(input_ids, self.mm_pad_substitute_id)
-        # Llama Eagle3 and Qwen3.5 NextN narrow for any non-idle catch-up
-        # (EXTEND/MIXED/TARGET_VERIFY/DECODE); DeepSeek keeps is_decode() only.
+        # Llama Eagle3 narrows for any non-idle catch-up; Qwen/DeepSeek
+        # keep is_decode() only.
         draft_first_step_reduce = forward_mode.is_decode() or (
             isinstance(
                 self.draft_model_runner.model,
                 (LlamaForCausalLMEagle3, Qwen3_5ForConditionalGenerationNextN),
             )
             and not forward_mode.is_idle()
-        )
-
-        draft_first_mode = (
-            ForwardMode.DRAFT_EXTEND
-            if forward_mode.is_target_verify()
-            else forward_mode
         )
 
         ctx = ForwardContext(
@@ -266,7 +260,7 @@ class Eagle(BaseDrafter):
             bs=bs,
             num_extends=draft_input.num_extends,
             input_num_tokens=draft_input.input_num_tokens,
-            forward_mode=draft_first_mode,
+            forward_mode=forward_mode,
             capture_hidden_mode=CaptureHiddenMode.LAST,
             gather_ids=gather_ids,
             global_num_tokens=draft_input.global_num_tokens,
@@ -457,9 +451,9 @@ class Eagle(BaseDrafter):
             return next_tokens
 
         if self.input_buffers.all_extends_mid_chunk and self.dp_size == 1:
-            # Skip multi-step when the whole batch is mid-chunk EXTEND: no
-            # request transitions to target_verify after this forward, so
-            # any speculative tokens we draft would be discarded.
+            # Skip multi-step when the whole batch is mid-chunk EXTEND:
+            # no request completes a target-side speculative verification
+            # after this forward, so any speculative tokens would be discarded.
             #
             # In DP we still run, because peer ranks may have completing
             # extends or decodes; diverging here would desync the drafter's

--- a/python/tokenspeed/runtime/execution/forward_batch_info.py
+++ b/python/tokenspeed/runtime/execution/forward_batch_info.py
@@ -39,10 +39,6 @@ class ForwardMode(IntEnum):
     MIXED = auto()
     # No sequence to forward; used for data parallel attention idle ranks.
     IDLE = auto()
-    # Used in speculative decoding: verify a batch in the target model.
-    TARGET_VERIFY = auto()
-    # Used in speculative decoding: extend a batch in the draft model.
-    DRAFT_EXTEND = auto()
 
     def is_extend(self):
         return self == ForwardMode.EXTEND
@@ -59,47 +55,17 @@ class ForwardMode(IntEnum):
     def is_extend_or_mixed(self):
         return self == ForwardMode.EXTEND or self == ForwardMode.MIXED
 
-    def is_target_verify(self):
-        return self == ForwardMode.TARGET_VERIFY
-
-    def is_draft_extend(self):
-        return self == ForwardMode.DRAFT_EXTEND
-
-    def is_speculative(self):
-        return self == ForwardMode.TARGET_VERIFY or self == ForwardMode.DRAFT_EXTEND
-
     def is_decode_or_idle(self):
         return self == ForwardMode.DECODE or self == ForwardMode.IDLE
 
     @staticmethod
-    def decode_or_target_verify(
-        *,
-        has_drafter: bool = False,
-        use_target_verify: bool = False,
-    ) -> "ForwardMode":
-        return (
-            ForwardMode.TARGET_VERIFY
-            if has_drafter and use_target_verify
-            else ForwardMode.DECODE
-        )
-
-    @staticmethod
-    def from_num_extends(
-        num_extends: int,
-        batch_size: int,
-        *,
-        has_drafter: bool = False,
-        use_target_verify: bool = False,
-    ) -> "ForwardMode":
+    def from_num_extends(num_extends: int, batch_size: int) -> "ForwardMode":
         if batch_size <= 0:
             return ForwardMode.IDLE
         elif num_extends > 0:
             return ForwardMode.MIXED if num_extends < batch_size else ForwardMode.EXTEND
         else:
-            return ForwardMode.decode_or_target_verify(
-                has_drafter=has_drafter,
-                use_target_verify=use_target_verify,
-            )
+            return ForwardMode.DECODE
 
 
 class CaptureHiddenMode(IntEnum):

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -124,7 +124,7 @@ class ModelExecutorConfig:
     spec_num_tokens: int | None = None
     dp_sampling: bool = False
     dp_sampling_min_bs: int | None = None
-    use_target_verify_forward_mode: bool = False
+    use_v4_mtp_paged_metadata: bool = False
 
     # ====== GRAMMAR =========
     # "none" disables all grammar handling; otherwise the backend name
@@ -179,7 +179,7 @@ class ModelExecutorConfig:
             dp_sampling=server_args.dp_sampling,
             dp_sampling_min_bs=server_args.dp_sampling_min_bs,
             enable_nan_detection=server_args.enable_nan_detection,
-            use_target_verify_forward_mode=model_config.use_target_verify_forward_mode,
+            use_v4_mtp_paged_metadata=model_config.use_v4_mtp_paged_metadata,
             grammar_backend=server_args.grammar_backend,
             disable_capturable_grammar=server_args.disable_capturable_grammar,
             mamba_cache_chunk_size=server_args.mamba_cache_chunk_size,
@@ -604,7 +604,7 @@ class ModelExecutor:
             or runtime.min_bs is None
             or runtime.topology is None
             or ctx.forward_mode is None
-            or not (ctx.forward_mode.is_decode() or ctx.forward_mode.is_target_verify())
+            or not ctx.forward_mode.is_decode()
         ):
             return
 
@@ -650,9 +650,7 @@ class ModelExecutor:
         # attention/MoE. Rejoined at wait_bitmask() before apply_mask.
         if self.capturable_grammar is not None:
             n = self.capturable_grammar.max_tokens_per_req
-            is_spec_verify = n > 1 and (
-                ctx.forward_mode.is_decode() or ctx.forward_mode.is_target_verify()
-            )
+            is_spec_verify = n > 1 and ctx.forward_mode.is_decode()
             slice_ = (
                 self.input_buffers.input_ids_buf[: bs * n] if is_spec_verify else None
             )
@@ -1056,10 +1054,7 @@ class ModelExecutor:
         ranks do. The MoE all-to-all is a collective that requires ALL
         ranks to participate.
         """
-        graph_forward_mode = ForwardMode.decode_or_target_verify(
-            has_drafter=self.drafter is not None,
-            use_target_verify=self.config.use_target_verify_forward_mode,
-        )
+        graph_forward_mode = ForwardMode.DECODE
         ctx = ForwardContext(
             attn_backend=self.attn_backend,
             token_to_kv_pool=self.token_to_kv_pool,
@@ -1401,12 +1396,7 @@ class ModelExecutor:
             if timing_enabled:
                 mrope_ms = (time.perf_counter() - mrope_start) * 1000.0
 
-            forward_mode = ForwardMode.from_num_extends(
-                num_extends,
-                bs,
-                has_drafter=self.drafter is not None,
-                use_target_verify=self.config.use_target_verify_forward_mode,
-            )
+            forward_mode = ForwardMode.from_num_extends(num_extends, bs)
 
             if num_extends <= 0:
                 self._prev_decode_bs = bs

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -331,6 +331,22 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         extend_prefix_lens: torch.Tensor | None,
     ) -> torch.Tensor:
         if forward_mode is not None and forward_mode.is_decode_or_idle():
+            if forward_mode.is_decode() and num_tokens != bs:
+                if bs == 0:
+                    return torch.zeros(0, dtype=torch.int32, device=seq_lens.device)
+                if num_tokens % bs != 0:
+                    raise RuntimeError(
+                        "DeepSeek V4 packed decode metadata expects uniformly "
+                        f"packed tokens per request, got num_tokens={num_tokens}, "
+                        f"bs={bs}"
+                    )
+                tokens_per_req = num_tokens // bs
+                return torch.full(
+                    (bs,),
+                    tokens_per_req,
+                    dtype=torch.int32,
+                    device=seq_lens.device,
+                )
             return torch.ones(bs, dtype=torch.int32, device=seq_lens.device)
         if forward_mode is not None and forward_mode.is_mixed():
             lens = torch.ones(bs, dtype=torch.int32, device=seq_lens.device)
@@ -356,21 +372,6 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             else:
                 lens[:num_prefill_reqs] = seq_lens[:num_prefill_reqs].to(torch.int32)
             return lens
-        if forward_mode is not None and forward_mode.is_speculative():
-            if bs == 0:
-                return torch.zeros(0, dtype=torch.int32, device=seq_lens.device)
-            if num_tokens % bs != 0:
-                raise RuntimeError(
-                    "DeepSeek V4 speculative metadata expects uniformly packed "
-                    f"tokens per request, got num_tokens={num_tokens}, bs={bs}"
-                )
-            tokens_per_req = num_tokens // bs
-            return torch.full(
-                (bs,),
-                tokens_per_req,
-                dtype=torch.int32,
-                device=seq_lens.device,
-            )
         if extend_seq_lens_cpu is not None:
             return extend_seq_lens_cpu[:bs].to(seq_lens.device, dtype=torch.int32)
         if extend_prefix_lens_cpu is not None:
@@ -552,11 +553,6 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             num_tokens = int(num_tokens_arg)
         elif isinstance(positions, torch.Tensor):
             num_tokens = int(positions.numel())
-        elif forward_mode is not None and forward_mode.is_speculative():
-            raise RuntimeError(
-                "DeepSeek V4 speculative metadata requires explicit num_tokens "
-                "or positions"
-            )
         else:
             num_tokens = bs
         del kwargs
@@ -573,11 +569,11 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             extend_prefix_lens_cpu,
             extend_prefix_lens,
         )
-        is_spec = forward_mode is not None and forward_mode.is_speculative()
-        metadata_forward_mode = ForwardMode.DECODE if is_spec else forward_mode
-        if is_spec:
-            num_prefill_reqs = 0
-        elif forward_mode is not None and forward_mode.is_mixed():
+        is_packed_decode = (
+            forward_mode is not None and forward_mode.is_decode() and num_tokens != bs
+        )
+        metadata_forward_mode = forward_mode
+        if forward_mode is not None and forward_mode.is_mixed():
             num_prefill_reqs = max(0, min(num_extends, bs))
         elif forward_mode is not None and forward_mode.is_extend_or_mixed():
             num_prefill_reqs = bs
@@ -618,12 +614,10 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             elif forward_mode.is_mixed():
                 seq_lens_cpu = seq_lens[:bs].to(dtype=torch.int32, device="cpu")
         max_seq_len = int(seq_lens.max().item()) if bs else 0
-        if forward_mode is not None and (
-            forward_mode.is_extend()
-            or forward_mode.is_target_verify()
-            or forward_mode.is_draft_extend()
-        ):
+        if forward_mode is not None and forward_mode.is_extend():
             max_seq_len += max(self.speculative_num_steps - 1, 0)
+        if is_packed_decode:
+            max_seq_len += max(int(query_lens.max().item()) - 1, 0)
         max_pages = (max_seq_len + self.page_size - 1) // self.page_size
         if req_to_page is None:
             block_table = torch.zeros(
@@ -693,9 +687,9 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             num_prefill_tokens=num_prefill_tokens,
             forward_mode=metadata_forward_mode,
         )
-        if is_spec:
+        if is_packed_decode:
             self.forward_decode_metadata = self.forward_metadata
-            if forward_mode is not None and forward_mode.is_draft_extend():
+            if getattr(self, "is_draft", False):
                 self._prepare_draft_decode_metadata(
                     self.forward_metadata,
                     seq_lens.clone(),
@@ -1741,19 +1735,19 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         num_tokens: int,
         forward_mode: Optional[ForwardMode],
     ) -> int:
-        if forward_mode is not None and forward_mode.is_speculative():
+        if num_tokens != bs:
             if bs == 0:
                 return self._cuda_graph_max_tokens_per_req
             if num_tokens % bs != 0:
                 raise RuntimeError(
-                    "DeepSeek V4 speculative CUDA graph metadata expects "
-                    f"uniformly packed tokens per request, got "
-                    f"num_tokens={num_tokens}, bs={bs}"
+                    "DeepSeek V4 packed CUDA graph metadata expects uniformly "
+                    f"packed tokens per request, got num_tokens={num_tokens}, "
+                    f"bs={bs}"
                 )
             tokens_per_req = num_tokens // bs
             if tokens_per_req > self._cuda_graph_max_tokens_per_req:
                 raise RuntimeError(
-                    "DeepSeek V4 speculative CUDA graph metadata was initialized "
+                    "DeepSeek V4 packed CUDA graph metadata was initialized "
                     f"for at most {self._cuda_graph_max_tokens_per_req} tokens "
                     f"per request, got {tokens_per_req}"
                 )
@@ -1800,37 +1794,32 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         )
         num_tokens_arg = kwargs.pop("num_tokens", None)
         del kwargs
-        if forward_mode is not None and not (
-            forward_mode.is_decode_or_idle()
-            or forward_mode.is_target_verify()
-            or forward_mode.is_draft_extend()
-        ):
+        if forward_mode is not None and not forward_mode.is_decode_or_idle():
             raise NotImplementedError(
                 f"DeepSeek V4 CUDA graph capture not supported for {forward_mode}"
             )
         if num_tokens_arg is None:
-            if forward_mode is not None and forward_mode.is_speculative():
-                num_tokens = bs * self._cuda_graph_max_tokens_per_req
-            else:
-                num_tokens = bs
+            num_tokens = bs
         else:
             num_tokens = int(num_tokens_arg)
         tokens_per_req = self._cuda_graph_tokens_per_req(bs, num_tokens, forward_mode)
+        is_packed_decode = (
+            forward_mode is not None and forward_mode.is_decode() and num_tokens != bs
+        )
         total_tokens = self._refresh_cuda_graph_packed_metadata(
             bs=bs,
             actual_bs=bs,
             tokens_per_req=tokens_per_req,
         )
-        is_spec = forward_mode is not None and forward_mode.is_speculative()
         capture_seq_lens = seq_lens[:bs].to(torch.int32)
-        if is_spec:
+        if is_packed_decode:
             capture_seq_lens = torch.maximum(
                 capture_seq_lens,
                 torch.full_like(capture_seq_lens, tokens_per_req),
             )
         self._cuda_graph_req_pool_indices[:bs].copy_(req_pool_indices[:bs])
         self._cuda_graph_seq_lens[:bs].copy_(capture_seq_lens)
-        metadata_forward_mode = ForwardMode.DECODE if is_spec else forward_mode
+        metadata_forward_mode = forward_mode
         is_decode = (
             metadata_forward_mode is not None and metadata_forward_mode.is_decode()
         )
@@ -1906,7 +1895,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             metadata.query_lens_cpu = None
             metadata.forward_mode = metadata_forward_mode
         self._cuda_graph_metadata[bs] = metadata
-        if forward_mode is not None and forward_mode.is_draft_extend():
+        if is_packed_decode and getattr(self, "is_draft", False):
             self._prepare_draft_decode_metadata(
                 metadata,
                 self._cuda_graph_seq_lens[:bs],
@@ -1931,24 +1920,18 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         actual_bs = max(0, min(int(kwargs.pop("actual_bs", bs)), bs))
         num_tokens_arg = kwargs.pop("num_tokens", None)
         del kwargs
-        if forward_mode is not None and not (
-            forward_mode.is_decode_or_idle()
-            or forward_mode.is_target_verify()
-            or forward_mode.is_draft_extend()
-        ):
+        if forward_mode is not None and not forward_mode.is_decode_or_idle():
             raise NotImplementedError(
                 f"DeepSeek V4 CUDA graph replay not supported for {forward_mode}"
             )
         if num_tokens_arg is None:
-            if forward_mode is not None and forward_mode.is_speculative():
-                raise RuntimeError(
-                    "DeepSeek V4 speculative CUDA graph replay requires "
-                    "explicit num_tokens"
-                )
             num_tokens = bs
         else:
             num_tokens = int(num_tokens_arg)
         tokens_per_req = self._cuda_graph_tokens_per_req(bs, num_tokens, forward_mode)
+        is_packed_decode = (
+            forward_mode is not None and forward_mode.is_decode() and num_tokens != bs
+        )
         total_tokens = self._refresh_cuda_graph_packed_metadata(
             bs=bs,
             actual_bs=actual_bs,
@@ -1988,8 +1971,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             metadata_paged,
             metadata_base_offsets,
         )
-        is_spec = forward_mode is not None and forward_mode.is_speculative()
-        metadata_forward_mode = ForwardMode.DECODE if is_spec else forward_mode
+        metadata_forward_mode = forward_mode
         is_decode = (
             metadata_forward_mode is not None and metadata_forward_mode.is_decode()
         )
@@ -2013,7 +1995,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         )
         metadata.num_prefill_reqs = 0
         metadata.num_prefill_tokens = 0
-        if forward_mode is not None and forward_mode.is_draft_extend():
+        if is_packed_decode and getattr(self, "is_draft", False):
             self._prepare_draft_decode_metadata(
                 metadata,
                 self._cuda_graph_seq_lens[:bs],

--- a/python/tokenspeed/runtime/layers/attention/backends/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/dsa.py
@@ -354,15 +354,12 @@ class DSABackend(AttentionBackend):
         spec_info=None,
         **kwargs,
     ):
-        dense_forward_mode = (
-            ForwardMode.DECODE if forward_mode.is_target_verify() else forward_mode
-        )
         out = self._dense_backend.init_forward_metadata(
             bs=bs,
             num_extends=num_extends,
             req_pool_indices=req_pool_indices,
             seq_lens=seq_lens,
-            forward_mode=dense_forward_mode,
+            forward_mode=forward_mode,
             req_to_page=req_to_page,
             spec_info=spec_info,
             **kwargs,

--- a/python/tokenspeed/runtime/layers/logits_processor.py
+++ b/python/tokenspeed/runtime/layers/logits_processor.py
@@ -249,10 +249,7 @@ class LogitsProcessor(nn.Module):
     ) -> LogitsLayoutPlan | None:
         if not self.dp_sampling_enabled:
             return None
-        if not (
-            logits_metadata.forward_mode.is_decode()
-            or logits_metadata.forward_mode.is_target_verify()
-        ):
+        if not logits_metadata.forward_mode.is_decode():
             return None
         n = self.dp_num_tokens_per_req
         rows = hidden_states.shape[0]

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -164,35 +164,31 @@ def _deepseek_v4_indexer_token_split(
 ) -> tuple[int, int]:
     if forward_mode is not None and forward_mode.is_mixed():
         return int(metadata.num_prefill_tokens), metadata.decode_token_count()
-    if forward_mode is not None and (
-        forward_mode.is_decode()
-        or forward_mode.is_target_verify()
-        or forward_mode.is_draft_extend()
-    ):
+    if forward_mode is not None and forward_mode.is_decode():
         return 0, int(total_tokens)
     return int(total_tokens), 0
 
 
 def _deepseek_v4_forward_metadata(ctx: ForwardContext):
     metadata = getattr(ctx.attn_backend, "forward_metadata", None)
-    if ctx.forward_mode == ForwardMode.EXTEND:
+    forward_mode = getattr(ctx, "forward_mode", None)
+    if forward_mode == ForwardMode.EXTEND:
         return getattr(ctx.attn_backend, "forward_prefill_metadata", None) or metadata
-    if ctx.forward_mode is not None and ctx.forward_mode.is_draft_extend():
-        prefill_metadata = getattr(ctx.attn_backend, "forward_prefill_metadata", None)
-        if _deepseek_v4_metadata_matches_tokens(
-            prefill_metadata,
-            ctx.input_num_tokens,
-        ):
-            return prefill_metadata
-        return metadata or prefill_metadata
-    if ctx.forward_mode is not None and ctx.forward_mode.is_decode_or_idle():
+    if forward_mode is not None and forward_mode.is_decode_or_idle():
+        input_num_tokens = getattr(ctx, "input_num_tokens", None)
         decode_metadata = getattr(ctx.attn_backend, "forward_decode_metadata", None)
-        if _deepseek_v4_metadata_matches_tokens(
+        if input_num_tokens is not None and _deepseek_v4_metadata_matches_tokens(
             decode_metadata,
-            ctx.input_num_tokens,
+            input_num_tokens,
         ):
             return decode_metadata
-        return decode_metadata or metadata
+        prefill_metadata = getattr(ctx.attn_backend, "forward_prefill_metadata", None)
+        if input_num_tokens is not None and _deepseek_v4_metadata_matches_tokens(
+            prefill_metadata,
+            input_num_tokens,
+        ):
+            return prefill_metadata
+        return decode_metadata or metadata or prefill_metadata
     return metadata
 
 
@@ -2966,11 +2962,7 @@ class DeepseekV4Indexer(nn.Module):
         if forward_mode is not None and forward_mode.is_mixed():
             num_prefill_tokens = int(metadata.num_prefill_tokens)
             num_decode_tokens = metadata.decode_token_count()
-        elif forward_mode is not None and (
-            forward_mode.is_decode()
-            or forward_mode.is_target_verify()
-            or forward_mode.is_draft_extend()
-        ):
+        elif forward_mode is not None and forward_mode.is_decode():
             num_prefill_tokens = 0
             num_decode_tokens = positions.numel()
         else:
@@ -3695,7 +3687,7 @@ class DeepseekV4Attention(nn.Module):
                     attn_sink=self.attn_sink,
                     topk_indices=topk_indices,
                 )
-        elif forward_mode.is_decode() or forward_mode.is_speculative():
+        elif forward_mode.is_decode():
             with nvtx_range(f"{profile_prefix}_decode_backend"):
                 attn_output = ctx.attn_backend.forward_deepseek_v4_decode(
                     q=q,

--- a/python/tokenspeed/runtime/models/glm5.py
+++ b/python/tokenspeed/runtime/models/glm5.py
@@ -113,19 +113,12 @@ class GlmDsaDecodeWindow:
 
 def _glm_dsa_is_decode_token_mode(forward_mode: ForwardMode | None) -> bool:
     return forward_mode is not None and (
-        forward_mode.is_decode()
-        or forward_mode.is_mixed()
-        or forward_mode.is_target_verify()
-        or forward_mode.is_draft_extend()
+        forward_mode.is_decode() or forward_mode.is_mixed()
     )
 
 
 def _glm_dsa_is_pure_decode_token_mode(forward_mode: ForwardMode | None) -> bool:
-    return forward_mode is not None and (
-        forward_mode.is_decode()
-        or forward_mode.is_target_verify()
-        or forward_mode.is_draft_extend()
-    )
+    return forward_mode is not None and forward_mode.is_decode()
 
 
 def _glm_dsa_skip_indexer_topk(config, layer_id: int | None) -> bool:
@@ -873,7 +866,8 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
         draft_catchup = bool(
             getattr(ctx.attn_backend, "is_draft", False)
             and ctx.forward_mode is not None
-            and ctx.forward_mode.is_draft_extend()
+            and ctx.forward_mode.is_decode()
+            and decode_window.q_len_per_req > 1
         )
         seq_lens_per_token = self._expand_decode_seq_lens_per_token(
             seq_lens,
@@ -984,7 +978,8 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
         draft_catchup = bool(
             getattr(ctx.attn_backend, "is_draft", False)
             and ctx.forward_mode is not None
-            and ctx.forward_mode.is_draft_extend()
+            and ctx.forward_mode.is_decode()
+            and decode_window.q_len_per_req > 1
         )
         seq_lens_per_token = self._expand_decode_seq_lens_per_token(
             seq_lens,

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -44,7 +44,6 @@ from tokenspeed.runtime.configs.model_config import (
 from tokenspeed.runtime.distributed import Mapping
 from tokenspeed.runtime.execution.cuda_graph_wrapper import (
     CudaGraphWrapper,
-    _draft_decode_forward_mode,
     _should_update_mamba_state_after_mtp_verify,
 )
 from tokenspeed.runtime.execution.drafter.eagle import (
@@ -277,42 +276,13 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertTrue(ForwardMode.EXTEND.is_extend_or_mixed())
         self.assertTrue(ForwardMode.MIXED.is_extend_or_mixed())
         self.assertFalse(ForwardMode.DECODE.is_extend_or_mixed())
-        self.assertFalse(ForwardMode.TARGET_VERIFY.is_extend_or_mixed())
-        self.assertTrue(ForwardMode.TARGET_VERIFY.is_target_verify())
-        self.assertTrue(ForwardMode.DRAFT_EXTEND.is_draft_extend())
         self.assertTrue(ForwardMode.DECODE.is_decode_or_idle())
         self.assertTrue(ForwardMode.IDLE.is_decode_or_idle())
         self.assertFalse(ForwardMode.EXTEND.is_decode_or_idle())
-        self.assertFalse(ForwardMode.TARGET_VERIFY.is_decode_or_idle())
-        self.assertTrue(ForwardMode.TARGET_VERIFY.is_speculative())
-        self.assertTrue(ForwardMode.DRAFT_EXTEND.is_speculative())
-        self.assertFalse(ForwardMode.DECODE.is_speculative())
-        self.assertFalse(ForwardMode.EXTEND.is_speculative())
-        self.assertFalse(ForwardMode.MIXED.is_speculative())
         self.assertEqual(ForwardMode.from_num_extends(0, 0), ForwardMode.IDLE)
         self.assertEqual(ForwardMode.from_num_extends(0, 2), ForwardMode.DECODE)
-        self.assertEqual(
-            ForwardMode.from_num_extends(0, 2, has_drafter=True),
-            ForwardMode.DECODE,
-        )
-        self.assertEqual(
-            ForwardMode.from_num_extends(
-                0, 2, has_drafter=True, use_target_verify=True
-            ),
-            ForwardMode.TARGET_VERIFY,
-        )
         self.assertEqual(ForwardMode.from_num_extends(2, 2), ForwardMode.EXTEND)
         self.assertEqual(ForwardMode.from_num_extends(1, 2), ForwardMode.MIXED)
-        self.assertEqual(
-            ForwardMode.decode_or_target_verify(has_drafter=True),
-            ForwardMode.DECODE,
-        )
-        self.assertEqual(
-            ForwardMode.decode_or_target_verify(
-                has_drafter=True, use_target_verify=True
-            ),
-            ForwardMode.TARGET_VERIFY,
-        )
 
     def test_model_runner_forwards_supported_spec_step_idx(self):
         class ModelWithSpecStep:
@@ -425,19 +395,12 @@ class TestDeepseekV4Config(unittest.TestCase):
             _deepseek_v4_indexer_token_split(ForwardMode.EXTEND, metadata, 5),
             (5, 0),
         )
-        for mode in (
-            ForwardMode.DECODE,
-            ForwardMode.TARGET_VERIFY,
-            ForwardMode.DRAFT_EXTEND,
-        ):
-            self.assertEqual(
-                _deepseek_v4_indexer_token_split(mode, metadata, 5), (0, 5)
-            )
+        self.assertEqual(
+            _deepseek_v4_indexer_token_split(ForwardMode.DECODE, metadata, 5),
+            (0, 5),
+        )
 
     def test_spec_helpers_preserve_non_v4_backend_contracts(self):
-        self.assertEqual(_draft_decode_forward_mode(False), ForwardMode.DECODE)
-        self.assertEqual(_draft_decode_forward_mode(True), ForwardMode.DRAFT_EXTEND)
-
         seq_lens = object()
         calls = []
 
@@ -762,7 +725,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             req_to_page=torch.zeros((1, 1), dtype=torch.int32)
         )
         wrapper.max_tokens_per_req = 4
-        wrapper.use_target_verify_forward_mode = True
+        wrapper.use_v4_mtp_paged_metadata = True
 
         table = torch.tensor([[7], [8]], dtype=torch.int32)
         offsets = {"v4.swa": torch.tensor([1, 2], dtype=torch.int64)}
@@ -772,7 +735,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             req_pool_indices=torch.zeros(4, dtype=torch.int32),
             seq_lens=torch.ones(4, dtype=torch.int32),
             req_to_page=torch.zeros((1, 1), dtype=torch.int32),
-            forward_mode=ForwardMode.TARGET_VERIFY,
+            forward_mode=ForwardMode.DECODE,
             paged_cache_block_tables={"v4.swa": table},
             paged_cache_block_table_base_offsets=offsets,
         )
@@ -786,7 +749,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             draft_kwargs["paged_cache_block_table_base_offsets"]["v4.swa"].tolist(),
             [1, 2, 0, 0],
         )
-        self.assertEqual(draft_kwargs["forward_mode"], ForwardMode.DRAFT_EXTEND)
+        self.assertEqual(draft_kwargs["forward_mode"], ForwardMode.DECODE)
 
     def test_cuda_graph_mamba_verify_state_update_keeps_decode_mode_speculation(self):
         class BackendWithMambaUpdate:
@@ -799,11 +762,6 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertTrue(
             _should_update_mamba_state_after_mtp_verify(
                 drafter, backend, ForwardMode.DECODE
-            )
-        )
-        self.assertTrue(
-            _should_update_mamba_state_after_mtp_verify(
-                drafter, backend, ForwardMode.TARGET_VERIFY
             )
         )
         self.assertFalse(
@@ -822,7 +780,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
         )
 
-    def test_cuda_graph_eager_draft_extend_uses_single_non_v4_metadata_init(self):
+    def test_cuda_graph_eager_draft_prefill_uses_single_non_v4_metadata_init(self):
         captured = {"target": [], "draft": []}
 
         class FakeBackend:
@@ -842,7 +800,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             req_to_page=torch.zeros((1, 1), dtype=torch.int32),
             draft_seq_lens_buf=torch.tensor([0, 0], dtype=torch.int32),
         )
-        wrapper.use_target_verify_forward_mode = False
+        wrapper.use_v4_mtp_paged_metadata = False
 
         seq_lens = torch.tensor([21, 22], dtype=torch.int32)
         wrapper._init_forward_metadata(
@@ -886,7 +844,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
 
         seq_lens = torch.tensor([21, 22], dtype=torch.int32)
-        wrapper.use_target_verify_forward_mode = False
+        wrapper.use_v4_mtp_paged_metadata = False
         wrapper._init_forward_metadata(
             padded_bs=2,
             num_extends=0,
@@ -903,19 +861,19 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
         self.assertEqual(non_v4_kwargs["forward_mode"], ForwardMode.DECODE)
 
-        wrapper.use_target_verify_forward_mode = True
+        wrapper.use_v4_mtp_paged_metadata = True
         wrapper._init_forward_metadata(
             padded_bs=2,
             num_extends=0,
             req_pool_indices=torch.zeros(2, dtype=torch.int32),
             seq_lens=seq_lens,
             req_to_page=torch.zeros((1, 1), dtype=torch.int32),
-            forward_mode=ForwardMode.TARGET_VERIFY,
+            forward_mode=ForwardMode.DECODE,
         )
 
         _, v4_kwargs = captured["draft"][-1]
         self.assertEqual(v4_kwargs["seq_lens"].data_ptr(), seq_lens.data_ptr())
-        self.assertEqual(v4_kwargs["forward_mode"], ForwardMode.DRAFT_EXTEND)
+        self.assertEqual(v4_kwargs["forward_mode"], ForwardMode.DECODE)
 
     def test_deepseek_v4_tokenizer_wrapper_uses_model_encoder(self):
         calls = []
@@ -2406,7 +2364,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             num_tokens=8,
             req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
             seq_lens=torch.tensor([70, 3], dtype=torch.int32),
-            forward_mode=ForwardMode.TARGET_VERIFY,
+            forward_mode=ForwardMode.DECODE,
             req_to_page=torch.tensor([[10, 11], [20, 21]], dtype=torch.int32),
         )
         self.assertTrue(
@@ -2420,17 +2378,38 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertEqual(backend.forward_metadata.decode_req_count(), 2)
         self.assertEqual(backend.forward_metadata.decode_token_count(), 8)
 
-        backend.init_forward_metadata(
+        draft_backend = DeepseekV4AttentionBackend(
+            SimpleNamespace(
+                page_size=64,
+                device="cpu",
+                num_attention_heads=64,
+                num_kv_heads=1,
+                attn_tp_size=1,
+                dtype=torch.bfloat16,
+                is_draft=True,
+                head_dim=512,
+                context_len=4096,
+                speculative_num_draft_tokens=4,
+            )
+        )
+        draft_backend.init_forward_metadata(
             bs=2,
             num_tokens=8,
             req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
             seq_lens=torch.tensor([70, 3], dtype=torch.int32),
-            forward_mode=ForwardMode.DRAFT_EXTEND,
+            forward_mode=ForwardMode.DECODE,
             req_to_page=torch.tensor([[10, 11], [20, 21]], dtype=torch.int32),
         )
-        self.assertEqual(backend.forward_metadata.forward_mode, ForwardMode.DECODE)
-        self.assertIs(backend.forward_prefill_metadata, backend.forward_metadata)
-        self.assertIs(backend.forward_decode_metadata, backend.forward_metadata)
+        self.assertEqual(
+            draft_backend.forward_metadata.forward_mode, ForwardMode.DECODE
+        )
+        self.assertIs(
+            draft_backend.forward_prefill_metadata,
+            draft_backend.forward_metadata,
+        )
+        self.assertIs(
+            draft_backend.forward_decode_metadata, draft_backend.forward_metadata
+        )
 
         with self.assertRaisesRegex(RuntimeError, "uniformly packed"):
             backend.init_forward_metadata(
@@ -2438,11 +2417,11 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_tokens=7,
                 req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
                 seq_lens=torch.tensor([70, 3], dtype=torch.int32),
-                forward_mode=ForwardMode.TARGET_VERIFY,
+                forward_mode=ForwardMode.DECODE,
                 req_to_page=torch.tensor([[10, 11], [20, 21]], dtype=torch.int32),
             )
 
-    def test_deepseek_v4_spec_metadata_requires_explicit_token_count(self):
+    def test_deepseek_v4_decode_metadata_defaults_to_one_token(self):
         backend = DeepseekV4AttentionBackend(
             SimpleNamespace(
                 page_size=64,
@@ -2458,14 +2437,22 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
         )
 
-        with self.assertRaisesRegex(RuntimeError, "requires explicit num_tokens"):
-            backend.init_forward_metadata(
-                bs=2,
-                req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
-                seq_lens=torch.tensor([70, 3], dtype=torch.int32),
-                forward_mode=ForwardMode.TARGET_VERIFY,
-                req_to_page=torch.tensor([[10, 11], [20, 21]], dtype=torch.int32),
+        backend.init_forward_metadata(
+            bs=2,
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+            seq_lens=torch.tensor([70, 3], dtype=torch.int32),
+            forward_mode=ForwardMode.DECODE,
+            req_to_page=torch.tensor([[10, 11], [20, 21]], dtype=torch.int32),
+        )
+
+        self.assertTrue(
+            torch.equal(
+                backend.forward_metadata.query_lens,
+                torch.tensor([1, 1], dtype=torch.int32),
             )
+        )
+        self.assertEqual(backend.forward_metadata.forward_mode, ForwardMode.DECODE)
+        self.assertEqual(backend.forward_metadata.decode_token_count(), 2)
 
     def test_deepseek_v4_select_decode_metadata_ignores_prefill_fallback(self):
         backend = DeepseekV4AttentionBackend(
@@ -2512,7 +2499,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         backend.forward_decode_metadata = decode_metadata
         self.assertIs(backend._select_decode_metadata(8), decode_metadata)
 
-    def test_deepseek_v4_cuda_graph_replay_requires_explicit_spec_token_count(self):
+    def test_deepseek_v4_cuda_graph_replay_without_num_tokens_uses_plain_decode(self):
         backend = DeepseekV4AttentionBackend(
             SimpleNamespace(
                 page_size=64,
@@ -2533,16 +2520,23 @@ class TestDeepseekV4Config(unittest.TestCase):
             num_tokens=8,
             req_pool_indices=torch.tensor([0, 1], dtype=torch.int32),
             seq_lens=torch.tensor([70, 3], dtype=torch.int32),
-            forward_mode=ForwardMode.TARGET_VERIFY,
+            forward_mode=ForwardMode.DECODE,
         )
 
-        with self.assertRaisesRegex(RuntimeError, "requires explicit num_tokens"):
-            backend.init_forward_metadata_replay_cuda_graph(
-                bs=2,
-                req_pool_indices=torch.tensor([0, 1], dtype=torch.int32),
-                seq_lens=torch.tensor([70, 3], dtype=torch.int32),
-                forward_mode=ForwardMode.TARGET_VERIFY,
+        backend.init_forward_metadata_replay_cuda_graph(
+            bs=2,
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int32),
+            seq_lens=torch.tensor([70, 3], dtype=torch.int32),
+            forward_mode=ForwardMode.DECODE,
+        )
+
+        self.assertTrue(
+            torch.equal(
+                backend.forward_metadata.query_lens,
+                torch.tensor([1, 1], dtype=torch.int32),
             )
+        )
+        self.assertEqual(backend.forward_metadata.decode_token_count(), 2)
 
     def test_deepseek_v4_decode_backend_maps_compressed_slots_batched(self):
         backend = DeepseekV4AttentionBackend(
@@ -3049,7 +3043,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
         )
 
-    def test_deepseek_v4_cuda_graph_target_verify_uses_packed_decode_metadata(self):
+    def test_deepseek_v4_cuda_graph_decode_uses_packed_metadata(self):
         backend = DeepseekV4AttentionBackend(
             SimpleNamespace(
                 page_size=64,
@@ -3070,7 +3064,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             num_tokens=16,
             req_pool_indices=torch.arange(4, dtype=torch.int32),
             seq_lens=torch.ones(4, dtype=torch.int32),
-            forward_mode=ForwardMode.TARGET_VERIFY,
+            forward_mode=ForwardMode.DECODE,
         )
 
         metadata = backend.forward_metadata
@@ -3104,7 +3098,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             num_tokens=16,
             req_pool_indices=torch.arange(4, dtype=torch.int32),
             seq_lens=torch.tensor([70, 3, 1, 1], dtype=torch.int32),
-            forward_mode=ForwardMode.TARGET_VERIFY,
+            forward_mode=ForwardMode.DECODE,
             req_to_page=torch.tensor(
                 [
                     [10, 11],
@@ -3130,7 +3124,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertEqual(metadata.decode_req_count(), 4)
         self.assertEqual(metadata.decode_token_count(), 16)
 
-    def test_deepseek_v4_cuda_graph_draft_extend_advances_decode_metadata(self):
+    def test_deepseek_v4_cuda_graph_packed_draft_decode_advances_metadata(self):
         backend = DeepseekV4AttentionBackend(
             SimpleNamespace(
                 page_size=64,
@@ -3139,7 +3133,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_kv_heads=1,
                 attn_tp_size=1,
                 dtype=torch.bfloat16,
-                is_draft=False,
+                is_draft=True,
                 head_dim=512,
                 context_len=128,
                 speculative_num_draft_tokens=4,
@@ -3151,7 +3145,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             num_tokens=16,
             req_pool_indices=torch.arange(4, dtype=torch.int32),
             seq_lens=torch.ones(4, dtype=torch.int32),
-            forward_mode=ForwardMode.DRAFT_EXTEND,
+            forward_mode=ForwardMode.DECODE,
         )
         backend.init_forward_metadata_replay_cuda_graph(
             bs=4,
@@ -3159,7 +3153,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             num_tokens=16,
             req_pool_indices=torch.arange(4, dtype=torch.int32),
             seq_lens=torch.tensor([70, 3, 1, 1], dtype=torch.int32),
-            forward_mode=ForwardMode.DRAFT_EXTEND,
+            forward_mode=ForwardMode.DECODE,
             req_to_page=torch.tensor(
                 [
                     [10, 11],
@@ -3198,7 +3192,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             num_tokens=16,
             req_pool_indices=torch.arange(4, dtype=torch.int32),
             seq_lens=torch.ones(4, dtype=torch.int32),
-            forward_mode=ForwardMode.DRAFT_EXTEND,
+            forward_mode=ForwardMode.DECODE,
         )
         backend.advance_draft_forward_metadata()
         self.assertIs(backend.forward_metadata, first_decode_metadata)
@@ -3212,7 +3206,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             token_to_req_indices=torch.arange(1, dtype=torch.int32)
         )
         ctx = SimpleNamespace(
-            forward_mode=ForwardMode.DRAFT_EXTEND,
+            forward_mode=ForwardMode.DECODE,
             input_num_tokens=1,
             attn_backend=SimpleNamespace(
                 forward_metadata=decode_metadata,
@@ -3231,7 +3225,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_kv_heads=1,
                 attn_tp_size=1,
                 dtype=torch.bfloat16,
-                is_draft=False,
+                is_draft=True,
                 head_dim=512,
                 context_len=128,
                 speculative_num_draft_tokens=4,
@@ -3243,7 +3237,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             num_tokens=16,
             req_pool_indices=torch.arange(4, dtype=torch.int32),
             seq_lens=torch.ones(4, dtype=torch.int32),
-            forward_mode=ForwardMode.DRAFT_EXTEND,
+            forward_mode=ForwardMode.DECODE,
         )
         self.assertEqual(backend._draft_decode_metadata.token_to_req_indices.numel(), 4)
 

--- a/test/runtime/test_deepseek_v4_mtp_prefix_cache.py
+++ b/test/runtime/test_deepseek_v4_mtp_prefix_cache.py
@@ -70,7 +70,7 @@ def test_deepseek_v4_swa_slot_mapping_prefers_draft_prefill_metadata():
         cache=cache,
     )
     ctx = SimpleNamespace(
-        forward_mode=ForwardMode.DRAFT_EXTEND,
+        forward_mode=ForwardMode.DECODE,
         input_num_tokens=5,
         attn_backend=SimpleNamespace(
             forward_metadata=decode_metadata,
@@ -101,7 +101,7 @@ def test_deepseek_v4_swa_slot_mapping_falls_back_for_incompatible_draft_metadata
         ),
     )
     ctx = SimpleNamespace(
-        forward_mode=ForwardMode.DRAFT_EXTEND,
+        forward_mode=ForwardMode.DECODE,
         input_num_tokens=5,
         attn_backend=SimpleNamespace(forward_metadata=metadata),
         token_to_kv_pool=SimpleNamespace(swa_block_size=2),

--- a/test/runtime/test_dp_sampling_routing_metadata.py
+++ b/test/runtime/test_dp_sampling_routing_metadata.py
@@ -106,12 +106,6 @@ def test_logits_processor_dp_layout_threshold_and_modes():
     )
     assert decode_plan is not None
 
-    verify_plan = processor._resolve_logits_layout_plan(
-        torch.empty(16 * 6, 3),
-        LogitsMetadata(forward_mode=ForwardMode.TARGET_VERIFY),
-    )
-    assert verify_plan is not None
-
     assert (
         processor._resolve_logits_layout_plan(
             torch.empty(32 * 6, 3),
@@ -266,7 +260,7 @@ def test_resolve_dp_sampling_runtime_uses_grouped_metadata():
 
 @pytest.mark.parametrize(
     "forward_mode",
-    [ForwardMode.DECODE, ForwardMode.TARGET_VERIFY],
+    [ForwardMode.DECODE],
 )
 def test_logits_processor_derives_dp_layout_from_effective_hidden_states(
     forward_mode,


### PR DESCRIPTION
## Summary

Follow-up to PR #207 / Enwei's cleanup comment and re-applies the cleanup from #164. This removes the V4-specific speculative `ForwardMode` values that PR #207 reintroduced and keeps the runtime-facing forward-mode contract aligned with the existing base modes. 

Changes:
- Remove global `ForwardMode.TARGET_VERIFY` / `ForwardMode.DRAFT_EXTEND` and related helpers.
- Use normal `ForwardMode.DECODE` plus explicit packed `num_tokens` for V4 MTP target-verify / draft packed metadata.
- Rename the config gate to `use_v4_mtp_paged_metadata` so it describes the remaining V4-specific behavior instead of exposing a special forward mode.
- Preserve non-V4 speculative metadata behavior and clean latest-main GLM5/DSA references to the removed helpers.
- Update focused tests to assert the packed metadata behavior without special enum values.

## Validation

- `rg` stale API grep: no `TARGET_VERIFY`, `DRAFT_EXTEND`, `is_target_verify`, `is_draft_extend`, `is_speculative`, `decode_or_target_verify` references under `python/tokenspeed/runtime` or `test/runtime`.
- `git diff --check --cached`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile $(git diff --cached --name-only -- "*.py")`
- Docker focused pytest:
  - `test/runtime/test_deepseek_v4_config.py`
  - `test/runtime/test_dp_sampling_routing_metadata.py`
  - `test/runtime/test_deepseek_v4_mtp_prefix_cache.py`
  - `test/runtime/test_logits_processor.py`
  - result: `120 passed, 6 skipped`
- `pre-commit run --all-files`