### PR TITLE
feat: support qwen3.5 on Hopper GPUs

### DIFF
--- a/test/runtime/layers/test_gdn_flashinfer_fastpath.py
+++ b/test/runtime/layers/test_gdn_flashinfer_fastpath.py
@@ -15,7 +15,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""sm100 GDN fast-path must match the Triton FLA reference it replaces."""
+"""flashinfer GDN fast-path (Hopper sm90 / Blackwell sm100) must match the Triton FLA reference it replaces."""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ import torch.nn.functional as F
 from tokenspeed_kernel.ops.attention.flashinfer import gated_delta_rule as gdn
 
 pytestmark = pytest.mark.skipif(
-    not gdn.is_available(), reason="sm100 GDN kernel unavailable"
+    not gdn.is_available(), reason="flashinfer GDN prefill kernel unavailable"
 )
 
 
@@ -87,7 +87,7 @@ def test_matches_fla(
         head_first=False,
         use_qk_l2norm_in_kernel=True,
     )
-    o_fi, st_fi = gdn.gdn_chunk_prefill(
+    result = gdn.gdn_chunk_prefill(
         l2norm_fwd(q),
         l2norm_fwd(k),
         v,
@@ -97,6 +97,7 @@ def test_matches_fla(
         initial_state=h0.clone(),
         cu_seqlens=cu,
     )
+    o_fi, st_fi = result.out, result.final_state
 
     assert o_fi.shape == o_ref.shape
     assert o_fi.dtype == o_ref.dtype

--- a/tokenspeed-kernel/python/requirements/cuda.txt
+++ b/tokenspeed-kernel/python/requirements/cuda.txt
@@ -2,7 +2,7 @@
 nvidia-cutlass-dsl[cu13]==4.6.0
 nvidia-cutlass-dsl-libs-cu13==4.6.0
 torch==2.11.0
-flashinfer-python==0.6.13
-flashinfer-cubin==0.6.13
+flashinfer-python==0.6.14
+flashinfer-cubin==0.6.14
 nvidia-ml-py==13.580.82
 nvtx

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flashinfer/gated_delta_rule.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flashinfer/gated_delta_rule.py
@@ -15,17 +15,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""FlashInfer Blackwell (sm100) gated delta net chunked prefill.
+"""FlashInfer gated delta net chunked prefill (Hopper sm90 + Blackwell sm100/sm103).
 
-Fast-path for GDN prefill on Blackwell (sm100/sm103) + CUDA 13 + bf16 +
-head_dim==128. The caller gates on ``is_supported`` and must fail fast when the
-fast-path is unavailable;
-this module has no Triton fallback.
+Fast-path for GDN prefill on bf16 + head_dim==128. flashinfer's
+``chunk_gated_delta_rule`` is a unified API that dispatches by architecture under
+the hood to a CuTe DSL kernel per SM generation (``chunk_gated_delta_rule_sm90``
+on Hopper, ``chunk_gated_delta_rule_sm100`` on Blackwell). Both share the same
+input/output conventions and both support state checkpointing (the ``output_h``
+path). The caller gates on ``is_supported`` and must fail fast when the fast-path
+is unavailable; this module has no Triton fallback.
 
