### PR TITLE
feat: breakable CUDA graph for prefill forwards

### DIFF
--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -139,6 +139,7 @@ class DpForwardMetadata:
     global_batch_size: list[int]
     global_forward_mode: list[int]
     all_decode_or_idle: bool
+    all_extend: bool
     need_idle_forward: bool
 
 
@@ -668,6 +669,7 @@ class EventLoop:
         dp_all_decode_or_idle = (
             dp_metadata.all_decode_or_idle if dp_metadata is not None else False
         )
+        dp_all_extend = dp_metadata.all_extend if dp_metadata is not None else False
         multimodal_context = self._get_multimodal_context_for_forward(forward_op)
 
         self.model_executor.update_block_table(forward_op)
@@ -682,6 +684,7 @@ class EventLoop:
                     dp_global_num_tokens=dp_global_num_tokens,
                     dp_global_bs=dp_global_bs,
                     dp_all_decode_or_idle=dp_all_decode_or_idle,
+                    dp_all_extend=dp_all_extend,
                     grammar_inputs=grammar_inputs,
                     multimodal_context=multimodal_context,
                     **stats,
@@ -712,6 +715,7 @@ class EventLoop:
                         dp_global_num_tokens=dp_global_num_tokens,
                         dp_global_bs=dp_global_bs,
                         dp_all_decode_or_idle=dp_all_decode_or_idle,
+                        dp_all_extend=dp_all_extend,
                         multimodal_context=multimodal_context,
                         **stats,
                     ),
@@ -737,6 +741,7 @@ class EventLoop:
                         dp_global_num_tokens=dp_global_num_tokens,
                         dp_global_bs=dp_global_bs,
                         dp_all_decode_or_idle=dp_all_decode_or_idle,
+                        dp_all_extend=dp_all_extend,
                         grammar_inputs=grammar_inputs,
                         multimodal_context=multimodal_context,
                         capture_next_input_ids=True,
@@ -1219,11 +1224,16 @@ class EventLoop:
             )
             for mode in global_forward_mode
         )
+        # Replicated prefill-graph gate (see PrefillGraph._select_bucket).
+        all_extend = all(
+            mode == int(ForwardMode.EXTEND) for mode in global_forward_mode
+        )
         return DpForwardMetadata(
             global_num_tokens=global_num_tokens,
             global_batch_size=global_batch_size,
             global_forward_mode=global_forward_mode,
             all_decode_or_idle=all_decode_or_idle,
+            all_extend=all_extend,
             need_idle_forward=need_idle_forward,
         )
 

