### PR TITLE
fix(evalscope): preserve plain completion prefixes

### DIFF
--- a/test/agentic_benchmark/evalscope_trie/run_evalscope_perf.py
+++ b/test/agentic_benchmark/evalscope_trie/run_evalscope_perf.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Run EvalScope with prefix-stable plain completion prompts."""
+
+from typing import Any
+
+from evalscope.cli.cli import run_cmd
+from evalscope.perf.arguments import Arguments
+from evalscope.perf.plugin.api.openai_api import OpenaiPlugin
+from evalscope.perf.plugin.registry import register_api
+
+API_NAME = "openai_plain_completion"
+
+
+def serialize_plain_messages(messages: list[dict[str, Any]]) -> str:
+    """Join message contents while preserving the prior generation boundary."""
+    if not messages:
+        raise ValueError("plain completion serialization requires messages")
+
+    contents = []
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict):
+            raise TypeError(f"message {index} must be a dict")
+        content = message.get("content")
+        if not isinstance(content, str):
+            raise TypeError(f"message {index} content must be a string")
+        contents.append(content)
+    return "\n".join(contents) + "\n"
+
+
+@register_api(API_NAME)
+class PlainCompletionOpenaiPlugin(OpenaiPlugin):
+    """Send message contexts as prefix-stable OpenAI completion prompts."""
+
+    def build_request(self, messages, param: Arguments | None = None):
+        param = param or self.param
+        if (
+            not param.tokenize_prompt
+            and not param.apply_chat_template
+            and param.query_template is None
+            and isinstance(messages, list)
+            and messages
+            and isinstance(messages[0], dict)
+        ):
+            messages = serialize_plain_messages(messages)
+        return super().build_request(messages, param)
+
+
+if __name__ == "__main__":
+    run_cmd()


### PR DESCRIPTION
## Summary

- add a repository-local EvalScope launcher that registers the
  `openai_plain_completion` API
- serialize multi-turn message contents with a trailing newline before
  generation
- preserve the exact previous prompt plus generated response as the next-turn
  prefix
- reuse EvalScope's OpenAI request, response, and CLI handling without
  modifying the installed package

## Usage

```bash
python3 test/agentic_benchmark/evalscope_trie/run_evalscope_perf.py perf \
  --api openai_plain_completion \
  --url http://127.0.0.1:18023/v1/completions \
  --no-apply-chat-template \
  --dataset swe_smith \
  --dataset-path /path/to/agentic_dataset.json \
  --multi-turn
```

The full completions endpoint is required. This adapter is intended for
non-tokenized plain-completion requests; do not add `--tokenize-prompt`.

## Validation

- verified custom API registration through the EvalScope registry
- verified `next_prompt.startswith(previous_prompt + generated_text)`
- verified the runner CLI can load EvalScope's `perf` command
- `pre-commit run --all-files`

## Scope

This draft contains only the EvalScope runner. Local benchmark scripts,
results, tests, and documentation are intentionally excluded.
