### PR TITLE
fix(deepseek-v3): Route DeepSeek merge state through unified backend

### DIFF
--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -31,6 +31,7 @@ from typing import Any
 
 import torch
 import torch.nn.functional as F
+from tokenspeed_kernel.ops.attention import attn_merge_state
 from tokenspeed_kernel.ops.attention.tokenspeed_mla import mla_kv_pack_quantize_fp8
 from tokenspeed_kernel.ops.embedding import apply_rope_mla
 from tokenspeed_kernel.ops.gemm.cute_dsl import (
@@ -41,7 +42,6 @@ from tokenspeed_kernel.ops.quantization.flashinfer import fp4_quantize
 from tokenspeed_kernel.ops.quantization.triton import fp8_quantize
 from tokenspeed_kernel.platform import current_platform
 from tokenspeed_kernel.thirdparty.cuda import dsv3_router_gemm, moe_finalize_fuse_shared
-from tokenspeed_kernel.thirdparty.cuda.merge_state import merge_state
 from torch import nn
 from transformers import PretrainedConfig
 
@@ -1003,7 +1003,7 @@ class DeepseekV3AttentionMLA(nn.Module):
         # Causal self-attention over the new chunk tokens. q_lens == kv_lens ==
         # extend_seq_lens, so cum_seq_lens_q and cum_seq_lens_kv alias the same
         # cum_extend_seq_lens. Causal pass writes directly into output; each
-        # chunk's merge accumulates in place via merge_state(inplace=True).
+        # chunk's merge accumulates in place via attn_merge_state(inplace=True).
         num_extends = chunk_meta.extend_seq_lens.size(0)
         output_view = output.view(-1, self.num_local_heads, self.v_head_dim)
         _, accum_lse = attn_backend.forward_extend_chunked(
@@ -1070,7 +1070,7 @@ class DeepseekV3AttentionMLA(nn.Module):
                 causal=False,
             )
 
-            merge_state(
+            attn_merge_state(
                 output_view,
                 accum_lse,
                 chunk_output,

--- a/test/runtime/models/test_deepseek_v3_loader.py
+++ b/test/runtime/models/test_deepseek_v3_loader.py
@@ -1,10 +1,16 @@
 import unittest
 from unittest import mock
 
+from tokenspeed.runtime.models import deepseek_v3
 from tokenspeed.runtime.models.deepseek_v3 import DeepseekV3ForCausalLM
+from tokenspeed_kernel.ops.attention import attn_merge_state
 
 
 class TestDeepseekV3Loader(unittest.TestCase):
+    def test_cached_prefix_merge_uses_attention_dispatcher(self):
+        self.assertIs(deepseek_v3.attn_merge_state, attn_merge_state)
+        self.assertFalse(hasattr(deepseek_v3, "merge_state"))
+
     def test_missing_checkpoint_scale_params_are_silent(self):
         model = object.__new__(DeepseekV3ForCausalLM)
 

--- a/test/runtime/models/test_deepseek_v3_loader.py
+++ b/test/runtime/models/test_deepseek_v3_loader.py
@@ -1,9 +1,10 @@
 import unittest
 from unittest import mock
 
+from tokenspeed_kernel.ops.attention import attn_merge_state
+
 from tokenspeed.runtime.models import deepseek_v3
 from tokenspeed.runtime.models.deepseek_v3 import DeepseekV3ForCausalLM
-from tokenspeed_kernel.ops.attention import attn_merge_state
 
 
 class TestDeepseekV3Loader(unittest.TestCase):

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -1127,6 +1127,8 @@ def attn_merge_state(
     lse_b: torch.Tensor,
     *,
     lse_scale_log2: float = LSE_LN,
+    inplace: bool = False,
+    enable_pdl: bool = False,
     override: str | None = None,
     solution: str | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -1138,6 +1140,8 @@ def attn_merge_state(
         out_b: Second partial output with shape [total_q, num_heads, head_dim].
         lse_b: Second partial log-sum-exp with shape [total_q, num_heads].
         lse_scale_log2: Multiplier that converts input LSE to log2 domain.
+        inplace: Whether to write the merged state back into ``out_a``/``lse_a``.
+        enable_pdl: Whether the selected backend should enable PDL when supported.
         override: Optional kernel override name.
         solution: Optional kernel solution to force through normal selection.
 
@@ -1183,6 +1187,8 @@ def attn_merge_state(
             out_b=out_b,
             lse_b=lse_b,
             lse_scale_log2=lse_scale_log2,
+            inplace=inplace,
+            enable_pdl=enable_pdl,
         )
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cuda/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cuda/__init__.py
@@ -36,11 +36,15 @@ if platform.is_nvidia and platform.is_hopper_plus:
         out_b: torch.Tensor,
         lse_b: torch.Tensor,
         lse_scale_log2: float,
+        inplace: bool = False,
+        enable_pdl: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         return merge_state(
             out_a,
             lse_a,
             out_b,
             lse_b,
+            inplace=inplace,
             lse_scale_log2=lse_scale_log2,
+            enable_pdl=enable_pdl,
         )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cuda/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cuda/__init__.py
@@ -20,7 +20,7 @@ if platform.is_nvidia and platform.is_hopper_plus:
         name="cuda_attn_merge_state",
         solution="cuda",
         capability=CapabilityRequirement(
-            min_arch_version=ArchVersion(10, 0),
+            min_arch_version=ArchVersion(9, 0),
             vendors=frozenset({"nvidia"}),
         ),
         signatures=format_signatures(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/merge_state.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/merge_state.py
@@ -82,9 +82,12 @@ def triton_attn_merge_state(
     out_b: torch.Tensor,
     lse_b: torch.Tensor,
     lse_scale_log2: float,
+    inplace: bool = False,
+    enable_pdl: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    out = torch.empty_like(out_a)
-    lse = torch.empty_like(lse_a)
+    del enable_pdl
+    out = out_a if inplace else torch.empty_like(out_a)
+    lse = lse_a if inplace else torch.empty_like(lse_a)
     total_rows = out_a.shape[0] * out_a.shape[1]
     head_dim = out_a.shape[2]
     block_d = triton.next_power_of_2(head_dim)

--- a/tokenspeed-kernel/test/ops/test_attention.py
+++ b/tokenspeed-kernel/test/ops/test_attention.py
@@ -402,9 +402,11 @@ def test_mha_decode_with_kvcache(
     "solution",
     ["triton", "cuda"],
 )
+@pytest.mark.parametrize("inplace", [False, True], ids=["out-of-place", "in-place"])
 def test_attn_merge_state(
     device: str,
     solution: str,
+    inplace: bool,
     dtype: torch.dtype,
     head_dim: int,
     num_heads: int,
@@ -417,23 +419,34 @@ def test_attn_merge_state(
     out_b = torch.randn(total_q, num_heads, head_dim, device=device, dtype=dtype)
     lse_a = torch.randn(total_q, num_heads, device=device, dtype=torch.float32)
     lse_b = torch.randn(total_q, num_heads, device=device, dtype=torch.float32)
+    out_a_ref_input = out_a.clone()
+    lse_a_ref_input = lse_a.clone()
 
     out, lse = attn_merge_state(
         out_a,
         lse_a,
         out_b,
         lse_b,
+        inplace=inplace,
         solution=solution,
     )
 
-    lse_ref = torch.maximum(lse_a, lse_b)
-    weight_a = torch.exp(lse_a - lse_ref)
+    lse_ref = torch.maximum(lse_a_ref_input, lse_b)
+    weight_a = torch.exp(lse_a_ref_input - lse_ref)
     weight_b = torch.exp(lse_b - lse_ref)
     denom = weight_a + weight_b
     out_ref = (
-        out_a.float() * weight_a[..., None] + out_b.float() * weight_b[..., None]
+        out_a_ref_input.float() * weight_a[..., None]
+        + out_b.float() * weight_b[..., None]
     ) / denom[..., None]
     lse_ref = lse_ref + torch.log(denom)
+
+    if inplace:
+        assert out.data_ptr() == out_a.data_ptr()
+        assert lse.data_ptr() == lse_a.data_ptr()
+    else:
+        torch.testing.assert_close(out_a, out_a_ref_input)
+        torch.testing.assert_close(lse_a, lse_a_ref_input)
 
     assert out.shape == out_a.shape
     assert lse.shape == lse_a.shape

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -1334,6 +1334,38 @@ def selected_kernel_spy(monkeypatch):
     return active_case, calls
 
 
+def _find_case(*, arch: str, family: str, mode: str) -> KernelApiSelectionCase:
+    for case in _CASES:
+        if case.arch == arch and case.family == family and case.mode == mode:
+            return case
+    raise AssertionError(f"missing golden case for {arch}/{family}.{mode}")
+
+
+def test_attn_merge_state_routes_to_triton_on_cdna4(
+    mi350_platform: PlatformInfo,
+    selected_kernel_spy,
+) -> None:
+    case = _find_case(arch="cdna4", family="attention", mode="attn_merge_state")
+    registry = KernelRegistry.get()
+    expected_spec = registry.get_by_name(case.expected)
+    assert expected_spec is not None
+    assert expected_spec.capability.satisfied_by(mi350_platform)
+
+    real_platform = Platform.get()
+    active_case, calls = selected_kernel_spy
+    active_case["case"] = case
+    try:
+        Platform.override(mi350_platform)
+        registry.clear_cache()
+
+        case.invoke()
+
+        assert calls == ["triton_attn_merge_state"]
+    finally:
+        Platform.override(real_platform)
+        registry.clear_cache()
+
+
 @pytest.mark.parametrize("case", _CASES, ids=lambda case: case.id)
 def test_kernel_api_selection(case: KernelApiSelectionCase, selected_kernel_spy):
     platform = Platform.get()

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -981,7 +981,7 @@ _CASES = [
         "hopper",
         "attention",
         "attn_merge_state",
-        "triton_attn_merge_state",
+        "cuda_attn_merge_state",
         _attention_merge_state,
     ),
     _case(


### PR DESCRIPTION
## Summary

DeepseekV3's prefix-cache replay path used the CUDA-specific merge_state attention helper. On AMD, this caused TokenSpeed to try loading thirdparty/cuda/objs/merge_state/merge_state.so when caching prefix tokens.

This PR fixes the issue by routing through the unified `tokenspeed_kernel.ops.attention.attn_merge_state` backend, which has a triton implementation. On NVIDIA, this routes to the same merge_state helper that was used before.

## Test Plan

Ran `tokenspeed bench serve` with prefix caching enabled, which fails without the fix, and succeeds with the fix.
