### PR TITLE
fix(scheduler): clamp hybrid TakeFirst page-aligned to prevent OwnedP…

### DIFF
--- a/tokenspeed-scheduler/CMakeLists.txt
+++ b/tokenspeed-scheduler/CMakeLists.txt
@@ -127,6 +127,7 @@ if(TOKENSPEED_SCHEDULER_BUILD_TESTS)
         tests/cpp/test_kv_cache_events.cpp
         tests/cpp/test_eviction_lru.cpp
         tests/cpp/test_host_node_ref_lifetime.cpp
+        tests/cpp/test_hybrid_takefirst_overflow.cpp
     )
 
     target_link_libraries(tokenspeed_scheduler_tests

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
@@ -124,9 +124,21 @@ void InsertHybridCache(HybridPrefixCache* hybrid_cache,
         return;
     }
 
+    // Allocator may hold fewer pages than new_page_count by insert time; clamp page-aligned so
+    // prefix + inserted == full (a count-only clamp would relocate the overflow into Insert's TakeLast).
+    const std::vector<std::span<const std::int32_t>>* tokens_for_insert = &full_paged_tokens;
+    std::vector<std::span<const std::int32_t>> clamped_tokens;
+    const std::int32_t avail = static_cast<std::int32_t>(local_kv_allocator->PageCount());
+    if (new_page_count > avail) {
+        const std::int32_t keep = static_cast<std::int32_t>(prefix_pages->size()) + avail;
+        clamped_tokens.assign(full_paged_tokens.begin(), full_paged_tokens.begin() + keep);
+        tokens_for_insert = &clamped_tokens;
+        new_page_count = avail;
+    }
+
     OwnedPages pages_to_insert = local_kv_allocator->TakeFirst(new_page_count);
-    auto insert_result = hybrid_cache->GetKVPrefixCache().Insert<ResourceType::Device>(full_paged_tokens, *prefix_pages,
-                                                                                       std::move(pages_to_insert));
+    auto insert_result = hybrid_cache->GetKVPrefixCache().Insert<ResourceType::Device>(
+        *tokens_for_insert, *prefix_pages, std::move(pages_to_insert));
 
     if (local_mamba_allocator != nullptr && local_mamba_allocator->HasCheckpoint()) {
         const bool publish = ShouldPublishMambaCheckpoint(hybrid_cache, chunk_begin, chunk_size, page_size);
@@ -360,6 +372,13 @@ std::variant<Draining, Finished> FinishEvent::apply(ForwardStateT&& state) {
     auto local_mamba_allocator = std::move(state).TakeLocalMambaAllocator();
     auto local_allocator = std::move(state).TakeLocalKVAllocator();
     if (alloc_count > 0) {
+        // Same page-aligned clamp as InsertHybridCache, keeping prefix + inserted == full.
+        const std::int32_t avail = static_cast<std::int32_t>(local_allocator->PageCount());
+        if (alloc_count > avail) {
+            full_paged_tokens.resize(prefix_pages.size() + avail);
+            alloc_count = static_cast<std::int32_t>(full_paged_tokens.size()) -
+                          static_cast<std::int32_t>(prefix_pages.size());
+        }
         OwnedPages alloc_pages = local_allocator->TakeFirst(alloc_count);
 
         kv_prefix_cache_->Insert<ResourceType::Device>(full_paged_tokens, prefix_pages, std::move(alloc_pages),

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
@@ -376,8 +376,8 @@ std::variant<Draining, Finished> FinishEvent::apply(ForwardStateT&& state) {
         const std::int32_t avail = static_cast<std::int32_t>(local_allocator->PageCount());
         if (alloc_count > avail) {
             full_paged_tokens.resize(prefix_pages.size() + avail);
-            alloc_count = static_cast<std::int32_t>(full_paged_tokens.size()) -
-                          static_cast<std::int32_t>(prefix_pages.size());
+            alloc_count =
+                static_cast<std::int32_t>(full_paged_tokens.size()) - static_cast<std::int32_t>(prefix_pages.size());
         }
         OwnedPages alloc_pages = local_allocator->TakeFirst(alloc_count);
 

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -335,9 +335,11 @@ std::optional<fsm::ScheduleRetractEvent> Scheduler::scheduleRetract(Request* req
     std::int32_t alloc_count =
         static_cast<std::int32_t>(full_paged_tokens.size()) - static_cast<std::int32_t>(prefix_pages.size());
 
-    OwnedPages alloc_pages = request->TakeFirstPages(alloc_count);
-
-    kv_prefix_cache_.Insert<ResourceType::Device>(full_paged_tokens, prefix_pages, std::move(alloc_pages));
+    // Skip when alloc_count <= 0: a prefix deeper than total_available would make TakeFirstPages negative.
+    if (alloc_count > 0) {
+        OwnedPages alloc_pages = request->TakeFirstPages(alloc_count);
+        kv_prefix_cache_.Insert<ResourceType::Device>(full_paged_tokens, prefix_pages, std::move(alloc_pages));
+    }
 
     MatchResult match_result = kv_prefix_cache_.Match(full_paged_tokens, MatchIntent::StateRecovery);
 

--- a/tokenspeed-scheduler/tests/cpp/test_hybrid_takefirst_overflow.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_hybrid_takefirst_overflow.cpp
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 LightSeek Foundation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+
+// Regression tests for the hybrid-path "OwnedPages::TakeFirst: count out of range" crash. The
+// LocalKVAllocator is sized at schedule time, but InsertHybridCache/FinishEvent/scheduleRetract
+// recompute pages-to-insert later, so MTP/overlap growth or a prefix shrink can exceed it. Synthetic.
+
+#include <gtest/gtest.h>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "integration_test_helper.h"
+
+namespace tokenspeed::test {
+
+class HybridTakeFirstOverflowTest : public SchedulerTestSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        auto cfg = SchedulerTestSuite::MakeConfig();
+        cfg.enable_mamba = true;
+        cfg.mamba_pool_total_chunks = 16;
+        cfg.decode_input_tokens = 0;
+        cfg.page_size = 2;
+        cfg.device_allocator.total_pages = 64;  // ample, so the only possible failure is count > size
+        cfg.host_allocator.total_pages = 64;
+        cfg.enable_l3_storage = false;
+        return cfg;
+    }
+
+    void BringToDecoding(const std::string& id, std::int32_t num_pages = 1, token_t start = 1) {
+        Submit(MakeRequestSpec(id, num_pages, start));
+        PlanOnce();
+        SendForwardDone(id, {42});
+        PlanOnce();
+    }
+};
+
+// Growing the tokens past the allocator via an unscheduled extend, then finishing, must clamp not throw.
+TEST_F(HybridTakeFirstOverflowTest, FinishAfterUnscheduledExtend_ClampsInsteadOfOverflow) {
+    BringToDecoding("r1", 1, 1);
+
+    std::vector<std::int32_t> big;
+    big.reserve(60);
+    for (int i = 0; i < 60; ++i) big.push_back(1000 + i);
+    SendForwardDone("r1", big);
+
+    ASSERT_NO_THROW({
+        SendFinish("r1");
+        PlanOnce();
+    });
+}
+
+class HybridTakeFirstOverflowMitigationTest : public HybridTakeFirstOverflowTest {
+protected:
+    SchedulerConfig MakeConfig() override {
+        auto cfg = HybridTakeFirstOverflowTest::MakeConfig();
+        cfg.disable_prefix_cache = true;
+        return cfg;
+    }
+};
+
+// The guard clamps even with prefix caching off, so --no-enable-prefix-caching is not a mitigation.
+TEST_F(HybridTakeFirstOverflowMitigationTest, DisablePrefixCache_AlsoClampsCleanly) {
+    BringToDecoding("r1", 1, 1);
+
+    std::vector<std::int32_t> big;
+    big.reserve(60);
+    for (int i = 0; i < 60; ++i) big.push_back(1000 + i);
+    SendForwardDone("r1", big);
+
+    ASSERT_NO_THROW({
+        SendFinish("r1");
+        PlanOnce();
+    });
+}
+
+// After the clamped finish the engine is not wedged: r1 drains and a fresh request still schedules.
+TEST_F(HybridTakeFirstOverflowTest, FinishAfterUnscheduledExtend_ClampsAndStaysUsable) {
+    BringToDecoding("r1", 1, 1);
+
+    std::vector<std::int32_t> big;
+    big.reserve(60);
+    for (int i = 0; i < 60; ++i) big.push_back(1000 + i);
+    SendForwardDone("r1", big);
+
+    ASSERT_NO_THROW({
+        SendFinish("r1");
+        PlanOnce();
+    }) << "FinishEvent must clamp page-aligned, not throw and not relocate the "
+          "throw into KVPrefixCache::Insert TakeLast";
+
+    EXPECT_EQ(scheduler_->DecodingSize(), 0u) << "r1 should have left Decoding after finish";
+
+    Submit(MakeRequestSpec("r2", 1, 5000));
+    auto plan = PlanOnce();
+    bool r2_scheduled = false;
+    for (const auto& op : plan.Operations()) {
+        if (auto* fwd = std::get_if<FlatForwardOperation>(&op)) {
+            for (const auto& rid : fwd->request_ids) {
+                if (rid == "r2") r2_scheduled = true;
+            }
+        }
+    }
+    EXPECT_TRUE(r2_scheduled) << "engine wedged: a fresh request after the clamped finish was not scheduled";
+}
+
+class HybridRetractNegativeAllocTest : public SchedulerTestSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        auto cfg = SchedulerTestSuite::MakeConfig();
+        cfg.enable_mamba = true;
+        cfg.mamba_pool_total_chunks = 16;
+        cfg.decode_input_tokens = 0;
+        cfg.page_size = 2;
+        cfg.device_allocator.total_pages = 6;  // small, so the device exhausts and a retract is forced
+        cfg.host_allocator.total_pages = 6;
+        cfg.enable_l3_storage = false;
+        return cfg;
+    }
+
+    // Commit the device node to an exact page boundary so the prefix holds N pages while
+    // GetFullPagedTokens(true) drops the last page, leaving N-1 token pages.
+    void BringToDecodingExactPages(const std::string& id, std::int32_t num_pages, token_t start) {
+        Submit(MakeRequestSpec(id, num_pages, start));
+        PlanOnce();
+        PlanOnce();
+    }
+
+    void SendReserveNumTokens(const std::string& id, std::int32_t n) {
+        ExecutionEvent event;
+        event.With(ForwardEvent{forward::UpdateReserveNumTokens{
+            .request_id = id,
+            .reserve_num_tokens_in_next_schedule_event = n,
+        }});
+        scheduler_->Advance(std::move(event));
+    }
+};
+
+// A device prefix deeper than the tokens drives alloc_count negative; scheduleRetract must skip, not TakeFirst(<0).
+TEST_F(HybridRetractNegativeAllocTest, RetractWithDeepPrefix_NegativeAllocCount_SkipsCleanly) {
+    BringToDecodingExactPages("r1", 2, 1);
+    BringToDecodingExactPages("r2", 2, 100);
+
+    SendReserveNumTokens("r1", 4);
+    SendReserveNumTokens("r2", 4);
+
+    ASSERT_NO_THROW({ PlanOnce(); }) << "scheduleRetract must skip negative alloc_count, not call TakeFirst(<0)";
+
+    EXPECT_GE(scheduler_->RetractedSize(), 1u) << "no retract occurred — the negative-alloc path was not reached";
+}
+
+}  // namespace tokenspeed::test


### PR DESCRIPTION
The hybrid Mamba+MoE path recomputes pages-to-insert at InsertHybridCache, FinishEvent, and scheduleRetract. By insert time the LocalKVAllocator can hold fewer pages than the recomputed count, so TakeFirst throws "count out of range". Clamp page-aligned (keeping prefix + inserted == full) and skip negative alloc_count so TakeFirst can't overflow. Adds regression tests.

## Summary
- Fixes an `OwnedPages::TakeFirst: count out of range` crash on the hybrid Mamba+MoE path.
- Root cause: `InsertHybridCache`, `FinishEvent`, and `scheduleRetract` recompute pages-to-insert as `full_paged_tokens.size() - prefix_pages.size()`, but by the time `TakeFirst` runs the `LocalKVAllocator` may hold fewer pages, so the call overflows. A count-only clamp just relocates the throw into `Insert`'s `TakeLast`.
- Fix: clamp page-aligned at all three sites so `prefix + inserted == full` still holds, and skip the insert when `alloc_count <= 0`.

## Test Plan
- Adds `test_hybrid_takefirst_overflow.cpp`: clamp-stays-usable, prefix-cache-disabled, and `scheduleRetract` negative-alloc cases.
- Without the guard the repro throws `count out of range`; with it the requests clamp cleanly and the engine keeps scheduling.