### PR TITLE
feat: distributed argmax for EAGLE greedy sampling

### DIFF
--- a/python/tokenspeed/runtime/execution/drafter/eagle.py
+++ b/python/tokenspeed/runtime/execution/drafter/eagle.py
@@ -24,7 +24,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import torch
-from tokenspeed_kernel.ops.sampling import argmax as sampling_argmax
 from typing_extensions import override
 
 from tokenspeed.runtime.execution.cache_loc_kernel import (
@@ -398,7 +397,7 @@ class Eagle(BaseDrafter):
                 dsa_topk = self._extract_dsa_topk(ctx, dsa_topk)
 
             with nvtx_range("draft_sample", color="yellow"):
-                draft_ids = sampling_argmax(logits_output.next_token_logits)
+                draft_ids = logits_output.next_token_ids
                 draft_ids.clamp_(min=0)
                 # Column 0 holds last_verified_ids; drafter writes step `i` into column `i + 1`.
                 next_tokens[:, i + 1] = self._map_hot(draft_ids)
@@ -470,7 +469,7 @@ class Eagle(BaseDrafter):
         # down to `[bs, ...]`, so logits/hidden_states arrive here already aligned to one row per request.
         logits_output, dsa_topk = self._run_first_step(bs, draft_input)
 
-        draft_ids = sampling_argmax(logits_output.next_token_logits)
+        draft_ids = logits_output.next_token_ids
         draft_ids.clamp_(min=0)
         next_tokens[:, 1] = self._map_hot(draft_ids)
 

--- a/python/tokenspeed/runtime/layers/logits_processor.py
+++ b/python/tokenspeed/runtime/layers/logits_processor.py
@@ -618,17 +618,17 @@ class LogitsProcessor(nn.Module):
 
         return logits
 
-    def _argmax(
-        self, logits: torch.Tensor, *, out: torch.Tensor | None = None
-    ) -> torch.Tensor:
-        if self.tp_size > 1 and logits.size(-1) < self.config.vocab_size:
-            assert self._dist_argmax_state is not None
-            assert not self.final_logit_softcapping
-            assert logits.size(0) <= self._LOGITS_DIST_ARGMAX_MAX_TOKENS
+    def _argmax(self, logits: torch.Tensor) -> torch.Tensor:
+        if (
+            self._dist_argmax_state
+            not in (self._LOGITS_DIST_ARGMAX_UNINITIALIZED, None)
+            and not self.final_logit_softcapping
+            and logits.size(0) <= self._LOGITS_DIST_ARGMAX_MAX_TOKENS
+        ):
             _, idx = distributed_argmax(self._dist_argmax_state, logits)
             return idx
         else:
-            return sampling_argmax(logits, out=out)
+            return sampling_argmax(logits)
 
     @staticmethod
     def get_top_logprobs(all_logprobs: torch.Tensor, logits_metadata: LogitsMetadata):

--- a/python/tokenspeed/runtime/layers/logits_processor.py
+++ b/python/tokenspeed/runtime/layers/logits_processor.py
@@ -26,6 +26,11 @@ import torch
 import triton
 import triton.language as tl
 from tokenspeed_kernel.ops.communication.triton import all_gather_inner, create_state
+from tokenspeed_kernel.ops.sampling import argmax as sampling_argmax
+from tokenspeed_kernel.ops.sampling.cute_dsl import (
+    create_dist_argmax_state,
+    distributed_argmax,
+)
 from tokenspeed_kernel.platform import current_platform
 from torch import nn
 
@@ -58,6 +63,8 @@ class LogitsProcessorOutput:
     ## Part 1: This part will be assigned in python/tokenspeed/runtime/layers/logits_processor.py::LogitsProcessor
     # The logits of the next tokens.       shape: [#seq, vocab_size]
     next_token_logits: torch.Tensor
+    # Used when ``do_argmax=True``.   shape: [#seq]
+    next_token_ids: torch.Tensor | None = None
     # Used by speculative decoding.
     # The last hidden layers
     hidden_states: torch.Tensor | None = None
@@ -179,10 +186,15 @@ class LogitsProcessor(nn.Module):
     _LOGITS_AG_STATE_UNINITIALIZED = object()
     _LOGITS_AG_STATES = {}
 
+    _LOGITS_DIST_ARGMAX_MAX_TOKENS = 8192
+    _LOGITS_DIST_ARGMAX_UNINITIALIZED = object()
+    _LOGITS_DIST_ARGMAX_STATES = {}
+
     def __init__(
         self,
         config,
         skip_all_gather: bool = False,
+        do_argmax: bool = False,
         logit_scale: float | None = None,
         tp_rank: int | None = None,
         tp_size: int | None = None,
@@ -191,6 +203,7 @@ class LogitsProcessor(nn.Module):
         super().__init__()
         self.config = config
         self.skip_all_gather = skip_all_gather
+        self.do_argmax = do_argmax
         self.dp_sampling_enabled = False
         self.dp_num_tokens_per_req = 1
         self.dp_sampling_min_bs = 0
@@ -206,6 +219,7 @@ class LogitsProcessor(nn.Module):
         self.tp_rank, self.tp_size, self.tp_group = tp_rank, tp_size, tp_group
 
         self._all_gather_state = self._LOGITS_AG_STATE_UNINITIALIZED
+        self._dist_argmax_state = self._LOGITS_DIST_ARGMAX_UNINITIALIZED
 
         self.final_logit_softcapping = getattr(
             self.config, "final_logit_softcapping", None
@@ -286,6 +300,32 @@ class LogitsProcessor(nn.Module):
                 hidden_size=vocab_padded,
             )
         return self._LOGITS_AG_STATES[key]
+
+    def _init_dist_argmax_state(self, lm_head: VocabParallelEmbedding):
+        if not current_platform().is_nvidia:
+            return None
+
+        if self.tp_size == 1 or self.skip_all_gather or self.dp_sampling_enabled:
+            return None
+
+        vocab_per_rank = lm_head.weight.size(0)
+        if vocab_per_rank * self.tp_size != self.config.vocab_size:
+            return None  # padded vocab: sharded argmax could pick a pad column
+        if vocab_per_rank < 4096 or vocab_per_rank % 32 != 0:
+            return None  # below the kernel's vocab floor / alignment
+
+        key = (self.tp_group, vocab_per_rank)
+        if key not in self._LOGITS_DIST_ARGMAX_STATES:
+            self._LOGITS_DIST_ARGMAX_STATES[key] = create_dist_argmax_state(
+                group=pg_manager.get_process_group("nccl", self.tp_group),
+                rank_in_group=self.tp_rank,
+                max_M=self._LOGITS_DIST_ARGMAX_MAX_TOKENS,
+                dtype=lm_head.weight.dtype,
+                device=lm_head.weight.device,
+                skip_ping_pong=True,
+            )
+
+        return self._LOGITS_DIST_ARGMAX_STATES[key]
 
     def forward(
         self,
@@ -412,8 +452,12 @@ class LogitsProcessor(nn.Module):
 
         if not logits_metadata.extend_return_logprob:
             # Decode mode or extend mode without return_logprob.
+            # Greedy draft path: emit token ids here, fusing the cross-rank
+            # vocab reduction into the argmax when gated on.
+            next_token_ids = self._argmax(sampled_logits) if self.do_argmax else None
             return LogitsProcessorOutput(
                 next_token_logits=sampled_logits,
+                next_token_ids=next_token_ids,
                 hidden_states=hidden_states_to_store,
                 logits_layout_plan=logits_layout_plan,
             )
@@ -522,7 +566,19 @@ class LogitsProcessor(nn.Module):
                     "dp_sampling logits layout executor is not configured"
                 )
             logits = self._logits_layout_executor.swap_batch_vocab(logits, plan)
+
         elif not dp_sampling and self.tp_size > 1 and not self.skip_all_gather:
+            if self.do_argmax:
+                if self._dist_argmax_state is self._LOGITS_DIST_ARGMAX_UNINITIALIZED:
+                    self._dist_argmax_state = self._init_dist_argmax_state(lm_head)
+
+                if (
+                    self._dist_argmax_state is not None
+                    and not self.final_logit_softcapping
+                    and logits.size(0) <= self._LOGITS_DIST_ARGMAX_MAX_TOKENS
+                ):
+                    return logits
+
             if self._all_gather_state is self._LOGITS_AG_STATE_UNINITIALIZED:
                 self._all_gather_state = self._init_all_gather_state(lm_head)
 
@@ -561,6 +617,18 @@ class LogitsProcessor(nn.Module):
             fused_softcap_generic(logits, self.final_logit_softcapping)
 
         return logits
+
+    def _argmax(
+        self, logits: torch.Tensor, *, out: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        if self.tp_size > 1 and logits.size(-1) < self.config.vocab_size:
+            assert self._dist_argmax_state is not None
+            assert not self.final_logit_softcapping
+            assert logits.size(0) <= self._LOGITS_DIST_ARGMAX_MAX_TOKENS
+            _, idx = distributed_argmax(self._dist_argmax_state, logits)
+            return idx
+        else:
+            return sampling_argmax(logits, out=out)
 
     @staticmethod
     def get_top_logprobs(all_logprobs: torch.Tensor, logits_metadata: LogitsMetadata):

--- a/python/tokenspeed/runtime/models/deepseek_nextn.py
+++ b/python/tokenspeed/runtime/models/deepseek_nextn.py
@@ -203,6 +203,7 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
         self.logits_processor = LogitsProcessor(
             config,
             skip_all_gather=self.mapping.attn.has_dp,
+            do_argmax=True,
             tp_rank=self.mapping.attn.tp_rank,
             tp_size=self.mapping.attn.tp_size,
             tp_group=self.mapping.attn.tp_group,

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -1932,6 +1932,8 @@ class Eagle3DeepseekV2ForCausalLM(DeepseekV3ForCausalLM):
 
         self.logits_processor = LogitsProcessor(
             config,
+            skip_all_gather=self.mapping.attn.has_dp,
+            do_argmax=True,
             tp_rank=self.mapping.attn.tp_rank,
             tp_size=self.mapping.attn.tp_size,
             tp_group=self.mapping.attn.tp_group,

--- a/python/tokenspeed/runtime/models/deepseek_v4_mtp.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_mtp.py
@@ -308,6 +308,7 @@ class DeepseekV4ForCausalLMNextN(nn.Module):
         self.logits_processor = LogitsProcessor(
             config,
             skip_all_gather=self.mapping.attn.has_dp,
+            do_argmax=True,
             tp_rank=self.mapping.attn.tp_rank,
             tp_size=self.mapping.attn.tp_size,
             tp_group=self.mapping.attn.tp_group,

--- a/python/tokenspeed/runtime/models/glm5_nextn.py
+++ b/python/tokenspeed/runtime/models/glm5_nextn.py
@@ -216,6 +216,7 @@ class GlmMoeDsaForCausalLMNextN(GlmMoeDsaForCausalLM):
         self.logits_processor = LogitsProcessor(
             config,
             skip_all_gather=self.mapping.attn.has_dp,
+            do_argmax=True,
             tp_rank=self.mapping.attn.tp_rank,
             tp_size=self.mapping.attn.tp_size,
             tp_group=self.mapping.attn.tp_group,

--- a/python/tokenspeed/runtime/models/llama_eagle3.py
+++ b/python/tokenspeed/runtime/models/llama_eagle3.py
@@ -43,6 +43,7 @@ from tokenspeed.runtime.layers.linear import (
     MergedColumnParallelLinear,
     RowParallelLinear,
 )
+from tokenspeed.runtime.layers.logits_processor import LogitsProcessor
 from tokenspeed.runtime.layers.quantization.base_config import QuantizationConfig
 from tokenspeed.runtime.layers.vocab_parallel_embedding import ParallelLMHead
 from tokenspeed.runtime.model_loader.weight_utils import default_weight_loader
@@ -533,7 +534,14 @@ class LlamaForCausalLMEagle3(BaseCausalLM):
                 prefix=add_prefix("lm_head", prefix),
             )
 
-        self.logits_processor = self.resolve_logits_processor(config)
+        self.logits_processor = LogitsProcessor(
+            config,
+            skip_all_gather=self.mapping.attn.has_dp,
+            do_argmax=True,
+            tp_rank=self.mapping.attn.tp_rank,
+            tp_size=self.mapping.attn.tp_size,
+            tp_group=self.mapping.attn.tp_group,
+        )
         self.capture_aux_hidden_states = True
         self.hot_token_id = None
 

--- a/python/tokenspeed/runtime/models/qwen3_5_nextn.py
+++ b/python/tokenspeed/runtime/models/qwen3_5_nextn.py
@@ -206,6 +206,7 @@ class Qwen3_5ForConditionalGenerationNextN(nn.Module):
         self.logits_processor = LogitsProcessor(
             config,
             skip_all_gather=self.mapping.attn.has_dp,
+            do_argmax=True,
             tp_rank=self.mapping.attn.tp_rank,
             tp_size=self.mapping.attn.tp_size,
             tp_group=self.mapping.attn.tp_group,

--- a/test/runtime/test_logits_processor.py
+++ b/test/runtime/test_logits_processor.py
@@ -105,3 +105,107 @@ def test_fused_softcap_handles_large_logits_without_nan():
 
     assert torch.isfinite(out).all()
     torch.testing.assert_close(out, expected, rtol=1e-5, atol=2e-5)
+
+
+def test_argmax_routes_sharded_to_kernel(monkeypatch):
+    """Sharded logits (tp shards reconstruct vocab) hit the fused kernel."""
+    proc = LogitsProcessor(
+        config=SimpleNamespace(model_type="test", vocab_size=8),
+        tp_rank=0,
+        tp_size=2,
+        tp_group=(0, 1),
+    )
+    proc._dist_argmax_state = object()  # non-None, non-sentinel => active
+
+    recorded = {}
+
+    def fake_dist(state, logits):
+        recorded["called"] = True
+        return None, logits.argmax(dim=-1)
+
+    monkeypatch.setattr(logits_processor_module, "distributed_argmax", fake_dist)
+
+    shard = torch.randn(4, 4, dtype=torch.float32)  # 4 * tp_size(2) == vocab_size(8)
+    ids = proc._argmax(shard)
+    assert recorded.get("called")
+    assert torch.equal(ids, shard.argmax(dim=-1))
+
+
+def test_argmax_full_vocab_skips_kernel(monkeypatch):
+    """Full-vocab logits fall back to argmax even when a state is present."""
+    proc = LogitsProcessor(
+        config=SimpleNamespace(model_type="test", vocab_size=8),
+        tp_rank=0,
+        tp_size=2,
+        tp_group=(0, 1),
+    )
+    proc._dist_argmax_state = object()
+
+    monkeypatch.setattr(
+        logits_processor_module,
+        "distributed_argmax",
+        lambda *a, **k: pytest.fail("kernel must not run on full-vocab logits"),
+    )
+
+    full = torch.randn(4, 8, dtype=torch.float32)  # width == vocab_size => not sharded
+    ids = proc._argmax(full)
+    assert torch.equal(ids, full.argmax(dim=-1))
+
+
+def test_get_logits_skips_gather_when_dist_argmax_active(monkeypatch):
+    """do_argmax + active state keeps logits sharded (no all-gather)."""
+    proc = LogitsProcessor(
+        config=SimpleNamespace(
+            model_type="test", vocab_size=8, final_logit_softcapping=None
+        ),
+        tp_rank=0,
+        tp_size=2,
+        tp_group=(0, 1),
+        do_argmax=True,
+    )
+    monkeypatch.setattr(proc, "_init_dist_argmax_state", lambda lm_head: object())
+    monkeypatch.setattr(
+        logits_processor_module,
+        "all_gather_inner",
+        lambda *a, **k: pytest.fail("gather must be skipped on the fused path"),
+    )
+
+    hidden = torch.randn(4, 2, dtype=torch.float32)
+    lm_head = SimpleNamespace(weight=torch.randn(4, 2, dtype=torch.float32))  # 4*2 == 8
+    md = LogitsMetadata(forward_mode=ForwardMode.DECODE)
+    out = proc._get_logits(hidden, lm_head, md)
+    assert out.shape == (4, 4)  # local shard width retained, not gathered to 8
+
+
+def test_get_logits_softcap_disables_fused_argmax(monkeypatch):
+    """final_logit_softcapping must disable the fused early-return so the
+    softcap is applied to full-vocab logits (then a plain argmax runs)."""
+    proc = LogitsProcessor(
+        config=SimpleNamespace(
+            model_type="test", vocab_size=8, final_logit_softcapping=30.0
+        ),
+        tp_rank=0,
+        tp_size=2,
+        tp_group=(0, 1),
+        do_argmax=True,
+    )
+    # Fused state is otherwise eligible; softcap must still force the gather.
+    monkeypatch.setattr(proc, "_init_dist_argmax_state", lambda lm_head: object())
+    monkeypatch.setattr(proc, "_init_all_gather_state", lambda lm_head: object())
+    called = {}
+
+    def fake_ag(state, logits, **kw):
+        called["ag"] = True
+        return logits.repeat(1, proc.tp_size)  # [bs, vocab/tp] -> [bs, vocab]
+
+    monkeypatch.setattr(logits_processor_module, "all_gather_inner", fake_ag)
+    monkeypatch.setattr(
+        logits_processor_module, "fused_softcap_generic", lambda *a, **k: None
+    )
+
+    hidden = torch.randn(4, 2, dtype=torch.float32)
+    lm_head = SimpleNamespace(weight=torch.randn(4, 2, dtype=torch.float32))  # 4*2 == 8
+    md = LogitsMetadata(forward_mode=ForwardMode.DECODE)
+    out = proc._get_logits(hidden, lm_head, md)
+    assert called.get("ag")  # gathered (softcap on full vocab), not early-returned
+    assert out.shape == (4, 8)

--- a/test/runtime/test_logits_processor.py
+++ b/test/runtime/test_logits_processor.py
@@ -131,25 +131,27 @@ def test_argmax_routes_sharded_to_kernel(monkeypatch):
     assert torch.equal(ids, shard.argmax(dim=-1))
 
 
-def test_argmax_full_vocab_skips_kernel(monkeypatch):
-    """Full-vocab logits fall back to argmax even when a state is present."""
+def test_argmax_falls_back_without_state(monkeypatch):
+    """No fused state (e.g. EAGLE3 draft vocab != target, or gate failed):
+    _argmax falls back to a plain argmax instead of routing to the kernel."""
     proc = LogitsProcessor(
-        config=SimpleNamespace(model_type="test", vocab_size=8),
+        config=SimpleNamespace(model_type="test", vocab_size=100),
         tp_rank=0,
         tp_size=2,
         tp_group=(0, 1),
     )
-    proc._dist_argmax_state = object()
+    proc._dist_argmax_state = None  # gate failed (draft vocab != target vocab)
 
     monkeypatch.setattr(
         logits_processor_module,
         "distributed_argmax",
-        lambda *a, **k: pytest.fail("kernel must not run on full-vocab logits"),
+        lambda *a, **k: pytest.fail("kernel must not run without a fused state"),
     )
 
-    full = torch.randn(4, 8, dtype=torch.float32)  # width == vocab_size => not sharded
-    ids = proc._argmax(full)
-    assert torch.equal(ids, full.argmax(dim=-1))
+    # Gathered draft logits are narrower than the target config.vocab_size.
+    draft = torch.randn(4, 32, dtype=torch.float32)
+    ids = proc._argmax(draft)
+    assert torch.equal(ids, draft.argmax(dim=-1))
 
 
 def test_get_logits_skips_gather_when_dist_argmax_active(monkeypatch):

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
@@ -44,9 +44,12 @@ The common ``tokenspeed_kernel.ops.sampling.argmax`` API selects this
 registered solution on NVIDIA.
 """
 
-from __future__ import annotations
+from dataclasses import dataclass
 
 import torch
+import torch.distributed as _dist
+import torch.distributed._symmetric_memory as _symm_mem
+
 from tokenspeed_kernel.platform import (
     ArchVersion,
     CapabilityRequirement,
@@ -58,7 +61,9 @@ from tokenspeed_kernel.signature import format_signatures
 __all__ = [
     "argmax",
     "argmax_pair",
+    "create_dist_argmax_state",
     "cute_dsl_argmax",
+    "distributed_argmax",
     "is_available",
 ]
 
@@ -140,12 +145,23 @@ _CUTE_AVAILABLE = False
 if _ARCH_SUPPORTED and _has_cluster_launch_support():
     try:
         import cuda.bindings.driver as cuda
+        import cutlass
         import cutlass.cute as cute
+        from cutlass._mlir.dialects import llvm
         from cutlass.cute.runtime import from_dlpack
+        from cutlass.cute.typing import Float32, Int32
+        from cutlass.cutlass_dsl import T, dsl_user_op
         from tokenspeed_kernel.thirdparty.cute_dsl.argmax import (
             ArgmaxKernel,
             CUDAGraphCompatibleWrapper,
+            domain_offset_i64,
+            elem_pointer,
+            fill_oob,
+            predicate_k,
+            store_shared_remote,
             torch2cute_dtype_map,
+            warp_argmax_redux,
+            warp_reduce_argmax,
         )
 
         _CUTE_AVAILABLE = True
@@ -389,3 +405,685 @@ if _CUTE_AVAILABLE:
 else:
     argmax = _argmax_torch_fallback
     argmax_pair = _argmax_pair_torch_fallback
+
+
+# Distributed (cross-rank) argmax — kernel + operator with symm-mem workspace.
+if _CUTE_AVAILABLE:
+
+    @dsl_user_op
+    def ptx_multimem_st_release_u64(
+        mc_ptr: cutlass.Int64, value: cutlass.Int64, *, loc=None, ip=None
+    ) -> None:
+        llvm.inline_asm(
+            None,
+            [
+                cutlass.Int64(mc_ptr).ir_value(loc=loc, ip=ip),
+                cutlass.Int64(value).ir_value(loc=loc, ip=ip),
+            ],
+            """multimem.st.release.sys.global.b64 [$0], $1;""",
+            "l,l",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+
+    @dsl_user_op
+    def ptx_ld_acquire_sys_u64(
+        addr: cutlass.Int64, *, loc=None, ip=None
+    ) -> cutlass.Int64:
+        return cutlass.Int64(
+            llvm.inline_asm(
+                T.i64(),
+                [cutlass.Int64(addr).ir_value(loc=loc, ip=ip)],
+                """ld.acquire.sys.global.u64 $0, [$1];""",
+                "=l,l",
+                has_side_effects=True,
+                is_align_stack=False,
+                asm_dialect=llvm.AsmDialect.AD_ATT,
+            )
+        )
+
+    @dsl_user_op
+    def ptx_atomic_and_relaxed_sys_u64(
+        addr: cutlass.Int64, mask: cutlass.Int64, *, loc=None, ip=None
+    ) -> cutlass.Int64:
+        return cutlass.Int64(
+            llvm.inline_asm(
+                T.i64(),
+                [
+                    cutlass.Int64(addr).ir_value(loc=loc, ip=ip),
+                    cutlass.Int64(mask).ir_value(loc=loc, ip=ip),
+                ],
+                """atom.and.relaxed.sys.global.b64 $0, [$1], $2;""",
+                "=l,l,l",
+                has_side_effects=True,
+                is_align_stack=False,
+                asm_dialect=llvm.AsmDialect.AD_ATT,
+            )
+        )
+
+    # u64 slot layout: [flag:63 | idx:32..62 | f32 value:0..31].
+    @cute.jit
+    def pack_argmax_payload_u64(
+        val_f32: cutlass.Float32, global_idx: cutlass.Int32
+    ) -> cutlass.Int64:
+        val_bits = (
+            val_f32.bitcast(cutlass.Int32).to(cutlass.Int64)
+            & cutlass.Int64(0xFFFFFFFF)
+        )
+        idx_bits = cutlass.Int64(global_idx) & cutlass.Int64(0x7FFFFFFF)
+        flag_bit = cutlass.Int64(1) << cutlass.Int64(63)
+        return flag_bit | (idx_bits << cutlass.Int64(32)) | val_bits
+
+    @cute.jit
+    def unpack_argmax_payload_u64(packed: cutlass.Int64):
+        val_bits32 = (packed & cutlass.Int64(0xFFFFFFFF)).to(Int32)
+        val_f32 = val_bits32.bitcast(cutlass.Float32)
+        idx_i32 = (
+            (packed >> cutlass.Int64(32)) & cutlass.Int64(0x7FFFFFFF)
+        ).to(Int32)
+        return val_f32, idx_i32
+
+    @dsl_user_op
+    def ptx_ld_global_u32(
+        addr: cutlass.Int64, *, loc=None, ip=None
+    ) -> cutlass.Int32:
+        return cutlass.Int32(
+            llvm.inline_asm(
+                T.i32(),
+                [cutlass.Int64(addr).ir_value(loc=loc, ip=ip)],
+                """ld.global.u32 $0, [$1];""",
+                "=r,l",
+                has_side_effects=True,
+                is_align_stack=False,
+                asm_dialect=llvm.AsmDialect.AD_ATT,
+            )
+        )
+
+    @dsl_user_op
+    def ptx_atomic_add_acq_rel_sys_u32(
+        addr: cutlass.Int64, val: cutlass.Int32, *, loc=None, ip=None
+    ) -> cutlass.Int32:
+        return cutlass.Int32(
+            llvm.inline_asm(
+                T.i32(),
+                [
+                    cutlass.Int64(addr).ir_value(loc=loc, ip=ip),
+                    cutlass.Int32(val).ir_value(loc=loc, ip=ip),
+                ],
+                """atom.add.acq_rel.sys.global.u32 $0, [$1], $2;""",
+                "=r,l,r",
+                has_side_effects=True,
+                is_align_stack=False,
+                asm_dialect=llvm.AsmDialect.AD_ATT,
+            )
+        )
+
+    @dsl_user_op
+    def ptx_st_relaxed_sys_u32(
+        addr: cutlass.Int64, val: cutlass.Int32, *, loc=None, ip=None
+    ) -> None:
+        llvm.inline_asm(
+            None,
+            [
+                cutlass.Int64(addr).ir_value(loc=loc, ip=ip),
+                cutlass.Int32(val).ir_value(loc=loc, ip=ip),
+            ],
+            """st.relaxed.sys.global.u32 [$0], $1;""",
+            "l,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+
+    class DistArgmaxKernel(ArgmaxKernel):
+        """Cross-rank argmax: per-rank local argmax + warp-level peer reduce.
+
+        ``skip_ping_pong=False`` (default): kernel reads ``round_id`` and
+        alternates between two slot bands so back-to-back calls are
+        race-free on their own. ``skip_ping_pong=True``: hardcodes band
+        0; caller must guarantee an external sync between consecutive
+        calls (same contract as ``all_gather_inner``'s
+        ``SKIP_ENTRY_SYNC=True``).
+        """
+
+        def __init__(
+            self,
+            dtype,
+            N: int,
+            use_redux: bool = False,
+            world_size: int = 1,
+            rank: int = 0,
+            skip_ping_pong: bool = False,
+        ):
+            super().__init__(dtype, N, use_redux=use_redux)
+            self.world_size = world_size
+            self.rank = rank
+            self.dist_tp_enabled = world_size > 1
+            self.skip_ping_pong = skip_ping_pong
+
+        @cute.jit
+        def __call__(
+            self,
+            mX: cute.Tensor,
+            mO_max: cute.Tensor,
+            mO_idx: cute.Tensor,
+            stream: cuda.CUstream,
+            slot_ptrs: cutlass.Int64,
+            slot_multicast_ptr: cutlass.Int64,
+            round_id_ptr: cutlass.Int64,
+            warps_done_ptr: cutlass.Int64,
+        ):
+            self._set_cluster_n()
+            tiler_mn, tv_layout = self._get_tv_layout()
+            num_threads = cute.size(tv_layout, mode=[0])
+            num_warps = num_threads // cute.arch.WARP_SIZE
+
+            self.kernel(
+                mX,
+                mO_max,
+                mO_idx,
+                tv_layout,
+                tiler_mn,
+                slot_ptrs,
+                slot_multicast_ptr,
+                round_id_ptr,
+                warps_done_ptr,
+            ).launch(
+                grid=[cute.ceil_div(mX.shape[0], tiler_mn[0]), self.cluster_n, 1],
+                block=[num_threads, 1, 1],
+                cluster=(
+                    [1, self.cluster_n, 1]
+                    if cutlass.const_expr(self.cluster_n > 1)
+                    else None
+                ),
+                smem=self._smem_size_in_bytes(tiler_mn, num_warps),
+                stream=stream,
+            )
+
+        @cute.kernel
+        def kernel(
+            self,
+            mX: cute.Tensor,
+            mO_max: cute.Tensor,
+            mO_idx: cute.Tensor,
+            tv_layout: cute.Layout,
+            tiler_mn: cute.Shape,
+            slot_ptrs: cutlass.Int64,
+            slot_multicast_ptr: cutlass.Int64,
+            round_id_ptr: cutlass.Int64,
+            warps_done_ptr: cutlass.Int64,
+        ):
+            tidx, _, _ = cute.arch.thread_idx()
+            bidx, bidy, bidz = cute.arch.block_idx()
+
+            if cutlass.const_expr(self.cluster_n > 1):
+                cluster_y = cute.arch.block_idx()[1]
+            else:
+                cluster_y = cutlass.const_expr(0)
+
+            shape = mX.shape
+            idX = cute.make_identity_tensor(shape)
+
+            mX = domain_offset_i64((bidx * tiler_mn[0], 0), mX)
+            gX = cute.local_tile(mX, tiler_mn, (0, cluster_y))
+            mO_max = domain_offset_i64((bidx * tiler_mn[0],), mO_max)
+            mO_idx = domain_offset_i64((bidx * tiler_mn[0],), mO_idx)
+            cX = cute.local_tile(idX, tiler_mn, (bidx, cluster_y))
+
+            smem = cutlass.utils.SmemAllocator()
+            sX = smem.allocate_tensor(
+                mX.element_type,
+                cute.make_ordered_layout(tiler_mn, order=(1, 0)),
+                byte_alignment=16,
+            )
+            reduction_buffer, mbar_ptr = self._allocate_reduction_buffer_and_mbar(
+                smem, tv_layout
+            )
+
+            copy_atom_load_X = cute.make_copy_atom(
+                cute.nvgpu.cpasync.CopyG2SOp(),
+                mX.element_type,
+                num_bits_per_copy=128,
+            )
+            thr_copy_X = cute.make_tiled_copy(
+                copy_atom_load_X, tv_layout, tiler_mn
+            ).get_slice(tidx)
+
+            tXgX = thr_copy_X.partition_S(gX)
+            tXsX = thr_copy_X.partition_D(sX)
+            tXcX = thr_copy_X.partition_S(cX)[(0, None), None, None]
+
+            tvlayout_cX = cute.composition(cX, tv_layout)
+            thr_coord = (tidx, (None, None))
+            thr_cX = tvlayout_cX[thr_coord]
+
+            tXrX = cute.make_fragment_like(tXgX)
+            num_warps = cute.size(tv_layout, mode=[0]) // cute.arch.WARP_SIZE
+            self._initialize_cluster(tidx, mbar_ptr, num_warps)
+
+            is_even_N = cutlass.const_expr(shape[1] == tiler_mn[1] * self.cluster_n)
+            tXpX = (
+                predicate_k(thr_copy_X.partition_S(cX), limit=shape[1])
+                if not is_even_N
+                else None
+            )
+
+            if tXcX[0][0] < shape[0]:
+                cute.copy(copy_atom_load_X, tXgX, tXsX, pred=tXpX)
+            cute.arch.cp_async_commit_group()
+            cute.arch.cp_async_wait_group(0)
+
+            if cutlass.const_expr(not is_even_N):
+                fill_oob(tXsX, tXpX, -tXsX.element_type.inf)
+
+            cute.autovec_copy(tXsX, tXrX)
+            x = tXrX.load().to(cute.Float32)
+
+            current_max = -tXsX.element_type.inf
+            current_argmax = Int32(0xFFFFFFFF)
+
+            for i in cutlass.range_constexpr(thr_cX.shape[0]):
+                for j in cutlass.range_constexpr(thr_cX.shape[1]):
+                    col_idx = thr_cX[i, j][1]
+                    linear_idx = i + j * thr_cX.shape[0]
+                    element_value1 = x[linear_idx]
+                    if element_value1 > current_max:
+                        current_max = element_value1
+                        current_argmax = Int32(col_idx)
+
+            lane_idx, warp_idx = cute.arch.lane_idx(), cute.arch.warp_idx()
+            if cutlass.const_expr(self.use_redux):
+                warp_max, warp_argmax = warp_argmax_redux(current_max, current_argmax)
+            else:
+                warp_max, warp_argmax = warp_reduce_argmax(current_max, current_argmax)
+
+            if cutlass.const_expr(self.cluster_n == 1):
+                warps_per_row = cute.size(reduction_buffer.shape[1])
+                row_idx_buf, col_idx_buf = (
+                    warp_idx // warps_per_row,
+                    warp_idx % warps_per_row,
+                )
+
+                if lane_idx == 0:
+                    reduction_buffer[row_idx_buf, col_idx_buf, 0, 0] = warp_max
+                    reduction_buffer[row_idx_buf, col_idx_buf, 0, 1] = warp_argmax.to(
+                        cutlass.Float32
+                    )
+
+                cute.arch.barrier()
+                block_reduce_max = -tXsX.element_type.inf
+                block_reduce_argmax = Int32(0xFFFFFFFF)
+
+                if lane_idx < warps_per_row:
+                    block_reduce_max = reduction_buffer[row_idx_buf, lane_idx, 0, 0]
+                    block_reduce_argmax = reduction_buffer[
+                        row_idx_buf, lane_idx, 0, 1
+                    ].to(cutlass.Int32)
+
+                if cutlass.const_expr(self.use_redux):
+                    warp_max, warp_argmax = warp_argmax_redux(
+                        block_reduce_max, block_reduce_argmax
+                    )
+                else:
+                    warp_max, warp_argmax = warp_reduce_argmax(
+                        block_reduce_max, block_reduce_argmax
+                    )
+            else:
+                cute.arch.cluster_wait()
+                warps_per_row, cluster_n = reduction_buffer.shape[1]
+                cta_rank_in_cluster = cute.arch.block_idx_in_cluster()
+                rows_per_block, (warps_per_row, cluster_n), _, _ = (
+                    reduction_buffer.shape
+                )
+                row_idx_buf, col_idx_buf = (
+                    warp_idx // warps_per_row,
+                    warp_idx % warps_per_row,
+                )
+
+                if warp_idx == 0:
+                    with cute.arch.elect_one():
+                        num_warps_total = rows_per_block * warps_per_row
+                        cute.arch.mbarrier_arrive_and_expect_tx(
+                            mbar_ptr,
+                            num_warps_total
+                            * cluster_n
+                            * 2
+                            * reduction_buffer.element_type.width
+                            // 8,
+                        )
+
+                if lane_idx < cluster_n:
+                    store_shared_remote(
+                        warp_max,
+                        elem_pointer(
+                            reduction_buffer,
+                            (row_idx_buf, (col_idx_buf, cta_rank_in_cluster), 0, 0),
+                        ),
+                        mbar_ptr,
+                        peer_cta_rank_in_cluster=lane_idx,
+                    )
+                    store_shared_remote(
+                        warp_argmax.to(cutlass.Float32),
+                        elem_pointer(
+                            reduction_buffer,
+                            (row_idx_buf, (col_idx_buf, cta_rank_in_cluster), 0, 1),
+                        ),
+                        mbar_ptr,
+                        peer_cta_rank_in_cluster=lane_idx,
+                    )
+
+                cute.arch.mbarrier_wait(mbar_ptr, phase=0)
+                block_reduce_val = -tXsX.element_type.inf
+                block_reduce_argmax = Int32(0xFFFFFFFF)
+                num_iter = cute.ceil_div(
+                    warps_per_row * cluster_n, cute.arch.WARP_SIZE
+                )
+
+                for i in cutlass.range_constexpr(num_iter):
+                    idx = lane_idx + i * cute.arch.WARP_SIZE
+                    if idx < cute.size(reduction_buffer, mode=[1]):
+                        element_max = reduction_buffer[row_idx_buf, idx, 0, 0]
+                        element_argmax = reduction_buffer[
+                            row_idx_buf, idx, 0, 1
+                        ].to(cutlass.Int32)
+                        if element_max > block_reduce_val:
+                            block_reduce_val = element_max
+                            block_reduce_argmax = element_argmax
+                        elif element_max == block_reduce_val:
+                            if element_argmax < block_reduce_argmax:
+                                block_reduce_argmax = element_argmax
+
+                if cutlass.const_expr(self.use_redux):
+                    warp_max, warp_argmax = warp_argmax_redux(
+                        block_reduce_val, block_reduce_argmax
+                    )
+                else:
+                    warp_max, warp_argmax = warp_reduce_argmax(
+                        block_reduce_val, block_reduce_argmax
+                    )
+
+            row_idx = tXcX[0][0]
+            warps_per_row = tv_layout.shape[0][0] // cute.arch.WARP_SIZE
+            local_row_idx = row_idx - (bidx * tiler_mn[0])
+            first_warp_for_row = local_row_idx * warps_per_row
+            first_thread_for_row = first_warp_for_row * cute.arch.WARP_SIZE
+
+            if cutlass.const_expr(self.dist_tp_enabled):
+                row_is_valid = (
+                    row_idx < shape[0]
+                    and local_row_idx >= 0
+                    and local_row_idx < tiler_mn[0]
+                    and (self.cluster_n == 1 or bidy == 0)
+                )
+                is_leader_warp = (warp_idx == first_warp_for_row) and row_is_valid
+
+                if is_leader_warp:
+                    if cutlass.const_expr(self.skip_ping_pong):
+                        round_bit = Int32(0)
+                    else:
+                        round_id_val = ptx_ld_global_u32(round_id_ptr)
+                        round_bit = round_id_val & Int32(1)
+                    band_off_u64 = (
+                        cutlass.Int64(row_idx) * cutlass.Int64(2)
+                        + cutlass.Int64(round_bit)
+                    ) * cutlass.Int64(self.world_size)
+
+                    if lane_idx == 0:
+                        global_idx = Int32(self.rank * self.N) + warp_argmax
+                        if warp_argmax == Int32(0xFFFFFFFF):
+                            global_idx = Int32(0x7FFFFFFF)
+                        packed = pack_argmax_payload_u64(warp_max, global_idx)
+                        mc_addr = slot_multicast_ptr + (
+                            band_off_u64 + cutlass.Int64(self.rank)
+                        ) * cutlass.Int64(8)
+                        ptx_multimem_st_release_u64(mc_addr, packed)
+
+                    local_pad = ptx_ld_acquire_sys_u64(
+                        slot_ptrs + cutlass.Int64(self.rank) * cutlass.Int64(8)
+                    )
+
+                    flag_bit_check = cutlass.Int64(1) << cutlass.Int64(63)
+                    clear_mask = cutlass.Int64(0x7FFFFFFFFFFFFFFF)
+                    peer_val = -tXsX.element_type.inf
+                    peer_idx = Int32(0x7FFFFFFF)
+                    if lane_idx < self.world_size:
+                        slot_addr = local_pad + (
+                            band_off_u64 + cutlass.Int64(lane_idx)
+                        ) * cutlass.Int64(8)
+                        v = cutlass.Int64(0)
+                        while (v & flag_bit_check) == cutlass.Int64(0):
+                            v = ptx_ld_acquire_sys_u64(slot_addr)
+                        peer_val, peer_idx = unpack_argmax_payload_u64(v)
+                        ptx_atomic_and_relaxed_sys_u64(slot_addr, clear_mask)
+
+                    if cutlass.const_expr(self.use_redux):
+                        warp_max, warp_argmax = warp_argmax_redux(
+                            peer_val, peer_idx
+                        )
+                    else:
+                        warp_max, warp_argmax = warp_reduce_argmax(
+                            peer_val, peer_idx
+                        )
+                    if warp_argmax == Int32(0x7FFFFFFF):
+                        warp_argmax = Int32(0xFFFFFFFF)
+
+                    if cutlass.const_expr(not self.skip_ping_pong):
+                        if lane_idx == 0:
+                            old = ptx_atomic_add_acq_rel_sys_u32(
+                                warps_done_ptr, cutlass.Int32(1)
+                            )
+                            if old == cutlass.Int32(shape[0]) - cutlass.Int32(1):
+                                ptx_atomic_add_acq_rel_sys_u32(
+                                    round_id_ptr, cutlass.Int32(1)
+                                )
+                                ptx_st_relaxed_sys_u32(
+                                    warps_done_ptr, cutlass.Int32(0)
+                                )
+
+            if (
+                tidx == first_thread_for_row
+                and row_idx < shape[0]
+                and local_row_idx >= 0
+                and local_row_idx < tiler_mn[0]
+                and (self.cluster_n == 1 or bidy == 0)
+            ):
+                mO_max[local_row_idx] = warp_max.to(mO_max.element_type)
+                mO_idx[local_row_idx] = warp_argmax.to(mO_idx.element_type)
+
+
+_dist_argmax_compile_cache: dict[tuple, object] = {}
+
+
+@dataclass
+class DistArgmaxState:
+    group: _dist.ProcessGroup
+    rank_in_group: int
+    world_size: int
+    max_M: int
+    dtype: torch.dtype
+    device: torch.device
+    slot_buffer: torch.Tensor
+    slot_handle: object
+    round_id_gpu: torch.Tensor
+    warps_done_gpu: torch.Tensor
+    use_redux: bool
+    skip_ping_pong: bool = False
+
+
+def create_dist_argmax_state(
+    group: _dist.ProcessGroup,
+    rank_in_group: int,
+    max_M: int,
+    dtype: torch.dtype = torch.bfloat16,
+    device: torch.device | None = None,
+    skip_ping_pong: bool = False,
+) -> DistArgmaxState:
+    assert dtype in (torch.bfloat16, torch.float16, torch.float32), (
+        f"distributed argmax supports bf16/fp16/fp32 value dtype; got {dtype}"
+    )
+    assert _ARCH_SUPPORTED and _CUTE_AVAILABLE, (
+        "distributed_argmax requires CuTe DSL on NVIDIA Hopper+/Blackwell; "
+        "current platform doesn't qualify."
+    )
+    device = device or torch.device(f"cuda:{torch.cuda.current_device()}")
+    world_size = group.size()
+    assert 1 <= world_size <= 32, (
+        f"world_size={world_size} unsupported; must be 1..32 (cross-rank "
+        f"reduce uses a single warp shuffle)"
+    )
+    p = current_platform()
+    sm = p.arch_version.major * 10 + p.arch_version.minor
+    use_redux = 100 <= sm < 120
+    slots = _symm_mem.empty(
+        (2 * max_M * world_size,), dtype=torch.int64, device=device,
+    )
+    slots.zero_()
+    round_id_gpu = torch.zeros(1, dtype=torch.int32, device=device)
+    warps_done_gpu = torch.zeros(1, dtype=torch.int32, device=device)
+    torch.cuda.current_stream().synchronize()
+    hdl = _symm_mem.rendezvous(slots, group=group)
+    assert hdl.rank == rank_in_group and hdl.world_size == world_size, (
+        f"symm-mem handle reports rank={hdl.rank}, world_size={hdl.world_size}, "
+        f"but state was constructed with rank_in_group={rank_in_group}, "
+        f"world_size={world_size}"
+    )
+    if not hdl.multicast_ptr:
+        raise RuntimeError(
+            f"distributed_argmax requires CUDA multicast / NVLS, but the "
+            f"symm-mem handle on device {device} reports multicast_ptr="
+            f"{hdl.multicast_ptr}. The kernel uses multimem.st.release.sys "
+            f"which needs NVSwitch + sm_90+ multicast support; non-NVLS "
+            f"hardware (PCIe-only, passthrough, etc.) cannot run this op."
+        )
+    _dist.barrier(group=group, device_ids=[device.index])
+    return DistArgmaxState(
+        group=group,
+        rank_in_group=rank_in_group,
+        world_size=world_size,
+        max_M=max_M,
+        dtype=dtype,
+        device=device,
+        slot_buffer=slots,
+        slot_handle=hdl,
+        round_id_gpu=round_id_gpu,
+        warps_done_gpu=warps_done_gpu,
+        use_redux=use_redux,
+        skip_ping_pong=skip_ping_pong,
+    )
+
+
+def _dist_argmax_validate_inputs(
+    state: DistArgmaxState,
+    logits: torch.Tensor,
+    out_max: torch.Tensor | None,
+    out_idx: torch.Tensor | None,
+) -> tuple[int, int]:
+    assert logits.dim() == 2, (
+        f"logits must be 2D (M, N); got shape {tuple(logits.shape)}"
+    )
+    M, N = logits.shape
+    assert logits.device == state.device, (
+        f"logits.device={logits.device} != state.device={state.device}"
+    )
+    assert logits.dtype == state.dtype, (
+        f"logits.dtype={logits.dtype} != state.dtype={state.dtype}"
+    )
+    assert N >= _MIN_VOCAB_SIZE, (
+        f"per-rank vocab N={N} below kernel floor {_MIN_VOCAB_SIZE}"
+    )
+    assert N % _VOCAB_SIZE_ALIGNMENT == 0, (
+        f"per-rank vocab N={N} not aligned to {_VOCAB_SIZE_ALIGNMENT}"
+    )
+    if out_max is not None:
+        assert out_max.shape == (M,) and out_max.device == logits.device, (
+            f"out_max must be shape ({M},) on logits.device; got "
+            f"shape={tuple(out_max.shape)} device={out_max.device}"
+        )
+    if out_idx is not None:
+        _validate_argmax_out(logits, out_idx)
+    return M, N
+
+
+def _dist_argmax_invoke_kernel(
+    state: DistArgmaxState,
+    logits: torch.Tensor,
+    out_max: torch.Tensor,
+    out_idx: torch.Tensor,
+) -> None:
+    dtype = torch2cute_dtype_map[logits.dtype]
+    x_tensor = _convert_to_cute(logits)
+    max_tensor = _convert_to_cute_1d(out_max)
+    idx_tensor = _convert_to_cute_1d(out_idx)
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    N = logits.shape[1]
+    compile_key = (
+        dtype, N, state.use_redux, out_max.dtype, out_idx.dtype,
+        state.world_size, state.rank_in_group, state.skip_ping_pong,
+    )
+    round_id_ptr = state.round_id_gpu.data_ptr()
+    warps_done_ptr = state.warps_done_gpu.data_ptr()
+    compiled = _dist_argmax_compile_cache.get(compile_key)
+    if compiled is None:
+        kernel = DistArgmaxKernel(
+            dtype, N, use_redux=state.use_redux,
+            world_size=state.world_size, rank=state.rank_in_group,
+            skip_ping_pong=state.skip_ping_pong,
+        )
+        compiled = cute.compile(
+            kernel, x_tensor, max_tensor, idx_tensor, stream,
+            state.slot_handle.buffer_ptrs_dev,
+            state.slot_handle.multicast_ptr,
+            round_id_ptr,
+            warps_done_ptr,
+        )
+        _dist_argmax_compile_cache[compile_key] = compiled
+
+    compiled(
+        x_tensor, max_tensor, idx_tensor, stream,
+        state.slot_handle.buffer_ptrs_dev,
+        state.slot_handle.multicast_ptr,
+        round_id_ptr,
+        warps_done_ptr,
+    )
+
+
+def distributed_argmax(
+    state: DistArgmaxState,
+    logits: torch.Tensor,
+    *,
+    out_max: torch.Tensor | None = None,
+    out_idx: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Distributed argmax over the vocab dim, across ``state.group``.
+
+    Contract: every rank in ``state.group`` calls this in lockstep with
+    matching ``M, N``, same ``state``, and the same call ordering — the
+    cross-rank exchange is collective and slot bands are reused across
+    calls. Do not share one ``DistArgmaxState`` across concurrent streams.
+    """
+    M, N = _dist_argmax_validate_inputs(state, logits, out_max, out_idx)
+    device = logits.device
+
+    if state.world_size == 1:
+        max_vals, idx_vals = logits.max(dim=-1)
+        if out_max is not None:
+            out_max.copy_(max_vals.to(out_max.dtype))
+            max_vals = out_max
+        if out_idx is not None:
+            out_idx.copy_(idx_vals)
+            idx_vals = out_idx
+        return max_vals, idx_vals
+
+    assert M <= state.max_M, f"batch size {M} exceeds state.max_M={state.max_M}"
+    assert state.world_size * N < 0x7FFFFFFF, (
+        f"world_size*N = {state.world_size * N} overflows the 31-bit slot idx"
+    )
+
+    if out_max is None:
+        out_max = torch.empty((M,), dtype=logits.dtype, device=device)
+    if out_idx is None:
+        out_idx = torch.empty((M,), dtype=torch.int64, device=device)
+    _dist_argmax_invoke_kernel(state, logits, out_max, out_idx)
+    return out_max, out_idx

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
@@ -49,7 +49,6 @@ from dataclasses import dataclass
 import torch
 import torch.distributed as _dist
 import torch.distributed._symmetric_memory as _symm_mem
-
 from tokenspeed_kernel.platform import (
     ArchVersion,
     CapabilityRequirement,
@@ -467,9 +466,8 @@ if _CUTE_AVAILABLE:
     def pack_argmax_payload_u64(
         val_f32: cutlass.Float32, global_idx: cutlass.Int32
     ) -> cutlass.Int64:
-        val_bits = (
-            val_f32.bitcast(cutlass.Int32).to(cutlass.Int64)
-            & cutlass.Int64(0xFFFFFFFF)
+        val_bits = val_f32.bitcast(cutlass.Int32).to(cutlass.Int64) & cutlass.Int64(
+            0xFFFFFFFF
         )
         idx_bits = cutlass.Int64(global_idx) & cutlass.Int64(0x7FFFFFFF)
         flag_bit = cutlass.Int64(1) << cutlass.Int64(63)
@@ -479,15 +477,11 @@ if _CUTE_AVAILABLE:
     def unpack_argmax_payload_u64(packed: cutlass.Int64):
         val_bits32 = (packed & cutlass.Int64(0xFFFFFFFF)).to(Int32)
         val_f32 = val_bits32.bitcast(cutlass.Float32)
-        idx_i32 = (
-            (packed >> cutlass.Int64(32)) & cutlass.Int64(0x7FFFFFFF)
-        ).to(Int32)
+        idx_i32 = ((packed >> cutlass.Int64(32)) & cutlass.Int64(0x7FFFFFFF)).to(Int32)
         return val_f32, idx_i32
 
     @dsl_user_op
-    def ptx_ld_global_u32(
-        addr: cutlass.Int64, *, loc=None, ip=None
-    ) -> cutlass.Int32:
+    def ptx_ld_global_u32(addr: cutlass.Int64, *, loc=None, ip=None) -> cutlass.Int32:
         return cutlass.Int32(
             llvm.inline_asm(
                 T.i32(),
@@ -776,17 +770,15 @@ if _CUTE_AVAILABLE:
                 cute.arch.mbarrier_wait(mbar_ptr, phase=0)
                 block_reduce_val = -tXsX.element_type.inf
                 block_reduce_argmax = Int32(0xFFFFFFFF)
-                num_iter = cute.ceil_div(
-                    warps_per_row * cluster_n, cute.arch.WARP_SIZE
-                )
+                num_iter = cute.ceil_div(warps_per_row * cluster_n, cute.arch.WARP_SIZE)
 
                 for i in cutlass.range_constexpr(num_iter):
                     idx = lane_idx + i * cute.arch.WARP_SIZE
                     if idx < cute.size(reduction_buffer, mode=[1]):
                         element_max = reduction_buffer[row_idx_buf, idx, 0, 0]
-                        element_argmax = reduction_buffer[
-                            row_idx_buf, idx, 0, 1
-                        ].to(cutlass.Int32)
+                        element_argmax = reduction_buffer[row_idx_buf, idx, 0, 1].to(
+                            cutlass.Int32
+                        )
                         if element_max > block_reduce_val:
                             block_reduce_val = element_max
                             block_reduce_argmax = element_argmax
@@ -858,13 +850,9 @@ if _CUTE_AVAILABLE:
                         ptx_atomic_and_relaxed_sys_u64(slot_addr, clear_mask)
 
                     if cutlass.const_expr(self.use_redux):
-                        warp_max, warp_argmax = warp_argmax_redux(
-                            peer_val, peer_idx
-                        )
+                        warp_max, warp_argmax = warp_argmax_redux(peer_val, peer_idx)
                     else:
-                        warp_max, warp_argmax = warp_reduce_argmax(
-                            peer_val, peer_idx
-                        )
+                        warp_max, warp_argmax = warp_reduce_argmax(peer_val, peer_idx)
                     if warp_argmax == Int32(0x7FFFFFFF):
                         warp_argmax = Int32(0xFFFFFFFF)
 
@@ -877,9 +865,7 @@ if _CUTE_AVAILABLE:
                                 ptx_atomic_add_acq_rel_sys_u32(
                                     round_id_ptr, cutlass.Int32(1)
                                 )
-                                ptx_st_relaxed_sys_u32(
-                                    warps_done_ptr, cutlass.Int32(0)
-                                )
+                                ptx_st_relaxed_sys_u32(warps_done_ptr, cutlass.Int32(0))
 
             if (
                 tidx == first_thread_for_row
@@ -919,9 +905,11 @@ def create_dist_argmax_state(
     device: torch.device | None = None,
     skip_ping_pong: bool = False,
 ) -> DistArgmaxState:
-    assert dtype in (torch.bfloat16, torch.float16, torch.float32), (
-        f"distributed argmax supports bf16/fp16/fp32 value dtype; got {dtype}"
-    )
+    assert dtype in (
+        torch.bfloat16,
+        torch.float16,
+        torch.float32,
+    ), f"distributed argmax supports bf16/fp16/fp32 value dtype; got {dtype}"
     assert _ARCH_SUPPORTED and _CUTE_AVAILABLE, (
         "distributed_argmax requires CuTe DSL on NVIDIA Hopper+/Blackwell; "
         "current platform doesn't qualify."
@@ -936,7 +924,9 @@ def create_dist_argmax_state(
     sm = p.arch_version.major * 10 + p.arch_version.minor
     use_redux = 100 <= sm < 120
     slots = _symm_mem.empty(
-        (2 * max_M * world_size,), dtype=torch.int64, device=device,
+        (2 * max_M * world_size,),
+        dtype=torch.int64,
+        device=device,
     )
     slots.zero_()
     round_id_gpu = torch.zeros(1, dtype=torch.int32, device=device)
@@ -979,22 +969,22 @@ def _dist_argmax_validate_inputs(
     out_max: torch.Tensor | None,
     out_idx: torch.Tensor | None,
 ) -> tuple[int, int]:
-    assert logits.dim() == 2, (
-        f"logits must be 2D (M, N); got shape {tuple(logits.shape)}"
-    )
+    assert (
+        logits.dim() == 2
+    ), f"logits must be 2D (M, N); got shape {tuple(logits.shape)}"
     M, N = logits.shape
-    assert logits.device == state.device, (
-        f"logits.device={logits.device} != state.device={state.device}"
-    )
-    assert logits.dtype == state.dtype, (
-        f"logits.dtype={logits.dtype} != state.dtype={state.dtype}"
-    )
-    assert N >= _MIN_VOCAB_SIZE, (
-        f"per-rank vocab N={N} below kernel floor {_MIN_VOCAB_SIZE}"
-    )
-    assert N % _VOCAB_SIZE_ALIGNMENT == 0, (
-        f"per-rank vocab N={N} not aligned to {_VOCAB_SIZE_ALIGNMENT}"
-    )
+    assert (
+        logits.device == state.device
+    ), f"logits.device={logits.device} != state.device={state.device}"
+    assert (
+        logits.dtype == state.dtype
+    ), f"logits.dtype={logits.dtype} != state.dtype={state.dtype}"
+    assert (
+        N >= _MIN_VOCAB_SIZE
+    ), f"per-rank vocab N={N} below kernel floor {_MIN_VOCAB_SIZE}"
+    assert (
+        N % _VOCAB_SIZE_ALIGNMENT == 0
+    ), f"per-rank vocab N={N} not aligned to {_VOCAB_SIZE_ALIGNMENT}"
     if out_max is not None:
         assert out_max.shape == (M,) and out_max.device == logits.device, (
             f"out_max must be shape ({M},) on logits.device; got "
@@ -1019,20 +1009,33 @@ def _dist_argmax_invoke_kernel(
 
     N = logits.shape[1]
     compile_key = (
-        dtype, N, state.use_redux, out_max.dtype, out_idx.dtype,
-        state.world_size, state.rank_in_group, state.skip_ping_pong,
+        dtype,
+        N,
+        state.use_redux,
+        out_max.dtype,
+        out_idx.dtype,
+        state.world_size,
+        state.rank_in_group,
+        state.skip_ping_pong,
     )
     round_id_ptr = state.round_id_gpu.data_ptr()
     warps_done_ptr = state.warps_done_gpu.data_ptr()
     compiled = _dist_argmax_compile_cache.get(compile_key)
     if compiled is None:
         kernel = DistArgmaxKernel(
-            dtype, N, use_redux=state.use_redux,
-            world_size=state.world_size, rank=state.rank_in_group,
+            dtype,
+            N,
+            use_redux=state.use_redux,
+            world_size=state.world_size,
+            rank=state.rank_in_group,
             skip_ping_pong=state.skip_ping_pong,
         )
         compiled = cute.compile(
-            kernel, x_tensor, max_tensor, idx_tensor, stream,
+            kernel,
+            x_tensor,
+            max_tensor,
+            idx_tensor,
+            stream,
             state.slot_handle.buffer_ptrs_dev,
             state.slot_handle.multicast_ptr,
             round_id_ptr,
@@ -1041,7 +1044,10 @@ def _dist_argmax_invoke_kernel(
         _dist_argmax_compile_cache[compile_key] = compiled
 
     compiled(
-        x_tensor, max_tensor, idx_tensor, stream,
+        x_tensor,
+        max_tensor,
+        idx_tensor,
+        stream,
         state.slot_handle.buffer_ptrs_dev,
         state.slot_handle.multicast_ptr,
         round_id_ptr,
@@ -1077,9 +1083,9 @@ def distributed_argmax(
         return max_vals, idx_vals
 
     assert M <= state.max_M, f"batch size {M} exceeds state.max_M={state.max_M}"
-    assert state.world_size * N < 0x7FFFFFFF, (
-        f"world_size*N = {state.world_size * N} overflows the 31-bit slot idx"
-    )
+    assert (
+        state.world_size * N < 0x7FFFFFFF
+    ), f"world_size*N = {state.world_size * N} overflows the 31-bit slot idx"
 
     if out_max is None:
         out_max = torch.empty((M,), dtype=logits.dtype, device=device)


### PR DESCRIPTION
## Summary

Adds a CuTe DSL `distributed_argmax` kernel and wires it into the EAGLE draft loop. For TP-sharded vocab, each rank's local top-1 is exchanged cross-rank via NVLS multicast + symm-mem and reduced in one kernel — replacing the **all-gather of full `[T, V]` logits + argmax** with a single fused op.

- `LogitsProcessor(do_argmax=True)` (draft models) emits `next_token_ids` in `forward`, choosing the fused kernel when gated on and otherwise falling back to all-gather + argmax. `eagle.py` just consumes `next_token_ids`.
- **Safe gate** (else fallback): NVIDIA+CuTe, `tp_size>1`, non-DP, no vocab padding, `N≥4096 & %32`, NVLS available. Disabled under `final_logit_softcapping`.

## Performance Impact

Fusing the gather into the argmax avoids materializing `[T, V]` on every rank.

**TP4, B200, K2.5 (V=163840):**

| Tokens | 4 | 16 | 64 | 128 |
|--------|------|------|------|--------|
| Speedup | 1.47× | 1.93× | 3.27× | **5.56×** |
