### PR TITLE
fix(trtllm-mla): make spec-decode CUDA graph capture causal

### DIFF
--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -353,6 +353,33 @@ class CudaGraphWrapper:
             variant=variant,
         )
 
+    def _prepare_attention_capture_buffers(self, bs: int) -> None:
+        """Seed a finite, internally consistent cache state for graph capture."""
+        tokens_per_req = self.max_tokens_per_req
+        self.input_buffers.seq_lens_buf[:bs].fill_(tokens_per_req)
+
+        page_size = self.input_buffers.page_size
+        dummy_slot = int(self.input_buffers.dummy_kv_slot)
+        dummy_page = dummy_slot // page_size
+        for backend in (self.attn_backend, self.draft_attn_backend):
+            if backend is not None:
+                backend.cuda_graph_capture_dummy_page = dummy_page
+        self.input_buffers.out_cache_loc_buf[: bs * tokens_per_req].fill_(dummy_slot)
+
+        dummy_page_start = dummy_page * page_size
+        dummy_page_end = dummy_page_start + page_size
+        for pool in (self.token_to_kv_pool, self.draft_token_to_kv_pool):
+            if pool is None:
+                continue
+            for layer_buf in getattr(pool, "kv_buffer", ()):
+                buffers = (
+                    layer_buf if isinstance(layer_buf, (tuple, list)) else (layer_buf,)
+                )
+                for buffer in buffers:
+                    # Hybrid cache pools use None for state-only layers.
+                    if buffer is not None:
+                        buffer[dummy_page_start:dummy_page_end].zero_()
+
     def _cuda_graph_replay_variant(self) -> str:
         if self.sampling_backend is None:
             return CUDA_GRAPH_VARIANT_DEFAULT
@@ -476,7 +503,7 @@ class CudaGraphWrapper:
                 self._prepare_sampling_capture(bs=bs, variant=variant)
                 # Keep warmup seq_lens >= q_len_per_req so no query row gets an
                 # empty causal span; a stale seq_len of 1 overflows to non-finite KV.
-                self.input_buffers.seq_lens_buf[:bs].fill_(self.max_tokens_per_req)
+                self._prepare_attention_capture_buffers(bs)
                 self._init_capture_metadata(bs)
                 run_once()
             # Order the reset below after the last warmup's stateful kernels.
@@ -493,12 +520,14 @@ class CudaGraphWrapper:
         # Warmups can switch a backend back to eager metadata objects. Restore
         # the graph-backed metadata immediately before capture so replay-time
         # metadata refreshes update the same tensors recorded by the graph.
+        self._prepare_attention_capture_buffers(bs)
         self._init_capture_metadata(bs)
 
         # Fill sampler buffers OUTSIDE the capture so RNG ops aren't recorded.
         self._prepare_sampling_capture(bs=bs, variant=variant)
         # Warmup forwards can mutate aliased metadata buffers, so refresh
         # them again immediately before graph capture records the final views.
+        self._prepare_attention_capture_buffers(bs)
         self._init_capture_metadata(bs)
 
         self.deepep_adapter.capture()

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
@@ -462,9 +462,13 @@ class TRTLLMMLABackend(MlaCacheGroupMixin, AttentionBackend):
         max_blocks = self._calc_padded_blocks(self.max_context_len)
         block_kv_indices = self.decode_cuda_graph_kv_indices[:bs, :max_blocks]
 
-        # For capture we don't have page_table yet; just zero-fill the block indices.
-        # The actual indices will be filled on replay. seq_lens_k views the
-        # backend-owned cuda_graph_seq_lens_buf (set in init_cuda_graph_state).
+        # For capture we don't have a page table yet. Use the reserved null page
+        # for every synthetic row so capture does not depend on private request
+        # pages. Replay replaces these entries with the live page table.
+        block_kv_indices.fill_(int(getattr(self, "cuda_graph_capture_dummy_page", 0)))
+
+        # seq_lens_k views the backend-owned cuda_graph_seq_lens_buf (set in
+        # init_cuda_graph_state).
         capture_q_len = self._graph_verify_q_len()
         group_out_cache_loc = None
         if self._cache_contract_bound:
@@ -619,7 +623,10 @@ class TRTLLMMLABackend(MlaCacheGroupMixin, AttentionBackend):
         num_extends = 0 if self.draft_block_decode else metadata.num_extends
         q_len_per_req = q.shape[0] // bs if bs > 0 else 1
 
