### PR TITLE
fix(deepseek-v4): gate experimental TRT-LLM mHC backend

### DIFF
--- a/docs/recipes/models.md
+++ b/docs/recipes/models.md
@@ -203,6 +203,19 @@ speculative decoding and paged-cache groups are both active — and prefix cachi
 stays on by default. Add `--enable-metrics` to read `Decoded Tok/Iter` and the
 speculative accept rate from the run summary.
 
+The TRT-LLM mHC backend is experimental and disabled by default. Set
+`TOKENSPEED_V4_MHC_BACKEND=auto` to use it for decode and idle batches,
+including CUDA graph capture, while retaining the original DeepGEMM and Triton
+path for target-model eager extend and mixed batches. MTP drafter follow-up
+steps are intentionally represented as `DECODE` after the first catch-up step,
+even when that first step originated from an extend batch, so those draft
+substeps can select TRT-LLM mHC in `auto` mode. Set the value to `trtllm` to
+require the TRT-LLM path for every supported batch and fail fast during model
+construction when the package, device, or tensor shape is unsupported. Set it
+to `native`, the default, to retain the
+original path. The selective `auto` policy still requires larger repeated
+benchmarks before it should become the default.
+
 ## Tuning Order
 
 1. Set model ID, trust policy, tokenizer mode, and served model name.

--- a/python/tokenspeed/runtime/layers/deepseek_v4_mhc.py
+++ b/python/tokenspeed/runtime/layers/deepseek_v4_mhc.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import logging
 from functools import cache
 
 import torch
@@ -19,6 +20,84 @@ from tokenspeed_kernel.ops.mhc import (
 )
 
 from tokenspeed.runtime.utils import ceil_div
+from tokenspeed.runtime.utils.env import envs
+
+_MHC_BACKEND_ENV = "TOKENSPEED_V4_MHC_BACKEND"
+_MHC_BACKEND_SELECTIONS_LOGGED: set[tuple[str, bool, bool, torch.device, int, int]] = (
+    set()
+)
+logger = logging.getLogger(__name__)
+
+
+def _mhc_backend() -> str:
+    backend = envs.TOKENSPEED_V4_MHC_BACKEND.get().strip().lower()
+    if backend not in {"auto", "native", "trtllm"}:
+        raise ValueError(
+            f"{_MHC_BACKEND_ENV}={backend!r} must be one of " "'auto'|'native'|'trtllm'"
+        )
+    return backend
+
+
+def _validate_mhc_backend_config(
+    device: torch.device,
+    hc_mult: int,
+    hidden_size: int,
+) -> None:
+    """Validate static mHC backend configuration before model construction."""
+
+    backend = _mhc_backend()
+    if backend == "trtllm" and not supports_trtllm_mhc(device, hc_mult, hidden_size):
+        raise RuntimeError(
+            "TRT-LLM mHC was requested but is unavailable for "
+            f"device={device}, hc_mult={hc_mult}, hidden_size={hidden_size}"
+        )
+
+
+def _use_trtllm_mhc(
+    device: torch.device,
+    hc_mult: int,
+    hidden_size: int,
+    allow_trtllm_auto: bool = False,
+) -> bool:
+    """Resolve the experimental V4 mHC backend for one supported tensor shape."""
+
+    backend = _mhc_backend()
+    supported: bool | None = None
+    if backend == "native":
+        selected = False
+    elif backend == "auto" and not allow_trtllm_auto:
+        selected = False
+    else:
+        supported = supports_trtllm_mhc(device, hc_mult, hidden_size)
+        if backend == "trtllm" and not supported:
+            raise RuntimeError(
+                "TRT-LLM mHC was requested but is unavailable for "
+                f"device={device}, hc_mult={hc_mult}, hidden_size={hidden_size}"
+            )
+        selected = supported
+
+    selection = (
+        backend,
+        allow_trtllm_auto,
+        selected,
+        device,
+        hc_mult,
+        hidden_size,
+    )
+    if selection not in _MHC_BACKEND_SELECTIONS_LOGGED:
+        _MHC_BACKEND_SELECTIONS_LOGGED.add(selection)
+        logger.info(
+            "V4 mHC backend selection: requested=%s selected=%s "
+            "allow_trtllm_auto=%s supported=%s device=%s hc_mult=%d hidden_size=%d",
+            backend,
+            "trtllm" if selected else "native",
+            allow_trtllm_auto,
+            supported if supported is not None else "not-probed",
+            device,
+            hc_mult,
+            hidden_size,
+        )
+    return selected
 
 
 @cache
