### PR TITLE
perf(deepseek-v4): sanitize SWA slot mapping once per step

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
@@ -1018,6 +1018,14 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
     def get_swa_kv_buffer(self, layer_id: int) -> torch.Tensor:
         return self.swa_kv_buffer[layer_id]
 
+    @property
+    def swa_capacity_slots(self) -> int:
+        # Every layer's SWA buffer is allocated with the same page count, so a
+        # single capacity bounds the write-slot mapping shared across layers.
+        if not self.swa_kv_buffer:
+            return 0
+        return int(self.swa_kv_buffer[0].shape[0]) * int(self.swa_block_size)
+
     def get_compressed_kv_buffer_2d(self, layer_id: int) -> torch.Tensor:
         return self._require(self.compressed_kv_buffer, layer_id, "compressed KV")
 

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
@@ -1020,8 +1020,13 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
 
     @property
     def swa_capacity_slots(self) -> int:
-        # Every layer's SWA buffer is allocated with the same page count, so a
-        # single capacity bounds the write-slot mapping shared across layers.
+        """Writable SWA cache capacity shared by every layer, in token slots.
+
+        Every layer's SWA buffer is allocated with the same page count, so a
+        single capacity (pages * tokens per block) bounds the write-slot
+        mapping shared across layers. Returns 0 when no SWA buffers exist;
+        callers must then mask all slots rather than skip the bounds check.
+        """
         if not self.swa_kv_buffer:
             return 0
         return int(self.swa_kv_buffer[0].shape[0]) * int(self.swa_block_size)

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -1981,12 +1981,12 @@ def _deepseek_v4_padded_heads(num_local_heads: int) -> int:
 
 def _deepseek_v4_sanitize_swa_slot_mapping(
     slot_mapping: torch.Tensor,
-    swa_kv_cache: torch.Tensor,
-    block_size: int,
+    capacity: int | None,
     is_valid_token: torch.Tensor | None = None,
 ) -> torch.Tensor:
     slot_mapping = _mask_invalid_graph_tokens(slot_mapping, is_valid_token)
