### PR TITLE
Support Heterogeneous block_size

### DIFF
--- a/tokenspeed-scheduler/csrc/cache/README.md
+++ b/tokenspeed-scheduler/csrc/cache/README.md
@@ -124,9 +124,10 @@ ref 归 0 后仍可命中,直到被驱逐)。
 
 约束是"整除 base",不是任意粒度:这样所有组的块边界都落在同一张 base 细网格上,
 哈希只需一条细链、各组在细边界上取子集,省掉了重复 SHA。base(GCD)是折叠和
-索引的粒度;coordinator 还持一个 lcm(各组 block_size 的 LCM),预留给将来需要
-"取整到所有组共同块边界"的对齐点(chunk/reserved 记账),目前 flat 准入路径上
-还没有这样的点,故暂无消费者。
+索引的粒度;lcm(各组 block_size 的 LCM)是**匹配收敛的对齐粒度**:
+`SweepThenConverge` 每次收紧边界都向下取整到 lcm——可服务边界必须落在每个组的
+整块上,否则先匹配的 closed 粗组会在截短时留下"报了命中却没有覆盖"的幽灵区间。
+代价是命中粒度统一到 lcm。
 
 mamba 组的 block_size 若与 base 不同,它的粗块只在自己的对齐边界成块
 (`RegistersAlignedFinalPageOnly` + 折叠),命中粒度天然变粗——这与状态快照

