### PR TITLE
feat(multimodal): add item-level encoder data parallelism

### DIFF
--- a/docs/configuration/compatible-parameters.md
+++ b/docs/configuration/compatible-parameters.md
@@ -38,6 +38,7 @@ TokenSpeed-specific behavior explicitly.
 | `--max-cudagraph-capture-size` | Largest CUDA graph capture size. |
 | `--tensor-parallel-size`, `--tp` | Set attention tensor parallel size. |
 | `--data-parallel-size` | Data parallel size. |
+| `--mm-encoder-tp-mode` | Select multimodal encoder weight TP (`weights`) or item data parallelism (`data`). |
 | `--enable-expert-parallel` | Enable expert parallelism. |
 | `--speculative-config` | JSON speculative decoding config. |
 | `--kv-events-config` | JSON KV cache event publisher config; the vLLM-style `enable_kv_cache_events` field is accepted and defaults to ZMQ when enabled. |

--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -73,6 +73,7 @@ issue budget, while `--max-total-tokens` controls the global token pool.
 | `--dense-tp-size` | Tensor parallel size for dense layers. |
 | `--moe-tp-size` | Tensor parallel size for MoE layers. |
 | `--data-parallel-size` | Number of data-parallel replicas. |
+| `--mm-encoder-tp-mode` | Multimodal encoder parallelism: `weights` shards encoder weights with attention TP; `data` uses TP1 whole-item DP and currently requires aggregate serving, one node, and no attention context parallelism. |
 | `--enable-expert-parallel` | Set expert parallelism across the selected world size. |
 | `--expert-parallel-size`, `--ep-size` | Explicit expert parallel size. |
 | `--world-size` | Total worker process count across all nodes. |

--- a/docs/serving/parallelism.md
+++ b/docs/serving/parallelism.md
@@ -35,6 +35,7 @@ tokenspeed serve <model> \
 | `--dense-tp-size` | Dense layer tensor parallel size. |
 | `--moe-tp-size` | MoE layer tensor parallel size. |
 | `--data-parallel-size` | Replicated data-parallel groups. |
+| `--mm-encoder-tp-mode` | `weights` (default), or TP1 whole-item DP within each attention TP group (`data`). |
 | `--enable-expert-parallel` | Expert parallelism across the selected world size. |
 | `--expert-parallel-size` | Explicit expert parallel size. |
 

--- a/python/tokenspeed/runtime/configs/model_config.py
+++ b/python/tokenspeed/runtime/configs/model_config.py
@@ -368,6 +368,12 @@ class ModelConfig:
             )
         # ``is_multimodal`` is the architectural fact; this is the runtime gate.
         self.is_multimodal_active = self.is_multimodal and not apply_language_model_only
+        if (
+            not is_draft_worker
+            and getattr(server_args, "mm_encoder_tp_mode", "weights") == "data"
+        ):
+            if not self.is_multimodal_active:
+                raise ValueError("item-DP requires an active multimodal encoder")
         # Vision-only role (EPD encode): the inverse axis of language_model_only.
         # Build the vision tower (is_multimodal_active stays True) but SKIP LM
         # construction + LM weight load so a full ViT fits at encode TP=1.

--- a/python/tokenspeed/runtime/distributed/mapping.py
+++ b/python/tokenspeed/runtime/distributed/mapping.py
@@ -267,9 +267,12 @@ class MoeLayerMapping(MappingBase):
 
 
 class VisionTowerMapping(MappingBase):
