### PR TITLE
feat(profile): Add multi-rank trace merge support

### DIFF
--- a/python/tokenspeed/cli/__main__.py
+++ b/python/tokenspeed/cli/__main__.py
@@ -86,8 +86,8 @@ def main() -> None:
     merge_traces_parser = subparsers.add_parser(
         "merge-traces",
         add_help=False,
-        help="Merge a Proton chrome trace into a VizTracer report on a "
-        "shared timeline.",
+        help="Merge one or more Proton/VizTracer trace pairs onto a shared "
+        "timeline.",
     )
     merge_traces_parser.set_defaults(func=_merge_traces, merge_args=[])
 

--- a/python/tokenspeed/cli/trace_merge.py
+++ b/python/tokenspeed/cli/trace_merge.py
@@ -18,20 +18,31 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Merge a Proton chrome trace into a VizTracer report on one timeline.
+"""Merge Proton chrome traces into one or more VizTracer timelines.
 
 Both profilers can run in the same scheduler process (``/start_profile``
 with ``{"activities": ["VIZTRACER", "PROTON"]}``) but write separate files
 with timestamps relative to their own start. Each file also records the
 absolute wall-clock time its ``ts=0`` refers to — ``viztracer_metadata.
-baseTimeNanoseconds`` in VizTracer reports, top-level
-``baseTimeNanoseconds`` in Proton chrome traces — so the two timelines can
-be shifted onto a shared axis after the fact.
+baseTimeNanoseconds`` in VizTracer reports, top-level ``baseTimeNanoseconds``
+in Proton chrome traces — so the two timelines can be shifted onto a shared
+axis after the fact.
 
 Usage (one file pair per scheduler rank):
 
     tokenspeed merge-traces <run>-TP0.viztracer.json \
         <run>-TP0.proton.chrome_trace -o <run>-TP0-merged.json
+
+Usage (one final report for multiple scheduler ranks):
+
+    tokenspeed merge-traces --all-ranks \
+        --rank 0 <run>-TP0.viztracer.json <run>-TP0.proton.chrome_trace \
+        --rank 1 <run>-TP1.viztracer.json <run>-TP1.proton.chrome_trace \
+        -o <run>-all-ranks-merged.json
+
+In all-ranks mode, the TP rank is encoded into each numeric Proton flow ID.
+This keeps CPU-to-GPU flow arrows within a rank while preventing matching
+launch IDs on different ranks from cross-linking.
 
 Open the merged report in vizviewer or https://ui.perfetto.dev — Python
 frames and Proton's kernel/scope lanes share one time axis. Alignment
@@ -43,15 +54,23 @@ gaps, not for sub-microsecond attribution.
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
-__all__ = ["merge_proton_viztracer", "main"]
+__all__ = ["merge_all_ranks", "merge_proton_viztracer", "main"]
 
 # Proton labels its single synthetic process (pid 0) "Trace"; rename it so
 # the lanes are recognizable next to the VizTracer process in a merged view.
 _PROTON_PROCESS_NAME = "Proton"
+_PROTON_PID_BASE = 10_000
+_FLOW_PHASES = frozenset({"s", "t", "f"})
+_FLOW_ID_RANK_SHIFT = 32
+_FLOW_ID_LOCAL_MASK = (1 << _FLOW_ID_RANK_SHIFT) - 1
+_MAX_SAFE_JSON_INTEGER = (1 << 53) - 1
+
+TracePair = tuple[int, str | Path, str | Path]
 
 
 def _load_json(path: str | Path, kind: str) -> dict[str, Any]:
@@ -60,6 +79,101 @@ def _load_json(path: str | Path, kind: str) -> dict[str, Any]:
             return json.load(f)
     except json.JSONDecodeError as exc:
         raise ValueError(f"{kind} file {path} is not valid JSON: {exc}") from exc
+
+
+def _viztracer_base_time_ns(
+    viztracer_json: dict[str, Any], viztracer_path: str | Path
+) -> int | float:
+    base_time_ns = viztracer_json.get("viztracer_metadata", {}).get(
+        "baseTimeNanoseconds"
+    )
+    if base_time_ns is None:
+        raise ValueError(
+            f"{viztracer_path} has no viztracer_metadata.baseTimeNanoseconds; "
+            "re-record with a viztracer version that stores the report's "
+            "absolute time base."
+        )
+    return base_time_ns
+
+
+def _proton_base_time_ns(
+    proton_json: dict[str, Any], proton_path: str | Path
+) -> int | float:
+    base_time_ns = proton_json.get("baseTimeNanoseconds")
+    if base_time_ns is None:
+        raise ValueError(
+            f"{proton_path} has no baseTimeNanoseconds; Upgrade "
+            "tokenspeed-proton and re-record."
+        )
+    return base_time_ns
+
+
+def _namespace_proton_flow_id(event: dict[str, Any], rank: int) -> None:
+    """Make a numeric Proton flow ID globally unique for an all-ranks trace."""
+    if event.get("ph") not in _FLOW_PHASES:
+        return
+
+    flow_id = event.get("id")
+    if flow_id is None:
+        return
+    if (
+        not isinstance(flow_id, int)
+        or isinstance(flow_id, bool)
+        or not 0 <= flow_id <= _FLOW_ID_LOCAL_MASK
+    ):
+        raise ValueError(
+            f"Proton flow ID must be an unsigned 32-bit integer: {flow_id!r}"
+        )
+
+    namespaced_id = (rank << _FLOW_ID_RANK_SHIFT) | flow_id
+    if namespaced_id > _MAX_SAFE_JSON_INTEGER:
+        raise ValueError(
+            f"TP rank {rank} is too large to encode in a JSON-safe flow ID"
+        )
+    event["id"] = namespaced_id
+
+
+def _prepare_proton_events(
+    proton_json: dict[str, Any],
+    proton_path: str | Path,
+    viztracer_base_ns: int | float,
+    *,
+    rank: int | None = None,
+) -> list[dict[str, Any]]:
+    """Align Proton events to a VizTracer base and optionally scope a rank."""
+    proton_base_ns = _proton_base_time_ns(proton_json, proton_path)
+    offset_us = (proton_base_ns - viztracer_base_ns) / 1000.0
+    process_name = (
+        _PROTON_PROCESS_NAME if rank is None else f"{_PROTON_PROCESS_NAME} TP{rank}"
+    )
+
+    proton_events = proton_json.get("traceEvents", [])
+    for event in proton_events:
+        if rank is not None:
+            _namespace_proton_flow_id(event, rank)
+            if event.get("pid") == 0:
+                event["pid"] = _PROTON_PID_BASE + rank
+
+        if event.get("ph") == "M":
+            # Metadata events carry no meaningful timestamp; drop any so
+            # they cannot clobber the report's process/thread names.
+            event.pop("ts", None)
+            if (
+                event.get("name") == "process_name"
+                and event.get("args", {}).get("name") == "Trace"
+            ):
+                event["args"]["name"] = process_name
+        elif "ts" in event:
+            event["ts"] += offset_us
+
+    return proton_events
+
+
+def _write_json(output_path: str | Path, trace: dict[str, Any]) -> None:
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(trace, f)
 
 
 def merge_proton_viztracer(
@@ -90,47 +204,87 @@ def merge_proton_viztracer(
     """
     viztracer_json = _load_json(viztracer_path, "VizTracer report")
     proton_json = _load_json(proton_path, "Proton trace")
