### PR TITLE
Optimize GLM DSA decode graph contexts

### DIFF
--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -648,6 +648,9 @@ class EventLoop:
             dp_metadata.all_decode_or_idle if dp_metadata is not None else False
         )
         multimodal_context = self._get_multimodal_context_for_forward(forward_op)
+        decode_seq_len_upper_bound = self._get_decode_seq_len_upper_bound_for_forward(
+            forward_op
+        )
 
         self.model_executor.update_block_table(forward_op)
 
@@ -663,6 +666,7 @@ class EventLoop:
                     dp_all_decode_or_idle=dp_all_decode_or_idle,
                     grammar_inputs=grammar_inputs,
                     multimodal_context=multimodal_context,
+                    decode_seq_len_upper_bound=decode_seq_len_upper_bound,
                     **stats,
                 ),
                 None,
@@ -692,6 +696,7 @@ class EventLoop:
                         dp_global_bs=dp_global_bs,
                         dp_all_decode_or_idle=dp_all_decode_or_idle,
                         multimodal_context=multimodal_context,
+                        decode_seq_len_upper_bound=decode_seq_len_upper_bound,
                         **stats,
                     ),
                     None,
@@ -717,11 +722,42 @@ class EventLoop:
                         dp_all_decode_or_idle=dp_all_decode_or_idle,
                         grammar_inputs=grammar_inputs,
                         multimodal_context=multimodal_context,
+                        decode_seq_len_upper_bound=decode_seq_len_upper_bound,
                         capture_next_input_ids=True,
                         **stats,
                     ),
                     self.pd_kv_transfer.store_prefill_token,
                 )
+
+    def _get_decode_seq_len_upper_bound_for_forward(self, forward_op) -> int | None:
+        if forward_op is None:
+            return None
+        num_extends = forward_op.num_extends()
+        bs = len(forward_op.request_ids)
+        if num_extends >= bs:
+            return None
+
+        rid_to_state = self.output_processor.rid_to_state
+        hist_token_lens = getattr(forward_op, "hist_token_lens", None)
+        decode_margin = max(1, int(self.model_executor.config.output_length or 1))
+        max_seq_len = 0
+        for row_idx in range(num_extends, bs):
+            rid = forward_op.request_ids[row_idx]
+            state = rid_to_state.get(rid)
+            if state is None:
+                return None
+            input_len = int(forward_op.input_lengths[row_idx])
+            hist_len = None
+            if hist_token_lens is not None and row_idx < len(hist_token_lens):
+                raw_hist_len = int(hist_token_lens[row_idx])
+                if raw_hist_len >= 0:
+                    hist_len = raw_hist_len
+            if hist_len is None:
+                seq_len = state.input_length + state.output_length + input_len
+            else:
+                seq_len = hist_len + input_len
+            max_seq_len = max(max_seq_len, seq_len + decode_margin)
+        return max_seq_len or None
 
     def _get_multimodal_context_for_forward(self, forward_op):
         if not self.model_config.is_multimodal_active:

--- a/python/tokenspeed/runtime/execution/context.py
+++ b/python/tokenspeed/runtime/execution/context.py
@@ -55,6 +55,9 @@ class ForwardContext:
     draft_first_step_reduce: bool = False
     # Normalized explicit decode input overrides for this forward, if any.
     decode_input_ids: list[int] | None = None
+    # CPU-side upper bound for decode seq_lens, used to select safe graph
+    # profiles and skip context-limit clamps without syncing GPU seq_lens.
+    decode_seq_len_upper_bound: int | None = None
 
     # --- dp attention ---
     global_num_tokens: list[int] | None = None

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -36,6 +36,7 @@ from tokenspeed.runtime.execution.forward_batch_info import (
     CaptureHiddenMode,
     ForwardMode,
 )
