### PR TITLE
[wip] refactor(kernel): migrate GDN Triton kernels to tensor descriptors

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/_triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/_triton.py
@@ -40,6 +40,7 @@ from tokenspeed_triton.tools.tensor_descriptor import TensorDescriptor
 __all__ = [
     "aggregate",
     "TensorDescriptor",
+    "ensure_descriptor_allocator",
     "gl",
     "gluon",
     "libdevice",
@@ -48,6 +49,32 @@ __all__ = [
     "tl",
     "triton",
 ]
+
+
+_DESCRIPTOR_ALLOCATOR_SET = False
+
+
+def _descriptor_scratch_allocator(size: int, alignment: int, stream):
+    """Torch-backed scratch allocator for on-device tensor descriptors."""
+    import torch
+
+    return torch.empty(size, device="cuda", dtype=torch.int8)
+
+
+def ensure_descriptor_allocator() -> None:
+    """Register a global scratch allocator for on-device tensor descriptors.
+
+    ``tl.make_tensor_descriptor`` needs a global-memory scratch buffer for the
+    descriptor object, which Triton requests through a process-global allocator
+    callback. Kernels that build descriptors in-kernel must call this once
+    before launch. The registration is idempotent so repeated calls (and
+    multiple kernel families) share a single torch-backed allocator.
+    """
+    global _DESCRIPTOR_ALLOCATOR_SET
+    if _DESCRIPTOR_ALLOCATOR_SET:
+        return
+    triton.set_allocator(_descriptor_scratch_allocator)
+    _DESCRIPTOR_ALLOCATOR_SET = True
 
 
 _TRITON_SRC = "triton"

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/linear/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/linear/__init__.py
@@ -16,3 +16,10 @@
 # SOFTWARE.
 
 """FLA-derived Triton helpers vendored for GDN chunk prefill."""
+
+from tokenspeed_kernel._triton import ensure_descriptor_allocator
+
+# These kernels build tensor descriptors in-kernel via tl.make_tensor_descriptor,
+# which needs a process-global scratch allocator. Register it when the package is
+# imported so any kernel here can launch without a per-call setup step.
+ensure_descriptor_allocator()

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/linear/chunk_delta_h.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/linear/chunk_delta_h.py
@@ -114,87 +114,63 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
 
     # load initial state
     if USE_INITIAL_STATE:
-        p_h0_1 = tl.make_block_ptr(h0, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        b_h1 += tl.load(p_h0_1, boundary_check=(0, 1)).to(tl.float32)
+        p_h0_1 = tl.make_tensor_descriptor(h0, (K, V), (V, 1), (64, BV))
+        b_h1 += p_h0_1.load([0, i_v * BV]).to(tl.float32)
         if K > 64:
-            p_h0_2 = tl.make_block_ptr(
-                h0, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
-            )
-            b_h2 += tl.load(p_h0_2, boundary_check=(0, 1)).to(tl.float32)
+            p_h0_2 = tl.make_tensor_descriptor(h0, (K, V), (V, 1), (64, BV))
+            b_h2 += p_h0_2.load([64, i_v * BV]).to(tl.float32)
         if K > 128:
-            p_h0_3 = tl.make_block_ptr(
-                h0, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
-            )
-            b_h3 += tl.load(p_h0_3, boundary_check=(0, 1)).to(tl.float32)
+            p_h0_3 = tl.make_tensor_descriptor(h0, (K, V), (V, 1), (64, BV))
+            b_h3 += p_h0_3.load([128, i_v * BV]).to(tl.float32)
         if K > 192:
-            p_h0_4 = tl.make_block_ptr(
-                h0, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
-            )
-            b_h4 += tl.load(p_h0_4, boundary_check=(0, 1)).to(tl.float32)
+            p_h0_4 = tl.make_tensor_descriptor(h0, (K, V), (V, 1), (64, BV))
+            b_h4 += p_h0_4.load([192, i_v * BV]).to(tl.float32)
 
     # main recurrence
     for i_t in range(NT):
-        p_h1 = tl.make_block_ptr(
-            h + i_t * stride_h, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0)
-        )
-        tl.store(p_h1, b_h1.to(p_h1.dtype.element_ty), boundary_check=(0, 1))
+        p_h1 = tl.make_tensor_descriptor(h + i_t * stride_h, (K, V), (V, 1), (64, BV))
+        p_h1.store([0, i_v * BV], b_h1.to(p_h1.dtype))
         if K > 64:
-            p_h2 = tl.make_block_ptr(
-                h + i_t * stride_h, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
+            p_h2 = tl.make_tensor_descriptor(
+                h + i_t * stride_h, (K, V), (V, 1), (64, BV)
             )
-            tl.store(p_h2, b_h2.to(p_h2.dtype.element_ty), boundary_check=(0, 1))
+            p_h2.store([64, i_v * BV], b_h2.to(p_h2.dtype))
         if K > 128:
-            p_h3 = tl.make_block_ptr(
-                h + i_t * stride_h, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
+            p_h3 = tl.make_tensor_descriptor(
+                h + i_t * stride_h, (K, V), (V, 1), (64, BV)
             )
-            tl.store(p_h3, b_h3.to(p_h3.dtype.element_ty), boundary_check=(0, 1))
+            p_h3.store([128, i_v * BV], b_h3.to(p_h3.dtype))
         if K > 192:
-            p_h4 = tl.make_block_ptr(
-                h + i_t * stride_h, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
+            p_h4 = tl.make_tensor_descriptor(
+                h + i_t * stride_h, (K, V), (V, 1), (64, BV)
             )
-            tl.store(p_h4, b_h4.to(p_h4.dtype.element_ty), boundary_check=(0, 1))
+            p_h4.store([192, i_v * BV], b_h4.to(p_h4.dtype))
 
-        p_w = tl.make_block_ptr(
-            w, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, 64), (1, 0)
-        )
-        b_w = tl.load(p_w, boundary_check=(0, 1))
+        p_w = tl.make_tensor_descriptor(w, (T, K), (stride_w, 1), (BT, 64))
+        b_w = p_w.load([i_t * BT, 0])
         b_v = tl.dot(b_w, b_h1.to(b_w.dtype))
         if K > 64:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_w, 1), (i_t * BT, 64), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_w = p_w.load([i_t * BT, 64])
             b_v += tl.dot(b_w, b_h2.to(b_w.dtype))
         if K > 128:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_w, 1), (i_t * BT, 128), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_w = p_w.load([i_t * BT, 128])
             b_v += tl.dot(b_w, b_h3.to(b_w.dtype))
         if K > 192:
-            p_w = tl.make_block_ptr(
-                w, (T, K), (stride_w, 1), (i_t * BT, 192), (BT, 64), (1, 0)
-            )
-            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_w = p_w.load([i_t * BT, 192])
             b_v += tl.dot(b_w, b_h4.to(b_w.dtype))
-        p_v = tl.make_block_ptr(
-            v, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-        )
-        b_v = tl.load(p_v, boundary_check=(0, 1)) - b_v
+        p_v = tl.make_tensor_descriptor(v, (T, V), (stride_v, 1), (BT, BV))
+        b_v = p_v.load([i_t * BT, i_v * BV]) - b_v
 
         if SAVE_NEW_VALUE:
-            p_v = tl.make_block_ptr(
-                v_new, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-            )
-            tl.store(p_v, b_v.to(p_v.dtype.element_ty), boundary_check=(0, 1))
+            p_vn = tl.make_tensor_descriptor(v_new, (T, V), (stride_v, 1), (BT, BV))
+            p_vn.store([i_t * BT, i_v * BV], b_v.to(p_vn.dtype))
 
         last_idx = min((i_t + 1) * BT, T) - 1
         if USE_G:
             b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
-            p_g = tl.make_block_ptr(
-                g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
-            )
-            b_g = tl.load(p_g, boundary_check=(0,))
+            # ``g`` is one scalar per token (stride H); use a masked load.
+            o_g = i_t * BT + tl.arange(0, BT)
+            b_g = tl.load(g + bos * H + i_h + o_g * H, mask=o_g < T, other=0.0)
             b_v = b_v * safe_exp(b_g_last - b_g)[:, None]
             b_g_last = exp(b_g_last)
             b_h1 = b_h1 * b_g_last
@@ -239,49 +215,34 @@ def chunk_gated_delta_rule_fwd_kernel_h_blockdim64(
                 b_h4 *= exp(b_gk_last4)[:, None]
         b_v = b_v.to(k.dtype.element_ty)
 
-        p_k = tl.make_block_ptr(
-            k, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1)
-        )
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        # ``k`` is consumed transposed ([64, BT]); descriptors need a contiguous
+        # innermost dim, so load the natural [BT, 64] layout and transpose.
+        p_k = tl.make_tensor_descriptor(k, (T, K), (stride_k, 1), (BT, 64))
+        b_k = tl.trans(p_k.load([i_t * BT, 0]))
         b_h1 += tl.dot(b_k, b_v)
         if K > 64:
-            p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_k = tl.trans(p_k.load([i_t * BT, 64]))
             b_h2 += tl.dot(b_k, b_v)
         if K > 128:
-            p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_k = tl.trans(p_k.load([i_t * BT, 128]))
             b_h3 += tl.dot(b_k, b_v)
         if K > 192:
-            p_k = tl.make_block_ptr(
-                k, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1)
-            )
-            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_k = tl.trans(p_k.load([i_t * BT, 192]))
             b_h4 += tl.dot(b_k, b_v)
 
     # epilogue
     if STORE_FINAL_STATE:
-        p_ht = tl.make_block_ptr(ht, (K, V), (V, 1), (0, i_v * BV), (64, BV), (1, 0))
-        tl.store(p_ht, b_h1.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+        p_ht = tl.make_tensor_descriptor(ht, (K, V), (V, 1), (64, BV))
+        p_ht.store([0, i_v * BV], b_h1.to(p_ht.dtype))
         if K > 64:
-            p_ht = tl.make_block_ptr(
-                ht, (K, V), (V, 1), (64, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_ht, b_h2.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = tl.make_tensor_descriptor(ht, (K, V), (V, 1), (64, BV))
+            p_ht.store([64, i_v * BV], b_h2.to(p_ht.dtype))
         if K > 128:
-            p_ht = tl.make_block_ptr(
-                ht, (K, V), (V, 1), (128, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_ht, b_h3.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = tl.make_tensor_descriptor(ht, (K, V), (V, 1), (64, BV))
+            p_ht.store([128, i_v * BV], b_h3.to(p_ht.dtype))
         if K > 192:
-            p_ht = tl.make_block_ptr(
-                ht, (K, V), (V, 1), (192, i_v * BV), (64, BV), (1, 0)
-            )
-            tl.store(p_ht, b_h4.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+            p_ht = tl.make_tensor_descriptor(ht, (K, V), (V, 1), (64, BV))
+            p_ht.store([192, i_v * BV], b_h4.to(p_ht.dtype))
 
 
 def chunk_gated_delta_rule_fwd_h(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/linear/chunk_o.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/linear/chunk_o.py
@@ -88,21 +88,18 @@ def chunk_fwd_kernel_o(
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_q = tl.make_block_ptr(
-            q, (T, K), (Hg * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
-        )
-        p_k = tl.make_block_ptr(
-            k, (K, T), (1, Hg * K), (i_k * BK, i_t * BT), (BK, BT), (0, 1)
-        )
-        p_h = tl.make_block_ptr(
-            h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0)
-        )
+        p_q = tl.make_tensor_descriptor(q, (T, K), (Hg * K, 1), (BT, BK))
+        # ``k`` is consumed transposed ([BK, BT]); descriptors require a
+        # contiguous innermost dim, so load it in its natural [BT, BK] layout
+        # and transpose in-register.
+        p_k = tl.make_tensor_descriptor(k, (T, K), (Hg * K, 1), (BT, BK))
+        p_h = tl.make_tensor_descriptor(h, (K, V), (V, 1), (BK, BV))
         # [BT, BK]
-        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = p_q.load([i_t * BT, i_k * BK])
         # [BK, BT]
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = tl.trans(p_k.load([i_t * BT, i_k * BK]))
         # [BK, BV]
-        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_h = p_h.load([i_k * BK, i_v * BV])
 
         # [BT, BK] @ [BK, BV] -> [BT, BV]
         b_o += tl.dot(b_q, b_h)
@@ -111,8 +108,10 @@ def chunk_fwd_kernel_o(
 
     if USE_G:
         g += bos * H + i_h
-        p_g = tl.make_block_ptr(g, (T,), (H,), (i_t * BT,), (BT,), (0,))
-        b_g = tl.load(p_g, boundary_check=(0,))
+        # ``g`` is one scalar per token (stride H), not contiguous; use a
+        # masked pointer load rather than a descriptor.
+        o_g = i_t * BT + tl.arange(0, BT)
+        b_g = tl.load(g + o_g * H, mask=o_g < T, other=0.0)
         b_o = b_o * exp(b_g)[:, None]
         b_A = b_A * safe_exp(b_g[:, None] - b_g[None, :])
 
@@ -120,18 +119,14 @@ def chunk_fwd_kernel_o(
     m_A = o_i[:, None] >= o_i[None, :]
     b_A = tl.where(m_A, b_A, 0)
 
-    p_v = tl.make_block_ptr(
-        v, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-    )
-    p_o = tl.make_block_ptr(
-        o, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
-    )
-    b_v = tl.load(p_v, boundary_check=(0, 1))
+    p_v = tl.make_tensor_descriptor(v, (T, V), (H * V, 1), (BT, BV))
+    p_o = tl.make_tensor_descriptor(o, (T, V), (H * V, 1), (BT, BV))
+    b_v = p_v.load([i_t * BT, i_v * BV])
 
     # to fix mma -> mma layout conversion
     # already solved by triton v3.2 or higher
     b_o = b_o * scale + tl.dot(b_A.to(b_v.dtype), b_v) * scale
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    p_o.store([i_t * BT, i_v * BV], b_o.to(p_o.dtype))
 
 
 def chunk_fwd_o(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/linear/chunk_scaled_dot_kkt.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/linear/chunk_scaled_dot_kkt.py
@@ -67,39 +67,36 @@ def chunk_scaled_dot_kkt_fwd_kernel(
     else:
         bos, eos = i_b * T, i_b * T + T
     o_t = tl.arange(0, BT)
+    # ``beta``/``g`` are gathered with stride ``H`` (one scalar per token), which
+    # is not a contiguous innermost dimension, so tensor descriptors do not
+    # apply; use masked pointer loads for these 1D strided vectors.
+    o_row = i_t * BT + o_t
+    m_row = o_row < T
 
-    p_beta = tl.make_block_ptr(
-        beta + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
-    )
-    b_beta = tl.load(p_beta, boundary_check=(0,))
+    b_beta = tl.load(beta + bos * H + i_h + o_row * H, mask=m_row, other=0.0)
 
     b_A = tl.zeros([BT, BT], dtype=tl.float32)
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(
+        p_k = tl.make_tensor_descriptor(
             k + (bos * Hg + i_h // (H // Hg)) * K,
             (T, K),
             (Hg * K, 1),
-            (i_t * BT, i_k * BK),
             (BT, BK),
-            (1, 0),
         )
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = p_k.load([i_t * BT, i_k * BK])
         b_kb = b_k * b_beta[:, None]
         b_A += tl.dot(b_kb.to(b_k.dtype), tl.trans(b_k))
 
     if USE_G:
-        p_g = tl.make_block_ptr(
-            g_cumsum + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
-        )
-        b_g = tl.load(p_g, boundary_check=(0,))
+        b_g = tl.load(g_cumsum + bos * H + i_h + o_row * H, mask=m_row, other=0.0)
         b_g_diff = b_g[:, None] - b_g[None, :]
         b_A = b_A * safe_exp(b_g_diff)
 
     b_A = tl.where(o_t[:, None] > o_t[None, :], b_A, 0)
-    p_A = tl.make_block_ptr(
-        A + (bos * H + i_h) * BT, (T, BT), (BT * H, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+    p_A = tl.make_tensor_descriptor(
+        A + (bos * H + i_h) * BT, (T, BT), (BT * H, 1), (BT, BT)
     )
-    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+    p_A.store([i_t * BT, 0], b_A.to(p_A.dtype))
 
 
 def chunk_scaled_dot_kkt_fwd(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/linear/cumsum.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/linear/cumsum.py
@@ -71,25 +71,26 @@ def chunk_local_cumsum_scalar_kernel(
     else:
         bos, eos = i_b * T, i_b * T + T
 
+    # Scalar gate is a 1D per-token vector; tensor descriptors need a contiguous
+    # innermost dim which does not hold in the non-head-first (stride H) layout,
+    # so use masked pointer loads for both layouts.
+    o_row = i_t * BT + tl.arange(0, BT)
+    m_row = o_row < T
     if HEAD_FIRST:
-        p_s = tl.make_block_ptr(
-            s + bos * H + i_h * T, (T,), (1,), (i_t * BT,), (BT,), (0,)
-        )
-        p_o = tl.make_block_ptr(
-            o + bos * H + i_h * T, (T,), (1,), (i_t * BT,), (BT,), (0,)
-        )
+        p_s = s + bos * H + i_h * T + o_row
+        p_o = o + bos * H + i_h * T + o_row
     else:
-        p_s = tl.make_block_ptr(s + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
-        p_o = tl.make_block_ptr(o + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+        p_s = s + bos * H + i_h + o_row * H
+        p_o = o + bos * H + i_h + o_row * H
     # [BT]
-    b_s = tl.load(p_s, boundary_check=(0,)).to(tl.float32)
+    b_s = tl.load(p_s, mask=m_row, other=0.0).to(tl.float32)
     b_o = tl.cumsum(b_s, axis=0)
     if REVERSE:
         b_z = tl.sum(b_s, axis=0)
         b_o = -b_o + b_z[None] + b_s
     if HAS_SCALE:
         b_o *= scale
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_row)
 
 
 @triton.heuristics(
@@ -144,45 +145,25 @@ def chunk_local_cumsum_vector_kernel(
         m_s = tl.where(o_i[:, None] >= o_i[None, :], 1.0, 0.0)
 
     if HEAD_FIRST:
-        p_s = tl.make_block_ptr(
-            s + (bos * H + i_h * T) * S,
-            (T, S),
-            (S, 1),
-            (i_t * BT, i_s * BS),
-            (BT, BS),
-            (1, 0),
+        p_s = tl.make_tensor_descriptor(
+            s + (bos * H + i_h * T) * S, (T, S), (S, 1), (BT, BS)
         )
-        p_o = tl.make_block_ptr(
-            o + (bos * H + i_h * T) * S,
-            (T, S),
-            (S, 1),
-            (i_t * BT, i_s * BS),
-            (BT, BS),
-            (1, 0),
+        p_o = tl.make_tensor_descriptor(
+            o + (bos * H + i_h * T) * S, (T, S), (S, 1), (BT, BS)
         )
     else:
-        p_s = tl.make_block_ptr(
-            s + (bos * H + i_h) * S,
-            (T, S),
-            (H * S, 1),
-            (i_t * BT, i_s * BS),
-            (BT, BS),
-            (1, 0),
+        p_s = tl.make_tensor_descriptor(
+            s + (bos * H + i_h) * S, (T, S), (H * S, 1), (BT, BS)
         )
-        p_o = tl.make_block_ptr(
-            o + (bos * H + i_h) * S,
-            (T, S),
-            (H * S, 1),
-            (i_t * BT, i_s * BS),
-            (BT, BS),
-            (1, 0),
+        p_o = tl.make_tensor_descriptor(
+            o + (bos * H + i_h) * S, (T, S), (H * S, 1), (BT, BS)
         )
     # [BT, BS]
-    b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+    b_s = p_s.load([i_t * BT, i_s * BS]).to(tl.float32)
     b_o = tl.dot(m_s, b_s, allow_tf32=False)
     if HAS_SCALE:
         b_o *= scale
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    p_o.store([i_t * BT, i_s * BS], b_o.to(p_o.dtype))
 
 
 def chunk_local_cumsum_scalar(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/linear/l2norm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/linear/l2norm.py
@@ -65,12 +65,12 @@ def l2norm_fwd_kernel(
     BD: tl.constexpr,
 ):
     i_t = tl.program_id(0)
-    p_x = tl.make_block_ptr(x, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-    b_x = tl.load(p_x, boundary_check=(0, 1)).to(tl.float32)
+    p_x = tl.make_tensor_descriptor(x, (T, D), (D, 1), (BT, BD))
+    b_x = p_x.load([i_t * BT, 0]).to(tl.float32)
     b_var = tl.sum(b_x * b_x, axis=1)
     b_y = b_x / tl.sqrt(b_var + eps)[:, None]
-    p_y = tl.make_block_ptr(y, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
-    tl.store(p_y, b_y.to(p_y.dtype.element_ty), boundary_check=(0, 1))
+    p_y = tl.make_tensor_descriptor(y, (T, D), (D, 1), (BT, BD))
+    p_y.store([i_t * BT, 0], b_y.to(p_y.dtype))
 
 
 def l2norm_fwd(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/linear/solve_tril.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/linear/solve_tril.py
@@ -60,11 +60,9 @@ def solve_tril_16x16_kernel(
     Ad = Ad + (bos * H + i_h) * 16
 
     offset = (i_t * 16) % BT
-    p_A = tl.make_block_ptr(
-        A, (T, BT), (H * BT, 1), (i_t * 16, offset), (16, 16), (1, 0)
-    )
-    p_Ai = tl.make_block_ptr(Ad, (T, 16), (H * 16, 1), (i_t * 16, 0), (16, 16), (1, 0))
-    b_A = tl.load(p_A, boundary_check=(0, 1)).to(tl.float32)
+    p_A = tl.make_tensor_descriptor(A, (T, BT), (H * BT, 1), (16, 16))
+    p_Ai = tl.make_tensor_descriptor(Ad, (T, 16), (H * 16, 1), (16, 16))
+    b_A = p_A.load([i_t * 16, offset]).to(tl.float32)
     b_A = -tl.where(tl.arange(0, 16)[:, None] > tl.arange(0, 16)[None, :], b_A, 0)
 
     o_i = tl.arange(0, 16)
@@ -74,10 +72,9 @@ def solve_tril_16x16_kernel(
         mask = o_i == i
         b_A = tl.where(mask[:, None], b_a, b_A)
     b_A += o_i[:, None] == o_i[None, :]
-    tl.store(
-        p_Ai,
-        b_A.to(p_Ai.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
+    p_Ai.store(
+        [i_t * 16, 0],
+        b_A.to(p_Ai.dtype, fp_downcast_rounding="rtne"),
     )
 
 
@@ -111,45 +108,25 @@ def merge_16x16_to_32x32_inverse_kernel(
     Ad += (bos * H + i_h) * 16
     Ai += (bos * H + i_h) * 32
 
-    p_A_21 = tl.make_block_ptr(
-        A, (T, 32), (H * 32, 1), (i_t * 32 + 16, 0), (16, 16), (1, 0)
-    )
-    p_Ad_11 = tl.make_block_ptr(
-        Ad, (T, 16), (H * 16, 1), (i_t * 32, 0), (16, 16), (1, 0)
-    )
-    p_Ad_22 = tl.make_block_ptr(
-        Ad, (T, 16), (H * 16, 1), (i_t * 32 + 16, 0), (16, 16), (1, 0)
-    )
-    p_Ai_11 = tl.make_block_ptr(
-        Ai, (T, 32), (H * 32, 1), (i_t * 32, 0), (16, 16), (1, 0)
-    )
-    p_Ai_22 = tl.make_block_ptr(
-        Ai, (T, 32), (H * 32, 1), (i_t * 32 + 16, 16), (16, 16), (1, 0)
-    )
-    p_Ai_21 = tl.make_block_ptr(
-        Ai, (T, 32), (H * 32, 1), (i_t * 32 + 16, 0), (16, 16), (1, 0)
-    )
+    p_A_21 = tl.make_tensor_descriptor(A, (T, 32), (H * 32, 1), (16, 16))
+    p_Ad_11 = tl.make_tensor_descriptor(Ad, (T, 16), (H * 16, 1), (16, 16))
+    p_Ad_22 = tl.make_tensor_descriptor(Ad, (T, 16), (H * 16, 1), (16, 16))
+    p_Ai_11 = tl.make_tensor_descriptor(Ai, (T, 32), (H * 32, 1), (16, 16))
+    p_Ai_22 = tl.make_tensor_descriptor(Ai, (T, 32), (H * 32, 1), (16, 16))
+    p_Ai_21 = tl.make_tensor_descriptor(Ai, (T, 32), (H * 32, 1), (16, 16))
 
-    A_21 = tl.load(p_A_21, boundary_check=(0, 1)).to(tl.float32)
-    Ai_11 = tl.load(p_Ad_11, boundary_check=(0, 1)).to(tl.float32)
-    Ai_22 = tl.load(p_Ad_22, boundary_check=(0, 1)).to(tl.float32)
+    A_21 = p_A_21.load([i_t * 32 + 16, 0]).to(tl.float32)
+    Ai_11 = p_Ad_11.load([i_t * 32, 0]).to(tl.float32)
+    Ai_22 = p_Ad_22.load([i_t * 32 + 16, 0]).to(tl.float32)
     Ai_21 = -tl.dot(
         tl.dot(Ai_22, A_21, input_precision="ieee"), Ai_11, input_precision="ieee"
     )
-    tl.store(
-        p_Ai_11,
-        Ai_11.to(p_Ai_11.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
+    p_Ai_11.store([i_t * 32, 0], Ai_11.to(p_Ai_11.dtype, fp_downcast_rounding="rtne"))
+    p_Ai_22.store(
+        [i_t * 32 + 16, 16], Ai_22.to(p_Ai_22.dtype, fp_downcast_rounding="rtne")
     )
-    tl.store(
-        p_Ai_22,
-        Ai_22.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
-    )
-    tl.store(
-        p_Ai_21,
-        Ai_21.to(p_Ai_21.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
+    p_Ai_21.store(
+        [i_t * 32 + 16, 0], Ai_21.to(p_Ai_21.dtype, fp_downcast_rounding="rtne")
     )
 
 
@@ -183,48 +160,20 @@ def merge_16x16_to_64x64_inverse_kernel(
     Ad += (bos * H + i_h) * 16
     Ai += (bos * H + i_h) * 64
 
-    p_A_21 = tl.make_block_ptr(
-        A, (T, 64), (H * 64, 1), (i_t * 64 + 16, 0), (16, 16), (1, 0)
-    )
-    p_A_32 = tl.make_block_ptr(
-        A, (T, 64), (H * 64, 1), (i_t * 64 + 32, 16), (16, 16), (1, 0)
-    )
-    p_A_31 = tl.make_block_ptr(
-        A, (T, 64), (H * 64, 1), (i_t * 64 + 32, 0), (16, 16), (1, 0)
-    )
-    p_A_43 = tl.make_block_ptr(
-        A, (T, 64), (H * 64, 1), (i_t * 64 + 48, 32), (16, 16), (1, 0)
-    )
-    p_A_42 = tl.make_block_ptr(
-        A, (T, 64), (H * 64, 1), (i_t * 64 + 48, 16), (16, 16), (1, 0)
-    )
-    p_A_41 = tl.make_block_ptr(
-        A, (T, 64), (H * 64, 1), (i_t * 64 + 48, 0), (16, 16), (1, 0)
-    )
-    p_Ad_11 = tl.make_block_ptr(
-        Ad, (T, 16), (H * 16, 1), (i_t * 64, 0), (16, 16), (1, 0)
-    )
-    p_Ad_22 = tl.make_block_ptr(
-        Ad, (T, 16), (H * 16, 1), (i_t * 64 + 16, 0), (16, 16), (1, 0)
-    )
-    p_Ad_33 = tl.make_block_ptr(
-        Ad, (T, 16), (H * 16, 1), (i_t * 64 + 32, 0), (16, 16), (1, 0)
-    )
-    p_Ad_44 = tl.make_block_ptr(
-        Ad, (T, 16), (H * 16, 1), (i_t * 64 + 48, 0), (16, 16), (1, 0)
-    )
+    p_A = tl.make_tensor_descriptor(A, (T, 64), (H * 64, 1), (16, 16))
+    p_Ad = tl.make_tensor_descriptor(Ad, (T, 16), (H * 16, 1), (16, 16))
 
-    A_21 = tl.load(p_A_21, boundary_check=(0, 1)).to(tl.float32)
-    A_32 = tl.load(p_A_32, boundary_check=(0, 1)).to(tl.float32)
-    A_31 = tl.load(p_A_31, boundary_check=(0, 1)).to(tl.float32)
-    A_43 = tl.load(p_A_43, boundary_check=(0, 1)).to(tl.float32)
-    A_42 = tl.load(p_A_42, boundary_check=(0, 1)).to(tl.float32)
-    A_41 = tl.load(p_A_41, boundary_check=(0, 1)).to(tl.float32)
+    A_21 = p_A.load([i_t * 64 + 16, 0]).to(tl.float32)
+    A_32 = p_A.load([i_t * 64 + 32, 16]).to(tl.float32)
+    A_31 = p_A.load([i_t * 64 + 32, 0]).to(tl.float32)
+    A_43 = p_A.load([i_t * 64 + 48, 32]).to(tl.float32)
+    A_42 = p_A.load([i_t * 64 + 48, 16]).to(tl.float32)
+    A_41 = p_A.load([i_t * 64 + 48, 0]).to(tl.float32)
 
-    Ai_11 = tl.load(p_Ad_11, boundary_check=(0, 1)).to(tl.float32)
-    Ai_22 = tl.load(p_Ad_22, boundary_check=(0, 1)).to(tl.float32)
-    Ai_33 = tl.load(p_Ad_33, boundary_check=(0, 1)).to(tl.float32)
-    Ai_44 = tl.load(p_Ad_44, boundary_check=(0, 1)).to(tl.float32)
+    Ai_11 = p_Ad.load([i_t * 64, 0]).to(tl.float32)
+    Ai_22 = p_Ad.load([i_t * 64 + 16, 0]).to(tl.float32)
+    Ai_33 = p_Ad.load([i_t * 64 + 32, 0]).to(tl.float32)
+    Ai_44 = p_Ad.load([i_t * 64 + 48, 0]).to(tl.float32)
 
     Ai_21 = -tl.dot(
         tl.dot(Ai_22, A_21, input_precision="ieee"), Ai_11, input_precision="ieee"
@@ -256,136 +205,26 @@ def merge_16x16_to_64x64_inverse_kernel(
         input_precision="ieee",
     )
 
-    p_Ai_11 = tl.make_block_ptr(
-        Ai, (T, 64), (H * 64, 1), (i_t * 64, 0), (16, 16), (1, 0)
-    )
-    p_Ai_22 = tl.make_block_ptr(
-        Ai, (T, 64), (H * 64, 1), (i_t * 64 + 16, 16), (16, 16), (1, 0)
-    )
-    p_Ai_33 = tl.make_block_ptr(
-        Ai, (T, 64), (H * 64, 1), (i_t * 64 + 32, 32), (16, 16), (1, 0)
-    )
-    p_Ai_44 = tl.make_block_ptr(
-        Ai, (T, 64), (H * 64, 1), (i_t * 64 + 48, 48), (16, 16), (1, 0)
-    )
-    p_Ai_21 = tl.make_block_ptr(
-        Ai, (T, 64), (H * 64, 1), (i_t * 64 + 16, 0), (16, 16), (1, 0)
-    )
-    p_Ai_31 = tl.make_block_ptr(
-        Ai, (T, 64), (H * 64, 1), (i_t * 64 + 32, 0), (16, 16), (1, 0)
-    )
-    p_Ai_32 = tl.make_block_ptr(
-        Ai, (T, 64), (H * 64, 1), (i_t * 64 + 32, 16), (16, 16), (1, 0)
-    )
-    p_Ai_41 = tl.make_block_ptr(
-        Ai, (T, 64), (H * 64, 1), (i_t * 64 + 48, 0), (16, 16), (1, 0)
-    )
-    p_Ai_42 = tl.make_block_ptr(
-        Ai, (T, 64), (H * 64, 1), (i_t * 64 + 48, 16), (16, 16), (1, 0)
-    )
-    p_Ai_43 = tl.make_block_ptr(
-        Ai, (T, 64), (H * 64, 1), (i_t * 64 + 48, 32), (16, 16), (1, 0)
-    )
-    tl.store(
-        p_Ai_11,
-        Ai_11.to(p_Ai_11.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
-    )
-    tl.store(
-        p_Ai_22,
-        Ai_22.to(p_Ai_22.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
-    )
-    tl.store(
-        p_Ai_33,
-        Ai_33.to(p_Ai_33.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
-    )
-    tl.store(
-        p_Ai_44,
-        Ai_44.to(p_Ai_44.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
-    )
-    tl.store(
-        p_Ai_21,
-        Ai_21.to(p_Ai_21.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
-    )
-    tl.store(
-        p_Ai_31,
-        Ai_31.to(p_Ai_31.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
-    )
-    tl.store(
-        p_Ai_32,
-        Ai_32.to(p_Ai_32.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
-    )
-    tl.store(
-        p_Ai_41,
-        Ai_41.to(p_Ai_41.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
-    )
-    tl.store(
-        p_Ai_42,
-        Ai_42.to(p_Ai_42.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
-    )
-    tl.store(
-        p_Ai_43,
-        Ai_43.to(p_Ai_43.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
-    )
+    p_Ai = tl.make_tensor_descriptor(Ai, (T, 64), (H * 64, 1), (16, 16))
+    p_Ai.store([i_t * 64, 0], Ai_11.to(p_Ai.dtype, fp_downcast_rounding="rtne"))
+    p_Ai.store([i_t * 64 + 16, 16], Ai_22.to(p_Ai.dtype, fp_downcast_rounding="rtne"))
+    p_Ai.store([i_t * 64 + 32, 32], Ai_33.to(p_Ai.dtype, fp_downcast_rounding="rtne"))
+    p_Ai.store([i_t * 64 + 48, 48], Ai_44.to(p_Ai.dtype, fp_downcast_rounding="rtne"))
+    p_Ai.store([i_t * 64 + 16, 0], Ai_21.to(p_Ai.dtype, fp_downcast_rounding="rtne"))
+    p_Ai.store([i_t * 64 + 32, 0], Ai_31.to(p_Ai.dtype, fp_downcast_rounding="rtne"))
+    p_Ai.store([i_t * 64 + 32, 16], Ai_32.to(p_Ai.dtype, fp_downcast_rounding="rtne"))
+    p_Ai.store([i_t * 64 + 48, 0], Ai_41.to(p_Ai.dtype, fp_downcast_rounding="rtne"))
+    p_Ai.store([i_t * 64 + 48, 16], Ai_42.to(p_Ai.dtype, fp_downcast_rounding="rtne"))
+    p_Ai.store([i_t * 64 + 48, 32], Ai_43.to(p_Ai.dtype, fp_downcast_rounding="rtne"))
 
     fill_zeros = tl.zeros((16, 16), dtype=tl.float32)
-    p_Ai_12 = tl.make_block_ptr(
-        Ai, (T, 64), (H * 64, 1), (i_t * 64, 16), (16, 16), (1, 0)
-    )
-    p_Ai_13 = tl.make_block_ptr(
-        Ai, (T, 64), (H * 64, 1), (i_t * 64, 32), (16, 16), (1, 0)
-    )
-    p_Ai_14 = tl.make_block_ptr(
-        Ai, (T, 64), (H * 64, 1), (i_t * 64, 48), (16, 16), (1, 0)
-    )
-    p_Ai_23 = tl.make_block_ptr(
-        Ai, (T, 64), (H * 64, 1), (i_t * 64 + 16, 32), (16, 16), (1, 0)
-    )
-    p_Ai_24 = tl.make_block_ptr(
-        Ai, (T, 64), (H * 64, 1), (i_t * 64 + 16, 48), (16, 16), (1, 0)
-    )
-    p_Ai_34 = tl.make_block_ptr(
-        Ai, (T, 64), (H * 64, 1), (i_t * 64 + 32, 48), (16, 16), (1, 0)
-    )
-    tl.store(
-        p_Ai_12,
-        fill_zeros.to(p_Ai_12.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
-    )
-    tl.store(
-        p_Ai_13,
-        fill_zeros.to(p_Ai_13.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
-    )
-    tl.store(
-        p_Ai_14,
-        fill_zeros.to(p_Ai_14.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
-    )
-    tl.store(
-        p_Ai_23,
-        fill_zeros.to(p_Ai_23.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
-    )
-    tl.store(
-        p_Ai_24,
-        fill_zeros.to(p_Ai_24.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
-    )
-    tl.store(
-        p_Ai_34,
-        fill_zeros.to(p_Ai_34.dtype.element_ty, fp_downcast_rounding="rtne"),
-        boundary_check=(0, 1),
-    )
+    z = fill_zeros.to(p_Ai.dtype, fp_downcast_rounding="rtne")
+    p_Ai.store([i_t * 64, 16], z)
+    p_Ai.store([i_t * 64, 32], z)
+    p_Ai.store([i_t * 64, 48], z)
+    p_Ai.store([i_t * 64 + 16, 32], z)
+    p_Ai.store([i_t * 64 + 16, 48], z)
+    p_Ai.store([i_t * 64 + 32, 48], z)
 
 
 @input_guard

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/linear/wy_fast.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/linear/wy_fast.py
@@ -64,60 +64,41 @@ def recompute_w_u_fwd_kernel(
         T = eos - bos
     else:
         bos, eos = i_b * T, i_b * T + T
-    p_beta = tl.make_block_ptr(
-        beta + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+    # ``beta``/``g`` are one scalar per token (stride H), not contiguous, so use
+    # masked pointer loads rather than tensor descriptors.
+    o_row = i_t * BT + tl.arange(0, BT)
+    m_row = o_row < T
+    b_beta = tl.load(beta + bos * H + i_h + o_row * H, mask=m_row, other=0.0)
+    b_g = tl.exp(tl.load(g + (bos * H + i_h) + o_row * H, mask=m_row, other=0.0))
+
+    p_A = tl.make_tensor_descriptor(
+        A + (bos * H + i_h) * BT, (T, BT), (H * BT, 1), (BT, BT)
     )
-    p_g = tl.make_block_ptr(g + (bos * H + i_h), (T,), (H,), (i_t * BT,), (BT,), (0,))
-    p_A = tl.make_block_ptr(
-        A + (bos * H + i_h) * BT, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
-    )
-    b_beta = tl.load(p_beta, boundary_check=(0,))
-    b_A = tl.load(p_A, boundary_check=(0, 1))
-    b_g = tl.exp(tl.load(p_g, boundary_check=(0,)))
+    b_A = p_A.load([i_t * BT, 0])
 
     for i_v in range(tl.cdiv(V, BV)):
-        p_v = tl.make_block_ptr(
-            v + (bos * H + i_h) * V,
-            (T, V),
-            (H * V, 1),
-            (i_t * BT, i_v * BV),
-            (BT, BV),
-            (1, 0),
+        p_v = tl.make_tensor_descriptor(
+            v + (bos * H + i_h) * V, (T, V), (H * V, 1), (BT, BV)
         )
-        p_u = tl.make_block_ptr(
-            u + (bos * H + i_h) * V,
-            (T, V),
-            (H * V, 1),
-            (i_t * BT, i_v * BV),
-            (BT, BV),
-            (1, 0),
+        p_u = tl.make_tensor_descriptor(
+            u + (bos * H + i_h) * V, (T, V), (H * V, 1), (BT, BV)
         )
-        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_v = p_v.load([i_t * BT, i_v * BV])
         b_vb = (b_v * b_beta[:, None]).to(b_v.dtype)
         b_u = tl.dot(b_A, b_vb, allow_tf32=False)
-        tl.store(p_u, b_u.to(p_u.dtype.element_ty), boundary_check=(0, 1))
+        p_u.store([i_t * BT, i_v * BV], b_u.to(p_u.dtype))
 
     for i_k in range(tl.cdiv(K, BK)):
-        p_k = tl.make_block_ptr(
-            k + (bos * Hg + i_h // (H // Hg)) * K,
-            (T, K),
-            (Hg * K, 1),
-            (i_t * BT, i_k * BK),
-            (BT, BK),
-            (1, 0),
+        p_k = tl.make_tensor_descriptor(
+            k + (bos * Hg + i_h // (H // Hg)) * K, (T, K), (Hg * K, 1), (BT, BK)
         )
-        p_w = tl.make_block_ptr(
-            w + (bos * H + i_h) * K,
-            (T, K),
-            (H * K, 1),
-            (i_t * BT, i_k * BK),
-            (BT, BK),
-            (1, 0),
+        p_w = tl.make_tensor_descriptor(
+            w + (bos * H + i_h) * K, (T, K), (H * K, 1), (BT, BK)
         )
-        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_k = p_k.load([i_t * BT, i_k * BK])
         b_kb = (b_k * b_beta[:, None] * b_g[:, None]).to(b_k.dtype)
         b_w = tl.dot(b_A, b_kb)
-        tl.store(p_w, b_w.to(p_w.dtype.element_ty), boundary_check=(0, 1))
+        p_w.store([i_t * BT, i_k * BK], b_w.to(p_w.dtype))
 
 
 def recompute_w_u_fwd(


### PR DESCRIPTION
## Summary
Ports the linear-attention (gated delta net) chunk-prefill Triton kernels off the deprecated `tl.make_block_ptr` API to the recommended in-kernel **tensor descriptor** style (`tl.make_tensor_descriptor` + `.load`/`.store`), ahead of the upstream Triton removal of block pointers.

- Removes **all 84** `make_block_ptr` sites across `l2norm`, `chunk_scaled_dot_kkt`, `chunk_o`, `wy_fast`, `cumsum`, `chunk_delta_h`, and `solve_tril`.
- Contiguous 2D blocks map directly to descriptors; descriptor loads zero-fill OOB, so `boundary_check`/`padding_option` are dropped.
- **Transposed** accesses (`order=(0,1)`, non-unit inner stride) load the natural layout and transpose in-register via `tl.trans`, since descriptors require a contiguous innermost dimension.
- **1D per-token strided vectors** (`beta`/`g`, scalar gate) fall back to masked pointer loads, which descriptors cannot express.
- Registers a process-global scratch allocator for on-device descriptors via `_triton.ensure_descriptor_allocator()`, wired at `linear` package import (verified it applies even for kernels that don't import `utils`).

Net `+206 / -418` lines.

## Test plan
- [x] `pytest tokenspeed-kernel/test/ops/test_attention_gdn.py` on AMD MI350X — 4 passed, 2 skipped; matches torch + FLA references (prefill, varlen, state contract). `make_block_ptr` deprecation warnings 18 -> 0.
- [x] Standalone numerical checks: `l2norm` (fp32/bf16) and `cumsum` (scalar+vector, both head-first layouts, fwd+reverse) at float epsilon.
- [x] End-to-end **Qwen3.5-397B-A17B-MXFP4** (TP=4): AIME25 `mean_acc=0.875` (>= 0.75 CI threshold); coherency prompt generates correct, coherent output. (Strict cross-request identity remains non-deterministic — a pre-existing batch-shape property, not introduced here.)
- [x] `pre-commit run --all-files` clean.

## Notes
- Descriptors are created per loop-iteration in `chunk_delta_h` to mirror the original structure; hoisting loop-invariant descriptors is a straightforward perf follow-up if profiling warrants it.