### PR TITLE
perf(kernel): tune gfx950 A4W4 MXFP4 MoE for Kimi-K2.5 (decode cap + prefill tile)

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
@@ -8145,6 +8145,24 @@ def _maybe_route_owned_mxfp4_mfma_decode(
             return None
         if correction_bias is not None and (n_group != 0 or topk_group != 0):
             return None
+        # Scaling-semantics guard. For the grouped-one-group config
+        # (n_group == topk_group == 1) the generic path routes through
+        # ``default_grouped_route`` -> ``_grouped_topk_reference``, which does
+        # NOT apply ``routed_scaling_factor`` when weights are left unnormalized
+        # (scale_when_unnormalized=False). ``invoke_softmax_topk_route_gluon``
+        # always multiplies by ROUTED_SCALING_FACTOR, so those two disagree by
+        # exactly ``routed_scaling_factor`` for unnormalized weights. Defer that
+        # case to the generic path so results are unchanged. (The non-grouped
+        # n_group==topk_group==0 case uses default_scaled_route ->
+        # _softmax_topk_reference with scale_when_unnormalized=True, which
+        # matches the gluon kernel, so it is safe here.)
+        uses_grouped = _uses_grouped_routing(n_group, topk_group)
+        if (
+            uses_grouped
+            and not normalize_topk_weights
+            and float(routed_scaling_factor) != 1.0
+        ):
+            return None
         topk_ids, topk_weights = invoke_softmax_topk_route_gluon(
             router_logits,
             top_k,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
@@ -8382,34 +8382,21 @@ def _maybe_gluon_package_mxfp4_prefill(
 
     q_inter, q_inter_scale = _quantize_mxfp4_activation(inter_flat)
 
-    # Stage 2 uses its own, smaller-block sort at small M. When tokens spread
-    # across many experts (e.g. top-8 over 384 experts at M<=512), a 128-row
-    # per-expert pad inflates the routed extent ~40x, so the down-projection
-    # GEMM burns almost all of its MFMA cycles on padding rows. A 32/64 sort
-    # block cuts that padding proportionally. Stage 1 keeps the 128 layout its
-    # kernel requires; stage 2 is free to use a different layout because it
-    # indexes ``inter_flat`` by ``(token, slot)``, not by stage-1 sorted slot.
-    stage2_block_m = 32 if n_tokens <= 512 else (64 if n_tokens <= 1024 else 128)
-    if stage2_block_m == sort_block_m:
-        s2_sorted_ids = sorted_ids
-        s2_sorted_weights = sorted_weights
-        s2_sorted_expert_ids = sorted_expert_ids
-        s2_num_valid_ids = num_valid_ids
-    else:
-        (
-            s2_sorted_ids,
-            s2_sorted_weights,
-            s2_sorted_expert_ids,
-            s2_num_valid_ids,
-            _,
-        ) = gluon_moe_sorting(
-            topk_ids,
-            topk_weights,
-            n_experts,
-            hidden_dim,
-            out_dtype,
-            stage2_block_m,
-        )
+    # Stage 2 down-projection block size. A smaller block reduces per-expert
+    # 128-row sort padding (top-8 over 384 experts), but on gfx950 the
+    # MFMA-utilization win of the 128-row tile dominates that padding cost.
+    # Sweep-tuned on the Kimi TP4 shard (E=384, D=7168, I=512, topk=8),
+    # BLOCK_M=128 is 10-17% faster than the old 32/64 tiers at M<=1024 and is
+    # fastest at every M; on the gpt-oss shape (E=128, topk=4) it is within ~1%
+    # of the old tiers (no regression). Forcing sort_block_m<128 at large M also
+    # overflows the routed buffers (illegal access), so a flat 128 is both
+    # faster and safer. It also matches ``sort_block_m``, so stage 2 reuses the
+    # stage-1 sort directly (no second moe_sorting pass).
+    stage2_block_m = 128
+    s2_sorted_ids = sorted_ids
+    s2_sorted_weights = sorted_weights
+    s2_sorted_expert_ids = sorted_expert_ids
+    s2_num_valid_ids = num_valid_ids
 
     stage2_scale = gather_package_cdna4_scale(
         q_inter_scale,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/fused_mxfp_gfx950.py
@@ -8555,7 +8555,7 @@ def gluon_mxfp_dynamic_mxfp4_fused_moe(
                     return decode_out
 
     else:
-        if int(n_tokens) <= _ROUTE_OWNED_DECODE_MAX_M:
+        if int(n_tokens) <= _DECODE_MAX_M:
             decode_out = _maybe_route_owned_mxfp4_mfma_decode(
                 hidden_states,
                 router_logits,
@@ -8573,11 +8573,11 @@ def gluon_mxfp_dynamic_mxfp4_fused_moe(
                 w13_bias=w13_bias,
                 w2_bias=w2_bias,
                 out_dtype=out_dtype,
-                max_m=_ROUTE_OWNED_DECODE_MAX_M,
+                max_m=_DECODE_MAX_M,
                 swiglu_alpha=swiglu_alpha,
                 swiglu_limit=swiglu_limit,
                 swiglu_beta=swiglu_beta,
-                allow_generic_fallback=False,
+                allow_generic_fallback=True,
             )
             if decode_out is not None:
                 return decode_out

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/prefill_stage1.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/prefill_stage1.py
@@ -626,6 +626,10 @@ def gluon_mxfp4_moe_stage1_kernel(
         B_SCALE_K_STEP: gl.constexpr = 1024
     b_scale_static_offs_gate = b_n_part_gate_scale + b_k_lane_offsets
     b_scale_static_offs_up = b_n_part_up_scale + b_k_lane_offsets
+
+    b_off_gate = b_scale_static_offs_gate
+    b_off_up = b_scale_static_offs_up
+
     b_scales_ptr_e = b_scales_ptr + off_experts.to(gl.int64) * stride_bse_e
 
     # ---- LDS allocation (2 A-data slots, ping-pong) --------------------
@@ -680,18 +684,8 @@ def gluon_mxfp4_moe_stage1_kernel(
         offs_b_up,
         0,
     )
-    b_scale_gate = _load_b_scale_vgpr(
-        b_scales_ptr_e,
-        b_scale_static_offs_gate,
-        0,
-        B_SCALE_K_STEP,
-    )
-    b_scale_up = _load_b_scale_vgpr(
-        b_scales_ptr_e,
-        b_scale_static_offs_up,
-        0,
-        B_SCALE_K_STEP,
-    )
+    b_scale_gate = _load_b_scale_vgpr(b_scales_ptr_e, b_off_gate, 0, B_SCALE_K_STEP)
+    b_scale_up = _load_b_scale_vgpr(b_scales_ptr_e, b_off_up, 0, B_SCALE_K_STEP)
 
     cdna4_async_copy.wait_group(0)
     cur_a_group0 = _read_a_lds_group(
@@ -780,16 +774,10 @@ def gluon_mxfp4_moe_stage1_kernel(
             nxt_b_data_off,
         )
         next_bsc_gate = _load_b_scale_vgpr(
-            b_scales_ptr_e,
-            b_scale_static_offs_gate,
-            nxt_b_scale_k,
-            B_SCALE_K_STEP,
+            b_scales_ptr_e, b_off_gate, nxt_b_scale_k, B_SCALE_K_STEP
         )
         next_bsc_up = _load_b_scale_vgpr(
-            b_scales_ptr_e,
-            b_scale_static_offs_up,
-            nxt_b_scale_k,
-            B_SCALE_K_STEP,
+            b_scales_ptr_e, b_off_up, nxt_b_scale_k, B_SCALE_K_STEP
         )
 
         # MFMA groups 0,1 with current A[k] + current B[k].
@@ -952,16 +940,10 @@ def gluon_mxfp4_moe_stage1_kernel(
             nxt_b_data_off,
         )
         next_bsc_gate = _load_b_scale_vgpr(
-            b_scales_ptr_e,
-            b_scale_static_offs_gate,
-            nxt_b_scale_k,
-            B_SCALE_K_STEP,
+            b_scales_ptr_e, b_off_gate, nxt_b_scale_k, B_SCALE_K_STEP
         )
         next_bsc_up = _load_b_scale_vgpr(
-            b_scales_ptr_e,
-            b_scale_static_offs_up,
-            nxt_b_scale_k,
-            B_SCALE_K_STEP,
+            b_scales_ptr_e, b_off_up, nxt_b_scale_k, B_SCALE_K_STEP
         )
 
         gate_acc_group0 = _compute_mxfp4_group(
@@ -1117,16 +1099,10 @@ def gluon_mxfp4_moe_stage1_kernel(
             nxt_b_data_off,
         )
         next_bsc_gate = _load_b_scale_vgpr(
-            b_scales_ptr_e,
-            b_scale_static_offs_gate,
-            nxt_b_scale_k,
-            B_SCALE_K_STEP,
+            b_scales_ptr_e, b_off_gate, nxt_b_scale_k, B_SCALE_K_STEP
         )
         next_bsc_up = _load_b_scale_vgpr(
-            b_scales_ptr_e,
-            b_scale_static_offs_up,
-            nxt_b_scale_k,
-            B_SCALE_K_STEP,
+            b_scales_ptr_e, b_off_up, nxt_b_scale_k, B_SCALE_K_STEP
         )
 
         gate_acc_group0 = _compute_mxfp4_group(

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/scale.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a4w4_gfx950/scale.py
@@ -37,12 +37,18 @@ import torch
 import triton
 import triton.language as tl
 
-# MXFP4 microblock size and the CDNA4 scale-swizzle alignment. These are fixed
-# properties of the CDNA4 MXFP4 scale layout, kept local so the package is
-# self-contained.
-_MXFP4_BLOCK = 32
-_NON_K_PRESHUFFLE_BLOCK_SIZE = 32
-_ALIGN_K_SCALE_SWIZZLE = 8
+# MXFP4 microblock size and the CDNA4 scale-swizzle alignment are defined once in
+# mxfp4_cdna4_scale_layout, shared with the weight-scale (B) preshuffle in the
+# preprocessor. Local aliases preserve the names used throughout this module.
+from tokenspeed_kernel_amd.ops.moe.mxfp4_cdna4_scale_layout import (
+    CDNA4_SCALE_K_BLOCK as _ALIGN_K_SCALE_SWIZZLE,
+)
+from tokenspeed_kernel_amd.ops.moe.mxfp4_cdna4_scale_layout import (
+    CDNA4_SCALE_N_BLOCK as _NON_K_PRESHUFFLE_BLOCK_SIZE,
+)
+from tokenspeed_kernel_amd.ops.moe.mxfp4_cdna4_scale_layout import (
+    MXFP4_BLOCK as _MXFP4_BLOCK,
+)
 
 
 @triton.jit

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/mxfp4_cdna4_scale_layout.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/mxfp4_cdna4_scale_layout.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Single source of truth for the gfx950 A4W4 CDNA4 MXFP4 scale layout.
+
+Both scale producers and consumers must agree on the CDNA4 MXFP4 scale-swizzle
+parameters and byte permutation:
+
+* B-scales (weights): swizzled at load time by the weight preprocessor
+  (``mxfp4_gfx950_preprocess._swizzle_mxfp4`` via
+  :func:`swizzle_cdna4_mxfp4_scale`).
+* A-scales (activations): emitted in token order by the MXFP4 activation
+  quantizer and re-gathered into sorted-route order by
+  ``gluon_a4w4_gfx950.scale.gather_package_cdna4_scale``.
+* Consumers: the package stage kernels (``prefill_stage1/2``,
+  ``decode_stage1/2``) address the scales with the matching CDNA4 MFMA scale
+  layout (``gl.amd.cdna4.get_mfma_scale_layout``).
+
+Historically these constants were duplicated (under different names) across the
+preprocessor and the activation-scale gather. Centralizing them here makes a
+scale-layout change a single-file edit: update the constants / permutation
+below, keep the stage-kernel scale addressing in sync, and the bit-exact
+package tests gate correctness.
+
+This module is intentionally a leaf (only depends on ``torch``) so every
+producer/consumer can import it without pulling in the Triton stage kernels.
+
+
+Why a swizzle at all
+--------------------
+An MXFP4 tensor carries one e8m0 block scale per 32 elements along K. The
+gfx950 ``v_mfma_scale_f32_*`` instructions consume those block scales from a
+*fixed distribution across the 64 lanes and their VGPRs* -- each lane must
+already hold the scale bytes for the (row, K-block) coordinates it is
+responsible for. A plain row-major ``(N, K//32)`` scale array does not land in
+those positions under a coalesced load, so we permute the bytes at load time
+(the "swizzle") such that a single direct global->VGPR gather drops every byte
+where the MFMA expects it, with no in-kernel shuffle.
+
+The permutation is dictated entirely by the MFMA instruction shape the stage
+kernels issue. We support exactly one shape, ``mfma16`` (16x16x128), so there
+is a single scale swizzle (:func:`swizzle_cdna4_mxfp4_scale`). Producer and
+consumer are hard-coupled: the byte order this swizzle bakes into memory must
+match the ``get_mfma_scale_layout`` the stage kernels address with, so any
+change here must be mirrored in the kernels' scale addressing.
+
+The swizzled scales feed a direct global->VGPR gather in the stage kernels, so
+the scale bytes arrive in registers already distributed for the MFMA with no
+in-kernel shuffle.
+"""
+
+from __future__ import annotations
+
+import torch
+
+# MXFP4 microblock: one e8m0 block scale per 32 elements along the K (reduction)
+# axis. Fixed by the OCP MXFP4 format.
+MXFP4_BLOCK = 32
+
+# CDNA4 scale-swizzle block sizes.
+#   N (non-K / row) preshuffle block: rows are grouped/padded to multiples of 32.
+#   K (scale) swizzle alignment: the per-32-element scale columns are grouped
+#   and padded to multiples of 8.
+CDNA4_SCALE_N_BLOCK = 32
+CDNA4_SCALE_K_BLOCK = 8
+
+# MFMA non-K dimension used by the a4w4 stage kernels
+# (``v_mfma_scale_f32_16x16x128_f8f6f4``). The scale swizzle below is fixed to
+# this shape.
+MFMA_NONK_DIM = 16
+
+__all__ = [
+    "MXFP4_BLOCK",
+    "CDNA4_SCALE_N_BLOCK",
+    "CDNA4_SCALE_K_BLOCK",
+    "MFMA_NONK_DIM",
+    "swizzle_cdna4_mxfp4_scale",
+]
+
+
+def swizzle_cdna4_mxfp4_scale(scale: torch.Tensor) -> torch.Tensor:
+    """CDNA4 MXFP4 block-scale swizzle for the 16x16x128 MFMA (canonical).
+
+    This is the single canonical definition of the B-scale (and, structurally,
+    the A-scale) CDNA4 swizzle used by the runtime. Any change here must be
+    mirrored in the stage kernels' scale addressing.
+
+    Input:  MXFP4 block scales with the logical ``(..., N, K // 32)`` layout
+            (last two dims are rows and per-block scale columns).
+    Output: CDNA4-swizzled scales with ``stride(-2) == 1`` (the byte order the
+            CDNA4 16x16x128 MFMA scaled-dot path expects for the B operand).
+
+    Lane 0 access block (what one lane reads)
+    -----------------------------------------
+    For a 32-row x 8-K-block tile, the swizzle interleaves rows in 16-apart
+    pairs ``(n, n + 16)`` and K-blocks in 4-apart pairs ``(kb, kb + 4)`` so the
+    first eight bytes a coalesced load anchored at lane 0 sees are::
+
+        mem[0] = (n=0,  kb=0)     mem[4] = (n=1,  kb=0)
+        mem[1] = (n=16, kb=0)     mem[5] = (n=17, kb=0)
+        mem[2] = (n=0,  kb=4)     mem[6] = (n=1,  kb=4)
+        mem[3] = (n=16, kb=4)     mem[7] = (n=17, kb=4)
+
+    i.e. lane 0 ends up holding the scale bytes for the row/K-block quarters the
+    16x16x128 ``mfma_scaled`` op reduces over -- two 16-row halves and two
+    K-quarters spaced 4 blocks apart -- with no in-kernel shuffle. That
+    (row-pair, K-quarter-pair) grouping is exactly the permutation encoded by
+    ``view(N//32, 2, 16, K//8, 2, 4, 1).permute(N//32, K//8, 4, 16, 2, 2, 1)``
+    below.
+    """
+    if scale.ndim < 2:
+        raise ValueError("MXFP4 scale tensor must have at least 2 dimensions")
+    scale = scale.transpose(-2, -1).contiguous()
+    *leading_shape, k_scale, n = scale.shape
+    leading = 1
+    for dim in leading_shape:
+        leading *= dim
+    k_scale_pad = (k_scale + CDNA4_SCALE_K_BLOCK - 1) // CDNA4_SCALE_K_BLOCK
+    k_scale_pad *= CDNA4_SCALE_K_BLOCK
+    n_pad = (n + CDNA4_SCALE_N_BLOCK - 1) // CDNA4_SCALE_N_BLOCK
+    n_pad *= CDNA4_SCALE_N_BLOCK
+
+    scale = scale.mT.contiguous().mT
+    scale = torch.nn.functional.pad(scale, (0, n_pad - n, 0, k_scale_pad - k_scale))
+    scale = scale.transpose(-1, -2)
+    scale = scale.reshape(leading, n_pad, k_scale_pad)
+    scale = scale.view(leading, n_pad // 32, 2, 16, k_scale_pad // 8, 2, 4, 1)
+    scale = scale.permute(0, 1, 4, 6, 3, 5, 2, 7).contiguous()
+    scale = scale.reshape(leading, n_pad // 32, k_scale_pad * 32)
+    scale = scale.transpose(-1, -2)
+    assert scale.stride(-2) == 1
+    return scale

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/mxfp4_cdna4_scale_layout.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/mxfp4_cdna4_scale_layout.py
@@ -43,7 +43,7 @@ This module is intentionally a leaf (only depends on ``torch``) so every
 producer/consumer can import it without pulling in the Triton stage kernels.
 
 
-Why a swizzle at all
+Why swizzle at all
 --------------------
 An MXFP4 tensor carries one e8m0 block scale per 32 elements along K. The
 gfx950 ``v_mfma_scale_f32_*`` instructions consume those block scales from a

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/mxfp4_gfx950_preprocess.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/mxfp4_gfx950_preprocess.py
@@ -25,10 +25,24 @@ from typing import Any
 
 import torch
 
-_MXFP_BLOCK_SIZE = 32
+# CDNA4 MXFP4 scale layout is defined once in mxfp4_cdna4_scale_layout so the
+# weight-scale (B) preshuffle here and the activation-scale (A) gather in
+# gluon_a4w4_gfx950.scale stay in lock-step. Local aliases preserve the
+# historical private names used throughout this module.
+from tokenspeed_kernel_amd.ops.moe.mxfp4_cdna4_scale_layout import (
+    CDNA4_SCALE_K_BLOCK as _CDNA4_SCALE_K_BLOCK,
+)
+from tokenspeed_kernel_amd.ops.moe.mxfp4_cdna4_scale_layout import (
+    CDNA4_SCALE_N_BLOCK as _CDNA4_SCALE_N_BLOCK,
+)
+from tokenspeed_kernel_amd.ops.moe.mxfp4_cdna4_scale_layout import (
+    MXFP4_BLOCK as _MXFP_BLOCK_SIZE,
+)
+from tokenspeed_kernel_amd.ops.moe.mxfp4_cdna4_scale_layout import (
+    swizzle_cdna4_mxfp4_scale as _swizzle_cdna4_mxfp4_scale,
+)
+
 _GLUON_COMBINE_BLOCK_N = 128
-_CDNA4_SCALE_N_BLOCK = 32
-_CDNA4_SCALE_K_BLOCK = 8
 
 
 @dataclass
@@ -71,32 +85,6 @@ def _make_k_packed_mxfp4_weight(quant_tensor: torch.Tensor) -> torch.Tensor:
     )
     out.copy_(quant_tensor.transpose(-2, -1))
     return out
-
-
-def _swizzle_cdna4_mxfp4_scale(scale: torch.Tensor) -> torch.Tensor:
-    """Match triton_kernels' CDNA4MXScaleLayout byte swizzle using PyTorch ops."""
-    if scale.ndim < 2:
-        raise ValueError("MXFP4 scale tensor must have at least 2 dimensions")
-    scale = scale.transpose(-2, -1).contiguous()
-    *leading_shape, k_scale, n = scale.shape
-    leading = 1
-    for dim in leading_shape:
-        leading *= dim
-    k_scale_pad = (k_scale + _CDNA4_SCALE_K_BLOCK - 1) // _CDNA4_SCALE_K_BLOCK
-    k_scale_pad *= _CDNA4_SCALE_K_BLOCK
-    n_pad = (n + _CDNA4_SCALE_N_BLOCK - 1) // _CDNA4_SCALE_N_BLOCK
-    n_pad *= _CDNA4_SCALE_N_BLOCK
-
-    scale = scale.mT.contiguous().mT
-    scale = torch.nn.functional.pad(scale, (0, n_pad - n, 0, k_scale_pad - k_scale))
-    scale = scale.transpose(-1, -2)
-    scale = scale.reshape(leading, n_pad, k_scale_pad)
-    scale = scale.view(leading, n_pad // 32, 2, 16, k_scale_pad // 8, 2, 4, 1)
-    scale = scale.permute(0, 1, 4, 6, 3, 5, 2, 7).contiguous()
-    scale = scale.reshape(leading, n_pad // 32, k_scale_pad * 32)
-    scale = scale.transpose(-1, -2)
-    assert scale.stride(-2) == 1
-    return scale
 
 
 def _swizzle_mxfp4(quant_tensor: torch.Tensor, scale: torch.Tensor, num_warps: int):

--- a/tokenspeed-kernel-amd/test/ops/test_mxfp4_clean_warp_decode_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_mxfp4_clean_warp_decode_gfx950.py
@@ -1451,3 +1451,93 @@ def test_kernel_routing_decode_reaches_route_owned_up_to_decode_max_m(
     # the precomputed-MFMA decode kernel for the M=3..8 range.
     assert captured["max_m"] == fused_mxfp_gfx950._DECODE_MAX_M
     assert captured["allow_generic_fallback"] is True
+
+
+@pytest.mark.parametrize("num_tokens", [16, 64, 256])
+def test_package_prefill_stage2_bm128_matches_ragged_reference(
+    num_tokens: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Package prefill (flat stage2 BLOCK_M=128) must match the ragged reference.
+
+    The package-prefill path (stage1/stage2 kernels, stage2 down-proj at the
+    tuned flat BLOCK_M=128) must be bit-exact against the generic ragged
+    reference (``_gluon_mxfp_dynamic_mxfp4_fused_moe_from_route`` reached by
+    disabling package prefill). This pins the correctness of the BLOCK_M=128
+    tuning change: it is 10-17% faster on Kimi with no gpt-oss regression, and
+    here we confirm it does not change the MoE result.
+    """
+    hidden_size = 1024
+    intermediate_size = 512
+    num_experts = 16
+    topk = 4
+    device = "cuda"
+    gen = torch.Generator(device=device).manual_seed(20260716 + num_tokens)
+    hidden = (
+        torch.randn(
+            (num_tokens, hidden_size),
+            device=device,
+            dtype=torch.bfloat16,
+            generator=gen,
+        )
+        * 0.01
+    ).contiguous()
+    router = torch.randn(
+        (num_tokens, num_experts), device=device, dtype=torch.bfloat16, generator=gen
+    )
+    topk_weights, topk_ids = torch.topk(torch.softmax(router.float(), dim=-1), topk)
+    topk_ids = topk_ids.to(torch.int32).contiguous()
+    topk_weights = topk_weights.to(torch.float32).contiguous()
+    w13, w13_scale, w2, w2_scale = _make_weights(
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        device=device,
+    )
+    layer = _make_preprocessed_layer(
+        w13,
+        w13_scale,
+        w2,
+        w2_scale,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        device=device,
+    )
+
+    def run():
+        return fused_mxfp_gfx950.gluon_mxfp_dynamic_mxfp4_fused_moe(
+            hidden,
+            router,
+            layer.w13_weight_triton_tensor,
+            layer.w2_weight_triton_tensor,
+            w13_mx_scale=layer.w13_precision_config.b_mx_scale,
+            w2_mx_scale=layer.w2_precision_config.b_mx_scale,
+            top_k=topk,
+            correction_bias=None,
+            n_group=1,
+            topk_group=1,
+            routed_scaling_factor=1.0,
+            normalize_topk_weights=True,
+            routing_method_type=0,
+            out_dtype=torch.bfloat16,
+            precomputed_topk_weights=topk_weights,
+            precomputed_topk_ids=topk_ids,
+        )
+
+    # Reference: disable package prefill so the dispatch falls to the generic
+    # ragged path (the trusted MXFP4 MoE reference).
+    monkeypatch.setattr(
+        fused_mxfp_gfx950,
+        "_maybe_gluon_package_mxfp4_prefill",
+        lambda *args, **kwargs: None,
+    )
+    ref = run()
+    torch.cuda.synchronize()
+
+    # Package prefill (flat stage2 BLOCK_M=128).
+    monkeypatch.undo()
+    out = run()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(out.float(), ref.float(), rtol=0.0, atol=0.0)

--- a/tokenspeed-kernel-amd/test/ops/test_mxfp4_clean_warp_decode_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_mxfp4_clean_warp_decode_gfx950.py
@@ -1541,3 +1541,167 @@ def test_package_prefill_stage2_bm128_matches_ragged_reference(
     torch.cuda.synchronize()
 
     torch.testing.assert_close(out.float(), ref.float(), rtol=0.0, atol=0.0)
+
+
+@pytest.mark.parametrize(
+    "normalize, rsf, expect_bail",
+    [
+        (False, 2.5, True),  # divergent: grouped-one-group, unnormalized, rsf!=1
+        (True, 2.5, False),  # normalized -> gluon kernel matches generic
+        (False, 1.0, False),  # rsf==1 -> scaling is a no-op, matches generic
+    ],
+)
+def test_route_owned_bails_on_unnormalized_grouped_scaling(
+    normalize: bool,
+    rsf: float,
+    expect_bail: bool,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Route-owned decode must defer the grouped-one-group unnormalized-scaling
+    case to the generic path.
+
+    For n_group == topk_group == 1 with no correction bias, the generic path
+    (default_grouped_route -> _grouped_topk_reference) does NOT apply
+    routed_scaling_factor when weights are unnormalized
+    (scale_when_unnormalized=False), but invoke_softmax_topk_route_gluon always
+    multiplies by ROUTED_SCALING_FACTOR. Route-owned decode must return None
+    (bail to generic) in that config, and must NOT bail when the config is safe
+    (normalized, or routed_scaling_factor == 1).
+    """
+    n_tokens = 8
+    hidden = torch.empty((n_tokens, 8), device="cuda", dtype=torch.bfloat16)
+    router = torch.randn((n_tokens, 8), device="cuda", dtype=torch.bfloat16)
+    dummy_w = torch.empty((1, 4, 4), device="cuda", dtype=torch.uint8)
+    dummy_scale = torch.empty((1, 4, 1), device="cuda", dtype=torch.uint8)
+
+    route_called = 0
+
+    def spy_softmax_route(*args, **kwargs):
+        nonlocal route_called
+        route_called += 1
+        # Return shape-correct dummies so the (unused for this assertion)
+        # downstream decode returns None on the dummy weights.
+        ids = torch.zeros((n_tokens, 2), device="cuda", dtype=torch.int32)
+        wts = torch.ones((n_tokens, 2), device="cuda", dtype=torch.float32)
+        return ids, wts
+
+    import tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.routing as routing_mod
+
+    monkeypatch.setattr(
+        routing_mod, "invoke_softmax_topk_route_gluon", spy_softmax_route
+    )
+
+    out = fused_mxfp_gfx950._maybe_route_owned_mxfp4_mfma_decode(
+        hidden,
+        router,
+        dummy_w,
+        dummy_w,
+        w13_mx_scale=dummy_scale,
+        w2_mx_scale=dummy_scale,
+        top_k=2,
+        correction_bias=None,
+        n_group=1,
+        topk_group=1,
+        routed_scaling_factor=rsf,
+        normalize_topk_weights=normalize,
+        routing_method_type=0,
+        w13_bias=None,
+        w2_bias=None,
+        out_dtype=torch.bfloat16,
+        max_m=fused_mxfp_gfx950._DECODE_MAX_M,
+        swiglu_alpha=1.702,
+        swiglu_limit=7.0,
+        swiglu_beta=1.0,
+        allow_generic_fallback=False,
+    )
+
+    if expect_bail:
+        # Guard fired before routing: no gluon route call, returns None.
+        assert out is None
+        assert route_called == 0
+    else:
+        # Safe config: the guard did not fire, so the gluon route ran (the
+        # decode then returns None on the dummy weights, which is fine here --
+        # we only assert the guard let it through to routing).
+        assert route_called == 1
+
+
+@pytest.mark.parametrize("num_tokens", [4, 8])
+def test_route_owned_grouped_unnormalized_matches_generic(num_tokens: int):
+    """End-to-end: the divergent config must match the generic path exactly.
+
+    With the guard in place, the grouped-one-group unnormalized-scaling config
+    is deferred to the generic route, so gluon_mxfp_dynamic_mxfp4_fused_moe must
+    produce the same result as the generic ragged path (decode disabled).
+    """
+    hidden_size = 1024
+    intermediate_size = 512
+    num_experts = 8
+    topk = 2
+    rsf = 2.5
+    device = "cuda"
+    gen = torch.Generator(device=device).manual_seed(20260716 + num_tokens)
+    hidden = (
+        torch.randn(
+            (num_tokens, hidden_size),
+            device=device,
+            dtype=torch.bfloat16,
+            generator=gen,
+        )
+        * 0.01
+    ).contiguous()
+    router = torch.randn(
+        (num_tokens, num_experts), device=device, dtype=torch.bfloat16, generator=gen
+    )
+    w13, w13_scale, w2, w2_scale = _make_weights(
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        device=device,
+    )
+    layer = _make_preprocessed_layer(
+        w13,
+        w13_scale,
+        w2,
+        w2_scale,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        device=device,
+    )
+
+    def run():
+        return fused_mxfp_gfx950.gluon_mxfp_dynamic_mxfp4_fused_moe(
+            hidden,
+            router,
+            layer.w13_weight_triton_tensor,
+            layer.w2_weight_triton_tensor,
+            w13_mx_scale=layer.w13_precision_config.b_mx_scale,
+            w2_mx_scale=layer.w2_precision_config.b_mx_scale,
+            top_k=topk,
+            correction_bias=None,
+            n_group=1,
+            topk_group=1,
+            routed_scaling_factor=rsf,
+            normalize_topk_weights=False,
+            routing_method_type=0,
+            w13_bias=None,
+            w2_bias=None,
+        )
+
+    # Reference: force the fully-generic path (no decode fast path).
+    import unittest.mock as _mock
+
+    with _mock.patch.object(
+        fused_mxfp_gfx950,
+        "_maybe_route_owned_mxfp4_mfma_decode",
+        lambda *a, **k: None,
+    ):
+        ref = run()
+        torch.cuda.synchronize()
+
+    # Real path: the guard should defer this config to the same generic route.
+    out = run()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(out.float(), ref.float(), rtol=0.0, atol=0.0)

--- a/tokenspeed-kernel-amd/test/ops/test_mxfp4_clean_warp_decode_gfx950.py
+++ b/tokenspeed-kernel-amd/test/ops/test_mxfp4_clean_warp_decode_gfx950.py
@@ -1002,7 +1002,7 @@ def test_dynamic_mxfp4_generic_path_consumes_precomputed_topk(
     assert matmul_calls == 2
 
 
-@pytest.mark.parametrize("num_tokens", [1, 2])
+@pytest.mark.parametrize("num_tokens", [1, 2, 3, 4, 8])
 def test_dynamic_mxfp4_route_owned_softmax_mfma_decode(
     num_tokens: int,
     monkeypatch: pytest.MonkeyPatch,
@@ -1076,7 +1076,7 @@ def test_dynamic_mxfp4_route_owned_softmax_mfma_decode(
     torch.testing.assert_close(out.float(), expected.float(), rtol=0.0, atol=0.0)
 
 
-@pytest.mark.parametrize("num_tokens", [1, 2])
+@pytest.mark.parametrize("num_tokens", [1, 2, 3, 4, 8])
 def test_dynamic_mxfp4_route_owned_kimi_sigmoid_mfma_decode(
     num_tokens: int,
     monkeypatch: pytest.MonkeyPatch,
@@ -1383,3 +1383,71 @@ def test_precomputed_entry_rejects_missing_or_mismatched_topk():
             w13_mx_scale=scale,
             w2_mx_scale=scale,
         )
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2, 3, 4, 8])
+def test_kernel_routing_decode_reaches_route_owned_up_to_decode_max_m(
+    num_tokens: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Kernel-routing (no precomputed top-k) must hit route-owned decode M<=8.
+
+    This pins the dispatch cap lift: without precomputed top-k, batches up to
+    ``_DECODE_MAX_M`` must be handed to ``_maybe_route_owned_mxfp4_mfma_decode``
+    (which routes in-kernel and dispatches to the tuned decode kernels) rather
+    than falling through to the generic ragged GEMM. Previously only M <=
+    ``_ROUTE_OWNED_DECODE_MAX_M`` (=2) reached it, so Kimi-style M=8 decode
+    silently used the slow ragged path.
+    """
+    assert num_tokens <= fused_mxfp_gfx950._DECODE_MAX_M
+    hidden = torch.empty((num_tokens, 8), device="cuda", dtype=torch.bfloat16)
+    router = torch.empty((num_tokens, 4), device="cuda", dtype=torch.float32)
+    dummy_w = torch.empty((1, 4, 4), device="cuda", dtype=torch.uint8)
+    dummy_scale = torch.empty((1, 4, 1), device="cuda", dtype=torch.uint8)
+    sentinel = torch.empty_like(hidden)
+    route_owned_calls = 0
+    captured = {}
+
+    def fake_route_owned(*args, **kwargs):
+        nonlocal route_owned_calls
+        route_owned_calls += 1
+        captured["max_m"] = kwargs.get("max_m")
+        captured["allow_generic_fallback"] = kwargs.get("allow_generic_fallback")
+        return sentinel
+
+    def fail_route(*args, **kwargs):
+        raise AssertionError(
+            "kernel-routing decode fell through to the ragged reference path"
+        )
+
+    monkeypatch.setattr(
+        fused_mxfp_gfx950,
+        "_maybe_route_owned_mxfp4_mfma_decode",
+        fake_route_owned,
+    )
+    monkeypatch.setattr(fused_mxfp_gfx950, "_dynamic_mxfp4_route", fail_route)
+
+    out = fused_mxfp_gfx950.gluon_mxfp_dynamic_mxfp4_fused_moe(
+        hidden,
+        router,
+        dummy_w,
+        dummy_w,
+        w13_mx_scale=dummy_scale,
+        w2_mx_scale=dummy_scale,
+        top_k=1,
+        correction_bias=None,
+        n_group=1,
+        topk_group=1,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=True,
+        routing_method_type=0,
+        w13_bias=None,
+        w2_bias=None,
+    )
+
+    assert out is sentinel
+    assert route_owned_calls == 1
+    # The cap lift forwards the full decode ceiling and lets route-owned reach
+    # the precomputed-MFMA decode kernel for the M=3..8 range.
+    assert captured["max_m"] == fused_mxfp_gfx950._DECODE_MAX_M
+    assert captured["allow_generic_fallback"] is True


### PR DESCRIPTION
  ## Summary

   This PR makes three related improvements to the gfx950 (CDNA4) A4W4 MXFP4 MoE path for Kimi-K2.5. First, it centralizes the CDNA4 MXFP4 scale-swizzle constants and byte permutation into a single `mxfp4_cdna4_scale_layout` module (removing the unused, slower `GLUON_MXFP4_LDS_BSCALE` LDS-staged path and dead reference code). Second, it raises the kernel-routing decode cap from M≤2 to M≤8 so Kimi's M=8 decode reaches the tuned MFMA decode kernels instead of the slow ragged fallback. Third, it sets a flat stage2 down-projection `BLOCK_M=128` in package prefill (dropping a redundant sort), which is 10–17% faster on the Kimi shape at M≤1024 with no gpt-oss regression.

   ## Testing

   Validated on MI350X/gfx950: the full op suite (139 tests) passes, including new bit-exact parity tests (route-owned decode M∈{1,2,3,4,8} vs MFMA reference, and package prefill BLOCK_M=128 vs the generic ragged reference) and dispatch-cap assertions; Microbenchmarks on the Kimi TP4 shard (E=384, D=7168, I=512, topk=8) confirmed the wins:

   - **Decode cap (M≤8):** with the cap raised, Kimi's M=8 decode now enters the tuned MFMA decode path (routing kernels switch from the ragged `_fused_biased_grouped_route_small_m` to `_sigmoid_bias_topk_route_gluon` + `_fused_precomputed_topk_route_small_m`), cutting per-layer MoE matmul time ~3.5× (≈1065µs → ≈305µs on TP0)  end-to-end serving throughput rose ~2.5× (20.5 -> 51.7 tok/s total) in the profiled window.
   - **Prefill stage2 BLOCK_M=128:** 10–17% faster than the old 32/64 tiers at M∈{128,256,512,1024} (e.g. M=256: 872µs → 744µs = 1.17×; M=1024: 958µs → 867µs = 1.10×), fastest at every M
 
   End-to-end, serving Kimi-K2.5-MXFP4 (TP4) on a fixed chat prompt produces byte-identical output before/after the prefill tiling change (SHA-256 match), confirming the perf changes are output-preserving.

