### PR TITLE
fix(sampling): CuteDSL argmax crashes the server on empty-row input

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/__init__.py
@@ -85,7 +85,16 @@ def argmax(
     Returns:
         A tensor containing argmax indices for each row of ``logits``.
     """
-    if logits.dim() != 2 or not logits.is_cuda or logits.dtype not in _SUPPORTED_DTYPES:
+    if (
+        logits.dim() != 2
+        or logits.shape[0] == 0
+        or not logits.is_cuda
+        or logits.dtype not in _SUPPORTED_DTYPES
+    ):
+        # An empty row dim (e.g. an idle data-parallel rank running the draft
+        # forward with bs=0) makes the kernel launch a 0-block grid over the
+        # vocab tiles and raise CUDA_ERROR_INVALID_VALUE; torch.argmax handles
+        # the empty case and returns an empty index tensor.
         return _argmax_torch_fallback(logits, out=out)
 
     signature = format_signature(logits=dense_tensor_format(logits.dtype))

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/__init__.py
@@ -91,10 +91,6 @@ def argmax(
         or not logits.is_cuda
         or logits.dtype not in _SUPPORTED_DTYPES
     ):
-        # An empty row dim (e.g. an idle data-parallel rank running the draft
-        # forward with bs=0) makes the kernel launch a 0-block grid over the
-        # vocab tiles and raise CUDA_ERROR_INVALID_VALUE; torch.argmax handles
-        # the empty case and returns an empty index tensor.
         return _argmax_torch_fallback(logits, out=out)
 
     signature = format_signature(logits=dense_tensor_format(logits.dtype))

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
@@ -331,8 +331,8 @@ def _argmax_cute(
     """CuTe DSL fast path for argmax.
 
     Falls back per-call to :func:`_argmax_torch_fallback` when the input
-    isn't kernel-eligible (1D / non-CUDA / unsupported dtype / small N /
-    unaligned N). Only ever bound to the public ``argmax`` name on NVIDIA
+    isn't kernel-eligible (1D / empty rows / non-CUDA / unsupported dtype /
+    small N / unaligned N). Only ever bound to the public ``argmax`` name on NVIDIA
     hosts with the cute DSL Python packages available — see the module-level
     dispatch below.
     """
@@ -345,9 +345,6 @@ def _argmax_cute(
         or not logits.is_cuda
         or not _supports_cute(logits.shape[1], logits.dtype)
     ):
-        # ``shape[0] == 0`` (e.g. an idle data-parallel rank's draft forward with
-        # bs=0) would launch a 0-block grid over the vocab tiles and raise
-        # CUDA_ERROR_INVALID_VALUE; torch.argmax returns an empty index tensor.
         return _argmax_torch_fallback(logits, out=out)
 
     M = logits.shape[0]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
@@ -341,9 +341,13 @@ def _argmax_cute(
 
     if (
         logits.dim() != 2
+        or logits.shape[0] == 0
         or not logits.is_cuda
         or not _supports_cute(logits.shape[1], logits.dtype)
     ):
+        # ``shape[0] == 0`` (e.g. an idle data-parallel rank's draft forward with
+        # bs=0) would launch a 0-block grid over the vocab tiles and raise
+        # CUDA_ERROR_INVALID_VALUE; torch.argmax returns an empty index tensor.
         return _argmax_torch_fallback(logits, out=out)
 
     M = logits.shape[0]

--- a/tokenspeed-kernel/test/ops/test_sampling_cute_dsl.py
+++ b/tokenspeed-kernel/test/ops/test_sampling_cute_dsl.py
@@ -41,6 +41,7 @@ cute_dsl = pytest.importorskip("tokenspeed_kernel.ops.sampling.cute_dsl")
 cute_argmax = cute_dsl.argmax
 cute_argmax_pair = cute_dsl.argmax_pair
 
+from tokenspeed_kernel.ops.sampling import argmax as public_argmax  # noqa: E402
 
 # Vocab sizes for the models tokenspeed actively serves — same list as
 # ``tmp/integrate_cutedsl_argmax/bench_argmax.py::DEFAULT_N``.
@@ -146,6 +147,22 @@ def test_argmax_falls_back_for_unaligned_N(N):
     torch.manual_seed(N)
     x = torch.randn(M, N, device="cuda", dtype=torch.float32)
     torch.testing.assert_close(cute_argmax(x), torch.argmax(x, dim=-1), atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("N", [4096, MODEL_VOCABS["kimi_k2_5"]])
+def test_argmax_empty_rows_falls_back(N):
+    """An idle data-parallel rank runs the draft forward with bs=0, so argmax
+    sees a ``(0, N)`` tensor over the real vocab. The kernel would launch a
+    0-block grid and raise CUDA_ERROR_INVALID_VALUE; both the cute entry and the
+    public dispatcher must route the empty case through ``torch.argmax`` and
+    return an empty index tensor."""
+    _need_cuda()
+    x = torch.randn(0, N, device="cuda", dtype=torch.float32)
+    expected = torch.argmax(x, dim=-1)
+    for fn in (cute_argmax, public_argmax):
+        out = fn(x)
+        assert out.shape == (0,)
+        torch.testing.assert_close(out, expected, atol=0, rtol=0)
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])

--- a/tokenspeed-kernel/test/ops/test_sampling_cute_dsl.py
+++ b/tokenspeed-kernel/test/ops/test_sampling_cute_dsl.py
@@ -41,7 +41,6 @@ cute_dsl = pytest.importorskip("tokenspeed_kernel.ops.sampling.cute_dsl")
 cute_argmax = cute_dsl.argmax
 cute_argmax_pair = cute_dsl.argmax_pair
 
-from tokenspeed_kernel.ops.sampling import argmax as public_argmax  # noqa: E402
 
 # Vocab sizes for the models tokenspeed actively serves — same list as
 # ``tmp/integrate_cutedsl_argmax/bench_argmax.py::DEFAULT_N``.
@@ -147,22 +146,6 @@ def test_argmax_falls_back_for_unaligned_N(N):
     torch.manual_seed(N)
     x = torch.randn(M, N, device="cuda", dtype=torch.float32)
     torch.testing.assert_close(cute_argmax(x), torch.argmax(x, dim=-1), atol=0, rtol=0)
-
-
-@pytest.mark.parametrize("N", [4096, MODEL_VOCABS["kimi_k2_5"]])
-def test_argmax_empty_rows_falls_back(N):
-    """An idle data-parallel rank runs the draft forward with bs=0, so argmax
-    sees a ``(0, N)`` tensor over the real vocab. The kernel would launch a
-    0-block grid and raise CUDA_ERROR_INVALID_VALUE; both the cute entry and the
-    public dispatcher must route the empty case through ``torch.argmax`` and
-    return an empty index tensor."""
-    _need_cuda()
-    x = torch.randn(0, N, device="cuda", dtype=torch.float32)
-    expected = torch.argmax(x, dim=-1)
-    for fn in (cute_argmax, public_argmax):
-        out = fn(x)
-        assert out.shape == (0,)
-        torch.testing.assert_close(out, expected, atol=0, rtol=0)
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])


### PR DESCRIPTION
## Summary
**Impact:** The server **crashes during startup** — the warmup request triggers
an idle data-parallel rank's draft forward, which runs argmax over a
`(0, vocab)` logits tensor. The CuteDSL argmax kernel launches a 0-block grid
over the vocab tiles and raises `CUDA_ERROR_INVALID_VALUE`, killing the
scheduler; the remaining ranks then time out on the DeepGEMM NVLink barrier and
the whole serve goes down. Only reproduces at a real vocab size — `(0, 128)`
survives, `(0, 163840)` does not. 

**Fix:** Add `shape[0] == 0` to the existing torch-fallback guard in `argmax`
and `_argmax_cute`, so empty input goes through `torch.argmax` (already the path
for other unsupported inputs). Non-empty inputs unchanged.

