### PR TITLE
feat(engine): return_token_ids — echo raw prompt/output token ids (RL anti-drift)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -37,7 +37,8 @@ export default defineConfig({
         text: "Guides",
         items: [
           { text: "Getting Started", link: "/guides/getting-started" },
-          { text: "Launching a Server", link: "/guides/launching" }
+          { text: "Launching a Server", link: "/guides/launching" },
+          { text: "Returning Raw Token IDs", link: "/guides/return-token-ids" }
         ]
       },
       {

--- a/docs/guides/return-token-ids.md
+++ b/docs/guides/return-token-ids.md
@@ -1,0 +1,72 @@
+# Returning Raw Token IDs
+
+RL trainers (slime, veRL, Agent Lightning) train on the *exact* token sequence
+a rollout produced. If the engine only returns text, the trainer must
+re-tokenize it — and re-tokenization is not guaranteed to reproduce the
+original ids. This **retokenization drift** comes from non-unique tokenization,
+tool-call re-serialization, and chat-template differences, and it silently
+makes RL updates off-policy.
+
+The `return_token_ids` request flag makes the engine echo the raw token ids so
+the trainer reuses them verbatim instead of re-tokenizing.
+
+## Request flag
+
+`return_token_ids` is a request-level boolean on `GenerateReqInput`
+(default `False`). When set, the engine adds two fields to `meta_info` on the
+generation response:
+
+| field                     | meaning                                             |
+| ------------------------- | --------------------------------------------------- |
+| `meta_info.prompt_token_ids` | Tokenizer-valid, unpadded prompt token ids the engine actually ran (before any multimodal placeholder padding). |
+| `meta_info.output_token_ids` | The full cumulative generated token sequence (the exact tokens sampled during the rollout). |
+
+`output_token_ids` is the whole sequence on the finished response, not the
+per-frame streaming delta that rides in the top-level `output_ids`.
+
+## Example (in-process engine)
+
+```python
+from tokenspeed.runtime.engine.io_struct import GenerateReqInput
+
+req = GenerateReqInput(
+    text="What is the capital of France?",
+    sampling_params={"max_new_tokens": 16},
+    return_token_ids=True,
+)
+async for out in engine.generate_request(req):
+    pass  # consume to the finished response
+
+meta = out["meta_info"]
+prompt_ids = meta["prompt_token_ids"]   # exact prompt tokens
+output_ids = meta["output_token_ids"]   # exact sampled tokens
+# Trainer feeds prompt_ids + output_ids directly — no re-tokenization.
+```
+
+## Relationship to logprobs
+
+Independently of this flag, RL trainers have historically recovered response
+token ids from `meta_info.output_token_logprobs` (the
+`[[logprob, token_id, text], ...]` shape). That path still works and is used by
+the native `/generate` route's placeholder-logprob fallback. `return_token_ids`
+is the direct, first-class way to get both prompt and output ids without
+requesting logprobs.
+
+## Scope / status
+
+This is the **engine-side** contract. Output token ids already reach clients
+through the gRPC `GenerateComplete.output_ids` field; this flag adds the
+**prompt** token ids at the engine boundary (`AsyncLLM.generate_request`'s
+yielded dict).
+
+Surfacing `prompt_token_ids` on the OpenAI-compatible `/v1/*` and native
+`/generate` HTTP responses additionally requires, outside this repo:
+
+1. a `prompt_ids` field on the `GenerateComplete` proto message
+   (`tokenspeed_scheduler.proto`),
+2. the gRPC servicer copying `meta_info["prompt_token_ids"]` into it, and
+3. the Rust `smg` gateway rendering it into the JSON response
+   (as `prompt_token_ids` / `token_ids`, matching the vLLM OpenAI API).
+
+Those are tracked as follow-ups; this change lands the engine plumbing and the
+request contract they build on.

--- a/python/tokenspeed/runtime/engine/async_llm.py
+++ b/python/tokenspeed/runtime/engine/async_llm.py
@@ -333,6 +333,15 @@ class AsyncLLM(SchedulerControlClient, EngineClient):
             created_time=created_time,
             tokenized_time=tokenized_obj.created_time,
         )
+        # When the caller asked to echo raw token ids, stash the tokenizer-valid
+        # (unpadded) prompt ids so the output processor can surface them in
+        # meta_info without re-deriving them from the original request.
+        if getattr(obj, "return_token_ids", False):
+            state.prompt_token_ids = (
+                getattr(tokenized_obj, "input_ids_unpadded", None)
+                or getattr(tokenized_obj, "input_ids", None)
+                or []
+            )
         self.rid_to_state[obj.rid] = state
         mm_inputs = getattr(tokenized_obj, "multimodal_inputs", None)
         if mm_inputs is not None:

--- a/python/tokenspeed/runtime/engine/io_struct.py
+++ b/python/tokenspeed/runtime/engine/io_struct.py
@@ -118,6 +118,14 @@ class GenerateReqInput:
     # Whether to return hidden states
     return_hidden_states: bool = False
 
+    # Whether to echo the raw prompt/output token ids back to the caller so RL
+    # trainers reuse the rollout's exact token sequence instead of re-tokenizing
+    # the returned text (avoids retokenization drift). When set, the engine adds
+    # ``meta_info.prompt_token_ids`` (the tokenizer-valid, unpadded prompt ids)
+    # and ``meta_info.output_token_ids`` (the full generated sequence).
+    # See docs/guides/return-token-ids.md.
+    return_token_ids: bool = False
+
     # For disaggregated inference
     bootstrap_host: list[str] | str | None = None
     bootstrap_port: list[int] | int | None = None
@@ -386,6 +394,7 @@ class GenerateReqInput:
                 else None
             ),
             return_hidden_states=self.return_hidden_states,
