### PR TITLE
feat(spec): EAGLE3/MTP speculative decoding on the flat KV-cache path

### DIFF
--- a/python/tokenspeed/runtime/configs/paged_cache_spec.py
+++ b/python/tokenspeed/runtime/configs/paged_cache_spec.py
@@ -73,7 +73,6 @@ STATE_LAYER_TYPES = frozenset({LINEAR_ATTENTION})
 def hybrid_slab_group_size(
     layer_types: Sequence[str] | None,
     *,
-    speculative_enabled: bool,
     sliding_window_tokens: int | Sequence[int | None] | None = None,
 ) -> int | None:
     """Group size for the hybrid slab KV layout (one layer of EACH group
@@ -90,7 +89,7 @@ def hybrid_slab_group_size(
     window) degrade to None: the slab pairing is per raw label, not per
     (retention, window) group.
     """
-    if speculative_enabled or not scheduler_ext_flat_kvcache():
+    if not scheduler_ext_flat_kvcache():
         return None
     if not layer_types:
         return None
@@ -142,7 +141,7 @@ def validate_flat_scheduler_config(
     paged_cache_groups: Sequence[object],
     attn_backend: object,
     kv_pool: object,
-    speculative_enabled: bool,
+    speculative_algorithm: str | None = None,
 ) -> None:
     """Fail fast, before the C++ ``Scheduler`` ctor, when a flat-built ext
     cannot drive this setup: a backend (or hybrid sub-backend) that would not
@@ -166,6 +165,21 @@ def validate_flat_scheduler_config(
             "placeholders. Use a radix-built tokenspeed_scheduler extension "
             "for this model."
         )
+    if speculative_algorithm is not None and not getattr(
+        backend, "flat_spec_capable", True
+    ):
+        raise RuntimeError(
+            "flat scheduler build (TOKENSPEED_FLAT_KVCACHE): attention backend "
+            f"{backend_name} does not support flat cache groups with "
+            "speculative decoding yet. Use the MHA backend or a radix-built "
+            "tokenspeed_scheduler extension."
+        )
+    if speculative_algorithm == "DFLASH":
+        raise RuntimeError(
+            "flat scheduler build (TOKENSPEED_FLAT_KVCACHE): DFLASH block "
+            "decode is unsupported on the flat path. Use a radix-built "
+            "tokenspeed_scheduler extension."
+        )
     if len(paged_cache_groups) > 1 and not uses_flat:
         # A table-blind backend on a multi-group pool would index every
         # layer through the C++ single-table fallback (a first-group
@@ -181,26 +195,11 @@ def validate_flat_scheduler_config(
             "or use a radix-built tokenspeed_scheduler extension."
         )
     if not paged_cache_groups:
-        if speculative_enabled:
-            cause = (
-                "speculative decoding is enabled, which gates paged-cache "
-                "group publication off"
-            )
-            action = (
-                "Disable speculative decoding or use a radix-built "
-                "tokenspeed_scheduler extension."
-            )
-        else:
-            cause = (
-                f"KV pool {pool_name} publishes no paged-cache groups (e.g. "
-                "mamba/state-only pools)"
-            )
-            action = (
-                "Use a radix-built tokenspeed_scheduler extension for this " "model."
-            )
         raise RuntimeError(
             "flat scheduler build (TOKENSPEED_FLAT_KVCACHE) requires at least "
-            f"one paged-cache group, but {cause}. {action}"
+            f"one paged-cache group, but KV pool {pool_name} publishes none "
+            "(e.g. mamba/state-only pools). Use a radix-built "
+            "tokenspeed_scheduler extension for this model."
         )
 
 
@@ -451,7 +450,6 @@ def publish_paged_cache_groups(
     layer_types: Sequence[str],
     sliding_window_tokens: int | Sequence[int | None] | None,
     page_size: int,
-    speculative_enabled: bool,
     max_live_requests: int,
     max_scheduled_tokens: int,
     max_total_tokens: int,
@@ -460,27 +458,25 @@ def publish_paged_cache_groups(
     """Publication rule (canonical) for a KV pool's paged-cache groups.
 
     Publish groups iff the scheduler ext is flat-built (a radix ext never
-    delivers flat tables — capture would bind dead buffers) and spec decode
-    is off (flat tables do not support spec-expanded metadata; non-empty
-    groups would also disable the overlap scheduler under spec). Publication
-    is THE upstream signal every flat consumer keys off.
-    TODO(flat+spec): publish under spec.
+    delivers flat tables — capture would bind dead buffers). Speculative
+    decoding is supported: verify writes per-group [bs*N] locations and the
+    drafter consumes the full-attention group's table (mirrored into
+    req_to_page each step). Publication is THE upstream signal every flat
+    consumer keys off.
 
     Args:
         layer_types: Per-layer paged-cache labels (empty -> single
             full-history group).
         sliding_window_tokens / page_size: Forwarded to
             group_specs_from_layer_types.
-        speculative_enabled: Gates publication off.
         max_live_requests / max_scheduled_tokens / max_total_tokens /
             max_context_len: Sizing inputs for
             compute_paged_cache_group_page_counts.
 
     Returns:
-        (specs, page_counts) when publishing, None when publication is
-        gated off (radix ext or spec decode).
+        (specs, page_counts) when publishing, None on a radix ext.
     """
-    if speculative_enabled or not scheduler_ext_flat_kvcache():
+    if not scheduler_ext_flat_kvcache():
         return None
     specs = group_specs_from_layer_types(
         layer_types=tuple(layer_types) or (FULL_ATTENTION,),

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -372,7 +372,7 @@ class EventLoop:
             paged_cache_groups=paged_cache_groups,
             attn_backend=attn_backend,
             kv_pool=token_to_kv_pool,
-            speculative_enabled=server_args.speculative_algorithm is not None,
+            speculative_algorithm=server_args.speculative_algorithm,
         )
         self._paged_cache_groups = paged_cache_groups
         prefix_cache_adjunct = None

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -535,6 +535,30 @@ class CudaGraphWrapper:
             return ()
         return tuple(str(spec.group_id) for spec in pool.paged_cache_group_specs)
 
+    def _draft_flat_group_ids(self) -> tuple[str, ...]:
+        """The draft head shares the target full-attention group's page ids
+        (EAGLE writes its own pool tensors at the same indices), so the
+        drafter consumes exactly that group's table on the flat path."""
+        if self.draft_attn_backend is None or not getattr(
+            self.draft_attn_backend, "uses_flat_cache_groups", False
+        ):
+            return ()
+        return tuple(
+            str(spec.group_id)
+            for spec in self.token_to_kv_pool.paged_cache_group_specs
+            if spec.family != "state" and spec.retention == "full_history"
+        )
+
+    def _draft_flat_tables(self, flat_block_tables):
+        """Subset of the target's per-group tables the drafter consumes."""
+        gids = self._draft_flat_group_ids()
+        if not gids or not flat_block_tables:
+            return None
+        subset = {
+            gid: flat_block_tables[gid] for gid in gids if gid in flat_block_tables
+        }
+        return subset or None
+
     def _init_capture_metadata(self, bs: int):
         capture_kwargs = {}
         if self.input_buffers.has_mamba:
@@ -575,6 +599,9 @@ class CudaGraphWrapper:
                         draft_paged_cache_block_tables
                     )
                     draft_kwargs["num_tokens"] = bs * self.max_tokens_per_req
+            draft_flat_ids = self._draft_flat_group_ids()
+            if draft_flat_ids:
+                draft_kwargs["flat_cache_group_ids"] = draft_flat_ids
             # Drafter mutates seq_lens_buf in place per step; backends alias.
             self.draft_attn_backend.init_forward_metadata_capture_cuda_graph(
                 bs,
@@ -742,6 +769,9 @@ class CudaGraphWrapper:
                     )
             if getattr(self.draft_attn_backend, "uses_padded_decode_token_mask", False):
                 draft_attn_kwargs["actual_bs"] = actual_bs
+            draft_flat = self._draft_flat_tables(kwargs.get("flat_block_tables"))
+            if draft_flat is not None:
+                draft_attn_kwargs["flat_block_tables"] = draft_flat
             draft_forward_mode = ForwardMode.DECODE
             if draft_uses_paged_groups:
                 draft_attn_kwargs["num_tokens"] = padded_bs * self.max_tokens_per_req
@@ -793,6 +823,9 @@ class CudaGraphWrapper:
                     value = kwargs.get(key)
                     if value is not None:
                         draft_kwargs[key] = value
+            draft_flat = self._draft_flat_tables(kwargs.get("flat_block_tables"))
+            if draft_flat is not None:
+                draft_kwargs["flat_block_tables"] = draft_flat
 
             # The drafter mutates draft_seq_lens_buf between MTP draft steps;
             # decode metadata must alias that buffer.
