### PR TITLE
refactor(attention): consolidate gfx950 gluon MHA layouts into shared helper

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_decode_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_decode_gfx950.py
@@ -31,6 +31,7 @@ from tokenspeed_kernel_amd.ops.attention.gluon.utils import (
     _INV_LN2,
     _INV_LN2_VALUE,
     InputStrides,
+    attention_layouts,
     max,
     maximum,
 )
@@ -92,6 +93,7 @@ class AttentionConfig:
         IS_SLIDING,
         WINDOW_LEFT,
         IS_FP8,
+        KV_DTYPE,
         q_strides,
     ):
         assert NUM_Q_HEADS % NUM_KV_HEADS == 0
@@ -102,48 +104,27 @@ class AttentionConfig:
         else:
             assert WINDOW_LEFT == -1
 
-        mfma_layout = gl.amd.AMDMFMALayout(
-            version=4,
+        # Decode uses a [16, 16, 32] MFMA with 1-warp tiling.
+        (
+            qk_layout,
+            pv_layout,
+            q_layout,
+            k_layout,
+            p_layout,
+            v_layout,
+            load_layout,
+            store_layout,
+            k_smem_layout,
+            v_smem_layout,
+        ) = attention_layouts(
+            HEAD_DIM,
+            BLOCK_N,
+            IS_FP8,
+            KV_DTYPE,
+            num_warps=1,
             instr_shape=[16, 16, 32],
-            transposed=True,
-            warps_per_cta=[1, 1],
-        )
-        qk_layout = mfma_layout
-        pv_layout = mfma_layout
-        # qk_kw is derived from a 128-bit load / dtype bitwidth.
-        # pv_kw is empirically tuned.
-        qk_kw = 16 if IS_FP8 else 8
-        pv_kw = 8 if IS_FP8 else 4
-        q_layout = gl.DotOperandLayout(0, qk_layout, k_width=qk_kw)
-        k_layout = gl.DotOperandLayout(1, qk_layout, k_width=qk_kw)
-        p_layout = gl.DotOperandLayout(0, pv_layout, k_width=pv_kw)
-        v_layout = gl.DotOperandLayout(1, pv_layout, k_width=pv_kw)
-        # load_vec is the number of elements per lane, depends on the input dtype, same as qk_kw.
-        # load_threads is how many lanes span HEAD_DIM.
-        load_vec = 16 if IS_FP8 else 8
-        load_threads = HEAD_DIM // load_vec
-        load_layout = gl.BlockedLayout(
-            [1, load_vec], [64 // load_threads, load_threads], [1, 1], [1, 0]
-        )
-        # store_vec depends on the output dtype, always 16-bit regardless of input dtype, so 128 / 16 = 8.
-        # store_threads is how many lanes span HEAD_DIM.
-        store_vec = 8
-        store_threads = HEAD_DIM // store_vec
-        store_layout = gl.BlockedLayout(
-            [1, store_vec], [64 // store_threads, store_threads], [1, 1], [1, 0]
         )
         reduce_layout = gl.BlockedLayout([1, HEAD_DIM // 64], [1, 64], [1, 1], [1, 0])
-        # Padding interval is 64 lanes * load_vec elems.
-        pad_interval = 64 * load_vec
-        # Empirically tuned.
-        pad_k = 16 if IS_FP8 else 8
-        pad_v = 32
-        k_smem_layout = gl.PaddedSharedLayout.with_identity_for(
-            [[pad_interval, pad_k]], [BLOCK_N, HEAD_DIM], [1, 0]
-        )
-        v_smem_layout = gl.PaddedSharedLayout.with_identity_for(
-            [[pad_interval, pad_v]], [BLOCK_N, HEAD_DIM], [1, 0]
-        )
 
         self.SM_SCALE = gl.constexpr(SM_SCALE)
         self.PAGE_TABLE_STRIDE = gl.constexpr(PAGE_TABLE_STRIDE)
@@ -485,7 +466,7 @@ class AttentionProgram:
 
 
 @gluon.jit
-def _mha_decode_fp16(
+def _mha_decode(
     q_ptr,
     k_cache_ptr,
     v_cache_ptr,
@@ -524,6 +505,7 @@ def _mha_decode_fp16(
         IS_SLIDING,
         WINDOW_LEFT,
         IS_FP8,
+        k_cache_ptr.dtype.element_ty,
         InputStrides(Q_STRIDE_B, Q_STRIDE_H, Q_STRIDE_D),
     )
     program = AttentionProgram.create(
@@ -570,7 +552,7 @@ def _mha_decode_fp16(
 
 
 @gluon.jit
-def _mha_decode_sliding_fp16(
+def _mha_decode_sliding(
     q_ptr,
     k_cache_ptr,
     v_cache_ptr,
@@ -609,6 +591,7 @@ def _mha_decode_sliding_fp16(
         IS_SLIDING,
         WINDOW_LEFT,
         IS_FP8,
+        k_cache_ptr.dtype.element_ty,
         InputStrides(Q_STRIDE_B, Q_STRIDE_H, Q_STRIDE_D),
     )
     program = AttentionProgram.create(
@@ -650,12 +633,13 @@ def _mha_decode_sliding_fp16(
 
 
 @gluon.jit
-def _mha_decode_reduce_fp16(
+def _mha_decode_reduce(
     mid_o_ptr,
     mid_lse_ptr,
     out_ptr,
     cache_seqlens_ptr,
     sink_ptr,
+    k_cache_ptr,  # unused for loads; only its dtype feeds the shared config
     SM_SCALE: gl.constexpr,
     PAGE_TABLE_STRIDE: gl.constexpr,
     NUM_KV_SPLITS: gl.constexpr,
@@ -683,6 +667,7 @@ def _mha_decode_reduce_fp16(
         False,  # IS_SLIDING
         -1,  # WINDOW_LEFT
         IS_FP8,
+        k_cache_ptr.dtype.element_ty,
         InputStrides(1, 1, 1),
     )
     q_index = gl.program_id(0)
@@ -858,7 +843,7 @@ def gluon_mha_decode_gfx950(
     if config.is_sliding:
         # No split-k for sliding window attention
         grid = (total_q, config.num_kv_heads * config.num_groups, 1)
-        _mha_decode_sliding_fp16[grid](
+        _mha_decode_sliding[grid](
             q,
             k_cache,
             v_cache,
@@ -902,7 +887,7 @@ def gluon_mha_decode_gfx950(
             config.num_kv_heads * config.num_groups,
             config.num_kv_splits,
         )
-        _mha_decode_fp16[grid](
+        _mha_decode[grid](
             q,
             k_cache,
             v_cache,
@@ -932,12 +917,13 @@ def gluon_mha_decode_gfx950(
         # Sink is a single global softmax entry, so split-k must merge it once in
         # reduce. Adding it in each split would count the sink once per split.
         grid = (total_q, config.num_q_heads)
-        _mha_decode_reduce_fp16[grid](
+        _mha_decode_reduce[grid](
             mid_o,
             mid_lse,
             output,
             cache_seqlens,
             sink_arg,
+            k_cache,
             config.sm_scale,
             page_table.stride(0),
             config.num_kv_splits,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_extend_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_extend_gfx950.py
@@ -53,6 +53,7 @@ from tokenspeed_kernel_amd.ops.attention.gluon.utils import (
     _INV_LN2_VALUE,
     _LN2,
     InputStrides,
+    attention_layouts,
     max,
     maximum,
 )
@@ -136,44 +137,31 @@ class ExtendConfig:
         HAS_LSE,
         WINDOW_LEFT,
         IS_FP8,
+        KV_DTYPE,
         q_strides,
     ):
         assert HEAD_DIM in (64, 128)
         assert BLOCK_N == PAGE_SIZE
 
-        instr_shape = [32, 32, 16]
-        mfma_layout = gl.amd.AMDMFMALayout(
-            version=4,
-            instr_shape=instr_shape,
-            transposed=True,
-            warps_per_cta=[NUM_WARPS, 1],
-        )
-        qk_layout = mfma_layout
-        pv_layout = mfma_layout
-        # load_vec is the number of elements per lane, depends on the input dtype, same as qk_kw.
-        # load_threads is how many lanes span HEAD_DIM.
-        load_vec = 16 if IS_FP8 else 8
-        load_threads = HEAD_DIM // load_vec
-        load_layout = gl.BlockedLayout(
-            [1, load_vec], [64 // load_threads, load_threads], [NUM_WARPS, 1], [1, 0]
-        )
-        # store_vec depends on the output dtype, always 16-bit regardless of input dtype, so 128 / 16 = 8.
-        # store_threads is how many lanes span HEAD_DIM.
-        store_vec = 8
-        store_threads = HEAD_DIM // store_vec
-        store_layout = gl.BlockedLayout(
-            [1, store_vec], [64 // store_threads, store_threads], [NUM_WARPS, 1], [1, 0]
-        )
-        # Padding interval is 64 lanes * load_vec elems.
-        pad_interval = 64 * load_vec
-        # Empirically tuned.
-        pad_k = 16 if IS_FP8 else 8
-        pad_v = 16 if IS_FP8 else 32
-        k_smem_layout = gl.PaddedSharedLayout.with_identity_for(
-            [[pad_interval, pad_k]], [BLOCK_N, HEAD_DIM], [1, 0]
-        )
-        v_smem_layout = gl.PaddedSharedLayout.with_identity_for(
-            [[pad_interval, pad_v]], [BLOCK_N, HEAD_DIM], [1, 0]
+        # Extend uses a [32, 32, 16] MFMA with NUM_WARPS warp tiling.
+        (
+            qk_layout,
+            pv_layout,
+            q_layout,
+            k_layout,
+            p_layout,
+            v_layout,
+            load_layout,
+            store_layout,
+            k_smem_layout,
+            v_smem_layout,
+        ) = attention_layouts(
+            HEAD_DIM,
+            BLOCK_N,
+            IS_FP8,
+            KV_DTYPE,
+            num_warps=NUM_WARPS,
+            instr_shape=[32, 32, 16],
         )
 
         self.N_HEADS = gl.constexpr(N_HEADS)
@@ -194,14 +182,10 @@ class ExtendConfig:
         self.q_strides = q_strides
         self.qk_layout = gl.constexpr(qk_layout)
         self.pv_layout = gl.constexpr(pv_layout)
-        # qk_kw is derived from a 128-bit load / dtype bitwidth.
-        # pv_kw is empirically tuned.
-        qk_kw = 16 if IS_FP8 else 8
-        pv_kw = 16 if IS_FP8 else 4
-        self.q_layout = gl.constexpr(gl.DotOperandLayout(0, qk_layout, k_width=qk_kw))
-        self.k_layout = gl.constexpr(gl.DotOperandLayout(1, qk_layout, k_width=qk_kw))
-        self.p_layout = gl.constexpr(gl.DotOperandLayout(0, pv_layout, k_width=pv_kw))
-        self.v_layout = gl.constexpr(gl.DotOperandLayout(1, pv_layout, k_width=pv_kw))
+        self.q_layout = gl.constexpr(q_layout)
+        self.k_layout = gl.constexpr(k_layout)
+        self.p_layout = gl.constexpr(p_layout)
+        self.v_layout = gl.constexpr(v_layout)
         self.load_layout = gl.constexpr(load_layout)
         self.store_layout = gl.constexpr(store_layout)
         self.k_smem_layout = gl.constexpr(k_smem_layout)
@@ -485,7 +469,7 @@ class ExtendProgram:
 
 
 @gluon.jit
-def _mha_extend_fp16(
+def _mha_extend(
     q_ptr,
     k_cache_ptr,
     v_cache_ptr,
@@ -528,6 +512,7 @@ def _mha_extend_fp16(
         HAS_LSE,
         WINDOW_LEFT,
         IS_FP8,
+        k_cache_ptr.dtype.element_ty,
         InputStrides(Q_STRIDE_T, Q_STRIDE_H, Q_STRIDE_D),
     )
     program = ExtendProgram.create(
@@ -667,7 +652,7 @@ def gluon_mha_extend_gfx950(
         lse = None
         lse_arg = q
     grid = (blocks_per_req, batch, n_heads)
-    _mha_extend_fp16[grid](
+    _mha_extend[grid](
         q,
         k_cache,
         v_cache,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_prefill_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_prefill_gfx950.py
@@ -32,6 +32,7 @@ from tokenspeed_kernel_amd.ops.attention.gluon.utils import (
     _INV_LN2_VALUE,
     _LN2,
     InputStrides,
+    attention_layouts,
     max,
     maximum,
 )
@@ -90,6 +91,7 @@ class AttentionConfig:
         HAS_LSE,
         WINDOW_LEFT,
         IS_FP8,
+        KV_DTYPE,
         q_strides,
         k_strides,
         v_strides,
@@ -97,43 +99,25 @@ class AttentionConfig:
         assert HEAD_DIM in (64, 128)
         assert NUM_WARPS == 4
 
-        instr_shape = [32, 32, 16]
-        qk_layout = gl.amd.AMDMFMALayout(
-            version=4,
-            instr_shape=instr_shape,
-            transposed=True,
-            warps_per_cta=[NUM_WARPS, 1],
-        )
-        pv_layout = gl.amd.AMDMFMALayout(
-            version=4,
-            instr_shape=instr_shape,
-            transposed=True,
-            warps_per_cta=[NUM_WARPS, 1],
-        )
-        # load_vec is the number of elements per lane, depends on the input dtype, same as qk_kw.
-        # load_threads is how many lanes span HEAD_DIM.
-        load_vec = 16 if IS_FP8 else 8
-        load_threads = HEAD_DIM // load_vec
-        load_layout = gl.BlockedLayout(
-            [1, load_vec], [64 // load_threads, load_threads], [4, 1], [1, 0]
-        )
-        # store_vec depends on the output dtype, always 16-bit regardless of input dtype, so 128 / 16 = 8.
-        # store_threads is how many lanes span HEAD_DIM.
-        store_vec = 8
-        store_threads = HEAD_DIM // store_vec
-        store_layout = gl.BlockedLayout(
-            [1, store_vec], [64 // store_threads, store_threads], [4, 1], [1, 0]
-        )
-        # Padding interval is 64 lanes * load_vec elems.
-        pad_interval = 64 * load_vec
-        # Empirically tuned.
-        pad_k = 16 if IS_FP8 else 8
-        pad_v = 16 if IS_FP8 else 32
-        k_smem_layout = gl.PaddedSharedLayout.with_identity_for(
-            [[pad_interval, pad_k]], [BLOCK_N, HEAD_DIM], [1, 0]
-        )
-        v_smem_layout = gl.PaddedSharedLayout.with_identity_for(
-            [[pad_interval, pad_v]], [BLOCK_N, HEAD_DIM], [1, 0]
+        # Prefill uses a [32, 32, 16] MFMA with NUM_WARPS warp tiling.
+        (
+            qk_layout,
+            pv_layout,
+            q_layout,
+            k_layout,
+            p_layout,
+            v_layout,
+            load_layout,
+            store_layout,
+            k_smem_layout,
+            v_smem_layout,
+        ) = attention_layouts(
+            HEAD_DIM,
+            BLOCK_N,
+            IS_FP8,
+            KV_DTYPE,
+            num_warps=NUM_WARPS,
+            instr_shape=[32, 32, 16],
         )
         self.N_HEADS = gl.constexpr(N_HEADS)
         self.N_KV_HEADS = gl.constexpr(N_KV_HEADS)
@@ -154,14 +138,6 @@ class AttentionConfig:
         self.v_strides = v_strides
         self.qk_layout = gl.constexpr(qk_layout)
         self.pv_layout = gl.constexpr(pv_layout)
-        # qk_kw is derived from a 128-bit load / dtype bitwidth.
-        # pv_kw is empirically tuned.
-        qk_kw = 16 if IS_FP8 else 8
-        pv_kw = 16 if IS_FP8 else 4
-        q_layout = gl.DotOperandLayout(0, qk_layout, k_width=qk_kw)
-        k_layout = gl.DotOperandLayout(1, qk_layout, k_width=qk_kw)
-        p_layout = gl.DotOperandLayout(0, pv_layout, k_width=pv_kw)
-        v_layout = gl.DotOperandLayout(1, pv_layout, k_width=pv_kw)
         self.q_layout = gl.constexpr(q_layout)
         self.k_layout = gl.constexpr(k_layout)
         self.p_layout = gl.constexpr(p_layout)
@@ -861,7 +837,7 @@ def process_sliding_attention_tile(
 
 
 @gluon.jit
-def _mha_prefill_fp16(
+def _mha_prefill(
     q_ptr,
     k_ptr,
     v_ptr,
@@ -905,6 +881,7 @@ def _mha_prefill_fp16(
         HAS_LSE,
         -1,
         IS_FP8,
+        k_ptr.dtype.element_ty,
         InputStrides(Q_STRIDE_T, Q_STRIDE_H, Q_STRIDE_D),
         InputStrides(K_STRIDE_T, K_STRIDE_H, K_STRIDE_D),
         InputStrides(V_STRIDE_T, V_STRIDE_H, V_STRIDE_D),
@@ -948,7 +925,7 @@ def _mha_prefill_fp16(
 
 
 @gluon.jit
-def _mha_prefill_sliding_fp16(
+def _mha_prefill_sliding(
     q_ptr,
     k_ptr,
     v_ptr,
@@ -992,6 +969,7 @@ def _mha_prefill_sliding_fp16(
         HAS_LSE,
         WINDOW_LEFT,
         IS_FP8,
+        k_ptr.dtype.element_ty,
         InputStrides(Q_STRIDE_T, Q_STRIDE_H, Q_STRIDE_D),
         InputStrides(K_STRIDE_T, K_STRIDE_H, K_STRIDE_D),
         InputStrides(V_STRIDE_T, V_STRIDE_H, V_STRIDE_D),
@@ -1106,7 +1084,7 @@ def gluon_mha_prefill_gfx950(
     sink_arg = sinks if sinks is not None else q
     lse_arg = lse if lse is not None else q
 
-    kernel = _mha_prefill_sliding_fp16 if config.window_left >= 0 else _mha_prefill_fp16
+    kernel = _mha_prefill_sliding if config.window_left >= 0 else _mha_prefill
     kernel[config.grid](
         q,
         k,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/utils.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/utils.py
@@ -38,6 +38,75 @@ def max(input, axis=None, keep_dims=False):
     return gl.reduce(input, axis, maximum, keep_dims=keep_dims)
 
 
+@gluon.constexpr_function
+def attention_layouts(head_dim, block_n, is_fp8, dtype, num_warps, instr_shape):
+    mfma = gl.amd.AMDMFMALayout(
+        version=4,
+        instr_shape=instr_shape,
+        transposed=True,
+        warps_per_cta=[num_warps, 1],
+    )
+    qk_layout = mfma
+    pv_layout = mfma
+    # qk_kw is derived from a 128-bit load / dtype bitwidth; pv_kw is tuned.
+    qk_kw = 16 if is_fp8 else 8
+    pv_kw = 8 if is_fp8 else 4
+    q_layout = gl.DotOperandLayout(0, qk_layout, k_width=qk_kw)
+    k_layout = gl.DotOperandLayout(1, qk_layout, k_width=qk_kw)
+    p_layout = gl.DotOperandLayout(0, pv_layout, k_width=pv_kw)
+    v_layout = gl.DotOperandLayout(1, pv_layout, k_width=pv_kw)
+    # load_vec = elems/lane (dtype-dependent, == qk_kw); load_threads span HEAD_DIM.
+    load_vec = 16 if is_fp8 else 8
+    load_threads = head_dim // load_vec
+    load_layout = gl.BlockedLayout(
+        [1, load_vec], [64 // load_threads, load_threads], [num_warps, 1], [1, 0]
+    )
+    # store_vec is always 16-bit (128 / 16 = 8) regardless of input dtype.
+    store_vec = 8
+    store_threads = head_dim // store_vec
+    store_layout = gl.BlockedLayout(
+        [1, store_vec], [64 // store_threads, store_threads], [num_warps, 1], [1, 0]
+    )
+    # Take only the built-in's padding, not its swizzle: the swizzle scatters
+    # head_dim across banks, making the LDS write stride non-constant, so it can't
+    # lower through async_copy's affine [1, 0] load. Padding-only is affine and
+    # DMA-legal.
+    # TODO(perf): to also use the swizzle, co-design a matched load layout so the
+    # DMA stays legal.
+    k_api = gl.amd.cdna4.compute_efficient_padded_shared_layout(
+        k_layout, [block_n, head_dim], dtype, is_k_contig=True
+    )
+    v_api = gl.amd.cdna4.compute_efficient_padded_shared_layout(
+        v_layout, [block_n, head_dim], dtype, is_k_contig=False
+    )
+    assert (
+        k_api is not None and v_api is not None
+    ), "no CDNA4 padded shared layout for this operand/dtype"
+    k_pairs = list(k_api.interval_padding_pairs)
+    v_pairs = list(v_api.interval_padding_pairs)
+    assert (
+        len(k_pairs) == 1 and len(v_pairs) == 1
+    ), "expected a single interval padding pair from the built-in"
+    k_smem_layout = gl.PaddedSharedLayout.with_identity_for(
+        [[int(k_pairs[0][0]), int(k_pairs[0][1])]], [block_n, head_dim], [1, 0]
+    )
+    v_smem_layout = gl.PaddedSharedLayout.with_identity_for(
+        [[int(v_pairs[0][0]), int(v_pairs[0][1])]], [block_n, head_dim], [1, 0]
+    )
+    return (
+        qk_layout,
+        pv_layout,
+        q_layout,
+        k_layout,
+        p_layout,
+        v_layout,
+        load_layout,
+        store_layout,
+        k_smem_layout,
+        v_smem_layout,
+    )
+
+
 @gluon.aggregate
 class InputStrides:
     stride_t: gl.constexpr


### PR DESCRIPTION
Address https://github.com/lightseekorg/tokenspeed/pull/625#discussion_r3554818644.

Use the gluon utility to get the padded layout: https://github.com/lightseekorg/tokenspeed/pull/625#discussion_r3554823493

Also drop the redundant `_fp16` suffix from the function names, since fp8 is now supported too.