-
-    viztracer_base_ns = viztracer_json.get("viztracer_metadata", {}).get(
-        "baseTimeNanoseconds"
-    )
-    if viztracer_base_ns is None:
-        raise ValueError(
-            f"{viztracer_path} has no viztracer_metadata.baseTimeNanoseconds; "
-            "re-record with a viztracer version that stores the report's "
-            "absolute time base."
-        )
-
-    proton_base_ns = proton_json.get("baseTimeNanoseconds")
-    if proton_base_ns is None:
-        raise ValueError(
-            f"{proton_path} has no baseTimeNanoseconds; Upgrade "
-            "tokenspeed-proton and re-record."
-        )
-
-    offset_us = (proton_base_ns - viztracer_base_ns) / 1000.0
-
-    proton_events = proton_json.get("traceEvents", [])
-    for event in proton_events:
-        if event.get("ph") == "M":
-            # Metadata events carry no meaningful timestamp; drop any so
-            # they cannot clobber the report's process/thread names.
-            event.pop("ts", None)
-            if (
-                event.get("name") == "process_name"
-                and event.get("args", {}).get("name") == "Trace"
-            ):
-                event["args"]["name"] = _PROTON_PROCESS_NAME
-        elif "ts" in event:
-            event["ts"] += offset_us
+    viztracer_base_ns = _viztracer_base_time_ns(viztracer_json, viztracer_path)
+    proton_events = _prepare_proton_events(proton_json, proton_path, viztracer_base_ns)
 
     viztracer_json.setdefault("traceEvents", []).extend(proton_events)
