### PR TITLE
fix(glm-5.2): remove unnecessary DSA KV-cache and flashmla DSA path

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/base.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/base.py
@@ -48,6 +48,10 @@ class AttentionBackend(ABC):
         self.head_dim = config.head_dim
         self.is_draft = config.is_draft
         self.spec_num_tokens = config.speculative_num_draft_tokens
+        # True when this backend's CUDA-graph block-table (kv_indices) buffer is
+        # aliased to a peer backend's (e.g. a drafter sharing the target's), so
+        # the replay path skips rebuilding it — the peer already populates it.
+        self._block_table_aliased = False
 
     @contextmanager
     def override_num_extends(self, num_extends: int):

--- a/python/tokenspeed/runtime/layers/attention/backends/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/dsa.py
@@ -92,11 +92,12 @@ class DSABackend(AttentionBackend):
 
     @property
     def _block_table_aliased(self):
-        return getattr(self._dense_backend, "_block_table_aliased", False)
+        return self._dense_backend._block_table_aliased
 
     @_block_table_aliased.setter
     def _block_table_aliased(self, value):
-        self._dense_backend._block_table_aliased = value
+        if hasattr(self, "_dense_backend"):
+            self._dense_backend._block_table_aliased = value
 
     def register_step_counter(self, step_counter):
         super().register_step_counter(step_counter)

--- a/python/tokenspeed/runtime/layers/attention/backends/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/dsa.py
@@ -61,7 +61,6 @@ class DSABackend(AttentionBackend):
         self.data_type = config.kv_cache_dtype
         self.q_data_type = config.dtype
         self.num_local_heads = config.num_attention_heads // config.attn_tp_size
-        self._prefill_block_tables: torch.Tensor | None = None
 
     @property
     def forward_decode_metadata(self):
@@ -242,16 +241,12 @@ class DSABackend(AttentionBackend):
             spec_info=spec_info,
             **kwargs,
         )
-        self._prefill_block_tables = None
-        if (
-            num_extends > 0
-            and req_to_page is not None
-            and forward_mode.is_extend_or_mixed()
-        ):
-            cmeta = getattr(self._dense_backend, "chunked_prefill_metadata", None)
-            if cmeta is not None and cmeta.req_pool_indices is not None:
-                ext_idx = cmeta.req_pool_indices[:num_extends].long()
-                self._prefill_block_tables = req_to_page[ext_idx]
+
+        if forward_mode.is_extend_or_mixed():
+            chunk_meta = self._dense_backend.chunked_prefill_metadata
+            chunk_meta.block_tables = req_to_page[
+                chunk_meta.req_pool_indices[:num_extends]
+            ]
         return out
 
     def _validate_logit_cap(self, logits_soft_cap: float) -> None:

--- a/python/tokenspeed/runtime/layers/attention/backends/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/dsa.py
@@ -21,15 +21,9 @@
 from __future__ import annotations
 
 import torch
-from tokenspeed_kernel.ops.attention.flash_mla import (
-    flash_mla_sparse_fwd,
-    flash_mla_with_kvcache,
-    get_mla_metadata,
-)
 from tokenspeed_kernel.ops.attention.flashinfer import (
     trtllm_batch_decode_with_kv_cache_mla,
 )
-from tokenspeed_kernel.platform import current_platform
 from tokenspeed_kernel.registry import error_fn
 
 try:
@@ -44,67 +38,6 @@ from tokenspeed.runtime.layers.attention.backends.trtllm_mla import TRTLLMMLABac
 from tokenspeed.runtime.layers.attention.configs.dsa import DSAConfig
 from tokenspeed.runtime.layers.attention.dsa.utils import workspace_indices_to_kv_slots
 from tokenspeed.runtime.layers.attention.registry import register_backend
