### PR TITLE
perf(deepseek-v4): capture DSA projections and cache writes into the prefill graph

### DIFF
--- a/python/tokenspeed/runtime/execution/context.py
+++ b/python/tokenspeed/runtime/execution/context.py
@@ -82,6 +82,9 @@ class ForwardContext:
     # DSA SWA slot mapping + compressor memo, computed once per forward, shared across layers.
     dsa_swa_slot_mapping: torch.Tensor | None = None
     dsa_compressor_slot_cache: Any | None = None
+    # Armed by the prefill-graph replay hook: the captured segment wrote the
+    # DSA caches, so the attention break skips its eager cache writes.
+    dsa_pregraph_writes: bool = False
 
 
 @contextmanager

--- a/python/tokenspeed/runtime/execution/prefill_graph.py
+++ b/python/tokenspeed/runtime/execution/prefill_graph.py
@@ -224,6 +224,20 @@ class PrefillGraph:
         # Embedding runs eagerly OUTSIDE the graphs (see capture); the graphs
         # read a static input-embeds buffer instead of gathering from input_ids.
         self._embed_tokens = getattr(self.inner_model, "embed_tokens", None)
+        # Optional model seam for captured cache writes fed by persistent
+        # metadata buffers (DeepSeek-V4 DSA): resolved once here like the
+        # other model seams; the hooks ship as a pair.
+        self._prepare_replay_hook = getattr(
+            self.inner_model, "prepare_prefill_graph_replay", None
+        )
+        self._finish_replay_hook = getattr(
+            self.inner_model, "finish_prefill_graph_replay", None
+        )
+        if (self._prepare_replay_hook is None) != (self._finish_replay_hook is None):
+            raise ValueError(
+                "prepare_prefill_graph_replay and finish_prefill_graph_replay "
+                "must be implemented together"
+            )
         self._input_embeds_buf: torch.Tensor | None = None
         self.attn_backend = attn_backend
         self.token_to_kv_pool = token_to_kv_pool
@@ -452,7 +466,7 @@ class PrefillGraph:
         )
         ib.req_pool_indices_buf[:1].zero_()
         ib.seq_lens_buf[:1].fill_(num_tokens)
-        ib.extend_seq_lens_buf[:1].fill_(num_tokens)
+        ib.input_lengths_buf[:1].fill_(num_tokens)
         ib.extend_seq_lens_cpu[:1].fill_(num_tokens)
         ib.extend_prefix_lens_buf[:1].zero_()
         ib.extend_prefix_lens_cpu[:1].zero_()
@@ -497,12 +511,16 @@ class PrefillGraph:
             seq_lens=ib.seq_lens_buf[:1],
             req_to_page=self.req_to_page,
             forward_mode=ForwardMode.EXTEND,
-            extend_seq_lens=ib.extend_seq_lens_buf[:1],
+            extend_seq_lens=ib.input_lengths_buf[:1],
             extend_seq_lens_cpu=ib.extend_seq_lens_cpu[:1],
             extend_prefix_lens=ib.extend_prefix_lens_buf[:1],
             extend_prefix_lens_cpu=ib.extend_prefix_lens_cpu[:1],
             **extra_metadata_kwargs,
         )
+        # The capture call is the one place the pregraph staging buffers may
+        # allocate, sized from the dummy metadata built above.
+        if self._prepare_replay_hook is not None:
+            self._prepare_replay_hook(ctx, ib.positions_buf[:num_tokens], capture=True)
         return ctx
 
     def _capture_unanimous(self, captured_ok: bool) -> bool:
@@ -579,8 +597,22 @@ class PrefillGraph:
                 ib.mrope_positions_buf[:, num_tokens:bucket].zero_()
             else:
                 ib.positions_buf[num_tokens:bucket].zero_()
-        with self._padded_to(ctx, bucket):
-            self._captures[bucket].replay()
+        # Same model seam as capture: stage (or disarm) the persistent
+        # metadata feeding captured cache writes from THIS forward's live
+        # metadata. The finish call runs in a finally as exception-path
+        # hygiene, keeping the armed flag scoped strictly to this replay.
+        try:
+            if self._prepare_replay_hook is not None:
+                self._prepare_replay_hook(
+                    ctx,
+                    self.input_buffers.positions_buf[:num_tokens],
+                    capture=False,
+                )
+            with self._padded_to(ctx, bucket):
+                self._captures[bucket].replay()
+        finally:
+            if self._finish_replay_hook is not None:
+                self._finish_replay_hook(ctx)
         hidden_states, aux_hidden_states = self._outputs[bucket].sliced(num_tokens)
         # The eager logits tail of BaseCausalLM.forward, on the replayed hidden states.
         logits_metadata = LogitsMetadata.from_forward_context(ctx)

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -1969,6 +1969,142 @@ class _DeepseekV4TopKBuffer:
         return self.buffer[:num_tokens]
 
 
+class _DeepseekV4PregraphStateGroup:
+    """One compressor-family staging group for the captured cache writes.
+
+    Holds the per-token state/compressed slot mappings plus the compact state
+    block table and its sliding base pages at stable addresses the captured
+    kernels bake. ``-1`` slot mappings make every captured write a per-token
+    no-op (the kernels check them before reading the table or base pages).
+    """
+
+    def __init__(self) -> None:
+        self.state_slot_mapping: torch.Tensor | None = None
+        self.kv_slot_mapping: torch.Tensor | None = None
+        self.state_block_table: torch.Tensor | None = None
+        self.state_base_pages: torch.Tensor | None = None
+
+    def allocate(
+        self,
+        num_tokens: int,
+        max_reqs: int,
+        table_width: int,
+        device: torch.device,
+    ) -> None:
+        self.state_slot_mapping = torch.empty(
+            num_tokens, dtype=torch.int64, device=device
+        )
+        self.kv_slot_mapping = torch.empty(num_tokens, dtype=torch.int64, device=device)
+        self.state_block_table = torch.empty(
+            (max_reqs, table_width), dtype=torch.int32, device=device
+        )
+        self.state_base_pages = torch.empty(max_reqs, dtype=torch.int32, device=device)
+
+    def fits(self, num_tokens: int, max_reqs: int, table_width: int) -> bool:
+        return (
+            self.state_block_table is not None
+            and self.state_slot_mapping.shape[0] >= num_tokens
+            and self.state_block_table.shape[0] >= max_reqs
+            and self.state_block_table.shape[1] >= table_width
+        )
+
+    def disarm(self) -> None:
+        self.state_slot_mapping.fill_(-1)
+        self.kv_slot_mapping.fill_(-1)
+        self.state_block_table.fill_(-1)
+        self.state_base_pages.fill_(0)
+
+    def stage(
+        self,
+        num_tokens: int,
+        state_slot_mapping: torch.Tensor,
+        kv_slot_mapping: torch.Tensor,
+        block_table: torch.Tensor,
+        base_pages: torch.Tensor | None,
+    ) -> None:
+        """Refresh this group in place from live per-replay values.
+
+        Rows beyond ``num_tokens`` / the live table extent keep their
+        disarmed fill, unreachable behind the -1 slots.
+        """
+        self.state_slot_mapping[:num_tokens].copy_(state_slot_mapping)
+        self.kv_slot_mapping[:num_tokens].copy_(kv_slot_mapping)
+        num_reqs = int(block_table.shape[0])
+        self.state_block_table[:num_reqs, : block_table.shape[1]].copy_(
+            block_table.to(torch.int32)
+        )
+        if base_pages is not None:
+            self.state_base_pages[:num_reqs].copy_(
+                base_pages[:num_reqs].to(torch.int32)
+            )
+
+
+class _DeepseekV4PregraphBuffers:
+    """Persistent DSA metadata staging for the captured pre-break cache writes.
+
+    The prefill breakable graph captures the CSA indexer's AND the main C4
+    compressor's state save + cache insert in the pre-break segment, which
+    bakes their metadata addresses. Per-replay values (a shared
+    token->request map plus one staging group per write set) live here at
+    stable addresses: the pre-replay hook refreshes them in place from live
+    metadata when the forward is safe, and otherwise disarms them, making
+    every captured write a per-token no-op (fail-open).
+    """
+
+    def __init__(self) -> None:
+        self.token_to_req: torch.Tensor | None = None
+        self.indexer = _DeepseekV4PregraphStateGroup()
+        self.c4 = _DeepseekV4PregraphStateGroup()
+
+    @property
+    def allocated(self) -> bool:
+        return self.token_to_req is not None
+
+    def allocate(
+        self,
+        num_tokens: int,
+        max_reqs: int,
+        table_width: int,
+        c4_table_width: int,
+        device: torch.device,
+    ) -> None:
+        """Allocate (or grow) the staging buffers, disarmed.
+
+        Only legal outside stream capture: the capture loop visits buckets
+        largest-first, so the first dummy batch sizes every buffer and later
+        buckets reuse the same addresses the captured kernels baked.
+        """
+        needs_alloc = (
+            self.token_to_req is None
+            or self.token_to_req.device != device
+            or self.token_to_req.shape[0] < num_tokens
+            or not self.indexer.fits(num_tokens, max_reqs, table_width)
+            or not self.c4.fits(num_tokens, max_reqs, c4_table_width)
+        )
+        if not needs_alloc:
+            self.disarm()
+            return
+        if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "DeepSeek V4 pregraph buffers must be allocated before "
+                "CUDA graph capture"
+            )
+        with torch.inference_mode(False):
+            self.token_to_req = torch.empty(
+                num_tokens, dtype=torch.int32, device=device
+            )
+            self.indexer.allocate(num_tokens, max_reqs, table_width, device)
+            self.c4.allocate(num_tokens, max_reqs, c4_table_width, device)
+        self.disarm()
+
+    def disarm(self) -> None:
+        """Make every captured write a no-op: -1 slots gate the kernels before
+        they read the request map, block table, or base pages."""
+        self.token_to_req.fill_(-1)
+        self.indexer.disarm()
+        self.c4.disarm()
+
+
 def _deepseek_v4_padded_heads(num_local_heads: int) -> int:
     if num_local_heads <= 64:
         return 64
@@ -2753,6 +2889,68 @@ class DeepseekV4Compressor(nn.Module):
             kv_score = torch.matmul(hidden_states.float(), weight.float().T)
         return kv_score
 
+    def insert_cache_pregraph(
+        self,
+        *,
+        positions: torch.Tensor,
+        ctx: ForwardContext,
+        layer_index: int,
+        cos_sin_cache: torch.Tensor,
+        kv_score: torch.Tensor,
+        buffers: "_DeepseekV4PregraphBuffers",
+    ) -> None:
+        """Run the main C4 compressor state save + compressed cache insert in
+        the captured pre-break prefill-graph segment.
+
+        The C4 sibling of :meth:`DeepseekV4Indexer.insert_cache_pregraph`,
+        against the ``buffers.c4`` staging group: armed replays perform this
+        layer's compressor writes here and the break skips its eager
+        ``run_compressor`` call; behind disarmed (-1) slots every token is a
+        kernel-side no-op.
+
+        Args:
+            positions: Padded bucket positions (the static input buffer slice).
+            ctx: Forward context supplying the KV pool.
+            layer_index: This layer's compact cache slot.
+            cos_sin_cache: fp32 rope cache shared with the eager insert path.
+            kv_score: This compressor's fused ``[kv | score]`` GEMM output
+                from the current segment.
+            buffers: The model-owned pregraph staging buffers.
+        """
+        pool = ctx.token_to_kv_pool
+        num_tokens = positions.numel()
+        kv, score = kv_score.split([self.coff * self.head_dim] * 2, dim=-1)
+        state_cache = pool.get_compressor_state_buffer(layer_index)
+        state_block_size = pool.get_compressor_state_block_size(layer_index)
+        with nvtx_range("compressor_pregraph_save_state"):
+            save_deepseek_v4_compressor_state(
+                kv=kv,
+                score=score,
+                ape=self.ape,
+                state_cache=state_cache,
+                slot_mapping=buffers.c4.state_slot_mapping[:num_tokens],
+                positions=positions,
+                block_size=state_block_size,
+                compress_ratio=self.compress_ratio,
+            )
+        with nvtx_range("compressor_pregraph_cache_insert"):
+            deepseek_v4_csa_compress_kv_cache_insert(
+                state_cache=state_cache,
+                token_to_req_indices=buffers.token_to_req[:num_tokens],
+                positions=positions,
+                compressor_slot_mapping=buffers.c4.state_slot_mapping[:num_tokens],
+                block_table=buffers.c4.state_block_table,
+                block_table_base_offsets=buffers.c4.state_base_pages,
+                compressor_block_size=state_block_size,
+                rms_norm_weight=self.norm.weight,
+                rms_norm_eps=self.norm.variance_epsilon,
+                cos_sin_cache=cos_sin_cache,
+                kv_cache_2d=pool.get_compressed_kv_buffer_2d(layer_index),
+                kv_slot_mapping=buffers.c4.kv_slot_mapping[:num_tokens],
+                kv_cache_block_size=pool.get_compressed_block_size(layer_index),
+                compress_ratio=self.compress_ratio,
+            )
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -2797,9 +2995,10 @@ class DeepseekV4Compressor(nn.Module):
         if state_cache is None:
             state_cache = pool.get_compressor_state_buffer(layer_index)
         cache_metadata = metadata.cache
