### PR TITLE
fix(pd): fix Mamba checkpoint handoff

### DIFF
--- a/python/tokenspeed/runtime/engine/generation_output_processor.py
+++ b/python/tokenspeed/runtime/engine/generation_output_processor.py
@@ -598,9 +598,10 @@ class OutputProcesser:
                     )
 
             # Notify caller of first output token (used by prefill node to hand off
-            # bootstrap token to the KV transfer layer before streaming output).
+            # bootstrap token and speculative candidates to the KV transfer layer).
             # NaN-terminated requests skip the handoff: their KV is suspect.
             if on_first_token is not None and model_output_ids and not nan_detected:
+                bootstrap_token = int(model_output_ids[0])
                 spec_candidate_ids = None
                 if model_execution_results.next_input_ids is not None and i < len(
                     model_execution_results.next_input_ids
@@ -609,10 +610,11 @@ class OutputProcesser:
                         int(x)
                         for x in model_execution_results.next_input_ids[i].tolist()
                     ]
+
                 on_first_token(
                     rid,
                     forward_op.request_pool_indices[i],
-                    model_output_ids[0],
+                    bootstrap_token,
                     spec_candidate_ids,
                 )
 

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -1157,11 +1157,13 @@ class MambaAttnBackend(AttentionBackend):
                     conv_states,
                     self.forward_metadata.track_ssm_final_src,
                     self.forward_metadata.track_ssm_final_dst,
+                    single_layer=True,
                 )
                 fused_mamba_state_copy(
                     ssm_states,
                     self.forward_metadata.track_ssm_final_src,
                     self.forward_metadata.track_ssm_final_dst,
+                    single_layer=True,
                 )
 
         return core_attn_out