--- a/python/tokenspeed/runtime/execution/breakable_cuda_graph.py
+++ b/python/tokenspeed/runtime/execution/breakable_cuda_graph.py
@@ -1,0 +1,452 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Breakable CUDA graph capture for variable-shape (prefill / extend) forwards.
+
+A *breakable* CUDA graph captures a forward as an ordered list of zero-arg
+callables -- each is either a captured ``CUDAGraph.replay`` (a "graph segment")
+or an eager Python function (a "break"). At designated break points (attention /
+KV-cache ops, whose metadata is data-dependent and cannot be captured) the
+current stream capture is ended, the op runs eagerly, and a fresh segment begins
+capturing the remainder. Replay simply calls each segment in order.
+
+This is the ``torch.compile``-free alternative to piecewise CUDA graphs. The
+design is gratefully adapted from vLLM and SGLang, who pioneered the breakable
+prefill graph: vLLM's ``BreakableCUDAGraphWrapper`` (the homogeneous segment-list
+structure + the ``set_forward_context``/``get_forward_context`` ambient pattern we
+mirror in :func:`active_forward`/:func:`current_forward_ctx`) and SGLang's
+breakable prefill graph (the eager-copy output handoff at each break). Unlike a
+full prefill graph, attention -- the only batch/length-aware op and the source of
+the host-side ``max_seq_len_q`` scalar -- stays eager, so it never enters a graph.
+Keeping all KV-cache reads/writes in the eager breaks also makes them honor the
+per-layer transfer consumer index naturally.
+
+Address-stability contract (the load-bearing invariant):
+
+* All segments share one CUDA mempool, so graph-allocated intermediates keep
+  stable device addresses across replays.
+* The runner must copy live inputs into the *same* static input buffers used at
+  capture before calling :meth:`BreakableCapture.replay`.
+* Break-point outputs must land at the *same* address each replay. We achieve
+  this by allocating a destination buffer in the captured segment (pool-pinned)
+  and copying the eager op's result into it; the next segment reads that address.
+"""
+
+from __future__ import annotations
+
+import functools
+import gc
+from collections import deque
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import torch
+from tokenspeed_kernel.ops.transform.weak_ref import weak_ref_tensor as _kernel_weak_ref
+
+__all__ = [
+    "BreakableCapture",
+    "active_forward",
+    "break_here",
+    "break_point",
+    "current_forward_ctx",
+    "is_breakable_capture_active",
+    "scrub_padding_tail",
+    "slice_to_real_tokens",
+    "weak_ref_tensor",
+]
+
+
+# Ambient per-forward ctx; plain module state (one launch thread per rank).
+_ambient_ctx: Any = None
+
+
+@contextmanager
+def active_forward(ctx: Any) -> Iterator[None]:
+    """Publish ``ctx`` as the ambient forward context for the enclosed block.
+
+    An eager break runs once at capture and again on every replay, and the args
+    it closed over at capture are the *dummy* batch's, hence stale. Rather than
+    thread the live context through ``replay()`` (which would conflate graph
+    mechanics with forward semantics), the runner wraps capture and each replay
+    in this, and breaks rebind their captured context arg to the ambient one by
+    identity (see :func:`break_here`) -- so break bodies read live ``ctx``
+    fields exactly like the eager path. Re-entrant (saves/restores the
+    previous value).
+    """
+    global _ambient_ctx
+    prev = _ambient_ctx
+    _ambient_ctx = ctx
+    try:
+        yield
+    finally:
+        _ambient_ctx = prev
+
+
+def current_forward_ctx() -> Any:
+    """The ambient forward context, or ``None`` outside an :func:`active_forward`."""
+    return _ambient_ctx
+
+
+def weak_ref_tensor(t: Any) -> Any:
+    """Reference a break-point tensor without pinning its cudagraph mempool slot.
+
+    CUDA tensors are wrapped in a non-owning view (``tokenspeed_kernel``
+    ``ops.transform.weak_ref``, an ``at::from_blob`` alias -- the vLLM/sglang
+    approach), so break closures do not pin pool blocks and graph capture
+    memory stays ~peak-live instead of scaling with the bucket sum. Safe
+    because replay is stream-ordered: the captured segment rewrites the
+    aliased address before the break reads it. Non-tensors and CPU tensors
+    pass through; if the kernel extension is unavailable this degrades to
+    the identity (strong ref -- correct, more memory).
+    """
+    if isinstance(t, torch.Tensor) and t.is_cuda:
+        return _kernel_weak_ref(t)
+    return t
+
+
+class BreakableCapture:
+    """Context manager that captures a breakable graph.
+
+    Usage::
+
+        cap = BreakableCapture(pool=shared_pool)
+        with cap:
+            model_forward(...)        # attention calls hit break_here()
+        # later, after copying live inputs into the static buffers:
+        cap.replay()
+
+    Args:
+        pool: An optional CUDA mempool id (as returned by
+            ``torch.cuda.graph_pool_handle()`` or ``CUDAGraph.pool()``) shared by
+            all segments. If ``None``, the first segment allocates a fresh pool
+            and the rest reuse it.
+        stream: An optional dedicated capture stream. CUDA forbids stream capture
+            on the default stream; if ``None``, a single class-level side stream is
+            (lazily) created and SHARED by all captures. Sharing one capture stream
+            is load-bearing for memory: the caching allocator's pool blocks are
+            stream-keyed, so captures on different streams can never reuse each
+            other's freed blocks -- a fresh stream per capture makes graph-pool
+            memory grow with the SUM of bucket sizes instead of the max (measured:
+            2478MB -> 564MB for buckets [8192,4096,2048,1024] on the repro). This
+            mirrors ``torch.cuda.graph``'s shared ``default_capture_stream`` and
+            its documented "pass the same stream for effective memory sharing".
+    """
+
+    _active: BreakableCapture | None = None
+    _default_capture_stream: torch.cuda.Stream | None = None
+
+    def __init__(
+        self, pool: Any | None = None, stream: torch.cuda.Stream | None = None
+    ) -> None:
+        self.pool = pool
+        self.segments: list[Callable[[], Any]] = []
+        self._current_graph: torch.cuda.CUDAGraph | None = None
+        self._capturing = False
+        if stream is None:
+            if BreakableCapture._default_capture_stream is None:
+                BreakableCapture._default_capture_stream = torch.cuda.Stream()
+            stream = BreakableCapture._default_capture_stream
+        self._stream = stream
+        self._stream_ctx: Any | None = None
+        # Break-output handoff buffers keyed by (shape, dtype, device); see break_point.
+        self._handoff: dict[Any, torch.Tensor] = {}
+
+    @classmethod
+    def current(cls) -> BreakableCapture | None:
+        return cls._active
+
+    # -- capture lifecycle -------------------------------------------------
+
+    def __enter__(self) -> BreakableCapture:
+        if BreakableCapture.current() is not None:
+            raise RuntimeError("Nested BreakableCapture is not supported.")
+        # A GC run during capture invalidates it: destructors of collected
+        # CUDA graphs call reset, which is illegal while a stream is capturing.
+        # Clear pending garbage, then keep automatic GC off for the whole
+        # capture window (restored in __exit__).
+        gc.collect()
+        self._gc_was_enabled = gc.isenabled()
+        gc.disable()
+        # The capture stream must observe prior entry-stream work (warmup, buffers).
+        self._stream.wait_stream(torch.cuda.current_stream())
+        self._stream_ctx = torch.cuda.stream(self._stream)
+        self._stream_ctx.__enter__()
+        BreakableCapture._active = self
+        self._begin_segment()
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        try:
+            self._end_segment()
+        finally:
+            BreakableCapture._active = None
+            if self._stream_ctx is not None:
+                self._stream_ctx.__exit__(*exc)
+                self._stream_ctx = None
+            # Eager breaks ran on the side stream; entry stream must observe them.
+            torch.cuda.current_stream().wait_stream(self._stream)
+            if self._gc_was_enabled:
+                gc.enable()
+        return False
+
+    def _begin_segment(self) -> None:
+        assert not self._capturing
+        graph = torch.cuda.CUDAGraph()
+        if self.pool is not None:
+            graph.capture_begin(pool=self.pool)
+        else:
+            graph.capture_begin()
+        self._current_graph = graph
+        self._capturing = True
+
+    def _end_segment(self) -> None:
+        if not self._capturing:
+            return
+        assert self._current_graph is not None
+        self._current_graph.capture_end()
+        self.segments.append(self._current_graph.replay)
+        # All segments share one pool so intermediate addresses stay stable.
+        if self.pool is None:
+            self.pool = self._current_graph.pool()
+        self._current_graph = None
+        self._capturing = False
+
+    def add_eager(self, fn: Callable[[], Any]) -> Any:
+        """End the current segment, run ``fn`` eagerly, record it, start a new one.
+
+        ``fn`` is a zero-arg callable that performs the break-point op and writes
+        its result into a stable (pool-pinned) address. It is stored verbatim and
+        re-invoked on every :meth:`replay`.
+        """
+        assert self._capturing, "add_eager called outside an active capture"
+        self._end_segment()
+        result = fn()
+        self.segments.append(fn)
+        self._begin_segment()
+        return result
+
+    # -- replay ------------------------------------------------------------
+
+    def replay(self) -> None:
+        """Replay all segments in order.
+
+        Breaks read the live forward context from the ambient :func:`active_forward`
+        scope (the runner wraps replay in it), so this stays a pure graph primitive.
+        """
+        deque((run() for run in self.segments), maxlen=0)
+
+    @property
+    def num_segments(self) -> int:
+        return len(self.segments)
+
+
+def is_breakable_capture_active() -> bool:
+    """True while a :class:`BreakableCapture` is open AND currently capturing."""
+    cap = BreakableCapture.current()
+    return cap is not None and cap._capturing
+
+
+def _record_break(
+    cap: BreakableCapture,
+    fn: Callable[..., torch.Tensor],
+    resolve_dst: Callable[[torch.Tensor], torch.Tensor],
+    args: tuple,
+    kwargs: dict,
+) -> torch.Tensor:
+    """Record ``fn(*args, **kwargs)`` as an eager break on ``cap`` (the one closure
+    builder shared by :func:`break_here` and :func:`break_point`).
+
+    Args/kwargs are bound once at capture time, with two live exceptions: (1) tensor
+    args alias persistent storage (the static input buffers / pool-pinned segment
+    intermediates), so they carry live values at replay -- ``weak_ref_tensor`` is
+    the (currently identity) hook to avoid pinning their pool slots; (2) the
+    per-forward ``ForwardContext`` is rebound by identity to the live ambient
+    context each replay (see :func:`active_forward`), so ``fn`` may read live
+    ``ctx`` fields exactly like the eager path. **Other (loose) non-tensor scalars
+    are frozen** to their capture-time value -- route per-request quantities
+    through ``ctx`` / ``forward_*_metadata`` rather than a bare scalar arg.
+
+    ``resolve_dst(result)`` maps the break's first output to its stable handoff
+    buffer; it is called once (on the capture-time invocation) and the buffer is
+    reused verbatim on every replay, where the (possibly shorter, see
+    :func:`_land_in`) live result is copied into it.
+    """
+    weak_args = tuple(weak_ref_tensor(a) for a in args)
+    weak_kwargs = {k: weak_ref_tensor(v) for k, v in kwargs.items()}
+    # Capture-time ambient ctx (the dummy batch's), rebound live at replay.
+    captured_ctx = current_forward_ctx()
+    state: dict[str, torch.Tensor] = {}
+
+    def replay_fn() -> torch.Tensor:
+        live_ctx = current_forward_ctx()
+
+        def sub(a: Any) -> Any:
+            return live_ctx if a is captured_ctx else a
+
+        result = fn(
+            *(sub(a) for a in weak_args),
+            **{k: sub(v) for k, v in weak_kwargs.items()},
+        )
+        dst = state.get("dst")
+        if dst is None:
+            dst = state["dst"] = resolve_dst(result)
+        _land_in(dst, result)
+        return dst
+
+    return cap.add_eager(replay_fn)
+
+
+def break_here(
+    fn: Callable[..., torch.Tensor],
+    dst: torch.Tensor,
+    *args: Any,
+    **kwargs: Any,
+) -> torch.Tensor:
+    """Run ``fn(*args, **kwargs)`` as an eager break, landing its result in ``dst``.
+
+    The low-level explicit-destination primitive underneath :func:`break_point`
+    (which is the decorator every model actually uses -- prefer it; this exists
+    for callers that must control the handoff buffer's placement themselves, e.g.
+    a pool-pinned ``dst`` allocated in the current captured segment, and for
+    exercising the break mechanics directly in unit tests).
+
+    ``dst`` must have a replay-stable address (pool-pinned or persistently owned).
+    At capture and on every replay, ``fn`` runs eagerly and its result is copied
+    into ``dst`` (unless ``fn`` already wrote ``dst`` in place and returned it);
+    the following graph segment reads ``dst``. Outside an active capture this is
+    a transparent pass-through. Argument binding/freezing semantics are those of
+    :func:`_record_break`.
+
+    Returns:
+        ``dst`` (the stable handoff buffer).
+    """
+    cap = BreakableCapture.current()
+    if cap is None or not cap._capturing:
+        _land_in(dst, fn(*args, **kwargs))
+        return dst
+    weak_dst = weak_ref_tensor(dst)
+    return _record_break(cap, fn, lambda _result: weak_dst, args, kwargs)
+
+
+def break_point(method: Callable | None = None) -> Callable:
+    """Mark a sequence-mixing method as an eager breakable-graph break point.
+
+    Decorate a sequence-mixing method (attention / MLA / linear-mixer / sparse
+    indexer ``forward``) and it runs as an eager break under a breakable capture --
+    the surrounding token-shaped compute (norms, MoE, projections, collectives) is
+    captured around it automatically, while everything inside the method stays
+    eager -- or a zero-overhead direct call when not capturing. This is the one
+    decorator every model uses to mark a break. Use it bare: ``@break_point``.
+
+    The handoff buffer's shape/dtype/device are **inferred from the method's actual
+    output** at capture time (the break runs during capture regardless), so no
+    output spec is needed -- it works uniformly for breaks whose output matches no
+    input (MLA: ``[tokens, heads*v_head_dim]`` vs ``q``'s ``[tokens, heads*qk_head_dim]``)
+    and for one wrapper that returns different shapes per call (e.g. hybrid full-attn
+    q-shaped vs GDN z-shaped). Buffers live in a per-capture shape-keyed cache
+    (:attr:`BreakableCapture._handoff`), shared across same-shape breaks. That
+    sharing relies on break outputs having strictly sequential lifetimes -- break
+    K's output is consumed by K's following segment before break K+1 runs (true
+    for transformer topology, where attention output feeds the adjacent
+    o-proj/residual). A model whose break output is read by a LATER segment must
+    not share its shape with an intervening break, or replay silently corrupts.
+
+    Inside the method ``ctx`` is live (rebound by identity at replay), so write the
+    body exactly like the eager path. Loose non-tensor scalar args are frozen to
+    their capture-time value -- route per-request quantities through ``ctx`` / metadata.
+    The decorator never skips the method: 0-row / idle batches remain each decorated
+    model method's own explicit guard, on the eager path and under capture alike.
+    """
+
+    def decorator(method: Callable) -> Callable:
+        @functools.wraps(method)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            # Zero-overhead passthrough off the capture path (no 0-row skipping here).
+            if not is_breakable_capture_active():
+                return method(*args, **kwargs)
+            cap = BreakableCapture.current()
+
+            def resolve_dst(result: torch.Tensor) -> torch.Tensor:
+                # Handoff buffer inferred from the capture-time output, shape-keyed.
+                key = (tuple(result.shape), result.dtype, result.device)
+                dst = cap._handoff.get(key)
+                if dst is None:
+                    dst = cap._handoff[key] = torch.empty(
+                        result.shape, dtype=result.dtype, device=result.device
+                    )
+                return dst
+
+            return _record_break(cap, method, resolve_dst, args, kwargs)
+
+        return wrapper
+
+    return decorator(method) if method is not None else decorator
+
+
+# -- padded-input helpers (the two strategies of the prefill padding contract) --
+
+
+def scrub_padding_tail(num_real_tokens: int, *tensors: torch.Tensor | None) -> None:
+    """Zero the padded tail rows ``[num_real_tokens:]`` of token-shaped tensors in place.
+
+    Under a padded-bucket replay, an eager break receives ``bucket`` rows whose
+    tail holds garbage (it grows across layers and can overflow to NaN through
+    projections / FP8 quantize). Zeroing suits breaks whose kernel honors the
+    live cu-seqlens but whose surrounding ops (varlen attention read, recurrent
+    scan writeback, FP8 quantize) would otherwise touch the garbage rows. Pass
+    the real token count from the live metadata's CPU mirror (sync-free on the
+    launch thread); a no-op on unpadded forwards, and ``None`` tensors are
+    skipped.
+    """
+    for t in tensors:
+        if t is not None and num_real_tokens < t.shape[0]:
+            t[num_real_tokens:].zero_()
+
+
+def slice_to_real_tokens(num_real_tokens: int, *tensors: torch.Tensor | None):
+    """Return ``tensors`` (in order) each sliced to the real leading rows ``[:num_real_tokens]``.
+
+    The slice-strategy counterpart to :func:`scrub_padding_tail`, for coarse breaks whose
+    kernel asserts the input row count equals the live metadata token count (e.g. DSA
+    sparse attention). A tensor already the right length (or ``None``) is returned
+    unchanged.
+    """
+    return tuple(
+        t[:num_real_tokens] if (t is not None and num_real_tokens < t.shape[0]) else t
+        for t in tensors
+    )
+
+
+def _land_in(dst: torch.Tensor, result: torch.Tensor) -> None:
+    """Copy ``result`` into ``dst`` at a stable address.
+
+    ``dst`` is the (possibly token-padded) handoff buffer the next graph segment
+    reads. ``result`` may cover only the real (unpadded) leading rows -- e.g. a
+    varlen attention kernel writes only ``sum(cu_seqlens_q)`` rows -- so we copy
+    into the matching leading slice. Padded rows are left as-is (discarded by the
+    final output slice). No-op when the op already wrote ``dst`` in place.
+    """
+    if result is dst:
+        return
+    if result.shape == dst.shape:
+        dst.copy_(result)
+    else:
+        dst.narrow(0, 0, result.shape[0]).copy_(result)

--- a/python/tokenspeed/runtime/execution/context.py
+++ b/python/tokenspeed/runtime/execution/context.py
@@ -60,6 +60,7 @@ class ForwardContext:
     global_num_tokens: list[int] | None = None
     global_bs: list[int] | None = None
     all_decode_or_idle: bool = False
+    all_extend: bool = False
 
     # --- logits processor ---
     gather_ids: torch.Tensor | None = None
@@ -73,3 +74,7 @@ class ForwardContext:
     # DSA sparse top-k shared across layers and draft steps.
     dsa_prefill_topk: Any | None = None
     dsa_decode_topk: Any | None = None
+
+    # DSA SWA slot mapping + compressor memo, computed once per forward, shared across layers.
+    dsa_swa_slot_mapping: torch.Tensor | None = None
+    dsa_compressor_slot_cache: Any | None = None

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import torch
+from tokenspeed_kernel.ops.tuning import freeze_autotuning
 from tokenspeed_kernel.platform import current_platform
 
 from tokenspeed.runtime.configs.model_config import ModelConfig
@@ -45,6 +46,7 @@ from tokenspeed.runtime.execution.forward_batch_info import (
 from tokenspeed.runtime.execution.input_buffer import InputBuffers
 from tokenspeed.runtime.execution.model_runner import ModelRunner
 from tokenspeed.runtime.execution.nan_guard import NanGuard
+from tokenspeed.runtime.execution.prefill_graph import PrefillGraph
 from tokenspeed.runtime.execution.runtime_states import RuntimeStates
 from tokenspeed.runtime.execution.types import ModelExecutionResult
 from tokenspeed.runtime.grammar.capturable_grammar import setup_grammar_step
@@ -152,6 +154,13 @@ class ModelExecutorConfig:
     disable_capturable_grammar: bool = False
     mamba_cache_chunk_size: int = 64
 
+    # ====== PREFILL CUDA GRAPH (breakable) =========
+    disable_prefill_graph: bool = False
+    # Opt-in: > 0 enables the prefill graph and caps the largest token bucket.
+    prefill_graph_max_tokens: int = 0
+    # Explicit bucket list overriding the ladder (see get_prefill_token_buckets).
+    prefill_graph_capture_sizes: list[int] | None = None
+
     @staticmethod
     def from_server_args(
         server_args: ServerArgs,
@@ -187,6 +196,9 @@ class ModelExecutorConfig:
             cudagraph_capture_sizes=server_args.cudagraph_capture_sizes,
             disable_cuda_graph_padding=server_args.disable_cuda_graph_padding,
             max_cudagraph_capture_size=server_args.max_cudagraph_capture_size,
+            disable_prefill_graph=bool(server_args.disable_prefill_graph),
+            prefill_graph_max_tokens=int(server_args.prefill_graph_max_tokens or 0),
+            prefill_graph_capture_sizes=server_args.prefill_graph_capture_sizes,
             model_is_mrope=model_is_mrope,
             data_parallel_size=server_args.mapping.attn.dp_size,
             world_size=server_args.mapping.world_size,
@@ -458,6 +470,20 @@ class ModelExecutor:
             runtime_states=self.runtime_states,
         )
 
+        # Breakable prefill (extend) CUDA graphs, the extend-mode analogue of
+        # the decode wrapper above; captures in __init__, borrowing the decode
+        # capture stream so all graphs share one mempool-reuse domain.
+        self.prefill_graph = PrefillGraph(
+            model_runner=self.model_runner,
+            attn_backend=attn_backend,
+            token_to_kv_pool=token_to_kv_pool,
+            input_buffers=self.input_buffers,
+            config=config,
+            req_to_page=self.req_to_page,
+            drafter=self.drafter,
+            decode_wrapper=self.forward_step,
+        )
+
         # Encoder CUDA graph: install model-built wrappers by overriding
         # modality encoder callables (e.g. ``image_encoder``, ``video_encoder``).
         # Multimodal-encoder analogue of ``forward_step``'s ``CudaGraphWrapper``.
@@ -519,6 +545,9 @@ class ModelExecutor:
 
         set_random_seed(48)
 
+        # Startup has tuned every size class it serves; serving must never autotune.
+        freeze_autotuning()
+
         logger.info("ModelExecutor initialized")
 
     @staticmethod
@@ -569,6 +598,23 @@ class ModelExecutor:
                 ]
             else:
                 positions = self.input_buffers.positions_buf[: ctx.input_num_tokens]
+        # Prefill-graph replay when captured for this forward (the decode graph
+        # replays one level up: it captures the whole _forward_step). The mode
+        # check is LOAD-BEARING, not an optimization: the decode capture runs
+        # this dispatch before prefill_graph exists (it is constructed after
+        # the decode wrapper, whose capture stream it borrows), and decode-mode
+        # forwards must short-circuit before touching it.
+        mode = ctx.forward_mode
+        if (
+            mode is not None
+            and (mode.is_extend() or mode.is_mixed())
+            and self.prefill_graph.can_run(ctx, self._active_multimodal_context)
+        ):
+            return self.prefill_graph.replay(
+                ctx,
+                self.input_buffers.input_ids_buf[: ctx.input_num_tokens],
+                self._active_multimodal_context,
+            )
         return self.model_runner.forward(
             ctx,
             self.input_buffers.input_ids_buf[: ctx.input_num_tokens],
@@ -1054,6 +1100,7 @@ class ModelExecutor:
         dp_global_num_tokens=None,
         dp_global_bs=None,
         dp_all_decode_or_idle: bool = False,
+        dp_all_extend: bool = False,
         grammar_inputs=None,
         multimodal_context=None,
         capture_next_input_ids: bool = False,
@@ -1093,6 +1140,7 @@ class ModelExecutor:
             dp_global_num_tokens,
             dp_global_bs,
             dp_all_decode_or_idle,
+            dp_all_extend,
             grammar_inputs=grammar_inputs,
             multimodal_context=multimodal_context,
             capture_next_input_ids=capture_next_input_ids,
@@ -1516,6 +1564,7 @@ class ModelExecutor:
         dp_global_num_tokens=None,
         dp_global_bs=None,
         dp_all_decode_or_idle: bool = False,
+        dp_all_extend: bool = False,
         grammar_inputs=None,
         multimodal_context=None,
         capture_next_input_ids: bool = False,
@@ -1665,6 +1714,7 @@ class ModelExecutor:
                     ctx.global_num_tokens = dp_global_num_tokens
                     ctx.global_bs = dp_global_bs
                     ctx.all_decode_or_idle = dp_all_decode_or_idle
+                    ctx.all_extend = dp_all_extend
                 with nvtx_range("sampling_prep", color="yellow"):
                     sampling_start = time.perf_counter() if timing_enabled else 0.0
                     sampling_info = self._build_sampling_info(bs, sampling_params_list)

--- a/python/tokenspeed/runtime/execution/prefill_graph.py
+++ b/python/tokenspeed/runtime/execution/prefill_graph.py
@@ -1,0 +1,645 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Breakable CUDA graphs for prefill (extend) forwards.
+
+:class:`PrefillGraph` holds one breakable graph per padded token bucket
+(captured from a dummy bs=1 extend batch). The embedding lookup stays OUTSIDE
+the captured region: graphs start from a static input-embeds buffer, filled at
+replay by an eager ``embed_tokens`` gather (text) or by precomputed merged
+embeddings (multimodal, via the model's ``multimodal_input_embeds`` seam).
+Constructed after the decode
+:class:`~tokenspeed.runtime.execution.cuda_graph_wrapper.CudaGraphWrapper`,
+borrowing its capture stream so all graphs share one mempool. At serving time
+the executor's target-forward dispatch is a flat
+three-way -- decode & captured replays the decode graph (one level up, since
+it captures the whole step), prefill & captured replays here (:meth:`can_run`
+/ :meth:`replay`), everything else runs the eager model forward.
+
+Unlike decode (whole forward captured, keyed by batch size), the captured
+region here is purely token-shaped compute keyed by total token count:
+attention runs as an eager break (see
+:mod:`tokenspeed.runtime.execution.breakable_cuda_graph`), so one graph per
+bucket serves any batch size at that token count, and a replayed forward is
+finished with the model's eager logits tail.
+"""
+
+from __future__ import annotations
+
+import bisect
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, NamedTuple
+
+import torch
+
+from tokenspeed.runtime.execution import cuda_graph_wrapper as _cuda_graph_wrapper
+from tokenspeed.runtime.execution.breakable_cuda_graph import (
+    BreakableCapture,
+    active_forward,
+)
+from tokenspeed.runtime.execution.context import ForwardContext
+from tokenspeed.runtime.execution.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardMode,
+)
+from tokenspeed.runtime.layers.logits_processor import LogitsMetadata
+from tokenspeed.runtime.utils import get_colorful_logger
+from tokenspeed.runtime.utils.common import maybe_inference_mode
+
+logger = get_colorful_logger(__name__)
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.execution.cuda_graph_wrapper import CudaGraphWrapper
+    from tokenspeed.runtime.execution.input_buffer import InputBuffers
+    from tokenspeed.runtime.execution.model_executor import ModelExecutorConfig
+    from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
+
+
+# Smallest prefill bucket; below this, denser rungs would only add capture time.
+PREFILL_BUCKET_FLOOR: int = 16
+
+# Relative rung spacing (largest pow2 <= size/8), bounding the padded tail at ~12.5%.
+PREFILL_BUCKET_STEP_DIVISOR: int = 8
+
+# Absolute rung-spacing cap, bounding the worst case at the top of the ladder.
+PREFILL_BUCKET_MAX_STEP: int = 512
+
+
+def get_prefill_token_buckets(config: ModelExecutorConfig) -> list[int]:
+    """Padded token-count buckets to capture for the breakable prefill graph.
+
+    Unlike decode (keyed by batch size), the breakable prefill graph captures
+    pure token-shaped compute, so it is keyed by total token count. A live extend
+    forward is padded up to the smallest bucket >= its token count; forwards above
+    the largest bucket run eager.
+
+    Returns an empty list (graph disabled) when ``disable_prefill_graph`` is set or
+    ``prefill_graph_max_tokens <= 0``. The largest bucket is clamped to the
+    chunked-prefill size: the scheduler's per-forward token budget
+    (``max_scheduled_tokens`` = chunked-prefill size) covers extends AND any fused
+    decode rows -- with mixed batching, decodes are scheduled first and each
+    decrements the budget, and the prefill chunk is sized to what remains
+    (scheduler ``newForwardOperation``/``push_op``) -- so no forward, mixed or
+    pure, ever exceeds the chunk. No headroom above it is needed.
+
+    The default ladder bounds RELATIVE padding waste: a forward pads its graphed
+    compute to the next bucket, so what matters is the gap as a fraction of the
+    size -- a flat stride is needlessly coarse for short prompts and needlessly
+    dense at the top. Each bucket's step is the largest power of two <= size/8
+    (padded tail at most ~12.5% anywhere on the ladder), floored at 16 tokens and
+    capped at 512 so the absolute worst case stays bounded at the top end. Dense
+    ladders are cheap: all captures share one stream + mempool, so graph memory
+    is ~the largest bucket's peak regardless of bucket count (see
+    ``BreakableCapture``); the remaining cost is ~0.5s of startup capture per
+    bucket.
+
+    ``prefill_graph_capture_sizes`` overrides the ladder with an explicit list
+    (mirroring decode's ``cudagraph_capture_sizes``) -- e.g. a short list for
+    faster startup on dev boots; sizes are clamped to the largest bucket.
+
+    Args:
+        config: The model-executor config carrying ``disable_prefill_graph``,
+            ``prefill_graph_max_tokens``, ``prefill_graph_capture_sizes`` and
+            ``chunked_prefill_size``.
+
+    Returns:
+        Sorted ascending list of token-bucket sizes (possibly empty).
+    """
+    max_tokens = int(config.prefill_graph_max_tokens or 0)
+    if config.disable_prefill_graph or max_tokens <= 0:
+        return []
+    chunk = int(config.chunked_prefill_size or 0)
+    if chunk > 0:
+        max_tokens = min(max_tokens, chunk)
+    explicit = config.prefill_graph_capture_sizes
+    if explicit:
+        buckets = {int(b) for b in explicit if 0 < int(b) <= max_tokens}
+        buckets.add(max_tokens)
+        return sorted(buckets)
+    buckets = []
+    size = min(PREFILL_BUCKET_FLOOR, max_tokens)
+    while size < max_tokens:
+        buckets.append(size)
+        size += _prefill_bucket_step(size)
+    buckets.append(max_tokens)
+    return sorted(set(buckets))
+
+
+def _prefill_bucket_step(size: int) -> int:
+    """Distance from bucket ``size`` to the next rung.
+
+    The largest power of two <= ``size / PREFILL_BUCKET_STEP_DIVISOR`` (so the
+    padded tail stays within ~1/8 of the real token count), clamped between
+    ``PREFILL_BUCKET_FLOOR`` and ``PREFILL_BUCKET_MAX_STEP``.
+    """
+    relative = size // PREFILL_BUCKET_STEP_DIVISOR
+    if relative <= PREFILL_BUCKET_FLOOR:
+        return PREFILL_BUCKET_FLOOR
+    largest_pow2 = 1 << (relative.bit_length() - 1)
+    return min(largest_pow2, PREFILL_BUCKET_MAX_STEP)
+
+
+class CapturedForward(NamedTuple):
+    """A bucket's captured inner-forward outputs (stable pool addresses)."""
+
+    # Final hidden states with shape [bucket, hidden]; padded tail is garbage.
+    hidden_states: torch.Tensor
+
+    # Aux hidden states for drafting, each [bucket, hidden]; None when mode is NULL.
+    aux_hidden_states: list[torch.Tensor] | None
+
+    def sliced(self, num_tokens: int) -> tuple[torch.Tensor, list[torch.Tensor] | None]:
+        """The leading real-token rows, in the (hidden, aux) shape callers expect."""
+        hidden = self.hidden_states[:num_tokens]
+        if self.aux_hidden_states is None:
+            return hidden, None
+        return hidden, [a[:num_tokens] for a in self.aux_hidden_states]
+
+
+class PrefillGraph:
+    """The breakable prefill (extend) CUDA graphs.
+
+    A pure graph object -- :meth:`can_run` / :meth:`replay` -- holding no
+    reference to any other component. Constructed AFTER the decode
+    ``CudaGraphWrapper`` and captures in ``__init__`` like it: the decode
+    wrapper is used transiently for its capture stream and dummy paged-cache
+    tables, not kept. (The executor's target-forward dispatch therefore mode-
+    checks before touching this object -- decode capture runs that dispatch
+    while this object does not exist yet.) The dispatch checks :meth:`can_run`
+    and calls :meth:`replay`; the eager path stays a direct
+    ``model_runner.forward`` call at that call site. Capture failure degrades
+    to eager -- world-agreed, so DP/TP ranks stay in lockstep.
+
+    Args:
+        model_runner: The target ModelRunner. Supplies the loaded model
+            (multimodal wrappers are unwrapped internally: the graph wraps the
+            nested ``language_model``'s text transformer, image prefills run
+            eager) and ``is_generation`` (embedding models run eager).
+        attn_backend: Backend whose extend metadata the dummy capture batch sets.
+        token_to_kv_pool: KV pool the dummy batch points at (reserved dummy slot).
+        input_buffers: The shared static input buffers the graphs read from.
+        config: Model-executor config (buckets, DP/world topology, device).
+        req_to_page: Request page table; row 0 backs the dummy capture request.
+        drafter: If present, aux-hidden capture (EAGLE3/MTP) is baked into the
+            captured graphs.
+    """
+
+    def __init__(
+        self,
+        model_runner,
+        attn_backend: AttentionBackend,
+        token_to_kv_pool,
+        input_buffers: InputBuffers,
+        config: ModelExecutorConfig,
+        req_to_page: torch.Tensor | None,
+        drafter=None,
+        decode_wrapper: CudaGraphWrapper | None = None,
+        num_warmup: int = 3,
+    ) -> None:
+        model = model_runner.model if model_runner is not None else None
+        # Multimodal seam: models whose multimodal path is embeds-only expose
+        # multimodal_input_embeds; others (e.g. deepstack) replay text only.
+        self._multimodal_input_embeds = getattr(model, "multimodal_input_embeds", None)
+        self.text_model = (
+            model.language_model if hasattr(model, "language_model") else model
+        )
+        self.inner_model = getattr(self.text_model, "model", None)
+        # Embedding runs eagerly OUTSIDE the graphs (see capture); the graphs
+        # read a static input-embeds buffer instead of gathering from input_ids.
+        self._embed_tokens = getattr(self.inner_model, "embed_tokens", None)
+        self._input_embeds_buf: torch.Tensor | None = None
+        self.attn_backend = attn_backend
+        self.token_to_kv_pool = token_to_kv_pool
+        self.input_buffers = input_buffers
+        self.config = config
+        self.req_to_page = req_to_page
+        self.drafter = drafter
+        self.num_warmup = num_warmup
+        self.dp_size = config.data_parallel_size
+
+        self.capture_buckets = get_prefill_token_buckets(config)
+        self.disable = (
+            config.enforce_eager
+            or config.disable_prefill_graph
+            or not self.capture_buckets
+            or self.inner_model is None
+            or self._embed_tokens is None
+            or model_runner is None
+            or not model_runner.is_generation
+            # DP replay decisions must come from replicated state, and a
+            # forward's multimodal-ness is rank-local: one rank running its mm
+            # prefill eager while text-only peers replay desyncs the EP
+            # collectives. Until the DP metadata gather carries a multimodal
+            # flag, keep the graph off for multimodal models under DP.
+            or (config.data_parallel_size > 1 and model_runner.is_multimodal)
+        )
+
+        self._ctx: ForwardContext | None = None
+        self._pool = None
+        self._engaged_logged: set[str] = set()
+        # Aux-capture mode baked into the graphs; mismatched live forwards run eager.
+        self._captured_hidden_mode = None
+        # One captured graph + bucket-sized output per padded token bucket.
+        self._captures: dict[int, BreakableCapture] = {}
+        self._outputs: dict[int, CapturedForward] = {}
+
+        if not self.disable:
+            self.capture(decode_wrapper)
+
+    # ------------------------------------------------------------------
+    # Graph capture
+    # ------------------------------------------------------------------
+
+    def capture(self, decode_wrapper: CudaGraphWrapper | None = None) -> None:
+        """Capture one breakable graph per token bucket (no-op when disabled).
+
+        Called from ``__init__``; ``decode_wrapper`` supplies the shared
+        capture stream and dummy paged-cache block tables (used here only,
+        not stored). Sharing
+        decode's stream + mempool puts all graphs in one pool-reuse domain
+        (pool blocks are stream-keyed), so graph memory stays ~the largest
+        bucket's peak instead of growing per bucket.
+
+        Runs under inference mode like serving forwards (in-place updates on
+        inference-mode model state buffers are only legal there). OOM
+        propagates -- the buckets genuinely didn't fit, don't silently boot in
+        a slower eager mode. Any other failure means the dummy-batch machinery
+        doesn't cover this model family yet: degrade to eager prefill instead
+        of crashing the server, and agree on that across the world (a MIN
+        all-reduce over the success flag) -- replay force-sets
+        ``global_num_tokens`` on every rank, so one eager rank among replaying
+        peers diverges the token counts and deadlocks the next collective.
+        """
+        if self.disable:
+            return
+        weight = self._embed_tokens.weight
+        self._input_embeds_buf = torch.zeros(
+            max(self.capture_buckets),
+            weight.shape[1],
+            dtype=weight.dtype,
+            device=weight.device,
+        )
+        self._pool = _cuda_graph_wrapper.global_graph_memory_pool
+        captured_ok = True
+        try:
+            with maybe_inference_mode():
+                self._capture_all_buckets(decode_wrapper)
+        except torch.cuda.OutOfMemoryError:
+            raise
+        except (NotImplementedError, AttributeError, KeyError, RuntimeError) as exc:
+            logger.warning(
+                "Prefill graph capture failed (%s: %s); falling back to eager "
+                "prefill. This model family may need dedicated dummy-batch support.",
+                type(exc).__name__,
+                exc,
+            )
+            captured_ok = False
+        if not self._capture_unanimous(captured_ok):
+            self.disable = True
+
+    def _capture_all_buckets(self, decode_wrapper: CudaGraphWrapper | None) -> None:
+        for bucket in sorted(self.capture_buckets, reverse=True):
+            self._ctx = self._make_dummy_batch(bucket, decode_wrapper)
+            self._land_input_embeds(
+                self._embed_tokens(self.input_buffers.input_ids_buf[:bucket]), bucket
+            )
+            self._captured_hidden_mode = self._ctx.capture_hidden_mode
+            # Breaks record the ambient dummy ctx; it is rebound live at replay.
+            try:
+                with active_forward(self._ctx):
+                    self._capture_bucket(bucket, decode_wrapper)
+            finally:
+                self._ctx = None
+        if self.config.global_rank == 0:
+            sample = next(iter(self._captures.values()), None)
+            logger.info(
+                "prefill breakable graph: captured buckets %s (segments=%d, eager "
+                "attention breaks)",
+                sorted(self._captures),
+                sample.num_segments if sample is not None else 0,
+            )
+
+    def _capture_bucket(
+        self, bucket: int, decode_wrapper: CudaGraphWrapper | None
+    ) -> None:
+        """Warm up and capture the breakable graph for ``bucket`` from the buffers."""
+        for _ in range(self.num_warmup):
+            self._run_inner(bucket)
+        torch.cuda.synchronize()
+        stream = decode_wrapper.stream if decode_wrapper is not None else None
+        cap = BreakableCapture(pool=self._pool, stream=stream)
+        with cap:
+            self._outputs[bucket] = CapturedForward(*self._run_inner(bucket))
+        if self._pool is None:
+            self._pool = cap.pool  # share the pool across all subsequent buckets
+        cap.replay()  # capture records kernels without executing; smoke-test replay
+        self._captures[bucket] = cap
+
+    def _run_inner(self, num_tokens: int):
+        """Run the inner model over the leading ``num_tokens`` of the static buffers.
+
+        ``num_tokens`` is the padded bucket size; the padded tail [real:bucket] is
+        already scrubbed to safe values (embeds=0, positions=0,
+        out_cache_loc=dummy_kv_slot) by :meth:`_land_input_embeds` and
+        ``InputBuffers.fill_input_buffers``. The embedding is NOT part of the
+        graph: the inner model starts from the static input-embeds buffer, so a
+        replay can take precomputed (e.g. merged multimodal) embeddings.
+        """
+        ib = self.input_buffers
+        if self.config.model_is_mrope:
+            positions = ib.mrope_positions_buf[:, :num_tokens]
+        else:
+            positions = ib.positions_buf[:num_tokens]
+        return self.inner_model(
+            ib.input_ids_buf[:num_tokens],
+            positions,
+            self._ctx,
+            ib.out_cache_loc_buf[:num_tokens],
+            input_embeds=self._input_embeds_buf[:num_tokens],
+        )
+
+    def _land_input_embeds(self, embeds: torch.Tensor, bucket: int) -> None:
+        """Copy ``embeds`` into the static buffer's leading rows, zero the tail.
+
+        The zeroed padded tail keeps the graphed compute over garbage-free rows
+        (RMSNorm of zeros is zeros; the tail is discarded by the output slice).
+        """
+        num_tokens = embeds.shape[0]
+        self._input_embeds_buf[:num_tokens].copy_(embeds)
+        if num_tokens < bucket:
+            self._input_embeds_buf[num_tokens:bucket].zero_()
+
+    def _make_dummy_batch(
+        self, num_tokens: int, decode_wrapper: CudaGraphWrapper | None
+    ) -> ForwardContext:
+        """Populate the static buffers + attention metadata for a dummy bs=1 extend
+        forward of ``num_tokens`` tokens, and return its ForwardContext.
+
+        The prefill analogue of decode's ``_init_capture_metadata``. KV writes
+        go to the reserved dummy slot and the page table points at page 0, so
+        the forward runs (producing discarded garbage) without touching real
+        cache state. Backends with extra paged caches (DeepSeek-V4 DSA: SWA +
+        compressor + indexer state) also need per-cache block tables, or their
+        extend metadata comes up incomplete and the eager attention break
+        aborts the capture -- reuse the decode wrapper's dummy-table builder
+        (all zeros, the safe page 0) for those.
+        """
+        ib = self.input_buffers
+        ib.input_ids_buf[:num_tokens].fill_(1)
+        ib.out_cache_loc_buf[:num_tokens].fill_(ib.dummy_kv_slot)
+        ib.positions_buf[:num_tokens].copy_(
+            torch.arange(num_tokens, device=self.config.device)
+        )
+        ib.req_pool_indices_buf[:1].zero_()
+        ib.seq_lens_buf[:1].fill_(num_tokens)
+        ib.extend_seq_lens_buf[:1].fill_(num_tokens)
+        ib.extend_seq_lens_cpu[:1].fill_(num_tokens)
+        ib.extend_prefix_lens_buf[:1].zero_()
+        ib.extend_prefix_lens_cpu[:1].zero_()
+        self.req_to_page[0].zero_()  # dummy request's pages -> page 0 (valid memory)
+
+        ctx = ForwardContext(
+            attn_backend=self.attn_backend,
+            token_to_kv_pool=self.token_to_kv_pool,
+            req_to_page=self.req_to_page,
+            bs=1,
+            num_extends=1,
+            input_num_tokens=num_tokens,
+            forward_mode=ForwardMode.EXTEND,
+            capture_hidden_mode=(
+                CaptureHiddenMode.FULL
+                if self.drafter is not None
+                else CaptureHiddenMode.NULL
+            ),
+        )
+        if self.dp_size > 1:
+            ctx.global_num_tokens = [num_tokens] * self.config.world_size
+            ctx.global_bs = [1] * self.config.world_size
+        extra_metadata_kwargs: dict = {}
+        if (
+            getattr(self.attn_backend, "uses_paged_cache_groups", False)
+            and decode_wrapper is not None
+        ):
+            tables = decode_wrapper._capture_paged_cache_block_tables(
+                1, self.token_to_kv_pool
+            )
+            if tables is not None:
+                extra_metadata_kwargs["paged_cache_block_tables"] = tables
+            extra_metadata_kwargs["num_tokens"] = num_tokens
+            extra_metadata_kwargs["positions"] = ib.positions_buf[:num_tokens]
+        self.attn_backend.init_forward_metadata(
+            bs=1,
+            num_extends=1,
+            req_pool_indices=ib.req_pool_indices_buf[:1],
+            seq_lens=ib.seq_lens_buf[:1],
+            req_to_page=self.req_to_page,
+            forward_mode=ForwardMode.EXTEND,
+            extend_seq_lens=ib.extend_seq_lens_buf[:1],
+            extend_seq_lens_cpu=ib.extend_seq_lens_cpu[:1],
+            extend_prefix_lens=ib.extend_prefix_lens_buf[:1],
+            extend_prefix_lens_cpu=ib.extend_prefix_lens_cpu[:1],
+            **extra_metadata_kwargs,
+        )
+        return ctx
+
+    def _capture_unanimous(self, captured_ok: bool) -> bool:
+        """MIN-reduce capture success across the world (see ``capture``)."""
+        if self.config.world_group is None or self.config.world_size <= 1:
+            return captured_ok
+        from tokenspeed.runtime.distributed.process_group_manager import (
+            process_group_manager as pg_manager,
+        )
+
+        cpu_group = pg_manager.get_process_group("gloo", self.config.world_group)
+        flag = torch.tensor([1 if captured_ok else 0], dtype=torch.int32)
+        torch.distributed.all_reduce(
+            flag, op=torch.distributed.ReduceOp.MIN, group=cpu_group
+        )
+        unanimous = bool(flag.item())
+        if not unanimous and captured_ok:
+            logger.warning(
+                "Prefill graph: a peer rank failed capture; falling back to "
+                "eager prefill on all ranks to keep DP/TP token counts in lockstep."
+            )
+        return unanimous
+
+    # ------------------------------------------------------------------
+    # Replay dispatch
+    # ------------------------------------------------------------------
+
+    def can_run(self, ctx: ForwardContext, multimodal_context=None) -> bool:
+        """Whether this forward replays a captured graph (mirrors decode's can_run).
+
+        A forward carrying multimodal inputs replays only when the model
+        exposes the embeds-only ``multimodal_input_embeds`` seam; models with
+        extra per-layer inputs (deepstack) run eager.
+        """
+        if multimodal_context is not None and self._multimodal_input_embeds is None:
+            return False
+        return self._replay_bucket(ctx) is not None
+
+    def replay(
+        self,
+        ctx: ForwardContext,
+        input_ids: torch.Tensor,
+        multimodal_context=None,
+    ):
+        """Replay the captured graph for ``ctx`` (caller checked :meth:`can_run`).
+
+        The embedding runs eagerly here, outside the graph: a plain text
+        prefill gathers ``embed_tokens(input_ids)`` into the static buffer; a
+        multimodal prefill builds the merged text+vision embeddings via the
+        model's ``multimodal_input_embeds`` seam (vision encoder included)
+        instead -- both replay the same graphs. Then the inner stack replays
+        over the padded bucket and the model's eager logits tail finishes on
+        the real-token rows.
+        """
+        bucket = self._replay_bucket(ctx)
+        assert bucket is not None, "replay() called without can_run()"
+        self._log_engaged_once(bucket, ctx, multimodal_context is not None)
+        num_tokens = ctx.input_num_tokens
+        input_embeds = None
+        if multimodal_context is not None:
+            input_embeds = self._multimodal_input_embeds(
+                input_ids, ctx, multimodal_context
+            )
+        self._land_input_embeds(
+            input_embeds if input_embeds is not None else self._embed_tokens(input_ids),
+            bucket,
+        )
+        with self._padded_to(ctx, bucket):
+            self._captures[bucket].replay()
+        hidden_states, aux_hidden_states = self._outputs[bucket].sliced(num_tokens)
+        # The eager logits tail of BaseCausalLM.forward, on the replayed hidden states.
+        logits_metadata = LogitsMetadata.from_forward_context(ctx)
+        return self.text_model.logits_processor(
+            input_ids,
+            hidden_states,
+            self.text_model.lm_head,
+            logits_metadata,
+            aux_hidden_states,
+        )
+
+    def _replay_bucket(self, ctx: ForwardContext) -> int | None:
+        """The captured bucket this forward replays, or ``None`` to run eager.
+
+        Pure-extend AND mixed extend+decode batches are eligible: the attention
+        break reads the LIVE ambient ctx and dispatches the prefill/decode
+        split itself, while the captured token-shaped compute is uniform over
+        all rows (pure decode is the decode graph's job). Two ctx fields are
+        baked into the captured segments rather than rebound at replay -- the
+        ``draft_first_step_reduce`` in-graph row reduction and the
+        ``capture_hidden_mode`` aux-hidden capture -- so a live forward carrying
+        different values falls back to eager rather than silently dropping the
+        reduce / mismatching aux. Prefix caching (cache hits and chunked-prefill
+        chunks 2+) IS eligible: the prefix affects only the ragged attention,
+        which runs entirely inside the eager break, and it adds zero new tokens,
+        so the padded bucket -- hence the baked EP all-to-all shape under DP --
+        is identical on prefix and non-prefix ranks.
+        """
+        if self.disable or ctx.forward_mode is None:
+            return None
+        if ctx.num_extends <= 0:
+            return None
+        if not (ctx.forward_mode.is_extend() or ctx.forward_mode.is_mixed()):
+            return None
+        if ctx.draft_first_step_reduce:
+            return None
+        if ctx.capture_hidden_mode != self._captured_hidden_mode:
+            return None
+        bucket = self._select_bucket(ctx)
+        if bucket is None or bucket not in self._captures:
+            return None
+        return bucket
+
+    def _select_bucket(self, ctx: ForwardContext) -> int | None:
+        """The padded bucket for this forward, or ``None`` to run eager.
+
+        Under data parallelism the MoE expert-parallel all-to-all is a collective
+        across ALL ranks, sized from a replicated per-rank token list. The captured
+        graph bakes a uniform ``[bucket]*world_size`` layout, so every rank must
+        replay the SAME bucket or the collective desyncs (NCCL deadlock). Decide
+        purely from replicated global state -- the all-extend flag and the global
+        max token count -- so all ranks reach the identical decision/bucket with no
+        extra sync (mirrors the decode graph). Idle ranks run a DECODE forward, so
+        ``all_extend`` is False whenever any rank is idle and the graph stays off
+        (e.g. warmup), correctly falling back to eager.
+        """
+        if self.dp_size <= 1 or ctx.global_num_tokens is None:
+            return self._padded_bucket(ctx.input_num_tokens)
+        if not ctx.all_extend:
+            return None
+        return self._padded_bucket(max(ctx.global_num_tokens))
+
+    def _padded_bucket(self, num_tokens: int) -> int | None:
+        """Smallest bucket >= ``num_tokens``, or ``None`` if over the largest.
+
+        With ``--disable-cuda-graph-padding``, only an exact bucket match
+        replays (mirroring the decode wrapper's no-padding semantics).
+        """
+        idx = bisect.bisect_left(self.capture_buckets, num_tokens)
+        if idx == len(self.capture_buckets):
+            return None
+        bucket = self.capture_buckets[idx]
+        if self.config.disable_cuda_graph_padding and bucket != num_tokens:
+            return None
+        return bucket
+
+    @contextmanager
+    def _padded_to(self, ctx: ForwardContext, bucket: int):
+        """Publish ``ctx`` as the ambient live context, pinned to the padded bucket.
+
+        The graph replays over ``bucket`` (padded) tokens; attention metadata stays
+        at the real count (set upstream), so the eager attention break only touches
+        real tokens and the padded rows produce discarded garbage. Pin
+        ``input_num_tokens`` to the bucket and, under DP, ``global_num_tokens`` /
+        ``global_bs`` to the captured uniform layout so any live read during the
+        break matches the baked EP shapes. The break reads ``forward_mode`` / ``bs``
+        / ``num_extends`` LIVE off this same (ambient) ctx -- which we do NOT pin --
+        so models split prefill vs decode and dispatch the per-mode backend
+        correctly with no side channel.
+        """
+        saved = (ctx.input_num_tokens, ctx.global_num_tokens, ctx.global_bs)
+        ctx.input_num_tokens = bucket
+        if self.dp_size > 1 and ctx.global_num_tokens is not None:
+            ctx.global_num_tokens = [bucket] * self.config.world_size
+            ctx.global_bs = [1] * self.config.world_size
+        try:
+            with active_forward(ctx):
+                yield
+        finally:
+            ctx.input_num_tokens, ctx.global_num_tokens, ctx.global_bs = saved
+
+    def _log_engaged_once(
+        self, bucket: int, ctx: ForwardContext, is_multimodal: bool
+    ) -> None:
+        kind = "multimodal" if is_multimodal else "text"
+        if kind in self._engaged_logged:
+            return
+        self._engaged_logged.add(kind)
+        logger.info(
+            "prefill breakable graph ENGAGED (%s): bucket=%d dp=%s mode=%s "
+            "(mixed prefill+decode batches supported)",
+            kind,
+            bucket,
+            # The replay mode actually taken (mirrors _select_bucket), a DP-debug anchor.
+            self.dp_size > 1 and ctx.global_num_tokens is not None,
+            ctx.forward_mode,
+        )

