### PR TITLE
feat(profile): Link VizTracer to Proton CPU scopes

### DIFF
--- a/python/tokenspeed/cli/trace_merge.py
+++ b/python/tokenspeed/cli/trace_merge.py
@@ -72,7 +72,7 @@ _FLOW_ID_RANK_SHIFT = 32
 _FLOW_ID_LOCAL_MASK = (1 << _FLOW_ID_RANK_SHIFT) - 1
 _VIZTRACER_PROTON_FLOW_NAME = "viztracer->proton"
 _VIZTRACER_PROTON_FLOW_CATEGORY = "tokenspeed.proton"
-_PROTON_SCOPE_ID_ARG = "proton_scope_id"
+_SCOPE_ID_ARG = "scope_id"
 _VIZTRACER_PROTON_FLOW_TAG = 1 << 52
 _MAX_FLOW_RANK = (_VIZTRACER_PROTON_FLOW_TAG - 1) >> _FLOW_ID_RANK_SHIFT
 
@@ -163,7 +163,7 @@ def _link_viztracer_to_proton_cpu(
         args = event.get("args")
         if not isinstance(args, dict):
             continue
-        scope_id = args.get(_PROTON_SCOPE_ID_ARG)
+        scope_id = args.get(_SCOPE_ID_ARG)
         if isinstance(scope_id, int) and not isinstance(scope_id, bool):
             proton_cpu_scopes[scope_id] = event
 

--- a/python/tokenspeed/cli/trace_merge.py
+++ b/python/tokenspeed/cli/trace_merge.py
@@ -42,7 +42,9 @@ Usage (one final report for multiple scheduler ranks):
 
 In all-ranks mode, the TP rank is encoded into each numeric Proton flow ID.
 This keeps CPU-to-GPU flow arrows within a rank while preventing matching
-launch IDs on different ranks from cross-linking.
+launch IDs on different ranks from cross-linking. When TokenSpeed emits
+VizTracer scope-entry flows and Proton exports their scope IDs, the merger also
+links VizTracer Python slices to Proton CPU scopes.
 
 Open the merged report in vizviewer or https://ui.perfetto.dev — Python
 frames and Proton's kernel/scope lanes share one time axis. Alignment
@@ -68,7 +70,11 @@ _PROTON_PID_BASE = 10_000
 _FLOW_PHASES = frozenset({"s", "t", "f"})
 _FLOW_ID_RANK_SHIFT = 32
 _FLOW_ID_LOCAL_MASK = (1 << _FLOW_ID_RANK_SHIFT) - 1
-_MAX_SAFE_JSON_INTEGER = (1 << 53) - 1
+_VIZTRACER_PROTON_FLOW_NAME = "viztracer->proton"
+_VIZTRACER_PROTON_FLOW_CATEGORY = "tokenspeed.proton"
+_PROTON_SCOPE_ID_ARG = "proton_scope_id"
+_VIZTRACER_PROTON_FLOW_TAG = 1 << 52
+_MAX_FLOW_RANK = (_VIZTRACER_PROTON_FLOW_TAG - 1) >> _FLOW_ID_RANK_SHIFT
 
 TracePair = tuple[int, str | Path, str | Path]
 
@@ -125,12 +131,69 @@ def _namespace_proton_flow_id(event: dict[str, Any], rank: int) -> None:
             f"Proton flow ID must be an unsigned 32-bit integer: {flow_id!r}"
         )
 
+    if rank > _MAX_FLOW_RANK:
+        raise ValueError(f"TP rank {rank} is too large to encode in a flow ID")
     namespaced_id = (rank << _FLOW_ID_RANK_SHIFT) | flow_id
-    if namespaced_id > _MAX_SAFE_JSON_INTEGER:
-        raise ValueError(
-            f"TP rank {rank} is too large to encode in a JSON-safe flow ID"
-        )
     event["id"] = namespaced_id
