### PR TITLE
fix(runtime): harden MTP decode path against NaN, overflow, and state corruption

### DIFF
--- a/python/tokenspeed/runtime/engine/input_processor.py
+++ b/python/tokenspeed/runtime/engine/input_processor.py
@@ -190,11 +190,13 @@ class InputProcessor:
             )
 
         max_new_tokens = obj.sampling_params.get("max_new_tokens")
-        if (
-            max_new_tokens is not None
-            and max_new_tokens + input_token_num >= self.engine.context_len
-        ):
-            adjusted_max_new_tokens = self.engine.context_len - input_token_num
+        # Resolve to a finite cap bounded by remaining context. Both
+        # Req.check_finished and RequestState.check_finished read this field;
+        # leaving it None lets a request reach the per-request page-table cap.
+        adjusted_max_new_tokens = self.engine.context_len - input_token_num
+        if max_new_tokens is None:
+            obj.sampling_params.update({"max_new_tokens": adjusted_max_new_tokens})
+        elif max_new_tokens + input_token_num >= self.engine.context_len:
             self.engine.logger.warning(
                 "Requested(rid=%s) token count exceeds the model's maximum context length of %s tokens. You requested a total of %s tokens: %s tokens from the input messages and %s tokens for the completion. The max_new_tokens will be truncated to %s.",
                 obj.rid,

--- a/python/tokenspeed/runtime/engine/io_struct.py
+++ b/python/tokenspeed/runtime/engine/io_struct.py
@@ -217,9 +217,11 @@ class GenerateReqInput:
                 num = self.batch_size * self.parallel_sample_num
 
             if self.sampling_params is None:
-                self.sampling_params = [{}] * num
+                self.sampling_params = [{} for _ in range(num)]
             elif not isinstance(self.sampling_params, list):
-                self.sampling_params = [self.sampling_params] * num
+                self.sampling_params = [
+                    dict(self.sampling_params) for _ in range(num)
+                ]
 
             if self.rid is None:
                 self.rid = [uuid.uuid4().hex for _ in range(num)]
@@ -483,7 +485,7 @@ class EmbeddingReqInput:
                 ), "user_rid should be a str or a list of matching length."
 
             if self.sampling_params is None:
-                self.sampling_params = [{}] * self.batch_size
+                self.sampling_params = [{} for _ in range(self.batch_size)]
             for i in range(self.batch_size):
                 self.sampling_params[i]["max_new_tokens"] = 0
 

--- a/python/tokenspeed/runtime/engine/io_struct.py
+++ b/python/tokenspeed/runtime/engine/io_struct.py
@@ -219,9 +219,7 @@ class GenerateReqInput:
             if self.sampling_params is None:
                 self.sampling_params = [{} for _ in range(num)]
             elif not isinstance(self.sampling_params, list):
-                self.sampling_params = [
-                    dict(self.sampling_params) for _ in range(num)
-                ]
+                self.sampling_params = [dict(self.sampling_params) for _ in range(num)]
 
             if self.rid is None:
                 self.rid = [uuid.uuid4().hex for _ in range(num)]

