### PR TITLE
feat(attention): add gluon MHA extend kernel for gfx950

### DIFF
--- a/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
+++ b/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
@@ -13,7 +13,6 @@ runner:
       GPT_OSS_EVAL_MODEL: openai/gpt-oss-120b
     amd-mi35x-2gpu-test:
       GPT_OSS_EVAL_DISABLE_KVSTORE: "1"
-      GPT_OSS_EVAL_DISABLE_PREFIX_CACHING: "1"
       GPT_OSS_EVAL_MODEL: amd/gpt-oss-120b-w-mxfp4-a-fp8
 env:
   CI: "true"
@@ -29,7 +28,6 @@ server:
     --trust-remote-code
     --reasoning-parser base
     ${GPT_OSS_EVAL_DISABLE_KVSTORE:+--disable-kvstore}
-    ${GPT_OSS_EVAL_DISABLE_PREFIX_CACHING:+--no-enable-prefix-caching}
     --enable-cache-report
     --host 127.0.0.1
     --port 8000

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/__init__.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/__init__.py
@@ -25,6 +25,9 @@ from __future__ import annotations
 from tokenspeed_kernel_amd.ops.attention.gluon.mha_decode_fp16_gfx950 import (  # noqa: F401
     gluon_mha_decode_fp16_gfx950,
 )
