### PR TITLE
feat(attention): trtllm backend consumes flat per-group KV-cache tables

### DIFF
--- a/python/tokenspeed/runtime/configs/paged_cache_spec.py
+++ b/python/tokenspeed/runtime/configs/paged_cache_spec.py
@@ -123,19 +123,17 @@ def hybrid_slab_group_size(
     return sizes.pop()
 
 
-def _flat_backend_leaves(attn_backend: object) -> list[object]:
-    """The backends whose table consumption matters for flat safety: the
-    backend itself, plus composite sub-backends (hybrid routes per layer to
-    user-selectable sub-backends, so each must be checked on its own).
+def _flat_kv_backend(attn_backend: object) -> object:
+    """The backend whose KV-table consumption matters for flat safety: the
+    backend itself, or a composite's full-attention sub-backend (hybrid's
+    per-layer KV routing lives there and is user-selectable). The linear
+    side consumes only the state group's table through its own explicit
+    flat path and is out of scope here.
     """
-    leaves = []
-    for sub in (
-        getattr(attn_backend, "full_attn_backend", None),
-        getattr(attn_backend, "linear_attn_backend", None),
-    ):
-        if sub is not None:
-            leaves.extend(_flat_backend_leaves(sub))
-    return leaves or [attn_backend]
+    sub = getattr(attn_backend, "full_attn_backend", None)
+    if sub is not None:
+        return _flat_kv_backend(sub)
+    return attn_backend
 
 
 def validate_flat_scheduler_config(
@@ -154,34 +152,34 @@ def validate_flat_scheduler_config(
     if not flat_kvcache_ext:
         return
     pool_name = type(kv_pool).__name__
-    for backend in _flat_backend_leaves(attn_backend):
-        backend_name = type(backend).__name__
-        uses_paged = bool(getattr(backend, "uses_paged_cache_groups", False))
-        uses_flat = bool(getattr(backend, "uses_flat_cache_groups", False))
-        if uses_paged and not uses_flat:
-            raise RuntimeError(
-                "flat scheduler build (TOKENSPEED_FLAT_KVCACHE) does not support "
-                f"this model's cache layout yet: attention backend {backend_name} "
-                f"(KV pool {pool_name}) consumes paged-cache groups through the "
-                "radix scheduler's populate path, which the flat build compiles "
-                "out — CUDA graphs would silently replay against stale capture "
-                "placeholders. Use a radix-built tokenspeed_scheduler extension "
-                "for this model."
-            )
-        if len(paged_cache_groups) > 1 and not uses_flat:
-            # A table-blind backend on a multi-group pool would index every
-            # layer through the C++ single-table fallback (a first-group
-            # sample) — with slab-aliased layouts that silently corrupts KV
-            # past the sliding window. Refuse at startup instead.
-            raise RuntimeError(
-                "flat scheduler build (TOKENSPEED_FLAT_KVCACHE): KV pool "
-                f"{pool_name} publishes {len(paged_cache_groups)} cache groups "
-                f"but attention backend {backend_name} does not consume flat "
-                "per-group tables (uses_flat_cache_groups=False); the single-"
-                "table fallback would serve one group's pages to every layer, "
-                "silently corrupting KV. Pick a flat-capable attention backend "
-                "or use a radix-built tokenspeed_scheduler extension."
-            )
+    backend = _flat_kv_backend(attn_backend)
+    backend_name = type(backend).__name__
+    uses_paged = bool(getattr(backend, "uses_paged_cache_groups", False))
+    uses_flat = bool(getattr(backend, "uses_flat_cache_groups", False))
+    if uses_paged and not uses_flat:
+        raise RuntimeError(
+            "flat scheduler build (TOKENSPEED_FLAT_KVCACHE) does not support "
+            f"this model's cache layout yet: attention backend {backend_name} "
+            f"(KV pool {pool_name}) consumes paged-cache groups through the "
+            "radix scheduler's populate path, which the flat build compiles "
+            "out — CUDA graphs would silently replay against stale capture "
+            "placeholders. Use a radix-built tokenspeed_scheduler extension "
+            "for this model."
+        )
+    if len(paged_cache_groups) > 1 and not uses_flat:
+        # A table-blind backend on a multi-group pool would index every
+        # layer through the C++ single-table fallback (a first-group
+        # sample) — with slab-aliased layouts that silently corrupts KV
+        # past the sliding window. Refuse at startup instead.
+        raise RuntimeError(
+            "flat scheduler build (TOKENSPEED_FLAT_KVCACHE): KV pool "
+            f"{pool_name} publishes {len(paged_cache_groups)} cache groups "
+            f"but attention backend {backend_name} does not consume flat "
+            "per-group tables (uses_flat_cache_groups=False); the single-"
+            "table fallback would serve one group's pages to every layer, "
+            "silently corrupting KV. Pick a flat-capable attention backend "
+            "or use a radix-built tokenspeed_scheduler extension."
+        )
     if not paged_cache_groups:
         if speculative_enabled:
             cause = (

--- a/python/tokenspeed/runtime/configs/paged_cache_spec.py
+++ b/python/tokenspeed/runtime/configs/paged_cache_spec.py
@@ -123,6 +123,21 @@ def hybrid_slab_group_size(
     return sizes.pop()
 
 
+def _flat_backend_leaves(attn_backend: object) -> list[object]:
+    """The backends whose table consumption matters for flat safety: the
+    backend itself, plus composite sub-backends (hybrid routes per layer to
+    user-selectable sub-backends, so each must be checked on its own).
+    """
+    leaves = []
+    for sub in (
+        getattr(attn_backend, "full_attn_backend", None),
+        getattr(attn_backend, "linear_attn_backend", None),
+    ):
+        if sub is not None:
+            leaves.extend(_flat_backend_leaves(sub))
+    return leaves or [attn_backend]
+
+
 def validate_flat_scheduler_config(
     *,
     flat_kvcache_ext: bool,
@@ -132,25 +147,41 @@ def validate_flat_scheduler_config(
     speculative_enabled: bool,
 ) -> None:
     """Fail fast, before the C++ ``Scheduler`` ctor, when a flat-built ext
