### PR TITLE
feat(rl): stamp weight versions on generation responses

### DIFF
--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -43,6 +43,29 @@ For a compact compatibility table, see
 | `--chat-template` | Built-in chat template name or template file path (handled by the smg gateway). |
 | `--stream-interval` | Streaming buffer interval in generated tokens. Smaller values stream more frequently. |
 | `--stream-output` | Return generated text as disjoint streaming segments. |
+| `--weight-version` | Initial model-weight version stamped into generation metadata. Defaults to `default`. |
+
+### Weight Version Metadata
+
+Every generation response includes the current version in
+`meta_info["weight_version"]`. RL trainers can use this value to identify the
+policy version that produced a sample.
+
+The RL control plane updates the version only when the trainer supplies one:
+
+- SGLang-compatible `update_weights_from_distributed`,
+  `update_weights_from_tensor`, and `update_weights_from_disk` requests accept
+  an optional `weight_version`. The version changes only after the update
+  succeeds.
+- The vLLM-compatible `finish_weight_update` request accepts an optional
+  `weight_version`. A version sent with an update chunk is deferred until
+  `finish_weight_update`, so partially updated weights never advertise the new
+  version.
+- Omitting `weight_version` preserves the current value.
+
+Use `GET /get_weight_version` to read the current value,
+`POST /update_weight_version` with `{"new_version": "..."}` to set it directly,
+and `GET /model_info` to read the model path and version together.
 
 ## Scheduler And Memory
 

--- a/python/tokenspeed/runtime/engine/io_struct.py
+++ b/python/tokenspeed/runtime/engine/io_struct.py
@@ -719,6 +719,8 @@ class UpdateWeightFromDiskReqInput:
     model_path: str
     # The format to load the weights
     load_format: str | None = None
+    # Optional: update the weight version after a successful load.
+    weight_version: str | None = None
 
 
 @dataclass
@@ -748,6 +750,9 @@ class UpdateWeightsFromDistributedReqInput:
     packed_num_buffers: int = DEFAULT_PACKED_NUM_BUFFERS
     group_name: str = "weight_update_group"
     flush_cache: bool = True
+    # Optional: update the weight version after a successful push. When provided,
+    # subsequent generation responses will carry this version in meta_info.
+    weight_version: str | None = None
 
 
 @dataclass
@@ -763,6 +768,8 @@ class UpdateWeightsFromTensorReqInput:
     serialized_named_tensors: list[bytes]
     load_format: str | None
     flush_cache: bool
+    # Optional: update the weight version after a successful push.
+    weight_version: str | None = None
 
 
 @dataclass

--- a/python/tokenspeed/runtime/engine/output_processor.py
+++ b/python/tokenspeed/runtime/engine/output_processor.py
@@ -125,6 +125,7 @@ class OutputProcessor:
                 "id": rid,
                 "finish_reason": recv_obj.finished_reasons[i],
                 "prompt_tokens": recv_obj.prompt_tokens[i],
+                "weight_version": self.engine.server_args.weight_version,
             }
             logprobs_info = state.logprobs_info if not state.obj.stream else {}
 

--- a/python/tokenspeed/runtime/engine/weight_transfer/manager.py
+++ b/python/tokenspeed/runtime/engine/weight_transfer/manager.py
@@ -81,6 +81,9 @@ class WeightTransferManager:
         # Lifecycle state.
         self._engine_inited = False
         self._update_active = False
+        # Monotonic counter for auto-incrementing weight versions when the
+        # trainer does not supply an explicit version string.
+        self._auto_version_counter = 0
 
     # ------------------------------------------------------------------ #
     # Introspection
@@ -144,6 +147,7 @@ class WeightTransferManager:
                 "/finish_weight_update before starting another."
             )
         self._update_active = True
+        self._version_set_this_update = False
         logger.info("Weight update started")
 
     async def update(self, update_info: dict[str, Any]) -> None:
@@ -162,6 +166,9 @@ class WeightTransferManager:
             )
             if not success:
                 raise RuntimeError(f"Failed to update weights: {message}")
