### PR TITLE
Fix b200 runner env lookup with label overrides

### DIFF
--- a/test/ci_system/pipeline.py
+++ b/test/ci_system/pipeline.py
@@ -289,6 +289,18 @@ def get_default_runner_env(runner: str) -> Dict[str, str]:
     return {}
 
 
+def get_runner_specific_env(task: Dict[str, Any], runner: str) -> Dict[str, str]:
+    runner_env = task["runner"].get("env", {})
+    if runner in runner_env:
+        return dict(runner_env[runner])
+
+    for label in task["runner"]["labels"]:
+        if resolve_runner_label(label) == runner:
+            return dict(runner_env.get(label, {}))
+
+    return {}
+
+
 def create_ci_venv_name(runner_name: str | None = None) -> str:
     if runner_name:
         # Fixed path per runner so flashinfer JIT cache (which embeds the
@@ -1311,7 +1323,7 @@ def execute_task(
     env["CI_TASK_TYPE"] = str(task["type"])
     env["CI_RUNNER_LABEL"] = runner
     env.update(get_default_runner_env(runner))
-    env.update(task["runner"].get("env", {}).get(runner, {}))
+    env.update(get_runner_specific_env(task, runner))
 
     stages = filter_stage_commands(
         get_stage_commands(task),

--- a/test/ci_system/test_pipeline.py
+++ b/test/ci_system/test_pipeline.py
@@ -13,6 +13,7 @@ from pipeline import (
     extract_perf_summary_rows,
     format_perf_reference_markdown_table,
     format_perf_reference_table,
+    get_runner_specific_env,
     is_amd_runner,
     is_gb200_runner,
     resolve_score_threshold_for_runner,
@@ -71,6 +72,39 @@ def test_nvidia_gpu_cleanup_runner_prefixes_cover_gb200_and_b300():
     assert not should_run_nvidia_gpu_cleanup("amd-mi35x-2gpu-test")
     assert not should_run_nvidia_gpu_cleanup("amd-mi355-1gpu-bench")
     assert not should_run_nvidia_gpu_cleanup("amd-mi350-1gpu-bench")
+
+
+def test_runner_specific_env_uses_original_label_after_b200_override(monkeypatch):
+    monkeypatch.setenv("TOKENSPEED_B200_RUNNER_LABEL", "b200v2")
+    task = {
+        "runner": {
+            "labels": ["b200-2gpu"],
+            "env": {
+                "b200-2gpu": {
+                    "GPT_OSS_EVAL_MODEL": "openai/gpt-oss-120b",
+                },
+            },
+        },
+    }
+
+    assert get_runner_specific_env(task, "b200v2-2gpu") == {
+        "GPT_OSS_EVAL_MODEL": "openai/gpt-oss-120b",
+    }
+
+
+def test_runner_specific_env_prefers_exact_label(monkeypatch):
+    monkeypatch.setenv("TOKENSPEED_B200_RUNNER_LABEL", "b200v2")
+    task = {
+        "runner": {
+            "labels": ["b200-2gpu", "b200v2-2gpu"],
+            "env": {
+                "b200-2gpu": {"MODEL": "original"},
+                "b200v2-2gpu": {"MODEL": "exact"},
+            },
+        },
+    }
+
+    assert get_runner_specific_env(task, "b200v2-2gpu") == {"MODEL": "exact"}
 
 
 def test_extract_evalscope_score_from_pipe_table():


### PR DESCRIPTION
The b200 runner label override can select `b200v2-*` labels while task YAML still stores runner-specific environment under the original `b200-*` label. That leaves variables such as `GPT_OSS_EVAL_MODEL` unset and turns commands into invalid invocations like `--model` without a value.

Validation:
- `python3 -m pytest test/ci_system/test_pipeline.py`
- `pre-commit run --files test/ci_system/pipeline.py test/ci_system/test_pipeline.py`