--- a/python/tokenspeed/runtime/layers/attention/backends/base.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/base.py
@@ -26,6 +26,8 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from tokenspeed.runtime.execution.breakable_cuda_graph import break_point
+
 if TYPE_CHECKING:
     from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
     from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
@@ -160,6 +162,7 @@ class AttentionBackend(ABC):
         if record_cache and save_kv_cache:
             self.step_counter.record_cache()
 
+    @break_point
     def forward(
         self,
         q: torch.Tensor,

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -33,6 +33,11 @@ from tokenspeed_kernel.ops.attention.triton.gdn_qkv_split import (
     fused_qkv_split_gdn_prefill,
 )
 
+from tokenspeed.runtime.execution.breakable_cuda_graph import (
+    break_point,
+    current_forward_ctx,
+    scrub_padding_tail,
+)
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
 from tokenspeed.runtime.layers.attention.linear.causal_conv1d import (
@@ -1032,6 +1037,11 @@ class MambaAttnBackend(AttentionBackend):
                 and self.forward_metadata.track_ssm_h_src.numel() > 0
             )
 
+            # Zero padded rows so garbage can't reach recurrent state (see scrub_padding_tail).
+            if extend_seq_lens_cpu is not None:
+                ntok = int(sum(int(x) for x in extend_seq_lens_cpu))
+                scrub_padding_tail(ntok, mixed_qkv, a, b)
+
             mixed_qkv_t = mixed_qkv.transpose(0, 1)
             if need_h_track:
                 if self.forward_metadata.track_conv_indices is None:
@@ -1254,6 +1264,7 @@ class HybridLinearAttnBackend(AttentionBackend):
 
     # ---- Forward dispatch ----
 
+    @break_point
     def forward(
         self,
         q: torch.Tensor,
@@ -1268,6 +1279,23 @@ class HybridLinearAttnBackend(AttentionBackend):
         record_kv_cache: bool | None = None,
         **kwargs,
     ):
+        """Dispatch one layer to its full-attention or GDN backend (the break point).
+
+        This wrapper OVERRIDES the base forward, so it carries its own
+        ``@break_point`` (else its full-attn + GDN layers bypass the base
+        decoration). The handoff buffer is inferred from the actual output --
+        q-shaped for full-attention layers, z-shaped for the GDN path (q=None)
+        -- so no per-branch out-spec is needed. Under a prefill-graph replay
+        the decorated scalar args (``forward_mode``, ``bs``) are frozen to the
+        capture-time dummy (EXTEND, bs=1) and are re-read from the live ambient
+        ctx instead, so a MIXED or bs>1 replay dispatches the per-mode backend
+        (and the GDN scan) correctly. The GDN scan's output rank is
+        canonicalized here to a stable [T, Hv, D] (== z.shape), as the
+        ``@break_point`` handoff buffer requires: ``gdn_chunk_prefill`` mirrors
+        its input rank, returning batched [1, T, Hv, D] on the uniform bs=1
+        path (which the dummy capture batch hits) vs ragged [T, Hv, D]
+        otherwise; full-attention output is 2D and untouched.
+        """
         if forward_mode is None:
             return super().forward(
                 q,
@@ -1282,6 +1310,12 @@ class HybridLinearAttnBackend(AttentionBackend):
                 record_kv_cache=record_kv_cache,
                 **kwargs,
             )
+
+        # Frozen capture-time scalars, re-read live (see docstring); no-op in eager.
+        amb = current_forward_ctx()
+        if amb is not None:
+            forward_mode = amb.forward_mode
+            bs = amb.bs
 
         if forward_mode.is_idle():
             if layer is None:
@@ -1320,6 +1354,13 @@ class HybridLinearAttnBackend(AttentionBackend):
                     forward_mode=forward_mode,
                     **kwargs,
                 )
