### PR TITLE
chore(kernel): bump flashinfer to 0.6.13, add <cfloat> include

### DIFF
--- a/tokenspeed-kernel/python/requirements/cuda.txt
+++ b/tokenspeed-kernel/python/requirements/cuda.txt
@@ -2,7 +2,7 @@
 nvidia-cutlass-dsl==4.5.2
 nvidia-cutlass-dsl-libs-cu13==4.5.2
 torch==2.11.0
-flashinfer-python==0.6.11.post3
-flashinfer-cubin==0.6.11.post3
+flashinfer-python==0.6.13
+flashinfer-cubin==0.6.13
 nvidia-ml-py==13.580.82
 nvtx

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/silu_and_mul_fuse_nvfp4_quant.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/silu_and_mul_fuse_nvfp4_quant.cu
@@ -32,6 +32,7 @@
  * 128x4 swizzled layout. SM100+ required (PTX cvt.rn.satfinite.e2m1x2.f32).
  */
 
+#include <cfloat>
 #include <cuda_runtime.h>
 
 #include "tensorrt_llm/kernels/quantization_utils.cuh"


### PR DESCRIPTION
Update flashinfer-python/flashinfer-cubin to 0.6.13 in cuda.txt and add the missing <cfloat> include (FLT_MAX) to silu_and_mul_fuse_nvfp4_quant.cu so it builds against the new flashinfer headers.

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
