### PR TITLE
fix: fix cutedsl argmax for NaN inputs and drop now-redundant guards

### DIFF
--- a/python/tokenspeed/runtime/execution/drafter/eagle.py
+++ b/python/tokenspeed/runtime/execution/drafter/eagle.py
@@ -398,7 +398,6 @@ class Eagle(BaseDrafter):
 
             with nvtx_range("draft_sample", color="yellow"):
                 draft_ids = logits_output.next_token_ids
-                draft_ids.clamp_(min=0)
                 # Column 0 holds last_verified_ids; drafter writes step `i` into column `i + 1`.
                 next_tokens[:, i + 1] = self._map_hot(draft_ids)
                 if i + 1 < self.spec_num_steps:
@@ -470,7 +469,6 @@ class Eagle(BaseDrafter):
         logits_output, dsa_topk = self._run_first_step(bs, draft_input)
 
         draft_ids = logits_output.next_token_ids
-        draft_ids.clamp_(min=0)
         next_tokens[:, 1] = self._map_hot(draft_ids)
 
         if self.spec_num_steps <= 1:

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -448,11 +448,6 @@ class ModelExecutor:
             runtime_states=self.runtime_states,
         )
 
-        # CUDA graph warmup runs the drafter with dummy data whose
-        # uninitialized KV cache produces NaN → argmax sentinel -1.
-        # Clear the residue so pool slots reused by real requests start clean.
-        self.runtime_states.future_input_map.zero_()
-
         # Encoder CUDA graph: install model-built wrappers by overriding
         # modality encoder callables (e.g. ``image_encoder``, ``video_encoder``).
         # Multimodal-encoder analogue of ``forward_step``'s ``CudaGraphWrapper``.
@@ -785,19 +780,10 @@ class ModelExecutor:
             logits_output, sampling_info, ctx, candidates
         )
 
-        # Single choke point for every (sample/verify) x (greedy/flashinfer)
-        # path: NaN logits (e.g. DP dummy/warmup batches over uninitialized KV)
-        # make sampling argmax emit the -1 sentinel. Left unclamped, that -1 poisons
-        # both consumers below -- it flows into output_ids -> detokenizer (the
-        # HF Rust tokenizer raises OverflowError on a negative id and kills the
-        # engine) and, via the drafter, back into future_input_map as the next
-        # round's input_ids (negative embedding index -> garbage / CUDA illegal
-        # access). Clamp in place (this runs inside the CUDA graph) so grammar,
-        # drafter, and the return value all observe clean ids. Mirror of the
-        # draft-side draft_ids.clamp_(min=0) guard.
-        # Record which requests produced bad ids before the clamp erases them.
+        # Backstop: flag any request whose sampled id falls outside [0, vocab)
+        # so the output processor can terminate it. Covers sampler/verify kernel
+        # corruption and DP-sharded steps that audit_logits cannot attribute.
         self.nan_guard.merge_oov(output_tokens, ctx, self.runtime_states.vocab_size)
-        output_tokens.clamp_(min=0)
 
         # Fork sampler-output D2H onto the grammar side stream so the
         # next step's build hostfunc can advance the matcher.

--- a/python/tokenspeed/runtime/execution/nan_guard.py
+++ b/python/tokenspeed/runtime/execution/nan_guard.py
@@ -70,7 +70,7 @@ class NanGuard:
         guard.reset(bs)                    # outside the graph
         ... per forward cycle (in-graph):
             guard.audit_logits(logits_output, ctx)     # pre-sampling
-            guard.merge_oov(tokens, ctx, vocab_size)   # pre-clamp
+            guard.merge_oov(tokens, ctx, vocab_size)   # OOV backstop
         flags = guard.flags_cpu            # with the output D2H batch
     """
 
@@ -108,8 +108,7 @@ class NanGuard:
         """Backstop: flag requests whose sampled ids fall outside [0, vocab).
 
         Catches corruption past the logits (sampler/verify kernel output) and