+        # Collapse the GDN scan's batched [1, T, Hv, D] to z-shaped (see docstring).
+        if ret is not None and ret.dim() == 4:
+            # Strictly [1, T, Hv, D]: a genuine B>1 must fail loud, not corrupt the handoff.
+            assert (
+                ret.shape[0] == 1
+            ), f"GDN scan batched rank expected leading 1, got {ret.shape}"
+            ret = ret.flatten(0, 1)
         return ret
 
     def forward_decode(

--- a/python/tokenspeed/runtime/layers/attention/backends/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mha.py
@@ -37,6 +37,7 @@ from tokenspeed_kernel.ops.kvcache.triton import (
 )
 
 from tokenspeed.runtime.configs.model_config import AttentionArch
+from tokenspeed.runtime.execution.breakable_cuda_graph import scrub_padding_tail
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
@@ -55,6 +56,15 @@ _KERNEL_SOLUTION_BY_BACKEND = {
     "triton": "triton",
     "flashinfer": "flashinfer",
 }
+
+
+def _scrub_extend_padding(metadata, q, k, v) -> None:
+    """Zero the q/k/v rows beyond the real (unpadded) token count under a prefill graph.
+
+    Reads the count from the pinned CPU cu-seqlens mirror (sync-free) and delegates the
+    zeroing to the shared prefill-graph padding helper. No-op on normal unpadded forwards.
+    """
+    scrub_padding_tail(metadata.cu_extend_seq_lens_cpu[-1], q, k, v)
 
 
 @dataclass(kw_only=True)
@@ -457,6 +467,7 @@ class MHAAttnBackend(AttentionBackend):
         save_kv_cache: bool,
         sinks: torch.Tensor | None,
     ) -> torch.Tensor:
+        _scrub_extend_padding(metadata, q, k, v)
         # TODO: use a custom kernel to do downcast
         if self.is_fp8:
             q = q.to(torch.float8_e4m3fn)
@@ -492,6 +503,7 @@ class MHAAttnBackend(AttentionBackend):
         save_kv_cache: bool,
         sinks: torch.Tensor | None,
     ) -> torch.Tensor:
+        _scrub_extend_padding(metadata, q, k, v)
         if save_kv_cache:
             self._save_kv_cache(layer, out_cache_loc, token_to_kv_pool, k, v)
 

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -66,6 +66,10 @@ _device_sm = _platform.arch_version.major * 10 + _platform.arch_version.minor
 
 from tokenspeed.runtime.distributed import Mapping
 from tokenspeed.runtime.distributed.comm_manager import CommManager
+from tokenspeed.runtime.execution.breakable_cuda_graph import (
+    break_point,
+    scrub_padding_tail,
+)
 from tokenspeed.runtime.execution.context import ForwardContext
 from tokenspeed.runtime.execution.cuda_graph_wrapper import get_is_capture_mode
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
@@ -635,6 +639,19 @@ class DeepseekV3AttentionMLA(nn.Module):
         comm_manager: CommManager,
         block_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        """MLA attention with a NARROW prefill-graph break.
+
+        The token-shaped input/output projections (q/kv-down, layernorm,
+        q_b_proj, o_proj) stay in the captured prefill graph; only the
+        data-dependent attention -- KV write + varlen prefill / absorb decode
+        kernels + the live prefill/decode split -- runs as the eager break
+        (``_attention_core``). This keeps the big projection GEMMs graphed
+        instead of dispatch-bound eager, collapsing the inter-segment bubbles a
+        coarse whole-attention break leaves. Outside capture the
+        ``@break_point`` is a direct call, so the eager path is unchanged.
+        """
+        if hidden_states.shape[0] == 0:
+            return hidden_states
         if self.q_lora_rank is not None:
             qkv = self.fused_qkv_a_proj_with_mqa(
                 hidden_states, block_scale, torch.bfloat16
@@ -658,9 +675,44 @@ class DeepseekV3AttentionMLA(nn.Module):
             kv_a = latent_cache[..., : self.kv_lora_rank]
             self.kv_a_layernorm(kv_a, inplace=True)
 
-        num_decodes = ctx.bs - ctx.num_extends
-        num_decode_tokens = num_decodes * ctx.attn_backend.spec_num_tokens
-        num_prefill_tokens = q.size(0) - num_decode_tokens
+        attn_output = self._attention_core(
+            positions, q, latent_cache, ctx, out_cache_loc
+        )
+
+        if ctx.draft_first_step_reduce:
+            # KV already written; keep one live row per request for o_proj/MLP.
+            attn_output = attn_output.index_select(0, ctx.gather_ids)
+        output, _ = self.o_proj(attn_output)
+        return output
+
+    @break_point
+    def _attention_core(
+        self,
+        positions: torch.Tensor,
+        q: torch.Tensor,
+        latent_cache: torch.Tensor,
+        ctx: ForwardContext,
+        out_cache_loc: torch.Tensor,
+    ) -> torch.Tensor:
+        """The eager break: KV write + varlen prefill / absorb decode attention.
+
+        The prefill/decode split is recovered from LIVE state -- correct both
+        in eager and under a prefill-graph replay, where ``ctx`` is the live
+        ambient context but ``q`` is padded to the graph bucket (``q.size(0)``
+        is NOT the real token count). The decode token count comes from the
+        live ctx; the real prefill token count from the live attention
+        metadata (the same source the padding scrub uses). Padded tail rows
+        produce discarded garbage.
+        """
+        spec = ctx.attn_backend.spec_num_tokens or 1
+        num_decodes = max(ctx.bs - ctx.num_extends, 0)
+        num_decode_tokens = num_decodes * spec
+        if ctx.num_extends > 0:
+            cmeta = ctx.attn_backend.chunked_prefill_metadata
+            num_prefill_tokens = int(sum(cmeta.extend_seq_lens_cpu))
+        else:
+            num_prefill_tokens = 0
+        real_total = num_prefill_tokens + num_decode_tokens
         attn_output = torch.empty(
             q.size(0),
             self.num_local_heads * self.v_head_dim,
@@ -668,10 +720,11 @@ class DeepseekV3AttentionMLA(nn.Module):
             device=q.device,
         )
 
-        if ctx.num_extends > 0:
+        if num_prefill_tokens > 0:
             prefill_ctx = replace(
                 ctx,
-                bs=ctx.num_extends,
+                bs=max(ctx.bs - num_decodes, 1),
+                num_extends=max(ctx.bs - num_decodes, 1),
                 input_num_tokens=num_prefill_tokens,
                 forward_mode=ForwardMode.EXTEND,
             )
@@ -684,7 +737,7 @@ class DeepseekV3AttentionMLA(nn.Module):
                 attn_output[:num_prefill_tokens],
             )
 
-        if ctx.num_extends < ctx.bs:
+        if num_decode_tokens > 0:
             decode_ctx = replace(
                 ctx,
                 bs=num_decodes,
@@ -693,20 +746,15 @@ class DeepseekV3AttentionMLA(nn.Module):
                 forward_mode=ForwardMode.DECODE,
             )
             self.forward_absorb(
-                positions[num_prefill_tokens:],
-                q[num_prefill_tokens:],
-                latent_cache[num_prefill_tokens:],
+                positions[num_prefill_tokens:real_total],
+                q[num_prefill_tokens:real_total],
+                latent_cache[num_prefill_tokens:real_total],
                 decode_ctx,
-                out_cache_loc[num_prefill_tokens:],
-                attn_output[num_prefill_tokens:],
+                out_cache_loc[num_prefill_tokens:real_total],
+                attn_output[num_prefill_tokens:real_total],
             )
 
-        if ctx.draft_first_step_reduce:
-            # KV already written; drop dead-position rows so o_proj / MLP /
-            # post-norms only run on one live row per request.
-            attn_output = attn_output.index_select(0, ctx.gather_ids)
-        output, _ = self.o_proj(attn_output)
-        return output
+        return attn_output
 
     def forward_absorb(
         self,
@@ -882,6 +930,10 @@ class DeepseekV3AttentionMLA(nn.Module):
         out_cache_loc: torch.Tensor,
         output: torch.Tensor,
     ) -> torch.Tensor:
+        # Prefill-graph padding contract: zero garbage rows the per-row projections
+        # + FP8 quantize would otherwise touch (see scrub_padding_tail).
+        ntok = sum(ctx.attn_backend.chunked_prefill_metadata.extend_seq_lens_cpu)
+        scrub_padding_tail(ntok, q, latent_cache)
         q, k, v = self.forward_normal_chunked_kv_prepare(
             positions, q, latent_cache, ctx, out_cache_loc
         )

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -81,6 +81,11 @@ from tokenspeed.runtime.distributed.comm_manager import CommManager
 from tokenspeed.runtime.distributed.process_group_manager import (
     process_group_manager as pg_manager,
 )
+from tokenspeed.runtime.execution.breakable_cuda_graph import (
+    break_point,
+    current_forward_ctx,
+    slice_to_real_tokens,
+)
 from tokenspeed.runtime.execution.context import ForwardContext
 from tokenspeed.runtime.execution.cuda_graph_wrapper import get_is_capture_mode
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
@@ -3557,6 +3562,7 @@ class DeepseekV4Attention(nn.Module):
         out, _ = self.wo_b(z.flatten(1))
         return out
 
+    @break_point
     def forward(
         self,
         positions: torch.Tensor,
@@ -3566,10 +3572,27 @@ class DeepseekV4Attention(nn.Module):
         swa_slot_mapping: torch.Tensor | None = None,
         compressor_slot_cache: dict | None = None,
     ) -> torch.Tensor:
+        """DSA attention, one COARSE breakable-graph break point.
+
+        Per layer it does multiple paged-cache writes (SWA / compressor /
+        indexer), a data/length-dependent indexer -> top-k stage, the FlashMLA
+        sparse kernel, AND aux-stream forks -- none capturable into a CUDA
+        graph. Under a prefill-graph capture the whole attention runs eager
+        (reading the live ``ctx``) while the layer's norms + MoE stay graphed;
+        direct call otherwise (see ``break_point``). Padding rows are handled
+        by the existing ``metadata.is_valid_token`` masking, and the
+        token-shaped inputs are sliced to the real count DSA kernels assert
+        (see ``slice_to_real_tokens`` below). The cross-layer SWA slot mapping
+        and compressor memo are shared via ctx -- replay-safe because ctx is
+        rebound to the live forward (see ``DeepseekV4Model.forward``).
+        """
         if hidden_states.shape[0] == 0:
             return hidden_states
+        # Cross-layer compressor memo, created once per forward by the first layer.
         if compressor_slot_cache is None:
-            compressor_slot_cache = {}
+            compressor_slot_cache = ctx.dsa_compressor_slot_cache
+            if compressor_slot_cache is None:
+                compressor_slot_cache = ctx.dsa_compressor_slot_cache = {}
         profile_prefix = f"attn_{self.attention_kind}"
         cos_sin_cache = self.rotary_emb.cos_sin_cache
         if cos_sin_cache.dtype != torch.float32:
@@ -3578,6 +3601,22 @@ class DeepseekV4Attention(nn.Module):
         metadata = ctx.attn_backend.forward_metadata
         if metadata is None:
             raise RuntimeError("DeepSeek V4 attention requires forward metadata")
+
+        # Slice padded inputs to the real count the DSA kernels assert (see
+        # docstring). Only under a breakable capture/replay (ambient ctx set):
+        # eager forwards are never padded, and the MTP draft path reaches here
+        # with metadata whose token_to_req_indices does NOT describe q's rows.
+        token_to_req = getattr(metadata, "token_to_req_indices", None)
+        if current_forward_ctx() is not None and token_to_req is not None:
+            positions, hidden_states, out_cache_loc, swa_slot_mapping = (
+                slice_to_real_tokens(
+                    token_to_req.numel(),
+                    positions,
+                    hidden_states,
+                    out_cache_loc,
+                    swa_slot_mapping,
+                )
+            )
 
         # --- Phase 1: pre-compute input GEMMs in parallel ---
         # Q/KV projection on main stream; compressor GEMM(s) on aux stream.
@@ -3604,11 +3643,15 @@ class DeepseekV4Attention(nn.Module):
                         )
 
         if swa_slot_mapping is None:
-            swa_slot_mapping = _deepseek_v4_swa_slot_mapping(
-                ctx,
-                positions,
-                out_cache_loc,
-            )
+            # Cross-layer SWA slot mapping (per-token, layer-invariant), first layer computes.
+            swa_slot_mapping = ctx.dsa_swa_slot_mapping
+            if swa_slot_mapping is None:
+                swa_slot_mapping = _deepseek_v4_swa_slot_mapping(
+                    ctx,
+                    positions,
+                    out_cache_loc,
+                )
+                ctx.dsa_swa_slot_mapping = swa_slot_mapping
 
         def insert_swa_cache() -> None:
             with nvtx_range(f"{profile_prefix}_insert_swa_cache"):
@@ -4012,18 +4055,10 @@ class DeepseekV4Model(nn.Module):
                 hidden_states = self.embed_tokens(input_ids)
         with nvtx_range("hc_repeat"):
             hidden_states = hidden_states.unsqueeze(1).repeat(1, self.hc_mult, 1)
-        # The SWA write-slot mapping is identical across all layers, so compute
-        # it once per step here instead of recomputing it in every attention
-        # layer (DeepSeek-V3 likewise derives its slot mapping once per step).
-        swa_slot_mapping = _deepseek_v4_swa_slot_mapping(
-            ctx,
-            positions,
-            out_cache_loc,
-        )
-        # Per-(step, ratio) compressor slot mappings are identical across layers of the
-        # same ratio; memoize within the step (filled lazily by the first compressor of
-        # each ratio, reused by the rest).
-        compressor_slot_cache: dict = {}
+        # Layer-invariant DSA memos: computing them HERE (graphed scope) would bake
+        # dummy addresses; the first attention break computes them LIVE onto ctx.
+        ctx.dsa_swa_slot_mapping = None
+        ctx.dsa_compressor_slot_cache = None
         hc_x_prev = None
         hc_post_prev = None
         hc_comb_prev = None
@@ -4034,8 +4069,8 @@ class DeepseekV4Model(nn.Module):
                 ctx,
                 out_cache_loc,
                 input_ids,
-                swa_slot_mapping,
-                compressor_slot_cache,
+                None,  # swa_slot_mapping: first break computes + caches on ctx
+                None,  # compressor_slot_cache: shared dict created on ctx
                 hc_x_prev,
                 hc_post_prev,
                 hc_comb_prev,

--- a/python/tokenspeed/runtime/models/glm5.py
+++ b/python/tokenspeed/runtime/models/glm5.py
@@ -38,6 +38,11 @@ from transformers import PretrainedConfig
 from tokenspeed.runtime.configs.utils import get_rope_theta
 from tokenspeed.runtime.distributed import Mapping
 from tokenspeed.runtime.distributed.comm_manager import CommManager
+from tokenspeed.runtime.execution.breakable_cuda_graph import (
+    break_point,
+    current_forward_ctx,
+    slice_to_real_tokens,
+)
 from tokenspeed.runtime.execution.context import ForwardContext
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.layernorm import FusedRMSNorm, LayerNorm, RMSNorm
@@ -805,6 +810,7 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
             kv_workspace_slots=kv_workspace_slots,
         )
 