-        # state/compressed slot mappings depend only on (per-step state, ratio), so reuse
-        # them across layers of the same ratio within a step. Attn-compressor path only:
-        # the indexer-compressor passes an explicit state_block_table and is excluded.
+        # State mappings depend on per-step state and ratio; compressed mappings also
+        # depend on the actual cache block size. Reuse each exact mapping across layers
+        # within a step. Attn-compressor path only: the indexer-compressor passes an
+        # explicit state_block_table and is excluded.
         memo = compressor_slot_cache if state_block_table is None else None
         if state_block_table is None:
             state_block_table = cache_metadata.compressor_state_block_tables.get(
@@ -2864,9 +3063,12 @@ class DeepseekV4Compressor(nn.Module):
             return kv, score
 
         kv_cache_block_size = pool.get_compressed_block_size(layer_index)
-        compressed_hit = (
-            memo.get(("compressed", self.compress_ratio)) if memo is not None else None
+        compressed_slot_key = (
+            "compressed_slot_mapping",
+            self.compress_ratio,
+            kv_cache_block_size,
         )
+        compressed_hit = memo.get(compressed_slot_key) if memo is not None else None
         if compressed_hit is not None:
             compressed_slots = compressed_hit
         else:
@@ -2886,7 +3088,7 @@ class DeepseekV4Compressor(nn.Module):
                     is_valid_token=valid_token,
                 )
             if memo is not None:
-                memo[("compressed", self.compress_ratio)] = compressed_slots
+                memo[compressed_slot_key] = compressed_slots
         with nvtx_range(f"{profile_prefix}_cache_insert"):
             insert = (
                 deepseek_v4_csa_compress_kv_cache_insert
@@ -3071,6 +3273,9 @@ class DeepseekV4Indexer(nn.Module):
         indexer_cache: torch.Tensor,
         indexer_block_size: int,
         cos_sin_cache: torch.Tensor,
+        packed_q_values: torch.Tensor | None = None,
+        packed_q_scales: torch.Tensor | None = None,
+        packed_weights: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if not self.use_fp4_cache:
             raise RuntimeError(
@@ -3093,23 +3298,32 @@ class DeepseekV4Indexer(nn.Module):
             total_tokens,
         )
 
-        with nvtx_range("indexer_wq_b"):
-            index_q, _ = self.wq_b(qr)
-            index_q = index_q.view(-1, self.n_head, self.head_dim)
-        with nvtx_range("indexer_weights_proj"):
-            weights, _ = self.weights_proj(hidden_states)
-        with nvtx_range("indexer_prepare_mxfp4"):
-            packed_index_q, packed_weights = deepseek_v4_prepare_indexer_q_mxfp4(
-                index_q=index_q,
-                positions=positions,
-                cos_sin_cache=cos_sin_cache,
-                weights=weights,
-                softmax_scale=self.softmax_scale,
-                head_scale=self.n_head**-0.5,
+        packed_inputs_supplied = (
+            packed_q_values is not None,
+            packed_q_scales is not None,
+            packed_weights is not None,
+        )
+        if any(packed_inputs_supplied) and not all(packed_inputs_supplied):
+            raise ValueError(
+                "packed_q_values, packed_q_scales, and packed_weights must be "
+                "provided together"
+            )
+        if not any(packed_inputs_supplied):
+            packed_q_values, packed_q_scales, packed_weights = (
+                self._prepare_packed_inputs(
+                    hidden_states=hidden_states,
+                    qr=qr,
+                    positions=positions,
+                    cos_sin_cache=cos_sin_cache,
+                )
             )
 
+        assert packed_q_values is not None
+        assert packed_q_scales is not None
+        assert packed_weights is not None
+
         packed_indexer_available = _deepseek_v4_deepgemm_fp4_indexer_available(
-            packed_index_q[0]
+            packed_q_values
         )
         if not packed_indexer_available:
             raise RuntimeError(
@@ -3201,8 +3415,8 @@ class DeepseekV4Indexer(nn.Module):
             indexer_block_table=indexer_block_table,
             indexer_block_size=indexer_block_size,
             compress_ratio=self.compress_ratio,
-            packed_q_values=packed_index_q[0],
-            packed_q_scales=packed_index_q[1],
+            packed_q_values=packed_q_values,
+            packed_q_scales=packed_q_scales,
             packed_weights=packed_weights,
             topk_indices_buffer=topk_out,
             prefill_gather_values_workspace=prefill_gather_values,
@@ -3210,6 +3424,98 @@ class DeepseekV4Indexer(nn.Module):
             persistent_topk_workspace=self._persistent_topk_workspace,
             topk_tokens=self.topk_tokens,
         )
+
+    def _prepare_packed_inputs(
+        self,
+        *,
+        hidden_states: torch.Tensor,
+        qr: torch.Tensor,
+        positions: torch.Tensor,
+        cos_sin_cache: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        with nvtx_range("indexer_wq_b"):
+            index_q, _ = self.wq_b(qr)
+            index_q = index_q.view(-1, self.n_head, self.head_dim)
+        with nvtx_range("indexer_weights_proj"):
+            weights, _ = self.weights_proj(hidden_states)
+        with nvtx_range("indexer_prepare_mxfp4"):
+            # This call consumes the disposable projection output. The
+            # large-token TRT-LLM kernel path applies RoPE to index_q in place.
+            packed_index_q, packed_weights = deepseek_v4_prepare_indexer_q_mxfp4(
+                index_q=index_q,
+                positions=positions,
+                cos_sin_cache=cos_sin_cache,
+                weights=weights,
+                softmax_scale=self.softmax_scale,
+                head_scale=self.n_head**-0.5,
+            )
+        return packed_index_q[0], packed_index_q[1], packed_weights
+
+    def insert_cache_pregraph(
+        self,
+        *,
+        positions: torch.Tensor,
+        ctx: ForwardContext,
+        layer_index: int,
+        cos_sin_cache: torch.Tensor,
+        kv_score: torch.Tensor,
+        buffers: _DeepseekV4PregraphBuffers,
+    ) -> None:
+        """Run the CSA indexer state save + fused cache insert in the captured
+        pre-break prefill-graph segment.
+
+        Captured over the padded bucket against the pregraph staging
+        ``buffers``: when the pre-replay hook armed them with live metadata,
+        these kernels perform this layer's indexer cache writes and the break
+        skips its eager duplicates; behind disarmed (-1) slots -- including the
+        padded tail, whose positions are washed to 0 upstream -- every token is
+        a kernel-side no-op.
+
+        Args:
+            positions: Padded bucket positions (the static input buffer slice).
+            ctx: Forward context supplying the KV pool.
+            layer_index: This layer's compact cache slot.
+            cos_sin_cache: fp32 rope cache shared with the eager insert path.
+            kv_score: The indexer compressor's fused ``[kv | score]`` GEMM
+                output from the current segment.
+            buffers: The model-owned pregraph staging buffers.
+        """
+        pool = ctx.token_to_kv_pool
+        num_tokens = positions.numel()
+        kv, score = kv_score.split(
+            [self.compressor.coff * self.compressor.head_dim] * 2, dim=-1
+        )
+        state_cache = pool.get_indexer_state_buffer(layer_index)
+        state_block_size = pool.get_indexer_state_block_size(layer_index)
+        with nvtx_range("indexer_pregraph_save_state"):
+            save_deepseek_v4_compressor_state(
+                kv=kv,
+                score=score,
+                ape=self.compressor.ape,
+                state_cache=state_cache,
+                slot_mapping=buffers.indexer.state_slot_mapping[:num_tokens],
+                positions=positions,
+                block_size=state_block_size,
+                compress_ratio=self.compress_ratio,
+            )
+        with nvtx_range("indexer_pregraph_cache_insert"):
+            deepseek_v4_csa_indexer_cache_insert(
+                state_cache=state_cache,
+                token_to_req_indices=buffers.token_to_req[:num_tokens],
+                positions=positions,
+                compressor_slot_mapping=buffers.indexer.state_slot_mapping[:num_tokens],
+                block_table=buffers.indexer.state_block_table,
+                block_table_base_offsets=buffers.indexer.state_base_pages,
+                compressor_block_size=state_block_size,
+                rms_norm_weight=self.compressor.norm.weight,
+                rms_norm_eps=self.compressor.norm.variance_epsilon,
+                cos_sin_cache=cos_sin_cache,
+                kv_cache_2d=pool.get_indexer_kv_buffer_2d(layer_index),
+                kv_slot_mapping=buffers.indexer.kv_slot_mapping[:num_tokens],
+                kv_cache_block_size=pool.get_indexer_block_size(layer_index),
+                use_fp4_cache=self.use_fp4_cache,
+                compress_ratio=self.compress_ratio,
+            )
 
     def forward(
         self,
@@ -3222,6 +3528,9 @@ class DeepseekV4Indexer(nn.Module):
         cos_sin_cache: torch.Tensor,
         compressor_slot_cache: dict,
         indexer_compressor_kv_score: torch.Tensor | None = None,
+        packed_q_values: torch.Tensor | None = None,
+        packed_q_scales: torch.Tensor | None = None,
+        packed_weights: torch.Tensor | None = None,
     ) -> torch.Tensor:
         pool = ctx.token_to_kv_pool
         metadata = _deepseek_v4_forward_metadata(ctx)
@@ -3234,6 +3543,23 @@ class DeepseekV4Indexer(nn.Module):
             if getattr(metadata, "is_valid_token", None) is not None
             else None
         )
+        indexer_block_size = pool.get_indexer_block_size(layer_index)
+        if self.use_fp4_cache and ctx.dsa_pregraph_writes:
+            # Captured segment already wrote this layer; skip to the sparse
+            # indexer. Disarmed/eager forwards keep the path below.
+            return self._forward_sparse_indexer_custom_op(
+                hidden_states=hidden_states,
+                qr=qr,
+                positions=positions,
+                metadata=metadata,
+                ctx=ctx,
+                indexer_cache=pool.get_indexer_kv_buffer_2d(layer_index),
+                indexer_block_size=indexer_block_size,
+                cos_sin_cache=cos_sin_cache,
+                packed_q_values=packed_q_values,
+                packed_q_scales=packed_q_scales,
+                packed_weights=packed_weights,
+            )
         idx_hit = (
             compressor_slot_cache.get("indexer_state")
             if compressor_slot_cache is not None
@@ -3292,19 +3618,33 @@ class DeepseekV4Indexer(nn.Module):
                 kv_score=indexer_compressor_kv_score,
             )
         with nvtx_range("indexer_compressed_slot_mapping"):
-            indexer_block_size = pool.get_indexer_block_size(layer_index)
-            compressed_slots = cache_metadata.compressed_slot_mapping(
-                positions,
+            compressed_slot_key = (
+                "compressed_slot_mapping",
                 self.compress_ratio,
-                token_to_req_indices=metadata.token_to_req_indices[: positions.numel()],
-                query_start_loc=metadata.query_start_loc,
-                seq_lens=metadata.seq_lens,
-                kv_cache_block_size=indexer_block_size,
-                use_decode_cache=(
-                    ctx.forward_mode is not None and ctx.forward_mode.is_decode()
-                ),
-                is_valid_token=valid_token,
+                indexer_block_size,
             )
+            compressed_slots = (
+                compressor_slot_cache.get(compressed_slot_key)
+                if compressor_slot_cache is not None
+                else None
+            )
+            if compressed_slots is None:
+                compressed_slots = cache_metadata.compressed_slot_mapping(
+                    positions,
+                    self.compress_ratio,
+                    token_to_req_indices=metadata.token_to_req_indices[
+                        : positions.numel()
+                    ],
+                    query_start_loc=metadata.query_start_loc,
+                    seq_lens=metadata.seq_lens,
+                    kv_cache_block_size=indexer_block_size,
+                    use_decode_cache=(
+                        ctx.forward_mode is not None and ctx.forward_mode.is_decode()
+                    ),
+                    is_valid_token=valid_token,
+                )
+                if compressor_slot_cache is not None:
+                    compressor_slot_cache[compressed_slot_key] = compressed_slots
         with nvtx_range("indexer_cache_insert"):
             deepseek_v4_csa_indexer_cache_insert(
                 state_cache=indexer_state,
@@ -3332,6 +3672,9 @@ class DeepseekV4Indexer(nn.Module):
             indexer_cache=pool.get_indexer_kv_buffer_2d(layer_index),
             indexer_block_size=indexer_block_size,
             cos_sin_cache=cos_sin_cache,
+            packed_q_values=packed_q_values,
+            packed_q_scales=packed_q_scales,
+            packed_weights=packed_weights,
         )
 
 
@@ -3346,11 +3689,13 @@ class DeepseekV4Attention(nn.Module):
         aux_stream: torch.cuda.Stream | None = None,
         topk_buffer: _DeepseekV4TopKBuffer | None = None,
         cache_layer_index: int | None = None,
+        pregraph_buffers: _DeepseekV4PregraphBuffers | None = None,
     ) -> None:
         super().__init__()
         # `layer_index` addresses checkpoint/config metadata; `cache_layer_index`
         # addresses this model's compact KV cache slot.
         self.layer_index = layer_index
+        self.pregraph_buffers = pregraph_buffers
         self.cache_layer_index = (
             layer_index if cache_layer_index is None else cache_layer_index
         )
@@ -3581,7 +3926,6 @@ class DeepseekV4Attention(nn.Module):
         out, _ = self.wo_b(z.flatten(1))
         return out
 
-    @break_point
     def forward(
         self,
         positions: torch.Tensor,
@@ -3591,51 +3935,13 @@ class DeepseekV4Attention(nn.Module):
         swa_slot_mapping: torch.Tensor | None = None,
         compressor_slot_cache: dict | None = None,
     ) -> torch.Tensor:
-        """DSA attention, one COARSE breakable-graph break point.
-
-        Per layer it does multiple paged-cache writes (SWA / compressor /
-        indexer), a data/length-dependent indexer -> top-k stage, the FlashMLA
-        sparse kernel, AND aux-stream forks -- none capturable into a CUDA
-        graph. Under a prefill-graph capture the whole attention runs eager
-        (reading the live ``ctx``) while the layer's norms + MoE stay graphed;
-        direct call otherwise (see ``break_point``). Padding rows are handled
-        by the existing ``metadata.is_valid_token`` masking, and the
-        token-shaped inputs are sliced to the real count DSA kernels assert
-        (see ``slice_to_real_tokens`` below). The cross-layer SWA slot mapping
-        and compressor memo are shared via ctx -- replay-safe because ctx is
-        rebound to the live forward (see ``DeepseekV4Model.forward``).
-        """
+        """Run token-local projections around the live DSA core break."""
         if hidden_states.shape[0] == 0:
             return hidden_states
-        # Cross-layer compressor memo, created once per forward by the first layer.
-        if compressor_slot_cache is None:
-            compressor_slot_cache = ctx.dsa_compressor_slot_cache
-            if compressor_slot_cache is None:
-                compressor_slot_cache = ctx.dsa_compressor_slot_cache = {}
         profile_prefix = f"attn_{self.attention_kind}"
         cos_sin_cache = self.rotary_emb.cos_sin_cache
         if cos_sin_cache.dtype != torch.float32:
             cos_sin_cache = cos_sin_cache.float()
-        pool = ctx.token_to_kv_pool
-        metadata = ctx.attn_backend.forward_metadata
-        if metadata is None:
-            raise RuntimeError("DeepSeek V4 attention requires forward metadata")
-
-        # Slice padded inputs to the real count the DSA kernels assert (see
-        # docstring). Only under a breakable capture/replay (ambient ctx set):
-        # eager forwards are never padded, and the MTP draft path reaches here
-        # with metadata whose token_to_req_indices does NOT describe q's rows.
-        token_to_req = getattr(metadata, "token_to_req_indices", None)
-        if current_forward_ctx() is not None and token_to_req is not None:
-            positions, hidden_states, out_cache_loc, swa_slot_mapping = (
-                slice_to_real_tokens(
-                    token_to_req.numel(),
-                    positions,
-                    hidden_states,
-                    out_cache_loc,
-                    swa_slot_mapping,
-                )
-            )
 
         # --- Phase 1: pre-compute input GEMMs in parallel ---
         # Q/KV projection on main stream; compressor GEMM(s) on aux stream.
@@ -3644,6 +3950,9 @@ class DeepseekV4Attention(nn.Module):
         # shared-weight dependency that prevents safe multi-stream overlap.
         compressor_kv_score: torch.Tensor | None = None
         indexer_compressor_kv_score: torch.Tensor | None = None
+        packed_q_values: torch.Tensor | None = None
+        packed_q_scales: torch.Tensor | None = None
+        packed_weights: torch.Tensor | None = None
         with self.stream_fork.scope(
             enable=self.stream_fork.aux_stream is not None
         ) as fork:
@@ -3660,6 +3969,156 @@ class DeepseekV4Attention(nn.Module):
                         indexer_compressor_kv_score = (
                             self.indexer.compressor.compute_kv_score(hidden_states)
                         )
+            # Prefill-graph query packing stays on the main stream after qr is
+            # ready and overlaps the compressor GEMMs already queued on aux.
+            if self.indexer is not None and current_forward_ctx() is not None:
+                packed_q_values, packed_q_scales, packed_weights = (
+                    self.indexer._prepare_packed_inputs(
+                        hidden_states=hidden_states,
+                        qr=qr,
+                        positions=positions,
+                        cos_sin_cache=cos_sin_cache,
+                    )
+                )
+
+        # Captured CSA cache writes (indexer + main C4 compressor): only under
+        # an ambient breakable capture/replay, and only once the pregraph
+        # buffers exist (they are allocated by the model's capture hook, so
+        # eligibility here exactly matches what the pre-replay hook may arm).
+        # Eager forwards skip this block entirely and keep their writes inside
+        # the break.
+        # Indexer exists only on CSA (ratio 4) layers -> the layer-kind gate.
+        # Must stay equivalent to run_compressor's compress_ratio == 4 skip, or
+        # an armed replay double-writes; see run_compressor.
+        if (
+            self.indexer is not None
+            and self.pregraph_buffers is not None
+            and self.pregraph_buffers.allocated
+            and current_forward_ctx() is not None
+        ):
+            if self.indexer.use_fp4_cache:
+                with nvtx_range(f"{profile_prefix}_indexer_pregraph_insert"):
+                    self.indexer.insert_cache_pregraph(
+                        positions=positions,
+                        ctx=ctx,
+                        layer_index=self.cache_layer_index,
+                        cos_sin_cache=cos_sin_cache,
+                        kv_score=indexer_compressor_kv_score,
+                        buffers=self.pregraph_buffers,
+                    )
+            if self.compressor is not None:
+                with nvtx_range(f"{profile_prefix}_compressor_pregraph_insert"):
+                    self.compressor.insert_cache_pregraph(
+                        positions=positions,
+                        ctx=ctx,
+                        layer_index=self.cache_layer_index,
+                        cos_sin_cache=cos_sin_cache,
+                        kv_score=compressor_kv_score,
+                        buffers=self.pregraph_buffers,
+                    )
+
+        # Keep these as three top-level tensor args: break-point capture weakly
+        # aliases tensor args, but intentionally does not recurse into tuples.
+        attn_output = self._forward_attention_core(
+            positions,
+            hidden_states,
+            q,
+            kv,
+            qr,
+            cos_sin_cache,
+            ctx,
+            out_cache_loc,
+            compressor_kv_score,
+            indexer_compressor_kv_score,
+            swa_slot_mapping,
+            compressor_slot_cache,
+            packed_q_values,
+            packed_q_scales,
+            packed_weights,
+        )
+        with nvtx_range(f"{profile_prefix}_output_proj"):
+            return self._project_attention_output(
+                attn_output,
+                positions,
+                cos_sin_cache,
+            )
+
+    @break_point
+    def _forward_attention_core(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        q: torch.Tensor,
+        kv: torch.Tensor,
+        qr: torch.Tensor,
+        cos_sin_cache: torch.Tensor,
+        ctx: ForwardContext,
+        out_cache_loc: torch.Tensor,
+        compressor_kv_score: torch.Tensor | None,
+        indexer_compressor_kv_score: torch.Tensor | None,
+        swa_slot_mapping: torch.Tensor | None = None,
+        compressor_slot_cache: dict | None = None,
+        packed_q_values: torch.Tensor | None = None,
+        packed_q_scales: torch.Tensor | None = None,
+        packed_weights: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Run the request-dependent DSA work as one breakable-graph break.
+
+        The token-local projections are produced by the preceding graph segment
+        at the padded bucket size. This eager core rebinds ``ctx`` to the live
+        forward, slices every token-shaped input to the real metadata count, and
+        keeps all cache writes, sparse-indexer planning, and attention outside
+        the graph. Its raw attention output lands in the stable handoff buffer so
+        the caller's token-local output projection joins the following segment.
+        """
+        # Cross-layer compressor memo, created once per forward by the first layer.
+        if compressor_slot_cache is None:
+            compressor_slot_cache = ctx.dsa_compressor_slot_cache
+            if compressor_slot_cache is None:
+                compressor_slot_cache = ctx.dsa_compressor_slot_cache = {}
+        profile_prefix = f"attn_{self.attention_kind}"
+        pool = ctx.token_to_kv_pool
+        metadata = ctx.attn_backend.forward_metadata
+        if metadata is None:
+            raise RuntimeError("DeepSeek V4 attention requires forward metadata")
+        forward_mode = ctx.forward_mode
+        if forward_mode is None:
+            raise RuntimeError("DeepSeek V4 attention requires forward mode")
+
+        # Slice padded inputs to the real count the DSA kernels assert (see
+        # docstring). Only under a breakable capture/replay (ambient ctx set):
+        # eager forwards are never padded, and the MTP draft path reaches here
+        # with metadata whose token_to_req_indices does NOT describe q's rows.
+        token_to_req = getattr(metadata, "token_to_req_indices", None)
+        if current_forward_ctx() is not None and token_to_req is not None:
+            (
+                positions,
+                hidden_states,
+                q,
+                kv,
+                qr,
+                out_cache_loc,
+                compressor_kv_score,
+                indexer_compressor_kv_score,
+                swa_slot_mapping,
+                packed_q_values,
+                packed_q_scales,
+                packed_weights,
+            ) = slice_to_real_tokens(
+                token_to_req.numel(),
+                positions,
+                hidden_states,
+                q,
+                kv,
+                qr,
+                out_cache_loc,
+                compressor_kv_score,
+                indexer_compressor_kv_score,
+                swa_slot_mapping,
+                packed_q_values,
+                packed_q_scales,
+                packed_weights,
+            )
 
         if swa_slot_mapping is None:
             # Cross-layer SWA slot mapping (per-token, layer-invariant), first layer computes.
@@ -3686,6 +4145,11 @@ class DeepseekV4Attention(nn.Module):
 
         def run_compressor() -> None:
             if self.compressor is None:
+                return
+            if self.compress_ratio == 4 and ctx.dsa_pregraph_writes:
+                # Captured pre-break segment already wrote this CSA layer;
+                # HCA (C128) keeps the eager path. Gate must match the
+                # captured-write gate (see insert_cache_pregraph call site).
                 return
             with nvtx_range(f"{profile_prefix}_compressor"):
                 self.compressor(
@@ -3730,6 +4194,9 @@ class DeepseekV4Attention(nn.Module):
                         cos_sin_cache=cos_sin_cache,
                         compressor_slot_cache=compressor_slot_cache,
                         indexer_compressor_kv_score=indexer_compressor_kv_score,
+                        packed_q_values=packed_q_values,
+                        packed_q_scales=packed_q_scales,
+                        packed_weights=packed_weights,
                     )
                 with fork.branch():
                     insert_swa_cache()
@@ -3799,12 +4266,7 @@ class DeepseekV4Attention(nn.Module):
                 )
         else:
             raise RuntimeError(f"Unsupported DeepSeek V4 forward mode: {forward_mode}")
-        with nvtx_range(f"{profile_prefix}_output_proj"):
-            return self._project_attention_output(
-                attn_output,
-                positions,
-                cos_sin_cache,
-            )
+        return attn_output
 
 
 class DeepseekV4DecoderLayer(nn.Module):
@@ -3818,6 +4280,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         aux_stream: torch.cuda.Stream | None = None,
         topk_buffer: _DeepseekV4TopKBuffer | None = None,
         cache_layer_index: int | None = None,
+        pregraph_buffers: _DeepseekV4PregraphBuffers | None = None,
     ) -> None:
         super().__init__()
         self.mapping = mapping
@@ -3838,6 +4301,7 @@ class DeepseekV4DecoderLayer(nn.Module):
             aux_stream=aux_stream,
             topk_buffer=topk_buffer,
             cache_layer_index=cache_layer_index,
+            pregraph_buffers=pregraph_buffers,
         )
         self.ffn = DeepseekV4MoE(
             config,
@@ -4019,6 +4483,7 @@ class DeepseekV4Model(nn.Module):
         self.rms_norm_eps = config.rms_norm_eps
         self.aux_stream = torch.cuda.Stream() if torch.cuda.is_available() else None
         self.topk_indices_buffer = _DeepseekV4TopKBuffer(int(config.index_topk))
+        self.pregraph_buffers = _DeepseekV4PregraphBuffers()
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
@@ -4037,9 +4502,27 @@ class DeepseekV4Model(nn.Module):
                     add_prefix(f"layers.{layer_id}", prefix),
                     aux_stream=self.aux_stream,
                     topk_buffer=self.topk_indices_buffer,
+                    pregraph_buffers=self.pregraph_buffers,
                 )
                 for layer_id in range(config.num_hidden_layers)
             ]
+        )
+        # First CSA layer eligible for captured indexer cache writes (the
+        # indexer state mapping and block sizes are layer-invariant, like the
+        # cross-layer memo); the prefill-graph hooks stay inert when None.
+        pregraph_attn = next(
+            (
+                layer.attn
+                for layer in self.layers
+                if layer.attn.indexer is not None and layer.attn.indexer.use_fp4_cache
+            ),
+            None,
+        )
+        self._pregraph_indexer_cache_layer_index = (
+            pregraph_attn.cache_layer_index if pregraph_attn is not None else None
+        )
+        self._pregraph_indexer_compress_ratio = (
+            pregraph_attn.indexer.compress_ratio if pregraph_attn is not None else 0
         )
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         hc_dim = config.hc_mult * config.hidden_size
@@ -4111,6 +4594,183 @@ class DeepseekV4Model(nn.Module):
         with nvtx_range("final_norm"):
             hidden_states = self.norm(hidden_states)
         return hidden_states, aux_hidden_states
+
+    def prepare_prefill_graph_replay(
+        self,
+        ctx: ForwardContext,
+        positions: torch.Tensor,
+        *,
+        capture: bool = False,
+    ) -> None:
+        """Stage the pregraph DSA cache-write metadata for a prefill-graph run.
+
+        The :class:`PrefillGraph` optional model hook. On the dummy capture
+        batch (``capture=True``, the only call allowed to allocate) this sizes
+        the staging buffers from the dummy metadata and leaves them disarmed.
+        Before each replay it re-checks safety -- pure extend, FP4 indexer,
+        complete metadata whose shapes fit the captured buffers -- and either
+        refreshes the buffers in place from live metadata (indexer AND main
+        C4 compressor staging, armed together or not at all) and sets
+        ``ctx.dsa_pregraph_writes`` so the attention break skips its eager
+        indexer and CSA-compressor cache writes; anything unsafe disarms the
+        buffers, so the captured writes replay as per-token no-ops while the
+        break keeps the eager path unchanged.
+
+        Args:
+            ctx: The forward context about to capture or replay.
+            positions: The static positions-buffer slice -- the padded bucket
+                at capture, the real token count at replay (tail rows beyond
+                it are washed to 0 upstream and stay behind -1 slots).
+            capture: True only for the dummy capture batch.
+        """
+        ctx.dsa_pregraph_writes = False
+        cache_layer_index = self._pregraph_indexer_cache_layer_index
+        if cache_layer_index is None:
+            return
+        compress_ratio = self._pregraph_indexer_compress_ratio
+        buffers = self.pregraph_buffers
+        metadata = _deepseek_v4_forward_metadata(ctx)
+        cache_metadata = metadata.cache if metadata is not None else None
+        state_table = (
+            cache_metadata.indexer_state_block_table
+            if cache_metadata is not None
+            else None
+        )
+        c4_state_table = (
+            cache_metadata.compressor_state_block_tables.get(compress_ratio)
+            if cache_metadata is not None
+            else None
+        )
+        if capture:
+            # No indexer/compressor-state group in the dummy metadata -> stay
+            # unallocated so replays are permanently disarmed, matching that
+            # the captured segments skip these writes too.
+            if state_table is None or c4_state_table is None or ctx.req_to_page is None:
+                return
+            max_reqs = max(1, min(int(ctx.req_to_page.shape[0]), positions.numel()))
+            buffers.allocate(
+                positions.numel(),
+                max_reqs,
+                int(state_table.shape[1]),
+                int(c4_state_table.shape[1]),
+                positions.device,
+            )
+            return
+        if not buffers.allocated:
+            return
+        num_tokens = positions.numel()
+        forward_mode = ctx.forward_mode
+        if (
+            forward_mode is None
+            or not forward_mode.is_extend()
+            or forward_mode.is_mixed()
+            or state_table is None
+            or c4_state_table is None
+            or not _deepseek_v4_metadata_matches_tokens(metadata, num_tokens)
+            or int(metadata.num_prefill_tokens) != num_tokens
+            or metadata.decode_token_count() != 0
+            or metadata.query_start_loc is None
+            or metadata.seq_lens is None
+            or num_tokens > buffers.token_to_req.shape[0]
+            or int(state_table.shape[0]) > buffers.indexer.state_block_table.shape[0]
+            or int(state_table.shape[1]) > buffers.indexer.state_block_table.shape[1]
+            or int(c4_state_table.shape[0]) > buffers.c4.state_block_table.shape[0]
+            or int(c4_state_table.shape[1]) > buffers.c4.state_block_table.shape[1]
+        ):
+            buffers.disarm()
+            return
+        num_reqs = int(state_table.shape[0])
+        base_pages = cache_metadata.indexer_state_base_logical_page
+        c4_num_reqs = int(c4_state_table.shape[0])
+        c4_base_pages = cache_metadata.compressor_state_base_logical_pages.get(
+            compress_ratio
+        )
+        if (base_pages is not None and int(base_pages.shape[0]) < num_reqs) or (
+            c4_base_pages is not None and int(c4_base_pages.shape[0]) < c4_num_reqs
+        ):
+            buffers.disarm()
+            return
+        pool = ctx.token_to_kv_pool
+        token_to_req = metadata.token_to_req_indices[:num_tokens]
+        valid_token = (
+            metadata.is_valid_token[:num_tokens]
+            if getattr(metadata, "is_valid_token", None) is not None
+            else None
+        )
+        state_slot_mapping = _group_slot_mapping_from_raw(
+            positions,
+            token_to_req,
+            state_table,
+            pool.get_indexer_state_block_size(cache_layer_index),
+            base_offsets=base_pages,
+        )
+        state_slot_mapping = _mask_invalid_graph_tokens(
+            state_slot_mapping,
+            valid_token,
+        )
+        indexer_block_size = pool.get_indexer_block_size(cache_layer_index)
+        compressed_slots = cache_metadata.compressed_slot_mapping(
+            positions,
+            compress_ratio,
+            token_to_req_indices=token_to_req,
+            query_start_loc=metadata.query_start_loc,
+            seq_lens=metadata.seq_lens,
+            kv_cache_block_size=indexer_block_size,
+            use_decode_cache=False,
+            is_valid_token=valid_token,
+        )
+        c4_state_slot_mapping = _group_slot_mapping_from_raw(
+            positions,
+            token_to_req,
+            c4_state_table,
+            pool.get_compressor_state_block_size(cache_layer_index),
+            base_offsets=c4_base_pages,
+        )
+        c4_state_slot_mapping = _mask_invalid_graph_tokens(
+            c4_state_slot_mapping,
+            valid_token,
+        )
+        c4_kv_block_size = pool.get_compressed_block_size(cache_layer_index)
+        if c4_kv_block_size == indexer_block_size:
+            c4_compressed_slots = compressed_slots
+        else:
+            c4_compressed_slots = cache_metadata.compressed_slot_mapping(
+                positions,
+                compress_ratio,
+                token_to_req_indices=token_to_req,
+                query_start_loc=metadata.query_start_loc,
+                seq_lens=metadata.seq_lens,
+                kv_cache_block_size=c4_kv_block_size,
+                use_decode_cache=False,
+                is_valid_token=valid_token,
+            )
+        buffers.disarm()
+        buffers.token_to_req[:num_tokens].copy_(token_to_req)
+        buffers.indexer.stage(
+            num_tokens,
+            state_slot_mapping,
+            compressed_slots,
+            state_table,
+            base_pages,
+        )
+        buffers.c4.stage(
+            num_tokens,
+            c4_state_slot_mapping,
+            c4_compressed_slots,
+            c4_state_table,
+            c4_base_pages,
+        )
+        ctx.dsa_pregraph_writes = True
+
+    def finish_prefill_graph_replay(self, ctx: ForwardContext) -> None:
+        """Clear the pregraph arm flag; called in the replay ``finally``.
+
+        Buffers are left armed: the capture block only runs under an ambient
+        context, entered solely by capture or by replay right after prepare
+        armed/disarmed them. A new ambient entry that skips prepare would
+        break exactly-once.
+        """
+        ctx.dsa_pregraph_writes = False
 
 
 class DeepseekV4ForCausalLM(BaseCausalLM):

--- a/test/runtime/execution/test_breakable_cuda_graph.py
+++ b/test/runtime/execution/test_breakable_cuda_graph.py
@@ -32,6 +32,7 @@ from tokenspeed.runtime.execution.breakable_cuda_graph import (  # noqa: E402
     scrub_padding_tail,
     slice_to_real_tokens,
 )
+from tokenspeed.runtime.utils.cuda_stream import StreamFork  # noqa: E402
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
@@ -328,6 +329,215 @@ class TestBreakPointAndAmbientCtx(unittest.TestCase):
         expected = torch.relu((new_x @ self.w0) @ self.w1) * 5.0
         torch.testing.assert_close(captured, expected, rtol=1e-4, atol=1e-4)
 
+    def test_multistream_segment_then_eager_break_reuses_events(self):
+        """A joined graph fork may feed a break that reuses the same events.
+
+        DeepSeek-V4 projects Q/KV on the capture stream and compressor inputs on
+        an auxiliary stream, then its eager attention core reuses that
+        ``StreamFork`` for cache writes. Exercise that exact ordering while also
+        proving that both graph-produced break arguments refresh on replay.
+        """
+        stream_fork = StreamFork(torch.cuda.Stream())
+        w2 = torch.randn(self.d, self.d, device=self.dev, dtype=self.dtype)
+        w3 = torch.randn(self.d, self.d, device=self.dev, dtype=self.dtype)
+        calls = {"outer": 0, "core": 0}
+        observed_rows = []
+
+        class M:
+            def forward(inner_self, x, ctx):
+                calls["outer"] += 1
+                with stream_fork.scope(enable=True) as fork:
+                    q = x @ self.w0
+                    with fork.branch():
+                        score1 = x @ self.w1
+                        score2 = score1 * 2.0
+                return inner_self.core(q, score1, score2, ctx) @ w3
+
+            @break_point
+            def core(inner_self, q, score1, score2, ctx):
+                calls["core"] += 1
+                q, score1, score2 = slice_to_real_tokens(
+                    ctx.real_tokens, q, score1, score2
+                )
+                observed_rows.append((q.shape[0], score1.shape[0], score2.shape[0]))
+                with stream_fork.scope(enable=True) as fork:
+                    main = torch.relu(q + score1) * ctx.scale
+                    with fork.branch():
+                        aux = (q - score2) @ w2
+                return main + aux
+
+        model = M()
+        dummy = SimpleNamespace(scale=2.0, real_tokens=self.x_static.shape[0])
+
+        for _ in range(3):
+            with active_forward(dummy):
+                model.forward(self.x_static, dummy)
+        torch.cuda.synchronize()
+        observed_rows.clear()
+
+        cap = BreakableCapture()
+        with active_forward(dummy):
+            with cap:
+                captured = model.forward(self.x_static, dummy)
+        self.assertEqual(cap.num_segments, 3)
+        outer_calls_after_capture = calls["outer"]
+        core_calls_after_capture = calls["core"]
+
+        for trial, (real_tokens, scale) in enumerate(((5, 3.0), (3, 5.0))):
+            new_x = torch.randn(8, self.d, device=self.dev, dtype=self.dtype)
+            self.x_static.copy_(new_x)
+            live = SimpleNamespace(scale=scale, real_tokens=real_tokens)
+            with active_forward(live):
+                cap.replay()
+            torch.cuda.synchronize()
+
+            q = new_x @ self.w0
+            score1 = new_x @ self.w1
+            score2 = score1 * 2.0
+            expected = (
+                torch.relu(q[:real_tokens] + score1[:real_tokens]) * scale
+                + (q[:real_tokens] - score2[:real_tokens]) @ w2
+            ) @ w3
+            self.assertEqual(captured.shape[0], self.x_static.shape[0])
+            torch.testing.assert_close(
+                captured[:real_tokens],
+                expected,
+                rtol=1e-4,
+                atol=1e-4,
+                msg=f"trial {trial}",
+            )
+
+        self.assertEqual(calls["outer"], outer_calls_after_capture)
+        self.assertEqual(calls["core"], core_calls_after_capture + 2)
+        self.assertEqual(
+            observed_rows,
+            [(8, 8, 8), (5, 5, 5), (3, 3, 3)],
+        )
+
+    def test_short_handoff_with_live_positions_and_same_shape_reuse(self):
+        """Short breaks may share one handoff before row-local graph work.
+
+        Mirrors DeepSeek-V4's eager attention-core -> graphed output-
+        projection boundary.  Two same-shaped breaks reuse one handoff, each
+        following graph segment consumes it before the next break overwrites it,
+        and only the real prefix is refreshed on replay.  Poisoning the untouched
+        tail proves that row-local work cannot contaminate real-token rows.
+        """
+        positions_static = torch.zeros(
+            self.x_static.shape[0], device=self.dev, dtype=self.dtype
+        )
+        projection_weights = [
+            torch.randn(self.d, self.d, device=self.dev, dtype=self.dtype)
+            for _ in range(2)
+        ]
+        position_scales = (0.03125, -0.015625)
+        observed_rows = []
+
+        class M:
+            def forward(inner_self, x, positions, ctx):
+                h = x @ self.w0
+                for layer, weight in enumerate(projection_weights):
+                    h = inner_self.core(h, ctx, layer)
+                    # The output projection remains in the following graph
+                    # segment and reads the persistent, replay-refreshed positions.
+                    h = (
+                        torch.tanh(h + positions[:, None] * position_scales[layer])
+                        @ weight
+                    )
+                return h
+
+            @break_point
+            def core(inner_self, h, ctx, layer):
+                (h,) = slice_to_real_tokens(ctx.real_tokens, h)
+                observed_rows.append((layer, h.shape[0]))
+                return torch.sin(h + ctx.core_offsets[layer])
+
+        def eager(x, positions, core_offsets):
+            h = x @ self.w0
+            for layer, weight in enumerate(projection_weights):
+                h = torch.sin(h + core_offsets[layer])
+                h = torch.tanh(h + positions[:, None] * position_scales[layer]) @ weight
+            return h
+
+        model = M()
+        dummy = SimpleNamespace(
+            real_tokens=self.x_static.shape[0], core_offsets=(0.125, -0.25)
+        )
+        positions_static.copy_(
+            torch.arange(self.x_static.shape[0], device=self.dev, dtype=self.dtype)
+        )
+
+        for _ in range(3):
+            with active_forward(dummy):
+                model.forward(self.x_static, positions_static, dummy)
+        torch.cuda.synchronize()
+        observed_rows.clear()
+
+        cap = BreakableCapture()
+        with active_forward(dummy):
+            with cap:
+                captured = model.forward(self.x_static, positions_static, dummy)
+
+        # graph -> break -> graph -> break -> graph, with both breaks sharing
+        # the same shape-keyed destination.
+        self.assertEqual(cap.num_segments, 5)
+        self.assertEqual(len(cap._handoff), 1)
+        handoff = next(iter(cap._handoff.values()))
+        self.assertEqual(tuple(handoff.shape), tuple(self.x_static.shape))
+
+        trials = (
+            (5, (0.5, -0.75), "nan"),
+            (3, (-0.375, 0.625), "inf"),
+        )
+        for trial, (real_tokens, core_offsets, poison_kind) in enumerate(trials):
+            new_x = torch.randn_like(self.x_static)
+            self.x_static.copy_(new_x)
+            live_positions = (
+                torch.arange(real_tokens, device=self.dev, dtype=self.dtype)
+                * (trial + 2)
+                + 17
+            )
+            positions_static.zero_()
+            positions_static[:real_tokens].copy_(live_positions)
+
+            tail = handoff[real_tokens:]
+            if poison_kind == "nan":
+                tail.fill_(float("nan"))
+            else:
+                row_poison = torch.where(
+                    torch.arange(tail.shape[0], device=self.dev) % 2 == 0,
+                    torch.tensor(float("inf"), device=self.dev),
+                    torch.tensor(-float("inf"), device=self.dev),
+                ).to(self.dtype)
+                tail.copy_(row_poison[:, None].expand_as(tail))
+            torch.cuda.synchronize()
+
+            live = SimpleNamespace(real_tokens=real_tokens, core_offsets=core_offsets)
+            with active_forward(live):
+                cap.replay()
+            torch.cuda.synchronize()
+
+            expected = eager(new_x[:real_tokens], live_positions, core_offsets)
+            self.assertEqual(captured.shape[0], self.x_static.shape[0])
+            self.assertTrue(bool(torch.isfinite(captured[:real_tokens]).all()))
+            torch.testing.assert_close(
+                captured[:real_tokens],
+                expected,
+                rtol=1e-4,
+                atol=1e-4,
+                msg=f"trial {trial}",
+            )
+            self.assertTrue(bool((positions_static[real_tokens:] == 0).all()))
+            if poison_kind == "nan":
+                self.assertTrue(bool(torch.isnan(tail).all()))
+            else:
+                self.assertTrue(bool(torch.isinf(tail).all()))
+
+        self.assertEqual(
+            observed_rows,
+            [(0, 8), (1, 8), (0, 5), (1, 5), (0, 3), (1, 3)],
+        )
+
     def test_break_reads_live_scalar_off_ambient_not_frozen_arg(self):
         """Scalar args freeze at capture; live values must come off the ambient ctx.
 
@@ -517,6 +727,317 @@ class TestPrefillTokenBuckets(unittest.TestCase):
             self._cfg(prefill_graph_capture_sizes=[256, 1024, 4096])
         )
         self.assertEqual(buckets, [256, 1024, 2048])
+
+
+class TestPrefillDummyBatch(unittest.TestCase):
+    """CPU-only checks for the prefill capture metadata wiring."""
+
+    def test_dummy_batch_uses_input_lengths_for_paged_extend_metadata(self):
+        from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
+        from tokenspeed.runtime.execution.prefill_graph import PrefillGraph
+
+        class RecordingBackend:
+            uses_paged_cache_groups = True
+
+            def init_forward_metadata(self, **kwargs):
+                self.metadata = kwargs
+
+        class RecordingDecodeWrapper:
+            def _capture_paged_cache_block_tables(self, bs, token_to_kv_pool):
+                self.call = (bs, token_to_kv_pool)
+                return paged_cache_block_tables
+
+        num_tokens = 4
+        input_buffers = SimpleNamespace(
+            input_ids_buf=torch.empty(num_tokens, dtype=torch.int32),
+            out_cache_loc_buf=torch.empty(num_tokens, dtype=torch.int64),
+            positions_buf=torch.empty(num_tokens, dtype=torch.int64),
+            req_pool_indices_buf=torch.empty(1, dtype=torch.int32),
+            seq_lens_buf=torch.empty(1, dtype=torch.int32),
+            input_lengths_buf=torch.empty(1, dtype=torch.int32),
+            extend_seq_lens_cpu=torch.empty(1, dtype=torch.int32),
+            extend_prefix_lens_buf=torch.empty(1, dtype=torch.int32),
+            extend_prefix_lens_cpu=torch.empty(1, dtype=torch.int32),
+            dummy_kv_slot=7,
+        )
+        self.assertFalse(hasattr(input_buffers, "extend_seq_lens_buf"))
+
+        backend = RecordingBackend()
+        decode_wrapper = RecordingDecodeWrapper()
+        token_to_kv_pool = object()
+        paged_cache_block_tables = {"v4.swa_kv": torch.zeros(1, 1)}
+
+        graph = PrefillGraph.__new__(PrefillGraph)
+        graph.input_buffers = input_buffers
+        graph.config = SimpleNamespace(device="cpu", world_size=1)
+        graph.req_to_page = torch.ones(1, 2, dtype=torch.int32)
+        graph.attn_backend = backend
+        graph.token_to_kv_pool = token_to_kv_pool
+        graph.drafter = None
+        graph.dp_size = 1
+        graph._prepare_replay_hook = None
+
+        ctx = graph._make_dummy_batch(num_tokens, decode_wrapper)
+
+        extend_seq_lens = backend.metadata["extend_seq_lens"]
+        self.assertEqual(input_buffers.input_lengths_buf.tolist(), [num_tokens])
+        self.assertEqual(extend_seq_lens.tolist(), [num_tokens])
+        self.assertEqual(
+            extend_seq_lens.data_ptr(), input_buffers.input_lengths_buf.data_ptr()
+        )
+        self.assertIs(extend_seq_lens._base, input_buffers.input_lengths_buf)
+        self.assertEqual(input_buffers.extend_seq_lens_cpu.tolist(), [num_tokens])
+        self.assertEqual(input_buffers.extend_prefix_lens_buf.tolist(), [0])
+        self.assertEqual(input_buffers.extend_prefix_lens_cpu.tolist(), [0])
+        self.assertEqual(backend.metadata["seq_lens"].tolist(), [num_tokens])
+
+        self.assertEqual(ctx.bs, 1)
+        self.assertEqual(ctx.num_extends, 1)
+        self.assertEqual(ctx.input_num_tokens, num_tokens)
+        self.assertEqual(ctx.forward_mode, ForwardMode.EXTEND)
+        self.assertEqual(decode_wrapper.call, (1, token_to_kv_pool))
+        self.assertIs(
+            backend.metadata["paged_cache_block_tables"], paged_cache_block_tables
+        )
+        self.assertEqual(backend.metadata["num_tokens"], num_tokens)
+        self.assertEqual(
+            backend.metadata["positions"].tolist(), list(range(num_tokens))
+        )
+        # Capture-safety: the throwaway forward's KV writes must target the
+        # reserved dummy slot and the dummy request's pages must point at
+        # page 0, so capturing never touches real cache state.
+        self.assertEqual(
+            input_buffers.out_cache_loc_buf.tolist(),
+            [input_buffers.dummy_kv_slot] * num_tokens,
+        )
+        self.assertEqual(input_buffers.input_ids_buf.tolist(), [1] * num_tokens)
+        self.assertEqual(graph.req_to_page[0].tolist(), [0, 0])
+
+    def test_replay_bucket_eligibility_gate(self):
+        from tokenspeed.runtime.execution.forward_batch_info import (
+            CaptureHiddenMode,
+            ForwardMode,
+        )
+        from tokenspeed.runtime.execution.prefill_graph import PrefillGraph
+
+        graph = PrefillGraph.__new__(PrefillGraph)
+        graph.disable = False
+        graph.dp_size = 1
+        graph._captured_hidden_mode = CaptureHiddenMode.NULL
+        graph.capture_buckets = [4]
+        graph._captures = {4: object()}
+        graph.config = SimpleNamespace(disable_cuda_graph_padding=False)
+
+        def ctx(**over):
+            base = dict(
+                forward_mode=ForwardMode.EXTEND,
+                num_extends=1,
+                accept_lengths=None,
+                capture_hidden_mode=CaptureHiddenMode.NULL,
+                input_num_tokens=4,
+                global_num_tokens=None,
+            )
+            base.update(over)
+            return SimpleNamespace(**base)
+
+        # Eligible: pure extend, matching hidden mode, bucket captured.
+        self.assertEqual(graph._replay_bucket(ctx()), 4)
+        self.assertEqual(graph._replay_bucket(ctx(forward_mode=ForwardMode.MIXED)), 4)
+        # Each ineligibility condition must force eager (None):
+        self.assertIsNone(graph._replay_bucket(ctx(forward_mode=ForwardMode.DECODE)))
+        self.assertIsNone(graph._replay_bucket(ctx(num_extends=0)))
+        self.assertIsNone(graph._replay_bucket(ctx(accept_lengths=torch.tensor([1]))))
+        self.assertIsNone(
+            graph._replay_bucket(ctx(capture_hidden_mode=CaptureHiddenMode.FULL))
+        )
+        self.assertIsNone(graph._replay_bucket(ctx(input_num_tokens=9)))  # > bucket
+        graph.disable = True
+        self.assertIsNone(graph._replay_bucket(ctx()))
+
+    def test_capture_unanimous_min_reduce_disables_on_any_rank_failure(self):
+        from unittest import mock
+
+        from tokenspeed.runtime.execution.prefill_graph import PrefillGraph
+
+        graph = PrefillGraph.__new__(PrefillGraph)
+        graph.config = SimpleNamespace(world_group="w", world_size=2)
+
+        # Single-rank / no group short-circuits to the local flag.
+        solo = PrefillGraph.__new__(PrefillGraph)
+        solo.config = SimpleNamespace(world_group=None, world_size=1)
+        self.assertTrue(solo._capture_unanimous(True))
+        self.assertFalse(solo._capture_unanimous(False))
+
+        # Multi-rank: MIN all-reduce means any rank's False makes all False.
+        for local_ok, peer_result, expected in ((True, 0, False), (True, 1, True)):
+            with mock.patch(
+                "tokenspeed.runtime.distributed.process_group_manager."
+                "process_group_manager.get_process_group",
+                return_value=object(),
+            ), mock.patch("torch.distributed.all_reduce") as all_reduce:
+
+                def fill(flag, op=None, group=None, _r=peer_result):
+                    flag.fill_(_r)
+
+                all_reduce.side_effect = fill
+                self.assertEqual(graph._capture_unanimous(local_ok), expected)
+                op = all_reduce.call_args.kwargs.get("op")
+                self.assertIs(op, torch.distributed.ReduceOp.MIN)
+
+    def test_prepare_finish_hooks_must_be_implemented_together(self):
+        from tokenspeed.runtime.execution.prefill_graph import PrefillGraph
+
+        def resolve(model):
+            g = PrefillGraph.__new__(PrefillGraph)
+            g.inner_model = model
+            g._prepare_replay_hook = getattr(
+                model, "prepare_prefill_graph_replay", None
+            )
+            g._finish_replay_hook = getattr(model, "finish_prefill_graph_replay", None)
+            if (g._prepare_replay_hook is None) != (g._finish_replay_hook is None):
+                raise ValueError("both-or-neither")
+            return g
+
+        # Neither hook: fine (non-V4 models).
+        self.assertIsNone(resolve(SimpleNamespace())._prepare_replay_hook)
+        # Both hooks: fine.
+        both = resolve(
+            SimpleNamespace(
+                prepare_prefill_graph_replay=lambda *a, **k: None,
+                finish_prefill_graph_replay=lambda *a, **k: None,
+            )
+        )
+        self.assertIsNotNone(both._prepare_replay_hook)
+        # Exactly one: rejected.
+        with self.assertRaises(ValueError):
+            resolve(SimpleNamespace(prepare_prefill_graph_replay=lambda *a, **k: None))
+        with self.assertRaises(ValueError):
+            resolve(SimpleNamespace(finish_prefill_graph_replay=lambda *a, **k: None))
+
+    def test_dummy_batch_calls_model_pregraph_hook_with_capture(self):
+        from unittest import mock
+
+        from tokenspeed.runtime.execution.prefill_graph import PrefillGraph
+
+        num_tokens = 4
+        input_buffers = SimpleNamespace(
+            input_ids_buf=torch.empty(num_tokens, dtype=torch.int32),
+            out_cache_loc_buf=torch.empty(num_tokens, dtype=torch.int64),
+            positions_buf=torch.empty(num_tokens, dtype=torch.int64),
+            req_pool_indices_buf=torch.empty(1, dtype=torch.int32),
+            seq_lens_buf=torch.empty(1, dtype=torch.int32),
+            input_lengths_buf=torch.empty(1, dtype=torch.int32),
+            extend_seq_lens_cpu=torch.empty(1, dtype=torch.int32),
+            extend_prefix_lens_buf=torch.empty(1, dtype=torch.int32),
+            extend_prefix_lens_cpu=torch.empty(1, dtype=torch.int32),
+            dummy_kv_slot=7,
+        )
+        backend = SimpleNamespace(
+            uses_paged_cache_groups=False,
+            init_forward_metadata=mock.Mock(),
+        )
+
+        graph = PrefillGraph.__new__(PrefillGraph)
+        graph.input_buffers = input_buffers
+        graph.config = SimpleNamespace(device="cpu", world_size=1)
+        graph.req_to_page = torch.ones(1, 2, dtype=torch.int32)
+        graph.attn_backend = backend
+        graph.token_to_kv_pool = object()
+        graph.drafter = None
+        graph.dp_size = 1
+        graph._prepare_replay_hook = mock.Mock()
+
+        ctx = graph._make_dummy_batch(num_tokens, None)
+
+        hook = graph._prepare_replay_hook
+        hook.assert_called_once()
+        hook_ctx, hook_positions = hook.call_args.args
+        self.assertIs(hook_ctx, ctx)
+        self.assertEqual(hook_positions.shape[0], num_tokens)
+        self.assertIs(hook_positions._base, input_buffers.positions_buf)
+        self.assertEqual(hook.call_args.kwargs, {"capture": True})
+
+    def test_replay_runs_pregraph_hooks_around_graph_and_clears_on_error(self):
+        from unittest import mock
+
+        from tokenspeed.runtime.execution import prefill_graph as prefill_graph_mod
+        from tokenspeed.runtime.execution.context import ForwardContext
+        from tokenspeed.runtime.execution.forward_batch_info import (
+            CaptureHiddenMode,
+            ForwardMode,
+        )
+        from tokenspeed.runtime.execution.prefill_graph import (
+            CapturedForward,
+            PrefillGraph,
+        )
+
+        bucket = 4
+        calls: list[str] = []
+        input_buffers = SimpleNamespace(
+            positions_buf=torch.arange(bucket, dtype=torch.int64),
+        )
+
+        graph = PrefillGraph.__new__(PrefillGraph)
+        graph.disable = False
+        graph.dp_size = 1
+        graph.config = SimpleNamespace(
+            device="cpu", world_size=1, disable_cuda_graph_padding=False
+        )
+        graph.capture_buckets = [bucket]
+        graph.input_buffers = input_buffers
+        graph._multimodal_input_embeds = None
+        graph._embed_tokens = lambda ids: torch.zeros(ids.shape[0], 2)
+        graph._input_embeds_buf = torch.zeros(bucket, 2)
+        graph._captured_hidden_mode = CaptureHiddenMode.NULL
+        graph._engaged_logged = {"text", "multimodal"}
+        graph._captures = {
+            bucket: SimpleNamespace(replay=lambda: calls.append("graph"))
+        }
+        graph._outputs = {
+            bucket: CapturedForward(
+                hidden_states=torch.zeros(bucket, 2), aux_hidden_states=None
+            )
+        }
+        graph.text_model = SimpleNamespace(
+            logits_processor=mock.Mock(return_value="logits"),
+            lm_head=object(),
+        )
+        graph._prepare_replay_hook = mock.Mock(
+            side_effect=lambda *a, **k: calls.append("prepare")
+        )
+        graph._finish_replay_hook = mock.Mock(
+            side_effect=lambda ctx: calls.append("finish")
+        )
+
+        ctx = ForwardContext(
+            attn_backend=None,
+            token_to_kv_pool=None,
+            bs=1,
+            num_extends=1,
+            input_num_tokens=bucket,
+            forward_mode=ForwardMode.EXTEND,
+        )
+        with mock.patch.object(prefill_graph_mod, "LogitsMetadata"):
+            result = graph.replay(ctx, torch.zeros(bucket, dtype=torch.int64))
+
+        self.assertEqual(result, "logits")
+        self.assertEqual(calls, ["prepare", "graph", "finish"])
+        prepare = graph._prepare_replay_hook
+        prepare_ctx, prepare_positions = prepare.call_args.args
+        self.assertIs(prepare_ctx, ctx)
+        self.assertIs(prepare_positions._base, input_buffers.positions_buf)
+        self.assertEqual(prepare.call_args.kwargs, {"capture": False})
+        graph._finish_replay_hook.assert_called_once_with(ctx)
+
+        # A replay failure must still clear the armed flag via the finish hook.
+        calls.clear()
+        graph._captures[bucket] = SimpleNamespace(
+            replay=mock.Mock(side_effect=RuntimeError("boom"))
+        )
+        with mock.patch.object(prefill_graph_mod, "LogitsMetadata"):
+            with self.assertRaises(RuntimeError):
+                graph.replay(ctx, torch.zeros(bucket, dtype=torch.int64))
+        self.assertEqual(calls, ["prepare", "finish"])
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")

--- a/test/runtime/test_deepseek_v4_attention_ops.py
+++ b/test/runtime/test_deepseek_v4_attention_ops.py
@@ -15,6 +15,8 @@ import math
 import os
 import sys
 import unittest
+from types import SimpleNamespace
+from unittest import mock
 
 import torch
 
@@ -36,6 +38,7 @@ from tokenspeed.runtime.configs.deepseek_v4_cache_spec import (
     deepseek_v4_swa_scale_dim,
     deepseek_v4_swa_token_stride,
 )
+from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (
     deepseek_v4_combine_dense_swa_indices,
     deepseek_v4_combine_topk_swa_indices,
@@ -56,11 +59,18 @@ from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (
     write_deepseek_v4_indexer_mxfp4_cache,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
+    _group_slot_mapping_from_raw,
     _mask_invalid_graph_tokens,
 )
+from tokenspeed.runtime.models import deepseek_v4 as deepseek_v4_model
 from tokenspeed.runtime.models.deepseek_v4 import (
+    DeepseekV4Attention,
+    DeepseekV4Compressor,
+    DeepseekV4Indexer,
     _deepseek_v4_sanitize_swa_slot_mapping,
+    _DeepseekV4PregraphBuffers,
 )
+from tokenspeed.runtime.utils.cuda_stream import StreamFork
 
 HEAD_DIM = 512
 NOPE_DIM = 448
@@ -188,6 +198,29 @@ def _mxfp4_bytes_and_scales(
     return torch.cat(packed_blocks), torch.stack(scales), torch.cat(dequant_blocks)
 
 
+def _dequantize_packed_indexer_q(
+    values: torch.Tensor,
+    scales: torch.Tensor,
+) -> torch.Tensor:
+    """Decode the four MXFP4 blocks used by the indexer Q tests."""
+    scale_bytes = scales.contiguous().view(torch.uint8).reshape(*scales.shape, 4)
+    out = torch.empty(
+        (*values.shape[:-1], values.shape[-1] * 2),
+        device=values.device,
+        dtype=torch.float32,
+    )
+    for block_id in range(4):
+        packed = values[..., block_id * 16 : (block_id + 1) * 16]
+        scale = torch.pow(
+            2.0,
+            scale_bytes[..., block_id].to(torch.float32) - 127.0,
+        ).unsqueeze(-1)
+        target = out[..., block_id * 32 : (block_id + 1) * 32]
+        target[..., 0::2] = _e2m1_values(packed & 0x0F) * scale
+        target[..., 1::2] = _e2m1_values(packed >> 4) * scale
+    return out
+
+
 def _hadamard_rotate(row: torch.Tensor) -> torch.Tensor:
     shape = row.shape
     return hadamard_transform(
@@ -296,6 +329,1107 @@ def _expected_overlap_normed(
 
 
 class DeepseekV4AttentionOpsCpuValidationTest(unittest.TestCase):
+    def test_attention_phase1_uses_bucket_then_core_slices_every_tensor(self):
+        bucket_tokens = 5
+        real_tokens = 3
+
+        for ambient, expected_rows in ((True, real_tokens), (False, bucket_tokens)):
+            with self.subTest(ambient=ambient):
+                attention = object.__new__(DeepseekV4Attention)
+                torch.nn.Module.__init__(attention)
+                attention.attention_kind = "csa"
+                attention.rotary_emb = SimpleNamespace(
+                    cos_sin_cache=torch.zeros(1, ROPE_DIM, dtype=torch.float32)
+                )
+                attention.stream_fork = StreamFork(None)
+                attention.padded_heads = 16
+                attention.cache_layer_index = 0
+                attention.compress_ratio = 4
+                attention.pregraph_buffers = None
+                attention.num_local_heads = 16
+                attention.head_dim = HEAD_DIM
+                attention.swa_window = 64
+                attention.scale = 1.0
+                attention.attn_sink = torch.zeros(1)
+
+                q = torch.randn(bucket_tokens, 16, HEAD_DIM, dtype=torch.bfloat16)
+                kv = torch.randn(bucket_tokens, HEAD_DIM, dtype=torch.bfloat16)
+                qr = torch.randn(bucket_tokens, 32, dtype=torch.bfloat16)
+                compressor_score = torch.randn(bucket_tokens, 17)
+                indexer_compressor_score = torch.randn(bucket_tokens, 19)
+                attention._project_q_kv = mock.Mock(return_value=(q, kv, qr))
+
+                compressor = mock.Mock()
+                compressor.compute_kv_score.return_value = compressor_score
+                attention.compressor = compressor
+                indexer = mock.Mock()
+                indexer.compressor.compute_kv_score.return_value = (
+                    indexer_compressor_score
+                )
+                packed_q_values = torch.full(
+                    (bucket_tokens, 2, 64), 0x11, dtype=torch.uint8
+                )
+                packed_q_scales = torch.full(
+                    (bucket_tokens, 2), 0x01010101, dtype=torch.int32
+                )
+                packed_weights = torch.ones(bucket_tokens, 2)
+                packed_q_values[real_tokens:].fill_(0xFF)
+                packed_q_scales[real_tokens:].fill_(torch.iinfo(torch.int32).max)
+                packed_weights[real_tokens:].fill_(float("nan"))
+                indexer._prepare_packed_inputs.return_value = (
+                    packed_q_values,
+                    packed_q_scales,
+                    packed_weights,
+                )
+                indexer.side_effect = lambda **kw: torch.zeros(
+                    (kw["positions"].shape[0], 4), dtype=torch.int32
+                )
+                attention.indexer = indexer
+                attention._insert_swa_cache = mock.Mock()
+                attention._project_attention_output = mock.Mock(
+                    side_effect=lambda output, *_: output
+                )
+
+                metadata = SimpleNamespace(
+                    is_valid_token=None,
+                    token_to_req_indices=torch.arange(real_tokens),
+                )
+                backend = SimpleNamespace(
+                    forward_metadata=metadata,
+                    forward_deepseek_v4_prefill=mock.Mock(
+                        side_effect=lambda **kw: kw["q"]
+                    ),
+                )
+                pool = SimpleNamespace(
+                    swa_block_size=4,
+                    get_swa_kv_buffer=mock.Mock(
+                        return_value=torch.empty(1, 4 * 584, dtype=torch.uint8)
+                    ),
+                    get_indexer_block_size=mock.Mock(return_value=64),
+                )
+                ctx = SimpleNamespace(
+                    dsa_compressor_slot_cache=None,
+                    dsa_swa_slot_mapping=None,
+                    token_to_kv_pool=pool,
+                    attn_backend=backend,
+                    forward_mode=ForwardMode.EXTEND,
+                    dsa_pregraph_writes=False,
+                )
+                positions = torch.arange(bucket_tokens, dtype=torch.int64)
+                hidden_states = torch.randn(bucket_tokens, 8)
+                out_cache_loc = torch.arange(bucket_tokens, dtype=torch.int64) + 10
+                swa_slot_mapping = torch.arange(bucket_tokens, dtype=torch.int64) + 20
+
+                with mock.patch(
+                    "tokenspeed.runtime.models.deepseek_v4.current_forward_ctx",
+                    return_value=ctx if ambient else None,
+                ):
+                    attention(
+                        positions,
+                        hidden_states,
+                        ctx,
+                        out_cache_loc,
+                        swa_slot_mapping=swa_slot_mapping,
+                    )
+
+                self.assertEqual(
+                    attention._project_q_kv.call_args.args[0].shape[0], bucket_tokens
+                )
+                self.assertEqual(
+                    compressor.compute_kv_score.call_args.args[0].shape[0],
+                    bucket_tokens,
+                )
+                self.assertEqual(
+                    indexer.compressor.compute_kv_score.call_args.args[0].shape[0],
+                    bucket_tokens,
+                )
+
+                compressor_args = compressor.call_args.kwargs
+                self.assertEqual(
+                    compressor_args["hidden_states"].shape[0], expected_rows
+                )
+                self.assertEqual(compressor_args["positions"].shape[0], expected_rows)
+                self.assertEqual(
+                    compressor_args["out_cache_loc"].shape[0], expected_rows
+                )
+                self.assertEqual(compressor_args["kv_score"].shape[0], expected_rows)
+
+                indexer_args = indexer.call_args.kwargs
+                self.assertEqual(indexer_args["hidden_states"].shape[0], expected_rows)
+                self.assertEqual(indexer_args["qr"].shape[0], expected_rows)
+                self.assertEqual(indexer_args["positions"].shape[0], expected_rows)
+                self.assertEqual(indexer_args["out_cache_loc"].shape[0], expected_rows)
+                self.assertEqual(
+                    indexer_args["indexer_compressor_kv_score"].shape[0],
+                    expected_rows,
+                )
+                prepared_sources = {
+                    "packed_q_values": packed_q_values,
+                    "packed_q_scales": packed_q_scales,
+                    "packed_weights": packed_weights,
+                }
+                if ambient:
+                    indexer._prepare_packed_inputs.assert_called_once_with(
+                        hidden_states=hidden_states,
+                        qr=qr,
+                        positions=positions,
+                        cos_sin_cache=attention.rotary_emb.cos_sin_cache,
+                    )
+                    for name, source in prepared_sources.items():
+                        actual = indexer_args[name]
+                        self.assertEqual(actual.shape[0], real_tokens)
+                        self.assertEqual(actual.data_ptr(), source.data_ptr())
+                        self.assertIs(actual._base, source)
+                    self.assertTrue(
+                        bool((indexer_args["packed_q_values"] == 0x11).all())
+                    )
+                    self.assertTrue(
+                        bool((indexer_args["packed_q_scales"] == 0x01010101).all())
+                    )
+                    self.assertTrue(
+                        bool(torch.isfinite(indexer_args["packed_weights"]).all())
+                    )
+                else:
+                    indexer._prepare_packed_inputs.assert_not_called()
+                    for name in prepared_sources:
+                        self.assertIsNone(indexer_args[name])
+
+                insert_args = attention._insert_swa_cache.call_args.kwargs
+                self.assertEqual(insert_args["q"].shape[0], expected_rows)
+                self.assertEqual(insert_args["kv"].shape[0], expected_rows)
+                self.assertEqual(insert_args["positions"].shape[0], expected_rows)
+                self.assertEqual(insert_args["slot_mapping"].shape[0], expected_rows)
+                backend_args = backend.forward_deepseek_v4_prefill.call_args.kwargs
+                self.assertEqual(backend_args["q"].shape[0], expected_rows)
+                attention._project_attention_output.assert_called_once()
+                output_args = attention._project_attention_output.call_args.args
+                self.assertEqual(output_args[0].shape[0], expected_rows)
+                # The real-token slice is local to the eager core. The output
+                # projection sits after the break and therefore retains the
+                # outer bucket-shaped positions tensor; during CUDA-graph
+                # replay the raw attention output lands in a bucket-shaped
+                # handoff buffer before this call as well.
+                self.assertIs(output_args[1], positions)
+                self.assertEqual(output_args[1].shape[0], bucket_tokens)
+                self.assertIs(output_args[2], attention.rotary_emb.cos_sin_cache)
+                if ambient:
+                    leading_views = (
+                        (insert_args["q"], q),
+                        (insert_args["kv"], kv),
+                        (indexer_args["qr"], qr),
+                        (compressor_args["kv_score"], compressor_score),
+                        (
+                            indexer_args["indexer_compressor_kv_score"],
+                            indexer_compressor_score,
+                        ),
+                        (indexer_args["packed_q_values"], packed_q_values),
+                        (indexer_args["packed_q_scales"], packed_q_scales),
+                        (indexer_args["packed_weights"], packed_weights),
+                    )
+                    for actual, source in leading_views:
+                        self.assertEqual(actual.data_ptr(), source.data_ptr())
+                        self.assertIs(actual._base, source)
+
+    def test_indexer_forward_threads_prepared_triplet_to_custom_op(self):
+        num_tokens = 2
+        indexer = object.__new__(DeepseekV4Indexer)
+        torch.nn.Module.__init__(indexer)
+        indexer.compress_ratio = 4
+        indexer.use_fp4_cache = True
+        compressor = mock.Mock()
+        compressor.norm = SimpleNamespace(
+            weight=torch.ones(1),
+            variance_epsilon=1.0e-6,
+        )
+        indexer.compressor = compressor
+        expected_topk = torch.full((num_tokens, 2), 7, dtype=torch.int32)
+        indexer._forward_sparse_indexer_custom_op = mock.Mock(
+            return_value=expected_topk
+        )
+
+        state_cache = torch.empty(1, 1)
+        indexer_cache = torch.empty(1, 1, dtype=torch.uint8)
+        state_slots = torch.arange(num_tokens, dtype=torch.int64)
+        state_table = torch.zeros(1, 1, dtype=torch.int32)
+        compressed_slots = torch.arange(num_tokens, dtype=torch.int64)
+        cache_metadata = SimpleNamespace(
+            compressed_slot_mapping=mock.Mock(return_value=compressed_slots)
+        )
+        metadata = SimpleNamespace(
+            cache=cache_metadata,
+            token_to_req_indices=torch.zeros(num_tokens, dtype=torch.int32),
+            is_valid_token=None,
+            query_start_loc=torch.tensor([0, num_tokens], dtype=torch.int32),
+            seq_lens=torch.tensor([num_tokens], dtype=torch.int32),
+        )
+        pool = SimpleNamespace(
+            get_indexer_state_buffer=mock.Mock(return_value=state_cache),
+            get_indexer_block_size=mock.Mock(return_value=4),
+            get_indexer_kv_buffer_2d=mock.Mock(return_value=indexer_cache),
+        )
+        ctx = SimpleNamespace(
+            token_to_kv_pool=pool,
+            attn_backend=SimpleNamespace(
+                forward_metadata=metadata,
+                forward_prefill_metadata=metadata,
+            ),
+            forward_mode=ForwardMode.MIXED,
+            dsa_pregraph_writes=False,
+        )
+        packed_q_values = torch.full((num_tokens, 2, 2), 1, dtype=torch.uint8)
+        packed_q_scales = torch.full((num_tokens, 2), 2, dtype=torch.int32)
+        packed_weights = torch.full((num_tokens, 2), 3.0)
+
+        with mock.patch.object(
+            deepseek_v4_model,
+            "deepseek_v4_csa_indexer_cache_insert",
+        ):
+            actual = indexer(
+                hidden_states=torch.zeros(num_tokens, 4),
+                qr=torch.zeros(num_tokens, 4),
+                positions=torch.arange(num_tokens, dtype=torch.int64),
+                ctx=ctx,
+                out_cache_loc=torch.arange(num_tokens, dtype=torch.int64),
+                layer_index=0,
+                cos_sin_cache=torch.empty(1, ROPE_DIM),
+                compressor_slot_cache={
+                    "indexer_state": (state_slots, state_table, 4, None)
+                },
+                packed_q_values=packed_q_values,
+                packed_q_scales=packed_q_scales,
+                packed_weights=packed_weights,
+            )
+
+        self.assertIs(actual, expected_topk)
+        custom_args = indexer._forward_sparse_indexer_custom_op.call_args.kwargs
+        self.assertIs(custom_args["packed_q_values"], packed_q_values)
+        self.assertIs(custom_args["packed_q_scales"], packed_q_scales)
+        self.assertIs(custom_args["packed_weights"], packed_weights)
+
+    def test_compressed_slot_mapping_memo_is_shared_by_block_size(self):
+        num_tokens = 2
+        positions = torch.arange(num_tokens, dtype=torch.int64)
+        state_slots = torch.arange(num_tokens, dtype=torch.int64)
+        state_table = torch.zeros(1, 1, dtype=torch.int32)
+        compressed_slots_64 = torch.tensor([11, 12], dtype=torch.int64)
+        compressed_slots_32 = torch.tensor([21, 22], dtype=torch.int64)
+        slots_by_block_size = {
+            64: compressed_slots_64,
+            32: compressed_slots_32,
+        }
+
+        def compressed_slot_mapping(*args, kv_cache_block_size, **kwargs):
+            del args, kwargs
+            return slots_by_block_size[kv_cache_block_size]
+
+        cache_metadata = SimpleNamespace(
+            compressed_slot_mapping=mock.Mock(side_effect=compressed_slot_mapping),
+            compressor_state_block_tables={4: state_table},
+            compressor_state_base_logical_pages={4: None},
+        )
+        metadata = SimpleNamespace(
+            cache=cache_metadata,
+            token_to_req_indices=torch.zeros(num_tokens, dtype=torch.int32),
+            is_valid_token=None,
+            query_start_loc=torch.tensor([0, num_tokens], dtype=torch.int32),
+            seq_lens=torch.tensor([num_tokens], dtype=torch.int32),
+        )
+        compressed_block_size = mock.Mock(return_value=64)
+        pool = SimpleNamespace(
+            get_indexer_state_buffer=mock.Mock(return_value=torch.empty(1, 1)),
+            get_indexer_block_size=mock.Mock(return_value=64),
+            get_indexer_kv_buffer_2d=mock.Mock(
+                return_value=torch.empty(1, 1, dtype=torch.uint8)
+            ),
+            get_compressed_block_size=compressed_block_size,
+            get_compressed_kv_buffer_2d=mock.Mock(
+                return_value=torch.empty(1, 1, dtype=torch.uint8)
+            ),
+        )
+        ctx = SimpleNamespace(
+            token_to_kv_pool=pool,
+            attn_backend=SimpleNamespace(forward_metadata=metadata),
+            forward_mode=ForwardMode.MIXED,
+            dsa_pregraph_writes=False,
+        )
+        slot_cache = {
+            "indexer_state": (state_slots, state_table, 4, None),
+        }
+
+        indexer = object.__new__(DeepseekV4Indexer)
+        torch.nn.Module.__init__(indexer)
+        indexer.compress_ratio = 4
+        indexer.use_fp4_cache = True
+        indexer.compressor = mock.Mock()
+        indexer.compressor.norm = SimpleNamespace(
+            weight=torch.ones(1),
+            variance_epsilon=1.0e-6,
+        )
+        indexer._forward_sparse_indexer_custom_op = mock.Mock(
+            return_value=torch.zeros(num_tokens, 1, dtype=torch.int32)
+        )
+        packed_q_values = torch.zeros(num_tokens, 1, 1, dtype=torch.uint8)
+        packed_q_scales = torch.zeros(num_tokens, 1, dtype=torch.int32)
+        packed_weights = torch.zeros(num_tokens, 1)
+
+        compressor = SimpleNamespace(
+            compress_ratio=4,
+            coff=1,
+            head_dim=2,
+            ape=torch.empty((4, 2), dtype=torch.float32),
+            norm=SimpleNamespace(
+                weight=torch.ones(2),
+                variance_epsilon=1.0e-6,
+            ),
+        )
+        kv_score = torch.empty((num_tokens, 4), dtype=torch.float32)
+
+        with (
+            mock.patch.object(
+                deepseek_v4_model,
+                "deepseek_v4_csa_indexer_cache_insert",
+            ) as indexer_insert,
+            mock.patch.object(
+                deepseek_v4_model,
+                "save_deepseek_v4_compressor_state",
+            ),
+            mock.patch.object(
+                deepseek_v4_model,
+                "deepseek_v4_csa_compress_kv_cache_insert",
+            ) as compressor_insert,
+        ):
+            indexer(
+                hidden_states=torch.zeros(num_tokens, 4),
+                qr=torch.zeros(num_tokens, 4),
+                positions=positions,
+                ctx=ctx,
+                out_cache_loc=state_slots,
+                layer_index=0,
+                cos_sin_cache=torch.empty(1, ROPE_DIM),
+                compressor_slot_cache=slot_cache,
+                packed_q_values=packed_q_values,
+                packed_q_scales=packed_q_scales,
+                packed_weights=packed_weights,
+            )
+            DeepseekV4Compressor.forward(
+                compressor,
+                hidden_states=torch.empty(num_tokens, 1),
+                positions=positions,
+                ctx=ctx,
+                out_cache_loc=state_slots,
+                layer_index=0,
+                cos_sin_cache=torch.empty(1, ROPE_DIM),
+                state_cache=torch.empty(1, 1),
+                state_block_size=4,
+                state_slot_mapping=state_slots,
+                compressor_slot_cache=slot_cache,
+                kv_score=kv_score,
+            )
+
+            key_64 = ("compressed_slot_mapping", 4, 64)
+            self.assertIs(slot_cache[key_64], compressed_slots_64)
+            self.assertIs(
+                indexer_insert.call_args.kwargs["kv_slot_mapping"],
+                compressed_slots_64,
+            )
+            self.assertIs(
+                compressor_insert.call_args.kwargs["kv_slot_mapping"],
+                compressed_slots_64,
+            )
+            cache_metadata.compressed_slot_mapping.assert_called_once()
+
+            compressed_block_size.return_value = 32
+            DeepseekV4Compressor.forward(
+                compressor,
+                hidden_states=torch.empty(num_tokens, 1),
+                positions=positions,
+                ctx=ctx,
+                out_cache_loc=state_slots,
+                layer_index=0,
+                cos_sin_cache=torch.empty(1, ROPE_DIM),
+                state_cache=torch.empty(1, 1),
+                state_block_size=4,
+                state_slot_mapping=state_slots,
+                compressor_slot_cache=slot_cache,
+                kv_score=kv_score,
+            )
+
+        key_32 = ("compressed_slot_mapping", 4, 32)
+        self.assertIs(slot_cache[key_32], compressed_slots_32)
+        self.assertEqual(cache_metadata.compressed_slot_mapping.call_count, 2)
+        self.assertIs(
+            compressor_insert.call_args.kwargs["kv_slot_mapping"],
+            compressed_slots_32,
+        )
+
+    def test_pregraph_buffers_allocate_disarmed_and_reuse(self):
+        buffers = _DeepseekV4PregraphBuffers()
+        self.assertFalse(buffers.allocated)
+        buffers.allocate(4, 2, 3, 2, torch.device("cpu"))
+        self.assertTrue(buffers.allocated)
+        self.assertEqual(buffers.token_to_req.tolist(), [-1] * 4)
+        self.assertEqual(buffers.indexer.state_slot_mapping.tolist(), [-1] * 4)
+        self.assertEqual(buffers.indexer.kv_slot_mapping.tolist(), [-1] * 4)
+        self.assertEqual(buffers.indexer.state_block_table.tolist(), [[-1] * 3] * 2)
+        self.assertEqual(buffers.indexer.state_base_pages.tolist(), [0, 0])
+        self.assertEqual(buffers.c4.state_slot_mapping.tolist(), [-1] * 4)
+        self.assertEqual(buffers.c4.kv_slot_mapping.tolist(), [-1] * 4)
+        self.assertEqual(buffers.c4.state_block_table.tolist(), [[-1] * 2] * 2)
+        self.assertEqual(buffers.c4.state_base_pages.tolist(), [0, 0])
+
+        # A smaller re-allocation keeps the captured storage and re-disarms it.
+        buffers.token_to_req.fill_(5)
+        buffers.c4.state_slot_mapping.fill_(5)
+        table = buffers.indexer.state_block_table
+        buffers.allocate(2, 1, 3, 2, torch.device("cpu"))
+        self.assertIs(buffers.indexer.state_block_table, table)
+        self.assertEqual(buffers.token_to_req.tolist(), [-1] * 4)
+        self.assertEqual(buffers.c4.state_slot_mapping.tolist(), [-1] * 4)
+
+    def test_model_pregraph_hook_arms_pure_extend_and_disarms_unsafe(self):
+        model = object.__new__(deepseek_v4_model.DeepseekV4Model)
+        torch.nn.Module.__init__(model)
+        model.pregraph_buffers = _DeepseekV4PregraphBuffers()
+        model._pregraph_indexer_cache_layer_index = 0
+        model._pregraph_indexer_compress_ratio = 4
+
+        num_tokens = 4
+        positions = torch.tensor([0, 1, 2, 3], dtype=torch.int64)
+        token_to_req = torch.tensor([0, 0, 1, 1], dtype=torch.int32)
+        state_table = torch.tensor([[3, 4], [5, 6]], dtype=torch.int32)
+        c4_state_table = torch.tensor([[7], [9]], dtype=torch.int32)
+        compressed_slots = torch.tensor([9, -1, 13, 15], dtype=torch.int64)
+        cache_metadata = SimpleNamespace(
+            indexer_state_block_table=state_table,
+            indexer_state_base_logical_page=None,
+            compressor_state_block_tables={4: c4_state_table},
+            compressor_state_base_logical_pages={4: None},
+            compressed_slot_mapping=mock.Mock(return_value=compressed_slots),
+        )
+        metadata = SimpleNamespace(
+            cache=cache_metadata,
+            token_to_req_indices=token_to_req,
+            is_valid_token=None,
+            num_prefill_tokens=num_tokens,
+            decode_token_count=mock.Mock(return_value=0),
+            query_start_loc=torch.tensor([0, 2, 4], dtype=torch.int32),
+            seq_lens=torch.tensor([2, 4], dtype=torch.int32),
+        )
+        pool = SimpleNamespace(
+            get_indexer_state_block_size=mock.Mock(return_value=2),
+            get_indexer_block_size=mock.Mock(return_value=64),
+            get_compressor_state_block_size=mock.Mock(return_value=4),
+            get_compressed_block_size=mock.Mock(return_value=64),
+        )
+        ctx = SimpleNamespace(
+            forward_mode=ForwardMode.EXTEND,
+            token_to_kv_pool=pool,
+            req_to_page=torch.zeros(8, 2, dtype=torch.int32),
+            attn_backend=SimpleNamespace(
+                forward_metadata=metadata,
+                forward_prefill_metadata=metadata,
+            ),
+            dsa_compressor_slot_cache=None,
+        )
+
+        # The capture call sizes and disarms the buffers from dummy metadata.
+        model.prepare_prefill_graph_replay(
+            ctx, torch.zeros(6, dtype=torch.int64), capture=True
+        )
+        buffers = model.pregraph_buffers
+        self.assertTrue(buffers.allocated)
+        self.assertFalse(ctx.dsa_pregraph_writes)
+        self.assertEqual(buffers.token_to_req.shape[0], 6)
+        self.assertEqual(list(buffers.indexer.state_block_table.shape), [6, 2])
+        self.assertEqual(list(buffers.c4.state_block_table.shape), [6, 1])
+
+        # A safe pure-extend replay stages live metadata and arms the flag.
+        model.prepare_prefill_graph_replay(ctx, positions, capture=False)
+        self.assertTrue(ctx.dsa_pregraph_writes)
+        self.assertEqual(
+            buffers.token_to_req[:num_tokens].tolist(), token_to_req.tolist()
+        )
+        self.assertEqual(buffers.token_to_req[num_tokens:].tolist(), [-1, -1])
+        expected_state = _group_slot_mapping_from_raw(
+            positions, token_to_req, state_table, 2
+        )
+        self.assertEqual(
+            buffers.indexer.state_slot_mapping[:num_tokens].tolist(),
+            expected_state.tolist(),
+        )
+        self.assertEqual(
+            buffers.indexer.state_slot_mapping[num_tokens:].tolist(), [-1, -1]
+        )
+        self.assertEqual(
+            buffers.indexer.kv_slot_mapping[:num_tokens].tolist(),
+            compressed_slots.tolist(),
+        )
+        self.assertEqual(
+            buffers.indexer.state_block_table[:2].tolist(), state_table.tolist()
+        )
+        self.assertEqual(buffers.indexer.state_block_table[2:].tolist(), [[-1, -1]] * 4)
+        expected_c4_state = _group_slot_mapping_from_raw(
+            positions, token_to_req, c4_state_table, 4
+        )
+        self.assertEqual(
+            buffers.c4.state_slot_mapping[:num_tokens].tolist(),
+            expected_c4_state.tolist(),
+        )
+        self.assertEqual(buffers.c4.state_slot_mapping[num_tokens:].tolist(), [-1, -1])
+        # Equal compressed block sizes share one mapping computation.
+        self.assertEqual(
+            buffers.c4.kv_slot_mapping[:num_tokens].tolist(),
+            compressed_slots.tolist(),
+        )
+        self.assertEqual(
+            buffers.c4.state_block_table[:2].tolist(), c4_state_table.tolist()
+        )
+        self.assertEqual(buffers.c4.state_block_table[2:].tolist(), [[-1]] * 4)
+        cache_metadata.compressed_slot_mapping.assert_called_once()
+        mapping_kwargs = cache_metadata.compressed_slot_mapping.call_args.kwargs
+        self.assertEqual(mapping_kwargs["kv_cache_block_size"], 64)
+        self.assertFalse(mapping_kwargs["use_decode_cache"])
+        model.finish_prefill_graph_replay(ctx)
+        self.assertFalse(ctx.dsa_pregraph_writes)
+
+        # Mixed forwards disarm (isolates the is_mixed() guard: MIXED is also
+        # not a pure extend, so this alone would not distinguish the two, but
+        # the DECODE case below covers the not-is_extend() guard).
+        ctx.forward_mode = ForwardMode.MIXED
+        model.prepare_prefill_graph_replay(ctx, positions, capture=False)
+        self.assertFalse(ctx.dsa_pregraph_writes)
+        self.assertEqual(buffers.indexer.state_slot_mapping.tolist(), [-1] * 6)
+
+        # Pure decode disarms (isolates the not-is_extend() guard).
+        ctx.forward_mode = ForwardMode.DECODE
+        buffers.indexer.state_slot_mapping[:num_tokens].fill_(0)
+        model.prepare_prefill_graph_replay(ctx, positions, capture=False)
+        self.assertFalse(ctx.dsa_pregraph_writes)
+        self.assertEqual(buffers.indexer.state_slot_mapping.tolist(), [-1] * 6)
+        ctx.forward_mode = ForwardMode.EXTEND
+
+        # Base pages shorter than the live table's request count disarm (the
+        # kernel would otherwise index out of the base-page tensor).
+        cache_metadata.indexer_state_base_logical_page = torch.zeros(
+            1, dtype=torch.int32
+        )
+        buffers.indexer.state_slot_mapping[:num_tokens].fill_(0)
+        model.prepare_prefill_graph_replay(ctx, positions, capture=False)
+        self.assertFalse(ctx.dsa_pregraph_writes)
+        self.assertEqual(buffers.indexer.state_slot_mapping.tolist(), [-1] * 6)
+        cache_metadata.indexer_state_base_logical_page = None
+
+        # A live table wider than the captured buffers disarms too.
+        ctx.forward_mode = ForwardMode.EXTEND
+        cache_metadata.indexer_state_block_table = torch.zeros(2, 3, dtype=torch.int32)
+        buffers.indexer.state_slot_mapping[:num_tokens].fill_(0)
+        model.prepare_prefill_graph_replay(ctx, positions, capture=False)
+        self.assertFalse(ctx.dsa_pregraph_writes)
+        self.assertEqual(buffers.indexer.state_slot_mapping.tolist(), [-1] * 6)
+
+        # A missing compressor-state table disarms (arm-both-or-none).
+        cache_metadata.indexer_state_block_table = state_table
+        cache_metadata.compressor_state_block_tables = {}
+        buffers.c4.state_slot_mapping[:num_tokens].fill_(0)
+        model.prepare_prefill_graph_replay(ctx, positions, capture=False)
+        self.assertFalse(ctx.dsa_pregraph_writes)
+        self.assertEqual(buffers.c4.state_slot_mapping.tolist(), [-1] * 6)
+
+        # Unequal compressed block sizes compute and stage a second C4
+        # mapping.
+        cache_metadata.compressor_state_block_tables = {4: c4_state_table}
+        c4_compressed_slots = torch.tensor([21, 22, -1, 25], dtype=torch.int64)
+        slots_by_block_size = {64: compressed_slots, 32: c4_compressed_slots}
+
+        def compressed_by_size(*args, kv_cache_block_size, **kwargs):
+            del args, kwargs
+            return slots_by_block_size[kv_cache_block_size]
+
+        cache_metadata.compressed_slot_mapping = mock.Mock(
+            side_effect=compressed_by_size
+        )
+        pool.get_compressed_block_size.return_value = 32
+        model.prepare_prefill_graph_replay(ctx, positions, capture=False)
+        self.assertTrue(ctx.dsa_pregraph_writes)
+        self.assertEqual(cache_metadata.compressed_slot_mapping.call_count, 2)
+        self.assertEqual(
+            buffers.indexer.kv_slot_mapping[:num_tokens].tolist(),
+            compressed_slots.tolist(),
+        )
+        self.assertEqual(
+            buffers.c4.kv_slot_mapping[:num_tokens].tolist(),
+            c4_compressed_slots.tolist(),
+        )
+        model.finish_prefill_graph_replay(ctx)
+
+    def test_insert_cache_pregraph_binds_staged_buffers_to_kernels(self):
+        num_tokens = 2
+        buffers = _DeepseekV4PregraphBuffers()
+        buffers.allocate(num_tokens, 1, 1, 1, torch.device("cpu"))
+        pool = SimpleNamespace(
+            get_indexer_state_buffer=mock.Mock(return_value=torch.empty(1, 1)),
+            get_indexer_state_block_size=mock.Mock(return_value=2),
+            get_indexer_block_size=mock.Mock(return_value=64),
+            get_indexer_kv_buffer_2d=mock.Mock(
+                return_value=torch.empty(1, 1, dtype=torch.uint8)
+            ),
+            get_compressor_state_buffer=mock.Mock(return_value=torch.empty(1, 1)),
+            get_compressor_state_block_size=mock.Mock(return_value=4),
+            get_compressed_kv_buffer_2d=mock.Mock(
+                return_value=torch.empty(1, 1, dtype=torch.uint8)
+            ),
+            get_compressed_block_size=mock.Mock(return_value=64),
+        )
+        ctx = SimpleNamespace(token_to_kv_pool=pool)
+        positions = torch.arange(num_tokens, dtype=torch.int64)
+
+        indexer = object.__new__(DeepseekV4Indexer)
+        torch.nn.Module.__init__(indexer)
+        indexer.compress_ratio = 4
+        indexer.use_fp4_cache = True
+        indexer.compressor = SimpleNamespace(
+            coff=1,
+            head_dim=2,
+            ape=torch.empty(4, 2),
+            norm=SimpleNamespace(weight=torch.ones(2), variance_epsilon=1.0e-6),
+        )
+        with (
+            mock.patch.object(
+                deepseek_v4_model, "save_deepseek_v4_compressor_state"
+            ) as save_state,
+            mock.patch.object(
+                deepseek_v4_model, "deepseek_v4_csa_indexer_cache_insert"
+            ) as indexer_insert,
+        ):
+            indexer.insert_cache_pregraph(
+                positions=positions,
+                ctx=ctx,
+                layer_index=0,
+                cos_sin_cache=torch.empty(1, ROPE_DIM),
+                kv_score=torch.zeros(num_tokens, 4),
+                buffers=buffers,
+            )
+        self.assertIs(
+            save_state.call_args.kwargs["slot_mapping"]._base,
+            buffers.indexer.state_slot_mapping,
+        )
+        kwargs = indexer_insert.call_args.kwargs
+        self.assertIs(
+            kwargs["compressor_slot_mapping"]._base,
+            buffers.indexer.state_slot_mapping,
+        )
+        self.assertIs(kwargs["kv_slot_mapping"]._base, buffers.indexer.kv_slot_mapping)
+        self.assertIs(kwargs["block_table"], buffers.indexer.state_block_table)
+        self.assertIs(
+            kwargs["block_table_base_offsets"], buffers.indexer.state_base_pages
+        )
+        self.assertIs(kwargs["token_to_req_indices"]._base, buffers.token_to_req)
+        self.assertTrue(kwargs["use_fp4_cache"])
+
+        compressor = object.__new__(DeepseekV4Compressor)
+        torch.nn.Module.__init__(compressor)
+        compressor.compress_ratio = 4
+        compressor.coff = 1
+        compressor.head_dim = 2
+        compressor.ape = torch.empty(4, 2)
+        compressor.norm = SimpleNamespace(weight=torch.ones(2), variance_epsilon=1.0e-6)
+        with (
+            mock.patch.object(
+                deepseek_v4_model, "save_deepseek_v4_compressor_state"
+            ) as save_state,
+            mock.patch.object(
+                deepseek_v4_model, "deepseek_v4_csa_compress_kv_cache_insert"
+            ) as compressor_insert,
+        ):
+            compressor.insert_cache_pregraph(
+                positions=positions,
+                ctx=ctx,
+                layer_index=0,
+                cos_sin_cache=torch.empty(1, ROPE_DIM),
+                kv_score=torch.zeros(num_tokens, 4),
+                buffers=buffers,
+            )
+        self.assertIs(
+            save_state.call_args.kwargs["slot_mapping"]._base,
+            buffers.c4.state_slot_mapping,
+        )
+        kwargs = compressor_insert.call_args.kwargs
+        self.assertIs(
+            kwargs["compressor_slot_mapping"]._base,
+            buffers.c4.state_slot_mapping,
+        )
+        self.assertIs(kwargs["kv_slot_mapping"]._base, buffers.c4.kv_slot_mapping)
+        self.assertIs(kwargs["block_table"], buffers.c4.state_block_table)
+        self.assertIs(kwargs["block_table_base_offsets"], buffers.c4.state_base_pages)
+        self.assertIs(kwargs["token_to_req_indices"]._base, buffers.token_to_req)
+
+    def test_indexer_forward_skips_cache_writes_when_pregraph_armed(self):
+        num_tokens = 2
+        indexer = object.__new__(DeepseekV4Indexer)
+        torch.nn.Module.__init__(indexer)
+        indexer.compress_ratio = 4
+        indexer.use_fp4_cache = True
+        indexer.compressor = mock.Mock()
+        expected_topk = torch.full((num_tokens, 2), 7, dtype=torch.int32)
+        indexer._forward_sparse_indexer_custom_op = mock.Mock(
+            return_value=expected_topk
+        )
+        packed_q_values = torch.zeros(num_tokens, 1, 1, dtype=torch.uint8)
+        packed_q_scales = torch.zeros(num_tokens, 1, dtype=torch.int32)
+        packed_weights = torch.zeros(num_tokens, 1)
+
+        cache_metadata = SimpleNamespace(compressed_slot_mapping=mock.Mock())
+        metadata = SimpleNamespace(
+            cache=cache_metadata,
+            token_to_req_indices=torch.zeros(num_tokens, dtype=torch.int32),
+            is_valid_token=None,
+            query_start_loc=torch.tensor([0, num_tokens], dtype=torch.int32),
+            seq_lens=torch.tensor([num_tokens], dtype=torch.int32),
+        )
+        pool = SimpleNamespace(
+            get_indexer_state_buffer=mock.Mock(return_value=torch.empty(1, 1)),
+            get_indexer_block_size=mock.Mock(return_value=64),
+            get_indexer_kv_buffer_2d=mock.Mock(
+                return_value=torch.empty(1, 1, dtype=torch.uint8)
+            ),
+        )
+        ctx = SimpleNamespace(
+            token_to_kv_pool=pool,
+            attn_backend=SimpleNamespace(
+                forward_metadata=metadata,
+                forward_prefill_metadata=metadata,
+            ),
+            forward_mode=ForwardMode.EXTEND,
+            dsa_pregraph_writes=True,
+        )
+
+        with (
+            mock.patch.object(
+                deepseek_v4_model,
+                "deepseek_v4_csa_indexer_cache_insert",
+            ) as indexer_insert,
+            mock.patch.object(
+                deepseek_v4_model,
+                "save_deepseek_v4_compressor_state",
+            ) as save_state,
+        ):
+            actual = indexer(
+                hidden_states=torch.zeros(num_tokens, 4),
+                qr=torch.zeros(num_tokens, 4),
+                positions=torch.arange(num_tokens, dtype=torch.int64),
+                ctx=ctx,
+                out_cache_loc=torch.arange(num_tokens, dtype=torch.int64),
+                layer_index=0,
+                cos_sin_cache=torch.empty(1, ROPE_DIM),
+                compressor_slot_cache={},
+                packed_q_values=packed_q_values,
+                packed_q_scales=packed_q_scales,
+                packed_weights=packed_weights,
+            )
+
+        self.assertIs(actual, expected_topk)
+        indexer.compressor.assert_not_called()
+        indexer_insert.assert_not_called()
+        save_state.assert_not_called()
+        cache_metadata.compressed_slot_mapping.assert_not_called()
+        custom_kwargs = indexer._forward_sparse_indexer_custom_op.call_args.kwargs
+        self.assertEqual(custom_kwargs["indexer_block_size"], 64)
+        # The skip path must thread the caller's already-packed triplet through
+        # unchanged (not drop/recompute it inside the sparse indexer op).
+        self.assertIs(custom_kwargs["packed_q_values"], packed_q_values)
+        self.assertIs(custom_kwargs["packed_q_scales"], packed_q_scales)
+        self.assertIs(custom_kwargs["packed_weights"], packed_weights)
+
+    def test_attention_forward_pregraph_insert_gate(self):
+        # The gate is load-bearing: the staging buffers stay armed with the
+        # last replay's mappings after finish clears the ctx flag, so the
+        # captured-write kernels must fire ONLY under an ambient breakable
+        # capture/replay with allocated buffers -- never on eager forwards.
+        num_tokens = 4
+        positions = torch.arange(num_tokens, dtype=torch.int64)
+
+        def build_attention(pregraph_buffers, use_fp4_cache):
+            attention = object.__new__(DeepseekV4Attention)
+            torch.nn.Module.__init__(attention)
+            attention.attention_kind = "csa"
+            attention.rotary_emb = SimpleNamespace(
+                cos_sin_cache=torch.zeros(1, ROPE_DIM, dtype=torch.float32)
+            )
+            attention.stream_fork = StreamFork(None)
+            attention.cache_layer_index = 0
+            attention.compress_ratio = 4
+            attention.pregraph_buffers = pregraph_buffers
+            attention._project_q_kv = mock.Mock(
+                return_value=(
+                    torch.zeros(num_tokens, 1, 2),
+                    torch.zeros(num_tokens, 2),
+                    torch.zeros(num_tokens, 2),
+                )
+            )
+            compressor = mock.Mock()
+            compressor_score = torch.zeros(num_tokens, 2)
+            compressor.compute_kv_score.return_value = compressor_score
+            attention.compressor = compressor
+            indexer = mock.Mock()
+            indexer.use_fp4_cache = use_fp4_cache
+            indexer_score = torch.zeros(num_tokens, 3)
+            indexer.compressor.compute_kv_score.return_value = indexer_score
+            indexer._prepare_packed_inputs.return_value = (None, None, None)
+            attention.indexer = indexer
+            attention._forward_attention_core = mock.Mock(
+                return_value=torch.zeros(num_tokens, 2)
+            )
+            attention._project_attention_output = mock.Mock(
+                side_effect=lambda output, *_: output
+            )
+            return attention, indexer, indexer_score, compressor, compressor_score
+
+        allocated = _DeepseekV4PregraphBuffers()
+        allocated.allocate(num_tokens, 1, 1, 1, torch.device("cpu"))
+        unallocated = _DeepseekV4PregraphBuffers()
+        cases = (
+            # (name, ambient, buffers, use_fp4, expect_indexer, expect_c4)
+            ("armed", True, allocated, True, True, True),
+            ("eager", False, allocated, True, False, False),
+            ("unallocated", True, unallocated, True, False, False),
+            # Gate structure check: with fp4 off only the indexer part is
+            # suppressed. In production fp8 configs the buffers are never
+            # allocated (the model hook is inert without an fp4 indexer
+            # layer), so allocated+fp8 is defense-in-depth, not a reachable
+            # serving state.
+            ("fp8_cache", True, allocated, False, False, True),
+        )
+        for name, ambient, buffers, use_fp4, expect_indexer, expect_c4 in cases:
+            with self.subTest(case=name):
+                attention, indexer, indexer_score, compressor, compressor_score = (
+                    build_attention(buffers, use_fp4)
+                )
+                ctx = SimpleNamespace()
+                with mock.patch(
+                    "tokenspeed.runtime.models.deepseek_v4.current_forward_ctx",
+                    return_value=ctx if ambient else None,
+                ):
+                    attention(
+                        positions,
+                        torch.zeros(num_tokens, 8),
+                        ctx,
+                        torch.arange(num_tokens, dtype=torch.int64),
+                    )
+                if expect_indexer:
+                    indexer.insert_cache_pregraph.assert_called_once()
+                    kwargs = indexer.insert_cache_pregraph.call_args.kwargs
+                    self.assertIs(kwargs["buffers"], buffers)
+                    self.assertIs(kwargs["kv_score"], indexer_score)
+                    self.assertIs(kwargs["positions"], positions)
+                    self.assertEqual(kwargs["layer_index"], 0)
+                else:
+                    indexer.insert_cache_pregraph.assert_not_called()
+                if expect_c4:
+                    compressor.insert_cache_pregraph.assert_called_once()
+                    kwargs = compressor.insert_cache_pregraph.call_args.kwargs
+                    self.assertIs(kwargs["buffers"], buffers)
+                    self.assertIs(kwargs["kv_score"], compressor_score)
+                    self.assertIs(kwargs["positions"], positions)
+                    self.assertEqual(kwargs["layer_index"], 0)
+                else:
+                    compressor.insert_cache_pregraph.assert_not_called()
+
+    def test_attention_core_skips_csa_compressor_when_pregraph_armed(self):
+        num_tokens = 2
+        cases = (
+            # (kind, ratio, armed, expect_compressor_called)
+            ("csa", 4, True, False),
+            ("csa", 4, False, True),
+            # HCA (C128) layers keep the eager compressor even when armed.
+            ("hca", 128, True, True),
+        )
+        for kind, ratio, armed, expect_called in cases:
+            with self.subTest(kind=kind, armed=armed):
+                attention = object.__new__(DeepseekV4Attention)
+                torch.nn.Module.__init__(attention)
+                attention.attention_kind = kind
+                attention.stream_fork = StreamFork(None)
+                attention.cache_layer_index = 0
+                attention.compress_ratio = ratio
+                attention.padded_heads = 2
+                attention.num_local_heads = 2
+                attention.head_dim = HEAD_DIM
+                attention.swa_window = 64
+                attention.scale = 1.0
+                attention.attn_sink = torch.zeros(1)
+                attention.compressor = mock.Mock()
+                attention.indexer = None
+                attention._insert_swa_cache = mock.Mock()
+
+                metadata = SimpleNamespace(
+                    token_to_req_indices=torch.arange(num_tokens, dtype=torch.int32),
+                    is_valid_token=None,
+                )
+                backend = SimpleNamespace(
+                    forward_metadata=metadata,
+                    forward_deepseek_v4_prefill=mock.Mock(
+                        side_effect=lambda **kw: kw["q"]
+                    ),
+                )
+                pool = SimpleNamespace(
+                    swa_block_size=4,
+                    get_swa_kv_buffer=mock.Mock(
+                        return_value=torch.empty(1, 1, dtype=torch.uint8)
+                    ),
+                )
+                ctx = SimpleNamespace(
+                    dsa_compressor_slot_cache=None,
+                    dsa_swa_slot_mapping=None,
+                    token_to_kv_pool=pool,
+                    attn_backend=backend,
+                    forward_mode=ForwardMode.EXTEND,
+                    dsa_pregraph_writes=armed,
+                )
+                with mock.patch(
+                    "tokenspeed.runtime.models.deepseek_v4.current_forward_ctx",
+                    return_value=None,
+                ):
+                    attention._forward_attention_core(
+                        torch.arange(num_tokens, dtype=torch.int64),
+                        torch.zeros(num_tokens, 8),
+                        torch.zeros(num_tokens, 2, HEAD_DIM),
+                        torch.zeros(num_tokens, HEAD_DIM),
+                        torch.zeros(num_tokens, 4),
+                        torch.zeros(1, ROPE_DIM),
+                        ctx,
+                        torch.arange(num_tokens, dtype=torch.int64),
+                        None,
+                        None,
+                        swa_slot_mapping=torch.arange(num_tokens, dtype=torch.int64),
+                        compressor_slot_cache={},
+                    )
+                if expect_called:
+                    attention.compressor.assert_called_once()
+                else:
+                    attention.compressor.assert_not_called()
+                attention._insert_swa_cache.assert_called_once()
+
+    def test_attention_core_returns_raw_output_without_projection(self):
+        attention = object.__new__(DeepseekV4Attention)
+        torch.nn.Module.__init__(attention)
+        attention.attention_kind = "swa"
+        attention.stream_fork = StreamFork(None)
+        attention.compressor = None
+        attention.indexer = None
+        attention.padded_heads = 2
+        attention.cache_layer_index = 0
+        attention.compress_ratio = 1
+        attention.num_local_heads = 2
+        attention.head_dim = HEAD_DIM
+        attention.swa_window = 64
+        attention.scale = 1.0
+        attention.attn_sink = torch.zeros(1)
+        attention._insert_swa_cache = mock.Mock()
+        attention._project_attention_output = mock.Mock()
+
+        positions = torch.arange(2, dtype=torch.int64)
+        hidden_states = torch.randn(2, 8)
+        q = torch.randn(2, 2, HEAD_DIM, dtype=torch.bfloat16)
+        kv = torch.randn(2, HEAD_DIM, dtype=torch.bfloat16)
+        qr = torch.randn(2, 32, dtype=torch.bfloat16)
+        cos_sin_cache = torch.zeros(1, ROPE_DIM, dtype=torch.float32)
+        raw_output = torch.randn_like(q)
+        backend = SimpleNamespace(
+            forward_metadata=SimpleNamespace(token_to_req_indices=None),
+            forward_deepseek_v4_prefill=mock.Mock(return_value=raw_output),
+        )
+        pool = SimpleNamespace(
+            swa_block_size=4,
+            get_swa_kv_buffer=mock.Mock(
+                return_value=torch.empty(1, 4 * 584, dtype=torch.uint8)
+            ),
+        )
+        ctx = SimpleNamespace(
+            dsa_compressor_slot_cache={},
+            dsa_swa_slot_mapping=None,
+            token_to_kv_pool=pool,
+            attn_backend=backend,
+            forward_mode=ForwardMode.EXTEND,
+        )
+
+        output = attention._forward_attention_core(
+            positions,
+            hidden_states,
+            q,
+            kv,
+            qr,
+            cos_sin_cache,
+            ctx,
+            torch.arange(2, dtype=torch.int64),
+            None,
+            None,
+            torch.arange(2, dtype=torch.int64),
+            {},
+        )
+
+        self.assertIs(output, raw_output)
+        attention._project_attention_output.assert_not_called()
+
+    def test_attention_forward_projects_core_output_once(self):
+        attention = object.__new__(DeepseekV4Attention)
+        torch.nn.Module.__init__(attention)
+        attention.attention_kind = "swa"
+        attention.stream_fork = StreamFork(None)
+        attention.compressor = None
+        attention.indexer = None
+        attention.rotary_emb = SimpleNamespace(
+            cos_sin_cache=torch.zeros(1, ROPE_DIM, dtype=torch.float64)
+        )
+
+        positions = torch.arange(3, dtype=torch.int64)
+        hidden_states = torch.randn(3, 8)
+        q = torch.randn(3, 2, HEAD_DIM, dtype=torch.bfloat16)
+        kv = torch.randn(3, HEAD_DIM, dtype=torch.bfloat16)
+        qr = torch.randn(3, 32, dtype=torch.bfloat16)
+        raw_output = torch.randn_like(q)
+        projected_output = torch.randn(3, 8)
+        attention._project_q_kv = mock.Mock(return_value=(q, kv, qr))
+        attention._forward_attention_core = mock.Mock(return_value=raw_output)
+        attention._project_attention_output = mock.Mock(return_value=projected_output)
+
+        output = attention(
+            positions,
+            hidden_states,
+            object(),
+            torch.arange(3, dtype=torch.int64),
+        )
+
+        self.assertIs(output, projected_output)
+        attention._forward_attention_core.assert_called_once()
+        attention._project_attention_output.assert_called_once()
+        core_args = attention._forward_attention_core.call_args.args
+        project_args = attention._project_attention_output.call_args.args
+        self.assertIs(core_args[0], positions)
+        self.assertIs(project_args[0], raw_output)
+        self.assertIs(project_args[1], positions)
+        self.assertIs(core_args[5], project_args[2])
+        self.assertEqual(project_args[2].dtype, torch.float32)
+
+    def test_attention_empty_input_skips_phase1(self):
+        attention = object.__new__(DeepseekV4Attention)
+        torch.nn.Module.__init__(attention)
+        attention._project_q_kv = mock.Mock()
+        attention._forward_attention_core = mock.Mock()
+        attention._project_attention_output = mock.Mock()
+        hidden_states = torch.empty(0, 8)
+
+        output = attention(
+            torch.empty(0, dtype=torch.int64),
+            hidden_states,
+            None,
+            torch.empty(0, dtype=torch.int64),
+        )
+
+        self.assertIs(output, hidden_states)
+        attention._project_q_kv.assert_not_called()
+        attention._forward_attention_core.assert_not_called()
+        attention._project_attention_output.assert_not_called()
+
     def test_swa_slot_mapping_guard_masks_out_of_range_slots(self):
         slots = torch.tensor([-3, -1, 0, 7, 8, 99], dtype=torch.int64)
 
@@ -457,6 +1591,121 @@ class DeepseekV4AttentionOpsCpuValidationTest(unittest.TestCase):
 
 @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
 class DeepseekV4AttentionOpsTest(unittest.TestCase):
+
+    def test_indexer_custom_op_routes_complete_triplet_or_legacy(self):
+        device = torch.device("cuda")
+        num_tokens = 3
+        indexer = object.__new__(DeepseekV4Indexer)
+        torch.nn.Module.__init__(indexer)
+        indexer.use_fp4_cache = True
+        indexer.compress_ratio = 4
+        indexer.topk_tokens = 2
+        indexer.topk_buffer = None
+        indexer._persistent_topk_workspace = torch.empty(
+            0, device=device, dtype=torch.uint8
+        )
+        empty_workspace = torch.empty((0, 0), device=device, dtype=torch.uint8)
+        indexer._prefill_gather_workspace = mock.Mock(
+            return_value=(empty_workspace, empty_workspace)
+        )
+
+        def triplet(seed):
+            return (
+                torch.full((num_tokens, 2, 2), seed, device=device, dtype=torch.uint8),
+                torch.full((num_tokens, 2), seed + 1, device=device, dtype=torch.int32),
+                torch.full((num_tokens, 2), float(seed + 2), device=device),
+            )
+
+        legacy = triplet(1)
+        supplied = triplet(11)
+        indexer._prepare_packed_inputs = mock.Mock(return_value=legacy)
+        block_table = torch.zeros((1, 1), device=device, dtype=torch.int32)
+        metadata = SimpleNamespace(
+            cache=SimpleNamespace(
+                compressed_block_table=mock.Mock(return_value=block_table)
+            ),
+            token_to_req_indices=torch.zeros(
+                num_tokens, device=device, dtype=torch.int32
+            ),
+            seq_lens_cpu=None,
+            query_lens_cpu=None,
+        )
+        prefill_metadata = SimpleNamespace(max_gather_rows=mock.Mock(return_value=0))
+        ctx = SimpleNamespace(forward_mode=ForwardMode.EXTEND)
+        hidden_states = torch.zeros(num_tokens, 4, device=device)
+        qr = torch.zeros(num_tokens, 4, device=device)
+        positions = torch.arange(num_tokens, device=device, dtype=torch.int64)
+        cos_sin_cache = torch.empty(1, ROPE_DIM, device=device)
+        sparse_indexer = mock.Mock(
+            side_effect=lambda **kwargs: kwargs["topk_indices_buffer"]
+        )
+
+        def run(prepared=(None, None, None)):
+            return indexer._forward_sparse_indexer_custom_op(
+                hidden_states=hidden_states,
+                qr=qr,
+                positions=positions,
+                metadata=metadata,
+                ctx=ctx,
+                indexer_cache=torch.empty(1, 1, device=device, dtype=torch.uint8),
+                indexer_block_size=1,
+                cos_sin_cache=cos_sin_cache,
+                packed_q_values=prepared[0],
+                packed_q_scales=prepared[1],
+                packed_weights=prepared[2],
+            )
+
+        with (
+            mock.patch.object(
+                deepseek_v4_model,
+                "_deepseek_v4_deepgemm_fp4_indexer_available",
+                return_value=True,
+            ),
+            mock.patch.object(
+                deepseek_v4_model,
+                "_deepseek_v4_indexer_prefill_metadata",
+                return_value=prefill_metadata,
+            ),
+            mock.patch.object(
+                deepseek_v4_model,
+                "_deepseek_v4_sparse_attn_indexer",
+                sparse_indexer,
+            ),
+        ):
+            run()
+            indexer._prepare_packed_inputs.assert_called_once_with(
+                hidden_states=hidden_states,
+                qr=qr,
+                positions=positions,
+                cos_sin_cache=cos_sin_cache,
+            )
+            sparse_args = sparse_indexer.call_args.kwargs
+            self.assertIs(sparse_args["packed_q_values"], legacy[0])
+            self.assertIs(sparse_args["packed_q_scales"], legacy[1])
+            self.assertIs(sparse_args["packed_weights"], legacy[2])
+
+            indexer._prepare_packed_inputs.reset_mock()
+            sparse_indexer.reset_mock()
+            run(supplied)
+            indexer._prepare_packed_inputs.assert_not_called()
+            sparse_args = sparse_indexer.call_args.kwargs
+            self.assertIs(sparse_args["packed_q_values"], supplied[0])
+            self.assertIs(sparse_args["packed_q_scales"], supplied[1])
+            self.assertIs(sparse_args["packed_weights"], supplied[2])
+
+            partials = (
+                (supplied[0], supplied[1], None),
+                (supplied[0], None, supplied[2]),
+                (None, supplied[1], supplied[2]),
+            )
+            for partial in partials:
+                with self.subTest(partial=tuple(x is not None for x in partial)):
+                    indexer._prepare_packed_inputs.reset_mock()
+                    sparse_indexer.reset_mock()
+                    with self.assertRaisesRegex(ValueError, "provided together"):
+                        run(partial)
+                    indexer._prepare_packed_inputs.assert_not_called()
+                    sparse_indexer.assert_not_called()
 
     def test_sanitized_insert_write_safety_under_graph_replay(self):
         # Full producer -> sanitize -> CUDA graph replay -> cache write path.


### PR DESCRIPTION
## Summary

Narrow the DeepSeek-V4 attention break to the request-dependent DSA core and move the surrounding token-shaped work into the captured prefill-graph segments, removing kernel launches from the eager critical path.

- **E1** — phase-1 Q/KV/QR projections and the compressor-score GEMMs run in the pre-break segment, overlapped on an aux stream.
- **E2** — the attention output projection joins the post-break segment.
- **E3** — the CSA indexer query packing (wq_b / weights_proj / mxfp4) runs pre-break.
- **E4a** — per-forward memoization of compressed/state slot mappings, shared across the CSA indexer, the 30 CSA layers, and the C4 compressor.
- **E4b/E4c** — the CSA indexer and main C4 compressor state-save + cache-insert writes are captured in the pre-break segment, fed by persistent staging buffers refreshed by `prepare/finish_prefill_graph_replay` model hooks, with a -1 fail-open contract and a single `ctx.dsa_pregraph_writes` arm flag so the eager break skips exactly what the captured segment wrote (exactly-once across capture / replay / eager / mixed / decode / MTP-draft).

Structure is unchanged: 61 eager attention breaks / 62 graph segments / 123 callables.

## Verification

Verified on top of current `origin/main` (rebuilt matching `tokenspeed-kernel` objs + `tokenspeed-scheduler` 0.1.2 exposing `flat_block_tables_arrays`):

- **GSM8K** (V4-Flash, TP4, 5-shot first-50, greedy): strict **0.98** / flexible **0.98** (gate ≥ 0.92), 0 fatal server lines.
- Prefill breakable graph **engaged** on all TP ranks (87 segments, buckets 16–8192), no eager-prefill fallback.
- CPU unit tests: **65 passed / 5 skipped** — pin the control-flow invariants (arm/disarm matrix, skip gates, hook seam, staging bind). Numerical byte-equality is covered by the GPU gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
