### PR TITLE
ci: reenable mi350-1gpu-bench and support optional jobs

### DIFF
--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -149,6 +149,7 @@ jobs:
     name: ${{ matrix.name }} (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
+    continue-on-error: ${{ matrix.optional }}
     env:
       # When the scan job determined that this run touched `tokenspeed-mla/`,
       # `install_deps.sh` will reinstall the in-tree source on top of the

--- a/.github/workflows/pr-test-nvidia-arm.yml
+++ b/.github/workflows/pr-test-nvidia-arm.yml
@@ -149,6 +149,7 @@ jobs:
     name: ${{ matrix.name }} (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
+    continue-on-error: ${{ matrix.optional }}
     env:
       # When the scan job determined that this run touched `tokenspeed-mla/`,
       # `install_deps.sh` will reinstall the in-tree source on top of the

--- a/.github/workflows/pr-test-nvidia.yml
+++ b/.github/workflows/pr-test-nvidia.yml
@@ -149,6 +149,7 @@ jobs:
     name: ${{ matrix.name }} (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
+    continue-on-error: ${{ matrix.optional }}
     env:
       # When the scan job determined that this run touched `tokenspeed-mla/`,
       # `install_deps.sh` will reinstall the in-tree source on top of the

--- a/test/ci/README.md
+++ b/test/ci/README.md
@@ -45,6 +45,20 @@ Typical use: lower a 1gpu kernel unit-test on `b300-1gpu` so the heavier
 b300-4gpu evals that share the same box claim the runner first, without
 disturbing the same task's ordering on the other GPU families.
 
+`optional` marks a task or per-label matrix entry as non-blocking.
+Optional entries are emitted with `matrix.optional: true`, and the PR workflows
+map that to GitHub Actions `continue-on-error`.
+
+```yaml
+# whole task can fail without blocking the workflow
+optional: true
+
+# only the MI355 bench entry is non-blocking; the MI350 entry of the same
+# task still blocks on failure
+optional:
+  amd-mi355-1gpu-bench: true
+```
+
 `b200-<Ngpu>` labels are the default B200 runners. Set the
 `TOKENSPEED_B200_RUNNER_LABEL` repository variable in GitHub Actions
 (`Settings` -> `Secrets and variables` -> `Actions` -> `Variables`) to a

--- a/test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi35x.yaml
+++ b/test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi35x.yaml
@@ -6,6 +6,7 @@ triggers:
   - manual
 runner:
   labels:
+    - amd-mi350-1gpu-bench
     - amd-mi355-1gpu-bench
 env:
   CI: "true"

--- a/test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi35x.yaml
+++ b/test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi35x.yaml
@@ -8,6 +8,8 @@ runner:
   labels:
     - amd-mi350-1gpu-bench
     - amd-mi355-1gpu-bench
+optional:
+  amd-mi355-1gpu-bench: true
 env:
   CI: "true"
 install:

--- a/test/ci_system/pipeline.py
+++ b/test/ci_system/pipeline.py
@@ -180,6 +180,31 @@ def validate_task(data: Dict[str, Any], path: Path) -> None:
                 f"{path}: priority must be a string or a per-label mapping; "
                 f"got {type(priority).__name__}"
             )
+    if "optional" in data:
+        optional = data["optional"]
+        if isinstance(optional, bool):
+            pass
+        elif isinstance(optional, dict):
+            unknown_labels = sorted(set(optional) - set(labels))
+            if unknown_labels:
+                raise ValueError(
+                    f"{path}: optional contains unknown labels: {unknown_labels}"
+                )
+            bad_values = sorted(
+                label
+                for label, value in optional.items()
+                if not isinstance(value, bool)
+            )
+            if bad_values:
+                raise ValueError(
+                    f"{path}: optional values must be booleans for labels: "
+                    f"{bad_values}"
+                )
+        else:
+            raise ValueError(
+                f"{path}: optional must be a boolean or a per-label mapping; "
+                f"got {type(optional).__name__}"
+            )
 
 
 def normalize_task(path: Path, repo_root: Path) -> Dict[str, Any]:
@@ -230,6 +255,17 @@ def resolve_priority_for_label(priority: Any, label: str) -> str:
     return DEFAULT_PRIORITY
 
 
+def resolve_optional_for_label(optional: Any, label: str) -> bool:
+    """Pick whether ``label`` is allowed to fail from task ``optional`` data."""
+    if optional is None:
+        return False
+    if isinstance(optional, bool):
+        return optional
+    if isinstance(optional, dict):
+        return optional.get(label, False)
+    return False
+
+
 def build_matrix(
     root: Path,
     repo_root: Path,
@@ -242,10 +278,13 @@ def build_matrix(
         if trigger and trigger not in task["triggers"]:
             continue
         priority = task.get("priority")
+        optional = task.get("optional")
         for label in task["runner"]["labels"]:
             # `priority` keys are the labels as written in YAML, so look
-            # up before `resolve_runner_label` rewrites b200 to b200v2.
+            # up per-label metadata before `resolve_runner_label` rewrites
+            # b200 to b200v2.
             effective = resolve_priority_for_label(priority, label)
+            is_optional = resolve_optional_for_label(optional, label)
             runner = resolve_runner_label(label)
             if not runner_matches_group(runner, runner_group):
                 continue
@@ -256,6 +295,7 @@ def build_matrix(
                     "config": task["_source_path"],
                     "runner": runner,
                     "priority": effective,
+                    "optional": is_optional,
                 }
             )
     # Stable sort: tasks at the same priority keep their file-path / label

--- a/test/ci_system/test_pipeline.py
+++ b/test/ci_system/test_pipeline.py
@@ -395,6 +395,61 @@ def test_validate_task_rejects_unknown_priority(tmp_path):
         validate_task(_yaml.safe_load(path.read_text()), path)
 
 
+def test_validate_task_accepts_boolean_optional(tmp_path):
+    body = _default_body("ut-a", ["b300-1gpu"], extra="optional: true\n")
+    path = _write_task_yaml(tmp_path, "optional.yaml", body)
+    import yaml as _yaml
+
+    validate_task(_yaml.safe_load(path.read_text()), path)
+
+
+def test_validate_task_rejects_non_boolean_optional(tmp_path):
+    body = _default_body("ut-a", ["b300-1gpu"], extra="optional: flaky\n")
+    path = _write_task_yaml(tmp_path, "bad-optional.yaml", body)
+    import yaml as _yaml
+
+    with pytest.raises(ValueError, match=r"optional must be a boolean"):
+        validate_task(_yaml.safe_load(path.read_text()), path)
+
+
+def test_validate_task_accepts_per_label_optional_dict(tmp_path):
+    body = _default_body(
+        "ut-a",
+        ["b300-1gpu", "h100-1gpu"],
+        extra="optional:\n  b300-1gpu: true\n",
+    )
+    path = _write_task_yaml(tmp_path, "per-label-optional.yaml", body)
+    import yaml as _yaml
+
+    validate_task(_yaml.safe_load(path.read_text()), path)
+
+
+def test_validate_task_rejects_per_label_optional_with_unknown_label(tmp_path):
+    body = _default_body(
+        "ut-a",
+        ["b300-1gpu"],
+        extra="optional:\n  h100-1gpu: true\n",
+    )
+    path = _write_task_yaml(tmp_path, "unknown-optional.yaml", body)
+    import yaml as _yaml
+
+    with pytest.raises(ValueError, match=r"optional contains unknown labels"):
+        validate_task(_yaml.safe_load(path.read_text()), path)
+
+
+def test_validate_task_rejects_per_label_optional_with_non_boolean_value(tmp_path):
+    body = _default_body(
+        "ut-a",
+        ["b300-1gpu"],
+        extra="optional:\n  b300-1gpu: flaky\n",
+    )
+    path = _write_task_yaml(tmp_path, "bad-optional-value.yaml", body)
+    import yaml as _yaml
+
+    with pytest.raises(ValueError, match=r"optional values must be booleans"):
+        validate_task(_yaml.safe_load(path.read_text()), path)
+
+
 def test_build_matrix_default_priority_preserves_existing_order(tmp_path):
     # Two tasks; both omit `priority`. Order must match the existing
     # behaviour: alphabetical by file path, then label order from the yaml.
@@ -415,6 +470,7 @@ def test_build_matrix_default_priority_preserves_existing_order(tmp_path):
         ("ut-b", "b200-1gpu"),
     ]
     assert all(e["priority"] == "normal" for e in matrix["include"])
+    assert all(e["optional"] is False for e in matrix["include"])
 
 
 def test_build_matrix_sorts_high_priority_before_low(tmp_path):
@@ -507,6 +563,23 @@ def test_build_matrix_per_label_priority_only_affects_listed_label(tmp_path):
         ("ut-kernel", "h100-1gpu", "normal"),
         ("ut-kernel", "b200-1gpu", "normal"),
         ("ut-kernel", "b300-1gpu", "low"),
+    ]
+
+
+def test_build_matrix_per_label_optional_only_affects_listed_label(tmp_path):
+    _write_task_yaml(
+        tmp_path,
+        "ut-kernel.yaml",
+        _default_body(
+            "ut-kernel",
+            ["h100-1gpu", "amd-mi355-1gpu-bench"],
+            extra="optional:\n  amd-mi355-1gpu-bench: true\n",
+        ),
+    )
+    matrix = build_matrix(tmp_path, tmp_path, trigger="per-commit")
+    assert [(e["runner"], e["optional"]) for e in matrix["include"]] == [
+        ("h100-1gpu", False),
+        ("amd-mi355-1gpu-bench", True),
     ]
 
 


### PR DESCRIPTION
Turns out mi355 is acting up again..
Reverts lightseekorg/tokenspeed#629

Along the way, add support for optional tasks
that can fail but not blocking.