### PR TITLE
fix(kernel): avoid mixing CUDA toolkit headers

### DIFF
--- a/tokenspeed-kernel/python/setup.py
+++ b/tokenspeed-kernel/python/setup.py
@@ -508,25 +508,38 @@ class CudaKernelBuilder:
                 dirs.append(path_str)
                 seen.add(path_str)
 
+        def _is_complete_cuda_include(path: Path) -> bool:
+            return all(
+                (path / header).exists() for header in ("cuda_runtime.h", "cublas_v2.h")
+            )
+
         found_toolkit_headers = False
         for cuda_root in self._cuda_toolkit_roots():
             cuda_include = cuda_root / "include"
-            if (cuda_include / "cuda_runtime.h").exists():
-                _add_dir(cuda_include)
-                found_toolkit_headers = True
+            if not _is_complete_cuda_include(cuda_include):
+                continue
+            _add_dir(cuda_include)
             if (cuda_include / "cccl").exists():
                 _add_dir(cuda_include / "cccl")
+            found_toolkit_headers = True
+            break
 
         # Do not mix wheel CUDA headers with an available toolkit.
         if not found_toolkit_headers:
+            found_wheel_headers = False
             for base_path in self._site_paths():
                 for candidate in sorted(
                     base_path.glob("nvidia/cu*/include"), reverse=True
                 ):
-                    if (candidate / "cuda_runtime.h").exists():
-                        _add_dir(candidate)
+                    if not _is_complete_cuda_include(candidate):
+                        continue
+                    _add_dir(candidate)
                     if (candidate / "cccl").exists():
                         _add_dir(candidate / "cccl")
+                    found_wheel_headers = True
+                    break
+                if found_wheel_headers:
+                    break
 
         try:
             tvm_ffi = importlib.import_module("tvm_ffi")

--- a/tokenspeed-kernel/python/setup.py
+++ b/tokenspeed-kernel/python/setup.py
@@ -508,19 +508,25 @@ class CudaKernelBuilder:
                 dirs.append(path_str)
                 seen.add(path_str)
 
+        found_toolkit_headers = False
         for cuda_root in self._cuda_toolkit_roots():
             cuda_include = cuda_root / "include"
             if (cuda_include / "cuda_runtime.h").exists():
                 _add_dir(cuda_include)
+                found_toolkit_headers = True
             if (cuda_include / "cccl").exists():
                 _add_dir(cuda_include / "cccl")
 
-        for base_path in self._site_paths():
-            for candidate in sorted(base_path.glob("nvidia/cu*/include"), reverse=True):
-                if (candidate / "cuda_runtime.h").exists():
-                    _add_dir(candidate)
-                if (candidate / "cccl").exists():
-                    _add_dir(candidate / "cccl")
+        # Do not mix wheel CUDA headers with an available toolkit.
+        if not found_toolkit_headers:
+            for base_path in self._site_paths():
+                for candidate in sorted(
+                    base_path.glob("nvidia/cu*/include"), reverse=True
+                ):
+                    if (candidate / "cuda_runtime.h").exists():
+                        _add_dir(candidate)
+                    if (candidate / "cccl").exists():
+                        _add_dir(candidate / "cccl")
 
         try:
             tvm_ffi = importlib.import_module("tvm_ffi")

--- a/tokenspeed-kernel/test/test_setup.py
+++ b/tokenspeed-kernel/test/test_setup.py
@@ -8,7 +8,36 @@ import setuptools
 SETUP_PY = Path(__file__).parents[1] / "python" / "setup.py"
 
 
