### PR TITLE
refactor(spec): separate multi-layer MTP from Eagle

### DIFF
--- a/python/tokenspeed/runtime/execution/drafter/eagle.py
+++ b/python/tokenspeed/runtime/execution/drafter/eagle.py
@@ -20,13 +20,10 @@
 
 from __future__ import annotations
 
-import logging
-import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import torch
-from tokenspeed_kernel.ops.conv import seq_idx_from_cu_seqlens
 from tokenspeed_kernel.ops.sampling import argmax as sampling_argmax
 from typing_extensions import override
 
@@ -44,18 +41,6 @@ from tokenspeed.runtime.utils.nvtx import nvtx_range
 
 DsaTopKState = tuple[Any | None, Any | None]
 
-logger = logging.getLogger(__name__)
-
-# Multi-depth window dataflow A/B knobs (the 53a50800 MTP head ships no
-# reference implementation; these resolve its training dataflow empirically):
-# - CHAIN_TARGET_HIDDEN: every depth consumes the TARGET model's hidden
-#   (DeepSeek-MTP style) instead of the previous depth's chain-normed rows.
-# - POS_SHIFT: depth d's window rows carry positions p_j + d instead of p_j.
-_WINDOW_CHAIN_TARGET_HIDDEN = (
-    os.environ.get("INKLING_MTP_CHAIN_TARGET_HIDDEN", "0") == "1"
-)
-_WINDOW_POS_SHIFT = os.environ.get("INKLING_MTP_WINDOW_POS_SHIFT", "0") == "1"
-
 if TYPE_CHECKING:
     from tokenspeed.runtime.execution.input_buffer import InputBuffers
     from tokenspeed.runtime.execution.model_runner import ModelRunner
@@ -69,245 +54,6 @@ def _advance_draft_forward_metadata_if_supported(attn_backend, seq_lens) -> None
     advance = getattr(attn_backend, "advance_draft_forward_metadata", None)
     if advance is not None:
         advance(seq_lens)
