### PR TITLE
fix(scheduler): account for terminal state checkpoints in admission

### DIFF
--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
@@ -39,6 +39,58 @@
 #include <utility>
 
 namespace tokenspeed {
+namespace {
+
+const TreeNode* FindExactRadixNode(const KVPrefixCache& cache,
+                                   std::span<const std::span<const std::int32_t>> token_pages,
+                                   std::int32_t target_raw_tokens) {
+    const RadixTree& tree = cache.GetRadixTree();
+    const std::int32_t page_size = tree.PageSize();
+    if (target_raw_tokens <= 0 || page_size <= 0 || target_raw_tokens % page_size != 0) {
+        return nullptr;
+    }
+
+    const std::int32_t target_pages = target_raw_tokens / page_size;
+    if (target_pages > static_cast<std::int32_t>(token_pages.size())) {
+        return nullptr;
+    }
+
+    const TreeNode* current = tree.Root();
+    std::int32_t matched_pages = 0;
+    while (matched_pages < target_pages) {
+        const auto& first_page = token_pages[matched_pages];
+        if (first_page.size() != static_cast<std::size_t>(page_size)) {
+            return nullptr;
+        }
+
+        const token_vec_t key(first_page.begin(), first_page.end());
+        const TreeNode* child = FindChild(current, key);
+        if (child == nullptr || child->Tokens().size() % static_cast<std::size_t>(page_size) != 0) {
+            return nullptr;
+        }
+
+        const std::int32_t child_pages = static_cast<std::int32_t>(child->Tokens().size()) / page_size;
+        if (child_pages <= 0 || matched_pages + child_pages > target_pages) {
+            return nullptr;
+        }
+        for (std::int32_t page = 0; page < child_pages; ++page) {
+            const auto& expected = token_pages[matched_pages + page];
+            if (expected.size() != static_cast<std::size_t>(page_size)) {
+                return nullptr;
+            }
+            const auto actual_begin = child->Tokens().begin() + page * page_size;
+            if (!std::equal(actual_begin, actual_begin + page_size, expected.begin(), expected.end())) {
+                return nullptr;
+            }
+        }
+
+        matched_pages += child_pages;
+        current = child;
+    }
+    return current;
+}
+
+}  // namespace
 
 HybridPrefixCache::HybridPrefixCache(KVPrefixCache& kv_prefix_cache, MambaChunkAllocator* mamba_allocator,
                                      std::int32_t mamba_cache_chunk_size, MambaHostAllocator* mamba_host_allocator)
@@ -1074,6 +1126,18 @@ HybridPrefixCache::PagedCacheGroupAdmission HybridPrefixCache::checkPagedCacheGr
         return result;
     }
 
+    std::unordered_set<std::string> existing_commit_snapshot_groups;
+    if (context.commit_target_raw_tokens.has_value()) {
+        const TreeNode* terminal =
+            FindExactRadixNode(kv_prefix_cache_, context.commit_token_pages, *context.commit_target_raw_tokens);
+        const PagedCacheSnapshot* snapshot = terminal != nullptr ? terminal->GetPagedCacheSnapshot() : nullptr;
+        if (snapshot != nullptr) {
+            for (const auto& [gid, _] : snapshot->groups) {
+                existing_commit_snapshot_groups.insert(gid);
+            }
+        }
+    }
+
     auto req_it =
         context.fresh_table_view ? request_paged_cache_tables_.end() : request_paged_cache_tables_.find(request_id);
     const bool has_hit = (paged_cache_hit.last_node != nullptr) && (paged_cache_hit.prefix_len_tokens > 0);
@@ -1148,8 +1212,8 @@ HybridPrefixCache::PagedCacheGroupAdmission HybridPrefixCache::checkPagedCacheGr
             // snapshot tail from owned to borrowed before ReleaseSkipped runs,
             // so the only immediate pool credit is from stale-owned pages
             // dropped at the first commit step. Transport-only State groups do
-            // not participate in intermediate snapshots and must keep the
-            // ReleaseSkipped estimate above.
+            // not participate in intermediate snapshots; their terminal-only
+            // checkpoint is accounted separately below when one is pending.
             const std::int32_t lcm = paged_cache_history_alignment_tokens_;
             const bool required_state_group =
                 paged_cache_state_group_set_.find(gid) != paged_cache_state_group_set_.end();
