### PR TITLE
perf(deepseek-v4): widen sparse compress cache launch for large ratios

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/deepseek_v4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/deepseek_v4.py
@@ -24,6 +24,8 @@
 
 from __future__ import annotations
 
+import functools
+
 import torch
 from tokenspeed_kernel._triton import tl, triton
 
@@ -402,6 +404,28 @@ def _deepseek_v4_fused_sparse_compress_cache_kernel(
     )
 
 
+@functools.lru_cache(maxsize=None)
+def _wide_compress_launch_supported(device: "torch.device | int | None") -> bool:
+    """Whether the 16-warp sparse-compress launch is validated for a GPU.
+
+    Args:
+        device: Device the kernel launches on (the state cache's device);
+            results are cached per device so mixed-architecture processes
+            pick the right launch width per GPU.
+
+    Returns:
+        True only on NVIDIA sm100 (B200), where the wide launch was
+        microbenched and parity-tested. Other targets, including ROCm
+        devices reached through the ``torch.cuda`` API, keep 4 warps.
+    """
+    try:
+        if not torch.cuda.is_available() or torch.version.hip is not None:
+            return False
+        return torch.cuda.get_device_capability(device) == (10, 0)
+    except Exception:
+        return False
+
+
 def deepseek_v4_fused_sparse_compress_cache_insert(
     *,
     state_cache: torch.Tensor,
@@ -461,7 +485,18 @@ def deepseek_v4_fused_sparse_compress_cache_insert(
         TOKEN_STRIDE=DEEPSEEK_V4_SWA_TOKEN_STRIDE,
         SCALE_DIM=DEEPSEEK_V4_SWA_SCALE_DIM,
         KV_BLOCK_STRIDE=kv_cache_2d.stride(0),
-        num_warps=4,
+        # Compress-boundary tokens reduce a (1+overlap)*ratio x HEAD window
+        # inside one CTA: 128 rows on the production HCA path (overlap=False);
+        # overlapping configurations reduce 256. At ratio>=128 four warps
+        # leave that reduction 3-4x slower than 16 (validated on NVIDIA sm100
+        # only; other targets keep 4). Small ratios keep 4 warps, where 16 is
+        # slightly slower.
+        num_warps=(
+            16
+            if compress_ratio >= 128
+            and _wide_compress_launch_supported(state_cache.device)
+            else 4
+        ),
     )
 
 

--- a/tokenspeed-kernel/test/test_deepseek_v4_sparse_compress_launch.py
+++ b/tokenspeed-kernel/test/test_deepseek_v4_sparse_compress_launch.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 LightSeek Foundation
+
+"""Launch-config tests for the fused sparse compress cache insert."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import torch
+from tokenspeed_kernel.ops.attention.triton import deepseek_v4 as ops
+
+
+def _launch(compress_ratio, overlap=False, wide_supported=True):
+    recorded = {}
+
+    class _Grid:
+        def __getitem__(self, grid):
+            def _call(*args, **kwargs):
+                recorded["grid"] = grid
+                recorded["num_warps"] = kwargs.get("num_warps")
+
+            return _call
+
+    m = 8
+    with (
+        patch.object(ops, "_deepseek_v4_fused_sparse_compress_cache_kernel", _Grid()),
+        patch.object(
+            ops, "_wide_compress_launch_supported", return_value=wide_supported
+        ),
+    ):
+        ops.deepseek_v4_fused_sparse_compress_cache_insert(
+            state_cache=torch.zeros(4, 8),
+            token_to_req_indices=torch.zeros(m, dtype=torch.int32),
+            positions=torch.zeros(m, dtype=torch.int32),
+            compressor_slot_mapping=torch.zeros(m, dtype=torch.int32),
+            block_table=torch.zeros(2, 4, dtype=torch.int32),
+            compressor_block_size=64,
+            rms_norm_weight=torch.ones(ops.DEEPSEEK_V4_HEAD_DIM),
+            rms_norm_eps=1e-6,
+            cos_sin_cache=torch.zeros(16, ops.DEEPSEEK_V4_ROPE_DIM),
+            kv_cache_2d=torch.zeros(4, 8, dtype=torch.uint8),
+            kv_slot_mapping=torch.zeros(m, dtype=torch.int32),
+            kv_cache_block_size=64,
+            compress_ratio=compress_ratio,
+            overlap=overlap,
+        )
+    return recorded
+
+
+def test_sparse_compress_uses_wide_launch_for_large_ratio():
+    # Production HCA (ratio=128, overlap=False) reduces a 128-row window in
+    # one CTA; the launch must request 16 warps there on supported targets.
+    assert _launch(128)["num_warps"] == 16
+
+
+def test_sparse_compress_keeps_narrow_launch_on_unsupported_target():
+    # The wide launch is validated on sm100 only; other targets keep 4.
+    assert _launch(128, wide_supported=False)["num_warps"] == 4
+
+
+def test_sparse_compress_keeps_narrow_launch_for_small_ratio():
+    assert _launch(4)["num_warps"] == 4
+
+
+def test_sparse_compress_grid_is_one_program_per_token():
+    assert _launch(128)["grid"] == (8,)
+
+
+def test_sparse_compress_skips_empty_batch():
+    mock = MagicMock()
+    with patch.object(ops, "_deepseek_v4_fused_sparse_compress_cache_kernel", mock):
+        ops.deepseek_v4_fused_sparse_compress_cache_insert(
+            state_cache=torch.zeros(4, 8),
+            token_to_req_indices=torch.zeros(0, dtype=torch.int32),
+            positions=torch.zeros(0, dtype=torch.int32),
+            compressor_slot_mapping=torch.zeros(0, dtype=torch.int32),
+            block_table=torch.zeros(2, 4, dtype=torch.int32),
+            compressor_block_size=64,
+            rms_norm_weight=torch.ones(ops.DEEPSEEK_V4_HEAD_DIM),
+            rms_norm_eps=1e-6,
+            cos_sin_cache=torch.zeros(16, ops.DEEPSEEK_V4_ROPE_DIM),
+            kv_cache_2d=torch.zeros(4, 8, dtype=torch.uint8),
+            kv_slot_mapping=torch.zeros(0, dtype=torch.int32),
+            kv_cache_block_size=64,
+            compress_ratio=128,
+            overlap=True,
+        )
+    mock.__getitem__.assert_not_called()

--- a/tokenspeed-kernel/test/test_deepseek_v4_sparse_compress_parity_gpu.py
+++ b/tokenspeed-kernel/test/test_deepseek_v4_sparse_compress_parity_gpu.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2026 LightSeek Foundation
+
+"""GPU parity for the sparse compress cache insert at 4 vs 16 warps.
+
+The wide launch reorganizes the cross-thread softmax/sum reductions, so the
+fp32 accumulation order can differ before quantization. This test runs the
+production HCA shape (ratio=128, overlap=False) on identical inputs at both
+warp counts and compares every WRITTEN row: scale bytes exactly, FP8 and
+RoPE BF16 regions by decoded value (signed-zero encodings can legitimately
+differ under reduction reorder; observed on GB200), each region separately. Token classes cover early-return (non-boundary), the first-window boundary
+(start == 0), full history, and — via block_table_base_offsets — partially
+masked windows crossing the base logical page.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from tokenspeed_kernel._triton import triton
+from tokenspeed_kernel.ops.attention.triton import deepseek_v4 as ops
+
+
+def _is_sm100() -> bool:
+    return (
+        torch.cuda.is_available()
+        and torch.version.hip is None
+        and torch.cuda.get_device_capability(0) == (10, 0)
+    )
+
+
+# The 16-warp launch is gated to NVIDIA sm100 in production; this parity
+# test forces both warp counts directly and is only meaningful (and only
+# safe to run) on that target.
+pytestmark = pytest.mark.skipif(not _is_sm100(), reason="requires NVIDIA sm100")
+
+HEAD = ops.DEEPSEEK_V4_HEAD_DIM
+RATIO = 128
+STATE_BLOCK = 64
+KV_BLOCK = 64
+N_BLOCKS = 2048
+TOKEN_STRIDE = ops.DEEPSEEK_V4_SWA_TOKEN_STRIDE
+SCALE_DIM = ops.DEEPSEEK_V4_SWA_SCALE_DIM
+NOPE = HEAD - ops.DEEPSEEK_V4_ROPE_DIM
+
+
+def _run(m, num_warps, seed, base_offsets=None):
+    dev = "cuda:0"
+    torch.manual_seed(seed)
+    width = 2 * HEAD
+    state = (torch.randn(N_BLOCKS, STATE_BLOCK * width, device=dev) * 0.3).view(
+        N_BLOCKS, -1
+    )
+    t2r = (torch.arange(m, device=dev, dtype=torch.int32) % 4).contiguous()
+    # Mix token classes: early-return (non-boundary), boundary with history,
+    # and the first full boundary window (window start == 0). Partially masked
+    # windows are covered by the dedicated base-offsets test.
+    pos = torch.arange(m, device=dev, dtype=torch.int32) + 4096
+    pos[0::4] = RATIO - 1  # first full boundary window (start == 0)
+    pos[1::4] = 8 * RATIO - 1  # boundary, full history
+    slot = torch.arange(m, device=dev, dtype=torch.int32) + 7
+    kv_slot = torch.arange(m, device=dev, dtype=torch.int32) + 3
+    bt = torch.arange(4 * 256, device=dev, dtype=torch.int32).view(4, 256) % N_BLOCKS
+    rms_w = torch.rand(HEAD, device=dev) + 0.5
+    cs = torch.randn(65536, ops.DEEPSEEK_V4_ROPE_DIM, device=dev)
+    kvc = torch.zeros(
+        N_BLOCKS,
+        KV_BLOCK * (TOKEN_STRIDE + SCALE_DIM),
+        dtype=torch.uint8,
+        device=dev,
+    )
+    ops._deepseek_v4_fused_sparse_compress_cache_kernel[(m,)](
+        state,
+        state.stride(0),
+        width,
+        t2r,
+        pos,
+        slot,
+        bt,
+        base_offsets,
+        bt.stride(0),
+        bt.shape[-1],
+        STATE_BLOCK,
+        rms_w,
+        1e-6,
+        cs,
+        cs.stride(0),
+        kvc,
+        kv_slot,
+        KV_BLOCK,
+        HEAD_SIZE=HEAD,
+        TRITON_BLOCK_SIZE=triton.next_power_of_2(HEAD),
+        STATE_WIDTH=HEAD,
+        COMPRESS_RATIO=RATIO,
+        OVERLAP=False,
+        ROPE_HEAD_DIM=ops.DEEPSEEK_V4_ROPE_DIM,
+        FP8_MAX=ops.DEEPSEEK_V4_FP8_MAX,
+        QUANT_BLOCK=ops.DEEPSEEK_V4_FP8_QUANT_BLOCK,
+        TOKEN_STRIDE=TOKEN_STRIDE,
+        SCALE_DIM=SCALE_DIM,
+        KV_BLOCK_STRIDE=kvc.stride(0),
+        num_warps=num_warps,
+    )
+    torch.cuda.synchronize()
+    return kvc
+
+
+def _written_slots(m):
+    # Mirror the kernel's write condition: compress-boundary position with a
+    # non-negative state slot and kv slot (matches _run's input construction).
+    pos = torch.arange(m, dtype=torch.int64) + 4096
+    pos[0::4] = RATIO - 1
+    pos[1::4] = 8 * RATIO - 1
+    kv_slot = torch.arange(m, dtype=torch.int64) + 3
+    boundary = (pos + 1) % RATIO == 0
+    return kv_slot[boundary]
+
+
+def _written_views(kvc, slots):
+    blocks = kvc.view(N_BLOCKS, -1)
+    rows_v, rows_s, rows_r = [], [], []
+    for slot in slots.tolist():
+        blk, off = slot // KV_BLOCK, slot % KV_BLOCK
+        row = blocks[blk]
+        vals = row[: KV_BLOCK * TOKEN_STRIDE].view(KV_BLOCK, TOKEN_STRIDE)[off]
+        scale = row[KV_BLOCK * TOKEN_STRIDE :].view(KV_BLOCK, SCALE_DIM)[off]
+        rows_v.append(vals[:NOPE])
+        rows_r.append(vals[NOPE:TOKEN_STRIDE])
+        rows_s.append(scale)
+    return (
+        torch.stack(rows_v),  # FP8 value bytes
+        torch.stack(rows_s),  # encoded scale bytes
+        torch.stack(rows_r),  # RoPE BF16 tail bytes
+    )
+
+
+@pytest.mark.parametrize("m", [16, 32, 64, 2048])
+def test_sparse_compress_parity_4_vs_16_warps(m):
+    slots = _written_slots(m)
+    assert slots.numel() > 0, "test must exercise written rows"
+    for seed in (0, 1, 2):
+        a = _run(m, 4, seed)
+        b = _run(m, 16, seed)
+        fa, sa, ra = _written_views(a, slots)
+        fb, sb, rb = _written_views(b, slots)
+        # B200-measured behavior is byte-identical on every written row;
+        # compare the three written regions separately so any future
+        # divergence is attributable to values, scales, or the RoPE tail.
+        assert torch.equal(sa, sb), f"M={m} seed={seed}: scale bytes differ"
+        # FP8/BF16 regions: compare decoded VALUES, not raw bytes. Reduction
+        # reorder can flip a signed zero (0x00 vs 0x80 encode the same 0.0;
+        # observed on GB200 at M=2048), which is byte-different but
+        # value-identical.
+        da = _dequant_rows(fa, sa)
+        db = _dequant_rows(fb, sb)
+        if not torch.equal(da, db):
+            # Reduction reorder can flip an FP8 rounding tie on isolated
+            # values (observed on GB200: 1 value in ~4.6e5 differing by one
+            # quantization step, 1.5e-5). Bound the fraction and magnitude
+            # instead of requiring bit equality across schedulers.
+            frac = (da != db).float().mean().item()
+            err = (da - db).abs().max().item()
+            rel = ((da - db).abs() / db.abs().clamp_min(1e-6)).max().item()
+            assert frac < 1e-4, f"M={m} seed={seed}: mismatch fraction {frac:.2e}"
+            assert err < 0.25, f"M={m} seed={seed}: dequant max abs {err:.6f}"
+            assert rel < 0.25, f"M={m} seed={seed}: dequant max rel {rel:.4f}"
+        va = ra.view(torch.bfloat16).float()
+        vb = rb.view(torch.bfloat16).float()
+        assert torch.equal(va, vb), f"M={m} seed={seed}: RoPE tail values differ"
+
+
+def _dequant_rows(fp8_bytes, scale_bytes):
+    fp8 = fp8_bytes.view(torch.float8_e4m3fn).float()
+    exp = scale_bytes[:, : NOPE // ops.DEEPSEEK_V4_FP8_QUANT_BLOCK].float() - 127.0
+    scale = torch.exp2(exp).repeat_interleave(ops.DEEPSEEK_V4_FP8_QUANT_BLOCK, dim=-1)
+    return fp8 * scale
+
+
+@pytest.mark.parametrize("m", [16, 64])
+def test_sparse_compress_parity_partial_window_with_base_offsets(m):
+    # Production passes state_base_logical_page; when the reduction window
+    # crosses the base offset, leading rows resolve to table_idx < 0 and are
+    # masked. The masked-softmax reduction is exactly where a warp-count
+    # change reorganizes the computation, so compare 4 vs 16 warps here too.
+    # pos[1::4] = 1023 boundaries: rows 896..959 fall below base page 15 and
+    # are masked, rows 960..1023 stay valid -> a genuine partial window.
+    base = torch.full((4,), 15, device="cuda:0", dtype=torch.int32)
+    # Only the pos=1023 boundaries have a genuine partial window here; the
+    # pos=127 boundaries fall entirely below base page 15 (all-masked window,
+    # undefined softmax output) and are excluded from byte comparison.
+    pos = torch.arange(m, dtype=torch.int64) + 4096
+    pos[0::4] = RATIO - 1
+    pos[1::4] = 8 * RATIO - 1
+    kv_slot = torch.arange(m, dtype=torch.int64) + 3
+    slots = kv_slot[((pos + 1) % RATIO == 0) & (pos == 8 * RATIO - 1)]
+    assert slots.numel() > 0
+    for seed in (0, 1):
+        a = _run(m, 4, seed, base_offsets=base)
+        b = _run(m, 16, seed, base_offsets=base)
+        fa, sa, ra = _written_views(a, slots)
+        fb, sb, rb = _written_views(b, slots)
+        assert torch.equal(sa, sb), f"M={m} seed={seed}: scale bytes differ"
+        da, db = _dequant_rows(fa, sa), _dequant_rows(fb, sb)
+        assert (da != db).float().mean().item() < 1e-4 and (
+            da - db
+        ).abs().max().item() < 0.25, f"M={m} seed={seed}: FP8 values differ"
+        assert torch.equal(
+            ra.view(torch.bfloat16).float(), rb.view(torch.bfloat16).float()
+        ), f"M={m} seed={seed}: RoPE tail values differ"


### PR DESCRIPTION
## Summary

Launch change for the fused sparse compress cache insert: 16 warps when `compress_ratio >= 128` on validated targets (NVIDIA sm100 only, gated by `_wide_compress_launch_supported()`; all other targets including ROCm keep 4 warps), plus launch-config and GPU parity tests.

Boundary tokens reduce a (1+overlap)*ratio x HEAD window inside one CTA: 128 rows on the production HCA path (overlap=False); overlapping configurations reduce 256. At 4 warps that reduction is severely under-parallelized.

## Evidence

- Microbench (B200, graph replay): boundary path 450-730us -> 143-190us (3-3.8x); prefill shapes ratio=128 M=8192: 905 -> 281us; ratio=4 path unchanged (kept at 4 warps, where 16 is slightly slower).
- p8 exact decode trace (same protocol pair): kernel-sum 2.184 -> 0.561 ms/step (-74%, 36.2 -> 9.3 us/call, 60 calls/step).
- Cadence in that trace improved 0.56 ms/step, but the traced tree also contained the SWA sanitize hoist (#614); the cadence change is not isolated to this patch.
- Endpoint gain is not certified: expected magnitude (~2%) is below current arm-level measurement noise.
- Numerics: the wide launch can reorder fp32 reductions before FP8/BF16 quantization. GPU parity tests (production HCA shape ratio=128/overlap=False, M in {16,32,64,2048}, multi-seed) compare every byte of every WRITTEN row at 4 vs 16 warps — FP8 values, encoded scales, and the RoPE BF16 tail as separate regions — including a partial-window case where block_table_base_offsets masks the leading window rows. On B200 all written rows are byte-identical (asserted with torch.equal).
- Microbench overlap note: the 3-3.8x boundary-path numbers were measured on a synthetic overlap=True (256-row) shape; the production claim is carried by the exact trace (36.2 -> 9.3 us/call).
- Scope: 16-warp launch is gated to NVIDIA sm100; ROCm and other targets keep 4 warps by construction.

Tests: 5 launch-config tests (wide/narrow launch per ratio, unsupported-target fallback, one-program-per-token grid, empty batch) + 6 GPU parity cases (sm100-gated). The 16-warp gate is cached per device (mixed-architecture processes pick per-GPU).






## Update: interaction with the newer #563 prefill-fusion commits (2026-07-10)

#563's `HCA_BLOCK_TABLE_CAPACITY` constexpr touches the same kernel. Re-microbenched on a stack including those commits (B200, production HCA shape, boundary tokens):

| M | 4 warps | 16 warps | speedup |
| ---: | ---: | ---: | ---: |
| 16-64 (constexpr path) | 142-191 us | 63-73 us | 2.2-2.6x |
| 16-64 (legacy path) | 145-192 us | 43-47 us | 3.3-4.0x |
| 2048 prefill | 221-222 us | 52-92 us | 2.4-4.3x |

- The 16-warp win survives the newer #563 base (2.2-4x on the boundary reduction); absolute per-step savings there are smaller than on the base this PR was first traced on, so the endpoint claim remains "kernel-level only".
- Noted for joint tuning: at 16 warps the pow2-bucket constexpr path measures slower than the legacy runtime-bound path (63 vs 44 us); capacity specialization and warp count interact.
- This PR stays main-based; if #563 merges first, the known conflict in this file (`max_gather_len`, `HCA_BLOCK_TABLE_CAPACITY`) resolves by applying this one-line launch change on top (verified resolution exists).