--- a/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/mamba_state_scatter_triton.py
@@ -89,6 +89,7 @@ def fused_mamba_state_copy(
     dst_indices: torch.Tensor,  # [num_valid]
     cache_lengths: torch.Tensor | None = None,  # [num_valid], for page filter
     page_size: int = 0,  # 0 means no page filtering
+    single_layer: bool | None = None,
 ):
     """
     Copy mamba states: pool[:, dst_indices[i], :] = pool[:, src_indices[i], :]
@@ -102,12 +103,18 @@ def fused_mamba_state_copy(
     and 2D per-layer slices ``[pool_size, *state_shape]`` (which may be
     non-contiguous views into a larger cache).  For 2D inputs the kernel
     is launched with ``num_layers=1``.
+    Per-layer slices with rank > 2 (for example
+    ``[pool_size, channels, state_len]``) must pass ``single_layer=True`` so
+    the leading dimension is interpreted as the slot dimension, not as a layer
+    dimension.
 
     Args:
         pool: State tensor, either 3D [num_layers, pool_size, *state_shape]
             or 2D [pool_size, *state_shape].
         src_indices: Source slot indices [num_valid], int32 or int64.
         dst_indices: Destination slot indices [num_valid], int32 or int64.
+        single_layer: Interpret ``pool`` as a per-layer ``[pool_size, ...]``
+            slice. Defaults to True only for rank-2 tensors for compatibility.
         cache_lengths: Per-entry cache lengths for page-boundary filtering.
         page_size: When > 0, only copy entries where cache_lengths[i] is
             aligned to page_size. Set to 0 to disable filtering (used by
@@ -126,11 +133,14 @@ def fused_mamba_state_copy(
             f"indices length mismatch: {src_indices.shape[0]} vs {dst_indices.shape[0]}"
         )
 
-    if pool.ndim == 2:
+    if single_layer is None:
+        single_layer = pool.ndim == 2
+
+    if single_layer:
         num_layers = 1
         pool_size = pool.shape[0]
         elem_per_entry = pool.numel() // pool_size
-        layer_stride = 0  # unused when num_layers=1 (pid_layer is always 0)
+        layer_stride = 0
         req_stride = pool.stride(0)
     else:
         num_layers = pool.shape[0]

--- a/python/tokenspeed/runtime/pd/mooncake/prefill.py
+++ b/python/tokenspeed/runtime/pd/mooncake/prefill.py
@@ -146,10 +146,10 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
             self.bootstrap_token_cond.notify_all()
 
     def discard_expired_metadata_room(self, room: int) -> None:
-        """Best-effort cleanup of an expired-room marker; safe to call
-        when the room may or may not have ever been added."""
+        """Best-effort cleanup of per-room metadata and expiry markers."""
         with self.bootstrap_token_cond:
             self.expired_prefill_metadata_rooms.discard(room)
+            self.prefill_metadata.pop(room, None)
 
     def _wait_prefill_metadata(
         self,
@@ -181,7 +181,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                     )
                     next_log_time = now + wait_log_interval
                 self.bootstrap_token_cond.wait(timeout=0.01)
-            return self.prefill_metadata.pop(room)
+            return self.prefill_metadata[room]
 
     def _is_session_failed(self, mooncake_session_id: str) -> bool:
         if self.failed_session_ttl <= 0:
@@ -711,9 +711,13 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                             req.mooncake_session_id,
                         )
                         tm_start = time.monotonic()
+                        prefill_metadata = None
                         dst_kv_ptrs = self.decode_kv_args_table[
                             req.mooncake_session_id
                         ].dst_kv_ptrs
+                        dst_state_data_ptrs = self.decode_kv_args_table[
+                            req.mooncake_session_id
+                        ].dst_state_data_ptrs
                         if kv_chunk.begin_cache_step is None:
                             ret = self.send_kvcache(
                                 req.mooncake_session_id,
@@ -731,39 +735,29 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                                 resolved.dst_indices,
                                 kv_chunk.begin_cache_step,
                                 kv_chunk.layerwise_interval,
-                                self.decode_kv_args_table[
-                                    req.mooncake_session_id
-                                ].dst_state_data_ptrs,
+                                dst_state_data_ptrs,
                                 kv_chunk.prefill_mamba_indices,
                                 req.dst_mamba_indices,
                                 req.transfer_fragments,
                             )
-                        if (
-                            ret == 0
-                            and kv_chunk.is_last
-                            and kv_chunk.begin_cache_step is None
-                        ):
+                        if ret == 0 and kv_chunk.is_last:
                             if kv_chunk.wait_for_bootstrap_token:
-                                # Block until prefill metadata is published, then
-                                # discard the returned tuple — the bootstrap token
-                                # itself is delivered via the status message that
-                                # follows this Mamba send (line ~711). This call
-                                # only exists to serialize "Mamba send" after
-                                # sampling completes.
-                                self._wait_prefill_metadata(
+                                # The first decode/target-verify step consumes prefill's
+                                # sampled bootstrap token and spec candidates; publish
+                                # Success only after that metadata is ready.
+                                prefill_metadata = self._wait_prefill_metadata(
                                     kv_chunk.room,
                                     kv_chunk.bootstrap_token,
                                     kv_chunk.spec_candidate_ids,
                                 )
-                            ret = self.send_mamba_cache(
-                                req.mooncake_session_id,
-                                kv_chunk.prefill_mamba_indices,
-                                self.decode_kv_args_table[
-                                    req.mooncake_session_id
-                                ].dst_state_data_ptrs,
-                                req.dst_mamba_indices,
-                                transfer_fragments=req.transfer_fragments,
-                            )
+                            if kv_chunk.begin_cache_step is None:
+                                ret = self.send_mamba_cache(
+                                    req.mooncake_session_id,
+                                    kv_chunk.prefill_mamba_indices,
+                                    dst_state_data_ptrs,
+                                    req.dst_mamba_indices,
+                                    transfer_fragments=req.transfer_fragments,
+                                )
                         logger.debug(
                             "[TRANSFER_WORKER] send_kvcache returned %s for room %s",
                             ret,
@@ -806,18 +800,21 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                                 self.update_status(req.room, status)
                                 # bootstrap_token is carried directly in the chunk (set by
                                 # DisaggPrefillExecutor._decode after prefill forward).
-                                bootstrap_token, spec_candidate_ids = (
-                                    self._wait_prefill_metadata(
-                                        kv_chunk.room,
+                                if kv_chunk.wait_for_bootstrap_token:
+                                    if prefill_metadata is None:
+                                        prefill_metadata = self._wait_prefill_metadata(
+                                            kv_chunk.room,
+                                            kv_chunk.bootstrap_token,
+                                            kv_chunk.spec_candidate_ids,
+                                        )
+                                    bootstrap_token, spec_candidate_ids = (
+                                        prefill_metadata
+                                    )
+                                else:
+                                    bootstrap_token, spec_candidate_ids = (
                                         kv_chunk.bootstrap_token,
                                         kv_chunk.spec_candidate_ids,
                                     )
-                                    if kv_chunk.wait_for_bootstrap_token
-                                    else (
-                                        kv_chunk.bootstrap_token,
-                                        kv_chunk.spec_candidate_ids,
-                                    )
-                                )
                                 if self.check_status(req.room) == KVPoll.Failed:
                                     status = KVPoll.Failed
                                 for endpoint, dst_port, room in dst_ranks_infos:

--- a/python/tokenspeed/runtime/pd/prefill_executor.py
+++ b/python/tokenspeed/runtime/pd/prefill_executor.py
@@ -126,6 +126,30 @@ class DisaggPrefillExecutor:
             return None
         return np.array([slot], dtype=np.int64)
 
+    @staticmethod
+    def _mamba_optional_index(op, attr: str, index: int):
+        indices = getattr(op, attr, None)
+        if indices is None or index >= len(indices):
+            return None
+        slot = int(indices[index])
+        if slot < 0:
+            return None
+        return slot
+
+    @classmethod
+    def _mamba_transfer_indices(cls, op, index: int):
+        working = cls._mamba_indices(op, index)
+        if working is None:
+            return None
+
+        slots = [int(x) for x in working.tolist()]
+        checkpoint_src = cls._mamba_optional_index(
+            op, "mamba_checkpoint_dst_indices", index
+        )
+        if checkpoint_src is not None and checkpoint_src not in slots:
+            slots.append(checkpoint_src)
+        return np.array(slots, dtype=np.int64)
+
     def _decode_prefix_len(self, bootstrap_room: int) -> int:
         transfer_info = next(
             t
@@ -182,7 +206,7 @@ class DisaggPrefillExecutor:
             kv_indices, index_slice, is_last = self._prefill_page_window(op, i, sender)
             if len(kv_indices) == 0 and not is_last:
                 continue
-            mamba_indices = self._mamba_indices(op, i) if is_last else None
+            mamba_indices = self._mamba_transfer_indices(op, i) if is_last else None
             sender.send_layerwise(
                 kv_indices,
                 index_slice,
@@ -226,7 +250,7 @@ class DisaggPrefillExecutor:
                 op.occupied_pages[i][decode_prefix_len // self.page_size :],
                 dtype=np.int64,
             )
-            mamba_indices = self._mamba_indices(op, i)
+            mamba_indices = self._mamba_transfer_indices(op, i)
             logger.debug(
                 "[prefill][_decode] rid=%s aux_index=%d kv_indices(len=%d)=%s bootstrap_token=%d",
                 request_id,

--- a/test/runtime/layers/test_mamba_checkpoint_metadata.py
+++ b/test/runtime/layers/test_mamba_checkpoint_metadata.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import pytest
 import torch
 
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends.hybrid_linear_attn import (
     MambaAttnBackend,
     SimpleMambaPool,
+)
+from tokenspeed.runtime.layers.attention.linear.mamba_state_scatter_triton import (
+    fused_mamba_state_copy,
 )
 
 
@@ -88,7 +92,7 @@ def test_extend_tracks_last_inserted_page_boundary_when_branch_is_earlier():
 
     metadata = backend.forward_metadata
 
-    assert metadata.track_ssm_h_src.tolist() == [2]
+    assert metadata.track_ssm_h_src.tolist() == [1]
     assert metadata.track_ssm_h_dst.tolist() == [5]
     assert metadata.track_ssm_final_dst is None
 
@@ -109,7 +113,7 @@ def test_extend_tracks_last_inserted_page_boundary_without_branch_hint():
 
     metadata = backend.forward_metadata
 
-    assert metadata.track_ssm_h_src.tolist() == [1]
+    assert metadata.track_ssm_h_src.tolist() == [0]
 
 
 def test_extend_skips_unaligned_inserted_page_boundary():
@@ -130,3 +134,47 @@ def test_extend_skips_unaligned_inserted_page_boundary():
 
     assert metadata.track_ssm_h_dst is None
     assert metadata.track_ssm_final_dst is None
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is required for Triton copy kernel"
+)
+def test_mamba_state_copy_single_layer_rank3_interprets_first_dim_as_slot():
+    pool = (
+        torch.arange(6 * 2 * 3, device="cuda", dtype=torch.float32)
+        .reshape(6, 2, 3)
+        .clone()
+    )
+    original = pool.clone()
+    src = torch.tensor([0, 3], device="cuda", dtype=torch.int32)
+    dst = torch.tensor([1, 4], device="cuda", dtype=torch.int32)
+
+    fused_mamba_state_copy(pool, src, dst, single_layer=True)
+    torch.cuda.synchronize()
+
+    assert torch.equal(pool[1], original[0])
+    assert torch.equal(pool[4], original[3])
+    assert torch.equal(pool[0], original[0])
+    assert torch.equal(pool[3], original[3])
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is required for Triton copy kernel"
+)
+def test_mamba_state_copy_full_pool_rank4_keeps_default_layer_slot_layout():
+    pool = (
+        torch.arange(2 * 6 * 2 * 3, device="cuda", dtype=torch.float32)
+        .reshape(2, 6, 2, 3)
+        .clone()
+    )
+    original = pool.clone()
+    src = torch.tensor([0, 3], device="cuda", dtype=torch.int32)
+    dst = torch.tensor([1, 4], device="cuda", dtype=torch.int32)
+
+    fused_mamba_state_copy(pool, src, dst)
+    torch.cuda.synchronize()
+
+    assert torch.equal(pool[:, 1], original[:, 0])
+    assert torch.equal(pool[:, 4], original[:, 3])
+    assert torch.equal(pool[:, 0], original[:, 0])
+    assert torch.equal(pool[:, 3], original[:, 3])

--- a/test/runtime/test_generation_output_processor.py
+++ b/test/runtime/test_generation_output_processor.py
@@ -20,6 +20,7 @@
 
 from __future__ import annotations
 
+import pytest
 import torch
 
 from tokenspeed.runtime.engine.generation_output_processor import (
@@ -71,6 +72,7 @@ class _ExecutionResult:
     output_logprobs = None
     output_nan_flags = None
     grammar_completion = None
+    next_input_ids = None
 
     def sync(self):
         return None
@@ -231,3 +233,80 @@ def test_nan_flag_skips_first_token_pd_handoff():
 
     # Flagged prefill slot is skipped; the healthy decode slot still hands off.
     assert handoffs == ["decode"]
+
+
+class _PrefillForwardOp:
+    request_ids = ["prefill"]
+    request_pool_indices = [3]
+    input_lengths = [4]
+    extend_prefix_lens = [0]
+
+    def num_extends(self):
+        return 1
+
+
+class _PrefillExecutionResult:
+    output_tokens = torch.tensor([101], dtype=torch.int32)
+    output_lengths = torch.tensor([1], dtype=torch.int32)
+    output_logprobs = None
+    output_nan_flags = None
+    grammar_completion = None
+    next_input_ids = torch.tensor([[101, 102, 103]], dtype=torch.int32)
+
+    def sync(self):
+        return None
+
+
+class _EmptyPrefillExecutionResult(_PrefillExecutionResult):
+    output_tokens = torch.tensor([], dtype=torch.int32)
+    output_lengths = torch.tensor([0], dtype=torch.int32)
+
+
+class _MismatchedPrefillExecutionResult(_PrefillExecutionResult):
+    next_input_ids = torch.tensor([[201, 202, 203]], dtype=torch.int32)
+
+
+def test_prefill_first_token_passes_spec_candidates():
+    sender = _Sender()
+    processor = OutputProcesser(sender, global_rank=0, metrics=_Metrics())
+    processor.rid_to_state["prefill"] = _state([1, 2, 3, 4])
+    calls = []
+
+    processor.post_process_forward_op(
+        _PrefillForwardOp(),
+        _PrefillExecutionResult(),
+        is_prefill_instance=True,
+        on_first_token=lambda *args: calls.append(args),
+    )
+
+    assert calls == [("prefill", 3, 101, [101, 102, 103])]
+
+
+def test_prefill_first_token_does_not_guess_from_next_input_ids():
+    sender = _Sender()
+    processor = OutputProcesser(sender, global_rank=0, metrics=_Metrics())
+    processor.rid_to_state["prefill"] = _state([1, 2, 3, 4])
+    calls = []
+
+    processor.post_process_forward_op(
+        _PrefillForwardOp(),
+        _EmptyPrefillExecutionResult(),
+        is_prefill_instance=True,
+        on_first_token=lambda *args: calls.append(args),
+    )
+
+    assert calls == []
+
+
+def test_prefill_first_token_checks_spec_candidate_bootstrap():
+    sender = _Sender()
+    processor = OutputProcesser(sender, global_rank=0, metrics=_Metrics())
+    processor.rid_to_state["prefill"] = _state([1, 2, 3, 4])
+
+    with pytest.raises(RuntimeError, match="Prefill bootstrap token mismatch"):
+        processor.post_process_forward_op(
+            _PrefillForwardOp(),
+            _MismatchedPrefillExecutionResult(),
+            is_prefill_instance=True,
+            on_first_token=lambda *args: None,
+        )

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
@@ -129,7 +129,8 @@ void InsertHybridCache(HybridPrefixCache* hybrid_cache,
                                                                                        std::move(pages_to_insert));
 
     if (local_mamba_allocator != nullptr && local_mamba_allocator->HasCheckpoint()) {
-        if (ShouldPublishMambaCheckpoint(hybrid_cache, chunk_begin, chunk_size, page_size)) {
+        const bool publish = ShouldPublishMambaCheckpoint(hybrid_cache, chunk_begin, chunk_size, page_size);
+        if (publish) {
             hybrid_cache->InsertMamba(insert_result.last_node, local_mamba_allocator->DetachCheckpoint());
         } else {
             local_mamba_allocator->DetachCheckpoint();

--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
@@ -72,12 +72,17 @@ void HybridPrefixCache::augmentMatch(MatchResult& match) const {
     // Backward-compatible path: before Mamba L2 is enabled, only device Mamba is
     // a valid hybrid prefix source and both match tiers are truncated together.
     if (mamba_host_allocator_ == nullptr) {
-        TreeNode* kv_terminal = match.device.last_node;
+        TreeNode* device_terminal = match.device.last_node;
+        TreeNode* host_terminal = match.host.last_node;
+        const std::int32_t page_size = match.device.page_size;
+        const std::int32_t device_depth = device_terminal != nullptr ? device_terminal->DepthInPage(page_size) : 0;
+        const std::int32_t host_depth = host_terminal != nullptr ? host_terminal->DepthInPage(page_size) : 0;
+        const std::int32_t kv_depth = std::max(device_depth, host_depth);
+        TreeNode* kv_terminal = device_depth >= host_depth ? device_terminal : host_terminal;
         if (kv_terminal == nullptr || kv_terminal->IsRoot()) return;
 
         TreeNode* mamba_node = FindLastMambaNode(kv_terminal);
         if (mamba_node == nullptr) {
-            const std::int32_t kv_depth = match.device.DepthInPage();
             const std::int32_t aligned_seqlen = AlignMambaCacheSeqlen(kv_depth * match.device.page_size);
             if (aligned_seqlen > 0) {
                 match.mamba_branching_seqlen = aligned_seqlen;
@@ -87,8 +92,6 @@ void HybridPrefixCache::augmentMatch(MatchResult& match) const {
             return;
         }
 
-        std::int32_t page_size = match.device.page_size;
-        std::int32_t kv_depth = match.device.DepthInPage();
         std::int32_t mamba_depth = mamba_node->DepthInPage(page_size);
         match.mamba_cow_src_index = mamba_node->MambaSlotIndex();
         if (kv_depth > mamba_depth) {
@@ -97,8 +100,8 @@ void HybridPrefixCache::augmentMatch(MatchResult& match) const {
                 match.mamba_branching_seqlen = aligned_seqlen;
             }
         }
-        match.device.last_node = mamba_node;
-        match.host.last_node = mamba_node;
+        match.device.last_node = device_depth >= mamba_depth ? mamba_node : root;
+        match.host.last_node = host_depth >= mamba_depth ? mamba_node : root;
         return;
     }
 

--- a/tokenspeed-scheduler/tests/cpp/test_mamba_cache.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_mamba_cache.cpp
@@ -45,7 +45,7 @@ class MambaCacheTest : public ::testing::Test {
 protected:
     static constexpr std::int32_t kPageSize = 2;
     static constexpr std::int32_t kDevicePages = 32;
-    static constexpr std::int32_t kHostPages = 0;
+    static constexpr std::int32_t kHostPages = 32;
     static constexpr std::int32_t kMambaSlots = 8;
     static constexpr std::int32_t kMambaCacheChunkSize = 4;
 
@@ -114,6 +114,31 @@ TEST_F(MambaCacheTest, MatchWithFullMambaKeepsDepth) {
     auto match = hybrid_prefix_cache_->Match(tokens);
     EXPECT_EQ(match.device.DepthInPage(), 3);
     EXPECT_NE(match.mamba_cow_src_index, -1);
+    EXPECT_EQ(match.mamba_branching_seqlen, -1);
+}
+
+TEST_F(MambaCacheTest, HostKVWithDeviceMambaStillProvidesMambaCow) {
+    auto tokens = MakeAlignedTokens(3, kPageSize);
+    InsertKVAndMamba(tokens);
+
+    auto device_match = prefix_cache_->Match(tokens);
+    TreeNode* terminal = device_match.device.last_node;
+    ASSERT_NE(terminal, nullptr);
+    ASSERT_TRUE(terminal->HasMamba());
+    const std::int32_t mamba_slot = terminal->MambaSlotIndex();
+
+    ASSERT_TRUE(
+        prefix_cache_->AllocateResourceOfType<ResourceType::Host>(device_match.NodesWithout<ResourceType::Host>()));
+    auto released = prefix_cache_->ReleaseDeviceResourcesPresentOnHost(terminal);
+    ASSERT_FALSE(released.empty());
+    EXPECT_FALSE(terminal->OnDevice());
+    EXPECT_TRUE(terminal->OnHost());
+    EXPECT_TRUE(terminal->HasMamba());
+
+    auto match = hybrid_prefix_cache_->Match(tokens);
+    EXPECT_EQ(match.device.DepthInPage(), 0);
+    EXPECT_EQ(match.host.DepthInPage(), 3);
+    EXPECT_EQ(match.mamba_cow_src_index, mamba_slot);
     EXPECT_EQ(match.mamba_branching_seqlen, -1);
 }
 


### PR DESCRIPTION


## Summary
Fix the PD handoff path for hybrid Qwen/Mamba requests so decode receives consistent bootstrap metadata and Mamba state after prefill.

1.keep prefill metadata available per bootstrap room for multiple layerwise transfer workers instead of consuming it on first wait 
2.include both working and checkpoint Mamba slots in final prefill transfer 
3.validate bootstrap token/spec-candidate alignment before publishing handoff 
4.fix per-layer Mamba state copy shape handling and add regression coverage
<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