@@ -809,6 +842,12 @@ class CudaGraphWrapper:
                 draft_prefill_seq_lens = (
                     seq_lens if self.use_v4_mtp_paged_metadata else draft_seq_lens
                 )
+                # Drafter consumes only the full group's table (see _draft_flat_tables).
+                draft_extend_kwargs = (
+                    {**kwargs, "flat_block_tables": draft_flat}
+                    if kwargs.get("flat_block_tables") is not None
+                    else kwargs
+                )
                 self.draft_attn_backend.init_forward_metadata(
                     bs=padded_bs,
                     num_extends=num_extends,
@@ -816,7 +855,7 @@ class CudaGraphWrapper:
                     seq_lens=draft_prefill_seq_lens,
                     req_to_page=self.drafter.req_to_page,
                     forward_mode=forward_mode,
-                    **kwargs,
+                    **draft_extend_kwargs,
                 )
                 if self.use_v4_mtp_paged_metadata:
                     self.draft_attn_backend.init_forward_metadata(

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -29,6 +29,10 @@ from tokenspeed_kernel.ops.tuning import freeze_autotuning
 from tokenspeed_kernel.platform import current_platform
 
 from tokenspeed.runtime.configs.model_config import ModelConfig
+from tokenspeed.runtime.configs.paged_cache_spec import (
+    scheduler_ext_flat_kvcache,
+    validate_flat_scheduler_config,
+)
 from tokenspeed.runtime.configs.utils import get_rope_parameters
 from tokenspeed.runtime.engine.scheduler_utils import (
     flat_block_tables_from_forward_op,
@@ -240,9 +244,34 @@ class ModelExecutor:
         self.sampling_backend = sampling_backend
         self.attn_backend = attn_backend
         self.token_to_kv_pool = token_to_kv_pool
+        # Full-attention group mirrored into req_to_page each step (flat+spec).
+        _group_specs = getattr(token_to_kv_pool, "paged_cache_group_specs", ()) or ()
+        self._flat_full_group_id = next(
+            (
+                str(spec.group_id)
+                for spec in _group_specs
+                if getattr(spec, "family", "history") != "state"
+                and getattr(spec, "retention", None) == "full_history"
+            ),
+            None,
+        )
+        self._mirror_idx_cpu: torch.Tensor | None = None
+        self._mirror_idx_dev: torch.Tensor | None = None
+        self._mirror_row_buf: torch.Tensor | None = None
         self.draft_attn_backend = draft_attn_backend
         self.draft_token_to_kv_pool = draft_token_to_kv_pool
         self._layerwise_mamba_cow_done = None
+
+        # Must precede CUDA-graph capture: unsupported flat combinations
+        # (e.g. spec on a backend without flat_spec_capable) would otherwise
+        # die on a capture-path assert instead of this actionable error.
+        validate_flat_scheduler_config(
+            flat_kvcache_ext=scheduler_ext_flat_kvcache(),
+            paged_cache_groups=_group_specs,
+            attn_backend=attn_backend,
+            kv_pool=token_to_kv_pool,
+            speculative_algorithm=config.spec_algo,
+        )
 
         if config.spec_algo is not None:
             # The DFLASH overlap scheduler reserves a fresh draft block per
@@ -597,6 +626,54 @@ class ModelExecutor:
             if isinstance(self.grammar_runtime, EagerGrammarBuffers)
             else None
         )
+
+    def _mirror_flat_full_table_into_req_to_page(
+        self, forward_op, flat_block_tables
+    ) -> None:
+        """Flat + spec: scatter the full-attention group's per-batch table
+        into req_to_page rows, restoring the radix contract for every
+        legacy consumer (input prep's out_cache_loc kernels, the drafter's
+        per-step location chains). The flat scheduler never populates
+        req_to_page itself; column tails zero-fill to the dummy page so
+        stale longer rows can't leak."""
+        if (
+            self.drafter is None
+            or not flat_block_tables
+            or self._flat_full_group_id is None
+        ):
+            return
+        table = flat_block_tables.get(self._flat_full_group_id)
+        if table is None:
+            return
+        bs = len(forward_op.request_pool_indices)
+        if self._mirror_idx_cpu is None or self._mirror_idx_cpu.shape[0] < bs:
+            cap = max(bs, self.input_buffers.max_bs)
+            self._mirror_idx_cpu = torch.empty(cap, dtype=torch.long, pin_memory=True)
+            self._mirror_idx_dev = torch.empty(
+                cap, dtype=torch.long, device=self.device
+            )
+        self._mirror_idx_cpu[:bs] = torch.tensor(
+            forward_op.request_pool_indices, dtype=torch.long
+        )
+        self._mirror_idx_dev[:bs].copy_(self._mirror_idx_cpu[:bs], non_blocking=True)
+        idx = self._mirror_idx_dev[:bs]
+        width = table.shape[1]
+        max_width = self.req_to_page.shape[1]
+        if self._mirror_row_buf is None:
+            self._mirror_row_buf = torch.zeros(
+                (self.input_buffers.max_bs, max_width),
+                dtype=self.req_to_page.dtype,
+                device=self.device,
+            )
+        # Staged rows + index_copy_ (advanced-index setitem costs ~150us dispatch).
+        rows = self._mirror_row_buf[:bs]
+        rows[:, :width].copy_(table)
+        rows[:, :width].clamp_min_(
+            0
+        )  # -1 column pads -> dummy page 0 (negative locs otherwise)
+        if width < max_width:
+            rows[:, width:].zero_()
+        self.req_to_page.index_copy_(0, idx, rows)
 
     @nvtx_range("target_forward", color="red")
     def _run_target_forward(self, bs: int, ctx: ForwardContext, req_pool_indices):
@@ -1591,6 +1668,13 @@ class ModelExecutor:
             bs = len(forward_op.request_ids)
             # Outside the graph: in-graph sites only OR into the flag buffer.
             self.nan_guard.reset(bs)
+            # Mirror the full group's flat table into req_to_page (flat+spec).
+            flat_block_tables = flat_block_tables_from_forward_op(
+                forward_op,
+                device=self.device,
+                num_reqs=bs,
+            )
+            self._mirror_flat_full_table_into_req_to_page(forward_op, flat_block_tables)
             decode_input_ids = self.input_buffers.fill_input_buffers(
                 forward_op=forward_op,
                 runtime_states=self.runtime_states,
@@ -1770,11 +1854,7 @@ class ModelExecutor:
                         device=self.device,
                         num_reqs=bs,
                     )
-                    flat_block_tables = flat_block_tables_from_forward_op(
-                        forward_op,
-                        device=self.device,
-                        num_reqs=bs,
-                    )
+                    # flat_block_tables computed once in pre_fill above.
                     (
                         paged_cache_block_table_base_offsets,
                         _paged_cache_block_table_base_offset_max,

--- a/python/tokenspeed/runtime/layers/attention/backends/base.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/base.py
@@ -68,6 +68,8 @@ class AttentionBackend(ABC):
     # different hole/index semantics; a group-aware flat backend (Phase 4) sets
     # this True. Default False keeps every existing backend on today's path.
     uses_flat_cache_groups: bool = False
+    # False for flat-capable backends whose spec-verify path is not wired yet.
+    flat_spec_capable: bool = True
     uses_padded_decode_token_mask: bool = False
 
     def __init__(self, config: BaseAttnConfig) -> None:

--- a/python/tokenspeed/runtime/layers/attention/backends/flat_groups.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/flat_groups.py
@@ -67,9 +67,11 @@ class FlatCacheGroupsMixin:
             return metadata.page_table
         return self._select_group_entry(layer, metadata.page_tables, "page table")
 
-    def _select_out_cache_loc(self, layer, metadata, out_cache_loc):
-        # KV writes must land in the pages the layer's group reads (M-W1).
-        if metadata.out_cache_locs is None:
+    def _select_out_cache_loc(
+        self, layer, metadata, out_cache_loc, prefer_caller=False
+    ):
+        # prefer_caller: draft chains own per-step locs; metadata's single loc would pin every step to one slot.
+        if metadata.out_cache_locs is None or prefer_caller:
             return out_cache_loc
         return self._select_group_entry(
             layer, metadata.out_cache_locs, "flat write locs"
@@ -123,17 +125,32 @@ class FlatCacheGroupsMixin:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _compute_flat_decode_out_cache_locs(page_tables, seq_lens, page_size):
-        """Per-group decode write locs: one token per request at seq_len-1,
-        gathered from the group's own read table (M-W1). The tail page is
-        never a hole (SWA holes sit only at the window front).
+    def _compute_flat_decode_out_cache_locs(
+        page_tables, seq_lens, page_size, num_tokens_per_req=1
+    ):
+        """Per-group decode write locs, gathered from the group's own read
+        table (M-W1). Plain decode writes one token per request at seq_len-1;
+        spec verify writes num_tokens_per_req at seq_len-N..seq_len-1,
+        flattened token-major per request ([bs*N], radix verify layout).
+        Positions clamp at 0 for graph-padded rows (seq_len 1 < N), which
+        dereference the dummy page harmlessly. The tail page is never a hole
+        (SWA holes sit only at the window front).
         """
-        pos = (seq_lens - 1).to(torch.int64)
+        n = num_tokens_per_req
+        if n == 1:
+            pos = (seq_lens - 1).to(torch.int64)
+        else:
+            steps = torch.arange(n, device=seq_lens.device, dtype=torch.int64)
+            pos = (seq_lens.to(torch.int64).unsqueeze(1) - n + steps).clamp_min(0)
+            pos = pos.reshape(-1)
         page_idx = pos // page_size
         off = (pos % page_size).to(torch.int32)
         out = {}
         for gid, table in page_tables.items():
-            pages = table.gather(1, page_idx.unsqueeze(1)).squeeze(1)
+            if n == 1:
+                pages = table.gather(1, page_idx.unsqueeze(1)).squeeze(1)
+            else:
+                pages = table.gather(1, page_idx.view(-1, n)).reshape(-1)
             out[gid] = pages * page_size + off
         return out
 
@@ -198,10 +215,14 @@ class FlatCacheGroupsMixin:
         self.cuda_graph_flat_out_cache_locs: dict[str, torch.Tensor] = {}
         self._cuda_graph_max_bs = max_bs
 
-    def _flat_capture_group_views(self, bs: int, flat_cache_group_ids):
+    def _flat_capture_group_views(
+        self, bs: int, flat_cache_group_ids, tokens_per_req: int = 1
+    ):
         """Capture-time (page_tables, out_cache_locs) per-group views into the
         persistent buffers, lazily allocated. Real tables only arrive at
         replay, which copy_s fresh data to these graph-recorded addresses.
+        Verify (tokens_per_req = spec_num_tokens) keeps [bs]-row tables but
+        records [bs*N] write-loc views (token-major, radix verify layout).
         Returns (None, None) when only state groups (or none) are delivered.
         """
         if not flat_cache_group_ids:
@@ -221,15 +242,18 @@ class FlatCacheGroupsMixin:
                 )
                 self.cuda_graph_flat_page_tables[gid] = buf
             loc_buf = self.cuda_graph_flat_out_cache_locs.get(gid)
-            if loc_buf is None:
+            if (
+                loc_buf is None
+                or loc_buf.shape[0] < self._cuda_graph_max_bs * tokens_per_req
+            ):
                 loc_buf = torch.zeros(
-                    (self._cuda_graph_max_bs,),
+                    (self._cuda_graph_max_bs * tokens_per_req,),
                     dtype=torch.int32,
                     device=self.device,
                 )
                 self.cuda_graph_flat_out_cache_locs[gid] = loc_buf
             page_tables[gid] = buf[:bs, :]
-            out_cache_locs[gid] = loc_buf[:bs]
+            out_cache_locs[gid] = loc_buf[: bs * tokens_per_req]
         if not page_tables:
             # Only state groups delivered: nothing for this backend.
             return None, None
@@ -259,9 +283,12 @@ class FlatCacheGroupsMixin:
                 "graph would read stale page tables for those groups."
             )
 
-    def _flat_replay_fill(self, bs: int, flat_block_tables, seq_lens) -> None:
+    def _flat_replay_fill(
+        self, bs: int, flat_block_tables, seq_lens, tokens_per_req: int = 1
+    ) -> None:
         """Copy this replay's tables into the captured buffers and recompute
-        the per-group write locs from the live seq_lens.
+        the per-group write locs from the live seq_lens (tokens_per_req locs
+        per request on the spec-verify path).
 
         Padding contract (canonical; bs is the padded bs): dummy ROWS pad
         with 0 — replayed at seq_lens=1 they dereference exactly col 0,
@@ -298,6 +325,7 @@ class FlatCacheGroupsMixin:
             },
             seq_lens[:bs],
             self.page_size,
+            tokens_per_req,
         )
         for gid, val in locs.items():
-            self.cuda_graph_flat_out_cache_locs[gid][:bs].copy_(val)
+            self.cuda_graph_flat_out_cache_locs[gid][: bs * tokens_per_req].copy_(val)

--- a/python/tokenspeed/runtime/layers/attention/backends/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mha.py
@@ -187,11 +187,10 @@ class MHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
         flat_page_tables = self._shed_state_groups(flat_block_tables)
         flat_out_cache_locs = None
         if flat_page_tables:
-            # Mirrors the capture-time assert: flat + spec is unsupported.
+            # Verify keeps [bs]-row tables; only DFLASH expands rows. TODO(flat+dflash).
             assert not (
-                self.spec_num_tokens > 1
-                and (not self.is_draft or self.draft_block_decode)
-            ), "flat cache groups are unsupported with spec_num_tokens > 1"
+                self.draft_block_decode and self.spec_num_tokens > 1
+            ), "flat cache groups are unsupported with DFLASH block decode"
             # The flat path routes every read/write through the per-group
             # tables; the radix single table would be dead work.
             page_table = None
