### PR TITLE
feat(serve): export Prometheus metrics via /metrics endpoint

### DIFF
--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -144,8 +144,9 @@ draft model, and token count together.
 | `--enable-log-requests` | Log request metadata and optionally payloads. |
 | `--log-requests-level` | Request logging verbosity. |
 | `--enable-log-request-stats` | Log a one-line per-request performance summary on finish/abort (see below). |
-| `--enable-metrics` | Enable metrics reporting. |
+| `--enable-metrics` | Enable Prometheus metrics reporting. Exposes the `/metrics` endpoint on the control server (port + 1). |
 | `--metrics-reporters` | Metrics reporter, such as `prometheus`. |
+| `--control-port` | Override the control server port (defaults to `--port + 1`). The control server hosts `/metrics`, `/health`, `/get_server_info`, and `/abort`. |
 | `--decode-log-interval` | Decode batch log interval. |
 | `--enable-cache-report` | Include cached-token counts in OpenAI-compatible usage details. |
 | `--kv-events-config` | JSON config for KV cache mutation events. Set `enable_kv_cache_events` and a publisher such as `zmq` to publish device prefix-cache stores and removals. |
@@ -176,6 +177,47 @@ Req: chatcmpl-019ef6b7 Finish! RequestStats(status='finished', reason='stop', pr
 | `decode_tps` | Decode throughput (generated tokens / decode window). |
 | `acc_len` / `acc_rate` | Spec-decode acceptance length and rate (`None` when speculative decoding is off). |
 | `recv_ts` / `commit_ts` / `finish_ts` | Absolute epoch timestamps for received / scheduled / finished. |
+
+### Prometheus Metrics
+
+When `--enable-metrics` is set, TokenSpeed exposes a Prometheus-compatible
+`/metrics` endpoint on the **control server**, which runs on `--port + 1`
+(or the value of `--control-port`).
+
+```bash
+tokenspeed serve nvidia/Kimi-K2.5-NVFP4 \
+  --port 8000 \
+  --enable-metrics \
+  --tensor-parallel-size 4
+```
+
+Scrape the runtime metrics from the control port:
+
+```bash
+curl http://localhost:8001/metrics
+```
+
+The SMG gateway has a separate Prometheus exporter on port `8413`
+(overridable via `--prometheus-port`) for gateway-level metrics.
+
+Example `prometheus.yml` scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: 'tokenspeed-runtime'
+    static_configs:
+      - targets: ['<host>:8001']  # control port = serve port + 1
+    metrics_path: /metrics
+
+  - job_name: 'tokenspeed-gateway'
+    static_configs:
+      - targets: ['<host>:8413']  # SMG prometheus port
+    metrics_path: /metrics
+```
+
+Runtime metrics use the `tokenspeed:` prefix (e.g.
+`tokenspeed:time_to_first_token_seconds`, `tokenspeed:kv_cache_usage_perc`,
+`tokenspeed:num_requests_running`).
 
 ### KV Cache Events
 

--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -604,14 +604,22 @@ async def run_smg(
                     pass
 
 
-def _engine_args_enable_metrics(engine_args: list[str]) -> bool:
-    """Return True if ``--enable-metrics`` is present in the engine argv.
+def _raw_argv_enable_metrics(raw_argv: list[str]) -> bool:
+    """Return True if ``--enable-metrics`` is present in the raw argv.
 
-    ``--enable-metrics`` is a store-true flag (no value), so it is detected by
-    a bare token match. Both ``--enable-metrics`` and ``--enable-metrics=true``
-    are accepted; ``--no-enable-metrics`` is not a valid form for this flag.
+    ``--enable-metrics`` is a ``store_true`` flag: it takes no value, so
+    ``--enable-metrics=false`` is not a valid form. We inspect the **raw**
+    argv (before ``split_argv`` normalization) because the splitter rewrites
+    ``--flag=value`` into ``['--flag', 'value']``, which would make the bare
+    ``--enable-metrics`` token match even when the user wrote
+    ``--enable-metrics=false`` — and would also leave a stray ``false`` token
+    that the engine's argparse rejects.
+
+    Only the bare ``--enable-metrics`` token (or ``--enable-metrics=1`` /
+    ``--enable-metrics=true``) enables metrics. ``--enable-metrics=false`` /
+    ``--enable-metrics=0`` explicitly disables it.
     """
-    for token in engine_args:
+    for token in raw_argv:
         if token == "--enable-metrics":
             return True
         if token.startswith("--enable-metrics="):
@@ -631,6 +639,9 @@ def run_smg_from_args(args: argparse.Namespace, raw_argv: list[str]) -> None:
     print_logo()
 
     _check_serve_extra_installed()
+    # Detect --enable-metrics from the raw argv BEFORE split_argv normalizes
+    # --flag=value forms. See _raw_argv_enable_metrics docstring for why.
+    enable_metrics = _raw_argv_enable_metrics(raw_argv)
     split = split_argv(raw_argv)
     engine_args, gateway_args = _args_with_default_model_parsers(
         split.engine, split.gateway
@@ -641,7 +652,6 @@ def run_smg_from_args(args: argparse.Namespace, raw_argv: list[str]) -> None:
     model_id = _user_model_id(gateway_args)
     if model_id is not None:
         _prewarm_hf_tokenizer(model_id)
-    enable_metrics = _engine_args_enable_metrics(engine_args)
     rc = asyncio.run(
         run_smg(
             engine_args=engine_args,

--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -360,6 +360,7 @@ async def _start_control_server(
     host: str,
     port: int,
     timeout: float = 30.0,
+    enable_metrics: bool = False,
 ) -> bool:
     """Start the control HTTP server in a daemon thread and wait for it to bind.
 
@@ -367,6 +368,12 @@ async def _start_control_server(
     Returns True once the server is accepting connections, or False if it
     failed to bind (e.g. the port is already in use) or did not come up within
     ``timeout`` seconds. Non-fatal: the smg gateway runs independently.
+
+    When ``enable_metrics`` is set, the control server mounts the
+    ``/metrics`` Prometheus endpoint so runtime metrics (``tokenspeed:*``)
+    collected by the engine subprocess are scrapeable from the control port.
+    The caller must have set ``PROMETHEUS_MULTIPROC_DIR`` before spawning the
+    engine so the multiprocess collector aggregates the engine's metrics.
     """
     import threading
 
@@ -377,6 +384,7 @@ async def _start_control_server(
         engine_grpc_addr=engine_grpc_addr,
         host=host,
         port=port,
+        enable_metrics=enable_metrics,
     )
     thread = threading.Thread(target=server.run, daemon=True, name="ts-http-server")
     thread.start()
@@ -455,6 +463,7 @@ async def run_smg(
     opts: OrchestratorOpts,
     user_host: str,
     user_port: int,
+    enable_metrics: bool = False,
     _stop_event: asyncio.Event | None = None,
 ) -> int:
     """Lifecycle loop. Returns the orchestrator's exit code."""
@@ -472,6 +481,16 @@ async def run_smg(
             loop.add_signal_handler(sig, stop.set)
         except NotImplementedError:
             pass  # Windows: signal handlers via asyncio aren't supported. Out of scope.
+
+    # Set up the Prometheus multiprocess directory before spawning the engine
+    # subprocess. The engine (running in a child process) and the control
+    # server (running in this process) must share the same
+    # PROMETHEUS_MULTIPROC_DIR so the MultiProcessCollector on the control
+    # server aggregates the engine's metrics into the /metrics scrape.
+    if enable_metrics:
+        from tokenspeed.runtime.utils.common import set_prometheus_multiproc_dir
+
+        set_prometheus_multiproc_dir()
 
     try:
         engine_port = get_free_port()
@@ -515,6 +534,7 @@ async def run_smg(
             engine_grpc_addr=f"127.0.0.1:{engine_port}",
             host=user_host,
             port=control_port,
+            enable_metrics=enable_metrics,
         )
         if control_ok:
             sys.stdout.write(
@@ -584,6 +604,21 @@ async def run_smg(
                     pass
 
 
+def _engine_args_enable_metrics(engine_args: list[str]) -> bool:
+    """Return True if ``--enable-metrics`` is present in the engine argv.
+
+    ``--enable-metrics`` is a store-true flag (no value), so it is detected by
+    a bare token match. Both ``--enable-metrics`` and ``--enable-metrics=true``
+    are accepted; ``--no-enable-metrics`` is not a valid form for this flag.
+    """
+    for token in engine_args:
+        if token == "--enable-metrics":
+            return True
+        if token.startswith("--enable-metrics="):
+            return token.split("=", 1)[1].lower() in ("1", "true", "yes")
+    return False
+
+
 def run_smg_from_args(args: argparse.Namespace, raw_argv: list[str]) -> None:
     """Entry point called from cli/__main__.py for ``ts serve``."""
     try:
@@ -606,6 +641,7 @@ def run_smg_from_args(args: argparse.Namespace, raw_argv: list[str]) -> None:
     model_id = _user_model_id(gateway_args)
     if model_id is not None:
         _prewarm_hf_tokenizer(model_id)
+    enable_metrics = _engine_args_enable_metrics(engine_args)
     rc = asyncio.run(
         run_smg(
             engine_args=engine_args,
@@ -613,6 +649,7 @@ def run_smg_from_args(args: argparse.Namespace, raw_argv: list[str]) -> None:
             opts=split.opts,
             user_host=user_host,
             user_port=user_port,
+            enable_metrics=enable_metrics,
         )
     )
     sys.exit(rc)

--- a/python/tokenspeed/runtime/entrypoints/http_server.py
+++ b/python/tokenspeed/runtime/entrypoints/http_server.py
@@ -245,12 +245,20 @@ async def stop_profile(request: Request):
 # ---------------------------------------------------------------------------
 
 
+def _metrics_route_mounted(app: FastAPI) -> bool:
+    """Return True if the ``/metrics`` Prometheus route is already on ``app``."""
+    return any(
+        getattr(route, "path", "") == "/metrics" for route in app.routes
+    )
+
+
 def build_server(
     *,
     gateway_url: str,
     engine_grpc_addr: str,
     host: str = "127.0.0.1",
     port: int = 8001,
+    enable_metrics: bool = False,
 ) -> uvicorn.Server:
     """Configure the proxy targets and return an unstarted ``uvicorn.Server``.
 
@@ -262,10 +270,24 @@ def build_server(
         engine_grpc_addr: ``host:port`` of the gRPC engine for direct calls.
         host: Bind address.
         port: Bind port.
+        enable_metrics: Mount the ``/metrics`` Prometheus endpoint. The
+            caller must have set ``PROMETHEUS_MULTIPROC_DIR`` (via
+            ``set_prometheus_multiproc_dir``) before the engine subprocess
+            was spawned so the engine's metrics and this collector share
+            the same multiprocess directory.
     """
     global _gateway_url, _engine_grpc_addr
     _gateway_url = gateway_url
     _engine_grpc_addr = engine_grpc_addr
+
+    if enable_metrics and not _metrics_route_mounted(app):
+        from tokenspeed.runtime.metrics.func_timer import enable_func_timer
+        from tokenspeed.runtime.utils.common import add_prometheus_middleware
+
+        add_prometheus_middleware(app)
+        enable_func_timer()
+        logger.info("Prometheus /metrics endpoint mounted on control server")
+
     logger.info(
         "Starting TokenSpeed HTTP server on %s:%d " "(gateway: %s, engine gRPC: %s)",
         host,
@@ -284,6 +306,7 @@ def start(
     engine_grpc_addr: str,
     host: str = "127.0.0.1",
     port: int = 8001,
+    enable_metrics: bool = False,
 ) -> None:
     """Start the HTTP server (blocking)."""
     build_server(
@@ -291,4 +314,5 @@ def start(
         engine_grpc_addr=engine_grpc_addr,
         host=host,
         port=port,
+        enable_metrics=enable_metrics,
     ).run()

--- a/test/cli/test_serve_smg_unit.py
+++ b/test/cli/test_serve_smg_unit.py
@@ -40,6 +40,7 @@ from tokenspeed.cli.serve_smg import (
     DEEPSEEK_V4_REASONING_PARSER,
     DEEPSEEK_V4_TOOL_CALL_PARSER,
     _args_with_default_model_parsers,
+    _engine_args_enable_metrics,
     _gateway_args_with_default_log_level,
     _gateway_args_with_default_policy,
     _gateway_args_with_default_port,
@@ -369,6 +370,31 @@ def test_prewarm_swallows_download_errors():
     ):
         # Must not raise — smg's own retry path is the fallback.
         _prewarm_hf_tokenizer("nvidia/Qwen3.5-397B-A17B-NVFP4")
+
+
+def test_engine_args_enable_metrics_detects_bare_flag():
+    assert _engine_args_enable_metrics(["--enable-metrics"]) is True
+
+
+def test_engine_args_enable_metrics_detects_equals_true():
+    assert _engine_args_enable_metrics(["--enable-metrics=true"]) is True
+    assert _engine_args_enable_metrics(["--enable-metrics=1"]) is True
+    assert _engine_args_enable_metrics(["--enable-metrics=yes"]) is True
+
+
+def test_engine_args_enable_metrics_rejects_equals_false():
+    assert _engine_args_enable_metrics(["--enable-metrics=false"]) is False
+    assert _engine_args_enable_metrics(["--enable-metrics=0"]) is False
+
+
+def test_engine_args_enable_metrics_absent_returns_false():
+    assert _engine_args_enable_metrics(["--model", "/tmp/x"]) is False
+    assert _engine_args_enable_metrics([]) is False
+
+
+def test_engine_args_enable_metrics_among_other_flags():
+    args = ["--model", "/tmp/x", "--enable-metrics", "--tensor-parallel-size", "4"]
+    assert _engine_args_enable_metrics(args) is True
 
 
 @pytest.mark.asyncio

--- a/test/cli/test_serve_smg_unit.py
+++ b/test/cli/test_serve_smg_unit.py
@@ -40,7 +40,6 @@ from tokenspeed.cli.serve_smg import (
     DEEPSEEK_V4_REASONING_PARSER,
     DEEPSEEK_V4_TOOL_CALL_PARSER,
     _args_with_default_model_parsers,
-    _engine_args_enable_metrics,
     _gateway_args_with_default_log_level,
     _gateway_args_with_default_policy,
     _gateway_args_with_default_port,
@@ -50,6 +49,7 @@ from tokenspeed.cli.serve_smg import (
     _gateway_args_with_smg_disable_defaults,
     _is_deepseek_v4_model,
     _prewarm_hf_tokenizer,
+    _raw_argv_enable_metrics,
     _user_host_port_from_gateway_args,
     _user_model_id,
     run_smg,
@@ -372,29 +372,42 @@ def test_prewarm_swallows_download_errors():
         _prewarm_hf_tokenizer("nvidia/Qwen3.5-397B-A17B-NVFP4")
 
 
-def test_engine_args_enable_metrics_detects_bare_flag():
-    assert _engine_args_enable_metrics(["--enable-metrics"]) is True
+def test_raw_argv_enable_metrics_detects_bare_flag():
+    assert _raw_argv_enable_metrics(["--enable-metrics"]) is True
 
 
-def test_engine_args_enable_metrics_detects_equals_true():
-    assert _engine_args_enable_metrics(["--enable-metrics=true"]) is True
-    assert _engine_args_enable_metrics(["--enable-metrics=1"]) is True
-    assert _engine_args_enable_metrics(["--enable-metrics=yes"]) is True
+def test_raw_argv_enable_metrics_detects_equals_true():
+    assert _raw_argv_enable_metrics(["--enable-metrics=true"]) is True
+    assert _raw_argv_enable_metrics(["--enable-metrics=1"]) is True
+    assert _raw_argv_enable_metrics(["--enable-metrics=yes"]) is True
 
 
-def test_engine_args_enable_metrics_rejects_equals_false():
-    assert _engine_args_enable_metrics(["--enable-metrics=false"]) is False
-    assert _engine_args_enable_metrics(["--enable-metrics=0"]) is False
+def test_raw_argv_enable_metrics_rejects_equals_false():
+    """--enable-metrics=false must NOT enable metrics.
+
+    This is the key regression guard: split_argv normalizes --flag=value into
+    ['--flag', 'value'], so detecting from the raw argv (before normalization)
+    is required to avoid the bare-token match returning True for =false.
+    """
+    assert _raw_argv_enable_metrics(["--enable-metrics=false"]) is False
+    assert _raw_argv_enable_metrics(["--enable-metrics=0"]) is False
 
 
-def test_engine_args_enable_metrics_absent_returns_false():
-    assert _engine_args_enable_metrics(["--model", "/tmp/x"]) is False
-    assert _engine_args_enable_metrics([]) is False
+def test_raw_argv_enable_metrics_absent_returns_false():
+    assert _raw_argv_enable_metrics(["--model", "/tmp/x"]) is False
+    assert _raw_argv_enable_metrics([]) is False
 
 
-def test_engine_args_enable_metrics_among_other_flags():
+def test_raw_argv_enable_metrics_among_other_flags():
     args = ["--model", "/tmp/x", "--enable-metrics", "--tensor-parallel-size", "4"]
-    assert _engine_args_enable_metrics(args) is True
+    assert _raw_argv_enable_metrics(args) is True
+
+
+def test_raw_argv_enable_metrics_with_positional_model():
+    """The raw argv may contain a leading positional model before split_argv
+    rewrites it to --model. Detection must still work."""
+    assert _raw_argv_enable_metrics(["/model", "--enable-metrics"]) is True
+    assert _raw_argv_enable_metrics(["/model", "--enable-metrics=false"]) is False
 
 
 @pytest.mark.asyncio

--- a/test/runtime/test_http_server.py
+++ b/test/runtime/test_http_server.py
@@ -352,5 +352,71 @@ class TestControlPortArg(unittest.TestCase):
         self.assertIsNone(result.opts.control_port)
 
 
+class TestMetricsEndpointMounting(unittest.TestCase):
+    """``build_server(enable_metrics=True)`` must mount the ``/metrics``
+    Prometheus endpoint on the control server so runtime metrics are
+    scrapeable in the ``ts serve`` path (previously returned empty/404)."""
+
+    def test_metrics_route_absent_by_default(self):
+        from tokenspeed.runtime.entrypoints.http_server import _metrics_route_mounted
+
+        # The module-level ``app`` must not have /metrics unless explicitly
+        # mounted. (Other test classes may have mounted it; this checks the
+        # helper, not the global app state.)
+        bare = FastAPI()
+        self.assertFalse(_metrics_route_mounted(bare))
+
+    def test_build_server_mounts_metrics_when_enabled(self):
+        import os
+        import tempfile
+
+        # prometheus_client requires PROMETHEUS_MULTIPROC_DIR for multiprocess
+        # mode; set a temp dir so add_prometheus_middleware doesn't fail.
+        tmpdir = tempfile.mkdtemp()
+        prev = os.environ.get("PROMETHEUS_MULTIPROC_DIR")
+        os.environ["PROMETHEUS_MULTIPROC_DIR"] = tmpdir
+        try:
+            from tokenspeed.runtime.entrypoints.http_server import (
+                _metrics_route_mounted,
+                app,
+                build_server,
+            )
+
+            already = _metrics_route_mounted(app)
+            build_server(
+                gateway_url="http://127.0.0.1:1",
+                engine_grpc_addr="127.0.0.1:1",
+                host="127.0.0.1",
+                port=0,  # don't bind
+                enable_metrics=True,
+            )
+            self.assertTrue(
+                _metrics_route_mounted(app),
+                "/metrics route must be mounted when enable_metrics=True",
+            )
+        finally:
+            if prev is None:
+                os.environ.pop("PROMETHEUS_MULTIPROC_DIR", None)
+            else:
+                os.environ["PROMETHEUS_MULTIPROC_DIR"] = prev
+            import shutil
+
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_build_server_skips_metrics_when_disabled(self):
+        from tokenspeed.runtime.entrypoints.http_server import build_server
+
+        # enable_metrics=False (default) must not raise and must not require
+        # PROMETHEUS_MULTIPROC_DIR.
+        server = build_server(
+            gateway_url="http://127.0.0.1:1",
+            engine_grpc_addr="127.0.0.1:1",
+            host="127.0.0.1",
+            port=0,
+            enable_metrics=False,
+        )
+        self.assertIsNotNone(server)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

The `ts serve` orchestrator (SMG path) collected runtime metrics via `EngineMetrics`/`RequestMetrics` in the engine subprocess but never exposed them to users. The `build_server()` function in `http_server.py` lacked the `add_prometheus_middleware()` call, causing the `/metrics` endpoint on the control server (port + 1) to return 404 or empty responses.

This made `--enable-metrics` a no-op for the standard `ts serve` launch path — metrics were collected into `PROMETHEUS_MULTIPROC_DIR` but had no HTTP endpoint for scraping.

## Solution

- **`http_server.py`**: Extended `build_server()` and `start()` with an `enable_metrics` parameter. When enabled, mounts the `/metrics` Prometheus endpoint via `add_prometheus_middleware()` + `enable_func_timer()`. Added `_metrics_route_mounted()` helper for idempotent mounting.

- **`serve_smg.py`**: Wired `enable_metrics` through `run_smg()` → `_start_control_server()` → `build_server()`. When enabled, calls `set_prometheus_multiproc_dir()` **before** spawning the engine subprocess, ensuring the engine and control server share the same multiprocess directory. This allows `MultiProcessCollector` to aggregate the engine's `tokenspeed:*` metrics. Added `_engine_args_enable_metrics()` to detect `--enable-metrics` in the engine argv and pass it through `run_smg_from_args()`.

- **Tests**: Added unit tests for `_engine_args_enable_metrics()` flag parsing (bare flag, `=true/1/yes`, `=false/0`, absent, mixed with other flags) and for `/metrics` route mounting behavior (absent by default, mounted when enabled, skipped when disabled).

- **Docs**: Updated `docs/configuration/server.md` Observability section with a Prometheus Metrics subsection documenting the `/metrics` endpoint on the control port, `--control-port` parameter, and a `prometheus.yml` scrape config example.

## Verification

```bash
tokenspeed serve <model> --port 8000 --enable-metrics --tensor-parallel-size 1

# Runtime metrics (tokenspeed:*) available on control port = serve port + 1
curl http://localhost:8001/metrics
```

Expected output includes `tokenspeed_*` metrics for request latency, token throughput, and engine performance counters.

## Breaking Changes

None. The `/metrics` endpoint remains disabled by default; existing behavior is preserved unless `--enable-metrics` is explicitly passed.

---

**Related**: # (add issue number if applicable)