### PR TITLE
Fix DP cache sizing

### DIFF
--- a/python/tokenspeed/runtime/cache/executor/memory_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/memory_executor.py
@@ -33,6 +33,7 @@ from tokenspeed.runtime.cache.kv_cache_host import (
     DSATokenToKVPoolHost,
     MHATokenToKVPoolHost,
     MLATokenToKVPoolHost,
+    get_available_host_memory_bytes,
 )
 from tokenspeed.runtime.cache.mamba_cache_host import MambaPoolHost
 from tokenspeed.runtime.cache.transfer.kv_pool import KVCachePool
@@ -52,6 +53,8 @@ class MemoryExecutorConfig:
     page_size: int = 64
     host_ratio: float = 2.0
     host_size_gb: int = 0
+    host_parallel_count: int = 1
+    host_reserve_gb: float = 10.0
     io_backend: str = "kernel"
     host_layout: str = "layer_first"
     storage_backend: Optional[str] = "mooncake"
@@ -61,6 +64,51 @@ class MemoryExecutorConfig:
     mamba_l2_host_slots: int = 0
     mamba_l2_layout: str = "layer_first"
     mamba_l2_io_backend: str = "kernel"
+
+
+def _aligned_token_count(size: int, page_size: int) -> int:
+    return (size // page_size + 1) * page_size
+
+
+def _pool_size_per_token(pool) -> int:
+    dtype_size = pool.store_dtype.itemsize
+    if isinstance(pool, DSATokenToKVPool):
+        latent_size = (
+            (pool.kv_lora_rank + pool.qk_rope_head_dim) * dtype_size * pool.layer_num
+        )
+        return latent_size + pool.index_k_row_bytes * pool.layer_num
+    if isinstance(pool, MHATokenToKVPool):
+        return pool.head_dim * pool.head_num * pool.layer_num * dtype_size * 2
+    if isinstance(pool, MLATokenToKVPool):
+        return (pool.kv_lora_rank + pool.qk_rope_head_dim) * dtype_size * pool.layer_num
+    raise ValueError(f"Unsupported KV pool type for host budget: {type(pool)}")
+
+
+def _auto_capped_host_size_tokens(
+    *,
+    requested_tokens: int,
+    page_size: int,
+    size_per_token: int,
+    available_host_memory_bytes: int,
+    host_parallel_count: int,
+) -> int:
+    """Return a HostKVCache host_size_tokens override, or 0 when no cap is needed."""
+
+    aligned_requested_tokens = _aligned_token_count(requested_tokens, page_size)
+    requested_bytes = aligned_requested_tokens * size_per_token
+    per_rank_budget = available_host_memory_bytes // max(host_parallel_count, 1)
+    if requested_bytes <= per_rank_budget:
+        return 0
+
+    budget_tokens = per_rank_budget // max(size_per_token, 1)
+    max_aligned_tokens = (budget_tokens // page_size) * page_size
+    if max_aligned_tokens <= page_size:
+        raise ValueError(
+            "Not enough host memory available for KVStore after cgroup-aware "
+            f"budgeting: per-rank budget={per_rank_budget / 1e9:.2f} GB, "
+            f"size_per_token={size_per_token}."
+        )
+    return max_aligned_tokens - page_size
 
 
 class MemoryExecutor:
@@ -76,13 +124,68 @@ class MemoryExecutor:
         mamba_pool=None,
     ):
         self.page_size = config.page_size
+        kv_pool_types = (DSATokenToKVPool, MHATokenToKVPool, MLATokenToKVPool)
 
         # Unwrap LayerMappedKVPool (hybrid GDN models) to get the inner MHA pool.
         actual_pool = device_pool
-        if hasattr(device_pool, "inner") and not isinstance(
-            device_pool, (MHATokenToKVPool, MLATokenToKVPool)
-        ):
+        if hasattr(device_pool, "inner") and not isinstance(device_pool, kv_pool_types):
             actual_pool = device_pool.inner
+
+        actual_draft_pool = None
+        if draft_device_pool is not None:
+            actual_draft_pool = draft_device_pool
+            if hasattr(draft_device_pool, "inner") and not isinstance(
+                draft_device_pool, kv_pool_types
+            ):
+                actual_draft_pool = draft_device_pool.inner
+            if not isinstance(actual_draft_pool, kv_pool_types):
+                raise ValueError(
+                    f"draft_device_pool only supports DSA, MHA and MLA, "
+                    f"got {type(actual_draft_pool)}"
+                )
+
+        host_size_tokens = 0
+        if config.host_size_gb == 0:
+            target_size_per_token = _pool_size_per_token(actual_pool)
+            draft_size_per_token = (
+                _pool_size_per_token(actual_draft_pool)
+                if actual_draft_pool is not None
+                else 0
+            )
+            combined_size_per_token = target_size_per_token + draft_size_per_token
+            reserve_bytes = int(config.host_reserve_gb * (1024**3))
+            available_bytes, _, cgroup_available = get_available_host_memory_bytes(
+                reserve_bytes
+            )
+            requested_tokens = int(actual_pool.size * config.host_ratio)
+            host_size_tokens = _auto_capped_host_size_tokens(
+                requested_tokens=requested_tokens,
+                page_size=config.page_size,
+                size_per_token=combined_size_per_token,
+                available_host_memory_bytes=available_bytes,
+                host_parallel_count=config.host_parallel_count,
+            )
+            if host_size_tokens > 0:
+                capped_tokens = _aligned_token_count(host_size_tokens, config.page_size)
+                requested_tokens_aligned = _aligned_token_count(
+                    requested_tokens, config.page_size
+                )
+                logger.warning(
+                    "Capping KVStore host pool for cgroup budget: "
+                    "tokens %s -> %s, total bytes %.2f GB -> %.2f GB "
+                    "(parallel_count=%s, available=%.2f GB, cgroup_available=%s)",
+                    requested_tokens_aligned,
+                    capped_tokens,
+                    requested_tokens_aligned * combined_size_per_token / 1e9,
+                    capped_tokens * combined_size_per_token / 1e9,
+                    config.host_parallel_count,
+                    available_bytes / 1e9,
+                    (
+                        f"{cgroup_available / 1e9:.2f} GB"
+                        if cgroup_available is not None
+                        else "unlimited"
+                    ),
+                )
 
         # DSA subclasses MLA, so it must be matched before the MLA branch.
         if isinstance(actual_pool, DSATokenToKVPool):
@@ -92,6 +195,7 @@ class MemoryExecutor:
                 config.host_size_gb,
                 config.page_size,
                 config.host_layout,
+                host_size_tokens=host_size_tokens,
             )
         elif isinstance(actual_pool, MHATokenToKVPool):
             self.host_pool = MHATokenToKVPoolHost(
@@ -100,6 +204,7 @@ class MemoryExecutor:
                 config.host_size_gb,
                 config.page_size,
                 config.host_layout,
+                host_size_tokens=host_size_tokens,
             )
         elif isinstance(actual_pool, MLATokenToKVPool):
             self.host_pool = MLATokenToKVPoolHost(
@@ -108,22 +213,18 @@ class MemoryExecutor:
                 config.host_size_gb,
                 config.page_size,
                 config.host_layout,
+                host_size_tokens=host_size_tokens,
             )
         else:
             raise ValueError(
-                f"host_pool only supports MHA and MLA, got {type(actual_pool)} "
+                f"host_pool only supports DSA, MHA and MLA, got {type(actual_pool)} "
                 f"from module {type(actual_pool).__module__}"
             )
 
         # Draft model L2 cache: draft shares the same page mapping as the base
         # model, so its host pool must hold exactly the same number of tokens.
         # Pass host_size_tokens directly to bypass ratio/GB recalculation.
