### PR TITLE
fix(perf): fix qwen3.5 tp8 agentic ci perf regression

### DIFF
--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -535,11 +535,17 @@ class EventLoop:
         # _pending_cache_event_payloads) diverges transiently. A rank-local skip
         # would let some ranks gather while others return, deadlocking the group.
         # Agree on the skip via a cheap single-int all_reduce.
+        # NOTE: For non-DFLASH algorithms, cache ops are deterministic across
+        # ranks, so the local short-circuit is safe and avoids collective overhead.
         local_has_work = bool(
             self._num_inflight_cache_ops != 0 or self._pending_cache_event_payloads
         )
-        if not self._cache_group_has_work(local_has_work):
-            return
+        if self.server_args.speculative_algorithm == "DFLASH":
+            if not self._cache_group_has_work(local_has_work):
+                return
+        else:
+            if not local_has_work:
+                return
 
         ready_payloads = self._pop_ready_cache_event_payloads()
         if not ready_payloads:

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -851,21 +851,22 @@ class CudaGraphWrapper:
         pad = padded_bs - active_req_pool_indices.shape[0]
         if pad <= 0:
             return active_req_pool_indices
-        # Route padding rows to the sentinel req-pool slot (max_req_pool_size),
-        # not slot 0. valid_cache_lengths / req_to_page are sized
-        # [max_req_pool_size + 1]; the sentinel row stays zero-init (length 0,
-        # dummy page 0) since _update_runtime_state only writes real rows. Slot 0
-        # would alias the live first request: harmless for verify (seq_len == 1),
-        # but the DFLASH draft derives each row's block seq_len from
-        # valid_cache_lengths[req_pool], so padding rows would grow unbounded with
-        # request 0's context and hang the draft block-decode kernel. The sentinel
-        # keeps that derived length inert for every drafter backend.
-        sentinel = int(self.config.max_req_pool_size)
+        if self.config.spec_algo == "DFLASH":
+            # Route padding rows to the sentinel req-pool slot
+            # (max_req_pool_size), not slot 0. The DFLASH draft derives each
+            # row's block seq_len from valid_cache_lengths[req_pool], so
+            # padding rows pointing at slot 0 would grow unbounded with
+            # request 0's context and hang the draft block-decode kernel.
+            # The sentinel row stays zero-init (length 0, dummy page 0).
+            sentinel = int(self.config.max_req_pool_size)
+            return torch.cat(
+                [
+                    active_req_pool_indices,
+                    active_req_pool_indices.new_full((pad,), sentinel),
+                ]
+            )
         return torch.cat(
-            [
-                active_req_pool_indices,
-                active_req_pool_indices.new_full((pad,), sentinel),
-            ]
+            [active_req_pool_indices, active_req_pool_indices.new_zeros(pad)]
         )
 
     def _set_graph_state_write_indices(

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -233,14 +233,16 @@ class ModelExecutor:
         self._layerwise_mamba_cow_done = None
 
         if config.spec_algo is not None:
-            # The overlap scheduler reserves a fresh draft block per decode step
-            # a request stays scheduled, including the few steps it lingers
-            # between finishing and eviction, so peak page count runs ~1 page past
-            # context_len + spec_num_tokens. Without headroom req_to_page
-            # overflows and the next draft block's page write goes out of bounds,
-            # hanging the attention kernel. Pad generously; a few int32 columns
-            # per request.
-            draft_block_reservation_slack = config.spec_num_tokens * 64
+            # The DFLASH overlap scheduler reserves a fresh draft block per
+            # decode step a request stays scheduled, including the few steps it
+            # lingers between finishing and eviction, so peak page count runs
+            # ~1 page past context_len + spec_num_tokens. Without headroom
+            # req_to_page overflows and the next draft block's page write goes
+            # out of bounds, hanging the attention kernel. Pad generously; a few
+            # int32 columns per request. Non-DFLASH algorithms do not need this.
+            draft_block_reservation_slack = (
+                config.spec_num_tokens * 64 if config.spec_algo == "DFLASH" else 0
+            )
             max_num_pages_per_req = (
                 config.context_len
                 + config.spec_num_tokens
@@ -678,9 +680,10 @@ class ModelExecutor:
             accept_lengths = self._apply_force_single_token_verify(
                 accept_lengths, 0, num_decodes, ctx.decode_input_ids
             )
-            accept_lengths = self._cap_accept_to_context_len(
-                accept_lengths, sampling_info.req_pool_indices[:num_decodes]
-            )
+            if self.config.spec_algo == "DFLASH":
+                accept_lengths = self._cap_accept_to_context_len(
+                    accept_lengths, sampling_info.req_pool_indices[:num_decodes]
+                )
             return output_tokens, accept_lengths
 
         logits = logits_output.next_token_logits
@@ -695,9 +698,10 @@ class ModelExecutor:
         decode_accept = self._apply_force_single_token_verify(
             decode_accept, num_extends, num_decodes, ctx.decode_input_ids
         )
-        decode_accept = self._cap_accept_to_context_len(
-            decode_accept, sampling_info.req_pool_indices[num_extends:]
-        )
+        if self.config.spec_algo == "DFLASH":
+            decode_accept = self._cap_accept_to_context_len(
+                decode_accept, sampling_info.req_pool_indices[num_extends:]
+            )
         if (
             prefill_out.next_token_logprobs is not None
             and decode_out.next_token_logprobs is not None
@@ -1767,13 +1771,14 @@ class ModelExecutor:
                             time.perf_counter() - forward_step_start
                         ) * 1000.0
 
-                # Clamp the committed-length delta so no request grows past
-                # context_len. Done here (outside the graph) so it reaches both
-                # _update_runtime_state and the scheduler page reservation; see
-                # _clamp_committed_to_context_len.
-                output_lengths = self._clamp_committed_to_context_len(
-                    output_lengths, num_extends, bs
-                )
+                if self.config.spec_algo == "DFLASH":
+                    # Clamp the committed-length delta so no request grows past
+                    # context_len. Done here (outside the graph) so it reaches
+                    # both _update_runtime_state and the scheduler page
+                    # reservation; see _clamp_committed_to_context_len.
+                    output_lengths = self._clamp_committed_to_context_len(
+                        output_lengths, num_extends, bs
+                    )
 
                 # Update runtime state on execution_stream (NOT in the CUDA graph).
                 self._update_runtime_state(


### PR DESCRIPTION
## Summary
Commit a6578e5 ("fix(dflash): fix server hang issue") introduced DFLASH-specific safety logic that ran unconditionally on all speculative algorithms, causing ~23% decode TPS regression (580→446) on Qwen3.5 TP8 MTP.

### Changes Causing Regression
- model_executor.py: Inflated max_num_pages_per_req with spec_num_tokens * 64 slack, enlarging page-table buffers and CUDA graph metadata for every spec model.
- model_executor.py: Added _cap_accept_to_context_len and _clamp_committed_to_context_len on every decode step, creating fresh tensors that force the slow two-D2H fallback path.
- cuda_graph_wrapper.py: Changed padding from zero (slot 0) to sentinel (max_req_pool_size), adding per-step overhead for non-DFLASH models that don't need it.
- event_loop.py: Replaced the fast local short-circuit with a collective all_reduce on every event-loop iteration across all TP ranks.

### Fix
   - Guard all four changes behind self.config.spec_algo == "DFLASH", restoring the original fast paths for MTP/EAGLE3 while preserving DFLASH correctness.
<!-- What changed and why? -->

NOTE: This is a temporary fix — DFLASH-specific perf issues will be addressed in a follow-up PR.

## Test Plan

<!-- How was this validated? -->
