### PR TITLE
Route MLA RoPE KV writes through embedding API

### DIFF
--- a/python/tokenspeed/runtime/layers/rotary_embedding.py
+++ b/python/tokenspeed/runtime/layers/rotary_embedding.py
@@ -28,11 +28,13 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-from tokenspeed_kernel.ops.embedding import FusedSetKVBufferArg, apply_rope
-from tokenspeed_kernel.platform import current_platform
+from tokenspeed_kernel.ops.embedding import (
+    FusedMLASetKVBufferArg,
+    FusedSetKVBufferArg,
+    apply_rope,
+)
 from tokenspeed_kernel.torch_compile import get_compiler_backend
 
-_is_nvidia = current_platform().is_nvidia
 logger = logging.getLogger(__name__)
 
 
@@ -173,6 +175,7 @@ class RotaryEmbedding(torch.nn.Module):
         key: torch.Tensor,
         offsets: torch.Tensor | None = None,
         fused_set_kv_buffer_arg: FusedSetKVBufferArg | None = None,
+        fused_mla_set_kv_buffer_arg: FusedMLASetKVBufferArg | None = None,
         output_q_rope: torch.Tensor | None = None,
         output_k_rope: torch.Tensor | None = None,
         enable_pdl: bool = False,
@@ -187,6 +190,7 @@ class RotaryEmbedding(torch.nn.Module):
             cos_sin_cache=self.cos_sin_cache,
             is_neox=self.is_neox_style,
             fused_set_kv_buffer_arg=fused_set_kv_buffer_arg,
+            fused_mla_set_kv_buffer_arg=fused_mla_set_kv_buffer_arg,
             q_rope_out=output_q_rope,
             k_rope_out=output_k_rope,
             enable_pdl=enable_pdl,
@@ -672,17 +676,30 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbedding):
         query: torch.Tensor,
         key: torch.Tensor,
         fused_set_kv_buffer_arg=None,
+        fused_mla_set_kv_buffer_arg=None,
         output_q_rope=None,
         offsets: torch.Tensor | None = None,
+        enable_pdl: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        if _is_nvidia:
+        if offsets is None:
             return super().forward(
                 positions=positions,
                 query=query,
                 key=key,
                 fused_set_kv_buffer_arg=fused_set_kv_buffer_arg,
+                fused_mla_set_kv_buffer_arg=fused_mla_set_kv_buffer_arg,
                 output_q_rope=output_q_rope,
                 offsets=offsets,
+                enable_pdl=enable_pdl,
+            )
+        if (
+            fused_set_kv_buffer_arg is not None
+            or fused_mla_set_kv_buffer_arg is not None
+            or output_q_rope is not None
+        ):
+            raise ValueError(
+                "DeepseekScalingRotaryEmbedding offset path does not support "
+                "fused KV writes or output_q_rope"
             )
 
         dtype = query.dtype

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -106,9 +106,7 @@ from tokenspeed.runtime.model_loader.weight_utils import (
     kv_cache_scales_loader,
 )
 from tokenspeed.runtime.models.base import BaseCausalLM
-from tokenspeed.runtime.models.utils import (
-    create_fused_set_kv_buffer_arg,
-)
+from tokenspeed.runtime.models.utils import create_fused_mla_set_kv_buffer_arg
 from tokenspeed.runtime.moe.distribution_recorder import (
     get_global_expert_distribution_recorder,
 )
@@ -508,7 +506,7 @@ class DeepseekV3AttentionMLA(nn.Module):
         self.max_position_embeddings = max_position_embeddings
         self.config = config
         self.alt_stream = alt_stream
-        self.attention_backend = global_server_args_dict["attention_backend"]
+        self.attention_backend = global_server_args_dict["attention_backend"] or "mla"
         self.cli_factor = getattr(config, "cli_factor", 1)
         self.prefix = prefix
 
@@ -604,14 +602,6 @@ class DeepseekV3AttentionMLA(nn.Module):
                 self.scaling = self.scaling * mscale * mscale
         else:
             self.rotary_emb = None
