### PR TITLE
fix(attention): treat window_left as exclusive

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_decode_fp16_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_decode_fp16_gfx950.py
@@ -237,8 +237,13 @@ class AttentionProgram:
         cache_len = cache_len - (cfg.MAX_SEQLEN_Q - 1 - q_pos)
         cache_len = maximum(cache_len, 0)
         if cfg.IS_SLIDING:
-            window_len = min(cache_len, cfg.WINDOW_LEFT)
-            kv_start = cache_len - window_len
+            # WINDOW_LEFT is defined as exclusive (keys strictly to the left, not
+            # counting the current token), so the window is WINDOW_LEFT + 1 keys
+            # once the current token is included. E.g. with
+            # WINDOW_LEFT = 127 and cache_len = 500 (current token at index 499),
+            # kv_start = 500 - (127 + 1) = 372 keeps keys [372, 499] = 128 keys.
+            # Without the + 1, kv_start = 373 would drop the leftmost key.
+            kv_start = cache_len - min(cache_len, cfg.WINDOW_LEFT + 1)
         else:
             kv_start = cache_len - cache_len
         first_page = kv_start // cfg.PAGE_SIZE

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -101,7 +101,7 @@ def mha_prefill(
         cu_seqlens_cpu: Host-side cumulative sequence lengths as a strict
             list[int]. Used for host-side launch metadata; must match cu_seqlens.
         max_seqlen: Maximum sequence length.
-        window_left: Inclusive left sliding-window size. -1 means full attention.
+        window_left: Exclusive left sliding-window size. -1 means full attention.
         logit_cap: Optional soft cap applied to attention logits.
         sinks: Optional attention sink tensor.
         return_lse: Whether to also return natural-log log-sum-exp values with
@@ -206,7 +206,7 @@ def mha_extend_with_kvcache(
         max_seqlen_q: Maximum query length.
         max_seqlen_k: Maximum KV length.
         is_causal: Whether query tokens are a causal suffix of cached KV.
-        window_left: Inclusive left sliding-window size. -1 means full attention.
+        window_left: Exclusive left sliding-window size. -1 means full attention.
         logit_cap: Optional soft cap applied to attention logits.
         sinks: Optional attention sink tensor.
         return_lse: Whether to also return natural-log log-sum-exp values with
@@ -313,7 +313,7 @@ def mha_decode_with_kvcache(
         max_seqlen_q: Number of uniformly packed query tokens per request. This
             is 1 for normal decode and `spec_num_tokens` for compact
             speculative decode.
-        window_left: Inclusive left sliding-window size. -1 means full attention.
+        window_left: Exclusive left sliding-window size. -1 means full attention.
         logit_cap: Optional soft cap applied to attention logits.
         sinks: Optional attention sink tensor.
         return_lse: Whether to also return log-sum-exp values.
@@ -1228,7 +1228,8 @@ def mha_plan(
     Args:
         dtype: Query/K/V dtype for prefill planning.
         head_dim: Attention head dimension.
-        window_left: Sliding-window size, or -1 for full-context attention.
+        window_left: Exclusive left sliding-window size, or -1 for full-context
+            attention.
         logit_cap: Logit soft-cap value, or 0.0 when disabled.
         sinks: Attention sinks tensor when sinks are enabled.
         return_lse: Whether the selected path must return LSE values.

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/mha_decode.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/mha_decode.py
@@ -84,8 +84,10 @@ def _fwd_kernel_stage1(
     cache_len = tl.load(cache_seqlens + cur_batch)
     cache_len = cache_len - (MAX_SEQLEN_Q - 1 - q_pos)
     cache_len = tl.maximum(cache_len, 0)
+    # WINDOW_LEFT is exclusive of the current token, so keep WINDOW_LEFT + 1
+    # keys (window_left left keys plus the current one).
     cur_batch_seq_len = (
-        tl.minimum(cache_len, WINDOW_LEFT) if WINDOW_LEFT >= 0 else cache_len
+        tl.minimum(cache_len, WINDOW_LEFT + 1) if WINDOW_LEFT >= 0 else cache_len
     )
     kv_start_offset = cache_len - cur_batch_seq_len
     kv_splits = tl.load(num_kv_splits + cur_batch)
@@ -316,8 +318,10 @@ def _fwd_grouped_kernel_stage1(
     cache_len = tl.load(cache_seqlens + cur_batch)
     cache_len = cache_len - (MAX_SEQLEN_Q - 1 - q_pos)
     cache_len = tl.maximum(cache_len, 0)
+    # WINDOW_LEFT is exclusive of the current token, so keep WINDOW_LEFT + 1
+    # keys (window_left left keys plus the current one).
     cur_batch_seq_len = (
-        tl.minimum(cache_len, WINDOW_LEFT) if WINDOW_LEFT >= 0 else cache_len
+        tl.minimum(cache_len, WINDOW_LEFT + 1) if WINDOW_LEFT >= 0 else cache_len
     )
     kv_start_offset = cache_len - cur_batch_seq_len
     kv_splits = tl.load(num_kv_splits + cur_batch)
@@ -559,8 +563,10 @@ def _fwd_kernel_stage2(
     cache_len = tl.load(cache_seqlens + cur_batch)
     cache_len = cache_len - (MAX_SEQLEN_Q - 1 - q_pos)
     cache_len = tl.maximum(cache_len, 0)
+    # WINDOW_LEFT is exclusive of the current token, so keep WINDOW_LEFT + 1
+    # keys (window_left left keys plus the current one).
     cur_batch_seq_len = (
-        tl.minimum(cache_len, WINDOW_LEFT) if WINDOW_LEFT >= 0 else cache_len
+        tl.minimum(cache_len, WINDOW_LEFT + 1) if WINDOW_LEFT >= 0 else cache_len
     )
     kv_splits = tl.load(num_kv_splits + cur_batch)
 


### PR DESCRIPTION
In TokenSpeed, `window_left` / `sliding_window_size` is exclusive of the current
token, so a sliding window spans `window_left + 1` keys:
https://github.com/lightseekorg/tokenspeed/blob/cbf132b86f9a511a66b137ca7b9a24f1174506e9/python/tokenspeed/runtime/models/gpt_oss.py#L432-L435

Fixed a few places inconsistent with that definition:
- MHA decode clamped to `min(cache_len, WINDOW_LEFT)`, attending one key
  too few (127 instead of 128 for gpt-oss); now `min(cache_len, WINDOW_LEFT + 1)`.
- Corrected the `window_left` docstrings from "inclusive" to "exclusive".