### PR TITLE
fix(spec): restore sentinel padding + context clamps for every drafter

### DIFF
--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -851,22 +851,22 @@ class CudaGraphWrapper:
         pad = padded_bs - active_req_pool_indices.shape[0]
         if pad <= 0:
             return active_req_pool_indices
-        if self.config.spec_algo == "DFLASH":
-            # Route padding rows to the sentinel req-pool slot
-            # (max_req_pool_size), not slot 0. The DFLASH draft derives each
-            # row's block seq_len from valid_cache_lengths[req_pool], so
-            # padding rows pointing at slot 0 would grow unbounded with
-            # request 0's context and hang the draft block-decode kernel.
-            # The sentinel row stays zero-init (length 0, dummy page 0).
-            sentinel = int(self.config.max_req_pool_size)
-            return torch.cat(
-                [
-                    active_req_pool_indices,
-                    active_req_pool_indices.new_full((pad,), sentinel),
-                ]
-            )
+        # Route padding rows to the sentinel req-pool slot (max_req_pool_size),
+        # not slot 0 -- for EVERY spec algorithm. Slot 0 aliases the live first
+        # request: harmless for the plain verify decode (seq_len == 1), but any
+        # DRAFTER in the captured graph re-derives per-row state from the pool
+        # index -- DFLASH grows its block seq_len with request 0's context and
+        # hangs; Eagle/MTP reads request 0's committed length and resolves
+        # draft-KV write slots through request 0's live frontier (a write-write
+        # race + wild paged-indexer accesses at ragged batch sizes -> IMA on
+        # GB10 MTP2 conc8). The sentinel row stays zero-init (length 0, dummy
+        # page 0), keeping the derived lengths inert for every drafter backend.
+        sentinel = int(self.config.max_req_pool_size)
         return torch.cat(
-            [active_req_pool_indices, active_req_pool_indices.new_zeros(pad)]
+            [
+                active_req_pool_indices,
+                active_req_pool_indices.new_full((pad,), sentinel),
+            ]
         )
 
     def _set_graph_state_write_indices(

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -252,10 +252,11 @@ class ModelExecutor:
             # ~1 page past context_len + spec_num_tokens. Without headroom
             # req_to_page overflows and the next draft block's page write goes
             # out of bounds, hanging the attention kernel. Pad generously; a few
-            # int32 columns per request. Non-DFLASH algorithms do not need this.
-            draft_block_reservation_slack = (
-                config.spec_num_tokens * 64 if config.spec_algo == "DFLASH" else 0
-            )
+            # int32 columns per request. Kept for EVERY drafter (not just
+            # DFLASH): Eagle/MTP draft steps also write KV at the reservation
+            # frontier, and running out degrades to a clamped KV-drop near
+            # context_len.
+            draft_block_reservation_slack = config.spec_num_tokens * 64
             max_num_pages_per_req = (
                 config.context_len
                 + config.spec_num_tokens
@@ -727,10 +728,9 @@ class ModelExecutor:
             accept_lengths = self._apply_force_single_token_verify(
                 accept_lengths, 0, num_decodes, ctx.decode_input_ids
             )
-            if self.config.spec_algo == "DFLASH":
-                accept_lengths = self._cap_accept_to_context_len(
-                    accept_lengths, sampling_info.req_pool_indices[:num_decodes]
-                )
+            accept_lengths = self._cap_accept_to_context_len(
+                accept_lengths, sampling_info.req_pool_indices[:num_decodes]
+            )
             return output_tokens, accept_lengths
 
         logits = logits_output.next_token_logits
@@ -745,10 +745,9 @@ class ModelExecutor:
         decode_accept = self._apply_force_single_token_verify(
             decode_accept, num_extends, num_decodes, ctx.decode_input_ids
         )
-        if self.config.spec_algo == "DFLASH":
-            decode_accept = self._cap_accept_to_context_len(
-                decode_accept, sampling_info.req_pool_indices[num_extends:]
-            )
+        decode_accept = self._cap_accept_to_context_len(
+            decode_accept, sampling_info.req_pool_indices[num_extends:]
+        )
         if (
             prefill_out.next_token_logprobs is not None
             and decode_out.next_token_logprobs is not None
@@ -1816,9 +1815,10 @@ class ModelExecutor:
                             time.perf_counter() - forward_step_start
                         ) * 1000.0
 
-                if self.config.spec_algo == "DFLASH":
+                if self.config.spec_algo is not None:
                     # Clamp the committed-length delta so no request grows past
-                    # context_len. Done here (outside the graph) so it reaches
+                    # context_len (every drafter can overshoot near the limit).
+                    # Done here (outside the graph) so it reaches
                     # both _update_runtime_state and the scheduler page
                     # reservation; see _clamp_committed_to_context_len.
                     output_lengths = self._clamp_committed_to_context_len(


### PR DESCRIPTION
## Disclaimer

The PR body and the code were written by Claude and reviewed by me.
I'm hacking TokenSpeed to support SM10x, and I believe this patch is valid for all archs.

## Summary

#594 narrowed four MTP/spec safety mechanisms to `spec_algo == "DFLASH"`, regressing every other drafter (Eagle/MTP/EAGLE3):

1. **Decode-graph padding rows went back to req-pool slot 0**, aliasing the live first request. Harmless for the plain verify decode (`seq_len == 1`), but any drafter inside the captured graph re-derives per-row state from the pool index: Eagle/MTP padding rows read request 0's committed length and resolve draft-KV write slots through request 0's live frontier — a write-write race plus wild paged-indexer accesses whenever the batch pads (`bs ∉ capture_bs`, i.e. exactly at mid-serve completions and admission ramps). The pre-#594 comment documented this hazard verbatim. **Restored: unconditional sentinel (`max_req_pool_size`) padding.**
2. `_cap_accept_to_context_len` (both verify sites), `_clamp_committed_to_context_len`, and `draft_block_reservation_slack` were DFLASH-gated. All three guard **any** drafter near `context_len` (accept/commit overshoot, reservation overflow → KV drop). **Restored for every spec algorithm** — arithmetically inert mid-context, load-bearing at the limit.

## Evidence

Observed on a 2-node DGX Spark (GB10, TP=2) serving DeepSeek-V4-Flash with MTP2 (`num_speculative_tokens=2`, capture_bs=[1,2,4,7,8]):

- **Crash**: CUDA `illegal memory access` → NCCL watchdog kills the process group, mid-way through an 8-concurrent long-context recall gate (reproduced twice, both times right as batch sizes went ragged: 3/5/6 from completions/admissions).
- **Isolation matrix**: conc1 ✅ · nomtp conc8 ✅ 16/16 · **eager** MTP2 conc8 ✅ 16/16 · **graphed MTP2 conc8 ❌ IMA** — pinning the fault to MTP × decode-graph replay at padded batch sizes.
- Pre-#594 (same serving stack on the older base) the identical gate passed 16/16 repeatedly.

## Validation

With this fix, on the same 2-node GB10 MTP2 serve:
- arthur 900-line recall gate conc8: **16/16, twice consecutively, zero IMA**; conc1 2/2.
- Decode/prefill throughput unchanged (pinned llama-benchy standard, 3 depths — all within noise of the pre-#594-regression numbers).
- nomtp + DFLASH paths unaffected (sentinel row is zero-init; the clamps are identity ops away from `context_len`).

## Notes

- The padding-row hazard reproduces for any non-DFLASH drafter whose draft runs inside the decode graph; DSv3/GLM MTP configurations are exposed the same way.