@@ -205,10 +204,16 @@ class MHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
                     self.page_size,
                 )
             else:
+                verify_tokens = (
+                    self.spec_num_tokens
+                    if self.spec_num_tokens > 1 and not self.is_draft
+                    else 1
+                )
                 flat_out_cache_locs = self._compute_flat_decode_out_cache_locs(
                     flat_page_tables,
                     seq_lens,
                     self.page_size,
+                    verify_tokens,
                 )
             self._maybe_check_flat_write_locs(
                 flat_page_tables, flat_out_cache_locs, self.page_size
@@ -367,14 +372,18 @@ class MHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
         # persistent per-group buffers and records metadata views into them,
         # so replay can copy_ fresh data to the graph-recorded addresses.
         if flat_cache_group_ids:
-            # Per-group views are bs rows; spec buffers expand to
-            # bs * spec_num_tokens rows. TODO(flat+spec).
+            # Verify keeps [bs]-row tables + [bs*N] loc views. TODO(flat+dflash).
             assert not (
-                self.spec_num_tokens > 1
-                and (not self.is_draft or self.draft_block_decode)
-            ), "flat_cache_group_ids is unsupported with spec_num_tokens > 1"
+                self.draft_block_decode and self.spec_num_tokens > 1
+            ), "flat_cache_group_ids is unsupported with DFLASH block decode"
         page_tables, out_cache_locs = self._flat_capture_group_views(
-            bs, flat_cache_group_ids
+            bs,
+            flat_cache_group_ids,
+            tokens_per_req=(
+                self.spec_num_tokens
+                if self.spec_num_tokens > 1 and not self.is_draft
+                else 1
+            ),
         )
 
         if self.draft_block_decode and self.spec_num_tokens > 1:
@@ -450,10 +459,18 @@ class MHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
                 bs, self.spec_num_tokens, self.max_num_pages
             ).copy_(base_page_table[:, None, :])
 
-        # cuda_graph_seq_lens aliases the controller's seq_lens_buf, which
-        # input prep fills (current lens + padding 1s) BEFORE this call.
+        # cuda_graph_seq_lens is filled by input prep / the spec copy above.
         if flat_block_tables:
-            self._flat_replay_fill(bs, flat_block_tables, self.cuda_graph_seq_lens)
+            self._flat_replay_fill(
+                bs,
+                flat_block_tables,
+                self.cuda_graph_seq_lens,
+                tokens_per_req=(
+                    self.spec_num_tokens
+                    if self.spec_num_tokens > 1 and not self.is_draft
+                    else 1
+                ),
+            )
 
         if bs in self.cuda_graph_decode_metadata:
             self.forward_decode_metadata = self.cuda_graph_decode_metadata[bs]
@@ -505,7 +522,10 @@ class MHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
         sinks = kwargs.get("sinks")
 
         out_cache_loc = self._select_out_cache_loc(
-            layer, self.forward_decode_metadata, out_cache_loc
+            layer,
+            self.forward_decode_metadata,
+            out_cache_loc,
+            prefer_caller=self.is_draft,
         )
 
         return self._forward_decode(

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -118,8 +118,11 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
 
     def _prewrite_metadata(self, forward_mode):
         # Prewrite fires on extend too (unlike MHA): route it to the slot
-        # init_forward_metadata filled for this forward.
+        # init_forward_metadata filled for this forward. Target verify is
+        # DECODE mode but its multi-token metadata lives in the prefill slot.
         if forward_mode is not None and forward_mode.is_extend_or_mixed():
+            return self.forward_prefill_metadata
+        if self.spec_num_tokens > 1 and not self.is_draft:
             return self.forward_prefill_metadata
         return self.forward_decode_metadata
 
@@ -307,7 +310,9 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
                 else self.forward_decode_metadata
             )
 