+from tokenspeed_kernel_amd.ops.attention.gluon.mha_extend_fp16_gfx950 import (  # noqa: F401
+    gluon_mha_extend_fp16_gfx950,
+)
 from tokenspeed_kernel_amd.ops.attention.gluon.mha_prefill_fp16_gfx950 import (  # noqa: F401
     gluon_mha_prefill_fp16_gfx950,
 )

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_extend_fp16_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_extend_fp16_gfx950.py
@@ -1,0 +1,671 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""MHA extend (prefix-cache / chunked-prefill) Gluon kernel for AMD GFX950.
+
+This handles ragged, multi-token queries against a paged KV cache. The query
+axis is tiled into the MFMA ``M`` dimension (prefill-style): ``BLOCK_M`` query
+rows of a single q-head share each paged KV tile, so every KV tile is loaded
+once and reused across all rows in the tile. The grid is
+``(blocks_per_req, batch, n_heads)`` -- all host-known sizes -- and each program
+self-locates its request from ``cu_seqlens_q`` / ``cache_seqlens`` in-kernel, so
+the launch stays CUDA-graph static with no device->host sync.
+
+Visibility per query row depends on ``is_causal`` and the optional sliding
+window:
+
+* ``is_causal=False``: every query token attends the full visible cache, i.e.
+  ``visible_kv = cache_seqlens[batch]``.
+* ``is_causal=True``: query tokens are a causal suffix, so the ``i``-th query
+  token of a request (0-indexed) attends ``prefix + i + 1`` tokens, where
+  ``prefix = cache_seqlens[batch] - query_len[batch]``.
+
+Causal masking only touches the few KV tiles that reach the diagonal; the long
+prefix is a mask-free fast path. Sinks and sliding windows (causal or not) are
+applied per tile. This is the sole Gluon extend implementation.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from tokenspeed_kernel_amd._triton import gl, gluon
+from tokenspeed_kernel_amd.ops.attention.gluon.utils import (
+    _INV_LN2,
+    _INV_LN2_VALUE,
+    _LN2,
+    InputStrides,
+    max,
+    maximum,
+)
+
+cdna4 = gl.amd.cdna4
+async_copy = cdna4.async_copy
+
+
+# ===-----------------------------------------------------------------------===#
+# Query-batched path
+#
+# This path tiles BLOCK_M query rows (of a single q-head) into the MFMA M
+# dimension -- like the prefill kernel -- so each paged KV tile is loaded once
+# and reused across all BLOCK_M rows. KV still comes from the paged cache
+# (decode-style async page loads). Causal masking only touches the few KV tiles
+# that reach the diagonal; the long prefix is a mask-free fast path.
+# ===-----------------------------------------------------------------------===#
+
+_EXTEND_BLOCK_N = 64
+_EXTEND_SHORT_Q_BLOCK_M = 64
+_EXTEND_SHORT_Q_NUM_WARPS = 2
+_EXTEND_LONG_Q_BLOCK_M = 128
+_EXTEND_LONG_Q_NUM_WARPS = 4
+
+
+def _select_extend_tile(max_seqlen_q: int) -> tuple[int, int, int]:
+    """Return (BLOCK_M, BLOCK_N, NUM_WARPS) for the given max query length.
+
+    Queries that fit in a single short tile use it (least padding, most
+    occupancy); longer ones use the tall tile that covers more rows per
+    shared-KV pass.
+    """
+    if max_seqlen_q <= _EXTEND_SHORT_Q_BLOCK_M:
+        return _EXTEND_SHORT_Q_BLOCK_M, _EXTEND_BLOCK_N, _EXTEND_SHORT_Q_NUM_WARPS
+    return _EXTEND_LONG_Q_BLOCK_M, _EXTEND_BLOCK_N, _EXTEND_LONG_Q_NUM_WARPS
+
+
+@gluon.aggregate
+class ExtendConfig:
+    N_HEADS: gl.constexpr
+    N_KV_HEADS: gl.constexpr
+    GROUP_SIZE: gl.constexpr
+    HEAD_DIM: gl.constexpr
+    SM_SCALE: gl.constexpr
+    BLOCK_M: gl.constexpr
+    BLOCK_N: gl.constexpr
+    NUM_WARPS: gl.constexpr
+    PAGE_SIZE: gl.constexpr
+    PAGE_TABLE_STRIDE: gl.constexpr
+    IS_CAUSAL: gl.constexpr
+    HAS_SINK: gl.constexpr
+    HAS_LSE: gl.constexpr
+    WINDOW_LEFT: gl.constexpr
+    q_strides: InputStrides
+    qk_layout: gl.constexpr
+    pv_layout: gl.constexpr
+    q_layout: gl.constexpr
+    k_layout: gl.constexpr
+    p_layout: gl.constexpr
+    v_layout: gl.constexpr
+    load_layout: gl.constexpr
+    store_layout: gl.constexpr
+    k_smem_layout: gl.constexpr
+    v_smem_layout: gl.constexpr
+
+    @gluon.constexpr_function
+    def __init__(
+        self,
+        N_HEADS,
+        N_KV_HEADS,
+        HEAD_DIM,
+        SM_SCALE,
+        BLOCK_M,
+        BLOCK_N,
+        NUM_WARPS,
+        PAGE_SIZE,
+        PAGE_TABLE_STRIDE,
+        IS_CAUSAL,
+        HAS_SINK,
+        HAS_LSE,
+        WINDOW_LEFT,
+        q_strides,
+    ):
+        assert HEAD_DIM == 64
+        assert BLOCK_N == PAGE_SIZE
+
+        mfma_layout = gl.amd.AMDMFMALayout(
+            version=4,
+            instr_shape=[32, 32, 16],
+            transposed=True,
+            warps_per_cta=[NUM_WARPS, 1],
+        )
+        qk_layout = mfma_layout
+        pv_layout = mfma_layout
+        load_layout = gl.BlockedLayout([1, 8], [8, 8], [NUM_WARPS, 1], [1, 0])
+        store_layout = load_layout
+        k_smem_layout = gl.PaddedSharedLayout.with_identity_for(
+            [[512, 8]], [BLOCK_N, HEAD_DIM], [1, 0]
+        )
+        v_smem_layout = gl.PaddedSharedLayout.with_identity_for(
+            [[512, 32]], [BLOCK_N, HEAD_DIM], [1, 0]
+        )
+
+        self.N_HEADS = gl.constexpr(N_HEADS)
+        self.N_KV_HEADS = gl.constexpr(N_KV_HEADS)
+        self.GROUP_SIZE = gl.constexpr(N_HEADS // N_KV_HEADS)
+        self.HEAD_DIM = gl.constexpr(HEAD_DIM)
+        self.SM_SCALE = gl.constexpr(SM_SCALE)
+        self.BLOCK_M = gl.constexpr(BLOCK_M)
+        self.BLOCK_N = gl.constexpr(BLOCK_N)
+        self.NUM_WARPS = gl.constexpr(NUM_WARPS)
+        self.PAGE_SIZE = gl.constexpr(PAGE_SIZE)
+        self.PAGE_TABLE_STRIDE = gl.constexpr(PAGE_TABLE_STRIDE)
+        self.IS_CAUSAL = gl.constexpr(IS_CAUSAL)
+        self.HAS_SINK = gl.constexpr(HAS_SINK)
+        self.HAS_LSE = gl.constexpr(HAS_LSE)
+        self.WINDOW_LEFT = gl.constexpr(WINDOW_LEFT)
+        self.q_strides = q_strides
+        self.qk_layout = gl.constexpr(qk_layout)
+        self.pv_layout = gl.constexpr(pv_layout)
+        self.q_layout = gl.constexpr(gl.DotOperandLayout(0, qk_layout, k_width=8))
+        self.k_layout = gl.constexpr(gl.DotOperandLayout(1, qk_layout, k_width=8))
+        self.p_layout = gl.constexpr(gl.DotOperandLayout(0, pv_layout, k_width=4))
+        self.v_layout = gl.constexpr(gl.DotOperandLayout(1, pv_layout, k_width=4))
+        self.load_layout = gl.constexpr(load_layout)
+        self.store_layout = gl.constexpr(store_layout)
+        self.k_smem_layout = gl.constexpr(k_smem_layout)
+        self.v_smem_layout = gl.constexpr(v_smem_layout)
+
+
+@gluon.aggregate
+class ExtendProgram:
+    cfg: gl.constexpr
+    q_ptr: gl.tensor
+    k_cache_ptr: gl.tensor
+    v_cache_ptr: gl.tensor
+    page_table_ptr: gl.tensor
+    output_ptr: gl.tensor
+    lse_ptr: gl.tensor
+    sink_ptr: gl.tensor
+    batch: gl.tensor
+    q_head: gl.tensor
+    kv_head: gl.tensor
+    q_start: gl.tensor
+    seq_base: gl.tensor
+    seq_len: gl.tensor
+    prefix: gl.tensor
+    cache_len: gl.tensor
+
+    @gluon.constexpr_function
+    def __init__(
+        self,
+        cfg,
+        q_ptr,
+        k_cache_ptr,
+        v_cache_ptr,
+        page_table_ptr,
+        output_ptr,
+        lse_ptr,
+        sink_ptr,
+        batch,
+        q_head,
+        kv_head,
+        q_start,
+        seq_base,
+        seq_len,
+        prefix,
+        cache_len,
+    ):
+        self.cfg = gl.constexpr(cfg)
+        self.q_ptr = q_ptr
+        self.k_cache_ptr = k_cache_ptr
+        self.v_cache_ptr = v_cache_ptr
+        self.page_table_ptr = page_table_ptr
+        self.output_ptr = output_ptr
+        self.lse_ptr = lse_ptr
+        self.sink_ptr = sink_ptr
+        self.batch = batch
+        self.q_head = q_head
+        self.kv_head = kv_head
+        self.q_start = q_start
+        self.seq_base = seq_base
+        self.seq_len = seq_len
+        self.prefix = prefix
+        self.cache_len = cache_len
+
+    @gluon.jit
+    def create(
+        cfg,
+        q_ptr,
+        k_cache_ptr,
+        v_cache_ptr,
+        page_table_ptr,
+        output_ptr,
+        lse_ptr,
+        sink_ptr,
+        cu_seqlens_q_ptr,
+        cache_seqlens_ptr,
+    ):
+        block_in_req = gl.program_id(0)
+        batch = gl.program_id(1)
+        q_head = gl.program_id(2)
+        q_start = block_in_req * cfg.BLOCK_M
+        seq_base = gl.load(cu_seqlens_q_ptr + batch)
+        seq_end = gl.load(cu_seqlens_q_ptr + batch + 1)
+        seq_len = seq_end - seq_base
+        cache_len = gl.load(cache_seqlens_ptr + batch)
+        prefix = cache_len - seq_len
+        kv_head = q_head // cfg.GROUP_SIZE
+        return ExtendProgram(
+            gl.constexpr(cfg),
+            q_ptr,
+            k_cache_ptr,
+            v_cache_ptr,
+            page_table_ptr,
+            output_ptr,
+            lse_ptr,
+            sink_ptr,
+            batch,
+            q_head,
+            kv_head,
+            q_start,
+            seq_base,
+            seq_len,
+            prefix,
+            cache_len,
+        )
+
+    @gluon.jit
+    def load_q(self):
+        cfg = self.cfg
+        offs_m = self.q_start + gl.arange(
+            0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.q_layout)
+        )
+        offs_d = gl.arange(0, cfg.HEAD_DIM, layout=gl.SliceLayout(0, cfg.q_layout))
+        row = self.seq_base + offs_m
+        offsets = cfg.q_strides.offsets(row[:, None], self.q_head, offs_d[None, :])
+        mask = offs_m[:, None] < self.seq_len
+        return cdna4.buffer_load(self.q_ptr, offsets, mask=mask, other=0.0)
+
+    @gluon.jit
+    def load_page(self, start_n):
+        cfg = self.cfg
+        page_index = start_n // cfg.PAGE_SIZE
+        valid = start_n < self.cache_len
+        return gl.load(
+            self.page_table_ptr + self.batch * cfg.PAGE_TABLE_STRIDE + page_index,
+            mask=valid,
+            other=0,
+        )
+
+    @gluon.jit
+    def issue_load_k(self, physical_page, k_smem):
+        cfg = self.cfg
+        offs_n = gl.arange(0, cfg.BLOCK_N, layout=gl.SliceLayout(1, cfg.load_layout))
+        offs_d = gl.arange(0, cfg.HEAD_DIM, layout=gl.SliceLayout(0, cfg.load_layout))
+        token_loc = physical_page.to(gl.int64) * cfg.PAGE_SIZE + offs_n.to(gl.int64)
+        offsets = (
+            token_loc[:, None] * cfg.N_KV_HEADS * cfg.HEAD_DIM
+            + self.kv_head * cfg.HEAD_DIM
+            + offs_d[None, :]
+        )
+        async_copy.global_load_to_shared(k_smem, self.k_cache_ptr + offsets)
+        async_copy.commit_group()
+
+    @gluon.jit
+    def issue_load_v(self, physical_page, v_smem):
+        cfg = self.cfg
+        offs_n = gl.arange(0, cfg.BLOCK_N, layout=gl.SliceLayout(1, cfg.load_layout))
+        offs_d = gl.arange(0, cfg.HEAD_DIM, layout=gl.SliceLayout(0, cfg.load_layout))
+        token_loc = physical_page.to(gl.int64) * cfg.PAGE_SIZE + offs_n.to(gl.int64)
+        offsets = (
+            token_loc[:, None] * cfg.N_KV_HEADS * cfg.HEAD_DIM
+            + self.kv_head * cfg.HEAD_DIM
+            + offs_d[None, :]
+        )
+        async_copy.global_load_to_shared(v_smem, self.v_cache_ptr + offsets)
+        async_copy.commit_group()
+
+    @gluon.jit
+    def shared_load_k(self, k_smem):
+        cfg = self.cfg
+        k_buffer = k_smem.permute([1, 0])
+        return k_buffer.load(cfg.k_layout)
+
+    @gluon.jit
+    def shared_load_v(self, v_smem):
+        cfg = self.cfg
+        return v_smem.load(cfg.v_layout)
+
+    @gluon.jit
+    def compute_qk(self, q, k):
+        cfg = self.cfg
+        qk = gl.zeros(
+            [cfg.BLOCK_M, cfg.BLOCK_N], dtype=gl.float32, layout=cfg.qk_layout
+        )
+        return cdna4.mfma(q, k, qk)
+
+    @gluon.jit
+    def compute_pv(self, p, v, acc):
+        return cdna4.mfma(p, v, acc)
+
+    @gluon.jit
+    def init_attention_state(self):
+        cfg = self.cfg
+        if cfg.HAS_SINK:
+            sink_log2 = gl.load(self.sink_ptr + self.q_head).to(gl.float32) * _INV_LN2
+            sink_unscaled = sink_log2 / cfg.SM_SCALE
+            m_i = gl.full(
+                [cfg.BLOCK_M],
+                value=0,
+                dtype=gl.float32,
+                layout=gl.SliceLayout(1, cfg.pv_layout),
+            )
+            m_i += sink_unscaled
+        else:
+            sink_log2 = 0.0
+            m_i = gl.full(
+                [cfg.BLOCK_M],
+                value=-float("inf"),
+                dtype=gl.float32,
+                layout=gl.SliceLayout(1, cfg.pv_layout),
+            )
+        l_i = gl.full(
+            [cfg.BLOCK_M],
+            value=0,
+            dtype=gl.float32,
+            layout=gl.SliceLayout(1, cfg.pv_layout),
+        )
+        acc = gl.zeros(
+            [cfg.BLOCK_M, cfg.HEAD_DIM], dtype=gl.float32, layout=cfg.pv_layout
+        )
+        return m_i, l_i, acc, sink_log2
+
+    @gluon.jit
+    def softmax(self, qk, m_i, l_i, acc):
+        cfg = self.cfg
+        # In sliding window case, some rows can see fully masked tiles before
+        # any valid KV. Guard the online softmax state so `-inf - -inf` does not
+        # produce NaNs. This does not happen when having sink, because m_i
+        # is initialized to sink value instead of -inf.
+        HAS_INVALID: gl.constexpr = cfg.WINDOW_LEFT >= 0 and not cfg.HAS_SINK
+
+        row_max = max(qk, 1)
+        m_new = maximum(m_i, row_max)
+        m_new_scaled = m_new * cfg.SM_SCALE
+        if HAS_INVALID:
+            invalid = m_new == -float("inf")
+            m_new_scaled = gl.where(invalid, 0.0, m_new_scaled)
+
+        qk_shifted = qk * cfg.SM_SCALE - m_new_scaled[:, None]
+        p = gl.exp2(qk_shifted)
+        m_diff = m_i * cfg.SM_SCALE - m_new_scaled
+        if HAS_INVALID:
+            m_diff = gl.where(invalid, 0.0, m_diff)
+
+        alpha = gl.exp2(m_diff)
+        l_ij = gl.sum(p, axis=1)
+        l_i = l_i * alpha + l_ij
+        acc = acc * alpha[:, None]
+        p = p.to(self.q_ptr.dtype.element_ty)
+        p = gl.convert_layout(p, cfg.p_layout)
+        return p, m_new, l_i, acc
+
+    @gluon.jit
+    def apply_sinks(self, l_i, m_i, sink_log2):
+        cfg = self.cfg
+        if cfg.HAS_SINK:
+            l_i += gl.exp2(sink_log2 - m_i * cfg.SM_SCALE)
+        return l_i
+
+    @gluon.jit
+    def store_output(self, output):
+        cfg = self.cfg
+        offs_m = self.q_start + gl.arange(
+            0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.store_layout)
+        )
+        offs_d = gl.arange(0, cfg.HEAD_DIM, layout=gl.SliceLayout(0, cfg.store_layout))
+        offsets = (
+            ((self.seq_base + offs_m[:, None]) * cfg.N_HEADS + self.q_head)
+            * cfg.HEAD_DIM
+            + offs_d[None, :]
+        ).to(gl.int32)
+        mask = offs_m[:, None] < self.seq_len
+        output = output.to(self.output_ptr.dtype.element_ty)
+        cdna4.buffer_store(output, self.output_ptr, offsets, mask=mask)
+
+    @gluon.jit
+    def store_lse(self, l_i, m_i):
+        cfg = self.cfg
+        if cfg.HAS_LSE:
+            offs_m = self.q_start + gl.arange(
+                0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.pv_layout)
+            )
+            offsets = ((self.seq_base + offs_m) * cfg.N_HEADS + self.q_head).to(
+                gl.int32
+            )
+            mask = offs_m < self.seq_len
+            lse_l_i = gl.where(l_i > 0.0, l_i, 1.0)
+            # Softmax runs in base-2 (exp2 hardware fast path), so m_i*SM_SCALE +
+            # log2(l_i) is the LSE in base-2 units. Convert to natural log (the
+            # public op contract / torch.logsumexp convention) by scaling by ln2.
+            lse = (m_i * cfg.SM_SCALE + gl.log2(lse_l_i)) * _LN2
+            cdna4.buffer_store(lse, self.lse_ptr, offsets, mask=mask)
+
+
+@gluon.jit
+def _mha_extend_fp16(
+    q_ptr,
+    k_cache_ptr,
+    v_cache_ptr,
+    page_table_ptr,
+    output_ptr,
+    lse_ptr,
+    sink_ptr,
+    cu_seqlens_q_ptr,
+    cache_seqlens_ptr,
+    Q_STRIDE_T: gl.constexpr,
+    Q_STRIDE_H: gl.constexpr,
+    Q_STRIDE_D: gl.constexpr,
+    SM_SCALE: gl.constexpr,
+    PAGE_TABLE_STRIDE: gl.constexpr,
+    PAGE_SIZE: gl.constexpr,
+    N_HEADS: gl.constexpr,
+    N_KV_HEADS: gl.constexpr,
+    HEAD_DIM: gl.constexpr,
+    BLOCK_M: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+    IS_CAUSAL: gl.constexpr,
+    HAS_SINK: gl.constexpr,
+    HAS_LSE: gl.constexpr,
+    WINDOW_LEFT: gl.constexpr,
+):
+    cfg = ExtendConfig(
+        N_HEADS,
+        N_KV_HEADS,
+        HEAD_DIM,
+        SM_SCALE,
+        BLOCK_M,
+        BLOCK_N,
+        NUM_WARPS,
+        PAGE_SIZE,
+        PAGE_TABLE_STRIDE,
+        IS_CAUSAL,
+        HAS_SINK,
+        HAS_LSE,
+        WINDOW_LEFT,
+        InputStrides(Q_STRIDE_T, Q_STRIDE_H, Q_STRIDE_D),
+    )
+    program = ExtendProgram.create(
+        cfg,
+        q_ptr,
+        k_cache_ptr,
+        v_cache_ptr,
+        page_table_ptr,
+        output_ptr,
+        lse_ptr,
+        sink_ptr,
+        cu_seqlens_q_ptr,
+        cache_seqlens_ptr,
+    )
+    # Over-provisioned tile past this request's real query rows: nothing to do.
+    if program.q_start >= program.seq_len:
+        return
+    k_smem = gl.allocate_shared_memory(
+        k_cache_ptr.dtype.element_ty, [cfg.BLOCK_N, cfg.HEAD_DIM], cfg.k_smem_layout
+    )
+    v_smem = gl.allocate_shared_memory(
+        v_cache_ptr.dtype.element_ty, [cfg.BLOCK_N, cfg.HEAD_DIM], cfg.v_smem_layout
+    )
+
+    q = program.load_q()
+    m_i, l_i, acc, sink_log2 = program.init_attention_state()
+
+    offs_m_q = program.q_start + gl.arange(
+        0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.qk_layout)
+    )
+    offs_n_q = gl.arange(0, cfg.BLOCK_N, layout=gl.SliceLayout(0, cfg.qk_layout))
+    diag_row = program.prefix + offs_m_q
+
+    if IS_CAUSAL:
+        kv_end = min(program.cache_len, program.prefix + program.q_start + cfg.BLOCK_M)
+    else:
+        kv_end = program.cache_len
+
+    # Sliding window (inclusive-left, matches flash-attn window_size=(W, 0)):
+    # skip KV tiles entirely below the window's lower edge. The tile's top query
+    # row sits at absolute position pos_top; its window opens at
+    # pos_top - WINDOW_LEFT (that key is visible -> W + 1 keys total). The min()
+    # form clamps to 0 without the shadowed builtin max().
+    if cfg.WINDOW_LEFT >= 0:
+        pos_top = program.prefix + program.q_start
+        kv_start = pos_top - min(pos_top, cfg.WINDOW_LEFT)
+        kv_start = (kv_start // cfg.BLOCK_N) * cfg.BLOCK_N
+    else:
+        kv_start = 0
+
+    for start_n in range(kv_start, kv_end, cfg.BLOCK_N):
+        physical_page = program.load_page(start_n)
+        program.issue_load_k(physical_page, k_smem)
+        program.issue_load_v(physical_page, v_smem)
+
+        async_copy.wait_group(1)
+        k = program.shared_load_k(k_smem)
+        qk = program.compute_qk(q, k)
+
+        if cfg.WINDOW_LEFT >= 0:
+            # Window lower edge + cache bound always apply; causal upper edge only
+            # when IS_CAUSAL (independent layering keeps non-causal + window correct).
+            offs_n_abs = start_n + offs_n_q
+            mask = (offs_n_abs[None, :] >= diag_row[:, None] - cfg.WINDOW_LEFT) & (
+                offs_n_abs[None, :] < program.cache_len
+            )
+            if IS_CAUSAL:
+                mask &= offs_n_abs[None, :] <= diag_row[:, None]
+            qk = gl.where(mask, qk, -float("inf"))
+        elif IS_CAUSAL:
+            if start_n + cfg.BLOCK_N > program.prefix + program.q_start:
+                offs_n_abs = start_n + offs_n_q
+                mask = (offs_n_abs[None, :] <= diag_row[:, None]) & (
+                    offs_n_abs[None, :] < program.cache_len
+                )
+                qk = gl.where(mask, qk, -float("inf"))
+        else:
+            if start_n + cfg.BLOCK_N > program.cache_len:
+                offs_n_abs = start_n + offs_n_q
+                qk = gl.where(
+                    offs_n_abs[None, :] < program.cache_len, qk, -float("inf")
+                )
+
+        p, m_i, l_i, acc = program.softmax(qk, m_i, l_i, acc)
+
+        async_copy.wait_group(0)
+        v = program.shared_load_v(v_smem)
+        acc = program.compute_pv(p, v, acc)
+
+    l_i = program.apply_sinks(l_i, m_i, sink_log2)
+    denom = gl.where(l_i > 0.0, l_i, 1.0)
+    output = acc * (1.0 / denom)[:, None]
+    output = gl.convert_layout(output, cfg.store_layout)
+    program.store_output(output)
+    program.store_lse(l_i, m_i)
+
+
+def gluon_mha_extend_fp16_gfx950(
+    q: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_kv: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    is_causal: bool = False,
+    window_left: int = -1,
+    logit_cap: float = 0.0,
+    sinks: torch.Tensor | None = None,
+    return_lse: bool = False,
+    max_seqlen_q: int = 1,
+    max_seqlen_k: int = 1,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    head_dim = q.shape[2]
+    n_heads = q.shape[1]
+    n_kv_heads = k_cache.shape[2]
+    page_size = k_cache.shape[1]
+    block_m, block_n, num_warps = _select_extend_tile(max_seqlen_q)
+    sm_scale = (1.0 / math.sqrt(head_dim)) * _INV_LN2_VALUE
+
+    # max_seqlen_q must be >= the true max query length; extra tiles early-exit.
+    batch = cu_seqlens_q.shape[0] - 1
+    safe_max_q = max_seqlen_q if max_seqlen_q > 0 else 1
+    blocks_per_req = (safe_max_q + block_m - 1) // block_m
+    has_sink = sinks is not None
+    sink_arg = sinks if has_sink else q
+    cu_q_i32 = cu_seqlens_q.to(torch.int32).contiguous()
+    cache_i32 = cache_seqlens.to(torch.int32).contiguous()
+
+    output = torch.empty(q.shape, device=q.device, dtype=q.dtype)
+    if return_lse:
+        lse = torch.empty((q.shape[0], n_heads), device=q.device, dtype=torch.float32)
+        lse_arg = lse
+    else:
+        lse = None
+        lse_arg = q
+    grid = (blocks_per_req, batch, n_heads)
+    _mha_extend_fp16[grid](
+        q,
+        k_cache,
+        v_cache,
+        page_table,
+        output,
+        lse_arg,
+        sink_arg,
+        cu_q_i32,
+        cache_i32,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        sm_scale,
+        page_table.stride(0),
+        page_size,
+        n_heads,
+        n_kv_heads,
+        head_dim,
+        block_m,
+        block_n,
+        num_warps,
+        is_causal,
+        has_sink,
+        return_lse,
+        window_left,
+        num_warps=num_warps,
+    )
+    if return_lse:
+        return output, lse
+    return output

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
@@ -35,6 +35,9 @@ if current_platform().is_amd:
     from tokenspeed_kernel_amd.ops.attention.gluon.mha_decode_fp16_gfx950 import (
         gluon_mha_decode_fp16_gfx950 as _decode_impl,
     )
+    from tokenspeed_kernel_amd.ops.attention.gluon.mha_extend_fp16_gfx950 import (
+        gluon_mha_extend_fp16_gfx950 as _extend_impl,
+    )
     from tokenspeed_kernel_amd.ops.attention.gluon.mha_prefill_fp16_gfx950 import (
         gluon_mha_prefill_fp16_gfx950 as _prefill_impl,
     )
@@ -91,3 +94,32 @@ if current_platform().is_amd:
     )
     def gluon_mha_prefill_fp16_gfx950(*args, **kwargs):
         return _prefill_impl(*args, **kwargs)
+
+    @register_kernel(
+        "attention",
+        "mha_extend_with_kvcache",
+        name="gluon_mha_extend_fp16_gfx950",
+        solution="gluon",
+        capability=CapabilityRequirement(
+            min_arch_version=ArchVersion(9, 5),
+            max_arch_version=ArchVersion(9, 5),
+            vendors=frozenset({"amd"}),
+        ),
+        signatures=format_signatures(
+            ("q", "k_cache", "v_cache"),
+            "dense",
+            {torch.float16, torch.bfloat16},
+        ),
+        priority=Priority.SPECIALIZED,
+        traits={
+            "head_dim": frozenset({64}),
+            "page_size": frozenset({64}),
+            "is_causal": frozenset({False, True}),
+            "sliding_window": frozenset({False, True}),
+            "support_sinks": frozenset({False, True}),
+            "support_logit_cap": frozenset({False}),
+            "return_lse": frozenset({False, True}),
+        },
+    )
+    def gluon_mha_extend_fp16_gfx950(*args, **kwargs):
+        return _extend_impl(*args, **kwargs)

--- a/tokenspeed-kernel/test/ops/test_attention.py
+++ b/tokenspeed-kernel/test/ops/test_attention.py
@@ -165,7 +165,7 @@ def test_mha_prefill_lse(
         pytest.param(torch.float8_e4m3fn, 64, 8, 2, id="fp8"),
     ],
 )
