### PR TITLE
fix(spec): fix Kimi DP EAGLE3 mixed-step hang

### DIFF
--- a/python/tokenspeed/runtime/execution/drafter/eagle.py
+++ b/python/tokenspeed/runtime/execution/drafter/eagle.py
@@ -36,13 +36,8 @@ from tokenspeed.runtime.execution.forward_batch_info import (
     CaptureHiddenMode,
     ForwardMode,
 )
-from tokenspeed.runtime.models.llama_eagle3 import LlamaForCausalLMEagle3
-from tokenspeed.runtime.models.qwen3_5_nextn import Qwen3_5ForConditionalGenerationNextN
 from tokenspeed.runtime.multimodal.inputs import maybe_substitute_mm_pad
-from tokenspeed.runtime.utils import get_colorful_logger
 from tokenspeed.runtime.utils.nvtx import nvtx_range
-
-logger = get_colorful_logger(__name__)
 
 DsaTopKState = tuple[Any | None, Any | None]
 
@@ -53,6 +48,11 @@ if TYPE_CHECKING:
     from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
     from tokenspeed.runtime.layers.attention.kv_cache.base import BaseTokenToKVPool
     from tokenspeed.runtime.layers.logits_processor import LogitsProcessorOutput
+
+
+def draft_model_reduces_first_step_catchup(draft_model) -> bool:
+    """Whether a draft first-step catch-up trims activations to one row per request."""
+    return bool(getattr(draft_model, "draft_first_step_reduce_for_catchup", False))
 
 
 def _advance_draft_forward_metadata_if_supported(attn_backend, seq_lens) -> None:
@@ -274,12 +274,7 @@ class Eagle(BaseDrafter):
         draft_model = self.draft_model_runner.model
         # These draft models run first-step catch-up on the full input window,
         # then narrow to one row per request for sampling and later MTP steps.
-        reduce_first_step_catchup = bool(
-            getattr(draft_model, "draft_first_step_reduce_for_catchup", False)
-        ) or isinstance(
-            draft_model,
-            (LlamaForCausalLMEagle3, Qwen3_5ForConditionalGenerationNextN),
-        )
+        reduce_first_step_catchup = draft_model_reduces_first_step_catchup(draft_model)
         draft_first_step_reduce = forward_mode.is_decode() or (
             reduce_first_step_catchup and not forward_mode.is_idle()
         )

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -37,7 +37,10 @@ from tokenspeed.runtime.execution.cache_loc_kernel import update_block_table
 from tokenspeed.runtime.execution.context import ForwardContext
 from tokenspeed.runtime.execution.cuda_graph_wrapper import CudaGraphWrapper
 from tokenspeed.runtime.execution.drafter.dflash import DFlash
