### PR TITLE
fix(runtime): restore Qwen3.5 OCRBench accuracy to unblock CI

### DIFF
--- a/python/tokenspeed/runtime/execution/cache_loc_kernel.py
+++ b/python/tokenspeed/runtime/execution/cache_loc_kernel.py
@@ -35,10 +35,10 @@ logger = get_colorful_logger(__name__)
 def update_req_to_page_kernel(
     # Input pointers
     req_pool_indices_ptr,  # [batch_size]
-    new_occupied_pages_ptr,  # [total_pages] - flattened
-    new_occupied_pages_num_ptr,  # [batch_size]
+    new_occupied_pages_ptr,  # [total_entries] - flattened refresh page IDs
+    new_occupied_pages_num_ptr,  # [batch_size] - refresh entries per request
     pages_copy_starts_ptr,  # [batch_size]
-    cumsum_pages_ptr,  # [batch_size] - cumulative sum of new_occupied_pages_num
+    cumsum_pages_ptr,  # [batch_size] - cumulative refresh-entry counts
     # Output pointer
     req_to_page_ptr,  # [req_pool_size+1, context_len]
     # Scalars
@@ -46,7 +46,7 @@ def update_req_to_page_kernel(
     BLOCK_SIZE: tl.constexpr,
 ):
     """
-    Update req_to_page table with new occupied pages.
+    Apply emitted page-table refresh slices to req_to_page.
     Each program handles one request in the batch.
     """
     req_idx = tl.program_id(0)
@@ -56,7 +56,7 @@ def update_req_to_page_kernel(
     num_pages = tl.load(new_occupied_pages_num_ptr + req_idx)
     copy_start = tl.load(pages_copy_starts_ptr + req_idx)
 
-    # Get offset into flattened new_occupied_pages
+    # Get the request's offset into the flattened refresh entries.
     offset_idx = tl.where(req_idx > 0, req_idx - 1, 0)
     pages_offset = tl.load(cumsum_pages_ptr + offset_idx)
     pages_offset = tl.where(req_idx > 0, pages_offset, 0)
@@ -70,7 +70,7 @@ def update_req_to_page_kernel(
         page_offsets = block_start + tl.arange(0, BLOCK_SIZE)
         mask = page_offsets < num_pages
 
-        # Load new page IDs
+        # Load the page IDs to refresh.
         page_ptrs = new_occupied_pages_ptr + pages_offset + page_offsets
         new_page_ids = tl.load(page_ptrs, mask=mask, other=0)
 
@@ -90,13 +90,13 @@ def update_req_to_page(
     pages_copy_starts: torch.Tensor,
 ) -> None:
     """
-    Update req_to_page table with new occupied pages using Triton kernel.
+    Apply emitted page-table refresh slices to req_to_page using Triton.
 
     Args:
         req_to_page: Request to page table [req_pool_size+1, context_len]
         req_pool_indices: Request pool indices [batch_size]
-        new_occupied_pages: New page IDs [total_pages] - flattened
-        new_occupied_pages_num: Number of new pages per request [batch_size]
+        new_occupied_pages: Refresh page IDs [total_entries] - flattened
+        new_occupied_pages_num: Number of refresh entries per request [batch_size]
         pages_copy_starts: Start position in req_to_page for each request [batch_size]
     """
     batch_size = req_pool_indices.shape[0]
@@ -484,7 +484,9 @@ def update_block_table(forward_op, device, req_to_page):
         tensor = torch.tensor(flat, dtype=dtype, device="cpu", pin_memory=True)
         return tensor.to(device, non_blocking=True)
 
-    # sizes[i] is the number of newly allocated pages for request i.
+    # sizes[i] is the number of page-table entries to refresh. Besides newly
+    # allocated pages, this can include an existing radix prefix whose physical
+    # IDs changed when duplicate request-local pages were canonicalized.
     if all(n == 0 for n in forward_op.sizes):
         return
 

--- a/python/tokenspeed/runtime/multimodal/embedder.py
+++ b/python/tokenspeed/runtime/multimodal/embedder.py
@@ -492,8 +492,8 @@ class MultimodalEmbedder:
         Inputs that originate from the SHM transport are pinned, so the
         H2D copy can actually run async with respect to the LM kernels
         already queued on the current stream. We synchronise the current
-        stream with the H2D stream before returning so the encode call
-        sees the moved tensors.
+        stream with the H2D stream so the encoder sees the moved tensors,
+        then record that consumer stream for allocator-safe reuse.
         """
         pending = [
             it
@@ -521,6 +521,9 @@ class MultimodalEmbedder:
                 if isinstance(it.feature, torch.Tensor):
                     it.feature = it.feature.to(device, non_blocking=True)
         current.wait_stream(h2d)
+        for it in pending:
+            if isinstance(it.feature, torch.Tensor):
+                it.feature.record_stream(current)
 
     @staticmethod
     def _drop_raw_feature(item: MultimodalDataItem) -> bool:

--- a/python/tokenspeed/runtime/pd/decode_executor.py
+++ b/python/tokenspeed/runtime/pd/decode_executor.py
@@ -117,8 +117,15 @@ class DisaggDecodeExecutor:
                 # the scheduler may still dispatch its forward op one last time.
                 continue
             extend_prefix_len = op.extend_prefix_lens[i]
+            # Exclude pages held only for reserved decode input token(s); P has
+            # source KV only through the logical end of the prompt.
+            prompt_end_page = (
+                op.prefill_lengths[i] + self.page_size - 1
+            ) // self.page_size
             kv_indices = np.array(
-                op.occupied_pages[i][extend_prefix_len // self.page_size :],
+                op.occupied_pages[i][
+                    extend_prefix_len // self.page_size : prompt_end_page
+                ],
                 dtype=np.int64,
             )
             aux_index = op.request_pool_indices[i]

--- a/python/tokenspeed/runtime/pd/prefill_executor.py
+++ b/python/tokenspeed/runtime/pd/prefill_executor.py
@@ -172,10 +172,9 @@ class DisaggPrefillExecutor:
         is_last = chunk_end >= op.prefill_lengths[index]
 
         decode_prefix_pages = decode_prefix_len // self.page_size
-        start_page = max(
-            decode_prefix_pages + sender.curr_idx,
-            chunk_begin // self.page_size,
-        )
+        # Transfer progress is relative to D's missing-page window. P's local
+        # prefix may be deeper and must not hide pages that D still needs.
+        start_page = decode_prefix_pages + sender.curr_idx
         if is_last:
             end_page = (chunk_end + self.page_size - 1) // self.page_size
         else:

--- a/test/runtime/distributed/test_pd_transfer_plan.py
+++ b/test/runtime/distributed/test_pd_transfer_plan.py
@@ -1,6 +1,10 @@
+from types import SimpleNamespace
+
+from tokenspeed.runtime.pd.decode_executor import DisaggDecodeExecutor
 from tokenspeed.runtime.pd.mooncake.receiver import (
     _build_buffer_layout_pair,
 )
+from tokenspeed.runtime.pd.prefill_executor import DisaggPrefillExecutor
 from tokenspeed.runtime.pd.transfer_plan import (
     BufferKind,
     ParallelLayout,
@@ -47,3 +51,46 @@ def test_replicated_prefill_kv_heads_transfer_to_decode_full_kv_heads():
     assert second_head.src_byte_offset == 0
     assert second_head.dst_byte_offset == 16_384
     assert second_head.bytes_per_page == 16_384
+
+
+def test_prefill_transfer_uses_decode_prefix_and_sender_progress():
+    executor = DisaggPrefillExecutor.__new__(DisaggPrefillExecutor)
+    executor.page_size = 64
+    executor._decode_prefix_len = lambda _room: 128
+    sender = SimpleNamespace(bootstrap_room=1, curr_idx=7)
+    op = SimpleNamespace(
+        extend_prefix_lens=[8192],
+        input_lengths=[8109],
+        prefill_lengths=[16301],
+        occupied_pages=[list(range(255))],
+    )
+
+    indices, index_slice, is_last = executor._prefill_page_window(op, 0, sender)
+
+    assert indices.tolist() == list(range(9, 255))
+    assert index_slice == slice(7, 253)
+    assert is_last
+
+
+def test_decode_transfer_excludes_reserved_page_after_aligned_prompt():
+    executor = DisaggDecodeExecutor.__new__(DisaggDecodeExecutor)
+    executor.page_size = 64
+    executor._request_pool_indices = {}
+    calls = []
+    executor.receivers = {
+        "request": SimpleNamespace(prefill=lambda *args: calls.append(args))
+    }
+    op = SimpleNamespace(
+        request_ids=["request"],
+        occupied_pages=[list(range(129))],
+        begins=[0],
+        sizes=[129],
+        request_pool_indices=[3],
+        extend_prefix_lens=[4096],
+        prefill_lengths=[8192],
+    )
+
+    executor._prefill(op)
+
+    assert len(calls) == 1
+    assert calls[0][0].tolist() == list(range(64, 128))

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
@@ -226,7 +226,10 @@ std::variant<PrefillDone, Prefilling> SchedulePrefillFirstChunkEvent::operator()
     coordinator_->CacheFullBlocks(tables, flat_ext_hashes_,
                                   /*first_slot=*/flat_hit_.num_common_tokens / state.GetPageSize(),
                                   /*end_tokens=*/hit_tokens);
-    if (!coordinator_->Acquire(tables, tokens_this_round_)) {
+    // Role kD cannot defer its decode reserve until RemotePrefillDone: the
+    // remote transfer may complete after other requests consume the pool.
+    const std::int32_t tokens_to_acquire = tokens_this_round_ + (role_ == Role::kD ? decode_input_tokens_ : 0);
+    if (!coordinator_->Acquire(tables, tokens_to_acquire)) {
         _assert(false, "flat path: allocation failure unsupported in C slice");
     }
 

--- a/tokenspeed-scheduler/csrc/fsm/pd_events.cpp
+++ b/tokenspeed-scheduler/csrc/fsm/pd_events.cpp
@@ -39,6 +39,7 @@ Finished SucceededEvent::operator()(Decoding&& /*state*/) {
 
 PrefillDone RemotePrefillDoneEvent::operator()(Prefilling&& state) {
     TokenContainer::Window w = state.window;
+    auto block_tables = std::move(state).TakeBlockTables();
     auto prefill_done = PrefillDone{
         state.GetTokenContainer(),
         state.GetPageSize(),
@@ -51,6 +52,7 @@ PrefillDone RemotePrefillDoneEvent::operator()(Prefilling&& state) {
         std::move(state).TakeLocalMambaAllocator(),
     };
 
+    prefill_done.SetBlockTables(std::move(block_tables));
     prefill_done.ExtendResultTokens({bootstrap_token});
     return prefill_done;
 }

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -996,7 +996,11 @@ Scheduler::newForwardOperation(std::vector<Request*> candidates) {
             // PrefetchDone: host cache populated; treat same as Submitted for forward scheduling.
             std::int32_t decode_input_tokens = config_.role == Role::kP ? 0 : config_.decode_input_tokens;
 
-            if (auto ev = schedulePrefillFirstChunk(request, token_budget, decode_input_tokens,
+            // Role D only reserves the remote-prefill destination. A partial
+            // first chunk cannot be completed locally, so admit the whole
+            // prompt atomically without applying the prefill compute budget.
+            const std::int32_t prefill_budget = config_.role == Role::kD ? request->PrefillSize() : token_budget;
+            if (auto ev = schedulePrefillFirstChunk(request, prefill_budget, decode_input_tokens,
                                                     config_.disable_l2_cache, simulated_free)) {
                 std::vector<TreeNode*> loadback_diff = ev->GetLoadbackDiff();
                 std::vector<TreeNode*> mamba_loadback_nodes = ev->GetMambaLoadbackNodes();

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -22,6 +22,7 @@
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <limits>
 #include <map>
 #include <memory>
@@ -669,11 +670,62 @@ std::optional<WriteBackOperation> Scheduler::newRetractOperation(Request* retrac
     return std::nullopt;
 }
 
+#if !TOKENSPEED_FLAT_KVCACHE
+void Scheduler::finalizeRadixPageTableEmission(Request* request, ForwardOperationBase& op, bool force_full) {
+    // Without a hybrid cache, local pages are never published into the radix tree
+    // during an active forward lease, so the builder's append-only delta is exact.
+    if (!hybrid_prefix_cache_) return;
+
+    if (op.request_pool_index <= 0 ||
+        static_cast<std::size_t>(op.request_pool_index) >= radix_page_table_emissions_.size()) {
+        throw std::logic_error("Scheduler::finalizeRadixPageTableEmission: invalid request-pool index=" +
+                               std::to_string(op.request_pool_index));
+    }
+
+    RadixPageTableEmission& previous = radix_page_table_emissions_[op.request_pool_index];
+    const std::int32_t current_size = static_cast<std::int32_t>(op.occupied_pages.size());
+    const std::int32_t current_prefix = request->GetDeviceNode()->DepthInPage(config_.block_size);
+    if (current_prefix < 0 || current_prefix > current_size) {
+        throw std::logic_error("Scheduler::finalizeRadixPageTableEmission: invalid radix prefix size=" +
+                               std::to_string(current_prefix) + "; page-table size=" + std::to_string(current_size));
+    }
+
+    std::int32_t begin = 0;
+    if (!force_full && previous.prefix_pages >= 0) {
+        const std::int32_t previous_size =
+            previous.prefix_pages + static_cast<std::int32_t>(previous.local_pages.size());
+
+        // The emitted table is an immutable, pinned radix prefix followed by an
+        // append-only local tail. Publication can replace ids only in that old
+        // tail. If a lifecycle or ordering invariant changes, refresh safely.
+        const bool valid_incremental =
+            current_prefix >= previous.prefix_pages && op.begin == previous_size && current_size >= previous_size;
+        if (valid_incremental) {
+            auto mismatch = std::mismatch(previous.local_pages.begin(), previous.local_pages.end(),
+                                          op.occupied_pages.begin() + previous.prefix_pages,
+                                          op.occupied_pages.begin() + previous_size);
+            begin = op.begin;
+            if (mismatch.first != previous.local_pages.end()) {
+                begin = previous.prefix_pages +
+                        static_cast<std::int32_t>(std::distance(previous.local_pages.begin(), mismatch.first));
+            }
+        }
+    }
+
+    op.begin = begin;
+    op.size = current_size - begin;
+    previous.prefix_pages = current_prefix;
+    previous.local_pages.assign(op.occupied_pages.begin() + current_prefix, op.occupied_pages.end());
+}
+#endif
+
 // By-reference so the first-chunk caller can harvest the transition's flat load pairs afterwards.
 template <typename Event>
     requires(std::same_as<Event, fsm::SchedulePrefillFirstChunkEvent> || std::same_as<Event, fsm::SchedulePrefillEvent>)
 static PrefillOperation applyPrefillEvent(Request* request, Event& event, std::span<const std::string> flat_group_ids) {
-    // begin/size are PAGE-space: the occupied_pages slice new this round (Python copies it into req_to_page).
+    // begin/size are PAGE-space: the req_to_page refresh slice for this operation.
+    // The builder starts with appended pages; radix finalization may move begin
+    // backward when publication canonicalizes an already-emitted physical page.
     // A first-chunk prefix hit enters during the event, so begin stays 0 and size counts the hit rows too;
     // the op's token-space INPUT window intentionally starts past the hit.
     std::int32_t begin = static_cast<std::int32_t>(request->GetOccupiedPages().size());
@@ -751,6 +803,7 @@ PrefillOperation Scheduler::applyEventAndGenerateOp(Request* request, fsm::Sched
                                                 op.extend_prefix_len + op.input_length, match.paged_cache);
         hybrid_prefix_cache_->PopulateOp(op);
     }
+    finalizeRadixPageTableEmission(request, op, /*force_full=*/true);
 #endif
     return op;
 }
@@ -764,6 +817,7 @@ PrefillOperation Scheduler::applyEventAndGenerateOp(Request* request, fsm::Sched
                                                 op.extend_prefix_len + op.input_length);
         hybrid_prefix_cache_->PopulateOp(op);
     }
+    finalizeRadixPageTableEmission(request, op, /*force_full=*/false);
 #endif
     return op;
 }
@@ -829,6 +883,7 @@ DecodeOperation Scheduler::applyEventAndGenerateOp(Request* request, fsm::Schedu
         hybrid_prefix_cache_->AcquireForRequest(op.request_id, first_pos, target);
         hybrid_prefix_cache_->PopulateOp(op);
     }
+    finalizeRadixPageTableEmission(request, op, /*force_full=*/false);
 #endif
     return op;
 }
@@ -877,6 +932,7 @@ DecodeOperation Scheduler::applyEventAndGenerateOp(Request* request, fsm::Schedu
         hybrid_prefix_cache_->AcquireForRequest(op.request_id, op.hist_token_len, target, paged_cache_hit);
         hybrid_prefix_cache_->PopulateOp(op);
     }
+    finalizeRadixPageTableEmission(request, op, /*force_full=*/true);
 #endif
 
     MaybeFillFlatBlockTables(op, request, FlatGroupIds());

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.h
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.h
@@ -38,9 +38,11 @@ struct ForwardOperationBase {
     std::int32_t input_length;
     // All pages currently occupied by this request (existing + newly allocated).
     std::vector<int32_t> occupied_pages;
-    // Index into occupied_pages where newly allocated pages begin.
+    // Index into occupied_pages where the emitted page-table refresh begins.
+    // On the radix path this may precede newly allocated pages when publishing
+    // canonicalizes a duplicate physical page.
     std::int32_t begin;
-    // Number of newly allocated pages (starting at occupied_pages[begin]).
+    // Number of page-table entries to refresh from occupied_pages[begin].
     std::int32_t size;
 
     std::int32_t prefill_length;

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -86,6 +86,9 @@ Scheduler::Scheduler(SchedulerConfig config)
     if (config_.overlap_schedule_depth > 0 && config_.decode_input_tokens == 0) {
         throw std::invalid_argument("Scheduler: overlapped decode requires decode_input_tokens > 0");
     }
+#if !TOKENSPEED_FLAT_KVCACHE
+    radix_page_table_emissions_.resize(static_cast<std::size_t>(config_.max_batch_size) + 1);
+#endif
     if (auto* env = std::getenv("SPDLOG_LEVEL")) {
         std::string level_str{env};
         spdlog::level::level_enum level = spdlog::level::from_str(level_str);

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.h
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.h
@@ -110,6 +110,10 @@ private:
     std::optional<WriteBackOperation> applyEventAndGenerateOp(Request* request, fsm::ScheduleRetractEvent event);
     PrefetchOperation applyEventAndGenerateOp(Request* request, fsm::SchedulePrefetchEvent event);
 
+#if !TOKENSPEED_FLAT_KVCACHE
+    void finalizeRadixPageTableEmission(Request* request, ForwardOperationBase& op, bool force_full);
+#endif
+
     std::optional<fsm::SchedulePrefetchEvent> schedulePrefetch(Request* request, const MatchResult& match);
 
     std::optional<fsm::SchedulePrefillFirstChunkEvent> schedulePrefillFirstChunk(
@@ -185,6 +189,16 @@ private:
     KVPrefixCache kv_prefix_cache_;
     ReqPoolAllocator req_pool_allocator_;
     std::optional<HybridPrefixCache> hybrid_prefix_cache_{};
+
+#if !TOKENSPEED_FLAT_KVCACHE
+    struct RadixPageTableEmission {
+        std::int32_t prefix_pages{-1};
+        std::vector<std::int32_t> local_pages;
+    };
+    // Baseline of the page table last emitted for each Python req_to_page row.
+    // Slot 0 is reserved, matching ReqPoolAllocator and the Python request pool.
+    std::vector<RadixPageTableEmission> radix_page_table_emissions_;
+#endif
 
 #if TOKENSPEED_FLAT_KVCACHE
     BlockPool block_pool_;

--- a/tokenspeed-scheduler/python/tests/test_new_occupied_pages.py
+++ b/tokenspeed-scheduler/python/tests/test_new_occupied_pages.py
@@ -22,7 +22,7 @@
 
 Covers:
   - Prefill allocates pages; occupied_pages contains all held page indices,
-    begins/sizes describe the newly allocated slice
+    begins/sizes describe the page-table slice that must be refreshed
   - begins is 0 on first schedule (no pages were occupied before)
   - Chunked prefill: begins grows across chunks as more pages are allocated
   - Decode step: no new pages allocated when tail page still has capacity

--- a/tokenspeed-scheduler/tests/cpp/test_outside_event_handler.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_outside_event_handler.cpp
@@ -132,4 +132,71 @@ TEST_F(LoadBackDoneTestSuite, LoadBack_SubsequentPlanProceeds) {
     EXPECT_TRUE(true);
 }
 
+class DisaggDecodeAdmissionTestSuite : public SchedulerTestSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        SchedulerConfig cfg{};
+        cfg.block_size = 2;
+        // Flat block 0 is the null page, leaving three usable pages.
+        cfg.device_allocator.total_pages = 4;
+        cfg.host_allocator.total_pages = 4;
+        cfg.max_scheduled_tokens = 2;
+        cfg.max_batch_size = 1;
+        cfg.decode_input_tokens = 1;
+        cfg.role = Role::kD;
+        cfg.enable_l3_storage = false;
+        cfg.disable_l2_cache = true;
+        cfg.disable_prefix_cache = true;
+
+        PagedCacheGroupConfig full;
+        full.group_id = "full";
+        full.rows_per_page = cfg.block_size;
+        full.entry_stride_tokens = 1;
+        full.total_pages = cfg.device_allocator.total_pages;
+        full.retention = PagedCacheGroupConfig::Retention::FullHistory;
+        full.family = PagedCacheGroupFamily::History;
+        cfg.paged_cache_groups = {full};
+        return cfg;
+    }
+
+    void SendBootstrapped(const std::string& request_id) {
+        ExecutionEvent event;
+        event.With(PDEvent{pd::BootstrappedEvent{request_id}});
+        scheduler_->Advance(std::move(event));
+    }
+
+    void SendRemotePrefillDone(const std::string& request_id, std::int32_t bootstrap_token) {
+        ExecutionEvent event;
+        event.With(PDEvent{pd::RemotePrefillDoneEvent{request_id, bootstrap_token}});
+        scheduler_->Advance(std::move(event));
+    }
+};
+
+TEST_F(DisaggDecodeAdmissionTestSuite, ReservesWholeDestinationAndSurvivesRemoteCompletion) {
+    Submit({MakeRequestSpec("r0", /*num_pages=*/2, /*start=*/1)});
+    SendBootstrapped("r0");
+
+    const ExecutionPlan admission = PlanOnce();
+    const FlatForwardOperation* prefill = GetForwardOp(admission.Operations());
+    ASSERT_NE(prefill, nullptr);
+    EXPECT_EQ(prefill->request_ids, (std::vector<std::string>{"r0"}));
+    EXPECT_EQ(prefill->input_lengths, (std::vector<std::int32_t>{4}));
+    ASSERT_EQ(prefill->occupied_pages.size(), 1u);
+    EXPECT_EQ(prefill->occupied_pages[0].size(), 3u);
+    EXPECT_EQ(scheduler_->ActiveKvPages(), 3u);
+
+    SendRemotePrefillDone("r0", /*bootstrap_token=*/42);
+    const ExecutionPlan decode_plan = PlanOnce();
+    const FlatForwardOperation* decode = GetForwardOp(decode_plan.Operations());
+    ASSERT_NE(decode, nullptr);
+    const std::int32_t r0 = FindRequestIndex(decode, "r0");
+    ASSERT_GE(r0, 0);
+    EXPECT_EQ(decode->decode_input_ids[static_cast<std::size_t>(r0)], 42);
+    EXPECT_EQ(decode->occupied_pages[static_cast<std::size_t>(r0)].size(), 3u);
+#if TOKENSPEED_FLAT_KVCACHE
+    ASSERT_EQ(decode->flat_block_tables.count("full"), 1u);
+    EXPECT_EQ(decode->flat_block_tables.at("full")[static_cast<std::size_t>(r0)].size(), 3u);
+#endif
+}
+
 }  // namespace tokenspeed::test


### PR DESCRIPTION
## Summary

Fix three runtime correctness issues found while validating the Qwen3.5-122B-NVFP4 OCRBench CI added in #549:

- Refresh stale radix page-table entries after cache publication canonicalizes physical pages.
- Align EPD KV transfer ranges and decode-side destination reservation.
- Protect asynchronously copied vision features from premature CUDA storage reuse.

## Motivation

Both the aggregate and EPD jobs in #549 produced scores below the `0.90` CI threshold, while the expected score was around `0.91`. The threshold was not the issue: the investigation found three runtime correctness bugs affecting KV page tracking, EPD KV transfer, and Vision H2D storage lifetime.

## Fixes

1. **Radix page tables:** Publishing request-local pages can replace previously emitted IDs with canonical pages. Refresh from the first changed entry so `req_to_page` does not retain mappings to pages that may be released and reused.
2. **EPD KV transfer:** Derive transfer progress from D's missing prompt window, exclude decode-only reserve pages, reserve the complete remote-prefill destination, and preserve flat block tables across `RemotePrefillDone`.
3. **Vision H2D lifetime:** Record copied feature tensors on the encoder execution stream so the CUDA allocator cannot reuse their storage before encoder reads complete.

## Testing

Ran five completed OCRBench evaluations for each cumulative patch state using the aggregate and EPD CI configurations from #549.

| Patch state | Aggregate scores | Mean | EPD scores | Mean |
| --- | --- | ---: | --- | ---: |
| Before | 0.894, 0.895, 0.896, 0.896, 0.900 | **0.8962** | 0.904, 0.903, 0.900, 0.898, 0.896 | **0.9002** |
| + Fix 1 | 0.912, 0.911, 0.908, 0.911, 0.905 | **0.9094** | 0.898, 0.901, 0.903, 0.900, 0.899 | **0.9002** |
| + Fix 1 & 2 | 0.910, 0.912, 0.915, 0.912, 0.909 | **0.9116** | 0.906, 0.916, 0.915, 0.913, 0.911 | **0.9122** |
| + Fix 1, 2 & 3 | 0.907, 0.909, 0.914, 0.910, 0.907 | **0.9094** | 0.913, 0.914, 0.919, 0.912, 0.914 | **0.9144** |

- **Fix 1** restores Aggregate accuracy from `0.8962` to `0.9094`; the EPD results remain within the run-to-run spread.
- **Fix 2** restores EPD accuracy from `0.9002` to `0.9122`; the Aggregate results remain within the run-to-run spread.
- **Fix 3** is a storage-lifetime hardening change; both Aggregate and EPD results remain within the run-to-run spread.