-Convention vs the Triton FLA path (verified equal to bf16 on B200):
-- q, k must be L2-normalized by the caller (the sm100 kernel ignores its own
+Convention vs the Triton FLA path (verified equal to bf16 on B200 and H200):
+- q, k must be L2-normalized by the caller (the kernel ignores its own
   use_qk_l2norm flag).
-- g is the FLA log-space forget gate; the sm100 kernel takes log internally, so
+- g is the FLA log-space forget gate; the kernel takes log internally, so
   we pass alpha = exp(g).
 - beta is cast to float32 (flashinfer passes it through without casting).
 - the recurrent state is stored transposed (K<->V) vs FLA, so we transpose the
@@ -53,13 +56,17 @@ platform = current_platform()
 SUPPORTED_HEAD_DIM = 128
 
 _chunk_gated_delta_rule = error_fn
-_has_blackwell_prefill = False
+_fi_sm90 = None
+_fi_sm100 = None
 
-if platform.is_blackwell:
+if platform.is_hopper or platform.is_blackwell:
     try:
-        from flashinfer.gdn_kernels import (
-            _has_blackwell_prefill,
-        )
+        # flashinfer >= 0.6.14 dispatches inside chunk_gated_delta_rule by
+        # architecture to a per-SM CuTe DSL kernel. Each kernel symbol is None
+        # when its module failed to import (e.g. missing nvidia-cutlass-dsl), so
+        # probe the one that matches this platform rather than assuming presence.
+        from flashinfer.gdn_kernels import chunk_gated_delta_rule_sm90 as _fi_sm90
+        from flashinfer.gdn_kernels import chunk_gated_delta_rule_sm100 as _fi_sm100
         from flashinfer.gdn_prefill import chunk_gated_delta_rule as _fi_chunk
 
         _chunk_gated_delta_rule = _fi_chunk
@@ -68,18 +75,17 @@ if platform.is_blackwell:
 
 
 def is_available() -> bool:
-    """Whether the sm100 GDN kernel can run on this platform."""
-    cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
-    # flashinfer's gdn_prefill treats compute-capability major 10 as the
-    # Blackwell path (sm100 B200/GB200, sm103 B300), gated on CUDA>=13 and the
-    # prefill kernel being present; it raises NotImplementedError otherwise.
-    # Mirror that here so the caller does not commit to a crashing fast-path.
-    return (
-        _chunk_gated_delta_rule is not error_fn
-        and platform.is_blackwell
-        and cuda_major >= 13
-        and _has_blackwell_prefill
-    )
+    """Whether the flashinfer GDN prefill kernel can run on this platform."""
+    if _chunk_gated_delta_rule is error_fn:
+        return False
+    if platform.is_hopper:
+        # sm90 Hopper CuTe DSL kernel.
+        return _fi_sm90 is not None
+    if platform.is_blackwell:
+        # sm100/sm103 Blackwell CuTe DSL kernel needs CUDA>=13.
+        cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
+        return _fi_sm100 is not None and cuda_major >= 13
+    return False
 
 
 def is_supported(
@@ -109,7 +115,7 @@ if is_available():
         name="flashinfer_gdn_chunk_prefill",
         solution="flashinfer",
         capability=CapabilityRequirement(
-            min_arch_version=ArchVersion(10, 0),
+            min_arch_version=ArchVersion(9, 0),
             max_arch_version=ArchVersion(10, 3),
             vendors=frozenset({"nvidia"}),
         ),
@@ -123,7 +129,7 @@ if is_available():
             "qk_l2norm": frozenset({False, True}),
             "output_h": frozenset({False, True}),
         },
-        tags={"blackwell", "latency"},
+        tags={"hopper", "blackwell", "latency"},
     )
     def gdn_chunk_prefill(
         q: torch.Tensor,
@@ -139,7 +145,7 @@ if is_available():
         output_final_state: bool = True,
         output_h: bool = False,
     ):
-        """Run one chunked GDN prefill on the sm100 kernel.
+        """Run one chunked GDN prefill on the flashinfer CuTe DSL kernel.
 
         q, k, v are [B, T, H, D] (B==1) or [T, H, D]; q/k already L2-normalized.
         g, beta are [B, T, H] or [T, H]; g in log space. initial_state is the FLA