+from tokenspeed.runtime.layers.attention.backends.base import CudaGraphProfile
 from tokenspeed.runtime.sampling.sampling_batch_info import SamplingBatchInfo
 from tokenspeed.runtime.utils import (
     get_available_gpu_memory,
@@ -233,66 +234,135 @@ class CudaGraphWrapper:
         self.use_v4_mtp_paged_metadata = config.use_v4_mtp_paged_metadata
         self.dp_size = config.data_parallel_size
         self.world_size = config.world_size
+        self.cuda_graph_profiles = self._get_cuda_graph_profiles(attn_backend)
+        self.default_cuda_graph_profile = self.cuda_graph_profiles[0]
         # Backends alias their cache_seqlens buffer. Draft backend aliases
         # the drafter-owned draft_seq_lens to keep InputBuffers read-only.
         paged_cache_group_specs = tuple(token_to_kv_pool.paged_cache_group_specs)
-        try:
-            attn_backend.init_cuda_graph_state(
-                self.max_bs,
-                self.input_buffers.seq_lens_buf,
-                paged_cache_group_specs=paged_cache_group_specs,
-                max_tokens_per_req=self.max_tokens_per_req,
-            )
-        except TypeError:
-            attn_backend.init_cuda_graph_state(
-                self.max_bs,
-                self.input_buffers.seq_lens_buf,
-            )
+        self._init_backend_cuda_graph_states(
+            attn_backend,
+            self.input_buffers.seq_lens_buf,
+            paged_cache_group_specs=paged_cache_group_specs,
+        )
         if draft_attn_backend is not None:
             draft_paged_cache_group_specs = tuple(
                 draft_token_to_kv_pool.paged_cache_group_specs
             )
-            try:
-                draft_attn_backend.init_cuda_graph_state(
-                    self.max_bs,
-                    self.drafter.draft_seq_lens_buf,
-                    paged_cache_group_specs=draft_paged_cache_group_specs,
-                    max_tokens_per_req=self.max_tokens_per_req,
-                )
-            except TypeError:
-                draft_attn_backend.init_cuda_graph_state(
-                    self.max_bs, self.drafter.draft_seq_lens_buf
-                )
+            self._init_backend_cuda_graph_states(
+                draft_attn_backend,
+                self.drafter.draft_seq_lens_buf,
+                paged_cache_group_specs=draft_paged_cache_group_specs,
+            )
 
-            # Drafter (Eagle) is constructed with the target's req_to_page
-            # (ModelExecutor passes the same self.req_to_page to both), and the
-            # replay path hands both backends the same req_pool_indices. The
-            # block-table gather is req_to_page[req_pool_indices] (see
-            # _create_block_kv_indices; it does not depend on seq_lens), so both
-            # backends would compute identical block_kv_indices. When the backing
-            # buffer shapes/dtypes also line up, point the draft backend at the
-            # target's buffer and skip its gather+copy in the replay path: the
-            # target's metadata prep runs first and populates the shared buffer
-            # (see init_forward_metadata_replay_cuda_graph).
-            target_kv = getattr(attn_backend, "decode_cuda_graph_kv_indices", None)
-            draft_kv = getattr(draft_attn_backend, "decode_cuda_graph_kv_indices", None)
-            if (
-                target_kv is not None
-                and draft_kv is not None
-                and target_kv.shape == draft_kv.shape
-                and target_kv.dtype == draft_kv.dtype
-            ):
-                draft_attn_backend.decode_cuda_graph_kv_indices = target_kv
-                draft_attn_backend._block_table_aliased = True
+            self._alias_draft_decode_block_tables(attn_backend, draft_attn_backend)
 
-        self.graphs: dict[int, torch.cuda.CUDAGraph] = {}
-        self.output_buffers: dict[int, tuple] = {}
+        self.graphs: dict[tuple[CudaGraphProfile, int], torch.cuda.CUDAGraph] = {}
+        self.output_buffers: dict[tuple[CudaGraphProfile, int], tuple] = {}
 
         self._forward_func: Callable | None = forward_func
         self.disable = config.enforce_eager
         self.deepep_adapter = DeepEPCudaGraphRunnerAdapter()
         if not self.disable:
             self.capture()
+
+    def _get_cuda_graph_profiles(
+        self,
+        attn_backend: AttentionBackend,
+    ) -> tuple[CudaGraphProfile, ...]:
+        default_profile = CudaGraphProfile()
+        profiles = [default_profile]
+        if self.dp_size > 1:
+            return tuple(profiles)
+
+        seen = {default_profile}
+        for profile in attn_backend.get_cuda_graph_profiles():
+            if profile.is_default:
+                continue
+            if profile in seen:
+                continue
+            profiles.append(profile)
+            seen.add(profile)
+        return tuple(profiles)
+
+    @staticmethod
+    def _graph_dict_key(
+        profile: CudaGraphProfile, bs: int
+    ) -> tuple[CudaGraphProfile, int]:
+        return (profile, int(bs))
+
+    @staticmethod
+    def _compatible_alias_buffer(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
+        return (
+            lhs.shape == rhs.shape
+            and lhs.dtype == rhs.dtype
+            and lhs.device == rhs.device
+        )
+
+    def _init_backend_cuda_graph_states(
+        self,
+        backend: AttentionBackend,
+        seq_lens_buf: torch.Tensor,
+        *,
+        paged_cache_group_specs: tuple,
+    ) -> None:
+        for profile in self.cuda_graph_profiles:
+            kwargs = {
+                "paged_cache_group_specs": paged_cache_group_specs,
+                "max_tokens_per_req": self.max_tokens_per_req,
+            }
+            if not profile.is_default:
+                kwargs["cuda_graph_profile"] = profile
+            try:
+                backend.init_cuda_graph_state(self.max_bs, seq_lens_buf, **kwargs)
+            except TypeError:
+                if not profile.is_default:
+                    raise
+                backend.init_cuda_graph_state(self.max_bs, seq_lens_buf)
+
+    def _alias_draft_decode_block_tables(
+        self,
+        attn_backend: AttentionBackend,
+        draft_attn_backend: AttentionBackend,
+    ) -> None:
+        # Drafter and target gather the same req_to_page rows. If their graph
+        # block-table buffers match, target replay can populate them once.
+        target_by_context = getattr(
+            attn_backend,
+            "decode_cuda_graph_kv_indices_by_context",
+            None,
+        )
+        draft_by_context = getattr(
+            draft_attn_backend,
+            "decode_cuda_graph_kv_indices_by_context",
+            None,
+        )
+        if isinstance(target_by_context, dict) and isinstance(draft_by_context, dict):
+            if target_by_context.keys() != draft_by_context.keys():
+                return
+            if not all(
+                self._compatible_alias_buffer(
+                    target_by_context[context_len],
+                    draft_by_context[context_len],
+                )
+                for context_len in target_by_context
+            ):
+                return
+            draft_by_context.update(target_by_context)
+            target_kv = getattr(attn_backend, "decode_cuda_graph_kv_indices", None)
+            if target_kv is not None:
+                draft_attn_backend.decode_cuda_graph_kv_indices = target_kv
+            draft_attn_backend._block_table_aliased = True
+            return
+
+        target_kv = getattr(attn_backend, "decode_cuda_graph_kv_indices", None)
+        draft_kv = getattr(draft_attn_backend, "decode_cuda_graph_kv_indices", None)
+        if (
+            target_kv is not None
+            and draft_kv is not None
+            and self._compatible_alias_buffer(target_kv, draft_kv)
+        ):
+            draft_attn_backend.decode_cuda_graph_kv_indices = target_kv
+            draft_attn_backend._block_table_aliased = True
 
     # ------------------------------------------------------------------
     # Graph capture
@@ -308,22 +378,31 @@ class CudaGraphWrapper:
         rank = self.global_rank
         with freeze_gc(self.enable_cudagraph_gc):
             self.stream = torch.cuda.Stream()
-            capture_range = tqdm.tqdm(self.capture_bs) if rank == 0 else self.capture_bs
-            if rank == 0:
-                logger.info("Capturing batches: %s", self.capture_bs)
-            for bs in capture_range:
+            for profile in self.cuda_graph_profiles:
+                capture_range = (
+                    tqdm.tqdm(self.capture_bs) if rank == 0 else self.capture_bs
+                )
                 if rank == 0:
-                    avail_mem = get_available_gpu_memory(
-                        self.device, self.gpu_id, empty_cache=False
+                    logger.info(
+                        "Capturing %s batches: %s", profile.label, self.capture_bs
                     )
-                    capture_range.set_description(
-                        f"Capturing batches ({bs=} {avail_mem=:.2f} GB)"
+                for bs in capture_range:
+                    if rank == 0:
+                        avail_mem = get_available_gpu_memory(
+                            self.device, self.gpu_id, empty_cache=False
+                        )
+                        capture_range.set_description(
+                            f"Capturing {profile.label} batches ({bs=} {avail_mem=:.2f} GB)"
+                        )
+                    graph, output_buffers = self._capture_one(
+                        bs,
+                        cuda_graph_profile=profile,
                     )
-                graph, output_buffers = self._capture_one(bs)
-                self.graphs[bs] = graph
-                self.output_buffers[bs] = output_buffers
+                    dict_key = self._graph_dict_key(profile, bs)
+                    self.graphs[dict_key] = graph
+                    self.output_buffers[dict_key] = output_buffers
 
-    def _capture_one(self, bs: int):
+    def _capture_one(self, bs: int, cuda_graph_profile: CudaGraphProfile):
         graph = torch.cuda.CUDAGraph()
 
         capture_forward_mode = ForwardMode.DECODE
@@ -339,6 +418,7 @@ class CudaGraphWrapper:
                 if self.drafter is not None
                 else CaptureHiddenMode.NULL
             ),
+            **cuda_graph_profile.forward_context_kwargs(),
         )
 
         # For DP mode, global_num_tokens must be set so that the MoE
@@ -411,7 +491,7 @@ class CudaGraphWrapper:
             # Keep warmup seq_lens >= q_len_per_req so no query row gets an
             # empty causal span; a stale seq_len of 1 overflows to non-finite KV.
             self.input_buffers.seq_lens_buf[:bs].fill_(self.max_tokens_per_req)
-            self._init_capture_metadata(bs)
+            self._init_capture_metadata(bs, cuda_graph_profile=cuda_graph_profile)
             run_once()
 
         # Clear any per-pool state that warm-up dirtied at pool row 0,
@@ -425,7 +505,7 @@ class CudaGraphWrapper:
         # Warmups can switch a backend back to eager metadata objects. Restore
         # the graph-backed metadata immediately before capture so replay-time
         # metadata refreshes update the same tensors recorded by the graph.
-        self._init_capture_metadata(bs)
+        self._init_capture_metadata(bs, cuda_graph_profile=cuda_graph_profile)
 
         # Fill sampler buffers OUTSIDE the capture so RNG ops aren't recorded.
         if self.sampling_backend is not None:
@@ -434,7 +514,7 @@ class CudaGraphWrapper:
             )
         # Warmup forwards can mutate aliased metadata buffers, so refresh
         # them again immediately before graph capture records the final views.
-        self._init_capture_metadata(bs)
+        self._init_capture_metadata(bs, cuda_graph_profile=cuda_graph_profile)
 
         self.deepep_adapter.capture()
 
@@ -485,8 +565,14 @@ class CudaGraphWrapper:
             )
         return out
 
