### PR TITLE
 perf(scheduler): Split mixed prefill/decode forwards to preserve decode graphs

### DIFF
--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -1828,9 +1828,11 @@ class EventLoop:
                         self._execute_forward_op_in_plan(execution_plan, op, stats)
                     )
 
-                if self.pd_kv_transfer is not None:
-                    pd_events = self.pd_kv_transfer.generate_events()
-                    request_changes.extend(self._process_pd_events(pd_events))
+                if self.kv_transfer is not None:
+                    kv_transfer_events = self.kv_transfer.generate_events()
+                    request_changes.extend(
+                        self._process_kv_transfer_events(kv_transfer_events)
+                    )
 
                 if request_changes:
                     advance_forward(self.scheduler, request_changes)

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -944,9 +944,9 @@ class EventLoop:
         )
 
     def _build_mamba_layerwise_cow(
-        self, execution_plan, forward_op
+        self, execution_plan, forward_ops
     ) -> dict[int, list[int]]:
-        if forward_op is None:
+        if not forward_ops:
             return {}
         loaded_mamba_slots: set[int] = set()
         for cache_op in execution_plan.cache:
@@ -962,28 +962,28 @@ class EventLoop:
         if not loaded_mamba_slots:
             return {}
 
-        cow_src_indices = getattr(forward_op, "mamba_cow_src_indices", None)
-        working_indices = getattr(forward_op, "mamba_pool_indices", None)
-        if cow_src_indices is None or working_indices is None:
-            return {}
-
         cow_by_src: dict[int, list[int]] = {}
-        for cow_src, working in zip(list(cow_src_indices), list(working_indices)):
-            cow_src = int(cow_src)
-            working = int(working)
-            if cow_src < 0 or working < 0 or cow_src not in loaded_mamba_slots:
+        for forward_op in forward_ops:
+            cow_src_indices = getattr(forward_op, "mamba_cow_src_indices", None)
+            working_indices = getattr(forward_op, "mamba_pool_indices", None)
+            if cow_src_indices is None or working_indices is None:
                 continue
-            cow_dsts = cow_by_src.setdefault(cow_src, [])
-            if working not in cow_dsts:
-                cow_dsts.append(working)
+            for cow_src, working in zip(list(cow_src_indices), list(working_indices)):
+                cow_src = int(cow_src)
+                working = int(working)
+                if cow_src < 0 or working < 0 or cow_src not in loaded_mamba_slots:
+                    continue
+                cow_dsts = cow_by_src.setdefault(cow_src, [])
+                if working not in cow_dsts:
+                    cow_dsts.append(working)
         return cow_by_src
 
     def _submit_cache_ops(self, execution_plan) -> None:
         if self.memory_executor is None:
             return
-        forward_op = self._get_forward_op(execution_plan)
+        forward_ops = self._get_forward_ops(execution_plan)
         mamba_layerwise_cow = self._build_mamba_layerwise_cow(
-            execution_plan, forward_op
+            execution_plan, forward_ops
         )
         if mamba_layerwise_cow:
             self.model_executor.set_layerwise_mamba_cow_done(mamba_layerwise_cow)
@@ -1318,12 +1318,70 @@ class EventLoop:
 
         return request_changes
 
+    def _get_forward_ops(self, execution_plan, *, include_empty: bool = False) -> list:
+        """Return forward ops from the given plan in execution order."""
+        if include_empty:
+            return list(execution_plan.forward)
+        return [op for op in execution_plan.forward if len(op.request_ids) > 0]
+
     def _get_forward_op(self, execution_plan):