-    """Parallel mapping for vision encoders. Vision layers run colocated and
-    share the attention TP group; non-colocated deployments should run the
-    encoder out-of-engine (EPD-style workers + gateway dispatch).
+    """Parallel mapping for colocated multimodal encoders.
+
+    ``tp_size`` controls weight tensor parallelism inside the encoder, while
+    ``dp_size`` controls item data parallelism. The mapping's world is one
+    attention TP group, so item-DP composes independently with outer request
+    data parallelism.
     """
 
     def __init__(
@@ -277,9 +280,12 @@ class VisionTowerMapping(MappingBase):
         rank: int | None = None,
         world_size: int = 1,
         tp_size: int | None = None,
+        dp_size: int | None = None,
     ):
         super().__init__(rank, world_size)
-        (self.tp_size,) = _resolve_parallelism_sizes(self.world_size, tp_size)
+        self.tp_size, self.dp_size = _resolve_parallelism_sizes(
+            self.world_size, tp_size, dp_size
+        )
 
     @cached_property
     def has_tp(self) -> bool:
@@ -292,6 +298,18 @@ class VisionTowerMapping(MappingBase):
     @cached_property
     def tp_group(self) -> Group:
         return _make_parallelism_group(self.rank, self.tp_size, stride=1)
+
+    @cached_property
+    def has_dp(self) -> bool:
+        return self.dp_size > 1
+
+    @cached_property
+    def dp_rank(self) -> int:
+        return _make_parallelism_rank(self.rank, self.dp_size, stride=self.tp_size)
+
+    @cached_property
+    def dp_group(self) -> Group:
+        return _make_parallelism_group(self.rank, self.dp_size, stride=self.tp_size)
 
 
 class Mapping(MappingBase):
@@ -309,6 +327,8 @@ class Mapping(MappingBase):
         moe_tp_size: int | None = None,
         moe_ep_size: int | None = None,
         moe_dp_size: int | None = None,
+        vision_tp_size: int | None = None,
+        vision_dp_size: int | None = None,
         nprocs_per_node: int | None = None,
         nnodes: int | None = None,
         base_gpu_id: int = 0,
@@ -335,11 +355,13 @@ class Mapping(MappingBase):
             ep_size=moe_ep_size,
             dp_size=moe_dp_size,
         )
-        # Vision tower runs colocated on the attention TP group.
+        # The vision mapping is local to each attention TP group. With both
+        # sizes omitted it resolves to weight TP, preserving the legacy mode.
         self.vision = VisionTowerMapping(
             rank=rank,
             world_size=self.attn.tp_size,
-            tp_size=self.attn.tp_size,
+            tp_size=vision_tp_size,
+            dp_size=vision_dp_size,
         )
         self.nprocs_per_node, self.nnodes = _resolve_parallelism_sizes(
             self.world_size, nprocs_per_node, nnodes
@@ -385,7 +407,7 @@ class Mapping(MappingBase):
             f"Mapping(rank={rank_str}, world_size={self.world_size})",
             f"  Cluster : {self.nnodes} node(s) x {self.nprocs_per_node} proc(s)",
             f"  Attention: tp={self.attn.tp_size}  cp={self.attn.cp_size}  dp={self.attn.dp_size}",
-            f"    Vision: tp={self.vision.tp_size}",
+            f"    Vision: tp={self.vision.tp_size}  item_dp={self.vision.dp_size}",
             f"  Dense   : tp={self.dense.tp_size}  dp={self.dense.dp_size}",
             f"  MoE     : tp={self.moe.tp_size}  ep={self.moe.ep_size}  dp={self.moe.dp_size}",
         ]

--- a/python/tokenspeed/runtime/models/inkling.py
+++ b/python/tokenspeed/runtime/models/inkling.py
@@ -1516,6 +1516,8 @@ class InklingTextModel(nn.Module):
             return embed_norm(embeds) if embed_norm is not None else embeds
 
         embed.num_embeddings = embed_tokens.num_embeddings
+        embed.embedding_dim = embed_tokens.embedding_dim
+        embed.weight = embed_tokens.weight
         return embed
 
     def forward(
@@ -1628,7 +1630,7 @@ class InklingForConditionalGeneration(nn.Module):
             else None
         )
         self.vision_embedder = (
-            VisionEmbedder()
+            VisionEmbedder(encoder_mapping=mapping.vision)
             if (self.audio is not None or self.visual is not None)
             else None
         )
@@ -1710,20 +1712,15 @@ class InklingForConditionalGeneration(nn.Module):
             )
         encoders = {}
         if self.visual is not None:
-            encoders[Modality.IMAGE] = EncoderSpec(
-                self.get_image_feature, deepstack=False
-            )
+            encoders[Modality.IMAGE] = EncoderSpec(self.get_image_feature)
         if self.audio is not None:
-            encoders[Modality.AUDIO] = EncoderSpec(
-                self.get_audio_feature, deepstack=False
-            )
+            encoders[Modality.AUDIO] = EncoderSpec(self.get_audio_feature)
         input_embeds, _ = self.vision_embedder.apply(
             input_ids=input_ids,
             text_embedding=self.model.mm_text_embedding(),
             ctx=multimodal_context,
             encoders=encoders,
             multimodal_model=self,
-            is_decode_or_idle=ctx.forward_mode.is_decode_or_idle(),
         )
         return input_embeds
 

--- a/python/tokenspeed/runtime/models/kimi_k25.py
+++ b/python/tokenspeed/runtime/models/kimi_k25.py
@@ -789,7 +789,7 @@ class KimiK25ForConditionalGeneration(nn.Module):
                 self.mm_projector = self.mm_projector.to(dtype=target_dtype)
 
             # image_encoder may be swapped to a cudagraph wrapper by ModelExecutor.
-            self.vision_embedder = VisionEmbedder()
+            self.vision_embedder = VisionEmbedder(encoder_mapping=mapping.vision)
             self.image_encoder = self.get_image_feature
         else:
             self.vision_embedder = None
@@ -910,7 +910,6 @@ class KimiK25ForConditionalGeneration(nn.Module):
             ctx=multimodal_context,
             encoders={Modality.IMAGE: EncoderSpec(self.image_encoder)},
             multimodal_model=self,
-            is_decode_or_idle=ctx.forward_mode.is_decode_or_idle(),
         )
         assert not model_kwargs, "Kimi-K2.5 multimodal path must stay embeds-only"
         return input_embeds

--- a/python/tokenspeed/runtime/models/qwen3_5.py
+++ b/python/tokenspeed/runtime/models/qwen3_5.py
@@ -1225,7 +1225,7 @@ class Qwen3_5ForConditionalGeneration(BaseCausalLM):
             self.num_deepstack_embeddings = len(self.deepstack_visual_indexes)
             # Encoder callables may be swapped to cudagraph wrappers by
             # ModelExecutor.
-            self.vision_embedder = VisionEmbedder()
+            self.vision_embedder = VisionEmbedder(encoder_mapping=mapping.vision)
             self.image_encoder = self.get_image_feature
             self.video_encoder = self.get_video_feature
 
@@ -1416,7 +1416,6 @@ class Qwen3_5ForConditionalGeneration(BaseCausalLM):
                 Modality.VIDEO: EncoderSpec(self.video_encoder, deepstack=True),
             },
             multimodal_model=self,
-            is_decode_or_idle=ctx.forward_mode.is_decode_or_idle(),
         )
         hidden_states, aux_hidden_states = self.model(
             input_ids,

--- a/python/tokenspeed/runtime/models/qwen3_asr.py
+++ b/python/tokenspeed/runtime/models/qwen3_asr.py
@@ -112,7 +112,9 @@ class Qwen3ASRForConditionalGeneration(nn.Module):
                 prefix=add_prefix("audio_tower", prefix),
                 mm_attention_backend=mm_attention_backend,
             )
-            self.multimodal_embedder = MultimodalEmbedder()
+            self.multimodal_embedder = MultimodalEmbedder(
+                encoder_mapping=mapping.vision
+            )
             # ModelExecutor may replace this callable with an encoder graph.
             self.audio_encoder = self.get_audio_feature
         else:
@@ -188,14 +190,8 @@ class Qwen3ASRForConditionalGeneration(nn.Module):
                 input_ids=input_ids,
                 text_embedding=self.get_input_embeddings(),
                 ctx=multimodal_context,
-                encoders={
-                    Modality.AUDIO: EncoderSpec(
-                        self.audio_encoder,
-                        deepstack=False,
-                    )
-                },
+                encoders={Modality.AUDIO: EncoderSpec(self.audio_encoder)},
                 multimodal_model=self,
-                is_decode_or_idle=ctx.forward_mode.is_decode_or_idle(),
             )
             kwargs.update(model_kwargs)
             if input_embeds is not None:

--- a/python/tokenspeed/runtime/models/qwen3_omni.py
+++ b/python/tokenspeed/runtime/models/qwen3_omni.py
@@ -166,7 +166,9 @@ class Qwen3OmniMoeForConditionalGeneration(Qwen3MoeForCausalLM):
 
         self.is_multimodal_active = is_multimodal_active
         self.multimodal_embedder = (
-            MultimodalEmbedder() if is_multimodal_active else None
+            MultimodalEmbedder(encoder_mapping=mapping.vision)
+            if is_multimodal_active
+            else None
         )
         if not is_multimodal_active:
             self.visual = None
@@ -340,7 +342,6 @@ class Qwen3OmniMoeForConditionalGeneration(Qwen3MoeForCausalLM):
                 Modality.AUDIO: EncoderSpec(self.audio_encoder),
             },
             multimodal_model=self,
-            is_decode_or_idle=ctx.forward_mode.is_decode_or_idle(),
         )
         hidden_states, aux_hidden_states = self.model(
             input_ids,

--- a/python/tokenspeed/runtime/multimodal/embedder.py
+++ b/python/tokenspeed/runtime/multimodal/embedder.py
@@ -28,10 +28,12 @@ Three sequential phases:
      position in ``input_ids`` that should be filled from an encoder token,
      along with the source range inside the owning item's encoded tensor.
 
-  2. ``_encode`` invokes the model-supplied encoder once per modality with
-     every miss in the batch in a single call, then writes each item's
-     output back onto the item itself (``item.encoded`` /
-     ``item.encoded_deepstack``).
+  2. ``_encode`` invokes the model-supplied encoder once per modality, then
+     writes each item's output back onto the item itself (``item.encoded`` /
+     ``item.encoded_deepstack``). In weight-TP mode every rank encodes the
+     full miss list together. In item-DP mode each rank encodes a deterministic
+     subset of whole items and collects the variable-length results with
+     exact-size broadcasts.
 
   3. ``_assemble`` runs the text-token embedding lookup and slices the
      encoder-token ranges into the right positions using the plan's
@@ -55,13 +57,17 @@ from __future__ import annotations
 import logging
 import time
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 import torch
 from torch import nn
 
+from tokenspeed.runtime.distributed.mapping import VisionTowerMapping
+from tokenspeed.runtime.distributed.process_group_manager import (
+    process_group_manager,
+)
 from tokenspeed.runtime.multimodal.inputs import (
     Modality,
     MultimodalDataItem,
@@ -174,6 +180,46 @@ def _item_token_count(item: MultimodalDataItem) -> int:
     return sum(end - start + 1 for start, end in item.offsets)
 
 
+@dataclass(frozen=True)
+class EncoderDPAssignment:
+    """Deterministic ownership and rank-major output sizes for encoder items."""
+
+    item_indices_by_rank: tuple[tuple[int, ...], ...]
+    token_counts_by_rank: tuple[int, ...]
+
+
+def _assign_encoder_items(
+    item_token_counts: Sequence[int], dp_size: int
+) -> EncoderDPAssignment:
+    """Assign whole items with deterministic longest-processing-time packing.
+
+    Encoder DP intentionally never splits one multimodal item. The encoded
+    token count is available before execution from the authored placeholder
+    offsets and is a stable proxy for encoder work across every rank.
+    """
+    rank_loads = [0] * dp_size
+    item_indices_by_rank: list[list[int]] = [[] for _ in range(dp_size)]
+
+    # Stable tie breaks are part of the collective protocol: all ranks must
+    # derive exactly the same owner without exchanging Python objects.
+    for item_index in sorted(
+        range(len(item_token_counts)),
+        key=lambda index: (-item_token_counts[index], index),
+    ):
+        owner = min(range(dp_size), key=lambda rank: (rank_loads[rank], rank))
+        item_indices_by_rank[owner].append(item_index)
+        rank_loads[owner] += item_token_counts[item_index]
+
+    # The encoder concatenates outputs in input order. Keep each rank's local
+    # subset in that order so rank-major gathered rows can be reconstructed.
+    for indices in item_indices_by_rank:
+        indices.sort()
+    return EncoderDPAssignment(
+        item_indices_by_rank=tuple(tuple(indices) for indices in item_indices_by_rank),
+        token_counts_by_rank=tuple(rank_loads),
+    )
+
+
 # ---------------------------------------------------------------------------
 # MultimodalEmbedder
 # ---------------------------------------------------------------------------
@@ -182,8 +228,21 @@ def _item_token_count(item: MultimodalDataItem) -> int:
 class MultimodalEmbedder:
     """Multimodal input embedding pipeline for one model executor."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        encoder_mapping: VisionTowerMapping | None = None,
