### PR TITLE
feat(distributed): wire TensorRT-LLM all-reduce backend

### DIFF
--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -221,3 +221,7 @@ features directly:
 - `--comm-fusion-max-num-tokens`
 - `--enable-allreduce-fusion`
 - `--enable-trtllm-allreduce` (experimental, single-node NVIDIA TP only)
+
+The TRT-LLM backend accelerates eligible contiguous 2D BF16 SUM collectives
+for attention, dense, and pure-TP MoE groups. Groups that include expert
+parallelism and unsupported tensor layouts continue to use NCCL.

--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -220,3 +220,4 @@ features directly:
 - `--disaggregation-*`
 - `--comm-fusion-max-num-tokens`
 - `--enable-allreduce-fusion`
+- `--enable-trtllm-allreduce` (experimental, single-node NVIDIA TP only)

--- a/python/tokenspeed/runtime/distributed/comm_backend/trtllm_allreduce.py
+++ b/python/tokenspeed/runtime/distributed/comm_backend/trtllm_allreduce.py
@@ -28,17 +28,23 @@ The workspace is created once per group via ``configure_group`` and
 reused for every subsequent ``all_reduce`` on that group.
 """
 
+import logging
+
 import torch
 from tokenspeed_kernel.ops.communication.trtllm import (
     AllReduceFusionPattern,
     trtllm_allreduce_fusion,
     trtllm_create_ipc_workspace_for_all_reduce_fusion,
+    trtllm_destroy_ipc_workspace_for_all_reduce_fusion,
 )
 from tokenspeed_kernel.platform import current_platform
 
 from tokenspeed.runtime.distributed.comm_backend.base import CommBackend, Group
 
 _MAX_ONESHOT_BYTES = 2 * 1024 * 1024
+_SUPPORTED_WORLD_SIZES = frozenset((2, 4, 8, 16))
+
+logger = logging.getLogger(__name__)
 
 
 class TrtllmAllReduceBackend(CommBackend):
@@ -68,50 +74,110 @@ class TrtllmAllReduceBackend(CommBackend):
         hidden_dim: int,
         use_fp32_lamport: bool = False,
     ) -> bool:
-        """Create IPC workspace for *group*.  Returns True on success."""
+        """Create an IPC workspace for a communication group.
+
+        Args:
+            rank: Rank within ``group``, not the global distributed rank.
+            group: Tuple of global ranks participating in the collective.
+            max_token_num: Requested maximum token rows. It is clamped to the
+                BF16 rows covered by the backend's one-shot byte limit.
+            hidden_dim: Maximum hidden dimension accepted by the workspace.
+            use_fp32_lamport: Whether the Lamport communication buffer uses
+                FP32 elements.
+
+        Returns:
+            ``True`` when the workspace is configured. Unsupported platforms
+            return ``False``. Configuration failures raise instead of allowing
+            different ranks to silently select different collective backends.
+        """
         if group in self._resources:
             return True
 
         if not self._load_comm():
             return False
-
-        try:
-
-            from tokenspeed.runtime.distributed.process_group_manager import (
-                process_group_manager as pg_manager,
+        if len(group) not in _SUPPORTED_WORLD_SIZES:
+            raise ValueError(
+                f"TRT-LLM all-reduce does not support group size {len(group)}"
+            )
+        if not 0 <= rank < len(group):
+            raise ValueError(f"group-local rank {rank} is invalid for group {group}")
+        if hidden_dim <= 0 or max_token_num <= 0:
+            raise ValueError(
+                "TRT-LLM all-reduce requires positive hidden_dim and max_token_num"
             )
 
-            device_group = pg_manager.get_process_group("nccl", group)
-
-            ipc_handles, workspace_tensor = (
-                trtllm_create_ipc_workspace_for_all_reduce_fusion(
-                    rank,
-                    len(group),
-                    max_token_num,
-                    hidden_dim,
-                    group=device_group,
-                    use_fp32_lamport=use_fp32_lamport,
-                )
+        max_bf16_tokens = _MAX_ONESHOT_BYTES // (
+            hidden_dim * torch.empty((), dtype=torch.bfloat16).element_size()
+        )
+        workspace_max_tokens = min(max_token_num, max_bf16_tokens)
+        if workspace_max_tokens <= 0:
+            raise ValueError(
+                f"hidden_dim={hidden_dim} exceeds the TRT-LLM one-shot byte limit"
             )
 
-            self._resources[group] = {
-                "ipc_handles": ipc_handles,
-                "workspace": workspace_tensor,
-                "rank": rank,
-                "world_size": len(group),
-                "max_token_num": max_token_num,
-                "hidden_dim": hidden_dim,
-                "device_group": device_group,
-            }
+        from tokenspeed.runtime.distributed.process_group_manager import (
+            process_group_manager as pg_manager,
+        )
 
-            return True
+        device_group = pg_manager.get_process_group("nccl", group)
+        ipc_handles, workspace_tensor = (
+            trtllm_create_ipc_workspace_for_all_reduce_fusion(
+                rank,
+                len(group),
+                workspace_max_tokens,
+                hidden_dim,
+                group=device_group,
+                use_fp32_lamport=use_fp32_lamport,
+            )
+        )
 
-        except Exception:
-
-            return False
+        self._resources[group] = {
+            "ipc_handles": ipc_handles,
+            "workspace": workspace_tensor,
+            "rank": rank,
+            "world_size": len(group),
+            "max_token_num": workspace_max_tokens,
+            "hidden_dim": hidden_dim,
+            "device_group": device_group,
+        }
+        logger.info(
+            "Configured TRT-LLM all-reduce group=%s local_rank=%s "
+            "max_token_num=%s hidden_dim=%s",
+            group,
+            rank,
+            workspace_max_tokens,
+            hidden_dim,
+        )
+        return True
 
     def has_trtllm_ar(self, group: Group) -> bool:
         return group in self._resources
+
+    def close_group(self, group: Group) -> None:
+        """Destroy the IPC workspace associated with ``group`` if present."""
+        res = self._resources.pop(group, None)
+        if res is None:
+            return
+        trtllm_destroy_ipc_workspace_for_all_reduce_fusion(
+            res["ipc_handles"], group=res["device_group"]
+        )
+
+    def can_run(self, tensor: torch.Tensor, group: Group, op=None) -> bool:
+        """Return whether an all-reduce call can use the configured backend."""
+        if op is None:
+            op = torch.distributed.ReduceOp.SUM
+        res = self._resources.get(group)
+        return bool(
+            res is not None
+            and op == torch.distributed.ReduceOp.SUM
+            and tensor.is_cuda
+            and tensor.dtype == torch.bfloat16
+            and tensor.is_contiguous()
+            and tensor.dim() == 2
+            and 0 < tensor.shape[0] <= res["max_token_num"]
+            and 0 < tensor.shape[1] <= res["hidden_dim"]
+            and tensor.numel() * tensor.element_size() <= _MAX_ONESHOT_BYTES
+        )
 
     # ------------------------------------------------------------------
     # CommBackend interface
@@ -124,11 +190,7 @@ class TrtllmAllReduceBackend(CommBackend):
 
         res = self._resources.get(group)
 
-        if (
-            res is not None
-            and op == torch.distributed.ReduceOp.SUM
-            and tensor.numel() * tensor.element_size() <= _MAX_ONESHOT_BYTES
-        ):
+        if self.can_run(tensor, group, op=op):
 
             result = self._lamport_allreduce(tensor, res)
 

--- a/python/tokenspeed/runtime/distributed/comm_backend/trtllm_allreduce.py
+++ b/python/tokenspeed/runtime/distributed/comm_backend/trtllm_allreduce.py
@@ -80,7 +80,8 @@ class TrtllmAllReduceBackend(CommBackend):
             rank: Rank within ``group``, not the global distributed rank.
             group: Tuple of global ranks participating in the collective.
             max_token_num: Requested maximum token rows. It is clamped to the
-                BF16 rows covered by the backend's one-shot byte limit.
+                rows covered by the backend's one-shot byte limit and selected
+                Lamport communication dtype.
             hidden_dim: Maximum hidden dimension accepted by the workspace.
             use_fp32_lamport: Whether the Lamport communication buffer uses
                 FP32 elements.
@@ -106,10 +107,11 @@ class TrtllmAllReduceBackend(CommBackend):
                 "TRT-LLM all-reduce requires positive hidden_dim and max_token_num"
             )
 
-        max_bf16_tokens = _MAX_ONESHOT_BYTES // (
-            hidden_dim * torch.empty((), dtype=torch.bfloat16).element_size()
+        lamport_dtype = torch.float32 if use_fp32_lamport else torch.bfloat16
+        max_lamport_tokens = _MAX_ONESHOT_BYTES // (
+            hidden_dim * torch.empty((), dtype=lamport_dtype).element_size()
         )
-        workspace_max_tokens = min(max_token_num, max_bf16_tokens)
+        workspace_max_tokens = min(max_token_num, max_lamport_tokens)
         if workspace_max_tokens <= 0:
             raise ValueError(
                 f"hidden_dim={hidden_dim} exceeds the TRT-LLM one-shot byte limit"
@@ -163,7 +165,12 @@ class TrtllmAllReduceBackend(CommBackend):
         )
 
     def can_run(self, tensor: torch.Tensor, group: Group, op=None) -> bool:
-        """Return whether an all-reduce call can use the configured backend."""
+        """Return whether an all-reduce call can use the configured backend.
+
+        Only the production decode layout ``[tokens, hidden]`` is enabled.
+        Other tensor ranks deliberately fall back until reshape semantics have
+        dedicated correctness and CUDA Graph coverage.
+        """
         if op is None:
             op = torch.distributed.ReduceOp.SUM
         res = self._resources.get(group)
@@ -202,27 +209,20 @@ class TrtllmAllReduceBackend(CommBackend):
     def _lamport_allreduce(
         self, tensor: torch.Tensor, res: dict
     ) -> torch.Tensor | None:
-        """Run the Lamport 1-shot kernel, return None on failure."""
-        orig_shape = tensor.shape
+        """Run the Lamport 1-shot kernel for a 2D decode tensor."""
+        if tensor.dim() != 2:
+            return None
 
-        # The fused kernel expects 2D [token_num, hidden_dim].
-        if tensor.dim() == 1:
-            tensor_2d = tensor.unsqueeze(0)
-        elif tensor.dim() > 2:
-            tensor_2d = tensor.reshape(-1, tensor.shape[-1])
-        else:
-            tensor_2d = tensor
-
-        token_num, hidden_dim = tensor_2d.shape
+        token_num, hidden_dim = tensor.shape
         if hidden_dim > res["hidden_dim"] or token_num > res["max_token_num"]:
             return None
 
         from tokenspeed.runtime.utils.pdl import pdl_enabled
 
-        allreduce_out = torch.empty_like(tensor_2d)
+        allreduce_out = torch.empty_like(tensor)
 
         trtllm_allreduce_fusion(
-            allreduce_in=tensor_2d,
+            allreduce_in=tensor,
             world_size=res["world_size"],
             world_rank=res["rank"],
             token_num=token_num,
@@ -236,7 +236,7 @@ class TrtllmAllReduceBackend(CommBackend):
             allreduce_out=allreduce_out,
         )
 
-        return allreduce_out.view(orig_shape)
+        return allreduce_out
 
     # ---- Delegate everything else to fallback ----
 

--- a/python/tokenspeed/runtime/execution/distributed_initializer.py
+++ b/python/tokenspeed/runtime/execution/distributed_initializer.py
@@ -81,6 +81,7 @@ class DistributedConfig:
 
     # Feature flags
     disable_custom_all_reduce: bool = False
+    enable_trtllm_allreduce: bool = False
     force_deterministic_rsag: bool = False
 
     # The full Mapping object for pg_manager initialization
@@ -121,12 +122,66 @@ class DistributedConfig:
             hidden_size=hidden_size,
             max_num_tokens=max_num_tokens,
             disable_custom_all_reduce=server_args.disable_custom_all_reduce,
+            enable_trtllm_allreduce=server_args.enable_trtllm_allreduce,
             force_deterministic_rsag=server_args.force_deterministic_rsag,
             mapping=mapping,
         )
 
 
 class DistributedInitializer:
+    @staticmethod
+    def _configure_trtllm_allreduce(config: DistributedConfig) -> None:
+        """Create per-group Lamport workspaces before CUDA graph capture."""
+        if not config.enable_trtllm_allreduce:
+            return
+
+        if config.nnodes != 1:
+            raise RuntimeError(
+                "TRT-LLM all-reduce currently supports single-node groups only"
+            )
+
+        from tokenspeed.runtime.distributed.comm_backend.auto import AutoBackend
+        from tokenspeed.runtime.distributed.comm_backend.registry import (
+            get_global_backend,
+        )
+
+        backend = get_global_backend()
+        if not isinstance(backend, AutoBackend):
+            raise RuntimeError("TRT-LLM all-reduce requires the global AutoBackend")
+
+        mapping = config.mapping
+        groups = dict.fromkeys(
+            (
+                mapping.attn.tp_group,
+                mapping.dense.tp_group,
+                mapping.moe.tp_ep_group,
+            )
+        )
+        configured_groups = []
+        for group in groups:
+            if len(group) <= 1:
+                continue
+            if config.global_rank not in group:
+                raise RuntimeError(
+                    f"global rank {config.global_rank} is not in communication group {group}"
+                )
+            local_rank = group.index(config.global_rank)
+            if not backend.trtllm_ar.configure_group(
+                rank=local_rank,
+                group=group,
+                max_token_num=config.max_num_tokens,
+                hidden_dim=config.hidden_size,
+            ):
+                raise RuntimeError(
+                    f"TRT-LLM all-reduce is unavailable for communication group {group}"
+                )
+            configured_groups.append(group)
+
+        logger.info(
+            "Configured TRT-LLM all-reduce for groups=%s",
+            configured_groups,
+        )
+
     @staticmethod
     def initialize(config: DistributedConfig) -> float:
         torch.get_device_module(config.device).set_device(config.gpu_id)
@@ -160,6 +215,7 @@ class DistributedInitializer:
         pg_manager.init_process_group(config.mapping.attn.tp_group)
         pg_manager.init_process_group(config.mapping.dense.tp_group)
         pg_manager.init_process_group(config.mapping.moe.tp_ep_group)
+        DistributedInitializer._configure_trtllm_allreduce(config)
 
         logger.info(
             "Init comm buff end. Avail mem=%.4f GB",

--- a/python/tokenspeed/runtime/execution/distributed_initializer.py
+++ b/python/tokenspeed/runtime/execution/distributed_initializer.py
@@ -150,13 +150,15 @@ class DistributedInitializer:
             raise RuntimeError("TRT-LLM all-reduce requires the global AutoBackend")
 
         mapping = config.mapping
-        groups = dict.fromkeys(
-            (
-                mapping.attn.tp_group,
-                mapping.dense.tp_group,
+        tp_groups = [mapping.attn.tp_group, mapping.dense.tp_group]
+        if mapping.moe.ep_size == 1:
+            tp_groups.append(mapping.moe.tp_ep_group)
+        else:
+            logger.info(
+                "Skipping TRT-LLM all-reduce for unvalidated MoE TP/EP group=%s",
                 mapping.moe.tp_ep_group,
             )
-        )
+        groups = dict.fromkeys(tp_groups)
         configured_groups = []
         for group in groups:
             if len(group) <= 1:

--- a/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
+++ b/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
@@ -58,6 +58,12 @@ from tokenspeed_kernel.ops.attention.triton.deepseek_v4 import (
 from tokenspeed_kernel.ops.attention.triton.deepseek_v4 import (
     write_deepseek_v4_indexer_mxfp4_cache_cuda as _triton_write_indexer_mxfp4_cache_cuda,
 )
+from tokenspeed_kernel.ops.attention.trtllm.deepseek_v4 import (
+    supports_trtllm_deepseek_v4_indexer_q_prepare as _supports_trtllm_indexer_q_prepare,
+)
+from tokenspeed_kernel.ops.attention.trtllm.deepseek_v4 import (
+    trtllm_deepseek_v4_indexer_q_prepare_mxfp4 as _trtllm_indexer_q_prepare_mxfp4,
+)
 
 from tokenspeed.runtime.configs.deepseek_v4_cache_spec import (
     DEEPSEEK_V4_FP8_MAX,
@@ -75,6 +81,12 @@ from tokenspeed.runtime.configs.deepseek_v4_cache_spec import (
     deepseek_v4_swa_scale_dim,
     deepseek_v4_swa_token_stride,
 )
+
+# The vendored TRT-LLM chain replaces one fused Triton launch with RoPE,
+# fast-Hadamard, FP4-pack, and weight-scale launches.  B200 measurements show
+# a clear prefill win at this conservative crossover while preserving the
+# lower-launch-overhead Triton path for decode and small mixed batches.
+_TRTLLM_INDEXER_Q_MIN_TOKENS = 128
 
 
 def _indexer_mxfp4_layout_from_cache(
@@ -270,7 +282,12 @@ def deepseek_v4_prepare_indexer_q_mxfp4(
     softmax_scale: float,
     head_scale: float,
 ) -> tuple[tuple[torch.Tensor, torch.Tensor], torch.Tensor]:
-    """Apply indexer Q RoPE and return DeepGEMM-ready MXFP4 values/scales."""
+    """Apply indexer Q RoPE and return DeepGEMM-ready MXFP4 values/scales.
+
+    The specialized large-token path applies RoPE in place to ``index_q``.
+    The model passes the disposable output of the indexer projection here, so
+    callers must not reuse that tensor after this function returns.
+    """
 
     if index_q.dim() != 3:
         raise ValueError(f"index_q must be [tokens, heads, dim], got {index_q.shape}")
@@ -291,6 +308,22 @@ def deepseek_v4_prepare_indexer_q_mxfp4(
     if not index_q.is_cuda:
         raise ValueError(
             "deepseek_v4_prepare_indexer_q_mxfp4 only supports CUDA tensors."
+        )
+    if index_q.shape[
+        0
+    ] >= _TRTLLM_INDEXER_Q_MIN_TOKENS and _supports_trtllm_indexer_q_prepare(
+        index_q,
+        positions,
+        cos_sin_cache,
+    ):
+        return _trtllm_indexer_q_prepare_mxfp4(
+            index_q=index_q,
+            positions=positions,
+            cos_sin_cache=cos_sin_cache,
+            weights=weights,
+            softmax_scale=softmax_scale,
+            head_scale=head_scale,
+            enable_pdl=True,
         )
     return _triton_fused_indexer_q_rope_hadamard_mxfp4(
         index_q=index_q,

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -3073,6 +3073,8 @@ class DeepseekV4Indexer(nn.Module):
         with nvtx_range("indexer_weights_proj"):
             weights, _ = self.weights_proj(hidden_states)
         with nvtx_range("indexer_prepare_mxfp4"):
+            # This call consumes the disposable projection output. The
+            # large-token TRT-LLM kernel path applies RoPE to index_q in place.
             packed_index_q, packed_weights = deepseek_v4_prepare_indexer_q_mxfp4(
                 index_q=index_q,
                 positions=positions,

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -1554,7 +1554,8 @@ class ServerArgs:
             action="store_true",
             help=(
                 "Enable the experimental TRT-LLM Lamport one-shot all-reduce "
-                "backend for eligible single-node tensor-parallel collectives."
+                "backend for eligible single-node tensor-parallel collectives. "
+                "Groups that include expert parallelism continue to use NCCL."
             ),
         )
         parser.add_argument(

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -238,6 +238,7 @@ class ServerArgs:
     enable_nccl_nvls: bool = False
     enable_symm_mem: bool = False
     disable_custom_all_reduce: bool = False
+    enable_trtllm_allreduce: bool = False
     disable_overlap_schedule: bool = False
     disable_tf32: bool = False
     force_deterministic_rsag: bool = False
@@ -1547,6 +1548,14 @@ class ServerArgs:
             "--disable-custom-all-reduce",
             action="store_true",
             help="Disable the custom all-reduce kernel and fall back to NCCL.",
+        )
+        parser.add_argument(
+            "--enable-trtllm-allreduce",
+            action="store_true",
+            help=(
+                "Enable the experimental TRT-LLM Lamport one-shot all-reduce "
+                "backend for eligible single-node tensor-parallel collectives."
+            ),
         )
         parser.add_argument(
             "--disable-overlap-schedule",

--- a/test/runtime/distributed/test_comm_ops.py
+++ b/test/runtime/distributed/test_comm_ops.py
@@ -317,67 +317,6 @@ def _test_backend_registry(rank, world_size, device, group, ref_group):
     assert result.shape == inp.shape
 
 
-def _test_trtllm_allreduce_graph_replay(rank, world_size, device, group, ref_group):
-    from tokenspeed.runtime.distributed.comm_backend.nccl import NcclBackend
-    from tokenspeed.runtime.distributed.comm_backend.trtllm_allreduce import (
-        TrtllmAllReduceBackend,
-    )
-
-    hidden_dim = 512
-    token_num = 16
-    backend = TrtllmAllReduceBackend(fallback=NcclBackend())
-    assert backend.configure_group(
-        rank=rank,
-        group=group,
-        max_token_num=128,
-        hidden_dim=hidden_dim,
-    )
-
-    try:
-        torch.manual_seed(1000 + rank)
-        eager_input = torch.randn(
-            token_num, hidden_dim, dtype=torch.bfloat16, device=device
-        )
-        eager_expected = eager_input.clone()
-        dist.all_reduce(eager_expected, group=ref_group)
-        assert backend.can_run(eager_input, group)
-        eager_result = backend.all_reduce(eager_input, group)
-        torch.cuda.synchronize(device)
-        torch.testing.assert_close(eager_result, eager_expected, atol=0.125, rtol=0.05)
-
-        static_input = eager_input.clone()
-        capture_stream = torch.cuda.Stream(device=device)
-        capture_stream.wait_stream(torch.cuda.current_stream(device))
-        with torch.cuda.stream(capture_stream):
-            for _ in range(3):
-                backend.all_reduce(eager_input, group)
-        torch.cuda.current_stream(device).wait_stream(capture_stream)
-        torch.cuda.synchronize(device)
-        dist.barrier(group=ref_group)
-
-        graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph, stream=capture_stream):
-            graph_result = backend.all_reduce(static_input, group)
-        torch.cuda.synchronize(device)
-        dist.barrier(group=ref_group)
-
-        for iteration in range(10):
-            torch.manual_seed(2000 + iteration * world_size + rank)
-            replay_input = torch.randn_like(static_input)
-            replay_expected = replay_input.clone()
-            dist.all_reduce(replay_expected, group=ref_group)
-            static_input.copy_(replay_input)
-            dist.barrier(group=ref_group)
-            graph.replay()
-            torch.cuda.synchronize(device)
-            torch.testing.assert_close(
-                graph_result, replay_expected, atol=0.125, rtol=0.05
-            )
-            dist.barrier(group=ref_group)
-    finally:
-        backend.close_group(group)
-
-
 # ---------------------------------------------------------------------------
 # FusionParams (no GPU needed)
 # ---------------------------------------------------------------------------
@@ -450,9 +389,3 @@ class TestCommOps:
     @pytest.mark.parametrize("world_size", WORLD_SIZES)
     def test_backend_registry(self, world_size):
         _run(world_size, _test_backend_registry)
-
-
-class TestTrtllmAllReduceBackend:
-
-    def test_tp8_correctness_and_cuda_graph_replay(self):
-        _run(8, _test_trtllm_allreduce_graph_replay)

--- a/test/runtime/distributed/test_comm_ops.py
+++ b/test/runtime/distributed/test_comm_ops.py
@@ -317,6 +317,67 @@ def _test_backend_registry(rank, world_size, device, group, ref_group):
     assert result.shape == inp.shape
 
 
+def _test_trtllm_allreduce_graph_replay(rank, world_size, device, group, ref_group):
+    from tokenspeed.runtime.distributed.comm_backend.nccl import NcclBackend
+    from tokenspeed.runtime.distributed.comm_backend.trtllm_allreduce import (
+        TrtllmAllReduceBackend,
+    )
+
+    hidden_dim = 512
+    token_num = 16
+    backend = TrtllmAllReduceBackend(fallback=NcclBackend())
+    assert backend.configure_group(
+        rank=rank,
+        group=group,
+        max_token_num=128,
+        hidden_dim=hidden_dim,
+    )
+
+    try:
+        torch.manual_seed(1000 + rank)
+        eager_input = torch.randn(
+            token_num, hidden_dim, dtype=torch.bfloat16, device=device
+        )
+        eager_expected = eager_input.clone()
+        dist.all_reduce(eager_expected, group=ref_group)
+        assert backend.can_run(eager_input, group)
+        eager_result = backend.all_reduce(eager_input, group)
+        torch.cuda.synchronize(device)
+        torch.testing.assert_close(eager_result, eager_expected, atol=0.125, rtol=0.05)
+
+        static_input = eager_input.clone()
+        capture_stream = torch.cuda.Stream(device=device)
+        capture_stream.wait_stream(torch.cuda.current_stream(device))
+        with torch.cuda.stream(capture_stream):
+            for _ in range(3):
+                backend.all_reduce(eager_input, group)
+        torch.cuda.current_stream(device).wait_stream(capture_stream)
+        torch.cuda.synchronize(device)
+        dist.barrier(group=ref_group)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=capture_stream):
+            graph_result = backend.all_reduce(static_input, group)
+        torch.cuda.synchronize(device)
+        dist.barrier(group=ref_group)
+
+        for iteration in range(10):
+            torch.manual_seed(2000 + iteration * world_size + rank)
+            replay_input = torch.randn_like(static_input)
+            replay_expected = replay_input.clone()
+            dist.all_reduce(replay_expected, group=ref_group)
+            static_input.copy_(replay_input)
+            dist.barrier(group=ref_group)
+            graph.replay()
+            torch.cuda.synchronize(device)
+            torch.testing.assert_close(
+                graph_result, replay_expected, atol=0.125, rtol=0.05
+            )
+            dist.barrier(group=ref_group)
+    finally:
+        backend.close_group(group)
+
+
 # ---------------------------------------------------------------------------
 # FusionParams (no GPU needed)
 # ---------------------------------------------------------------------------
@@ -389,3 +450,9 @@ class TestCommOps:
     @pytest.mark.parametrize("world_size", WORLD_SIZES)
     def test_backend_registry(self, world_size):
         _run(world_size, _test_backend_registry)
+
+
+class TestTrtllmAllReduceBackend:
+
+    def test_tp8_correctness_and_cuda_graph_replay(self):
+        _run(8, _test_trtllm_allreduce_graph_replay)

--- a/test/runtime/distributed/test_trtllm_allreduce_backend.py
+++ b/test/runtime/distributed/test_trtllm_allreduce_backend.py
@@ -1,0 +1,155 @@
+"""CPU-side tests for TRT-LLM all-reduce selection and runtime wiring."""
+
+import argparse
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from tokenspeed.runtime.distributed.comm_backend.auto import AutoBackend
+from tokenspeed.runtime.distributed.comm_backend.trtllm_allreduce import (
+    TrtllmAllReduceBackend,
+)
+from tokenspeed.runtime.execution.distributed_initializer import (
+    DistributedInitializer,
+)
+from tokenspeed.runtime.utils.server_args import ServerArgs
+
+
+def _fake_cuda_bf16_tensor(rows: int, columns: int):
+    tensor = MagicMock()
+    tensor.is_cuda = True
+    tensor.dtype = torch.bfloat16
+    tensor.shape = (rows, columns)
+    tensor.is_contiguous.return_value = True
+    tensor.dim.return_value = 2
+    tensor.numel.return_value = rows * columns
+    tensor.element_size.return_value = 2
+    return tensor
+
+
+def test_server_flag_is_explicit_opt_in():
+    parser = argparse.ArgumentParser()
+    ServerArgs.add_cli_args(parser)
+
+    default_args = parser.parse_args(["--model=stub"])
+    enabled_args = parser.parse_args(
+        ["--model=stub", "--enable-trtllm-allreduce"]
+    )
+
+    assert default_args.enable_trtllm_allreduce is False
+    assert enabled_args.enable_trtllm_allreduce is True
+
+
+def test_auto_backend_selects_configured_trtllm_backend():
+    backend = AutoBackend()
+    group = (0, 1)
+    tensor = object()
+    expected = object()
+
+    backend._custom_ar = SimpleNamespace(has_custom_ar=lambda _group: False)
+    backend._trtllm_ar = SimpleNamespace(
+        has_trtllm_ar=lambda _group: True,
+        all_reduce=lambda _tensor, _group, op=None: expected,
+    )
+    backend._triton_ar = SimpleNamespace(can_run=lambda *_args, **_kwargs: False)
+    backend._nccl = SimpleNamespace(
+        all_reduce=lambda *_args, **_kwargs: pytest.fail("unexpected NCCL fallback")
+    )
+
+    assert backend.all_reduce(tensor, group) is expected
+
+
+def test_configure_group_clamps_workspace_to_oneshot_limit(monkeypatch):
+    from tokenspeed.runtime.distributed import process_group_manager
+    from tokenspeed.runtime.distributed.comm_backend import trtllm_allreduce
+
+    backend = TrtllmAllReduceBackend(fallback=MagicMock())
+    group = tuple(range(8))
+    calls = []
+
+    monkeypatch.setattr(backend, "_load_comm", lambda: True)
+    monkeypatch.setattr(
+        process_group_manager.process_group_manager,
+        "get_process_group",
+        lambda kind, requested_group: (kind, requested_group),
+    )
+
+    def create_workspace(rank, size, max_tokens, hidden_dim, **kwargs):
+        calls.append((rank, size, max_tokens, hidden_dim, kwargs))
+        return [[1]], object()
+
+    monkeypatch.setattr(
+        trtllm_allreduce,
+        "trtllm_create_ipc_workspace_for_all_reduce_fusion",
+        create_workspace,
+    )
+
+    assert backend.configure_group(
+        rank=3,
+        group=group,
+        max_token_num=8192,
+        hidden_dim=7168,
+    )
+    assert calls[0][2] == 146
+    assert backend._resources[group]["max_token_num"] == 146
+
+
+def test_backend_eligibility_is_fail_closed():
+    backend = TrtllmAllReduceBackend(fallback=MagicMock())
+    group = tuple(range(8))
+    backend._resources[group] = {
+        "max_token_num": 146,
+        "hidden_dim": 7168,
+    }
+
+    assert backend.can_run(_fake_cuda_bf16_tensor(16, 7168), group)
+    assert not backend.can_run(_fake_cuda_bf16_tensor(147, 7168), group)
+
+    fp32 = _fake_cuda_bf16_tensor(16, 7168)
+    fp32.dtype = torch.float32
+    assert not backend.can_run(fp32, group)
+
+    noncontiguous = _fake_cuda_bf16_tensor(16, 7168)
+    noncontiguous.is_contiguous.return_value = False
+    assert not backend.can_run(noncontiguous, group)
+
+
+def test_distributed_wiring_deduplicates_alias_groups(monkeypatch):
+    from tokenspeed.runtime.distributed.comm_backend import registry
+
+    backend = AutoBackend()
+    configure_group = MagicMock(return_value=True)
+    backend._trtllm_ar = SimpleNamespace(configure_group=configure_group)
+    monkeypatch.setattr(registry, "get_global_backend", lambda: backend)
+
+    group = tuple(range(8))
+    mapping = SimpleNamespace(
+        attn=SimpleNamespace(tp_group=group),
+        dense=SimpleNamespace(tp_group=group),
+        moe=SimpleNamespace(tp_ep_group=group),
+    )
+    config = SimpleNamespace(
+        enable_trtllm_allreduce=True,
+        nnodes=1,
+        mapping=mapping,
+        global_rank=5,
+        max_num_tokens=8192,
+        hidden_size=7168,
+    )
+
+    DistributedInitializer._configure_trtllm_allreduce(config)
+
+    configure_group.assert_called_once_with(
+        rank=5,
+        group=group,
+        max_token_num=8192,
+        hidden_dim=7168,
+    )
+
+
+def test_distributed_wiring_rejects_multinode():
+    config = SimpleNamespace(enable_trtllm_allreduce=True, nnodes=2)
+    with pytest.raises(RuntimeError, match="single-node"):
+        DistributedInitializer._configure_trtllm_allreduce(config)

--- a/test/runtime/distributed/test_trtllm_allreduce_backend.py
+++ b/test/runtime/distributed/test_trtllm_allreduce_backend.py
@@ -59,7 +59,13 @@ def test_auto_backend_selects_configured_trtllm_backend():
     assert backend.all_reduce(tensor, group) is expected
 
 
-def test_configure_group_clamps_workspace_to_oneshot_limit(monkeypatch):
+@pytest.mark.parametrize(
+    ("use_fp32_lamport", "expected_max_tokens"),
+    ((False, 146), (True, 73)),
+)
+def test_configure_group_clamps_workspace_to_oneshot_limit(
+    monkeypatch, use_fp32_lamport, expected_max_tokens
+):
     from tokenspeed.runtime.distributed import process_group_manager
     from tokenspeed.runtime.distributed.comm_backend import trtllm_allreduce
 
@@ -89,9 +95,11 @@ def test_configure_group_clamps_workspace_to_oneshot_limit(monkeypatch):
         group=group,
         max_token_num=8192,
         hidden_dim=7168,
+        use_fp32_lamport=use_fp32_lamport,
     )
-    assert calls[0][2] == 146
-    assert backend._resources[group]["max_token_num"] == 146
+    assert calls[0][2] == expected_max_tokens
+    assert calls[0][4]["use_fp32_lamport"] is use_fp32_lamport
+    assert backend._resources[group]["max_token_num"] == expected_max_tokens
 
 
 def test_backend_eligibility_is_fail_closed():
@@ -113,6 +121,14 @@ def test_backend_eligibility_is_fail_closed():
     noncontiguous.is_contiguous.return_value = False
     assert not backend.can_run(noncontiguous, group)
 
+    one_dimensional = _fake_cuda_bf16_tensor(16, 7168)
+    one_dimensional.dim.return_value = 1
+    assert not backend.can_run(one_dimensional, group)
+
+    three_dimensional = _fake_cuda_bf16_tensor(16, 7168)
+    three_dimensional.dim.return_value = 3
+    assert not backend.can_run(three_dimensional, group)
+
 
 def test_distributed_wiring_deduplicates_alias_groups(monkeypatch):
     from tokenspeed.runtime.distributed.comm_backend import registry
@@ -126,7 +142,7 @@ def test_distributed_wiring_deduplicates_alias_groups(monkeypatch):
     mapping = SimpleNamespace(
         attn=SimpleNamespace(tp_group=group),
         dense=SimpleNamespace(tp_group=group),
-        moe=SimpleNamespace(tp_ep_group=group),
+        moe=SimpleNamespace(ep_size=1, tp_ep_group=group),
     )
     config = SimpleNamespace(
         enable_trtllm_allreduce=True,
@@ -145,6 +161,33 @@ def test_distributed_wiring_deduplicates_alias_groups(monkeypatch):
         max_token_num=8192,
         hidden_dim=7168,
     )
+
+
+def test_distributed_wiring_skips_expert_parallel_group(monkeypatch):
+    from tokenspeed.runtime.distributed.comm_backend import registry
+
+    backend = AutoBackend()
+    configure_group = MagicMock(return_value=True)
+    backend._trtllm_ar = SimpleNamespace(configure_group=configure_group)
+    monkeypatch.setattr(registry, "get_global_backend", lambda: backend)
+
+    mapping = SimpleNamespace(
+        attn=SimpleNamespace(tp_group=(0,)),
+        dense=SimpleNamespace(tp_group=(0,)),
+        moe=SimpleNamespace(ep_size=8, tp_ep_group=tuple(range(8))),
+    )
+    config = SimpleNamespace(
+        enable_trtllm_allreduce=True,
+        nnodes=1,
+        mapping=mapping,
+        global_rank=0,
+        max_num_tokens=8192,
+        hidden_size=7168,
+    )
+
+    DistributedInitializer._configure_trtllm_allreduce(config)
+
+    configure_group.assert_not_called()
 
 
 def test_distributed_wiring_rejects_multinode():

--- a/test/runtime/distributed/test_trtllm_allreduce_backend.py
+++ b/test/runtime/distributed/test_trtllm_allreduce_backend.py
@@ -34,9 +34,7 @@ def test_server_flag_is_explicit_opt_in():
     ServerArgs.add_cli_args(parser)
 
     default_args = parser.parse_args(["--model=stub"])
-    enabled_args = parser.parse_args(
-        ["--model=stub", "--enable-trtllm-allreduce"]
-    )
+    enabled_args = parser.parse_args(["--model=stub", "--enable-trtllm-allreduce"])
 
     assert default_args.enable_trtllm_allreduce is False
     assert enabled_args.enable_trtllm_allreduce is True

--- a/test/runtime/distributed/test_trtllm_allreduce_cuda.py
+++ b/test/runtime/distributed/test_trtllm_allreduce_cuda.py
@@ -1,0 +1,152 @@
+"""CUDA correctness and graph-replay tests for TRT-LLM all-reduce."""
+
+import socket
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from ci_system.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=90, suite="runtime-2gpu")
+
+
+def _get_open_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        return sock.getsockname()[1]
+
+
+def _worker_main(rank, world_size, port):
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"tcp://localhost:{port}",
+        rank=rank,
+        world_size=world_size,
+    )
+
+    try:
+        from tokenspeed.runtime.distributed.process_group_manager import (
+            process_group_manager as pg_manager,
+        )
+
+        group = tuple(range(world_size))
+        pg_manager.init_process_group(group)
+        ref_group = pg_manager.get_process_group("nccl", group)
+        _exercise_allreduce(rank, world_size, device, group, ref_group)
+    finally:
+        dist.destroy_process_group()
+
+
+def _worker_entry(rank, world_size, port, errors):
+    try:
+        _worker_main(rank, world_size, port)
+    except Exception:
+        import traceback
+
+        errors[rank] = traceback.format_exc()
+
+
+def _exercise_allreduce(rank, world_size, device, group, ref_group):
+    from tokenspeed.runtime.distributed.comm_backend.nccl import NcclBackend
+    from tokenspeed.runtime.distributed.comm_backend.trtllm_allreduce import (
+        TrtllmAllReduceBackend,
+    )
+
+    hidden_dim = 512
+    token_num = 16
+    backend = TrtllmAllReduceBackend(fallback=NcclBackend())
+    assert backend.configure_group(
+        rank=rank,
+        group=group,
+        max_token_num=128,
+        hidden_dim=hidden_dim,
+    )
+
+    try:
+        torch.manual_seed(1000 + rank)
+        eager_input = torch.randn(
+            token_num, hidden_dim, dtype=torch.bfloat16, device=device
+        )
+        eager_expected = eager_input.clone()
+        dist.all_reduce(eager_expected, group=ref_group)
+        assert backend.can_run(eager_input, group)
+        eager_result = backend.all_reduce(eager_input, group)
+        torch.cuda.synchronize(device)
+        torch.testing.assert_close(eager_result, eager_expected, atol=0.125, rtol=0.05)
+
+        for fallback_shape in ((129, hidden_dim), (hidden_dim,)):
+            fallback_input = torch.randn(
+                fallback_shape,
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            fallback_expected = fallback_input.clone()
+            dist.all_reduce(fallback_expected, group=ref_group)
+            assert not backend.can_run(fallback_input, group)
+            fallback_result = backend.all_reduce(fallback_input, group)
+            torch.testing.assert_close(fallback_result, fallback_expected)
+
+        static_input = eager_input.clone()
+        capture_stream = torch.cuda.Stream(device=device)
+        capture_stream.wait_stream(torch.cuda.current_stream(device))
+        with torch.cuda.stream(capture_stream):
+            for _ in range(3):
+                backend.all_reduce(eager_input, group)
+        torch.cuda.current_stream(device).wait_stream(capture_stream)
+        torch.cuda.synchronize(device)
+        dist.barrier(group=ref_group)
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=capture_stream):
+            graph_result = backend.all_reduce(static_input, group)
+        torch.cuda.synchronize(device)
+        dist.barrier(group=ref_group)
+
+        for iteration in range(10):
+            torch.manual_seed(2000 + iteration * world_size + rank)
+            replay_input = torch.randn_like(static_input)
+            replay_expected = replay_input.clone()
+            dist.all_reduce(replay_expected, group=ref_group)
+            static_input.copy_(replay_input)
+            dist.barrier(group=ref_group)
+            graph.replay()
+            torch.cuda.synchronize(device)
+            torch.testing.assert_close(
+                graph_result, replay_expected, atol=0.125, rtol=0.05
+            )
+            dist.barrier(group=ref_group)
+    finally:
+        backend.close_group(group)
+
+
+def _run(world_size):
+    if world_size > torch.cuda.device_count():
+        pytest.skip(f"Need {world_size} GPUs, have {torch.cuda.device_count()}")
+
+    port = _get_open_port()
+    errors = mp.Manager().dict()
+    mp.spawn(
+        _worker_entry,
+        args=(world_size, port, errors),
+        nprocs=world_size,
+        join=True,
+    )
+
+    if errors:
+        raise RuntimeError(
+            "\n".join(f"Rank {rank}: {error}" for rank, error in errors.items())
+        )
+
+
+@pytest.mark.parametrize(
+    "world_size",
+    (
+        pytest.param(2, id="tp2-ci"),
+        pytest.param(8, id="tp8-manual"),
+    ),
+)
+def test_correctness_and_cuda_graph_replay(world_size):
+    _run(world_size)

--- a/test/runtime/test_deepseek_v4_attention_ops.py
+++ b/test/runtime/test_deepseek_v4_attention_ops.py
@@ -13,6 +13,7 @@
 
 import math
 import unittest
+from unittest import mock
 
 import torch
 from tokenspeed_kernel.ops.attention.cuda.deepseek_v4 import (
@@ -1302,6 +1303,152 @@ class DeepseekV4AttentionOpsTest(unittest.TestCase):
                 expected_scales.contiguous().view(torch.int32).squeeze(-1).cpu(),
             )
         )
+
+    def test_large_indexer_q_prepare_dispatches_to_trtllm_kernels(self):
+        from tokenspeed_kernel.ops.attention.trtllm.deepseek_v4 import (
+            has_trtllm_deepseek_v4_indexer_q_prepare,
+            trtllm_deepseek_v4_indexer_q_prepare_mxfp4,
+        )
+
+        if (
+            torch.cuda.get_device_capability()[0] != 10
+            or not has_trtllm_deepseek_v4_indexer_q_prepare()
+        ):
+            self.skipTest("TRT-LLM indexer Q kernels require NVIDIA SM100/SM10x")
+
+        torch.manual_seed(9125)
+        num_tokens = 128
+        num_heads = 64
+        index_q = torch.randn(
+            num_tokens,
+            num_heads,
+            128,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        original_q = index_q.clone()
+        expected_q = index_q.clone()
+        positions = torch.arange(num_tokens, device="cuda", dtype=torch.int64)
+        cos_sin = torch.randn(
+            num_tokens,
+            ROPE_DIM,
+            device="cuda",
+            dtype=torch.float32,
+        )
+        weights = torch.randn(
+            num_tokens,
+            num_heads,
+            device="cuda",
+            dtype=torch.float32,
+        )
+        kwargs = {
+            "positions": positions,
+            "cos_sin_cache": cos_sin,
+            "weights": weights,
+            "softmax_scale": 0.25,
+            "head_scale": num_heads**-0.5,
+        }
+
+        expected = trtllm_deepseek_v4_indexer_q_prepare_mxfp4(
+            index_q=expected_q,
+            enable_pdl=True,
+            **kwargs,
+        )
+        actual = deepseek_v4_prepare_indexer_q_mxfp4(
+            index_q=index_q,
+            **kwargs,
+        )
+
+        self.assertTrue(torch.equal(actual[0][0], expected[0][0]))
+        self.assertTrue(torch.equal(actual[0][1], expected[0][1]))
+        self.assertTrue(torch.equal(actual[1], expected[1]))
+        self.assertTrue(torch.equal(index_q, expected_q))
+        self.assertFalse(torch.equal(index_q, original_q))
+
+    def test_small_indexer_q_prepare_keeps_triton_fallback(self):
+        from tokenspeed_kernel.ops.attention.trtllm.deepseek_v4 import (
+            has_trtllm_deepseek_v4_indexer_q_prepare,
+        )
+
+        if (
+            torch.cuda.get_device_capability()[0] != 10
+            or not has_trtllm_deepseek_v4_indexer_q_prepare()
+        ):
+            self.skipTest("TRT-LLM indexer Q kernels require NVIDIA SM100/SM10x")
+
+        torch.manual_seed(9126)
+        num_tokens = 127
+        index_q = torch.randn(
+            num_tokens,
+            64,
+            128,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        original_q = index_q.clone()
+        positions = torch.arange(num_tokens, device="cuda", dtype=torch.int64)
+        cos_sin = torch.randn(
+            num_tokens,
+            ROPE_DIM,
+            device="cuda",
+            dtype=torch.float32,
+        )
+        weights = torch.randn(num_tokens, 64, device="cuda", dtype=torch.float32)
+
+        deepseek_v4_prepare_indexer_q_mxfp4(
+            index_q=index_q,
+            positions=positions,
+            cos_sin_cache=cos_sin,
+            weights=weights,
+            softmax_scale=0.25,
+            head_scale=64**-0.5,
+        )
+
+        self.assertTrue(torch.equal(index_q, original_q))
+
+    def test_large_indexer_q_prepare_keeps_triton_fallback_when_unsupported(self):
+        num_tokens = 128
+        index_q = torch.empty(
+            num_tokens,
+            64,
+            128,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        positions = torch.zeros(num_tokens, device="cuda", dtype=torch.int64)
+        cos_sin = torch.empty(1, ROPE_DIM, device="cuda", dtype=torch.float32)
+        weights = torch.empty(num_tokens, 64, device="cuda", dtype=torch.float32)
+        sentinel = object()
+
+        with (
+            mock.patch(
+                "tokenspeed.runtime.layers.attention.deepseek_v4_ops."
+                "_supports_trtllm_indexer_q_prepare",
+                return_value=False,
+            ) as supports,
+            mock.patch(
+                "tokenspeed.runtime.layers.attention.deepseek_v4_ops."
+                "_trtllm_indexer_q_prepare_mxfp4"
+            ) as trtllm_prepare,
+            mock.patch(
+                "tokenspeed.runtime.layers.attention.deepseek_v4_ops."
+                "_triton_fused_indexer_q_rope_hadamard_mxfp4",
+                return_value=sentinel,
+            ) as triton_prepare,
+        ):
+            actual = deepseek_v4_prepare_indexer_q_mxfp4(
+                index_q,
+                positions,
+                cos_sin,
+                weights,
+                0.25,
+                64**-0.5,
+            )
+
+        self.assertIs(actual, sentinel)
+        supports.assert_called_once()
+        trtllm_prepare.assert_not_called()
+        triton_prepare.assert_called_once()
 
     def test_sparse_prefill_combine_topk_swa_indices_matches_reference(self):
         device = torch.device("cuda")

--- a/tokenspeed-kernel/python/setup.py
+++ b/tokenspeed-kernel/python/setup.py
@@ -306,6 +306,19 @@ KERNEL_GROUPS = [
         ],
         [],
     ),
+    # TODO: Import these kernels from tokenspeed_trtllm_kernel once they are
+    # exposed there, instead of building this standalone vendored extension.
+    (
+        "trtllm_deepseek_v4_indexer_q",
+        [
+            CUDA_CSRC_DIR / "trtllm_deepseek_v4_indexer_q.cu",
+        ],
+        [],
+        # TRT-LLM's fusedCat contract requires IEEE division for bit-exact
+        # DeepGEMM parity. Override TokenSpeed's global fast-math expansion for
+        # this separately built vendored source without changing other groups.
+        ["--ftz=false", "--prec-div=true", "--prec-sqrt=true"],
+    ),
     (
         "dsv3_gemm",
         [

--- a/tokenspeed-kernel/python/setup.py
+++ b/tokenspeed-kernel/python/setup.py
@@ -319,6 +319,18 @@ KERNEL_GROUPS = [
         # this separately built vendored source without changing other groups.
         ["--ftz=false", "--prec-div=true", "--prec-sqrt=true"],
     ),
+    # TODO: Import this kernel from tokenspeed_trtllm_kernel instead of
+    # compiling this standalone adapter once the project pin moves beyond
+    # 1.2.1 and exposes this op with per-call PDL control. Keeping it separate
+    # for now avoids coupling this change to the full third-party package
+    # upgrade and its load-order changes.
+    (
+        "trtllm_fp8_quant_packed",
+        [
+            CUDA_CSRC_DIR / "trtllm_fp8_quant_packed.cu",
+        ],
+        [],
+    ),
     (
         "dsv3_gemm",
         [

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -28,6 +28,7 @@ import tokenspeed_kernel.ops.attention.flash_attn  # noqa: F401
 import tokenspeed_kernel.ops.attention.flashinfer  # noqa: F401
 import tokenspeed_kernel.ops.attention.gluon  # noqa: F401
 import tokenspeed_kernel.ops.attention.triton  # noqa: F401
+import tokenspeed_kernel.ops.attention.trtllm  # noqa: F401
 import torch
 from tokenspeed_kernel.platform import current_platform
 from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/trtllm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/trtllm/__init__.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from tokenspeed_kernel.ops.attention.trtllm.deepseek_v4 import (
+    has_trtllm_deepseek_v4_indexer_q_prepare,
+    supports_trtllm_deepseek_v4_indexer_q_prepare,
+    trtllm_deepseek_v4_indexer_q_prepare_mxfp4,
+)
+
+__all__ = [
+    "has_trtllm_deepseek_v4_indexer_q_prepare",
+    "supports_trtllm_deepseek_v4_indexer_q_prepare",
+    "trtllm_deepseek_v4_indexer_q_prepare_mxfp4",
+]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/trtllm/deepseek_v4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/trtllm/deepseek_v4.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""TRT-LLM DeepSeek-V4 sparse-indexer preparation kernels."""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel.platform import (
+    ArchVersion,
+    CapabilityRequirement,
+    current_platform,
+)
+from tokenspeed_kernel.registry import Priority, register_kernel
+from tokenspeed_kernel.signature import format_signatures
+from tokenspeed_kernel.thirdparty.cuda.trtllm_deepseek_v4_indexer import (
+    has_trtllm_indexer_q_kernels,
+    trtllm_fused_cat_fp4,
+    trtllm_mla_rope_inplace,
+)
+
+try:
+    from tokenspeed_kernel.thirdparty.fast_hadamard_transform import (
+        hadamard_transform,
+    )
+except (ImportError, OSError):
+    hadamard_transform = None
+
+_HEAD_DIM = 128
+_ROPE_DIM = 64
+_MXFP4_VALUE_BYTES = _HEAD_DIM // 2
+_BLACKWELL_CAPABILITY = CapabilityRequirement(
+    min_arch_version=ArchVersion(10, 0),
+    max_arch_version=ArchVersion(10, 9),
+    vendors=frozenset({"nvidia"}),
+)
+
+
+def has_trtllm_deepseek_v4_indexer_q_prepare() -> bool:
+    """Return whether the TRT-LLM Q preparation chain is importable."""
+
+    return has_trtllm_indexer_q_kernels() and hadamard_transform is not None
+
+
+def supports_trtllm_deepseek_v4_indexer_q_prepare(
+    index_q: torch.Tensor,
+    positions: torch.Tensor | None = None,
+    cos_sin_cache: torch.Tensor | None = None,
+) -> bool:
+    """Return whether inputs satisfy the specialized SM100 kernel contract.
+
+    Args:
+        index_q: Candidate BF16 tensor shaped ``[tokens, 64, 128]``.
+        positions: Optional INT32/INT64 position vector for full validation.
+        cos_sin_cache: Optional contiguous FP32 RoPE cache for full validation.
+
+    Returns:
+        ``True`` when the vendored kernels, fast Hadamard transform, device,
+        dtype, and production DeepSeek-V4 shape are all supported.
+    """
+
+    if (
+        not has_trtllm_deepseek_v4_indexer_q_prepare()
+        or not index_q.is_cuda
+        or index_q.dtype != torch.bfloat16
+        or index_q.ndim != 3
+        or tuple(index_q.shape[1:]) != (64, _HEAD_DIM)
+        or not index_q.is_contiguous()
+        or index_q.data_ptr() % 16 != 0
+    ):
+        return False
+    if positions is not None and (
+        not positions.is_cuda
+        or positions.device != index_q.device
+        or positions.dtype not in (torch.int32, torch.int64)
+        or positions.ndim != 1
+        or positions.shape[0] != index_q.shape[0]
+        or not positions.is_contiguous()
+    ):
+        return False
+    if cos_sin_cache is not None and (
+        not cos_sin_cache.is_cuda
+        or cos_sin_cache.device != index_q.device
+        or cos_sin_cache.dtype != torch.float32
+        or cos_sin_cache.ndim != 2
+        or cos_sin_cache.shape[1] != _ROPE_DIM
+        or not cos_sin_cache.is_contiguous()
+    ):
+        return False
+    device_index = index_q.device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    major, _minor = torch.cuda.get_device_capability(device_index)
+    return major == 10
+
+
+def trtllm_deepseek_v4_indexer_q_prepare_mxfp4(
+    *,
+    index_q: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    weights: torch.Tensor,
+    softmax_scale: float,
+    head_scale: float,
+    enable_pdl: bool = False,
+) -> tuple[tuple[torch.Tensor, torch.Tensor], torch.Tensor]:
+    """Prepare DeepGEMM MXFP4 indexer Q with vendored TRT-LLM kernels.
+
+    The composite follows TRT-LLM's intended sequence: in-place interleaved
+    MLA RoPE, normalized fast Hadamard transform, fused per-block MXFP4 pack,
+    and FP32 index-head weight scaling. ``index_q`` is mutated by the RoPE op
+    and must not be reused by the caller.
+
+    Args:
+        index_q: Contiguous BF16 ``[tokens, 64, 128]`` projection output.
+        positions: INT32/INT64 absolute positions shaped ``[tokens]``.
+        cos_sin_cache: FP32 RoPE table shaped ``[max_position, 64]``.
+        weights: Index-head weights shaped ``[tokens, 64]`` or
+            ``[tokens, 64, 1]``.
+        softmax_scale: Indexer attention scale.
+        head_scale: Per-head normalization scale.
+        enable_pdl: Whether the RoPE launch may use PDL.
+
+    Returns:
+        ``((packed_q, packed_scales), scaled_weights)``. Packed Q is UINT8
+        ``[tokens, 64, 64]``, scales are INT32 ``[tokens, 64]``, and weights
+        are FP32 ``[tokens, 64]``.
+    """
+
+    if not supports_trtllm_deepseek_v4_indexer_q_prepare(
+        index_q,
+        positions,
+        cos_sin_cache,
+    ):
+        raise RuntimeError(
+            "TRT-LLM DeepSeek-V4 indexer Q preparation requires built kernels, "
+            "fast Hadamard, SM100, and contiguous BF16 [tokens, 64, 128] input"
+        )
+    if positions.ndim != 1 or positions.shape[0] != index_q.shape[0]:
+        raise ValueError(
+            f"positions must be [{index_q.shape[0]}], got {tuple(positions.shape)}"
+        )
+    if cos_sin_cache.shape[-1] != _ROPE_DIM:
+        raise ValueError(
+            f"cos_sin_cache width must be {_ROPE_DIM}, got {cos_sin_cache.shape[-1]}"
+        )
+    if weights.ndim == 3:
+        weights = weights.squeeze(-1)
+    if weights.shape != index_q.shape[:2]:
+        raise ValueError(
+            f"weights must be {tuple(index_q.shape[:2])}, got {tuple(weights.shape)}"
+        )
+
+    num_tokens, num_heads, _head_dim = index_q.shape
+    if num_tokens == 0:
+        packed_q = torch.empty(
+            (0, num_heads, _MXFP4_VALUE_BYTES),
+            dtype=torch.uint8,
+            device=index_q.device,
+        )
+        packed_scales = torch.empty(
+            (0, num_heads), dtype=torch.int32, device=index_q.device
+        )
+        return (packed_q, packed_scales), weights.float()
+
+    trtllm_mla_rope_inplace(
+        index_q,
+        positions,
+        cos_sin_cache,
+        enable_pdl=enable_pdl,
+    )
+    rotated = hadamard_transform(
+        index_q.reshape(-1, _HEAD_DIM),
+        scale=_HEAD_DIM**-0.5,
+    )
+    first, second = rotated.split((_ROPE_DIM, _HEAD_DIM - _ROPE_DIM), dim=-1)
+    packed_q, packed_scales = trtllm_fused_cat_fp4(first, second)
+    scaled_weights = weights.float() * float(softmax_scale * head_scale)
+    return (
+        packed_q.view(num_tokens, num_heads, _MXFP4_VALUE_BYTES),
+        packed_scales.view(num_tokens, num_heads),
+    ), scaled_weights
+
+
+if has_trtllm_deepseek_v4_indexer_q_prepare() and current_platform().is_nvidia:
+    trtllm_deepseek_v4_indexer_q_prepare_mxfp4 = register_kernel(
+        "attention",
+        "deepseek_v4_indexer_q_prepare_mxfp4",
+        name="trtllm_deepseek_v4_indexer_q_prepare_mxfp4",
+        solution="trtllm",
+        capability=_BLACKWELL_CAPABILITY,
+        signatures=format_signatures("index_q", "dense", {torch.bfloat16}),
+        traits={
+            "num_heads": frozenset({64}),
+            "head_dim": frozenset({_HEAD_DIM}),
+            "rope_dim": frozenset({_ROPE_DIM}),
+        },
+        priority=Priority.SPECIALIZED,
+        tags={"latency", "throughput"},
+    )(trtllm_deepseek_v4_indexer_q_prepare_mxfp4)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/trtllm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/trtllm.py
@@ -39,6 +39,7 @@ __all__ = [
     "reducescatter_residual_rmsnorm",
     "trtllm_allreduce_fusion",
     "trtllm_create_ipc_workspace_for_all_reduce_fusion",
+    "trtllm_destroy_ipc_workspace_for_all_reduce_fusion",
     "trtllm_create_ipc_workspace_for_minimax",
 ]
 
