### PR TITLE
perf(deepseek-v4): deferred-state MHC forward for cross-layer fusion

### DIFF
--- a/python/tokenspeed/runtime/layers/deepseek_v4_mhc.py
+++ b/python/tokenspeed/runtime/layers/deepseek_v4_mhc.py
@@ -305,6 +305,35 @@ def _mhc_post_hc4_triton_kernel(
     )
 
 
+def mhc_fused_hc(
+    x_prev: torch.Tensor,
+    residual_prev: torch.Tensor,
+    post_prev: torch.Tensor,
+    comb_prev: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused post_mapping(prev) + pre_mapping(curr).
+
+    Returns (residual_cur, layer_input, post_cur, comb_cur).
+    """
+    residual_cur = mhc_post(x_prev, residual_prev, post_prev, comb_prev)
+    layer_input, post_cur, comb_cur = mhc_pre(
+        residual_cur,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_eps,
+        sinkhorn_iters,
+    )
+    return residual_cur, layer_input, post_cur, comb_cur
+
+
 def mhc_pre(
     residual: torch.Tensor,
     fn: torch.Tensor,

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -106,6 +106,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
     _group_slot_mapping_from_raw,
     _mask_invalid_graph_tokens,
 )
+from tokenspeed.runtime.layers.deepseek_v4_mhc import mhc_fused_hc as fast_mhc_fused_hc
 from tokenspeed.runtime.layers.deepseek_v4_mhc import mhc_post as fast_mhc_post
 from tokenspeed.runtime.layers.deepseek_v4_mhc import mhc_pre as fast_mhc_pre
 from tokenspeed.runtime.layers.layernorm import FusedRMSNorm, RMSNorm
@@ -389,6 +390,32 @@ def mhc_post(
     comb: torch.Tensor,
 ) -> torch.Tensor:
     return fast_mhc_post(hidden_states, residual, post, comb)
+
+
+def mhc_fused_hc(
+    x_prev: torch.Tensor,
+    residual_prev: torch.Tensor,
+    post_prev: torch.Tensor,
+    comb_prev: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    return fast_mhc_fused_hc(
+        x_prev,
+        residual_prev,
+        post_prev,
+        comb_prev,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_eps,
+        sinkhorn_iters,
+    )
 
 
 def hc_head(
@@ -3839,20 +3866,39 @@ class DeepseekV4DecoderLayer(nn.Module):
         input_ids: torch.Tensor,
         swa_slot_mapping: torch.Tensor | None = None,
         compressor_slot_cache: dict | None = None,
-    ) -> torch.Tensor:
-        residual = hidden_states
-        with nvtx_range("hc_attn_pre"):
-            hidden_states, post, comb = mhc_pre(
-                hidden_states,
-                self.hc_attn_fn,
-                self.hc_attn_scale,
-                self.hc_attn_base,
-                self.rms_norm_eps,
-                self.hc_eps,
-                self.hc_sinkhorn_iters,
-            )
+        hc_x_prev: torch.Tensor | None = None,
+        hc_post_prev: torch.Tensor | None = None,
+        hc_comb_prev: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        if hc_x_prev is not None:
+            with nvtx_range("hc_fused_attn_pre"):
+                residual, hidden_states, post, comb = mhc_fused_hc(
+                    hc_x_prev,
+                    hidden_states,
+                    hc_post_prev,
+                    hc_comb_prev,
+                    self.hc_attn_fn,
+                    self.hc_attn_scale,
+                    self.hc_attn_base,
+                    self.rms_norm_eps,
+                    self.hc_eps,
+                    self.hc_sinkhorn_iters,
+                )
+        else:
+            residual = hidden_states
+            with nvtx_range("hc_attn_pre"):
+                hidden_states, post, comb = mhc_pre(
+                    hidden_states,
+                    self.hc_attn_fn,
+                    self.hc_attn_scale,
+                    self.hc_attn_base,
+                    self.rms_norm_eps,
+                    self.hc_eps,
+                    self.hc_sinkhorn_iters,
+                )
         with nvtx_range("attn_norm"):
             hidden_states = self.attn_norm(hidden_states)
+
         with nvtx_range("attn_total"):
             hidden_states = self.attn(
                 positions,
@@ -3862,13 +3908,13 @@ class DeepseekV4DecoderLayer(nn.Module):
                 swa_slot_mapping,
                 compressor_slot_cache,
             )
-        with nvtx_range("hc_attn_post"):
-            hidden_states = mhc_post(hidden_states, residual, post, comb)
 
-        residual = hidden_states
-        with nvtx_range("hc_ffn_pre"):
-            hidden_states, post, comb = mhc_pre(
+        with nvtx_range("hc_fused_ffn_pre"):
+            residual, hidden_states, post, comb = mhc_fused_hc(
                 hidden_states,
+                residual,
+                post,
+                comb,
                 self.hc_ffn_fn,
                 self.hc_ffn_scale,
                 self.hc_ffn_base,
@@ -3878,6 +3924,7 @@ class DeepseekV4DecoderLayer(nn.Module):
             )
         with nvtx_range("ffn_norm"):
             hidden_states = self.ffn_norm(hidden_states)
+
         ffn_input_ids = input_ids
         use_mega_moe = getattr(self.ffn, "use_mega_moe", False)
         if use_mega_moe:
@@ -3909,9 +3956,8 @@ class DeepseekV4DecoderLayer(nn.Module):
                 hidden_states, _ = self.comm_manager.post_mlp_comm(
                     hidden_states, None, ctx
                 )
-        with nvtx_range("hc_ffn_post"):
-            hidden_states = mhc_post(hidden_states, residual, post, comb)
-        return hidden_states
+        # Defer ffn post_mapping to next layer's fused_hc
+        return residual, hidden_states, post, comb
 
 
 class DeepseekV4Model(nn.Module):
@@ -3993,8 +4039,11 @@ class DeepseekV4Model(nn.Module):
         # same ratio; memoize within the step (filled lazily by the first compressor of
         # each ratio, reused by the rest).
         compressor_slot_cache: dict = {}
+        hc_x_prev = None
+        hc_post_prev = None
+        hc_comb_prev = None
         for layer in self.layers:
-            hidden_states = layer(
+            hidden_states, hc_x_prev, hc_post_prev, hc_comb_prev = layer(
                 positions,
                 hidden_states,
                 ctx,
@@ -4002,6 +4051,13 @@ class DeepseekV4Model(nn.Module):
                 input_ids,
                 swa_slot_mapping,
                 compressor_slot_cache,
+                hc_x_prev,
+                hc_post_prev,
+                hc_comb_prev,
+            )
+        with nvtx_range("hc_ffn_post_final"):
+            hidden_states = mhc_post(
+                hc_x_prev, hidden_states, hc_post_prev, hc_comb_prev
             )
         aux_hidden_states = None
         if (

--- a/python/tokenspeed/runtime/models/deepseek_v4_mtp.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_mtp.py
@@ -52,6 +52,7 @@ from tokenspeed.runtime.models.deepseek_v4 import (
     DeepseekV4MegaMoEExperts,
     _deepseek_v4_swa_slot_mapping,
     hc_head,
+    mhc_post,
 )
 from tokenspeed.runtime.utils import add_prefix
 
@@ -180,7 +181,7 @@ class DeepseekV4MultiTokenPredictorLayer(nn.Module):
             positions,
             out_cache_loc,
         )
-        return self.mtp_block(
+        residual, x_def, post_def, comb_def = self.mtp_block(
             positions,
             hidden_states,
             ctx,
@@ -188,6 +189,7 @@ class DeepseekV4MultiTokenPredictorLayer(nn.Module):
             input_ids,
             swa_slot_mapping,
         )
+        return mhc_post(x_def, residual, post_def, comb_def)
 
     def compute_logits_hidden(self, hidden_states: torch.Tensor) -> torch.Tensor:
         hidden_states = hidden_states.view(-1, self.hc_mult, self.config.hidden_size)


### PR DESCRIPTION
## Summary
- Restructure V4 decoder layer to defer FFN `post_mapping` across layer boundaries, enabling cross-layer fusion of `mhc_post(prev) + mhc_pre(curr)` via new `mhc_fused_hc()` function
- Currently uses Triton fallback (same kernels as before, no perf change) — lays the structural groundwork for TRT-LLM MHC kernel integration (follow-up)
- With TRT-LLM `mhc_fused_hc` wired in: MHC decode time reduces ~5× (81us → 16.5us per post+pre boundary at bs≤8), saving ~7ms/step (~20% of graph-mode decode)

## Changes
- `deepseek_v4_mhc.py`: add `mhc_fused_hc()` (Triton fallback: `mhc_post + mhc_pre`)
- `deepseek_v4.py`: `DecoderLayer.forward()` accepts/returns deferred state `(residual, x, post, comb)` instead of single tensor; `Model.forward()` passes deferred state through layer loop, resolves final with `mhc_post` before `hc_head`
- `deepseek_v4_mtp.py`: MTP unpacks 4-tuple return from decoder layer

## Test plan
- [x] GSM8K 5-shot 50-sample: **0.94** (expected 0.96±0.04)
- [x] Standalone numerical correctness verified (2-layer pipeline, Triton ref vs fused path)
- [x] Pre-commit formatting pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)