### PR TITLE
fix(attention): use int64 paged-KV addressing in MHA Triton kernels

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/mha_decode.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/mha_decode.py
@@ -109,7 +109,8 @@ def _fwd_kernel_stage1(
                 mask=offs_n < split_kv_end,
                 other=0,
             )
-            kv_loc = physical_pages * PAGE_SIZE + page_offsets
+            # int64 to avoid address overflow for large (>int32 range) KV caches
+            kv_loc = physical_pages.to(tl.int64) * PAGE_SIZE + page_offsets
             offs_buf_k = (
                 kv_loc[:, None] * stride_buf_kbs
                 + cur_kv_head * stride_buf_kh
@@ -349,7 +350,8 @@ def _fwd_grouped_kernel_stage1(
                 mask=offs_n < split_kv_end,
                 other=0,
             )
-            kv_loc = physical_pages * PAGE_SIZE + page_offsets
+            # int64 to avoid address overflow for large (>int32 range) KV caches
+            kv_loc = physical_pages.to(tl.int64) * PAGE_SIZE + page_offsets
             offs_buf_k = (
                 kv_loc[None, :] * stride_buf_kbs
                 + cur_kv_head * stride_buf_kh

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/mha_prefill.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/mha_prefill.py
@@ -170,7 +170,8 @@ def _fwd_kernel(
                     mask=mask_n,
                     other=0,
                 )
-                offs_kv_loc = physical_pages * PAGE_SIZE + page_offsets
+                # int64 to avoid address overflow for large (>int32 range) KV caches
+                offs_kv_loc = physical_pages.to(tl.int64) * PAGE_SIZE + page_offsets
                 offs_k = (
                     offs_kv_loc[None, :] * stride_buf_kbs
                     + cur_kv_head * stride_buf_kh


### PR DESCRIPTION
Promote physical_pages to int64 before computing the KV element offset in mha_decode (grouped and ungrouped stage-1) and mha_prefill, so large (>int32 range) KV caches no longer wrap to a negative address.

Fixes issues similar to https://github.com/lightseekorg/tokenspeed/issues/521 and https://github.com/lightseekorg/tokenspeed/commit/fd789ef720eb922c0b32b22ebe960cf8b867be0c

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
