### PR TITLE
fix(deepseek-v4): size CUDA graph sliding-window capture to full window.

### DIFF
--- a/python/tokenspeed/runtime/configs/paged_cache_spec.py
+++ b/python/tokenspeed/runtime/configs/paged_cache_spec.py
@@ -101,6 +101,7 @@ def compute_paged_cache_group_page_counts(
                     f"PagedCacheGroupSpec {spec.group_id}: sliding group missing "
                     "positive sliding_window_tokens"
                 )
+            # Capacity tracks resident history before the next token.
             resident_tokens_per_req = min(max(window - 1, 0), max_context_len)
             resident_pages = max_live_requests * ceil_div(
                 resident_tokens_per_req, raw_per_page
@@ -170,8 +171,10 @@ def compute_max_logical_pages_for_capture(
                 f"PagedCacheGroupSpec {spec.group_id}: sliding group missing "
                 "positive sliding_window_tokens"
             )
-        retained_history = min(window - 1, max_context_len)
-        live_tokens = retained_history + reservation_horizon
+        # Capture uses a conservative metadata bound; it does not change the
+        # per-token attention history counted as window - 1 above.
+        retention_bound = min(window, max_context_len)
+        live_tokens = retention_bound + reservation_horizon
         return ceil_div(live_tokens, raw_per_page) + 1
     if spec.retention == "full_history":
         live_tokens = max_context_len + reservation_horizon

--- a/test/runtime/test_v4_sliding_window_groups_smoke.py
+++ b/test/runtime/test_v4_sliding_window_groups_smoke.py
@@ -159,46 +159,54 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
                         self.assertEqual(
                             sliding_pages,
                             math.ceil(
-                                (window - 1 + (overlap_depth + 1) * verify_width)
+                                (window + (overlap_depth + 1) * verify_width)
                                 / raw_per_page
                             )
                             + 1,
                         )
 
-    def test_sliding_capture_width_covers_absolute_reservation_range(self):
+    def test_sliding_capture_width_covers_conservative_reservation_bound(self):
         for rows_per_page, entry_stride_tokens in _PAGE_SHAPES:
             raw_per_page = rows_per_page * entry_stride_tokens
-            window = 3 * raw_per_page + 1
-            spec = PagedCacheGroupSpec(
-                group_id="sliding",
-                retention="sliding_window",
-                rows_per_page=rows_per_page,
-                entry_stride_tokens=entry_stride_tokens,
-                sliding_window_tokens=window,
-            )
-            for context_len in (2 * raw_per_page + 1, 5 * raw_per_page + 1):
-                for verify_width in (1, 2, 4, 8):
-                    for overlap_depth in (0, 1):
-                        reservation_end = (
-                            context_len + (overlap_depth + 1) * verify_width
-                        )
-                        with self.subTest(
-                            raw_per_page=raw_per_page,
-                            context_len=context_len,
-                            verify_width=verify_width,
-                            overlap_depth=overlap_depth,
-                        ):
-                            capture_pages = compute_max_logical_pages_for_capture(
-                                spec,
-                                max_context_len=context_len,
-                                max_tokens_per_req=verify_width,
-                                overlap_schedule_depth=overlap_depth,
+            # Cover a window that is a multiple of raw_per_page and one that is
+            # not, exercising both page-alignment relationships between the
+            # window and the physical page stride.
+            for window in (3 * raw_per_page, 3 * raw_per_page + 1):
+                spec = PagedCacheGroupSpec(
+                    group_id="sliding",
+                    retention="sliding_window",
+                    rows_per_page=rows_per_page,
+                    entry_stride_tokens=entry_stride_tokens,
+                    sliding_window_tokens=window,
+                )
+                for context_len in (2 * raw_per_page + 1, 5 * raw_per_page + 1):
+                    for verify_width in (1, 2, 4, 8):
+                        for overlap_depth in (0, 1):
+                            reservation_end = (
+                                context_len + (overlap_depth + 1) * verify_width
                             )
-                            retained_begin = max(0, context_len - (window - 1))
-                            required_pages = math.ceil(
-                                reservation_end / raw_per_page
-                            ) - math.floor(retained_begin / raw_per_page)
-                            self.assertGreaterEqual(capture_pages, required_pages)
+                            with self.subTest(
+                                raw_per_page=raw_per_page,
+                                window=window,
+                                context_len=context_len,
+                                verify_width=verify_width,
+                                overlap_depth=overlap_depth,
+                            ):
+                                capture_pages = compute_max_logical_pages_for_capture(
+                                    spec,
+                                    max_context_len=context_len,
+                                    max_tokens_per_req=verify_width,
+                                    overlap_schedule_depth=overlap_depth,
+                                )
+                                # Exercise the conservative full-window
+                                # metadata bound used for capture.
+                                retained_begin = max(0, reservation_end - window)
+                                conservative_pages = math.ceil(
+                                    reservation_end / raw_per_page
+                                ) - math.floor(retained_begin / raw_per_page)
+                                self.assertGreaterEqual(
+                                    capture_pages, conservative_pages
+                                )
 
     def test_overlap_sizing_rejects_invalid_runtime_parameters(self):
         spec = PagedCacheGroupSpec(


### PR DESCRIPTION

## Summary

Fix DeepSeek V4 CUDA graph capture sizing for sliding-window paged-cache groups.

The previous capture buffer width used the per-token attention history size (`window - 1`). This PR uses the full sliding-window value as a conservative metadata bound for CUDA graph block tables, while keeping runtime capacity sizing and attention history semantics unchanged.

## Notes

- This only widens the captured block-table metadata buffer for affected shapes.
- It does not change SWA attention behavior.
- The `window - 1` sizing in allocation/capacity paths remains intentional.

original cuda-graph capture exception:

```
[ts] [2026-07-08 03:55:02,246  ATTN TP RANK 0] - ERROR - Scheduler hit an exception: Traceback (most recent call last):
[ts]   File "/home/runner/SimonCqk/tokenspeed/python/tokenspeed/runtime/engine/event_loop.py", line 1731, in run_event_loop
[ts]     event_loop.event_loop_overlap()
[ts]   File "/home/runner/SimonCqk/tokenspeed/python/tokenspeed/runtime/engine/event_loop.py", line 1653, in event_loop_overlap
[ts]     curr_results, _ = self._dispatch_forward(
[ts]                       ^^^^^^^^^^^^^^^^^^^^^^^
[ts]   File "/home/runner/SimonCqk/tokenspeed/python/tokenspeed/runtime/engine/event_loop.py", line 747, in _dispatch_forward
[ts]     self.model_executor.execute_forward_op_with_log(
[ts]   File "/home/runner/SimonCqk/tokenspeed/python/tokenspeed/runtime/execution/model_executor.py", line 1102, in execute_forward_op_with_log
[ts]     result = self.execute_forward_op(
[ts]              ^^^^^^^^^^^^^^^^^^^^^^^^
[ts]   File "/home/runner/SimonCqk/tokenspeed/python/tokenspeed/runtime/execution/model_executor.py", line 1770, in execute_forward_op
[ts]     output_tokens, output_lengths, output_logprobs = self.forward_step(
[ts]                                                      ^^^^^^^^^^^^^^^^^^
[ts]   File "/home/runner/SimonCqk/tokenspeed/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py", line 973, in __call__
[ts]     self._init_replay_metadata(
[ts]   File "/home/runner/SimonCqk/tokenspeed/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py", line 691, in _init_replay_metadata
[ts]     self.attn_backend.init_forward_metadata_replay_cuda_graph(
[ts]   File "/home/runner/SimonCqk/tokenspeed/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py", line 1976, in init_forward_metadata_replay_cuda_graph
[ts]     metadata_paged = self._refresh_cuda_graph_paged_cache_block_tables(
[ts]                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[ts]   File "/home/runner/SimonCqk/tokenspeed/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py", line 1722, in _refresh_cuda_graph_paged_cache_block_tables
[ts]     raise RuntimeError(
[ts] RuntimeError: DeepSeek V4 CUDA graph paged cache table width mismatch for 'v4.swa_kv': got 5, capture buffer has 4
[ts]  (event_loop.py:1737)
```

## Test Plan

- No regression observed, gsm8k -limit 200 accuracy: 0.985;