--- a/tokenspeed-kernel/test/ops/test_attention_gdn.py
+++ b/tokenspeed-kernel/test/ops/test_attention_gdn.py
@@ -332,3 +332,34 @@ def test_gdn_chunk_prefill_output_h_contract(device: str, solution: str, require
 
     assert result.out.shape == v.shape
     assert result.final_state.shape == initial_state.shape
+
+
+def test_gdn_chunk_prefill_prefers_flashinfer_when_available(device: str):
+    # On any arch where the flashinfer GDN prefill fast-path is available
+    # (Hopper sm90 or Blackwell sm100/sm103), default selection must pick the
+    # SPECIALIZED flashinfer kernel over the PORTABLE triton fallback.
+    from tokenspeed_kernel.ops.attention import _attention_format_signature
+    from tokenspeed_kernel.ops.attention.flashinfer import (
+        gated_delta_rule as gdn_flashinfer,
+    )
+    from tokenspeed_kernel.selection import select_kernel
+
+    if not gdn_flashinfer.is_available():
+        pytest.skip("flashinfer GDN prefill kernel unavailable on this platform")
+
+    q, k, v, _, _, _, _ = _make_inputs(device=device, dtype=torch.bfloat16)
+    signature = _attention_format_signature(q=q, k=k, v=v)
+    kernel = select_kernel(
+        "attention",
+        "gdn_chunk_prefill",
+        signature,
+        traits={
+            "head_dim": q.shape[-1],
+            "head_v_dim": v.shape[-1],
+            "head_v_eq_head_k": v.shape[-1] == k.shape[-1],
+            "num_v_gte_num_q": v.shape[-2] >= q.shape[-2],
+            "qk_l2norm": True,
+            "output_h": False,
+        },
+    )
+    assert kernel.name == "flashinfer_gdn_chunk_prefill"


### PR DESCRIPTION
## Summary

This PR support qwen3.5 dense and moe model on Hopper GPUs, but it needs `flashinfer>=0.6.14`.

## Test Plan

The test is based on flashinfer latest main branch on H200 GPU.
Here is the server startup command:
```bash
tokenspeed serve --model "$MODEL_PATH" \
  --port "$PORT" \
  --served-model-name Qwen35-35B-A3B \
  --enable-expert-parallel \
  --moe-backend flashinfer_cutlass \
  --tensor-parallel-size 2 \
  --max-model-len 40960
```

Here is the accuracy test result using evalscope:
```
│ Model          │ Dataset   │ Metric   │ Subset   │   Num │   Score │ Cat.0   │
├────────────────┼───────────┼──────────┼──────────┼───────┼─────────┼─────────┤
│ Qwen35-35B-A3B │ gsm8k     │ mean_acc │ main     │  1319 │  0.9348 │ default │
```

Here is the bench command and result:
```bash
tokenspeed bench serve \
    --backend tokenspeed \
    --base-url "http://${HOST}:${PORT}" \
    --model "${MODEL_PATH}" \
    --tokenizer "${MODEL_PATH}" \
    --served-model-name "${SERVED_MODEL}" \
    --dataset-name random \
    --random-input-len 2048 \
    --random-output-len 2048 \
    --num-prompts 128 \
    --max-concurrency 2048 \
    --num-warmups 4
```
```
============ Serving Benchmark Result ============
Successful requests:                     128       
Failed requests:                         0         
Maximum request concurrency:             2048      
Benchmark duration (s):                  54.50     
Total input tokens:                      251519    
Total generated tokens:                  262144    
Request throughput (req/s):              2.35      
Output token throughput (tok/s):         4810.31   
Peak output token throughput (tok/s):    7224.00   
Peak concurrent requests:                128.00    
Total token throughput (tok/s):          9425.65   
---------------Time to First Token----------------
Mean TTFT (ms):                          8867.92   
Median TTFT (ms):                        2306.42   
P99 TTFT (ms):                           34174.23  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          14.08     
Median TPOT (ms):                        15.00     
P99 TPOT (ms):                           15.90     
---------------Inter-token Latency----------------
Mean ITL (ms):                           14.23     
Median ITL (ms):                         14.35     
P99 ITL (ms):                            16.38     
==================================================
```