-@pytest.mark.parametrize("solution", ["triton", "fa3", "fa4", "flashinfer"])
+@pytest.mark.parametrize("solution", ["triton", "fa3", "fa4", "flashinfer", "gluon"])
 def test_mha_extend_with_kvcache(
     device: str,
     solution: str,
@@ -270,8 +270,8 @@ def test_mha_extend_with_kvcache(
 
     assert out.shape == q.shape
 
-    if solution == "triton":
-        triton_out, triton_lse = mha_extend_with_kvcache(
+    if solution in ("triton", "gluon"):
+        lse_out, lse = mha_extend_with_kvcache(
             q=q,
             cu_seqlens_q=cu_seqlens_q,
             cu_seqlens_kv=cu_seqlens_kv,
@@ -285,8 +285,8 @@ def test_mha_extend_with_kvcache(
             solution=solution,
         )
 
-        assert triton_out.shape == q.shape
-        assert triton_lse.shape == (q.shape[0], q.shape[1])
+        assert lse_out.shape == q.shape
+        assert lse.shape == (q.shape[0], q.shape[1])
 
 
 @pytest.mark.parametrize(

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -1053,7 +1053,7 @@ _CASES = [
         "cdna4",
         "attention",
         "mha_extend_with_kvcache",
-        "triton_mha_extend_with_kvcache",
+        "gluon_mha_extend_fp16_gfx950",
         _attention_extend,
     ),
     _case(


### PR DESCRIPTION
The extend kernel is essentially a combination of the two gluon attention kernels we already have:

from the prefill kernel: multi-token query handling with query-axis MFMA batching and the guarded online softmax;
from the decode kernel: paged KV-cache traversal, sinks, and sliding-window support.

### 1. Kernel benchmark — gluon vs triton
#### Full causal attention (no sliding window)
| scenario      | batch | prefix | q_len | gluon(ms) | triton(ms) | speedup |
|---------------|------:|-------:|------:|----------:|-----------:|--------:|
| spec-verify   |    64 |    32k |     2 |    3.6836 |    21.7938 |   5.92x |
| spec-verify   |    64 |    32k |     4 |    3.6113 |    21.8155 |   6.04x |
| spec-verify   |    64 |    32k |     8 |    3.7540 |    21.7562 |   5.80x |
| spec-verify   |    16 |     8k |     4 |    0.2240 |     0.7376 |   3.29x |
| spec-verify   |    16 |    32k |     4 |    0.9270 |     3.4478 |   3.72x |
| spec-verify   |    16 |   128k |     4 |    3.6574 |    21.6249 |   5.91x |
| spec-verify   |    32 |    32k |     4 |    1.8227 |     6.9712 |   3.82x |
| spec-verify   |    64 |    32k |     4 |    3.6950 |    21.6852 |   5.87x |
| prefix-cache  |    64 |     8k |    64 |    0.9338 |     3.4280 |   3.67x |
| prefix-cache  |    64 |     8k |   128 |    1.5232 |     6.4982 |   4.27x |
| prefix-cache  |    64 |     8k |   256 |    3.0406 |    13.2877 |   4.37x |
| prefix-cache  |    16 |     8k |   128 |    0.4403 |     1.6856 |   3.83x |
| prefix-cache  |    16 |    32k |   128 |    1.6532 |     6.9558 |   4.21x |
| prefix-cache  |    16 |   128k |   128 |    6.7847 |    43.2146 |   6.37x |
| prefix-cache  |    64 |     8k |   128 |    1.5390 |     6.8611 |   4.46x |
| prefix-cache  |   128 |     8k |   128 |    3.2623 |    14.5544 |   4.46x |
| chunk-prefill |     4 |     8k |  2048 |    1.6493 |     6.8454 |   4.15x |
| chunk-prefill |     2 |     8k |  4096 |    1.8524 |     8.2051 |   4.43x |
| chunk-prefill |     1 |     8k |  8192 |    2.2327 |    10.8968 |   4.88x |
| chunk-prefill |     4 |     2k |  2048 |    0.6402 |     2.7590 |   4.31x |
| chunk-prefill |     4 |    32k |  2048 |    5.9163 |    27.0829 |   4.58x |
#### Sliding window (128 tokens)
| scenario      | batch | prefix | q_len | gluon(ms) | triton(ms) | speedup  |
|---------------|------:|-------:|------:|----------:|-----------:|---------:|
| spec-verify   |    64 |    32k |     2 |    0.0354 |     8.8115 |  248.71x |
| spec-verify   |    64 |    32k |     4 |    0.0345 |     8.8158 |  255.45x |
| spec-verify   |    64 |    32k |     8 |    0.0347 |     8.8138 |  254.35x |
| spec-verify   |    16 |     8k |     4 |    0.0346 |     0.5774 |   16.69x |
| spec-verify   |    16 |    32k |     4 |    0.0337 |     2.2089 |   65.64x |
| spec-verify   |    16 |   128k |     4 |    0.0348 |     8.7187 |  250.69x |
| spec-verify   |    32 |    32k |     4 |    0.0339 |     4.4058 |  130.03x |
| spec-verify   |    64 |    32k |     4 |    0.0356 |     8.8071 |  247.34x |
| prefix-cache  |    64 |     8k |    64 |    0.0371 |     2.3089 |   62.16x |
| prefix-cache  |    64 |     8k |   128 |    0.0764 |     4.6372 |   60.68x |
| prefix-cache  |    64 |     8k |   256 |    0.1592 |     9.4306 |   59.23x |
| prefix-cache  |    16 |     8k |   128 |    0.0356 |     1.1626 |   32.65x |
| prefix-cache  |    16 |    32k |   128 |    0.0354 |     4.4198 |  124.97x |
| prefix-cache  |    16 |   128k |   128 |    0.0353 |    17.4530 |  494.19x |
| prefix-cache  |    64 |     8k |   128 |    0.0762 |     4.6345 |   60.86x |
| prefix-cache  |   128 |     8k |   128 |    0.1631 |     9.2894 |   56.95x |
| chunk-prefill |     4 |     8k |  2048 |    0.0801 |     5.6457 |   70.52x |
| chunk-prefill |     2 |     8k |  4096 |    0.0748 |     6.7338 |   90.00x |
| chunk-prefill |     1 |     8k |  8192 |    0.0717 |     8.8513 |  123.46x |
| chunk-prefill |     4 |     2k |  2048 |    0.0782 |     2.3833 |   30.47x |
| chunk-prefill |     4 |    32k |  2048 |    0.0763 |    18.6580 |  244.45x |

### 2. End-to-end gpt-oss-120b serving

> **Note on the split:** *cache off (full prefill)* sends a single full-length prompt
> (prefix=0, prompt=T), so the whole input is prefilled on every request. *cache on*
> sends a half split (prefix=T/2 + prompt=T/2); after warmup the T/2 prefix is a cache
> hit and only the remaining T/2 goes through the extend kernel.

#### TTFT (ms)
| input length | batch size | cache off (full prefill) | cache ON (triton extend) | cache ON (gluon extend) |
|-------------:|-----------:|-------------------------:|-------------------------:|------------------------:|
| 1k           | 1          |                     80.0 |                     83.2 |                    82.0 |
| 1k           | 2          |                     94.5 |                    109.0 |                    96.0 |
| 1k           | 4          |                    122.0 |                    116.6 |                   116.1 |
| 1k           | 8          |                    154.7 |                    140.2 |                   133.4 |
| 1k           | 16         |                    215.6 |                    184.4 |                   165.4 |
| 4k           | 1          |                    109.9 |                    110.7 |                    90.3 |
| 4k           | 2          |                    154.1 |                    152.7 |                   119.6 |
| 4k           | 4          |                    217.2 |                    217.2 |                   225.0 |
| 4k           | 8          |                    316.4 |                    342.0 |                   227.4 |
| 4k           | 16         |                    489.8 |                    532.8 |                   330.8 |
| 8k           | 1          |                    161.9 |                    209.7 |                   129.2 |
| 8k           | 2          |                    224.0 |                    295.2 |                   175.3 |
| 8k           | 4          |                    329.0 |                    498.2 |                   243.5 |
| 8k           | 8          |                    524.8 |                    934.9 |                   364.0 |
| 8k           | 16         |                    902.3 |                   1518.7 |                   572.0 |