@@ -1163,6 +1227,32 @@ HybridPrefixCache::PagedCacheGroupAdmission HybridPrefixCache::checkPagedCacheGr
                     base += std::min(live_lower_page - base, borrowed_in_table);
                 }
                 releasable_owned = (live_lower_page > base) ? std::min(live_lower_page - base, owned_in_table) : 0;
+            }
+
+            // A terminal continuation checkpoint runs before ReleaseSkipped.
+            // For transport-only State groups, owned pages in the trailing
+            // checkpoint window become borrowed snapshot pages. Dropping
+            // those borrowed ids later does not return pages to this pool,
+            // so remove their overlap from the immediate release credit.
+            const bool continuation_state_group =
+                paged_cache_continuation_state_group_set_.find(gid) != paged_cache_continuation_state_group_set_.end();
+            const bool terminal_group_already_exists =
+                existing_commit_snapshot_groups.find(gid) != existing_commit_snapshot_groups.end();
+            if (!required_state_group && continuation_state_group && table_exists && lcm > 0 &&
+                context.commit_target_raw_tokens.has_value() && !terminal_group_already_exists) {
+                const std::int32_t commit_target = *context.commit_target_raw_tokens;
+                const std::int32_t retained_tokens = *cfg.sliding_window_tokens;
+                if (commit_target > committed_prefix && commit_target <= raw_cursor && commit_target % lcm == 0 &&
+                    commit_target % raw_per_page == 0 && retained_tokens % raw_per_page == 0) {
+                    const std::int32_t owned_begin = already_released + borrowed_in_table;
+                    const std::int32_t owned_end = owned_begin + owned_in_table;
+                    const std::int32_t checkpoint_begin = std::max(0, commit_target - retained_tokens) / raw_per_page;
+                    const std::int32_t checkpoint_end = commit_target / raw_per_page;
+                    const std::int32_t retained_begin = std::max(owned_begin, checkpoint_begin);
+                    const std::int32_t retained_end = std::min({owned_end, checkpoint_end, target_releases});
+                    const std::int32_t retained_release_credit = std::max(0, retained_end - retained_begin);
+                    releasable_owned = std::max(0, releasable_owned - retained_release_credit);
+                }
             }
         }
 
@@ -1358,9 +1448,15 @@ bool HybridPrefixCache::tryPrunePagedCacheSnapshot(AdmissionFailureKind kind) {
 bool HybridPrefixCache::AdmitChunk(const std::string& request_id, std::int32_t first_raw_position_of_op,
                                    std::int32_t target_raw_tokens_exclusive,
                                    std::map<std::string, std::int32_t>& simulated_free,
-                                   const MatchResult::PagedCache& paged_cache_hit) {
+                                   const MatchResult::PagedCache& paged_cache_hit,
+                                   std::optional<std::int32_t> commit_target_raw_tokens,
+                                   std::span<const std::span<const std::int32_t>> commit_token_pages) {
+    PagedCacheAdmissionContext context{
+        .commit_target_raw_tokens = commit_target_raw_tokens,
+        .commit_token_pages = commit_token_pages,
+    };
     return admitPagedCacheChunk(request_id, first_raw_position_of_op, target_raw_tokens_exclusive, simulated_free,
-                                paged_cache_hit, {});
+                                paged_cache_hit, context);
 }
 
 bool HybridPrefixCache::AdmitChunkFromRetracted(const std::string& request_id, std::int32_t target_raw_tokens_exclusive,

--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.h
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.h
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <optional>
 #include <span>
 #include <string>
 #include <unordered_map>
@@ -116,10 +117,17 @@ public:
     void PopulateOp(ForwardOperationBase& op_base) const;
 
     // Run admission against `simulated_free`; prunes evictable snapshots on
-    // group-pool pressure, then applies the debit on success.
+    // group-pool pressure, then applies the debit on success. When present,
+    // `commit_target_raw_tokens` is the terminal depth CommitChunk will publish
+    // immediately before AcquireForRequest for this chunk. `commit_token_pages`
+    // identifies an already-existing exact terminal so admission can account
+    // for continuation-state groups that CommitChunk will reuse rather than
+    // checkpoint again.
     bool AdmitChunk(const std::string& request_id, std::int32_t first_raw_position_of_op,
                     std::int32_t target_raw_tokens_exclusive, std::map<std::string, std::int32_t>& simulated_free,
-                    const MatchResult::PagedCache& paged_cache_hit = {});
+                    const MatchResult::PagedCache& paged_cache_hit = {},
+                    std::optional<std::int32_t> commit_target_raw_tokens = std::nullopt,
+                    std::span<const std::span<const std::int32_t>> commit_token_pages = {});
 
     // Retract-decode variant: admission uses a fresh-table view and credits
     // pages owned by the stale table before it is released.
