### PR TITLE
feat(attention): add fp8 support to gfx950 gluon MHA kernels

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mha.py
@@ -121,10 +121,13 @@ class MHAAttnBackend(AttentionBackend):
         self.head_dim = config.head_dim
         self.qkv_dtype = config.dtype
         self.kv_cache_dtype = config.kv_cache_dtype
-        self.is_fp8 = self.kv_cache_dtype == torch.float8_e4m3fn
+        self.is_fp8 = self.kv_cache_dtype in (
+            torch.float8_e4m3fn,
+            torch.float8_e5m2,
+        )
         self.plan = partial(
             mha_plan,
-            dtype=torch.float8_e4m3fn if self.is_fp8 else self.qkv_dtype,
+            dtype=self.kv_cache_dtype if self.is_fp8 else self.qkv_dtype,
             head_dim=self.head_dim,
             return_lse=False,
             solution=self.kernel_solution,
@@ -470,9 +473,9 @@ class MHAAttnBackend(AttentionBackend):
         _scrub_extend_padding(metadata, q, k, v)
         # TODO: use a custom kernel to do downcast
         if self.is_fp8:
-            q = q.to(torch.float8_e4m3fn)
-            k = k.to(torch.float8_e4m3fn)
-            v = v.to(torch.float8_e4m3fn)
+            q = q.to(self.kv_cache_dtype)
+            k = k.to(self.kv_cache_dtype)
+            v = v.to(self.kv_cache_dtype)
 
         output = mha_prefill(
             q=q,
@@ -508,7 +511,7 @@ class MHAAttnBackend(AttentionBackend):
             self._save_kv_cache(layer, out_cache_loc, token_to_kv_pool, k, v)
 
         if self.is_fp8:
-            q = q.to(torch.float8_e4m3fn)
+            q = q.to(self.kv_cache_dtype)
 
         k_cache, v_cache = self._get_kv_cache(layer, token_to_kv_pool)
         output = mha_extend_with_kvcache(
@@ -548,7 +551,7 @@ class MHAAttnBackend(AttentionBackend):
             self._save_kv_cache(layer, out_cache_loc, token_to_kv_pool, k, v)
 
         if self.is_fp8:
-            q = q.to(torch.float8_e4m3fn)
+            q = q.to(self.kv_cache_dtype)
 
         k_cache, v_cache = self._get_kv_cache(layer, token_to_kv_pool)
         max_seqlen_q = q.shape[0] // metadata.seq_lens.shape[0]
@@ -582,7 +585,10 @@ class MHAAttnBackend(AttentionBackend):
         if k is None:
             return
 
-        if self.is_fp8 and k.dtype != torch.float8_e4m3fn:
+        if (
+            self.kv_cache_dtype == torch.float8_e4m3fn
+            and k.dtype != torch.float8_e4m3fn
+        ):
             k_cache, v_cache = token_to_kv_pool.get_kv_buffer(layer.layer_id)
             fused_fp8_set_kv_buffer(
                 k=k,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/__init__.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/__init__.py
@@ -22,12 +22,12 @@
 
 from __future__ import annotations
 
-from tokenspeed_kernel_amd.ops.attention.gluon.mha_decode_fp16_gfx950 import (  # noqa: F401
-    gluon_mha_decode_fp16_gfx950,
+from tokenspeed_kernel_amd.ops.attention.gluon.mha_decode_gfx950 import (  # noqa: F401
+    gluon_mha_decode_gfx950,
 )
-from tokenspeed_kernel_amd.ops.attention.gluon.mha_extend_fp16_gfx950 import (  # noqa: F401
-    gluon_mha_extend_fp16_gfx950,
+from tokenspeed_kernel_amd.ops.attention.gluon.mha_extend_gfx950 import (  # noqa: F401
+    gluon_mha_extend_gfx950,
 )
-from tokenspeed_kernel_amd.ops.attention.gluon.mha_prefill_fp16_gfx950 import (  # noqa: F401
-    gluon_mha_prefill_fp16_gfx950,
+from tokenspeed_kernel_amd.ops.attention.gluon.mha_prefill_gfx950 import (  # noqa: F401
+    gluon_mha_prefill_gfx950,
 )

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_decode_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_decode_gfx950.py
@@ -851,7 +851,7 @@ def gluon_mha_decode_gfx950(
         window_left=window_left,
     )
 
-    is_fp8 = q.dtype == torch.float8_e4m3fn
+    is_fp8 = q.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
     out_dtype = torch.bfloat16 if is_fp8 else q.dtype
     output = torch.empty(q.shape, device=q.device, dtype=out_dtype)
 

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_decode_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_decode_gfx950.py
@@ -60,6 +60,7 @@ class AttentionConfig:
     BLOCK_N: gl.constexpr
     IS_SLIDING: gl.constexpr
     WINDOW_LEFT: gl.constexpr
+    IS_FP8: gl.constexpr
     GROUP_SIZE: gl.constexpr
     NUM_GROUPS: gl.constexpr
     q_strides: InputStrides
@@ -90,10 +91,11 @@ class AttentionConfig:
         BLOCK_N,
         IS_SLIDING,
         WINDOW_LEFT,
+        IS_FP8,
         q_strides,
     ):
         assert NUM_Q_HEADS % NUM_KV_HEADS == 0
-        assert HEAD_DIM == 64
+        assert HEAD_DIM in (64, 128)
         assert BLOCK_N == PAGE_SIZE
         if IS_SLIDING:
             assert WINDOW_LEFT >= 0
@@ -108,18 +110,39 @@ class AttentionConfig:
         )
         qk_layout = mfma_layout
         pv_layout = mfma_layout
-        q_layout = gl.DotOperandLayout(0, qk_layout, k_width=8)
-        k_layout = gl.DotOperandLayout(1, qk_layout, k_width=8)
-        p_layout = gl.DotOperandLayout(0, pv_layout, k_width=4)
-        v_layout = gl.DotOperandLayout(1, pv_layout, k_width=4)
-        load_layout = gl.BlockedLayout([1, 8], [8, 8], [1, 1], [1, 0])
-        store_layout = gl.BlockedLayout([1, 8], [8, 8], [1, 1], [1, 0])
-        reduce_layout = gl.BlockedLayout([1, 1], [1, 64], [1, 1], [1, 0])
+        # qk_kw is derived from a 128-bit load / dtype bitwidth.
+        # pv_kw is empirically tuned.
+        qk_kw = 16 if IS_FP8 else 8
+        pv_kw = 8 if IS_FP8 else 4
+        q_layout = gl.DotOperandLayout(0, qk_layout, k_width=qk_kw)
+        k_layout = gl.DotOperandLayout(1, qk_layout, k_width=qk_kw)
+        p_layout = gl.DotOperandLayout(0, pv_layout, k_width=pv_kw)
+        v_layout = gl.DotOperandLayout(1, pv_layout, k_width=pv_kw)
+        # load_vec is the number of elements per lane, depends on the input dtype, same as qk_kw.
+        # load_threads is how many lanes span HEAD_DIM.
+        load_vec = 16 if IS_FP8 else 8
+        load_threads = HEAD_DIM // load_vec
+        load_layout = gl.BlockedLayout(
+            [1, load_vec], [64 // load_threads, load_threads], [1, 1], [1, 0]
+        )
+        # store_vec depends on the output dtype, always 16-bit regardless of input dtype, so 128 / 16 = 8.
+        # store_threads is how many lanes span HEAD_DIM.
+        store_vec = 8
+        store_threads = HEAD_DIM // store_vec
+        store_layout = gl.BlockedLayout(
+            [1, store_vec], [64 // store_threads, store_threads], [1, 1], [1, 0]
+        )
+        reduce_layout = gl.BlockedLayout([1, HEAD_DIM // 64], [1, 64], [1, 1], [1, 0])
+        # Padding interval is 64 lanes * load_vec elems.
+        pad_interval = 64 * load_vec
+        # Empirically tuned.
+        pad_k = 16 if IS_FP8 else 8
+        pad_v = 32
         k_smem_layout = gl.PaddedSharedLayout.with_identity_for(
-            [[512, 8]], [BLOCK_N, HEAD_DIM], [1, 0]
+            [[pad_interval, pad_k]], [BLOCK_N, HEAD_DIM], [1, 0]
         )
         v_smem_layout = gl.PaddedSharedLayout.with_identity_for(
-            [[512, 32]], [BLOCK_N, HEAD_DIM], [1, 0]
+            [[pad_interval, pad_v]], [BLOCK_N, HEAD_DIM], [1, 0]
         )
 
         self.SM_SCALE = gl.constexpr(SM_SCALE)
@@ -134,6 +157,7 @@ class AttentionConfig:
         self.BLOCK_N = gl.constexpr(BLOCK_N)
         self.IS_SLIDING = gl.constexpr(IS_SLIDING)
         self.WINDOW_LEFT = gl.constexpr(WINDOW_LEFT)
+        self.IS_FP8 = gl.constexpr(IS_FP8)
         self.GROUP_SIZE = gl.constexpr(NUM_Q_HEADS // NUM_KV_HEADS)
         self.NUM_GROUPS = gl.constexpr((self.GROUP_SIZE + BLOCK_M - 1) // BLOCK_M)
         self.q_strides = q_strides
@@ -484,6 +508,7 @@ def _mha_decode_fp16(
     BLOCK_N: gl.constexpr,
     IS_SLIDING: gl.constexpr,
     WINDOW_LEFT: gl.constexpr,
+    IS_FP8: gl.constexpr,
 ):
     cfg = AttentionConfig(
         SM_SCALE,
@@ -498,6 +523,7 @@ def _mha_decode_fp16(
         BLOCK_N,
         IS_SLIDING,
         WINDOW_LEFT,
+        IS_FP8,
         InputStrides(Q_STRIDE_B, Q_STRIDE_H, Q_STRIDE_D),
     )
     program = AttentionProgram.create(
@@ -567,6 +593,7 @@ def _mha_decode_sliding_fp16(
     IS_SLIDING: gl.constexpr,
     WINDOW_LEFT: gl.constexpr,
     HAS_SINK: gl.constexpr,
+    IS_FP8: gl.constexpr,
 ):
     cfg = AttentionConfig(
         SM_SCALE,
@@ -581,6 +608,7 @@ def _mha_decode_sliding_fp16(
         BLOCK_N,
         IS_SLIDING,
         WINDOW_LEFT,
+        IS_FP8,
         InputStrides(Q_STRIDE_B, Q_STRIDE_H, Q_STRIDE_D),
     )
     program = AttentionProgram.create(
@@ -639,6 +667,7 @@ def _mha_decode_reduce_fp16(
     BLOCK_M: gl.constexpr,
     BLOCK_N: gl.constexpr,
     HAS_SINK: gl.constexpr,
+    IS_FP8: gl.constexpr,
 ):
     cfg = AttentionConfig(
         SM_SCALE,
@@ -653,6 +682,7 @@ def _mha_decode_reduce_fp16(
         BLOCK_N,
         False,  # IS_SLIDING
         -1,  # WINDOW_LEFT
+        IS_FP8,
         InputStrides(1, 1, 1),
     )
     q_index = gl.program_id(0)
@@ -797,7 +827,7 @@ def get_config(
     )
 
 
-def gluon_mha_decode_fp16_gfx950(
+def gluon_mha_decode_gfx950(
     q: torch.Tensor,
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
@@ -821,7 +851,9 @@ def gluon_mha_decode_fp16_gfx950(
         window_left=window_left,
     )
 
-    output = torch.empty(q.shape, device=q.device, dtype=q.dtype)
+    is_fp8 = q.dtype == torch.float8_e4m3fn
+    out_dtype = torch.bfloat16 if is_fp8 else q.dtype
+    output = torch.empty(q.shape, device=q.device, dtype=out_dtype)
 
     if config.is_sliding:
         # No split-k for sliding window attention
@@ -849,6 +881,7 @@ def gluon_mha_decode_fp16_gfx950(
             config.is_sliding,
             config.window_left,
             has_sink,
+            is_fp8,
             num_warps=1,
         )
     else:
@@ -892,6 +925,7 @@ def gluon_mha_decode_fp16_gfx950(
             config.block_n,
             config.is_sliding,
             config.window_left,
+            is_fp8,
             num_warps=1,
         )
 
@@ -915,6 +949,7 @@ def gluon_mha_decode_fp16_gfx950(
             config.block_m,
             config.block_n,
             has_sink,
+            is_fp8,
             num_warps=1,
         )
     return output

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_extend_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_extend_gfx950.py
@@ -106,6 +106,7 @@ class ExtendConfig:
     HAS_SINK: gl.constexpr
     HAS_LSE: gl.constexpr
     WINDOW_LEFT: gl.constexpr
+    IS_FP8: gl.constexpr
     q_strides: InputStrides
     qk_layout: gl.constexpr
     pv_layout: gl.constexpr
@@ -134,26 +135,47 @@ class ExtendConfig:
         HAS_SINK,
         HAS_LSE,
         WINDOW_LEFT,
+        IS_FP8,
         q_strides,
     ):
-        assert HEAD_DIM == 64
+        assert HEAD_DIM in (64, 128)
         assert BLOCK_N == PAGE_SIZE
 
+        # fp8 has no valid [32,32,16] MFMA; use the [16,16,32] shape (same as the
+        # decode kernel) which lowers to the CDNA4 fp8 MFMA with k_width=16.
+        instr_shape = [16, 16, 32] if IS_FP8 else [32, 32, 16]
         mfma_layout = gl.amd.AMDMFMALayout(
             version=4,
-            instr_shape=[32, 32, 16],
+            instr_shape=instr_shape,
             transposed=True,
             warps_per_cta=[NUM_WARPS, 1],
         )
         qk_layout = mfma_layout
         pv_layout = mfma_layout
-        load_layout = gl.BlockedLayout([1, 8], [8, 8], [NUM_WARPS, 1], [1, 0])
-        store_layout = load_layout
+        # load_vec is the number of elements per lane, depends on the input dtype, same as qk_kw.
+        # load_threads is how many lanes span HEAD_DIM.
+        load_vec = 16 if IS_FP8 else 8
+        load_threads = HEAD_DIM // load_vec
+        load_layout = gl.BlockedLayout(
+            [1, load_vec], [64 // load_threads, load_threads], [NUM_WARPS, 1], [1, 0]
+        )
+        # store_vec depends on the output dtype, always 16-bit regardless of input dtype, so 128 / 16 = 8.
+        # store_threads is how many lanes span HEAD_DIM.
+        store_vec = 8
+        store_threads = HEAD_DIM // store_vec
+        store_layout = gl.BlockedLayout(
+            [1, store_vec], [64 // store_threads, store_threads], [NUM_WARPS, 1], [1, 0]
+        )
+        # Padding interval is 64 lanes * load_vec elems.
+        pad_interval = 64 * load_vec
+        # Empirically tuned.
+        pad_k = 16 if IS_FP8 else 8
+        pad_v = 16 if IS_FP8 else 32
         k_smem_layout = gl.PaddedSharedLayout.with_identity_for(
-            [[512, 8]], [BLOCK_N, HEAD_DIM], [1, 0]
+            [[pad_interval, pad_k]], [BLOCK_N, HEAD_DIM], [1, 0]
         )
         v_smem_layout = gl.PaddedSharedLayout.with_identity_for(
-            [[512, 32]], [BLOCK_N, HEAD_DIM], [1, 0]
+            [[pad_interval, pad_v]], [BLOCK_N, HEAD_DIM], [1, 0]
         )
 
         self.N_HEADS = gl.constexpr(N_HEADS)
@@ -170,13 +192,18 @@ class ExtendConfig:
         self.HAS_SINK = gl.constexpr(HAS_SINK)
         self.HAS_LSE = gl.constexpr(HAS_LSE)
         self.WINDOW_LEFT = gl.constexpr(WINDOW_LEFT)
+        self.IS_FP8 = gl.constexpr(IS_FP8)
         self.q_strides = q_strides
         self.qk_layout = gl.constexpr(qk_layout)
         self.pv_layout = gl.constexpr(pv_layout)
-        self.q_layout = gl.constexpr(gl.DotOperandLayout(0, qk_layout, k_width=8))
-        self.k_layout = gl.constexpr(gl.DotOperandLayout(1, qk_layout, k_width=8))
-        self.p_layout = gl.constexpr(gl.DotOperandLayout(0, pv_layout, k_width=4))
-        self.v_layout = gl.constexpr(gl.DotOperandLayout(1, pv_layout, k_width=4))
+        # qk_kw is derived from a 128-bit load / dtype bitwidth.
+        # pv_kw is empirically tuned.
+        qk_kw = 16 if IS_FP8 else 8
+        pv_kw = 16 if IS_FP8 else 4
+        self.q_layout = gl.constexpr(gl.DotOperandLayout(0, qk_layout, k_width=qk_kw))
+        self.k_layout = gl.constexpr(gl.DotOperandLayout(1, qk_layout, k_width=qk_kw))
+        self.p_layout = gl.constexpr(gl.DotOperandLayout(0, pv_layout, k_width=pv_kw))
+        self.v_layout = gl.constexpr(gl.DotOperandLayout(1, pv_layout, k_width=pv_kw))
         self.load_layout = gl.constexpr(load_layout)
         self.store_layout = gl.constexpr(store_layout)
         self.k_smem_layout = gl.constexpr(k_smem_layout)
@@ -486,6 +513,7 @@ def _mha_extend_fp16(
     HAS_SINK: gl.constexpr,
     HAS_LSE: gl.constexpr,
     WINDOW_LEFT: gl.constexpr,
+    IS_FP8: gl.constexpr,
 ):
     cfg = ExtendConfig(
         N_HEADS,
@@ -501,6 +529,7 @@ def _mha_extend_fp16(
         HAS_SINK,
         HAS_LSE,
         WINDOW_LEFT,
+        IS_FP8,
         InputStrides(Q_STRIDE_T, Q_STRIDE_H, Q_STRIDE_D),
     )
     program = ExtendProgram.create(
@@ -598,7 +627,7 @@ def _mha_extend_fp16(
     program.store_lse(l_i, m_i)
 
 
-def gluon_mha_extend_fp16_gfx950(
+def gluon_mha_extend_gfx950(
     q: torch.Tensor,
     cu_seqlens_q: torch.Tensor,
     cu_seqlens_kv: torch.Tensor,
@@ -630,7 +659,9 @@ def gluon_mha_extend_fp16_gfx950(
     cu_q_i32 = cu_seqlens_q.to(torch.int32).contiguous()
     cache_i32 = cache_seqlens.to(torch.int32).contiguous()
 
-    output = torch.empty(q.shape, device=q.device, dtype=q.dtype)
+    is_fp8 = q.dtype == torch.float8_e4m3fn
+    out_dtype = torch.bfloat16 if is_fp8 else q.dtype
+    output = torch.empty(q.shape, device=q.device, dtype=out_dtype)
     if return_lse:
         lse = torch.empty((q.shape[0], n_heads), device=q.device, dtype=torch.float32)
         lse_arg = lse
@@ -664,6 +695,7 @@ def gluon_mha_extend_fp16_gfx950(
         has_sink,
         return_lse,
         window_left,
+        is_fp8,
         num_warps=num_warps,
     )
     if return_lse:

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_extend_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_extend_gfx950.py
@@ -141,9 +141,7 @@ class ExtendConfig:
         assert HEAD_DIM in (64, 128)
         assert BLOCK_N == PAGE_SIZE
 
-        # fp8 has no valid [32,32,16] MFMA; use the [16,16,32] shape (same as the
-        # decode kernel) which lowers to the CDNA4 fp8 MFMA with k_width=16.
-        instr_shape = [16, 16, 32] if IS_FP8 else [32, 32, 16]
+        instr_shape = [32, 32, 16]
         mfma_layout = gl.amd.AMDMFMALayout(
             version=4,
             instr_shape=instr_shape,
@@ -659,7 +657,7 @@ def gluon_mha_extend_gfx950(
     cu_q_i32 = cu_seqlens_q.to(torch.int32).contiguous()
     cache_i32 = cache_seqlens.to(torch.int32).contiguous()
 
-    is_fp8 = q.dtype == torch.float8_e4m3fn
+    is_fp8 = q.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
     out_dtype = torch.bfloat16 if is_fp8 else q.dtype
     output = torch.empty(q.shape, device=q.device, dtype=out_dtype)
     if return_lse:

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_prefill_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_prefill_gfx950.py
@@ -60,6 +60,7 @@ class AttentionConfig:
     WINDOW_LEFT: gl.constexpr
     NUM_XCDS: gl.constexpr
     NUM_BLOCKS: gl.constexpr
+    IS_FP8: gl.constexpr
     q_strides: InputStrides
     k_strides: InputStrides
     v_strides: InputStrides
@@ -88,32 +89,53 @@ class AttentionConfig:
         HAS_SINK,
         HAS_LSE,
         WINDOW_LEFT,
+        IS_FP8,
         q_strides,
         k_strides,
         v_strides,
     ):
-        assert HEAD_DIM == 64
+        assert HEAD_DIM in (64, 128)
         assert NUM_WARPS == 4
 
+        # fp8 has no valid [32,32,16] MFMA; use the [16,16,32] shape which lowers
+        # to the CDNA4 fp8 MFMA with k_width=16.
+        instr_shape = [16, 16, 32] if IS_FP8 else [32, 32, 16]
         qk_layout = gl.amd.AMDMFMALayout(
             version=4,
-            instr_shape=[32, 32, 16],
+            instr_shape=instr_shape,
             transposed=True,
             warps_per_cta=[NUM_WARPS, 1],
         )
         pv_layout = gl.amd.AMDMFMALayout(
             version=4,
-            instr_shape=[32, 32, 16],
+            instr_shape=instr_shape,
             transposed=True,
             warps_per_cta=[NUM_WARPS, 1],
         )
-        load_layout = gl.BlockedLayout([1, 8], [8, 8], [4, 1], [1, 0])
-        store_layout = load_layout
+        # load_vec is the number of elements per lane, depends on the input dtype, same as qk_kw.
+        # load_threads is how many lanes span HEAD_DIM.
+        load_vec = 16 if IS_FP8 else 8
+        load_threads = HEAD_DIM // load_vec
+        load_layout = gl.BlockedLayout(
+            [1, load_vec], [64 // load_threads, load_threads], [4, 1], [1, 0]
+        )
+        # store_vec depends on the output dtype, always 16-bit regardless of input dtype, so 128 / 16 = 8.
+        # store_threads is how many lanes span HEAD_DIM.
+        store_vec = 8
+        store_threads = HEAD_DIM // store_vec
+        store_layout = gl.BlockedLayout(
+            [1, store_vec], [64 // store_threads, store_threads], [4, 1], [1, 0]
+        )
+        # Padding interval is 64 lanes * load_vec elems.
+        pad_interval = 64 * load_vec
+        # Empirically tuned.
+        pad_k = 16 if IS_FP8 else 8
+        pad_v = 16 if IS_FP8 else 32
         k_smem_layout = gl.PaddedSharedLayout.with_identity_for(
-            [[512, 8]], [BLOCK_N, HEAD_DIM], [1, 0]
+            [[pad_interval, pad_k]], [BLOCK_N, HEAD_DIM], [1, 0]
         )
         v_smem_layout = gl.PaddedSharedLayout.with_identity_for(
-            [[512, 32]], [BLOCK_N, HEAD_DIM], [1, 0]
+            [[pad_interval, pad_v]], [BLOCK_N, HEAD_DIM], [1, 0]
         )
         self.N_HEADS = gl.constexpr(N_HEADS)
         self.N_KV_HEADS = gl.constexpr(N_KV_HEADS)
@@ -128,15 +150,20 @@ class AttentionConfig:
         self.WINDOW_LEFT = gl.constexpr(WINDOW_LEFT)
         self.NUM_XCDS = gl.constexpr(8)
         self.NUM_BLOCKS = gl.constexpr(512)
+        self.IS_FP8 = gl.constexpr(IS_FP8)
         self.q_strides = q_strides
         self.k_strides = k_strides
         self.v_strides = v_strides
         self.qk_layout = gl.constexpr(qk_layout)
         self.pv_layout = gl.constexpr(pv_layout)
-        q_layout = gl.DotOperandLayout(0, qk_layout, k_width=8)
-        k_layout = gl.DotOperandLayout(1, qk_layout, k_width=8)
-        p_layout = gl.DotOperandLayout(0, pv_layout, k_width=4)
-        v_layout = gl.DotOperandLayout(1, pv_layout, k_width=4)
+        # qk_kw is derived from a 128-bit load / dtype bitwidth.
+        # pv_kw is empirically tuned.
+        qk_kw = 16 if IS_FP8 else 8
+        pv_kw = 16 if IS_FP8 else 4
+        q_layout = gl.DotOperandLayout(0, qk_layout, k_width=qk_kw)
+        k_layout = gl.DotOperandLayout(1, qk_layout, k_width=qk_kw)
+        p_layout = gl.DotOperandLayout(0, pv_layout, k_width=pv_kw)
+        v_layout = gl.DotOperandLayout(1, pv_layout, k_width=pv_kw)
         self.q_layout = gl.constexpr(q_layout)
         self.k_layout = gl.constexpr(k_layout)
         self.p_layout = gl.constexpr(p_layout)
@@ -865,6 +892,7 @@ def _mha_prefill_fp16(
     HAS_SINK: gl.constexpr,
     HAS_LSE: gl.constexpr,
     WINDOW_LEFT: gl.constexpr,
+    IS_FP8: gl.constexpr,
 ):
     cfg = AttentionConfig(
         N_HEADS,
@@ -878,6 +906,7 @@ def _mha_prefill_fp16(
         HAS_SINK,
         HAS_LSE,
         -1,
+        IS_FP8,
         InputStrides(Q_STRIDE_T, Q_STRIDE_H, Q_STRIDE_D),
         InputStrides(K_STRIDE_T, K_STRIDE_H, K_STRIDE_D),
         InputStrides(V_STRIDE_T, V_STRIDE_H, V_STRIDE_D),
@@ -950,6 +979,7 @@ def _mha_prefill_sliding_fp16(
     HAS_SINK: gl.constexpr,
     HAS_LSE: gl.constexpr,
     WINDOW_LEFT: gl.constexpr,
+    IS_FP8: gl.constexpr,
 ):
     cfg = AttentionConfig(
         N_HEADS,
@@ -963,6 +993,7 @@ def _mha_prefill_sliding_fp16(
         HAS_SINK,
         HAS_LSE,
         WINDOW_LEFT,
+        IS_FP8,
         InputStrides(Q_STRIDE_T, Q_STRIDE_H, Q_STRIDE_D),
         InputStrides(K_STRIDE_T, K_STRIDE_H, K_STRIDE_D),
         InputStrides(V_STRIDE_T, V_STRIDE_H, V_STRIDE_D),
@@ -1044,7 +1075,7 @@ def get_config(
     )
 
 
-def gluon_mha_prefill_fp16_gfx950(
+def gluon_mha_prefill_gfx950(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -1064,7 +1095,9 @@ def gluon_mha_prefill_fp16_gfx950(
         max_seqlen=max_seqlen,
         window_left=window_left,
     )
-    output = torch.empty(q.shape, device=q.device, dtype=q.dtype)
+    is_fp8 = q.dtype == torch.float8_e4m3fn
+    out_dtype = torch.bfloat16 if is_fp8 else q.dtype
+    output = torch.empty(q.shape, device=q.device, dtype=out_dtype)
     lse = (
         torch.empty((total_tokens, n_heads), device=q.device, dtype=torch.float32)
         if return_lse
@@ -1105,6 +1138,7 @@ def gluon_mha_prefill_fp16_gfx950(
         has_sink,
         has_lse,
         config.window_left,
+        is_fp8,
         num_warps=config.num_warps,
     )
     if return_lse:

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_prefill_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_prefill_gfx950.py
@@ -97,9 +97,7 @@ class AttentionConfig:
         assert HEAD_DIM in (64, 128)
         assert NUM_WARPS == 4
 
-        # fp8 has no valid [32,32,16] MFMA; use the [16,16,32] shape which lowers
-        # to the CDNA4 fp8 MFMA with k_width=16.
-        instr_shape = [16, 16, 32] if IS_FP8 else [32, 32, 16]
+        instr_shape = [32, 32, 16]
         qk_layout = gl.amd.AMDMFMALayout(
             version=4,
             instr_shape=instr_shape,
@@ -1095,7 +1093,7 @@ def gluon_mha_prefill_gfx950(
         max_seqlen=max_seqlen,
         window_left=window_left,
     )
-    is_fp8 = q.dtype == torch.float8_e4m3fn
+    is_fp8 = q.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
     out_dtype = torch.bfloat16 if is_fp8 else q.dtype
     output = torch.empty(q.shape, device=q.device, dtype=out_dtype)
     lse = (

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
@@ -55,7 +55,12 @@ if current_platform().is_amd:
         signatures=format_signatures(
             ("q", "k_cache", "v_cache"),
             "dense",
-            {torch.float16, torch.bfloat16, torch.float8_e4m3fn},
+            {
+                torch.float16,
+                torch.bfloat16,
+                torch.float8_e4m3fn,
+                torch.float8_e5m2,
+            },
         ),
         priority=Priority.SPECIALIZED,
         traits={
@@ -83,7 +88,12 @@ if current_platform().is_amd:
         signatures=format_signatures(
             ("q", "k", "v"),
             "dense",
-            {torch.float16, torch.bfloat16, torch.float8_e4m3fn},
+            {
+                torch.float16,
+                torch.bfloat16,
+                torch.float8_e4m3fn,
+                torch.float8_e5m2,
+            },
         ),
         priority=Priority.SPECIALIZED,
         traits={
@@ -110,7 +120,12 @@ if current_platform().is_amd:
         signatures=format_signatures(
             ("q", "k_cache", "v_cache"),
             "dense",
-            {torch.float16, torch.bfloat16, torch.float8_e4m3fn},
+            {
+                torch.float16,
+                torch.bfloat16,
+                torch.float8_e4m3fn,
+                torch.float8_e5m2,
+            },
         ),
         priority=Priority.SPECIALIZED,
         traits={

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
@@ -32,20 +32,20 @@ from tokenspeed_kernel.registry import Priority, register_kernel
 from tokenspeed_kernel.signature import format_signatures
 
 if current_platform().is_amd:
-    from tokenspeed_kernel_amd.ops.attention.gluon.mha_decode_fp16_gfx950 import (
-        gluon_mha_decode_fp16_gfx950 as _decode_impl,
+    from tokenspeed_kernel_amd.ops.attention.gluon.mha_decode_gfx950 import (
+        gluon_mha_decode_gfx950 as _decode_impl,
     )
-    from tokenspeed_kernel_amd.ops.attention.gluon.mha_extend_fp16_gfx950 import (
-        gluon_mha_extend_fp16_gfx950 as _extend_impl,
+    from tokenspeed_kernel_amd.ops.attention.gluon.mha_extend_gfx950 import (
+        gluon_mha_extend_gfx950 as _extend_impl,
     )
-    from tokenspeed_kernel_amd.ops.attention.gluon.mha_prefill_fp16_gfx950 import (
-        gluon_mha_prefill_fp16_gfx950 as _prefill_impl,
+    from tokenspeed_kernel_amd.ops.attention.gluon.mha_prefill_gfx950 import (
+        gluon_mha_prefill_gfx950 as _prefill_impl,
     )
 
     @register_kernel(
         "attention",
         "mha_decode_with_kvcache",
-        name="gluon_mha_decode_fp16_gfx950",
+        name="gluon_mha_decode_gfx950",
         solution="gluon",
         capability=CapabilityRequirement(
             min_arch_version=ArchVersion(9, 5),
@@ -55,11 +55,11 @@ if current_platform().is_amd:
         signatures=format_signatures(
             ("q", "k_cache", "v_cache"),
             "dense",
-            {torch.float16, torch.bfloat16},
+            {torch.float16, torch.bfloat16, torch.float8_e4m3fn},
         ),
         priority=Priority.SPECIALIZED,
         traits={
-            "head_dim": frozenset({64}),
+            "head_dim": frozenset({64, 128}),
             "page_size": frozenset({64}),
             "sliding_window": frozenset({False, True}),
             "support_sinks": frozenset({False, True}),
@@ -67,13 +67,13 @@ if current_platform().is_amd:
             "return_lse": frozenset({False}),
         },
     )
-    def gluon_mha_decode_fp16_gfx950(*args, **kwargs):
+    def gluon_mha_decode_gfx950(*args, **kwargs):
         return _decode_impl(*args, **kwargs)
 
     @register_kernel(
         "attention",
         "mha_prefill",
-        name="gluon_mha_prefill_fp16_gfx950",
+        name="gluon_mha_prefill_gfx950",
         solution="gluon",
         capability=CapabilityRequirement(
             min_arch_version=ArchVersion(9, 5),
@@ -81,24 +81,26 @@ if current_platform().is_amd:
             vendors=frozenset({"amd"}),
         ),
         signatures=format_signatures(
-            ("q", "k", "v"), "dense", {torch.float16, torch.bfloat16}
+            ("q", "k", "v"),
+            "dense",
+            {torch.float16, torch.bfloat16, torch.float8_e4m3fn},
         ),
         priority=Priority.SPECIALIZED,
         traits={
-            "head_dim": frozenset({64}),
+            "head_dim": frozenset({64, 128}),
             "sliding_window": frozenset({False, True}),
             "support_sinks": frozenset({False, True}),
             "support_logit_cap": frozenset({False}),
             "return_lse": frozenset({False, True}),
         },
     )
-    def gluon_mha_prefill_fp16_gfx950(*args, **kwargs):
+    def gluon_mha_prefill_gfx950(*args, **kwargs):
         return _prefill_impl(*args, **kwargs)
 
     @register_kernel(
         "attention",
         "mha_extend_with_kvcache",
-        name="gluon_mha_extend_fp16_gfx950",
+        name="gluon_mha_extend_gfx950",
         solution="gluon",
         capability=CapabilityRequirement(
             min_arch_version=ArchVersion(9, 5),
@@ -108,11 +110,11 @@ if current_platform().is_amd:
         signatures=format_signatures(
             ("q", "k_cache", "v_cache"),
             "dense",
-            {torch.float16, torch.bfloat16},
+            {torch.float16, torch.bfloat16, torch.float8_e4m3fn},
         ),
         priority=Priority.SPECIALIZED,
         traits={
-            "head_dim": frozenset({64}),
+            "head_dim": frozenset({64, 128}),
             "page_size": frozenset({64}),
             "is_causal": frozenset({False, True}),
             "sliding_window": frozenset({False, True}),
@@ -121,5 +123,5 @@ if current_platform().is_amd:
             "return_lse": frozenset({False, True}),
         },
     )
-    def gluon_mha_extend_fp16_gfx950(*args, **kwargs):
+    def gluon_mha_extend_gfx950(*args, **kwargs):
         return _extend_impl(*args, **kwargs)

--- a/tokenspeed-kernel/test/ops/test_attention.py
+++ b/tokenspeed-kernel/test/ops/test_attention.py
@@ -171,6 +171,8 @@ def test_mha_prefill_lse(
         pytest.param(torch.bfloat16, 128, 8, 2, id="bf16-d128"),
         pytest.param(torch.float8_e4m3fn, 64, 8, 2, id="fp8"),
         pytest.param(torch.float8_e4m3fn, 128, 8, 2, id="fp8-d128"),
+        pytest.param(torch.float8_e5m2, 64, 8, 2, id="fp8-e5m2"),
+        pytest.param(torch.float8_e5m2, 128, 8, 2, id="fp8-e5m2-d128"),
     ],
 )
 @pytest.mark.parametrize("solution", ["triton", "fa3", "fa4", "flashinfer", "gluon"])
@@ -304,6 +306,8 @@ def test_mha_extend_with_kvcache(
         pytest.param(torch.bfloat16, 128, 8, 2, id="bf16-d128"),
         pytest.param(torch.float8_e4m3fn, 64, 8, 2, id="fp8"),
         pytest.param(torch.float8_e4m3fn, 128, 8, 2, id="fp8-d128"),
+        pytest.param(torch.float8_e5m2, 64, 8, 2, id="fp8-e5m2"),
+        pytest.param(torch.float8_e5m2, 128, 8, 2, id="fp8-e5m2-d128"),
     ],
 )
 @pytest.mark.parametrize("solution", ["triton", "fa3", "fa4", "flashinfer", "gluon"])

--- a/tokenspeed-kernel/test/ops/test_attention.py
+++ b/tokenspeed-kernel/test/ops/test_attention.py
@@ -46,7 +46,10 @@ def _randn(shape: tuple[int, ...], *, device: str, dtype: torch.dtype) -> torch.
 
 @pytest.mark.parametrize(
     "dtype,head_dim,num_q_heads,num_kv_heads",
-    [(torch.bfloat16, 64, 8, 2)],
+    [
+        pytest.param(torch.bfloat16, 64, 8, 2, id="bf16-d64"),
+        pytest.param(torch.bfloat16, 128, 8, 2, id="bf16-d128"),
+    ],
 )
 @pytest.mark.parametrize("solution", ["triton", "fa3", "fa4", "gluon"])
 @pytest.mark.parametrize("has_sink", [False, True], ids=["no-sink", "sink"])
@@ -99,7 +102,10 @@ def test_mha_prefill(
 
 @pytest.mark.parametrize(
     "dtype,head_dim,num_q_heads,num_kv_heads",
-    [(torch.bfloat16, 64, 8, 2)],
+    [
+        pytest.param(torch.bfloat16, 64, 8, 2, id="bf16-d64"),
+        pytest.param(torch.bfloat16, 128, 8, 2, id="bf16-d128"),
+    ],
 )
 @pytest.mark.parametrize("solution", ["triton", "gluon"])
 def test_mha_prefill_lse(
@@ -162,7 +168,9 @@ def test_mha_prefill_lse(
     "dtype,head_dim,num_q_heads,num_kv_heads",
     [
         pytest.param(torch.bfloat16, 64, 8, 2, id="bf16"),
+        pytest.param(torch.bfloat16, 128, 8, 2, id="bf16-d128"),
         pytest.param(torch.float8_e4m3fn, 64, 8, 2, id="fp8"),
+        pytest.param(torch.float8_e4m3fn, 128, 8, 2, id="fp8-d128"),
     ],
 )
 @pytest.mark.parametrize("solution", ["triton", "fa3", "fa4", "flashinfer", "gluon"])
@@ -293,7 +301,9 @@ def test_mha_extend_with_kvcache(
     "dtype,head_dim,num_q_heads,num_kv_heads",
     [
         pytest.param(torch.bfloat16, 64, 8, 2, id="bf16"),
+        pytest.param(torch.bfloat16, 128, 8, 2, id="bf16-d128"),
         pytest.param(torch.float8_e4m3fn, 64, 8, 2, id="fp8"),
+        pytest.param(torch.float8_e4m3fn, 128, 8, 2, id="fp8-d128"),
     ],
 )
 @pytest.mark.parametrize("solution", ["triton", "fa3", "fa4", "flashinfer", "gluon"])

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -1098,7 +1098,7 @@ _CASES = [
         "cdna4",
         "attention",
         "mha_prefill",
-        "gluon_mha_prefill_fp16_gfx950",
+        "gluon_mha_prefill_gfx950",
         _attention_prefill,
     ),
     _case(
@@ -1106,7 +1106,7 @@ _CASES = [
         "cdna4",
         "attention",
         "mha_extend_with_kvcache",
-        "gluon_mha_extend_fp16_gfx950",
+        "gluon_mha_extend_gfx950",
         _attention_extend,
     ),
     _case(
@@ -1114,7 +1114,7 @@ _CASES = [
         "cdna4",
         "attention",
         "mha_decode_with_kvcache",
-        "gluon_mha_decode_fp16_gfx950",
+        "gluon_mha_decode_gfx950",
         _attention_decode,
     ),
     _case(


### PR DESCRIPTION
Current kernels support only `bf16 + head_dim=64`. This PR extends the support to cover three new cases: `bf16 + head_dim=128`, `fp8 + head_dim=64` and `fp8 + head_dim=128`.
