### PR TITLE
fix: decompose PrecisionConfig from tokenspeed-kernel-amd gluon moe

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
@@ -25,11 +25,6 @@ from typing import Any, Optional
 
 import torch
 from tokenspeed_kernel_amd._triton import aggregate, gl, gluon, tl, triton
-from tokenspeed_kernel_amd.ops.moe.mxfp4_gfx950_preprocess import (
-    FlexCtx,
-    InFlexData,
-    PrecisionConfig,
-)
 from tokenspeed_kernel_amd.ops.moe.utils import (
     FnSpecs,
     FusedActivation,
@@ -6394,47 +6389,38 @@ def gluon_mxfp_ragged_matmul(
     w: torch.Tensor,
     bias: torch.Tensor | None,
     *,
+    w_mx_scale: torch.Tensor,
+    x_global_scale: Optional[torch.Tensor] = None,
+    x_mx_scale: Optional[torch.Tensor] = None,
+    out_dtype: Optional[torch.dtype] = None,
+    x_format: str = "e4m3",
     a_ragged_metadata=None,
     gather_indx=None,
     scatter_indx=None,
-    precision_config: PrecisionConfig | None = None,
     fused_activation=None,
     n_tokens=None,
     n_expts_act=None,
     **extra_kwargs,
 ) -> torch.Tensor | None:
-    assert isinstance(precision_config, PrecisionConfig)
-    w_mx_scale = precision_config.b_mx_scale
     assert w_mx_scale is not None
 
-    flex = precision_config.flex_ctx
-    assert flex is None or isinstance(flex, FlexCtx)
-    lhs = flex.lhs_data if flex is not None else None
-    assert lhs is None or isinstance(lhs, InFlexData)
-    fp8_dtype = lhs.dtype if lhs is not None else None
-    fp8_scale = lhs.scale if lhs is not None else None
-
-    x_mx_scale = precision_config.a_mx_scale
-
-    if fp8_dtype is not None:
-        x_format = "e4m3"
-        x_global_scale = _global_scale_passthrough(fp8_scale)
+    if x_format == "e4m3":
+        x_global_scale = _global_scale_passthrough(x_global_scale)
         x_view = x.view(torch.uint8) if x.dtype != torch.uint8 else x
         x_scale = None
-    elif x_mx_scale is not None:
-        x_format = "e2m1"
+    elif x_format == "e2m1":
+        if x_mx_scale is None:
+            raise RuntimeError("x_mx_scale is required for e2m1 input X")
         x_global_scale = 1.0
         x_view = x.view(torch.uint8) if x.dtype != torch.uint8 else x
         x_scale = _extract_gluon_raw_s(x_mx_scale)
         assert isinstance(x_scale, torch.Tensor)
     else:
-        raise RuntimeError("missing required precision config for input X")
+        raise RuntimeError(f"unsupported input X format: {x_format}")
 
-    if precision_config.out_dtype is not None:
-        out_dtype = precision_config.out_dtype
-    elif x.dtype.is_floating_point:
+    if out_dtype is None and x.dtype.is_floating_point:
         out_dtype = x.dtype
-    else:
+    elif out_dtype is None:
         out_dtype = torch.bfloat16
 
     prefer_unshuffled_w = bool(extra_kwargs.get("prefer_unshuffled_w", False))
@@ -6527,10 +6513,11 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
     *,
     w13_bias=None,
     w2_bias=None,
-    w13_precision_config: PrecisionConfig | None = None,
-    w2_precision_config: PrecisionConfig | None = None,
+    w13_mx_scale: torch.Tensor,
+    w2_mx_scale: torch.Tensor,
     w13_act_scale: torch.Tensor,
     w2_act_scale: torch.Tensor,
+    out_dtype: torch.dtype,
     top_k: int,
     swiglu_alpha: float = 1.702,
     swiglu_limit: float = 7.0,
@@ -6545,12 +6532,6 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
     if n_tokens > WARP_DECODE_MAX_M:
         return None
     if not gluon_route_supported(router_logits, top_k, router_logits.dtype):
-        return None
-    if w13_precision_config is None or w2_precision_config is None:
-        return None
-    if not isinstance(w13_precision_config, PrecisionConfig) or not isinstance(
-        w2_precision_config, PrecisionConfig
-    ):
         return None
 
     # Use the optional Gluon dot-layout preshuffled attachments when they match
@@ -6571,8 +6552,8 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         and int(getattr(w2_raw_candidate, "gluon_dot_block_n", 0)) == 128
     )
     w2_raw = w2_raw_candidate if w2_preshuffled else _extract_gluon_raw_s(w2_weight)
-    w13_scale = _extract_gluon_raw_s(w13_precision_config.b_mx_scale)
-    w2_scale = _extract_gluon_raw_s(w2_precision_config.b_mx_scale)
+    w13_scale = _extract_gluon_raw_s(w13_mx_scale)
+    w2_scale = _extract_gluon_raw_s(w2_mx_scale)
     if not all(
         isinstance(t, torch.Tensor) for t in (w13_raw, w2_raw, w13_scale, w2_scale)
     ):