@@ -173,6 +181,8 @@ private:
     struct PagedCacheAdmissionContext {
         bool fresh_table_view{false};
         std::map<std::string, std::int32_t> owned_release_credit{};
+        std::optional<std::int32_t> commit_target_raw_tokens{};
+        std::span<const std::span<const std::int32_t>> commit_token_pages{};
     };
 
     // Classify which family caused `admission.ok == false`.

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -188,8 +188,13 @@ std::optional<fsm::SchedulePrefillEvent> Scheduler::schedulePrefill(
 
     const std::int32_t first_pos = request->PrefillSize() - unscheduled;
     const std::int32_t target = first_pos + tokens_this_round;
-    if (hybrid_prefix_cache_ && !hybrid_prefix_cache_->AdmitChunk(request->Id(), first_pos, target, simulated_free)) {
-        return {};
+    if (hybrid_prefix_cache_) {
+        const std::int32_t commit_target = (first_pos / config_.page_size) * config_.page_size;
+        const auto commit_token_pages = request->GetFullPagedTokens(false);
+        if (!hybrid_prefix_cache_->AdmitChunk(request->Id(), first_pos, target, simulated_free, {}, commit_target,
+                                              commit_token_pages)) {
+            return {};
+        }
     }
 
     return fsm::SchedulePrefillEvent{tokens_this_round, reserve_num_tokens_in_next_schedule_event,
@@ -214,8 +219,17 @@ std::optional<fsm::ScheduleDecodeEvent> Scheduler::scheduleDecode(Request* reque
 
     const std::int32_t first_pos = request->TokenSize();
     const std::int32_t target = first_pos + config_.decode_input_tokens;
-    if (hybrid_prefix_cache_ && !hybrid_prefix_cache_->AdmitChunk(request->Id(), first_pos, target, simulated_free)) {
-        return {};
+    if (hybrid_prefix_cache_) {
+        std::optional<std::int32_t> commit_target;
+        std::vector<std::span<const std::int32_t>> commit_token_pages;
+        if (request->Is<fsm::PrefillDone>()) {
+            commit_target = (request->PrefillSize() / config_.page_size) * config_.page_size;
+            commit_token_pages = request->GetFullPagedTokens(false);
+        }
+        if (!hybrid_prefix_cache_->AdmitChunk(request->Id(), first_pos, target, simulated_free, {}, commit_target,
+                                              commit_token_pages)) {
+            return {};
+        }
     }
 
     return fsm::ScheduleDecodeEvent{config_.decode_input_tokens,

--- a/tokenspeed-scheduler/python/tests/test_paged_cache_group_admission.py
+++ b/tokenspeed-scheduler/python/tests/test_paged_cache_group_admission.py
@@ -2,7 +2,9 @@ from tokenspeed_scheduler import (
     ExecutionEvent,
     ForwardEvent,
     PagedCacheGroupConfig,
+    PagedCacheGroupFamily,
     PagedCacheRetention,
+    PrefixCacheAdjunctSpec,
     RequestSpec,
     Scheduler,
     SchedulerConfig,
@@ -162,3 +164,204 @@ def test_batch_admission_debits_simulated_free_pages():
     assert len(admitted & {"r0", "r1"}) <= 1
     for gid in ("swa.g0", "swa.g1"):
         assert scheduler.paged_cache_group_failed_alloc_count(gid) == 0
+
+
+def _transport_state_checkpoint_scheduler(
+    state_total_pages: int,
+    *,
+    max_scheduled_tokens: int = 64,
+    requests: list[tuple[str, list[int]]] | None = None,
+    decode_input_tokens: int = 1,
+    enable_mixed_prefill_decode: bool = False,
+    num_host_pages: int = 0,
+) -> Scheduler:
+    cfg = _base_config(num_device_pages=256)
+    cfg.page_size = 16
+    cfg.max_scheduled_tokens = max_scheduled_tokens
+    cfg.max_batch_size = 2
+    cfg.decode_input_tokens = decode_input_tokens
+    cfg.enable_mixed_prefill_decode = enable_mixed_prefill_decode
+    cfg.num_host_pages = num_host_pages
+    cfg.paged_cache_groups = [
+        PagedCacheGroupConfig(
+            group_id="fh.test",
+            rows_per_page=16,
+            entry_stride_tokens=1,
+            total_pages=256,
+            retention=PagedCacheRetention.FullHistory,
+            family=PagedCacheGroupFamily.History,
+        ),
+        PagedCacheGroupConfig(
+            group_id="c4.test",
+            rows_per_page=4,
+            entry_stride_tokens=1,
+            total_pages=state_total_pages,
+            retention=PagedCacheRetention.SlidingWindow,
+            sliding_window_tokens=8,
+            family=PagedCacheGroupFamily.State,
+        ),
+    ]
+    adjunct = PrefixCacheAdjunctSpec()
+    adjunct.required_groups = ["fh.test"]
+    cfg.prefix_cache_adjunct = adjunct
+
+    scheduler = Scheduler(cfg)
+    if requests is None:
+        requests = [
+            ("A", list(range(260))),
+            ("B", list(range(1_000, 1_500))),
+        ]
+    scheduler.submit_requests(
+        [_make_spec(request_id, tokens) for request_id, tokens in requests]
+    )
+    return scheduler
+
+
+def _request_input_lengths(plan) -> dict[str, int]:
+    return {
+        request_id: input_length
+        for op in plan.forward
+        for request_id, input_length in zip(op.request_ids, op.input_lengths)
+    }
+
+
+def test_transport_state_terminal_checkpoint_credit_is_not_overcounted():
+    scheduler = _transport_state_checkpoint_scheduler(state_total_pages=23)
+
+    for _ in range(4):
+        assert _request_ids_in_plan(scheduler.next_execution_plan()) == {"A"}
+
+    split_plan = scheduler.next_execution_plan()
+    assert _request_ids_in_plan(split_plan) == {"A", "B"}
+    split_op = next(op for op in split_plan.forward if "B" in op.request_ids)
+    assert list(split_op.request_ids) == ["A", "B"]
+    assert list(split_op.input_lengths) == [4, 60]
+    assert len(scheduler.get_request_paged_cache_page_ids("B", "c4.test")) == 15
+    assert scheduler.get_request_paged_cache_base_logical_page("B", "c4.test") == 0
+
+    # Publishing B's 48-token terminal checkpoint retains two owned state
+    # pages as borrowed snapshot pages before ReleaseSkipped runs. Admission
+    # must not count those pages as immediately available to the next acquire.
+    next_plan = scheduler.next_execution_plan()
+    assert _request_ids_in_plan(next_plan) == {"A"}
+    assert len(scheduler.get_request_paged_cache_page_ids("B", "c4.test")) == 15
+    assert scheduler.get_request_paged_cache_base_logical_page("B", "c4.test") == 0
+    assert scheduler.paged_cache_group_failed_alloc_count("c4.test") == 0
+
+    finish = ForwardEvent.Finish()
+    finish.request_id = "A"
+    execution_event = ExecutionEvent()
+    execution_event.add_event(finish)
+    scheduler.advance(execution_event)
+
+    resumed_plan = scheduler.next_execution_plan()
+    assert _request_ids_in_plan(resumed_plan) == {"B"}
+    assert scheduler.paged_cache_group_failed_alloc_count("c4.test") == 0
+
+
+def test_transport_state_terminal_checkpoint_exact_capacity_is_admitted():
+    scheduler = _transport_state_checkpoint_scheduler(state_total_pages=24)
+
+    for _ in range(4):
+        assert _request_input_lengths(scheduler.next_execution_plan()) == {"A": 64}
+
+    split_plan = scheduler.next_execution_plan()
+    assert _request_input_lengths(split_plan) == {"A": 4, "B": 60}
+
+    next_plan = scheduler.next_execution_plan()
+    assert _request_input_lengths(next_plan) == {"B": 64}
+    assert scheduler.paged_cache_group_available_pages("c4.test") == 0
+    assert scheduler.paged_cache_group_failed_alloc_count("c4.test") == 0
+
+
+def test_existing_terminal_state_snapshot_preserves_real_release_credit():
+    scheduler = _transport_state_checkpoint_scheduler(
+        state_total_pages=41,
+        max_scheduled_tokens=136,
+        enable_mixed_prefill_decode=True,
+        requests=[
+            ("A", list(range(68))),
+            ("B", list(range(203))),
+        ],
+    )
+
+    first_plan = scheduler.next_execution_plan()
+    assert _request_input_lengths(first_plan) == {"A": 68, "B": 68}
+    assert scheduler.paged_cache_group_available_pages("c4.test") == 6
+
+    # A first publishes the depth-64 continuation snapshot. B reaches the
+    # exact same terminal in this plan, so CommitChunk reuses that snapshot
+    # and B's stale owned page remains real release credit.
+    second_plan = scheduler.next_execution_plan()
+    assert _request_input_lengths(second_plan) == {"B": 135, "A": 1}
+    assert scheduler.paged_cache_group_available_pages("c4.test") == 0
+    assert scheduler.paged_cache_group_failed_alloc_count("c4.test") == 0
+
+
+def test_existing_terminal_state_snapshot_credit_is_branch_specific():
+    scheduler = _transport_state_checkpoint_scheduler(
+        state_total_pages=41,
+        max_scheduled_tokens=136,
+        enable_mixed_prefill_decode=True,
+        requests=[
+            ("A", list(range(68))),
+            ("B", list(range(1_000, 1_203))),
+        ],
+    )
+
+    first_plan = scheduler.next_execution_plan()
+    assert _request_input_lengths(first_plan) == {"A": 68, "B": 68}
+
+    # A has a continuation snapshot at the same depth, but B is on another
+    # token branch and must still reserve the pages its own checkpoint retains.
+    second_plan = scheduler.next_execution_plan()
+    assert _request_input_lengths(second_plan) == {"A": 1}
+    assert scheduler.paged_cache_group_failed_alloc_count("c4.test") == 0
+
+
+def test_transport_state_decode_checkpoint_credit_is_not_overcounted():
+    scheduler = _transport_state_checkpoint_scheduler(
+        state_total_pages=20,
+        max_scheduled_tokens=72,
+        decode_input_tokens=64,
+        enable_mixed_prefill_decode=True,
+        num_host_pages=256,
+        requests=[
+            ("A", list(range(68))),
+            ("B", list(range(1_000, 1_004))),
+        ],
+    )
+
+    first_plan = scheduler.next_execution_plan()
+    assert _request_input_lengths(first_plan) == {"A": 68, "B": 4}
+    assert scheduler.paged_cache_group_available_pages("c4.test") == 1
+
+    # The terminal checkpoint retains one of the pages that ReleaseSkipped
+    # would otherwise return, so A cannot safely fit at this capacity.
+    second_plan = scheduler.next_execution_plan()
+    assert _request_input_lengths(second_plan) == {}
+    assert scheduler.paged_cache_group_available_pages("c4.test") == 1
+    assert scheduler.paged_cache_group_failed_alloc_count("c4.test") == 0
+
+
+def test_transport_state_decode_checkpoint_exact_capacity_is_admitted():
+    scheduler = _transport_state_checkpoint_scheduler(
+        state_total_pages=21,
+        max_scheduled_tokens=72,
+        decode_input_tokens=64,
+        enable_mixed_prefill_decode=True,
+        num_host_pages=256,
+        requests=[
+            ("A", list(range(68))),
+            ("B", list(range(1_000, 1_004))),
+        ],
+    )
+
+    first_plan = scheduler.next_execution_plan()
+    assert _request_input_lengths(first_plan) == {"A": 68, "B": 4}
+    assert scheduler.paged_cache_group_available_pages("c4.test") == 2
+
+    second_plan = scheduler.next_execution_plan()
+    assert _request_input_lengths(second_plan) == {"A": 64}
+    assert scheduler.paged_cache_group_available_pages("c4.test") == 0
+    assert scheduler.paged_cache_group_failed_alloc_count("c4.test") == 0


### PR DESCRIPTION
## Summary

Fix paged-cache admission for terminal-only continuation State groups such as DeepSeek-V4 C4.

CommitChunk publishes a terminal State snapshot before ReleaseSkipped and AcquireForRequest. The previous admission estimate counted all skipped owned pages as immediately returned to the pool, even when the terminal snapshot first retained its trailing window. This could over-admit a request and exhaust the C4 page pool during the subsequent acquire.

Pass the pending terminal target and token pages into admission, detect exact branch-specific snapshots that will be reused, and subtract pages retained by a new terminal checkpoint from immediate release credit. Add boundary and snapshot-reuse coverage for continued prefill and prefill-to-decode admission.

## Test Plan

- pre-commit run --all-files
- Release scheduler extension build
- tokenspeed-scheduler Python test suite: 66 passed
- DeepSeek-V4-Flash GSM8K, 5-shot, 50 samples, deterministic single-request concurrency: strict/flexible exact match 0.94 (47/50), above the 0.92 gate
- Post-evaluation health/readiness passed; 50/50 requests completed; no fatal log matches after readiness

Performance was not evaluated for this exact rebased fix branch; this PR makes no performance improvement claim.
