### PR TITLE
[GLM] perf: Optimize GLM DSA decode top-k

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/deep_gemm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/deep_gemm/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import torch
 from tokenspeed_kernel.ops.attention.flashinfer.dsa_topk import (
     deterministic_decode_topk,
-    has_deterministic_decode_topk,
+    has_ragged_decode_topk,
 )
 from tokenspeed_kernel.ops.attention.triton.dsa_sparse_layout import (
     local_topk_to_global_slots,
@@ -18,6 +18,7 @@ from tokenspeed_kernel.registry import Priority, register_kernel
 from tokenspeed_kernel.signature import dense_tensor_format, format_signature
 
 platform = current_platform()
+_PERSISTENT_TOPK_WORKSPACE_BYTES = 1024 * 1024
 
 
 def _check_out(
@@ -217,10 +218,26 @@ if platform.is_nvidia:
         logits.nan_to_num_(
             nan=float("-inf"), posinf=float("-inf"), neginf=float("-inf")
         )
-        col_ids = torch.arange(logits.shape[1], dtype=torch.int32, device=q.device)
-        logits.masked_fill_(col_ids.view(1, -1) >= seq_lens.view(-1, 1), float("-inf"))
         local_topk_offsets = torch.empty_like(out)
-        deterministic_decode_topk(logits, local_topk_offsets, int(topk))
+        if has_ragged_decode_topk():
+            deterministic_decode_topk(
+                logits,
+                local_topk_offsets,
+                int(topk),
+                lengths=seq_lens,
+                workspace=torch.empty(
+                    (_PERSISTENT_TOPK_WORKSPACE_BYTES,),
+                    dtype=torch.uint8,
+                    device=q.device,
+                ),
+                max_seq_len=max_seq_len,
+            )
+        else:
+            col_ids = torch.arange(logits.shape[1], dtype=torch.int32, device=q.device)
+            logits.masked_fill_(
+                col_ids.view(1, -1) >= seq_lens.view(-1, 1), float("-inf")
+            )
+            deterministic_decode_topk(logits, local_topk_offsets, int(topk))
         return local_topk_to_global_slots(
             local_topk_offsets=local_topk_offsets,
             block_table=block_table,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flashinfer/dsa_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flashinfer/dsa_topk.py
@@ -33,6 +33,10 @@ output order become deterministic).
 from __future__ import annotations
 
 import torch
+from tokenspeed_kernel.ops.attention.cuda.deepseek_v4 import (
+    has_persistent_topk,
+    persistent_topk,
+)
 from tokenspeed_kernel.platform import current_platform
 
 platform = current_platform()
@@ -48,24 +52,47 @@ if platform.is_nvidia:
 
 
 def has_deterministic_decode_topk() -> bool:
-    """Whether the flashinfer deterministic top-k path is importable."""
+    """Whether the flashinfer deterministic top-k fallback is importable."""
     return top_k is not None and TopKTieBreak is not None
+
+
+def has_ragged_decode_topk() -> bool:
+    """Whether the length-aware CUDA top-k path is importable."""
+    return has_persistent_topk()
 
 
 def deterministic_decode_topk(
     logits: torch.Tensor,
     out: torch.Tensor,
     topk: int,
+    *,
+    lengths: torch.Tensor | None = None,
+    workspace: torch.Tensor | None = None,
+    max_seq_len: int | None = None,
 ) -> None:
     """Select per-row top-``topk`` local offsets deterministically.
 
-    ``logits`` rows are pre-masked with ``-inf`` beyond each request's valid
-    length (so a global per-row top-``topk`` yields the in-sequence candidates).
-    Writes int32 local offsets into ``out`` in-place. Uses a stable
-    ``tie_break=SMALL`` (smallest index wins ties) and ``deterministic`` +
-    ``dsa_graph_safe`` so eager and CUDA-graph replay agree.
+    When ``lengths`` and ``workspace`` are provided, use the ragged CUDA top-k
+    path so padded logits beyond each row's valid context are not scanned. This
+    path delegates tie handling to the persistent top-k kernel. Otherwise,
+    ``logits`` rows must already be pre-masked with ``-inf`` beyond each
+    request's valid length, and the flashinfer fallback uses a stable
+    ``tie_break=SMALL`` plus ``deterministic`` + ``dsa_graph_safe``.
     """
-    if not has_deterministic_decode_topk():
+    if lengths is not None or workspace is not None:
+        if lengths is None or workspace is None or not has_ragged_decode_topk():
+            raise RuntimeError("length-aware DSA decode top-k is unavailable.")
+        persistent_topk(
+            logits.contiguous(),
+            lengths.to(torch.int32).contiguous().reshape(-1),
+            out,
+            workspace,
+            int(topk),
+            int(max_seq_len or logits.shape[1]),
+        )
+        return
+
+    if top_k is None or TopKTieBreak is None:
         raise RuntimeError("flashinfer deterministic top_k is unavailable.")
     _values, indices = top_k(
         logits.contiguous(),

--- a/tokenspeed-kernel/test/ops/test_dsa_topk.py
+++ b/tokenspeed-kernel/test/ops/test_dsa_topk.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from tokenspeed_kernel.ops.attention.flashinfer import dsa_topk
+
+
+def test_decode_topk_uses_ragged_path_when_lengths_and_workspace_are_provided(
+    monkeypatch,
+):
+    calls = {}
+
+    monkeypatch.setattr(dsa_topk, "has_persistent_topk", lambda: True)
+
+    def fake_persistent_topk(logits, lengths, output, workspace, k, max_seq_len):
+        calls["logits"] = logits
+        calls["lengths"] = lengths
+        calls["workspace"] = workspace
+        calls["k"] = k
+        calls["max_seq_len"] = max_seq_len
+        output.fill_(7)
+
+    monkeypatch.setattr(dsa_topk, "persistent_topk", fake_persistent_topk)
+
+    logits = torch.randn(2, 8, dtype=torch.float32)
+    lengths = torch.tensor([[3], [6]], dtype=torch.int64)
+    output = torch.empty(2, 4, dtype=torch.int32)
+    workspace = torch.empty(32, dtype=torch.uint8)
+
+    dsa_topk.deterministic_decode_topk(
+        logits,
+        output,
+        4,
+        lengths=lengths,
+        workspace=workspace,
+        max_seq_len=8,
+    )
+
+    assert torch.equal(output, torch.full_like(output, 7))
+    assert calls["logits"].is_contiguous()
+    assert torch.equal(calls["lengths"], torch.tensor([3, 6], dtype=torch.int32))
+    assert calls["workspace"] is workspace
+    assert calls["k"] == 4
+    assert calls["max_seq_len"] == 8
+
+
+def test_decode_topk_rejects_partial_or_unavailable_ragged_inputs(monkeypatch):
+    monkeypatch.setattr(dsa_topk, "has_persistent_topk", lambda: False)
+
+    logits = torch.randn(2, 8, dtype=torch.float32)
+    output = torch.empty(2, 4, dtype=torch.int32)
+    lengths = torch.tensor([3, 6], dtype=torch.int32)
+    workspace = torch.empty(32, dtype=torch.uint8)
+
+    with pytest.raises(RuntimeError, match="length-aware"):
+        dsa_topk.deterministic_decode_topk(
+            logits,
+            output,
+            4,
+            lengths=lengths,
+            workspace=workspace,
+            max_seq_len=8,
+        )
+
+    monkeypatch.setattr(dsa_topk, "has_persistent_topk", lambda: True)
+    with pytest.raises(RuntimeError, match="length-aware"):
+        dsa_topk.deterministic_decode_topk(
+            logits,
+            output,
+            4,
+            lengths=lengths,
+            workspace=None,
+            max_seq_len=8,
+        )
+
+
+def test_decode_topk_falls_back_to_flashinfer_deterministic_topk(monkeypatch):
+    calls = {}
+    indices = torch.tensor([[1, 0, 3], [2, 4, 1]], dtype=torch.int64)
+
+    def fake_top_k(logits, k, *, deterministic, tie_break, dsa_graph_safe):
+        calls["logits"] = logits
+        calls["k"] = k
+        calls["deterministic"] = deterministic
+        calls["tie_break"] = tie_break
+        calls["dsa_graph_safe"] = dsa_graph_safe
+        return None, indices
+
+    monkeypatch.setattr(dsa_topk, "top_k", fake_top_k)
+    monkeypatch.setattr(dsa_topk, "TopKTieBreak", SimpleNamespace(SMALL="small"))
+
+    logits = torch.randn(2, 8, dtype=torch.float32)
+    output = torch.empty(2, 3, dtype=torch.int32)
+
+    dsa_topk.deterministic_decode_topk(logits, output, 3)
+
+    assert torch.equal(output, indices.to(torch.int32))
+    assert calls["logits"].is_contiguous()
+    assert calls["k"] == 3
+    assert calls["deterministic"] is True
+    assert calls["tie_break"] == "small"
+    assert calls["dsa_graph_safe"] is True


### PR DESCRIPTION
## Summary

- Add a length-aware DSA decode top-k path to the existing FlashInfer wrapper by dispatching to the DeepSeek V4 persistent top-k kernel when `lengths` and `workspace` are provided.
- Use that ragged path from the DeepGEMM DSA decode backend when available, so decode top-k scans only the real visible context instead of masking and scanning the full padded graph/block-table width.
- Keep the existing mask + FlashInfer deterministic top-k fallback for environments without the persistent top-k kernel.
- Add focused wrapper tests for ragged dispatch, unavailable/partial ragged inputs, and the deterministic fallback path.

## Why

GLM DSA decode on batch-size CUDA graphs can have a large static block-table capacity. The old DeepGEMM backend materialized logits to that full width, then masked padded columns and ran global top-k over all columns. For short/medium prompts inside a large graph capture, that makes top-k pay for mostly padding.

The ragged persistent top-k path takes per-row `seq_lens`, so padded columns do not need to be masked or scanned. The model layer stays on the generic `dsa_decode_topk` API; the optimization lives behind the `tokenspeed-kernel` boundary.

## Local Performance

On our local GLM5.1 NVFP4 TP4 ShareGPT run with the first 128 prompts and concurrency 16:

- Dataset: `/raid/cache/datasets/ShareGPT_V3_unfiltered_cleaned_split.json`, sha256 `35f0e213ce091ed9b9af2a1f0755e9d39f9ccec34ab281cd4ca60d70f6479ba4`.
- Workload shape matched the repro: `#Input tokens: 42015`, `#Output tokens: 32768`.
- Each run completed cleanly: `128/128` successful, `0` failed.

| Run | Output tok/s | Duration | Generated tokens | Mean TTFT | Mean TPOT |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1 | `610.56` | `53.35s` | `32573` | `559.34 ms` | `23.69 ms` |
| 2 | `657.18` | `49.62s` | `32609` | `447.66 ms` | `22.20 ms` |
| 3 | `658.33` | `49.45s` | `32554` | `447.93 ms` | `22.26 ms` |

The three-run mean is `642.02 tok/s`; excluding the fresh-server first run, the steady-state mean is `657.76 tok/s`. Compared with the pre-change local baseline of about `523 tok/s`, this is roughly `+23%` on the full three-run mean and `+26%` on the steady-state mean.

In the CUDA profile from the same optimization pass, the old padded FlashInfer top-k hot section cost about `0.1378 ms/call`; the new ragged top-k path was about `0.0084 ms/call` for the same hot section, roughly a `16x` reduction there.

This is intended as a practical TS-side speedup for the GLM DSA decode path, without carrying the previous CUDA-graph context-length specialization into the model layer.

## Validation

- `pre-commit run --all-files`
- `pytest -q tokenspeed-kernel/test/ops/test_dsa_topk.py`
- `PYTHONPATH=/workspace/flamingo/tokenspeed/python:/workspace/flamingo/tokenspeed/tokenspeed-kernel/python CUDA_VISIBLE_DEVICES=0 pytest -q test/runtime/test_deepseek_v4_attention_ops.py -k persistent_topk`
- Local CUDA sanity from the same ragged top-k change: valid selected sets matched the old masked FlashInfer path.

## Notes

- The ragged path delegates tie handling to the persistent top-k kernel. The fallback path still uses FlashInfer deterministic `tie_break=SMALL`.
- This PR intentionally avoids model-layer graph/context specialization; it keeps graph selection unchanged and only optimizes the backend top-k implementation.
