### PR TITLE
feat(kernel): add gfx950 Gluon mxfp4 MoE decode and prefill kernels

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
@@ -21,6 +21,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any, Optional
 
 import torch
@@ -34,10 +35,36 @@ from tokenspeed_kernel_amd.ops.moe.utils import (
     topk,
 )
 
+# The gfx950 MXFP4 kernels are dominated by uint8 activation/weight/scale buffer
+# loads in the M=4/8 decode regime. Keep the backend's i8 buffer-load coalescer
+# enabled unless the caller explicitly overrides it before import/compilation.
+os.environ.setdefault("AMDGCN_COALESCE_BUFFER_LOAD_I8", "1")
+
 MXFP4_BLOCK = 32
 _MXFP4_QUANT_TILED_MIN_ROWS = 128
 _MXFP4_QUANT_TILED_BLOCK_M = 32
 _MXFP4_QUANT_TILED_BLOCK_K_SCALE = 32
+
+_DEFAULT_SWIGLU_ALPHA = 1.702
+_DEFAULT_SWIGLU_LIMIT = 7.0
+_DEFAULT_SWIGLU_BETA = 1.0
+_DEFAULT_SWIGLU_ACT = FusedActivation(
+    FnSpecs("swiglu", swiglu_fn, ("alpha", "limit", "beta"), reduction_n=2),
+    (_DEFAULT_SWIGLU_ALPHA, _DEFAULT_SWIGLU_LIMIT, _DEFAULT_SWIGLU_BETA),
+)
+
+
+def _swiglu_activation(alpha: float, limit: float, beta: float) -> FusedActivation:
+    if (
+        float(alpha) == _DEFAULT_SWIGLU_ALPHA
+        and float(limit) == _DEFAULT_SWIGLU_LIMIT
+        and float(beta) == _DEFAULT_SWIGLU_BETA
+    ):
+        return _DEFAULT_SWIGLU_ACT
+    return FusedActivation(
+        FnSpecs("swiglu", swiglu_fn, ("alpha", "limit", "beta"), reduction_n=2),
+        (float(alpha), float(limit), float(beta)),
+    )
 
 
 def _as_int32(t):
@@ -123,6 +150,20 @@ _GLUON_DOT_SUB_TILE_K = _GLUON_DOT_K_QUAD * _GLUON_DOT_K_WIDTH  # = 64
 
 _TCP_INFLIGHT_CAP_BYTES = 32 * 1024  # gfx9 L1/TCP per-CU in-flight cap
 _CDNA4_NUM_XCDS = 8  # MI355X has 8 XCDs (chiplets) per device.
+
+# Tuned decode dispatch defaults (rocprofv3 real-GPU tuned). Decode owns the
+# small-M regime below the package-prefill gate; the kernel is chosen purely by
+# batch size and whether the caller supplied precomputed top-k:
+#   M <= _DIRECT_DECODE_MAX_M                       -> direct top-k MXFP4 MFMA decode
+#   _PRECOMPUTED_MFMA_MIN_M <= M <= _DECODE_MAX_M   -> precomputed-activation MFMA decode
+#   (no precomputed top-k) M <= _ROUTE_OWNED_DECODE_MAX_M -> route-owned direct decode
+# These replace the former GLUON_MXFP4_* environment overrides.
+_DECODE_MAX_M = 8
+_DIRECT_DECODE_MAX_M = 2
+_PRECOMPUTED_MFMA_MIN_M = 4
+_ROUTE_OWNED_DECODE_MAX_M = 2
+_ROUTE_OWNED_MIN_M = 1
+_DIRECT_STAGE2_BLOCK_N = 16
 
 
 def shuffle_weight_for_gluon_dot_layout(
@@ -7700,10 +7741,7 @@ def gluon_mxfp_fused_moe(
             dtype=router_logits.dtype,
         )
 
-    act = FusedActivation(
-        FnSpecs("swiglu", swiglu_fn, ("alpha", "limit", "beta"), reduction_n=2),
-        (swiglu_alpha, swiglu_limit, swiglu_beta),
-    )
+    act = _swiglu_activation(swiglu_alpha, swiglu_limit, swiglu_beta)
 
     gemm1_input = x_fp8
 
@@ -7739,6 +7777,669 @@ def gluon_mxfp_fused_moe(
     )
 
 
+def _maybe_precomputed_mxfp4_direct_mfma_decode(
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor,
+    w13_weight: torch.Tensor,
+    w2_weight: torch.Tensor,
+    *,
+    w13_mx_scale: torch.Tensor,
+    w2_mx_scale: torch.Tensor,
+    top_k: int,
+    w13_bias: Optional[torch.Tensor],
+    w2_bias: Optional[torch.Tensor],
+    out_dtype: torch.dtype,
+    max_m: int,
+    precomputed_topk_weights: torch.Tensor | None,
+    precomputed_topk_ids: torch.Tensor | None,
+    swiglu_alpha: float,
+    swiglu_limit: float,
+    swiglu_beta: float,
+) -> torch.Tensor | None:
+    """Direct top-k MXFP4xMXFP4 decode for tiny precomputed-routing batches.
+
+    Unlike the generic reference precomputed path, this does not build
+    ragged metadata.  It quantizes hidden states in token order, runs direct
+    W13 MFMA into (token, top-k slot) intermediate rows, quantizes those rows,
+    then runs direct W2 MFMA with fused top-k combine.  Weight/scales are still
+    the exact gdot128-shuffled runtime tensors.
+    """
+    n_tokens = int(hidden_states.shape[0])
+    direct_max_m = _DIRECT_DECODE_MAX_M
+    if (
+        precomputed_topk_weights is None
+        or precomputed_topk_ids is None
+        or n_tokens <= 0
+        or n_tokens > min(max_m, direct_max_m)
+        or hidden_states.dtype != torch.bfloat16
+        or out_dtype != torch.bfloat16
+        or w13_bias is not None
+        or w2_bias is not None
+        or precomputed_topk_ids.ndim != 2
+        or precomputed_topk_weights.shape != precomputed_topk_ids.shape
+        or int(precomputed_topk_ids.shape[0]) != n_tokens
+        or int(precomputed_topk_ids.shape[1]) != top_k
+    ):
+        return None
+
+    w13_runtime = _extract_gluon_raw_w(w13_weight)
+    w2_runtime = _extract_gluon_raw_w(w2_weight)
+    w13_scale = _extract_gluon_raw_s(w13_mx_scale)
+    w2_scale = _extract_gluon_raw_s(w2_mx_scale)
+    if (
+        not isinstance(w13_runtime, torch.Tensor)
+        or not isinstance(w2_runtime, torch.Tensor)
+        or not isinstance(w13_scale, torch.Tensor)
+        or not isinstance(w2_scale, torch.Tensor)
+        or w13_runtime.dtype != torch.uint8
+        or w2_runtime.dtype != torch.uint8
+        or w13_scale.dtype != torch.uint8
+        or w2_scale.dtype != torch.uint8
+        or w13_runtime.ndim != 3
+        or w2_runtime.ndim != 3
+    ):
+        return None
+    if (
+        not bool(getattr(w13_runtime, "is_shuffled_for_gluon_dot", False))
+        or not bool(getattr(w2_runtime, "is_shuffled_for_gluon_dot", False))
+        or int(getattr(w13_runtime, "gluon_dot_block_k_pk", 0)) != 128
+        or int(getattr(w13_runtime, "gluon_dot_block_n", 0)) != 128
+        or int(getattr(w2_runtime, "gluon_dot_block_k_pk", 0)) != 128
+        or int(getattr(w2_runtime, "gluon_dot_block_n", 0)) != 128
+        or w13_scale.stride(-2) != 1
+        or w2_scale.stride(-2) != 1
+    ):
+        return None
+
+    hidden_dim = int(hidden_states.shape[1])
+    if hidden_dim % MXFP4_BLOCK != 0:
+        return None
+    w13_k_pk = int(getattr(w13_runtime, "original_k_pk", int(w13_runtime.shape[1])))
+    if w13_k_pk * 2 != hidden_dim:
+        return None
+    inter_dim = int(w13_runtime.shape[2]) // 2
+    if int(w13_runtime.shape[2]) != 2 * inter_dim or inter_dim % MXFP4_BLOCK != 0:
+        return None
+    w2_k_pk = int(getattr(w2_runtime, "original_k_pk", int(w2_runtime.shape[1])))
+    out_dim = int(getattr(w2_runtime, "original_n", int(w2_runtime.shape[2])))
+    if w2_k_pk * 2 != inter_dim or out_dim != hidden_dim:
+        return None
+
+    topk_ids = (
+        precomputed_topk_ids
+        if precomputed_topk_ids.dtype == torch.int32
+        else precomputed_topk_ids.to(torch.int32)
+    )
+    topk_weights = (
+        precomputed_topk_weights
+        if precomputed_topk_weights.dtype == torch.float32
+        else precomputed_topk_weights.to(torch.float32)
+    )
+
+    from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.decode_stage1 import (
+        invoke_stage1_mxfp4_mfma_decode_gluon,
+    )
+    from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.decode_stage2 import (
+        invoke_stage2_mxfp4_mfma_decode_gluon,
+    )
+
+    q_hidden, q_hidden_scale = _quantize_mxfp4_activation(hidden_states)
+    inter = torch.empty(
+        (n_tokens * top_k, inter_dim), dtype=torch.bfloat16, device=hidden_states.device
+    )
+    invoke_stage1_mxfp4_mfma_decode_gluon(
+        q_hidden,
+        q_hidden_scale,
+        w13_runtime,
+        w13_scale,
+        topk_ids,
+        inter,
+        top_k,
+        BLOCK_N=16 if n_tokens <= 2 else 32,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_limit=swiglu_limit,
+        swiglu_beta=swiglu_beta,
+    )
+    q_inter, q_inter_scale = _quantize_mxfp4_activation(inter)
+    out = torch.empty((n_tokens, out_dim), dtype=out_dtype, device=hidden_states.device)
+    invoke_stage2_mxfp4_mfma_decode_gluon(
+        q_inter,
+        q_inter_scale,
+        w2_runtime,
+        w2_scale,
+        topk_ids,
+        topk_weights,
+        out,
+        top_k,
+        BLOCK_N=_DIRECT_STAGE2_BLOCK_N,
+    )
+    return out
+
+
+def _maybe_precomputed_mxfp4_mfma_decode(
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor,
+    w13_weight: torch.Tensor,
+    w2_weight: torch.Tensor,
+    *,
+    w13_mx_scale: torch.Tensor,
+    w2_mx_scale: torch.Tensor,
+    top_k: int,
+    w13_bias: Optional[torch.Tensor],
+    w2_bias: Optional[torch.Tensor],
+    out_dtype: torch.dtype,
+    max_m: int,
+    precomputed_topk_weights: torch.Tensor | None,
+    precomputed_topk_ids: torch.Tensor | None,
+    swiglu_alpha: float,
+    swiglu_limit: float,
+    swiglu_beta: float,
+    min_m: int = _PRECOMPUTED_MFMA_MIN_M,
+) -> torch.Tensor | None:
+    """Precomputed top-k dynamic MXFP4-activation decode path.
+
+    This covers the M=4/8 regime where the BF16-activation scalar decode path
+    is dominated by global-load waits, while the reference MXFP4xMXFP4 MFMA path is
+    faster once routing/top-k has already been computed by the caller.
+    """
+    n_tokens = int(hidden_states.shape[0])
+    if (
+        precomputed_topk_weights is None
+        or precomputed_topk_ids is None
+        or n_tokens < min_m
+        or n_tokens > max_m
+        or hidden_states.dtype != torch.bfloat16
+        or out_dtype != torch.bfloat16
+        or w13_bias is not None
+        or w2_bias is not None
+        or top_k != int(precomputed_topk_ids.shape[1])
+    ):
+        return None
+
+    topk_ids = (
+        precomputed_topk_ids
+        if precomputed_topk_ids.dtype == torch.int32
+        else precomputed_topk_ids.to(torch.int32)
+    )
+    topk_weights = (
+        precomputed_topk_weights
+        if precomputed_topk_weights.dtype == torch.float32
+        else precomputed_topk_weights.to(torch.float32)
+    )
+
+    w13_runtime = _extract_gluon_raw_w(w13_weight)
+    w2_runtime = _extract_gluon_raw_w(w2_weight)
+    w13_scale = _extract_gluon_raw_s(w13_mx_scale)
+    w2_scale = _extract_gluon_raw_s(w2_mx_scale)
+    if (
+        not isinstance(w13_runtime, torch.Tensor)
+        or not isinstance(w2_runtime, torch.Tensor)
+        or not isinstance(w13_scale, torch.Tensor)
+        or not isinstance(w2_scale, torch.Tensor)
+        or w13_runtime.dtype != torch.uint8
+        or w2_runtime.dtype != torch.uint8
+        or w13_scale.dtype != torch.uint8
+        or w2_scale.dtype != torch.uint8
+        or w13_runtime.ndim != 3
+        or w2_runtime.ndim != 3
+    ):
+        return None
+    if (
+        not bool(getattr(w13_runtime, "is_shuffled_for_gluon_dot", False))
+        or not bool(getattr(w2_runtime, "is_shuffled_for_gluon_dot", False))
+        or int(getattr(w13_runtime, "gluon_dot_block_k_pk", 0)) != 128
+        or int(getattr(w13_runtime, "gluon_dot_block_n", 0)) != 128
+        or int(getattr(w2_runtime, "gluon_dot_block_k_pk", 0)) != 128
+        or int(getattr(w2_runtime, "gluon_dot_block_n", 0)) != 128
+        or w13_scale.stride(-2) != 1
+        or w2_scale.stride(-2) != 1
+    ):
+        return None
+
+    hidden_dim = int(hidden_states.shape[1])
+    w13_k_pk = int(getattr(w13_runtime, "original_k_pk", int(w13_runtime.shape[1])))
+    if w13_k_pk * 2 != hidden_dim:
+        return None
+    inter_dim = int(w13_runtime.shape[2]) // 2
+    w2_k_pk = int(getattr(w2_runtime, "original_k_pk", int(w2_runtime.shape[1])))
+    out_dim = int(getattr(w2_runtime, "original_n", int(w2_runtime.shape[2])))
+    if w2_k_pk * 2 != inter_dim or out_dim != hidden_dim:
+        return None
+    if not gluon_precomputed_topk_route_supported(
+        topk_weights,
+        topk_ids,
+        num_experts=int(w13_runtime.shape[0]),
+        dtype=router_logits.dtype,
+    ):
+        return None
+
+    use_flat_m1_route = n_tokens == 1
+    if use_flat_m1_route:
+        ragged_metadata, gather_indx, scatter_indx, gate_scal = (
+            gluon_precomputed_topk_flat_m1_route(
+                topk_weights,
+                topk_ids,
+                num_experts=int(w13_runtime.shape[0]),
+                dtype=router_logits.dtype,
+            )
+        )
+        x_scale_ragged_padded = False
+    else:
+        ragged_metadata, gather_indx, scatter_indx, gate_scal = (
+            gluon_precomputed_topk_fused_route(
+                topk_weights,
+                topk_ids,
+                num_experts=int(w13_runtime.shape[0]),
+                dtype=router_logits.dtype,
+            )
+        )
+        x_scale_ragged_padded = True
+    tiny_m_matmul_kwargs = (
+        {
+            "block_m": 64,
+            "block_n": 128,
+            "block_k": 256,
+            "use_slice_n": False,
+        }
+        if n_tokens <= 2
+        else {}
+    )
+    gemm1_input, gemm1_scale = _quantize_mxfp4_activation(
+        hidden_states,
+        gather_indx=gather_indx,
+        ragged_metadata=ragged_metadata if x_scale_ragged_padded else None,
+    )
+    act = _swiglu_activation(swiglu_alpha, swiglu_limit, swiglu_beta)
+    intermediate_cache = gluon_mxfp_ragged_matmul(
+        gemm1_input,
+        w13_runtime,
+        None,
+        w_mx_scale=w13_scale,
+        x_mx_scale=gemm1_scale,
+        x_format="e2m1",
+        out_dtype=out_dtype,
+        a_ragged_metadata=ragged_metadata,
+        fused_activation=act,
+        x_scale_ragged_padded=x_scale_ragged_padded,
+        **tiny_m_matmul_kwargs,
+    )
+    gemm2_input, gemm2_scale = _quantize_mxfp4_activation(
+        intermediate_cache,
+        ragged_metadata=ragged_metadata if x_scale_ragged_padded else None,
+    )
+    return gluon_mxfp_ragged_matmul(
+        gemm2_input,
+        w2_runtime,
+        None,
+        w_mx_scale=w2_scale,
+        x_mx_scale=gemm2_scale,
+        x_format="e2m1",
+        out_dtype=out_dtype,
+        a_ragged_metadata=ragged_metadata,
+        scatter_indx=scatter_indx,
+        gammas=gate_scal,
+        n_tokens=n_tokens,
+        n_expts_act=top_k,
+        x_scale_ragged_padded=x_scale_ragged_padded,
+        **tiny_m_matmul_kwargs,
+    )
+
+
+def _maybe_route_owned_mxfp4_mfma_decode(
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor,
+    w13_weight: torch.Tensor,
+    w2_weight: torch.Tensor,
+    *,
+    w13_mx_scale: torch.Tensor,
+    w2_mx_scale: torch.Tensor,
+    top_k: int,
+    correction_bias: torch.Tensor | None,
+    n_group: int,
+    topk_group: int,
+    routed_scaling_factor: float,
+    normalize_topk_weights: bool,
+    routing_method_type: int,
+    w13_bias: Optional[torch.Tensor],
+    w2_bias: Optional[torch.Tensor],
+    out_dtype: torch.dtype,
+    max_m: int,
+    swiglu_alpha: float,
+    swiglu_limit: float,
+    swiglu_beta: float,
+    allow_generic_fallback: bool = True,
+) -> torch.Tensor | None:
+    """Route-owned MXFP4xMXFP4 decode for tiny batches without precomputed top-k.
+
+    Computes top-k in Gluon (softmax or sigmoid-bias) directly from the router
+    logits, then prefers the direct top-k MXFP4xMXFP4 decode path. When
+    ``allow_generic_fallback`` is set it falls back to the generic ragged MFMA;
+    otherwise it returns ``None`` so the caller's own generic path takes over.
+    """
+    n_tokens = int(router_logits.shape[0])
+    if n_tokens < _ROUTE_OWNED_MIN_M or n_tokens > max_m:
+        return None
+    if not gluon_route_supported(router_logits, top_k, router_logits.dtype):
+        return None
+
+    method = int(routing_method_type)
+    from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.routing import (
+        invoke_sigmoid_bias_topk_route_gluon,
+        invoke_softmax_topk_route_gluon,
+    )
+
+    if method == _ROUTING_METHOD_RENORMALIZE:
+        return None
+    if correction_bias is not None and n_group == 1 and topk_group == 1:
+        topk_ids, topk_weights = invoke_sigmoid_bias_topk_route_gluon(
+            router_logits,
+            correction_bias,
+            top_k,
+            routed_scaling_factor=routed_scaling_factor,
+            normalize_topk_weights=normalize_topk_weights,
+        )
+    elif method == 0:
+        # Global softmax, optionally with a choice bias. Grouped softmax only
+        # degenerates to this when there is exactly one group.
+        if n_group not in (0, 1) or topk_group not in (0, 1):
+            return None
+        if correction_bias is not None and (n_group != 0 or topk_group != 0):
+            return None
+        topk_ids, topk_weights = invoke_softmax_topk_route_gluon(
+            router_logits,
+            top_k,
+            correction_bias=correction_bias,
+            routed_scaling_factor=routed_scaling_factor,
+            normalize_topk_weights=normalize_topk_weights,
+        )
+    else:
+        return None
+
+    out = _maybe_precomputed_mxfp4_direct_mfma_decode(
+        hidden_states,
+        router_logits,
+        w13_weight,
+        w2_weight,
+        w13_mx_scale=w13_mx_scale,
+        w2_mx_scale=w2_mx_scale,
+        top_k=top_k,
+        w13_bias=w13_bias,
+        w2_bias=w2_bias,
+        out_dtype=out_dtype,
+        max_m=max_m,
+        precomputed_topk_weights=topk_weights,
+        precomputed_topk_ids=topk_ids,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_limit=swiglu_limit,
+        swiglu_beta=swiglu_beta,
+    )
+    if out is not None:
+        return out
+    if not allow_generic_fallback:
+        return None
+
+    return _maybe_precomputed_mxfp4_mfma_decode(
+        hidden_states,
+        router_logits,
+        w13_weight,
+        w2_weight,
+        w13_mx_scale=w13_mx_scale,
+        w2_mx_scale=w2_mx_scale,
+        top_k=top_k,
+        w13_bias=w13_bias,
+        w2_bias=w2_bias,
+        out_dtype=out_dtype,
+        max_m=max_m,
+        precomputed_topk_weights=topk_weights,
+        precomputed_topk_ids=topk_ids,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_limit=swiglu_limit,
+        swiglu_beta=swiglu_beta,
+    )
+
+
+# Tuned default: rocprofv3 kernel-trace (real GPU time) shows package prefill
+# beats the reference ragged path at every M >= 9 (1.03x-1.24x, bit-exact) on
+# the Kimi shape, and the decode kernels own M <= 8. So package prefill is
+# selected automatically for M >= this threshold (no env toggle).
+_PACKAGE_PREFILL_MIN_M = 9
+
+
+def _maybe_gluon_package_mxfp4_prefill(
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor,
+    w13_weight: torch.Tensor,
+    w2_weight: torch.Tensor,
+    *,
+    w13_mx_scale: torch.Tensor,
+    w2_mx_scale: torch.Tensor,
+    top_k: int,
+    correction_bias: torch.Tensor | None,
+    n_group: int,
+    topk_group: int,
+    routed_scaling_factor: float,
+    normalize_topk_weights: bool,
+    routing_method_type: int,
+    precomputed_topk_weights: torch.Tensor | None,
+    precomputed_topk_ids: torch.Tensor | None,
+    out_dtype: torch.dtype,
+    swiglu_alpha: float,
+    swiglu_limit: float,
+    swiglu_beta: float,
+) -> torch.Tensor | None:
+    """Dispatch into the dedicated gfx950 A4W4 block-ragged prefill package.
+
+    Routing top-k and activation quantization reuse the shared MXFP4
+    implementation; the block-aligned sort and both stage GEMMs are the
+    dedicated package kernels, launched directly.
+
+    Selection is automatic: this returns ``None`` (so the caller falls back to
+    the reference path) unless the batch is large enough
+    (``M >= _PACKAGE_PREFILL_MIN_M``) and the weights were gdot128-preshuffled
+    (the preprocessor attaches the zero-copy gdot128-storage aliases).
+    """
+    if int(hidden_states.shape[0]) < _PACKAGE_PREFILL_MIN_M:
+        return None
+    if out_dtype != torch.bfloat16:
+        return None
+    package_w13 = getattr(w13_weight, "gluon_package_prefill_weight", None)
+    package_w13_scale = getattr(w13_weight, "gluon_package_prefill_scale", None)
+    package_w2 = getattr(w2_weight, "gluon_package_prefill_weight", None)
+    package_w2_scale = getattr(w2_weight, "gluon_package_prefill_scale", None)
+    if not all(
+        isinstance(t, torch.Tensor)
+        for t in (package_w13, package_w13_scale, package_w2, package_w2_scale)
+    ):
+        return None
+
+    topk_weights = precomputed_topk_weights
+    topk_ids = precomputed_topk_ids
+    if topk_weights is None or topk_ids is None:
+        method = int(routing_method_type)
+        if method == _ROUTING_METHOD_RENORMALIZE:
+            topk_logits, topk_ids = _stable_topk_smaller_index(
+                router_logits, k=top_k, dim=-1, sorted=True
+            )
+            topk_weights = topk_logits.exp()
+            topk_weights = _normalize_route_weights(
+                topk_weights,
+                normalize_topk_weights=normalize_topk_weights,
+                routed_scaling_factor=1.0,
+                scale_when_unnormalized=False,
+            )
+            topk_weights = topk_weights.to(torch.float32)
+            topk_ids = topk_ids.to(torch.int32)
+        elif _uses_grouped_routing(n_group, topk_group):
+            if correction_bias is None:
+                topk_weights, topk_ids = _grouped_topk_reference(
+                    router_logits,
+                    top_k,
+                    n_group=n_group,
+                    topk_group=topk_group,
+                    routed_scaling_factor=routed_scaling_factor,
+                    normalize_topk_weights=normalize_topk_weights,
+                )
+            else:
+                topk_weights, topk_ids = _biased_grouped_topk_reference(
+                    router_logits,
+                    correction_bias,
+                    top_k,
+                    n_group=n_group,
+                    topk_group=topk_group,
+                    routed_scaling_factor=routed_scaling_factor,
+                    normalize_topk_weights=normalize_topk_weights,
+                )
+        elif _has_incomplete_grouped_routing(n_group, topk_group):
+            return None
+        else:
+            topk_weights, topk_ids = _softmax_topk_reference(
+                router_logits,
+                top_k,
+                correction_bias=correction_bias,
+                routed_scaling_factor=routed_scaling_factor,
+                normalize_topk_weights=normalize_topk_weights,
+            )
+
+    topk_ids = topk_ids.to(torch.int32).contiguous()
+    topk_weights = topk_weights.to(torch.float32).contiguous()
+    n_tokens = int(hidden_states.shape[0])
+    n_experts = int(package_w13.shape[0])
+    hidden_dim = int(hidden_states.shape[1])
+    inter_dim = int(package_w13.shape[1]) // 2
+    if (
+        int(package_w13.shape[1]) != 2 * inter_dim
+        or int(package_w13.shape[2]) * 2 != hidden_dim
+        or int(package_w2.shape[1]) != hidden_dim
+        or int(package_w2.shape[2]) * 2 != inter_dim
+    ):
+        return None
+
+    from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.moe_sorting import (
+        gluon_moe_sorting,
+    )
+    from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.prefill_stage1 import (
+        invoke_gluon_mxfp4_moe_stage1,
+    )
+    from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.prefill_stage2 import (
+        invoke_gluon_mxfp4_moe_stage2_1x2,
+    )
+    from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.scale import (
+        gather_package_cdna4_scale,
+    )
+
+    sort_block_m = 128
+    # In-house block-aligned sort: runs on the caller's stream with no
+    # device-to-host sync. The worst-case padded route buffers are kept at full
+    # length -- padding blocks carry the ``-1`` expert sentinel (stage1
+    # early-exits) and stage2 skips tiles past ``num_valid_ids[0]`` on-device,
+    # so no host-side trim is needed.
+    sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids, out = (
+        gluon_moe_sorting(
+            topk_ids,
+            topk_weights,
+            n_experts,
+            hidden_dim,
+            out_dtype,
+            sort_block_m,
+        )
+    )
+
+    # Stage 1: quantize the hidden state, gather its scale into sorted-route
+    # order, and run the package gate/up MFMA with fused SwiGLU.
+    q_hidden, q_hidden_scale = _quantize_mxfp4_activation(hidden_states)
+    stage1_scale = gather_package_cdna4_scale(
+        q_hidden_scale,
+        sorted_ids,
+        source_rows=n_tokens,
+        cols=hidden_dim,
+        top_k=top_k,
+        flatten_topk=False,
+    )
+    inter = torch.empty(
+        (n_tokens, top_k, inter_dim),
+        dtype=torch.bfloat16,
+        device=hidden_states.device,
+    )
+    invoke_gluon_mxfp4_moe_stage1(
+        q_hidden,
+        package_w13.view(torch.uint8),
+        None,
+        sorted_ids,
+        sorted_expert_ids,
+        num_valid_ids,
+        inter,
+        top_k,
+        w1_scale=package_w13_scale.view(torch.uint8),
+        a1_scale=stage1_scale,
+        sorted_weights=None,
+        b_preshuffled=True,
+        b_gdot128=True,
+        swiglu_alpha=float(swiglu_alpha),
+        swiglu_limit=float(swiglu_limit),
+        swiglu_beta=float(swiglu_beta),
+    )
+    inter_flat = inter.view(n_tokens * top_k, inter_dim)
+
+    q_inter, q_inter_scale = _quantize_mxfp4_activation(inter_flat)
+
+    # Stage 2 uses its own, smaller-block sort at small M. When tokens spread
+    # across many experts (e.g. top-8 over 384 experts at M<=512), a 128-row
+    # per-expert pad inflates the routed extent ~40x, so the down-projection
+    # GEMM burns almost all of its MFMA cycles on padding rows. A 32/64 sort
+    # block cuts that padding proportionally. Stage 1 keeps the 128 layout its
+    # kernel requires; stage 2 is free to use a different layout because it
+    # indexes ``inter_flat`` by ``(token, slot)``, not by stage-1 sorted slot.
+    stage2_block_m = 32 if n_tokens <= 512 else (64 if n_tokens <= 1024 else 128)
+    if stage2_block_m == sort_block_m:
+        s2_sorted_ids = sorted_ids
+        s2_sorted_weights = sorted_weights
+        s2_sorted_expert_ids = sorted_expert_ids
+        s2_num_valid_ids = num_valid_ids
+    else:
+        (
+            s2_sorted_ids,
+            s2_sorted_weights,
+            s2_sorted_expert_ids,
+            s2_num_valid_ids,
+            _,
+        ) = gluon_moe_sorting(
+            topk_ids,
+            topk_weights,
+            n_experts,
+            hidden_dim,
+            out_dtype,
+            stage2_block_m,
+        )
+
+    stage2_scale = gather_package_cdna4_scale(
+        q_inter_scale,
+        s2_sorted_ids,
+        source_rows=n_tokens * top_k,
+        cols=inter_dim,
+        top_k=top_k,
+        flatten_topk=True,
+    )
+    invoke_gluon_mxfp4_moe_stage2_1x2(
+        q_inter,
+        None,
+        package_w2.view(torch.uint8),
+        s2_sorted_ids,
+        s2_sorted_expert_ids,
+        s2_num_valid_ids,
+        out,
+        top_k,
+        w2_scale=package_w2_scale.view(torch.uint8),
+        a2_scale=stage2_scale,
+        sorted_weights=s2_sorted_weights,
+        b_preshuffled=True,
+        b_gdot128=True,
+        block_m=stage2_block_m,
+        sort_block_m=stage2_block_m,
+        force_reduce=True,
+    )
+    return out
+
+
 def gluon_mxfp_dynamic_mxfp4_fused_moe(
     hidden_states: torch.Tensor,
     router_logits: torch.Tensor,
@@ -7760,6 +8461,8 @@ def gluon_mxfp_dynamic_mxfp4_fused_moe(
     swiglu_alpha: float = 1.702,
     swiglu_limit: float = 7.0,
     swiglu_beta: float = 1.0,
+    precomputed_topk_weights: torch.Tensor | None = None,
+    precomputed_topk_ids: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Route + dispatch + combine for dynamic MXFP4 activations on gfx950.
 
@@ -7769,18 +8472,135 @@ def gluon_mxfp_dynamic_mxfp4_fused_moe(
     """
     route_dtype = router_logits.dtype
 
-    ragged_metadata, gather_indx, scatter_indx, gate_scal = _dynamic_mxfp4_route(
+    has_precomputed_topk = (
+        precomputed_topk_weights is not None and precomputed_topk_ids is not None
+    )
+    n_tokens = router_logits.shape[0]
+    # Package prefill is selected automatically by batch size and weight layout
+    # (see _maybe_gluon_package_mxfp4_prefill); it returns None when not
+    # applicable and the dispatch falls through to decode / the reference path.
+    # It uses the in-house gluon_moe_sorting and runs on the caller's stream, so
+    # no cross-stream fence or default-stream ownership is required.
+    package_prefill_out = _maybe_gluon_package_mxfp4_prefill(
+        hidden_states,
         router_logits,
-        top_k,
+        w13_weight,
+        w2_weight,
+        w13_mx_scale=w13_mx_scale,
+        w2_mx_scale=w2_mx_scale,
+        top_k=top_k,
         correction_bias=correction_bias,
         n_group=n_group,
         topk_group=topk_group,
         routed_scaling_factor=routed_scaling_factor,
         normalize_topk_weights=normalize_topk_weights,
         routing_method_type=routing_method_type,
-        dtype=route_dtype,
+        precomputed_topk_weights=precomputed_topk_weights,
+        precomputed_topk_ids=precomputed_topk_ids,
+        out_dtype=out_dtype,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_limit=swiglu_limit,
+        swiglu_beta=swiglu_beta,
     )
+    if package_prefill_out is not None:
+        return package_prefill_out
 
+    # Small-M decode fast paths (M < _PACKAGE_PREFILL_MIN_M). The kernel is
+    # selected purely by batch size and whether the caller supplied precomputed
+    # top-k; each helper returns None when the weights/shapes are unsupported
+    # and the dispatch falls through to the generic reference path below.
+    if has_precomputed_topk:
+        if int(n_tokens) <= _DECODE_MAX_M:
+            decode_out = _maybe_precomputed_mxfp4_direct_mfma_decode(
+                hidden_states,
+                router_logits,
+                w13_weight,
+                w2_weight,
+                w13_mx_scale=w13_mx_scale,
+                w2_mx_scale=w2_mx_scale,
+                top_k=top_k,
+                w13_bias=w13_bias,
+                w2_bias=w2_bias,
+                out_dtype=out_dtype,
+                max_m=_DECODE_MAX_M,
+                precomputed_topk_weights=precomputed_topk_weights,
+                precomputed_topk_ids=precomputed_topk_ids,
+                swiglu_alpha=swiglu_alpha,
+                swiglu_limit=swiglu_limit,
+                swiglu_beta=swiglu_beta,
+            )
+            if decode_out is not None:
+                return decode_out
+
+            if int(n_tokens) >= _PRECOMPUTED_MFMA_MIN_M:
+                decode_out = _maybe_precomputed_mxfp4_mfma_decode(
+                    hidden_states,
+                    router_logits,
+                    w13_weight,
+                    w2_weight,
+                    w13_mx_scale=w13_mx_scale,
+                    w2_mx_scale=w2_mx_scale,
+                    top_k=top_k,
+                    w13_bias=w13_bias,
+                    w2_bias=w2_bias,
+                    out_dtype=out_dtype,
+                    max_m=_DECODE_MAX_M,
+                    precomputed_topk_weights=precomputed_topk_weights,
+                    precomputed_topk_ids=precomputed_topk_ids,
+                    swiglu_alpha=swiglu_alpha,
+                    swiglu_limit=swiglu_limit,
+                    swiglu_beta=swiglu_beta,
+                )
+                if decode_out is not None:
+                    return decode_out
+
+    else:
+        if int(n_tokens) <= _ROUTE_OWNED_DECODE_MAX_M:
+            decode_out = _maybe_route_owned_mxfp4_mfma_decode(
+                hidden_states,
+                router_logits,
+                w13_weight,
+                w2_weight,
+                w13_mx_scale=w13_mx_scale,
+                w2_mx_scale=w2_mx_scale,
+                top_k=top_k,
+                correction_bias=correction_bias,
+                n_group=n_group,
+                topk_group=topk_group,
+                routed_scaling_factor=routed_scaling_factor,
+                normalize_topk_weights=normalize_topk_weights,
+                routing_method_type=routing_method_type,
+                w13_bias=w13_bias,
+                w2_bias=w2_bias,
+                out_dtype=out_dtype,
+                max_m=_ROUTE_OWNED_DECODE_MAX_M,
+                swiglu_alpha=swiglu_alpha,
+                swiglu_limit=swiglu_limit,
+                swiglu_beta=swiglu_beta,
+                allow_generic_fallback=False,
+            )
+            if decode_out is not None:
+                return decode_out
+
+    if has_precomputed_topk:
+        ragged_metadata, gather_indx, scatter_indx, gate_scal = _route_from_topk(
+            precomputed_topk_weights.to(torch.float32),
+            precomputed_topk_ids.to(torch.int32),
+            num_experts=router_logits.shape[1],
+            dtype=route_dtype,
+        )
+    else:
+        ragged_metadata, gather_indx, scatter_indx, gate_scal = _dynamic_mxfp4_route(
+            router_logits,
+            top_k,
+            correction_bias=correction_bias,
+            n_group=n_group,
+            topk_group=topk_group,
+            routed_scaling_factor=routed_scaling_factor,
+            normalize_topk_weights=normalize_topk_weights,
+            routing_method_type=routing_method_type,
+            dtype=route_dtype,
+        )
     return _gluon_mxfp_dynamic_mxfp4_fused_moe_from_route(
         hidden_states,
         w13_weight,
@@ -8047,6 +8867,65 @@ def _normalize_route_weights(
     return topk_weights
 
 
+def _stable_topk_smaller_index(
+    values: torch.Tensor,
+    k: int,
+    *,
+    dim: int = -1,
+    sorted: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Top-k with the same exact-tie rule as the reference streaming top-k.
+
+    The reference ranks a packed ``(ordered float bits, inverse index)`` integer key,
+    so equal floating-point values select the smaller expert id.  ``torch.topk``
+    does not define which index wins an exact tie, which is observable for BF16
+    router logits after sigmoid.  Pack the same key here while gathering the
+    original values so non-tied ordering and route weights remain unchanged.
+    """
+    if values.dtype == torch.float32:
+        integer_dtype = torch.int32
+        value_mask = 0xFFFFFFFF
+        sign_mask = 0x80000000
+    elif values.dtype in (torch.float16, torch.bfloat16):
+        integer_dtype = torch.int16
+        value_mask = 0xFFFF
+        sign_mask = 0x8000
+    else:
+        raise TypeError(
+            "stable route top-k supports float16, bfloat16, and float32; "
+            f"got {values.dtype}"
+        )
+
+    dim = dim if dim >= 0 else values.ndim + dim
+    if dim < 0 or dim >= values.ndim:
+        raise IndexError(f"top-k dimension {dim} is invalid for rank {values.ndim}")
+    width = int(values.shape[dim])
+    if not 0 < k <= width:
+        raise ValueError(f"top-k requires 0 < k <= {width}; got {k}")
+    if width >= 1 << 16:
+        raise ValueError(
+            f"stable route top-k supports fewer than 65536 values: {width}"
+        )
+
+    raw = values.contiguous().view(integer_dtype).to(torch.int64) & value_mask
+    # Build the flip masks on-device with ``full_like`` rather than
+    # ``raw.new_tensor(<python int>)``: the latter materializes a CPU tensor and
+    # copies it to the GPU, which is illegal during CUDA-graph capture.
+    ordered = raw ^ torch.where(
+        (raw & sign_mask) != 0,
+        torch.full_like(raw, value_mask),
+        torch.full_like(raw, sign_mask),
+    )
+    index_shape = [1] * values.ndim
+    index_shape[dim] = width
+    index = torch.arange(width, device=values.device, dtype=torch.int64).view(
+        index_shape
+    )
+    packed = (ordered << 16) | (width - index)
+    _, topk_ids = torch.topk(packed, k=k, dim=dim, sorted=sorted)
+    return values.gather(dim, topk_ids), topk_ids
+
+
 def _softmax_topk_reference(
     logits: torch.Tensor,
     topk: int,
@@ -8059,7 +8938,9 @@ def _softmax_topk_reference(
     scores_for_choice = scores
     if correction_bias is not None:
         scores_for_choice = scores + correction_bias.to(scores.dtype).unsqueeze(0)
-    _, topk_ids = torch.topk(scores_for_choice, k=topk, dim=-1, sorted=True)
+    _, topk_ids = _stable_topk_smaller_index(
+        scores_for_choice, k=topk, dim=-1, sorted=True
+    )
     topk_weights = scores.gather(1, topk_ids)
     topk_weights = _normalize_route_weights(
         topk_weights,
@@ -8082,7 +8963,9 @@ def _grouped_topk_reference(
     scores = torch.softmax(logits.float(), dim=-1)
     n_tokens, n_experts = scores.shape
     group_scores = scores.view(n_tokens, n_group, -1).max(dim=-1).values
-    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[1]
+    _, group_idx = _stable_topk_smaller_index(
+        group_scores, k=topk_group, dim=-1, sorted=False
+    )
     group_mask = torch.zeros_like(group_scores)
     group_mask.scatter_(1, group_idx, 1)
     score_mask = (
@@ -8091,7 +8974,9 @@ def _grouped_topk_reference(
         .reshape(n_tokens, -1)
     )
     tmp_scores = scores.masked_fill(~score_mask.bool(), 0.0)
-    topk_weights, topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=False)
+    topk_weights, topk_ids = _stable_topk_smaller_index(
+        tmp_scores, k=topk, dim=-1, sorted=False
+    )
     topk_weights = _normalize_route_weights(
         topk_weights,
         normalize_topk_weights=normalize_topk_weights,
@@ -8131,7 +9016,9 @@ def default_packed_topk_route(
     normalize_topk_weights: bool,
     dtype: torch.dtype | None = None,
 ) -> tuple[RaggedTensorMetadata, torch.Tensor, torch.Tensor, torch.Tensor]:
-    topk_logits, topk_ids = torch.topk(logits, k=topk, dim=-1, sorted=True)
+    topk_logits, topk_ids = _stable_topk_smaller_index(
+        logits, k=topk, dim=-1, sorted=True
+    )
     topk_weights = topk_logits.exp()
     topk_weights = _normalize_route_weights(
         topk_weights,
@@ -8702,6 +9589,174 @@ def _fused_biased_grouped_route_small_m(
     gl.store(GatherIndx + pos, tok, mask=gmask)
     gl.store(ScatterIndx + pos, g.to(gl.int32), mask=gmask)
     gl.store(GateScal + pos, vals, mask=gmask)
+
+
+@gluon.jit
+def _precomputed_topk_route_small_m(
+    TopkIds,  # [M, TOPK] int32
+    TopkWeights,  # [M, TOPK] fp/bf
+    SliceSizes,  # [E] int32
+    SliceOffs,  # [E+1] int32
+    BlockOffs,  # [NB, E+1] int32
+    BlockSched,  # [NB, MAXBLK] int32
+    GatherIndx,  # [G] int32
+    ScatterIndx,  # [G] int32
+    GateScal,  # [G] dtype
+    stride_tim,
+    stride_tik,
+    stride_twm,
+    stride_twk,
+    M: gl.constexpr,
+    E: gl.constexpr,
+    TOPK: gl.constexpr,
+    GP: gl.constexpr,
+    EP: gl.constexpr,
+    MAXBLK: gl.constexpr,
+    MAXBLKP: gl.constexpr,
+    NB_C: gl.constexpr,
+    X_DTYPE: gl.constexpr,
+    NW_C: gl.constexpr,
+    bo_stride: gl.constexpr,
+    bs_stride: gl.constexpr,
+):
+    G: gl.constexpr = M * TOPK
+    LE: gl.constexpr = gl.BlockedLayout([1], [64], [NW_C], [0])
+    LG: gl.constexpr = gl.BlockedLayout([1], [64], [NW_C], [0])
+    LB: gl.constexpr = gl.BlockedLayout([1], [64], [NW_C], [0])
+    LT: gl.constexpr = gl.BlockedLayout([1, 1], [1, 64], [NW_C, 1], [1, 0])
+
+    g = gl.arange(0, GP, layout=LG)
+    gmask = g < G
+    tok = (g // TOPK).to(gl.int32)
+    slot = (g % TOPK).to(gl.int32)
+
+    idx_raw = gl.load(
+        TopkIds + tok.to(gl.int64) * stride_tim + slot.to(gl.int64) * stride_tik,
+        mask=gmask,
+        other=0,
+    ).to(gl.int32)
+    valid = gmask & (idx_raw >= 0) & (idx_raw < E)
+    idx = gl.where(valid, idx_raw, gl.zeros([GP], gl.int32, layout=LG))
+    vals = gl.load(
+        TopkWeights + tok.to(gl.int64) * stride_twm + slot.to(gl.int64) * stride_twk,
+        mask=valid,
+        other=0.0,
+    ).to(gl.float32)
+
+    e = gl.arange(0, EP, layout=LE)
+    emask = e < E
+    hist = gl.histogram(idx, EP, mask=valid, layout=LE)
+    gl.store(SliceSizes + e, hist, mask=emask)
+
+    incl = gl.associative_scan(hist, 0, _route_add)
+    col_offs = incl - hist
+    last = e == (E - 1)
+    gl.store(SliceOffs + e, col_offs, mask=emask)
+    gl.store(SliceOffs + e + 1, incl, mask=emask & last)
+
+    n_blk = (hist > 0).to(gl.int32)
+    blk_incl = gl.associative_scan(n_blk, 0, _route_add)
+    blk_excl = blk_incl - n_blk
+    n_total = gl.sum(n_blk, 0)
+    jb = gl.arange(0, MAXBLKP, layout=LB)
+    jbmask = jb < MAXBLK
+    neg_fill = gl.full([MAXBLKP], -1, gl.int32, layout=LB)
+    for k in gl.static_range(NB_C):
+        gl.store(BlockOffs + k * bo_stride + e, blk_excl, mask=emask)
+        gl.store(BlockOffs + k * bo_stride + e + 1, blk_incl, mask=emask & last)
+        gl.store(
+            BlockSched + k * bs_stride + jb,
+            neg_fill,
+            mask=jbmask & (jb >= n_total),
+        )
+        gl.store(
+            BlockSched + k * bs_stride + blk_excl,
+            e,
+            mask=(hist > 0) & emask,
+        )
+
+    idx_row = gl.expand_dims(gl.convert_layout(idx, gl.SliceLayout(1, LT)), 1)
+    idx_col = gl.expand_dims(gl.convert_layout(idx, gl.SliceLayout(0, LT)), 0)
+    valid_row = gl.expand_dims(gl.convert_layout(valid, gl.SliceLayout(1, LT)), 1)
+    valid_col = gl.expand_dims(gl.convert_layout(valid, gl.SliceLayout(0, LT)), 0)
+    g_row = gl.expand_dims(gl.arange(0, GP, layout=gl.SliceLayout(1, LT)), 1)
+    g_col = gl.expand_dims(gl.arange(0, GP, layout=gl.SliceLayout(0, LT)), 0)
+    match = (valid_row & valid_col & (idx_row == idx_col) & (g_col < g_row)).to(
+        gl.int32
+    )
+    rank = gl.convert_layout(gl.sum(match, axis=1), LG)
+
+    pos = gl.gather(col_offs, idx, axis=0) + rank
+    gl.store(GatherIndx + pos, tok, mask=valid)
+    gl.store(ScatterIndx + pos, g.to(gl.int32), mask=valid)
+    gl.store(GateScal + pos, vals.to(X_DTYPE), mask=valid)
+
+
+@gluon.jit
+def _precomputed_topk_route_m1_flat(
+    TopkIds,  # [1, TOPK] int32
+    TopkWeights,  # [1, TOPK] fp/bf
+    SliceSizes,  # [E] int32
+    SliceOffs,  # [E+1] int32
+    BlockOffs,  # [NB, E+1] int32
+    BlockSched,  # [NB, TOPK] int32
+    GatherIndx,  # [TOPK] int32
+    ScatterIndx,  # [TOPK] int32
+    GateScal,  # [TOPK] dtype
+    stride_tik,
+    stride_twk,
+    E: gl.constexpr,
+    TOPK: gl.constexpr,
+    EP: gl.constexpr,
+    TKP: gl.constexpr,
+    NB_C: gl.constexpr,
+    X_DTYPE: gl.constexpr,
+    bo_stride: gl.constexpr,
+    bs_stride: gl.constexpr,
+):
+    """Flat precomputed route for M=1.
+
+    For one token, torch/top-k returns unique expert ids, so each active expert
+    owns exactly one flat slot row. The matmul block-schedule path only needs
+    the active experts' slice offsets and a compact schedule; it does not need
+    the full histogram/prefix/rank route used for M>=2.
+    """
+    LE: gl.constexpr = gl.BlockedLayout([1], [64], [1], [0])
+    LT: gl.constexpr = gl.BlockedLayout([1], [64], [1], [0])
+
+    e = gl.arange(0, EP, layout=LE)
+    emask = e < E
+    gl.store(SliceSizes + e, gl.full([EP], 0, gl.int32, layout=LE), mask=emask)
+    gl.store(SliceOffs + e, gl.full([EP], 0, gl.int32, layout=LE), mask=emask)
+    last = e == (E - 1)
+    gl.store(SliceOffs + e + 1, TOPK, mask=emask & last)
+    for k in gl.static_range(NB_C):
+        gl.store(
+            BlockOffs + k * bo_stride + e,
+            gl.full([EP], 0, gl.int32, layout=LE),
+            mask=emask,
+        )
+        gl.store(BlockOffs + k * bo_stride + e + 1, TOPK, mask=emask & last)
+
+    slot = gl.arange(0, TKP, layout=LT)
+    smask = slot < TOPK
+    expert = gl.load(TopkIds + slot * stride_tik, mask=smask, other=0).to(gl.int32)
+    valid = smask & (expert >= 0) & (expert < E)
+    weight = gl.load(TopkWeights + slot * stride_twk, mask=valid, other=0.0).to(
+        gl.float32
+    )
+
+    gl.store(SliceSizes + expert, 1, mask=valid)
+    gl.store(SliceOffs + expert, slot.to(gl.int32), mask=valid)
+    for k in gl.static_range(NB_C):
+        gl.store(
+            BlockSched + k * bs_stride + slot,
+            expert,
+            mask=valid,
+        )
+    gl.store(GatherIndx + slot, 0, mask=smask)
+    gl.store(ScatterIndx + slot, slot.to(gl.int32), mask=smask)
+    gl.store(GateScal + slot, weight.to(X_DTYPE), mask=valid)
 
 
 # ===========================================================================
@@ -9609,6 +10664,195 @@ def _route_small_m(logits, topk, dtype):
     return ragged, gather_indx, scatter_indx, gate_scal
 
 
+def gluon_precomputed_topk_route_supported(
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    *,
+    num_experts: int,
+    dtype: torch.dtype,
+) -> bool:
+    if (
+        topk_weights.ndim != 2
+        or topk_ids.ndim != 2
+        or topk_weights.shape != topk_ids.shape
+        or dtype not in GLUON_ROUTE_DTYPES
+    ):
+        return False
+    M, topk = topk_ids.shape
+    G = M * topk
+    return (
+        M <= SMALLM_MAX_M
+        and G <= GLUON_ROUTE_MAX_G
+        and 0 < topk <= num_experts <= GLUON_ROUTE_MAX_E
+    )
+
+
+def gluon_precomputed_topk_flat_m1_route(
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    *,
+    num_experts: int,
+    dtype: torch.dtype | None = None,
+) -> tuple[
+    RaggedTensorMetadata,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """Specialized flat precomputed route for a single decode token.
+
+    The output row order remains the caller's top-k slot order. This is valid
+    for M=1 because top-k ids are unique within a token, so each active expert
+    has one contiguous row. M>=2 still uses the general expert-grouped route
+    because experts can repeat across tokens.
+    """
+    if dtype is None:
+        dtype = topk_weights.dtype
+    if not gluon_precomputed_topk_route_supported(
+        topk_weights,
+        topk_ids,
+        num_experts=num_experts,
+        dtype=dtype,
+    ):
+        raise ValueError("unsupported precomputed-topk Gluon route configuration")
+    if int(topk_ids.shape[0]) != 1:
+        raise ValueError("flat M=1 route requires exactly one token")
+
+    device = topk_ids.device
+    topk = int(topk_ids.shape[1])
+    if topk_ids.dtype != torch.int32:
+        topk_ids = topk_ids.to(torch.int32)
+    topk_ids = topk_ids.contiguous()
+    topk_weights = topk_weights.contiguous()
+
+    slice_sizes = torch.empty(num_experts, dtype=torch.int32, device=device)
+    slice_offs = torch.empty(num_experts + 1, dtype=torch.int32, device=device)
+    block_offs_data = torch.empty(
+        _ROUTE_NB, num_experts + 1, dtype=torch.int32, device=device
+    )
+    block_schedule_data = torch.empty(_ROUTE_NB, topk, dtype=torch.int32, device=device)
+    gather_indx = torch.empty(topk, dtype=torch.int32, device=device)
+    scatter_indx = torch.empty(topk, dtype=torch.int32, device=device)
+    gate_scal = torch.empty(topk, dtype=dtype, device=device)
+
+    _precomputed_topk_route_m1_flat[(1,)](
+        topk_ids,
+        topk_weights,
+        slice_sizes,
+        slice_offs,
+        block_offs_data,
+        block_schedule_data,
+        gather_indx,
+        scatter_indx,
+        gate_scal,
+        topk_ids.stride(1),
+        topk_weights.stride(1),
+        E=num_experts,
+        TOPK=topk,
+        EP=_route_next_pow2(num_experts),
+        TKP=_route_next_pow2(topk),
+        NB_C=_ROUTE_NB,
+        X_DTYPE=_ROUTE_GL_DTYPE[dtype],
+        bo_stride=block_offs_data.stride(0),
+        bs_stride=block_schedule_data.stride(0),
+        num_warps=1,
+    )
+    ragged = RaggedTensorMetadata(
+        slice_sizes, slice_offs, block_offs_data, block_schedule_data
+    )
+    return ragged, gather_indx, scatter_indx, gate_scal
+
+
+def gluon_precomputed_topk_fused_route(
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    *,
+    num_experts: int,
+    dtype: torch.dtype | None = None,
+) -> tuple[
+    RaggedTensorMetadata,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """1-kernel stable route metadata from already-computed top-k.
+
+    This is the precomputed-top-k analogue of ``gluon_fused_route``: it keeps
+    the same single-block small-M ragged metadata contract, but skips in-kernel
+    softmax/top-k and consumes the caller-provided ``topk_ids`` /
+    ``topk_weights`` directly.
+    """
+    if dtype is None:
+        dtype = topk_weights.dtype
+    if not gluon_precomputed_topk_route_supported(
+        topk_weights,
+        topk_ids,
+        num_experts=num_experts,
+        dtype=dtype,
+    ):
+        raise ValueError("unsupported precomputed-topk Gluon route configuration")
+
+    M, topk = topk_ids.shape
+    G = M * topk
+    device = topk_ids.device
+    if topk_ids.dtype != torch.int32:
+        topk_ids = topk_ids.to(torch.int32)
+    topk_ids = topk_ids.contiguous()
+    topk_weights = topk_weights.contiguous()
+
+    slice_sizes = torch.empty(num_experts, dtype=torch.int32, device=device)
+    slice_offs = torch.empty(num_experts + 1, dtype=torch.int32, device=device)
+    block_offs_data = torch.empty(
+        _ROUTE_NB, num_experts + 1, dtype=torch.int32, device=device
+    )
+    maxblk = RaggedTensorMetadata.max_n_blocks(num_experts, G)
+    block_schedule_data = torch.empty(
+        _ROUTE_NB, maxblk, dtype=torch.int32, device=device
+    )
+    gather_indx = torch.empty(G, dtype=torch.int32, device=device)
+    scatter_indx = torch.empty(G, dtype=torch.int32, device=device)
+    gate_scal = torch.empty(G, dtype=dtype, device=device)
+
+    # Precomputed top-k skips the O(M*E) route-owned top-k work. The remaining
+    # histogram/prefix/rank metadata kernel has different balance across decode
+    # sizes: M=1 and M=4 are fastest with one warp; M=2 and M>=8 benefit from
+    # two warps without paying the full four-warp barrier cost used by
+    # route-owned top-k.
+    nw = 1 if M <= 1 else (2 if M <= 2 else (1 if M <= 4 else 2))
+    _precomputed_topk_route_small_m[(1,)](
+        topk_ids,
+        topk_weights,
+        slice_sizes,
+        slice_offs,
+        block_offs_data,
+        block_schedule_data,
+        gather_indx,
+        scatter_indx,
+        gate_scal,
+        topk_ids.stride(0),
+        topk_ids.stride(1),
+        topk_weights.stride(0),
+        topk_weights.stride(1),
+        M=M,
+        E=num_experts,
+        TOPK=topk,
+        GP=_route_next_pow2(G),
+        EP=_route_next_pow2(num_experts),
+        MAXBLK=maxblk,
+        MAXBLKP=_route_next_pow2(maxblk),
+        NB_C=_ROUTE_NB,
+        X_DTYPE=_ROUTE_GL_DTYPE[dtype],
+        NW_C=nw,
+        bo_stride=block_offs_data.stride(0),
+        bs_stride=block_schedule_data.stride(0),
+        num_warps=nw,
+    )
+    ragged = RaggedTensorMetadata(
+        slice_sizes, slice_offs, block_offs_data, block_schedule_data
+    )
+    return ragged, gather_indx, scatter_indx, gate_scal
+
+
 def _route_from_topk(
     topk_weights: torch.Tensor,
     topk_ids: torch.Tensor,
@@ -9832,12 +11076,16 @@ def _biased_grouped_topk_reference(
     scores = logits.sigmoid()
     n_tokens, n_experts = scores.shape
     scores_for_choice = scores + correction_bias.unsqueeze(0)
-    group_scores = (
-        scores_for_choice.view(n_tokens, n_group, -1)
-        .topk(2, dim=-1, sorted=True)[0]
-        .sum(dim=-1)
+    group_top2, _ = _stable_topk_smaller_index(
+        scores_for_choice.view(n_tokens, n_group, -1),
+        k=2,
+        dim=-1,
+        sorted=True,
     )
-    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=True)[1]
+    group_scores = group_top2.sum(dim=-1)
+    _, group_idx = _stable_topk_smaller_index(
+        group_scores, k=topk_group, dim=-1, sorted=True
+    )
     group_mask = torch.zeros_like(group_scores)
     group_mask.scatter_(1, group_idx, 1)
     score_mask = (
@@ -9846,7 +11094,7 @@ def _biased_grouped_topk_reference(
         .reshape(n_tokens, -1)
     )
     tmp_scores = scores_for_choice.masked_fill(~score_mask.bool(), float("-inf"))
-    _, topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=True)
+    _, topk_ids = _stable_topk_smaller_index(tmp_scores, k=topk, dim=-1, sorted=True)
     topk_weights = scores.gather(1, topk_ids)
     if normalize_topk_weights:
         topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/__init__.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/__init__.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""Gluon A4W4 MoE kernels for AMD CDNA4/gfx950.
+
+The package keeps the four production stages behind stage-specific modules:
+prefill stage 1/2 and decode stage 1/2.  ``moe.py`` provides the small-M
+end-to-end decode entry point, while ``routing.py`` exposes the fused decode
+top-k helpers.
+"""
+
+from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.decode_stage1 import (
+    invoke_stage1_mxfp4_mfma_decode_gluon,
+)
+from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.decode_stage2 import (
+    invoke_stage2_mxfp4_mfma_decode_gluon,
+)
+from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.moe import gluon_mxfp4_moe_decode
+from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.prefill_stage1 import (
+    invoke_gluon_mxfp4_moe_stage1,
+)
+from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.prefill_stage2 import (
+    invoke_gluon_mxfp4_moe_stage2_1x2,
+)
+from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.preprocess import (
+    attach_prefill_aliases,
+)
+from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.routing import (
+    invoke_sigmoid_bias_topk_route_gluon,
+    invoke_softmax_topk_route_gluon,
+)
+from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.scale import (
+    gather_package_cdna4_scale,
+)
+
+__all__ = [
+    "attach_prefill_aliases",
+    "gather_package_cdna4_scale",
+    "gluon_mxfp4_moe_decode",
+    "invoke_gluon_mxfp4_moe_stage1",
+    "invoke_gluon_mxfp4_moe_stage2_1x2",
+    "invoke_sigmoid_bias_topk_route_gluon",
+    "invoke_softmax_topk_route_gluon",
+    "invoke_stage1_mxfp4_mfma_decode_gluon",
+    "invoke_stage2_mxfp4_mfma_decode_gluon",
+]

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/decode_kernels.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/decode_kernels.py
@@ -1,0 +1,1460 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""Small-M decode kernels for the gfx950 A4W4 MoE package.
+
+The production entry points in this module consume packed E2M1 activations,
+E8M0 activation scales, and gdot128-shuffled MXFP4 weights/scales,
+then execute direct CDNA4 MFMA for both MoE stages.
+
+The older ``invoke_stage*_warp_decode_gluon`` helpers consume BF16
+activations and scalar-dequantize only the MXFP4 weights.  They are retained
+solely for historical microbenchmarks through ``mxfp4_warp_decode_gfx950``;
+the public ``gluon_a4w4_gfx950`` package and production dispatch do not export
+or call them.
+"""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel_amd._triton import gl, gluon, triton
+
+_LANES = gl.constexpr(64)  # wavefront width (reduction lanes)
+_ROUTE_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+_ROUTE_MAX_E = 1024
+_ROUTE_MAX_G = 64
+_ROUTE_GL_DTYPE = {
+    torch.float16: gl.float16,
+    torch.bfloat16: gl.bfloat16,
+    torch.float32: gl.float32,
+}
+
+
+def _next_pow2(x: int) -> int:
+    return 1 << (max(1, x) - 1).bit_length()
+
+
+@gluon.jit
+def _e2m1_to_f32(n):
+    """Decode a 4-bit e2m1 (fp4) code (0..15) to f32.
+
+    magnitude by (e,m): e==0 -> m*0.5 (0 or 0.5); e>0 -> 2^(e-1) * (1 + 0.5*m)
+    => {0,0.5,1,1.5,2,3,4,6}; sign bit negates.
+    """
+    sign = (n >> 3) & 1
+    idx = n & 7
+    m = (idx & 1).to(gl.float32)
+    e = idx >> 1
+    mag = gl.where(e == 0, m * 0.5, gl.exp2((e - 1).to(gl.float32)) * (1.0 + 0.5 * m))
+    return gl.where(sign == 1, -mag, mag)
+
+
+@gluon.jit
+def _gluon_dot_preshuffled_w_offset(w_expert_off, k_pack, n_col, n_phys):
+    """Return flat byte offset for the 128x128 Gluon-dot W layout."""
+    k_in_block = k_pack % 128
+    n_in_block = n_col % 128
+
+    k_within = k_in_block % 16
+    k_quad = (k_in_block // 16) % 4
+    k_block = k_in_block // 64
+    n_in_sub = n_in_block % 16
+    n_block = n_in_block // 16
+
+    in_tile = (
+        n_block.to(gl.int64) * 2048
+        + k_block.to(gl.int64) * 1024
+        + k_quad.to(gl.int64) * 256
+        + n_in_sub.to(gl.int64) * 16
+        + k_within.to(gl.int64)
+    )
+    n_tiles = n_phys // 128
+    tile_id = (k_pack // 128).to(gl.int64) * n_tiles + (n_col // 128).to(gl.int64)
+    return w_expert_off + tile_id * (128 * 128) + in_tile
+
+
+@gluon.jit
+def _cdna4_swizzled_mxfp4_scale_offset(
+    scale_expert_off,
+    n_col,
+    k_scale,
+    stride_slin,
+    stride_snb,
+):
+    """Return byte offset for CDNA4-swizzled e8m0 scales.
+
+    The preprocessor stores scales as ``(E, K_scale_padded * 32, N_padded / 32)``
+    with ``stride(-2) == 1``.  This is the scalar form of the unswizzle used by
+    the reference MFMA path.
+    """
+    n_block = n_col // 32
+    n_mix = (n_col % 16) * 4 + ((n_col % 32) // 16)
+    k_lin = (
+        (k_scale // 8).to(gl.int64) * 256
+        + (k_scale % 4).to(gl.int64) * 64
+        + ((k_scale % 8) // 4).to(gl.int64) * 2
+        + n_mix.to(gl.int64)
+    )
+    return scale_expert_off + k_lin * stride_slin + n_block.to(gl.int64) * stride_snb
+
+
+# ---------------------------------------------------------------------------
+# Route-owned decode: produce top-k ids/weights in Gluon.
+#
+# The dynamic MXFP4 route-owned path must not bounce through torch.softmax /
+# torch.topk before entering warp-decode.  These kernels produce the same
+# ``topk_ids`` / ``topk_weights`` contract consumed by stage1/stage2.
+# ---------------------------------------------------------------------------
+@gluon.jit
+def _softmax_topk_route_gluon_kernel(
+    logits_ptr,  # (M, E)
+    bias_ptr,  # (E), read only when HAS_BIAS
+    topk_ids_ptr,  # (M, TOPK) int32
+    topk_weights_ptr,  # (M, TOPK) float32
+    stride_lm,
+    stride_le,
+    stride_be,
+    stride_tim,
+    stride_tik,
+    stride_twm,
+    stride_twk,
+    M: gl.constexpr,
+    E: gl.constexpr,
+    TOPK: gl.constexpr,
+    MP: gl.constexpr,
+    EP: gl.constexpr,
+    TKP: gl.constexpr,
+    HAS_BIAS: gl.constexpr,
+    NORMALIZE_TOPK_WEIGHTS: gl.constexpr,
+    ROUTED_SCALING_FACTOR: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+):
+    NEG: gl.constexpr = float("-inf")
+    lt: gl.constexpr = gl.BlockedLayout([1, 1], [1, 64], [NUM_WARPS, 1], [1, 0])
+    row = gl.expand_dims(gl.arange(0, MP, layout=gl.SliceLayout(1, lt)), 1)
+    col = gl.expand_dims(gl.arange(0, EP, layout=gl.SliceLayout(0, lt)), 0)
+    mask = (row < M) & (col < E)
+
+    logits = gl.load(
+        logits_ptr + row.to(gl.int64) * stride_lm + col.to(gl.int64) * stride_le,
+        mask=mask,
+        other=NEG,
+    ).to(gl.float32)
+    rmax = gl.max(logits, axis=1, keep_dims=True)
+    num = gl.exp(logits - rmax)
+    den = gl.sum(num, axis=1, keep_dims=True)
+    scores = gl.fdiv(num, den)
+    choice = scores
+    if HAS_BIAS:
+        bias = gl.load(
+            bias_ptr + col.to(gl.int64) * stride_be,
+            mask=col < E,
+            other=0.0,
+        ).to(gl.float32)
+        choice = choice + bias
+    choice = gl.where(mask, choice, NEG)
+
+    tcol = gl.expand_dims(gl.arange(0, TKP, layout=gl.SliceLayout(0, lt)), 0)
+    val_t = gl.zeros([MP, TKP], gl.float32, layout=lt)
+    idx_t = gl.zeros([MP, TKP], gl.int32, layout=lt)
+    big_e = gl.full([MP, EP], E, gl.int32, layout=lt)
+    cur = choice
+    for r in gl.static_range(TOPK):
+        vmax = gl.max(cur, axis=1, keep_dims=True)
+        ismax = (cur == vmax) & mask
+        amax = gl.min(gl.where(ismax, col, big_e), axis=1, keep_dims=True)
+        gate = gl.sum(gl.where(col == amax, scores, gl.zeros_like(scores)), axis=1)
+        sel = tcol == r
+        val_t = gl.where(sel, gl.expand_dims(gate, 1), val_t)
+        idx_t = gl.where(sel, amax, idx_t)
+        cur = gl.where(col == amax, NEG, cur)
+
+    if NORMALIZE_TOPK_WEIGHTS:
+        denom = gl.sum(val_t, axis=1, keep_dims=True)
+        denom = gl.where(denom != 0.0, denom, 1.0)
+        val_t = gl.fdiv(val_t, denom)
+    val_t = val_t * ROUTED_SCALING_FACTOR
+
+    m = gl.arange(0, MP, layout=gl.SliceLayout(1, lt))
+    zero_i = gl.zeros([MP, TKP], gl.int32, layout=lt)
+    zero_f = gl.zeros([MP, TKP], gl.float32, layout=lt)
+    for r in gl.static_range(TOPK):
+        sel = tcol == r
+        idx_r = gl.sum(gl.where(sel, idx_t, zero_i), axis=1)
+        val_r = gl.sum(gl.where(sel, val_t, zero_f), axis=1)
+        valid_m = m < M
+        gl.store(
+            topk_ids_ptr + m.to(gl.int64) * stride_tim + r * stride_tik,
+            idx_r,
+            mask=valid_m,
+        )
+        gl.store(
+            topk_weights_ptr + m.to(gl.int64) * stride_twm + r * stride_twk,
+            val_r,
+            mask=valid_m,
+        )
+
+
+@gluon.jit
+def _sigmoid_bias_topk_route_gluon_kernel(
+    logits_ptr,  # (M, E)
+    bias_ptr,  # (E)
+    topk_ids_ptr,  # (M, TOPK) int32
+    topk_weights_ptr,  # (M, TOPK) float32
+    stride_lm,
+    stride_le,
+    stride_be,
+    stride_tim,
+    stride_tik,
+    stride_twm,
+    stride_twk,
+    M: gl.constexpr,
+    E: gl.constexpr,
+    TOPK: gl.constexpr,
+    MP: gl.constexpr,
+    EP: gl.constexpr,
+    TKP: gl.constexpr,
+    NORMALIZE_TOPK_WEIGHTS: gl.constexpr,
+    ROUTED_SCALING_FACTOR: gl.constexpr,
+    X_DTYPE: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+):
+    NEG: gl.constexpr = float("-inf")
+    lt: gl.constexpr = gl.BlockedLayout([1, 1], [1, 64], [NUM_WARPS, 1], [1, 0])
+    row = gl.expand_dims(gl.arange(0, MP, layout=gl.SliceLayout(1, lt)), 1)
+    col = gl.expand_dims(gl.arange(0, EP, layout=gl.SliceLayout(0, lt)), 0)
+    mask = (row < M) & (col < E)
+
+    logits = gl.load(
+        logits_ptr + row.to(gl.int64) * stride_lm + col.to(gl.int64) * stride_le,
+        mask=mask,
+        other=NEG,
+    ).to(gl.float32)
+    # Match the reference grouped-biased route: sigmoid scores are rounded to the
+    # router dtype before the bias add, top-k choice, and optional normalization.
+    scores = gl.fdiv(1.0, 1.0 + gl.exp(-logits)).to(X_DTYPE)
+    bias = gl.load(
+        bias_ptr + col.to(gl.int64) * stride_be,
+        mask=col < E,
+        other=0.0,
+    ).to(gl.float32)
+    cur = gl.where(mask, scores.to(gl.float32) + bias, NEG)
+
+    tcol = gl.expand_dims(gl.arange(0, TKP, layout=gl.SliceLayout(0, lt)), 0)
+    val_t = gl.zeros([MP, TKP], gl.float32, layout=lt)
+    idx_t = gl.zeros([MP, TKP], gl.int32, layout=lt)
+    big_e = gl.full([MP, EP], E, gl.int32, layout=lt)
+    for r in gl.static_range(TOPK):
+        vmax = gl.max(cur, axis=1, keep_dims=True)
+        ismax = (cur == vmax) & mask
+        amax = gl.min(gl.where(ismax, col, big_e), axis=1, keep_dims=True)
+        gate = gl.sum(gl.where(col == amax, scores, gl.zeros_like(scores)), axis=1)
+        sel = tcol == r
+        val_t = gl.where(sel, gl.expand_dims(gate, 1), val_t)
+        idx_t = gl.where(sel, amax, idx_t)
+        cur = gl.where(col == amax, NEG, cur)
+
+    if NORMALIZE_TOPK_WEIGHTS:
+        val_t = val_t.to(X_DTYPE)
+        denom = gl.sum(val_t, axis=1, keep_dims=True)
+        denom = gl.where(denom != 0.0, denom, 1.0)
+        val_t = gl.fdiv(val_t, denom) * ROUTED_SCALING_FACTOR
+
+    m = gl.arange(0, MP, layout=gl.SliceLayout(1, lt))
+    zero_i = gl.zeros([MP, TKP], gl.int32, layout=lt)
+    zero_f = gl.zeros([MP, TKP], gl.float32, layout=lt)
+    for r in gl.static_range(TOPK):
+        sel = tcol == r
+        idx_r = gl.sum(gl.where(sel, idx_t, zero_i), axis=1)
+        val_r = gl.sum(gl.where(sel, val_t, zero_f), axis=1)
+        valid_m = m < M
+        gl.store(
+            topk_ids_ptr + m.to(gl.int64) * stride_tim + r * stride_tik,
+            idx_r,
+            mask=valid_m,
+        )
+        gl.store(
+            topk_weights_ptr + m.to(gl.int64) * stride_twm + r * stride_twk,
+            val_r,
+            mask=valid_m,
+        )
+
+
+def _route_supported(router_logits: torch.Tensor, topk: int) -> bool:
+    if router_logits.ndim != 2 or router_logits.dtype not in _ROUTE_DTYPES:
+        return False
+    M, E = router_logits.shape
+    return 0 < topk <= E <= _ROUTE_MAX_E and M * topk <= _ROUTE_MAX_G
+
+
+def invoke_softmax_topk_route_gluon(
+    router_logits: torch.Tensor,
+    topk: int,
+    *,
+    correction_bias: torch.Tensor | None = None,
+    routed_scaling_factor: float = 1.0,
+    normalize_topk_weights: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Route with full-row softmax semantics.
+
+    Selection is by ``softmax(logits) + correction_bias`` when a bias is
+    supplied; stored weights are the unbiased selected full-row softmax scores,
+    optionally renormalized across the selected experts and always scaled.
+    """
+    if not _route_supported(router_logits, topk):
+        raise ValueError("unsupported MXFP4 warp-decode softmax route shape")
+    router_logits = router_logits.contiguous()
+    if correction_bias is not None:
+        if (
+            correction_bias.ndim != 1
+            or correction_bias.shape[0] != router_logits.shape[1]
+        ):
+            raise ValueError("correction_bias must be a rank-1 tensor with E elements")
+        correction_bias = correction_bias.contiguous()
+    M, E = router_logits.shape
+    topk_ids = torch.empty((M, topk), dtype=torch.int32, device=router_logits.device)
+    topk_weights = torch.empty(
+        (M, topk), dtype=torch.float32, device=router_logits.device
+    )
+    bias = correction_bias if correction_bias is not None else topk_weights
+    nw = 1 if M <= 2 else 4
+    _softmax_topk_route_gluon_kernel[(1,)](
+        router_logits,
+        bias,
+        topk_ids,
+        topk_weights,
+        router_logits.stride(0),
+        router_logits.stride(1),
+        bias.stride(0),
+        topk_ids.stride(0),
+        topk_ids.stride(1),
+        topk_weights.stride(0),
+        topk_weights.stride(1),
+        M=M,
+        E=E,
+        TOPK=topk,
+        MP=_next_pow2(M),
+        EP=_next_pow2(E),
+        TKP=_next_pow2(topk),
+        HAS_BIAS=correction_bias is not None,
+        NORMALIZE_TOPK_WEIGHTS=normalize_topk_weights,
+        ROUTED_SCALING_FACTOR=float(routed_scaling_factor),
+        NUM_WARPS=nw,
+        num_warps=nw,
+    )
+    return topk_ids, topk_weights
+
+
+def invoke_sigmoid_bias_topk_route_gluon(
+    router_logits: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    *,
+    routed_scaling_factor: float = 1.0,
+    normalize_topk_weights: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Route with DeepSeekV3/Kimi noaux_tc semantics for a single group.
+
+    Selection is by ``sigmoid(logits) + correction_bias``; stored weights are
+    the unbiased selected sigmoid scores.  With Kimi's ``n_group=1`` and
+    ``topk_group=1`` the grouped route degenerates to this global top-k.
+    """
+    if not _route_supported(router_logits, topk):
+        raise ValueError("unsupported MXFP4 warp-decode sigmoid route shape")
+    if correction_bias.ndim != 1 or correction_bias.shape[0] != router_logits.shape[1]:
+        raise ValueError("correction_bias must be a rank-1 tensor with E elements")
+    router_logits = router_logits.contiguous()
+    correction_bias = correction_bias.contiguous()
+    M, E = router_logits.shape
+    topk_ids = torch.empty((M, topk), dtype=torch.int32, device=router_logits.device)
+    topk_weights = torch.empty(
+        (M, topk), dtype=torch.float32, device=router_logits.device
+    )
+    nw = 1 if M <= 2 else 4
+    _sigmoid_bias_topk_route_gluon_kernel[(1,)](
+        router_logits,
+        correction_bias,
+        topk_ids,
+        topk_weights,
+        router_logits.stride(0),
+        router_logits.stride(1),
+        correction_bias.stride(0),
+        topk_ids.stride(0),
+        topk_ids.stride(1),
+        topk_weights.stride(0),
+        topk_weights.stride(1),
+        M=M,
+        E=E,
+        TOPK=topk,
+        MP=_next_pow2(M),
+        EP=_next_pow2(E),
+        TKP=_next_pow2(topk),
+        NORMALIZE_TOPK_WEIGHTS=normalize_topk_weights,
+        ROUTED_SCALING_FACTOR=float(routed_scaling_factor),
+        X_DTYPE=_ROUTE_GL_DTYPE[router_logits.dtype],
+        NUM_WARPS=nw,
+        num_warps=nw,
+    )
+    return topk_ids, topk_weights
+
+
+# ---------------------------------------------------------------------------
+# Stage 1: bf16 x fp4 W13 (gdot128 runtime layout) + e8m0 -> SwiGLU.
+# ---------------------------------------------------------------------------
+@gluon.jit
+def _stage1_mxfp4_warp_gemv_gluon(
+    x_ptr,  # hidden (num_tokens, D)         bf16
+    w1_ptr,  # w1     (E, D//2 padded, 2*I_r) uint8 gdot128-shuffled
+    w1s_ptr,  # w1s    (E, Kscale*32, N/32)    uint8 CDNA4-swizzled e8m0
+    out_ptr,  # inter  (num_tokens*topk, I_r)  bf16
+    topk_ids_ptr,  # (num_tokens, topk) int32
+    D,
+    I_r,
+    num_tokens,
+    top_k,
+    stride_xm,
+    stride_xk,
+    stride_we,
+    stride_se,
+    stride_slin,
+    stride_snb,
+    stride_om,
+    stride_on,
+    stride_tit,
+    stride_tis,
+    N_PHYS: gl.constexpr,
+    BLOCK_N: gl.constexpr,  # neurons per program
+    BLOCK_KB: gl.constexpr,  # weight bytes per reduction tile (= h/2)
+    NUM_WARPS: gl.constexpr,
+):
+    pid = gl.program_id(0)
+    num_pid_n = gl.cdiv(I_r, BLOCK_N)
+    slot = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    token = slot // top_k
+    e = gl.load(topk_ids_ptr + token * stride_tit + (slot % top_k) * stride_tis)
+
+    # warps span the neurons, lanes span the byte reduction -> gl.sum(axis=1) warp-reduces
+    blk: gl.constexpr = gl.BlockedLayout(
+        [(BLOCK_N + NUM_WARPS - 1) // NUM_WARPS, BLOCK_KB // _LANES],
+        [1, _LANES],
+        [NUM_WARPS, 1],
+        [1, 0],
+    )
+    n_layout: gl.constexpr = gl.SliceLayout(1, blk)
+    k_layout: gl.constexpr = gl.SliceLayout(0, blk)
+
+    offs_n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=n_layout)
+    n_mask = offs_n < I_r
+    Dh = D // 2
+    x_row = x_ptr + token.to(gl.int64) * stride_xm
+    w_expert_off = e.to(gl.int64) * stride_we
+    s_expert_off = e.to(gl.int64) * stride_se
+    # gdot128 W13 runtime layout is interleaved by output column:
+    # even columns are gate, odd columns are up.
+    g_col = 2 * offs_n
+    u_col = g_col + 1
+
+    acc_g = gl.zeros([BLOCK_N], gl.float32, n_layout)
+    acc_u = gl.zeros([BLOCK_N], gl.float32, n_layout)
+    for kb0 in range(0, Dh, BLOCK_KB):
+        offs_kb = kb0 + gl.arange(0, BLOCK_KB, layout=k_layout)
+        kb_mask = offs_kb < Dh
+        grp = offs_kb // 16  # 32 h == 16 bytes -> one e8m0 group
+        tile_mask = n_mask[:, None] & kb_mask[None, :]
+        # even/odd h packed in each byte: h = 2*byte (low nibble), 2*byte+1 (high)
+        xe = gl.load(x_row + (2 * offs_kb) * stride_xk, mask=kb_mask, other=0.0).to(
+            gl.float32
+        )
+        xo = gl.load(x_row + (2 * offs_kb + 1) * stride_xk, mask=kb_mask, other=0.0).to(
+            gl.float32
+        )
+        wk_g = _gluon_dot_preshuffled_w_offset(
+            w_expert_off, offs_kb[None, :], g_col[:, None], N_PHYS
+        )
+        wk_u = _gluon_dot_preshuffled_w_offset(
+            w_expert_off, offs_kb[None, :], u_col[:, None], N_PHYS
+        )
+        sk_g = _cdna4_swizzled_mxfp4_scale_offset(
+            s_expert_off, g_col[:, None], grp[None, :], stride_slin, stride_snb
+        )
+        sk_u = _cdna4_swizzled_mxfp4_scale_offset(
+            s_expert_off, u_col[:, None], grp[None, :], stride_slin, stride_snb
+        )
+        bg = gl.load(w1_ptr + wk_g, mask=tile_mask, other=0).to(gl.int32)
+        bu = gl.load(w1_ptr + wk_u, mask=tile_mask, other=0).to(gl.int32)
+        sg = gl.exp2(
+            (gl.load(w1s_ptr + sk_g, mask=tile_mask, other=127).to(gl.int32) - 127).to(
+                gl.float32
+            )
+        )
+        su = gl.exp2(
+            (gl.load(w1s_ptr + sk_u, mask=tile_mask, other=127).to(gl.int32) - 127).to(
+                gl.float32
+            )
+        )
+        acc_g += gl.sum(
+            sg
+            * (
+                _e2m1_to_f32(bg & 0xF) * xe[None, :]
+                + _e2m1_to_f32((bg >> 4) & 0xF) * xo[None, :]
+            ),
+            axis=1,
+        )
+        acc_u += gl.sum(
+            su
+            * (
+                _e2m1_to_f32(bu & 0xF) * xe[None, :]
+                + _e2m1_to_f32((bu >> 4) & 0xF) * xo[None, :]
+            ),
+            axis=1,
+        )
+
+    inter = acc_g * (1.0 / (1.0 + gl.exp(-acc_g))) * acc_u  # SwiGLU: silu(gate) * up
+    gl.store(
+        out_ptr + slot.to(gl.int64) * stride_om + offs_n * stride_on,
+        inter.to(out_ptr.dtype.element_ty),
+        mask=n_mask,
+    )
+
+
+def invoke_stage1_warp_decode_gluon(
+    hidden_states,  # (num_tokens, D)   bf16
+    w1,  # (E, D//2 padded, 2*I_r) uint8 gdot128-shuffled
+    w1_scale,  # (E, Kscale*32, ceil(2*I_r/32)) uint8 CDNA4-swizzled
+    topk_ids,  # (num_tokens, topk) int
+    out,  # (num_tokens*topk, I_r) bf16
+    topk,
+    BLOCK_N: int = 8,
+    BLOCK_KB: int = 128,
+    num_warps: int = 8,
+):
+    assert hidden_states.dtype == torch.bfloat16 and w1.dtype == torch.uint8
+    assert w1_scale.dtype == torch.uint8 and out.dtype == torch.bfloat16
+    num_tokens, D = hidden_states.shape
+    E, Dh_phys, two_I = w1.shape
+    Dh = int(getattr(w1, "original_k_pk", Dh_phys))
+    assert Dh == D // 2 and two_I % 2 == 0 and Dh % BLOCK_KB == 0
+    assert bool(getattr(w1, "is_shuffled_for_gluon_dot", False))
+    assert int(getattr(w1, "gluon_dot_block_k_pk", 0)) == 128
+    assert int(getattr(w1, "gluon_dot_block_n", 0)) == 128
+    assert w1_scale.stride(-2) == 1
+    I_r = two_I // 2
+    assert out.shape == (num_tokens * topk, I_r)
+    topk_ids = topk_ids.to(torch.int32)
+    grid = (num_tokens * topk * triton.cdiv(I_r, BLOCK_N),)
+    _stage1_mxfp4_warp_gemv_gluon[grid](
+        hidden_states,
+        w1,
+        w1_scale,
+        out,
+        topk_ids,
+        D,
+        I_r,
+        num_tokens,
+        topk,
+        hidden_states.stride(0),
+        hidden_states.stride(1),
+        w1.stride(0),
+        w1_scale.stride(0),
+        w1_scale.stride(1),
+        w1_scale.stride(2),
+        out.stride(0),
+        out.stride(1),
+        topk_ids.stride(0),
+        topk_ids.stride(1),
+        w1.shape[2],
+        BLOCK_N=BLOCK_N,
+        BLOCK_KB=BLOCK_KB,
+        NUM_WARPS=num_warps,
+        num_warps=num_warps,
+    )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Stage 2: bf16 inter x fp4 W2 (gdot128 runtime layout) + e8m0, fused topk combine.
+# ---------------------------------------------------------------------------
+@gluon.jit
+def _stage2_mxfp4_warp_gemv_gluon(
+    inter_ptr,  # inter (num_tokens*topk, I_r)  bf16
+    w2_ptr,  # w2    (E, I_r//2 padded, D)    uint8 gdot128-shuffled
+    w2s_ptr,  # w2s   (E, Kscale*32, D/32)     uint8 CDNA4-swizzled e8m0
+    y_ptr,  # out   (num_tokens, D)         bf16
+    topk_ids_ptr,  # (num_tokens, topk) int32
+    topk_weights_ptr,  # (num_tokens, topk) float32
+    D,
+    N_PHYS: gl.constexpr,
+    I_r,
+    num_tokens,
+    top_k,
+    stride_im,
+    stride_ik,
+    stride_we,
+    stride_se,
+    stride_slin,
+    stride_snb,
+    stride_yt,
+    stride_yd,
+    stride_tit,
+    stride_tis,
+    stride_twt,
+    stride_tws,
+    BLOCK_D: gl.constexpr,  # output dims per program
+    BLOCK_KB: gl.constexpr,  # inter bytes per reduction tile (= n/2)
+    NUM_WARPS: gl.constexpr,
+):
+    pid = gl.program_id(0)
+    num_pid_d = gl.cdiv(D, BLOCK_D)
+    token = pid // num_pid_d
+    pid_d = pid % num_pid_d
+
+    # warps span the output dims, lanes span the byte reduction -> gl.sum(axis=1) warp-reduces
+    blk: gl.constexpr = gl.BlockedLayout(
+        [(BLOCK_D + NUM_WARPS - 1) // NUM_WARPS, BLOCK_KB // _LANES],
+        [1, _LANES],
+        [NUM_WARPS, 1],
+        [1, 0],
+    )
+    d_layout: gl.constexpr = gl.SliceLayout(1, blk)
+    k_layout: gl.constexpr = gl.SliceLayout(0, blk)
+
+    offs_d = pid_d * BLOCK_D + gl.arange(0, BLOCK_D, layout=d_layout)
+    d_mask = offs_d < D
+    Ih = I_r // 2
+
+    acc = gl.zeros([BLOCK_D], gl.float32, d_layout)
+    for s in range(0, top_k):  # fuse the topk combine
+        e = gl.load(topk_ids_ptr + token * stride_tit + s * stride_tis)
+        prob = gl.load(topk_weights_ptr + token * stride_twt + s * stride_tws).to(
+            gl.float32
+        )
+        in_row = inter_ptr + (token * top_k + s).to(gl.int64) * stride_im
+        w_expert_off = e.to(gl.int64) * stride_we
+        s_expert_off = e.to(gl.int64) * stride_se
+        dot = gl.zeros([BLOCK_D], gl.float32, d_layout)
+        for kb0 in range(0, Ih, BLOCK_KB):
+            offs_kb = kb0 + gl.arange(0, BLOCK_KB, layout=k_layout)
+            kb_mask = offs_kb < Ih
+            grp = offs_kb // 16
+            tile_mask = d_mask[:, None] & kb_mask[None, :]
+            ve = gl.load(
+                in_row + (2 * offs_kb) * stride_ik, mask=kb_mask, other=0.0
+            ).to(gl.float32)
+            vo = gl.load(
+                in_row + (2 * offs_kb + 1) * stride_ik, mask=kb_mask, other=0.0
+            ).to(gl.float32)
+            wk = _gluon_dot_preshuffled_w_offset(
+                w_expert_off, offs_kb[None, :], offs_d[:, None], N_PHYS
+            )
+            sk = _cdna4_swizzled_mxfp4_scale_offset(
+                s_expert_off, offs_d[:, None], grp[None, :], stride_slin, stride_snb
+            )
+            b = gl.load(
+                w2_ptr + wk,
+                mask=tile_mask,
+                other=0,
+            ).to(gl.int32)
+            sc = gl.exp2(
+                (
+                    gl.load(
+                        w2s_ptr + sk,
+                        mask=tile_mask,
+                        other=127,
+                    ).to(gl.int32)
+                    - 127
+                ).to(gl.float32)
+            )
+            dot += gl.sum(
+                sc
+                * (
+                    _e2m1_to_f32(b & 0xF) * ve[None, :]
+                    + _e2m1_to_f32((b >> 4) & 0xF) * vo[None, :]
+                ),
+                axis=1,
+            )
+        acc += prob * dot
+
+    gl.store(
+        y_ptr + token * stride_yt + offs_d * stride_yd,
+        acc.to(y_ptr.dtype.element_ty),
+        mask=d_mask,
+    )
+
+
+def invoke_stage2_warp_decode_gluon(
+    inter_states,  # (num_tokens*topk, I_r) bf16
+    w2,  # (E, I_r//2 padded, D padded) uint8 gdot128-shuffled
+    w2_scale,  # (E, Kscale*32, ceil(D/32)) uint8 CDNA4-swizzled
+    topk_ids,  # (num_tokens, topk) int
+    topk_weights,  # (num_tokens, topk) float
+    out,  # (num_tokens, D) bf16
+    topk,
+    BLOCK_D: int = 8,
+    BLOCK_KB: int = 128,
+    num_warps: int = 4,
+):
+    assert inter_states.dtype == torch.bfloat16 and w2.dtype == torch.uint8
+    assert w2_scale.dtype == torch.uint8 and out.dtype == torch.bfloat16
+    _, Ih_phys, N_phys = w2.shape
+    Ih = int(getattr(w2, "original_k_pk", Ih_phys))
+    I_r = Ih * 2
+    num_tokens, D = out.shape
+    assert out.shape == (num_tokens, D)
+    assert inter_states.shape == (num_tokens * topk, I_r) and Ih % BLOCK_KB == 0
+    assert D <= N_phys
+    assert bool(getattr(w2, "is_shuffled_for_gluon_dot", False))
+    assert int(getattr(w2, "gluon_dot_block_k_pk", 0)) == 128
+    assert int(getattr(w2, "gluon_dot_block_n", 0)) == 128
+    assert w2_scale.stride(-2) == 1
+    topk_ids = topk_ids.to(torch.int32)
+    topk_weights = topk_weights.to(torch.float32)
+    grid = (num_tokens * triton.cdiv(D, BLOCK_D),)
+    _stage2_mxfp4_warp_gemv_gluon[grid](
+        inter_states,
+        w2,
+        w2_scale,
+        out,
+        topk_ids,
+        topk_weights,
+        D,
+        N_phys,
+        I_r,
+        num_tokens,
+        topk,
+        inter_states.stride(0),
+        inter_states.stride(1),
+        w2.stride(0),
+        w2_scale.stride(0),
+        w2_scale.stride(1),
+        w2_scale.stride(2),
+        out.stride(0),
+        out.stride(1),
+        topk_ids.stride(0),
+        topk_ids.stride(1),
+        topk_weights.stride(0),
+        topk_weights.stride(1),
+        BLOCK_D=BLOCK_D,
+        BLOCK_KB=BLOCK_KB,
+        NUM_WARPS=num_warps,
+        num_warps=num_warps,
+    )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Experimental stage 2: MXFP4 inter x MXFP4 W2 direct MFMA + fused topk combine.
+#
+# This is the direct top-k variant of the reference combine GEMM.  It assumes the
+# intermediate rows are already in (token, topk-slot) order, so it does not
+# consume ragged metadata / scatter indices.  Keep it out of default dispatch
+# until the matching direct stage1 path writes this row order with MXFP4 output.
+# ---------------------------------------------------------------------------
+@gluon.constexpr_function
+def _direct_mxfp4_mfma_layouts(m_dup, block_n, block_k_scale):
+    mfma = gl.amd.AMDMFMALayout(
+        version=4, instr_shape=[16, 16, 128], transposed=True, warps_per_cta=[1, 1]
+    )
+    dot_a = gl.DotOperandLayout(operand_index=0, parent=mfma, k_width=16)
+    dot_b = gl.DotOperandLayout(operand_index=1, parent=mfma, k_width=16)
+    a_scale = gl.amd.cdna4.get_mfma_scale_layout(dot_a, [m_dup, block_k_scale])
+    b_scale = gl.amd.cdna4.get_mfma_scale_layout(dot_b, [block_n, block_k_scale])
+    return mfma, dot_a, dot_b, a_scale, b_scale
+
+
+@gluon.jit
+def _direct_mxfp4_load_tile(
+    kt,
+    ak,
+    bk,
+    ask,
+    bsk,
+    am,
+    asm,
+    x_ptr,
+    x_scale_ptr,
+    w_ptr,
+    w_scale_ptr,
+    x_row_off,
+    w_expert_off,
+    s_expert_off,
+    n_cols,
+    n_cols_s,
+    x_scale_row,
+    stride_xk,
+    stride_xslin,
+    stride_xsnb,
+    stride_slin,
+    stride_snb,
+    N_PHYS,
+    K_DIM,
+    N_DIM,
+    K_PACKED: gl.constexpr,
+    BLOCK_K_PACKED: gl.constexpr,
+    BLOCK_K_SCALE: gl.constexpr,
+):
+    """Load one direct MXFP4xMXFP4 K tile into MFMA operand layouts."""
+    k_pack_a = kt * BLOCK_K_PACKED + ak
+    k_pack_b = kt * BLOCK_K_PACKED + bk
+    k_scale_a = kt * BLOCK_K_SCALE + ask
+    k_scale_b = kt * BLOCK_K_SCALE + bsk
+    a_off = x_row_off + k_pack_a.to(gl.int64) * stride_xk + am.to(gl.int64) * 0
+    b_off = _gluon_dot_preshuffled_w_offset(w_expert_off, k_pack_b, n_cols, N_PHYS)
+    a_scale_off = _cdna4_swizzled_mxfp4_scale_offset(
+        0,
+        x_scale_row + asm * 0,
+        k_scale_a,
+        stride_xslin,
+        stride_xsnb,
+    )
+    b_scale_off = _cdna4_swizzled_mxfp4_scale_offset(
+        s_expert_off,
+        n_cols_s,
+        k_scale_b,
+        stride_slin,
+        stride_snb,
+    )
+    a = gl.amd.cdna4.buffer_load(
+        ptr=x_ptr,
+        offsets=a_off.to(gl.int32),
+        mask=k_pack_a < K_PACKED,
+        other=0,
+    )
+    b = gl.amd.cdna4.buffer_load(
+        ptr=w_ptr,
+        offsets=b_off.to(gl.int32),
+        mask=(n_cols < N_DIM) & (k_pack_b < K_PACKED),
+        other=0,
+    )
+    a_scale = gl.amd.cdna4.buffer_load(
+        ptr=x_scale_ptr,
+        offsets=a_scale_off.to(gl.int32),
+        mask=k_scale_a < (K_DIM // 32),
+        other=127,
+    )
+    b_scale = gl.amd.cdna4.buffer_load(
+        ptr=w_scale_ptr,
+        offsets=b_scale_off.to(gl.int32),
+        mask=(n_cols_s < N_DIM) & (k_scale_b < (K_DIM // 32)),
+        other=127,
+    )
+    return a, b, a_scale, b_scale
+
+
+@gluon.jit
+def _direct_mxfp4_mfma(acc, a, b, a_scale, b_scale):
+    return gl.amd.cdna4.mfma_scaled(
+        a=a,
+        a_scale=a_scale,
+        a_format="e2m1",
+        b=b,
+        b_scale=b_scale,
+        b_format="e2m1",
+        acc=acc,
+    )
+
+
+@gluon.constexpr_function
+def _direct_swiglu_split_layout(
+    block_m: int, block_n_full: int, num_warps: int
+) -> gl.constexpr:
+    del block_m, block_n_full
+    threads_per_warp = 64
+    return gl.BlockedLayout(
+        size_per_thread=[1, 8],
+        threads_per_warp=[4, threads_per_warp // 4],
+        warps_per_cta=[num_warps, 1],
+        order=[1, 0],
+    )
+
+
+@gluon.jit
+def _direct_swiglu_reduce(
+    acc,
+    alpha: gl.constexpr,
+    limit: gl.constexpr,
+    beta: gl.constexpr,
+    OUT_BLOCK_N: gl.constexpr,
+):
+    BLOCK_M: gl.constexpr = acc.shape[0]
+    BLOCK_N_FULL: gl.constexpr = acc.shape[1]
+    split_layout: gl.constexpr = _direct_swiglu_split_layout(
+        BLOCK_M, BLOCK_N_FULL, gl.num_warps()
+    )
+    acc = gl.convert_layout(acc, split_layout)
+    reshaped = acc.reshape((BLOCK_M, OUT_BLOCK_N, 2))
+    gate, linear = gl.split(reshaped)
+    if limit > 0.0:
+        gate = gl.minimum(gate, limit)
+        linear = gl.clamp(linear, -limit, limit)
+    s = gate / (1.0 + gl.exp(-alpha * gate))
+    return s * (linear + beta)
+
+
+@gluon.jit
+def _stage1_mxfp4_direct_mfma_gluon(
+    hidden_ptr,  # (M, D/2) uint8 e2m1 packed, token order
+    hidden_scale_ptr,  # (Kscale_pad*32, ceil(M/32)) uint8 CDNA4 swizzled
+    w1_ptr,  # (E, D/2 padded, 2*I) uint8 gdot128-shuffled
+    w1s_ptr,  # (E, Kscale*32, ceil((2*I)/32)) uint8 CDNA4-swizzled
+    topk_ids_ptr,  # (M, TOPK) int32
+    out_ptr,  # (M*TOPK, I) bf16, slot order
+    M,
+    D,
+    TWO_I,
+    N_PHYS: gl.constexpr,
+    stride_xm,
+    stride_xk,
+    stride_xslin,
+    stride_xsnb,
+    stride_we,
+    stride_se,
+    stride_slin,
+    stride_snb,
+    stride_om,
+    stride_on,
+    stride_tit,
+    stride_tis,
+    K_PACKED: gl.constexpr,
+    TOPK: gl.constexpr,
+    BLOCK_K: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    M_DUP: gl.constexpr,
+    SWIGLU_ALPHA: gl.constexpr,
+    SWIGLU_LIMIT: gl.constexpr,
+    SWIGLU_BETA: gl.constexpr,
+):
+    BLOCK_K_PACKED: gl.constexpr = BLOCK_K // 2
+    BLOCK_K_SCALE: gl.constexpr = BLOCK_K // 32
+    OUT_BLOCK_N: gl.constexpr = BLOCK_N // 2
+    gl.static_assert(
+        BLOCK_K == 128 and BLOCK_K_PACKED == 64,
+        "direct MXFP4 stage1 currently assumes one CDNA4 scaled-MFMA K tile",
+    )
+    gl.static_assert(BLOCK_N % 2 == 0, "SwiGLU stage1 needs even BLOCK_N")
+    gl.static_assert(
+        128 % BLOCK_N == 0,
+        "direct MXFP4 stage1 BLOCK_N must divide the gdot128 128-wide W tile",
+    )
+
+    pid = gl.program_id(axis=0)
+    num_n = gl.cdiv(TWO_I, BLOCK_N)
+    slot_flat = pid // num_n
+    pid_n = pid % num_n
+    token = slot_flat // TOPK
+    slot = slot_flat - token * TOPK
+    expert = gl.load(topk_ids_ptr + token * stride_tit + slot * stride_tis)
+
+    layouts: gl.constexpr = _direct_mxfp4_mfma_layouts(M_DUP, BLOCK_N, BLOCK_K_SCALE)
+    mfma_layout: gl.constexpr = layouts[0]
+    dot_a_layout: gl.constexpr = layouts[1]
+    dot_b_layout: gl.constexpr = layouts[2]
+    a_scale_layout: gl.constexpr = layouts[3]
+    b_scale_layout: gl.constexpr = layouts[4]
+
+    am = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, dot_a_layout))[:, None]
+    ak = gl.arange(0, BLOCK_K_PACKED, layout=gl.SliceLayout(0, dot_a_layout))[None, :]
+    bk = gl.arange(0, BLOCK_K_PACKED, layout=gl.SliceLayout(1, dot_b_layout))[:, None]
+    bn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, dot_b_layout))[None, :]
+    asm = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, a_scale_layout))[:, None]
+    ask = gl.arange(0, BLOCK_K_SCALE, layout=gl.SliceLayout(0, a_scale_layout))[None, :]
+    bsn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(1, b_scale_layout))[:, None]
+    bsk = gl.arange(0, BLOCK_K_SCALE, layout=gl.SliceLayout(0, b_scale_layout))[None, :]
+
+    n_cols = pid_n * BLOCK_N + bn
+    n_cols_s = pid_n * BLOCK_N + bsn
+    x_row_off = token.to(gl.int64) * stride_xm
+    w_expert_off = expert.to(gl.int64) * stride_we
+    s_expert_off = expert.to(gl.int64) * stride_se
+    # Keep the trip count compile-time.  With runtime ``D`` Gluon emitted one
+    # load/wait/MFMA group per K tile; the constexpr bound lets the backend
+    # overlap adjacent groups and cuts the 56-tile Kimi stage1 wait chain.
+    TOTAL_KT: gl.constexpr = gl.cdiv(K_PACKED, BLOCK_K_PACKED)
+    acc = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
+
+    if token < M:
+        for kt in range(0, TOTAL_KT):
+            a, b, a_scale, b_scale = _direct_mxfp4_load_tile(
+                kt,
+                ak,
+                bk,
+                ask,
+                bsk,
+                am,
+                asm,
+                hidden_ptr,
+                hidden_scale_ptr,
+                w1_ptr,
+                w1s_ptr,
+                x_row_off,
+                w_expert_off,
+                s_expert_off,
+                n_cols,
+                n_cols_s,
+                token,
+                stride_xk,
+                stride_xslin,
+                stride_xsnb,
+                stride_slin,
+                stride_snb,
+                N_PHYS,
+                D,
+                TWO_I,
+                K_PACKED,
+                BLOCK_K_PACKED,
+                BLOCK_K_SCALE,
+            )
+            acc = _direct_mxfp4_mfma(acc, a, b, a_scale, b_scale)
+
+    out_tile = _direct_swiglu_reduce(
+        acc,
+        SWIGLU_ALPHA,
+        SWIGLU_LIMIT,
+        SWIGLU_BETA,
+        OUT_BLOCK_N,
+    )
+    sm = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, out_tile.type.layout))[:, None]
+    sn = gl.arange(0, OUT_BLOCK_N, layout=gl.SliceLayout(0, out_tile.type.layout))[
+        None, :
+    ]
+    out_col = pid_n * OUT_BLOCK_N + sn
+    gl.store(
+        out_ptr
+        + slot_flat.to(gl.int64) * stride_om
+        + out_col.to(gl.int64) * stride_on
+        + sm.to(gl.int64) * 0,
+        out_tile.to(out_ptr.dtype.element_ty),
+        mask=(token < M) & (sm == 0) & (out_col < (TWO_I // 2)),
+    )
+
+
+def invoke_stage1_mxfp4_mfma_decode_gluon(
+    hidden_states_mxfp4,  # (num_tokens, D//2) uint8 e2m1, token order
+    hidden_scale,  # CDNA4-swizzled e8m0 scales from _quantize_mxfp4_activation
+    w1,  # (E, D//2 padded, 2*I_r) uint8 gdot128-shuffled
+    w1_scale,  # (E, Kscale*32, ceil(2*I_r/32)) uint8 CDNA4-swizzled
+    topk_ids,
+    out,  # (num_tokens*topk, I_r) bf16
+    topk: int,
+    BLOCK_N: int = 32,
+    BLOCK_K: int = 128,
+    M_DUP: int = 4,
+    swiglu_alpha: float = 1.702,
+    swiglu_limit: float = 7.0,
+    swiglu_beta: float = 1.0,
+):
+    assert hidden_states_mxfp4.dtype == torch.uint8
+    assert hidden_scale.dtype == torch.uint8
+    assert w1.dtype == torch.uint8 and w1_scale.dtype == torch.uint8
+    assert out.dtype == torch.bfloat16
+    num_tokens = int(hidden_states_mxfp4.shape[0])
+    E, Dh_phys, two_I = w1.shape
+    del E
+    Dh = int(getattr(w1, "original_k_pk", Dh_phys))
+    D = Dh * 2
+    I_r = two_I // 2
+    assert two_I % 2 == 0
+    assert hidden_states_mxfp4.shape == (num_tokens, Dh)
+    assert out.shape == (num_tokens * topk, I_r)
+    assert bool(getattr(w1, "is_shuffled_for_gluon_dot", False))
+    assert int(getattr(w1, "gluon_dot_block_k_pk", 0)) == 128
+    assert int(getattr(w1, "gluon_dot_block_n", 0)) == 128
+    assert w1_scale.stride(-2) == 1
+    assert hidden_scale.stride(-2) == 1
+    topk_ids = topk_ids.to(torch.int32)
+    grid = (num_tokens * topk * triton.cdiv(two_I, BLOCK_N),)
+    _stage1_mxfp4_direct_mfma_gluon[grid](
+        hidden_states_mxfp4,
+        hidden_scale,
+        w1,
+        w1_scale,
+        topk_ids,
+        out,
+        num_tokens,
+        D,
+        two_I,
+        w1.shape[2],
+        hidden_states_mxfp4.stride(0),
+        hidden_states_mxfp4.stride(1),
+        hidden_scale.stride(0),
+        hidden_scale.stride(1),
+        w1.stride(0),
+        w1_scale.stride(0),
+        w1_scale.stride(1),
+        w1_scale.stride(2),
+        out.stride(0),
+        out.stride(1),
+        topk_ids.stride(0),
+        topk_ids.stride(1),
+        K_PACKED=Dh,
+        TOPK=topk,
+        BLOCK_K=BLOCK_K,
+        BLOCK_N=BLOCK_N,
+        M_DUP=M_DUP,
+        SWIGLU_ALPHA=float(swiglu_alpha),
+        SWIGLU_LIMIT=float(swiglu_limit),
+        SWIGLU_BETA=float(swiglu_beta),
+        num_warps=1,
+    )
+    return out
+
+
+@gluon.jit
+def _stage2_mxfp4_direct_mfma_gluon(
+    inter_ptr,  # (M*TOPK, I/2) uint8 e2m1 packed, slot order
+    inter_scale_ptr,  # (Kscale_pad*32, ceil((M*TOPK)/32)) uint8 CDNA4 swizzled
+    w2_ptr,  # (E, I/2 padded, D padded) uint8 gdot128-shuffled
+    w2s_ptr,  # (E, Kscale*32, ceil(D/32)) uint8 CDNA4-swizzled
+    topk_ids_ptr,  # (M, TOPK) int32
+    topk_weights_ptr,  # (M, TOPK) float32
+    out_ptr,  # (M, D) bf16
+    M,
+    D,
+    N_PHYS: gl.constexpr,
+    I_DIM,
+    stride_im,
+    stride_ik,
+    stride_xslin,
+    stride_xsnb,
+    stride_we,
+    stride_se,
+    stride_slin,
+    stride_snb,
+    stride_om,
+    stride_on,
+    stride_tit,
+    stride_tis,
+    stride_twt,
+    stride_tws,
+    I_PACKED: gl.constexpr,
+    TOPK: gl.constexpr,
+    BLOCK_K: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    M_DUP: gl.constexpr,
+    PIPELINE_K: gl.constexpr,
+):
+    BLOCK_K_PACKED: gl.constexpr = BLOCK_K // 2
+    BLOCK_K_SCALE: gl.constexpr = BLOCK_K // 32
+    gl.static_assert(
+        BLOCK_K == 128 and BLOCK_K_PACKED == 64,
+        "direct MXFP4 stage2 currently assumes one CDNA4 scaled-MFMA K tile",
+    )
+    gl.static_assert(
+        128 % BLOCK_N == 0,
+        "direct MXFP4 stage2 BLOCK_N must divide the gdot128 128-wide W tile",
+    )
+
+    pid = gl.program_id(axis=0)
+    num_n = gl.cdiv(D, BLOCK_N)
+    token = pid // num_n
+    pid_n = pid % num_n
+
+    layouts: gl.constexpr = _direct_mxfp4_mfma_layouts(M_DUP, BLOCK_N, BLOCK_K_SCALE)
+    mfma_layout: gl.constexpr = layouts[0]
+    dot_a_layout: gl.constexpr = layouts[1]
+    dot_b_layout: gl.constexpr = layouts[2]
+    a_scale_layout: gl.constexpr = layouts[3]
+    b_scale_layout: gl.constexpr = layouts[4]
+
+    am = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, dot_a_layout))[:, None]
+    ak = gl.arange(0, BLOCK_K_PACKED, layout=gl.SliceLayout(0, dot_a_layout))[None, :]
+    bk = gl.arange(0, BLOCK_K_PACKED, layout=gl.SliceLayout(1, dot_b_layout))[:, None]
+    bn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, dot_b_layout))[None, :]
+    asm = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, a_scale_layout))[:, None]
+    ask = gl.arange(0, BLOCK_K_SCALE, layout=gl.SliceLayout(0, a_scale_layout))[None, :]
+    bsn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(1, b_scale_layout))[:, None]
+    bsk = gl.arange(0, BLOCK_K_SCALE, layout=gl.SliceLayout(0, b_scale_layout))[None, :]
+
+    n_cols = pid_n * BLOCK_N + bn
+    n_cols_s = pid_n * BLOCK_N + bsn
+    TOTAL_KT: gl.constexpr = gl.cdiv(I_PACKED, BLOCK_K_PACKED)
+    acc_total = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
+
+    if token < M:
+        for slot in gl.static_range(0, TOPK):
+            expert = gl.load(topk_ids_ptr + token * stride_tit + slot * stride_tis)
+            gate = gl.load(
+                topk_weights_ptr + token * stride_twt + slot * stride_tws
+            ).to(gl.float32)
+            row = token * TOPK + slot
+            x_row_off = row.to(gl.int64) * stride_im
+            w_expert_off = expert.to(gl.int64) * stride_we
+            s_expert_off = expert.to(gl.int64) * stride_se
+            acc = gl.zeros((M_DUP, BLOCK_N), dtype=gl.float32, layout=mfma_layout)
+
+            if PIPELINE_K and TOTAL_KT > 1:
+                # Hold one K tile in VGPRs while issuing the next tile's four
+                # global loads.  Kimi stage2 has only four tiles, so this small
+                # lookahead hides most VMEM waits without an LDS round trip.
+                a, b, a_scale, b_scale = _direct_mxfp4_load_tile(
+                    0,
+                    ak,
+                    bk,
+                    ask,
+                    bsk,
+                    am,
+                    asm,
+                    inter_ptr,
+                    inter_scale_ptr,
+                    w2_ptr,
+                    w2s_ptr,
+                    x_row_off,
+                    w_expert_off,
+                    s_expert_off,
+                    n_cols,
+                    n_cols_s,
+                    row,
+                    stride_ik,
+                    stride_xslin,
+                    stride_xsnb,
+                    stride_slin,
+                    stride_snb,
+                    N_PHYS,
+                    I_DIM,
+                    D,
+                    I_PACKED,
+                    BLOCK_K_PACKED,
+                    BLOCK_K_SCALE,
+                )
+                for kt in range(0, TOTAL_KT - 1):
+                    next_a, next_b, next_a_scale, next_b_scale = (
+                        _direct_mxfp4_load_tile(
+                            kt + 1,
+                            ak,
+                            bk,
+                            ask,
+                            bsk,
+                            am,
+                            asm,
+                            inter_ptr,
+                            inter_scale_ptr,
+                            w2_ptr,
+                            w2s_ptr,
+                            x_row_off,
+                            w_expert_off,
+                            s_expert_off,
+                            n_cols,
+                            n_cols_s,
+                            row,
+                            stride_ik,
+                            stride_xslin,
+                            stride_xsnb,
+                            stride_slin,
+                            stride_snb,
+                            N_PHYS,
+                            I_DIM,
+                            D,
+                            I_PACKED,
+                            BLOCK_K_PACKED,
+                            BLOCK_K_SCALE,
+                        )
+                    )
+                    acc = _direct_mxfp4_mfma(acc, a, b, a_scale, b_scale)
+                    a, b, a_scale, b_scale = (
+                        next_a,
+                        next_b,
+                        next_a_scale,
+                        next_b_scale,
+                    )
+                acc = _direct_mxfp4_mfma(acc, a, b, a_scale, b_scale)
+            else:
+                for kt in range(0, TOTAL_KT):
+                    a, b, a_scale, b_scale = _direct_mxfp4_load_tile(
+                        kt,
+                        ak,
+                        bk,
+                        ask,
+                        bsk,
+                        am,
+                        asm,
+                        inter_ptr,
+                        inter_scale_ptr,
+                        w2_ptr,
+                        w2s_ptr,
+                        x_row_off,
+                        w_expert_off,
+                        s_expert_off,
+                        n_cols,
+                        n_cols_s,
+                        row,
+                        stride_ik,
+                        stride_xslin,
+                        stride_xsnb,
+                        stride_slin,
+                        stride_snb,
+                        N_PHYS,
+                        I_DIM,
+                        D,
+                        I_PACKED,
+                        BLOCK_K_PACKED,
+                        BLOCK_K_SCALE,
+                    )
+                    acc = _direct_mxfp4_mfma(acc, a, b, a_scale, b_scale)
+            # Match the reference combine epilogue ordering.  Its GEMM kernel first
+            # rounds each expert partial to the output dtype, multiplies by a
+            # routed weight in that same dtype, stores BF16 partial rows, and
+            # only then reduces top-k.  Keeping ``gate * acc`` in FP32 until
+            # the final store changes thousands of Kimi decode elements by a
+            # BF16 ULP even when routing, quantization, and stage 1 are exact.
+            partial = acc.to(out_ptr.dtype.element_ty)
+            routed_weight = gate.to(partial.dtype)
+            acc_total += (partial * routed_weight).to(gl.float32)
+
+    sm = gl.arange(0, M_DUP, layout=gl.SliceLayout(1, mfma_layout))[:, None]
+    sn = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, mfma_layout))[None, :]
+    col = pid_n * BLOCK_N + sn
+    gl.store(
+        out_ptr
+        + token.to(gl.int64) * stride_om
+        + col.to(gl.int64) * stride_on
+        + sm.to(gl.int64) * 0,
+        acc_total.to(out_ptr.dtype.element_ty),
+        mask=(token < M) & (sm == 0) & (col < D),
+    )
+
+
+def invoke_stage2_mxfp4_mfma_decode_gluon(
+    inter_states_mxfp4,  # (num_tokens*topk, I_r//2) uint8 e2m1, slot order
+    inter_scale,  # CDNA4-swizzled e8m0 scales from _quantize_mxfp4_activation
+    w2,  # (E, I_r//2 padded, D padded) uint8 gdot128-shuffled
+    w2_scale,  # (E, Kscale*32, ceil(D/32)) uint8 CDNA4-swizzled
+    topk_ids,
+    topk_weights,
+    out,  # (num_tokens, D) bf16
+    topk: int,
+    BLOCK_N: int = 16,
+    BLOCK_K: int = 128,
+    M_DUP: int = 4,
+    PIPELINE_K: bool = True,
+):
+    assert inter_states_mxfp4.dtype == torch.uint8
+    assert inter_scale.dtype == torch.uint8
+    assert w2.dtype == torch.uint8 and w2_scale.dtype == torch.uint8
+    assert out.dtype == torch.bfloat16
+    _, Ih_phys, N_phys = w2.shape
+    Ih = int(getattr(w2, "original_k_pk", Ih_phys))
+    I_r = Ih * 2
+    num_tokens, D = out.shape
+    assert inter_states_mxfp4.shape == (num_tokens * topk, Ih)
+    assert D <= N_phys
+    assert bool(getattr(w2, "is_shuffled_for_gluon_dot", False))
+    assert int(getattr(w2, "gluon_dot_block_k_pk", 0)) == 128
+    assert int(getattr(w2, "gluon_dot_block_n", 0)) == 128
+    assert w2_scale.stride(-2) == 1
+    assert inter_scale.stride(-2) == 1
+    topk_ids = topk_ids.to(torch.int32)
+    topk_weights = topk_weights.to(torch.float32)
+    grid = (num_tokens * triton.cdiv(D, BLOCK_N),)
+    _stage2_mxfp4_direct_mfma_gluon[grid](
+        inter_states_mxfp4,
+        inter_scale,
+        w2,
+        w2_scale,
+        topk_ids,
+        topk_weights,
+        out,
+        num_tokens,
+        D,
+        N_phys,
+        I_r,
+        inter_states_mxfp4.stride(0),
+        inter_states_mxfp4.stride(1),
+        inter_scale.stride(0),
+        inter_scale.stride(1),
+        w2.stride(0),
+        w2_scale.stride(0),
+        w2_scale.stride(1),
+        w2_scale.stride(2),
+        out.stride(0),
+        out.stride(1),
+        topk_ids.stride(0),
+        topk_ids.stride(1),
+        topk_weights.stride(0),
+        topk_weights.stride(1),
+        I_PACKED=Ih,
+        TOPK=topk,
+        BLOCK_K=BLOCK_K,
+        BLOCK_N=BLOCK_N,
+        M_DUP=M_DUP,
+        PIPELINE_K=PIPELINE_K,
+        num_warps=1,
+    )
+    return out
+
+
+def _legacy_a16w4_decode_block_n1(num_tokens: int) -> int:
+    # Runtime gdot128-shuffled indexing has enough fixed address math that the
+    # 8-neuron tile wins for the decode M=1/2 path.
+    if num_tokens < 16:
+        return 8
+    return 8
+
+
+def _legacy_a16w4_moe_decode(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w1_scale: torch.Tensor,
+    w2: torch.Tensor,
+    w2_scale: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    block_n1: int | None = None,
+    block_d2: int = 8,
+) -> torch.Tensor:
+    """Legacy BF16-activation x MXFP4-weight scalar decode benchmark.
+
+    Args:
+        hidden_states: ``(M, D)`` bf16 activations.
+        w1: gdot128 runtime ``(E, D//2 padded, 2*I)`` shuffled uint8 weights.
+        w1_scale: CDNA4-swizzled uint8 e8m0 scales.
+        w2: gdot128 runtime ``(E, I//2 padded, D padded)`` shuffled uint8 weights.
+        w2_scale: CDNA4-swizzled uint8 e8m0 scales.
+        topk_ids/topk_weights: precomputed routing output.
+    """
+    assert hidden_states.dtype == torch.bfloat16
+    assert w1.dtype == torch.uint8 and w2.dtype == torch.uint8
+    assert w1_scale.dtype == torch.uint8 and w2_scale.dtype == torch.uint8
+    num_tokens, D = hidden_states.shape
+    E, w1_k_phys, two_I = w1.shape
+    w1_k = int(getattr(w1, "original_k_pk", w1_k_phys))
+    assert w1_k == D // 2
+    I_r = two_I // 2
+    assert two_I % 2 == 0
+    assert w2.shape[0] == E
+    w2_k = int(getattr(w2, "original_k_pk", int(w2.shape[1])))
+    assert w2_k * 2 == I_r
+    assert int(getattr(w2, "original_n", int(w2.shape[2]))) == D
+    topk = topk_ids.shape[1]
+    if block_n1 is None:
+        block_n1 = _legacy_a16w4_decode_block_n1(num_tokens)
+    inter = torch.empty(
+        (num_tokens * topk, I_r), dtype=torch.bfloat16, device=hidden_states.device
+    )
+    invoke_stage1_warp_decode_gluon(
+        hidden_states, w1, w1_scale, topk_ids, inter, topk, BLOCK_N=block_n1
+    )
+    out = torch.empty(
+        (num_tokens, D), dtype=torch.bfloat16, device=hidden_states.device
+    )
+    invoke_stage2_warp_decode_gluon(
+        inter, w2, w2_scale, topk_ids, topk_weights, out, topk, BLOCK_D=block_d2
+    )
+    return out

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/decode_stage1.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/decode_stage1.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""Stage-1 exports for gfx950 A4W4 decode."""
+
+from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.decode_kernels import (
+    invoke_stage1_mxfp4_mfma_decode_gluon,
+)
+
+__all__ = [
+    "invoke_stage1_mxfp4_mfma_decode_gluon",
+]

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/decode_stage2.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/decode_stage2.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""Stage-2 exports for gfx950 A4W4 decode."""
+
+from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.decode_kernels import (
+    invoke_stage2_mxfp4_mfma_decode_gluon,
+)
+
+__all__ = [
+    "invoke_stage2_mxfp4_mfma_decode_gluon",
+]

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/moe.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/moe.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""End-to-end entry points for gfx950 A4W4 MoE."""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.decode_stage1 import (
+    invoke_stage1_mxfp4_mfma_decode_gluon,
+)
+from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.decode_stage2 import (
+    invoke_stage2_mxfp4_mfma_decode_gluon,
+)
+
+
+def gluon_mxfp4_moe_decode(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w1_scale: torch.Tensor,
+    w2: torch.Tensor,
+    w2_scale: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    block_n1: int | None = None,
+    block_d2: int = 16,
+    *,
+    swiglu_alpha: float = 1.702,
+    swiglu_limit: float = 7.0,
+    swiglu_beta: float = 1.0,
+) -> torch.Tensor:
+    """Run the small-M direct MXFP4-activation x MXFP4-weight MoE.
+
+    BF16 is only the entry/intermediate/output storage contract.  Both GEMM
+    inputs are dynamically quantized to packed E2M1 plus E8M0 block scales
+    before the direct CDNA4 MFMA kernels are launched.
+    """
+    from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import (
+        _extract_gluon_raw_s,
+        _extract_gluon_raw_w,
+        _quantize_mxfp4_activation,
+    )
+
+    assert hidden_states.dtype == torch.bfloat16
+    w1_runtime = _extract_gluon_raw_w(w1)
+    w2_runtime = _extract_gluon_raw_w(w2)
+    w1_scale_runtime = _extract_gluon_raw_s(w1_scale)
+    w2_scale_runtime = _extract_gluon_raw_s(w2_scale)
+    assert all(
+        isinstance(t, torch.Tensor)
+        for t in (w1_runtime, w2_runtime, w1_scale_runtime, w2_scale_runtime)
+    )
+
+    num_tokens, hidden_dim = hidden_states.shape
+    topk = int(topk_ids.shape[1])
+    inter_dim = int(w1_runtime.shape[2]) // 2
+    out_dim = int(getattr(w2_runtime, "original_n", int(w2_runtime.shape[2])))
+    assert out_dim == hidden_dim
+    if block_n1 is None:
+        block_n1 = 16 if num_tokens <= 2 else 32
+
+    hidden_mxfp4, hidden_scale = _quantize_mxfp4_activation(hidden_states)
+    inter = torch.empty(
+        (num_tokens * topk, inter_dim),
+        dtype=torch.bfloat16,
+        device=hidden_states.device,
+    )
+    invoke_stage1_mxfp4_mfma_decode_gluon(
+        hidden_mxfp4,
+        hidden_scale,
+        w1_runtime,
+        w1_scale_runtime,
+        topk_ids,
+        inter,
+        topk,
+        BLOCK_N=block_n1,
+        swiglu_alpha=swiglu_alpha,
+        swiglu_limit=swiglu_limit,
+        swiglu_beta=swiglu_beta,
+    )
+
+    inter_mxfp4, inter_scale = _quantize_mxfp4_activation(inter)
+    out = torch.empty(
+        (num_tokens, out_dim), dtype=torch.bfloat16, device=hidden_states.device
+    )
+    invoke_stage2_mxfp4_mfma_decode_gluon(
+        inter_mxfp4,
+        inter_scale,
+        w2_runtime,
+        w2_scale_runtime,
+        topk_ids,
+        topk_weights,
+        out,
+        topk,
+        BLOCK_N=block_d2,
+    )
+    return out
+
+
+__all__ = ["gluon_mxfp4_moe_decode"]

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/moe_sorting.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/moe_sorting.py
@@ -1,0 +1,302 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""In-house MoE block-aligned expert sort for the gfx950 A4W4 prefill path.
+
+Produces the block-aligned sorted routing metadata the package prefill stage
+kernels consume. It launches entirely on the *caller's* CUDA stream and
+performs **no** device-to-host synchronization, so the whole prefill path is
+CUDA-graph capturable.
+
+The routing buffers are sized to the worst case and padding is marked with
+sentinels: ``sorted_expert_ids`` padding blocks are ``-1`` and
+``sorted_token_ids`` padding slots are ``(topk << 24) | M``. The stage kernels
+self-skip padding on-device (expert ``-1`` early-exits; token field ``>= M`` is
+masked), so the launcher sizes its grid from the deterministic worst-case shape
+with no host readback.
+
+Implemented in Triton Gluon (``@gluon.jit``) to match the AMD-kernel convention
+for this package and to leave room for manual layout/scheduling optimization
+later. The algorithm is a four-stage block-aligned sort: a per-program expert
+histogram, a column prefix sum, block-padded per-expert offsets, and a
+race-free scatter -- scalar/scan control code with no MFMA. The vectorized
+prefix sums use ``gl.associative_scan``; the histogram and scatter use scalar
+dynamic-index loops.
+
+Output contract::
+
+    max_num_tokens_padded = M * TOPK + E * B - TOPK
+    max_num_m_blocks      = ceil(max_num_tokens_padded / B)
+    sorted_ids            (max_num_tokens_padded,) int32
+        low 24 bits = token_id, high bits = topk slot; padding = (TOPK << 24) | M
+    sorted_weights        (max_num_tokens_padded,) float32; padding = 0.0
+    sorted_expert_ids     (max_num_m_blocks,)       int32; padding block = -1
+    num_valid_ids         (2,) int32; [0] = total padded slots, [1] = M
+    out                   (M, model_dim) uninitialized ``out_dtype`` buffer
+                          (stage2 overwrites/zeros it; see wrapper note)
+"""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel_amd._triton import gl, gluon, triton
+
+# Warp count for the vectorized (prefix-sum) stages. Must match the hardcoded
+# ``warps_per_cta`` (the ``4`` in ``gl.BlockedLayout([1], [64], [4], [0])``)
+# inside stage2/stage3 -- Gluon kernels cannot read plain Python globals, so the
+# layout literal and this launch constant are kept in sync by hand.
+_SCAN_NUM_WARPS = 4
+
+
+@gluon.jit
+def _add(a, b):
+    return a + b
+
+
+@gluon.jit
+def _moe_sorting_stage1_kernel(
+    topk_ids_ptr,  # (numel,) int32, row-major (M, TOPK)
+    tokens_cnts_ptr,  # (E + 1, E) int32, zero-initialized
+    num_experts: gl.constexpr,
+    numel: gl.constexpr,
+    tokens_per_thread: gl.constexpr,
+):
+    """Per-program expert histogram.
+
+    Program ``pid`` counts the experts appearing in flat token slice
+    ``[pid * tokens_per_thread, (pid + 1) * tokens_per_thread)`` and writes them
+    to row ``pid + 1`` of ``tokens_cnts`` (row 0 is reserved as the zero base
+    for the stage-2 column scan). Scalar uniform loads/stores -- no tile math.
+    """
+    pid = gl.program_id(0)
+    start_idx = pid * tokens_per_thread
+    off_c = (pid + 1) * num_experts
+
+    for i in range(tokens_per_thread):
+        if start_idx + i < numel:
+            expert_id = gl.load(topk_ids_ptr + start_idx + i)
+            if (expert_id >= 0) and (expert_id < num_experts):
+                cnt = gl.load(tokens_cnts_ptr + off_c + expert_id)
+                gl.store(tokens_cnts_ptr + off_c + expert_id, cnt + 1)
+
+
+@gluon.jit
+def _moe_sorting_stage2_kernel(
+    tokens_cnts_ptr,  # (E + 1, E) int32
+    num_experts: gl.constexpr,
+    E_PAD: gl.constexpr,
+):
+    """Column-wise inclusive prefix sum over programs (vectorized).
+
+    Program ``pid`` owns expert column ``pid`` and turns per-program counts into
+    the running start offset of each program's tokens *within* that expert:
+    after this pass ``tokens_cnts[p][pid]`` == number of expert-``pid`` tokens
+    contributed by programs ``0..p-1``. Row 0 stays the zero base.
+    """
+    pid = gl.program_id(0)
+    layout: gl.constexpr = gl.BlockedLayout([1], [64], [4], [0])
+    rows = gl.arange(0, E_PAD, layout=layout)  # maps to source rows 1..num_experts
+    mask = rows < num_experts
+    offs = (rows + 1) * num_experts + pid
+    cnt = gl.load(tokens_cnts_ptr + offs, mask=mask, other=0)
+    inclusive = gl.associative_scan(cnt, 0, _add)
+    gl.store(tokens_cnts_ptr + offs, inclusive, mask=mask)
+
+
+@gluon.jit
+def _moe_sorting_stage3_kernel(
+    num_valid_ids_ptr,  # (2,) int32
+    tokens_cnts_ptr,  # (E + 1, E) int32
+    cumsum_ptr,  # (E + 1,) int32
+    m_total,  # python int -> int32 scalar
+    num_experts: gl.constexpr,
+    block_size: gl.constexpr,
+    E_PAD: gl.constexpr,
+):
+    """Block-aligned per-expert slot offsets (single program, vectorized).
+
+    ``cumsum[e + 1]`` becomes the first sorted slot owned by expert ``e + 1``
+    (``cumsum[0] == 0``); each expert's token run is padded up to a multiple of
+    ``block_size`` so the next expert starts on a block boundary.
+    ``num_valid_ids[0]`` is the total padded extent; ``num_valid_ids[1]``
+    carries ``M`` (the token count) in the second slot.
+    """
+    layout: gl.constexpr = gl.BlockedLayout([1], [64], [4], [0])
+    e = gl.arange(0, E_PAD, layout=layout)
+    mask = e < num_experts
+    off_last = num_experts * num_experts  # row E == total count per expert
+    cnt = gl.load(tokens_cnts_ptr + off_last + e, mask=mask, other=0)
+    padded = ((cnt + block_size - 1) // block_size) * block_size
+    inclusive = gl.associative_scan(padded, 0, _add)
+    gl.store(cumsum_ptr + 1 + e, inclusive, mask=mask)
+    gl.store(num_valid_ids_ptr + 0, gl.sum(padded))
+    gl.store(num_valid_ids_ptr + 1, m_total)
+
+
+@gluon.jit
+def _moe_sorting_stage4_kernel(
+    topk_ids_ptr,  # (numel,) int32
+    topk_weights_ptr,  # (numel,) float32
+    sorted_ids_ptr,  # (max_num_tokens_padded,) int32, pre-filled with sentinel
+    sorted_weights_ptr,  # (max_num_tokens_padded,) float32, pre-filled with 0
+    expert_ids_ptr,  # (max_num_m_blocks,) int32, pre-filled with -1
+    tokens_cnts_ptr,  # (E + 1, E) int32
+    cumsum_ptr,  # (E + 1,) int32
+    num_experts: gl.constexpr,
+    block_size: gl.constexpr,
+    numel: gl.constexpr,
+    tokens_per_thread: gl.constexpr,
+    TOPK: gl.constexpr,
+):
+    """Fill ``expert_ids`` block map and scatter routed rows + weights.
+
+    Program ``pid`` writes ``expert_ids`` for expert ``pid``'s block range and
+    scatters the routed rows in its own token slice. Because each program owns a
+    disjoint token slice *and* a disjoint sub-range of every expert's slots
+    (via the stage-2 offsets), the scatter is race-free with no atomics.
+    """
+    pid = gl.program_id(0)
+
+    # Block map: mark every block owned by expert ``pid``.
+    start_slot = gl.load(cumsum_ptr + pid)
+    end_slot = gl.load(cumsum_ptr + pid + 1)
+    for slot in range(start_slot, end_slot, block_size):
+        gl.store(expert_ids_ptr + slot // block_size, pid)
+
+    # Scatter this program's token slice into per-expert padded slots.
+    start_idx = pid * tokens_per_thread
+    off_t = pid * num_experts
+    for i in range(tokens_per_thread):
+        idx = start_idx + i
+        if idx < numel:
+            expert_id = gl.load(topk_ids_ptr + idx)
+            if (expert_id >= 0) and (expert_id < num_experts):
+                cursor = gl.load(tokens_cnts_ptr + off_t + expert_id)
+                rank = cursor + gl.load(cumsum_ptr + expert_id)
+                token_id = idx // TOPK
+                topk_id = idx % TOPK
+                packed = (topk_id << 24) | token_id
+                gl.store(sorted_ids_ptr + rank, packed)
+                weight = gl.load(topk_weights_ptr + idx)
+                gl.store(sorted_weights_ptr + rank, weight)
+                gl.store(tokens_cnts_ptr + off_t + expert_id, cursor + 1)
+
+
+def gluon_moe_sorting(
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    num_experts: int,
+    model_dim: int,
+    out_dtype: torch.dtype,
+    block_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Block-aligned expert sort producing sorted routing metadata.
+
+    Runs four small Gluon kernels on the *current* CUDA stream with no
+    device-to-host synchronization (see the module docstring for the output
+    contract).
+
+    Args:
+        topk_ids: ``(M, TOPK)`` int32 expert assignments. ``-1`` entries are
+            treated as unrouted and skipped.
+        topk_weights: ``(M, TOPK)`` float32 routing weights, same layout.
+        num_experts: total number of experts ``E``.
+        model_dim: hidden dim of the ``out`` buffer.
+        out_dtype: dtype of the ``out`` buffer (bf16 in production).
+        block_size: per-expert padding granularity ``B`` (the stage BLOCK_M).
+
+    Returns:
+        ``(sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids, out)``
+        with shapes/semantics matching ``moe_sorting(..., accumulate=True)``.
+    """
+    assert topk_ids.dim() == 2, "topk_ids must be (M, TOPK)"
+    assert topk_weights.shape == topk_ids.shape, "topk_weights must match topk_ids"
+    device = topk_ids.device
+
+    M, topk = topk_ids.shape
+    numel = M * topk
+    E = int(num_experts)
+    B = int(block_size)
+
+    # Worst-case allocation: every routed slot could land in its own
+    # partially-filled per-expert block.
+    max_num_tokens_padded = numel + E * B - topk
+    max_num_m_blocks = triton.cdiv(max_num_tokens_padded, B)
+
+    topk_ids = topk_ids.to(torch.int32).contiguous()
+    topk_weights = topk_weights.to(torch.float32).contiguous()
+
+    # Padding sentinels let the stage kernels self-skip padding on-device
+    # (token field >= M is masked; expert -1 early-exits).
+    init_sorted_id = (int(topk) << 24) | int(M)
+    sorted_ids = torch.full(
+        (max_num_tokens_padded,), init_sorted_id, dtype=torch.int32, device=device
+    )
+    sorted_weights = torch.zeros(
+        (max_num_tokens_padded,), dtype=torch.float32, device=device
+    )
+    sorted_expert_ids = torch.full(
+        (max_num_m_blocks,), -1, dtype=torch.int32, device=device
+    )
+    num_valid_ids = torch.empty((2,), dtype=torch.int32, device=device)
+    # ``out`` does not need zeroing: stage2's reduce epilogue overwrites every
+    # token row, and its small-M atomic epilogue zeroes ``out`` itself. Zeroing
+    # here would redundantly clear up to tens of MB at large M.
+    out = torch.empty((M, model_dim), dtype=out_dtype, device=device)
+
+    # Scratch: (E+1, E) histogram + (E+1,) padded prefix sums.
+    tokens_cnts = torch.zeros((E + 1, E), dtype=torch.int32, device=device)
+    cumsum = torch.zeros((E + 1,), dtype=torch.int32, device=device)
+    tokens_per_thread = triton.cdiv(numel, E)
+    e_pad = triton.next_power_of_2(E)
+
+    grid = (E,)
+    _moe_sorting_stage1_kernel[grid](
+        topk_ids, tokens_cnts, E, numel, tokens_per_thread, num_warps=1
+    )
+    _moe_sorting_stage2_kernel[grid](tokens_cnts, E, e_pad, num_warps=_SCAN_NUM_WARPS)
+    _moe_sorting_stage3_kernel[(1,)](
+        num_valid_ids,
+        tokens_cnts,
+        cumsum,
+        int(M),
+        E,
+        B,
+        e_pad,
+        num_warps=_SCAN_NUM_WARPS,
+    )
+    _moe_sorting_stage4_kernel[grid](
+        topk_ids,
+        topk_weights,
+        sorted_ids,
+        sorted_weights,
+        sorted_expert_ids,
+        tokens_cnts,
+        cumsum,
+        E,
+        B,
+        numel,
+        tokens_per_thread,
+        int(topk),
+        num_warps=1,
+    )
+
+    return sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids, out

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/prefill_stage1.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/prefill_stage1.py
@@ -1,0 +1,1700 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""Gluon MXFP4 MoE stage 1: gate + up GEMM with fused SwiGLU.
+
+For each MoE expert ``e``::
+
+    inter_e = silu(hidden_states_e @ w1_e[:I_r, :].T)        # gate
+              * (hidden_states_e @ w1_e[I_r:, :].T)          # up
+
+where ``hidden_states_e`` is the subset of input rows routed to
+expert ``e``. The kernel computes that for all experts in one launch
+by walking the ``sorted_token_ids`` / ``sorted_expert_ids`` arrays
+produced by the upstream routing kernel.
+
+Kernel shape:
+  BLOCK_M = BLOCK_N = 128, BLOCK_K = 256, num_warps = 4,
+  warps_per_cta = [1, 4]. ``BLOCK_M`` rows split into 4 quarters of
+  ``GROUP_MFMA_M = 32`` so each K-tile fires 4 (quarter) x 2 (gate/up)
+  = 8 ``mfma_scaled`` instructions on the production K = 7168 shape.
+  K-loop pipelining: 2-slot LDS ping-pong for A data and A scale, and
+  2-slot VGPR ping-pong for B data and B scale; B[k+1] is issued at
+  the top of tile k so its VMEM latency hides behind tile k's MFMAs.
+
+B-data is consumed in a (16, 16)-tile layout so each MFMA fetches its
+tile with a single 128-bit ``buffer_load``. The byte at logical
+``(e, n, k_pk)`` lives at::
+
+    e * (N * K_pk)
+      + (n // 16) * (16 * K_PACKED_TOTAL)
+      + (k_pk // 32) * 512
+      + ((k_pk // 16) % 2) * 256
+      + (n % 16) * 16
+      + (k_pk % 16)
+
+The per-expert term is folded into ``b_base_ptr``; ``K_PACKED_TOTAL``
+is the full B tensor's packed-K dim (= K // 2). The host wrapper
+applies this permutation via ``_b_preshuffle_3d`` when callers pass
+plain B, or skips it when ``b_preshuffled=True``.
+
+Layout contract:
+  hidden_states  (M_padded, K_packed)        uint8, fp4x2 packed
+  w1             (E, 2 * I_r, K_packed)      uint8, (16, 16) shuffled
+  a1_scale       (M_padded_aligned, K // 32) uint8, e8m0
+  w1_scale       (E, 2 * I_r, K // 32)       uint8, e8m0 (shuffled)
+  out            (EM, I_r) or (token_num, topk, I_r)  bf16
+  sorted_token_ids    (EM,)             int32; low 24 bits = token_id
+  sorted_expert_ids   (EM // BLOCK_M,)  int32; -1 marks a padding block
+  sorted_weights      (EM,)             fp32  (REQUIRED to be empty here;
+                                               stage 1 doesn't fold weights)
+
+Stage 1 output is post-SwiGLU at ``I_r`` columns (half of the un-fused
+gate||up width). ``N = 2 * I_r`` is the B-operand column count and is
+passed in for indexing only; the C-side is ``I_r``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional  # noqa: F401  (kept for downstream type hints)
+
+import torch
+import triton
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+from triton.experimental.gluon.language.amd.cdna4 import async_copy as cdna4_async_copy
+
+
+def _b_preshuffle_3d(b: torch.Tensor) -> torch.Tensor:
+    """Permute a 3-D MoE weight into the (16, 16) MFMA-tile layout.
+
+    The kernel's MFMA instruction wants a tile's 16 rows and 16
+    K-columns to be contiguous in HBM so each lane can issue a single
+    128-bit ``buffer_load`` for its share. Naively-laid-out ``w1``
+    forces strided gathers; this permutation does it once on the host.
+
+    ``(E, N, K_pk)`` is viewed as ``(E, N // 16, 16, K_pk // 32, 2, 16)``
+    then permuted ``(0, 1, 3, 4, 2, 5)`` and made contiguous. The
+    operation is a pure data rearrangement -- numerically a no-op.
+
+    Callers that already hold a permuted ``w1`` pass
+    ``b_preshuffled=True`` to skip this pass.
+    """
+    assert b.dtype == torch.uint8, "B must be packed fp4 in uint8"
+    assert b.ndim == 3, f"B must be 3-D (E, N, K/2), got {tuple(b.shape)}"
+    E, N, K_pk = b.shape
+    assert N % 16 == 0, f"N ({N}) must be divisible by 16"
+    assert K_pk % 32 == 0, f"K/2 ({K_pk}) must be divisible by 32"
+    b_6d = b.view(E, N // 16, 16, K_pk // 32, 2, 16)
+    return b_6d.permute(0, 1, 3, 4, 2, 5).contiguous().view(E, N, K_pk)
+
+
+# ---------------------------------------------------------------------------
+# Module-private @gluon.jit helpers used by the K-loop pipeline.
+# ``_prefetch_a_data_lds`` accepts a ``mask`` kwarg so the per-token
+# A gather can plumb ``token_mask[:, None]`` through the prologue,
+# steady-state, peel, and drain prefetch sites.
+# ---------------------------------------------------------------------------
+
+
+@gluon.jit
+def _load_a_scale_vgpr(
+    a_scales_ptr,
+    a_scale_base_offsets,
+    GROUP_IDX: gl.constexpr,
+    tile_k,
+    group_stride,
+    A_SCALE_K_STEP: gl.constexpr,
+):
+    # Direct-to-VGPR A-scale load in the same CDNA4-swizzled scale contract
+    # used by decode. ``a_scale_base_offsets`` is group-0, current pid_m,
+    # [GROUP_MFMA_M, BLOCK_K_SCALE] in the native MFMA scale layout. Each
+    # successive 32-row group advances the row block by stride_npad * 32.
+    return gl.amd.cdna4.buffer_load(
+        ptr=a_scales_ptr,
+        offsets=(
+            a_scale_base_offsets + GROUP_IDX * group_stride + tile_k * A_SCALE_K_STEP
+        ),
+    )
+
+
+@gluon.jit
+def _prefetch_a_data_lds(
+    smem_a_tile,
+    a_base_ptr,
+    offs_a,
+    a_data_k_off,
+    mask=None,
+):
+    # A_scale path is sorted-padded so the wave-uniform K-step
+    # is enough; the A data path is per-token-gathered, so callers plumb
+    # ``mask=token_mask[:, None]`` here to zero-fill padded sorted slots.
+    cdna4_async_copy.buffer_load_to_shared(
+        smem_a_tile,
+        a_base_ptr,
+        offs_a + a_data_k_off,
+        mask=mask,
+    )
+
+
+@gluon.jit
+def _load_b_data_vgpr(
+    b_base_ptr,
+    offs_b,
+    b_data_k_off,
+    mask=None,
+    other=None,
+):
+    return gl.amd.cdna4.buffer_load(
+        ptr=b_base_ptr, offsets=offs_b + b_data_k_off, mask=mask, other=other
+    )
+
+
+@gluon.jit
+def _load_b_scale_vgpr(
+    b_scales_ptr,
+    b_scale_static_offs,
+    k,
+    b_scale_k_step: gl.constexpr,
+    mask=None,
+    other=None,
+):
+    # The shuffle layout factors offset = K_PART(k_iter) + N_PART(b_rows)
+    # with k_iter = k*8 + lane, lane in [0, 8). For that range the only
+    # k-variant term is (k_iter//8)*1024 = k*1024; both (k_iter%4) and
+    # ((k_iter%8)//4) reduce to lane-only expressions. The caller has
+    # therefore precomputed the lane- and N-only piece into
+    # ``b_scale_static_offs`` (a 128x8 tensor in the b_scale layout) so
+    # the per-iteration arithmetic collapses to a single scalar mul +
+    # tensor add. This removes ~10 tensor ops (div/mod/mul chains)
+    # from each K-loop iteration and gives the AMD instruction
+    # scheduler much more freedom to interleave loads with MFMAs.
+    return gl.amd.cdna4.buffer_load(
+        ptr=b_scales_ptr,
+        offsets=b_scale_static_offs + k * b_scale_k_step,
+        mask=mask,
+        other=other,
+    )
+
+
+@gluon.jit
+def _read_a_lds_group(
+    smem_a_tile,
+    GROUP_IDX: gl.constexpr,
+    dot_a_layout: gl.constexpr,
+    GROUP_M: gl.constexpr,
+):
+    cur_a = cdna4_async_copy.load_shared_relaxed(
+        smem_a_tile.slice(GROUP_IDX * GROUP_M, GROUP_M, dim=0),
+        dot_a_layout,
+    )
+    return cur_a
+
+
+@gluon.jit
+def _compute_mxfp4_group(cur_a, a_scale, cur_b, b_scale, acc):
+    return gl.amd.cdna4.mfma_scaled(
+        a=cur_a,
+        a_scale=a_scale,
+        a_format="e2m1",
+        b=cur_b,
+        b_scale=b_scale,
+        b_format="e2m1",
+        acc=acc,
+    )
+
+
+@gluon.jit
+def _store_swiglu_tile_group(
+    acc_swiglu,
+    c_ptr,
+    sorted_token_ids_ptr,
+    pid_m,
+    pid_n,
+    EM,
+    num_tokens,
+    top_k,
+    stride_cm,
+    stride_cn,
+    mfma_layout: gl.constexpr,
+    GROUP_IDX: gl.constexpr,
+    GROUP_M: gl.constexpr,
+    BLOCK_M: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    I_r: gl.constexpr,
+):
+    c_val = acc_swiglu.to(c_ptr.type.element_ty)
+    cm_layout: gl.constexpr = gl.SliceLayout(1, mfma_layout)
+    cn_layout: gl.constexpr = gl.SliceLayout(0, mfma_layout)
+    offs_cm = (
+        pid_m * BLOCK_M + GROUP_IDX * GROUP_M + gl.arange(0, GROUP_M, layout=cm_layout)
+    )
+    offs_cn = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=cn_layout)
+    offs_token_cm = gl.load(
+        sorted_token_ids_ptr + offs_cm,
+        mask=offs_cm < EM,
+        other=num_tokens,
+    )
+    token_id_cm = offs_token_cm & 0xFFFFFF
+    topk_id_cm = offs_token_cm >> 24
+    dst_row_cm = token_id_cm * top_k + topk_id_cm
+    c_ptrs = (
+        c_ptr
+        + dst_row_cm[:, None].to(gl.int64) * stride_cm
+        + offs_cn[None, :].to(gl.int64) * stride_cn
+    )
+    token_mask_cm = token_id_cm < num_tokens
+    c_mask = token_mask_cm[:, None] & (offs_cn[None, :] < I_r)
+    gl.store(c_ptrs, c_val, mask=c_mask)
+
+
+@gluon.jit
+def gluon_mxfp4_moe_stage1_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    a_scales_ptr,
+    b_scales_ptr,
+    sorted_token_ids_ptr,
+    sorted_expert_ids_ptr,
+    num_tokens_post_padded_ptr,
+    sorted_weights_ptr,
+    N,
+    K,
+    EM,
+    num_tokens,
+    top_k,
+    stride_am,
+    stride_ak,
+    stride_be,
+    stride_bn,
+    stride_bk,
+    stride_cm,
+    stride_cn,
+    stride_ase_m,
+    stride_ase_k,
+    stride_bse_e,
+    stride_bse_n,
+    stride_bse_k,
+    stride_se_n_pad,
+    K_PACKED_TOTAL: gl.constexpr,
+    BLOCK_M: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    BLOCK_K: gl.constexpr,
+    GROUP_SIZE_M: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+    I_r: gl.constexpr,
+    B_GDOT128: gl.constexpr,
+    SWIGLU_ALPHA: gl.constexpr,
+    SWIGLU_LIMIT: gl.constexpr,
+    SWIGLU_BETA: gl.constexpr,
+):
+    """Stage 1 kernel: per-token A gather + 4-deep A LDS ring + 4-deep
+    A_scale LDS ring + per-quarter MFMA K-loop with fused SwiGLU.
+
+    Tile config (fixed): ``128 x 128 x 256`` (M x N x K), ``num_warps=4``,
+    ``warps_per_cta=[1, 4]``. MFMA target:
+    ``v_mfma_scale_f32_16x16x128_f8f6f4`` (gfx950, AMDMFMALayout
+    version=4). The launch grid covers ``num_pid_m * (I_r / BLOCK_N)``
+    programs (i.e. ``num_pid_n = I_r / BLOCK_N``, NOT ``N / BLOCK_N``);
+    each CTA owns one ``BLOCK_N`` slab of the ``[EM, I_r]`` SwiGLU
+    output and computes the corresponding gate and up contributions
+    itself.
+
+    Each K tile fires EIGHT ``mfma_scaled`` calls (4 quarters x 2 accs);
+    the four quarter-pairs share ``cur_b_gate`` / ``cur_b_up`` /
+    ``b_scale_gate`` / ``b_scale_up`` loaded inline at the tile head
+    (4 buffer_loads per tile). The 4x unroll matches the 4-deep A LDS
+    ring depth, so each Python iter of the steady-state body cycles the
+    ring back to its starting state. The K-loop opens with a 3-tile
+    prologue (3 ``buffer_load_to_shared`` for A data + 3 for A_scale,
+    each followed by ``commit_group``) and closes with a 3-tile drain
+    epilogue (``wait_group(2)``, ``wait_group(1)``, ``wait_group(0)``).
+    Mirrors dense reference lines 376 to 1305.
+
+    Epilogue: ``silu(gate_acc_groupX) * up_acc_groupX`` for X in 0..3,
+    cast to bf16, stored at sorted-row positions over ``BLOCK_N`` cols
+    starting at ``pid_n * BLOCK_N`` of the ``[EM, I_r]`` output buffer.
+    """
+
+    gl.static_assert(BLOCK_M == 128, "stage1 kernel requires BLOCK_M=128")
+    gl.static_assert(BLOCK_N == 128, "stage1 kernel requires BLOCK_N=128")
+    gl.static_assert(BLOCK_K == 256, "stage1 kernel requires BLOCK_K=256")
+    gl.static_assert(NUM_WARPS == 4, "stage1 kernel requires NUM_WARPS=4")
+
+    SCALE_GROUP: gl.constexpr = 32
+    DIV: gl.constexpr = 2
+    BLOCK_K_PACKED: gl.constexpr = BLOCK_K // DIV
+    BLOCK_K_SCALE: gl.constexpr = BLOCK_K // SCALE_GROUP
+    NUM_BUFFERS: gl.constexpr = 2
+    GROUP_MFMA_M: gl.constexpr = 32
+
+    pid = gl.program_id(axis=0)
+    num_pid_m = gl.cdiv(EM, BLOCK_M)
+    # Grid covers the SwiGLU output columns ``I_r``, not the un-fused
+    # gate||up GEMM columns ``N = 2 * I_r``. Each CTA owns one
+    # ``BLOCK_N`` slab of the ``I_r``-wide output and internally issues
+    # both the gate MFMAs (B columns ``pid_n * BLOCK_N``) and the up
+    # MFMAs (B columns ``(pid_n + num_pid_n) * BLOCK_N``) against the
+    # same A operand.
+    num_pid_n = gl.cdiv(I_r, BLOCK_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    num_tokens_post_padded = gl.load(num_tokens_post_padded_ptr)
+    if pid_m * BLOCK_M >= num_tokens_post_padded:
+        return
+
+    mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
+        version=4,
+        instr_shape=[16, 16, 128],
+        transposed=True,
+        warps_per_cta=[1, NUM_WARPS],
+    )
+    dot_a_layout: gl.constexpr = gl.DotOperandLayout(
+        operand_index=0, parent=mfma_layout, k_width=16
+    )
+    dot_b_layout: gl.constexpr = gl.DotOperandLayout(
+        operand_index=1, parent=mfma_layout, k_width=16
+    )
+    a_scale_group_layout: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
+        dot_a_layout, [GROUP_MFMA_M, BLOCK_K_SCALE]
+    )
+    b_scale_layout: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
+        dot_b_layout, [BLOCK_N, BLOCK_K_SCALE]
+    )
+
+    # A HBM->LDS gather and LDS storage layouts. The ``shared_a`` padding
+    # rule ``[[4096, 128]]`` (insert padding every 32 rows, at M-quarter
+    # boundaries) lets each per-quarter ``ds_read`` share a base VGPR with
+    # immediate offsets. A-scale bypasses LDS and is loaded direct-to-VGPR
+    # in the native MFMA scale layout below.
+    gload_a_layout: gl.constexpr = gl.BlockedLayout(
+        [1, 16],
+        [8, 8],
+        [4, 1],
+        [1, 0],
+    )
+    shared_a: gl.constexpr = gl.PaddedSharedLayout(
+        [[4096, 128]],
+        [
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [0, 16],
+            [0, 32],
+            [0, 64],
+            [1, 0],
+            [2, 0],
+            [4, 0],
+            [8, 0],
+            [16, 0],
+            [32, 0],
+            [64, 0],
+        ],
+        [],
+        [BLOCK_M, BLOCK_K_PACKED],
+    )
+
+    # ---- per-token A row gather -----------------------------------------
+    # ``sorted_token_ids`` packs ``(topk_id << 24) | token_id`` per
+    # entry, so ``offs_token & 0xFFFFFF`` is already the source row
+    # index into ``hidden_states``. Do NOT divide by ``top_k``.
+    #
+    # Validity bound is ``token_id < num_tokens`` (NOT
+    # ``< num_valid_ids[0]``): ``num_valid_ids`` counts routed slots
+    # over all experts and over-shoots the per-token row range, which
+    # would let the gather walk off the end of ``hidden_states`` at
+    # production scale.
+    m_layout: gl.constexpr = gl.SliceLayout(1, gload_a_layout)
+    k_layout: gl.constexpr = gl.SliceLayout(0, gload_a_layout)
+    offs_token_id = pid_m * BLOCK_M + gl.arange(0, BLOCK_M, layout=m_layout)
+    offs_token = gl.load(
+        sorted_token_ids_ptr + offs_token_id,
+        mask=offs_token_id < EM,
+        other=num_tokens,
+    )
+    token_mask = (offs_token & 0xFFFFFF) < num_tokens
+    a_row = offs_token & 0xFFFFFF
+
+    # ---- expert id (per-pid_m scalar; sentinel-checked) ----------------
+    # Stage 1 writes zeros and returns when this block has no expert
+    # assigned (``off_experts == -1``).
+    off_experts = gl.load(sorted_expert_ids_ptr + pid_m)
+    if off_experts == -1:
+        cm_layout_zero: gl.constexpr = gl.SliceLayout(1, mfma_layout)
+        cn_layout_zero: gl.constexpr = gl.SliceLayout(0, mfma_layout)
+        offs_cm_zero = pid_m * BLOCK_M + gl.arange(0, BLOCK_M, layout=cm_layout_zero)
+        offs_cn_zero = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=cn_layout_zero)
+        zero_token = gl.load(
+            sorted_token_ids_ptr + offs_cm_zero,
+            mask=offs_cm_zero < EM,
+            other=num_tokens,
+        )
+        zero_token_id = zero_token & 0xFFFFFF
+        zero_topk_id = zero_token >> 24
+        zero_dst_row = zero_token_id * top_k + zero_topk_id
+        zero_c_ptrs = (
+            c_ptr
+            + zero_dst_row[:, None].to(gl.int64) * stride_cm
+            + offs_cn_zero[None, :].to(gl.int64) * stride_cn
+        )
+        zero_mask = (zero_token_id < num_tokens)[:, None] & (
+            offs_cn_zero[None, :] < I_r
+        )
+        zero_val = gl.zeros([BLOCK_M, BLOCK_N], dtype=gl.bfloat16, layout=mfma_layout)
+        gl.store(zero_c_ptrs, zero_val, mask=zero_mask)
+        return
+
+    # ---- A data-load offsets (consumed by per-tile prefetch) ----------
+    offs_ak = gl.arange(0, BLOCK_K_PACKED, layout=k_layout)
+    offs_a = a_row[:, None].to(gl.int64) * stride_am + offs_ak[None, :] * stride_ak
+
+    # ---- A_scale gather offsets ----------------------------------------
+    # The scale tensor is laid out by the upstream sort kernel as::
+    #
+    #     addr = (x/32) * scaleN_pad * 32
+    #          + (y/8)  * 256
+    #          + (y%4)  * 64
+    #          + (x%16) * 4
+    #          + ((y%8)/4) * 2          (y-half bit  -> +2)
+    #          + ((x%32)/16) * 1        (x-half bit  -> +1)
+    #
+    # ``x`` is the sorted-padded row index and ``y`` is the K-group
+    # lane. Note the half-bit ordering: m at +1, y at +2 -- the
+    # opposite convention from some dense-GEMM scale layouts.
+    #
+    # Row index: scales are written at the SORTED-PADDED slot, NOT at
+    # the source ``token_id``, so we index directly by
+    # ``pid_m * BLOCK_M + arange`` (no ``gl.load(sorted_token_ids)`` /
+    # ``& 0xFFFFFF`` here).
+    # Direct-to-VGPR A-scale: build group-0 offsets in the same native MFMA
+    # scale layout decode uses for direct scale loads. Other 32-row groups are
+    # reached by adding ``stride_se_n_pad * 32`` per group.
+    m_scale_layout: gl.constexpr = gl.SliceLayout(1, a_scale_group_layout)
+    k_scale_layout: gl.constexpr = gl.SliceLayout(0, a_scale_group_layout)
+    a_scale_rows = (
+        pid_m * BLOCK_M + gl.arange(0, GROUP_MFMA_M, layout=m_scale_layout)
+    ).to(gl.uint32)
+    a_m_part = (
+        (a_scale_rows // 32) * (stride_se_n_pad * 32)
+        + (a_scale_rows % 16) * 4
+        + ((a_scale_rows % 32) // 16)
+    )[:, None]
+    a_k_lanes = gl.arange(0, BLOCK_K_SCALE, layout=k_scale_layout).to(gl.uint32)
+    a_k_lane = ((a_k_lanes % 4) * 64 + ((a_k_lanes % 8) // 4) * 2)[None, :]
+    a_scale_base_offsets = a_m_part + a_k_lane
+    a_scale_group_stride = stride_se_n_pad * 32
+
+    # ---- B data offsets (gate + up halves; preshuffle-B closed form) ---
+    # B is in the (16, 16) MFMA-tile layout described in the module
+    # docstring, so the byte for logical ``(n, k_pk)`` is the closed
+    # form computed below (the per-expert term is folded into
+    # ``b_base_ptr``). GU-fusion builds two N-offset tensors -- one
+    # for the gate half starting at column ``pid_n * BLOCK_N``, one
+    # for the up half starting at ``(pid_n + num_pid_n) * BLOCK_N`` --
+    # against the same K offsets. The ``% N`` wrap defends a
+    # degenerate ``I_r < BLOCK_N`` test path where the up rows would
+    # otherwise exceed ``N``.
+    offs_bk = gl.arange(0, BLOCK_K_PACKED, layout=gl.SliceLayout(1, dot_b_layout))
+    offs_bn_gate = (
+        pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, dot_b_layout))
+    ) % N
+    offs_bn_up = (
+        (pid_n + num_pid_n) * BLOCK_N
+        + gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, dot_b_layout))
+    ) % N
+    if B_GDOT128:
+        n_tiles: gl.constexpr = (2 * I_r) // 128
+        # Tokenspeed stores gate/up rows interleaved (g0,u0,g1,u1,...),
+        # while this kernel's logical N axis is concatenated gate||up.
+        n_gate_phys = offs_bn_gate * 2
+        n_up_phys = (offs_bn_up - I_r) * 2 + 1
+        k_in = offs_bk % 128
+        k_within = k_in % 16
+        k_quad = (k_in // 16) % 4
+        k_block = k_in // 64
+        n_gate_in = n_gate_phys % 128
+        n_up_in = n_up_phys % 128
+        in_gate = (
+            (n_gate_in // 16)[None, :] * 2048
+            + k_block[:, None] * 1024
+            + k_quad[:, None] * 256
+            + (n_gate_in % 16)[None, :] * 16
+            + k_within[:, None]
+        )
+        in_up = (
+            (n_up_in // 16)[None, :] * 2048
+            + k_block[:, None] * 1024
+            + k_quad[:, None] * 256
+            + (n_up_in % 16)[None, :] * 16
+            + k_within[:, None]
+        )
+        offs_b_gate = (
+            (offs_bk // 128)[:, None] * n_tiles + (n_gate_phys // 128)[None, :]
+        ) * (128 * 128) + in_gate
+        offs_b_up = (
+            (offs_bk // 128)[:, None] * n_tiles + (n_up_phys // 128)[None, :]
+        ) * (128 * 128) + in_up
+    else:
+        b_k_part = (
+            (offs_bk // 32) * 512 + ((offs_bk // 16) % 2) * 256 + (offs_bk % 16)
+        )[:, None]
+        b_n_part_gate = (
+            (offs_bn_gate // 16) * (16 * K_PACKED_TOTAL) + (offs_bn_gate % 16) * 16
+        )[None, :]
+        b_n_part_up = (
+            (offs_bn_up // 16) * (16 * K_PACKED_TOTAL) + (offs_bn_up % 16) * 16
+        )[None, :]
+        offs_b_gate = b_k_part + b_n_part_gate
+        offs_b_up = b_k_part + b_n_part_up
+
+    # ---- B_scale offsets (gate + up halves; e8m0_shuffle_opsel_b) -----
+    # Same row-part decomposition as the prior preshuffle-B port; the
+    # cross-tile step is the constexpr ``B_SCALE_K_STEP = 1024`` because
+    # ``BLOCK_K_SCALE = 8`` covers a full ``y/8`` block per K iter. The
+    # per-expert offset folds into ``b_scale_offsets_e_*`` here so the
+    # K-loop only carries the K-step.
+    b_n_layout_scale: gl.constexpr = gl.SliceLayout(1, b_scale_layout)
+    b_k_layout_scale: gl.constexpr = gl.SliceLayout(0, b_scale_layout)
+    b_rows_gate = (pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=b_n_layout_scale)).to(
+        gl.uint32
+    )
+    b_rows_up = (
+        (pid_n + num_pid_n) * BLOCK_N + gl.arange(0, BLOCK_N, layout=b_n_layout_scale)
+    ).to(gl.uint32)
+    if B_GDOT128:
+        b_rows_gate_phys = b_rows_gate * 2
+        b_rows_up_phys = (b_rows_up - I_r) * 2 + 1
+        b_n_part_gate_scale = (
+            (b_rows_gate_phys // 32) * (K_PACKED_TOTAL * 2)
+            + (b_rows_gate_phys % 16) * 4
+            + ((b_rows_gate_phys % 32) // 16)
+        )[:, None]
+        b_n_part_up_scale = (
+            (b_rows_up_phys // 32) * (K_PACKED_TOTAL * 2)
+            + (b_rows_up_phys % 16) * 4
+            + ((b_rows_up_phys % 32) // 16)
+        )[:, None]
+    else:
+        b_n_part_gate_scale = (
+            (b_rows_gate // 128) * (stride_se_n_pad * 128)
+            + ((b_rows_gate % 64) // 16) * 64
+            + (b_rows_gate % 16) * 4
+            + ((b_rows_gate % 128) // 64) * 2
+        )[:, None]
+        b_n_part_up_scale = (
+            (b_rows_up // 128) * (stride_se_n_pad * 128)
+            + ((b_rows_up % 64) // 16) * 64
+            + (b_rows_up % 16) * 4
+            + ((b_rows_up % 128) // 64) * 2
+        )[:, None]
+    b_k_lanes = gl.arange(0, BLOCK_K_SCALE, layout=b_k_layout_scale).to(gl.uint32)
+    # Loop-invariant K-part of the B-scale gather offset. The full
+    # per-K offset is k*1024 + b_k_lane_offsets; the second term only
+    # depends on the lane index in [0,8), so we hoist it (and its sum
+    # with the per-row N-part) out of the K-loop. See _load_b_scale_vgpr
+    # for the algebraic justification.
+    if B_GDOT128:
+        b_k_lane_offsets = ((b_k_lanes % 4) * 64 + ((b_k_lanes % 8) // 4) * 2)[None, :]
+        B_SCALE_K_STEP: gl.constexpr = 256
+    else:
+        b_k_lane_offsets = ((b_k_lanes % 4) * 256 + (b_k_lanes // 4))[None, :]
+        B_SCALE_K_STEP: gl.constexpr = 1024
+    b_scale_static_offs_gate = b_n_part_gate_scale + b_k_lane_offsets
+    b_scale_static_offs_up = b_n_part_up_scale + b_k_lane_offsets
+    b_scales_ptr_e = b_scales_ptr + off_experts.to(gl.int64) * stride_bse_e
+
+    # ---- LDS allocation (2 A-data slots, ping-pong) --------------------
+    # A fp4 data is still gathered through LDS. A scales use direct VGPR
+    # loads in the decode/CDNA4-swizzled layout, avoiding the tiny A-scale
+    # async-copy path that Gluon fails to lower for prefill.
+    smem_a = gl.allocate_shared_memory(
+        a_ptr.type.element_ty,
+        [NUM_BUFFERS, BLOCK_M, BLOCK_K_PACKED],
+        shared_a,
+    )
+
+    a_base_ptr = a_ptr
+    b_base_ptr = b_ptr + off_experts.to(gl.int64) * stride_be
+
+    offs_a_i32 = offs_a.to(gl.int32)
+
+    A_DATA_K_STEP: gl.constexpr = BLOCK_K_PACKED
+    if B_GDOT128:
+        B_DATA_K_STEP: gl.constexpr = ((2 * I_r) // 128) * (128 * 128)
+    else:
+        B_DATA_K_STEP: gl.constexpr = (BLOCK_K_PACKED // 32) * 512
+    A_SCALE_K_STEP: gl.constexpr = 256
+
+    GROUP0_IDX: gl.constexpr = 0
+    GROUP1_IDX: gl.constexpr = 1
+    GROUP2_IDX: gl.constexpr = 2
+    GROUP3_IDX: gl.constexpr = 3
+
+    smem_a_slot0 = smem_a.index(0)
+    smem_a_slot1 = smem_a.index(1)
+
+    # ---- 1-tile prologue ------------------------------------------------
+    # Prefetch A[0] data into LDS slot 0, load B[0] into VGPRs. A-scale is
+    # direct-to-VGPR in the decode/CDNA4-swizzled layout.
+    _prefetch_a_data_lds(
+        smem_a_slot0,
+        a_base_ptr,
+        offs_a_i32,
+        0,
+        mask=token_mask[:, None],
+    )
+    cdna4_async_copy.commit_group()
+
+    cur_b_gate = _load_b_data_vgpr(
+        b_base_ptr,
+        offs_b_gate,
+        0,
+    )
+    cur_b_up = _load_b_data_vgpr(
+        b_base_ptr,
+        offs_b_up,
+        0,
+    )
+    b_scale_gate = _load_b_scale_vgpr(
+        b_scales_ptr_e,
+        b_scale_static_offs_gate,
+        0,
+        B_SCALE_K_STEP,
+    )
+    b_scale_up = _load_b_scale_vgpr(
+        b_scales_ptr_e,
+        b_scale_static_offs_up,
+        0,
+        B_SCALE_K_STEP,
+    )
+
+    cdna4_async_copy.wait_group(0)
+    cur_a_group0 = _read_a_lds_group(
+        smem_a_slot0,
+        GROUP0_IDX,
+        dot_a_layout,
+        GROUP_MFMA_M,
+    )
+    a_scale_group0 = _load_a_scale_vgpr(
+        a_scales_ptr,
+        a_scale_base_offsets,
+        GROUP0_IDX,
+        0,
+        a_scale_group_stride,
+        A_SCALE_K_STEP,
+    )
+    cur_a_group1 = _read_a_lds_group(
+        smem_a_slot0,
+        GROUP1_IDX,
+        dot_a_layout,
+        GROUP_MFMA_M,
+    )
+    a_scale_group1 = _load_a_scale_vgpr(
+        a_scales_ptr,
+        a_scale_base_offsets,
+        GROUP1_IDX,
+        0,
+        a_scale_group_stride,
+        A_SCALE_K_STEP,
+    )
+
+    # ---- 8 per-quarter accumulators (gate + up x 4 quarters) ----------
+    gate_acc_group0 = gl.zeros(
+        (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
+    )
+    gate_acc_group1 = gl.zeros(
+        (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
+    )
+    gate_acc_group2 = gl.zeros(
+        (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
+    )
+    gate_acc_group3 = gl.zeros(
+        (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
+    )
+    up_acc_group0 = gl.zeros(
+        (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
+    )
+    up_acc_group1 = gl.zeros(
+        (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
+    )
+    up_acc_group2 = gl.zeros(
+        (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
+    )
+    up_acc_group3 = gl.zeros(
+        (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
+    )
+
+    num_k_iter = gl.cdiv(K, BLOCK_K)
+    # Steady tiles: 0 .. num_k_iter-2 (last tile handled in drain).
+    steady_iters = num_k_iter - 1
+    unrolled_iters = steady_iters // 2
+    peel_iters = steady_iters % 2
+
+    # ---- 2x-unrolled steady-state K-loop with B VGPR ping-pong -------
+    # Per tile body: issue B[k+1] loads FIRST (overlap with MFMA),
+    # then compute with A[k]+B[k], prefetch A[k+1] to LDS, swap slots.
+    for unrolled_k in range(unrolled_iters):
+        tile0_k = unrolled_k * 2
+        tile1_k = tile0_k + 1
+
+        # ==============================================================
+        # ---- Tile 0 (even k, cur_slot=slot0, next_slot=slot1) --------
+        # ==============================================================
+        nxt_b_data_off = (tile0_k + 1) * B_DATA_K_STEP
+        nxt_b_scale_k = tile0_k + 1
+
+        # Issue B[k+1] loads early for overlap with MFMA below.
+        next_b_gate = _load_b_data_vgpr(
+            b_base_ptr,
+            offs_b_gate,
+            nxt_b_data_off,
+        )
+        next_b_up = _load_b_data_vgpr(
+            b_base_ptr,
+            offs_b_up,
+            nxt_b_data_off,
+        )
+        next_bsc_gate = _load_b_scale_vgpr(
+            b_scales_ptr_e,
+            b_scale_static_offs_gate,
+            nxt_b_scale_k,
+            B_SCALE_K_STEP,
+        )
+        next_bsc_up = _load_b_scale_vgpr(
+            b_scales_ptr_e,
+            b_scale_static_offs_up,
+            nxt_b_scale_k,
+            B_SCALE_K_STEP,
+        )
+
+        # MFMA groups 0,1 with current A[k] + current B[k].
+        gate_acc_group0 = _compute_mxfp4_group(
+            cur_a_group0,
+            a_scale_group0,
+            cur_b_gate,
+            b_scale_gate,
+            gate_acc_group0,
+        )
+        up_acc_group0 = _compute_mxfp4_group(
+            cur_a_group0,
+            a_scale_group0,
+            cur_b_up,
+            b_scale_up,
+            up_acc_group0,
+        )
+        gate_acc_group1 = _compute_mxfp4_group(
+            cur_a_group1,
+            a_scale_group1,
+            cur_b_gate,
+            b_scale_gate,
+            gate_acc_group1,
+        )
+        up_acc_group1 = _compute_mxfp4_group(
+            cur_a_group1,
+            a_scale_group1,
+            cur_b_up,
+            b_scale_up,
+            up_acc_group1,
+        )
+
+        # Prefetch A[k+1] data into LDS slot1. A-scale stays direct-to-VGPR.
+        _prefetch_a_data_lds(
+            smem_a_slot1,
+            a_base_ptr,
+            offs_a_i32,
+            (tile0_k + 1) * A_DATA_K_STEP,
+            mask=token_mask[:, None],
+        )
+
+        # Read remaining A[k] groups from current LDS slot0.
+        cur_a_group2 = _read_a_lds_group(
+            smem_a_slot0,
+            GROUP2_IDX,
+            dot_a_layout,
+            GROUP_MFMA_M,
+        )
+        a_scale_group2 = _load_a_scale_vgpr(
+            a_scales_ptr,
+            a_scale_base_offsets,
+            GROUP2_IDX,
+            tile0_k,
+            a_scale_group_stride,
+            A_SCALE_K_STEP,
+        )
+        cur_a_group3 = _read_a_lds_group(
+            smem_a_slot0,
+            GROUP3_IDX,
+            dot_a_layout,
+            GROUP_MFMA_M,
+        )
+        a_scale_group3 = _load_a_scale_vgpr(
+            a_scales_ptr,
+            a_scale_base_offsets,
+            GROUP3_IDX,
+            tile0_k,
+            a_scale_group_stride,
+            A_SCALE_K_STEP,
+        )
+
+        cdna4_async_copy.commit_group()
+
+        # MFMA groups 2,3 with current A[k] + current B[k].
+        gate_acc_group2 = _compute_mxfp4_group(
+            cur_a_group2,
+            a_scale_group2,
+            cur_b_gate,
+            b_scale_gate,
+            gate_acc_group2,
+        )
+        up_acc_group2 = _compute_mxfp4_group(
+            cur_a_group2,
+            a_scale_group2,
+            cur_b_up,
+            b_scale_up,
+            up_acc_group2,
+        )
+        gate_acc_group3 = _compute_mxfp4_group(
+            cur_a_group3,
+            a_scale_group3,
+            cur_b_gate,
+            b_scale_gate,
+            gate_acc_group3,
+        )
+        up_acc_group3 = _compute_mxfp4_group(
+            cur_a_group3,
+            a_scale_group3,
+            cur_b_up,
+            b_scale_up,
+            up_acc_group3,
+        )
+
+        # Drain A[k+1] prefetch; B[k+1] should also be done by now.
+        cdna4_async_copy.wait_group(0)
+
+        # Read A[k+1] groups 0,1 from LDS slot1.
+        cur_a_group0 = _read_a_lds_group(
+            smem_a_slot1,
+            GROUP0_IDX,
+            dot_a_layout,
+            GROUP_MFMA_M,
+        )
+        a_scale_group0 = _load_a_scale_vgpr(
+            a_scales_ptr,
+            a_scale_base_offsets,
+            GROUP0_IDX,
+            tile0_k + 1,
+            a_scale_group_stride,
+            A_SCALE_K_STEP,
+        )
+        cur_a_group1 = _read_a_lds_group(
+            smem_a_slot1,
+            GROUP1_IDX,
+            dot_a_layout,
+            GROUP_MFMA_M,
+        )
+        a_scale_group1 = _load_a_scale_vgpr(
+            a_scales_ptr,
+            a_scale_base_offsets,
+            GROUP1_IDX,
+            tile0_k + 1,
+            a_scale_group_stride,
+            A_SCALE_K_STEP,
+        )
+
+        # Swap B: next -> current.
+        cur_b_gate = next_b_gate
+        cur_b_up = next_b_up
+        b_scale_gate = next_bsc_gate
+        b_scale_up = next_bsc_up
+
+        # Swap A LDS slots.
+        smem_a_slot0, smem_a_slot1 = smem_a_slot1, smem_a_slot0
+
+        # ==============================================================
+        # ---- Tile 1 (odd k+1, cur_slot=slot0, next_slot=slot1) -------
+        # ==============================================================
+        nxt_b_data_off = (tile1_k + 1) * B_DATA_K_STEP
+        nxt_b_scale_k = tile1_k + 1
+
+        next_b_gate = _load_b_data_vgpr(
+            b_base_ptr,
+            offs_b_gate,
+            nxt_b_data_off,
+        )
+        next_b_up = _load_b_data_vgpr(
+            b_base_ptr,
+            offs_b_up,
+            nxt_b_data_off,
+        )
+        next_bsc_gate = _load_b_scale_vgpr(
+            b_scales_ptr_e,
+            b_scale_static_offs_gate,
+            nxt_b_scale_k,
+            B_SCALE_K_STEP,
+        )
+        next_bsc_up = _load_b_scale_vgpr(
+            b_scales_ptr_e,
+            b_scale_static_offs_up,
+            nxt_b_scale_k,
+            B_SCALE_K_STEP,
+        )
+
+        gate_acc_group0 = _compute_mxfp4_group(
+            cur_a_group0,
+            a_scale_group0,
+            cur_b_gate,
+            b_scale_gate,
+            gate_acc_group0,
+        )
+        up_acc_group0 = _compute_mxfp4_group(
+            cur_a_group0,
+            a_scale_group0,
+            cur_b_up,
+            b_scale_up,
+            up_acc_group0,
+        )
+        gate_acc_group1 = _compute_mxfp4_group(
+            cur_a_group1,
+            a_scale_group1,
+            cur_b_gate,
+            b_scale_gate,
+            gate_acc_group1,
+        )
+        up_acc_group1 = _compute_mxfp4_group(
+            cur_a_group1,
+            a_scale_group1,
+            cur_b_up,
+            b_scale_up,
+            up_acc_group1,
+        )
+
+        _prefetch_a_data_lds(
+            smem_a_slot1,
+            a_base_ptr,
+            offs_a_i32,
+            (tile1_k + 1) * A_DATA_K_STEP,
+            mask=token_mask[:, None],
+        )
+
+        cur_a_group2 = _read_a_lds_group(
+            smem_a_slot0,
+            GROUP2_IDX,
+            dot_a_layout,
+            GROUP_MFMA_M,
+        )
+        a_scale_group2 = _load_a_scale_vgpr(
+            a_scales_ptr,
+            a_scale_base_offsets,
+            GROUP2_IDX,
+            tile1_k,
+            a_scale_group_stride,
+            A_SCALE_K_STEP,
+        )
+        cur_a_group3 = _read_a_lds_group(
+            smem_a_slot0,
+            GROUP3_IDX,
+            dot_a_layout,
+            GROUP_MFMA_M,
+        )
+        a_scale_group3 = _load_a_scale_vgpr(
+            a_scales_ptr,
+            a_scale_base_offsets,
+            GROUP3_IDX,
+            tile1_k,
+            a_scale_group_stride,
+            A_SCALE_K_STEP,
+        )
+
+        cdna4_async_copy.commit_group()
+
+        gate_acc_group2 = _compute_mxfp4_group(
+            cur_a_group2,
+            a_scale_group2,
+            cur_b_gate,
+            b_scale_gate,
+            gate_acc_group2,
+        )
+        up_acc_group2 = _compute_mxfp4_group(
+            cur_a_group2,
+            a_scale_group2,
+            cur_b_up,
+            b_scale_up,
+            up_acc_group2,
+        )
+        gate_acc_group3 = _compute_mxfp4_group(
+            cur_a_group3,
+            a_scale_group3,
+            cur_b_gate,
+            b_scale_gate,
+            gate_acc_group3,
+        )
+        up_acc_group3 = _compute_mxfp4_group(
+            cur_a_group3,
+            a_scale_group3,
+            cur_b_up,
+            b_scale_up,
+            up_acc_group3,
+        )
+
+        cdna4_async_copy.wait_group(0)
+
+        cur_a_group0 = _read_a_lds_group(
+            smem_a_slot1,
+            GROUP0_IDX,
+            dot_a_layout,
+            GROUP_MFMA_M,
+        )
+        a_scale_group0 = _load_a_scale_vgpr(
+            a_scales_ptr,
+            a_scale_base_offsets,
+            GROUP0_IDX,
+            tile1_k + 1,
+            a_scale_group_stride,
+            A_SCALE_K_STEP,
+        )
+        cur_a_group1 = _read_a_lds_group(
+            smem_a_slot1,
+            GROUP1_IDX,
+            dot_a_layout,
+            GROUP_MFMA_M,
+        )
+        a_scale_group1 = _load_a_scale_vgpr(
+            a_scales_ptr,
+            a_scale_base_offsets,
+            GROUP1_IDX,
+            tile1_k + 1,
+            a_scale_group_stride,
+            A_SCALE_K_STEP,
+        )
+
+        cur_b_gate = next_b_gate
+        cur_b_up = next_b_up
+        b_scale_gate = next_bsc_gate
+        b_scale_up = next_bsc_up
+
+        smem_a_slot0, smem_a_slot1 = smem_a_slot1, smem_a_slot0
+
+    # ---- Peel loop (0 or 1 single-tile advance) ----------------------
+    peel_base = unrolled_iters * 2
+    for peel_k_offset in range(peel_iters):
+        pk = peel_base + peel_k_offset
+        nxt_b_data_off = (pk + 1) * B_DATA_K_STEP
+        nxt_b_scale_k = pk + 1
+
+        next_b_gate = _load_b_data_vgpr(
+            b_base_ptr,
+            offs_b_gate,
+            nxt_b_data_off,
+        )
+        next_b_up = _load_b_data_vgpr(
+            b_base_ptr,
+            offs_b_up,
+            nxt_b_data_off,
+        )
+        next_bsc_gate = _load_b_scale_vgpr(
+            b_scales_ptr_e,
+            b_scale_static_offs_gate,
+            nxt_b_scale_k,
+            B_SCALE_K_STEP,
+        )
+        next_bsc_up = _load_b_scale_vgpr(
+            b_scales_ptr_e,
+            b_scale_static_offs_up,
+            nxt_b_scale_k,
+            B_SCALE_K_STEP,
+        )
+
+        gate_acc_group0 = _compute_mxfp4_group(
+            cur_a_group0,
+            a_scale_group0,
+            cur_b_gate,
+            b_scale_gate,
+            gate_acc_group0,
+        )
+        up_acc_group0 = _compute_mxfp4_group(
+            cur_a_group0,
+            a_scale_group0,
+            cur_b_up,
+            b_scale_up,
+            up_acc_group0,
+        )
+        gate_acc_group1 = _compute_mxfp4_group(
+            cur_a_group1,
+            a_scale_group1,
+            cur_b_gate,
+            b_scale_gate,
+            gate_acc_group1,
+        )
+        up_acc_group1 = _compute_mxfp4_group(
+            cur_a_group1,
+            a_scale_group1,
+            cur_b_up,
+            b_scale_up,
+            up_acc_group1,
+        )
+
+        _prefetch_a_data_lds(
+            smem_a_slot1,
+            a_base_ptr,
+            offs_a_i32,
+            (pk + 1) * A_DATA_K_STEP,
+            mask=token_mask[:, None],
+        )
+
+        cur_a_group2 = _read_a_lds_group(
+            smem_a_slot0,
+            GROUP2_IDX,
+            dot_a_layout,
+            GROUP_MFMA_M,
+        )
+        a_scale_group2 = _load_a_scale_vgpr(
+            a_scales_ptr,
+            a_scale_base_offsets,
+            GROUP2_IDX,
+            pk,
+            a_scale_group_stride,
+            A_SCALE_K_STEP,
+        )
+        cur_a_group3 = _read_a_lds_group(
+            smem_a_slot0,
+            GROUP3_IDX,
+            dot_a_layout,
+            GROUP_MFMA_M,
+        )
+        a_scale_group3 = _load_a_scale_vgpr(
+            a_scales_ptr,
+            a_scale_base_offsets,
+            GROUP3_IDX,
+            pk,
+            a_scale_group_stride,
+            A_SCALE_K_STEP,
+        )
+
+        cdna4_async_copy.commit_group()
+
+        gate_acc_group2 = _compute_mxfp4_group(
+            cur_a_group2,
+            a_scale_group2,
+            cur_b_gate,
+            b_scale_gate,
+            gate_acc_group2,
+        )
+        up_acc_group2 = _compute_mxfp4_group(
+            cur_a_group2,
+            a_scale_group2,
+            cur_b_up,
+            b_scale_up,
+            up_acc_group2,
+        )
+        gate_acc_group3 = _compute_mxfp4_group(
+            cur_a_group3,
+            a_scale_group3,
+            cur_b_gate,
+            b_scale_gate,
+            gate_acc_group3,
+        )
+        up_acc_group3 = _compute_mxfp4_group(
+            cur_a_group3,
+            a_scale_group3,
+            cur_b_up,
+            b_scale_up,
+            up_acc_group3,
+        )
+
+        cdna4_async_copy.wait_group(0)
+
+        cur_a_group0 = _read_a_lds_group(
+            smem_a_slot1,
+            GROUP0_IDX,
+            dot_a_layout,
+            GROUP_MFMA_M,
+        )
+        a_scale_group0 = _load_a_scale_vgpr(
+            a_scales_ptr,
+            a_scale_base_offsets,
+            GROUP0_IDX,
+            pk + 1,
+            a_scale_group_stride,
+            A_SCALE_K_STEP,
+        )
+        cur_a_group1 = _read_a_lds_group(
+            smem_a_slot1,
+            GROUP1_IDX,
+            dot_a_layout,
+            GROUP_MFMA_M,
+        )
+        a_scale_group1 = _load_a_scale_vgpr(
+            a_scales_ptr,
+            a_scale_base_offsets,
+            GROUP1_IDX,
+            pk + 1,
+            a_scale_group_stride,
+            A_SCALE_K_STEP,
+        )
+
+        cur_b_gate = next_b_gate
+        cur_b_up = next_b_up
+        b_scale_gate = next_bsc_gate
+        b_scale_up = next_bsc_up
+
+        smem_a_slot0, smem_a_slot1 = smem_a_slot1, smem_a_slot0
+
+    # ---- 1-tile drain (last K tile, no prefetch) ---------------------
+    # cur_a_group0/1 and cur_b_* hold the last tile's data.
+    cur_a_group2 = _read_a_lds_group(
+        smem_a_slot0,
+        GROUP2_IDX,
+        dot_a_layout,
+        GROUP_MFMA_M,
+    )
+    a_scale_group2 = _load_a_scale_vgpr(
+        a_scales_ptr,
+        a_scale_base_offsets,
+        GROUP2_IDX,
+        num_k_iter - 1,
+        a_scale_group_stride,
+        A_SCALE_K_STEP,
+    )
+    cur_a_group3 = _read_a_lds_group(
+        smem_a_slot0,
+        GROUP3_IDX,
+        dot_a_layout,
+        GROUP_MFMA_M,
+    )
+    a_scale_group3 = _load_a_scale_vgpr(
+        a_scales_ptr,
+        a_scale_base_offsets,
+        GROUP3_IDX,
+        num_k_iter - 1,
+        a_scale_group_stride,
+        A_SCALE_K_STEP,
+    )
+
+    gate_acc_group0 = _compute_mxfp4_group(
+        cur_a_group0,
+        a_scale_group0,
+        cur_b_gate,
+        b_scale_gate,
+        gate_acc_group0,
+    )
+    up_acc_group0 = _compute_mxfp4_group(
+        cur_a_group0,
+        a_scale_group0,
+        cur_b_up,
+        b_scale_up,
+        up_acc_group0,
+    )
+    gate_acc_group1 = _compute_mxfp4_group(
+        cur_a_group1,
+        a_scale_group1,
+        cur_b_gate,
+        b_scale_gate,
+        gate_acc_group1,
+    )
+    up_acc_group1 = _compute_mxfp4_group(
+        cur_a_group1,
+        a_scale_group1,
+        cur_b_up,
+        b_scale_up,
+        up_acc_group1,
+    )
+    gate_acc_group2 = _compute_mxfp4_group(
+        cur_a_group2,
+        a_scale_group2,
+        cur_b_gate,
+        b_scale_gate,
+        gate_acc_group2,
+    )
+    up_acc_group2 = _compute_mxfp4_group(
+        cur_a_group2,
+        a_scale_group2,
+        cur_b_up,
+        b_scale_up,
+        up_acc_group2,
+    )
+    gate_acc_group3 = _compute_mxfp4_group(
+        cur_a_group3,
+        a_scale_group3,
+        cur_b_gate,
+        b_scale_gate,
+        gate_acc_group3,
+    )
+    up_acc_group3 = _compute_mxfp4_group(
+        cur_a_group3,
+        a_scale_group3,
+        cur_b_up,
+        b_scale_up,
+        up_acc_group3,
+    )
+
+    # ---- SwiGLU epilogue ------------------------------------------------
+    # Per-quarter SwiGLU.  The historical path is plain
+    # ``silu(gate) * up`` and is represented by
+    # ``alpha=1, limit=0, beta=0``.  Kimi uses the parameterized
+    # form ``gate * sigmoid(alpha * gate) * (clamp(up) + beta)`` with
+    # optional gate/up clamping.
+    # ``gl.sigmoid`` is not in the Gluon language module today, so we
+    # build sigmoid from ``gl.exp``. Each quarter's fp32 result casts to
+    # bf16 inside ``_store_swiglu_tile_group`` and lands at
+    # ``dst_row = token_id * top_k + topk_id`` decoded from the
+    # bit-packed ``sorted_token_ids[m]``; padding rows are mask-rejected.
+    if SWIGLU_LIMIT > 0.0:
+        gate_acc_group0 = gl.minimum(gate_acc_group0, SWIGLU_LIMIT)
+        gate_acc_group1 = gl.minimum(gate_acc_group1, SWIGLU_LIMIT)
+        gate_acc_group2 = gl.minimum(gate_acc_group2, SWIGLU_LIMIT)
+        gate_acc_group3 = gl.minimum(gate_acc_group3, SWIGLU_LIMIT)
+        up_acc_group0 = gl.minimum(
+            gl.maximum(up_acc_group0, -SWIGLU_LIMIT), SWIGLU_LIMIT
+        )
+        up_acc_group1 = gl.minimum(
+            gl.maximum(up_acc_group1, -SWIGLU_LIMIT), SWIGLU_LIMIT
+        )
+        up_acc_group2 = gl.minimum(
+            gl.maximum(up_acc_group2, -SWIGLU_LIMIT), SWIGLU_LIMIT
+        )
+        up_acc_group3 = gl.minimum(
+            gl.maximum(up_acc_group3, -SWIGLU_LIMIT), SWIGLU_LIMIT
+        )
+    # Match the reference exact floating-point grouping.  Computing a reciprocal
+    # first and then multiplying by ``gate`` is algebraically equivalent but
+    # changes sparse near-zero BF16 results by one ULP after the final cast.
+    silu_g0 = gate_acc_group0 / (1.0 + gl.exp(-(SWIGLU_ALPHA * gate_acc_group0)))
+    acc_swiglu_group0 = gl.fma(silu_g0, up_acc_group0, silu_g0 * SWIGLU_BETA)
+    silu_g1 = gate_acc_group1 / (1.0 + gl.exp(-(SWIGLU_ALPHA * gate_acc_group1)))
+    acc_swiglu_group1 = gl.fma(silu_g1, up_acc_group1, silu_g1 * SWIGLU_BETA)
+    silu_g2 = gate_acc_group2 / (1.0 + gl.exp(-(SWIGLU_ALPHA * gate_acc_group2)))
+    acc_swiglu_group2 = gl.fma(silu_g2, up_acc_group2, silu_g2 * SWIGLU_BETA)
+    silu_g3 = gate_acc_group3 / (1.0 + gl.exp(-(SWIGLU_ALPHA * gate_acc_group3)))
+    acc_swiglu_group3 = gl.fma(silu_g3, up_acc_group3, silu_g3 * SWIGLU_BETA)
+
+    _store_swiglu_tile_group(
+        acc_swiglu_group0,
+        c_ptr,
+        sorted_token_ids_ptr,
+        pid_m,
+        pid_n,
+        EM,
+        num_tokens,
+        top_k,
+        stride_cm,
+        stride_cn,
+        mfma_layout,
+        GROUP0_IDX,
+        GROUP_MFMA_M,
+        BLOCK_M,
+        BLOCK_N,
+        I_r,
+    )
+    _store_swiglu_tile_group(
+        acc_swiglu_group1,
+        c_ptr,
+        sorted_token_ids_ptr,
+        pid_m,
+        pid_n,
+        EM,
+        num_tokens,
+        top_k,
+        stride_cm,
+        stride_cn,
+        mfma_layout,
+        GROUP1_IDX,
+        GROUP_MFMA_M,
+        BLOCK_M,
+        BLOCK_N,
+        I_r,
+    )
+    _store_swiglu_tile_group(
+        acc_swiglu_group2,
+        c_ptr,
+        sorted_token_ids_ptr,
+        pid_m,
+        pid_n,
+        EM,
+        num_tokens,
+        top_k,
+        stride_cm,
+        stride_cn,
+        mfma_layout,
+        GROUP2_IDX,
+        GROUP_MFMA_M,
+        BLOCK_M,
+        BLOCK_N,
+        I_r,
+    )
+    _store_swiglu_tile_group(
+        acc_swiglu_group3,
+        c_ptr,
+        sorted_token_ids_ptr,
+        pid_m,
+        pid_n,
+        EM,
+        num_tokens,
+        top_k,
+        stride_cm,
+        stride_cn,
+        mfma_layout,
+        GROUP3_IDX,
+        GROUP_MFMA_M,
+        BLOCK_M,
+        BLOCK_N,
+        I_r,
+    )
+
+
+def invoke_gluon_mxfp4_moe_stage1(
+    hidden_states,
+    w1,
+    w2,
+    sorted_token_ids,
+    sorted_expert_ids,
+    num_valid_ids,
+    out,
+    topk,
+    kernelName="",
+    w1_scale=None,
+    a1_scale=None,
+    block_m=32,
+    sorted_weights=None,
+    quant_type=None,
+    activation=None,
+    splitk=1,
+    use_non_temporal_load=False,
+    dst_type=None,
+    b_preshuffled: bool = False,
+    b_gdot128: bool = False,
+    swiglu_alpha: float = 1.0,
+    swiglu_limit: float = 0.0,
+    swiglu_beta: float = 0.0,
+):
+    """Host-side launcher for Gluon MXFP4 MoE stage 1.
+
+    Computes, for each expert ``e``::
+
+        inter_e = silu(hidden_states_e @ w1_e[:I_r, :].T)
+                  * (hidden_states_e @ w1_e[I_r:, :].T)
+
+    in one kernel launch over all experts. The grid is one CTA per
+    (M-tile, N-tile); each CTA owns one ``BLOCK_M`` x ``BLOCK_N``
+    output region for the expert ``sorted_expert_ids[pid_m]``.
+
+    Steps below correspond to the ``# Step N:`` comments in the body:
+      1. Validate dtypes / shapes; reject unsupported options.
+      2. Permute ``w1`` to the (16, 16) MFMA-tile layout (see
+         :func:`_b_preshuffle_3d`), or skip if the caller already did.
+      3. Materialise ``num_valid_ids`` / ``sorted_weights`` as device
+         tensors when the caller passed a Python scalar / ``None``.
+      4. Launch the GEMM kernel.
+
+    Layout contract: see the module docstring.
+
+    Unsupported (raises ``NotImplementedError``):
+      ``quant_type != per_1x32``, ``activation != Silu``,
+      ``splitk not in {0, 1, None}``, non-empty ``sorted_weights``,
+      ``dst_type != bfloat16``.
+
+    Accepted-but-ignored, kept for signature compatibility with
+    upstream dispatchers: ``kernelName``, ``block_m`` (kernel hardcodes
+    128), ``w2``, ``use_non_temporal_load``.
+    """
+    # Step 1: validate inputs and reject unsupported modes.
+    del quant_type, activation  # only per-1x32 MXFP4 + SwiGLU is implemented
+    if splitk not in (0, 1, None):
+        raise NotImplementedError(
+            "invoke_gluon_mxfp4_moe_stage1: splitk in {0, 1} expected "
+            f"(got splitk={splitk!r})"
+        )
+    if sorted_weights is not None and sorted_weights.numel() > 0:
+        raise NotImplementedError(
+            "invoke_gluon_mxfp4_moe_stage1: do_weight_stage1 (a non-empty "
+            "sorted_weights tensor) is not implemented; pass None or a "
+            "0-element placeholder"
+        )
+    if dst_type is not None and dst_type != torch.bfloat16:
+        raise NotImplementedError(
+            "invoke_gluon_mxfp4_moe_stage1: only dst_type=torch.bfloat16 is "
+            f"supported, got dst_type={dst_type!r}"
+        )
+    del kernelName, block_m, use_non_temporal_load, w2
+
+    assert (
+        hidden_states.dtype == torch.uint8
+    ), f"hidden_states must be packed fp4x2 (uint8), got {hidden_states.dtype}"
+    assert w1.dtype == torch.uint8, f"w1 must be packed fp4x2 (uint8), got {w1.dtype}"
+    # Step 2: shuffle w1 to the MFMA-tile layout the kernel expects.
+    if not b_preshuffled:
+        w1 = _b_preshuffle_3d(w1)
+    if b_gdot128 and not b_preshuffled:
+        raise ValueError("b_gdot128 requires a preshuffled gdot128 weight alias")
+    assert w1_scale is not None and w1_scale.dtype == torch.uint8, (
+        "w1_scale must be a uint8 e8m0 tensor, got "
+        f"{None if w1_scale is None else w1_scale.dtype}"
+    )
+    assert a1_scale is not None and a1_scale.dtype == torch.uint8, (
+        "a1_scale must be a uint8 e8m0 tensor, got "
+        f"{None if a1_scale is None else a1_scale.dtype}"
+    )
+    assert out.dtype == torch.bfloat16, f"out must be bfloat16, got {out.dtype}"
+    assert (
+        sorted_token_ids.dtype == torch.int32
+    ), f"sorted_token_ids must be int32, got {sorted_token_ids.dtype}"
+    assert (
+        sorted_expert_ids.dtype == torch.int32
+    ), f"sorted_expert_ids must be int32, got {sorted_expert_ids.dtype}"
+
+    assert hidden_states.dim() == 2, (
+        f"hidden_states must be 2-D (M_padded, K_packed), got "
+        f"shape {tuple(hidden_states.shape)}"
+    )
+    M_padded, D_packed = hidden_states.shape
+    K = D_packed * 2
+    assert (
+        w1.dim() == 3
+    ), f"w1 must be 3-D (E, 2*I_r, K_packed), got shape {tuple(w1.shape)}"
+    E_w, two_Ir, D_packed_w = w1.shape
+    assert D_packed_w == D_packed, (
+        f"w1 K-packed dim ({D_packed_w}) must match hidden_states K-packed "
+        f"dim ({D_packed})"
+    )
+    assert two_Ir % 2 == 0, f"w1.shape[1] (= 2*I_r) must be even, got {two_Ir}"
+    I_r = two_Ir // 2
+    N = 2 * I_r
+    EM = sorted_token_ids.shape[0]
+    if out.dim() == 3:
+        token_num, top_k_dim, I_r_dim = out.shape
+        assert top_k_dim == topk, f"out top_k mismatch: {top_k_dim} vs topk={topk}"
+        assert I_r_dim == I_r, f"out I_r mismatch: {I_r_dim} vs {I_r}"
+        assert out.is_contiguous(), (
+            "3-D out tensor must be contiguous so .view(token_num*topk, I_r) "
+            "shares memory with the original; got non-contiguous out"
+        )
+        out_2d = out.view(token_num * topk, I_r)
+    elif out.dim() == 2:
+        out_2d = out
+        assert out.shape[0] >= EM, f"out 2-D first dim {out.shape[0]} < EM={EM}"
+        assert (
+            out.shape[1] == I_r
+        ), f"out 2-D second dim {out.shape[1]} must equal I_r={I_r}"
+    else:
+        raise NotImplementedError(
+            "out must be 2-D (EM, I_r) or 3-D (token_num, topk, I_r); "
+            f"got shape {tuple(out.shape)}"
+        )
+    K_scale = K // 32
+    assert a1_scale.dim() == 2 and a1_scale.shape[1] == K_scale, (
+        f"a1_scale.shape {tuple(a1_scale.shape)} must be "
+        f"(M_padded_aligned, K // 32 = {K_scale})"
+    )
+    assert w1_scale.shape == (E_w, N, K_scale), (
+        f"w1_scale.shape {tuple(w1_scale.shape)} must be (E, N, K//32) = "
+        f"({E_w}, {N}, {K_scale})"
+    )
+    num_tokens = M_padded
+    del M_padded
+
+    # Step 3: materialise scalar / None args as device tensors so the
+    # kernel can just `gl.load` from them.
+    if torch.is_tensor(num_valid_ids):
+        num_valid_ids_ptr = num_valid_ids
+    else:
+        num_valid_ids_ptr = torch.tensor(
+            [int(num_valid_ids)], dtype=torch.int32, device=hidden_states.device
+        )
+    if sorted_weights is None:
+        sw_ptr = torch.zeros(1, dtype=torch.float32, device=hidden_states.device)
+    else:
+        sw_ptr = sorted_weights
+
+    BLOCK_M = 128
+    BLOCK_N = 128
+    BLOCK_K = 256
+    GROUP_SIZE_M = 1
+    NUM_WARPS = 4
+    num_pid_m = triton.cdiv(EM, BLOCK_M)
+    num_pid_n = triton.cdiv(I_r, BLOCK_N)
+    grid = (num_pid_m * num_pid_n,)
+
+    stride_am = hidden_states.stride(0)
+    stride_ak = hidden_states.stride(1)
+    stride_be = w1.stride(0)
+    stride_bn = w1.stride(1)
+    stride_bk = w1.stride(2)
+    stride_cm = out_2d.stride(0)
+    stride_cn = out_2d.stride(1)
+    stride_ase_m = a1_scale.stride(0)
+    stride_ase_k = a1_scale.stride(1)
+    stride_bse_e = w1_scale.stride(0)
+    stride_bse_n = w1_scale.stride(1)
+    stride_bse_k = w1_scale.stride(2)
+    stride_se_n_pad = a1_scale.shape[1]
+    K_packed_total = K // 2
+
+    # Step 4: launch the GEMM. One CTA per (M-tile, N-tile); the per-CTA
+    # expert id is ``sorted_expert_ids[pid_m]``. Each CTA produces
+    # BLOCK_M rows x BLOCK_N cols of the gate-up fused intermediate.
+    gluon_mxfp4_moe_stage1_kernel[grid](
+        hidden_states,
+        w1,
+        out_2d,
+        a1_scale,
+        w1_scale,
+        sorted_token_ids,
+        sorted_expert_ids,
+        num_valid_ids_ptr,
+        sw_ptr,
+        N,
+        K,
+        EM,
+        num_tokens,
+        topk,
+        stride_am,
+        stride_ak,
+        stride_be,
+        stride_bn,
+        stride_bk,
+        stride_cm,
+        stride_cn,
+        stride_ase_m,
+        stride_ase_k,
+        stride_bse_e,
+        stride_bse_n,
+        stride_bse_k,
+        stride_se_n_pad,
+        K_PACKED_TOTAL=K_packed_total,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        GROUP_SIZE_M=GROUP_SIZE_M,
+        NUM_WARPS=NUM_WARPS,
+        I_r=I_r,
+        B_GDOT128=bool(b_gdot128),
+        SWIGLU_ALPHA=float(swiglu_alpha),
+        SWIGLU_LIMIT=float(swiglu_limit),
+        SWIGLU_BETA=float(swiglu_beta),
+        num_warps=NUM_WARPS,
+    )
+    return out

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/prefill_stage2.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/prefill_stage2.py
@@ -1,0 +1,1751 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""Gluon MXFP4 MoE stage 2: down-projection GEMM with reduce-mode epilogue.
+
+For each expert ``e``::
+
+    out_e += topk_w_e * (inter_e @ w2_e.T)
+
+where ``inter_e`` is stage 1's post-SwiGLU output for the rows routed
+to expert ``e``, and ``topk_w_e`` is the routing weight for that
+``(token, slot)`` pair.
+
+Kernel shape ("1x4"): 4 wave64/CTA with ``warps_per_cta = [1, 4]``
+(four waves split the N axis), ``BLOCK_M`` selected by the caller from
+``{32, 64, 128}``, ``BLOCK_N = 256``, and ``BLOCK_K = 128``. At
+production K = 256 that is 2 K-iters with a 2-buffer LDS ping-pong and
+``v_mfma_scale_f32_16x16x128_f8f6f4``.
+A data goes HBM -> LDS via the async copy + ping-pong; A scale, B,
+B scale are direct-to-VGPR. B is consumed in the (16, 16) MFMA-tile
+layout produced by :func:`_b_preshuffle_3d`.
+
+Epilogue:
+  acc (fp32) * routed weight -> bf16 -> ``convert_layout`` through
+  LDS to ``BlockedLayout([128, 2], [1, 64])`` -> scatter. All 64 lanes
+  hit the same output row, so each store is 2 cache-line writes
+  instead of 64 scattered ones. The N axis is split into 4 chunks of
+  ``BLOCK_N // 4`` columns; each chunk runs the convert_layout +
+  store independently so the scheduler can hide a chunk's LDS
+  shuffle behind the prior chunk's VMEM in flight.
+
+Reduce mode (``USE_REDUCE=True``):
+  the scatter target becomes ``scratch[token, topk_id, n]`` and the
+  per-chunk ``atomic_add`` is replaced with a plain ``gl.store``.
+  Each ``(token, slot)`` cell is written by exactly one CTA --
+  ``sorted_token_ids`` packs ``(topk_id << 24 | token_id)`` and the
+  block-M math sends each entry to a single ``pid_m`` -- so the
+  no-atomic store is race-free. The host wrapper then launches a
+  small reduce kernel (``gluon_mxfp4_moe_stage2_reduce_kernel``)
+  that sums ``scratch`` over the topk dim with fp32 accumulation
+  into the user-visible bf16 output. This removes the
+  ``M * topk``-way contended global ``atomic_add`` on overlapping
+  output rows, which dominates large-M cost when the epilogue does
+  the cross-slot reduction inline.
+
+Persistent grid (``PERSISTENT=True``): launch one CTA per N tile per
+CU and walk a contiguous-M slice of the tile space inside the kernel.
+The launcher always selects the non-persistent grid; the persistent
+branch is retained only as a kernel-level config.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import triton
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+from triton.experimental.gluon.language.amd.cdna4 import async_copy as cdna4_async_copy
+
+_USES_FP32_ATOMIC: Optional[bool] = None
+
+
+def _b_preshuffle_3d(b: torch.Tensor) -> torch.Tensor:
+    """Permute a 3-D MoE weight into the (16, 16) MFMA-tile layout.
+
+    Identical to ``stage1_kernel._b_preshuffle_3d`` but kept local so
+    this file doesn't import across stage modules. The MFMA
+    instruction wants a tile's 16 rows and 16 K-columns contiguous in
+    HBM; this permutation arranges them that way. Numerically a no-op.
+    """
+    assert b.dtype == torch.uint8, "B must be packed fp4 in uint8"
+    assert b.ndim == 3, f"B must be 3-D (E, N, K/2), got {tuple(b.shape)}"
+    E, N, K_pk = b.shape
+    assert N % 16 == 0, f"N ({N}) must be divisible by 16"
+    assert K_pk % 32 == 0, f"K/2 ({K_pk}) must be divisible by 32"
+    b_6d = b.view(E, N // 16, 16, K_pk // 32, 2, 16)
+    return b_6d.permute(0, 1, 3, 4, 2, 5).contiguous().view(E, N, K_pk)
+
+
+@gluon.jit
+def _gdot128_weight_offset(k_pack, n_col, n_phys: gl.constexpr):
+    """Flat byte offset for the 128x128 Gluon-dot weight layout."""
+    k_in = k_pack % 128
+    n_in = n_col % 128
+    in_tile = (
+        (n_in // 16) * 2048
+        + (k_in // 64) * 1024
+        + ((k_in // 16) % 4) * 256
+        + (n_in % 16) * 16
+        + (k_in % 16)
+    )
+    n_tiles: gl.constexpr = n_phys // 128
+    tile = (k_pack // 128) * n_tiles + (n_col // 128)
+    return tile * (128 * 128) + in_tile
+
+
+# ---------------------------------------------------------------------------
+# Kernel
+# ---------------------------------------------------------------------------
+
+
+@gluon.jit
+def gluon_mxfp4_moe_stage2_1x2_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    a_scales_ptr,
+    b_scales_ptr,
+    sorted_token_ids_ptr,
+    sorted_expert_ids_ptr,
+    num_tokens_post_padded_ptr,
+    sorted_weights_ptr,
+    N,
+    K,
+    EM,
+    num_valid_tokens,
+    token_num,
+    top_k,
+    stride_am,
+    stride_ak,
+    stride_be,
+    stride_bn,
+    stride_bk,
+    stride_cm,
+    stride_cn,
+    stride_ase_m,
+    stride_ase_k,
+    stride_bse_e,
+    stride_bse_n,
+    stride_bse_k,
+    stride_se_n_pad,
+    K_PACKED_TOTAL: gl.constexpr,
+    N_PHYS: gl.constexpr,
+    BLOCK_M: gl.constexpr,
+    SORT_BLOCK_M: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    BLOCK_K: gl.constexpr,
+    GROUP_SIZE_M: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+    B_GDOT128: gl.constexpr = False,
+    USE_REDUCE: gl.constexpr = False,
+    MFMA_STORE_LAYOUT: gl.constexpr = False,
+    PERSISTENT: gl.constexpr = True,
+    CU_NUM: gl.constexpr = 256,
+    COALESCE_SCALES: gl.constexpr = False,
+    DIRECT_SCALE_LAYOUT: gl.constexpr = False,
+    DEFER_EPILOGUE: gl.constexpr = True,
+):
+    """Stage 2 1x2 kernel: 2 waves/CTA, BLOCK_N=256, 2-stage v3 pipeline.
+
+    When ``USE_REDUCE`` is True, the epilogue writes per-(token, slot)
+    partials with plain stores instead of contending atomic_adds; the
+    user must separately invoke ``gluon_mxfp4_moe_stage2_reduce_kernel``
+    to sum across the topk dim. ``c_ptr`` is then expected to point at
+    a ``[token_num * topk, N]`` bf16 scratch buffer; ``stride_cm`` /
+    ``stride_cn`` describe that shape (``stride_cm = N``).
+
+    When ``PERSISTENT`` is True, the kernel is launched with
+    ``grid = (CU_NUM,)`` and each CTA walks a contiguous-M slice of the
+    ``num_pid_m * num_pid_n`` tile space. ``flat_tile = cta_id *
+    tiles_per_block + tile_iter``; ``pid_m = flat_tile % num_pid_m``,
+    ``pid_n = flat_tile // num_pid_m``. Iterating M-fast within a
+    fixed N means consecutive iters share the same expert
+    (``sorted_expert_ids`` is monotone in M), so that expert's B
+    weight stays L2-resident across iters. ``PERSISTENT=False``
+    (the default for this wrapper) launches the per-tile grid
+    ``(num_pid_m * num_pid_n,)``.
+    """
+
+    gl.static_assert(
+        BLOCK_M == 32 or BLOCK_M == 64 or BLOCK_M == 128,
+        "1x2 kernel requires BLOCK_M in {32, 64, 128}",
+    )
+    gl.static_assert(
+        SORT_BLOCK_M == 32 or SORT_BLOCK_M == 64 or SORT_BLOCK_M == 128,
+        "1x2 kernel requires SORT_BLOCK_M in {32, 64, 128}",
+    )
+    gl.static_assert(SORT_BLOCK_M % BLOCK_M == 0)
+    gl.static_assert(BLOCK_N == 256, "1x2 kernel requires BLOCK_N=256")
+    gl.static_assert(BLOCK_K == 128, "1x2 kernel requires BLOCK_K=128")
+    gl.static_assert(NUM_WARPS == 4, "1x2 kernel requires NUM_WARPS=4")
+
+    BLOCK_K_PACKED: gl.constexpr = BLOCK_K // 2  # 64
+    BLOCK_K_SCALE: gl.constexpr = BLOCK_K // 32  # 4
+    NUM_BUFFERS: gl.constexpr = 2
+    # 4 N-chunks of 64 cols each at BLOCK_N = 256. With warps_per_cta=[1, 4]
+    # each wave owns 1/4 of a chunk = 16 cols, so per wave [128, 16] per chunk.
+    NUM_N_CHUNKS: gl.constexpr = 4
+    BLOCK_N_CHUNK: gl.constexpr = BLOCK_N // NUM_N_CHUNKS  # 64
+
+    # MFMA + dot operand + scale layouts. warps_per_cta=[1, 4] splits the N
+    # axis across 4 waves; each wave's portion of acc[BLOCK_M, BLOCK_N=256]
+    # is [128, 64], and each per-chunk [BLOCK_M, BLOCK_N_CHUNK=64] tile is
+    # [128, 16] per wave. Halves per-wave accumulator and B operand vs the
+    # earlier 2-wave layout -- the change targets register pressure to fit
+    # more than one wave per SIMD on MI350.
+    # COALESCE_SCALES does not change this layout; it only changes how the
+    # scale operands are loaded (address-ordered coalesced load + convert to
+    # the operand layout). Supported for BLOCK_M == 64, BLOCK_N == 256 only;
+    # the caller must gate the flag on that.
+    mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
+        version=4,
+        instr_shape=[16, 16, 128],
+        transposed=True,
+        warps_per_cta=[1, 4],
+    )
+    dot_a_layout: gl.constexpr = gl.DotOperandLayout(
+        operand_index=0, parent=mfma_layout, k_width=16
+    )
+    dot_b_layout: gl.constexpr = gl.DotOperandLayout(
+        operand_index=1, parent=mfma_layout, k_width=16
+    )
+    a_scale_layout: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
+        dot_a_layout, [BLOCK_M, BLOCK_K_SCALE]
+    )
+    BLOCK_K_SCALE_FULL: gl.constexpr = 2 * BLOCK_K_SCALE  # K // 32 = 8
+    a_scale_layout_full: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
+        dot_a_layout, [BLOCK_M, BLOCK_K_SCALE_FULL]
+    )
+    # Per-chunk B-scale layout. mfma_scaled requires the scale shape to be
+    # consistent with the per-chunk B operand [BLOCK_N_CHUNK, K_SCALE].
+    b_scale_layout_chunk: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
+        dot_b_layout, [BLOCK_N_CHUNK, BLOCK_K_SCALE]
+    )
+    # Full-N, full-K B-scale operand layout (COALESCE_SCALES).
+    b_scale_layout_full: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
+        dot_b_layout, [BLOCK_N, BLOCK_K_SCALE_FULL]
+    )
+
+    # A global-load layout for HBM -> LDS async copy.  The CDNA4
+    # buffer_load_to_shared verifier accepts BlockedLayout/SliceLayout
+    # offsets, not the arbitrary DistributedLinearLayout we use for some
+    # direct VGPR loads.  Each thread reads 16 contiguous bytes along K
+    # (128-bit load).  BM128 uses the gdot128 K64 split; BM32/BM64 use
+    # a [2,2] warp split, which is the verifier-safe layout that preserves
+    # identical numerics against BM128 for the package stage2 contract.
+    # The LDS layout below remains the original padded swizzle consumed by
+    # the MFMA dot operand.
+    if BLOCK_M == 32:
+        gload_a_layout: gl.constexpr = gl.BlockedLayout(
+            [1, 16],
+            [16, 4],
+            [2, 2],
+            [1, 0],
+        )
+        shared_a_bases: gl.constexpr = [
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [0, 16],
+            [0, 32],
+            [1, 0],
+            [2, 0],
+            [4, 0],
+            [8, 0],
+            [16, 0],
+        ]
+    elif BLOCK_M == 64:
+        gload_a_layout: gl.constexpr = gl.BlockedLayout(
+            [1, 16],
+            [16, 4],
+            [2, 2],
+            [1, 0],
+        )
+        shared_a_bases: gl.constexpr = [
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [0, 16],
+            [0, 32],
+            [1, 0],
+            [2, 0],
+            [4, 0],
+            [8, 0],
+            [16, 0],
+            [32, 0],
+        ]
+    else:
+        gload_a_layout: gl.constexpr = gl.BlockedLayout(
+            [1, 16],
+            [16, 4],
+            [4, 1],
+            [1, 0],
+        )
+        shared_a_bases: gl.constexpr = [
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [0, 16],
+            [0, 32],
+            [1, 0],
+            [2, 0],
+            [4, 0],
+            [8, 0],
+            [16, 0],
+            [32, 0],
+            [64, 0],
+        ]
+
+    # Padded shared layout for A data. Scales bypass LDS (direct-to-VGPR).
+    shared_a: gl.constexpr = gl.PaddedSharedLayout(
+        [[1024, 16]],
+        shared_a_bases,
+        [],
+        [BLOCK_M, BLOCK_K_PACKED],
+    )
+
+    cta_id = gl.program_id(axis=0)
+    num_pid_m = gl.cdiv(EM, BLOCK_M)
+    num_pid_n = gl.cdiv(N, BLOCK_N)
+    total_tiles = num_pid_m * num_pid_n
+    num_tokens_post_padded = gl.load(num_tokens_post_padded_ptr)
+    if PERSISTENT:
+        worker_id = gl.program_id(axis=1)
+        worker_count = gl.num_programs(axis=1)
+        m_tiles_floor = num_pid_m // worker_count
+        m_tiles_rem = num_pid_m - m_tiles_floor * worker_count
+        m_tile_extra = gl.where(worker_id < m_tiles_rem, 1, 0)
+        start_pid_m = worker_id * m_tiles_floor + gl.minimum(worker_id, m_tiles_rem)
+        tiles_per_block = m_tiles_floor + m_tile_extra
+    else:
+        tiles_per_block = 1
+    # Persistent tile loop: grid axis 0 owns a fixed N tile;
+    # grid axis 1 owns a contiguous floor/ceil M-tile slice.  This keeps
+    # adjacent iterations in the same or adjacent expert ranges so B rows
+    # stay L2-resident across the worker's slice.
+    for tile_iter in range(0, tiles_per_block):
+        if PERSISTENT:
+            pid_m = start_pid_m + tile_iter
+            pid_n = cta_id
+            flat_tile = pid_n * num_pid_m + pid_m
+        else:
+            flat_tile = cta_id
+            pid_m = flat_tile % num_pid_m
+            pid_n = flat_tile // num_pid_m
+        tile_ok = (
+            (pid_n < num_pid_n)
+            & (pid_m < num_pid_m)
+            & (pid_m * BLOCK_M < num_tokens_post_padded)
+        )
+        if tile_ok:
+            # A row gather (topk-aware): sorted_token_ids packs (topk_id << 24 | token_id)
+            m_layout: gl.constexpr = gl.SliceLayout(1, gload_a_layout)
+            k_layout: gl.constexpr = gl.SliceLayout(0, gload_a_layout)
+            offs_sorted_slot = pid_m * BLOCK_M + gl.arange(0, BLOCK_M, layout=m_layout)
+            # ``buffer_load`` (SRD-relative addressing) instead of
+            # ``gl.load(ptr + offs)`` (absolute 64-bit ``global_load``):
+            # the latter cost ~1 M cycles of global_load stall on this
+            # gather alone in the previous ATT run.
+            # No runtime mask: EM is BLOCK_M-aligned (SORT_BLOCK_M % BLOCK_M == 0,
+            # EM % SORT_BLOCK_M == 0), so offs_sorted_slot < EM always holds for
+            # valid tiles. The mask/other lower to a v_cmp + 2 v_cndmask per
+            # element (x4 per lane); padding slots carry a sentinel token_id >=
+            # token_num that token_mask/tok_ok gate downstream.
+            offs_token = gl.amd.cdna4.buffer_load(
+                ptr=sorted_token_ids_ptr,
+                offsets=offs_sorted_slot,
+            )
+            token_id = offs_token & 0xFFFFFF
+            topk_id = offs_token >> 24
+            inter_row = token_id * top_k + topk_id
+            token_mask = token_id < token_num
+
+            offs_ak = gl.arange(0, BLOCK_K_PACKED, layout=k_layout)
+            offs_a = (
+                inter_row[:, None].to(gl.int64) * stride_am
+                + offs_ak[None, :] * stride_ak
+            )
+
+            # Expert id is indexed at the sort-block granularity.  FlyDSL
+            # uses tile_m=64 with sort_block_m=128 for large Kimi shapes, so
+            # two compute M-tiles share one sorted_expert_ids entry.
+            sort_pid_m = (pid_m * BLOCK_M) // SORT_BLOCK_M
+            off_experts = gl.load(sorted_expert_ids_ptr + sort_pid_m)
+            if off_experts != -1:
+
+                # A_scale offsets (direct-to-VGPR). Half-bit ordering
+                # matches what the upstream sort kernel writes:
+                # m-half at +1, y-half at +2 within a 4-byte panel.
+                m_scale_layout: gl.constexpr = gl.SliceLayout(1, a_scale_layout)
+                k_scale_layout: gl.constexpr = gl.SliceLayout(0, a_scale_layout)
+                a_scale_rows = (
+                    pid_m * BLOCK_M + gl.arange(0, BLOCK_M, layout=m_scale_layout)
+                ).to(gl.uint32)
+                a_m_part = (
+                    (a_scale_rows // 32) * (stride_se_n_pad * 32)
+                    + (a_scale_rows % 16) * 4
+                    + ((a_scale_rows % 32) // 16)
+                )[:, None]
+                a_k_lanes = gl.arange(0, BLOCK_K_SCALE, layout=k_scale_layout).to(
+                    gl.uint32
+                )
+
+                if COALESCE_SCALES:
+                    if DIRECT_SCALE_LAYOUT:
+                        # Diagnostic path: load A scales directly in the MFMA
+                        # scale layout.  This removes the full-layout
+                        # convert_layout that emits v_cndmask near line 395,
+                        # at the cost of a less coalescer-friendly load shape.
+                        m_full_layout: gl.constexpr = gl.SliceLayout(
+                            1, a_scale_layout_full
+                        )
+                        k_full_layout: gl.constexpr = gl.SliceLayout(
+                            0, a_scale_layout_full
+                        )
+                        a_scale_rows_full = (
+                            pid_m * BLOCK_M
+                            + gl.arange(0, BLOCK_M, layout=m_full_layout)
+                        ).to(gl.uint32)
+                        a_k_full = gl.arange(
+                            0, BLOCK_K_SCALE_FULL, layout=k_full_layout
+                        ).to(gl.uint32)
+                        a_m_part_full = (
+                            (a_scale_rows_full // 32) * (stride_se_n_pad * 32)
+                            + (a_scale_rows_full % 16) * 4
+                            + ((a_scale_rows_full % 32) // 16)
+                        )[:, None]
+                        a_k_part_full = ((a_k_full % 4) * 64 + (a_k_full // 4) * 2)[
+                            None, :
+                        ]
+                        a_scale_all = gl.amd.cdna4.buffer_load(
+                            ptr=a_scales_ptr,
+                            offsets=a_m_part_full + a_k_part_full,
+                        )
+                    else:
+                        # Coalesced full-K A-scale load via a 3D [m_hi=m//32,
+                        # m_lo=m%32, k] layout so the coalescer proof gets
+                        # clean per-axis atoms. Then convert to the operand
+                        # layout and split into the K-iters.
+                        if BLOCK_M == 32:
+                            gload_a3d: gl.constexpr = gl.DistributedLinearLayout(
+                                reg_bases=[[0, 16, 0], [0, 0, 4]],
+                                lane_bases=[
+                                    [0, 1, 0],
+                                    [0, 2, 0],
+                                    [0, 4, 0],
+                                    [0, 8, 0],
+                                    [0, 0, 1],
+                                    [0, 0, 2],
+                                ],
+                                warp_bases=[[0, 0, 0], [0, 0, 0]],
+                                block_bases=[],
+                                shape=[BLOCK_M // 32, 32, BLOCK_K_SCALE_FULL],
+                            )
+                        elif BLOCK_M == 64:
+                            gload_a3d: gl.constexpr = gl.DistributedLinearLayout(
+                                reg_bases=[[0, 16, 0], [0, 0, 4], [0, 1, 0]],
+                                lane_bases=[
+                                    [1, 0, 0],
+                                    [0, 2, 0],
+                                    [0, 4, 0],
+                                    [0, 8, 0],
+                                    [0, 0, 1],
+                                    [0, 0, 2],
+                                ],
+                                warp_bases=[[0, 0, 0], [0, 0, 0]],
+                                block_bases=[],
+                                shape=[BLOCK_M // 32, 32, BLOCK_K_SCALE_FULL],
+                            )
+                        else:  # BLOCK_M == 128
+                            gload_a3d: gl.constexpr = gl.DistributedLinearLayout(
+                                reg_bases=[
+                                    [0, 16, 0],
+                                    [0, 0, 4],
+                                    [0, 1, 0],
+                                    [0, 2, 0],
+                                ],
+                                lane_bases=[
+                                    [1, 0, 0],
+                                    [2, 0, 0],
+                                    [0, 4, 0],
+                                    [0, 8, 0],
+                                    [0, 0, 1],
+                                    [0, 0, 2],
+                                ],
+                                warp_bases=[[0, 0, 0], [0, 0, 0]],
+                                block_bases=[],
+                                shape=[BLOCK_M // 32, 32, BLOCK_K_SCALE_FULL],
+                            )
+                        l_amhi: gl.constexpr = gl.SliceLayout(
+                            1, gl.SliceLayout(2, gload_a3d)
+                        )
+                        l_amlo: gl.constexpr = gl.SliceLayout(
+                            0, gl.SliceLayout(2, gload_a3d)
+                        )
+                        l_ak: gl.constexpr = gl.SliceLayout(
+                            0, gl.SliceLayout(1, gload_a3d)
+                        )
+                        a_mhi = (
+                            pid_m * (BLOCK_M // 32)
+                            + gl.arange(0, BLOCK_M // 32, layout=l_amhi)
+                        ).to(gl.uint32)
+                        a_mlo = gl.arange(0, 32, layout=l_amlo).to(gl.uint32)
+                        a_kax = gl.arange(0, BLOCK_K_SCALE_FULL, layout=l_ak).to(
+                            gl.uint32
+                        )
+                        a_off3d = (
+                            a_mhi[:, None, None] * (stride_se_n_pad * 32)
+                            + ((a_mlo % 16) * 4 + (a_mlo // 16))[None, :, None]
+                            + ((a_kax % 4) * 64 + (a_kax // 4) * 2)[None, None, :]
+                        )
+                        a_scale_all = gl.amd.cdna4.buffer_load(
+                            ptr=a_scales_ptr, offsets=a_off3d
+                        )
+                        a_scale_all = gl.reshape(
+                            a_scale_all, [BLOCK_M, BLOCK_K_SCALE_FULL]
+                        )
+                        a_scale_all = gl.convert_layout(
+                            a_scale_all, a_scale_layout_full
+                        )
+                    a_scale_all = gl.reshape(a_scale_all, [BLOCK_M, 2, BLOCK_K_SCALE])
+                    a_scale_all = gl.permute(a_scale_all, [0, 2, 1])
+                    a_scale0_raw, a_scale1_raw = gl.split(a_scale_all)
+                    a_scale0 = gl.convert_layout(a_scale0_raw, a_scale_layout)
+                    a_scale1 = gl.convert_layout(a_scale1_raw, a_scale_layout)
+
+                # B data offsets (preshuffled B, direct-to-VGPR).
+                # NOTE: dot_b_layout is shape-agnostic, so we reuse it for the [K, 32]
+                # per-chunk tile. SliceLayout(0,dot_b_layout) over arange(0,32) yields the
+                # natural N-axis sublayout for each 32-col chunk.
+                offs_bk = gl.arange(
+                    0, BLOCK_K_PACKED, layout=gl.SliceLayout(1, dot_b_layout)
+                )
+                b_k_part = (
+                    (offs_bk // 32) * 512 + ((offs_bk // 16) % 2) * 256 + (offs_bk % 16)
+                )[:, None]
+
+                bn_slice: gl.constexpr = gl.SliceLayout(0, dot_b_layout)
+                # Kimi/DSv3 stage2 only dispatches this 1x2 kernel for N
+                # divisible by BLOCK_N=256, so every pid_n chunk is in-bounds.
+                # Avoid dynamic modulo in the B address arithmetic; the
+                # stage2 kernels rely on full-N tiles for these shapes.
+                offs_bn_c0 = (
+                    pid_n * BLOCK_N
+                    + 0 * BLOCK_N_CHUNK
+                    + gl.arange(0, BLOCK_N_CHUNK, layout=bn_slice)
+                )
+                offs_bn_c1 = (
+                    pid_n * BLOCK_N
+                    + 1 * BLOCK_N_CHUNK
+                    + gl.arange(0, BLOCK_N_CHUNK, layout=bn_slice)
+                )
+                offs_bn_c2 = (
+                    pid_n * BLOCK_N
+                    + 2 * BLOCK_N_CHUNK
+                    + gl.arange(0, BLOCK_N_CHUNK, layout=bn_slice)
+                )
+                offs_bn_c3 = (
+                    pid_n * BLOCK_N
+                    + 3 * BLOCK_N_CHUNK
+                    + gl.arange(0, BLOCK_N_CHUNK, layout=bn_slice)
+                )
+                if B_GDOT128:
+                    offs_b_c0 = _gdot128_weight_offset(
+                        offs_bk[:, None], offs_bn_c0[None, :], N_PHYS
+                    )
+                    offs_b_c1 = _gdot128_weight_offset(
+                        offs_bk[:, None], offs_bn_c1[None, :], N_PHYS
+                    )
+                    offs_b_c2 = _gdot128_weight_offset(
+                        offs_bk[:, None], offs_bn_c2[None, :], N_PHYS
+                    )
+                    offs_b_c3 = _gdot128_weight_offset(
+                        offs_bk[:, None], offs_bn_c3[None, :], N_PHYS
+                    )
+                else:
+                    offs_b_c0 = (
+                        b_k_part
+                        + (
+                            (offs_bn_c0 // 16) * (16 * K_PACKED_TOTAL)
+                            + (offs_bn_c0 % 16) * 16
+                        )[None, :]
+                    )
+                    offs_b_c1 = (
+                        b_k_part
+                        + (
+                            (offs_bn_c1 // 16) * (16 * K_PACKED_TOTAL)
+                            + (offs_bn_c1 % 16) * 16
+                        )[None, :]
+                    )
+                    offs_b_c2 = (
+                        b_k_part
+                        + (
+                            (offs_bn_c2 // 16) * (16 * K_PACKED_TOTAL)
+                            + (offs_bn_c2 % 16) * 16
+                        )[None, :]
+                    )
+                    offs_b_c3 = (
+                        b_k_part
+                        + (
+                            (offs_bn_c3 // 16) * (16 * K_PACKED_TOTAL)
+                            + (offs_bn_c3 % 16) * 16
+                        )[None, :]
+                    )
+
+                # B_scale offsets (direct-to-VGPR), per-chunk along N.
+                b_n_layout: gl.constexpr = gl.SliceLayout(1, b_scale_layout_chunk)
+                b_k_layout: gl.constexpr = gl.SliceLayout(0, b_scale_layout_chunk)
+                b_rows_c0 = (
+                    pid_n * BLOCK_N
+                    + 0 * BLOCK_N_CHUNK
+                    + gl.arange(0, BLOCK_N_CHUNK, layout=b_n_layout)
+                ).to(gl.uint32)
+                b_rows_c1 = (
+                    pid_n * BLOCK_N
+                    + 1 * BLOCK_N_CHUNK
+                    + gl.arange(0, BLOCK_N_CHUNK, layout=b_n_layout)
+                ).to(gl.uint32)
+                b_rows_c2 = (
+                    pid_n * BLOCK_N
+                    + 2 * BLOCK_N_CHUNK
+                    + gl.arange(0, BLOCK_N_CHUNK, layout=b_n_layout)
+                ).to(gl.uint32)
+                b_rows_c3 = (
+                    pid_n * BLOCK_N
+                    + 3 * BLOCK_N_CHUNK
+                    + gl.arange(0, BLOCK_N_CHUNK, layout=b_n_layout)
+                ).to(gl.uint32)
+                b_n_scale_part_c0 = (
+                    (b_rows_c0 // 32) * (stride_bse_n * 32)
+                    + (b_rows_c0 % 16) * 4
+                    + ((b_rows_c0 % 32) // 16)
+                )[:, None]
+                b_n_scale_part_c1 = (
+                    (b_rows_c1 // 32) * (stride_bse_n * 32)
+                    + (b_rows_c1 % 16) * 4
+                    + ((b_rows_c1 % 32) // 16)
+                )[:, None]
+                b_n_scale_part_c2 = (
+                    (b_rows_c2 // 32) * (stride_bse_n * 32)
+                    + (b_rows_c2 % 16) * 4
+                    + ((b_rows_c2 % 32) // 16)
+                )[:, None]
+                b_n_scale_part_c3 = (
+                    (b_rows_c3 // 32) * (stride_bse_n * 32)
+                    + (b_rows_c3 % 16) * 4
+                    + ((b_rows_c3 % 32) // 16)
+                )[:, None]
+
+                b_k_lanes = gl.arange(0, BLOCK_K_SCALE, layout=b_k_layout).to(gl.uint32)
+
+                # LDS holds A data only; 2 ping-pong buffers
+                smem_a = gl.allocate_shared_memory(
+                    a_ptr.type.element_ty,
+                    [NUM_BUFFERS, BLOCK_M, BLOCK_K_PACKED],
+                    shared_a,
+                )
+
+                a_base_ptr = a_ptr
+                b_base_ptr = b_ptr + off_experts.to(gl.int64) * stride_be
+                b_scale_base = b_scales_ptr + off_experts.to(gl.uint32) * stride_bse_e
+                offs_a_i32 = offs_a.to(gl.int32)
+
+                A_DATA_K_STEP: gl.constexpr = BLOCK_K_PACKED  # 64
+                if B_GDOT128:
+                    B_DATA_K_STEP1: gl.constexpr = 1024
+                    B_DATA_K_STEP2: gl.constexpr = (N_PHYS // 128) * (128 * 128)
+                    B_DATA_K_STEP3: gl.constexpr = B_DATA_K_STEP2 + 1024
+                else:
+                    B_DATA_K_STEP1: gl.constexpr = (BLOCK_K_PACKED // 32) * 512
+                    B_DATA_K_STEP2: gl.constexpr = 2 * B_DATA_K_STEP1
+                    B_DATA_K_STEP3: gl.constexpr = 3 * B_DATA_K_STEP1
+
+                # 4 independent accumulators of shape [BLOCK_M, BLOCK_N_CHUNK=32].
+                # mfma_layout is shape-agnostic; each acc covers 8 (M) x 2 (N) x 2 (K) =
+                # 32 v_mfma_scale_f32_16x16x128_f8f6f4 instructions total, summing to 128.
+                acc0 = gl.zeros(
+                    (BLOCK_M, BLOCK_N_CHUNK), dtype=gl.float32, layout=mfma_layout
+                )
+                acc1 = gl.zeros(
+                    (BLOCK_M, BLOCK_N_CHUNK), dtype=gl.float32, layout=mfma_layout
+                )
+                acc2 = gl.zeros(
+                    (BLOCK_M, BLOCK_N_CHUNK), dtype=gl.float32, layout=mfma_layout
+                )
+                acc3 = gl.zeros(
+                    (BLOCK_M, BLOCK_N_CHUNK), dtype=gl.float32, layout=mfma_layout
+                )
+
+                # ---- paired K=128 subtiles (production K=256) -------------------
+                # Issue both K-subtiles' B/B_scale/A_scale loads before the first
+                # MFMA block so tile-1 global-load latency overlaps tile-0 compute.
+                cdna4_async_copy.buffer_load_to_shared(
+                    smem_a.index(0),
+                    a_base_ptr,
+                    offs_a_i32,
+                    mask=token_mask[:, None],
+                )
+                cdna4_async_copy.commit_group()
+                cdna4_async_copy.buffer_load_to_shared(
+                    smem_a.index(1),
+                    a_base_ptr,
+                    offs_a_i32 + A_DATA_K_STEP,
+                    mask=token_mask[:, None],
+                )
+                cdna4_async_copy.commit_group()
+
+                if not COALESCE_SCALES:
+                    a_k_iter0 = a_k_lanes
+                    a_k_part0 = (
+                        (a_k_iter0 // 8) * 256
+                        + (a_k_iter0 % 4) * 64
+                        + ((a_k_iter0 % 8) // 4) * 2
+                    )[None, :]
+                    a_scale0 = gl.amd.cdna4.buffer_load(
+                        ptr=a_scales_ptr, offsets=a_m_part + a_k_part0
+                    )
+                b0_c0 = gl.amd.cdna4.buffer_load(ptr=b_base_ptr, offsets=offs_b_c0)
+                b0_c1 = gl.amd.cdna4.buffer_load(ptr=b_base_ptr, offsets=offs_b_c1)
+                b0_c2 = gl.amd.cdna4.buffer_load(ptr=b_base_ptr, offsets=offs_b_c2)
+                b0_c3 = gl.amd.cdna4.buffer_load(ptr=b_base_ptr, offsets=offs_b_c3)
+                if not COALESCE_SCALES:
+                    bsc_k_iter0 = b_k_lanes
+                    bsc_k_off0 = (
+                        (bsc_k_iter0 // 8) * 256
+                        + (bsc_k_iter0 % 4) * 64
+                        + ((bsc_k_iter0 % 8) // 4) * 2
+                    )[None, :]
+                    b_scale0_c0 = gl.amd.cdna4.buffer_load(
+                        ptr=b_scale_base, offsets=b_n_scale_part_c0 + bsc_k_off0
+                    )
+                    b_scale0_c1 = gl.amd.cdna4.buffer_load(
+                        ptr=b_scale_base, offsets=b_n_scale_part_c1 + bsc_k_off0
+                    )
+                    b_scale0_c2 = gl.amd.cdna4.buffer_load(
+                        ptr=b_scale_base, offsets=b_n_scale_part_c2 + bsc_k_off0
+                    )
+                    b_scale0_c3 = gl.amd.cdna4.buffer_load(
+                        ptr=b_scale_base, offsets=b_n_scale_part_c3 + bsc_k_off0
+                    )
+
+                if not COALESCE_SCALES:
+                    a_k_iter1 = BLOCK_K_SCALE + a_k_lanes
+                    a_k_part1 = (
+                        (a_k_iter1 // 8) * 256
+                        + (a_k_iter1 % 4) * 64
+                        + ((a_k_iter1 % 8) // 4) * 2
+                    )[None, :]
+                    a_scale1 = gl.amd.cdna4.buffer_load(
+                        ptr=a_scales_ptr, offsets=a_m_part + a_k_part1
+                    )
+                b1_c0 = gl.amd.cdna4.buffer_load(
+                    ptr=b_base_ptr, offsets=offs_b_c0 + B_DATA_K_STEP1
+                )
+                b1_c1 = gl.amd.cdna4.buffer_load(
+                    ptr=b_base_ptr, offsets=offs_b_c1 + B_DATA_K_STEP1
+                )
+                b1_c2 = gl.amd.cdna4.buffer_load(
+                    ptr=b_base_ptr, offsets=offs_b_c2 + B_DATA_K_STEP1
+                )
+                b1_c3 = gl.amd.cdna4.buffer_load(
+                    ptr=b_base_ptr, offsets=offs_b_c3 + B_DATA_K_STEP1
+                )
+                if not COALESCE_SCALES:
+                    bsc_k_iter1 = BLOCK_K_SCALE + b_k_lanes
+                    bsc_k_off1 = (
+                        (bsc_k_iter1 // 8) * 256
+                        + (bsc_k_iter1 % 4) * 64
+                        + ((bsc_k_iter1 % 8) // 4) * 2
+                    )[None, :]
+                    b_scale1_c0 = gl.amd.cdna4.buffer_load(
+                        ptr=b_scale_base, offsets=b_n_scale_part_c0 + bsc_k_off1
+                    )
+                    b_scale1_c1 = gl.amd.cdna4.buffer_load(
+                        ptr=b_scale_base, offsets=b_n_scale_part_c1 + bsc_k_off1
+                    )
+                    b_scale1_c2 = gl.amd.cdna4.buffer_load(
+                        ptr=b_scale_base, offsets=b_n_scale_part_c2 + bsc_k_off1
+                    )
+                    b_scale1_c3 = gl.amd.cdna4.buffer_load(
+                        ptr=b_scale_base, offsets=b_n_scale_part_c3 + bsc_k_off1
+                    )
+
+                if COALESCE_SCALES:
+                    # One coalesced full-N, full-K B-scale load via a 4D
+                    # [n7, n6, n_lo=n%64, k] layout (clean per-axis atoms; the
+                    # contiguous byte pair straddles two N-chunks so this must be
+                    # a single full-N load), then convert to the full operand
+                    # layout and slice into the 4 chunks x 2 K-iters. Registers =
+                    # {n6->+1, k2->+2, n0->+4} (address order) -> dwordx2; n4,n5
+                    # map to the N warps. Requires BLOCK_N == 256 (caller-gated).
+                    gload_b4d: gl.constexpr = gl.DistributedLinearLayout(
+                        reg_bases=[[0, 1, 0, 0], [0, 0, 0, 4], [0, 0, 1, 0]],
+                        lane_bases=[
+                            [1, 0, 0, 0],
+                            [0, 0, 2, 0],
+                            [0, 0, 4, 0],
+                            [0, 0, 8, 0],
+                            [0, 0, 0, 1],
+                            [0, 0, 0, 2],
+                        ],
+                        warp_bases=[[0, 0, 16, 0], [0, 0, 32, 0]],
+                        block_bases=[],
+                        shape=[BLOCK_N // 128, 2, 64, BLOCK_K_SCALE_FULL],
+                    )
+                    l_bn7: gl.constexpr = gl.SliceLayout(
+                        1, gl.SliceLayout(2, gl.SliceLayout(3, gload_b4d))
+                    )
+                    l_bn6: gl.constexpr = gl.SliceLayout(
+                        0, gl.SliceLayout(2, gl.SliceLayout(3, gload_b4d))
+                    )
+                    l_bnlo: gl.constexpr = gl.SliceLayout(
+                        0, gl.SliceLayout(1, gl.SliceLayout(3, gload_b4d))
+                    )
+                    l_bk: gl.constexpr = gl.SliceLayout(
+                        0, gl.SliceLayout(1, gl.SliceLayout(2, gload_b4d))
+                    )
+                    bn7 = gl.arange(0, BLOCK_N // 128, layout=l_bn7).to(gl.uint32)
+                    bn6 = gl.arange(0, 2, layout=l_bn6).to(gl.uint32)
+                    bnlo = gl.arange(0, 64, layout=l_bnlo).to(gl.uint32)
+                    bk = gl.arange(0, BLOCK_K_SCALE_FULL, layout=l_bk).to(gl.uint32)
+                    n7abs = pid_n * (BLOCK_N // 128) + bn7
+                    boff4d = (
+                        n7abs[:, None, None, None] * (stride_se_n_pad * 128)
+                        + bn6[None, :, None, None]
+                        + (bnlo * 4)[None, None, :, None]
+                        + ((bk % 4) * 256 + (bk // 4) * 2)[None, None, None, :]
+                    )
+                    b_all = gl.amd.cdna4.buffer_load(ptr=b_scale_base, offsets=boff4d)
+                    b_all = gl.reshape(b_all, [BLOCK_N, BLOCK_K_SCALE_FULL])
+                    b_all = gl.convert_layout(b_all, b_scale_layout_full)
+                    b_all = gl.reshape(b_all, [BLOCK_N, 2, BLOCK_K_SCALE])
+                    b_all = gl.permute(b_all, [0, 2, 1])
+                    b_it0, b_it1 = gl.split(b_all)
+                    t0 = gl.permute(
+                        gl.reshape(b_it0, [BLOCK_N // 128, 2, 64, BLOCK_K_SCALE]),
+                        [2, 3, 0, 1],
+                    )
+                    t0a, t0b = gl.split(t0)
+                    b_scale0_c0, b_scale0_c2 = gl.split(t0a)
+                    b_scale0_c1, b_scale0_c3 = gl.split(t0b)
+                    t1 = gl.permute(
+                        gl.reshape(b_it1, [BLOCK_N // 128, 2, 64, BLOCK_K_SCALE]),
+                        [2, 3, 0, 1],
+                    )
+                    t1a, t1b = gl.split(t1)
+                    b_scale1_c0, b_scale1_c2 = gl.split(t1a)
+                    b_scale1_c1, b_scale1_c3 = gl.split(t1b)
+                    b_scale0_c0 = gl.convert_layout(b_scale0_c0, b_scale_layout_chunk)
+                    b_scale0_c1 = gl.convert_layout(b_scale0_c1, b_scale_layout_chunk)
+                    b_scale0_c2 = gl.convert_layout(b_scale0_c2, b_scale_layout_chunk)
+                    b_scale0_c3 = gl.convert_layout(b_scale0_c3, b_scale_layout_chunk)
+                    b_scale1_c0 = gl.convert_layout(b_scale1_c0, b_scale_layout_chunk)
+                    b_scale1_c1 = gl.convert_layout(b_scale1_c1, b_scale_layout_chunk)
+                    b_scale1_c2 = gl.convert_layout(b_scale1_c2, b_scale_layout_chunk)
+                    b_scale1_c3 = gl.convert_layout(b_scale1_c3, b_scale_layout_chunk)
+
+                cdna4_async_copy.wait_group(1)
+                a0 = cdna4_async_copy.load_shared_relaxed(smem_a.index(0), dot_a_layout)
+                acc0 = gl.amd.cdna4.mfma_scaled(
+                    a=a0,
+                    a_scale=a_scale0,
+                    a_format="e2m1",
+                    b=b0_c0,
+                    b_scale=b_scale0_c0,
+                    b_format="e2m1",
+                    acc=acc0,
+                )
+                acc1 = gl.amd.cdna4.mfma_scaled(
+                    a=a0,
+                    a_scale=a_scale0,
+                    a_format="e2m1",
+                    b=b0_c1,
+                    b_scale=b_scale0_c1,
+                    b_format="e2m1",
+                    acc=acc1,
+                )
+                acc2 = gl.amd.cdna4.mfma_scaled(
+                    a=a0,
+                    a_scale=a_scale0,
+                    a_format="e2m1",
+                    b=b0_c2,
+                    b_scale=b_scale0_c2,
+                    b_format="e2m1",
+                    acc=acc2,
+                )
+                acc3 = gl.amd.cdna4.mfma_scaled(
+                    a=a0,
+                    a_scale=a_scale0,
+                    a_format="e2m1",
+                    b=b0_c3,
+                    b_scale=b_scale0_c3,
+                    b_format="e2m1",
+                    acc=acc3,
+                )
+
+                # Hoist routed-weight load while tile-1 A/MFMA work is still pending.
+                # The value is consumed after the second MFMA, but issuing the HBM load
+                # here gives it the A1 wait and second MFMA block to arrive.
+                cm_layout: gl.constexpr = gl.SliceLayout(1, mfma_layout)
+                offs_cm = pid_m * BLOCK_M + gl.arange(0, BLOCK_M, layout=cm_layout)
+                # buffer_load (SRD) -- see prologue comment. offs_cm < EM always
+                # (BLOCK_M-aligned EM); padding-row weights are gated by tok_ok in
+                # the store, so no runtime mask/other is needed.
+                moe_weight = gl.amd.cdna4.buffer_load(
+                    ptr=sorted_weights_ptr,
+                    offsets=offs_cm,
+                )
+
+                # Set up the epilogue layout + per-chunk pointer arithmetic
+                # BEFORE the K-iter 1 MFMAs so the ``sorted_token_ids`` reload
+                # and column-offset compute land in flight while the second
+                # MFMA tile runs. Per-chunk epilogue work is then emitted
+                # IMMEDIATELY after each chunk's final MFMA below, so the
+                # convert + LDS-shuffle + store of chunk i hides behind the
+                # MFMA of chunk i+1.
+                #
+                # ``store_layout`` shape per chunk = [128, 64] across
+                # the 4-wave CTA. We choose ``warps_per_cta=[4, 1]``
+                # (waves split M, not N like the MFMA layout) so the
+                # convert_layout LDS shuffle redistributes data such
+                # that within one wave the N axis is contiguous and
+                # each lane can own 8 N-cols = one dwordx4. Per wave:
+                # 32 M-rows x 64 N-cols, with 8 M-lanes x 8 N-lanes,
+                # each lane owning [4 M, 8 N] = 4 dwordx4 stores per
+                # chunk. Per simultaneous-store iteration: 8 M-rows hit
+                # 16 cache lines (8 rows x 2 lines per 64-col row),
+                # vs the 32+ rows the in-place wide layouts hit.
+                if MFMA_STORE_LAYOUT:
+                    # Small-M atomic A/B path: keep the accumulator's MFMA
+                    # layout through the store to avoid the convert_layout
+                    # LDS shuffle/barrier tax.  Stores are less coalesced, so
+                    # reduce mode keeps the coalesced C-shuffle layout because
+                    # the launcher pairs MFMA-store layout with atomic mode.
+                    store_layout: gl.constexpr = mfma_layout
+                else:
+                    store_layout: gl.constexpr = gl.BlockedLayout(
+                        size_per_thread=[4, 8],
+                        threads_per_warp=[8, 8],
+                        warps_per_cta=[4, 1],
+                        order=[1, 0],
+                    )
+                sm_layout: gl.constexpr = gl.SliceLayout(1, store_layout)
+                sn_layout: gl.constexpr = gl.SliceLayout(0, store_layout)
+                offs_sorted_slot_s = pid_m * BLOCK_M + gl.arange(
+                    0, BLOCK_M, layout=sm_layout
+                )
+                # buffer_load (SRD) for the store-layout reload. Same invariant as
+                # the prologue gather: offs < EM always, sentinel + tok_ok handle
+                # padding, so no runtime mask/other.
+                offs_token_s = gl.amd.cdna4.buffer_load(
+                    ptr=sorted_token_ids_ptr,
+                    offsets=offs_sorted_slot_s,
+                )
+                token_id_s = offs_token_s & 0xFFFFFF
+                topk_id_s = offs_token_s >> 24
+                if USE_REDUCE:
+                    dst_row_s = token_id_s * top_k + topk_id_s
+                else:
+                    dst_row_s = token_id_s
+                offs_cn_chunk = pid_n * BLOCK_N + gl.arange(
+                    0, BLOCK_N_CHUNK, layout=sn_layout
+                )
+                cn0 = offs_cn_chunk + 0 * BLOCK_N_CHUNK
+                cn1 = offs_cn_chunk + 1 * BLOCK_N_CHUNK
+                cn2 = offs_cn_chunk + 2 * BLOCK_N_CHUNK
+                cn3 = offs_cn_chunk + 3 * BLOCK_N_CHUNK
+                p0 = (
+                    c_ptr
+                    + dst_row_s[:, None].to(gl.int64) * stride_cm
+                    + cn0[None, :].to(gl.int64) * stride_cn
+                )
+                p1 = (
+                    c_ptr
+                    + dst_row_s[:, None].to(gl.int64) * stride_cm
+                    + cn1[None, :].to(gl.int64) * stride_cn
+                )
+                p2 = (
+                    c_ptr
+                    + dst_row_s[:, None].to(gl.int64) * stride_cm
+                    + cn2[None, :].to(gl.int64) * stride_cn
+                )
+                p3 = (
+                    c_ptr
+                    + dst_row_s[:, None].to(gl.int64) * stride_cm
+                    + cn3[None, :].to(gl.int64) * stride_cn
+                )
+                # N-mask (cn_i < N) elided: the partials buffer is exactly
+                # [token_num, topk, N] and BLOCK_N divides N for our DSv3 /
+                # Kimi shapes, so every chunk column is in-bounds. Keeping
+                # the per-element N check would block dword->dwordx4 store
+                # vectorisation because the compiler can't prove uniformity.
+                # Token-row validity is kept -- padded rows have
+                # token_id == num_valid_tokens >= token_num.
+                tok_ok = token_id_s[:, None] < token_num
+                m0 = tok_ok
+                m1 = tok_ok
+                m2 = tok_ok
+                m3 = tok_ok
+
+                cdna4_async_copy.wait_group(0)
+                a1 = cdna4_async_copy.load_shared_relaxed(smem_a.index(1), dot_a_layout)
+
+                if DEFER_EPILOGUE:
+                    # FlyDSL-like: run the K-iter-1 MFMAs as one uninterrupted
+                    # cluster, then do the whole epilogue in a single phase. The
+                    # unbroken MFMA cluster keeps the matrix pipe fed (~3.6%
+                    # faster than the per-chunk interleave; bit-exact).
+                    acc0 = gl.amd.cdna4.mfma_scaled(
+                        a=a1,
+                        a_scale=a_scale1,
+                        a_format="e2m1",
+                        b=b1_c0,
+                        b_scale=b_scale1_c0,
+                        b_format="e2m1",
+                        acc=acc0,
+                    )
+                    acc1 = gl.amd.cdna4.mfma_scaled(
+                        a=a1,
+                        a_scale=a_scale1,
+                        a_format="e2m1",
+                        b=b1_c1,
+                        b_scale=b_scale1_c1,
+                        b_format="e2m1",
+                        acc=acc1,
+                    )
+                    acc2 = gl.amd.cdna4.mfma_scaled(
+                        a=a1,
+                        a_scale=a_scale1,
+                        a_format="e2m1",
+                        b=b1_c2,
+                        b_scale=b_scale1_c2,
+                        b_format="e2m1",
+                        acc=acc2,
+                    )
+                    acc3 = gl.amd.cdna4.mfma_scaled(
+                        a=a1,
+                        a_scale=a_scale1,
+                        a_format="e2m1",
+                        b=b1_c3,
+                        b_scale=b_scale1_c3,
+                        b_format="e2m1",
+                        acc=acc3,
+                    )
+                    if K_PACKED_TOTAL > 2 * BLOCK_K_PACKED:
+                        # Kimi TP4 stage2 has logical K=512.  The original
+                        # production body above covers the first K=256
+                        # (two K=128 scaled-MFMA subtiles); accumulate the
+                        # second K=256 pair before the epilogue.  The host
+                        # wrapper gates this path to direct-scale loads for
+                        # now; the coalesced full-K scale loader is currently
+                        # specialized to one K=256 pair.
+                        cdna4_async_copy.buffer_load_to_shared(
+                            smem_a.index(0),
+                            a_base_ptr,
+                            offs_a_i32 + 2 * A_DATA_K_STEP,
+                            mask=token_mask[:, None],
+                        )
+                        cdna4_async_copy.commit_group()
+                        cdna4_async_copy.buffer_load_to_shared(
+                            smem_a.index(1),
+                            a_base_ptr,
+                            offs_a_i32 + 3 * A_DATA_K_STEP,
+                            mask=token_mask[:, None],
+                        )
+                        cdna4_async_copy.commit_group()
+
+                        a_k_iter2 = 2 * BLOCK_K_SCALE + a_k_lanes
+                        a_k_part2 = (
+                            (a_k_iter2 // 8) * 256
+                            + (a_k_iter2 % 4) * 64
+                            + ((a_k_iter2 % 8) // 4) * 2
+                        )[None, :]
+                        a_scale2 = gl.amd.cdna4.buffer_load(
+                            ptr=a_scales_ptr, offsets=a_m_part + a_k_part2
+                        )
+                        b2_c0 = gl.amd.cdna4.buffer_load(
+                            ptr=b_base_ptr, offsets=offs_b_c0 + B_DATA_K_STEP2
+                        )
+                        b2_c1 = gl.amd.cdna4.buffer_load(
+                            ptr=b_base_ptr, offsets=offs_b_c1 + B_DATA_K_STEP2
+                        )
+                        b2_c2 = gl.amd.cdna4.buffer_load(
+                            ptr=b_base_ptr, offsets=offs_b_c2 + B_DATA_K_STEP2
+                        )
+                        b2_c3 = gl.amd.cdna4.buffer_load(
+                            ptr=b_base_ptr, offsets=offs_b_c3 + B_DATA_K_STEP2
+                        )
+                        bsc_k_iter2 = 2 * BLOCK_K_SCALE + b_k_lanes
+                        bsc_k_off2 = (
+                            (bsc_k_iter2 // 8) * 256
+                            + (bsc_k_iter2 % 4) * 64
+                            + ((bsc_k_iter2 % 8) // 4) * 2
+                        )[None, :]
+                        b_scale2_c0 = gl.amd.cdna4.buffer_load(
+                            ptr=b_scale_base, offsets=b_n_scale_part_c0 + bsc_k_off2
+                        )
+                        b_scale2_c1 = gl.amd.cdna4.buffer_load(
+                            ptr=b_scale_base, offsets=b_n_scale_part_c1 + bsc_k_off2
+                        )
+                        b_scale2_c2 = gl.amd.cdna4.buffer_load(
+                            ptr=b_scale_base, offsets=b_n_scale_part_c2 + bsc_k_off2
+                        )
+                        b_scale2_c3 = gl.amd.cdna4.buffer_load(
+                            ptr=b_scale_base, offsets=b_n_scale_part_c3 + bsc_k_off2
+                        )
+
+                        a_k_iter3 = 3 * BLOCK_K_SCALE + a_k_lanes
+                        a_k_part3 = (
+                            (a_k_iter3 // 8) * 256
+                            + (a_k_iter3 % 4) * 64
+                            + ((a_k_iter3 % 8) // 4) * 2
+                        )[None, :]
+                        a_scale3 = gl.amd.cdna4.buffer_load(
+                            ptr=a_scales_ptr, offsets=a_m_part + a_k_part3
+                        )
+                        b3_c0 = gl.amd.cdna4.buffer_load(
+                            ptr=b_base_ptr, offsets=offs_b_c0 + B_DATA_K_STEP3
+                        )
+                        b3_c1 = gl.amd.cdna4.buffer_load(
+                            ptr=b_base_ptr, offsets=offs_b_c1 + B_DATA_K_STEP3
+                        )
+                        b3_c2 = gl.amd.cdna4.buffer_load(
+                            ptr=b_base_ptr, offsets=offs_b_c2 + B_DATA_K_STEP3
+                        )
+                        b3_c3 = gl.amd.cdna4.buffer_load(
+                            ptr=b_base_ptr, offsets=offs_b_c3 + B_DATA_K_STEP3
+                        )
+                        bsc_k_iter3 = 3 * BLOCK_K_SCALE + b_k_lanes
+                        bsc_k_off3 = (
+                            (bsc_k_iter3 // 8) * 256
+                            + (bsc_k_iter3 % 4) * 64
+                            + ((bsc_k_iter3 % 8) // 4) * 2
+                        )[None, :]
+                        b_scale3_c0 = gl.amd.cdna4.buffer_load(
+                            ptr=b_scale_base, offsets=b_n_scale_part_c0 + bsc_k_off3
+                        )
+                        b_scale3_c1 = gl.amd.cdna4.buffer_load(
+                            ptr=b_scale_base, offsets=b_n_scale_part_c1 + bsc_k_off3
+                        )
+                        b_scale3_c2 = gl.amd.cdna4.buffer_load(
+                            ptr=b_scale_base, offsets=b_n_scale_part_c2 + bsc_k_off3
+                        )
+                        b_scale3_c3 = gl.amd.cdna4.buffer_load(
+                            ptr=b_scale_base, offsets=b_n_scale_part_c3 + bsc_k_off3
+                        )
+
+                        cdna4_async_copy.wait_group(1)
+                        a2 = cdna4_async_copy.load_shared_relaxed(
+                            smem_a.index(0), dot_a_layout
+                        )
+                        acc0 = gl.amd.cdna4.mfma_scaled(
+                            a=a2,
+                            a_scale=a_scale2,
+                            a_format="e2m1",
+                            b=b2_c0,
+                            b_scale=b_scale2_c0,
+                            b_format="e2m1",
+                            acc=acc0,
+                        )
+                        acc1 = gl.amd.cdna4.mfma_scaled(
+                            a=a2,
+                            a_scale=a_scale2,
+                            a_format="e2m1",
+                            b=b2_c1,
+                            b_scale=b_scale2_c1,
+                            b_format="e2m1",
+                            acc=acc1,
+                        )
+                        acc2 = gl.amd.cdna4.mfma_scaled(
+                            a=a2,
+                            a_scale=a_scale2,
+                            a_format="e2m1",
+                            b=b2_c2,
+                            b_scale=b_scale2_c2,
+                            b_format="e2m1",
+                            acc=acc2,
+                        )
+                        acc3 = gl.amd.cdna4.mfma_scaled(
+                            a=a2,
+                            a_scale=a_scale2,
+                            a_format="e2m1",
+                            b=b2_c3,
+                            b_scale=b_scale2_c3,
+                            b_format="e2m1",
+                            acc=acc3,
+                        )
+                        cdna4_async_copy.wait_group(0)
+                        a3 = cdna4_async_copy.load_shared_relaxed(
+                            smem_a.index(1), dot_a_layout
+                        )
+                        acc0 = gl.amd.cdna4.mfma_scaled(
+                            a=a3,
+                            a_scale=a_scale3,
+                            a_format="e2m1",
+                            b=b3_c0,
+                            b_scale=b_scale3_c0,
+                            b_format="e2m1",
+                            acc=acc0,
+                        )
+                        acc1 = gl.amd.cdna4.mfma_scaled(
+                            a=a3,
+                            a_scale=a_scale3,
+                            a_format="e2m1",
+                            b=b3_c1,
+                            b_scale=b_scale3_c1,
+                            b_format="e2m1",
+                            acc=acc1,
+                        )
+                        acc2 = gl.amd.cdna4.mfma_scaled(
+                            a=a3,
+                            a_scale=a_scale3,
+                            a_format="e2m1",
+                            b=b3_c2,
+                            b_scale=b_scale3_c2,
+                            b_format="e2m1",
+                            acc=acc2,
+                        )
+                        acc3 = gl.amd.cdna4.mfma_scaled(
+                            a=a3,
+                            a_scale=a_scale3,
+                            a_format="e2m1",
+                            b=b3_c3,
+                            b_scale=b_scale3_c3,
+                            b_format="e2m1",
+                            acc=acc3,
+                        )
+                    # Match the reference combine epilogue ordering: round the GEMM
+                    # accumulator to bf16 first, then multiply by the bf16
+                    # routed weight. Multiplying in fp32 and rounding once at
+                    # the end changes near-zero values by one or two bf16 ULPs.
+                    c0 = acc0.to(c_ptr.type.element_ty)
+                    c1 = acc1.to(c_ptr.type.element_ty)
+                    c2 = acc2.to(c_ptr.type.element_ty)
+                    c3 = acc3.to(c_ptr.type.element_ty)
+                    routed_weight = moe_weight[:, None].to(c0.dtype)
+                    c0_co = gl.convert_layout(c0 * routed_weight, store_layout)
+                    c1_co = gl.convert_layout(c1 * routed_weight, store_layout)
+                    c2_co = gl.convert_layout(c2 * routed_weight, store_layout)
+                    c3_co = gl.convert_layout(c3 * routed_weight, store_layout)
+                    if USE_REDUCE:
+                        # ``.cs`` (cache-streaming) on the partials write: the
+                        # reduce kernel reads each cell exactly once.
+                        gl.store(p0, c0_co, mask=m0, cache_modifier=".cs")
+                        gl.store(p1, c1_co, mask=m1, cache_modifier=".cs")
+                        gl.store(p2, c2_co, mask=m2, cache_modifier=".cs")
+                        gl.store(p3, c3_co, mask=m3, cache_modifier=".cs")
+                    else:
+                        gl.atomic_add(p0, c0_co, mask=m0, sem="relaxed")
+                        gl.atomic_add(p1, c1_co, mask=m1, sem="relaxed")
+                        gl.atomic_add(p2, c2_co, mask=m2, sem="relaxed")
+                        gl.atomic_add(p3, c3_co, mask=m3, sem="relaxed")
+                else:
+                    # K-iter 1 MFMAs and the chunked epilogue interleaved per
+                    # chunk: ``mfma(chunk_i)`` -> ``cvt + store(chunk_i)`` -> ...
+                    acc0 = gl.amd.cdna4.mfma_scaled(
+                        a=a1,
+                        a_scale=a_scale1,
+                        a_format="e2m1",
+                        b=b1_c0,
+                        b_scale=b_scale1_c0,
+                        b_format="e2m1",
+                        acc=acc0,
+                    )
+                    c0 = acc0.to(c_ptr.type.element_ty)
+                    c0 = c0 * moe_weight[:, None].to(c0.dtype)
+                    c0_co = gl.convert_layout(c0, store_layout)
+                    if USE_REDUCE:
+                        gl.store(p0, c0_co, mask=m0, cache_modifier=".cs")
+                    else:
+                        gl.atomic_add(p0, c0_co, mask=m0, sem="relaxed")
+
+                    acc1 = gl.amd.cdna4.mfma_scaled(
+                        a=a1,
+                        a_scale=a_scale1,
+                        a_format="e2m1",
+                        b=b1_c1,
+                        b_scale=b_scale1_c1,
+                        b_format="e2m1",
+                        acc=acc1,
+                    )
+                    c1 = acc1.to(c_ptr.type.element_ty)
+                    c1 = c1 * moe_weight[:, None].to(c1.dtype)
+                    c1_co = gl.convert_layout(c1, store_layout)
+                    if USE_REDUCE:
+                        gl.store(p1, c1_co, mask=m1, cache_modifier=".cs")
+                    else:
+                        gl.atomic_add(p1, c1_co, mask=m1, sem="relaxed")
+
+                    acc2 = gl.amd.cdna4.mfma_scaled(
+                        a=a1,
+                        a_scale=a_scale1,
+                        a_format="e2m1",
+                        b=b1_c2,
+                        b_scale=b_scale1_c2,
+                        b_format="e2m1",
+                        acc=acc2,
+                    )
+                    c2 = acc2.to(c_ptr.type.element_ty)
+                    c2 = c2 * moe_weight[:, None].to(c2.dtype)
+                    c2_co = gl.convert_layout(c2, store_layout)
+                    if USE_REDUCE:
+                        gl.store(p2, c2_co, mask=m2, cache_modifier=".cs")
+                    else:
+                        gl.atomic_add(p2, c2_co, mask=m2, sem="relaxed")
+
+                    acc3 = gl.amd.cdna4.mfma_scaled(
+                        a=a1,
+                        a_scale=a_scale1,
+                        a_format="e2m1",
+                        b=b1_c3,
+                        b_scale=b_scale1_c3,
+                        b_format="e2m1",
+                        acc=acc3,
+                    )
+                    c3 = acc3.to(c_ptr.type.element_ty)
+                    c3 = c3 * moe_weight[:, None].to(c3.dtype)
+                    c3_co = gl.convert_layout(c3, store_layout)
+                    if USE_REDUCE:
+                        gl.store(p3, c3_co, mask=m3, cache_modifier=".cs")
+                    else:
+                        gl.atomic_add(p3, c3_co, mask=m3, sem="relaxed")
+
+
+# ---------------------------------------------------------------------------
+# Reduce kernel (sums [token, topk, N] -> [token, N], fp32 accumulate)
+# ---------------------------------------------------------------------------
+
+
+@gluon.jit
+def gluon_mxfp4_moe_stage2_reduce_kernel(
+    partials_ptr,  # bf16, shape [token_num, topk, N], contiguous
+    out_ptr,  # bf16, shape [token_num, N]
+    token_num,
+    N,
+    top_k,
+    stride_pt,  # partials: stride for token dim = topk * N
+    stride_ps,  # partials: stride for slot  dim = N
+    stride_pn,  # partials: stride for col   dim = 1
+    stride_ot,
+    stride_on,
+    BLOCK_M: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    TOP_K: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+):
+    """Sum per-(token, slot) partials over the topk dim.
+
+    Grid: ``(cdiv(token_num, BLOCK_M) * cdiv(N, BLOCK_N),)``. Each CTA
+    owns a ``[BLOCK_M, BLOCK_N]`` tile of the output and reads
+    ``TOP_K`` slices from the partial buffer, accumulating in fp32 and
+    casting back to bf16 at the end. ``TOP_K`` is a constexpr so the
+    accumulation loop unrolls (TOP_K is small: 4-10 across the models
+    we serve).
+    """
+    pid = gl.program_id(axis=0)
+    num_pid_n = gl.cdiv(N, BLOCK_N)
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
+
+    # Plain blocked layout for the bf16 tile. 1 wave / CTA, NUM_WARPS=1.
+    blk: gl.constexpr = gl.BlockedLayout(
+        size_per_thread=[1, 8],
+        threads_per_warp=[16, 4],
+        warps_per_cta=[1, 1],
+        order=[1, 0],
+    )
+    rm_layout: gl.constexpr = gl.SliceLayout(1, blk)
+    cn_layout: gl.constexpr = gl.SliceLayout(0, blk)
+    offs_m = pid_m * BLOCK_M + gl.arange(0, BLOCK_M, layout=rm_layout)
+    offs_n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=cn_layout)
+    m_mask = (offs_m[:, None] < token_num) & (offs_n[None, :] < N)
+
+    acc = gl.zeros([BLOCK_M, BLOCK_N], dtype=gl.float32, layout=blk)
+    base = (
+        partials_ptr
+        + offs_m[:, None].to(gl.int64) * stride_pt
+        + offs_n[None, :].to(gl.int64) * stride_pn
+    )
+    for s in gl.static_range(0, TOP_K):
+        p = base + s * stride_ps
+        v = gl.load(p, mask=m_mask, other=0.0)
+        acc += v.to(gl.float32)
+
+    out_ptrs = (
+        out_ptr
+        + offs_m[:, None].to(gl.int64) * stride_ot
+        + offs_n[None, :].to(gl.int64) * stride_on
+    )
+    gl.store(out_ptrs, acc.to(out_ptr.type.element_ty), mask=m_mask)
+
+
+# ---------------------------------------------------------------------------
+# Wrapper
+# ---------------------------------------------------------------------------
+
+
+def _record_atomic_lowering() -> None:
+    global _USES_FP32_ATOMIC
+    try:
+        kf = gluon_mxfp4_moe_stage2_1x2_kernel
+        for cache_tuple in getattr(kf, "device_caches", {}).values():
+            kernel_cache = cache_tuple[0]
+            for compiled in kernel_cache.values():
+                asm = getattr(compiled, "asm", None)
+                if asm is None or "amdgcn" not in asm:
+                    continue
+                amdgcn = asm["amdgcn"]
+                if "pk_add_bf16" in amdgcn:
+                    _USES_FP32_ATOMIC = False
+                    return
+                # ``pk_add_bf16`` was ruled out above, so any remaining
+                # ``atomic_add_f32`` is a true fp32 atomic lowering.
+                if "atomic_add_f32" in amdgcn:
+                    _USES_FP32_ATOMIC = True
+                    return
+    except Exception:
+        return
+
+
+def invoke_gluon_mxfp4_moe_stage2_1x2(
+    inter_states,
+    w1,
+    w2,
+    sorted_token_ids,
+    sorted_expert_ids,
+    num_valid_ids,
+    out,
+    topk,
+    kernelName="",
+    w2_scale=None,
+    a2_scale=None,
+    block_m=None,
+    sort_block_m=None,
+    sorted_weights=None,
+    quant_type=None,
+    activation=None,
+    splitk=1,
+    use_non_temporal_load=False,
+    dst_type=None,
+    b_preshuffled: bool = False,
+    b_gdot128: bool = False,
+    force_reduce: bool | None = None,
+):
+    """Host-side launcher for Gluon MXFP4 MoE stage 2.
+
+    Computes, for each expert ``e``::
+
+        out_e += topk_w_e * (inter_e @ w2_e.T)
+
+    by launching the GEMM kernel followed, in reduce mode, by a small
+    reduce that sums each token's ``topk`` partial contributions into
+    ``out``. The wrapper can instead use the direct-atomic path for
+    small M, but the standalone Kimi comparison currently forces reduce
+    mode at M512 because this Gluon atomic epilogue is still slower.
+
+    Steps below correspond to the ``# Step N:`` comments in the body:
+      1. Validate inputs; reject unsupported modes.
+      2. Permute ``w2`` to the (16, 16) MFMA-tile layout (see
+         :func:`_b_preshuffle_3d`), or skip if the caller already did.
+      3. Flatten ``inter_states`` ``(token_num, topk, K_packed)`` to
+         ``(token_num * topk, K_packed)`` -- one row per (token, slot).
+      4. Allocate a ``(token_num, topk, N)`` bf16 ``partials`` scratch
+         only when reduce mode is selected.
+      5. Launch the GEMM. The per-CTA epilogue either writes
+         ``partials[token, slot]`` with plain stores or atomically adds
+         into ``out[token]``.
+      6. In reduce mode, launch the reduce kernel: sum over the
+         ``topk`` dim with fp32 accumulation, cast back to bf16 into
+         ``out``.
+
+    Layout contract:
+        inter_states : (token_num, topk, K_packed) uint8
+                       OR (M_padded, K_packed) uint8 (already flattened)
+        w2           : (E, D, I_r_packed) uint8 in MFMA-tile layout
+        a2_scale     : (M_padded_aligned, K // 32) uint8 e8m0
+        w2_scale     : (E, D, K // 32) uint8 e8m0
+        out          : (token_num, D) bf16 -- final per-token output
+        sorted_*     : generated with ``sort_block_m`` when it differs
+                       from compute ``block_m``; use 32/64/128 to mirror
+                       FlyDSL sort_block_m
+
+    Unsupported: ``quant_type`` and ``activation`` are signature
+    stubs (kernel does the down-projection with no activation);
+    ``splitk not in {0, 1, None}``; ``sorted_weights=None``.
+    """
+    global _USES_FP32_ATOMIC
+
+    # Step 1: validate inputs and reject unsupported modes.
+    del quant_type, activation  # signature stubs (no activation in stage 2)
+    if splitk not in (0, 1, None):
+        raise NotImplementedError(f"splitk in {{0, 1}} expected, got {splitk!r}")
+    if sorted_weights is None or sorted_weights.numel() == 0:
+        raise NotImplementedError("sorted_weights is REQUIRED for stage 2")
+    if dst_type is not None and dst_type != torch.bfloat16:
+        raise NotImplementedError(f"only dst_type=bfloat16 supported, got {dst_type!r}")
+    del kernelName, use_non_temporal_load, w1
+
+    assert inter_states.dtype == torch.uint8
+    assert w2.dtype == torch.uint8
+    # Step 2: shuffle w2 to MFMA-tile layout if the caller didn't.
+    if not b_preshuffled:
+        w2 = _b_preshuffle_3d(w2)
+    if b_gdot128 and not b_preshuffled:
+        raise ValueError("b_gdot128 requires a preshuffled gdot128 weight alias")
+    assert w2_scale is not None and w2_scale.dtype == torch.uint8
+    assert a2_scale is not None and a2_scale.dtype == torch.uint8
+    assert out.dtype == torch.bfloat16
+    assert sorted_token_ids.dtype == torch.int32
+    assert sorted_expert_ids.dtype == torch.int32
+    assert sorted_weights.dtype == torch.float32
+
+    # Step 3: flatten the (token, slot) axes so each row is one routed
+    # token-slot. Zero-copy via .view when inter_states is contiguous.
+    if inter_states.dim() == 3:
+        token_num_dim, top_k_dim, K_packed_3d = inter_states.shape
+        assert top_k_dim == topk
+        assert inter_states.is_contiguous()
+        inter_2d = inter_states.view(token_num_dim * topk, K_packed_3d)
+    elif inter_states.dim() == 2:
+        inter_2d = inter_states
+    else:
+        raise NotImplementedError(
+            f"inter_states must be 2-D or 3-D, got {tuple(inter_states.shape)}"
+        )
+    if out.dim() != 2:
+        raise NotImplementedError(f"stage 2 out must be 2-D, got {tuple(out.shape)}")
+    token_num = out.shape[0]
+    M_padded, I_r_packed = inter_2d.shape
+    K = I_r_packed * 2
+
+    assert w2.dim() == 3
+    E_w, D, I_r_packed_w = w2.shape
+    N = D
+    assert I_r_packed_w == I_r_packed
+    EM = sorted_token_ids.shape[0]
+    K_scale = K // 32
+    assert a2_scale.dim() == 2 and a2_scale.shape[1] == K_scale
+    assert w2_scale.shape == (E_w, N, K_scale)
+    assert sorted_weights.shape[0] == EM
+
+    # The kernel reads the valid extent from ``num_valid_ids_ptr`` on-device
+    # (``num_tokens_post_padded = gl.load(...)``), so the ``num_valid_tokens``
+    # scalar arg is vestigial. Avoid a device-to-host ``.item()`` sync here and
+    # pass a placeholder; the device pointer is the single source of truth.
+    if torch.is_tensor(num_valid_ids):
+        num_valid_tokens = 0
+        num_valid_ids_ptr = num_valid_ids
+    else:
+        num_valid_tokens = int(num_valid_ids)
+        num_valid_ids_ptr = torch.tensor(
+            [num_valid_tokens], dtype=torch.int32, device=inter_states.device
+        )
+
+    BLOCK_M = 128 if block_m is None else int(block_m)
+    if BLOCK_M not in (32, 64, 128):
+        raise NotImplementedError(
+            f"stage2 1x2 block_m must be one of 32, 64, 128; got {BLOCK_M}"
+        )
+    SORT_BLOCK_M = BLOCK_M if sort_block_m is None else int(sort_block_m)
+    if SORT_BLOCK_M not in (32, 64, 128) or SORT_BLOCK_M % BLOCK_M != 0:
+        raise NotImplementedError(
+            "stage2 1x2 sort_block_m must be one of 32, 64, 128 "
+            f"and divisible by block_m; got {SORT_BLOCK_M} for block_m={BLOCK_M}"
+        )
+    BLOCK_N = 256
+    BLOCK_K = 128
+    GROUP_SIZE_M = 1
+    NUM_WARPS = 4
+    assert K % BLOCK_K == 0, f"K ({K}) must be divisible by BLOCK_K ({BLOCK_K})"
+
+    num_pid_m = triton.cdiv(EM, BLOCK_M)
+    num_pid_n = triton.cdiv(N, BLOCK_N)
+    # Grid sizing. Persistent grid is off by default -- the persistent
+    # loop structure alone (without true cross-tile prefetch) doesn't
+    # win: at large M it shaves only ~3 % off stage 2 because L2 reuse
+    # benefits only kick in within one CTA's iterations and the first
+    # iter of each CTA is still cold; at small M it wastes most CTAs
+    # on no-op iterations. Re-enabled when a follow-up adds actual
+    # next-tile load overlap inside the per-tile body.
+    CU_NUM = 256
+    PERSISTENT_BLOCKS = CU_NUM
+    total_tiles_host = num_pid_m * num_pid_n
+    PERSISTENT = False
+    grid = (num_pid_n, PERSISTENT_BLOCKS) if PERSISTENT else (total_tiles_host,)
+
+    # The coalesced B-scale loader and the direct-scale layout still encode the
+    # legacy stage2-specific half-bit scale layout, so they stay off for the
+    # generic CDNA4/e8m0 scale contract used by the package/decode kernels.
+    COALESCE_SCALES = False
+    DIRECT_SCALE_LAYOUT = False
+    # Deferred epilogue (run the K-iter MFMAs as one cluster then a single
+    # epilogue phase) is ~3.6% faster and bit-exact, so it is always on.
+    DEFER_EPILOGUE = True
+
+    # Atomic vs reduce dispatch.
+    #
+    # At small M, the cross-slot reduce overhead (extra scratch write +
+    # separate reduce kernel launch) dominates: at M=16 the reduce alone
+    # is ~12 % of the stage 2 budget while reducing essentially nothing
+    # (each output row has at most a handful of contributors and the
+    # atomic_add path costs ~3-4 atomic_pk_add_bf16 per row instead).
+    #
+    # At large M the atomic_add path loses to scratch+reduce because
+    # M * topk concurrent atomic_pk_add_bf16 ops contend on the same
+    # output rows (the cost is in serialization at the HBM line, not
+    # the instruction).
+    #
+    # With FlyDSL-like smaller sort blocks, the reduce path is faster
+    # starting at M512: direct atomic avoids the reduce launch, but this
+    # Gluon epilogue still loses to topk-way output-row contention.
+    # Keep tiny/decode shapes on atomic and switch to scratch+reduce for
+    # M>=512. The ``force_reduce`` caller argument overrides the tuned default.
+    if force_reduce is not None:
+        _use_reduce = bool(force_reduce)
+    else:
+        _use_reduce = token_num >= 512
+    _mfma_store_layout = not _use_reduce
+
+    stride_am = inter_2d.stride(0)
+    stride_ak = inter_2d.stride(1)
+    stride_be = w2.stride(0)
+    stride_bn = w2.stride(1)
+    stride_bk = w2.stride(2)
+    stride_ase_m = a2_scale.stride(0)
+    stride_ase_k = a2_scale.stride(1)
+    stride_bse_e = w2_scale.stride(0)
+    stride_bse_n = w2_scale.stride(1)
+    stride_bse_k = w2_scale.stride(2)
+    stride_se_n_pad = a2_scale.shape[1]
+    K_packed_total = K // 2
+
+    if _use_reduce:
+        # Reduce path (large M): GEMM writes per-(token, slot) cells of
+        # a scratch tensor with plain stores (race-free, each cell has
+        # exactly one writer CTA), then a small reduce kernel sums the
+        # topk dim into `out` with fp32 accumulation.
+        partials = torch.empty(
+            (token_num, topk, N), dtype=torch.bfloat16, device=inter_states.device
+        )
+        c_ptr = partials
+        # M-row index into `partials` is the flattened (token, slot) row;
+        # row stride = topk * N // topk = N elements (one slot row).
+        c_stride_m = partials.stride(1)
+        c_stride_n = partials.stride(2)  # = 1
+    else:
+        # Atomic path (small M): GEMM atomic_add_pk_bf16's directly into
+        # `out`. Caller's `out` must be zero-initialised so the first
+        # accumulator lands on a clean slate. We zero it here -- one
+        # bf16 fill is cheap relative to skipping the scratch + reduce.
+        out.zero_()
+        c_ptr = out
+        c_stride_m = out.stride(0)
+        c_stride_n = out.stride(1)
+
+    # Step 5: GEMM. Writes either to `partials` (reduce mode) or directly
+    # to `out` (atomic mode), selected by ``USE_REDUCE``.
+    gluon_mxfp4_moe_stage2_1x2_kernel[grid](
+        inter_2d,
+        w2,
+        c_ptr,
+        a2_scale,
+        w2_scale,
+        sorted_token_ids,
+        sorted_expert_ids,
+        num_valid_ids_ptr,
+        sorted_weights,
+        N,
+        K,
+        EM,
+        num_valid_tokens,
+        token_num,
+        topk,
+        stride_am,
+        stride_ak,
+        stride_be,
+        stride_bn,
+        stride_bk,
+        c_stride_m,
+        c_stride_n,
+        stride_ase_m,
+        stride_ase_k,
+        stride_bse_e,
+        stride_bse_n,
+        stride_bse_k,
+        stride_se_n_pad,
+        K_PACKED_TOTAL=K_packed_total,
+        N_PHYS=N,
+        BLOCK_M=BLOCK_M,
+        SORT_BLOCK_M=SORT_BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        GROUP_SIZE_M=GROUP_SIZE_M,
+        NUM_WARPS=NUM_WARPS,
+        B_GDOT128=bool(b_gdot128),
+        USE_REDUCE=_use_reduce,
+        MFMA_STORE_LAYOUT=_mfma_store_layout,
+        PERSISTENT=PERSISTENT,
+        COALESCE_SCALES=COALESCE_SCALES,
+        DIRECT_SCALE_LAYOUT=DIRECT_SCALE_LAYOUT,
+        DEFER_EPILOGUE=DEFER_EPILOGUE,
+        # ``CU_NUM`` is the divisor for ``tiles_per_block`` in the
+        # persistent path. When PERSISTENT=False it is unused inside
+        # the kernel (branch is constexpr-pruned), so we keep it at the
+        # historical 256 in that case to avoid invalidating the cached
+        # binary for the small-M atomic dispatch.
+        CU_NUM=PERSISTENT_BLOCKS if PERSISTENT else 256,
+        num_warps=NUM_WARPS,
+    )
+
+    if _use_reduce:
+        # Step 6: reduce. Sum partials[token, :, n] over the topk dim
+        # (fp32 accumulate, bf16 output) into `out`. Tile (32, 256),
+        # 1 wave/CTA.
+        BLOCK_M_R = 16 if token_num >= 4096 else 32
+        BLOCK_N_R = 256
+        NUM_WARPS_R = 1
+        rgrid = (triton.cdiv(token_num, BLOCK_M_R) * triton.cdiv(N, BLOCK_N_R),)
+        gluon_mxfp4_moe_stage2_reduce_kernel[rgrid](
+            partials,
+            out,
+            token_num,
+            N,
+            topk,
+            partials.stride(0),
+            partials.stride(1),
+            partials.stride(2),
+            out.stride(0),
+            out.stride(1),
+            BLOCK_M=BLOCK_M_R,
+            BLOCK_N=BLOCK_N_R,
+            TOP_K=topk,
+            NUM_WARPS=NUM_WARPS_R,
+            num_warps=NUM_WARPS_R,
+        )
+    if _USES_FP32_ATOMIC is None:
+        _record_atomic_lowering()
+    return out

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/preprocess.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/preprocess.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""Model-load helpers for the gfx950 A4W4 MoE package.
+
+The package-prefill kernels consume the same gdot128-preshuffled weight storage
+that the decode/prefill stages use, but with the ``(E, N, K/2)`` /
+``(E, N, K/32)`` logical shapes. This module exposes ``attach_prefill_aliases``,
+which the top-level weight preprocessor calls once per layer to attach
+metadata-only views (``torch.as_strided``) of that storage onto the runtime
+weight tensors. The views share storage with the preshuffled weights -- no
+second model-sized copy is retained -- so attaching them is effectively free.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def _is_gdot128_weight(weight: torch.Tensor) -> bool:
+    """True if ``weight`` is a gdot128-preshuffled 3-D expert weight tensor."""
+    return weight.ndim == 3 and bool(
+        getattr(weight, "is_shuffled_for_gluon_dot", False)
+    )
+
+
+def _is_cdna4_scale(scale: torch.Tensor) -> bool:
+    """True if ``scale`` is a CDNA4-swizzled 3-D scale tensor."""
+    return scale.ndim == 3 and scale.stride(-2) == 1 and int(scale.shape[1]) % 32 == 0
+
+
+def _make_gdot128_weight_alias(weight: torch.Tensor) -> torch.Tensor:
+    """Expose gdot128 weight storage with the ``(E, N, K/2)`` logical shape.
+
+    This is a metadata-only alias. The package kernels use the
+    ``is_gdot128_shuffled`` marker to apply gdot128 byte addressing instead of
+    interpreting the storage as a 16x16 shuffle.
+    """
+    if weight.ndim != 3 or not bool(
+        getattr(weight, "is_shuffled_for_gluon_dot", False)
+    ):
+        raise ValueError("package prefill requires gdot128-preshuffled 3-D weights")
+    experts, k_packed, n_cols = map(int, weight.shape)
+    alias = torch.as_strided(
+        weight,
+        (experts, n_cols, k_packed),
+        (n_cols * k_packed, k_packed, 1),
+    )
+    if hasattr(torch, "float4_e2m1fn_x2"):
+        alias = alias.view(torch.float4_e2m1fn_x2)
+    alias.is_shuffled = True
+    alias.is_gdot128_shuffled = True
+    return alias
+
+
+def _make_gdot128_scale_alias(scale: torch.Tensor) -> torch.Tensor:
+    """Expose CDNA4-swizzled scales with the ``(E, N, K/32)`` logical shape."""
+    if scale.ndim != 3 or scale.stride(-2) != 1:
+        raise ValueError("package prefill requires CDNA4-swizzled 3-D scales")
+    experts, scale_linear, n_blocks = map(int, scale.shape)
+    if scale_linear % 32 != 0:
+        raise ValueError(f"invalid CDNA4 scale shape: {tuple(scale.shape)}")
+    n_cols = n_blocks * 32
+    k_scale = scale_linear // 32
+    return torch.as_strided(
+        scale,
+        (experts, n_cols, k_scale),
+        (n_cols * k_scale, k_scale, 1),
+    )
+
+
+def attach_prefill_aliases(
+    w: torch.nn.Module,
+    w13_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+) -> None:
+    """Attach zero-copy package-prefill weight/scale aliases onto ``w``.
+
+    Call once, after preshuffle has produced the gdot128 layout on
+    ``w.w13_weight_triton_tensor`` / ``w.w2_weight_triton_tensor``. The aliases
+    are metadata-only views over that existing storage, so this is free and
+    lets the flag toggle at runtime without a restart. The dynamic apply entry
+    reads these attributes off the runtime W tensors, so they are carried there.
+
+    Best-effort: the aliases are only attached when the weights are
+    gdot128-preshuffled 3-D tensors and the scales are CDNA4-swizzled. Models
+    whose weights are not in that layout are left untouched and fall back to the
+    reference path (the dynamic entry returns None without these aliases).
+
+    Args:
+        w: the MoE layer whose ``w13_weight_triton_tensor`` /
+            ``w2_weight_triton_tensor`` were gdot128-preshuffled.
+        w13_scale: swizzled CDNA4 gate/up scale tensor.
+        w2_scale: swizzled CDNA4 down-projection scale tensor.
+    """
+    w13 = w.w13_weight_triton_tensor
+    w2 = w.w2_weight_triton_tensor
+    if not (
+        _is_gdot128_weight(w13)
+        and _is_gdot128_weight(w2)
+        and _is_cdna4_scale(w13_scale)
+        and _is_cdna4_scale(w2_scale)
+    ):
+        return
+    w13.gluon_package_prefill_weight = _make_gdot128_weight_alias(w13)
+    w13.gluon_package_prefill_scale = _make_gdot128_scale_alias(w13_scale)
+    w2.gluon_package_prefill_weight = _make_gdot128_weight_alias(w2)
+    w2.gluon_package_prefill_scale = _make_gdot128_scale_alias(w2_scale)

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/routing.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/routing.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""Fused routing exports used by the gfx950 A4W4 decode path."""
+
+from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.decode_kernels import (
+    invoke_sigmoid_bias_topk_route_gluon,
+    invoke_softmax_topk_route_gluon,
+)
+
+__all__ = [
+    "invoke_sigmoid_bias_topk_route_gluon",
+    "invoke_softmax_topk_route_gluon",
+]

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/scale.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/scale.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""Package-prefill activation-scale gather for the gfx950 A4W4 MoE package.
+
+The MXFP4 quantizer emits CDNA4-swizzled, token-order activation scales, but the
+package stage kernels need those same bytes in sorted-route row order. This
+module copies directly between the two CDNA4 layouts (token order -> sorted
+route order) with no intermediate unswizzle.
+
+It is package-specific glue -- it understands the CDNA4 scale layout and the
+sorted-route packing produced by :mod:`moe_sorting` -- so it lives next to the
+stage kernels that consume it.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+# MXFP4 microblock size and the CDNA4 scale-swizzle alignment. These are fixed
+# properties of the CDNA4 MXFP4 scale layout, kept local so the package is
+# self-contained.
+_MXFP4_BLOCK = 32
+_NON_K_PRESHUFFLE_BLOCK_SIZE = 32
+_ALIGN_K_SCALE_SWIZZLE = 8
+
+
+@triton.jit
+def _gather_package_cdna4_scale_kernel(
+    src_scale,
+    sorted_ids,
+    dst_scale,
+    source_rows,
+    src_mblock_stride,
+    dst_mblock_stride,
+    num_sorted_ids,
+    K_SCALE: tl.constexpr,
+    TOPK: tl.constexpr,
+    FLATTEN_TOPK: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Gather a CDNA4-swizzled activation scale by sorted-route rows.
+
+    Copies directly between the token-order and sorted-route CDNA4 layouts;
+    ``sorted_ids`` packs ``(topk_id << 24) | token_id`` per slot.
+    """
+    linear = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    dst_row = linear // K_SCALE
+    k_scale = linear % K_SCALE
+    in_bounds = dst_row < num_sorted_ids
+
+    packed = tl.load(sorted_ids + dst_row, mask=in_bounds, other=source_rows)
+    token = packed & 0xFFFFFF
+    if FLATTEN_TOPK:
+        slot = packed >> 24
+        src_row = token * TOPK + slot
+    else:
+        src_row = token
+    valid = in_bounds & (src_row < source_rows)
+
+    src_m_in = src_row % 32
+    src_m_hi = src_m_in // 16
+    src_m_lo = src_m_in % 16
+    k_block = k_scale // 8
+    k_hi = (k_scale % 8) // 4
+    k_lo = k_scale % 4
+    src_swizzled_k = (((k_block * 4 + k_lo) * 16 + src_m_lo) * 2 + k_hi) * 2 + src_m_hi
+    src_off = src_swizzled_k + (src_row // 32) * src_mblock_stride
+
+    dst_m_in = dst_row % 32
+    dst_m_hi = dst_m_in // 16
+    dst_m_lo = dst_m_in % 16
+    dst_swizzled_k = (((k_block * 4 + k_lo) * 16 + dst_m_lo) * 2 + k_hi) * 2 + dst_m_hi
+    dst_off = dst_swizzled_k + (dst_row // 32) * dst_mblock_stride
+
+    value = tl.load(src_scale + src_off, mask=valid, other=127)
+    tl.store(dst_scale + dst_off, value, mask=in_bounds)
+
+
+def gather_package_cdna4_scale(
+    scale: torch.Tensor,
+    sorted_ids: torch.Tensor,
+    *,
+    source_rows: int,
+    cols: int,
+    top_k: int,
+    flatten_topk: bool,
+) -> torch.Tensor:
+    """Remap a CDNA4-swizzled activation scale into sorted-route row order.
+
+    Args:
+        scale: rank-2 uint8 CDNA4-swizzled activation scale.
+        sorted_ids: sorted-route slots (``(topk_id << 24) | token_id``).
+        source_rows: number of valid source rows (token or token*topk extent).
+        cols: activation column count (K), must divide 32.
+        top_k: experts per token.
+        flatten_topk: if True, source rows are flattened ``token * TOPK + slot``.
+
+    Returns:
+        ``(rows_pad, K // 32)`` uint8 scale in sorted-route order.
+    """
+    if scale.dtype != torch.uint8 or scale.ndim != 2:
+        raise ValueError(
+            "package prefill requires a rank-2 uint8 gdot128 activation scale"
+        )
+    if cols % _MXFP4_BLOCK != 0:
+        raise ValueError(f"package prefill scale columns must divide by 32: {cols}")
+    k_scale = cols // _MXFP4_BLOCK
+    if k_scale % _ALIGN_K_SCALE_SWIZZLE != 0:
+        raise ValueError(
+            "package prefill currently requires K/32 divisible by "
+            f"{_ALIGN_K_SCALE_SWIZZLE}, got {k_scale}"
+        )
+    sorted_rows = int(sorted_ids.shape[0])
+    rows_pad = (
+        (sorted_rows + _NON_K_PRESHUFFLE_BLOCK_SIZE - 1)
+        // _NON_K_PRESHUFFLE_BLOCK_SIZE
+        * _NON_K_PRESHUFFLE_BLOCK_SIZE
+    )
+    out = torch.empty((rows_pad, k_scale), dtype=torch.uint8, device=scale.device)
+    if sorted_rows == 0:
+        return out
+    block = 256
+    _gather_package_cdna4_scale_kernel[(triton.cdiv(sorted_rows * k_scale, block),)](
+        scale,
+        sorted_ids,
+        out,
+        source_rows,
+        scale.stride(1),
+        k_scale * _NON_K_PRESHUFFLE_BLOCK_SIZE,
+        sorted_rows,
+        K_SCALE=k_scale,
+        TOPK=top_k,
+        FLATTEN_TOPK=flatten_topk,
+        BLOCK=block,
+        num_warps=4,
+    )
+    return out

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/mxfp4_gfx950_preprocess.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/mxfp4_gfx950_preprocess.py
@@ -215,6 +215,7 @@ def preprocess_gluon_mxfp4_gfx950_moe_weights(
 
     w13_weight = w.w13_weight
     w13_weight_scale = w.w13_weight_scale
+
     if w13_layout == "concatenated":
         w13_weight = torch.nn.Parameter(
             _interleave_gate_up_rows(w13_weight.data, dim=-2),
@@ -231,9 +232,13 @@ def preprocess_gluon_mxfp4_gfx950_moe_weights(
         w13_weight_bias = w.w13_weight_bias.to(torch.float32)
         if w13_layout == "concatenated":
             w13_weight_bias = _interleave_gate_up_rows(w13_weight_bias, dim=-1)
+        w._gluon_w13_bias_is_zero = not bool(
+            torch.count_nonzero(w13_weight_bias).item()
+        )
         w.w13_weight_bias = torch.nn.Parameter(w13_weight_bias, requires_grad=False)
     if hasattr(w, "w2_weight_bias"):
         w2_weight_bias = w.w2_weight_bias.to(torch.float32)
+        w._gluon_w2_bias_is_zero = not bool(torch.count_nonzero(w2_weight_bias).item())
         w.w2_weight_bias = torch.nn.Parameter(w2_weight_bias, requires_grad=False)
 
     num_warps = 8
@@ -302,5 +307,15 @@ def preprocess_gluon_mxfp4_gfx950_moe_weights(
 
     if preshuffle:
         _attach_gluon_preshuffle(w)
+
+    # Attach the gluon_a4w4_gfx950 package-prefill aliases whenever preshuffle
+    # produced the gdot128 layout. They are metadata-only views over that storage
+    # (no second model-sized copy), so attaching them is free. When preshuffle is
+    # disabled the package path cannot run anyway (the dynamic entry returns None
+    # without these aliases and falls back to the reference path).
+    if preshuffle:
+        from tokenspeed_kernel_amd.ops.moe import gluon_a4w4_gfx950
+
+        gluon_a4w4_gfx950.attach_prefill_aliases(w, w13_scale, w2_scale)
 
     torch.cuda.empty_cache()

--- a/tokenspeed-kernel-amd/test/ops/test_moe_sorting_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_moe_sorting_gfx950.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2026 LightSeek Foundation
+
+"""Parity + stream-safety tests for the in-house MoE block-aligned sorter.
+
+These tests assert ``gluon_moe_sorting`` produces the block-aligned sorted
+routing metadata expected by the gfx950 A4W4 package-prefill stage kernels
+(byte-for-byte against an independent reference) and that it is CUDA-graph
+capturable (i.e. performs no device-to-host synchronization), which is what
+lets the package-prefill path run under graph capture.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+
+def _is_gfx950() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    arch = getattr(torch.cuda.get_device_properties(0), "gcnArchName", "")
+    return "gfx950" in arch
+
+
+if not _is_gfx950():
+    pytest.skip(
+        "AMD GFX950 is required for MoE sorting tests",
+        allow_module_level=True,
+    )
+
+
+from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.moe_sorting import (  # noqa: E402
+    gluon_moe_sorting,
+)
+
+
+def _ref_moe_sorting_native(
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    num_experts: int,
+    block_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Independent reference for the block-aligned sort contract.
+
+    Builds the same block-padded, per-expert sorted layout the package stage
+    kernels consume, in plain PyTorch, so the kernel output can be checked
+    byte-for-byte.
+    """
+    device = topk_ids.device
+    M, topk = topk_ids.shape
+    max_num_tokens_padded = topk_ids.numel() + num_experts * block_size - topk
+    max_num_m_blocks = (max_num_tokens_padded + block_size - 1) // block_size
+    init_val = topk << 24 | M
+    sorted_ids = torch.full(
+        (max_num_tokens_padded,), init_val, dtype=torch.int32, device=device
+    )
+    sorted_weights = torch.zeros(
+        (max_num_tokens_padded,), dtype=torch.float32, device=device
+    )
+    sorted_expert_ids = torch.full(
+        (max_num_m_blocks,), -1, dtype=torch.int32, device=device
+    )
+    num_valid = torch.empty((2,), dtype=torch.int32, device=device)
+
+    slot = 0
+    block = 0
+    for expert in range(num_experts):
+        token_id, topk_id = torch.where(topk_ids == expert)
+        n = token_id.numel()
+        n_blocks = (n + block_size - 1) // block_size
+        n_pad = n_blocks * block_size
+        sorted_ids[slot : slot + n] = (topk_id.to(torch.int32) << 24) | token_id.to(
+            torch.int32
+        )
+        sorted_weights[slot : slot + n] = topk_weights[token_id, topk_id]
+        slot += n_pad
+        sorted_expert_ids[block : block + n_blocks] = expert
+        block += n_blocks
+    num_valid[0] = slot
+    num_valid[1] = M
+    return sorted_ids, sorted_weights, sorted_expert_ids, num_valid
+
+
+def _random_topk(M, E, topk, seed):
+    gen = torch.Generator(device="cuda").manual_seed(seed)
+    logits = torch.randn(M, E, device="cuda", generator=gen)
+    weights, ids = torch.topk(logits.softmax(-1), topk, dim=-1)
+    return ids.to(torch.int32).contiguous(), weights.to(torch.float32).contiguous()
+
+
+@pytest.mark.parametrize(
+    "M,E,topk,B",
+    [
+        (128, 8, 2, 128),  # small dense
+        (4096, 32, 8, 128),  # medium expert count
+        (4096, 384, 8, 128),  # Kimi prefill shape
+        (1, 8, 2, 128),  # single token
+        (37, 16, 3, 128),  # ragged / M not block-aligned
+        (512, 256, 6, 64),  # large expert count, small block
+        (2048, 128, 4, 32),  # small block
+        (4096, 384, 8, 32),  # Kimi expert count, small block
+    ],
+)
+def test_matches_ck_reference(M, E, topk, B):
+    topk_ids, topk_weights = _random_topk(M, E, topk, seed=M * 31 + E)
+    r_ids, r_w, r_eids, r_nv = _ref_moe_sorting_native(topk_ids, topk_weights, E, B)
+    g_ids, g_w, g_eids, g_nv, g_out = gluon_moe_sorting(
+        topk_ids, topk_weights, E, 32, torch.bfloat16, B
+    )
+
+    assert torch.equal(g_ids, r_ids), "sorted_ids mismatch"
+    assert torch.equal(g_eids, r_eids), "sorted_expert_ids mismatch"
+    assert torch.equal(g_nv, r_nv), "num_valid_ids mismatch"
+    assert torch.allclose(g_w, r_w), "sorted_weights mismatch"
+    assert g_out.shape == (M, 32) and g_out.dtype == torch.bfloat16
+
+
+def test_unrouted_expert_ids_are_skipped():
+    """``-1`` (unrouted) entries must be ignored, matching the CK reference."""
+    topk_ids, topk_weights = _random_topk(256, 64, 4, seed=7)
+    # Mark a handful of assignments as unrouted.
+    topk_ids[::17, 0] = -1
+    r_ids, r_w, r_eids, r_nv = _ref_moe_sorting_native(topk_ids, topk_weights, 64, 128)
+    g_ids, g_w, g_eids, g_nv, _ = gluon_moe_sorting(
+        topk_ids, topk_weights, 64, 32, torch.bfloat16, 128
+    )
+    assert torch.equal(g_ids, r_ids)
+    assert torch.equal(g_eids, r_eids)
+    assert torch.equal(g_nv, r_nv)
+    assert torch.allclose(g_w, r_w)
+
+
+def test_cuda_graph_capturable():
+    """The sorter must run with no device-to-host sync (graph-capturable)."""
+    M, E, topk, B = 4096, 384, 8, 128
+    topk_ids, topk_weights = _random_topk(M, E, topk, seed=123)
+
+    # Reference values (eager).
+    e_ids, e_w, e_eids, e_nv, _ = gluon_moe_sorting(
+        topk_ids, topk_weights, E, 32, torch.bfloat16, B
+    )
+
+    # Warmup on a side stream, then capture.
+    side = torch.cuda.Stream()
+    side.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side):
+        for _ in range(3):
+            gluon_moe_sorting(topk_ids, topk_weights, E, 32, torch.bfloat16, B)
+    torch.cuda.current_stream().wait_stream(side)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        c_ids, c_w, c_eids, c_nv, _ = gluon_moe_sorting(
+            topk_ids, topk_weights, E, 32, torch.bfloat16, B
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert torch.equal(c_ids, e_ids)
+    assert torch.equal(c_eids, e_eids)
+    assert torch.equal(c_nv, e_nv)
+    assert torch.allclose(c_w, e_w)

--- a/tokenspeed-kernel-amd/test/ops/test_mxfp4_clean_warp_decode_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_mxfp4_clean_warp_decode_gfx950.py
@@ -1,0 +1,1158 @@
+# Copyright (c) 2026 LightSeek Foundation
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+
+def _is_gfx950() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    arch = getattr(torch.cuda.get_device_properties(0), "gcnArchName", "")
+    return "gfx950" in arch
+
+
+if not _is_gfx950():
+    pytest.skip(
+        "AMD GFX950 is required for MXFP4 warp-decode tests",
+        allow_module_level=True,
+    )
+
+
+from tokenspeed_kernel_amd.ops.moe import fused_mxfp_gfx950  # noqa: E402
+from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import (  # noqa: E402
+    gluon_mxfp_dynamic_mxfp4_fused_moe,
+)
+from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950 import (  # noqa: E402
+    gluon_mxfp4_moe_decode,
+    invoke_sigmoid_bias_topk_route_gluon,
+    invoke_softmax_topk_route_gluon,
+)
+from tokenspeed_kernel_amd.ops.moe.mxfp4_gfx950_preprocess import (  # noqa: E402
+    preprocess_gluon_mxfp4_gfx950_moe_weights,
+)
+
+
+def _make_weights(
+    *,
+    num_experts: int,
+    hidden_size: int,
+    intermediate_size: int,
+    device: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    generator = torch.Generator(device=device).manual_seed(910603)
+    nibble_values = torch.tensor((0, 1, 2, 9, 10), device=device, dtype=torch.uint8)
+
+    def packed(shape):
+        lo = nibble_values[
+            torch.randint(
+                0, len(nibble_values), shape, device=device, generator=generator
+            )
+        ]
+        hi = nibble_values[
+            torch.randint(
+                0, len(nibble_values), shape, device=device, generator=generator
+            )
+        ]
+        return lo | (hi << 4)
+
+    w13 = packed((num_experts, 2 * intermediate_size, hidden_size // 2))
+    w2 = packed((num_experts, hidden_size, intermediate_size // 2))
+    w13_scale = torch.full(
+        (num_experts, 2 * intermediate_size, hidden_size // 32),
+        127,
+        device=device,
+        dtype=torch.uint8,
+    )
+    w2_scale = torch.full(
+        (num_experts, hidden_size, intermediate_size // 32),
+        127,
+        device=device,
+        dtype=torch.uint8,
+    )
+    return w13, w13_scale, w2, w2_scale
+
+
+def test_dynamic_mxfp4_precomputed_tiny_m_prefers_direct_over_mfma(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Below _PRECOMPUTED_MFMA_MIN_M the dispatch must try the direct decode
+    # kernel and must not fall through to the precomputed-MFMA decode.
+    hidden = torch.empty((1, 8), device="cuda", dtype=torch.bfloat16)
+    router = torch.empty((1, 4), device="cuda", dtype=torch.float32)
+    dummy_w = torch.empty((1, 4, 4), device="cuda", dtype=torch.uint8)
+    dummy_scale = torch.empty((1, 4, 1), device="cuda", dtype=torch.uint8)
+    topk_ids = torch.empty((1, 1), device="cuda", dtype=torch.int32)
+    topk_weights = torch.empty((1, 1), device="cuda", dtype=torch.float32)
+    direct_sentinel = torch.empty_like(hidden)
+    direct_calls = 0
+    mfma_calls = 0
+
+    def fake_direct_decode(*args, **kwargs):
+        nonlocal direct_calls
+        direct_calls += 1
+        assert kwargs["precomputed_topk_ids"] is topk_ids
+        assert kwargs["precomputed_topk_weights"] is topk_weights
+        return direct_sentinel
+
+    def fake_mfma_decode(*args, **kwargs):
+        nonlocal mfma_calls
+        mfma_calls += 1
+        return torch.empty_like(hidden)
+
+    monkeypatch.setattr(
+        fused_mxfp_gfx950,
+        "_maybe_precomputed_mxfp4_direct_mfma_decode",
+        fake_direct_decode,
+    )
+    monkeypatch.setattr(
+        fused_mxfp_gfx950,
+        "_maybe_precomputed_mxfp4_mfma_decode",
+        fake_mfma_decode,
+    )
+    out = fused_mxfp_gfx950.gluon_mxfp_dynamic_mxfp4_fused_moe(
+        hidden,
+        router,
+        dummy_w,
+        dummy_w,
+        w13_mx_scale=dummy_scale,
+        w2_mx_scale=dummy_scale,
+        top_k=1,
+        correction_bias=None,
+        n_group=1,
+        topk_group=1,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=True,
+        routing_method_type=0,
+        w13_bias=None,
+        w2_bias=None,
+        precomputed_topk_ids=topk_ids,
+        precomputed_topk_weights=topk_weights,
+    )
+
+    assert out is direct_sentinel
+    assert direct_calls == 1
+    assert mfma_calls == 0
+
+
+def test_dynamic_mxfp4_precomputed_default_uses_mfma_for_medium_m(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    hidden = torch.empty((4, 8), device="cuda", dtype=torch.bfloat16)
+    router = torch.empty((4, 4), device="cuda", dtype=torch.float32)
+    dummy_w = torch.empty((1, 4, 4), device="cuda", dtype=torch.uint8)
+    dummy_scale = torch.empty((1, 4, 1), device="cuda", dtype=torch.uint8)
+    topk_ids = torch.empty((4, 1), device="cuda", dtype=torch.int32)
+    topk_weights = torch.empty((4, 1), device="cuda", dtype=torch.float32)
+    sentinel = torch.empty_like(hidden)
+    mfma_calls = 0
+
+    def fake_mfma_decode(*args, **kwargs):
+        nonlocal mfma_calls
+        mfma_calls += 1
+        assert kwargs["precomputed_topk_ids"] is topk_ids
+        assert kwargs["precomputed_topk_weights"] is topk_weights
+        return sentinel
+
+    monkeypatch.setattr(
+        fused_mxfp_gfx950,
+        "_maybe_precomputed_mxfp4_mfma_decode",
+        fake_mfma_decode,
+    )
+    out = fused_mxfp_gfx950.gluon_mxfp_dynamic_mxfp4_fused_moe(
+        hidden,
+        router,
+        dummy_w,
+        dummy_w,
+        w13_mx_scale=dummy_scale,
+        w2_mx_scale=dummy_scale,
+        top_k=1,
+        correction_bias=None,
+        n_group=1,
+        topk_group=1,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=True,
+        routing_method_type=0,
+        w13_bias=None,
+        w2_bias=None,
+        precomputed_topk_ids=topk_ids,
+        precomputed_topk_weights=topk_weights,
+    )
+
+    assert out is sentinel
+    assert mfma_calls == 1
+
+
+def test_dynamic_mxfp4_package_prefill_runs_on_caller_stream(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # The package-prefill bridge uses the in-house ``gluon_moe_sorting``, which
+    # runs on the caller's stream, so the bridge must execute entirely on that
+    # stream with no cross-stream fence or ``record_stream`` fixup.
+    hidden = torch.empty((128, 8), device="cuda", dtype=torch.bfloat16)
+    router = torch.empty((128, 4), device="cuda", dtype=torch.float32)
+    dummy_w = torch.empty((1, 4, 4), device="cuda", dtype=torch.uint8)
+    dummy_scale = torch.empty((1, 4, 1), device="cuda", dtype=torch.uint8)
+    caller_stream = torch.cuda.Stream()
+
+    class Sentinel:
+        def record_stream(self, stream):  # pragma: no cover - must not be called
+            raise AssertionError(
+                "package prefill must not need cross-stream record_stream"
+            )
+
+    sentinel = Sentinel()
+    observed = {}
+
+    def fake_package_prefill(*args, **kwargs):
+        observed["stream"] = torch.cuda.current_stream()
+        return sentinel
+
+    monkeypatch.setattr(
+        fused_mxfp_gfx950,
+        "_maybe_gluon_package_mxfp4_prefill",
+        fake_package_prefill,
+    )
+
+    with torch.cuda.stream(caller_stream):
+        out = fused_mxfp_gfx950.gluon_mxfp_dynamic_mxfp4_fused_moe(
+            hidden,
+            router,
+            dummy_w,
+            dummy_w,
+            w13_mx_scale=dummy_scale,
+            w2_mx_scale=dummy_scale,
+            top_k=1,
+            correction_bias=None,
+            n_group=1,
+            topk_group=1,
+            routed_scaling_factor=1.0,
+            normalize_topk_weights=True,
+        )
+
+    assert out is sentinel
+    # The bridge ran on the caller's stream, not the default stream.
+    assert observed["stream"] == caller_stream
+    assert observed["stream"] != torch.cuda.default_stream()
+
+
+def test_package_exposes_prefill_stage_entry_points():
+    from tokenspeed_kernel_amd.ops.moe import gluon_a4w4_gfx950 as package
+    from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950 import (
+        invoke_gluon_mxfp4_moe_stage1,
+        invoke_gluon_mxfp4_moe_stage2_1x2,
+    )
+
+    assert not hasattr(fused_mxfp_gfx950, "_maybe_runtime_mxfp4_warp_decode")
+    assert not hasattr(package, "invoke_stage1_warp_decode_gluon")
+    assert not hasattr(package, "invoke_stage2_warp_decode_gluon")
+    assert invoke_gluon_mxfp4_moe_stage1.__module__.endswith(".prefill_stage1")
+    assert invoke_gluon_mxfp4_moe_stage2_1x2.__module__.endswith(".prefill_stage2")
+
+
+def _make_preprocessed_layer(
+    w13: torch.Tensor,
+    w13_scale: torch.Tensor,
+    w2: torch.Tensor,
+    w2_scale: torch.Tensor,
+    *,
+    num_experts: int,
+    hidden_size: int,
+    intermediate_size: int,
+    device: str,
+) -> torch.nn.Module:
+    layer = torch.nn.Module()
+    layer.quant_config = type("QuantConfig", (), {})()
+    layer.quant_config.use_dynamic_mxfp4_activations = True
+    layer.w13_input_layout = "concatenated"
+    layer.w13_weight = torch.nn.Parameter(w13.clone(), requires_grad=False)
+    layer.w13_weight_scale = torch.nn.Parameter(w13_scale.clone(), requires_grad=False)
+    layer.w2_weight = torch.nn.Parameter(w2.clone(), requires_grad=False)
+    layer.w2_weight_scale = torch.nn.Parameter(w2_scale.clone(), requires_grad=False)
+    layer.w13_weight_bias = torch.nn.Parameter(
+        torch.zeros(num_experts, 2 * intermediate_size, device=device),
+        requires_grad=False,
+    )
+    layer.w2_weight_bias = torch.nn.Parameter(
+        torch.zeros(num_experts, hidden_size, device=device),
+        requires_grad=False,
+    )
+    preprocess_gluon_mxfp4_gfx950_moe_weights({}, layer)
+    return layer
+
+
+def _precomputed_mfma_expected(
+    hidden: torch.Tensor,
+    router: torch.Tensor,
+    layer: torch.nn.Module,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    *,
+    topk: int,
+) -> torch.Tensor:
+    # Force the MFMA decode kernel below its tuned batch-size gate so it can be
+    # used as the bit-exact reference for the direct/route-owned decode tests.
+    out = fused_mxfp_gfx950._maybe_precomputed_mxfp4_mfma_decode(
+        hidden,
+        router,
+        layer.w13_weight_triton_tensor,
+        layer.w2_weight_triton_tensor,
+        w13_mx_scale=layer.w13_precision_config.b_mx_scale,
+        w2_mx_scale=layer.w2_precision_config.b_mx_scale,
+        top_k=topk,
+        w13_bias=None,
+        w2_bias=None,
+        out_dtype=torch.bfloat16,
+        max_m=8,
+        precomputed_topk_weights=topk_weights,
+        precomputed_topk_ids=topk_ids,
+        swiglu_alpha=1.702,
+        swiglu_limit=7.0,
+        swiglu_beta=1.0,
+        min_m=1,
+    )
+    assert out is not None
+    return out
+
+
+def _softmax_topk_reference(
+    router: torch.Tensor,
+    topk: int,
+    *,
+    correction_bias: torch.Tensor | None = None,
+    routed_scaling_factor: float = 1.0,
+    normalize_topk_weights: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    scores = torch.softmax(router.float(), dim=-1)
+    choice = scores
+    if correction_bias is not None:
+        choice = choice + correction_bias.float().unsqueeze(0)
+    _, topk_ids = torch.topk(choice, k=topk, dim=-1, sorted=True)
+    topk_weights = scores.gather(1, topk_ids)
+    if normalize_topk_weights:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+    topk_weights = topk_weights * routed_scaling_factor
+    return topk_ids.to(torch.int32), topk_weights.to(torch.float32)
+
+
+def _sigmoid_bias_topk_reference(
+    router: torch.Tensor,
+    correction_bias: torch.Tensor,
+    topk: int,
+    *,
+    routed_scaling_factor: float = 1.0,
+    normalize_topk_weights: bool = True,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    scores = torch.sigmoid(router.float()).to(router.dtype)
+    _, topk_ids = torch.topk(
+        scores.float() + correction_bias.float().unsqueeze(0),
+        k=topk,
+        dim=-1,
+        sorted=True,
+    )
+    topk_weights = scores.gather(1, topk_ids)
+    if normalize_topk_weights:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+        topk_weights = topk_weights * routed_scaling_factor
+    return topk_ids.to(torch.int32), topk_weights.to(torch.float32)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_stable_topk_uses_smaller_index_for_exact_ties(dtype: torch.dtype):
+    values = torch.tensor([[1.0, 3.0, 3.0, -2.0, 3.0, 0.5]], device="cuda", dtype=dtype)
+
+    selected, ids = fused_mxfp_gfx950._stable_topk_smaller_index(values, 4)
+
+    torch.testing.assert_close(
+        ids,
+        torch.tensor([[1, 2, 4, 0]], device="cuda", dtype=torch.int64),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        selected,
+        torch.tensor([[3.0, 3.0, 3.0, 1.0]], device="cuda", dtype=dtype),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_stable_topk_preserves_non_tied_values_and_order():
+    generator = torch.Generator(device="cuda").manual_seed(20260712)
+    values = torch.randn(
+        (32, 384), device="cuda", dtype=torch.float32, generator=generator
+    )
+    expected_values, expected_ids = torch.topk(values, 8, dim=-1, sorted=True)
+
+    actual_values, actual_ids = fused_mxfp_gfx950._stable_topk_smaller_index(
+        values, 8, dim=-1, sorted=True
+    )
+
+    torch.testing.assert_close(actual_ids, expected_ids, rtol=0, atol=0)
+    torch.testing.assert_close(actual_values, expected_values, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_stable_topk_is_cuda_graph_capturable(dtype: torch.dtype):
+    """Regression: stable top-k must not copy CPU->CUDA (illegal under capture).
+
+    The prior form built the tie-break masks with ``raw.new_tensor(<int>)``,
+    which materializes a CPU tensor and copies it to the GPU -- this crashed
+    CUDA-graph capture in the runtime model tests.
+    """
+    values = torch.randn((8, 128), device="cuda", dtype=dtype)
+    eager_v, eager_i = fused_mxfp_gfx950._stable_topk_smaller_index(
+        values, 8, dim=-1, sorted=True
+    )
+
+    side = torch.cuda.Stream()
+    side.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side):
+        for _ in range(3):
+            fused_mxfp_gfx950._stable_topk_smaller_index(values, 8, dim=-1, sorted=True)
+    torch.cuda.current_stream().wait_stream(side)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        cap_v, cap_i = fused_mxfp_gfx950._stable_topk_smaller_index(
+            values, 8, dim=-1, sorted=True
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(cap_i, eager_i, rtol=0, atol=0)
+    torch.testing.assert_close(cap_v, eager_v, rtol=0, atol=0)
+
+
+def test_biased_grouped_route_is_repeatable_with_bf16_ties():
+    num_tokens = 512
+    num_experts = 384
+    topk = 8
+    generator = torch.Generator(device="cuda").manual_seed(603)
+    logits = torch.randn(
+        (num_tokens, num_experts),
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    correction_bias = torch.zeros((num_experts,), device="cuda", dtype=torch.bfloat16)
+
+    expected_weights, expected_ids = fused_mxfp_gfx950._biased_grouped_topk_reference(
+        logits,
+        correction_bias,
+        topk,
+        n_group=1,
+        topk_group=1,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=True,
+    )
+    for _ in range(4):
+        actual_weights, actual_ids = fused_mxfp_gfx950._biased_grouped_topk_reference(
+            logits,
+            correction_bias,
+            topk,
+            n_group=1,
+            topk_group=1,
+            routed_scaling_factor=1.0,
+            normalize_topk_weights=True,
+        )
+        torch.testing.assert_close(actual_ids, expected_ids, rtol=0, atol=0)
+        torch.testing.assert_close(actual_weights, expected_weights, rtol=0, atol=0)
+
+
+def test_softmax_topk_route_gluon_matches_reference():
+    device = "cuda"
+    router = torch.tensor(
+        [
+            [1.0, -0.5, 0.25, 0.75, -1.0, 0.5, -0.25, 1.25],
+            [-0.75, 0.5, 1.5, -0.25, 0.0, 1.0, -1.5, 0.25],
+        ],
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    correction_bias = torch.tensor(
+        [0.0, 0.2, -0.1, 0.3, -0.2, 0.1, 0.4, -0.3],
+        device=device,
+        dtype=torch.float32,
+    )
+    topk = 3
+    expected_ids, expected_weights = _softmax_topk_reference(
+        router,
+        topk,
+        correction_bias=correction_bias,
+        routed_scaling_factor=1.75,
+        normalize_topk_weights=True,
+    )
+
+    topk_ids, topk_weights = invoke_softmax_topk_route_gluon(
+        router,
+        topk,
+        correction_bias=correction_bias,
+        routed_scaling_factor=1.75,
+        normalize_topk_weights=True,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(topk_ids, expected_ids)
+    torch.testing.assert_close(topk_weights, expected_weights, atol=5e-3, rtol=5e-3)
+
+
+def test_sigmoid_bias_topk_route_gluon_matches_reference():
+    device = "cuda"
+    router = torch.tensor(
+        [
+            [1.0, -0.5, 0.25, 0.75, -1.0, 0.5, -0.25, 1.25],
+            [-0.75, 0.5, 1.5, -0.25, 0.0, 1.0, -1.5, 0.25],
+        ],
+        device=device,
+        dtype=torch.float32,
+    )
+    correction_bias = torch.tensor(
+        [0.0, 0.2, -0.1, 0.3, -0.2, 0.1, 0.4, -0.3],
+        device=device,
+        dtype=torch.float32,
+    )
+    topk = 3
+    expected_ids, expected_weights = _sigmoid_bias_topk_reference(
+        router,
+        correction_bias,
+        topk,
+        routed_scaling_factor=2.827,
+        normalize_topk_weights=True,
+    )
+
+    topk_ids, topk_weights = invoke_sigmoid_bias_topk_route_gluon(
+        router,
+        correction_bias,
+        topk,
+        routed_scaling_factor=2.827,
+        normalize_topk_weights=True,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(topk_ids, expected_ids)
+    torch.testing.assert_close(topk_weights, expected_weights, atol=5e-3, rtol=5e-3)
+
+
+def test_sigmoid_bias_topk_route_gluon_matches_bf16_kimi_shape():
+    device = "cuda"
+    num_tokens = 8
+    num_experts = 384
+    topk = 8
+    generator = torch.Generator(device=device).manual_seed(990611)
+    router = torch.randn(
+        (num_tokens, num_experts),
+        device=device,
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    correction_bias = (
+        torch.randn(
+            (num_experts,),
+            device=device,
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.01
+    )
+    expected_ids, expected_weights = _sigmoid_bias_topk_reference(
+        router,
+        correction_bias,
+        topk,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=True,
+    )
+
+    topk_ids, topk_weights = invoke_sigmoid_bias_topk_route_gluon(
+        router,
+        correction_bias,
+        topk,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=True,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(topk_ids, expected_ids)
+    torch.testing.assert_close(topk_weights, expected_weights, atol=5e-3, rtol=5e-3)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2, 4, 8])
+def test_precomputed_topk_fused_route_matches_route_from_topk(num_tokens: int):
+    device = "cuda"
+    num_experts = 16
+    topk = 8
+    topk_ids = (
+        (torch.arange(num_tokens * topk, device=device, dtype=torch.int32) * 7 + 3)
+        .reshape(num_tokens, topk)
+        .remainder(num_experts)
+    )
+    topk_weights = torch.linspace(
+        0.125,
+        1.0,
+        steps=num_tokens * topk,
+        device=device,
+        dtype=torch.float32,
+    ).reshape(num_tokens, topk)
+
+    actual = fused_mxfp_gfx950.gluon_precomputed_topk_fused_route(
+        topk_weights,
+        topk_ids,
+        num_experts=num_experts,
+        dtype=torch.bfloat16,
+    )
+    expected = fused_mxfp_gfx950._route_from_topk(
+        topk_weights,
+        topk_ids,
+        num_experts,
+        dtype=torch.bfloat16,
+    )
+    torch.cuda.synchronize()
+
+    actual_ragged, actual_gather, actual_scatter, actual_gate = actual
+    expected_ragged, expected_gather, expected_scatter, expected_gate = expected
+    torch.testing.assert_close(actual_gather, expected_gather, rtol=0, atol=0)
+    torch.testing.assert_close(actual_scatter, expected_scatter, rtol=0, atol=0)
+    torch.testing.assert_close(actual_gate, expected_gate, rtol=0, atol=0)
+    torch.testing.assert_close(
+        actual_ragged.slice_sizes, expected_ragged.slice_sizes, rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        actual_ragged.slice_offs, expected_ragged.slice_offs, rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        actual_ragged.block_offs_data,
+        expected_ragged.block_offs_data,
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        actual_ragged.block_schedule_data,
+        expected_ragged.block_schedule_data,
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2])
+def test_package_mxfp4_decode_matches_reference_mfma_exact(num_tokens: int):
+    hidden_size = 1024
+    intermediate_size = 512
+    num_experts = 8
+    topk = 2
+    device = "cuda"
+    generator = torch.Generator(device=device).manual_seed(20260710 + num_tokens)
+    hidden = (
+        torch.randn(
+            (num_tokens, hidden_size),
+            device=device,
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.01
+    ).contiguous()
+    w13, w13_scale, w2, w2_scale = _make_weights(
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        device=device,
+    )
+    layer = _make_preprocessed_layer(
+        w13,
+        w13_scale,
+        w2,
+        w2_scale,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        device=device,
+    )
+    router = torch.randn(
+        (num_tokens, num_experts),
+        device=device,
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    topk_weights, topk_ids = torch.topk(torch.softmax(router.float(), dim=-1), topk)
+    topk_ids = topk_ids.to(torch.int32)
+
+    out = gluon_mxfp4_moe_decode(
+        hidden,
+        layer.w13_weight_triton_tensor,
+        layer.w13_precision_config.b_mx_scale,
+        layer.w2_weight_triton_tensor,
+        layer.w2_precision_config.b_mx_scale,
+        topk_ids,
+        topk_weights,
+    )
+    torch.cuda.synchronize()
+
+    expected = _precomputed_mfma_expected(
+        hidden,
+        router,
+        layer,
+        topk_ids,
+        topk_weights,
+        topk=topk,
+    )
+    torch.testing.assert_close(out.float(), expected.float(), rtol=0.0, atol=0.0)
+
+
+@pytest.mark.parametrize("num_tokens", [4, 8])
+def test_dynamic_mxfp4_dispatch_uses_mfma_with_topk(
+    num_tokens: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # At M in the precomputed-MFMA decode range the dispatch must route to the
+    # MFMA decode kernel and match it bit-exactly.
+    hidden_size = 1024
+    intermediate_size = 512
+    num_experts = 8
+    topk = 2
+    device = "cuda"
+    generator = torch.Generator(device=device).manual_seed(20260710)
+    hidden = (
+        torch.randn(
+            (num_tokens, hidden_size),
+            device=device,
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.01
+    ).contiguous()
+    router = torch.randn(
+        (num_tokens, num_experts),
+        device=device,
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    topk_weights, topk_ids = torch.topk(torch.softmax(router.float(), dim=-1), topk)
+    topk_ids = topk_ids.to(torch.int32)
+    w13, w13_scale, w2, w2_scale = _make_weights(
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        device=device,
+    )
+    layer = _make_preprocessed_layer(
+        w13,
+        w13_scale,
+        w2,
+        w2_scale,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        device=device,
+    )
+
+    # the reference default runtime path consumes preshuffled Gluon-dot tensors.
+    # The tiny-M decode path must accept those same runtime objects directly.
+    assert getattr(layer.w13_weight_triton_tensor, "is_shuffled_for_gluon_dot", False)
+    assert getattr(layer.w2_weight_triton_tensor, "is_shuffled_for_gluon_dot", False)
+    assert not hasattr(layer.w13_weight_triton_tensor, "gluon_decode_clean_weight")
+    assert not hasattr(layer.w13_weight_triton_tensor, "gluon_decode_clean_scale")
+    assert not hasattr(layer.w2_weight_triton_tensor, "gluon_decode_clean_weight")
+    assert not hasattr(layer.w2_weight_triton_tensor, "gluon_decode_clean_scale")
+
+    out = gluon_mxfp_dynamic_mxfp4_fused_moe(
+        hidden,
+        router,
+        layer.w13_weight_triton_tensor,
+        layer.w2_weight_triton_tensor,
+        w13_mx_scale=layer.w13_precision_config.b_mx_scale,
+        w2_mx_scale=layer.w2_precision_config.b_mx_scale,
+        top_k=topk,
+        correction_bias=None,
+        n_group=1,
+        topk_group=1,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=True,
+        w13_bias=None,
+        w2_bias=None,
+        precomputed_topk_weights=topk_weights,
+        precomputed_topk_ids=topk_ids,
+    )
+    torch.cuda.synchronize()
+
+    expected = _precomputed_mfma_expected(
+        hidden,
+        router,
+        layer,
+        topk_ids,
+        topk_weights,
+        topk=topk,
+    )
+    torch.testing.assert_close(out.float(), expected.float(), rtol=0.0, atol=0.0)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2])
+def test_dynamic_mxfp4_direct_precomputed_matches_mfma_exact(
+    num_tokens: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    hidden_size = 1024
+    intermediate_size = 512
+    num_experts = 8
+    topk = 2
+    device = "cuda"
+    generator = torch.Generator(device=device).manual_seed(20260713 + num_tokens)
+    hidden = (
+        torch.randn(
+            (num_tokens, hidden_size),
+            device=device,
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.01
+    ).contiguous()
+    router = torch.randn(
+        (num_tokens, num_experts),
+        device=device,
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    topk_weights, topk_ids = torch.topk(torch.softmax(router.float(), dim=-1), topk)
+    topk_ids = topk_ids.to(torch.int32)
+    w13, w13_scale, w2, w2_scale = _make_weights(
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        device=device,
+    )
+    layer = _make_preprocessed_layer(
+        w13,
+        w13_scale,
+        w2,
+        w2_scale,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        device=device,
+    )
+
+    out = gluon_mxfp_dynamic_mxfp4_fused_moe(
+        hidden,
+        router,
+        layer.w13_weight_triton_tensor,
+        layer.w2_weight_triton_tensor,
+        w13_mx_scale=layer.w13_precision_config.b_mx_scale,
+        w2_mx_scale=layer.w2_precision_config.b_mx_scale,
+        top_k=topk,
+        correction_bias=None,
+        n_group=1,
+        topk_group=1,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=True,
+        w13_bias=None,
+        w2_bias=None,
+        precomputed_topk_weights=topk_weights,
+        precomputed_topk_ids=topk_ids,
+    )
+    torch.cuda.synchronize()
+
+    expected = _precomputed_mfma_expected(
+        hidden,
+        router,
+        layer,
+        topk_ids,
+        topk_weights,
+        topk=topk,
+    )
+    torch.testing.assert_close(out.float(), expected.float(), rtol=0.0, atol=0.0)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2])
+def test_dynamic_mxfp4_route_owned_default_falls_back_when_direct_unsupported(
+    num_tokens: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    hidden = torch.empty((num_tokens, 8), device="cuda", dtype=torch.bfloat16)
+    router = torch.empty((num_tokens, 4), device="cuda", dtype=torch.float32)
+    dummy_w = torch.empty((1, 4, 4), device="cuda", dtype=torch.uint8)
+    dummy_scale = torch.empty((1, 4, 1), device="cuda", dtype=torch.uint8)
+    intermediate = torch.empty_like(hidden)
+    sentinel = torch.empty_like(hidden)
+    route_calls = 0
+    quantize_calls = 0
+    matmul_calls = 0
+
+    def fake_route(*args, **kwargs):
+        nonlocal route_calls
+        route_calls += 1
+        return None, None, None, None
+
+    def fake_quantize(x, *args, **kwargs):
+        nonlocal quantize_calls
+        quantize_calls += 1
+        return x, dummy_scale
+
+    def fake_matmul(*args, **kwargs):
+        nonlocal matmul_calls
+        matmul_calls += 1
+        # gemm1 fuses the intermediate requant (out_quant_format="mxfp4") and
+        # returns (intermediate, gemm2_scale); gemm2 returns the final output.
+        return (intermediate, dummy_scale) if matmul_calls == 1 else sentinel
+
+    monkeypatch.setattr(fused_mxfp_gfx950, "_dynamic_mxfp4_route", fake_route)
+    monkeypatch.setattr(
+        fused_mxfp_gfx950,
+        "_quantize_mxfp4_activation",
+        fake_quantize,
+    )
+    monkeypatch.setattr(fused_mxfp_gfx950, "gluon_mxfp_ragged_matmul", fake_matmul)
+
+    out = fused_mxfp_gfx950.gluon_mxfp_dynamic_mxfp4_fused_moe(
+        hidden,
+        router,
+        dummy_w,
+        dummy_w,
+        w13_mx_scale=dummy_scale,
+        w2_mx_scale=dummy_scale,
+        top_k=1,
+        correction_bias=None,
+        n_group=1,
+        topk_group=1,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=True,
+        routing_method_type=0,
+        w13_bias=None,
+        w2_bias=None,
+    )
+
+    assert out is sentinel
+    assert route_calls == 1
+    # Only the hidden state is quantized explicitly; the intermediate requant is
+    # fused into the gemm1 ragged matmul (out_quant_format="mxfp4").
+    assert quantize_calls == 1
+    assert matmul_calls == 2
+
+
+def test_dynamic_mxfp4_generic_path_consumes_precomputed_topk(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Large-M fallback must not silently recompute routing from logits."""
+
+    hidden = torch.empty((32, 8), device="cuda", dtype=torch.bfloat16)
+    router = torch.empty((32, 4), device="cuda", dtype=torch.float32)
+    topk_weights = torch.ones((32, 1), device="cuda", dtype=torch.float32)
+    topk_ids = torch.zeros((32, 1), device="cuda", dtype=torch.int32)
+    dummy_w = torch.empty((1, 4, 4), device="cuda", dtype=torch.uint8)
+    dummy_scale = torch.empty((1, 4, 1), device="cuda", dtype=torch.uint8)
+    intermediate = torch.empty_like(hidden)
+    sentinel = torch.empty_like(hidden)
+    route_calls = 0
+    matmul_calls = 0
+
+    def fake_route_from_topk(weights, ids, *, num_experts, dtype):
+        nonlocal route_calls
+        route_calls += 1
+        assert weights.data_ptr() == topk_weights.data_ptr()
+        assert ids.data_ptr() == topk_ids.data_ptr()
+        assert num_experts == router.shape[1]
+        assert dtype == router.dtype
+        return None, None, None, None
+
+    def fail_dynamic_route(*args, **kwargs):
+        raise AssertionError("precomputed top-k was ignored")
+
+    def fake_quantize(x, *args, **kwargs):
+        return x, dummy_scale
+
+    def fake_matmul(*args, **kwargs):
+        nonlocal matmul_calls
+        matmul_calls += 1
+        # gemm1 fuses the intermediate requant and returns (intermediate, scale).
+        return (intermediate, dummy_scale) if matmul_calls == 1 else sentinel
+
+    monkeypatch.setattr(fused_mxfp_gfx950, "_route_from_topk", fake_route_from_topk)
+    monkeypatch.setattr(fused_mxfp_gfx950, "_dynamic_mxfp4_route", fail_dynamic_route)
+    monkeypatch.setattr(
+        fused_mxfp_gfx950,
+        "_quantize_mxfp4_activation",
+        fake_quantize,
+    )
+    monkeypatch.setattr(fused_mxfp_gfx950, "gluon_mxfp_ragged_matmul", fake_matmul)
+
+    out = fused_mxfp_gfx950.gluon_mxfp_dynamic_mxfp4_fused_moe(
+        hidden,
+        router,
+        dummy_w,
+        dummy_w,
+        w13_mx_scale=dummy_scale,
+        w2_mx_scale=dummy_scale,
+        top_k=1,
+        correction_bias=None,
+        n_group=1,
+        topk_group=1,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=True,
+        routing_method_type=0,
+        w13_bias=None,
+        w2_bias=None,
+        precomputed_topk_weights=topk_weights,
+        precomputed_topk_ids=topk_ids,
+    )
+
+    assert out is sentinel
+    assert route_calls == 1
+    assert matmul_calls == 2
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2])
+def test_dynamic_mxfp4_route_owned_softmax_mfma_decode(
+    num_tokens: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    hidden_size = 1024
+    intermediate_size = 512
+    num_experts = 8
+    topk = 2
+    device = "cuda"
+    generator = torch.Generator(device=device).manual_seed(20260711 + num_tokens)
+    hidden = (
+        torch.randn(
+            (num_tokens, hidden_size),
+            device=device,
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.01
+    ).contiguous()
+    router = torch.randn(
+        (num_tokens, num_experts),
+        device=device,
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    topk_ids, topk_weights = invoke_softmax_topk_route_gluon(router, topk)
+    w13, w13_scale, w2, w2_scale = _make_weights(
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        device=device,
+    )
+    layer = _make_preprocessed_layer(
+        w13,
+        w13_scale,
+        w2,
+        w2_scale,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        device=device,
+    )
+
+    out = gluon_mxfp_dynamic_mxfp4_fused_moe(
+        hidden,
+        router,
+        layer.w13_weight_triton_tensor,
+        layer.w2_weight_triton_tensor,
+        w13_mx_scale=layer.w13_precision_config.b_mx_scale,
+        w2_mx_scale=layer.w2_precision_config.b_mx_scale,
+        top_k=topk,
+        correction_bias=None,
+        n_group=1,
+        topk_group=1,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=True,
+        routing_method_type=0,
+        w13_bias=None,
+        w2_bias=None,
+    )
+    torch.cuda.synchronize()
+
+    expected = _precomputed_mfma_expected(
+        hidden,
+        router,
+        layer,
+        topk_ids,
+        topk_weights,
+        topk=topk,
+    )
+    torch.testing.assert_close(out.float(), expected.float(), rtol=0.0, atol=0.0)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2])
+def test_dynamic_mxfp4_route_owned_kimi_sigmoid_mfma_decode(
+    num_tokens: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    hidden_size = 1024
+    intermediate_size = 512
+    num_experts = 8
+    topk = 2
+    scale = 2.827
+    device = "cuda"
+    generator = torch.Generator(device=device).manual_seed(20260712 + num_tokens)
+    hidden = (
+        torch.randn(
+            (num_tokens, hidden_size),
+            device=device,
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.01
+    ).contiguous()
+    router = torch.randn(
+        (num_tokens, num_experts),
+        device=device,
+        dtype=torch.float32,
+        generator=generator,
+    )
+    correction_bias = torch.tensor(
+        [0.0, 0.2, -0.1, 0.3, -0.2, 0.1, 0.05, -0.05],
+        device=device,
+        dtype=torch.float32,
+    )
+    topk_ids, topk_weights = invoke_sigmoid_bias_topk_route_gluon(
+        router,
+        correction_bias,
+        topk,
+        routed_scaling_factor=scale,
+        normalize_topk_weights=True,
+    )
+    w13, w13_scale, w2, w2_scale = _make_weights(
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        device=device,
+    )
+    layer = _make_preprocessed_layer(
+        w13,
+        w13_scale,
+        w2,
+        w2_scale,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        device=device,
+    )
+
+    out = gluon_mxfp_dynamic_mxfp4_fused_moe(
+        hidden,
+        router,
+        layer.w13_weight_triton_tensor,
+        layer.w2_weight_triton_tensor,
+        w13_mx_scale=layer.w13_precision_config.b_mx_scale,
+        w2_mx_scale=layer.w2_precision_config.b_mx_scale,
+        top_k=topk,
+        correction_bias=correction_bias,
+        n_group=1,
+        topk_group=1,
+        routed_scaling_factor=scale,
+        normalize_topk_weights=True,
+        routing_method_type=2,
+        w13_bias=None,
+        w2_bias=None,
+    )
+    torch.cuda.synchronize()
+
+    expected = _precomputed_mfma_expected(
+        hidden,
+        router,
+        layer,
+        topk_ids,
+        topk_weights,
+        topk=topk,
+    )
+    torch.testing.assert_close(out.float(), expected.float(), rtol=0.0, atol=0.0)

--- a/tokenspeed-kernel-amd/test/ops/test_mxfp4_clean_warp_decode_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_mxfp4_clean_warp_decode_gfx950.py
@@ -23,6 +23,7 @@ if not _is_gfx950():
 from tokenspeed_kernel_amd.ops.moe import fused_mxfp_gfx950  # noqa: E402
 from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import (  # noqa: E402
     gluon_mxfp_dynamic_mxfp4_fused_moe,
+    gluon_mxfp_precomputed_mxfp4_fused_moe,
 )
 from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950 import (  # noqa: E402
     gluon_mxfp4_moe_decode,
@@ -698,13 +699,16 @@ def test_package_mxfp4_decode_matches_reference_mfma_exact(num_tokens: int):
     torch.testing.assert_close(out.float(), expected.float(), rtol=0.0, atol=0.0)
 
 
-@pytest.mark.parametrize("num_tokens", [4, 8])
+@pytest.mark.parametrize("num_tokens", [3, 4, 8])
 def test_dynamic_mxfp4_dispatch_uses_mfma_with_topk(
     num_tokens: int,
     monkeypatch: pytest.MonkeyPatch,
 ):
     # At M in the precomputed-MFMA decode range the dispatch must route to the
-    # MFMA decode kernel and match it bit-exactly.
+    # MFMA decode kernel and match it bit-exactly. M=3 is the previously-gapped
+    # interval (_DIRECT_DECODE_MAX_M, _PRECOMPUTED_MFMA_MIN_M): the apply
+    # wrapper now forwards precomputed top-k for it too, so it must also match
+    # the MFMA reference exactly rather than falling back to logit routing.
     hidden_size = 1024
     intermediate_size = 512
     num_experts = 8
@@ -1156,3 +1160,226 @@ def test_dynamic_mxfp4_route_owned_kimi_sigmoid_mfma_decode(
         topk=topk,
     )
     torch.testing.assert_close(out.float(), expected.float(), rtol=0.0, atol=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Precomputed entry point (``gluon_mxfp_precomputed_mxfp4_fused_moe``) dispatch.
+#
+# This is the entry consumed by ``gluon_mxfp4_precomputed_moe_apply`` (the
+# ``routing_mode="precomputed_topk"`` registered kernel). These tests pin down
+# its *current* dispatch behavior so we can validate the observation that,
+# unlike ``gluon_mxfp_dynamic_mxfp4_fused_moe``, it does NOT route to the decode
+# or package-prefill fast paths: every batch size falls through to the generic
+# ragged path. If we later wire the fast paths into this entry, these tests are
+# the ones that must change.
+# ---------------------------------------------------------------------------
+
+
+def _spy_precomputed_entry_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[dict[str, int], object]:
+    """Install spies on every dispatch helper the precomputed entry could hit.
+
+    Returns ``(counters, sentinel)`` where ``counters`` maps each helper to its
+    call count and ``sentinel`` is the object the stubbed ragged path returns.
+    The generic ragged path is stubbed so no real kernel launches are needed;
+    the decode / package-prefill helpers raise if the precomputed entry ever
+    reaches them.
+    """
+
+    counters: dict[str, int] = {
+        "package_prefill": 0,
+        "direct_decode": 0,
+        "mfma_decode": 0,
+        "fused_route": 0,
+        "route_from_topk": 0,
+        "ragged": 0,
+    }
+
+    def fail_package_prefill(*args, **kwargs):
+        counters["package_prefill"] += 1
+        raise AssertionError(
+            "precomputed entry unexpectedly reached the package-prefill path"
+        )
+
+    def fail_direct_decode(*args, **kwargs):
+        counters["direct_decode"] += 1
+        raise AssertionError(
+            "precomputed entry unexpectedly reached the direct MFMA decode path"
+        )
+
+    def fail_mfma_decode(*args, **kwargs):
+        counters["mfma_decode"] += 1
+        raise AssertionError(
+            "precomputed entry unexpectedly reached the precomputed-MFMA decode path"
+        )
+
+    def fake_fused_route(*args, **kwargs):
+        counters["fused_route"] += 1
+        return None, None, None, None
+
+    def fake_route_from_topk(*args, **kwargs):
+        counters["route_from_topk"] += 1
+        return None, None, None, None
+
+    sentinel = object()
+
+    def fake_ragged(*args, **kwargs):
+        counters["ragged"] += 1
+        return sentinel
+
+    monkeypatch.setattr(
+        fused_mxfp_gfx950, "_maybe_gluon_package_mxfp4_prefill", fail_package_prefill
+    )
+    monkeypatch.setattr(
+        fused_mxfp_gfx950,
+        "_maybe_precomputed_mxfp4_direct_mfma_decode",
+        fail_direct_decode,
+    )
+    monkeypatch.setattr(
+        fused_mxfp_gfx950,
+        "_maybe_precomputed_mxfp4_mfma_decode",
+        fail_mfma_decode,
+    )
+    monkeypatch.setattr(
+        fused_mxfp_gfx950, "gluon_precomputed_topk_fused_route", fake_fused_route
+    )
+    monkeypatch.setattr(fused_mxfp_gfx950, "_route_from_topk", fake_route_from_topk)
+    monkeypatch.setattr(
+        fused_mxfp_gfx950,
+        "_gluon_mxfp_dynamic_mxfp4_fused_moe_from_route",
+        fake_ragged,
+    )
+    return counters, sentinel
+
+
+def _make_dummy_weights_1x4(device: str = "cuda"):
+    # Rank-3 expert weight tensor so ``_extract_gluon_raw_w_unshuffled`` accepts
+    # it; the ragged path is stubbed so contents never get read.
+    w = torch.empty((1, 4, 4), device=device, dtype=torch.uint8)
+    scale = torch.empty((1, 4, 1), device=device, dtype=torch.uint8)
+    return w, scale
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2, 4, 8])
+def test_precomputed_entry_decode_sizes_use_ragged_not_fast_paths(
+    num_tokens: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Decode-sized batches must NOT reach decode/package-prefill from this entry.
+
+    This documents the gap versus ``gluon_mxfp_dynamic_mxfp4_fused_moe``: the
+    precomputed entry ignores the tuned decode kernels and always builds ragged
+    metadata + runs the generic matmul.
+    """
+    counters, sentinel = _spy_precomputed_entry_dispatch(monkeypatch)
+    w, scale = _make_dummy_weights_1x4()
+    topk_weights = torch.ones((num_tokens, 1), device="cuda", dtype=torch.float32)
+    topk_ids = torch.zeros((num_tokens, 1), device="cuda", dtype=torch.int32)
+    hidden = torch.empty((num_tokens, 8), device="cuda", dtype=torch.bfloat16)
+
+    out = gluon_mxfp_precomputed_mxfp4_fused_moe(
+        hidden,
+        topk_weights,
+        topk_ids,
+        w,
+        w,
+        w13_mx_scale=scale,
+        w2_mx_scale=scale,
+    )
+
+    assert out is sentinel
+    assert counters["ragged"] == 1
+    # The fast paths are never consulted.
+    assert counters["package_prefill"] == 0
+    assert counters["direct_decode"] == 0
+    assert counters["mfma_decode"] == 0
+    # Small-M uses the single-kernel fused route; either way we routed exactly
+    # once and never recomputed from logits.
+    assert counters["fused_route"] + counters["route_from_topk"] == 1
+
+
+def test_precomputed_entry_prefill_size_uses_ragged_not_package_prefill(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Prefill-sized batches must NOT reach the package-prefill path either."""
+    counters, sentinel = _spy_precomputed_entry_dispatch(monkeypatch)
+    w, scale = _make_dummy_weights_1x4()
+    num_tokens = 128
+    topk_weights = torch.ones((num_tokens, 1), device="cuda", dtype=torch.float32)
+    topk_ids = torch.zeros((num_tokens, 1), device="cuda", dtype=torch.int32)
+    hidden = torch.empty((num_tokens, 8), device="cuda", dtype=torch.bfloat16)
+
+    out = gluon_mxfp_precomputed_mxfp4_fused_moe(
+        hidden,
+        topk_weights,
+        topk_ids,
+        w,
+        w,
+        w13_mx_scale=scale,
+        w2_mx_scale=scale,
+    )
+
+    assert out is sentinel
+    assert counters["ragged"] == 1
+    assert counters["package_prefill"] == 0
+    assert counters["direct_decode"] == 0
+    assert counters["mfma_decode"] == 0
+    # Large M builds ragged metadata via the generic host route helper.
+    assert counters["route_from_topk"] == 1
+    assert counters["fused_route"] == 0
+
+
+def test_precomputed_entry_small_m_uses_fused_route(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Small-M precomputed entry uses the single-kernel fused route helper."""
+    counters, _sentinel = _spy_precomputed_entry_dispatch(monkeypatch)
+    w, scale = _make_dummy_weights_1x4()
+    # M=2, top_k=1 -> M < SMALLM_MAX_M and M*top_k <= GLUON_ROUTE_MAX_G.
+    topk_weights = torch.ones((2, 1), device="cuda", dtype=torch.float32)
+    topk_ids = torch.zeros((2, 1), device="cuda", dtype=torch.int32)
+    hidden = torch.empty((2, 8), device="cuda", dtype=torch.bfloat16)
+
+    gluon_mxfp_precomputed_mxfp4_fused_moe(
+        hidden,
+        topk_weights,
+        topk_ids,
+        w,
+        w,
+        w13_mx_scale=scale,
+        w2_mx_scale=scale,
+    )
+
+    assert counters["fused_route"] == 1
+    assert counters["route_from_topk"] == 0
+
+
+def test_precomputed_entry_rejects_missing_or_mismatched_topk():
+    """Shape/None validation on the precomputed entry."""
+    w, scale = _make_dummy_weights_1x4()
+    hidden = torch.empty((2, 8), device="cuda", dtype=torch.bfloat16)
+
+    # rank-1 topk_ids is rejected.
+    with pytest.raises(ValueError, match="rank-2"):
+        gluon_mxfp_precomputed_mxfp4_fused_moe(
+            hidden,
+            torch.ones((2,), device="cuda", dtype=torch.float32),
+            torch.zeros((2,), device="cuda", dtype=torch.int32),
+            w,
+            w,
+            w13_mx_scale=scale,
+            w2_mx_scale=scale,
+        )
+
+    # mismatched weights/ids shapes are rejected.
+    with pytest.raises(ValueError, match="same shape"):
+        gluon_mxfp_precomputed_mxfp4_fused_moe(
+            hidden,
+            torch.ones((2, 2), device="cuda", dtype=torch.float32),
+            torch.zeros((2, 1), device="cuda", dtype=torch.int32),
+            w,
+            w,
+            w13_mx_scale=scale,
+            w2_mx_scale=scale,
+        )

--- a/tokenspeed-kernel-amd/test/ops/test_mxfp4_gfx950_preprocess.py
+++ b/tokenspeed-kernel-amd/test/ops/test_mxfp4_gfx950_preprocess.py
@@ -1,3 +1,24 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest
@@ -5,6 +26,10 @@ import torch
 
 mxfp4_preprocess = pytest.importorskip(
     "tokenspeed_kernel_amd.ops.moe.mxfp4_gfx950_preprocess",
+    exc_type=ImportError,
+)
+gluon_a4w4 = pytest.importorskip(
+    "tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950",
     exc_type=ImportError,
 )
 
@@ -88,6 +113,10 @@ def test_preprocess_gluon_mxfp4_gfx950_mutates_module_state(monkeypatch):
     w2_storage = module.w2_weight_triton_tensor
     assert w13_storage.dtype == torch.uint8
     assert w2_storage.dtype == torch.uint8
+    assert not hasattr(w13_storage, "gluon_decode_clean_weight")
+    assert not hasattr(w13_storage, "gluon_decode_clean_scale")
+    assert not hasattr(w2_storage, "gluon_decode_clean_weight")
+    assert not hasattr(w2_storage, "gluon_decode_clean_scale")
     assert module.w13_weight_triton_tensor.shape == (2, 128, 256)
     assert module.w2_weight_triton_tensor.shape == (2, 128, 128)
     assert module._w2_logical_n == 64
@@ -148,3 +177,34 @@ def test_preprocess_gluon_mxfp4_gfx950_can_disable_preshuffle(monkeypatch):
     assert not hasattr(w2_storage, "_gluon_shuffled")
     assert not hasattr(module.w13_weight_triton_tensor, "_gluon_shuffled")
     assert not hasattr(module.w2_weight_triton_tensor, "_gluon_shuffled")
+
+
+def test_preprocess_gluon_mxfp4_gfx950_keeps_interleaved_runtime_w13_without_clean_copy(
+    monkeypatch,
+):
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: None)
+    module = _make_module()
+    module.w13_input_layout = "interleaved"
+
+    mxfp4_preprocess.preprocess_gluon_mxfp4_gfx950_moe_weights({}, module)
+
+    assert module.w13_weight_triton_tensor.is_shuffled_for_gluon_dot is True
+    assert not hasattr(module.w13_weight_triton_tensor, "gluon_decode_clean_weight")
+    assert not hasattr(module.w13_weight_triton_tensor, "gluon_decode_clean_scale")
+
+
+def test_attach_prefill_aliases_skips_non_gdot128_weights():
+    """Regression: the package-prefill alias attach must no-op (not raise) when
+    the weights are not gdot128-preshuffled (e.g. gpt-oss), so those models load
+    and fall back to the reference path instead of crashing at model load.
+    """
+    module = torch.nn.Module()
+    # Plain 3-D weights WITHOUT the ``is_shuffled_for_gluon_dot`` marker.
+    module.w13_weight_triton_tensor = torch.zeros((4, 8, 8), dtype=torch.uint8)
+    module.w2_weight_triton_tensor = torch.zeros((4, 8, 8), dtype=torch.uint8)
+    scale = torch.zeros((4, 32, 1), dtype=torch.uint8)
+
+    gluon_a4w4.attach_prefill_aliases(module, scale, scale)  # must not raise
+
+    assert not hasattr(module.w13_weight_triton_tensor, "gluon_package_prefill_weight")
+    assert not hasattr(module.w2_weight_triton_tensor, "gluon_package_prefill_weight")

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
@@ -34,8 +34,6 @@ platform = current_platform()
 
 if platform.is_amd:
     from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import (
-        _DIRECT_DECODE_MAX_M,
-        _PRECOMPUTED_MFMA_MIN_M,
         gluon_mxfp_dynamic_mxfp4_fused_moe,
         gluon_mxfp_fused_moe,
         gluon_mxfp_precomputed_mxfp4_fused_moe,
@@ -107,23 +105,14 @@ if platform.is_amd:
         swiglu_alpha, swiglu_limit, swiglu_beta = _swiglu_args(w)
         w13_precision_config = w.w13_precision_config
         w2_precision_config = w.w2_precision_config
-        # Forward the caller's precomputed top-k to the decode fast paths when
-        # the batch is in their tuned range: direct decode owns M <=
-        # _DIRECT_DECODE_MAX_M, precomputed-MFMA decode owns M >=
-        # _PRECOMPUTED_MFMA_MIN_M (see fused_mxfp_gfx950 tuned defaults).
-        use_precomputed_for_direct = int(x.shape[0]) <= _DIRECT_DECODE_MAX_M
-        forward_precomputed_topk = (
-            topk_weights is not None
-            and topk_ids is not None
-            and (
-                int(x.shape[0]) >= _PRECOMPUTED_MFMA_MIN_M or use_precomputed_for_direct
-            )
-        )
-        keep_zero_bias_for_tiny_route = (
-            topk_weights is not None
-            and topk_ids is not None
-            and not forward_precomputed_topk
-        )
+        # Forward the caller's precomputed top-k whenever it is supplied. The
+        # downstream dispatch picks the tuned kernel by batch size (direct
+        # decode owns M <= _DIRECT_DECODE_MAX_M, precomputed-MFMA decode owns
+        # M >= _PRECOMPUTED_MFMA_MIN_M) and otherwise builds ragged metadata
+        # directly from the forwarded top-k. Dropping it for any M in between
+        # (e.g. M == 3) would silently recompute routing from router_logits,
+        # so we always forward and let the dispatch choose.
+        forward_precomputed_topk = topk_weights is not None and topk_ids is not None
 
         return gluon_mxfp_dynamic_mxfp4_fused_moe(
             x,
@@ -131,22 +120,14 @@ if platform.is_amd:
             w.w13_weight_triton_tensor,
             w.w2_weight_triton_tensor,
             w13_bias=(
-                getattr(w, "w13_weight_bias", None)
-                if keep_zero_bias_for_tiny_route
-                else (
-                    None
-                    if getattr(w, "_gluon_w13_bias_is_zero", False)
-                    else getattr(w, "w13_weight_bias", None)
-                )
+                None
+                if getattr(w, "_gluon_w13_bias_is_zero", False)
+                else getattr(w, "w13_weight_bias", None)
             ),
             w2_bias=(
-                getattr(w, "w2_weight_bias", None)
-                if keep_zero_bias_for_tiny_route
-                else (
-                    None
-                    if getattr(w, "_gluon_w2_bias_is_zero", False)
-                    else getattr(w, "w2_weight_bias", None)
-                )
+                None
+                if getattr(w, "_gluon_w2_bias_is_zero", False)
+                else getattr(w, "w2_weight_bias", None)
             ),
             w13_mx_scale=w13_precision_config.b_mx_scale,
             w2_mx_scale=w2_precision_config.b_mx_scale,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
@@ -34,6 +34,8 @@ platform = current_platform()
 
 if platform.is_amd:
     from tokenspeed_kernel_amd.ops.moe.fused_mxfp_gfx950 import (
+        _DIRECT_DECODE_MAX_M,
+        _PRECOMPUTED_MFMA_MIN_M,
         gluon_mxfp_dynamic_mxfp4_fused_moe,
         gluon_mxfp_fused_moe,
         gluon_mxfp_precomputed_mxfp4_fused_moe,
@@ -99,20 +101,53 @@ if platform.is_amd:
         do_finalize: bool = True,
         enable_pdl: bool = False,
     ):
-        del topk_weights, topk_ids, num_tokens_global, max_num_tokens_per_gpu
+        del num_tokens_global, max_num_tokens_per_gpu
         del do_finalize, enable_pdl
         top_k = getattr(w, "top_k")
         swiglu_alpha, swiglu_limit, swiglu_beta = _swiglu_args(w)
         w13_precision_config = w.w13_precision_config
         w2_precision_config = w.w2_precision_config
+        # Forward the caller's precomputed top-k to the decode fast paths when
+        # the batch is in their tuned range: direct decode owns M <=
+        # _DIRECT_DECODE_MAX_M, precomputed-MFMA decode owns M >=
+        # _PRECOMPUTED_MFMA_MIN_M (see fused_mxfp_gfx950 tuned defaults).
+        use_precomputed_for_direct = int(x.shape[0]) <= _DIRECT_DECODE_MAX_M
+        forward_precomputed_topk = (
+            topk_weights is not None
+            and topk_ids is not None
+            and (
+                int(x.shape[0]) >= _PRECOMPUTED_MFMA_MIN_M or use_precomputed_for_direct
+            )
+        )
+        keep_zero_bias_for_tiny_route = (
+            topk_weights is not None
+            and topk_ids is not None
+            and not forward_precomputed_topk
+        )
 
         return gluon_mxfp_dynamic_mxfp4_fused_moe(
             x,
             router_logits,
             w.w13_weight_triton_tensor,
             w.w2_weight_triton_tensor,
-            w13_bias=getattr(w, "w13_weight_bias", None),
-            w2_bias=getattr(w, "w2_weight_bias", None),
+            w13_bias=(
+                getattr(w, "w13_weight_bias", None)
+                if keep_zero_bias_for_tiny_route
+                else (
+                    None
+                    if getattr(w, "_gluon_w13_bias_is_zero", False)
+                    else getattr(w, "w13_weight_bias", None)
+                )
+            ),
+            w2_bias=(
+                getattr(w, "w2_weight_bias", None)
+                if keep_zero_bias_for_tiny_route
+                else (
+                    None
+                    if getattr(w, "_gluon_w2_bias_is_zero", False)
+                    else getattr(w, "w2_weight_bias", None)
+                )
+            ),
             w13_mx_scale=w13_precision_config.b_mx_scale,
             w2_mx_scale=w2_precision_config.b_mx_scale,
             out_dtype=w2_precision_config.out_dtype or torch.bfloat16,
@@ -128,6 +163,8 @@ if platform.is_amd:
             swiglu_alpha=swiglu_alpha,
             swiglu_limit=swiglu_limit,
             swiglu_beta=swiglu_beta,
+            precomputed_topk_weights=topk_weights if forward_precomputed_topk else None,
+            precomputed_topk_ids=topk_ids if forward_precomputed_topk else None,
         )
 
     @register_kernel(
@@ -251,8 +288,16 @@ if platform.is_amd:
             router_logits,
             w.w13_weight_triton_tensor,
             w.w2_weight_triton_tensor,
-            w13_bias=getattr(w, "w13_weight_bias", None),
-            w2_bias=getattr(w, "w2_weight_bias", None),
+            w13_bias=(
+                None
+                if getattr(w, "_gluon_w13_bias_is_zero", False)
+                else getattr(w, "w13_weight_bias", None)
+            ),
+            w2_bias=(
+                None
+                if getattr(w, "_gluon_w2_bias_is_zero", False)
+                else getattr(w, "w2_weight_bias", None)
+            ),
             w13_mx_scale=w13_precision_config.b_mx_scale,
             w2_mx_scale=w2_precision_config.b_mx_scale,
             w13_act_scale=w.w13_act_scale,

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -637,6 +637,162 @@ def test_gluon_mxfp4_swiglu_args_default_missing_values_to_standard_swiglu() -> 
     assert _moe_gluon_mxfp4._swiglu_args(w) == (1.702, 7.0, 1.0)
 
 
+def test_gluon_mxfp4_apply_priority_prefers_dynamic_over_precomputed() -> None:
+    """The dynamic gluon mxfp4 apply outranks the precomputed one.
+
+    ``moe_plan`` never requests a ``routing_mode`` trait, so both the
+    ``kernel_routing`` (dynamic) and ``precomputed_topk`` apply kernels match a
+    gluon mxfp4 plan's traits. Selection therefore falls to declared priority.
+    The dynamic entry (``SPECIALIZED + 3``) is the one that forwards caller
+    top-k into BOTH the decode and package-prefill fast paths, so it must win
+    over the precomputed entry (``SPECIALIZED + 2``), which only runs the
+    generic ragged path. This test pins that ordering so a future priority
+    bump doesn't silently route the AMD mxfp4 MoE onto the slower entry.
+    """
+    registry = KernelRegistry.get()
+    dynamic = registry.get_by_name("gluon_mxfp4_dynamic_moe_apply")
+    precomputed = registry.get_by_name("gluon_mxfp4_precomputed_moe_apply")
+    if dynamic is None or precomputed is None:
+        pytest.skip("gluon mxfp4 apply kernels are AMD-only")
+
+    # Trait profiles differ only by routing_mode; everything else that gates
+    # selection is identical, so priority is the tiebreaker.
+    assert dynamic.traits.get("routing_mode") == frozenset({"kernel_routing"})
+    assert precomputed.traits.get("routing_mode") == frozenset({"precomputed_topk"})
+    for trait in (
+        "weight_dtype",
+        "activation",
+        "internal_activation_dtype",
+        "supports_bias",
+        "ispp_alignment",
+    ):
+        assert dynamic.traits.get(trait) == precomputed.traits.get(trait)
+    assert dynamic.priority > precomputed.priority
+
+
+def test_gluon_mxfp4_plan_selects_dynamic_apply_on_cdna4(
+    mi350_platform: PlatformInfo,
+) -> None:
+    """A CDNA4 gluon mxfp4 plan resolves to the dynamic apply, not precomputed.
+
+    This is the end-to-end confirmation of the priority test above: with the
+    platform overridden to CDNA4 (so both AMD apply kernels satisfy their
+    capability gate), ``moe_plan`` picks ``gluon_mxfp4_dynamic_moe_apply``.
+    That is the entry whose decode + package-prefill paths honor precomputed
+    ``topk_weights`` / ``topk_ids``.
+    """
+    registry = KernelRegistry.get()
+    if registry.get_by_name("gluon_mxfp4_dynamic_moe_apply") is None:
+        pytest.skip("gluon mxfp4 apply kernels are AMD-only")
+
+    real_platform = Platform.get()
+    try:
+        Platform.override(mi350_platform)
+        registry.clear_cache()
+        plan = tokenspeed_kernel.moe_plan(
+            "mxfp4",
+            input_dtype=torch.bfloat16,
+            activation="swiglu",
+            ispp=128,
+            internal_activation_dtype="input",
+            with_bias=True,
+            solution="gluon",
+        )
+    finally:
+        Platform.override(real_platform)
+        registry.clear_cache()
+
+    _assert_moe_plan(
+        plan,
+        apply="gluon_mxfp4_dynamic_moe_apply",
+        preprocessor="gluon_mxfp4_gfx950_moe_weights",
+    )
+    # support_routing is True because the selected (dynamic) kernel advertises
+    # kernel_routing; precomputed top-k is still forwarded as an optimization.
+    assert plan["support_routing"] is True
+
+
+def _make_fake_gluon_mxfp4_layer(top_k: int) -> torch.nn.Module:
+    """Minimal ``w`` exposing only the attributes the apply wrapper reads.
+
+    The downstream ``gluon_mxfp_dynamic_mxfp4_fused_moe`` is spied on, so the
+    weight/scale tensors are never dereferenced by a real kernel launch.
+    """
+    w = torch.nn.Module()
+    w.top_k = top_k
+    w.w13_weight_triton_tensor = object()
+    w.w2_weight_triton_tensor = object()
+    w.w13_precision_config = type("PC", (), {"b_mx_scale": object()})()
+    w.w2_precision_config = type(
+        "PC", (), {"b_mx_scale": object(), "out_dtype": torch.bfloat16}
+    )()
+    return w
+
+
+@pytest.mark.parametrize(
+    "num_tokens, expect_forwarded",
+    [
+        (1, True),  # M <= _DIRECT_DECODE_MAX_M -> direct decode
+        (2, True),  # M == _DIRECT_DECODE_MAX_M -> direct decode
+        (3, True),  # previously-gapped interval (2, 4): now forwarded too
+        (4, True),  # M >= _PRECOMPUTED_MFMA_MIN_M -> precomputed MFMA decode
+        (16, True),  # large M still forwards for the generic precomputed route
+    ],
+)
+def test_gluon_mxfp4_dynamic_apply_forwards_precomputed_topk_by_batch_size(
+    num_tokens: int,
+    expect_forwarded: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test for precomputed-top-k forwarding across batch sizes.
+
+    ``gluon_mxfp4_dynamic_moe_apply`` now forwards the caller's precomputed
+    ``topk_weights`` / ``topk_ids`` for every batch size when they are
+    supplied, and lets the downstream dispatch pick the tuned kernel. This
+    guards against regressing the old M=3 gap, where batches in the open
+    interval (_DIRECT_DECODE_MAX_M, _PRECOMPUTED_MFMA_MIN_M) silently dropped
+    the precomputed top-k and recomputed routing from ``router_logits``.
+    """
+    if not hasattr(_moe_gluon_mxfp4, "gluon_mxfp4_dynamic_moe_apply"):
+        pytest.skip("gluon mxfp4 dynamic apply is AMD-only")
+
+    captured: dict[str, object] = {}
+
+    def fake_fused_moe(*args, **kwargs):
+        captured["precomputed_topk_weights"] = kwargs.get("precomputed_topk_weights")
+        captured["precomputed_topk_ids"] = kwargs.get("precomputed_topk_ids")
+        return "sentinel"
+
+    monkeypatch.setattr(
+        _moe_gluon_mxfp4, "gluon_mxfp_dynamic_mxfp4_fused_moe", fake_fused_moe
+    )
+
+    w = _make_fake_gluon_mxfp4_layer(top_k=1)
+    x = torch.empty((num_tokens, 16), dtype=torch.bfloat16)
+    router_logits = torch.empty((num_tokens, 8), dtype=torch.float32)
+    topk_weights = torch.ones((num_tokens, 1), dtype=torch.float32)
+    topk_ids = torch.zeros((num_tokens, 1), dtype=torch.int32)
+
+    out = _moe_gluon_mxfp4.gluon_mxfp4_dynamic_moe_apply(
+        {},
+        x,
+        w,
+        router_logits,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+    )
+
+    assert out == "sentinel"
+    if expect_forwarded:
+        assert captured["precomputed_topk_weights"] is topk_weights
+        assert captured["precomputed_topk_ids"] is topk_ids
+    else:
+        # Reserved for batch sizes that intentionally drop precomputed top-k;
+        # currently none do, so this branch guards against a future regression.
+        assert captured["precomputed_topk_weights"] is None
+        assert captured["precomputed_topk_ids"] is None
+
+
 def _moe_apply_unquant_trtllm() -> object:
     plan = tokenspeed_kernel.moe_plan(
         "unquant",


### PR DESCRIPTION


## Summary
Adds a dedicated `gluon_a4w4_gfx950` Triton/Gluon kernel package implementing the full MXFP4-activation × MXFP4-weight MoE for AMD CDNA4 (gfx950), plus the dynamic dispatch that selects it. The package provides prefill stage 1 (gate/up MFMA + fused SwiGLU) and stage 2 (down-projection MFMA + top-k combine), small-M direct-MFMA decode stages, fused softmax / sigmoid-bias top-k routing, an in-house block-aligned expert `moe_sorting` (runs on the caller's stream with no device-to-host sync, so the whole path is CUDA-graph capturable), a CDNA4 activation-scale gather, and zero-copy weight-alias attachment at model load. `fused_mxfp_gfx950.py` routes each MoE call by batch size — direct/route-owned MFMA decode for M ≤ 8 and the package prefill path for M ≥ 9, falling back to the existing ragged path otherwise. The package prefill path is on by default (`GLUON_MXFP4_PACKAGE_PREFILL`, a pure runtime toggle) and is numerically exact against the existing reference across M=128–4096. End-to-end this improves generation throughput ~16% and TPOT ~14% at 1k/1k on Kimi-K2.5-MXFP4 (TP4), with the prefill MoE up to ~3× faster at large M; per-M GPU-time wins (M ≥ 9) were confirmed with rocprofv3 kernel traces.

## Testing
25 gfx950 op tests under `tokenspeed-kernel-amd/test/ops/` cover: `moe_sorting` block-aligned parity against a reference plus CUDA-graph capture; dispatch selection, routing parity, and decode numerical exactness; and preprocess/alias attachment. Package prefill verified bit-exact vs the reference path across M=128–4096; all op tests pass on gfx950.
 
