### PR TITLE
Fix DeepGEMM wrapper optional symbols

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/deep_gemm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/deep_gemm/__init__.py
@@ -68,27 +68,41 @@ def _prepare_deep_gemm_cuda_home() -> None:
 
 _prepare_deep_gemm_cuda_home()
 
-from deep_gemm import (
-    ceil_div,
-    ceil_to_ue8m0,
-    fp8_einsum,
-    fp8_fp4_mega_moe,
-    fp8_fp4_mqa_logits,
-    fp8_fp4_paged_mqa_logits,
-    fp8_gemm_nt,
-    fp8_mqa_logits,
-    fp8_paged_mqa_logits,
-    get_mn_major_tma_aligned_tensor,
-    get_num_sms,
-    get_paged_mqa_logits_metadata,
-    get_symm_buffer_for_mega_moe,
-    m_grouped_fp8_gemm_nt_contiguous,
-    m_grouped_fp8_gemm_nt_masked,
-    set_num_sms,
-    tf32_hc_prenorm_gemm,
-    transform_sf_into_required_layout,
-    transform_weights_for_mega_moe,
+import deep_gemm as _deep_gemm
+
+_DEEP_GEMM_EXPORTS = (
+    "ceil_div",
+    "ceil_to_ue8m0",
+    "fp8_einsum",
+    "fp8_fp4_mega_moe",
+    "fp8_fp4_mqa_logits",
+    "fp8_fp4_paged_mqa_logits",
+    "fp8_gemm_nt",
+    "fp8_mqa_logits",
+    "fp8_paged_mqa_logits",
+    "get_mn_major_tma_aligned_tensor",
+    "get_num_sms",
+    "get_paged_mqa_logits_metadata",
+    "get_symm_buffer_for_mega_moe",
+    "m_grouped_fp8_gemm_nt_contiguous",
+    "m_grouped_fp8_gemm_nt_masked",
+    "set_num_sms",
+    "tf32_hc_prenorm_gemm",
+    "transform_sf_into_required_layout",
+    "transform_weights_for_mega_moe",
 )
+
+for _name in _DEEP_GEMM_EXPORTS:
+    if hasattr(_deep_gemm, _name):
+        globals()[_name] = getattr(_deep_gemm, _name)
+
+
+def __getattr__(name: str):
+    if name in _DEEP_GEMM_EXPORTS:
+        raise AttributeError(f"installed deep_gemm package does not provide {name!r}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 from tokenspeed_kernel.thirdparty.deep_gemm.warmup import (
     warmup_fp8_gemm_nt,
     warmup_fp8_gemm_nt_from_model,
@@ -97,24 +111,7 @@ from tokenspeed_kernel.thirdparty.deep_gemm.warmup import (
 )
 
 __all__ = [
-    "ceil_div",
-    "ceil_to_ue8m0",
-    "fp8_fp4_mega_moe",
-    "fp8_fp4_mqa_logits",
-    "fp8_fp4_paged_mqa_logits",
-    "fp8_einsum",
-    "fp8_gemm_nt",
-    "get_num_sms",
-    "get_symm_buffer_for_mega_moe",
-    "m_grouped_fp8_gemm_nt_contiguous",
-    "m_grouped_fp8_gemm_nt_masked",
-    "set_num_sms",
-    "tf32_hc_prenorm_gemm",
-    "transform_sf_into_required_layout",
-    "transform_weights_for_mega_moe",
-    "get_paged_mqa_logits_metadata",
-    "fp8_paged_mqa_logits",
-    "fp8_mqa_logits",
+    *[name for name in _DEEP_GEMM_EXPORTS if name in globals()],
     "warmup_fp8_gemm_nt",
     "warmup_fp8_gemm_nt_from_model",
     "warmup_mega_moe_jit",

--- a/tokenspeed-kernel/test/thirdparty/test_deep_gemm_wrapper.py
+++ b/tokenspeed-kernel/test/thirdparty/test_deep_gemm_wrapper.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def test_deep_gemm_wrapper_tolerates_missing_optional_symbols(monkeypatch):
+    wrapper_name = "tokenspeed_kernel.thirdparty.deep_gemm"
+    package_name = "tokenspeed_kernel.thirdparty"
+    old_wrapper = sys.modules.pop(wrapper_name, None)
+    old_package_attr = getattr(sys.modules.get(package_name), "deep_gemm", None)
+
+    fake_deep_gemm = types.ModuleType("deep_gemm")
+    fake_deep_gemm.ceil_div = object()
+    fake_deep_gemm.fp8_paged_mqa_logits = object()
+    fake_deep_gemm.get_num_sms = object()
+    monkeypatch.setitem(sys.modules, "deep_gemm", fake_deep_gemm)
+
+    try:
+        wrapper = importlib.import_module(wrapper_name)
+
+        assert wrapper.ceil_div is fake_deep_gemm.ceil_div
+        assert wrapper.fp8_paged_mqa_logits is fake_deep_gemm.fp8_paged_mqa_logits
+        assert wrapper.get_num_sms is fake_deep_gemm.get_num_sms
+        assert "fp8_einsum" not in wrapper.__all__
+        with pytest.raises(AttributeError, match="fp8_einsum"):
+            wrapper.fp8_einsum
+    finally:
+        sys.modules.pop(wrapper_name, None)
+        if old_wrapper is not None:
+            sys.modules[wrapper_name] = old_wrapper
+            package = sys.modules.get(package_name)
+            if package is not None:
+                setattr(package, "deep_gemm", old_wrapper)
+        elif old_package_attr is not None:
+            package = sys.modules.get(package_name)
+            if package is not None:
+                setattr(package, "deep_gemm", old_package_attr)


### PR DESCRIPTION
## Summary

- make the `tokenspeed_kernel.thirdparty.deep_gemm` wrapper export only symbols provided by the installed `deep_gemm` package
- keep missing optional DeepGEMM symbols as `AttributeError` instead of failing the entire wrapper import
- add a unit test covering a partial DeepGEMM install

## Why

The current wrapper imports every expected DeepGEMM symbol eagerly. When the installed `tokenspeed-deepgemm` package lacks optional symbols such as newer FP4 or einsum helpers, importing `tokenspeed_kernel.thirdparty.deep_gemm` fails entirely. That hides symbols that are actually available, including the paged MQA helpers used by GLM DSA.

This does not switch TokenSpeed to `sgl-deep-gemm`; it keeps the existing dependency boundary and makes the kernel wrapper tolerant of optional symbol drift.

## Validation

- `pre-commit run --all-files`
- `PYTHONPATH=/raid/cache/tmp/tokenspeed_kernel_release/tokenspeed-kernel/python /workspace/flamingo/tokenspeed/.venv/bin/python -m pytest tokenspeed-kernel/test/thirdparty/test_deep_gemm_wrapper.py -q`
