### PR TITLE
[WIP][AMD] Implement MTP support for qwen3.5 MXFP4

### DIFF
--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -72,6 +72,7 @@ DEFAULT_SMG_POLICY = "passthrough"
 _DEFAULT_SMG_DISABLE_FLAGS = (
     "--disable-circuit-breaker",
     "--disable-retries",
+    "--disable-health-check",
 )
 
 

--- a/python/tokenspeed/runtime/layers/moe/topk.py
+++ b/python/tokenspeed/runtime/layers/moe/topk.py
@@ -196,6 +196,14 @@ def _mask_topk_ids_padded_region(
     topk_ids[indices >= num_token_non_padded, :] = -1
 
 
+def _stable_descending_topk(
+    scores: torch.Tensor,
+    topk: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    values, indices = torch.sort(scores, dim=-1, descending=True, stable=True)
+    return values[:, :topk], indices[:, :topk]
+
+
 def torch_native_fused_topk(
     hidden_states: torch.Tensor,
     gating_output: torch.Tensor,
@@ -209,14 +217,14 @@ def torch_native_fused_topk(
         scores_for_choice = scores.view(
             -1, n_routed_experts
         ) + correction_bias.unsqueeze(0)
-        topk_ids = torch.topk(scores_for_choice, k=topk, dim=-1, sorted=False)[1]
+        _, topk_ids = _stable_descending_topk(scores_for_choice, topk)
         topk_weights = scores.gather(1, topk_ids)
     else:
         assert (
             hidden_states.shape[0] == gating_output.shape[0]
         ), f"Number of tokens mismatch, {hidden_states.shape=} vs {gating_output.shape=}"
-        topk_weights = F.softmax(gating_output.float(), dim=-1)
-        topk_weights, topk_ids = torch.topk(topk_weights, topk, dim=-1)
+        scores = F.softmax(gating_output.float(), dim=-1)
+        topk_weights, topk_ids = _stable_descending_topk(scores, topk)
 
     if renormalize:
         topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)

--- a/python/tokenspeed/runtime/models/qwen3_5_nextn.py
+++ b/python/tokenspeed/runtime/models/qwen3_5_nextn.py
@@ -163,8 +163,8 @@ class Qwen3_5ForConditionalGenerationNextN(nn.Module):
         if self.is_multimodal:
             config = config.text_config
 
-        # The MTP model is unquantized in the nvfp4 checkpoint.
-        if quant_config and quant_config.get_name() == "nvfp4":
+        # The MTP model is unquantized in the nvfp4 and mxfp4 checkpoints.
+        if quant_config and quant_config.get_name() in ("nvfp4", "mxfp4"):
             quant_config = None
 
         self.config = config

--- a/test/ci/eval/qwen3.5-397b-a17b-mxfp4-evalscope-aime25.yaml
+++ b/test/ci/eval/qwen3.5-397b-a17b-mxfp4-evalscope-aime25.yaml
@@ -21,6 +21,10 @@ server:
     --trust-remote-code
     --quantization mxfp4
     --weight-loader-prefetch-checkpoints
+    --speculative-algorithm MTP
+    --speculative-num-steps 3
+    --speculative-num-draft-tokens 4
+    --speculative-draft-model-quantization unquant
     --sampling-backend greedy
     --disable-kvstore
     --kvstore-ratio 0.0
@@ -45,7 +49,7 @@ eval:
     --limit 8
     --eval-batch-size 8
     --stream
-    --generation-config '{"do_sample":false,"temperature":0.0,"max_tokens":16384}'
+    --generation-config '{"do_sample":false,"temperature":0.0,"max_tokens":32768}'
 report:
   github_step_summary: true
 score_threshold: 0.75

--- a/test/cli/test_serve_smg_unit.py
+++ b/test/cli/test_serve_smg_unit.py
@@ -147,6 +147,7 @@ def test_gateway_args_defaults_include_port_and_reasoning_parser():
         "passthrough",
         "--disable-circuit-breaker",
         "--disable-retries",
+        "--disable-health-check",
         "--policy",
         "passthrough",
         "--tokenizer-cache-enable-l0",
@@ -219,6 +220,7 @@ def test_smg_disable_flags_appended_when_absent():
         "/tmp/x",
         "--disable-circuit-breaker",
         "--disable-retries",
+        "--disable-health-check",
     ]
 
 
@@ -231,6 +233,7 @@ def test_smg_disable_flags_not_duplicated():
     assert gateway_args == [
         "--disable-circuit-breaker",
         "--disable-retries",
+        "--disable-health-check",
     ]
 
 
@@ -238,6 +241,7 @@ def test_smg_disable_flag_set_covers_both():
     assert _DEFAULT_SMG_DISABLE_FLAGS == (
         "--disable-circuit-breaker",
         "--disable-retries",
+        "--disable-health-check",
     )
 
 

--- a/test/runtime/layers/test_moe_topk.py
+++ b/test/runtime/layers/test_moe_topk.py
@@ -4,7 +4,11 @@ import pytest
 import torch
 
 from tokenspeed.runtime.layers.moe import topk as topk_module
-from tokenspeed.runtime.layers.moe.topk import TopKConfig, select_experts
+from tokenspeed.runtime.layers.moe.topk import (
+    TopKConfig,
+    select_experts,
+    torch_native_fused_topk,
+)
 
 
 @pytest.mark.parametrize("renormalize", [False, True])
@@ -45,3 +49,47 @@ def test_correction_bias_route_forwards_renormalize(
     )
 
     assert calls == [renormalize]
+
+
+def test_torch_native_fused_topk_breaks_exact_ties_by_expert_order() -> None:
+    hidden_states = torch.zeros((2, 1), dtype=torch.float32)
+    router_logits = torch.tensor(
+        [
+            [0.0, 0.0, 0.0, 0.0],
+            [2.0, 1.0, 2.0, 1.0],
+        ],
+        dtype=torch.float32,
+    )
+
+    topk_weights, topk_ids = torch_native_fused_topk(
+        hidden_states,
+        router_logits,
+        topk=2,
+        renormalize=True,
+    )
+
+    torch.testing.assert_close(topk_ids, torch.tensor([[0, 1], [0, 2]]))
+    torch.testing.assert_close(
+        topk_weights,
+        torch.full((2, 2), 0.5, dtype=torch.float32),
+    )
+
+
+def test_torch_native_fused_topk_uses_biased_scores_only_for_choice() -> None:
+    hidden_states = torch.zeros((1, 1), dtype=torch.float32)
+    router_logits = torch.zeros((1, 4), dtype=torch.float32)
+    correction_bias = torch.tensor([0.2, 0.1, 0.2, 0.0], dtype=torch.float32)
+
+    topk_weights, topk_ids = torch_native_fused_topk(
+        hidden_states,
+        router_logits,
+        topk=2,
+        renormalize=True,
+        correction_bias=correction_bias,
+    )
+
+    torch.testing.assert_close(topk_ids, torch.tensor([[0, 2]]))
+    torch.testing.assert_close(
+        topk_weights,
+        torch.tensor([[0.5, 0.5]], dtype=torch.float32),
+    )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/__init__.py
@@ -21,3 +21,4 @@
 import tokenspeed_kernel.ops.moe.triton.fp8  # noqa: F401
 import tokenspeed_kernel.ops.moe.triton.inkling_topk  # noqa: F401
 import tokenspeed_kernel.ops.moe.triton.mxfp4  # noqa: F401
+import tokenspeed_kernel.ops.moe.triton.unquant  # noqa: F401

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/unquant.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/unquant.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel._triton import redirect_triton_to_tokenspeed_triton
+from tokenspeed_kernel.platform import CapabilityRequirement
+from tokenspeed_kernel.registry import Priority, register_kernel
+from tokenspeed_kernel.signature import format_signatures
+
+with redirect_triton_to_tokenspeed_triton():
+    import triton_kernels  # noqa: F401
+    import triton_kernels.matmul  # noqa: F401
+    import triton_kernels.tensor  # noqa: F401
+    import triton_kernels.tensor_details  # noqa: F401
+    import triton_kernels.tensor_details.layout  # noqa: F401
+    import triton_kernels.topk  # noqa: F401
+
+from tokenspeed_kernel.ops.moe.triton.mxfp4 import (
+    _local_topk_for_ep,
+    _release_parameter,
+    _routing_from_topk,
+    _silu_gate_up,
+)
+from triton_kernels.matmul import FnSpecs, FusedActivation, matmul
+from triton_kernels.swiglu import swiglu_fn
+
+
+def triton_unquant_moe_weights(plan: dict, w: torch.nn.Module):
+    w.w13_weight_triton_tensor = w.w13_weight.transpose(-2, -1).contiguous()
+    w.w2_weight_triton_tensor = w.w2_weight.transpose(-2, -1).contiguous()
+
+    _release_parameter(w, "w13_weight")
+    _release_parameter(w, "w2_weight")
+    torch.cuda.empty_cache()
+
+
+@register_kernel(
+    "moe",
+    "apply",
+    name="triton_unquant_precomputed_moe_apply",
+    solution="triton",
+    weight_preprocessor=triton_unquant_moe_weights,
+    capability=CapabilityRequirement(vendors=frozenset({"amd"})),
+    signatures=format_signatures(
+        "x",
+        "dense",
+        {torch.float16, torch.bfloat16},
+    ),
+    traits={
+        "weight_dtype": frozenset({"unquant"}),
+        "activation": frozenset({"silu"}),
+        "routing_mode": frozenset({"precomputed_topk"}),
+        "supports_deferred_finalize": frozenset({False}),
+        "supports_ep": frozenset({False}),
+        "supports_all_to_all_ep": frozenset({False}),
+        "ispp_alignment": frozenset({1}),
+        "internal_activation_dtype": frozenset({"input"}),
+        "supports_bias": frozenset({False}),
+    },
+    priority=Priority.PORTABLE + 1,
+)
+@register_kernel(
+    "moe",
+    "apply",
+    name="triton_unquant_ep_precomputed_moe_apply",
+    solution="triton",
+    weight_preprocessor=triton_unquant_moe_weights,
+    capability=CapabilityRequirement(vendors=frozenset({"amd"})),
+    signatures=format_signatures(
+        "x",
+        "dense",
+        {torch.float16, torch.bfloat16},
+    ),
+    traits={
+        "weight_dtype": frozenset({"unquant"}),
+        "activation": frozenset({"silu"}),
+        "routing_mode": frozenset({"precomputed_topk"}),
+        "supports_deferred_finalize": frozenset({False}),
+        "supports_ep": frozenset({True}),
+        "supports_all_to_all_ep": frozenset({False}),
+        "ispp_alignment": frozenset({1}),
+        "internal_activation_dtype": frozenset({"input"}),
+        "supports_bias": frozenset({False}),
+    },
+    priority=Priority.PORTABLE,
+)
+def triton_unquant_moe_apply(
+    plan: dict,
+    x: torch.Tensor,
+    w: torch.nn.Module,
+    router_logits: torch.Tensor,
+    topk_weights: torch.Tensor | None = None,
+    topk_ids: torch.Tensor | None = None,
+    num_tokens_global: int | None = None,
+    max_num_tokens_per_gpu: int | None = None,
+    do_finalize: bool = True,
+    enable_pdl: bool = False,
+) -> torch.Tensor:
+    del plan, num_tokens_global, max_num_tokens_per_gpu, enable_pdl
+    if not do_finalize:
+        raise RuntimeError("triton unquant MoE does not support deferred finalize")
+    if topk_weights is None or topk_ids is None:
+        raise RuntimeError(
+            "triton unquant MoE requires precomputed topk_weights/topk_ids"
+        )
+    if topk_weights.shape != topk_ids.shape:
+        raise RuntimeError(
+            "topk_weights and topk_ids must have the same shape, got "
+            f"{tuple(topk_weights.shape)} and {tuple(topk_ids.shape)}"
+        )
+
+    top_k = getattr(w, "top_k", topk_ids.shape[1])
+    n_tokens = x.shape[0]
+    topk_weights, topk_ids, num_experts = _local_topk_for_ep(
+        topk_weights,
+        topk_ids,
+        w,
+    )
+    ragged_metadata, gather_indx, scatter_indx, gate_scal = _routing_from_topk(
+        topk_weights,
+        topk_ids,
+        num_experts=num_experts,
+        dtype=router_logits.dtype,
+    )
+
+    swiglu_arg = getattr(w, "swiglu_arg", None)
+    act = None
+    if swiglu_arg is not None:
+        act = FusedActivation(
+            FnSpecs("swiglu", swiglu_fn, ("alpha", "limit"), reduction_n=2),
+            (swiglu_arg.alpha, swiglu_arg.limit),
+        )
+
+    intermediate_cache = matmul(
+        x,
+        w.w13_weight_triton_tensor,
+        None,
+        a_ragged_metadata=ragged_metadata,
+        gather_indx=gather_indx,
+        fused_activation=act,
+    )
+    if act is None:
+        intermediate_cache = _silu_gate_up(
+            intermediate_cache,
+            output_dtype=x.dtype,
+        )
+
+    output = matmul(
+        intermediate_cache,
+        w.w2_weight_triton_tensor,
+        None,
+        a_ragged_metadata=ragged_metadata,
+        scatter_indx=scatter_indx,
+        gammas=gate_scal,
+    )
+    if top_k > 1:
+        return output.view(n_tokens, top_k, output.shape[-1]).sum(dim=1)
+    return output

--- a/tokenspeed-kernel/test/ops/test_moe.py
+++ b/tokenspeed-kernel/test/ops/test_moe.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import importlib
+
+import tokenspeed_kernel
+import torch
+import torch.nn.functional as F
+from tokenspeed_kernel.ops.moe.triton import unquant as _triton_unquant
+
+
+def _torch_unquant_moe_reference(
+    x: torch.Tensor,
+    w13_weight: torch.Tensor,
+    w2_weight: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+) -> torch.Tensor:
+    out = torch.zeros_like(x, dtype=torch.float32)
+    for token_idx in range(x.shape[0]):
+        for topk_idx in range(topk_ids.shape[1]):
+            expert_id = int(topk_ids[token_idx, topk_idx])
+            gate_up = F.linear(x[token_idx].float(), w13_weight[expert_id].float())
+            gate, up = gate_up.chunk(2, dim=-1)
+            down = F.linear(F.silu(gate) * up, w2_weight[expert_id].float())
+            out[token_idx] += topk_weights[token_idx, topk_idx].float() * down
+    return out.to(x.dtype)
+
+
+def test_triton_unquant_moe_matches_torch_reference(device: str, require) -> None:
+    # MTP draft experts are bf16; this verifies the registry path and weight layout.
+    importlib.reload(_triton_unquant)
+    require("moe", "apply", "triton", torch.bfloat16, "x")
+
+    torch.manual_seed(1234)
+    num_tokens = 5
+    hidden_size = 16
+    intermediate_size = 32
+    num_experts = 4
+    top_k = 2
+    dtype = torch.bfloat16
+
+    x = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype) * 0.1
+    w13_weight = (
+        torch.randn(
+            num_experts,
+            2 * intermediate_size,
+            hidden_size,
+            device=device,
+            dtype=dtype,
+        )
+        * 0.1
+    )
+    w2_weight = (
+        torch.randn(
+            num_experts,
+            hidden_size,
+            intermediate_size,
+            device=device,
+            dtype=dtype,
+        )
+        * 0.1
+    )
+    topk_ids = torch.tensor(
+        [[0, 1], [2, 3], [1, 2], [3, 0], [0, 2]],
+        device=device,
+        dtype=torch.int64,
+    )
+    topk_weights = torch.tensor(
+        [[0.7, 0.3], [0.6, 0.4], [0.8, 0.2], [0.5, 0.5], [0.9, 0.1]],
+        device=device,
+        dtype=torch.float32,
+    )
+
+    plan = tokenspeed_kernel.moe_plan(
+        "unquant",
+        input_dtype=dtype,
+        activation="silu",
+        ep_size=1,
+        ispp=intermediate_size,
+        solution="triton",
+    )
+    assert plan["apply_kernel_name"] == "triton_unquant_precomputed_moe_apply"
+
+    w = torch.nn.Module()
+    w.top_k = top_k
+    w.num_experts = num_experts
+    w.num_local_experts = num_experts
+    w.ep_size = 1
+    w.ep_rank = 0
+    w.w13_weight = torch.nn.Parameter(w13_weight.clone(), requires_grad=False)
+    w.w2_weight = torch.nn.Parameter(w2_weight.clone(), requires_grad=False)
+    tokenspeed_kernel.moe_process_weights(plan, w)
+
+    out = tokenspeed_kernel.moe_apply(
+        plan,
+        x,
+        w,
+        torch.empty(num_tokens, num_experts, device=device, dtype=torch.float32),
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+    )
+    ref = _torch_unquant_moe_reference(
+        x,
+        w13_weight,
+        w2_weight,
+        topk_weights,
+        topk_ids,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(out.float(), ref.float(), rtol=2e-2, atol=2e-2)

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -93,6 +93,7 @@ from tokenspeed_kernel.ops.moe.flashinfer import trtllm_unquant as _moe_trtllm_u
 from tokenspeed_kernel.ops.moe.gluon import mxfp4 as _moe_gluon_mxfp4
 from tokenspeed_kernel.ops.moe.triton import fp8 as _moe_triton_fp8
 from tokenspeed_kernel.ops.moe.triton import mxfp4 as _moe_triton_mxfp4
+from tokenspeed_kernel.ops.moe.triton import unquant as _moe_triton_unquant
 from tokenspeed_kernel.platform import ArchVersion, Platform, PlatformInfo
 from tokenspeed_kernel.registry import KernelRegistry
 from tokenspeed_kernel.selection import SelectedKernel
@@ -139,6 +140,7 @@ _RELOAD_MODULES = [
     _moe_gluon,
     _moe_triton_fp8,
     _moe_triton_mxfp4,
+    _moe_triton_unquant,
     _moe_triton,
     _moe_pkg,
     # Quantization registration modules.
@@ -1658,6 +1660,35 @@ def _moe_apply_mxfp4_precomputed_ep() -> object:
     )
 
 
+def _moe_apply_unquant_precomputed_tp() -> object:
+    plan = tokenspeed_kernel.moe_plan(
+        "unquant",
+        input_dtype=torch.bfloat16,
+        activation="silu",
+        ep_size=1,
+        ispp=256,
+        internal_activation_dtype="input",
+        solution="triton",
+    )
+    _assert_moe_plan(
+        plan,
+        apply="triton_unquant_precomputed_moe_apply",
+        preprocessor="triton_unquant_moe_weights",
+    )
+    x = torch.empty((4, 16), dtype=torch.bfloat16)
+    router_logits = torch.empty((4, 8), dtype=torch.float32)
+    topk_weights = torch.empty((4, 2), dtype=torch.float32)
+    topk_ids = torch.empty((4, 2), dtype=torch.int64)
+    return tokenspeed_kernel.moe_apply(
+        plan,
+        x,
+        torch.nn.Module(),
+        router_logits,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+    )
+
+
 def test_mxfp4_ep_topk_localization_masks_remote_experts() -> None:
     w = torch.nn.Module()
     w.num_experts = 8
@@ -2168,6 +2199,14 @@ _CASES = [
         "apply",
         "triton_fp8_ep_precomputed_moe_apply",
         _moe_apply_fp8_precomputed_ep,
+    ),
+    _case(
+        _is_cdna4,
+        "cdna4",
+        "moe",
+        "apply",
+        "triton_unquant_precomputed_moe_apply",
+        _moe_apply_unquant_precomputed_tp,
     ),
 ]
 


### PR DESCRIPTION
## Summary

Enables Multi-Token Prediction (MTP / speculative decoding) for **Qwen3.5-397B-A17B MXFP4 on AMD**. The MXFP4 checkpoint keeps its MTP/NextN draft branch in bf16 even though the target model is MXFP4, so the draft path needs an unquantized MoE apply kernel that AMD did not previously have. This PR adds that path, wires the draft branch through the existing kernel-registry boundary, and stabilizes MoE routing so greedy MTP stays target-equivalent.

## Key changes and why

**1. AMD Triton unquant MoE draft path** (`tokenspeed-kernel/.../ops/moe/triton/unquant.py`)
- Adds a registry-selected unquant MoE apply kernel for precomputed top-k routing on AMD.
- Reuses the existing MXFP4 ragged-matmul routing flow and transposes dense expert weights into the `[expert, K, N]` layout consumed by `triton_kernels.matmul`.
- Registers TP and EP precomputed-topk variants.
- *Why:* the bf16 draft branch had no registry path on AMD; this lets the draft model load/execute through the same boundary as the rest of MoE instead of a runtime special case.

**2. Treat the mxfp4 draft branch as unquantized** (`qwen3_5_nextn.py`)
- The MTP branch is dense bf16 in both nvfp4 and mxfp4 checkpoints; treating it as quantized wrongly selected MXFP4 expert weights.
- *Why:* fixes draft-model construction for MXFP4 targets.

**3. Deterministic MoE routing under MTP** (`runtime/layers/moe/topk.py`)
- Native top-k helper now resolves exact routing ties with a stable descending sort for both normal and bias-corrected routing.
- *Why:* MTP changes target-verify batch shape from `batch_size` to `batch_size * draft_width` rows, which can perturb expert selection on exact ties. The Triton MXFP4 precomputed MoE path consumes these ids directly, so stable ids are required for MTP/non-MTP target equivalence.

**4. Disable SMG health checks under `ts serve` by default** (`cli/serve_smg.py`)
- *Why:* the gateway health probe was being scheduled as real `HEALTH_CHECK_*` generation work during long eval batches, changing batch composition while measuring deterministic greedy evals.

**5. CI eval exercises MTP** (`test/ci/eval/qwen3.5-397b-a17b-mxfp4-evalscope-aime25.yaml`)
- Adds `--speculative-algorithm MTP --speculative-num-steps 3 --speculative-num-draft-tokens 4 --speculative-draft-model-quantization unquant` and disables thinking traces in the chat template to measure the faster speculative path.

**6. Tests**
- Kernel-selection coverage + a torch-reference test for the bf16 unquant MoE layout.
- Top-k tie contract tests (exact-tie and bias-corrected) in `test/runtime/layers/test_moe_topk.py`.
- Gateway-args test for the health-check default.

## Local validation (TP=4, Qwen3.5-397B-A17B MXFP4)

- AIME25 limit-8: **score 1.0** with `enable_thinking=false` (~3.5 min) and **1.0** with thinking on (~6 min).
- MTP accept length ~3.3–3.7 of 4 draft tokens; accept rate ~0.85.
- Avg TPOT ~13 ms (thinking off) / ~15 ms (thinking on).

## Known limitations (why WIP)

- The stable-sort fix only guarantees **exact-tie** determinism. **Near-tie** batch-shape invariance is still open (identical concurrent requests can diverge in trajectory while remaining correct) — tracked as production work.
- The stable full sort is O(E log E); a deterministic O(E log K) top-k is the preferred production form.
- Only the torch-native routing path is covered; other routing paths (grouped/CUDA/flashinfer) are not yet audited to the same tie contract.
- Disabling SMG health checks is a mitigation; the health probe should instead be excluded from scheduler batch composition.

## Test plan

- [ ] TP=4 Qwen3.5 397B MXFP4 AIME25 limit-8 MTP eval meets threshold in CI
- [ ] Unit tests pass (MoE top-k tie contract, unquant MoE torch reference, kernel selection, gateway args)
- [ ] No `HEALTH_CHECK_*` generation requests during `ts serve` eval after readiness