### PR TITLE
fix(kvcache): route negative pages to the dummy page in flat_decode_locs

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/flat_groups.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/flat_groups.py
@@ -222,7 +222,8 @@ class FlatCacheGroupsMixin:
                 pages = table.gather(1, page_idx.unsqueeze(1)).squeeze(1)
             else:
                 pages = table.gather(1, page_idx.view(-1, n)).reshape(-1)
-            out[gid] = pages * ps + off
+            # Mirror the graph-path kernel's clamp: -1 pads/holes route to dummy page 0.
+            out[gid] = pages.clamp_min(0) * ps + off
         return out
 
     def _compute_flat_extend_out_cache_locs(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
@@ -1480,7 +1480,8 @@ def _flat_decode_locs_kernel(
     page = tl.load(tab_ptr + g * stride_g + b * stride_b + col, mask=mask, other=0).to(
         tl.int64
     )
-    loc = page * ps + pos % ps
+    # Negative pages (-1 column-tail pad / holes) route to dummy page 0, never a negative slot.
+    loc = tl.maximum(page, 0) * ps + pos % ps
     tl.store(out_ptr + g * out_stride_g + i, loc.to(tl.int32), mask=mask)
 
 

--- a/tokenspeed-kernel/test/ops/test_flat_tables_unpack.py
+++ b/tokenspeed-kernel/test/ops/test_flat_tables_unpack.py
@@ -90,3 +90,31 @@ def test_locs_multiquery(n):
         ref = (pages * p + (pos % p).to(torch.int32)).reshape(-1).to(torch.int32)
         assert torch.equal(out[i, : bs * n], ref), i
         assert (out[i, bs * n :] == -7).all(), i
+
+
+@pytest.mark.parametrize("n", [1, 4])
+def test_locs_negative_page_routes_to_dummy(n):
+    """A -1 table entry (column-tail pad / hole) must yield a slot in dummy
+    page 0, never a negative loc: a stale seq_lens can point the gather past
+    the bridge row's filled width (the 2026-07 DFLASH draft KV-scatter IMA)."""
+    dev = "cuda"
+    g_att, max_bs, wmax, bs = 2, 8, 16, 3
+    stack = torch.full((g_att, max_bs, wmax), -1, dtype=torch.int32, device=dev)
+    stack[:, :, :2] = 5  # only the first 2 columns are real pages
+    ps = torch.tensor([256, 128], dtype=torch.int32, device=dev)
+    # request 1's length reaches column 4 -> gathers the -1 tail pad
+    seq = torch.tensor([100, 1100, 30], dtype=torch.int32, device=dev)
+    out = torch.full((g_att, max_bs * n), -7, dtype=torch.int32, device=dev)
+    flat_decode_locs(stack, ps, seq, out, bs, tokens_per_req=n)
+    live = out[:, : bs * n]
+    assert (live >= 0).all(), live
+    for i in range(g_att):
+        p = int(ps[i])
+        pos = (
+            seq.to(torch.int64).unsqueeze(1) - n + torch.arange(n, device=dev)
+        ).clamp_min(0)
+        hit_pad = stack[i, :bs].gather(1, pos // p) < 0
+        # pad hits land inside dummy page 0 at the position's in-page offset
+        expect = (pos % p).to(torch.int32)
+        got = out[i, : bs * n].view(bs, n)
+        assert torch.equal(got[hit_pad], expect[hit_pad]), i


### PR DESCRIPTION
A -1 table entry (the flat graph tables' column-tail pad) reaching the write-loc gather produces a negative KV slot, and the store kernel then writes below the pool base: an async illegal memory access when that VA is unmapped, silent corruption when it is. Observed in production as the Inkling MTP residual IMA (_store_kv_cache_kernel, loc = -1 * 256 + off)

Clamp gathered pages to >= 0 so such locs land in dummy page 0, matching the existing padded-row write contract.

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