-
-
-def _window_shifted_ids(
-    v: torch.Tensor,
-    accept: torch.Tensor,
-    next_tokens: torch.Tensor,
-    depth: int,
-    src: torch.Tensor | None = None,
-) -> torch.Tensor:
-    """Depth-``depth`` input ids over a decode verify window.
-
-    Row ``j`` consumes the token at source position ``p_j + depth``; in
-    verify-output coordinates that is ``src[j]``: ``src < accept`` reads
-    this round's verify output ``v[:, src]``, else the round's own draft
-    ``d_m`` (m = src - accept + 1 <= depth) from ``next_tokens`` columns
-    1..depth. Negative ``src`` rows (lookback) come out as ``drafts[:, 0]``;
-    the caller overlays them (see ``_window_lookback_shifted_ids``).
-
-    Args:
-        v: [bs, k] int64 verify outputs.
-        accept: [bs, 1] int64 accepted lengths clamped to [1, k].
-        next_tokens: [bs, >= depth+1] col 0 = last verified id, cols 1.. =
-            this round's drafts.
-        depth: draft depth d >= 1.
-        src: optional [1, n] (or [bs, n]) int64 source coordinates; defaults
-            to ``arange(k) + depth`` (the plain forward window).
-
-    Returns:
-        [bs, n] int64 input ids.
-    """
-    bs, k = v.shape
-    if src is None:
-        src = torch.arange(k, dtype=torch.int64, device=v.device).view(1, k) + depth
-    n = src.shape[-1]
-    from_verify = torch.gather(v, 1, src.clamp(0, k - 1).expand(bs, n))
-    drafts = next_tokens[:, 1 : depth + 1].to(torch.int64)
-    m = (src - accept).clamp(0, depth - 1)  # draft index - 1
-    from_draft = torch.gather(drafts, 1, m.expand(bs, n))
-    return torch.where(src < accept, from_verify, from_draft)
-
-
-def _extend_depth_precompute(
-    shift1_ids: torch.Tensor,
-    input_lengths: torch.Tensor,
-    last_row: torch.Tensor | None = None,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Depth-invariant pieces of :func:`_extend_depth_shifted_ids`.
-
-    Hoisted out of the catch-up depth loop; ``last_row`` (per-request cumsum
-    of ``input_lengths`` minus one) may be passed in when the caller already
-    computed it.
-
-    Returns:
-        ``(shift1_i64, base, req_of_row, row_last)``: the int64 shift-1 ids,
-        ``arange(num_rows)``, each row's request index, and the global index
-        of each row's request-final row.
-    """
-    device = shift1_ids.device
-    lengths = input_lengths.to(torch.int64)
-    num_rows = shift1_ids.shape[0]
-    if last_row is None:
-        last_row = lengths.cumsum(0) - 1
-    cu_seqlens = torch.nn.functional.pad(last_row + 1, (1, 0))
-    # Sync-free repeat_interleave(arange(ne), lengths) equivalent.
-    req_of_row = seq_idx_from_cu_seqlens(cu_seqlens, num_rows).to(torch.int64)
-    base = torch.arange(num_rows, dtype=torch.int64, device=device)
-    return shift1_ids.to(torch.int64), base, req_of_row, last_row[req_of_row]
-
-
-def _extend_depth_shifted_ids_from(
-    pre: tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
-    next_tokens: torch.Tensor,
-    depth: int,
-) -> torch.Tensor:
-    """Per-depth gather of :func:`_extend_depth_shifted_ids` over ``pre``
-    (= :func:`_extend_depth_precompute` output)."""
-    shift1_i64, base, req_of_row, row_last = pre
-    num_rows = shift1_i64.shape[0]
-    src = base + depth
-    from_prompt = shift1_i64[src.clamp(max=num_rows - 1)]
-    overshoot = (src - row_last).clamp(1, depth)
-    from_draft = next_tokens.to(torch.int64)[req_of_row, overshoot]
-    return torch.where(src <= row_last, from_prompt, from_draft)
-
-
-def _extend_depth_shifted_ids(
-    shift1_ids: torch.Tensor,
-    input_lengths: torch.Tensor,
-    next_tokens: torch.Tensor,
-    depth: int,
-) -> torch.Tensor:
-    """Depth-``depth`` input ids for the ragged prefill rows of an EXTEND round.
-
-    ``shift1_ids`` are the first draft step's prefill inputs (prompt tokens
-    shifted by one within each request, last row already holding the round's
-    sampled token on final chunks). Depth ``d`` at local row ``i`` consumes the
-    token ``d`` further along: ``shift1_ids[row + d]`` while that stays inside
-    the request, else the request's own draft ``d_m`` (``m = overshoot``) from
-    ``next_tokens`` — columns ``1..d`` are already filled when depth ``d``
-    runs. On mid-chunk rows the overshoot tokens are not staged; those
-    trailing ``d`` rows per chunk consume the placeholder ``next_tokens``
-    columns (known §14 Step 1 approximation, <= steps-1 rows per chunk).
-
-    Args:
-        shift1_ids: [num_prefill_rows] first-step prefill input ids.
-        input_lengths: [num_extends] per-request prefill row counts.
-        next_tokens: [>=num_extends, >=depth+1] col 0 = last verified token,
-            cols 1.. = this round's drafts, per request.
-        depth: draft depth d >= 1.
-
-    Returns:
-        [num_prefill_rows] int64 input ids for the depth-``depth`` pass.
-    """
-    return _extend_depth_shifted_ids_from(
-        _extend_depth_precompute(shift1_ids, input_lengths), next_tokens, depth
-    )
-
-
-def _window_lookback_shifted_ids(
-    v: torch.Tensor,
-    accept: torch.Tensor,
-    next_tokens: torch.Tensor,
-    stash_tokens: torch.Tensor,
-    depth: int,
-    lookback: int,
-    src: torch.Tensor | None = None,
-) -> torch.Tensor:
-    """Depth-``depth`` input ids for a lookback decode window (§12 Hole 2).
-
-    Row ``r`` of the ``lookback + k`` window sits at source position
-    ``vc - lookback + r`` and consumes the token at source + depth + 1;
-    in verify-output coordinates that is ``src = r - lookback + depth``:
-    ``src < 0`` reads the stash of the last ``lookback`` committed tokens
-    (entry ``lookback + src``), ``src < accept`` this round's verify output
-    ``v[src]``, else this round's own draft ``d_m`` (m = src - accept + 1
-    <= depth) — identical to the plain window for the trailing k rows.
-
-    Args:
-        v: [bs, k] int64 verify outputs (token at position vc+j+1 = v[:, j]).
-        accept: [bs, 1] int64 accepted lengths clamped to [1, k].
-        next_tokens: [bs, >= depth+1] col 0 = last verified id, cols 1.. =
-            this round's drafts.
-        stash_tokens: [bs, lookback] int64 committed tokens at positions
-            vc-lookback+1 .. vc (the pre-window tail).
-        depth: draft depth d >= 1.
-        lookback: D >= 1 lookback rows.
-        src: optional [1, lookback + k] precomputed source coordinates
-            (``arange(total) - lookback + depth``), hoistable per depth.
-
-    Returns:
-        [bs * (lookback + k)] int64 input ids.
-    """
-    bs, k = v.shape
-    total = lookback + k
-    if src is None:
-        src = (
-            torch.arange(total, dtype=torch.int64, device=v.device).view(1, total)
-            - lookback
-            + depth
-        )
-    ids = _window_shifted_ids(v, accept, next_tokens, depth, src=src)
-    from_stash = stash_tokens.gather(
-        1, (src + lookback).clamp(0, lookback - 1).expand(bs, total)
-    )
-    ids = torch.where(src < 0, from_stash, ids)
-    return ids.reshape(-1)
-
-
-def _committed_tail_update(
-    stash: torch.Tensor,
-    fresh: torch.Tensor,
-    valid: torch.Tensor,
-    lookback: int,
-) -> torch.Tensor:
-    """Roll a committed-tail stash: last ``lookback`` of [stash || fresh[:valid]].
-
-    ``stash``: [bs, lookback, ...] previous tail; ``fresh``: [bs, k, ...]
-    this round's per-row values whose committed prefix is the first
-    ``valid`` rows (``fresh`` row 0 must directly follow the stash's last
-    entry); ``valid``: [bs] int64 in [1, k].
-
-    Returns:
-        The updated [bs, lookback, ...] tail.
-    """
-    bs = fresh.shape[0]
-    rows = (
-        valid.view(bs, 1)
-        - lookback
-        + torch.arange(lookback, dtype=torch.int64, device=fresh.device).view(
-            1, lookback
-        )
-    )
-    idx_shape = (bs, lookback) + (1,) * (fresh.dim() - 2)
-    expand = (bs, lookback) + fresh.shape[2:]
-    new_rows = fresh.gather(1, rows.clamp_min(0).view(idx_shape).expand(expand))
-    old_rows = stash.gather(
-        1, (rows + lookback).clamp(0, lookback - 1).view(idx_shape).expand(expand)
-    )
-    return torch.where((rows >= 0).view(idx_shape), new_rows, old_rows)
-
-
-def _ragged_tail_rows(
-    flat: torch.Tensor,
-    lengths: torch.Tensor,
-    old_tail: torch.Tensor,
-    lookback: int,
-) -> torch.Tensor:
-    """Per-request last ``lookback`` rows of ragged ``flat`` chunks.
-
-    Requests whose chunk is shorter than ``lookback`` borrow leading entries
-    from ``old_tail`` (the previous chunk's tail, contiguous with this
-    chunk's first row).
-
-    Args:
-        flat: [total, ...] ragged per-request rows.
-        lengths: [n] per-request row counts.
-        old_tail: [n, lookback, ...] previous tail.
-
-    Returns:
-        The updated [n, lookback, ...] tail.
-    """
-    n = lengths.shape[0]
-    lens = lengths.to(torch.int64)
-    starts = lens.cumsum(0) - lens
-    offs = (
-        lens.view(n, 1)
-        - lookback
-        + torch.arange(lookback, dtype=torch.int64, device=flat.device).view(
-            1, lookback
-        )
-    )
-    rows = (starts.view(n, 1) + offs.clamp_min(0)).clamp(max=max(flat.shape[0] - 1, 0))
-    new_rows = flat[rows.reshape(-1)].reshape((n, lookback) + flat.shape[1:])
-    idx_shape = (n, lookback) + (1,) * (old_tail.dim() - 2)
-    expand = (n, lookback) + old_tail.shape[2:]
-    old_rows = old_tail.gather(
-        1, (offs + lookback).clamp(0, lookback - 1).view(idx_shape).expand(expand)
-    )
-    return torch.where((offs >= 0).view(idx_shape), new_rows, old_rows)
 
 
 @dataclass
@@ -389,56 +135,12 @@ class Eagle(BaseDrafter):
             - 1
         )
 
-        # In-vocab media tokens plumbed by ModelExecutor. The content-derived
-        # prefix-cache pad IDs retain a modality tag and are restored here before
-        # the text-only speculative draft performs its embedding lookup.
+        # VLM placeholder ids plumbed by ModelExecutor; empty for text-only targets.
         self.mm_pad_substitute_ids: dict[Modality, int] = {}
         hf_config = getattr(draft_model_runner.model_config, "hf_config", None)
         self._dsa_reuse_mtp_topk = bool(
             getattr(hf_config, "index_share_for_mtp_iteration", False)
         )
-
-        # Log-once flags for the window/lookback/catch-up engagement banners.
-        self._window_mode_logged = False
-        self._lookback_mode_logged = False
-        self._extend_catchup_logged = False
-
-        # Decode-window lookback: the model's
-        # draft_decode_lookback already folds in window mode AND extend
-        # catch-up (the lookback's prompt boundary and per-depth conv lag are
-        # built by those passes); armed only when the backend supports the
-        # lagged-conv recurrence. DP is excluded: the lookback rows change
-        # per-rank token counts.
-        model = draft_model_runner.model
-        lookback = 0
-        if (
-            spec_num_steps > 1
-            and self.dp_size == 1
-            and not _WINDOW_CHAIN_TARGET_HIDDEN
-            and getattr(model, "draft_decode_lookback", False)
-        ):
-            lookback = spec_num_steps - 1
-            configure = getattr(self.attn_backend, "configure_draft_lookback", None)
-            if configure is None or not configure(lookback):
-                lookback = 0
-        self.draft_lookback = lookback
-        # Cross-round stashes keyed by req_pool_indices (PAD rows clamp to the
-        # reserved slot 0): the last D committed tokens and depth-0 chain rows
-        # per request. Allocated eagerly — the decode rounds that fill them
-        # run inside CUDA graph capture, where allocation is off-limits.
-        self._lookback_hidden_buf: torch.Tensor | None = None
-        if lookback:
-            model_config = draft_model_runner.model_config
-            self._lookback_tokens_buf = torch.zeros(
-                (req_to_page.shape[0], lookback),
-                dtype=torch.int64,
-                device=self.device,
-            )
-            self._lookback_hidden_buf = torch.zeros(
-                (req_to_page.shape[0], lookback, model_config.hidden_size),
-                dtype=model_config.dtype,
-                device=self.device,
-            )
 
     def _accepted_output_indices(
         self,
@@ -488,64 +190,6 @@ class Eagle(BaseDrafter):
         input_ids = maybe_substitute_mm_pad(input_ids, self.mm_pad_substitute_ids)
         return input_ids.clamp(0, self.vocab_size - 1)
 
-    def _use_multi_depth_windows(self, draft_input: EagleDraftInput) -> bool:
-        """Teacher-forced multi-depth catch-up (draft-model opt-in).
-
-        Multi-depth MTP heads are trained as full-sequence layers: depth d's
-        attention at source position p runs over depth-d activations of ALL
-        positions <= p. The classic multi-step loop gives depth d>0 exactly
-        one new row per round, so its decode queries attend over a KV window
-        it mostly never wrote (stale garbage). In window mode every step
-        re-runs its depth over the whole verify window — dense per-depth KV
-        and sconv state over the accepted prefix — with per-depth
-        token-shifted inputs and the previous depth's full-row chain-normed
-        hidden. Pure-decode rounds only; MIXED rounds keep the classic loop.
-        """
-        return (
-            self.spec_num_steps > 1
-            and draft_input.num_extends == 0
-            and not draft_input.forward_mode.is_idle()
-            and bool(
-                getattr(
-                    self.draft_model_runner.model, "draft_multi_depth_windows", False
-                )
-            )
-        )
-
-    def _use_extend_depth_catchup(self, draft_input: EagleDraftInput) -> bool:
-        """Per-depth prompt coverage at EXTEND rounds (draft-model opt-in).
-
-        Window mode (above) only repairs pure-decode rounds, so depths >= 1
-        never write KV or sconv state over the prompt region — their decode
-        queries then attend over never-written prompt keys
-        forever. When the draft model opts in, EXTEND and
-        MIXED rounds re-run depths 1..steps-1 over the same ragged rows as the
-        first step (per-depth token-shifted inputs, chained full-row hidden),
-        which builds every used depth's dense prompt KV and sconv prompt
-        state chunk by chunk and replaces the classic loop's one-token steps.
-        """
-        return (
-            self.spec_num_steps > 1
-            and draft_input.num_extends > 0
-            and not draft_input.forward_mode.is_idle()
-            and bool(
-                getattr(
-                    self.draft_model_runner.model, "draft_extend_depth_catchup", False
-                )
-            )
-        )
-
-    def _use_decode_lookback(self, draft_input: EagleDraftInput) -> bool:
-        """Lookback rows for the window pass (§12 Hole 2, armed at init).
-
-        At depth d, the last d committed rows of each round's window embed
-        the round's own unverified drafts; once a draft is rejected those
-        KV/conv entries are permanently wrong under the forward-only window.
-        The lookback variant prepends D = steps-1 rows so the previous
-        round's provisional entries are recomputed from committed tokens.
-        """
-        return self.draft_lookback > 0 and self._use_multi_depth_windows(draft_input)
-
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
@@ -571,13 +215,6 @@ class Eagle(BaseDrafter):
     def _map_hot(self, ids: torch.Tensor) -> torch.Tensor:
         """Map token ids through hot_token_ids if available, otherwise return as-is."""
         return self.hot_token_ids[ids] if self.hot_token_ids is not None else ids
-
-    def _sample_step_tokens(self, logits_output: LogitsProcessorOutput) -> torch.Tensor:
-        """One draft step's raw sampled ids: the logits processor's
-        pre-sampled ids when present, greedy argmax otherwise."""
-        if logits_output.next_token_ids is not None:
-            return logits_output.next_token_ids
-        return sampling_argmax(logits_output.next_token_logits)
 
     def _get_first_step_input(
         self,
@@ -653,16 +290,6 @@ class Eagle(BaseDrafter):
         draft_model = self.draft_model_runner.model
         input_num_tokens = draft_input.input_num_tokens
 
-        # Multi-depth window mode and extend catch-up chain FULL per-row
-        # hidden states between depths (see _run_multi_step_windows /
-        # _run_extend_depth_catchup); logits stay gathered.
-        capture_mode = (
-            CaptureHiddenMode.FULL
-            if self._use_multi_depth_windows(draft_input)
-            or self._use_extend_depth_catchup(draft_input)
-            else CaptureHiddenMode.LAST
-        )
-
         ctx = ForwardContext(
             attn_backend=self.attn_backend,
             token_to_kv_pool=self.token_to_kv_pool,
@@ -671,7 +298,7 @@ class Eagle(BaseDrafter):
             num_extends=draft_input.num_extends,
             input_num_tokens=input_num_tokens,
             forward_mode=forward_mode,
-            capture_hidden_mode=capture_mode,
+            capture_hidden_mode=CaptureHiddenMode.LAST,
             gather_ids=gather_ids,
             global_num_tokens=draft_input.global_num_tokens,
             global_bs=draft_input.global_bs,
@@ -711,424 +338,6 @@ class Eagle(BaseDrafter):
                 num_prefill_rows=draft_input.num_extends,
             )
         return logits_output, dsa_topk
-
-    @nvtx_range("draft_multi_step_windows", color="purple")
-    def _run_multi_step_windows(
-        self,
-        bs: int,
-        next_tokens: torch.Tensor,
-        logits_output: LogitsProcessorOutput,
-        draft_input: EagleDraftInput,
-    ) -> None:
-        """Teacher-forced multi-depth catch-up (see _use_multi_depth_windows).
-
-        Every step d re-runs depth layer d over the SAME verify window the
-        first step processed (same positions and KV slot locations — the KV
-        pool write is layer-indexed), consuming:
-
-        - the previous depth's FULL chain-normed window rows as
-          captured_hidden_states (row j = source position p_j), and
-        - per-depth shifted input ids: row j of depth d needs the token at
-          source p_j + d, which is the verify output ``v[j + d]`` while it
-          lands inside the accepted prefix and the drafter's own token
-          ``d_m`` (m = j + d - accept + 1 <= d) at the accepted tail. Rows
-          past the accepted prefix are rejected-tail garbage; their KV is
-          rewritten by the next round's window, which starts at the first
-          uncommitted position.
-
-        The drafted token for step d is sampled at the accept-position row
-        (same gather as the first step). Nothing advances between steps: the
-        attention metadata, conv metadata (valid-length catch-up mode),
-        positions, and out_cache_loc of the first step are all reused.
-        """
-        if not self._window_mode_logged:
-            self._window_mode_logged = True
-            logger.info(
-                "MTP multi-depth window mode engaged (bs=%d, k=%d, steps=%d)",
-                bs,
-                self.spec_num_tokens,
-                self.spec_num_steps,
-            )
-        k = self.spec_num_tokens
-        buffers = self.input_buffers
-        v = draft_input.base_model_output.view(bs, k).to(torch.int64)
-        accept = draft_input.accept_lengths[:bs].to(torch.int64).clamp(1, k).view(bs, 1)
-        gather_ids = self._accepted_output_indices(draft_input.accept_lengths, bs)
-        positions = buffers.positions_buf[: bs * k]
-        out_cache_loc = buffers.out_cache_loc_buf[: bs * k]
-        col = torch.arange(k, dtype=torch.int64, device=v.device).view(1, k)
-
-        prev_hidden = logits_output.hidden_states  # [bs*k, H], depth d-1 rows
-        for d in range(1, self.spec_num_steps):
-            input_ids = _window_shifted_ids(
-                v, accept, next_tokens, d, src=col + d
-            ).reshape(-1)
-
-            if _WINDOW_CHAIN_TARGET_HIDDEN:
-                prev_hidden = draft_input.base_out_hidden_states
-            step_positions = positions + d if _WINDOW_POS_SHIFT else positions
-
-            ctx = ForwardContext(
-                bs=bs,
-                num_extends=0,
-                attn_backend=self.attn_backend,
-                token_to_kv_pool=self.token_to_kv_pool,
-                req_to_page=self.req_to_page,
-                input_num_tokens=bs * k,
-                forward_mode=ForwardMode.DECODE,
-                capture_hidden_mode=CaptureHiddenMode.FULL,
-                gather_ids=gather_ids,
-                global_num_tokens=draft_input.global_num_tokens,
-                global_bs=draft_input.global_bs,
-                all_decode_or_idle=draft_input.all_decode_or_idle,
-                draft_seq_lens_buf=self.draft_seq_lens_buf,
-                accept_lengths=draft_input.accept_lengths,
-            )
-
-            with nvtx_range("draft_window_forward", color="red"):
-                logits_output = self.draft_model_runner.forward(
-                    ctx=ctx,
-                    input_ids=self._map_hot(input_ids),
-                    positions=step_positions,
-                    out_cache_loc=out_cache_loc,
-                    captured_hidden_states=prev_hidden,
-                    spec_step_idx=d,
-                )
-            prev_hidden = logits_output.hidden_states
-
-            with nvtx_range("draft_sample", color="yellow"):
-                next_tokens[:, d + 1] = self._map_hot(
-                    self._sample_step_tokens(logits_output)
-                )
-
-    @nvtx_range("draft_multi_step_windows_lookback", color="purple")
-    def _run_multi_step_windows_lookback(
-        self,
-        bs: int,
-        next_tokens: torch.Tensor,
-        logits_output: LogitsProcessorOutput,
-        draft_input: EagleDraftInput,
-        slot: torch.Tensor,
-        v: torch.Tensor,
-        accept: torch.Tensor,
-    ) -> bool:
-        """Lookback variant of ``_run_multi_step_windows`` (§12 Hole 2).
-
-        Every depth d >= 1 re-runs over ``D + k`` rows per request
-        (D = steps-1): the D leading rows re-cover the last D committed
-        positions — whose entries were first written while their input
-        tokens were still unverified drafts — from now-committed tokens,
-        overwriting the stale KV and conv contributions in place. Depth 1's
-        lookback rows chain the stashed depth-0 hidden (depth 0 has no
-        residue of its own, so it never re-runs); deeper depths chain the
-        previous pass's corrected full rows directly.
-
-        Attention rides the first step's decode metadata unchanged: the rel
-        decode kernel derives ``max_seqlen_q`` from the row count, and with
-        the round's ``seq_lens`` the D+k queries land at positions
-        ``vc-D .. vc+k-1`` — exactly the extended window. Conv metadata is
-        rebuilt by the backend hook (lagged-window recurrence).
-
-        ``slot``/``v``/``accept`` come pre-sliced from the caller (see
-        ``_decode_window_slices``), which also feeds them to the stash roll.
-
-        Returns False when the backend refuses the lookback metadata; the
-        caller then falls back to the plain window pass. This runs inside
-        CUDA graph capture (MTP decode rounds are graph-captured), so there
-        are no host syncs: sub-D prompts, whose lookback would cross
-        position 0, are clamped GPU-side instead — their first positions
-        get wrong-shift rewrites, bounded to prompts shorter than steps-1
-        tokens (below any real chat traffic).
-        """
-        k = self.spec_num_tokens
-        lb = self.draft_lookback
-        buffers = self.input_buffers
-        positions = buffers.positions_buf[: bs * k]
-        first_pos = positions.view(bs, k)[:, 0]
-        enter = getattr(self.attn_backend, "enter_draft_lookback_window", None)
-        if enter is None or not enter(bs):
-            return False
-        if not self._lookback_mode_logged:
-            self._lookback_mode_logged = True
-            logger.info(
-                "MTP lookback window mode engaged (bs=%d, k=%d, D=%d, steps=%d)",
-                bs,
-                k,
-                lb,
-                self.spec_num_steps,
-            )
-        total = lb + k
-        gather_ids = (
-            torch.arange(bs, dtype=torch.int64, device=v.device) * total
-            + (lb - 1)
-            + accept.view(-1)
-        )
-        # The D lookback rows prepend the committed slots just before the
-        # verify window; their cache locs go through the paged mapping.
-        lb_positions = (
-            first_pos.view(bs, 1)
-            - lb
-            + torch.arange(lb, dtype=positions.dtype, device=v.device).view(1, lb)
-        ).clamp_min(0)
-        step_positions = torch.cat([lb_positions, positions.view(bs, k)], 1).reshape(-1)
-        lb_cache_loc = self.draft_out_cache_loc_buf[: bs * lb]
-        compute_out_cache_loc_uniform(
-            out_cache_loc_ptr=lb_cache_loc,
-            req_pool_indices=buffers.req_pool_indices_buf[:bs],
-            uniform_input_length=lb,
-            cache_start=(first_pos - lb).clamp_min(0).to(torch.int32),
-            req_to_pages=self.req_to_page,
-            page_size=self.page_size,
-        )
-        out_cache_loc = torch.cat(
-            [
-                lb_cache_loc.view(bs, lb),
-                buffers.out_cache_loc_buf[: bs * k].view(bs, k),
-            ],
-            1,
-        ).reshape(-1)
-        stash_tokens = self._lookback_tokens_buf[slot]
-        hidden_stash = self._lookback_hidden_buf
-        h0 = logits_output.hidden_states  # [bs*k, H], depth-0 rows
-        prev_hidden = torch.cat([hidden_stash[slot], h0.view(bs, k, -1)], 1).reshape(
-            bs * total, -1
-        )
-        # Depth-invariant base of the per-depth source coordinates.
-        base_src = (
-            torch.arange(total, dtype=torch.int64, device=v.device).view(1, total) - lb
-        )
-        for d in range(1, self.spec_num_steps):
-            input_ids = _window_lookback_shifted_ids(
-                v, accept, next_tokens, stash_tokens, d, lb, src=base_src + d
-            )
-            input_ids = self._prepare_draft_input_ids(input_ids)
-            pass_positions = step_positions + d if _WINDOW_POS_SHIFT else step_positions
-
-            ctx = ForwardContext(
-                bs=bs,
-                num_extends=0,
-                attn_backend=self.attn_backend,
-                token_to_kv_pool=self.token_to_kv_pool,
-                req_to_page=self.req_to_page,
-                input_num_tokens=bs * total,
-                forward_mode=ForwardMode.DECODE,
-                capture_hidden_mode=CaptureHiddenMode.FULL,
-                gather_ids=gather_ids,
-                global_num_tokens=draft_input.global_num_tokens,
-                global_bs=draft_input.global_bs,
-                all_decode_or_idle=draft_input.all_decode_or_idle,
-                draft_seq_lens_buf=self.draft_seq_lens_buf,
-                accept_lengths=draft_input.accept_lengths,
-            )
-
-            with nvtx_range("draft_window_lookback_forward", color="red"):
-                logits_output = self.draft_model_runner.forward(
-                    ctx=ctx,
-                    input_ids=self._map_hot(input_ids),
-                    positions=pass_positions,
-                    out_cache_loc=out_cache_loc,
-                    captured_hidden_states=prev_hidden,
-                    spec_step_idx=d,
-                )
-            prev_hidden = logits_output.hidden_states
-
-            with nvtx_range("draft_sample", color="yellow"):
-                next_tokens[:, d + 1] = self._map_hot(
-                    self._sample_step_tokens(logits_output)
-                )
-        return True
-
-    def _decode_window_slices(
-        self, bs: int, draft_input: EagleDraftInput
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """``(slot, v, accept)`` shared by the lookback window pass and the
-        decode stash roll: [bs] int64 stash slots, [bs, k] int64 verify
-        outputs, [bs, 1] int64 accepted lengths clamped to [1, k]."""
-        k = self.spec_num_tokens
-        slot = self.input_buffers.req_pool_indices_buf[:bs].to(torch.int64).clamp_min(0)
-        v = draft_input.base_model_output.view(bs, k).to(torch.int64)
-        accept = draft_input.accept_lengths[:bs].to(torch.int64).clamp(1, k).view(bs, 1)
-        return slot, v, accept
-
-    def _update_lookback_stash_decode(
-        self,
-        slot: torch.Tensor,
-        accept: torch.Tensor,
-        v: torch.Tensor,
-        h0: torch.Tensor,
-    ) -> None:
-        """Roll the cross-round stashes past a round's decode-row commits.
-
-        Args come pre-sliced per decode row: ``slot`` [n] int64 stash slots,
-        ``accept`` [n]-viewable int64 accepts clamped to [1, k], ``v`` [n, k]
-        int64 verify outputs, ``h0`` [n, k, H] depth-0 hidden rows.
-        """
-        lb = self.draft_lookback
-        tokens = self._lookback_tokens_buf
-        tokens[slot] = _committed_tail_update(tokens[slot], v, accept, lb)
-        hidden = self._lookback_hidden_buf
-        hidden[slot] = _committed_tail_update(hidden[slot], h0, accept, lb)
-
-    def _update_lookback_stash_extend(
-        self,
-        draft_input: EagleDraftInput,
-        h0_full: torch.Tensor,
-    ) -> None:
-        """Roll the stashes across an EXTEND/MIXED round's chunk rows.
-
-        Prefill requests stash the last D shift-1 ids and depth-0 rows of
-        their chunk (blending across chunk boundaries when a chunk is
-        shorter than D); MIXED decode rows roll the same committed-tail
-        update as pure decode, offset past the prefill rows.
-        """
-        lb = self.draft_lookback
-        k = self.spec_num_tokens
-        buffers = self.input_buffers
-        ne = draft_input.num_extends
-        bs = draft_input.accept_lengths.shape[0]
-        nd = bs - ne
-        num_prefill_tokens = draft_input.input_num_tokens - nd * k
-        slot = buffers.req_pool_indices_buf[:bs].to(torch.int64).clamp_min(0)
-        lengths = buffers.input_lengths_buf[:ne]
-        tokens = self._lookback_tokens_buf
-        hidden = self._lookback_hidden_buf
-        shift1 = buffers.shifted_prefill_ids_buf[:num_prefill_tokens].to(torch.int64)
-        extend_slot = slot[:ne]
-        tokens[extend_slot] = _ragged_tail_rows(
-            shift1, lengths, tokens[extend_slot], lb
-        )
-        hidden[extend_slot] = _ragged_tail_rows(
-            h0_full[:num_prefill_tokens], lengths, hidden[extend_slot], lb
-        )
-        if nd > 0:
-            self._update_lookback_stash_decode(
-                slot[ne:],
-                draft_input.accept_lengths[ne:bs].to(torch.int64).clamp(1, k),
-                draft_input.base_model_output[ne:].view(nd, k).to(torch.int64),
-                h0_full[num_prefill_tokens:].view(nd, k, -1),
-            )
-
-    @nvtx_range("draft_extend_catchup", color="purple")
-    def _run_extend_depth_catchup(
-        self,
-        bs: int,
-        next_tokens: torch.Tensor,
-        logits_output: LogitsProcessorOutput,
-        draft_input: EagleDraftInput,
-    ) -> None:
-        """Per-depth prompt coverage at EXTEND rounds (see the gate above).
-
-        Each step d re-runs depth layer d over the SAME ragged rows the first
-        step processed — identical positions, out_cache_loc, and attention /
-        conv metadata (the KV and conv pools are layer-indexed, so depth d's
-        writes land in its own layer) — consuming the previous depth's FULL
-        rows as captured_hidden_states and inputs shifted d further:
-
-        - prefill rows: the request's own prompt tokens (all known), with the
-          trailing d rows taking the round's fresh drafts (final chunk) or
-          placeholder columns (mid-chunk; backfilled never — known §14
-          approximation, <= steps-1 rows per chunk boundary);
-        - decode rows (MIXED batches): the window-mode gather over verify
-          outputs and drafts, offset past the prefill rows.
-
-        Step d's draft token is sampled at the same rows as the first step
-        (request-last prefill row / accept-position decode row), so this also
-        replaces the classic loop's one-token steps for EXTEND rounds.
-        """
-        if not self._extend_catchup_logged:
-            self._extend_catchup_logged = True
-            logger.info(
-                "MTP extend-time per-depth catch-up engaged "
-                "(bs=%d, num_extends=%d, steps=%d)",
-                bs,
-                draft_input.num_extends,
-                self.spec_num_steps,
-            )
-        k = self.spec_num_tokens
-        buffers = self.input_buffers
-        ne = draft_input.num_extends
-        nd = bs - ne
-        input_num_tokens = draft_input.input_num_tokens
-        num_prefill_tokens = input_num_tokens - nd * k
-
-        if self.draft_lookback:
-            # Before the loop rebinds logits_output: this round's chunk tail
-            # (tokens + depth-0 rows) feeds the next decode round's lookback.
-            self._update_lookback_stash_extend(draft_input, logits_output.hidden_states)
-
-        shift1_ids = buffers.shifted_prefill_ids_buf[:num_prefill_tokens]
-        input_lengths = buffers.input_lengths_buf[:ne]
-        gather_ids = input_lengths.to(torch.int64).cumsum(0) - 1
-        # Depth-invariant pieces of the per-depth shifted-id gathers
-        # (gather_ids doubles as the precompute's per-request last row).
-        extend_pre = _extend_depth_precompute(
-            shift1_ids, input_lengths, last_row=gather_ids
-        )
-        if nd > 0:
-            v = draft_input.base_model_output[ne:].view(nd, k).to(torch.int64)
-            accept = (
-                draft_input.accept_lengths[ne:].to(torch.int64).clamp(1, k).view(nd, 1)
-            )
-            col = torch.arange(k, dtype=torch.int64, device=v.device).view(1, k)
-            gather_ids = torch.cat(
-                [
-                    gather_ids,
-                    self._accepted_output_indices(
-                        draft_input.accept_lengths[ne:],
-                        nd,
-                        base_offset=num_prefill_tokens,
-                    ),
-                ]
-            )
-        positions = buffers.positions_buf[:input_num_tokens]
-        out_cache_loc = buffers.out_cache_loc_buf[:input_num_tokens]
-
-        prev_hidden = logits_output.hidden_states  # [input_num_tokens, H]
-        for d in range(1, self.spec_num_steps):
-            input_ids = _extend_depth_shifted_ids_from(extend_pre, next_tokens[:ne], d)
-            if nd > 0:
-                decode_ids = _window_shifted_ids(
-                    v, accept, next_tokens[ne:], d, src=col + d
-                )
-                input_ids = torch.cat([input_ids, decode_ids.reshape(-1)])
-            input_ids = self._prepare_draft_input_ids(input_ids)
-
-            if _WINDOW_CHAIN_TARGET_HIDDEN:
-                prev_hidden = draft_input.base_out_hidden_states
-            step_positions = positions + d if _WINDOW_POS_SHIFT else positions
-
-            ctx = ForwardContext(
-                bs=bs,
-                num_extends=ne,
-                attn_backend=self.attn_backend,
-                token_to_kv_pool=self.token_to_kv_pool,
-                req_to_page=self.req_to_page,
-                input_num_tokens=input_num_tokens,
-                forward_mode=draft_input.forward_mode,
-                capture_hidden_mode=CaptureHiddenMode.FULL,
-                gather_ids=gather_ids,
-                global_num_tokens=draft_input.global_num_tokens,
-                global_bs=draft_input.global_bs,
-                all_decode_or_idle=draft_input.all_decode_or_idle,
-                draft_seq_lens_buf=self.draft_seq_lens_buf,
-                accept_lengths=draft_input.accept_lengths,
-            )
-
-            with nvtx_range("draft_extend_catchup_forward", color="red"):
-                logits_output = self.draft_model_runner.forward(
-                    ctx=ctx,
-                    input_ids=self._map_hot(input_ids),
-                    positions=step_positions,
-                    out_cache_loc=out_cache_loc,
-                    captured_hidden_states=prev_hidden,
-                    spec_step_idx=d,
-                )
-            prev_hidden = logits_output.hidden_states
-
-            with nvtx_range("draft_sample", color="yellow"):
-                next_tokens[:, d + 1] = self._map_hot(
-                    self._sample_step_tokens(logits_output)
-                )
 
     @nvtx_range("draft_multi_step", color="purple")
     def _run_multi_step_decode(
@@ -1220,7 +429,10 @@ class Eagle(BaseDrafter):
                 dsa_topk = self._extract_dsa_topk(ctx, dsa_topk)
 
             with nvtx_range("draft_sample", color="yellow"):
-                draft_ids = self._sample_step_tokens(logits_output)
+                if logits_output.next_token_ids is not None:
+                    draft_ids = logits_output.next_token_ids
+                else:
+                    draft_ids = sampling_argmax(logits_output.next_token_logits)
                 # Column 0 holds last_verified_ids; drafter writes step `i` into column `i + 1`.
                 next_tokens[:, i + 1] = self._map_hot(draft_ids)
                 if i + 1 < self.spec_num_steps:
@@ -1291,7 +503,10 @@ class Eagle(BaseDrafter):
         # down to `[bs, ...]`, so logits/hidden_states arrive here already aligned to one row per request.
         logits_output, dsa_topk = self._run_first_step(bs, draft_input)
 
-        draft_ids = self._sample_step_tokens(logits_output)
+        if logits_output.next_token_ids is not None:
+            draft_ids = logits_output.next_token_ids
+        else:
+            draft_ids = sampling_argmax(logits_output.next_token_logits)
         next_tokens[:, 1] = self._map_hot(draft_ids)
 
         if self.spec_num_steps <= 1:
@@ -1305,22 +520,6 @@ class Eagle(BaseDrafter):
             # In DP we still run, because peer ranks may have completing
             # extends or decodes; diverging here would desync the drafter's
             # dense-TP / MoE-EP collectives (NCCL hang or RSAG mismatch).
-            #
-            # Extend catch-up still runs: its point is per-depth KV/sconv
-            # coverage of THIS chunk's rows, not the (discarded) drafts —
-            # skipping mid-chunks would leave every chunk but the last
-            # uncovered for depths >= 1 on long prompts.
-            if self._use_extend_depth_catchup(draft_input):
-                self._run_extend_depth_catchup(
-                    bs, next_tokens, logits_output, draft_input
-                )
-            return next_tokens
-
-        if self._use_extend_depth_catchup(draft_input):
-            # EXTEND/MIXED with per-depth prompt coverage: reuses the first
-            # step's extend metadata as-is, so it must run OUTSIDE the
-            # override_num_extends(0) below.
-            self._run_extend_depth_catchup(bs, next_tokens, logits_output, draft_input)
             return next_tokens
 
         # Draft step 2+ (multi-step decode).
@@ -1329,46 +528,14 @@ class Eagle(BaseDrafter):
         # backends that fill separate prefill/decode metadata at init
         # time.
         with self.attn_backend.override_num_extends(0):
-            if self._use_multi_depth_windows(draft_input):
-                use_lookback = self._use_decode_lookback(draft_input)
-                ran_lookback = False
-                if use_lookback:
-                    slot, v, accept = self._decode_window_slices(bs, draft_input)
-                    ran_lookback = self._run_multi_step_windows_lookback(
-                        bs,
-                        next_tokens,
-                        logits_output,
-                        draft_input,
-                        slot,
-                        v,
-                        accept,
-                    )
-                if not ran_lookback:
-                    self._run_multi_step_windows(
-                        bs,
-                        next_tokens,
-                        logits_output,
-                        draft_input,
-                    )
-                if use_lookback:
-                    # Keep the stashes fresh even on fallback rounds; the
-                    # next round may look back. logits_output here is still
-                    # the first step's FULL depth-0 capture.
-                    self._update_lookback_stash_decode(
-                        slot,
-                        accept,
-                        v,
-                        logits_output.hidden_states.view(bs, self.spec_num_tokens, -1),
-                    )
-            else:
-                self._run_multi_step_decode(
-                    bs,
-                    draft_ids,
-                    next_tokens,
-                    logits_output,
-                    draft_input,
-                    dsa_topk,
-                )
+            self._run_multi_step_decode(
+                bs,
+                draft_ids,
+                next_tokens,
+                logits_output,
+                draft_input,
+                dsa_topk,
+            )
         return next_tokens
 
     @override

--- a/python/tokenspeed/runtime/execution/drafter/mtp.py
+++ b/python/tokenspeed/runtime/execution/drafter/mtp.py
@@ -1,0 +1,1338 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Original multi-depth MTP drafter (e.g. Inkling).
+
+Hosts speculative drafting for MTP heads with multiple distinct depth
+layers, where speculative step ``d`` runs depth layer ``d`` over a shifted
+window and rejected drafts leave per-depth KV slots to repair (extend
+catch-up, decode windows, lookback stashes).
+
+Eagle-like MTP (MTP-Eagle: a single MTP layer chained on its own hidden,
+e.g. DeepSeek) stays in ``eagle.py``. Both register under
+``--speculative-algorithm MTP``; ``ModelExecutor`` routes to this drafter
+when the draft model declares ``draft_multi_depth_windows``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import torch
+from tokenspeed_kernel.ops.conv import seq_idx_from_cu_seqlens
+from tokenspeed_kernel.ops.sampling import argmax as sampling_argmax
+from typing_extensions import override
+
+from tokenspeed.runtime.execution.cache_loc_kernel import (
+    compute_out_cache_loc_uniform,
+)
+from tokenspeed.runtime.execution.context import ForwardContext
+from tokenspeed.runtime.execution.drafter.base import BaseDrafter
+from tokenspeed.runtime.execution.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardMode,
+)
+from tokenspeed.runtime.multimodal.inputs import Modality, maybe_substitute_mm_pad
+from tokenspeed.runtime.utils.nvtx import nvtx_range
+
+logger = logging.getLogger(__name__)
+
+# Multi-depth window dataflow A/B knobs (the 53a50800 MTP head ships no
+# reference implementation; these resolve its training dataflow empirically):
+# - CHAIN_TARGET_HIDDEN: every depth consumes the TARGET model's hidden
+#   (DeepSeek-MTP style) instead of the previous depth's chain-normed rows.
+# - POS_SHIFT: depth d's window rows carry positions p_j + d instead of p_j.
+_WINDOW_CHAIN_TARGET_HIDDEN = (
+    os.environ.get("INKLING_MTP_CHAIN_TARGET_HIDDEN", "0") == "1"
+)
+_WINDOW_POS_SHIFT = os.environ.get("INKLING_MTP_WINDOW_POS_SHIFT", "0") == "1"
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.execution.input_buffer import InputBuffers
+    from tokenspeed.runtime.execution.model_runner import ModelRunner
+    from tokenspeed.runtime.execution.runtime_states import RuntimeStates
+    from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
+    from tokenspeed.runtime.layers.attention.kv_cache.base import BaseTokenToKVPool
+    from tokenspeed.runtime.layers.logits_processor import LogitsProcessorOutput
+
+
+def _advance_draft_forward_metadata_if_supported(attn_backend, seq_lens) -> None:
+    advance = getattr(attn_backend, "advance_draft_forward_metadata", None)
+    if advance is not None:
+        advance(seq_lens)
+
+
+def _window_shifted_ids(
+    v: torch.Tensor,
+    accept: torch.Tensor,
+    next_tokens: torch.Tensor,
+    depth: int,
+    src: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Depth-``depth`` input ids over a decode verify window.
+
+    Row ``j`` consumes the token at source position ``p_j + depth``; in
+    verify-output coordinates that is ``src[j]``: ``src < accept`` reads
+    this round's verify output ``v[:, src]``, else the round's own draft
+    ``d_m`` (m = src - accept + 1 <= depth) from ``next_tokens`` columns
+    1..depth. Negative ``src`` rows (lookback) come out as ``drafts[:, 0]``;
+    the caller overlays them (see ``_window_lookback_shifted_ids``).
+
+    Args:
+        v: [bs, k] int64 verify outputs.
+        accept: [bs, 1] int64 accepted lengths clamped to [1, k].
+        next_tokens: [bs, >= depth+1] col 0 = last verified id, cols 1.. =
+            this round's drafts.
+        depth: draft depth d >= 1.
+        src: optional [1, n] (or [bs, n]) int64 source coordinates; defaults
+            to ``arange(k) + depth`` (the plain forward window).
+
+    Returns:
+        [bs, n] int64 input ids.
+    """
+    bs, k = v.shape
+    if src is None:
+        src = torch.arange(k, dtype=torch.int64, device=v.device).view(1, k) + depth
+    n = src.shape[-1]
+    from_verify = torch.gather(v, 1, src.clamp(0, k - 1).expand(bs, n))
+    drafts = next_tokens[:, 1 : depth + 1].to(torch.int64)
+    m = (src - accept).clamp(0, depth - 1)  # draft index - 1
+    from_draft = torch.gather(drafts, 1, m.expand(bs, n))
+    return torch.where(src < accept, from_verify, from_draft)
+
+
+def _extend_depth_precompute(
+    shift1_ids: torch.Tensor,
+    input_lengths: torch.Tensor,
+    last_row: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Depth-invariant pieces of :func:`_extend_depth_shifted_ids`.
+
+    Hoisted out of the catch-up depth loop; ``last_row`` (per-request cumsum
+    of ``input_lengths`` minus one) may be passed in when the caller already
+    computed it.
+
+    Returns:
+        ``(shift1_i64, base, req_of_row, row_last)``: the int64 shift-1 ids,
+        ``arange(num_rows)``, each row's request index, and the global index
+        of each row's request-final row.
+    """
+    device = shift1_ids.device
+    lengths = input_lengths.to(torch.int64)
+    num_rows = shift1_ids.shape[0]
+    if last_row is None:
+        last_row = lengths.cumsum(0) - 1
+    cu_seqlens = torch.nn.functional.pad(last_row + 1, (1, 0))
+    # Sync-free repeat_interleave(arange(ne), lengths) equivalent.
+    req_of_row = seq_idx_from_cu_seqlens(cu_seqlens, num_rows).to(torch.int64)
+    base = torch.arange(num_rows, dtype=torch.int64, device=device)
+    return shift1_ids.to(torch.int64), base, req_of_row, last_row[req_of_row]
+
+
+def _extend_depth_shifted_ids_from(
+    pre: tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+    next_tokens: torch.Tensor,
+    depth: int,
+) -> torch.Tensor:
+    """Per-depth gather of :func:`_extend_depth_shifted_ids` over ``pre``
+    (= :func:`_extend_depth_precompute` output)."""
+    shift1_i64, base, req_of_row, row_last = pre
+    num_rows = shift1_i64.shape[0]
+    src = base + depth
+    from_prompt = shift1_i64[src.clamp(max=num_rows - 1)]
+    overshoot = (src - row_last).clamp(1, depth)
+    from_draft = next_tokens.to(torch.int64)[req_of_row, overshoot]
+    return torch.where(src <= row_last, from_prompt, from_draft)
+
+
+def _extend_depth_shifted_ids(
+    shift1_ids: torch.Tensor,
+    input_lengths: torch.Tensor,
+    next_tokens: torch.Tensor,
+    depth: int,
+) -> torch.Tensor:
+    """Depth-``depth`` input ids for the ragged prefill rows of an EXTEND round.
+
+    ``shift1_ids`` are the first draft step's prefill inputs (prompt tokens
+    shifted by one within each request, last row already holding the round's
+    sampled token on final chunks). Depth ``d`` at local row ``i`` consumes the
+    token ``d`` further along: ``shift1_ids[row + d]`` while that stays inside
+    the request, else the request's own draft ``d_m`` (``m = overshoot``) from
+    ``next_tokens`` — columns ``1..d`` are already filled when depth ``d``
+    runs. On mid-chunk rows the overshoot tokens are not staged; those
+    trailing ``d`` rows per chunk consume the placeholder ``next_tokens``
+    columns (known §14 Step 1 approximation, <= steps-1 rows per chunk).
+
+    Args:
+        shift1_ids: [num_prefill_rows] first-step prefill input ids.
+        input_lengths: [num_extends] per-request prefill row counts.
+        next_tokens: [>=num_extends, >=depth+1] col 0 = last verified token,
+            cols 1.. = this round's drafts, per request.
+        depth: draft depth d >= 1.
+
+    Returns:
+        [num_prefill_rows] int64 input ids for the depth-``depth`` pass.
+    """
+    return _extend_depth_shifted_ids_from(
+        _extend_depth_precompute(shift1_ids, input_lengths), next_tokens, depth
+    )
+
+
+def _window_lookback_shifted_ids(
+    v: torch.Tensor,
+    accept: torch.Tensor,
+    next_tokens: torch.Tensor,
+    stash_tokens: torch.Tensor,
+    depth: int,
+    lookback: int,
+    src: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Depth-``depth`` input ids for a lookback decode window (§12 Hole 2).
+
+    Row ``r`` of the ``lookback + k`` window sits at source position
+    ``vc - lookback + r`` and consumes the token at source + depth + 1;
+    in verify-output coordinates that is ``src = r - lookback + depth``:
+    ``src < 0`` reads the stash of the last ``lookback`` committed tokens
+    (entry ``lookback + src``), ``src < accept`` this round's verify output
+    ``v[src]``, else this round's own draft ``d_m`` (m = src - accept + 1
+    <= depth) — identical to the plain window for the trailing k rows.
+
+    Args:
+        v: [bs, k] int64 verify outputs (token at position vc+j+1 = v[:, j]).
+        accept: [bs, 1] int64 accepted lengths clamped to [1, k].
+        next_tokens: [bs, >= depth+1] col 0 = last verified id, cols 1.. =
+            this round's drafts.
+        stash_tokens: [bs, lookback] int64 committed tokens at positions
+            vc-lookback+1 .. vc (the pre-window tail).
+        depth: draft depth d >= 1.
+        lookback: D >= 1 lookback rows.
+        src: optional [1, lookback + k] precomputed source coordinates
+            (``arange(total) - lookback + depth``), hoistable per depth.
+
+    Returns:
+        [bs * (lookback + k)] int64 input ids.
+    """
+    bs, k = v.shape
+    total = lookback + k
+    if src is None:
+        src = (
+            torch.arange(total, dtype=torch.int64, device=v.device).view(1, total)
+            - lookback
+            + depth
+        )
+    ids = _window_shifted_ids(v, accept, next_tokens, depth, src=src)
+    from_stash = stash_tokens.gather(
+        1, (src + lookback).clamp(0, lookback - 1).expand(bs, total)
+    )
+    ids = torch.where(src < 0, from_stash, ids)
+    return ids.reshape(-1)
+
+
+def _committed_tail_update(
+    stash: torch.Tensor,
+    fresh: torch.Tensor,
+    valid: torch.Tensor,
+    lookback: int,
+) -> torch.Tensor:
+    """Roll a committed-tail stash: last ``lookback`` of [stash || fresh[:valid]].
+
+    ``stash``: [bs, lookback, ...] previous tail; ``fresh``: [bs, k, ...]
+    this round's per-row values whose committed prefix is the first
+    ``valid`` rows (``fresh`` row 0 must directly follow the stash's last
+    entry); ``valid``: [bs] int64 in [1, k].
+
+    Returns:
+        The updated [bs, lookback, ...] tail.
+    """
+    bs = fresh.shape[0]
+    rows = (
+        valid.view(bs, 1)
+        - lookback
+        + torch.arange(lookback, dtype=torch.int64, device=fresh.device).view(
+            1, lookback
+        )
+    )
+    idx_shape = (bs, lookback) + (1,) * (fresh.dim() - 2)
+    expand = (bs, lookback) + fresh.shape[2:]
+    new_rows = fresh.gather(1, rows.clamp_min(0).view(idx_shape).expand(expand))
+    old_rows = stash.gather(
+        1, (rows + lookback).clamp(0, lookback - 1).view(idx_shape).expand(expand)
+    )
+    return torch.where((rows >= 0).view(idx_shape), new_rows, old_rows)
+
+
+def _ragged_tail_rows(
+    flat: torch.Tensor,
+    lengths: torch.Tensor,
+    old_tail: torch.Tensor,
+    lookback: int,
+) -> torch.Tensor:
+    """Per-request last ``lookback`` rows of ragged ``flat`` chunks.
+
+    Requests whose chunk is shorter than ``lookback`` borrow leading entries
+    from ``old_tail`` (the previous chunk's tail, contiguous with this
+    chunk's first row).
+
+    Args:
+        flat: [total, ...] ragged per-request rows.
+        lengths: [n] per-request row counts.
+        old_tail: [n, lookback, ...] previous tail.
+
+    Returns:
+        The updated [n, lookback, ...] tail.
+    """
+    n = lengths.shape[0]
+    lens = lengths.to(torch.int64)
+    starts = lens.cumsum(0) - lens
+    offs = (
+        lens.view(n, 1)
+        - lookback
+        + torch.arange(lookback, dtype=torch.int64, device=flat.device).view(
+            1, lookback
+        )
+    )
+    rows = (starts.view(n, 1) + offs.clamp_min(0)).clamp(max=max(flat.shape[0] - 1, 0))
+    new_rows = flat[rows.reshape(-1)].reshape((n, lookback) + flat.shape[1:])
+    idx_shape = (n, lookback) + (1,) * (old_tail.dim() - 2)
+    expand = (n, lookback) + old_tail.shape[2:]
+    old_rows = old_tail.gather(
+        1, (offs + lookback).clamp(0, lookback - 1).view(idx_shape).expand(expand)
+    )
+    return torch.where((offs >= 0).view(idx_shape), new_rows, old_rows)
+
+
+@dataclass
+class MtpDraftInput:
+    input_num_tokens: int
+    num_extends: int
+    forward_mode: ForwardMode
+    base_model_output: torch.Tensor  # [bs]
+    accept_lengths: torch.Tensor  # [bs]
+    base_out_hidden_states: torch.Tensor
+    global_num_tokens: list[int] | None = None
+    global_bs: list[int] | None = None
+    all_decode_or_idle: bool = False
+
+
+class Mtp(BaseDrafter):
+    """
+    Draft model runner for original multi-depth MTP heads.
+    """
+
+    def __init__(
+        self,
+        spec_num_tokens: int,
+        spec_num_steps: int,
+        page_size: int,
+        draft_model_runner: ModelRunner,
+        req_to_page: torch.Tensor,
+        attn_backend: AttentionBackend | None = None,
+        token_to_kv_pool: BaseTokenToKVPool | None = None,
+        runtime_states: RuntimeStates | None = None,
+        input_buffers: InputBuffers | None = None,
+        vocab_size: int | None = None,
+    ) -> None:
+
+        super().__init__(
+            spec_num_tokens,
+            spec_num_steps,
+            draft_model_runner,
+            runtime_states=runtime_states,
+            input_buffers=input_buffers,
+            page_size=page_size,
+            req_to_page=req_to_page,
+            attn_backend=attn_backend,
+            token_to_kv_pool=token_to_kv_pool,
+            vocab_size=vocab_size,
+        )
+
+        self.device = draft_model_runner.device
+
+        # For constructing fallback global_num_tokens during CUDA graph capture.
+        self.dp_size = draft_model_runner.mapping.attn.dp_size
+        self.world_size = draft_model_runner.mapping.world_size
+
+        # Drafter-owned alias source for the draft attn backend; advanced in
+        # place during multi-step decode.
+        self.draft_seq_lens_buf = torch.zeros_like(self.input_buffers.seq_lens_buf)
+
+        # Persistent output buffer for the draft step's compute_out_cache_loc.
+        self.draft_out_cache_loc_buf = torch.empty(
+            (self.input_buffers.max_bs * (spec_num_steps - 1),),
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+        # Precomputed `arange(max_bs) * spec_num_tokens - 1`
+        # gather_ids = gather_ids_offsets + accept_lengths
+        self.padded_gather_ids_offsets_buf = (
+            torch.arange(
+                self.input_buffers.max_bs, dtype=torch.int64, device=self.device
+            )
+            * spec_num_tokens
+            - 1
+        )
+
+        # In-vocab media tokens plumbed by ModelExecutor. The content-derived
+        # prefix-cache pad IDs retain a modality tag and are restored here before
+        # the text-only speculative draft performs its embedding lookup.
+        self.mm_pad_substitute_ids: dict[Modality, int] = {}
+
+        # Log-once flags for the window/lookback/catch-up engagement banners.
+        self._window_mode_logged = False
+        self._lookback_mode_logged = False
+        self._extend_catchup_logged = False
+
+        # Decode-window lookback: the model's
+        # draft_decode_lookback already folds in window mode AND extend
+        # catch-up (the lookback's prompt boundary and per-depth conv lag are
+        # built by those passes); armed only when the backend supports the
+        # lagged-conv recurrence. DP is excluded: the lookback rows change
+        # per-rank token counts.
+        model = draft_model_runner.model
+        lookback = 0
+        if (
+            spec_num_steps > 1
+            and self.dp_size == 1
+            and not _WINDOW_CHAIN_TARGET_HIDDEN
+            and getattr(model, "draft_decode_lookback", False)
+        ):
+            lookback = spec_num_steps - 1
+            configure = getattr(self.attn_backend, "configure_draft_lookback", None)
+            if configure is None or not configure(lookback):
+                lookback = 0
+        self.draft_lookback = lookback
+        # Cross-round stashes keyed by req_pool_indices (PAD rows clamp to the
+        # reserved slot 0): the last D committed tokens and depth-0 chain rows
+        # per request. Allocated eagerly — the decode rounds that fill them
+        # run inside CUDA graph capture, where allocation is off-limits.
+        self._lookback_hidden_buf: torch.Tensor | None = None
+        if lookback:
+            model_config = draft_model_runner.model_config
+            self._lookback_tokens_buf = torch.zeros(
+                (req_to_page.shape[0], lookback),
+                dtype=torch.int64,
+                device=self.device,
+            )
+            self._lookback_hidden_buf = torch.zeros(
+                (req_to_page.shape[0], lookback, model_config.hidden_size),
+                dtype=model_config.dtype,
+                device=self.device,
+            )
+
+    def _accepted_output_indices(
+        self,
+        accept_lengths: torch.Tensor,
+        row_count: int,
+        *,
+        base_offset: int = 0,
+    ) -> torch.Tensor:
+        """Return safe flat output-token indices for each decode request.
+
+        ``accept_lengths`` is the number of tokens that may be committed.  When
+        the context-length cap reduces a row to 0 there is no real newly
+        committed output token, but the drafter still runs to preserve graph
+        shape.  Use the row's first verify output as a valid dummy source rather
+        than producing ``row * N - 1``.
+        """
+        safe_accept_lengths = (
+            accept_lengths[:row_count].to(torch.int64).clamp(1, self.spec_num_tokens)
+        )
+        return (
+            self.padded_gather_ids_offsets_buf[:row_count]
+            + safe_accept_lengths
+            + base_offset
+        )
+
+    def set_mm_pad_substitute_ids(self, substitute_ids: dict[Modality, int]) -> None:
+        if self.vocab_size is None:
+            raise ValueError("MM draft substitution requires a known vocabulary size")
+        invalid = {
+            modality: token_id
+            for modality, token_id in substitute_ids.items()
+            if token_id < 0 or token_id >= self.vocab_size
+        }
+        if invalid:
+            raise ValueError(
+                "MM draft substitute token IDs must be inside the target vocabulary: "
+                f"{invalid} (vocab_size={self.vocab_size})"
+            )
+        self.mm_pad_substitute_ids = dict(substitute_ids)
+
+    def _prepare_draft_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        """Restore tagged media pads, then guard the draft embedding lookup."""
+        input_ids = maybe_substitute_mm_pad(input_ids, self.mm_pad_substitute_ids)
+        return input_ids.clamp(0, self.vocab_size - 1)
+
+    def _use_multi_depth_windows(self, draft_input: MtpDraftInput) -> bool:
+        """Teacher-forced multi-depth catch-up (draft-model opt-in).
+
+        Multi-depth MTP heads are trained as full-sequence layers: depth d's
+        attention at source position p runs over depth-d activations of ALL
+        positions <= p. The classic multi-step loop gives depth d>0 exactly
+        one new row per round, so its decode queries attend over a KV window
+        it mostly never wrote (stale garbage). In window mode every step
+        re-runs its depth over the whole verify window — dense per-depth KV
+        and sconv state over the accepted prefix — with per-depth
+        token-shifted inputs and the previous depth's full-row chain-normed
+        hidden. Pure-decode rounds only; MIXED rounds keep the classic loop.
+        """
+        return (
+            self.spec_num_steps > 1
+            and draft_input.num_extends == 0
+            and not draft_input.forward_mode.is_idle()
+            and bool(
+                getattr(
+                    self.draft_model_runner.model, "draft_multi_depth_windows", False
+                )
+            )
+        )
+
+    def _use_extend_depth_catchup(self, draft_input: MtpDraftInput) -> bool:
+        """Per-depth prompt coverage at EXTEND rounds (draft-model opt-in).
+
+        Window mode (above) only repairs pure-decode rounds, so depths >= 1
+        never write KV or sconv state over the prompt region — their decode
+        queries then attend over never-written prompt keys
+        forever. When the draft model opts in, EXTEND and
+        MIXED rounds re-run depths 1..steps-1 over the same ragged rows as the
+        first step (per-depth token-shifted inputs, chained full-row hidden),
+        which builds every used depth's dense prompt KV and sconv prompt
+        state chunk by chunk and replaces the classic loop's one-token steps.
+        """
+        return (
+            self.spec_num_steps > 1
+            and draft_input.num_extends > 0
+            and not draft_input.forward_mode.is_idle()
+            and bool(
+                getattr(
+                    self.draft_model_runner.model, "draft_extend_depth_catchup", False
+                )
+            )
+        )
+
+    def _use_decode_lookback(self, draft_input: MtpDraftInput) -> bool:
+        """Lookback rows for the window pass (§12 Hole 2, armed at init).
+
+        At depth d, the last d committed rows of each round's window embed
+        the round's own unverified drafts; once a draft is rejected those
+        KV/conv entries are permanently wrong under the forward-only window.
+        The lookback variant prepends D = steps-1 rows so the previous
+        round's provisional entries are recomputed from committed tokens.
+        """
+        return self.draft_lookback > 0 and self._use_multi_depth_windows(draft_input)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _sample_step_tokens(self, logits_output: LogitsProcessorOutput) -> torch.Tensor:
+        """One draft step's raw sampled ids: the logits processor's
+        pre-sampled ids when present, greedy argmax otherwise."""
+        if logits_output.next_token_ids is not None:
+            return logits_output.next_token_ids
+        return sampling_argmax(logits_output.next_token_logits)
+
+    def _get_first_step_input(
+        self,
+        draft_input: MtpDraftInput,
+        bs: int,
+        input_num_tokens: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Returns (input_ids, gather_ids) for the first draft step.
+
+        The first-step input shape matches the base model's: ragged
+        ``[prefill_part || decode_part]`` under MIXED, full prefill chunks
+        under EXTEND, ``base_model_output`` directly under DECODE.
+        """
+        num_extends = draft_input.num_extends
+        num_decodes = bs - num_extends
+        if num_extends > 0:
+            num_decode_tokens = num_decodes * self.spec_num_tokens
+            num_prefill_tokens = input_num_tokens - num_decode_tokens
+
+            input_ids = self.input_buffers.shifted_prefill_ids_buf[:input_num_tokens]
+            unpadded_input_lengths = self.input_buffers.input_lengths_buf[:bs]
+            if num_decodes > 0:
+                input_ids[num_prefill_tokens:].copy_(
+                    draft_input.base_model_output[num_extends:]
+                )
+                unpadded_input_lengths[num_extends:].copy_(
+                    draft_input.accept_lengths[num_extends:]
+                )
+
+            last_indices = unpadded_input_lengths[:num_extends].cumsum(0) - 1
+            last_input_ids = input_ids[last_indices]
+            input_ids[last_indices] = torch.where(
+                last_input_ids == -1,
+                draft_input.base_model_output[:num_extends],
+                last_input_ids,
+            )
+
+            gather_ids = last_indices
+            if num_decodes > 0:
+                gather_ids = torch.cat(
+                    [
+                        gather_ids,
+                        self._accepted_output_indices(
+                            draft_input.accept_lengths[num_extends:],
+                            num_decodes,
+                            base_offset=num_prefill_tokens,
+                        ),
+                    ]
+                )
+        else:
+            input_ids = draft_input.base_model_output
+            gather_ids = self._accepted_output_indices(
+                draft_input.accept_lengths,
+                bs,
+            )
+
+        return input_ids, gather_ids
+
+    @nvtx_range("draft_first_step", color="purple")
+    def _run_first_step(
+        self,
+        bs: int,
+        draft_input: MtpDraftInput,
+    ) -> LogitsProcessorOutput:
+
+        buffers = self.input_buffers
+        forward_mode = draft_input.forward_mode
+
+        input_ids, gather_ids = self._get_first_step_input(
+            draft_input, bs, draft_input.input_num_tokens
+        )
+        input_ids = self._prepare_draft_input_ids(input_ids)
+        input_num_tokens = draft_input.input_num_tokens
+
+        # Multi-depth window mode and extend catch-up chain FULL per-row
+        # hidden states between depths (see _run_multi_step_windows /
+        # _run_extend_depth_catchup); logits stay gathered.
+        capture_mode = (
+            CaptureHiddenMode.FULL
+            if self._use_multi_depth_windows(draft_input)
+            or self._use_extend_depth_catchup(draft_input)
+            else CaptureHiddenMode.LAST
+        )
+
+        ctx = ForwardContext(
+            attn_backend=self.attn_backend,
+            token_to_kv_pool=self.token_to_kv_pool,
+            req_to_page=self.req_to_page,
+            bs=bs,
+            num_extends=draft_input.num_extends,
+            input_num_tokens=input_num_tokens,
+            forward_mode=forward_mode,
+            capture_hidden_mode=capture_mode,
+            gather_ids=gather_ids,
+            global_num_tokens=draft_input.global_num_tokens,
+            global_bs=draft_input.global_bs,
+            all_decode_or_idle=draft_input.all_decode_or_idle,
+            draft_seq_lens_buf=self.draft_seq_lens_buf,
+            accept_lengths=draft_input.accept_lengths,
+        )
+
+        logits_output = self.draft_model_runner.forward(
+            ctx=ctx,
+            input_ids=input_ids,
+            positions=buffers.positions_buf[:input_num_tokens],
+            out_cache_loc=buffers.out_cache_loc_buf[:input_num_tokens],
+            captured_hidden_states=draft_input.base_out_hidden_states,
+            spec_step_idx=0,
+        )
+        return logits_output
+
+    @nvtx_range("draft_multi_step_windows", color="purple")
+    def _run_multi_step_windows(
+        self,
+        bs: int,
+        next_tokens: torch.Tensor,
+        logits_output: LogitsProcessorOutput,
+        draft_input: MtpDraftInput,
+    ) -> None:
+        """Teacher-forced multi-depth catch-up (see _use_multi_depth_windows).
+
+        Every step d re-runs depth layer d over the SAME verify window the
+        first step processed (same positions and KV slot locations — the KV
+        pool write is layer-indexed), consuming:
+
+        - the previous depth's FULL chain-normed window rows as
+          captured_hidden_states (row j = source position p_j), and
+        - per-depth shifted input ids: row j of depth d needs the token at
+          source p_j + d, which is the verify output ``v[j + d]`` while it
+          lands inside the accepted prefix and the drafter's own token
+          ``d_m`` (m = j + d - accept + 1 <= d) at the accepted tail. Rows
+          past the accepted prefix are rejected-tail garbage; their KV is
+          rewritten by the next round's window, which starts at the first
+          uncommitted position.
+
+        The drafted token for step d is sampled at the accept-position row
+        (same gather as the first step). Nothing advances between steps: the
+        attention metadata, conv metadata (valid-length catch-up mode),
+        positions, and out_cache_loc of the first step are all reused.
+        """
+        if not self._window_mode_logged:
+            self._window_mode_logged = True
+            logger.info(
+                "MTP multi-depth window mode engaged (bs=%d, k=%d, steps=%d)",
+                bs,
+                self.spec_num_tokens,
+                self.spec_num_steps,
+            )
+        k = self.spec_num_tokens
+        buffers = self.input_buffers
+        v = draft_input.base_model_output.view(bs, k).to(torch.int64)
+        accept = draft_input.accept_lengths[:bs].to(torch.int64).clamp(1, k).view(bs, 1)
+        gather_ids = self._accepted_output_indices(draft_input.accept_lengths, bs)
+        positions = buffers.positions_buf[: bs * k]
+        out_cache_loc = buffers.out_cache_loc_buf[: bs * k]
+        col = torch.arange(k, dtype=torch.int64, device=v.device).view(1, k)
+
+        prev_hidden = logits_output.hidden_states  # [bs*k, H], depth d-1 rows
+        for d in range(1, self.spec_num_steps):
+            input_ids = _window_shifted_ids(
+                v, accept, next_tokens, d, src=col + d
+            ).reshape(-1)
+
+            if _WINDOW_CHAIN_TARGET_HIDDEN:
+                prev_hidden = draft_input.base_out_hidden_states
+            step_positions = positions + d if _WINDOW_POS_SHIFT else positions
+
+            ctx = ForwardContext(
+                bs=bs,
+                num_extends=0,
+                attn_backend=self.attn_backend,
+                token_to_kv_pool=self.token_to_kv_pool,
+                req_to_page=self.req_to_page,
+                input_num_tokens=bs * k,
+                forward_mode=ForwardMode.DECODE,
+                capture_hidden_mode=CaptureHiddenMode.FULL,
+                gather_ids=gather_ids,
+                global_num_tokens=draft_input.global_num_tokens,
+                global_bs=draft_input.global_bs,
+                all_decode_or_idle=draft_input.all_decode_or_idle,
+                draft_seq_lens_buf=self.draft_seq_lens_buf,
+                accept_lengths=draft_input.accept_lengths,
+            )
+
+            with nvtx_range("draft_window_forward", color="red"):
+                logits_output = self.draft_model_runner.forward(
+                    ctx=ctx,
+                    input_ids=input_ids,
+                    positions=step_positions,
+                    out_cache_loc=out_cache_loc,
+                    captured_hidden_states=prev_hidden,
+                    spec_step_idx=d,
+                )
+            prev_hidden = logits_output.hidden_states
+
+            with nvtx_range("draft_sample", color="yellow"):
+                next_tokens[:, d + 1] = self._sample_step_tokens(logits_output)
+
+    @nvtx_range("draft_multi_step_windows_lookback", color="purple")
+    def _run_multi_step_windows_lookback(
+        self,
+        bs: int,
+        next_tokens: torch.Tensor,
+        logits_output: LogitsProcessorOutput,
+        draft_input: MtpDraftInput,
+        slot: torch.Tensor,
+        v: torch.Tensor,
+        accept: torch.Tensor,
+    ) -> bool:
+        """Lookback variant of ``_run_multi_step_windows`` (§12 Hole 2).
+
+        Every depth d >= 1 re-runs over ``D + k`` rows per request
+        (D = steps-1): the D leading rows re-cover the last D committed
+        positions — whose entries were first written while their input
+        tokens were still unverified drafts — from now-committed tokens,
+        overwriting the stale KV and conv contributions in place. Depth 1's
+        lookback rows chain the stashed depth-0 hidden (depth 0 has no
+        residue of its own, so it never re-runs); deeper depths chain the
+        previous pass's corrected full rows directly.
+
+        Attention rides the first step's decode metadata unchanged: the rel
+        decode kernel derives ``max_seqlen_q`` from the row count, and with
+        the round's ``seq_lens`` the D+k queries land at positions
+        ``vc-D .. vc+k-1`` — exactly the extended window. Conv metadata is
+        rebuilt by the backend hook (lagged-window recurrence).
+
+        ``slot``/``v``/``accept`` come pre-sliced from the caller (see
+        ``_decode_window_slices``), which also feeds them to the stash roll.
+
+        Returns False when the backend refuses the lookback metadata; the
+        caller then falls back to the plain window pass. This runs inside
+        CUDA graph capture (MTP decode rounds are graph-captured), so there
+        are no host syncs: sub-D prompts, whose lookback would cross
+        position 0, are clamped GPU-side instead — their first positions
+        get wrong-shift rewrites, bounded to prompts shorter than steps-1
+        tokens (below any real chat traffic).
+        """
+        k = self.spec_num_tokens
+        lb = self.draft_lookback
+        buffers = self.input_buffers
+        positions = buffers.positions_buf[: bs * k]
+        first_pos = positions.view(bs, k)[:, 0]
+        enter = getattr(self.attn_backend, "enter_draft_lookback_window", None)
+        if enter is None or not enter(bs):
+            return False
+        if not self._lookback_mode_logged:
+            self._lookback_mode_logged = True
+            logger.info(
+                "MTP lookback window mode engaged (bs=%d, k=%d, D=%d, steps=%d)",
+                bs,
+                k,
+                lb,
+                self.spec_num_steps,
+            )
+        total = lb + k
+        gather_ids = (
+            torch.arange(bs, dtype=torch.int64, device=v.device) * total
+            + (lb - 1)
+            + accept.view(-1)
+        )
+        # The D lookback rows prepend the committed slots just before the
+        # verify window; their cache locs go through the paged mapping.
+        lb_positions = (
+            first_pos.view(bs, 1)
+            - lb
+            + torch.arange(lb, dtype=positions.dtype, device=v.device).view(1, lb)
+        ).clamp_min(0)
+        step_positions = torch.cat([lb_positions, positions.view(bs, k)], 1).reshape(-1)
+        lb_cache_loc = self.draft_out_cache_loc_buf[: bs * lb]
+        compute_out_cache_loc_uniform(
+            out_cache_loc_ptr=lb_cache_loc,
+            req_pool_indices=buffers.req_pool_indices_buf[:bs],
+            uniform_input_length=lb,
+            cache_start=(first_pos - lb).clamp_min(0).to(torch.int32),
+            req_to_pages=self.req_to_page,
+            page_size=self.page_size,
+        )
+        out_cache_loc = torch.cat(
+            [
+                lb_cache_loc.view(bs, lb),
+                buffers.out_cache_loc_buf[: bs * k].view(bs, k),
+            ],
+            1,
+        ).reshape(-1)
+        stash_tokens = self._lookback_tokens_buf[slot]
+        hidden_stash = self._lookback_hidden_buf
+        h0 = logits_output.hidden_states  # [bs*k, H], depth-0 rows
+        prev_hidden = torch.cat([hidden_stash[slot], h0.view(bs, k, -1)], 1).reshape(
+            bs * total, -1
+        )
+        # Depth-invariant base of the per-depth source coordinates.
+        base_src = (
+            torch.arange(total, dtype=torch.int64, device=v.device).view(1, total) - lb
+        )
+        for d in range(1, self.spec_num_steps):
+            input_ids = _window_lookback_shifted_ids(
+                v, accept, next_tokens, stash_tokens, d, lb, src=base_src + d
+            )
+            input_ids = self._prepare_draft_input_ids(input_ids)
+            pass_positions = step_positions + d if _WINDOW_POS_SHIFT else step_positions
+
+            ctx = ForwardContext(
+                bs=bs,
+                num_extends=0,
+                attn_backend=self.attn_backend,
+                token_to_kv_pool=self.token_to_kv_pool,
+                req_to_page=self.req_to_page,
+                input_num_tokens=bs * total,
+                forward_mode=ForwardMode.DECODE,
+                capture_hidden_mode=CaptureHiddenMode.FULL,
+                gather_ids=gather_ids,
+                global_num_tokens=draft_input.global_num_tokens,
+                global_bs=draft_input.global_bs,
+                all_decode_or_idle=draft_input.all_decode_or_idle,
+                draft_seq_lens_buf=self.draft_seq_lens_buf,
+                accept_lengths=draft_input.accept_lengths,
+            )
+
+            with nvtx_range("draft_window_lookback_forward", color="red"):
+                logits_output = self.draft_model_runner.forward(
+                    ctx=ctx,
+                    input_ids=input_ids,
+                    positions=pass_positions,
+                    out_cache_loc=out_cache_loc,
+                    captured_hidden_states=prev_hidden,
+                    spec_step_idx=d,
+                )
+            prev_hidden = logits_output.hidden_states
+
+            with nvtx_range("draft_sample", color="yellow"):
+                next_tokens[:, d + 1] = self._sample_step_tokens(logits_output)
+        return True
+
+    def _decode_window_slices(
+        self, bs: int, draft_input: MtpDraftInput
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """``(slot, v, accept)`` shared by the lookback window pass and the
+        decode stash roll: [bs] int64 stash slots, [bs, k] int64 verify
+        outputs, [bs, 1] int64 accepted lengths clamped to [1, k]."""
+        k = self.spec_num_tokens
+        slot = self.input_buffers.req_pool_indices_buf[:bs].to(torch.int64).clamp_min(0)
+        v = draft_input.base_model_output.view(bs, k).to(torch.int64)
+        accept = draft_input.accept_lengths[:bs].to(torch.int64).clamp(1, k).view(bs, 1)
+        return slot, v, accept
+
+    def _update_lookback_stash_decode(
+        self,
+        slot: torch.Tensor,
+        accept: torch.Tensor,
+        v: torch.Tensor,
+        h0: torch.Tensor,
+    ) -> None:
+        """Roll the cross-round stashes past a round's decode-row commits.
+
+        Args come pre-sliced per decode row: ``slot`` [n] int64 stash slots,
+        ``accept`` [n]-viewable int64 accepts clamped to [1, k], ``v`` [n, k]
+        int64 verify outputs, ``h0`` [n, k, H] depth-0 hidden rows.
+        """
+        lb = self.draft_lookback
+        tokens = self._lookback_tokens_buf
+        tokens[slot] = _committed_tail_update(tokens[slot], v, accept, lb)
+        hidden = self._lookback_hidden_buf
+        hidden[slot] = _committed_tail_update(hidden[slot], h0, accept, lb)
+
+    def _update_lookback_stash_extend(
+        self,
+        draft_input: MtpDraftInput,
+        h0_full: torch.Tensor,
+    ) -> None:
+        """Roll the stashes across an EXTEND/MIXED round's chunk rows.
+
+        Prefill requests stash the last D shift-1 ids and depth-0 rows of
+        their chunk (blending across chunk boundaries when a chunk is
+        shorter than D); MIXED decode rows roll the same committed-tail
+        update as pure decode, offset past the prefill rows.
+        """
+        lb = self.draft_lookback
+        k = self.spec_num_tokens
+        buffers = self.input_buffers
+        ne = draft_input.num_extends
+        bs = draft_input.accept_lengths.shape[0]
+        nd = bs - ne
+        num_prefill_tokens = draft_input.input_num_tokens - nd * k
+        slot = buffers.req_pool_indices_buf[:bs].to(torch.int64).clamp_min(0)
+        lengths = buffers.input_lengths_buf[:ne]
+        tokens = self._lookback_tokens_buf
+        hidden = self._lookback_hidden_buf
+        shift1 = buffers.shifted_prefill_ids_buf[:num_prefill_tokens].to(torch.int64)
+        extend_slot = slot[:ne]
+        tokens[extend_slot] = _ragged_tail_rows(
+            shift1, lengths, tokens[extend_slot], lb
+        )
+        hidden[extend_slot] = _ragged_tail_rows(
+            h0_full[:num_prefill_tokens], lengths, hidden[extend_slot], lb
+        )
+        if nd > 0:
+            self._update_lookback_stash_decode(
+                slot[ne:],
+                draft_input.accept_lengths[ne:bs].to(torch.int64).clamp(1, k),
+                draft_input.base_model_output[ne:].view(nd, k).to(torch.int64),
+                h0_full[num_prefill_tokens:].view(nd, k, -1),
+            )
+
+    @nvtx_range("draft_extend_catchup", color="purple")
+    def _run_extend_depth_catchup(
+        self,
+        bs: int,
+        next_tokens: torch.Tensor,
+        logits_output: LogitsProcessorOutput,
+        draft_input: MtpDraftInput,
+    ) -> None:
+        """Per-depth prompt coverage at EXTEND rounds (see the gate above).
+
+        Each step d re-runs depth layer d over the SAME ragged rows the first
+        step processed — identical positions, out_cache_loc, and attention /
+        conv metadata (the KV and conv pools are layer-indexed, so depth d's
+        writes land in its own layer) — consuming the previous depth's FULL
+        rows as captured_hidden_states and inputs shifted d further:
+
+        - prefill rows: the request's own prompt tokens (all known), with the
+          trailing d rows taking the round's fresh drafts (final chunk) or
+          placeholder columns (mid-chunk; backfilled never — known §14
+          approximation, <= steps-1 rows per chunk boundary);
+        - decode rows (MIXED batches): the window-mode gather over verify
+          outputs and drafts, offset past the prefill rows.
+
+        Step d's draft token is sampled at the same rows as the first step
+        (request-last prefill row / accept-position decode row), so this also
+        replaces the classic loop's one-token steps for EXTEND rounds.
+        """
+        if not self._extend_catchup_logged:
+            self._extend_catchup_logged = True
+            logger.info(
+                "MTP extend-time per-depth catch-up engaged "
+                "(bs=%d, num_extends=%d, steps=%d)",
+                bs,
+                draft_input.num_extends,
+                self.spec_num_steps,
+            )
+        k = self.spec_num_tokens
+        buffers = self.input_buffers
+        ne = draft_input.num_extends
+        nd = bs - ne
+        input_num_tokens = draft_input.input_num_tokens
+        num_prefill_tokens = input_num_tokens - nd * k
+
+        if self.draft_lookback:
+            # Before the loop rebinds logits_output: this round's chunk tail
+            # (tokens + depth-0 rows) feeds the next decode round's lookback.
+            self._update_lookback_stash_extend(draft_input, logits_output.hidden_states)
+
+        shift1_ids = buffers.shifted_prefill_ids_buf[:num_prefill_tokens]
+        input_lengths = buffers.input_lengths_buf[:ne]
+        gather_ids = input_lengths.to(torch.int64).cumsum(0) - 1
+        # Depth-invariant pieces of the per-depth shifted-id gathers
+        # (gather_ids doubles as the precompute's per-request last row).
+        extend_pre = _extend_depth_precompute(
+            shift1_ids, input_lengths, last_row=gather_ids
+        )
+        if nd > 0:
+            v = draft_input.base_model_output[ne:].view(nd, k).to(torch.int64)
+            accept = (
+                draft_input.accept_lengths[ne:].to(torch.int64).clamp(1, k).view(nd, 1)
+            )
+            col = torch.arange(k, dtype=torch.int64, device=v.device).view(1, k)
+            gather_ids = torch.cat(
+                [
+                    gather_ids,
+                    self._accepted_output_indices(
+                        draft_input.accept_lengths[ne:],
+                        nd,
+                        base_offset=num_prefill_tokens,
+                    ),
+                ]
+            )
+        positions = buffers.positions_buf[:input_num_tokens]
+        out_cache_loc = buffers.out_cache_loc_buf[:input_num_tokens]
+
+        prev_hidden = logits_output.hidden_states  # [input_num_tokens, H]
+        for d in range(1, self.spec_num_steps):
+            input_ids = _extend_depth_shifted_ids_from(extend_pre, next_tokens[:ne], d)
+            if nd > 0:
+                decode_ids = _window_shifted_ids(
+                    v, accept, next_tokens[ne:], d, src=col + d
+                )
+                input_ids = torch.cat([input_ids, decode_ids.reshape(-1)])
+            input_ids = self._prepare_draft_input_ids(input_ids)
+
+            if _WINDOW_CHAIN_TARGET_HIDDEN:
+                prev_hidden = draft_input.base_out_hidden_states
+            step_positions = positions + d if _WINDOW_POS_SHIFT else positions
+
+            ctx = ForwardContext(
+                bs=bs,
+                num_extends=ne,
+                attn_backend=self.attn_backend,
+                token_to_kv_pool=self.token_to_kv_pool,
+                req_to_page=self.req_to_page,
+                input_num_tokens=input_num_tokens,
+                forward_mode=draft_input.forward_mode,
+                capture_hidden_mode=CaptureHiddenMode.FULL,
+                gather_ids=gather_ids,
+                global_num_tokens=draft_input.global_num_tokens,
+                global_bs=draft_input.global_bs,
+                all_decode_or_idle=draft_input.all_decode_or_idle,
+                draft_seq_lens_buf=self.draft_seq_lens_buf,
+                accept_lengths=draft_input.accept_lengths,
+            )
+
+            with nvtx_range("draft_extend_catchup_forward", color="red"):
+                logits_output = self.draft_model_runner.forward(
+                    ctx=ctx,
+                    input_ids=input_ids,
+                    positions=step_positions,
+                    out_cache_loc=out_cache_loc,
+                    captured_hidden_states=prev_hidden,
+                    spec_step_idx=d,
+                )
+            prev_hidden = logits_output.hidden_states
+
+            with nvtx_range("draft_sample", color="yellow"):
+                next_tokens[:, d + 1] = self._sample_step_tokens(logits_output)
+
+    @nvtx_range("draft_multi_step", color="purple")
+    def _run_multi_step_decode(
+        self,
+        bs: int,
+        draft_ids: torch.Tensor,
+        next_tokens: torch.Tensor,
+        logits_output: LogitsProcessorOutput,
+        draft_input: MtpDraftInput,
+    ) -> None:
+        num_extends = draft_input.num_extends
+        num_decodes = bs - num_extends
+        req_pool_indices = self.input_buffers.req_pool_indices_buf[:bs]
+        cache_start = self.input_buffers.seq_lens_buf[:bs].clone()
+        # Step 1's write position uses vc+accept_length after target verify so
+        # rotary/cache metadata stay on the accepted prefix, not rejected tail.
+        if num_decodes > 0:
+            cache_start[num_extends:] = (
+                self.runtime_states.valid_cache_lengths.index_select(
+                    0, req_pool_indices[num_extends:]
+                )
+                + draft_input.accept_lengths[num_extends:]
+            )
+
+        # Write cache slots for steps 1..N-1.
+        cache_locs = self.draft_out_cache_loc_buf[: bs * (self.spec_num_steps - 1)]
+        compute_out_cache_loc_uniform(
+            out_cache_loc_ptr=cache_locs,
+            req_pool_indices=req_pool_indices,
+            uniform_input_length=self.spec_num_steps - 1,
+            cache_start=cache_start,
+            req_to_pages=self.req_to_page,
+            page_size=self.page_size,
+        )
+        cache_locs = cache_locs.view(bs, self.spec_num_steps - 1)
+        # +1 is the kernel's read-inclusive convention; advanced per iter.
+        draft_seq_lens = self.draft_seq_lens_buf[:bs]
+        torch.add(cache_start, 1, out=draft_seq_lens)
+
+        positions = cache_start.clone()
+
+        for i in range(1, self.spec_num_steps):
+            # make a ctx every time model runner forward
+            # Multi-step decode is pure DECODE mode: one token per request.
+            # global_num_tokens must reflect each rank's batch size, not the
+            # target model's total tokens (which may be bs * spec_num_tokens).
+            global_num_tokens = draft_input.global_num_tokens
+
+            if self.dp_size > 1:
+                if draft_input.global_bs is not None:
+                    global_num_tokens = draft_input.global_bs
+                else:
+                    # CUDA graph capture path: uniform batch size across ranks.
+                    global_num_tokens = [bs] * self.world_size
+
+            ctx = ForwardContext(
+                bs=bs,
+                num_extends=0,
+                attn_backend=self.attn_backend,
+                token_to_kv_pool=self.token_to_kv_pool,
+                req_to_page=self.req_to_page,
+                input_num_tokens=bs,
+                forward_mode=ForwardMode.DECODE,
+                capture_hidden_mode=CaptureHiddenMode.LAST,
+                global_num_tokens=global_num_tokens,
+                global_bs=draft_input.global_bs,
+                all_decode_or_idle=draft_input.all_decode_or_idle,
+            )
+
+            out_cache_loc = cache_locs[:, i - 1].contiguous()
+            # Keep attention metadata on the accepted prefix; rejected verify
+            # tail slots may still contain stale draft KV.
+            _advance_draft_forward_metadata_if_supported(
+                ctx.attn_backend,
+                draft_seq_lens,
+            )
+
+            with nvtx_range("draft_forward", color="red"):
+                logits_output = self.draft_model_runner.forward(
+                    ctx=ctx,
+                    input_ids=draft_ids,
+                    positions=positions,
+                    out_cache_loc=out_cache_loc,
+                    captured_hidden_states=logits_output.hidden_states,
+                    spec_step_idx=i,
+                )
+
+            with nvtx_range("draft_sample", color="yellow"):
+                draft_ids = self._sample_step_tokens(logits_output)
+                # Column 0 holds last_verified_ids; drafter writes step `i` into column `i + 1`.
+                next_tokens[:, i + 1] = draft_ids
+                if i + 1 < self.spec_num_steps:
+                    positions.add_(1)
+                    draft_seq_lens.add_(1)
+
+    # ------------------------------------------------------------------
+    # Public entry point (type-based dispatch from ModelExecutor)
+    # ------------------------------------------------------------------
+
+    @override
+    def get_candidates(
+        self,
+        base_ctx: ForwardContext,
+    ) -> torch.Tensor | None:
+        num_extends = base_ctx.num_extends
+        num_decodes = base_ctx.bs - num_extends
+        if num_decodes == 0:
+            return None
+
+        num_decode_tokens = num_decodes * self.spec_num_tokens
+        num_prefill_tokens = base_ctx.input_num_tokens - num_decode_tokens
+        return self.input_buffers.input_ids_buf[
+            num_prefill_tokens : base_ctx.input_num_tokens
+        ].reshape(num_decodes, self.spec_num_tokens)
+
+    @override
+    def draft(
+        self,
+        draft_input: MtpDraftInput,
+    ) -> torch.Tensor:
+
+        bs = draft_input.accept_lengths.shape[0]
+
+        # Layout: column 0 holds the last verified id (the base model's accepted token);
+        # columns 1..spec_num_steps hold the drafter's speculative tokens.
+        next_tokens = torch.empty(
+            (bs, self.spec_num_steps + 1),
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+        # Last verified id per request → next_tokens[:, 0].
+        num_extends = draft_input.num_extends
+        num_decodes = bs - num_extends
+        if num_extends > 0:
+            next_tokens[:num_extends, 0] = draft_input.base_model_output[:num_extends]
+        if num_decodes > 0:
+            indices = self._accepted_output_indices(
+                draft_input.accept_lengths[num_extends:],
+                num_decodes,
+            )
+            if num_extends > 0:
+                indices.add_(num_extends)
+            torch.index_select(
+                draft_input.base_model_output,
+                0,
+                indices,
+                out=next_tokens[num_extends:, 0],
+            )
+        if self.spec_num_steps > 0:
+            next_tokens[:, 1:] = next_tokens[:, :1]
+
+        # Seed the draft attn backend's aliased seq_lens for the first step.
+        self.draft_seq_lens_buf[:bs].copy_(self.input_buffers.seq_lens_buf[:bs])
+
+        # First draft step. LogitsProcessor prunes `[num_prefill_tokens + num_decodes * spec_num_tokens, ...]`
+        # down to `[bs, ...]`, so logits/hidden_states arrive here already aligned to one row per request.
+        logits_output = self._run_first_step(bs, draft_input)
+
+        draft_ids = self._sample_step_tokens(logits_output)
+        next_tokens[:, 1] = draft_ids
+
+        if self.spec_num_steps <= 1:
+            return next_tokens
+
+        if self.input_buffers.all_extends_mid_chunk and self.dp_size == 1:
+            # Skip multi-step when the whole batch is mid-chunk EXTEND:
+            # no request completes a target-side speculative verification
+            # after this forward, so any speculative tokens would be discarded.
+            #
+            # In DP we still run, because peer ranks may have completing
+            # extends or decodes; diverging here would desync the drafter's
+            # dense-TP / MoE-EP collectives (NCCL hang or RSAG mismatch).
+            #
+            # Extend catch-up still runs: its point is per-depth KV/sconv
+            # coverage of THIS chunk's rows, not the (discarded) drafts —
+            # skipping mid-chunks would leave every chunk but the last
+            # uncovered for depths >= 1 on long prompts.
+            if self._use_extend_depth_catchup(draft_input):
+                self._run_extend_depth_catchup(
+                    bs, next_tokens, logits_output, draft_input
+                )
+            return next_tokens
+
+        if self._use_extend_depth_catchup(draft_input):
+            # EXTEND/MIXED with per-depth prompt coverage: reuses the first
+            # step's extend metadata as-is, so it must run OUTSIDE the
+            # override_num_extends(0) below.
+            self._run_extend_depth_catchup(bs, next_tokens, logits_output, draft_input)
+            return next_tokens
+
+        # Draft step 2+ (multi-step decode).
+        # Multi-step decode operates on full bs; drop the [num_extends:]
+        # slice that step 0 may have set up for MIXED target. No-op on
+        # backends that fill separate prefill/decode metadata at init
+        # time.
+        with self.attn_backend.override_num_extends(0):
+            if self._use_multi_depth_windows(draft_input):
+                use_lookback = self._use_decode_lookback(draft_input)
+                ran_lookback = False
+                if use_lookback:
+                    slot, v, accept = self._decode_window_slices(bs, draft_input)
+                    ran_lookback = self._run_multi_step_windows_lookback(
+                        bs,
+                        next_tokens,
+                        logits_output,
+                        draft_input,
+                        slot,
+                        v,
+                        accept,
+                    )
+                if not ran_lookback:
+                    self._run_multi_step_windows(
+                        bs,
+                        next_tokens,
+                        logits_output,
+                        draft_input,
+                    )
+                if use_lookback:
+                    # Keep the stashes fresh even on fallback rounds; the
+                    # next round may look back. logits_output here is still
+                    # the first step's FULL depth-0 capture.
+                    self._update_lookback_stash_decode(
+                        slot,
+                        accept,
+                        v,
+                        logits_output.hidden_states.view(bs, self.spec_num_tokens, -1),
+                    )
+            else:
+                self._run_multi_step_decode(
+                    bs,
+                    draft_ids,
+                    next_tokens,
+                    logits_output,
+                    draft_input,
+                )
+        return next_tokens
+
+    @override
+    @nvtx_range("drafter", color="purple")
+    def run(
+        self,
+        base_ctx: ForwardContext,
+        logits_output: LogitsProcessorOutput,
+        output_tokens: torch.Tensor,
+        accept_lengths: torch.Tensor,
+    ) -> torch.Tensor:
+
+        draft_input = MtpDraftInput(
+            input_num_tokens=base_ctx.input_num_tokens,
+            num_extends=base_ctx.num_extends,
+            forward_mode=base_ctx.forward_mode,
+            base_model_output=output_tokens,
+            accept_lengths=accept_lengths,
+            base_out_hidden_states=logits_output.hidden_states,
+            global_num_tokens=base_ctx.global_num_tokens,
+            global_bs=base_ctx.global_bs,
+            all_decode_or_idle=base_ctx.all_decode_or_idle,
+        )
+
+        # next_tokens layout: column 0 = last verified id, columns 1.. = drafter tokens.
+        return self.draft(draft_input)

--- a/python/tokenspeed/runtime/execution/drafter/mtp.py
+++ b/python/tokenspeed/runtime/execution/drafter/mtp.py
@@ -62,7 +62,7 @@ if TYPE_CHECKING:
     from tokenspeed.runtime.layers.logits_processor import LogitsProcessorOutput
 
 
-def _window_shifted_ids(
+def _decode_shifted_ids(
     v: torch.Tensor,
     accept: torch.Tensor,
     next_tokens: torch.Tensor,
@@ -76,7 +76,7 @@ def _window_shifted_ids(
     this round's verify output ``v[:, src]``, else the round's own draft
     ``d_m`` (m = src - accept + 1 <= depth) from ``next_tokens`` columns
     1..depth. Negative ``src`` rows (lookback) come out as ``drafts[:, 0]``;
-    the caller overlays them (see ``_window_lookback_shifted_ids``).
+    the caller overlays them (see ``_lookback_shifted_ids``).
 
     Args:
         v: [bs, k] int64 verify outputs.
@@ -178,7 +178,7 @@ def _extend_depth_shifted_ids(
     )
 
 
-def _window_lookback_shifted_ids(
+def _lookback_shifted_ids(
     v: torch.Tensor,
     accept: torch.Tensor,
     next_tokens: torch.Tensor,
@@ -220,7 +220,7 @@ def _window_lookback_shifted_ids(
             - lookback
             + depth
         )
-    ids = _window_shifted_ids(v, accept, next_tokens, depth, src=src)
+    ids = _decode_shifted_ids(v, accept, next_tokens, depth, src=src)
     from_stash = stash_tokens.gather(
         1, (src + lookback).clamp(0, lookback - 1).expand(bs, total)
     )
@@ -460,64 +460,6 @@ class Mtp(BaseDrafter):
         input_ids = maybe_substitute_mm_pad(input_ids, self.mm_pad_substitute_ids)
         return input_ids.clamp(0, self.vocab_size - 1)
 
-    def _use_multi_depth_windows(self, draft_input: MtpDraftInput) -> bool:
-        """Teacher-forced multi-depth catch-up (draft-model opt-in).
-
-        Multi-depth MTP heads are trained as full-sequence layers: depth d's
-        attention at source position p runs over depth-d activations of ALL
-        positions <= p. The classic multi-step loop gives depth d>0 exactly
-        one new row per round, so its decode queries attend over a KV window
-        it mostly never wrote (stale garbage). In window mode every step
-        re-runs its depth over the whole verify window — dense per-depth KV
-        and sconv state over the accepted prefix — with per-depth
-        token-shifted inputs and the previous depth's full-row chain-normed
-        hidden. Pure-decode rounds only; EXTEND/MIXED rounds run catch-up.
-        """
-        return (
-            self.spec_num_steps > 1
-            and draft_input.num_extends == 0
-            and not draft_input.forward_mode.is_idle()
-            and bool(
-                getattr(
-                    self.draft_model_runner.model, "draft_multi_depth_windows", False
-                )
-            )
-        )
-
-    def _use_extend_depth_catchup(self, draft_input: MtpDraftInput) -> bool:
-        """Per-depth prompt coverage at EXTEND rounds (draft-model opt-in).
-
-        Window mode (above) only repairs pure-decode rounds, so depths >= 1
-        never write KV or sconv state over the prompt region — their decode
-        queries then attend over never-written prompt keys
-        forever. When the draft model opts in, EXTEND and
-        MIXED rounds re-run depths 1..steps-1 over the same ragged rows as the
-        first step (per-depth token-shifted inputs, chained full-row hidden),
-        which builds every used depth's dense prompt KV and sconv prompt
-        state chunk by chunk and replaces the classic loop's one-token steps.
-        """
-        return (
-            self.spec_num_steps > 1
-            and draft_input.num_extends > 0
-            and not draft_input.forward_mode.is_idle()
-            and bool(
-                getattr(
-                    self.draft_model_runner.model, "draft_extend_depth_catchup", False
-                )
-            )
-        )
-
-    def _use_decode_lookback(self, draft_input: MtpDraftInput) -> bool:
-        """Lookback rows for the window pass (§12 Hole 2, armed at init).
-
-        At depth d, the last d committed rows of each round's window embed
-        the round's own unverified drafts; once a draft is rejected those
-        KV/conv entries are permanently wrong under the forward-only window.
-        The lookback variant prepends D = steps-1 rows so the previous
-        round's provisional entries are recomputed from committed tokens.
-        """
-        return self.draft_lookback > 0 and self._use_multi_depth_windows(draft_input)
-
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
@@ -603,12 +545,11 @@ class Mtp(BaseDrafter):
         input_num_tokens = draft_input.input_num_tokens
 
         # Multi-depth window mode and extend catch-up chain FULL per-row
-        # hidden states between depths (see _run_multi_step_windows /
+        # hidden states between depths (see _run_multi_step /
         # _run_extend_depth_catchup); logits stay gathered.
         capture_mode = (
             CaptureHiddenMode.FULL
-            if self._use_multi_depth_windows(draft_input)
-            or self._use_extend_depth_catchup(draft_input)
+            if self.spec_num_steps > 1
             else CaptureHiddenMode.LAST
         )
 
@@ -639,15 +580,20 @@ class Mtp(BaseDrafter):
         )
         return logits_output
 
-    @nvtx_range("draft_multi_step_windows", color="purple")
-    def _run_multi_step_windows(
+    @nvtx_range("draft_multi_step", color="purple")
+    def _run_multi_step(
         self,
         bs: int,
         next_tokens: torch.Tensor,
         logits_output: LogitsProcessorOutput,
         draft_input: MtpDraftInput,
     ) -> None:
-        """Teacher-forced multi-depth catch-up (see _use_multi_depth_windows).
+        """Multi-depth decode window passes.
+
+        Multi-depth MTP heads are trained as full-sequence layers: depth d's
+        attention at source position p runs over depth-d activations of ALL
+        positions <= p, so a one-row-per-step chain loop would leave its
+        queries attending over KV it mostly never wrote.
 
         Every step d re-runs depth layer d over the SAME verify window the
         first step processed (same positions and KV slot locations — the KV
@@ -679,7 +625,7 @@ class Mtp(BaseDrafter):
 
         prev_hidden = logits_output.hidden_states  # [bs*k, H], depth d-1 rows
         for d in range(1, self.spec_num_steps):
-            input_ids = _window_shifted_ids(
+            input_ids = _decode_shifted_ids(
                 v, accept, next_tokens, d, src=col + d
             ).reshape(-1)
 
@@ -700,7 +646,7 @@ class Mtp(BaseDrafter):
                 accept_lengths=draft_input.accept_lengths,
             )
 
-            with nvtx_range("draft_window_forward", color="red"):
+            with nvtx_range("draft_step_forward", color="red"):
                 logits_output = self.draft_model_runner.forward(
                     ctx=ctx,
                     input_ids=input_ids,
@@ -714,8 +660,8 @@ class Mtp(BaseDrafter):
             with nvtx_range("draft_sample", color="yellow"):
                 next_tokens[:, d + 1] = self._sample_step_tokens(logits_output)
 
-    @nvtx_range("draft_multi_step_windows_lookback", color="purple")
-    def _run_multi_step_windows_lookback(
+    @nvtx_range("draft_multi_step_lookback", color="purple")
+    def _run_multi_step_lookback(
         self,
         bs: int,
         next_tokens: torch.Tensor,
@@ -725,7 +671,7 @@ class Mtp(BaseDrafter):
         v: torch.Tensor,
         accept: torch.Tensor,
     ) -> bool:
-        """Lookback variant of ``_run_multi_step_windows`` (§12 Hole 2).
+        """Lookback variant of ``_run_multi_step`` (§12 Hole 2).
 
         Every depth d >= 1 re-runs over ``D + k`` rows per request
         (D = steps-1): the D leading rows re-cover the last D committed
@@ -743,7 +689,7 @@ class Mtp(BaseDrafter):
         rebuilt by the backend hook (lagged-window recurrence).
 
         ``slot``/``v``/``accept`` come pre-sliced from the caller (see
-        ``_decode_window_slices``), which also feeds them to the stash roll.
+        ``_decode_slices``), which also feeds them to the stash roll.
 
         Returns False when the backend refuses the lookback metadata; the
         caller then falls back to the plain window pass. This runs inside
@@ -802,7 +748,7 @@ class Mtp(BaseDrafter):
             torch.arange(total, dtype=torch.int64, device=v.device).view(1, total) - lb
         )
         for d in range(1, self.spec_num_steps):
-            input_ids = _window_lookback_shifted_ids(
+            input_ids = _lookback_shifted_ids(
                 v, accept, next_tokens, stash_tokens, d, lb, src=base_src + d
             )
             input_ids = self._prepare_draft_input_ids(input_ids)
@@ -824,7 +770,7 @@ class Mtp(BaseDrafter):
                 accept_lengths=draft_input.accept_lengths,
             )
 
-            with nvtx_range("draft_window_lookback_forward", color="red"):
+            with nvtx_range("draft_lookback_forward", color="red"):
                 logits_output = self.draft_model_runner.forward(
                     ctx=ctx,
                     input_ids=input_ids,
@@ -839,7 +785,7 @@ class Mtp(BaseDrafter):
                 next_tokens[:, d + 1] = self._sample_step_tokens(logits_output)
         return True
 
-    def _decode_window_slices(
+    def _decode_slices(
         self, bs: int, draft_input: MtpDraftInput
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """``(slot, v, accept)`` shared by the lookback window pass and the
@@ -917,7 +863,12 @@ class Mtp(BaseDrafter):
         logits_output: LogitsProcessorOutput,
         draft_input: MtpDraftInput,
     ) -> None:
-        """Per-depth prompt coverage at EXTEND rounds (see the gate above).
+        """Per-depth prompt coverage at EXTEND rounds.
+
+        The decode windows only repair pure-decode rounds, so without this
+        pass depths >= 1 would never write KV or sconv state over the prompt
+        region and their decode queries would attend over never-written
+        prompt keys forever.
 
         Each step d re-runs depth layer d over the SAME ragged rows the first
         step processed — identical positions, out_cache_loc, and attention /
@@ -979,7 +930,7 @@ class Mtp(BaseDrafter):
         for d in range(1, self.spec_num_steps):
             input_ids = _extend_depth_shifted_ids_from(extend_pre, next_tokens[:ne], d)
             if nd > 0:
-                decode_ids = _window_shifted_ids(
+                decode_ids = _decode_shifted_ids(
                     v, accept, next_tokens[ne:], d, src=col + d
                 )
                 input_ids = torch.cat([input_ids, decode_ids.reshape(-1)])
@@ -1095,13 +1046,10 @@ class Mtp(BaseDrafter):
             # coverage of THIS chunk's rows, not the (discarded) drafts —
             # skipping mid-chunks would leave every chunk but the last
             # uncovered for depths >= 1 on long prompts.
-            if self._use_extend_depth_catchup(draft_input):
-                self._run_extend_depth_catchup(
-                    bs, next_tokens, logits_output, draft_input
-                )
+            self._run_extend_depth_catchup(bs, next_tokens, logits_output, draft_input)
             return next_tokens
 
-        if self._use_extend_depth_catchup(draft_input):
+        if draft_input.num_extends > 0:
             # EXTEND/MIXED with per-depth prompt coverage: reuses the first
             # step's extend metadata as-is, so it must run OUTSIDE the
             # override_num_extends(0) below.
@@ -1113,11 +1061,11 @@ class Mtp(BaseDrafter):
         # MIXED target. No-op on backends that fill separate prefill/decode
         # metadata at init time.
         with self.attn_backend.override_num_extends(0):
-            use_lookback = self._use_decode_lookback(draft_input)
+            use_lookback = self.draft_lookback > 0
             ran_lookback = False
             if use_lookback:
-                slot, v, accept = self._decode_window_slices(bs, draft_input)
-                ran_lookback = self._run_multi_step_windows_lookback(
+                slot, v, accept = self._decode_slices(bs, draft_input)
+                ran_lookback = self._run_multi_step_lookback(
                     bs,
                     next_tokens,
                     logits_output,
@@ -1127,7 +1075,7 @@ class Mtp(BaseDrafter):
                     accept,
                 )
             if not ran_lookback:
-                self._run_multi_step_windows(
+                self._run_multi_step(
                     bs,
                     next_tokens,
                     logits_output,

--- a/python/tokenspeed/runtime/execution/drafter/mtp.py
+++ b/python/tokenspeed/runtime/execution/drafter/mtp.py
@@ -27,8 +27,8 @@ catch-up, decode windows, lookback stashes).
 
 Eagle-like MTP (MTP-Eagle: a single MTP layer chained on its own hidden,
 e.g. DeepSeek) stays in ``eagle.py``. Both register under
-``--speculative-algorithm MTP``; ``ModelExecutor`` routes to this drafter
-when the draft model declares ``draft_multi_depth_windows``.
+``--speculative-algorithm MTP``; ``ModelExecutor`` routes multi-depth
+draft model classes to this drafter (see ``_get_drafter_impl``).
 """
 
 from __future__ import annotations
@@ -106,7 +106,7 @@ def _extend_depth_precompute(
     input_lengths: torch.Tensor,
     last_row: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Depth-invariant pieces of :func:`_extend_depth_shifted_ids`.
+    """Depth-invariant pieces of :func:`_extend_depth_shifted_ids_from`.
 
     Hoisted out of the catch-up depth loop; ``last_row`` (per-request cumsum
     of ``input_lengths`` minus one) may be passed in when the caller already
@@ -134,38 +134,21 @@ def _extend_depth_shifted_ids_from(
     next_tokens: torch.Tensor,
     depth: int,
 ) -> torch.Tensor:
-    """Per-depth gather of :func:`_extend_depth_shifted_ids` over ``pre``
-    (= :func:`_extend_depth_precompute` output)."""
-    shift1_i64, base, req_of_row, row_last = pre
-    num_rows = shift1_i64.shape[0]
-    src = base + depth
-    from_prompt = shift1_i64[src.clamp(max=num_rows - 1)]
-    overshoot = (src - row_last).clamp(1, depth)
-    from_draft = next_tokens.to(torch.int64)[req_of_row, overshoot]
-    return torch.where(src <= row_last, from_prompt, from_draft)
-
-
-def _extend_depth_shifted_ids(
-    shift1_ids: torch.Tensor,
-    input_lengths: torch.Tensor,
-    next_tokens: torch.Tensor,
-    depth: int,
-) -> torch.Tensor:
     """Depth-``depth`` input ids for the ragged prefill rows of an EXTEND round.
 
-    ``shift1_ids`` are the first draft step's prefill inputs (prompt tokens
-    shifted by one within each request, last row already holding the round's
-    sampled token on final chunks). Depth ``d`` at local row ``i`` consumes the
-    token ``d`` further along: ``shift1_ids[row + d]`` while that stays inside
-    the request, else the request's own draft ``d_m`` (``m = overshoot``) from
-    ``next_tokens`` — columns ``1..d`` are already filled when depth ``d``
-    runs. On mid-chunk rows the overshoot tokens are not staged; those
-    trailing ``d`` rows per chunk consume the placeholder ``next_tokens``
-    columns (known §14 Step 1 approximation, <= steps-1 rows per chunk).
+    ``pre`` is :func:`_extend_depth_precompute` output over the first draft
+    step's prefill inputs ``shift1_ids`` (prompt tokens shifted by one within
+    each request, last row already holding the round's sampled token on final
+    chunks). Depth ``d`` at local row ``i`` consumes the token ``d`` further
+    along: ``shift1_ids[row + d]`` while that stays inside the request, else
+    the request's own draft ``d_m`` (``m = overshoot``) from ``next_tokens``
+    — columns ``1..d`` are already filled when depth ``d`` runs. On mid-chunk
+    rows the overshoot tokens are not staged; those trailing ``d`` rows per
+    chunk consume the placeholder ``next_tokens`` columns (known
+    approximation, <= steps-1 rows per chunk).
 
     Args:
-        shift1_ids: [num_prefill_rows] first-step prefill input ids.
-        input_lengths: [num_extends] per-request prefill row counts.
+        pre: :func:`_extend_depth_precompute` output.
         next_tokens: [>=num_extends, >=depth+1] col 0 = last verified token,
             cols 1.. = this round's drafts, per request.
         depth: draft depth d >= 1.
@@ -173,9 +156,13 @@ def _extend_depth_shifted_ids(
     Returns:
         [num_prefill_rows] int64 input ids for the depth-``depth`` pass.
     """
-    return _extend_depth_shifted_ids_from(
-        _extend_depth_precompute(shift1_ids, input_lengths), next_tokens, depth
-    )
+    shift1_i64, base, req_of_row, row_last = pre
+    num_rows = shift1_i64.shape[0]
+    src = base + depth
+    from_prompt = shift1_i64[src.clamp(max=num_rows - 1)]
+    overshoot = (src - row_last).clamp(1, depth)
+    from_draft = next_tokens.to(torch.int64)[req_of_row, overshoot]
+    return torch.where(src <= row_last, from_prompt, from_draft)
 
 
 def _lookback_shifted_ids(
@@ -187,7 +174,7 @@ def _lookback_shifted_ids(
     lookback: int,
     src: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Depth-``depth`` input ids for a lookback decode window (§12 Hole 2).
+    """Depth-``depth`` input ids for a lookback decode window.
 
     Row ``r`` of the ``lookback + k`` window sits at source position
     ``vc - lookback + r`` and consumes the token at source + depth + 1;
@@ -348,9 +335,7 @@ class Mtp(BaseDrafter):
 
         self.device = draft_model_runner.device
 
-        # For constructing fallback global_num_tokens during CUDA graph capture.
         self.dp_size = draft_model_runner.mapping.attn.dp_size
-        self.world_size = draft_model_runner.mapping.world_size
 
         # Drafter-owned alias source for the draft attn backend; advanced in
         # place during multi-step decode.
@@ -671,7 +656,7 @@ class Mtp(BaseDrafter):
         v: torch.Tensor,
         accept: torch.Tensor,
     ) -> bool:
-        """Lookback variant of ``_run_multi_step`` (§12 Hole 2).
+        """Lookback variant of ``_run_multi_step``.
 
         Every depth d >= 1 re-runs over ``D + k`` rows per request
         (D = steps-1): the D leading rows re-cover the last D committed
@@ -878,7 +863,7 @@ class Mtp(BaseDrafter):
 
         - prefill rows: the request's own prompt tokens (all known), with the
           trailing d rows taking the round's fresh drafts (final chunk) or
-          placeholder columns (mid-chunk; backfilled never — known §14
+          placeholder columns (mid-chunk; backfilled never — known
           approximation, <= steps-1 rows per chunk boundary);
         - decode rows (MIXED batches): the window-mode gather over verify
           outputs and drafts, offset past the prefill rows.
@@ -1021,8 +1006,7 @@ class Mtp(BaseDrafter):
                 indices,
                 out=next_tokens[num_extends:, 0],
             )
-        if self.spec_num_steps > 0:
-            next_tokens[:, 1:] = next_tokens[:, :1]
+        next_tokens[:, 1:] = next_tokens[:, :1]
 
         # Seed the draft attn backend's aliased seq_lens for the first step.
         self.draft_seq_lens_buf[:bs].copy_(self.input_buffers.seq_lens_buf[:bs])
@@ -1037,22 +1021,15 @@ class Mtp(BaseDrafter):
         if self.spec_num_steps <= 1:
             return next_tokens
 
-        if self.input_buffers.all_extends_mid_chunk:
-            # Skip multi-step when the whole batch is mid-chunk EXTEND:
-            # no request completes a target-side speculative verification
-            # after this forward, so any speculative tokens would be discarded.
-            #
-            # Extend catch-up still runs: its point is per-depth KV/sconv
-            # coverage of THIS chunk's rows, not the (discarded) drafts —
-            # skipping mid-chunks would leave every chunk but the last
-            # uncovered for depths >= 1 on long prompts.
-            self._run_extend_depth_catchup(bs, next_tokens, logits_output, draft_input)
-            return next_tokens
-
         if draft_input.num_extends > 0:
             # EXTEND/MIXED with per-depth prompt coverage: reuses the first
             # step's extend metadata as-is, so it must run OUTSIDE the
-            # override_num_extends(0) below.
+            # override_num_extends(0) below. This covers mid-chunk EXTEND
+            # rounds too — their drafts get discarded (no verification
+            # completes after this forward), but catch-up's point is
+            # per-depth KV/sconv coverage of THIS chunk's rows; skipping
+            # mid-chunks would leave every chunk but the last uncovered for
+            # depths >= 1 on long prompts.
             self._run_extend_depth_catchup(bs, next_tokens, logits_output, draft_input)
             return next_tokens
 

--- a/python/tokenspeed/runtime/execution/drafter/mtp.py
+++ b/python/tokenspeed/runtime/execution/drafter/mtp.py
@@ -33,8 +33,6 @@ when the draft model declares ``draft_multi_depth_windows``.
 
 from __future__ import annotations
 
-import logging
-import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -55,18 +53,6 @@ from tokenspeed.runtime.execution.forward_batch_info import (
 from tokenspeed.runtime.multimodal.inputs import Modality, maybe_substitute_mm_pad
 from tokenspeed.runtime.utils.nvtx import nvtx_range
 
-logger = logging.getLogger(__name__)
-
-# Multi-depth window dataflow A/B knobs (the 53a50800 MTP head ships no
-# reference implementation; these resolve its training dataflow empirically):
-# - CHAIN_TARGET_HIDDEN: every depth consumes the TARGET model's hidden
-#   (DeepSeek-MTP style) instead of the previous depth's chain-normed rows.
-# - POS_SHIFT: depth d's window rows carry positions p_j + d instead of p_j.
-_WINDOW_CHAIN_TARGET_HIDDEN = (
-    os.environ.get("INKLING_MTP_CHAIN_TARGET_HIDDEN", "0") == "1"
-)
-_WINDOW_POS_SHIFT = os.environ.get("INKLING_MTP_WINDOW_POS_SHIFT", "0") == "1"
-
 if TYPE_CHECKING:
     from tokenspeed.runtime.execution.input_buffer import InputBuffers
     from tokenspeed.runtime.execution.model_runner import ModelRunner
@@ -74,12 +60,6 @@ if TYPE_CHECKING:
     from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
     from tokenspeed.runtime.layers.attention.kv_cache.base import BaseTokenToKVPool
     from tokenspeed.runtime.layers.logits_processor import LogitsProcessorOutput
-
-
-def _advance_draft_forward_metadata_if_supported(attn_backend, seq_lens) -> None:
-    advance = getattr(attn_backend, "advance_draft_forward_metadata", None)
-    if advance is not None:
-        advance(seq_lens)
 
 
 def _window_shifted_ids(
@@ -398,25 +378,21 @@ class Mtp(BaseDrafter):
         # the text-only speculative draft performs its embedding lookup.
         self.mm_pad_substitute_ids: dict[Modality, int] = {}
 
-        # Log-once flags for the window/lookback/catch-up engagement banners.
-        self._window_mode_logged = False
-        self._lookback_mode_logged = False
-        self._extend_catchup_logged = False
+        # Multi-depth drafting has no DP support: idle rounds (a DP rank
+        # keeping collectives in sync with no work of its own) have no
+        # window to run, and the lookback rows change per-rank token counts.
+        if self.dp_size > 1:
+            raise NotImplementedError(
+                "multi-depth MTP drafting does not support data parallelism "
+                f"(dp_size={self.dp_size})"
+            )
 
-        # Decode-window lookback: the model's
-        # draft_decode_lookback already folds in window mode AND extend
-        # catch-up (the lookback's prompt boundary and per-depth conv lag are
-        # built by those passes); armed only when the backend supports the
-        # lagged-conv recurrence. DP is excluded: the lookback rows change
-        # per-rank token counts.
+        # Decode-window lookback (INKLING_MTP_DECODE_LOOKBACK A/B knob via
+        # the model's draft_decode_lookback); armed only when the backend
+        # supports the lagged-conv recurrence.
         model = draft_model_runner.model
         lookback = 0
-        if (
-            spec_num_steps > 1
-            and self.dp_size == 1
-            and not _WINDOW_CHAIN_TARGET_HIDDEN
-            and getattr(model, "draft_decode_lookback", False)
-        ):
+        if spec_num_steps > 1 and getattr(model, "draft_decode_lookback", False):
             lookback = spec_num_steps - 1
             configure = getattr(self.attn_backend, "configure_draft_lookback", None)
             if configure is None or not configure(lookback):
@@ -495,7 +471,7 @@ class Mtp(BaseDrafter):
         re-runs its depth over the whole verify window — dense per-depth KV
         and sconv state over the accepted prefix — with per-depth
         token-shifted inputs and the previous depth's full-row chain-normed
-        hidden. Pure-decode rounds only; MIXED rounds keep the classic loop.
+        hidden. Pure-decode rounds only; EXTEND/MIXED rounds run catch-up.
         """
         return (
             self.spec_num_steps > 1
@@ -692,14 +668,6 @@ class Mtp(BaseDrafter):
         attention metadata, conv metadata (valid-length catch-up mode),
         positions, and out_cache_loc of the first step are all reused.
         """
-        if not self._window_mode_logged:
-            self._window_mode_logged = True
-            logger.info(
-                "MTP multi-depth window mode engaged (bs=%d, k=%d, steps=%d)",
-                bs,
-                self.spec_num_tokens,
-                self.spec_num_steps,
-            )
         k = self.spec_num_tokens
         buffers = self.input_buffers
         v = draft_input.base_model_output.view(bs, k).to(torch.int64)
@@ -714,10 +682,6 @@ class Mtp(BaseDrafter):
             input_ids = _window_shifted_ids(
                 v, accept, next_tokens, d, src=col + d
             ).reshape(-1)
-
-            if _WINDOW_CHAIN_TARGET_HIDDEN:
-                prev_hidden = draft_input.base_out_hidden_states
-            step_positions = positions + d if _WINDOW_POS_SHIFT else positions
 
             ctx = ForwardContext(
                 bs=bs,
@@ -740,7 +704,7 @@ class Mtp(BaseDrafter):
                 logits_output = self.draft_model_runner.forward(
                     ctx=ctx,
                     input_ids=input_ids,
-                    positions=step_positions,
+                    positions=positions,
                     out_cache_loc=out_cache_loc,
                     captured_hidden_states=prev_hidden,
                     spec_step_idx=d,
@@ -797,15 +761,6 @@ class Mtp(BaseDrafter):
         enter = getattr(self.attn_backend, "enter_draft_lookback_window", None)
         if enter is None or not enter(bs):
             return False
-        if not self._lookback_mode_logged:
-            self._lookback_mode_logged = True
-            logger.info(
-                "MTP lookback window mode engaged (bs=%d, k=%d, D=%d, steps=%d)",
-                bs,
-                k,
-                lb,
-                self.spec_num_steps,
-            )
         total = lb + k
         gather_ids = (
             torch.arange(bs, dtype=torch.int64, device=v.device) * total
@@ -851,7 +806,6 @@ class Mtp(BaseDrafter):
                 v, accept, next_tokens, stash_tokens, d, lb, src=base_src + d
             )
             input_ids = self._prepare_draft_input_ids(input_ids)
-            pass_positions = step_positions + d if _WINDOW_POS_SHIFT else step_positions
 
             ctx = ForwardContext(
                 bs=bs,
@@ -874,7 +828,7 @@ class Mtp(BaseDrafter):
                 logits_output = self.draft_model_runner.forward(
                     ctx=ctx,
                     input_ids=input_ids,
-                    positions=pass_positions,
+                    positions=step_positions,
                     out_cache_loc=out_cache_loc,
                     captured_hidden_states=prev_hidden,
                     spec_step_idx=d,
@@ -982,15 +936,6 @@ class Mtp(BaseDrafter):
         (request-last prefill row / accept-position decode row), so this also
         replaces the classic loop's one-token steps for EXTEND rounds.
         """
-        if not self._extend_catchup_logged:
-            self._extend_catchup_logged = True
-            logger.info(
-                "MTP extend-time per-depth catch-up engaged "
-                "(bs=%d, num_extends=%d, steps=%d)",
-                bs,
-                draft_input.num_extends,
-                self.spec_num_steps,
-            )
         k = self.spec_num_tokens
         buffers = self.input_buffers
         ne = draft_input.num_extends
@@ -1040,10 +985,6 @@ class Mtp(BaseDrafter):
                 input_ids = torch.cat([input_ids, decode_ids.reshape(-1)])
             input_ids = self._prepare_draft_input_ids(input_ids)
 
-            if _WINDOW_CHAIN_TARGET_HIDDEN:
-                prev_hidden = draft_input.base_out_hidden_states
-            step_positions = positions + d if _WINDOW_POS_SHIFT else positions
-
             ctx = ForwardContext(
                 bs=bs,
                 num_extends=ne,
@@ -1065,7 +1006,7 @@ class Mtp(BaseDrafter):
                 logits_output = self.draft_model_runner.forward(
                     ctx=ctx,
                     input_ids=input_ids,
-                    positions=step_positions,
+                    positions=positions,
                     out_cache_loc=out_cache_loc,
                     captured_hidden_states=prev_hidden,
                     spec_step_idx=d,
@@ -1074,100 +1015,6 @@ class Mtp(BaseDrafter):
 
             with nvtx_range("draft_sample", color="yellow"):
                 next_tokens[:, d + 1] = self._sample_step_tokens(logits_output)
-
-    @nvtx_range("draft_multi_step", color="purple")
-    def _run_multi_step_decode(
-        self,
-        bs: int,
-        draft_ids: torch.Tensor,
-        next_tokens: torch.Tensor,
-        logits_output: LogitsProcessorOutput,
-        draft_input: MtpDraftInput,
-    ) -> None:
-        num_extends = draft_input.num_extends
-        num_decodes = bs - num_extends
-        req_pool_indices = self.input_buffers.req_pool_indices_buf[:bs]
-        cache_start = self.input_buffers.seq_lens_buf[:bs].clone()
-        # Step 1's write position uses vc+accept_length after target verify so
-        # rotary/cache metadata stay on the accepted prefix, not rejected tail.
-        if num_decodes > 0:
-            cache_start[num_extends:] = (
-                self.runtime_states.valid_cache_lengths.index_select(
-                    0, req_pool_indices[num_extends:]
-                )
-                + draft_input.accept_lengths[num_extends:]
-            )
-
-        # Write cache slots for steps 1..N-1.
-        cache_locs = self.draft_out_cache_loc_buf[: bs * (self.spec_num_steps - 1)]
-        compute_out_cache_loc_uniform(
-            out_cache_loc_ptr=cache_locs,
-            req_pool_indices=req_pool_indices,
-            uniform_input_length=self.spec_num_steps - 1,
-            cache_start=cache_start,
-            req_to_pages=self.req_to_page,
-            page_size=self.page_size,
-        )
-        cache_locs = cache_locs.view(bs, self.spec_num_steps - 1)
-        # +1 is the kernel's read-inclusive convention; advanced per iter.
-        draft_seq_lens = self.draft_seq_lens_buf[:bs]
-        torch.add(cache_start, 1, out=draft_seq_lens)
-
-        positions = cache_start.clone()
-
-        for i in range(1, self.spec_num_steps):
-            # make a ctx every time model runner forward
-            # Multi-step decode is pure DECODE mode: one token per request.
-            # global_num_tokens must reflect each rank's batch size, not the
-            # target model's total tokens (which may be bs * spec_num_tokens).
-            global_num_tokens = draft_input.global_num_tokens
-
-            if self.dp_size > 1:
-                if draft_input.global_bs is not None:
-                    global_num_tokens = draft_input.global_bs
-                else:
-                    # CUDA graph capture path: uniform batch size across ranks.
-                    global_num_tokens = [bs] * self.world_size
-
-            ctx = ForwardContext(
-                bs=bs,
-                num_extends=0,
-                attn_backend=self.attn_backend,
-                token_to_kv_pool=self.token_to_kv_pool,
-                req_to_page=self.req_to_page,
-                input_num_tokens=bs,
-                forward_mode=ForwardMode.DECODE,
-                capture_hidden_mode=CaptureHiddenMode.LAST,
-                global_num_tokens=global_num_tokens,
-                global_bs=draft_input.global_bs,
-                all_decode_or_idle=draft_input.all_decode_or_idle,
-            )
-
-            out_cache_loc = cache_locs[:, i - 1].contiguous()
-            # Keep attention metadata on the accepted prefix; rejected verify
-            # tail slots may still contain stale draft KV.
-            _advance_draft_forward_metadata_if_supported(
-                ctx.attn_backend,
-                draft_seq_lens,
-            )
-
-            with nvtx_range("draft_forward", color="red"):
-                logits_output = self.draft_model_runner.forward(
-                    ctx=ctx,
-                    input_ids=draft_ids,
-                    positions=positions,
-                    out_cache_loc=out_cache_loc,
-                    captured_hidden_states=logits_output.hidden_states,
-                    spec_step_idx=i,
-                )
-
-            with nvtx_range("draft_sample", color="yellow"):
-                draft_ids = self._sample_step_tokens(logits_output)
-                # Column 0 holds last_verified_ids; drafter writes step `i` into column `i + 1`.
-                next_tokens[:, i + 1] = draft_ids
-                if i + 1 < self.spec_num_steps:
-                    positions.add_(1)
-                    draft_seq_lens.add_(1)
 
     # ------------------------------------------------------------------
     # Public entry point (type-based dispatch from ModelExecutor)
@@ -1239,14 +1086,10 @@ class Mtp(BaseDrafter):
         if self.spec_num_steps <= 1:
             return next_tokens
 
-        if self.input_buffers.all_extends_mid_chunk and self.dp_size == 1:
+        if self.input_buffers.all_extends_mid_chunk:
             # Skip multi-step when the whole batch is mid-chunk EXTEND:
             # no request completes a target-side speculative verification
             # after this forward, so any speculative tokens would be discarded.
-            #
-            # In DP we still run, because peer ranks may have completing
-            # extends or decodes; diverging here would desync the drafter's
-            # dense-TP / MoE-EP collectives (NCCL hang or RSAG mismatch).
             #
             # Extend catch-up still runs: its point is per-depth KV/sconv
             # coverage of THIS chunk's rows, not the (discarded) drafts —
@@ -1265,50 +1108,40 @@ class Mtp(BaseDrafter):
             self._run_extend_depth_catchup(bs, next_tokens, logits_output, draft_input)
             return next_tokens
 
-        # Draft step 2+ (multi-step decode).
-        # Multi-step decode operates on full bs; drop the [num_extends:]
-        # slice that step 0 may have set up for MIXED target. No-op on
-        # backends that fill separate prefill/decode metadata at init
-        # time.
+        # Draft steps 2+ (pure-decode window passes): operate on full bs;
+        # drop the [num_extends:] slice that step 0 may have set up for
+        # MIXED target. No-op on backends that fill separate prefill/decode
+        # metadata at init time.
         with self.attn_backend.override_num_extends(0):
-            if self._use_multi_depth_windows(draft_input):
-                use_lookback = self._use_decode_lookback(draft_input)
-                ran_lookback = False
-                if use_lookback:
-                    slot, v, accept = self._decode_window_slices(bs, draft_input)
-                    ran_lookback = self._run_multi_step_windows_lookback(
-                        bs,
-                        next_tokens,
-                        logits_output,
-                        draft_input,
-                        slot,
-                        v,
-                        accept,
-                    )
-                if not ran_lookback:
-                    self._run_multi_step_windows(
-                        bs,
-                        next_tokens,
-                        logits_output,
-                        draft_input,
-                    )
-                if use_lookback:
-                    # Keep the stashes fresh even on fallback rounds; the
-                    # next round may look back. logits_output here is still
-                    # the first step's FULL depth-0 capture.
-                    self._update_lookback_stash_decode(
-                        slot,
-                        accept,
-                        v,
-                        logits_output.hidden_states.view(bs, self.spec_num_tokens, -1),
-                    )
-            else:
-                self._run_multi_step_decode(
+            use_lookback = self._use_decode_lookback(draft_input)
+            ran_lookback = False
+            if use_lookback:
+                slot, v, accept = self._decode_window_slices(bs, draft_input)
+                ran_lookback = self._run_multi_step_windows_lookback(
                     bs,
-                    draft_ids,
                     next_tokens,
                     logits_output,
                     draft_input,
+                    slot,
+                    v,
+                    accept,
+                )
+            if not ran_lookback:
+                self._run_multi_step_windows(
+                    bs,
+                    next_tokens,
+                    logits_output,
+                    draft_input,
+                )
+            if use_lookback:
+                # Keep the stashes fresh even on fallback rounds; the
+                # next round may look back. logits_output here is still
+                # the first step's FULL depth-0 capture.
+                self._update_lookback_stash_decode(
+                    slot,
+                    accept,
+                    v,
+                    logits_output.hidden_states.view(bs, self.spec_num_tokens, -1),
                 )
         return next_tokens
 

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -44,6 +44,7 @@ from tokenspeed.runtime.execution.context import ForwardContext
 from tokenspeed.runtime.execution.cuda_graph_wrapper import CudaGraphWrapper
 from tokenspeed.runtime.execution.drafter.dflash import DFlash
 from tokenspeed.runtime.execution.drafter.eagle import Eagle
+from tokenspeed.runtime.execution.drafter.mtp import Mtp
 from tokenspeed.runtime.execution.forward_batch_info import (
     CaptureHiddenMode,
     ForwardMode,
@@ -81,8 +82,23 @@ if TYPE_CHECKING:
 
 logger = get_colorful_logger(__name__)
 
-_DRAFTER_MAPPING = {"EAGLE3": Eagle, "MTP": Eagle, "DFLASH": DFlash}
 LOG_MM_TIMING = envs.TOKENSPEED_LOG_MM_TIMING.get()
+
+
+def _get_drafter_impl(spec_algo: str, model: torch.nn.Module):
+    from tokenspeed.runtime.models.inkling_nextn import (
+        InklingForConditionalGenerationNextN,
+    )
+
+    DRAFTER_MAPPING = {"EAGLE3": Eagle, "MTP": Eagle, "DFLASH": DFlash}
+
+    # "MTP" covers two algorithms:
+    # (1) Eagle-like MTP (e.g. DeepSeek) stays on Eagle in eagle.py;
+    # (2) Vanilla MTP (e.g. Inkling) with multi-layer weights stays on Mtp in mtp.py.
+    if spec_algo == "MTP" and isinstance(model, InklingForConditionalGenerationNextN):
+        return Mtp
+    else:
+        return DRAFTER_MAPPING[spec_algo]
 
 
 def _eagle_aux_layer_ids(hf_config) -> list[int] | None:
@@ -356,7 +372,7 @@ class ModelExecutor:
             self.device,
         )
         if self.config.spec_algo is not None:
-            DrafterImpl = _DRAFTER_MAPPING[config.spec_algo]
+            DrafterImpl = _get_drafter_impl(config.spec_algo, draft_model_runner.model)
             self.drafter = DrafterImpl(
                 spec_num_tokens=config.spec_num_tokens,
                 spec_num_steps=config.spec_num_steps,

--- a/python/tokenspeed/runtime/layers/attention/backends/inkling.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/inkling.py
@@ -699,11 +699,10 @@ class InklingAttnBackend(AttentionBackend):
         activations. Name matches the generic executor hook.
 
         Runs outside the captured graph once per MTP round, so it is batched
-        over all layers in one shot: the per-layer ``_write_window_at`` loop
-        costs ~500 eager launches/round (~14 ms host-bound at bs=1, the bulk
-        of MTP round time), the batched blend ~10. The blend is cat-free —
-        two gathers selected by ``where`` — to avoid materializing a
-        ``[L, n, W-1+k, D]`` extension buffer at full batch.
+        over all layers in one shot (the per-layer ``_write_window_at`` loop
+        is host-launch-bound). The blend is cat-free — two gathers selected
+        by ``where`` — to avoid materializing a ``[L, n, W-1+k, D]`` extension
+        buffer at full batch.
         """
         del model
         md = self.conv_metadata
@@ -839,8 +838,7 @@ class InklingAttnBackend(AttentionBackend):
                 f"Inkling decode KV write: {k.shape[0]} rows vs "
                 f"{out_cache_loc.shape[0]} write locs (layer "
                 f"{layer.layer_id}, group {layer.group_id!r}); a chaining "
-                "draft loop (INKLING_MTP_CLASSIC_LOOP=1) is unsupported on "
-                "the flat arm."
+                "one-row-per-step draft loop is unsupported on the flat arm."
             )
             inner._save_kv_cache(layer, out_cache_loc, token_to_kv_pool, k, v)
         scale_kwargs = {}

--- a/python/tokenspeed/runtime/models/inkling.py
+++ b/python/tokenspeed/runtime/models/inkling.py
@@ -168,9 +168,6 @@ _KV_REPLICATED_SUFFIXES = (
 # ModelOpt NVFP4: input_scale = amax/(448*6) (E4M3 max * E2M1 max); ckpt stores raw amax.
 _NVFP4_AMAX_TO_SCALE = 448.0 * 6.0
 
-# MTP capture A/B: draft consumes the pre-final-norm residual (not post-norm hidden).
-_MTP_PRENORM_CAPTURE = os.environ.get("INKLING_MTP_PRENORM_CAPTURE", "0") == "1"
-
 
 def _translate_inkling_quant_pattern(pattern: str) -> str:
     is_regex = pattern.startswith("re:")
@@ -1552,13 +1549,9 @@ class InklingTextModel(nn.Module):
                 log_scaling_tau=log_scaling_tau,
             )
         if residual is None:
-            prenorm = hidden_states
             hidden_states = self.norm(hidden_states)
         else:
-            hidden_states, prenorm = self.norm(hidden_states, residual)
-        # aux = prenorm residual under INKLING_MTP_PRENORM_CAPTURE, else None.
-        if _MTP_PRENORM_CAPTURE and ctx.capture_hidden_mode.need_capture():
-            return hidden_states, [prenorm]
+            hidden_states, _ = self.norm(hidden_states, residual)
         return hidden_states, None
 
 

--- a/python/tokenspeed/runtime/models/inkling_nextn.py
+++ b/python/tokenspeed/runtime/models/inkling_nextn.py
@@ -227,7 +227,7 @@ class InklingForConditionalGenerationNextN(nn.Module):
     # Catch-up runs the full padded window; ctx.gather_ids narrows to one row per request.
     draft_first_step_reduce_for_catchup = True
     # Full-sequence depths: re-run each depth over the whole verify window
-    # (eagle.py window mode); INKLING_MTP_CLASSIC_LOOP=1 reverts for A/B.
+    # (mtp.py window mode); INKLING_MTP_CLASSIC_LOOP=1 reverts for A/B.
     draft_multi_depth_windows = os.environ.get("INKLING_MTP_CLASSIC_LOOP", "0") != "1"
     # Prompt catch-up: at EXTEND rounds run depths
     # 1..steps-1 over the prompt rows too (inputs shifted d+1, chaining the

--- a/python/tokenspeed/runtime/models/inkling_nextn.py
+++ b/python/tokenspeed/runtime/models/inkling_nextn.py
@@ -26,9 +26,11 @@ The checkpoint ships an 8-depth MTP chain (``mtp_config``) under
 embed_norm(token_embed)]`` (hidden FIRST — the reverse of DeepSeek's
 ``eh_proj``), and one full Inkling transformer block (full attention +
 dense MLP, both with sconv), plus ONE ``chain_norm`` shared by all depths.
-``chain_hidden_post_norm=true``: the chain-normalized block output is both
-the logits input and the hidden chained to the next depth. Embedding and
-LM head are shared with the target model (``set_embed_and_head``).
+The (possibly chain-normalized) block output is both the logits input and
+the hidden chained to the next depth; ``chain_hidden_post_norm`` in the
+model config decides whether the post-norm applies when the checkpoint
+ships no ``chain_norm`` weight. Embedding and LM head are shared with the
+target model (``set_embed_and_head``).
 
 Depth blocks reuse ``InklingDecoderLayer`` unmodified: a copied text config
 with ``local_layer_ids`` from ``mtp_config`` (checkpoints since 4d71c3ea mix
@@ -73,25 +75,6 @@ from tokenspeed.runtime.models.inkling import (
 from tokenspeed.runtime.utils import add_prefix
 
 logger = logging.getLogger(__name__)
-
-# Checkpoints since 53a50800 ship no ``model.mtp.chain_norm.weight``; the
-# model provider confirmed (2026-07-14) the head is trained WITHOUT a chain
-# post-norm and the checkpoint's ``chain_hidden_post_norm=true`` is stale —
-# the intended value is false. Default "none" skips the norm (keeping the
-# residual add). The alternatives produce identical draft tokens under
-# greedy drafting (a weightless RMSNorm is a per-token scalar rescale —
-# absorbed by the next depth's hidden_norm and by the bias-free lm_head
-# argmax) and remain as A/B probes:
-# - "unit": post-depth RMSNorm with its init weight of 1.
-# - "base": the target model's llm.norm.weight as the chain scale.
-_CHAIN_NORM_FALLBACK = os.environ.get("INKLING_MTP_CHAIN_NORM", "none")
-
-# Draft embedding: apply the BASE model's embed_norm to the token embedding
-# before each depth's own embed_norm. Resolved empirically on BOTH heads
-# (pre-53a50800: accept 1.36-1.77 -> 1.61-1.96; 53a50800: counting probe
-# 1.32 -> 2.32) — the head is trained on the normalized embeddings the base
-# decoder consumes. INKLING_MTP_RAW_EMBED=1 reverts to the raw lookup.
-_USE_BASE_EMBED_NORM = os.environ.get("INKLING_MTP_RAW_EMBED", "0") != "1"
 
 
 def _draft_text_config(text_config: InklingModelConfig) -> InklingModelConfig:
@@ -179,16 +162,20 @@ class InklingMultiTokenPredictor(nn.Module):
             )
             for idx in range(self.num_mtp_layers)
         )
-        # Shared post-depth norm slot: applied when the checkpoint ships a
-        # learned ``chain_norm`` weight, otherwise resolved by
-        # _CHAIN_NORM_FALLBACK (see the module-level history there).
-        self.chain_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.chain_norm_identity = False
-        # A/B knob: base-model embed_norm before the depth's own embed_norm
-        # (weight loaded from the base checkpoint's llm.embed_norm).
+        # Post-depth chain norm, per the ``chain_hidden_post_norm`` model
+        # config (weight from the checkpoint's ``chain_norm`` if shipped,
+        # else its init weight of 1).
+        self.chain_norm = (
+            RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            if config.chain_hidden_post_norm
+            else None
+        )
+        # Base-model embed_norm before the depth's own embed_norm (weight
+        # loaded from the base checkpoint's llm.embed_norm): the head is
+        # trained on the normalized embeddings the base decoder consumes.
         self.base_embed_norm = (
             RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-            if _USE_BASE_EMBED_NORM and config.use_embed_norm
+            if config.use_embed_norm
             else None
         )
 
@@ -214,10 +201,10 @@ class InklingMultiTokenPredictor(nn.Module):
         if ctx.forward_mode.is_idle():
             return hidden
         if residual is None:
-            if self.chain_norm_identity:
+            if self.chain_norm is None:
                 return hidden
             return self.chain_norm(hidden)
-        if self.chain_norm_identity:
+        if self.chain_norm is None:
             return hidden + residual
         hidden, _ = self.chain_norm(hidden, residual)
         return hidden
@@ -227,28 +214,20 @@ class InklingForConditionalGenerationNextN(nn.Module):
     # Catch-up runs the full padded window; ctx.gather_ids narrows to one row per request.
     draft_first_step_reduce_for_catchup = True
     # Full-sequence depths: re-run each depth over the whole verify window
-    # (mtp.py window mode); INKLING_MTP_CLASSIC_LOOP=1 reverts for A/B.
-    draft_multi_depth_windows = os.environ.get("INKLING_MTP_CLASSIC_LOOP", "0") != "1"
+    # (mtp.py window mode); the trained dataflow, not optional.
+    draft_multi_depth_windows = True
     # Prompt catch-up: at EXTEND rounds run depths
     # 1..steps-1 over the prompt rows too (inputs shifted d+1, chaining the
     # previous depth's full-row hidden), so every used depth gets dense
-    # prompt KV and sconv prompt state. INKLING_MTP_EXTEND_CATCHUP=0 reverts
-    # for A/B (depths >= 1 then never cover the prompt region).
-    draft_extend_depth_catchup = (
-        os.environ.get("INKLING_MTP_EXTEND_CATCHUP", "1") != "0"
-    )
+    # prompt KV and sconv prompt state.
+    draft_extend_depth_catchup = True
     # Provisional-tail recompute: decode windows carry D=steps-1
     # lookback rows so the previous round's provisional tail entries (written
     # from then-unverified drafts) are recomputed from committed tokens.
-    # Requires window mode + extend catch-up (the lookback's prompt boundary
-    # and per-depth conv lag are built by those passes) — folded in here so
-    # the drafter need not re-derive the invariant. INKLING_MTP_DECODE_LOOKBACK=0
-    # reverts for A/B (depth-d KV/conv keeps ~d/<a>*(1-p) stale slots).
-    draft_decode_lookback = (
-        os.environ.get("INKLING_MTP_DECODE_LOOKBACK", "1") != "0"
-        and draft_multi_depth_windows
-        and draft_extend_depth_catchup
-    )
+    # Kept as an A/B knob for further experiments:
+    # INKLING_MTP_DECODE_LOOKBACK=0 reverts (depth-d KV/conv then keeps
+    # ~d/<a>*(1-p) stale slots).
+    draft_decode_lookback = os.environ.get("INKLING_MTP_DECODE_LOOKBACK", "1") != "0"
 
     def __init__(
         self,
@@ -370,14 +349,10 @@ class InklingForConditionalGenerationNextN(nn.Module):
 
         for name, w in weights:
             name = name.removeprefix("model.")
-            if name == "llm.embed_norm.weight" and _USE_BASE_EMBED_NORM:
+            if name == "llm.embed_norm.weight":
                 # The base embedding norm, applied before each depth's own
-                # embed_norm (absent only under INKLING_MTP_RAW_EMBED=1).
+                # embed_norm.
                 load_param("model.base_embed_norm.weight", w)
-                continue
-            if name == "llm.norm.weight" and _CHAIN_NORM_FALLBACK == "base":
-                # A/B probe: target final-norm weight as the chain scale.
-                load_param("model.chain_norm.weight", w)
                 continue
             if not name.startswith("mtp."):
                 continue  # base-model tensor; the target worker owns it
@@ -407,30 +382,9 @@ class InklingForConditionalGenerationNextN(nn.Module):
                 "Use a checkpoint that ships `model.mtp.*` weights or disable "
                 "MTP speculative decoding."
             )
-        if "model.chain_norm.weight" not in loaded:
-            if _CHAIN_NORM_FALLBACK == "none":
-                self.model.chain_norm_identity = True
-            elif _CHAIN_NORM_FALLBACK == "base":
-                raise ValueError(
-                    "INKLING_MTP_CHAIN_NORM=base but llm.norm.weight never "
-                    "appeared in the weight stream"
-                )
-            elif _CHAIN_NORM_FALLBACK != "unit":
-                raise ValueError(
-                    "INKLING_MTP_CHAIN_NORM must be 'unit', 'none' or 'base', "
-                    f"got {_CHAIN_NORM_FALLBACK!r}"
-                )
-            logger.info(
-                "Inkling MTP checkpoint ships no chain_norm weight; running "
-                "the chain post-norm as %r (INKLING_MTP_CHAIN_NORM)",
-                _CHAIN_NORM_FALLBACK,
-            )
-
         if dropped:
             logger.warning(
-                "Inkling NextN load_weights dropped %d tensors (first: %s)",
-                len(dropped),
-                dropped[:8],
+                f"Inkling NextN load_weights dropped {len(dropped)} tensors (first: {dropped[:8]})"
             )
         return loaded
 

--- a/test/runtime/test_drafter_accept_indexing.py
+++ b/test/runtime/test_drafter_accept_indexing.py
@@ -4,9 +4,8 @@ from types import SimpleNamespace
 import torch
 
 from tokenspeed.runtime.execution.drafter.dflash import DFlash
-from tokenspeed.runtime.execution.drafter.eagle import (
-    Eagle,
-    EagleDraftInput,
+from tokenspeed.runtime.execution.drafter.eagle import Eagle, EagleDraftInput
+from tokenspeed.runtime.execution.drafter.mtp import (
     _committed_tail_update,
     _extend_depth_shifted_ids,
     _ragged_tail_rows,

--- a/test/runtime/test_drafter_accept_indexing.py
+++ b/test/runtime/test_drafter_accept_indexing.py
@@ -7,7 +7,8 @@ from tokenspeed.runtime.execution.drafter.dflash import DFlash
 from tokenspeed.runtime.execution.drafter.eagle import Eagle, EagleDraftInput
 from tokenspeed.runtime.execution.drafter.mtp import (
     _committed_tail_update,
-    _extend_depth_shifted_ids,
+    _extend_depth_precompute,
+    _extend_depth_shifted_ids_from,
     _lookback_shifted_ids,
     _ragged_tail_rows,
 )
@@ -123,8 +124,9 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
             [[500, 501, 502, 502], [600, 601, 602, 602]], dtype=torch.int32
         )
 
-        depth1 = _extend_depth_shifted_ids(shift1_ids, input_lengths, next_tokens, 1)
-        depth2 = _extend_depth_shifted_ids(shift1_ids, input_lengths, next_tokens, 2)
+        pre = _extend_depth_precompute(shift1_ids, input_lengths)
+        depth1 = _extend_depth_shifted_ids_from(pre, next_tokens, 1)
+        depth2 = _extend_depth_shifted_ids_from(pre, next_tokens, 2)
 
         self.assertEqual(depth1.tolist(), [12, 13, 14, 500, 501, 22, 600, 601])
         self.assertEqual(depth2.tolist(), [13, 14, 500, 501, 502, 600, 601, 602])
@@ -134,7 +136,8 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
         input_lengths = torch.tensor([3], dtype=torch.int32)
         next_tokens = torch.tensor([[700, 701, 702, 703]], dtype=torch.int32)
 
-        depth3 = _extend_depth_shifted_ids(shift1_ids, input_lengths, next_tokens, 3)
+        pre = _extend_depth_precompute(shift1_ids, input_lengths)
+        depth3 = _extend_depth_shifted_ids_from(pre, next_tokens, 3)
 
         # With P=3 and depth 3 every row overshoots the shift-1 ids: local
         # row i consumes t_{i+4}, i.e. drafts d_1..d_3.

--- a/test/runtime/test_drafter_accept_indexing.py
+++ b/test/runtime/test_drafter_accept_indexing.py
@@ -8,8 +8,8 @@ from tokenspeed.runtime.execution.drafter.eagle import Eagle, EagleDraftInput
 from tokenspeed.runtime.execution.drafter.mtp import (
     _committed_tail_update,
     _extend_depth_shifted_ids,
+    _lookback_shifted_ids,
     _ragged_tail_rows,
-    _window_lookback_shifted_ids,
 )
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.multimodal.inputs import Modality, MultimodalDataItem
@@ -140,7 +140,7 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
         # row i consumes t_{i+4}, i.e. drafts d_1..d_3.
         self.assertEqual(depth3.tolist(), [701, 702, 703])
 
-    def test_window_lookback_shifted_ids_reads_stash_verify_and_drafts(self):
+    def test_lookback_shifted_ids_reads_stash_verify_and_drafts(self):
         # k=4, D=2. Request A accepts 2 of [v0..v3]; request B accepts all 4.
         # Stash entry i holds the committed token at position vc-D+1+i, so
         # entry 1 (= token at vc) is the only one any depth >= 1 consumes.
@@ -151,8 +151,8 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
         )
         stash = torch.tensor([[41, 42], [71, 72]])
 
-        depth1 = _window_lookback_shifted_ids(v, accept, next_tokens, stash, 1, 2)
-        depth2 = _window_lookback_shifted_ids(v, accept, next_tokens, stash, 2, 2)
+        depth1 = _lookback_shifted_ids(v, accept, next_tokens, stash, 1, 2)
+        depth2 = _lookback_shifted_ids(v, accept, next_tokens, stash, 2, 2)
 
         # depth 1: src = [-1, 0, 1, 2, 3, 4] per request.
         self.assertEqual(


### PR DESCRIPTION
## Summary

Inkling-style MTP is arguably the vanilla MTP: multiple distinct depth
layers, each re-run over shifted verify windows with per-depth KV repair
(extend catch-up, decode windows, lookback stashes). This is essentially
different from eagle-like MTP (one layer chained on its own hidden, e.g.
DeepSeek), so it moves into its own drafter.

### Changes

- **New `drafter/mtp.py`**: standalone `Mtp(BaseDrafter)` hosting all
  multi-depth window/lookback/catch-up drafting. `eagle.py` is restored to
  its pre-Inkling state (`93ecb3ae~1`), keeping only the updated
  dict-by-modality mm-pad substitution API.
- **Dispatch**: both algorithms stay under `--speculative-algorithm MTP`;
  `ModelExecutor` routes Inkling's NextN model to `Mtp` by model class,
  everything else to `Eagle`. No CLI change.
- **Remove resolved bring-up A/B knobs**: the `INKLING_MTP_*` env vars
  resolved the head's training dataflow empirically; only the default paths
  remain. The classic chain loop is deleted (structurally wrong for a
  full-sequence-trained head; `Mtp` now fails fast on `dp_size > 1`).
  `INKLING_MTP_CHAIN_NORM` is replaced by the `chain_hidden_post_norm`
  model config. `INKLING_MTP_DECODE_LOOKBACK` is kept for further
  experiments.
- **Cleanup**: drop the `_use_*` gates and window-mode naming, the MTP
  mode-engagement log banners, and measured bring-up numbers in comments.