-    cannot drive this setup: a paged-groups backend that is not flat-group
-    capable, or zero published groups. No-op on a radix build.
+    cannot drive this setup: a backend (or hybrid sub-backend) that would not
+    consume the per-group flat tables, or zero published groups. No-op on a
+    radix build.
     """
     if not flat_kvcache_ext:
         return
-    backend_name = type(attn_backend).__name__
     pool_name = type(kv_pool).__name__
-    uses_paged = bool(getattr(attn_backend, "uses_paged_cache_groups", False))
-    uses_flat = bool(getattr(attn_backend, "uses_flat_cache_groups", False))
-    if uses_paged and not uses_flat:
-        raise RuntimeError(
-            "flat scheduler build (TOKENSPEED_FLAT_KVCACHE) does not support "
-            f"this model's cache layout yet: attention backend {backend_name} "
-            f"(KV pool {pool_name}) consumes paged-cache groups through the "
-            "radix scheduler's populate path, which the flat build compiles "
-            "out — CUDA graphs would silently replay against stale capture "
-            "placeholders. Use a radix-built tokenspeed_scheduler extension "
-            "for this model."
-        )
+    for backend in _flat_backend_leaves(attn_backend):
+        backend_name = type(backend).__name__
+        uses_paged = bool(getattr(backend, "uses_paged_cache_groups", False))
+        uses_flat = bool(getattr(backend, "uses_flat_cache_groups", False))
+        if uses_paged and not uses_flat:
+            raise RuntimeError(
+                "flat scheduler build (TOKENSPEED_FLAT_KVCACHE) does not support "
+                f"this model's cache layout yet: attention backend {backend_name} "
+                f"(KV pool {pool_name}) consumes paged-cache groups through the "
+                "radix scheduler's populate path, which the flat build compiles "
+                "out — CUDA graphs would silently replay against stale capture "
+                "placeholders. Use a radix-built tokenspeed_scheduler extension "
+                "for this model."
+            )
+        if len(paged_cache_groups) > 1 and not uses_flat:
+            # A table-blind backend on a multi-group pool would index every
+            # layer through the C++ single-table fallback (a first-group
+            # sample) — with slab-aliased layouts that silently corrupts KV
+            # past the sliding window. Refuse at startup instead.
+            raise RuntimeError(
+                "flat scheduler build (TOKENSPEED_FLAT_KVCACHE): KV pool "
+                f"{pool_name} publishes {len(paged_cache_groups)} cache groups "
+                f"but attention backend {backend_name} does not consume flat "
+                "per-group tables (uses_flat_cache_groups=False); the single-"
+                "table fallback would serve one group's pages to every layer, "
+                "silently corrupting KV. Pick a flat-capable attention backend "
+                "or use a radix-built tokenspeed_scheduler extension."
+            )
     if not paged_cache_groups:
         if speculative_enabled:
             cause = (

--- a/python/tokenspeed/runtime/layers/attention/backends/base.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/base.py
@@ -99,9 +99,11 @@ class AttentionBackend(ABC):
     ) -> bool:
         return False
 
-    def select_out_cache_loc(self, layer, out_cache_loc):
-        """Flat per-group write-location hook; identity for backends
-        without flat cache groups (see uses_flat_cache_groups)."""
+    def select_out_cache_loc(self, layer, out_cache_loc, forward_mode=None):
+        """Flat per-group write-location hook for out-of-backend KV writers
+        (fused RoPE prewrite); identity for backends without flat cache
+        groups (see uses_flat_cache_groups). ``forward_mode`` picks the
+        metadata slot for backends that prewrite on extend as well."""
         return out_cache_loc
 
     @property

--- a/python/tokenspeed/runtime/layers/attention/backends/flat_groups.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/flat_groups.py
@@ -1,0 +1,303 @@
+"""Shared flat KV-cache group machinery for attention backends.
+
+A flat-capable backend (``uses_flat_cache_groups = True``) receives one page
+table per cache group (``flat_block_tables: dict[group_id, [bs, max_pages]]``)
+instead of the radix single table, and must route every KV read AND write
+through the layer's own group (M-W1). This mixin holds the group-selection,
+write-location, and CUDA-graph per-group buffer machinery shared by the MHA
+and TRT-LLM backends; model/kernel-specific constraints (spec decode, DFLASH)
+stay in the backends.
+
+Table contract (canonical): rows are requests (padded rows carry the
+zero-init dummy page 0), column tails pad with -1 and are never read past
+``cache_seqlens``; SWA holes sit only at the window front and are written as
+the null page 0 by the scheduler export.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+
+class FlatCacheGroupsMixin:
+    """Per-group table/write-loc selection + CUDA-graph buffer discipline.
+
+    Host class requirements: ``self.device``, ``self.page_size``,
+    ``self.max_num_pages``, ``self.forward_decode_metadata`` (with
+    ``page_tables``/``out_cache_locs`` fields), and calling
+    :meth:`_init_flat_graph_buffers` from ``init_cuda_graph_state``.
+    """
+
+    # family="state" group ids (GDN/mamba state pages); learned from the
+    # pool's specs in init_cuda_graph_state, shed from every table here.
+    flat_state_group_ids: frozenset[str] = frozenset()
+
+    # Value for CUDA-graph buffer column tails past this replay's table
+    # width. -1 is a debug tripwire (never read past cache_seqlens by the
+    # MHA kernels); backends whose kernels assume a full-width table
+    # (trtllm: row stride derived from max_kv_len) override with 0, the
+    # zero-init dummy page — always safe to dereference.
+    flat_table_tail_pad: int = -1
+
+    # ------------------------------------------------------------------
+    # Group selection
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _select_group_entry(layer, mapping, what: str):
+        """Pick this layer's entry from a flat per-group dict (page tables or
+        write locs): the layer's group entry, or the sole entry when the
+        layer carries no/unknown group id. TODO(radix-removal): collapses to
+        `mapping[layer.group_id]` once flat is the only path.
+        """
+        group_id = getattr(layer, "group_id", "")
+        if not group_id or group_id not in mapping:
+            if len(mapping) == 1:
+                return next(iter(mapping.values()))
+            raise KeyError(
+                f"{what}: layer group_id={group_id!r} not in flat group "
+                f"keys {sorted(mapping)}"
+            )
+        return mapping[group_id]
+
+    def _select_page_table(self, layer, metadata):
+        if metadata.page_tables is None:
+            return metadata.page_table
+        return self._select_group_entry(layer, metadata.page_tables, "page table")
+
+    def _select_out_cache_loc(self, layer, metadata, out_cache_loc):
+        # KV writes must land in the pages the layer's group reads (M-W1).
+        if metadata.out_cache_locs is None:
+            return out_cache_loc
+        return self._select_group_entry(
+            layer, metadata.out_cache_locs, "flat write locs"
+        )
+
+    def _prewrite_metadata(self, forward_mode):
+        """Metadata slot the fused prewrite writes against. Default: the
+        decode slot (MHA gates prewrite to decode); backends that prewrite
+        on extend too (trtllm) override to pick their extend/prefill slot.
+        """
+        return self.forward_decode_metadata
+
+    def select_out_cache_loc(self, layer, out_cache_loc, forward_mode=None):
+        """Per-group write locations for out-of-backend KV writers (fused
+        RoPE prewrite): the write must land in the pages this layer's group
+        reads, never the scheduler's single-table locations.
+        """
+        metadata = self._prewrite_metadata(forward_mode)
+        if metadata is None or metadata.out_cache_locs is None:
+            return out_cache_loc
+        return self._select_out_cache_loc(layer, metadata, out_cache_loc)
+
+    def _shed_state_groups(self, tables):
+        """Drop family="state" groups (GDN/mamba state pages, consumed by the
+        mamba backend): computing write locs / capture buffers over the
+        hole-heavy state table writes the dummy page and trips
+        TOKENSPEED_FLAT_DEBUG. Returns None when nothing is left.
+        """
+        if not tables:
+            return None
+        if self.flat_state_group_ids:
+            tables = {
+                gid: table
+                for gid, table in tables.items()
+                if gid not in self.flat_state_group_ids
+            }
+        return tables or None
+
+    def _learn_flat_state_groups(self, paged_cache_group_specs) -> None:
+        """Record the pool's family="state" group ids (see
+        flat_state_group_ids); called from init_cuda_graph_state, the one
+        place the pool's specs reach every backend."""
+        self.flat_state_group_ids = frozenset(
+            str(spec.group_id)
+            for spec in paged_cache_group_specs
+            if spec.family == "state"
+        )
+
+    # ------------------------------------------------------------------
+    # Write locations
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compute_flat_decode_out_cache_locs(page_tables, seq_lens, page_size):
+        """Per-group decode write locs: one token per request at seq_len-1,
+        gathered from the group's own read table (M-W1). The tail page is
+        never a hole (SWA holes sit only at the window front).
+        """
+        pos = (seq_lens - 1).to(torch.int64)
+        page_idx = pos // page_size
+        off = (pos % page_size).to(torch.int32)
+        out = {}
+        for gid, table in page_tables.items():
+            pages = table.gather(1, page_idx.unsqueeze(1)).squeeze(1)
+            out[gid] = pages * page_size + off
+        return out
+
+    @staticmethod
+    def _compute_flat_extend_out_cache_locs(
+        page_tables, extend_prefix_lens_cpu, extend_seq_lens_cpu, page_size
+    ):
+        """Per-group extend write locs: positions [prefix_len, seq_len) per
+        request, flattened in q/k/v token order (cu_extend_seq_lens). Bounds
+        come from the CPU mirrors — no per-request GPU sync.
+        TODO(flat-perf): batch the per-request loop via repeat_interleave.
+        """
+        device = next(iter(page_tables.values())).device
+        prefix_lens = [int(x) for x in extend_prefix_lens_cpu.tolist()]
+        extend_lens = [int(x) for x in extend_seq_lens_cpu.tolist()]
+        out = {gid: [] for gid in page_tables}
+        for i, (start, num_new) in enumerate(zip(prefix_lens, extend_lens)):
+            pos = torch.arange(start, start + num_new, dtype=torch.int64, device=device)
+            page_idx = pos // page_size
+            off = (pos % page_size).to(torch.int32)
+            for gid, table in page_tables.items():
+                pages = table[i].gather(0, page_idx)
+                out[gid].append(pages * page_size + off)
+        return {
+            gid: (
+                torch.cat(chunks)
+                if chunks
+                else torch.empty(0, dtype=torch.int32, device=device)
+            )
+            for gid, chunks in out.items()
+        }
+
+    @staticmethod
+    def _maybe_check_flat_write_locs(page_tables, out_cache_locs, page_size):
+        """TOKENSPEED_FLAT_DEBUG=1 (eager only, GPU sync): write pages must
+        be real and inside the group's table. Not for graph-padded batches —
+        dummy rows would trip the non-hole assert (see the padding contract
+        in _flat_replay_fill).
+        """
+        if os.environ.get("TOKENSPEED_FLAT_DEBUG") != "1":
+            return
+        for gid, locs in out_cache_locs.items():
+            pages = (locs // page_size).to(torch.int32)
+            table = page_tables[gid]
+            assert (
+                pages != 0
+            ).all(), f"flat write loc in null page 0 for group {gid!r}"
+            real = table[table > 0]
+            assert torch.isin(
+                pages, real
+            ).all(), f"flat write pages escape group {gid!r}'s table"
+
+    # ------------------------------------------------------------------
+    # CUDA-graph per-group buffers
+    # ------------------------------------------------------------------
+
+    def _init_flat_graph_buffers(self, max_bs: int) -> None:
+        """Reset the lazily-allocated per-group persistent buffers; call from
+        init_cuda_graph_state BEFORE any backend early return — replay reads
+        the dict unconditionally for the stale-table guard."""
+        self.cuda_graph_flat_page_tables: dict[str, torch.Tensor] = {}
+        self.cuda_graph_flat_out_cache_locs: dict[str, torch.Tensor] = {}
+        self._cuda_graph_max_bs = max_bs
+
+    def _flat_capture_group_views(self, bs: int, flat_cache_group_ids):
+        """Capture-time (page_tables, out_cache_locs) per-group views into the
+        persistent buffers, lazily allocated. Real tables only arrive at
+        replay, which copy_s fresh data to these graph-recorded addresses.
+        Returns (None, None) when only state groups (or none) are delivered.
+        """
+        if not flat_cache_group_ids:
+            return None, None
+        page_tables = {}
+        out_cache_locs = {}
+        for gid in flat_cache_group_ids:
+            if gid in self.flat_state_group_ids:
+                # State pages ride to the mamba backend; no buffers here.
+                continue
+            buf = self.cuda_graph_flat_page_tables.get(gid)
+            if buf is None:
+                buf = torch.zeros(
+                    (self._cuda_graph_max_bs, self.max_num_pages),
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+                self.cuda_graph_flat_page_tables[gid] = buf
+            loc_buf = self.cuda_graph_flat_out_cache_locs.get(gid)
+            if loc_buf is None:
+                loc_buf = torch.zeros(
+                    (self._cuda_graph_max_bs,),
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+                self.cuda_graph_flat_out_cache_locs[gid] = loc_buf
+            page_tables[gid] = buf[:bs, :]
+            out_cache_locs[gid] = loc_buf[:bs]
+        if not page_tables:
+            # Only state groups delivered: nothing for this backend.
+            return None, None
+        return page_tables, out_cache_locs
+
+    def _flat_replay_stale_guard(self, bs: int, flat_block_tables) -> None:
+        """Fail loudly instead of replaying over stale/zero page tables.
+        bs == 0 may skip: col-0 buffer entries stay valid (never -1),
+        outputs are discarded, and only unit tests reach it."""
+        if not self.cuda_graph_flat_page_tables or bs <= 0:
+            return
+        name = type(self).__name__
+        if not flat_block_tables:
+            raise RuntimeError(
+                f"{name} replay: flat per-group CUDA-graph buffers "
+                f"exist for groups "
+                f"{sorted(self.cuda_graph_flat_page_tables)} "
+                f"but flat_block_tables is missing/empty at bs={bs}; the "
+                "captured graph would read stale page tables."
+            )
+        missing = set(self.cuda_graph_flat_page_tables) - set(flat_block_tables)
+        if missing:
+            raise RuntimeError(
+                f"{name} replay: flat_block_tables at bs="
+                f"{bs} is missing captured groups {sorted(missing)} "
+                f"(delivered: {sorted(flat_block_tables)}); the captured "
+                "graph would read stale page tables for those groups."
+            )
+
+    def _flat_replay_fill(self, bs: int, flat_block_tables, seq_lens) -> None:
+        """Copy this replay's tables into the captured buffers and recompute
+        the per-group write locs from the live seq_lens.
+
+        Padding contract (canonical; bs is the padded bs): dummy ROWS pad
+        with 0 — replayed at seq_lens=1 they dereference exactly col 0,
+        the zero-init dummy page. Column tails pad with -1, never read
+        past cache_seqlens.
+        """
+        for gid, src in flat_block_tables.items():
+            if gid in self.flat_state_group_ids:
+                # State group: the mamba backend consumes it directly.
+                continue
+            buf = self.cuda_graph_flat_page_tables[gid]
+            cols = src.shape[1]
+            # cols >= 1: a zero-width table would leave dummy rows'
+            # col 0 unwritten.
+            assert 1 <= cols <= buf.shape[1], (
+                f"flat table for group {gid!r}: {cols} cols outside"
+                f" [1, {buf.shape[1]}] (CUDA-graph buffer width)"
+            )
+            assert src.shape[0] >= bs, (
+                f"flat table for group {gid!r} has {src.shape[0]} rows"
+                f" < padded bs {bs}"
+            )
+            buf[:bs, :cols].copy_(src[:bs, :])
+            if cols < buf.shape[1]:
+                buf[:bs, cols:].fill_(self.flat_table_tail_pad)
+
+        # seq_lens is the controller-filled live buffer (current lens +
+        # padding 1s), written BEFORE replay init, so [:bs] is current.
+        locs = self._compute_flat_decode_out_cache_locs(
+            {
+                gid: self.cuda_graph_flat_page_tables[gid][:bs, :]
+                for gid in flat_block_tables
+                if gid not in self.flat_state_group_ids
+            },
+            seq_lens[:bs],
+            self.page_size,
+        )
+        for gid, val in locs.items():
+            self.cuda_graph_flat_out_cache_locs[gid][:bs].copy_(val)

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -487,6 +487,11 @@ class SimpleMambaPool:
 class MambaAttnBackend(AttentionBackend):
     """Attention backend for Mamba/GDN linear attention layers."""
 
+    # Consumes the state group's flat table via dual in/out page indexing
+    # (see _flat_state_pages); declared so the flat config guard's
+    # sub-backend recursion recognizes it as flat-capable.
+    uses_flat_cache_groups: bool = True
+
     def __init__(self, config: BaseAttnConfig):
         super().__init__(config)
         self.pad_slot_id = -1

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -487,11 +487,6 @@ class SimpleMambaPool:
 class MambaAttnBackend(AttentionBackend):
     """Attention backend for Mamba/GDN linear attention layers."""
 
-    # Consumes the state group's flat table via dual in/out page indexing
-    # (see _flat_state_pages); declared so the flat config guard's
-    # sub-backend recursion recognizes it as flat-capable.
-    uses_flat_cache_groups: bool = True
-
     def __init__(self, config: BaseAttnConfig):
         super().__init__(config)
         self.pad_slot_id = -1

--- a/python/tokenspeed/runtime/layers/attention/backends/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mha.py
@@ -20,7 +20,6 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import partial
@@ -42,6 +41,9 @@ from tokenspeed.runtime.configs.model_config import AttentionArch
 from tokenspeed.runtime.execution.breakable_cuda_graph import scrub_padding_tail
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
+from tokenspeed.runtime.layers.attention.backends.flat_groups import (
+    FlatCacheGroupsMixin,
+)
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 from tokenspeed.runtime.layers.attention.registry import register_backend
 from tokenspeed.runtime.layers.attention.utils import build_page_table
@@ -107,7 +109,7 @@ class MHADecodeMetadata:
     out_cache_locs: dict[str, torch.Tensor] | None = None
 
 
-class MHAAttnBackend(AttentionBackend):
+class MHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
     """Standard MHA backend that routes through tokenspeed_kernel attention APIs."""
 
     # Unconditional: safety comes from the publication rule
@@ -155,10 +157,6 @@ class MHAAttnBackend(AttentionBackend):
         # Forward metadata is initialized in the runner per forward call
         self.forward_decode_metadata: MHADecodeMetadata | None = None
         self.forward_extend_metadata: MHAExtendMetadata | None = None
-
-        # family="state" group ids (GDN/mamba state pages) learned from the
-        # pool's specs in init_cuda_graph_state; this backend sheds them.
-        self.flat_state_group_ids: frozenset[str] = frozenset()
 
     # ------------------------------------------------------------------
     # Metadata initialization
@@ -315,11 +313,7 @@ class MHAAttnBackend(AttentionBackend):
         # State-family groups (GDN/mamba pages) belong to the mamba backend;
         # learn their ids from the pool's specs so every flat table/loc path
         # here (eager, capture, replay) sheds them.
-        self.flat_state_group_ids = frozenset(
-            str(spec.group_id)
-            for spec in paged_cache_group_specs
-            if spec.family == "state"
-        )
+        self._learn_flat_state_groups(paged_cache_group_specs)
         assert (
             seq_lens_buf.dtype == torch.int32
             and seq_lens_buf.dim() == 1
@@ -334,9 +328,7 @@ class MHAAttnBackend(AttentionBackend):
         # capture. TODO(radix-removal): parallels cuda_graph_page_table.
         # Initialized before the DFLASH early return: replay reads the dict
         # unconditionally for the stale-table guard.
-        self.cuda_graph_flat_page_tables: dict[str, torch.Tensor] = {}
-        self.cuda_graph_flat_out_cache_locs: dict[str, torch.Tensor] = {}
-        self._cuda_graph_max_bs = max_bs
+        self._init_flat_graph_buffers(max_bs)
         if self.draft_block_decode and self.spec_num_tokens > 1:
             # DFLASH draft block: expand to spec_num_tokens decode rows per
             # request (one row per block position), so max_seqlen_q == 1 per row
@@ -374,8 +366,6 @@ class MHAAttnBackend(AttentionBackend):
         # Real tables only arrive at replay: capture lazily allocates
         # persistent per-group buffers and records metadata views into them,
         # so replay can copy_ fresh data to the graph-recorded addresses.
-        page_tables = None
-        out_cache_locs = None
         if flat_cache_group_ids:
             # Per-group views are bs rows; spec buffers expand to
             # bs * spec_num_tokens rows. TODO(flat+spec).
@@ -383,34 +373,9 @@ class MHAAttnBackend(AttentionBackend):
                 self.spec_num_tokens > 1
                 and (not self.is_draft or self.draft_block_decode)
             ), "flat_cache_group_ids is unsupported with spec_num_tokens > 1"
-            page_tables = {}
-            out_cache_locs = {}
-            for gid in flat_cache_group_ids:
-                if gid in self.flat_state_group_ids:
-                    # State pages ride to the mamba backend; no MHA buffers.
-                    continue
-                buf = self.cuda_graph_flat_page_tables.get(gid)
-                if buf is None:
-                    buf = torch.zeros(
-                        (self._cuda_graph_max_bs, self.max_num_pages),
-                        dtype=torch.int32,
-                        device=self.device,
-                    )
-                    self.cuda_graph_flat_page_tables[gid] = buf
-                loc_buf = self.cuda_graph_flat_out_cache_locs.get(gid)
-                if loc_buf is None:
-                    loc_buf = torch.zeros(
-                        (self._cuda_graph_max_bs,),
-                        dtype=torch.int32,
-                        device=self.device,
-                    )
-                    self.cuda_graph_flat_out_cache_locs[gid] = loc_buf
-                page_tables[gid] = buf[:bs, :]
-                out_cache_locs[gid] = loc_buf[:bs]
-            if not page_tables:
-                # Only state groups delivered: nothing for this backend.
-                page_tables = None
-                out_cache_locs = None
+        page_tables, out_cache_locs = self._flat_capture_group_views(
+            bs, flat_cache_group_ids
+        )
 
         if self.draft_block_decode and self.spec_num_tokens > 1:
             # DFLASH draft block: spec_num_tokens decode rows per request.
@@ -458,25 +423,7 @@ class MHAAttnBackend(AttentionBackend):
         assert not forward_mode.is_extend_or_mixed()
 
         # Fail loudly instead of replaying over stale/zero page tables.
-        # bs == 0 may skip: col-0 buffer entries stay valid (never -1),
-        # outputs are discarded, and only unit tests reach it.
-        if self.cuda_graph_flat_page_tables and bs > 0:
-            if not flat_block_tables:
-                raise RuntimeError(
-                    "MHAAttnBackend replay: flat per-group CUDA-graph buffers "
-                    f"exist for groups "
-                    f"{sorted(self.cuda_graph_flat_page_tables)} "
-                    f"but flat_block_tables is missing/empty at bs={bs}; the "
-                    "captured graph would read stale page tables."
-                )
-            missing = set(self.cuda_graph_flat_page_tables) - set(flat_block_tables)
-            if missing:
-                raise RuntimeError(
-                    "MHAAttnBackend replay: flat_block_tables at bs="
-                    f"{bs} is missing captured groups {sorted(missing)} "
-                    f"(delivered: {sorted(flat_block_tables)}); the captured "
-                    "graph would read stale page tables for those groups."
-                )
+        self._flat_replay_stale_guard(bs, flat_block_tables)
 
         # Flat captures read only the per-group buffers; the radix single
         # table (cuda_graph_page_table) would be dead work there.
@@ -503,45 +450,10 @@ class MHAAttnBackend(AttentionBackend):
                 bs, self.spec_num_tokens, self.max_num_pages
             ).copy_(base_page_table[:, None, :])
 
-        # Padding contract (canonical; bs is the padded bs): dummy ROWS pad
-        # with 0 — replayed at seq_lens=1 they dereference exactly col 0,
-        # the zero-init dummy page. Column tails pad with -1, never read
-        # past cache_seqlens.
+        # cuda_graph_seq_lens aliases the controller's seq_lens_buf, which
+        # input prep fills (current lens + padding 1s) BEFORE this call.
         if flat_block_tables:
-            for gid, src in flat_block_tables.items():
-                if gid in self.flat_state_group_ids:
-                    # State group: the mamba backend consumes it directly.
-                    continue
-                buf = self.cuda_graph_flat_page_tables[gid]
-                cols = src.shape[1]
-                # cols >= 1: a zero-width table would leave dummy rows'
-                # col 0 unwritten.
-                assert 1 <= cols <= buf.shape[1], (
-                    f"flat table for group {gid!r}: {cols} cols outside"
-                    f" [1, {buf.shape[1]}] (CUDA-graph buffer width)"
-                )
-                assert src.shape[0] >= bs, (
-                    f"flat table for group {gid!r} has {src.shape[0]} rows"
-                    f" < padded bs {bs}"
-                )
-                buf[:bs, :cols].copy_(src[:bs, :])
-                if cols < buf.shape[1]:
-                    buf[:bs, cols:].fill_(-1)
-
-            # cuda_graph_seq_lens aliases the controller's seq_lens_buf,
-            # which input prep fills (current lens + padding 1s) BEFORE this
-            # call, so [:bs] is current when recomputing write locs.
-            locs = self._compute_flat_decode_out_cache_locs(
-                {
-                    gid: self.cuda_graph_flat_page_tables[gid][:bs, :]
-                    for gid in flat_block_tables
-                    if gid not in self.flat_state_group_ids
-                },
-                self.cuda_graph_seq_lens[:bs],
-                self.page_size,
-            )
-            for gid, val in locs.items():
-                self.cuda_graph_flat_out_cache_locs[gid][:bs].copy_(val)
+            self._flat_replay_fill(bs, flat_block_tables, self.cuda_graph_seq_lens)
 
         if bs in self.cuda_graph_decode_metadata:
             self.forward_decode_metadata = self.cuda_graph_decode_metadata[bs]
@@ -662,125 +574,6 @@ class MHAAttnBackend(AttentionBackend):
                 save_kv_cache,
                 sinks,
             )
-
-    @staticmethod
-    def _select_group_entry(layer, mapping, what: str):
-        """Pick this layer's entry from a flat per-group dict (page tables or
-        write locs): the layer's group entry, or the sole entry when the
-        layer carries no/unknown group id. TODO(radix-removal): collapses to
-        `mapping[layer.group_id]` once flat is the only path.
-        """
-        group_id = getattr(layer, "group_id", "")
-        if not group_id or group_id not in mapping:
-            if len(mapping) == 1:
-                return next(iter(mapping.values()))
-            raise KeyError(
-                f"{what}: layer group_id={group_id!r} not in flat group "
-                f"keys {sorted(mapping)}"
-            )
-        return mapping[group_id]
-
-    def _select_page_table(self, layer, metadata):
-        if metadata.page_tables is None:
-            return metadata.page_table
-        return self._select_group_entry(layer, metadata.page_tables, "page table")
-
-    def _select_out_cache_loc(self, layer, metadata, out_cache_loc):
-        # KV writes must land in the pages the layer's group reads (M-W1).
-        if metadata.out_cache_locs is None:
-            return out_cache_loc
-        return self._select_group_entry(
-            layer, metadata.out_cache_locs, "flat write locs"
-        )
-
-    def select_out_cache_loc(self, layer, out_cache_loc):
-        """Per-group write locations for out-of-backend KV writers (fused
-        RoPE prewrite); prewrite is decode-only, so reads decode metadata.
-        """
-        metadata = self.forward_decode_metadata
-        if metadata is None or metadata.out_cache_locs is None:
-            return out_cache_loc
-        return self._select_out_cache_loc(layer, metadata, out_cache_loc)
-
-    @staticmethod
-    def _compute_flat_decode_out_cache_locs(page_tables, seq_lens, page_size):
-        """Per-group decode write locs: one token per request at seq_len-1,
-        gathered from the group's own read table (M-W1). The tail page is
-        never a hole (SWA holes sit only at the window front).
-        """
-        pos = (seq_lens - 1).to(torch.int64)
-        page_idx = pos // page_size
-        off = (pos % page_size).to(torch.int32)
-        out = {}
-        for gid, table in page_tables.items():
-            pages = table.gather(1, page_idx.unsqueeze(1)).squeeze(1)
-            out[gid] = pages * page_size + off
-        return out
-
-    def _shed_state_groups(self, tables):
-        """Drop family="state" groups (GDN/mamba state pages, consumed by the
-        mamba backend): computing write locs / capture buffers over the
-        hole-heavy state table writes the dummy page and trips
-        TOKENSPEED_FLAT_DEBUG. Returns None when nothing is left.
-        """
-        if not tables:
-            return None
-        if self.flat_state_group_ids:
-            tables = {
-                gid: table
-                for gid, table in tables.items()
-                if gid not in self.flat_state_group_ids
-            }
-        return tables or None
-
-    @staticmethod
-    def _compute_flat_extend_out_cache_locs(
-        page_tables, extend_prefix_lens_cpu, extend_seq_lens_cpu, page_size
-    ):
-        """Per-group extend write locs: positions [prefix_len, seq_len) per
-        request, flattened in q/k/v token order (cu_extend_seq_lens). Bounds
-        come from the CPU mirrors — no per-request GPU sync.
-        TODO(flat-perf): batch the per-request loop via repeat_interleave.
-        """
-        device = next(iter(page_tables.values())).device
-        prefix_lens = [int(x) for x in extend_prefix_lens_cpu.tolist()]
-        extend_lens = [int(x) for x in extend_seq_lens_cpu.tolist()]
-        out = {gid: [] for gid in page_tables}
-        for i, (start, num_new) in enumerate(zip(prefix_lens, extend_lens)):
-            pos = torch.arange(start, start + num_new, dtype=torch.int64, device=device)
-            page_idx = pos // page_size
-            off = (pos % page_size).to(torch.int32)
-            for gid, table in page_tables.items():
-                pages = table[i].gather(0, page_idx)
-                out[gid].append(pages * page_size + off)
-        return {
-            gid: (
-                torch.cat(chunks)
-                if chunks
-                else torch.empty(0, dtype=torch.int32, device=device)
-            )
-            for gid, chunks in out.items()
-        }
-
-    @staticmethod
-    def _maybe_check_flat_write_locs(page_tables, out_cache_locs, page_size):
-        """TOKENSPEED_FLAT_DEBUG=1 (eager only, GPU sync): write pages must
-        be real and inside the group's table. Not for graph-padded batches —
-        dummy rows would trip the non-hole assert (see the padding contract
-        in init_forward_metadata_replay_cuda_graph).
-        """
-        if os.environ.get("TOKENSPEED_FLAT_DEBUG") != "1":
-            return
-        for gid, locs in out_cache_locs.items():
-            pages = (locs // page_size).to(torch.int32)
-            table = page_tables[gid]
-            assert (
-                pages != 0
-            ).all(), f"flat write loc in null page 0 for group {gid!r}"
-            real = table[table > 0]
-            assert torch.isin(
-                pages, real
-            ).all(), f"flat write pages escape group {gid!r}'s table"
 
     def _forward_prefill(
         self,

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -26,6 +26,7 @@ Supports sliding window, attention sinks, and FP8 KV cache.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -42,6 +43,9 @@ from tokenspeed_kernel.ops.kvcache.triton import (
 from tokenspeed.runtime.configs.model_config import AttentionArch
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
+from tokenspeed.runtime.layers.attention.backends.flat_groups import (
+    FlatCacheGroupsMixin,
+)
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 from tokenspeed.runtime.layers.attention.registry import register_backend
 from tokenspeed.runtime.layers.common import fp8_cast_contiguous
@@ -90,16 +94,34 @@ class TRTLLMMHAMetadata:
     max_seq_len_k: int = 0
     cu_seqlens_q: torch.Tensor = None
     cu_seqlens_k: torch.Tensor = None
+    # page_table is None on the flat path (per-group page_tables route reads).
     page_table: torch.Tensor = None
+    # Flat per-group tables/write-locs, keyed by group id (see flat_groups).
+    page_tables: dict[str, torch.Tensor] | None = None
+    out_cache_locs: dict[str, torch.Tensor] | None = None
 
 
-class TRTLLMMHAAttnBackend(AttentionBackend):
+class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
     """trtllm_mha attention backend optimized for SM100 (Blackwell)."""
+
+    # Per-group flat tables: reads and writes route by layer.group_id, so
+    # slab-aliased pools (e.g. gpt-oss sliding+full pairing) are safe.
+    uses_flat_cache_groups: bool = True
+    # Graph-buffer column tails pad with the zero-init dummy page, matching
+    # the radix replay contract (gather_page_table_with_padding dummy_slot=0).
+    flat_table_tail_pad: int = 0
 
     def support_kv_cache_prewrite(
         self, forward_mode: ForwardMode | None = None
     ) -> bool:
         return True
+
+    def _prewrite_metadata(self, forward_mode):
+        # Prewrite fires on extend too (unlike MHA): route it to the slot
+        # init_forward_metadata filled for this forward.
+        if forward_mode is not None and forward_mode.is_extend_or_mixed():
+            return self.forward_prefill_metadata
+        return self.forward_decode_metadata
 
     @property
     def sinks_dtype(self) -> torch.dtype:
@@ -269,16 +291,6 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         save_kv_cache: bool = True,
         **kwargs,
     ) -> torch.Tensor:
-        q = self._save_kv_and_prepare_q(
-            q, k, v, layer, out_cache_loc, token_to_kv_pool, save_kv_cache
-        )
-        k_cache, v_cache = self._get_kv_cache_permuted(layer, token_to_kv_pool)
-        bmm1_scale, bmm2_scale = self._compute_scales(layer)
-
-        attention_sink = kwargs.get("sinks", None)
-        if attention_sink is not None:
-            attention_sink = attention_sink.float()
-
         if self.draft_block_decode and self.spec_num_tokens > 1:
             # DFLASH draft block: metadata is expanded to bs*spec_num_tokens
             # single-query rows, so use the decode slot directly. Inferring
@@ -295,11 +307,22 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
                 else self.forward_decode_metadata
             )
 
+        out_cache_loc = self._select_out_cache_loc(layer, metadata, out_cache_loc)
+        q = self._save_kv_and_prepare_q(
+            q, k, v, layer, out_cache_loc, token_to_kv_pool, save_kv_cache
+        )
+        k_cache, v_cache = self._get_kv_cache_permuted(layer, token_to_kv_pool)
+        bmm1_scale, bmm2_scale = self._compute_scales(layer)
+
+        attention_sink = kwargs.get("sinks", None)
+        if attention_sink is not None:
+            attention_sink = attention_sink.float()
+
         o = trtllm_batch_decode_with_kv_cache(
             query=q,
             kv_cache=(k_cache, v_cache),
             workspace_buffer=self.workspace_buffer,
-            block_tables=metadata.page_table,
+            block_tables=self._select_page_table(layer, metadata),
             seq_lens=metadata.cache_seqlens_int32,
             max_seq_len=self.max_context_len,
             bmm1_scale=bmm1_scale,
@@ -323,6 +346,8 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         save_kv_cache: bool = True,
         **kwargs,
     ) -> torch.Tensor:
+        metadata = self.forward_prefill_metadata
+        out_cache_loc = self._select_out_cache_loc(layer, metadata, out_cache_loc)
         q = self._save_kv_and_prepare_q(
             q, k, v, layer, out_cache_loc, token_to_kv_pool, save_kv_cache
         )
@@ -333,12 +358,11 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         if attention_sink is not None:
             attention_sink = attention_sink.float()
 
-        metadata = self.forward_prefill_metadata
         o = trtllm_batch_context_with_kv_cache(
             query=q,
             kv_cache=(k_cache, v_cache),
             workspace_buffer=self.workspace_buffer,
-            block_tables=metadata.page_table,
+            block_tables=self._select_page_table(layer, metadata),
             seq_lens=metadata.cache_seqlens_int32,
             max_q_len=metadata.max_seq_len_q,
             max_kv_len=self.max_context_len,
@@ -370,8 +394,37 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         extend_seq_lens_cpu: torch.Tensor | None = None,
         spec_info=None,
         use_cuda_graph: bool = False,
+        flat_block_tables: dict[str, torch.Tensor] | None = None,
         **kwargs,
     ):
+        flat_page_tables = self._shed_state_groups(flat_block_tables)
+        flat_out_cache_locs = None
+        if flat_page_tables:
+            # Mirrors the MHA backend: flat + spec is unsupported (the
+            # publication rule never delivers tables under spec decode).
+            assert not (
+                self.spec_num_tokens > 1
+                and (not self.is_draft or self.draft_block_decode)
+            ), "flat cache groups are unsupported with spec_num_tokens > 1"
+            if forward_mode.is_extend_or_mixed():
+                assert extend_prefix_lens_cpu is not None
+                assert extend_seq_lens_cpu is not None
+                flat_out_cache_locs = self._compute_flat_extend_out_cache_locs(
+                    flat_page_tables,
+                    extend_prefix_lens_cpu[:bs],
+                    extend_seq_lens_cpu[:bs],
+                    self.page_size,
+                )
+            else:
+                flat_out_cache_locs = self._compute_flat_decode_out_cache_locs(
+                    flat_page_tables,
+                    seq_lens[:bs],
+                    self.page_size,
+                )
+            self._maybe_check_flat_write_locs(
+                flat_page_tables, flat_out_cache_locs, self.page_size
+            )
+
         if forward_mode.is_extend_or_mixed():
             self._init_extend_metadata(
                 bs,
@@ -382,6 +435,8 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
                 extend_prefix_lens=extend_prefix_lens,
                 extend_prefix_lens_cpu=extend_prefix_lens_cpu,
                 extend_seq_lens_cpu=extend_seq_lens_cpu,
+                flat_page_tables=flat_page_tables,
+                flat_out_cache_locs=flat_out_cache_locs,
             )
             # Drafter: also fill decode_metadata so step 1+ multi-step has
             # metadata under EXTEND/MIXED target. seq_lens is the drafter's
@@ -407,7 +462,14 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
                 # Drafter's N-1 single-token steps after the first.
                 self._init_decode_metadata(bs, req_pool_indices, seq_lens, req_to_page)
         else:
-            self._init_decode_metadata(bs, req_pool_indices, seq_lens, req_to_page)
+            self._init_decode_metadata(
+                bs,
+                req_pool_indices,
+                seq_lens,
+                req_to_page,
+                flat_page_tables=flat_page_tables,
+                flat_out_cache_locs=flat_out_cache_locs,
+            )
 
     def _init_decode_metadata(
         self,
@@ -415,21 +477,30 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         req_to_page: torch.Tensor,
+        flat_page_tables: dict[str, torch.Tensor] | None = None,
+        flat_out_cache_locs: dict[str, torch.Tensor] | None = None,
     ):
         assert (
             seq_lens.dtype == torch.int32
         ), f"seq_lens must be int32, got {seq_lens.dtype}"
         device = seq_lens.device
         # Alias seq_lens (no copy, no mutation). cu_seqlens_k omitted:
-        # the decode kernel doesn't read it.
+        # the decode kernel doesn't read it. On the flat path the per-group
+        # tables route every read; the radix single table would be dead work.
         self.forward_decode_metadata = TRTLLMMHAMetadata(
             cache_seqlens_int32=seq_lens[:bs],
             max_seq_len_q=1,
             max_seq_len_k=self.max_context_len,
             cu_seqlens_q=torch.arange(0, bs + 1, dtype=torch.int32, device=device),
-            page_table=self._build_page_table(
-                req_pool_indices, seq_lens, bs, req_to_page, self.page_table_buf
+            page_table=(
+                None
+                if flat_page_tables
+                else self._build_page_table(
+                    req_pool_indices, seq_lens, bs, req_to_page, self.page_table_buf
+                )
             ),
+            page_tables=flat_page_tables,
+            out_cache_locs=flat_out_cache_locs,
         )
 
     def _replicate_block_page_table(
@@ -551,6 +622,8 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         extend_prefix_lens: torch.Tensor | None = None,
         extend_prefix_lens_cpu=None,
         extend_seq_lens_cpu=None,
+        flat_page_tables: dict[str, torch.Tensor] | None = None,
+        flat_out_cache_locs: dict[str, torch.Tensor] | None = None,
     ):
         """Populate prefill slot for regular EXTEND (ragged query)."""
         assert (
@@ -563,8 +636,13 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         cu_seqlens_k = torch.nn.functional.pad(
             torch.cumsum(seq_lens, dim=0, dtype=torch.int32), (1, 0)
         )
-        page_table = self._build_page_table(
-            req_pool_indices, seq_lens, bs, req_to_page, self.page_table_buf
+        # Flat path: per-group tables route every read (see _init_decode_metadata).
+        page_table = (
+            None
+            if flat_page_tables
+            else self._build_page_table(
+                req_pool_indices, seq_lens, bs, req_to_page, self.page_table_buf
+            )
         )
 
         # Read the max from the pinned-CPU mirror — avoids a per-iter
@@ -598,13 +676,21 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
             cu_seqlens_q=cu_seqlens_q,
             cu_seqlens_k=cu_seqlens_k,
             page_table=page_table,
+            page_tables=flat_page_tables,
+            out_cache_locs=flat_out_cache_locs,
         )
 
     # ------------------------------------------------------------------
     # CUDA graph support
     # ------------------------------------------------------------------
 
-    def init_cuda_graph_state(self, max_bs: int, seq_lens_buf: torch.Tensor):
+    def init_cuda_graph_state(
+        self,
+        max_bs: int,
+        seq_lens_buf: torch.Tensor,
+        paged_cache_group_specs: Sequence = (),
+        **kwargs,
+    ):
         assert (
             seq_lens_buf.dtype == torch.int32
             and seq_lens_buf.dim() == 1
@@ -615,6 +701,10 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         )
         self.cuda_graph_prefill_metadata = {}
         self.cuda_graph_decode_metadata = {}
+        # Flat per-group persistent buffers + state-group shed; before the
+        # DFLASH early return (replay reads the dict for the stale guard).
+        self._learn_flat_state_groups(paged_cache_group_specs)
+        self._init_flat_graph_buffers(max_bs)
         if self.draft_block_decode and self.spec_num_tokens > 1:
             # DFLASH draft block: spec_num_tokens decode rows per request. Unlike
             # the plain path, cache_seqlens is a dedicated buffer (NOT aliasing
@@ -643,11 +733,24 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode,
+        flat_cache_group_ids: tuple[str, ...] = (),
+        **kwargs,
     ):
         if forward_mode.is_extend_or_mixed():
             raise NotImplementedError(
                 f"trtllm CUDA graph capture not supported for {forward_mode}"
             )
+
+        # Real tables only arrive at replay: capture lazily allocates
+        # persistent per-group buffers and records metadata views into them.
+        if flat_cache_group_ids:
+            assert not (
+                self.spec_num_tokens > 1
+                and (not self.is_draft or self.draft_block_decode)
+            ), "flat_cache_group_ids is unsupported with spec_num_tokens > 1"
+        page_tables, out_cache_locs = self._flat_capture_group_views(
+            bs, flat_cache_group_ids
+        )
 
         if self.draft_block_decode and self.spec_num_tokens > 1:
             self._init_block_decode_metadata_capture(bs)
@@ -658,7 +761,9 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
             if self.is_draft:
                 self._init_decode_metadata_capture(bs, seq_lens)
         else:
-            self._init_decode_metadata_capture(bs, seq_lens)
+            self._init_decode_metadata_capture(
+                bs, seq_lens, page_tables, out_cache_locs
+            )
 
     def _init_block_decode_metadata_capture(self, bs: int):
         """DFLASH draft block (cuda-graph capture): spec_num_tokens single-query
@@ -679,14 +784,27 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         self.cuda_graph_decode_metadata[bs] = metadata
         self.forward_decode_metadata = metadata
 
-    def _init_decode_metadata_capture(self, bs: int, seq_lens: torch.Tensor):
+    def _init_decode_metadata_capture(
+        self,
+        bs: int,
+        seq_lens: torch.Tensor,
+        page_tables: dict[str, torch.Tensor] | None = None,
+        out_cache_locs: dict[str, torch.Tensor] | None = None,
+    ):
         # cache_seqlens aliases seq_lens_buf (set in init_cuda_graph_state).
+        # Flat captures route reads through the per-group buffer views and
+        # replay never fills the radix single table, so record page_table=None
+        # instead of a slice of the never-filled zero buffer.
         metadata = TRTLLMMHAMetadata(
             cache_seqlens_int32=self.cuda_graph_cache_seqlens[:bs],
             max_seq_len_q=1,
             max_seq_len_k=self.max_context_len,
             cu_seqlens_q=torch.arange(0, bs + 1, dtype=torch.int32, device=self.device),
-            page_table=self.cuda_graph_page_table[:bs, :],
+            page_table=(
+                None if page_tables is not None else self.cuda_graph_page_table[:bs, :]
+            ),
+            page_tables=page_tables,
+            out_cache_locs=out_cache_locs,
         )
         self.cuda_graph_decode_metadata[bs] = metadata
         self.forward_decode_metadata = metadata
@@ -721,12 +839,16 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode,
         req_to_page: torch.Tensor = None,
+        flat_block_tables: dict[str, torch.Tensor] | None = None,
         **kwargs,
     ):
         if forward_mode.is_extend_or_mixed():
             raise NotImplementedError(
                 f"trtllm CUDA graph replay not supported for {forward_mode}"
             )
+
+        # Fail loudly instead of replaying over stale/zero page tables.
+        self._flat_replay_stale_guard(bs, flat_block_tables)
 
         if self.draft_block_decode and self.spec_num_tokens > 1:
             # DFLASH draft block: replicate the page table to each request's
@@ -739,8 +861,11 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
                 self.forward_decode_metadata = self.cuda_graph_decode_metadata[bs]
             return
 
-        # cache_seqlens aliases seq_lens_buf; only page_table needs refresh.
-        if req_to_page is not None:
+        # cache_seqlens aliases seq_lens_buf; only page tables need refresh.
+        # Flat captures read only the per-group buffers; the radix single
+        # table would be dead work there (and req_to_page is unpopulated on
+        # a flat scheduler build).
+        if not self.cuda_graph_flat_page_tables and req_to_page is not None:
             gather_page_table_with_padding(
                 req_to_page=req_to_page,
                 req_pool_indices=req_pool_indices,
@@ -751,6 +876,10 @@ class TRTLLMMHAAttnBackend(AttentionBackend):
                 page_size=self.page_size,
                 dummy_slot=0,
             )
+        if flat_block_tables:
+            # cuda_graph_cache_seqlens aliases the controller's seq_lens_buf,
+            # filled by input prep BEFORE this call.
+            self._flat_replay_fill(bs, flat_block_tables, self.cuda_graph_cache_seqlens)
 
         # Refresh for both verify and draft: draft step 1 is multi-token
         # and reads spec_cache_seqlens_buf; later single-token steps don't.

--- a/python/tokenspeed/runtime/models/gpt_oss.py
+++ b/python/tokenspeed/runtime/models/gpt_oss.py
@@ -237,7 +237,7 @@ class GptOssAttention(nn.Module):
                 layer=self.attn,
                 # Flat path: prewrite at this layer's group locations.
                 out_cache_loc=ctx.attn_backend.select_out_cache_loc(
-                    self.attn, out_cache_loc
+                    self.attn, out_cache_loc, ctx.forward_mode
                 ),
                 token_to_kv_pool=ctx.token_to_kv_pool,
             )

--- a/test/runtime/test_flat_scheduler_config_guard.py
+++ b/test/runtime/test_flat_scheduler_config_guard.py
@@ -189,6 +189,32 @@ class ValidateFlatSchedulerConfigTest(unittest.TestCase):
                 speculative_enabled=False,
             )
 
+    def test_hybrid_with_flat_capable_sub_backends_passes(self):
+        # The Qwen3.5 shape: hybrid wrapper over a flat-capable full backend
+        # and the mamba backend (declares uses_flat_cache_groups: it consumes
+        # the state group's table), pool publishing KV + state groups. The
+        # sub-backend recursion must not reject it.
+        class FlatFull:
+            uses_flat_cache_groups = True
+
+        class FlatMamba:
+            uses_flat_cache_groups = True
+
+        class FlatWrapper:
+            uses_flat_cache_groups = True
+
+            def __init__(self):
+                self.full_attn_backend = FlatFull()
+                self.linear_attn_backend = FlatMamba()
+
+        _pcs.validate_flat_scheduler_config(
+            flat_kvcache_ext=True,
+            paged_cache_groups=[FakeGroup(), FakeGroup()],
+            attn_backend=FlatWrapper(),
+            kv_pool=FakeMHAPool(),
+            speculative_enabled=False,
+        )
+
     def test_hybrid_sub_backend_recursed(self):
         # The hybrid wrapper is flat-capable, but its user-selectable full
         # sub-backend must be checked on its own: a table-blind sub-backend

--- a/test/runtime/test_flat_scheduler_config_guard.py
+++ b/test/runtime/test_flat_scheduler_config_guard.py
@@ -189,23 +189,23 @@ class ValidateFlatSchedulerConfigTest(unittest.TestCase):
                 speculative_enabled=False,
             )
 
-    def test_hybrid_with_flat_capable_sub_backends_passes(self):
-        # The Qwen3.5 shape: hybrid wrapper over a flat-capable full backend
-        # and the mamba backend (declares uses_flat_cache_groups: it consumes
-        # the state group's table), pool publishing KV + state groups. The
-        # sub-backend recursion must not reject it.
+    def test_hybrid_with_flat_capable_full_sub_backend_passes(self):
+        # The GDN-hybrid shape: hybrid wrapper over a flat-capable full
+        # backend, pool publishing KV + state groups. Only the KV-table
+        # consumer (full sub-backend) is checked; the linear side has its
+        # own explicit flat path and is out of scope for this guard.
         class FlatFull:
             uses_flat_cache_groups = True
 
-        class FlatMamba:
-            uses_flat_cache_groups = True
+        class LinearWithoutFlag:
+            pass
 
         class FlatWrapper:
             uses_flat_cache_groups = True
 
             def __init__(self):
                 self.full_attn_backend = FlatFull()
-                self.linear_attn_backend = FlatMamba()
+                self.linear_attn_backend = LinearWithoutFlag()
 
         _pcs.validate_flat_scheduler_config(
             flat_kvcache_ext=True,
@@ -215,7 +215,7 @@ class ValidateFlatSchedulerConfigTest(unittest.TestCase):
             speculative_enabled=False,
         )
 
-    def test_hybrid_sub_backend_recursed(self):
+    def test_hybrid_full_sub_backend_recursed(self):
         # The hybrid wrapper is flat-capable, but its user-selectable full
         # sub-backend must be checked on its own: a table-blind sub-backend
         # would silently drop the per-group tables from common_kw.

--- a/test/runtime/test_flat_scheduler_config_guard.py
+++ b/test/runtime/test_flat_scheduler_config_guard.py
@@ -158,9 +158,10 @@ class ValidateFlatSchedulerConfigTest(unittest.TestCase):
                 speculative_enabled=spec,
             )
 
-    def test_backend_without_flags_defaults_safe(self):
-        # Backends predating the class flags (getattr defaults False) must
-        # not trip the layout arm; the zero-group arm still applies.
+    def test_backend_without_flags_single_group_falls_back(self):
+        # Backends predating the class flags (getattr defaults False) may
+        # fall back to the C++ single table when exactly one group is
+        # published: the first-group sample IS the only group.
         class LegacyBackend:
             pass
 
@@ -171,6 +172,45 @@ class ValidateFlatSchedulerConfigTest(unittest.TestCase):
             kv_pool=FakeMHAPool(),
             speculative_enabled=False,
         )
+
+    def test_backend_without_flags_multi_group_rejected(self):
+        # A table-blind backend on a >1-group pool would index every layer
+        # through the first-group sample — silent KV corruption on slab
+        # layouts. Must refuse at startup.
+        class LegacyBackend:
+            pass
+
+        with self.assertRaisesRegex(RuntimeError, "single-table fallback"):
+            _pcs.validate_flat_scheduler_config(
+                flat_kvcache_ext=True,
+                paged_cache_groups=[FakeGroup(), FakeGroup()],
+                attn_backend=LegacyBackend(),
+                kv_pool=FakeMHAPool(),
+                speculative_enabled=False,
+            )
+
+    def test_hybrid_sub_backend_recursed(self):
+        # The hybrid wrapper is flat-capable, but its user-selectable full
+        # sub-backend must be checked on its own: a table-blind sub-backend
+        # would silently drop the per-group tables from common_kw.
+        class FlatWrapper:
+            uses_flat_cache_groups = True
+
+            def __init__(self, full):
+                self.full_attn_backend = full
+                self.linear_attn_backend = None
+
+        class LegacyFull:
+            pass
+
+        with self.assertRaisesRegex(RuntimeError, "LegacyFull"):
+            _pcs.validate_flat_scheduler_config(
+                flat_kvcache_ext=True,
+                paged_cache_groups=[FakeGroup(), FakeGroup()],
+                attn_backend=FlatWrapper(LegacyFull()),
+                kv_pool=FakeMHAPool(),
+                speculative_enabled=False,
+            )
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_trtllm_flat_groups.py
+++ b/test/runtime/test_trtllm_flat_groups.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+# CI Registration (parsed via AST, runtime no-op)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=15, suite="runtime-1gpu")
+
+
+def _import_backend():
+    from tokenspeed.runtime.layers.attention.backends.trtllm import (
+        TRTLLMMHAAttnBackend,
+        TRTLLMMHAMetadata,
+    )
+
+    return TRTLLMMHAAttnBackend, TRTLLMMHAMetadata
+
+
+class TRTLLMFlatGroupsTest(unittest.TestCase):
+    """The trtllm backend consumes flat per-group tables through the shared
+    FlatCacheGroupsMixin: table/write-loc selection routes by layer.group_id,
+    metadata drops the radix single table on the flat path, and the CUDA-graph
+    buffers follow the capture/replay discipline."""
+
+    def setUp(self):
+        try:
+            self.Backend, self.Metadata = _import_backend()
+        except (ImportError, ModuleNotFoundError) as exc:
+            self.skipTest(f"needs torch + tokenspeed_kernel: {exc}")
+        import torch
+
+        self.torch = torch
+
+    def _bare_backend(self, *, page_size=64, max_num_pages=8, spec_num_tokens=1):
+        # Bypass __init__: the paths under test read only these attributes.
+        b = self.Backend.__new__(self.Backend)
+        b.page_size = page_size
+        b.max_num_pages = max_num_pages
+        b.max_context_len = page_size * max_num_pages
+        b.device = "cpu"
+        b.spec_num_tokens = spec_num_tokens
+        b.is_draft = False
+        b.draft_block_decode = False
+        b.forward_decode_metadata = None
+        b.forward_prefill_metadata = None
+        b.cuda_graph_prefill_metadata = {}
+        b.cuda_graph_decode_metadata = {}
+        return b
+
+    def _layer(self, group_id):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(group_id=group_id)
+
+    def test_flag_declared(self):
+        self.assertTrue(self.Backend.uses_flat_cache_groups)
+
+    def test_select_page_table_routes_by_group(self):
+        b = self._bare_backend()
+        full = self.torch.tensor([[1, 2]], dtype=self.torch.int32)
+        swa = self.torch.tensor([[3, 0]], dtype=self.torch.int32)
+        meta = self.Metadata(
+            page_tables={"full_attention": full, "sliding_attention": swa}
+        )
+        self.assertIs(b._select_page_table(self._layer("full_attention"), meta), full)
+        self.assertIs(b._select_page_table(self._layer("sliding_attention"), meta), swa)
+
+    def test_select_out_cache_loc_routes_by_group(self):
+        b = self._bare_backend()
+        radix_loc = self.torch.tensor([7], dtype=self.torch.int32)
+        full_loc = self.torch.tensor([64], dtype=self.torch.int32)
+        meta_none = self.Metadata(out_cache_locs=None)
+        self.assertIs(
+            b._select_out_cache_loc(
+                self._layer("full_attention"), meta_none, radix_loc
+            ),
+            radix_loc,
+        )
+        meta = self.Metadata(out_cache_locs={"full_attention": full_loc})
+        self.assertIs(
+            b._select_out_cache_loc(self._layer("full_attention"), meta, radix_loc),
+            full_loc,
+        )
+
+    def test_decode_metadata_flat_drops_single_table(self):
+        b = self._bare_backend()
+        bs = 2
+        seq_lens = self.torch.tensor([65, 3], dtype=self.torch.int32)
+        tables = {
+            "full_attention": self.torch.tensor(
+                [[11, 12], [13, -1]], dtype=self.torch.int32
+            ),
+            "sliding_attention": self.torch.tensor(
+                [[21, 22], [23, -1]], dtype=self.torch.int32
+            ),
+        }
+        locs = b._compute_flat_decode_out_cache_locs(tables, seq_lens, b.page_size)
+        b._init_decode_metadata(
+            bs,
+            req_pool_indices=self.torch.tensor([0, 1], dtype=self.torch.int32),
+            seq_lens=seq_lens,
+            req_to_page=None,
+            flat_page_tables=tables,
+            flat_out_cache_locs=locs,
+        )
+        meta = b.forward_decode_metadata
+        self.assertIsNone(meta.page_table)
+        self.assertIs(meta.page_tables, tables)
+        # seq_len 65 -> page index 1, offset 0; seq_len 3 -> page 0, offset 2.
+        self.assertEqual(
+            meta.out_cache_locs["full_attention"].tolist(),
+            [12 * 64 + 0, 13 * 64 + 2],
+        )
+        self.assertEqual(
+            meta.out_cache_locs["sliding_attention"].tolist(),
+            [22 * 64 + 0, 23 * 64 + 2],
+        )
+
+    def test_extend_metadata_flat_drops_single_table(self):
+        b = self._bare_backend()
+        bs = 1
+        seq_lens = self.torch.tensor([66], dtype=self.torch.int32)
+        tables = {"full_attention": self.torch.tensor([[5, 6]], dtype=self.torch.int32)}
+        locs = b._compute_flat_extend_out_cache_locs(
+            tables,
+            self.torch.tensor([64], dtype=self.torch.int32),
+            self.torch.tensor([2], dtype=self.torch.int32),
+            b.page_size,
+        )
+        b._init_extend_metadata(
+            bs,
+            req_pool_indices=self.torch.tensor([0], dtype=self.torch.int32),
+            seq_lens=seq_lens,
+            req_to_page=None,
+            extend_seq_lens_cpu=self.torch.tensor([2], dtype=self.torch.int32),
+            flat_page_tables=tables,
+            flat_out_cache_locs=locs,
+        )
+        meta = b.forward_prefill_metadata
+        self.assertIsNone(meta.page_table)
+        self.assertIs(meta.page_tables, tables)
+        # New tokens at positions 64, 65 -> page 6, offsets 0 and 1.
+        self.assertEqual(
+            meta.out_cache_locs["full_attention"].tolist(), [6 * 64, 6 * 64 + 1]
+        )
+
+    def test_graph_capture_and_replay_discipline(self):
+        b = self._bare_backend()
+        max_bs, bs = 4, 2
+        b._init_flat_graph_buffers(max_bs)
+        gids = ("full_attention", "sliding_attention")
+        page_tables, out_cache_locs = b._flat_capture_group_views(bs, gids)
+        self.assertEqual(set(page_tables), set(gids))
+        self.assertEqual(page_tables["full_attention"].shape, (bs, b.max_num_pages))
+
+        # Replay without tables must fail loudly (stale-table guard).
+        with self.assertRaisesRegex(RuntimeError, "stale page tables"):
+            b._flat_replay_stale_guard(bs, None)
+        with self.assertRaisesRegex(RuntimeError, "missing captured groups"):
+            b._flat_replay_stale_guard(
+                bs, {"full_attention": self.torch.zeros((bs, 1))}
+            )
+
+        # Replay fill copies rows, pads column tails with the trtllm dummy
+        # page 0 (flat_table_tail_pad), recomputes locs.
+        seq_lens = self.torch.tensor([65, 1, 1, 1], dtype=self.torch.int32)
+        src = {
+            "full_attention": self.torch.tensor(
+                [[11, 12], [0, -1]], dtype=self.torch.int32
+            ),
+            "sliding_attention": self.torch.tensor(
+                [[21, 22], [0, -1]], dtype=self.torch.int32
+            ),
+        }
+        b._flat_replay_fill(bs, src, seq_lens)
+        buf = b.cuda_graph_flat_page_tables["full_attention"]
+        self.assertEqual(buf[0, :2].tolist(), [11, 12])
+        self.assertEqual(self.Backend.flat_table_tail_pad, 0)
+        self.assertEqual(buf[0, 2:].tolist(), [0] * (b.max_num_pages - 2))
+        self.assertEqual(
+            b.cuda_graph_flat_out_cache_locs["full_attention"][:bs].tolist(),
+            [12 * 64 + 0, 0 * 64 + 0],
+        )
+
+    def test_flat_with_spec_asserts(self):
+        b = self._bare_backend(spec_num_tokens=4)
+        tables = {"full_attention": self.torch.zeros((1, 1), dtype=self.torch.int32)}
+        with self.assertRaisesRegex(AssertionError, "spec_num_tokens"):
+            b.init_forward_metadata(
+                bs=1,
+                req_pool_indices=self.torch.tensor([0], dtype=self.torch.int32),
+                seq_lens=self.torch.tensor([1], dtype=self.torch.int32),
+                forward_mode=_DecodeMode(),
+                req_to_page=None,
+                flat_block_tables=tables,
+            )
+
+
+class _DecodeMode:
+    """Minimal ForwardMode stand-in for the decode dispatch path."""
+
+    def is_extend_or_mixed(self):
+        return False
+
+    def is_mixed(self):
+        return False
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Extract the MHA backend's flat-group machinery (table/write-loc selection, extend+decode write-loc computation, CUDA-graph per-group buffer discipline) into a shared FlatCacheGroupsMixin and adopt it in the trtllm backend, so slab-aliased flat pools (gpt-oss sliding+full pairing) are safe under --attention-backend trtllm.

The fused-RoPE KV prewrite hook becomes forward_mode-aware: trtllm prewrites on extend as well (MHA is decode-only), and the extend prewrite must land in the layer group's pages rather than the scheduler's legacy locations, which a flat build never populates (illegal memory access in the RoPE kernel).

Close the flat config-guard hole: reject table-blind backends when the pool publishes more than one cache group (the C++ single-table fallback is a first-group sample and silently corrupts aliased slabs past the sliding window), recurse into hybrid sub-backends, and declare the mamba backend flat-capable (it already consumes the state group's tables).

Validated e2e on gpt-oss-120b (1xB200): flat+trtllm slab layout at 2x token pool, passkey retrieval past the sliding window correct in eager and graph mode, shared_prefix stress 2336/2336 with zero errors; radix+trtllm regression arm clean.

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