-
-_DSA_TRTLLM_WORKSPACE_BYTES = 384 * 1024 * 1024
-_SPARSE_IMPL_FLASHMLA = "flashmla"
-_SPARSE_IMPL_TRTLLM = "trtllm"
-_dsa_trtllm_workspace_buffers: dict[torch.device, torch.Tensor] = {}
-
-
-def _get_dsa_trtllm_workspace_buffer(device: torch.device | str) -> torch.Tensor:
-    device = torch.device(device)
-    workspace = _dsa_trtllm_workspace_buffers.get(device)
-    if workspace is None:
-        # Sparse prefill treats every query token as a decode row, so the
-        # plain TRTLLM MLA workspace is too small for long prefill chunks.
-        workspace = torch.zeros(
-            _DSA_TRTLLM_WORKSPACE_BYTES,
-            dtype=torch.uint8,
-            device=device,
-        )
-        _dsa_trtllm_workspace_buffers[device] = workspace
-    return workspace
-
-
-def _flashmla_sparse_prefill_head_multiple() -> int:
-    platform = current_platform()
-    return 128 if platform.is_nvidia and platform.is_blackwell_plus else 64
-
-
-def _flashmla_sparse_prefill_padded_heads(
-    num_heads: int,
-    head_multiple: int,
-) -> int:
-    if num_heads <= 0:
-        raise RuntimeError(
-            "DSA sparse prefill requires a positive query head count, "
-            f"got {num_heads}."
-        )
-    return ((num_heads + head_multiple - 1) // head_multiple) * head_multiple
-
-
-def _flashmla_sparse_decode_padded_heads(num_heads: int) -> int:
-    if num_heads <= 0:
-        raise RuntimeError(
-            "DSA sparse decode requires a positive query head count, "
-            f"got {num_heads}."
-        )
-    if num_heads <= 64:
-        return 64
-    if num_heads <= 128:
-        return 128
-    return num_heads
-
-
-def _default_dsa_sparse_prefill_impl(kv_cache_dtype: torch.dtype | None = None) -> str:
-    platform = current_platform()
-    if (
-        platform.is_nvidia
-        and platform.is_blackwell
-        and kv_cache_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
-    ):
-        return _SPARSE_IMPL_TRTLLM
-    return _SPARSE_IMPL_FLASHMLA
 
 
 class DSABackend(AttentionBackend):
@@ -128,57 +61,7 @@ class DSABackend(AttentionBackend):
         self.data_type = config.kv_cache_dtype
         self.q_data_type = config.dtype
         self.num_local_heads = config.num_attention_heads // config.attn_tp_size
-        self.trtllm_workspace = _get_dsa_trtllm_workspace_buffer(config.device)
-        self._prefill_workspace_buffer: torch.Tensor | None = None
-        self._prefill_workspace_rows = 0
-        self._prefill_workspace_dim = 0
-        self._prefill_query_workspace: torch.Tensor | None = None
-        self._decode_query_workspace: torch.Tensor | None = None
-        self._prefill_query_workspace_num_heads: int | None = None
-        self._decode_query_workspace_num_heads: int | None = None
         self._prefill_block_tables: torch.Tensor | None = None
-        # Only graph-captured decode workspaces must survive a regrow. Eager
-        # buffers are not referenced by replay and can be released normally.
-        self._decode_query_workspace_captured = False
-        self._sparse_prefill_impl = _default_dsa_sparse_prefill_impl(self.data_type)
-        self._sparse_decode_impl = _SPARSE_IMPL_TRTLLM
-
-    def _get_trtllm_workspace(self) -> torch.Tensor:
-        workspace = getattr(self, "trtllm_workspace", None)
-        if workspace is not None:
-            return workspace
-        dense_backend = getattr(self, "_dense_backend", None)
-        workspace = getattr(dense_backend, "trtllm_workspace", None)
-        if workspace is not None:
-            self.trtllm_workspace = workspace
-            return workspace
-        raise RuntimeError("DSA TRTLLM sparse path requires a workspace buffer.")
-
-    def _get_sparse_prefill_forward(self):
-        name = getattr(
-            self,
-            "_sparse_prefill_impl",
-            _default_dsa_sparse_prefill_impl(getattr(self, "data_type", None)),
-        )
-        if name == _SPARSE_IMPL_TRTLLM:
-            return self._forward_sparse_prefill_trtllm
-        if name == _SPARSE_IMPL_FLASHMLA:
-            return self._forward_sparse_prefill_flashmla
-        raise ValueError(
-            f"Unknown DSA sparse prefill implementation: {name}. "
-            f"Expected one of: {_SPARSE_IMPL_FLASHMLA}, {_SPARSE_IMPL_TRTLLM}."
-        )
-
-    def _get_sparse_decode_forward(self):
-        name = getattr(self, "_sparse_decode_impl", _SPARSE_IMPL_TRTLLM)
-        if name == _SPARSE_IMPL_TRTLLM:
-            return self._forward_sparse_decode_trtllm
-        if name == _SPARSE_IMPL_FLASHMLA:
-            return self._forward_sparse_decode_flashmla
-        raise ValueError(
-            f"Unknown DSA sparse decode implementation: {name}. "
-            f"Expected one of: {_SPARSE_IMPL_FLASHMLA}, {_SPARSE_IMPL_TRTLLM}."
-        )
 
     @property
     def forward_decode_metadata(self):
@@ -203,6 +86,10 @@ class DSABackend(AttentionBackend):
     @decode_cuda_graph_kv_indices.setter
     def decode_cuda_graph_kv_indices(self, value):
         self._dense_backend.decode_cuda_graph_kv_indices = value
+
+    @property
+    def trtllm_workspace(self):
+        return self._dense_backend.trtllm_workspace
 
     @property
     def _block_table_aliased(self):
@@ -367,208 +254,6 @@ class DSABackend(AttentionBackend):
                 self._prefill_block_tables = req_to_page[ext_idx]
         return out
 
-    def _get_sparse_decode_tile_metadata(self, num_reqs: int, q_len: int):
-        if get_mla_metadata is error_fn:
-            raise RuntimeError(
-                "DSA sparse decode requires FlashMLA. "
-                "Build/install `tokenspeed-kernel/python` with FlashMLA."
-            )
-        # FlashMLA lazily generates the tile schedule on the first kernel call
-        # with a given sched_meta and only allows reuse while the inputs that
-        # shaped it stay constant. We never pass topk_length (see the kernel
-        # call site), so the schedule depends only on (batch, q_len, heads,
-        # topk) and a per-shape persistent sched_meta is safe to reuse —
-        # including under CUDA graph, where the first call for a shape happens
-        # during eager warmup and capture/replay then reuse the initialized
-        # metadata buffers at fixed addresses.
-        cache = getattr(self, "_sparse_decode_sched_meta", None)
-        if cache is None:
-            cache = {}
-            self._sparse_decode_sched_meta = cache
-        key = (int(num_reqs), int(q_len))
-        meta = cache.get(key)
-        if meta is None:
-            meta = get_mla_metadata()[0]
-            cache[key] = meta
-        return meta
-
-    def _get_prefill_workspace(
-        self,
-        *,
-        num_reqs: int,
-        max_seq_len: int,
-        device: torch.device,
-    ) -> torch.Tensor:
-        workspace_reqs = max(1, int(num_reqs))
-        workspace_seq_len = max(1, int(max_seq_len))
-        rows = workspace_reqs * workspace_seq_len
-        workspace = self._get_prefill_workspace_rows(rows=rows, device=device)
-        return workspace[:rows].view(
-            workspace_reqs,
-            workspace_seq_len,
-            1,
-            self.kv_cache_dim,
-        )
-
-    def _get_prefill_workspace_rows(
-        self,
-        *,
-        rows: int,
-        device: torch.device,
-    ) -> torch.Tensor:
-        rows = max(1, int(rows))
-        if (
-            self._prefill_workspace_buffer is None
-            or self._prefill_workspace_buffer.device != device
-            or self._prefill_workspace_dim != self.kv_cache_dim
-            or self._prefill_workspace_rows < rows
-        ):
-            self._prefill_workspace_buffer = torch.empty(
-                (rows, 1, self.kv_cache_dim),
-                dtype=torch.bfloat16,
-                device=device,
-            )
-            self._prefill_workspace_rows = rows
-            self._prefill_workspace_dim = self.kv_cache_dim
-        assert self._prefill_workspace_buffer is not None
-        return self._prefill_workspace_buffer[:rows]
-
-    def _get_prefill_query_workspace(
-        self,
-        *,
-        rows: int,
-        padded_heads: int,
-        head_dim: int,
-        device: torch.device,
-        dtype: torch.dtype,
-    ) -> torch.Tensor:
-        if (
-            self._prefill_query_workspace is None
-            or self._prefill_query_workspace.device != device
-            or self._prefill_query_workspace.dtype != dtype
-            or self._prefill_query_workspace.shape[0] < rows
-            or self._prefill_query_workspace.shape[1] != padded_heads
-            or self._prefill_query_workspace.shape[2] != head_dim
-        ):
-            self._prefill_query_workspace = torch.empty(
-                (rows, padded_heads, head_dim),
-                dtype=dtype,
-                device=device,
-            )
-            self._prefill_query_workspace.zero_()
-            self._prefill_query_workspace_num_heads = 0
-        return self._prefill_query_workspace[:rows]
-
-    def _get_decode_query_workspace(
-        self,
-        *,
-        num_tokens: int,
-        seq_len: int,
-        padded_heads: int,
-        head_dim: int,
-        device: torch.device,
-        dtype: torch.dtype,
-    ) -> torch.Tensor:
-        capturing = (
-            torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()
-        )
-        if (
-            self._decode_query_workspace is None
-            or self._decode_query_workspace.device != device
-            or self._decode_query_workspace.dtype != dtype
-            or self._decode_query_workspace.shape[0] < num_tokens
-            or self._decode_query_workspace.shape[1] != seq_len
-            or self._decode_query_workspace.shape[2] != padded_heads
-            or self._decode_query_workspace.shape[3] != head_dim
-        ):
-            if (
-                self._decode_query_workspace is not None
-                and self._decode_query_workspace_captured
-            ):
-                # A captured CUDA graph may still replay into the old buffer
-                # (q_len flips between decode and spec-verify re-trigger this
-                # path); keep it alive instead of returning it to the
-                # allocator.
-                retired = getattr(self, "_retired_decode_query_workspaces", None)
-                if retired is None:
-                    retired = []
-                    self._retired_decode_query_workspaces = retired
-                retired.append(self._decode_query_workspace)
-            self._decode_query_workspace = torch.empty(
-                (num_tokens, seq_len, padded_heads, head_dim),
-                dtype=dtype,
-                device=device,
-            )
-            self._decode_query_workspace.zero_()
-            self._decode_query_workspace_num_heads = 0
-            self._decode_query_workspace_captured = capturing
-        elif capturing:
-            self._decode_query_workspace_captured = True
-        return self._decode_query_workspace[:num_tokens]
-
-    def _pad_sparse_prefill_query_heads(
-        self,
-        q: torch.Tensor,
-        *,
-        num_heads: int,
-        head_dim: int,
-        head_multiple: int,
-    ) -> tuple[torch.Tensor, int]:
-        q = q.view(-1, num_heads, head_dim)
-        padded_heads = _flashmla_sparse_prefill_padded_heads(
-            num_heads,
-            head_multiple,
-        )
-        if padded_heads == num_heads:
-            return q.contiguous(), num_heads
-
-        q_padded = self._get_prefill_query_workspace(
-            rows=q.shape[0],
-            padded_heads=padded_heads,
-            head_dim=head_dim,
-            device=q.device,
-            dtype=q.dtype,
-        )
-        q_padded[:, :num_heads, :].copy_(q)
-        previous_num_heads = getattr(
-            self,
-            "_prefill_query_workspace_num_heads",
-            None,
-        )
-        if previous_num_heads is None or previous_num_heads > num_heads:
-            q_padded[:, num_heads:, :].zero_()
-        self._prefill_query_workspace_num_heads = num_heads
-        return q_padded, num_heads
-
-    def _pad_sparse_decode_query_heads(
-        self,
-        q: torch.Tensor,
-        *,
-        num_heads: int,
-    ) -> tuple[torch.Tensor, int]:
-        padded_heads = _flashmla_sparse_decode_padded_heads(num_heads)
-        if padded_heads == num_heads:
-            return q.contiguous(), num_heads
-
-        q_padded = self._get_decode_query_workspace(
-            num_tokens=q.shape[0],
-            seq_len=q.shape[1],
-            padded_heads=padded_heads,
-            head_dim=q.shape[3],
-            device=q.device,
-            dtype=q.dtype,
-        )
-        q_padded[:, :, :num_heads, :].copy_(q)
-        previous_num_heads = getattr(
-            self,
-            "_decode_query_workspace_num_heads",
-            None,
-        )
-        if previous_num_heads is None or previous_num_heads > num_heads:
-            q_padded[:, :, num_heads:, :].zero_()
-        self._decode_query_workspace_num_heads = num_heads
-        return q_padded, num_heads
-
     def _validate_logit_cap(self, logits_soft_cap: float) -> None:
         if logits_soft_cap and logits_soft_cap > 0:
             raise NotImplementedError(
@@ -684,7 +369,7 @@ class DSABackend(AttentionBackend):
         kv_workspace_slots: torch.Tensor | None = None,
         max_seq_len: int,
     ) -> torch.Tensor:
-        return self._get_sparse_prefill_forward()(
+        return self._forward_sparse_prefill_trtllm(
             q=q,
             layer=layer,
             token_to_kv_pool=token_to_kv_pool,
@@ -695,136 +380,6 @@ class DSABackend(AttentionBackend):
             kv_workspace_slots=kv_workspace_slots,
             max_seq_len=max_seq_len,
         )
-
-    def _forward_sparse_prefill_flashmla(
-        self,
-        *,
-        q: torch.Tensor,
-        layer,
-        token_to_kv_pool,
-        block_tables: torch.Tensor,
-        seq_lens: torch.Tensor,
-        workspace_indices: torch.Tensor,
-        topk_lens: torch.Tensor,
-        kv_workspace_slots: torch.Tensor | None = None,
-        max_seq_len: int,
-    ) -> torch.Tensor:
-        if flash_mla_sparse_fwd is error_fn:
-            raise RuntimeError(
-                "DSA sparse prefill requires FlashMLA. "
-                "Build/install `tokenspeed-kernel/python` with FlashMLA."
-            )
-        if layer.logit_cap and layer.logit_cap > 0:
-            self._validate_logit_cap(layer.logit_cap)
-        if self.page_size != 64:
-            raise RuntimeError(
-                "DSA sparse prefill currently requires page_size=64 for "
-                f"FlashMLA sparse KV layout, got {self.page_size}."
-            )
-        if self.kv_lora_rank != 512:
-            raise RuntimeError(
-                "DSA sparse prefill requires kv_lora_rank=512 for FlashMLA, "
-                f"got {self.kv_lora_rank}."
-            )
-        if getattr(token_to_kv_pool, "quant_method", None) == "per_token_head":
-            raise RuntimeError(
-                "DSA sparse prefill does not support "
-                "kv_cache_quant_method='per_token_head' yet."
-            )
-        if self.data_type in (torch.float8_e4m3fn, torch.float8_e5m2):
-            raise RuntimeError(
-                "DSA sparse prefill does not support FP8 MLA KV cache layout yet."
-            )
-        if q.dtype != torch.bfloat16:
-            raise RuntimeError(
-                "DSA sparse prefill requires BF16 query tensors, " f"got {q.dtype}."
-            )
-
-        num_reqs = int(seq_lens.numel())
-        if workspace_indices.shape[0] != q.shape[0]:
-            raise RuntimeError(
-                "DSA sparse prefill metadata token mismatch: "
-                f"indices={workspace_indices.shape[0]}, q_tokens={q.shape[0]}"
-            )
-        if topk_lens.shape[0] != q.shape[0]:
-            raise RuntimeError(
-                "DSA sparse prefill top-k length mismatch: "
-                f"lens={topk_lens.shape[0]}, q_tokens={q.shape[0]}"
-            )
-        if num_reqs == 0 or q.shape[0] == 0:
-            return q.new_empty((0, layer.tp_q_head_num * layer.v_head_dim))
-
-        k_cache = token_to_kv_pool.get_key_buffer(layer.layer_id)
-        if k_cache.dtype != torch.bfloat16:
-            raise RuntimeError(
-                "DSA sparse prefill currently requires BF16 MLA KV cache, "
-                f"got {k_cache.dtype}."
-            )
-
-        if kv_workspace_slots is not None:
-            if kv_workspace_slots.dim() != 1:
-                raise RuntimeError(
-                    "DSA sparse prefill KV slot shape mismatch: "
-                    f"expected 1-D packed slots, got "
-                    f"{tuple(kv_workspace_slots.shape)}"
-                )
-            kv_workspace = self._get_prefill_workspace_rows(
-                rows=kv_workspace_slots.numel(),
-                device=q.device,
-            )
-            flat_slots = kv_workspace_slots.to(
-                device=q.device,
-                dtype=torch.int64,
-            )
-            flat_workspace = kv_workspace.view(-1, 1, self.kv_cache_dim)
-            flat_workspace.copy_(
-                k_cache.index_select(0, flat_slots).view_as(flat_workspace)
-            )
-        else:
-            kv_workspace = self._get_prefill_workspace(
-                num_reqs=num_reqs,
-                max_seq_len=int(max_seq_len),
-                device=q.device,
-            )
-            for req_idx in range(num_reqs):
-                seq_len = int(seq_lens[req_idx].item())
-                if seq_len <= 0:
-                    continue
-                local = torch.arange(seq_len, dtype=torch.int64, device=q.device)
-                page_offsets = torch.div(
-                    local,
-                    self.page_size,
-                    rounding_mode="floor",
-                )
-                pages = (
-                    block_tables[req_idx]
-                    .to(torch.int64)
-                    .index_select(
-                        0,
-                        page_offsets,
-                    )
-                )
-                slots = pages * self.page_size + (local % self.page_size)
-                kv_workspace[req_idx, :seq_len].copy_(k_cache.index_select(0, slots))
-
-        q_kernel, actual_num_heads = self._pad_sparse_prefill_query_heads(
-            q,
-            num_heads=layer.tp_q_head_num,
-            head_dim=layer.head_dim,
-            head_multiple=_flashmla_sparse_prefill_head_multiple(),
-        )
-
-        # Invalid sparse slots are encoded as -1; do not pass topk_length here.
-        out, _, _ = flash_mla_sparse_fwd(
-            q=q_kernel,
-            kv=kv_workspace.view(-1, 1, self.kv_cache_dim),
-            indices=workspace_indices.unsqueeze(1),
-            sm_scale=layer.scaling,
-            d_v=layer.v_head_dim,
-        )
-        if out.shape[1] != actual_num_heads:
-            out = out[:, :actual_num_heads, :]
-        return out.reshape(-1, layer.tp_q_head_num * layer.v_head_dim)
 
     def _forward_sparse_prefill_trtllm(
         self,
@@ -895,7 +450,7 @@ class DSABackend(AttentionBackend):
         out = trtllm_batch_decode_with_kv_cache_mla(
             query=q,
             kv_cache=kv_cache,
-            workspace_buffer=self._get_trtllm_workspace(),
+            workspace_buffer=self.trtllm_workspace,
             qk_nope_head_dim=self.qk_nope_head_dim,
             kv_lora_rank=self.kv_lora_rank,
             qk_rope_head_dim=self.qk_rope_head_dim,
@@ -933,12 +488,11 @@ class DSABackend(AttentionBackend):
                 "DSA sparse decode does not support "
                 "kv_cache_quant_method='per_token_head' yet."
             )
-        allow_trtllm_fp8_query = (
-            getattr(self, "_sparse_decode_impl", "trtllm") == "trtllm"
-            and getattr(self, "data_type", torch.bfloat16) == torch.float8_e4m3fn
+        allow_fp8_query = (
+            getattr(self, "data_type", torch.bfloat16) == torch.float8_e4m3fn
             and q.dtype == torch.float8_e4m3fn
         )
-        if q.dtype != torch.bfloat16 and not allow_trtllm_fp8_query:
+        if q.dtype != torch.bfloat16 and not allow_fp8_query:
             raise RuntimeError(
                 "DSA sparse decode requires BF16 query tensors, or FP8 query "
                 f"tensors on the TRTLLM FP8 KV path, got {q.dtype}."
@@ -971,7 +525,7 @@ class DSABackend(AttentionBackend):
             q_len_per_req = 1
         num_reqs = num_tokens // q_len_per_req
 
-        return self._get_sparse_decode_forward()(
+        return self._forward_sparse_decode_trtllm(
             q=q,
             layer=layer,
             token_to_kv_pool=token_to_kv_pool,
@@ -980,59 +534,6 @@ class DSABackend(AttentionBackend):
             topk_lens=topk_lens,
             q_len_per_req=q_len_per_req,
         )
-
-    def _forward_sparse_decode_flashmla(
-        self,
-        *,
-        q: torch.Tensor,
-        layer,
-        token_to_kv_pool,
-        num_reqs: int,
-        topk_indices: torch.Tensor,
-        topk_lens: torch.Tensor | None = None,
-        q_len_per_req: int = 1,
-    ) -> torch.Tensor:
-        del topk_lens
-        if flash_mla_with_kvcache is error_fn:
-            raise RuntimeError(
-                "DSA multi-token sparse decode requires FlashMLA. "
-                "Build/install `tokenspeed-kernel/python` with FlashMLA."
-            )
-        if not hasattr(token_to_kv_pool, "get_sparse_decode_kv_buffer"):
-            raise RuntimeError(
-                "DSA multi-token sparse decode requires a DSA KV pool with "
-                "sparse decode cache storage."
-            )
-        q = q.view(num_reqs, q_len_per_req, layer.tp_q_head_num, layer.head_dim)
-        q, actual_num_heads = self._pad_sparse_decode_query_heads(
-            q,
-            num_heads=layer.tp_q_head_num,
-        )
-        k_cache = token_to_kv_pool.get_sparse_decode_kv_buffer(layer.layer_id)
-        kv_cache = k_cache.view(-1, self.page_size, 1, k_cache.shape[-1])
-
-        out, _ = flash_mla_with_kvcache(
-            q=q,
-            k_cache=kv_cache,
-            block_table=None,
-            cache_seqlens=None,
-            head_dim_v=self.kv_lora_rank,
-            tile_scheduler_metadata=self._get_sparse_decode_tile_metadata(
-                num_reqs,
-                q_len_per_req,
-            ),
-            softmax_scale=layer.scaling,
-            is_fp8_kvcache=True,
-            indices=topk_indices.view(num_reqs, q_len_per_req, -1),
-            # Lengths are carried by -1 padding; keep FlashMLA scheduling static.
-        )
-        if out.dim() == 4:
-            if out.shape[2] != actual_num_heads:
-                out = out[:, :, :actual_num_heads, :]
-            out = out.reshape(-1, actual_num_heads, out.shape[-1])
-        elif out.shape[1] != actual_num_heads:
-            out = out[:, :actual_num_heads, :]
-        return out.reshape(-1, layer.tp_q_head_num * layer.v_head_dim)
 
     def _forward_sparse_decode_trtllm(
         self,
@@ -1128,7 +629,7 @@ class DSABackend(AttentionBackend):
         out = trtllm_batch_decode_with_kv_cache_mla(
             query=q,
             kv_cache=kv_cache,
-            workspace_buffer=self._get_trtllm_workspace(),
+            workspace_buffer=self.trtllm_workspace,
             qk_nope_head_dim=self.qk_nope_head_dim,
             kv_lora_rank=self.kv_lora_rank,
             qk_rope_head_dim=self.qk_rope_head_dim,

--- a/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
@@ -406,7 +406,7 @@ class CuteDSLMLABackend(AttentionBackend):
         # When the buffer is aliased to a peer backend (e.g. drafter aliasing
         # the target's kv_indices), the peer's replay has already populated it
         # with identical content.
-        if req_to_page is not None and not getattr(self, "_block_table_aliased", False):
+        if req_to_page is not None and not self._block_table_aliased:
             self._create_block_kv_indices(
                 bs,
                 metadata.block_kv_indices.shape[1],

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
@@ -96,6 +96,9 @@ class TRTLLMMLAChunkedPrefillMetadata:
     chunked_seq_len: torch.Tensor  # (chunked_loop_num, num_extends) int32 GPU
     cu_chunked_seq_len: torch.Tensor  # (chunked_loop_num, num_extends+1) int32 GPU
     max_chunk_len_per_loop: list  # List[int], one per loop_idx
+    # Per-request page table (req_to_page[req_pool_indices]). Populated only by
+    # the DSA backend for sparse-prefill top-k; plain MLA leaves it None.
+    block_tables: torch.Tensor | None = None
 
 
 @dataclass

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
@@ -377,7 +377,7 @@ class TRTLLMMLABackend(AttentionBackend):
         # When the buffer is aliased to a peer backend (e.g. drafter aliasing
         # the target's kv_indices), the peer's replay has already populated it
         # with identical content.
-        if req_to_page is not None and not getattr(self, "_block_table_aliased", False):
+        if req_to_page is not None and not self._block_table_aliased:
             self._create_block_kv_indices(
                 bs,
                 metadata.block_kv_indices.shape[1],

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
@@ -56,7 +56,7 @@ logger = logging.getLogger(__name__)
 # Block constraint from flashinfer: block_num % (128 / page_size) == 0
 TRTLLM_BLOCK_CONSTRAINT = 128
 
-# Shared workspace buffer for fused kernels (150 MB, zero-initialized).
+# Shared workspace buffer for fused kernels (256 MB, zero-initialized).
 # Zero-init is required for the kernel's internal semaphore mechanism.
 _trtllm_workspace_buffer = None
 
@@ -66,7 +66,7 @@ def get_trtllm_workspace_buffer(device):
     global _trtllm_workspace_buffer
     if _trtllm_workspace_buffer is None:
         _trtllm_workspace_buffer = torch.zeros(
-            150 * 1024 * 1024,
+            256 * 1024 * 1024,
             dtype=torch.uint8,
             device=device,
         )

--- a/python/tokenspeed/runtime/layers/attention/configs/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/dsa.py
@@ -33,6 +33,9 @@ _SPARSE_DECODE_FP8_QUANT_BLOCK = 128
 _SPARSE_DECODE_FP8_SCALE_BYTES = torch._utils._element_size(torch.float32)
 _SPARSE_DECODE_ROPE_BYTES = torch._utils._element_size(torch.bfloat16)
 
+_INDEX_K_FP8_GROUP_SIZE = 128
+_INDEX_K_SCALE_BYTES = torch._utils._element_size(torch.float32)
+
 
 def _is_blackwell_device(device: str) -> bool:
     if not torch.cuda.is_available() or not str(device).startswith("cuda"):
@@ -65,6 +68,18 @@ def dsa_sparse_decode_row_bytes(
     )
 
 
+def dsa_index_k_row_bytes(index_head_dim: int) -> int:
+    if index_head_dim % _INDEX_K_FP8_GROUP_SIZE != 0:
+        raise ValueError(
+            "DSA index_head_dim must be divisible by "
+            f"{_INDEX_K_FP8_GROUP_SIZE}, got {index_head_dim}"
+        )
+    return (
+        index_head_dim
+        + index_head_dim // _INDEX_K_FP8_GROUP_SIZE * _INDEX_K_SCALE_BYTES
+    )
+
+
 @dataclass
 class DSAConfig(MLAConfig):
     index_topk: int
@@ -94,12 +109,14 @@ class DSAConfig(MLAConfig):
         )
 
     def cache_cell_size(self) -> int:
-        index_cell_size = self.index_head_dim * torch._utils._element_size(self.dtype)
         sparse_decode_cell_size = dsa_sparse_decode_row_bytes(
             self.kv_lora_rank,
             self.qk_rope_head_dim,
         )
-        return super().cache_cell_size() + index_cell_size + sparse_decode_cell_size
+        index_k_cell_size = dsa_index_k_row_bytes(
+            self.index_head_dim,
+        )
+        return super().cache_cell_size() + sparse_decode_cell_size + index_k_cell_size
 
     def create_pool(
         self,

--- a/python/tokenspeed/runtime/layers/attention/configs/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/dsa.py
@@ -29,10 +29,6 @@ from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.kv_cache.base import BaseTokenToKVPool
 from tokenspeed.runtime.utils.server_args import ServerArgs
 
-_SPARSE_DECODE_FP8_QUANT_BLOCK = 128
-_SPARSE_DECODE_FP8_SCALE_BYTES = torch._utils._element_size(torch.float32)
-_SPARSE_DECODE_ROPE_BYTES = torch._utils._element_size(torch.bfloat16)
-
 _INDEX_K_FP8_GROUP_SIZE = 128
 _INDEX_K_SCALE_BYTES = torch._utils._element_size(torch.float32)
 
@@ -45,27 +41,6 @@ def _is_blackwell_device(device: str) -> bool:
     except (AssertionError, RuntimeError, ValueError):
         major, _minor = torch.cuda.get_device_capability()
     return major >= 10
-
-
-def dsa_sparse_decode_row_bytes(
-    kv_lora_rank: int,
-    qk_rope_head_dim: int,
-) -> int:
-    """Return bytes in one packed DSA sparse-decode KV cache row."""
-    kv_lora_rank = int(kv_lora_rank)
-    qk_rope_head_dim = int(qk_rope_head_dim)
-    if kv_lora_rank % _SPARSE_DECODE_FP8_QUANT_BLOCK != 0:
-        raise ValueError(
-            "DSA sparse decode NoPE dim must be divisible by "
-            f"{_SPARSE_DECODE_FP8_QUANT_BLOCK}, got {kv_lora_rank}"
-        )
-    return (
-        kv_lora_rank
-        + kv_lora_rank
-        // _SPARSE_DECODE_FP8_QUANT_BLOCK
-        * _SPARSE_DECODE_FP8_SCALE_BYTES
-        + qk_rope_head_dim * _SPARSE_DECODE_ROPE_BYTES
-    )
 
 
 def dsa_index_k_row_bytes(index_head_dim: int) -> int:
@@ -109,14 +84,10 @@ class DSAConfig(MLAConfig):
         )
 
     def cache_cell_size(self) -> int:
-        sparse_decode_cell_size = dsa_sparse_decode_row_bytes(
-            self.kv_lora_rank,
-            self.qk_rope_head_dim,
-        )
         index_k_cell_size = dsa_index_k_row_bytes(
             self.index_head_dim,
         )
-        return super().cache_cell_size() + sparse_decode_cell_size + index_k_cell_size
+        return super().cache_cell_size() + index_k_cell_size
 
     def create_pool(
         self,

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
@@ -67,12 +67,7 @@ class BaseTokenToKVPool:
         # default state for optional layer-wise transfer control
         self.layer_transfer_counter = None
         logger.info(
-            "Initialized token to kv pool with size %s, dtype %s, device %s, page size %s, rank %s",
-            size,
-            dtype,
-            device,
-            page_size,
-            rank,
+            f"Initialized token to kv pool with size {size}, dtype {dtype}, device {device}, page size {page_size}, rank {rank}"
         )
 
     @classmethod

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
@@ -26,7 +26,10 @@ from tokenspeed_kernel.ops.attention.triton.dsa_sparse_layout import (
 )
 from tokenspeed_kernel.ops.quantization import quantize_fp8_with_scale
 
-from tokenspeed.runtime.layers.attention.configs.dsa import dsa_sparse_decode_row_bytes
+from tokenspeed.runtime.layers.attention.configs.dsa import (
+    dsa_index_k_row_bytes,
+    dsa_sparse_decode_row_bytes,
+)
 from tokenspeed.runtime.layers.attention.kv_cache.mla import (
     MLATokenToKVPool,
     _get_tensor_size_bytes,
@@ -57,14 +60,10 @@ class DSATokenToKVPool(MLATokenToKVPool):
             kv_lora_rank,
             qk_rope_head_dim,
         )
-        if self.index_head_dim % _INDEX_K_FP8_GROUP_SIZE == 0:
-            self.index_k_with_scale_row_bytes = (
-                self.index_head_dim
-                + self.index_head_dim // _INDEX_K_FP8_GROUP_SIZE * _INDEX_K_SCALE_BYTES
-            )
-        else:
-            self.index_k_with_scale_row_bytes = 0
-        self._index_k_with_scale_available = self.index_k_with_scale_row_bytes > 0
+        self.index_k_row_bytes = dsa_index_k_row_bytes(
+            self.index_head_dim,
+        )
+        self._index_k_available = self.index_k_row_bytes > 0
         super().__init__(*args, **kwargs)
         with self.memory_saver_adapter.region():
             self.sparse_decode_kv_buffer = [
@@ -76,24 +75,16 @@ class DSATokenToKVPool(MLATokenToKVPool):
                 for _ in range(self.layer_num)
             ]
             self.index_k_buffer = [
-                torch.zeros(
-                    (self.size + self.page_size, self.index_head_dim),
-                    dtype=self.model_dtype,
-                    device=self.device,
-                )
-                for _ in range(self.layer_num)
-            ]
-            self.index_k_with_scale_buffer = [
                 (
                     torch.zeros(
                         (
                             self.size + self.page_size,
-                            self.index_k_with_scale_row_bytes,
+                            self.index_k_row_bytes,
                         ),
                         dtype=torch.uint8,
                         device=self.device,
                     )
-                    if self.index_k_with_scale_row_bytes > 0
+                    if self.index_k_row_bytes > 0
                     else None
                 )
                 for _ in range(self.layer_num)
@@ -101,24 +92,19 @@ class DSATokenToKVPool(MLATokenToKVPool):
 
     def _get_page_size_bytes(self):
         sparse_decode_size_bytes = self.sparse_decode_kv_row_bytes
-        index_size_bytes = self.index_head_dim * torch._utils._element_size(
-            self.model_dtype
-        )
-        index_with_scale_size_bytes = self.index_k_with_scale_row_bytes
+        index_size_bytes = self.index_k_row_bytes
         return (
             super()._get_page_size_bytes()
             + self.page_size * self.layer_num * sparse_decode_size_bytes
             + self.page_size * self.layer_num * index_size_bytes
-            + self.page_size * self.layer_num * index_with_scale_size_bytes
         )
 
     def get_kv_size_bytes(self):
         return (
             super().get_kv_size_bytes()
             + _get_tensor_size_bytes(self.sparse_decode_kv_buffer)
-            + _get_tensor_size_bytes(self.index_k_buffer)
             + _get_tensor_size_bytes(
-                [buf for buf in self.index_k_with_scale_buffer if buf is not None]
+                [buf for buf in self.index_k_buffer if buf is not None]
             )
         )
 
@@ -131,13 +117,11 @@ class DSATokenToKVPool(MLATokenToKVPool):
         for buf in self.sparse_decode_kv_buffer:
             buf[tgt_loc_flat] = buf[src_loc_flat]
         for buf in self.index_k_buffer:
-            buf[tgt_loc_flat] = buf[src_loc_flat]
-        for buf in self.index_k_with_scale_buffer:
             if buf is not None:
                 # Packed FP8 index-K is block-split per page, so a single
                 # token's bytes are NOT a contiguous row; move the FP8 values
                 # and FP32 scales through their block-split views instead.
-                fp8_view, scale_view = self._index_k_with_scale_block_views(buf)
+                fp8_view, scale_view = self._index_k_block_views(buf)
                 ps = self.page_size
                 tgt_page = tgt_loc_flat // ps
                 tgt_slot = tgt_loc_flat % ps
@@ -171,19 +155,14 @@ class DSATokenToKVPool(MLATokenToKVPool):
             self.layer_transfer_counter.wait_until(layer_id)
         return self.sparse_decode_kv_buffer[layer_id]
 
+    def has_index_k_buffer(self) -> bool:
+        return self._index_k_available
+
     def get_index_k_buffer(self, layer_id: int) -> torch.Tensor:
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id)
-        return self.index_k_buffer[layer_id]
-
-    def has_index_k_with_scale_buffer(self) -> bool:
-        return self._index_k_with_scale_available
-
-    def get_index_k_with_scale_buffer(self, layer_id: int) -> torch.Tensor:
-        if self.layer_transfer_counter is not None:
-            self.layer_transfer_counter.wait_until(layer_id)
-        buf = self.index_k_with_scale_buffer[layer_id]
-        if buf is None or not self._index_k_with_scale_available:
+        buf = self.index_k_buffer[layer_id]
+        if buf is None or not self._index_k_available:
             raise RuntimeError("GLM DSA FP8 index K cache is unavailable")
         return buf
 
@@ -196,10 +175,9 @@ class DSATokenToKVPool(MLATokenToKVPool):
         if index_k.dtype != self.model_dtype:
             index_k = index_k.to(self.model_dtype)
         index_k = index_k.view(-1, self.index_head_dim)
-        self.index_k_buffer[layer_id][loc] = index_k
-        self._set_index_k_with_scale_buffer(layer_id, loc, index_k)
+        self._set_index_k_buffer(layer_id, loc, index_k)
 
-    def _index_k_with_scale_block_views(
+    def _index_k_block_views(
         self, buf: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Return per-page block-split views into a packed FP8 index-K buffer.
@@ -242,13 +220,13 @@ class DSATokenToKVPool(MLATokenToKVPool):
         )
         return fp8_view, scale_view
 
-    def gather_index_k_with_scale(
+    def gather_index_k(
         self, layer_id: int, slots: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Gather per-token FP8 index-K values and scales from the cache.
 
         The packed FP8 index-K buffer is stored block-split per page (see
-        :meth:`_index_k_with_scale_block_views`), so the non-paged prefill
+        :meth:`_index_k_block_views`), so the non-paged prefill
         scoring kernel (``fp8_mqa_logits``), which consumes contiguous
         ``(k_fp8, k_scale)`` tensors, must gather token rows through the
         block-split views rather than indexing raw rows.
@@ -262,8 +240,8 @@ class DSATokenToKVPool(MLATokenToKVPool):
             ``[num_slots, head_dim]`` (FP8 e4m3) and ``k_scale`` has shape
             ``[num_slots, num_groups]`` (float32).
         """
-        buf = self.get_index_k_with_scale_buffer(layer_id)
-        fp8_view, scale_view = self._index_k_with_scale_block_views(buf)
+        buf = self.get_index_k_buffer(layer_id)
+        fp8_view, scale_view = self._index_k_block_views(buf)
         slots = slots.to(torch.long)
         page = slots // self.page_size
         slot_in_page = slots % self.page_size
@@ -271,15 +249,15 @@ class DSATokenToKVPool(MLATokenToKVPool):
         k_scale = scale_view[page, slot_in_page]
         return k_fp8, k_scale
 
-    def _set_index_k_with_scale_buffer(
+    def _set_index_k_buffer(
         self,
         layer_id: int,
         loc: torch.Tensor,
         index_k: torch.Tensor,
     ) -> None:
-        if not self._index_k_with_scale_available:
+        if not self._index_k_available:
             return
-        buf = self.index_k_with_scale_buffer[layer_id]
+        buf = self.index_k_buffer[layer_id]
         if buf is None:
             raise RuntimeError("DSA FP8 index K cache is unavailable")
         index_k_fp8, index_k_scale = quantize_fp8_with_scale(
@@ -289,7 +267,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
             scale_encoding="float32",
         )
 
-        fp8_view, scale_view = self._index_k_with_scale_block_views(buf)
+        fp8_view, scale_view = self._index_k_block_views(buf)
         loc = loc.to(torch.long)
         page = loc // self.page_size
         slot_in_page = loc % self.page_size
@@ -308,10 +286,6 @@ class DSATokenToKVPool(MLATokenToKVPool):
             data_lens.append(buf.nbytes)
             item_lens.append(buf[0].nbytes * self.page_size)
         for buf in self.index_k_buffer:
-            data_ptrs.append(buf.data_ptr())
-            data_lens.append(buf.nbytes)
-            item_lens.append(buf[0].nbytes * self.page_size)
-        for buf in self.index_k_with_scale_buffer:
             if buf is not None:
                 data_ptrs.append(buf.data_ptr())
                 data_lens.append(buf.nbytes)
@@ -328,10 +302,9 @@ class DSATokenToKVPool(MLATokenToKVPool):
             layer_offsets
             + [
                 start_idx + base_count + layer_id,
-                start_idx + base_count + self.layer_num + layer_id,
                 *(
-                    [start_idx + base_count + 2 * self.layer_num + layer_id]
-                    if self.index_k_with_scale_row_bytes > 0
+                    [start_idx + base_count + self.layer_num + layer_id]
+                    if self.index_k_row_bytes > 0
                     else []
                 ),
             ]

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
@@ -21,15 +21,9 @@
 from __future__ import annotations
 
 import torch
-from tokenspeed_kernel.ops.attention.triton.dsa_sparse_layout import (
-    pack_sparse_decode_kv,
-)
 from tokenspeed_kernel.ops.quantization import quantize_fp8_with_scale
 
-from tokenspeed.runtime.layers.attention.configs.dsa import (
-    dsa_index_k_row_bytes,
-    dsa_sparse_decode_row_bytes,
-)
+from tokenspeed.runtime.layers.attention.configs.dsa import dsa_index_k_row_bytes
 from tokenspeed.runtime.layers.attention.kv_cache.mla import (
     MLATokenToKVPool,
     _get_tensor_size_bytes,
@@ -51,29 +45,12 @@ class DSATokenToKVPool(MLATokenToKVPool):
         **kwargs,
     ):
         self.index_head_dim = int(index_head_dim)
-        kv_lora_rank = kwargs.get("kv_lora_rank", args[4] if len(args) > 4 else None)
-        qk_rope_head_dim = kwargs.get(
-            "qk_rope_head_dim",
-            args[5] if len(args) > 5 else None,
-        )
-        self.sparse_decode_kv_row_bytes = dsa_sparse_decode_row_bytes(
-            kv_lora_rank,
-            qk_rope_head_dim,
-        )
         self.index_k_row_bytes = dsa_index_k_row_bytes(
             self.index_head_dim,
         )
         self._index_k_available = self.index_k_row_bytes > 0
         super().__init__(*args, **kwargs)
         with self.memory_saver_adapter.region():
-            self.sparse_decode_kv_buffer = [
-                torch.zeros(
-                    (self.size + self.page_size, self.sparse_decode_kv_row_bytes),
-                    dtype=torch.uint8,
-                    device=self.device,
-                )
-                for _ in range(self.layer_num)
-            ]
             self.index_k_buffer = [
                 (
                     torch.zeros(
@@ -91,21 +68,15 @@ class DSATokenToKVPool(MLATokenToKVPool):
             ]
 
     def _get_page_size_bytes(self):
-        sparse_decode_size_bytes = self.sparse_decode_kv_row_bytes
         index_size_bytes = self.index_k_row_bytes
         return (
             super()._get_page_size_bytes()
-            + self.page_size * self.layer_num * sparse_decode_size_bytes
             + self.page_size * self.layer_num * index_size_bytes
         )
 
     def get_kv_size_bytes(self):
-        return (
-            super().get_kv_size_bytes()
-            + _get_tensor_size_bytes(self.sparse_decode_kv_buffer)
-            + _get_tensor_size_bytes(
-                [buf for buf in self.index_k_buffer if buf is not None]
-            )
+        return super().get_kv_size_bytes() + _get_tensor_size_bytes(
+            [buf for buf in self.index_k_buffer if buf is not None]
         )
 
     def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
@@ -114,8 +85,6 @@ class DSATokenToKVPool(MLATokenToKVPool):
             return
         tgt_loc_flat = tgt_loc.view(-1).long()
         src_loc_flat = src_loc.view(-1).long()
-        for buf in self.sparse_decode_kv_buffer:
-            buf[tgt_loc_flat] = buf[src_loc_flat]
         for buf in self.index_k_buffer:
             if buf is not None:
                 # Packed FP8 index-K is block-split per page, so a single
@@ -129,31 +98,6 @@ class DSATokenToKVPool(MLATokenToKVPool):
                 src_slot = src_loc_flat % ps
                 fp8_view[tgt_page, tgt_slot] = fp8_view[src_page, src_slot]
                 scale_view[tgt_page, tgt_slot] = scale_view[src_page, src_slot]
-
-    def set_mla_kv_buffer(
-        self,
-        layer,
-        loc: torch.Tensor,
-        cache_k_nope: torch.Tensor,
-        cache_k_rope: torch.Tensor,
-    ):
-        super().set_mla_kv_buffer(layer, loc, cache_k_nope, cache_k_rope)
-        if self.quant_method == "per_token_head":
-            return
-        if cache_k_nope.dtype != torch.bfloat16:
-            cache_k_nope = cache_k_nope.to(torch.bfloat16)
-            cache_k_rope = cache_k_rope.to(torch.bfloat16)
-        pack_sparse_decode_kv(
-            out=self.sparse_decode_kv_buffer[layer.layer_id],
-            loc=loc,
-            cache_k_nope=cache_k_nope,
-            cache_k_rope=cache_k_rope,
-        )
-
-    def get_sparse_decode_kv_buffer(self, layer_id: int) -> torch.Tensor:
-        if self.layer_transfer_counter is not None:
-            self.layer_transfer_counter.wait_until(layer_id)
-        return self.sparse_decode_kv_buffer[layer_id]
 
     def has_index_k_buffer(self) -> bool:
         return self._index_k_available
@@ -281,10 +225,6 @@ class DSATokenToKVPool(MLATokenToKVPool):
         data_ptrs = list(data_ptrs)
         data_lens = list(data_lens)
         item_lens = list(item_lens)
-        for buf in self.sparse_decode_kv_buffer:
-            data_ptrs.append(buf.data_ptr())
-            data_lens.append(buf.nbytes)
-            item_lens.append(buf[0].nbytes * self.page_size)
         for buf in self.index_k_buffer:
             if buf is not None:
                 data_ptrs.append(buf.data_ptr())
@@ -300,14 +240,11 @@ class DSATokenToKVPool(MLATokenToKVPool):
             base_count = self.layer_num
         return [
             layer_offsets
-            + [
-                start_idx + base_count + layer_id,
-                *(
-                    [start_idx + base_count + self.layer_num + layer_id]
-                    if self.index_k_row_bytes > 0
-                    else []
-                ),
-            ]
+            + (
+                [start_idx + base_count + layer_id]
+                if self.index_k_row_bytes > 0
+                else []
+            )
             for layer_id, layer_offsets in enumerate(offsets)
         ]
 

--- a/python/tokenspeed/runtime/models/glm5.py
+++ b/python/tokenspeed/runtime/models/glm5.py
@@ -1195,9 +1195,7 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
         if ctx.num_extends <= 0 or num_prefill_tokens <= 0:
             return None
 
-        chunk_meta = getattr(ctx.attn_backend, "chunked_prefill_metadata", None)
-        if chunk_meta is None:
-            return None
+        chunk_meta = ctx.attn_backend.chunked_prefill_metadata
         prefix_lens = chunk_meta.extend_prefix_lens[: ctx.num_extends].to(torch.int32)
         extend_lens = chunk_meta.extend_seq_lens[: ctx.num_extends].to(torch.int32)
         seq_lens = prefix_lens + extend_lens
@@ -1216,11 +1214,7 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
         page_size = ctx.token_to_kv_pool.page_size
         max_seq_len = int(seq_lens.max().item())
         max_pages = (max_seq_len + page_size - 1) // page_size
-        block_tables_snapshot = getattr(ctx.attn_backend, "_prefill_block_tables", None)
-        if block_tables_snapshot is None:
-            req_pool_indices = chunk_meta.req_pool_indices[: ctx.num_extends].long()
-            block_tables_snapshot = ctx.req_to_page[req_pool_indices]
-        block_tables = block_tables_snapshot[:, :max_pages].to(
+        block_tables = chunk_meta.block_tables[:, :max_pages].to(
             device=indexer_output.query.device,
             dtype=torch.int32,
         )

--- a/python/tokenspeed/runtime/models/glm5.py
+++ b/python/tokenspeed/runtime/models/glm5.py
@@ -1036,8 +1036,8 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
         if topk not in (512, 1024, 2048):
             raise RuntimeError(f"GLM DSA decode top-k does not support topk={topk}.")
         if (
-            not hasattr(ctx.token_to_kv_pool, "has_index_k_with_scale_buffer")
-            or not ctx.token_to_kv_pool.has_index_k_with_scale_buffer()
+            not hasattr(ctx.token_to_kv_pool, "has_index_k_buffer")
+            or not ctx.token_to_kv_pool.has_index_k_buffer()
         ):
             raise RuntimeError(
                 "GLM DSA decode top-k requires FP8 index-K cache with scales."
@@ -1118,14 +1118,12 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
                     "_dsa_paged_mqa_schedule_shape",
                     schedule_shape,
                 )
-        index_k_with_scale_cache = ctx.token_to_kv_pool.get_index_k_with_scale_buffer(
-            self.attn_mqa.layer_id
-        )
-        kv_cache = index_k_with_scale_cache.view(
+        index_k_cache = ctx.token_to_kv_pool.get_index_k_buffer(self.attn_mqa.layer_id)
+        kv_cache = index_k_cache.view(
             -1,
             page_size,
             1,
-            index_k_with_scale_cache.shape[-1],
+            index_k_cache.shape[-1],
         )
         logits = deep_gemm.fp8_paged_mqa_logits(
             q_fp8.view(
@@ -1267,8 +1265,8 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
         if topk not in (512, 1024, 2048):
             raise RuntimeError(f"GLM DSA prefill top-k does not support topk={topk}.")
         if (
-            not hasattr(ctx.token_to_kv_pool, "has_index_k_with_scale_buffer")
-            or not ctx.token_to_kv_pool.has_index_k_with_scale_buffer()
+            not hasattr(ctx.token_to_kv_pool, "has_index_k_buffer")
+            or not ctx.token_to_kv_pool.has_index_k_buffer()
         ):
             raise RuntimeError(
                 "GLM DSA prefill top-k requires FP8 index-K cache with scales."
@@ -1300,7 +1298,7 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
             * self.indexer.softmax_scale
         ).squeeze(-1)
 
-        k_fp8, k_scale = ctx.token_to_kv_pool.gather_index_k_with_scale(
+        k_fp8, k_scale = ctx.token_to_kv_pool.gather_index_k(
             self.attn_mqa.layer_id,
             kv_workspace_slots,
         )


### PR DESCRIPTION
### Summary
Reduces the GLM-5.x DSA (DeepSeek Sparse Attention) per-token KV-cache footprint
by ~56% and consolidates the DSA attention backend onto the trtllm path only.
This roughly doubles the TP4 token pool capacity, enabling higher concurrency.

### Changes
- **Drop the write-only bf16 `index_k` buffer** (256 B/tok/layer). Verified it
  was written but never read by any kernel.
- **Remove the `sparse_decode_kv` buffer** and the entire flashmla DSA path
  (forward methods, dispatchers, head-pad/workspace helpers); bf16 is now routed
  through trtllm. Renamed the sole remaining `index_k_with_scale` cache to
  `index_k`.
- **Consolidate the trtllm workspace**: DSA (384 MB) + dense (150 MB) → a single
  shared 256 MB workspace; DSA reuses the dense backend's via a property.
- **Move the `_prefill_block_tables` cache into `TRTLLMMLAChunkedPrefillMetadata`**
  as a field (lifetime-coupled, populated only by DSA); `glm5.py` reads it
  directly per layer instead of recomputing.
- **Formalize `_block_table_aliased`** as a base `AttentionBackend` field,
  removing three `getattr`-defensive read sites.

### Impact
- GLM5.2 TP4 DSA token pool ~420k → ~1052k tokens.
- GLM5.2 TP8 DSA token pool ~915k → ~2093k tokens.
- Single 256 MB attention workspace (was 534 MB across two buffers).
- ~690 lines of dead/redundant DSA code removed.