-        out_cache_loc = self._select_out_cache_loc(layer, metadata, out_cache_loc)
+        out_cache_loc = self._select_out_cache_loc(
+            layer, metadata, out_cache_loc, prefer_caller=self.is_draft
+        )
         q = self._save_kv_and_prepare_q(
             q, k, v, layer, out_cache_loc, token_to_kv_pool, save_kv_cache
         )
@@ -400,12 +405,10 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
         flat_page_tables = self._shed_state_groups(flat_block_tables)
         flat_out_cache_locs = None
         if flat_page_tables:
-            # Mirrors the MHA backend: flat + spec is unsupported (the
-            # publication rule never delivers tables under spec decode).
+            # Verify keeps [bs]-row tables; only DFLASH expands rows. TODO(flat+dflash).
             assert not (
-                self.spec_num_tokens > 1
-                and (not self.is_draft or self.draft_block_decode)
-            ), "flat cache groups are unsupported with spec_num_tokens > 1"
+                self.draft_block_decode and self.spec_num_tokens > 1
+            ), "flat cache groups are unsupported with DFLASH block decode"
             if forward_mode.is_extend_or_mixed():
                 assert extend_prefix_lens_cpu is not None
                 assert extend_seq_lens_cpu is not None
@@ -420,6 +423,7 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
                     flat_page_tables,
                     seq_lens[:bs],
                     self.page_size,