+            # If the trainer passed a weight_version with this update chunk,
+            # apply it immediately (same semantics as sglang).
+            self._apply_weight_version_if_provided(update_info.get("weight_version"))
         else:  # ipc
             self._parse_ipc_update(update_info)
             # The CUDA-IPC receive path (rebuild_cuda_tensor + load_weights on the
@@ -178,18 +185,33 @@ class WeightTransferManager:
                 "use backend='nccl' for now."
             )
 
-    async def finish_update(self) -> None:
-        """Finalize the current weight update."""
+    async def finish_update(self, weight_version: str | None = None) -> None:
+        """Finalize the current weight update.
+
+        Args:
+            weight_version: If provided, set the weight version explicitly.
+                If None and no version was set during the update chunks,
+                auto-increments a monotonic counter.
+        """
         if not self._update_active:
             raise WeightTransferStateError(
                 "No active weight update to finish; call /start_weight_update first."
             )
         self._update_active = False
-        # A worker-side layerwise-reload finalize lives on the (deferred) worker
-        # path; the checkpoint-format flag will be threaded through start_update
-        # when that lands. Cache invalidation is handled by the update step's
-        # flush_cache.
-        logger.info("Weight update finished")
+
+        # Apply the weight version: explicit finish arg > set-during-chunks > auto.
+        if weight_version is not None:
+            self._apply_weight_version(weight_version)
+        elif not self._version_set_this_update:
+            # No explicit version was provided at any point in this update cycle;
+            # auto-increment so staleness is always detectable.
+            self._auto_version_counter += 1
+            self._apply_weight_version(str(self._auto_version_counter))
+
+        logger.info(
+            "Weight update finished (weight_version=%s)",
+            self._async_llm.server_args.weight_version,
+        )
 
     # ------------------------------------------------------------------ #
     # Pause / resume
@@ -231,6 +253,25 @@ class WeightTransferManager:
         """Resume generation after a pause."""
         self._async_llm.weight_transfer_allow_admission()
         logger.info("Generation resumed")
+
+    # ------------------------------------------------------------------ #
+    # Weight version management
+    # ------------------------------------------------------------------ #
+
+    @property
+    def weight_version(self) -> str:
+        """Current weight version string."""
+        return self._async_llm.server_args.weight_version
+
+    def _apply_weight_version(self, version: str) -> None:
+        """Set the weight version on server_args (stamps future responses)."""
+        self._async_llm.server_args.weight_version = version
+
+    def _apply_weight_version_if_provided(self, version: str | None) -> None:
+        """Set the weight version if the caller supplied one."""
+        if version is not None:
+            self._apply_weight_version(version)
+            self._version_set_this_update = True
 
     # ------------------------------------------------------------------ #
     # Backend-specific parsing
@@ -294,6 +335,7 @@ class WeightTransferManager:
             "flush_cache",
             "update_kind",
             "num_updates_list",
+            "weight_version",
         )
         self._require_keys(update_info, required, allowed, "NCCL update_info")
         self._check_dense(update_info, "NCCL update_info")

--- a/python/tokenspeed/runtime/engine/weight_transfer/manager.py
+++ b/python/tokenspeed/runtime/engine/weight_transfer/manager.py
@@ -81,9 +81,10 @@ class WeightTransferManager:
         # Lifecycle state.
         self._engine_inited = False
         self._update_active = False
-        # Monotonic counter for auto-incrementing weight versions when the
-        # trainer does not supply an explicit version string.
-        self._auto_version_counter = 0
+        # Tracks whether an explicit weight_version was set during the current
+        # update cycle (via chunk metadata or finish_update arg).
+        self._version_set_this_update = False
+        self._pending_weight_version: str | None = None
 
     # ------------------------------------------------------------------ #
     # Introspection
@@ -148,6 +149,7 @@ class WeightTransferManager:
             )
         self._update_active = True
         self._version_set_this_update = False
+        self._pending_weight_version: str | None = None
         logger.info("Weight update started")
 
     async def update(self, update_info: dict[str, Any]) -> None:
@@ -166,9 +168,13 @@ class WeightTransferManager:
             )
             if not success:
                 raise RuntimeError(f"Failed to update weights: {message}")
