### PR TITLE
ci: drop mi350-1gpu-bench

### DIFF
--- a/test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi35x.yaml
+++ b/test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi35x.yaml
@@ -6,7 +6,6 @@ triggers:
   - manual
 runner:
   labels:
-    - amd-mi350-1gpu-bench
     - amd-mi355-1gpu-bench
 env:
   CI: "true"


### PR DESCRIPTION
mi355-1gpu-bench is stable enough lately so drop this one to save resources.