### PR TITLE
feat: support qwen3.5 on Hopper GPUs

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -1110,13 +1110,14 @@ class MambaAttnBackend(AttentionBackend):
                     and head_v_dim == head_k_dim
                 ):
                     raise RuntimeError(
-                        "GDN prefill requires the flashinfer Blackwell fast-path "
-                        "(sm100/sm103 + CUDA 13 + bf16 + head_dim=128 + "
-                        "head_v == head_k + num_v >= num_q). Got "
+                        "GDN prefill requires the flashinfer fast-path "
+                        "(sm90 Hopper, or sm100/sm103 Blackwell + CUDA 13; "
+                        "bf16 + head_dim=128 + head_v == head_k + num_v >= num_q). "
+                        "Got "
                         f"dtype={query.dtype}, head_k={head_k_dim}, "
                         f"head_v={head_v_dim}, num_q={num_heads}, "
                         f"num_v={num_value_heads}, "
-                        f"sm100_available={gdn_flashinfer.is_available()}."
+                        f"fi_available={gdn_flashinfer.is_available()}."
                     )
                 self._gdn_fastpath_checked = True
             if need_h_track:

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flashinfer/gated_delta_rule.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flashinfer/gated_delta_rule.py
@@ -15,17 +15,21 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""FlashInfer Blackwell (sm100) gated delta net chunked prefill.
+"""FlashInfer gated delta net chunked prefill (Hopper sm90 + Blackwell sm100/sm103).
 
-Fast-path for GDN prefill on Blackwell (sm100/sm103) + CUDA 13 + bf16 +
-head_dim==128. The caller gates on ``is_supported`` and must fail fast when the
-fast-path is unavailable;
-this module has no Triton fallback.
+Fast-path for GDN prefill on bf16 + head_dim==128. flashinfer's
+``chunk_gated_delta_rule`` is a unified API that dispatches by architecture under
+the hood: a CuTe DSL kernel on Blackwell (sm100/sm103, CUDA 13) and a C++ JIT
+kernel on Hopper (sm90). Both share the same input/output conventions and are
+validated against the same reference in flashinfer's
+``tests/gdn/test_prefill_delta_rule.py``. The caller gates on ``is_supported``
+and must fail fast when the fast-path is unavailable; this module has no Triton
+fallback.
 
-Convention vs the Triton FLA path (verified equal to bf16 on B200):
-- q, k must be L2-normalized by the caller (the sm100 kernel ignores its own
+Convention vs the Triton FLA path (verified equal to bf16 on B200 and H200):
+- q, k must be L2-normalized by the caller (the kernel ignores its own
   use_qk_l2norm flag).
-- g is the FLA log-space forget gate; the sm100 kernel takes log internally, so
+- g is the FLA log-space forget gate; flashinfer takes log internally, so
   we pass alpha = exp(g).
 - beta is cast to float32 (flashinfer passes it through without casting).
 - the recurrent state is stored transposed (K<->V) vs FLA, so we transpose the
@@ -45,29 +49,43 @@ _AVAILABLE = False
 
 if current_platform().is_nvidia:
     try:
-        from flashinfer.gdn_kernels import (
-            _has_blackwell_prefill as _fi_has_blackwell_prefill,
-        )
         from flashinfer.gdn_prefill import chunk_gated_delta_rule as _fi_chunk
+
+        # flashinfer < 0.6.13 exposed `_has_blackwell_prefill` from
+        # flashinfer.gdn_kernels to tell whether the Blackwell CuTe DSL prefill
+        # kernel is present. flashinfer main removed that symbol (the kernels are
+        # now imported directly), so treat its absence as "present" -- on main
+        # the sm100 path is always available when the arch/CUDA match.
+        try:
+            from flashinfer.gdn_kernels import (
+                _has_blackwell_prefill as _fi_has_blackwell_prefill,
+            )
+        except ImportError:
+            _fi_has_blackwell_prefill = True
 
         _chunk_gated_delta_rule = _fi_chunk
         _p = current_platform()
         _cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
-        # flashinfer's gdn_prefill treats any compute-capability major 10 as the
-        # Blackwell path (sm100 B200/GB200, sm103 B300), gated on CUDA>=13 and the
-        # prefill kernel being present; it raises NotImplementedError otherwise.
-        # Mirror that here so the caller does not commit to a crashing fast-path.
-        _AVAILABLE = (
+        # flashinfer's chunk_gated_delta_rule is a unified API that dispatches by
+        # architecture internally:
+        #   - sm100/sm103 (Blackwell): CuTe DSL kernel, needs CUDA>=13 and the
+        #     blackwell prefill module present, else it falls through.
+        #   - sm90 (Hopper): C++ JIT kernel, always available on major==9.
+        # Mirror that dispatch here so the caller only commits to a fast-path
+        # that flashinfer can actually run.
+        _is_blackwell = (
             _p.arch_version.major == 10
             and _cuda_major >= 13
             and _fi_has_blackwell_prefill
         )
+        _is_hopper = _p.arch_version.major == 9
+        _AVAILABLE = _is_blackwell or _is_hopper
     except ImportError:
         _AVAILABLE = False
 
 
 def is_available() -> bool:
-    """Whether the sm100 GDN kernel can run on this platform."""
+    """Whether the flashinfer GDN prefill kernel can run on this platform."""
     return _AVAILABLE
 
 


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

This PR support qwen3.5 on Hopper GPUs, but there is a bug in flashinfer gdn kernel until the latest release. 

If processing one request, the ouput is OK, but if processing varlen batched requests, e.g. accuracy benchmark using evalscope, the result is not right.

However, this bug was resolved in the main branch of flashinfer, so I leave this pr as draft and think it's better to upgrade flashinfer to the latest in the future, maybe v0.6.14.


## Test Plan

The test is based on flashinfer latest main branch on H200 GPU.
Here is the server startup command:
```bash
tokenspeed serve --model "$MODEL_PATH" \
  --port "$PORT" \
  --served-model-name Qwen35-35B-A3B \
  --enable-expert-parallel \
  --moe-backend flashinfer_cutlass \
  --tensor-parallel-size 2 \
  --max-model-len 40960
```

Here is the accuracy test result using evalscope:
```
┌────────────────┬───────────┬──────────┬──────────┬───────┬─────────┬─────────┐
│ Model          │ Dataset   │ Metric   │ Subset   │   Num │   Score │ Cat.0   │
├────────────────┼───────────┼──────────┼──────────┼───────┼─────────┼─────────┤
│ Qwen35-35B-A3B │ gsm8k     │ mean_acc │ main     │  1319 │  0.9575 │ default │
└────────────────┴───────────┴──────────┴──────────┴───────┴─────────┴─────────┘ 
```

Here is the bench command and result:
```bash
tokenspeed bench serve \
    --backend tokenspeed \
    --base-url "http://${HOST}:${PORT}" \
    --model "${MODEL_PATH}" \
    --tokenizer "${MODEL_PATH}" \
    --served-model-name "${SERVED_MODEL}" \
    --dataset-name random \
    --random-input-len 2048 \
    --random-output-len 2048 \
    --num-prompts 128 \
    --max-concurrency 2048 \
    --num-warmups 4
```
```
============ Serving Benchmark Result ============
Successful requests:                     128       
Failed requests:                         0         
Maximum request concurrency:             2048      
Benchmark duration (s):                  57.39     
Total input tokens:                      251519    
Total generated tokens:                  262008    
Request throughput (req/s):              2.23      
Output token throughput (tok/s):         4565.69   
Peak output token throughput (tok/s):    7313.00   
Peak concurrent requests:                128.00    
Total token throughput (tok/s):          8948.59   
---------------Time to First Token----------------
Mean TTFT (ms):                          10762.61  
Median TTFT (ms):                        4353.72   
P99 TTFT (ms):                           37139.91  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          14.44     
Median TPOT (ms):                        15.30     
P99 TPOT (ms):                           17.03     
---------------Inter-token Latency----------------
Mean ITL (ms):                           14.63     
Median ITL (ms):                         14.22     
P99 ITL (ms):                            27.44     
==================================================
```
<!-- How was this validated? -->