-    def _init_capture_metadata(self, bs: int):
+    def _init_capture_metadata(
+        self,
+        bs: int,
+        cuda_graph_profile: CudaGraphProfile,
+    ):
         capture_kwargs = {}
+        if not cuda_graph_profile.is_default:
+            capture_kwargs["cuda_graph_profile"] = cuda_graph_profile
         if self.input_buffers.has_mamba:
             capture_kwargs["mamba_pool_indices"] = (
                 self.input_buffers.mamba_pool_indices_buf[:bs]
@@ -511,6 +597,8 @@ class CudaGraphWrapper:
         )
         if self.draft_attn_backend is not None:
             draft_kwargs = {}
+            if not cuda_graph_profile.is_default:
+                draft_kwargs["cuda_graph_profile"] = cuda_graph_profile
             if self.draft_token_to_kv_pool is not None:
                 draft_paged_cache_block_tables = self._capture_paged_cache_block_tables(
                     bs,
@@ -593,6 +681,7 @@ class CudaGraphWrapper:
         seq_lens: torch.Tensor,
         req_to_page: torch.Tensor,
         forward_mode: ForwardMode,
+        cuda_graph_profile: CudaGraphProfile,
         **kwargs,
     ):
         """Graph-replay path — update persistent cuda-graph buffers in place."""
