### PR TITLE
Add Gluon fused MoE support for dynamic MXFP4 activations

### DIFF
--- a/python/tokenspeed/runtime/layers/moe/expert.py
+++ b/python/tokenspeed/runtime/layers/moe/expert.py
@@ -142,6 +142,9 @@ class MoELayer(torch.nn.Module):
         self._n_group = routing_config.get("n_group", 0)
         self._topk_group = routing_config.get("topk_group", 0)
         self._routed_scaling_factor = routing_config.get("routed_scaling_factor", 1.0)
+        self._normalize_topk_weights = routing_config.get(
+            "normalize_topk_weights", True
+        )
 
         # Quantization config. ignored_layers (compressed-tensors) keys the MoE
         # block; exclude_modules (ModelOpt) keys the fused experts.

--- a/python/tokenspeed/runtime/layers/moe/topk.py
+++ b/python/tokenspeed/runtime/layers/moe/topk.py
@@ -537,7 +537,7 @@ def select_experts(
             topk_weights,
             num_real_experts,
             routed_scaling_factor,
-            True,
+            renormalize,
         )
     elif custom_routing_function is None:
         topk_weights, topk_ids = torch_native_fused_topk(

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -314,6 +314,7 @@ class DeepseekV3MoE(nn.Module):
                 "n_group": getattr(config, "n_group", 0),
                 "topk_group": getattr(config, "topk_group", 0),
                 "routed_scaling_factor": getattr(config, "routed_scaling_factor", 1.0),
+                "normalize_topk_weights": config.norm_topk_prob,
                 "correction_bias": self.gate.e_score_correction_bias,
                 "routing_method_type": RoutingMethodType.DeepSeekV3,
             },

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -2514,6 +2514,7 @@ class DeepseekV4MoE(nn.Module):
                 with_bias=True,
                 routing_config={
                     "routed_scaling_factor": self.routed_scaling_factor,
+                    "normalize_topk_weights": config.norm_topk_prob,
                     "correction_bias": self.gate.e_score_correction_bias,
                     "routing_method_type": RoutingMethodType.Renormalize,
                 },

--- a/python/tokenspeed/runtime/models/longcat_flash.py
+++ b/python/tokenspeed/runtime/models/longcat_flash.py
@@ -249,6 +249,7 @@ class _RuntimeLongcatMoE(nn.Module):
             zero_expert_type=config.zero_expert_type,
             routing_config={
                 "routed_scaling_factor": self.routed_scaling_factor,
+                "normalize_topk_weights": config.norm_topk_prob,
                 "correction_bias": self.router.e_score_correction_bias[
                     : config.n_routed_experts
                 ],

--- a/python/tokenspeed/runtime/models/minimax_m2.py
+++ b/python/tokenspeed/runtime/models/minimax_m2.py
@@ -138,6 +138,7 @@ class MiniMaxM2SparseMoeBlock(nn.Module):
             "n_group": 1,
             "topk_group": 1,
             "routed_scaling_factor": 1.0,
+            "normalize_topk_weights": True,
             "correction_bias": self.routing_bias,
             "routing_method_type": RoutingMethodType.MiniMax2,
         }

--- a/python/tokenspeed/runtime/models/qwen3_5_moe.py
+++ b/python/tokenspeed/runtime/models/qwen3_5_moe.py
@@ -222,7 +222,10 @@ class Qwen3_5MoeSparseMoeBlock(nn.Module):
             tp_size=self.mapping.moe.tp_size,
             ep_rank=self.mapping.moe.ep_rank,
             ep_size=self.mapping.moe.ep_size,