-def test_cuda_include_dirs_do_not_mix_toolkit_and_wheel_headers(
+def test_cuda_include_dirs_prefer_complete_toolkit_headers(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("TOKENSPEED_KERNEL_BACKEND", "cuda")
+    monkeypatch.setattr(setuptools, "setup", lambda **_kwargs: None)
+    setup_namespace = runpy.run_path(str(SETUP_PY))
+
+    cuda_root = tmp_path / "cuda"
+    cuda_include = cuda_root / "include"
+    cuda_include.mkdir(parents=True)
+    (cuda_include / "cuda_runtime.h").touch()
+    (cuda_include / "cublas_v2.h").touch()
+
+    site_packages = tmp_path / "site-packages"
+    wheel_include = site_packages / "nvidia" / "cu13" / "include"
+    wheel_include.mkdir(parents=True)
+    (wheel_include / "cuda_runtime.h").touch()
+    (wheel_include / "cublas_v2.h").touch()
+
+    builder = setup_namespace["CudaKernelBuilder"]([], verbose=False)
+    monkeypatch.setattr(builder, "_cuda_toolkit_roots", lambda: iter([cuda_root]))
+    monkeypatch.setattr(builder, "_site_paths", lambda: iter([site_packages]))
+
+    include_dirs = builder._resolve_include_dirs()
+
+    assert str(cuda_include) in include_dirs
+    assert str(wheel_include) not in include_dirs
+
+
+def test_cuda_include_dirs_fall_back_from_partial_toolkit(
     tmp_path, monkeypatch
 ) -> None:
     monkeypatch.setenv("TOKENSPEED_KERNEL_BACKEND", "cuda")
@@ -24,6 +53,7 @@ def test_cuda_include_dirs_do_not_mix_toolkit_and_wheel_headers(
     wheel_include = site_packages / "nvidia" / "cu13" / "include"
     wheel_include.mkdir(parents=True)
     (wheel_include / "cuda_runtime.h").touch()
+    (wheel_include / "cublas_v2.h").touch()
 
     builder = setup_namespace["CudaKernelBuilder"]([], verbose=False)
     monkeypatch.setattr(builder, "_cuda_toolkit_roots", lambda: iter([cuda_root]))
@@ -31,5 +61,5 @@ def test_cuda_include_dirs_do_not_mix_toolkit_and_wheel_headers(
 
     include_dirs = builder._resolve_include_dirs()
 
-    assert str(cuda_include) in include_dirs
-    assert str(wheel_include) not in include_dirs
+    assert str(cuda_include) not in include_dirs
+    assert str(wheel_include) in include_dirs

--- a/tokenspeed-kernel/test/test_setup.py
+++ b/tokenspeed-kernel/test/test_setup.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+import setuptools
+
+SETUP_PY = Path(__file__).parents[1] / "python" / "setup.py"
+
+
+def test_cuda_include_dirs_do_not_mix_toolkit_and_wheel_headers(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("TOKENSPEED_KERNEL_BACKEND", "cuda")
+    monkeypatch.setattr(setuptools, "setup", lambda **_kwargs: None)
+    setup_namespace = runpy.run_path(str(SETUP_PY))
+
+    cuda_root = tmp_path / "cuda"
+    cuda_include = cuda_root / "include"
+    cuda_include.mkdir(parents=True)
+    (cuda_include / "cuda_runtime.h").touch()
+
+    site_packages = tmp_path / "site-packages"
+    wheel_include = site_packages / "nvidia" / "cu13" / "include"
+    wheel_include.mkdir(parents=True)
+    (wheel_include / "cuda_runtime.h").touch()
+
+    builder = setup_namespace["CudaKernelBuilder"]([], verbose=False)
+    monkeypatch.setattr(builder, "_cuda_toolkit_roots", lambda: iter([cuda_root]))
+    monkeypatch.setattr(builder, "_site_paths", lambda: iter([site_packages]))
+
+    include_dirs = builder._resolve_include_dirs()
+
+    assert str(cuda_include) in include_dirs
+    assert str(wheel_include) not in include_dirs


### PR DESCRIPTION
## Summary

- prefer the CUDA toolkit header tree when `CUDA_HOME` provides `cuda_runtime.h`
- use PyPI `nvidia/cu*/include` headers only as a fallback
- add a focused regression test for toolkit/wheel header isolation

## Root cause

The kernel build added both `${CUDA_HOME}/include` and CUDA headers installed by NVIDIA Python wheels to the NVCC include path. When those trees came from different CUDA patches, NVCC could combine incompatible headers and generate host stubs with a mismatched `__cudaLaunch` signature.

## Impact

CUDA toolkit builds now use one CUDA header source. Environments without toolkit headers retain the existing wheel-header fallback.

## Validation

- `inferlab run --environment tokenspeed -- pytest tokenspeed/tokenspeed-kernel/test/test_setup.py -q` (`1 passed`)
- the regression test fails on upstream `main` and passes with this fix
- `prek run --all-files`