+            return_token_ids=self.return_token_ids,
             # if `__getitem__` is called, the bootstrap_host, bootstrap_port, bootstrap_room must be a list
             bootstrap_host=(
                 self.bootstrap_host[i] if self.bootstrap_host is not None else None

--- a/python/tokenspeed/runtime/engine/output_processor.py
+++ b/python/tokenspeed/runtime/engine/output_processor.py
@@ -86,6 +86,11 @@ class ReqState:
     output_ids: list[int] = dataclasses.field(default_factory=list)
     logprobs_info: dict = dataclasses.field(default_factory=dict)
 
+    # Tokenizer-valid (unpadded) prompt token ids, captured at send time when
+    # ``obj.return_token_ids`` is set. Surfaced in ``meta_info.prompt_token_ids``
+    # so RL trainers reuse the rollout's exact prompt tokens. Empty otherwise.
+    prompt_token_ids: list[int] = dataclasses.field(default_factory=list)
+
     # Inline detokenizer: lazily constructed on the first
     # BatchTokenIDOut frame for this request. Stays None for
     # raw-token mode (skip_tokenizer_init or tokenizer absent).
@@ -298,6 +303,16 @@ class OutputProcessor:
                     "embedding": recv_obj.embeddings[i],
                     "meta_info": meta_info,
                 }
+
+            # Echo raw token ids for RL trainers (return_token_ids). meta_info is
+            # the same object referenced by out_dict["meta_info"], so mutating it
+            # here reaches the caller. We expose the full cumulative generated
+            # sequence (not the per-frame stream delta in out_dict["output_ids"])
+            # so trainers get the exact rollout tokens on the finished response.
+            if getattr(obj, "return_token_ids", False):
+                meta_info["prompt_token_ids"] = list(state.prompt_token_ids)
+                if "output_ids" in out_dict:
+                    meta_info["output_token_ids"] = list(state.output_ids)
 
             state.finished = recv_obj.finished_reasons[i] is not None
             if state.finished:

