### PR TITLE
feat(multimodal): support ASR and Omni thinker

### DIFF
--- a/python/tokenspeed/runtime/configs/__init__.py
+++ b/python/tokenspeed/runtime/configs/__init__.py
@@ -26,6 +26,11 @@ from tokenspeed.runtime.configs.kimi_k25_config import KimiK25Config
 from tokenspeed.runtime.configs.minimax_m2_config import MiniMaxM2Config
 from tokenspeed.runtime.configs.qwen2_config import Qwen2Config
 from tokenspeed.runtime.configs.qwen3_5_config import Qwen3_5Config, Qwen3_5MoeConfig
+from tokenspeed.runtime.configs.qwen3_asr_config import (
+    Qwen3ASRAudioEncoderConfig,
+    Qwen3ASRConfig,
+    Qwen3ASRThinkerConfig,
+)
 from tokenspeed.runtime.configs.qwen3_config import Qwen3Config
 from tokenspeed.runtime.configs.qwen3_moe_config import Qwen3MoeConfig
 
@@ -36,6 +41,9 @@ __all__ = [
     "Qwen3MoeConfig",
     "Qwen3_5Config",
     "Qwen3_5MoeConfig",
+    "Qwen3ASRAudioEncoderConfig",
+    "Qwen3ASRConfig",
+    "Qwen3ASRThinkerConfig",
     "MiniMaxM2Config",
     "KimiK2Config",
     "KimiK25Config",

--- a/python/tokenspeed/runtime/configs/model_config.py
+++ b/python/tokenspeed/runtime/configs/model_config.py
@@ -364,6 +364,11 @@ class ModelConfig:
                 "disaggregation_mode=encode (encoder-only) and language_model_only "
                 "are mutually exclusive."
             )
+        if encoder_only and self.is_audio_model:
+            raise ValueError(
+                "disaggregation_mode=encode does not support audio models; "
+                "only image/video encoders are currently supported."
+            )
         if encoder_only:
             # Single model-facing gate: Kimi reads hf_config.encoder_only directly;
             # Qwen3_5ForConditionalGeneration reads it to skip LM construction.
@@ -625,6 +630,11 @@ def get_hf_text_config(config: PretrainedConfig):
         config.dtype = torch.float16
         return config
 
+    if hasattr(config, "thinker_config"):
+        thinker_config = config.thinker_config
+        if hasattr(thinker_config, "text_config"):
+            return thinker_config.text_config
+        return thinker_config
     if hasattr(config, "text_config"):
         if not hasattr(config.text_config, "num_attention_heads"):
             raise ValueError("text_config must define num_attention_heads")
@@ -699,6 +709,8 @@ def is_multimodal_model(model_architectures: list[str] | None):
     multimodal_architectures = {
         "Qwen3_5ForConditionalGeneration",
         "Qwen3_5MoeForConditionalGeneration",
+        "Qwen3OmniMoeForConditionalGeneration",
+        "Qwen3ASRForConditionalGeneration",
         "KimiK25ForConditionalGeneration",
     }
     return any(arch in multimodal_architectures for arch in model_architectures or [])
@@ -712,8 +724,12 @@ def is_image_gen_model(model_architectures: list[str]):
     return False
 
 
-def is_audio_model(model_architectures: list[str]):
-    return False
+def is_audio_model(model_architectures: list[str] | None):
+    audio_architectures = {
+        "Qwen3OmniMoeForConditionalGeneration",
+        "Qwen3ASRForConditionalGeneration",
+    }
+    return any(arch in audio_architectures for arch in model_architectures or [])
 
 
 def yarn_get_mscale(scale: float = 1, mscale: float = 1) -> float:

--- a/python/tokenspeed/runtime/configs/qwen3_asr_config.py
+++ b/python/tokenspeed/runtime/configs/qwen3_asr_config.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Qwen3-ASR nested configuration definitions.
+
+Transformers 5.12 contains the shared Qwen3-Omni audio architecture but does
+not yet register ``model_type: qwen3_asr``.  These small wrappers preserve the
+official checkpoint's ``thinker_config`` shape while reusing TokenSpeed's
+Qwen3 text configuration.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from transformers import PretrainedConfig
+
+from tokenspeed.runtime.configs.qwen3_config import Qwen3Config
+
+
+class Qwen3ASRAudioEncoderConfig(PretrainedConfig):
+    """Qwen3 audio tower configuration shipped by Qwen3-ASR."""
+
+    model_type = "qwen3_asr_audio_encoder"
+    base_config_key = "audio_config"
+    attribute_map = {
+        "num_hidden_layers": "encoder_layers",
+        "hidden_size": "d_model",
+        "num_attention_heads": "encoder_attention_heads",
+        "intermediate_size": "encoder_ffn_dim",
+    }
+
+    def __init__(
+        self,
+        *,
+        num_mel_bins: int = 128,
+        encoder_layers: int = 24,
+        encoder_attention_heads: int = 16,
+        encoder_ffn_dim: int = 4096,
+        d_model: int = 1024,
+        dropout: float = 0.0,
+        attention_dropout: float = 0.0,
+        activation_function: str = "gelu",
+        activation_dropout: float = 0.0,
+        scale_embedding: bool = False,
+        initializer_range: float = 0.02,
+        max_source_positions: int = 1500,
+        n_window: int = 50,
+        n_window_infer: int = 800,
+        conv_chunksize: int = 500,
+        downsample_hidden_size: int = 480,
+        output_dim: int = 2048,
+        **kwargs: Any,
+    ) -> None:
+        self.num_mel_bins = num_mel_bins
+        self.encoder_layers = encoder_layers
+        self.encoder_attention_heads = encoder_attention_heads
+        self.encoder_ffn_dim = encoder_ffn_dim
+        self.d_model = d_model
+        self.dropout = dropout
+        self.attention_dropout = attention_dropout
+        self.activation_function = activation_function
+        self.activation_dropout = activation_dropout
+        self.scale_embedding = scale_embedding
+        self.initializer_range = initializer_range
+        self.max_source_positions = max_source_positions
+        self.n_window = n_window
+        self.n_window_infer = n_window_infer
+        self.conv_chunksize = conv_chunksize
+        self.downsample_hidden_size = downsample_hidden_size
+        self.output_dim = output_dim
+        super().__init__(**kwargs)
+
+
+class Qwen3ASRThinkerConfig(PretrainedConfig):
+    """Audio/text thinker configuration nested below the outer ASR config."""
+
+    model_type = "qwen3_asr_thinker"
+    base_config_key = "thinker_config"
+    keys_to_ignore_at_inference = ["past_key_values"]
+    sub_configs = {
+        "audio_config": Qwen3ASRAudioEncoderConfig,
+        "text_config": Qwen3Config,
+    }
+
+    def __init__(
+        self,
+        *,
+        audio_config: dict[str, Any] | Qwen3ASRAudioEncoderConfig | None = None,
+        text_config: dict[str, Any] | Qwen3Config | None = None,
+        audio_start_token_id: int = 151669,
+        audio_end_token_id: int = 151670,
+        audio_token_id: int = 151676,
+        initializer_range: float = 0.02,
+        **kwargs: Any,
+    ) -> None:
+        self.audio_config = self._ensure_audio_config(audio_config)
+        self.text_config = self._ensure_text_config(text_config)
+        self.audio_start_token_id = audio_start_token_id
+        self.audio_end_token_id = audio_end_token_id
+        self.audio_token_id = audio_token_id
+        self.initializer_range = initializer_range
+        super().__init__(**kwargs)
+
+    @staticmethod
+    def _ensure_audio_config(
+        config: dict[str, Any] | Qwen3ASRAudioEncoderConfig | None,
+    ) -> Qwen3ASRAudioEncoderConfig:
+        if isinstance(config, Qwen3ASRAudioEncoderConfig):
+            return config
+        return Qwen3ASRAudioEncoderConfig(**(config or {}))
+
+    @staticmethod
+    def _ensure_text_config(
+        config: dict[str, Any] | Qwen3Config | None,
+    ) -> Qwen3Config:
+        if isinstance(config, Qwen3Config):
+            return config
+        return Qwen3Config(**(config or {}))
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == "audio_config" and isinstance(value, dict):
+            value = self._ensure_audio_config(value)
+        elif name == "text_config" and isinstance(value, dict):
+            value = self._ensure_text_config(value)
+        super().__setattr__(name, value)
+
+    def get_text_config(self, *args: Any, **kwargs: Any) -> Qwen3Config:
+        return self.text_config
+
+
+class Qwen3ASRConfig(PretrainedConfig):
+    """Outer config matching ``Qwen/Qwen3-ASR-*`` config.json files."""
+
+    model_type = "qwen3_asr"
+    keys_to_ignore_at_inference = ["past_key_values"]
+    sub_configs = {"thinker_config": Qwen3ASRThinkerConfig}
+
+    def __init__(
+        self,
+        *,
+        thinker_config: dict[str, Any] | Qwen3ASRThinkerConfig | None = None,
+        support_languages: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.thinker_config = self._ensure_thinker_config(thinker_config)
+        self.support_languages = list(support_languages or [])
+        super().__init__(**kwargs)
+
+    @staticmethod
+    def _ensure_thinker_config(
+        config: dict[str, Any] | Qwen3ASRThinkerConfig | None,
+    ) -> Qwen3ASRThinkerConfig:
+        if isinstance(config, Qwen3ASRThinkerConfig):
+            return config
+        return Qwen3ASRThinkerConfig(**(config or {}))
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == "thinker_config" and isinstance(value, dict):
+            value = self._ensure_thinker_config(value)
+        super().__setattr__(name, value)
+
+    def get_text_config(self, *args: Any, **kwargs: Any) -> Qwen3Config:
+        return self.thinker_config.text_config
+
+    @property
+    def audio_config(self) -> Qwen3ASRAudioEncoderConfig:
+        return self.thinker_config.audio_config
+
+    @property
+    def audio_start_token_id(self) -> int:
+        return self.thinker_config.audio_start_token_id
+
+    @property
+    def audio_end_token_id(self) -> int:
+        return self.thinker_config.audio_end_token_id
+
+    @property
+    def audio_token_id(self) -> int:
+        return self.thinker_config.audio_token_id
+
+
+__all__ = [
+    "Qwen3ASRAudioEncoderConfig",
+    "Qwen3ASRConfig",
+    "Qwen3ASRThinkerConfig",
+]

--- a/python/tokenspeed/runtime/engine/input_processor.py
+++ b/python/tokenspeed/runtime/engine/input_processor.py
@@ -141,7 +141,7 @@ class InputProcessor:
             # built by an upstream preprocessor and the input_ids carry the
             # expanded placeholder tokens (im_token_id) at the right offsets.
             # We still need to run pad_input_tokens so the engine's
-            # VisionEmbedder can plan vision-token scatter ranges from each
+            # MultimodalEmbedder can plan encoder-token scatter ranges from each
             # item's offsets — the bare placeholder token alone would not
             # encode per-item uniqueness needed by the radix prefix layer.
             if not self.engine.model_config.is_multimodal_active:

--- a/python/tokenspeed/runtime/layers/attention/mm_encoder_attention.py
+++ b/python/tokenspeed/runtime/layers/attention/mm_encoder_attention.py
@@ -18,10 +18,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Cache-less multi-headed attention used by VLM vision encoders.
+"""Cache-less multi-headed attention used by multimodal encoders.
 
-Encode-only attention layer used by Qwen3.5-VL / Kimi-K2.5-VL vision towers,
-plus its backend dispatch table. Backends are free functions (not
+Encode-only attention layer used by vision and audio towers, plus its backend
+dispatch table. Backends are free functions (not
 ``AttentionBackend`` subclasses) because the vision encoder is single-shot
 with no KV cache, no decode/extend split, and no graph capture protocol --
 the ``AttentionBackend`` ABC's prefill/decode/extend lifecycle does not
@@ -73,7 +73,7 @@ from tokenspeed_kernel.ops.attention.triton.qkv_rotary import (
 # CUDA-graph bucketing for the cuDNN vision prefill backend: batch and max
 # seqlen are quantized so a small set of captured graphs covers the request
 # distribution. The consts are consumed by VLM tower models, not by
-# ``VisionAttention`` itself.
+# ``MultimodalEncoderAttention`` itself.
 VIT_CUDNN_WORKSPACE_BYTES = 128 * 1024 * 1024
 VIT_CUDNN_BATCH_BUCKETS: tuple[int, ...] = (8, 16, 32, 64)
 VIT_CUDNN_SEQLEN_BUCKETS: tuple[int, ...] = (4096, 8192, 16384, 32768, 65536, 131072)
@@ -299,7 +299,7 @@ _BACKENDS: dict[str, Callable[..., torch.Tensor]] = {
 }
 
 
-def _default_vision_attn_backend() -> str:
+def _default_multimodal_encoder_attn_backend() -> str:
     """Platform default backend name."""
     if _is_nvidia:
         if _platform.arch_version.major == 9:  # Hopper SM90
@@ -310,7 +310,7 @@ def _default_vision_attn_backend() -> str:
     if _is_amd:
         return "triton_attn"
     raise RuntimeError(
-        f"No default vision attention backend for platform {_platform}; "
+        f"No default multimodal encoder attention backend for platform {_platform}; "
         "set --mm-attention-backend explicitly."
     )
 
@@ -325,27 +325,29 @@ def _resolve_backend(name: str | None) -> Callable[..., torch.Tensor]:
     """
     explicit = name is not None
     if name is None:
-        name = _default_vision_attn_backend()
+        name = _default_multimodal_encoder_attn_backend()
     fn = _BACKENDS.get(name)
     if fn is None:
         raise ValueError(
-            f"Unknown vision attention backend {name!r} "
+            f"Unknown multimodal encoder attention backend {name!r} "
             f"(check --mm-attention-backend); available: {sorted(_BACKENDS)}"
         )
     if name in ("fa3", "fa4", "flashinfer_cudnn") and not _is_nvidia:
         raise ValueError(
-            f"vision attention backend {name!r} is only available on NVIDIA CUDA"
+            f"multimodal encoder attention backend {name!r} is only available "
+            "on NVIDIA CUDA"
         )
     if name == "fa3" and _platform.is_blackwell:
         raise ValueError("The 'fa3' backend is not supported on Blackwell GPUs")
     logger.info(
-        f"vision attention backend: {name} ({'override' if explicit else 'auto'})"
+        f"multimodal encoder attention backend: {name} "
+        f"({'override' if explicit else 'auto'})"
     )
     return fn
 
 
-class VisionAttention(nn.Module):
-    r"""Multi-headed attention without any cache, mostly used for multimodal transformers."""
+class MultimodalEncoderAttention(nn.Module):
+    r"""Multi-headed attention without a KV cache for multimodal encoders."""
 
     def __init__(
         self,
@@ -552,3 +554,7 @@ class VisionAttention(nn.Module):
         output, _ = self.proj(output)
 
         return output
+
+
+# Compatibility alias for existing vision tower implementations.
+VisionAttention = MultimodalEncoderAttention

--- a/python/tokenspeed/runtime/models/qwen3_asr.py
+++ b/python/tokenspeed/runtime/models/qwen3_asr.py
@@ -1,0 +1,274 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Inference-only Qwen3-ASR model compatible with Hugging Face weights."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+from torch import nn
+
+from tokenspeed.runtime.distributed.mapping import Mapping
+from tokenspeed.runtime.layers.quantization.base_config import QuantizationConfig
+from tokenspeed.runtime.model_loader.weight_utils import default_weight_loader
+from tokenspeed.runtime.models.qwen3 import Qwen3ForCausalLM
+from tokenspeed.runtime.models.qwen3_audio import Qwen3AudioEncoder
+from tokenspeed.runtime.multimodal.embedder import (
+    EncoderSpec,
+    MultimodalEmbedder,
+    pad_input_tokens,
+)
+from tokenspeed.runtime.multimodal.inputs import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from tokenspeed.runtime.utils import add_prefix
+
+
+class Qwen3ASRForConditionalGeneration(nn.Module):
+    """Qwen3 dense language model plus the shared Qwen audio tower."""
+
+    default_bitsandbytes_target_modules = [
+        ".gate_proj.",
+        ".down_proj.",
+        ".up_proj.",
+        ".q_proj.",
+        ".k_proj.",
+        ".v_proj.",
+        ".o_proj.",
+    ]
+    bitsandbytes_stacked_params_mapping = {
+        "q_proj": ("qkv_proj", 0),
+        "k_proj": ("qkv_proj", 1),
+        "v_proj": ("qkv_proj", 2),
+        "gate_proj": ("gate_up_proj", 0),
+        "up_proj": ("gate_up_proj", 1),
+    }
+
+    def __init__(
+        self,
+        config: Any,
+        mapping: Mapping,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        is_multimodal_active: bool = True,
+        mm_attention_backend: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.mapping = mapping
+        self.quant_config = quant_config
+        self.is_multimodal_active = is_multimodal_active
+
+        thinker_config = getattr(config, "thinker_config", config)
+        self.thinker_config = thinker_config
+        text_config = thinker_config.text_config
+        audio_config = getattr(thinker_config, "audio_config", None)
+        if audio_config is None:
+            raise ValueError("Qwen3-ASR config is missing thinker_config.audio_config")
+        if int(audio_config.output_dim) != int(text_config.hidden_size):
+            raise ValueError(
+                "audio output_dim must match the language hidden_size: "
+                f"{audio_config.output_dim} != {text_config.hidden_size}"
+            )
+
+        # Qwen3ForCausalLM currently owns the model/lm_head prefixes internally;
+        # nesting it under this attribute yields the desired runtime parameter
+        # names (language_model.model.*, language_model.lm_head.*).
+        self.language_model = Qwen3ForCausalLM(
+            text_config,
+            mapping=mapping,
+            quant_config=quant_config,
+        )
+        if is_multimodal_active:
+            self.audio_tower = Qwen3AudioEncoder(
+                audio_config,
+                mapping,
+                # Keep the encoder in BF16/FP16 unless a future quantizer
+                # explicitly supports this tower.  Text quantization remains
+                # active through language_model.
+                quant_config=None,
+                prefix=add_prefix("audio_tower", prefix),
+                mm_attention_backend=mm_attention_backend,
+            )
+            self.multimodal_embedder = MultimodalEmbedder()
+            # ModelExecutor may replace this callable with an encoder graph.
+            self.audio_encoder = self.get_audio_feature
+        else:
+            self.audio_tower = None
+            self.multimodal_embedder = None
+            self.audio_encoder = None
+
+    def get_audio_feature(self, items: list[MultimodalDataItem]) -> torch.Tensor:
+        if self.audio_tower is None:
+            raise RuntimeError("Qwen3-ASR audio tower is disabled")
+        return self.audio_tower.encode(items)
+
+    def pad_input_ids(
+        self, input_ids: list[int], mm_inputs: MultimodalInputs
+    ) -> list[int]:
+        return pad_input_tokens(input_ids, mm_inputs)
+
+    @property
+    def start_layer(self) -> int:
+        return int(getattr(self.language_model.model, "start_layer", 0))
+
+    @property
+    def end_layer(self) -> int:
+        return int(
+            getattr(
+                self.language_model.model,
+                "end_layer",
+                self.thinker_config.text_config.num_hidden_layers,
+            )
+        )
+
+    @property
+    def lm_head(self):
+        return self.language_model.lm_head
+
+    @property
+    def logits_processor(self):
+        return self.language_model.logits_processor
+
+    def get_input_embeddings(self):
+        return self.language_model.model.embed_tokens
+
+    def get_embed_and_head(self):
+        return self.language_model.get_embed_and_head()
+
+    def set_embed_and_head(self, embed, head) -> None:
+        self.language_model.set_embed_and_head(embed, head)
+
+    def load_kv_cache_scales(self, quantization_param_path: str) -> None:
+        self.language_model.load_kv_cache_scales(quantization_param_path)
+
+    @torch.no_grad()
+    def forward(
+        self,
+        ctx,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        out_cache_loc: torch.Tensor,
+        **kwargs,
+    ):
+        multimodal_context = kwargs.pop("multimodal_context", None)
+        if (
+            multimodal_context is not None
+            and multimodal_context.has_extend_inputs()
+            and not ctx.forward_mode.is_decode_or_idle()
+        ):
+            if self.multimodal_embedder is None or self.audio_encoder is None:
+                raise RuntimeError(
+                    "audio input was provided while Qwen3-ASR runs with "
+                    "--language-model-only"
+                )
+            input_embeds, model_kwargs = self.multimodal_embedder.apply(
+                input_ids=input_ids,
+                text_embedding=self.get_input_embeddings(),
+                ctx=multimodal_context,
+                encoders={
+                    Modality.AUDIO: EncoderSpec(
+                        self.audio_encoder,
+                        deepstack=False,
+                    )
+                },
+                multimodal_model=self,
+                is_decode_or_idle=ctx.forward_mode.is_decode_or_idle(),
+            )
+            kwargs.update(model_kwargs)
+            if input_embeds is not None:
+                kwargs["input_embeds"] = input_embeds
+
+        return self.language_model(
+            ctx,
+            input_ids,
+            positions,
+            out_cache_loc,
+            **kwargs,
+        )
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Stream the official ``thinker.*`` ASR checkpoint layout."""
+        loaded: set[str] = set()
+        params = dict(self.named_parameters(remove_duplicate=False))
+
+        for name, tensor in weights:
+            if "talker." in name or "code2wav." in name:
+                continue
+            if name.startswith("thinker.audio_tower.") or name.startswith(
+                "audio_tower."
+            ):
+                if self.audio_tower is None:
+                    continue
+                loaded_name = self.audio_tower.load_weight(name, tensor)
+                if loaded_name is None:
+                    raise ValueError(f"unknown Qwen audio weight {name}")
+                loaded.add(f"audio_tower.{loaded_name}")
+                continue
+
+            name, shard_id = self.map_language_weight_name(name)
+            if (
+                self.thinker_config.text_config.tie_word_embeddings
+                and name == "language_model.lm_head.weight"
+            ):
+                continue
+            if name not in params:
+                raise ValueError(f"unknown Qwen3-ASR language weight {name}")
+            param = params[name]
+            if shard_id is not None:
+                param.weight_loader(param, tensor, shard_id)
+            else:
+                loader = getattr(param, "weight_loader", default_weight_loader)
+                loader(param, tensor)
+            loaded.add(name)
+        return loaded
+
+    @staticmethod
+    def map_language_weight_name(name: str) -> tuple[str, str | int | None]:
+        """Map an official text checkpoint name to a wrapper parameter."""
+        if name.startswith("thinker.model."):
+            name = name.replace("thinker.model.", "language_model.model.", 1)
+        elif name.startswith("thinker.lm_head."):
+            name = name.replace("thinker.lm_head.", "language_model.lm_head.", 1)
+        elif name.startswith("language_model."):
+            pass
+        elif name.startswith("thinker."):
+            raise ValueError(f"unsupported Qwen3-ASR thinker weight {name}")
+        else:
+            name = f"language_model.{name}"
+
+        for checkpoint_name, fused_name, shard_id in (
+            (".q_proj.", ".qkv_proj.", "q"),
+            (".k_proj.", ".qkv_proj.", "k"),
+            (".v_proj.", ".qkv_proj.", "v"),
+            (".gate_proj.", ".gate_up_proj.", 0),
+            (".up_proj.", ".gate_up_proj.", 1),
+        ):
+            if checkpoint_name in name:
+                return name.replace(checkpoint_name, fused_name), shard_id
+        return name, None
+
+
+EntryClass = [Qwen3ASRForConditionalGeneration]

--- a/python/tokenspeed/runtime/models/qwen3_audio.py
+++ b/python/tokenspeed/runtime/models/qwen3_audio.py
@@ -1,0 +1,559 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Shared Qwen3-ASR/Qwen3-Omni audio encoder.
+
+The gateway extracts log-Mel features with the Whisper-compatible Qwen3
+frontend. Each multimodal item contains one ``[num_mel_bins, num_frames]``
+tensor (a leading singleton batch dimension is also accepted) and optionally
+carries ``audio_feature_lengths`` or ``feature_attention_mask`` in
+``model_specific_data``. This module packs those request-local tensors and
+implements the common Qwen3 audio tower used by both Qwen3-ASR and the
+Qwen3-Omni thinker.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from numbers import Integral
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers.activations import ACT2FN
+
+from tokenspeed.runtime.distributed.mapping import Mapping
+from tokenspeed.runtime.layers.attention.mm_encoder_attention import (
+    MultimodalEncoderAttention,
+)
+from tokenspeed.runtime.layers.linear import (
+    ColumnParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from tokenspeed.runtime.layers.quantization.base_config import QuantizationConfig
+from tokenspeed.runtime.model_loader.weight_utils import default_weight_loader
+from tokenspeed.runtime.multimodal.inputs import MultimodalDataItem
+from tokenspeed.runtime.utils import add_prefix
+
+
+def _cnn_output_lengths(input_lengths: torch.Tensor) -> torch.Tensor:
+    """Lengths after the tower's three stride-2, padding-1 convolutions."""
+    lengths = input_lengths
+    for _ in range(3):
+        lengths = (lengths - 1) // 2 + 1
+    return lengths
+
+
+def qwen3_audio_output_lengths(
+    input_lengths: torch.Tensor | Sequence[int] | int,
+    *,
+    n_window: int = 50,
+) -> torch.Tensor:
+    """Return language-token counts produced for log-Mel frame lengths.
+
+    Qwen processes audio in chunks of ``2 * n_window`` frames.  Convolution
+    padding is applied independently to every chunk, so applying a single
+    ``ceil(length / 8)`` to a long clip would under-count tokens at chunk
+    boundaries.
+
+    Args:
+        input_lengths: Scalar or one-dimensional Mel-frame lengths.
+        n_window: Half of the frontend chunk size from the audio config.
+
+    Returns:
+        A one-dimensional ``torch.long`` tensor with one token count per input.
+    """
+    if n_window <= 0:
+        raise ValueError(f"n_window must be positive, got {n_window}")
+    if isinstance(input_lengths, Integral):
+        lengths = torch.tensor([int(input_lengths)], dtype=torch.long)
+    elif isinstance(input_lengths, torch.Tensor):
+        lengths = input_lengths.to(dtype=torch.long)
+        if lengths.ndim == 0:
+            lengths = lengths.unsqueeze(0)
+    else:
+        lengths = torch.as_tensor(list(input_lengths), dtype=torch.long)
+    if lengths.ndim != 1:
+        raise ValueError(
+            f"audio feature lengths must be one-dimensional, got {lengths.shape}"
+        )
+    if torch.any(lengths < 0):
+        raise ValueError("audio feature lengths cannot be negative")
+
+    chunk_size = 2 * n_window
+    full_chunks = lengths // chunk_size
+    tail = lengths % chunk_size
+    full_chunk_output = int(
+        _cnn_output_lengths(torch.tensor([chunk_size], dtype=torch.long)).item()
+    )
+    tail_output = _cnn_output_lengths(tail)
+    tail_output = torch.where(tail == 0, torch.zeros_like(tail), tail_output)
+    return full_chunks * full_chunk_output + tail_output
+
+
+def _one_item_feature_length(item: MultimodalDataItem, max_frames: int) -> int:
+    explicit_length = item.model_specific_data.get("audio_feature_lengths")
+    if explicit_length is not None:
+        if isinstance(explicit_length, torch.Tensor):
+            if explicit_length.numel() != 1:
+                raise ValueError(
+                    "one audio item must carry exactly one audio_feature_lengths "
+                    f"value, got shape {explicit_length.shape}"
+                )
+            length = int(explicit_length.reshape(-1)[0].item())
+        elif isinstance(explicit_length, Integral):
+            length = int(explicit_length)
+        else:
+            raise TypeError(
+                "audio_feature_lengths must be an integer or tensor, got "
+                f"{type(explicit_length).__name__}"
+            )
+    else:
+        attention_mask = item.model_specific_data.get("feature_attention_mask")
+        if attention_mask is None:
+            length = max_frames
+        else:
+            attention_mask = torch.as_tensor(attention_mask)
+            if attention_mask.ndim == 2 and attention_mask.shape[0] == 1:
+                attention_mask = attention_mask.squeeze(0)
+            if attention_mask.ndim != 1:
+                raise ValueError(
+                    "one audio item must carry a one-dimensional "
+                    f"feature_attention_mask, got {attention_mask.shape}"
+                )
+            if attention_mask.numel() != max_frames:
+                raise ValueError(
+                    "feature_attention_mask length does not match the audio "
+                    f"feature: {attention_mask.numel()} != {max_frames}"
+                )
+            # Whisper masks are right-padded.  Requiring a contiguous prefix
+            # prevents silently packing frames from a malformed sparse mask.
+            mask = attention_mask.to(dtype=torch.bool)
+            length = int(mask.sum().item())
+            expected = torch.arange(max_frames, device=mask.device) < length
+            if not torch.equal(mask, expected):
+                raise ValueError("feature_attention_mask must be right-padded")
+
+    if length <= 0 or length > max_frames:
+        raise ValueError(
+            f"audio feature length must be in [1, {max_frames}], got {length}"
+        )
+    return length
+
+
+def pack_qwen3_audio_features(
+    items: Sequence[MultimodalDataItem],
+    *,
+    num_mel_bins: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pack itemized log-Mel tensors for :class:`Qwen3AudioEncoder`.
+
+    Returns a feature tensor shaped ``[num_mel_bins, sum(valid_frames)]`` and
+    a length tensor shaped ``[num_items]``.  Padding is removed before packing.
+    """
+    if not items:
+        raise ValueError("at least one audio item is required")
+
+    features: list[torch.Tensor] = []
+    lengths: list[int] = []
+    for item in items:
+        feature = item.feature
+        if not isinstance(feature, torch.Tensor):
+            raise TypeError(
+                "audio item feature must be materialized as a torch.Tensor, got "
+                f"{type(feature).__name__}"
+            )
+        if feature.ndim == 3 and feature.shape[0] == 1:
+            feature = feature.squeeze(0)
+        if feature.ndim != 2:
+            raise ValueError(
+                "audio feature must have shape [mel, frames] or [1, mel, frames], "
+                f"got {feature.shape}"
+            )
+        if feature.shape[0] != num_mel_bins:
+            raise ValueError(
+                f"expected {num_mel_bins} Mel bins, got feature shape {feature.shape}"
+            )
+        length = _one_item_feature_length(item, feature.shape[1])
+        features.append(feature[:, :length].to(device=device, dtype=dtype))
+        lengths.append(length)
+
+    return (
+        torch.cat(features, dim=1).contiguous(),
+        torch.tensor(lengths, dtype=torch.long, device=device),
+    )
+
+
+class SinusoidsPositionEmbedding(nn.Module):
+    """Non-trainable absolute position embedding used by the audio tower."""
+
+    def __init__(self, length: int, channels: int, max_timescale: int = 10000):
+        super().__init__()
+        if channels % 2:
+            raise ValueError("sinusoidal position embeddings need even channels")
+        log_increment = torch.log(torch.tensor(float(max_timescale))) / (
+            channels // 2 - 1
+        )
+        inv_timescales = torch.exp(-log_increment * torch.arange(channels // 2))
+        positions = torch.arange(length).unsqueeze(1) * inv_timescales.unsqueeze(0)
+        self.register_buffer(
+            "positional_embedding",
+            torch.cat([positions.sin(), positions.cos()], dim=1),
+            persistent=False,
+        )
+
+    def forward(self, sequence_length: int) -> torch.Tensor:
+        return self.positional_embedding[:sequence_length]
+
+
+class Qwen3AudioEncoderLayer(nn.Module):
+    def __init__(
+        self,
+        config: Any,
+        mapping: Mapping,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        mm_attention_backend: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.self_attn = MultimodalEncoderAttention(
+            embed_dim=config.d_model,
+            num_heads=config.encoder_attention_heads,
+            mapping=mapping,
+            qkv_bias=True,
+            proj_bias=True,
+            quant_config=quant_config,
+            prefix=add_prefix("self_attn", prefix),
+            mm_attention_backend=mm_attention_backend,
+        )
+        self.self_attn_layer_norm = nn.LayerNorm(config.d_model)
+        self.final_layer_norm = nn.LayerNorm(config.d_model)
+        self.activation_fn = ACT2FN[config.activation_function]
+
+        vision = mapping.vision
+        self.fc1 = ColumnParallelLinear(
+            config.d_model,
+            config.encoder_ffn_dim,
+            bias=True,
+            quant_config=quant_config,
+            prefix=add_prefix("fc1", prefix),
+            tp_rank=vision.tp_rank,
+            tp_size=vision.tp_size,
+            tp_group=vision.tp_group,
+        )
+        self.fc2 = RowParallelLinear(
+            config.encoder_ffn_dim,
+            config.d_model,
+            bias=True,
+            quant_config=quant_config,
+            prefix=add_prefix("fc2", prefix),
+            tp_rank=vision.tp_rank,
+            tp_size=vision.tp_size,
+            tp_group=vision.tp_group,
+            reduce_results=True,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        normed = self.self_attn_layer_norm(hidden_states)
+        attended = self.self_attn(
+            normed.unsqueeze(0),
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        ).squeeze(0)
+        hidden_states = residual + attended
+
+        residual = hidden_states
+        hidden_states = self.final_layer_norm(hidden_states)
+        hidden_states, _ = self.fc1(hidden_states)
+        hidden_states = self.activation_fn(hidden_states)
+        hidden_states, _ = self.fc2(hidden_states)
+        hidden_states = residual + hidden_states
+
+        if hidden_states.dtype == torch.float16:
+            limit = torch.finfo(hidden_states.dtype).max - 1000
+            hidden_states = hidden_states.clamp(min=-limit, max=limit)
+        return hidden_states
+
+
+class Qwen3AudioEncoder(nn.Module):
+    """Parameterizable Qwen audio tower shared by ASR and Omni thinker."""
+
+    @staticmethod
+    def _normalize_attention_backend(name: str | None) -> str | None:
+        # The cuDNN path consumes vision-specific sequence metadata. Audio can
+        # still use the platform default while an Omni vision tower uses cuDNN.
+        return None if name == "flashinfer_cudnn" else name
+
+    def __init__(
+        self,
+        config: Any,
+        mapping: Mapping,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        mm_attention_backend: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.num_mel_bins = int(config.num_mel_bins)
+        self.n_window = int(config.n_window)
+        self.n_window_infer = int(config.n_window_infer)
+        self.conv_chunksize = int(config.conv_chunksize)
+        mm_attention_backend = self._normalize_attention_backend(mm_attention_backend)
+
+        self.positional_embedding = SinusoidsPositionEmbedding(
+            int(config.max_source_positions), int(config.d_model)
+        )
+        self.conv2d1 = nn.Conv2d(
+            1, config.downsample_hidden_size, kernel_size=3, stride=2, padding=1
+        )
+        self.conv2d2 = nn.Conv2d(
+            config.downsample_hidden_size,
+            config.downsample_hidden_size,
+            kernel_size=3,
+            stride=2,
+            padding=1,
+        )
+        self.conv2d3 = nn.Conv2d(
+            config.downsample_hidden_size,
+            config.downsample_hidden_size,
+            kernel_size=3,
+            stride=2,
+            padding=1,
+        )
+        conv_out_dim = config.downsample_hidden_size * (
+            (((config.num_mel_bins + 1) // 2 + 1) // 2 + 1) // 2
+        )
+        self.conv_out = ReplicatedLinear(
+            conv_out_dim,
+            config.d_model,
+            bias=False,
+            quant_config=quant_config,
+            prefix=add_prefix("conv_out", prefix),
+        )
+        self.layers = nn.ModuleList(
+            [
+                Qwen3AudioEncoderLayer(
+                    config,
+                    mapping,
+                    quant_config=quant_config,
+                    prefix=add_prefix(f"layers.{index}", prefix),
+                    mm_attention_backend=mm_attention_backend,
+                )
+                for index in range(config.encoder_layers)
+            ]
+        )
+        self.ln_post = nn.LayerNorm(config.d_model)
+        self.proj1 = ReplicatedLinear(
+            config.d_model,
+            config.d_model,
+            bias=True,
+            quant_config=quant_config,
+            prefix=add_prefix("proj1", prefix),
+        )
+        self.act = ACT2FN[config.activation_function]
+        self.proj2 = ReplicatedLinear(
+            config.d_model,
+            config.output_dim,
+            bias=True,
+            quant_config=quant_config,
+            prefix=add_prefix("proj2", prefix),
+        )
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.conv2d1.weight.dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.conv2d1.weight.device
+
+    def encode(self, items: Sequence[MultimodalDataItem]) -> torch.Tensor:
+        input_features, feature_lengths = pack_qwen3_audio_features(
+            items,
+            num_mel_bins=self.num_mel_bins,
+            device=self.device,
+            dtype=self.dtype,
+        )
+        return self(input_features, feature_lengths)
+
+    def forward(
+        self,
+        input_features: torch.Tensor,
+        feature_lengths: torch.Tensor,
+    ) -> torch.Tensor:
+        """Encode packed features into concatenated LM-space audio tokens.
+
+        Args:
+            input_features: Packed log-Mel features shaped
+                ``[num_mel_bins, sum(feature_lengths)]``.
+            feature_lengths: Valid frame count for every original audio item.
+
+        Returns:
+            Audio embeddings shaped ``[sum(output_lengths), output_dim]`` in
+            the same item order as ``feature_lengths``.
+        """
+        input_features = input_features.to(device=self.device, dtype=self.dtype)
+        feature_lengths = feature_lengths.to(device=self.device, dtype=torch.long)
+        if input_features.ndim != 2 or input_features.shape[0] != self.num_mel_bins:
+            raise ValueError(
+                f"expected packed features [{self.num_mel_bins}, frames], got "
+                f"{input_features.shape}"
+            )
+        if feature_lengths.ndim != 1 or feature_lengths.numel() == 0:
+            raise ValueError("feature_lengths must be a non-empty vector")
+        if torch.any(feature_lengths <= 0):
+            raise ValueError("feature_lengths must be positive")
+        if int(feature_lengths.sum().item()) != input_features.shape[1]:
+            raise ValueError(
+                "packed feature width does not match feature_lengths: "
+                f"{input_features.shape[1]} != {int(feature_lengths.sum().item())}"
+            )
+
+        chunk_size = self.n_window * 2
+        chunk_lengths_list: list[int] = []
+        for length in feature_lengths.tolist():
+            full_chunks, tail = divmod(int(length), chunk_size)
+            chunk_lengths_list.extend([chunk_size] * full_chunks)
+            if tail:
+                chunk_lengths_list.append(tail)
+        chunk_lengths = torch.tensor(
+            chunk_lengths_list, dtype=torch.long, device=self.device
+        )
+
+        chunks = input_features.transpose(0, 1).split(chunk_lengths_list, dim=0)
+        padded_features = nn.utils.rnn.pad_sequence(chunks, batch_first=True).transpose(
+            1, 2
+        )
+        chunk_output_lengths = _cnn_output_lengths(chunk_lengths)
+        max_chunk_output = int(chunk_output_lengths.max().item())
+        output_mask = torch.arange(max_chunk_output, device=self.device).unsqueeze(
+            0
+        ) < chunk_output_lengths.unsqueeze(1)
+
+        padded_features = padded_features.unsqueeze(1)
+        encoded_chunks: list[torch.Tensor] = []
+        for conv_input in padded_features.split(self.conv_chunksize, dim=0):
+            hidden = F.gelu(self.conv2d1(conv_input))
+            hidden = F.gelu(self.conv2d2(hidden))
+            hidden = F.gelu(self.conv2d3(hidden))
+            encoded_chunks.append(hidden)
+        hidden = torch.cat(encoded_chunks, dim=0)
+
+        batch, channels, frequency, time = hidden.shape
+        hidden, _ = self.conv_out(
+            hidden.permute(0, 3, 1, 2)
+            .contiguous()
+            .view(batch, time, channels * frequency)
+        )
+        if hidden.shape[1] > self.positional_embedding.positional_embedding.shape[0]:
+            raise ValueError(
+                "audio chunk exceeds max_source_positions after convolution: "
+                f"{hidden.shape[1]}"
+            )
+        hidden = hidden + self.positional_embedding(hidden.shape[1]).to(hidden.dtype)
+        hidden_states = hidden[output_mask]
+
+        output_lengths = qwen3_audio_output_lengths(
+            feature_lengths, n_window=self.n_window
+        ).to(device=self.device)
+        chunks_per_attention_window = max(1, self.n_window_infer // chunk_size)
+        attention_window = max_chunk_output * chunks_per_attention_window
+        attention_lengths: list[int] = []
+        for length in output_lengths.tolist():
+            full_windows, tail = divmod(int(length), attention_window)
+            attention_lengths.extend([attention_window] * full_windows)
+            if tail:
+                attention_lengths.append(tail)
+        cu_seqlens = torch.tensor(
+            [0, *attention_lengths], dtype=torch.int32, device=self.device
+        ).cumsum(0, dtype=torch.int32)
+        max_seqlen = max(attention_lengths)
+
+        for layer in self.layers:
+            hidden_states = layer(hidden_states, cu_seqlens, max_seqlen)
+
+        hidden_states = self.ln_post(hidden_states)
+        hidden_states, _ = self.proj1(hidden_states)
+        hidden_states = self.act(hidden_states)
+        hidden_states, _ = self.proj2(hidden_states)
+        return hidden_states
+
+    @staticmethod
+    def map_weight_name(name: str) -> tuple[str, str | None]:
+        """Map an HF audio-tower name to ``(TokenSpeed name, shard id)``."""
+        marker = "audio_tower."
+        if marker in name:
+            name = name.split(marker, 1)[1]
+        name = name.replace("self_attn.out_proj.", "self_attn.proj.")
+        for checkpoint_name, shard_id in (
+            ("q_proj", "q"),
+            ("k_proj", "k"),
+            ("v_proj", "v"),
+        ):
+            needle = f"self_attn.{checkpoint_name}."
+            if needle in name:
+                return name.replace(needle, "self_attn.qkv_proj."), shard_id
+        return name, None
+
+    def load_weight(self, name: str, loaded_weight: torch.Tensor) -> str | None:
+        """Load one audio-tower checkpoint tensor.
+
+        ``name`` may be relative to the tower or retain a
+        ``thinker.audio_tower``/``audio_tower`` prefix.  Q/K/V checkpoint
+        projections are fused into TokenSpeed's ``qkv_proj`` parameter and the
+        HF ``out_proj`` name is mapped to ``MultimodalEncoderAttention.proj``.
+        """
+        name, shard_id = self.map_weight_name(name)
+        params = dict(self.named_parameters(remove_duplicate=False))
+        if name not in params:
+            return None
+        param = params[name]
+        if shard_id is not None:
+            param.weight_loader(param, loaded_weight, shard_id)
+        else:
+            loader = getattr(param, "weight_loader", default_weight_loader)
+            loader(param, loaded_weight)
+        return name
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loaded: set[str] = set()
+        for name, tensor in weights:
+            loaded_name = self.load_weight(name, tensor)
+            if loaded_name is not None:
+                loaded.add(loaded_name)
+        return loaded
+
+
+__all__ = [
+    "Qwen3AudioEncoder",
+    "Qwen3AudioEncoderLayer",
+    "pack_qwen3_audio_features",
+    "qwen3_audio_output_lengths",
+]

--- a/python/tokenspeed/runtime/models/qwen3_omni.py
+++ b/python/tokenspeed/runtime/models/qwen3_omni.py
@@ -1,0 +1,485 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Inference-only Qwen3-Omni thinker (text output only).
+
+The thinker composes TokenSpeed's shared Qwen3 MoE language model, Qwen3 vision
+tower, and Qwen3-Omni audio tower. Talker/Code2Wav weights are deliberately
+ignored: this entry point implements ``return_audio=False`` and independent
+image/audio/video inputs (``use_audio_in_video=False``).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+
+import torch
+
+from tokenspeed.runtime.configs.qwen3_vision_config import Qwen3VLVisionConfig
+from tokenspeed.runtime.distributed.mapping import Mapping
+from tokenspeed.runtime.execution.context import ForwardContext
+from tokenspeed.runtime.layers.logits_processor import LogitsMetadata
+from tokenspeed.runtime.layers.moe import (
+    ExpertCheckpointSchema,
+    build_moe_checkpoint_loader,
+)
+from tokenspeed.runtime.layers.quantization.base_config import QuantizationConfig
+from tokenspeed.runtime.layers.utils import get_layer_id
+from tokenspeed.runtime.model_loader.weight_utils import default_weight_loader
+from tokenspeed.runtime.models.qwen3_audio import Qwen3AudioEncoder
+from tokenspeed.runtime.models.qwen3_moe import Qwen3MoeForCausalLM, Qwen3MoeModel
+from tokenspeed.runtime.models.qwen3_vision import Qwen3VLMoeVisionModel
+from tokenspeed.runtime.multimodal.embedder import (
+    EncoderSpec,
+    MultimodalEmbedder,
+    pad_input_tokens,
+)
+from tokenspeed.runtime.multimodal.encoder_cudagraph import (
+    EncoderCudaGraphWrapper,
+    VisionEncoderCudaGraphAdapter,
+)
+from tokenspeed.runtime.multimodal.inputs import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from tokenspeed.runtime.utils.env import envs
+
+logger = logging.getLogger(__name__)
+
+
+def _get_thinker_config(config):
+    return getattr(config, "thinker_config", config)
+
+
+def _shared_vision_config(vision_config) -> Qwen3VLVisionConfig:
+    if not getattr(vision_config, "apply_vit_abs_pos_embed", True):
+        raise ValueError("Qwen3-Omni without absolute vision positions is unsupported")
+    values = (
+        vision_config.to_dict()
+        if hasattr(vision_config, "to_dict")
+        else dict(vars(vision_config))
+    )
+    patch_size = int(values.get("patch_size", 16))
+    image_size = values.get("image_size")
+    if image_size is not None:
+        image_size = int(image_size)
+        if image_size % patch_size:
+            raise ValueError("Qwen3-Omni image_size must be divisible by patch_size")
+        expected_positions = (image_size // patch_size) ** 2
+        configured_positions = values.get("num_position_embeddings")
+        if (
+            configured_positions is not None
+            and int(configured_positions) != expected_positions
+        ):
+            raise ValueError(
+                "Qwen3-Omni image_size/patch_size disagrees with "
+                "num_position_embeddings"
+            )
+        values["num_position_embeddings"] = expected_positions
+    values["deepstack_visual_indexes"] = (
+        values.get("deepstack_visual_indexes", [8, 16, 24]) or []
+    )
+    return Qwen3VLVisionConfig(**values)
+
+
+class Qwen3OmniMoeTextModel(Qwen3MoeModel):
+    """Qwen3 MoE decoder with Omni visual deepstack injection."""
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        ctx: ForwardContext,
+        out_cache_loc: torch.Tensor,
+        input_embeds: torch.Tensor | None = None,
+        input_deepstack_embeds: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, None]:
+        hidden_states = (
+            self.embed_tokens(input_ids) if input_embeds is None else input_embeds
+        )
+        residual = None
+        hidden_size = self.config.hidden_size
+        num_deepstack = (
+            input_deepstack_embeds.shape[-1] // hidden_size
+            if input_deepstack_embeds is not None
+            else 0
+        )
+
+        for layer_idx, layer in enumerate(self.layers):
+            hidden_states, residual = layer(
+                positions,
+                hidden_states,
+                ctx,
+                out_cache_loc,
+                residual,
+                cos_sin=None,
+            )
+            if layer_idx < num_deepstack and input_deepstack_embeds.numel() > 0:
+                start = layer_idx * hidden_size
+                hidden_states.add_(
+                    input_deepstack_embeds[:, start : start + hidden_size]
+                )
+
+        if not ctx.forward_mode.is_idle():
+            hidden_states, _ = layer.comm_manager.final_norm(
+                hidden_states, residual, ctx, self.norm
+            )
+        return hidden_states, None
+
+
+class Qwen3OmniMoeForConditionalGeneration(Qwen3MoeForCausalLM):
+    """Qwen3-Omni thinker for text-only generation."""
+
+    model_cls = Qwen3OmniMoeTextModel
+
+    def __init__(
+        self,
+        config,
+        mapping: Mapping,
+        quant_config: QuantizationConfig | None = None,
+        is_multimodal_active: bool = True,
+        mm_attention_backend: str | None = None,
+    ) -> None:
+        self.omni_config = config
+        self.thinker_config = _get_thinker_config(config)
+        text_config = self.thinker_config.text_config
+        super().__init__(config=text_config, mapping=mapping, quant_config=quant_config)
+
+        self.is_multimodal_active = is_multimodal_active
+        self.multimodal_embedder = (
+            MultimodalEmbedder() if is_multimodal_active else None
+        )
+        if not is_multimodal_active:
+            self.visual = None
+            self.audio_tower = None
+            self.deepstack_visual_indexes = []
+            self.num_deepstack_embeddings = 0
+            self.image_encoder = None
+            self.video_encoder = None
+            self.audio_encoder = None
+            return
+
+        vision_config = _shared_vision_config(self.thinker_config.vision_config)
+        if vision_config.out_hidden_size != text_config.hidden_size:
+            raise ValueError(
+                "Qwen3-Omni vision output size must match text hidden size"
+            )
+        if self.thinker_config.audio_config.output_dim != text_config.hidden_size:
+            raise ValueError("Qwen3-Omni audio output size must match text hidden size")
+
+        self.visual = Qwen3VLMoeVisionModel(
+            vision_config,
+            mapping=mapping,
+            quant_config=None,
+            norm_eps=getattr(text_config, "rms_norm_eps", 1e-6),
+            prefix="visual",
+            mm_attention_backend=mm_attention_backend,
+        )
+        self.audio_tower = Qwen3AudioEncoder(
+            self.thinker_config.audio_config,
+            mapping=mapping,
+            quant_config=None,
+            prefix="audio_tower",
+            mm_attention_backend=mm_attention_backend,
+        )
+        self.deepstack_visual_indexes = self.visual.deepstack_visual_indexes
+        self.num_deepstack_embeddings = len(self.deepstack_visual_indexes)
+
+        # Encoder callables can be replaced by CUDA graph wrappers at runtime.
+        self.image_encoder = self.get_image_feature
+        self.video_encoder = self.get_video_feature
+        self.audio_encoder = self.audio_tower.encode
+
+    def separate_deepstack_embeds(
+        self, embedding: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        expected_parts = 1 + self.num_deepstack_embeddings
+        if embedding.shape[-1] != self.config.hidden_size * expected_parts:
+            raise ValueError(
+                f"vision embedding width {embedding.shape[-1]} does not match "
+                f"{expected_parts} x text hidden size {self.config.hidden_size}"
+            )
+        split = self.config.hidden_size
+        return embedding[:, :split], embedding[:, split:]
+
+    def pad_input_ids(
+        self, input_ids: list[int], mm_inputs: MultimodalInputs
+    ) -> list[int]:
+        return pad_input_tokens(input_ids, mm_inputs)
+
+    def pre_encode(
+        self, items: list[MultimodalDataItem]
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        pixel_values = torch.cat([item.feature for item in items], dim=0).type(
+            self.visual.dtype
+        )
+        grid = torch.cat(
+            [
+                (
+                    item.video_grid_thw
+                    if item.modality == Modality.VIDEO
+                    else item.image_grid_thw
+                )
+                for item in items
+            ],
+            dim=0,
+        )
+        if pixel_values.dim() != 2 or grid.dim() != 2:
+            raise ValueError("Qwen3-Omni vision features require 2-D patches and grids")
+        return self.visual.prepare_patch_embed(pixel_values, grid), grid
+
+    def post_encode(
+        self, encoder_outs: list[torch.Tensor], grid: torch.Tensor
+    ) -> torch.Tensor:
+        del grid
+        return torch.cat(encoder_outs, dim=0)
+
+    def get_image_feature(self, items: list[MultimodalDataItem]) -> torch.Tensor:
+        tokens, grid = self.pre_encode(items)
+        output = self.visual.forward_blocks(tokens, self.visual.prepare_metadata(grid))
+        return self.post_encode([output], grid)
+
+    def get_video_feature(self, items: list[MultimodalDataItem]) -> torch.Tensor:
+        tokens, grid = self.pre_encode(items)
+        output = self.visual.forward_blocks(tokens, self.visual.prepare_metadata(grid))
+        return self.post_encode([output], grid)
+
+    def _build_encoder_cudagraph_wrapper(
+        self,
+        mapping: Mapping,
+        *,
+        max_metadata_sequences_per_batch: int | None = None,
+        metadata_sequence_budget_from_encoder_output_budget: bool = False,
+    ) -> EncoderCudaGraphWrapper:
+        adapter = VisionEncoderCudaGraphAdapter(
+            tower=self.visual,
+            pre_encode=self.pre_encode,
+            post_encode=self.post_encode,
+            out_div=self.visual.spatial_merge_size**2,
+            merge=self.visual.spatial_merge_size,
+            input_feature_shape=(1, self.visual.hidden_size),
+            modality_name="vision",
+            capture_tp_size=mapping.vision.tp_size,
+            capture_tp_group=mapping.vision.tp_group,
+        )
+        return EncoderCudaGraphWrapper(
+            adapter=adapter,
+            budget_range=(64, 4096),
+            max_metadata_sequences_per_batch=max_metadata_sequences_per_batch,
+            metadata_sequence_budget_from_encoder_output_budget=(
+                metadata_sequence_budget_from_encoder_output_budget
+            ),
+        )
+
+    def make_encoder_cudagraph_wrappers(self, mapping: Mapping) -> dict:
+        max_video_sequences = (
+            envs.TOKENSPEED_MM_VIDEO_ENCODER_CUDA_GRAPH_MAX_SEQUENCES_PER_BATCH.get()
+        )
+        if max_video_sequences is not None:
+            max_video_sequences = max(1, max_video_sequences)
+        shared = self._build_encoder_cudagraph_wrapper(
+            mapping,
+            max_metadata_sequences_per_batch=max_video_sequences,
+            metadata_sequence_budget_from_encoder_output_budget=(
+                max_video_sequences is None
+            ),
+        )
+        return {"image_encoder": shared, "video_encoder": shared}
+
+    @torch.no_grad()
+    def forward(
+        self,
+        ctx: ForwardContext,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        out_cache_loc: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        multimodal_context = kwargs.pop("multimodal_context", None)
+        if (
+            not self.is_multimodal_active
+            and multimodal_context is not None
+            and multimodal_context.has_extend_inputs()
+        ):
+            raise RuntimeError(
+                "Qwen3-Omni received multimodal inputs while its encoders are disabled"
+            )
+        if (
+            multimodal_context is None
+            or not multimodal_context.has_extend_inputs()
+            or ctx.forward_mode.is_decode_or_idle()
+        ):
+            return super().forward(ctx, input_ids, positions, out_cache_loc, **kwargs)
+
+        input_embeds, model_kwargs = self.multimodal_embedder.apply(
+            input_ids=input_ids,
+            text_embedding=self.model.embed_tokens,
+            ctx=multimodal_context,
+            encoders={
+                Modality.IMAGE: EncoderSpec(self.image_encoder, deepstack=True),
+                Modality.VIDEO: EncoderSpec(self.video_encoder, deepstack=True),
+                Modality.AUDIO: EncoderSpec(self.audio_encoder),
+            },
+            multimodal_model=self,
+            is_decode_or_idle=ctx.forward_mode.is_decode_or_idle(),
+        )
+        hidden_states, aux_hidden_states = self.model(
+            input_ids,
+            positions,
+            ctx,
+            out_cache_loc,
+            input_embeds=input_embeds,
+            **model_kwargs,
+        )
+        return self.logits_processor(
+            input_ids,
+            hidden_states,
+            self.lm_head,
+            LogitsMetadata.from_forward_context(ctx),
+            aux_hidden_states,
+        )
+
+    @staticmethod
+    def _map_visual_weight(name: str) -> str:
+        name = name.replace("attn.qkv.", "attn.qkv_proj.")
+        name = name.replace("merger_list.", "deepstack_merger_list.")
+        name = name.replace(".ln_q.", ".norm.")
+        name = name.replace(".mlp.0.", ".linear_fc1.")
+        name = name.replace(".mlp.2.", ".linear_fc2.")
+        return name
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        ignore_suffixes = (
+            ".bias",
+            "_bias",
+            ".k_scale",
+            "_k_scale",
+            ".v_scale",
+            "_v_scale",
+            ".weight_scale",
+            "_weight_scale",
+            ".input_scale",
+            "_input_scale",
+        )
+        params = dict(self.named_parameters(remove_duplicate=False))
+        moe_loader = build_moe_checkpoint_loader(
+            params_dict=params,
+            expert_schema=ExpertCheckpointSchema(
+                gate_proj_name="gate_proj",
+                down_proj_name="down_proj",
+                up_proj_name="up_proj",
+            ),
+            fused_schema=ExpertCheckpointSchema(
+                gate_up_fused_name="gate_up_proj",
+                down_proj_name="down_proj",
+            ),
+            num_experts=self.config.num_experts,
+            ep_rank=self.mapping.moe.ep_rank,
+            ep_size=self.mapping.moe.ep_size,
+        )
+        loaded = set()
+
+        for original_name, loaded_weight in weights:
+            if original_name.startswith(("talker.", "code2wav.")):
+                continue
+            name = (
+                original_name[len("thinker.") :]
+                if original_name.startswith("thinker.")
+                else original_name
+            )
+
+            if name.startswith("visual."):
+                if not self.is_multimodal_active:
+                    continue
+                name = self._map_visual_weight(name)
+                if name not in params:
+                    logger.warning("Parameter %s not found in Qwen3-Omni", name)
+                    continue
+                param = params[name]
+                loader = getattr(param, "weight_loader", default_weight_loader)
+                loader(param, loaded_weight)
+                loaded.add(name)
+                continue
+
+            if name.startswith("audio_tower."):
+                if not self.is_multimodal_active:
+                    continue
+                loaded_name = self.audio_tower.load_weight(name, loaded_weight)
+                if loaded_name is None:
+                    logger.warning("Parameter %s not found in Qwen3-Omni", name)
+                else:
+                    loaded.add(f"audio_tower.{loaded_name}")
+                continue
+
+            layer_id = get_layer_id(name)
+            if (
+                layer_id is not None
+                and hasattr(self.model, "start_layer")
+                and not self.model.start_layer <= layer_id < self.model.end_layer
+            ):
+                continue
+            if "rotary_emb" in name:
+                continue
+            if self.config.tie_word_embeddings and name == "lm_head.weight":
+                continue
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name or "mlp.experts" in name:
+                    continue
+                mapped_name = name.replace(weight_name, param_name)
+                if mapped_name.endswith(ignore_suffixes) and mapped_name not in params:
+                    break
+                if mapped_name not in params:
+                    break
+                param = params[mapped_name]
+                param.weight_loader(param, loaded_weight, shard_id)
+                loaded.add(mapped_name)
+                break
+            else:
+                if name.endswith((".bias", "_bias")) and name not in params:
+                    continue
+                if moe_loader.matches(name):
+                    loaded.add(moe_loader.load(name, loaded_weight))
+                    continue
+                if moe_loader.is_expert_checkpoint_weight(name):
+                    continue
+                if name.endswith(ignore_suffixes) and name not in params:
+                    continue
+                if name not in params:
+                    logger.warning("Parameter %s not found in Qwen3-Omni", name)
+                    continue
+                param = params[name]
+                loader = getattr(param, "weight_loader", default_weight_loader)
+                loader(param, loaded_weight)
+                loaded.add(name)
+
+        return loaded
+
+
+EntryClass = [Qwen3OmniMoeForConditionalGeneration]

--- a/python/tokenspeed/runtime/multimodal/embedder.py
+++ b/python/tokenspeed/runtime/multimodal/embedder.py
@@ -18,14 +18,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""VisionEmbedder: assemble LM input embeddings with vision tokens spliced in.
+"""Assemble LM input embeddings with multimodal encoder tokens spliced in.
 
 Three sequential phases:
 
   1. ``_plan`` walks the active multimodal inputs in the current forward
      batch and emits an :class:`EncodePlan` listing (a) the unique items
      that still need to be encoded this iteration and (b) every flat
-     position in ``input_ids`` that should be filled from a vision token,
+     position in ``input_ids`` that should be filled from an encoder token,
      along with the source range inside the owning item's encoded tensor.
 
   2. ``_encode`` invokes the model-supplied encoder once per modality with
@@ -34,7 +34,7 @@ Three sequential phases:
      ``item.encoded_deepstack``).
 
   3. ``_assemble`` runs the text-token embedding lookup and slices the
-     vision-token ranges into the right positions using the plan's
+     encoder-token ranges into the right positions using the plan's
      :class:`ScatterRange` records.
 
 Per-item encoded tensors live on the :class:`MultimodalDataItem` itself,
@@ -44,10 +44,10 @@ released by GC. Across chunked-prefill iterations of the same request the
 item is identical Python object, so the second chunk sees ``item.encoded``
 already set and skips re-encoding.
 
-Within a single forward batch we still de-duplicate by ``item.hash``: if
-two requests reference the same image content, only the first item is
-fed to the encoder; the second request's scatter ranges read from the
-first item's ``encoded`` tensor.
+Within a single forward batch we still de-duplicate by modality and
+``item.hash``: if two requests reference the same media content using
+the same modality, only the first item is fed to the encoder; the second
+request's scatter ranges read from the first item's ``encoded`` tensor.
 """
 
 from __future__ import annotations
@@ -129,7 +129,7 @@ def pad_input_tokens(input_ids: list[int], mm_inputs: MultimodalInputs) -> list[
 
 @dataclass(frozen=True)
 class ScatterRange:
-    """One contiguous range to fill with vision tokens.
+    """One contiguous range to fill with multimodal encoder tokens.
 
     ``flat_dst_*`` are positions in the batch-flat ``input_ids`` tensor
     (inclusive on both ends). ``item_src_*`` are positions within
@@ -150,8 +150,8 @@ class EncodePlan:
     """Work to do this prefill iteration.
 
     ``misses_by_modality`` lists the canonical items the encoder needs to
-    process; each unique content hash appears at most once.
-    ``scatter_ranges`` describes every place a vision token must land.
+    process; each modality/content-hash pair appears at most once.
+    ``scatter_ranges`` describes every place an encoder token must land.
     """
 
     misses_by_modality: dict[Modality, list[MultimodalDataItem]] = field(
@@ -175,12 +175,12 @@ def _item_token_count(item: MultimodalDataItem) -> int:
 
 
 # ---------------------------------------------------------------------------
-# VisionEmbedder
+# MultimodalEmbedder
 # ---------------------------------------------------------------------------
 
 
-class VisionEmbedder:
-    """Vision-aware input embedding pipeline for one model executor."""
+class MultimodalEmbedder:
+    """Multimodal input embedding pipeline for one model executor."""
 
     def __init__(self) -> None:
         self._h2d_stream: torch.cuda.Stream | None = None
@@ -196,7 +196,7 @@ class VisionEmbedder:
         multimodal_model: nn.Module,
         is_decode_or_idle: bool = False,
     ) -> tuple[torch.Tensor | None, dict[str, Any]]:
-        """Compose LM input embeddings with vision tokens scattered in.
+        """Compose LM input embeddings with encoder tokens scattered in.
 
         Returns ``(None, {})`` when there is nothing multimodal to do this
         forward (decode iteration, or no active multimodal inputs). The
@@ -243,7 +243,7 @@ class VisionEmbedder:
         )
 
         cleanup_started = time.perf_counter() if LOG_MM_TIMING else None
-        released_encoded_features = self._drop_encoded_pixel_features(ctx)
+        released_encoded_features = self._drop_encoded_features(ctx)
         cleanup_elapsed_ms = (
             (time.perf_counter() - cleanup_started) * 1000
             if cleanup_started is not None
@@ -256,7 +256,7 @@ class VisionEmbedder:
                 if items
             }
             logger.info(
-                "mm_timing vision_embedder_apply_ms total=%.3f plan=%.3f "
+                "mm_timing multimodal_embedder_apply_ms total=%.3f plan=%.3f "
                 "encode=%.3f alias=%.3f assemble=%.3f feature_cleanup=%.3f "
                 "scatter_ranges=%d misses=%s input_rows=%d aliases=%d "
                 "released_alias_features=%d released_encoded_features=%d",
@@ -282,9 +282,9 @@ class VisionEmbedder:
         if not ctx.mm_inputs:
             return plan
 
-        # Within-batch dedup: first item per content hash is canonical;
-        # duplicates reuse its encoded tensor.
-        canonical_by_hash: dict[int, MultimodalDataItem] = {}
+        # Within-batch dedup: first item per modality and content hash is
+        # canonical; duplicates reuse its encoded tensor.
+        canonical_by_key: dict[tuple[Modality, int], MultimodalDataItem] = {}
         scheduled: set[MultimodalDataItem] = set()
 
         # Walk the FULL batch (including text-only / decode requests)
@@ -312,12 +312,15 @@ class VisionEmbedder:
 
                 if item.encoded is not None:
                     canonical = item
-                elif item.hash is not None and item.hash in canonical_by_hash:
-                    canonical = canonical_by_hash[item.hash]
+                elif (
+                    item.hash is not None
+                    and (item.modality, item.hash) in canonical_by_key
+                ):
+                    canonical = canonical_by_key[(item.modality, item.hash)]
                 else:
                     canonical = item
                     if item.hash is not None:
-                        canonical_by_hash[item.hash] = item
+                        canonical_by_key[(item.modality, item.hash)] = item
 
                 if canonical is not item:
                     plan.aliases_by_canonical[canonical].append(item)
@@ -365,11 +368,11 @@ class VisionEmbedder:
             spec = encoders.get(modality)
             if spec is None:
                 raise RuntimeError(
-                    f"VisionEmbedder: no encoder registered for {modality}"
+                    f"MultimodalEmbedder: no encoder registered for {modality}"
                 )
 
             move_started = time.perf_counter() if LOG_MM_TIMING else None
-            self._move_pixel_features_to_device(items, device)
+            self._move_features_to_device(items, device)
             move_elapsed_ms = (
                 (time.perf_counter() - move_started) * 1000
                 if move_started is not None
@@ -441,7 +444,10 @@ class VisionEmbedder:
 
         kwargs: dict[str, Any] = {}
         deepstack_buffer: torch.Tensor | None = None
-        if any(spec.deepstack for spec in encoders.values()):
+        deepstack_modalities = {
+            modality for modality, spec in encoders.items() if spec.deepstack
+        }
+        if any(r.item.modality in deepstack_modalities for r in plan.scatter_ranges):
             num_deepstack = len(multimodal_model.deepstack_visual_indexes)
             shape = input_embeds.shape[:-1] + (input_embeds.shape[-1] * num_deepstack,)
             deepstack_buffer = torch.zeros(
@@ -453,7 +459,7 @@ class VisionEmbedder:
             main = r.item.encoded
             if main is None:
                 raise RuntimeError(
-                    "VisionEmbedder: item scheduled for encode has no "
+                    "MultimodalEmbedder: item scheduled for encode has no "
                     "encoded tensor after _encode; this is a bug"
                 )
             src = main[r.item_src_start : r.item_src_end + 1]
@@ -478,10 +484,10 @@ class VisionEmbedder:
             self._h2d_stream = torch.cuda.Stream(device=device)
         return self._h2d_stream
 
-    def _move_pixel_features_to_device(
+    def _move_features_to_device(
         self, items: list[MultimodalDataItem], device: torch.device
     ) -> None:
-        """Stage pixel features onto ``device`` on a dedicated H2D stream.
+        """Stage encoder features onto ``device`` on a dedicated H2D stream.
 
         Inputs that originate from the SHM transport are pinned, so the
         H2D copy can actually run async with respect to the LM kernels
@@ -526,12 +532,16 @@ class VisionEmbedder:
         return True
 
     @staticmethod
-    def _drop_encoded_pixel_features(ctx: MultimodalForwardContext) -> int:
+    def _drop_encoded_features(ctx: MultimodalForwardContext) -> int:
         released = 0
         for mm in ctx.mm_inputs:
             if mm is None:
                 continue
             for it in mm.mm_items:
-                if it.encoded is not None and VisionEmbedder._drop_raw_feature(it):
+                if it.encoded is not None and MultimodalEmbedder._drop_raw_feature(it):
                     released += 1
         return released
+
+
+# Compatibility alias for model implementations that predate audio support.
+VisionEmbedder = MultimodalEmbedder

--- a/python/tokenspeed/runtime/multimodal/mrope.py
+++ b/python/tokenspeed/runtime/multimodal/mrope.py
@@ -42,7 +42,194 @@ from tokenspeed.runtime.layers.rotary_embedding import MRotaryEmbedding
 _MROPE_ARCHITECTURES = {
     "Qwen3_5ForConditionalGeneration",
     "Qwen3_5MoeForConditionalGeneration",
+    "Qwen3OmniMoeForConditionalGeneration",
 }
+
+_QWEN3_OMNI_ARCHITECTURES = {
+    "Qwen3OmniMoeForConditionalGeneration",
+}
+
+
+def _modality_name(item) -> str:
+    modality = item.modality
+    return getattr(modality, "name", str(modality)).lower()
+
+
+def _as_grid_rows(value, key: str) -> torch.Tensor:
+    grid = torch.as_tensor(value, dtype=torch.long).reshape(-1, 3).cpu()
+    if torch.any(grid <= 0):
+        raise ValueError(f"{key} must contain positive [T, H, W] values")
+    return grid
+
+
+def _per_grid_seconds(item, num_grids: int, default: float) -> list[float]:
+    data = item.model_specific_data
+    value = data.get("video_second_per_grid")
+    if value is None:
+        return [default] * num_grids
+
+    values = torch.as_tensor(value, dtype=torch.float32).flatten().tolist()
+    if len(values) == 1:
+        return values * num_grids
+    if len(values) != num_grids:
+        raise ValueError(
+            "video_second_per_grid must be scalar or have one value per video grid"
+        )
+    return values
+
+
+def _omni_media_segments(thinker_config, input_len: int, mm_items):
+    """Return authored media spans with one position descriptor per span."""
+    merge = thinker_config.vision_config.spatial_merge_size
+    default_seconds = float(getattr(thinker_config, "seconds_per_chunk", 2.0))
+    segments = []
+
+    for item in mm_items:
+        offsets = list(item.offsets or [])
+        if not offsets:
+            continue
+        modality = _modality_name(item)
+
+        if modality == "audio":
+            descriptors = [("audio", None, None)] * len(offsets)
+        elif modality in ("image", "video"):
+            key = f"{modality}_grid_thw"
+            if key not in item.model_specific_data:
+                raise ValueError(f"Qwen3-Omni {modality} item is missing {key}")
+            if modality == "video" and "use_audio_in_video" in item.model_specific_data:
+                interleaved = torch.as_tensor(
+                    item.model_specific_data["use_audio_in_video"]
+                )
+                if bool(interleaved.any().item()):
+                    raise ValueError(
+                        "Qwen3-Omni use_audio_in_video=true is not supported"
+                    )
+            grids = _as_grid_rows(item.model_specific_data[key], key)
+
+            if len(grids) != len(offsets):
+                raise ValueError(
+                    f"Qwen3-Omni {modality} has {len(offsets)} placeholder spans "
+                    f"but {len(grids)} grid rows"
+                )
+
+            seconds = (
+                _per_grid_seconds(item, len(grids), default_seconds)
+                if modality == "video"
+                else [None] * len(grids)
+            )
+            descriptors = [
+                (modality, grid, second)
+                for grid, second in zip(grids, seconds, strict=True)
+            ]
+        else:
+            raise ValueError(f"Unsupported Qwen3-Omni modality: {modality}")
+
+        for offset, descriptor in zip(offsets, descriptors, strict=True):
+            start, end = map(int, offset)
+            if start < 0 or end < start or end >= input_len:
+                raise ValueError(
+                    f"Invalid Qwen3-Omni media offset [{start}, {end}] for "
+                    f"input length {input_len}"
+                )
+            segments.append((start, end, *descriptor))
+
+    segments.sort(key=lambda segment: segment[0])
+    return segments, merge
+
+
+def _compute_qwen3_omni_mrope_positions(hf_config, input_ids, mm_items):
+    """Compute Qwen3-Omni M-RoPE for independent image/audio/video inputs.
+
+    The gateway's inclusive item offsets are authoritative. Audio advances all
+    three axes linearly. Vision uses T/H/W axes; video T is expressed on the
+    model's ``position_id_per_seconds`` clock. Audio extracted from a video is
+    intentionally not interleaved here (``use_audio_in_video=false``).
+    """
+    thinker_config = getattr(hf_config, "thinker_config", hf_config)
+    position_id_per_seconds = float(
+        getattr(thinker_config, "position_id_per_seconds", 13)
+    )
+    input_len = len(input_ids)
+    segments, spatial_merge_size = _omni_media_segments(
+        thinker_config, input_len, mm_items
+    )
+
+    position_chunks = []
+    cursor = 0
+    next_position = 0
+
+    def append_linear(length: int) -> None:
+        nonlocal next_position
+        if length <= 0:
+            return
+        positions = torch.arange(
+            next_position, next_position + length, dtype=torch.long
+        )
+        position_chunks.append(positions.unsqueeze(0).expand(3, -1))
+        next_position += length
+
+    for start, end, modality, grid, seconds_per_grid in segments:
+        if start < cursor:
+            raise ValueError("Qwen3-Omni media placeholder spans overlap")
+        append_linear(start - cursor)
+        span = end - start + 1
+
+        if modality == "audio":
+            append_linear(span)
+        else:
+            t, h, w = (int(value) for value in grid)
+            if h % spatial_merge_size or w % spatial_merge_size:
+                raise ValueError(
+                    "Qwen3-Omni vision grids must be divisible by spatial_merge_size"
+                )
+            h //= spatial_merge_size
+            w //= spatial_merge_size
+            expected_span = t * h * w
+            if span != expected_span:
+                raise ValueError(
+                    f"Qwen3-Omni {modality} placeholder span has {span} tokens; "
+                    f"grid requires {expected_span}"
+                )
+
+            temporal = torch.arange(t, dtype=torch.float32)
+            if modality == "video":
+                temporal *= float(seconds_per_grid) * position_id_per_seconds
+            else:
+                temporal *= position_id_per_seconds
+            temporal = temporal.to(torch.long)
+            temporal = temporal.view(-1, 1).expand(-1, h * w).flatten()
+            height = (
+                torch.arange(h, dtype=torch.long)
+                .view(1, -1, 1)
+                .expand(t, -1, w)
+                .flatten()
+            )
+            width = (
+                torch.arange(w, dtype=torch.long)
+                .view(1, 1, -1)
+                .expand(t, h, -1)
+                .flatten()
+            )
+            media_positions = (
+                torch.stack((temporal, height, width), dim=0) + next_position
+            )
+            position_chunks.append(media_positions)
+            next_position = int(media_positions.max().item()) + 1
+
+        cursor = end + 1
+
+    append_linear(input_len - cursor)
+    positions = (
+        torch.cat(position_chunks, dim=1)
+        if position_chunks
+        else torch.empty((3, 0), dtype=torch.long)
+    )
+    if positions.shape[1] != input_len:
+        raise RuntimeError(
+            "Qwen3-Omni M-RoPE position count does not match the input length"
+        )
+    delta = torch.tensor([[next_position - input_len]], dtype=torch.long)
+    return positions, delta
 
 
 def compute_mrope_positions(hf_config, input_ids, mm_items):
@@ -55,6 +242,9 @@ def compute_mrope_positions(hf_config, input_ids, mm_items):
     architectures = getattr(hf_config, "architectures", None) or []
     if not any(arch in _MROPE_ARCHITECTURES for arch in architectures):
         return None, None
+
+    if any(arch in _QWEN3_OMNI_ARCHITECTURES for arch in architectures):
+        return _compute_qwen3_omni_mrope_positions(hf_config, input_ids, mm_items)
 
     image_grids = [
         item.model_specific_data["image_grid_thw"]

--- a/python/tokenspeed/runtime/utils/hf_transformers_utils.py
+++ b/python/tokenspeed/runtime/utils/hf_transformers_utils.py
@@ -50,6 +50,7 @@ from tokenspeed.runtime.configs import (
     Qwen2Config,
     Qwen3_5Config,
     Qwen3_5MoeConfig,
+    Qwen3ASRConfig,
     Qwen3Config,
     Qwen3MoeConfig,
 )
@@ -59,6 +60,7 @@ _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = {
     Qwen2Config.model_type: Qwen2Config,
     Qwen3Config.model_type: Qwen3Config,
     Qwen3MoeConfig.model_type: Qwen3MoeConfig,
+    Qwen3ASRConfig.model_type: Qwen3ASRConfig,
     DeepseekV4Config.model_type: DeepseekV4Config,
     Qwen3_5Config.model_type: Qwen3_5Config,
     Qwen3_5MoeConfig.model_type: Qwen3_5MoeConfig,
@@ -112,7 +114,7 @@ def get_hf_text_config(config: PretrainedConfig):
     if hasattr(config, "language_config"):
         text_config = config.language_config
     if hasattr(config, "thinker_config"):
-        # qwen2.5 omni
+        # Qwen Omni wrappers keep the language model below thinker_config.
         thinker_config = config.thinker_config
         if hasattr(thinker_config, "text_config"):
             thinker_config.text_config.dtype = thinker_config.dtype
@@ -282,6 +284,10 @@ def get_config(
         "Qwen3_5MoeConfig",
         "Qwen3_5ForConditionalGeneration",
         "Qwen3_5ForConditionalGenerationNextN",
+        "Qwen3OmniMoeForConditionalGeneration",
+        "Qwen3OmniMoeConfig",
+        "Qwen3ASRForConditionalGeneration",
+        "Qwen3ASRConfig",
     ]:
         config.text_config = text_config
         return config

--- a/test/runtime/models/test_qwen3_audio.py
+++ b/test/runtime/models/test_qwen3_audio.py
@@ -1,0 +1,287 @@
+"""Unit tests for the shared Qwen3-ASR/Qwen3-Omni audio tower."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tokenspeed.runtime.models.qwen3_audio import (
+    Qwen3AudioEncoder,
+    pack_qwen3_audio_features,
+    qwen3_audio_output_lengths,
+)
+from tokenspeed.runtime.multimodal.inputs import Modality, MultimodalDataItem
+
+
+def _upstream_output_lengths(lengths: torch.Tensor) -> torch.Tensor:
+    remainder = lengths % 100
+    after_first_conv = (remainder - 1) // 2 + 1
+    tail = ((after_first_conv - 1) // 2 + 1 - 1) // 2 + 1
+    return tail + (lengths // 100) * 13
+
+
+def _audio_item(feature, **model_specific_data):
+    return MultimodalDataItem(
+        modality=Modality.AUDIO,
+        feature=feature,
+        offsets=[(0, 0)],
+        model_specific_data=model_specific_data,
+    )
+
+
+def _tiny_config():
+    return SimpleNamespace(
+        activation_function="gelu",
+        conv_chunksize=2,
+        d_model=32,
+        downsample_hidden_size=4,
+        encoder_attention_heads=4,
+        encoder_ffn_dim=64,
+        encoder_layers=1,
+        max_source_positions=16,
+        n_window=4,
+        n_window_infer=16,
+        num_mel_bins=8,
+        output_dim=32,
+    )
+
+
+def _tiny_asr_config():
+    return SimpleNamespace(
+        architectures=["Qwen3ASRForConditionalGeneration"],
+        thinker_config=SimpleNamespace(
+            audio_config=_tiny_config(),
+            text_config=SimpleNamespace(hidden_size=32, num_hidden_layers=2),
+        ),
+    )
+
+
+def test_output_lengths_match_reference_and_custom_chunking():
+    lengths = torch.tensor([1, 2, 7, 8, 99, 100, 101, 199, 200, 3000])
+    torch.testing.assert_close(
+        qwen3_audio_output_lengths(lengths), _upstream_output_lengths(lengths)
+    )
+    custom = qwen3_audio_output_lengths([8, 9, 16, 17], n_window=4)
+    assert custom.tolist() == [1, 2, 2, 3]
+
+
+def test_audio_tower_uses_platform_default_for_vision_only_cudnn_backend():
+    normalize = Qwen3AudioEncoder._normalize_attention_backend
+    assert normalize("flashinfer_cudnn") is None
+    assert normalize("fa4") == "fa4"
+
+
+def test_asr_config_parses_official_nested_shape(tmp_path):
+    from tokenspeed.runtime.configs.qwen3_asr_config import Qwen3ASRConfig
+
+    raw_config = {
+        "architectures": ["Qwen3ASRForConditionalGeneration"],
+        "model_type": "qwen3_asr",
+        "support_languages": ["Chinese", "English"],
+        "thinker_config": {
+            "audio_config": {
+                "model_type": "qwen3_asr_audio_encoder",
+                "d_model": 1024,
+                "encoder_layers": 24,
+                "n_window": 50,
+                "output_dim": 2048,
+            },
+            "audio_start_token_id": 151669,
+            "audio_end_token_id": 151670,
+            "audio_token_id": 151676,
+            "dtype": "bfloat16",
+            "text_config": {
+                "model_type": "qwen3",
+                "hidden_size": 2048,
+                "num_hidden_layers": 28,
+                "num_attention_heads": 16,
+                "num_key_value_heads": 8,
+                "head_dim": 128,
+                "intermediate_size": 6144,
+                "vocab_size": 151936,
+            },
+        },
+    }
+    (tmp_path / "config.json").write_text(json.dumps(raw_config))
+    config = Qwen3ASRConfig.from_pretrained(tmp_path)
+
+    assert config.architectures == ["Qwen3ASRForConditionalGeneration"]
+    assert config.thinker_config.text_config.hidden_size == 2048
+    assert config.thinker_config.audio_config.encoder_layers == 24
+    assert config.audio_start_token_id == 151669
+    assert config.audio_end_token_id == 151670
+    assert config.audio_token_id == 151676
+
+
+def test_pack_features_uses_explicit_lengths_and_masks():
+    first = torch.arange(8 * 6, dtype=torch.float32).reshape(1, 8, 6)
+    second = torch.arange(8 * 5, dtype=torch.float32).reshape(8, 5) + 100
+    packed, lengths = pack_qwen3_audio_features(
+        [
+            _audio_item(first, audio_feature_lengths=torch.tensor([4])),
+            _audio_item(
+                second,
+                feature_attention_mask=torch.tensor([[1, 1, 1, 0, 0]]),
+            ),
+        ],
+        num_mel_bins=8,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+
+    assert lengths.tolist() == [4, 3]
+    assert packed.shape == (8, 7)
+    torch.testing.assert_close(packed[:, :4], first[0, :, :4])
+    torch.testing.assert_close(packed[:, 4:], second[:, :3])
+
+
+def test_pack_features_rejects_sparse_mask():
+    item = _audio_item(
+        torch.zeros(8, 4),
+        feature_attention_mask=torch.tensor([1, 0, 1, 0]),
+    )
+    with pytest.raises(ValueError, match="right-padded"):
+        pack_qwen3_audio_features(
+            [item],
+            num_mel_bins=8,
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+        )
+
+
+def test_asr_wrapper_maps_official_thinker_weight_names():
+    from tokenspeed.runtime.models import qwen3_asr
+
+    assert Qwen3AudioEncoder.map_weight_name(
+        "thinker.audio_tower.layers.0.self_attn.q_proj.weight"
+    ) == ("layers.0.self_attn.qkv_proj.weight", "q")
+    assert qwen3_asr.Qwen3ASRForConditionalGeneration.map_language_weight_name(
+        "thinker.model.layers.0.self_attn.k_proj.weight"
+    ) == ("language_model.model.layers.0.self_attn.qkv_proj.weight", "k")
+    assert qwen3_asr.Qwen3ASRForConditionalGeneration.map_language_weight_name(
+        "thinker.model.layers.0.mlp.gate_proj.weight"
+    ) == ("language_model.model.layers.0.mlp.gate_up_proj.weight", 0)
+    assert qwen3_asr.Qwen3ASRForConditionalGeneration.map_language_weight_name(
+        "thinker.lm_head.weight"
+    ) == ("language_model.lm_head.weight", None)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="model loader needs CUDA")
+def test_tiny_asr_wrapper_loads_audio_and_language_roots():
+    from tokenspeed.runtime.configs.qwen3_asr_config import (
+        Qwen3ASRAudioEncoderConfig,
+        Qwen3ASRConfig,
+        Qwen3ASRThinkerConfig,
+    )
+    from tokenspeed.runtime.configs.qwen3_config import Qwen3Config
+    from tokenspeed.runtime.distributed.mapping import Mapping
+    from tokenspeed.runtime.models.qwen3_asr import Qwen3ASRForConditionalGeneration
+
+    audio_config = Qwen3ASRAudioEncoderConfig(**vars(_tiny_config()))
+    text_config = Qwen3Config(
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=8,
+        max_position_embeddings=128,
+        tie_word_embeddings=False,
+    )
+    config = Qwen3ASRConfig(
+        architectures=["Qwen3ASRForConditionalGeneration"],
+        thinker_config=Qwen3ASRThinkerConfig(
+            audio_config=audio_config,
+            text_config=text_config,
+        ),
+    )
+    with torch.device("cuda"):
+        model = Qwen3ASRForConditionalGeneration(
+            config,
+            Mapping(rank=0, world_size=1),
+            mm_attention_backend="triton_attn",
+        ).eval()
+
+    qkv = model.language_model.model.layers[0].self_attn.qkv_proj.weight
+    q_weight = torch.randn(32, 32, device="cuda", dtype=qkv.dtype)
+    audio_bias = torch.randn_like(model.audio_tower.conv2d1.bias)
+    lm_head = torch.randn_like(model.language_model.lm_head.weight)
+    loaded = model.load_weights(
+        [
+            ("thinker.audio_tower.conv2d1.bias", audio_bias),
+            ("thinker.model.layers.0.self_attn.q_proj.weight", q_weight),
+            ("thinker.lm_head.weight", lm_head),
+        ]
+    )
+
+    torch.testing.assert_close(model.audio_tower.conv2d1.bias, audio_bias)
+    torch.testing.assert_close(qkv[:32], q_weight)
+    torch.testing.assert_close(model.language_model.lm_head.weight, lm_head)
+    assert loaded == {
+        "audio_tower.conv2d1.bias",
+        "language_model.model.layers.0.self_attn.qkv_proj.weight",
+        "language_model.lm_head.weight",
+    }
+
+
+def test_asr_wrapper_rejects_audio_text_dimension_mismatch():
+    from tokenspeed.runtime.distributed.mapping import Mapping
+    from tokenspeed.runtime.models.qwen3_asr import Qwen3ASRForConditionalGeneration
+
+    config = _tiny_asr_config()
+    config.thinker_config.audio_config.output_dim = 8
+    with pytest.raises(ValueError, match="output_dim"):
+        Qwen3ASRForConditionalGeneration(config, Mapping(rank=0, world_size=1))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="audio tower needs CUDA")
+def test_tiny_audio_tower_matches_transformers_and_loads_fused_qkv():
+    from transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe import (
+        Qwen3OmniMoeAudioEncoderConfig,
+    )
+    from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
+        Qwen3OmniMoeAudioEncoder as HFAudioEncoder,
+    )
+
+    from tokenspeed.runtime.distributed.mapping import Mapping
+
+    config = Qwen3OmniMoeAudioEncoderConfig(**vars(_tiny_config()))
+    mapping = Mapping(rank=0, world_size=1)
+    torch.manual_seed(4)
+    reference = HFAudioEncoder(config).cuda().eval()
+    with torch.device("cuda"):
+        tower = Qwen3AudioEncoder(
+            config,
+            mapping,
+            mm_attention_backend="triton_attn",
+        ).eval()
+    loaded = tower.load_weights(reference.state_dict().items())
+    assert loaded == set(dict(tower.named_parameters()))
+
+    items = [
+        _audio_item(torch.randn(8, 8)),
+        _audio_item(torch.randn(1, 8, 10), audio_feature_lengths=9),
+    ]
+    with torch.no_grad():
+        output = tower.encode(items)
+        packed, feature_lengths = pack_qwen3_audio_features(
+            items,
+            num_mel_bins=config.num_mel_bins,
+            device=tower.device,
+            dtype=tower.dtype,
+        )
+        expected = reference(
+            input_features=packed,
+            feature_lens=feature_lengths,
+        ).last_hidden_state
+    expected_tokens = qwen3_audio_output_lengths([8, 9], n_window=4).sum().item()
+    assert output.shape == (expected_tokens, config.output_dim)
+    torch.testing.assert_close(output, expected, atol=2e-4, rtol=2e-4)
+
+    qkv = tower.layers[0].self_attn.qkv_proj.weight
+    q = torch.randn(config.d_model, config.d_model, device="cuda", dtype=qkv.dtype)
+    loaded_name = tower.load_weight("layers.0.self_attn.q_proj.weight", q)
+    assert loaded_name == "layers.0.self_attn.qkv_proj.weight"
+    torch.testing.assert_close(qkv[: config.d_model], q)

--- a/test/runtime/models/test_qwen3_omni.py
+++ b/test/runtime/models/test_qwen3_omni.py
@@ -1,0 +1,414 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+from tokenspeed.runtime.configs.model_config import (
+    ModelConfig,
+    get_hf_text_config,
+    is_audio_model,
+    is_multimodal_model,
+)
+from tokenspeed.runtime.models.qwen3_omni import (
+    Qwen3OmniMoeForConditionalGeneration,
+    Qwen3OmniMoeTextModel,
+    _shared_vision_config,
+)
+from tokenspeed.runtime.multimodal.embedder import (
+    EncodePlan,
+    EncoderSpec,
+    MultimodalEmbedder,
+    ScatterRange,
+)
+from tokenspeed.runtime.multimodal.inputs import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalForwardContext,
+    MultimodalInputs,
+)
+from tokenspeed.runtime.multimodal.mrope import compute_mrope_positions
+
+
+def _omni_config():
+    vision = SimpleNamespace(spatial_merge_size=2)
+    text = SimpleNamespace(hidden_size=2)
+    thinker = SimpleNamespace(
+        vision_config=vision,
+        text_config=text,
+        position_id_per_seconds=13,
+        seconds_per_chunk=2,
+    )
+    return SimpleNamespace(
+        architectures=["Qwen3OmniMoeForConditionalGeneration"],
+        thinker_config=thinker,
+    )
+
+
+class TestQwen3OmniConfig(unittest.TestCase):
+    def test_architecture_flags_cover_asr_and_omni(self):
+        for architecture in (
+            "Qwen3ASRForConditionalGeneration",
+            "Qwen3OmniMoeForConditionalGeneration",
+        ):
+            with self.subTest(architecture=architecture):
+                self.assertTrue(is_multimodal_model([architecture]))
+                self.assertTrue(is_audio_model([architecture]))
+
+        direct_thinker = "Qwen3OmniMoeThinkerForConditionalGeneration"
+        self.assertFalse(is_multimodal_model([direct_thinker]))
+        self.assertFalse(is_audio_model([direct_thinker]))
+
+    def test_model_config_unwraps_omni_thinker_text(self):
+        config = _omni_config()
+        self.assertIs(get_hf_text_config(config), config.thinker_config.text_config)
+
+    def test_encode_disaggregation_rejects_audio_models(self):
+        hf_config = SimpleNamespace(architectures=["Qwen3ASRForConditionalGeneration"])
+        server_args = SimpleNamespace(
+            mapping=None,
+            language_model_only=False,
+            disaggregation_mode="encode",
+        )
+        with (
+            patch(
+                "tokenspeed.runtime.configs.model_config.get_config",
+                return_value=hf_config,
+            ),
+            patch(
+                "tokenspeed.runtime.configs.model_config.get_generation_config",
+                return_value=None,
+            ),
+            patch(
+                "tokenspeed.runtime.configs.model_config.get_hf_text_config",
+                return_value=SimpleNamespace(),
+            ),
+            self.assertRaisesRegex(ValueError, "does not support audio models"),
+        ):
+            ModelConfig(
+                "stub",
+                model_override_args="{}",
+                server_args=server_args,
+            )
+
+
+class TestQwen3OmniMultimodalEmbedder(unittest.TestCase):
+    @staticmethod
+    def _plan_for(item: MultimodalDataItem) -> EncodePlan:
+        return EncodePlan(
+            scatter_ranges=[
+                ScatterRange(
+                    flat_dst_start=0,
+                    flat_dst_end=0,
+                    item=item,
+                    item_src_start=0,
+                    item_src_end=0,
+                )
+            ]
+        )
+
+    def test_same_hash_does_not_alias_across_modalities(self):
+        audio = MultimodalDataItem(
+            modality=Modality.AUDIO,
+            hash=7,
+            offsets=[(0, 0)],
+        )
+        video = MultimodalDataItem(
+            modality=Modality.VIDEO,
+            hash=7,
+            offsets=[(1, 1)],
+        )
+        ctx = MultimodalForwardContext(
+            mm_inputs=[MultimodalInputs(mm_items=[audio, video])],
+            extend_prefix_lens=[0],
+            extend_seq_lens=[2],
+        )
+
+        plan = MultimodalEmbedder()._plan(ctx)
+
+        self.assertEqual(plan.misses_by_modality[Modality.AUDIO], [audio])
+        self.assertEqual(plan.misses_by_modality[Modality.VIDEO], [video])
+        self.assertEqual([r.item for r in plan.scatter_ranges], [audio, video])
+        self.assertFalse(plan.aliases_by_canonical)
+
+    def test_deepstack_buffer_only_for_active_deepstack_modality(self):
+        embedder = MultimodalEmbedder()
+        text_embedding = nn.Embedding(2, 2)
+        input_ids = torch.tensor([0])
+        encoders = {
+            Modality.AUDIO: EncoderSpec(fn=lambda _: torch.empty(0, 2)),
+            Modality.IMAGE: EncoderSpec(fn=lambda _: torch.empty(0, 2), deepstack=True),
+        }
+        model = SimpleNamespace(deepstack_visual_indexes=[0])
+
+        audio = MultimodalDataItem(
+            modality=Modality.AUDIO,
+            encoded=torch.tensor([[1.0, 2.0]]),
+        )
+        _, audio_kwargs = embedder._assemble(
+            input_ids,
+            text_embedding,
+            self._plan_for(audio),
+            encoders,
+            model,
+        )
+        self.assertNotIn("input_deepstack_embeds", audio_kwargs)
+
+        image = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            encoded=torch.tensor([[1.0, 2.0]]),
+            encoded_deepstack=torch.tensor([[3.0, 4.0]]),
+        )
+        _, image_kwargs = embedder._assemble(
+            input_ids,
+            text_embedding,
+            self._plan_for(image),
+            encoders,
+            model,
+        )
+        torch.testing.assert_close(
+            image_kwargs["input_deepstack_embeds"],
+            image.encoded_deepstack,
+        )
+
+
+class TestQwen3OmniMrope(unittest.TestCase):
+    def test_mixed_modalities_follow_authored_offsets(self):
+        audio = MultimodalDataItem(
+            modality=Modality.AUDIO,
+            offsets=[(2, 4)],
+        )
+        image = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            offsets=[(8, 11)],
+            model_specific_data={"image_grid_thw": torch.tensor([[1, 4, 4]])},
+        )
+        video = MultimodalDataItem(
+            modality=Modality.VIDEO,
+            offsets=[(15, 22)],
+            model_specific_data={
+                "video_grid_thw": torch.tensor([[2, 4, 4]]),
+                "video_second_per_grid": torch.tensor([1.0]),
+            },
+        )
+
+        # Pass items out of order: item offsets, not modality batches, define
+        # the authored image/audio/video sequence.
+        positions, delta = compute_mrope_positions(
+            _omni_config(), list(range(25)), [video, audio, image]
+        )
+
+        self.assertEqual(positions.shape, (3, 25))
+        self.assertTrue(torch.equal(positions[:, :8], torch.arange(8).expand(3, -1)))
+        self.assertEqual(
+            positions[:, 8:12].tolist(),
+            [
+                [8, 8, 8, 8],
+                [8, 8, 9, 9],
+                [8, 9, 8, 9],
+            ],
+        )
+        self.assertTrue(
+            torch.equal(positions[:, 12:15], torch.arange(10, 13).expand(3, -1))
+        )
+        self.assertEqual(positions[0, 15:23].tolist(), [13] * 4 + [26] * 4)
+        self.assertEqual(positions[1, 15:23].tolist(), [13, 13, 14, 14] * 2)
+        self.assertEqual(positions[2, 15:23].tolist(), [13, 14, 13, 14] * 2)
+        self.assertTrue(
+            torch.equal(positions[:, 23:], torch.arange(27, 29).expand(3, -1))
+        )
+        self.assertEqual(delta.tolist(), [[4]])
+
+    def test_multiple_videos_support_fractional_seconds_per_grid(self):
+        first = MultimodalDataItem(
+            modality=Modality.VIDEO,
+            offsets=[(2, 9)],
+            model_specific_data={
+                "video_grid_thw": torch.tensor([[2, 4, 4]]),
+                "video_second_per_grid": torch.tensor([0.5]),
+            },
+        )
+        second = MultimodalDataItem(
+            modality=Modality.VIDEO,
+            offsets=[(12, 19)],
+            model_specific_data={
+                "video_grid_thw": torch.tensor([[2, 4, 4]]),
+                "video_second_per_grid": torch.tensor([1.5]),
+            },
+        )
+        positions, delta = compute_mrope_positions(
+            _omni_config(), list(range(22)), [second, first]
+        )
+
+        self.assertEqual(positions[0, 2:10].tolist(), [2] * 4 + [8] * 4)
+        self.assertEqual(positions[0, 12:20].tolist(), [11] * 4 + [30] * 4)
+        self.assertEqual(delta.tolist(), [[11]])
+
+    def test_rejects_audio_in_video_interleaving(self):
+        video = MultimodalDataItem(
+            modality=Modality.VIDEO,
+            offsets=[(1, 4)],
+            model_specific_data={
+                "video_grid_thw": torch.tensor([[1, 4, 4]]),
+                "use_audio_in_video": torch.tensor([True]),
+            },
+        )
+        with self.assertRaisesRegex(ValueError, "use_audio_in_video=true"):
+            compute_mrope_positions(_omni_config(), list(range(6)), [video])
+
+    def test_rejects_placeholder_grid_mismatch(self):
+        image = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            offsets=[(1, 3)],
+            model_specific_data={"image_grid_thw": torch.tensor([[1, 4, 4]])},
+        )
+        with self.assertRaisesRegex(ValueError, "grid requires 4"):
+            compute_mrope_positions(_omni_config(), list(range(5)), [image])
+
+
+class _FakeCommManager:
+    def final_norm(self, hidden_states, residual, ctx, norm):
+        return hidden_states, None
+
+
+class _IdentityDecoderLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.comm_manager = _FakeCommManager()
+
+    def forward(
+        self,
+        positions,
+        hidden_states,
+        ctx,
+        out_cache_loc,
+        residual,
+        cos_sin=None,
+    ):
+        return hidden_states, residual
+
+
+class TestQwen3OmniModelHelpers(unittest.TestCase):
+    def test_language_only_mode_rejects_multimodal_context(self):
+        model = Qwen3OmniMoeForConditionalGeneration.__new__(
+            Qwen3OmniMoeForConditionalGeneration
+        )
+        nn.Module.__init__(model)
+        model.is_multimodal_active = False
+        multimodal_context = SimpleNamespace(has_extend_inputs=lambda: True)
+        ctx = SimpleNamespace(
+            forward_mode=SimpleNamespace(is_decode_or_idle=lambda: False)
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "encoders are disabled"):
+            model.forward(
+                ctx,
+                torch.tensor([0]),
+                torch.tensor([0]),
+                torch.tensor([0]),
+                multimodal_context=multimodal_context,
+            )
+
+    def test_deepstack_is_injected_after_early_decoder_layers(self):
+        model = Qwen3OmniMoeTextModel.__new__(Qwen3OmniMoeTextModel)
+        nn.Module.__init__(model)
+        model.config = SimpleNamespace(hidden_size=2)
+        model.embed_tokens = nn.Embedding(4, 2)
+        model.layers = nn.ModuleList([_IdentityDecoderLayer(), _IdentityDecoderLayer()])
+        model.norm = nn.Identity()
+        ctx = SimpleNamespace(forward_mode=SimpleNamespace(is_idle=lambda: False))
+
+        hidden_states, _ = model(
+            input_ids=torch.tensor([0]),
+            positions=torch.tensor([0]),
+            ctx=ctx,
+            out_cache_loc=torch.tensor([0]),
+            input_embeds=torch.zeros(1, 2),
+            input_deepstack_embeds=torch.tensor([[1.0, 2.0, 3.0, 4.0]]),
+        )
+        self.assertTrue(torch.equal(hidden_states, torch.tensor([[4.0, 6.0]])))
+
+    def test_visual_checkpoint_names_map_to_shared_qwen3_tower(self):
+        map_weight = Qwen3OmniMoeForConditionalGeneration._map_visual_weight
+        self.assertEqual(
+            map_weight("visual.blocks.0.attn.qkv.weight"),
+            "visual.blocks.0.attn.qkv_proj.weight",
+        )
+        self.assertEqual(
+            map_weight("visual.merger_list.2.ln_q.weight"),
+            "visual.deepstack_merger_list.2.norm.weight",
+        )
+        self.assertEqual(
+            map_weight("visual.merger.mlp.2.bias"),
+            "visual.merger.linear_fc2.bias",
+        )
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and torch.version.cuda is not None,
+        "Qwen3 vision parity requires an NVIDIA GPU",
+    )
+    def test_shared_vision_tower_matches_transformers_omni(self):
+        from transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe import (
+            Qwen3OmniMoeVisionEncoderConfig,
+        )
+        from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
+            Qwen3OmniMoeVisionEncoder,
+        )
+
+        from tokenspeed.runtime.distributed.mapping import Mapping
+        from tokenspeed.runtime.model_loader.weight_utils import default_weight_loader
+        from tokenspeed.runtime.models.qwen3_vision import Qwen3VLMoeVisionModel
+
+        config = Qwen3OmniMoeVisionEncoderConfig(
+            depth=1,
+            hidden_size=16,
+            intermediate_size=32,
+            num_heads=2,
+            patch_size=2,
+            temporal_patch_size=2,
+            spatial_merge_size=2,
+            out_hidden_size=16,
+            num_position_embeddings=4,
+            deepstack_visual_indexes=[0],
+        )
+        torch.manual_seed(1)
+        reference = Qwen3OmniMoeVisionEncoder(config).cuda().bfloat16().eval()
+        tower = (
+            Qwen3VLMoeVisionModel(
+                _shared_vision_config(config),
+                Mapping(rank=0, world_size=1),
+                prefix="visual",
+            )
+            .cuda()
+            .bfloat16()
+            .eval()
+        )
+        params = dict(tower.named_parameters(remove_duplicate=False))
+        for name, weight in reference.state_dict().items():
+            mapped = Qwen3OmniMoeForConditionalGeneration._map_visual_weight(
+                f"visual.{name}"
+            ).removeprefix("visual.")
+            self.assertIn(mapped, params)
+            param = params[mapped]
+            loader = getattr(param, "weight_loader", default_weight_loader)
+            loader(param, weight)
+
+        patches = torch.randn(16, 24, device="cuda", dtype=torch.bfloat16)
+        grid = torch.tensor([[1, 4, 4]], device="cuda")
+        with torch.no_grad():
+            reference_output = reference(patches, grid)
+            tokens = tower.prepare_patch_embed(patches, grid)
+            output = tower.forward_blocks(tokens, tower.prepare_metadata(grid))
+        expected = torch.cat(
+            [
+                reference_output.pooler_output,
+                *reference_output.deepstack_features,
+            ],
+            dim=-1,
+        )
+        torch.testing.assert_close(output, expected, atol=3e-2, rtol=3e-2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add local Qwen3-ASR configuration support for Transformers versions that do not register `qwen3_asr`.
- Add a shared Qwen3 audio tower with itemized log-Mel packing, windowed attention, and official checkpoint weight mapping.
- Add the Qwen3-ASR dense language-model wrapper.
- Add the Qwen3-Omni Thinker using the shared Qwen3 vision and audio towers.
- Add mixed image/audio/video M-RoPE and modality-aware embedding assembly.
- Generalize multimodal encoder attention and embedding while retaining compatibility aliases for existing vision models.

## Scope

- Qwen3-Omni is inference-only and text-output-only (`return_audio=false`).
- Talker, Code2Wav, audio-in-video, realtime transcription, timestamps, and generated audio are out of scope.
- Audio is supported on the regular TokenSpeed path.
- Encoder-only audio and audio EPD are not supported in this change.

## Testing

- `CUDA_VISIBLE_DEVICES=0 PYTHONPATH=python:tokenspeed-kernel/python python -m pytest -q test/runtime/models/test_qwen3_audio.py` (9 passed)
- `CUDA_VISIBLE_DEVICES=0 PYTHONPATH=python:tokenspeed-kernel/python python -m pytest -q test/runtime/models/test_qwen3_omni.py` (13 passed)
- Black formatting check
- isort import-order check
- Python syntax compilation
