### PR TITLE
fix(profile): barrier TP peers before replying to a Proton /stop_profile

### DIFF
--- a/python/tokenspeed/runtime/engine/request_handler.py
+++ b/python/tokenspeed/runtime/engine/request_handler.py
@@ -515,6 +515,7 @@ class RequestHandler:
             # Finalizes the session and writes the profile now, while this
             # process is still alive (shutdown is SIGKILL; no atexit).
             stop_profiling()
+            torch.distributed.barrier(self.attn_tp_cpu_group)
 
         if "VIZTRACER" in self.profiler_activities and self.viztracer is not None:
             self.viztracer.stop()

--- a/test/runtime/test_request_handler_profile.py
+++ b/test/runtime/test_request_handler_profile.py
@@ -28,6 +28,7 @@ def _make_handler(attn_mapping: SimpleNamespace | None = None) -> RequestHandler
     handler.forward_ct = 0
     attn_mapping = attn_mapping or _attn_mapping()
     handler.attn_tp_rank = attn_mapping.tp_rank
+    handler.attn_tp_cpu_group = None
     handler.profile_rank_tag = request_handler_mod._profile_rank_tag(attn_mapping)
     handler.init_profiler()
     return handler
@@ -49,6 +50,13 @@ class TestRequestHandlerProtonProfile(unittest.TestCase):
         self.output_dir = tempfile.mkdtemp()
         profiling.ProfilingState.reset()
         self.addCleanup(profiling.ProfilingState.reset)
+        # stop_profile barriers the attn-TP CPU group; there is no real
+        # process group in unit tests.
+        barrier_patcher = mock.patch.object(
+            request_handler_mod.torch.distributed, "barrier"
+        )
+        self.barrier = barrier_patcher.start()
+        self.addCleanup(barrier_patcher.stop)
 
     def test_init_fails_when_proton_unavailable(self):
         with mock.patch.object(
@@ -176,6 +184,25 @@ class TestRequestHandlerProtonProfile(unittest.TestCase):
         self.assertNotEqual(outputs[0], outputs[1])
         self.assertTrue(outputs[0].endswith("test-profile-DP0-TP0.proton"))
         self.assertTrue(outputs[1].endswith("test-profile-DP1-TP0.proton"))
+
+    def test_stop_profile_barriers_tp_peers_after_proton_finalize(self):
+        # Only attn-TP rank 0 replies to /stop_profile; the reply must wait
+        # until every TP peer has finalized its proton file.
+        self.handler.attn_tp_cpu_group = object()
+
+        with mock.patch.object(
+            request_handler_mod, "proton_available", return_value=True
+        ), mock.patch.object(request_handler_mod, "start_profiling"), mock.patch.object(
+            request_handler_mod, "stop_profiling"
+        ) as stop_profiling:
+            self.barrier.side_effect = lambda group: self.assertTrue(
+                stop_profiling.called
+            )
+            self.handler.profile(_start_req(self.output_dir))
+            result = self.handler.profile(ProfileReq(type=ProfileReqType.STOP_PROFILE))
+
+        self.assertTrue(result.success)
+        self.barrier.assert_called_once_with(self.handler.attn_tp_cpu_group)
 
     def test_num_steps_window_finalizes_proton(self):
         with mock.patch.object(


### PR DESCRIPTION
Only attn-TP rank 0 sends the ProfileReqOutput reply, and the existing torch-profiler barrier runs before the Proton finalize, so a /stop_profile using PROTON could return as soon as rank 0 finished proton.finalize while other TP ranks were still writing their .proton.* files. Scripts that collect traces or stop the server as soon as the request returns could then miss or truncate nonzero-rank outputs.

Barrier the attention TP CPU group after stop_profiling() and before rank 0 replies, mirroring the torch trace path (unconditionally: the attn TP gloo group exists even for world size 1, where the barrier returns immediately). All TP ranks execute stop_profile in lockstep — control requests are broadcast and the step-window predicate fires at the same forward count on every rank — so the barrier is balanced.