-            # If the trainer passed a weight_version with this update chunk,
-            # apply it immediately (same semantics as sglang).
-            self._apply_weight_version_if_provided(update_info.get("weight_version"))
+            # Record the weight_version from this chunk for deferred application
+            # at finish_update (not applied mid-update to avoid stamping responses
+            # while the model holds partially-updated weights).
+            version = update_info.get("weight_version")
+            if version is not None:
+                self._pending_weight_version = version
+                self._version_set_this_update = True
         else:  # ipc
             self._parse_ipc_update(update_info)
             # The CUDA-IPC receive path (rebuild_cuda_tensor + load_weights on the
@@ -190,8 +196,10 @@ class WeightTransferManager:
 
         Args:
             weight_version: If provided, set the weight version explicitly.
-                If None and no version was set during the update chunks,
-                auto-increments a monotonic counter.
+                The version is only updated when the trainer supplies one —
+                either here or during the update chunks. If no version was
+                provided at any point, the existing version is left unchanged
+                (same semantics as SGLang).
         """
         if not self._update_active:
             raise WeightTransferStateError(
@@ -199,14 +207,12 @@ class WeightTransferManager:
             )
         self._update_active = False
 
-        # Apply the weight version: explicit finish arg > set-during-chunks > auto.
+        # Apply the weight version: explicit finish arg > pending from chunks > unchanged.
         if weight_version is not None:
             self._apply_weight_version(weight_version)
-        elif not self._version_set_this_update:
-            # No explicit version was provided at any point in this update cycle;
-            # auto-increment so staleness is always detectable.
-            self._auto_version_counter += 1
-            self._apply_weight_version(str(self._auto_version_counter))
+        elif self._version_set_this_update and self._pending_weight_version is not None:
+            self._apply_weight_version(self._pending_weight_version)
+        # else: trainer chose not to supply a version (leave as-is).
 
         logger.info(
             "Weight update finished (weight_version=%s)",

--- a/python/tokenspeed/runtime/engine/weight_transfer/manager.py
+++ b/python/tokenspeed/runtime/engine/weight_transfer/manager.py
@@ -81,9 +81,6 @@ class WeightTransferManager:
         # Lifecycle state.
         self._engine_inited = False
         self._update_active = False
-        # Tracks whether an explicit weight_version was set during the current
-        # update cycle (via chunk metadata or finish_update arg).
-        self._version_set_this_update = False
         self._pending_weight_version: str | None = None
 
     # ------------------------------------------------------------------ #
@@ -148,8 +145,7 @@ class WeightTransferManager:
                 "/finish_weight_update before starting another."
             )
         self._update_active = True
-        self._version_set_this_update = False
-        self._pending_weight_version: str | None = None
+        self._pending_weight_version = None
         logger.info("Weight update started")
 
     async def update(self, update_info: dict[str, Any]) -> None:
@@ -174,7 +170,6 @@ class WeightTransferManager:
             version = update_info.get("weight_version")
             if version is not None:
                 self._pending_weight_version = version
-                self._version_set_this_update = True
         else:  # ipc
             self._parse_ipc_update(update_info)
             # The CUDA-IPC receive path (rebuild_cuda_tensor + load_weights on the
@@ -207,10 +202,10 @@ class WeightTransferManager:
             )
         self._update_active = False
 
-        # Apply the weight version: explicit finish arg > pending from chunks > unchanged.
+        # Apply the explicit finish version first, then any version from a chunk.
         if weight_version is not None:
             self._apply_weight_version(weight_version)
-        elif self._version_set_this_update and self._pending_weight_version is not None:
+        elif self._pending_weight_version is not None:
             self._apply_weight_version(self._pending_weight_version)
         # else: trainer chose not to supply a version (leave as-is).
 
@@ -272,12 +267,6 @@ class WeightTransferManager:
     def _apply_weight_version(self, version: str) -> None:
         """Set the weight version on server_args (stamps future responses)."""
         self._async_llm.server_args.weight_version = version
-
-    def _apply_weight_version_if_provided(self, version: str | None) -> None:
-        """Set the weight version if the caller supplied one."""
-        if version is not None:
-            self._apply_weight_version(version)
-            self._version_set_this_update = True
 
     # ------------------------------------------------------------------ #
     # Backend-specific parsing

--- a/python/tokenspeed/runtime/entrypoints/control_server.py
+++ b/python/tokenspeed/runtime/entrypoints/control_server.py
@@ -508,6 +508,16 @@ async def health_generate(request: Request):
     return await _proxy_to_rl_control(request)
 
 
+@app.get("/get_weight_version")
+async def get_weight_version(request: Request):
+    return await _proxy_to_rl_control(request)
+
+
+@app.post("/update_weight_version")
+async def update_weight_version(request: Request):
+    return await _proxy_to_rl_control(request)
+
+
 # ---------------------------------------------------------------------------
 # Server lifecycle
 # ---------------------------------------------------------------------------

--- a/python/tokenspeed/runtime/entrypoints/control_server.py
+++ b/python/tokenspeed/runtime/entrypoints/control_server.py
@@ -513,6 +513,11 @@ async def get_weight_version(request: Request):
     return await _proxy_to_rl_control(request)
 
 
+@app.get("/model_info")
+async def model_info(request: Request):
+    return await _proxy_to_rl_control(request)
+
+
 @app.post("/update_weight_version")
 async def update_weight_version(request: Request):
     return await _proxy_to_rl_control(request)

--- a/python/tokenspeed/runtime/entrypoints/sglang_compat_http.py
+++ b/python/tokenspeed/runtime/entrypoints/sglang_compat_http.py
@@ -77,6 +77,14 @@ def _llm(request: Request) -> "AsyncLLM":
     return async_llm
 
 
+def _stamp_weight_version(request: Request, version: str | None, message: str) -> str:
+    """Apply weight_version to server_args on success, return updated message."""
+    if version is not None:
+        _llm(request).server_args.weight_version = version
+        message += f" Weight version updated to {version}."
+    return message
+
+
 async def _guarded(
     build_payload: Callable[[], Awaitable[dict[str, Any]]],
 ) -> JSONResponse:
@@ -172,10 +180,8 @@ async def update_weights_from_distributed(request: Request) -> JSONResponse:
             weight_version=body.get("weight_version"),
         )
         success, message = await _llm(request).update_weights_from_distributed(obj)
-        if success and obj.weight_version is not None:
-            llm = _llm(request)
-            llm.server_args.weight_version = obj.weight_version
-            message += f" Weight version updated to {obj.weight_version}."
+        if success:
+            message = _stamp_weight_version(request, obj.weight_version, message)
         return {"success": success, "message": message}
 
     return await _guarded(_do)
@@ -193,10 +199,8 @@ async def update_weights_from_tensor(request: Request) -> JSONResponse:
             weight_version=body.get("weight_version"),
         )
         success, message = await _llm(request).update_weights_from_tensor(obj)
-        if success and obj.weight_version is not None:
-            llm = _llm(request)
-            llm.server_args.weight_version = obj.weight_version
-            message += f" Weight version updated to {obj.weight_version}."
+        if success:
+            message = _stamp_weight_version(request, obj.weight_version, message)
         return {"success": success, "message": message}
 
     return await _guarded(_do)
@@ -213,10 +217,8 @@ async def update_weights_from_disk(request: Request) -> JSONResponse:
             weight_version=body.get("weight_version"),
         )
         success, message, *_ = await _llm(request).update_weights_from_disk(obj)
-        if success and obj.weight_version is not None:
-            llm = _llm(request)
-            llm.server_args.weight_version = obj.weight_version
-            message += f" Weight version updated to {obj.weight_version}."
+        if success:
+            message = _stamp_weight_version(request, obj.weight_version, message)
         return {"success": success, "message": message}
 
     return await _guarded(_do)

--- a/python/tokenspeed/runtime/entrypoints/sglang_compat_http.py
+++ b/python/tokenspeed/runtime/entrypoints/sglang_compat_http.py
@@ -169,8 +169,13 @@ async def update_weights_from_distributed(request: Request) -> JSONResponse:
             shapes=shapes,
             group_name=str(body.get("group_name", "weight_update_group")),
             flush_cache=bool(body.get("flush_cache", False)),
+            weight_version=body.get("weight_version"),
         )
         success, message = await _llm(request).update_weights_from_distributed(obj)
+        if success and obj.weight_version is not None:
+            llm = _llm(request)
+            llm.server_args.weight_version = obj.weight_version
+            message += f" Weight version updated to {obj.weight_version}."
         return {"success": success, "message": message}
 
     return await _guarded(_do)
@@ -185,8 +190,13 @@ async def update_weights_from_tensor(request: Request) -> JSONResponse:
             serialized_named_tensors=body["serialized_named_tensors"],
             load_format=body.get("load_format"),
             flush_cache=bool(body.get("flush_cache", False)),
+            weight_version=body.get("weight_version"),
         )
         success, message = await _llm(request).update_weights_from_tensor(obj)
+        if success and obj.weight_version is not None:
+            llm = _llm(request)
+            llm.server_args.weight_version = obj.weight_version
+            message += f" Weight version updated to {obj.weight_version}."
         return {"success": success, "message": message}
 
     return await _guarded(_do)
@@ -200,8 +210,13 @@ async def update_weights_from_disk(request: Request) -> JSONResponse:
         obj = UpdateWeightFromDiskReqInput(
             model_path=str(body["model_path"]),
             load_format=body.get("load_format"),
+            weight_version=body.get("weight_version"),
         )
         success, message, *_ = await _llm(request).update_weights_from_disk(obj)
+        if success and obj.weight_version is not None:
+            llm = _llm(request)
+            llm.server_args.weight_version = obj.weight_version
+            message += f" Weight version updated to {obj.weight_version}."
         return {"success": success, "message": message}
 
     return await _guarded(_do)
@@ -290,6 +305,42 @@ async def abort_request(request: Request) -> JSONResponse:
 @router.get("/health_generate")
 async def health_generate() -> JSONResponse:
     return JSONResponse({"status": "ok"})
+
+
+@router.get("/get_weight_version")
+async def get_weight_version(request: Request) -> JSONResponse:
+    llm = _llm(request)
+    return JSONResponse({"weight_version": llm.server_args.weight_version})
+
+
+@router.post("/update_weight_version")
+async def update_weight_version(request: Request) -> JSONResponse:
+    body = await request.json()
+
+    async def _do() -> dict[str, Any]:
+        new_version = body.get("new_version")
+        if new_version is None:
+            raise ValueError("Missing 'new_version' in request body")
+        llm = _llm(request)
+        llm.server_args.weight_version = str(new_version)
+        return {
+            "success": True,
+            "message": f"Weight version updated to {new_version}",
+            "new_version": str(new_version),
+        }
+
+    return await _guarded(_do)
+
+
+@router.get("/model_info")
+async def model_info(request: Request) -> JSONResponse:
+    llm = _llm(request)
+    return JSONResponse(
+        {
+            "model_path": llm.server_args.model,
+            "weight_version": llm.server_args.weight_version,
+        }
+    )
 
 
 # --------------------------------------------------------------------------- #

--- a/python/tokenspeed/runtime/entrypoints/vllm_compat_http.py
+++ b/python/tokenspeed/runtime/entrypoints/vllm_compat_http.py
@@ -134,7 +134,10 @@ async def update_weights(raw_request: Request) -> JSONResponse:
 
 @router.post("/finish_weight_update")
 async def finish_weight_update(raw_request: Request) -> JSONResponse:
-    await _manager(raw_request).finish_update()
+    body = (
+        await _read_json(raw_request) if raw_request.headers.get("content-type") else {}
+    )
+    await _manager(raw_request).finish_update(weight_version=body.get("weight_version"))
     return JSONResponse(content={"message": "Weight update finished"})
 
 

--- a/python/tokenspeed/runtime/entrypoints/vllm_compat_http.py
+++ b/python/tokenspeed/runtime/entrypoints/vllm_compat_http.py
@@ -134,9 +134,18 @@ async def update_weights(raw_request: Request) -> JSONResponse:
 
 @router.post("/finish_weight_update")
 async def finish_weight_update(raw_request: Request) -> JSONResponse:
-    body = (
-        await _read_json(raw_request) if raw_request.headers.get("content-type") else {}
-    )
+    # Tolerant body parsing: accept empty bodies (backward compat with trainers
+    # that POST with no payload) and JSON bodies (new: carries weight_version).
+    raw = await raw_request.body()
+    if raw:
+        try:
+            body = json.loads(raw)
+            if not isinstance(body, dict):
+                body = {}
+        except (json.JSONDecodeError, ValueError):
+            body = {}
+    else:
+        body = {}
     await _manager(raw_request).finish_update(weight_version=body.get("weight_version"))
     return JSONResponse(content={"message": "Weight update finished"})
 

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -143,6 +143,11 @@ class ServerArgs:
     # the ``ts serve`` orchestrator (allocated + proxied by the sidecar); None
     # disables the in-engine app.
     rl_control_port: int | None = None
+    # Version identifier for the model weights. Stamped into every generation
+    # response's meta_info so RL trainers know which policy version produced each
+    # sample. Updated atomically on successful weight pushes (the trainer may pass
+    # a new version string with each update, or it auto-increments).
+    weight_version: str = "default"
 
     # Data parallelism
     data_parallel_size: int | None = None

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -145,8 +145,8 @@ class ServerArgs:
     rl_control_port: int | None = None
     # Version identifier for the model weights. Stamped into every generation
     # response's meta_info so RL trainers know which policy version produced each
-    # sample. Updated atomically on successful weight pushes (the trainer may pass
-    # a new version string with each update, or it auto-increments).
+    # sample. Updated atomically after a successful weight push when the trainer
+    # supplies a new version string.
     weight_version: str = "default"
 
     # Data parallelism

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -1944,6 +1944,12 @@ class ServerArgs:
             "pause/resume, memory occupation). Normally allocated automatically "
             "by the `ts serve` orchestrator.",
         )
+        parser.add_argument(
+            "--weight-version",
+            type=str,
+            default=ServerArgs.weight_version,
+            help="Initial model-weight version stamped into generation metadata.",
+        )
 
     @classmethod
     def from_cli_args(cls, args: argparse.Namespace):

--- a/test/runtime/test_inline_detokenizer_receiver.py
+++ b/test/runtime/test_inline_detokenizer_receiver.py
@@ -116,6 +116,7 @@ class _StubTokenizerManager(AsyncLLM):
             stream_output=stream_output,
             speculative_algorithm=speculative_algorithm,
             skip_tokenizer_init=False,
+            weight_version="test-v0",
         )
         # OutputProcessor holds a back-reference to this stub via
         # ``engine``.
@@ -356,6 +357,7 @@ class TestInlineBasicEmit(unittest.TestCase):
         self.assertEqual(
             out["meta_info"]["finish_reason"], {"type": "stop", "matched": None}
         )
+        self.assertEqual(out["meta_info"]["weight_version"], "test-v0")
         self.assertTrue(state.finished)
 
 

--- a/test/runtime/test_weight_version.py
+++ b/test/runtime/test_weight_version.py
@@ -1,0 +1,252 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Regression coverage for generation weight-version metadata."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+# CI registration (AST-parsed, runtime no-op).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=10, suite="runtime-1gpu")
+
+from tokenspeed.runtime.engine.collector import RequestOutputCollector  # noqa: E402
+from tokenspeed.runtime.engine.io_struct import BatchEmbeddingOut  # noqa: E402
+from tokenspeed.runtime.engine.output_processor import (  # noqa: E402
+    OutputProcessor,
+    ReqState,
+)
+from tokenspeed.runtime.engine.weight_transfer.manager import (  # noqa: E402
+    WeightTransferManager,
+)
+from tokenspeed.runtime.entrypoints import control_server  # noqa: E402
+from tokenspeed.runtime.entrypoints.sglang_compat_http import (  # noqa: E402
+    build_sglang_compat_app,
+)
+from tokenspeed.runtime.entrypoints.vllm_compat_http import (  # noqa: E402
+    build_vllm_compat_app,
+)
+from tokenspeed.runtime.utils.server_args import ServerArgs  # noqa: E402
+
+
+class _FakeLLM:
+    def __init__(self) -> None:
+        self.server_args = SimpleNamespace(
+            weight_version="default",
+            model="model-x",
+        )
+        self.updates = []
+        self.succeed = True
+
+    async def init_weights_update_group(self, obj):
+        return True, "initialized"
+
+    async def update_weights_from_distributed(self, obj):
+        self.updates.append(obj)
+        return self.succeed, "distributed"
+
+    async def update_weights_from_tensor(self, obj):
+        self.updates.append(obj)
+        return self.succeed, "tensor"
+
+    async def update_weights_from_disk(self, obj):
+        self.updates.append(obj)
+        return self.succeed, "disk", None
+
+
+class TestWeightTransferVersionLifecycle(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.llm = _FakeLLM()
+        self.manager = WeightTransferManager(self.llm)
+        await self.manager.init_engine(
+            {
+                "master_address": "127.0.0.1",
+                "master_port": 1234,
+                "rank_offset": 1,
+                "world_size": 2,
+            }
+        )
+        self.payload = {
+            "names": ["weight"],
+            "dtype_names": ["float32"],
+            "shapes": [[1]],
+        }
+
+    async def test_chunk_version_is_deferred_until_finish(self):
+        await self.manager.start_update()
+        await self.manager.update({**self.payload, "weight_version": "v1"})
+
+        self.assertEqual(self.manager.weight_version, "default")
+        await self.manager.finish_update()
+        self.assertEqual(self.manager.weight_version, "v1")
+
+    async def test_finish_version_overrides_chunk_version(self):
+        await self.manager.start_update()
+        await self.manager.update({**self.payload, "weight_version": "chunk"})
+
+        await self.manager.finish_update(weight_version="finish")
+        self.assertEqual(self.manager.weight_version, "finish")
+
+    async def test_missing_version_preserves_current_version(self):
+        self.llm.server_args.weight_version = "existing"
+        await self.manager.start_update()
+        await self.manager.update(self.payload)
+
+        await self.manager.finish_update()
+        self.assertEqual(self.manager.weight_version, "existing")
+
+
+class _FinishManager:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def finish_update(self, weight_version=None):
+        self.calls.append(weight_version)
+
+
+class TestWeightVersionHTTP(unittest.TestCase):
+    def test_vllm_finish_accepts_legacy_and_versioned_bodies(self):
+        manager = _FinishManager()
+        client = TestClient(build_vllm_compat_app(manager))
+
+        self.assertEqual(client.post("/finish_weight_update").status_code, 200)
+        self.assertEqual(
+            client.post("/finish_weight_update", content=b"not-json").status_code,
+            200,
+        )
+        self.assertEqual(
+            client.post(
+                "/finish_weight_update",
+                json={"weight_version": "v3"},
+            ).status_code,
+            200,
+        )
+        self.assertEqual(manager.calls, [None, None, "v3"])
+
+    def test_sglang_version_endpoints(self):
+        llm = _FakeLLM()
+        client = TestClient(build_sglang_compat_app(llm))
+
+        self.assertEqual(
+            client.get("/get_weight_version").json(),
+            {"weight_version": "default"},
+        )
+        self.assertEqual(
+            client.get("/model_info").json(),
+            {"model_path": "model-x", "weight_version": "default"},
+        )
+        response = client.post("/update_weight_version", json={"new_version": 7})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(llm.server_args.weight_version, "7")
+        self.assertEqual(
+            client.post("/update_weight_version", json={}).status_code,
+            400,
+        )
+
+    def test_sglang_updates_stamp_only_after_success(self):
+        llm = _FakeLLM()
+        client = TestClient(build_sglang_compat_app(llm))
+
+        response = client.post(
+            "/update_weights_from_distributed",
+            json={
+                "names": ["weight"],
+                "dtypes": ["float32"],
+                "shapes": [[1]],
+                "weight_version": "v8",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(llm.updates[-1].weight_version, "v8")
+        self.assertEqual(llm.server_args.weight_version, "v8")
+
+        llm.succeed = False
+        response = client.post(
+            "/update_weights_from_disk",
+            json={"model_path": "/tmp/model", "weight_version": "failed"},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(llm.server_args.weight_version, "v8")
+
+    def test_control_server_registers_version_proxy_routes(self):
+        routes = {
+            (route.path, frozenset(route.methods or []))
+            for route in control_server.app.routes
+        }
+        self.assertIn(("/get_weight_version", frozenset({"GET"})), routes)
+        self.assertIn(("/update_weight_version", frozenset({"POST"})), routes)
+
+
+class _Request:
+    stream = False
+    sampling_params = {}
+    return_logprob = False
+    log_metrics = False
+
+
+class TestGenerationVersionStamp(unittest.TestCase):
+    def test_output_meta_info_carries_current_version(self):
+        engine = SimpleNamespace(
+            server_args=SimpleNamespace(
+                weight_version="v-output",
+                speculative_algorithm=None,
+            ),
+            rid_to_state={},
+            enable_metrics=False,
+            dump_requests_folder=False,
+        )
+        state = ReqState(
+            RequestOutputCollector(),
+            False,
+            asyncio.Event(),
+            _Request(),
+            created_time=0.0,
+        )
+        engine.rid_to_state["rid"] = state
+
+        OutputProcessor(engine).handle_batch_output(
+            BatchEmbeddingOut(
+                rids=["rid"],
+                finished_reasons=[None],
+                embeddings=[[1.0]],
+                prompt_tokens=[3],
+            )
+        )
+
+        self.assertEqual(
+            state.collector.take()["meta_info"]["weight_version"],
+            "v-output",
+        )
+
+    def test_server_args_default_version(self):
+        self.assertEqual(ServerArgs(model="model-x").weight_version, "default")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/runtime/test_weight_version.py
+++ b/test/runtime/test_weight_version.py
@@ -52,7 +52,10 @@ from tokenspeed.runtime.entrypoints.sglang_compat_http import (  # noqa: E402
 from tokenspeed.runtime.entrypoints.vllm_compat_http import (  # noqa: E402
     build_vllm_compat_app,
 )
-from tokenspeed.runtime.utils.server_args import ServerArgs  # noqa: E402
+from tokenspeed.runtime.utils.server_args import (  # noqa: E402
+    ServerArgs,
+    prepare_server_args,
+)
 
 
 class _FakeLLM:
@@ -200,6 +203,7 @@ class TestWeightVersionHTTP(unittest.TestCase):
             for route in control_server.app.routes
         }
         self.assertIn(("/get_weight_version", frozenset({"GET"})), routes)
+        self.assertIn(("/model_info", frozenset({"GET"})), routes)
         self.assertIn(("/update_weight_version", frozenset({"POST"})), routes)
 
 
@@ -246,6 +250,10 @@ class TestGenerationVersionStamp(unittest.TestCase):
 
     def test_server_args_default_version(self):
         self.assertEqual(ServerArgs(model="model-x").weight_version, "default")
+
+    def test_server_args_accepts_initial_version_from_cli(self):
+        server_args = prepare_server_args(["model-x", "--weight-version", "policy-v1"])
+        self.assertEqual(server_args.weight_version, "policy-v1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Stamp every generation response with `meta_info["weight_version"]` so RL trainers can identify the policy version that produced each sample.
- Accept explicit versions through the vLLM- and SGLang-compatible weight-update APIs, while preserving the current version when the trainer omits one.
- Expose `GET /get_weight_version`, `POST /update_weight_version`, and `GET /model_info`, and document the control-plane semantics.

## Behavior

- `ServerArgs.weight_version` is the single source of truth and defaults to `"default"`.
- SGLang-compatible direct updates apply a supplied version only after the weight update succeeds.
- vLLM-compatible chunk updates defer a supplied version until `finish_weight_update`; a version on the finish request takes precedence.
- Bodyless and malformed-body `finish_weight_update` requests retain backward-compatible behavior.

## Test plan

- [x] Weight-version lifecycle and HTTP regression suite: 9/9 passed.
- [x] Inline detokenizer/output metadata suite: 22/22 passed.
- [x] Focused runtime suite: 190 passed; one unrelated failure reproduced on `main`.
- [x] B200 `runtime-1gpu` matrix: PR-relevant tests passed. Two FlashInfer `numTokensPerPage=1088` model failures were reproduced unchanged on `main`.
- [x] `pre-commit run --all-files`.

The branch is rebased on `origin/main` at `61183a2`.