### PR TITLE
perf(kernel): optimize gfx950 gluon MHA extend kernel

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_decode_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_decode_gfx950.py
@@ -34,6 +34,7 @@ from tokenspeed_kernel_amd.ops.attention.gluon.utils import (
     attention_layouts,
     max,
     maximum,
+    select_kv_splits,
 )
 
 cdna4 = gl.amd.cdna4
@@ -720,44 +721,6 @@ def _mha_decode_reduce(
     cdna4.buffer_store(output, out_ptr, out_base + offs_d)
 
 
-def _select_num_kv_splits(
-    *,
-    batch: int,
-    num_kv_heads: int,
-    num_groups: int,
-    num_pages: int,
-    sm_count: int,
-) -> int:
-    """Pick num_kv_splits to balance occupancy against reduce overhead.
-
-    The launch grid is (batch * num_kv_heads * num_groups) * num_kv_splits
-    work-groups. Too few splits under-fill the machine at low batch; too many
-    leave each split with a handful of pages, so the reduce kernel dominates.
-
-    Return the smaller of two candidate counts: splits_for_occupancy (enough to
-    fill ~wave_target waves of CUs) and splits_for_pages (~min_pages_per_split
-    pages per split), with the pages candidate clamped to [min_page_splits,
-    max_page_splits] so a short context still splits without launching empty work
-    and a long one does not over-split where reduce cost outgrows the decode win.
-    """
-    wave_target = 2
-    min_pages_per_split = 2
-    min_page_splits = 8
-    max_page_splits = 32
-
-    base_ctas = batch * num_kv_heads * num_groups
-    target_ctas = sm_count * wave_target
-    splits_for_occupancy = (target_ctas + base_ctas - 1) // base_ctas
-
-    splits_for_pages = num_pages // min_pages_per_split
-    min_page_splits = min(min_page_splits, num_pages)
-    if splits_for_pages < min_page_splits:
-        splits_for_pages = min_page_splits
-    if splits_for_pages > max_page_splits:
-        splits_for_pages = max_page_splits
-    return min(splits_for_occupancy, splits_for_pages)
-
-
 class LaunchConfig(NamedTuple):
     num_q_heads: int
     num_kv_heads: int
@@ -792,10 +755,8 @@ def get_config(
         softmax_scale = 1.0 / math.sqrt(head_dim)
     effective_seqlen_k = min(max_seqlen_k, window_left) if is_sliding else max_seqlen_k
     num_pages = (effective_seqlen_k + page_size - 1) // page_size
-    num_kv_splits = _select_num_kv_splits(
-        batch=q.shape[0],
-        num_kv_heads=k_cache.shape[2],
-        num_groups=num_groups,
+    num_kv_splits = select_kv_splits(
+        base_ctas=q.shape[0] * k_cache.shape[2] * num_groups,
         num_pages=num_pages,
         sm_count=_GFX950_SM_COUNT,
     )

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_extend_gfx950.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/mha_extend_gfx950.py
@@ -20,26 +20,13 @@
 
 """MHA extend (prefix-cache / chunked-prefill) Gluon kernel for AMD GFX950.
 
-This handles ragged, multi-token queries against a paged KV cache. The query
-axis is tiled into the MFMA ``M`` dimension (prefill-style): ``BLOCK_M`` query
-rows of a single q-head share each paged KV tile, so every KV tile is loaded
-once and reused across all rows in the tile. The grid is
-``(blocks_per_req, batch, n_heads)`` -- all host-known sizes -- and each program
-self-locates its request from ``cu_seqlens_q`` / ``cache_seqlens`` in-kernel, so
-the launch stays CUDA-graph static with no device->host sync.
-
-Visibility per query row depends on ``is_causal`` and the optional sliding
-window:
-
-* ``is_causal=False``: every query token attends the full visible cache, i.e.
-  ``visible_kv = cache_seqlens[batch]``.
-* ``is_causal=True``: query tokens are a causal suffix, so the ``i``-th query
-  token of a request (0-indexed) attends ``prefix + i + 1`` tokens, where
-  ``prefix = cache_seqlens[batch] - query_len[batch]``.
-
-Causal masking only touches the few KV tiles that reach the diagonal; the long
-prefix is a mask-free fast path. Sinks and sliding windows (causal or not) are
-applied per tile. This is the sole Gluon extend implementation.
+Ragged, multi-token queries against a paged KV cache. Each program owns one
+kv-head and packs the GQA query-head group with ``BLOCK_Q`` query positions into
+the MFMA ``M`` dimension (``BLOCK_M = BLOCK_Q * GROUP_SIZE``), so each KV tile is
+loaded once and reused across the group. The grid is ragged and token-based,
+``(total_num_q_blocks, n_kv_heads)``: each program binary-searches
+``cu_seqlens_q`` to self-locate its request/q-block, keeping the launch
+CUDA-graph static while a ``q=1`` request costs a single block.
 """
 
 from __future__ import annotations
@@ -56,10 +43,52 @@ from tokenspeed_kernel_amd.ops.attention.gluon.utils import (
     attention_layouts,
     max,
     maximum,
+    select_kv_splits,
 )
 
 cdna4 = gl.amd.cdna4
 async_copy = cdna4.async_copy
+
+
+@gluon.jit
+def _find_seq_idx(cu_seqlens_q_ptr, target_block, num_seqs, BLOCK_Q: gl.constexpr):
+    # Map a ragged global q-block index to its request via binary search.
+    left = 0
+    right = num_seqs
+    while left < right:
+        mid = (left + right) // 2
+        val = gl.load(cu_seqlens_q_ptr + mid)
+        mid_val = val // BLOCK_Q + mid
+        if mid_val <= target_block:
+            left = mid + 1
+        else:
+            right = mid
+    return left - 1
+
+
+@gluon.jit
+def _resolve_grid(
+    cu_seqlens_q_ptr,
+    num_seqs,
+    RAGGED: gl.constexpr,
+    BLOCK_Q: gl.constexpr,
+    pid_qblock,
+    pid_batch,
+):
+    # Resolve (batch, q_pos_base) from the launch grid:
+    #   * rectangular ``(blocks_per_req, batch, n_kv_heads)``: ``pid_qblock`` is
+    #     the block within the request and ``pid_batch`` the request.
+    #   * ragged ``(total_num_q_blocks, ...)``: ``pid_qblock`` is a global q-block
+    #     that binary-searches ``cu_seqlens_q`` to find its request.
+    if RAGGED:
+        batch = _find_seq_idx(cu_seqlens_q_ptr, pid_qblock, num_seqs, BLOCK_Q)
+        seq_base = gl.load(cu_seqlens_q_ptr + batch)
+        q_block_start = seq_base // BLOCK_Q + batch
+        q_pos_base = (pid_qblock - q_block_start) * BLOCK_Q
+    else:
+        batch = pid_batch
+        q_pos_base = pid_qblock * BLOCK_Q
+    return batch, q_pos_base
 
 
 # ===-----------------------------------------------------------------------===#
@@ -79,16 +108,20 @@ _EXTEND_LONG_Q_BLOCK_M = 128
 _EXTEND_LONG_Q_NUM_WARPS = 4
 
 
-def _select_extend_tile(max_seqlen_q: int) -> tuple[int, int, int]:
-    """Return (BLOCK_M, BLOCK_N, NUM_WARPS) for the given max query length.
-
-    Queries that fit in a single short tile use it (least padding, most
-    occupancy); longer ones use the tall tile that covers more rows per
-    shared-KV pass.
-    """
+def _select_extend_tile(
+    max_seqlen_q: int, group_size: int
+) -> tuple[int, int, int, int]:
+    # Return (BLOCK_M, BLOCK_Q, BLOCK_N, NUM_WARPS) for the given max query length.
     if max_seqlen_q <= _EXTEND_SHORT_Q_BLOCK_M:
-        return _EXTEND_SHORT_Q_BLOCK_M, _EXTEND_BLOCK_N, _EXTEND_SHORT_Q_NUM_WARPS
-    return _EXTEND_LONG_Q_BLOCK_M, _EXTEND_BLOCK_N, _EXTEND_LONG_Q_NUM_WARPS
+        block_m, num_warps = _EXTEND_SHORT_Q_BLOCK_M, _EXTEND_SHORT_Q_NUM_WARPS
+    else:
+        block_m, num_warps = _EXTEND_LONG_Q_BLOCK_M, _EXTEND_LONG_Q_NUM_WARPS
+    # Floor BLOCK_M down to a whole number of query positions.
+    block_q = block_m // group_size
+    if block_q < 1:
+        block_q = 1
+    block_m = block_q * group_size
+    return block_m, block_q, _EXTEND_BLOCK_N, num_warps
 
 
 @gluon.aggregate
@@ -99,8 +132,10 @@ class ExtendConfig:
     HEAD_DIM: gl.constexpr
     SM_SCALE: gl.constexpr
     BLOCK_M: gl.constexpr
+    BLOCK_Q: gl.constexpr
     BLOCK_N: gl.constexpr
     NUM_WARPS: gl.constexpr
+    NUM_KV_SPLITS: gl.constexpr
     PAGE_SIZE: gl.constexpr
     PAGE_TABLE_STRIDE: gl.constexpr
     IS_CAUSAL: gl.constexpr
@@ -128,8 +163,10 @@ class ExtendConfig:
         HEAD_DIM,
         SM_SCALE,
         BLOCK_M,
+        BLOCK_Q,
         BLOCK_N,
         NUM_WARPS,
+        NUM_KV_SPLITS,
         PAGE_SIZE,
         PAGE_TABLE_STRIDE,
         IS_CAUSAL,
@@ -142,6 +179,7 @@ class ExtendConfig:
     ):
         assert HEAD_DIM in (64, 128)
         assert BLOCK_N == PAGE_SIZE
+        assert BLOCK_M == BLOCK_Q * (N_HEADS // N_KV_HEADS)
 
         # Extend uses a [32, 32, 16] MFMA with NUM_WARPS warp tiling.
         (
@@ -170,8 +208,10 @@ class ExtendConfig:
         self.HEAD_DIM = gl.constexpr(HEAD_DIM)
         self.SM_SCALE = gl.constexpr(SM_SCALE)
         self.BLOCK_M = gl.constexpr(BLOCK_M)
+        self.BLOCK_Q = gl.constexpr(BLOCK_Q)
         self.BLOCK_N = gl.constexpr(BLOCK_N)
         self.NUM_WARPS = gl.constexpr(NUM_WARPS)
+        self.NUM_KV_SPLITS = gl.constexpr(NUM_KV_SPLITS)
         self.PAGE_SIZE = gl.constexpr(PAGE_SIZE)
         self.PAGE_TABLE_STRIDE = gl.constexpr(PAGE_TABLE_STRIDE)
         self.IS_CAUSAL = gl.constexpr(IS_CAUSAL)
@@ -203,9 +243,8 @@ class ExtendProgram:
     lse_ptr: gl.tensor
     sink_ptr: gl.tensor
     batch: gl.tensor
-    q_head: gl.tensor
     kv_head: gl.tensor
-    q_start: gl.tensor
+    q_pos_base: gl.tensor
     seq_base: gl.tensor
     seq_len: gl.tensor
     prefix: gl.tensor
@@ -223,9 +262,8 @@ class ExtendProgram:
         lse_ptr,
         sink_ptr,
         batch,
-        q_head,
         kv_head,
-        q_start,
+        q_pos_base,
         seq_base,
         seq_len,
         prefix,
@@ -240,9 +278,8 @@ class ExtendProgram:
         self.lse_ptr = lse_ptr
         self.sink_ptr = sink_ptr
         self.batch = batch
-        self.q_head = q_head
         self.kv_head = kv_head
-        self.q_start = q_start
+        self.q_pos_base = q_pos_base
         self.seq_base = seq_base
         self.seq_len = seq_len
         self.prefix = prefix
@@ -260,17 +297,15 @@ class ExtendProgram:
         sink_ptr,
         cu_seqlens_q_ptr,
         cache_seqlens_ptr,
+        batch,
+        kv_head,
+        q_pos_base,
     ):
-        block_in_req = gl.program_id(0)
-        batch = gl.program_id(1)
-        q_head = gl.program_id(2)
-        q_start = block_in_req * cfg.BLOCK_M
         seq_base = gl.load(cu_seqlens_q_ptr + batch)
         seq_end = gl.load(cu_seqlens_q_ptr + batch + 1)
         seq_len = seq_end - seq_base
         cache_len = gl.load(cache_seqlens_ptr + batch)
         prefix = cache_len - seq_len
-        kv_head = q_head // cfg.GROUP_SIZE
         return ExtendProgram(
             gl.constexpr(cfg),
             q_ptr,
@@ -281,9 +316,8 @@ class ExtendProgram:
             lse_ptr,
             sink_ptr,
             batch,
-            q_head,
             kv_head,
-            q_start,
+            q_pos_base,
             seq_base,
             seq_len,
             prefix,
@@ -291,15 +325,25 @@ class ExtendProgram:
         )
 
     @gluon.jit
+    def row_qpos(self, offs_m):
+        # Head-minor packing: row m -> query position (m // GROUP_SIZE).
+        return self.q_pos_base + offs_m // self.cfg.GROUP_SIZE
+
+    @gluon.jit
+    def row_qhead(self, offs_m):
+        # Head-minor packing: row m -> group head (m % GROUP_SIZE).
+        return self.kv_head * self.cfg.GROUP_SIZE + offs_m % self.cfg.GROUP_SIZE
+
+    @gluon.jit
     def load_q(self):
         cfg = self.cfg
-        offs_m = self.q_start + gl.arange(
-            0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.q_layout)
-        )
+        offs_m = gl.arange(0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.q_layout))
         offs_d = gl.arange(0, cfg.HEAD_DIM, layout=gl.SliceLayout(0, cfg.q_layout))
-        row = self.seq_base + offs_m
-        offsets = cfg.q_strides.offsets(row[:, None], self.q_head, offs_d[None, :])
-        mask = offs_m[:, None] < self.seq_len
+        q_pos = self.row_qpos(offs_m)
+        q_head = self.row_qhead(offs_m)
+        row = self.seq_base + q_pos
+        offsets = cfg.q_strides.offsets(row[:, None], q_head[:, None], offs_d[None, :])
+        mask = q_pos[:, None] < self.seq_len
         return cdna4.buffer_load(self.q_ptr, offsets, mask=mask, other=0.0)
 
     @gluon.jit
@@ -368,17 +412,17 @@ class ExtendProgram:
     def init_attention_state(self):
         cfg = self.cfg
         if cfg.HAS_SINK:
-            sink_log2 = gl.load(self.sink_ptr + self.q_head).to(gl.float32) * _INV_LN2
-            sink_unscaled = sink_log2 / cfg.SM_SCALE
-            m_i = gl.full(
+            offs_m = gl.arange(0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.pv_layout))
+            q_head = self.row_qhead(offs_m)
+            sink_log2 = gl.load(self.sink_ptr + q_head).to(gl.float32) * _INV_LN2
+            m_i = sink_log2 / cfg.SM_SCALE
+        else:
+            sink_log2 = gl.full(
                 [cfg.BLOCK_M],
-                value=0,
+                value=0.0,
                 dtype=gl.float32,
                 layout=gl.SliceLayout(1, cfg.pv_layout),
             )
-            m_i += sink_unscaled
-        else:
-            sink_log2 = 0.0
             m_i = gl.full(
                 [cfg.BLOCK_M],
                 value=-float("inf"),
@@ -397,13 +441,17 @@ class ExtendProgram:
         return m_i, l_i, acc, sink_log2
 
     @gluon.jit
-    def softmax(self, qk, m_i, l_i, acc):
+    def softmax(self, qk, m_i, l_i, acc, allow_invalid: gl.constexpr = False):
         cfg = self.cfg
         # In sliding window case, some rows can see fully masked tiles before
         # any valid KV. Guard the online softmax state so `-inf - -inf` does not
         # produce NaNs. This does not happen when having sink, because m_i
-        # is initialized to sink value instead of -inf.
-        HAS_INVALID: gl.constexpr = cfg.WINDOW_LEFT >= 0 and not cfg.HAS_SINK
+        # is initialized to sink value instead of -inf. Under split-K a whole
+        # (non-empty) KV split can also sit above a row's causal diagonal, so
+        # the split-K compute passes allow_invalid=True to enable the guard.
+        HAS_INVALID: gl.constexpr = (
+            cfg.WINDOW_LEFT >= 0 or allow_invalid
+        ) and not cfg.HAS_SINK
 
         row_max = max(qk, 1)
         m_new = maximum(m_i, row_max)
@@ -436,16 +484,16 @@ class ExtendProgram:
     @gluon.jit
     def store_output(self, output):
         cfg = self.cfg
-        offs_m = self.q_start + gl.arange(
-            0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.store_layout)
-        )
+        offs_m = gl.arange(0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.store_layout))
         offs_d = gl.arange(0, cfg.HEAD_DIM, layout=gl.SliceLayout(0, cfg.store_layout))
