### PR TITLE
feat(profile): drive Proton via the /start_profile control plane

### DIFF
--- a/python/tokenspeed/bench.py
+++ b/python/tokenspeed/bench.py
@@ -1406,6 +1406,7 @@ async def benchmark(
     num_warmups: int,
     profile: bool,
     profile_num_steps: int | None,
+    profile_activities: list[str] | None,
     selected_percentile_metrics: list[str],
     selected_percentiles: list[float],
     ignore_eos: bool,
@@ -1485,9 +1486,13 @@ async def benchmark(
             print("Starting profiler...")
         else:
             print(f"Starting profiler for {profile_num_steps} steps...")
-        extra_body = dict(extra_body or {})
+        # Use a dedicated body for the /start_profile request so profiler
+        # fields don't leak into the generation request payloads below.
+        profile_body = dict(extra_body or {})
         if profile_num_steps is not None:
-            extra_body["num_steps"] = profile_num_steps
+            profile_body["num_steps"] = profile_num_steps
+        if profile_activities is not None:
+            profile_body["activities"] = profile_activities
         profile_input = RequestFuncInput(
             model=model_id,
             model_name=model_name,
@@ -1498,7 +1503,7 @@ async def benchmark(
             logprobs=logprobs,
             ignore_eos=ignore_eos,
             extra_headers=extra_headers,
-            extra_body=extra_body,
+            extra_body=profile_body,
         )
         profile_output = await request_func(profile_input, session=session)
         if profile_output.success:
@@ -1796,6 +1801,17 @@ def add_serving_cli_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--disable-tqdm", action="store_true")
     parser.add_argument("--profile", action="store_true")
     parser.add_argument("--profile-num-steps", type=int, default=None)
+    parser.add_argument(
+        "--profile-activities",
+        nargs="+",
+        choices=["CPU", "GPU", "MEM", "CUDA_PROFILER", "VIZTRACER", "PROTON"],
+        default=None,
+        help="Profiler activities for /start_profile (default: server-side "
+        "default, CPU and GPU via the torch profiler). PROTON drives the "
+        "Triton Proton profiler inside each scheduler process; it cannot be "
+        "combined with GPU or CUDA_PROFILER, which need the same "
+        "CUPTI/roctracer interface.",
+    )
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--ignore-eos", action="store_true")
     parser.add_argument("--disable-ignore-eos", action="store_true")
@@ -1835,6 +1851,8 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
             raise ValueError("--profile-num-steps must be positive.")
         if not args.profile:
             raise ValueError("--profile-num-steps requires --profile.")
+    if args.profile_activities is not None and not args.profile:
+        raise ValueError("--profile-activities requires --profile.")
     if args.input_len is not None:
         args.random_input_len = args.input_len
     if args.output_len is not None:
@@ -1920,6 +1938,7 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
         num_warmups=args.num_warmups,
         profile=args.profile,
         profile_num_steps=args.profile_num_steps,
+        profile_activities=args.profile_activities,
         selected_percentile_metrics=percentile_metrics.split(","),
         selected_percentiles=[float(p) for p in args.metric_percentiles.split(",")],
         ignore_eos=args.ignore_eos,

--- a/python/tokenspeed/runtime/engine/request_handler.py
+++ b/python/tokenspeed/runtime/engine/request_handler.py
@@ -324,13 +324,14 @@ class RequestHandler:
                 message="Profiling is already in progress. Call /stop_profile first.",
             )
 
-        self.profile_by_stage = profile_by_stage
-
         if output_dir is None:
             output_dir = envs.TOKENSPEED_PROFILER_DIR.get()
         if activities is None:
             activities = ["CPU", "GPU"]
 
+        # All validation must precede any state mutation: the event loop runs
+        # _profile_batch_predicate on every batch, so a rejected request that
+        # left partial profiler state behind would crash the scheduler.
         if "PROTON" in activities:
             conflicting = sorted({"GPU", "CUDA_PROFILER"} & set(activities))
             if conflicting:
@@ -354,6 +355,7 @@ class RequestHandler:
                     "be controlled through /start_profile.",
                 )
 
+        self.profile_by_stage = profile_by_stage
         self.profiler_output_dir = output_dir
         self.torch_profiler_with_stack = with_stack
         self.torch_profiler_record_shapes = record_shapes

--- a/python/tokenspeed/runtime/engine/request_handler.py
+++ b/python/tokenspeed/runtime/engine/request_handler.py
@@ -27,6 +27,13 @@ from typing import TYPE_CHECKING
 
 import torch
 import zmq
+from tokenspeed_kernel.profiling import (
+    ProfilingState,
+    profile_config_from_env,
+    proton_available,
+    start_profiling,
+    stop_profiling,
+)
 from viztracer import VizTracer
 
 from tokenspeed.runtime.distributed.process_group_manager import (
@@ -266,8 +273,11 @@ class RequestHandler:
         )
 
     # ------------------------------------------------------------------
-    # Profiling: torch / cuda / viztracer / mem-snapshot, driven by
-    # /start_profile and /stop_profile control requests.
+    # Profiling: torch / cuda / viztracer / mem-snapshot / proton, driven
+    # by /start_profile and /stop_profile control requests. Proton must be
+    # driven from this process (not the frontend): its GPU hooks are
+    # per-process and the scheduler subprocess is torn down with SIGKILL,
+    # so an atexit-based finalize would never write the profile.
     # ------------------------------------------------------------------
 
     def init_profiler(self):
@@ -308,6 +318,29 @@ class RequestHandler:
             output_dir = envs.TOKENSPEED_PROFILER_DIR.get()
         if activities is None:
             activities = ["CPU", "GPU"]
+
+        if "PROTON" in activities:
+            conflicting = sorted({"GPU", "CUDA_PROFILER"} & set(activities))
+            if conflicting:
+                return ProfileReqOutput(
+                    success=False,
+                    message="PROTON cannot be combined with "
+                    f"{', '.join(conflicting)}: CUPTI/roctracer supports only "
+                    "one GPU profiling client per process.",
+                )
+            if not proton_available():
+                return ProfileReqOutput(
+                    success=False,
+                    message="Proton is not available: the installed "
+                    "tokenspeed-triton does not provide a profiler.",
+                )
+            if ProfilingState.get().active:
+                return ProfileReqOutput(
+                    success=False,
+                    message="A Proton session is already active in this "
+                    "process (e.g. via TOKENSPEED_KERNEL_PROFILE); it cannot "
+                    "be controlled through /start_profile.",
+                )
 
         self.profiler_output_dir = output_dir
         self.torch_profiler_with_stack = with_stack
@@ -368,6 +401,15 @@ class RequestHandler:
         if "CUDA_PROFILER" in activities:
             torch.cuda.cudart().cudaProfilerStart()
 
+        if "PROTON" in activities:
+            Path(self.profiler_output_dir).mkdir(parents=True, exist_ok=True)
+            # Proton appends the output format extension (e.g. ".hatchet").
+            proton_output = os.path.join(
+                self.profiler_output_dir,
+                f"{self.profile_id}-TP-{self.attn_tp_rank}{stage_suffix}.proton",
+            )
+            start_profiling(profile_config_from_env(output=proton_output))
+
         if "VIZTRACER" in activities:
             Path(self.profiler_output_dir).mkdir(parents=True, exist_ok=True)
             self.viztracer = VizTracer(
@@ -426,6 +468,11 @@ class RequestHandler:
 
         if "CUDA_PROFILER" in self.profiler_activities:
             torch.cuda.cudart().cudaProfilerStop()
+
+        if "PROTON" in self.profiler_activities:
+            # Finalizes the session and writes the profile now, while this
+            # process is still alive (shutdown is SIGKILL; no atexit).
+            stop_profiling()
 
         if "VIZTRACER" in self.profiler_activities and self.viztracer is not None:
             self.viztracer.stop()

--- a/python/tokenspeed/runtime/engine/request_handler.py
+++ b/python/tokenspeed/runtime/engine/request_handler.py
@@ -78,6 +78,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _profile_rank_tag(attn_mapping) -> str:
+    """File-name tag identifying this scheduler process's profile outputs."""
+    parts = []
+    if attn_mapping.has_dp:
+        parts.append(f"DP{attn_mapping.dp_rank}")
+    if attn_mapping.has_cp:
+        parts.append(f"CP{attn_mapping.cp_rank}")
+    parts.append(f"TP{attn_mapping.tp_rank}")
+    return "-".join(parts)
+
+
 class RequestHandler:
     """
     1. Recv Reqs from ZMQ
@@ -113,6 +124,7 @@ class RequestHandler:
             "gloo", mapping.attn.tp_group
         )
         self.attn_tp_src_rank = mapping.attn.tp_group[0]
+        self.profile_rank_tag = _profile_rank_tag(mapping.attn)
 
         self.hf_eos_token_id = hf_eos_token_id
         self.max_req_len = max_req_len
@@ -406,7 +418,7 @@ class RequestHandler:
             # Proton appends the output format extension (e.g. ".hatchet").
             proton_output = os.path.join(
                 self.profiler_output_dir,
-                f"{self.profile_id}-TP-{self.attn_tp_rank}{stage_suffix}.proton",
+                f"{self.profile_id}-{self.profile_rank_tag}{stage_suffix}.proton",
             )
             start_profiling(profile_config_from_env(output=proton_output))
 
@@ -415,7 +427,7 @@ class RequestHandler:
             self.viztracer = VizTracer(
                 output_file=os.path.join(
                     self.profiler_output_dir,
-                    f"{self.profile_id}-TP-{self.attn_tp_rank}{stage_suffix}.viztracer.json",
+                    f"{self.profile_id}-{self.profile_rank_tag}{stage_suffix}.viztracer.json",
                 ),
                 min_duration=int(
                     os.environ.get("TOKENSPEED_VIZTRACER_MIN_DURATION_US", "100")
@@ -453,7 +465,7 @@ class RequestHandler:
             self.torch_profiler.export_chrome_trace(
                 os.path.join(
                     self.profiler_output_dir,
-                    f"{self.profile_id}-TP-{self.attn_tp_rank}{stage_suffix}.trace.json.gz",
+                    f"{self.profile_id}-{self.profile_rank_tag}{stage_suffix}.trace.json.gz",
                 )
             )
             torch.distributed.barrier(self.attn_tp_cpu_group)
@@ -461,7 +473,7 @@ class RequestHandler:
         if self.profiler_activities is not None and "MEM" in self.profiler_activities:
             memory_profile_path = os.path.join(
                 self.profiler_output_dir,
-                f"{self.profile_id}-TP-{self.attn_tp_rank}-memory{stage_suffix}.pickle",
+                f"{self.profile_id}-{self.profile_rank_tag}-memory{stage_suffix}.pickle",
             )
             torch.cuda.memory._dump_snapshot(memory_profile_path)
             torch.cuda.memory._record_memory_history(enabled=None)

--- a/test/runtime/test_request_handler_profile.py
+++ b/test/runtime/test_request_handler_profile.py
@@ -1,5 +1,6 @@
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 from tokenspeed_kernel import profiling
@@ -9,10 +10,24 @@ from tokenspeed.runtime.engine.io_struct import ProfileReq, ProfileReqType
 from tokenspeed.runtime.engine.request_handler import RequestHandler
 
 
-def _make_handler() -> RequestHandler:
+def _attn_mapping(
+    tp_rank: int = 0, dp_rank: int | None = None, cp_rank: int | None = None
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        tp_rank=tp_rank,
+        has_dp=dp_rank is not None,
+        dp_rank=dp_rank or 0,
+        has_cp=cp_rank is not None,
+        cp_rank=cp_rank or 0,
+    )
+
+
+def _make_handler(attn_mapping: SimpleNamespace | None = None) -> RequestHandler:
     handler = RequestHandler.__new__(RequestHandler)
     handler.forward_ct = 0
-    handler.attn_tp_rank = 0
+    attn_mapping = attn_mapping or _attn_mapping()
+    handler.attn_tp_rank = attn_mapping.tp_rank
+    handler.profile_rank_tag = request_handler_mod._profile_rank_tag(attn_mapping)
     handler.init_profiler()
     return handler
 
@@ -91,7 +106,7 @@ class TestRequestHandlerProtonProfile(unittest.TestCase):
         self.assertFalse(self.handler.profile_in_progress)
 
     def test_start_and_stop_drive_proton_session_per_rank(self):
-        self.handler.attn_tp_rank = 3
+        self.handler = _make_handler(_attn_mapping(tp_rank=3))
         with mock.patch.object(
             request_handler_mod, "proton_available", return_value=True
         ), mock.patch.object(
@@ -105,13 +120,49 @@ class TestRequestHandlerProtonProfile(unittest.TestCase):
 
             config = start_profiling.call_args[0][0]
             self.assertEqual(config.output.rsplit("/", 1)[0], self.output_dir)
-            self.assertTrue(config.output.endswith("test-profile-TP-3.proton"))
+            self.assertTrue(config.output.endswith("test-profile-TP3.proton"))
             stop_profiling.assert_not_called()
 
             result = self.handler.profile(ProfileReq(type=ProfileReqType.STOP_PROFILE))
             self.assertTrue(result.success)
             stop_profiling.assert_called_once()
             self.assertFalse(self.handler.profile_in_progress)
+
+    def test_rank_tag_includes_dp_cp_ranks_when_present(self):
+        self.assertEqual(
+            request_handler_mod._profile_rank_tag(_attn_mapping(tp_rank=3)), "TP3"
+        )
+        self.assertEqual(
+            request_handler_mod._profile_rank_tag(_attn_mapping(tp_rank=0, dp_rank=1)),
+            "DP1-TP0",
+        )
+        self.assertEqual(
+            request_handler_mod._profile_rank_tag(
+                _attn_mapping(tp_rank=2, dp_rank=1, cp_rank=0)
+            ),
+            "DP1-CP0-TP2",
+        )
+
+    def test_proton_outputs_do_not_collide_across_dp_ranks(self):
+        # Two DP peers share attn_tp_rank=0 but must write distinct files.
+        outputs = []
+        for dp_rank in (0, 1):
+            handler = _make_handler(_attn_mapping(tp_rank=0, dp_rank=dp_rank))
+            with mock.patch.object(
+                request_handler_mod, "proton_available", return_value=True
+            ), mock.patch.object(
+                request_handler_mod, "start_profiling"
+            ) as start_profiling, mock.patch.object(
+                request_handler_mod, "stop_profiling"
+            ):
+                result = handler.profile(_start_req(self.output_dir))
+                self.assertTrue(result.success)
+                outputs.append(start_profiling.call_args[0][0].output)
+                handler.profile(ProfileReq(type=ProfileReqType.STOP_PROFILE))
+
+        self.assertNotEqual(outputs[0], outputs[1])
+        self.assertTrue(outputs[0].endswith("test-profile-DP0-TP0.proton"))
+        self.assertTrue(outputs[1].endswith("test-profile-DP1-TP0.proton"))
 
     def test_num_steps_window_finalizes_proton(self):
         with mock.patch.object(

--- a/test/runtime/test_request_handler_profile.py
+++ b/test/runtime/test_request_handler_profile.py
@@ -1,0 +1,137 @@
+import tempfile
+import unittest
+from unittest import mock
+
+from tokenspeed_kernel import profiling
+
+from tokenspeed.runtime.engine import request_handler as request_handler_mod
+from tokenspeed.runtime.engine.io_struct import ProfileReq, ProfileReqType
+from tokenspeed.runtime.engine.request_handler import RequestHandler
+
+
+def _make_handler() -> RequestHandler:
+    handler = RequestHandler.__new__(RequestHandler)
+    handler.forward_ct = 0
+    handler.attn_tp_rank = 0
+    handler.init_profiler()
+    return handler
+
+
+def _start_req(output_dir: str, **kwargs) -> ProfileReq:
+    return ProfileReq(
+        type=ProfileReqType.START_PROFILE,
+        output_dir=output_dir,
+        activities=["PROTON"],
+        profile_id="test-profile",
+        **kwargs,
+    )
+
+
+class TestRequestHandlerProtonProfile(unittest.TestCase):
+    def setUp(self):
+        self.handler = _make_handler()
+        self.output_dir = tempfile.mkdtemp()
+        profiling.ProfilingState.reset()
+        self.addCleanup(profiling.ProfilingState.reset)
+
+    def test_init_fails_when_proton_unavailable(self):
+        with mock.patch.object(
+            request_handler_mod, "proton_available", return_value=False
+        ):
+            result = self.handler.profile(_start_req(self.output_dir))
+
+        self.assertFalse(result.success)
+        self.assertIn("Proton is not available", result.message)
+        self.assertFalse(self.handler.profile_in_progress)
+
+    def test_init_rejects_proton_mixed_with_gpu_profilers(self):
+        for conflicting in (["GPU"], ["CUDA_PROFILER"], ["GPU", "CUDA_PROFILER"]):
+            req = _start_req(self.output_dir)
+            req.activities = ["CPU", "PROTON", *conflicting]
+
+            result = self.handler.profile(req)
+
+            self.assertFalse(result.success)
+            for activity in conflicting:
+                self.assertIn(activity, result.message)
+            self.assertFalse(self.handler.profile_in_progress)
+
+    def test_init_allows_proton_with_host_side_profilers(self):
+        req = _start_req(self.output_dir)
+        req.activities = ["CPU", "MEM", "VIZTRACER", "PROTON"]
+
+        with mock.patch.object(
+            request_handler_mod, "proton_available", return_value=True
+        ):
+            result = self.handler.init_profile(
+                output_dir=self.output_dir,
+                start_step=None,
+                num_steps=None,
+                activities=req.activities,
+                with_stack=None,
+                record_shapes=None,
+                profile_by_stage=False,
+                profile_id="test-profile",
+            )
+
+        self.assertTrue(result.success)
+
+    def test_init_fails_when_env_bootstrap_session_active(self):
+        state = profiling.ProfilingState.get()
+        state.enabled = True
+        state._session = 1
+
+        with mock.patch.object(
+            request_handler_mod, "proton_available", return_value=True
+        ):
+            result = self.handler.profile(_start_req(self.output_dir))
+
+        self.assertFalse(result.success)
+        self.assertIn("already active", result.message)
+        self.assertFalse(self.handler.profile_in_progress)
+
+    def test_start_and_stop_drive_proton_session_per_rank(self):
+        self.handler.attn_tp_rank = 3
+        with mock.patch.object(
+            request_handler_mod, "proton_available", return_value=True
+        ), mock.patch.object(
+            request_handler_mod, "start_profiling"
+        ) as start_profiling, mock.patch.object(
+            request_handler_mod, "stop_profiling"
+        ) as stop_profiling:
+            result = self.handler.profile(_start_req(self.output_dir))
+            self.assertTrue(result.success)
+            self.assertTrue(self.handler.profile_in_progress)
+
+            config = start_profiling.call_args[0][0]
+            self.assertEqual(config.output.rsplit("/", 1)[0], self.output_dir)
+            self.assertTrue(config.output.endswith("test-profile-TP-3.proton"))
+            stop_profiling.assert_not_called()
+
+            result = self.handler.profile(ProfileReq(type=ProfileReqType.STOP_PROFILE))
+            self.assertTrue(result.success)
+            stop_profiling.assert_called_once()
+            self.assertFalse(self.handler.profile_in_progress)
+
+    def test_num_steps_window_finalizes_proton(self):
+        with mock.patch.object(
+            request_handler_mod, "proton_available", return_value=True
+        ), mock.patch.object(request_handler_mod, "start_profiling"), mock.patch.object(
+            request_handler_mod, "stop_profiling"
+        ) as stop_profiling:
+            result = self.handler.profile(_start_req(self.output_dir, num_steps=2))
+            self.assertTrue(result.success)
+            self.assertTrue(self.handler.profile_in_progress)
+
+            self.handler.forward_ct = 1
+            self.handler._profile_batch_predicate()
+            stop_profiling.assert_not_called()
+
+            self.handler.forward_ct = 2
+            self.handler._profile_batch_predicate()
+            stop_profiling.assert_called_once()
+            self.assertFalse(self.handler.profile_in_progress)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/runtime/test_request_handler_profile.py
+++ b/test/runtime/test_request_handler_profile.py
@@ -8,6 +8,7 @@ from tokenspeed_kernel import profiling
 from tokenspeed.runtime.engine import request_handler as request_handler_mod
 from tokenspeed.runtime.engine.io_struct import ProfileReq, ProfileReqType
 from tokenspeed.runtime.engine.request_handler import RequestHandler
+from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 
 
 def _attn_mapping(
@@ -70,6 +71,18 @@ class TestRequestHandlerProtonProfile(unittest.TestCase):
             for activity in conflicting:
                 self.assertIn(activity, result.message)
             self.assertFalse(self.handler.profile_in_progress)
+
+    def test_rejected_request_leaves_profiler_state_untouched(self):
+        req = _start_req(self.output_dir, profile_by_stage=True, num_steps=2)
+        req.activities = ["PROTON", "GPU"]
+
+        result = self.handler.profile(req)
+
+        self.assertFalse(result.success)
+        self.assertFalse(self.handler.profile_by_stage)
+        self.handler.forward_ct = 1
+        self.handler._profile_batch_predicate(ForwardMode.EXTEND)
+        self.assertFalse(self.handler.profile_in_progress)
 
     def test_init_allows_proton_with_host_side_profilers(self):
         req = _start_req(self.output_dir)

--- a/tokenspeed-kernel/README.md
+++ b/tokenspeed-kernel/README.md
@@ -124,13 +124,8 @@ iteration.
   `{"activities": ["PROTON"]}`). Each scheduler process — the process where
   kernels actually launch — runs its own Proton session and finalizes it on
   `/stop_profile`, writing `<output_dir>/<profile_id>-TP-<rank>.proton.<fmt>`
-  per rank. `TOKENSPEED_KERNEL_PROFILE_DATA/BACKEND/MODE/...` still select
-  the Proton data/backend/mode. `PROTON` composes with host-side activities
-  (`CPU`, `MEM`, `VIZTRACER`) but is rejected alongside `GPU` or
-  `CUDA_PROFILER` — CUPTI/roctracer allows one GPU profiling client per
-  process. The import-time `TOKENSPEED_KERNEL_PROFILE=1`
-  bootstrap only suits single-process scripts: serving schedulers are torn
-  down with SIGKILL, so its atexit finalize never writes a profile there.
+  per rank. `PROTON` composes only with host-side activities (`CPU`, `MEM`,
+  `VIZTRACER`).
 
 ### Plugins
 

--- a/tokenspeed-kernel/README.md
+++ b/tokenspeed-kernel/README.md
@@ -119,6 +119,18 @@ iteration.
   (FLOPs / bytes) per op family, tabular reports, and Proton integration.
 - Runtime shape capture feeds replay and tuning workflows; `kernel_scope`
   scopes are visible in Proton/Chrome traces.
+- End-to-end serving: pass `--profile --profile-activities PROTON` to
+  `tokenspeed bench serve` (or POST `/start_profile` / `/stop_profile` with
+  `{"activities": ["PROTON"]}`). Each scheduler process — the process where
+  kernels actually launch — runs its own Proton session and finalizes it on
+  `/stop_profile`, writing `<output_dir>/<profile_id>-TP-<rank>.proton.<fmt>`
+  per rank. `TOKENSPEED_KERNEL_PROFILE_DATA/BACKEND/MODE/...` still select
+  the Proton data/backend/mode. `PROTON` composes with host-side activities
+  (`CPU`, `MEM`, `VIZTRACER`) but is rejected alongside `GPU` or
+  `CUDA_PROFILER` — CUPTI/roctracer allows one GPU profiling client per
+  process. The import-time `TOKENSPEED_KERNEL_PROFILE=1`
+  bootstrap only suits single-process scripts: serving schedulers are torn
+  down with SIGKILL, so its atexit finalize never writes a profile there.
 
 ### Plugins
 

--- a/tokenspeed-kernel/README.md
+++ b/tokenspeed-kernel/README.md
@@ -123,7 +123,8 @@ iteration.
   `tokenspeed bench serve` (or POST `/start_profile` / `/stop_profile` with
   `{"activities": ["PROTON"]}`). Each scheduler process — the process where
   kernels actually launch — runs its own Proton session and finalizes it on
-  `/stop_profile`, writing `<output_dir>/<profile_id>-TP-<rank>.proton.<fmt>`
+  `/stop_profile`, writing
+  `<output_dir>/<profile_id>[-DP<rank>][-CP<rank>]-TP<rank>.proton.<fmt>`
   per rank. `PROTON` composes only with host-side activities (`CPU`, `MEM`,
   `VIZTRACER`).
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/profiling.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/profiling.py
@@ -42,7 +42,9 @@ __all__ = [
     "ShapeCapture",
     "bootstrap_profiling_from_env",
     "kernel_scope",
+    "profile_config_from_env",
     "profiling",
+    "proton_available",
     "shape_capture",
     "start_shape_capture",
     "start_profiling",
@@ -193,9 +195,32 @@ def _is_truthy(value: str | None) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _profile_config_from_env() -> ProfilingConfig:
+def proton_available() -> bool:
+    """Report whether the Proton profiler can be used in this process.
+
+    Returns:
+        True if the vendored Triton distribution provides
+        ``tokenspeed_triton.profiler``; False otherwise (profiling calls
+        become no-ops with a warning).
+    """
+    return _HAS_PROTON
+
+
+def profile_config_from_env(output: str | None = None) -> ProfilingConfig:
+    """Build a :class:`ProfilingConfig` from ``TOKENSPEED_KERNEL_PROFILE_*``.
+
+    Args:
+        output: Optional Proton output prefix/path. When provided it takes
+            precedence over ``TOKENSPEED_KERNEL_PROFILE_OUTPUT``; callers that
+            profile multiple processes (e.g. one scheduler per rank) use this
+            to give each process a distinct output file.
+
+    Returns:
+        A :class:`ProfilingConfig` with ``data``/``backend``/``mode``/``hook``/
+        ``output_format`` sourced from the environment.
+    """
     return ProfilingConfig(
-        output=os.environ.get(_ENV_PROFILE_OUTPUT, "profile"),
+        output=output or os.environ.get(_ENV_PROFILE_OUTPUT, "profile"),
         data=os.environ.get(_ENV_PROFILE_DATA, "tree"),
         backend=os.environ.get(_ENV_PROFILE_BACKEND),
         mode=os.environ.get(_ENV_PROFILE_MODE),
@@ -316,7 +341,7 @@ def bootstrap_profiling_from_env() -> None:
     _BOOTSTRAPPED = True
 
     if _is_truthy(os.environ.get(_ENV_PROFILE)):
-        start_profiling(_profile_config_from_env())
+        start_profiling(profile_config_from_env())
     if _is_truthy(os.environ.get(_ENV_CAPTURE_SHAPES)):
         start_shape_capture()
 

--- a/tokenspeed-kernel/test/test_profiling.py
+++ b/tokenspeed-kernel/test/test_profiling.py
@@ -199,6 +199,46 @@ def test_bootstrap_reads_env_and_only_runs_once(monkeypatch):
     assert len(registrations) == 2
 
 
+def test_proton_available_reflects_import(monkeypatch):
+    monkeypatch.setattr(profiling, "_HAS_PROTON", True)
+    assert profiling.proton_available()
+
+    monkeypatch.setattr(profiling, "_HAS_PROTON", False)
+    assert not profiling.proton_available()
+
+
+def test_profile_config_from_env_defaults(monkeypatch):
+    for env in (
+        "TOKENSPEED_KERNEL_PROFILE_OUTPUT",
+        "TOKENSPEED_KERNEL_PROFILE_DATA",
+        "TOKENSPEED_KERNEL_PROFILE_BACKEND",
+        "TOKENSPEED_KERNEL_PROFILE_MODE",
+        "TOKENSPEED_KERNEL_PROFILE_HOOK",
+        "TOKENSPEED_KERNEL_PROFILE_OUTPUT_FORMAT",
+    ):
+        monkeypatch.delenv(env, raising=False)
+
+    cfg = profiling.profile_config_from_env()
+    assert cfg == profiling.ProfilingConfig()
+
+
+def test_profile_config_from_env_output_override_wins(monkeypatch):
+    monkeypatch.setenv("TOKENSPEED_KERNEL_PROFILE_OUTPUT", "env_profile")
+    monkeypatch.setenv("TOKENSPEED_KERNEL_PROFILE_DATA", "trace")
+    monkeypatch.setenv("TOKENSPEED_KERNEL_PROFILE_BACKEND", "roctracer")
+    monkeypatch.setenv("TOKENSPEED_KERNEL_PROFILE_MODE", "periodic_flushing")
+    monkeypatch.setenv("TOKENSPEED_KERNEL_PROFILE_OUTPUT_FORMAT", "chrome_trace")
+
+    cfg = profiling.profile_config_from_env(output="rank0/step5.proton")
+
+    assert cfg.output == "rank0/step5.proton"
+    assert cfg.data == "trace"
+    assert cfg.backend == "roctracer"
+    assert cfg.mode == "periodic_flushing"
+    assert cfg.hook == "triton"
+    assert cfg.output_format == "chrome_trace"
+
+
 def test_shape_capture_records_dump_and_clear(tmp_path):
     output = tmp_path / "shapes.json"
 


### PR DESCRIPTION
Proton could not profile serving workloads: GPU kernels run in scheduler subprocesses (mp.Process spawned in _launch_subprocesses), and those are torn down with SIGKILL on both crash and clean engine shutdown. The import-time TOKENSPEED_KERNEL_PROFILE bootstrap finalizes via atexit, which never runs under SIGKILL, so no profile was ever written; all ranks also shared one default output path.

Fix by running Proton where the kernels launch, controlled through the existing profile control plane:

* request_handler: new PROTON activity for /start_profile and /stop_profile. Each scheduler rank starts its own Proton session writing <output_dir>/<profile_id>-TP-<rank>[-STAGE].proton.<fmt> and finalizes it on /stop_profile while the process is alive, so nothing depends on atexit or graceful exit. The existing start_step / num_steps / profile_by_stage step windows apply to Proton unchanged.

* init_profile validation: reject PROTON combined with GPU or CUDA_PROFILER (CUPTI/roctracer allows one GPU profiling client per process; host-side CPU/MEM/VIZTRACER still compose), and fail cleanly when Proton is unavailable or an env-bootstrap session already owns the process.

* tokenspeed_kernel.profiling: expose proton_available() and profile_config_from_env(output=...) so the control plane reuses the TOKENSPEED_KERNEL_PROFILE_* env config (data/backend/mode/ hook) with a per-rank output override. Env bootstrap behavior is unchanged and remains the right tool for single-process scripts.

* bench serve: new --profile-activities flag (e.g. PROTON) sent in the /start_profile body. The profile request now uses a dedicated body dict, so profiler fields like num_steps no longer leak into every generation request payload.

* Document the serving flow in the tokenspeed-kernel README; add unit tests for the new helpers and the scheduler-side PROTON dispatch, activity-conflict rejection, and step-window finalize.