@@ -425,6 +504,8 @@ def mhc_fused_hc(
     hc_eps: float,
     sinkhorn_iters: int,
     workspace: MhcFusedWorkspace,
+    *,
+    allow_trtllm_auto: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Fused post_mapping(prev) + pre_mapping(curr).
 
@@ -440,6 +521,7 @@ def mhc_fused_hc(
         hc_eps: Hyper-connection normalization epsilon.
         sinkhorn_iters: Number of Sinkhorn normalization iterations.
         workspace: Model-owned serial fused-mHC workspace.
+        allow_trtllm_auto: Allow the experimental backend when mode is `auto`.
 
     Returns:
         ``(residual_cur, layer_input, post_cur, comb_cur)``. The TRT-LLM path
@@ -458,7 +540,7 @@ def mhc_fused_hc(
         or comb_prev.dtype != torch.float32
     ):
         raise RuntimeError("fast mHC requires bf16 states and fp32 weights/mixes")
-    if supports_trtllm_mhc(residual_prev.device, hc_mult, hidden_size):
+    if _use_trtllm_mhc(residual_prev.device, hc_mult, hidden_size, allow_trtllm_auto):
         return _trtllm_mhc_fused_hc(
             x_prev,
             residual_prev,
@@ -472,7 +554,13 @@ def mhc_fused_hc(
             sinkhorn_iters,
             workspace,
         )
-    residual_cur = mhc_post(x_prev, residual_prev, post_prev, comb_prev)
+    residual_cur = mhc_post(
+        x_prev,
+        residual_prev,
+        post_prev,
+        comb_prev,
+        allow_trtllm_auto=allow_trtllm_auto,
+    )
     layer_input, post_cur, comb_cur = mhc_pre(
         residual_cur,
         fn,
@@ -481,6 +569,7 @@ def mhc_fused_hc(
         rms_eps,
         hc_eps,
         sinkhorn_iters,
+        allow_trtllm_auto=allow_trtllm_auto,
     )
     return residual_cur, layer_input, post_cur, comb_cur
 
@@ -676,6 +765,8 @@ def mhc_pre(
     rms_eps: float,
     hc_eps: float,
     sinkhorn_iters: int,
+    *,
+    allow_trtllm_auto: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     hc_mult = residual.shape[-2]
     hidden_size = residual.shape[-1]
@@ -686,7 +777,7 @@ def mhc_pre(
         or hc_base.dtype != torch.float32
     ):
         raise RuntimeError("fast mHC requires bf16 residual and fp32 weights")
-    if supports_trtllm_mhc(residual.device, hc_mult, hidden_size):
+    if _use_trtllm_mhc(residual.device, hc_mult, hidden_size, allow_trtllm_auto):
         return _trtllm_mhc_pre(
             residual, fn, hc_scale, hc_base, rms_eps, hc_eps, sinkhorn_iters
         )
@@ -797,6 +888,8 @@ def mhc_post(
     residual: torch.Tensor,
     post: torch.Tensor,
     comb: torch.Tensor,
+    *,
+    allow_trtllm_auto: bool = False,
 ) -> torch.Tensor:
     hc_mult = residual.shape[-2]
     hidden_size = residual.shape[-1]
@@ -807,7 +900,7 @@ def mhc_post(
         or comb.dtype != torch.float32
     ):
         raise RuntimeError("fast mHC requires bf16 states and fp32 mixes")
-    if supports_trtllm_mhc(residual.device, hc_mult, hidden_size):
+    if _use_trtllm_mhc(residual.device, hc_mult, hidden_size, allow_trtllm_auto):
         return _trtllm_mhc_post(hidden_states, residual, post, comb)
     if not hidden_states.is_cuda:
         raise RuntimeError("fast mHC requires CUDA tensors")

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -108,6 +108,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
 )
 from tokenspeed.runtime.layers.deepseek_v4_mhc import (
     MhcFusedWorkspace,
+    _validate_mhc_backend_config,
 )
 from tokenspeed.runtime.layers.deepseek_v4_mhc import mhc_fused_hc as fast_mhc_fused_hc
 from tokenspeed.runtime.layers.deepseek_v4_mhc import mhc_post as fast_mhc_post
@@ -362,6 +363,12 @@ def _deepseek_v4_reorder_c4_ape_2604(ape: torch.Tensor) -> torch.Tensor:
     return torch.cat([older, newer], dim=0).reshape_as(ape)
 
 
+def _use_trtllm_mhc_auto(ctx: ForwardContext) -> bool:
+    """Use the TRT-LLM mHC backend only for decode-shaped V4 batches."""
+
+    return ctx.forward_mode is not None and ctx.forward_mode.is_decode_or_idle()
+
+
 def mhc_pre(
     residual: torch.Tensor,
     fn: torch.Tensor,
@@ -370,6 +377,8 @@ def mhc_pre(
     rms_eps: float,
     hc_eps: float,
     sinkhorn_iters: int,
+    *,
+    allow_trtllm_auto: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     return fast_mhc_pre(
         residual,
@@ -379,6 +388,7 @@ def mhc_pre(
         rms_eps,
         hc_eps,
         sinkhorn_iters,
+        allow_trtllm_auto=allow_trtllm_auto,
     )
 
 
@@ -387,8 +397,12 @@ def mhc_post(
     residual: torch.Tensor,
     post: torch.Tensor,
     comb: torch.Tensor,
+    *,
+    allow_trtllm_auto: bool = False,
 ) -> torch.Tensor:
-    return fast_mhc_post(hidden_states, residual, post, comb)
+    return fast_mhc_post(
+        hidden_states, residual, post, comb, allow_trtllm_auto=allow_trtllm_auto
+    )
 
 
 def mhc_fused_hc(
@@ -403,6 +417,8 @@ def mhc_fused_hc(
     hc_eps: float,
     sinkhorn_iters: int,
     workspace: MhcFusedWorkspace,
+    *,
+    allow_trtllm_auto: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     return fast_mhc_fused_hc(
         x_prev,
@@ -416,6 +432,7 @@ def mhc_fused_hc(
         hc_eps,
         sinkhorn_iters,
         workspace,
+        allow_trtllm_auto=allow_trtllm_auto,
     )
 
 
@@ -3869,6 +3886,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         hc_post_prev: torch.Tensor | None = None,
         hc_comb_prev: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        allow_trtllm_auto = _use_trtllm_mhc_auto(ctx)
         if hc_x_prev is not None:
             with nvtx_range("hc_fused_attn_pre"):
                 residual, hidden_states, post, comb = mhc_fused_hc(
@@ -3883,6 +3901,7 @@ class DeepseekV4DecoderLayer(nn.Module):
                     self.hc_eps,
                     self.hc_sinkhorn_iters,
                     self.mhc_workspace,
+                    allow_trtllm_auto=allow_trtllm_auto,
                 )
         else:
             residual = hidden_states
@@ -3895,6 +3914,7 @@ class DeepseekV4DecoderLayer(nn.Module):
                     self.rms_norm_eps,
                     self.hc_eps,
                     self.hc_sinkhorn_iters,
+                    allow_trtllm_auto=allow_trtllm_auto,
                 )
         with nvtx_range("attn_norm"):
             hidden_states = self.attn_norm(hidden_states)
@@ -3922,6 +3942,7 @@ class DeepseekV4DecoderLayer(nn.Module):
                 self.hc_eps,
                 self.hc_sinkhorn_iters,
                 self.mhc_workspace,
+                allow_trtllm_auto=allow_trtllm_auto,
             )
         with nvtx_range("ffn_norm"):
             hidden_states = self.ffn_norm(hidden_states)
@@ -3977,6 +3998,12 @@ class DeepseekV4Model(nn.Module):
         self.hc_mult = config.hc_mult
         self.hc_eps = config.hc_eps
         self.rms_norm_eps = config.rms_norm_eps
+        mhc_device = (
+            torch.device("cuda", torch.cuda.current_device())
+            if torch.cuda.is_available()
+            else torch.device("cpu")
+        )
+        _validate_mhc_backend_config(mhc_device, self.hc_mult, config.hidden_size)
         self.aux_stream = torch.cuda.Stream() if torch.cuda.is_available() else None
         self.topk_indices_buffer = _DeepseekV4TopKBuffer(int(config.index_topk))
         self.mhc_workspace = MhcFusedWorkspace()
@@ -4061,7 +4088,11 @@ class DeepseekV4Model(nn.Module):
             )
         with nvtx_range("hc_ffn_post_final"):
             hidden_states = mhc_post(
-                hc_x_prev, hidden_states, hc_post_prev, hc_comb_prev
+                hc_x_prev,
+                hidden_states,
+                hc_post_prev,
+                hc_comb_prev,
+                allow_trtllm_auto=_use_trtllm_mhc_auto(ctx),
             )
         aux_hidden_states = None
         if (

--- a/python/tokenspeed/runtime/models/deepseek_v4_mtp.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_mtp.py
@@ -51,6 +51,7 @@ from tokenspeed.runtime.models.deepseek_v4 import (
     DeepseekV4DecoderLayer,
     DeepseekV4MegaMoEExperts,
     _deepseek_v4_swa_slot_mapping,
+    _use_trtllm_mhc_auto,
     hc_head,
     mhc_post,
 )
@@ -190,7 +191,13 @@ class DeepseekV4MultiTokenPredictorLayer(nn.Module):
             input_ids,
             swa_slot_mapping,
         )
-        return mhc_post(x_def, residual, post_def, comb_def)
+        return mhc_post(
+            x_def,
+            residual,
+            post_def,
+            comb_def,
+            allow_trtllm_auto=_use_trtllm_mhc_auto(ctx),
+        )
 
     def compute_logits_hidden(self, hidden_states: torch.Tensor) -> torch.Tensor:
         hidden_states = hidden_states.view(-1, self.hc_mult, self.config.hidden_size)

--- a/python/tokenspeed/runtime/utils/env.py
+++ b/python/tokenspeed/runtime/utils/env.py
@@ -238,6 +238,7 @@ class Envs:
     TOKENSPEED_CI_SMALL_KV_SIZE = EnvInt(-1)
     TOKENSPEED_NVTX = EnvBool(False)
     TOKENSPEED_DP_SAMPLING_BACKEND = EnvStr(None)
+    TOKENSPEED_V4_MHC_BACKEND = EnvStr("native")
 
     # Scheduler
     TOKENSPEED_BLOCK_NONZERO_RANK_CHILDREN = EnvBool(True)

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -1,4 +1,5 @@
 import argparse
+import inspect
 import os
 import sys
 import unittest
@@ -3593,30 +3594,37 @@ class TestDeepseekV4Config(unittest.TestCase):
             max_context_len=1,
         )
 
-        with patch.object(
-            deepseek_v4_model,
-            "deepseek_v4_prepare_indexer_q_mxfp4",
-            side_effect=fake_prepare_mxfp4,
-        ), patch.object(
-            deepseek_v4_model,
-            "_deepseek_v4_deepgemm_fp4_indexer_available",
-            return_value=True,
-        ), patch.object(
-            deepseek_v4_model,
-            "_deepseek_v4_indexer_prefill_metadata",
-            return_value=empty_prefill_metadata,
-        ), patch.object(
-            deepseek_v4_model,
-            "_deepseek_v4_indexer_decode_plan",
-            return_value=decode_metadata,
-        ), patch.object(
-            deepseek_v4_model,
-            "_deepseek_v4_indexer_decode_schedule_metadata",
-            return_value=None,
-        ), patch.object(
-            deepseek_v4_model,
-            "_deepseek_v4_sparse_attn_indexer",
-            side_effect=fake_sparse_indexer,
+        with (
+            patch.object(
+                deepseek_v4_model,
+                "deepseek_v4_prepare_indexer_q_mxfp4",
+                side_effect=fake_prepare_mxfp4,
+            ),
+            patch.object(
+                deepseek_v4_model,
+                "_deepseek_v4_deepgemm_fp4_indexer_available",
+                return_value=True,
+            ),
+            patch.object(
+                deepseek_v4_model,
+                "_deepseek_v4_indexer_prefill_metadata",
+                return_value=empty_prefill_metadata,
+            ),
+            patch.object(
+                deepseek_v4_model,
+                "_deepseek_v4_indexer_decode_plan",
+                return_value=decode_metadata,
+            ),
+            patch.object(
+                deepseek_v4_model,
+                "_deepseek_v4_indexer_decode_schedule_metadata",
+                return_value=None,
+            ),
+            patch.object(
+                deepseek_v4_model,
+                "_deepseek_v4_sparse_attn_indexer",
+                side_effect=fake_sparse_indexer,
+            ),
         ):
             actual = DeepseekV4Indexer._forward_sparse_indexer_custom_op(
                 self_obj,
@@ -4011,7 +4019,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             mhc_post(hidden_states, residual, post, comb)
 
-    def test_mhc_post_uses_triton_for_unsupported_trtllm_shape(self):
+    def test_mhc_post_auto_falls_back_for_unsupported_trtllm_shape(self):
         if not torch.cuda.is_available():
             self.skipTest("CUDA is required for the fast mHC fallback")
 
@@ -4027,10 +4035,205 @@ class TestDeepseekV4Config(unittest.TestCase):
         post = torch.randn(tokens, hc_mult, 1, dtype=torch.float32, device=device)
         comb = torch.randn(tokens, hc_mult, hc_mult, dtype=torch.float32, device=device)
 
-        actual = deepseek_v4_mhc.mhc_post(hidden_states, residual, post, comb)
+        with deepseek_v4_mhc.envs.TOKENSPEED_V4_MHC_BACKEND.override("auto"):
+            actual = deepseek_v4_mhc.mhc_post(
+                hidden_states, residual, post, comb, allow_trtllm_auto=True
+            )
         expected = _mhc_post_reference(hidden_states, residual, post, comb)
 
         torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+    def test_mhc_backend_native_disables_trtllm(self):
+        with (
+            deepseek_v4_mhc.envs.TOKENSPEED_V4_MHC_BACKEND.override("native"),
+            patch.object(
+                deepseek_v4_mhc, "supports_trtllm_mhc", return_value=True
+            ) as supports,
+        ):
+            self.assertFalse(
+                deepseek_v4_mhc._use_trtllm_mhc(torch.device("cuda"), 4, 7168, True)
+            )
+        supports.assert_not_called()
+
+    def test_mhc_backend_auto_falls_back_when_shape_is_unsupported(self):
+        with (
+            deepseek_v4_mhc.envs.TOKENSPEED_V4_MHC_BACKEND.override("auto"),
+            patch.object(deepseek_v4_mhc, "supports_trtllm_mhc", return_value=False),
+        ):
+            self.assertFalse(
+                deepseek_v4_mhc._use_trtllm_mhc(torch.device("cuda"), 4, 7168, True)
+            )
+
+    def test_mhc_backend_startup_auto_does_not_require_trtllm(self):
+        with (
+            deepseek_v4_mhc.envs.TOKENSPEED_V4_MHC_BACKEND.override("auto"),
+            patch.object(
+                deepseek_v4_mhc, "supports_trtllm_mhc", return_value=False
+            ) as supports,
+        ):
+            deepseek_v4_mhc._validate_mhc_backend_config(torch.device("cpu"), 4, 7168)
+        supports.assert_not_called()
+
+    def test_mhc_backend_validation_runs_during_model_init(self):
+        config = SimpleNamespace(
+            hc_mult=4,
+            hc_eps=1e-6,
+            rms_norm_eps=1e-6,
+            index_topk=2,
+            vocab_size=128,
+            hidden_size=7168,
+            num_hidden_layers=0,
+        )
+        mapping = SimpleNamespace(
+            attn=SimpleNamespace(tp_rank=0, tp_size=1, tp_group=None)
+        )
+        expected_device = (
+            torch.device("cuda", torch.cuda.current_device())
+            if torch.cuda.is_available()
+            else torch.device("cpu")
+        )
+
+        with (
+            patch.object(deepseek_v4_model, "_validate_mhc_backend_config") as validate,
+            patch.object(
+                deepseek_v4_model,
+                "VocabParallelEmbedding",
+                return_value=torch.nn.Identity(),
+            ),
+            patch.object(
+                deepseek_v4_model, "RMSNorm", return_value=torch.nn.Identity()
+            ),
+        ):
+            deepseek_v4_model.DeepseekV4Model(config, mapping)
+
+        validate.assert_called_once_with(expected_device, 4, 7168)
+
+    def test_mhc_backend_trtllm_rejects_unavailable_shape(self):
+        with (
+            deepseek_v4_mhc.envs.TOKENSPEED_V4_MHC_BACKEND.override("trtllm"),
+            patch.object(deepseek_v4_mhc, "supports_trtllm_mhc", return_value=False),
+            self.assertRaisesRegex(RuntimeError, "TRT-LLM mHC was requested"),
+        ):
+            deepseek_v4_mhc._use_trtllm_mhc(torch.device("cuda"), 4, 7168, True)
+
+    def test_mhc_backend_startup_rejects_unavailable_forced_backend(self):
+        with (
+            deepseek_v4_mhc.envs.TOKENSPEED_V4_MHC_BACKEND.override("trtllm"),
+            patch.object(deepseek_v4_mhc, "supports_trtllm_mhc", return_value=False),
+            self.assertRaisesRegex(RuntimeError, "TRT-LLM mHC was requested"),
+        ):
+            deepseek_v4_mhc._validate_mhc_backend_config(torch.device("cpu"), 4, 7168)
+
+    def test_mhc_backend_auto_uses_trtllm_when_enabled(self):
+        with (
+            deepseek_v4_mhc.envs.TOKENSPEED_V4_MHC_BACKEND.override("auto"),
+            patch.object(deepseek_v4_mhc, "supports_trtllm_mhc", return_value=True),
+        ):
+            self.assertTrue(
+                deepseek_v4_mhc._use_trtllm_mhc(torch.device("cuda"), 4, 7168, True)
+            )
+
+    def test_mhc_backend_selection_logs_each_path_once(self):
+        selections = deepseek_v4_mhc._MHC_BACKEND_SELECTIONS_LOGGED
+        selections.clear()
+        self.addCleanup(selections.clear)
+
+        with (
+            deepseek_v4_mhc.envs.TOKENSPEED_V4_MHC_BACKEND.override("auto"),
+            patch.object(deepseek_v4_mhc, "supports_trtllm_mhc", return_value=True),
+            self.assertLogs(deepseek_v4_mhc.logger, level="INFO") as logs,
+        ):
+            for _ in range(2):
+                self.assertTrue(
+                    deepseek_v4_mhc._use_trtllm_mhc(torch.device("cuda"), 4, 7168, True)
+                )
+            self.assertFalse(
+                deepseek_v4_mhc._use_trtllm_mhc(torch.device("cuda"), 4, 7168)
+            )
+            self.assertTrue(
+                deepseek_v4_mhc._use_trtllm_mhc(torch.device("cuda"), 4, 4096, True)
+            )
+
+        self.assertEqual(
+            sum("selected=trtllm" in message for message in logs.output), 2
+        )
+        self.assertEqual(
+            sum("selected=native" in message for message in logs.output), 1
+        )
+        self.assertTrue(
+            any("supported=not-probed" in message for message in logs.output)
+        )
+        self.assertTrue(any("hidden_size=4096" in message for message in logs.output))
+        self.assertTrue(any("hidden_size=7168" in message for message in logs.output))
+
+    def test_mhc_backend_auto_fails_closed_when_flag_is_omitted(self):
+        with (
+            deepseek_v4_mhc.envs.TOKENSPEED_V4_MHC_BACKEND.override("auto"),
+            patch.object(
+                deepseek_v4_mhc, "supports_trtllm_mhc", return_value=True
+            ) as supports,
+        ):
+            self.assertFalse(
+                deepseek_v4_mhc._use_trtllm_mhc(torch.device("cuda"), 4, 7168)
+            )
+        supports.assert_not_called()
+
+    def test_mhc_wrapper_auto_flags_default_to_false(self):
+        functions = (
+            deepseek_v4_mhc.mhc_pre,
+            deepseek_v4_mhc.mhc_post,
+            deepseek_v4_mhc.mhc_fused_hc,
+            deepseek_v4_model.mhc_pre,
+            deepseek_v4_model.mhc_post,
+            deepseek_v4_model.mhc_fused_hc,
+        )
+        for function in functions:
+            with self.subTest(function=function.__qualname__):
+                parameter = inspect.signature(function).parameters["allow_trtllm_auto"]
+                self.assertIs(parameter.default, False)
+
+    def test_mhc_model_wrappers_forward_auto_flag(self):
+        cases = (
+            ("fast_mhc_pre", deepseek_v4_model.mhc_pre, (object(),) * 7),
+            ("fast_mhc_post", deepseek_v4_model.mhc_post, (object(),) * 4),
+            (
+                "fast_mhc_fused_hc",
+                deepseek_v4_model.mhc_fused_hc,
+                (object(),) * 11,
+            ),
+        )
+        for target, wrapper, args in cases:
+            with (
+                self.subTest(wrapper=wrapper.__qualname__),
+                patch.object(
+                    deepseek_v4_model, target, return_value=object()
+                ) as fast_mhc,
+            ):
+                wrapper(*args, allow_trtllm_auto=True)
+                self.assertTrue(fast_mhc.call_args.kwargs["allow_trtllm_auto"])
+
+    def test_mhc_backend_auto_is_decode_only(self):
+        for mode in (ForwardMode.DECODE, ForwardMode.IDLE):
+            with self.subTest(mode=mode):
+                self.assertTrue(
+                    deepseek_v4_model._use_trtllm_mhc_auto(
+                        SimpleNamespace(forward_mode=mode)
+                    )
+                )
+        for mode in (ForwardMode.EXTEND, ForwardMode.MIXED, None):
+            with self.subTest(mode=mode):
+                self.assertFalse(
+                    deepseek_v4_model._use_trtllm_mhc_auto(
+                        SimpleNamespace(forward_mode=mode)
+                    )
+                )
+
+    def test_mhc_backend_rejects_invalid_override(self):
+        with (
+            deepseek_v4_mhc.envs.TOKENSPEED_V4_MHC_BACKEND.override("unknown"),
+            self.assertRaisesRegex(ValueError, "TOKENSPEED_V4_MHC_BACKEND"),
+        ):
+            deepseek_v4_mhc._validate_mhc_backend_config(torch.device("cpu"), 4, 7168)
 
     def test_mhc_fused_workspace_separates_capture_and_eager_buffers(self):
         if not torch.cuda.is_available():
@@ -4241,7 +4444,8 @@ class TestDeepseekV4Config(unittest.TestCase):
                 sentinel_expected=sentinel_expected,
             )
 
-        small = capture_bucket(1)
+        with deepseek_v4_mhc.envs.TOKENSPEED_V4_MHC_BACKEND.override("trtllm"):
+            small = capture_bucket(1)
         small_pp = next(iter(workspace._captured.values()))
         small_ptrs = {
             tensor.data_ptr() for buffer_set in small_pp.bufs for tensor in buffer_set
@@ -4253,7 +4457,8 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
         del small_pp
 
-        large = capture_bucket(33, sentinel_specs)
+        with deepseek_v4_mhc.envs.TOKENSPEED_V4_MHC_BACKEND.override("trtllm"):
+            large = capture_bucket(33, sentinel_specs)
         self.assertEqual(len(workspace._retired_captured), 1)
         self.assertEqual(
             next(iter(workspace._captured.values())).bufs[0][0].shape[0], 64
@@ -4330,6 +4535,65 @@ class TestDeepseekV4Config(unittest.TestCase):
             empty_x, empty_residual, empty_post, empty_comb
         )
         self.assertEqual(tuple(empty_post_result.shape), (0, hc_mult, hidden_size))
+
+    def test_mhc_trtllm_zero_token_early_returns(self):
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA is required for TRT-LLM mHC")
+
+        device = torch.device("cuda")
+        hc_mult, hidden_size = 4, 4096
+        if not supports_trtllm_mhc(device, hc_mult, hidden_size):
+            self.skipTest("TRT-LLM mHC requires a supported SM100 installation")
+
+        mix_hc = hc_mult * (2 + hc_mult)
+        empty_x = torch.empty(0, hidden_size, dtype=torch.bfloat16, device=device)
+        empty_residual = torch.empty(
+            0, hc_mult, hidden_size, dtype=torch.bfloat16, device=device
+        )
+        empty_post = torch.empty(0, hc_mult, 1, dtype=torch.float32, device=device)
+        empty_comb = torch.empty(
+            0, hc_mult, hc_mult, dtype=torch.float32, device=device
+        )
+        weight = torch.empty(
+            mix_hc, hc_mult * hidden_size, dtype=torch.float32, device=device
+        )
+        scale = torch.ones(3, dtype=torch.float32, device=device)
+        base = torch.zeros(mix_hc, dtype=torch.float32, device=device)
+        workspace = deepseek_v4_mhc.MhcFusedWorkspace()
+
+        with (
+            deepseek_v4_mhc.envs.TOKENSPEED_V4_MHC_BACKEND.override("trtllm"),
+            patch.object(deepseek_v4_mhc, "trtllm_mhc_fused_hc") as fused_kernel,
+            patch.object(deepseek_v4_mhc, "trtllm_mhc_big_fuse") as pre_kernel,
+            patch.object(deepseek_v4_mhc, "trtllm_mhc_post_mapping") as post_kernel,
+        ):
+            state = deepseek_v4_mhc.mhc_fused_hc(
+                empty_x,
+                empty_residual,
+                empty_post,
+                empty_comb,
+                weight,
+                scale,
+                base,
+                1e-6,
+                1e-6,
+                2,
+                workspace,
+            )
+            pre = deepseek_v4_mhc.mhc_pre(
+                empty_residual, weight, scale, base, 1e-6, 1e-6, 2
+            )
+            post = deepseek_v4_mhc.mhc_post(
+                empty_x, empty_residual, empty_post, empty_comb
+            )
+
+        fused_kernel.assert_not_called()
+        pre_kernel.assert_not_called()
+        post_kernel.assert_not_called()
+        self.assertEqual(tuple(state[0].shape), tuple(empty_residual.shape))
+        self.assertEqual(tuple(state[1].shape), tuple(empty_x.shape))
+        self.assertEqual(tuple(pre[0].shape), tuple(empty_x.shape))
+        self.assertEqual(tuple(post.shape), tuple(empty_residual.shape))
 
     def test_hc_head_matches_shape_contract(self):
         tokens, hc_mult, hidden = 2, 4, 6


### PR DESCRIPTION
## Summary

Stacked follow-up to #547, based on `perf/v4-trtllm-mhc@dc2fbb5`. This branch contains no #563/#580 code and is intended to be merged or cherry-picked into #547 after review.

- `auto` selects TRT-LLM mHC for decode/idle batches only; target prefill/mixed stay native, while missing opt-in or unsupported shapes fail closed
- forced `trtllm` and invalid configurations fail fast during model construction, before weight loading and CUDA Graph capture
- first-selection logging is deduplicated per device and shape; capability is reported as `supported=not-probed` when intentionally not queried
- eager and CUDA Graph workspaces are separated, with bucket growth and replay safety validated
- `TOKENSPEED_V4_MHC_BACKEND` is documented; MTP drafter substeps after the first catch-up step run as `DECODE` and may intentionally select TRT-LLM mHC under an outer extend batch

## Evidence

- selection proof: all eight TP ranks logged `selected=trtllm` for decode and `selected=native` for target prefill/mixed
- tests: pre-commit, DCO, and CI lint passed; 17 runtime mHC tests (+14 subtests) and 5 kernel mHC tests passed
- covered behaviors include startup validation, unsupported-shape auto fallback, wrapper kwarg forwarding, zero-token early returns, workspace isolation, and CUDA Graph replay

## Performance (p4, matched adjacent A/B, non-profile)

8×B200 TP8, FlashInfer 0.6.13, TRT-LLM all-reduce enabled. Both arms completed 87/87 requests with matched output volume, MTP acceptance, and prefix-cache hit rate.

| Metric | native | auto (this PR) | Δ |
| --- | ---: | ---: | ---: |
| TPS/GPU | 4,709.47 | 4,928.18 | **+4.64%** |
| TPS/user | 93.28 | 97.85 | **+4.89%** |
| TPOT | 10.72 ms | 10.22 ms | **−4.66% (−0.50 ms)** |
| MTP acceptance | 0.6701 | 0.6692 | −0.09 pp |
| Prefix-cache hit | 90.331% | 90.334% | +0.003 pp |

The −0.50 ms TPOT gain matches the kernel-level saving in the exact decode trace: TRT-LLM mHC takes about 2.66 ms/iteration versus about 4.45–4.60 ms/iteration for native mHC, corresponding to an approximately 0.6 ms/token ceiling at roughly 3 decoded tokens/iteration. The endpoint result is therefore mechanism-consistent.

A full p1→p2→p4→p8 sweep passed at every point and is used as functional coverage only, not for performance claims. Numbers are from the #563+#579+#580+#583 stack at the time of measurement; a final sanity run will follow when #547 rebases onto current main.