-        """Return the next forward op from the given plan, or None if there is nothing to run."""
-        forward_ops = execution_plan.forward
-        if len(forward_ops) == 0 or len(forward_ops[0].request_ids) == 0:
-            return None
-        return forward_ops[0]
+        """Return the first forward op from the given plan, or None if there is nothing to run."""
+        forward_ops = self._get_forward_ops(execution_plan)
+        return forward_ops[0] if forward_ops else None
+
+    def _execute_forward_op_in_plan(
+        self,
+        execution_plan,
+        forward_op,
+        stats: dict,
+    ) -> list:
+        if forward_op is None or len(forward_op.request_ids) == 0:
+            self._flush_mamba_retract_states(None)
+            if self.has_dp:
+                dp_metadata = self._dp_sync_and_check(None)
+                if dp_metadata.need_idle_forward:
+                    self.model_executor.execute_idle_forward(
+                        dp_metadata.global_num_tokens,
+                        dp_metadata.global_batch_size,
+                        dp_metadata.all_decode_or_idle,
+                    )
+            self._record_scheduler_iteration_metrics(stats, 0)
+            return []
+
+        self._flush_mamba_retract_states(forward_op)
+
+        num_iter_tokens = sum(forward_op.input_lengths)
+        dp_metadata = None
+        if self.has_dp:
+            dp_metadata = self._dp_sync_and_check(forward_op)
+            if dp_metadata.need_idle_forward:
+                self.model_executor.execute_idle_forward(
+                    dp_metadata.global_num_tokens,
+                    dp_metadata.global_batch_size,
+                    dp_metadata.all_decode_or_idle,
+                )
+                self._record_scheduler_iteration_metrics(stats, num_iter_tokens)
+                return []
+
+        sampling_params_list = self._gather_sampling_params(forward_op)
+        grammar_inputs = self._gather_grammar_state(forward_op)
+        self._mark_stats_scheduled(forward_op)
+        results, on_first_token = self._dispatch_forward(
+            forward_op,
+            sampling_params_list,
+            execution_plan,
+            dp_metadata=dp_metadata,
+            stats=stats,
+            grammar_inputs=grammar_inputs,
+        )
+
+        request_changes = []
+        if results is not None:
+            request_changes.extend(
+                self._commit_forward_results(forward_op, results, on_first_token)
+            )
+        self._record_scheduler_iteration_metrics(stats, num_iter_tokens)
+        return request_changes
 
     def _handle_flat_oom_terminals(self, execution_plan) -> None:
         """Surface flat-KV OOM terminals to their clients as abort finishes.
@@ -1588,47 +1646,20 @@ class EventLoop:
             self._handle_flat_oom_terminals(execution_plan)
             self._submit_cache_ops(execution_plan)
 
-            forward_op = self._get_forward_op(execution_plan)
-            self._flush_mamba_retract_states(forward_op)
+            forward_ops = self._get_forward_ops(
+                execution_plan,
+                include_empty=self.has_dp,
+            )
+            if not forward_ops:
+                self._flush_mamba_retract_states(None)
 
             stats = self._get_scheduler_stats()
-            num_iter_tokens = (
-                sum(forward_op.input_lengths) if forward_op is not None else 0
-            )
-
-            # DP sync: all ranks must participate even when idle.
-            dp_metadata = None
-            if self.has_dp:
-                dp_metadata = self._dp_sync_and_check(forward_op)
-                if dp_metadata.need_idle_forward:
-                    self.model_executor.execute_idle_forward(
-                        dp_metadata.global_num_tokens,
-                        dp_metadata.global_batch_size,
-                        dp_metadata.all_decode_or_idle,
-                    )
-                    self._record_scheduler_iteration_metrics(stats, num_iter_tokens)
-                    continue
-
             request_changes = []
 
-            if forward_op is not None:
-                sampling_params_list = self._gather_sampling_params(forward_op)
-                grammar_inputs = self._gather_grammar_state(forward_op)
-                self._mark_stats_scheduled(forward_op)
-                results, on_first_token = self._dispatch_forward(
-                    forward_op,
-                    sampling_params_list,
-                    execution_plan,
-                    dp_metadata=dp_metadata,
-                    stats=stats,
-                    grammar_inputs=grammar_inputs,
+            for forward_op in forward_ops:
+                request_changes.extend(
+                    self._execute_forward_op_in_plan(execution_plan, forward_op, stats)
                 )
-                if results is not None:
-                    request_changes.extend(
-                        self._commit_forward_results(
-                            forward_op, results, on_first_token
-                        )
-                    )
 
             if self.kv_transfer is not None:
                 kv_transfer_events = self.kv_transfer.generate_events()
@@ -1643,7 +1674,8 @@ class EventLoop:
             # Resolve a deferred abort/wait pause reply once in-flight work drains.
             self._pause.maybe_finish_drain(self.scheduler)
 
-            self._record_scheduler_iteration_metrics(stats, num_iter_tokens)
+            if not forward_ops:
+                self._record_scheduler_iteration_metrics(stats, 0)
 
     def _mark_stats_scheduled(self, forward_op) -> None:
         # Stamp the pre-forward "scheduled" time on each request's stats tracker
@@ -1735,14 +1767,33 @@ class EventLoop:
                 prev_results = None
                 prev_forward_op = None
                 continue
+
+            if self.server_args.enable_mixed_batch and prev_results is not None:
+                request_changes = self._commit_forward_results(
+                    prev_forward_op, prev_results
+                )
+                if request_changes:
+                    advance_forward(self.scheduler, request_changes)
+                    self._publish_scheduler_kv_events()
+                prev_results = None
+                prev_forward_op = None
+
             execution_plan = self.scheduler.next_execution_plan()
             self._publish_scheduler_kv_events()
             self._handle_flat_oom_terminals(execution_plan)
 
             self._submit_cache_ops(execution_plan)
 
-            forward_op = self._get_forward_op(execution_plan)
-            self._flush_mamba_retract_states(forward_op)
+            forward_ops = self._get_forward_ops(
+                execution_plan,
+                include_empty=self.has_dp,
+            )
+            forward_op = next(
+                (op for op in forward_ops if len(op.request_ids) > 0),
+                None,
+            )
+            if not forward_ops:
+                self._flush_mamba_retract_states(None)
 
             stats = self._get_scheduler_stats()
             num_iter_tokens = (
@@ -1758,6 +1809,31 @@ class EventLoop:
                 # forward_op.
                 sampling_params_list = self._gather_sampling_params(forward_op)
                 grammar_inputs = self._gather_grammar_state(forward_op)
+
+            if len(forward_ops) > 1:
+                request_changes = []
+                if prev_results is not None:
+                    request_changes.extend(
+                        self._commit_forward_results(prev_forward_op, prev_results)
+                    )
+                    prev_results = None
+                    prev_forward_op = None
+
+                for op in forward_ops:
+                    request_changes.extend(
+                        self._execute_forward_op_in_plan(execution_plan, op, stats)
+                    )
+
+                if self.pd_kv_transfer is not None:
+                    pd_events = self.pd_kv_transfer.generate_events()
+                    request_changes.extend(self._process_pd_events(pd_events))
+
+                if request_changes:
+                    advance_forward(self.scheduler, request_changes)
+                    self._publish_scheduler_kv_events()
+
+                self._pause.maybe_finish_drain(self.scheduler)
+                continue
 
             # DP sync: all ranks must participate even when idle.
             dp_metadata = None

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -1768,7 +1768,11 @@ class EventLoop:
                 prev_forward_op = None
                 continue
 
-            if self.server_args.enable_mixed_batch and prev_results is not None:
+            if (
+                self.server_args.enable_mixed_batch
+                and prev_results is not None
+                and (self.has_dp or self.scheduler.has_pending_prefill())
+            ):
                 request_changes = self._commit_forward_results(
                     prev_forward_op, prev_results
                 )

--- a/tokenspeed-scheduler/bindings/python_module.cpp
+++ b/tokenspeed-scheduler/bindings/python_module.cpp
@@ -449,6 +449,7 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .def("waiting_size", &tokenspeed::Scheduler::WaitingSize)
         .def("decoding_size", &tokenspeed::Scheduler::DecodingSize)
         .def("prefilling_size", &tokenspeed::Scheduler::PrefillSize)
+        .def("has_pending_prefill", &tokenspeed::Scheduler::HasPendingPrefill)
         .def("retract_count", &tokenspeed::Scheduler::RetractedSize)
         .def("available_kv_pages", &tokenspeed::Scheduler::AvailableKvPages)
         .def("active_kv_pages", &tokenspeed::Scheduler::ActiveKvPages)

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.h
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.h
@@ -82,6 +82,8 @@ struct DecodeOperation : public ForwardOperationBase {
 using ForwardOperation = std::variant<PrefillOperation, DecodeOperation>;
 
 struct FlatForwardOperation {
+    enum class Order { kPrefillFirst, kPreserve };
+
     std::vector<std::string> request_ids;
     std::vector<std::int32_t> request_pool_indices;
     std::vector<std::int32_t> input_lengths;
@@ -120,9 +122,11 @@ struct FlatForwardOperation {
     // (null hole = 0, no compaction); there is no base-offset companion.
     std::map<std::string, std::vector<std::vector<std::int32_t>>> flat_block_tables;
 
-    explicit FlatForwardOperation(std::vector<ForwardOperation> ops) {
-        std::stable_partition(ops.begin(), ops.end(),
-                              [](const ForwardOperation& a) { return std::holds_alternative<PrefillOperation>(a); });
+    explicit FlatForwardOperation(std::vector<ForwardOperation> ops, Order order = Order::kPrefillFirst) {
+        if (order == Order::kPrefillFirst) {
+            std::stable_partition(ops.begin(), ops.end(),
+                                  [](const ForwardOperation& a) { return std::holds_alternative<PrefillOperation>(a); });
+        }
         for (auto& op : ops) {
             std::visit(
                 [this](auto& inner) {

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -374,7 +374,21 @@ ExecutionPlan Scheduler::NextExecutionPlan() {
     }
 
     auto [fwd_ops, cache_ops] = newForwardOperation(candidates);
-    plan.With(FlatForwardOperation{std::move(fwd_ops)});
+    if (config_.enable_mixed_prefill_decode) {
+        std::vector<ForwardOperation> decode_ops;
+        std::vector<ForwardOperation> prefill_ops;
+        for (auto& op : fwd_ops) {
+            if (std::holds_alternative<DecodeOperation>(op)) {
+                decode_ops.push_back(std::move(op));
+            } else {
+                prefill_ops.push_back(std::move(op));
+            }
+        }
+        plan.With(FlatForwardOperation{std::move(decode_ops), FlatForwardOperation::Order::kPreserve});
+        plan.With(FlatForwardOperation{std::move(prefill_ops), FlatForwardOperation::Order::kPreserve});
+    } else {
+        plan.With(FlatForwardOperation{std::move(fwd_ops)});
+    }
 #if TOKENSPEED_FLAT_KVCACHE
     plan.flat_oom_request_ids = std::exchange(flat_oom_request_ids_, {});
 #endif

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -237,6 +237,15 @@ std::size_t Scheduler::PrefillSize() const {
     return count;
 }
 
+bool Scheduler::HasPendingPrefill() const {
+    for (const auto& [id, req] : requests_) {
+        if (req->Is<fsm::Submitted>() || req->Is<fsm::PrefetchDone>() || req->Is<fsm::Prefilling>()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 std::size_t Scheduler::RetractedSize() const {
     std::size_t count = 0;
     for (const auto& [id, req] : requests_) {

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.h
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.h
@@ -76,6 +76,7 @@ public:
     std::size_t AvailableKvPages() const;
     std::size_t ActiveKvPages() const;
     std::size_t PrefillSize() const;
+    bool HasPendingPrefill() const;
     std::int32_t GetRequestTokenSize(const std::string& id) const;
     std::vector<std::string> PagedCacheGroupIds() const;
     std::int32_t PagedCacheGroupTotalPages(const std::string& group_id) const;

--- a/tokenspeed-scheduler/python/tests/test_fsm_and_scheduling.py
+++ b/tokenspeed-scheduler/python/tests/test_fsm_and_scheduling.py
@@ -277,6 +277,7 @@ class TestPrefillFirst:
 
         plan = s.next_execution_plan()  # Should schedule r1 prefill, not decode r0
         assert s.waiting_size() == 0  # r1 moved out of Submitted
+        assert len(plan.forward) == 1
         assert plan.forward[0].num_extends() > 0
         assert plan.forward[0].request_ids == ["r1"]
 
@@ -292,13 +293,21 @@ class TestPrefillFirst:
 
         submit(s, "r1", list(range(8)))
         plan = s.next_execution_plan()
-        op = plan.forward[0]
+        assert len(plan.forward) == 2
+        decode_op, prefill_op = plan.forward
 
-        assert op.request_ids == ["r1", "r0"]
-        assert op.num_extends() == 1
-        assert len(op.input_ids) == sum(op.input_lengths[: op.num_extends()])
-        assert len(op.input_ids) + len(op.decode_input_ids) == sum(op.input_lengths)
-        assert op.sizes == [1, 0]
+        assert decode_op.request_ids == ["r0"]
+        assert decode_op.num_extends() == 0
+        assert decode_op.input_lengths == [1]
+        assert decode_op.decode_input_ids == [-1]
+        assert decode_op.sizes == [0]
+
+        assert prefill_op.request_ids == ["r1"]
+        assert prefill_op.num_extends() == 1
+        assert prefill_op.input_lengths == [8]
+        assert prefill_op.input_ids == list(range(8))
+        assert prefill_op.decode_input_ids == []
+        assert prefill_op.sizes == [1]
 
     def test_mixed_prefill_decode_decode_not_starved_by_long_prefill(self):
         """Decode-first priority: active decode is scheduled even when a long prefill would consume the full budget."""
@@ -313,13 +322,16 @@ class TestPrefillFirst:
 
         submit(s, "r1", list(range(32)))  # 32 > budget=16
         plan = s.next_execution_plan()
-        op = plan.forward[0]
+        assert len(plan.forward) == 2
+        decode_op, prefill_op = plan.forward
 
-        # Layout is prefill-first/decode-second (FlatForwardOperation::stable_partition).
-        assert op.request_ids == ["r1", "r0"]
-        assert op.num_extends() == 1
-        # r0 decode = 1 token; r1 prefill chunk takes the remaining 15.
-        assert op.input_lengths == [15, 1]
+        assert decode_op.request_ids == ["r0"]
+        assert decode_op.num_extends() == 0
+        assert decode_op.input_lengths == [1]
+
+        assert prefill_op.request_ids == ["r1"]
+        assert prefill_op.num_extends() == 1
+        assert prefill_op.input_lengths == [15]
 
     def test_max_batch_size_limits_scheduled_requests(self):
         """max_batch_size caps the number of requests per plan."""
@@ -781,7 +793,13 @@ class TestDecodeInputIds:
         # Submit r1 so that next plan has one prefill + one decode.
         submit(s, "r1", list(range(8)))
         mixed_plan = s.next_execution_plan()
-        op = mixed_plan.forward[0]
-        num_decodes = len(op.request_ids) - op.num_extends()
-        assert len(op.decode_input_ids) == num_decodes
-        assert all(did == -1 for did in op.decode_input_ids)
+        assert len(mixed_plan.forward) == 2
+        decode_op, prefill_op = mixed_plan.forward
+
+        assert decode_op.request_ids == ["r0"]
+        assert decode_op.num_extends() == 0
+        assert decode_op.decode_input_ids == [-1]
+
+        assert prefill_op.request_ids == ["r1"]
+        assert prefill_op.num_extends() == 1
+        assert prefill_op.decode_input_ids == []

--- a/tokenspeed-scheduler/python/tests/test_fsm_and_scheduling.py
+++ b/tokenspeed-scheduler/python/tests/test_fsm_and_scheduling.py
@@ -121,6 +121,25 @@ class TestFSMTransitions:
         assert s.prefilling_size() == 0
         assert s.decoding_size() == 0
 
+    def test_pending_prefill_tracks_only_prefill_candidates(self):
+        s = Scheduler(make_config(max_scheduled_tokens=8))
+        assert not s.has_pending_prefill()
+
+        submit(s, "r0", list(range(16)))
+        assert s.has_pending_prefill()
+
+        s.next_execution_plan()  # Submitted -> Prefilling.
+        assert s.has_pending_prefill()
+
+        s.next_execution_plan()  # Prefilling -> PrefillDone.
+        assert not s.has_pending_prefill()
+
+        s.next_execution_plan()  # PrefillDone -> Decoding.
+        assert not s.has_pending_prefill()
+
+        submit(s, "r1", list(range(8)))
+        assert s.has_pending_prefill()
+
     def test_first_plan_moves_submitted_to_prefilling(self):
         """After first next_execution_plan, request leaves Submitted (waiting → 0)."""
         s = Scheduler(make_config())

--- a/tokenspeed-scheduler/tests/cpp/test_paged_cache_replay.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_paged_cache_replay.cpp
@@ -76,6 +76,14 @@ protected:
         }
         return nullptr;
     }
+
+    static std::vector<const FlatForwardOperation*> GetForwardOps(const ExecutionPlan& plan) {
+        std::vector<const FlatForwardOperation*> out;
+        for (const auto& op : plan.Operations()) {
+            if (auto* f = std::get_if<FlatForwardOperation>(&op)) out.push_back(f);
+        }
+        return out;
+    }
 };
 
 class PagedCacheTerminalMixedSchedulerTest : public PagedCacheTerminalSchedulerTest {
@@ -914,24 +922,34 @@ TEST_F(PagedCacheTerminalMixedSchedulerTest, MixedPrefillDecodePagedTablesCoverS
     });
 
     auto plan = PlanOnce();
-    auto* fwd = GetForwardOp(plan);
-    ASSERT_NE(fwd, nullptr);
-    ASSERT_EQ(fwd->request_ids.size(), 8u);
-    ASSERT_EQ(fwd->extend_prefix_lens.size(), 3u);
+    auto fwds = GetForwardOps(plan);
+    ASSERT_EQ(fwds.size(), 2u);
 
-    for (std::size_t row = 0; row < fwd->request_ids.size(); ++row) {
-        std::int32_t first_token = 0;
-        if (row < fwd->extend_prefix_lens.size()) {
-            first_token = fwd->extend_prefix_lens[row];
-        } else {
-            auto it = decode_first_pos.find(fwd->request_ids[row]);
-            ASSERT_NE(it, decode_first_pos.end()) << "request_id=" << fwd->request_ids[row];
-            first_token = it->second;
+    const auto* decode_fwd = fwds[0];
+    const auto* prefill_fwd = fwds[1];
+    ASSERT_EQ(decode_fwd->request_ids.size(), 5u);
+    ASSERT_EQ(decode_fwd->extend_prefix_lens.size(), 0u);
+    ASSERT_EQ(prefill_fwd->request_ids.size(), 3u);
+    ASSERT_EQ(prefill_fwd->extend_prefix_lens.size(), 3u);
+    EXPECT_EQ(prefill_fwd->request_ids, std::vector<std::string>({"prefill_0", "prefill_1", "prefill_2"}));
+
+    auto check_rows = [&](const FlatForwardOperation& fwd) {
+        for (std::size_t row = 0; row < fwd.request_ids.size(); ++row) {
+            std::int32_t first_token = 0;
+            if (row < fwd.extend_prefix_lens.size()) {
+                first_token = fwd.extend_prefix_lens[row];
+            } else {
+                auto it = decode_first_pos.find(fwd.request_ids[row]);
+                ASSERT_NE(it, decode_first_pos.end()) << "request_id=" << fwd.request_ids[row];
+                first_token = it->second;
+            }
+            ASSERT_LT(row, fwd.input_lengths.size());
+            ExpectPagedGroupCoversRange(fwd, Config(), "fh", row, first_token, fwd.input_lengths[row]);
+            ExpectPagedGroupCoversRange(fwd, Config(), "swa", row, first_token, fwd.input_lengths[row]);
         }
-        ASSERT_LT(row, fwd->input_lengths.size());
-        ExpectPagedGroupCoversRange(*fwd, Config(), "fh", row, first_token, fwd->input_lengths[row]);
-        ExpectPagedGroupCoversRange(*fwd, Config(), "swa", row, first_token, fwd->input_lengths[row]);
-    }
+    };
+    check_rows(*decode_fwd);
+    check_rows(*prefill_fwd);
 }
 
 }  // namespace tokenspeed::test


### PR DESCRIPTION
## Summary

I split mixed batch scheduling into two forward phases when decode and prefill are both admitted in one scheduler tick. decode rows run first as a decode-only forward, which keeps them eligible for CUDA graph replay, followed by an extend-only forward for prefill rows.

## Test Plan

b300, Kimi-K2.5-NVFP4

```
python3 -m smg_grpc_servicer.tokenspeed \
  --model /models/Kimi-K2.5-NVFP4 \
  --served-model-name kimi-k25-nvfp4 \
  --trust-remote-code \
  --attn-tp-size 8 \
  --moe-tp-size 8 \
  --max-model-len 131072 \
  --max-num-seqs 64 \
  --max-prefill-tokens 32768 \
  --chunked-prefill-size 32768 \
  --gpu-memory-utilization 0.85 \
  --attention-backend tokenspeed_mla \
  --mm-attention-backend fa4 \
  --moe-backend flashinfer_trtllm \
  --sampling-backend flashinfer \
  --quantization nvfp4 \
  --kv-cache-dtype fp8 \
  --disable-kvstore \
  --kvstore-ratio 0.05 \
  --enable-mixed-batch \
  --host 127.0.0.1 \
  --port 50051
```

`default` is main with no `--enable-mixed-batch`
`baseline mixed` is main with `--enable-mixed-batch`
`split mixed` this branch with `--enable-mixed-batch`

| Server config | Conc | Wall | Req/s | Tok/s | Tok/s vs baseline mixed | p50 TTFT | p95 TTFT | p95 vs baseline mixed | p50 Total | p50 total vs baseline mixed |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| default | 4 | 51.30s | 1.25 | 79.9 | +0.4% | 860.3ms | 1493.4ms | -2.1% | 1436.1ms | -1.5% |
| baseline mixed | 4 | 51.47s | 1.24 | 79.6 |  | 869.6ms | 1525.2ms |  | 1458.2ms |  |
| split mixed | 4 | 47.09s | 1.36 | 87.0 | +9.3% | 814.6ms | 1421.5ms | -6.8% | 1149.9ms | -21.1% |
| default | 8 | 14.11s | 4.54 | 290.3 | -10.2% | 1042.3ms | 1192.5ms | +4.0% | 1703.7ms | +15.1% |
| baseline mixed | 8 | 12.67s | 5.05 | 323.2 |  | 890.5ms | 1146.4ms |  | 1480.7ms |  |
| split mixed | 8 | 12.21s | 5.24 | 335.6 | +3.8% | 836.4ms | 1034.9ms | -9.7% | 1473.4ms | -0.5% |
| default | 16 | 9.24s | 6.93 | 443.5 | -9.8% | 1292.0ms | 1970.1ms | +19.2% | 2110.5ms | +14.1% |
| baseline mixed | 16 | 8.33s | 7.68 | 491.5 |  | 1161.3ms | 1652.8ms |  | 1849.3ms |  |
| split mixed | 16 | 8.60s | 7.44 | 476.3 | -3.1% | 1081.2ms | 1655.3ms | +0.2% | 2088.5ms | +12.9% |

`max_tokens=256`, 32 requests per row:

| Server config | Conc | Wall | Req/s | Tok/s | Tok/s vs baseline mixed | p50 TTFT | p95 TTFT | p95 vs baseline mixed | p50 Total | p50 total vs baseline mixed |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| default | 8 | 43.48s | 0.74 | 156.4 | +17.9% | 926.6ms | 28988.1ms | +1.6% | 3979.9ms | -1.8% |
| baseline mixed | 8 | 42.39s | 0.75 | 132.7 |  | 956.1ms | 28538.1ms |  | 4051.0ms |  |
| split mixed | 8 | 37.32s | 0.86 | 163.2 | +23.0% | 922.6ms | 28530.0ms | ~0.0% | 2761.3ms | -31.8% |
| default | 16 | 7.35s | 4.35 | 747.8 | +9.6% | 1087.2ms | 1595.9ms | -9.8% | 3174.4ms | -0.7% |
| baseline mixed | 16 | 7.28s | 4.40 | 682.2 |  | 1227.0ms | 1769.3ms |  | 3197.2ms |  |
| split mixed | 16 | 5.60s | 5.72 | 878.6 | +28.8% | 966.2ms | 1240.7ms | -29.9% | 2455.0ms | -23.2% |

My implementation improves over without `--enable-mixed-batch` on all results and gives the biggest improvements for longer generations (max_tokens=256, up to +28.8% tok/s and -29.9% p95 TTFT vs baseline mixed), but it slightly regresses versus existing (main) mixed batching at max_tokens=64, concurrency 16