### PR TITLE
refactor: drop ad-hoc usage of is hip

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/utils.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/utils.py
@@ -1038,7 +1038,7 @@ class RaggedTensorMetadata:
 
     @staticmethod
     def block_sizes_log2():
-        return range(4, 9) if torch.version.hip is not None else range(4, 8)
+        return range(4, 9)
 
     @staticmethod
     def block_sizes():

--- a/tokenspeed-kernel/test/ops/test_iris_communication.py
+++ b/tokenspeed-kernel/test/ops/test_iris_communication.py
@@ -27,6 +27,7 @@ import pytest
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
+from tokenspeed_kernel.platform import current_platform
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -44,7 +45,7 @@ def _skip_if_unsupported(world_size: int, reason_prefix: str) -> None:
         pytest.skip(f"CUDA/ROCm is required for {reason_prefix}")
     if world_size > torch.cuda.device_count():
         pytest.skip(f"Need {world_size} GPUs, have {torch.cuda.device_count()}")
-    if not torch.version.hip:
+    if not current_platform().is_amd:
         pytest.skip(f"{reason_prefix} only targets AMD ROCm")
     try:
         import iris  # noqa: F401


### PR DESCRIPTION
## Summary

Replace `torch.version.hip` with `current_platform()`

## Test Plan

<!-- How was this validated? -->