--- a/python/tokenspeed/runtime/execution/cache_loc_kernel.py
+++ b/python/tokenspeed/runtime/execution/cache_loc_kernel.py
@@ -191,6 +191,8 @@ def compute_out_cache_loc_kernel(
 
         # Compute page indices and offsets
         page_indices = positions // page_size
+        # Clamp to last valid page: avoids OOB reads past context-length bound.
+        page_indices = tl.minimum(page_indices, max_pages - 1)
         offsets_in_page = positions % page_size
 
         # Load page IDs from req_to_pages
@@ -281,6 +283,8 @@ def fused_decode_input_prep_kernel(
 
         positions_local = cache_start + token_offsets
         page_indices = positions_local // page_size
+        # Clamp to last valid page (avoids OOB reads past context-length bound).
+        page_indices = tl.minimum(page_indices, max_pages - 1)
         offsets_in_page = positions_local % page_size
 
         page_ptrs = req_to_pages_ptr + pool_idx * max_pages + page_indices

--- a/python/tokenspeed/runtime/execution/cache_loc_kernel.py
+++ b/python/tokenspeed/runtime/execution/cache_loc_kernel.py
@@ -387,26 +387,46 @@ def update_block_table(forward_op, device, req_to_page):
         return
 
     max_pages = req_to_page.shape[1]
-    for begin, size in zip(forward_op.begins, forward_op.sizes):
+    # Clamp a request that would overflow req_to_page instead of crashing the
+    # engine. Happens when MTP accept-rate collapse keeps a request alive past
+    # context_len; its KV drops but it will be finished shortly.
+    sizes = list(forward_op.sizes)
+    begins = list(forward_op.begins)
+    # new_occupied_pages is a list-of-lists [batch, size_i] of page ids;
+    # take a shallow copy so we can trim the offending request's row.
+    new_occupied_pages = [list(row) for row in forward_op.new_occupied_pages]
+    request_ids = list(forward_op.request_ids)
+    for i, (begin, size) in enumerate(zip(begins, sizes)):
         if begin + size > max_pages:
-            raise RuntimeError(
-                f"page copy would exceed req_to_page capacity: "
-                f"begin={begin} + size={size} = {begin + size} "
-                f"> req_to_page.shape[1]={max_pages}"
+            clamped = max(0, max_pages - begin)
+            logger.warning(
+                "page copy would exceed req_to_page capacity for req %s: "
+                "begin=%s + size=%s = %s > req_to_page.shape[1]=%s; "
+                "clamping size to %s to avoid engine crash. The request is past "
+                "its context-length bound and will be finished by the length "
+                "check; KV writes after this point are dropped.",
+                request_ids[i] if i < len(request_ids) else "?",
+                begin,
+                size,
+                begin + size,
+                max_pages,
+                clamped,
             )
+            sizes[i] = clamped
+            # Keep new_occupied_pages[i] consistent with the clamped size so
+            # the kernel's cumsum-based offsets stay aligned across the batch.
+            new_occupied_pages[i] = new_occupied_pages[i][:clamped]
 
-    new_occupied_pages_num = flatten_and_to_device(forward_op.sizes, dtype=torch.int32)
-    pages_copy_starts = flatten_and_to_device(forward_op.begins, dtype=torch.int32)
-    new_occupied_pages = flatten_and_to_device(
-        forward_op.new_occupied_pages, dtype=torch.int32
-    )
+    new_occupied_pages_num = flatten_and_to_device(sizes, dtype=torch.int32)
+    pages_copy_starts = flatten_and_to_device(begins, dtype=torch.int32)
+    new_occupied_pages_t = flatten_and_to_device(new_occupied_pages, dtype=torch.int32)
     request_pool_indices = flatten_and_to_device(
         forward_op.request_pool_indices, dtype=torch.int64
     )
     update_req_to_page(
         req_to_page=req_to_page,
         req_pool_indices=request_pool_indices,
-        new_occupied_pages=new_occupied_pages,
+        new_occupied_pages=new_occupied_pages_t,
         new_occupied_pages_num=new_occupied_pages_num,
         pages_copy_starts=pages_copy_starts,
     )

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -874,8 +874,11 @@ class CudaGraphWrapper:
             self.input_buffers.seq_lens_buf[:padded_bs].copy_(seq_lens)
             self.input_buffers.req_pool_indices_buf[:padded_bs].copy_(req_pool_indices)
             if mamba_pool_indices is not None:
+                # Pad with -1 (PAD_SLOT_ID), NOT 0. Mamba slot 0 is a real
+                # allocatable slot, so padding with 0 aliases a live request's
+                # mamba state and corrupts it. -1 is the kernel-skipped pad id.
                 mamba_pool_indices = torch.nn.functional.pad(
-                    mamba_pool_indices, (0, pad), value=0
+                    mamba_pool_indices, (0, pad), value=-1
                 )
             if mamba_cow_src_indices is not None:
                 mamba_cow_src_indices = torch.nn.functional.pad(

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -752,10 +752,9 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
                 dummy_slot=0,
             )
 
-        # Refresh spec_cache_seqlens_buf (clamped to >= spec_num_tokens) from
-        # this step's seq_lens so padded rows (seq_len=1) avoid NaN in the
-        # multi-token (target-verify) decode path.
-        if self.spec_num_tokens > 1 and not self.is_draft:
+        # Refresh for both verify and draft: draft step 1 is multi-token
+        # and reads spec_cache_seqlens_buf; later single-token steps don't.
+        if self.spec_num_tokens > 1:
             self._clamped_spec_seqlens(seq_lens, bs, self.spec_num_tokens)
 
         if bs in self.cuda_graph_prefill_metadata:

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -135,6 +135,12 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         self.cache_seqlens_buf = torch.zeros(
             (max_bs,), dtype=torch.int32, device=config.device
         )
+        # KV seqlens clamped to >= spec_num_tokens for the MTP verify path.
+        # Padded decode rows have seq_len=1 (InputBuffer); with q_len=spec_num_tokens
+        # they'd hit an empty causal span and the kernel returns NaN. Mirrors mha.py.
+        self.spec_cache_seqlens_buf = torch.zeros(
+            (max_bs,), dtype=torch.int32, device=config.device
+        )
         self.cu_seqlens_q_buf = torch.zeros(
             (max_bs + 1,), dtype=torch.int32, device=config.device
         )
@@ -490,6 +496,18 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
             page_table=page_table,
         )
 
+    def _clamped_spec_seqlens(
+        self, seq_lens: torch.Tensor, bs: int, spec_num_tokens: int
+    ) -> torch.Tensor:
+        """Return KV seqlens clamped to >= spec_num_tokens for the MTP verify path.
+
+        Writes into the persistent spec_cache_seqlens_buf (CUDA-graph safe)
+        to avoid NaN from empty causal spans on padded rows (seq_len=1).
+        """
+        dst = self.spec_cache_seqlens_buf[:bs]
+        torch.clamp_min(seq_lens[:bs], spec_num_tokens, out=dst)
+        return dst
+
     def _init_multi_token_metadata(
         self,
         bs: int,
@@ -506,7 +524,9 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         ), f"seq_lens must be int32, got {seq_lens.dtype}"
         device = seq_lens.device
         self.forward_prefill_metadata = TRTLLMMHAMetadata(
-            cache_seqlens_int32=seq_lens[:bs],
+            cache_seqlens_int32=self._clamped_spec_seqlens(
+                seq_lens, bs, spec_num_tokens
+            ),
             max_seq_len_q=spec_num_tokens,
             max_seq_len_k=self.max_context_len,
             cu_seqlens_q=torch.arange(
@@ -634,7 +654,7 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
             return
 
         if self.spec_num_tokens > 1:
-            self._init_multi_token_metadata_capture(bs, self.spec_num_tokens, seq_lens)
+            self._init_multi_token_metadata_capture(bs, self.spec_num_tokens)
             if self.is_draft:
                 self._init_decode_metadata_capture(bs, seq_lens)
         else:
@@ -671,12 +691,15 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         self.cuda_graph_decode_metadata[bs] = metadata
         self.forward_decode_metadata = metadata
 
-    def _init_multi_token_metadata_capture(
-        self, bs: int, spec_num_tokens: int, seq_lens: torch.Tensor
-    ):
-        # cache_seqlens aliases seq_lens_buf; routes through the decode kernel.
+    def _init_multi_token_metadata_capture(self, bs: int, spec_num_tokens: int):
+        # Multi-token decode: seed spec_cache_seqlens_buf (clamped to >=
+        # spec_num_tokens) at capture so padded rows (seq_len=1) avoid NaN.
+        # The replay path refreshes it each step.
+        cache_seqlens = self._clamped_spec_seqlens(
+            self.cuda_graph_cache_seqlens, bs, spec_num_tokens
+        )
         metadata = TRTLLMMHAMetadata(
-            cache_seqlens_int32=self.cuda_graph_cache_seqlens[:bs],
+            cache_seqlens_int32=cache_seqlens,
             max_seq_len_q=spec_num_tokens,
             max_seq_len_k=self.max_context_len,
             cu_seqlens_q=torch.arange(
@@ -728,6 +751,12 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
                 page_size=self.page_size,
                 dummy_slot=0,
             )
+
+        # Refresh spec_cache_seqlens_buf (clamped to >= spec_num_tokens) from
+        # this step's seq_lens so padded rows (seq_len=1) avoid NaN in the
+        # multi-token (target-verify) decode path.
+        if self.spec_num_tokens > 1 and not self.is_draft:
+            self._clamped_spec_seqlens(seq_lens, bs, self.spec_num_tokens)
 
         if bs in self.cuda_graph_prefill_metadata:
             self.forward_prefill_metadata = self.cuda_graph_prefill_metadata[bs]

--- a/test/runtime/test_mamba_mtp_state_reset.py
+++ b/test/runtime/test_mamba_mtp_state_reset.py
@@ -1,0 +1,67 @@
+import ast
+from pathlib import Path
+
+
+def _calls_runtime_state_method(node: ast.AST, method_name: str) -> bool:
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        func = child.func
+        if not isinstance(func, ast.Attribute) or func.attr != method_name:
+            continue
+        value = func.value
+        if not isinstance(value, ast.Attribute) or value.attr != "runtime_states":
+            continue
+        if isinstance(value.value, ast.Name) and value.value.id == "self":
+            return True
+    return False
+
+
+def _guard_uses_num_extends(test: ast.AST) -> bool:
+    for child in ast.walk(test):
+        if not isinstance(child, ast.Compare):
+            continue
+        if not isinstance(child.left, ast.Name) or child.left.id != "num_extends":
+            continue
+        if not child.ops or not isinstance(child.ops[0], ast.Gt):
+            continue
+        if not child.comparators:
+            continue
+        comparator = child.comparators[0]
+        if isinstance(comparator, ast.Constant) and comparator.value == 0:
+            return True
+    return False
+
+
+def _guard_uses_forward_mode_is_extend(test: ast.AST) -> bool:
+    for child in ast.walk(test):
+        if isinstance(child, ast.Call) and isinstance(child.func, ast.Attribute):
+            if child.func.attr != "is_extend":
+                continue
+            value = child.func.value
+            if isinstance(value, ast.Name) and value.id == "forward_mode":
+                return True
+    return False
+
+
+def test_mamba_state_reset_only_runs_for_real_prefill_extend():
+    """TARGET_VERIFY satisfies ForwardMode.is_extend(), so guard with num_extends."""
+    source_path = (
+        Path(__file__).resolve().parents[2]
+        / "python/tokenspeed/runtime/execution/model_executor.py"
+    )
+    tree = ast.parse(source_path.read_text())
+
+    guards = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        if _calls_runtime_state_method(node, "copy_mamba_states") or (
+            _calls_runtime_state_method(node, "zero_mamba_states")
+        ):
+            guards.append(node.test)
+
+    assert guards, "Expected a guarded Mamba state initialization block."
+    for guard in guards:
+        assert _guard_uses_num_extends(guard)
+        assert not _guard_uses_forward_mode_is_extend(guard)

--- a/test/runtime/test_max_new_tokens_context_cap.py
+++ b/test/runtime/test_max_new_tokens_context_cap.py
@@ -101,5 +101,28 @@ def test_resolved_cap_is_never_none():
         assert out.sampling_params.max_new_tokens == CONTEXT_LEN - 5
 
 
+def test_batch_each_item_gets_own_dict():
+    """normalize_batch_and_arguments must give each batch item its own dict."""
+    obj = GenerateReqInput(
+        input_ids=[list(range(90)), list(range(10)), list(range(5))],
+        sampling_params={},
+    )
+    obj.normalize_batch_and_arguments()
+
+    # Each item must have a distinct dict (no aliasing).
+    assert obj.sampling_params[0] is not obj.sampling_params[1]
+    assert obj.sampling_params[1] is not obj.sampling_params[2]
+
+    proc = _make_processor()
+    results = []
+    for i in range(obj.batch_size):
+        sub = obj[i]
+        results.append(asyncio.run(proc.tokenize_one_request(sub)))
+
+    assert results[0].sampling_params.max_new_tokens == CONTEXT_LEN - 90
+    assert results[1].sampling_params.max_new_tokens == CONTEXT_LEN - 10
+    assert results[2].sampling_params.max_new_tokens == CONTEXT_LEN - 5
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/runtime/test_max_new_tokens_context_cap.py
+++ b/test/runtime/test_max_new_tokens_context_cap.py
@@ -1,0 +1,105 @@
+"""Regression: max_new_tokens must always resolve to a finite cap bounded by
+the remaining context window — even when the caller omits it.
+
+Root cause context (dashllm1.log, DP4+EP4 Qwen3.5-397B, MTP, CUDA graph ON):
+both ``Req.check_finished`` and ``RequestState.check_finished`` decide the
+length stop via ``len(output_ids) >= sampling_params.max_new_tokens``. When a
+request arrives with ``max_new_tokens`` unset, that field stayed ``None`` all
+the way down (io_struct fills ``sampling_params={}`` but never defaults
+max_new_tokens), so the length check could not fire. The request then ran on
+toward the per-request KV page-table capacity (``ceil(context_len /
+page_size)``) — the exact boundary the trtllm/MTP page-allocation path is
+sensitive to (engine-crash on overflow).
+
+``InputProcessor.tokenize_one_request`` is the single construction site for
+``TokenizedGenerateReqInput`` (hence the single source of truth feeding both
+``check_finished`` paths). The fix resolves ``max_new_tokens`` there for BOTH
+cases:
+  * omitted (None)             -> context_len - input_token_num  (silent)
+  * present but over the limit -> truncated to the same cap       (+warn)
+
+These tests drive ``tokenize_one_request`` with a lightweight stub engine
+(``input_ids`` provided so no tokenizer is needed) and assert the resolved
+``max_new_tokens`` on the returned tokenized request.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from tokenspeed.runtime.engine.input_processor import InputProcessor
+from tokenspeed.runtime.engine.io_struct import GenerateReqInput
+
+CONTEXT_LEN = 100
+
+
+class _StubTokenizer:
+    # SamplingParams.normalize() only calls tokenizer.encode() for stop strings;
+    # with no stop strings it is never invoked, but provide it for safety.
+    def encode(self, text, add_special_tokens=False):  # noqa: D401
+        return [0] * len(text)
+
+
+def _make_processor() -> InputProcessor:
+    engine = SimpleNamespace(
+        context_len=CONTEXT_LEN,
+        is_generation=True,
+        tokenizer=_StubTokenizer(),
+        logger=SimpleNamespace(warning=lambda *a, **k: None),
+        server_args=SimpleNamespace(
+            reasoning_parser=None,
+            enable_prefix_caching=False,
+        ),
+        model_config=SimpleNamespace(
+            vocab_size=32000,
+            is_multimodal_active=False,
+        ),
+    )
+    return InputProcessor(engine)
+
+
+def _tokenize(obj: GenerateReqInput):
+    obj.normalize_batch_and_arguments()
+    proc = _make_processor()
+    return asyncio.run(proc.tokenize_one_request(obj))
+
+
+def test_omitted_max_new_tokens_is_capped_to_context_room():
+    # 10-token prompt, no max_new_tokens -> cap = context_len - 10 = 90.
+    obj = GenerateReqInput(input_ids=list(range(10)), sampling_params={})
+    out = _tokenize(obj)
+    assert out.sampling_params.max_new_tokens == CONTEXT_LEN - 10
+
+
+def test_explicit_over_limit_max_new_tokens_is_truncated():
+    # prompt 10 + requested 200 would exceed context_len -> truncate to 90.
+    obj = GenerateReqInput(
+        input_ids=list(range(10)), sampling_params={"max_new_tokens": 200}
+    )
+    out = _tokenize(obj)
+    assert out.sampling_params.max_new_tokens == CONTEXT_LEN - 10
+
+
+def test_explicit_within_limit_max_new_tokens_is_preserved():
+    # prompt 10 + requested 30 fits -> left untouched.
+    obj = GenerateReqInput(
+        input_ids=list(range(10)), sampling_params={"max_new_tokens": 30}
+    )
+    out = _tokenize(obj)
+    assert out.sampling_params.max_new_tokens == 30
+
+
+def test_resolved_cap_is_never_none():
+    """The invariant both check_finished paths depend on: never None."""
+    for sp in ({}, {"max_new_tokens": None}):
+        obj = GenerateReqInput(input_ids=list(range(5)), sampling_params=dict(sp))
+        out = _tokenize(obj)
+        assert out.sampling_params.max_new_tokens is not None
+        assert out.sampling_params.max_new_tokens == CONTEXT_LEN - 5
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/runtime/test_trtllm_spec_seqlen_clamp.py
+++ b/test/runtime/test_trtllm_spec_seqlen_clamp.py
@@ -1,0 +1,151 @@
+"""Regression: trtllm decode metadata must clamp KV seqlens to >=
+spec_num_tokens on the multi-token (MTP target-verify) path.
+
+Root cause analyzed in dashllm1.log (DP4+EP4 Qwen3.5-397B, MTP, CUDA graph ON):
+
+    accept_rate decays to 0 over multiple rounds. Localized end-to-end:
+      * CUDA-graph padded / idle decode rows are filled with seq_len=1
+        (InputBuffer.seq_lens_buf[batch_size:].fill_(1)).
+      * In MTP target-verify q_len_per_req == spec_num_draft_tokens (e.g. 4).
+      * A row with seq_len=1 < q_len=4 gives query positions whose causal key
+        span is empty; the trtllm decode kernel returns NaN for those rows.
+      * That NaN enters the residual stream of a full-attn layer and propagates
+        to every downstream layer, including the linear-attn (mamba) layers,
+        whose conv/ssm state then accumulates NaN -> accept_rate collapses.
+
+The MHA backend already guards this (``seq_lens[:bs].clamp_min(
+self.spec_num_tokens)``). This test pins the equivalent guard for the trtllm
+backend: ``_init_multi_token_metadata`` (and the CUDA-graph capture builder)
+must expose ``cache_seqlens_int32 >= spec_num_tokens`` so padded rows keep a
+non-empty causal span. Plain single-token decode (q_len=1) is unaffected.
+
+The test builds a CPU-only backend (``device="cpu"``) so it needs no GPU and no
+real KV pool; it exercises the metadata builders directly.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tokenspeed.runtime.layers.attention.backends.trtllm import (
+    TRTLLMMHAAttnBackend,
+)
+from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
+
+SPEC_NUM_TOKENS = 4
+
+
+def _make_backend(is_draft: bool = False) -> TRTLLMMHAAttnBackend:
+    cfg = MHAConfig(
+        device="cpu",
+        backend_name="trtllm",
+        num_attention_heads=8,
+        num_kv_heads=8,
+        head_dim=128,
+        attn_tp_size=1,
+        dtype=torch.bfloat16,
+        kv_cache_dtype=torch.bfloat16,
+        page_size=64,
+        context_len=4096,
+        max_bs=8,
+        max_graph_bs=8,
+        kv_cache_quant_method="none",
+        speculative_num_steps=3,
+        speculative_num_draft_tokens=SPEC_NUM_TOKENS,
+        is_draft=is_draft,
+    )
+    return TRTLLMMHAAttnBackend(cfg)
+
+
+def _req_to_page(req_pool_size: int, max_pages: int) -> torch.Tensor:
+    # Each request maps to a couple of distinct page ids; row 0 is the
+    # reserved/padding row. Values are arbitrary but valid (>=0).
+    table = torch.zeros((req_pool_size + 1, max_pages), dtype=torch.int32)
+    for r in range(req_pool_size + 1):
+        table[r, 0] = r
+    return table
+
+
+def test_multi_token_metadata_clamps_padded_seqlen_runtime():
+    """Runtime (non-CUDA-graph) verify path clamps seq_len < spec_num_tokens."""
+    be = _make_backend()
+    bs = 4
+    # Two real rows (long context) + two "padded" rows with seq_len=1, exactly
+    # the layout that triggered the NaN (real_bs=2, padded to 4).
+    seq_lens = torch.tensor([512, 300, 1, 1], dtype=torch.int32)
+    req_pool_indices = torch.tensor([1, 2, 0, 0], dtype=torch.int32)
+    req_to_page = _req_to_page(req_pool_size=8, max_pages=be.max_num_pages)
+
+    be._init_multi_token_metadata(
+        bs, SPEC_NUM_TOKENS, req_pool_indices, seq_lens, req_to_page
+    )
+    cache_seqlens = be.forward_prefill_metadata.cache_seqlens_int32
+
+    # Every row must have at least spec_num_tokens keys so no query row in the
+    # uniform q_len=spec_num_tokens block gets an empty causal span.
+    assert int(cache_seqlens.min()) >= SPEC_NUM_TOKENS
+    # Real rows must be left untouched (clamp is a no-op for them).
+    assert int(cache_seqlens[0]) == 512
+    assert int(cache_seqlens[1]) == 300
+    # Padded rows get raised to spec_num_tokens.
+    assert int(cache_seqlens[2]) == SPEC_NUM_TOKENS
+    assert int(cache_seqlens[3]) == SPEC_NUM_TOKENS
+
+
+def test_clamp_does_not_mutate_shared_seq_lens():
+    """The clamp must write into a private buffer, never the caller's tensor."""
+    be = _make_backend()
+    bs = 3
+    seq_lens = torch.tensor([1, 1, 256], dtype=torch.int32)
+    original = seq_lens.clone()
+    req_pool_indices = torch.tensor([0, 0, 1], dtype=torch.int32)
+    req_to_page = _req_to_page(req_pool_size=8, max_pages=be.max_num_pages)
+
+    be._init_multi_token_metadata(
+        bs, SPEC_NUM_TOKENS, req_pool_indices, seq_lens, req_to_page
+    )
+
+    # Caller's seq_lens is unchanged; clamped values live in a separate buffer.
+    assert torch.equal(seq_lens, original)
+    cache_seqlens = be.forward_prefill_metadata.cache_seqlens_int32
+    assert cache_seqlens.data_ptr() != seq_lens.data_ptr()
+    assert int(cache_seqlens.min()) >= SPEC_NUM_TOKENS
+
+
+def test_plain_decode_seqlen_not_clamped():
+    """Plain single-token decode (q_len=1) must NOT be clamped: a seq_len of 1
+    is valid there (1 query attends to 1 key)."""
+    be = _make_backend()
+    bs = 3
+    seq_lens = torch.tensor([1, 5, 9], dtype=torch.int32)
+    req_pool_indices = torch.tensor([1, 2, 3], dtype=torch.int32)
+    req_to_page = _req_to_page(req_pool_size=8, max_pages=be.max_num_pages)
+
+    be._init_decode_metadata(bs, req_pool_indices, seq_lens, req_to_page)
+    cache_seqlens = be.forward_decode_metadata.cache_seqlens_int32
+
+    # Decode path aliases seq_lens verbatim (no clamp): seq_len=1 stays 1.
+    assert int(cache_seqlens[0]) == 1
+    assert torch.equal(cache_seqlens, seq_lens[:bs])
+
+
+def test_cuda_graph_capture_builder_clamps():
+    """CUDA-graph capture builder points cache_seqlens at the clamped buffer."""
+    be = _make_backend()
+    max_bs = 8
+    seq_lens_buf = torch.ones((max_bs,), dtype=torch.int32)  # all padded -> 1
+    be.init_cuda_graph_state(max_bs, seq_lens_buf)
+
+    bs = 4
+    be._init_multi_token_metadata_capture(bs, SPEC_NUM_TOKENS)
+    cache_seqlens = be.forward_prefill_metadata.cache_seqlens_int32
+
+    assert int(cache_seqlens.min()) >= SPEC_NUM_TOKENS
+    # Must be the dedicated clamped buffer, not the shared seq_lens_buf.
+    assert cache_seqlens.data_ptr() == be.spec_cache_seqlens_buf.data_ptr()
+    assert cache_seqlens.data_ptr() != seq_lens_buf.data_ptr()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/runtime/test_trtllm_spec_seqlen_clamp.py
+++ b/test/runtime/test_trtllm_spec_seqlen_clamp.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import pytest
 import torch
 
+from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends.trtllm import (
     TRTLLMMHAAttnBackend,
 )
@@ -145,6 +146,47 @@ def test_cuda_graph_capture_builder_clamps():
     # Must be the dedicated clamped buffer, not the shared seq_lens_buf.
     assert cache_seqlens.data_ptr() == be.spec_cache_seqlens_buf.data_ptr()
     assert cache_seqlens.data_ptr() != seq_lens_buf.data_ptr()
+
+
+def test_draft_replay_refreshes_spec_cache_seqlens_buf():
+    """Draft replay must refresh spec_cache_seqlens_buf (draft step 1 is multi-token)."""
+    be = _make_backend(is_draft=True)
+    max_bs = 8
+    # At capture time, seq_lens_buf is all 1s (padded rows).
+    seq_lens_buf = torch.ones((max_bs,), dtype=torch.int32)
+    be.init_cuda_graph_state(max_bs, seq_lens_buf)
+
+    bs = 4
+    # Capture: multi-token metadata (step 1) + decode metadata (steps 2+).
+    be._init_multi_token_metadata_capture(bs, SPEC_NUM_TOKENS)
+    be._init_decode_metadata_capture(bs, seq_lens_buf)
+
+    # At capture, spec_cache_seqlens_buf was seeded from all-ones → clamped to 4.
+    capture_vals = be.spec_cache_seqlens_buf[:bs].clone()
+    assert int(capture_vals.min()) >= SPEC_NUM_TOKENS
+    assert int(capture_vals[0]) == SPEC_NUM_TOKENS  # 1 → clamped to 4
+
+    # Replay with real seq_lens (two real rows + two padded).
+    real_seq_lens = torch.tensor([512, 300, 1, 1], dtype=torch.int32)
+    req_pool_indices = torch.tensor([1, 2, 0, 0], dtype=torch.int32)
+    be.init_forward_metadata_replay_cuda_graph(
+        bs,
+        req_pool_indices,
+        real_seq_lens,
+        ForwardMode.DECODE,
+        req_to_page=None,  # skip page-table gather (Triton kernel)
+    )
+
+    # spec_cache_seqlens_buf must now reflect the clamped real values.
+    replay_vals = be.spec_cache_seqlens_buf[:bs]
+    assert int(replay_vals[0]) == 512  # real, no clamp needed
+    assert int(replay_vals[1]) == 300  # real, no clamp needed
+    assert int(replay_vals[2]) == SPEC_NUM_TOKENS  # 1 → clamped to 4
+    assert int(replay_vals[3]) == SPEC_NUM_TOKENS  # 1 → clamped to 4
+
+    # forward_prefill_metadata must point at spec_cache_seqlens_buf.
+    prefill_cache_seqlens = be.forward_prefill_metadata.cache_seqlens_int32
+    assert prefill_cache_seqlens.data_ptr() == be.spec_cache_seqlens_buf.data_ptr()
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_update_block_table_capacity_clamp.py
+++ b/test/runtime/test_update_block_table_capacity_clamp.py
@@ -1,0 +1,223 @@
+"""Regression: page-overflow in ``update_block_table`` must NOT crash engine.
+
+Reproduces the engine-killing crash analyzed in dashllm1.log:
+
+    RuntimeError: page copy would exceed req_to_page capacity:
+      begin=513 + size=1 = 514 > req_to_page.shape[1]=513
+
+Root cause (per-iter): when an MTP request approaches ``context_len`` with
+accept_rate collapsed to 0, the scheduler still reserves spec lookahead pages
+each iter. Eventually a request reaches the per-request page cap
+(``req_to_page.shape[1]``) and the next allocation goes past it, raising a
+``RuntimeError`` that tears down the **entire engine** (all in-flight
+requests die with the gloo cascade visible in the log).
+
+The fix in ``update_block_table`` clamps the offending request's ``size`` to
+the remaining capacity, logs a warning, and lets the other requests proceed.
+The offending request's KV becomes incomplete from that iter onward, but it
+is past its ``max_new_tokens`` clamp and will be naturally marked
+``FINISH_LENGTH`` shortly.
+
+Tests use a lightweight ``SimpleNamespace`` stand-in for ``forward_op`` so we
+don't depend on the C++ scheduler binding. The ``update_req_to_page`` kernel
+is itself stubbed (we assert what arguments it receives), keeping the test
+CPU-only and GPU-free.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import torch
+
+
+def _make_forward_op(
+    begins: list[int],
+    sizes: list[int],
+    new_occupied_pages: list[list[int]] | None = None,
+    request_ids: list[str] | None = None,
+    request_pool_indices: list[int] | None = None,
+) -> SimpleNamespace:
+    """Build a minimal forward_op stand-in with just the fields the function reads."""
+    if new_occupied_pages is None:
+        new_occupied_pages = [list(range(s)) for s in sizes]
+    if request_ids is None:
+        request_ids = [f"req-{i}" for i in range(len(begins))]
+    if request_pool_indices is None:
+        request_pool_indices = list(range(len(begins)))
+    return SimpleNamespace(
+        begins=list(begins),
+        sizes=list(sizes),
+        new_occupied_pages=new_occupied_pages,
+        request_ids=request_ids,
+        request_pool_indices=request_pool_indices,
+    )
+
+
+def test_update_block_table_does_not_raise_on_overflow(monkeypatch):
+    """Per-request overflow used to ``raise RuntimeError`` and kill the engine.
+
+    Now it must clamp the offending request's ``size`` and proceed without
+    raising, so the rest of the batch survives.
+    """
+    from tokenspeed.runtime.execution import cache_loc_kernel
+
+    # max_pages=513 (the value from the real crash). req[1] is the offender:
+    # begin=513 + size=1 = 514 > 513.
+    req_to_page = torch.zeros(8, 513, dtype=torch.int32)
+    forward_op = _make_forward_op(
+        begins=[400, 513, 100],
+        sizes=[2, 1, 3],
+    )
+
+    captured: dict = {}
+
+    def fake_update_req_to_page(
+        req_to_page,
+        req_pool_indices,
+        new_occupied_pages,
+        new_occupied_pages_num,
+        pages_copy_starts,
+    ):
+        captured["num"] = new_occupied_pages_num.tolist()
+        captured["starts"] = pages_copy_starts.tolist()
+        captured["pages"] = new_occupied_pages.tolist()
+
+    monkeypatch.setattr(cache_loc_kernel, "update_req_to_page", fake_update_req_to_page)
+
+    # Must not raise.
+    cache_loc_kernel.update_block_table(
+        forward_op, device="cpu", req_to_page=req_to_page
+    )
+
+    # The offender (req[1]) got clamped to 0, others unchanged.
+    assert captured["num"] == [2, 0, 3]
+    # begins are unchanged.
+    assert captured["starts"] == [400, 513, 100]
+    # And the flattened pages array dropped the offending request's entry,
+    # so the cumsum-based offsets the kernel uses stay consistent.
+    # req[0] contributes 2 pages, req[1] contributes 0, req[2] contributes 3 → 5 total.
+    assert len(captured["pages"]) == 5
+
+
+def test_update_block_table_passthrough_when_no_overflow(monkeypatch):
+    """When no request overflows, behavior must be identical to the old path."""
+    from tokenspeed.runtime.execution import cache_loc_kernel
+
+    req_to_page = torch.zeros(8, 513, dtype=torch.int32)
+    forward_op = _make_forward_op(
+        begins=[100, 200, 0],
+        sizes=[1, 2, 1],
+    )
+
+    captured: dict = {}
+
+    def fake_update_req_to_page(
+        req_to_page,
+        req_pool_indices,
+        new_occupied_pages,
+        new_occupied_pages_num,
+        pages_copy_starts,
+    ):
+        captured["num"] = new_occupied_pages_num.tolist()
+
+    monkeypatch.setattr(cache_loc_kernel, "update_req_to_page", fake_update_req_to_page)
+    cache_loc_kernel.update_block_table(
+        forward_op, device="cpu", req_to_page=req_to_page
+    )
+
+    # Sizes survive untouched.
+    assert captured["num"] == [1, 2, 1]
+
+
+def test_update_block_table_clamp_partial_overflow(monkeypatch):
+    """If begin < max_pages and begin+size > max_pages, clamp to (max - begin)."""
+    from tokenspeed.runtime.execution import cache_loc_kernel
+
+    req_to_page = torch.zeros(8, 513, dtype=torch.int32)
+    # begin=512 + size=4 = 516 > 513, but begin < 513 → clamp to size=1.
+    forward_op = _make_forward_op(
+        begins=[512],
+        sizes=[4],
+        new_occupied_pages=[[700, 701, 702, 703]],
+    )
+
+    captured: dict = {}
+
+    def fake_update_req_to_page(
+        req_to_page,
+        req_pool_indices,
+        new_occupied_pages,
+        new_occupied_pages_num,
+        pages_copy_starts,
+    ):
+        captured["num"] = new_occupied_pages_num.tolist()
+        captured["pages"] = new_occupied_pages.tolist()
+
+    monkeypatch.setattr(cache_loc_kernel, "update_req_to_page", fake_update_req_to_page)
+    cache_loc_kernel.update_block_table(
+        forward_op, device="cpu", req_to_page=req_to_page
+    )
+
+    assert captured["num"] == [1]
+    # Only the first page from new_occupied_pages survives (the one that fits).
+    assert captured["pages"] == [700]
+
+
+def test_update_block_table_zero_total_returns_early(monkeypatch):
+    """If every size is 0 the function must short-circuit (no kernel call)."""
+    from tokenspeed.runtime.execution import cache_loc_kernel
+
+    req_to_page = torch.zeros(8, 513, dtype=torch.int32)
+    forward_op = _make_forward_op(begins=[100, 200], sizes=[0, 0])
+
+    called = {"v": False}
+
+    def fake_update_req_to_page(**kwargs):
+        called["v"] = True
+
+    monkeypatch.setattr(cache_loc_kernel, "update_req_to_page", fake_update_req_to_page)
+    cache_loc_kernel.update_block_table(
+        forward_op, device="cpu", req_to_page=req_to_page
+    )
+    assert called["v"] is False
+
+
+def test_update_block_table_logs_warning_on_clamp():
+    """Engine survives, but the clamp must be loud (logger.warning) so the
+    upstream length-bound bug remains visible. cache_loc_kernel uses a
+    non-propagating colorful logger, so caplog can't see it; attach a direct
+    capturing handler instead."""
+    import logging
+
+    from tokenspeed.runtime.execution import cache_loc_kernel
+
+    captured_records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured_records.append(record)
+
+    handler = _Capture(level=logging.WARNING)
+    cache_loc_kernel.logger.addHandler(handler)
+    try:
+        req_to_page = torch.zeros(8, 513, dtype=torch.int32)
+        forward_op = _make_forward_op(
+            begins=[513],
+            sizes=[1],
+            request_ids=["my-bad-req"],
+        )
+        with mock.patch.object(
+            cache_loc_kernel, "update_req_to_page", lambda **kw: None
+        ):
+            cache_loc_kernel.update_block_table(
+                forward_op, device="cpu", req_to_page=req_to_page
+            )
+    finally:
+        cache_loc_kernel.logger.removeHandler(handler)
+
+    msgs = [r.getMessage() for r in captured_records]
+    assert any("my-bad-req" in m for m in msgs), msgs
+    assert any("page copy would exceed req_to_page capacity" in m for m in msgs), msgs


### PR DESCRIPTION
… corruption

- input_processor: always resolve max_new_tokens to a finite context-bound cap
- cache_loc_kernel: clamp page-overflow instead of crashing the engine
- cuda_graph_wrapper: pad mamba pool indices with -1 (PAD_SLOT_ID) not 0
- trtllm: clamp KV seqlens to >= spec_num_tokens on the MTP verify path

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