-    capacity = int(swa_kv_cache.shape[0]) * int(block_size)
+    if not capacity:
+        return slot_mapping
     valid = (slot_mapping >= 0) & (slot_mapping < capacity)
     return torch.where(
         valid,
@@ -2000,26 +2000,43 @@ def _deepseek_v4_swa_slot_mapping(
     positions: torch.Tensor,
     out_cache_loc: torch.Tensor,
 ) -> torch.Tensor:
+    """Build the SWA write-slot mapping, already sanitized for cache inserts.
+
+    The returned mapping has invalid CUDA-graph tokens and out-of-capacity
+    slots masked to -1, so per-layer SWA inserts can consume it directly.
+    Sanitizing here keeps the mask/clamp elementwise chain at once per step;
+    doing it per layer previously baked ~7 tiny kernels x 61 layers into the
+    captured decode graph.
+    """
     if positions.numel() == 0:
         return out_cache_loc
     metadata = _deepseek_v4_forward_metadata(ctx)
     if metadata is None:
         raise RuntimeError("DeepSeek V4 attention requires forward metadata")
     cache_metadata = metadata.cache
-    if cache_metadata.swa_block_table is None:
-        return out_cache_loc
     token_to_req_indices = metadata.token_to_req_indices[: positions.numel()]
-    if token_to_req_indices.numel() != positions.numel() and (
+    if cache_metadata.swa_block_table is None:
+        slot_mapping = out_cache_loc
+    elif token_to_req_indices.numel() != positions.numel() and (
         token_to_req_indices.numel() <= 0
         or positions.numel() % token_to_req_indices.numel() != 0
     ):
-        return out_cache_loc
-    return _group_slot_mapping_from_raw(
-        positions,
-        token_to_req_indices,
-        cache_metadata.swa_block_table,
-        ctx.token_to_kv_pool.swa_block_size,
-        base_offsets=cache_metadata.swa_base_logical_page,
+        slot_mapping = out_cache_loc
+    else:
+        slot_mapping = _group_slot_mapping_from_raw(
+            positions,
+            token_to_req_indices,
+            cache_metadata.swa_block_table,
+            ctx.token_to_kv_pool.swa_block_size,
+            base_offsets=cache_metadata.swa_base_logical_page,
+        )
+    is_valid_token = getattr(metadata, "is_valid_token", None)
+    if is_valid_token is not None:
+        is_valid_token = is_valid_token[: positions.numel()]
+    return _deepseek_v4_sanitize_swa_slot_mapping(
+        slot_mapping,
+        getattr(ctx.token_to_kv_pool, "swa_capacity_slots", None),
+        is_valid_token,
     )
 
 
@@ -3502,16 +3519,12 @@ class DeepseekV4Attention(nn.Module):
         positions: torch.Tensor,
         cos_sin_cache: torch.Tensor,
         block_size: int,
-        is_valid_token: torch.Tensor | None = None,
     ) -> None:
+        # slot_mapping arrives pre-sanitized from _deepseek_v4_swa_slot_mapping
+        # (invalid tokens and out-of-capacity slots masked to -1); sanitizing
+        # here again would re-run the mask chain once per layer.
         if q.shape[0] == 0:
             return
-        slot_mapping = _deepseek_v4_sanitize_swa_slot_mapping(
-            slot_mapping,
-            swa_kv_cache,
-            block_size,
-            is_valid_token=is_valid_token,
-        )
         fused_qnorm_rope_kv_insert(
             q=q,
             kv=kv,
@@ -3656,11 +3669,6 @@ class DeepseekV4Attention(nn.Module):
 
         def insert_swa_cache() -> None:
             with nvtx_range(f"{profile_prefix}_insert_swa_cache"):
-                is_valid_token = (
-                    metadata.is_valid_token[: positions.numel()]
-                    if metadata.is_valid_token is not None
-                    else None
-                )
                 self._insert_swa_cache(
                     q=q,
                     kv=kv,
@@ -3669,7 +3677,6 @@ class DeepseekV4Attention(nn.Module):
                     positions=positions,
                     cos_sin_cache=cos_sin_cache,
                     block_size=pool.swa_block_size,
-                    is_valid_token=is_valid_token,
                 )
 
         def run_compressor() -> None:

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -1981,12 +1981,14 @@ def _deepseek_v4_padded_heads(num_local_heads: int) -> int:
 
 def _deepseek_v4_sanitize_swa_slot_mapping(
     slot_mapping: torch.Tensor,
-    capacity: int | None,
+    capacity: int,
     is_valid_token: torch.Tensor | None = None,
 ) -> torch.Tensor:
+    # Fail closed: with no writable SWA capacity every slot is masked, so an
+    # unchecked mapping can never reach the fused cache-insert kernels.
+    if capacity <= 0:
+        return torch.full_like(slot_mapping, -1)
     slot_mapping = _mask_invalid_graph_tokens(slot_mapping, is_valid_token)
-    if not capacity:
-        return slot_mapping
     valid = (slot_mapping >= 0) & (slot_mapping < capacity)
     return torch.where(
         valid,
@@ -2033,9 +2035,12 @@ def _deepseek_v4_swa_slot_mapping(
     is_valid_token = getattr(metadata, "is_valid_token", None)
     if is_valid_token is not None:
         is_valid_token = is_valid_token[: positions.numel()]
+    # Attribute access is deliberately unguarded: a pool without
+    # swa_capacity_slots must fail fast here rather than skip the bounds
+    # check that protects the fused cache-insert kernels.
     return _deepseek_v4_sanitize_swa_slot_mapping(
         slot_mapping,
-        getattr(ctx.token_to_kv_pool, "swa_capacity_slots", None),
+        ctx.token_to_kv_pool.swa_capacity_slots,
         is_valid_token,
     )
 

--- a/test/runtime/test_deepseek_v4_attention_ops.py
+++ b/test/runtime/test_deepseek_v4_attention_ops.py
@@ -15,6 +15,7 @@ import math
 import unittest
 
 import torch
+from ci_system.ci_register import register_cuda_ci
 from tokenspeed_kernel.ops.attention.cuda.deepseek_v4 import (
     has_indexer_mxfp4_paged_gather,
     has_persistent_topk,
@@ -52,6 +53,8 @@ from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
 from tokenspeed.runtime.models.deepseek_v4 import (
     _deepseek_v4_sanitize_swa_slot_mapping,
 )
+
+register_cuda_ci(est_time=90, suite="runtime-1gpu")
 
 HEAD_DIM = 512
 NOPE_DIM = 448
@@ -448,6 +451,121 @@ class DeepseekV4AttentionOpsCpuValidationTest(unittest.TestCase):
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
 class DeepseekV4AttentionOpsTest(unittest.TestCase):
+
+    def test_sanitized_insert_write_safety_under_graph_replay(self):
+        # Full producer -> sanitize -> CUDA graph replay -> cache write path.
+        # Slots and validity mutate between replays through static buffers;
+        # sentinel bytes prove only legal cache slots are ever written.
+        from tokenspeed.runtime.models.deepseek_v4 import (
+            _deepseek_v4_sanitize_swa_slot_mapping,
+        )
+
+        torch.manual_seed(7)
+        device = torch.device("cuda")
+        dtype = torch.bfloat16
+        num_tokens = 4
+        num_heads = 2
+        block_size = 4
+        num_blocks = 2
+        capacity = num_blocks * block_size
+        eps = 1.0e-6
+        sentinel = 0xAB
+        token_bytes = 576
+        scale_bytes = 8
+        block_stride = block_size * (token_bytes + scale_bytes)
+        guard_bytes = 4096
+
+        storage = torch.full(
+            (num_blocks * block_stride + guard_bytes,),
+            sentinel,
+            device=device,
+            dtype=torch.uint8,
+        )
+        cache = storage[: num_blocks * block_stride].view(num_blocks, block_stride)
+        guard = storage[num_blocks * block_stride :]
+
+        q = torch.randn(num_tokens, num_heads, HEAD_DIM, device=device, dtype=dtype)
+        kv = torch.randn(num_tokens, HEAD_DIM, device=device, dtype=dtype)
+        positions = torch.tensor([0, 3, 5, 7], dtype=torch.int64, device=device)
+        cos_sin = torch.randn(16, ROPE_DIM, device=device, dtype=torch.float32) * 0.1
+        raw_slots = torch.zeros(num_tokens, dtype=torch.int64, device=device)
+        is_valid = torch.ones(num_tokens, dtype=torch.bool, device=device)
+
+        def run_once():
+            sanitized = _deepseek_v4_sanitize_swa_slot_mapping(
+                raw_slots, capacity, is_valid
+            )
+            fused_qnorm_rope_kv_insert(
+                q=q,
+                kv=kv,
+                swa_kv_cache_2d=cache,
+                slot_mapping=sanitized,
+                positions=positions,
+                cos_sin_cache=cos_sin,
+                rms_norm_eps=eps,
+                block_size=block_size,
+            )
+
+        stream = torch.cuda.Stream()
+        with torch.cuda.stream(stream):
+            try:
+                run_once()
+            except RuntimeError as exc:
+                if "fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert" in str(exc):
+                    self.skipTest(str(exc))
+                raise
+            run_once()
+        torch.cuda.current_stream().wait_stream(stream)
+        torch.cuda.synchronize()
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            run_once()
+
+        def written_mask(slots):
+            mask = torch.zeros(storage.numel(), dtype=torch.bool)
+            for slot in slots:
+                if slot < 0 or slot >= capacity:
+                    continue
+                block, pos = divmod(slot, block_size)
+                base = block * block_stride
+                start = base + pos * token_bytes
+                mask[start : start + token_bytes] = True
+                sstart = base + block_size * token_bytes + pos * scale_bytes
+                mask[sstart : sstart + scale_bytes] = True
+            return mask
+
+        replays = [
+            # (raw slots, validity, slots the kernel may legally write)
+            ([0, 5, 99, -1], [True, True, True, True], [0, 5]),
+            ([2, 0, 7, 3], [True, False, True, True], [2, 7, 3]),
+        ]
+        for slots, valid, expected in replays:
+            storage.fill_(sentinel)
+            raw_slots.copy_(torch.tensor(slots, dtype=torch.int64, device=device))
+            is_valid.copy_(torch.tensor(valid, dtype=torch.bool, device=device))
+            graph.replay()
+            torch.cuda.synchronize()
+            host = storage.cpu()
+            allowed = written_mask(expected)
+            outside = host[~allowed]
+            self.assertTrue(
+                bool((outside == sentinel).all()),
+                f"bytes outside legal slots {expected} were modified",
+            )
+            for slot in expected:
+                block, pos = divmod(slot, block_size)
+                region = host[
+                    block * block_stride
+                    + pos * token_bytes : block * block_stride
+                    + (pos + 1) * token_bytes
+                ]
+                self.assertFalse(
+                    bool((region == sentinel).all()),
+                    f"legal slot {slot} was not written",
+                )
+        self.assertTrue(bool((guard.cpu() == sentinel).all()))
+
     def test_fused_qnorm_rope_kv_insert_matches_reference(self):
         torch.manual_seed(1234)
         dtype = torch.bfloat16

--- a/test/runtime/test_deepseek_v4_attention_ops.py
+++ b/test/runtime/test_deepseek_v4_attention_ops.py
@@ -12,10 +12,18 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
 
 import math
+import os
+import sys
 import unittest
 
 import torch
+
+# CI Registration (parsed via AST, runtime no-op)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from ci_system.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=90, suite="runtime-1gpu")
+
 from tokenspeed_kernel.ops.attention.cuda.deepseek_v4 import (
     has_indexer_mxfp4_paged_gather,
     has_persistent_topk,
@@ -53,8 +61,6 @@ from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
 from tokenspeed.runtime.models.deepseek_v4 import (
     _deepseek_v4_sanitize_swa_slot_mapping,
 )
-
-register_cuda_ci(est_time=90, suite="runtime-1gpu")
 
 HEAD_DIM = 512
 NOPE_DIM = 448

--- a/test/runtime/test_deepseek_v4_attention_ops.py
+++ b/test/runtime/test_deepseek_v4_attention_ops.py
@@ -288,10 +288,9 @@ def _expected_overlap_normed(
 
 class DeepseekV4AttentionOpsCpuValidationTest(unittest.TestCase):
     def test_swa_slot_mapping_guard_masks_out_of_range_slots(self):
-        cache = torch.empty((2, 4 * SWA_TOKEN_STRIDE), dtype=torch.uint8)
         slots = torch.tensor([-3, -1, 0, 7, 8, 99], dtype=torch.int64)
 
-        sanitized = _deepseek_v4_sanitize_swa_slot_mapping(slots, cache, 4)
+        sanitized = _deepseek_v4_sanitize_swa_slot_mapping(slots, capacity=2 * 4)
 
         torch.testing.assert_close(
             sanitized,
@@ -299,14 +298,12 @@ class DeepseekV4AttentionOpsCpuValidationTest(unittest.TestCase):
         )
 
     def test_swa_slot_mapping_guard_masks_invalid_graph_tokens(self):
-        cache = torch.empty((2, 4 * SWA_TOKEN_STRIDE), dtype=torch.uint8)
         slots = torch.tensor([0, 1, 2, 9, -1, 3], dtype=torch.int64)
         is_valid_token = torch.tensor([True, False, True, True, True, False])
 
         sanitized = _deepseek_v4_sanitize_swa_slot_mapping(
             slots,
-            cache,
-            4,
+            capacity=2 * 4,
             is_valid_token=is_valid_token,
         )
 

--- a/test/runtime/test_deepseek_v4_mtp_prefix_cache.py
+++ b/test/runtime/test_deepseek_v4_mtp_prefix_cache.py
@@ -86,6 +86,37 @@ def test_deepseek_v4_swa_slot_mapping_prefers_draft_prefill_metadata():
     assert slot_mapping.tolist() == [20, 21, 22, 40, 41]
 
 
+def test_deepseek_v4_swa_slot_mapping_masks_invalid_and_overflow_slots():
+    # The mapping must arrive at per-layer SWA inserts already sanitized:
+    # invalid CUDA-graph tokens and out-of-capacity slots masked to -1.
+    metadata = SimpleNamespace(
+        token_to_req_indices=torch.tensor([0, 1], dtype=torch.int32),
+        cache=SimpleNamespace(
+            swa_block_table=torch.tensor(
+                [
+                    [10, 11],
+                    [20, 21],
+                ],
+                dtype=torch.int32,
+            ),
+            swa_base_logical_page=None,
+        ),
+        is_valid_token=torch.tensor([True, True, False, True]),
+    )
+    ctx = SimpleNamespace(
+        attn_backend=SimpleNamespace(forward_metadata=metadata),
+        token_to_kv_pool=SimpleNamespace(swa_block_size=2, swa_capacity_slots=43),
+    )
+    positions = torch.tensor([0, 1, 2, 3], dtype=torch.int32)
+    out_cache_loc = torch.tensor([100, 101, 102, 103], dtype=torch.int32)
+
+    slot_mapping = _deepseek_v4_swa_slot_mapping(ctx, positions, out_cache_loc)
+
+    # Raw mapping is [20, 21, 42, 43]: index 2 is masked by is_valid_token,
+    # index 3 exceeds the 43-slot capacity.
+    assert slot_mapping.tolist() == [20, 21, -1, -1]
+
+
 def test_deepseek_v4_swa_slot_mapping_falls_back_for_incompatible_draft_metadata():
     metadata = SimpleNamespace(
         token_to_req_indices=torch.tensor([0, 1], dtype=torch.int32),

--- a/test/runtime/test_deepseek_v4_mtp_prefix_cache.py
+++ b/test/runtime/test_deepseek_v4_mtp_prefix_cache.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
@@ -40,7 +41,7 @@ def test_deepseek_v4_swa_slot_mapping_expands_mtp_decode_requests():
     )
     ctx = SimpleNamespace(
         attn_backend=SimpleNamespace(forward_metadata=metadata),
-        token_to_kv_pool=SimpleNamespace(swa_block_size=2),
+        token_to_kv_pool=SimpleNamespace(swa_block_size=2, swa_capacity_slots=1024),
     )
     positions = torch.tensor([0, 1, 2, 3], dtype=torch.int32)
     out_cache_loc = torch.tensor([100, 101, 102, 103], dtype=torch.int32)
@@ -76,7 +77,7 @@ def test_deepseek_v4_swa_slot_mapping_prefers_draft_prefill_metadata():
             forward_metadata=decode_metadata,
             forward_prefill_metadata=prefill_metadata,
         ),
-        token_to_kv_pool=SimpleNamespace(swa_block_size=2),
+        token_to_kv_pool=SimpleNamespace(swa_block_size=2, swa_capacity_slots=1024),
     )
     positions = torch.tensor([0, 1, 2, 0, 1], dtype=torch.int32)
     out_cache_loc = torch.tensor([100, 101, 102, 103, 104], dtype=torch.int32)
@@ -117,6 +118,43 @@ def test_deepseek_v4_swa_slot_mapping_masks_invalid_and_overflow_slots():
     assert slot_mapping.tolist() == [20, 21, -1, -1]
 
 
+def test_deepseek_v4_swa_slot_mapping_fails_closed_without_capacity():
+    # Zero capacity masks every slot; a pool without the property fails fast.
+    # Both protect the fused cache-insert kernels now that per-layer
+    # sanitization is gone.
+    metadata = SimpleNamespace(
+        token_to_req_indices=torch.tensor([0, 1], dtype=torch.int32),
+        cache=SimpleNamespace(
+            swa_block_table=torch.tensor(
+                [
+                    [10, 11],
+                    [20, 21],
+                ],
+                dtype=torch.int32,
+            ),
+            swa_base_logical_page=None,
+        ),
+    )
+    positions = torch.tensor([0, 1, 2, 3], dtype=torch.int32)
+    out_cache_loc = torch.tensor([100, 101, 102, 103], dtype=torch.int32)
+
+    zero_capacity_ctx = SimpleNamespace(
+        attn_backend=SimpleNamespace(forward_metadata=metadata),
+        token_to_kv_pool=SimpleNamespace(swa_block_size=2, swa_capacity_slots=0),
+    )
+    slot_mapping = _deepseek_v4_swa_slot_mapping(
+        zero_capacity_ctx, positions, out_cache_loc
+    )
+    assert slot_mapping.tolist() == [-1, -1, -1, -1]
+
+    no_capacity_ctx = SimpleNamespace(
+        attn_backend=SimpleNamespace(forward_metadata=metadata),
+        token_to_kv_pool=SimpleNamespace(swa_block_size=2),
+    )
+    with pytest.raises(AttributeError, match="swa_capacity_slots"):
+        _deepseek_v4_swa_slot_mapping(no_capacity_ctx, positions, out_cache_loc)
+
+
 def test_deepseek_v4_swa_slot_mapping_falls_back_for_incompatible_draft_metadata():
     metadata = SimpleNamespace(
         token_to_req_indices=torch.tensor([0, 1], dtype=torch.int32),
@@ -135,7 +173,7 @@ def test_deepseek_v4_swa_slot_mapping_falls_back_for_incompatible_draft_metadata
         forward_mode=ForwardMode.DECODE,
         input_num_tokens=5,
         attn_backend=SimpleNamespace(forward_metadata=metadata),
-        token_to_kv_pool=SimpleNamespace(swa_block_size=2),
+        token_to_kv_pool=SimpleNamespace(swa_block_size=2, swa_capacity_slots=1024),
     )
     positions = torch.arange(5, dtype=torch.int32)
     out_cache_loc = torch.tensor([100, 101, 102, 103, 104], dtype=torch.int32)

--- a/test/runtime/test_deepseek_v4_mtp_prefix_cache.py
+++ b/test/runtime/test_deepseek_v4_mtp_prefix_cache.py
@@ -13,19 +13,24 @@
 
 from __future__ import annotations
 
+import os
+import sys
 from types import SimpleNamespace
 
 import pytest
 import torch
+
+# CI Registration (parsed via AST, runtime no-op)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from ci_system.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, suite="runtime-1gpu")
 
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.execution.model_executor import (
     _draft_idle_global_num_tokens_for_step,
 )
 from tokenspeed.runtime.models.deepseek_v4 import _deepseek_v4_swa_slot_mapping
-
-register_cuda_ci(est_time=30, suite="runtime-1gpu")
 
 
 def test_deepseek_v4_swa_slot_mapping_expands_mtp_decode_requests():
@@ -206,3 +211,7 @@ def test_draft_idle_global_num_tokens_match_multi_step_decode_shape():
         _draft_idle_global_num_tokens_for_step(1, global_num_tokens, None)
         is global_num_tokens
     )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/runtime/test_deepseek_v4_mtp_prefix_cache.py
+++ b/test/runtime/test_deepseek_v4_mtp_prefix_cache.py
@@ -17,12 +17,15 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from ci_system.ci_register import register_cuda_ci
 
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.execution.model_executor import (
     _draft_idle_global_num_tokens_for_step,
 )
 from tokenspeed.runtime.models.deepseek_v4 import _deepseek_v4_swa_slot_mapping
+
+register_cuda_ci(est_time=30, suite="runtime-1gpu")
 
 
 def test_deepseek_v4_swa_slot_mapping_expands_mtp_decode_requests():


### PR DESCRIPTION
## Summary

The SWA write-slot mapping is computed once per step in `DeepseekV4Model.forward`, but every attention layer re-ran the same sanitize (mask invalid CUDA-graph tokens + capacity clamp, ~7 tiny elementwise kernels) on this layer-invariant mapping. Inside the captured MTP decode graph this baked ~430 redundant kernel nodes that re-executed on every replay.

- Move sanitization into `_deepseek_v4_swa_slot_mapping` so both producers (model-level hoist and the attention-local fallback) return a mapping with invalid tokens and out-of-capacity slots already masked to `-1`; drop the per-layer sanitize from `_insert_swa_cache`.
- Add pool property `swa_capacity_slots` (all layers share one SWA buffer shape). Sanitization fails closed: zero capacity masks every slot, and a pool without the property raises instead of skipping the bounds check.
- Numerics are unchanged: the same mask/clamp runs, once per step instead of once per layer.

## Evidence

Mechanism (exact decode nsys trace, TP8 p4/n8, B200, node-mode; measured on the current V4 integration stack since V4 TP8 serving requires #563/#580/#547):

| | before | after | delta |
| --- | ---: | ---: | ---: |
| decode graph kernel nodes | 4,102 | 3,682 | -420 (matches 61 layers x ~7 kernels) |
| bookkeeping elementwise nodes | 743 | 323 | -420 |
| bookkeeping replay time | 0.842 ms/step | 0.381 ms/step | -0.46 ms/step |
| Memory/elementwise category | 1.982 ms/step | 1.554 ms/step | -21.6% |
| median decode cadence | 20.66 ms | 20.23 ms | -2.1% |

All other kernel categories moved less than +/-0.02 ms/step, so the change is surgical.

Endpoint (adjacent non-profile p4 A/B, same node/container/protocol): neutral within run noise — TPS/GPU +1.00%, TPOT +0.23%, MTP acceptance and cache hit matched (87/87 both arms). The ~2% cadence saving is below single-pair noise resolution, so this PR claims the mechanism win, not an endpoint win.

Tests: `test_deepseek_v4_{config,attention_ops,mtp_prefix_cache}.py` pass on this branch (133 passed); on the integration stack the same change passes the fuller 181-test set. New tests cover mask+capacity sanitization and the fail-closed capacity contract.

## Notes for review

- The remaining 323 baked bookkeeping nodes (~0.38 ms/step) are per-key indexer plan / dense-indices builds captured at graph-capture time; they are a separate, larger change and intentionally out of scope here.
- Graph-replay write-safety test added (producer -> sanitize -> replay -> cache write, sentinel-checked); test_deepseek_v4_attention_ops.py and test_deepseek_v4_mtp_prefix_cache.py are now registered in the runtime-1gpu CUDA CI lane (previously never executed in CI).
- Rebased onto current main. A p4 correctness sanity run (main+this branch, 87/87) is in progress; result will be posted in a comment.