-        covers DP-sharded steps. Must run before the in-vocab clamps — they
-        erase the evidence. Token ids are already rank-synced here.
+        covers DP-sharded steps. Token ids are already rank-synced here.
         """
         self._or_per_request((output_tokens < 0) | (output_tokens >= vocab_size), ctx)
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
@@ -853,8 +853,10 @@ if _CUTE_AVAILABLE:
                         warp_max, warp_argmax = warp_argmax_redux(peer_val, peer_idx)
                     else:
                         warp_max, warp_argmax = warp_reduce_argmax(peer_val, peer_idx)
+                    # A row whose elements never beat -inf (all-NaN / all -inf) leaves
+                    # the argmax at its 0xFFFFFFFF sentinel; emit the in-range index 0.
                     if warp_argmax == Int32(0x7FFFFFFF):
-                        warp_argmax = Int32(0xFFFFFFFF)
+                        warp_argmax = Int32(0)
 
                     if cutlass.const_expr(not self.skip_ping_pong):
                         if lane_idx == 0:

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/argmax.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/argmax.py
@@ -663,5 +663,9 @@ class ArgmaxKernel(ReductionBase):
             and local_row_idx < tiler_mn[0]
             and (self.cluster_n == 1 or bidy == 0)
         ):
+            # A row whose elements never beat -inf (all-NaN / all -inf) leaves
+            # the argmax at its 0xFFFFFFFF sentinel; emit the in-range index 0.
+            if warp_argmax == Int32(0xFFFFFFFF):
+                warp_argmax = Int32(0)
             mO_max[local_row_idx] = warp_max.to(mO_max.element_type)
             mO_idx[local_row_idx] = warp_argmax.to(mO_idx.element_type)

--- a/tokenspeed-kernel/test/ops/test_sampling_cute_dsl.py
+++ b/tokenspeed-kernel/test/ops/test_sampling_cute_dsl.py
@@ -286,6 +286,39 @@ def test_argmax_returns_first_index_on_ties_like_torch():
     torch.testing.assert_close(out, torch.argmax(x, dim=-1), atol=0, rtol=0)
 
 
+@pytest.mark.parametrize(
+    "N", [4096, MODEL_VOCABS["kimi_k2_5"], MODEL_VOCABS["qwen3_5"]]
+)
+def test_argmax_in_range_for_nan_and_neg_inf_rows(N):
+    """A row whose elements never beat ``-inf`` (all-NaN or all ``-inf``) must
+    still yield an *in-range* index, not the ``0xFFFFFFFF`` (-1) sentinel.
+
+    The kernel suppresses NaN (IEEE ``NaN > x`` is false) and the warp/block/
+    cluster max reductions are NaN-suppressing, so NaN never wins; the argmax
+    sentinels are seeded to 0 so such rows resolve to index 0. ``N`` covers both
+    the single-block (``cluster_n == 1``) and the cluster reduction path (fp32
+    ``N > 32K``), since the cluster path has its own sentinel seed.
+    """
+    _need_cuda()
+    nan, ninf = float("nan"), float("-inf")
+    x = torch.full((4, N), -100.0, device="cuda", dtype=torch.float32)
+    x[0].fill_(nan)  # all-NaN -> sentinel row, must map to a valid index (0)
+    x[1].fill_(ninf)  # all -inf -> never beats the -inf init, also sentinel
+    x[2, 2000] = 5.0  # mixed: real max at 2000 ...
+    x[2, 100] = nan  # ... plus a NaN the kernel must ignore
+    # row 3 stays a plain non-degenerate row as a control.
+    x[3, 1234] = 0.0
+
+    out = cute_argmax(x)
+    assert ((out >= 0) & (out < N)).all(), f"out-of-range index: {out.tolist()}"
+    # Degenerate rows resolve to index 0 (lowest-index tie among equal maxima).
+    assert out[0].item() == 0
+    assert out[1].item() == 0
+    # Mixed row: NaN is suppressed, so the kernel returns the finite argmax.
+    assert out[2].item() == 2000
+    assert out[3].item() == 1234
+
+
 def test_argmax_mtp_pattern():
     """Matches the test_argmax_mtp_case in TRT-LLM: one hot row at vocab[1].
 

--- a/tokenspeed-kernel/test/ops/test_sampling_cute_dsl.py
+++ b/tokenspeed-kernel/test/ops/test_sampling_cute_dsl.py
@@ -41,6 +41,11 @@ cute_dsl = pytest.importorskip("tokenspeed_kernel.ops.sampling.cute_dsl")
 cute_argmax = cute_dsl.argmax
 cute_argmax_pair = cute_dsl.argmax_pair
 