+        q_pos = self.row_qpos(offs_m)
+        q_head = self.row_qhead(offs_m)
         offsets = (
-            ((self.seq_base + offs_m[:, None]) * cfg.N_HEADS + self.q_head)
+            ((self.seq_base + q_pos[:, None]) * cfg.N_HEADS + q_head[:, None])
             * cfg.HEAD_DIM
             + offs_d[None, :]
         ).to(gl.int32)
-        mask = offs_m[:, None] < self.seq_len
+        mask = q_pos[:, None] < self.seq_len
         output = output.to(self.output_ptr.dtype.element_ty)
         cdna4.buffer_store(output, self.output_ptr, offsets, mask=mask)
 
@@ -453,19 +501,53 @@ class ExtendProgram:
     def store_lse(self, l_i, m_i):
         cfg = self.cfg
         if cfg.HAS_LSE:
-            offs_m = self.q_start + gl.arange(
-                0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.pv_layout)
-            )
-            offsets = ((self.seq_base + offs_m) * cfg.N_HEADS + self.q_head).to(
-                gl.int32
-            )
-            mask = offs_m < self.seq_len
+            offs_m = gl.arange(0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.pv_layout))
+            q_pos = self.row_qpos(offs_m)
+            q_head = self.row_qhead(offs_m)
+            offsets = ((self.seq_base + q_pos) * cfg.N_HEADS + q_head).to(gl.int32)
+            mask = q_pos < self.seq_len
             lse_l_i = gl.where(l_i > 0.0, l_i, 1.0)
             # Softmax runs in base-2 (exp2 hardware fast path), so m_i*SM_SCALE +
             # log2(l_i) is the LSE in base-2 units. Convert to natural log (the
             # public op contract / torch.logsumexp convention) by scaling by ln2.
             lse = (m_i * cfg.SM_SCALE + gl.log2(lse_l_i)) * _LN2
             cdna4.buffer_store(lse, self.lse_ptr, offsets, mask=mask)