+                    self._flat_verify_tokens(),
                 )
             self._maybe_check_flat_write_locs(
                 flat_page_tables, flat_out_cache_locs, self.page_size
@@ -456,11 +460,24 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
 
         if self.spec_num_tokens > 1:
             self._init_multi_token_metadata(
-                bs, self.spec_num_tokens, req_pool_indices, seq_lens, req_to_page
+                bs,
+                self.spec_num_tokens,
+                req_pool_indices,
+                seq_lens,
+                req_to_page,
+                flat_page_tables=flat_page_tables,
+                flat_out_cache_locs=flat_out_cache_locs,
             )
             if self.is_draft:
                 # Drafter's N-1 single-token steps after the first.
-                self._init_decode_metadata(bs, req_pool_indices, seq_lens, req_to_page)
+                self._init_decode_metadata(
+                    bs,
+                    req_pool_indices,
+                    seq_lens,
+                    req_to_page,
+                    flat_page_tables=flat_page_tables,
+                    flat_out_cache_locs=flat_out_cache_locs,
+                )
         else:
             self._init_decode_metadata(
                 bs,
@@ -579,6 +596,15 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
         torch.clamp_min(seq_lens[:bs], spec_num_tokens, out=dst)
         return dst
 
+    def _flat_verify_tokens(self) -> int:
+        # Write locs per request on the flat path: N for target verify
+        # ([bs*N], token-major), 1 elsewhere (draft chains use caller locs).
+        return (
+            self.spec_num_tokens
+            if self.spec_num_tokens > 1 and not self.is_draft
+            else 1
+        )
+
     def _init_multi_token_metadata(
         self,
         bs: int,
@@ -586,6 +612,8 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
         req_to_page: torch.Tensor,
+        flat_page_tables: dict[str, torch.Tensor] | None = None,
+        flat_out_cache_locs: dict[str, torch.Tensor] | None = None,
     ):
         """Prefill-slot metadata for multi-token decode (uniform q_len per
         request). Routes through the decode kernel via q_len_per_req; the
@@ -607,9 +635,15 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
                 dtype=torch.int32,
                 device=device,
             ),
-            page_table=self._build_page_table(
-                req_pool_indices, seq_lens, bs, req_to_page, self.page_table_buf
+            page_table=(
+                None
+                if flat_page_tables
+                else self._build_page_table(
+                    req_pool_indices, seq_lens, bs, req_to_page, self.page_table_buf
+                )
             ),
+            page_tables=flat_page_tables,
+            out_cache_locs=flat_out_cache_locs,
         )
 
     def _init_extend_metadata(
@@ -744,12 +778,12 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
         # Real tables only arrive at replay: capture lazily allocates
         # persistent per-group buffers and records metadata views into them.
         if flat_cache_group_ids:
+            # Verify keeps [bs]-row tables + [bs*N] loc views. TODO(flat+dflash).
             assert not (
-                self.spec_num_tokens > 1
-                and (not self.is_draft or self.draft_block_decode)
-            ), "flat_cache_group_ids is unsupported with spec_num_tokens > 1"
+                self.draft_block_decode and self.spec_num_tokens > 1
+            ), "flat_cache_group_ids is unsupported with DFLASH block decode"
         page_tables, out_cache_locs = self._flat_capture_group_views(
-            bs, flat_cache_group_ids
+            bs, flat_cache_group_ids, tokens_per_req=self._flat_verify_tokens()
         )
 
         if self.draft_block_decode and self.spec_num_tokens > 1:
@@ -757,9 +791,13 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
             return
 
         if self.spec_num_tokens > 1:
-            self._init_multi_token_metadata_capture(bs, self.spec_num_tokens)
+            self._init_multi_token_metadata_capture(
+                bs, self.spec_num_tokens, page_tables, out_cache_locs
+            )
             if self.is_draft:
-                self._init_decode_metadata_capture(bs, seq_lens)
+                self._init_decode_metadata_capture(
+                    bs, seq_lens, page_tables, out_cache_locs
+                )
         else:
             self._init_decode_metadata_capture(
                 bs, seq_lens, page_tables, out_cache_locs
@@ -809,7 +847,13 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
         self.cuda_graph_decode_metadata[bs] = metadata
         self.forward_decode_metadata = metadata
 
-    def _init_multi_token_metadata_capture(self, bs: int, spec_num_tokens: int):
+    def _init_multi_token_metadata_capture(
+        self,
+        bs: int,
+        spec_num_tokens: int,
+        page_tables: dict[str, torch.Tensor] | None = None,
+        out_cache_locs: dict[str, torch.Tensor] | None = None,
+    ):
         # Multi-token decode: seed spec_cache_seqlens_buf (clamped to >=
         # spec_num_tokens) at capture so padded rows (seq_len=1) avoid NaN.
         # The replay path refreshes it each step.
@@ -827,7 +871,11 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
                 dtype=torch.int32,
                 device=self.device,
             ),
-            page_table=self.cuda_graph_page_table[:bs, :],
+            page_table=(
+                None if page_tables is not None else self.cuda_graph_page_table[:bs, :]
+            ),
+            page_tables=page_tables,
+            out_cache_locs=out_cache_locs,
         )
         self.cuda_graph_prefill_metadata[bs] = metadata
         self.forward_prefill_metadata = metadata
@@ -879,7 +927,12 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
         if flat_block_tables:
             # cuda_graph_cache_seqlens aliases the controller's seq_lens_buf,
             # filled by input prep BEFORE this call.
-            self._flat_replay_fill(bs, flat_block_tables, self.cuda_graph_cache_seqlens)
+            self._flat_replay_fill(
+                bs,
+                flat_block_tables,
+                self.cuda_graph_cache_seqlens,
+                tokens_per_req=self._flat_verify_tokens(),
+            )
 
         # Refresh for both verify and draft: draft step 1 is multi-token
         # and reads spec_cache_seqlens_buf; later single-token steps don't.

--- a/python/tokenspeed/runtime/layers/attention/configs/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/mha.py
@@ -44,9 +44,6 @@ class MHAConfig(BaseAttnConfig):
     layer_types: tuple[str, ...] = ()
     sliding_window_tokens: int | tuple[int | None, ...] | None = None
     max_scheduled_tokens: int = 0
-    # True iff server_args.speculative_algorithm is set (publication rule:
-    # paged_cache_spec.publish_paged_cache_groups).
-    speculative_enabled: bool = False
     # True iff server_args.disaggregation_mode != "null"; the pool's slab
     # guards consume it.
     pd_disaggregation_enabled: bool = False
@@ -121,7 +118,6 @@ class MHAConfig(BaseAttnConfig):
             layer_types=layer_types,
             sliding_window_tokens=sliding_window_tokens,
             max_scheduled_tokens=getattr(server_args, "chunked_prefill_size", 8192),
-            speculative_enabled=server_args.speculative_algorithm is not None,
             pd_disaggregation_enabled=getattr(
                 server_args, "disaggregation_mode", "null"
             )
@@ -165,7 +161,6 @@ class MHAConfig(BaseAttnConfig):
             layer_types=self.layer_types,
             sliding_window_tokens=self.sliding_window_tokens,
             max_scheduled_tokens=self.max_scheduled_tokens,
-            speculative_enabled=self.speculative_enabled,
             pd_disaggregation_enabled=self.pd_disaggregation_enabled,
             conv_state_shape=self.conv_state_shape,
             temporal_state_shape=self.temporal_state_shape,

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/mha.py
@@ -64,7 +64,6 @@ class MHATokenToKVPool(BaseTokenToKVPool):
         layer_types: tuple[str, ...] = (),
         sliding_window_tokens: int | tuple[int | None, ...] | None = None,
         max_scheduled_tokens: int = 0,
-        speculative_enabled: bool = False,
         pd_disaggregation_enabled: bool = False,
         enable_kv_cache_copy: bool = False,
         enable_alt_stream: bool = True,
@@ -88,7 +87,6 @@ class MHATokenToKVPool(BaseTokenToKVPool):
         self._pd_disaggregation_enabled = pd_disaggregation_enabled
         self._slab_group_size = hybrid_slab_group_size(
             self._layer_types,
-            speculative_enabled=speculative_enabled,
             sliding_window_tokens=sliding_window_tokens,
         )
         # GDN/mamba2 recurrent state slabs live under this same pool object
@@ -135,7 +133,6 @@ class MHATokenToKVPool(BaseTokenToKVPool):
             layer_types=self._layer_types,
             sliding_window_tokens=sliding_window_tokens,
             page_size=page_size,
-            speculative_enabled=speculative_enabled,
             max_live_requests=max_batch_size,
             max_scheduled_tokens=max_scheduled_tokens,
             max_total_tokens=size,
@@ -255,9 +252,8 @@ class MHATokenToKVPool(BaseTokenToKVPool):
                 else:
                     logger.info(
                         "KV layout: per-layer (%d buffers; hybrid slab "
-                        "inactive: predicate returned None -- radix ext, "
-                        "spec decode, or non-uniform/single-group "
-                        "layer_types)",
+                        "inactive: predicate returned None -- radix ext "
+                        "or non-uniform/single-group layer_types)",
                         self.layer_num,
                     )
             # Pointer/stride tables carry the REAL tensors only: _kv_copy

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -56,15 +56,12 @@ if TYPE_CHECKING:
     from tokenspeed.runtime.utils.server_args import ServerArgs
 
 
-def _kv_profile_layer_divisor(
-    num_layers, layer_types, *, speculative_enabled, sliding_window_tokens=None
-):
+def _kv_profile_layer_divisor(num_layers, layer_types, *, sliding_window_tokens=None):
     """Attention layers to charge per token in the KV memory profile:
     layers-per-group under the slab layout, else all layers (single
     source: hybrid_slab_group_size)."""
     gs = hybrid_slab_group_size(
         layer_types,
-        speculative_enabled=speculative_enabled,
         sliding_window_tokens=sliding_window_tokens,
     )
     return gs if gs is not None else num_layers
@@ -668,7 +665,6 @@ def create_attn_components(
         slab_divisor = _kv_profile_layer_divisor(
             num_layers,
             getattr(config, "layer_types", None),
-            speculative_enabled=server_args.speculative_algorithm is not None,
             sliding_window_tokens=getattr(config, "sliding_window_tokens", None),
         )
         if profile_cache_cell_size is not None and slab_divisor != num_layers:

--- a/test/runtime/test_flat_cudagraph_per_group.py
+++ b/test/runtime/test_flat_cudagraph_per_group.py
@@ -470,14 +470,30 @@ class BackendCaptureFlatTest(_BackendCase):
         )
         self.assertIsNot(first, second)
 
-    def test_flat_with_spec_decode_asserts(self):
+    def test_flat_with_spec_verify_records_expanded_loc_views(self):
+        # Verify (spec target) keeps [bs]-row tables but records [bs*N]
+        # write-loc views (token-major), sized off the persistent buffers.
         self.backend.spec_num_tokens = 2
         torch = self.torch
         self.backend.cuda_graph_page_table = torch.zeros(
             (MAX_BS * 2, MAX_NUM_PAGES), dtype=torch.int32
         )
         self.backend.cuda_graph_seq_lens = torch.zeros(MAX_BS * 2, dtype=torch.int32)
-        with self.assertRaisesRegex(AssertionError, "spec_num_tokens"):
+        self._capture(2, _GROUP_IDS)
+        meta = self.backend.forward_decode_metadata
+        for gid in _GROUP_IDS:
+            self.assertEqual(meta.page_tables[gid].shape[0], 2)
+            self.assertEqual(meta.out_cache_locs[gid].shape[0], 2 * 2)
+
+    def test_flat_with_dflash_block_decode_asserts(self):
+        self.backend.spec_num_tokens = 2
+        self.backend.draft_block_decode = True
+        torch = self.torch
+        self.backend.cuda_graph_page_table = torch.zeros(
+            (MAX_BS * 2, MAX_NUM_PAGES), dtype=torch.int32
+        )
+        self.backend.cuda_graph_seq_lens = torch.zeros(MAX_BS * 2, dtype=torch.int32)
+        with self.assertRaisesRegex(AssertionError, "DFLASH"):
             self._capture(2, _GROUP_IDS)
 
 

--- a/test/runtime/test_flat_scheduler_config_guard.py
+++ b/test/runtime/test_flat_scheduler_config_guard.py
@@ -62,10 +62,19 @@ class FakeV4StyleBackend:
 
 
 class FakeFlatMHABackend:
-    """backends/mha.py shape: flat-group capable."""
+    """backends/mha.py shape: flat-group capable, spec-verify wired."""
 
     uses_paged_cache_groups = False
     uses_flat_cache_groups = True
+
+
+class FakeSpecIncapableBackend:
+    """Flat-capable backend whose spec-verify path is not wired
+    (flat_spec_capable=False); rejected at startup under spec decode."""
+
+    uses_paged_cache_groups = False
+    uses_flat_cache_groups = True
+    flat_spec_capable = False
 
 
 class FakeV4Pool:
@@ -94,7 +103,7 @@ class ValidateFlatSchedulerConfigTest(unittest.TestCase):
                 paged_cache_groups=[FakeGroup()],
                 attn_backend=FakeV4StyleBackend(),
                 kv_pool=FakeV4Pool(),
-                speculative_enabled=False,
+                speculative_algorithm=None,
             )
         msg = str(ctx.exception)
         self.assertIn("does not support this model's cache layout", msg)
@@ -102,21 +111,20 @@ class ValidateFlatSchedulerConfigTest(unittest.TestCase):
         self.assertIn("FakeV4Pool", msg)
         self.assertIn("radix-built", msg)
 
-    def test_flat_ext_zero_groups_spec_decode_names_the_knob(self):
-        # The error must name spec decode as the cause, not surface the
-        # cryptic C++ MakeCoordinator abort.
+    def test_flat_ext_zero_groups_rejected_regardless_of_spec(self):
+        # Spec decode no longer gates publication (flat+spec is supported);
+        # a zero-group pool is rejected with the generic pool-shaped cause.
         with self.assertRaises(RuntimeError) as ctx:
             _pcs.validate_flat_scheduler_config(
                 flat_kvcache_ext=True,
                 paged_cache_groups=[],
                 attn_backend=FakeFlatMHABackend(),
                 kv_pool=FakeMHAPool(),
-                speculative_enabled=True,
+                speculative_algorithm="EAGLE3",
             )
         msg = str(ctx.exception)
         self.assertIn("at least one paged-cache group", msg)
-        self.assertIn("speculative decoding is enabled", msg)
-        self.assertIn("Disable speculative decoding", msg)
+        self.assertIn("publishes none", msg)
 
     def test_flat_ext_zero_groups_groupless_pool_names_the_pool(self):
         # Group-less pools (e.g. mamba) publish nothing without spec decode.
@@ -126,7 +134,7 @@ class ValidateFlatSchedulerConfigTest(unittest.TestCase):
                 paged_cache_groups=[],
                 attn_backend=FakeFlatMHABackend(),
                 kv_pool=FakeMambaPool(),
-                speculative_enabled=False,
+                speculative_algorithm=None,
             )
         msg = str(ctx.exception)
         self.assertIn("at least one paged-cache group", msg)
@@ -140,22 +148,64 @@ class ValidateFlatSchedulerConfigTest(unittest.TestCase):
             paged_cache_groups=[FakeGroup()],
             attn_backend=FakeFlatMHABackend(),
             kv_pool=FakeMHAPool(),
-            speculative_enabled=False,
+            speculative_algorithm=None,
         )
 
     def test_radix_ext_is_a_noop_regardless(self):
         # Every combination the flat arms reject must pass untouched.
         for backend, pool, groups, spec in (
-            (FakeV4StyleBackend(), FakeV4Pool(), [FakeGroup()], False),
-            (FakeFlatMHABackend(), FakeMHAPool(), [], True),
-            (FakeFlatMHABackend(), FakeMambaPool(), [], False),
+            (FakeV4StyleBackend(), FakeV4Pool(), [FakeGroup()], None),
+            (FakeFlatMHABackend(), FakeMHAPool(), [], "EAGLE3"),
+            (FakeSpecIncapableBackend(), FakeMHAPool(), [FakeGroup()], "EAGLE3"),
+            (FakeFlatMHABackend(), FakeMambaPool(), [], "DFLASH"),
         ):
             _pcs.validate_flat_scheduler_config(
                 flat_kvcache_ext=False,
                 paged_cache_groups=groups,
                 attn_backend=backend,
                 kv_pool=pool,
-                speculative_enabled=spec,
+                speculative_algorithm=spec,
+            )
+
+    def test_flat_ext_spec_incapable_backend_rejected_under_spec(self):
+        # Without this guard the server would crash on the backend's
+        # capture/forward spec assert instead of failing at startup.
+        with self.assertRaisesRegex(RuntimeError, "speculative decoding"):
+            _pcs.validate_flat_scheduler_config(
+                flat_kvcache_ext=True,
+                paged_cache_groups=[FakeGroup()],
+                attn_backend=FakeSpecIncapableBackend(),
+                kv_pool=FakeMHAPool(),
+                speculative_algorithm="EAGLE3",
+            )
+
+    def test_flat_ext_spec_incapable_backend_passes_without_spec(self):
+        _pcs.validate_flat_scheduler_config(
+            flat_kvcache_ext=True,
+            paged_cache_groups=[FakeGroup()],
+            attn_backend=FakeSpecIncapableBackend(),
+            kv_pool=FakeMHAPool(),
+            speculative_algorithm=None,
+        )
+
+    def test_flat_ext_spec_capable_backend_passes_under_spec(self):
+        _pcs.validate_flat_scheduler_config(
+            flat_kvcache_ext=True,
+            paged_cache_groups=[FakeGroup()],
+            attn_backend=FakeFlatMHABackend(),
+            kv_pool=FakeMHAPool(),
+            speculative_algorithm="EAGLE3",
+        )
+
+    def test_flat_ext_dflash_rejected_even_on_capable_backend(self):
+        # DFLASH block decode stays asserted-out in the backends.
+        with self.assertRaisesRegex(RuntimeError, "DFLASH"):
+            _pcs.validate_flat_scheduler_config(
+                flat_kvcache_ext=True,
+                paged_cache_groups=[FakeGroup()],
+                attn_backend=FakeFlatMHABackend(),
+                kv_pool=FakeMHAPool(),
+                speculative_algorithm="DFLASH",
             )
 
     def test_backend_without_flags_single_group_falls_back(self):
@@ -170,7 +220,7 @@ class ValidateFlatSchedulerConfigTest(unittest.TestCase):
             paged_cache_groups=[FakeGroup()],
             attn_backend=LegacyBackend(),
             kv_pool=FakeMHAPool(),
-            speculative_enabled=False,
+            speculative_algorithm=None,
         )
 
     def test_backend_without_flags_multi_group_rejected(self):
@@ -186,7 +236,7 @@ class ValidateFlatSchedulerConfigTest(unittest.TestCase):
                 paged_cache_groups=[FakeGroup(), FakeGroup()],
                 attn_backend=LegacyBackend(),
                 kv_pool=FakeMHAPool(),
-                speculative_enabled=False,
+                speculative_algorithm=None,
             )
 
     def test_hybrid_with_flat_capable_full_sub_backend_passes(self):
@@ -212,7 +262,7 @@ class ValidateFlatSchedulerConfigTest(unittest.TestCase):
             paged_cache_groups=[FakeGroup(), FakeGroup()],
             attn_backend=FlatWrapper(),
             kv_pool=FakeMHAPool(),
-            speculative_enabled=False,
+            speculative_algorithm=None,
         )
 
     def test_hybrid_full_sub_backend_recursed(self):
@@ -235,7 +285,7 @@ class ValidateFlatSchedulerConfigTest(unittest.TestCase):
                 paged_cache_groups=[FakeGroup(), FakeGroup()],
                 attn_backend=FlatWrapper(LegacyFull()),
                 kv_pool=FakeMHAPool(),
-                speculative_enabled=False,
+                speculative_algorithm=None,
             )
 
 

--- a/test/runtime/test_mha_pool_spec_decode_groups.py
+++ b/test/runtime/test_mha_pool_spec_decode_groups.py
@@ -1,9 +1,10 @@
-"""MHA pool paged-cache group publication vs ext build flavor + spec decode.
+"""MHA pool paged-cache group publication vs ext build flavor.
 
 Rule under test (kv_cache/mha.py): the pool publishes
 paged_cache_group_specs iff the tokenspeed_scheduler ext is flat-built
-(TOKENSPEED_FLAT_KVCACHE) AND speculative decoding is off; radix builds and
-spec decode publish nothing.
+(TOKENSPEED_FLAT_KVCACHE); radix builds publish nothing. Speculative
+decoding does not gate publication (flat+spec is supported); backend
+capability is checked separately by validate_flat_scheduler_config.
 
 The installed ext's real build flavor must not decide these tests, so the
 scheduler_ext_flat_kvcache probe is patched per case; the probe's own
@@ -16,7 +17,6 @@ import os
 import sys
 import types
 import unittest
-from types import SimpleNamespace
 from unittest import mock
 
 # CI Registration (parsed via AST, runtime no-op)
@@ -98,22 +98,6 @@ class MHAPoolGroupPublicationTest(unittest.TestCase):
             {"full_attention", "sliding_attention"},
         )
 
-    def test_spec_decode_plain_publishes_no_groups(self):
-        # Publishing under spec decode would trip the backend's capture
-        # assert and silently disable overlap scheduling.
-        pool = self._pool(speculative_enabled=True)
-        self.assertEqual(pool.paged_cache_group_specs, ())
-        self.assertEqual(pool.paged_cache_group_page_counts, {})
-
-    def test_spec_decode_hybrid_publishes_no_groups(self):
-        pool = self._pool(
-            layer_types=GPT_OSS_LAYER_TYPES,
-            sliding_window_tokens=128,
-            speculative_enabled=True,
-        )
-        self.assertEqual(pool.paged_cache_group_specs, ())
-        self.assertEqual(pool.paged_cache_group_page_counts, {})
-
     def test_radix_ext_plain_publishes_no_groups(self):
         # A radix scheduler never fills flat_block_tables, so publication
         # must stay off or graph capture binds buffers that never refresh.
@@ -127,11 +111,6 @@ class MHAPoolGroupPublicationTest(unittest.TestCase):
             layer_types=GPT_OSS_LAYER_TYPES,
             sliding_window_tokens=128,
         )
-        self.assertEqual(pool.paged_cache_group_specs, ())
-        self.assertEqual(pool.paged_cache_group_page_counts, {})
-
-    def test_radix_ext_with_spec_decode_publishes_no_groups(self):
-        pool = self._pool(flat_ext=False, speculative_enabled=True)
         self.assertEqual(pool.paged_cache_group_specs, ())
         self.assertEqual(pool.paged_cache_group_page_counts, {})
 
@@ -174,66 +153,6 @@ class SchedulerExtFlatKvcacheProbeTest(unittest.TestCase):
         # sys.modules[name] = None makes `import name` raise ImportError.
         with mock.patch.dict(sys.modules, {"tokenspeed_scheduler": None}):
             self.assertFalse(self.probe())
-
-
-class MHAConfigSpecSignalTest(unittest.TestCase):
-    """MHAConfig.generate derives speculative_enabled from
-    server_args.speculative_algorithm — the same authoritative signal the
-    scheduler config (event_loop) and should_use_overlap_schedule read."""
-
-    def setUp(self):
-        try:
-            from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
-        except (ImportError, ModuleNotFoundError) as exc:
-            self.skipTest(f"needs torch: {exc}")
-        self.MHAConfig = MHAConfig
-
-    def _server_args(self, speculative_algorithm):
-        return SimpleNamespace(
-            device="cpu",
-            speculative_algorithm=speculative_algorithm,
-            speculative_num_steps=3,
-            speculative_num_draft_tokens=4,
-            attention_backend="mha",
-            drafter_attention_backend="mha",
-            attn_tp_size=1,
-            mapping=SimpleNamespace(attn=SimpleNamespace(tp_size=1, dp_size=1)),
-            kv_cache_dtype="bfloat16",
-            block_size=16,
-            max_num_seqs=8,
-            data_parallel_size=1,
-            max_cudagraph_capture_size=4,
-            kv_cache_quant_method="",
-            chunked_prefill_size=512,
-            enable_kvstore=False,
-            disaggregation_mode="null",
-        )
-
-    def _model_config(self):
-        import torch
-
-        return SimpleNamespace(
-            hf_config=SimpleNamespace(layer_types=None, sliding_window=None),
-            context_len=64,
-            num_attention_heads=4,
-            num_key_value_heads=4,
-            head_dim=8,
-            dtype=torch.bfloat16,
-        )
-
-    def test_spec_algorithm_sets_speculative_enabled(self):
-        cfg = self.MHAConfig.generate(
-            self._server_args(speculative_algorithm="EAGLE3"),
-            self._model_config(),
-        )
-        self.assertTrue(cfg.speculative_enabled)
-
-    def test_no_spec_algorithm_leaves_speculative_disabled(self):
-        cfg = self.MHAConfig.generate(
-            self._server_args(speculative_algorithm=None),
-            self._model_config(),
-        )
-        self.assertFalse(cfg.speculative_enabled)
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_trtllm_flat_groups.py
+++ b/test/runtime/test_trtllm_flat_groups.py
@@ -49,6 +49,7 @@ class TRTLLMFlatGroupsTest(unittest.TestCase):
         b.forward_prefill_metadata = None
         b.cuda_graph_prefill_metadata = {}
         b.cuda_graph_decode_metadata = {}
+        b.spec_cache_seqlens_buf = self.torch.zeros(8, dtype=self.torch.int32)
         return b
 
     def _layer(self, group_id):
@@ -58,6 +59,8 @@ class TRTLLMFlatGroupsTest(unittest.TestCase):
 
     def test_flag_declared(self):
         self.assertTrue(self.Backend.uses_flat_cache_groups)
+        # Verify path is wired: the startup guard must not reject flat+spec.
+        self.assertTrue(getattr(self.Backend, "flat_spec_capable", True))
 
     def test_select_page_table_routes_by_group(self):
         b = self._bare_backend()
@@ -186,10 +189,96 @@ class TRTLLMFlatGroupsTest(unittest.TestCase):
             [12 * 64 + 0, 0 * 64 + 0],
         )
 
-    def test_flat_with_spec_asserts(self):
+    def test_verify_metadata_expanded_write_locs(self):
+        # Target verify (spec N, not draft): [bs]-row per-group tables in the
+        # prefill slot + [bs*N] token-major write locs (radix verify layout).
         b = self._bare_backend(spec_num_tokens=4)
+        seq_lens = self.torch.tensor([65, 3], dtype=self.torch.int32)
+        tables = {
+            "full_attention": self.torch.tensor(
+                [[11, 12], [13, -1]], dtype=self.torch.int32
+            ),
+            "sliding_attention": self.torch.tensor(
+                [[21, 22], [23, -1]], dtype=self.torch.int32
+            ),
+        }
+        b.init_forward_metadata(
+            bs=2,
+            req_pool_indices=self.torch.tensor([0, 1], dtype=self.torch.int32),
+            seq_lens=seq_lens,
+            forward_mode=_DecodeMode(),
+            req_to_page=None,
+            flat_block_tables=tables,
+        )
+        meta = b.forward_prefill_metadata
+        self.assertIsNone(meta.page_table)
+        self.assertIs(meta.page_tables, tables)
+        # req0 positions 61..64 (pages 11,11,11,12); req1 clamps 0,0,1,2 (page 13).
+        self.assertEqual(
+            meta.out_cache_locs["full_attention"].tolist(),
+            [11 * 64 + 61, 11 * 64 + 62, 11 * 64 + 63, 12 * 64 + 0]
+            + [13 * 64 + 0, 13 * 64 + 0, 13 * 64 + 1, 13 * 64 + 2],
+        )
+        self.assertEqual(
+            meta.out_cache_locs["sliding_attention"].tolist(),
+            [21 * 64 + 61, 21 * 64 + 62, 21 * 64 + 63, 22 * 64 + 0]
+            + [23 * 64 + 0, 23 * 64 + 0, 23 * 64 + 1, 23 * 64 + 2],
+        )
+        # KV seqlens clamped >= N so padded rows avoid empty causal spans.
+        self.assertEqual(meta.cache_seqlens_int32.tolist(), [65, 4])
+
+    def test_verify_capture_replay_expanded_loc_views(self):
+        b = self._bare_backend(spec_num_tokens=4)
+        max_bs, bs = 4, 2
+        b._init_flat_graph_buffers(max_bs)
+        b.cuda_graph_cache_seqlens = self.torch.ones(max_bs, dtype=self.torch.int32)
+        b.init_forward_metadata_capture_cuda_graph(
+            bs,
+            req_pool_indices=self.torch.tensor([0, 1], dtype=self.torch.int32),
+            seq_lens=b.cuda_graph_cache_seqlens[:bs],
+            forward_mode=_DecodeMode(),
+            flat_cache_group_ids=("full_attention",),
+        )
+        meta = b.cuda_graph_prefill_metadata[bs]
+        self.assertIsNone(meta.page_table)
+        self.assertEqual(meta.out_cache_locs["full_attention"].shape[0], bs * 4)
+        # Replay refreshes tables and recomputes [bs*N] locs from live lens.
+        b.cuda_graph_cache_seqlens[:bs] = self.torch.tensor(
+            [65, 1], dtype=self.torch.int32
+        )
+        src = {
+            "full_attention": self.torch.tensor(
+                [[11, 12], [0, -1]], dtype=self.torch.int32
+            )
+        }
+        b.init_forward_metadata_replay_cuda_graph(
+            bs,
+            req_pool_indices=self.torch.tensor([0, 1], dtype=self.torch.int32),
+            seq_lens=b.cuda_graph_cache_seqlens,
+            forward_mode=_DecodeMode(),
+            flat_block_tables=src,
+        )
+        locs = b.cuda_graph_flat_out_cache_locs["full_attention"][: bs * 4]
+        self.assertEqual(
+            locs.tolist(),
+            [11 * 64 + 61, 11 * 64 + 62, 11 * 64 + 63, 12 * 64 + 0] + [0, 0, 0, 0],
+        )
+
+    def test_prewrite_metadata_routes_verify_to_prefill_slot(self):
+        b = self._bare_backend(spec_num_tokens=4)
+        prefill, decode = self.Metadata(), self.Metadata()
+        b.forward_prefill_metadata, b.forward_decode_metadata = prefill, decode
+        # Target verify is DECODE mode; its metadata lives in the prefill slot.
+        self.assertIs(b._prewrite_metadata(_DecodeMode()), prefill)
+        b.is_draft = True
+        self.assertIs(b._prewrite_metadata(_DecodeMode()), decode)
+
+    def test_flat_with_dflash_asserts(self):
+        b = self._bare_backend(spec_num_tokens=4)
+        b.is_draft = True
+        b.draft_block_decode = True
         tables = {"full_attention": self.torch.zeros((1, 1), dtype=self.torch.int32)}
-        with self.assertRaisesRegex(AssertionError, "spec_num_tokens"):
+        with self.assertRaisesRegex(AssertionError, "DFLASH"):
             b.init_forward_metadata(
                 bs=1,
                 req_pool_indices=self.torch.tensor([0], dtype=self.torch.int32),

--- a/test/runtime/test_unified_kv_slab_pool.py
+++ b/test/runtime/test_unified_kv_slab_pool.py
@@ -3,8 +3,8 @@ KV slab pool (M12), and its two consumers (registry sizing divisor and
 MHATokenToKVPool buffer layout).
 
 The predicate returns the common layers-per-group count exactly when the
-slab layout may activate (flat ext, no spec decode, >= 2 equal-size known
-groups) and None otherwise (legacy per-layer layout). The installed ext's
+slab layout may activate (flat ext, >= 2 equal-size known groups) and None
+otherwise (legacy per-layer layout). The installed ext's
 real build flavor must not decide these tests, so the
 scheduler_ext_flat_kvcache probe is patched per case.
 """
@@ -67,47 +67,35 @@ class HybridSlabGroupSizeTest(unittest.TestCase):
         # gpt-oss: 12 sliding + 12 full, alternating -> 12 layers per group.
         with self._flat_ext(True):
             self.assertEqual(
-                hybrid_slab_group_size(GPT_OSS_LAYER_TYPES, speculative_enabled=False),
+                hybrid_slab_group_size(GPT_OSS_LAYER_TYPES),
                 12,
             )
 
     def test_none_when_radix_ext(self):
         with self._flat_ext(False):
-            self.assertIsNone(
-                hybrid_slab_group_size(GPT_OSS_LAYER_TYPES, speculative_enabled=False)
-            )
-
-    def test_none_when_speculative(self):
-        with self._flat_ext(True):
-            self.assertIsNone(
-                hybrid_slab_group_size(GPT_OSS_LAYER_TYPES, speculative_enabled=True)
-            )
+            self.assertIsNone(hybrid_slab_group_size(GPT_OSS_LAYER_TYPES))
 
     def test_none_when_single_group(self):
         with self._flat_ext(True):
-            self.assertIsNone(
-                hybrid_slab_group_size(
-                    ("full_attention",) * 24, speculative_enabled=False
-                )
-            )
+            self.assertIsNone(hybrid_slab_group_size(("full_attention",) * 24))
 
     def test_none_when_unequal_groups(self):
         lt = ("sliding_attention",) * 8 + ("full_attention",) * 16
         with self._flat_ext(True):
-            self.assertIsNone(hybrid_slab_group_size(lt, speculative_enabled=False))
+            self.assertIsNone(hybrid_slab_group_size(lt))
 
     def test_none_when_unknown_label(self):
         # Unknown input degrades to None (safe legacy layout), never raises;
         # loud rejection is group_specs_from_layer_types' job.
         lt = GPT_OSS_LAYER_TYPES + ("banana_attention",)
         with self._flat_ext(True):
-            self.assertIsNone(hybrid_slab_group_size(lt, speculative_enabled=False))
+            self.assertIsNone(hybrid_slab_group_size(lt))
 
     def test_none_when_empty(self):
         # Plain models pass empty or None layer_types.
         with self._flat_ext(True):
-            self.assertIsNone(hybrid_slab_group_size((), speculative_enabled=False))
-            self.assertIsNone(hybrid_slab_group_size(None, speculative_enabled=False))
+            self.assertIsNone(hybrid_slab_group_size(()))
+            self.assertIsNone(hybrid_slab_group_size(None))
 
     def test_none_when_multi_window_sequence(self):
         # 多种 sliding window:保守退 legacy(M14 spec §2.3)。
@@ -120,7 +108,6 @@ class HybridSlabGroupSizeTest(unittest.TestCase):
             self.assertIsNone(
                 hybrid_slab_group_size(
                     GPT_OSS_LAYER_TYPES,
-                    speculative_enabled=False,
                     sliding_window_tokens=windows,
                 )
             )
@@ -133,7 +120,6 @@ class HybridSlabGroupSizeTest(unittest.TestCase):
             self.assertEqual(
                 hybrid_slab_group_size(
                     GPT_OSS_LAYER_TYPES,
-                    speculative_enabled=False,
                     sliding_window_tokens=windows,
                 ),
                 12,
@@ -144,7 +130,6 @@ class HybridSlabGroupSizeTest(unittest.TestCase):
             self.assertEqual(
                 hybrid_slab_group_size(
                     GPT_OSS_LAYER_TYPES,
-                    speculative_enabled=False,
                     sliding_window_tokens=128,
                 ),
                 12,
@@ -156,7 +141,6 @@ class HybridSlabGroupSizeTest(unittest.TestCase):
             self.assertIsNone(
                 hybrid_slab_group_size(
                     GPT_OSS_LAYER_TYPES,
-                    speculative_enabled=False,
                     sliding_window_tokens=[128],
                 )
             )
@@ -167,7 +151,6 @@ class HybridSlabGroupSizeTest(unittest.TestCase):
             self.assertEqual(
                 hybrid_slab_group_size(
                     GPT_OSS_LAYER_TYPES,
-                    speculative_enabled=False,
                     sliding_window_tokens=["a"] * len(GPT_OSS_LAYER_TYPES),
                 ),
                 12,
@@ -203,27 +186,14 @@ class KvProfileLayerDivisorTest(unittest.TestCase):
         # 24 layers, 12+12 alternating -> charge 12 (per-token bytes halve).
         with self._pkg_flat_ext(True):
             self.assertEqual(
-                self._registry._kv_profile_layer_divisor(
-                    24, GPT_OSS_LAYER_TYPES, speculative_enabled=False
-                ),
+                self._registry._kv_profile_layer_divisor(24, GPT_OSS_LAYER_TYPES),
                 12,
             )
 
     def test_all_layers_when_radix_ext(self):
         with self._pkg_flat_ext(False):
             self.assertEqual(
-                self._registry._kv_profile_layer_divisor(
-                    24, GPT_OSS_LAYER_TYPES, speculative_enabled=False
-                ),
-                24,
-            )
-
-    def test_all_layers_when_speculative(self):
-        with self._pkg_flat_ext(True):
-            self.assertEqual(
-                self._registry._kv_profile_layer_divisor(
-                    24, GPT_OSS_LAYER_TYPES, speculative_enabled=True
-                ),
+                self._registry._kv_profile_layer_divisor(24, GPT_OSS_LAYER_TYPES),
                 24,
             )
 
@@ -231,15 +201,11 @@ class KvProfileLayerDivisorTest(unittest.TestCase):
         # () from MHAConfig's default, None from MLA configs via getattr.
         with self._pkg_flat_ext(True):
             self.assertEqual(
-                self._registry._kv_profile_layer_divisor(
-                    24, (), speculative_enabled=False
-                ),
+                self._registry._kv_profile_layer_divisor(24, ()),
                 24,
             )
             self.assertEqual(
-                self._registry._kv_profile_layer_divisor(
-                    24, None, speculative_enabled=False
-                ),
+                self._registry._kv_profile_layer_divisor(24, None),
                 24,
             )
 
@@ -256,7 +222,6 @@ class KvProfileLayerDivisorTest(unittest.TestCase):
                 self._registry._kv_profile_layer_divisor(
                     24,
                     GPT_OSS_LAYER_TYPES,
-                    speculative_enabled=False,
                     sliding_window_tokens=windows,
                 ),
                 24,
@@ -271,7 +236,6 @@ class KvProfileLayerDivisorTest(unittest.TestCase):
                 self._registry._kv_profile_layer_divisor(
                     24,
                     GPT_OSS_LAYER_TYPES,
-                    speculative_enabled=False,
                     sliding_window_tokens=windows,
                 ),
                 12,
@@ -360,7 +324,6 @@ class MHAPoolSlabLayoutTest(unittest.TestCase):
     def test_fallback_matrix_keeps_24_buffers(self):
         cases = dict(
             radix_ext=dict(flat_ext=False),
-            spec_decode=dict(speculative_enabled=True),
             single_group=dict(
                 layer_types=("full_attention",) * 24,
                 sliding_window_tokens=None,


### PR DESCRIPTION
## What

Enables speculative decoding on the flat KV-cache path. `publish_paged_cache_groups` and `hybrid_slab_group_size` no longer gate on `speculative_enabled`: a flat-built ext serves EAGLE3/MTP through the per-group tables, with the slab layout (and its capacity gain) active. **Radix builds are untouched** — both gates still key on `scheduler_ext_flat_kvcache()`, so a radix ext publishes nothing and every flat branch stays dormant, spec or not.

## How

- **Verify path**: the spec target writes `spec_num_tokens` tokens per request per step; the flat write-location computation generalizes from one loc per request to a token-major `[bs*N]` batch, in eager and CUDA-graph capture/replay (page tables stay `[bs]`-row; only the loc views expand). DFLASH block decode remains unsupported on flat (asserted).
- **Drafter**: the EAGLE head is dense and shares the target's page-id space, so it consumes the target **full-attention group's** table: the graph wrapper feeds that subset to the draft backend (eager/capture/replay/extend), and the model executor mirrors the same table into `req_to_page` each step so the drafter's per-step location kernel and input prep keep their radix-era contract unchanged.
- **Draft decode chains keep caller-computed per-step locations** (`prefer_caller`); the metadata's single decode location would pin every draft step to one slot.

## Bugs found on the way (all fixed in this PR)

1. Draft per-step write locations were overridden by the metadata's static decode location — every draft step wrote the same slot.
2. `out_cache_loc_buf` gathered from the never-populated `req_to_page` on flat builds — garbage draft step-0 locations (fixed by the mirror).
3. Mixed advanced-index setitem (`t[idx, :w] = x`) costs ~150us of dispatch per call — replaced with staged rows + `index_copy_` (~13us); this alone was a 12% single-stream decode regression.
4. The marshalled tables pad column tails with `-1` (per-batch max width); mirroring them verbatim turned into negative write locations under mixed-length concurrent batches → illegal memory access. The mirror clamps to the dummy page 0.

## Validation (gpt-oss-120b + nvidia/gpt-oss-120b-Eagle3-long-context, B200)

| Check | Result |
|---|---|
| Correctness (passkey past the sliding window, long generations, graphs on) | pass |
| Acceptance | **digit-identical trajectories** to the radix arm on a fixed prompt battery |
| Single-stream decode | 229.5 vs 229.8 tok/s (5 interleaved rounds); nsys shows ~2% residual prep cost (29 small ops/round, batchable) |
| Concurrency stress (shared_prefix, rate 8, conc 32) | 10 min, 4692/4692 completed, zero errors; server healthy after (previously fatal <1 min) |
| Unit tests | 112 pass; spec-gating tests flipped to the new semantics |

## Follow-ups (not in this PR)

- Batch the per-group replay-prep ops (reclaims the ~2% residual; existing flat-perf TODO).
- trtllm backend spec support on flat (MHA-family only for now).
- DFLASH block decode on flat.