-
-    output_path = Path(output_path)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w", encoding="utf-8") as f:
-        json.dump(viztracer_json, f)
+    _write_json(output_path, viztracer_json)
     return len(proton_events)
+
+
+def merge_all_ranks(rank_traces: Iterable[TracePair], output_path: str | Path) -> int:
+    """Merge and align Proton/VizTracer trace pairs from several TP ranks.
+
+    Every input pair is first aligned using its own VizTracer time base. All
+    resulting events are then shifted to the earliest VizTracer time base, so
+    the final report has one shared absolute timeline. Proton always uses a
+    synthetic pid 0 and launch IDs that restart in every scheduler process;
+    the all-ranks output gives it a pid of ``10000 + rank`` and encodes its TP
+    rank in each numeric flow ID. The latter preserves CPU-to-GPU arrows
+    within a rank without allowing equal launch IDs from two ranks to
+    cross-link.
+
+    Args:
+        rank_traces: ``(rank, viztracer_path, proton_path)`` triples. Ranks
+            must be unique non-negative integers.
+        output_path: Destination for the consolidated Chrome trace JSON.
+
+    Returns:
+        The total number of Proton events added to the final trace.
+
+    Raises:
+        ValueError: If no inputs are supplied, a rank is negative or
+            duplicated, or an input trace lacks an absolute time anchor.
+    """
+    pairs = sorted(rank_traces, key=lambda pair: pair[0])
+    if not pairs:
+        raise ValueError("at least one --rank trace pair is required")
+
+    ranks = [rank for rank, _, _ in pairs]
+    if any(rank < 0 for rank in ranks):
+        raise ValueError(f"ranks must be non-negative: {ranks}")
+    if len(set(ranks)) != len(ranks):
+        raise ValueError(f"duplicate ranks are not allowed: {ranks}")
+
+    loaded_pairs: list[
+        tuple[int, dict[str, Any], int | float, dict[str, Any], str | Path]
+    ] = []
+    for rank, viztracer_path, proton_path in pairs:
+        viztracer_json = _load_json(viztracer_path, "VizTracer report")
+        viztracer_base_ns = _viztracer_base_time_ns(viztracer_json, viztracer_path)
+        proton_json = _load_json(proton_path, "Proton trace")
+        loaded_pairs.append(
+            (rank, viztracer_json, viztracer_base_ns, proton_json, proton_path)
+        )
+
+    global_base_ns = min(pair[2] for pair in loaded_pairs)
+    merged_trace = copy.deepcopy(loaded_pairs[0][1])
+    merged_trace["traceEvents"] = []
+    merged_trace.setdefault("viztracer_metadata", {})[
+        "baseTimeNanoseconds"
+    ] = global_base_ns
+
+    proton_event_count = 0
+    for (
+        rank,
+        viztracer_json,
+        viztracer_base_ns,
+        proton_json,
+        proton_path,
+    ) in loaded_pairs:
+        rank_offset_us = (viztracer_base_ns - global_base_ns) / 1000.0
+        proton_events = _prepare_proton_events(
+            proton_json, proton_path, viztracer_base_ns, rank=rank
+        )
+        rank_events = [*viztracer_json.get("traceEvents", []), *proton_events]
+        for event in rank_events:
+            if event.get("ph") != "M" and "ts" in event:
+                event["ts"] += rank_offset_us
+        merged_trace["traceEvents"].extend(rank_events)
+        proton_event_count += len(proton_events)
+
+    _write_json(output_path, merged_trace)
+    return proton_event_count
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -141,18 +295,69 @@ def main(argv: list[str] | None = None) -> None:
     """
     parser = argparse.ArgumentParser(
         prog="tokenspeed merge-traces",
-        description="Merge a Proton chrome trace into a VizTracer report "
-        "on a shared timeline (one file pair per scheduler rank).",
+        description="Merge one or more Proton/VizTracer trace pairs onto a "
+        "shared timeline.",
     )
-    parser.add_argument("viztracer_json", help="VizTracer report (.json)")
-    parser.add_argument("proton_trace", help="Proton chrome trace (.chrome_trace)")
+    parser.add_argument(
+        "viztracer_json",
+        nargs="?",
+        help="VizTracer report (.json; single-rank mode)",
+    )
+    parser.add_argument(
+        "proton_trace",
+        nargs="?",
+        help="Proton chrome trace (.chrome_trace; single-rank mode)",
+    )
     parser.add_argument(
         "-o",
         "--output",
         default=None,
-        help="Output path (default: <viztracer stem>-merged.json)",
+        help=(
+            "Output path (required with --all-ranks; default: "
+            "<viztracer stem>-merged.json)"
+        ),
+    )
+    parser.add_argument(
+        "--all-ranks",
+        action="store_true",
+        help="Merge several rank pairs into one Chrome trace.",
+    )
+    parser.add_argument(
+        "--rank",
+        dest="rank_traces",
+        action="append",
+        nargs=3,
+        metavar=("RANK", "VIZTRACER_JSON", "PROTON_TRACE"),
+        help="TP rank and its VizTracer/Proton inputs; repeat with --all-ranks.",
     )
     args = parser.parse_args(argv)
+
+    if args.all_ranks:
+        if args.viztracer_json is not None or args.proton_trace is not None:
+            parser.error("--all-ranks accepts inputs only through --rank")
+        if not args.rank_traces:
+            parser.error("--all-ranks requires at least one --rank triple")
+        if args.output is None:
+            parser.error("--all-ranks requires --output")
+
+        rank_traces: list[TracePair] = []
+        for rank, viztracer_path, proton_path in args.rank_traces:
+            try:
+                rank_traces.append((int(rank), viztracer_path, proton_path))
+            except ValueError:
+                parser.error(f"--rank expects an integer rank, got {rank!r}")
+
+        merged = merge_all_ranks(rank_traces, args.output)
+        print(
+            f"Merged {merged} Proton events across {len(rank_traces)} ranks into "
+            f"{args.output}"
+        )
+        return
+
+    if args.rank_traces:
+        parser.error("--rank requires --all-ranks")
+    if args.viztracer_json is None or args.proton_trace is None:
+        parser.error("single-rank mode requires VIZTRACER_JSON and PROTON_TRACE")
 
     output = args.output
     if output is None:

--- a/test/cli/test_trace_merge.py
+++ b/test/cli/test_trace_merge.py
@@ -34,7 +34,11 @@ import json
 
 import pytest
 
-from tokenspeed.cli.trace_merge import main, merge_proton_viztracer
+from tokenspeed.cli.trace_merge import (
+    main,
+    merge_all_ranks,
+    merge_proton_viztracer,
+)
 
 VIZTRACER_BASE_NS = 1_000_000_000_000_000
 # Proton session started 2.5 ms after the viztracer clock origin.
@@ -147,6 +151,7 @@ def test_merge_shifts_proton_events_onto_viztracer_axis(tmp_path):
     assert by_name["gemm.mm[triton_mm]"]["dur"] == 5.0
     flow_ts = sorted(e["ts"] for e in events if e.get("cat") == "flow")
     assert flow_ts == [8.0 + EXPECTED_OFFSET_US, 10.0 + EXPECTED_OFFSET_US]
+    assert {e["id"] for e in events if e.get("cat") == "flow"} == {1}
 
 
 def test_merge_rejects_viztracer_report_without_anchor(tmp_path):
@@ -178,3 +183,130 @@ def test_cli_defaults_output_next_to_viztracer_report(tmp_path, capsys):
     default_output = tmp_path / "run.viztracer-merged.json"
     assert default_output.exists()
     assert "Merged 5 Proton events" in capsys.readouterr().out
+
+
+def _rank_viztracer_report(*, base_time_ns: int, pid: int) -> dict:
+    report = _viztracer_report()
+    event = report["traceEvents"][0]
+    event["pid"] = pid
+    event["tid"] = pid
+    report["viztracer_metadata"]["baseTimeNanoseconds"] = base_time_ns
+    return report
+
+
+def _rank_proton_trace(*, base_time_ns: int) -> dict:
+    trace = _proton_trace()
+    trace["baseTimeNanoseconds"] = base_time_ns
+    return trace
+
+
+def test_merge_all_ranks_aligns_timelines_and_namespaces_flow_ids(tmp_path):
+    rank0_viz = _write(
+        tmp_path,
+        "run-TP0.viztracer.json",
+        _rank_viztracer_report(base_time_ns=VIZTRACER_BASE_NS, pid=4242),
+    )
+    rank0_proton = _write(
+        tmp_path,
+        "run-TP0.proton.chrome_trace",
+        _rank_proton_trace(base_time_ns=PROTON_BASE_NS),
+    )
+
+    rank1_base = VIZTRACER_BASE_NS + 10_000
+    rank1_viz = _write(
+        tmp_path,
+        "run-TP1.viztracer.json",
+        _rank_viztracer_report(base_time_ns=rank1_base, pid=4243),
+    )
+    rank1_proton = _write(
+        tmp_path,
+        "run-TP1.proton.chrome_trace",
+        _rank_proton_trace(base_time_ns=rank1_base + 2_500_000),
+    )
+    output_path = tmp_path / "all-ranks.json"
+
+    merged_count = merge_all_ranks(
+        [(1, rank1_viz, rank1_proton), (0, rank0_viz, rank0_proton)],
+        output_path,
+    )
+    assert merged_count == 10
+
+    merged = json.loads(output_path.read_text())
+    assert merged["viztracer_metadata"]["baseTimeNanoseconds"] == VIZTRACER_BASE_NS
+    assert len(merged["traceEvents"]) == 12
+
+    forwards = sorted(
+        (event["pid"], event["ts"])
+        for event in merged["traceEvents"]
+        if event["name"] == "forward"
+    )
+    assert forwards == [(4242, 100.0), (4243, 110.0)]
+
+    proton_processes = {
+        event["pid"]: event["args"]["name"]
+        for event in merged["traceEvents"]
+        if event["ph"] == "M" and event["name"] == "process_name"
+    }
+    assert proton_processes == {10000: "Proton TP0", 10001: "Proton TP1"}
+
+    flow_events = [
+        event
+        for event in merged["traceEvents"]
+        if event.get("name") == "launch->kernel"
+    ]
+    assert {(event["pid"], event["id"]) for event in flow_events} == {
+        (10000, 1),
+        (10001, (1 << 32) | 1),
+    }
+    assert {event["id"] for event in flow_events if event["ph"] == "s"} == {
+        1,
+        (1 << 32) | 1,
+    }
+    assert {event["id"] for event in flow_events if event["ph"] == "f"} == {
+        1,
+        (1 << 32) | 1,
+    }
+    assert all(isinstance(event["id"], int) for event in flow_events)
+
+
+def test_all_ranks_cli_merges_explicit_rank_triples(tmp_path, capsys):
+    rank0_viz = _write(
+        tmp_path,
+        "run-TP0.viztracer.json",
+        _rank_viztracer_report(base_time_ns=VIZTRACER_BASE_NS, pid=4242),
+    )
+    rank0_proton = _write(
+        tmp_path,
+        "run-TP0.proton.chrome_trace",
+        _rank_proton_trace(base_time_ns=PROTON_BASE_NS),
+    )
+    rank1_viz = _write(
+        tmp_path,
+        "run-TP1.viztracer.json",
+        _rank_viztracer_report(base_time_ns=VIZTRACER_BASE_NS, pid=4243),
+    )
+    rank1_proton = _write(
+        tmp_path,
+        "run-TP1.proton.chrome_trace",
+        _rank_proton_trace(base_time_ns=PROTON_BASE_NS),
+    )
+    output_path = tmp_path / "all-ranks.json"
+
+    main(
+        [
+            "--all-ranks",
+            "--rank",
+            "0",
+            rank0_viz,
+            rank0_proton,
+            "--rank",
+            "1",
+            rank1_viz,
+            rank1_proton,
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    assert output_path.exists()
+    assert "Merged 10 Proton events across 2 ranks" in capsys.readouterr().out


### PR DESCRIPTION
Merge VizTracer and Proton traces from multiple TP ranks onto a shared timeline. Namespace Proton global flow IDs per rank so CPU-to-GPU arrows remain intact without cross-linking ranks.