### PR TITLE
perf(glm-5.2): remove per-token expansion of seq_lens and block_table for DSA decode path

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/dsa.py
@@ -140,9 +140,7 @@ class DSABackend(AttentionBackend):
         # Full-length broadcast: the plan and paged-MQA-logits kernels read only
         # the last column, and the per-token causal bound is applied downstream.
         metadata._dsa_seq_lens_2d = (
-            metadata.seq_lens_k.unsqueeze(1)
-            .expand(-1, self.spec_num_tokens)
-            .contiguous()
+            seq_lens.unsqueeze(1).expand(-1, self.spec_num_tokens).contiguous()
         )
         metadata._dsa_plan = dsa_plan(
             seq_lens_2d=metadata._dsa_seq_lens_2d, page_size=self.page_size
@@ -167,7 +165,7 @@ class DSABackend(AttentionBackend):
         )
         metadata = self.forward_decode_metadata
         metadata._dsa_seq_lens_2d.copy_(
-            metadata.seq_lens_k.unsqueeze(1).expand(-1, self.spec_num_tokens)
+            seq_lens.unsqueeze(1).expand(-1, self.spec_num_tokens)
         )
         dsa_plan(
             seq_lens_2d=metadata._dsa_seq_lens_2d,
@@ -223,13 +221,15 @@ class DSABackend(AttentionBackend):
             # Full-length broadcast: the plan and paged-MQA-logits kernels read only
             # the last column, and the per-token causal bound is applied downstream.
             metadata._dsa_seq_lens_2d = (
-                metadata.seq_lens_k[num_extends:]
-                .unsqueeze(1)
-                .expand(-1, self.spec_num_tokens)
-                .contiguous()
+                seq_lens.unsqueeze(1).expand(-1, self.spec_num_tokens).contiguous()
             )
+            if num_extends < bs:
+                seq_lens_2d = metadata._dsa_seq_lens_2d[num_extends:]
+            else:
+                # The dsa_plan is unused, alias to full-batch seq_lens_2d to generate dsa_plan as a placeholder
+                seq_lens_2d = metadata._dsa_seq_lens_2d
             metadata._dsa_plan = dsa_plan(
-                seq_lens_2d=metadata._dsa_seq_lens_2d, page_size=self.page_size
+                seq_lens_2d=seq_lens_2d, page_size=self.page_size
             )
 
         self._prefill_block_tables = None

--- a/python/tokenspeed/runtime/layers/attention/backends/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/dsa.py
@@ -121,49 +121,7 @@ class DSABackend(AttentionBackend):
         return self._dense_backend.override_num_extends(num_extends)
 
     def init_cuda_graph_state(self, max_bs: int, seq_lens_buf: torch.Tensor):
-        return self._dense_backend.init_cuda_graph_state(max_bs, seq_lens_buf)
-
-    def _clear_metadata_caches(self) -> None:
-        metadata_objects = [
-            self.forward_decode_metadata,
-            self.forward_prefill_metadata,
-        ]
-        metadata_objects.extend(self.decode_cuda_graph_metadata.values())
-        seen = set()
-        for metadata in metadata_objects:
-            if metadata is None or id(metadata) in seen:
-                continue
-            seen.add(id(metadata))
-            for attr in tuple(vars(metadata)):
-                if attr.startswith("_dsa_") and attr.endswith("_cache"):
-                    delattr(metadata, attr)
-
-    def _refresh_decode_topk_schedule_metadata(self, bs: int) -> None:
-        metadata = getattr(self._dense_backend, "forward_decode_metadata", None)
-        if metadata is None:
-            return
-        plan = getattr(metadata, "_dsa_plan", None)
-        if plan is None:
-            return
-
-        q_len = int(getattr(metadata, "_dsa_plan_q_len", 1) or 1)
-        base_lens = metadata.seq_lens_k[:bs].to(torch.int32)
-        if q_len == 1:
-            seq_lens = base_lens.contiguous()
-        else:
-            offsets = torch.arange(
-                1 - q_len, 1, device=base_lens.device, dtype=torch.int32
-            )
-            seq_lens = (
-                (base_lens.view(-1, 1) + offsets.view(1, -1)).clamp_min_(0).contiguous()
-            )
-        with torch.inference_mode():
-            dsa_plan(
-                seq_lens=seq_lens,
-                page_size=self.page_size,
-                q_len_per_req=q_len,
-                out=plan,
-            )
+        self._dense_backend.init_cuda_graph_state(max_bs, seq_lens_buf)
 
     def init_forward_metadata_capture_cuda_graph(
         self,
@@ -172,14 +130,21 @@ class DSABackend(AttentionBackend):
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode,
     ):
-        result = self._dense_backend.init_forward_metadata_capture_cuda_graph(
+        self._dense_backend.init_forward_metadata_capture_cuda_graph(
             bs=bs,
             req_pool_indices=req_pool_indices,
             seq_lens=seq_lens,
             forward_mode=forward_mode,
         )
-        self._clear_metadata_caches()
-        return result
+        metadata = self.forward_decode_metadata
+        metadata._dsa_seq_lens_2d = (
+            metadata.seq_lens_k.unsqueeze(1)
+            .expand(-1, self.spec_num_tokens)
+            .contiguous()
+        )
+        metadata._dsa_plan = dsa_plan(
+            seq_lens_2d=metadata._dsa_seq_lens_2d, page_size=self.page_size
+        )
 
     def init_forward_metadata_replay_cuda_graph(
         self,
@@ -190,7 +155,7 @@ class DSABackend(AttentionBackend):
         req_to_page: torch.Tensor = None,
         **kwargs,
     ):
-        result = self._dense_backend.init_forward_metadata_replay_cuda_graph(
+        self._dense_backend.init_forward_metadata_replay_cuda_graph(
             bs=bs,
             req_pool_indices=req_pool_indices,
             seq_lens=seq_lens,
@@ -198,8 +163,15 @@ class DSABackend(AttentionBackend):
             req_to_page=req_to_page,
             **kwargs,
         )
-        self._refresh_decode_topk_schedule_metadata(bs)
-        return result
+        metadata = self.forward_decode_metadata
+        metadata._dsa_seq_lens_2d.copy_(
+            metadata.seq_lens_k.unsqueeze(1).expand(-1, self.spec_num_tokens)
+        )
+        dsa_plan(
+            seq_lens_2d=metadata._dsa_seq_lens_2d,
+            page_size=self.page_size,
+            out=metadata._dsa_plan,
+        )
 
     def get_cuda_graph_seq_len_fill_value(self):
         return self._dense_backend.get_cuda_graph_seq_len_fill_value()
@@ -212,7 +184,12 @@ class DSABackend(AttentionBackend):
             metadata.seq_lens_k.add_(1)
         else:
             metadata.seq_lens_k.copy_(seq_lens[: metadata.seq_lens_k.numel()])
-        self._refresh_decode_topk_schedule_metadata(metadata.seq_lens_k.numel())
+
+        dsa_plan(
+            seq_lens_2d=metadata.seq_lens_k.unsqueeze(1),
+            page_size=self.page_size,
+            out=metadata._dsa_plan,
+        )
 
     def init_forward_metadata(
         self,
@@ -225,7 +202,7 @@ class DSABackend(AttentionBackend):
         spec_info=None,
         **kwargs,
     ):
-        out = self._dense_backend.init_forward_metadata(
+        self._dense_backend.init_forward_metadata(
             bs=bs,
             num_extends=num_extends,
             req_pool_indices=req_pool_indices,
@@ -235,6 +212,21 @@ class DSABackend(AttentionBackend):
             spec_info=spec_info,
             **kwargs,
         )
+        if (
+            forward_mode.is_decode()
+            or forward_mode.is_mixed()
+            or (forward_mode.is_extend() and self.is_draft)
+        ):
+            metadata = self._dense_backend.forward_decode_metadata
+            metadata._dsa_seq_lens_2d = (
+                metadata.seq_lens_k.unsqueeze(1)
+                .expand(-1, self.spec_num_tokens)
+                .contiguous()
+            )
+            metadata._dsa_plan = dsa_plan(
+                seq_lens_2d=metadata._dsa_seq_lens_2d, page_size=self.page_size
+            )
+
         self._prefill_block_tables = None
         if (
             num_extends > 0
@@ -247,7 +239,6 @@ class DSABackend(AttentionBackend):
                 ext_idx = cmeta_req_pool_indices[:num_extends].long()
                 self._prefill_block_tables = req_to_page[ext_idx]
                 cmeta.block_tables = self._prefill_block_tables
-        return out
 
     def _validate_logit_cap(self, logits_soft_cap: float) -> None:
         if logits_soft_cap and logits_soft_cap > 0:

--- a/python/tokenspeed/runtime/layers/attention/backends/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/dsa.py
@@ -137,6 +137,8 @@ class DSABackend(AttentionBackend):
             forward_mode=forward_mode,
         )
         metadata = self.forward_decode_metadata
+        # Full-length broadcast: the plan and paged-MQA-logits kernels read only
+        # the last column, and the per-token causal bound is applied downstream.
         metadata._dsa_seq_lens_2d = (
             metadata.seq_lens_k.unsqueeze(1)
             .expand(-1, self.spec_num_tokens)
@@ -217,9 +219,12 @@ class DSABackend(AttentionBackend):
             or forward_mode.is_mixed()
             or (forward_mode.is_extend() and self.is_draft)
         ):
-            metadata = self._dense_backend.forward_decode_metadata
+            metadata = self.forward_decode_metadata
+            # Full-length broadcast: the plan and paged-MQA-logits kernels read only
+            # the last column, and the per-token causal bound is applied downstream.
             metadata._dsa_seq_lens_2d = (
-                metadata.seq_lens_k.unsqueeze(1)
+                metadata.seq_lens_k[num_extends:]
+                .unsqueeze(1)
                 .expand(-1, self.spec_num_tokens)
                 .contiguous()
             )

--- a/python/tokenspeed/runtime/models/glm5.py
+++ b/python/tokenspeed/runtime/models/glm5.py
@@ -29,7 +29,6 @@ from typing import Any
 import torch
 from tokenspeed_kernel.ops.attention import (
     dsa_decode_topk,
-    dsa_plan,
     dsa_prefill_topk,
 )
 from torch import nn
@@ -497,19 +496,6 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
         retired.append(buffer)
 
     @staticmethod
-    def _expand_decode_seq_lens_per_token(
-        seq_lens: torch.Tensor,
-        q_len_per_req: int,
-    ) -> torch.Tensor:
-        if q_len_per_req == 1:
-            return seq_lens
-        offsets = torch.arange(
-            1 - q_len_per_req, 1, device=seq_lens.device, dtype=seq_lens.dtype
-        )
-        # Padded graph rows can be shorter than q_len; real rows are unaffected.
-        return (seq_lens.view(-1, 1) + offsets).clamp_min_(0).reshape(-1)
-
-    @staticmethod
     def _check_decode_q_len_per_req(q_len_per_req: int) -> None:
         # Multi-step MTP verify runs num_draft_tokens query rows per request.
         # DeepGEMM paged MQA logits (our fork) and FlashMLA sparse decode are
@@ -547,21 +533,12 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
         block_tables = metadata.block_kv_indices[
             num_extends : num_extends + decode_window.num_reqs
         ]
-        seq_lens_per_token = self._expand_decode_seq_lens_per_token(
-            seq_lens,
-            decode_window.q_len_per_req,
-        )
-        block_tables_per_token = (
-            block_tables
-            if decode_window.q_len_per_req == 1
-            else block_tables.repeat_interleave(decode_window.q_len_per_req, dim=0)
-        )
         topk = self.index_topk
         return self._compute_decode_topk_indices_portable(
             indexer_output=indexer_output,
             ctx=ctx,
-            seq_lens_per_token=seq_lens_per_token,
-            block_tables_per_token=block_tables_per_token,
+            seq_lens=seq_lens,
+            block_tables=block_tables,
             q_len_per_req=decode_window.q_len_per_req,
             decode_start=decode_window.start,
             num_tokens=num_tokens,
@@ -569,59 +546,23 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
             topk=topk,
         )
 
-    def _get_decode_topk_plan(
-        self,
-        *,
-        ctx: ForwardContext,
-        seq_lens_per_token: torch.Tensor,
-        q_len_per_req: int,
-    ) -> object | None:
-        decode_metadata = getattr(ctx.attn_backend, "forward_decode_metadata", None)
-        if decode_metadata is None:
-            return None
-        q_len_per_req = int(q_len_per_req)
-        plan_shape = (
-            int(seq_lens_per_token.numel()) // q_len_per_req,
-            q_len_per_req,
-        )
-        plan = getattr(decode_metadata, "_dsa_plan", None)
-        if (
-            plan is None
-            or getattr(decode_metadata, "_dsa_plan_q_len", None) != q_len_per_req
-            or getattr(decode_metadata, "_dsa_plan_shape", None) != plan_shape
-        ):
-            plan = dsa_plan(
-                seq_lens=seq_lens_per_token.to(torch.int32).contiguous(),
-                page_size=ctx.token_to_kv_pool.page_size,
-                q_len_per_req=q_len_per_req,
-            )
-            if plan is not None:
-                setattr(decode_metadata, "_dsa_plan", plan)
-                setattr(decode_metadata, "_dsa_plan_q_len", q_len_per_req)
-                setattr(decode_metadata, "_dsa_plan_shape", plan_shape)
-        return plan
-
     def _compute_decode_topk_indices_portable(
         self,
         *,
         indexer_output: GlmDsaIndexerOutput,
         ctx: ForwardContext,
-        seq_lens_per_token: torch.Tensor,
-        block_tables_per_token: torch.Tensor,
+        seq_lens: torch.Tensor,
+        block_tables: torch.Tensor,
         q_len_per_req: int,
         decode_start: int,
         num_tokens: int,
         num_decode_tokens: int,
         topk: int,
     ) -> GlmDsaDecodeTopK:
-        q = indexer_output.query[
+        q = indexer_output.query[decode_start : decode_start + num_decode_tokens]
+        weights = indexer_output.weights[
             decode_start : decode_start + num_decode_tokens
-        ].contiguous()
-        weights = (
-            indexer_output.weights[decode_start : decode_start + num_decode_tokens]
-            .float()
-            .contiguous()
-        )
+        ]
         index_k_cache = ctx.token_to_kv_pool.get_index_k_buffer(self.attn_mqa.layer_id)
         if index_k_cache is None:
             raise RuntimeError("GLM DSA top-k requires an index-K cache.")
@@ -636,22 +577,26 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
         topk_slice = topk_indices[decode_start : decode_start + num_decode_tokens]
         topk_lens = self._get_decode_topk_lens_workspace(num_tokens, q.device)
         topk_lens_slice = topk_lens[decode_start : decode_start + num_decode_tokens]
-        plan = self._get_decode_topk_plan(
-            ctx=ctx,
-            seq_lens_per_token=seq_lens_per_token,
-            q_len_per_req=q_len_per_req,
+
+        metadata = ctx.attn_backend.forward_decode_metadata
+        seq_lens_2d = (
+            metadata._dsa_seq_lens_2d
+            if q_len_per_req > 1
+            else metadata.seq_lens_k.unsqueeze(1)
         )
+        dsa_plan = metadata._dsa_plan
         dsa_decode_topk(
             q,
             weights,
-            seq_lens_per_token,
-            block_tables_per_token,
+            seq_lens,
+            block_tables,
             page_size=ctx.token_to_kv_pool.page_size,
             topk=topk,
             softmax_scale=self.indexer.softmax_scale,
             q_len_per_req=q_len_per_req,
             index_k_cache=index_k_cache,
-            plan=plan,
+            seq_lens_2d=seq_lens_2d,
+            plan=dsa_plan,
             out=topk_slice,
             lens_out=topk_lens_slice,
         )

--- a/python/tokenspeed/runtime/models/glm5.py
+++ b/python/tokenspeed/runtime/models/glm5.py
@@ -580,7 +580,9 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
 
         metadata = ctx.attn_backend.forward_decode_metadata
         seq_lens_2d = (
-            metadata._dsa_seq_lens_2d if q_len_per_req > 1 else seq_lens.unsqueeze(1)
+            metadata._dsa_seq_lens_2d[ctx.num_extends :]
+            if q_len_per_req > 1
+            else seq_lens.unsqueeze(1)
         )
         dsa_decode_topk(
             q,

--- a/python/tokenspeed/runtime/models/glm5.py
+++ b/python/tokenspeed/runtime/models/glm5.py
@@ -580,11 +580,8 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
 
         metadata = ctx.attn_backend.forward_decode_metadata
         seq_lens_2d = (
-            metadata._dsa_seq_lens_2d
-            if q_len_per_req > 1
-            else metadata.seq_lens_k.unsqueeze(1)
+            metadata._dsa_seq_lens_2d if q_len_per_req > 1 else seq_lens.unsqueeze(1)
         )
-        dsa_plan = metadata._dsa_plan
         dsa_decode_topk(
             q,
             weights,
@@ -596,7 +593,7 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
             q_len_per_req=q_len_per_req,
             index_k_cache=index_k_cache,
             seq_lens_2d=seq_lens_2d,
-            plan=dsa_plan,
+            plan=metadata._dsa_plan,
             out=topk_slice,
             lens_out=topk_lens_slice,
         )

--- a/python/tokenspeed/runtime/models/glm5.py
+++ b/python/tokenspeed/runtime/models/glm5.py
@@ -500,31 +500,12 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
     def _expand_decode_seq_lens_per_token(
         seq_lens: torch.Tensor,
         q_len_per_req: int,
-        *,
-        draft_catchup: bool = False,
     ) -> torch.Tensor:
-        """Per-token visible KV lengths for multi-query (spec-verify) decode.
-
-        ``seq_lens`` holds the FULL per-request context: during target verify
-        the draft tokens are already written to the KV cache and counted, so
-        token ``j`` of a request may only see
-        ``seq_lens - q_len_per_req + j + 1`` positions. With
-        ``q_len_per_req == 1`` this is ``seq_lens`` itself (plain decode).
-
-        The draft model's first catch-up step is the opposite: it writes its KV
-        one token at a time after target verify, so visible lengths advance from
-        ``seq_lens`` through ``seq_lens + q_len_per_req - 1``.
-        """
         if q_len_per_req == 1:
             return seq_lens
-        if draft_catchup:
-            offsets = torch.arange(
-                q_len_per_req, device=seq_lens.device, dtype=seq_lens.dtype
-            )
-        else:
-            offsets = torch.arange(
-                1 - q_len_per_req, 1, device=seq_lens.device, dtype=seq_lens.dtype
-            )
+        offsets = torch.arange(
+            1 - q_len_per_req, 1, device=seq_lens.device, dtype=seq_lens.dtype
+        )
         # Padded graph rows can be shorter than q_len; real rows are unaffected.
         return (seq_lens.view(-1, 1) + offsets).clamp_min_(0).reshape(-1)
 
@@ -566,16 +547,9 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
         block_tables = metadata.block_kv_indices[
             num_extends : num_extends + decode_window.num_reqs
         ]
-        draft_catchup = bool(
-            getattr(ctx.attn_backend, "is_draft", False)
-            and ctx.forward_mode is not None
-            and ctx.forward_mode.is_decode()
-            and decode_window.q_len_per_req > 1
-        )
         seq_lens_per_token = self._expand_decode_seq_lens_per_token(
             seq_lens,
             decode_window.q_len_per_req,
-            draft_catchup=draft_catchup,
         )
         block_tables_per_token = (
             block_tables

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -953,6 +953,7 @@ def dsa_decode_topk(
     softmax_scale: float,
     q_len_per_req: int = 1,
     index_k_cache: torch.Tensor | None = None,
+    seq_lens_2d: torch.Tensor | None = None,
     plan: object | None = None,
     out: torch.Tensor | None = None,
     lens_out: torch.Tensor | None = None,
@@ -964,12 +965,16 @@ def dsa_decode_topk(
     Args:
         q: BF16 indexer query with shape [tokens, index_heads, head_dim].
         weights: FP32 per-token/head weights with shape [tokens, index_heads].
-        seq_lens: Visible KV length per query token, shape [tokens].
-        block_table: Paged KV block table with one row per query token.
+        seq_lens: Per-request full KV length, shape [num_reqs] (= tokens /
+            q_len_per_req). Each query token's causal bound
+            seq_lens[req] - (q_len_per_req - 1) + j is derived in-kernel.
+        block_table: Paged KV block table with one row per request,
+            shape [num_reqs, max_pages].
         page_size: Number of tokens per KV page.
         topk: Number of KV candidates to select.
         softmax_scale: Score scale, normally index_head_dim ** -0.5.
-        q_len_per_req: Query rows per request. Plain decode uses 1.
+        q_len_per_req: Query rows per request (spec-verify next_n). Plain
+            decode uses 1, where per-request is equivalent to per-token.
         index_k_cache: Packed FP8 index-K cache with scales (uint8). Used by
             both Triton and DeepGEMM.
         plan: Optional opaque backend-specific plan.
@@ -1035,6 +1040,7 @@ def dsa_decode_topk(
             softmax_scale=softmax_scale,
             q_len_per_req=q_len_per_req,
             index_k_cache=index_k_cache,
+            seq_lens_2d=seq_lens_2d,
             plan=plan,
             out=out,
             lens_out=lens_out,
@@ -1042,10 +1048,9 @@ def dsa_decode_topk(
 
 
 def dsa_plan(
-    seq_lens: torch.Tensor,
     *,
     page_size: int,
-    q_len_per_req: int = 1,
+    seq_lens_2d: torch.Tensor,
     out: object | None = None,
     override: str | None = None,
     solution: str | None = None,
@@ -1053,10 +1058,9 @@ def dsa_plan(
     """Build or refresh an opaque plan for DSA decode top-k.
 
     Args:
-        seq_lens: Visible KV length per query token, shape [tokens] or
-            [batch, q_len_per_req].
         page_size: KV cache page size.
-        q_len_per_req: Query rows per request. Plain decode uses 1.
+        seq_lens_2d: Prebuilt [num_reqs, next_n] context_lens (last column =
+            full per-request KV length), built once per forward by the caller.
         out: Optional previously allocated plan object to refresh in place.
         override: Optional exact kernel override name.
         solution: Optional kernel solution to force through normal selection.
@@ -1065,14 +1069,12 @@ def dsa_plan(
         Opaque backend-owned plan object, or None when no selected backend needs
         an explicit plan.
     """
-    if seq_lens.dtype != torch.int32:
-        seq_lens = seq_lens.to(torch.int32)
-    q_len_per_req = int(q_len_per_req)
+    if seq_lens_2d.dtype != torch.int32:
+        seq_lens_2d = seq_lens_2d.to(torch.int32)
     traits = {
         "page_size": int(page_size),
-        "q_len_per_req": q_len_per_req,
     }
-    signature = format_signature(seq_lens=dense_tensor_format(seq_lens.dtype))
+    signature = format_signature()
     try:
         kernel = select_kernel(
             "attention",
@@ -1085,32 +1087,24 @@ def dsa_plan(
     except NoKernelFoundError:
         return None
 
-    if seq_lens.dim() == 1:
-        batch_size = int(seq_lens.numel()) // max(q_len_per_req, 1)
-        tokens = int(seq_lens.numel())
-    else:
-        batch_size = int(seq_lens.shape[0])
-        tokens = int(seq_lens.numel())
     shape_params = {
-        "batch_size": batch_size,
-        "tokens": tokens,
-        "q_len_per_req": q_len_per_req,
+        "batch_size": int(seq_lens_2d.shape[0]),
+        "tokens": int(seq_lens_2d.numel()),
         "page_size": int(page_size),
     }
     ShapeCapture.get().record(
-        "attention", "dsa_plan", kernel.name, seq_lens.dtype, shape_params
+        "attention", "dsa_plan", kernel.name, seq_lens_2d.dtype, shape_params
     )
     with kernel_scope(
         "attention",
         "dsa_plan",
-        seq_lens.dtype,
+        seq_lens_2d.dtype,
         kernel_name=kernel.name,
         **shape_params,
     ):
         return kernel(
-            seq_lens=seq_lens,
+            seq_lens_2d=seq_lens_2d,
             page_size=page_size,
-            q_len_per_req=q_len_per_req,
             out=out,
         )
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/deep_gemm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/deep_gemm/__init__.py
@@ -66,35 +66,26 @@ if platform.is_nvidia:
             min_arch_version=ArchVersion(9, 0),
             vendors=frozenset({"nvidia"}),
         ),
-        signatures=frozenset(
-            {format_signature(seq_lens=dense_tensor_format(torch.int32))}
-        ),
+        signatures=frozenset({format_signature()}),
         traits={
             "page_size": frozenset({64}),
-            "q_len_per_req": frozenset({1, 2, 3, 4, 5, 6}),
         },
         priority=Priority.PERFORMANT,
     )
     def deep_gemm_dsa_plan(
-        seq_lens: torch.Tensor,
         *,
         page_size: int,
-        q_len_per_req: int = 1,
+        seq_lens_2d: torch.Tensor,
         out: object | None = None,
     ) -> torch.Tensor:
-        q_len_per_req = int(q_len_per_req)
-        seq_lens = seq_lens.to(dtype=torch.int32).contiguous()
-        if seq_lens.dim() == 1:
-            seq_lens = seq_lens.view(-1, q_len_per_req).contiguous()
-        else:
-            seq_lens = seq_lens.contiguous()
         refreshed = deep_gemm.get_paged_mqa_logits_metadata(
-            seq_lens,
-            int(page_size),
+            seq_lens_2d,
+            page_size,
             deep_gemm.get_num_sms(),
         )
         if out is None:
             return refreshed
+
         if (
             not isinstance(out, torch.Tensor)
             or out.shape != refreshed.shape
@@ -152,19 +143,22 @@ if platform.is_nvidia:
         softmax_scale: float,
         q_len_per_req: int = 1,
         index_k_cache: torch.Tensor | None = None,
+        seq_lens_2d: torch.Tensor | None = None,
         plan: object | None = None,
         out: torch.Tensor | None = None,
         lens_out: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        q = q.contiguous()
-        weights = weights.float().contiguous()
-        seq_lens = seq_lens.to(device=q.device, dtype=torch.int32).contiguous()
-        block_table = block_table.to(device=q.device, dtype=torch.int32).contiguous()
-        tokens = q.shape[0]
+        assert weights.dtype == torch.float32
+        assert weights.is_contiguous()
+        assert seq_lens.dtype == torch.int32
+        assert seq_lens.is_contiguous()
+        assert block_table.dtype == torch.int32
+        assert block_table.is_contiguous()
+
         out, lens_out = _check_out(
             out,
             lens_out,
-            tokens=tokens,
+            tokens=q.shape[0],
             topk=topk,
             device=q.device,
         )
@@ -177,27 +171,24 @@ if platform.is_nvidia:
             scale_encoding="float32",
         )
         q_fp8 = q_fp8.view_as(q)
-        q_scale = q_scale.view(tokens, q.shape[1], 1)
+        q_scale = q_scale.view(q.shape[0], q.shape[1], 1)
         scaled_weights = (
             weights.unsqueeze(-1) * q_scale * float(softmax_scale)
         ).squeeze(-1)
 
-        q_len_per_req = int(q_len_per_req)
-        seq_lens_2d = seq_lens.view(-1, q_len_per_req).contiguous()
-        request_block_table = block_table[::q_len_per_req].contiguous()
-        max_seq_len = int(request_block_table.shape[1]) * int(page_size)
+        if seq_lens_2d is None or plan is None:
+            raise RuntimeError(
+                "DeepGEMM DSA decode top-k requires precomputed plan and "
+                "seq_lens_2d (built once per forward via dsa_plan)."
+            )
+
+        max_seq_len = block_table.shape[1] * page_size
         if max_seq_len < int(topk):
             raise RuntimeError(
                 "DeepGEMM DSA paged top-k requires block table capacity >= topk; "
                 f"got capacity={max_seq_len}, topk={topk}"
             )
-        schedule_metadata = plan
-        if schedule_metadata is None:
-            schedule_metadata = deep_gemm.get_paged_mqa_logits_metadata(
-                seq_lens_2d,
-                int(page_size),
-                deep_gemm.get_num_sms(),
-            )
+
         kv_cache = index_k_cache.view(
             -1,
             int(page_size),
@@ -209,8 +200,8 @@ if platform.is_nvidia:
             kv_cache,
             scaled_weights.contiguous(),
             seq_lens_2d,
-            request_block_table,
-            schedule_metadata,
+            block_table,
+            plan,
             max_seq_len,
             clean_logits=False,
         )
@@ -224,6 +215,7 @@ if platform.is_nvidia:
                 local_topk_offsets,
                 int(topk),
                 lengths=seq_lens,
+                q_len_per_req=q_len_per_req,
                 workspace=torch.empty(
                     (_PERSISTENT_TOPK_WORKSPACE_BYTES,),
                     dtype=torch.uint8,
@@ -232,16 +224,19 @@ if platform.is_nvidia:
                 max_seq_len=max_seq_len,
             )
         else:
+            per_token_len = seq_lens_2d.reshape(-1)
             col_ids = torch.arange(logits.shape[1], dtype=torch.int32, device=q.device)
             logits.masked_fill_(
-                col_ids.view(1, -1) >= seq_lens.view(-1, 1), float("-inf")
+                col_ids.view(1, -1) >= per_token_len.view(-1, 1), float("-inf")
             )
             deterministic_decode_topk(logits, local_topk_offsets, int(topk))
+
         return local_topk_to_global_slots(
             local_topk_offsets=local_topk_offsets,
             block_table=block_table,
             block_size=int(page_size),
             seq_lens=seq_lens,
+            q_len_per_req=q_len_per_req,
             out=out,
             lens_out=lens_out,
         )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/deep_gemm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/deep_gemm/__init__.py
@@ -213,7 +213,7 @@ if platform.is_nvidia:
             deterministic_decode_topk(
                 logits,
                 local_topk_offsets,
-                int(topk),
+                topk,
                 lengths=seq_lens,
                 q_len_per_req=q_len_per_req,
                 workspace=torch.empty(
@@ -224,12 +224,19 @@ if platform.is_nvidia:
                 max_seq_len=max_seq_len,
             )
         else:
-            per_token_len = seq_lens_2d.reshape(-1)
+            # No ragged CUDA top-k: mask each row to its causal window first.
+            # seq_lens_2d is a full-length broadcast (only its last column is
+            # read on the hot path), so derive the per-token bound from the
+            # per-request seq_lens: seq_lens[req] - (q_len_per_req - 1) + j.
+            offsets = torch.arange(
+                1 - q_len_per_req, 1, device=seq_lens.device, dtype=torch.int32
+            )
+            seq_lens_per_token = (seq_lens.unsqueeze(1) + offsets).reshape(-1)
             col_ids = torch.arange(logits.shape[1], dtype=torch.int32, device=q.device)
             logits.masked_fill_(
-                col_ids.view(1, -1) >= per_token_len.view(-1, 1), float("-inf")
+                col_ids.view(1, -1) >= seq_lens_per_token.view(-1, 1), float("-inf")
             )
-            deterministic_decode_topk(logits, local_topk_offsets, int(topk))
+            deterministic_decode_topk(logits, local_topk_offsets, topk)
 
         return local_topk_to_global_slots(
             local_topk_offsets=local_topk_offsets,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flashinfer/dsa_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flashinfer/dsa_topk.py
@@ -69,6 +69,7 @@ def deterministic_decode_topk(
     lengths: torch.Tensor | None = None,
     workspace: torch.Tensor | None = None,
     max_seq_len: int | None = None,
+    q_len_per_req: int = 1,
 ) -> None:
     """Select per-row top-``topk`` local offsets deterministically.
 
@@ -89,6 +90,7 @@ def deterministic_decode_topk(
             workspace,
             int(topk),
             int(max_seq_len or logits.shape[1]),
+            int(q_len_per_req),
         )
         return
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/dsa_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/dsa_topk.py
@@ -44,13 +44,17 @@ def _local_topk_to_global_slots_kernel(
     block_size: tl.constexpr,
     topk: tl.constexpr,
     has_seq_lens: tl.constexpr,
+    q_len_per_req: tl.constexpr,
     block: tl.constexpr,
 ):
     token_idx = tl.program_id(0)
+    req_idx = token_idx // q_len_per_req
     count = tl.zeros((), dtype=tl.int32)
     seq_len = tl.full((), block_table_cols * block_size, dtype=tl.int32)
     if has_seq_lens:
-        seq_len = tl.load(seq_lens_ptr + token_idx).to(tl.int32)
+        base = tl.load(seq_lens_ptr + req_idx).to(tl.int32)
+        seq_len = base - (q_len_per_req - 1) + (token_idx % q_len_per_req)
+        seq_len = tl.maximum(seq_len, 0)
 
     for start in range(0, topk, block):
         offsets = start + tl.arange(0, block)
@@ -65,7 +69,7 @@ def _local_topk_to_global_slots_kernel(
         block_offset = local_idx % block_size
         valid = valid & (block_idx >= 0) & (block_idx < block_table_cols)
         page = tl.load(
-            block_table_ptr + token_idx * block_table_stride + block_idx,
+            block_table_ptr + req_idx * block_table_stride + block_idx,
             mask=mask & valid,
             other=0,
         )
@@ -86,6 +90,7 @@ def local_topk_to_global_slots(
     block_table: torch.Tensor,
     block_size: int,
     seq_lens: torch.Tensor | None = None,
+    q_len_per_req: int = 1,
     out: torch.Tensor | None = None,
     lens_out: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -105,17 +110,23 @@ def local_topk_to_global_slots(
     if block_table.shape[1] == 0:
         raise ValueError("block_table must have at least one page column")
     num_tokens, topk = local_topk_offsets.shape
-    if block_table.shape[0] < num_tokens:
+    q_len_per_req = int(q_len_per_req)
+    if q_len_per_req < 1 or num_tokens % q_len_per_req != 0:
         raise ValueError(
-            "block_table must have at least one row per token: "
-            f"rows={block_table.shape[0]}, tokens={num_tokens}"
+            f"q_len_per_req={q_len_per_req} must divide tokens={num_tokens}"
+        )
+    num_reqs = num_tokens // q_len_per_req
+    if block_table.shape[0] < num_reqs:
+        raise ValueError(
+            "block_table must have at least one row per request: "
+            f"rows={block_table.shape[0]}, reqs={num_reqs}"
         )
     if seq_lens is not None and seq_lens.dim() != 1:
         raise ValueError(f"seq_lens must be 1-D, got {tuple(seq_lens.shape)}")
-    if seq_lens is not None and seq_lens.numel() < num_tokens:
+    if seq_lens is not None and seq_lens.numel() < num_reqs:
         raise ValueError(
-            "seq_lens must have at least one entry per token: "
-            f"lens={seq_lens.numel()}, tokens={num_tokens}"
+            "seq_lens must have at least one entry per request: "
+            f"lens={seq_lens.numel()}, reqs={num_reqs}"
         )
 
     if out is None:
@@ -176,6 +187,7 @@ def local_topk_to_global_slots(
         block_size=int(block_size),
         topk=topk,
         has_seq_lens=seq_lens is not None,
+        q_len_per_req=q_len_per_req,
         block=1024,
     )
     return global_slots, lens
@@ -278,19 +290,23 @@ def _dsa_decode_logits_fp8_kernel(
     head_dim: tl.constexpr,
     num_groups: tl.constexpr,
     softmax_scale: tl.constexpr,
+    q_len_per_req: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_D: tl.constexpr,
 ):
     token = tl.program_id(0)
     block_id = tl.program_id(1)
+    req = token // q_len_per_req
     offsets = block_id * BLOCK_N + tl.arange(0, BLOCK_N)
-    seq_len = tl.load(seq_lens + token).to(tl.int32)
+    base = tl.load(seq_lens + req).to(tl.int32)
+    seq_len = base - (q_len_per_req - 1) + (token % q_len_per_req)
+    seq_len = tl.maximum(seq_len, 0)
     valid = offsets < seq_len
     block_idx = offsets // page_size
     block_offset = offsets - block_idx * page_size
     valid = valid & (offsets < max_seq_len)
     page = tl.load(
-        block_table + token * block_table_stride + block_idx,
+        block_table + req * block_table_stride + block_idx,
         mask=valid,
         other=0,
     ).to(tl.int64)
@@ -814,19 +830,27 @@ def dsa_decode_topk_fp8(
     page_size: int,
     topk: int,
     softmax_scale: float,
+    q_len_per_req: int = 1,
     out: torch.Tensor | None = None,
     lens_out: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     row_bytes = _check_packed_fp8_inputs(q, index_k_cache, weights, page_size)
-    if seq_lens.dim() != 1 or seq_lens.numel() != q.shape[0]:
+    q_len_per_req = int(q_len_per_req)
+    if q_len_per_req < 1 or q.shape[0] % q_len_per_req != 0:
         raise ValueError(
-            "seq_lens must be [tokens], got "
-            f"{tuple(seq_lens.shape)} for q={tuple(q.shape)}"
+            f"q_len_per_req={q_len_per_req} must divide tokens={q.shape[0]}"
         )
-    if block_table.dim() != 2 or block_table.shape[0] < q.shape[0]:
+    num_reqs = q.shape[0] // q_len_per_req
+    if seq_lens.dim() != 1 or seq_lens.numel() != num_reqs:
         raise ValueError(
-            "block_table must have at least one row per token, got "
-            f"block_table={tuple(block_table.shape)}, q={tuple(q.shape)}"
+            "seq_lens must be [num_reqs], got "
+            f"{tuple(seq_lens.shape)} for q={tuple(q.shape)}, "
+            f"q_len_per_req={q_len_per_req}"
+        )
+    if block_table.dim() != 2 or block_table.shape[0] < num_reqs:
+        raise ValueError(
+            "block_table must have at least one row per request, got "
+            f"block_table={tuple(block_table.shape)}, num_reqs={num_reqs}"
         )
     if topk <= 0:
         raise ValueError(f"topk must be positive, got {topk}")
@@ -874,6 +898,7 @@ def dsa_decode_topk_fp8(
         head_dim=q.shape[2],
         num_groups=q.shape[2] // 128,
         softmax_scale=float(softmax_scale),
+        q_len_per_req=q_len_per_req,
         BLOCK_N=block_n,
         BLOCK_D=64,
         num_warps=4,
@@ -885,6 +910,7 @@ def dsa_decode_topk_fp8(
         block_table=block_table,
         block_size=int(page_size),
         seq_lens=seq_lens,
+        q_len_per_req=q_len_per_req,
         out=out,
         lens_out=lens_out,
     )
@@ -992,7 +1018,7 @@ def dsa_prefill_topk_fp8(
     name="triton_dsa_plan",
     solution="triton",
     capability=CapabilityRequirement(vendors=frozenset({"nvidia", "amd"})),
-    signatures=frozenset({format_signature(seq_lens=dense_tensor_format(torch.int32))}),
+    signatures=frozenset({format_signature()}),
     traits={
         "page_size": frozenset({64}),
     },
@@ -1000,46 +1026,13 @@ def dsa_prefill_topk_fp8(
     tags={"portability"},
 )
 def triton_dsa_plan(
-    seq_lens: torch.Tensor,
     *,
     page_size: int,
-    q_len_per_req: int = 1,
+    seq_lens_2d: torch.Tensor,
     out: object | None = None,
 ) -> torch.Tensor:
-    q_len_per_req = int(q_len_per_req)
-    seq_lens = seq_lens.to(dtype=torch.int32).contiguous()
-    if seq_lens.dim() == 1:
-        seq_lens = seq_lens.view(-1, q_len_per_req).contiguous()
-    else:
-        seq_lens = seq_lens.contiguous()
-    refreshed = torch.empty(
-        (seq_lens.shape[0], 4), dtype=torch.int32, device=seq_lens.device
-    )
-    refreshed[:, 0].copy_(seq_lens[:, 0])
-    refreshed[:, 1].copy_(seq_lens[:, -1])
-    refreshed[:, 2].fill_(q_len_per_req)
-    refreshed[:, 3].fill_(int(page_size))
-    if out is None:
-        return refreshed
-    if (
-        not isinstance(out, torch.Tensor)
-        or out.shape != refreshed.shape
-        or out.device != refreshed.device
-        or out.dtype != refreshed.dtype
-    ):
-        actual = (
-            f"{tuple(out.shape)} {out.dtype} {out.device}"
-            if isinstance(out, torch.Tensor)
-            else type(out).__name__
-        )
-        raise RuntimeError(
-            "DSA paged top-k plan changed shape during CUDA graph replay; "
-            "recapture or use eager for this batch. "
-            f"captured={actual}, refreshed={tuple(refreshed.shape)} "
-            f"{refreshed.dtype} {refreshed.device}"
-        )
-    out.copy_(refreshed)
-    return out
+    # plan is unused
+    return object() if out is None else out
 
 
 @register_kernel(
@@ -1076,6 +1069,7 @@ def triton_dsa_decode_topk_fp8(
     softmax_scale: float,
     q_len_per_req: int = 1,
     index_k_cache: torch.Tensor | None = None,
+    seq_lens_2d: torch.Tensor | None = None,
     plan: object | None = None,
     out: torch.Tensor | None = None,
     lens_out: torch.Tensor | None = None,
@@ -1091,6 +1085,7 @@ def triton_dsa_decode_topk_fp8(
         page_size=page_size,
         topk=topk,
         softmax_scale=softmax_scale,
+        q_len_per_req=q_len_per_req,
         out=out,
         lens_out=lens_out,
     )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/deepseek_v4_attention_binding.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/deepseek_v4_attention_binding.cu
@@ -51,7 +51,8 @@ void deepseek_v4_persistent_topk(TensorView logits,
                                  TensorView output,
                                  TensorView workspace,
                                  int64_t k,
-                                 int64_t max_seq_len);
+                                 int64_t max_seq_len,
+                                 int64_t q_len_per_req);
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert,
                               fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert);

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/deepseek_v4_persistent_topk.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/deepseek_v4_persistent_topk.cuh
@@ -18,6 +18,22 @@
 #include <cstdint>
 
 namespace vllm {
+
+// Per-row visible KV length for DSA decode top-k. q_len_per_req == 1 keeps the
+// legacy per-token behavior (lengths[row]); q_len_per_req > 1 treats `lengths`
+// as per-request and applies the verify causal bound
+// lengths[row / q] - (q - 1) + (row % q), clamped to >= 0.
+__device__ __forceinline__ uint32_t dsa_topk_row_seq_len(
+    const int32_t* __restrict__ lengths, uint32_t row, uint32_t q_len_per_req) {
+  if (q_len_per_req <= 1) {
+    return static_cast<uint32_t>(lengths[row]);
+  }
+  uint32_t req = row / q_len_per_req;
+  int j = static_cast<int>(row - req * q_len_per_req);
+  int v = lengths[req] - (static_cast<int>(q_len_per_req) - 1) + j;
+  return v > 0 ? static_cast<uint32_t>(v) : 0;
+}
+
 namespace persistent {
 
 // ============================================================================
@@ -142,6 +158,7 @@ struct PersistentTopKParams {
   uint32_t chunk_size;      // large path: elements per CTA
   uint32_t ctas_per_group;  // 1=medium, >1=large
   uint32_t max_seq_len;     // max seq_len across all rows (for early CTA exit)
+  uint32_t q_len_per_req;   // >1: `lengths` is per-request (verify causal bound)
 };
 
 // ============================================================================
@@ -901,7 +918,8 @@ __global__ void __launch_bounds__(kThreadsPerBlock, 2)
     uint32_t row_idx = group_id + iter * num_groups;
     if (row_idx >= params.num_rows) break;
 
-    const uint32_t seq_len = params.lengths[row_idx];
+    const uint32_t seq_len =
+        dsa_topk_row_seq_len(params.lengths, row_idx, params.q_len_per_req);
     int32_t* row_output = params.output + row_idx * params.top_k;
     const float* row_input = params.input + row_idx * params.stride;
 
@@ -1016,7 +1034,7 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
                               IdType* __restrict__ output,
                               const IdType* __restrict__ lengths,
                               uint32_t num_rows, uint32_t top_k,
-                              uint32_t max_len) {
+                              uint32_t max_len, uint32_t q_len_per_req) {
   constexpr uint32_t BLOCK_SIZE = FILTERED_TOPK_BLOCK_THREADS;
   constexpr int RADIX = 256;
   constexpr int SMEM_INPUT_SIZE = FILTERED_TOPK_SMEM_INPUT_SIZE;
@@ -1027,7 +1045,9 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
   if (bid >= num_rows) return;
 
   const int length =
-      (lengths != nullptr) ? lengths[bid] : static_cast<int>(max_len);
+      (lengths != nullptr)
+          ? static_cast<int>(dsa_topk_row_seq_len(lengths, bid, q_len_per_req))
+          : static_cast<int>(max_len);
   const DType* score = input + bid * max_len;
   IdType* dst = output + bid * top_k;
 
@@ -1269,14 +1289,15 @@ template <typename DType, typename IdType, uint32_t MAX_K = 2048>
 cudaError_t FilteredTopKRaggedTransform(DType* input, IdType* output_indices,
                                         IdType* lengths, uint32_t num_rows,
                                         uint32_t top_k_val, uint32_t max_len,
+                                        uint32_t q_len_per_req,
                                         cudaStream_t stream = 0) {
   constexpr size_t smem_size = FILTERED_TOPK_SMEM_DYNAMIC;
   constexpr int MAX_VEC = 16 / sizeof(DType);
 
   dim3 grid(num_rows);
   dim3 block(FILTERED_TOPK_BLOCK_THREADS);
-  void* args[] = {&input,    &output_indices, &lengths,
-                  &num_rows, &top_k_val,      &max_len};
+  void* args[] = {&input,    &output_indices, &lengths,       &num_rows,
+                  &top_k_val, &max_len,       &q_len_per_req};
 
   const int vec_size = ComputeFilteredTopKVecSize<DType>(max_len);
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/deepseek_v4_topk.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/deepseek_v4_topk.cu
@@ -451,6 +451,7 @@ void launch_persistent_topk(const TensorView& logits,
                             TensorView& output,
                             TensorView& workspace,
                             int64_t max_seq_len,
+                            int64_t q_len_per_req,
                             cudaStream_t stream) {
   namespace P = vllm::persistent;
 
@@ -482,7 +483,8 @@ void launch_persistent_topk(const TensorView& logits,
             static_cast<int32_t*>(output.data_ptr()),
             static_cast<int32_t*>(lengths.data_ptr()),
             static_cast<uint32_t>(num_rows), static_cast<uint32_t>(TopK),
-            static_cast<uint32_t>(stride), stream);
+            static_cast<uint32_t>(stride),
+            static_cast<uint32_t>(q_len_per_req), stream);
     TVM_FFI_ICHECK(status == cudaSuccess)
         << "FilteredTopK failed: " << cudaGetErrorString(status);
   } else {
@@ -575,6 +577,7 @@ void launch_persistent_topk(const TensorView& logits,
         reinterpret_cast<P::RadixRowState*>(workspace.data_ptr());
     params.ctas_per_group = ctas_per_group;
     params.max_seq_len = static_cast<uint32_t>(max_seq_len);
+    params.q_len_per_req = static_cast<uint32_t>(q_len_per_req);
 
 #define LAUNCH_PERSISTENT(TOPK_VAL, VS)                                      \
   do {                                                                       \
@@ -608,7 +611,8 @@ void deepseek_v4_persistent_topk(TensorView logits,
                                  TensorView output,
                                  TensorView workspace,
                                  int64_t k,
-                                 int64_t max_seq_len) {
+                                 int64_t max_seq_len,
+                                 int64_t q_len_per_req) {
   CHECK_CUDA(logits);
   CHECK_CUDA(lengths);
   CHECK_CUDA(output);
@@ -626,8 +630,11 @@ void deepseek_v4_persistent_topk(TensorView logits,
   TVM_FFI_ICHECK(lengths.dtype() == dl_int32) << "lengths must be int32";
   TVM_FFI_ICHECK(output.dtype() == dl_int32) << "output must be int32";
   TVM_FFI_ICHECK(workspace.dtype() == dl_uint8) << "workspace must be uint8";
-  TVM_FFI_ICHECK(lengths.numel() == logits.size(0))
-      << "lengths size mismatch";
+  TVM_FFI_ICHECK(q_len_per_req >= 1) << "q_len_per_req must be >= 1";
+  TVM_FFI_ICHECK(logits.size(0) % q_len_per_req == 0)
+      << "q_len_per_req must divide num_rows";
+  TVM_FFI_ICHECK(lengths.numel() == logits.size(0) / q_len_per_req)
+      << "lengths size mismatch (expected num_rows / q_len_per_req)";
   TVM_FFI_ICHECK(output.size(0) == logits.size(0) && output.size(1) == k)
       << "output size mismatch";
   TVM_FFI_ICHECK(k == 512 || k == 1024 || k == 2048)
@@ -640,12 +647,12 @@ void deepseek_v4_persistent_topk(TensorView logits,
   cudaStream_t stream = get_stream(logits.device());
   if (k == 512) {
     launch_persistent_topk<512>(logits, lengths, output, workspace, max_seq_len,
-                                stream);
+                                q_len_per_req, stream);
   } else if (k == 1024) {
     launch_persistent_topk<1024>(logits, lengths, output, workspace, max_seq_len,
-                                 stream);
+                                 q_len_per_req, stream);
   } else {
     launch_persistent_topk<2048>(logits, lengths, output, workspace, max_seq_len,
-                                 stream);
+                                 q_len_per_req, stream);
   }
 }

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/deepseek_v4_attention.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/deepseek_v4_attention.py
@@ -157,6 +157,7 @@ def persistent_topk(
     workspace: torch.Tensor,
     k: int,
     max_seq_len: int,
+    q_len_per_req: int = 1,
 ) -> None:
     if logits.dtype != torch.float32:
         raise TypeError(f"logits must be float32, got {logits.dtype}")
@@ -177,4 +178,5 @@ def persistent_topk(
         workspace,
         int(k),
         int(max_seq_len),
+        int(q_len_per_req),
     )

--- a/tokenspeed-kernel/test/ops/test_attention_dsa.py
+++ b/tokenspeed-kernel/test/ops/test_attention_dsa.py
@@ -125,6 +125,63 @@ def test_dsa_decode_topk_fp8(device: str, require) -> None:
     assert (topk_slots[0, int(expected_lens[0].item()) :] == -1).all()
 
 
+@pytest.mark.parametrize("q_len_per_req", [2, 4])
+def test_dsa_decode_topk_fp8_mtp(device: str, q_len_per_req: int, require) -> None:
+    """Per-request (MTP) decode: seq_lens/block_table are per-request and the
+    kernel derives each token's causal bound seq_lens[req] - (q-1) + j."""
+    require("attention", "dsa_decode_topk", "triton", torch.bfloat16, "q")
+
+    page_size = 64
+    topk = 512
+    num_reqs = 2
+    pages = 8  # capacity 8*64=512 >= topk
+    tokens = num_reqs * q_len_per_req
+    q = torch.randn((tokens, 2, 128), device=device, dtype=torch.bfloat16)
+    weights = torch.randn((tokens, 2), device=device, dtype=torch.float32)
+    packed_index_k, index_k = _pack_index_k_cache(
+        torch.randn((pages * page_size, 128), device=device, dtype=torch.bfloat16),
+        page_size,
+    )
+    seq_lens = torch.tensor([200, 130], device=device, dtype=torch.int32)  # per-req
+    block_table = (
+        torch.arange(pages, device=device, dtype=torch.int32)
+        .view(1, -1)
+        .repeat(num_reqs, 1)
+    )
+
+    topk_slots, topk_lens = dsa_decode_topk(
+        q,
+        weights,
+        seq_lens,
+        block_table,
+        page_size=page_size,
+        topk=topk,
+        softmax_scale=128**-0.5,
+        q_len_per_req=q_len_per_req,
+        index_k_cache=packed_index_k,
+        solution="triton",
+    )
+
+    for r in range(num_reqs):
+        for jj in range(q_len_per_req):
+            token = r * q_len_per_req + jj
+            causal_len = int(seq_lens[r].item()) - (q_len_per_req - 1) + jj
+            scores = []
+            slots = []
+            for off in range(causal_len):
+                page = int(block_table[r, off // page_size].item())
+                slot = page * page_size + off % page_size
+                per_head = (q[token].float() * index_k[slot].float()).sum(dim=-1)
+                scores.append((per_head * weights[token]).sum() * (128**-0.5))
+                slots.append(slot)
+            k = min(causal_len, topk)
+            local = torch.topk(torch.stack(scores), k).indices
+            ref = {slots[int(i)] for i in local.tolist()}
+            got = {int(x) for x in topk_slots[token, :k].tolist() if x >= 0}
+            assert int(topk_lens[token].item()) == k, (token, topk_lens[token], k)
+            assert ref == got, f"token {token}: {len(ref ^ got)} slots differ"
+
+
 def test_dsa_prefill_topk_fp8(device: str, require) -> None:
     require("attention", "dsa_prefill_topk", "triton", torch.bfloat16, "q")
 
@@ -177,36 +234,25 @@ def test_dsa_prefill_topk_fp8(device: str, require) -> None:
     assert (workspace_indices[0, int(expected_lens[0].item()) :] == -1).all()
 
 
-def test_dsa_plan_triton(device: str, require) -> None:
-    require("attention", "dsa_plan", "triton", torch.int32, "seq_lens")
+def test_dsa_plan_triton(device: str) -> None:
+    # The triton decode kernel derives its own causal bounds and ignores the
+    # plan, so triton_dsa_plan is a no-op returning an opaque, non-None
+    # placeholder; passing out= returns that same placeholder.
+    seq_lens_2d = torch.tensor([[20], [65], [3]], device=device, dtype=torch.int32)
+    plan = dsa_plan(seq_lens_2d=seq_lens_2d, page_size=64, solution="triton")
+    if plan is None:
+        pytest.skip("triton dsa_plan is not registered on this platform")
 
-    seq_lens = torch.tensor([20, 65, 3], device=device, dtype=torch.int32)
-    plan = dsa_plan(seq_lens, page_size=64, solution="triton")
-
-    assert isinstance(plan, torch.Tensor)
-    assert plan.shape == (3, 4)
-    assert plan.dtype == torch.int32
-    torch.testing.assert_close(plan[:, 0].cpu(), seq_lens.cpu())
-    torch.testing.assert_close(plan[:, 1].cpu(), seq_lens.cpu())
-    torch.testing.assert_close(plan[:, 2].cpu(), torch.full((3,), 1, dtype=torch.int32))
-    torch.testing.assert_close(
-        plan[:, 3].cpu(), torch.full((3,), 64, dtype=torch.int32)
+    refreshed = dsa_plan(
+        seq_lens_2d=seq_lens_2d, page_size=64, out=plan, solution="triton"
     )
-
-    plan_ptr = plan.data_ptr()
-    refreshed = dsa_plan(seq_lens + 1, page_size=64, out=plan, solution="triton")
     assert refreshed is plan
-    assert plan.data_ptr() == plan_ptr
-    torch.testing.assert_close(plan[:, 0].cpu(), (seq_lens + 1).cpu())
-
-    with pytest.raises(RuntimeError, match="DSA paged top-k plan changed shape"):
-        dsa_plan(seq_lens[:2], page_size=64, out=plan, solution="triton")
 
 
 def test_dsa_plan_returns_none_without_kernel(device: str) -> None:
-    seq_lens = torch.tensor([1], device=device, dtype=torch.int32)
+    seq_lens_2d = torch.tensor([[1]], device=device, dtype=torch.int32)
 
-    assert dsa_plan(seq_lens, page_size=64, solution="missing") is None
+    assert dsa_plan(seq_lens_2d=seq_lens_2d, page_size=64, solution="missing") is None
 
 
 def test_dsa_workspace_topk_to_global_slots(device: str) -> None:

--- a/tokenspeed-kernel/test/ops/test_dsa_topk.py
+++ b/tokenspeed-kernel/test/ops/test_dsa_topk.py
@@ -34,12 +34,15 @@ def test_decode_topk_uses_ragged_path_when_lengths_and_workspace_are_provided(
 
     monkeypatch.setattr(dsa_topk, "has_persistent_topk", lambda: True)
 
-    def fake_persistent_topk(logits, lengths, output, workspace, k, max_seq_len):
+    def fake_persistent_topk(
+        logits, lengths, output, workspace, k, max_seq_len, q_len_per_req=1
+    ):
         calls["logits"] = logits
         calls["lengths"] = lengths
         calls["workspace"] = workspace
         calls["k"] = k
         calls["max_seq_len"] = max_seq_len
+        calls["q_len_per_req"] = q_len_per_req
         output.fill_(7)
 
     monkeypatch.setattr(dsa_topk, "persistent_topk", fake_persistent_topk)
@@ -64,6 +67,7 @@ def test_decode_topk_uses_ragged_path_when_lengths_and_workspace_are_provided(
     assert calls["workspace"] is workspace
     assert calls["k"] == 4
     assert calls["max_seq_len"] == 8
+    assert calls["q_len_per_req"] == 1
 
 
 def test_decode_topk_rejects_partial_or_unavailable_ragged_inputs(monkeypatch):

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -548,8 +548,8 @@ def _attention_dsa_prefill_topk() -> object:
 
 
 def _attention_dsa_plan() -> object:
-    seq_lens = torch.tensor([64, 64], dtype=torch.int32)
-    return tokenspeed_kernel.dsa_plan(seq_lens, page_size=64)
+    seq_lens_2d = torch.tensor([[64], [64]], dtype=torch.int32)
+    return tokenspeed_kernel.dsa_plan(seq_lens_2d=seq_lens_2d, page_size=64)
 
 
 def _attention_merge_state() -> object:


### PR DESCRIPTION
## Summary

Moves DSA decode top-k metadata ownership from the model into the attention backend and drops the per-token seq-len/block-table expansion in favor of passing per-request tensors plus q_len_per_req down to the kernel, which now derives the per-row causal window itself.

### What changed

- dsa.py (backend owns metadata): builds the paged-MQA-logits plan and the broadcast _dsa_seq_lens_2d once per forward (capture/replay/advance/eager), instead of the model rebuilding them each layer. The plan is scoped to the decode subset ([num_extends:]) for mixed batches.
- glm5.py / glm5_nextn.py: the model now just reads backend metadata and passes per-request seq_lens + block_tables + q_len_per_req; removes the per-token expand/repeat_interleave and the lazy plan cache.
- Kernels (deep_gemm, triton, vendored CUDA): accept q_len_per_req and per-request seq_lens; the causal bound seq_lens[req] - (q_len-1) + j is computed in-kernel (persistent top-k) or via a fallback mask on the deep_gemm path. Matches the TRT-LLM topKPerRowDecode reference.