@@ -6616,7 +6597,6 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
     # Pass the FP8 tensor straight to Gluon.  ``view(torch.uint8)`` materializes a
     # copy for float8 tensors on this stack and dominates small-M latency.
 
-    out_dtype = w2_precision_config.out_dtype or torch.bfloat16
     out = torch.empty((n_tokens, N), dtype=out_dtype, device=hidden_states.device)
 
     # The kernels only read the bias pointer when HAS_BIAS; allocate the
@@ -6729,16 +6709,17 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
 def gluon_mxfp_fused_moe(
     hidden_states: torch.Tensor,
     router_logits: torch.Tensor,
-    w13_weight,
-    w2_weight,
+    w13_weight: torch.Tensor,
+    w2_weight: torch.Tensor,
     *,
-    w13_bias=None,
-    w2_bias=None,
-    w13_precision_config: PrecisionConfig | None = None,
-    w2_precision_config: PrecisionConfig | None = None,
+    w13_mx_scale: torch.Tensor,
+    w2_mx_scale: torch.Tensor,
     w13_act_scale: torch.Tensor,
     w2_act_scale: torch.Tensor,
     top_k: int,
+    w13_bias: Optional[torch.Tensor] = None,
+    w2_bias: Optional[torch.Tensor] = None,
+    out_dtype: torch.dtype = torch.bfloat16,
     enable_warp_decode: bool = True,
     swiglu_alpha: float = 1.702,
     swiglu_limit: float = 7.0,
@@ -6752,10 +6733,11 @@ def gluon_mxfp_fused_moe(
         w13_weight, w2_weight: gluon-swizzled MXFP4 expert weights
             (``RaggedTensorMetadata``-compatible wrapped tensors).
         w13_bias, w2_bias: optional float32 expert biases.
-        w13_precision_config, w2_precision_config: ``PrecisionConfig``
-            built by the backend (encodes fp8 LHS scale + mxfp4 RHS).
+        w13_mx_scale, w2_mx_scale: gluon-swizzled MXFP4 expert weight
+            scales for the two GEMMs.
         w13_act_scale, w2_act_scale: per-tensor FP8 activation scales
             for the two GEMMs.
+        out_dtype: output dtype for the final combine output.
         top_k: routing top_k.
         swiglu_alpha / swiglu_limit: SwiGLU activation parameters.
 
@@ -6778,10 +6760,11 @@ def gluon_mxfp_fused_moe(
             w2_weight,
             w13_bias=w13_bias,
             w2_bias=w2_bias,
-            w13_precision_config=w13_precision_config,
-            w2_precision_config=w2_precision_config,
+            w13_mx_scale=w13_mx_scale,
+            w2_mx_scale=w2_mx_scale,
             w13_act_scale=w13_act_scale,
             w2_act_scale=w2_act_scale,
+            out_dtype=out_dtype,
             top_k=top_k,
             swiglu_alpha=swiglu_alpha,
             swiglu_limit=swiglu_limit,
@@ -6818,9 +6801,11 @@ def gluon_mxfp_fused_moe(
         gemm1_input,
         w13_weight,
         w13_bias,
+        w_mx_scale=w13_mx_scale,
+        x_global_scale=w13_act_scale,
+        out_dtype=out_dtype,
         a_ragged_metadata=ragged_metadata,
         gather_indx=gather_indx,
-        precision_config=w13_precision_config,
         fused_activation=act,
         out_quant_scale=w2_act_scale,
         prefer_unshuffled_w=use_medium_decode,
@@ -6832,9 +6817,11 @@ def gluon_mxfp_fused_moe(
         gemm2_input,
         w2_weight,
         w2_bias,
+        w_mx_scale=w2_mx_scale,
+        x_global_scale=w2_act_scale,
+        out_dtype=out_dtype,
         a_ragged_metadata=ragged_metadata,
         scatter_indx=scatter_indx,
-        precision_config=w2_precision_config,
         gammas=gate_scal,
         n_tokens=n_tokens,
         n_expts_act=top_k,

--- a/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
@@ -700,33 +700,3 @@ def test_gluon_moe_gemms_with_preshuffle_match_torch_gfx950(
         weights=mxfp4_weights.preshuffled,
         torch_references=torch_references,
     )
-
-
-@requires_gfx950
-def test_gluon_mxfp_fused_moe_accepts_flat_precision_args_gfx950(
-    mxfp4_weights: Mxfp4WeightVariants,
-) -> None:
-    weights = mxfp4_weights.nonpreshuffled
-    hidden_states, router_logits = _make_hidden_and_router(1)
-
-    with torch.no_grad():
-        out = gluon_moe.gluon_mxfp_fused_moe(
-            hidden_states,
-            router_logits,
-            weights.w13_weight,
-            weights.w2_weight,
-            w13_bias=weights.w13_bias,
-            w2_bias=weights.w2_bias,
-            w13_mx_scale=weights.w13_precision_config.b_mx_scale,
-            w2_mx_scale=weights.w2_precision_config.b_mx_scale,
-            w13_act_scale=weights.w13_act_scale,
-            w2_act_scale=weights.w2_act_scale,
-            out_dtype=weights.w2_precision_config.out_dtype,
-            top_k=TOPK,
-            enable_warp_decode=False,
-        )
-
-    torch.cuda.synchronize()
-    assert out.shape == (1, HIDDEN_SIZE)
-    assert out.dtype == torch.bfloat16
-    assert torch.isfinite(out).all()

--- a/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
@@ -625,9 +625,11 @@ def _run_gluon_gemms(
             reference.gemm1_input,
             weights.w13_weight,
             weights.w13_bias,
+            w_mx_scale=weights.w13_precision_config.b_mx_scale,
+            x_global_scale=weights.w13_act_scale,
+            out_dtype=weights.w13_precision_config.out_dtype,
             a_ragged_metadata=reference.ragged_metadata,
             gather_indx=reference.gather_indx,
-            precision_config=weights.w13_precision_config,
             fused_activation=_swiglu_activation(),
         )
 
@@ -635,9 +637,11 @@ def _run_gluon_gemms(
             reference.gemm2_input,
             weights.w2_weight,
             weights.w2_bias,
+            w_mx_scale=weights.w2_precision_config.b_mx_scale,
+            x_global_scale=weights.w2_act_scale,
+            out_dtype=weights.w2_precision_config.out_dtype,
             a_ragged_metadata=reference.ragged_metadata,
             scatter_indx=reference.scatter_indx,
-            precision_config=weights.w2_precision_config,
             gammas=reference.gate_scal,
             n_tokens=reference.gate_scal.shape[0] // TOPK,
             n_expts_act=TOPK,
@@ -696,3 +700,33 @@ def test_gluon_moe_gemms_with_preshuffle_match_torch_gfx950(
         weights=mxfp4_weights.preshuffled,
         torch_references=torch_references,
     )
+
+
+@requires_gfx950
+def test_gluon_mxfp_fused_moe_accepts_flat_precision_args_gfx950(
+    mxfp4_weights: Mxfp4WeightVariants,
+) -> None:
+    weights = mxfp4_weights.nonpreshuffled
+    hidden_states, router_logits = _make_hidden_and_router(1)
+
+    with torch.no_grad():
+        out = gluon_moe.gluon_mxfp_fused_moe(
+            hidden_states,
+            router_logits,
+            weights.w13_weight,
+            weights.w2_weight,
+            w13_bias=weights.w13_bias,
+            w2_bias=weights.w2_bias,
+            w13_mx_scale=weights.w13_precision_config.b_mx_scale,
+            w2_mx_scale=weights.w2_precision_config.b_mx_scale,
+            w13_act_scale=weights.w13_act_scale,
+            w2_act_scale=weights.w2_act_scale,
+            out_dtype=weights.w2_precision_config.out_dtype,
+            top_k=TOPK,
+            enable_warp_decode=False,
+        )
+
+    torch.cuda.synchronize()
+    assert out.shape == (1, HIDDEN_SIZE)
+    assert out.dtype == torch.bfloat16
+    assert torch.isfinite(out).all()

--- a/tokenspeed-kernel-amd/test/ops/test_moe_gluon_warp_decode_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_moe_gluon_warp_decode_gfx950.py
@@ -147,10 +147,11 @@ def _run_kernel(case: dict) -> torch.Tensor:
         case["wt2"],
         w13_bias=case["w13_bias"],
         w2_bias=case["w2_bias"],
-        w13_precision_config=case["pc1"],
-        w2_precision_config=case["pc2"],
+        w13_mx_scale=case["pc1"].b_mx_scale,
+        w2_mx_scale=case["pc2"].b_mx_scale,
         w13_act_scale=case["scale1"],
         w2_act_scale=case["scale2"],
+        out_dtype=case["pc2"].out_dtype,
         top_k=case["topk"],
     )
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
@@ -90,6 +90,8 @@ if platform.is_amd:
 
         swiglu_alpha = swiglu_arg.alpha if swiglu_arg else 1.702
         swiglu_limit = swiglu_arg.limit if swiglu_arg else 7.0
+        w13_precision_config = w.w13_precision_config
+        w2_precision_config = w.w2_precision_config
 
         return gluon_mxfp_fused_moe(
             x,
@@ -98,10 +100,11 @@ if platform.is_amd:
             w.w2_weight_triton_tensor,
             w13_bias=getattr(w, "w13_weight_bias", None),
             w2_bias=getattr(w, "w2_weight_bias", None),
-            w13_precision_config=getattr(w, "w13_precision_config", None),
-            w2_precision_config=getattr(w, "w2_precision_config", None),
+            w13_mx_scale=w13_precision_config.b_mx_scale,
+            w2_mx_scale=w2_precision_config.b_mx_scale,
             w13_act_scale=w.w13_act_scale,
             w2_act_scale=w.w2_act_scale,
+            out_dtype=w2_precision_config.out_dtype or torch.bfloat16,
             top_k=top_k,
             swiglu_alpha=swiglu_alpha,
             swiglu_limit=swiglu_limit,


### PR DESCRIPTION
## Summary

From the request https://github.com/lightseekorg/tokenspeed/issues/521, decompose the `PrecisionConfig` in moe api.

## Test Plan

```sh
pytest tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
```
