### PR TITLE
[AMD] fix(gluon): support dynamic MXFP4 combine K=256

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
@@ -1441,6 +1441,17 @@ class MoEPipelinedProgram:
         return x, w, scale_x, scale_w
 
     @gluon.jit
+    def run(self, loop_k, USE_WARP_PIPELINE: gl.constexpr):
+        # A single BLOCK_K tile cannot fill the double-buffered pipelines, so
+        # route it to the decode schedule; otherwise pick warp vs local-prefetch.
+        cfg = self.cfg
+        if cfg.K_ITERS == 1:
+            return self.decode_pipeline(loop_k)
+        if USE_WARP_PIPELINE:
+            return self.warp_pipeline(loop_k)
+        return self.pipeline(loop_k)
+
+    @gluon.jit
     def decode_pipeline(self, loop_k):
         cfg = self.cfg
         EVEN_K: gl.constexpr = cfg.EVEN_K
@@ -2579,6 +2590,11 @@ class MoESliceNProgram:
             NB == 2,
             "current SliceN local-prefetch pipeline requires exactly two LDS buffers",
         )
+        gl.static_assert(
+            cfg.K_ITERS != 1,
+            "SliceN requires K_ITERS >= 2; single BLOCK_K tile shapes must route "
+            "to the full-N decode schedule (see _is_single_k_tile host gate)",
+        )
 
         if self.bottom_valid:
             return self._pipeline_full(loop_k)