@@ -51,6 +52,7 @@ minimax_allreduce_rms_qk = error_fn
 reducescatter_residual_rmsnorm = error_fn
 trtllm_allreduce_fusion = error_fn
 trtllm_create_ipc_workspace_for_all_reduce_fusion = error_fn
+trtllm_destroy_ipc_workspace_for_all_reduce_fusion = error_fn
 trtllm_create_ipc_workspace_for_minimax = error_fn
 
 if current_platform().is_nvidia:

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/__init__.py
@@ -154,6 +154,7 @@ def _online_quantize_mxfp8(
     A: torch.Tensor,
     block_size: list[int],
     kernel_name: str,
+    enable_pdl: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Perform online activation quantization for mxfp8 block-scaled GEMM.
 
@@ -199,6 +200,7 @@ def _online_quantize_mxfp8(
             column_major_scales=True,
             scale_tma_aligned=True,
             scale_ue8m0=_platform.is_blackwell_plus,
+            enable_pdl=enable_pdl,
         )
     elif kernel_name == "flashinfer_mm_fp8_blockscale":
         from tokenspeed_kernel.ops.gemm.fp8_utils import (
@@ -267,6 +269,8 @@ def mm(
         quant: Explicit quant type override.  One of ``"mxfp8"``,
             ``"fp8"``, ``"nvfp4"``, ``"mxfp4"``, ``"none"``.
             If ``None``, inferred from input dtypes and scales.
+        enable_pdl: Whether online quantization and the selected GEMM may use
+            Programmatic Dependent Launch.
         override: Force selection of a specific kernel by name (e.g.
             ``"cublaslt_mm_nvfp4"``). Bypasses heuristic scoring.
         expected_kernel_name: Debug hint for expected kernel selection.
@@ -308,7 +312,12 @@ def mm(
         assert (
             block_size is not None
         ), "block_size is required for online activation quantization"
-        A, A_scales = _online_quantize_mxfp8(A, block_size, kernel.name)
+        A, A_scales = _online_quantize_mxfp8(
+            A,
+            block_size,
+            kernel.name,
+            enable_pdl=enable_pdl,
+        )
 
     kernel_args = (A, B, A_scales, B_scales, out_dtype)
     kernel_kwargs: dict[str, object] = {"alpha": alpha, "block_size": block_size}

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/fp8_utils.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/fp8_utils.py
@@ -36,6 +36,12 @@ if _is_nvidia:
     from tokenspeed_kernel.ops.quantization.flashinfer import (
         fp8_blockscale_quantize_runner_sm90 as _flashinfer_fp8_blockscale_quantize_runner_sm90,
     )
+    from tokenspeed_kernel.ops.quantization.trtllm import (
+        supports_trtllm_fp8_packed_ue8m0 as _supports_trtllm_fp8_packed_ue8m0,
+    )
+    from tokenspeed_kernel.ops.quantization.trtllm import (
+        trtllm_fp8_packed_ue8m0 as _trtllm_fp8_packed_ue8m0,
+    )
     from tokenspeed_kernel.thirdparty.trtllm import (
         per_token_group_quant_8bit as _trtllm_per_token_group_quant_fp8,
     )
@@ -400,6 +406,7 @@ def per_token_group_quant_fp8(
     column_major_scales: bool = False,
     scale_tma_aligned: bool = False,
     scale_ue8m0: bool = False,
+    enable_pdl: bool = False,
 ):
     flashinfer_quantized = _flashinfer_sm90_per_token_group_quant_fp8(
         x,
@@ -410,6 +417,18 @@ def per_token_group_quant_fp8(
     )
     if flashinfer_quantized is not None:
         return flashinfer_quantized
+
+    if (
+        _is_nvidia
+        and group_size == 128
+        and column_major_scales
+        and scale_tma_aligned
+        and scale_ue8m0
+        and _supports_trtllm_fp8_packed_ue8m0(x)
+    ):
+        # Preserve the existing TokenSpeed quantization contract while using
+        # TRT-LLM's packed SM100 launch and memory layout.
+        return _trtllm_fp8_packed_ue8m0(x, enable_pdl=enable_pdl)
 
     if (
         _is_nvidia

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/trtllm.py
@@ -20,17 +20,33 @@
 from __future__ import annotations
 
 import torch
-from tokenspeed_kernel.platform import current_platform
+from tokenspeed_kernel.platform import (
+    ArchVersion,
+    CapabilityRequirement,
+    current_platform,
+)
 from tokenspeed_kernel.registry import Priority, error_fn, register_kernel
 from tokenspeed_kernel.signature import format_signatures
 
 platform = current_platform()
 
+_trtllm_fp8_quantize_1x128_packed_ue8m0 = error_fn
+_supports_trtllm_fp8_quant_packed = None
 trtllm_fp8_token_group_128 = error_fn
+trtllm_fp8_packed_ue8m0 = error_fn
 trtllm_fp8_token = error_fn
 trtllm_fp8_tensor = error_fn
 
 if platform.is_nvidia:
+    from tokenspeed_kernel.thirdparty.cuda.trtllm_fp8_quant import (
+        has_trtllm_fp8_quant_packed,
+    )
+    from tokenspeed_kernel.thirdparty.cuda.trtllm_fp8_quant import (
+        supports_trtllm_fp8_quant_packed as _supports_trtllm_fp8_quant_packed,
+    )
+    from tokenspeed_kernel.thirdparty.cuda.trtllm_fp8_quant import (
+        trtllm_fp8_quantize_1x128_packed_ue8m0,
+    )
     from tokenspeed_kernel.thirdparty.trtllm import (
         per_tensor_quant_fp8 as _trtllm_per_tensor_quant_fp8,
     )
@@ -42,10 +58,67 @@ if platform.is_nvidia:
     )
 
     _FP8_DTYPE = platform.fp8e4m3fn.dtype
+    if has_trtllm_fp8_quant_packed():
+        _trtllm_fp8_quantize_1x128_packed_ue8m0 = trtllm_fp8_quantize_1x128_packed_ue8m0
 
     def trtllm_fp8_token_group_128(x: torch.Tensor) -> torch.Tensor:
         qweight, _scale = _trtllm_per_token_group_quant_8bit(x, group_size=128)
         return qweight.float()
+
+    if _trtllm_fp8_quantize_1x128_packed_ue8m0 is not error_fn:
+
+        @register_kernel(
+            "quantization",
+            "fp8_with_scale",
+            name="trtllm_quantize_fp8_packed_ue8m0",
+            solution="trtllm",
+            capability=CapabilityRequirement(
+                min_arch_version=ArchVersion(10, 0),
+                max_arch_version=ArchVersion(10, 0),
+                vendors=frozenset({"nvidia"}),
+            ),
+            signatures=format_signatures("x", "dense", {torch.bfloat16}),
+            traits={
+                "granularity": frozenset({"token_group_128"}),
+                "scale_encoding": frozenset({"packed_ue8m0"}),
+            },
+            priority=Priority.SPECIALIZED,
+        )
+        def trtllm_fp8_packed_ue8m0(
+            x: torch.Tensor,
+            granularity: str = "token_group",
+            group_size: int | None = 128,
+            scale_encoding: str = "packed_ue8m0",
+            enable_pdl: bool = False,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            """Quantize a BF16 matrix with 1x128 packed UE8M0 scales.
+
+            Args:
+                x: Contiguous, 32-byte-aligned CUDA BF16 matrix. Its column
+                    count must be divisible by 128.
+                granularity: Must be ``"token_group"``.
+                group_size: Must be 128.
+                scale_encoding: Must be ``"packed_ue8m0"``.
+                enable_pdl: Whether to enable Programmatic Dependent Launch.
+
+            Returns:
+                Quantized E4M3 values and INT32 packed UE8M0 scales. The scale
+                view has shape ``[M, ceil(K / 512)]`` and stride
+                ``(1, align(M, 4))``.
+            """
+            if granularity != "token_group" or group_size != 128:
+                raise ValueError(
+                    "TRT-LLM packed UE8M0 requires token_group granularity "
+                    "with group_size=128"
+                )
+            if scale_encoding != "packed_ue8m0":
+                raise ValueError(
+                    "TRT-LLM packed UE8M0 requires scale_encoding='packed_ue8m0'"
+                )
+            return _trtllm_fp8_quantize_1x128_packed_ue8m0(
+                x,
+                enable_pdl=enable_pdl,
+            )
 
     def trtllm_fp8_token(x: torch.Tensor) -> torch.Tensor:
         output = torch.empty_like(x, dtype=_FP8_DTYPE)
@@ -102,7 +175,35 @@ if platform.is_nvidia:
         raise ValueError(f"unsupported TRT-LLM FP8 granularity: {granularity!r}")
 
 
+def has_trtllm_fp8_packed_ue8m0() -> bool:
+    """Return whether the optional TRT-LLM packed quantizer is importable.
+
+    Returns:
+        ``True`` when the vendored shared library and packed op are available.
+    """
+    return _trtllm_fp8_quantize_1x128_packed_ue8m0 is not error_fn
+
+
+def supports_trtllm_fp8_packed_ue8m0(x: torch.Tensor) -> bool:
+    """Check whether an input satisfies the SM100 packed-quantizer contract.
+
+    Args:
+        x: Candidate activation tensor.
+
+    Returns:
+        ``True`` when the op is present and ``x`` has the required device,
+        dtype, shape, contiguity, and alignment.
+    """
+    return (
+        _supports_trtllm_fp8_quant_packed is not None
+        and _supports_trtllm_fp8_quant_packed(x)
+    )
+
+
 __all__ = [
+    "has_trtllm_fp8_packed_ue8m0",
+    "supports_trtllm_fp8_packed_ue8m0",
+    "trtllm_fp8_packed_ue8m0",
     "trtllm_fp8_token_group_128",
     "trtllm_fp8_token",
     "trtllm_fp8_tensor",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/trtllm_deepseek_v4_indexer_q.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/trtllm_deepseek_v4_indexer_q.cu
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Adapted from TensorRT-LLM commit
+ * 1a4fc3e05cea6e2843db8ba7a14e0c3a1a2a7018:
+ *   cpp/tensorrt_llm/kernels/mlaKernels.cu
+ *   cpp/tensorrt_llm/kernels/fusedCatFp4.cu
+ *
+ * The kernel math and launch layouts are preserved.  TensorRT-LLM framework
+ * checks and launch helpers are replaced by TokenSpeed's TVM-FFI boundary.
+ */
+
+#include <cmath>
+#include <climits>
+#include <cstdint>
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+#include "tvm_ffi_utils.h"
+
+using tvm::ffi::TensorView;
+
+namespace {
+
+constexpr int kIndexerHeadDim = 128;
+constexpr int kIndexerRopeDim = 64;
+constexpr int kIndexerNopeDim = kIndexerHeadDim - kIndexerRopeDim;
+
+// TensorRT-LLM's MLA RoPE kernel uses 16-byte vector loads and groups up to
+// sixteen heads in one CTA.  DeepSeek-V4 uses interleaved/GPT-J RoPE.
+constexpr int kRopeBytesPerLoad = 16;
+constexpr int kRopeElemsPerLoad = kRopeBytesPerLoad / sizeof(__nv_bfloat16);
+constexpr int kRopeHeadsPerBlock = 16;
+constexpr int kRopeThreadsPerHead = kIndexerRopeDim / kRopeElemsPerLoad;
+
+union Bf16x8 {
+  uint4 vec;
+  __nv_bfloat162 pairs[kRopeElemsPerLoad / 2];
+};
+
+inline __device__ float2 rotary_embedding_transform(
+    const float2 value,
+    const float2 coefficient) {
+  float2 rotated;
+  rotated.x =
+      coefficient.x * value.x - coefficient.y * value.y;
+  rotated.y =
+      coefficient.x * value.y + coefficient.y * value.x;
+  return rotated;
+}
+
+inline __device__ __nv_bfloat162 rotary_embedding_transform(
+    const __nv_bfloat162 value,
+    const float2 coefficient) {
+  const float2 float_value = __bfloat1622float2(value);
+  const float2 rotated = rotary_embedding_transform(float_value, coefficient);
+  return __floats2bfloat162_rn(rotated.x, rotated.y);
+}
+
+template <typename PositionT>
+__global__ void mla_rope_inplace_bf16_kernel(
+    __nv_bfloat16* __restrict__ data,
+    const PositionT* __restrict__ position_ids,
+    const float* __restrict__ cos_sin_cache,
+    int num_heads) {
+  const int head_idx = blockIdx.y * kRopeHeadsPerBlock + threadIdx.y;
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  cudaGridDependencySynchronize();
+#endif
+  if (head_idx >= num_heads || threadIdx.x >= kRopeThreadsPerHead) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+    cudaTriggerProgrammaticLaunchCompletion();
+#endif
+    return;
+  }
+
+  __nv_bfloat16* head_ptr =
+      data + (static_cast<int64_t>(blockIdx.x) * num_heads + head_idx) *
+                 kIndexerHeadDim;
+  const int position = static_cast<int>(position_ids[blockIdx.x]);
+  const int elem_offset = threadIdx.x * kRopeElemsPerLoad;
+  const int pair_offset = elem_offset / 2;
+  const float* cos_ptr =
+      cos_sin_cache + static_cast<int64_t>(position) * kIndexerRopeDim +
+      pair_offset;
+  const float* sin_ptr = cos_ptr + kIndexerRopeDim / 2;
+
+  Bf16x8 values;
+  values.vec = *reinterpret_cast<const uint4*>(
+      head_ptr + kIndexerNopeDim + elem_offset);
+
+#pragma unroll
+  for (int pair_idx = 0; pair_idx < kRopeElemsPerLoad / 2; ++pair_idx) {
+    const float2 coefficient{cos_ptr[pair_idx], sin_ptr[pair_idx]};
+    values.pairs[pair_idx] =
+        rotary_embedding_transform(values.pairs[pair_idx], coefficient);
+  }
+
+  *reinterpret_cast<uint4*>(head_ptr + kIndexerNopeDim + elem_offset) =
+      values.vec;
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  cudaTriggerProgrammaticLaunchCompletion();
+#endif
+}
+
+constexpr int kWarpSize = 32;
+constexpr int kElemsPerThread = 4;
+constexpr int kRowsPerBlock = 8;
+constexpr int kFp4BlockSize = 32;
+constexpr int kLanesPerFp4Block = kFp4BlockSize / kElemsPerThread;
+constexpr float kInvFp4E2m1Max = 1.0f / 6.0f;
+// TRT-LLM's source uses 1e-12, but its stated DeepGEMM reference and
+// TokenSpeed's existing Q-preparation contract both clamp at 1e-4. Preserve
+// that runtime contract across the token-count dispatch boundary.
+constexpr float kMinAmax = 1.0e-4f;
+
+union Bf16x4 {
+  int2 vec;
+  __nv_bfloat162 pairs[2];
+};
+
+__device__ __forceinline__ uint32_t quantize_fp4_e2m1(float scaled) {
+  const float absolute = fminf(fabsf(scaled), 6.0f);
+  const uint32_t magnitude = static_cast<uint32_t>(
+      (absolute > 0.25f) + (absolute > 0.75f) + (absolute > 1.25f) +
+      (absolute > 1.75f) + (absolute > 2.5f) + (absolute > 3.5f) +
+      (absolute > 5.0f));
+  const uint32_t sign = (scaled < 0.0f && magnitude != 0u) ? 1u : 0u;
+  return (magnitude & 0x7u) | (sign << 3);
+}
+
+// Direct adaptation of TensorRT-LLM's fusedCatFp4Kernel.  Each warp owns one
+// 128-element row.  Inputs may be non-contiguous split views as long as their
+// innermost dimensions are contiguous.
+__global__ __launch_bounds__(kWarpSize * kRowsPerBlock)
+void fused_cat_fp4_kernel(
+    uint8_t* __restrict__ packed_out,
+    int32_t* __restrict__ scale_out,
+    const __nv_bfloat16* __restrict__ first,
+    const __nv_bfloat16* __restrict__ second,
+    int rows,
+    int first_dim,
+    int first_row_stride,
+    int second_row_stride) {
+  const int warp_in_block = threadIdx.x / kWarpSize;
+  const int lane = threadIdx.x % kWarpSize;
+  const int row = blockIdx.x * kRowsPerBlock + warp_in_block;
+  if (row >= rows) {
+    return;
+  }
+
+  const int input_offset = lane * kElemsPerThread;
+  const bool from_first = input_offset < first_dim;
+  const __nv_bfloat16* input_row =
+      (from_first ? first + static_cast<int64_t>(row) * first_row_stride
+                  : second + static_cast<int64_t>(row) * second_row_stride);
+  const int input_column =
+      from_first ? input_offset : input_offset - first_dim;
+
+  Bf16x4 loaded;
+  loaded.vec = *reinterpret_cast<const int2*>(input_row + input_column);
+  const float2 values01 = __bfloat1622float2(loaded.pairs[0]);
+  const float2 values23 = __bfloat1622float2(loaded.pairs[1]);
+
+  float amax = fmaxf(
+      fmaxf(fabsf(values01.x), fabsf(values01.y)),
+      fmaxf(fabsf(values23.x), fabsf(values23.y)));
+  amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 1));
+  amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 2));
+  amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 4));
+  amax = fmaxf(amax, kMinAmax);
+
+  const float ratio = amax * kInvFp4E2m1Max;
+  const uint32_t ratio_bits = __float_as_uint(ratio);
+  uint32_t exponent_bits = ratio_bits & 0x7f800000u;
+  if ((ratio_bits & 0x007fffffu) != 0u) {
+    exponent_bits += 0x00800000u;
+  }
+  const float scale = __uint_as_float(exponent_bits);
+
+  const uint32_t code0 = quantize_fp4_e2m1(values01.x / scale);
+  const uint32_t code1 = quantize_fp4_e2m1(values01.y / scale);
+  const uint32_t code2 = quantize_fp4_e2m1(values23.x / scale);
+  const uint32_t code3 = quantize_fp4_e2m1(values23.y / scale);
+
+  const int output_offset = row * (kIndexerHeadDim / 2) + lane * 2;
+  packed_out[output_offset] =
+      static_cast<uint8_t>(code0 | (code1 << 4));
+  packed_out[output_offset + 1] =
+      static_cast<uint8_t>(code2 | (code3 << 4));
+
+  const uint32_t exponent = (__float_as_uint(scale) >> 23) & 0xffu;
+  const uint32_t exponent0 =
+      __shfl_sync(0xffffffffu, exponent, 0 * kLanesPerFp4Block);
+  const uint32_t exponent1 =
+      __shfl_sync(0xffffffffu, exponent, 1 * kLanesPerFp4Block);
+  const uint32_t exponent2 =
+      __shfl_sync(0xffffffffu, exponent, 2 * kLanesPerFp4Block);
+  const uint32_t exponent3 =
+      __shfl_sync(0xffffffffu, exponent, 3 * kLanesPerFp4Block);
+  if (lane == 0) {
+    scale_out[row] = static_cast<int32_t>(
+        exponent0 | (exponent1 << 8) | (exponent2 << 16) |
+        (exponent3 << 24));
+  }
+}
+
+template <typename PositionT>
+cudaError_t launch_mla_rope_inplace(
+    __nv_bfloat16* data,
+    const PositionT* position_ids,
+    const float* cos_sin_cache,
+    int num_tokens,
+    int num_heads,
+    bool enable_pdl,
+    cudaStream_t stream) {
+  if (num_tokens == 0) {
+    return cudaSuccess;
+  }
+  const dim3 grid(
+      num_tokens,
+      (num_heads + kRopeHeadsPerBlock - 1) / kRopeHeadsPerBlock);
+  const dim3 block(kRopeThreadsPerHead, kRopeHeadsPerBlock);
+  cudaLaunchConfig_t config{};
+  config.gridDim = grid;
+  config.blockDim = block;
+  config.dynamicSmemBytes = 0;
+  config.stream = stream;
+  cudaLaunchAttribute attrs[1]{};
+  attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attrs[0].val.programmaticStreamSerializationAllowed = enable_pdl;
+  config.attrs = attrs;
+  config.numAttrs = 1;
+  return cudaLaunchKernelEx(
+      &config,
+      mla_rope_inplace_bf16_kernel<PositionT>,
+      data,
+      position_ids,
+      cos_sin_cache,
+      num_heads);
+}
+
+}  // namespace
+
+void trtllm_deepseek_v4_mla_rope_inplace(
+    TensorView data,
+    TensorView position_ids,
+    TensorView cos_sin_cache,
+    bool enable_pdl) {
+  CHECK_CUDA(data);
+  CHECK_CUDA(position_ids);
+  CHECK_CUDA(cos_sin_cache);
+  CHECK_DEVICE(data, position_ids);
+  CHECK_DEVICE(data, cos_sin_cache);
+  CHECK_DIM(3, data);
+  CHECK_DIM(1, position_ids);
+  CHECK_DIM(2, cos_sin_cache);
+  CHECK_INPUT_TYPE(data, dl_bfloat16);
+  CHECK_INPUT_TYPE(cos_sin_cache, dl_float32);
+  TVM_FFI_ICHECK(
+      position_ids.dtype() == dl_int32 || position_ids.dtype() == dl_int64)
+      << "position_ids must be int32 or int64";
+  CHECK_CONTIGUOUS(data);
+  CHECK_CONTIGUOUS(position_ids);
+  CHECK_CONTIGUOUS(cos_sin_cache);
+  TVM_FFI_ICHECK_EQ(data.size(2), kIndexerHeadDim)
+      << "data head_dim must be 128";
+  TVM_FFI_ICHECK_EQ(position_ids.size(0), data.size(0))
+      << "position_ids must cover every token";
+  TVM_FFI_ICHECK_EQ(cos_sin_cache.size(1), kIndexerRopeDim)
+      << "cos_sin_cache width must be 64";
+  TVM_FFI_ICHECK_EQ(
+      reinterpret_cast<uintptr_t>(data.data_ptr()) % kRopeBytesPerLoad, 0)
+      << "data must be 16-byte aligned";
+
+  cudaSetDevice(data.device().device_id);
+  const cudaStream_t stream = get_stream(data.device());
+  auto* data_ptr = static_cast<__nv_bfloat16*>(data.data_ptr());
+  const auto* cos_sin_ptr = static_cast<const float*>(cos_sin_cache.data_ptr());
+  const int num_tokens = static_cast<int>(data.size(0));
+  const int num_heads = static_cast<int>(data.size(1));
+  cudaError_t status;
+  if (position_ids.dtype() == dl_int32) {
+    status = launch_mla_rope_inplace(
+        data_ptr,
+        static_cast<const int32_t*>(position_ids.data_ptr()),
+        cos_sin_ptr,
+        num_tokens,
+        num_heads,
+        enable_pdl,
+        stream);
+  } else {
+    status = launch_mla_rope_inplace(
+        data_ptr,
+        static_cast<const int64_t*>(position_ids.data_ptr()),
+        cos_sin_ptr,
+        num_tokens,
+        num_heads,
+        enable_pdl,
+        stream);
+  }
+
+  TVM_FFI_ICHECK_EQ(status, cudaSuccess)
+      << "TRT-LLM MLA RoPE launch failed: " << cudaGetErrorString(status);
+  status = cudaGetLastError();
+  TVM_FFI_ICHECK_EQ(status, cudaSuccess)
+      << "TRT-LLM MLA RoPE launch state failed: "
+      << cudaGetErrorString(status);
+}
+
+void trtllm_deepseek_v4_fused_cat_fp4(
+    TensorView first,
+    TensorView second,
+    TensorView packed_out,
+    TensorView scale_out) {
+  CHECK_CUDA(first);
+  CHECK_CUDA(second);
+  CHECK_CUDA(packed_out);
+  CHECK_CUDA(scale_out);
+  CHECK_DEVICE(first, second);
+  CHECK_DEVICE(first, packed_out);
+  CHECK_DEVICE(first, scale_out);
+  TVM_FFI_ICHECK_GE(first.ndim(), 2) << "first must be at least 2-D";
+  TVM_FFI_ICHECK_GE(second.ndim(), 2) << "second must be at least 2-D";
+  CHECK_DIM(2, packed_out);
+  CHECK_DIM(2, scale_out);
+  CHECK_INPUT_TYPE(first, dl_bfloat16);
+  CHECK_INPUT_TYPE(second, dl_bfloat16);
+  CHECK_INPUT_TYPE(packed_out, dl_uint8);
+  CHECK_INPUT_TYPE(scale_out, dl_int32);
+  TVM_FFI_ICHECK_EQ(first.stride(-1), 1)
+      << "first innermost dimension must be contiguous";
+  TVM_FFI_ICHECK_EQ(second.stride(-1), 1)
+      << "second innermost dimension must be contiguous";
+  CHECK_CONTIGUOUS(packed_out);
+  CHECK_CONTIGUOUS(scale_out);
+
+  const int first_dim = static_cast<int>(first.size(-1));
+  const int second_dim = static_cast<int>(second.size(-1));
+  TVM_FFI_ICHECK_EQ(first_dim + second_dim, kIndexerHeadDim)
+      << "input dimensions must concatenate to 128";
+  TVM_FFI_ICHECK_EQ(first_dim % kElemsPerThread, 0)
+      << "first dimension must be divisible by 4";
+  const int64_t first_rows = first.numel() / first_dim;
+  const int64_t second_rows = second.numel() / second_dim;
+  TVM_FFI_ICHECK_EQ(first_rows, second_rows)
+      << "inputs must contain the same number of rows";
+  TVM_FFI_ICHECK_LE(first_rows, static_cast<int64_t>(INT32_MAX))
+      << "row count exceeds int32 range";
+  TVM_FFI_ICHECK_EQ(packed_out.size(0), first_rows);
+  TVM_FFI_ICHECK_EQ(packed_out.size(1), kIndexerHeadDim / 2);
+  TVM_FFI_ICHECK_EQ(scale_out.size(0), first_rows);
+  TVM_FFI_ICHECK_EQ(scale_out.size(1), 1);
+  int64_t first_expected_stride = first.stride(-2);
+  int64_t second_expected_stride = second.stride(-2);
+  if (first_rows > 0) {
+    for (int axis = static_cast<int>(first.ndim()) - 2; axis >= 0; --axis) {
+      if (first.size(axis) > 1) {
+        TVM_FFI_ICHECK_EQ(first.stride(axis), first_expected_stride)
+            << "first leading dimensions must be row-linear";
+      }
+      first_expected_stride *= first.size(axis);
+    }
+    for (int axis = static_cast<int>(second.ndim()) - 2; axis >= 0; --axis) {
+      if (second.size(axis) > 1) {
+        TVM_FFI_ICHECK_EQ(second.stride(axis), second_expected_stride)
+            << "second leading dimensions must be row-linear";
+      }
+      second_expected_stride *= second.size(axis);
+    }
+  }
+  TVM_FFI_ICHECK_GE(first.stride(-2), 0);
+  TVM_FFI_ICHECK_LE(first.stride(-2), static_cast<int64_t>(INT32_MAX));
+  TVM_FFI_ICHECK_GE(second.stride(-2), 0);
+  TVM_FFI_ICHECK_LE(second.stride(-2), static_cast<int64_t>(INT32_MAX));
+  TVM_FFI_ICHECK_EQ(first.stride(-2) % kElemsPerThread, 0)
+      << "first row stride must preserve vector alignment";
+  TVM_FFI_ICHECK_EQ(second.stride(-2) % kElemsPerThread, 0)
+      << "second row stride must preserve vector alignment";
+  TVM_FFI_ICHECK_EQ(reinterpret_cast<uintptr_t>(first.data_ptr()) % 8, 0)
+      << "first pointer must be 8-byte aligned";
+  TVM_FFI_ICHECK_EQ(reinterpret_cast<uintptr_t>(second.data_ptr()) % 8, 0)
+      << "second pointer must be 8-byte aligned";
+
+  const int rows = static_cast<int>(first_rows);
+  if (rows == 0) {
+    return;
+  }
+  cudaSetDevice(first.device().device_id);
+  const cudaStream_t stream = get_stream(first.device());
+  const int blocks = (rows + kRowsPerBlock - 1) / kRowsPerBlock;
+  fused_cat_fp4_kernel<<<blocks, kWarpSize * kRowsPerBlock, 0, stream>>>(
+      static_cast<uint8_t*>(packed_out.data_ptr()),
+      static_cast<int32_t*>(scale_out.data_ptr()),
+      static_cast<const __nv_bfloat16*>(first.data_ptr()),
+      static_cast<const __nv_bfloat16*>(second.data_ptr()),
+      rows,
+      first_dim,
+      static_cast<int>(first.stride(-2)),
+      static_cast<int>(second.stride(-2)));
+
+  const cudaError_t status = cudaGetLastError();
+  TVM_FFI_ICHECK_EQ(status, cudaSuccess)
+      << "TRT-LLM fusedCatFp4 launch failed: " << cudaGetErrorString(status);
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    trtllm_deepseek_v4_mla_rope_inplace,
+    trtllm_deepseek_v4_mla_rope_inplace);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    trtllm_deepseek_v4_fused_cat_fp4,
+    trtllm_deepseek_v4_fused_cat_fp4);

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/trtllm_fp8_quant_packed.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/trtllm_fp8_quant_packed.cu
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Adapted from TensorRT-LLM commit
+ * 1a4fc3e05cea6e2843db8ba7a14e0c3a1a2a7018:
+ *   cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/
+ *   fp8_blockscale_quant_packed.cu
+ *
+ * TensorRT-LLM introduced the kernel in 096f86eca5 and completed padded-row
+ * initialization in d2ba38fccd. TokenSpeed retains the kernel launch/layout,
+ * constrains K to complete 128-element groups, exposes per-call PDL through a
+ * TVM-FFI adapter, and keeps TokenSpeed's pre-existing post-division scale
+ * floor so this performance change does not alter fallback numerics.
+ */
+
+#include <climits>
+#include <cstdint>
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+#include "tvm_ffi_utils.h"
+
+using tvm::ffi::TensorView;
+
+namespace {
+
+__device__ __forceinline__ float reciprocal_approximate_ftz(float value) {
+  float reciprocal;
+  asm volatile("rcp.approx.ftz.f32 %0, %1;\n"
+               : "=f"(reciprocal)
+               : "f"(value));
+  return reciprocal;
+}
+
+// Each warp consumes one row by four 128-element quantization groups. The
+// four eight-lane subgroups reduce one amax each, then lane 0 packs their
+// UE8M0 bytes into the final DeepGEMM int32 layout.
+template <int WarpsPerBlock>
+__global__ void fp8_quantize_1x128_packed_kernel(
+    __nv_fp8_e4m3* __restrict__ fp8_output,
+    int32_t* __restrict__ packed_scale_output,
+    const __nv_bfloat16* __restrict__ input,
+    int rows,
+    int columns,
+    int scale_leading_dim) {
+  const int packed_scale_column = static_cast<int>(blockIdx.x);
+  const int warp_id = static_cast<int>(threadIdx.x) >> 5;
+  const int lane_id = static_cast<int>(threadIdx.x) & 31;
+  const int row = static_cast<int>(blockIdx.y) * WarpsPerBlock + warp_id;
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  cudaGridDependencySynchronize();
+#endif
+
+  const bool row_in_range = row < rows;
+  uint32_t packed_scale = 0u;
+  if (row_in_range) {
+    const int column_base = packed_scale_column * 512 + lane_id * 16;
+
+    constexpr int kLoadElements = sizeof(double4) / sizeof(__nv_bfloat16);
+    union Bf16Load {
+      double4 vector;
+      __nv_bfloat16 values[kLoadElements];
+    };
+
+    Bf16Load loaded;
+    const bool column_in_range = column_base < columns;
+    if (column_in_range) {
+      const auto* input_vector = reinterpret_cast<const double4*>(
+          input + static_cast<int64_t>(row) * columns + column_base);
+      loaded.vector = input_vector[0];
+    } else {
+      loaded.vector = double4{};
+    }
+
+    if (column_in_range && column_base + kLoadElements > columns) {
+      const int valid = columns - column_base;
+#pragma unroll
+      for (int index = 0; index < kLoadElements; ++index) {
+        if (index >= valid) {
+          loaded.values[index] = __nv_bfloat16(0.0f);
+        }
+      }
+    }
+
+    __nv_bfloat16 max_value = __nv_bfloat16(0.0f);
+#pragma unroll
+    for (int index = 0; index < kLoadElements; ++index) {
+      max_value = __hmax(max_value, __habs(loaded.values[index]));
+    }
+    float amax = static_cast<float>(max_value);
+    amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 4, 8));
+    amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 2, 8));
+    amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 1, 8));
+    const float raw_scale = fmaxf(
+        amax * reciprocal_approximate_ftz(448.0f), 1.0e-10f);
+    __nv_fp8_e8m0 ue8m0_scale;
+    ue8m0_scale.__x = __nv_cvt_float_to_e8m0(
+        raw_scale, __NV_SATFINITE, cudaRoundPosInf);
+
+    constexpr uint32_t kFp32ExponentBias = 127u;
+    const float quant_scale = ue8m0_scale.__x == 0
+                                  ? 1.0f
+                                  : exp2f(static_cast<float>(kFp32ExponentBias) -
+                                          static_cast<float>(ue8m0_scale.__x));
+
+    constexpr int kStoreElements = sizeof(float4) / sizeof(__nv_fp8_e4m3);
+    union Fp8Store {
+      float4 vector;
+      __nv_fp8_e4m3 values[kStoreElements];
+    };
+
+    Fp8Store quantized;
+    quantized.vector = float4{};
+#pragma unroll
+    for (int index = 0; index < kStoreElements; ++index) {
+      quantized.values[index] = __nv_fp8_e4m3(
+          static_cast<float>(loaded.values[index]) * quant_scale);
+    }
+    if (column_in_range) {
+      if (column_base + kStoreElements > columns) {
+        const int valid = columns - column_base;
+#pragma unroll
+        for (int index = 0; index < kStoreElements; ++index) {
+          if (index >= valid) {
+            quantized.values[index] = __nv_fp8_e4m3(0.0f);
+          }
+        }
+      }
+      auto* output_vector = reinterpret_cast<float4*>(
+          fp8_output + static_cast<int64_t>(row) * columns + column_base);
+      output_vector[0] = quantized.vector;
+    }
+
+    const uint32_t scale0 = __shfl_sync(
+        0xffffffffu, static_cast<uint32_t>(ue8m0_scale.__x), 0);
+    const uint32_t scale1 = __shfl_sync(
+        0xffffffffu, static_cast<uint32_t>(ue8m0_scale.__x), 8);
+    const uint32_t scale2 = __shfl_sync(
+        0xffffffffu, static_cast<uint32_t>(ue8m0_scale.__x), 16);
+    const uint32_t scale3 = __shfl_sync(
+        0xffffffffu, static_cast<uint32_t>(ue8m0_scale.__x), 24);
+    if (lane_id == 0) {
+      const int scale_columns = (columns + 127) / 128;
+      const int scale_column_base = packed_scale_column * 4;
+      if (scale_column_base < scale_columns) {
+        packed_scale |= scale0;
+      }
+      if (scale_column_base + 1 < scale_columns) {
+        packed_scale |= scale1 << 8;
+      }
+      if (scale_column_base + 2 < scale_columns) {
+        packed_scale |= scale2 << 16;
+      }
+      if (scale_column_base + 3 < scale_columns) {
+        packed_scale |= scale3 << 24;
+      }
+    }
+  }
+
+  if (lane_id == 0 && row < scale_leading_dim) {
+    packed_scale_output[
+        static_cast<int64_t>(packed_scale_column) * scale_leading_dim + row] =
+        static_cast<int32_t>(packed_scale);
+  }
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  cudaTriggerProgrammaticLaunchCompletion();
+#endif
+}
+
+cudaError_t launch_fp8_quantize_1x128_packed(
+    __nv_fp8_e4m3* fp8_output,
+    int32_t* packed_scale_output,
+    const __nv_bfloat16* input,
+    int rows,
+    int columns,
+    int scale_leading_dim,
+    bool enable_pdl,
+    cudaStream_t stream) {
+  constexpr int kWarpsPerBlock = 4;
+  const int packed_scale_columns = ((columns + 127) / 128 + 3) / 4;
+  const int row_blocks =
+      (scale_leading_dim + kWarpsPerBlock - 1) / kWarpsPerBlock;
+  const dim3 grid(packed_scale_columns, row_blocks, 1);
+  const dim3 block(kWarpsPerBlock * 32, 1, 1);
+
+  cudaLaunchConfig_t config{};
+  config.gridDim = grid;
+  config.blockDim = block;
+  config.dynamicSmemBytes = 0;
+  config.stream = stream;
+  cudaLaunchAttribute attributes[1]{};
+  attributes[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attributes[0].val.programmaticStreamSerializationAllowed = enable_pdl;
+  config.attrs = attributes;
+  config.numAttrs = 1;
+  return cudaLaunchKernelEx(
+      &config,
+      fp8_quantize_1x128_packed_kernel<kWarpsPerBlock>,
+      fp8_output,
+      packed_scale_output,
+      input,
+      rows,
+      columns,
+      scale_leading_dim);
+}
+
+}  // namespace
+
+void trtllm_fp8_quantize_1x128_packed_ue8m0(
+    TensorView input,
+    TensorView fp8_output,
+    TensorView packed_scale_output,
+    bool enable_pdl) {
+  CHECK_CUDA(input);
+  CHECK_CUDA(fp8_output);
+  CHECK_CUDA(packed_scale_output);
+  CHECK_DEVICE(input, fp8_output);
+  CHECK_DEVICE(input, packed_scale_output);
+  CHECK_DIM(2, input);
+  CHECK_DIM(2, fp8_output);
+  CHECK_DIM(2, packed_scale_output);
+  CHECK_INPUT_TYPE(input, dl_bfloat16);
+  CHECK_INPUT_TYPE(fp8_output, dl_float8_e4m3fn);
+  CHECK_INPUT_TYPE(packed_scale_output, dl_int32);
+  CHECK_CONTIGUOUS(input);
+  CHECK_CONTIGUOUS(fp8_output);
+  CHECK_CONTIGUOUS(packed_scale_output);
+
+  const int64_t rows64 = input.size(0);
+  const int64_t columns64 = input.size(1);
+  TVM_FFI_ICHECK_GT(rows64, 0) << "input must contain at least one row";
+  TVM_FFI_ICHECK_LE(rows64, static_cast<int64_t>(INT32_MAX));
+  TVM_FFI_ICHECK_GT(columns64, 0) << "input must contain at least one column";
+  TVM_FFI_ICHECK_LE(columns64, static_cast<int64_t>(INT32_MAX));
+  TVM_FFI_ICHECK_EQ(columns64 % 128, 0)
+      << "input columns must be divisible by 128";
+  TVM_FFI_ICHECK_EQ(fp8_output.size(0), rows64);
+  TVM_FFI_ICHECK_EQ(fp8_output.size(1), columns64);
+
+  const int64_t aligned_rows = (rows64 + 3) / 4 * 4;
+  const int64_t packed_scale_columns = (columns64 / 128 + 3) / 4;
+  TVM_FFI_ICHECK_EQ(packed_scale_output.size(0), packed_scale_columns);
+  TVM_FFI_ICHECK_EQ(packed_scale_output.size(1), aligned_rows);
+  TVM_FFI_ICHECK_EQ(
+      reinterpret_cast<uintptr_t>(input.data_ptr()) % sizeof(double4), 0)
+      << "input must be 32-byte aligned";
+  TVM_FFI_ICHECK_EQ(
+      reinterpret_cast<uintptr_t>(fp8_output.data_ptr()) % sizeof(float4), 0)
+      << "fp8_output must be 16-byte aligned";
+
+  const int device_id = input.device().device_id;
+  cudaError_t status = cudaSetDevice(device_id);
+  TVM_FFI_ICHECK_EQ(status, cudaSuccess)
+      << "cudaSetDevice failed: " << cudaGetErrorString(status);
+
+  const cudaStream_t stream = get_stream(input.device());
+  status = launch_fp8_quantize_1x128_packed(
+      static_cast<__nv_fp8_e4m3*>(fp8_output.data_ptr()),
+      static_cast<int32_t*>(packed_scale_output.data_ptr()),
+      static_cast<const __nv_bfloat16*>(input.data_ptr()),
+      static_cast<int>(rows64),
+      static_cast<int>(columns64),
+      static_cast<int>(aligned_rows),
+      enable_pdl,
+      stream);
+  TVM_FFI_ICHECK_EQ(status, cudaSuccess)
+      << "TRT-LLM packed FP8 quantization launch failed: "
+      << cudaGetErrorString(status);
+  status = cudaGetLastError();
+  TVM_FFI_ICHECK_EQ(status, cudaSuccess)
+      << "TRT-LLM packed FP8 quantization launch state failed: "
+      << cudaGetErrorString(status);
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    trtllm_fp8_quantize_1x128_packed_ue8m0,
+    trtllm_fp8_quantize_1x128_packed_ue8m0);

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/trtllm_deepseek_v4_indexer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/trtllm_deepseek_v4_indexer.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Wrappers for vendored TRT-LLM DeepSeek-V4 indexer Q kernels."""
+
+from __future__ import annotations
+
+import functools
+from pathlib import Path
+
+import torch
+import tvm_ffi
+
+
+@functools.cache
+def _load_module():
+    so_path = (
+        Path(__file__).resolve().parent
+        / "objs"
+        / "trtllm_deepseek_v4_indexer_q"
+        / "trtllm_deepseek_v4_indexer_q.so"
+    )
+    if not so_path.exists():
+        raise RuntimeError(
+            "tokenspeed_kernel TRT-LLM DeepSeek-V4 indexer library not found at "
+            f"{so_path}. Run `pip install -e tokenspeed-kernel/python/` to build."
+        )
+    return tvm_ffi.load_module(str(so_path))
+
+
+def has_trtllm_indexer_q_kernels() -> bool:
+    """Return whether the vendored TRT-LLM RoPE and FP4 pack ops are built."""
+
+    try:
+        module = _load_module()
+    except Exception:
+        return False
+    return all(
+        hasattr(module, name)
+        for name in (
+            "trtllm_deepseek_v4_mla_rope_inplace",
+            "trtllm_deepseek_v4_fused_cat_fp4",
+        )
+    )
+
+
+def trtllm_mla_rope_inplace(
+    data: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    enable_pdl: bool = False,
+) -> None:
+    """Apply TRT-LLM's interleaved DeepSeek-V4 MLA RoPE in place.
+
+    Args:
+        data: Contiguous BF16 tensor shaped ``[tokens, heads, 128]``.
+        positions: Contiguous INT32/INT64 absolute positions shaped ``[tokens]``.
+        cos_sin_cache: Contiguous FP32 table shaped ``[max_position, 64]``.
+        enable_pdl: Whether to enable programmatic dependent launch.
+
+    Returns:
+        ``None``. The final 64 elements of each head in ``data`` are updated.
+    """
+
+    if data.dtype != torch.bfloat16:
+        raise TypeError(f"data must be bfloat16, got {data.dtype}")
+    if data.ndim != 3 or data.shape[-1] != 128:
+        raise ValueError(f"data must be [tokens, heads, 128], got {tuple(data.shape)}")
+    if not data.is_contiguous():
+        raise ValueError("data must be contiguous")
+    if positions.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f"positions must be int32 or int64, got {positions.dtype}")
+    if positions.ndim != 1 or positions.shape[0] != data.shape[0]:
+        raise ValueError(
+            f"positions must be [{data.shape[0]}], got {tuple(positions.shape)}"
+        )
+    if cos_sin_cache.dtype != torch.float32:
+        raise TypeError(f"cos_sin_cache must be float32, got {cos_sin_cache.dtype}")
+    if cos_sin_cache.ndim != 2 or cos_sin_cache.shape[1] != 64:
+        raise ValueError(
+            "cos_sin_cache must be [max_position, 64], "
+            f"got {tuple(cos_sin_cache.shape)}"
+        )
+    _load_module().trtllm_deepseek_v4_mla_rope_inplace(
+        data,
+        positions.contiguous(),
+        cos_sin_cache.contiguous(),
+        bool(enable_pdl),
+    )
+
+
+def trtllm_fused_cat_fp4(
+    first: torch.Tensor,
+    second: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run TRT-LLM's fused concat plus per-block MXFP4 pack kernel.
+
+    Args:
+        first: BF16 tensor with a contiguous innermost dimension and
+            row-linear leading dimensions.
+        second: BF16 tensor with the same flattened row count and layout
+            contract as ``first``.
+
+    Returns:
+        A pair ``(packed, scales)``. ``packed`` is UINT8 ``[rows, 64]`` and
+        ``scales`` is INT32 ``[rows, 1]`` containing four packed UE8M0 bytes.
+    """
+
+    if first.dtype != torch.bfloat16 or second.dtype != torch.bfloat16:
+        raise TypeError(
+            f"first and second must be bfloat16, got {first.dtype} and {second.dtype}"
+        )
+    if first.ndim < 2 or second.ndim < 2:
+        raise ValueError("first and second must be at least 2-D")
+    if first.shape[-1] + second.shape[-1] != 128:
+        raise ValueError(
+            "first and second innermost dimensions must sum to 128, got "
+            f"{first.shape[-1]} + {second.shape[-1]}"
+        )
+    if first.stride(-1) != 1 or second.stride(-1) != 1:
+        raise ValueError("first and second innermost dimensions must be contiguous")
+    for name, tensor in (("first", first), ("second", second)):
+        if tensor.numel() == 0:
+            continue
+        expected_stride = tensor.stride(-2)
+        for size, stride in zip(
+            reversed(tensor.shape[:-1]),
+            reversed(tensor.stride()[:-1]),
+        ):
+            if size > 1 and stride != expected_stride:
+                raise ValueError(
+                    f"{name} leading dimensions must be row-linear, got "
+                    f"shape {tuple(tensor.shape)} and strides {tensor.stride()}"
+                )
+            expected_stride *= size
+    first_rows = first.numel() // first.shape[-1]
+    second_rows = second.numel() // second.shape[-1]
+    if first_rows != second_rows:
+        raise ValueError(
+            f"first and second row counts must match, got {first_rows} and {second_rows}"
+        )
+    packed = torch.empty((first_rows, 64), dtype=torch.uint8, device=first.device)
+    scales = torch.empty((first_rows, 1), dtype=torch.int32, device=first.device)
+    _load_module().trtllm_deepseek_v4_fused_cat_fp4(
+        first,
+        second,
+        packed,
+        scales,
+    )
+    return packed, scales

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/trtllm_fp8_quant.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/trtllm_fp8_quant.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Wrapper for the vendored TRT-LLM packed UE8M0 FP8 quantizer."""
+
+from __future__ import annotations
+
+import functools
+from pathlib import Path
+
+import torch
+import tvm_ffi
+
+
+@functools.cache
+def _load_module():
+    so_path = (
+        Path(__file__).resolve().parent
+        / "objs"
+        / "trtllm_fp8_quant_packed"
+        / "trtllm_fp8_quant_packed.so"
+    )
+    if not so_path.exists():
+        raise RuntimeError(
+            "tokenspeed_kernel TRT-LLM packed FP8 quantization library not "
+            f"found at {so_path}. Run `pip install -e tokenspeed-kernel/python/` "
+            "to build."
+        )
+    return tvm_ffi.load_module(str(so_path))
+
+
+@functools.cache
+def has_trtllm_fp8_quant_packed() -> bool:
+    """Return whether the vendored TRT-LLM packed quantizer is built.
+
+    Returns:
+        ``True`` when the shared library can be loaded and exports the op.
+    """
+
+    try:
+        module = _load_module()
+    except Exception:
+        return False
+    return hasattr(module, "trtllm_fp8_quantize_1x128_packed_ue8m0")
+
+
+@functools.cache
+def _is_supported_device(device_index: int) -> bool:
+    return torch.cuda.get_device_capability(device_index) == (10, 0)
+
+
+def supports_trtllm_fp8_quant_packed(x: torch.Tensor) -> bool:
+    """Check whether an input can use the vendored SM100 quantizer.
+
+    Args:
+        x: Candidate activation tensor.
+
+    Returns:
+        ``True`` when the op is present and ``x`` has the required device,
+        dtype, shape, contiguity, and alignment.
+    """
+
+    if (
+        not has_trtllm_fp8_quant_packed()
+        or not x.is_cuda
+        or x.dtype != torch.bfloat16
+        or x.ndim != 2
+        or not x.is_contiguous()
+        or x.shape[0] == 0
+        or x.shape[1] == 0
+        or x.shape[1] % 128 != 0
+        or x.data_ptr() % 32 != 0
+    ):
+        return False
+    device_index = x.device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    return _is_supported_device(device_index)
+
+
+def trtllm_fp8_quantize_1x128_packed_ue8m0(
+    x: torch.Tensor,
+    *,
+    enable_pdl: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize BF16 rows and emit DeepGEMM packed UE8M0 scales.
+
+    Args:
+        x: Contiguous, 32-byte-aligned CUDA BF16 matrix shaped
+            ``[rows, columns]``. The column count must be divisible by 128.
+        enable_pdl: Whether to allow programmatic dependent launch.
+
+    Returns:
+        A pair ``(values, scales)``. ``values`` is row-major E4M3 with the same
+        shape as ``x``. ``scales`` is an INT32 view shaped
+        ``[rows, ceil(columns / 512)]`` with stride ``(1, align(rows, 4))``.
+    """
+
+    if not x.is_cuda:
+        raise ValueError("x must be a CUDA tensor")
+    if x.dtype != torch.bfloat16:
+        raise TypeError(f"x must be bfloat16, got {x.dtype}")
+    if x.ndim != 2:
+        raise ValueError(f"x must be a matrix, got shape {tuple(x.shape)}")
+    if not x.is_contiguous():
+        raise ValueError("x must be contiguous")
+    if x.data_ptr() % 32 != 0:
+        raise ValueError("x must be 32-byte aligned")
+    rows, columns = x.shape
+    if rows == 0:
+        raise ValueError("x must contain at least one row")
+    if columns == 0 or columns % 128 != 0:
+        raise ValueError(f"x columns must be divisible by 128, got {columns}")
+
+    aligned_rows = (rows + 3) // 4 * 4
+    device_index = x.device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    if not _is_supported_device(device_index):
+        raise RuntimeError("TRT-LLM packed UE8M0 quantization requires SM100")
+
+    value_storage = torch.empty(
+        (aligned_rows, columns),
+        dtype=torch.float8_e4m3fn,
+        device=x.device,
+    )
+    values = value_storage[:rows]
+    packed_scale_columns = (columns // 128 + 3) // 4
+    scale_storage = torch.empty(
+        (packed_scale_columns, aligned_rows),
+        dtype=torch.int32,
+        device=x.device,
+    )
+    _load_module().trtllm_fp8_quantize_1x128_packed_ue8m0(
+        x,
+        values,
+        scale_storage,
+        bool(enable_pdl),
+    )
+    scales = scale_storage.transpose(0, 1)[:rows, :]
+    return values, scales
+
+
+__all__ = [
+    "has_trtllm_fp8_quant_packed",
+    "supports_trtllm_fp8_quant_packed",
+    "trtllm_fp8_quantize_1x128_packed_ue8m0",
+]

--- a/tokenspeed-kernel/test/ops/test_quantization.py
+++ b/tokenspeed-kernel/test/ops/test_quantization.py
@@ -29,10 +29,21 @@ from tokenspeed_kernel import (
     quantize_mxfp8,
     quantize_nvfp4,
 )
+from tokenspeed_kernel.ops.gemm import _online_quantize_mxfp8
+from tokenspeed_kernel.ops.gemm.fp8_utils import (
+    _per_token_group_quant_8bit_raw,
+    per_token_group_quant_fp8,
+)
 from tokenspeed_kernel.ops.quantization.triton import fp8_quantize
-from tokenspeed_kernel.platform import current_platform
+from tokenspeed_kernel.ops.quantization.trtllm import (
+    supports_trtllm_fp8_packed_ue8m0,
+    trtllm_fp8_packed_ue8m0,
+)
+from tokenspeed_kernel.platform import ArchVersion, current_platform
 
 FP8_E4M3_FNUZ_MAX = 240.0
+_PLATFORM = current_platform()
+_IS_SM100 = _PLATFORM.is_nvidia and _PLATFORM.arch_version == ArchVersion(10, 0)
 
 
 def _bitwise_equal(a: torch.Tensor, b: torch.Tensor) -> bool:
@@ -333,6 +344,391 @@ def test_quantize_fp8_with_scale_token_group(
     assert out.dtype == fp8.dtype
     assert scale.dtype == torch.float32
     assert scale.numel() > 0
+
+
+@pytest.mark.skipif(
+    not _IS_SM100,
+    reason="packed UE8M0 TRT-LLM quantization requires SM100",
+)
+@pytest.mark.parametrize(
+    "shape",
+    [(1, 128), (2, 2048), (4, 7168), (8, 28672), (17, 512)],
+)
+def test_quantize_fp8_with_packed_ue8m0(
+    device: str,
+    shape: tuple[int, int],
+    require,
+) -> None:
+    dtype = torch.bfloat16
+    require("quantization", "fp8_with_scale", "trtllm", dtype, "x")
+    torch.manual_seed(8)
+    x = torch.randn(shape, device=device, dtype=dtype)
+
+    out, scale = quantize_fp8_with_scale(
+        x,
+        granularity="token_group",
+        group_size=128,
+        scale_encoding="packed_ue8m0",
+        solution="trtllm",
+    )
+    ref_out, ref_scale = _per_token_group_quant_8bit_raw(
+        x,
+        128,
+        column_major_scales=True,
+        scale_tma_aligned=True,
+        scale_ue8m0=True,
+    )
+    torch.cuda.synchronize()
+
+    assert _bitwise_equal(out, ref_out)
+    assert scale.dtype == torch.int32
+    assert scale.shape == ref_scale.shape
+    assert scale.stride() == ref_scale.stride()
+    assert torch.equal(scale, ref_scale)
+
+
+@pytest.mark.skipif(
+    not _IS_SM100,
+    reason="packed UE8M0 TRT-LLM quantization requires SM100",
+)
+@pytest.mark.parametrize(
+    ("value", "expected_scale_byte"),
+    [(0.0, 94), (1e-10, 94), (4.5e-8, 94), (6e-8, 95)],
+)
+def test_packed_ue8m0_scale_floor_matches_existing_contract(
+    device: str,
+    value: float,
+    expected_scale_byte: int,
+) -> None:
+    x = torch.full((4, 128), value, device=device, dtype=torch.bfloat16)
+
+    ref_out, ref_scale = _per_token_group_quant_8bit_raw(
+        x,
+        128,
+        column_major_scales=True,
+        scale_tma_aligned=True,
+        scale_ue8m0=True,
+    )
+    out, scale = trtllm_fp8_packed_ue8m0(x)
+    torch.cuda.synchronize()
+
+    assert _bitwise_equal(out, ref_out)
+    assert scale.stride() == ref_scale.stride()
+    assert torch.equal(scale, ref_scale)
+    physical = torch.as_strided(scale, size=(1, 4), stride=(4, 1))
+    scale_bytes = physical.view(torch.uint8).reshape(4, 4)
+    assert torch.equal(
+        scale_bytes[:, 0],
+        torch.full((4,), expected_scale_byte, device=device, dtype=torch.uint8),
+    )
+
+
+@pytest.mark.skipif(
+    not _IS_SM100,
+    reason="packed UE8M0 TRT-LLM quantization requires SM100",
+)
+@pytest.mark.parametrize("exponent", [-16, -1, 0, 8, 16])
+def test_packed_ue8m0_rounding_boundaries(
+    device: str,
+    exponent: int,
+) -> None:
+    boundary = torch.tensor(
+        448.0 * 2.0**exponent,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    above = torch.nextafter(
+        boundary,
+        torch.tensor(float("inf"), device=device, dtype=torch.bfloat16),
+    )
+    x = torch.stack((boundary, above)).unsqueeze(1).expand(2, 128).contiguous()
+
+    out, scale = trtllm_fp8_packed_ue8m0(x)
+    ref_out, ref_scale = _per_token_group_quant_8bit_raw(
+        x,
+        128,
+        column_major_scales=True,
+        scale_tma_aligned=True,
+        scale_ue8m0=True,
+    )
+    torch.cuda.synchronize()
+
+    assert _bitwise_equal(out, ref_out)
+    assert torch.equal(scale, ref_scale)
+    physical = torch.as_strided(scale, size=(1, 4), stride=(4, 1))
+    scale_bytes = physical.view(torch.uint8).reshape(4, 4)
+    assert scale_bytes[0, 0].item() == exponent + 127
+    assert scale_bytes[1, 0].item() == exponent + 128
+
+
+@pytest.mark.skipif(
+    not _IS_SM100,
+    reason="packed UE8M0 TRT-LLM quantization requires SM100",
+)
+def test_packed_ue8m0_padding_is_initialized(device: str) -> None:
+    rows, columns = 3, 128
+    x = torch.zeros((rows, columns), device=device, dtype=torch.bfloat16)
+
+    out, scale = trtllm_fp8_packed_ue8m0(x)
+    torch.cuda.synchronize()
+
+    aligned_rows = 4
+    physical = torch.as_strided(
+        scale,
+        size=(1, aligned_rows),
+        stride=(aligned_rows, 1),
+    )
+    valid_scale_bytes = physical[0, :rows].view(torch.uint8).reshape(rows, 4)
+    assert torch.equal(
+        valid_scale_bytes[:, 0],
+        torch.full((rows,), 94, device=device, dtype=torch.uint8),
+    )
+    assert torch.count_nonzero(valid_scale_bytes[:, 1:]) == 0
+    assert physical[0, rows:].item() == 0
+    assert out.untyped_storage().nbytes() == aligned_rows * columns
+
+
+@pytest.mark.skipif(
+    not _IS_SM100,
+    reason="packed UE8M0 TRT-LLM quantization requires SM100",
+)
+@pytest.mark.parametrize("enable_pdl", [False, True])
+def test_online_quantization_selects_packed_ue8m0_kernel(
+    device: str,
+    monkeypatch: pytest.MonkeyPatch,
+    enable_pdl: bool,
+) -> None:
+    x = torch.randn((4, 512), device=device, dtype=torch.bfloat16)
+    expected = (
+        torch.empty_like(x, dtype=torch.float8_e4m3fn),
+        torch.empty((4, 1), device=device, dtype=torch.int32),
+    )
+    calls = []
+
+    def fake_packed_quant(arg: torch.Tensor, *, enable_pdl: bool):
+        calls.append((arg, enable_pdl))
+        return expected
+
+    monkeypatch.setattr(
+        "tokenspeed_kernel.ops.gemm.fp8_utils._trtllm_fp8_packed_ue8m0",
+        fake_packed_quant,
+    )
+    actual = per_token_group_quant_fp8(
+        x,
+        128,
+        column_major_scales=True,
+        scale_tma_aligned=True,
+        scale_ue8m0=True,
+        enable_pdl=enable_pdl,
+    )
+
+    assert calls == [(x, enable_pdl)]
+    assert actual is expected
+
+
+@pytest.mark.skipif(
+    not _IS_SM100,
+    reason="packed UE8M0 TRT-LLM quantization requires SM100",
+)
+def test_online_quantization_misaligned_input_falls_back(
+    device: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rows, columns = 4, 512
+    storage = torch.randn(
+        rows * columns + 1,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    x = storage[1:].view(rows, columns)
+    expected = (
+        torch.empty_like(x, dtype=torch.float8_e4m3fn),
+        torch.empty((rows, 1), device=device, dtype=torch.int32),
+    )
+    fallback_calls = []
+
+    assert x.is_contiguous()
+    assert x.data_ptr() % 32 != 0
+    assert not supports_trtllm_fp8_packed_ue8m0(x)
+
+    def fail_fast_path(*args, **kwargs):
+        raise AssertionError("misaligned input must not use the fast path")
+
+    def fake_fallback(*args, **kwargs):
+        fallback_calls.append((args, kwargs))
+        return expected
+
+    monkeypatch.setattr(
+        "tokenspeed_kernel.ops.gemm.fp8_utils._trtllm_fp8_packed_ue8m0",
+        fail_fast_path,
+    )
+    monkeypatch.setattr(
+        "tokenspeed_kernel.ops.gemm.fp8_utils._per_token_group_quant_8bit_raw",
+        fake_fallback,
+    )
+    actual = per_token_group_quant_fp8(
+        x,
+        128,
+        column_major_scales=True,
+        scale_tma_aligned=True,
+        scale_ue8m0=True,
+    )
+
+    assert len(fallback_calls) == 1
+    assert actual is expected
+
+
+@pytest.mark.skipif(
+    not _IS_SM100,
+    reason="packed UE8M0 TRT-LLM quantization requires SM100",
+)
+def test_online_quantization_unavailable_kernel_falls_back(
+    device: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    x = torch.randn((4, 512), device=device, dtype=torch.bfloat16)
+    expected = (
+        torch.empty_like(x, dtype=torch.float8_e4m3fn),
+        torch.empty((4, 1), device=device, dtype=torch.int32),
+    )
+
+    monkeypatch.setattr(
+        "tokenspeed_kernel.ops.gemm.fp8_utils._supports_trtllm_fp8_packed_ue8m0",
+        lambda _x: False,
+    )
+    monkeypatch.setattr(
+        "tokenspeed_kernel.ops.gemm.fp8_utils._trtllm_fp8_packed_ue8m0",
+        lambda *args, **kwargs: pytest.fail("unavailable kernel was called"),
+    )
+    monkeypatch.setattr(
+        "tokenspeed_kernel.ops.gemm.fp8_utils._per_token_group_quant_8bit_raw",
+        lambda *args, **kwargs: expected,
+    )
+
+    actual = per_token_group_quant_fp8(
+        x,
+        128,
+        column_major_scales=True,
+        scale_tma_aligned=True,
+        scale_ue8m0=True,
+    )
+    assert actual is expected
+
+
+@pytest.mark.skipif(
+    not _IS_SM100,
+    reason="packed UE8M0 TRT-LLM quantization requires SM100",
+)
+@pytest.mark.parametrize("enable_pdl", [False, True])
+def test_online_mxfp8_forwards_pdl_to_quantizer(
+    device: str,
+    monkeypatch: pytest.MonkeyPatch,
+    enable_pdl: bool,
+) -> None:
+    x = torch.randn((4, 512), device=device, dtype=torch.bfloat16)
+    expected = (
+        torch.empty_like(x, dtype=torch.float8_e4m3fn),
+        torch.empty((4, 1), device=device, dtype=torch.int32),
+    )
+    calls = []
+
+    def fake_quant(arg, group_size, **kwargs):
+        calls.append((arg, group_size, kwargs))
+        return expected
+
+    monkeypatch.setattr(
+        "tokenspeed_kernel.ops.gemm.fp8_utils.per_token_group_quant_fp8",
+        fake_quant,
+    )
+    actual = _online_quantize_mxfp8(
+        x,
+        [128, 128],
+        "deep_gemm_mm_fp8_blockscale",
+        enable_pdl=enable_pdl,
+    )
+
+    assert actual is expected
+    assert calls[0][0] is x
+    assert calls[0][1] == 128
+    assert calls[0][2]["enable_pdl"] is enable_pdl
+
+
+@pytest.mark.skipif(
+    not _IS_SM100,
+    reason="packed UE8M0 TRT-LLM quantization requires SM100",
+)
+@pytest.mark.parametrize("enable_pdl", [False, True])
+def test_packed_ue8m0_non_default_stream(
+    device: str,
+    enable_pdl: bool,
+) -> None:
+    torch.manual_seed(10)
+    x = torch.randn((8, 2048), device=device, dtype=torch.bfloat16)
+    producer_stream = torch.cuda.current_stream()
+    stream = torch.cuda.Stream(device=device)
+    with torch.cuda.stream(stream):
+        stream.wait_stream(producer_stream)
+        out, scale = trtllm_fp8_packed_ue8m0(x, enable_pdl=enable_pdl)
+    stream.synchronize()
+    ref_out, ref_scale = _per_token_group_quant_8bit_raw(
+        x,
+        128,
+        column_major_scales=True,
+        scale_tma_aligned=True,
+        scale_ue8m0=True,
+    )
+    torch.cuda.synchronize()
+
+    assert _bitwise_equal(out, ref_out)
+    assert torch.equal(scale, ref_scale)
+
+
+@pytest.mark.skipif(
+    not _IS_SM100,
+    reason="packed UE8M0 TRT-LLM quantization requires SM100",
+)
+def test_online_packed_ue8m0_quantization_cuda_graph(device: str) -> None:
+    torch.manual_seed(9)
+    x = torch.randn((16, 7168), device=device, dtype=torch.bfloat16)
+
+    def run():
+        return per_token_group_quant_fp8(
+            x,
+            128,
+            column_major_scales=True,
+            scale_tma_aligned=True,
+            scale_ue8m0=True,
+            enable_pdl=True,
+        )
+
+    run()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        out, scale = run()
+    for _ in range(100):
+        graph.replay()
+    torch.cuda.synchronize()
+
+    replacement = torch.randn_like(x)
+    x.copy_(replacement)
+    out.view(torch.uint8).fill_(0xFF)
+    scale.zero_()
+    torch.cuda.synchronize()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    ref_out, ref_scale = _per_token_group_quant_8bit_raw(
+        replacement,
+        128,
+        column_major_scales=True,
+        scale_tma_aligned=True,
+        scale_ue8m0=True,
+    )
+    torch.cuda.synchronize()
+    assert _bitwise_equal(out, ref_out)
+    assert scale.stride() == ref_scale.stride()
+    assert torch.equal(scale, ref_scale)
 
 
 @pytest.mark.parametrize("solution", ["flashinfer"])

--- a/tokenspeed-kernel/test/ops/test_trtllm_deepseek_v4_indexer_registration.py
+++ b/tokenspeed-kernel/test/ops/test_trtllm_deepseek_v4_indexer_registration.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import importlib
+
+import tokenspeed_kernel.ops.attention.trtllm.deepseek_v4 as trtllm_indexer
+import torch
+from tokenspeed_kernel.platform import ArchVersion, current_platform
+from tokenspeed_kernel.registry import KernelRegistry, Priority
+from tokenspeed_kernel.signature import format_signatures
+
+
+def test_trtllm_indexer_q_registration_matches_availability(fresh_registry) -> None:
+    importlib.reload(trtllm_indexer)
+    spec = KernelRegistry.get().get_by_name(
+        "trtllm_deepseek_v4_indexer_q_prepare_mxfp4"
+    )
+    available = (
+        trtllm_indexer.has_trtllm_deepseek_v4_indexer_q_prepare()
+        and current_platform().is_nvidia
+    )
+    assert (spec is not None) is available
+    if spec is None:
+        return
+
+    assert spec.family == "attention"
+    assert spec.mode == "deepseek_v4_indexer_q_prepare_mxfp4"
+    assert spec.solution == "trtllm"
+    assert spec.priority == Priority.SPECIALIZED
+    assert spec.format_signatures == format_signatures(
+        "index_q", "dense", {torch.bfloat16}
+    )
+    assert spec.traits == {
+        "num_heads": frozenset({64}),
+        "head_dim": frozenset({128}),
+        "rope_dim": frozenset({64}),
+    }
+    assert spec.capability.min_arch_version == ArchVersion(10, 0)
+    assert spec.capability.max_arch_version == ArchVersion(10, 9)

--- a/tokenspeed-kernel/test/thirdparty/test_deep_gemm.py
+++ b/tokenspeed-kernel/test/thirdparty/test_deep_gemm.py
@@ -27,7 +27,9 @@ deep_gemm_testing = pytest.importorskip("deep_gemm.testing")
 deep_gemm_utils = pytest.importorskip("deep_gemm.utils")
 
 from tokenspeed_kernel.ops.gemm import deep_gemm as deep_gemm_ops
-from tokenspeed_kernel.platform import current_platform
+from tokenspeed_kernel.ops.gemm.fp8_utils import _per_token_group_quant_8bit_raw
+from tokenspeed_kernel.ops.quantization.trtllm import trtllm_fp8_packed_ue8m0
+from tokenspeed_kernel.platform import ArchVersion, current_platform
 
 platform = current_platform()
 
@@ -71,3 +73,53 @@ def test_deep_gemm_mm_fp8_blockscale_matches_reference(device: str) -> None:
 
     torch.cuda.synchronize()
     assert deep_gemm_testing.calc_diff(actual, expected) < 0.001
+
+
+@pytest.mark.skipif(
+    not (platform.is_nvidia and platform.arch_version == ArchVersion(10, 0)),
+    reason="packed UE8M0 TRT-LLM quantization requires SM100",
+)
+def test_deep_gemm_consumes_trtllm_packed_ue8m0(device: str) -> None:
+    kernel = getattr(deep_gemm_ops, "deep_gemm_mm_fp8_blockscale", None)
+    if kernel is None:
+        pytest.skip("DeepGEMM kernel is not available")
+
+    torch.manual_seed(11)
+    m, n, k = 3, 128, 2048
+    a = torch.randn((m, k), device=device, dtype=torch.bfloat16)
+    b = torch.randn((n, k), device=device, dtype=torch.bfloat16)
+    expected = (a.float() @ b.float().T).to(torch.bfloat16)
+
+    candidate_a, candidate_scales = trtllm_fp8_packed_ue8m0(a)
+    baseline_a, baseline_scales = _per_token_group_quant_8bit_raw(
+        a,
+        128,
+        column_major_scales=True,
+        scale_tma_aligned=True,
+        scale_ue8m0=True,
+    )
+    b_fp8, b_scales = deep_gemm_utils.per_block_cast_to_fp8(
+        b,
+        use_ue8m0=True,
+        gran_k=128,
+    )
+    candidate = kernel(
+        candidate_a,
+        b_fp8,
+        candidate_scales,
+        b_scales,
+        torch.bfloat16,
+        block_size=[128, 128],
+    )
+    baseline = kernel(
+        baseline_a,
+        b_fp8,
+        baseline_scales,
+        b_scales,
+        torch.bfloat16,
+        block_size=[128, 128],
+    )
+
+    torch.cuda.synchronize()
+    assert torch.equal(candidate.view(torch.int16), baseline.view(torch.int16))
+    assert deep_gemm_testing.calc_diff(candidate, expected) < 0.001

--- a/tokenspeed-kernel/test/thirdparty/test_trtllm_deepseek_v4_indexer.py
+++ b/tokenspeed-kernel/test/thirdparty/test_trtllm_deepseek_v4_indexer.py
@@ -1,0 +1,300 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import pytest
+import torch
+from tokenspeed_kernel.ops.attention.triton.deepseek_v4 import (
+    deepseek_v4_fused_indexer_q_rope_hadamard_mxfp4,
+)
+from tokenspeed_kernel.ops.attention.trtllm.deepseek_v4 import (
+    has_trtllm_deepseek_v4_indexer_q_prepare,
+    supports_trtllm_deepseek_v4_indexer_q_prepare,
+    trtllm_deepseek_v4_indexer_q_prepare_mxfp4,
+)
+from tokenspeed_kernel.thirdparty.cuda.trtllm_deepseek_v4_indexer import (
+    _load_module,
+    trtllm_fused_cat_fp4,
+    trtllm_mla_rope_inplace,
+)
+
+
+def _is_supported() -> bool:
+    return (
+        torch.cuda.is_available()
+        and torch.cuda.get_device_capability()[0] == 10
+        and has_trtllm_deepseek_v4_indexer_q_prepare()
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    not _is_supported(),
+    reason="TRT-LLM DeepSeek-V4 indexer kernels require NVIDIA SM100+",
+)
+
+
+def _cos_sin_cache(max_position: int = 64) -> torch.Tensor:
+    positions = torch.arange(max_position, device="cuda", dtype=torch.float32)
+    frequencies = torch.exp(
+        -torch.arange(32, device="cuda", dtype=torch.float32) / 32 * 8.0
+    )
+    angles = positions[:, None] * frequencies[None, :]
+    return torch.cat((angles.cos(), angles.sin()), dim=-1).contiguous()
+
+
+def _rope_reference(
+    data: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+) -> torch.Tensor:
+    out = data.float().clone()
+    cos_sin = cos_sin_cache[positions.long()]
+    cosine = cos_sin[:, None, :32]
+    sine = cos_sin[:, None, 32:]
+    even = out[..., 64::2].clone()
+    odd = out[..., 65::2].clone()
+    out[..., 64::2] = even * cosine - odd * sine
+    out[..., 65::2] = even * sine + odd * cosine
+    return out.to(torch.bfloat16)
+
+
+def _fp4_reference(rows: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    blocks = rows.float().reshape(-1, 4, 32)
+    amax = blocks.abs().amax(dim=-1).clamp_min(1.0e-4)
+    exponent = torch.ceil(torch.log2(amax / 6.0))
+    scaled = blocks / torch.pow(2.0, exponent).unsqueeze(-1)
+    absolute = scaled.abs().clamp_max(6.0)
+    code = sum(
+        (absolute > boundary).to(torch.uint8)
+        for boundary in (0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0)
+    )
+    code |= ((scaled < 0) & (code != 0)).to(torch.uint8) << 3
+    packed = (code[..., 0::2] | (code[..., 1::2] << 4)).reshape(-1, 64)
+    scales = (exponent + 127).to(torch.uint8).contiguous().view(torch.int32)
+    return packed, scales
+
+
+@pytest.mark.parametrize("enable_pdl", [False, True])
+def test_mla_rope_inplace_matches_reference(enable_pdl: bool) -> None:
+    torch.manual_seed(101)
+    data = torch.randn(7, 64, 128, device="cuda", dtype=torch.bfloat16)
+    positions = torch.tensor([0, 1, 3, 7, 15, 31, 62], device="cuda")
+    cos_sin_cache = _cos_sin_cache()
+    expected = _rope_reference(data, positions, cos_sin_cache)
+
+    results = []
+    for position_dtype in (torch.int32, torch.int64):
+        actual = data.clone()
+        trtllm_mla_rope_inplace(
+            actual,
+            positions.to(position_dtype),
+            cos_sin_cache,
+            enable_pdl=enable_pdl,
+        )
+        torch.testing.assert_close(actual, expected, atol=2.0e-4, rtol=0)
+        assert torch.equal(actual[..., :64], data[..., :64])
+        results.append(actual)
+
+    assert torch.equal(results[0], results[1])
+
+
+def test_fused_cat_fp4_matches_deepgemm_layout() -> None:
+    torch.manual_seed(102)
+    rows = torch.randn(7, 64, 128, device="cuda", dtype=torch.bfloat16)
+    rows[0].zero_()
+    rows[1].fill_(1.0e-5)
+    first, second = rows.split((64, 64), dim=-1)
+
+    packed, scales = trtllm_fused_cat_fp4(first, second)
+    expected_packed, expected_scales = _fp4_reference(rows)
+
+    assert torch.equal(packed, expected_packed)
+    assert torch.equal(scales, expected_scales)
+
+
+@pytest.mark.parametrize("invalid_input", ["first", "second"])
+def test_fused_cat_fp4_rejects_non_row_linear_input(invalid_input: str) -> None:
+    backing = torch.empty(2048, device="cuda", dtype=torch.bfloat16)
+    non_row_linear = torch.as_strided(
+        backing,
+        size=(2, 3, 64),
+        stride=(400, 128, 1),
+    )
+    rows = torch.empty(2, 3, 128, device="cuda", dtype=torch.bfloat16)
+    first, second = rows.split((64, 64), dim=-1)
+    if invalid_input == "first":
+        first = non_row_linear
+    else:
+        second = non_row_linear
+
+    with pytest.raises(
+        ValueError,
+        match=rf"{invalid_input} leading dimensions must be row-linear",
+    ):
+        trtllm_fused_cat_fp4(first, second)
+
+
+def test_fused_cat_fp4_ffi_rejects_non_row_linear_input() -> None:
+    backing = torch.empty(2048, device="cuda", dtype=torch.bfloat16)
+    first = torch.as_strided(
+        backing,
+        size=(2, 3, 64),
+        stride=(400, 128, 1),
+    )
+    rows = torch.empty(2, 3, 128, device="cuda", dtype=torch.bfloat16)
+    _, second = rows.split((64, 64), dim=-1)
+    packed = torch.empty(6, 64, device="cuda", dtype=torch.uint8)
+    scales = torch.empty(6, 1, device="cuda", dtype=torch.int32)
+
+    with pytest.raises(RuntimeError, match="leading dimensions must be row-linear"):
+        _load_module().trtllm_deepseek_v4_fused_cat_fp4(
+            first,
+            second,
+            packed,
+            scales,
+        )
+
+
+@pytest.mark.parametrize("position_dtype", [torch.int32, torch.int64])
+def test_indexer_q_composite_matches_fused_triton(position_dtype: torch.dtype) -> None:
+    torch.manual_seed(103)
+    index_q = torch.randn(7, 64, 128, device="cuda", dtype=torch.bfloat16)
+    positions = torch.tensor([0, 1, 3, 7, 15, 31, 62], device="cuda")
+    positions = positions.to(position_dtype)
+    cos_sin_cache = _cos_sin_cache()
+    weights = torch.randn(7, 64, device="cuda", dtype=torch.float32)
+    kwargs = {
+        "positions": positions,
+        "cos_sin_cache": cos_sin_cache,
+        "weights": weights,
+        "softmax_scale": 0.25,
+        "head_scale": 64**-0.5,
+    }
+
+    (expected_q, expected_scales), expected_weights = (
+        deepseek_v4_fused_indexer_q_rope_hadamard_mxfp4(
+            index_q=index_q,
+            **kwargs,
+        )
+    )
+    (actual_q, actual_scales), actual_weights = (
+        trtllm_deepseek_v4_indexer_q_prepare_mxfp4(
+            index_q=index_q.clone(),
+            enable_pdl=True,
+            **kwargs,
+        )
+    )
+
+    assert torch.equal(actual_q, expected_q)
+    assert torch.equal(actual_scales, expected_scales)
+    assert torch.equal(actual_weights, expected_weights)
+
+
+def test_indexer_q_composite_cuda_graph_replay() -> None:
+    torch.manual_seed(104)
+    index_q = torch.randn(32, 64, 128, device="cuda", dtype=torch.bfloat16)
+    graph_q = index_q.clone()
+    positions = torch.arange(32, device="cuda", dtype=torch.int64)
+    cos_sin_cache = _cos_sin_cache()
+    weights = torch.randn(32, 64, device="cuda", dtype=torch.float32)
+    kwargs = {
+        "positions": positions,
+        "cos_sin_cache": cos_sin_cache,
+        "weights": weights,
+        "softmax_scale": 0.25,
+        "head_scale": 64**-0.5,
+        "enable_pdl": True,
+    }
+
+    warmup_stream = torch.cuda.Stream()
+    with torch.cuda.stream(warmup_stream):
+        trtllm_deepseek_v4_indexer_q_prepare_mxfp4(
+            index_q=index_q.clone(),
+            **kwargs,
+        )
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_output = trtllm_deepseek_v4_indexer_q_prepare_mxfp4(
+            index_q=graph_q,
+            **kwargs,
+        )
+
+    graph_q.copy_(index_q)
+    graph.replay()
+    expected = trtllm_deepseek_v4_indexer_q_prepare_mxfp4(
+        index_q=index_q.clone(),
+        **kwargs,
+    )
+    torch.cuda.synchronize()
+
+    assert torch.equal(graph_output[0][0], expected[0][0])
+    assert torch.equal(graph_output[0][1], expected[0][1])
+    assert torch.equal(graph_output[1], expected[1])
+
+
+def test_indexer_q_composite_empty_and_off_shape_contracts() -> None:
+    index_q = torch.empty(0, 64, 128, device="cuda", dtype=torch.bfloat16)
+    positions = torch.empty(0, device="cuda", dtype=torch.int64)
+    cos_sin_cache = _cos_sin_cache()
+    weights = torch.empty(0, 64, device="cuda", dtype=torch.float32)
+
+    assert supports_trtllm_deepseek_v4_indexer_q_prepare(index_q)
+    (packed, scales), scaled_weights = trtllm_deepseek_v4_indexer_q_prepare_mxfp4(
+        index_q=index_q,
+        positions=positions,
+        cos_sin_cache=cos_sin_cache,
+        weights=weights,
+        softmax_scale=0.25,
+        head_scale=64**-0.5,
+        enable_pdl=True,
+    )
+    assert packed.shape == (0, 64, 64)
+    assert scales.shape == (0, 64)
+    assert scaled_weights.shape == (0, 64)
+
+    assert not supports_trtllm_deepseek_v4_indexer_q_prepare(
+        torch.empty(1, 63, 128, device="cuda", dtype=torch.bfloat16)
+    )
+    assert not supports_trtllm_deepseek_v4_indexer_q_prepare(
+        torch.empty(1, 64, 128, device="cuda", dtype=torch.float16)
+    )
+    assert not supports_trtllm_deepseek_v4_indexer_q_prepare(
+        torch.empty(1, 64, 256, device="cuda", dtype=torch.bfloat16)[..., ::2]
+    )
+    misaligned = torch.empty(
+        64 * 128 + 1,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )[
+        1:
+    ].view(1, 64, 128)
+    assert misaligned.is_contiguous()
+    assert misaligned.data_ptr() % 16 != 0
+    assert not supports_trtllm_deepseek_v4_indexer_q_prepare(misaligned)
+
+    assert not supports_trtllm_deepseek_v4_indexer_q_prepare(
+        torch.empty(1, 64, 128, device="cuda", dtype=torch.bfloat16),
+        torch.empty(1, device="cpu", dtype=torch.int64),
+        cos_sin_cache,
+    )


### PR DESCRIPTION
## Summary

- add an explicit `--enable-trtllm-allreduce` opt-in for eligible single-node NVIDIA tensor-parallel collectives
- configure deduplicated attention, dense, and pure-TP MoE groups before CUDA graph capture; groups containing expert parallelism remain on NCCL
- fail closed on unsupported topology, dtype, tensor rank, shape, operation, or workspace capacity and fall back to NCCL for ineligible calls
- size the one-shot workspace limit from the selected Lamport buffer dtype, including the FP32 path
- expose workspace cleanup through the `tokenspeed-kernel` boundary
- add backend-selection, registered 2-GPU correctness/fallback/CUDA Graph replay coverage, manual TP8 coverage, and server configuration documentation

## Root cause

`TrtllmAllReduceBackend` existed, but no runtime call configured its per-group IPC workspace. Consequently `AutoBackend.has_trtllm_ar()` remained false and DeepSeek-V4-Pro TP8 decode collectives fell back to NCCL Ring LL.

This PR wires the workspace explicitly after process-group initialization and before model CUDA Graph capture. The feature remains disabled by default.

## Selection and fallback

The Lamport path is selected only for configured, contiguous, 2-D CUDA BF16 SUM tensors that fit the workspace shape and the 2 MiB one-shot byte limit. Large prefill tensors, non-2-D layouts, unsupported dtypes/ops, and unconfigured groups continue to use NCCL. MoE groups containing expert parallelism are intentionally out of scope for this change.

## Decode trace evidence

Matched exact p4 decode traces show the backend switch directly:

| Kernel | Off launches/step | On launches/step | Off duration/step | On duration/step |
|---|---:|---:|---:|---:|
| `ncclDevKernel_AllReduce_Sum_bf16_RING_LL` | 130.11 | 0 (not observed) | 4.848 ms | 0 |
| `allreduce_fusion_kernel_oneshot_lamport` | 0 (not observed) | 130.68 | 0 | 1.976 ms |

The on-side decode window therefore executed the Lamport kernel rather than silently falling back. The nearly identical launch counts show that the comparison switches the backend for the same collective workload.

## Validation

- `pre-commit run --all-files` passed on the final local head
- the new CUDA test is registered in the per-commit `runtime-2gpu` suite; it covers eager correctness, oversized and 1-D NCCL fallback, and 10 changing-input CUDA Graph replays
- TP8 BF16 eager correctness matched NCCL in the manual 8-GPU run
- TP8 CUDA Graph replay passed for 10 changing per-rank inputs
- full DeepSeek-V4-Pro CUDA Graph capture passed for batch sizes `[1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 79, 80]`
- matched non-profile p1→p2→p4→p8 curves completed with all requests successful on both sides

At p4, enabling the backend improved CI TPS/user by 8.99%, CI TPS/GPU by 10.29%, and steady completion throughput by 11.69%; TPOT decreased by 8.25%. Cache hit and speculative acceptance were unchanged. Across p1, p2, p4, and p8, TPS/user improved by 8.99–12.69% and TPOT decreased by 8.25–11.26%.

The endpoint curve currently has one matched off/on run per concurrency point, so it does not claim a variance estimate.

## Stacking

This draft is intentionally based on the head branch of #563 so that its diff contains only the all-reduce wiring changes.