### PR TITLE
feat(moe): R3 rollout routing replay — slot-indexed expert-routing pool (scaffold)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -37,7 +37,8 @@ export default defineConfig({
         text: "Guides",
         items: [
           { text: "Getting Started", link: "/guides/getting-started" },
-          { text: "Launching a Server", link: "/guides/launching" }
+          { text: "Launching a Server", link: "/guides/launching" },
+          { text: "Rollout Routing Replay (R3)", link: "/guides/routing-replay-r3" }
         ]
       },
       {

--- a/docs/guides/routing-replay-r3.md
+++ b/docs/guides/routing-replay-r3.md
@@ -38,10 +38,13 @@ about 1-5% of the KV footprint.
   `MHATokenToKVPool.set_kv_buffer`; `gather(loc)` returns `[n, num_moe_layers,
   top_k]` — the prefix-hit retrieval.
 - **`RoutedExpertsCapturer`** — per-forward controller:
-  `begin_forward(out_cache_loc)` → `capture(layer_id, topk_ids)` per MoE layer →
+  `begin_forward(out_cache_loc)` → `capture_in_order(topk_ids)` per MoE layer →
   `commit()` scatters into the pool. No-op when inactive, so the hook is free on
   requests that didn't ask for replay. Rows that don't match the forward's slot
   count (TP/EP all-gather) are skipped and counted, never written.
+- `build_routed_experts_capturer(server_args, model_config, size)` sizes the
+  pool from the model config (`num_hidden_layers`, `num_experts_per_tok`);
+  returns `None` for dense models.
 - A process-global accessor (`get/set_global_routed_experts_capturer`) mirroring
   `moe/distribution_recorder.py`'s global recorder.
 - Request flag **`GenerateReqInput.return_routed_experts`** (opt-in, off by
@@ -49,44 +52,56 @@ about 1-5% of the KV footprint.
 
 The repo already captures per-token per-layer `topk_ids` for *offline*
 distribution analysis (`moe/distribution_recorder.py`'s
-`_DetailSinglePassGatherer._topk_ids_of_layer`) and tracks the current layer via
-`with_current_layer`. R3 reuses that shape but adds slot-indexed **persistence**
-and a **return path**.
+`_DetailSinglePassGatherer._topk_ids_of_layer`). R3 reuses that shape but adds
+slot-indexed **persistence** and a **return path**.
 
-## Remaining wiring (model forward + serving) — follow-ups
+## Forward wiring (landed, guarded by `--enable-routing-replay`)
 
-These need a running model, so they are tracked separately from the tested core:
+All hooks are no-ops unless the flag is set, so default behavior is unchanged:
 
-1. **Allocate the pool.** Add a `ServerArgs` flag (e.g.
-   `--enable-routing-replay`) that constructs a `RoutedExpertsPool` sized to the
-   KV pool's `size`, with `num_moe_layers`/`top_k` from the model config, and
-   installs a `RoutedExpertsCapturer` via `set_global_routed_experts_capturer`.
-2. **Capture hook.** In `runtime/layers/moe/topk.py::select_experts` (next to
-   the existing `get_global_expert_distribution_recorder().on_select_experts`
-   call), call `capturer.capture(layer_id, topk_ids)`. The layer index is
-   available through the same `with_current_layer` mechanism the distribution
-   recorder uses.
-3. **Slot mapping into the MoE layer.** `out_cache_loc` currently reaches
-   attention but not the MoE block (`ForwardContext` holds no tensors by
-   design). Thread it into `forward_mlp`/the sparse block, or stash it on the
-   capturer via `begin_forward(out_cache_loc)` at forward start (in
-   `model_runner`) and `commit()` at forward end.
-4. **TP/EP alignment.** In the TP path `topk_ids` rows are the global
-   all-gathered token set, not the rank-local tokens `out_cache_loc` indexes.
-   Either capture before `pre_mlp_comm`, or slice the gathered rows back to
-   local using the comm manager's bookkeeping. The DeepEP path routes locally
-   and is easier. Until this lands, the capturer skips misaligned layers.
-5. **Bypassed/fused routing.** When routing is fused into the kernel
-   (`TopK` `BYPASSED` output), `topk_ids` never materializes in Python; R3 runs
-   need a kernel-level capture or a forced standard-topk path.
-6. **Prefix-hit retrieval + return.** On a prefix hit, `gather` the reused
+1. **Allocate + install** — `engine/event_loop.py` builds the pool (sized to the
+   KV pool's `max_total_num_tokens`) and installs the capturer right after the
+   KV pool is created.
+2. **Forward lifecycle** — `execution/model_runner.py::forward` calls
+   `begin_forward(out_cache_loc)` before `model.forward` and `commit()` after
+   (in a `finally`). `out_cache_loc` is the exact per-token KV-slot vector.
+3. **Capture hook** — `layers/moe/topk.py::select_experts` calls
+   `capture_in_order(topk_ids)` next to the existing `on_select_experts`. Layer
+   index is assigned by per-forward invocation order (MoE layers fire in order),
+   avoiding edits to every model file. The standard (non-`BYPASSED`) path is the
+   only one that materializes `topk_ids` in Python, so fused-routing models are
+   naturally skipped.
+
+## Remaining wiring — follow-ups (need GPU validation)
+
+1. **CUDA-graph decode.** The decode forward is CUDA-graph captured;
+   `capture_in_order` currently **skips under
+   `torch.cuda.is_current_stream_capturing()`** (correct — it never corrupts the
+   graph), so only eager forwards are captured today. To cover graphed decode,
+   record the scatter into the graph using only stable-address buffers (mirror
+   `distribution_recorder._on_hook`, which deliberately fires during capture).
+2. **TP/EP alignment.** In the TP path `topk_ids` rows are the global
+   all-gathered token set, not the rank-local tokens `out_cache_loc` indexes, so
+   the capturer safe-skips (counted in `skipped_misaligned`). Capture before
+   `pre_mlp_comm`, or slice the gathered rows back to local. TP=1 works today;
+   the DeepEP path routes locally and is easier.
+3. **Bypassed/fused routing.** When routing is fused into the kernel
+   (`TopK` `BYPASSED`), `topk_ids` never materializes in Python; R3 runs need a
+   kernel-level capture or a forced standard-topk path.
+4. **Layer-index precision.** Invocation-order indexing assumes one
+   `select_experts` per MoE layer per forward; multi-pass (spec/MTP) or
+   multi-router layers would need the global layer index from
+   `with_current_layer` instead (which also requires installing a non-noop layer
+   tracker — the recorder is a noop in this fork).
+5. **Prefix-hit retrieval + return.** On a prefix hit, `gather` the reused
    slots' routing and merge with the freshly captured tail; surface it to the
    caller (`meta_info.routed_experts`, shape `[seq_len, num_moe_layers,
-   top_k]`). Crossing the gRPC/gateway boundary needs a proto field +
-   servicer + Rust gateway rendering, same as the `return_token_ids` follow-up.
+   top_k]`). Crossing the gRPC/gateway boundary needs a proto field + servicer +
+   Rust gateway rendering, same as the `return_token_ids` follow-up.
 
 ## Status
 
-This PR is a **design-review scaffold**: the storage + capture/commit + retrieval
-core is implemented and unit-tested (CPU); the model-forward and serving wiring
-above are the follow-ups it is built to support.
+The storage/capture core is unit-tested (CPU, 25 tests) and the forward wiring
+is landed but **guarded and not yet GPU-validated end to end** (this venv can't
+run a model). The follow-ups above — chiefly CUDA-graph decode capture, TP/EP
+alignment, and the retrieval/return path — are the remaining work.

--- a/docs/guides/routing-replay-r3.md
+++ b/docs/guides/routing-replay-r3.md
@@ -1,0 +1,92 @@
+# Rollout Routing Replay (R3)
+
+**R3** ([arXiv:2510.11370](https://arxiv.org/abs/2510.11370)) stabilizes RL
+training of Mixture-of-Experts models. During a rollout the inference router and
+the training router pick experts *independently*; tiny numerical differences
+flip a token's top-k selection, which inflates the KL between the training and
+inference policies and destabilizes learning. R3 removes that mismatch: the
+engine records the per-token, per-layer top-k expert ids it selected during the
+rollout, and the trainer **replays** that exact selection in its forward pass.
+Reported effect: train/inference KL cut ~50%, smoother curves. R3 integrates
+with slime and veRL.
+
+## Design: store routing in the KV memory pool
+
+The distinctive choice here (vs. vllm-ascend's transient
+`RoutedExpertsCapturer`) is to persist routing in a pool **indexed by the KV
+slot**, alongside the KV cache.
+
+Why: on a **prefix-cache hit** the shared prefix tokens are dropped from the
+forward entirely — their KV is reused and their MoE layers never run (see
+`runtime/execution/cache_loc_kernel.py`; `out_cache_loc` covers only *new*
+tokens). A transient per-forward capturer therefore has **no routing for the
+prefix**, and you'd have to force a re-forward to recover it. If routing instead
+lives in a slot-indexed pool, it *follows the KV*: a prefix hit that reuses
+slots also reuses the routing captured when those slots were first written —
+zero recompute, and guaranteed consistent with the reused KV.
+
+Per-token cost is `num_moe_layers * top_k * 4` bytes (int32), ~1-2 KB/token —
+about 1-5% of the KV footprint.
+
+## What this change lands (engine core)
+
+`runtime/cache/routed_experts_pool.py`:
+
+- **`RoutedExpertsPool`** — buffer `[size + 1, num_moe_layers, top_k]` int32,
+  indexed on dim 0 by KV slot (row 0 reserved for padding, mirroring the KV
+  pools). `store_layer(layer_id, loc, topk_ids)` scatters by slot exactly like
+  `MHATokenToKVPool.set_kv_buffer`; `gather(loc)` returns `[n, num_moe_layers,
+  top_k]` — the prefix-hit retrieval.
+- **`RoutedExpertsCapturer`** — per-forward controller:
+  `begin_forward(out_cache_loc)` → `capture(layer_id, topk_ids)` per MoE layer →
+  `commit()` scatters into the pool. No-op when inactive, so the hook is free on
+  requests that didn't ask for replay. Rows that don't match the forward's slot
+  count (TP/EP all-gather) are skipped and counted, never written.
+- A process-global accessor (`get/set_global_routed_experts_capturer`) mirroring
+  `moe/distribution_recorder.py`'s global recorder.
+- Request flag **`GenerateReqInput.return_routed_experts`** (opt-in, off by
+  default, propagated through `__getitem__`).
+
+The repo already captures per-token per-layer `topk_ids` for *offline*
+distribution analysis (`moe/distribution_recorder.py`'s
+`_DetailSinglePassGatherer._topk_ids_of_layer`) and tracks the current layer via
+`with_current_layer`. R3 reuses that shape but adds slot-indexed **persistence**
+and a **return path**.
+
+## Remaining wiring (model forward + serving) — follow-ups
+
+These need a running model, so they are tracked separately from the tested core:
+
+1. **Allocate the pool.** Add a `ServerArgs` flag (e.g.
+   `--enable-routing-replay`) that constructs a `RoutedExpertsPool` sized to the
+   KV pool's `size`, with `num_moe_layers`/`top_k` from the model config, and
+   installs a `RoutedExpertsCapturer` via `set_global_routed_experts_capturer`.
+2. **Capture hook.** In `runtime/layers/moe/topk.py::select_experts` (next to
+   the existing `get_global_expert_distribution_recorder().on_select_experts`
+   call), call `capturer.capture(layer_id, topk_ids)`. The layer index is
+   available through the same `with_current_layer` mechanism the distribution
+   recorder uses.
+3. **Slot mapping into the MoE layer.** `out_cache_loc` currently reaches
+   attention but not the MoE block (`ForwardContext` holds no tensors by
+   design). Thread it into `forward_mlp`/the sparse block, or stash it on the
+   capturer via `begin_forward(out_cache_loc)` at forward start (in
+   `model_runner`) and `commit()` at forward end.
+4. **TP/EP alignment.** In the TP path `topk_ids` rows are the global
+   all-gathered token set, not the rank-local tokens `out_cache_loc` indexes.
+   Either capture before `pre_mlp_comm`, or slice the gathered rows back to
+   local using the comm manager's bookkeeping. The DeepEP path routes locally
+   and is easier. Until this lands, the capturer skips misaligned layers.
+5. **Bypassed/fused routing.** When routing is fused into the kernel
+   (`TopK` `BYPASSED` output), `topk_ids` never materializes in Python; R3 runs
+   need a kernel-level capture or a forced standard-topk path.
+6. **Prefix-hit retrieval + return.** On a prefix hit, `gather` the reused
+   slots' routing and merge with the freshly captured tail; surface it to the
+   caller (`meta_info.routed_experts`, shape `[seq_len, num_moe_layers,
+   top_k]`). Crossing the gRPC/gateway boundary needs a proto field +
+   servicer + Rust gateway rendering, same as the `return_token_ids` follow-up.
+
+## Status
+
+This PR is a **design-review scaffold**: the storage + capture/commit + retrieval
+core is implemented and unit-tested (CPU); the model-forward and serving wiring
+above are the follow-ups it is built to support.

--- a/python/tokenspeed/runtime/cache/routed_experts_pool.py
+++ b/python/tokenspeed/runtime/cache/routed_experts_pool.py
@@ -115,7 +115,9 @@ class RoutedExpertsPool:
             device=device,
         )
 
-    def store_layer(self, layer_id: int, loc: torch.Tensor, topk_ids: torch.Tensor) -> None:
+    def store_layer(
+        self, layer_id: int, loc: torch.Tensor, topk_ids: torch.Tensor
+    ) -> None:
         """Scatter one layer's routing into the pool at the given KV slots.
 
         Args:
@@ -201,7 +203,12 @@ class RoutedExpertsCapturer:
         self.pool = pool
         self._loc: torch.Tensor | None = None
         self._captured: dict[int, torch.Tensor] = {}
+        # Per-forward MoE-layer counter. MoE layers invoke select_experts in
+        # layer order within a forward, so the n-th capture_in_order() call is
+        # MoE layer n. Reset by begin_forward().
+        self._layer_counter: int = 0
         self.skipped_misaligned: int = 0
+        self.skipped_overflow: int = 0
 
     @property
     def active(self) -> bool:
@@ -215,6 +222,7 @@ class RoutedExpertsCapturer:
         """
         self._loc = out_cache_loc
         self._captured.clear()
+        self._layer_counter = 0
 
     def capture(self, layer_id: int, topk_ids: torch.Tensor) -> None:
         """Record one MoE layer's ``topk_ids`` for the active forward.
@@ -230,6 +238,28 @@ class RoutedExpertsCapturer:
         # Detach + clone: topk_ids is transient inside the MoE forward and may be
         # freed/overwritten before commit.
         self._captured[layer_id] = topk_ids.detach().clone()
+
+    def capture_in_order(self, topk_ids: torch.Tensor) -> None:
+        """Capture ``topk_ids`` for the next MoE layer in invocation order.
+
+        The MoE forward hook calls this without a layer index; layers fire in
+        order, so the k-th call in a forward is MoE layer k. No-op when capture
+        is inactive. Skipped (and counted) under CUDA-graph capture — the Python
+        counter runs only once at capture time, so baking the scatter into the
+        graph is deferred to a later increment (see docs).
+        """
+        if self._loc is None:
+            return
+        if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+            return
+        layer_id = self._layer_counter
+        self._layer_counter += 1
+        if layer_id >= self.pool.num_moe_layers:
+            # More MoE invocations this forward than the pool was sized for
+            # (e.g. speculative/MTP multi-pass). Skip rather than overflow.
+            self.skipped_overflow += 1
+            return
+        self.capture(layer_id, topk_ids)
 
     def commit(self) -> None:
         """Scatter all captured layers into the pool, then end the forward."""
@@ -260,3 +290,66 @@ def set_global_routed_experts_capturer(
     """Install (or clear with ``None``) the process-global capturer."""
     global _global_routed_experts_capturer
     _global_routed_experts_capturer = capturer
+
+
+def _config_value(model_config, name: str):
+    """Read ``name`` from the model's text config, falling back to hf_config."""
+    hf = getattr(model_config, "hf_config", None)
+    text = getattr(hf, "text_config", None) if hf is not None else None
+    for cfg in (text, hf):
+        if cfg is not None and hasattr(cfg, name):
+            return getattr(cfg, name)
+    return None
+
+
+def build_routed_experts_capturer(
+    server_args,
+    model_config,
+    size: int,
+) -> RoutedExpertsCapturer | None:
+    """Construct a :class:`RoutedExpertsCapturer` sized from the model config.
+
+    Args:
+        server_args: The server args (for ``device``).
+        model_config: The loaded model config (exposes ``hf_config`` /
+            ``hf_config.text_config`` with ``num_hidden_layers`` and
+            ``num_experts_per_tok``).
+        size: Number of KV slots (the KV pool's ``max_total_num_tokens``).
+
+    Returns:
+        A capturer wrapping a pool of shape
+        ``[size + 1, num_hidden_layers, num_experts_per_tok]``, or ``None`` for a
+        dense (non-MoE) model where ``num_experts_per_tok`` is absent — routing
+        replay does not apply there. The layer axis is sized to
+        ``num_hidden_layers`` (the total transformer-layer count, matching
+        ``ExpertLocationMetadata.num_layers``); dense layers simply never write.
+
+    Does not install the capturer; call
+    :func:`set_global_routed_experts_capturer` with the result.
+    """
+    top_k = _config_value(model_config, "num_experts_per_tok")
+    num_layers = _config_value(model_config, "num_hidden_layers")
+    if top_k is None or num_layers is None:
+        logger.warning(
+            "routing replay requested but the model config exposes no "
+            "num_experts_per_tok/num_hidden_layers (dense model?); "
+            "routing replay disabled."
+        )
+        return None
+    device = getattr(server_args, "device", "cuda")
+    pool = RoutedExpertsPool(
+        size=size,
+        num_moe_layers=int(num_layers),
+        top_k=int(top_k),
+        device=device,
+    )
+    logger.info(
+        "routing replay enabled: RoutedExpertsPool size=%d layers=%d top_k=%d "
+        "(%.1f MiB) on %s",
+        size,
+        int(num_layers),
+        int(top_k),
+        pool.num_bytes / (1024 * 1024),
+        device,
+    )
+    return RoutedExpertsCapturer(pool)

--- a/python/tokenspeed/runtime/cache/routed_experts_pool.py
+++ b/python/tokenspeed/runtime/cache/routed_experts_pool.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Rollout Routing Replay (R3): per-KV-slot storage of MoE routing decisions.
+
+R3 (`arXiv:2510.11370 <https://arxiv.org/abs/2510.11370>`_) stabilizes RL
+training of Mixture-of-Experts models by making the training forward *replay*
+the exact expert selection the rollout/inference engine made, instead of
+letting the two routers pick experts independently (numerical differences flip
+routing decisions for tokens and inflate the train/inference KL). To replay,
+the trainer needs the per-token, per-layer top-k expert ids the rollout used.
+
+**Why store routing in a slot-indexed pool (the key design choice).**
+A transient per-forward capturer (as in vllm-ascend's ``RoutedExpertsCapturer``)
+only sees routing for tokens actually forwarded in that step. But on a
+prefix-cache hit the shared prefix tokens are *dropped from the forward
+entirely* — their KV is reused and their MoE layers never run — so a transient
+capturer returns nothing for the prefix and you would have to force a re-forward
+to recover it. Storing routing in a pool **indexed by the same KV slot as the
+KV cache** makes routing follow the KV: a prefix hit that reuses slots also
+reuses the routing captured when those slots were first written, with zero
+recompute and guaranteed consistency with the reused KV.
+
+This module provides the storage (:class:`RoutedExpertsPool`) and the
+per-forward capture/commit controller (:class:`RoutedExpertsCapturer`). Wiring
+the capture hook into the MoE forward and the retrieval into the prefix-cache
+hit path is documented in ``docs/guides/routing-replay-r3.md`` (it requires
+threading ``out_cache_loc`` into the MoE block and handling TP/EP all-gather
+alignment, which are model-forward changes).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+# Sentinel for an unwritten routing entry. -1 matches the fill the existing
+# expert-distribution recorder uses for empty topk slots
+# (moe/distribution_recorder.py::_DetailSinglePassGatherer.reset).
+ROUTING_UNSET = -1
+
+
+class RoutedExpertsPool:
+    """Persistent, KV-slot-indexed store of per-layer top-k expert ids.
+
+    Layout mirrors the KV pools (``layers/attention/kv_cache/mha.py``): a single
+    contiguous buffer of shape ``[size + 1, num_moe_layers, top_k]`` indexed on
+    dim 0 by the flat KV **slot** index. Row 0 is a reserved padding/dummy slot,
+    exactly like the KV pools' reserved slot 0, so a padding slot index of 0
+    never aliases a real token's routing.
+
+    The per-token memory cost is ``num_moe_layers * top_k * 4`` bytes (int32),
+    typically ~1-2 KB/token — roughly 1-5% of the KV footprint per token.
+
+    Args:
+        size: Number of real KV slots (matches the KV pool's ``size``). One
+            extra reserved slot (index 0) is allocated internally.
+        num_moe_layers: Number of MoE layers whose routing is stored.
+        top_k: Experts selected per token per layer (``num_experts_per_tok``).
+        device: Device for the buffer (e.g. ``"cuda"``). Defaults to ``"cpu"``.
+        dtype: Integer dtype for stored ids. Defaults to ``torch.int32``,
+            matching ``TopK.topk_indices_dtype``.
+        fill: Sentinel written to unset entries. Defaults to
+            :data:`ROUTING_UNSET`.
+
+    Attributes:
+        buffer: The backing tensor ``[size + 1, num_moe_layers, top_k]``.
+    """
+
+    def __init__(
+        self,
+        size: int,
+        num_moe_layers: int,
+        top_k: int,
+        device: str | torch.device = "cpu",
+        dtype: torch.dtype = torch.int32,
+        fill: int = ROUTING_UNSET,
+    ) -> None:
+        if size < 0:
+            raise ValueError(f"size must be non-negative, got {size}.")
+        if num_moe_layers <= 0:
+            raise ValueError(f"num_moe_layers must be positive, got {num_moe_layers}.")
+        if top_k <= 0:
+            raise ValueError(f"top_k must be positive, got {top_k}.")
+
+        self.size = size
+        self.num_moe_layers = num_moe_layers
+        self.top_k = top_k
+        self.fill = fill
+        # +1 for the reserved padding slot at index 0.
+        self.buffer = torch.full(
+            (size + 1, num_moe_layers, top_k),
+            fill,
+            dtype=dtype,
+            device=device,
+        )
+
+    def store_layer(self, layer_id: int, loc: torch.Tensor, topk_ids: torch.Tensor) -> None:
+        """Scatter one layer's routing into the pool at the given KV slots.
+
+        Args:
+            layer_id: MoE layer index in ``[0, num_moe_layers)``.
+            loc: 1-D int tensor of KV slot indices, shape ``[n]``. These are the
+                same ``out_cache_loc`` slots the KV cache was written to.
+            topk_ids: Expert ids for those slots, shape ``[n, top_k]``.
+
+        Mirrors ``MHATokenToKVPool.set_kv_buffer``'s scatter-by-``loc``.
+        """
+        self._check_layer(layer_id)
+        if topk_ids.shape[0] != loc.shape[0]:
+            raise ValueError(
+                f"topk_ids rows ({topk_ids.shape[0]}) must match loc rows "
+                f"({loc.shape[0]}); routing rows must be the rank-local tokens "
+                "that out_cache_loc indexes (see TP/EP alignment note in docs)."
+            )
+        if topk_ids.shape[1] != self.top_k:
+            raise ValueError(
+                f"topk_ids has top_k={topk_ids.shape[1]}, pool expects {self.top_k}."
+            )
+        self.buffer[loc.long(), layer_id, :] = topk_ids.to(self.buffer.dtype)
+
+    def gather(self, loc: torch.Tensor) -> torch.Tensor:
+        """Return all layers' routing for the given KV slots.
+
+        Args:
+            loc: 1-D int tensor of KV slot indices, shape ``[n]``.
+
+        Returns:
+            Tensor ``[n, num_moe_layers, top_k]``. Slots never written read back
+            as ``fill``. This is the retrieval used on a prefix-cache hit to
+            recover the shared prefix's routing without recompute.
+        """
+        return self.buffer[loc.long()]
+
+    def gather_layer(self, layer_id: int, loc: torch.Tensor) -> torch.Tensor:
+        """Return one layer's routing for the given KV slots, shape ``[n, top_k]``."""
+        self._check_layer(layer_id)
+        return self.buffer[loc.long(), layer_id, :]
+
+    def reset(self) -> None:
+        """Clear the whole pool back to ``fill`` (e.g. between eval runs)."""
+        self.buffer.fill_(self.fill)
+
+    @property
+    def num_bytes(self) -> int:
+        """Total bytes held by the backing buffer."""
+        return self.buffer.element_size() * self.buffer.nelement()
+
+    def _check_layer(self, layer_id: int) -> None:
+        if not 0 <= layer_id < self.num_moe_layers:
+            raise ValueError(
+                f"layer_id={layer_id} out of range [0, {self.num_moe_layers})."
+            )
+
+
+class RoutedExpertsCapturer:
+    """Per-forward capture controller that commits routing to a pool by slot.
+
+    Lifecycle per model forward::
+
+        capturer.begin_forward(out_cache_loc)   # slots the KV write targets
+        ...                                       # for each MoE layer:
+        capturer.capture(layer_id, topk_ids)      # after select_experts
+        capturer.commit()                         # scatter all layers into pool
+
+    ``begin_forward(None)`` (or never calling it) makes ``capture`` a no-op, so
+    the hook can stay installed and cost nothing on requests that did not ask
+    for routing replay.
+
+    Retrieval is just ``capturer.pool.gather(slots)``.
+
+    TP/EP note: under tensor/expert parallelism ``topk_ids`` rows are the
+    *global* all-gathered token set, not the rank-local tokens ``out_cache_loc``
+    indexes. When the row counts disagree we skip the layer (and count it in
+    :attr:`skipped_misaligned`) rather than corrupt the pool — aligning the
+    gathered rows back to local is the remaining model-forward work tracked in
+    the docs.
+    """
+
+    def __init__(self, pool: RoutedExpertsPool) -> None:
+        self.pool = pool
+        self._loc: torch.Tensor | None = None
+        self._captured: dict[int, torch.Tensor] = {}
+        self.skipped_misaligned: int = 0
+
+    @property
+    def active(self) -> bool:
+        """True between ``begin_forward(loc)`` and ``commit()`` for a real ``loc``."""
+        return self._loc is not None
+
+    def begin_forward(self, out_cache_loc: torch.Tensor | None) -> None:
+        """Start capturing for a forward whose KV write targets ``out_cache_loc``.
+
+        Pass ``None`` to leave capture disabled for this forward.
+        """
+        self._loc = out_cache_loc
+        self._captured.clear()
+
+    def capture(self, layer_id: int, topk_ids: torch.Tensor) -> None:
+        """Record one MoE layer's ``topk_ids`` for the active forward.
+
+        No-op when capture is not active. Rows that don't line up with the
+        forward's slots (TP/EP all-gather) are skipped and counted.
+        """
+        if self._loc is None:
+            return
+        if topk_ids.shape[0] != self._loc.shape[0]:
+            self.skipped_misaligned += 1
+            return
+        # Detach + clone: topk_ids is transient inside the MoE forward and may be
+        # freed/overwritten before commit.
+        self._captured[layer_id] = topk_ids.detach().clone()
+
+    def commit(self) -> None:
+        """Scatter all captured layers into the pool, then end the forward."""
+        if self._loc is not None:
+            for layer_id, topk_ids in self._captured.items():
+                self.pool.store_layer(layer_id, self._loc, topk_ids)
+        self._loc = None
+        self._captured.clear()
+
+
+# --------------------------------------------------------------------------- #
+# Global accessor, mirroring moe/distribution_recorder.py's global recorder so
+# the MoE forward hook can reach the capturer without threading it through every
+# layer signature.
+# --------------------------------------------------------------------------- #
+
+_global_routed_experts_capturer: RoutedExpertsCapturer | None = None
+
+
+def get_global_routed_experts_capturer() -> RoutedExpertsCapturer | None:
+    """Return the process-global capturer, or ``None`` if R3 capture is off."""
+    return _global_routed_experts_capturer
+
+
+def set_global_routed_experts_capturer(
+    capturer: RoutedExpertsCapturer | None,
+) -> None:
+    """Install (or clear with ``None``) the process-global capturer."""
+    global _global_routed_experts_capturer
+    _global_routed_experts_capturer = capturer

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -212,6 +212,21 @@ class EventLoop:
             overlap_schedule_depth=self.overlap_schedule_depth,
         )
 
+        # Rollout Routing Replay (R3): allocate the slot-indexed routing pool and
+        # install a process-global capturer, sized to the KV pool. Off by default;
+        # a dense model yields None (no-op). See docs/guides/routing-replay-r3.md.
+        if getattr(server_args, "enable_routing_replay", False):
+            from tokenspeed.runtime.cache.routed_experts_pool import (
+                build_routed_experts_capturer,
+                set_global_routed_experts_capturer,
+            )
+
+            set_global_routed_experts_capturer(
+                build_routed_experts_capturer(
+                    server_args, self.model_config, self.max_total_num_tokens
+                )
+            )
+
         num_total_pages = self.max_total_num_tokens // server_args.block_size
         hf_config = getattr(self.model_config, "hf_config", None)
         text_config = getattr(hf_config, "text_config", None) if hf_config else None

--- a/python/tokenspeed/runtime/engine/io_struct.py
+++ b/python/tokenspeed/runtime/engine/io_struct.py
@@ -118,6 +118,13 @@ class GenerateReqInput:
     # Whether to return hidden states
     return_hidden_states: bool = False
 
+    # Rollout Routing Replay (R3): whether to return the per-token, per-MoE-layer
+    # top-k expert ids the rollout selected, so an RL trainer can replay the exact
+    # expert selection and cut the train/inference routing mismatch. Backed by the
+    # slot-indexed pool in runtime/cache/routed_experts_pool.py.
+    # See docs/guides/routing-replay-r3.md.
+    return_routed_experts: bool = False
+
     # For disaggregated inference
     bootstrap_host: list[str] | str | None = None
     bootstrap_port: list[int] | int | None = None
@@ -386,6 +393,7 @@ class GenerateReqInput:
                 else None
             ),
             return_hidden_states=self.return_hidden_states,
+            return_routed_experts=self.return_routed_experts,
             # if `__getitem__` is called, the bootstrap_host, bootstrap_port, bootstrap_room must be a list
             bootstrap_host=(
                 self.bootstrap_host[i] if self.bootstrap_host is not None else None

--- a/python/tokenspeed/runtime/execution/model_runner.py
+++ b/python/tokenspeed/runtime/execution/model_runner.py
@@ -25,6 +25,9 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from tokenspeed.runtime.cache.routed_experts_pool import (
+    get_global_routed_experts_capturer,
+)
 from tokenspeed.runtime.execution.weight_loader import WeightLoader
 from tokenspeed.runtime.layers.moe.utils import initialize_moe_config
 from tokenspeed.runtime.utils import get_colorful_logger
@@ -161,13 +164,22 @@ class ModelRunner:
         if kv_sync_event is not None:
             kwargs["kv_sync_event"] = kv_sync_event
 
-        return self.model.forward(
-            ctx,
-            input_ids,
-            positions,
-            out_cache_loc,
-            **kwargs,
-        )
+        # Rollout Routing Replay (R3): capture MoE routing keyed by this forward's
+        # KV slots. No-op unless a capturer is installed (--enable-routing-replay).
+        capturer = get_global_routed_experts_capturer()
+        if capturer is not None:
+            capturer.begin_forward(out_cache_loc)
+        try:
+            return self.model.forward(
+                ctx,
+                input_ids,
+                positions,
+                out_cache_loc,
+                **kwargs,
+            )
+        finally:
+            if capturer is not None:
+                capturer.commit()
 
     # ------------------------------------------------------------------ #
     # RL online weight sync: receive NCCL-broadcast weights from a trainer.

--- a/python/tokenspeed/runtime/layers/moe/topk.py
+++ b/python/tokenspeed/runtime/layers/moe/topk.py
@@ -29,6 +29,9 @@ from tokenspeed_kernel.ops.moe.triton.inkling_topk import inkling_topk
 from tokenspeed_kernel.thirdparty.cuda import routing_flash as cuda_routing_flash
 from tokenspeed_kernel.thirdparty.triton import minimax_biased_grouped_topk
 
+from tokenspeed.runtime.cache.routed_experts_pool import (
+    get_global_routed_experts_capturer,
+)
 from tokenspeed.runtime.moe.distribution_recorder import (
     get_global_expert_distribution_recorder,
 )
@@ -596,5 +599,13 @@ def select_experts(
             topk_weights *= routed_scaling_factor
 
     get_global_expert_distribution_recorder().on_select_experts(topk_ids=topk_ids)
+
+    # Rollout Routing Replay (R3): persist this layer's routing into the
+    # slot-indexed pool. No-op unless --enable-routing-replay installed a
+    # capturer. Only the standard (non-BYPASSED) path materializes topk_ids in
+    # Python, so fused-routing models are naturally skipped (see docs).
+    _r3_capturer = get_global_routed_experts_capturer()
+    if _r3_capturer is not None:
+        _r3_capturer.capture_in_order(topk_ids)
 
     return StandardTopKOutput(topk_weights, topk_ids, router_logits)

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -171,6 +171,12 @@ class ServerArgs:
     enable_expert_distribution_metrics: bool = False
     enable_eplb: bool = False
 
+    # Rollout Routing Replay (R3): capture per-token, per-MoE-layer top-k expert
+    # ids into a KV-slot-indexed pool so RL trainers can replay the rollout's
+    # exact expert selection. Off by default.
+    # See docs/guides/routing-replay-r3.md.
+    enable_routing_replay: bool = False
+
     # MoE backend
     moe_backend: str = "auto"
     draft_moe_backend: str | None = None
@@ -1282,6 +1288,13 @@ class ServerArgs:
             "--enable-expert-distribution-metrics",
             action="store_true",
             help="Enable logging metrics for expert balancedness",
+        )
+        parser.add_argument(
+            "--enable-routing-replay",
+            action="store_true",
+            help="Enable Rollout Routing Replay (R3): capture per-token, "
+            "per-MoE-layer top-k expert ids into a KV-slot-indexed pool so RL "
+            "trainers can replay the rollout's exact expert selection.",
         )
         parser.add_argument(
             "--enable-eplb",

--- a/test/runtime/test_routed_experts_pool.py
+++ b/test/runtime/test_routed_experts_pool.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for the R3 (Rollout Routing Replay) slot-indexed routing pool.
+
+Covers :class:`RoutedExpertsPool` (store/gather by KV slot, reserved slot 0,
+sizing) and :class:`RoutedExpertsCapturer` (per-forward capture/commit, the
+prefix-hit retrieval property, no-op when inactive, and the TP/EP row-count
+misalignment guard). Pure CPU tensors — no GPU or kernel stack needed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+# CI registration (AST-parsed, runtime no-op).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=30, suite="runtime-1gpu")
+
+import torch  # noqa: E402
+
+from tokenspeed.runtime.cache.routed_experts_pool import (  # noqa: E402
+    ROUTING_UNSET,
+    RoutedExpertsCapturer,
+    RoutedExpertsPool,
+    get_global_routed_experts_capturer,
+    set_global_routed_experts_capturer,
+)
+
+
+class TestRoutedExpertsPool(unittest.TestCase):
+    def _pool(self, size=16, num_moe_layers=3, top_k=2):
+        return RoutedExpertsPool(size=size, num_moe_layers=num_moe_layers, top_k=top_k)
+
+    def test_shape_and_reserved_slot(self):
+        pool = self._pool(size=16, num_moe_layers=3, top_k=2)
+        # +1 reserved padding row at index 0.
+        self.assertEqual(tuple(pool.buffer.shape), (17, 3, 2))
+        self.assertEqual(pool.buffer.dtype, torch.int32)
+        # Everything starts unset.
+        self.assertTrue(torch.all(pool.buffer == ROUTING_UNSET))
+
+    def test_store_and_gather_roundtrip(self):
+        pool = self._pool()
+        loc = torch.tensor([1, 5, 9])
+        ids_l0 = torch.tensor([[3, 7], [1, 2], [4, 4]], dtype=torch.int32)
+        pool.store_layer(0, loc, ids_l0)
+        got = pool.gather_layer(0, loc)
+        self.assertTrue(torch.equal(got, ids_l0))
+
+    def test_gather_all_layers_shape(self):
+        pool = self._pool(num_moe_layers=3, top_k=2)
+        loc = torch.tensor([2, 4])
+        pool.store_layer(0, loc, torch.tensor([[1, 1], [2, 2]], dtype=torch.int32))
+        pool.store_layer(2, loc, torch.tensor([[7, 8], [9, 0]], dtype=torch.int32))
+        allrouting = pool.gather(loc)
+        self.assertEqual(tuple(allrouting.shape), (2, 3, 2))
+        # Layer 1 was never written → still unset.
+        self.assertTrue(torch.all(allrouting[:, 1, :] == ROUTING_UNSET))
+        self.assertTrue(torch.equal(allrouting[:, 0, :], torch.tensor([[1, 1], [2, 2]])))
+        self.assertTrue(torch.equal(allrouting[:, 2, :], torch.tensor([[7, 8], [9, 0]])))
+
+    def test_reserved_slot_zero_does_not_alias(self):
+        pool = self._pool()
+        # Writing real slots must never touch the reserved padding row 0.
+        pool.store_layer(0, torch.tensor([1, 2, 3]), torch.tensor(
+            [[5, 5], [6, 6], [7, 7]], dtype=torch.int32
+        ))
+        self.assertTrue(torch.all(pool.buffer[0] == ROUTING_UNSET))
+
+    def test_store_rejects_row_mismatch(self):
+        pool = self._pool()
+        with self.assertRaises(ValueError):
+            pool.store_layer(0, torch.tensor([1, 2]), torch.tensor(
+                [[1, 1]], dtype=torch.int32
+            ))
+
+    def test_store_rejects_topk_mismatch(self):
+        pool = self._pool(top_k=2)
+        with self.assertRaises(ValueError):
+            pool.store_layer(0, torch.tensor([1]), torch.tensor(
+                [[1, 2, 3]], dtype=torch.int32
+            ))
+
+    def test_store_rejects_bad_layer(self):
+        pool = self._pool(num_moe_layers=3)
+        with self.assertRaises(ValueError):
+            pool.store_layer(3, torch.tensor([1]), torch.tensor([[1, 1]]))
+
+    def test_reset(self):
+        pool = self._pool()
+        pool.store_layer(0, torch.tensor([1]), torch.tensor([[9, 9]], dtype=torch.int32))
+        pool.reset()
+        self.assertTrue(torch.all(pool.buffer == ROUTING_UNSET))
+
+    def test_num_bytes(self):
+        pool = self._pool(size=100, num_moe_layers=4, top_k=8)
+        # (100 + 1) * 4 * 8 * 4 bytes (int32)
+        self.assertEqual(pool.num_bytes, 101 * 4 * 8 * 4)
+
+    def test_constructor_validation(self):
+        with self.assertRaises(ValueError):
+            RoutedExpertsPool(size=-1, num_moe_layers=1, top_k=1)
+        with self.assertRaises(ValueError):
+            RoutedExpertsPool(size=1, num_moe_layers=0, top_k=1)
+        with self.assertRaises(ValueError):
+            RoutedExpertsPool(size=1, num_moe_layers=1, top_k=0)
+
+
+class TestRoutedExpertsCapturer(unittest.TestCase):
+    def _setup(self, num_moe_layers=2, top_k=2):
+        pool = RoutedExpertsPool(size=16, num_moe_layers=num_moe_layers, top_k=top_k)
+        return pool, RoutedExpertsCapturer(pool)
+
+    def test_capture_commit_writes_pool(self):
+        pool, cap = self._setup(num_moe_layers=2, top_k=2)
+        loc = torch.tensor([3, 4, 5])
+        cap.begin_forward(loc)
+        self.assertTrue(cap.active)
+        cap.capture(0, torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=torch.int32))
+        cap.capture(1, torch.tensor([[7, 8], [9, 0], [1, 1]], dtype=torch.int32))
+        cap.commit()
+        self.assertFalse(cap.active)
+        got = pool.gather(loc)
+        self.assertTrue(torch.equal(got[:, 0, :], torch.tensor([[1, 2], [3, 4], [5, 6]])))
+        self.assertTrue(torch.equal(got[:, 1, :], torch.tensor([[7, 8], [9, 0], [1, 1]])))
+
+    def test_prefix_hit_retrieval_property(self):
+        # The core R3 property: routing written for a set of slots is retrievable
+        # later purely from those slots — exactly what a prefix-cache hit does
+        # when it reuses the KV slots of a shared prefix.
+        pool, cap = self._setup(num_moe_layers=2, top_k=2)
+        prefix_slots = torch.tensor([10, 11, 12, 13])
+        cap.begin_forward(prefix_slots)
+        cap.capture(0, torch.tensor([[1, 1], [2, 2], [3, 3], [4, 4]], dtype=torch.int32))
+        cap.capture(1, torch.tensor([[5, 5], [6, 6], [7, 7], [8, 8]], dtype=torch.int32))
+        cap.commit()
+
+        # A later request whose prefix hit reuses slots 11..13 recovers routing
+        # with no recompute, consistent with the reused KV.
+        reused = torch.tensor([11, 12, 13])
+        routing = pool.gather(reused)
+        self.assertTrue(torch.equal(routing[:, 0, :], torch.tensor([[2, 2], [3, 3], [4, 4]])))
+        self.assertTrue(torch.equal(routing[:, 1, :], torch.tensor([[6, 6], [7, 7], [8, 8]])))
+
+    def test_capture_noop_when_inactive(self):
+        pool, cap = self._setup()
+        # No begin_forward → capture must be a no-op (hook stays installed cheaply).
+        cap.capture(0, torch.tensor([[1, 2]], dtype=torch.int32))
+        cap.commit()
+        self.assertTrue(torch.all(pool.buffer == ROUTING_UNSET))
+
+    def test_begin_forward_none_disables(self):
+        pool, cap = self._setup()
+        cap.begin_forward(None)
+        self.assertFalse(cap.active)
+        cap.capture(0, torch.tensor([[1, 2]], dtype=torch.int32))
+        cap.commit()
+        self.assertTrue(torch.all(pool.buffer == ROUTING_UNSET))
+
+    def test_tp_row_misalignment_is_skipped(self):
+        # Under TP/EP, topk_ids rows are the global all-gathered token set, not
+        # the rank-local slots. Skip rather than corrupt, and count it.
+        pool, cap = self._setup(top_k=2)
+        loc = torch.tensor([1, 2, 3])  # 3 local slots
+        cap.begin_forward(loc)
+        # 6 global rows (e.g. TP=2 all-gather) — must be skipped.
+        cap.capture(0, torch.tensor([[i, i] for i in range(6)], dtype=torch.int32))
+        cap.commit()
+        self.assertEqual(cap.skipped_misaligned, 1)
+        self.assertTrue(torch.all(pool.buffer == ROUTING_UNSET))
+
+    def test_capture_detaches_from_source(self):
+        # commit must persist a snapshot even if the source tensor is mutated
+        # after capture (topk_ids is transient inside the MoE forward).
+        pool, cap = self._setup(num_moe_layers=1, top_k=2)
+        loc = torch.tensor([1, 2])
+        src = torch.tensor([[1, 1], [2, 2]], dtype=torch.int32)
+        cap.begin_forward(loc)
+        cap.capture(0, src)
+        src.fill_(0)  # overwrite the source before commit
+        cap.commit()
+        self.assertTrue(torch.equal(pool.gather_layer(0, loc), torch.tensor([[1, 1], [2, 2]])))
+
+
+class TestReturnRoutedExpertsFlag(unittest.TestCase):
+    """The request-level flag defaults off and propagates through __getitem__.
+
+    io_struct is imported lazily so the kernel-free pool tests above still run
+    in environments where the full engine import chain is unavailable.
+    """
+
+    def test_flag_defaults_off_and_propagates(self):
+        from tokenspeed.runtime.engine.io_struct import GenerateReqInput
+
+        self.assertFalse(GenerateReqInput(text="hi").return_routed_experts)
+
+        obj = GenerateReqInput(text=["a", "b"], return_routed_experts=True)
+        obj.normalize_batch_and_arguments()
+        for i in range(2):
+            self.assertTrue(obj[i].return_routed_experts)
+
+
+class TestGlobalCapturer(unittest.TestCase):
+    def tearDown(self):
+        set_global_routed_experts_capturer(None)
+
+    def test_global_accessor_roundtrip(self):
+        self.assertIsNone(get_global_routed_experts_capturer())
+        pool = RoutedExpertsPool(size=4, num_moe_layers=1, top_k=1)
+        cap = RoutedExpertsCapturer(pool)
+        set_global_routed_experts_capturer(cap)
+        self.assertIs(get_global_routed_experts_capturer(), cap)
+        set_global_routed_experts_capturer(None)
+        self.assertIsNone(get_global_routed_experts_capturer())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/runtime/test_routed_experts_pool.py
+++ b/test/runtime/test_routed_experts_pool.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import os
 import sys
+import types
 import unittest
 
 # CI registration (AST-parsed, runtime no-op).
@@ -44,6 +45,7 @@ from tokenspeed.runtime.cache.routed_experts_pool import (  # noqa: E402
     ROUTING_UNSET,
     RoutedExpertsCapturer,
     RoutedExpertsPool,
+    build_routed_experts_capturer,
     get_global_routed_experts_capturer,
     set_global_routed_experts_capturer,
 )
@@ -78,30 +80,36 @@ class TestRoutedExpertsPool(unittest.TestCase):
         self.assertEqual(tuple(allrouting.shape), (2, 3, 2))
         # Layer 1 was never written → still unset.
         self.assertTrue(torch.all(allrouting[:, 1, :] == ROUTING_UNSET))
-        self.assertTrue(torch.equal(allrouting[:, 0, :], torch.tensor([[1, 1], [2, 2]])))
-        self.assertTrue(torch.equal(allrouting[:, 2, :], torch.tensor([[7, 8], [9, 0]])))
+        self.assertTrue(
+            torch.equal(allrouting[:, 0, :], torch.tensor([[1, 1], [2, 2]]))
+        )
+        self.assertTrue(
+            torch.equal(allrouting[:, 2, :], torch.tensor([[7, 8], [9, 0]]))
+        )
 
     def test_reserved_slot_zero_does_not_alias(self):
         pool = self._pool()
         # Writing real slots must never touch the reserved padding row 0.
-        pool.store_layer(0, torch.tensor([1, 2, 3]), torch.tensor(
-            [[5, 5], [6, 6], [7, 7]], dtype=torch.int32
-        ))
+        pool.store_layer(
+            0,
+            torch.tensor([1, 2, 3]),
+            torch.tensor([[5, 5], [6, 6], [7, 7]], dtype=torch.int32),
+        )
         self.assertTrue(torch.all(pool.buffer[0] == ROUTING_UNSET))
 
     def test_store_rejects_row_mismatch(self):
         pool = self._pool()
         with self.assertRaises(ValueError):
-            pool.store_layer(0, torch.tensor([1, 2]), torch.tensor(
-                [[1, 1]], dtype=torch.int32
-            ))
+            pool.store_layer(
+                0, torch.tensor([1, 2]), torch.tensor([[1, 1]], dtype=torch.int32)
+            )
 
     def test_store_rejects_topk_mismatch(self):
         pool = self._pool(top_k=2)
         with self.assertRaises(ValueError):
-            pool.store_layer(0, torch.tensor([1]), torch.tensor(
-                [[1, 2, 3]], dtype=torch.int32
-            ))
+            pool.store_layer(
+                0, torch.tensor([1]), torch.tensor([[1, 2, 3]], dtype=torch.int32)
+            )
 
     def test_store_rejects_bad_layer(self):
         pool = self._pool(num_moe_layers=3)
@@ -110,7 +118,9 @@ class TestRoutedExpertsPool(unittest.TestCase):
 
     def test_reset(self):
         pool = self._pool()
-        pool.store_layer(0, torch.tensor([1]), torch.tensor([[9, 9]], dtype=torch.int32))
+        pool.store_layer(
+            0, torch.tensor([1]), torch.tensor([[9, 9]], dtype=torch.int32)
+        )
         pool.reset()
         self.assertTrue(torch.all(pool.buffer == ROUTING_UNSET))
 
@@ -143,8 +153,12 @@ class TestRoutedExpertsCapturer(unittest.TestCase):
         cap.commit()
         self.assertFalse(cap.active)
         got = pool.gather(loc)
-        self.assertTrue(torch.equal(got[:, 0, :], torch.tensor([[1, 2], [3, 4], [5, 6]])))
-        self.assertTrue(torch.equal(got[:, 1, :], torch.tensor([[7, 8], [9, 0], [1, 1]])))
+        self.assertTrue(
+            torch.equal(got[:, 0, :], torch.tensor([[1, 2], [3, 4], [5, 6]]))
+        )
+        self.assertTrue(
+            torch.equal(got[:, 1, :], torch.tensor([[7, 8], [9, 0], [1, 1]]))
+        )
 
     def test_prefix_hit_retrieval_property(self):
         # The core R3 property: routing written for a set of slots is retrievable
@@ -153,16 +167,24 @@ class TestRoutedExpertsCapturer(unittest.TestCase):
         pool, cap = self._setup(num_moe_layers=2, top_k=2)
         prefix_slots = torch.tensor([10, 11, 12, 13])
         cap.begin_forward(prefix_slots)
-        cap.capture(0, torch.tensor([[1, 1], [2, 2], [3, 3], [4, 4]], dtype=torch.int32))
-        cap.capture(1, torch.tensor([[5, 5], [6, 6], [7, 7], [8, 8]], dtype=torch.int32))
+        cap.capture(
+            0, torch.tensor([[1, 1], [2, 2], [3, 3], [4, 4]], dtype=torch.int32)
+        )
+        cap.capture(
+            1, torch.tensor([[5, 5], [6, 6], [7, 7], [8, 8]], dtype=torch.int32)
+        )
         cap.commit()
 
         # A later request whose prefix hit reuses slots 11..13 recovers routing
         # with no recompute, consistent with the reused KV.
         reused = torch.tensor([11, 12, 13])
         routing = pool.gather(reused)
-        self.assertTrue(torch.equal(routing[:, 0, :], torch.tensor([[2, 2], [3, 3], [4, 4]])))
-        self.assertTrue(torch.equal(routing[:, 1, :], torch.tensor([[6, 6], [7, 7], [8, 8]])))
+        self.assertTrue(
+            torch.equal(routing[:, 0, :], torch.tensor([[2, 2], [3, 3], [4, 4]]))
+        )
+        self.assertTrue(
+            torch.equal(routing[:, 1, :], torch.tensor([[6, 6], [7, 7], [8, 8]]))
+        )
 
     def test_capture_noop_when_inactive(self):
         pool, cap = self._setup()
@@ -201,7 +223,95 @@ class TestRoutedExpertsCapturer(unittest.TestCase):
         cap.capture(0, src)
         src.fill_(0)  # overwrite the source before commit
         cap.commit()
-        self.assertTrue(torch.equal(pool.gather_layer(0, loc), torch.tensor([[1, 1], [2, 2]])))
+        self.assertTrue(
+            torch.equal(pool.gather_layer(0, loc), torch.tensor([[1, 1], [2, 2]]))
+        )
+
+
+class TestCaptureInOrder(unittest.TestCase):
+    """capture_in_order assigns MoE layers by per-forward invocation order."""
+
+    def _setup(self, num_moe_layers=3, top_k=2):
+        pool = RoutedExpertsPool(size=16, num_moe_layers=num_moe_layers, top_k=top_k)
+        return pool, RoutedExpertsCapturer(pool)
+
+    def test_sequential_layer_assignment(self):
+        pool, cap = self._setup(num_moe_layers=3, top_k=2)
+        loc = torch.tensor([1, 2])
+        cap.begin_forward(loc)
+        cap.capture_in_order(torch.tensor([[0, 0], [0, 0]], dtype=torch.int32))  # -> 0
+        cap.capture_in_order(torch.tensor([[1, 1], [1, 1]], dtype=torch.int32))  # -> 1
+        cap.capture_in_order(torch.tensor([[2, 2], [2, 2]], dtype=torch.int32))  # -> 2
+        cap.commit()
+        got = pool.gather(loc)
+        self.assertTrue(torch.equal(got[:, 0, :], torch.zeros(2, 2, dtype=torch.int32)))
+        self.assertTrue(torch.equal(got[:, 1, :], torch.ones(2, 2, dtype=torch.int32)))
+        self.assertTrue(
+            torch.equal(got[:, 2, :], torch.full((2, 2), 2, dtype=torch.int32))
+        )
+
+    def test_counter_resets_each_forward(self):
+        pool, cap = self._setup(num_moe_layers=2, top_k=1)
+        loc = torch.tensor([5])
+        cap.begin_forward(loc)
+        cap.capture_in_order(torch.tensor([[9]], dtype=torch.int32))  # layer 0
+        cap.commit()
+        # New forward → counter back to 0, layer 0 overwritten.
+        cap.begin_forward(loc)
+        cap.capture_in_order(torch.tensor([[3]], dtype=torch.int32))  # layer 0 again
+        cap.commit()
+        self.assertTrue(torch.equal(pool.gather_layer(0, loc), torch.tensor([[3]])))
+
+    def test_overflow_is_skipped_and_counted(self):
+        pool, cap = self._setup(num_moe_layers=2, top_k=1)
+        loc = torch.tensor([1])
+        cap.begin_forward(loc)
+        cap.capture_in_order(torch.tensor([[1]], dtype=torch.int32))  # layer 0
+        cap.capture_in_order(torch.tensor([[2]], dtype=torch.int32))  # layer 1
+        cap.capture_in_order(torch.tensor([[3]], dtype=torch.int32))  # overflow
+        cap.commit()
+        self.assertEqual(cap.skipped_overflow, 1)
+        self.assertTrue(torch.equal(pool.gather_layer(0, loc), torch.tensor([[1]])))
+        self.assertTrue(torch.equal(pool.gather_layer(1, loc), torch.tensor([[2]])))
+
+    def test_inactive_is_noop(self):
+        pool, cap = self._setup()
+        cap.capture_in_order(torch.tensor([[1, 2]], dtype=torch.int32))
+        cap.commit()
+        self.assertTrue(torch.all(pool.buffer == ROUTING_UNSET))
+
+
+class TestBuildFromConfig(unittest.TestCase):
+    """build_routed_experts_capturer derives size/layers/top_k from config."""
+
+    @staticmethod
+    def _model_config(*, num_hidden_layers, num_experts_per_tok):
+        text = types.SimpleNamespace()
+        if num_hidden_layers is not None:
+            text.num_hidden_layers = num_hidden_layers
+        if num_experts_per_tok is not None:
+            text.num_experts_per_tok = num_experts_per_tok
+        hf = types.SimpleNamespace(text_config=text)
+        return types.SimpleNamespace(hf_config=hf)
+
+    def test_moe_config_builds_capturer(self):
+        server_args = types.SimpleNamespace(device="cpu")
+        mc = self._model_config(num_hidden_layers=6, num_experts_per_tok=4)
+        cap = build_routed_experts_capturer(server_args, mc, size=32)
+        self.assertIsInstance(cap, RoutedExpertsCapturer)
+        self.assertEqual(tuple(cap.pool.buffer.shape), (33, 6, 4))
+
+    def test_dense_config_returns_none(self):
+        server_args = types.SimpleNamespace(device="cpu")
+        mc = self._model_config(num_hidden_layers=6, num_experts_per_tok=None)
+        self.assertIsNone(build_routed_experts_capturer(server_args, mc, size=32))
+
+    def test_reads_from_hf_config_when_no_text_config(self):
+        server_args = types.SimpleNamespace(device="cpu")
+        hf = types.SimpleNamespace(num_hidden_layers=4, num_experts_per_tok=2)
+        mc = types.SimpleNamespace(hf_config=hf)
+        cap = build_routed_experts_capturer(server_args, mc, size=8)
+        self.assertEqual(tuple(cap.pool.buffer.shape), (9, 4, 2))
 
 
 class TestReturnRoutedExpertsFlag(unittest.TestCase):


### PR DESCRIPTION
## What & why

**R3** ([arXiv:2510.11370](https://arxiv.org/abs/2510.11370)) stabilizes RL training of MoE models: the training forward **replays** the exact expert selection the rollout made, instead of letting the inference and training routers pick experts independently. Independent routers + tiny numerical drift flip a token's top-k choice → train/inference KL blows up. R3 records per-token, per-layer top-k expert ids at rollout and replays them in training (KL cut ~50%; integrates with slime/veRL).

## Design — store routing in the KV memory pool

The distinctive choice vs. vllm-ascend's transient `RoutedExpertsCapturer`: persist routing in a pool **indexed by the KV slot**, alongside KV.

On a **prefix-cache hit** the shared prefix tokens are dropped from the forward entirely — their MoE layers never run (`out_cache_loc` covers only new tokens). A transient capturer therefore returns **nothing** for the prefix; you'd have to force a re-forward. A slot-indexed pool makes routing *follow the KV*: a prefix hit that reuses slots also reuses the routing captured when those slots were first written — zero recompute, guaranteed consistent with the reused KV. Cost ≈ `num_moe_layers * top_k * 4` B/token (~1-5% of KV).

This builds on infra the repo already has (`moe/distribution_recorder.py` already captures per-token per-layer `topk_ids` for offline analysis + tracks the current layer); R3 adds slot-indexed **persistence** and a **return path**.

## What this PR lands (tested engine core)

`runtime/cache/routed_experts_pool.py`:
- **`RoutedExpertsPool`** — `[size+1, num_moe_layers, top_k]` int32, slot-indexed on dim 0 (row 0 reserved, mirrors the KV pools). `store_layer()` scatters by slot like `set_kv_buffer`; `gather()` is the prefix-hit retrieval.
- **`RoutedExpertsCapturer`** — per-forward `begin_forward`/`capture`/`commit`; no-op when inactive; skips + counts TP/EP-misaligned rows rather than corrupt the pool.
- process-global accessor (mirrors the distribution recorder).
- **`GenerateReqInput.return_routed_experts`** opt-in flag (propagated via `__getitem__`).

**18 CPU unit tests**: store/gather, reserved slot, sizing, the prefix-hit retrieval property, capture/commit, inactive no-op, TP-misalignment skip, detach-on-capture, flag propagation.

## Remaining wiring (needs a running model) — documented follow-ups

In `docs/guides/routing-replay-r3.md`: allocate the pool via a `ServerArgs` flag; capture hook at `topk.py::select_experts` (beside the existing `on_select_experts`); thread `out_cache_loc` into the MoE block; TP/EP all-gather alignment; `BYPASSED` fused-routing capture; prefix-hit retrieval + return path across the gRPC/gateway boundary (proto + servicer + Rust gateway, same boundary as the `return_token_ids` follow-up).

## Docs

Adds `docs/guides/routing-replay-r3.md` + sidebar entry.

> Local note: this venv can't import the full kernel stack on `main` (unrelated `triton_kernels`/`flashinfer` version drift). The pool/capturer tests are kernel-free and run directly (18 passed); the one lazy-imported flag test also passes.

🤖 Draft opened for design review.