--- a/tokenspeed-scheduler/csrc/cache/kv_cache_coordinator.cpp
+++ b/tokenspeed-scheduler/csrc/cache/kv_cache_coordinator.cpp
@@ -66,12 +66,18 @@ namespace {
 // bound UNDER an earlier one's boundary-dependent match. A re-matched group lands at or
 // under the current bound and only a further bound drop can lift it back above, so
 // re-matches are finite; the result is the greatest boundary every group supports.
+//
+// Bounds align DOWN to align_tokens (the groups' lcm): a servable boundary must land on a
+// whole block of EVERY group, else a closed group's floor-truncation drops straddled coverage.
 template <typename MatchGroup, typename ExtentTokens>
 std::int32_t SweepThenConverge(std::span<const std::size_t> order, const std::vector<CacheGroup>& groups,
-                               std::int32_t bound_tokens, const MatchGroup& match, const ExtentTokens& extent) {
+                               std::int32_t bound_tokens, std::int32_t align_tokens, const MatchGroup& match,
+                               const ExtentTokens& extent) {
+    const auto align_down = [align_tokens](std::int32_t tokens) { return tokens - tokens % align_tokens; };
+    bound_tokens = align_down(bound_tokens);
     for (std::size_t i : order) {
         match(i, bound_tokens);
-        bound_tokens = std::min(bound_tokens, extent(i));
+        bound_tokens = std::min(bound_tokens, align_down(extent(i)));
     }
     for (bool changed = true; changed;) {
         changed = false;
@@ -80,7 +86,7 @@ std::int32_t SweepThenConverge(std::span<const std::size_t> order, const std::ve
                 continue;
             }
             match(i, bound_tokens);
-            bound_tokens = std::min(bound_tokens, extent(i));
+            bound_tokens = std::min(bound_tokens, align_down(extent(i)));
             changed = true;
         }
     }
@@ -111,7 +117,7 @@ CoordinatorMatch KvCacheCoordinator::matchTierWithKeys(const BlockPool& pool,
         return out;
     }
     const std::int32_t boundary_tokens = SweepThenConverge(
-        match_order_, groups_, num_base_pages * base_block_size_,
+        match_order_, groups_, num_base_pages * base_block_size_, lcm_block_size_,
         [&](std::size_t i, std::int32_t bound_tokens) {
             const std::int32_t group_block_size = groups_[i].Spec().block_size;
             out.per_group[i] = groups_[i].Manager().Match(pool, group_keys[i], floor_tokens / group_block_size,
@@ -123,8 +129,8 @@ CoordinatorMatch KvCacheCoordinator::matchTierWithKeys(const BlockPool& pool,
                    group_block_size;
         });
 
-    // Linear cleanup: closed groups truncate to the converged boundary (any prefix stays
-    // valid); non-closed groups are at or under it by construction above.
+    // Linear cleanup: closed groups truncate to the converged boundary (any prefix stays valid;
+    // the lcm-aligned boundary cuts on whole blocks); non-closed groups are at or under it.
     for (std::size_t i = 0; i < groups_.size(); ++i) {
         const std::int32_t group_block_size = groups_[i].Spec().block_size;
         PrefixMatch& m = out.per_group[i];

--- a/tokenspeed-scheduler/csrc/cache/kv_cache_coordinator.h
+++ b/tokenspeed-scheduler/csrc/cache/kv_cache_coordinator.h
@@ -85,6 +85,8 @@ public:
 
     // end_tokens = the chunk's end position (-1 = unknown/legacy): aligned-final-page-only
     // groups register nothing without it, since only an aligned chunk end holds a real snapshot.
+    // first_slot may reach back to the fold grid (decode re-covers so coarse groups can fold);
+    // registered slots are skipped per slot, so the overlap is idempotent.
     void CacheFullBlocks(std::span<BlockTable> tables, std::span<const std::string> content_hashes,
                          std::int32_t first_slot = 0, std::int32_t end_tokens = -1);
     void ReclaimExpired(std::span<BlockTable> tables, std::int32_t num_computed_tokens);

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
@@ -113,18 +113,44 @@ namespace {
     throw std::logic_error("flat path: retract/writeback/loadback unsupported in C slice");
 }
 
-// Hash the newly filled pages [chain.num_hashed_pages, filled_pages) onto the chain.
-std::vector<std::string> AdvanceFlatHashChain(FlatHashChain& chain,
-                                              const std::vector<std::span<const std::int32_t>>& paged,
-                                              std::int32_t filled_pages) {
+// Base-page hashes one decode step hands to registration, anchored at begin_page.
+struct HashesToRegister {
+    std::int32_t begin_page{0};
+    std::vector<std::string> hashes;
+};
+
+// Seed from a full-prefix hash list; the tail keeps the suffix from the last fold-grid boundary.
+HashChain MakeHashChain(const std::vector<std::string>& hashes, std::int32_t fold_align_pages) {
+    const std::int32_t n = static_cast<std::int32_t>(hashes.size());
+    const std::int32_t tail_begin = n / fold_align_pages * fold_align_pages;
+    return HashChain{.num_hashed_pages = n,
+                         .last_hash = n > 0 ? hashes.back() : std::string{},
+                         .tail_begin_page = tail_begin,
+                         .tail = {hashes.begin() + tail_begin, hashes.end()}};
+}
+
+// Hash the newly filled pages onto the chain; the returned batch reaches back to the fold grid
+// (fold_align_pages = lcm/base) so coarse groups fold the blocks completed this step. The
+// re-covered overlap is idempotent (m == 1 degenerates to exactly the fresh pages).
+HashesToRegister AdvanceHashChain(HashChain& chain,
+                                          const std::vector<std::span<const std::int32_t>>& paged,
+                                          std::int32_t filled_pages, std::int32_t fold_align_pages) {
     _assert(filled_pages > chain.num_hashed_pages, "caller must pre-check hash-chain progress");
     _assert(filled_pages <= static_cast<std::int32_t>(paged.size()),
             "flat decode hashing: filled pages exceed the container's full pages");
     const std::vector<std::span<const std::int32_t>> fresh(paged.begin() + chain.num_hashed_pages,
                                                            paged.begin() + filled_pages);
     std::vector<std::string> new_hashes = ComputePagedHashes(fresh, chain.last_hash);
-    chain = FlatHashChain{filled_pages, new_hashes.back()};
-    return new_hashes;
+
+    HashesToRegister batch{.begin_page = chain.tail_begin_page, .hashes = std::move(chain.tail)};
+    batch.hashes.insert(batch.hashes.end(), new_hashes.begin(), new_hashes.end());
+
+    const std::int32_t tail_begin = filled_pages / fold_align_pages * fold_align_pages;
+    chain.num_hashed_pages = filled_pages;
+    chain.last_hash = batch.hashes.back();
+    chain.tail_begin_page = tail_begin;
+    chain.tail.assign(batch.hashes.begin() + (tail_begin - batch.begin_page), batch.hashes.end());
+    return batch;
 }
 
 }  // namespace
@@ -384,8 +410,8 @@ Decoding ScheduleDecodeEvent::operator()(PrefillDone&& state) {
     Decoding decoding{state.GetTokenContainer(),           state.GetPageSize(),  nullptr, nullptr, nullptr,
                       std::move(state).TakeReqPoolIndex(), decode_input_tokens_, nullptr};
     decoding.SetBlockTables(std::move(tables));
-    decoding.SetFlatHashChain(
-        FlatHashChain{static_cast<std::int32_t>(hashes.size()), hashes.empty() ? std::string{} : hashes.back()});
+    decoding.SetHashChain(
+        MakeHashChain(hashes, coordinator_->LcmBlockSize() / coordinator_->BaseBlockSize()));
     return decoding;
 #else
     auto local_kv_allocator = std::move(state).TakeLocalKVAllocator();
@@ -426,24 +452,25 @@ Decoding ScheduleDecodeEvent::operator()(Decoding&& state) {
     // query still reads. scheduleDecode's gate credited the slide with this same value.
     const std::int32_t num_computed_tokens = state.GetTokenContainer()->Size() - decode_input_tokens_;
 
-    FlatHashChain chain = state.GetFlatHashChain();
-    const std::int32_t first_page_slot = chain.num_hashed_pages;
+    HashChain chain = std::move(state).TakeHashChain();
     const std::int32_t filled_pages = num_computed_tokens / state.GetPageSize();
     // A page fills only once every page_size steps; skip the span walk on the other steps.
-    const std::vector<std::string> new_hashes =
-        filled_pages > chain.num_hashed_pages
-            ? AdvanceFlatHashChain(chain, state.GetFullPagedTokens(false), filled_pages)
-            : std::vector<std::string>{};
+    HashesToRegister to_register{.begin_page = chain.num_hashed_pages};
+    if (filled_pages > chain.num_hashed_pages) {
+        to_register = AdvanceHashChain(chain, state.GetFullPagedTokens(false), filled_pages,
+                                           coordinator_->LcmBlockSize() / coordinator_->BaseBlockSize());
+    }
 
     auto tables = std::move(state).TakeBlockTables();
-    if (!DecodeStep(*coordinator_, tables, new_hashes, first_page_slot, reserve, num_computed_tokens)) {
+    if (!DecodeStep(*coordinator_, tables, to_register.hashes, to_register.begin_page, reserve,
+                    num_computed_tokens)) {
         _assert(false, "flat path: allocation failure unsupported in C slice");
     }
 
     Decoding decoding{state.GetTokenContainer(),           state.GetPageSize(),  nullptr, nullptr, nullptr,
                       std::move(state).TakeReqPoolIndex(), decode_input_tokens_, nullptr};
     decoding.SetBlockTables(std::move(tables));
-    decoding.SetFlatHashChain(std::move(chain));
+    decoding.SetHashChain(std::move(chain));
     return decoding;
 #else
     auto local_kv_allocator = std::move(state).TakeLocalKVAllocator();

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
@@ -124,17 +124,16 @@ HashChain MakeHashChain(const std::vector<std::string>& hashes, std::int32_t fol
     const std::int32_t n = static_cast<std::int32_t>(hashes.size());
     const std::int32_t tail_begin = n / fold_align_pages * fold_align_pages;
     return HashChain{.num_hashed_pages = n,
-                         .last_hash = n > 0 ? hashes.back() : std::string{},
-                         .tail_begin_page = tail_begin,
-                         .tail = {hashes.begin() + tail_begin, hashes.end()}};
+                     .last_hash = n > 0 ? hashes.back() : std::string{},
+                     .tail_begin_page = tail_begin,
+                     .tail = {hashes.begin() + tail_begin, hashes.end()}};
 }
 
 // Hash the newly filled pages onto the chain; the returned batch reaches back to the fold grid
 // (fold_align_pages = lcm/base) so coarse groups fold the blocks completed this step. The
 // re-covered overlap is idempotent (m == 1 degenerates to exactly the fresh pages).
-HashesToRegister AdvanceHashChain(HashChain& chain,
-                                          const std::vector<std::span<const std::int32_t>>& paged,
-                                          std::int32_t filled_pages, std::int32_t fold_align_pages) {
+HashesToRegister AdvanceHashChain(HashChain& chain, const std::vector<std::span<const std::int32_t>>& paged,
+                                  std::int32_t filled_pages, std::int32_t fold_align_pages) {
     _assert(filled_pages > chain.num_hashed_pages, "caller must pre-check hash-chain progress");
     _assert(filled_pages <= static_cast<std::int32_t>(paged.size()),
             "flat decode hashing: filled pages exceed the container's full pages");
@@ -410,8 +409,7 @@ Decoding ScheduleDecodeEvent::operator()(PrefillDone&& state) {
     Decoding decoding{state.GetTokenContainer(),           state.GetPageSize(),  nullptr, nullptr, nullptr,
                       std::move(state).TakeReqPoolIndex(), decode_input_tokens_, nullptr};
     decoding.SetBlockTables(std::move(tables));
-    decoding.SetHashChain(
-        MakeHashChain(hashes, coordinator_->LcmBlockSize() / coordinator_->BaseBlockSize()));
+    decoding.SetHashChain(MakeHashChain(hashes, coordinator_->LcmBlockSize() / coordinator_->BaseBlockSize()));
     return decoding;
 #else
     auto local_kv_allocator = std::move(state).TakeLocalKVAllocator();
@@ -458,12 +456,11 @@ Decoding ScheduleDecodeEvent::operator()(Decoding&& state) {
     HashesToRegister to_register{.begin_page = chain.num_hashed_pages};
     if (filled_pages > chain.num_hashed_pages) {
         to_register = AdvanceHashChain(chain, state.GetFullPagedTokens(false), filled_pages,
-                                           coordinator_->LcmBlockSize() / coordinator_->BaseBlockSize());
+                                       coordinator_->LcmBlockSize() / coordinator_->BaseBlockSize());
     }
 
     auto tables = std::move(state).TakeBlockTables();
-    if (!DecodeStep(*coordinator_, tables, to_register.hashes, to_register.begin_page, reserve,
-                    num_computed_tokens)) {
+    if (!DecodeStep(*coordinator_, tables, to_register.hashes, to_register.begin_page, reserve, num_computed_tokens)) {
         _assert(false, "flat path: allocation failure unsupported in C slice");
     }
 

--- a/tokenspeed-scheduler/csrc/fsm/forward_states.h
+++ b/tokenspeed-scheduler/csrc/fsm/forward_states.h
@@ -119,7 +119,8 @@ public:
 
     std::int32_t TailPageAvailableTokens() const {
         if (!block_tables_.empty()) {
-            // flat: every group Acquires the same token count each step, so tail_avail is identical across groups.
+            // flat: group-0 sample, feeding only the radix-era capacity probe (a flat no-op);
+            // real admission gates on the coordinator's per-group BlocksNeededFor.
             return block_tables_[0].TailAvailableTokens();
         }
         return local_kv_allocator_->TailPageAvailableTokens();  // radix
@@ -173,9 +174,8 @@ struct ForwardState : public BaseState {
     std::unique_ptr<ReqPoolIndex> TakeReqPoolIndex() && { return std::move(req_pool_index_); }
     std::int32_t GetReqPoolIndex() const { return req_pool_index_ ? req_pool_index_->slot_ : -1; }
 
-    // Flat: a single-group SAMPLE of group 0 (page ids differ per group, counts do not). KV writes use
-    // per-group metadata.out_cache_locs from each group's own table, so this sample feeds page counts,
-    // one-group stats and the radix-era req_to_page fallback only.
+    // Flat: group-0 SAMPLE (ids -- and with per-group block sizes, counts -- differ per group);
+    // feeds one-group stats and the radix-era req_to_page fallback, never cross-group accounting.
     std::vector<std::int32_t> GetOccupiedPages() const {
         if (!block_tables_.empty()) {
             return BlockTablePageIds(block_tables_[0]);  // flat: first-group sample (see above)
@@ -271,10 +271,14 @@ private:
 };
 
 #if TOKENSPEED_FLAT_KVCACHE
-// Rolling page-hash chain: pages [0, num_hashed_pages) are registered, last_hash seeds the next increment.
-struct FlatHashChain {
+// Rolling page-hash chain: pages [0, num_hashed_pages) are registered, last_hash seeds the
+// next increment. tail holds pages [tail_begin_page, num_hashed_pages) back to the fold grid
+// (lcm/base) so coarse groups can fold a block completed mid-decode.
+struct HashChain {
     std::int32_t num_hashed_pages{0};
     std::string last_hash;
+    std::int32_t tail_begin_page{0};
+    std::vector<std::string> tail;
 };
 #endif
 
@@ -304,15 +308,15 @@ struct Decoding : public ForwardState {
     std::unique_ptr<HostNodeRef> TakeHostNodeRef() && { return std::move(host_node_ref_); }
 
 #if TOKENSPEED_FLAT_KVCACHE
-    const FlatHashChain& GetFlatHashChain() const { return flat_hash_chain_; }
-    void SetFlatHashChain(FlatHashChain chain) { flat_hash_chain_ = std::move(chain); }
+    HashChain TakeHashChain() && { return std::move(hash_chain_); }
+    void SetHashChain(HashChain chain) { hash_chain_ = std::move(chain); }
 #endif
 
 private:
     std::unique_ptr<HostNodeRef> host_node_ref_{};  // pins host pages until the next state takes ownership
     std::int32_t reserve_num_tokens_in_next_schedule_event_{-1};
 #if TOKENSPEED_FLAT_KVCACHE
-    FlatHashChain flat_hash_chain_{};
+    HashChain hash_chain_{};
 #endif
 };
 

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -250,8 +250,8 @@ std::size_t Scheduler::RetractedSize() const {
 std::size_t Scheduler::AvailableKvPages() const {
 #if TOKENSPEED_FLAT_KVCACHE
     // The flat path never draws from the radix device_allocator_, so reporting it would show a
-    // permanently-full pool to Python monitoring. Report the flat BlockPool instead: one flat block
-    // is one page of block_size tokens, the same unit device_allocator_ uses. Block 0 is the
+    // permanently-full pool to Python monitoring. Report the flat BlockPool instead: one flat
+    // block is one pool row, interpreted at each group's own block_size. Block 0 is the
     // never-allocated null placeholder, so an idle pool reports total_pages - 1.
     return static_cast<std::size_t>(block_pool_.NumFreeBlocks());
 #else

--- a/tokenspeed-scheduler/tests/cpp/test_flat_kvcache_scenarios.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_flat_kvcache_scenarios.cpp
@@ -2616,6 +2616,371 @@ TEST_F(FlatDecodeCachingSuite, PoolBalanceAcrossDecodeCaching) {
 }
 
 // ---------------------------------------------------------------------------
+// Hetero decode caching: the coarse full group (block_size 4 = 2x base) folds
+// a block completed DURING decode, so a later turn hits past the prefill line.
+// ---------------------------------------------------------------------------
+class FlatHeteroDecodeCachingSuite : public FlatDecodeCachingSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        SchedulerConfig cfg = FlatDecodeCachingSuite::MakeConfig();  // base block_size 2, groups full+swa
+        cfg.paged_cache_groups[0].block_size = 4;                    // full group coarse: m = 2, lcm = 4
+        cfg.paged_cache_groups[0].rows_per_page = 4;
+        return cfg;
+    }
+};
+
+TEST_F(FlatHeteroDecodeCachingSuite, CoarseGroupDecodeBlockFoldsAndBecomesHittable) {
+    const std::int32_t free_at_start = scheduler_->FlatPoolFreeBlocks();
+
+    // Turn 1: finalize registers coarse block 0; the +105 round (filled base pages 4)
+    // completes coarse block 1, folded from the chain tail [h2, h3].
+    const auto r1_rows = RunTurnOne();
+    ASSERT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start) << "r1 must fully reclaim before r2 runs";
+    ASSERT_EQ(r1_rows.at("full").size(), 3u);  // ceil(9 tokens / 4) coarse blocks at the +105 round
+    ASSERT_EQ(r1_rows.at("swa").size(), 5u);
+
+    // Turn 2: first 8 of 10 tokens shared; both coarse blocks hit (block 1 registered
+    // mid-decode), swa keeps 4 base blocks -> lcm-aligned boundary 8.
+    Submit(MakeSpecWithTokens("r2", MakeTurnTwoPrompt()));
+    ExecutionPlan plan = PlanOnce();
+    const FlatForwardOperation* op = FindFlatOp(plan);
+    ASSERT_NE(op, nullptr);
+    ASSERT_EQ(op->request_ids.size(), 1u);
+
+    EXPECT_EQ(op->extend_prefix_lens.at(0), 8) << "coarse decode block must be hittable";
+    EXPECT_EQ(op->input_lengths.at(0), 2);
+    EXPECT_EQ(op->prefill_lengths.at(0), 10);
+    EXPECT_EQ(op->input_ids, MakeTokens(/*count=*/2, /*start=*/901));
+
+    const std::vector<std::int32_t> full_prefix(r1_rows.at("full").begin(), r1_rows.at("full").begin() + 2);
+    const std::vector<std::int32_t> swa_prefix(r1_rows.at("swa").begin(), r1_rows.at("swa").begin() + 4);
+    ExpectRowPrefixEq(op->flat_block_tables.at("full").at(0), full_prefix, "full row");
+    ExpectRowPrefixEq(op->flat_block_tables.at("swa").at(0), swa_prefix, "swa row");
+
+    // Pool: full claims 2 coarse + swa claims 4 base, then 1 fresh page per group = 8.
+    EXPECT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start - 8);
+
+    SendForwardDone("r2", {199});
+    PlanOnce();
+    SendForwardDone("r2", {200});
+    SendFinish("r2");
+    PlanOnce();
+    EXPECT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start) << "pool back to baseline after r2 finishes";
+}
+
+// ---------------------------------------------------------------------------
+// Hetero mamba-style state group (block_size 4 = 2x base): an aligned decode
+// end folds and registers ONLY the final coarse block -- pins the
+// coordinator's aligned_range assertion.
+// ---------------------------------------------------------------------------
+class FlatHeteroMambaDecodeSuite : public FlatDecodeCachingSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        SchedulerConfig cfg = FlatDecodeCachingSuite::MakeConfig();  // base block_size 2
+        // Swap the swa group for a coarse mamba-style state group: family State
+        // WITHOUT SlidingWindow retention -> kMambaState (see MakeSpecsFromConfig).
+        cfg.paged_cache_groups[1] = MakeGroup("state", /*block_size=*/4, cfg.device_allocator.total_pages,
+                                              PagedCacheGroupConfig::Retention::FullHistory,
+                                              PagedCacheGroupFamily::State);
+        cfg.paged_cache_groups[1].block_size = 4;
+        return cfg;
+    }
+};
+
+TEST_F(FlatHeteroMambaDecodeSuite, CoarseStateGroupRegistersAlignedSnapshotMidDecode) {
+    const std::int32_t free_at_start = scheduler_->FlatPoolFreeBlocks();
+
+    // Turn 1: finalize (end=4) registers state block 0; the +105 round (computed 8,
+    // aligned) folds state block 1 from the tail and registers ONLY it.
+    const auto r1_rows = RunTurnOne();
+    ASSERT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start) << "r1 must fully reclaim before r2 runs";
+    ASSERT_EQ(r1_rows.at("full").size(), 5u);   // m=1: ceil(9 / 2)
+    ASSERT_EQ(r1_rows.at("state").size(), 3u);  // m=2: ceil(9 / 4)
+
+    // Turn 2: first 8 of 10 tokens shared; the state group resumes off its decode-
+    // registered snapshot (slot 0 stays a hole), full hits 4 base blocks -> boundary 8.
+    Submit(MakeSpecWithTokens("r2", MakeTurnTwoPrompt()));
+    ExecutionPlan plan = PlanOnce();
+    const FlatForwardOperation* op = FindFlatOp(plan);
+    ASSERT_NE(op, nullptr);
+    ASSERT_EQ(op->request_ids.size(), 1u);
+
+    EXPECT_EQ(op->extend_prefix_lens.at(0), 8) << "state snapshot registered mid-decode must back the hit";
+    EXPECT_EQ(op->input_lengths.at(0), 2);
+    EXPECT_EQ(op->input_ids, MakeTokens(/*count=*/2, /*start=*/901));
+
+    const std::vector<std::int32_t> full_prefix(r1_rows.at("full").begin(), r1_rows.at("full").begin() + 4);
+    ExpectRowPrefixEq(op->flat_block_tables.at("full").at(0), full_prefix, "full row");
+    const auto& state_row = op->flat_block_tables.at("state").at(0);
+    ASSERT_GE(state_row.size(), 2u);
+    EXPECT_EQ(state_row[0], 0) << "only the aligned snapshot resumes; earlier state slots are holes";
+    EXPECT_EQ(state_row[1], r1_rows.at("state")[1]) << "the decode-registered snapshot block is claimed back";
+
+    // Pool: full claims 4 + state claims 1 (slot 0 is a hole), then 1 fresh page per group = 7.
+    EXPECT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start - 7);
+
+    SendForwardDone("r2", {199});
+    PlanOnce();
+    SendForwardDone("r2", {200});
+    SendFinish("r2");
+    PlanOnce();
+    EXPECT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start) << "pool back to baseline after r2 finishes";
+}
+
+// ---------------------------------------------------------------------------
+// Three granularities at once -- the "1 full + 5 swa + per-layer conv" model
+// shape scaled down: full block 8 (m=4), swa block 4 (m=2, W=8), conv as a
+// true swa group with block 2 (m=1) and W=2 <= block. base = 2, lcm = 8.
+// ---------------------------------------------------------------------------
+class FlatThreeGranularitySuite : public FlatDecodeCachingSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        SchedulerConfig cfg{};
+        cfg.block_size = 2;
+        cfg.device_allocator.total_pages = 64;
+        cfg.host_allocator.total_pages = 64;
+        cfg.max_scheduled_tokens = 64;
+        cfg.max_batch_size = 8;
+        cfg.enable_l3_storage = false;
+        cfg.disable_l2_cache = true;
+        cfg.disable_prefix_cache = false;
+
+        cfg.paged_cache_groups = {
+            MakeGroup("full", 8, cfg.device_allocator.total_pages, PagedCacheGroupConfig::Retention::FullHistory,
+                      PagedCacheGroupFamily::History),
+            MakeGroup("swa", 4, cfg.device_allocator.total_pages, PagedCacheGroupConfig::Retention::SlidingWindow,
+                      PagedCacheGroupFamily::State, /*sliding_window_tokens=*/8),
+            MakeGroup("conv", 2, cfg.device_allocator.total_pages, PagedCacheGroupConfig::Retention::SlidingWindow,
+                      PagedCacheGroupFamily::State, /*sliding_window_tokens=*/2),
+        };
+        cfg.paged_cache_groups[0].block_size = 8;
+        cfg.paged_cache_groups[1].block_size = 4;
+        cfg.paged_cache_groups[2].block_size = 2;
+        return cfg;
+    }
+};
+
+TEST_F(FlatThreeGranularitySuite, PrefixHitConvergesAcrossThreeBlockSizes) {
+    const std::int32_t free_at_start = scheduler_->FlatPoolFreeBlocks();
+
+    // r1: 16 tokens = 2 full blocks / 4 swa blocks / 8 conv blocks.
+    const token_vec_t prompt = MakeAlignedTokens(/*num_pages=*/8, PageSize());
+    Submit(MakeSpecWithTokens("r1", prompt));
+    ExecutionPlan prefill = PlanOnce();
+    const FlatForwardOperation* r1_op = FindFlatOp(prefill);
+    ASSERT_NE(r1_op, nullptr);
+    const auto full_row = r1_op->flat_block_tables.at("full").at(0);
+    const auto swa_row = r1_op->flat_block_tables.at("swa").at(0);
+    const auto conv_row = r1_op->flat_block_tables.at("conv").at(0);
+    ASSERT_EQ(full_row.size(), 2u);
+    ASSERT_EQ(swa_row.size(), 4u);
+    ASSERT_EQ(conv_row.size(), 8u);
+    SendForwardDone("r1", {9001});
+    PlanOnce();  // finalize registers all three granularities, then windows punch
+    SendForwardDone("r1", {9002});
+    SendFinish("r1");
+    PlanOnce();  // reap
+    ASSERT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start);
+
+    // r2: same 16 tokens + 4 fresh. All three groups converge on the lcm cut 16.
+    token_vec_t r2_tokens = prompt;
+    const token_vec_t fresh = MakeTokens(/*count=*/4, /*start=*/901);
+    r2_tokens.insert(r2_tokens.end(), fresh.begin(), fresh.end());
+    Submit(MakeSpecWithTokens("r2", r2_tokens));
+    ExecutionPlan plan = PlanOnce();
+    const FlatForwardOperation* op = FindFlatOp(plan);
+    ASSERT_NE(op, nullptr);
+    ASSERT_EQ(op->request_ids.size(), 1u);
+
+    EXPECT_EQ(op->extend_prefix_lens.at(0), 16);
+    EXPECT_EQ(op->input_lengths.at(0), 4);
+    EXPECT_EQ(op->prefill_lengths.at(0), 20);
+    EXPECT_EQ(op->input_ids, fresh);
+
+    // full reuses both coarse blocks; swa (W=8) claims 2 holes + the trailing run;
+    // conv (W=2 <= block) resumes off the final block alone: 7 holes + 1 real.
+    const std::vector<std::int32_t> full_prefix(full_row.begin(), full_row.begin() + 2);
+    ExpectRowPrefixEq(op->flat_block_tables.at("full").at(0), full_prefix, "full row");
+    const auto& swa2 = op->flat_block_tables.at("swa").at(0);
+    ASSERT_GE(swa2.size(), 4u);
+    EXPECT_EQ(swa2[0], 0);
+    EXPECT_EQ(swa2[1], 0);
+    EXPECT_EQ(swa2[2], swa_row[2]);
+    EXPECT_EQ(swa2[3], swa_row[3]);
+    const auto& conv2 = op->flat_block_tables.at("conv").at(0);
+    ASSERT_GE(conv2.size(), 8u);
+    for (int i = 0; i < 7; ++i) {
+        EXPECT_EQ(conv2[static_cast<std::size_t>(i)], 0) << "conv slot " << i;
+    }
+    EXPECT_EQ(conv2[7], conv_row[7]) << "punched-with-hash conv block claimed back";
+
+    // 5 real claims (2 full + 2 swa + 1 conv) + fresh pages 1/1/2 per group = 9.
+    EXPECT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start - 9);
+
+    SendForwardDone("r2", {199});
+    PlanOnce();
+    SendForwardDone("r2", {200});
+    SendFinish("r2");
+    PlanOnce();
+    EXPECT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start);
+}
+
+// The usable boundary snaps DOWN to the lcm cut: 10 shared tokens serve only 8,
+// because the closed 8-token full group cannot hand over a half block.
+TEST_F(FlatThreeGranularitySuite, PartialPrefixSnapsDownToLcmCut) {
+    const std::int32_t free_at_start = scheduler_->FlatPoolFreeBlocks();
+
+    const token_vec_t prompt = MakeAlignedTokens(/*num_pages=*/8, PageSize());  // {1..16}
+    Submit(MakeSpecWithTokens("r1", prompt));
+    ExecutionPlan prefill = PlanOnce();
+    ASSERT_NE(FindFlatOp(prefill), nullptr);
+    SendForwardDone("r1", {9001});
+    PlanOnce();  // finalize registers, windows punch
+    SendForwardDone("r1", {9002});
+    SendFinish("r1");
+    PlanOnce();  // reap
+    ASSERT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start);
+
+    // r2 shares tokens [0,10) then diverges: 10 is not a whole full block.
+    token_vec_t r2_tokens(prompt.begin(), prompt.begin() + 10);
+    const token_vec_t fresh = MakeTokens(/*count=*/6, /*start=*/901);
+    r2_tokens.insert(r2_tokens.end(), fresh.begin(), fresh.end());
+    Submit(MakeSpecWithTokens("r2", r2_tokens));
+    ExecutionPlan plan = PlanOnce();
+    const FlatForwardOperation* op = FindFlatOp(plan);
+    ASSERT_NE(op, nullptr);
+    ASSERT_EQ(op->request_ids.size(), 1u);
+
+    EXPECT_EQ(op->extend_prefix_lens.at(0), 8) << "10 shared tokens snap down to the lcm cut";
+    EXPECT_EQ(op->input_lengths.at(0), 8);
+    const token_vec_t expected_input(r2_tokens.begin() + 8, r2_tokens.end());
+    EXPECT_EQ(op->input_ids, expected_input);
+
+    // Claims at the 8-token cut: full 1, swa 2 (punched blocks revived by hash),
+    // conv 1 (trailing block only); fresh for 8 new tokens: 1 + 2 + 4.
+    EXPECT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start - 11);
+
+    SendForwardDone("r2", {199});
+    PlanOnce();
+    SendForwardDone("r2", {200});
+    SendFinish("r2");
+    PlanOnce();
+    EXPECT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start);
+}
+
+TEST_F(FlatThreeGranularitySuite, AbortDuringDecodeRestoresPoolBaseline) {
+    const std::int32_t free_at_start = scheduler_->FlatPoolFreeBlocks();
+
+    Submit(MakeSpecWithTokens("r1", MakeAlignedTokens(/*num_pages=*/4, PageSize())));
+    PlanOnce();  // single-chunk prefill
+    SendForwardDone("r1", {42});
+    PlanOnce();  // finalize + decode reserve across all three granularities
+    SendForwardDone("r1", {43});
+    EXPECT_LT(scheduler_->FlatPoolFreeBlocks(), free_at_start);
+
+    SendAbort(*scheduler_, "r1");
+    PlanOnce();
+    EXPECT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start)
+        << "abort must return every page of all three granularities";
+}
+
+// Tight pool: the admission gate charges each granularity at its own block
+// size; the pool fits exactly one 16-token request.
+class FlatThreeGranularityTinyPoolSuite : public FlatThreeGranularitySuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        SchedulerConfig cfg = FlatThreeGranularitySuite::MakeConfig();
+        // 16 tokens = 2 full + 4 swa + 8 conv = 14 blocks, + 1 reserve block per
+        // group = 17; 18 physical pages -> 17 usable (page 0 is the null block).
+        cfg.device_allocator.total_pages = 18;
+        cfg.host_allocator.total_pages = 18;
+        return cfg;
+    }
+};
+
+TEST_F(FlatThreeGranularityTinyPoolSuite, GateDefersSecondRequestPerGroupBlockMath) {
+    const std::int32_t free_at_start = scheduler_->FlatPoolFreeBlocks();
+    ASSERT_EQ(free_at_start, 17);
+
+    // r1 gate: 14 prefill + 3 reserve = 17 (exact fit); prefill consumes 14.
+    Submit(MakeSpecWithTokens("r1", MakeAlignedTokens(/*num_pages=*/8, PageSize())));
+    ExecutionPlan plan1 = PlanOnce();
+    ASSERT_NE(FindFlatOp(plan1), nullptr);
+    EXPECT_EQ(scheduler_->FlatPoolFreeBlocks(), 3);
+
+    // r2 (8 tokens) needs 1+2+4 prefill + 3 reserve = 10: deferred. r1's
+    // finalize punches 7 conv + 2 swa blocks and acquires the 3-block reserve,
+    // leaving 9 free -- still short of 10.
+    Submit(MakeSpecWithTokens("r2", MakeTokens(/*count=*/8, /*start=*/101)));
+    SendForwardDone("r1", {99});
+    ExecutionPlan starved = PlanOnce();
+    const FlatForwardOperation* starved_op = FindFlatOp(starved);
+    ASSERT_NE(starved_op, nullptr);
+    ASSERT_EQ(starved_op->request_ids.size(), 1u) << "only r1's reserved decode step fits this round";
+    EXPECT_EQ(starved_op->request_ids.at(0), "r1");
+    EXPECT_EQ(scheduler_->WaitingSize(), 1u);
+    EXPECT_EQ(scheduler_->FlatPoolFreeBlocks(), 9);
+
+    SendForwardDone("r1", {100});
+    SendFinish("r1");
+    ExecutionPlan plan2 = PlanOnce();
+    const FlatForwardOperation* op2 = FindFlatOp(plan2);
+    ASSERT_NE(op2, nullptr) << "deferred request must be schedulable after pages free up";
+    ASSERT_EQ(op2->request_ids.size(), 1u);
+    EXPECT_EQ(op2->request_ids.at(0), "r2");
+    EXPECT_EQ(scheduler_->WaitingSize(), 0u);
+
+    SendForwardDone("r2", {142});
+    SendFinish("r2");
+    PlanOnce();
+    EXPECT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start);
+}
+
+TEST_F(FlatThreeGranularitySuite, DecodeFoldedCoarseBlockHittableAlongsideWindowGroups) {
+    const std::int32_t free_at_start = scheduler_->FlatPoolFreeBlocks();
+
+    // r1: 8-token prompt; decode 101..109 pushes computed to 16, completing full
+    // coarse block 1 (tokens [8,16)) mid-decode -- folded from the chain tail
+    // while both window groups register at their own granularities.
+    const token_vec_t prompt = MakeAlignedTokens(/*num_pages=*/4, PageSize());
+    Submit(MakeSpecWithTokens("r1", prompt));
+    ExecutionPlan prefill = PlanOnce();
+    ASSERT_NE(FindFlatOp(prefill), nullptr);
+    for (token_t t = 101; t <= 109; ++t) {
+        AdvanceOneRound("r1", t);
+    }
+    SendFinish("r1");
+    PlanOnce();  // reap
+    ASSERT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start);
+
+    // r2: prompt + r1's first 8 generated + 2 fresh = 18 tokens; the hit crosses
+    // r1's prompt line (8) and lands on the lcm cut 16.
+    token_vec_t r2_tokens = prompt;
+    const token_vec_t generated = MakeTokens(/*count=*/8, /*start=*/101);
+    r2_tokens.insert(r2_tokens.end(), generated.begin(), generated.end());
+    const token_vec_t fresh = MakeTokens(/*count=*/2, /*start=*/901);
+    r2_tokens.insert(r2_tokens.end(), fresh.begin(), fresh.end());
+    Submit(MakeSpecWithTokens("r2", r2_tokens));
+    ExecutionPlan plan = PlanOnce();
+    const FlatForwardOperation* op = FindFlatOp(plan);
+    ASSERT_NE(op, nullptr);
+    ASSERT_EQ(op->request_ids.size(), 1u);
+
+    EXPECT_EQ(op->extend_prefix_lens.at(0), 16) << "decode-folded coarse block must extend the hit past the prompt";
+    EXPECT_EQ(op->input_lengths.at(0), 2);
+    EXPECT_EQ(op->input_ids, fresh);
+    // 5 real claims (2 full + 2 swa + 1 conv) + 1 fresh page per group = 8.
+    EXPECT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start - 8);
+
+    SendForwardDone("r2", {199});
+    PlanOnce();
+    SendForwardDone("r2", {200});
+    SendFinish("r2");
+    PlanOnce();
+    EXPECT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start);
+}
+
+// ---------------------------------------------------------------------------
 // M15 streaming L2 sink: pages registered by a planning round batch into ONE
 // D2H write-back; WriteBackDone commits/aborts the host index and unpins the
 // pinned source blocks. Byte movement itself is Phase D.

