### PR TITLE
perf(deepseek-v4): enable MTP overlap scheduling with paged cache

### DIFF
--- a/python/tokenspeed/runtime/configs/paged_cache_spec.py
+++ b/python/tokenspeed/runtime/configs/paged_cache_spec.py
@@ -47,6 +47,8 @@ def compute_paged_cache_group_page_counts(
     max_scheduled_tokens: int,
     max_total_tokens: int,
     max_context_len: int,
+    decode_input_tokens: int = 1,
+    overlap_schedule_depth: int = 0,
     safety_margin: int = 0,
 ) -> dict[str, int]:
     if max_live_requests < 0:
@@ -59,6 +61,16 @@ def compute_paged_cache_group_page_counts(
         raise ValueError(f"max_total_tokens must be >= 0, got {max_total_tokens}")
     if max_context_len < 0:
         raise ValueError(f"max_context_len must be >= 0, got {max_context_len}")
+    if decode_input_tokens < 0:
+        raise ValueError(f"decode_input_tokens must be >= 0, got {decode_input_tokens}")
+    if overlap_schedule_depth not in (0, 1):
+        raise ValueError(
+            f"overlap_schedule_depth must be 0 or 1, got {overlap_schedule_depth}"
+        )
+    if overlap_schedule_depth > 0 and decode_input_tokens == 0:
+        raise ValueError(
+            "overlapped paged-cache sizing requires decode_input_tokens > 0"
+        )
     if safety_margin < 0:
         raise ValueError(f"safety_margin must be >= 0, got {safety_margin}")
 
@@ -70,11 +82,15 @@ def compute_paged_cache_group_page_counts(
                 f"PagedCacheGroupSpec {spec.group_id}: rows_per_page * "
                 "entry_stride_tokens must be > 0"
             )
+        protected_pages = max_live_requests * ceil_div(
+            overlap_schedule_depth * decode_input_tokens, raw_per_page
+        )
         if spec.retention == "full_history":
             full_pages = ceil_div(max_total_tokens, raw_per_page)
             total = (
                 full_pages
                 + max_live_requests
+                + protected_pages
                 + _PAGED_CACHE_GROUP_DUMMY_PAGES
                 + safety_margin
             )
@@ -95,6 +111,7 @@ def compute_paged_cache_group_page_counts(
                 resident_pages
                 + scheduled_pages
                 + max_live_requests
+                + protected_pages
                 + _PAGED_CACHE_GROUP_DUMMY_PAGES
                 + safety_margin
             )
@@ -107,8 +124,67 @@ def compute_paged_cache_group_page_counts(
     return counts
 
 
+def compute_max_logical_pages_for_capture(
+    spec: PagedCacheGroupSpec,
+    *,
+    max_context_len: int,
+    max_tokens_per_req: int = 1,
+    overlap_schedule_depth: int = 0,
+) -> int:
+    """Return CUDA Graph block-table width for one paged-cache group.
+
+    Decode admission reserves the current verify span plus one span for each
+    overlapped schedule.  Include that complete reservation horizon here: a
+    request close to the model context limit can still expose the reserved
+    pages in its scheduler block-table row before the accepted tokens are
+    truncated by the request-length limit.
+
+    Args:
+        spec: Paged-cache group layout and retention policy.
+        max_context_len: Maximum accepted raw-token context length.
+        max_tokens_per_req: Runtime decode/verify width.
+        overlap_schedule_depth: Number of additionally in-flight decode steps.
+
+    Returns:
+        Required block-table columns for one request.
+    """
+    if max_context_len < 0:
+        raise ValueError(f"max_context_len must be >= 0, got {max_context_len}")
+    if max_tokens_per_req <= 0:
+        raise ValueError(f"max_tokens_per_req must be > 0, got {max_tokens_per_req}")
+    if overlap_schedule_depth not in (0, 1):
+        raise ValueError(
+            f"overlap_schedule_depth must be 0 or 1, got {overlap_schedule_depth}"
+        )
+    raw_per_page = spec.rows_per_page * spec.entry_stride_tokens
+    if raw_per_page <= 0:
+        raise ValueError(
+            f"PagedCacheGroupSpec {spec.group_id}: rows_per_page * "
+            "entry_stride_tokens must be > 0"
+        )
+    reservation_horizon = (overlap_schedule_depth + 1) * max_tokens_per_req
+    if spec.retention == "sliding_window":
+        window = spec.sliding_window_tokens
+        if window is None or window <= 0:
+            raise ValueError(
+                f"PagedCacheGroupSpec {spec.group_id}: sliding group missing "
+                "positive sliding_window_tokens"
+            )
+        retained_history = min(window - 1, max_context_len)
+        live_tokens = retained_history + reservation_horizon
+        return ceil_div(live_tokens, raw_per_page) + 1
+    if spec.retention == "full_history":
+        live_tokens = max_context_len + reservation_horizon
+        return ceil_div(live_tokens, raw_per_page)
+    raise ValueError(
+        f"PagedCacheGroupSpec {spec.group_id}: unsupported retention "
+        f"{spec.retention!r}"
+    )
+
+
 __all__ = [
     "PagedCacheGroupSpec",
     "Retention",
+    "compute_max_logical_pages_for_capture",
     "compute_paged_cache_group_page_counts",
 ]

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -173,6 +173,16 @@ class EventLoop:
         target, draft = create_model_runner(
             server_args, self.model_config, draft_model_config, gpu_id, global_rank
         )
+        self.use_overlap_schedule = should_use_overlap_schedule(
+            disable_overlap_schedule=server_args.disable_overlap_schedule,
+            disaggregation_mode=server_args.disaggregation_mode,
+        )
+        self.overlap_schedule_depth = int(self.use_overlap_schedule)
+        decode_input_tokens = (
+            server_args.speculative_num_draft_tokens
+            if server_args.speculative_algorithm is not None
+            else 1
+        )
 
         (
             attn_backend,
@@ -190,6 +200,8 @@ class EventLoop:
             min_per_gpu_mem,
             server_args.enable_memory_saver,
             draft_model_config,
+            decode_input_tokens=decode_input_tokens,
+            overlap_schedule_depth=self.overlap_schedule_depth,
         )
 
         num_total_pages = self.max_total_num_tokens // server_args.block_size
@@ -213,6 +225,7 @@ class EventLoop:
             gpu_id=gpu_id,
             global_rank=global_rank,
             num_total_pages=num_total_pages,
+            overlap_schedule_depth=self.overlap_schedule_depth,
         )
         self.model_executor = create_model_executor(
             server_args=server_args,
@@ -328,7 +341,6 @@ class EventLoop:
 
         # Adjunct enabled only when pool opts in AND prefix-caching switch is on.
         paged_cache_groups = pool_to_paged_cache_groups(token_to_kv_pool)
-        self._paged_cache_groups = paged_cache_groups
         prefix_cache_adjunct = None
         required_groups = token_to_kv_pool.prefix_cache_required_group_ids
         if required_groups is not None and server_args.enable_prefix_caching:
@@ -344,11 +356,8 @@ class EventLoop:
             prefetch_threshold=4,  # Keep this hard-coded until it becomes configurable.
             role=server_args.disaggregation_mode,
             enable_kv_cache_events=self._kv_events_enabled,
-            decode_input_tokens=(
-                server_args.speculative_num_draft_tokens
-                if server_args.speculative_algorithm is not None
-                else 1
-            ),
+            decode_input_tokens=decode_input_tokens,
+            overlap_schedule_depth=self.overlap_schedule_depth,
             disable_prefix_cache=not server_args.enable_prefix_caching,
             enable_mamba=has_mamba,
             mamba_cache_chunk_size=server_args.mamba_cache_chunk_size,
@@ -361,7 +370,8 @@ class EventLoop:
         )
         logger.info(
             "Scheduler config: page_size=%s num_device_pages=%s "
-            "max_scheduled_tokens=%s decode_input_tokens=%s disable_l2_cache=%s "
+            "max_scheduled_tokens=%s decode_input_tokens=%s "
+            "overlap_schedule_depth=%s disable_l2_cache=%s "
             "max_batch_size=%s (global max_num_seqs=%s, dp_size=%s) "
             "mamba_pool_total_chunks=%s enable_mamba=%s "
             "disable_prefix_cache=%s paged_cache_groups=%s",
@@ -369,6 +379,7 @@ class EventLoop:
             scheduler_cfg.num_device_pages,
             scheduler_cfg.max_scheduled_tokens,
             scheduler_cfg.decode_input_tokens,
+            scheduler_cfg.overlap_schedule_depth,
             scheduler_cfg.disable_l2_cache,
             scheduler_cfg.max_batch_size,
             server_args.max_num_seqs,
@@ -1600,13 +1611,7 @@ def run_event_loop(
             # the loop and starts the first DP metadata collective.
             dist.barrier(group=event_loop.world_cpu_group)
 
-        use_overlap = should_use_overlap_schedule(
-            disable_overlap_schedule=server_args.disable_overlap_schedule,
-            disaggregation_mode=server_args.disaggregation_mode,
-            speculative_algorithm=server_args.speculative_algorithm,
-            paged_cache_groups=getattr(event_loop, "_paged_cache_groups", ()),
-        )
-        if use_overlap:
+        if event_loop.use_overlap_schedule:
             event_loop.event_loop_overlap()
         else:
             event_loop.event_loop()

--- a/python/tokenspeed/runtime/engine/scheduler_utils.py
+++ b/python/tokenspeed/runtime/engine/scheduler_utils.py
@@ -63,6 +63,7 @@ def make_config(
     role: str,
     enable_kv_cache_events: bool = False,
     decode_input_tokens: int = 1,
+    overlap_schedule_depth: int = 0,
     disable_prefix_cache: bool = False,
     enable_mamba: bool = False,
     mamba_cache_chunk_size: int = 64,
@@ -92,6 +93,7 @@ def make_config(
         cfg.role = SchedulerConfig.Role.Fused
     cfg.num_device_pages = num_device_pages
     cfg.decode_input_tokens = decode_input_tokens
+    cfg.overlap_schedule_depth = overlap_schedule_depth
     cfg.disable_prefix_cache = disable_prefix_cache
     cfg.disable_l2_cache = disable_l2_cache
 
@@ -167,16 +169,12 @@ def should_use_overlap_schedule(
     *,
     disable_overlap_schedule: bool,
     disaggregation_mode: str,
-    speculative_algorithm: Any | None,
-    paged_cache_groups: Sequence["PagedCacheGroupConfig"] | None = None,
 ) -> bool:
     """Return whether the runtime can use the overlapped scheduler loop."""
 
     if disable_overlap_schedule:
         return False
     if disaggregation_mode == "prefill":
-        return False
-    if speculative_algorithm is not None and paged_cache_groups:
         return False
     return True
 

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -31,6 +31,9 @@ import torch
 import torch.distributed as dist
 import tqdm
 
+from tokenspeed.runtime.configs.paged_cache_spec import (
+    compute_max_logical_pages_for_capture,
+)
 from tokenspeed.runtime.execution.context import ForwardContext
 from tokenspeed.runtime.execution.forward_batch_info import (
     CaptureHiddenMode,
@@ -70,22 +73,6 @@ def _should_update_mamba_state_after_mtp_verify(
         and forward_mode.is_decode()
         and hasattr(attn_backend, "update_mamba_state_after_mtp_verify")
     )
-
-
-def compute_max_logical_pages_for_capture(
-    spec,
-    *,
-    max_context_len: int,
-    max_tokens_per_req: int = 1,
-) -> int:
-    raw_per_page = max(1, int(spec.rows_per_page) * int(spec.entry_stride_tokens))
-    if str(getattr(spec, "retention", "")) == "sliding_window":
-        window = int(getattr(spec, "sliding_window_tokens", 0) or 0)
-        live_tokens = max(1, window - 1 + max(1, int(max_tokens_per_req)))
-        if int(max_context_len) > 0:
-            live_tokens = min(live_tokens, int(max_context_len))
-        return max(1, (live_tokens + raw_per_page - 1) // raw_per_page + 1)
-    return max(1, (max(1, int(max_context_len)) + raw_per_page - 1) // raw_per_page)
 
 
 @contextmanager
@@ -231,6 +218,7 @@ class CudaGraphWrapper:
         self.max_tokens_per_req = (
             config.spec_num_tokens if config.spec_algo is not None else 1
         )
+        self.overlap_schedule_depth = config.overlap_schedule_depth
         self.use_v4_mtp_paged_metadata = config.use_v4_mtp_paged_metadata
         self.dp_size = config.data_parallel_size
         self.world_size = config.world_size
@@ -243,6 +231,7 @@ class CudaGraphWrapper:
                 self.input_buffers.seq_lens_buf,
                 paged_cache_group_specs=paged_cache_group_specs,
                 max_tokens_per_req=self.max_tokens_per_req,
+                overlap_schedule_depth=self.overlap_schedule_depth,
             )
         except TypeError:
             attn_backend.init_cuda_graph_state(
@@ -259,6 +248,7 @@ class CudaGraphWrapper:
                     self.drafter.draft_seq_lens_buf,
                     paged_cache_group_specs=draft_paged_cache_group_specs,
                     max_tokens_per_req=self.max_tokens_per_req,
+                    overlap_schedule_depth=self.overlap_schedule_depth,
                 )
             except TypeError:
                 draft_attn_backend.init_cuda_graph_state(
@@ -534,6 +524,7 @@ class CudaGraphWrapper:
                     else self.context_len
                 ),
                 max_tokens_per_req=self.max_tokens_per_req,
+                overlap_schedule_depth=self.overlap_schedule_depth,
             )
             out[str(spec.group_id)] = torch.zeros(
                 (bs, max_pages),
@@ -1019,6 +1010,11 @@ class CudaGraphWrapper:
             )
 
         else:
+            metadata_num_tokens = (
+                {"num_tokens": ctx.input_num_tokens}
+                if self.attn_backend.uses_paged_cache_groups
+                else {}
+            )
             self._init_forward_metadata(
                 padded_bs,
                 ctx.num_extends,
@@ -1037,6 +1033,7 @@ class CudaGraphWrapper:
                 all_decode_or_idle=ctx.all_decode_or_idle,
                 capture_hidden_mode=ctx.capture_hidden_mode,
                 spec_info=spec_info,
+                **metadata_num_tokens,
                 paged_cache_block_tables=(
                     paged_cache_block_tables
                     if self.attn_backend.uses_paged_cache_groups

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -138,6 +138,7 @@ class ModelExecutorConfig:
     spec_num_steps: int | None = None
     # spec_num_tokens == spec_num_steps + 1 for now (without Tree Attention)
     spec_num_tokens: int | None = None
+    overlap_schedule_depth: int = 0
     dp_sampling: bool = False
     dp_sampling_min_bs: int | None = None
     use_v4_mtp_paged_metadata: bool = False
@@ -159,6 +160,7 @@ class ModelExecutorConfig:
         gpu_id: int,
         global_rank: int,
         num_total_pages: int,
+        overlap_schedule_depth: int = 0,
     ) -> ModelExecutorConfig:
         output_length = (
             server_args.speculative_num_draft_tokens
@@ -192,6 +194,7 @@ class ModelExecutorConfig:
             spec_algo=server_args.speculative_algorithm,
             spec_num_steps=server_args.speculative_num_steps,
             spec_num_tokens=server_args.speculative_num_draft_tokens,
+            overlap_schedule_depth=overlap_schedule_depth,
             dp_sampling=server_args.dp_sampling,
             dp_sampling_min_bs=server_args.dp_sampling_min_bs,
             enable_nan_detection=server_args.enable_nan_detection,
@@ -1318,6 +1321,15 @@ class ModelExecutor:
         ).to(self.device, non_blocking=True)
         self.attn_backend.reset_current_inputs(req_pool_tensor, mamba_tensor)
 
+    @staticmethod
+    def _contains_retracted_decode(forward_op) -> bool:
+        # FlatForwardOperation stores hist_token_lens for decode rows only;
+        # non-recovery rows use -1.
+        return any(
+            hist_token_len != -1
+            for hist_token_len in getattr(forward_op, "hist_token_lens", ())
+        )
+
     @nvtx_range("reset_valid_cache_length", color="orange")
     def reset_valid_cache_length(self, forward_op) -> None:
 
@@ -1325,10 +1337,10 @@ class ModelExecutor:
         is_prefill = num_extends > 0
 
         # Retraction recovery: scheduler pushes -1 per decode op, overriding to
-        # a real length only on ScheduleDecodeFromRetractedEvent.
-        has_retract = not is_prefill and any(
-            x != -1 for x in forward_op.hist_token_lens
-        )
+        # a real length only on ScheduleDecodeFromRetractedEvent. Decode rows
+        # may follow prefill rows in a mixed batch, so this cannot be gated on
+        # pure-decode mode.
+        has_retract = self._contains_retracted_decode(forward_op)
 
         # Pure decode without retraction has nothing to do — skip the
         # cross-stream wait + stream-context entry entirely.
@@ -1342,15 +1354,15 @@ class ModelExecutor:
                 device="cpu",
                 pin_memory=True,
             )
-            all_pool_indices = torch.tensor(
-                forward_op.request_pool_indices,
+            decode_pool_indices = torch.tensor(
+                forward_op.request_pool_indices[num_extends:],
                 dtype=torch.int64,
                 device="cpu",
                 pin_memory=True,
             )
         else:
             hist_token_lens_tensor = None
-            all_pool_indices = None
+            decode_pool_indices = None
 
         self.execution_stream.wait_stream(torch.cuda.current_stream())
 
@@ -1374,11 +1386,11 @@ class ModelExecutor:
                     extend_request_pool_indices, extend_prefix_lens
                 )
 
-            elif hist_token_lens_tensor is not None:
+            if hist_token_lens_tensor is not None:
                 # Apply retraction recovery: override valid_cache_lengths with hist_token_lens
                 # where the scheduler has specified a non-(-1) value, so that out_cache_loc
                 # and position IDs are computed against the retracted KV length.
-                pool_idx_dev = all_pool_indices.to(self.device, non_blocking=True)
+                pool_idx_dev = decode_pool_indices.to(self.device, non_blocking=True)
                 hist_dev = hist_token_lens_tensor.to(self.device, non_blocking=True)
 
                 mask_1d = hist_dev != -1
@@ -1449,6 +1461,50 @@ class ModelExecutor:
             )
         return reset_mask
 
+    def _reset_mamba_current_inputs(
+        self,
+        *,
+        num_extends: int,
+        bs: int,
+        has_retract: bool,
+        mamba_pool_indices: torch.Tensor,
+        mamba_cow_src: torch.Tensor,
+        skipped_layerwise_cow_mask: torch.Tensor | None,
+    ) -> None:
+        if not hasattr(self.attn_backend, "reset_current_inputs"):
+            return
+
+        if num_extends > 0:
+            self.attn_backend.reset_current_inputs(
+                self.input_buffers.req_pool_indices_buf[:num_extends],
+                mamba_pool_indices[:num_extends],
+            )
+
+        if not has_retract:
+            return
+
+        # FlatForwardOperation places prefill rows first. Restrict recovery to
+        # the decode suffix so a prefix-cache COW on a prefill row cannot be
+        # mistaken for a retracted decode.
+        decode_begin = num_extends
+        decode_count = bs - decode_begin
+        if decode_count <= 0:
+            return
+        skipped_decode_mask = (
+            skipped_layerwise_cow_mask[decode_begin:bs]
+            if skipped_layerwise_cow_mask is not None
+            else None
+        )
+        retract_mask = self._mamba_retract_reset_mask(
+            mamba_cow_src[decode_begin:bs],
+            decode_count,
+            skipped_decode_mask,
+        )
+        self.attn_backend.reset_current_inputs(
+            self.input_buffers.req_pool_indices_buf[decode_begin:bs][retract_mask],
+            mamba_pool_indices[decode_begin:bs][retract_mask],
+        )
+
     def execute_forward_op(
         self,
         forward_op,
@@ -1475,9 +1531,7 @@ class ModelExecutor:
         graph_padded_bs = 0
 
         with nvtx_range("pre_fill_setup", color="orange"):
-            has_retract = num_extends <= 0 and any(
-                x != -1 for x in getattr(forward_op, "hist_token_lens", [])
-            )
+            has_retract = self._contains_retracted_decode(forward_op)
 
             # Wait for previous iteration's runtime state updates
             # (future_input_map, valid_cache_lengths) on execution_stream to
@@ -1529,22 +1583,14 @@ class ModelExecutor:
                         self.input_buffers.extend_prefix_lens_buf[:num_extends],
                         num_extends,
                     )
-                    if hasattr(self.attn_backend, "reset_current_inputs"):
-                        self.attn_backend.reset_current_inputs(
-                            self.input_buffers.req_pool_indices_buf[:num_extends],
-                            mamba_pool_indices[:num_extends],
-                        )
-                elif has_retract:
-                    if hasattr(self.attn_backend, "reset_current_inputs"):
-                        retract_mask = self._mamba_retract_reset_mask(
-                            mamba_cow_src,
-                            bs,
-                            skipped_layerwise_cow_mask,
-                        )
-                        self.attn_backend.reset_current_inputs(
-                            self.input_buffers.req_pool_indices_buf[:bs][retract_mask],
-                            mamba_pool_indices[:bs][retract_mask],
-                        )
+                self._reset_mamba_current_inputs(
+                    num_extends=num_extends,
+                    bs=bs,
+                    has_retract=has_retract,
+                    mamba_pool_indices=mamba_pool_indices,
+                    mamba_cow_src=mamba_cow_src,
+                    skipped_layerwise_cow_mask=skipped_layerwise_cow_mask,
+                )
 
             grammar_completion = None
 

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -35,6 +35,9 @@ from tokenspeed.runtime.configs.deepseek_v4_cache_spec import (
     v4_compressed_kv_group_id,
 )
 from tokenspeed.runtime.configs.model_config import AttentionArch
+from tokenspeed.runtime.configs.paged_cache_spec import (
+    compute_max_logical_pages_for_capture,
+)
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
 from tokenspeed.runtime.layers.attention.deepseek_v4.metadata import (
@@ -347,7 +350,13 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                 )
             return torch.ones(bs, dtype=torch.int32, device=seq_lens.device)
         if forward_mode is not None and forward_mode.is_mixed():
-            lens = torch.ones(bs, dtype=torch.int32, device=seq_lens.device)
+            verify_width = max(1, int(self.speculative_num_draft_tokens))
+            lens = torch.full(
+                (bs,),
+                verify_width,
+                dtype=torch.int32,
+                device=seq_lens.device,
+            )
             num_prefill_reqs = max(0, min(int(num_extends), bs))
             if num_prefill_reqs == 0:
                 return lens
@@ -391,7 +400,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         if forward_mode is not None and forward_mode.is_decode_or_idle():
             return torch.ones(bs, dtype=torch.int32)
         if forward_mode is not None and forward_mode.is_mixed():
-            lens = torch.ones(bs, dtype=torch.int32)
+            verify_width = max(1, int(self.speculative_num_draft_tokens))
+            lens = torch.full((bs,), verify_width, dtype=torch.int32)
             num_prefill_reqs = max(0, min(int(num_extends), bs))
             if num_prefill_reqs == 0:
                 return lens
@@ -653,6 +663,21 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         )
         req_ids = torch.arange(bs, device=device, dtype=torch.int32)
         token_to_req = torch.repeat_interleave(req_ids, query_lens.clamp_min(0))
+        if (
+            forward_mode is not None
+            and forward_mode.is_mixed()
+            and num_tokens_arg is not None
+        ):
+            # numel() reads tensor shape metadata only. Reducing query_lens and
+            # calling .item() here would synchronize its CUDA stream on every
+            # eager mixed batch.
+            metadata_tokens = token_to_req.numel()
+            if metadata_tokens != num_tokens:
+                raise RuntimeError(
+                    "DeepSeek V4 mixed metadata token count mismatch: "
+                    f"query_lens describe {metadata_tokens} tokens, packed input has "
+                    f"{num_tokens}"
+                )
         num_prefill_tokens = (
             int(query_lens[:num_prefill_reqs].sum().item()) if num_prefill_reqs else 0
         )
@@ -706,7 +731,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                     self.forward_prefill_metadata,
                     seq_lens.clone(),
                 )
-        elif forward_mode == ForwardMode.EXTEND:
+        elif forward_mode is not None and forward_mode.is_extend_or_mixed():
             self.forward_prefill_metadata = self.forward_metadata
         self._decode_tile_metadata = {}
 
@@ -1087,7 +1112,17 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         topk_indices: torch.Tensor | None,
     ) -> torch.Tensor:
         metadata = self.forward_metadata
-        if metadata is None:
+        if (
+            metadata is None
+            or metadata.forward_mode is None
+            or not metadata.forward_mode.is_mixed()
+        ):
+            metadata = self.forward_prefill_metadata or metadata
+        if (
+            metadata is None
+            or metadata.forward_mode is None
+            or not metadata.forward_mode.is_mixed()
+        ):
             raise RuntimeError("DeepSeek V4 mixed attention requires forward metadata")
 
         num_prefill_reqs = metadata.num_prefill_reqs
@@ -1574,6 +1609,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         seq_lens_buf: torch.Tensor | None = None,
         paged_cache_group_specs=(),
         max_tokens_per_req: int = 1,
+        overlap_schedule_depth: int = 0,
     ):
         del seq_lens_buf
         self._decode_tile_metadata = {}
@@ -1636,23 +1672,14 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         self._cuda_graph_paged_cache_block_tables = {}
         self._cuda_graph_paged_cache_base_offsets = {}
         for spec in tuple(paged_cache_group_specs or ()):
-            raw_per_page = max(
-                1,
-                int(spec.rows_per_page) * int(spec.entry_stride_tokens),
-            )
             gid = str(spec.group_id)
             sliding = str(getattr(spec, "retention", "")) == "sliding_window"
-            if sliding:
-                window = int(getattr(spec, "sliding_window_tokens", 0) or 0)
-                live_tokens = max(1, window - 1 + max(1, int(max_tokens_per_req)))
-                if self.context_len > 0:
-                    live_tokens = min(live_tokens, self.context_len)
-                max_pages = max(1, (live_tokens + raw_per_page - 1) // raw_per_page + 1)
-            else:
-                max_pages = max(
-                    1,
-                    (self.context_len + raw_per_page - 1) // raw_per_page,
-                )
+            max_pages = compute_max_logical_pages_for_capture(
+                spec,
+                max_context_len=self.context_len,
+                max_tokens_per_req=max_tokens_per_req,
+                overlap_schedule_depth=overlap_schedule_depth,
+            )
             self._cuda_graph_paged_cache_block_tables[gid] = torch.zeros(
                 (max_bs, max_pages),
                 dtype=torch.int32,

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
@@ -238,6 +238,8 @@ def profile_deepseek_v4_max_num_pages(
     max_context_len: int,
     available_cache_memory_bytes: int,
     draft_cache_cell_size: int = 0,
+    decode_input_tokens: int = 1,
+    overlap_schedule_depth: int = 0,
 ) -> int:
     """Return the largest scheduler page budget that fits V4 grouped caches."""
     page_size = int(layout.page_size)
@@ -265,6 +267,8 @@ def profile_deepseek_v4_max_num_pages(
             max_scheduled_tokens=max_scheduled_tokens,
             max_total_tokens=num_tokens,
             max_context_len=max_context_len,
+            decode_input_tokens=decode_input_tokens,
+            overlap_schedule_depth=overlap_schedule_depth,
         )
         cache_bytes = sum(
             int(counts[gid]) * bytes_per_page
@@ -291,6 +295,8 @@ def profile_deepseek_v4_max_num_pages(
         max_scheduled_tokens=max_scheduled_tokens,
         max_total_tokens=0,
         max_context_len=max_context_len,
+        decode_input_tokens=decode_input_tokens,
+        overlap_schedule_depth=overlap_schedule_depth,
     )
     fixed_bytes = sum(
         int(fixed_counts[gid]) * bytes_per_page
@@ -773,6 +779,8 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
         rank: int,
         hf_config: Any,
         max_scheduled_tokens: int,
+        decode_input_tokens: int = 1,
+        overlap_schedule_depth: int = 0,
     ) -> None:
         if size <= 0:
             raise ValueError(f"DeepSeek V4 KV pool size must be positive, got {size}")
@@ -819,6 +827,8 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
             max_scheduled_tokens=max(0, int(max_scheduled_tokens)),
             max_total_tokens=size,
             max_context_len=max_context_len,
+            decode_input_tokens=decode_input_tokens,
+            overlap_schedule_depth=overlap_schedule_depth,
         )
 
         def _group_rows(group_id: str, default: int) -> int:

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -323,6 +323,8 @@ def create_attn_components(
     gpu_memory: int,
     enable_memory_saver: bool = False,
     draft_model_config: ModelConfig | None = None,
+    decode_input_tokens: int = 1,
+    overlap_schedule_depth: int = 0,
 ) -> tuple[
     AttentionBackend,
     BaseTokenToKVPool,
@@ -457,6 +459,8 @@ def create_attn_components(
                 world_group=server_args.mapping.world_group,
             ),
             draft_cache_cell_size=draft_cache_cell_size,
+            decode_input_tokens=decode_input_tokens,
+            overlap_schedule_depth=overlap_schedule_depth,
         )
         logger.info(
             "DeepSeek V4 grouped KV profile: max_live_requests=%s "
@@ -570,6 +574,8 @@ def create_attn_components(
             rank=rank,
             hf_config=model_config.hf_config,
             max_scheduled_tokens=server_args.chunked_prefill_size,
+            decode_input_tokens=decode_input_tokens,
+            overlap_schedule_depth=overlap_schedule_depth,
         )
     elif is_hybrid_gdn:
         resolved_original_backend = _BACKEND_ALIASES.get(
@@ -621,6 +627,8 @@ def create_attn_components(
                 rank=rank,
                 hf_config=draft_model_config.hf_config,
                 max_scheduled_tokens=server_args.chunked_prefill_size,
+                decode_input_tokens=decode_input_tokens,
+                overlap_schedule_depth=overlap_schedule_depth,
             )
         elif any(a in _HYBRID_GDN_ARCHITECTURES for a in draft_archs):
             resolved_draft_backend = _BACKEND_ALIASES.get(

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -172,7 +172,7 @@ def _deepseek_v4_indexer_token_split(
 def _deepseek_v4_forward_metadata(ctx: ForwardContext):
     metadata = getattr(ctx.attn_backend, "forward_metadata", None)
     forward_mode = getattr(ctx, "forward_mode", None)
-    if forward_mode == ForwardMode.EXTEND:
+    if forward_mode is not None and forward_mode.is_extend_or_mixed():
         return getattr(ctx.attn_backend, "forward_prefill_metadata", None) or metadata
     if forward_mode is not None and forward_mode.is_decode_or_idle():
         input_num_tokens = getattr(ctx, "input_num_tokens", None)

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -1640,6 +1640,155 @@ class TestDeepseekV4Config(unittest.TestCase):
             [0, 0, 0, 0, 0, 0, 0, 1, 2],
         )
 
+    def test_deepseek_v4_mixed_metadata_uses_runtime_verify_width(self):
+        for verify_width in (1, 2, 4, 8):
+            with self.subTest(verify_width=verify_width):
+                backend = DeepseekV4AttentionBackend(
+                    SimpleNamespace(
+                        page_size=64,
+                        device="cpu",
+                        num_attention_heads=64,
+                        num_kv_heads=1,
+                        attn_tp_size=1,
+                        dtype=torch.bfloat16,
+                        is_draft=False,
+                        speculative_num_draft_tokens=verify_width,
+                        head_dim=512,
+                        context_len=16384,
+                    )
+                )
+                prefill_tokens = 8192 - 2 * verify_width
+                total_tokens = prefill_tokens + 2 * verify_width
+                backend.init_forward_metadata(
+                    bs=3,
+                    num_tokens=total_tokens,
+                    req_pool_indices=torch.tensor([0, 1, 2], dtype=torch.int64),
+                    seq_lens=torch.tensor(
+                        [prefill_tokens, 100, 200], dtype=torch.int32
+                    ),
+                    forward_mode=ForwardMode.MIXED,
+                    req_to_page=torch.zeros((3, 256), dtype=torch.int32),
+                    extend_seq_lens_cpu=torch.tensor(
+                        [prefill_tokens], dtype=torch.int32
+                    ),
+                    num_extends=1,
+                )
+
+                metadata = backend.forward_metadata
+                self.assertIsNotNone(metadata)
+                assert metadata is not None
+                self.assertEqual(
+                    metadata.query_lens.tolist(),
+                    [prefill_tokens, verify_width, verify_width],
+                )
+                self.assertEqual(
+                    metadata.query_lens_cpu.tolist(),
+                    [prefill_tokens, verify_width, verify_width],
+                )
+                self.assertEqual(
+                    metadata.query_start_loc.tolist(),
+                    [
+                        0,
+                        prefill_tokens,
+                        prefill_tokens + verify_width,
+                        total_tokens,
+                    ],
+                )
+                self.assertEqual(metadata.token_to_req_indices.numel(), total_tokens)
+                self.assertEqual(
+                    metadata.token_to_req_indices[-2 * verify_width :].tolist(),
+                    [1] * verify_width + [2] * verify_width,
+                )
+
+    def test_deepseek_v4_mixed_metadata_rejects_packed_token_mismatch(self):
+        backend = DeepseekV4AttentionBackend(
+            SimpleNamespace(
+                page_size=64,
+                device="cpu",
+                num_attention_heads=64,
+                num_kv_heads=1,
+                attn_tp_size=1,
+                dtype=torch.bfloat16,
+                is_draft=False,
+                speculative_num_draft_tokens=4,
+                head_dim=512,
+                context_len=4096,
+            )
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "mixed metadata token count mismatch",
+        ):
+            backend.init_forward_metadata(
+                bs=2,
+                num_tokens=10,
+                req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+                seq_lens=torch.tensor([7, 20], dtype=torch.int32),
+                forward_mode=ForwardMode.MIXED,
+                req_to_page=torch.zeros((2, 64), dtype=torch.int32),
+                extend_seq_lens_cpu=torch.tensor([7], dtype=torch.int32),
+                num_extends=1,
+            )
+
+    def test_deepseek_v4_draft_keeps_mixed_step0_and_decode_step_metadata(self):
+        verify_width = 4
+        backend = DeepseekV4AttentionBackend(
+            SimpleNamespace(
+                page_size=64,
+                device="cpu",
+                num_attention_heads=64,
+                num_kv_heads=1,
+                attn_tp_size=1,
+                dtype=torch.bfloat16,
+                is_draft=True,
+                speculative_num_draft_tokens=verify_width,
+                head_dim=512,
+                context_len=4096,
+            )
+        )
+        req_pool_indices = torch.tensor([0, 1], dtype=torch.int64)
+        seq_lens = torch.tensor([7, 20], dtype=torch.int32)
+        req_to_page = torch.zeros((2, 64), dtype=torch.int32)
+        backend.init_forward_metadata(
+            bs=2,
+            num_tokens=7 + verify_width,
+            req_pool_indices=req_pool_indices,
+            seq_lens=seq_lens,
+            forward_mode=ForwardMode.MIXED,
+            req_to_page=req_to_page,
+            extend_seq_lens_cpu=torch.tensor([7], dtype=torch.int32),
+            num_extends=1,
+        )
+        mixed_metadata = backend.forward_metadata
+        self.assertIsNotNone(mixed_metadata)
+        self.assertIs(backend.forward_prefill_metadata, mixed_metadata)
+
+        backend.init_forward_metadata(
+            bs=2,
+            req_pool_indices=req_pool_indices,
+            seq_lens=seq_lens,
+            forward_mode=ForwardMode.DECODE,
+            req_to_page=req_to_page,
+            num_extends=0,
+        )
+        decode_metadata = backend.forward_metadata
+        self.assertIs(backend.forward_decode_metadata, decode_metadata)
+        self.assertEqual(decode_metadata.query_lens.tolist(), [1, 1])
+
+        mixed_ctx = SimpleNamespace(
+            attn_backend=backend,
+            forward_mode=ForwardMode.MIXED,
+            input_num_tokens=7 + verify_width,
+        )
+        decode_ctx = SimpleNamespace(
+            attn_backend=backend,
+            forward_mode=ForwardMode.DECODE,
+            input_num_tokens=2,
+        )
+        self.assertIs(_deepseek_v4_forward_metadata(mixed_ctx), mixed_metadata)
+        self.assertIs(_deepseek_v4_forward_metadata(decode_ctx), decode_metadata)
+
     def test_deepseek_v4_cuda_graph_refresh_keeps_compact_table_columns(self):
         backend = DeepseekV4AttentionBackend(
             SimpleNamespace(
@@ -2256,7 +2405,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertTrue(torch.equal(out[:3], torch.ones((3, 2, 4))))
         self.assertTrue(torch.equal(out[3:], torch.full((2, 2, 4), 2.0)))
 
-    def test_deepseek_v4_mixed_prefill_uses_current_slice(self):
+    def test_deepseek_v4_mixed_prefill_replaces_stale_slice(self):
         backend = DeepseekV4AttentionBackend(
             SimpleNamespace(
                 page_size=64,
@@ -2290,7 +2439,8 @@ class TestDeepseekV4Config(unittest.TestCase):
             num_extends=1,
         )
         mixed_metadata = backend.forward_metadata
-        self.assertIs(backend.forward_prefill_metadata, stale_prefill_metadata)
+        self.assertIs(backend.forward_prefill_metadata, mixed_metadata)
+        self.assertIsNot(backend.forward_prefill_metadata, stale_prefill_metadata)
 
         calls = []
 

--- a/test/runtime/test_model_executor_retraction.py
+++ b/test/runtime/test_model_executor_retraction.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tokenspeed.runtime.execution.model_executor import ModelExecutor
+
+
+class _RuntimeStates:
+    def __init__(self):
+        self.valid_cache_lengths = torch.arange(20, dtype=torch.int32)
+
+    def reset_states(self, req_pool_indices, prefix_lens):
+        self.valid_cache_lengths[req_pool_indices] = prefix_lens
+
+
+class _ExecutionStream:
+    def wait_stream(self, _):
+        return None
+
+
+class _RecordingAttentionBackend:
+    def __init__(self):
+        self.reset_calls = []
+
+    def reset_current_inputs(self, req_pool_indices, mamba_pool_indices):
+        self.reset_calls.append(
+            (req_pool_indices.tolist(), mamba_pool_indices.tolist())
+        )
+
+
+def test_mixed_batch_resets_prefill_and_retracted_decode_lengths(monkeypatch):
+    executor = ModelExecutor.__new__(ModelExecutor)
+    executor.device = "cpu"
+    executor.execution_stream = _ExecutionStream()
+    executor.runtime_states = _RuntimeStates()
+
+    forward_op = SimpleNamespace(
+        request_pool_indices=[2, 3, 4],
+        extend_prefix_lens=[10],
+        # hist_token_lens contains decode rows only: one normal decode and one
+        # recovery row following the prefill row.
+        hist_token_lens=[-1, 7],
+        num_extends=lambda: 1,
+    )
+
+    torch_tensor = torch.tensor
+
+    def tensor_without_pinning(*args, **kwargs):
+        kwargs.pop("pin_memory", None)
+        return torch_tensor(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "tensor", tensor_without_pinning)
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda: object())
+    monkeypatch.setattr(torch.cuda, "stream", lambda _: nullcontext())
+
+    executor.reset_valid_cache_length(forward_op)
+
+    assert executor.runtime_states.valid_cache_lengths[2].item() == 10
+    assert executor.runtime_states.valid_cache_lengths[3].item() == 3
+    assert executor.runtime_states.valid_cache_lengths[4].item() == 7
+
+
+@pytest.mark.parametrize(
+    ("mamba_cow_src", "skipped_layerwise_cow_mask"),
+    [
+        ([-1, -1, 77], None),
+        ([-1, -1, -1], [False, False, True]),
+    ],
+)
+def test_mixed_batch_resets_prefill_and_retracted_mamba_inputs(
+    mamba_cow_src,
+    skipped_layerwise_cow_mask,
+):
+    executor = ModelExecutor.__new__(ModelExecutor)
+    executor.attn_backend = _RecordingAttentionBackend()
+    executor.input_buffers = SimpleNamespace(
+        req_pool_indices_buf=torch.tensor([10, 11, 12], dtype=torch.int32)
+    )
+    forward_op = SimpleNamespace(hist_token_lens=[-1, 7])
+
+    executor._reset_mamba_current_inputs(
+        num_extends=1,
+        bs=3,
+        has_retract=executor._contains_retracted_decode(forward_op),
+        mamba_pool_indices=torch.tensor([20, 21, 22], dtype=torch.int32),
+        mamba_cow_src=torch.tensor(mamba_cow_src, dtype=torch.int32),
+        skipped_layerwise_cow_mask=(
+            torch.tensor(skipped_layerwise_cow_mask, dtype=torch.bool)
+            if skipped_layerwise_cow_mask is not None
+            else None
+        ),
+    )
+
+    assert executor.attn_backend.reset_calls == [
+        ([10], [20]),
+        ([12], [22]),
+    ]

--- a/test/runtime/test_v4_prefix_cache_metadata.py
+++ b/test/runtime/test_v4_prefix_cache_metadata.py
@@ -110,18 +110,30 @@ def _prime_r1(sched: "Scheduler") -> tuple[list[int], list[int]]:
     return r1_fh, r1_swa
 
 
-def _submit_r2_same_prefix(sched: "Scheduler") -> None:
+def _submit_r2_same_prefix(sched: "Scheduler") -> int:
     spec = RequestSpec()
     spec.request_id = "r2"
     spec.tokens = list(range(1, 13))
     sched.submit_requests([spec])
-    sched.next_execution_plan()
+    plan = sched.next_execution_plan()
+    assert len(plan.forward) == 1
+    forward = plan.forward[0]
+    assert forward.request_ids == ["r2"]
+    assert len(forward.extend_prefix_lens) == 1
+    return int(forward.extend_prefix_lens[0])
 
 
 class TestV4PrefixCacheMetadata(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.sched = Scheduler(_make_two_group_config())
+        config = _make_two_group_config()
+        fh_config = next(
+            group for group in config.paged_cache_groups if group.group_id == "fh"
+        )
+        self.fh_raw_tokens_per_page = (
+            fh_config.rows_per_page * fh_config.entry_stride_tokens
+        )
+        self.sched = Scheduler(config)
         self.r1_fh, self.r1_swa = _prime_r1(self.sched)
         self.assertNotEqual(
             self.r1_fh,
@@ -133,19 +145,25 @@ class TestV4PrefixCacheMetadata(unittest.TestCase):
             [],
             "r1 swa page ids must be captured before finish releases the request table",
         )
-        _submit_r2_same_prefix(self.sched)
+        self.r2_prefix_len = _submit_r2_same_prefix(self.sched)
 
     def test_block_table_borrowed_plus_suffix(self) -> None:
         """R2's table starts with r1's borrowed prefix page ids."""
         r2_fh = list(self.sched.get_request_paged_cache_page_ids("r2", "fh"))
-        self.assertGreaterEqual(len(r2_fh), 1)
-        n = min(len(self.r1_fh), len(r2_fh))
+        self.assertEqual(self.r2_prefix_len % self.fh_raw_tokens_per_page, 0)
+        borrowed_pages = self.r2_prefix_len // self.fh_raw_tokens_per_page
         self.assertGreater(
-            n,
+            borrowed_pages,
             0,
             "r2 must borrow at least one fh page from r1's prefix snapshot",
         )
-        self.assertEqual(r2_fh[:n], self.r1_fh[:n])
+        self.assertGreaterEqual(len(self.r1_fh), borrowed_pages)
+        self.assertGreater(
+            len(r2_fh),
+            borrowed_pages,
+            "r2 must allocate a suffix after its borrowed prefix pages",
+        )
+        self.assertEqual(r2_fh[:borrowed_pages], self.r1_fh[:borrowed_pages])
 
     def test_base_offsets_sliding_correct(self) -> None:
         """For sliding-window groups the per-request base_logical_page

--- a/test/runtime/test_v4_sliding_window_groups_smoke.py
+++ b/test/runtime/test_v4_sliding_window_groups_smoke.py
@@ -48,11 +48,246 @@ _v4 = _load(
 )
 
 build_v4_cache_specs = _v4.build_v4_cache_specs
+compute_max_logical_pages_for_capture = _generic.compute_max_logical_pages_for_capture
 compute_paged_cache_group_page_counts = _generic.compute_paged_cache_group_page_counts
 PagedCacheGroupSpec = _generic.PagedCacheGroupSpec
 
+_PAGE_SHAPES = ((4, 1), (4, 2), (16, 4), (2, 128))
+
 
 class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
+    def test_overlap_page_budget_is_parameterized_by_verify_width_and_depth(self):
+        max_live_requests = 3
+        for rows_per_page, entry_stride_tokens in _PAGE_SHAPES:
+            raw_per_page = rows_per_page * entry_stride_tokens
+            specs = [
+                PagedCacheGroupSpec(
+                    group_id="full",
+                    retention="full_history",
+                    rows_per_page=rows_per_page,
+                    entry_stride_tokens=entry_stride_tokens,
+                    sliding_window_tokens=None,
+                ),
+                PagedCacheGroupSpec(
+                    group_id="sliding",
+                    retention="sliding_window",
+                    rows_per_page=rows_per_page,
+                    entry_stride_tokens=entry_stride_tokens,
+                    sliding_window_tokens=3 * raw_per_page + 1,
+                ),
+            ]
+            common = dict(
+                max_live_requests=max_live_requests,
+                max_scheduled_tokens=1024,
+                max_total_tokens=4096,
+                max_context_len=4096,
+            )
+            for verify_width in (1, 2, 4, 8):
+                baseline = compute_paged_cache_group_page_counts(
+                    specs,
+                    **common,
+                    decode_input_tokens=verify_width,
+                    overlap_schedule_depth=0,
+                )
+                for overlap_depth in (0, 1):
+                    with self.subTest(
+                        raw_per_page=raw_per_page,
+                        verify_width=verify_width,
+                        overlap_depth=overlap_depth,
+                    ):
+                        actual = compute_paged_cache_group_page_counts(
+                            specs,
+                            **common,
+                            decode_input_tokens=verify_width,
+                            overlap_schedule_depth=overlap_depth,
+                        )
+                        protected_pages = max_live_requests * math.ceil(
+                            overlap_depth * verify_width / raw_per_page
+                        )
+                        for group_id in ("full", "sliding"):
+                            self.assertEqual(
+                                actual[group_id],
+                                baseline[group_id] + protected_pages,
+                            )
+
+    def test_capture_table_width_is_parameterized_by_verify_width_and_depth(self):
+        for rows_per_page, entry_stride_tokens in _PAGE_SHAPES:
+            raw_per_page = rows_per_page * entry_stride_tokens
+            full = PagedCacheGroupSpec(
+                group_id="full",
+                retention="full_history",
+                rows_per_page=rows_per_page,
+                entry_stride_tokens=entry_stride_tokens,
+                sliding_window_tokens=None,
+            )
+            window = 3 * raw_per_page + 1
+            sliding = PagedCacheGroupSpec(
+                group_id="sliding",
+                retention="sliding_window",
+                rows_per_page=rows_per_page,
+                entry_stride_tokens=entry_stride_tokens,
+                sliding_window_tokens=window,
+            )
+            context_len = 5 * raw_per_page + 1
+            for verify_width in (1, 2, 4, 8):
+                for overlap_depth in (0, 1):
+                    with self.subTest(
+                        raw_per_page=raw_per_page,
+                        verify_width=verify_width,
+                        overlap_depth=overlap_depth,
+                    ):
+                        full_pages = compute_max_logical_pages_for_capture(
+                            full,
+                            max_context_len=context_len,
+                            max_tokens_per_req=verify_width,
+                            overlap_schedule_depth=overlap_depth,
+                        )
+                        self.assertEqual(
+                            full_pages,
+                            math.ceil(
+                                (context_len + (overlap_depth + 1) * verify_width)
+                                / raw_per_page
+                            ),
+                        )
+
+                        sliding_pages = compute_max_logical_pages_for_capture(
+                            sliding,
+                            max_context_len=context_len,
+                            max_tokens_per_req=verify_width,
+                            overlap_schedule_depth=overlap_depth,
+                        )
+                        self.assertEqual(
+                            sliding_pages,
+                            math.ceil(
+                                (window - 1 + (overlap_depth + 1) * verify_width)
+                                / raw_per_page
+                            )
+                            + 1,
+                        )
+
+    def test_sliding_capture_width_covers_absolute_reservation_range(self):
+        for rows_per_page, entry_stride_tokens in _PAGE_SHAPES:
+            raw_per_page = rows_per_page * entry_stride_tokens
+            window = 3 * raw_per_page + 1
+            spec = PagedCacheGroupSpec(
+                group_id="sliding",
+                retention="sliding_window",
+                rows_per_page=rows_per_page,
+                entry_stride_tokens=entry_stride_tokens,
+                sliding_window_tokens=window,
+            )
+            for context_len in (2 * raw_per_page + 1, 5 * raw_per_page + 1):
+                for verify_width in (1, 2, 4, 8):
+                    for overlap_depth in (0, 1):
+                        reservation_end = (
+                            context_len + (overlap_depth + 1) * verify_width
+                        )
+                        with self.subTest(
+                            raw_per_page=raw_per_page,
+                            context_len=context_len,
+                            verify_width=verify_width,
+                            overlap_depth=overlap_depth,
+                        ):
+                            capture_pages = compute_max_logical_pages_for_capture(
+                                spec,
+                                max_context_len=context_len,
+                                max_tokens_per_req=verify_width,
+                                overlap_schedule_depth=overlap_depth,
+                            )
+                            retained_begin = max(0, context_len - (window - 1))
+                            required_pages = math.ceil(
+                                reservation_end / raw_per_page
+                            ) - math.floor(retained_begin / raw_per_page)
+                            self.assertGreaterEqual(capture_pages, required_pages)
+
+    def test_overlap_sizing_rejects_invalid_runtime_parameters(self):
+        spec = PagedCacheGroupSpec(
+            group_id="full",
+            retention="full_history",
+            rows_per_page=4,
+            entry_stride_tokens=1,
+            sliding_window_tokens=None,
+        )
+        count_args = dict(
+            max_live_requests=1,
+            max_scheduled_tokens=8,
+            max_total_tokens=8,
+            max_context_len=8,
+        )
+        for overrides, message in (
+            ({"decode_input_tokens": -1}, "decode_input_tokens"),
+            ({"overlap_schedule_depth": 2}, "overlap_schedule_depth"),
+            (
+                {"decode_input_tokens": 0, "overlap_schedule_depth": 1},
+                "decode_input_tokens",
+            ),
+        ):
+            with self.subTest(function="page_counts", overrides=overrides):
+                with self.assertRaisesRegex(ValueError, message):
+                    compute_paged_cache_group_page_counts(
+                        [spec], **count_args, **overrides
+                    )
+
+        for overrides, message in (
+            ({"max_context_len": -1}, "max_context_len"),
+            ({"max_tokens_per_req": 0}, "max_tokens_per_req"),
+            ({"overlap_schedule_depth": 2}, "overlap_schedule_depth"),
+        ):
+            with self.subTest(function="capture_width", overrides=overrides):
+                with self.assertRaisesRegex(ValueError, message):
+                    compute_max_logical_pages_for_capture(
+                        spec,
+                        **{
+                            "max_context_len": 8,
+                            "max_tokens_per_req": 1,
+                            **overrides,
+                        },
+                    )
+
+        invalid_specs = (
+            (
+                PagedCacheGroupSpec("bad-rows", "full_history", 0, 1, None),
+                "rows_per_page",
+            ),
+            (
+                PagedCacheGroupSpec("bad-window", "sliding_window", 4, 1, 0),
+                "sliding_window_tokens",
+            ),
+            (
+                PagedCacheGroupSpec("bad-retention", "unknown", 4, 1, None),
+                "unsupported retention",
+            ),
+        )
+        for invalid_spec, message in invalid_specs:
+            with self.subTest(group=invalid_spec.group_id):
+                with self.assertRaisesRegex(ValueError, message):
+                    compute_max_logical_pages_for_capture(
+                        invalid_spec,
+                        max_context_len=8,
+                    )
+
+    def test_overlap_schedule_enablement_truth_table(self):
+        from tokenspeed.runtime.engine.scheduler_utils import (
+            should_use_overlap_schedule,
+        )
+
+        cases = (
+            # disabled, mode, expected
+            (True, "fused", False),
+            (False, "prefill", False),
+            (False, "fused", True),
+            (False, "decode", True),
+        )
+        for disabled, mode, expected in cases:
+            with self.subTest(disabled=disabled, mode=mode):
+                self.assertEqual(
+                    should_use_overlap_schedule(
+                        disable_overlap_schedule=disabled,
+                        disaggregation_mode=mode,
+                    ),
+                    expected,
+                )
+
     def test_sliding_window_scheduled_tokens_are_global_and_capped(self):
         specs = [
             PagedCacheGroupSpec(

--- a/tokenspeed-scheduler/bindings/python_module.cpp
+++ b/tokenspeed-scheduler/bindings/python_module.cpp
@@ -222,6 +222,7 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .def_rw("max_scheduled_tokens", &tokenspeed::SchedulerConfig::max_scheduled_tokens)
         .def_rw("max_batch_size", &tokenspeed::SchedulerConfig::max_batch_size)
         .def_rw("decode_input_tokens", &tokenspeed::SchedulerConfig::decode_input_tokens)
+        .def_rw("overlap_schedule_depth", &tokenspeed::SchedulerConfig::overlap_schedule_depth)
         .def_rw("role", &tokenspeed::SchedulerConfig::role)
         .def_prop_rw(
             "num_device_pages", [](const tokenspeed::SchedulerConfig& c) { return c.device_allocator.total_pages; },

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.h
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.h
@@ -298,16 +298,24 @@ struct ExtendResultEvent : InvalidTransitionHandler<ExtendResultEvent> {
     ExtendResultEvent() = delete;
 
     ExtendResultEvent(std::string request_id, std::vector<std::int32_t> result_tokens,
-                      HybridPrefixCache* hybrid_prefix_cache = nullptr)
+                      HybridPrefixCache* hybrid_prefix_cache = nullptr, std::int32_t protected_tail_tokens = 0)
         : request_id_(std::move(request_id)),
           result_tokens_(std::move(result_tokens)),
-          hybrid_prefix_cache_(hybrid_prefix_cache) {}
+          hybrid_prefix_cache_(hybrid_prefix_cache),
+          protected_tail_tokens_(protected_tail_tokens) {}
 
 public:
     template <typename S>
         requires CanExtendTokenContainer<S>
     std::remove_cvref_t<S> operator()(S&& state) {
         state.ExtendResultTokens(result_tokens_);
+        using State = std::remove_cvref_t<S>;
+        if constexpr (std::same_as<State, Retracting> || std::same_as<State, Retracted>) {
+            if (hybrid_prefix_cache_ != nullptr) {
+                hybrid_prefix_cache_->RewindRequest(request_id_, state.GetTokenContainer()->Size(),
+                                                    protected_tail_tokens_);
+            }
+        }
         return std::move(state);
     }
 
@@ -331,7 +339,7 @@ public:
         const std::int32_t new_publishable_pages = publishable_pages(accepted_token_size);
 
         if (new_publishable_pages <= old_publishable_pages) {
-            hybrid_prefix_cache_->RewindRequest(request_id_, accepted_token_size);
+            hybrid_prefix_cache_->RewindRequest(request_id_, accepted_token_size, protected_tail_tokens_);
             return std::move(state);
         }
 
@@ -352,7 +360,7 @@ public:
                               static_cast<std::int32_t>(result_tokens_.size()), page_size, &prefix_pages);
             hybrid_prefix_cache_->CommitChunk(request_id_, device_node_ref->Node());
         }
-        hybrid_prefix_cache_->RewindRequest(request_id_, accepted_token_size);
+        hybrid_prefix_cache_->RewindRequest(request_id_, accepted_token_size, protected_tail_tokens_);
 
         return Decoding{token_container,
                         page_size,
@@ -375,6 +383,7 @@ private:
     std::string request_id_;
     std::vector<std::int32_t> result_tokens_;
     HybridPrefixCache* hybrid_prefix_cache_{};
+    std::int32_t protected_tail_tokens_{};
 };
 
 }  // namespace tokenspeed::fsm

--- a/tokenspeed-scheduler/csrc/resource/allocator/paged_cache_group.h
+++ b/tokenspeed-scheduler/csrc/resource/allocator/paged_cache_group.h
@@ -101,7 +101,8 @@ private:
 
 // One per request, per group. Two storage segments (no refcounts):
 //   - `borrowed_page_ids_`: page ids only; physical ownership lives in a
-//     TreeNode's PagedCacheSnapshot, pinned via the request's DeviceNodeRef.
+//     TreeNode's PagedCacheSnapshot. HybridPrefixCache treats these ids as an
+//     explicit borrow when deciding whether that snapshot can be reclaimed.
 //   - `owned_pages_`: RAII back to the allocator on release or moved to a
 //     snapshot via CommitHistoryToSnapshot / CheckpointStateToSnapshot.
 // PageIds() = borrowed ++ owned, where column c == absolute logical page
@@ -160,17 +161,21 @@ public:
     // Borrowed prefix pages and already committed pages are retained.
     std::vector<std::int32_t> RewindTail(std::int32_t target_raw_tokens_exclusive);
 
-    // Release everything; owned via RAII, borrowed by clearing. Used by finish/abort/retract.
+    // Release everything; owned via RAII, borrowed by clearing. Used when a
+    // request finishes or aborts; retraction preserves the table for recovery.
     std::vector<std::int32_t> ReleaseAll();
 
     // Compact: PageIds()[c] = absolute logical page BaseLogicalPage() + c.
     const std::vector<std::int32_t>& PageIds() const { return page_ids_view_; }
+    const std::vector<std::int32_t>& BorrowedPageIds() const { return borrowed_page_ids_; }
     std::int32_t Size() const { return static_cast<std::int32_t>(borrowed_page_ids_.size()) + owned_pages_.Size(); }
     std::int32_t ActivePagesCount() const { return Size(); }
     std::int32_t OwnedPagesCount() const { return owned_pages_.Size(); }
     std::int32_t BorrowedPagesCount() const { return static_cast<std::int32_t>(borrowed_page_ids_.size()); }
     std::int32_t ReleasedPagesCount() const { return base_logical_page_; }
     std::int32_t BaseLogicalPage() const { return base_logical_page_; }
+    // Exclusive logical reservation horizon. Under overlap this may be ahead
+    // of the accepted or snapshot-published token boundary.
     std::int32_t RawTokenCursor() const { return raw_token_cursor_; }
 
     // Independent of base_logical_page_; sliding ReleaseSkipped does not move this.

--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <numeric>
 #include <stdexcept>
 #include <utility>
@@ -99,6 +100,19 @@ HybridPrefixCache::HybridPrefixCache(KVPrefixCache& kv_prefix_cache, MambaChunkA
       mamba_host_allocator_{mamba_host_allocator},
       mamba_eviction_manager_{mamba_allocator},
       mamba_cache_chunk_size_{mamba_cache_chunk_size} {}
+
+HybridPrefixCache::~HybridPrefixCache() {
+    // Paged snapshots live on KVPrefixCache TreeNodes but own pages from the
+    // group allocators below. Scheduler destroys HybridPrefixCache before the
+    // KV tree, so detach every external owner while those allocators are still
+    // alive. Request tables are cleared first to drop their borrowed ids and
+    // return any request-owned tail pages.
+    request_paged_cache_tables_.clear();
+    while (!paged_cache_snapshot_nodes_.empty()) {
+        TreeNode* node = *paged_cache_snapshot_nodes_.begin();
+        DetachPagedCacheSnapshotFromNode(node);
+    }
+}
 
 MatchResult HybridPrefixCache::Match(const token_vec_t& token_ids, MatchIntent intent) {
     auto match = kv_prefix_cache_.Match(token_ids, intent);
@@ -430,7 +444,7 @@ bool HybridPrefixCache::commitTerminalContinuationSnapshot(std::map<std::string,
         PagedCacheGroupSnapshot group_snap{};
         group_snap.pages = std::move(result.pages);
         group_snap.base_logical_page = result.segment_base_logical_page;
-        group_snap.raw_token_cursor = action.table->RawTokenCursor();
+        group_snap.raw_token_cursor = target;
         group_snap.sliding = action.table->IsSliding();
         snapshot->groups.emplace(action.gid, std::move(group_snap));
     }
@@ -457,6 +471,35 @@ std::unique_ptr<PagedCacheSnapshot> HybridPrefixCache::DetachPagedCacheSnapshotF
     return node->DetachPagedCacheSnapshot();
 }
 
+bool HybridPrefixCache::isPagedCacheSnapshotBorrowed(const TreeNode* node,
+                                                     std::optional<PagedCacheGroupFamily> family) const {
+    if (node == nullptr) return false;
+    const PagedCacheSnapshot* snapshot = node->GetPagedCacheSnapshot();
+    if (snapshot == nullptr) return false;
+
+    for (const auto& [_, tables] : request_paged_cache_tables_) {
+        for (const auto& [group_id, group_snapshot] : snapshot->groups) {
+            if (family.has_value()) {
+                auto allocator_it = paged_cache_allocators_.find(group_id);
+                if (allocator_it == paged_cache_allocators_.end() || allocator_it->second == nullptr ||
+                    allocator_it->second->Config().family != *family) {
+                    continue;
+                }
+            }
+            auto table_it = tables.find(group_id);
+            if (table_it == tables.end()) continue;
+            const auto& borrowed = table_it->second.BorrowedPageIds();
+            const auto& snapshot_pages = group_snapshot.pages.Ids();
+            if (std::any_of(snapshot_pages.begin(), snapshot_pages.end(), [&borrowed](std::int32_t page_id) {
+                    return std::find(borrowed.begin(), borrowed.end(), page_id) != borrowed.end();
+                })) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 void HybridPrefixCache::OnKVEvict(TreeNode* node) {
     if (node == nullptr) return;
     if (mamba_allocator_ != nullptr && node->HasMamba()) {
@@ -466,10 +509,10 @@ void HybridPrefixCache::OnKVEvict(TreeNode* node) {
             mamba_eviction_manager_.UpdateLeaf(node->Parent());
         }
     }
-    // Passive paged-cache detach on KV LRU drop: returns OwnedPages via RAII;
-    // the chain scan sees the gap because `HasPagedCacheSnapshot()` is false.
-    // Route through DetachPagedCacheSnapshotFromNode to keep membership set in sync.
-    if (node->HasPagedCacheSnapshot()) {
+    // Passive paged-cache detach on KV LRU drop normally returns OwnedPages
+    // via RAII. A retracted/loadback request's side table can outlive the
+    // device KV resource, so retain snapshots whose page ids it still borrows.
+    if (node->HasPagedCacheSnapshot() && !isPagedCacheSnapshotBorrowed(node)) {
         DetachPagedCacheSnapshotFromNode(node);
     }
 }
@@ -492,6 +535,8 @@ void HybridPrefixCache::OnNodeDestroyed(TreeNode* node) {
         }
     }
     if (node->HasPagedCacheSnapshot()) {
+        _assert(!isPagedCacheSnapshotBorrowed(node),
+                "HybridPrefixCache::OnNodeDestroyed: paged snapshot still has a request-table borrower");
         DetachPagedCacheSnapshotFromNode(node);
     }
     // Host-side Mamba L2 bookkeeping (no-op when the L2 pool is disabled, since
@@ -1084,16 +1129,25 @@ void HybridPrefixCache::ReleaseRequest(const std::string& request_id) {
     DemoteIdleMambaDeviceCopiesPresentOnHost();
 }
 
-void HybridPrefixCache::RewindRequest(const std::string& request_id, std::int32_t accepted_raw_tokens) {
+void HybridPrefixCache::RewindRequest(const std::string& request_id, std::int32_t accepted_raw_tokens,
+                                      std::int32_t protected_tail_tokens) {
     if (accepted_raw_tokens < 0) {
         throw std::invalid_argument("HybridPrefixCache::RewindRequest: accepted_raw_tokens must be >= 0");
+    }
+    if (protected_tail_tokens < 0) {
+        throw std::invalid_argument("HybridPrefixCache::RewindRequest: protected_tail_tokens must be >= 0");
+    }
+    const std::int64_t target =
+        static_cast<std::int64_t>(accepted_raw_tokens) + static_cast<std::int64_t>(protected_tail_tokens);
+    if (target > std::numeric_limits<std::int32_t>::max()) {
+        throw std::overflow_error("HybridPrefixCache::RewindRequest: retained target exceeds int32 range");
     }
     auto it = request_paged_cache_tables_.find(request_id);
     if (it == request_paged_cache_tables_.end()) {
         return;
     }
     for (auto& [_, table] : it->second) {
-        table.RewindTail(accepted_raw_tokens);
+        table.RewindTail(static_cast<std::int32_t>(target));
     }
 }
 
@@ -1138,8 +1192,7 @@ HybridPrefixCache::PagedCacheGroupAdmission HybridPrefixCache::checkPagedCacheGr
         }
     }
 
-    auto req_it =
-        context.fresh_table_view ? request_paged_cache_tables_.end() : request_paged_cache_tables_.find(request_id);
+    auto req_it = request_paged_cache_tables_.find(request_id);
     const bool has_hit = (paged_cache_hit.last_node != nullptr) && (paged_cache_hit.prefix_len_tokens > 0);
     for (const auto& [gid, allocator] : paged_cache_allocators_) {
         const auto& cfg = allocator->Config();
@@ -1267,11 +1320,6 @@ HybridPrefixCache::PagedCacheGroupAdmission HybridPrefixCache::checkPagedCacheGr
         if (sf_it != simulated_free.end()) {
             free = sf_it->second;
         }
-        auto credit_it = context.owned_release_credit.find(gid);
-        if (credit_it != context.owned_release_credit.end()) {
-            free += credit_it->second;
-        }
-
         result.releasable_owned_pages[gid] = releasable_owned;
         result.new_pages_needed[gid] = new_pages;
         if (free + releasable_owned < new_pages) {
@@ -1334,9 +1382,6 @@ bool HybridPrefixCache::admitPagedCacheChunk(const std::string& request_id, std:
                                                   simulated_free, paged_cache_hit, context);
     }
     if (!admission.ok) return false;
-    for (const auto& [gid, credit] : context.owned_release_credit) {
-        simulated_free[gid] += credit;
-    }
     applyPagedCacheGroupAdmissionDebit(simulated_free, admission);
     return true;
 }
@@ -1367,7 +1412,8 @@ bool HybridPrefixCache::tryPrunePagedCacheSnapshot(AdmissionFailureKind kind) {
     if (!HasPagedCacheAdjunct()) return false;
     if (kind == AdmissionFailureKind::kNone) return false;
 
-    auto is_pinned = [](TreeNode* node) {
+    auto is_pinned = [this](TreeNode* node, std::optional<PagedCacheGroupFamily> borrowed_family = std::nullopt) {
+        if (isPagedCacheSnapshotBorrowed(node, borrowed_family)) return true;
         for (TreeNode* cur = node; cur != nullptr && !cur->IsRoot(); cur = cur->Parent()) {
             if (!cur->OnDevice()) continue;
             if (cur->Device().RefCount() > 0) return true;
@@ -1391,7 +1437,7 @@ bool HybridPrefixCache::tryPrunePagedCacheSnapshot(AdmissionFailureKind kind) {
 
     auto try_state_only = [&]() {
         for (TreeNode* node : candidates) {
-            if (is_pinned(node)) continue;
+            if (is_pinned(node, PagedCacheGroupFamily::State)) continue;
             const auto* snap = node->GetPagedCacheSnapshot();
             if (snap == nullptr) continue;
             if (!snap->IsCompleteFor(PagedCacheGroupFamily::State) && !snap->continuation_state_complete) continue;
@@ -1457,19 +1503,6 @@ bool HybridPrefixCache::AdmitChunk(const std::string& request_id, std::int32_t f
     };
     return admitPagedCacheChunk(request_id, first_raw_position_of_op, target_raw_tokens_exclusive, simulated_free,
                                 paged_cache_hit, context);
-}
-
-bool HybridPrefixCache::AdmitChunkFromRetracted(const std::string& request_id, std::int32_t target_raw_tokens_exclusive,
-                                                std::map<std::string, std::int32_t>& simulated_free,
-                                                const MatchResult::PagedCache& paged_cache_hit) {
-    PagedCacheAdmissionContext context{.fresh_table_view = true};
-    auto req_it = request_paged_cache_tables_.find(request_id);
-    if (req_it != request_paged_cache_tables_.end()) {
-        for (const auto& [gid, table] : req_it->second) {
-            context.owned_release_credit[gid] = table.OwnedPagesCount();
-        }
-    }
-    return admitPagedCacheChunk(request_id, 0, target_raw_tokens_exclusive, simulated_free, paged_cache_hit, context);
 }
 
 void HybridPrefixCache::CommitChunk(const std::string& request_id, TreeNode* terminal) {
@@ -1577,7 +1610,7 @@ void HybridPrefixCache::CommitChunk(const std::string& request_id, TreeNode* ter
             PagedCacheGroupSnapshot group_snap{};
             group_snap.pages = std::move(result.pages);
             group_snap.base_logical_page = result.segment_base_logical_page;
-            group_snap.raw_token_cursor = table.RawTokenCursor();
+            group_snap.raw_token_cursor = target;
             group_snap.sliding = table.IsSliding();
             snapshot->groups.emplace(gid, std::move(group_snap));
         }
@@ -1614,14 +1647,11 @@ void HybridPrefixCache::CommitChunk(const std::string& request_id, TreeNode* ter
     //   (1) the owning request's sliding window has advanced past the ancestor
     //       (node_depth + window <= chunk_depth), so ReleaseSkipped has already
     //       dropped those pages from this request's own borrowed set; and
-    //   (2) no OTHER request references the ancestor. Each request holds exactly
-    //       one DeviceNodeRef that Locks its whole path to root (NodeRef::Lock),
-    //       so Device().RefCount() == 1 means this committing request is the
-    //       sole referencer and no other request can be borrowing the node's
-    //       continuation-state window. When shared (RefCount > 1, e.g. a second
-    //       request whose prefix runs through this node), keep the snapshot so
-    //       the sharer's continuation-state resume stays valid; it is released
-    //       on a later commit once the sharer's ref drops.
+    //   (2) no request table still borrows the ancestor's State pages.
+    //       Device().RefCount() == 1 means this committing request is the sole
+    //       active device referencer, but its own table must still be checked:
+    //       an already-existing terminal snapshot can skip State adoption and
+    //       leave an older borrow alive.
     // Gate on a complete terminal snapshot so a resume anchor always remains.
     if (terminal_state_committed) {
         std::int32_t max_state_window = 0;
@@ -1638,6 +1668,7 @@ void HybridPrefixCache::CommitChunk(const std::string& request_id, TreeNode* ter
                 continue;
             }
             if (!cur->OnDevice() || cur->Device().RefCount() != 1) continue;
+            if (isPagedCacheSnapshotBorrowed(cur, PagedCacheGroupFamily::State)) continue;
             DetachStateSnapshotFromNode(cur);
         }
     }

--- a/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.h
+++ b/tokenspeed-scheduler/csrc/resource/hybrid_prefix_cache/hybrid_prefix_cache.h
@@ -51,6 +51,7 @@ public:
     // `mamba_allocator` may be null; paged-cache adjunct is enabled separately.
     HybridPrefixCache(KVPrefixCache& prefix_cache, MambaChunkAllocator* allocator, std::int32_t mamba_cache_chunk_size,
                       MambaHostAllocator* mamba_host_allocator = nullptr);
+    ~HybridPrefixCache();
 
     MatchResult Match(const token_vec_t& token_ids, MatchIntent intent = MatchIntent::PrefixReuse);
     MatchResult Match(const std::vector<std::span<const std::int32_t>>& token_pages,
@@ -110,8 +111,11 @@ public:
     // Owned pages return to the pool via OwnedPages RAII; borrowed ids are dropped.
     void ReleaseRequest(const std::string& request_id);
 
-    // Reclaim request-local paged-cache tail slots beyond the accepted token length.
-    void RewindRequest(const std::string& request_id, std::int32_t accepted_raw_tokens);
+    // Reclaim request-local paged-cache tail slots beyond the accepted token
+    // length while retaining slots referenced by an already-dispatched
+    // overlapped decode.
+    void RewindRequest(const std::string& request_id, std::int32_t accepted_raw_tokens,
+                       std::int32_t protected_tail_tokens = 0);
 
     // Fill op.paged_cache_pages / op.paged_cache_page_base_offsets from the tables.
     void PopulateOp(ForwardOperationBase& op_base) const;
@@ -129,12 +133,6 @@ public:
                     std::optional<std::int32_t> commit_target_raw_tokens = std::nullopt,
                     std::span<const std::span<const std::int32_t>> commit_token_pages = {});
 
-    // Retract-decode variant: admission uses a fresh-table view and credits
-    // pages owned by the stale table before it is released.
-    bool AdmitChunkFromRetracted(const std::string& request_id, std::int32_t target_raw_tokens_exclusive,
-                                 std::map<std::string, std::int32_t>& simulated_free,
-                                 const MatchResult::PagedCache& paged_cache_hit);
-
     // Commit newly-written full LCM segments into TreeNode PagedCacheSnapshots.
     void CommitChunk(const std::string& request_id, TreeNode* terminal);
 
@@ -151,14 +149,10 @@ public:
     // Callback from KV prefix-cache eviction.
     void OnKVEvict(TreeNode* node);
 
-    // Callback from RadixTree just before a node is destroyed by prune. Drops
-    // the dying node from every adjunct bookkeeping set that holds raw
-    // TreeNode* (mamba_leaves_, paged_cache_snapshot_nodes_) so no dangling
-    // pointer survives the free. Unlike OnKVEvict this must NOT detach the
-    // node's slots — the node (and its owned unique_ptr<MambaSlot> /
-    // PagedCacheSnapshot) is being destroyed, so the destructors free them; we
-    // only un-register the membership. Safe to call on a node that was never
-    // tracked (erase is a no-op).
+    // Callback from RadixTree just before prune destroys a node. Detaches its
+    // adjunct resources while their allocators are alive and removes every raw
+    // TreeNode* bookkeeping entry. A paged snapshot must have no table borrower
+    // at this point; violating that lifetime invariant is an error.
     void OnNodeDestroyed(TreeNode* node);
 
     std::int32_t AvailableSlots() const;
@@ -179,8 +173,6 @@ private:
     };
 
     struct PagedCacheAdmissionContext {
-        bool fresh_table_view{false};
-        std::map<std::string, std::int32_t> owned_release_credit{};
         std::optional<std::int32_t> commit_target_raw_tokens{};
         std::span<const std::span<const std::int32_t>> commit_token_pages{};
     };
@@ -193,6 +185,8 @@ private:
     bool DetachStateSnapshotFromNode(TreeNode* node);
 
     void RefreshPagedCacheSnapshotCompleteness(PagedCacheSnapshot& snapshot) const;
+    bool isPagedCacheSnapshotBorrowed(const TreeNode* node,
+                                      std::optional<PagedCacheGroupFamily> family = std::nullopt) const;
     bool adoptExistingPagedCacheSnapshot(PagedCacheSnapshot& existing,
                                          std::map<std::string, PagedCacheGroupTable>& tables, std::int32_t target);
     bool commitTerminalContinuationSnapshot(std::map<std::string, PagedCacheGroupTable>& tables, TreeNode* terminal,

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -22,6 +22,7 @@
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
@@ -59,6 +60,19 @@ namespace tokenspeed {
 namespace {
 
 constexpr std::int32_t kLocalMambaSlotsPerRequest = 2;
+
+std::int32_t DecodePagedCacheReservationEnd(std::int32_t first_pos, std::int32_t verify_width,
+                                            std::int32_t overlap_depth) {
+    if (first_pos < 0 || verify_width < 0 || overlap_depth < 0 || overlap_depth > 1) {
+        throw std::invalid_argument("invalid paged-cache decode reservation arguments");
+    }
+    const std::int64_t reservation_end =
+        static_cast<std::int64_t>(first_pos) + static_cast<std::int64_t>(overlap_depth + 1) * verify_width;
+    if (reservation_end > std::numeric_limits<std::int32_t>::max()) {
+        throw std::overflow_error("paged-cache decode reservation exceeds int32 range");
+    }
+    return static_cast<std::int32_t>(reservation_end);
+}
 
 std::int32_t CountMambaDeviceLoadBackSlots(const std::vector<TreeNode*>& nodes) {
     std::int32_t slots = 0;
@@ -218,7 +232,8 @@ std::optional<fsm::ScheduleDecodeEvent> Scheduler::scheduleDecode(Request* reque
     }
 
     const std::int32_t first_pos = request->TokenSize();
-    const std::int32_t target = first_pos + config_.decode_input_tokens;
+    const std::int32_t target =
+        DecodePagedCacheReservationEnd(first_pos, config_.decode_input_tokens, config_.overlap_schedule_depth);
     if (hybrid_prefix_cache_) {
         std::optional<std::int32_t> commit_target;
         std::vector<std::span<const std::int32_t>> commit_token_pages;
@@ -294,9 +309,12 @@ std::optional<fsm::ScheduleDecodeFromRetractedEvent> Scheduler::scheduleDecodeFr
         }
     }
 
-    const std::int32_t target = request->TokenSize();
-    if (hybrid_prefix_cache_ && !hybrid_prefix_cache_->AdmitChunkFromRetracted(request->Id(), target, simulated_free,
-                                                                               match_result.paged_cache)) {
+    const std::int32_t first_pos = request->TokenSize() - 1;
+    const std::int32_t target = std::max(
+        request->TokenSize(),
+        DecodePagedCacheReservationEnd(first_pos, config_.decode_input_tokens, config_.overlap_schedule_depth));
+    if (hybrid_prefix_cache_ &&
+        !hybrid_prefix_cache_->AdmitChunk(request->Id(), first_pos, target, simulated_free, match_result.paged_cache)) {
         return {};
     }
     if (needs_mamba_loadback) {
@@ -521,7 +539,9 @@ DecodeOperation Scheduler::applyEventAndGenerateOp(Request* request, fsm::Schedu
         if (came_from_prefill_done) {
             hybrid_prefix_cache_->CommitChunk(op.request_id, const_cast<TreeNode*>(request->GetDeviceNode()));
         }
-        hybrid_prefix_cache_->AcquireForRequest(op.request_id, first_pos, first_pos + op.input_length);
+        const std::int32_t target =
+            DecodePagedCacheReservationEnd(first_pos, op.input_length, config_.overlap_schedule_depth);
+        hybrid_prefix_cache_->AcquireForRequest(op.request_id, first_pos, target);
         hybrid_prefix_cache_->PopulateOp(op);
     }
     return op;
@@ -559,8 +579,13 @@ DecodeOperation Scheduler::applyEventAndGenerateOp(Request* request, fsm::Schedu
     }
 
     if (hybrid_prefix_cache_) {
-        hybrid_prefix_cache_->ReleaseRequest(op.request_id);
-        hybrid_prefix_cache_->AcquireForRequest(op.request_id, 0, request->TokenSize(), paged_cache_hit);
+        const std::int32_t target = std::max(
+            request->TokenSize(),
+            DecodePagedCacheReservationEnd(op.hist_token_len, op.input_length, config_.overlap_schedule_depth));
+        // Preserve the existing table across retraction. Its request-local
+        // tail contains state after the last published prefix checkpoint and
+        // cannot be reconstructed by importing that older snapshot alone.
+        hybrid_prefix_cache_->AcquireForRequest(op.request_id, op.hist_token_len, target, paged_cache_hit);
         hybrid_prefix_cache_->PopulateOp(op);
     }
     return op;

--- a/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
@@ -126,8 +126,10 @@ void Scheduler::handleEvent(const forward::UpdateReserveNumTokens& event) {
 }
 void Scheduler::handleEvent(const forward::ExtendResult& event) {
     if (auto req = find_request(event.request_id)) {
+        const std::int32_t protected_tail_tokens = config_.overlap_schedule_depth * config_.decode_input_tokens;
         req->Apply(fsm::ExtendResultEvent{event.request_id, event.tokens,
-                                          hybrid_prefix_cache_ ? &*hybrid_prefix_cache_ : nullptr});
+                                          hybrid_prefix_cache_ ? &*hybrid_prefix_cache_ : nullptr,
+                                          protected_tail_tokens});
     }
 }
 

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -61,6 +61,15 @@ Scheduler::Scheduler(SchedulerConfig config)
       mamba_allocator_{},
       kv_prefix_cache_{&device_allocator_, &host_allocator_, config_.enable_l3_storage, config_.disable_prefix_cache},
       req_pool_allocator_{config_.max_batch_size} {
+    if (config_.decode_input_tokens < 0) {
+        throw std::invalid_argument("Scheduler: decode_input_tokens must be >= 0");
+    }
+    if (config_.overlap_schedule_depth < 0 || config_.overlap_schedule_depth > 1) {
+        throw std::invalid_argument("Scheduler: overlap_schedule_depth must be 0 or 1");
+    }
+    if (config_.overlap_schedule_depth > 0 && config_.decode_input_tokens == 0) {
+        throw std::invalid_argument("Scheduler: overlapped decode requires decode_input_tokens > 0");
+    }
     if (auto* env = std::getenv("SPDLOG_LEVEL")) {
         std::string level_str{env};
         spdlog::level::level_enum level = spdlog::level::from_str(level_str);

--- a/tokenspeed-scheduler/csrc/scheduler/types.h
+++ b/tokenspeed-scheduler/csrc/scheduler/types.h
@@ -91,6 +91,10 @@ struct SchedulerConfig {
     std::int32_t max_scheduled_tokens{};
     std::int32_t max_batch_size{};
     std::int32_t decode_input_tokens{1};
+    // Number of scheduler iterations that may be dispatched before the
+    // accepted decode length is committed. The current event loop supports
+    // only the non-overlapped (0) and one-step-overlapped (1) contracts.
+    std::int32_t overlap_schedule_depth{0};
     bool disable_l2_cache{false};
     bool enable_l3_storage{false};
     std::int32_t prefetch_threshold{4};  // num pages

--- a/tokenspeed-scheduler/python/tests/test_paged_cache_group_admission.py
+++ b/tokenspeed-scheduler/python/tests/test_paged_cache_group_admission.py
@@ -1,3 +1,4 @@
+import pytest
 from tokenspeed_scheduler import (
     ExecutionEvent,
     ForwardEvent,
@@ -63,6 +64,66 @@ def _request_ids_in_plan(plan) -> set[str]:
     for op in plan.forward:
         out.update(op.request_ids)
     return out
+
+
+def _overlap_admission_scheduler(
+    verify_width: int, *, exact_capacity: bool
+) -> Scheduler:
+    committed_tokens = 3
+    reservation_end = committed_tokens + 2 * verify_width
+    cfg = _base_config(num_device_pages=256)
+    cfg.decode_input_tokens = verify_width
+    cfg.overlap_schedule_depth = 1
+    # Paged-cache group page 0 is reserved by the allocator.
+    cfg.paged_cache_groups = [
+        PagedCacheGroupConfig(
+            group_id="overlap.history",
+            rows_per_page=1,
+            entry_stride_tokens=1,
+            total_pages=reservation_end + (1 if exact_capacity else 0),
+            retention=PagedCacheRetention.FullHistory,
+            family=PagedCacheGroupFamily.History,
+        )
+    ]
+    scheduler = Scheduler(cfg)
+    scheduler.submit_requests([_make_spec("r", [1, 2])])
+    assert _request_ids_in_plan(scheduler.next_execution_plan()) == {"r"}
+    _advance_tokens(scheduler, "r", [3])
+    return scheduler
+
+
+@pytest.mark.parametrize("verify_width", [1, 2, 4, 8])
+def test_overlap_decode_admission_uses_runtime_verify_width(verify_width: int):
+    scheduler = _overlap_admission_scheduler(verify_width, exact_capacity=True)
+    assert _request_ids_in_plan(scheduler.next_execution_plan()) == {"r"}
+    assert scheduler.paged_cache_group_available_pages("overlap.history") == 0
+    assert scheduler.paged_cache_group_failed_alloc_count("overlap.history") == 0
+
+
+@pytest.mark.parametrize("verify_width", [1, 2, 4, 8])
+def test_overlap_decode_admission_rejects_one_page_short(verify_width: int):
+    scheduler = _overlap_admission_scheduler(verify_width, exact_capacity=False)
+    assert _request_ids_in_plan(scheduler.next_execution_plan()) == set()
+    assert scheduler.paged_cache_group_failed_alloc_count("overlap.history") == 0
+
+
+def test_overlap_schedule_depth_defaults_to_zero_and_rejects_deeper_pipeline():
+    assert SchedulerConfig().overlap_schedule_depth == 0
+    cfg = _base_config()
+    for invalid_depth in (-1, 2):
+        cfg.overlap_schedule_depth = invalid_depth
+        with pytest.raises(ValueError, match="overlap_schedule_depth"):
+            Scheduler(cfg)
+
+    cfg.overlap_schedule_depth = 1
+    cfg.decode_input_tokens = 0
+    with pytest.raises(ValueError, match="decode_input_tokens"):
+        Scheduler(cfg)
+
+    cfg.overlap_schedule_depth = 0
+    cfg.decode_input_tokens = -1
+    with pytest.raises(ValueError, match="decode_input_tokens"):
+        Scheduler(cfg)
 
 
 def test_full_history_admission_denies_instead_of_throwing():

--- a/tokenspeed-scheduler/tests/cpp/test_paged_cache_eviction.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_paged_cache_eviction.cpp
@@ -74,4 +74,59 @@ TEST_F(PagedCacheEvictionTest, PassiveEvictionReleasesPagedCachePages) {
     EXPECT_EQ(swa_alloc_->AvailablePages(), swa_before);
 }
 
+TEST_F(PagedCacheEvictionTest, BorrowedSnapshotSurvivesDeviceEviction) {
+    InsertDevicePages(/*num_pages=*/2, /*token_start=*/1);                   // branch A
+    auto* leaf_b = InsertDevicePages(/*num_pages=*/2, /*token_start=*/100);  // branch B
+    ASSERT_NE(leaf_b, nullptr);
+
+    TreeNode* attach_a = kv_cache_->GetRadixTree().SplitAt(
+        kv_cache_->Match(MakeAlignedTokens(2, kPageSize, /*start=*/1)).device.last_node, kLcm);
+    ASSERT_NE(attach_a, nullptr);
+
+    PageAllocator host_alloc{kPageSize, /*total_pages=*/8};
+    const auto host_pages = static_cast<std::int32_t>(attach_a->Tokens().size()) / kPageSize;
+    attach_a->AttachResource(std::make_unique<NodeResource<ResourceType::Host>>(host_alloc.Allocate(host_pages)));
+    auto host_ref = std::make_unique<HostNodeRef>(attach_a);
+
+    const std::int32_t fh_before = fh_alloc_->AvailablePages();
+    const std::int32_t swa_before = swa_alloc_->AvailablePages();
+    hybrid_->AttachPagedCacheSnapshotToNode(attach_a, MakeCompleteSnapshot(kLcm));
+    const std::int32_t fh_pinned = fh_alloc_->AvailablePages();
+    const std::int32_t swa_pinned = swa_alloc_->AvailablePages();
+    ASSERT_LT(fh_pinned, fh_before);
+    ASSERT_LT(swa_pinned, swa_before);
+
+    auto match_a = hybrid_->Match(MakeAlignedTokens(2, kPageSize, /*start=*/1));
+    ASSERT_EQ(match_a.paged_cache.prefix_len_tokens, kLcm);
+    hybrid_->AcquireForRequest("retracted", /*first_raw_position_of_op=*/0,
+                               /*target_raw_tokens_exclusive=*/kLcm, match_a.paged_cache);
+
+    auto match_b = kv_cache_->Match(MakeAlignedTokens(2, kPageSize, /*start=*/100));
+    DeviceNodeRef ref_b{match_b.device.last_node};
+    const std::int32_t target_available = device_alloc_->AvailablePages() + 1;
+    ASSERT_TRUE(kv_cache_->EnsureCapacityByEvict<ResourceType::Device>(target_available));
+
+    // Device eviction must not free side-cache pages still borrowed by a
+    // retracted/loadback request's retained table.
+    EXPECT_FALSE(attach_a->OnDevice());
+    EXPECT_TRUE(attach_a->HasPagedCacheSnapshot());
+    EXPECT_EQ(fh_alloc_->AvailablePages(), fh_pinned);
+    EXPECT_EQ(swa_alloc_->AvailablePages(), swa_pinned);
+    EXPECT_THROW(hybrid_->OnNodeDestroyed(attach_a), std::runtime_error);
+    EXPECT_TRUE(attach_a->HasPagedCacheSnapshot());
+
+    // Once the request table drops the borrow, the normal eviction callback
+    // can reclaim the snapshot and return its pages.
+    hybrid_->ReleaseRequest("retracted");
+    hybrid_->OnKVEvict(attach_a);
+    EXPECT_FALSE(attach_a->HasPagedCacheSnapshot());
+    EXPECT_EQ(fh_alloc_->AvailablePages(), fh_before);
+    EXPECT_EQ(swa_alloc_->AvailablePages(), swa_before);
+
+    // Destroy the manually attached host resource before its local allocator.
+    host_ref.reset();
+    auto host_resource = attach_a->DetachResource<ResourceType::Host>();
+    ASSERT_NE(host_resource, nullptr);
+}
+
 }  // namespace tokenspeed::test

--- a/tokenspeed-scheduler/tests/cpp/test_paged_cache_replay.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_paged_cache_replay.cpp
@@ -16,11 +16,14 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <variant>
 #include <vector>
@@ -124,6 +127,116 @@ protected:
     }
 };
 
+class PagedCacheOverlapSchedulerTest
+    : public SchedulerTestSuite,
+      public ::testing::WithParamInterface<std::tuple<std::int32_t, std::int32_t, std::int32_t>> {
+protected:
+    SchedulerConfig MakeConfig() override {
+        auto cfg = SchedulerTestSuite::MakeConfig();
+        cfg.page_size = 64;
+        cfg.device_allocator.total_pages = 256;
+        cfg.host_allocator.total_pages = 256;
+        cfg.max_scheduled_tokens = 256;
+        cfg.max_batch_size = 4;
+        cfg.decode_input_tokens = std::get<0>(GetParam());
+        cfg.overlap_schedule_depth = std::get<2>(GetParam());
+        cfg.disable_l2_cache = true;
+
+        PagedCacheGroupConfig history{};
+        history.group_id = "overlap.history";
+        history.rows_per_page = 1;
+        history.entry_stride_tokens = 1;
+        history.total_pages = 256;
+        history.retention = PagedCacheGroupConfig::Retention::FullHistory;
+        history.family = PagedCacheGroupFamily::History;
+        cfg.paged_cache_groups.push_back(history);
+
+        PagedCacheGroupConfig state{};
+        state.group_id = "overlap.state";
+        state.rows_per_page = 1;
+        state.entry_stride_tokens = 1;
+        state.total_pages = 64;
+        state.retention = PagedCacheGroupConfig::Retention::SlidingWindow;
+        state.sliding_window_tokens = 8;
+        state.family = PagedCacheGroupFamily::State;
+        cfg.paged_cache_groups.push_back(state);
+        return cfg;
+    }
+
+    static const FlatForwardOperation* GetForwardOp(const ExecutionPlan& plan) {
+        for (const auto& op : plan.Operations()) {
+            if (auto* f = std::get_if<FlatForwardOperation>(&op)) return f;
+        }
+        return nullptr;
+    }
+};
+
+class PagedCacheOverlapRetractTest
+    : public SchedulerTestSuite,
+      public ::testing::WithParamInterface<std::tuple<std::int32_t, std::int32_t, bool>> {
+protected:
+    SchedulerConfig MakeConfig() override {
+        auto cfg = SchedulerTestSuite::MakeConfig();
+        cfg.page_size = 2;
+        cfg.device_allocator.total_pages = 10;
+        cfg.host_allocator.total_pages = 64;
+        cfg.max_scheduled_tokens = 64;
+        cfg.max_batch_size = 4;
+        cfg.decode_input_tokens = 4;
+        cfg.overlap_schedule_depth = std::get<0>(GetParam());
+        cfg.enable_l3_storage = false;
+
+        PagedCacheGroupConfig history{};
+        history.group_id = "retract.history";
+        history.rows_per_page = 2;
+        history.entry_stride_tokens = 1;
+        history.total_pages = 128;
+        history.retention = PagedCacheGroupConfig::Retention::FullHistory;
+        history.family = PagedCacheGroupFamily::History;
+        cfg.paged_cache_groups.push_back(history);
+
+        PagedCacheGroupConfig state{};
+        state.group_id = "retract.state";
+        state.rows_per_page = 1;
+        state.entry_stride_tokens = 1;
+        state.total_pages = 64;
+        state.retention = PagedCacheGroupConfig::Retention::SlidingWindow;
+        state.sliding_window_tokens = 8;
+        state.family = PagedCacheGroupFamily::State;
+        cfg.paged_cache_groups.push_back(state);
+
+        PrefixCacheAdjunctSpec adjunct{};
+        adjunct.required_groups = {"retract.history"};
+        cfg.prefix_cache_adjunct = adjunct;
+        return cfg;
+    }
+
+    void SendReserveNumTokens(std::int32_t value) {
+        ExecutionEvent event;
+        event.With(ForwardEvent{forward::UpdateReserveNumTokens{
+            .request_id = "r",
+            .reserve_num_tokens_in_next_schedule_event = value,
+        }});
+        scheduler_->Advance(std::move(event));
+    }
+
+    static const FlatForwardOperation* GetForwardOp(const ExecutionPlan& plan) {
+        for (const auto& op : plan.Operations()) {
+            if (auto* f = std::get_if<FlatForwardOperation>(&op)) return f;
+        }
+        return nullptr;
+    }
+
+    static const FlatWriteBackOperation* GetWriteBack(const ExecutionPlan& plan) {
+        for (const auto& op : plan.Operations()) {
+            if (auto* cache_op = std::get_if<CacheOperation>(&op)) {
+                if (auto* writeback = std::get_if<FlatWriteBackOperation>(cache_op)) return writeback;
+            }
+        }
+        return nullptr;
+    }
+};
+
 class PagedCacheTerminalContinuationTest : public ::testing::Test {
 protected:
     static constexpr std::int32_t kPageSize = 64;
@@ -147,9 +260,11 @@ protected:
             kRequiredStateGroup, kRequiredStateRows, /*stride=*/1, PagedCacheGroupConfig::Retention::SlidingWindow,
             kRequiredStateWindow, PagedCacheGroupFamily::State,
             /*total_pages=*/128));
+        // Page 0 is reserved; the longest borrower/HostRef chain holds eight
+        // transport-only window pages concurrently.
         auto window_owner = std::make_unique<PagedCacheGroupAllocator>(MakeGroup(
             kWindowStateGroup, /*rows_per_page=*/64, /*stride=*/1, PagedCacheGroupConfig::Retention::SlidingWindow,
-            kWindowStateTokens, PagedCacheGroupFamily::State, /*total_pages=*/6));
+            kWindowStateTokens, PagedCacheGroupFamily::State, /*total_pages=*/9));
 
         hybrid_ = std::make_unique<HybridPrefixCache>(*kv_cache_, /*mamba=*/nullptr,
                                                       /*mamba_chunk_size=*/0);
@@ -277,6 +392,144 @@ TEST_F(PagedCacheTerminalContinuationTest, ExactTerminalHitUsesContinuationState
     EXPECT_EQ(second_match.paged_cache.per_group_page_ids.at(kRequiredStateGroup).size(), 2u);
 }
 
+TEST_F(PagedCacheTerminalContinuationTest, SnapshotCursorStopsAtCheckpointBeforeReservedTail) {
+    constexpr std::int32_t kCheckpoint = 256;
+    constexpr std::int32_t kVerifyWidth = 4;
+    TreeNode* terminal = InsertDeviceTokens(kCheckpoint);
+    ASSERT_NE(terminal, nullptr);
+
+    hybrid_->AcquireForRequest("r", /*first_raw_position_of_op=*/0,
+                               /*target_raw_tokens_exclusive=*/kCheckpoint + 2 * kVerifyWidth);
+    hybrid_->CommitChunk("r", terminal);
+
+    ASSERT_TRUE(terminal->HasPagedCacheSnapshot());
+    const auto* snapshot = terminal->GetPagedCacheSnapshot();
+    ASSERT_NE(snapshot, nullptr);
+    EXPECT_EQ(snapshot->prefix_len_tokens, kCheckpoint);
+    ASSERT_TRUE(snapshot->continuation_state_complete);
+    for (const auto& [group_id, group] : snapshot->groups) {
+        EXPECT_EQ(group.raw_token_cursor, kCheckpoint) << "group=" << group_id;
+    }
+
+    // The request still owns the physical lookahead page, but the snapshot
+    // advertises only the accepted checkpoint.
+    EXPECT_EQ(hybrid_->GetRequestPagedCachePageIds("r", kHistoryGroup).size(), 5u);
+}
+
+TEST_F(PagedCacheTerminalContinuationTest, RewindRejectsInvalidProtectedTail) {
+    EXPECT_THROW(hybrid_->RewindRequest("missing", /*accepted_raw_tokens=*/0,
+                                        /*protected_tail_tokens=*/-1),
+                 std::invalid_argument);
+    EXPECT_THROW(hybrid_->RewindRequest("missing", std::numeric_limits<std::int32_t>::max(),
+                                        /*protected_tail_tokens=*/1),
+                 std::overflow_error);
+}
+
+TEST_F(PagedCacheTerminalContinuationTest, TableBorrowPinsStateButHostRefDoesNot) {
+    TreeNode* n256 = InsertDeviceTokens(256);
+    ASSERT_NE(n256, nullptr);
+    CommitRequest("seed", /*first_token=*/0, /*target=*/256, n256);
+    hybrid_->ReleaseRequest("seed");
+    auto hit256 = MatchTokens(256);
+    ASSERT_EQ(hit256.paged_cache.prefix_len_tokens, 256);
+
+    // A retracted request can keep borrowing n256 after its DeviceNodeRef is
+    // gone. That table, not a coarse host-ref count, must pin the State pages.
+    hybrid_->AcquireForRequest("borrower", /*first_raw_position_of_op=*/0,
+                               /*target_raw_tokens_exclusive=*/256, hit256.paged_cache);
+
+    TreeNode* n512 = InsertDeviceTokens(512);
+    ASSERT_NE(n512, nullptr);
+    {
+        DeviceNodeRef writer_ref{n512};
+        CommitRequest("writer", /*first_token=*/256, /*target=*/512, n512, hit256.paged_cache);
+    }
+    ASSERT_TRUE(n256->HasPagedCacheSnapshot());
+    EXPECT_TRUE(n256->GetPagedCacheSnapshot()->continuation_state_complete);
+
+    hybrid_->ReleaseRequest("borrower");
+
+    // Model the writer's own recovery HostNodeRef. The former HostRef-based
+    // heuristic treated this as another sharer and leaked old State snapshots.
+    PageAllocator host_alloc{kPageSize, /*total_pages=*/64};
+    std::vector<TreeNode*> attached_host_nodes;
+    for (TreeNode* cur = n256; cur != nullptr && !cur->IsRoot(); cur = cur->Parent()) {
+        if (cur->OnHost()) continue;
+        const auto host_pages = static_cast<std::int32_t>(cur->Tokens().size()) / kPageSize;
+        cur->AttachResource(std::make_unique<NodeResource<ResourceType::Host>>(host_alloc.Allocate(host_pages)));
+        attached_host_nodes.push_back(cur);
+    }
+    auto writer_host_ref = std::make_unique<HostNodeRef>(n256);
+
+    TreeNode* n768 = InsertDeviceTokens(768);
+    ASSERT_NE(n768, nullptr);
+    {
+        DeviceNodeRef writer_ref{n768};
+        CommitRequest("writer", /*first_token=*/512, /*target=*/768, n768);
+    }
+
+    ASSERT_TRUE(n256->HasPagedCacheSnapshot());
+    EXPECT_FALSE(n256->GetPagedCacheSnapshot()->continuation_state_complete);
+    EXPECT_EQ(n256->GetPagedCacheSnapshot()->groups.find(kRequiredStateGroup),
+              n256->GetPagedCacheSnapshot()->groups.end());
+    EXPECT_EQ(n256->GetPagedCacheSnapshot()->groups.find(kWindowStateGroup),
+              n256->GetPagedCacheSnapshot()->groups.end());
+
+    hybrid_->ReleaseRequest("writer");
+    writer_host_ref.reset();
+    for (TreeNode* node : attached_host_nodes) {
+        auto host_resource = node->DetachResource<ResourceType::Host>();
+        ASSERT_NE(host_resource, nullptr);
+    }
+}
+
+TEST_F(PagedCacheTerminalContinuationTest, CurrentBorrowPinsAncestorWhenTerminalSnapshotAlreadyExists) {
+    TreeNode* n64 = InsertDeviceTokens(64);
+    ASSERT_NE(n64, nullptr);
+    CommitRequest("seed", /*first_token=*/0, /*target=*/64, n64);
+    hybrid_->ReleaseRequest("seed");
+
+    auto hit64 = MatchTokens(64);
+    ASSERT_EQ(hit64.paged_cache.prefix_len_tokens, 64);
+
+    // Keep n64's transport-only State page borrowed by the request that will
+    // later adopt an already-existing terminal snapshot at n192.
+    hybrid_->AcquireForRequest("current", /*first_raw_position_of_op=*/64,
+                               /*target_raw_tokens_exclusive=*/192, hit64.paged_cache);
+
+    TreeNode* n192 = InsertDeviceTokens(192);
+    ASSERT_NE(n192, nullptr);
+    {
+        DeviceNodeRef writer_ref{n192};
+        CommitRequest("writer", /*first_token=*/64, /*target=*/192, n192, hit64.paged_cache);
+    }
+    hybrid_->ReleaseRequest("writer");
+
+    ASSERT_TRUE(n64->HasPagedCacheSnapshot());
+    ASSERT_TRUE(n192->HasPagedCacheSnapshot());
+    ASSERT_TRUE(n192->GetPagedCacheSnapshot()->continuation_state_complete);
+    const auto& ancestor_state_pages = n64->GetPagedCacheSnapshot()->groups.at(kWindowStateGroup).pages.Ids();
+    const auto& current_state_pages = hybrid_->GetRequestPagedCachePageIds("current", kWindowStateGroup);
+    ASSERT_TRUE(std::any_of(ancestor_state_pages.begin(), ancestor_state_pages.end(), [&](std::int32_t page_id) {
+        return std::find(current_state_pages.begin(), current_state_pages.end(), page_id) != current_state_pages.end();
+    }));
+
+    // Required groups adopt n192's existing snapshot, while the
+    // transport-only group is already present and therefore is not adopted.
+    // The current request still borrows n64, so ancestor cleanup must retain
+    // that State snapshot.
+    {
+        DeviceNodeRef current_ref{n192};
+        hybrid_->CommitChunk("current", n192);
+    }
+
+    ASSERT_TRUE(n64->HasPagedCacheSnapshot());
+    EXPECT_TRUE(n64->GetPagedCacheSnapshot()->continuation_state_complete);
+    EXPECT_NE(n64->GetPagedCacheSnapshot()->groups.find(kWindowStateGroup), n64->GetPagedCacheSnapshot()->groups.end());
+
+    hybrid_->ReleaseRequest("current");
+}
+
 TEST_F(PagedCacheTerminalContinuationTest, StatePruneDropsContinuationAndFallsBackToColdPrefill) {
     TreeNode* n256 = InsertDeviceTokens(256);
     ASSERT_NE(n256, nullptr);
@@ -299,6 +552,48 @@ TEST_F(PagedCacheTerminalContinuationTest, StatePruneDropsContinuationAndFallsBa
     EXPECT_EQ(match.paged_cache.history_hit_tokens, 0);
     EXPECT_EQ(match.paged_cache.prefix_len_tokens, 0);
     EXPECT_TRUE(match.paged_cache.per_group_page_ids.empty());
+}
+
+TEST_F(PagedCacheTerminalContinuationTest, StateOnlyPruneIgnoresHistoryOnlySideTableBorrow) {
+    TreeNode* n64 = InsertDeviceTokens(64);
+    ASSERT_NE(n64, nullptr);
+    CommitRequest("seed", /*first_token=*/0, /*target=*/64, n64);
+    hybrid_->ReleaseRequest("seed");
+
+    auto hit = MatchTokens(64);
+    ASSERT_EQ(hit.paged_cache.prefix_len_tokens, 64);
+    hybrid_->AcquireForRequest("borrower", /*first_raw_position_of_op=*/192,
+                               /*target_raw_tokens_exclusive=*/192, hit.paged_cache);
+
+    auto shares_snapshot_pages = [&](const std::string& group_id) {
+        const auto& snapshot_pages = n64->GetPagedCacheSnapshot()->groups.at(group_id).pages.Ids();
+        const auto& request_pages = hybrid_->GetRequestPagedCachePageIds("borrower", group_id);
+        return std::any_of(snapshot_pages.begin(), snapshot_pages.end(), [&](std::int32_t page_id) {
+            return std::find(request_pages.begin(), request_pages.end(), page_id) != request_pages.end();
+        });
+    };
+
+    ASSERT_TRUE(n64->HasPagedCacheSnapshot());
+    EXPECT_TRUE(shares_snapshot_pages(kHistoryGroup));
+    EXPECT_FALSE(shares_snapshot_pages(kRequiredStateGroup));
+    EXPECT_FALSE(shares_snapshot_pages(kWindowStateGroup));
+    const auto history_pages_before = hybrid_->GetRequestPagedCachePageIds("borrower", kHistoryGroup);
+
+    auto simulated_free = hybrid_->InitialSimulatedFree();
+    simulated_free[kWindowStateGroup] = 0;
+    ASSERT_TRUE(hybrid_->AdmitChunk("pressure", /*first_raw_position_of_op=*/0,
+                                    /*target_raw_tokens_exclusive=*/64, simulated_free));
+
+    ASSERT_TRUE(n64->HasPagedCacheSnapshot());
+    const auto* snapshot = n64->GetPagedCacheSnapshot();
+    ASSERT_NE(snapshot, nullptr);
+    EXPECT_NE(snapshot->groups.find(kHistoryGroup), snapshot->groups.end());
+    EXPECT_EQ(snapshot->groups.find(kRequiredStateGroup), snapshot->groups.end());
+    EXPECT_EQ(snapshot->groups.find(kWindowStateGroup), snapshot->groups.end());
+    EXPECT_FALSE(snapshot->continuation_state_complete);
+    EXPECT_EQ(hybrid_->GetRequestPagedCachePageIds("borrower", kHistoryGroup), history_pages_before);
+
+    hybrid_->ReleaseRequest("borrower");
 }
 
 TEST(PagedCacheHistoryOnlyTest, HistoryOnlyPrefixHitRemainsUsable) {
@@ -445,6 +740,152 @@ TEST_F(PagedCacheDecodePublishTest, ContinuingDecodePublishesAcceptedPagesOnly) 
     EXPECT_EQ(prefix_by_request.at("hit4"), 4);
     EXPECT_EQ(prefix_by_request.at("probe_tail"), 4);
 }
+
+TEST_P(PagedCacheOverlapSchedulerTest, DynamicVerifyWidthRetainsAlreadyDispatchedRange) {
+    const auto [verify_width, accepted_length, overlap_depth] = GetParam();
+    Submit(RequestSpec{.request_id = "r", .tokens = {1, 2}});
+    ASSERT_NE(GetForwardOp(PlanOnce()), nullptr);
+
+    // Commit the prefill result so the request can enter decode at C=3.
+    SendForwardDone("r", {3});
+    const std::int32_t committed_before = scheduler_->GetRequestTokenSize("r");
+    ASSERT_EQ(committed_before, 3);
+
+    auto current_plan = PlanOnce();
+    auto* current = GetForwardOp(current_plan);
+    ASSERT_NE(current, nullptr);
+    ASSERT_EQ(current->request_ids.size(), 1u);
+    EXPECT_EQ(current->input_lengths.at(0), verify_width);
+    ExpectPagedGroupCoversRange(*current, Config(), "overlap.history", /*row=*/0, committed_before,
+                                /*token_count=*/(overlap_depth + 1) * verify_width);
+    ExpectPagedGroupCoversRange(*current, Config(), "overlap.state", /*row=*/0, committed_before,
+                                /*token_count=*/(overlap_depth + 1) * verify_width);
+
+    // The overlapped event loop dispatches the next plan before committing
+    // this result. Its CPU token length is still C, while the GPU will use the
+    // accepted length A after valid_cache_lengths is updated.
+    if (overlap_depth == 1) {
+        auto stale_plan = PlanOnce();
+        auto* stale = GetForwardOp(stale_plan);
+        ASSERT_NE(stale, nullptr);
+        ExpectPagedGroupCoversRange(*stale, Config(), "overlap.history", /*row=*/0, committed_before,
+                                    /*token_count=*/2 * verify_width);
+    }
+
+    const auto history_pages_before = scheduler_->GetRequestPagedCachePageIds("r", "overlap.history");
+    const auto state_pages_before = scheduler_->GetRequestPagedCachePageIds("r", "overlap.state");
+    const auto reserved_end = committed_before + (overlap_depth + 1) * verify_width;
+    ASSERT_EQ(history_pages_before.size(), static_cast<std::size_t>(reserved_end));
+    ASSERT_EQ(state_pages_before.size(), static_cast<std::size_t>(reserved_end));
+
+    std::vector<std::int32_t> accepted(static_cast<std::size_t>(accepted_length), 1000 + accepted_length);
+    SendForwardDone("r", accepted);
+    const std::int32_t accepted_end = committed_before + accepted_length;
+    ASSERT_EQ(scheduler_->GetRequestTokenSize("r"), accepted_end);
+
+    const auto history_pages_after = scheduler_->GetRequestPagedCachePageIds("r", "overlap.history");
+    const auto state_pages_after = scheduler_->GetRequestPagedCachePageIds("r", "overlap.state");
+    const auto protected_end = accepted_end + overlap_depth * verify_width;
+    ASSERT_EQ(history_pages_after.size(), static_cast<std::size_t>(protected_end));
+    ASSERT_EQ(state_pages_after.size(), static_cast<std::size_t>(protected_end));
+    for (std::int32_t pos = accepted_end; pos < accepted_end + overlap_depth * verify_width; ++pos) {
+        ASSERT_LT(static_cast<std::size_t>(pos), history_pages_before.size());
+        ASSERT_LT(static_cast<std::size_t>(pos), history_pages_after.size());
+        EXPECT_EQ(history_pages_after[static_cast<std::size_t>(pos)],
+                  history_pages_before[static_cast<std::size_t>(pos)])
+            << "history pos=" << pos;
+        ASSERT_LT(static_cast<std::size_t>(pos), state_pages_before.size());
+        ASSERT_LT(static_cast<std::size_t>(pos), state_pages_after.size());
+        EXPECT_EQ(state_pages_after[static_cast<std::size_t>(pos)], state_pages_before[static_cast<std::size_t>(pos)])
+            << "pos=" << pos;
+    }
+
+    auto next_plan = PlanOnce();
+    auto* next = GetForwardOp(next_plan);
+    ASSERT_NE(next, nullptr);
+    ExpectPagedGroupCoversRange(*next, Config(), "overlap.history", /*row=*/0, accepted_end,
+                                /*token_count=*/(overlap_depth + 1) * verify_width);
+    ExpectPagedGroupCoversRange(*next, Config(), "overlap.state", /*row=*/0, accepted_end,
+                                /*token_count=*/(overlap_depth + 1) * verify_width);
+}
+
+TEST_P(PagedCacheOverlapRetractTest, LateResultRecoveryRebuildsDynamicHorizon) {
+    const auto [overlap_depth, accepted_length, writeback_first] = GetParam();
+    Submit(RequestSpec{.request_id = "r", .tokens = {1, 2}});
+    ASSERT_NE(GetForwardOp(PlanOnce()), nullptr);
+    SendForwardDone("r", {3});
+
+    // Dispatch a decode at C=3, then let the next scheduler pass retract it
+    // before this in-flight result is committed.
+    ASSERT_NE(GetForwardOp(PlanOnce()), nullptr);
+    const auto history_pages_before = scheduler_->GetRequestPagedCachePageIds("r", "retract.history");
+    const auto state_pages_before = scheduler_->GetRequestPagedCachePageIds("r", "retract.state");
+    SendReserveNumTokens(/*value=*/100);
+    auto retract_plan = PlanOnce();
+    const auto* writeback = GetWriteBack(retract_plan);
+    ASSERT_NE(writeback, nullptr);
+    ASSERT_FALSE(writeback->op_ids.empty());
+    if (writeback_first) {
+        SendWriteBackDone(writeback->op_ids.front());
+        ASSERT_EQ(scheduler_->RetractedSize(), 1u);
+    }
+
+    std::vector<std::int32_t> accepted;
+    for (std::int32_t i = 0; i < accepted_length; ++i) {
+        accepted.push_back(4 + i);
+    }
+    SendForwardDone("r", accepted);
+    ASSERT_EQ(scheduler_->GetRequestTokenSize("r"), 3 + accepted_length);
+    const auto retained_end = 3 + accepted_length + overlap_depth * 4;
+    const auto history_pages_after_late_result = scheduler_->GetRequestPagedCachePageIds("r", "retract.history");
+    const auto state_pages_after_late_result = scheduler_->GetRequestPagedCachePageIds("r", "retract.state");
+    ASSERT_EQ(history_pages_after_late_result.size(), static_cast<std::size_t>((retained_end + 1) / 2));
+    ASSERT_EQ(state_pages_after_late_result.size(), static_cast<std::size_t>(retained_end));
+    EXPECT_TRUE(std::equal(history_pages_after_late_result.begin(), history_pages_after_late_result.end(),
+                           history_pages_before.begin()));
+    EXPECT_TRUE(std::equal(state_pages_after_late_result.begin(), state_pages_after_late_result.end(),
+                           state_pages_before.begin()));
+    if (!writeback_first) {
+        SendWriteBackDone(writeback->op_ids.front());
+    }
+    ASSERT_EQ(scheduler_->RetractedSize(), 1u);
+
+    auto recovery_plan = PlanOnce();
+    const auto* recovery = GetForwardOp(recovery_plan);
+    ASSERT_NE(recovery, nullptr);
+    ASSERT_EQ(recovery->request_ids.size(), 1u);
+    ASSERT_EQ(recovery->request_ids.front(), "r");
+    ASSERT_EQ(recovery->hist_token_lens.size(), 1u);
+    EXPECT_EQ(recovery->hist_token_lens.front(), 2 + accepted_length);
+    EXPECT_EQ(recovery->input_lengths.front(), 4);
+    ExpectPagedGroupCoversRange(*recovery, Config(), "retract.history", /*row=*/0,
+                                /*first_token=*/2 + accepted_length, /*token_count=*/(overlap_depth + 1) * 4);
+    ExpectPagedGroupCoversRange(*recovery, Config(), "retract.state", /*row=*/0,
+                                /*first_token=*/2 + accepted_length, /*token_count=*/(overlap_depth + 1) * 4);
+    const auto history_pages_after = scheduler_->GetRequestPagedCachePageIds("r", "retract.history");
+    const auto state_pages_after = scheduler_->GetRequestPagedCachePageIds("r", "retract.state");
+    ASSERT_GE(history_pages_after.size(), history_pages_after_late_result.size());
+    ASSERT_GE(state_pages_after.size(), state_pages_after_late_result.size());
+    EXPECT_TRUE(std::equal(history_pages_after_late_result.begin(), history_pages_after_late_result.end(),
+                           history_pages_after.begin()));
+    EXPECT_TRUE(std::equal(state_pages_after_late_result.begin(), state_pages_after_late_result.end(),
+                           state_pages_after.begin()));
+    EXPECT_EQ(scheduler_->DecodingSize(), 1u);
+    EXPECT_EQ(scheduler_->RetractedSize(), 0u);
+}
+
+INSTANTIATE_TEST_SUITE_P(OverlapDepthsAndAcceptLengths, PagedCacheOverlapRetractTest,
+                         ::testing::Values(std::make_tuple(0, 0, false), std::make_tuple(0, 2, false),
+                                           std::make_tuple(0, 4, false), std::make_tuple(1, 0, false),
+                                           std::make_tuple(1, 2, false), std::make_tuple(1, 4, false),
+                                           std::make_tuple(1, 0, true)));
+
+INSTANTIATE_TEST_SUITE_P(VerifyWidthsAndAcceptLengths, PagedCacheOverlapSchedulerTest,
+                         ::testing::Values(std::make_tuple(1, 1, 0), std::make_tuple(2, 1, 0), std::make_tuple(4, 1, 0),
+                                           std::make_tuple(8, 1, 0), std::make_tuple(1, 1, 1), std::make_tuple(2, 1, 1),
+                                           std::make_tuple(2, 2, 1), std::make_tuple(4, 0, 1), std::make_tuple(4, 2, 1),
+                                           std::make_tuple(4, 4, 1), std::make_tuple(8, 0, 1), std::make_tuple(8, 4, 1),
+                                           std::make_tuple(8, 7, 1), std::make_tuple(8, 8, 1)));
 
 TEST_F(PagedCacheTerminalMixedSchedulerTest, MixedPrefillDecodePagedTablesCoverScheduledTokens) {
     std::vector<std::string> decode_ids;


### PR DESCRIPTION
## Summary

- Enable the existing overlap scheduler for DeepSeek V4's speculative paged-cache groups.
- Propagate the runtime verify width and one-step overlap depth through scheduler admission, page-table reservations, retraction recovery, CUDA Graph sizing, and V4 attention metadata.
- Keep the already-dispatched speculative tail protected while publishing snapshots only at the accepted token boundary.
- Fix mixed prefill/decode MTP metadata so target and draft step 0 use the runtime verify width.

## Reservation contract

Let `W = decode_input_tokens` and `D = overlap_schedule_depth` (`D` is currently restricted to 0 or 1). A request whose committed token length is `C` reserves through `C + (D + 1) * W`. When a result accepts through `A`, the table rewinds only to `A + D * W`, preserving the next forward that is already in flight. Prefix-cache snapshots still publish only the real accepted/checkpoint boundary, not the reservation horizon.

## Validation

- `pre-commit run --all-files`: passed
- Targeted runtime/scheduler Python tests: 141 passed, 1 skipped, plus 145 subtests
- Scheduler ASAN/LSAN suite: 216 passed (1 disabled)
- DeepSeek V4-Flash deterministic GSM8K, 5-shot/50 questions, concurrency 1, temperature 0: strict and flexible exact match both 0.96 (required >= 0.92); all four ranks reported `W=4, D=1`
- V4-Pro SWE-smith matched overlap-off/on endpoint run: 350/350 requests succeeded on each side, with no C4/page-allocation/OOM/runtime fatal
  - TPS/GPU: p1 -3.19%, p2 +5.36%, p4 +15.43%, p8 -1.64%
  - TPOT: p1 -12.16%, p2 -19.00%, p4 -19.69%, p8 +4.45%
- Matched p4 Nsight Systems capture with CUDA Graph nodes and OSRT:
  - post-sync commit work overlapped the current graph in 0/768 off steps and 824/824 on steps
  - median inter-replay GPU bubble decreased from 7.197 ms to 0.670 ms

## Scope and limitations

- This change supports one in-flight overlap step only (`D <= 1`). A deeper pipeline would require additional table-versioning or page-lifetime work.
- Endpoint performance is intentionally reported as mixed: p2/p4 improve, while p1 has a TTFT tradeoff and p8 regresses slightly. Follow-up profiling is needed for the p1 prefill/TTFT path and p8 saturation; this PR does not claim a whole-curve performance win.