+
+    @gluon.jit
+    def store_partial(self, acc, l_i, m_i, split_id, mid_o_ptr, mid_lse_ptr):
+        # Split-K partial store: mid_o[row, head, split] = acc / l_i (this
+        # split's local softmax normalization) and mid_lse[row, head, split] =
+        # m_i * SM_SCALE + log2(l_i) in base-2 units, matching the decode
+        # kernel's store_split so a shared reduce can merge splits. Rows whose
+        # split saw no valid key (l_i == 0, e.g. a split entirely above the
+        # causal diagonal) store a -inf lse / zero output so the reduce ignores
+        # them without producing NaNs.
+        cfg = self.cfg
+        offs_m = gl.arange(0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.store_layout))
+        offs_d = gl.arange(0, cfg.HEAD_DIM, layout=gl.SliceLayout(0, cfg.store_layout))
+        q_pos = self.row_qpos(offs_m)
+        q_head = self.row_qhead(offs_m)
+        row = self.seq_base + q_pos
+        valid = q_pos < self.seq_len
+        has_kv = l_i > 0.0
+        acc = gl.convert_layout(acc, cfg.store_layout)
+        l_i = gl.convert_layout(l_i, gl.SliceLayout(1, cfg.store_layout))
+        m_i = gl.convert_layout(m_i, gl.SliceLayout(1, cfg.store_layout))
+        has_kv = gl.convert_layout(has_kv, gl.SliceLayout(1, cfg.store_layout))
+        inv_l = gl.where(has_kv, 1.0 / gl.where(has_kv, l_i, 1.0), 0.0)
+        part_o = acc * inv_l[:, None]
+        part_lse = gl.where(
+            has_kv,
+            m_i * cfg.SM_SCALE + gl.log2(gl.where(has_kv, l_i, 1.0)),
+            -float("inf"),
+        )
+        o_off = (
+            (row[:, None] * cfg.N_HEADS + q_head[:, None]) * cfg.NUM_KV_SPLITS
+            + split_id
+        ) * cfg.HEAD_DIM + offs_d[None, :]
+        lse_off = (row * cfg.N_HEADS + q_head) * cfg.NUM_KV_SPLITS + split_id
+        cdna4.buffer_store(part_o, mid_o_ptr, o_off, mask=valid[:, None])
+        cdna4.buffer_store(part_lse, mid_lse_ptr, lse_off, mask=valid)
 
 
 @gluon.jit