+requires_nvidia = pytest.mark.skipif(
+    not cute_dsl.current_platform().is_nvidia,
+    reason="CuTe DSL argmax kernel is NVIDIA-only",
+)
+
 
 # Vocab sizes for the models tokenspeed actively serves — same list as
 # ``tmp/integrate_cutedsl_argmax/bench_argmax.py::DEFAULT_N``.
@@ -286,6 +291,7 @@ def test_argmax_returns_first_index_on_ties_like_torch():
     torch.testing.assert_close(out, torch.argmax(x, dim=-1), atol=0, rtol=0)
 
 
+@requires_nvidia
 @pytest.mark.parametrize(
     "N", [4096, MODEL_VOCABS["kimi_k2_5"], MODEL_VOCABS["qwen3_5"]]
 )
@@ -300,23 +306,26 @@ def test_argmax_in_range_for_nan_and_neg_inf_rows(N):
     ``N > 32K``), since the cluster path has its own sentinel seed.
     """
     _need_cuda()
-    nan, ninf = float("nan"), float("-inf")
-    x = torch.full((4, N), -100.0, device="cuda", dtype=torch.float32)
-    x[0].fill_(nan)  # all-NaN -> sentinel row, must map to a valid index (0)
-    x[1].fill_(ninf)  # all -inf -> never beats the -inf init, also sentinel
-    x[2, 2000] = 5.0  # mixed: real max at 2000 ...
-    x[2, 100] = nan  # ... plus a NaN the kernel must ignore
-    # row 3 stays a plain non-degenerate row as a control.
-    x[3, 1234] = 0.0
-
+    x = torch.full((6, N), -100.0, device="cuda", dtype=torch.float32)
+    x[0].fill_(float("nan"))  # all NaN -> sentinel row, must map to a valid index (0)
+    x[1].fill_(float("inf"))  # all inf -> first element wins, so output index 0
+    x[2].fill_(float("-inf"))  # all -inf -> never beats the -inf init, also sentinel
+    x[3, 2000] = 5.0  # mixed: real max at 2000 ...
+    x[3, 100] = float("nan")  # ... plus a NaN the kernel must ignore
+    x[4, 2000] = float("nan")
+    x[4, 100] = 5.0
+    x[5, 1234] = 0.0
     out = cute_argmax(x)
+
     assert ((out >= 0) & (out < N)).all(), f"out-of-range index: {out.tolist()}"
     # Degenerate rows resolve to index 0 (lowest-index tie among equal maxima).
     assert out[0].item() == 0
     assert out[1].item() == 0
+    assert out[2].item() == 0
     # Mixed row: NaN is suppressed, so the kernel returns the finite argmax.
-    assert out[2].item() == 2000
-    assert out[3].item() == 1234
+    assert out[3].item() == 2000
+    assert out[4].item() == 100
+    assert out[5].item() == 1234
 
 
 def test_argmax_mtp_pattern():


### PR DESCRIPTION
## Summary
`cute_argmax` returned its internal sentinel `-1` (`0xFFFFFFFF`) for an all-NaN /
all-`-inf` row — an out-of-range index that poisons downstream consumers
(detokenizer `OverflowError`, embedding-gather IMA). It now returns in-range `0`.

### Changes
- **Kernel fix** (`thirdparty/cute_dsl/argmax.py`, `ops/sampling/cute_dsl.py`):
  keep `0xFFFFFFFF` as the internal sentinel throughout the reduction; convert
  to `0` only at the output write. Applied to both the base `ArgmaxKernel` and
  the cross-rank `DistArgmaxKernel`. Normal results unchanged.
- **Test** (`test_sampling_cute_dsl.py`): assert in-range output for all-NaN /
  all-`-inf` / mixed rows on both the single-block and cluster reduction paths.
- **Remove guards obsoleted by the fix** (from #341): the two
  `draft_ids.clamp_(min=0)` in `eagle.py`, `future_input_map.zero_()`, and the
  `output_tokens.clamp_(min=0)` in `model_executor.py` (with stale-comment
  cleanup in `nan_guard.py`).