@@ -3260,9 +3276,7 @@ def _run_moe_tile_w_via_vgpr(
         pgm = MoEPipelinedProgram.initialize(
             cfg, x_desc, w_desc, x_scale_desc, w_scale_desc
         )
-        if USE_WARP_PIPELINE:
-            return pgm.warp_pipeline(K)
-        return pgm.pipeline(K)
+        return pgm.run(K, USE_WARP_PIPELINE)
 
 
 @gluon.jit
@@ -3418,9 +3432,7 @@ def _run_moe_tile_preshuffled_lds_w(
     pgm = MoEPipelinedProgram.initialize(
         cfg, x_desc, w_desc, x_scale_desc, w_scale_desc
     )
-    if USE_WARP_PIPELINE:
-        return pgm.warp_pipeline(K)
-    return pgm.pipeline(K)
+    return pgm.run(K, USE_WARP_PIPELINE)
 
 
 @gluon.jit
@@ -3567,9 +3579,7 @@ def _run_moe_tile_transposed_w(
     pgm = MoEPipelinedProgram.initialize(
         cfg, x_desc, w_desc, x_scale_desc, w_scale_desc
     )
-    if USE_WARP_PIPELINE:
-        return pgm.warp_pipeline(K)
-    return pgm.pipeline(K)
+    return pgm.run(K, USE_WARP_PIPELINE)
 
 
 @gluon.jit
@@ -3716,9 +3726,7 @@ def _run_moe_tile_ncontig_w(
     pgm = MoEPipelinedProgram.initialize(
         cfg, x_desc, w_desc, x_scale_desc, w_scale_desc
     )
-    if USE_WARP_PIPELINE:
-        return pgm.warp_pipeline(K)
-    return pgm.pipeline(K)
+    return pgm.run(K, USE_WARP_PIPELINE)
 
 
 @gluon.jit
@@ -6085,6 +6093,16 @@ def _resolve_prefill_slice_modes(
     return use_slice_mn_resolved, use_slice_n_resolved
 
 
+def _is_single_k_tile(k: int, block_k: int) -> bool:
+    """Whether the K reduction fits in a single BLOCK_K tile (K_ITERS == 1).
+
+    The SliceN and pipelined schedules are double-buffered and require at least
+    two K tiles; a single tile has no dedicated SliceN path, so such shapes must
+    run on the full-N decode schedule instead.
+    """
+    return (k + block_k - 1) // block_k == 1
+
+
 def gluon_mxfp_dispatch_swiglu(
     x: torch.Tensor,
     w: torch.Tensor,
@@ -6181,6 +6199,9 @@ def gluon_mxfp_dispatch_swiglu(
         and a_ragged_metadata is not None
     ):
         use_slice_n = False
+    if _is_single_k_tile(K, block_k):
+        use_slice_n = False
+        use_slice_mn = False
     if w_preshuffle:
         block_n, use_slice_mn, use_slice_n = _align_block_n_to_preshuffled_layout(
             w,
@@ -6362,6 +6383,9 @@ def gluon_mxfp_combine(
         use_slice_n = False
         use_slice_mn = False
         use_small_prefill_m = False
+    if _is_single_k_tile(K, block_k):
+        use_slice_n = False
+        use_slice_mn = False
     if w_preshuffle:
         block_n, use_slice_mn, use_slice_n = _align_block_n_to_preshuffled_layout(
             w,

--- a/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py
@@ -155,6 +155,18 @@ def test_preshuffled_layout_selection_clamps_when_slicen_is_incompatible() -> No
     assert use_slice_n is False
 
 
+def test_single_k_tile_gate_matches_k_iters_one_gfx950() -> None:
+    from tokenspeed_kernel_amd.ops.moe import fused_mxfp_gfx950 as gluon_moe
+
+    # A single BLOCK_K tile (K_ITERS == 1) must be flagged so the host disables
+    # SliceN and routes the shape to the full-N decode schedule.
+    assert gluon_moe._is_single_k_tile(256, 256) is True
+    assert gluon_moe._is_single_k_tile(128, 256) is True
+    # Two or more K tiles keep the pipelined/SliceN schedules.
+    assert gluon_moe._is_single_k_tile(257, 256) is False
+    assert gluon_moe._is_single_k_tile(512, 256) is False
+
+
 def test_autotune_block_promotes_small_dispatch_shape() -> None:
     block_m, block_n, _block_k, _num_warps, use_slice_n, small = (
         gluon_moe._autotune_block(
@@ -1159,7 +1171,10 @@ def test_dynamic_route_without_topk_normalization_uses_full_softmax_gfx950() -> 
     )
 
 
-def test_gluon_dynamic_mxfp4_moe_concatenated_silu_matches_torch_gfx950() -> None:
+@pytest.mark.parametrize("intermediate_size", [256, 512])
+def test_gluon_dynamic_mxfp4_moe_concatenated_silu_matches_torch_gfx950(
+    intermediate_size: int,
+) -> None:
     from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import (
         _quantize_mxfp4_activation,
     )
@@ -1167,7 +1182,7 @@ def test_gluon_dynamic_mxfp4_moe_concatenated_silu_matches_torch_gfx950() -> Non
     torch.manual_seed(20260630)
     device = "cuda"
     generator = torch.Generator(device=device).manual_seed(20260631)
-    m, e, h, i, topk = 4, 8, 512, 512, 2
+    m, e, h, i, topk = 4, 8, 512, intermediate_size, 2
     n_group, topk_group = 2, 1
     hidden = (
         torch.randn((m, h), device=device, dtype=torch.bfloat16) * 0.1


### PR DESCRIPTION
## Summary

A few of the MoE pipelined schedules (MoEPipelinedProgram.pipeline, MoESliceNProgram._pipeline_full/_pipeline_top_only, MoESliceMNProgram.pipeline) assume at least two K-tiles: their prologue prefetches NB (2) tiles into the double buffer. For Qwen3.5 TP=4 the combine GEMM has K = 256 = a single BLOCK_K tile (K_ITERS == 1), so the second prefetch addresses a K-tile past the end of the input, and `main_iters = K_iters - NB` goes negative (violating assume(main_iters >= 0)). This either reads out-of-bounds → illegal memory access (HIP 719) surfacing during startup/graph capture, or deadlocks on an async-copy wait_group that never completes.
    
To fix this, we do: 

- single-tile (K_ITERS == 1) shapes to the full-N decode schedule instead. 
- Add a host-side gate that disable SliceN when K fits in one BLOCK_K tile, so the combine falls back to the 128-wide full-N tile whose decode_pipeline() already handles a single tile. 
- Ensure the four full-N helpers share this through a new MoEPipelinedProgram.run() dispatch, and SliceN.pipeline() now static_asserts K_ITERS >= 2. Larger-K paths stay on the existing pipelined schedule.

## Test Plan

Add focused tests for dynamic MXFP4 silu at intermediate sizes 256 and 512. The intermediate-256 case drives the combine GEMM down the single-tile path (now full-N decode), so it deadlocks on the pre-fix kernel and both runs and matches the torch reference once fixed. A unit test pins the single-K-tile gate.

- python -m pytest -q tokenspeed-kernel-amd/test/ops/test_gluon_moe_gemm_gfx950.py

- pre-commit run --all-files