-        if draft_device_pool is not None:
-            actual_draft_pool = draft_device_pool
-            if hasattr(draft_device_pool, "inner") and not isinstance(
-                draft_device_pool, (MHATokenToKVPool, MLATokenToKVPool)
-            ):
-                actual_draft_pool = draft_device_pool.inner
+        if actual_draft_pool is not None:
             if isinstance(actual_draft_pool, DSATokenToKVPool):
                 self.draft_host_pool = DSATokenToKVPoolHost(
                     actual_draft_pool,
@@ -153,7 +254,7 @@ class MemoryExecutor:
                 )
             else:
                 raise ValueError(
-                    f"draft_device_pool only supports MHA and MLA, "
+                    f"draft_device_pool only supports DSA, MHA and MLA, "
                     f"got {type(actual_draft_pool)}"
                 )
             draft_host_bytes = (

--- a/python/tokenspeed/runtime/cache/kv_cache_host.py
+++ b/python/tokenspeed/runtime/cache/kv_cache_host.py
@@ -27,6 +27,7 @@
 import abc
 import threading
 from functools import wraps
+from pathlib import Path
 from typing import Optional
 
 import psutil
@@ -67,6 +68,55 @@ if _platform.is_amd:
 
 MLA_KVSTORE_LOADBACK_BLOCK_QUOTA = 16
 MLA_KVSTORE_WRITEBACK_BLOCK_QUOTA = 16
+
+
+def _read_cgroup_memory_value(path: Path) -> int | None:
+    try:
+        raw = path.read_text().strip()
+    except OSError:
+        return None
+    if not raw or raw == "max":
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    if value <= 0 or value >= (1 << 60):
+        return None
+    return value
+
+
+def get_cgroup_memory_limit_and_current() -> tuple[int, int] | None:
+    """Return the active cgroup memory limit/current bytes, if constrained."""
+
+    limit = _read_cgroup_memory_value(Path("/sys/fs/cgroup/memory.max"))
+    current = _read_cgroup_memory_value(Path("/sys/fs/cgroup/memory.current"))
+    if limit is None or current is None:
+        limit = _read_cgroup_memory_value(
+            Path("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+        )
+        current = _read_cgroup_memory_value(
+            Path("/sys/fs/cgroup/memory/memory.usage_in_bytes")
+        )
+    if limit is None or current is None:
+        return None
+    host_total = psutil.virtual_memory().total
+    if limit >= host_total:
+        return None
+    return limit, current
+
+
+def get_available_host_memory_bytes(
+    reserve_bytes: int,
+) -> tuple[int, int, int | None]:
+    host_available = max(psutil.virtual_memory().available - reserve_bytes, 0)
+    cgroup_available = None
+    cgroup_info = get_cgroup_memory_limit_and_current()
+    if cgroup_info is not None:
+        limit, current = cgroup_info
+        cgroup_available = max(limit - current - reserve_bytes, 0)
+        return min(host_available, cgroup_available), host_available, cgroup_available
+    return host_available, host_available, None
 
 
 def synchronized(func):
@@ -115,11 +165,12 @@ class HostKVCache(abc.ABC):
             )
 
         # Verify there is enough available host memory.
-        host_mem = psutil.virtual_memory()
         requested_bytes = self.size * self.size_per_token
         # preserve at least 10GB for other usage
         ten_gb = 10 * (1024**3)
-        available_bytes = host_mem.available - ten_gb
+        available_bytes, host_available, cgroup_available = (
+            get_available_host_memory_bytes(ten_gb)
+        )
         if requested_bytes > available_bytes:
             raise ValueError(
                 f"Not enough host memory available. Requesting "
@@ -135,8 +186,13 @@ class HostKVCache(abc.ABC):
                 self.size_per_token,
                 host_to_device_ratio,
                 device_pool.size,
-                host_mem.available,
+                host_available,
             )
+            if cgroup_available is not None:
+                logger.info(
+                    "KVStore cgroup-aware available host memory: %.2f GB",
+                    cgroup_available / 1e9,
+                )
 
         self.kv_buffer = self.init_kv_buffer()
 

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -199,10 +199,17 @@ class EventLoop:
             text_config is not None and hasattr(text_config, "mamba2_cache_params")
         )
 
+        mapping = server_args.mapping
+        # The C++ scheduler's req_pool_idx range is rank-local and 1-based:
+        # real rows are 1..max_batch_size, row 0 is reserved, and CUDA graph
+        # padding needs one non-real sink row after the scheduler-owned range.
+        per_rank_max_batch = server_args.max_num_seqs // max(mapping.attn.dp_size, 1)
+        req_pool_padding_index = per_rank_max_batch + 1
+
         model_executor_config = ModelExecutorConfig.from_server_args(
             server_args=server_args,
             model_config=self.model_config,
-            max_req_pool_size=server_args.max_num_seqs,
+            max_req_pool_size=req_pool_padding_index,
             gpu_id=gpu_id,
             global_rank=global_rank,
             num_total_pages=num_total_pages,
@@ -222,7 +229,6 @@ class EventLoop:
         # Reserve one token slot because request validation uses a strict
         # ``< max_req_len`` check against the model context length.
         self.max_req_input_len = self.model_config.context_len - 1
-        mapping = server_args.mapping
         self.attn_tp_size = server_args.attn_tp_size or mapping.attn.tp_size
         self.world_size = server_args.world_size or mapping.world_size
         self.attn_tp_rank = attn_tp_rank
@@ -276,6 +282,9 @@ class EventLoop:
             page_size=server_args.block_size,
             host_ratio=server_args.kvstore_ratio,
             host_size_gb=server_args.kvstore_size,
+            host_parallel_count=max(
+                int(getattr(server_args.mapping, "nprocs_per_node", 1) or 1), 1
+            ),
             io_backend=server_args.kvstore_io_backend,
             host_layout=server_args.kvstore_mem_layout,
             storage_backend=server_args.kvstore_storage_backend,
@@ -305,11 +314,6 @@ class EventLoop:
             )
             num_host_pages = self.memory_executor.host_pool.page_num
 
-        # For DP attention, max_batch_size must be per-rank to avoid
-        # req_pool_allocator overflow.  The C++ scheduler allocates
-        # req_pool_slots based on this value, so it must match the
-        # per-DP-rank budget (same division used in cuda_graph_wrapper).
-        per_rank_max_batch = server_args.max_num_seqs // max(self.dp_size, 1)
         self._kv_events_enabled = (
             EventPublisherFactory.is_enabled(server_args.kv_events_config)
             and attn_tp_rank == 0
@@ -1589,6 +1593,11 @@ def run_event_loop(
                 "max_model_len": event_loop.model_config.context_len,
             }
         )
+
+        if event_loop.has_dp:
+            # All DP schedulers must finish initialization before any rank enters
+            # the loop and starts the first DP metadata collective.
+            dist.barrier(group=event_loop.world_cpu_group)
 
         use_overlap = should_use_overlap_schedule(
             disable_overlap_schedule=server_args.disable_overlap_schedule,

--- a/python/tokenspeed/runtime/execution/cache_loc_kernel.py
+++ b/python/tokenspeed/runtime/execution/cache_loc_kernel.py
@@ -191,7 +191,8 @@ def compute_out_cache_loc_kernel(
 
         # Compute page indices and offsets
         page_indices = positions // page_size
-        # Clamp to last valid page: avoids OOB reads past context-length bound.
+        overflow = page_indices >= max_pages
+        # Clamp to last valid page to avoid OOB GMEM read.
         page_indices = tl.minimum(page_indices, max_pages - 1)
         offsets_in_page = positions % page_size
 
@@ -202,6 +203,11 @@ def compute_out_cache_loc_kernel(
 
         # Compute physical cache locations
         cache_locs = page_ids * page_size + offsets_in_page
+        # For overflow tokens, route to slot 0 (a fixed safe dummy target that
+        # never aliases a real request's KV data). This avoids using a dynamic
+        # req_to_pages[0][0] load whose value can change at runtime and corrupt
+        # other requests' KV cache or trigger IndexKernel out-of-bounds.
+        cache_locs = tl.where(overflow, 0, cache_locs)
 
         # Store to output
         output_ptrs = out_cache_loc_ptr + output_offset + token_offsets
@@ -283,13 +289,16 @@ def fused_decode_input_prep_kernel(
 
         positions_local = cache_start + token_offsets
         page_indices = positions_local // page_size
-        # Clamp to last valid page (avoids OOB reads past context-length bound).
+        overflow = page_indices >= max_pages
+        # Clamp to last valid page to avoid OOB GMEM read.
         page_indices = tl.minimum(page_indices, max_pages - 1)
         offsets_in_page = positions_local % page_size
 
         page_ptrs = req_to_pages_ptr + pool_idx * max_pages + page_indices
         page_ids = tl.load(page_ptrs, mask=mask, other=0)
         cache_locs = page_ids * page_size + offsets_in_page
+        # Route overflow tokens to slot 0 (fixed safe dummy target).
+        cache_locs = tl.where(overflow, 0, cache_locs)
 
         tl.store(
             out_cache_loc_ptr + output_offset + token_offsets,

--- a/python/tokenspeed/runtime/execution/drafter/dflash.py
+++ b/python/tokenspeed/runtime/execution/drafter/dflash.py
@@ -431,9 +431,14 @@ class DFlash(BaseDrafter):
                 - 1
                 + num_extends
             )
-            current[num_extends:] = output_tokens[
-                offsets + accept_lengths[num_extends:].to(torch.int64)
-            ]
+            # ``accept_lengths`` can be clamped to 0 at the context limit.  The
+            # request will be finished by the scheduler, but the drafter still
+            # runs for graph shape. Select a valid in-row dummy token instead of
+            # producing ``row * N - 1`` or crossing into the previous row.
+            safe_accept_lengths = (
+                accept_lengths[num_extends:].to(torch.int64).clamp(1, spec_num_tokens)
+            )
+            current[num_extends:] = output_tokens[offsets + safe_accept_lengths]
         return current
 
     def get_candidates(self, base_ctx: ForwardContext) -> torch.Tensor | None:

--- a/python/tokenspeed/runtime/execution/drafter/eagle.py
+++ b/python/tokenspeed/runtime/execution/drafter/eagle.py
@@ -146,6 +146,30 @@ class Eagle(BaseDrafter):
             getattr(hf_config, "index_share_for_mtp_iteration", False)
         )
 
+    def _accepted_output_indices(
+        self,
+        accept_lengths: torch.Tensor,
+        row_count: int,
+        *,
+        base_offset: int = 0,
+    ) -> torch.Tensor:
+        """Return safe flat output-token indices for each decode request.
+
+        ``accept_lengths`` is the number of tokens that may be committed.  When
+        the context-length cap reduces a row to 0 there is no real newly
+        committed output token, but the drafter still runs to preserve graph
+        shape.  Use the row's first verify output as a valid dummy source rather
+        than producing ``row * N - 1``.
+        """
+        safe_accept_lengths = (
+            accept_lengths[:row_count].to(torch.int64).clamp(1, self.spec_num_tokens)
+        )
+        return (
+            self.padded_gather_ids_offsets_buf[:row_count]
+            + safe_accept_lengths
+            + base_offset
+        )
+
     def set_mm_pad_substitute_id(self, token_id: int) -> None:
         self.mm_pad_substitute_id = token_id
 
@@ -216,15 +240,18 @@ class Eagle(BaseDrafter):
                 gather_ids = torch.cat(
                     [
                         gather_ids,
-                        self.padded_gather_ids_offsets_buf[:num_decodes]
-                        + draft_input.accept_lengths[num_extends:]
-                        + num_prefill_tokens,
+                        self._accepted_output_indices(
+                            draft_input.accept_lengths[num_extends:],
+                            num_decodes,
+                            base_offset=num_prefill_tokens,
+                        ),
                     ]
                 )
         else:
             input_ids = draft_input.base_model_output
-            gather_ids = (
-                self.padded_gather_ids_offsets_buf[:bs] + draft_input.accept_lengths
+            gather_ids = self._accepted_output_indices(
+                draft_input.accept_lengths,
+                bs,
             )
 
         return input_ids, gather_ids
@@ -446,9 +473,9 @@ class Eagle(BaseDrafter):
         if num_extends > 0:
             next_tokens[:num_extends, 0] = draft_input.base_model_output[:num_extends]
         if num_decodes > 0:
-            indices = (
-                self.padded_gather_ids_offsets_buf[:num_decodes]
-                + draft_input.accept_lengths[num_extends:]
+            indices = self._accepted_output_indices(
+                draft_input.accept_lengths[num_extends:],
+                num_decodes,
             )
             if num_extends > 0:
                 indices.add_(num_extends)

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -106,6 +106,9 @@ class ModelExecutorConfig:
     Created once via from_server_args() and injected into ModelExecutor.
     """
 
+    # Rank-local graph-padding req-pool index. The C++ scheduler owns real rows
+    # 1..max_batch_size and row 0 is reserved, so this must sit after the
+    # scheduler-owned range.
     max_req_pool_size: int
     output_length: int
     enforce_eager: bool
@@ -247,6 +250,8 @@ class ModelExecutor:
                 config.context_len + config.block_size
             ) // config.block_size
 
+        max_bs = config.max_num_seqs // max(config.data_parallel_size, 1)
+
         self.req_to_page = torch.zeros(
             (config.max_req_pool_size + 1, max_num_pages_per_req),
             dtype=torch.int32,
@@ -254,7 +259,7 @@ class ModelExecutor:
         )
         spec_num_tokens = config.spec_num_tokens if config.spec_algo is not None else 1
         self.input_buffers = InputBuffers(
-            max_bs=config.max_num_seqs // max(config.data_parallel_size, 1),
+            max_bs=max_bs,
             max_num_tokens=config.chunked_prefill_size,
             page_size=config.block_size,
             # token_to_kv_pool allocates size+page_size slots; index `size` is
@@ -275,7 +280,7 @@ class ModelExecutor:
         # Sized like InputBuffers.max_bs so the padded graph-bucket bs fits.
         self.nan_guard = NanGuard.create(
             config.enable_nan_detection,
-            config.max_num_seqs // max(config.data_parallel_size, 1),
+            max_bs,
             self.device,
         )
         if self.config.spec_algo is not None:
@@ -345,14 +350,14 @@ class ModelExecutor:
             )
             if use_captured:
                 self.grammar_runtime = CapturableGrammarExecutor(
-                    max_bs=config.max_num_seqs,
+                    max_bs=max_bs,
                     vocab_size=config.vocab_size,
                     max_tokens_per_req=spec_num_tokens,
                     device=self.device,
                 )
             else:
                 self.grammar_runtime = EagerGrammarBuffers(
-                    max_bs=config.max_num_seqs // max(config.data_parallel_size, 1),
+                    max_bs=max_bs,
                     vocab_size=config.vocab_size,
                     max_tokens_per_req=spec_num_tokens,
                     device=self.device,
@@ -1010,12 +1015,17 @@ class ModelExecutor:
             req_pool_indices = self.input_buffers.req_pool_indices_buf[:bs]
             working = self.input_buffers.mamba_pool_indices_buf[:bs]
 
-            src_raw = pool.current_input_indices[req_pool_indices.clamp(0).long()].to(
-                dtype=torch.int64
-            )
+            req = req_pool_indices.to(dtype=torch.int64)
+            current_input_size = int(pool.current_input_indices.shape[0])
+            in_bounds = (req >= 0) & (req < current_input_size)
+            safe_req = req.clamp(0, current_input_size - 1)
+            src_raw = pool.current_input_indices[safe_req].to(dtype=torch.int64)
+            src_raw = torch.where(in_bounds, src_raw, sentinel)
             dst_raw = working.to(dtype=torch.int64)
 
-            invalid = (src_raw < 0) | (dst_raw < 0) | (src_raw == dst_raw)
+            invalid = (
+                (~in_bounds) | (src_raw < 0) | (dst_raw < 0) | (src_raw == dst_raw)
+            )
             src = torch.where(invalid, sentinel, src_raw)
             dst = torch.where(invalid, sentinel, dst_raw)
 

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -271,16 +271,14 @@ def _create_hybrid_linear_attn(
 
     # Mamba radix cache uses C++ chunk indices. Without radix cache, the
     # backend uses 1-based req_pool_indices directly, so keep slot 0 as padding.
+    per_rank_max_batch = server_args.max_num_seqs // max(
+        server_args.data_parallel_size or server_args.mapping.attn.dp_size, 1
+    )
+    req_pool_padding_index = per_rank_max_batch + 1
     mamba_pool_size = (
         mamba_pool_total_chunks + 1
         if mamba_pool_total_chunks > 0
-        else (
-            server_args.max_num_seqs
-            // max(
-                server_args.data_parallel_size or server_args.mapping.attn.dp_size, 1
-            )
-            + 1
-        )
+        else per_rank_max_batch + 1
     )
     mamba_pool = SimpleMambaPool(
         size=mamba_pool_size,
@@ -297,12 +295,10 @@ def _create_hybrid_linear_attn(
             if server_args.speculative_algorithm is not None
             else 0
         ),
-        max_req_pool_size=(
-            server_args.max_num_seqs
-            // max(
-                server_args.data_parallel_size or server_args.mapping.attn.dp_size, 1
-            )
-        ),
+        # ``current_input_indices`` is keyed by the scheduler's rank-local,
+        # 1-based req_pool_idx; the row after that range is the CUDA graph
+        # padding sentinel.
+        max_req_pool_size=req_pool_padding_index,
     )
     linear_attn_backend.set_pool(mamba_pool)
 

--- a/test/runtime/cache/test_memory_executor_host_budget.py
+++ b/test/runtime/cache/test_memory_executor_host_budget.py
@@ -1,0 +1,42 @@
+import pytest
+
+from tokenspeed.runtime.cache.executor.memory_executor import (
+    _aligned_token_count,
+    _auto_capped_host_size_tokens,
+)
+
+
+def test_host_budget_no_cap_when_request_fits():
+    assert (
+        _auto_capped_host_size_tokens(
+            requested_tokens=1024,
+            page_size=64,
+            size_per_token=12,
+            available_host_memory_bytes=1_000_000,
+            host_parallel_count=4,
+        )
+        == 0
+    )
+
+
+def test_host_budget_cap_accounts_for_draft_pool_and_page_alignment():
+    host_size_tokens = _auto_capped_host_size_tokens(
+        requested_tokens=1024,
+        page_size=64,
+        size_per_token=12,
+        available_host_memory_bytes=24_576,
+        host_parallel_count=4,
+    )
+
+    assert _aligned_token_count(host_size_tokens, 64) == 512
+
+
+def test_host_budget_raises_when_cgroup_budget_is_too_small():
+    with pytest.raises(ValueError, match="Not enough host memory"):
+        _auto_capped_host_size_tokens(
+            requested_tokens=1024,
+            page_size=64,
+            size_per_token=12,
+            available_host_memory_bytes=100,
+            host_parallel_count=1,
+        )

--- a/test/runtime/layers/test_mamba_checkpoint_metadata.py
+++ b/test/runtime/layers/test_mamba_checkpoint_metadata.py
@@ -35,6 +35,28 @@ def _new_backend(page_size: int = 64) -> MambaAttnBackend:
     return backend
 
 
+def test_simple_mamba_pool_current_input_map_uses_rank_local_req_pool_range():
+    pool = SimpleMambaPool(
+        size=48,
+        num_mamba_layers=1,
+        conv_state_shape=(4,),
+        temporal_state_shape=(2, 2),
+        conv_dtype=torch.float32,
+        ssm_dtype=torch.float32,
+        mamba_layer_ids=[0],
+        device="cpu",
+        page_size=64,
+        speculative_num_draft_tokens=4,
+        max_req_pool_size=21,
+    )
+
+    assert pool.current_input_size == 22
+    assert pool.current_input_indices.shape[0] == 22
+    # MTP draft slots are addressed by rank-local req_pool_idx, plus one
+    # graph-padding sink row after the scheduler-owned 1-based range.
+    assert pool.total_size == 48 + 22 * 3
+
+
 def test_extend_tracks_final_page_boundary_when_branch_checkpoint_is_inside():
     backend = _new_backend(page_size=64)
 

--- a/test/runtime/test_dp_sampling_routing_metadata.py
+++ b/test/runtime/test_dp_sampling_routing_metadata.py
@@ -137,12 +137,14 @@ def test_cuda_graph_wrapper_uses_existing_route_for_padding():
     assert wrapper.padded_bs(30, ctx) == 32
 
 
-def test_cuda_graph_req_pool_padding_keeps_attention_default_row():
+def test_cuda_graph_req_pool_padding_uses_reserved_sink_row():
+    wrapper = CudaGraphWrapper.__new__(CudaGraphWrapper)
+    wrapper.config = SimpleNamespace(max_req_pool_size=21)
     active_indices = torch.tensor([7, 8], dtype=torch.int64)
 
-    padded_indices = CudaGraphWrapper._pad_graph_req_pool_indices(active_indices, 4)
+    padded_indices = wrapper._pad_graph_req_pool_indices(active_indices, 4)
 
-    assert padded_indices.tolist() == [7, 8, 0, 0]
+    assert padded_indices.tolist() == [7, 8, 21, 21]
 
 
 def test_cuda_graph_state_write_padding_uses_reserved_sink_row():

--- a/test/runtime/test_drafter_accept_indexing.py
+++ b/test/runtime/test_drafter_accept_indexing.py
@@ -1,0 +1,106 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from tokenspeed.runtime.execution.drafter.dflash import DFlash
+from tokenspeed.runtime.execution.drafter.eagle import Eagle, EagleDraftInput
+from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
+
+
+def _make_eagle(spec_num_tokens: int = 4, max_bs: int = 8) -> Eagle:
+    drafter = Eagle.__new__(Eagle)
+    drafter.spec_num_tokens = spec_num_tokens
+    drafter.padded_gather_ids_offsets_buf = (
+        torch.arange(max_bs, dtype=torch.int64) * spec_num_tokens - 1
+    )
+    return drafter
+
+
+class TestDrafterAcceptIndexing(unittest.TestCase):
+    def test_eagle_accept_output_indices_stay_inside_each_decode_row(self):
+        drafter = _make_eagle(spec_num_tokens=4)
+
+        indices = drafter._accepted_output_indices(
+            torch.tensor([0, 1, 4, 99], dtype=torch.int32),
+            row_count=4,
+        )
+
+        self.assertEqual(indices.tolist(), [0, 4, 11, 15])
+
+    def test_eagle_decode_first_step_uses_safe_gather_ids_for_zero_accept(self):
+        drafter = _make_eagle(spec_num_tokens=4)
+        output_tokens = torch.arange(12, dtype=torch.int32)
+        draft_input = EagleDraftInput(
+            input_num_tokens=12,
+            num_extends=0,
+            forward_mode=ForwardMode.DECODE,
+            base_model_output=output_tokens,
+            accept_lengths=torch.tensor([0, 1, 4], dtype=torch.int32),
+            base_out_hidden_states=torch.empty(0),
+        )
+
+        input_ids, gather_ids = drafter._get_first_step_input(
+            draft_input,
+            bs=3,
+            input_num_tokens=12,
+        )
+
+        self.assertIs(input_ids, output_tokens)
+        self.assertEqual(gather_ids.tolist(), [0, 4, 11])
+
+    def test_eagle_mixed_first_step_keeps_decode_gather_ids_in_range(self):
+        drafter = _make_eagle(spec_num_tokens=4)
+        drafter.input_buffers = SimpleNamespace(
+            shifted_prefill_ids_buf=torch.arange(10, dtype=torch.int32),
+            input_lengths_buf=torch.tensor([2, 4, 4], dtype=torch.int32),
+        )
+        output_tokens = torch.arange(9, dtype=torch.int32) + 100
+        draft_input = EagleDraftInput(
+            input_num_tokens=10,
+            num_extends=1,
+            forward_mode=ForwardMode.MIXED,
+            base_model_output=output_tokens,
+            accept_lengths=torch.tensor([1, 0, 4], dtype=torch.int32),
+            base_out_hidden_states=torch.empty(0),
+        )
+
+        input_ids, gather_ids = drafter._get_first_step_input(
+            draft_input,
+            bs=3,
+            input_num_tokens=10,
+        )
+
+        self.assertEqual(gather_ids.tolist(), [1, 2, 9])
+        self.assertEqual(input_ids[2:].tolist(), output_tokens[1:].tolist())
+
+    def test_dflash_current_tokens_use_safe_in_row_dummy_for_zero_accept(self):
+        output_tokens = torch.arange(12, dtype=torch.int32)
+
+        current = DFlash._current_tokens_from_output(
+            output_tokens=output_tokens,
+            accept_lengths=torch.tensor([0, 1, 4], dtype=torch.int32),
+            num_extends=0,
+            spec_num_tokens=4,
+        )
+
+        self.assertEqual(current.tolist(), [0, 4, 11])
+
+    def test_dflash_mixed_current_tokens_do_not_cross_decode_rows(self):
+        output_tokens = torch.tensor(
+            [100, 10, 11, 12, 13, 20, 21, 22, 23],
+            dtype=torch.int32,
+        )
+
+        current = DFlash._current_tokens_from_output(
+            output_tokens=output_tokens,
+            accept_lengths=torch.tensor([1, 0, 4], dtype=torch.int32),
+            num_extends=1,
+            spec_num_tokens=4,
+        )
+
+        self.assertEqual(current.tolist(), [100, 10, 23])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- Cap KVStore host sizing by cgroup-aware per-rank memory budget.
- Use rank-local DP padding rows and safe cache/gather indexing.

Test:
- pre-commit run --all-files