### PR TITLE
ci: switch MI35x back to standard 1GPU CI

### DIFF
--- a/test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi35x.yaml
+++ b/test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi35x.yaml
@@ -6,6 +6,7 @@ triggers:
   - manual
 runner:
   labels:
+    - amd-mi350-1gpu-bench
     - amd-mi355-1gpu-bench
 env:
   CI: "true"

--- a/test/ci/ut/ut-runtime-1gpu.yaml
+++ b/test/ci/ut/ut-runtime-1gpu.yaml
@@ -9,9 +9,9 @@ runner:
     - h100-1gpu
     - b200-1gpu
     - gb200-1gpu
-    - amd-mi355-1gpu-bench
+    - amd-mi35x-1gpu-test
   env:
-    amd-mi355-1gpu-bench:
+    amd-mi35x-1gpu-test:
       CI_TIMEOUT_PER_FILE: "600"
 env:
   CI: "true"

--- a/test/ci/ut/ut-tokenspeed-kernel.yaml
+++ b/test/ci/ut/ut-tokenspeed-kernel.yaml
@@ -16,7 +16,7 @@ runner:
     - b200-1gpu
     - gb200-1gpu
     - b300-1gpu
-    - amd-mi355-1gpu-bench
+    - amd-mi35x-1gpu-test
 env:
   CI: "true"
 install:


### PR DESCRIPTION
This reverts commit d0a7faddb5ec0d4c6d037c4c3e6a781d2c5164a8.