-
-        # Fused RoPE+KV write kernel is incompatible with MLA: it assumes
-        # K and V have the same head_dim, but MLA's KV cache is a single
-        # [latent(512)|rope(64)] buffer where the two dimensions differ.
-        # Passing this to the kernel causes thread overflow and silent
-        # corruption of the latent cache.  All DeepSeek V2/V3 models use
-        # MLA (kv_lora_rank > 0), so we unconditionally disable it here.
-        self.use_fused_set_kv_buffer = False
 
         self.attn_mqa = PagedAttention(
             self.num_local_heads,
@@ -856,34 +846,43 @@ class DeepseekV3AttentionMLA(nn.Module):
             return query_fp8, key_fp8
 
         elif self.rotary_emb is not None and q_nope.size(0) > 0:
-            # Apply RoPE directly on Q and K slices
-            q_pe, k_pe = self.rotary_emb(
-                positions,
-                q_pe,
-                K[..., self.kv_lora_rank :],
-                fused_set_kv_buffer_arg=(
-                    create_fused_set_kv_buffer_arg(
-                        value=K[..., : self.kv_lora_rank],
-                        layer=self.attn_mqa,
-                        out_cache_loc=out_cache_loc,
-                        token_to_kv_pool=ctx.token_to_kv_pool,
-                    )
-                    if self.use_fused_set_kv_buffer
-                    else None
-                ),
+            fused_mla_kv_arg = (
+                create_fused_mla_set_kv_buffer_arg(
+                    k_nope=K[..., : self.kv_lora_rank],
+                    rope_dim=self.qk_rope_head_dim,
+                    out_cache_loc=out_cache_loc,
+                    token_to_kv_pool=ctx.token_to_kv_pool,
+                    layer_id=self.attn_mqa.layer_id,
+                )
+                if _is_amd and self.attention_backend in self._MLA_KERNEL_BACKENDS
+                else None
             )
-            Q[..., self.kv_lora_rank :].copy_(q_pe)
-            K[..., self.kv_lora_rank :].copy_(k_pe)
+            if fused_mla_kv_arg is not None:
+                self.rotary_emb(
+                    positions,
+                    q_pe,
+                    K[..., self.kv_lora_rank :],
+                    fused_mla_set_kv_buffer_arg=fused_mla_kv_arg,
+                    output_q_rope=Q[..., self.kv_lora_rank :],
+                    enable_pdl=pdl_enabled(),
+                )
+                K = None
+            else:
+                # Apply RoPE directly on Q and K slices
+                q_pe, k_pe = self.rotary_emb(
+                    positions,
+                    q_pe,
+                    K[..., self.kv_lora_rank :],
+                )
+                Q[..., self.kv_lora_rank :].copy_(q_pe)
+                K[..., self.kv_lora_rank :].copy_(k_pe)
         else:
             Q[..., self.kv_lora_rank :] = q_pe
 
         # For MLA kernel backends, write KV cache here (model-owned) so the
         # backend never has to. This unifies the FP8 fused path (written above)
         # and the BF16 path into a single ownership model.
-        if (
-            self.attention_backend in self._MLA_KERNEL_BACKENDS
-            and not self.use_fused_set_kv_buffer
-        ):
+        if self.attention_backend in self._MLA_KERNEL_BACKENDS and K is not None:
             ctx.token_to_kv_pool.set_mla_kv_buffer(
                 self.attn_mqa,
                 out_cache_loc,
@@ -903,16 +902,20 @@ class DeepseekV3AttentionMLA(nn.Module):
         record_kv_cache: bool | None = None,
     ) -> torch.Tensor:
         # MLA kernel backends: KV cache already written in forward_absorb_qkv_proj.
-        # Other backends: write via fused_set_kv_buffer or let backend handle it.
+        # Other backends write KV in the attention backend.
         if self.attention_backend in self._MLA_KERNEL_BACKENDS:
             need_save_kv = False
+            k_for_attn = K
+            v_for_attn = K[..., : self.kv_lora_rank] if K is not None else None
         else:
-            need_save_kv = not self.use_fused_set_kv_buffer
+            need_save_kv = True
+            k_for_attn = K
+            v_for_attn = K[..., : self.kv_lora_rank]
 
         attn_output = self.attn_mqa(
             Q,
-            K,
-            K[..., : self.kv_lora_rank],
+            k_for_attn,
+            v_for_attn,
             ctx,
             out_cache_loc,
             save_kv_cache=need_save_kv,
@@ -1019,16 +1022,6 @@ class DeepseekV3AttentionMLA(nn.Module):
                 positions,
                 q_pe,
                 k_pe,
-                fused_set_kv_buffer_arg=(
-                    create_fused_set_kv_buffer_arg(
-                        value=kv_a.unsqueeze(1),
-                        layer=self.attn_mha,
-                        out_cache_loc=out_cache_loc,
-                        token_to_kv_pool=ctx.token_to_kv_pool,
-                    )
-                    if self.use_fused_set_kv_buffer
-                    else None
-                ),
             )
 
         q[..., self.qk_nope_head_dim :] = q_pe
@@ -1036,13 +1029,12 @@ class DeepseekV3AttentionMLA(nn.Module):
         k[..., : self.qk_nope_head_dim] = k_nope
         k[..., self.qk_nope_head_dim :] = k_pe
 
-        if not self.use_fused_set_kv_buffer:
-            ctx.token_to_kv_pool.set_mla_kv_buffer(
-                self.attn_mha,
-                out_cache_loc,
-                cache_k_nope=kv_a.unsqueeze(1),
-                cache_k_rope=k_pe,
-            )
+        ctx.token_to_kv_pool.set_mla_kv_buffer(
+            self.attn_mha,
+            out_cache_loc,
+            cache_k_nope=kv_a.unsqueeze(1),
+            cache_k_rope=k_pe,
+        )
 
         return q, k, v
 

--- a/python/tokenspeed/runtime/models/utils.py
+++ b/python/tokenspeed/runtime/models/utils.py
@@ -21,7 +21,7 @@
 """Helpers shared across runtime model implementations."""
 
 import torch
-from tokenspeed_kernel.ops.embedding import FusedSetKVBufferArg
+from tokenspeed_kernel.ops.embedding import FusedMLASetKVBufferArg, FusedSetKVBufferArg
 
 from tokenspeed.runtime.layers.paged_attention import PagedAttention
 from tokenspeed.runtime.utils import print_warning_once
@@ -96,5 +96,36 @@ def create_fused_set_kv_buffer_arg(
         v_buffer=v_buffer,
         k_scale=None,
         v_scale=None,
+        cache_loc=out_cache_loc,
+    )
+
+
+def create_fused_mla_set_kv_buffer_arg(
+    k_nope: torch.Tensor,
+    rope_dim: int,
+    out_cache_loc: torch.Tensor,
+    token_to_kv_pool,
+    layer_id: int,
+):
+    """Build fused MLA RoPE+KV write arguments when the cache layout matches."""
+
+    from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
+
+    if not isinstance(token_to_kv_pool, MLATokenToKVPool):
+        return None
+
+    kv_buffer = token_to_kv_pool.get_key_buffer(layer_id)
+    if not isinstance(kv_buffer, torch.Tensor):
+        return None
+    if kv_buffer.dtype != k_nope.dtype:
+        return None
+    if kv_buffer.ndim != 3 or kv_buffer.shape[1] != 1:
+        return None
+    if kv_buffer.shape[2] != k_nope.shape[-1] + rope_dim:
+        return None
+
+    return FusedMLASetKVBufferArg(
+        k_nope=k_nope,
+        kv_buffer=kv_buffer.view(kv_buffer.shape[0], -1),
         cache_loc=out_cache_loc,
     )

--- a/test/runtime/cache/test_mla_kv_buffer.py
+++ b/test/runtime/cache/test_mla_kv_buffer.py
@@ -22,6 +22,10 @@ from __future__ import annotations
 
 import pytest
 import torch
+from tokenspeed_kernel.ops.embedding import (
+    FusedMLASetKVBufferArg,
+    apply_rope,
+)
 
 from tokenspeed.runtime.cache.utils import (
     get_mla_kv_buffer_triton,
@@ -89,6 +93,29 @@ def _torch_get_reference(kv: torch.Tensor, loc) -> tuple[torch.Tensor, torch.Ten
         kv[loc, :NOPE_DIM].unsqueeze(1).contiguous(),
         kv[loc, NOPE_DIM:].unsqueeze(1).contiguous(),
     )
+
+
+def _rotate_rope_reference(
+    x: torch.Tensor,
+    cos_sin: torch.Tensor,
+    positions: torch.Tensor,
+    is_neox: bool,
+) -> torch.Tensor:
+    cos, sin = cos_sin[positions].chunk(2, dim=-1)
+    half = x.shape[-1] // 2
+    x_float = x.float()
+    cos = cos.float().unsqueeze(-2)
+    sin = sin.float().unsqueeze(-2)
+    if is_neox:
+        x1 = x_float[..., :half]
+        x2 = x_float[..., half:]
+        out = torch.cat((x1 * cos - x2 * sin, x2 * cos + x1 * sin), dim=-1)
+    else:
+        x1 = x_float[..., 0::2]
+        x2 = x_float[..., 1::2]
+        out = torch.stack((x1 * cos - x2 * sin, x2 * cos + x1 * sin), dim=-1)
+        out = out.flatten(-2)
+    return out.to(x.dtype)
 
 
 # ─── set ─────────────────────────────────────────────────────────────
@@ -202,3 +229,55 @@ def test_set_then_get_round_trip(n_loc, dtype):
 
     assert _bitwise_equal(k_nope_out, k_nope_in)
     assert _bitwise_equal(k_rope_out, k_rope_in)
+
+
+@pytest.mark.parametrize("is_neox", [False, True])
+@pytest.mark.parametrize("loc_dtype", [torch.int32, torch.int64])
+def test_mla_rope_set_kv_buffer_matches_reference(is_neox, loc_dtype):
+    torch.manual_seed(0)
+    n_loc = 17
+    num_heads = 3
+    max_position = 128
+    device = "cuda"
+    dtype = torch.bfloat16
+
+    q_rope = torch.randn(n_loc, num_heads, ROPE_DIM, device=device, dtype=dtype)
+    k_nope = torch.randn(n_loc, 1, NOPE_DIM, device=device, dtype=dtype)
+    k_rope = torch.randn(n_loc, 1, ROPE_DIM, device=device, dtype=dtype)
+    q_out_rope = torch.empty_like(q_rope)
+    kv = _empty_kv(dtype)
+    loc = torch.randperm(NUM_PAGES, device=device, dtype=loc_dtype)[:n_loc]
+    positions = torch.randint(
+        0, max_position, (n_loc,), device=device, dtype=torch.int64
+    )
+
+    angles = torch.randn(max_position, ROPE_DIM, device=device, dtype=torch.float32)
+    cos_sin = torch.cat(
+        (torch.cos(angles[:, : ROPE_DIM // 2]), torch.sin(angles[:, : ROPE_DIM // 2])),
+        dim=-1,
+    )
+
+    q_ref = _rotate_rope_reference(q_rope, cos_sin, positions, is_neox)
+    k_rope_ref = _rotate_rope_reference(k_rope, cos_sin, positions, is_neox)
+    kv_ref = kv.clone()
+    kv_ref[loc.long(), :NOPE_DIM] = k_nope[:, 0, :]
+    kv_ref[loc.long(), NOPE_DIM:] = k_rope_ref[:, 0, :]
+
+    apply_rope(
+        cos_sin_cache=cos_sin,
+        fused_mla_set_kv_buffer_arg=FusedMLASetKVBufferArg(
+            k_nope=k_nope,
+            kv_buffer=kv,
+            cache_loc=loc,
+        ),
+        head_size=ROPE_DIM,
+        positions=positions,
+        q=q_rope,
+        k=k_rope,
+        q_rope_out=q_out_rope,
+        is_neox=is_neox,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(q_out_rope, q_ref, atol=0.01, rtol=0.01)
+    torch.testing.assert_close(kv[loc.long()], kv_ref[loc.long()], atol=0.01, rtol=0.01)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/__init__.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 import torch
 from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
@@ -31,8 +30,15 @@ class FusedSetKVBufferArg:
     value: torch.Tensor
     k_buffer: torch.Tensor
     v_buffer: torch.Tensor
-    k_scale: Optional[float]
-    v_scale: Optional[float]
+    k_scale: float | None
+    v_scale: float | None
+    cache_loc: torch.Tensor
+
+
+@dataclass
+class FusedMLASetKVBufferArg:
+    k_nope: torch.Tensor
+    kv_buffer: torch.Tensor
     cache_loc: torch.Tensor
 
 
@@ -46,6 +52,7 @@ def apply_rope(
     # embedding options
     is_neox: bool = True,
     fused_set_kv_buffer_arg: FusedSetKVBufferArg | None = None,
+    fused_mla_set_kv_buffer_arg: FusedMLASetKVBufferArg | None = None,
     q_rope_out: torch.Tensor | None = None,
     k_rope_out: torch.Tensor | None = None,
     # dispatch options
@@ -67,6 +74,10 @@ def apply_rope(
         fused_set_kv_buffer_arg: Optional fused KV-cache write arguments. Both
             CUDA and Triton implementations currently require k_scale and
             v_scale to be None.
+        fused_mla_set_kv_buffer_arg: Optional fused MLA KV-cache write
+            arguments. When provided, rotated K is written to the MLA cache
+            instead of k/k_rope_out because MLA stores [k_nope | k_rope] in a
+            single cache row with different component widths.
         q_rope_out: Optional output buffer for the rotated query. If omitted,
             q is updated in place.
         k_rope_out: Optional output buffer for the rotated key. If omitted,
@@ -82,6 +93,10 @@ def apply_rope(
     rotary_dim = cos_sin_cache.shape[-1]
     assert rotary_dim % 2 == 0, "embedding.rope requires even rotary_dim"
     assert rotary_dim <= head_size, "embedding.rope requires rotary_dim <= head_size"
+    if fused_set_kv_buffer_arg is not None and fused_mla_set_kv_buffer_arg is not None:
+        raise ValueError("standard and MLA fused KV writes are mutually exclusive")
+    if fused_mla_set_kv_buffer_arg is not None and k_rope_out is not None:
+        raise ValueError("MLA fused KV write stores rotated K directly in the cache")
 
     positions = positions.flatten()
     num_tokens = positions.shape[0]
@@ -90,14 +105,15 @@ def apply_rope(
             q_rope_out if q_rope_out is not None else q,
             k_rope_out if k_rope_out is not None else k,
         )
-    num_q_heads = q.shape[-1] // head_size
-    num_kv_heads = k.shape[-1] // head_size
+    num_q_heads = q.numel() // (num_tokens * head_size)
+    num_kv_heads = k.numel() // (num_tokens * head_size)
 
     traits = {
         "head_size": head_size,
         "partial_rotary": rotary_dim != head_size,
         "is_neox": is_neox,
         "has_fused_kv": fused_set_kv_buffer_arg is not None,
+        "has_fused_mla_kv": fused_mla_set_kv_buffer_arg is not None,
         "has_q_out": q_rope_out is not None,
         "has_k_out": k_rope_out is not None,
     }
@@ -121,6 +137,7 @@ def apply_rope(
         "head_size": head_size,
         "rotary_dim": rotary_dim,
         "has_fused_kv": fused_set_kv_buffer_arg is not None,
+        "has_fused_mla_kv": fused_mla_set_kv_buffer_arg is not None,
         "has_q_out": q_rope_out is not None,
         "has_k_out": k_rope_out is not None,
     }
@@ -147,6 +164,7 @@ def apply_rope(
             cos_sin_cache=cos_sin_cache,
             is_neox=is_neox,
             fused_set_kv_buffer_arg=fused_set_kv_buffer_arg,
+            fused_mla_set_kv_buffer_arg=fused_mla_set_kv_buffer_arg,
             q_rope_out=q_rope_out,
             k_rope_out=k_rope_out,
             enable_pdl=enable_pdl,
@@ -345,7 +363,12 @@ def apply_rope_mla(
     return query_fp8, key_fp8
 
 
-__all__ = ["FusedSetKVBufferArg", "apply_rope", "apply_rope_mla"]
+__all__ = [
+    "FusedMLASetKVBufferArg",
+    "FusedSetKVBufferArg",
+    "apply_rope",
+    "apply_rope_mla",
+]
 
 
 # Backend registration (side-effect imports).

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/cuda.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/cuda.py
@@ -46,6 +46,7 @@ if platform.is_nvidia:
             "partial_rotary": frozenset({True, False}),
             "is_neox": frozenset({True, False}),
             "has_fused_kv": frozenset({True, False}),
+            "has_fused_mla_kv": frozenset({False}),
             "has_q_out": frozenset({True, False}),
             "has_k_out": frozenset({True, False}),
         },
@@ -60,10 +61,13 @@ if platform.is_nvidia:
         cos_sin_cache: torch.Tensor,
         is_neox: bool = True,
         fused_set_kv_buffer_arg: Any = None,
+        fused_mla_set_kv_buffer_arg: Any = None,
         q_rope_out: torch.Tensor | None = None,
         k_rope_out: torch.Tensor | None = None,
         enable_pdl: bool = False,
     ) -> None:
+        if fused_mla_set_kv_buffer_arg is not None:
+            raise ValueError("CUDA RoPE does not support MLA fused KV write")
         apply_rope_with_cos_sin_cache_inplace(
             positions=positions,
             query=q,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/triton.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import torch
 from tokenspeed_kernel._triton import tl, triton
@@ -199,6 +199,177 @@ def _rope_apply_kernel(
         )
 
 
+@triton.jit
+def _mla_rope_set_kv_buffer_kernel(
+    q_rope_ptr,
+    k_nope_ptr,
+    k_rope_ptr,
+    q_out_rope_ptr,
+    kv_buffer_ptr,
+    loc_ptr,
+    cos_sin_cache_ptr,
+    positions_ptr,
+    q_rope_stride_t: tl.constexpr,
+    q_rope_stride_h: tl.constexpr,
+    k_nope_stride_t: tl.constexpr,
+    k_rope_stride_t: tl.constexpr,
+    q_out_rope_stride_t: tl.constexpr,
+    q_out_rope_stride_h: tl.constexpr,
+    kv_buffer_stride_t: tl.constexpr,
+    cos_sin_stride_p: tl.constexpr,
+    num_q_heads: tl.constexpr,
+    nope_dim: tl.constexpr,
+    rope_dim: tl.constexpr,
+    NOPE_BLOCK: tl.constexpr,
+    HALF_BLOCK: tl.constexpr,
+    IS_NEOX: tl.constexpr,
+    POSITION_INT64: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    half = rope_dim // 2
+    half_offsets = tl.arange(0, HALF_BLOCK)
+    half_mask = half_offsets < half
+
+    if POSITION_INT64:
+        pos = tl.load(positions_ptr + token_idx).to(tl.int64)
+    else:
+        pos = tl.load(positions_ptr + token_idx).to(tl.int32)
+
+    cos = tl.load(
+        cos_sin_cache_ptr + pos * cos_sin_stride_p + half_offsets,
+        mask=half_mask,
+        other=0.0,
+    ).to(tl.float32)
+    sin = tl.load(
+        cos_sin_cache_ptr + pos * cos_sin_stride_p + half + half_offsets,
+        mask=half_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    if head_idx < num_q_heads:
+        q_base = q_rope_ptr + token_idx * q_rope_stride_t + head_idx * q_rope_stride_h
+        q_out_base = (
+            q_out_rope_ptr
+            + token_idx * q_out_rope_stride_t
+            + head_idx * q_out_rope_stride_h
+        )
+        if IS_NEOX:
+            q1_offsets = half_offsets
+            q2_offsets = half + half_offsets
+        else:
+            q1_offsets = half_offsets * 2
+            q2_offsets = half_offsets * 2 + 1
+
+        q1 = tl.load(q_base + q1_offsets, mask=half_mask, other=0.0)
+        q2 = tl.load(q_base + q2_offsets, mask=half_mask, other=0.0)
+        q1_f = q1.to(tl.float32)
+        q2_f = q2.to(tl.float32)
+        q_out_1 = q1_f * cos - q2_f * sin
+        q_out_2 = q2_f * cos + q1_f * sin
+        tl.store(q_out_base + q1_offsets, q_out_1, mask=half_mask)
+        tl.store(q_out_base + q2_offsets, q_out_2, mask=half_mask)
+    else:
+        loc = tl.load(loc_ptr + token_idx).to(tl.int64)
+        kv_base = kv_buffer_ptr + loc * kv_buffer_stride_t
+
+        nope_offsets = tl.arange(0, NOPE_BLOCK)
+        nope_mask = nope_offsets < nope_dim
+        k_nope = tl.load(
+            k_nope_ptr + token_idx * k_nope_stride_t + nope_offsets,
+            mask=nope_mask,
+            other=0.0,
+        )
+        tl.store(kv_base + nope_offsets, k_nope, mask=nope_mask)
+
+        k_base = k_rope_ptr + token_idx * k_rope_stride_t
+        if IS_NEOX:
+            k1_offsets = half_offsets
+            k2_offsets = half + half_offsets
+        else:
+            k1_offsets = half_offsets * 2
+            k2_offsets = half_offsets * 2 + 1
+
+        k1 = tl.load(k_base + k1_offsets, mask=half_mask, other=0.0)
+        k2 = tl.load(k_base + k2_offsets, mask=half_mask, other=0.0)
+        k1_f = k1.to(tl.float32)
+        k2_f = k2.to(tl.float32)
+        k_out_1 = k1_f * cos - k2_f * sin
+        k_out_2 = k2_f * cos + k1_f * sin
+        tl.store(kv_base + nope_dim + k1_offsets, k_out_1, mask=half_mask)
+        tl.store(kv_base + nope_dim + k2_offsets, k_out_2, mask=half_mask)
+
+
+def apply_rope_mla_set_kv_buffer_triton(
+    positions: torch.Tensor,
+    q_rope: torch.Tensor,
+    k_rope: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+    fused_mla_set_kv_buffer_arg,
+    q_rope_out: torch.Tensor | None,
+) -> None:
+    """Apply MLA RoPE while writing Q rope and dense MLA KV cache outputs."""
+    q_rope_out = q_rope if q_rope_out is None else q_rope_out
+    k_nope = fused_mla_set_kv_buffer_arg.k_nope
+    kv_buffer = fused_mla_set_kv_buffer_arg.kv_buffer
+    loc = fused_mla_set_kv_buffer_arg.cache_loc
+
+    num_tokens = q_rope.shape[0]
+    if num_tokens == 0:
+        return
+
+    assert q_rope.ndim == 3
+    assert k_nope.ndim == 3 and k_nope.shape[1] == 1
+    assert k_rope.ndim == 3 and k_rope.shape[1] == 1
+    assert q_rope_out.shape == q_rope.shape
+    assert kv_buffer.ndim == 2
+    assert loc.numel() == num_tokens
+    assert positions.numel() == num_tokens
+    assert q_rope.dtype == k_nope.dtype == k_rope.dtype == q_rope_out.dtype
+    assert kv_buffer.dtype == q_rope.dtype
+
+    num_q_heads = q_rope.shape[1]
+    rope_dim = q_rope.shape[2]
+    nope_dim = k_nope.shape[2]
+    assert k_rope.shape == (num_tokens, 1, rope_dim)
+    assert kv_buffer.shape[1] == nope_dim + rope_dim
+    assert rope_dim % 2 == 0
+    assert cos_sin_cache.shape[-1] == rope_dim
+    assert loc.dtype in (torch.int32, torch.int64)
+    assert positions.dtype in (torch.int32, torch.int64)
+
+    half_block = max(_next_power_of_2(rope_dim // 2), 16)
+    nope_block = max(_next_power_of_2(nope_dim), 16)
+    grid = (num_tokens, num_q_heads + 1)
+    _mla_rope_set_kv_buffer_kernel[grid](
+        q_rope,
+        k_nope,
+        k_rope,
+        q_rope_out,
+        kv_buffer,
+        loc,
+        cos_sin_cache,
+        positions,
+        q_rope.stride(0),
+        q_rope.stride(1),
+        k_nope.stride(0),
+        k_rope.stride(0),
+        q_rope_out.stride(0),
+        q_rope_out.stride(1),
+        kv_buffer.stride(0),
+        cos_sin_cache.stride(0),
+        num_q_heads,
+        nope_dim,
+        rope_dim,
+        NOPE_BLOCK=nope_block,
+        HALF_BLOCK=half_block,
+        IS_NEOX=bool(is_neox),
+        POSITION_INT64=positions.dtype == torch.int64,
+        num_warps=4,
+    )
+
+
 def apply_rope_triton(
     positions: torch.Tensor,
     query: torch.Tensor,
@@ -206,11 +377,12 @@ def apply_rope_triton(
     head_size: int,
     cos_sin_cache: torch.Tensor,
     is_neox: bool = True,
-    offsets: Optional[torch.Tensor] = None,
-    rotary_dim: Optional[int] = None,
+    offsets: torch.Tensor | None = None,
+    rotary_dim: int | None = None,
     fused_set_kv_buffer_arg=None,
-    output_q_rope: Optional[torch.Tensor] = None,
-    output_k_rope: Optional[torch.Tensor] = None,
+    fused_mla_set_kv_buffer_arg=None,
+    output_q_rope: torch.Tensor | None = None,
+    output_k_rope: torch.Tensor | None = None,
 ) -> None:
     """Apply rotary positional embedding to query and key in-place.
 
@@ -254,6 +426,22 @@ def apply_rope_triton(
 
     num_tokens = positions.shape[0]
     if num_tokens == 0:
+        return
+
+    if fused_mla_set_kv_buffer_arg is not None:
+        if offsets is not None:
+            raise ValueError("MLA fused KV write does not support offsets")
+        if output_k_rope is not None:
+            raise ValueError("MLA fused KV write stores rotated K directly in cache")
+        apply_rope_mla_set_kv_buffer_triton(
+            positions=positions,
+            q_rope=query,
+            k_rope=key,
+            cos_sin_cache=cos_sin_cache,
+            is_neox=is_neox,
+            fused_mla_set_kv_buffer_arg=fused_mla_set_kv_buffer_arg,
+            q_rope_out=output_q_rope,
+        )
         return
 
     q_view = query.view(num_tokens, -1, head_size)
@@ -486,6 +674,7 @@ def mla_rope_quantize_fp8_triton(
         "partial_rotary": frozenset({True, False}),
         "is_neox": frozenset({True, False}),
         "has_fused_kv": frozenset({True, False}),
+        "has_fused_mla_kv": frozenset({True, False}),
         "has_q_out": frozenset({True, False}),
         "has_k_out": frozenset({True, False}),
     },
@@ -500,6 +689,7 @@ def triton_embedding_rope(
     cos_sin_cache: torch.Tensor,
     is_neox: bool = True,
     fused_set_kv_buffer_arg: Any = None,
+    fused_mla_set_kv_buffer_arg: Any = None,
     q_rope_out: torch.Tensor | None = None,
     k_rope_out: torch.Tensor | None = None,
     enable_pdl: bool = False,
@@ -512,6 +702,7 @@ def triton_embedding_rope(
         cos_sin_cache=cos_sin_cache,
         is_neox=is_neox,
         fused_set_kv_buffer_arg=fused_set_kv_buffer_arg,
+        fused_mla_set_kv_buffer_arg=fused_mla_set_kv_buffer_arg,
         output_q_rope=q_rope_out,
         output_k_rope=k_rope_out,
     )


### PR DESCRIPTION
## Summary
Add an MLA-specific fused RoPE KV-cache descriptor and route it through the existing embedding.rope API. The normal fused KV path assumes MHA-style K and V buffers with the same per-head width, but DeepSeek MLA stores one combined cache row shaped as k_nope / latent width kv_lora_rank concatenated with rotated k_rope width qk_rope_head_dim. The new fused_mla_set_kv_buffer_arg makes that layout explicit, letting the RoPE kernel copy k_nope and write rotated k_rope directly into the combined row. The normal fused-KV path for DeepSeekV3 was unused and replaced here.

## Testing Plan
- test/runtime/cache/test_mla_kv_buffer.py covers MLA KV set/get against torch references across bf16/fp8, cache locations, and round trips.
- test_mla_rope_set_kv_buffer_matches_reference covers the fused RoPE+MLA KV write path used by DeepSeek decode.
