### PR TITLE
feat(mla): support custom tree masks in decode

### DIFF
--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -296,8 +296,8 @@ class EventLoop:
             self.world_cpu_group = pg_manager.get_process_group(
                 "gloo", mapping.world_group
             )
-            self._dp_local_info = torch.zeros(1, 3, dtype=torch.int32)
-            self._dp_global_info = torch.zeros(mapping.world_size, 3, dtype=torch.int32)
+            self._dp_local_info = torch.zeros(1, 4, dtype=torch.int32)
+            self._dp_global_info = torch.zeros(mapping.world_size, 4, dtype=torch.int32)
         if server_args.enable_kvstore:
             if server_args.kvstore_storage_backend is not None:
                 raise NotImplementedError(
@@ -998,6 +998,12 @@ class EventLoop:
         self._dp_local_info[0, 0] = num_tokens
         self._dp_local_info[0, 1] = batch_size
         self._dp_local_info[0, 2] = int(forward_mode)
+        spec_info = getattr(forward_op, "spec_info", None)
+        self._dp_local_info[0, 3] = int(
+            executes_model_forward
+            and spec_info is not None
+            and getattr(spec_info, "custom_mask", None) is not None
+        )
         dist.all_gather_into_tensor(
             self._dp_global_info,
             self._dp_local_info,
@@ -1006,6 +1012,8 @@ class EventLoop:
         global_num_tokens = self._dp_global_info[:, 0].tolist()
         global_batch_size = self._dp_global_info[:, 1].tolist()
         global_forward_mode = self._dp_global_info[:, 2].tolist()
+        global_custom_tree_mask = self._dp_global_info[:, 3].tolist()
+        any_custom_tree_mask = max(global_custom_tree_mask) > 0
         any_rank_has_work = max(global_num_tokens) > 0
         need_idle_forward = num_tokens == 0 and any_rank_has_work
         all_decode_or_idle = all(
@@ -1026,6 +1034,7 @@ class EventLoop:
             global_forward_mode=global_forward_mode,
             all_decode_or_idle=all_decode_or_idle,
             all_extend=all_extend,
+            any_custom_tree_mask=any_custom_tree_mask,
             need_idle_forward=need_idle_forward,
         )
 

--- a/python/tokenspeed/runtime/execution/context.py
+++ b/python/tokenspeed/runtime/execution/context.py
@@ -58,6 +58,9 @@ class ForwardContext:
     global_bs: list[int] | None = None
     all_decode_or_idle: bool = False
     all_extend: bool = False
+    # Replicated by the event loop so every DP rank chooses the same
+    # graph/eager route when any rank carries per-request tree-mask metadata.
+    any_custom_tree_mask: bool = False
     # Models that need specific collective sizing (e.g. draft models whose
     # first-step forward narrows activations) report these via
     # ``report_collective_sizing``. Unset (None) means comm sizing falls

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -1005,12 +1005,12 @@ class CudaGraphWrapper:
                 draft_prefill_seq_lens = (
                     seq_lens if self.use_v4_mtp_paged_metadata else draft_seq_lens
                 )
-                # Drafter consumes its own groups' tables (see _draft_group_tables).
-                draft_extend_kwargs = (
-                    {**kwargs, "block_tables": draft_group_tables}
-                    if kwargs.get("block_tables") is not None
-                    else kwargs
-                )
+                # Drafter consumes its own groups' tables (see _draft_group_tables),
+                # but target verify metadata must never leak into draft attention.
+                draft_extend_kwargs = dict(kwargs)
+                draft_extend_kwargs.pop("spec_info", None)
+                if kwargs.get("block_tables") is not None:
+                    draft_extend_kwargs["block_tables"] = draft_group_tables
                 if self.use_v4_mtp_paged_metadata:
                     # cache_metadata describes the target pool and exposes all
                     # target cache groups. The V4 drafter has a narrower cache

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -1150,6 +1150,7 @@ class CudaGraphWrapper:
         extend_seq_lens_cpu: torch.Tensor | None = None,
         positions: torch.Tensor | None = None,
         out_cache_loc: torch.Tensor | None = None,
+        spec_info=None,
         block_tables: dict | None = None,
         block_table_base_offsets: dict | None = None,
         cache_metadata=None,
@@ -1294,6 +1295,7 @@ class CudaGraphWrapper:
                 global_num_tokens=ctx.global_num_tokens,
                 all_decode_or_idle=ctx.all_decode_or_idle,
                 capture_hidden_mode=ctx.capture_hidden_mode,
+                spec_info=spec_info,
                 **metadata_num_tokens,
                 block_tables=(
                     block_tables if self._any_backend_uses_cache_groups() else None

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -1071,6 +1071,8 @@ class CudaGraphWrapper:
             return False
         if not ctx.forward_mode.is_decode():
             return False
+        if getattr(ctx, "any_custom_tree_mask", False):
+            return False
         if self.dp_size > 1:
             if not ctx.all_decode_or_idle:
                 return False

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -1084,6 +1084,13 @@ class CudaGraphWrapper:
             return self._has_cuda_graph_for_bs(bs)
         return bs <= self.max_bs
 
+    @staticmethod
+    def _has_custom_tree_mask(spec_info) -> bool:
+        return (
+            spec_info is not None
+            and getattr(spec_info, "custom_mask", None) is not None
+        )
+
     def can_run(self, bs: int, ctx: ForwardContext) -> bool:
         return self._can_use_graph(bs, ctx)
 
@@ -1156,6 +1163,11 @@ class CudaGraphWrapper:
         path was taken.
         """
         use_graph = self._can_use_graph(bs, ctx)
+        if use_graph and self._has_custom_tree_mask(spec_info):
+            # Tree-mask verify needs per-request mask tensors. The current decode
+            # graph captures stable dummy non-tree masks and replay only refreshes
+            # metadata, so run these batches eagerly until graph mask buffers exist.
+            use_graph = False
         padded_bs = self._padded_bs(bs, ctx) if use_graph else bs
         active_req_pool_indices = self.input_buffers.req_pool_indices_buf[:bs]
 

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -1074,6 +1074,7 @@ class ModelExecutor:
             global_num_tokens=dp_metadata.global_num_tokens,
             global_bs=dp_metadata.global_batch_size,
             all_decode_or_idle=dp_metadata.all_decode_or_idle,
+            any_custom_tree_mask=dp_metadata.any_custom_tree_mask,
         )
         sampling_info = SamplingBatchInfo(
             req_pool_indices=self.input_buffers.req_pool_indices_buf[:0],
@@ -1431,6 +1432,7 @@ class ModelExecutor:
                     ctx.global_bs = dp_metadata.global_batch_size
                     ctx.all_decode_or_idle = dp_metadata.all_decode_or_idle
                     ctx.all_extend = dp_metadata.all_extend
+                    ctx.any_custom_tree_mask = dp_metadata.any_custom_tree_mask
                 with nvtx_range("sampling_prep", color="yellow"):
                     sampling_start = time.perf_counter() if timing_enabled else 0.0
                     sampling_info = self._build_sampling_info(bs, sampling_params_list)

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -1500,6 +1500,7 @@ class ModelExecutor:
                         forward_batch=(
                             forward_op if cache_metadata is not None else None
                         ),
+                        spec_info=getattr(forward_op, "spec_info", None),
                     )
                     if timing_enabled:
                         forward_step_ms = (

--- a/python/tokenspeed/runtime/execution/types.py
+++ b/python/tokenspeed/runtime/execution/types.py
@@ -48,6 +48,7 @@ class DpForwardMetadata:
     global_forward_mode: list[int]
     all_decode_or_idle: bool
     all_extend: bool
+    any_custom_tree_mask: bool
     need_idle_forward: bool
 
 

--- a/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
@@ -957,6 +957,7 @@ class CuteDSLMLABackend(AttentionBackend):
         token_to_kv_pool,
         bs: int,
         save_kv_cache: bool = True,
+        spec_info=None,
         **kwargs,
     ) -> torch.Tensor:
         # q is whole Q [T, H, head_dim]; k is whole latent [T, 1, head_dim].
@@ -1010,6 +1011,16 @@ class CuteDSLMLABackend(AttentionBackend):
 
         self.cutedsl_workspace = self._cutedsl_workspace(query.shape[1])
 
+        custom_mask = kwargs.get("custom_mask")
+        cmask_off = kwargs.get("cmask_off")
+        if spec_info is not None:
+            if custom_mask is None:
+                custom_mask = getattr(spec_info, "custom_mask", None)
+            if cmask_off is None:
+                cmask_off = getattr(spec_info, "cmask_off", None)
+                if cmask_off is None:
+                    cmask_off = getattr(spec_info, "custom_mask_offsets", None)
+
         raw_out = tokenspeed_mla_decode(
             query=query,
             kv_cache=kv_cache,
@@ -1021,6 +1032,8 @@ class CuteDSLMLABackend(AttentionBackend):
             max_seq_len=metadata.max_seq_len_k,
             softmax_scale=softmax_scale,
             enable_pdl=pdl_enabled(),
+            custom_mask=custom_mask,
+            cmask_off=cmask_off,
         )
 
         return raw_out.view(-1, layer.tp_q_head_num * layer.v_head_dim)

--- a/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
@@ -202,6 +202,7 @@ class CuteDSLMLABackend(AttentionBackend):
         # Allocated in init_cuda_graph_state only when _cache_contract_bound.
         self.decode_cuda_graph_group_out_cache_loc: torch.Tensor | None = None
         self.chunked_prefill_metadata: TRTLLMMLAChunkedPrefillMetadata | None = None
+        self.forward_decode_spec_info = None
 
     def _cutedsl_workspace(self, q_len_capacity: int) -> torch.Tensor:
         """Per-use view of the shared block, sized by the closed-form bound."""
@@ -385,8 +386,11 @@ class CuteDSLMLABackend(AttentionBackend):
         forward_mode: ForwardMode,
         page_table: torch.Tensor,
         seq_lens_cpu: torch.Tensor | None = None,
+        spec_info=None,
         **kwargs,
     ):
+        self.forward_decode_spec_info = spec_info
+
         cache_metadata = kwargs.pop("cache_metadata", None)
         forward_batch = kwargs.pop("forward_batch", None)
         group_table = None
@@ -1013,6 +1017,8 @@ class CuteDSLMLABackend(AttentionBackend):
 
         custom_mask = kwargs.get("custom_mask")
         cmask_off = kwargs.get("cmask_off")
+        if spec_info is None:
+            spec_info = self.forward_decode_spec_info
         if spec_info is not None:
             if custom_mask is None:
                 custom_mask = getattr(spec_info, "custom_mask", None)

--- a/test/runtime/distributed/test_pd_decode_dp_metadata.py
+++ b/test/runtime/distributed/test_pd_decode_dp_metadata.py
@@ -62,9 +62,21 @@ class _FakeLoop:
         self.kv_transfer = (
             object.__new__(DisaggDecodeExecutor) if disagg_decode else None
         )
-        self._dp_local_info = torch.zeros(1, 3, dtype=torch.int32)
-        self._dp_global_info = torch.zeros(world_size, 3, dtype=torch.int32)
+        self._forward_dispatcher = _FakeForwardDispatcher(disagg_decode=disagg_decode)
+        self._dp_local_info = torch.zeros(1, 4, dtype=torch.int32)
+        self._dp_global_info = torch.zeros(world_size, 4, dtype=torch.int32)
         self.world_cpu_group = None
+
+
+class _FakeForwardDispatcher:
+    def __init__(self, *, disagg_decode: bool):
+        self.disagg_decode = disagg_decode
+
+    def produces_model_output(self, forward_op):
+        remote_prefill = (
+            forward_op.num_extends() > 0 and not forward_op.is_local_prefill()
+        )
+        return not (self.disagg_decode and remote_prefill)
 
 
 def _sync(loop, forward_op, monkeypatch, other_rank_rows=()):
@@ -138,7 +150,7 @@ def test_zero_token_forward_op_is_not_model_work(monkeypatch):
 def test_idle_rank_joins_dummy_forward_only_when_a_peer_has_work(monkeypatch):
     # Two ranks: this one idle, the peer running a 4-token decode batch.
     loop = _FakeLoop(world_size=2)
-    busy_peer = (4, 4, int(ForwardMode.DECODE))
+    busy_peer = (4, 4, int(ForwardMode.DECODE), 0)
 
     meta = _sync(loop, None, monkeypatch, other_rank_rows=[busy_peer])
 
@@ -147,6 +159,6 @@ def test_idle_rank_joins_dummy_forward_only_when_a_peer_has_work(monkeypatch):
     assert meta.global_num_tokens == [0, 4]
 
     # Fully idle world: nothing to keep in lockstep with.
-    idle_peer = (0, 0, int(ForwardMode.IDLE))
+    idle_peer = (0, 0, int(ForwardMode.IDLE), 0)
     meta = _sync(loop, None, monkeypatch, other_rank_rows=[idle_peer])
     assert not meta.need_idle_forward

--- a/test/runtime/layers/test_mla_tree_mask_decode.py
+++ b/test/runtime/layers/test_mla_tree_mask_decode.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Blackwell correctness coverage for the FP8 MLA tree-mask kernel path."""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+import unittest
+
+import torch
+
+sys.path.insert(
+    0,
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+)
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(
+    est_time=300,
+    suite="runtime-1gpu",
+    disabled_on_runners=["amd-*"],
+    disabled_on_runners_reason="TokenSpeed MLA decode requires NVIDIA Blackwell",
+)
+
+_HAS_SM100 = torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10
+
+KV_LORA = 512
+ROPE = 64
+HEADS = 128
+PAGE_SIZE = 64
+Q_LEN = 4
+
+
+def _build_mask(seq_lens: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    ancestors = (
+        torch.tril(torch.ones(Q_LEN, Q_LEN, dtype=torch.bool)),
+        torch.tensor(
+            [
+                [1, 0, 0, 0],
+                [1, 1, 0, 0],
+                [1, 0, 1, 0],
+                [1, 1, 0, 1],
+            ],
+            dtype=torch.bool,
+        ),
+    )
+    offsets = torch.empty(len(ancestors), dtype=torch.int32, device="cuda")
+    masks = []
+    offset = 0
+    for batch_idx, ancestor in enumerate(ancestors):
+        seq_len = int(seq_lens[batch_idx])
+        history = seq_len - Q_LEN
+        mask = torch.ones(Q_LEN, seq_len, dtype=torch.bool, device="cuda")
+        mask[:, 1:history:3] = False
+        mask[:, history:] = ancestor.to("cuda")
+        offsets[batch_idx] = offset
+        masks.append(mask.flatten())
+        offset += Q_LEN * seq_len
+    return torch.cat(masks).contiguous(), offsets
+
+
+def _reference(
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    custom_mask: torch.Tensor,
+    cmask_off: torch.Tensor,
+) -> torch.Tensor:
+    output = torch.empty(
+        query.shape[0],
+        Q_LEN,
+        HEADS,
+        KV_LORA,
+        dtype=torch.float32,
+        device="cuda",
+    )
+    query_float = query.float()
+    scale = 1.0 / math.sqrt(KV_LORA + ROPE)
+    for batch_idx in range(query.shape[0]):
+        seq_len = int(seq_lens[batch_idx])
+        mask_start = int(cmask_off[batch_idx])
+        mask = custom_mask[mask_start : mask_start + Q_LEN * seq_len].view(
+            Q_LEN, seq_len
+        )
+        request_kv = kv_cache[block_tables[batch_idx]].reshape(-1, KV_LORA + ROPE)[
+            :seq_len
+        ]
+        scores = torch.einsum("qhd,kd->qhk", query_float[batch_idx], request_kv.float())
+        probabilities = torch.softmax(
+            (scores * scale).masked_fill(~mask[:, None, :], float("-inf")),
+            dim=-1,
+        )
+        output[batch_idx] = torch.einsum(
+            "qhk,kd->qhd", probabilities, request_kv[:, :KV_LORA].float()
+        )
+    return output
+
+
+def _relative_max_error(actual: torch.Tensor, expected: torch.Tensor) -> float:
+    denominator = expected.abs().max().clamp_min(1e-6)
+    return ((actual - expected).abs().max() / denominator).item()
+
+
+@unittest.skipUnless(_HAS_SM100, "TokenSpeed MLA decode requires Blackwell SM100")
+class TestMLATreeMaskDecode(unittest.TestCase):
+    def test_tree_mask_and_default_fp8_abi_match_reference(self):
+        from tokenspeed_mla import tokenspeed_mla_decode
+
+        torch.manual_seed(617)
+        dtype = torch.float8_e4m3fn
+        # Both lengths are non-tile-aligned and span at least three 128-column
+        # KV tiles, exercising global mask indexing for k_index > 0.
+        seq_lens = torch.tensor([300, 391], dtype=torch.int32, device="cuda")
+        max_seq_len = int(seq_lens.max())
+        pages_per_request = (max_seq_len + PAGE_SIZE - 1) // PAGE_SIZE
+        block_tables = torch.arange(
+            len(seq_lens) * pages_per_request, dtype=torch.int32, device="cuda"
+        ).view(len(seq_lens), pages_per_request)
+        query = (
+            torch.randn(
+                len(seq_lens),
+                Q_LEN,
+                HEADS,
+                KV_LORA + ROPE,
+                device="cuda",
+            )
+            * 0.3
+        ).to(dtype)
+        kv_cache = (
+            torch.randn(
+                len(seq_lens) * pages_per_request,
+                PAGE_SIZE,
+                KV_LORA + ROPE,
+                device="cuda",
+            )
+            * 0.3
+        ).to(dtype)
+        workspace = torch.empty(1 << 29, dtype=torch.int8, device="cuda")
+        custom_mask, cmask_off = _build_mask(seq_lens)
+
+        def decode(**mask_kwargs):
+            return tokenspeed_mla_decode(
+                query=query,
+                kv_cache=kv_cache,
+                workspace_buffer=workspace,
+                kv_lora_rank=KV_LORA,
+                qk_rope_head_dim=ROPE,
+                block_tables=block_tables,
+                seq_lens=seq_lens,
+                max_seq_len=max_seq_len,
+                softmax_scale=1.0 / math.sqrt(KV_LORA + ROPE),
+                causal_mask=False,
+                **mask_kwargs,
+            ).float()
+
+        expected_tree = _reference(
+            query, kv_cache, block_tables, seq_lens, custom_mask, cmask_off
+        )
+        actual_tree = decode(custom_mask=custom_mask, cmask_off=cmask_off)
+        derived_offset_tree = decode(custom_mask=custom_mask)
+
+        full_mask = torch.ones_like(custom_mask)
+        expected_full = _reference(
+            query, kv_cache, block_tables, seq_lens, full_mask, cmask_off
+        )
+        actual_full = decode()
+
+        self.assertLess(_relative_max_error(actual_tree, expected_tree), 6e-2)
+        self.assertLess(_relative_max_error(actual_full, expected_full), 6e-2)
+        torch.testing.assert_close(actual_tree, derived_offset_tree, rtol=0, atol=0)
+
+        self.assertGreater(_relative_max_error(expected_tree, expected_full), 6e-2)
+        self.assertGreater(_relative_max_error(actual_tree, actual_full), 6e-2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/runtime/layers/test_mla_verify_metadata.py
+++ b/test/runtime/layers/test_mla_verify_metadata.py
@@ -5,6 +5,9 @@ from types import SimpleNamespace
 import torch
 
 from tokenspeed.runtime.layers.attention.backends import mla as mla_backend
+from tokenspeed.runtime.layers.attention.backends import (
+    tokenspeed_mla as tokenspeed_mla_backend,
+)
 
 
 def _run_mla_decode(
@@ -92,3 +95,70 @@ def test_fp8_decode_dispatches_with_native_fp8_query(monkeypatch):
     )
 
     assert captured["q"].dtype == torch.float8_e4m3fn
+
+
+def test_tokenspeed_mla_forwards_cached_tree_mask_metadata(monkeypatch):
+    captured = {}
+
+    def fake_tokenspeed_mla_decode(**kwargs):
+        captured.update(kwargs)
+        query = kwargs["query"]
+        return torch.zeros(*query.shape[:-1], 4)
+
+    monkeypatch.setattr(
+        tokenspeed_mla_backend,
+        "tokenspeed_mla_decode",
+        fake_tokenspeed_mla_decode,
+    )
+    monkeypatch.setattr(
+        tokenspeed_mla_backend,
+        "get_cutedsl_workspace_buffer",
+        lambda *args, **kwargs: torch.empty(0, dtype=torch.int8),
+    )
+
+    custom_mask = torch.tensor([1, 1, 1, 0], dtype=torch.int8)
+    cmask_off = torch.tensor([0], dtype=torch.int32)
+    backend = object.__new__(tokenspeed_mla_backend.CuteDSLMLABackend)
+    backend.forward_decode_metadata = SimpleNamespace(
+        num_extends=0,
+        block_kv_indices=torch.zeros(1, 1, dtype=torch.int32),
+        seq_lens_k=torch.tensor([4], dtype=torch.int32),
+        max_seq_len_k=4,
+    )
+    backend.forward_decode_spec_info = SimpleNamespace(
+        custom_mask=custom_mask,
+        cmask_off=cmask_off,
+    )
+    backend._cache_groups_bound = False
+    backend.kernel_page_size = 4
+    backend.kv_lora_rank = 2
+    backend.qk_rope_head_dim = 2
+    backend.kv_cache_dim = 4
+    backend.data_type = torch.float32
+    backend.cutedsl_workspace = torch.empty(0, dtype=torch.int8)
+
+    layer = SimpleNamespace(
+        tp_q_head_num=1,
+        head_dim=4,
+        v_head_dim=4,
+        scaling=1.0,
+        k_scale_float=None,
+        layer_id=0,
+    )
+    token_to_kv_pool = SimpleNamespace(
+        get_key_buffer=lambda layer_id: torch.zeros(4, 4)
+    )
+
+    backend.forward_decode(
+        q=torch.zeros(1, 4),
+        k=None,
+        v=None,
+        layer=layer,
+        out_cache_loc=torch.empty(0, dtype=torch.int32),
+        token_to_kv_pool=token_to_kv_pool,
+        bs=1,
+        save_kv_cache=False,
+    )
+
+    assert captured["custom_mask"] is custom_mask
+    assert captured["cmask_off"] is cmask_off

--- a/test/runtime/test_cudagraph_per_group.py
+++ b/test/runtime/test_cudagraph_per_group.py
@@ -135,6 +135,28 @@ class CacheGroupIdsTest(_TorchCase):
         self.assertEqual(out, ())
 
 
+class TreeMaskGraphRoutingTest(_TorchCase):
+    """Tree-mask metadata must bypass graphs captured for causal decode."""
+
+    def setUp(self):
+        super().setUp()
+        from tokenspeed.runtime.execution.cuda_graph_wrapper import (
+            CudaGraphWrapper,
+        )
+
+        self.has_tree_mask = CudaGraphWrapper._has_custom_tree_mask
+
+    def test_detects_only_mask_bearing_spec_info(self):
+        torch = self.torch
+        self.assertFalse(self.has_tree_mask(None))
+        self.assertFalse(self.has_tree_mask(SimpleNamespace(custom_mask=None)))
+        self.assertTrue(
+            self.has_tree_mask(
+                SimpleNamespace(custom_mask=torch.ones(1, dtype=torch.int8))
+            )
+        )
+
+
 class DraftCacheGroupIdsTest(_TorchCase):
     """DFLASH owns an independent draft page table; EAGLE-style drafts use
     target cache-group tables at matching page ids."""

--- a/test/runtime/test_cudagraph_per_group.py
+++ b/test/runtime/test_cudagraph_per_group.py
@@ -170,7 +170,7 @@ class DraftTreeMaskMetadataIsolationTest(_TorchCase):
         captured = {"target": [], "draft": []}
 
         class FakeBackend:
-            uses_paged_cache_groups = False
+            needs_group_block_tables = False
 
             def __init__(self, key):
                 self.key = key

--- a/test/runtime/test_cudagraph_per_group.py
+++ b/test/runtime/test_cudagraph_per_group.py
@@ -157,6 +157,52 @@ class TreeMaskGraphRoutingTest(_TorchCase):
         )
 
 
+class DraftTreeMaskMetadataIsolationTest(_TorchCase):
+    """Target verify masks must not become draft attention metadata."""
+
+    def test_mixed_batch_drops_target_spec_info_from_draft_metadata(self):
+        torch = self.torch
+        from tokenspeed.runtime.execution.cuda_graph_wrapper import (
+            CudaGraphWrapper,
+        )
+        from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
+
+        captured = {"target": [], "draft": []}
+
+        class FakeBackend:
+            uses_paged_cache_groups = False
+
+            def __init__(self, key):
+                self.key = key
+
+            def init_forward_metadata(self, *args, **kwargs):
+                captured[self.key].append((args, kwargs))
+
+        wrapper = object.__new__(CudaGraphWrapper)
+        wrapper.attn_backend = FakeBackend("target")
+        wrapper.draft_attn_backend = FakeBackend("draft")
+        wrapper.max_tokens_per_req = 4
+        wrapper.drafter = SimpleNamespace(
+            cache_view=SimpleNamespace(table=torch.zeros((1, 1), dtype=torch.int32)),
+            draft_seq_lens_buf=torch.zeros(2, dtype=torch.int32),
+        )
+        wrapper.use_v4_mtp_paged_metadata = False
+
+        target_spec_info = SimpleNamespace(custom_mask=torch.ones(4, dtype=torch.int8))
+        wrapper._init_forward_metadata(
+            padded_bs=2,
+            num_extends=1,
+            req_pool_indices=torch.zeros(2, dtype=torch.int32),
+            seq_lens=torch.tensor([21, 22], dtype=torch.int32),
+            page_table=torch.zeros((1, 1), dtype=torch.int32),
+            forward_mode=ForwardMode.MIXED,
+            spec_info=target_spec_info,
+        )
+
+        self.assertIs(captured["target"][0][1]["spec_info"], target_spec_info)
+        self.assertNotIn("spec_info", captured["draft"][0][1])
+
+
 class DraftCacheGroupIdsTest(_TorchCase):
     """DFLASH owns an independent draft page table; EAGLE-style drafts use
     target cache-group tables at matching page ids."""

--- a/test/runtime/test_dp_sampling_routing_metadata.py
+++ b/test/runtime/test_dp_sampling_routing_metadata.py
@@ -187,6 +187,33 @@ def test_cuda_graph_route_uses_global_batch_for_dp_idle_rank():
     ) == (True, 32)
 
 
+@pytest.mark.parametrize(
+    ("bs", "input_num_tokens"),
+    [(2, 2), (0, 0)],
+)
+def test_cuda_graph_route_uses_dp_wide_tree_mask_bypass(bs: int, input_num_tokens: int):
+    ctx = ForwardContext(
+        attn_backend=None,
+        token_to_kv_pool=None,
+        bs=bs,
+        num_extends=0,
+        input_num_tokens=input_num_tokens,
+        forward_mode=ForwardMode.DECODE,
+        global_num_tokens=[2, 0],
+        all_decode_or_idle=True,
+        any_custom_tree_mask=True,
+    )
+
+    assert _graph_route(
+        bs,
+        ctx,
+        dp_size=2,
+        max_bs=32,
+        capture_bs=[16, 32],
+        max_tokens_per_req=1,
+    ) == (False, bs)
+
+
 def test_cuda_graph_route_respects_disable_padding_with_global_batch():
     ctx = ForwardContext(
         attn_backend=None,

--- a/test/runtime/test_dp_tree_mask_metadata.py
+++ b/test/runtime/test_dp_tree_mask_metadata.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+import torch
+
+# CPU-only tests scheduled in runtime-1gpu because they import the full runtime.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=5, suite="runtime-1gpu")
+
+from tokenspeed.runtime.engine.event_loop import EventLoop  # noqa: E402
+from tokenspeed.runtime.execution.forward_batch_info import ForwardMode  # noqa: E402
+
+
+def _forward_op(custom_mask):
+    return SimpleNamespace(
+        input_lengths=[2],
+        request_ids=["request-0"],
+        spec_info=SimpleNamespace(custom_mask=custom_mask),
+        num_extends=lambda: 0,
+    )
+
+
+def _event_loop_stub():
+    return SimpleNamespace(
+        _forward_dispatcher=SimpleNamespace(
+            produces_model_output=lambda forward_op: True
+        ),
+        world_cpu_group=object(),
+        _dp_local_info=torch.zeros(1, 4, dtype=torch.int32),
+        _dp_global_info=torch.zeros(2, 4, dtype=torch.int32),
+    )
+
+
+def test_dp_sync_publishes_local_tree_mask(monkeypatch):
+    loop = _event_loop_stub()
+    global_info = torch.tensor(
+        [
+            [2, 1, int(ForwardMode.DECODE), 1],
+            [0, 0, int(ForwardMode.IDLE), 0],
+        ],
+        dtype=torch.int32,
+    )
+
+    def fake_all_gather(output, local, *, group):
+        assert group is loop.world_cpu_group
+        assert local[0, 3].item() == 1
+        output.copy_(global_info)
+
+    monkeypatch.setattr(torch.distributed, "all_gather_into_tensor", fake_all_gather)
+
+    metadata = EventLoop._dp_sync_and_check(
+        loop, _forward_op(torch.ones(1, dtype=torch.int8))
+    )
+
+    assert metadata.any_custom_tree_mask
+    assert not metadata.need_idle_forward
+
+
+def test_dp_sync_propagates_remote_tree_mask_to_idle_rank(monkeypatch):
+    loop = _event_loop_stub()
+    global_info = torch.tensor(
+        [
+            [0, 0, int(ForwardMode.IDLE), 0],
+            [2, 1, int(ForwardMode.DECODE), 1],
+        ],
+        dtype=torch.int32,
+    )
+
+    def fake_all_gather(output, local, *, group):
+        assert group is loop.world_cpu_group
+        assert local[0, 3].item() == 0
+        output.copy_(global_info)
+
+    monkeypatch.setattr(torch.distributed, "all_gather_into_tensor", fake_all_gather)
+
+    metadata = EventLoop._dp_sync_and_check(loop, None)
+
+    assert metadata.any_custom_tree_mask
+    assert metadata.need_idle_forward
+    assert metadata.all_decode_or_idle

--- a/test/runtime/test_draft_page_table_scrub.py
+++ b/test/runtime/test_draft_page_table_scrub.py
@@ -154,6 +154,7 @@ class IdleReplayScrubTest(unittest.TestCase):
                 global_forward_mode=[int(ForwardMode.IDLE)],
                 all_decode_or_idle=True,
                 all_extend=False,
+                any_custom_tree_mask=False,
                 need_idle_forward=True,
             ),
         )

--- a/tokenspeed-mla/python/tokenspeed_mla/mla_decode.py
+++ b/tokenspeed-mla/python/tokenspeed_mla/mla_decode.py
@@ -586,6 +586,12 @@ def tokenspeed_mla_decode(
     elif q_dtype == torch.float8_e4m3fn:
         cmask_k, cmask_off_k = _get_dummy_tree_mask_tensors(query.device, B)
 
+    if tree_mask_mode and (cp_world > 1 or causal_seqs is not None):
+        raise ValueError(
+            "custom_mask is not currently supported with decode-context-parallel "
+            "causal bounds (cp_world > 1 or causal_seqs is set)"
+        )
+
     # Runtime validation (int comparisons only, negligible overhead)
     if max_seq_len <= 0:
         raise ValueError(f"max_seq_len must be > 0, got {max_seq_len}")

--- a/tokenspeed-mla/python/tokenspeed_mla/mla_decode.py
+++ b/tokenspeed-mla/python/tokenspeed_mla/mla_decode.py
@@ -50,6 +50,39 @@ from tokenspeed_mla.utils import (
 )
 
 
+_DUMMY_TREE_MASK_CACHE: dict[tuple[str, int], tuple[torch.Tensor, torch.Tensor]] = {}
+_ZERO_CMASK_OFF_CACHE: dict[str, torch.Tensor] = {}
+
+
+def _get_dummy_tree_mask_tensors(
+    device: torch.device, batch_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Persistent placeholders for the FP8 tree-mask kernel ABI.
+
+    In non-tree mode the tree branch is compiled out and these tensors are not
+    read. They still need stable device addresses, and cmask_off must carry the
+    runtime batch shape expected by the FFI call.
+    """
+
+    key = (str(device), int(batch_size))
+    cached = _DUMMY_TREE_MASK_CACHE.get(key)
+    if cached is None:
+        cached = (
+            torch.empty(1, dtype=torch.int8, device=device),
+            torch.empty(batch_size, dtype=torch.int32, device=device),
+        )
+        _DUMMY_TREE_MASK_CACHE[key] = cached
+    return cached
+
+
+def _get_zero_cmask_off_tensor(device: torch.device) -> torch.Tensor:
+    cached = _ZERO_CMASK_OFF_CACHE.get(str(device))
+    if cached is None:
+        cached = torch.zeros(1, dtype=torch.int32, device=device)
+        _ZERO_CMASK_OFF_CACHE[str(device)] = cached
+    return cached
+
+
 @functools.cache
 def _get_split_kv_and_workspace_size(
     B: int,
@@ -159,6 +192,7 @@ def _get_compiled_mla_kernel(
     num_heads: int = 128,
     seq_len_q: int = 1,
     cp_world: int = 1,  # DCP world size; >1 enables strided global-coord causal masking
+    tree_mask_mode: bool = False,
     use_pdl: bool = False,
     return_lse: bool = False,  # DCP: enable LSE output
     compute_capability: tuple[int, int] = (0, 0),
@@ -166,7 +200,8 @@ def _get_compiled_mla_kernel(
     """Compile and cache an MLA decode kernel.
 
     Returns a callable that accepts (q_latent, q_rope, c_latent, c_rope,
-    page_table, o, lse (None to skip), workspace, split_kv_scalar, cache_seqs,
+    page_table, [custom_mask, cmask_off, custom_mask_len for FP8], o,
+    lse (None to skip), workspace, split_kv_scalar, cache_seqs,
     block_split_kvs, softmax_scale_scalar, output_scale_scalar).
 
     All scalar arguments must be pre-wrapped as Int32/Float32.
@@ -210,6 +245,7 @@ def _get_compiled_mla_kernel(
     if is_fp8:
         # DCP (cp_world) strided global-coordinate causal masking is fp8-only.
         kernel_kwargs["cp_world"] = cp_world
+        kernel_kwargs["tree_mask_mode"] = tree_mask_mode
     kernel_obj = KernelClass(**kernel_kwargs)
 
     # All dimensions as sym_int — this matches the original kernel's use of
@@ -269,6 +305,20 @@ def _get_compiled_mla_kernel(
         stride_order=(1, 0),
         assumed_align=4,
     )
+    if is_fp8:
+        # Flattened per-request tree mask, int8 view of bool values
+        # (nonzero=attend). cmask_off[b] points to request b's row-major
+        # [seq_len_q x K_b] block inside custom_mask.
+        custom_mask_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int8,
+            (cute.sym_int(),),
+            assumed_align=1,
+        )
+        cmask_off_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (sym_batch,),
+            assumed_align=4,
+        )
     # o: [batch_size, seq_len_q, num_heads, latent_dim] — contiguous
     o_fake = cute.runtime.make_fake_compact_tensor(
         cutlass_out_dtype,
@@ -329,24 +379,33 @@ def _get_compiled_mla_kernel(
         c_latent_fake,
         c_rope_fake,
         page_table_fake,
-        o_fake,
-        lse_fake,
-        workspace_fake,
-        Int32(1),  # split_kv placeholder
-        cache_seqs_fake,
     ]
+    if is_fp8:
+        compile_args.extend([custom_mask_fake, cmask_off_fake, Int32(1)])
+    compile_args.extend(
+        [
+            o_fake,
+            lse_fake,
+            workspace_fake,
+            Int32(1),  # split_kv placeholder
+            cache_seqs_fake,
+        ]
+    )
     # DCP causal bound is an fp8-decode-kernel-only argument (see the call site).
     if is_fp8:
         compile_args.append(causal_seqs_fake)
-    compile_args += [
-        block_split_kvs_fake,
-        Float32(1.0),  # softmax_scale placeholder
-        Float32(1.0),  # output_scale placeholder
-        stream_fake,
-        use_pdl,
-    ]
+    compile_args.extend(
+        [
+            block_split_kvs_fake,
+            Float32(1.0),  # softmax_scale placeholder
+            Float32(1.0),  # output_scale placeholder
+            stream_fake,
+            use_pdl,
+        ]
+    )
     compiled_kernel = cute.compile(
-        *compile_args, options="--enable-tvm-ffi --opt-level 2"
+        *compile_args,
+        options="--enable-tvm-ffi --opt-level 2",
     )
 
     return compiled_kernel
@@ -373,6 +432,8 @@ def tokenspeed_mla_decode(
     ] = None,  # per-request global causal bound; None = local (non-DCP)
     cp_world: int = 1,  # decode-context-parallel world size (1 = no DCP)
     cp_rank: int = 0,  # this rank's index in [0, cp_world); subtracted from causal_seqs
+    custom_mask: Optional[torch.Tensor] = None,
+    cmask_off: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """CuTe DSL MLA decode kernel for Blackwell SM100.
 
@@ -441,6 +502,15 @@ def tokenspeed_mla_decode(
         bound is ``ceil((causal_seqs - cp_rank) / cp_world)``; the wrapper folds
         ``cp_rank`` in for you, so callers pass the same global ``causal_seqs`` on
         every rank. Must be 0 when ``cp_world == 1``.
+    custom_mask : Optional[torch.Tensor]
+        Optional flattened FP8 tree attention mask. The mask is per request,
+        row-major [q_len x K_b], concatenated over the batch, with nonzero
+        values indicating that a query token can attend to a KV column. History
+        columns are normally all True and the last q_len columns carry the tree
+        ancestry. Supported on the FP8 kernel path.
+    cmask_off : Optional[torch.Tensor]
+        Optional int32 [B] base offsets into custom_mask. CUDA graph callers
+        should pass this explicitly for B > 1 to avoid deriving a fresh tensor.
 
     Returns
     -------
@@ -477,6 +547,44 @@ def tokenspeed_mla_decode(
 
     # Page table: [B, max_pages]: passed directly, kernel reinterprets.
     page_table_k = block_tables
+
+    # cache_seqs: per-batch sequence lengths (skip .to() if already int32)
+    cache_seqs = seq_lens if seq_lens.dtype == torch.int32 else seq_lens.to(torch.int32)
+
+    tree_mask_mode = custom_mask is not None
+    if tree_mask_mode:
+        if q_dtype != torch.float8_e4m3fn:
+            raise ValueError("custom_mask is currently supported only for FP8 MLA decode")
+        if custom_mask.device != query.device:
+            raise ValueError("custom_mask must be on the same device as query")
+        if custom_mask.dtype not in (torch.bool, torch.int8):
+            raise ValueError(
+                f"custom_mask must be torch.bool or torch.int8, got {custom_mask.dtype}"
+            )
+        if not custom_mask.is_contiguous():
+            raise ValueError("custom_mask must be contiguous")
+        cmask_k = custom_mask.view(torch.int8).view(-1)
+        if cmask_k.numel() == 0:
+            raise ValueError("custom_mask must not be empty")
+        if cmask_off is not None:
+            if cmask_off.device != query.device:
+                raise ValueError("cmask_off must be on the same device as query")
+            if cmask_off.dtype != torch.int32:
+                raise ValueError(f"cmask_off must be torch.int32, got {cmask_off.dtype}")
+            if not cmask_off.is_contiguous():
+                raise ValueError("cmask_off must be contiguous")
+            if cmask_off.numel() != B:
+                raise ValueError(
+                    f"cmask_off must have {B} entries, got {cmask_off.numel()}"
+                )
+            cmask_off_k = cmask_off
+        elif B == 1:
+            cmask_off_k = _get_zero_cmask_off_tensor(query.device)
+        else:
+            excl = torch.cumsum(cache_seqs, dim=0, dtype=torch.int32) - cache_seqs
+            cmask_off_k = (q_len * excl).to(torch.int32)
+    elif q_dtype == torch.float8_e4m3fn:
+        cmask_k, cmask_off_k = _get_dummy_tree_mask_tensors(query.device, B)
 
     # Runtime validation (int comparisons only, negligible overhead)
     if max_seq_len <= 0:
@@ -621,6 +729,7 @@ def tokenspeed_mla_decode(
         num_heads=H,
         seq_len_q=q_len,
         cp_world=cp_world,
+        tree_mask_mode=tree_mask_mode,
         use_pdl=enable_pdl,
         return_lse=return_lse,
         compute_capability=compute_capability,
@@ -645,21 +754,29 @@ def tokenspeed_mla_decode(
         c_latent_k,
         c_rope_k,
         page_table_k,
-        o_k,
-        lse_real,
-        workspace_bytes,
-        Int32(split_kv),
-        cache_seqs,
     ]
+    if is_fp8:
+        call_args.extend([cmask_k, cmask_off_k, Int32(cmask_k.numel())])
+    call_args.extend(
+        [
+            o_k,
+            lse_real,
+            workspace_bytes,
+            Int32(split_kv),
+            cache_seqs,
+        ]
+    )
     # DCP: the per-request global causal bound is an fp8-decode-kernel-only
     # argument; the fp16 kernel masks against the local cache length.
     if is_fp8:
         call_args.append(causal_seqs_dev)
-    call_args += [
-        block_split_kvs,
-        Float32(softmax_scale),
-        Float32(output_scale),
-    ]
+    call_args.extend(
+        [
+            block_split_kvs,
+            Float32(softmax_scale),
+            Float32(output_scale),
+        ]
+    )
 
     with tvm_ffi.use_torch_stream():
         compiled_kernel(*call_args)

--- a/tokenspeed-mla/python/tokenspeed_mla/mla_decode.py
+++ b/tokenspeed-mla/python/tokenspeed_mla/mla_decode.py
@@ -49,7 +49,6 @@ from tokenspeed_mla.utils import (
     torch_to_cutlass_dtype,
 )
 
-
 _DUMMY_TREE_MASK_CACHE: dict[tuple[str, int], tuple[torch.Tensor, torch.Tensor]] = {}
 _ZERO_CMASK_OFF_CACHE: dict[str, torch.Tensor] = {}
 
@@ -554,7 +553,9 @@ def tokenspeed_mla_decode(
     tree_mask_mode = custom_mask is not None
     if tree_mask_mode:
         if q_dtype != torch.float8_e4m3fn:
-            raise ValueError("custom_mask is currently supported only for FP8 MLA decode")
+            raise ValueError(
+                "custom_mask is currently supported only for FP8 MLA decode"
+            )
         if custom_mask.device != query.device:
             raise ValueError("custom_mask must be on the same device as query")
         if custom_mask.dtype not in (torch.bool, torch.int8):
@@ -570,7 +571,9 @@ def tokenspeed_mla_decode(
             if cmask_off.device != query.device:
                 raise ValueError("cmask_off must be on the same device as query")
             if cmask_off.dtype != torch.int32:
-                raise ValueError(f"cmask_off must be torch.int32, got {cmask_off.dtype}")
+                raise ValueError(
+                    f"cmask_off must be torch.int32, got {cmask_off.dtype}"
+                )
             if not cmask_off.is_contiguous():
                 raise ValueError("cmask_off must be contiguous")
             if cmask_off.numel() != B:

--- a/tokenspeed-mla/python/tokenspeed_mla/mla_decode_fp8.py
+++ b/tokenspeed-mla/python/tokenspeed_mla/mla_decode_fp8.py
@@ -3228,9 +3228,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         if within_kv:
                             if cute.elem_less(cutlass.Int32(-1), cm_idx):
                                 if cute.elem_less(cm_idx, common_params.cmask_len):
-                                    cm_keep = cute.elem_less(
-                                        cutlass.Int32(0),
-                                        cutlass.Int32(common_params.cmask[cm_idx]),
+                                    cm_keep = (
+                                        cutlass.Int32(common_params.cmask[cm_idx])
+                                        != cutlass.Int32(0)
                                     )
                                     tTR_rAcc[i] = (
                                         tTR_rAcc[i]
@@ -3338,9 +3338,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         if within_kv:
                             if cute.elem_less(cutlass.Int32(-1), cm_idx):
                                 if cute.elem_less(cm_idx, common_params.cmask_len):
-                                    cm_keep = cute.elem_less(
-                                        cutlass.Int32(0),
-                                        cutlass.Int32(common_params.cmask[cm_idx]),
+                                    cm_keep = (
+                                        cutlass.Int32(common_params.cmask[cm_idx])
+                                        != cutlass.Int32(0)
                                     )
                                     tTR_rAcc[i] = (
                                         tTR_rAcc[i]

--- a/tokenspeed-mla/python/tokenspeed_mla/mla_decode_fp8.py
+++ b/tokenspeed-mla/python/tokenspeed_mla/mla_decode_fp8.py
@@ -2813,22 +2813,23 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         correction_factor = self.acc_dtype(1)
         common_params.p_cor_pipeline.producer_acquire(p_cor_producer_state)
 
-        # Number of tiles from the global-K end that may contain masked
-        # positions. Causal and tree masks both touch the last S_q KV columns,
-        # which can span up to ceil((S_q-1)/tile_N)+1 tiles in boundary cases.
-        # Non-causal dense attention only needs the final K-bound tile.
-        tile_n = self.mma_qk_tiler[1]
-        if cutlass.const_expr(self.is_causal or self.tree_mask_mode):
-            mask_tile_count = (self.seq_len_q - 1 + tile_n - 1) // tile_n + 1
+        # A custom tree mask is a full [S_q x K] matrix, so every global-K tile
+        # may contain denied positions. Causal masking only touches the last
+        # S_q KV columns, while non-causal dense attention only needs the final
+        # K-bound tile.
+        if cutlass.const_expr(self.tree_mask_mode):
+            first_mask_tile_idx = cutlass.Int32(0)
         else:
-            mask_tile_count = 1
+            tile_n = self.mma_qk_tiler[1]
+            if cutlass.const_expr(self.is_causal):
+                mask_tile_count = (self.seq_len_q - 1 + tile_n - 1) // tile_n + 1
+            else:
+                mask_tile_count = 1
 
-        # first_mask_tile_idx is the global index of the first tile that may
-        # need masking. Runtime because it depends on K (per-batch in
-        # var-seq / split-KV).
-        first_mask_tile_idx = k_tile_total - mask_tile_count
+            # Runtime because it depends on K (per-batch in var-seq / split-KV).
+            first_mask_tile_idx = k_tile_total - mask_tile_count
 
-        # Phase 1: pure unmasked bulk tiles (all columns strictly < min k_bound).
+        # Phase 1: pure unmasked bulk tiles (not used for a full custom mask).
         while k_tile_count > 1 and k_index < first_mask_tile_idx:
             (
                 mma_s_consumer_state,
@@ -2853,8 +2854,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             k_index = k_index + 1
             k_tile_count = k_tile_count - 1
 
-        # Phase 2: intermediate tiles that overlap the causal/K-bound region
-        # but are not this work-split's final tile.
+        # Phase 2: intermediate tiles that require mask evaluation but are not
+        # this work-split's final tile.
         while k_tile_count > 1:
             (
                 mma_s_consumer_state,

--- a/tokenspeed-mla/python/tokenspeed_mla/mla_decode_fp8.py
+++ b/tokenspeed-mla/python/tokenspeed_mla/mla_decode_fp8.py
@@ -220,6 +220,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         num_heads: int = 128,
         seq_len_q: int = 1,
         cp_world: int = 1,  # DCP world size; >1 enables strided global-coord causal masking
+        tree_mask_mode: bool = False,
     ):
         """Initializes the configuration for a Blackwell Multi-Head Latent Attention (MLA) kernel.
 
@@ -266,6 +267,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         self.num_heads = num_heads
         self.seq_len_q = seq_len_q
         self.cp_world = cp_world
+        # In tree-mask mode, the causal tail predicate is replaced by a direct
+        # lookup into a flattened per-request mask supplied by the caller.
+        self.tree_mask_mode = tree_mask_mode
         if mma_qk_tiler_mn[0] == 128:
             self.cluster_shape_mnk = (2, 1, 1)
             self.use_2cta_instrs = True
@@ -403,6 +407,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         c_latent: cute.Tensor,
         c_rope: cute.Tensor,
         page_table: cute.Tensor,
+        custom_mask: cute.Tensor,
+        cmask_off: cute.Tensor,
+        custom_mask_len: cutlass.Int32,
         o: cute.Tensor,
         lse: Optional[cute.Tensor],
         workspace: cute.Tensor,
@@ -435,6 +442,12 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         :type c_rope: cute.Tensor
         :param page_table: The page table tensor with shape [batch_size, page_count] (contiguous)
         :type page_table: cute.Tensor
+        :param custom_mask: Flattened per-request tree mask, int8/bool values where nonzero means attend
+        :type custom_mask: cute.Tensor
+        :param cmask_off: Per-request int32 base offsets into custom_mask
+        :type cmask_off: cute.Tensor
+        :param custom_mask_len: Number of flattened int8 entries in custom_mask
+        :type custom_mask_len: cutlass.Int32
         :param o: The output tensor with shape [batch_size, seq_len_q, num_head, latent_dim] (contiguous)
         :type o: cute.Tensor
         :param lse: The LSE tensor with shape [batch_size, seq_len_q, num_head] (contiguous)
@@ -949,6 +962,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             tma_atom_c_latent_transpose,
             tma_tensor_c_latent_transpose,
             page_table,
+            custom_mask,
+            cmask_off,
+            custom_mask_len,
             o,
             lse if not self.skip_lse else None,
             acc_o,
@@ -1057,6 +1073,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         tma_atom_c_latent_transpose: Optional[cute.CopyAtom],
         mCLT: cute.Tensor,
         mPT: cute.Tensor,
+        mCmask: cute.Tensor,
+        mCmaskOff: cute.Tensor,
+        custom_mask_len: cutlass.Int32,
         mO: Optional[cute.Tensor],
         mLSE: Optional[cute.Tensor],
         mAccO: Optional[cute.Tensor],
@@ -1566,6 +1585,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         mO=mO,
                         K=cache_seqs[blk_coord[2]],
                         K_causal=causal_seqs[blk_coord[2]],
+                        cmask=mCmask,
+                        cmask_off=mCmaskOff,
+                        cmask_len=custom_mask_len,
                         L=mCL.shape[1],
                         tmem_ptr=tmem_ptr,
                         tidx=tidx,
@@ -2791,12 +2813,12 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         correction_factor = self.acc_dtype(1)
         common_params.p_cor_pipeline.producer_acquire(p_cor_producer_state)
 
-        # Number of tiles from the global-K end that may contain causal-masked
-        # positions. For causal, min k_bound = K - (S_q-1), which can span up
-        # to ceil((S_q-1)/tile_N)+1 tiles (tile-boundary-crossing case).
-        # Non-causal only needs the final K-bound tile.
+        # Number of tiles from the global-K end that may contain masked
+        # positions. Causal and tree masks both touch the last S_q KV columns,
+        # which can span up to ceil((S_q-1)/tile_N)+1 tiles in boundary cases.
+        # Non-causal dense attention only needs the final K-bound tile.
         tile_n = self.mma_qk_tiler[1]
-        if cutlass.const_expr(self.is_causal):
+        if cutlass.const_expr(self.is_causal or self.tree_mask_mode):
             mask_tile_count = (self.seq_len_q - 1 + tile_n - 1) // tile_n + 1
         else:
             mask_tile_count = 1
@@ -3178,7 +3200,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
                 if apply_mask:
                     qk_col = tTR_tS[i][1]
-                    if cutlass.const_expr(self.is_causal):
+                    if cutlass.const_expr(self.tree_mask_mode):
                         if cutlass.const_expr(self.fold_sq_factor > 1):
                             qk_row = tTR_tS[i][0]
                             q_tok = (
@@ -3188,32 +3210,74 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                             )
                         else:
                             q_tok = common_params.blk_coord[1]
-                        if cutlass.const_expr(self.cp_world == 1):
-                            # Non-DCP: causal bound is the full local context length
-                            # (identical to the pre-DCP behavior; folded at compile time).
-                            k_bound = common_params.K - (self.seq_len_q - 1) + q_tok
-                        else:
-                            # DCP (cp_world>1): this rank holds a strided 1/cp_world slice of
-                            # the context (key c -> global position c*cp_world + dcp_rank). The
-                            # causal bound is therefore taken over the GLOBAL length passed in
-                            # K_causal (= global_seq - dcp_rank), divided by cp_world.
-                            k_bound = (
-                                common_params.K_causal
-                                - (self.seq_len_q - 1)
-                                + q_tok
-                                + self.cp_world
-                                - 1
-                            ) // self.cp_world
-                    else:
-                        k_bound = common_params.K
-                    tTR_rAcc[i] = (
-                        tTR_rAcc[i]
-                        if cute.elem_less(
-                            qk_col + self.mma_qk_tiler[1] * k_index,
-                            k_bound,
+                        kcol = qk_col + self.mma_qk_tiler[1] * k_index
+                        # custom_mask is row-major [seq_len_q x K] per request
+                        # (nonzero=attend). Padding columns and malformed
+                        # offsets must not drive an out-of-bounds mask read.
+                        within_kv = cute.elem_less(kcol, common_params.K)
+                        kcol_in = (
+                            kcol
+                            if within_kv
+                            else cutlass.Int32(common_params.K - 1)
                         )
-                        else self.acc_dtype(-1.0e6)
-                    )
+                        cm_idx = (
+                            common_params.cmask_off[common_params.blk_coord[2]]
+                            + q_tok * common_params.K
+                            + kcol_in
+                        )
+                        if within_kv:
+                            if cute.elem_less(cutlass.Int32(-1), cm_idx):
+                                if cute.elem_less(cm_idx, common_params.cmask_len):
+                                    cm_keep = cute.elem_less(
+                                        cutlass.Int32(0),
+                                        cutlass.Int32(common_params.cmask[cm_idx]),
+                                    )
+                                    tTR_rAcc[i] = (
+                                        tTR_rAcc[i]
+                                        if cm_keep
+                                        else self.acc_dtype(-1.0e6)
+                                    )
+                                else:
+                                    tTR_rAcc[i] = self.acc_dtype(-1.0e6)
+                            else:
+                                tTR_rAcc[i] = self.acc_dtype(-1.0e6)
+                        else:
+                            tTR_rAcc[i] = self.acc_dtype(-1.0e6)
+                    else:
+                        if cutlass.const_expr(self.is_causal):
+                            if cutlass.const_expr(self.fold_sq_factor > 1):
+                                qk_row = tTR_tS[i][0]
+                                q_tok = (
+                                    common_params.blk_coord[1] * self.fold_sq_factor
+                                    + (qk_row + common_params.blk_coord[0] * cta_m_rows)
+                                    // self.num_heads
+                                )
+                            else:
+                                q_tok = common_params.blk_coord[1]
+                            if cutlass.const_expr(self.cp_world == 1):
+                                # Non-DCP: causal bound is the full local context length.
+                                k_bound = (
+                                    common_params.K - (self.seq_len_q - 1) + q_tok
+                                )
+                            else:
+                                # DCP: local keys are a strided slice of global positions.
+                                k_bound = (
+                                    common_params.K_causal
+                                    - (self.seq_len_q - 1)
+                                    + q_tok
+                                    + self.cp_world
+                                    - 1
+                                ) // self.cp_world
+                        else:
+                            k_bound = common_params.K
+                        tTR_rAcc[i] = (
+                            tTR_rAcc[i]
+                            if cute.elem_less(
+                                qk_col + self.mma_qk_tiler[1] * k_index,
+                                k_bound,
+                            )
+                            else self.acc_dtype(-1.0e6)
+                        )
             # reduction for row_max
             row_max_new = tTR_rAcc.load().reduce(cute.ReductionOp.MAX, row_max_new, 0)
         elif cutlass.const_expr(arch >= Arch.sm_103 and arch <= Arch.sm_103f):
@@ -3244,7 +3308,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             tTR_rAcc = cute.make_tensor(tTR_rAcc_red.iterator, tTR_rAcc.layout)
             if apply_mask:
                 for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
-                    if cutlass.const_expr(self.is_causal):
+                    if cutlass.const_expr(self.tree_mask_mode):
                         if cutlass.const_expr(self.fold_sq_factor > 1):
                             q_tok = (
                                 common_params.blk_coord[1] * self.fold_sq_factor
@@ -3256,35 +3320,79 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                             )
                         else:
                             q_tok = common_params.blk_coord[1]
-                        # effective K(row) = K - (S_q - 1) + q_tok; equivalent to
-                        # K - (S_q - 1 - q_tok), written to avoid Python int/CuTe
-                        # Int32 __rsub__ quirks when self.seq_len_q==1.
-                        if cutlass.const_expr(self.cp_world == 1):
-                            # Non-DCP: causal bound is the full local context length
-                            # (identical to the pre-DCP behavior; folded at compile time).
-                            k_bound = common_params.K - (self.seq_len_q - 1) + q_tok
-                        else:
-                            # DCP (cp_world>1): this rank holds a strided 1/cp_world slice of
-                            # the context (key c -> global position c*cp_world + dcp_rank). The
-                            # causal bound is therefore taken over the GLOBAL length passed in
-                            # K_causal (= global_seq - dcp_rank), divided by cp_world.
-                            k_bound = (
-                                common_params.K_causal
-                                - (self.seq_len_q - 1)
-                                + q_tok
-                                + self.cp_world
-                                - 1
-                            ) // self.cp_world
-                    else:
-                        k_bound = common_params.K
-                    tTR_rAcc[i] = (
-                        tTR_rAcc[i]
-                        if cute.elem_less(
-                            tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index,
-                            k_bound,
+                        kcol = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
+                        # custom_mask is row-major [seq_len_q x K] per request
+                        # (nonzero=attend). Padding columns and malformed
+                        # offsets must not drive an out-of-bounds mask read.
+                        within_kv = cute.elem_less(kcol, common_params.K)
+                        kcol_in = (
+                            kcol
+                            if within_kv
+                            else cutlass.Int32(common_params.K - 1)
                         )
-                        else self.acc_dtype(-1.0e6)
-                    )
+                        cm_idx = (
+                            common_params.cmask_off[common_params.blk_coord[2]]
+                            + q_tok * common_params.K
+                            + kcol_in
+                        )
+                        if within_kv:
+                            if cute.elem_less(cutlass.Int32(-1), cm_idx):
+                                if cute.elem_less(cm_idx, common_params.cmask_len):
+                                    cm_keep = cute.elem_less(
+                                        cutlass.Int32(0),
+                                        cutlass.Int32(common_params.cmask[cm_idx]),
+                                    )
+                                    tTR_rAcc[i] = (
+                                        tTR_rAcc[i]
+                                        if cm_keep
+                                        else self.acc_dtype(-1.0e6)
+                                    )
+                                else:
+                                    tTR_rAcc[i] = self.acc_dtype(-1.0e6)
+                            else:
+                                tTR_rAcc[i] = self.acc_dtype(-1.0e6)
+                        else:
+                            tTR_rAcc[i] = self.acc_dtype(-1.0e6)
+                    else:
+                        if cutlass.const_expr(self.is_causal):
+                            if cutlass.const_expr(self.fold_sq_factor > 1):
+                                q_tok = (
+                                    common_params.blk_coord[1] * self.fold_sq_factor
+                                    + (
+                                        tTR_tS[i][0]
+                                        + common_params.blk_coord[0] * cta_m_rows
+                                    )
+                                    // self.num_heads
+                                )
+                            else:
+                                q_tok = common_params.blk_coord[1]
+                            # effective K(row) = K - (S_q - 1) + q_tok; equivalent to
+                            # K - (S_q - 1 - q_tok), written to avoid Python int/CuTe
+                            # Int32 __rsub__ quirks when self.seq_len_q==1.
+                            if cutlass.const_expr(self.cp_world == 1):
+                                # Non-DCP: causal bound is the full local context length.
+                                k_bound = (
+                                    common_params.K - (self.seq_len_q - 1) + q_tok
+                                )
+                            else:
+                                # DCP: local keys are a strided slice of global positions.
+                                k_bound = (
+                                    common_params.K_causal
+                                    - (self.seq_len_q - 1)
+                                    + q_tok
+                                    + self.cp_world
+                                    - 1
+                                ) // self.cp_world
+                        else:
+                            k_bound = common_params.K
+                        tTR_rAcc[i] = (
+                            tTR_rAcc[i]
+                            if cute.elem_less(
+                                tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index,
+                                k_bound,
+                            )
+                            else self.acc_dtype(-1.0e6)
+                        )
                 # reduction for row_max after manual masking
                 row_max_new = tTR_rAcc.load().reduce(
                     cute.ReductionOp.MAX, row_max_new, 0
@@ -4759,6 +4867,14 @@ def run(
     workspace, workspace_torch = create_workspace(
         num_heads_eff, seq_len_q_eff, latent_dim, batch_size, split_kv, acc_dtype
     )
+    dummy_custom_mask_torch = torch.empty(1, dtype=torch.int8, device="cuda")
+    dummy_custom_mask = from_dlpack(
+        dummy_custom_mask_torch, assumed_align=1
+    ).mark_layout_dynamic()
+    dummy_cmask_off_torch = torch.zeros(batch_size, dtype=torch.int32, device="cuda")
+    dummy_cmask_off = from_dlpack(
+        dummy_cmask_off_torch, assumed_align=16
+    ).mark_layout_dynamic()
 
     mla = BlackwellMultiHeadLatentAttentionForwardFP8(
         acc_dtype,
@@ -4790,6 +4906,9 @@ def run(
         c_latent,
         c_rope,
         page_table,
+        dummy_custom_mask,
+        dummy_cmask_off,
+        cutlass.Int32(1),
         o,
         lse,
         workspace,
@@ -4904,6 +5023,9 @@ def run(
             c_latent,
             c_rope,
             page_table,
+            dummy_custom_mask,
+            dummy_cmask_off,
+            cutlass.Int32(1),
             o,
             lse,
             workspace,
@@ -5041,6 +5163,9 @@ def run(
             c_latent,
             c_rope,
             page_table,
+            dummy_custom_mask,
+            dummy_cmask_off,
+            cutlass.Int32(1),
             o,
             lse,
             workspace,

--- a/tokenspeed-mla/python/tokenspeed_mla/mla_decode_fp8.py
+++ b/tokenspeed-mla/python/tokenspeed_mla/mla_decode_fp8.py
@@ -3216,9 +3216,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         # offsets must not drive an out-of-bounds mask read.
                         within_kv = cute.elem_less(kcol, common_params.K)
                         kcol_in = (
-                            kcol
-                            if within_kv
-                            else cutlass.Int32(common_params.K - 1)
+                            kcol if within_kv else cutlass.Int32(common_params.K - 1)
                         )
                         cm_idx = (
                             common_params.cmask_off[common_params.blk_coord[2]]
@@ -3228,10 +3226,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         if within_kv:
                             if cute.elem_less(cutlass.Int32(-1), cm_idx):
                                 if cute.elem_less(cm_idx, common_params.cmask_len):
-                                    cm_keep = (
-                                        cutlass.Int32(common_params.cmask[cm_idx])
-                                        != cutlass.Int32(0)
-                                    )
+                                    cm_keep = cutlass.Int32(
+                                        common_params.cmask[cm_idx]
+                                    ) != cutlass.Int32(0)
                                     tTR_rAcc[i] = (
                                         tTR_rAcc[i]
                                         if cm_keep
@@ -3256,9 +3253,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                                 q_tok = common_params.blk_coord[1]
                             if cutlass.const_expr(self.cp_world == 1):
                                 # Non-DCP: causal bound is the full local context length.
-                                k_bound = (
-                                    common_params.K - (self.seq_len_q - 1) + q_tok
-                                )
+                                k_bound = common_params.K - (self.seq_len_q - 1) + q_tok
                             else:
                                 # DCP: local keys are a strided slice of global positions.
                                 k_bound = (
@@ -3326,9 +3321,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         # offsets must not drive an out-of-bounds mask read.
                         within_kv = cute.elem_less(kcol, common_params.K)
                         kcol_in = (
-                            kcol
-                            if within_kv
-                            else cutlass.Int32(common_params.K - 1)
+                            kcol if within_kv else cutlass.Int32(common_params.K - 1)
                         )
                         cm_idx = (
                             common_params.cmask_off[common_params.blk_coord[2]]
@@ -3338,10 +3331,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         if within_kv:
                             if cute.elem_less(cutlass.Int32(-1), cm_idx):
                                 if cute.elem_less(cm_idx, common_params.cmask_len):
-                                    cm_keep = (
-                                        cutlass.Int32(common_params.cmask[cm_idx])
-                                        != cutlass.Int32(0)
-                                    )
+                                    cm_keep = cutlass.Int32(
+                                        common_params.cmask[cm_idx]
+                                    ) != cutlass.Int32(0)
                                     tTR_rAcc[i] = (
                                         tTR_rAcc[i]
                                         if cm_keep
@@ -3371,9 +3363,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                             # Int32 __rsub__ quirks when self.seq_len_q==1.
                             if cutlass.const_expr(self.cp_world == 1):
                                 # Non-DCP: causal bound is the full local context length.
-                                k_bound = (
-                                    common_params.K - (self.seq_len_q - 1) + q_tok
-                                )
+                                k_bound = common_params.K - (self.seq_len_q - 1) + q_tok
                             else:
                                 # DCP: local keys are a strided slice of global positions.
                                 k_bound = (

--- a/tokenspeed-mla/test/microbench_tree_decode.py
+++ b/tokenspeed-mla/test/microbench_tree_decode.py
@@ -1,0 +1,244 @@
+# Copyright (c) 2026 LightSeek Foundation
+
+"""Manual GB200 correctness/perf harness for FP8 MLA tree-mask decode.
+
+This is intentionally not a default pytest: it compiles and runs the Blackwell
+CuTe MLA kernel. It validates the optional custom_mask path against an
+independent absorbed-MLA PyTorch reference and includes non-tile-aligned K plus
+batched offsets.
+
+Example:
+    python tokenspeed-mla/test/microbench_tree_decode.py --iters 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+
+import torch
+from tokenspeed_mla import tokenspeed_mla_decode
+
+
+DEV = "cuda"
+FP8 = torch.float8_e4m3fn
+KV_LORA = 512
+ROPE = 64
+D_QK = KV_LORA + ROPE
+H = 128
+PAGE = 64
+
+
+def build_inputs(batch: int, q_len: int, seq_k: int, seed: int):
+    generator = torch.Generator(device=DEV).manual_seed(seed)
+    query = (
+        torch.randn(batch, q_len, H, D_QK, device=DEV, generator=generator) * 0.3
+    ).to(FP8)
+    pages_per_request = (seq_k + PAGE - 1) // PAGE
+    page_count = pages_per_request * batch
+    kv_cache = (
+        torch.randn(page_count, PAGE, D_QK, device=DEV, generator=generator) * 0.3
+    ).to(FP8)
+    block_tables = torch.arange(page_count, device=DEV, dtype=torch.int32).view(
+        batch, pages_per_request
+    )
+    seq_lens = torch.full((batch,), seq_k, device=DEV, dtype=torch.int32)
+    workspace = torch.empty(1 << 29, dtype=torch.int8, device=DEV)
+    return query, kv_cache, block_tables, seq_lens, workspace
+
+
+def chain_ancestor(batch: int, q_len: int) -> torch.Tensor:
+    ancestor = torch.tril(torch.ones(q_len, q_len, dtype=torch.bool))
+    return ancestor.unsqueeze(0).expand(batch, q_len, q_len).contiguous()
+
+
+def random_tree_ancestor(batch: int, q_len: int, seed: int) -> torch.Tensor:
+    generator = torch.Generator().manual_seed(seed)
+    ancestor = torch.zeros(batch, q_len, q_len, dtype=torch.bool)
+    for b in range(batch):
+        parent = [-1]
+        for i in range(1, q_len):
+            parent.append(int(torch.randint(0, i, (1,), generator=generator)))
+        for qi in range(q_len):
+            j = qi
+            while j != -1:
+                ancestor[b, qi, j] = True
+                j = parent[j]
+    return ancestor
+
+
+def build_custom_mask(ancestor: torch.Tensor, seq_lens: torch.Tensor):
+    batch, q_len, _ = ancestor.shape
+    offsets = torch.empty(batch, dtype=torch.int32, device=DEV)
+    parts = []
+    offset = 0
+    for b in range(batch):
+        K = int(seq_lens[b])
+        hist = K - q_len
+        mask = torch.zeros(q_len, K, dtype=torch.bool, device=DEV)
+        mask[:, :hist] = True
+        mask[:, hist:K] = ancestor[b].to(DEV)
+        offsets[b] = offset
+        parts.append(mask.reshape(-1))
+        offset += q_len * K
+    return torch.cat(parts).contiguous(), offsets
+
+
+def call_kernel(
+    query,
+    kv_cache,
+    block_tables,
+    seq_lens,
+    workspace,
+    seq_k,
+    *,
+    causal,
+    custom_mask=None,
+    cmask_off=None,
+):
+    return tokenspeed_mla_decode(
+        query=query,
+        kv_cache=kv_cache,
+        workspace_buffer=workspace,
+        kv_lora_rank=KV_LORA,
+        qk_rope_head_dim=ROPE,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        max_seq_len=seq_k,
+        softmax_scale=1.0 / math.sqrt(D_QK),
+        causal_mask=causal,
+        custom_mask=custom_mask,
+        cmask_off=cmask_off,
+    )
+
+
+def absorbed_ref(query, kv_cache, block_tables, seq_lens, ancestor):
+    batch, q_len = query.shape[:2]
+    scale = 1.0 / math.sqrt(D_QK)
+    out = torch.zeros(batch, q_len, H, KV_LORA, device=DEV, dtype=torch.float32)
+    qf = query.float()
+    for b in range(batch):
+        K = int(seq_lens[b])
+        hist = K - q_len
+        kv = kv_cache[block_tables[b]].reshape(-1, D_QK).float()[:K]
+        for qi in range(q_len):
+            valid = torch.zeros(K, dtype=torch.bool, device=DEV)
+            valid[:hist] = True
+            valid[hist:K] = ancestor[b, qi].to(DEV)
+            scores = (qf[b, qi] @ kv.t()) * scale
+            probs = torch.softmax(
+                scores.masked_fill(~valid.view(1, -1), float("-inf")), dim=-1
+            )
+            out[b, qi] = probs @ kv[:, :KV_LORA]
+    return out
+
+
+def measure_ms(fn, warmup: int, iters: int):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters
+
+
+def parse_cases(raw: str):
+    cases = []
+    for case in raw.split(";"):
+        if not case.strip():
+            continue
+        batch, q_len, seq_k = [int(part.strip()) for part in case.split(",")]
+        if batch <= 0 or q_len <= 0 or seq_k < q_len:
+            raise ValueError(f"invalid case {case!r}")
+        cases.append((batch, q_len, seq_k))
+    return cases
+
+
+def run_case(batch: int, q_len: int, seq_k: int, args) -> bool:
+    query, kv_cache, block_tables, seq_lens, workspace = build_inputs(
+        batch, q_len, seq_k, seed=batch * 1000 + q_len * 100 + seq_k
+    )
+    passed = True
+    for name, ancestor_cpu in (
+        ("chain", chain_ancestor(batch, q_len)),
+        ("random", random_tree_ancestor(batch, q_len, seed=seq_k)),
+    ):
+        custom_mask, cmask_off = build_custom_mask(ancestor_cpu, seq_lens)
+        actual = call_kernel(
+            query,
+            kv_cache,
+            block_tables,
+            seq_lens,
+            workspace,
+            seq_k,
+            causal=False,
+            custom_mask=custom_mask,
+            cmask_off=cmask_off,
+        ).float()
+        expected = absorbed_ref(query, kv_cache, block_tables, seq_lens, ancestor_cpu)
+        max_abs = (actual - expected).abs().max().item()
+        ok = max_abs < args.tolerance
+        print(
+            f"[B={batch} q={q_len} K={seq_k}] {name} tree vs ref "
+            f"max_abs={max_abs:.3e} {'OK' if ok else 'FAIL'}"
+        )
+        passed = passed and ok
+
+    if args.iters > 0:
+        random_mask, random_off = build_custom_mask(
+            random_tree_ancestor(batch, q_len, seed=seq_k), seq_lens
+        )
+        causal_ms = measure_ms(
+            lambda: call_kernel(
+                query, kv_cache, block_tables, seq_lens, workspace, seq_k, causal=True
+            ),
+            args.warmup,
+            args.iters,
+        )
+        tree_ms = measure_ms(
+            lambda: call_kernel(
+                query,
+                kv_cache,
+                block_tables,
+                seq_lens,
+                workspace,
+                seq_k,
+                causal=False,
+                custom_mask=random_mask,
+                cmask_off=random_off,
+            ),
+            args.warmup,
+            args.iters,
+        )
+        print(f"            timing causal={causal_ms:.4f} ms tree={tree_ms:.4f} ms")
+
+    return passed
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument(
+        "--cases",
+        default="1,4,256;1,8,250;1,8,300;1,16,250;2,8,250",
+        help="Semicolon-separated B,q_len,seq_k cases.",
+    )
+    parser.add_argument("--iters", type=int, default=0)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--tolerance", type=float, default=0.2)
+    args = parser.parse_args()
+
+    torch.cuda.set_device(args.device)
+    all_passed = True
+    for batch, q_len, seq_k in parse_cases(args.cases):
+        all_passed = run_case(batch, q_len, seq_k, args) and all_passed
+    raise SystemExit(0 if all_passed else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tokenspeed-mla/test/microbench_tree_decode.py
+++ b/tokenspeed-mla/test/microbench_tree_decode.py
@@ -19,7 +19,6 @@ import math
 import torch
 from tokenspeed_mla import tokenspeed_mla_decode
 
-
 DEV = "cuda"
 FP8 = torch.float8_e4m3fn
 KV_LORA = 512

--- a/tokenspeed-mla/test/microbench_tree_decode.py
+++ b/tokenspeed-mla/test/microbench_tree_decode.py
@@ -1,4 +1,22 @@
 # Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
 """Manual GB200 correctness/perf harness for FP8 MLA tree-mask decode.
 

--- a/tokenspeed-mla/test/microbench_tree_decode.py
+++ b/tokenspeed-mla/test/microbench_tree_decode.py
@@ -23,7 +23,7 @@
 This is intentionally not a default pytest: it compiles and runs the Blackwell
 CuTe MLA kernel. It validates the optional custom_mask path against an
 independent absorbed-MLA PyTorch reference and includes non-tile-aligned K plus
-batched offsets.
+batched offsets and masks that deny early history columns.
 
 Example:
     python tokenspeed-mla/test/microbench_tree_decode.py --iters 50
@@ -129,19 +129,18 @@ def call_kernel(
     )
 
 
-def absorbed_ref(query, kv_cache, block_tables, seq_lens, ancestor):
+def absorbed_ref(query, kv_cache, block_tables, seq_lens, custom_mask, cmask_off):
     batch, q_len = query.shape[:2]
     scale = 1.0 / math.sqrt(D_QK)
     out = torch.zeros(batch, q_len, H, KV_LORA, device=DEV, dtype=torch.float32)
     qf = query.float()
     for b in range(batch):
         K = int(seq_lens[b])
-        hist = K - q_len
+        mask_offset = int(cmask_off[b])
+        request_mask = custom_mask[mask_offset : mask_offset + q_len * K].view(q_len, K)
         kv = kv_cache[block_tables[b]].reshape(-1, D_QK).float()[:K]
         for qi in range(q_len):
-            valid = torch.zeros(K, dtype=torch.bool, device=DEV)
-            valid[:hist] = True
-            valid[hist:K] = ancestor[b, qi].to(DEV)
+            valid = request_mask[qi].bool()
             scores = (qf[b, qi] @ kv.t()) * scale
             probs = torch.softmax(
                 scores.masked_fill(~valid.view(1, -1), float("-inf")), dim=-1
@@ -197,11 +196,56 @@ def run_case(batch: int, q_len: int, seq_k: int, args) -> bool:
             custom_mask=custom_mask,
             cmask_off=cmask_off,
         ).float()
-        expected = absorbed_ref(query, kv_cache, block_tables, seq_lens, ancestor_cpu)
+        expected = absorbed_ref(
+            query,
+            kv_cache,
+            block_tables,
+            seq_lens,
+            custom_mask,
+            cmask_off,
+        )
         max_abs = (actual - expected).abs().max().item()
         ok = max_abs < args.tolerance
         print(
             f"[B={batch} q={q_len} K={seq_k}] {name} tree vs ref "
+            f"max_abs={max_abs:.3e} {'OK' if ok else 'FAIL'}"
+        )
+        passed = passed and ok
+
+    if seq_k > q_len:
+        history_mask, history_off = build_custom_mask(
+            chain_ancestor(batch, q_len), seq_lens
+        )
+        for b in range(batch):
+            K = int(seq_lens[b])
+            hist = K - q_len
+            offset = int(history_off[b])
+            request_mask = history_mask[offset : offset + q_len * K].view(q_len, K)
+            request_mask[:, :hist] = False
+
+        actual = call_kernel(
+            query,
+            kv_cache,
+            block_tables,
+            seq_lens,
+            workspace,
+            seq_k,
+            causal=False,
+            custom_mask=history_mask,
+            cmask_off=history_off,
+        ).float()
+        expected = absorbed_ref(
+            query,
+            kv_cache,
+            block_tables,
+            seq_lens,
+            history_mask,
+            history_off,
+        )
+        max_abs = (actual - expected).abs().max().item()
+        ok = max_abs < args.tolerance
+        print(
+            f"[B={batch} q={q_len} K={seq_k}] masked history vs ref "
             f"max_abs={max_abs:.3e} {'OK' if ok else 'FAIL'}"
         )
         passed = passed and ok

--- a/tokenspeed-mla/test/test_tree_mask_decode.py
+++ b/tokenspeed-mla/test/test_tree_mask_decode.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 LightSeek Foundation
+
+from __future__ import annotations
+
+import torch
+
+
+def build_ancestor_mask(parent: list[int]) -> torch.Tensor:
+    """ancestor[qi, j] is True iff new-token j is on qi's ancestry path."""
+
+    q_len = len(parent)
+    ancestor = torch.zeros(q_len, q_len, dtype=torch.bool)
+    for qi in range(q_len):
+        j = qi
+        seen = 0
+        while j != -1:
+            ancestor[qi, j] = True
+            j = parent[j]
+            seen += 1
+            assert seen <= q_len, f"cycle in parent array: {parent}"
+    return ancestor
+
+
+def chain_parent(q_len: int) -> list[int]:
+    return [i - 1 for i in range(q_len)]
+
+
+def build_custom_mask(
+    ancestor: torch.Tensor, seq_lens: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Flatten per-request [q_len x K_b] masks and return int32 offsets.
+
+    History columns are fully visible. The last q_len columns carry the
+    tree-ancestor mask for the drafted tokens.
+    """
+
+    batch, q_len, q_len_2 = ancestor.shape
+    assert q_len == q_len_2
+    offsets = torch.empty(batch, dtype=torch.int32)
+    flat_masks = []
+    offset = 0
+    for b in range(batch):
+        offsets[b] = offset
+        K = int(seq_lens[b])
+        hist = K - q_len
+        assert hist >= 0
+        mask = torch.zeros(q_len, K, dtype=torch.bool)
+        mask[:, :hist] = True
+        mask[:, hist:K] = ancestor[b]
+        flat_masks.append(mask.reshape(-1))
+        offset += q_len * K
+    return torch.cat(flat_masks).contiguous(), offsets
+
+
+def test_chain_tree_mask_matches_causal_layout():
+    for q_len in (1, 2, 4, 8, 16):
+        ancestor = build_ancestor_mask(chain_parent(q_len))
+        causal = torch.tril(torch.ones(q_len, q_len, dtype=torch.bool))
+        assert torch.equal(ancestor, causal)
+
+
+def test_custom_mask_layout_and_offsets_for_variable_batch():
+    ancestor = torch.stack(
+        [
+            build_ancestor_mask([-1, 0, 0, 2]),
+            build_ancestor_mask([-1, 0, 1, 1]),
+        ]
+    )
+    seq_lens = torch.tensor([10, 13], dtype=torch.int32)
+
+    custom_mask, offsets = build_custom_mask(ancestor, seq_lens)
+
+    assert offsets.tolist() == [0, 40]
+    first = custom_mask[offsets[0] : offsets[1]].view(4, 10)
+    second = custom_mask[offsets[1] :].view(4, 13)
+
+    assert first[3].tolist() == [True] * 6 + [True, False, True, True]
+    assert second[2].tolist() == [True] * 9 + [True, True, True, False]
+
+
+def test_custom_mask_rejects_cycles_in_tree_parent():
+    try:
+        build_ancestor_mask([1, 0])
+    except AssertionError as exc:
+        assert "cycle" in str(exc)
+    else:
+        raise AssertionError("expected cycle detection to fail")

--- a/tokenspeed-mla/test/test_tree_mask_decode.py
+++ b/tokenspeed-mla/test/test_tree_mask_decode.py
@@ -1,4 +1,22 @@
 # Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
 from __future__ import annotations
 


### PR DESCRIPTION
Replaces #338 after it was automatically closed for inactivity. GitHub reports `viewerCanReopen=false` for the closed PR, so this opens the rebased change on a fresh branch.

## Summary
- Adds optional FP8 custom tree-mask support to `tokenspeed_mla_decode` through flattened `custom_mask` data and `cmask_off` request offsets.
- Extends the FP8 CuTe MLA decode ABI with mask pointer, offset pointer, and mask length.
- Applies the custom mask in the softmax tail region, including folded `S_q` handling and non-tile-aligned K.
- Keeps FP16/BF16 on the current upstream call signature and uses stable dummy mask tensors for FP8 non-tree mode.
- Forwards mask kwargs through the runtime `tokenspeed_mla` attention backend.
- Adds a CPU mask-layout oracle and the GB200 manual kernel-vs-reference harness from the original PR.

## Rebase note
Current `main` added FP8 decode-context-parallel support (`cp_world` / `causal_seqs`) after the original PR. This rebase preserves the existing non-tree DCP path and adds tree-mask mode alongside it. Custom tree masks are explicitly rejected when DCP causal bounds are requested (`cp_world > 1` or `causal_seqs` is set) until that composition is implemented and tested.

## Validation
- `python3 -m py_compile tokenspeed-mla/python/tokenspeed_mla/mla_decode.py tokenspeed-mla/python/tokenspeed_mla/mla_decode_fp8.py python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py tokenspeed-mla/test/test_tree_mask_decode.py tokenspeed-mla/test/microbench_tree_decode.py`
- `git diff --check`
- Collaborative external review: initial HIGH finding on DCP + tree-mask composition was fixed; second review returned LGTM.

Not run locally: `pytest`, because this local Python environment does not have `pytest` or `torch` installed. The original #338 GB200 validation context still applies to the feature, but this rebased conflict resolution should be revalidated in the TokenSpeed runtime environment.