### PR TITLE
feat(glm-5.2): support hierarchical (host/L2) KV cache for DSA

### DIFF
--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -282,12 +282,20 @@ def _args_with_default_model_parsers(
     name to defer json_schema grammars past the reasoning channel.
     """
     model_id = _user_model_id(gateway_args) or _user_model_id(engine_args)
-    if not _is_deepseek_v4_model(model_id):
-        if not _is_glm_dsa_model(model_id):
-            return engine_args, gateway_args
+    engine_result = list(engine_args)
+    gateway_result = list(gateway_args)
 
-        engine_result = list(engine_args)
-        gateway_result = list(gateway_args)
+    if _is_deepseek_v4_model(model_id):
+        if (
+            "--reasoning-parser" not in engine_result
+            and "--reasoning-parser" not in gateway_result
+        ):
+            engine_result.extend(["--reasoning-parser", DEEPSEEK_V4_REASONING_PARSER])
+            gateway_result.extend(["--reasoning-parser", DEEPSEEK_V4_REASONING_PARSER])
+        if "--tool-call-parser" not in gateway_result:
+            gateway_result.extend(["--tool-call-parser", DEEPSEEK_V4_TOOL_CALL_PARSER])
+
+    elif _is_glm_dsa_model(model_id):
         if (
             "--reasoning-parser" not in engine_result
             and "--reasoning-parser" not in gateway_result
@@ -296,20 +304,7 @@ def _args_with_default_model_parsers(
             gateway_result.extend(["--reasoning-parser", GLM_REASONING_PARSER])
         if "--tool-call-parser" not in gateway_result:
             gateway_result.extend(["--tool-call-parser", GLM_TOOL_CALL_PARSER])
-        if "--disable-kvstore" not in engine_result:
-            engine_result.append("--disable-kvstore")
-        return engine_result, gateway_result
 
-    engine_result = list(engine_args)
-    gateway_result = list(gateway_args)
-    if (
-        "--reasoning-parser" not in engine_result
-        and "--reasoning-parser" not in gateway_result
-    ):
-        engine_result.extend(["--reasoning-parser", DEEPSEEK_V4_REASONING_PARSER])
-        gateway_result.extend(["--reasoning-parser", DEEPSEEK_V4_REASONING_PARSER])
-    if "--tool-call-parser" not in gateway_result:
-        gateway_result.extend(["--tool-call-parser", DEEPSEEK_V4_TOOL_CALL_PARSER])
     return engine_result, gateway_result
 
 

--- a/python/tokenspeed/runtime/cache/executor/memory_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/memory_executor.py
@@ -25,24 +25,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable, Optional
 
-try:
-    from tokenspeed.runtime.layers.attention.kv_cache.mha import (
-        MHATokenToKVPool as MHATokenToKVPoolPaged,
-    )
-except ImportError:
-    MHATokenToKVPoolPaged = None
-try:
-    from tokenspeed.runtime.layers.attention.kv_cache.mla import (
-        MLATokenToKVPool as MLATokenToKVPoolPaged,
-    )
-except (ImportError, AttributeError):
-    MLATokenToKVPoolPaged = None
-
 from tokenspeed_scheduler import Cache
 
 from tokenspeed.runtime.cache.executor.host_executor import HostExecutor
 from tokenspeed.runtime.cache.executor.storage_executor import StorageExecutor
 from tokenspeed.runtime.cache.kv_cache_host import (
+    DSATokenToKVPoolHost,
     MHATokenToKVPoolHost,
     MLATokenToKVPoolHost,
 )
@@ -50,6 +38,7 @@ from tokenspeed.runtime.cache.mamba_cache_host import MambaPoolHost
 from tokenspeed.runtime.cache.transfer.kv_pool import KVCachePool
 from tokenspeed.runtime.cache.transfer.mamba_pool import MambaCachePool
 from tokenspeed.runtime.cache.transfer.types import CacheKind
+from tokenspeed.runtime.layers.attention.kv_cache.dsa import DSATokenToKVPool
 from tokenspeed.runtime.layers.attention.kv_cache.mha import MHATokenToKVPool
 from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
 from tokenspeed.runtime.utils import get_colorful_logger
@@ -88,22 +77,23 @@ class MemoryExecutor:
     ):
         self.page_size = config.page_size
 
-        _mha_types = (MHATokenToKVPool,)
-        if MHATokenToKVPoolPaged is not None:
-            _mha_types = (MHATokenToKVPool, MHATokenToKVPoolPaged)
-
-        _mla_types = (MLATokenToKVPool,)
-        if MLATokenToKVPoolPaged is not None:
-            _mla_types = (MLATokenToKVPool, MLATokenToKVPoolPaged)
-
         # Unwrap LayerMappedKVPool (hybrid GDN models) to get the inner MHA pool.
         actual_pool = device_pool
         if hasattr(device_pool, "inner") and not isinstance(
-            device_pool, (*_mha_types, *_mla_types)
+            device_pool, (MHATokenToKVPool, MLATokenToKVPool)
         ):
             actual_pool = device_pool.inner
 
-        if isinstance(actual_pool, _mha_types):
+        # DSA subclasses MLA, so it must be matched before the MLA branch.
+        if isinstance(actual_pool, DSATokenToKVPool):
+            self.host_pool = DSATokenToKVPoolHost(
+                actual_pool,
+                config.host_ratio,
+                config.host_size_gb,
+                config.page_size,
+                config.host_layout,
+            )
+        elif isinstance(actual_pool, MHATokenToKVPool):
             self.host_pool = MHATokenToKVPoolHost(
                 actual_pool,
                 config.host_ratio,
@@ -111,7 +101,7 @@ class MemoryExecutor:
                 config.page_size,
                 config.host_layout,
             )
-        elif isinstance(actual_pool, _mla_types):
+        elif isinstance(actual_pool, MLATokenToKVPool):
             self.host_pool = MLATokenToKVPoolHost(
                 actual_pool,
                 config.host_ratio,
@@ -131,10 +121,19 @@ class MemoryExecutor:
         if draft_device_pool is not None:
             actual_draft_pool = draft_device_pool
             if hasattr(draft_device_pool, "inner") and not isinstance(
-                draft_device_pool, (*_mha_types, *_mla_types)
+                draft_device_pool, (MHATokenToKVPool, MLATokenToKVPool)
             ):
                 actual_draft_pool = draft_device_pool.inner
-            if isinstance(actual_draft_pool, _mha_types):
+            if isinstance(actual_draft_pool, DSATokenToKVPool):
+                self.draft_host_pool = DSATokenToKVPoolHost(
+                    actual_draft_pool,
+                    config.host_ratio,
+                    config.host_size_gb,
+                    config.page_size,
+                    config.host_layout,
+                    host_size_tokens=self.host_pool.size,
+                )
+            elif isinstance(actual_draft_pool, MHATokenToKVPool):
                 self.draft_host_pool = MHATokenToKVPoolHost(
                     actual_draft_pool,
                     config.host_ratio,
@@ -143,7 +142,7 @@ class MemoryExecutor:
                     config.host_layout,
                     host_size_tokens=self.host_pool.size,
                 )
-            elif isinstance(actual_draft_pool, _mla_types):
+            elif isinstance(actual_draft_pool, MLATokenToKVPool):
                 self.draft_host_pool = MLATokenToKVPoolHost(
                     actual_draft_pool,
                     config.host_ratio,

--- a/python/tokenspeed/runtime/cache/kv_cache_host.py
+++ b/python/tokenspeed/runtime/cache/kv_cache_host.py
@@ -34,6 +34,7 @@ import torch
 from tokenspeed_kernel.platform import current_platform
 
 from tokenspeed.runtime.layers.attention.kv_cache.base import BaseTokenToKVPool
+from tokenspeed.runtime.layers.attention.kv_cache.dsa import DSATokenToKVPool
 from tokenspeed.runtime.layers.attention.kv_cache.mha import MHATokenToKVPool
 from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
 from tokenspeed.runtime.utils import get_colorful_logger
@@ -797,3 +798,131 @@ class MLATokenToKVPoolHost(HostKVCache):
         else:
             raise ValueError(f"Unsupported layout: {self.layout}")
         return ptr_list, element_size_list
+
+
+class DSATokenToKVPoolHost(MLATokenToKVPoolHost):
+    """Host (L2) mirror of the GLM DSA KV pool.
+
+    Extends the MLA latent host pool with the DSA FP8 index-K buffer. Both buffers
+    mirror the device row layout and transfer per token. The index-K buffers are
+    in a block-split layout: each page is laid out as
+    ``[page_size * head_dim FP8 values]`` followed by ``[page_size * num_groups FP32 scales]``.
+    Hence, it requires the token indices are built as whole page-expanded blocks
+    (see host_executor.page_ids_to_token_indices); otherwise the D<->H transfer
+    would be corrupted.
+    """
+
+    device_pool: DSATokenToKVPool
+
+    def __init__(
+        self,
+        device_pool: DSATokenToKVPool,
+        host_to_device_ratio: float,
+        host_size: int,
+        page_size: int,
+        layout: str,
+        device: str = "cpu",
+        host_size_tokens: int = 0,
+    ):
+        if device_pool.quant_method == "per_token_head":
+            raise NotImplementedError(
+                "DSA KVStore does not support the per_token_head latent layout."
+            )
+        if layout != "layer_first":
+            raise NotImplementedError(
+                f"DSA KVStore supports only the layer_first host layout, got {layout}."
+            )
+        self.index_k_row_bytes = device_pool.index_k_row_bytes
+        super().__init__(
+            device_pool,
+            host_to_device_ratio,
+            host_size,
+            page_size,
+            layout,
+            device,
+            host_size_tokens=host_size_tokens,
+        )
+        self.index_k_refs = [self.index_k_buffer[i] for i in range(self.layer_num)]
+        platform = current_platform()
+        self.index_k_data_ptrs = torch.tensor(
+            [platform.device_visible_data_ptr(x) for x in self.index_k_refs],
+            dtype=torch.uint64,
+            device=self.device_pool.device,
+        )
+
+    def get_size_per_token(self):
+        return super().get_size_per_token() + self.index_k_row_bytes * self.layer_num
+
+    def init_kv_buffer(self):
+        kv_buffer = super().init_kv_buffer()
+        # Mirror the device index-K layout: page p of layer L occupies rows
+        # [p * page_size : (p + 1) * page_size], so a whole page is contiguous
+        # and the block-split FP8/scale bytes within it survive a raw page copy.
+
+        self.index_k_buffer = torch.zeros(
+            (self.layer_num, self.size, self.index_k_row_bytes),
+            dtype=torch.uint8,
+            device=self.device,
+        )
+        current_platform().register_host_tensor_for_gpu_access(self.index_k_buffer)
+        return kv_buffer
+
+    def load_to_device_per_layer(
+        self, device_pool, host_indices, device_indices, layer_id, io_backend
+    ):
+        super().load_to_device_per_layer(
+            device_pool, host_indices, device_indices, layer_id, io_backend
+        )
+        if io_backend == "kernel":
+            transfer_kv_per_layer_mla(
+                src=self.index_k_buffer[layer_id],
+                dst=device_pool.index_k_buffer[layer_id],
+                src_indices=host_indices,
+                dst_indices=device_indices,
+                item_size=self.index_k_row_bytes,
+                block_quota=MLA_KVSTORE_LOADBACK_BLOCK_QUOTA,
+            )
+        elif io_backend == "direct":
+            transfer_kv_direct(
+                src_layers=[self.index_k_buffer[layer_id]],
+                dst_layers=[device_pool.index_k_buffer[layer_id]],
+                src_indices=host_indices,
+                dst_indices=device_indices,
+                page_size=self.page_size,
+            )
+        else:
+            raise ValueError(f"Unsupported IO backend: {io_backend}")
+
+    def backup_from_device_all_layer(
+        self,
+        device_pool,
+        host_indices,
+        device_indices,
+        io_backend,
+        block_quota: Optional[int] = None,
+    ):
+        super().backup_from_device_all_layer(
+            device_pool, host_indices, device_indices, io_backend, block_quota
+        )
+        if io_backend == "kernel":
+            if block_quota is None:
+                block_quota = MLA_KVSTORE_WRITEBACK_BLOCK_QUOTA
+            transfer_kv_all_layer_mla(
+                src_layers=device_pool.index_k_data_ptrs,
+                dst_layers=self.index_k_data_ptrs,
+                src_indices=device_indices,
+                dst_indices=host_indices,
+                item_size=self.index_k_row_bytes,
+                num_layers=self.layer_num,
+                block_quota=block_quota,
+            )
+        elif io_backend == "direct":
+            transfer_kv_direct(
+                src_layers=list(device_pool.index_k_buffer),
+                dst_layers=self.index_k_refs,
+                src_indices=device_indices,
+                dst_indices=host_indices,
+                page_size=self.page_size,
+            )
+        else:
+            raise ValueError(f"Unsupported IO backend: {io_backend}")

--- a/python/tokenspeed/runtime/layers/attention/configs/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/dsa.py
@@ -35,9 +35,9 @@ _INDEX_K_SCALE_BYTES = torch._utils._element_size(torch.float32)
 
 
 def dsa_index_k_row_bytes(index_head_dim: int) -> int:
-    if index_head_dim % _INDEX_K_FP8_GROUP_SIZE != 0:
+    if index_head_dim <= 0 or index_head_dim % _INDEX_K_FP8_GROUP_SIZE != 0:
         raise ValueError(
-            f"DSA index_head_dim must be divisible by {_INDEX_K_FP8_GROUP_SIZE}, got {index_head_dim}"
+            f"DSA index_head_dim must be a positive multiple of {_INDEX_K_FP8_GROUP_SIZE}, got {index_head_dim}"
         )
     return (
         index_head_dim

--- a/python/tokenspeed/runtime/layers/attention/configs/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/dsa.py
@@ -37,8 +37,7 @@ _INDEX_K_SCALE_BYTES = torch._utils._element_size(torch.float32)
 def dsa_index_k_row_bytes(index_head_dim: int) -> int:
     if index_head_dim % _INDEX_K_FP8_GROUP_SIZE != 0:
         raise ValueError(
-            "DSA index_head_dim must be divisible by "
-            f"{_INDEX_K_FP8_GROUP_SIZE}, got {index_head_dim}"
+            f"DSA index_head_dim must be divisible by {_INDEX_K_FP8_GROUP_SIZE}, got {index_head_dim}"
         )
     return (
         index_head_dim

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
@@ -42,27 +42,20 @@ class DSATokenToKVPool(MLATokenToKVPool):
     ):
         self.index_head_dim = int(index_head_dim)
         self.index_k_row_bytes = dsa_index_k_row_bytes(self.index_head_dim)
-        self._index_k_available = self.index_k_row_bytes > 0
         super().__init__(*args, **kwargs)
+
         with self.memory_saver_adapter.region():
             self.index_k_buffer = [
-                (
-                    torch.zeros(
-                        (
-                            self.size + self.page_size,
-                            self.index_k_row_bytes,
-                        ),
-                        dtype=torch.uint8,
-                        device=self.device,
-                    )
-                    if self.index_k_row_bytes > 0
-                    else None
+                torch.zeros(
+                    (self.size + self.page_size, self.index_k_row_bytes),
+                    dtype=torch.uint8,
+                    device=self.device,
                 )
                 for _ in range(self.layer_num)
             ]
 
         self.index_k_data_ptrs = torch.tensor(
-            [buf.data_ptr() for buf in self.index_k_buffer if buf is not None],
+            [buf.data_ptr() for buf in self.index_k_buffer],
             dtype=torch.uint64,
             device=self.device,
         )
@@ -75,9 +68,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
         )
 
     def get_kv_size_bytes(self):
-        return super().get_kv_size_bytes() + _get_tensor_size_bytes(
-            [buf for buf in self.index_k_buffer if buf is not None]
-        )
+        return super().get_kv_size_bytes() + _get_tensor_size_bytes(self.index_k_buffer)
 
     def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
         super().move_kv_cache(tgt_loc, src_loc)
@@ -86,29 +77,25 @@ class DSATokenToKVPool(MLATokenToKVPool):
         tgt_loc_flat = tgt_loc.view(-1).long()
         src_loc_flat = src_loc.view(-1).long()
         for buf in self.index_k_buffer:
-            if buf is not None:
-                # Packed FP8 index-K is block-split per page, so a single
-                # token's bytes are NOT a contiguous row; move the FP8 values
-                # and FP32 scales through their block-split views instead.
-                fp8_view, scale_view = self._index_k_block_views(buf)
-                ps = self.page_size
-                tgt_page = tgt_loc_flat // ps
-                tgt_slot = tgt_loc_flat % ps
-                src_page = src_loc_flat // ps
-                src_slot = src_loc_flat % ps
-                fp8_view[tgt_page, tgt_slot] = fp8_view[src_page, src_slot]
-                scale_view[tgt_page, tgt_slot] = scale_view[src_page, src_slot]
+            # Packed FP8 index-K is block-split per page, so a single token's
+            # bytes are NOT a contiguous row; move the FP8 values and FP32
+            # scales through their block-split views instead.
+            fp8_view, scale_view = self._index_k_block_views(buf)
+            ps = self.page_size
+            tgt_page = tgt_loc_flat // ps
+            tgt_slot = tgt_loc_flat % ps
+            src_page = src_loc_flat // ps
+            src_slot = src_loc_flat % ps
+            fp8_view[tgt_page, tgt_slot] = fp8_view[src_page, src_slot]
+            scale_view[tgt_page, tgt_slot] = scale_view[src_page, src_slot]
 
     def has_index_k_buffer(self) -> bool:
-        return self._index_k_available
+        return True
 
     def get_index_k_buffer(self, layer_id: int) -> torch.Tensor:
         if self.layer_transfer_counter is not None:
             self.layer_transfer_counter.wait_until(layer_id)
-        buf = self.index_k_buffer[layer_id]
-        if buf is None or not self._index_k_available:
-            raise RuntimeError("GLM DSA FP8 index K cache is unavailable")
-        return buf
+        return self.index_k_buffer[layer_id]
 
     def set_index_k_buffer(
         self,
@@ -199,11 +186,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
         loc: torch.Tensor,
         index_k: torch.Tensor,
     ) -> None:
-        if not self._index_k_available:
-            return
         buf = self.index_k_buffer[layer_id]
-        if buf is None:
-            raise RuntimeError("DSA FP8 index K cache is unavailable")
         index_k_fp8, index_k_scale = quantize_fp8_with_scale(
             index_k,
             granularity="token_group",
@@ -226,10 +209,9 @@ class DSATokenToKVPool(MLATokenToKVPool):
         data_lens = list(data_lens)
         item_lens = list(item_lens)
         for buf in self.index_k_buffer:
-            if buf is not None:
-                data_ptrs.append(buf.data_ptr())
-                data_lens.append(buf.nbytes)
-                item_lens.append(buf[0].nbytes * self.page_size)
+            data_ptrs.append(buf.data_ptr())
+            data_lens.append(buf.nbytes)
+            item_lens.append(buf[0].nbytes * self.page_size)
         return data_ptrs, data_lens, item_lens
 
     def get_layerwise_buf_info_offsets(self, start_idx=0):
@@ -239,12 +221,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
         else:
             base_count = self.layer_num
         return [
-            layer_offsets
-            + (
-                [start_idx + base_count + layer_id]
-                if self.index_k_row_bytes > 0
-                else []
-            )
+            layer_offsets + [start_idx + base_count + layer_id]
             for layer_id, layer_offsets in enumerate(offsets)
         ]
 

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
@@ -34,10 +34,6 @@ _INDEX_K_SCALE_BYTES = torch._utils._element_size(torch.float32)
 
 
 class DSATokenToKVPool(MLATokenToKVPool):
-    # KVStore currently transfers only the base MLA KV rows. DSA also needs
-    # sparse/indexer cache rows to stay coherent with the reused KV pages.
-    supports_hierarchical_kv_cache = False
-
     def __init__(
         self,
         *args,
@@ -45,9 +41,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
         **kwargs,
     ):
         self.index_head_dim = int(index_head_dim)
-        self.index_k_row_bytes = dsa_index_k_row_bytes(
-            self.index_head_dim,
-        )
+        self.index_k_row_bytes = dsa_index_k_row_bytes(self.index_head_dim)
         self._index_k_available = self.index_k_row_bytes > 0
         super().__init__(*args, **kwargs)
         with self.memory_saver_adapter.region():
@@ -66,6 +60,12 @@ class DSATokenToKVPool(MLATokenToKVPool):
                 )
                 for _ in range(self.layer_num)
             ]
+
+        self.index_k_data_ptrs = torch.tensor(
+            [buf.data_ptr() for buf in self.index_k_buffer if buf is not None],
+            dtype=torch.uint64,
+            device=self.device,
+        )
 
     def _get_page_size_bytes(self):
         index_size_bytes = self.index_k_row_bytes

--- a/test/ci/eval/glm-5.2-nvfp4-mtp-evalscope-aime26.yaml
+++ b/test/ci/eval/glm-5.2-nvfp4-mtp-evalscope-aime26.yaml
@@ -21,7 +21,7 @@ server:
     --max-num-seqs 16
     --max-prefill-tokens 8192
     --chunked-prefill-size 8192
-    --gpu-memory-utilization 0.9
+    --gpu-memory-utilization 0.95
     --disable-cuda-graph-padding
     --trust-remote-code
     --moe-backend flashinfer_trtllm

--- a/test/runtime/cache/test_dsa_kvstore_host.py
+++ b/test/runtime/cache/test_dsa_kvstore_host.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tokenspeed.runtime.cache.kv_cache_host import DSATokenToKVPoolHost
+from tokenspeed.runtime.layers.attention.configs.dsa import dsa_index_k_row_bytes
+from tokenspeed.runtime.layers.attention.kv_cache.dsa import DSATokenToKVPool
+
+PAGE_SIZE = 64
+KV_LORA_RANK = 512
+QK_ROPE_HEAD_DIM = 64
+INDEX_HEAD_DIM = 128
+LAYER_NUM = 2
+SIZE = 2 * PAGE_SIZE
+
+cuda_only = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="DSA KVStore transfer requires CUDA"
+)
+
+
+def _make_device_pool() -> DSATokenToKVPool:
+    return DSATokenToKVPool(
+        size=SIZE,
+        dtype=torch.float8_e4m3fn,
+        model_dtype=torch.bfloat16,
+        quant_method="none",
+        kv_lora_rank=KV_LORA_RANK,
+        qk_rope_head_dim=QK_ROPE_HEAD_DIM,
+        layer_num=LAYER_NUM,
+        device="cuda",
+        enable_memory_saver=False,
+        max_batch_size=8,
+        max_context_len=256,
+        page_size=PAGE_SIZE,
+        rank=0,
+        index_head_dim=INDEX_HEAD_DIM,
+    )
+
+
+def _make_host_pool(device_pool: DSATokenToKVPool) -> DSATokenToKVPoolHost:
+    return DSATokenToKVPoolHost(
+        device_pool=device_pool,
+        host_to_device_ratio=2.0,
+        host_size=0,
+        page_size=PAGE_SIZE,
+        layout="layer_first",
+        device="cpu",
+    )
+
+
+@pytest.fixture(scope="module")
+def dsa_pools():
+    # cudaHostRegister-backed host memory is not released between pools in one
+    # process, so register a single device/host pool pair and share it.
+    device_pool = _make_device_pool()
+    host_pool = _make_host_pool(device_pool)
+    return device_pool, host_pool
+
+
+@cuda_only
+def test_dsa_host_pool_sizing_includes_index_k(dsa_pools):
+    _, host_pool = dsa_pools
+
+    row_bytes = dsa_index_k_row_bytes(INDEX_HEAD_DIM)
+    latent_bytes = (KV_LORA_RANK + QK_ROPE_HEAD_DIM) * LAYER_NUM  # uint8 store dtype
+    assert host_pool.index_k_row_bytes == row_bytes
+    assert host_pool.size_per_token == latent_bytes + row_bytes * LAYER_NUM
+    # Host index-K mirrors the device layout (layer_num, host_size, row_bytes).
+    assert host_pool.index_k_buffer.shape == (LAYER_NUM, host_pool.size, row_bytes)
+    assert host_pool.index_k_buffer.dtype == torch.uint8
+
+
+@cuda_only
+def test_dsa_host_pool_rejects_page_first_layout(dsa_pools):
+    device_pool, _ = dsa_pools
+    # The layout guard raises before any host memory is registered.
+    with pytest.raises(NotImplementedError):
+        DSATokenToKVPoolHost(
+            device_pool=device_pool,
+            host_to_device_ratio=2.0,
+            host_size=0,
+            page_size=PAGE_SIZE,
+            layout="page_first",
+            device="cpu",
+        )
+
+
+@cuda_only
+@pytest.mark.parametrize("io_backend", ["direct", "kernel"])
+def test_dsa_host_pool_roundtrip_preserves_index_k(dsa_pools, io_backend):
+    device_pool, host_pool = dsa_pools
+
+    torch.manual_seed(0)
+    # Fill latent + index-K with random bytes; byte-exact round trip proves the
+    # block-split index-K page layout survives the page-contiguous copy.
+    for layer_id in range(LAYER_NUM):
+        device_pool.kv_buffer[layer_id].copy_(
+            torch.randint(
+                0, 256, device_pool.kv_buffer[layer_id].shape, dtype=torch.uint8
+            ).cuda()
+        )
+        device_pool.index_k_buffer[layer_id].copy_(
+            torch.randint(
+                0, 256, device_pool.index_k_buffer[layer_id].shape, dtype=torch.uint8
+            ).cuda()
+        )
+
+    # Transfer device pages [1, 2] into host pages [0, 1] (skip padded page 0).
+    # The kernel backend requires CUDA indices (the cache controller moves them
+    # to device before the transfer); direct accepts them too.
+    device_indices = torch.arange(
+        PAGE_SIZE, 3 * PAGE_SIZE, dtype=torch.int64, device="cuda"
+    )
+    host_indices = torch.arange(0, 2 * PAGE_SIZE, dtype=torch.int64, device="cuda")
+
+    orig_latent = [
+        device_pool.kv_buffer[i][PAGE_SIZE : 3 * PAGE_SIZE].clone()
+        for i in range(LAYER_NUM)
+    ]
+    orig_index_k = [
+        device_pool.index_k_buffer[i][PAGE_SIZE : 3 * PAGE_SIZE].clone()
+        for i in range(LAYER_NUM)
+    ]
+
+    host_pool.backup_from_device_all_layer(
+        device_pool, host_indices, device_indices, io_backend
+    )
+    torch.cuda.synchronize()
+
+    for layer_id in range(LAYER_NUM):
+        device_pool.kv_buffer[layer_id][PAGE_SIZE : 3 * PAGE_SIZE].zero_()
+        device_pool.index_k_buffer[layer_id][PAGE_SIZE : 3 * PAGE_SIZE].zero_()
+
+    for layer_id in range(LAYER_NUM):
+        host_pool.load_to_device_per_layer(
+            device_pool, host_indices, device_indices, layer_id, io_backend
+        )
+    torch.cuda.synchronize()
+
+    for layer_id in range(LAYER_NUM):
+        assert torch.equal(
+            device_pool.kv_buffer[layer_id][PAGE_SIZE : 3 * PAGE_SIZE],
+            orig_latent[layer_id],
+        )
+        assert torch.equal(
+            device_pool.index_k_buffer[layer_id][PAGE_SIZE : 3 * PAGE_SIZE],
+            orig_index_k[layer_id],
+        )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/kvcacheio_transfer.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/kvcacheio_transfer.cu
@@ -108,14 +108,15 @@ inline void copy_token_span(
   copy_async_bytes(dst_ptr, src_ptr, copy_bytes, stream);
 }
 
+template <typename PackType>
 __device__ __forceinline__ void transfer_item_warp(
     int32_t lane_id,
     const void* src_addr,
     void* dst_addr,
     int64_t item_size_bytes) {
-  const uint64_t* __restrict__ src = static_cast<const uint64_t*>(src_addr);
-  uint64_t* __restrict__ dst = static_cast<uint64_t*>(dst_addr);
-  const int total_chunks = static_cast<int>(item_size_bytes / sizeof(uint64_t));
+  const PackType* __restrict__ src = static_cast<const PackType*>(src_addr);
+  PackType* __restrict__ dst = static_cast<PackType*>(dst_addr);
+  const int total_chunks = static_cast<int>(item_size_bytes / sizeof(PackType));
 
 #pragma unroll
   for (int j = lane_id; j < total_chunks; j += WARP_SIZE) {
@@ -203,7 +204,7 @@ __device__ __forceinline__ T* get_global_offset_ph(
          layer_id * item_size_bytes / head_num;                // layer_num dimension offset
 }
 
-template <auto SrcOffsetFn, auto DstOffsetFn>
+template <auto SrcOffsetFn, auto DstOffsetFn, typename PackType>
 __global__ void transfer_page_head_kernel_impl(
     const void* __restrict__ src_k,
     void* __restrict__ dst_k,
@@ -259,7 +260,7 @@ __global__ void transfer_page_head_kernel_impl(
             head_id,
             head_num,
             page_size);
-        transfer_item_warp(lane_id, src_k_ptr, dst_k_ptr, head_size_bytes);
+        transfer_item_warp<PackType>(lane_id, src_k_ptr, dst_k_ptr, head_size_bytes);
 
         const char* src_v_ptr = SrcOffsetFn(
             static_cast<const char*>(src_v),
@@ -281,13 +282,13 @@ __global__ void transfer_page_head_kernel_impl(
             head_id,
             head_num,
             page_size);
-        transfer_item_warp(lane_id, src_v_ptr, dst_v_ptr, head_size_bytes);
+        transfer_item_warp<PackType>(lane_id, src_v_ptr, dst_v_ptr, head_size_bytes);
       }
     }
   }
 }
 
-template <auto SrcOffsetFn, auto DstOffsetFn, bool IsMLA>
+template <auto SrcOffsetFn, auto DstOffsetFn, bool IsMLA, typename PackType>
 __global__ void transfer_kernel_impl(
     const void* __restrict__ src_k,
     void* __restrict__ dst_k,
@@ -323,14 +324,14 @@ __global__ void transfer_kernel_impl(
           static_cast<const char*>(src_k), src_k_layer_tbl, layer_id, src_layout_dim, src_page_id, item_size_bytes);
       char* dst_ptr = DstOffsetFn(
           static_cast<char*>(dst_k), dst_k_layer_tbl, layer_id, dst_layout_dim, dst_page_id, item_size_bytes);
-      transfer_item_warp(lane_id, src_ptr, dst_ptr, item_size_bytes);
+      transfer_item_warp<PackType>(lane_id, src_ptr, dst_ptr, item_size_bytes);
 
       if constexpr (!IsMLA) {
         const char* src_v_ptr = SrcOffsetFn(
             static_cast<const char*>(src_v), src_v_layer_tbl, layer_id, src_layout_dim, src_page_id, item_size_bytes);
         char* dst_v_ptr = DstOffsetFn(
             static_cast<char*>(dst_v), dst_v_layer_tbl, layer_id, dst_layout_dim, dst_page_id, item_size_bytes);
-        transfer_item_warp(lane_id, src_v_ptr, dst_v_ptr, item_size_bytes);
+        transfer_item_warp<PackType>(lane_id, src_v_ptr, dst_v_ptr, item_size_bytes);
       }
     }
   }
@@ -358,7 +359,8 @@ void transfer_kv_launcher(
     int64_t page_size = 16,
     int64_t head_num = 1) {
   check_indices(src_indices, dst_indices);
-  TVM_FFI_ICHECK_EQ(item_size % 8, 0) << "Item byte size must be divisible by 8";
+  const int64_t copy_granularity = PageHeadLayout ? (item_size / head_num) : item_size;
+  TVM_FFI_ICHECK_EQ(copy_granularity % 4, 0) << "Item copy granularity must be divisible by 4";
   TVM_FFI_ICHECK_GT(block_quota, 0);
   TVM_FFI_ICHECK_GT(num_warps_per_block, 0);
 
@@ -373,46 +375,57 @@ void transfer_kv_launcher(
   const dim3 grid_dim(num_blocks, 1, 1);
 
   const cudaStream_t stream = get_current_stream();
-  if constexpr (PageHeadLayout) {
-    transfer_page_head_kernel_impl<SrcOffsetFn, DstOffsetFn><<<grid_dim, threads_per_block, 0, stream>>>(
-        src_k,
-        dst_k,
-        src_v,
-        dst_v,
-        static_cast<const int64_t*>(src_indices.data_ptr()),
-        static_cast<const int64_t*>(dst_indices.data_ptr()),
-        start_layer_id,
-        num_layers_to_process,
-        num_items,
-        items_per_warp,
-        item_size,
-        src_layout_dim,
-        dst_layout_dim,
-        src_k_layers,
-        dst_k_layers,
-        src_v_layers,
-        dst_v_layers,
-        page_size,
-        head_num);
+  auto launch = [&](auto pack_tag) {
+    using PackType = decltype(pack_tag);
+    if constexpr (PageHeadLayout) {
+      transfer_page_head_kernel_impl<SrcOffsetFn, DstOffsetFn, PackType><<<grid_dim, threads_per_block, 0, stream>>>(
+          src_k,
+          dst_k,
+          src_v,
+          dst_v,
+          static_cast<const int64_t*>(src_indices.data_ptr()),
+          static_cast<const int64_t*>(dst_indices.data_ptr()),
+          start_layer_id,
+          num_layers_to_process,
+          num_items,
+          items_per_warp,
+          item_size,
+          src_layout_dim,
+          dst_layout_dim,
+          src_k_layers,
+          dst_k_layers,
+          src_v_layers,
+          dst_v_layers,
+          page_size,
+          head_num);
+    } else {
+      transfer_kernel_impl<SrcOffsetFn, DstOffsetFn, IsMLA, PackType><<<grid_dim, threads_per_block, 0, stream>>>(
+          src_k,
+          dst_k,
+          src_v,
+          dst_v,
+          static_cast<const int64_t*>(src_indices.data_ptr()),
+          static_cast<const int64_t*>(dst_indices.data_ptr()),
+          start_layer_id,
+          num_layers_to_process,
+          num_items,
+          items_per_warp,
+          item_size,
+          src_layout_dim,
+          dst_layout_dim,
+          src_k_layers,
+          dst_k_layers,
+          src_v_layers,
+          dst_v_layers);
+    }
+  };
+
+  if (copy_granularity % 16 == 0) {
+    launch(uint4{});
+  } else if (copy_granularity % 8 == 0) {
+    launch(uint64_t{});
   } else {
-    transfer_kernel_impl<SrcOffsetFn, DstOffsetFn, IsMLA><<<grid_dim, threads_per_block, 0, stream>>>(
-        src_k,
-        dst_k,
-        src_v,
-        dst_v,
-        static_cast<const int64_t*>(src_indices.data_ptr()),
-        static_cast<const int64_t*>(dst_indices.data_ptr()),
-        start_layer_id,
-        num_layers_to_process,
-        num_items,
-        items_per_warp,
-        item_size,
-        src_layout_dim,
-        dst_layout_dim,
-        src_k_layers,
-        dst_k_layers,
-        src_v_layers,
-        dst_v_layers);
+    launch(uint32_t{});
   }
 
   check_cuda(cudaGetLastError(), "transfer_kv kernel launch failed");


### PR DESCRIPTION
## Summary

This PR enables writeback→loadback of the DSA KV cache to host memory so GLM-5.2 can
offload evicted prefixes and reload them on cache hits — previously unsupported
because the DSA pool carries an extra block-split `index_k` buffer.

### What changed
- **Host pool** (`kv_cache_host.py`): new `DSATokenToKVPoolHost` mirroring both the
  MLA latent and the FP8 `index_k` buffer; transfers both under one page-aligned
  index mapping. `direct` and `kernel` IO backends, `layer_first` layout.
- **Transfer kernel** (`kvcacheio_transfer.cu`): templated the warp copy on a
  `PackType` word and dispatch 16/8/**4**-byte by `item_size` alignment. The 8-byte
  path is unchanged; the new 4-byte path lets the `index_k` row (`head_dim + scale`,
  not a multiple of 8) transfer per-token via the `kernel` backend.
- **Dispatch** (`memory_executor.py`): route `DSATokenToKVPool` to the DSA host pool
  **before** the MLA branch (DSA subclasses MLA); base + draft paths.
- **Device pool** (`kv_cache/dsa.py`): add `index_k_data_ptrs` for the all-layer
  backup kernel; flip `supports_hierarchical_kv_cache = True`; remove now-dead
  `index_k` `None`-guards (`dsa_index_k_row_bytes` now rejects non-positive
  `index_head_dim`, guaranteeing the buffers are always allocated).
- **smg gateway** (`serve_smg.py`): remove the stale `--disable-kvstore`
  auto-inject for GLM DSA models (a stopgap from when DSA lacked hierarchical
  support).