+    ) -> None:
+        self._encoder_dp_group = (
+            encoder_mapping.dp_group if encoder_mapping is not None else None
+        )
+        self._encoder_dp_rank = (
+            encoder_mapping.dp_rank if encoder_mapping is not None else 0
+        )
         self._h2d_stream: torch.cuda.Stream | None = None
+
+    @property
+    def has_encoder_dp(self) -> bool:
+        return self._encoder_dp_group is not None and len(self._encoder_dp_group) > 1
 
     # --- public entry point ------------------------------------------------
 
@@ -194,15 +253,15 @@ class MultimodalEmbedder:
         ctx: MultimodalForwardContext | None,
         encoders: dict[Modality, EncoderSpec],
         multimodal_model: nn.Module,
-        is_decode_or_idle: bool = False,
     ) -> tuple[torch.Tensor | None, dict[str, Any]]:
         """Compose LM input embeddings with encoder tokens scattered in.
 
-        Returns ``(None, {})`` when there is nothing multimodal to do this
-        forward (decode iteration, or no active multimodal inputs). The
-        caller falls back to the regular text-only path on that signal.
+        Returns ``(None, {})`` when there is no active multimodal overlap in
+        this forward. The caller falls back to the regular text-only path on
+        that signal. With multimodal timing enabled, CUDA encode time is
+        measured with events on the current stream.
         """
