### PR TITLE
fix(quant): honor layer-wise quantization exclusion for MoE experts

### DIFF
--- a/python/tokenspeed/runtime/layers/linear.py
+++ b/python/tokenspeed/runtime/layers/linear.py
@@ -58,7 +58,10 @@ from tokenspeed.runtime.layers.quantization.base_config import (
 from tokenspeed.runtime.layers.quantization.compressed_tensors.compressed_tensors import (
     CompressedTensorsConfig,
 )
-from tokenspeed.runtime.layers.quantization.utils import should_ignore_quant_layer
+from tokenspeed.runtime.layers.quantization.utils import (
+    should_exclude_quant_module,
+    should_ignore_quant_layer,
+)
 from tokenspeed.runtime.utils import get_colorful_logger, set_weight_attrs
 
 logger = get_colorful_logger(__name__)
@@ -175,7 +178,7 @@ class LinearBase(torch.nn.Module):
             self.quant_method: QuantizeMethodBase | None = UnquantizedLinearMethod()
         elif isinstance(quant_config, Nvfp4Config):
             # For NVFP4, excluded layers use unquantized (bf16)
-            if quant_config.is_layer_excluded(prefix):
+            if should_exclude_quant_module(prefix, quant_config.exclude_modules):
                 self.quant_method = UnquantizedLinearMethod()
             else:
                 self.quant_method = Nvfp4LinearMethod(quant_config)

--- a/python/tokenspeed/runtime/layers/moe/expert.py
+++ b/python/tokenspeed/runtime/layers/moe/expert.py
@@ -35,7 +35,10 @@ from tokenspeed.runtime.layers.moe.utils import (
 )
 from tokenspeed.runtime.layers.moe.weights import create_layer_weights
 from tokenspeed.runtime.layers.quantization.base_config import QuantizationConfig
-from tokenspeed.runtime.layers.quantization.utils import should_ignore_quant_layer
+from tokenspeed.runtime.layers.quantization.utils import (
+    should_exclude_quant_module,
+    should_ignore_quant_layer,
+)
 from tokenspeed.runtime.utils.env import global_server_args_dict
 from tokenspeed.runtime.utils.pdl import pdl_enabled
 
@@ -140,11 +143,15 @@ class MoELayer(torch.nn.Module):
         self._topk_group = routing_config.get("topk_group", 0)
         self._routed_scaling_factor = routing_config.get("routed_scaling_factor", 1.0)
 
-        # Quantization config
+        # Quantization config. ignored_layers (compressed-tensors) keys the MoE
+        # block; exclude_modules (ModelOpt) keys the fused experts.
         self._quant_kind = "unquant"
-        if quant_config is not None and not should_ignore_quant_layer(
-            prefix=self.prefix,
-            ignored_layers=quant_config.ignored_layers,
+        if (
+            quant_config is not None
+            and not should_ignore_quant_layer(self.prefix, quant_config.ignored_layers)
+            and not should_exclude_quant_module(
+                f"{self.prefix}.experts", quant_config.exclude_modules
+            )
         ):
             self._quant_kind = quant_config.moe_weight_dtype()
 

--- a/python/tokenspeed/runtime/layers/quantization/base_config.py
+++ b/python/tokenspeed/runtime/layers/quantization/base_config.py
@@ -56,8 +56,13 @@ class QuantizeMethodBase(ABC):
 class QuantizationConfig(ABC):
     """Base class for quantization configs."""
 
-    def __init__(self, ignored_layers: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        ignored_layers: list[str] | None = None,
+        exclude_modules: list[str] | None = None,
+    ) -> None:
         self.ignored_layers = ignored_layers or []
+        self.exclude_modules = exclude_modules or []
 
     @abstractmethod
     def get_name(self) -> str:

--- a/python/tokenspeed/runtime/layers/quantization/nvfp4.py
+++ b/python/tokenspeed/runtime/layers/quantization/nvfp4.py
@@ -39,10 +39,9 @@ class Nvfp4Config(QuantizationConfig):
         group_size: int = 16,
         exclude_modules: list[str] | None = None,
     ) -> None:
-        super().__init__()
+        super().__init__(exclude_modules=exclude_modules)
         self.kv_cache_quant_algo = kv_cache_quant_algo
         self.group_size = group_size
-        self.exclude_modules = exclude_modules or []
         self.weight_block_size = None  # FP4 uses group_size, not weight_block_size
 
     @classmethod
@@ -114,13 +113,3 @@ class Nvfp4Config(QuantizationConfig):
 
     def get_scaled_act_names(self) -> list[str]:
         return []
-
-    def is_layer_excluded(self, prefix: str) -> bool:
-        """Check if a layer should be excluded from FP4 quantization."""
-        import re
-
-        for pattern in self.exclude_modules:
-            regex_str = pattern.replace(".", r"\.").replace("*", ".*")
-            if re.fullmatch(regex_str, prefix):
-                return True
-        return False

--- a/python/tokenspeed/runtime/layers/quantization/utils.py
+++ b/python/tokenspeed/runtime/layers/quantization/utils.py
@@ -33,6 +33,17 @@ from tokenspeed.runtime.layers.quantization.compressed_tensors.scalar_type impor
 )
 
 
