### PR TITLE
feat(platform): model the Blackwell family — datacenter / Thor / consumer

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/flashinfer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/flashinfer.py
@@ -147,7 +147,10 @@ if gemm_fp8_nt_groupwise is not error_fn:
 
 mm_fp4 = error_fn
 
-if platform.is_nvidia and platform.is_blackwell:
+# NVFP4 GEMM runs across the Blackwell family (FP4 hardware); use
+# is_blackwell_plus so consumer (sm_120/sm_121) and Thor (sm_110) register it,
+# not just datacenter Blackwell.
+if platform.is_nvidia and platform.is_blackwell_plus:
     try:
         from flashinfer import mm_fp4
     except ImportError:

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/cutedsl_deepep_nvfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/cutedsl_deepep_nvfp4.py
@@ -113,6 +113,9 @@ if platform.is_nvidia:
         capability=CapabilityRequirement(
             vendors=frozenset({"nvidia"}),
             min_arch_version=ArchVersion(10, 0),
+            # FlashInfer CuTe-DSL blockscaled grouped GEMM supports SM100/SM103
+            # only; exclude Thor (sm_110) and consumer Blackwell (sm_120/sm_121).
+            max_arch_version=ArchVersion(10, 3),
         ),
         signatures=format_signatures(
             "x",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_fp8.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_fp8.py
@@ -79,6 +79,10 @@ if platform.is_nvidia:
         capability=CapabilityRequirement(
             vendors=frozenset({"nvidia"}),
             min_arch_version=ArchVersion(10, 0),
+            # Datacenter Blackwell only (sm_100/sm_103). TRT-LLM-Gen FP8 MoE is
+            # AOT-built for sm_100a/sm_103a — no consumer (sm_120/sm_121) or Thor
+            # (sm_110) binary. Mirrors the sibling mxfp4/nvfp4/mxint4 kernels.
+            max_arch_version=ArchVersion(10, 3),
         ),
         signatures=format_signatures(
             "x",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/mxfp4.py
@@ -187,7 +187,9 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps):
     scale_layout = layout.make_default_matmul_mxfp4_w_scale_layout(
         mx_axis=-2, num_warps=num_warps
     )
-    if platform.is_blackwell:
+    # Generic Triton matmul hints (persistent + epilogue subtiling), not a
+    # datacenter-only path — consumer Blackwell (sm_120/sm_121) wants them too.
+    if platform.is_blackwell_plus:
         constraints = {
             "is_persistent": True,
             "epilogue_subtile": 1,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/flashinfer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/flashinfer.py
@@ -58,7 +58,9 @@ if platform.is_nvidia:
         return mxfp8_quantize(x, False)
 
 
-if platform.is_nvidia and platform.is_blackwell:
+# NVFP4 quantize uses FP4 hardware present across the Blackwell family; gate on
+# is_blackwell_plus so consumer (sm_120/sm_121) and Thor (sm_110) register it.
+if platform.is_nvidia and platform.is_blackwell_plus:
     from flashinfer import (
         fp4_quantize,
         nvfp4_block_scale_interleave,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/platform.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/platform.py
@@ -142,7 +142,43 @@ class PlatformInfo:
 
     @property
     def is_blackwell(self) -> bool:
+        """Datacenter Blackwell only (sm_100/sm_103, major 10; B200/GB200).
+
+        Does NOT include Thor (major 11) or consumer Blackwell (major 12). Note
+        Thor ALSO has tcgen05/TMEM, so to gate "tcgen05-capable Blackwell"
+        (datacenter + Thor, excluding consumer) require the ``compute:tmem``
+        feature instead; use this predicate (or ``is_datacenter_blackwell``) only
+        when you specifically mean the datacenter SKUs.
+        """
         return self.is_nvidia and self.arch_version.major == 10
+
+    @property
+    def is_datacenter_blackwell(self) -> bool:
+        """Explicit alias of :attr:`is_blackwell` (datacenter Blackwell, major 10)."""
+        return self.is_nvidia and self.arch_version.major == 10
+
+    @property
+    def is_thor_blackwell(self) -> bool:
+        """Thor Blackwell SoC (sm_110, major 11; Jetson/DRIVE Thor).
+
+        Has FP4 (``tensor_core:f4``) AND tcgen05/TMEM (``compute:tmem``; see
+        triton-lang/triton#9160) — unlike consumer Blackwell. It is a distinct
+        SASS target (sm_110a) from datacenter, so arch-specific AOT binaries built
+        for sm_100a/sm_103a still do not run on it.
+        """
+        return self.is_nvidia and self.arch_version.major == 11
+
+    @property
+    def is_consumer_blackwell(self) -> bool:
+        """Consumer/workstation Blackwell (sm_120 and sm_121, major 12).
+
+        Covers RTX 50-series, RTX PRO 6000 Blackwell and GB10 (DGX Spark). One
+        instruction-compatible family (the ``sm_120f`` target): keying on
+        ``major == 12`` admits BOTH (12, 0) and (12, 1). Has FP4
+        (``tensor_core:f4``) but NOT tcgen05/TMEM (``compute:tmem``) — that is the
+        feature that distinguishes it from datacenter and Thor Blackwell.
+        """
+        return self.is_nvidia and self.arch_version.major == 12
 
     @property
     def is_ampere(self) -> bool:
@@ -170,6 +206,13 @@ class PlatformInfo:
 
     @property
     def is_blackwell_plus(self) -> bool:
+        """Blackwell-or-newer (arch >= 10.0): INCLUDES Thor (11) and consumer (12).
+
+        Do NOT use as a datacenter-only gate. ``compute:tmem`` /
+        ``tensor_core:tcgen05`` marks the tcgen05 tensor-core path (datacenter +
+        Thor, NOT consumer); ``is_blackwell`` / ``is_datacenter_blackwell`` is the
+        datacenter-only predicate.
+        """
         return self.is_nvidia and self.arch_version >= ArchVersion(10, 0)
 
     @property
@@ -230,7 +273,11 @@ class PlatformInfo:
                 (8, 6): "Ampere",
                 (8, 9): "Ada Lovelace",
                 (9, 0): "Hopper",
-                (10, 0): "Blackwell",
+                (10, 0): "Blackwell (Data Center)",
+                (10, 3): "Blackwell (Data Center)",
+                (11, 0): "Blackwell (Thor)",
+                (12, 0): "Blackwell (Consumer)",
+                (12, 1): "Blackwell (Consumer)",
             }
             return names.get(arch_version, f"SM{arch_version[0]}.{arch_version[1]}")
         if self.is_amd:
@@ -388,6 +435,16 @@ def _get_cuda_sm_features(arch_version: ArchVersion) -> frozenset[str]:
 
     if arch_version >= ArchVersion(10, 0):
         features |= {"tensor_core:f4"}
+
+    # tcgen05 (5th-gen tensor-core MMA) + tensor memory (TMEM): datacenter
+    # Blackwell (major 10; sm_100/sm_103) AND Thor (major 11; sm_110, per
+    # triton-lang/triton#9160 "Enable tcgen05 MMA for sm110"). Consumer Blackwell
+    # (major 12; sm_120/sm_121) has FP4 (granted above) but NOT this tensor-core
+    # path, so kernels gate on these features to auto-exclude consumer with a
+    # clean "missing features: compute:tmem" reason. (2-CTA UTCMMA is a separate,
+    # as-yet unmodeled capability — datacenter has it; Thor's status is unverified.)
+    if arch_version.major in (10, 11):
+        features |= {"tensor_core:tcgen05", "compute:tmem"}
 
     return frozenset(features)
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/registry.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/registry.py
@@ -403,7 +403,11 @@ def register_kernel(
             solution="triton",
             capability=CapabilityRequirement(
                 min_arch_version=ArchVersion(10, 0),
-                required_features=frozenset({"tensor_core:f8"}),
+                # tcgen05 tensor-core path: present on datacenter (sm_100/sm_103)
+                # and Thor (sm_110), absent on consumer Blackwell (sm_120/sm_121),
+                # so selection excludes consumer automatically — prefer a feature
+                # over a bare arch bound.
+                required_features=frozenset({"tensor_core:tcgen05"}),
             ),
             signatures=format_signatures(
                 ("q", "k", "v"), "dense", {torch.float16, torch.bfloat16}

--- a/tokenspeed-kernel/python/tokenspeed_kernel/selection.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/selection.py
@@ -855,6 +855,11 @@ def explain_selection(
                         f"arch mismatch (requires "
                         f"{spec.capability.min_arch_version})"
                     )
+            if spec.capability.max_arch_version:
+                if platform.arch_version > spec.capability.max_arch_version:
+                    reasons.append(
+                        f"arch mismatch (max " f"{spec.capability.max_arch_version})"
+                    )
             if format_signature and not spec.supports_format_signature(
                 format_signature
             ):


### PR DESCRIPTION
## What

Model NVIDIA's three Blackwell variants as distinct platform classes and fix the kernel mis-dispatch that came from conflating them.

`is_blackwell` (`major == 10`) was doing double duty as both "datacenter Blackwell" and "Blackwell family", so (a) **consumer Blackwell (sm_120/sm_121) was locked out** of kernels it can run (NVFP4 GEMM/quantize, MXFP4 swizzle hints) and (b) **datacenter-only kernels leaked onto consumer** via a bare `min_arch_version=(10,0)` with no upper bound.

## Taxonomy

| variant | major | example | tcgen05 / TMEM | FP4 |
|---|---|---|---|---|
| datacenter | 10 | B200 / GB200 (sm_100/sm_103) | ✅ | ✅ |
| Thor | 11 | Jetson/DRIVE Thor (sm_110) | ✅ | ✅ |
| consumer | 12 | RTX 50 / RTX PRO 6000 / GB10 (sm_120/sm_121) | ❌ | ✅ |

Consumer Blackwell is the sole Blackwell without the tcgen05 tensor-core path, so DC/Thor-only kernels can gate on the new `compute:tmem` / `tensor_core:tcgen05` feature and selection excludes consumer automatically (clean `missing features: compute:tmem`).

## Changes
- **platform**: `is_consumer_blackwell` / `is_thor_blackwell` / `is_datacenter_blackwell`; `tcgen05`+`tmem` features for major 10/11; `generation_name` labels; `explain_selection` reports `max_arch_version` violations; fixed the `register_kernel` docstring example.
- **kernel gates**: `trtllm_fp8` + `cutedsl_deepep_nvfp4` MoE bounded to `max=(10,3)` (no consumer binary); `mm_fp4`, `nvfp4` quantize, `mxfp4` swizzle gated on `is_blackwell_plus`. cutlass fp8/nvfp4 MoE already covers consumer and stays selectable.

Note: the `tensor_core:tcgen05` / `compute:tmem` features are forward-looking capability modeling for JIT/source datacenter-only kernels; the in-tree AOT flashinfer MoE kernels use `max_arch_version` because their binaries are arch-specific (no consumer/Thor build).

## Validation
- Taxonomy verified on **real RTX PRO 6000 (sm120)** and **GB10 (sm121)**: consumer predicate ✓, FP4 ✓, tcgen05/TMEM ✗, DC-feature kernel excluded ✓.
- flashinfer on sm120: `fp4_quantize` runs, `mm_fp4` JIT-compiles + executes, **cutlass sm120 MoE module builds**; trtllm-gen MoE confirmed sm100-only.
- End-to-end `explain_selection` on real sm120 dispatches fp8→cutlass, mxfp4→triton, nvfp4→cutlass with the bounded DC kernels excluded (`arch mismatch (max 10.3)`). Full trace in the validation comment below.
