### PR TITLE
fix(sampling): fix fused_topk_topp misaligned-address crash without losing float4 throughput

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/fused_topk_topp.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/fused_topk_topp.cu
@@ -463,15 +463,24 @@ __launch_bounds__(BLOCK_SIZE) __global__ void applyKernel(
     } else {
         // ── Mode 3.2: top-P only (radix top-p threshold) ────────────────────
         // Vectorized V-scan with float4: each thread reads/writes 16B per
-        // iteration, 4× fewer transactions than scalar. Row base is always
-        // 16B-aligned (PyTorch tensors are 256B-aligned). The tail (vocab_size
-        // not divisible by 4) is handled by a scalar epilogue.
+        // iteration, 4× fewer transactions than scalar. A float4 access must be
+        // naturally aligned, and a 16B-aligned row base is NOT guaranteed:
+        //   1. `probs`/`out_probs` may be views whose data_ptr is only 4B-aligned
+        //      (any slice or offset gather off a larger buffer), and
+        //   2. vocab_size % 4 != 0 pushes every row b >= 1 off a 16B boundary
+        //      even when the base allocation is 256B-aligned.
+        // Either one faults with "misaligned address". Gate the vector path on
+        // the actual row alignment; vec_count = 0 makes the scalar loop below
+        // cover the whole row [0, vocab_size), which is numerically identical.
         const float threshold =
             air_top_p::twiddleOut<float>(topp_counters[b].kthValueBits, false);
 
         float const* in_row = probs + b * vocab_size;
         float* out_row = out_probs + b * vocab_size;
-        const int vec_count = vocab_size / 4;            // # of float4 lanes
+        const bool vec_ok = ((reinterpret_cast<uintptr_t>(in_row) |
+                              reinterpret_cast<uintptr_t>(out_row)) &
+                             0xF) == 0;
+        const int vec_count = vec_ok ? (vocab_size / 4) : 0;  // # of float4 lanes
         const int vec_tail_start = vec_count * 4;        // start of scalar tail
 
         float4 const* in_row_v = reinterpret_cast<float4 const*>(in_row);

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/fused_topk_topp.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/fused_topk_topp.cu
@@ -329,7 +329,11 @@ size_t getWorkspaceSize(SizeType32 batchSize, SizeType32 vocabSize) {
 //
 // outProbs is pre-zeroed by an asynchronous memset on a side stream — both
 // branches write only the kept positions.
-template <int BLOCK_SIZE, int ITEMS_PER_THREAD>
+// ROWS_ALIGNED: the caller guarantees every row base of `probs`/`out_probs` is
+// 16B-aligned (both bases 16B-aligned and vocab_size % 4 == 0), so the top-p
+// V-scan can use float4 loads/stores with no peel. Decided host-side in
+// invokeFusedTopKTopP; see the mode 3.2 branch.
+template <int BLOCK_SIZE, int ITEMS_PER_THREAD, bool ROWS_ALIGNED>
 __launch_bounds__(BLOCK_SIZE) __global__ void applyKernel(
     float const* __restrict__ probs,
     float const* __restrict__ top_k_vals,
@@ -462,72 +466,146 @@ __launch_bounds__(BLOCK_SIZE) __global__ void applyKernel(
         }
     } else {
         // ── Mode 3.2: top-P only (radix top-p threshold) ────────────────────
-        // Vectorized V-scan with float4: each thread reads/writes 16B per
-        // iteration, 4× fewer transactions than scalar. A float4 access must be
-        // naturally aligned, and a 16B-aligned row base is NOT guaranteed:
+        // Vectorized V-scan with float4: each thread reads 16B per iteration,
+        // 4x fewer transactions than scalar. A float4 access must be naturally
+        // aligned, and a 16B-aligned row base is NOT guaranteed:
         //   1. `probs`/`out_probs` may be views whose data_ptr is only 4B-aligned
         //      (any slice or offset gather off a larger buffer), and
         //   2. vocab_size % 4 != 0 pushes every row b >= 1 off a 16B boundary
         //      even when the base allocation is 256B-aligned.
-        // Either one faults with "misaligned address". Gate the vector path on
-        // the actual row alignment; vec_count = 0 makes the scalar loop below
-        // cover the whole row [0, vocab_size), which is numerically identical.
+        // Either one used to fault with "misaligned address".
+        //
+        // Whether any row can be unaligned is a property of the launch (base
+        // pointers + vocab_size), so the host picks the instantiation and
+        // ROWS_ALIGNED is a compile-time constant here. Keeping it compile-time
+        // matters: a runtime branch leaves the unaligned code in the aligned
+        // path's register footprint and costs ~2.5% occupancy even on rows that
+        // never execute it.
         const float threshold =
             air_top_p::twiddleOut<float>(topp_counters[b].kthValueBits, false);
 
         float const* in_row = probs + b * vocab_size;
         float* out_row = out_probs + b * vocab_size;
-        const bool vec_ok = ((reinterpret_cast<uintptr_t>(in_row) |
-                              reinterpret_cast<uintptr_t>(out_row)) &
-                             0xF) == 0;
-        const int vec_count = vec_ok ? (vocab_size / 4) : 0;  // # of float4 lanes
-        const int vec_tail_start = vec_count * 4;        // start of scalar tail
 
-        float4 const* in_row_v = reinterpret_cast<float4 const*>(in_row);
+        if constexpr (ROWS_ALIGNED) {
+            // Every row base is 16B-aligned and in phase: no peel, no tail.
+            const int vec_count = vocab_size >> 2;
+            float4 const* in_row_v = reinterpret_cast<float4 const*>(in_row);
+            float4* out_row_v = reinterpret_cast<float4*>(out_row);
 
-        // Pass 1: sum of kept values.
-        float thread_sum = 0.0f;
-        for (int i = threadIdx.x; i < vec_count; i += BLOCK_SIZE) {
-            float4 v4 = in_row_v[i];
-            if (v4.x >= threshold) thread_sum += v4.x;
-            if (v4.y >= threshold) thread_sum += v4.y;
-            if (v4.z >= threshold) thread_sum += v4.z;
-            if (v4.w >= threshold) thread_sum += v4.w;
-        }
-        for (int i = vec_tail_start + threadIdx.x; i < vocab_size; i += BLOCK_SIZE) {
-            float v = in_row[i];
-            if (v >= threshold) thread_sum += v;
-        }
-        float row_sum = BlockReduce(temp_storage.reduce).Sum(thread_sum);
-
-        __shared__ float s_inv;
-        if (threadIdx.x == 0) {
-            s_inv = (row_sum > 1e-30f) ? (1.0f / row_sum) : 0.0f;
-        }
-        __syncthreads();
-        const float inv = s_inv;
-
-        // Pass 2: mask + renorm. Non-kept positions stay 0 (set by memset
-        // on the side stream and joined into this stream before this kernel).
-        float4* out_row_v = reinterpret_cast<float4*>(out_row);
-        for (int i = threadIdx.x; i < vec_count; i += BLOCK_SIZE) {
-            float4 v4 = in_row_v[i];
-            float4 o4;
-            o4.x = (v4.x >= threshold) ? v4.x * inv : 0.0f;
-            o4.y = (v4.y >= threshold) ? v4.y * inv : 0.0f;
-            o4.z = (v4.z >= threshold) ? v4.z * inv : 0.0f;
-            o4.w = (v4.w >= threshold) ? v4.w * inv : 0.0f;
-            // Only write the float4 if at least one lane is non-zero — keeps
-            // the write traffic ≈ kept positions × 4B in the common sharp-
-            // distribution case (most float4s have all 4 lanes below
-            // threshold and stay at their memset-0 value).
-            if (o4.x != 0.0f || o4.y != 0.0f || o4.z != 0.0f || o4.w != 0.0f) {
-                out_row_v[i] = o4;
+            float thread_sum = 0.0f;
+            for (int i = threadIdx.x; i < vec_count; i += BLOCK_SIZE) {
+                float4 v4 = in_row_v[i];
+                if (v4.x >= threshold) thread_sum += v4.x;
+                if (v4.y >= threshold) thread_sum += v4.y;
+                if (v4.z >= threshold) thread_sum += v4.z;
+                if (v4.w >= threshold) thread_sum += v4.w;
             }
-        }
-        for (int i = vec_tail_start + threadIdx.x; i < vocab_size; i += BLOCK_SIZE) {
-            float v = in_row[i];
-            if (v >= threshold) out_row[i] = v * inv;
+            float row_sum = BlockReduce(temp_storage.reduce).Sum(thread_sum);
+
+            __shared__ float s_inv;
+            if (threadIdx.x == 0) {
+                s_inv = (row_sum > 1e-30f) ? (1.0f / row_sum) : 0.0f;
+            }
+            __syncthreads();
+            const float inv = s_inv;
+
+            // Only write the float4 if at least one lane is non-zero -- keeps the
+            // write traffic ~ kept positions x 4B in the common sharp-distribution
+            // case (most float4s have all 4 lanes below threshold and stay at
+            // their memset-0 value, set on the side stream before this kernel).
+            for (int i = threadIdx.x; i < vec_count; i += BLOCK_SIZE) {
+                float4 v4 = in_row_v[i];
+                float4 o4;
+                o4.x = (v4.x >= threshold) ? v4.x * inv : 0.0f;
+                o4.y = (v4.y >= threshold) ? v4.y * inv : 0.0f;
+                o4.z = (v4.z >= threshold) ? v4.z * inv : 0.0f;
+                o4.w = (v4.w >= threshold) ? v4.w * inv : 0.0f;
+                if (o4.x != 0.0f || o4.y != 0.0f || o4.z != 0.0f || o4.w != 0.0f) {
+                    out_row_v[i] = o4;
+                }
+            }
+        } else {
+            // Some row may be unaligned. Rather than drop the whole row to a
+            // scalar loop (measured ~2x slower on this kernel -- the two V x 4B
+            // read passes dominate it, and with one block per row the slowest row
+            // gates the launch), peel it: a scalar prologue of 0-3 floats walks
+            // `in_row` up to a 16B boundary, the bulk stays vectorized, and a
+            // scalar tail finishes. Unaligned rows keep full read bandwidth.
+            const uintptr_t in_addr = reinterpret_cast<uintptr_t>(in_row);
+            const uintptr_t out_addr = reinterpret_cast<uintptr_t>(out_row);
+
+            // A float tensor is always 4B-aligned; if that ever fails, the row
+            // cannot be vectorized at all -- peel all of it.
+            const bool elem_aligned = ((in_addr | out_addr) & 0x3u) == 0;
+            const int head_want =
+                elem_aligned ? static_cast<int>(((16u - (in_addr & 15u)) & 15u) >> 2)
+                             : vocab_size;
+            const int head_end = min(head_want, vocab_size);       // end of prologue
+            const int vec_count = (vocab_size - head_end) >> 2;    // # of float4 lanes
+            const int tail_start = head_end + vec_count * 4;       // start of tail
+
+            // Stores can only ride along when `out_row` shares `in_row`'s 16B
+            // phase; otherwise no single peel aligns both. Then keep the
+            // vectorized loads and write kept lanes scalar (writes are sparse).
+            const bool store_vec = elem_aligned && ((in_addr ^ out_addr) & 15u) == 0;
+
+            float4 const* in_row_v =
+                reinterpret_cast<float4 const*>(in_row + head_end);
+            float4* out_row_v = reinterpret_cast<float4*>(out_row + head_end);
+
+            float thread_sum = 0.0f;
+            for (int i = threadIdx.x; i < head_end; i += BLOCK_SIZE) {
+                float v = in_row[i];
+                if (v >= threshold) thread_sum += v;
+            }
+            for (int i = threadIdx.x; i < vec_count; i += BLOCK_SIZE) {
+                float4 v4 = in_row_v[i];
+                if (v4.x >= threshold) thread_sum += v4.x;
+                if (v4.y >= threshold) thread_sum += v4.y;
+                if (v4.z >= threshold) thread_sum += v4.z;
+                if (v4.w >= threshold) thread_sum += v4.w;
+            }
+            for (int i = tail_start + threadIdx.x; i < vocab_size; i += BLOCK_SIZE) {
+                float v = in_row[i];
+                if (v >= threshold) thread_sum += v;
+            }
+            float row_sum = BlockReduce(temp_storage.reduce).Sum(thread_sum);
+
+            __shared__ float s_inv;
+            if (threadIdx.x == 0) {
+                s_inv = (row_sum > 1e-30f) ? (1.0f / row_sum) : 0.0f;
+            }
+            __syncthreads();
+            const float inv = s_inv;
+
+            for (int i = threadIdx.x; i < head_end; i += BLOCK_SIZE) {
+                float v = in_row[i];
+                if (v >= threshold) out_row[i] = v * inv;
+            }
+            for (int i = threadIdx.x; i < vec_count; i += BLOCK_SIZE) {
+                float4 v4 = in_row_v[i];
+                float4 o4;
+                o4.x = (v4.x >= threshold) ? v4.x * inv : 0.0f;
+                o4.y = (v4.y >= threshold) ? v4.y * inv : 0.0f;
+                o4.z = (v4.z >= threshold) ? v4.z * inv : 0.0f;
+                o4.w = (v4.w >= threshold) ? v4.w * inv : 0.0f;
+                if (o4.x != 0.0f || o4.y != 0.0f || o4.z != 0.0f || o4.w != 0.0f) {
+                    if (store_vec) {
+                        out_row_v[i] = o4;
+                    } else {
+                        float* o = out_row + head_end + i * 4;
+                        if (o4.x != 0.0f) o[0] = o4.x;
+                        if (o4.y != 0.0f) o[1] = o4.y;
+                        if (o4.z != 0.0f) o[2] = o4.z;
+                        if (o4.w != 0.0f) o[3] = o4.w;
+                    }
+                }
+            }
+            for (int i = tail_start + threadIdx.x; i < vocab_size; i += BLOCK_SIZE) {
+                float v = in_row[i];
+                if (v >= threshold) out_row[i] = v * inv;
+            }
         }
         (void)p;  // unused in this branch
     }
@@ -644,7 +722,16 @@ void invokeFusedTopKTopP(float const* probs, SizeType32 const* topKs, float cons
     // ── Stage 3: per-row apply. BLOCK=128, ITEMS=1 → MAX_K=128 sort window,
     //            and 128 threads handle V=160k via stride loops in the top-p
     //            branch (block reduce sized for 128).
-    launchKernel(enable_pdl, applyKernel<128, 1>, dim3(batchSize), dim3(128), 0, mainStream,
+    // Every row base is 16B-aligned iff both tensor bases are and vocab_size is a
+    // multiple of 4 (row b starts at base + b*vocab_size floats). Otherwise some
+    // row needs the peeled path — see the mode 3.2 branch in applyKernel. This is
+    // a launch property, so pick the instantiation here and keep the aligned
+    // kernel free of the peel code (and of its register cost).
+    const bool rowsAligned = (reinterpret_cast<uintptr_t>(probs) & 0xFu) == 0 &&
+                             (reinterpret_cast<uintptr_t>(outProbs) & 0xFu) == 0 &&
+                             (vocabSize % 4 == 0);
+    auto applyFn = rowsAligned ? applyKernel<128, 1, true> : applyKernel<128, 1, false>;
+    launchKernel(enable_pdl, applyFn, dim3(batchSize), dim3(128), 0, mainStream,
                  probs, topKVals, topKIdx, topKs, topPs, toppCounters, outProbs, vocabSize,
                  K_TOPK_MAX, enable_pdl);
 }

--- a/tokenspeed-kernel/test/ops/test_sampling.py
+++ b/tokenspeed-kernel/test/ops/test_sampling.py
@@ -281,6 +281,10 @@ def _offset_view(t: torch.Tensor, off: int) -> torch.Tensor:
         (2, 0, 8192, "probs-view-off-8B"),
         (0, 1, 8192, "out-view-off-4B"),
         (1, 1, 8192, "both-views-off-4B"),
+        # probs and out land in *different* 16B phases, so no single peel can
+        # align both: the kernel keeps vectorized loads and writes kept lanes
+        # scalar. Exercises that store path specifically.
+        (1, 2, 8192, "views-out-of-phase"),
         # (2) vocab_size % 4 != 0 pushes every row b >= 1 off a 16B boundary even
         # when the base allocation is 256B-aligned.
         (0, 0, 8191, "odd-vocab"),

--- a/tokenspeed-kernel/test/ops/test_sampling.py
+++ b/tokenspeed-kernel/test/ops/test_sampling.py
@@ -257,6 +257,77 @@ def test_fused_topk_topp_matches_pipeline(
     torch.testing.assert_close(ours, ref, atol=1e-5, rtol=1e-4)
 
 
+def _offset_view(t: torch.Tensor, off: int) -> torch.Tensor:
+    """Return a [shape]-view of ``t``'s data whose ``data_ptr`` sits ``off``
+    floats past a fresh allocation, so the row base is 4B- but not 16B-aligned.
+
+    The copy MUST be in-place: any out-of-place op would silently reallocate a
+    fresh (256B-aligned) tensor and destroy the offset under test.
+    """
+    flat = torch.empty(t.numel() + off, dtype=t.dtype, device=t.device)
+    view = flat[off : off + t.numel()].view(t.shape)
+    view.copy_(t)
+    return view
+
+
+@requires_nvidia
+@pytest.mark.parametrize(
+    "probs_off,out_off,V,tag",
+    [
+        (0, 0, 8192, "aligned-control"),
+        # (1) probs/out are views whose data_ptr is not 16B-aligned. Any slice or
+        # gather off a larger pooled buffer can produce this.
+        (1, 0, 8192, "probs-view-off-4B"),
+        (2, 0, 8192, "probs-view-off-8B"),
+        (0, 1, 8192, "out-view-off-4B"),
+        (1, 1, 8192, "both-views-off-4B"),
+        # (2) vocab_size % 4 != 0 pushes every row b >= 1 off a 16B boundary even
+        # when the base allocation is 256B-aligned.
+        (0, 0, 8191, "odd-vocab"),
+        (0, 0, 8190, "odd-vocab-2mod4"),
+    ],
+)
+def test_fused_topk_topp_unaligned_rows(
+    device: str, probs_off: int, out_off: int, V: int, tag: str
+) -> None:
+    """Rows that are not 16B-aligned must not fault.
+
+    Mode 3.2 (top-p only, reached via the top-k sentinel) scans the row with
+    float4 vector loads. A float4 access must be naturally aligned, so an
+    unaligned row base used to abort the process with CUDA "misaligned address".
+    The kernel now gates the vector path on the actual row alignment and falls
+    back to the scalar loop, which must stay numerically identical.
+    """
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA GPU is required for fused_topk_topp_renorm test")
+    torch.manual_seed(0)
+    bs = 4  # > 1, so the odd-V cases exercise a misaligned row b >= 1
+    probs = torch.softmax(
+        torch.randn(bs, V, device=device, dtype=torch.float32) * 3.0, dim=-1
+    )
+    # Sentinel top_k routes every row through the radix top-p path (mode 3.2).
+    top_ks = torch.full((bs,), _TOP_K_DISABLED, dtype=torch.int32, device=device)
+    top_ps = torch.full((bs,), 0.8, dtype=torch.float32, device=device)
+
+    ref = _ref_topk_topp(probs, top_ks, top_ps)
+
+    probs_in = _offset_view(probs, probs_off) if probs_off else probs
+    out = _offset_view(torch.empty_like(probs), out_off) if out_off else None
+    if probs_off:
+        assert probs_in.data_ptr() % 16 != 0, "offset lost; probs got re-aligned"
+
+    ours = fused_topk_topp_renorm(probs_in, top_ks, top_ps, out=out)
+    torch.cuda.synchronize()  # surface an async misaligned-address fault here
+
+    torch.testing.assert_close(
+        ours.sum(dim=-1), torch.ones(bs, device=device), atol=1e-5, rtol=1e-5
+    )
+    pos_diff = ((ref > 0) != (ours > 0)).sum(dim=-1).max().item()
+    assert pos_diff <= 1, f"[{tag}] kept-position mismatch up to {pos_diff} per row"
+    torch.testing.assert_close(ours, ref, atol=1e-5, rtol=1e-4)
+
+
 @requires_nvidia
 def test_fused_topk_topp_workspace_size_grows_with_batch(device: str) -> None:
     """Workspace size must grow monotonically with batch and vocab so callers


### PR DESCRIPTION
## Summary

`applyKernel` mode 3.2 (top-p only, reached via the `top_k` sentinel) scans each row
with `float4` vector loads and `reinterpret_cast`s the row pointer with no alignment
guard, on the assumption — stated in the source comment — that *"row base is always
16B-aligned (PyTorch tensors are 256B-aligned)"*. A `float4` access must be naturally
aligned, and that assumption is false in two independent ways, both of which abort the
process with CUDA `misaligned address`:

1. **`probs` / `out_probs` may be views** whose `data_ptr` is only 4B-aligned — any slice
   or gather off a larger pooled buffer produces one.
2. **`vocab_size % 4 != 0`** pushes every row `b >= 1` off a 16B boundary even when the
   base allocation is 256B-aligned.

**Neither needs a CUDA graph — both fault in eager mode too.** The crash was originally
attributed to side-stream capture semantics; that is a red herring. The captured verify
graph is merely where the MTP path happens to call this kernel. Since production vocabs
are all `% 4 == 0` (kimi 163840, minimax 200064), the field crash must be mechanism (1):
some tensor in the verify path arrives as a non-16B-offset view.

### Fix

Whether *any* row can be unaligned is a property of the **launch** (base pointers +
`vocab_size`), not of an individual row, so it is decided host-side in
`invokeFusedTopKTopP` and passed to `applyKernel` as a `ROWS_ALIGNED` template parameter.

* `ROWS_ALIGNED=true` compiles to **exactly the original loops** — no peel, no tail, no
  pointer-dependent branch. This is every production row.
* `ROWS_ALIGNED=false` **peels** the row: a scalar prologue of 0–3 floats walks the
  pointer up to a 16B boundary, the bulk stays vectorized, and a scalar tail finishes it.
  Unaligned rows keep full read bandwidth instead of collapsing to a scalar loop.
* When `probs` and `out_probs` sit in **different 16B phases**, no single peel can align
  both; that case keeps the vectorized loads and writes the kept lanes scalar (writes are
  sparse anyway).

Keeping the decision at compile time is load-bearing. The first commit on this branch
gated the vector path on a runtime `vec_ok` bool derived from the row pointers; because
that is opaque to the compiler, it pessimized the hot loop **even for rows that are
aligned**, costing ~27% on all production traffic. The second commit fixes that. The two
commits are kept separate so the measurement of the naive scalar-fallback approach stays
in the history.

### Performance

B200, mode 3.2, medians over 300 iters, **idle GPU**, builds interleaved A/B so drift
cannot bias the comparison. `pre-fix` faults on unaligned input, so it has no number there.

| rows | V | rows aligned? | pre-fix | scalar fallback (1st commit) | **this branch** |
|---|---|---|---|---|---|
| 40 | 163840 | yes | — | 169.0 µs | **128.1 µs** |
| 40 | 163840 | no | `misaligned address` | 331.6 µs | **179.0 µs** |
| 160 | 163840 | yes | 345.4 µs | 436.2 µs | **344.8 µs** |
| 160 | 163840 | no | `misaligned address` | 845.9 µs | **458.2 µs** |
| 512 | 163840 | yes | — | 969.9 µs | **879.3 µs** |
| 512 | 163840 | no | `misaligned address` | 1386.4 µs | **986.3 µs** |
| 160 | 200060 | yes | — | 548.3 µs | **410.9 µs** |
| 160 | 200058 | no (odd V) | `misaligned address` | 1062.1 µs | **572.4 µs** |

Aligned rows are back to pre-fix cost (345.4 → 344.8 µs) with **bit-identical output**;
unaligned rows run ~1.85× faster than the scalar fallback and no longer crash. Odd-V is
now roughly on par with even-V rather than ~2× off.

## Test Plan

* New `test_fused_topk_topp_unaligned_rows` covers both mechanisms — offset `probs` /
  `out` views (4B and 8B), an out-of-phase `probs` vs `out` pair (the scalar-store path),
  and `vocab_size % 4 != 0` with `bs > 1` — plus an aligned control.
  **It fails on the unpatched kernel with `misaligned address` and passes with this
  change.** The pre-existing tests all used `V=8192` with freshly allocated (aligned)
  tensors, which is why this went unnoticed.
* Full `tokenspeed-kernel/test/ops/test_sampling.py`: **39 passed**.
* Output on aligned input verified **bit-identical** (`array_equal`, not just within
  tolerance) against the pre-fix kernel, confirming the speedup is not skipped work.
* Standalone repro (offset views + odd V, eager and CUDA-graph capture/replay): all cases
  pass; numerics match a torch top-p reference to ~6e-8.
