### PR TITLE
fix: clear padded breakable graph handoffs

### DIFF
--- a/python/tokenspeed/runtime/execution/breakable_cuda_graph.py
+++ b/python/tokenspeed/runtime/execution/breakable_cuda_graph.py
@@ -168,6 +168,7 @@ class BreakableCapture:
         self._stream_ctx: Any | None = None
         # Break-output handoff buffers keyed by (shape, dtype, device); see break_point.
         self._handoff: dict[Any, torch.Tensor] = {}
+        self._valid_rows: int | None = None
 
     @classmethod
     def current(cls) -> BreakableCapture | None:
@@ -245,13 +246,24 @@ class BreakableCapture:
 
     # -- replay ------------------------------------------------------------
 
-    def replay(self) -> None:
+    def replay(self, valid_rows: int | None = None) -> None:
         """Replay all segments in order.
 
         Breaks read the live forward context from the ambient :func:`active_forward`
-        scope (the runner wraps replay in it), so this stays a pure graph primitive.
+        scope (the runner wraps replay in it).
+
+        Args:
+            valid_rows: Number of valid leading rows in a padded replay. After
+                each eager break, handoff rows beyond this prefix are cleared
+                before the following graph segment consumes them. ``None``
+                leaves handoff buffers unchanged.
         """
-        deque((run() for run in self.segments), maxlen=0)
+        previous_valid_rows = self._valid_rows
+        self._valid_rows = valid_rows
+        try:
+            deque((run() for run in self.segments), maxlen=0)
+        finally:
+            self._valid_rows = previous_valid_rows
 
     @property
     def num_segments(self) -> int:
@@ -309,6 +321,8 @@ def _record_break(
         if dst is None:
             dst = state["dst"] = resolve_dst(result)
         _land_in(dst, result)
+        if cap._valid_rows is not None:
+            scrub_padding_tail(cap._valid_rows, dst)
         return dst
 
     return cap.add_eager(replay_fn)
@@ -441,8 +455,10 @@ def _land_in(dst: torch.Tensor, result: torch.Tensor) -> None:
     ``dst`` is the (possibly token-padded) handoff buffer the next graph segment
     reads. ``result`` may cover only the real (unpadded) leading rows -- e.g. a
     varlen attention kernel writes only ``sum(cu_seqlens_q)`` rows -- so we copy
-    into the matching leading slice. Padded rows are left as-is (discarded by the
-    final output slice). No-op when the op already wrote ``dst`` in place.
+    into the matching leading slice. Padded rows are otherwise left as-is;
+    :meth:`BreakableCapture.replay` clears them before the following graph segment
+    when it is given the valid prefix length. No-op when the op already wrote
+    ``dst`` in place.
     """
     if result is dst:
         return

--- a/python/tokenspeed/runtime/execution/prefill_graph.py
+++ b/python/tokenspeed/runtime/execution/prefill_graph.py
@@ -580,7 +580,7 @@ class PrefillGraph:
             else:
                 ib.positions_buf[num_tokens:bucket].zero_()
         with self._padded_to(ctx, bucket):
-            self._captures[bucket].replay()
+            self._captures[bucket].replay(valid_rows=num_tokens)
         hidden_states, aux_hidden_states = self._outputs[bucket].sliced(num_tokens)
         # The eager logits tail of BaseCausalLM.forward, on the replayed hidden states.
         logits_metadata = LogitsMetadata.from_forward_context(ctx)
@@ -663,7 +663,8 @@ class PrefillGraph:
 
         The graph replays over ``bucket`` (padded) tokens; attention metadata stays
         at the real count (set upstream), so the eager attention break only touches
-        real tokens and the padded rows produce discarded garbage. Pin
+        real tokens; eager-break handoffs clear the padded rows before the
+        following graph segment consumes them. Pin
         ``input_num_tokens`` to the bucket and, under DP, ``global_num_tokens`` /
         ``global_bs`` to the captured uniform layout so any live read during the
         break matches the baked EP shapes. The break reads ``forward_mode`` / ``bs``

--- a/test/runtime/execution/test_breakable_cuda_graph.py
+++ b/test/runtime/execution/test_breakable_cuda_graph.py
@@ -96,6 +96,41 @@ class TestBreakableCudaGraph(unittest.TestCase):
                 captured_out, self._eager(new_x), msg=f"trial {trial}"
             )
 
+    def test_replay_clears_unwritten_padding_at_break_handoff(self):
+        """A padded replay must not pass an eager break's undefined tail onward."""
+        state = {"valid_rows": self.n}
+
+        class VarlenOp:
+            @break_point
+            def forward(self, x):
+                out = torch.full_like(x, torch.nan)
+                rows = state["valid_rows"]
+                out[:rows].copy_(x[:rows])
+                return out
+
+        op = VarlenOp()
+
+        def forward():
+            h = self.x_static @ self.w1
+            return op.forward(h) @ self.w2
+
+        for _ in range(3):
+            forward()
+        torch.cuda.synchronize()
+        cap = BreakableCapture()
+        with cap:
+            captured_out = forward()
+
+        state["valid_rows"] = 1
+        new_x = torch.randn(self.n, self.d, device=self.dev, dtype=self.dtype)
+        self.x_static.copy_(new_x)
+        cap.replay(valid_rows=1)
+        torch.cuda.synchronize()
+
+        expected = torch.zeros_like(captured_out)
+        expected[:1] = (new_x @ self.w1)[:1] @ self.w2
+        torch.testing.assert_close(captured_out, expected, rtol=1e-4, atol=1e-4)
+
     def test_multiple_breaks_chain(self):
         """Many breaks (like a deep transformer) must chain correctly."""
         depth = 6


### PR DESCRIPTION
## Summary

Fix padded prefill CUDA-graph replays leaking undefined eager-break output rows into the following captured graph segment.

### Reproduction

1. Capture a breakable prefill graph for a token bucket larger than the live request, for example a bucket of 8 rows.
2. Replay it for 1 real token.
3. Let an eager varlen operation return a bucket-shaped tensor while initializing only the real prefix. This matches kernels that honor live cu-seqlens but allocate an output for the captured bucket.
4. The old handoff copied that whole result into the stable destination. Rows 1-7 remained undefined, but the next graph segment consumed all 8 rows.

The added regression test makes this deterministic by filling the unwritten rows with NaN and placing a captured matrix multiplication after the eager break. Before this fix, the NaNs propagate through the padded rows. In a full model they can reach later quantization or MoE routing code and surface as an asynchronous CUDA error far from the original attention handoff.

### Fix

- Add an optional `valid_rows` argument to `BreakableCapture.replay()`.
- Have `PrefillGraph` pass the real token count before it temporarily pads the forward context to the selected bucket.
- Clear every eager-break handoff after landing its result and before replaying the following graph segment.
- Restore the previous replay state in `finally` so it cannot leak between replays.

This is a generic breakable-graph correctness fix. It does not depend on MiniMax M3, sparse attention, MoE, or flat KV cache behavior.

## Test Plan

- `python -m pytest test/runtime/execution/test_breakable_cuda_graph.py -q` (20 passed)
- `python -m pytest test/runtime/test_flat_prefill_graph.py -q` (8 passed)
- `pre-commit run --all-files`