+
+
+def _namespace_viztracer_proton_flow_id(scope_id: int, rank: int) -> int:
+    """Return a numeric rank-local ID reserved for VizTracer-to-Proton flows."""
+    if (
+        not isinstance(scope_id, int)
+        or isinstance(scope_id, bool)
+        or not 0 <= scope_id <= _FLOW_ID_LOCAL_MASK
+    ):
+        raise ValueError(
+            f"Proton scope ID must be an unsigned 32-bit integer: {scope_id!r}"
+        )
+    if rank > _MAX_FLOW_RANK:
+        raise ValueError(f"TP rank {rank} is too large to encode in a flow ID")
+    return _VIZTRACER_PROTON_FLOW_TAG | (rank << _FLOW_ID_RANK_SHIFT) | scope_id
+
+
+def _link_viztracer_to_proton_cpu(
+    viztracer_events: list[dict[str, Any]],
+    proton_events: list[dict[str, Any]],
+    rank: int,
+) -> list[dict[str, Any]]:
+    """Append endpoint flows from VizTracer scope starts to Proton CPU scopes."""
+    proton_cpu_scopes: dict[int, dict[str, Any]] = {}
+    for event in proton_events:
+        args = event.get("args")
+        if not isinstance(args, dict):
+            continue
+        scope_id = args.get(_PROTON_SCOPE_ID_ARG)
+        if isinstance(scope_id, int) and not isinstance(scope_id, bool):
+            proton_cpu_scopes[scope_id] = event
+
+    finish_events: list[dict[str, Any]] = []
+    for event in viztracer_events:
+        if (
+            event.get("name") != _VIZTRACER_PROTON_FLOW_NAME
+            or event.get("cat") != _VIZTRACER_PROTON_FLOW_CATEGORY
+            or event.get("ph") != "s"
+        ):
+            continue
+        scope_id = event.get("id")
+        proton_cpu_event = proton_cpu_scopes.get(scope_id)
+        if proton_cpu_event is None:
+            continue
+        flow_id = _namespace_viztracer_proton_flow_id(scope_id, rank)
+        event["id"] = flow_id
+        finish_events.append(
+            {
+                "name": _VIZTRACER_PROTON_FLOW_NAME,
+                "cat": _VIZTRACER_PROTON_FLOW_CATEGORY,
+                "ph": "f",
+                "ts": proton_cpu_event["ts"],
+                "pid": proton_cpu_event["pid"],
+                "tid": proton_cpu_event["tid"],
+                "id": flow_id,
+                "bp": "e",
+            }
+        )
+    return finish_events
 
 
 def _prepare_proton_events(
@@ -207,7 +270,11 @@ def merge_proton_viztracer(
     viztracer_base_ns = _viztracer_base_time_ns(viztracer_json, viztracer_path)
     proton_events = _prepare_proton_events(proton_json, proton_path, viztracer_base_ns)
 
-    viztracer_json.setdefault("traceEvents", []).extend(proton_events)
+    viztracer_events = viztracer_json.setdefault("traceEvents", [])
+    viztracer_events.extend(
+        _link_viztracer_to_proton_cpu(viztracer_events, proton_events, 0)
+    )
+    viztracer_events.extend(proton_events)
     _write_json(output_path, viztracer_json)
     return len(proton_events)
 
@@ -276,7 +343,11 @@ def merge_all_ranks(rank_traces: Iterable[TracePair], output_path: str | Path) -
         proton_events = _prepare_proton_events(
             proton_json, proton_path, viztracer_base_ns, rank=rank
         )
-        rank_events = [*viztracer_json.get("traceEvents", []), *proton_events]
+        viztracer_events = viztracer_json.get("traceEvents", [])
+        linked_flow_events = _link_viztracer_to_proton_cpu(
+            viztracer_events, proton_events, rank
+        )
+        rank_events = [*viztracer_events, *proton_events, *linked_flow_events]
         for event in rank_events:
             if event.get("ph") != "M" and "ts" in event:
                 event["ts"] += rank_offset_us

--- a/test/cli/test_trace_merge.py
+++ b/test/cli/test_trace_merge.py
@@ -142,7 +142,7 @@ def _add_proton_cpu_scope(trace: dict, scope_id: int) -> None:
             "tid": 1,
             "name": "gemm.mm",
             "cat": "scope",
-            "args": {"proton_scope_id": scope_id},
+            "args": {"scope_id": scope_id},
         }
     )
 

--- a/test/cli/test_trace_merge.py
+++ b/test/cli/test_trace_merge.py
@@ -117,6 +117,36 @@ def _proton_trace() -> dict:
     }
 
 
+def _add_viztracer_proton_flow(report: dict, scope_id: int) -> None:
+    report["traceEvents"].append(
+        {
+            "ph": "s",
+            "ts": 99.0,
+            "pid": 4242,
+            "tid": 4242,
+            "name": "viztracer->proton",
+            "cat": "tokenspeed.proton",
+            "id": scope_id,
+            "bp": "e",
+        }
+    )
+
+
+def _add_proton_cpu_scope(trace: dict, scope_id: int) -> None:
+    trace["traceEvents"].append(
+        {
+            "ph": "X",
+            "ts": 20.0,
+            "dur": 5.0,
+            "pid": 0,
+            "tid": 1,
+            "name": "gemm.mm",
+            "cat": "scope",
+            "args": {"proton_scope_id": scope_id},
+        }
+    )
+
+
 def _write(tmp_path, name: str, payload: dict) -> str:
     path = tmp_path / name
     path.write_text(json.dumps(payload))