-from tokenspeed.runtime.execution.drafter.eagle import Eagle
+from tokenspeed.runtime.execution.drafter.eagle import (
+    Eagle,
+    draft_model_reduces_first_step_catchup,
+)
 from tokenspeed.runtime.execution.forward_batch_info import (
     CaptureHiddenMode,
     ForwardMode,
@@ -49,8 +52,6 @@ from tokenspeed.runtime.execution.runtime_states import RuntimeStates
 from tokenspeed.runtime.execution.types import ModelExecutionResult
 from tokenspeed.runtime.grammar.capturable_grammar import setup_grammar_step
 from tokenspeed.runtime.layers.logits_processor import LogitsProcessorOutput
-from tokenspeed.runtime.models.llama_eagle3 import LlamaForCausalLMEagle3
-from tokenspeed.runtime.models.qwen3_5_nextn import Qwen3_5ForConditionalGenerationNextN
 from tokenspeed.runtime.sampling.backends.base import SamplingBackend
 from tokenspeed.runtime.sampling.dp_sampling_config import (
     DpSamplingRuntimeLimits,
@@ -1232,6 +1233,9 @@ class ModelExecutor:
             idle_forward_steps = getattr(
                 self.drafter, "idle_forward_steps", self.drafter.spec_num_steps
             )
+            draft_reduces_first_step_catchup = draft_model_reduces_first_step_catchup(
+                self.drafter.draft_model_runner.model
+            )
             for step_idx in range(idle_forward_steps or 0):
                 # Mirror active rank's catch-up step: when all non-idle ranks
                 # are decoding, step 0 sizes collectives from bs/global_bs.
@@ -1251,21 +1255,12 @@ class ModelExecutor:
                     global_num_tokens=draft_global_num_tokens,
                     global_bs=global_bs,
                     all_decode_or_idle=all_decode_or_idle,
-                    # Mirror the active-rank broaden in eagle.py: Llama Eagle3
-                    # and Qwen3.5 NextN narrow for any non-idle catch-up, so the
-                    # idle peer must size collectives the same way.
+                    # Mirror the active-rank broaden in eagle.py: some draft
+                    # models narrow for any non-idle catch-up, so idle peers
+                    # must size collectives the same way.
                     draft_first_step_reduce=(
                         step_idx == 0
-                        and (
-                            all_decode_or_idle
-                            or isinstance(
-                                self.drafter.draft_model_runner.model,
-                                (
-                                    LlamaForCausalLMEagle3,
-                                    Qwen3_5ForConditionalGenerationNextN,
-                                ),
-                            )
-                        )
+                        and (all_decode_or_idle or draft_reduces_first_step_catchup)
                     ),
                 )
                 self.drafter.draft_model_runner.forward(

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -1911,6 +1911,8 @@ class Eagle3DeepseekV2ForCausalLM(DeepseekV3ForCausalLM):
     concatenated [embeds || hidden_states] as input.
     """
 
+    draft_first_step_reduce_for_catchup = True
+
     def __init__(
         self,
         config: PretrainedConfig,

--- a/python/tokenspeed/runtime/models/llama_eagle3.py
+++ b/python/tokenspeed/runtime/models/llama_eagle3.py
@@ -510,6 +510,7 @@ class Eagle3LlamaModel(BaseTransformerModel):
 
 class LlamaForCausalLMEagle3(BaseCausalLM):
 
+    draft_first_step_reduce_for_catchup = True
     model_cls = Eagle3LlamaModel
 
     def __init__(

--- a/python/tokenspeed/runtime/models/qwen3_5_nextn.py
+++ b/python/tokenspeed/runtime/models/qwen3_5_nextn.py
@@ -147,6 +147,8 @@ class Qwen3_5DraftForCausalLM(Qwen3_5ForCausalLM):
 
 
 class Qwen3_5ForConditionalGenerationNextN(nn.Module):
+    draft_first_step_reduce_for_catchup = True
+
     def __init__(
         self,
         config: PretrainedConfig,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/lm_head_gemm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/lm_head_gemm.py
@@ -101,7 +101,7 @@ def is_supported(
 
     Capability gate (does the .so have it?), independent of perf:
       * bf16 only
-      * M = num_tokens <= num_tokens_max (default 16)
+      * 0 < M = num_tokens <= num_tokens_max (default 16)
       * (K, N) = (hidden_dim, vocab_shard) matches a compiled instantiation
       * CC >= 9.0 (Hopper or newer; uses HMMA + cp.async + mbarrier + PDL)
     """
@@ -113,7 +113,7 @@ def is_supported(
         return False
     num_tokens, hd_in = hidden_states.shape
     hd_out, hd_in_w = weight.shape
-    if hd_in != hd_in_w or num_tokens > num_tokens_max:
+    if hd_in != hd_in_w or num_tokens <= 0 or num_tokens > num_tokens_max:
         return False
     if (hd_in, hd_out) not in _SUPPORTED_SHAPES:
         return False
@@ -142,7 +142,7 @@ def should_use_fused(
     hd_in = hidden_states.shape[1]
     hd_out = weight.shape[0]
     cap = _FUSED_MAX_TOKENS.get((hd_in, hd_out), 0)
-    return num_tokens <= cap
+    return 0 < num_tokens <= cap
 
 
 def lm_head_gemm(
@@ -178,6 +178,8 @@ def lm_head_gemm(
         assert out.is_contiguous()
         assert out.shape == (num_tokens, hd_out)
         assert out.dtype == torch.bfloat16
+    if num_tokens == 0:
+        return out
     # tile_n=8 is the minimum-latency config for M<=8; tile_n=16 amortizes
     # the store/epilogue when M>8.
     tile_n = 8 if num_tokens <= 8 else 16


### PR DESCRIPTION
## Summary

Fixes a Kimi K2.5 DP + EAGLE3 hang when different DP ranks enter different forward modes in the same scheduler step. In the failing case, some ranks were in EXTEND while others were in DECODE. EAGLE3 first-step catch-up narrows activations to one row per request before later draft collectives, but the runtime only applied that reduced sizing on decode ranks. This could make ranks in the same DP step size draft collectives differently and hang.

This PR makes first-step catch-up reduction an explicit draft-model capability and uses it consistently for both active EAGLE forward and idle draft replay. It also guards fused `lm_head_gemm` against zero-token routing / launch.

## Changes

- Add `draft_first_step_reduce_for_catchup` capability to EAGLE/NextN draft models.
- Use the same capability predicate in active EAGLE forward and idle draft replay.
- Guard fused `lm_head_gemm` against zero-token routing / launch.

## Validation

- Before fix: DP8 + EAGLE3 hang.
- After fix: DP8 + EAGLE3 AIME25 completed with mean_acc 0.9333 (28/30).
- Ran `git diff --check` and import/capability smoke.