-        if is_decode_or_idle or ctx is None or not ctx.has_extend_inputs():
+        if ctx is None or not ctx.has_extend_inputs():
             return None, {}
 
         total_started = time.perf_counter() if LOG_MM_TIMING else None
@@ -216,13 +275,33 @@ class MultimodalEmbedder:
         if not plan:
             return None, {}
 
-        encode_started = time.perf_counter() if LOG_MM_TIMING else None
-        self._encode(plan, encoders, multimodal_model, input_ids.device)
-        encode_elapsed_ms = (
-            (time.perf_counter() - encode_started) * 1000
-            if encode_started is not None
-            else None
+        encode_started: float | None = None
+        encode_events: tuple[torch.cuda.Event, torch.cuda.Event] | None = None
+        encode_elapsed_ms: float | None = None
+        if LOG_MM_TIMING:
+            if input_ids.device.type == "cuda":
+                encode_events = (
+                    torch.cuda.Event(enable_timing=True),
+                    torch.cuda.Event(enable_timing=True),
+                )
+                encode_events[0].record(torch.cuda.current_stream(input_ids.device))
+            else:
+                encode_started = time.perf_counter()
+        self._encode(
+            plan,
+            encoders,
+            multimodal_model,
+            input_ids.device,
+            text_embedding.embedding_dim,
+            text_embedding.weight.dtype,
         )
+        if LOG_MM_TIMING:
+            if encode_events is not None:
+                encode_events[1].record(torch.cuda.current_stream(input_ids.device))
+                encode_events[1].synchronize()
+                encode_elapsed_ms = encode_events[0].elapsed_time(encode_events[1])
+            elif encode_started is not None:
+                encode_elapsed_ms = (time.perf_counter() - encode_started) * 1000
 
         alias_started = time.perf_counter() if LOG_MM_TIMING else None
         released_alias_features = self._share_encoded_aliases(plan)
@@ -361,6 +440,8 @@ class MultimodalEmbedder:
         encoders: dict[Modality, EncoderSpec],
         multimodal_model: nn.Module,
         device: torch.device,
+        embedding_width: int,
+        embedding_dtype: torch.dtype,
     ) -> None:
         for modality, items in plan.misses_by_modality.items():
             if not items:
@@ -371,47 +452,122 @@ class MultimodalEmbedder:
                     f"MultimodalEmbedder: no encoder registered for {modality}"
                 )
 
-            move_started = time.perf_counter() if LOG_MM_TIMING else None
-            self._move_features_to_device(items, device)
-            move_elapsed_ms = (
-                (time.perf_counter() - move_started) * 1000
-                if move_started is not None
-                else None
-            )
-            encoder_started = time.perf_counter() if LOG_MM_TIMING else None
-            output = spec.fn(items)
-            if LOG_MM_TIMING and device.type == "cuda":
-                torch.cuda.synchronize(device)
-            encoder_elapsed_ms = (
-                (time.perf_counter() - encoder_started) * 1000
-                if encoder_started is not None
-                else None
-            )
-            output = output.reshape(-1, output.shape[-1])
-
-            per_item_lens = [_item_token_count(it) for it in items]
-            per_item_embs = torch.split(output, per_item_lens, dim=0)
-
-            if spec.deepstack:
-                for item, emb in zip(items, per_item_embs):
-                    main, deep = multimodal_model.separate_deepstack_embeds(emb)
-                    item.encoded = main
-                    item.encoded_deepstack = deep
-            else:
-                for item, emb in zip(items, per_item_embs):
-                    item.encoded = emb
-            if LOG_MM_TIMING:
-                logger.info(
-                    "mm_timing encoder_ms modality=%s items=%d "
-                    "encoder_output_tokens=%d move_h2d=%.3f encode=%.3f "
-                    "per_item_tokens=%s",
-                    modality.name,
-                    len(items),
-                    int(output.shape[0]),
-                    move_elapsed_ms,
-                    encoder_elapsed_ms,
-                    per_item_lens,
+            if self.has_encoder_dp:
+                output_width = embedding_width
+                if spec.deepstack:
+                    output_width *= 1 + len(multimodal_model.deepstack_visual_indexes)
+                per_item_embs = self._encode_data_parallel(
+                    items,
+                    spec,
+                    device,
+                    output_width,
+                    embedding_dtype,
                 )
+            else:
+                output = self._run_encoder(items, spec, device)
+                per_item_lens = [_item_token_count(it) for it in items]
+                output = output.reshape(-1, output.shape[-1])
+                per_item_embs = list(torch.split(output, per_item_lens, dim=0))
+
+            self._store_encoder_outputs(items, per_item_embs, spec, multimodal_model)
+
+    def _run_encoder(
+        self,
+        items: list[MultimodalDataItem],
+        spec: EncoderSpec,
+        device: torch.device,
+    ) -> torch.Tensor:
+        self._move_features_to_device(items, device)
+        return spec.fn(items)
+
+    def _encode_data_parallel(
+        self,
+        items: list[MultimodalDataItem],
+        spec: EncoderSpec,
+        device: torch.device,
+        output_width: int,
+        output_dtype: torch.dtype,
+    ) -> list[torch.Tensor]:
+        assert self._encoder_dp_group is not None
+        per_item_lens = tuple(_item_token_count(item) for item in items)
+        assignment = _assign_encoder_items(per_item_lens, len(self._encoder_dp_group))
+        local_indices = assignment.item_indices_by_rank[self._encoder_dp_rank]
+        local_items = [items[index] for index in local_indices]
+        local_rows = assignment.token_counts_by_rank[self._encoder_dp_rank]
+
+        local_output = torch.empty((0, output_width), dtype=output_dtype, device=device)
+        if local_items:
+            local_output = self._run_encoder(local_items, spec, device)
+            local_output = local_output.reshape(local_rows, output_width).to(
+                device=device, dtype=output_dtype
+            )
+
+        gathered = self._gather_encoder_outputs(
+            local_output, assignment.token_counts_by_rank
+        )
+        per_item_embs: list[torch.Tensor | None] = [None] * len(items)
+        cursor = 0
+        for indices, rank_rows in zip(
+            assignment.item_indices_by_rank, assignment.token_counts_by_rank
+        ):
+            rank_output = gathered[cursor : cursor + rank_rows]
+            cursor += rank_rows
+            rank_cursor = 0
+            for item_index in indices:
+                item_rows = per_item_lens[item_index]
+                per_item_embs[item_index] = rank_output[
+                    rank_cursor : rank_cursor + item_rows
+                ]
+                rank_cursor += item_rows
+        return cast(list[torch.Tensor], per_item_embs)
+
+    def _gather_encoder_outputs(
+        self, local_output: torch.Tensor, token_counts_by_rank: Sequence[int]
+    ) -> torch.Tensor:
+        assert self._encoder_dp_group is not None
+        total_rows = sum(token_counts_by_rank)
+        output_width = local_output.shape[-1]
+        gathered = torch.empty(
+            (total_rows, output_width),
+            dtype=local_output.dtype,
+            device=local_output.device,
+        )
+        process_group = process_group_manager.get_process_group(
+            "nccl", self._encoder_dp_group
+        )
+        cursor = 0
+        for owner_rank, rows in enumerate(token_counts_by_rank):
+            if rows == 0:
+                continue
+            rank_output = gathered[cursor : cursor + rows]
+            if owner_rank == self._encoder_dp_rank:
+                rank_output.copy_(local_output)
+            # A sequence of exact-size broadcasts avoids max-row padding. In
+            # the common single-large-item case this reduces the temporary
+            # DP8 embedding buffer from 8x the result size to exactly 1x.
+            torch.distributed.broadcast(
+                rank_output,
+                src=self._encoder_dp_group[owner_rank],
+                group=process_group,
+            )
+            cursor += rows
+        return gathered
+
+    @staticmethod
+    def _store_encoder_outputs(
+        items: list[MultimodalDataItem],
+        per_item_embs: list[torch.Tensor],
+        spec: EncoderSpec,
+        multimodal_model: nn.Module,
+    ) -> None:
+        if spec.deepstack:
+            for item, emb in zip(items, per_item_embs):
+                main, deep = multimodal_model.separate_deepstack_embeds(emb)
+                item.encoded = main
+                item.encoded_deepstack = deep
+        else:
+            for item, emb in zip(items, per_item_embs):
+                item.encoded = emb
 
     def _share_encoded_aliases(self, plan: EncodePlan) -> int:
         released = 0

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -283,6 +283,7 @@ class ServerArgs:
 
     mla_chunk_multiplier: int = 4
     mm_attention_backend: str | None = None
+    mm_encoder_tp_mode: Literal["weights", "data"] = "weights"
 
     # For PD/EPD disaggregation: "null", "prefill", "decode", or "encode" (vision-tower-only).
     disaggregation_mode: str = "null"
@@ -492,6 +493,22 @@ class ServerArgs:
         )
         moe_dp_size = None
 