@@ -152,6 +182,35 @@ def test_merge_shifts_proton_events_onto_viztracer_axis(tmp_path):
     flow_ts = sorted(e["ts"] for e in events if e.get("cat") == "flow")
     assert flow_ts == [8.0 + EXPECTED_OFFSET_US, 10.0 + EXPECTED_OFFSET_US]
     assert {e["id"] for e in events if e.get("cat") == "flow"} == {1}
+
+
+def test_merge_links_viztracer_flow_to_matching_proton_cpu_scope(tmp_path):
+    scope_id = 42
+    report = _viztracer_report()
+    trace = _proton_trace()
+    _add_viztracer_proton_flow(report, scope_id)
+    _add_proton_cpu_scope(trace, scope_id)
+    viztracer_path = _write(tmp_path, "run.viztracer.json", report)
+    proton_path = _write(tmp_path, "run.proton.chrome_trace", trace)
+    output_path = tmp_path / "merged.json"
+
+    merge_proton_viztracer(viztracer_path, proton_path, output_path)
+
+    events = json.loads(output_path.read_text())["traceEvents"]
+    flow_events = [
+        event for event in events if event.get("name") == "viztracer->proton"
+    ]
+    assert len(flow_events) == 2
+    starts = [event for event in flow_events if event["ph"] == "s"]
+    finishes = [event for event in flow_events if event["ph"] == "f"]
+    assert len(starts) == len(finishes) == 1
+    assert starts[0]["id"] == finishes[0]["id"] == (1 << 52) | scope_id
+    assert starts[0]["ts"] == 99.0
+    assert (finishes[0]["ts"], finishes[0]["pid"], finishes[0]["tid"]) == (
+        20.0 + EXPECTED_OFFSET_US,
+        0,
+        1,
+    )
 
 
 def test_merge_rejects_viztracer_report_without_anchor(tmp_path):
@@ -267,6 +326,45 @@ def test_merge_all_ranks_aligns_timelines_and_namespaces_flow_ids(tmp_path):
         (1 << 32) | 1,
     }
     assert all(isinstance(event["id"], int) for event in flow_events)
+
+
+def test_merge_all_ranks_namespaces_viztracer_proton_flows(tmp_path):
+    scope_id = 42
+    rank0_report = _rank_viztracer_report(base_time_ns=VIZTRACER_BASE_NS, pid=4242)
+    rank0_trace = _rank_proton_trace(base_time_ns=PROTON_BASE_NS)
+    _add_viztracer_proton_flow(rank0_report, scope_id)
+    _add_proton_cpu_scope(rank0_trace, scope_id)
+    rank0_viz = _write(tmp_path, "run-TP0.viztracer.json", rank0_report)
+    rank0_proton = _write(tmp_path, "run-TP0.proton.chrome_trace", rank0_trace)
+
+    rank1_report = _rank_viztracer_report(base_time_ns=VIZTRACER_BASE_NS, pid=4243)
+    rank1_trace = _rank_proton_trace(base_time_ns=PROTON_BASE_NS)
+    _add_viztracer_proton_flow(rank1_report, scope_id)
+    _add_proton_cpu_scope(rank1_trace, scope_id)
+    rank1_viz = _write(tmp_path, "run-TP1.viztracer.json", rank1_report)
+    rank1_proton = _write(tmp_path, "run-TP1.proton.chrome_trace", rank1_trace)
+
+    output_path = tmp_path / "all-ranks.json"
+    merge_all_ranks(
+        [(0, rank0_viz, rank0_proton), (1, rank1_viz, rank1_proton)],
+        output_path,
+    )
+
+    events = json.loads(output_path.read_text())["traceEvents"]
+    flow_events = [
+        event for event in events if event.get("name") == "viztracer->proton"
+    ]
+    starts = [event for event in flow_events if event["ph"] == "s"]
+    finishes = [event for event in flow_events if event["ph"] == "f"]
+    assert {event["id"] for event in starts} == {
+        (1 << 52) | scope_id,
+        (1 << 52) | (1 << 32) | scope_id,
+    }
+    assert {event["id"] for event in finishes} == {event["id"] for event in starts}
+    assert {(event["pid"], event["id"]) for event in finishes} == {
+        (10000, (1 << 52) | scope_id),
+        (10001, (1 << 52) | (1 << 32) | scope_id),
+    }
 
 
 def test_all_ranks_cli_merges_explicit_rank_triples(tmp_path, capsys):