-        if q_len_per_req > 1 and self.is_draft:
+        if q_len_per_req > 1:
+            # Multi-token decode is used by target verification and by the
+            # draft first-step catch-up and block-decode paths. Flatten to one
+            # decode query per token so each row gets its own cache bound.
             query = q.view(-1, layer.tp_q_head_num, layer.head_dim).unsqueeze(1)
             page_table = metadata.block_kv_indices[num_extends:].repeat_interleave(
                 q_len_per_req, dim=0
@@ -632,13 +639,24 @@ class TRTLLMMLABackend(MlaCacheGroupMixin, AttentionBackend):
                 # query sees the same block-end length (non-causal block decode).
                 seq_lens = base_lens
                 max_seq_len = metadata.max_seq_len_k
-            else:
+            elif self.is_draft:
                 # Eagle/MTP catch-up: each successive token sees one more KV.
                 offsets = torch.arange(
                     q_len_per_req, device=base_lens.device, dtype=base_lens.dtype
                 ).repeat(bs)
                 seq_lens = base_lens + offsets
                 max_seq_len = metadata.max_seq_len_k + q_len_per_req
+            else:
+                # Target verification receives seq_lens at the end of the
+                # speculative window. Convert to per-token causal bounds.
+                base_lens = torch.clamp(base_lens - (q_len_per_req - 1), min=1)
+                offsets = torch.arange(
+                    q_len_per_req,
+                    device=base_lens.device,
+                    dtype=base_lens.dtype,
+                ).repeat(bs)
+                seq_lens = base_lens + offsets
+                max_seq_len = metadata.max_seq_len_k
         else:
             # Plain decode (q_len=1) or bs-grouped multi-token decode.
             query = q.view(bs, -1, layer.tp_q_head_num, layer.head_dim)

--- a/test/runtime/layers/test_mla_verify_metadata.py
+++ b/test/runtime/layers/test_mla_verify_metadata.py
@@ -5,6 +5,9 @@ from types import SimpleNamespace
 import torch
 
 from tokenspeed.runtime.layers.attention.backends import mla as mla_backend
+from tokenspeed.runtime.layers.attention.backends import (
+    trtllm_mla as trtllm_mla_backend,
+)
 
 
 def _run_mla_decode(
@@ -92,3 +95,79 @@ def test_fp8_decode_dispatches_with_native_fp8_query(monkeypatch):
     )
 
     assert captured["q"].dtype == torch.float8_e4m3fn
+
+
+def _run_trtllm_mla_decode(
+    monkeypatch,
+    *,
+    is_draft: bool,
+    bs: int = 2,
+    q_len_per_req: int = 2,
+) -> dict[str, torch.Tensor | int]:
+    captured = {}
+
+    def fake_trtllm_decode(**kwargs):
+        captured.update(kwargs)
+        query = kwargs["query"]
+        return torch.zeros(*query.shape[:-1], 4)
+
+    monkeypatch.setattr(
+        trtllm_mla_backend,
+        "trtllm_batch_decode_with_kv_cache_mla",
+        fake_trtllm_decode,
+    )
+    backend = object.__new__(trtllm_mla_backend.TRTLLMMLABackend)
+    backend.forward_decode_metadata = SimpleNamespace(
+        num_extends=0,
+        block_kv_indices=torch.tensor([[3], [5]], dtype=torch.int32)[:bs],
+        seq_lens_k=torch.tensor([64, 128], dtype=torch.int32)[:bs],
+        max_seq_len_k=256,
+    )
+    backend.is_draft = is_draft
+    backend.draft_block_decode = False
+    backend.kernel_page_size = 16
+    backend.kv_lora_rank = 2
+    backend.qk_nope_head_dim = 2
+    backend.qk_rope_head_dim = 2
+    backend.kv_cache_dim = 4
+    backend.data_type = torch.float32
+    backend.trtllm_workspace = torch.empty(0)
+
+    layer = SimpleNamespace(
+        tp_q_head_num=1,
+        head_dim=4,
+        v_head_dim=4,
+        scaling=1.0,
+        k_scale_float=None,
+        layer_id=0,
+    )
+    token_to_kv_pool = SimpleNamespace(
+        get_key_buffer=lambda layer_id: torch.zeros(32, 4)
+    )
+
+    backend.forward_decode(
+        q=torch.zeros(bs * q_len_per_req, 4),
+        k=None,
+        v=None,
+        layer=layer,
+        out_cache_loc=torch.empty(0, dtype=torch.int32),
+        token_to_kv_pool=token_to_kv_pool,
+        bs=bs,
+        save_kv_cache=False,
+    )
+    return captured
+
+
+def test_trtllm_target_verify_uses_per_token_causal_lengths(monkeypatch):
+    captured = _run_trtllm_mla_decode(monkeypatch, is_draft=False)
+
+    assert captured["seq_lens"].tolist() == [63, 64, 127, 128]
+    assert captured["block_tables"].tolist() == [[3], [3], [5], [5]]
+    assert captured["max_seq_len"] == 256
+
+
+def test_trtllm_draft_catchup_counts_forward_from_base_lengths(monkeypatch):
+    captured = _run_trtllm_mla_decode(monkeypatch, is_draft=True)
+
+    assert captured["seq_lens"].tolist() == [64, 65, 128, 129]
+    assert captured["max_seq_len"] == 258

--- a/test/runtime/test_cudagraph_per_group.py
+++ b/test/runtime/test_cudagraph_per_group.py
@@ -135,6 +135,53 @@ class CacheGroupIdsTest(_TorchCase):
         self.assertEqual(out, ())
 
 
+class AttentionCaptureBuffersTest(_TorchCase):
+    """Capture uses the shared null page without touching private pages."""
+
+    def setUp(self):
+        super().setUp()
+        from tokenspeed.runtime.execution.cuda_graph_wrapper import (
+            CudaGraphWrapper,
+        )
+
+        self.prepare = CudaGraphWrapper._prepare_attention_capture_buffers
+
+    def test_seeds_null_page_and_skips_state_only_layers(self):
+        torch = self.torch
+        target_backend = SimpleNamespace()
+        draft_backend = SimpleNamespace()
+        target_leaf = torch.ones(8)
+        target_quantized = torch.ones(8)
+        draft_leaf = torch.ones(8)
+        wrapper = SimpleNamespace(
+            max_tokens_per_req=3,
+            input_buffers=SimpleNamespace(
+                seq_lens_buf=torch.ones(4, dtype=torch.int32),
+                page_size=2,
+                dummy_kv_slot=2,
+                out_cache_loc_buf=torch.full((16,), -1, dtype=torch.int32),
+            ),
+            attn_backend=target_backend,
+            draft_attn_backend=draft_backend,
+            token_to_kv_pool=SimpleNamespace(
+                kv_buffer=[target_leaf, (target_quantized, None)]
+            ),
+            draft_token_to_kv_pool=SimpleNamespace(kv_buffer=[draft_leaf]),
+        )
+
+        self.prepare(wrapper, bs=2)
+
+        self.assertEqual(wrapper.input_buffers.seq_lens_buf.tolist(), [3, 3, 1, 1])
+        self.assertTrue((wrapper.input_buffers.out_cache_loc_buf[:6] == 2).all())
+        self.assertTrue((wrapper.input_buffers.out_cache_loc_buf[6:] == -1).all())
+        self.assertEqual(target_backend.cuda_graph_capture_dummy_page, 1)
+        self.assertEqual(draft_backend.cuda_graph_capture_dummy_page, 1)
+        for buffer in (target_leaf, target_quantized, draft_leaf):
+            self.assertTrue((buffer[:2] == 1).all())
+            self.assertTrue((buffer[2:4] == 0).all())
+            self.assertTrue((buffer[4:] == 1).all())
+
+
 class DraftCacheGroupIdsTest(_TorchCase):
     """DFLASH owns an independent draft page table; EAGLE-style drafts use
     target cache-group tables at matching page ids."""


### PR DESCRIPTION
Replaces #260 after it was automatically closed for inactivity. GitHub is not allowing the closed PR to be reopened through the API, so this keeps the same fix alive on a fresh rebased branch.

## Summary
- Keeps spec-decode CUDA graph capture seq_lens, output cache slots, and dummy KV page internally consistent during warmup and capture.
- Uses the reserved padding page for TRT-LLM MLA CUDA graph capture block tables.
- Flattens multi-token TRT-LLM MLA decode for both target verification and draft catch-up so each token gets its own causal seq_len bound.

## Validation
- `python3 -m py_compile python/tokenspeed/runtime/execution/cuda_graph_wrapper.py python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py`
- `git diff --check`