--- a/tokenspeed-scheduler/tests/cpp/test_flat_kvcache_scenarios.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_flat_kvcache_scenarios.cpp
@@ -2679,9 +2679,9 @@ protected:
         SchedulerConfig cfg = FlatDecodeCachingSuite::MakeConfig();  // base block_size 2
         // Swap the swa group for a coarse mamba-style state group: family State
         // WITHOUT SlidingWindow retention -> kMambaState (see MakeSpecsFromConfig).
-        cfg.paged_cache_groups[1] = MakeGroup("state", /*block_size=*/4, cfg.device_allocator.total_pages,
-                                              PagedCacheGroupConfig::Retention::FullHistory,
-                                              PagedCacheGroupFamily::State);
+        cfg.paged_cache_groups[1] =
+            MakeGroup("state", /*block_size=*/4, cfg.device_allocator.total_pages,
+                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::State);
         cfg.paged_cache_groups[1].block_size = 4;
         return cfg;
     }

--- a/tokenspeed-scheduler/tests/cpp/test_kv_cache_coordinator.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_kv_cache_coordinator.cpp
@@ -1391,6 +1391,57 @@ TEST(HeteroFoldedMatchTest, ConvergedBoundaryWithGroup0LargerThanBase) {
     EXPECT_EQ(m.per_group[1].blocks.size(), 2u);  // 8 tokens / 4 = 2 base blocks (truncated from 4)
 }
 