--- a/tokenspeed-kernel/python/tokenspeed_kernel/profiling.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/profiling.py
@@ -188,6 +188,47 @@ class _NoopScope:
 
 _NOOP_SCOPE = _NoopScope()
 _BOOTSTRAPPED = False
+_VIZTRACER_PROTON_FLOW_NAME = "viztracer->proton"
+_VIZTRACER_PROTON_FLOW_CATEGORY = "tokenspeed.proton"
+
+
+def _active_viztracer():
+    """Return the active process-local VizTracer instance, if any."""
+    try:
+        from viztracer import get_tracer
+    except ImportError:
+        return None
+
+    tracer = get_tracer()
+    return tracer if tracer is not None and tracer.enable else None
+
+
+class _VizTracerProtonScope:
+    """Emit a VizTracer flow start immediately before a Proton CPU scope."""
+
+    def __init__(self, scope: Any) -> None:
+        self._scope = scope
+
+    def __enter__(self) -> Any:
+        tracer = _active_viztracer()
+        timestamp = tracer.getts() if tracer is not None else None
+        entered_scope = self._scope.__enter__()
+        scope_id = getattr(self._scope, "id", None)
+        if tracer is not None and scope_id is not None:
+            tracer.add_raw(
+                {
+                    "name": _VIZTRACER_PROTON_FLOW_NAME,
+                    "cat": _VIZTRACER_PROTON_FLOW_CATEGORY,
+                    "ph": "s",
+                    "ts": timestamp,
+                    "id": scope_id,
+                    "bp": "e",
+                }
+            )
+        return entered_scope
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> Any:
+        return self._scope.__exit__(exc_type, exc_value, traceback)
 
 
 def _proton_metrics(metrics: dict[str, object]) -> dict[str, object]:
@@ -344,7 +385,7 @@ def kernel_scope(
 
     name = f"{family}.{mode}[{kernel_name}]" if kernel_name else f"{family}.{mode}"
     scope_metrics = _proton_metrics(metrics)
-    return proton.scope(name, metrics=scope_metrics)
+    return _VizTracerProtonScope(proton.scope(name, metrics=scope_metrics))
 
 
 def _atexit_stop_profiling() -> None:

--- a/tokenspeed-kernel/test/test_profiling.py
+++ b/tokenspeed-kernel/test/test_profiling.py
@@ -59,6 +59,19 @@ class _FakeProton:
         return _FakeScope(self.scope_log)
 
 
+class _FakeVizTracer:
+    enable = True
+
+    def __init__(self) -> None:
+        self.raw_events: list[dict[str, object]] = []
+
+    def getts(self) -> float:
+        return 1234.5
+
+    def add_raw(self, event: dict[str, object]) -> None:
+        self.raw_events.append(event)
+
+
 @pytest.fixture(autouse=True)
 def _reset_state():
     profiling.stop_profiling()
@@ -189,6 +202,38 @@ def test_kernel_scope_uses_proton_scope_when_active(monkeypatch):
         )
     ]
     assert fake.scope_log == ["enter", "exit"]
+
+
+def test_kernel_scope_links_active_viztracer_to_proton_scope(monkeypatch):
+    fake = _FakeProton()
+    scope = _FakeScope(fake.scope_log)
+    scope.id = 42
+    tracer = _FakeVizTracer()
+
+    def proton_scope(name: str, metrics: dict[str, object] | None = None):
+        fake.scope_calls.append((name, {} if metrics is None else dict(metrics)))
+        return scope
+
+    monkeypatch.setattr(profiling, "_HAS_PROTON", True)
+    monkeypatch.setattr(profiling, "proton", fake)
+    monkeypatch.setattr(fake, "scope", proton_scope)
+    monkeypatch.setattr(profiling, "_active_viztracer", lambda: tracer)
+    profiling.start_profiling()
+
+    with profiling.kernel_scope("gemm", "mm", torch.float16, M=32):
+        pass
+
+    assert fake.scope_log == ["enter", "exit"]
+    assert tracer.raw_events == [
+        {
+            "name": "viztracer->proton",
+            "cat": "tokenspeed.proton",
+            "ph": "s",
+            "ts": 1234.5,
+            "id": 42,
+            "bp": "e",
+        }
+    ]
 
 
 def test_kernel_scope_filters_unsupported_proton_metrics(monkeypatch):


### PR DESCRIPTION
Emit a VizTracer flow at kernel scope entry using Proton's Python scope ID. During trace merging, match that ID against Proton's exported CPU event and add a rank-namespaced endpoint flow. This keeps the VizTracer-to-CPU links distinct from Proton's existing CPU-to-GPU launch flows.