+def should_exclude_quant_module(prefix: str, exclude_modules: list[str]) -> bool:
+    """Whether ``prefix`` matches a ModelOpt-style glob in ``exclude_modules``."""
+    if prefix is None or not exclude_modules:
+        return False
+    for pattern in exclude_modules:
+        regex_str = pattern.replace(".", r"\.").replace("*", ".*")
+        if re.fullmatch(regex_str, prefix):
+            return True
+    return False
+
+
 def should_ignore_quant_layer(
     prefix: str,
     ignored_layers: list[str],

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -89,6 +89,7 @@ from tokenspeed.runtime.layers.quantization.base_config import QuantizationConfi
 from tokenspeed.runtime.layers.quantization.nvfp4 import Nvfp4Config
 from tokenspeed.runtime.layers.quantization.utils import (
     block_dequant,
+    should_exclude_quant_module,
     should_ignore_quant_layer,
 )
 from tokenspeed.runtime.layers.rotary_embedding import get_rope
@@ -418,9 +419,9 @@ class DeepseekV3FusedQkvAProjWithMqa(ReplicatedLinear):
             kv_a_prefix = prefix.replace(
                 "fused_qkv_a_proj_with_mqa", "kv_a_proj_with_mqa"
             )
-            if quant_config.is_layer_excluded(
-                q_a_prefix
-            ) or quant_config.is_layer_excluded(kv_a_prefix):
+            if should_exclude_quant_module(
+                q_a_prefix, quant_config.exclude_modules
+            ) or should_exclude_quant_module(kv_a_prefix, quant_config.exclude_modules):
                 quant_config = None
         super().__init__(
             input_size,


### PR DESCRIPTION
## Summary

ModelOpt (NVFP4) checkpoints exclude individual modules from quantization via
`hf_quant_config.json`'s `exclude_modules`. The existing `should_ignore_quant_layer`
path only covers compressed-tensors-style `ignored_layers`, and NVFP4 leaves
`ignored_layers` empty — so a mixed-precision ("skipedge") model that keeps some
MoE experts unquantized was getting quantized anyway.

This adds a **symmetric** exclusion path rather than a second ad-hoc mechanism:

- `exclude_modules` now lives on the base `QuantizationConfig`, right alongside
  `ignored_layers` (both default to `[]`).
- New free helper `should_exclude_quant_module(prefix, exclude_modules)` mirrors
  `should_ignore_quant_layer(prefix, ignored_layers)` — glob match for ModelOpt's
  `*` patterns.
- The MoE path (`expert.py`), `linear.py`, and `deepseek_v3.py` all check the two
  helpers symmetrically; the fused experts are keyed as `<prefix>.experts`.
- Removes the NVFP4-only `is_layer_excluded` method in favor of the shared helper —
  no more `isinstance` / `hasattr` branching at call sites.

```python
self._quant_kind = "unquant"
if (
    quant_config is not None
    and not should_ignore_quant_layer(self.prefix, quant_config.ignored_layers)
    and not should_exclude_quant_module(
        f"{self.prefix}.experts", quant_config.exclude_modules
    )
):
    self._quant_kind = quant_config.moe_weight_dtype()
```

No behavior change for non-NVFP4 configs (`exclude_modules` defaults to empty) or
for compressed-tensors `ignored_layers`.

## Test Plan

- `pre-commit run --all-files` passes.
- Helper sanity-checked: glob match (`*.experts`), empty-list no-op, and
  `Nvfp4Config(exclude_modules=…)` populates the field via the base config.
- [ ] Serve a ModelOpt NVFP4 "skipedge" checkpoint and confirm the excluded
  experts load as `unquant` while the rest quantize. *(pending — needs the model)*