-            routing_config={"routing_method_type": RoutingMethodType.RenormalizeNaive},
+            routing_config={
+                "routing_method_type": RoutingMethodType.RenormalizeNaive,
+                "normalize_topk_weights": config.norm_topk_prob,
+            },
         )
         self.topk = TopK(
             top_k=config.num_experts_per_tok,

--- a/test/runtime/layers/test_moe_topk.py
+++ b/test/runtime/layers/test_moe_topk.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tokenspeed.runtime.layers.moe import topk as topk_module
+from tokenspeed.runtime.layers.moe.topk import TopKConfig, select_experts
+
+
+@pytest.mark.parametrize("renormalize", [False, True])
+def test_correction_bias_route_forwards_renormalize(
+    monkeypatch: pytest.MonkeyPatch,
+    renormalize: bool,
+) -> None:
+    calls: list[bool] = []
+
+    def fake_cuda_routing_flash(
+        _router_logits: torch.Tensor,
+        _correction_bias: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+        _num_real_experts: int,
+        _routed_scaling_factor: float,
+        renorm: bool,
+    ) -> None:
+        calls.append(renorm)
+        topk_ids.fill_(0)
+        topk_weights.fill_(1.0)
+
+    monkeypatch.setattr(
+        topk_module,
+        "cuda_routing_flash",
+        fake_cuda_routing_flash,
+    )
+
+    select_experts(
+        hidden_states=torch.empty((1, 4), dtype=torch.float32),
+        router_logits=torch.empty((1, 8), dtype=torch.float32),
+        topk_config=TopKConfig(
+            top_k=2,
+            renormalize=renormalize,
+            correction_bias=torch.zeros((8,), dtype=torch.float32),
+            routed_scaling_factor=1.0,
+        ),
+    )
+
+    assert calls == [renormalize]

--- a/test/runtime/models/test_moe_routing_config.py
+++ b/test/runtime/models/test_moe_routing_config.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _call_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _routing_configs(relpath: str) -> list[dict[str, ast.AST]]:
+    tree = ast.parse((REPO_ROOT / relpath).read_text(), filename=relpath)
+    configs: list[dict[str, ast.AST]] = []
+    for scope in (node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)):
+        dict_assignments: dict[str, ast.Dict] = {}
+        for node in ast.walk(scope):
+            if isinstance(node, ast.Assign) and isinstance(node.value, ast.Dict):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        dict_assignments[target.id] = node.value
+        for node in ast.walk(scope):
+            if not isinstance(node, ast.Call):
+                continue
+            if _call_name(node.func) not in {"MoELayer", "_MoELayer"}:
+                continue
+            for keyword in node.keywords:
+                if keyword.arg != "routing_config":
+                    continue
+                value = keyword.value
+                if isinstance(value, ast.Name):
+                    value = dict_assignments.get(value.id)
+                if not isinstance(value, ast.Dict):
+                    continue
+                entries = {
+                    key.value: item
+                    for key, item in zip(value.keys, value.values)
+                    if isinstance(key, ast.Constant) and isinstance(key.value, str)
+                }
+                configs.append(entries)
+    return configs
+
+
+def _normalize_expr(relpath: str) -> str:
+    matches = [
+        ast.unparse(config["normalize_topk_weights"])
+        for config in _routing_configs(relpath)
+        if "normalize_topk_weights" in config
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def test_config_driven_moe_models_propagate_topk_normalization_flag() -> None:
+    for relpath in (
+        "python/tokenspeed/runtime/models/deepseek_v3.py",
+        "python/tokenspeed/runtime/models/deepseek_v4.py",
+        "python/tokenspeed/runtime/models/longcat_flash.py",
+        "python/tokenspeed/runtime/models/qwen3_5_moe.py",
+    ):
+        assert _normalize_expr(relpath) == "config.norm_topk_prob"
+
+
+def test_minimax_moe_routing_matches_hardcoded_topk_normalization() -> None:
+    assert _normalize_expr("python/tokenspeed/runtime/models/minimax_m2.py") == "True"

--- a/test/runtime/models/test_moe_routing_config.py
+++ b/test/runtime/models/test_moe_routing_config.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
@@ -34,6 +34,8 @@ from tokenspeed_kernel_amd.ops.moe.utils import (
     topk,
 )
 
+MXFP4_BLOCK = 32
+
 
 def _as_int32(t):
     if t is None or t.dtype == torch.int32:
@@ -54,6 +56,10 @@ _BLOCK_SIZE_TO_IDX = {bs: i for i, bs in enumerate(_BLOCK_SIZES_TUPLE)}
 
 def _ragged_block_offs(metadata, block_size: int):
     return metadata.block_offs_data[_BLOCK_SIZE_TO_IDX[block_size]]
+
+
+def _ragged_scale_block_offs(metadata):
+    return _ragged_block_offs(metadata, _NON_K_PRESHUFFLE_BLOCK_SIZE)
 
 
 def _ragged_block_schedule(metadata, block_size: int):
@@ -319,6 +325,7 @@ def _swiglu_reduce(
     acc,
     alpha: gl.constexpr,
     limit: gl.constexpr,
+    beta: gl.constexpr,
     OUT_BLOCK_N: gl.constexpr,
     MMA: gl.constexpr,
 ):
@@ -334,7 +341,7 @@ def _swiglu_reduce(
         gate = gl.minimum(gate, limit)
         linear = gl.clamp(linear, -limit, limit)
     s = gate / (1.0 + gl.exp(-alpha * gate))
-    return s * (linear + 1.0)
+    return s * (linear + beta)
 
 
 # ---------------------------------------------------------------------------
@@ -853,15 +860,15 @@ class AsyncCopyDescriptor:
         base_offset=0,
         cache_modifier: gl.constexpr = "",
     ):
+        base_offset_t = gl.to_tensor(base_offset)
+        ptr = ptr + base_offset_t
         offsets = (
             gl.expand_dims(off_k, op_idx) * stride_k
             + gl.expand_dims(off_nonk, 1 - op_idx) * stride_nonk
-            + base_offset
         )
         dtype: gl.constexpr = ptr.dtype.element_ty
         stride_k_t = gl.to_tensor(stride_k)
         stride_nonk_t = gl.to_tensor(stride_nonk)
-        base_offset_t = gl.to_tensor(base_offset)
         return AsyncCopyDescriptor(
             cfg,
             op_idx,
@@ -2605,6 +2612,52 @@ def _make_moe_x_desc(
 
 
 @gluon.jit
+def _make_swizzled_scale_direct_desc(
+    cfg,
+    scale_ptr,
+    rows_m_scale,
+    offs_ks,
+    stride_mblock,
+    stride_kswizzled,
+    mask_m_scale,
+    k_limit,
+    BLOCK_K_SCALE: gl.constexpr,
+):
+    m_block = rows_m_scale // cfg.PRESHUFFLE_FACTOR
+    m_in_block = rows_m_scale % cfg.PRESHUFFLE_FACTOR
+    m_hi = m_in_block // 16
+    m_lo = m_in_block % 16
+    k_block = offs_ks // 8
+    k_in_block = offs_ks % 8
+    k_hi = k_in_block // 4
+    k_lo = k_in_block % 4
+    stride_k_t = gl.to_tensor(stride_kswizzled * cfg.PRESHUFFLE_FACTOR)
+    stride_mblock_t = gl.to_tensor(stride_mblock)
+    swizzled_k = (
+        (((k_block[None, :] * 4 + k_lo[None, :]) * 16 + m_lo[:, None]) * 2)
+        + k_hi[None, :]
+    ) * 2 + m_hi[:, None]
+    offsets = (
+        swizzled_k * stride_kswizzled + m_block[:, None].to(gl.int64) * stride_mblock_t
+    )
+    return AsyncCopyDescriptor(
+        cfg,
+        0,
+        BLOCK_K_SCALE,
+        scale_ptr,
+        scale_ptr.dtype.element_ty,
+        stride_k_t,
+        stride_mblock_t,
+        offsets,
+        offs_ks,
+        rows_m_scale,
+        mask_m_scale[:, None],
+        k_limit,
+        gl.to_tensor(0),
+    )
+
+
+@gluon.jit
 def _make_slice_mn_x_descs(
     cfg,
     x_ptr,
@@ -3697,6 +3750,7 @@ def _pipelined_moe_tile_compute(
     gate_scal_ptr,
     slice_offs_ptr,
     slice_sizes_ptr,
+    x_scale_block_offs_ptr,
     stride_xm,
     stride_xk,
     stride_we,
@@ -3735,6 +3789,7 @@ def _pipelined_moe_tile_compute(
     DO_SWIGLU: gl.constexpr,
     SWIGLU_ALPHA: gl.constexpr,
     SWIGLU_LIMIT: gl.constexpr,
+    SWIGLU_BETA: gl.constexpr,
     OUT_BLOCK_N: gl.constexpr,
     APPLY_GATE_SCAL: gl.constexpr,
     HAS_RAGGED_OFFS: gl.constexpr,
@@ -3759,6 +3814,7 @@ def _pipelined_moe_tile_compute(
     X_SCALE_VIA_LDS: gl.constexpr = False,
     W_SCALE_VIA_LDS: gl.constexpr = False,
     USE_NARROW_N_STORE_LAYOUT: gl.constexpr = False,
+    X_SCALE_RAGGED_PADDED: gl.constexpr = False,
 ):
     expert_id = compact_idx
 
@@ -3778,8 +3834,12 @@ def _pipelined_moe_tile_compute(
         off_m = compact_idx * BLOCKS_PER_EXPERT * BLOCK_M + block_in_expert * BLOCK_M
         m_limit = M
     off_n = pid_n * BLOCK_N
-    w_base_offset = expert_id * stride_we
-    ws_base_offset = expert_id * stride_wse
+    if W_PRESHUFFLED:
+        w_base_offset = expert_id * stride_we
+        ws_base_offset = expert_id * stride_wse
+    else:
+        w_base_offset = expert_id.to(gl.int64) * stride_we
+        ws_base_offset = expert_id.to(gl.int64) * stride_wse
     N_LIMIT: gl.constexpr = N_CONST if N_CONST else 0
 
     STORE: gl.constexpr = _store_layout(
@@ -3903,7 +3963,15 @@ def _pipelined_moe_tile_compute(
                 0, BLOCK_K_SCALE, layout=gl.SliceLayout(0, cfg.layout_x_scale)
             )
             rows_m_scale = off_m + offs_xs_m
-            if HAS_GATHER:
+            if X_SCALE_RAGGED_PADDED:
+                local_rows_m_scale = block_in_expert * BLOCK_M + offs_xs_m
+                scale_base = (
+                    gl.load(x_scale_block_offs_ptr + expert_id).to(gl.int32)
+                    * cfg.PRESHUFFLE_FACTOR
+                )
+                rows_m_scale = scale_base + local_rows_m_scale
+                mask_m_scale = local_rows_m_scale < m_size
+            elif HAS_GATHER:
                 pre_gather_mask_scale = rows_m_scale < m_limit
                 rows_m_scale_safe = gl.where(
                     pre_gather_mask_scale,
@@ -3923,18 +3991,31 @@ def _pipelined_moe_tile_compute(
                     rows_m_scale,
                     gl.zeros_like(rows_m_scale),
                 )
-            x_scale_desc = AsyncCopyDescriptor.initialize(
-                cfg,
-                0,
-                BLOCK_K_SCALE,
-                x_scale_ptr,
-                rows_m_scale,
-                offs_xs_k,
-                stride_xsm,
-                stride_xsk,
-                mask_m_scale[:, None],
-                K // cfg.SCALE_BLOCK,
-            )
+            if SCALE_LOAD_MODE == "swizzle":
+                x_scale_desc = _make_swizzled_scale_direct_desc(
+                    cfg,
+                    x_scale_ptr,
+                    rows_m_scale,
+                    offs_xs_k,
+                    stride_xsm,
+                    stride_xsk,
+                    mask_m_scale,
+                    K // cfg.SCALE_BLOCK,
+                    BLOCK_K_SCALE,
+                )
+            else:
+                x_scale_desc = AsyncCopyDescriptor.initialize(
+                    cfg,
+                    0,
+                    BLOCK_K_SCALE,
+                    x_scale_ptr,
+                    rows_m_scale,
+                    offs_xs_k,
+                    stride_xsm,
+                    stride_xsk,
+                    mask_m_scale[:, None],
+                    K // cfg.SCALE_BLOCK,
+                )
     else:
         x_scale_desc: gl.constexpr = 0
 
@@ -4157,7 +4238,12 @@ def _pipelined_moe_tile_compute(
 
     if DO_SWIGLU:
         out = _swiglu_reduce(
-            acc, SWIGLU_ALPHA, SWIGLU_LIMIT, OUT_BLOCK_N, cfg.acc_layout
+            acc,
+            SWIGLU_ALPHA,
+            SWIGLU_LIMIT,
+            SWIGLU_BETA,
+            OUT_BLOCK_N,
+            cfg.acc_layout,
         )
         if HAS_FP8_QUANT_OUT:
             scale = gl.load(out_quant_scale_ptr).to(gl.float32)
@@ -4419,6 +4505,7 @@ def _medium_decode_body(
     HAS_BIAS: gl.constexpr,
     SWIGLU_ALPHA: gl.constexpr,
     SWIGLU_LIMIT: gl.constexpr,
+    SWIGLU_BETA: gl.constexpr,
     Y_N_CONST: gl.constexpr,
     MEDIUM_COMBINE: gl.constexpr,
 ):
@@ -4654,7 +4741,12 @@ def _medium_decode_body(
             acc = acc + bias[None, :]
 
         out = _swiglu_reduce(
-            acc, SWIGLU_ALPHA, SWIGLU_LIMIT, OUT_BLOCK_N, cfg.acc_layout
+            acc,
+            SWIGLU_ALPHA,
+            SWIGLU_LIMIT,
+            SWIGLU_BETA,
+            OUT_BLOCK_N,
+            cfg.acc_layout,
         )
         out_inv_scale = 1.0 / gl.load(out_quant_scale_ptr).to(gl.float32)
         out = (out * out_inv_scale).to(Y.dtype.element_ty)
@@ -4702,6 +4794,7 @@ def _pipelined_moe_kernel_scaled(
     gate_scal_ptr,
     slice_offs_ptr,
     slice_sizes_ptr,
+    x_scale_block_offs_ptr,
     block_offs_ptr,
     block_schedule_ptr,
     stride_xm,
@@ -4740,6 +4833,7 @@ def _pipelined_moe_kernel_scaled(
     DO_SWIGLU: gl.constexpr,
     SWIGLU_ALPHA: gl.constexpr,
     SWIGLU_LIMIT: gl.constexpr,
+    SWIGLU_BETA: gl.constexpr,
     OUT_BLOCK_N: gl.constexpr,
     APPLY_GATE_SCAL: gl.constexpr,
     HAS_RAGGED_OFFS: gl.constexpr,
@@ -4771,6 +4865,7 @@ def _pipelined_moe_kernel_scaled(
     USE_NARROW_N_STORE_LAYOUT: gl.constexpr = False,
     IS_MEDIUM_DECODE: gl.constexpr = False,
     MEDIUM_COMBINE: gl.constexpr = False,
+    X_SCALE_RAGGED_PADDED: gl.constexpr = False,
 ):
     if IS_MEDIUM_DECODE:
         # Medium-decode (M=8/16) reuses this kernel's signature but runs the
@@ -4818,6 +4913,7 @@ def _pipelined_moe_kernel_scaled(
             HAS_BIAS=HAS_BIAS,
             SWIGLU_ALPHA=SWIGLU_ALPHA,
             SWIGLU_LIMIT=SWIGLU_LIMIT,
+            SWIGLU_BETA=SWIGLU_BETA,
             Y_N_CONST=Y_N_CONST,
             MEDIUM_COMBINE=MEDIUM_COMBINE,
         )
@@ -4867,6 +4963,7 @@ def _pipelined_moe_kernel_scaled(
             gate_scal_ptr,
             slice_offs_ptr,
             slice_sizes_ptr,
+            x_scale_block_offs_ptr,
             stride_xm,
             stride_xk,
             stride_we,
@@ -4905,6 +5002,7 @@ def _pipelined_moe_kernel_scaled(
             DO_SWIGLU=DO_SWIGLU,
             SWIGLU_ALPHA=SWIGLU_ALPHA,
             SWIGLU_LIMIT=SWIGLU_LIMIT,
+            SWIGLU_BETA=SWIGLU_BETA,
             OUT_BLOCK_N=OUT_BLOCK_N,
             APPLY_GATE_SCAL=APPLY_GATE_SCAL,
             HAS_RAGGED_OFFS=HAS_RAGGED_OFFS,
@@ -4929,6 +5027,7 @@ def _pipelined_moe_kernel_scaled(
             X_SCALE_VIA_LDS=X_SCALE_VIA_LDS,
             W_SCALE_VIA_LDS=W_SCALE_VIA_LDS,
             USE_NARROW_N_STORE_LAYOUT=USE_NARROW_N_STORE_LAYOUT,
+            X_SCALE_RAGGED_PADDED=X_SCALE_RAGGED_PADDED,
         )
 
 
@@ -5097,7 +5196,7 @@ def _launch_kernel(
     scatter_indx,
     gate_scal: torch.Tensor | None,
     a_ragged_metadata,
-    swiglu: tuple[float, float] | None,
+    swiglu: tuple[float, float, float] | None,
     out_block_n: int,
     block_m: int,
     block_n: int,
@@ -5126,6 +5225,7 @@ def _launch_kernel(
     use_narrow_n_store_layout: bool = False,
     medium_decode_dispatch: bool = False,
     medium_decode_combine: bool = False,
+    x_scale_ragged_padded: bool = False,
 ):
     assert x_format in _SCALED_FORMATS, f"unknown x_format={x_format!r}"
     assert w_format in _SCALED_FORMATS, f"unknown w_format={w_format!r}"
@@ -5141,6 +5241,11 @@ def _launch_kernel(
         assert x_scale is not None, "mxfp4 A requires a block-scale tensor"
     if has_w_block_scale:
         assert w_scale is not None, "mxfp4 W requires a block-scale tensor"
+    if has_x_block_scale and gather_indx is not None:
+        raise ValueError(
+            "gathered MXFP4 activations must be quantized into gathered row "
+            "order before gluon_mxfp_ragged_matmul"
+        )
 
     M_X = x.shape[-2]
     if gather_indx is not None:
@@ -5159,7 +5264,7 @@ def _launch_kernel(
         block_n,
         block_k,
         scale_block=32,
-        has_x_scale=has_x_block_scale and gather_indx is None,
+        has_x_scale=has_x_block_scale,
         has_w_scale=has_w_block_scale,
         k=K,
         x_format=x_format,
@@ -5221,6 +5326,13 @@ def _launch_kernel(
     else:
         slice_offs_buf = _make_dummy(x.device, torch.int32)
         slice_sizes_buf = _make_dummy(x.device, torch.int32)
+    has_padded_x_scale_rows = (
+        has_ragged_offs and has_x_block_scale and bool(x_scale_ragged_padded)
+    )
+    if has_padded_x_scale_rows:
+        x_scale_block_offs_buf = _as_int32(_ragged_scale_block_offs(a_ragged_metadata))
+    else:
+        x_scale_block_offs_buf = _make_dummy(x.device, torch.int32)
 
     # Block-schedule path: host picks grid_m as an integer upper bound
     # (no D2H sync, graph-capturable) and the kernel decodes
@@ -5303,6 +5415,7 @@ def _launch_kernel(
 
     swiglu_alpha = swiglu[0] if swiglu is not None else 0.0
     swiglu_limit = swiglu[1] if swiglu is not None else 0.0
+    swiglu_beta = swiglu[2] if swiglu is not None else 0.0
 
     w3 = w if w.ndim == 3 else w.unsqueeze(0)
 
@@ -5322,10 +5435,12 @@ def _launch_kernel(
         stride_wn, stride_wk = w3.stride(-1), w3.stride(-2)
 
     x_scale_load_mode = scale_load_mode
-    if has_x_block_scale and gather_indx is not None:
-        x_scale_load_mode = "transpose"
     w_scale_load_mode = scale_load_mode
-    x_scale_via_lds = x_scale_load_mode == "swizzle" and has_x_block_scale
+    x_scale_via_lds = (
+        x_scale_load_mode == "swizzle"
+        and has_x_block_scale
+        and a_ragged_metadata is None
+    )
     w_scale_via_lds = w_scale_load_mode == "swizzle" and has_w_block_scale
 
     if has_w_block_scale:
@@ -5411,6 +5526,7 @@ def _launch_kernel(
         gate_scal_buf,
         slice_offs_buf,
         slice_sizes_buf,
+        x_scale_block_offs_buf,
     )
     common_strides = (
         x.stride(-2),
@@ -5453,6 +5569,7 @@ def _launch_kernel(
         DO_SWIGLU=swiglu is not None,
         SWIGLU_ALPHA=float(swiglu_alpha),
         SWIGLU_LIMIT=float(swiglu_limit),
+        SWIGLU_BETA=float(swiglu_beta),
         OUT_BLOCK_N=out_block_n,
         APPLY_GATE_SCAL=gate_scal is not None,
         HAS_RAGGED_OFFS=has_ragged_offs,
@@ -5477,6 +5594,7 @@ def _launch_kernel(
         X_SCALE_VIA_LDS=bool(x_scale_via_lds),
         W_SCALE_VIA_LDS=bool(w_scale_via_lds),
         USE_NARROW_N_STORE_LAYOUT=bool(use_narrow_n_store_layout),
+        X_SCALE_RAGGED_PADDED=bool(has_padded_x_scale_rows),
         GRID_N=grid_n,
         GROUP_M=group_m,
         XCD_SWIZZLE=xcd_swizzle,
@@ -5668,6 +5786,14 @@ def _autotune_block(
 
     if block_n == 256 and block_m > 64 and not use_large_m:
         block_m = 64
+
+    if (
+        requested_block_m is None
+        and scale_load_mode == "swizzle"
+        and x_format == "e2m1"
+        and block_m < _NON_K_PRESHUFFLE_BLOCK_SIZE
+    ):
+        block_m = _NON_K_PRESHUFFLE_BLOCK_SIZE
 
     return block_m, block_n, block_k, nw, use_slice_n, use_small_m
 
@@ -5973,6 +6099,7 @@ def gluon_mxfp_dispatch_swiglu(
     out_dtype: torch.dtype = torch.bfloat16,
     swiglu_alpha: float = 1.0,
     swiglu_limit: float = 0.0,
+    swiglu_beta: float = 1.0,
     block_m: int | None = None,
     block_n: int | None = None,
     block_k: int | None = None,
@@ -5987,6 +6114,7 @@ def gluon_mxfp_dispatch_swiglu(
     num_ctas: int | None = None,
     out_quant_scale: torch.Tensor | float | None = None,
     w_preshuffle: bool = False,
+    x_scale_ragged_padded: bool = False,
 ) -> torch.Tensor:
     assert w.ndim == 3 and w.shape[-1] % 2 == 0
     M_X = int(x.shape[-2])
@@ -6046,6 +6174,13 @@ def gluon_mxfp_dispatch_swiglu(
         use_slice_n = False
         use_slice_mn = False
         use_small_prefill_m = False
+    if (
+        use_slice_n is None
+        and x_format == "e2m1"
+        and scale_load_mode == "swizzle"
+        and a_ragged_metadata is not None
+    ):
+        use_slice_n = False
     if w_preshuffle:
         block_n, use_slice_mn, use_slice_n = _align_block_n_to_preshuffled_layout(
             w,
@@ -6115,7 +6250,7 @@ def gluon_mxfp_dispatch_swiglu(
         scatter_indx=None,
         gate_scal=None,
         a_ragged_metadata=a_ragged_metadata,
-        swiglu=(float(swiglu_alpha), float(swiglu_limit)),
+        swiglu=(float(swiglu_alpha), float(swiglu_limit), float(swiglu_beta)),
         out_block_n=out_block_n,
         block_m=block_m,
         block_n=block_n,
@@ -6140,6 +6275,7 @@ def gluon_mxfp_dispatch_swiglu(
         w_preshuffle=w_preshuffle,
         w_cache_cg=w_cache_cg,
         medium_decode_dispatch=medium_decode_dispatch_eligible,
+        x_scale_ragged_padded=x_scale_ragged_padded,
     )
     return y
 
@@ -6172,6 +6308,7 @@ def gluon_mxfp_combine(
     persistent: bool | None = None,
     num_ctas: int | None = None,
     w_preshuffle: bool = False,
+    x_scale_ragged_padded: bool = False,
 ) -> torch.Tensor:
     assert w.ndim == 3
     M = x.shape[-2]
@@ -6296,6 +6433,8 @@ def gluon_mxfp_combine(
     logical_n = int(getattr(w, "original_n", N))
     y_n = logical_n if logical_n < N else N
     y = torch.empty((n_rows, y_n), device=x.device, dtype=out_dtype)
+    # GEMM2 X is already in expert-sorted ragged order. Store through
+    # scatter_indx to recover flat token/top-k row order before reduction.
     _launch_kernel(
         x,
         w,
@@ -6331,6 +6470,7 @@ def gluon_mxfp_combine(
         w_cache_cg=w_cache_cg,
         use_narrow_n_store_layout=use_narrow_n_store_layout,
         medium_decode_combine=medium_decode_combine_eligible,
+        x_scale_ragged_padded=x_scale_ragged_padded,
     )
     if n_act_eff > 1:
         if medium_decode_combine_eligible:
@@ -6370,7 +6510,7 @@ _TUNING_KW = frozenset(
 )
 
 # Gluon-only kwargs; explicitly stripped before forwarding upstream.
-_GLUON_PRIVATE_KW = frozenset({"out_quant_scale"})
+_GLUON_PRIVATE_KW = frozenset({"out_quant_scale", "x_scale_ragged_padded"})
 
 
 def _extract_gluon_raw_w(w):
@@ -6419,7 +6559,7 @@ def _extract_gluon_raw_s(s):
 
 
 def _maybe_extract_swiglu_args(fused_activation):
-    """Pull ``(alpha, limit)`` from an upstream ``FusedActivation`` object
+    """Pull ``(alpha, limit, beta)`` from an upstream ``FusedActivation`` object
     representing SwiGLU. Returns ``None`` for any other activation."""
     if fused_activation is None:
         return None
@@ -6432,7 +6572,8 @@ def _maybe_extract_swiglu_args(fused_activation):
         args = getattr(fused_activation, "args", None)
     if args is None or len(args) < 2:
         return None
-    return float(args[0]), float(args[1])
+    beta = args[2] if len(args) >= 3 else 1.0
+    return float(args[0]), float(args[1]), float(beta)
 
 
 def _global_scale_passthrough(scale):
@@ -6443,6 +6584,254 @@ def _global_scale_passthrough(scale):
     if isinstance(scale, torch.Tensor):
         return scale
     return float(scale)
+
+
+@triton.jit
+def _mxfp4_quantize_block(x):
+    max_normal: tl.constexpr = 6
+    min_normal: tl.constexpr = 1
+    amax = tl.max(tl.abs(x), axis=0)
+    amax = amax.to(tl.int32, bitcast=True)
+    amax = (amax + 0x200000).to(tl.uint32, bitcast=True) & 0xFF800000
+    amax = amax.to(tl.float32, bitcast=True)
+    scale_e8m0_unbiased = tl.log2(amax).floor() - 2
+    scale_e8m0_unbiased = tl.clamp(scale_e8m0_unbiased, min=-127, max=127)
+    scale_byte = scale_e8m0_unbiased.to(tl.uint8) + 127
+    qx = x * tl.exp2(-scale_e8m0_unbiased)
+    qx = qx.to(tl.uint32, bitcast=True)
+
+    sign = qx & 0x80000000
+    qx = qx ^ sign
+    qx_fp32 = qx.to(tl.float32, bitcast=True)
+    saturate_mask = qx_fp32 >= max_normal
+    denormal_mask = (not saturate_mask) & (qx_fp32 < min_normal)
+    normal_mask = not (saturate_mask | denormal_mask)
+
+    denorm_exp: tl.constexpr = (127 - 1) + (23 - 1) + 1
+    denorm_mask_int: tl.constexpr = denorm_exp << 23
+    denorm_mask_float: tl.constexpr = tl.cast(denorm_mask_int, tl.float32, bitcast=True)
+    denormal_x = qx_fp32 + denorm_mask_float
+    denormal_x = denormal_x.to(tl.uint32, bitcast=True)
+    denormal_x -= denorm_mask_int
+    denormal_x = denormal_x.to(tl.uint8)
+
+    normal_x = qx
+    mant_odd = (normal_x >> (23 - 1)) & 1
+    normal_x += 0xC11FFFFF
+    normal_x += mant_odd
+    normal_x = normal_x >> (23 - 1)
+    normal_x = normal_x.to(tl.uint8)
+
+    e2m1 = tl.full(x.shape, 0x7, dtype=tl.uint8)
+    e2m1 = tl.where(normal_mask, normal_x, e2m1)
+    e2m1 = tl.where(denormal_mask, denormal_x, e2m1)
+    sign_lp = sign >> (23 + 8 - 1 - 2)
+    sign_lp = sign_lp.to(tl.uint8)
+    e2m1 = e2m1 | sign_lp
+    e2m1 = tl.reshape(e2m1, [16, 2])
+    evens, odds = tl.split(e2m1)
+    return evens | (odds << 4), scale_byte
+
+
+@triton.jit
+def _mxfp4_quantize_cdna4_scale_kernel(
+    x_ptr,
+    gather_ptr,
+    slice_offs_ptr,
+    scale_block_offs_ptr,
+    out_ptr,
+    scale_ptr,
+    x_row_stride,
+    out_row_stride,
+    scale_stride_kswizzled,
+    scale_stride_mblock,
+    M: tl.constexpr,
+    K_SCALE: tl.constexpr,
+    HAS_GATHER: tl.constexpr,
+    HAS_PADDED_SCALE_ROWS: tl.constexpr,
+    N_EXPERTS: tl.constexpr,
+    EXPERT_SEARCH_STEPS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    M_SWIZZLE: tl.constexpr,
+    K_SWIZZLE: tl.constexpr,
+):
+    out_m = tl.program_id(0)
+    k_group = tl.program_id(1)
+    valid = (out_m < M) & (k_group < K_SCALE)
+    src_m = out_m
+    if HAS_GATHER:
+        src_m = tl.load(gather_ptr + out_m, mask=out_m < M, other=0)
+
+    offs_k = k_group * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    x = tl.load(
+        x_ptr + src_m * x_row_stride + offs_k,
+        mask=valid,
+        other=0.0,
+    ).to(tl.float32)
+    packed, scale_byte = _mxfp4_quantize_block(x)
+    scale_byte = tl.where(valid, scale_byte, 0)
+
+    pack_idx = tl.arange(0, 16)
+    tl.store(
+        out_ptr + out_m * out_row_stride + k_group * 16 + pack_idx,
+        packed,
+        mask=valid,
+    )
+
+    scale_m = out_m
+    if HAS_PADDED_SCALE_ROWS:
+        search_m = tl.minimum(out_m, M - 1)
+        lo = tl.full((), 0, tl.int32)
+        hi = tl.full((), N_EXPERTS, tl.int32)
+        for _ in range(EXPERT_SEARCH_STEPS):
+            mid = (lo + hi) // 2
+            end = tl.load(slice_offs_ptr + mid + 1)
+            go_left = search_m < end
+            hi = tl.where(go_left, mid, hi)
+            lo = tl.where(go_left, lo, mid + 1)
+        expert = lo
+        compact_base = tl.load(slice_offs_ptr + expert)
+        scale_block_base = tl.load(scale_block_offs_ptr + expert)
+        scale_m = scale_block_base * M_SWIZZLE + (out_m - compact_base)
+
+    m_in_block = scale_m % M_SWIZZLE
+    m_hi = m_in_block // 16
+    m_lo = m_in_block % 16
+    k_block = k_group // K_SWIZZLE
+    k_in_block = k_group % K_SWIZZLE
+    k_hi = k_in_block // 4
+    k_lo = k_in_block % 4
+    swizzled_k = (((k_block * 4 + k_lo) * 16 + m_lo) * 2 + k_hi) * 2 + m_hi
+    m_block = scale_m // M_SWIZZLE
+    tl.store(
+        scale_ptr + swizzled_k * scale_stride_kswizzled + m_block * scale_stride_mblock,
+        scale_byte,
+        mask=valid,
+    )
+
+
+def _cdna4_swizzled_scale_empty(
+    rows: int,
+    k_scale: int,
+    *,
+    device: torch.device,
+) -> torch.Tensor:
+    k_scale_pad = (
+        (k_scale + _ALIGN_K_SCALE_SWIZZLE - 1)
+        // _ALIGN_K_SCALE_SWIZZLE
+        * _ALIGN_K_SCALE_SWIZZLE
+    )
+    rows_pad = (
+        (rows + _NON_K_PRESHUFFLE_BLOCK_SIZE - 1)
+        // _NON_K_PRESHUFFLE_BLOCK_SIZE
+        * _NON_K_PRESHUFFLE_BLOCK_SIZE
+    )
+    shape = (
+        k_scale_pad * _NON_K_PRESHUFFLE_BLOCK_SIZE,
+        rows_pad // _NON_K_PRESHUFFLE_BLOCK_SIZE,
+    )
+    return torch.empty_strided(
+        shape,
+        (1, shape[0]),
+        dtype=torch.uint8,
+        device=device,
+    )
+
+
+def _as_gather_tensor(gather_indx: Any | None) -> torch.Tensor | None:
+    if gather_indx is None:
+        return None
+    return gather_indx.src_indx if hasattr(gather_indx, "src_indx") else gather_indx
+
+
+def _quantize_mxfp4_activation(
+    activations: torch.Tensor,
+    gather_indx: Any | None = None,
+    ragged_metadata: Any | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if activations.dtype not in (torch.bfloat16, torch.float16):
+        raise TypeError(
+            "MXFP4 activation quantization requires bf16/fp16 input, "
+            f"got {activations.dtype}"
+        )
+    if activations.ndim != 2:
+        raise ValueError(
+            "MXFP4 activation quantization expects a rank-2 tensor, "
+            f"got shape={tuple(activations.shape)}"
+        )
+    if activations.shape[-1] % MXFP4_BLOCK != 0:
+        raise ValueError(
+            "MXFP4 activation quantization requires the last dimension to be "
+            f"divisible by {MXFP4_BLOCK}, got {activations.shape[-1]}"
+        )
+
+    x = activations.contiguous()
+    gather_tensor = _as_gather_tensor(gather_indx)
+    rows = int(gather_tensor.shape[0]) if gather_tensor is not None else int(x.shape[0])
+    k = int(x.shape[1])
+    k_scale = k // MXFP4_BLOCK
+    out = torch.empty((rows, k // 2), dtype=torch.uint8, device=x.device)
+    if ragged_metadata is not None:
+        n_slices = int(ragged_metadata.slice_sizes.shape[0])
+        scale_rows = (
+            RaggedTensorMetadata.n_blocks(
+                n_slices,
+                rows,
+                _NON_K_PRESHUFFLE_BLOCK_SIZE,
+            )
+            * _NON_K_PRESHUFFLE_BLOCK_SIZE
+        )
+        slice_offs = _as_int32(ragged_metadata.slice_offs)
+        scale_block_offs = _as_int32(_ragged_scale_block_offs(ragged_metadata))
+        expert_search_steps = (n_slices + 1).bit_length()
+    else:
+        n_slices = 0
+        scale_rows = rows
+        slice_offs = _make_dummy(x.device, torch.int32)
+        scale_block_offs = _make_dummy(x.device, torch.int32)
+        expert_search_steps = 0
+    scale = _cdna4_swizzled_scale_empty(scale_rows, k_scale, device=x.device)
+    if rows == 0:
+        return out, scale
+
+    k_scale_pad = (
+        (k_scale + _ALIGN_K_SCALE_SWIZZLE - 1)
+        // _ALIGN_K_SCALE_SWIZZLE
+        * _ALIGN_K_SCALE_SWIZZLE
+    )
+    rows_pad = (
+        (rows + _NON_K_PRESHUFFLE_BLOCK_SIZE - 1)
+        // _NON_K_PRESHUFFLE_BLOCK_SIZE
+        * _NON_K_PRESHUFFLE_BLOCK_SIZE
+    )
+    gather = (
+        _as_int32(gather_tensor).contiguous()
+        if gather_tensor is not None
+        else _make_dummy(x.device, torch.int32)
+    )
+    _mxfp4_quantize_cdna4_scale_kernel[(rows_pad, k_scale_pad)](
+        x,
+        gather,
+        slice_offs,
+        scale_block_offs,
+        out,
+        scale,
+        x.stride(0),
+        out.stride(0),
+        scale.stride(0),
+        scale.stride(1),
+        M=rows,
+        K_SCALE=k_scale,
+        HAS_GATHER=gather_tensor is not None,
+        HAS_PADDED_SCALE_ROWS=ragged_metadata is not None,
+        N_EXPERTS=n_slices,
+        EXPERT_SEARCH_STEPS=expert_search_steps,
+        BLOCK_SIZE=MXFP4_BLOCK,
+        M_SWIZZLE=_NON_K_PRESHUFFLE_BLOCK_SIZE,
+        K_SWIZZLE=_ALIGN_K_SCALE_SWIZZLE,
+        num_warps=1,
+    )
+    return out, scale
 
 
 def gluon_mxfp_ragged_matmul(
@@ -6518,6 +6907,22 @@ def gluon_mxfp_ragged_matmul(
 
     gammas = extra_kwargs.get("gammas")
     out_quant_scale = extra_kwargs.get("out_quant_scale")
+    x_scale_ragged_padded = bool(extra_kwargs.get("x_scale_ragged_padded", False))
+    scale_load_mode = extra_kwargs.get("scale_load_mode", "swizzle")
+    launch_kwargs = {
+        key: extra_kwargs[key]
+        for key in (
+            "block_m",
+            "block_n",
+            "block_k",
+            "num_warps",
+            "num_buffers",
+            "use_warp_pipeline",
+            "use_slice_mn",
+            "use_slice_n",
+        )
+        if key in extra_kwargs
+    }
 
     if has_scatter and not has_gather:
         # gemm + combine
@@ -6536,14 +6941,16 @@ def gluon_mxfp_ragged_matmul(
             n_tokens=n_tokens,
             n_expts_act=n_expts_act,
             out_dtype=out_dtype,
-            scale_load_mode="swizzle",
+            scale_load_mode=scale_load_mode,
             w_transpose=True,
             w_preshuffle=w_preshuffle,
+            x_scale_ragged_padded=x_scale_ragged_padded,
+            **launch_kwargs,
         )
         return out
 
     if not has_scatter and swiglu_args is not None:
-        swiglu_alpha, swiglu_limit = swiglu_args
+        swiglu_alpha, swiglu_limit, swiglu_beta = swiglu_args
         w_preshuffle = bool(getattr(w_raw, "is_shuffled_for_gluon_dot", False))
         out = gluon_mxfp_dispatch_swiglu(
             x_view,
@@ -6558,10 +6965,13 @@ def gluon_mxfp_ragged_matmul(
             out_dtype=out_dtype,
             swiglu_alpha=swiglu_alpha,
             swiglu_limit=swiglu_limit,
-            scale_load_mode="swizzle",
+            swiglu_beta=swiglu_beta,
+            scale_load_mode=scale_load_mode,
             w_transpose=True,
             out_quant_scale=out_quant_scale,
             w_preshuffle=w_preshuffle,
+            x_scale_ragged_padded=x_scale_ragged_padded,
+            **launch_kwargs,
         )
         return out
 
@@ -6582,6 +6992,7 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
     top_k: int,
     swiglu_alpha: float = 1.702,
     swiglu_limit: float = 7.0,
+    swiglu_beta: float = 1.0,
 ) -> torch.Tensor | None:
     """Small-M direct warp-decode MoE for GPT-OSS FP8 x MXFP4 path."""
     assert hidden_states.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
@@ -6724,6 +7135,7 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         EVEN_K=coop_even_k,
         HAS_BIAS=w13_bias is not None,
         SWIGLU_ALPHA=float(swiglu_alpha), SWIGLU_LIMIT=float(swiglu_limit),
+        SWIGLU_BETA=float(swiglu_beta),
         num_warps=COOP_NUM_WARPS,
     )
     # fmt: on
@@ -6791,6 +7203,7 @@ def gluon_mxfp_fused_moe(
     enable_warp_decode: bool = True,
     swiglu_alpha: float = 1.702,
     swiglu_limit: float = 7.0,
+    swiglu_beta: float = 1.0,
 ) -> torch.Tensor:
     """Route + dispatch GEMM + SwiGLU + combine GEMM, all fused for the
     gluon mxfp4 / fp8-activation path.
@@ -6836,13 +7249,14 @@ def gluon_mxfp_fused_moe(
             top_k=top_k,
             swiglu_alpha=swiglu_alpha,
             swiglu_limit=swiglu_limit,
+            swiglu_beta=swiglu_beta,
         )
         if out is not None:
             return out
 
     # Decode-small GPT-OSS routing is launch-overhead dominated. Prefer the
-    # single-kernel Gluon route for the M<=16 single-block-collapse regime;
-    # fall back to the generic Triton route for larger/unsupported shapes.
+    # single-kernel Gluon route when both M<=16 and G=M*top_k stays within
+    # the rank-tile bound; fall back for larger/unsupported route shapes.
     if n_tokens <= SMALLM_MAX_M and gluon_route_supported(
         router_logits, top_k, router_logits.dtype
     ):
@@ -6859,8 +7273,8 @@ def gluon_mxfp_fused_moe(
         )
 
     act = FusedActivation(
-        FnSpecs("swiglu", swiglu_fn, ("alpha", "limit"), reduction_n=2),
-        (swiglu_alpha, swiglu_limit),
+        FnSpecs("swiglu", swiglu_fn, ("alpha", "limit", "beta"), reduction_n=2),
+        (swiglu_alpha, swiglu_limit, swiglu_beta),
     )
 
     gemm1_input = x_fp8
@@ -6897,22 +7311,159 @@ def gluon_mxfp_fused_moe(
     )
 
 
+def gluon_mxfp_dynamic_mxfp4_fused_moe(
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor,
+    w13_weight: torch.Tensor,
+    w2_weight: torch.Tensor,
+    *,
+    w13_mx_scale: torch.Tensor,
+    w2_mx_scale: torch.Tensor,
+    top_k: int,
+    correction_bias: torch.Tensor | None,
+    n_group: int,
+    topk_group: int,
+    routed_scaling_factor: float,
+    normalize_topk_weights: bool,
+    w13_bias: Optional[torch.Tensor] = None,
+    w2_bias: Optional[torch.Tensor] = None,
+    out_dtype: torch.dtype = torch.bfloat16,
+    swiglu_alpha: float = 1.702,
+    swiglu_limit: float = 7.0,
+    swiglu_beta: float = 1.0,
+) -> torch.Tensor:
+    """Route + dispatch + combine for dynamic MXFP4 activations on gfx950.
+
+    The route path follows DeepSeek/Kimi grouped-biased top-k when the model
+    supplies a correction bias; the small-M decode case fuses top-k and ragged
+    metadata construction in one Gluon kernel.
+    """
+    n_tokens = router_logits.shape[0]
+    route_dtype = router_logits.dtype
+
+    if correction_bias is not None and (n_group <= 0 or topk_group <= 0):
+        raise ValueError(
+            "correction_bias requires grouped routing metadata: "
+            f"n_group={n_group}, topk_group={topk_group}"
+        )
+
+    if correction_bias is not None:
+        if n_tokens <= SMALLM_MAX_M and gluon_biased_grouped_route_supported(
+            router_logits,
+            correction_bias,
+            top_k,
+            n_group=n_group,
+            topk_group=topk_group,
+            dtype=route_dtype,
+        ):
+            (
+                ragged_metadata,
+                gather_indx,
+                scatter_indx,
+                gate_scal,
+            ) = gluon_biased_grouped_fused_route(
+                router_logits,
+                correction_bias,
+                top_k,
+                n_group=n_group,
+                topk_group=topk_group,
+                routed_scaling_factor=routed_scaling_factor,
+                normalize_topk_weights=normalize_topk_weights,
+                dtype=route_dtype,
+            )
+        else:
+            (
+                ragged_metadata,
+                gather_indx,
+                scatter_indx,
+                gate_scal,
+            ) = default_biased_grouped_route(
+                router_logits,
+                correction_bias,
+                top_k,
+                n_group=n_group,
+                topk_group=topk_group,
+                routed_scaling_factor=routed_scaling_factor,
+                normalize_topk_weights=normalize_topk_weights,
+                dtype=route_dtype,
+            )
+    elif n_tokens <= SMALLM_MAX_M and gluon_route_supported(
+        router_logits, top_k, route_dtype
+    ):
+        ragged_metadata, gather_indx, scatter_indx, gate_scal = gluon_fused_route(
+            router_logits,
+            top_k,
+            dtype=route_dtype,
+        )
+    else:
+        ragged_metadata, gather_indx, scatter_indx, gate_scal = default_route(
+            router_logits,
+            top_k,
+            dtype=route_dtype,
+        )
+
+    act = FusedActivation(
+        FnSpecs("swiglu", swiglu_fn, ("alpha", "limit", "beta"), reduction_n=2),
+        (swiglu_alpha, swiglu_limit, swiglu_beta),
+    )
+
+    gemm1_input, gemm1_scale = _quantize_mxfp4_activation(
+        hidden_states,
+        gather_indx=gather_indx,
+        ragged_metadata=ragged_metadata,
+    )
+    intermediate_cache = gluon_mxfp_ragged_matmul(
+        gemm1_input,
+        w13_weight,
+        w13_bias,
+        w_mx_scale=w13_mx_scale,
+        x_mx_scale=gemm1_scale,
+        x_format="e2m1",
+        out_dtype=out_dtype,
+        a_ragged_metadata=ragged_metadata,
+        fused_activation=act,
+        x_scale_ragged_padded=True,
+    )
+
+    gemm2_input, gemm2_scale = _quantize_mxfp4_activation(
+        intermediate_cache,
+        ragged_metadata=ragged_metadata,
+    )
+    return gluon_mxfp_ragged_matmul(
+        gemm2_input,
+        w2_weight,
+        w2_bias,
+        w_mx_scale=w2_mx_scale,
+        x_mx_scale=gemm2_scale,
+        x_format="e2m1",
+        out_dtype=out_dtype,
+        a_ragged_metadata=ragged_metadata,
+        scatter_indx=scatter_indx,
+        gammas=gate_scal,
+        n_tokens=n_tokens,
+        n_expts_act=top_k,
+        x_scale_ragged_padded=True,
+    )
+
+
 # ===========================================================================
 # Small-M (decode) fused MoE routing in Gluon.
 #
-# Decode routing is launch-overhead bound. For ``M <= SMALLM_MAX_M`` this
-# replaces the generic ``triton_kernels_routing`` pipeline (~12 kernel
-# launches) with a single Gluon kernel, producing output bit-for-bit identical
-# to the generic path. Larger M falls back; the caller gates on the bound.
+# Decode routing is launch-overhead bound. For route shapes satisfying both
+# ``M <= SMALLM_MAX_M`` and ``G = M*topk <= GLUON_ROUTE_MAX_G`` this replaces
+# the generic ``triton_kernels_routing`` pipeline (~12 kernel launches) with a
+# single Gluon kernel, producing output bit-for-bit identical to the generic
+# path. Larger M or G falls back; the caller gates on both bounds.
 #
-# Why M <= 16 makes this exact: 16 is the smallest RaggedTensorMetadata block
-# size, so every nonzero expert holds exactly one block (single-block collapse)
-# and the gather/scatter placement is stable. The kernel fuses the in-kernel
-# top-k, histogram/cumsum, single-block schedule, and a register-only counting
-# sort, reproducing ``moe_route(traits={"output_type": "ragged_metadata"})``:
+# Why the bounds make this exact: ``M <= 16`` means every nonzero expert holds
+# exactly one RaggedTensorMetadata block (single-block collapse), and
+# ``G = M*topk <= GLUON_ROUTE_MAX_G`` keeps the register-only counting sort in
+# the supported rank-tile regime. The kernel fuses in-kernel top-k,
+# histogram/cumsum, single-block schedule, and counting sort, reproducing
+# ``moe_route(traits={"output_type": "ragged_metadata"})``:
 # ``RaggedTensorMetadata`` + gather_indx/scatter_indx/gate_scal of length
-# ``G = M*topk``. Metadata shapes are queried from ``RaggedTensorMetadata`` so
-# they match ``make_ragged_tensor_metadata`` on HIP and non-HIP alike.
+# ``G``. Metadata shapes are queried from ``RaggedTensorMetadata`` so they match
+# ``make_ragged_tensor_metadata`` on HIP and non-HIP alike.
 # ===========================================================================
 
 # Number of block-size rows in RaggedTensorMetadata for the active platform
@@ -6921,12 +7472,10 @@ def gluon_mxfp_fused_moe(
 # exactly on every target.
 _ROUTE_NB = len(RaggedTensorMetadata.block_sizes())
 
-# Token-count bound for the small-M fused route. 16 == the smallest
+# Token-count bound for single-block collapse. 16 == the smallest
 # RaggedTensorMetadata block size, so for M <= 16 every expert's token count is
-# ``col_sum <= M <= 16``, i.e. exactly one block, and the single-block schedule
-# collapse is exact. The caller dispatches only ``M <= SMALLM_MAX_M`` to the
-# Gluon kernel (decode, where it wins ~6x on routing) and keeps the generic
-# ``triton_kernels_routing`` pipeline for larger M.
+# ``col_sum <= M <= 16``. The flat gate count ``G = M*topk`` is bounded
+# separately below; callers must satisfy both bounds to use the Gluon route.
 SMALLM_MAX_M = 16
 # Warp-decode is only for the smallest decode regime. M>=8 should use the
 # medium-decode direct path selected by the ragged matmul path below.
@@ -6938,9 +7487,9 @@ FUSED_ROUTE_MAX_M = SMALLM_MAX_M
 # generic triton_kernels_routing pipeline.
 GLUON_ROUTE_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
 GLUON_ROUTE_MAX_E = 1024  # next_pow2(E) bins / EP-wide tiles stay bounded
-# Upper bound on G = M*topk. The stable-sort rank tile is [GP, GP] and the
-# kernel's layouts assume the single-wavefront regime (GP <= 64); configs that
-# would exceed it fall back to the generic pipeline.
+# Flat gate-count bound, where ``G = M*topk``. The stable-sort rank tile is
+# [GP, GP] and the kernel's layouts assume the single-wavefront regime
+# (GP <= 64); configs that exceed it fall back to the generic pipeline.
 GLUON_ROUTE_MAX_G = 64
 
 # torch gate dtype -> gluon element type (for the in-kernel softmax cast that
@@ -7049,8 +7598,124 @@ def _fused_topk(
     return idx, valsf.to(X_DTYPE)
 
 
+@gluon.jit
+def _fused_biased_grouped_topk(
+    Logits,  # [M, E]   X_DTYPE   (raw routing logits)
+    CorrectionBias,  # [E]      fp32      expert correction bias
+    stride_lm,  # logits row stride
+    gmask,  # [GP]     bool      g < G
+    tok,  # [GP]     int32     g // TOPK
+    slot,  # [GP]     int32     g % TOPK
+    M: gl.constexpr,
+    E: gl.constexpr,
+    TOPK: gl.constexpr,
+    N_GROUP: gl.constexpr,
+    TOPK_GROUP: gl.constexpr,
+    EXPERTS_PER_GROUP: gl.constexpr,
+    NORMALIZE_TOPK_WEIGHTS: gl.constexpr,
+    ROUTED_SCALING_FACTOR: gl.constexpr,
+    MP: gl.constexpr,
+    EP: gl.constexpr,
+    GP: gl.constexpr,
+    TKP: gl.constexpr,
+    NGP: gl.constexpr,
+    X_DTYPE: gl.constexpr,
+    L1: gl.constexpr,
+    LT: gl.constexpr,
+):
+    NEG: gl.constexpr = float("-inf")
+
+    row = gl.expand_dims(gl.arange(0, MP, layout=gl.SliceLayout(1, LT)), 1)
+    col = gl.expand_dims(gl.arange(0, EP, layout=gl.SliceLayout(0, LT)), 0)
+    lmask = (row < M) & (col < E)
+
+    logits = gl.load(Logits + row * stride_lm + col, mask=lmask, other=NEG).to(
+        gl.float32
+    )
+    bias = gl.load(CorrectionBias + col, mask=col < E, other=NEG).to(gl.float32)
+    scores = gl.fdiv(1.0, 1.0 + gl.exp(-logits)).to(X_DTYPE)
+    choice = gl.where(lmask, scores.to(gl.float32) + bias, NEG)
+
+    gcol = gl.expand_dims(gl.arange(0, NGP, layout=gl.SliceLayout(0, LT)), 0)
+    group_scores = gl.full([MP, NGP], NEG, gl.float32, layout=LT)
+    big_e = gl.full([MP, EP], E, gl.int32, layout=LT)
+    expert_group = col // EXPERTS_PER_GROUP
+
+    for _g in gl.static_range(N_GROUP):
+        in_group = lmask & (expert_group == _g)
+        best1 = gl.max(gl.where(in_group, choice, NEG), axis=1, keep_dims=True)
+        best1_expert = gl.min(
+            gl.where(in_group & (choice == best1), col, big_e),
+            axis=1,
+            keep_dims=True,
+        )
+        choice2 = gl.where(col == best1_expert, NEG, choice)
+        best2 = gl.max(gl.where(in_group, choice2, NEG), axis=1, keep_dims=True)
+        group_scores = gl.where(gcol == _g, best1 + best2, group_scores)
+
+    group_cur = group_scores
+    group_selected = gl.zeros([MP, NGP], gl.int32, layout=LT)
+    big_g = gl.full([MP, NGP], N_GROUP, gl.int32, layout=LT)
+    for _r in gl.static_range(TOPK_GROUP):
+        gmax = gl.max(group_cur, axis=1, keep_dims=True)
+        gbest = gl.min(
+            gl.where(group_cur == gmax, gcol, big_g),
+            axis=1,
+            keep_dims=True,
+        )
+        group_selected = gl.where(gcol == gbest, 1, group_selected)
+        group_cur = gl.where(gcol == gbest, NEG, group_cur)
+
+    expert_selected = gl.zeros([MP, EP], gl.int32, layout=LT)
+    zero_groups = gl.zeros([MP, NGP], gl.int32, layout=LT)
+    for _g in gl.static_range(N_GROUP):
+        selected = gl.sum(
+            gl.where(gcol == _g, group_selected, zero_groups),
+            axis=1,
+            keep_dims=True,
+        )
+        expert_selected = gl.where(expert_group == _g, selected, expert_selected)
+
+    cur = gl.where((expert_selected > 0) & lmask, choice, NEG)
+
+    tcol = gl.expand_dims(gl.arange(0, TKP, layout=gl.SliceLayout(0, LT)), 0)
+    val_t = gl.zeros([MP, TKP], gl.float32, layout=LT)
+    idx_t = gl.zeros([MP, TKP], gl.int32, layout=LT)
+    for _r in gl.static_range(TOPK):
+        vmax = gl.max(cur, axis=1, keep_dims=True)
+        ismax = (cur == vmax) & (col < E)
+        amax = gl.min(gl.where(ismax, col, big_e), axis=1, keep_dims=True)
+        gate = gl.max(gl.where(col == amax, scores, 0.0), axis=1, keep_dims=True)
+        sel = tcol == _r
+        val_t = gl.where(sel, gate, val_t)
+        idx_t = gl.where(sel, amax, idx_t)
+        cur = gl.where(col == amax, NEG, cur)
+
+    if NORMALIZE_TOPK_WEIGHTS:
+        # Match the Python grouped route for bf16 router logits: selected gates
+        # are bf16 and the per-token normalization is performed in that dtype.
+        val_t = val_t.to(X_DTYPE)
+        den = gl.sum(val_t, axis=1, keep_dims=True)
+        den = gl.where(den != 0.0, den, 1.0)
+        val_t = gl.fdiv(val_t, den) * ROUTED_SCALING_FACTOR
+
+    z_i = gl.zeros([MP, TKP], gl.int32, layout=LT)
+    z_f = gl.zeros([MP, TKP], gl.float32, layout=LT)
+    idx = gl.zeros([GP], gl.int32, layout=L1)
+    valsf = gl.zeros([GP], gl.float32, layout=L1)
+    for _r in gl.static_range(TOPK):
+        sel = tcol == _r
+        idx_r = gl.convert_layout(gl.sum(gl.where(sel, idx_t, z_i), axis=1), L1)
+        gat_r = gl.convert_layout(gl.sum(gl.where(sel, val_t, z_f), axis=1), L1)
+        take = (slot == _r) & gmask
+        idx = gl.where(take, gl.gather(idx_r, tok, axis=0), idx)
+        valsf = gl.where(take, gl.gather(gat_r, tok, axis=0), valsf)
+    return idx, valsf.to(X_DTYPE)
+
+
 # ===========================================================================
-# Small-M (M <= 16): single-workgroup, stable-order, single-block collapse.
+# Small route shapes: M <= 16 and G=M*topk <= 64.
+# Single-workgroup, stable-order, single-block collapse.
 # ===========================================================================
 @gluon.jit
 def _fused_route_small_m(
@@ -7088,7 +7753,8 @@ def _fused_route_small_m(
     LB: gl.constexpr = gl.BlockedLayout([1], [64], [NW_C], [0])  # 1D (MAXBLKP)
     LT: gl.constexpr = gl.BlockedLayout([1, 1], [1, 64], [NW_C, 1], [1, 0])  # 2D
 
-    # ---- fused top-k: compute (expert id, softmax gate) per gate in-kernel,
+    # ---- fused top-k: compute (expert id, softmax gate) for each of the
+    # G=M*TOPK flat gates in-kernel,
     # replacing the separate topk_forward launch + y_vals/y_indx round-trip.
     g = gl.arange(0, GP, layout=LG)
     gmask = g < G
@@ -7129,9 +7795,9 @@ def _fused_route_small_m(
     gl.store(SliceOffs + e + 1, incl, mask=emask & last)
 
     # ---- block_offs_data / block_schedule_data ----------------------------
-    # Single-block collapse: at M <= 16 every nonzero expert is exactly one
-    # block at every block size, so all NB rows are identical and the packed
-    # block value is just the expert id.
+    # Single-block collapse: M<=16 bounds every per-expert token count to one
+    # block, while the separate G=M*TOPK bound keeps the rank tile small. All
+    # NB rows are identical, and the packed block value is just the expert id.
     n_blk = (hist > 0).to(gl.int32)
     blk_incl = gl.associative_scan(n_blk, 0, _route_add)
     blk_excl = blk_incl - n_blk
@@ -7168,6 +7834,119 @@ def _fused_route_small_m(
     rank = gl.convert_layout(gl.sum(match, axis=1), LG)
 
     # ---- scatter to destination = slice_offs[expert] + rank ---------------
+    pos = gl.gather(col_offs, idx, axis=0) + rank
+    gl.store(GatherIndx + pos, tok, mask=gmask)
+    gl.store(ScatterIndx + pos, g.to(gl.int32), mask=gmask)
+    gl.store(GateScal + pos, vals, mask=gmask)
+
+
+@gluon.jit
+def _fused_biased_grouped_route_small_m(
+    Logits,  # [M, E]       X_DTYPE (raw routing logits)
+    CorrectionBias,  # [E]          fp32
+    SliceSizes,  # [E]          int32
+    SliceOffs,  # [E+1]        int32
+    BlockOffs,  # [NB, E+1]    int32
+    BlockSched,  # [NB, MAXBLK] int32
+    GatherIndx,  # [G]          int32
+    ScatterIndx,  # [G]         int32
+    GateScal,  # [G]           dtype
+    stride_lm,  # logits row stride
+    M: gl.constexpr,
+    E: gl.constexpr,
+    TOPK: gl.constexpr,
+    N_GROUP: gl.constexpr,
+    TOPK_GROUP: gl.constexpr,
+    EXPERTS_PER_GROUP: gl.constexpr,
+    NORMALIZE_TOPK_WEIGHTS: gl.constexpr,
+    ROUTED_SCALING_FACTOR: gl.constexpr,
+    MP: gl.constexpr,
+    GP: gl.constexpr,
+    EP: gl.constexpr,
+    TKP: gl.constexpr,
+    NGP: gl.constexpr,
+    MAXBLK: gl.constexpr,
+    MAXBLKP: gl.constexpr,
+    NB_C: gl.constexpr,
+    X_DTYPE: gl.constexpr,
+    NW_C: gl.constexpr,
+    bo_stride: gl.constexpr,
+    bs_stride: gl.constexpr,
+):
+    G: gl.constexpr = M * TOPK
+    LE: gl.constexpr = gl.BlockedLayout([1], [64], [NW_C], [0])
+    LG: gl.constexpr = gl.BlockedLayout([1], [64], [NW_C], [0])
+    LB: gl.constexpr = gl.BlockedLayout([1], [64], [NW_C], [0])
+    LT: gl.constexpr = gl.BlockedLayout([1, 1], [1, 64], [NW_C, 1], [1, 0])
+
+    g = gl.arange(0, GP, layout=LG)
+    gmask = g < G
+    tok = (g // TOPK).to(gl.int32)
+    slot = (g % TOPK).to(gl.int32)
+    idx, vals = _fused_biased_grouped_topk(
+        Logits,
+        CorrectionBias,
+        stride_lm,
+        gmask,
+        tok,
+        slot,
+        M,
+        E,
+        TOPK,
+        N_GROUP,
+        TOPK_GROUP,
+        EXPERTS_PER_GROUP,
+        NORMALIZE_TOPK_WEIGHTS,
+        ROUTED_SCALING_FACTOR,
+        MP,
+        EP,
+        GP,
+        TKP,
+        NGP,
+        X_DTYPE,
+        LG,
+        LT,
+    )
+
+    e = gl.arange(0, EP, layout=LE)
+    emask = e < E
+    hist = gl.histogram(idx, EP, mask=gmask, layout=LE)
+    gl.store(SliceSizes + e, hist, mask=emask)
+
+    incl = gl.associative_scan(hist, 0, _route_add)
+    col_offs = incl - hist
+    last = e == (E - 1)
+    gl.store(SliceOffs + e, col_offs, mask=emask)
+    gl.store(SliceOffs + e + 1, incl, mask=emask & last)
+
+    n_blk = (hist > 0).to(gl.int32)
+    blk_incl = gl.associative_scan(n_blk, 0, _route_add)
+    blk_excl = blk_incl - n_blk
+    n_total = gl.sum(n_blk, 0)
+    jb = gl.arange(0, MAXBLKP, layout=LB)
+    jbmask = jb < MAXBLK
+    neg_fill = gl.full([MAXBLKP], -1, gl.int32, layout=LB)
+    for k in gl.static_range(NB_C):
+        gl.store(BlockOffs + k * bo_stride + e, blk_excl, mask=emask)
+        gl.store(BlockOffs + k * bo_stride + e + 1, blk_incl, mask=emask & last)
+        gl.store(
+            BlockSched + k * bs_stride + jb,
+            neg_fill,
+            mask=jbmask & (jb >= n_total),
+        )
+        gl.store(
+            BlockSched + k * bs_stride + blk_excl,
+            e,
+            mask=(hist > 0) & emask,
+        )
+
+    idx_row = gl.expand_dims(gl.convert_layout(idx, gl.SliceLayout(1, LT)), 1)
+    idx_col = gl.expand_dims(gl.convert_layout(idx, gl.SliceLayout(0, LT)), 0)
+    g_row = gl.expand_dims(gl.arange(0, GP, layout=gl.SliceLayout(1, LT)), 1)
+    g_col = gl.expand_dims(gl.arange(0, GP, layout=gl.SliceLayout(0, LT)), 0)
+    match = ((idx_row == idx_col) & (g_col < g_row)).to(gl.int32)
+    rank = gl.convert_layout(gl.sum(match, axis=1), LG)
+
     pos = gl.gather(col_offs, idx, axis=0) + rank
     gl.store(GatherIndx + pos, tok, mask=gmask)
     gl.store(ScatterIndx + pos, g.to(gl.int32), mask=gmask)
@@ -7268,16 +8047,6 @@ def _load_w_scale_tile_direct_cdna4(
 
 
 @gluon.jit
-def _swiglu_gate_up(gate, linear, alpha: gl.constexpr, limit: gl.constexpr):
-    """SwiGLU on separate gate/up MFMA accumulators (pre-split form)."""
-    if limit > 0.0:
-        gate = gl.minimum(gate, limit)
-        linear = gl.clamp(linear, -limit, limit)
-    sigmoid = 1.0 / (1.0 + gl.exp(-alpha * gate))
-    return (gate * sigmoid) * (linear + 1.0)
-
-
-@gluon.jit
 def _warp_decode_stage1_coop_compute(
     token,
     slot,
@@ -7314,6 +8083,7 @@ def _warp_decode_stage1_coop_compute(
     HAS_BIAS: gl.constexpr,
     SWIGLU_ALPHA: gl.constexpr,
     SWIGLU_LIMIT: gl.constexpr,
+    SWIGLU_BETA: gl.constexpr,
 ):
     """Cooperative gate_up GEMM + bias + SwiGLU + fp8-quant + store for one
     (token, slot, expert).  N runs over the INTERLEAVED gate_up rows (2*I);
@@ -7488,7 +8258,14 @@ def _warp_decode_stage1_coop_compute(
         )
         acc = acc + bias[None, :].to(gl.float32)
 
-    out = _swiglu_reduce(acc, SWIGLU_ALPHA, SWIGLU_LIMIT, OUT_BLOCK_N, cfg.acc_layout)
+    out = _swiglu_reduce(
+        acc,
+        SWIGLU_ALPHA,
+        SWIGLU_LIMIT,
+        SWIGLU_BETA,
+        OUT_BLOCK_N,
+        cfg.acc_layout,
+    )
     out_inv_scale = 1.0 / gl.load(out_quant_scale_ptr).to(gl.float32)
     out = (out * out_inv_scale).to(Y.dtype.element_ty)
     STORE_LAYOUT: gl.constexpr = out.type.layout
@@ -7552,6 +8329,7 @@ def _warp_decode_topk_stage1_coop_kernel(
     HAS_BIAS: gl.constexpr,
     SWIGLU_ALPHA: gl.constexpr,
     SWIGLU_LIMIT: gl.constexpr,
+    SWIGLU_BETA: gl.constexpr,
 ):
     """Cooperative (multi-warp) fused dense top-k + gate_up stage1.
 
@@ -7630,7 +8408,7 @@ def _warp_decode_topk_stage1_coop_kernel(
         stride_ym, stride_yn,
         x_global_scale_ptr, out_quant_scale_ptr, w13_bias,
         TOPK, BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, NUM_WARPS,
-        W_PRESHUFFLED, EVEN_K, HAS_BIAS, SWIGLU_ALPHA, SWIGLU_LIMIT,
+        W_PRESHUFFLED, EVEN_K, HAS_BIAS, SWIGLU_ALPHA, SWIGLU_LIMIT, SWIGLU_BETA,
     )
     # fmt: on
 
@@ -8023,7 +8801,7 @@ def _moe_partial_reduce(
 
 
 def _route_small_m(logits, topk, dtype):
-    """M <= 16: 1-kernel stable-order fused route (top-k fused in-kernel)."""
+    """1-kernel stable-order fused route for bounded M and G=M*topk."""
     M, E = logits.shape
     G = M * topk
     device = logits.device
@@ -8080,6 +8858,142 @@ def _route_small_m(logits, topk, dtype):
     return ragged, gather_indx, scatter_indx, gate_scal
 
 
+def _route_from_topk(
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    num_experts: int,
+    dtype: torch.dtype | None = None,
+) -> tuple[
+    RaggedTensorMetadata,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    flat_ids = topk_ids.reshape(-1).to(torch.long)
+    valid = flat_ids >= 0
+    safe_ids = torch.where(valid, flat_ids, flat_ids.new_zeros(()))
+    sort_order = torch.argsort(safe_ids, stable=True)
+
+    top_k = topk_ids.shape[1]
+    # sort_order defines the expert-sorted ragged row order. GEMM1 gathers
+    # source token rows; GEMM2 scatters back to flat token/top-k rows.
+    gather_indx = (sort_order // top_k).to(torch.int32)
+    scatter_indx = sort_order.to(torch.int32)
+    gate_scal = topk_weights.reshape(-1)[sort_order]
+    gate_scal = torch.where(valid[sort_order], gate_scal, torch.zeros_like(gate_scal))
+    if dtype is not None and gate_scal.dtype != dtype:
+        gate_scal = gate_scal.to(dtype)
+
+    col_sum = torch.zeros((num_experts,), dtype=torch.int32, device=safe_ids.device)
+    col_sum.scatter_add_(0, safe_ids, valid.to(torch.int32))
+    ragged_metadata = make_ragged_tensor_metadata(col_sum, int(sort_order.numel()))
+    return ragged_metadata, gather_indx, scatter_indx, gate_scal
+
+
+def _biased_grouped_topk_reference(
+    logits: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    *,
+    n_group: int,
+    topk_group: int,
+    routed_scaling_factor: float,
+    normalize_topk_weights: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    scores = logits.sigmoid()
+    n_tokens, n_experts = scores.shape
+    scores_for_choice = scores + correction_bias.unsqueeze(0)
+    group_scores = (
+        scores_for_choice.view(n_tokens, n_group, -1)
+        .topk(2, dim=-1, sorted=True)[0]
+        .sum(dim=-1)
+    )
+    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=True)[1]
+    group_mask = torch.zeros_like(group_scores)
+    group_mask.scatter_(1, group_idx, 1)
+    score_mask = (
+        group_mask.unsqueeze(-1)
+        .expand(n_tokens, n_group, n_experts // n_group)
+        .reshape(n_tokens, -1)
+    )
+    tmp_scores = scores_for_choice.masked_fill(~score_mask.bool(), float("-inf"))
+    _, topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=True)
+    topk_weights = scores.gather(1, topk_ids)
+    if normalize_topk_weights:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+        topk_weights *= routed_scaling_factor
+    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+
+
+def _biased_grouped_route_small_m(
+    logits: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    *,
+    n_group: int,
+    topk_group: int,
+    routed_scaling_factor: float,
+    normalize_topk_weights: bool,
+    dtype: torch.dtype,
+):
+    M, E = logits.shape
+    G = M * topk
+    device = logits.device
+    logits = logits.contiguous()
+    correction_bias = correction_bias.contiguous()
+
+    slice_sizes = torch.empty(E, dtype=torch.int32, device=device)
+    slice_offs = torch.empty(E + 1, dtype=torch.int32, device=device)
+    block_offs_data = torch.empty(_ROUTE_NB, E + 1, dtype=torch.int32, device=device)
+    maxblk = RaggedTensorMetadata.max_n_blocks(E, G)
+    block_schedule_data = torch.empty(
+        _ROUTE_NB, maxblk, dtype=torch.int32, device=device
+    )
+    gather_indx = torch.empty(G, dtype=torch.int32, device=device)
+    scatter_indx = torch.empty(G, dtype=torch.int32, device=device)
+    gate_scal = torch.empty(G, dtype=dtype, device=device)
+
+    nw = 1 if M <= 2 else 4
+    _fused_biased_grouped_route_small_m[(1,)](
+        logits,
+        correction_bias,
+        slice_sizes,
+        slice_offs,
+        block_offs_data,
+        block_schedule_data,
+        gather_indx,
+        scatter_indx,
+        gate_scal,
+        logits.stride(0),
+        M=M,
+        E=E,
+        TOPK=topk,
+        N_GROUP=n_group,
+        TOPK_GROUP=topk_group,
+        EXPERTS_PER_GROUP=E // n_group,
+        NORMALIZE_TOPK_WEIGHTS=normalize_topk_weights,
+        ROUTED_SCALING_FACTOR=float(routed_scaling_factor),
+        MP=_route_next_pow2(M),
+        GP=_route_next_pow2(G),
+        EP=_route_next_pow2(E),
+        TKP=_route_next_pow2(topk),
+        NGP=_route_next_pow2(n_group),
+        MAXBLK=maxblk,
+        MAXBLKP=_route_next_pow2(maxblk),
+        NB_C=_ROUTE_NB,
+        X_DTYPE=_ROUTE_GL_DTYPE[logits.dtype],
+        NW_C=nw,
+        bo_stride=block_offs_data.stride(0),
+        bs_stride=block_schedule_data.stride(0),
+        num_warps=nw,
+    )
+
+    ragged = RaggedTensorMetadata(
+        slice_sizes, slice_offs, block_offs_data, block_schedule_data
+    )
+    return ragged, gather_indx, scatter_indx, gate_scal
+
+
 def gluon_route_supported(
     logits: torch.Tensor,
     topk: int,
@@ -8110,6 +9024,29 @@ def gluon_route_supported(
     return True
 
 
+def gluon_biased_grouped_route_supported(
+    logits: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    *,
+    n_group: int,
+    topk_group: int,
+    dtype: torch.dtype | None = None,
+) -> bool:
+    if not gluon_route_supported(logits, topk, dtype):
+        return False
+    if correction_bias.ndim != 1 or correction_bias.shape[0] != logits.shape[1]:
+        return False
+    _, E = logits.shape
+    if n_group <= 0 or topk_group <= 0:
+        return False
+    if E % n_group != 0 or E // n_group < 2:
+        return False
+    if topk_group > n_group:
+        return False
+    return True
+
+
 def gluon_fused_route(
     logits: torch.Tensor,
     topk: int,
@@ -8120,8 +9057,9 @@ def gluon_fused_route(
     Reproduces ``moe_route(traits={"output_type": "ragged_metadata"})`` in a
     single Gluon kernel, returning ``(ragged_metadata, gather_indx,
     scatter_indx, gate_scal)`` bit-for-bit identical to the generic pipeline.
-    Valid for ``M <= SMALLM_MAX_M`` (the single-block-collapse regime); callers
-    gate on that bound and fall back to the generic pipeline for larger ``M``.
+    Valid when both ``M <= SMALLM_MAX_M`` and
+    ``G = M*topk <= GLUON_ROUTE_MAX_G`` hold; callers gate on both bounds and
+    fall back to the generic pipeline otherwise.
     """
     if dtype is None:
         dtype = logits.dtype
@@ -8133,6 +9071,84 @@ def gluon_fused_route(
             "through the generic triton_kernels_routing pipeline."
         )
     return _route_small_m(logits, topk, dtype)
+
+
+def gluon_biased_grouped_fused_route(
+    logits: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    *,
+    n_group: int,
+    topk_group: int,
+    routed_scaling_factor: float,
+    normalize_topk_weights: bool,
+    dtype: torch.dtype | None = None,
+) -> tuple[
+    RaggedTensorMetadata,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    if dtype is None:
+        dtype = logits.dtype
+    M = logits.shape[0]
+    if M > SMALLM_MAX_M:
+        raise ValueError(
+            f"gluon_biased_grouped_fused_route requires M <= {SMALLM_MAX_M}, "
+            f"got M={M}"
+        )
+    if not gluon_biased_grouped_route_supported(
+        logits,
+        correction_bias,
+        topk,
+        n_group=n_group,
+        topk_group=topk_group,
+        dtype=dtype,
+    ):
+        raise ValueError("unsupported grouped-biased Gluon route configuration")
+    return _biased_grouped_route_small_m(
+        logits,
+        correction_bias,
+        topk,
+        n_group=n_group,
+        topk_group=topk_group,
+        routed_scaling_factor=routed_scaling_factor,
+        normalize_topk_weights=normalize_topk_weights,
+        dtype=dtype,
+    )
+
+
+def default_biased_grouped_route(
+    logits: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    *,
+    n_group: int,
+    topk_group: int,
+    routed_scaling_factor: float,
+    normalize_topk_weights: bool,
+    dtype: torch.dtype | None = None,
+) -> tuple[
+    RaggedTensorMetadata,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    topk_weights, topk_ids = _biased_grouped_topk_reference(
+        logits,
+        correction_bias,
+        topk,
+        n_group=n_group,
+        topk_group=topk_group,
+        routed_scaling_factor=routed_scaling_factor,
+        normalize_topk_weights=normalize_topk_weights,
+    )
+    return _route_from_topk(
+        topk_weights,
+        topk_ids,
+        num_experts=logits.shape[1],
+        dtype=dtype,
+    )
 
 
 def default_route(

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
@@ -7479,25 +7479,14 @@ def _dynamic_mxfp4_route(
             dtype=dtype,
         )
 
-    if normalize_topk_weights or routed_scaling_factor != 1.0:
-        return default_scaled_route(
-            router_logits,
-            top_k,
-            routed_scaling_factor=routed_scaling_factor,
-            normalize_topk_weights=normalize_topk_weights,
-            dtype=dtype,
-        )
-
-    if n_tokens <= SMALLM_MAX_M and gluon_route_supported(router_logits, top_k, dtype):
-        return gluon_fused_route(
-            router_logits,
-            top_k,
-            dtype=dtype,
-        )
-
-    return default_route(
+    # Dynamic MXFP4 follows runtime TopK semantics: select from the full-row
+    # softmax. With normalize_topk_weights=False, gate weights must remain
+    # full-row probabilities instead of selected-logit softmax probabilities.
+    return default_scaled_route(
         router_logits,
         top_k,
+        routed_scaling_factor=routed_scaling_factor,
+        normalize_topk_weights=normalize_topk_weights,
         dtype=dtype,
     )
 

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
@@ -7416,10 +7416,9 @@ def _dynamic_mxfp4_route(
     n_tokens = router_logits.shape[0]
 
     if int(routing_method_type) == _ROUTING_METHOD_RENORMALIZE:
-        return default_scaled_route(
+        return default_packed_topk_route(
             router_logits,
             top_k,
-            routed_scaling_factor=1.0,
             normalize_topk_weights=normalize_topk_weights,
             dtype=dtype,
         )
@@ -7600,6 +7599,29 @@ def default_scaled_route(
     return _route_from_topk(
         topk_weights,
         topk_ids,
+        num_experts=logits.shape[1],
+        dtype=dtype,
+    )
+
+
+def default_packed_topk_route(
+    logits: torch.Tensor,
+    topk: int,
+    *,
+    normalize_topk_weights: bool,
+    dtype: torch.dtype | None = None,
+) -> tuple[RaggedTensorMetadata, torch.Tensor, torch.Tensor, torch.Tensor]:
+    topk_logits, topk_ids = torch.topk(logits, k=topk, dim=-1, sorted=True)
+    topk_weights = topk_logits.exp()
+    topk_weights = _normalize_route_weights(
+        topk_weights,
+        normalize_topk_weights=normalize_topk_weights,
+        routed_scaling_factor=1.0,
+        scale_when_unnormalized=False,
+    )
+    return _route_from_topk(
+        topk_weights.to(torch.float32),
+        topk_ids.to(torch.int32),
         num_experts=logits.shape[1],
         dtype=dtype,
     )

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
@@ -7325,6 +7325,7 @@ def gluon_mxfp_dynamic_mxfp4_fused_moe(
     topk_group: int,
     routed_scaling_factor: float,
     normalize_topk_weights: bool,
+    routing_method_type: int = 0,
     w13_bias: Optional[torch.Tensor] = None,
     w2_bias: Optional[torch.Tensor] = None,
     out_dtype: torch.dtype = torch.bfloat16,
@@ -7341,66 +7342,17 @@ def gluon_mxfp_dynamic_mxfp4_fused_moe(
     n_tokens = router_logits.shape[0]
     route_dtype = router_logits.dtype
 
-    if correction_bias is not None and (n_group <= 0 or topk_group <= 0):
-        raise ValueError(
-            "correction_bias requires grouped routing metadata: "
-            f"n_group={n_group}, topk_group={topk_group}"
-        )
-
-    if correction_bias is not None:
-        if n_tokens <= SMALLM_MAX_M and gluon_biased_grouped_route_supported(
-            router_logits,
-            correction_bias,
-            top_k,
-            n_group=n_group,
-            topk_group=topk_group,
-            dtype=route_dtype,
-        ):
-            (
-                ragged_metadata,
-                gather_indx,
-                scatter_indx,
-                gate_scal,
-            ) = gluon_biased_grouped_fused_route(
-                router_logits,
-                correction_bias,
-                top_k,
-                n_group=n_group,
-                topk_group=topk_group,
-                routed_scaling_factor=routed_scaling_factor,
-                normalize_topk_weights=normalize_topk_weights,
-                dtype=route_dtype,
-            )
-        else:
-            (
-                ragged_metadata,
-                gather_indx,
-                scatter_indx,
-                gate_scal,
-            ) = default_biased_grouped_route(
-                router_logits,
-                correction_bias,
-                top_k,
-                n_group=n_group,
-                topk_group=topk_group,
-                routed_scaling_factor=routed_scaling_factor,
-                normalize_topk_weights=normalize_topk_weights,
-                dtype=route_dtype,
-            )
-    elif n_tokens <= SMALLM_MAX_M and gluon_route_supported(
-        router_logits, top_k, route_dtype
-    ):
-        ragged_metadata, gather_indx, scatter_indx, gate_scal = gluon_fused_route(
-            router_logits,
-            top_k,
-            dtype=route_dtype,
-        )
-    else:
-        ragged_metadata, gather_indx, scatter_indx, gate_scal = default_route(
-            router_logits,
-            top_k,
-            dtype=route_dtype,
-        )
+    ragged_metadata, gather_indx, scatter_indx, gate_scal = _dynamic_mxfp4_route(
+        router_logits,
+        top_k,
+        correction_bias=correction_bias,
+        n_group=n_group,
+        topk_group=topk_group,
+        routed_scaling_factor=routed_scaling_factor,
+        normalize_topk_weights=normalize_topk_weights,
+        routing_method_type=routing_method_type,
+        dtype=route_dtype,
+    )
 
     act = FusedActivation(
         FnSpecs("swiglu", swiglu_fn, ("alpha", "limit", "beta"), reduction_n=2),
@@ -7443,6 +7395,263 @@ def gluon_mxfp_dynamic_mxfp4_fused_moe(
         n_tokens=n_tokens,
         n_expts_act=top_k,
         x_scale_ragged_padded=True,
+    )
+
+
+_ROUTING_METHOD_RENORMALIZE = 1
+
+
+def _dynamic_mxfp4_route(
+    router_logits: torch.Tensor,
+    top_k: int,
+    *,
+    correction_bias: torch.Tensor | None,
+    n_group: int,
+    topk_group: int,
+    routed_scaling_factor: float,
+    normalize_topk_weights: bool,
+    routing_method_type: int,
+    dtype: torch.dtype,
+) -> tuple[RaggedTensorMetadata, torch.Tensor, torch.Tensor, torch.Tensor]:
+    n_tokens = router_logits.shape[0]
+
+    if int(routing_method_type) == _ROUTING_METHOD_RENORMALIZE:
+        return default_scaled_route(
+            router_logits,
+            top_k,
+            routed_scaling_factor=1.0,
+            normalize_topk_weights=normalize_topk_weights,
+            dtype=dtype,
+        )
+
+    if _uses_grouped_routing(n_group, topk_group):
+        if correction_bias is None:
+            return default_grouped_route(
+                router_logits,
+                top_k,
+                n_group=n_group,
+                topk_group=topk_group,
+                routed_scaling_factor=routed_scaling_factor,
+                normalize_topk_weights=normalize_topk_weights,
+                dtype=dtype,
+            )
+        if n_tokens <= SMALLM_MAX_M and gluon_biased_grouped_route_supported(
+            router_logits,
+            correction_bias,
+            top_k,
+            n_group=n_group,
+            topk_group=topk_group,
+            dtype=dtype,
+        ):
+            return gluon_biased_grouped_fused_route(
+                router_logits,
+                correction_bias,
+                top_k,
+                n_group=n_group,
+                topk_group=topk_group,
+                routed_scaling_factor=routed_scaling_factor,
+                normalize_topk_weights=normalize_topk_weights,
+                dtype=dtype,
+            )
+        return default_biased_grouped_route(
+            router_logits,
+            correction_bias,
+            top_k,
+            n_group=n_group,
+            topk_group=topk_group,
+            routed_scaling_factor=routed_scaling_factor,
+            normalize_topk_weights=normalize_topk_weights,
+            dtype=dtype,
+        )
+
+    if _has_incomplete_grouped_routing(n_group, topk_group):
+        raise ValueError(
+            "grouped routing requires both n_group and topk_group; "
+            f"got n_group={n_group}, topk_group={topk_group}"
+        )
+
+    if correction_bias is not None:
+        return default_biased_route(
+            router_logits,
+            correction_bias,
+            top_k,
+            routed_scaling_factor=routed_scaling_factor,
+            normalize_topk_weights=normalize_topk_weights,
+            dtype=dtype,
+        )
+
+    if normalize_topk_weights or routed_scaling_factor != 1.0:
+        return default_scaled_route(
+            router_logits,
+            top_k,
+            routed_scaling_factor=routed_scaling_factor,
+            normalize_topk_weights=normalize_topk_weights,
+            dtype=dtype,
+        )
+
+    if n_tokens <= SMALLM_MAX_M and gluon_route_supported(router_logits, top_k, dtype):
+        return gluon_fused_route(
+            router_logits,
+            top_k,
+            dtype=dtype,
+        )
+
+    return default_route(
+        router_logits,
+        top_k,
+        dtype=dtype,
+    )
+
+
+def _uses_grouped_routing(n_group: int, topk_group: int) -> bool:
+    return n_group > 0 and topk_group > 0
+
+
+def _has_incomplete_grouped_routing(n_group: int, topk_group: int) -> bool:
+    return (n_group > 0) != (topk_group > 0)
+
+
+def _normalize_route_weights(
+    topk_weights: torch.Tensor,
+    *,
+    normalize_topk_weights: bool,
+    routed_scaling_factor: float,
+    scale_when_unnormalized: bool,
+) -> torch.Tensor:
+    if normalize_topk_weights:
+        tiny = torch.finfo(topk_weights.dtype).tiny
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True).clamp_min(
+            tiny
+        )
+    if normalize_topk_weights or scale_when_unnormalized:
+        topk_weights = topk_weights * routed_scaling_factor
+    return topk_weights
+
+
+def _softmax_topk_reference(
+    logits: torch.Tensor,
+    topk: int,
+    *,
+    correction_bias: torch.Tensor | None,
+    routed_scaling_factor: float,
+    normalize_topk_weights: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    scores = torch.softmax(logits.float(), dim=-1)
+    scores_for_choice = scores
+    if correction_bias is not None:
+        scores_for_choice = scores + correction_bias.to(scores.dtype).unsqueeze(0)
+    _, topk_ids = torch.topk(scores_for_choice, k=topk, dim=-1, sorted=True)
+    topk_weights = scores.gather(1, topk_ids)
+    topk_weights = _normalize_route_weights(
+        topk_weights,
+        normalize_topk_weights=normalize_topk_weights,
+        routed_scaling_factor=routed_scaling_factor,
+        scale_when_unnormalized=True,
+    )
+    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+
+
+def _grouped_topk_reference(
+    logits: torch.Tensor,
+    topk: int,
+    *,
+    n_group: int,
+    topk_group: int,
+    routed_scaling_factor: float,
+    normalize_topk_weights: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    scores = torch.softmax(logits.float(), dim=-1)
+    n_tokens, n_experts = scores.shape
+    group_scores = scores.view(n_tokens, n_group, -1).max(dim=-1).values
+    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[1]
+    group_mask = torch.zeros_like(group_scores)
+    group_mask.scatter_(1, group_idx, 1)
+    score_mask = (
+        group_mask.unsqueeze(-1)
+        .expand(n_tokens, n_group, n_experts // n_group)
+        .reshape(n_tokens, -1)
+    )
+    tmp_scores = scores.masked_fill(~score_mask.bool(), 0.0)
+    topk_weights, topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=False)
+    topk_weights = _normalize_route_weights(
+        topk_weights,
+        normalize_topk_weights=normalize_topk_weights,
+        routed_scaling_factor=routed_scaling_factor,
+        scale_when_unnormalized=False,
+    )
+    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+
+
+def default_scaled_route(
+    logits: torch.Tensor,
+    topk: int,
+    *,
+    routed_scaling_factor: float,
+    normalize_topk_weights: bool,
+    dtype: torch.dtype | None = None,
+) -> tuple[RaggedTensorMetadata, torch.Tensor, torch.Tensor, torch.Tensor]:
+    topk_weights, topk_ids = _softmax_topk_reference(
+        logits,
+        topk,
+        correction_bias=None,
+        routed_scaling_factor=routed_scaling_factor,
+        normalize_topk_weights=normalize_topk_weights,
+    )
+    return _route_from_topk(
+        topk_weights,
+        topk_ids,
+        num_experts=logits.shape[1],
+        dtype=dtype,
+    )
+
+
+def default_biased_route(
+    logits: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    *,
+    routed_scaling_factor: float,
+    normalize_topk_weights: bool,
+    dtype: torch.dtype | None = None,
+) -> tuple[RaggedTensorMetadata, torch.Tensor, torch.Tensor, torch.Tensor]:
+    topk_weights, topk_ids = _softmax_topk_reference(
+        logits,
+        topk,
+        correction_bias=correction_bias,
+        routed_scaling_factor=routed_scaling_factor,
+        normalize_topk_weights=normalize_topk_weights,
+    )
+    return _route_from_topk(
+        topk_weights,
+        topk_ids,
+        num_experts=logits.shape[1],
+        dtype=dtype,
+    )
+
+
+def default_grouped_route(
+    logits: torch.Tensor,
+    topk: int,
+    *,
+    n_group: int,
+    topk_group: int,
+    routed_scaling_factor: float,
+    normalize_topk_weights: bool,
+    dtype: torch.dtype | None = None,
+) -> tuple[RaggedTensorMetadata, torch.Tensor, torch.Tensor, torch.Tensor]:
+    topk_weights, topk_ids = _grouped_topk_reference(
+        logits,
+        topk,
+        n_group=n_group,
+        topk_group=topk_group,
+        routed_scaling_factor=routed_scaling_factor,
+        normalize_topk_weights=normalize_topk_weights,
+    )
+    return _route_from_topk(
+        topk_weights,
+        topk_ids,
+        num_experts=logits.shape[1],
+        dtype=dtype,
     )
 
 

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/mxfp4_gfx950_preprocess.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/mxfp4_gfx950_preprocess.py
@@ -107,6 +107,11 @@ def _swizzle_mxfp4(quant_tensor: torch.Tensor, scale: torch.Tensor, num_warps: i
     return quant_tensor, InFlexData(), scale
 
 
+def _release_parameter(module: torch.nn.Module, name: str) -> None:
+    if hasattr(module, name):
+        delattr(module, name)
+
+
 def _interleave_gate_up_rows(tensor: torch.Tensor, dim: int) -> torch.Tensor:
     dim = dim % tensor.ndim
     rows = int(tensor.shape[dim])
@@ -216,10 +221,12 @@ def preprocess_gluon_mxfp4_gfx950_moe_weights(
             _interleave_gate_up_rows(w13_weight.data, dim=-2),
             requires_grad=False,
         )
+        _release_parameter(w, "w13_weight")
         w13_weight_scale = torch.nn.Parameter(
             _interleave_gate_up_rows(w13_weight_scale.data, dim=-2),
             requires_grad=False,
         )
+        _release_parameter(w, "w13_weight_scale")
 
     if hasattr(w, "w13_weight_bias"):
         w13_weight_bias = w.w13_weight_bias.to(torch.float32)
@@ -289,8 +296,10 @@ def preprocess_gluon_mxfp4_gfx950_moe_weights(
     w.w13_weight_triton_tensor = w13_weight
     w.w2_weight_triton_tensor = w2_weight
     _attach_w2_logical_n(w)
-    del w.w13_weight
-    del w.w2_weight
+    _release_parameter(w, "w13_weight")
+    _release_parameter(w, "w2_weight")
+    _release_parameter(w, "w13_weight_scale")
+    _release_parameter(w, "w2_weight_scale")
 
     if preshuffle:
         _attach_gluon_preshuffle(w)

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/mxfp4_gfx950_preprocess.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/mxfp4_gfx950_preprocess.py
@@ -185,8 +185,7 @@ def _attach_gluon_preshuffle(w: torch.nn.Module) -> None:
             shuffled.original_n = int(logical_n)
             raw.original_n = int(logical_n)
             wrapped.original_n = int(logical_n)
-        raw._gluon_shuffled = shuffled
-        wrapped._gluon_shuffled = shuffled
+        setattr(w, attr, shuffled)
 
 
 def _attach_w2_logical_n(w: torch.nn.Module) -> None:

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/mxfp4_gfx950_preprocess.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/mxfp4_gfx950_preprocess.py
@@ -107,6 +107,16 @@ def _swizzle_mxfp4(quant_tensor: torch.Tensor, scale: torch.Tensor, num_warps: i
     return quant_tensor, InFlexData(), scale
 
 
+def _interleave_gate_up_rows(tensor: torch.Tensor, dim: int) -> torch.Tensor:
+    dim = dim % tensor.ndim
+    rows = int(tensor.shape[dim])
+    if rows % 2 != 0:
+        raise ValueError(f"W13 gate/up row dimension must be even, got {rows}")
+    gate, up = tensor.split(rows // 2, dim=dim)
+    shape = list(tensor.shape)
+    return torch.stack((gate, up), dim=dim + 1).reshape(shape).contiguous()
+
+
 def _pad_w2_to_block_n(w: torch.nn.Module, block_n: int) -> None:
     original_n = int(w.w2_weight.shape[-2])
     w._w2_logical_n = original_n
@@ -195,39 +205,72 @@ def preprocess_gluon_mxfp4_gfx950_moe_weights(
 ) -> None:
     _pad_w2_to_block_n(w, _GLUON_COMBINE_BLOCK_N)
 
-    w13_weight_bias = w.w13_weight_bias.to(torch.float32)
-    w2_weight_bias = w.w2_weight_bias.to(torch.float32)
-    w.w13_weight_bias = torch.nn.Parameter(w13_weight_bias, requires_grad=False)
-    w.w2_weight_bias = torch.nn.Parameter(w2_weight_bias, requires_grad=False)
+    w13_layout = getattr(w, "w13_input_layout", "concatenated")
+    if w13_layout not in {"interleaved", "concatenated"}:
+        raise ValueError(f"unknown w13_input_layout: {w13_layout!r}")
+
+    w13_weight = w.w13_weight
+    w13_weight_scale = w.w13_weight_scale
+    if w13_layout == "concatenated":
+        w13_weight = torch.nn.Parameter(
+            _interleave_gate_up_rows(w13_weight.data, dim=-2),
+            requires_grad=False,
+        )
+        w13_weight_scale = torch.nn.Parameter(
+            _interleave_gate_up_rows(w13_weight_scale.data, dim=-2),
+            requires_grad=False,
+        )
+
+    if hasattr(w, "w13_weight_bias"):
+        w13_weight_bias = w.w13_weight_bias.to(torch.float32)
+        if w13_layout == "concatenated":
+            w13_weight_bias = _interleave_gate_up_rows(w13_weight_bias, dim=-1)
+        w.w13_weight_bias = torch.nn.Parameter(w13_weight_bias, requires_grad=False)
+    if hasattr(w, "w2_weight_bias"):
+        w2_weight_bias = w.w2_weight_bias.to(torch.float32)
+        w.w2_weight_bias = torch.nn.Parameter(w2_weight_bias, requires_grad=False)
 
     num_warps = 8
     w13_weight, w13_flex, w13_scale = _swizzle_mxfp4(
-        w.w13_weight, w.w13_weight_scale, num_warps
+        w13_weight, w13_weight_scale, num_warps
     )
     w2_weight, w2_flex, w2_scale = _swizzle_mxfp4(
         w.w2_weight, w.w2_weight_scale, num_warps
     )
 
-    w13_in_scale = (
-        w.w13_input_scale.data.to(torch.float32)
-        .max()
-        .reshape(1)
-        .to(w.w13_input_scale.device)
-        .contiguous()
+    quant_config = getattr(w, "quant_config", None)
+    use_dynamic_mxfp4_activations = bool(
+        getattr(quant_config, "use_dynamic_mxfp4_activations", False)
     )
-    w2_in_scale = (
-        w.w2_input_scale.data.to(torch.float32)
-        .max()
-        .reshape(1)
-        .to(w.w2_input_scale.device)
-        .contiguous()
+    has_static_fp8_scales = (
+        hasattr(w, "w13_input_scale")
+        and hasattr(w, "w2_input_scale")
+        and not use_dynamic_mxfp4_activations
     )
-    w.w13_act_scale = w13_in_scale
-    w.w2_act_scale = w2_in_scale
+    if has_static_fp8_scales:
+        w13_in_scale = (
+            w.w13_input_scale.data.to(torch.float32)
+            .max()
+            .reshape(1)
+            .to(w.w13_input_scale.device)
+            .contiguous()
+        )
+        w2_in_scale = (
+            w.w2_input_scale.data.to(torch.float32)
+            .max()
+            .reshape(1)
+            .to(w.w2_input_scale.device)
+            .contiguous()
+        )
+        w.w13_act_scale = w13_in_scale
+        w.w2_act_scale = w2_in_scale
 
-    fp8_dtype = torch.float8_e4m3fn
-    w13_lhs = InFlexData(dtype=fp8_dtype, scale=w13_in_scale)
-    w2_lhs = InFlexData(dtype=fp8_dtype, scale=w2_in_scale)
+        fp8_dtype = torch.float8_e4m3fn
+        w13_lhs = InFlexData(dtype=fp8_dtype, scale=w13_in_scale)
+        w2_lhs = InFlexData(dtype=fp8_dtype, scale=w2_in_scale)
+    else:
+        w13_lhs = InFlexData()
+        w2_lhs = InFlexData()
     out_dtype = torch.bfloat16
 
     w.w13_precision_config = PrecisionConfig(

--- a/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
@@ -23,6 +23,9 @@ if not _IS_GFX950:
 
 from tokenspeed_kernel_amd.ops.moe import fused_mxfp_gfx950 as gluon_moe  # noqa: E402
 from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import (  # noqa: E402
+    _dynamic_mxfp4_route,
+    default_biased_route,
+    default_grouped_route,
     default_route,
     fp8_quantize,
     gluon_biased_grouped_fused_route,
@@ -742,6 +745,31 @@ def _compute_torch_gemm2_reference(
     return routed.view(num_tokens, TOPK, HIDDEN_SIZE).sum(dim=1)
 
 
+def _recover_topk_from_route(
+    ragged_metadata: Any,
+    scatter_indx: torch.Tensor,
+    gate_scal: torch.Tensor,
+    num_tokens: int,
+    topk: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    device = scatter_indx.device
+    expert_ids = torch.repeat_interleave(
+        torch.arange(
+            ragged_metadata.slice_sizes.numel(),
+            device=device,
+            dtype=torch.int32,
+        ),
+        ragged_metadata.slice_sizes.to(torch.long),
+    )
+    flat_ids = torch.empty((num_tokens * topk,), device=device, dtype=torch.int32)
+    flat_weights = torch.empty(
+        (num_tokens * topk,), device=device, dtype=gate_scal.dtype
+    )
+    flat_ids[scatter_indx.long()] = expert_ids
+    flat_weights[scatter_indx.long()] = gate_scal
+    return flat_weights.view(num_tokens, topk), flat_ids.view(num_tokens, topk)
+
+
 def test_gluon_dynamic_mxfp4_moe_small_matches_torch_gfx950() -> None:
     import tokenspeed_kernel
     from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import (
@@ -852,30 +880,151 @@ def test_gluon_dynamic_mxfp4_moe_small_matches_torch_gfx950() -> None:
     )
 
 
-def test_gluon_dynamic_mxfp4_moe_rejects_incomplete_grouped_bias_config_gfx950() -> (
-    None
-):
+def test_default_biased_route_handles_nongrouped_correction_bias_gfx950() -> None:
     device = "cuda"
-    hidden = torch.empty((1, 32), device=device, dtype=torch.bfloat16)
-    logits = torch.empty((1, 8), device=device, dtype=torch.bfloat16)
-    correction_bias = torch.zeros((8,), device=device, dtype=torch.float32)
-    dummy = torch.empty((1,), device=device, dtype=torch.uint8)
+    logits = torch.tensor(
+        [
+            [1.0, -0.5, 0.25, 0.75, -1.0, 0.5, -0.25, 1.25],
+            [-0.75, 0.5, 1.5, -0.25, 0.0, 1.0, -1.5, 0.25],
+        ],
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    correction_bias = torch.tensor(
+        [0.0, 0.2, -0.1, 0.3, -0.2, 0.1, 0.4, -0.3],
+        device=device,
+        dtype=torch.float32,
+    )
+    topk = 3
+    scale = 1.75
 
-    with pytest.raises(ValueError, match="correction_bias requires grouped routing"):
-        gluon_mxfp_dynamic_mxfp4_fused_moe(
-            hidden,
-            logits,
-            dummy,
-            dummy,
-            w13_mx_scale=dummy,
-            w2_mx_scale=dummy,
-            top_k=2,
-            correction_bias=correction_bias,
-            n_group=0,
-            topk_group=1,
-            routed_scaling_factor=1.0,
-            normalize_topk_weights=True,
-        )
+    ragged, _, scatter, gate = default_biased_route(
+        logits,
+        correction_bias,
+        topk,
+        routed_scaling_factor=scale,
+        normalize_topk_weights=True,
+        dtype=logits.dtype,
+    )
+    actual_weights, actual_ids = _recover_topk_from_route(
+        ragged, scatter, gate, logits.shape[0], topk
+    )
+
+    scores = torch.softmax(logits.float(), dim=-1)
+    _, expected_ids = torch.topk(
+        scores + correction_bias.unsqueeze(0),
+        k=topk,
+        dim=-1,
+        sorted=True,
+    )
+    expected_weights = scores.gather(1, expected_ids)
+    expected_weights = expected_weights / expected_weights.sum(dim=-1, keepdim=True)
+    expected_weights = expected_weights * scale
+
+    torch.testing.assert_close(actual_ids, expected_ids.to(torch.int32))
+    torch.testing.assert_close(
+        actual_weights.float(),
+        expected_weights,
+        atol=5e-3,
+        rtol=5e-3,
+    )
+
+
+def test_default_grouped_route_preserves_grouping_and_scaling_gfx950() -> None:
+    device = "cuda"
+    logits = torch.tensor(
+        [
+            [1.0, 0.75, -0.25, -0.5, 0.5, 0.25, -1.0, -0.75],
+            [-0.25, -0.5, 0.5, 1.0, -0.75, 0.25, 0.75, -1.0],
+        ],
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    topk = 2
+    n_group = 4
+    topk_group = 2
+    scale = 2.0
+
+    ragged, _, scatter, gate = default_grouped_route(
+        logits,
+        topk,
+        n_group=n_group,
+        topk_group=topk_group,
+        routed_scaling_factor=scale,
+        normalize_topk_weights=True,
+        dtype=logits.dtype,
+    )
+    actual_weights, actual_ids = _recover_topk_from_route(
+        ragged, scatter, gate, logits.shape[0], topk
+    )
+
+    scores = torch.softmax(logits.float(), dim=-1)
+    num_tokens, num_experts = scores.shape
+    group_scores = scores.view(num_tokens, n_group, -1).max(dim=-1).values
+    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[1]
+    group_mask = torch.zeros_like(group_scores)
+    group_mask.scatter_(1, group_idx, 1)
+    score_mask = (
+        group_mask.unsqueeze(-1)
+        .expand(num_tokens, n_group, num_experts // n_group)
+        .reshape(num_tokens, -1)
+    )
+    expected_weights, expected_ids = torch.topk(
+        scores.masked_fill(~score_mask.bool(), 0.0),
+        k=topk,
+        dim=-1,
+        sorted=False,
+    )
+    expected_weights = expected_weights / expected_weights.sum(dim=-1, keepdim=True)
+    expected_weights = expected_weights * scale
+
+    actual_order = actual_ids.argsort(dim=-1)
+    expected_order = expected_ids.argsort(dim=-1)
+    torch.testing.assert_close(
+        actual_ids.gather(1, actual_order),
+        expected_ids.to(torch.int32).gather(1, expected_order),
+    )
+    torch.testing.assert_close(
+        actual_weights.float().gather(1, actual_order),
+        expected_weights.gather(1, expected_order),
+        atol=5e-3,
+        rtol=5e-3,
+    )
+
+
+def test_renormalize_route_recovers_packed_topk_without_scaling_gfx950() -> None:
+    device = "cuda"
+    topk_ids = torch.tensor(
+        [[4, 1], [2, 7]],
+        device=device,
+        dtype=torch.int32,
+    )
+    topk_weights = torch.tensor(
+        [[0.7, 0.3], [0.6, 0.4]],
+        device=device,
+        dtype=torch.float32,
+    )
+    router_logits = torch.full((2, 8), -1e20, device=device, dtype=torch.float32)
+    router_logits.scatter_(1, topk_ids.long(), topk_weights.log())
+    correction_bias = torch.linspace(-4.0, 4.0, 8, device=device, dtype=torch.float32)
+
+    ragged, _, scatter, gate = _dynamic_mxfp4_route(
+        router_logits,
+        top_k=2,
+        correction_bias=correction_bias,
+        n_group=0,
+        topk_group=0,
+        routed_scaling_factor=3.0,
+        normalize_topk_weights=True,
+        routing_method_type=1,
+        dtype=router_logits.dtype,
+    )
+    actual_weights, actual_ids = _recover_topk_from_route(
+        ragged, scatter, gate, router_logits.shape[0], 2
+    )
+
+    torch.testing.assert_close(actual_ids, topk_ids)
+    torch.testing.assert_close(actual_weights, topk_weights)
 
 
 def test_gluon_dynamic_mxfp4_moe_concatenated_silu_matches_torch_gfx950() -> None:

--- a/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
@@ -1100,7 +1100,9 @@ def test_renormalize_route_recovers_packed_topk_without_scaling_gfx950(
         dtype=torch.int32,
     )
     topk_weights = torch.tensor(topk_weights, device=device, dtype=torch.float32)
-    expected_weights = torch.tensor(expected_weights, device=device, dtype=torch.float32)
+    expected_weights = torch.tensor(
+        expected_weights, device=device, dtype=torch.float32
+    )
     router_logits = torch.full((2, 8), -1e20, device=device, dtype=torch.float32)
     router_logits.scatter_(1, topk_ids.long(), topk_weights.log())
     correction_bias = torch.linspace(-4.0, 4.0, 8, device=device, dtype=torch.float32)

--- a/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
@@ -1012,18 +1012,39 @@ def test_default_grouped_route_preserves_grouping_and_scaling_gfx950() -> None:
     )
 
 
-def test_renormalize_route_recovers_packed_topk_without_scaling_gfx950() -> None:
+@pytest.mark.parametrize(
+    ("topk_weights", "normalize_topk_weights", "expected_weights"),
+    [
+        (
+            [[0.7, 0.3], [0.6, 0.4]],
+            True,
+            [[0.7, 0.3], [0.6, 0.4]],
+        ),
+        (
+            [[2.0, 0.5], [1.5, 0.25]],
+            False,
+            [[2.0, 0.5], [1.5, 0.25]],
+        ),
+        (
+            [[2.0, 0.5], [1.5, 0.25]],
+            True,
+            [[0.8, 0.2], [0.85714287, 0.14285715]],
+        ),
+    ],
+)
+def test_renormalize_route_recovers_packed_topk_without_scaling_gfx950(
+    topk_weights: list[list[float]],
+    normalize_topk_weights: bool,
+    expected_weights: list[list[float]],
+) -> None:
     device = "cuda"
     topk_ids = torch.tensor(
         [[4, 1], [2, 7]],
         device=device,
         dtype=torch.int32,
     )
-    topk_weights = torch.tensor(
-        [[0.7, 0.3], [0.6, 0.4]],
-        device=device,
-        dtype=torch.float32,
-    )
+    topk_weights = torch.tensor(topk_weights, device=device, dtype=torch.float32)
+    expected_weights = torch.tensor(expected_weights, device=device, dtype=torch.float32)
     router_logits = torch.full((2, 8), -1e20, device=device, dtype=torch.float32)
     router_logits.scatter_(1, topk_ids.long(), topk_weights.log())
     correction_bias = torch.linspace(-4.0, 4.0, 8, device=device, dtype=torch.float32)
@@ -1035,7 +1056,7 @@ def test_renormalize_route_recovers_packed_topk_without_scaling_gfx950() -> None
         n_group=0,
         topk_group=0,
         routed_scaling_factor=3.0,
-        normalize_topk_weights=True,
+        normalize_topk_weights=normalize_topk_weights,
         routing_method_type=1,
         dtype=router_logits.dtype,
     )
@@ -1044,7 +1065,7 @@ def test_renormalize_route_recovers_packed_topk_without_scaling_gfx950() -> None
     )
 
     torch.testing.assert_close(actual_ids, topk_ids)
-    torch.testing.assert_close(actual_weights, topk_weights)
+    torch.testing.assert_close(actual_weights, expected_weights)
 
 
 def test_gluon_dynamic_mxfp4_moe_concatenated_silu_matches_torch_gfx950() -> None:

--- a/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
@@ -21,15 +21,24 @@ if not _IS_GFX950:
         allow_module_level=True,
     )
 
-from tokenspeed_kernel_amd.ops.moe import fused_mxfp_gfx950 as gluon_moe
-from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import (
+from tokenspeed_kernel_amd.ops.moe import fused_mxfp_gfx950 as gluon_moe  # noqa: E402
+from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import (  # noqa: E402
     default_route,
     fp8_quantize,
+    gluon_biased_grouped_fused_route,
+    gluon_mxfp_dynamic_mxfp4_fused_moe,
+    gluon_mxfp_ragged_matmul,
 )
-from tokenspeed_kernel_amd.ops.moe.mxfp4_gfx950_preprocess import (
+from tokenspeed_kernel_amd.ops.moe.mxfp4_gfx950_preprocess import (  # noqa: E402
+    _interleave_gate_up_rows,
+    _make_k_packed_mxfp4_weight,
     preprocess_gluon_mxfp4_gfx950_moe_weights,
 )
-from tokenspeed_kernel_amd.ops.moe.utils import FnSpecs, FusedActivation, swiglu_fn
+from tokenspeed_kernel_amd.ops.moe.utils import (  # noqa: E402
+    FnSpecs,
+    FusedActivation,
+    swiglu_fn,
+)
 
 HIDDEN_SIZE = 2880
 INTERMEDIATE_SIZE = 2880
@@ -356,6 +365,7 @@ def _make_weight_module(raw: RawMxfp4Weights) -> torch.nn.Module:
     layer = torch.nn.Module()
     layer.activation = "swiglu"
     layer.swiglu_arg = None
+    layer.w13_input_layout = "interleaved"
     layer.w13_weight = torch.nn.Parameter(raw.w13_weight.clone(), requires_grad=False)
     layer.w13_weight_scale = torch.nn.Parameter(
         raw.w13_scale.clone(), requires_grad=False
@@ -511,36 +521,6 @@ def _make_hidden_and_router(num_tokens: int) -> tuple[torch.Tensor, torch.Tensor
     return hidden_states, router_logits
 
 
-def _quantize_mxfp4_for_test(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-    if x.shape[-1] % MXFP4_BLOCK != 0:
-        raise ValueError("MXFP4 test quantization requires 32-element blocks")
-
-    x_blocks = x.to(torch.float32).reshape(
-        *x.shape[:-1],
-        x.shape[-1] // MXFP4_BLOCK,
-        MXFP4_BLOCK,
-    )
-    max_abs = x_blocks.abs().amax(dim=-1)
-    min_exp = torch.full_like(max_abs, -127.0)
-    scale_exp = torch.where(
-        max_abs > 0,
-        torch.floor(torch.log2(max_abs)) - 2,
-        min_exp,
-    ).clamp(-127, 127)
-
-    scaled = x_blocks * torch.exp2(-scale_exp).unsqueeze(-1)
-    abs_scaled = scaled.abs()
-    codes = torch.zeros_like(abs_scaled, dtype=torch.uint8)
-    for threshold in (0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0):
-        codes += (abs_scaled >= threshold).to(torch.uint8)
-    codes |= (scaled < 0).to(torch.uint8) * 8
-
-    packed_blocks = codes[..., 0::2] | (codes[..., 1::2] << 4)
-    packed = packed_blocks.reshape(*x.shape[:-1], x.shape[-1] // 2).contiguous()
-    scales = (scale_exp.to(torch.int16) + 127).to(torch.uint8).contiguous()
-    return packed, scales
-
-
 def _make_gemm2_input(num_tokens: int, scale: torch.Tensor) -> torch.Tensor:
     generator = torch.Generator(device="cuda").manual_seed(19000 + num_tokens)
     exact_values = (
@@ -566,7 +546,39 @@ def _swiglu_activation() -> FusedActivation:
     )
 
 
-def _mxfp4_dequant(packed: torch.Tensor, scales: torch.Tensor) -> torch.Tensor:
+def _compact_ragged_scales(
+    scales: torch.Tensor,
+    expected_scale_shape: tuple[int, ...],
+    ragged_metadata,
+) -> torch.Tensor:
+    rows, k_scale = expected_scale_shape
+    padded_rows = int(scales.shape[1]) * 32
+    linear = _cdna4_swizzled_scales_to_linear(scales, (padded_rows, k_scale))
+    block_offs = ragged_metadata.block_offs(32).to(torch.int64).cpu().tolist()
+    slice_sizes = ragged_metadata.slice_sizes.to(torch.int64).cpu().tolist()
+    chunks = []
+    for expert, size in enumerate(slice_sizes):
+        if size == 0:
+            continue
+        start = int(block_offs[expert]) * 32
+        chunks.append(linear[start : start + int(size)])
+    if not chunks:
+        return linear[:0]
+    compact = torch.cat(chunks, dim=0)
+    assert compact.shape == (rows, k_scale)
+    return compact
+
+
+def _mxfp4_dequant(
+    packed: torch.Tensor,
+    scales: torch.Tensor,
+    ragged_metadata=None,
+) -> torch.Tensor:
+    expected_scale_shape = (*packed.shape[:-1], packed.shape[-1] * 2 // MXFP4_BLOCK)
+    if ragged_metadata is not None:
+        scales = _compact_ragged_scales(scales, expected_scale_shape, ragged_metadata)
+    elif scales.shape != expected_scale_shape:
+        scales = _cdna4_swizzled_scales_to_linear(scales, expected_scale_shape)
     positive = torch.tensor(
         E2M1_POSITIVE_VALUES, device=packed.device, dtype=torch.float32
     )
@@ -581,6 +593,32 @@ def _mxfp4_dequant(packed: torch.Tensor, scales: torch.Tensor) -> torch.Tensor:
     return (scaled * block_scales.unsqueeze(-1)).reshape_as(values)
 
 
+def _cdna4_swizzled_scales_to_linear(
+    scales: torch.Tensor,
+    linear_shape: tuple[int, ...],
+) -> torch.Tensor:
+    if len(linear_shape) != 2:
+        raise ValueError(
+            "test CDNA4 scale unswizzle only supports rank-2 scales, "
+            f"got {linear_shape}"
+        )
+    rows, k_scale = linear_shape
+    m = torch.arange(rows, device=scales.device)
+    k = torch.arange(k_scale, device=scales.device)
+    mm = m[:, None]
+    kk = k[None, :]
+    m_in_block = mm % 32
+    m_hi = m_in_block // 16
+    m_lo = m_in_block % 16
+    k_block = kk // 8
+    k_in_block = kk % 8
+    k_hi = k_in_block // 4
+    k_lo = k_in_block % 4
+    swizzled_k = (((k_block * 4 + k_lo) * 16 + m_lo) * 2 + k_hi) * 2 + m_hi
+    m_block = mm // 32
+    return scales[swizzled_k, m_block].contiguous()
+
+
 def _fp8_dequant(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
     return x.to(torch.float32) * scale.to(torch.float32).reshape(())
 
@@ -591,6 +629,23 @@ def _swiglu_reference(gate_up: torch.Tensor) -> torch.Tensor:
     linear = torch.clamp(linear, -SWIGLU_LIMIT, SWIGLU_LIMIT)
     sigmoid = 1.0 / (1.0 + torch.exp(-SWIGLU_ALPHA * gate))
     return (gate * sigmoid) * (linear + 1.0)
+
+
+def _silu_gate_up_reference(gate_up: torch.Tensor) -> torch.Tensor:
+    gate, up = gate_up.float().chunk(2, dim=-1)
+    sigmoid = 1.0 / (1.0 + torch.exp(-gate))
+    return (gate * sigmoid) * up
+
+
+def test_interleave_gate_up_rows_matches_even_odd_layout_gfx950() -> None:
+    gate = torch.tensor([[1, 2, 3]], device="cuda")
+    up = torch.tensor([[10, 20, 30]], device="cuda")
+    concat = torch.cat((gate, up), dim=-1)
+
+    actual = _interleave_gate_up_rows(concat, dim=-1)
+
+    expected = torch.tensor([[1, 10, 2, 20, 3, 30]], device="cuda")
+    torch.testing.assert_close(actual, expected)
 
 
 def _expert_ranges(ragged_metadata: Any) -> list[tuple[int, int]]:
@@ -635,10 +690,11 @@ def _compute_torch_gemm1_mxfp4_reference(
     gemm1_scale: torch.Tensor,
     weights: Mxfp4Weights,
     ragged_metadata: Any,
-    gather_indx: torch.Tensor,
+    gather_indx: torch.Tensor | None,
 ) -> torch.Tensor:
+    n_rows = gather_indx.numel() if gather_indx is not None else gemm1_input.shape[0]
     output = torch.empty(
-        (gather_indx.numel(), INTERMEDIATE_SIZE),
+        (n_rows, INTERMEDIATE_SIZE),
         device=gemm1_input.device,
         dtype=torch.bfloat16,
     )
@@ -646,9 +702,13 @@ def _compute_torch_gemm1_mxfp4_reference(
     for expert, (start, end) in enumerate(_expert_ranges(ragged_metadata)):
         if start == end:
             continue
-        row_idx = gather_indx[start:end].long()
         w13 = _mxfp4_dequant(raw.w13_weight[expert], raw.w13_scale[expert])
-        gate_up = x[row_idx] @ w13.T
+        x_rows = (
+            x[gather_indx[start:end].long()]
+            if gather_indx is not None
+            else x[start:end]
+        )
+        gate_up = x_rows @ w13.T
         if weights.w13_bias is not None:
             gate_up = gate_up + weights.w13_bias[expert][None, :]
         output[start:end] = _swiglu_reference(gate_up).to(torch.bfloat16)
@@ -680,6 +740,331 @@ def _compute_torch_gemm2_reference(
         expert_out = expert_out * gate_scal[start:end].to(torch.float32)[:, None]
         routed[scatter_indx[start:end].long()] = expert_out.to(torch.bfloat16)
     return routed.view(num_tokens, TOPK, HIDDEN_SIZE).sum(dim=1)
+
+
+def test_gluon_dynamic_mxfp4_moe_small_matches_torch_gfx950() -> None:
+    import tokenspeed_kernel
+    from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import (
+        _quantize_mxfp4_activation,
+    )
+
+    torch.manual_seed(20260630)
+    device = "cuda"
+    m, e, h, i, topk = 4, 8, 512, 512, 2
+    n_group, topk_group = 2, 1
+    hidden = (
+        torch.randn((m, h), device=device, dtype=torch.bfloat16) * 0.1
+    ).contiguous()
+    logits = torch.randn((m, e), device=device, dtype=torch.bfloat16)
+    correction_bias = torch.zeros((e,), device=device, dtype=torch.float32)
+
+    def quant_weight(
+        shape: tuple[int, ...],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        fp = (
+            torch.randn(shape, device=device, dtype=torch.bfloat16) * 0.02
+        ).contiguous()
+        quant, scale = tokenspeed_kernel.quantize_mxfp4(
+            fp,
+            scale_size=MXFP4_BLOCK,
+            scale_layout="linear",
+            solution="triton",
+            enable_pdl=False,
+        )
+        return (
+            quant,
+            scale,
+            gluon_moe._swizzle_scales_cdna4(scale),
+            _make_k_packed_mxfp4_weight(quant),
+        )
+
+    w13_quant, w13_scale, w13_scale_swizzled, w13_weight = quant_weight((e, 2 * i, h))
+    w2_quant, w2_scale, w2_scale_swizzled, w2_weight = quant_weight((e, h, i))
+
+    out = gluon_mxfp_dynamic_mxfp4_fused_moe(
+        hidden,
+        logits,
+        w13_weight,
+        w2_weight,
+        w13_mx_scale=w13_scale_swizzled,
+        w2_mx_scale=w2_scale_swizzled,
+        top_k=topk,
+        correction_bias=correction_bias,
+        n_group=n_group,
+        topk_group=topk_group,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=True,
+    )
+
+    ragged, gather_indx, scatter_indx, gate_scal = gluon_biased_grouped_fused_route(
+        logits,
+        correction_bias,
+        topk,
+        n_group=n_group,
+        topk_group=topk_group,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=True,
+        dtype=logits.dtype,
+    )
+
+    hidden_quant, hidden_scale = _quantize_mxfp4_activation(
+        hidden,
+        gather_indx,
+        ragged_metadata=ragged,
+    )
+    hidden_dequant = _mxfp4_dequant(hidden_quant, hidden_scale, ragged)
+    intermediate = torch.empty((m * topk, i), device=device, dtype=torch.bfloat16)
+    offset = 0
+    for expert, size in enumerate(ragged.slice_sizes.to(torch.int64).cpu().tolist()):
+        start, end = offset, offset + int(size)
+        offset = end
+        if start == end:
+            continue
+        w13 = _mxfp4_dequant(w13_quant[expert], w13_scale[expert])
+        intermediate[start:end] = _swiglu_reference(
+            hidden_dequant[start:end] @ w13.T
+        ).to(torch.bfloat16)
+
+    inter_quant, inter_scale = _quantize_mxfp4_activation(
+        intermediate,
+        ragged_metadata=ragged,
+    )
+    inter_dequant = _mxfp4_dequant(inter_quant, inter_scale, ragged)
+    routed = torch.empty((m * topk, h), device=device, dtype=torch.bfloat16)
+    offset = 0
+    for expert, size in enumerate(ragged.slice_sizes.to(torch.int64).cpu().tolist()):
+        start, end = offset, offset + int(size)
+        offset = end
+        if start == end:
+            continue
+        w2 = _mxfp4_dequant(w2_quant[expert], w2_scale[expert])
+        expert_out = inter_dequant[start:end] @ w2.T
+        expert_out = expert_out * gate_scal[start:end].to(torch.float32)[:, None]
+        routed[scatter_indx[start:end].long()] = expert_out.to(torch.bfloat16)
+    ref = routed.view(m, topk, h).sum(dim=1)
+
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        out.to(torch.float32),
+        ref.to(torch.float32),
+        atol=3e-3,
+        rtol=3e-2,
+    )
+
+
+def test_gluon_dynamic_mxfp4_moe_rejects_incomplete_grouped_bias_config_gfx950() -> (
+    None
+):
+    device = "cuda"
+    hidden = torch.empty((1, 32), device=device, dtype=torch.bfloat16)
+    logits = torch.empty((1, 8), device=device, dtype=torch.bfloat16)
+    correction_bias = torch.zeros((8,), device=device, dtype=torch.float32)
+    dummy = torch.empty((1,), device=device, dtype=torch.uint8)
+
+    with pytest.raises(ValueError, match="correction_bias requires grouped routing"):
+        gluon_mxfp_dynamic_mxfp4_fused_moe(
+            hidden,
+            logits,
+            dummy,
+            dummy,
+            w13_mx_scale=dummy,
+            w2_mx_scale=dummy,
+            top_k=2,
+            correction_bias=correction_bias,
+            n_group=0,
+            topk_group=1,
+            routed_scaling_factor=1.0,
+            normalize_topk_weights=True,
+        )
+
+
+def test_gluon_dynamic_mxfp4_moe_concatenated_silu_matches_torch_gfx950() -> None:
+    import tokenspeed_kernel
+    from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import (
+        _quantize_mxfp4_activation,
+    )
+
+    torch.manual_seed(20260630)
+    device = "cuda"
+    m, e, h, i, topk = 4, 8, 512, 512, 2
+    n_group, topk_group = 2, 1
+    hidden = (
+        torch.randn((m, h), device=device, dtype=torch.bfloat16) * 0.1
+    ).contiguous()
+    logits = torch.randn((m, e), device=device, dtype=torch.bfloat16)
+    correction_bias = torch.zeros((e,), device=device, dtype=torch.float32)
+
+    def quant_weight(
+        shape: tuple[int, ...],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        fp = (
+            torch.randn(shape, device=device, dtype=torch.bfloat16) * 0.02
+        ).contiguous()
+        return tokenspeed_kernel.quantize_mxfp4(
+            fp,
+            scale_size=MXFP4_BLOCK,
+            scale_layout="linear",
+            solution="triton",
+            enable_pdl=False,
+        )
+
+    w13_quant, w13_scale = quant_weight((e, 2 * i, h))
+    w2_quant, w2_scale = quant_weight((e, h, i))
+
+    layer = torch.nn.Module()
+    layer.quant_config = type("QuantConfig", (), {})()
+    layer.quant_config.use_dynamic_mxfp4_activations = True
+    layer.w13_input_layout = "concatenated"
+    layer.w13_weight = torch.nn.Parameter(w13_quant.clone(), requires_grad=False)
+    layer.w13_weight_scale = torch.nn.Parameter(w13_scale.clone(), requires_grad=False)
+    layer.w2_weight = torch.nn.Parameter(w2_quant.clone(), requires_grad=False)
+    layer.w2_weight_scale = torch.nn.Parameter(w2_scale.clone(), requires_grad=False)
+    layer.w13_weight_bias = torch.nn.Parameter(
+        torch.zeros(e, 2 * i, device=device), requires_grad=False
+    )
+    layer.w2_weight_bias = torch.nn.Parameter(
+        torch.zeros(e, h, device=device), requires_grad=False
+    )
+    preprocess_gluon_mxfp4_gfx950_moe_weights(
+        {"internal_activation_dtype": "input"}, layer, preshuffle=True
+    )
+
+    out = gluon_mxfp_dynamic_mxfp4_fused_moe(
+        hidden,
+        logits,
+        layer.w13_weight_triton_tensor,
+        layer.w2_weight_triton_tensor,
+        w13_mx_scale=layer.w13_precision_config.b_mx_scale,
+        w2_mx_scale=layer.w2_precision_config.b_mx_scale,
+        top_k=topk,
+        correction_bias=correction_bias,
+        n_group=n_group,
+        topk_group=topk_group,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=True,
+        w13_bias=layer.w13_weight_bias,
+        w2_bias=layer.w2_weight_bias,
+        swiglu_alpha=1.0,
+        swiglu_limit=0.0,
+        swiglu_beta=0.0,
+    )
+
+    ragged, gather_indx, scatter_indx, gate_scal = gluon_biased_grouped_fused_route(
+        logits,
+        correction_bias,
+        topk,
+        n_group=n_group,
+        topk_group=topk_group,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=True,
+        dtype=logits.dtype,
+    )
+
+    hidden_quant, hidden_scale = _quantize_mxfp4_activation(
+        hidden,
+        gather_indx,
+        ragged_metadata=ragged,
+    )
+    hidden_dequant = _mxfp4_dequant(hidden_quant, hidden_scale, ragged)
+    intermediate = torch.empty((m * topk, i), device=device, dtype=torch.bfloat16)
+    offset = 0
+    for expert, size in enumerate(ragged.slice_sizes.to(torch.int64).cpu().tolist()):
+        start, end = offset, offset + int(size)
+        offset = end
+        if start == end:
+            continue
+        w13 = _mxfp4_dequant(w13_quant[expert], w13_scale[expert])
+        intermediate[start:end] = _silu_gate_up_reference(
+            hidden_dequant[start:end] @ w13.T
+        ).to(torch.bfloat16)
+
+    inter_quant, inter_scale = _quantize_mxfp4_activation(
+        intermediate,
+        ragged_metadata=ragged,
+    )
+    inter_dequant = _mxfp4_dequant(inter_quant, inter_scale, ragged)
+    routed = torch.empty((m * topk, h), device=device, dtype=torch.bfloat16)
+    offset = 0
+    for expert, size in enumerate(ragged.slice_sizes.to(torch.int64).cpu().tolist()):
+        start, end = offset, offset + int(size)
+        offset = end
+        if start == end:
+            continue
+        w2 = _mxfp4_dequant(w2_quant[expert], w2_scale[expert])
+        expert_out = inter_dequant[start:end] @ w2.T
+        expert_out = expert_out * gate_scal[start:end].to(torch.float32)[:, None]
+        routed[scatter_indx[start:end].long()] = expert_out.to(torch.bfloat16)
+    ref = routed.view(m, topk, h).sum(dim=1)
+
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        out.to(torch.float32),
+        ref.to(torch.float32),
+        atol=3e-3,
+        rtol=3e-2,
+    )
+
+
+def test_gluon_mxfp4_dispatch_handles_large_expert_offsets_gfx950() -> None:
+    from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import (
+        _quantize_mxfp4_activation,
+    )
+
+    torch.manual_seed(20260630)
+    device = "cuda"
+    m, e, h, i, topk = 1, 65, 8192, 4096, 1
+    selected_expert = e - 1
+
+    hidden = (
+        torch.randn((m, h), device=device, dtype=torch.bfloat16) * 0.03
+    ).contiguous()
+    logits = torch.full((m, e), -1000.0, device=device, dtype=torch.bfloat16)
+    logits[:, selected_expert] = 1000.0
+    ragged, gather_indx, _scatter_indx, _gate_scal = default_route(
+        logits,
+        topk,
+        dtype=logits.dtype,
+    )
+
+    w13_quant = torch.empty((e, 2 * i, h // 2), device=device, dtype=torch.uint8)
+    w13_scale = torch.empty(
+        (e, 2 * i, h // MXFP4_BLOCK),
+        device=device,
+        dtype=torch.uint8,
+    )
+    w13_scale.fill_(120)
+    w13_quant[selected_expert].random_(0, 256)
+    w13_weight = torch.empty((e, h // 2, 2 * i), device=device, dtype=torch.uint8)
+    w13_weight[selected_expert].copy_(w13_quant[selected_expert].transpose(-2, -1))
+    w13_scale_swizzled = gluon_moe._swizzle_scales_cdna4(w13_scale)
+
+    hidden_quant, hidden_scale = _quantize_mxfp4_activation(hidden, gather_indx)
+    out = gluon_mxfp_ragged_matmul(
+        hidden_quant,
+        w13_weight,
+        None,
+        w_mx_scale=w13_scale_swizzled,
+        x_mx_scale=hidden_scale,
+        x_format="e2m1",
+        out_dtype=torch.bfloat16,
+        a_ragged_metadata=ragged,
+        fused_activation=_swiglu_activation(),
+    )
+
+    hidden_dequant = _mxfp4_dequant(hidden_quant, hidden_scale)
+    w13_dequant = _mxfp4_dequant(
+        w13_quant[selected_expert],
+        w13_scale[selected_expert],
+    )
+    ref = _swiglu_reference(hidden_dequant @ w13_dequant.T).to(torch.bfloat16)
+
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        out.to(torch.float32),
+        ref.to(torch.float32),
+        atol=3e-3,
+        rtol=3e-2,
+    )
 
 
 def _compute_torch_reference(
@@ -831,7 +1216,7 @@ def test_gluon_moe_gemms_with_preshuffle_match_torch_gfx950(
 @requires_gfx950
 @pytest.mark.parametrize("num_tokens", KEY_NUM_TOKENS)
 @pytest.mark.parametrize("variant", ("nonpreshuffled", "preshuffled"))
-def test_gluon_moe_gemm1_dynamic_mxfp4_gather_scales_match_torch_gfx950(
+def test_gluon_moe_gemm1_dynamic_mxfp4_pregathered_scales_match_torch_gfx950(
     num_tokens: int,
     mxfp4_weights: Mxfp4WeightVariants,
     variant: str,
@@ -843,7 +1228,10 @@ def test_gluon_moe_gemm1_dynamic_mxfp4_gather_scales_match_torch_gfx950(
         TOPK,
         dtype=router_logits.dtype,
     )
-    gemm1_input, gemm1_scale = _quantize_mxfp4_for_test(hidden_states)
+    gemm1_input, gemm1_scale = gluon_moe._quantize_mxfp4_activation(
+        hidden_states,
+        gather_indx,
+    )
 
     with torch.no_grad():
         actual = gluon_moe.gluon_mxfp_ragged_matmul(
@@ -855,7 +1243,6 @@ def test_gluon_moe_gemm1_dynamic_mxfp4_gather_scales_match_torch_gfx950(
             x_format="e2m1",
             out_dtype=weights.w13_precision_config.out_dtype,
             a_ragged_metadata=ragged_metadata,
-            gather_indx=gather_indx,
             fused_activation=_swiglu_activation(),
         )
         expected = _compute_torch_gemm1_mxfp4_reference(
@@ -864,7 +1251,7 @@ def test_gluon_moe_gemm1_dynamic_mxfp4_gather_scales_match_torch_gfx950(
             gemm1_scale,
             weights,
             ragged_metadata,
-            gather_indx,
+            None,
         )
 
     torch.testing.assert_close(

--- a/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
@@ -442,6 +442,62 @@ def _make_preprocessed_weights(
     )
 
 
+def test_preprocess_releases_raw_mxfp4_parameters() -> None:
+    device = "cuda"
+    e, h, i = 2, 64, 64
+    layer = torch.nn.Module()
+    layer.w13_input_layout = "concatenated"
+    layer.w13_weight = torch.nn.Parameter(
+        torch.zeros(e, 2 * i, h // 2, dtype=torch.uint8, device=device),
+        requires_grad=False,
+    )
+    layer.w13_weight_scale = torch.nn.Parameter(
+        torch.full(
+            (e, 2 * i, h // MXFP4_BLOCK),
+            124,
+            dtype=torch.uint8,
+            device=device,
+        ),
+        requires_grad=False,
+    )
+    layer.w2_weight = torch.nn.Parameter(
+        torch.zeros(e, h, i // 2, dtype=torch.uint8, device=device),
+        requires_grad=False,
+    )
+    layer.w2_weight_scale = torch.nn.Parameter(
+        torch.full(
+            (e, h, i // MXFP4_BLOCK),
+            124,
+            dtype=torch.uint8,
+            device=device,
+        ),
+        requires_grad=False,
+    )
+    layer.w13_weight_bias = torch.nn.Parameter(
+        torch.zeros(e, 2 * i, device=device), requires_grad=False
+    )
+    layer.w2_weight_bias = torch.nn.Parameter(
+        torch.zeros(e, h, device=device), requires_grad=False
+    )
+    layer.w13_input_scale = torch.nn.Parameter(
+        torch.ones(e, device=device), requires_grad=False
+    )
+    layer.w2_input_scale = torch.nn.Parameter(
+        torch.ones(e, device=device), requires_grad=False
+    )
+
+    preprocess_gluon_mxfp4_gfx950_moe_weights({}, layer, preshuffle=False)
+
+    assert not hasattr(layer, "w13_weight")
+    assert not hasattr(layer, "w13_weight_scale")
+    assert not hasattr(layer, "w2_weight")
+    assert not hasattr(layer, "w2_weight_scale")
+    assert hasattr(layer, "w13_weight_triton_tensor")
+    assert hasattr(layer, "w2_weight_triton_tensor")
+    assert layer.w13_precision_config.b_mx_scale is not None
+    assert layer.w2_precision_config.b_mx_scale is not None
+
+
 @pytest.fixture(scope="module")
 def mxfp4_weights() -> Mxfp4WeightVariants:
     raw_weights = _make_raw_mxfp4_weights()

--- a/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
@@ -1126,6 +1126,39 @@ def test_renormalize_route_recovers_packed_topk_without_scaling_gfx950(
     torch.testing.assert_close(actual_weights, expected_weights)
 
 
+def test_dynamic_route_without_topk_normalization_uses_full_softmax_gfx950() -> None:
+    device = "cuda"
+    router_logits = torch.tensor(
+        [[4.0, 3.0, 0.0, -2.0], [1.0, -1.0, 2.5, 0.5]],
+        device=device,
+        dtype=torch.float32,
+    )
+
+    ragged, _, scatter, gate = _dynamic_mxfp4_route(
+        router_logits,
+        top_k=2,
+        correction_bias=None,
+        n_group=0,
+        topk_group=0,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=False,
+        routing_method_type=0,
+        dtype=router_logits.dtype,
+    )
+    actual_weights, actual_ids = _recover_topk_from_route(
+        ragged, scatter, gate, router_logits.shape[0], 2
+    )
+    expected_weights, expected_ids = torch.softmax(router_logits, dim=-1).topk(
+        2, dim=-1, sorted=True
+    )
+
+    torch.testing.assert_close(actual_ids, expected_ids.to(torch.int32))
+    torch.testing.assert_close(actual_weights, expected_weights)
+    assert not torch.allclose(
+        actual_weights.sum(dim=-1), torch.ones_like(actual_weights.sum(dim=-1))
+    )
+
+
 def test_gluon_dynamic_mxfp4_moe_concatenated_silu_matches_torch_gfx950() -> None:
     from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import (
         _quantize_mxfp4_activation,

--- a/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
@@ -338,6 +338,31 @@ def _make_e8m0_scales(
     ]
 
 
+def _make_random_mxfp4_quantized_tensor(
+    logical_shape: tuple[int, ...],
+    *,
+    device: str,
+    generator: torch.Generator,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if logical_shape[-1] % MXFP4_BLOCK != 0:
+        raise ValueError(
+            f"MXFP4 test tensor K must be divisible by {MXFP4_BLOCK}, "
+            f"got {logical_shape[-1]}"
+        )
+    return (
+        _make_mxfp4_weight_bytes(
+            (*logical_shape[:-1], logical_shape[-1] // 2),
+            device=device,
+            generator=generator,
+        ),
+        _make_e8m0_scales(
+            (*logical_shape[:-1], logical_shape[-1] // MXFP4_BLOCK),
+            device=device,
+            generator=generator,
+        ),
+    )
+
+
 def _make_raw_mxfp4_weights() -> RawMxfp4Weights:
     device = "cuda"
     generator = torch.Generator(device=device).manual_seed(20260610)
@@ -771,13 +796,13 @@ def _recover_topk_from_route(
 
 
 def test_gluon_dynamic_mxfp4_moe_small_matches_torch_gfx950() -> None:
-    import tokenspeed_kernel
     from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import (
         _quantize_mxfp4_activation,
     )
 
     torch.manual_seed(20260630)
     device = "cuda"
+    generator = torch.Generator(device=device).manual_seed(20260630)
     m, e, h, i, topk = 4, 8, 512, 512, 2
     n_group, topk_group = 2, 1
     hidden = (
@@ -789,15 +814,10 @@ def test_gluon_dynamic_mxfp4_moe_small_matches_torch_gfx950() -> None:
     def quant_weight(
         shape: tuple[int, ...],
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        fp = (
-            torch.randn(shape, device=device, dtype=torch.bfloat16) * 0.02
-        ).contiguous()
-        quant, scale = tokenspeed_kernel.quantize_mxfp4(
-            fp,
-            scale_size=MXFP4_BLOCK,
-            scale_layout="linear",
-            solution="triton",
-            enable_pdl=False,
+        quant, scale = _make_random_mxfp4_quantized_tensor(
+            shape,
+            device=device,
+            generator=generator,
         )
         return (
             quant,
@@ -1028,13 +1048,13 @@ def test_renormalize_route_recovers_packed_topk_without_scaling_gfx950() -> None
 
 
 def test_gluon_dynamic_mxfp4_moe_concatenated_silu_matches_torch_gfx950() -> None:
-    import tokenspeed_kernel
     from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import (
         _quantize_mxfp4_activation,
     )
 
     torch.manual_seed(20260630)
     device = "cuda"
+    generator = torch.Generator(device=device).manual_seed(20260631)
     m, e, h, i, topk = 4, 8, 512, 512, 2
     n_group, topk_group = 2, 1
     hidden = (
@@ -1046,15 +1066,10 @@ def test_gluon_dynamic_mxfp4_moe_concatenated_silu_matches_torch_gfx950() -> Non
     def quant_weight(
         shape: tuple[int, ...],
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        fp = (
-            torch.randn(shape, device=device, dtype=torch.bfloat16) * 0.02
-        ).contiguous()
-        return tokenspeed_kernel.quantize_mxfp4(
-            fp,
-            scale_size=MXFP4_BLOCK,
-            scale_layout="linear",
-            solution="triton",
-            enable_pdl=False,
+        return _make_random_mxfp4_quantized_tensor(
+            shape,
+            device=device,
+            generator=generator,
         )
 
     w13_quant, w13_scale = quant_weight((e, 2 * i, h))

--- a/tokenspeed-kernel-amd/test/ops/test_moe_gluon_warp_decode_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_moe_gluon_warp_decode_gfx950.py
@@ -97,6 +97,7 @@ def _build_case(
     scale2 = torch.ones((1,), device=device, dtype=torch.float32)
 
     layer = torch.nn.Module()
+    layer.w13_input_layout = "interleaved"
     layer.w13_weight = torch.nn.Parameter(w13, requires_grad=False)
     layer.w13_weight_scale = torch.nn.Parameter(s13, requires_grad=False)
     layer.w2_weight = torch.nn.Parameter(w2, requires_grad=False)

--- a/tokenspeed-kernel-amd/test/ops/test_mxfp4_gfx950_preprocess.py
+++ b/tokenspeed-kernel-amd/test/ops/test_mxfp4_gfx950_preprocess.py
@@ -88,21 +88,23 @@ def test_preprocess_gluon_mxfp4_gfx950_mutates_module_state(monkeypatch):
     w2_storage = module.w2_weight_triton_tensor
     assert w13_storage.dtype == torch.uint8
     assert w2_storage.dtype == torch.uint8
-    assert module.w13_weight_triton_tensor.shape == (2, 32, 256)
-    assert module.w2_weight_triton_tensor.shape == (2, 64, 128)
-    assert module.w13_weight_triton_tensor.stride(-2) == 1
-    assert module.w2_weight_triton_tensor.stride(-2) == 1
+    assert module.w13_weight_triton_tensor.shape == (2, 128, 256)
+    assert module.w2_weight_triton_tensor.shape == (2, 128, 128)
     assert module._w2_logical_n == 64
     assert module.w2_weight_bias.shape == (2, 64)
 
-    assert hasattr(w13_storage, "_gluon_shuffled")
-    assert hasattr(w2_storage, "_gluon_shuffled")
-    assert hasattr(module.w13_weight_triton_tensor, "_gluon_shuffled")
-    assert hasattr(module.w2_weight_triton_tensor, "_gluon_shuffled")
+    assert w13_storage.is_shuffled_for_gluon_dot is True
+    assert w2_storage.is_shuffled_for_gluon_dot is True
+    assert w13_storage.original_k_pk == 32
+    assert w2_storage.original_k_pk == 64
+    assert w13_storage.gluon_dot_block_k_pk == 128
+    assert w2_storage.gluon_dot_block_k_pk == 128
+    assert w13_storage.gluon_dot_block_n == 128
+    assert w2_storage.gluon_dot_block_n == 128
+    assert not hasattr(w13_storage, "_gluon_shuffled")
+    assert not hasattr(w2_storage, "_gluon_shuffled")
     assert w2_storage.original_n == 64
     assert module.w2_weight_triton_tensor.original_n == 64
-    assert w2_storage._gluon_shuffled.original_n == 64
-    assert module.w2_weight_triton_tensor._gluon_shuffled.original_n == 64
 
     w13_config = module.w13_precision_config
     w2_config = module.w2_precision_config

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
@@ -33,13 +33,98 @@ platform = current_platform()
 
 
 if platform.is_amd:
-    from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import gluon_mxfp_fused_moe
+    from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import (
+        gluon_mxfp_dynamic_mxfp4_fused_moe,
+        gluon_mxfp_fused_moe,
+    )
     from tokenspeed_kernel_amd.ops.moe.mxfp4_gfx950_preprocess import (
         preprocess_gluon_mxfp4_gfx950_moe_weights,
     )
 
     def gluon_mxfp4_gfx950_moe_weights(plan: dict, w: torch.nn.Module):
         return preprocess_gluon_mxfp4_gfx950_moe_weights(plan, w, preshuffle=True)
+
+    def _swiglu_args(w: torch.nn.Module) -> tuple[float, float, float]:
+        swiglu_arg = getattr(w, "swiglu_arg", None)
+        if swiglu_arg is None:
+            return 1.0, 0.0, 0.0
+        swiglu_beta = getattr(w, "swiglu_beta", None)
+        return (
+            swiglu_arg.alpha,
+            swiglu_arg.limit,
+            1.0 if swiglu_beta is None else swiglu_beta,
+        )
+
+    @register_kernel(
+        "moe",
+        "apply",
+        name="gluon_mxfp4_dynamic_moe_apply",
+        solution="gluon",
+        weight_preprocessor=gluon_mxfp4_gfx950_moe_weights,
+        capability=CapabilityRequirement(
+            vendors=frozenset({"amd"}),
+            min_arch_version=ArchVersion(9, 5),
+            max_arch_version=ArchVersion(9, 5),
+        ),
+        signatures=format_signatures(
+            "x",
+            "dense",
+            {torch.float16, torch.bfloat16},
+        ),
+        traits={
+            "weight_dtype": frozenset({"mxfp4"}),
+            "activation": frozenset({"silu", "swiglu"}),
+            "routing_mode": frozenset({"kernel_routing"}),
+            "supports_deferred_finalize": frozenset({False}),
+            "supports_ep": frozenset({False}),
+            "supports_all_to_all_ep": frozenset({False}),
+            "ispp_alignment": frozenset({1}),
+            "internal_activation_dtype": frozenset({"input"}),
+            "supports_bias": frozenset({True}),
+        },
+        priority=Priority.SPECIALIZED + 3,
+    )
+    def gluon_mxfp4_dynamic_moe_apply(
+        plan: dict,
+        x: torch.Tensor,
+        w: torch.nn.Module,
+        router_logits: torch.Tensor,
+        topk_weights: torch.Tensor | None = None,
+        topk_ids: torch.Tensor | None = None,
+        num_tokens_global: int | None = None,
+        max_num_tokens_per_gpu: int | None = None,
+        do_finalize: bool = True,
+        enable_pdl: bool = False,
+    ):
+        del topk_weights, topk_ids, num_tokens_global, max_num_tokens_per_gpu
+        del do_finalize, enable_pdl
+        top_k = getattr(w, "top_k")
+        swiglu_alpha, swiglu_limit, swiglu_beta = _swiglu_args(w)
+        w13_precision_config = w.w13_precision_config
+        w2_precision_config = w.w2_precision_config
+
+        return gluon_mxfp_dynamic_mxfp4_fused_moe(
+            x,
+            router_logits,
+            w.w13_weight_triton_tensor,
+            w.w2_weight_triton_tensor,
+            w13_bias=getattr(w, "w13_weight_bias", None),
+            w2_bias=getattr(w, "w2_weight_bias", None),
+            w13_mx_scale=w13_precision_config.b_mx_scale,
+            w2_mx_scale=w2_precision_config.b_mx_scale,
+            out_dtype=w2_precision_config.out_dtype or torch.bfloat16,
+            top_k=top_k,
+            correction_bias=getattr(w, "_correction_bias", None),
+            n_group=int(getattr(w, "_n_group", 0) or 0),
+            topk_group=int(getattr(w, "_topk_group", 0) or 0),
+            routed_scaling_factor=float(
+                getattr(w, "_routed_scaling_factor", 1.0) or 1.0
+            ),
+            normalize_topk_weights=bool(getattr(w, "_normalize_topk_weights", True)),
+            swiglu_alpha=swiglu_alpha,
+            swiglu_limit=swiglu_limit,
+            swiglu_beta=swiglu_beta,
+        )
 
     @register_kernel(
         "moe",
@@ -83,13 +168,10 @@ if platform.is_amd:
         do_finalize: bool = True,
         enable_pdl: bool = False,
     ):
-        swiglu_arg = getattr(w, "swiglu_arg", None)
-
-        router_logits = router_logits
+        del topk_weights, topk_ids, num_tokens_global, max_num_tokens_per_gpu
+        del do_finalize, enable_pdl
         top_k = getattr(w, "top_k")
-
-        swiglu_alpha = swiglu_arg.alpha if swiglu_arg else 1.702
-        swiglu_limit = swiglu_arg.limit if swiglu_arg else 7.0
+        swiglu_alpha, swiglu_limit, swiglu_beta = _swiglu_args(w)
         w13_precision_config = w.w13_precision_config
         w2_precision_config = w.w2_precision_config
 
@@ -108,4 +190,5 @@ if platform.is_amd:
             top_k=top_k,
             swiglu_alpha=swiglu_alpha,
             swiglu_limit=swiglu_limit,
+            swiglu_beta=swiglu_beta,
         )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
@@ -47,6 +47,8 @@ if platform.is_amd:
     def _swiglu_args(w: torch.nn.Module) -> tuple[float, float, float]:
         swiglu_arg = getattr(w, "swiglu_arg", None)
         if swiglu_arg is None:
+            # alpha=1, limit=0, beta=0 makes the reducer use an unclamped
+            # SiLU gate multiplied by the linear branch.
             return 1.0, 0.0, 0.0
         swiglu_beta = getattr(w, "swiglu_beta", None)
         return (

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
@@ -50,9 +50,9 @@ if platform.is_amd:
             return 1.0, 0.0, 0.0
         swiglu_beta = getattr(w, "swiglu_beta", None)
         return (
-            swiglu_arg.alpha,
-            swiglu_arg.limit,
-            1.0 if swiglu_beta is None else swiglu_beta,
+            1.0 if swiglu_arg.alpha is None else swiglu_arg.alpha,
+            0.0 if swiglu_arg.limit is None else swiglu_arg.limit,
+            0.0 if swiglu_beta is None else swiglu_beta,
         )
 
     @register_kernel(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
@@ -121,6 +121,7 @@ if platform.is_amd:
                 getattr(w, "_routed_scaling_factor", 1.0) or 1.0
             ),
             normalize_topk_weights=bool(getattr(w, "_normalize_topk_weights", True)),
+            routing_method_type=int(getattr(w, "_routing_method_type", 0)),
             swiglu_alpha=swiglu_alpha,
             swiglu_limit=swiglu_limit,
             swiglu_beta=swiglu_beta,

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -835,7 +835,7 @@ def _moe_apply_mxint4_trtllm() -> object:
     return tokenspeed_kernel.moe_apply(plan, x, torch.nn.Module(), router_logits)
 
 
-def _moe_apply_mxfp4_precomputed_tp() -> object:
+def _moe_apply_mxfp4_dynamic_tp() -> object:
     plan = tokenspeed_kernel.moe_plan(
         "mxfp4",
         input_dtype=torch.bfloat16,
@@ -895,17 +895,18 @@ def _moe_apply_fp8_precomputed_ep() -> object:
         fp8_scale_block_shape=(128, 128),
         solution="triton",
     )
+    _assert_moe_plan(
+        plan,
+        apply="gluon_mxfp4_dynamic_moe_apply",
+        preprocessor="gluon_mxfp4_gfx950_moe_weights",
+    )
     x = torch.empty((4, 16), dtype=torch.bfloat16)
     router_logits = torch.empty((4, 8), dtype=torch.float32)
-    topk_weights = torch.empty((4, 2), dtype=torch.float32)
-    topk_ids = torch.empty((4, 2), dtype=torch.int64)
     return tokenspeed_kernel.moe_apply(
         plan,
         x,
         torch.nn.Module(),
         router_logits,
-        topk_weights=topk_weights,
-        topk_ids=topk_ids,
     )
 
 
@@ -1294,8 +1295,8 @@ _CASES = [
         "cdna4",
         "moe",
         "apply",
-        "triton_mxfp4_precomputed_moe_apply",
-        _moe_apply_mxfp4_precomputed_tp,
+        "gluon_mxfp4_dynamic_moe_apply",
+        _moe_apply_mxfp4_dynamic_tp,
     ),
     _case(
         _is_cdna4,

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -605,6 +605,21 @@ def _assert_moe_plan(plan: dict, *, apply: str, preprocessor: str | None) -> Non
     assert actual_name == preprocessor
 
 
+def test_gluon_mxfp4_swiglu_args_default_missing_values_to_standard_swiglu() -> None:
+    if not hasattr(_moe_gluon_mxfp4, "_swiglu_args"):
+        pytest.skip("Gluon MXFP4 SwiGLU args are AMD-only")
+
+    w = torch.nn.Module()
+    w.swiglu_arg = type("SwigluArg", (), {"alpha": None, "limit": None})()
+
+    assert _moe_gluon_mxfp4._swiglu_args(w) == (1.0, 0.0, 0.0)
+
+    w.swiglu_arg = type("SwigluArg", (), {"alpha": 1.702, "limit": 7.0})()
+    w.swiglu_beta = 1.0
+
+    assert _moe_gluon_mxfp4._swiglu_args(w) == (1.702, 7.0, 1.0)
+
+
 def _moe_apply_unquant_trtllm() -> object:
     plan = tokenspeed_kernel.moe_plan(
         "unquant",
@@ -842,24 +857,20 @@ def _moe_apply_mxfp4_dynamic_tp() -> object:
         activation="silu",
         ep_size=1,
         ispp=2048,
-        internal_activation_dtype="fp8",
+        internal_activation_dtype="input",
     )
     _assert_moe_plan(
         plan,
-        apply="triton_mxfp4_precomputed_moe_apply",
-        preprocessor="triton_mxfp4_moe_weights",
+        apply="gluon_mxfp4_dynamic_moe_apply",
+        preprocessor="gluon_mxfp4_gfx950_moe_weights",
     )
     x = torch.empty((4, 16), dtype=torch.bfloat16)
     router_logits = torch.empty((4, 8), dtype=torch.float32)
-    topk_weights = torch.empty((4, 2), dtype=torch.float32)
-    topk_ids = torch.empty((4, 2), dtype=torch.int64)
     return tokenspeed_kernel.moe_apply(
         plan,
         x,
         torch.nn.Module(),
         router_logits,
-        topk_weights=topk_weights,
-        topk_ids=topk_ids,
     )
 
 
@@ -897,16 +908,20 @@ def _moe_apply_fp8_precomputed_ep() -> object:
     )
     _assert_moe_plan(
         plan,
-        apply="gluon_mxfp4_dynamic_moe_apply",
-        preprocessor="gluon_mxfp4_gfx950_moe_weights",
+        apply="triton_fp8_ep_precomputed_moe_apply",
+        preprocessor="triton_fp8_moe_weights",
     )
     x = torch.empty((4, 16), dtype=torch.bfloat16)
     router_logits = torch.empty((4, 8), dtype=torch.float32)
+    topk_weights = torch.empty((4, 2), dtype=torch.float32)
+    topk_ids = torch.empty((4, 2), dtype=torch.int64)
     return tokenspeed_kernel.moe_apply(
         plan,
         x,
         torch.nn.Module(),
         router_logits,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
     )
 
 


### PR DESCRIPTION
## Summary

- Add gfx950 Gluon MXFP4 MoE for dynamic MXFP4 activations.
- Add BF16/FP16 -> MXFP4 activation quantization between expert GEMMs with swizzled/padded ragged scales.
- Add fused small-M decode routing/top-k metadata for MXFP4 MoE, falling back when `M * topk > 64`.
- Handle Kimi W13 gate/up layout, SiLU gate/up, and `norm_topk_prob` semantics.

## Testing Plan

This PR adds gfx950 coverage for:

- Fused dynamic MXFP4 MoE decode vs torch reference.
- Kimi concatenated W13 preprocessing + SiLU gate/up correctness.
- Routed/pregathered dynamic MXFP4 activation scales.
- Large expert-offset addressing.
- W13 gate/up interleave conversion.
- Grouped-routing config validation.
- Kernel API selection for `gluon_mxfp4_dynamic_moe_apply`.

## Benchmarks

### Synthetic TP4 MoE apply

AMD Instinct MI355X. Kimi TP4 dynamic MXFP4 MoE: `H=7168`, `I/rank=512`, `E=384`, `topk=8`, `n_group=1`, `topk_group=1`. Warmup/repeat: `100/1000`. Outputs checked with `rtol=3e-2`, `atol=3e-3`.

Fused route is active for `M * topk <= 64`; with Kimi `topk=8`, that means `tokens <= 8`.

| Tokens | Routed rows | Unfused median | Fused median | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 8 | 0.523 ms | 0.235 ms | 2.23x |
| 4 | 32 | 0.519 ms | 0.239 ms | 2.17x |
| 8 | 64 | 0.534 ms | 0.255 ms | 2.09x |

### Kimi TP4 e2e smoke sweep

`amd/Kimi-K2.5-MXFP4`, TP4, EvalScope random, 512 input / 32 output tokens, no warmup.

| Concurrency | Requests | Success | Gen/s | Total tok/s | Avg TTFT | Avg TPOT | Decode tok/s |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 1 | 100% | 13.91 | 236.47 | 1508.8 ms | 25.5 ms | 39.15 |
| 2 | 4 | 100% | 30.40 | 516.83 | 1266.8 ms | 26.8 ms | 37.30 |

Still overall quite slow but improving.