+    @break_point
     def forward(
         self,
         positions: torch.Tensor,
@@ -814,6 +820,22 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
         comm_manager: CommManager,
         block_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        """GLM-5 DSA attention, one COARSE breakable-graph break point.
+
+        Like DeepSeek-V4 it does paged-cache writes, a data-dependent indexer
+        -> top-k stage and the FlashMLA sparse kernel (plus pre-attn
+        collectives), none capturable. Under a prefill-graph capture the whole
+        attention runs eager (reading the live ``ctx``) while the layer's
+        norms + MoE stay graphed; direct call otherwise (see ``break_point``).
+        Padded token-shaped inputs are sliced to the real count the live
+        metadata describes -- DSA and the decode-window split (which derives
+        ``decode_start`` from the total token count) must not see padded rows,
+        or decode rows get sliced out of the padded tail. Mirrors the
+        DeepSeek-V4 DSA break.
+        """
+        # Empty (idle / DP-idle) batch: explicit skip, like the sibling MLP/MoE forwards.
+        if hidden_states.shape[0] == 0:
+            return hidden_states
         qkv = self.fused_qkv_a_proj_with_mqa(
             hidden_states,
             block_scale,
@@ -828,6 +850,17 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
         if qkv.shape[-1] != _qkv_width:
             qkv = qkv[..., :_qkv_width]
         qkv = comm_manager.pre_attn_comm(qkv, ctx)
+        # Slice only under a breakable capture/replay (see the DeepSeek-V4 break):
+        # eager forwards (incl. MTP draft steps) are never padded. Sliced AFTER
+        # the pre-attn comm: at replay ``_padded_to`` pins ``global_num_tokens``
+        # to the padded bucket, so the comm must see padded-length rows; only
+        # the DSA stack below needs exactly the real rows.
+        _metadata = getattr(ctx.attn_backend, "forward_metadata", None)
+        _token_to_req = getattr(_metadata, "token_to_req_indices", None)
+        if current_forward_ctx() is not None and _token_to_req is not None:
+            positions, qkv, out_cache_loc = slice_to_real_tokens(
+                _token_to_req.numel(), positions, qkv, out_cache_loc
+            )
         q_a, latent_cache = qkv.split(
             [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
             dim=-1,

--- a/python/tokenspeed/runtime/models/kimi_k25.py
+++ b/python/tokenspeed/runtime/models/kimi_k25.py
@@ -883,6 +883,38 @@ class KimiK25ForConditionalGeneration(nn.Module):
         )
 
     @torch.no_grad()
+    def multimodal_input_embeds(
+        self,
+        input_ids: torch.Tensor,
+        ctx,
+        multimodal_context,
+    ) -> torch.Tensor | None:
+        """Merged text+vision input embeddings, or ``None`` for a plain text step.
+
+        Kimi-K2.5's multimodal path is embeds-only -- the vision features are
+        scattered into the input embeddings and nothing else reaches the
+        language model (no per-layer extras like deepstack) -- so both the
+        eager ``forward`` below and a prefill-graph replay take the exact same
+        tensor from here.
+        """
+        if (
+            multimodal_context is None
+            or self.vision_embedder is None
+            or not multimodal_context.has_extend_inputs()
+            or ctx.forward_mode.is_decode_or_idle()
+        ):
+            return None
+        input_embeds, model_kwargs = self.vision_embedder.apply(
+            input_ids=input_ids,
+            text_embedding=self.get_input_embeddings(),
+            ctx=multimodal_context,
+            encoders={Modality.IMAGE: EncoderSpec(self.image_encoder)},
+            multimodal_model=self,
+            is_decode_or_idle=ctx.forward_mode.is_decode_or_idle(),
+        )
+        assert not model_kwargs, "Kimi-K2.5 multimodal path must stay embeds-only"
+        return input_embeds
+
     def forward(
         self,
         ctx,
@@ -894,22 +926,9 @@ class KimiK25ForConditionalGeneration(nn.Module):
         if self.language_model is None:
             raise RuntimeError("KimiK25 language_model is not initialized.")
         multimodal_context = kwargs.pop("multimodal_context", None)
-        if (
-            multimodal_context is not None
-            and multimodal_context.has_extend_inputs()
-            and not ctx.forward_mode.is_decode_or_idle()
-        ):
-            input_embeds, model_kwargs = self.vision_embedder.apply(
-                input_ids=input_ids,
-                text_embedding=self.get_input_embeddings(),
-                ctx=multimodal_context,
-                encoders={Modality.IMAGE: EncoderSpec(self.image_encoder)},
-                multimodal_model=self,
-                is_decode_or_idle=ctx.forward_mode.is_decode_or_idle(),
-            )
-            kwargs.update(model_kwargs)
-            if input_embeds is not None:
-                kwargs["input_embeds"] = input_embeds
+        input_embeds = self.multimodal_input_embeds(input_ids, ctx, multimodal_context)
+        if input_embeds is not None:
+            kwargs["input_embeds"] = input_embeds
         return self.language_model.forward(
             ctx,
             input_ids,

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -245,7 +245,10 @@ class ServerArgs:
     low_latency_max_num_tokens_per_gpu: int = 256
     max_cudagraph_capture_size: int | None = None
     disable_prefill_graph: bool | None = False
-    prefill_graph_max_tokens: int | None = 128
+    # Breakable prefill CUDA graph, opt-in: > 0 enables and caps the largest bucket.
+    prefill_graph_max_tokens: int | None = 0
+    # Explicit prefill bucket list; unset = the relative-stride ladder (see get_prefill_token_buckets).
+    prefill_graph_capture_sizes: list[int] | None = None
     cudagraph_capture_sizes: list[int] | None = None
     enable_nan_detection: bool = False
     enable_nvtx: bool = False
@@ -1594,7 +1597,18 @@ class ServerArgs:
             "--prefill-graph-max-tokens",
             type=int,
             default=ServerArgs.prefill_graph_max_tokens,
-            help="Max query tokens to capture when enable prefill graph",
+            help="Enable the breakable prefill CUDA graph and cap the largest "
+            "captured token bucket. 0 (default) disables it (opt-in).",
+        )
+        parser.add_argument(
+            "--prefill-graph-capture-sizes",
+            metavar="PREFILL_GRAPH_CAPTURE_SIZE",
+            type=int,
+            nargs="+",
+            help="Explicit list of token-bucket sizes to capture for the "
+            "breakable prefill graph (like --cudagraph-capture-sizes for "
+            "decode). Unset: a relative-stride ladder bounding padded compute "
+            "at ~12.5%% of any size.",
         )
         parser.add_argument(
             "--enable-nan-detection",

--- a/test/runtime/execution/test_autotune_freeze.py
+++ b/test/runtime/execution/test_autotune_freeze.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The kernel autotune-lifecycle switch the executor flips at end of startup."""
+
+import unittest
+
+from tokenspeed_kernel.ops import tuning
+
+
+class TestAutotuneFreeze(unittest.TestCase):
+    def tearDown(self):
+        tuning._frozen = False  # global switch; restore for other tests
+
+    def test_freeze_is_one_way_and_idempotent(self):
+        self.assertFalse(tuning.autotune_frozen())
+        tuning.freeze_autotuning()
+        self.assertTrue(tuning.autotune_frozen())
+        tuning.freeze_autotuning()
+        self.assertTrue(tuning.autotune_frozen())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/runtime/execution/test_breakable_cuda_graph.py
+++ b/test/runtime/execution/test_breakable_cuda_graph.py
@@ -1,0 +1,605 @@
+"""Unit tests for the breakable CUDA graph core (Phase 1).
+
+Captures a tiny ``Linear -> eager break -> Linear`` forward with
+:class:`BreakableCapture`, mutates the static input buffer, replays, and asserts
+the replayed output matches an eager recompute. This exercises the load-bearing
+invariants in isolation -- segment splitting, the eager break handoff, shared
+mempool address stability -- without touching the model or the hot path.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=15, suite="runtime-1gpu")
+
+from types import SimpleNamespace  # noqa: E402
+
+import torch  # noqa: E402
+
+from tokenspeed.runtime.execution.breakable_cuda_graph import (  # noqa: E402
+    BreakableCapture,
+    active_forward,
+    break_here,
+    break_point,
+    current_forward_ctx,
+    is_breakable_capture_active,
+    scrub_padding_tail,
+    slice_to_real_tokens,
+)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+class TestBreakableCudaGraph(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(0)
+        self.dev = "cuda"
+        self.dtype = torch.float32
+        self.n, self.d = 8, 16
+        self.w1 = torch.randn(self.d, self.d, device=self.dev, dtype=self.dtype)
+        self.w2 = torch.randn(self.d, self.d, device=self.dev, dtype=self.dtype)
+        # Static input buffer: graphs read this address; live inputs are copied in.
+        self.x_static = torch.zeros(self.n, self.d, device=self.dev, dtype=self.dtype)
+
+    def _eager(self, x):
+        """Reference forward: Linear -> relu (the "break" op) -> Linear."""
+        h = x @ self.w1
+        h = torch.relu(h)
+        return h @ self.w2
+
+    def _build_capture(self):
+        """Capture the same forward with relu as an eager break."""
+        cap = BreakableCapture()
+
+        def forward():
+            h = self.x_static @ self.w1
+            # Break-output buffer, allocated in-segment so it is pool-pinned.
+            dst = torch.empty_like(h)
+            h = break_here(torch.relu, dst, h)
+            return h @ self.w2
+
+        # Warm up (cublas workspace / lazy init) before capture.
+        for _ in range(3):
+            forward()
+        torch.cuda.synchronize()
+
+        with cap:
+            captured_out = forward()
+        return cap, captured_out
+
+    def test_break_here_passthrough_when_inactive(self):
+        self.assertFalse(is_breakable_capture_active())
+        h = torch.randn(self.n, self.d, device=self.dev, dtype=self.dtype)
+        dst = torch.empty_like(h)
+        out = break_here(torch.relu, dst, h)
+        self.assertIs(out, dst)
+        torch.testing.assert_close(out, torch.relu(h))
+
+    def test_segments_split_at_break(self):
+        cap, _ = self._build_capture()
+        # Two graph segments (before/after relu) + one eager break = 3.
+        self.assertEqual(cap.num_segments, 3)
+
+    def test_replay_matches_eager(self):
+        cap, captured_out = self._build_capture()
+        for trial in range(5):
+            new_x = torch.randn(self.n, self.d, device=self.dev, dtype=self.dtype)
+            self.x_static.copy_(new_x)
+            cap.replay()
+            torch.cuda.synchronize()
+            torch.testing.assert_close(
+                captured_out, self._eager(new_x), msg=f"trial {trial}"
+            )
+
+    def test_multiple_breaks_chain(self):
+        """Many breaks (like a deep transformer) must chain correctly."""
+        depth = 6
+        ws = [
+            torch.randn(self.d, self.d, device=self.dev, dtype=self.dtype)
+            for _ in range(depth + 1)
+        ]
+
+        def eager(x):
+            h = x @ ws[0]
+            for i in range(depth):
+                h = torch.relu(h)  # the "break" op
+                h = h @ ws[i + 1]
+            return h
+
+        cap = BreakableCapture()
+
+        def forward():
+            h = self.x_static @ ws[0]
+            for i in range(depth):
+                dst = torch.empty_like(h)
+                h = break_here(torch.relu, dst, h)
+                h = h @ ws[i + 1]
+            return h
+
+        for _ in range(3):
+            forward()
+        torch.cuda.synchronize()
+        with cap:
+            captured_out = forward()
+
+        # depth breaks => depth+1 graph segments + depth eager breaks.
+        self.assertEqual(cap.num_segments, 2 * depth + 1)
+        for trial in range(4):
+            new_x = torch.randn(self.n, self.d, device=self.dev, dtype=self.dtype)
+            self.x_static.copy_(new_x)
+            cap.replay()
+            torch.cuda.synchronize()
+            torch.testing.assert_close(captured_out, eager(new_x), msg=f"trial {trial}")
+
+    def test_nested_capture_rejected(self):
+        with BreakableCapture():
+            with self.assertRaises(RuntimeError):
+                with BreakableCapture():
+                    pass
+
+    def test_scrub_padding_tail(self):
+        # Zeros [num_real:] in place across tensors; skips None; no-op when unpadded.
+        t1 = torch.ones(6, 3, device=self.dev, dtype=self.dtype)
+        t2 = torch.ones(6, device=self.dev, dtype=self.dtype)
+        scrub_padding_tail(4, t1, None, t2)
+        self.assertTrue(bool((t1[:4] == 1).all()) and bool((t1[4:] == 0).all()))
+        self.assertTrue(bool((t2[:4] == 1).all()) and bool((t2[4:] == 0).all()))
+        # Unpadded (count == rows): untouched.
+        t3 = torch.ones(4, 3, device=self.dev, dtype=self.dtype)
+        scrub_padding_tail(4, t3)
+        self.assertTrue(bool((t3 == 1).all()))
+
+    def test_slice_to_real_tokens(self):
+        """Leading [:num_real] per tensor in order; None and unpadded pass through."""
+        a = torch.arange(6, device=self.dev)
+        b = torch.arange(6, device=self.dev).view(6, 1)
+        c = torch.arange(4, device=self.dev)  # already real length
+        ra, rn, rb, rc = slice_to_real_tokens(4, a, None, b, c)
+        self.assertEqual(ra.shape[0], 4)
+        self.assertEqual(rb.shape[0], 4)
+        self.assertIsNone(rn)
+        self.assertIs(rc, c)  # no-op: not padded
+        torch.testing.assert_close(ra, torch.arange(4, device=self.dev))
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+class TestBucketedCapture(unittest.TestCase):
+    """Per-token-bucket lazy capture with input padding (what PrefillGraph does).
+
+    A token-shaped inner forward whose per-layer "attention" runs as an eager
+    break is captured once per padded token bucket and replayed for any real token
+    count <= bucket. Mirrors the runner's mechanics directly on BreakableCapture so
+    the bucketing + padding + replay-parity invariant is unit-tested in isolation.
+    """
+
+    def setUp(self):
+        torch.manual_seed(1)
+        self.dev, self.dtype = "cuda", torch.float32
+        self.d, self.depth = 16, 3
+        self.buckets = [4, 8, 16]
+        self.ws = [
+            torch.randn(self.d, self.d, device=self.dev, dtype=self.dtype)
+            for _ in range(self.depth + 1)
+        ]
+        # Persistent static input buffer (max bucket); graph reads this address.
+        self.x_static = torch.zeros(
+            max(self.buckets), self.d, device=self.dev, dtype=self.dtype
+        )
+        self._captures: dict = {}
+        self._outputs: dict = {}
+        self._pool = None
+
+    def _inner(self, n):
+        """Inner forward over the leading ``n`` rows of the static buffer."""
+        h = self.x_static[:n] @ self.ws[0]
+        for i in range(self.depth):
+            dst = torch.empty_like(h)
+            h = break_here(torch.relu, dst, h)  # per-token "attention" break
+            h = h @ self.ws[i + 1]
+        return h
+
+    def _eager(self, x):
+        h = x @ self.ws[0]
+        for i in range(self.depth):
+            h = torch.relu(h)
+            h = h @ self.ws[i + 1]
+        return h
+
+    def _run_bucketed(self, n):
+        """Pad ``n`` up to a bucket, lazily capture/replay, return output[:n]."""
+        idx = next(i for i, b in enumerate(self.buckets) if b >= n)
+        bucket = self.buckets[idx]
+        cap = self._captures.get(bucket)
+        if cap is None:
+            for _ in range(2):  # warmup
+                self._inner(bucket)
+            torch.cuda.synchronize()
+            cap = BreakableCapture(pool=self._pool)
+            with cap:
+                out = self._inner(bucket)
+            self._pool = self._pool or cap.pool
+            cap.replay()  # capture doesn't execute; populate `out`
+            self._captures[bucket], self._outputs[bucket] = cap, out
+        else:
+            cap.replay()
+        return self._outputs[bucket][:n], bucket
+
+    def test_replay_matches_eager_across_buckets(self):
+        captured = set()
+        for n in [3, 4, 5, 8, 11, 16, 1]:
+            new_x = torch.randn(n, self.d, device=self.dev, dtype=self.dtype)
+            self.x_static.zero_()  # scrub the padded tail
+            self.x_static[:n].copy_(new_x)
+            out, bucket = self._run_bucketed(n)
+            captured.add(bucket)
+            torch.cuda.synchronize()
+            torch.testing.assert_close(
+                out, self._eager(new_x), msg=f"n={n}", rtol=1e-4, atol=1e-4
+            )
+        # First sighting of each distinct bucket captured once; later n replay.
+        self.assertEqual(set(self._captures), {4, 8, 16})
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+class TestBreakPointAndAmbientCtx(unittest.TestCase):
+    """The ``@break_point`` decorator + ambient live-context rebind.
+
+    Exercises the two properties the model refactor relies on: (1) a decorated
+    method runs as an eager break under capture / a direct call otherwise, with
+    its output buffer sized from the named ``out`` arg; (2) the ForwardContext a
+    break reads is rebound to the LIVE ambient context at replay, so a graph
+    captured with a dummy ctx replays correctly against a different live ctx.
+    """
+
+    def setUp(self):
+        torch.manual_seed(2)
+        self.dev, self.dtype = "cuda", torch.float32
+        self.d = 16
+        self.w0 = torch.randn(self.d, self.d, device=self.dev, dtype=self.dtype)
+        self.w1 = torch.randn(self.d, self.d, device=self.dev, dtype=self.dtype)
+        self.x_static = torch.zeros(8, self.d, device=self.dev, dtype=self.dtype)
+
+    def test_passthrough_runs_method_when_not_capturing(self):
+        """Off the capture path @break_point always runs the method.
+
+        Including side effects and 0-row inputs -- the decorator never silently
+        skips a method; 0-row / idle handling is each model's own explicit
+        ``if hidden_states.shape[0] == 0`` guard.
+        """
+        calls = []
+
+        class M:
+            @break_point
+            def forward(self, x, ctx):
+                calls.append(x.shape[0])
+                return x * ctx.scale
+
+        m = M()
+        self.assertFalse(is_breakable_capture_active())
+        x = torch.randn(4, self.d, device=self.dev, dtype=self.dtype)
+        out = m.forward(x, SimpleNamespace(scale=3.0))  # direct call
+        torch.testing.assert_close(out, x * 3.0)
+        # 0 rows: the method still runs and its output (not the input) is returned.
+        empty = torch.zeros(0, self.d, device=self.dev, dtype=self.dtype)
+        out0 = m.forward(empty, SimpleNamespace(scale=9.0))
+        torch.testing.assert_close(out0, empty * 9.0)
+        self.assertEqual(calls, [4, 0])  # method ran for both, including 0 rows
+
+    def test_ambient_ctx_rebinds_at_replay(self):
+        class M:
+            def __init__(self, w):
+                self.w = w
+
+            @break_point
+            def forward(self, x, ctx):
+                # Reads the (live) ctx; output [tokens, d] matches arg ``x``.
+                return torch.relu(x @ self.w) * ctx.scale
+
+        m = M(self.w1)
+        dummy = SimpleNamespace(scale=2.0)  # capture-time ctx
+        live = SimpleNamespace(scale=5.0)  # replay-time ctx
+
+        def outer():
+            h = self.x_static @ self.w0  # captured graph segment
+            return m.forward(h, dummy)  # eager break reading the ambient ctx
+
+        for _ in range(3):  # warmup
+            with active_forward(dummy):
+                outer()
+        torch.cuda.synchronize()
+        cap = BreakableCapture()
+        with active_forward(dummy):
+            with cap:
+                captured = outer()
+        # 1 break => 2 graph segments + 1 eager break.
+        self.assertEqual(cap.num_segments, 3)
+
+        new_x = torch.randn(8, self.d, device=self.dev, dtype=self.dtype)
+        self.x_static.copy_(new_x)
+        with active_forward(live):  # replay against a DIFFERENT live ctx
+            cap.replay()
+        torch.cuda.synchronize()
+        # The break must have used live.scale (5.0), not the captured dummy (2.0).
+        expected = torch.relu((new_x @ self.w0) @ self.w1) * 5.0
+        torch.testing.assert_close(captured, expected, rtol=1e-4, atol=1e-4)
+
+    def test_break_reads_live_scalar_off_ambient_not_frozen_arg(self):
+        """Scalar args freeze at capture; live values must come off the ambient ctx.
+
+        Mirrors the hybrid attention-backend pattern: only the ambient ctx is
+        rebound at replay, so a break needing a live scalar (forward_mode, bs)
+        reads current_forward_ctx(), never its own frozen arg.
+        """
+        seen = {}
+
+        class M:
+            @break_point
+            def forward(self, x, frozen_mode):
+                amb = current_forward_ctx()
+                seen["frozen"] = frozen_mode
+                seen["live"] = amb.mode
+                return x * amb.mult
+
+        m = M()
+        dummy = SimpleNamespace(mode="EXTEND", mult=1.0)  # capture-time ctx
+        live = SimpleNamespace(mode="MIXED", mult=4.0)  # replay-time ctx
+
+        def outer():
+            h = self.x_static @ self.w0
+            return m.forward(h, frozen_mode="EXTEND")  # frozen scalar arg
+
+        for _ in range(3):
+            with active_forward(dummy):
+                outer()
+        torch.cuda.synchronize()
+        cap = BreakableCapture()
+        with active_forward(dummy):
+            with cap:
+                captured = outer()
+
+        new_x = torch.randn(8, self.d, device=self.dev, dtype=self.dtype)
+        self.x_static.copy_(new_x)
+        with active_forward(live):  # replay against a DIFFERENT live ctx
+            cap.replay()
+        torch.cuda.synchronize()
+        # The positional/kw scalar arg stayed frozen at capture time...
+        self.assertEqual(seen["frozen"], "EXTEND")
+        # ...but the ambient read tracked the live ctx (mode + multiplier).
+        self.assertEqual(seen["live"], "MIXED")
+        torch.testing.assert_close(
+            captured, new_x @ self.w0 * 4.0, rtol=1e-4, atol=1e-4
+        )
+
+    def test_break_point_computed_out_shape(self):
+        """A NARROW break whose output shape matches no input (deepseek_v3 MLA-like)."""
+        d2 = self.d // 2
+        wv = torch.randn(self.d, d2, device=self.dev, dtype=self.dtype)
+
+        class M:
+            @break_point  # out-shape (d2 != input d) inferred from the actual output
+            def attn(self, x):  # output last-dim d2 != input last-dim d
+                return torch.relu(x) @ wv
+
+        m = M()
+
+        def outer():
+            h = self.x_static @ self.w0  # captured segment
+            return m.attn(h)  # narrow break, computed output shape
+
+        for _ in range(3):
+            outer()
+        torch.cuda.synchronize()
+        cap = BreakableCapture()
+        with cap:
+            captured = outer()
+        self.assertEqual(tuple(captured.shape), (self.x_static.size(0), d2))
+
+        new_x = torch.randn(8, self.d, device=self.dev, dtype=self.dtype)
+        self.x_static.copy_(new_x)
+        cap.replay()
+        torch.cuda.synchronize()
+        expected = torch.relu(new_x @ self.w0) @ wv
+        torch.testing.assert_close(captured, expected, rtol=1e-4, atol=1e-4)
+
+    def test_nested_break_inner_passes_through(self):
+        """A broader @break_point overrides a nested one.
+
+        Capture is inactive while the outer break runs eagerly, so an inner
+        break called inside it passes straight through -- exactly one break.
+        """
+        seen = {"inner_active": None}
+
+        class M:
+            @break_point
+            def inner(self, x):  # would-be default backend break
+                seen["inner_active"] = is_breakable_capture_active()
+                return torch.relu(x)
+
+            @break_point
+            def outer(self, x):  # broader override break
+                return self.inner(x) @ self_w1  # noqa: F821
+
+        self_w1 = self.w1
+        m = M()
+
+        def fwd():
+            h = self.x_static @ self.w0  # captured segment
+            return m.outer(h)  # broad break; inner passes through
+
+        for _ in range(3):
+            fwd()
+        torch.cuda.synchronize()
+        cap = BreakableCapture()
+        with cap:
+            captured = fwd()
+        # Exactly one break (outer) => 2 graph segments + 1 break = 3.
+        self.assertEqual(cap.num_segments, 3)
+        self.assertIs(seen["inner_active"], False)  # inner saw inactive capture
+
+        new_x = torch.randn(8, self.d, device=self.dev, dtype=self.dtype)
+        self.x_static.copy_(new_x)
+        cap.replay()
+        torch.cuda.synchronize()
+        expected = torch.relu(new_x @ self.w0) @ self.w1
+        torch.testing.assert_close(captured, expected, rtol=1e-4, atol=1e-4)
+
+
+class TestPrefillTokenBuckets(unittest.TestCase):
+    """Pure-function tests for the prefill-graph token-bucket schedule (no GPU)."""
+
+    @staticmethod
+    def _cfg(**overrides):
+        base = dict(
+            prefill_graph_max_tokens=2048,
+            disable_prefill_graph=False,
+            chunked_prefill_size=2048,
+            prefill_graph_capture_sizes=None,
+        )
+        base.update(overrides)
+        return SimpleNamespace(**base)
+
+    def test_disabled(self):
+        from tokenspeed.runtime.execution.prefill_graph import (
+            get_prefill_token_buckets,
+        )
+
+        self.assertEqual(
+            get_prefill_token_buckets(self._cfg(prefill_graph_max_tokens=0)), []
+        )
+        self.assertEqual(
+            get_prefill_token_buckets(self._cfg(disable_prefill_graph=True)), []
+        )
+
+    def test_clamped_to_chunk(self):
+        from tokenspeed.runtime.execution.prefill_graph import (
+            get_prefill_token_buckets,
+        )
+
+        # No bucket above the chunk (see get_prefill_token_buckets for why).
+        buckets = get_prefill_token_buckets(
+            self._cfg(prefill_graph_max_tokens=8192, chunked_prefill_size=2048)
+        )
+        self.assertEqual(buckets[-1], 2048)
+
+    def test_relative_ladder_properties(self):
+        from tokenspeed.runtime.execution.prefill_graph import (
+            get_prefill_token_buckets,
+        )
+
+        # Gaps bounded relatively (size/8) and absolutely (512); exact top; increasing.
+        for max_tokens in (8192, 2048, 1500):
+            buckets = get_prefill_token_buckets(
+                self._cfg(
+                    prefill_graph_max_tokens=max_tokens,
+                    chunked_prefill_size=max_tokens,
+                )
+            )
+            self.assertEqual(buckets[-1], max_tokens)
+            self.assertEqual(buckets, sorted(set(buckets)))
+            gaps = [b2 - b1 for b1, b2 in zip(buckets, buckets[1:])]
+            for b1, g in zip(buckets, gaps):
+                self.assertLessEqual(g, 512, f"cap violated at {b1}")
+                if b1 >= 256:
+                    self.assertLessEqual(g, max(b1 // 8, 16), f"relative bound at {b1}")
+
+    def test_explicit_capture_sizes(self):
+        from tokenspeed.runtime.execution.prefill_graph import (
+            get_prefill_token_buckets,
+        )
+
+        # Explicit list overrides the ladder; clamped to max_tokens (always included).
+        buckets = get_prefill_token_buckets(
+            self._cfg(prefill_graph_capture_sizes=[256, 1024, 4096])
+        )
+        self.assertEqual(buckets, [256, 1024, 2048])
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+class TestWeakRefTensor(unittest.TestCase):
+    """The non-owning-view op behind break-closure weak refs."""
+
+    def test_alias_without_ownership(self):
+        from tokenspeed.runtime.execution.breakable_cuda_graph import weak_ref_tensor
+
+        x = torch.arange(12, device="cuda", dtype=torch.float32).view(3, 4)[:, 1:]
+        w = weak_ref_tensor(x)
+        if w is x:  # identity fallback (no C++ toolchain) -- still correct
+            self.skipTest("weak_ref extension unavailable; identity fallback")
+        # Aliases the same memory (incl. strides), sees writes, owns nothing.
+        self.assertEqual(w.data_ptr(), x.data_ptr())
+        self.assertEqual(w.stride(), x.stride())
+        x.fill_(3.0)
+        torch.cuda.synchronize()
+        self.assertTrue(bool((w == 3.0).all()))
+        # Non-tensor / CPU passthrough.
+        self.assertIsNone(weak_ref_tensor(None))
+        cpu = torch.ones(2)
+        self.assertIs(weak_ref_tensor(cpu), cpu)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+class TestPoolReuseAcrossCaptures(unittest.TestCase):
+    """Graph-pool memory must NOT grow per capture (the dense-ladder enabler).
+
+    Allocator pool blocks are stream-keyed, so all BreakableCaptures must share
+    one capture stream (class-level default) -- a fresh stream per capture makes
+    pool memory grow with the SUM of bucket sizes instead of the max.
+    """
+
+    @staticmethod
+    def _pool_mb():
+        return (
+            sum(
+                s["total_size"]
+                for s in torch.cuda.memory_snapshot()
+                if s.get("segment_pool_id", (0, 0)) != (0, 0)
+            )
+            / 2**20
+        )
+
+    def test_same_and_smaller_captures_reuse_pool(self):
+        d, d2, depth = 512, 2048, 4
+        w1 = torch.randn(d, d2, device="cuda")
+        w2 = torch.randn(d2, d, device="cuda")
+        xbuf = torch.zeros(4096, d, device="cuda")
+
+        def fwd(n):
+            x = xbuf[:n]
+            for _ in range(depth):
+                h = x @ w1
+                dst = torch.empty_like(h)
+                h = break_here(torch.relu, dst, h)
+                x = h @ w2
+            return x
+
+        pool = torch.cuda.graph_pool_handle()
+        caps = []
+        deltas = []
+        for n in (4096, 2048, 4096):
+            for _ in range(2):
+                fwd(n)
+            torch.cuda.synchronize()
+            before = self._pool_mb()
+            cap = BreakableCapture(pool=pool)  # shared default capture stream
+            with cap:
+                out = fwd(n)
+            cap.replay()
+            torch.cuda.synchronize()
+            caps.append((cap, out))
+            deltas.append(self._pool_mb() - before)
+        # First capture claims ~peak-live; later ones must reuse it (small allowance).
+        self.assertLess(deltas[1], max(2.0, deltas[0] * 0.1), f"deltas={deltas}")
+        self.assertLess(deltas[2], max(2.0, deltas[0] * 0.1), f"deltas={deltas}")
+        # Replays still valid after cross-capture reuse.
+        for cap, _ in caps:
+            cap.replay()
+        torch.cuda.synchronize()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/cutlass_unquant.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/cutlass_unquant.py
@@ -20,7 +20,10 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
+
 import torch
+from tokenspeed_kernel.ops.tuning import autotune_frozen
 from tokenspeed_kernel.platform import (
     ArchVersion,
     CapabilityRequirement,
@@ -91,7 +94,8 @@ if platform.is_nvidia:
             )
             topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
             topk_weights = topk_weights.to(x.dtype)
-        with flashinfer_autotune():
+        # Tune new shapes during startup only, frozen once serving (see ops.tuning).
+        with nullcontext() if autotune_frozen() else flashinfer_autotune():
             return cutlass_fused_moe(
                 input=x,
                 token_selected_experts=topk_ids.to(torch.int),

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_mxfp4.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 import torch
+from tokenspeed_kernel.ops.tuning import autotune_frozen
 from tokenspeed_kernel.platform import (
     ArchVersion,
     CapabilityRequirement,
@@ -420,10 +421,15 @@ if platform.is_nvidia:
             x_quant.shape[0], h_dim, dtype=torch.bfloat16, device=x_quant.device
         )
 
-        if not getattr(w, "_flashinfer_trtllm_autotuned", False):
+        # Autotune per pow-2 token class, frozen once serving starts (see ops.tuning).
+        if not hasattr(w, "_flashinfer_trtllm_autotuned_sizes"):
+            w._flashinfer_trtllm_autotuned_sizes = set()
+        tuned_sizes = w._flashinfer_trtllm_autotuned_sizes
+        size_class = next_power_of_2(x_quant.shape[0])
+        if size_class not in tuned_sizes and not autotune_frozen():
             with autotune():
                 _call_mxfp4_moe(w, router_logits, x_quant, x_scale, output)
-            w._flashinfer_trtllm_autotuned = True
+            tuned_sizes.add(size_class)
 
         result = _call_mxfp4_moe(w, router_logits, x_quant, x_scale, output)
         if hidden_original != hidden_padded:

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/transform/weak_ref.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/transform/weak_ref.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Non-owning tensor view for CUDA-graph break closures.
+
+``weak_ref_tensor(t)`` returns a tensor aliasing ``t``'s memory WITHOUT owning
+its storage (``at::from_blob`` with a no-op deleter). A breakable-CUDA-graph
+break closure that holds such a view does not pin ``t``'s mempool block, so the
+graph pool can recycle blocks across segments and captures -- graph memory
+drops from sum-over-buckets of break inputs back to ~peak-live. Correctness
+relies on replay order: the captured segment rewrites the aliased address
+before the break reads it, every replay (the same discipline that lets the
+decode graph share one pool across batch sizes).
+
+Adapted from vLLM ``csrc/ops.h`` / SGLang ``sgl-kernel/csrc/memory/
+weak_ref_tensor.cpp``. Compiled lazily via ``torch.utils.cpp_extension``
+(pure C++ against ATen -- no nvcc, no wheel rebuild); falls back to identity
+(strong ref: correct, more memory) if compilation is unavailable.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+_CPP_SOURCE = r"""
+#include <ATen/ATen.h>
+#include <vector>
+
+at::Tensor weak_ref_tensor(const at::Tensor& tensor) {
+  TORCH_CHECK(tensor.is_cuda(), "weak_ref_tensor expects a CUDA tensor");
+  void* data_ptr = tensor.data_ptr();
+  std::vector<int64_t> sizes = tensor.sizes().vec();
+  std::vector<int64_t> strides = tensor.strides().vec();
+  auto options = tensor.options();
+  return at::from_blob(data_ptr, sizes, strides, options);
+}
+"""
+
+_module = None
+_load_failed = False
+
+
+def _load():
+    global _module, _load_failed
+    if _module is not None or _load_failed:
+        return _module
+    try:
+        from torch.utils.cpp_extension import load_inline
+
+        _module = load_inline(
+            name="tokenspeed_weak_ref_tensor",
+            cpp_sources=_CPP_SOURCE,
+            functions=["weak_ref_tensor"],
+            with_cuda=False,
+            verbose=False,
+        )
+    except Exception as exc:  # pragma: no cover - host without a C++ toolchain
+        _load_failed = True
+        logger.warning(
+            "weak_ref_tensor extension unavailable (%s: %s); falling back to "
+            "identity (strong refs pin graph-pool blocks -- correct, but "
+            "breakable-graph capture memory scales with the bucket sum).",
+            type(exc).__name__,
+            exc,
+        )
+    return _module
+
+
+def weak_ref_tensor(t: torch.Tensor) -> torch.Tensor:
+    """Return a non-owning view of CUDA tensor ``t`` (alias, same shape/strides).
+
+    Args:
+        t: A CUDA tensor. The caller must guarantee the aliased memory is
+            rewritten (or still valid) whenever the view is consumed -- for
+            breakable-graph closures this holds because the captured segment
+            producing ``t`` replays before the break reads the view.
+
+    Returns:
+        A tensor sharing ``t``'s memory without owning its storage, or ``t``
+        itself if the extension is unavailable (identity fallback).
+    """
+    mod = _load()
+    if mod is None:
+        return t
+    return mod.weak_ref_tensor(t)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/tuning.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/tuning.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Kernel autotune lifecycle.
+
+Ops that autotune lazily (e.g. the flashinfer trtllm MoE) consult
+:func:`autotune_frozen` before starting a new tuning run. The runtime calls
+:func:`freeze_autotuning` once engine startup (model load, CUDA-graph capture,
+warmup) completes, because an autotune during serving is a hazard twice over:
+it blocks the launch thread for the whole profiling run, and under tensor
+parallelism ranks that tune at different times miss their next collective and
+deadlock. Shapes first seen after the freeze run on each library's fallback
+tactics instead -- slower, never stalled.
+"""
+
+__all__ = ["autotune_frozen", "freeze_autotuning"]
+
+_frozen = False
+
+
+def autotune_frozen() -> bool:
+    """Whether lazy autotuning is frozen (engine is serving)."""
+    return _frozen
+
+
+def freeze_autotuning() -> None:
+    """Disallow any further lazy autotune runs (call once startup completes)."""
+    global _frozen
+    _frozen = True


### PR DESCRIPTION
## Breakable CUDA graph for prefill

Decode is graphed; prefill ran eagerly. A full prefill graph is impossible
(varlen attention, data-dependent host scalars), so this captures the forward
as graph segments split by eager breaks — no `torch.compile`. Kimi-K2.6
2048-token prefill: **123ms → 55ms** (~GPU compute floor).

- `@break_point`: models mark the attention/mixer method; it runs eagerly
  (live metadata, KV ops honor the per-layer transfer consumer index) while
  the token-shaped compute around it is captured. Direct call when not capturing.
- `PrefillGraph`: one graph per padded token bucket, captured at startup on
  the decode wrapper's stream/mempool (memory ~= largest bucket). Replay-or-
  eager dispatched in the executor; capture failure degrades to eager,
  world-agreed; DP replay decisions are replicated so EP stays in lockstep.
- Embedding stays outside the graph: text replays gather eagerly, multimodal
  replays take merged embeddings via an embeds-only model seam (Kimi-K2.5).
  Models and ModelRunner carry zero graph awareness.

Validated per family on hardware — mha (gpt-oss, qwen3), MLA (Kimi-K2.6), GDN
(Qwen3.5), DSA (V4-Flash, GLM-5 incl. DP8+EP), multimodal (Kimi-K2.5,
graph-vs-eager byte-identical) — plus prefix caching, mixed batches, and
gsm8k/gpqa A/B within noise.

## Test Plan

<!-- How was this validated? -->
