### PR TITLE
Update tokenspeed-smg dependency pins

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -65,9 +65,9 @@ dependencies = [
     "setproctitle",
     "tiktoken",
     "tokenspeed-mooncake>=0.3.11.post20260527",
-    "tokenspeed-smg==1.6.0.post20260623",
-    "tokenspeed-smg-grpc-proto==0.4.11.post20260623",
-    "tokenspeed-smg-grpc-servicer==0.5.6.post20260623",
+    "tokenspeed-smg==1.7.0.post20260630",
+    "tokenspeed-smg-grpc-proto==0.4.12.post20260630",
+    "tokenspeed-smg-grpc-servicer==0.6.0.post20260630",
     "torch==2.11.0",
     # Tag-capable sleep/wake allocator (region(tag, enable_cpu_backup)/pause/
     # resume). Bundles cu12/cu13 binaries; import-guarded so it's a no-op unless


### PR DESCRIPTION
Update the bundled SMG package pins to the latest published TokenSpeed repackaging builds.

This keeps the runtime dependency metadata aligned with the current tokenspeed-smg release set.

Validation:
- Confirmed the target versions are the latest available on PyPI
- Ran git diff --check
- Ran a pyproject dependency assertion
- Ran pre-commit run --all-files