+        # The colocated multimodal encoder lives inside each attention TP
+        # group. ``weights`` preserves the legacy weight-TP layout; ``data``
+        # replicates the encoder weights and assigns whole multimodal items to
+        # the ranks in that group.
+        if self.mm_encoder_tp_mode not in ("weights", "data"):
+            raise ValueError(
+                "mm_encoder_tp_mode must be one of {'weights', 'data'}, got "
+                f"{self.mm_encoder_tp_mode!r}"
+            )
+        if self.mm_encoder_tp_mode == "data":
+            vision_tp_size = 1
+            vision_dp_size = attn_tp_size
+        else:
+            vision_tp_size = attn_tp_size
+            vision_dp_size = 1
+
         self.mapping = Mapping(
             world_size=world_size,
             attn_tp_size=attn_tp_size,
@@ -502,6 +519,8 @@ class ServerArgs:
             moe_tp_size=moe_tp_size,
             moe_ep_size=moe_ep_size,
             moe_dp_size=moe_dp_size,
+            vision_tp_size=vision_tp_size,
+            vision_dp_size=vision_dp_size,
             nprocs_per_node=nprocs_per_node,
             nnodes=nnodes,
             base_gpu_id=self.base_gpu_id,
@@ -511,6 +530,22 @@ class ServerArgs:
         # Impl constraints:
         if self.mapping.moe.has_tp and self.mapping.moe.has_ep:
             raise ValueError("MoE TP and EP cannot be both > 1")
+
+        if self.mm_encoder_tp_mode == "data":
+            if self.disaggregation_mode != "null":
+                raise ValueError(
+                    "--mm-encoder-tp-mode data currently requires "
+                    "--disaggregation-mode null (aggregate serving)"
+                )
+            if self.mapping.nnodes != 1:
+                raise ValueError(
+                    "--mm-encoder-tp-mode data currently supports a single node only"
+                )
+            if self.mapping.has_attn_cp:
+                raise ValueError(
+                    "--mm-encoder-tp-mode data does not currently support "
+                    "attention context parallelism"
+                )
 
         logger.info("Parallelism configuration:\n%s", self.mapping)
 
@@ -1796,6 +1831,18 @@ class ServerArgs:
             choices=mm_attention_backend_choices,
             default=ServerArgs.mm_attention_backend,
             help="Set multimodal attention backend.",
+        )
+        parser.add_argument(
+            "--mm-encoder-tp-mode",
+            type=str,
+            choices=["weights", "data"],
+            default=ServerArgs.mm_encoder_tp_mode,
+            help=(
+                "Multimodal encoder parallelism within each attention TP "
+                "group. 'weights' shards encoder weights with TP (default); "
+                "'data' replicates encoder weights and distributes whole "
+                "multimodal items across the TP ranks."
+            ),
         )
         # Disaggregation
         parser.add_argument(

--- a/test/runtime/distributed/test_epd_encode.py
+++ b/test/runtime/distributed/test_epd_encode.py
@@ -75,6 +75,9 @@ class _FakeExecutor:
     def send_item(self, rid, item):
         self.sent_direct.append(item.hash)
 
+    def reap_concluded_senders(self, _pending_request_ids):
+        pass
+
     def drain_deferred(self):
         pass
 
@@ -167,6 +170,9 @@ class _RaisingExecutor:
         raise self._exc
 
     def send_item(self, rid, item):
+        pass
+
+    def reap_concluded_senders(self, _pending_request_ids):
         pass
 
     def drain_deferred(self):

--- a/test/runtime/distributed/test_multimodal_encoder_parallelism.py
+++ b/test/runtime/distributed/test_multimodal_encoder_parallelism.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# SPDX-License-Identifier: MIT
+
+"""Coverage for multimodal encoder weight-TP and item-DP execution."""
+
+from __future__ import annotations
+
+import argparse
+import socket
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from tokenspeed.runtime.distributed.mapping import Mapping
+from tokenspeed.runtime.multimodal.embedder import (
+    EncodePlan,
+    EncoderSpec,
+    MultimodalEmbedder,
+)
+from tokenspeed.runtime.multimodal.inputs import (
+    Modality,
+    MultimodalDataItem,
+)
+from tokenspeed.runtime.utils.server_args import ServerArgs
+
+
+def _mapping_from_cli(
+    mode: str | None = None, *, request_dp_size: int = 1, rank: int = 0
+) -> Mapping:
+    parser = argparse.ArgumentParser()
+    ServerArgs.add_cli_args(parser)
+    argv = ["--model", "test/model", "--tensor-parallel-size", "2"]
+    if mode is not None:
+        argv.extend(["--mm-encoder-tp-mode", mode])
+    if request_dp_size > 1:
+        argv.extend(["--data-parallel-size", str(request_dp_size)])
+    args = parser.parse_args(argv)
+    with patch.object(ServerArgs, "__post_init__"):
+        server_args = ServerArgs.from_cli_args(args)
+    server_args.resolve_basic_defaults()
+    server_args.resolve_parallelism()
+    server_args.mapping.rank = rank
+    return server_args.mapping
+
+
+def _item(item_id: int, rows: int) -> MultimodalDataItem:
+    return MultimodalDataItem(
+        modality=Modality.IMAGE,
+        hash=item_id,
+        offsets=[(0, rows - 1)],
+        feature=torch.tensor([item_id]),
+    )
+
+
+def _encoded_rows(
+    item: MultimodalDataItem, width: int, device: torch.device
+) -> torch.Tensor:
+    rows = sum(end - start + 1 for start, end in item.offsets)
+    row_ids = torch.arange(rows, dtype=torch.float32, device=device)
+    item_ids = torch.full_like(row_ids, float(item.hash))
+    columns = [item_ids, row_ids]
+    if width == 4:
+        columns.extend([item_ids + 1000, row_ids + 1000])
+    return torch.stack(columns, dim=1)
+
+
+def test_multimodal_encoder_weight_tp() -> None:
+    mapping = _mapping_from_cli(rank=1)
+    assert (mapping.vision.tp_size, mapping.vision.dp_size) == (2, 1)
+    assert mapping.vision.tp_group == mapping.attn.tp_group == (0, 1)
+
+    items = [_item(10, 2), _item(20, 3)]
+    calls: list[list[int]] = []
+
+    def encoder(batch):
+        calls.append([int(item.hash) for item in batch])
+        return torch.cat(
+            [_encoded_rows(item, 2, torch.device("cpu")) for item in batch], dim=0
+        )
+
+    embedder = MultimodalEmbedder(encoder_mapping=mapping.vision)
+    embedder._encode(
+        EncodePlan(misses_by_modality={Modality.IMAGE: items}),
+        {Modality.IMAGE: EncoderSpec(encoder)},
+        SimpleNamespace(),
+        torch.device("cpu"),
+        2,
+        torch.float32,
+    )
+
+    assert calls == [[10, 20]]
+    for item in items:
+        torch.testing.assert_close(
+            item.encoded, _encoded_rows(item, 2, torch.device("cpu"))
+        )
+
+
+def _run_item_dp_case(rank: int, device: torch.device, mapping: Mapping) -> None:
+    items = [_item(10, 1), _item(20, 4), _item(30, 2)]
+    owned_hashes_by_rank = ([20], [10, 30])
+    calls: list[list[int]] = []
+
+    def encoder(batch):
+        calls.append([int(item.hash) for item in batch])
+        assert all(item.feature.device == device for item in batch)
+        return torch.cat([_encoded_rows(item, 4, device) for item in batch], dim=0)
+
+    model = SimpleNamespace(
+        deepstack_visual_indexes=[0],
+        separate_deepstack_embeds=lambda output: (output[:, :2], output[:, 2:]),
+    )
+    embedder = MultimodalEmbedder(encoder_mapping=mapping.vision)
+    embedder._encode(
+        EncodePlan(misses_by_modality={Modality.IMAGE: items}),
+        {
+            Modality.IMAGE: EncoderSpec(
+                encoder,
+                deepstack=True,
+            )
+        },
+        model,
+        device,
+        2,
+        torch.float32,
+    )
+
+    assert calls == [owned_hashes_by_rank[rank]]
+    for item in items:
+        expected = _encoded_rows(item, 4, device)
+        torch.testing.assert_close(item.encoded, expected[:, :2])
+        torch.testing.assert_close(item.encoded_deepstack, expected[:, 2:])
+
+    # One item leaves rank 1 idle; it must skip the encoder and still receive
+    # the exact-size output from rank 0.
+    idle_item = _item(40, 3)
+    idle_calls = 0
+
+    def idle_encoder(batch):
+        nonlocal idle_calls
+        idle_calls += 1
+        return _encoded_rows(batch[0], 2, device)
+
+    embedder._encode(
+        EncodePlan(misses_by_modality={Modality.IMAGE: [idle_item]}),
+        {Modality.IMAGE: EncoderSpec(idle_encoder)},
+        SimpleNamespace(),
+        device,
+        2,
+        torch.float32,
+    )
+    assert idle_calls == (1 if rank == 0 else 0)
+    torch.testing.assert_close(idle_item.encoded, _encoded_rows(idle_item, 2, device))
+
+
+def _item_dp_worker(rank: int, world_size: int, port: int) -> None:
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"tcp://localhost:{port}",
+        rank=rank,
+        world_size=world_size,
+        device_id=device,
+    )
+    try:
+        from tokenspeed.runtime.distributed.process_group_manager import (
+            process_group_manager,
+        )
+
+        mapping = Mapping(
+            rank=rank,
+            world_size=world_size,
+            attn_tp_size=world_size,
+            vision_tp_size=1,
+            vision_dp_size=world_size,
+        )
+        process_group_manager.init_process_group(
+            mapping.vision.dp_group, backend="nccl"
+        )
+        _run_item_dp_case(rank, device, mapping)
+    finally:
+        dist.destroy_process_group()
+
+
+def test_multimodal_encoder_item_dp() -> None:
+    # Item-DP is scoped to each attention TP group, independently of outer
+    # request DP. Rank 3 belongs to the second request-DP replica.
+    mapping = _mapping_from_cli("data", request_dp_size=2, rank=3)
+    assert (mapping.vision.tp_size, mapping.vision.dp_size) == (1, 2)
+    assert mapping.vision.dp_group == (2, 3)
+
+    world_size = 2
+    if torch.cuda.device_count() < world_size:
+        pytest.skip(f"Need {world_size} GPUs, have {torch.cuda.device_count()}")
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("", 0))
+        port = sock.getsockname()[1]
+    mp.spawn(
+        _item_dp_worker,
+        args=(world_size, port),
+        nprocs=world_size,
+        join=True,
+    )