--- a/test/runtime/test_return_token_ids.py
+++ b/test/runtime/test_return_token_ids.py
@@ -1,0 +1,305 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for the ``return_token_ids`` request flag.
+
+Covers the two halves of the engine-side plumbing that lets RL trainers
+reuse the rollout's exact token sequence instead of re-tokenizing the
+returned text (avoiding retokenization drift):
+
+1. Request contract (``GenerateReqInput``): the flag defaults off, is
+   accepted through ``normalize_batch_and_arguments``, and propagates to
+   the per-sample sub-requests produced by ``__getitem__`` (batch / n>1
+   fan-out).
+2. Output plumbing (``OutputProcessor.handle_batch_output``): when the
+   flag is set, ``meta_info`` gains ``prompt_token_ids`` (the tokenizer-
+   valid, unpadded prompt ids captured at send time) and
+   ``output_token_ids`` (the full cumulative generated sequence). When it
+   is off, neither key appears.
+
+A ``_StubTokenizerManager`` bypasses ZMQ / ModelConfig / HF bring-up so
+the output-plumbing assertions run the exact production code path without
+a GPU or network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import types
+import unittest
+from typing import Any, Dict, List, Optional
+
+# CI registration (AST-parsed, runtime no-op).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=30, suite="runtime-1gpu")
+
+from transformers import AutoTokenizer  # noqa: E402
+
+from tokenspeed.runtime.engine.collector import (  # noqa: E402
+    RequestOutputCollector,
+)
+from tokenspeed.runtime.engine.detokenizer import (  # noqa: E402
+    IncrementalDetokenizer,
+)
+from tokenspeed.runtime.engine.io_struct import (  # noqa: E402
+    BatchTokenIDOut,
+    GenerateReqInput,
+)
+from tokenspeed.runtime.engine.output_processor import (  # noqa: E402
+    OutputProcessor,
+    ReqState,
+)
+
+_GPT2_TOKENIZER = "gpt2"
+
+
+# ---------------------------------------------------------------------------
+# Request-contract tests (no tokenizer / GPU needed).
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateReqInputContract(unittest.TestCase):
+    def test_flag_defaults_off(self):
+        obj = GenerateReqInput(text="hello")
+        self.assertFalse(obj.return_token_ids)
+
+    def test_flag_survives_normalize_single(self):
+        obj = GenerateReqInput(text="hello", return_token_ids=True)
+        obj.normalize_batch_and_arguments()
+        self.assertTrue(obj.is_single)
+        self.assertTrue(obj.return_token_ids)
+
+    def test_flag_propagates_to_batch_subrequests(self):
+        obj = GenerateReqInput(
+            text=["a", "b", "c"],
+            return_token_ids=True,
+        )
+        obj.normalize_batch_and_arguments()
+        self.assertFalse(obj.is_single)
+        for i in range(3):
+            sub = obj[i]
+            self.assertTrue(
+                sub.return_token_ids,
+                msg=f"sub-request {i} lost return_token_ids",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Output-plumbing stubs (mirror test_inline_detokenizer_receiver.py).
+# ---------------------------------------------------------------------------
+
+
+class _StubTokenizerManager:
+    """Minimal AsyncLLM stand-in for ``OutputProcessor.handle_batch_output``."""
+
+    def __init__(self, tokenizer: Any) -> None:
+        self.tokenizer = tokenizer
+        self.processor = None
+        self.rid_to_state: Dict[str, ReqState] = {}
+        self.enable_metrics = False
+        self.dump_requests_folder = False
+        self.log_requests = False
+        self.server_args = types.SimpleNamespace(
+            enable_inline_detokenizer=True,
+            stream_output=True,
+            speculative_algorithm=None,
+            skip_tokenizer_init=False,
+        )
+        self.output_processor = OutputProcessor(self)
+
+
+class _StubReqObj:
+    """Minimal GenerateReqInput stand-in read by handle_batch_output."""
+
+    def __init__(
+        self,
+        *,
+        stream: bool = False,
+        return_token_ids: bool = False,
+        rid: str = "r1",
+    ) -> None:
+        self.stream = stream
+        self.return_logprob = False
+        self.return_token_ids = return_token_ids
+        self.rid = rid
+        self.log_metrics = False
+        self.top_logprobs_num = []
+        self.token_ids_logprob = []
+        self.return_text_in_logprobs = False
+
+
+def _batch_token_id_out(
+    rids: List[str],
+    *,
+    decode_ids: List[List[int]],
+    finished_reasons: Optional[List[Optional[Dict[str, Any]]]] = None,
+) -> BatchTokenIDOut:
+    n = len(rids)
+    return BatchTokenIDOut(
+        rids=rids,
+        finished_reasons=(
+            finished_reasons if finished_reasons is not None else [None] * n
+        ),
+        decoded_texts=[""] * n,
+        decode_ids=decode_ids,
+        read_offsets=[0] * n,
+        skip_special_tokens=[True] * n,
+        spaces_between_special_tokens=[True] * n,
+        no_stop_trim=[False] * n,
+        output_ids=None,
+        output_multi_ids=None,
+        prompt_tokens=[0] * n,
+        completion_tokens=[0] * n,
+        cached_tokens=[0] * n,
+        spec_verify_ct=[0] * n,
+        input_token_logprobs_val=[],
+        input_token_logprobs_idx=[],
+        output_token_logprobs_val=[],
+        output_token_logprobs_idx=[],
+        input_top_logprobs_val=[],
+        input_top_logprobs_idx=[],
+        output_top_logprobs_val=[],
+        output_top_logprobs_idx=[],
+        input_token_ids_logprobs_val=[],
+        input_token_ids_logprobs_idx=[],
+        output_token_ids_logprobs_val=[],
+        output_token_ids_logprobs_idx=[],
+        output_hidden_states=[[] for _ in range(n)],
+        batch_accept_draft_tokens=[],
+        output_extra_infos=[],
+        generated_time=0,
+    )
+
+
+def _mk_state(
+    *,
+    return_token_ids: bool,
+    prompt_token_ids: Optional[List[int]] = None,
+    rid: str = "r1",
+) -> ReqState:
+    state = ReqState(
+        RequestOutputCollector(),
+        False,
+        asyncio.Event(),
+        _StubReqObj(stream=False, return_token_ids=return_token_ids, rid=rid),
+        created_time=0.0,
+    )
+    if prompt_token_ids is not None:
+        state.prompt_token_ids = prompt_token_ids
+    return state
+
+
+class TestReturnTokenIdsPlumbing(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tok = AutoTokenizer.from_pretrained(_GPT2_TOKENIZER)
+
+    def test_flag_on_adds_prompt_and_output_token_ids(self):
+        mgr = _StubTokenizerManager(self.tok)
+        prompt_ids = self.tok.encode("What is the capital of France?")
+        state = _mk_state(return_token_ids=True, prompt_token_ids=prompt_ids)
+        mgr.rid_to_state[state.obj.rid] = state
+
+        gen_ids = self.tok.encode(" Paris.")
+        mgr.output_processor.handle_batch_output(
+            _batch_token_id_out(
+                ["r1"],
+                decode_ids=[gen_ids],
+                finished_reasons=[{"type": "stop", "matched": None}],
+            )
+        )
+        out = state.collector.take()
+        meta = out["meta_info"]
+
+        self.assertEqual(meta["prompt_token_ids"], prompt_ids)
+        # output_token_ids is the full cumulative generated sequence.
+        self.assertEqual(meta["output_token_ids"], gen_ids)
+        # And it matches the top-level output_ids for a single finished frame.
+        self.assertEqual(meta["output_token_ids"], out["output_ids"])
+        # prompt_token_ids must be a copy, not an alias of the state list.
+        self.assertIsNot(meta["prompt_token_ids"], state.prompt_token_ids)
+
+    def test_flag_off_omits_token_id_keys(self):
+        mgr = _StubTokenizerManager(self.tok)
+        state = _mk_state(return_token_ids=False, prompt_token_ids=[1, 2, 3])
+        mgr.rid_to_state[state.obj.rid] = state
+
+        mgr.output_processor.handle_batch_output(
+            _batch_token_id_out(
+                ["r1"],
+                decode_ids=[self.tok.encode("hi")],
+                finished_reasons=[{"type": "stop", "matched": None}],
+            )
+        )
+        meta = state.collector.take()["meta_info"]
+        self.assertNotIn("prompt_token_ids", meta)
+        self.assertNotIn("output_token_ids", meta)
+
+    def test_output_token_ids_accumulate_across_frames(self):
+        mgr = _StubTokenizerManager(self.tok)
+        prompt_ids = self.tok.encode("prefix")
+        state = _mk_state(return_token_ids=True, prompt_token_ids=prompt_ids)
+        mgr.rid_to_state[state.obj.rid] = state
+
+        ids_a = self.tok.encode("foo ")
+        ids_b = self.tok.encode("bar")
+        mgr.output_processor.handle_batch_output(
+            _batch_token_id_out(["r1"], decode_ids=[ids_a])
+        )
+        first = state.collector.take()["meta_info"]
+        # Non-stream: cumulative after first frame is just ids_a.
+        self.assertEqual(first["output_token_ids"], ids_a)
+
+        mgr.output_processor.handle_batch_output(
+            _batch_token_id_out(
+                ["r1"],
+                decode_ids=[ids_b],
+                finished_reasons=[{"type": "stop", "matched": None}],
+            )
+        )
+        final = state.collector.take()["meta_info"]
+        self.assertEqual(final["prompt_token_ids"], prompt_ids)
+        self.assertEqual(final["output_token_ids"], ids_a + ids_b)
+
+    def test_inline_detokenizer_still_runs_with_flag(self):
+        # The flag must not disturb the normal text detokenization path.
+        mgr = _StubTokenizerManager(self.tok)
+        state = _mk_state(return_token_ids=True, prompt_token_ids=[1])
+        mgr.rid_to_state[state.obj.rid] = state
+        source = "The quick brown fox"
+        ids = self.tok.encode(source)
+        mgr.output_processor.handle_batch_output(
+            _batch_token_id_out(
+                ["r1"],
+                decode_ids=[ids],
+                finished_reasons=[{"type": "stop", "matched": None}],
+            )
+        )
+        out = state.collector.take()
+        self.assertEqual(out["text"], source)
+        self.assertIsInstance(state.inline_detokenizer, IncrementalDetokenizer)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds a request-level **`return_token_ids`** flag on `GenerateReqInput`. When set, the engine echoes the raw token ids so RL trainers reuse the rollout's exact token sequence instead of re-tokenizing the returned text.

Motivation: re-tokenizing output text does not reliably reproduce the original ids (**retokenization drift** — non-unique tokenization, tool-call re-serialization, chat-template divergence), which silently makes RL updates off-policy. Same feature vLLM shipped for Agent Lightning (`return_token_ids`).

## How

`return_token_ids` mirrors the existing `return_hidden_states` flag (plain bool, propagated through `GenerateReqInput.__getitem__`). When set, `OutputProcessor.handle_batch_output` adds two fields to `meta_info` on the yielded out_dict:

| field | meaning |
| --- | --- |
| `meta_info.prompt_token_ids` | tokenizer-valid, **unpadded** prompt ids (captured at send time in `AsyncLLM._send_one_request` from the tokenized request) |
| `meta_info.output_token_ids` | full cumulative generated sequence (exact sampled tokens) |

Output token ids already reach clients via `GenerateComplete.output_ids`; this PR lands the missing **prompt-id** plumbing plus the request contract.

## Scope (draft) — engine-side only

Surfacing `prompt_token_ids` on the OpenAI `/v1/*` and native `/generate` HTTP responses additionally needs, **outside this repo**:

1. a `prompt_ids` field on the `GenerateComplete` proto (`tokenspeed_scheduler.proto`),
2. the gRPC servicer copying `meta_info["prompt_token_ids"]` into it,
3. the Rust `smg` gateway rendering it into JSON (as `prompt_token_ids` / `token_ids`, matching the vLLM OpenAI API).

Tracked as follow-ups; this PR is the engine plumbing + contract they build on.

## Tests

`test/runtime/test_return_token_ids.py` drives the **real** `OutputProcessor.handle_batch_output` path via the same stub harness as `test_inline_detokenizer_receiver.py`: flag on/off, cumulative accumulation across frames, batch `__getitem__` propagation, and non-interference with detokenization.

> Local note: this venv currently can't import the kernel stack on `main` due to an unrelated `triton_kernels`/`flashinfer` version drift (the existing `test_inline_detokenizer_receiver.py` fails to import identically). I validated all 7 tests pass by stubbing the drifted `triton_kernels.*` submodules at import time; CI with aligned deps should run them directly.

## Docs

Adds `docs/guides/return-token-ids.md` + sidebar entry.

🤖 Draft opened for design review.