+// {8,4} MIRROR: the coarse closed group covers MORE (16) than the fine group (12). Without
+// lcm alignment the boundary settles at 12 while the coarse group floor-truncates to 8,
+// leaving [8,12) neither cached nor recomputed; the boundary must fall to the lcm (8).
+TEST(HeteroFoldedMatchTest, CoarseCoversMoreThanFineAlignsBoundaryToLcm) {
+    BlockPool pool(64, true);
+    std::vector<KvCacheSpec> specs = {{AttnKind::kFull, 8, 0}, {AttnKind::kFull, 4, 0}};
+    KvCacheCoordinator coord = MakeCoordinator(specs, pool);
+    ASSERT_EQ(coord.BaseBlockSize(), 4);
+    ASSERT_EQ(coord.LcmBlockSize(), 8);
+
+    // group0 (bs 8) caches both coarse blocks (16 tokens); group1 (bs 4) caches blocks 0..2 (12).
+    std::vector<std::string> ch = ContentHashes({{0, 0, 0, 0}, {1, 1, 1, 1}, {2, 2, 2, 2}, {3, 3, 3, 3}});
+    std::vector<std::string> folded_g0 = FoldBaseHashes(ch, /*first_base=*/0, /*m=*/2);
+    ASSERT_EQ(folded_g0.size(), 2u);
+    CacheForGroup(pool, folded_g0[0], 0);
+    CacheForGroup(pool, folded_g0[1], 0);
+    CacheForGroup(pool, ch[0], 1);
+    CacheForGroup(pool, ch[1], 1);
+    CacheForGroup(pool, ch[2], 1);
+
+    CoordinatorMatch m = coord.MatchPrefix(ch).device;
+    EXPECT_EQ(m.num_common_tokens, 8) << "12 is not a whole coarse block; boundary aligns down to lcm";
+    ASSERT_EQ(m.per_group.size(), 2u);
+    EXPECT_EQ(m.per_group[0].blocks.size(), 1u);  // coarse coverage == boundary, no phantom [8,12)
+    EXPECT_EQ(m.per_group[1].blocks.size(), 2u);  // fine truncated to the boundary
+}
+
+// Two WINDOW groups of different granularity: the fine group drags the aligned bound under
+// the coarse group's first match; the converge loop re-matches BOTH at the lcm-aligned bound.
+TEST(HeteroFoldedMatchTest, CoarseWindowGroupRematchesUnderAlignedBound) {
+    BlockPool pool(64, true);
+    std::vector<KvCacheSpec> specs = {{AttnKind::kSlidingWindow, 8, 8}, {AttnKind::kSlidingWindow, 4, 4}};
+    KvCacheCoordinator coord = MakeCoordinator(specs, pool);
+    ASSERT_EQ(coord.LcmBlockSize(), 8);
+
+    // group0 (coarse swa) caches 16 tokens; group1 (fine swa) caches 12 -> aligned bound 8.
+    std::vector<std::string> ch = ContentHashes({{0, 0, 0, 0}, {1, 1, 1, 1}, {2, 2, 2, 2}, {3, 3, 3, 3}});
+    std::vector<std::string> folded_g0 = FoldBaseHashes(ch, /*first_base=*/0, /*m=*/2);
+    CacheForGroup(pool, folded_g0[0], 0);
+    CacheForGroup(pool, folded_g0[1], 0);
+    CacheForGroup(pool, ch[0], 1);
+    CacheForGroup(pool, ch[1], 1);
+    CacheForGroup(pool, ch[2], 1);
+
+    CoordinatorMatch m = coord.MatchPrefix(ch).device;
+    EXPECT_EQ(m.num_common_tokens, 8) << "12 aligns down to 8; both window groups re-match there";
+    ASSERT_EQ(m.per_group.size(), 2u);
+    EXPECT_EQ(m.per_group[0].blocks.size(), 1u);  // re-matched at 8: one coarse block
+    EXPECT_EQ(m.per_group[1].blocks.size(), 2u);  // re-matched at 8: two fine blocks
+}
+
 // {4,8}: two full groups over 16 tokens register at their OWN folded granularity, and a
 // second MatchPrefix hits every registered block.
 TEST(HeteroFoldedRegistrationTest, EachGroupRegistersAtOwnGranularityThenHits) {


### PR DESCRIPTION
# Heterogeneous block_size: complete the scheduler-side support

1. **Match boundary aligns to the groups' lcm.** A prefix-closed coarse group can only
   hand over whole blocks, so the converged boundary must land on a common multiple of
   all group block sizes. `SweepThenConverge` now aligns every bound down to the lcm —
   the value the coordinator already carried, now with its consumer.
2. **Coarse blocks fold and register during decode.** The hash chain keeps a tail of
   base hashes back to the fold grid, so a group with block_size > base folds and
   registers the blocks it completes mid-decode. Overlap re-registration is skipped per
   slot (idempotent).