### PR DESCRIPTION
## Summary

- Add `--mm-encoder-tp-mode data` for TP1 whole-item encoder DP within each attention TP group; keep encoder weight TP as the default.
- Balance encoder misses deterministically by output-token count and broadcast exact-size outputs before the language forward.
- Keep language attention TP and outer request DP unchanged.
- Preserve per-rank encoder CUDA graph execution.
- Use the shared path for Qwen3.5, Kimi K2.5, Inkling, Qwen3-ASR, and Qwen3-Omni without a model whitelist.
- Add focused weight-TP and 2-GPU NCCL item-DP coverage and minimally document the new flag.

## Scope

- Item-DP currently supports aggregate serving on one node without attention context parallelism.
- EPD behavior is unchanged and continues to scale through independent encode workers.

## Validation

Representative post-cleanup reruns reproduced the previous OCRBench and performance results, so the full campaign results remain valid.

OCRBench on 8× B200:

| Model | Vision TP8 | Vision TP1 × item-DP8 |
| --- | ---: | ---: |
| Qwen3.5-122B-A10B-NVFP4 | 0.912 | 0.911 |
| Kimi-K2.5-NVFP4 | 0.908 | 0.912 |

Performance used language TP8, 32768-token prefill, unique 1080p images, three clients with concurrency 5 each, and three repetitions for the primary points:

| Model / workload | Vision TP8 | Vision TP1 × item-DP8 | Change |
| --- | ---: | ---: | ---: |
| Qwen, 1 image, max_tokens=1 | 14.149 req/s | 15.778 req/s | +11.51% |
| Qwen, 8 images, max_tokens=1 | 2.179 req/s | 2.884 req/s | +31.85% |
| Qwen, 8 images, max_tokens=256 | 1.552 req/s | 2.064 req/s | +33.58% |
| Kimi, 8 images, max_tokens=1 | 1.779 req/s | 2.323 req/s | +30.32% |
| Kimi, 8 images, max_tokens=256 | 1.342 req/s | 1.486 req/s | +10.62% |

Encoder CUDA graphs were captured on all eight item-DP ranks for both models.

- `pre-commit run --all-files`
- `PYTHONPATH=python:tokenspeed-kernel/python CUDA_VISIBLE_DEVICES=0,1 python -m pytest -q test/runtime/distributed/test_multimodal_encoder_parallelism.py test/runtime/distributed/test_epd_encode.py` (`18 passed`)