@@ -479,6 +561,7 @@ def _mha_extend(
     sink_ptr,
     cu_seqlens_q_ptr,
     cache_seqlens_ptr,
+    num_seqs,
     Q_STRIDE_T: gl.constexpr,
     Q_STRIDE_H: gl.constexpr,
     Q_STRIDE_D: gl.constexpr,
@@ -489,6 +572,7 @@ def _mha_extend(
     N_KV_HEADS: gl.constexpr,
     HEAD_DIM: gl.constexpr,
     BLOCK_M: gl.constexpr,
+    BLOCK_Q: gl.constexpr,
     BLOCK_N: gl.constexpr,
     NUM_WARPS: gl.constexpr,
     IS_CAUSAL: gl.constexpr,
@@ -496,6 +580,7 @@ def _mha_extend(
     HAS_LSE: gl.constexpr,
     WINDOW_LEFT: gl.constexpr,
     IS_FP8: gl.constexpr,
+    RAGGED: gl.constexpr,
 ):
     cfg = ExtendConfig(
         N_HEADS,
@@ -503,8 +588,10 @@ def _mha_extend(
         HEAD_DIM,
         SM_SCALE,
         BLOCK_M,
+        BLOCK_Q,
         BLOCK_N,
         NUM_WARPS,
+        1,  # NUM_KV_SPLITS: single-pass path has no split-K
         PAGE_SIZE,
         PAGE_TABLE_STRIDE,
         IS_CAUSAL,
@@ -514,6 +601,18 @@ def _mha_extend(
         IS_FP8,
         k_cache_ptr.dtype.element_ty,
         InputStrides(Q_STRIDE_T, Q_STRIDE_H, Q_STRIDE_D),
+    )
+    if RAGGED:
+        kv_head = gl.program_id(1)
+    else:
+        kv_head = gl.program_id(2)
+    batch, q_pos_base = _resolve_grid(
+        cu_seqlens_q_ptr,
+        num_seqs,
+        RAGGED,
+        cfg.BLOCK_Q,
+        gl.program_id(0),
+        gl.program_id(1),
     )
     program = ExtendProgram.create(
         cfg,
@@ -526,9 +625,12 @@ def _mha_extend(
         sink_ptr,
         cu_seqlens_q_ptr,
         cache_seqlens_ptr,
+        batch,
+        kv_head,
+        q_pos_base,
     )
     # Over-provisioned tile past this request's real query rows: nothing to do.
-    if program.q_start >= program.seq_len:
+    if program.q_pos_base >= program.seq_len:
         return
     k_smem = gl.allocate_shared_memory(
         k_cache_ptr.dtype.element_ty, [cfg.BLOCK_N, cfg.HEAD_DIM], cfg.k_smem_layout
@@ -540,24 +642,29 @@ def _mha_extend(
     q = program.load_q()
     m_i, l_i, acc, sink_log2 = program.init_attention_state()
 
-    offs_m_q = program.q_start + gl.arange(
-        0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.qk_layout)
-    )
+    # Row m packs (query position m // GROUP_SIZE, group head m % GROUP_SIZE);
+    # the causal/sliding masks key off the per-row query position only (heads in
+    # a group share visibility), so diag_row broadcasts across the packed heads.
+    offs_m_q = gl.arange(0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.qk_layout))
+    q_pos = program.q_pos_base + offs_m_q // cfg.GROUP_SIZE
     offs_n_q = gl.arange(0, cfg.BLOCK_N, layout=gl.SliceLayout(0, cfg.qk_layout))
-    diag_row = program.prefix + offs_m_q
+    diag_row = program.prefix + q_pos
 
     if IS_CAUSAL:
-        kv_end = min(program.cache_len, program.prefix + program.q_start + cfg.BLOCK_M)
+        # Deepest diagonal in this tile is the last packed query position.
+        kv_end = min(
+            program.cache_len, program.prefix + program.q_pos_base + cfg.BLOCK_Q
+        )
     else:
         kv_end = program.cache_len
 
     # Sliding window (inclusive-left, matches flash-attn window_size=(W, 0)):
     # skip KV tiles entirely below the window's lower edge. The tile's top query
-    # row sits at absolute position pos_top; its window opens at
+    # position sits at absolute position pos_top; its window opens at
     # pos_top - WINDOW_LEFT (that key is visible -> W + 1 keys total). The min()
     # form clamps to 0 without the shadowed builtin max().
     if cfg.WINDOW_LEFT >= 0:
-        pos_top = program.prefix + program.q_start
+        pos_top = program.prefix + program.q_pos_base
         kv_start = pos_top - min(pos_top, cfg.WINDOW_LEFT)
         kv_start = (kv_start // cfg.BLOCK_N) * cfg.BLOCK_N
     else:
@@ -583,7 +690,7 @@ def _mha_extend(
                 mask &= offs_n_abs[None, :] <= diag_row[:, None]
             qk = gl.where(mask, qk, -float("inf"))
         elif IS_CAUSAL:
-            if start_n + cfg.BLOCK_N > program.prefix + program.q_start:
+            if start_n + cfg.BLOCK_N > program.prefix + program.q_pos_base:
                 offs_n_abs = start_n + offs_n_q
                 mask = (offs_n_abs[None, :] <= diag_row[:, None]) & (
                     offs_n_abs[None, :] < program.cache_len
@@ -610,6 +717,222 @@ def _mha_extend(
     program.store_lse(l_i, m_i)
 
 
+@gluon.jit
+def _mha_extend_split(
+    q_ptr,
+    k_cache_ptr,
+    v_cache_ptr,
+    page_table_ptr,
+    mid_o_ptr,
+    mid_lse_ptr,
+    sink_ptr,
+    cu_seqlens_q_ptr,
+    cache_seqlens_ptr,
+    num_seqs,
+    Q_STRIDE_T: gl.constexpr,
+    Q_STRIDE_H: gl.constexpr,
+    Q_STRIDE_D: gl.constexpr,
+    SM_SCALE: gl.constexpr,
+    PAGE_TABLE_STRIDE: gl.constexpr,
+    PAGE_SIZE: gl.constexpr,
+    N_HEADS: gl.constexpr,
+    N_KV_HEADS: gl.constexpr,
+    HEAD_DIM: gl.constexpr,
+    BLOCK_M: gl.constexpr,
+    BLOCK_Q: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+    NUM_KV_SPLITS: gl.constexpr,
+    IS_CAUSAL: gl.constexpr,
+    IS_FP8: gl.constexpr,
+    RAGGED: gl.constexpr,
+):
+    # Split-K compute pass. Two grids share the body:
+    #   * ragged (total_num_q_blocks, n_kv_heads, NUM_KV_SPLITS): program_id(0)
+    #     self-locates its request/q-block, program_id(2) is the KV split.
+    #   * rectangular (blocks_per_req * NUM_KV_SPLITS, batch, n_kv_heads):
+    #     program_id(0) folds the query block and KV split.
+    # Each program streams only its slice of the request's visible KV range and
+    # writes a per-split partial (normalized O + base-2 LSE). Sinks are NOT folded
+    # here -- a sink is a single global softmax entry, so the reduce adds it once
+    # (folding it per split would count it NUM_KV_SPLITS times). HAS_SINK is
+    # therefore False in this config so the online softmax starts from -inf.
+    cfg = ExtendConfig(
+        N_HEADS,
+        N_KV_HEADS,
+        HEAD_DIM,
+        SM_SCALE,
+        BLOCK_M,
+        BLOCK_Q,
+        BLOCK_N,
+        NUM_WARPS,
+        NUM_KV_SPLITS,
+        PAGE_SIZE,
+        PAGE_TABLE_STRIDE,
+        IS_CAUSAL,
+        False,  # HAS_SINK: added once in the reduce, not per split
+        False,  # HAS_LSE: split partials store base-2 lse unconditionally
+        -1,  # WINDOW_LEFT: split-K is full-attention only
+        IS_FP8,
+        k_cache_ptr.dtype.element_ty,
+        InputStrides(Q_STRIDE_T, Q_STRIDE_H, Q_STRIDE_D),
+    )
+    if RAGGED:
+        kv_head = gl.program_id(1)
+        split_id = gl.program_id(2)
+        pid_qblock = gl.program_id(0)
+    else:
+        kv_head = gl.program_id(2)
+        split_id = gl.program_id(0) % NUM_KV_SPLITS
+        pid_qblock = gl.program_id(0) // NUM_KV_SPLITS
+    batch, q_pos_base = _resolve_grid(
+        cu_seqlens_q_ptr,
+        num_seqs,
+        RAGGED,
+        cfg.BLOCK_Q,
+        pid_qblock,
+        gl.program_id(1),
+    )
+    program = ExtendProgram.create(
+        cfg,
+        q_ptr,
+        k_cache_ptr,
+        v_cache_ptr,
+        page_table_ptr,
+        mid_o_ptr,
+        mid_lse_ptr,
+        sink_ptr,
+        cu_seqlens_q_ptr,
+        cache_seqlens_ptr,
+        batch,
+        kv_head,
+        q_pos_base,
+    )
+    # Over-provisioned tile past this request's real query rows: nothing to do.
+    if program.q_pos_base >= program.seq_len:
+        return
+
+    # Deepest key this query block can see (causal) or the whole cache.
+    if IS_CAUSAL:
+        kv_end = min(
+            program.cache_len, program.prefix + program.q_pos_base + cfg.BLOCK_Q
+        )
+    else:
+        kv_end = program.cache_len
+
+    # Partition [0, kv_end) into NUM_KV_SPLITS page-aligned slices (BLOCK_N ==
+    # PAGE_SIZE), mirroring the decode kernel's split math.
+    num_pages = gl.cdiv(kv_end, cfg.PAGE_SIZE)
+    pages_per_split = gl.cdiv(num_pages, cfg.NUM_KV_SPLITS)
+    split_start_page = split_id * pages_per_split
+    split_end_page = min(split_start_page + pages_per_split, num_pages)
+    split_start = split_start_page * cfg.PAGE_SIZE
+    split_end = min(split_end_page * cfg.PAGE_SIZE, kv_end)
+
+    k_smem = gl.allocate_shared_memory(
+        k_cache_ptr.dtype.element_ty, [cfg.BLOCK_N, cfg.HEAD_DIM], cfg.k_smem_layout
+    )
+    v_smem = gl.allocate_shared_memory(
+        v_cache_ptr.dtype.element_ty, [cfg.BLOCK_N, cfg.HEAD_DIM], cfg.v_smem_layout
+    )
+
+    q = program.load_q()
+    m_i, l_i, acc, sink_log2 = program.init_attention_state()
+
+    offs_m_q = gl.arange(0, cfg.BLOCK_M, layout=gl.SliceLayout(1, cfg.qk_layout))
+    q_pos = program.q_pos_base + offs_m_q // cfg.GROUP_SIZE
+    offs_n_q = gl.arange(0, cfg.BLOCK_N, layout=gl.SliceLayout(0, cfg.qk_layout))
+    diag_row = program.prefix + q_pos
+
+    for start_n in range(split_start, split_end, cfg.BLOCK_N):
+        physical_page = program.load_page(start_n)
+        program.issue_load_k(physical_page, k_smem)
+        program.issue_load_v(physical_page, v_smem)
+
+        async_copy.wait_group(1)
+        k = program.shared_load_k(k_smem)
+        qk = program.compute_qk(q, k)
+
+        if IS_CAUSAL:
+            if start_n + cfg.BLOCK_N > program.prefix + program.q_pos_base:
+                offs_n_abs = start_n + offs_n_q
+                mask = (offs_n_abs[None, :] <= diag_row[:, None]) & (
+                    offs_n_abs[None, :] < program.cache_len
+                )
+                qk = gl.where(mask, qk, -float("inf"))
+        else:
+            if start_n + cfg.BLOCK_N > program.cache_len:
+                offs_n_abs = start_n + offs_n_q
+                qk = gl.where(
+                    offs_n_abs[None, :] < program.cache_len, qk, -float("inf")
+                )
+
+        # allow_invalid: a whole split can sit above a row's causal diagonal.
+        p, m_i, l_i, acc = program.softmax(qk, m_i, l_i, acc, allow_invalid=True)
+
+        async_copy.wait_group(0)
+        v = program.shared_load_v(v_smem)
+        acc = program.compute_pv(p, v, acc)
+
+    program.store_partial(acc, l_i, m_i, split_id, mid_o_ptr, mid_lse_ptr)
+
+
+@gluon.jit
+def _mha_extend_reduce(
+    mid_o_ptr,
+    mid_lse_ptr,
+    out_ptr,
+    lse_out_ptr,
+    sink_ptr,
+    SM_SCALE: gl.constexpr,
+    NUM_KV_SPLITS: gl.constexpr,
+    N_HEADS: gl.constexpr,
+    HEAD_DIM: gl.constexpr,
+    HAS_SINK: gl.constexpr,
+    HAS_LSE: gl.constexpr,
+):
+    # Combine the NUM_KV_SPLITS partials for one (query token, head) with a
+    # global softmax rescale. Empty splits carry -inf lse (written by the
+    # compute pass) so they drop out. Grid is (total_q, N_HEADS).
+    reduce_layout: gl.constexpr = gl.BlockedLayout(
+        [1, HEAD_DIM // 64], [1, 64], [1, 1], [1, 0]
+    )
+    row = gl.program_id(0)
+    q_head = gl.program_id(1)
+
+    # SPLIT_TILE pads NUM_KV_SPLITS up to a power of 2 for the tensor shape.
+    SPLIT_TILE: gl.constexpr = 1 << (NUM_KV_SPLITS - 1).bit_length()
+    offs_s = gl.arange(0, SPLIT_TILE, layout=gl.SliceLayout(1, reduce_layout))
+    offs_d = gl.arange(0, HEAD_DIM, layout=gl.SliceLayout(0, reduce_layout))
+    split_valid = offs_s < NUM_KV_SPLITS
+    base = (row * N_HEADS + q_head) * NUM_KV_SPLITS + offs_s
+    part_lse = gl.load(mid_lse_ptr + base, mask=split_valid, other=-float("inf"))
+    o_off = base[:, None] * HEAD_DIM + offs_d[None, :]
+    part_o = cdna4.buffer_load(mid_o_ptr, o_off, mask=split_valid[:, None], other=0.0)
+
+    m_i = max(part_lse, axis=0)
+    if HAS_SINK:
+        sink = gl.load(sink_ptr + q_head).to(gl.float32) * _INV_LN2
+        m_i = maximum(m_i, sink)
+    beta = gl.exp2(part_lse - m_i)
+    l_i = gl.sum(beta, axis=0)
+    if HAS_SINK:
+        l_i = l_i + gl.exp2(sink - m_i)
+    acc = gl.sum(part_o * beta[:, None], axis=0)
+
+    denom = gl.where(l_i > 0.0, l_i, 1.0)
+    output = acc * (1.0 / denom)
+    output = output.to(out_ptr.dtype.element_ty)
+    out_base = (row * N_HEADS + q_head) * HEAD_DIM
+    cdna4.buffer_store(output, out_ptr, out_base + offs_d)
+    if HAS_LSE:
+        lse = (m_i + gl.log2(denom)) * _LN2
+        gl.store(lse_out_ptr + (row * N_HEADS + q_head), lse)
+
+
+_GFX950_SM_COUNT = 256
+
+
 def gluon_mha_extend_gfx950(
     q: torch.Tensor,
     cu_seqlens_q: torch.Tensor,
@@ -633,16 +956,32 @@ def gluon_mha_extend_gfx950(
     head_dim = q.shape[2]
     n_heads = q.shape[1]
     n_kv_heads = k_cache.shape[2]
+    group_size = n_heads // n_kv_heads
     page_size = k_cache.shape[1]
-    block_m, block_n, num_warps = _select_extend_tile(max_seqlen_q)
+    block_m, block_q, block_n, num_warps = _select_extend_tile(max_seqlen_q, group_size)
     if softmax_scale is None:
         softmax_scale = 1.0 / math.sqrt(head_dim)
     sm_scale = softmax_scale * _INV_LN2_VALUE
 
-    # max_seqlen_q must be >= the true max query length; extra tiles early-exit.
+    # Grid selection. Two layouts share the kernel body:
+    #   * rectangular (blocks_per_req * batch blocks): tight when every request
+    #     has the same query length (per-stage 3-launch dispatch).
+    #   * ragged (total_q // block_q + batch blocks, AITER-style): each program
+    #     binary-searches cu_seqlens_q to self-locate, so a q=1 request costs one
+    #     block instead of the batch-wide max. Tight for mixed query lengths
+    #     (the fused single call).
+    # Pick whichever launches fewer blocks: the ragged bound only wins when query
+    # lengths vary, and the rectangular bound only wins when they're uniform, so
+    # this avoids the ragged +num_seqs padding regressing uniform-q launches
+    # while still unlocking the fused mixed path.
     batch = cu_seqlens_q.shape[0] - 1
+    total_q = q.shape[0]
     safe_max_q = max_seqlen_q if max_seqlen_q > 0 else 1
-    blocks_per_req = (safe_max_q + block_m - 1) // block_m
+    blocks_per_req = (safe_max_q + block_q - 1) // block_q
+    rect_num_q_blocks = blocks_per_req * batch
+    ragged_num_q_blocks = total_q // block_q + batch
+    use_ragged = ragged_num_q_blocks < rect_num_q_blocks
+    grid_num_q_blocks = ragged_num_q_blocks if use_ragged else rect_num_q_blocks
     has_sink = sinks is not None
     sink_arg = sinks if has_sink else q
     cu_q_i32 = cu_seqlens_q.to(torch.int32).contiguous()
@@ -657,7 +996,92 @@ def gluon_mha_extend_gfx950(
     else:
         lse = None
         lse_arg = q
-    grid = (blocks_per_req, batch, n_heads)
+
+    # Split-K (full attention only): when the single-pass grid under-fills the
+    # machine (low batch / few query blocks) but the KV is long, split each
+    # request's KV stream across programs and merge with a reduce -- the same
+    # 2D/3D switch AITER's unified kernel and our decode kernel make.
+    is_sliding = window_left >= 0
+    num_kv_splits = 1
+    # Unlike decode (one q-pos per program -> a single scalar window), an extend
+    # tile packs many q-positions each with its own window, so the page-range
+    # split can't express a per-row window: split-K is full-attention only here.
+    if not is_sliding:
+        num_pages = (max_seqlen_k + page_size - 1) // page_size
+        num_kv_splits = select_kv_splits(
+            base_ctas=grid_num_q_blocks * n_kv_heads,
+            num_pages=num_pages,
+            sm_count=_GFX950_SM_COUNT,
+        )
+
+    if num_kv_splits > 1:
+        mid_o = torch.empty(
+            (total_q, n_heads, num_kv_splits, head_dim),
+            device=q.device,
+            dtype=torch.float32,
+        )
+        mid_lse = torch.empty(
+            (total_q, n_heads, num_kv_splits),
+            device=q.device,
+            dtype=torch.float32,
+        )
+        if use_ragged:
+            split_grid = (ragged_num_q_blocks, n_kv_heads, num_kv_splits)
+        else:
+            split_grid = (blocks_per_req * num_kv_splits, batch, n_kv_heads)
+        _mha_extend_split[split_grid](
+            q,
+            k_cache,
+            v_cache,
+            page_table,
+            mid_o,
+            mid_lse,
+            sink_arg,
+            cu_q_i32,
+            cache_i32,
+            batch,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            sm_scale,
+            page_table.stride(0),
+            page_size,
+            n_heads,
+            n_kv_heads,
+            head_dim,
+            block_m,
+            block_q,
+            block_n,
+            num_warps,
+            num_kv_splits,
+            is_causal,
+            is_fp8,
+            use_ragged,
+            num_warps=num_warps,
+        )
+        reduce_grid = (total_q, n_heads)
+        _mha_extend_reduce[reduce_grid](
+            mid_o,
+            mid_lse,
+            output,
+            lse_arg,
+            sink_arg,
+            sm_scale,
+            num_kv_splits,
+            n_heads,
+            head_dim,
+            has_sink,
+            return_lse,
+            num_warps=1,
+        )
+        if return_lse:
+            return output, lse
+        return output
+
+    if use_ragged:
+        grid = (ragged_num_q_blocks, n_kv_heads)
+    else:
+        grid = (blocks_per_req, batch, n_kv_heads)
     _mha_extend[grid](
         q,
         k_cache,
@@ -668,6 +1092,7 @@ def gluon_mha_extend_gfx950(
         sink_arg,
         cu_q_i32,
         cache_i32,
+        batch,
         q.stride(0),
         q.stride(1),
         q.stride(2),
@@ -678,6 +1103,7 @@ def gluon_mha_extend_gfx950(
         n_kv_heads,
         head_dim,
         block_m,
+        block_q,
         block_n,
         num_warps,
         is_causal,
@@ -685,6 +1111,7 @@ def gluon_mha_extend_gfx950(
         return_lse,
         window_left,
         is_fp8,
+        use_ragged,
         num_warps=num_warps,
     )
     if return_lse:

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/utils.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/attention/gluon/utils.py
@@ -28,6 +28,36 @@ _LN2_VALUE = 0.6931471805599453
 _LN2 = tl.constexpr(_LN2_VALUE)
 
 
+def select_kv_splits(*, base_ctas: int, num_pages: int, sm_count: int) -> int:
+    """Pick num_kv_splits to balance occupancy against reduce overhead.
+
+    The launch grid is base_ctas * num_kv_splits work-groups. Too few splits
+    under-fill the machine at low batch; too many leave each split with a
+    handful of pages, so the reduce kernel dominates.
+
+    Return the smaller of two candidate counts: splits_for_occupancy (enough to
+    fill ~wave_target waves of CUs) and splits_for_pages (~min_pages_per_split
+    pages per split), with the pages candidate clamped to [min_page_splits,
+    max_page_splits] so a short context still splits without launching empty work
+    and a long one does not over-split where reduce cost outgrows the decode win.
+    """
+    wave_target = 2
+    min_pages_per_split = 2
+    min_page_splits = 8
+    max_page_splits = 32
+
+    target_ctas = sm_count * wave_target
+    splits_for_occupancy = (target_ctas + base_ctas - 1) // base_ctas
+
+    splits_for_pages = num_pages // min_pages_per_split
+    min_page_splits = min(min_page_splits, num_pages)
+    if splits_for_pages < min_page_splits:
+        splits_for_pages = min_page_splits
+    if splits_for_pages > max_page_splits:
+        splits_for_pages = max_page_splits
+    return min(splits_for_occupancy, splits_for_pages)
+
+
 @gluon.jit
 def maximum(a, b, propagate_nan: gl.constexpr = tl.PropagateNan.ALL):
     return gl.maximum(a, b, propagate_nan=propagate_nan)
@@ -36,6 +66,25 @@ def maximum(a, b, propagate_nan: gl.constexpr = tl.PropagateNan.ALL):
 @gluon.jit
 def max(input, axis=None, keep_dims=False):
     return gl.reduce(input, axis, maximum, keep_dims=keep_dims)
+
+
+@gluon.constexpr_function
+def padded_shared_layout(operand_layout, shape, dtype, is_k_contig):
+    # Take only the built-in's padding, not its swizzle: the swizzle scatters the
+    # contraction dim across banks, making the LDS write stride non-constant, so it
+    # can't lower through async_copy's affine [1, 0] load. Padding-only is affine
+    # and DMA-legal.
+    # TODO(perf): to also use the swizzle, co-design a matched load layout so the
+    # DMA stays legal.
+    api = gl.amd.cdna4.compute_efficient_padded_shared_layout(
+        operand_layout, shape, dtype, is_k_contig=is_k_contig
+    )
+    assert api is not None, "no CDNA4 padded shared layout for this operand/dtype"
+    pairs = list(api.interval_padding_pairs)
+    assert len(pairs) == 1, "expected a single interval padding pair from the built-in"
+    return gl.PaddedSharedLayout.with_identity_for(
+        [[int(pairs[0][0]), int(pairs[0][1])]], shape, [1, 0]
+    )
 
 
 @gluon.constexpr_function
@@ -67,31 +116,11 @@ def attention_layouts(head_dim, block_n, is_fp8, dtype, num_warps, instr_shape):
     store_layout = gl.BlockedLayout(
         [1, store_vec], [64 // store_threads, store_threads], [num_warps, 1], [1, 0]
     )
-    # Take only the built-in's padding, not its swizzle: the swizzle scatters
-    # head_dim across banks, making the LDS write stride non-constant, so it can't
-    # lower through async_copy's affine [1, 0] load. Padding-only is affine and
-    # DMA-legal.
-    # TODO(perf): to also use the swizzle, co-design a matched load layout so the
-    # DMA stays legal.
-    k_api = gl.amd.cdna4.compute_efficient_padded_shared_layout(
+    k_smem_layout = padded_shared_layout(
         k_layout, [block_n, head_dim], dtype, is_k_contig=True
     )
-    v_api = gl.amd.cdna4.compute_efficient_padded_shared_layout(
+    v_smem_layout = padded_shared_layout(
         v_layout, [block_n, head_dim], dtype, is_k_contig=False
-    )
-    assert (
-        k_api is not None and v_api is not None
-    ), "no CDNA4 padded shared layout for this operand/dtype"
-    k_pairs = list(k_api.interval_padding_pairs)
-    v_pairs = list(v_api.interval_padding_pairs)
-    assert (
-        len(k_pairs) == 1 and len(v_pairs) == 1
-    ), "expected a single interval padding pair from the built-in"
-    k_smem_layout = gl.PaddedSharedLayout.with_identity_for(
-        [[int(k_pairs[0][0]), int(k_pairs[0][1])]], [block_n, head_dim], [1, 0]
-    )
-    v_smem_layout = gl.PaddedSharedLayout.with_identity_for(
-        [[int(v_pairs[0][0]), int(v_pairs[0][1])]], [block_n, head_dim], [1, 0]
     )
     return (
         qk_layout,


### PR DESCRIPTION
Fix https://github.com/lightseekorg/tokenspeed/issues/521#issuecomment-4986417504.

- Packed GQA layout — pack the query-head group into the MFMA M dim (BLOCK_M = BLOCK_Q × GROUP_SIZE) so each KV tile is loaded once per group instead of once per query head, killing the GROUP_SIZE× KV reload.
- Ragged token-based grid — grid over true q-block count with in-kernel cu_seqlens_q self-location, so a q=1 request costs exactly one block (no rectangular over-provisioning) while staying CUDA-graph static.
- Split-K (full attention only) — for low-occupancy long-KV cases, split each request's KV stream across programs (compute pass writes per-split partials + LSE) and merge in a reduce pass.

## Extend kernel: latency on the 6 mixed workloads (ms, gfx950 / MI355X)

| workload                    | before (main) | now   | AITER | now/AITER (<1 faster) |
|-----------------------------|--------------:|------:|------:|----------------------:|
| extend_full_q1              | 0.199         | 0.044 | 0.064 | 0.69                  |
| extend_full_q8              | 0.194         | 0.049 | 0.126 | 0.39                  |
| extend_sliding128_q8        | 0.050         | 0.023 | 0.030 | 0.78                  |
| mixed_balanced              | 0.224         | 0.065 | 0.088 | 0.74                  |
| mixed_balanced_sliding128   | 0.044         | 0.023 | 0.027 | 0.87                  |
| mixed_prefill_heavy         | 2.896         | 0.315 | 0.352 | 0.89                  |

*64 q-heads, 8 KV-heads, head_dim 64, bf16, sinks on; median of 100 iters.*

Signed-off-by: Yu-Zhewen <zhewenyu@amd.com>