@@ -638,6 +727,8 @@ class CudaGraphWrapper:
                     )
         if self.attn_backend.uses_padded_decode_token_mask:
             kwargs["actual_bs"] = actual_bs
+        if not cuda_graph_profile.is_default:
+            kwargs["cuda_graph_profile"] = cuda_graph_profile
         if target_uses_paged_groups and getattr(self, "drafter", None) is not None:
             kwargs["num_tokens"] = padded_bs * self.max_tokens_per_req
         self.attn_backend.init_forward_metadata_replay_cuda_graph(
@@ -650,6 +741,8 @@ class CudaGraphWrapper:
         )
         if self.draft_attn_backend is not None:
             draft_attn_kwargs = {}
+            if not cuda_graph_profile.is_default:
+                draft_attn_kwargs["cuda_graph_profile"] = cuda_graph_profile
             if draft_uses_paged_groups and paged_cache_block_tables is not None:
                 draft_attn_kwargs["paged_cache_block_tables"] = paged_cache_block_tables
                 if paged_cache_block_table_base_offsets is not None:
@@ -767,11 +860,30 @@ class CudaGraphWrapper:
         max_num_tokens = max(ctx.global_num_tokens)
         return (max_num_tokens + self.max_tokens_per_req - 1) // self.max_tokens_per_req
 
+    def _select_cuda_graph_profile(self, ctx: ForwardContext) -> CudaGraphProfile:
+        profile = self.attn_backend.select_cuda_graph_profile(
+            self.cuda_graph_profiles,
+            ctx,
+        )
+        if profile not in self.cuda_graph_profiles:
+            return self.default_cuda_graph_profile
+        return profile
+
+    def _captured_bs_for_target(self, target_bs: int) -> int | None:
+        index = bisect.bisect_left(self.capture_bs, target_bs)
+        if index >= len(self.capture_bs):
+            return None
+        return self.capture_bs[index]
+
+    def _has_graph(self, profile: CudaGraphProfile, bs: int) -> bool:
+        return self._graph_dict_key(profile, bs) in self.graphs
+
     def _can_use_graph(self, bs: int, ctx: ForwardContext) -> bool:
         if self.disable:
             return False
         if not ctx.forward_mode.is_decode():
             return False
+        graph_profile = self._select_cuda_graph_profile(ctx)
         if self.dp_size > 1:
             if not ctx.all_decode_or_idle:
                 return False
@@ -779,11 +891,13 @@ class CudaGraphWrapper:
             if global_bs is None or global_bs == 0:
                 return False
             if self.disable_padding:
-                return global_bs in self.graphs
-            return global_bs <= self.max_bs
+                return self._has_graph(graph_profile, global_bs)
+            padded_bs = self._captured_bs_for_target(global_bs)
+            return padded_bs is not None and self._has_graph(graph_profile, padded_bs)
         if self.disable_padding:
-            return bs in self.graphs
-        return bs <= self.max_bs
+            return self._has_graph(graph_profile, bs)
+        padded_bs = self._captured_bs_for_target(bs)
+        return padded_bs is not None and self._has_graph(graph_profile, padded_bs)
 
     def can_run(self, bs: int, ctx: ForwardContext) -> bool:
         return self._can_use_graph(bs, ctx)
@@ -794,8 +908,10 @@ class CudaGraphWrapper:
     def _padded_bs(self, bs: int, ctx: ForwardContext) -> int:
         graph_bs = self._global_graph_bs(ctx)
         target_bs = graph_bs if graph_bs is not None else bs
-        index = bisect.bisect_left(self.capture_bs, target_bs)
-        return self.capture_bs[index]
+        padded_bs = self._captured_bs_for_target(target_bs)
+        if padded_bs is None:
+            raise RuntimeError(f"No CUDA graph capture size for batch size {target_bs}")
+        return padded_bs
 
     def _pad_graph_req_pool_indices(
         self, active_req_pool_indices: torch.Tensor, padded_bs: int
@@ -860,6 +976,11 @@ class CudaGraphWrapper:
         """
         use_graph = self._can_use_graph(bs, ctx)
         padded_bs = self._padded_bs(bs, ctx) if use_graph else bs
+        graph_profile = (
+            self._select_cuda_graph_profile(ctx)
+            if use_graph
+            else self.default_cuda_graph_profile
+        )
         active_req_pool_indices = self.input_buffers.req_pool_indices_buf[:bs]
 
         if use_graph and padded_bs != bs:
@@ -928,6 +1049,7 @@ class CudaGraphWrapper:
                 seq_lens,
                 req_to_page=req_to_page,
                 forward_mode=ctx.forward_mode,
+                cuda_graph_profile=graph_profile,
                 num_padding=padded_bs - bs if padded_bs != bs else 0,
                 paged_cache_block_tables=paged_cache_block_tables,
                 paged_cache_block_table_base_offsets=(
@@ -942,10 +1064,11 @@ class CudaGraphWrapper:
             self.deepep_adapter.replay()
 
             with nvtx_range("graph_replay", color="red"):
-                self.graphs[padded_bs].replay()
+                dict_key = self._graph_dict_key(graph_profile, padded_bs)
+                self.graphs[dict_key].replay()
 
             output_tokens, output_lengths, output_logprobs = self.output_buffers[
-                padded_bs
+                dict_key
             ]
 
             result = (

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -590,6 +590,7 @@ class ModelExecutor:
         self,
         accept_lengths: torch.Tensor,
         decode_req_pool_indices: torch.Tensor,
+        decode_seq_len_upper_bound: int | None = None,
     ) -> torch.Tensor:
         """Clamp spec-verify accept so committed length never exceeds
         ``context_len``.
@@ -604,6 +605,10 @@ class ModelExecutor:
         """
         if accept_lengths.numel() == 0:
             return accept_lengths
+        if decode_seq_len_upper_bound is not None and int(
+            decode_seq_len_upper_bound
+        ) < int(self.config.context_len):
+            return accept_lengths
         committed = self.runtime_states.valid_cache_lengths.index_select(
             0, decode_req_pool_indices
         ).to(accept_lengths.dtype)
@@ -617,6 +622,7 @@ class ModelExecutor:
         output_lengths: torch.Tensor,
         num_extends: int,
         bs: int,
+        decode_seq_len_upper_bound: int | None = None,
     ) -> torch.Tensor:
         """Return ``output_lengths`` with decode rows clamped so committed KV
         length never exceeds ``context_len`` (post-forward, outside the CUDA
@@ -635,6 +641,10 @@ class ModelExecutor:
         pass through. Deterministic, so no cross-rank divergence.
         """
         if bs <= num_extends:
+            return output_lengths
+        if decode_seq_len_upper_bound is not None and int(
+            decode_seq_len_upper_bound
+        ) < int(self.config.context_len):
             return output_lengths
         decode_rpi = self.input_buffers.req_pool_indices_buf[num_extends:bs]
         committed = self.runtime_states.valid_cache_lengths.index_select(
@@ -671,7 +681,9 @@ class ModelExecutor:
                 accept_lengths, 0, num_decodes, ctx.decode_input_ids
             )
             accept_lengths = self._cap_accept_to_context_len(
-                accept_lengths, sampling_info.req_pool_indices[:num_decodes]
+                accept_lengths,
+                sampling_info.req_pool_indices[:num_decodes],
+                ctx.decode_seq_len_upper_bound,
             )
             return output_tokens, accept_lengths
 
@@ -688,7 +700,9 @@ class ModelExecutor:
             decode_accept, num_extends, num_decodes, ctx.decode_input_ids
         )
         decode_accept = self._cap_accept_to_context_len(
-            decode_accept, sampling_info.req_pool_indices[num_extends:]
+            decode_accept,
+            sampling_info.req_pool_indices[num_extends:],
+            ctx.decode_seq_len_upper_bound,
         )
         if (
             prefill_out.next_token_logprobs is not None
@@ -1040,6 +1054,7 @@ class ModelExecutor:
         grammar_inputs=None,
         multimodal_context=None,
         capture_next_input_ids: bool = False,
+        decode_seq_len_upper_bound: int | None = None,
     ) -> ModelExecutionResult:
         self.log_step += 1
 
@@ -1079,6 +1094,7 @@ class ModelExecutor:
             grammar_inputs=grammar_inputs,
             multimodal_context=multimodal_context,
             capture_next_input_ids=capture_next_input_ids,
+            decode_seq_len_upper_bound=decode_seq_len_upper_bound,
         )
 
         if is_decode and (
@@ -1449,6 +1465,7 @@ class ModelExecutor:
         grammar_inputs=None,
         multimodal_context=None,
         capture_next_input_ids: bool = False,
+        decode_seq_len_upper_bound: int | None = None,
     ) -> ModelExecutionResult:
         num_extends = forward_op.num_extends()
         total_tokens = sum(forward_op.input_lengths)
@@ -1595,6 +1612,7 @@ class ModelExecutor:
                     ),
                     gather_ids=gather_ids,
                     decode_input_ids=decode_input_ids,
+                    decode_seq_len_upper_bound=decode_seq_len_upper_bound,
                 )
                 if self.config.data_parallel_size > 1:
                     if dp_global_num_tokens is None:
@@ -1716,7 +1734,10 @@ class ModelExecutor:
                 # _update_runtime_state and the scheduler page reservation; see
                 # _clamp_committed_to_context_len.
                 output_lengths = self._clamp_committed_to_context_len(
-                    output_lengths, num_extends, bs
+                    output_lengths,
+                    num_extends,
+                    bs,
+                    decode_seq_len_upper_bound=decode_seq_len_upper_bound,
                 )
 
                 # Update runtime state on execution_stream (NOT in the CUDA graph).

--- a/python/tokenspeed/runtime/layers/attention/backends/base.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/base.py
@@ -22,16 +22,51 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import torch
 
 if TYPE_CHECKING:
+    from tokenspeed.runtime.execution.context import ForwardContext
     from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
     from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
     from tokenspeed.runtime.layers.attention.kv_cache.base import BaseTokenToKVPool
     from tokenspeed.runtime.layers.paged_attention import PagedAttention
     from tokenspeed.runtime.pd.utils import StepCounter
+
+
+@dataclass(frozen=True, slots=True)
+class CudaGraphProfile:
+    """CUDA graph capture/replay profile declared by a backend.
+
+    ``name`` is a stable human-readable profile label used in logs. ``metadata``
+    carries backend-owned profile dimensions as hashable key/value pairs; the
+    graph wrapper treats it as opaque and delegates profile selection to the
+    backend that declared it. ``forward_context_fields`` carries capture-time
+    ForwardContext overrides owned by the declaring backend.
+    """
+
+    name: str = "default"
+    metadata: tuple[tuple[str, int], ...] = ()
+    forward_context_fields: tuple[tuple[str, int], ...] = ()
+
+    @property
+    def is_default(self) -> bool:
+        return self.name == "default" and not self.metadata
+
+    @property
+    def label(self) -> str:
+        return self.name
+
+    def get_int(self, key: str, default: int | None = None) -> int | None:
+        for metadata_key, value in self.metadata:
+            if metadata_key == key:
+                return int(value)
+        return default
+
+    def forward_context_kwargs(self) -> dict[str, int]:
+        return {key: int(value) for key, value in self.forward_context_fields}
 
 
 class AttentionBackend(ABC):
@@ -87,6 +122,23 @@ class AttentionBackend(ABC):
         the controller-owned per-request seq_lens; backends should reference
         (alias) it rather than copy, and must not mutate the contents."""
         raise NotImplementedError()
+
+    def get_cuda_graph_profiles(self) -> tuple[CudaGraphProfile, ...]:
+        """Return CUDA graph profiles this backend wants captured."""
+        return (CudaGraphProfile(),)
+
+    def select_cuda_graph_profile(
+        self,
+        profiles: tuple[CudaGraphProfile, ...],
+        forward_context: ForwardContext,
+    ) -> CudaGraphProfile:
+        """Select a captured profile for the current forward batch.
+
+        Backends that declare non-default profiles should override this and use
+        CPU-side fields from ``forward_context``. The default keeps existing
+        behavior: a single full-context decode graph.
+        """
+        return profiles[0]
 
     def init_forward_metadata_capture_cuda_graph(
         self,

--- a/python/tokenspeed/runtime/layers/attention/backends/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/dsa.py
@@ -20,6 +20,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import torch
 from tokenspeed_kernel.ops.attention.flashinfer import (
     trtllm_batch_decode_with_kv_cache_mla,
@@ -33,11 +35,17 @@ except Exception:
 
 from tokenspeed.runtime.configs.model_config import AttentionArch
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
-from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
+from tokenspeed.runtime.layers.attention.backends.base import (
+    AttentionBackend,
+    CudaGraphProfile,
+)
 from tokenspeed.runtime.layers.attention.backends.trtllm_mla import TRTLLMMLABackend
 from tokenspeed.runtime.layers.attention.configs.dsa import DSAConfig
 from tokenspeed.runtime.layers.attention.dsa.utils import workspace_indices_to_kv_slots
 from tokenspeed.runtime.layers.attention.registry import register_backend
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.execution.context import ForwardContext
 
 
 class DSABackend(AttentionBackend):
@@ -87,6 +95,10 @@ class DSABackend(AttentionBackend):
         self._dense_backend.decode_cuda_graph_kv_indices = value
 
     @property
+    def decode_cuda_graph_kv_indices_by_context(self):
+        return self._dense_backend.decode_cuda_graph_kv_indices_by_context
+
+    @property
     def trtllm_workspace(self):
         return self._dense_backend.trtllm_workspace
 
@@ -106,8 +118,58 @@ class DSABackend(AttentionBackend):
     def override_num_extends(self, num_extends: int):
         return self._dense_backend.override_num_extends(num_extends)
 
-    def init_cuda_graph_state(self, max_bs: int, seq_lens_buf: torch.Tensor):
-        return self._dense_backend.init_cuda_graph_state(max_bs, seq_lens_buf)
+    @staticmethod
+    def _decode_context_profile(max_seq_len: int) -> CudaGraphProfile:
+        return CudaGraphProfile(
+            name=f"decode_ctx_{max_seq_len}",
+            metadata=(("max_seq_len", int(max_seq_len)),),
+            forward_context_fields=(("decode_seq_len_upper_bound", int(max_seq_len)),),
+        )
+
+    def get_cuda_graph_profiles(self) -> tuple[CudaGraphProfile, ...]:
+        profiles = [CudaGraphProfile()]
+        if self.index_topk <= 0 or self.max_context_len <= self.index_topk:
+            return tuple(profiles)
+        variants = (
+            int(self.index_topk),
+            int(self.index_topk + self.index_topk // 2),
+            int(self.index_topk * 2),
+        )
+        profiles.extend(
+            self._decode_context_profile(value)
+            for value in sorted(set(variants))
+            if 0 < value < int(self.max_context_len)
+        )
+        return tuple(profiles)
+
+    def select_cuda_graph_profile(
+        self,
+        profiles: tuple[CudaGraphProfile, ...],
+        forward_context: ForwardContext,
+    ) -> CudaGraphProfile:
+        upper_bound = getattr(forward_context, "decode_seq_len_upper_bound", None)
+        if upper_bound is None:
+            return profiles[0]
+        for profile in profiles:
+            max_seq_len = profile.get_int("max_seq_len")
+            if max_seq_len is not None and int(upper_bound) <= max_seq_len:
+                return profile
+        return profiles[0]
+
+    def init_cuda_graph_state(
+        self,
+        max_bs: int,
+        seq_lens_buf: torch.Tensor,
+        *,
+        cuda_graph_profile: CudaGraphProfile | None = None,
+        **kwargs,
+    ):
+        return self._dense_backend.init_cuda_graph_state(
+            max_bs,
+            seq_lens_buf,
+            cuda_graph_profile=cuda_graph_profile,
+            **kwargs,
+        )
 
     def _clear_metadata_caches(self) -> None:
         metadata_objects = [
@@ -130,12 +192,17 @@ class DSABackend(AttentionBackend):
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode,
+        *,
+        cuda_graph_profile: CudaGraphProfile | None = None,
+        **kwargs,
     ):
         result = self._dense_backend.init_forward_metadata_capture_cuda_graph(
             bs=bs,
             req_pool_indices=req_pool_indices,
             seq_lens=seq_lens,
             forward_mode=forward_mode,
+            cuda_graph_profile=cuda_graph_profile,
+            **kwargs,
         )
         self._clear_metadata_caches()
         return result

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
@@ -40,7 +40,10 @@ from tokenspeed_kernel.ops.attention.flashinfer import (
 
 from tokenspeed.runtime.configs.model_config import AttentionArch
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
-from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
+from tokenspeed.runtime.layers.attention.backends.base import (
+    AttentionBackend,
+    CudaGraphProfile,
+)
 from tokenspeed.runtime.layers.attention.chunk import (
     build_chunked_prefill_metadata_arrays,
 )
@@ -142,7 +145,10 @@ class TRTLLMMLABackend(AttentionBackend):
         # Metadata
         self.forward_decode_metadata: TRTLLMMLADecodeMetadata | None = None
         self.forward_prefill_metadata: TRTLLMMLAPrefillMetadata | None = None
-        self.decode_cuda_graph_metadata: dict[int, TRTLLMMLADecodeMetadata] = {}
+        self.decode_cuda_graph_metadata: dict[
+            tuple[int, int], TRTLLMMLADecodeMetadata
+        ] = {}
+        self.decode_cuda_graph_kv_indices_by_context: dict[int, torch.Tensor] = {}
         self.decode_cuda_graph_kv_indices = None
         self.chunked_prefill_metadata: TRTLLMMLAChunkedPrefillMetadata | None = None
 
@@ -313,7 +319,31 @@ class TRTLLMMLABackend(AttentionBackend):
 
     # ---- CUDA Graph ----
 
-    def init_cuda_graph_state(self, max_bs: int, seq_lens_buf: torch.Tensor):
+    def _cuda_graph_context_len(
+        self, cuda_graph_profile: CudaGraphProfile | None = None
+    ) -> int:
+        if cuda_graph_profile is None:
+            return int(self.max_context_len)
+        max_seq_len = cuda_graph_profile.get_int("max_seq_len")
+        if max_seq_len is None:
+            return int(self.max_context_len)
+        return max(1, min(int(max_seq_len), int(self.max_context_len)))
+
+    def _cuda_graph_metadata_key(
+        self,
+        bs: int,
+        cuda_graph_profile: CudaGraphProfile | None = None,
+    ) -> tuple[int, int]:
+        return (self._cuda_graph_context_len(cuda_graph_profile), int(bs))
+
+    def init_cuda_graph_state(
+        self,
+        max_bs: int,
+        seq_lens_buf: torch.Tensor,
+        *,
+        cuda_graph_profile: CudaGraphProfile | None = None,
+        **_,
+    ):
         assert (
             seq_lens_buf.dtype == torch.int32
             and seq_lens_buf.dim() == 1
@@ -324,10 +354,16 @@ class TRTLLMMLABackend(AttentionBackend):
         )
         # Alias controller's seq_lens_buf — backend never mutates it.
         self.cuda_graph_seq_lens_buf = seq_lens_buf
-        max_blocks = self._calc_padded_blocks(self.max_context_len)
-        self.decode_cuda_graph_kv_indices = torch.zeros(
-            (max_bs, max_blocks), dtype=torch.int32, device=self.device
-        )
+        context_len = self._cuda_graph_context_len(cuda_graph_profile)
+        if context_len not in self.decode_cuda_graph_kv_indices_by_context:
+            max_blocks = self._calc_padded_blocks(context_len)
+            self.decode_cuda_graph_kv_indices_by_context[context_len] = torch.zeros(
+                (max_bs, max_blocks), dtype=torch.int32, device=self.device
+            )
+        if cuda_graph_profile is None or cuda_graph_profile.is_default:
+            self.decode_cuda_graph_kv_indices = (
+                self.decode_cuda_graph_kv_indices_by_context[context_len]
+            )
 
     def init_forward_metadata_capture_cuda_graph(
         self,
@@ -335,14 +371,19 @@ class TRTLLMMLABackend(AttentionBackend):
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode,
+        *,
+        cuda_graph_profile: CudaGraphProfile | None = None,
+        **_,
     ):
         if forward_mode.is_extend_or_mixed():
             raise NotImplementedError(
                 f"trtllm_mla CUDA graph capture not supported for {forward_mode}"
             )
 
-        max_blocks = self._calc_padded_blocks(self.max_context_len)
-        block_kv_indices = self.decode_cuda_graph_kv_indices[:bs, :max_blocks]
+        context_len = self._cuda_graph_context_len(cuda_graph_profile)
+        kv_indices = self.decode_cuda_graph_kv_indices_by_context[context_len]
+        max_blocks = self._calc_padded_blocks(context_len)
+        block_kv_indices = kv_indices[:bs, :max_blocks]
 
         # For capture we don't have req_to_page yet; just zero-fill the block indices.
         # The actual indices will be filled on replay. seq_lens_k aliases
@@ -350,11 +391,11 @@ class TRTLLMMLABackend(AttentionBackend):
         metadata = TRTLLMMLADecodeMetadata(
             num_extends=0,
             block_kv_indices=block_kv_indices,
-            max_seq_len_k=self.max_context_len,
+            max_seq_len_k=context_len,
             seq_lens_k=self.cuda_graph_seq_lens_buf[:bs],
         )
 
-        self.decode_cuda_graph_metadata[bs] = metadata
+        self.decode_cuda_graph_metadata[(context_len, int(bs))] = metadata
         self.forward_decode_metadata = metadata
 
     def init_forward_metadata_replay_cuda_graph(
@@ -366,12 +407,15 @@ class TRTLLMMLABackend(AttentionBackend):
         req_to_page: torch.Tensor = None,
         **kwargs,
     ):
+        cuda_graph_profile = kwargs.pop("cuda_graph_profile", None)
         if forward_mode is not None and forward_mode.is_extend_or_mixed():
             raise NotImplementedError(
                 f"trtllm_mla CUDA graph replay not supported for {forward_mode}"
             )
 
-        metadata = self.decode_cuda_graph_metadata[bs]
+        metadata = self.decode_cuda_graph_metadata[
+            self._cuda_graph_metadata_key(bs, cuda_graph_profile)
+        ]
 
         # seq_lens_k aliases seq_lens_buf; only block indices need refresh.
         # When the buffer is aliased to a peer backend (e.g. drafter aliasing

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/deep_gemm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/deep_gemm/__init__.py
@@ -83,12 +83,19 @@ from deep_gemm import (
     get_paged_mqa_logits_metadata,
     get_symm_buffer_for_mega_moe,
     m_grouped_fp8_gemm_nt_contiguous,
-    m_grouped_fp8_gemm_nt_masked,
     set_num_sms,
     tf32_hc_prenorm_gemm,
     transform_sf_into_required_layout,
     transform_weights_for_mega_moe,
 )
+
+try:
+    from deep_gemm import m_grouped_fp8_gemm_nt_masked
+except ImportError:
+    from deep_gemm import (
+        fp8_m_grouped_gemm_nt_masked as m_grouped_fp8_gemm_nt_masked,
+    )
+
 from tokenspeed_kernel.thirdparty.deep_gemm.warmup import (
     warmup_fp8_gemm_nt,
     warmup_fp8_gemm_nt_from_model,


### PR DESCRIPTION
## Summary
- introduce backend-declared `CudaGraphProfile`s for CUDA graph capture/replay
- keep the default full-context graph as the safe fallback, and let attention backends declare/select any extra profiles they can use efficiently
- let GLM DSA request smaller decode-context profiles (`2048`, `3072`, `4096`) through the generic backend profile hook instead of hard-coding GLM policy in `CudaGraphWrapper`
- propagate a CPU-side `decode_seq_len_upper_bound` through `ForwardContext` so graph dispatch does not need to sync GPU `seq_lens`
- store TRTLLM MLA graph metadata/block-table buffers by backend profile context length and keep draft/target block-table aliasing compatible
- add a small DeepGEMM symbol-name compatibility fallback

## Root Cause
GLM 5.1 NVFP4 MTP decode was replaying decode graphs captured against the full max context length. On short/mid ShareGPT decode workloads this pays the long-context block-table/metadata cost even when the actual decode seq-len is much smaller.

## Design
This PR keeps the CUDA graph wrapper general:

- `CudaGraphProfile()` is the default/full-context fallback profile.
- `AttentionBackend.get_cuda_graph_profiles()` declares extra profiles.
- `AttentionBackend.select_cuda_graph_profile()` owns backend-specific profile selection.
- `CudaGraphWrapper` only enumerates, captures, validates, and replays profiles; it does not know GLM/DSA policy.
- `CudaGraphProfile.forward_context_fields` lets a backend make capture-time `ForwardContext` match the profile it declared.
- GLM DSA declares profiles derived from `index_topk`; TRTLLM MLA consumes the profile metadata to size its CUDA graph metadata/block-table state.

That keeps the performance optimization local to the backend that benefits from it, while leaving the runtime path usable for other backends that may want different graph profiles later.

## Performance
Benchmark setup:
- Model: `nvidia/GLM-5.1-NVFP4`
- Hardware/parallelism: 4x B200, `attn_tp_size=4`, `moe_tp_size=4`
- Workload: ShareGPT, first 128 prompts, max concurrency 16, output len 256, `temperature=0`
- Input/output shape check: `#Input tokens: 42015`, `#Output tokens: 32768`

Results:

| Version | Output tok/s | Total tok/s | Mean TPOT |
| --- | ---: | ---: | ---: |
| `origin/main` baseline | 508.40 | 1171.83 | 28.74 ms |
| This PR, first run | 642.64 | 1483.33 | 22.11 ms |
| This PR, hot repeat | 739.17 | 1704.40 | 19.69 ms |

Hot-repeat delta vs baseline:
- Output throughput: +45.4%
- Total throughput: +45.4%
- Mean TPOT: -31.5%

## Validation
- `pre-commit run --all-files`
- `python -m py_compile` on the modified runtime/backend files
- `pytest test/runtime/test_max_new_tokens_context_cap.py test/runtime/test_trtllm_spec_seqlen_clamp.py -q`
- GLM 5.1 NVFP4 4-card ShareGPT 128/16 benchmark described above; captured `default`, `decode_ctx_2048`, `decode_ctx_3072`, and `decode_ctx_4096` profiles successfully