### PR TITLE
[GLM] perf: optimize indexer small kernels

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
@@ -62,6 +62,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
         )
 
         # (loc, loc._version, page, slot_in_page) memo for the index-K write;
+        # only version-tracked loc is cached (inference-mode loc recomputes),
         # see _index_k_page_slot.
         self._index_k_loc_cache: (
             tuple[torch.Tensor, int, torch.Tensor, torch.Tensor] | None
@@ -187,6 +188,21 @@ class DSATokenToKVPool(MLATokenToKVPool):
         k_scale = scale_view[page, slot_in_page]
         return k_fp8, k_scale
 
+    @staticmethod
+    def _loc_version(loc: torch.Tensor) -> int | None:
+        """Version counter of ``loc``, or ``None`` when it isn't tracked.
+
+        The speculative draft path runs under ``torch.inference_mode()`` (see
+        the DFLASH drafter), whose tensors do not maintain a version counter, so
+        reading ``loc._version`` raises ``RuntimeError``. Returning ``None`` lets
+        the memo fall back to recomputation instead of crashing. That costs the
+        draft nothing: its ``GLM5 NextN`` model has a single DSA layer, so the
+        per-forward memo could never hit there anyway.
+        """
+        if loc.is_inference():
+            return None
+        return loc._version
+
     def _index_k_page_slot(
         self, loc: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -199,14 +215,25 @@ class DSATokenToKVPool(MLATokenToKVPool):
         storage in a fresh object also misses (identity differs), and under
         CUDA-graph replay this Python does not run. Numerically identical to the
         inline computation.
+
+        Inference-mode ``loc`` (no version counter) can't be validated across
+        calls, so it is never memoized and always recomputes -- correct, and
+        the only path that hits it (the draft) has nothing to gain from the memo.
         """
+        version = self._loc_version(loc)
         cached = self._index_k_loc_cache
-        if cached is not None and cached[0] is loc and cached[1] == loc._version:
+        if (
+            version is not None
+            and cached is not None
+            and cached[0] is loc
+            and cached[1] == version
+        ):
             return cached[2], cached[3]
         loc_long = loc.to(torch.long)
         page = loc_long // self.page_size
         slot_in_page = loc_long % self.page_size
-        self._index_k_loc_cache = (loc, loc._version, page, slot_in_page)
+        if version is not None:
+            self._index_k_loc_cache = (loc, version, page, slot_in_page)
         return page, slot_in_page
 
     def _set_index_k_buffer(

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 import torch
+from tokenspeed_kernel.ops.kvcache.triton import index_k_block_split_scatter
 from tokenspeed_kernel.ops.quantization import quantize_fp8_with_scale
 
 from tokenspeed.runtime.layers.attention.configs.dsa import dsa_index_k_row_bytes
@@ -59,6 +60,12 @@ class DSATokenToKVPool(MLATokenToKVPool):
             dtype=torch.uint64,
             device=self.device,
         )
+
+        # (loc, loc._version, page, slot_in_page) memo for the index-K write;
+        # see _index_k_page_slot.
+        self._index_k_loc_cache: (
+            tuple[torch.Tensor, int, torch.Tensor, torch.Tensor] | None
+        ) = None
 
     def _get_page_size_bytes(self):
         index_size_bytes = self.index_k_row_bytes
@@ -180,6 +187,28 @@ class DSATokenToKVPool(MLATokenToKVPool):
         k_scale = scale_view[page, slot_in_page]
         return k_fp8, k_scale
 
+    def _index_k_page_slot(
+        self, loc: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Map ``loc`` to ``(page, slot_in_page)``, memoized on ``loc``.
+
+        ``loc`` is the step's ``out_cache_loc``, shared by every indexer layer,
+        so the cast/floor-div/remainder fire once per forward instead of per
+        layer. Keyed on object identity *and* ``_version`` so an in-place
+        ``loc.copy_()`` (same object, new content) correctly misses; recycled
+        storage in a fresh object also misses (identity differs), and under
+        CUDA-graph replay this Python does not run. Numerically identical to the
+        inline computation.
+        """
+        cached = self._index_k_loc_cache
+        if cached is not None and cached[0] is loc and cached[1] == loc._version:
+            return cached[2], cached[3]
+        loc_long = loc.to(torch.long)
+        page = loc_long // self.page_size
+        slot_in_page = loc_long % self.page_size
+        self._index_k_loc_cache = (loc, loc._version, page, slot_in_page)
+        return page, slot_in_page
+
     def _set_index_k_buffer(
         self,
         layer_id: int,
@@ -194,13 +223,17 @@ class DSATokenToKVPool(MLATokenToKVPool):
             scale_encoding="float32",
         )
 
-        fp8_view, scale_view = self._index_k_block_views(buf)
-        loc = loc.to(torch.long)
-        page = loc // self.page_size
-        slot_in_page = loc % self.page_size
-        fp8_view[page, slot_in_page] = index_k_fp8.view(-1, self.index_head_dim)
-        scale_view[page, slot_in_page] = index_k_scale.view(
-            -1, self.index_head_dim // _INDEX_K_FP8_GROUP_SIZE
+        # One fused scatter, byte-exact with the two index_put writes it replaces.
+        page, slot_in_page = self._index_k_page_slot(loc)
+        index_k_block_split_scatter(
+            buf,
+            index_k_fp8,
+            index_k_scale,
+            page,
+            slot_in_page,
+            page_size=self.page_size,
+            head_dim=self.index_head_dim,
+            group_size=_INDEX_K_FP8_GROUP_SIZE,
         )
 
     def get_contiguous_buf_infos(self):

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
@@ -61,13 +61,6 @@ class DSATokenToKVPool(MLATokenToKVPool):
             device=self.device,
         )
 
-        # (loc, loc._version, page, slot_in_page) memo for the index-K write;
-        # only version-tracked loc is cached (inference-mode loc recomputes),
-        # see _index_k_page_slot.
-        self._index_k_loc_cache: (
-            tuple[torch.Tensor, int, torch.Tensor, torch.Tensor] | None
-        ) = None
-
     def _get_page_size_bytes(self):
         index_size_bytes = self.index_k_row_bytes
         return (
@@ -188,54 +181,6 @@ class DSATokenToKVPool(MLATokenToKVPool):
         k_scale = scale_view[page, slot_in_page]
         return k_fp8, k_scale
 
-    @staticmethod
-    def _loc_version(loc: torch.Tensor) -> int | None:
-        """Version counter of ``loc``, or ``None`` when it isn't tracked.
-
-        The speculative draft path runs under ``torch.inference_mode()`` (see
-        the DFLASH drafter), whose tensors do not maintain a version counter, so
-        reading ``loc._version`` raises ``RuntimeError``. Returning ``None`` lets
-        the memo fall back to recomputation instead of crashing. That costs the
-        draft nothing: its ``GLM5 NextN`` model has a single DSA layer, so the
-        per-forward memo could never hit there anyway.
-        """
-        if loc.is_inference():
-            return None
-        return loc._version
-
-    def _index_k_page_slot(
-        self, loc: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Map ``loc`` to ``(page, slot_in_page)``, memoized on ``loc``.
-
-        ``loc`` is the step's ``out_cache_loc``, shared by every indexer layer,
-        so the cast/floor-div/remainder fire once per forward instead of per
-        layer. Keyed on object identity *and* ``_version`` so an in-place
-        ``loc.copy_()`` (same object, new content) correctly misses; recycled
-        storage in a fresh object also misses (identity differs), and under
-        CUDA-graph replay this Python does not run. Numerically identical to the
-        inline computation.
-
-        Inference-mode ``loc`` (no version counter) can't be validated across
-        calls, so it is never memoized and always recomputes -- correct, and
-        the only path that hits it (the draft) has nothing to gain from the memo.
-        """
-        version = self._loc_version(loc)
-        cached = self._index_k_loc_cache
-        if (
-            version is not None
-            and cached is not None
-            and cached[0] is loc
-            and cached[1] == version
-        ):
-            return cached[2], cached[3]
-        loc_long = loc.to(torch.long)
-        page = loc_long // self.page_size
-        slot_in_page = loc_long % self.page_size
-        if version is not None:
-            self._index_k_loc_cache = (loc, version, page, slot_in_page)
-        return page, slot_in_page
-
     def _set_index_k_buffer(
         self,
         layer_id: int,
@@ -250,14 +195,12 @@ class DSATokenToKVPool(MLATokenToKVPool):
             scale_encoding="float32",
         )
 
-        # One fused scatter, byte-exact with the two index_put writes it replaces.
-        page, slot_in_page = self._index_k_page_slot(loc)
+        # Fused scatter; (page, slot_in_page) is derived from loc in-kernel.
         index_k_block_split_scatter(
             buf,
             index_k_fp8,
             index_k_scale,
-            page,
-            slot_in_page,
+            loc,
             page_size=self.page_size,
             head_dim=self.index_head_dim,
             group_size=_INDEX_K_FP8_GROUP_SIZE,

--- a/python/tokenspeed/runtime/models/glm5.py
+++ b/python/tokenspeed/runtime/models/glm5.py
@@ -185,8 +185,8 @@ class GlmDsaIndexer(nn.Module):
         self.index_head_dim = config.index_head_dim
         self.rope_head_dim = int(qk_rope_head_dim)
         self.softmax_scale = self.index_head_dim**-0.5
-        # Head norm folded into the top-k kernel's weights scale, so forward
-        # skips a separate weights-scale kernel (组A).
+        # Top-k scale with the per-head normalization folded in, so forward
+        # needs no separate weights-scale kernel.
         self.weights_softmax_scale = self.softmax_scale * (self.index_n_heads**-0.5)
 
         if self.rope_head_dim <= 0 or self.rope_head_dim > self.index_head_dim:
@@ -271,8 +271,10 @@ class GlmDsaIndexer(nn.Module):
         return GlmDsaIndexerOutput(
             query=index_q,
             key=index_k,
-            # Head norm folded into weights_softmax_scale (组A); only the cast here.
-            weights=weights.float(),
+            # Raw bf16 weights: the head-norm constant is folded into
+            # weights_softmax_scale and the fp32 upcast into the top-k
+            # kernels' fused combine.
+            weights=weights,
         )
 
 
@@ -579,8 +581,8 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
             raise RuntimeError("GLM DSA top-k requires an index-K cache.")
 
         # The top-k kernels overwrite the whole workspace when they cover all
-        # rows, making the sentinel pre-fills dead; keep the fills only when
-        # leading prefill rows stay unwritten but readable (mixed prefill) (组D).
+        # rows; the sentinel pre-fills are only needed for mixed prefill,
+        # where leading rows stay unwritten but readable.
         writes_full_workspace = decode_start == 0 and num_decode_tokens == num_tokens
         topk_indices = self._get_decode_topk_workspace(
             "_decode_topk_indices_buffer",
@@ -685,7 +687,9 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
         topk: int,
     ) -> GlmDsaPrefillTopK:
         q = indexer_output.query[:num_prefill_tokens].contiguous()
-        weights = indexer_output.weights[:num_prefill_tokens].float().contiguous()
+        # Raw bf16 weights view (may be column-split, non-compact); the top-k
+        # kernel's fused combine upcasts and compacts in one launch.
+        weights = indexer_output.weights[:num_prefill_tokens]
 
         req_ids = torch.arange(
             seq_lens.numel(),

--- a/python/tokenspeed/runtime/models/glm5.py
+++ b/python/tokenspeed/runtime/models/glm5.py
@@ -185,6 +185,9 @@ class GlmDsaIndexer(nn.Module):
         self.index_head_dim = config.index_head_dim
         self.rope_head_dim = int(qk_rope_head_dim)
         self.softmax_scale = self.index_head_dim**-0.5
+        # Head norm folded into the top-k kernel's weights scale, so forward
+        # skips a separate weights-scale kernel (组A).
+        self.weights_softmax_scale = self.softmax_scale * (self.index_n_heads**-0.5)
 
         if self.rope_head_dim <= 0 or self.rope_head_dim > self.index_head_dim:
             raise ValueError(
@@ -268,7 +271,8 @@ class GlmDsaIndexer(nn.Module):
         return GlmDsaIndexerOutput(
             query=index_q,
             key=index_k,
-            weights=weights.float() * (self.index_n_heads**-0.5),
+            # Head norm folded into weights_softmax_scale (组A); only the cast here.
+            weights=weights.float(),
         )
 
 
@@ -389,6 +393,7 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
         self,
         rows: int,
         device: torch.device,
+        fill: bool = True,
     ) -> torch.Tensor:
         buffer = getattr(self, "_decode_topk_lens_buffer", None)
         if buffer is None or buffer.device != device or buffer.numel() < rows:
@@ -401,7 +406,8 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
             )
             self._decode_topk_lens_buffer = buffer
         workspace = buffer[:rows]
-        workspace.fill_(0)
+        if fill:
+            workspace.fill_(0)
         return workspace
 
     @staticmethod
@@ -572,15 +578,21 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
         if index_k_cache is None:
             raise RuntimeError("GLM DSA top-k requires an index-K cache.")
 
+        # The top-k kernels overwrite the whole workspace when they cover all
+        # rows, making the sentinel pre-fills dead; keep the fills only when
+        # leading prefill rows stay unwritten but readable (mixed prefill) (组D).
+        writes_full_workspace = decode_start == 0 and num_decode_tokens == num_tokens
         topk_indices = self._get_decode_topk_workspace(
             "_decode_topk_indices_buffer",
             num_tokens,
             topk,
             q.device,
-            fill_value=-1,
+            fill_value=None if writes_full_workspace else -1,
         )
         topk_slice = topk_indices[decode_start : decode_start + num_decode_tokens]
-        topk_lens = self._get_decode_topk_lens_workspace(num_tokens, q.device)
+        topk_lens = self._get_decode_topk_lens_workspace(
+            num_tokens, q.device, fill=not writes_full_workspace
+        )
         topk_lens_slice = topk_lens[decode_start : decode_start + num_decode_tokens]
 
         metadata = ctx.attn_backend.forward_decode_metadata
@@ -596,7 +608,7 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
             block_tables,
             page_size=ctx.token_to_kv_pool.page_size,
             topk=topk,
-            softmax_scale=self.indexer.softmax_scale,
+            softmax_scale=self.indexer.weights_softmax_scale,
             q_len_per_req=q_len_per_req,
             index_k_cache=index_k_cache,
             seq_lens_2d=seq_lens_2d,
@@ -714,7 +726,7 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
             row_starts.to(torch.int32).contiguous(),
             row_ends.to(torch.int32).contiguous(),
             topk=topk,
-            softmax_scale=self.indexer.softmax_scale,
+            softmax_scale=self.indexer.weights_softmax_scale,
             index_k_cache=index_k_cache,
             page_size=ctx.token_to_kv_pool.page_size,
             max_logits_bytes=max(1, max_logits_mb) * 1024 * 1024,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -1416,7 +1416,8 @@ def dsa_prefill_topk(
 
     Args:
         q: BF16 indexer query with shape [tokens, index_heads, head_dim].
-        weights: FP32 per-token/head weights with shape [tokens, index_heads].
+        weights: Per-token/head weights with shape [tokens, index_heads],
+            FP32 or raw BF16 (implementations upcast on the fly).
         kv_workspace_slots: Global KV slot for each workspace row, shape
             [workspace_rows].
         row_starts: Inclusive workspace-row start per query token, shape [tokens].
@@ -1522,7 +1523,8 @@ def dsa_decode_topk(
 
     Args:
         q: BF16 indexer query with shape [tokens, index_heads, head_dim].
-        weights: FP32 per-token/head weights with shape [tokens, index_heads].
+        weights: Per-token/head weights with shape [tokens, index_heads],
+            FP32 or raw BF16 (implementations upcast on the fly).
         seq_lens: Per-request full KV length, shape [num_reqs] (= tokens /
             q_len_per_req). Each query token's causal bound
             seq_lens[req] - (q_len_per_req - 1) + j is derived in-kernel.

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/deep_gemm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/deep_gemm/__init__.py
@@ -15,6 +15,7 @@ from tokenspeed_kernel.ops.attention.flashinfer.dsa_topk import (
     deterministic_decode_topk,
 )
 from tokenspeed_kernel.ops.attention.triton.dsa_topk import (
+    combine_topk_weights,
     local_topk_to_global_slots,
 )
 from tokenspeed_kernel.ops.quantization import quantize_fp8_with_scale
@@ -37,6 +38,33 @@ _CUTE_DSL_DECODE_TOPK_ENABLED = os.environ.get("TS_DSA_DECODE_TOPK_CUTEDSL", "1"
 def _use_cute_dsl_decode_topk() -> bool:
     """Whether the DSA decode top-k should use the CuTe DSL cluster kernel."""
     return _CUTE_DSL_DECODE_TOPK_ENABLED and has_cute_dsl_decode_topk()
+
+
+def _prepare_logits_for_topk(logits: torch.Tensor) -> torch.Tensor:
+    """Return a top-k-ready view of DeepGEMM logits: compact rows, no NaN/inf.
+
+    DeepGEMM's ``fp8_mqa_logits`` family allocates ``[rows, aligned_cols]``
+    and returns the slice ``[:, :cols]``, which is non-contiguous whenever
+    ``cols < aligned_cols`` and would force a copy inside kernels that
+    require compact rows (e.g. the CuTe DSL top-k). When the input is such a
+    row slice of one owned allocation, widen it back to the full
+    ``[rows, aligned_cols]`` view — safe for length-aware consumers that
+    never read a row past its seq_len bound, since the extra columns are
+    allocation padding. Any other tensor is used as is.
+
+    Non-finite scores (NaN/±inf) are then scrubbed to ``-inf`` in place. The
+    returned view aliases the input's storage, so narrow slices held by
+    fallback top-k paths observe the same cleaned values.
+    """
+    full = logits
+    if logits.dim() == 2 and logits.stride(-1) == 1:
+        rows, cols = logits.shape
+        stride0 = logits.stride(0)
+        storage_elems = logits.untyped_storage().nbytes() // logits.element_size()
+        if stride0 > cols and logits.storage_offset() + rows * stride0 <= storage_elems:
+            full = logits.as_strided((rows, stride0), (stride0, 1))
+    full.nan_to_num_(nan=float("-inf"), posinf=float("-inf"), neginf=float("-inf"))
+    return full
 
 
 def _check_out(
@@ -138,7 +166,12 @@ if platform.is_nvidia:
                 format_signature(
                     q=dense_tensor_format(torch.bfloat16),
                     weights=dense_tensor_format(torch.float32),
-                )
+                ),
+                # Raw indexer weights: the fused combine kernel upcasts.
+                format_signature(
+                    q=dense_tensor_format(torch.bfloat16),
+                    weights=dense_tensor_format(torch.bfloat16),
+                ),
             }
         ),
         traits={
@@ -166,8 +199,10 @@ if platform.is_nvidia:
         out: torch.Tensor | None = None,
         lens_out: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        assert weights.dtype == torch.float32
-        assert weights.is_contiguous()
+        assert weights.dtype in (torch.float32, torch.bfloat16)
+        # Raw weights may be a column-split view of the fused wk_weights_proj
+        # output; the fused combine only needs unit-stride rows.
+        assert weights.stride(-1) == 1
         assert seq_lens.dtype == torch.int32
         assert seq_lens.is_contiguous()
         assert block_table.dtype == torch.int32
@@ -189,10 +224,7 @@ if platform.is_nvidia:
             scale_encoding="float32",
         )
         q_fp8 = q_fp8.view_as(q)
-        q_scale = q_scale.view(q.shape[0], q.shape[1], 1)
-        scaled_weights = (
-            weights.unsqueeze(-1) * q_scale * float(softmax_scale)
-        ).squeeze(-1)
+        scaled_weights = combine_topk_weights(weights, q_scale, softmax_scale)
 
         if seq_lens_2d is None or plan is None:
             raise RuntimeError(
@@ -216,22 +248,23 @@ if platform.is_nvidia:
         logits = deep_gemm.fp8_paged_mqa_logits(
             q_fp8.view(-1, q_len_per_req, q.shape[1], q.shape[-1]),
             kv_cache,
-            scaled_weights.contiguous(),
+            scaled_weights,
             seq_lens_2d,
             block_table,
             plan,
             max_seq_len,
             clean_logits=False,
         )
-        logits.nan_to_num_(
-            nan=float("-inf"), posinf=float("-inf"), neginf=float("-inf")
-        )
+        # Compact widened view with non-finite scores scrubbed; the
+        # length-aware CuTe DSL top-k below consumes it without a copy.
+        logits_full = _prepare_logits_for_topk(logits)
         local_topk_offsets = torch.empty_like(out)
         if _use_cute_dsl_decode_topk():
             # CuTe DSL cluster radix top-k: length-aware via seq_lens/q_len_per_req,
             # so no pre-masking needed; same local offsets as the ragged path.
+            # The widened view is safe: rows never read past their seq_len bound.
             cute_dsl_decode_topk(
-                logits,
+                logits_full,
                 seq_lens,
                 topk,
                 next_n=q_len_per_req,
@@ -290,7 +323,12 @@ if platform.is_nvidia:
                 format_signature(
                     q=dense_tensor_format(torch.bfloat16),
                     weights=dense_tensor_format(torch.float32),
-                )
+                ),
+                # Raw indexer weights: the fused combine kernel upcasts.
+                format_signature(
+                    q=dense_tensor_format(torch.bfloat16),
+                    weights=dense_tensor_format(torch.bfloat16),
+                ),
             }
         ),
         traits={
@@ -319,7 +357,6 @@ if platform.is_nvidia:
     ) -> tuple[torch.Tensor, torch.Tensor]:
 
         q = q.contiguous()
-        weights = weights.float().contiguous()
         row_starts = row_starts.to(device=q.device, dtype=torch.int32).contiguous()
         row_ends = row_ends.to(device=q.device, dtype=torch.int32).contiguous()
         tokens = q.shape[0]
@@ -340,10 +377,7 @@ if platform.is_nvidia:
             scale_encoding="float32",
         )
         q_fp8 = q_fp8.view_as(q)
-        q_scale = q_scale.view(tokens, q.shape[1], 1)
-        scaled_weights = (
-            weights.unsqueeze(-1) * q_scale * float(softmax_scale)
-        ).squeeze(-1)
+        scaled_weights = combine_topk_weights(weights, q_scale, softmax_scale)
         if index_k_fp8 is None or index_k_scale is None:
             hd = q.shape[-1]
             num_groups = hd // 128

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/dsa_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/dsa_topk.py
@@ -273,6 +273,76 @@ def workspace_topk_to_global_slots(
 
 
 @triton.jit
+def _combine_topk_weights_kernel(
+    weights_ptr,
+    q_scale_ptr,
+    out_ptr,
+    softmax_scale,
+    weights_row_stride,
+    heads,
+    numel,
+    BLOCK: tl.constexpr,
+):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < numel
+    t = offs // heads
+    h = offs % heads
+    w = tl.load(weights_ptr + t * weights_row_stride + h, mask=mask).to(tl.float32)
+    q_scale = tl.load(q_scale_ptr + offs, mask=mask)
+    tl.store(out_ptr + offs, w * q_scale * softmax_scale, mask=mask)
+
+
+def combine_topk_weights(
+    weights: torch.Tensor,
+    q_scale: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Build the combined per-(token, head) weights for DSA logits scoring.
+
+    Single-launch, bit-exact equivalent of
+    ``(weights.float().unsqueeze(-1) * q_scale * float(softmax_scale)).squeeze(-1)``
+    (same fp32 operation order).
+
+    Args:
+        weights: ``[tokens, heads]`` bf16/fp16/fp32 indexer weights. The
+            leading axis may have any stride (e.g. a column-``split`` view of
+            the fused ``wk_weights_proj`` output); only ``stride(-1) == 1``
+            is required.
+        q_scale: fp32 per-``(token, head)`` dequant scales with
+            ``tokens * heads`` elements in row-major order (any unit-trailing
+            shape such as ``[tokens * heads, 1]`` or ``[tokens, heads, 1]``).
+        softmax_scale: Constant score scale folded into the weights.
+
+    Returns:
+        ``[tokens, heads]`` contiguous fp32 combined weights.
+    """
+    tokens, heads = weights.shape
+    if weights.stride(-1) != 1:
+        raise ValueError("combine_topk_weights expects unit-stride weights rows")
+    if q_scale.dtype != torch.float32:
+        raise TypeError(f"q_scale must be fp32, got {q_scale.dtype}")
+    q_scale = q_scale.reshape(tokens * heads)
+    out = torch.empty(tokens, heads, dtype=torch.float32, device=weights.device)
+    numel = tokens * heads
+    if numel == 0:
+        return out
+    block = 1024
+    _combine_topk_weights_kernel[(triton.cdiv(numel, block),)](
+        weights,
+        q_scale,
+        out,
+        float(softmax_scale),
+        weights.stride(0),
+        heads,
+        numel,
+        BLOCK=block,
+        num_warps=4,
+        num_stages=1,
+    )
+    return out
+
+
+@triton.jit
 def _dsa_decode_logits_fp8_kernel(
     q,
     index_k_fp8,
@@ -1046,7 +1116,12 @@ def triton_dsa_plan(
             format_signature(
                 q=dense_tensor_format(torch.bfloat16),
                 weights=dense_tensor_format(torch.float32),
-            )
+            ),
+            # Raw indexer weights: the wrapper upcasts before scoring.
+            format_signature(
+                q=dense_tensor_format(torch.bfloat16),
+                weights=dense_tensor_format(torch.bfloat16),
+            ),
         }
     ),
     traits={
@@ -1076,6 +1151,8 @@ def triton_dsa_decode_topk_fp8(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if index_k_cache is None:
         raise RuntimeError("Triton DSA paged top-k requires packed FP8 index_k_cache")
+    if weights.dtype != torch.float32:
+        weights = weights.float()
     return dsa_decode_topk_fp8(
         q,
         index_k_cache,
@@ -1102,7 +1179,12 @@ def triton_dsa_decode_topk_fp8(
             format_signature(
                 q=dense_tensor_format(torch.bfloat16),
                 weights=dense_tensor_format(torch.float32),
-            )
+            ),
+            # Raw indexer weights: the wrapper upcasts before scoring.
+            format_signature(
+                q=dense_tensor_format(torch.bfloat16),
+                weights=dense_tensor_format(torch.bfloat16),
+            ),
         }
     ),
     traits={
@@ -1134,6 +1216,8 @@ def triton_dsa_prefill_topk_fp8(
         raise RuntimeError(
             "Triton DSA top-k requires packed FP8 index_k_cache and page_size"
         )
+    if weights.dtype != torch.float32:
+        weights = weights.float()
     return dsa_prefill_topk_fp8(
         q,
         index_k_cache,
@@ -1151,6 +1235,7 @@ def triton_dsa_prefill_topk_fp8(
 
 
 __all__ = [
+    "combine_topk_weights",
     "dsa_decode_topk_fp8",
     "dsa_prefill_topk_fp8",
     "local_topk_to_global_slots",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
@@ -1614,19 +1614,21 @@ def _index_k_scatter_kernel(
     scale_buf_ptr,  # float32 flat view of buf (aliases fp8_buf_ptr)
     k_fp8_ptr,  # uint8 [tokens, HD]
     k_scale_ptr,  # float32 [tokens, NG]
-    page_ptr,
-    slot_ptr,
+    loc_ptr,  # int [tokens] global slot index (non-negative)
     page_bytes,  # fp8 elements per page
     scale_page_off,  # float32 elements per page (page_bytes // 4)
     scale_base_off,  # float32 offset of the scale region ((ps*hd)//4)
+    PAGE_SIZE: tl.constexpr,
     HD: tl.constexpr,
     NG: tl.constexpr,
     BLOCK_HD: tl.constexpr,  # next_pow2(HD); masked so HD need not be pow2
     BLOCK_NG: tl.constexpr,  # next_pow2(NG)
 ):
     t = tl.program_id(0)
-    page = tl.load(page_ptr + t)
-    slot = tl.load(slot_ptr + t)
+    # loc >= 0 makes // and % exact.
+    loc = tl.load(loc_ptr + t).to(tl.int64)
+    page = loc // PAGE_SIZE
+    slot = loc % PAGE_SIZE
 
     d = tl.arange(0, BLOCK_HD)
     hd_mask = d < HD
@@ -1651,8 +1653,7 @@ def index_k_block_split_scatter(
     buf: torch.Tensor,
     index_k_fp8: torch.Tensor,
     index_k_scale: torch.Tensor,
-    page: torch.Tensor,
-    slot_in_page: torch.Tensor,
+    loc: torch.Tensor,
     *,
     page_size: int,
     head_dim: int,
@@ -1660,16 +1661,18 @@ def index_k_block_split_scatter(
 ) -> None:
     """Scatter FP8 index-K rows + scales into the block-split paged buffer.
 
-    Byte-exact single-launch equivalent of the two ``index_put`` writes through
+    Byte-exact single-launch equivalent of two ``index_put`` writes through
     the block-split ``as_strided`` views (see
-    ``DSATokenToKVPool._index_k_block_views``); sibling of
-    ``fused_fp8_set_kv_buffer`` for the non-block-split cache.
+    ``DSATokenToKVPool._index_k_block_views``). The ``(page, slot_in_page) =
+    (loc // page_size, loc % page_size)`` mapping is derived per token inside
+    the kernel, so callers pass raw cache locations.
 
     Args:
         buf: uint8 ``[num_slots, head_dim + num_groups*4]`` packed buffer.
         index_k_fp8: ``[tokens, head_dim]`` FP8 values.
         index_k_scale: ``[tokens, num_groups]`` float32 scales.
-        page, slot_in_page: ``[tokens]`` int write location (page / slot in page).
+        loc: ``[tokens]`` non-negative int global slot indices (any integer
+            dtype).
         page_size, head_dim, group_size: layout; ``num_groups = head_dim //
             group_size``.
 
@@ -1693,11 +1696,11 @@ def index_k_block_split_scatter(
         scale_buf,
         k_fp8,
         k_scale,
-        page.to(torch.int64),
-        slot_in_page.to(torch.int64),
+        loc.reshape(-1),
         page_bytes,
         page_bytes // 4,
         (page_size * head_dim) // 4,
+        PAGE_SIZE=page_size,
         HD=head_dim,
         NG=ng,
         BLOCK_HD=_next_power_of_two(head_dim),

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
@@ -42,6 +42,7 @@ __all__ = [
     "flat_decode_locs",
     "flat_tables_unpack",
     "gather_page_table_with_padding",
+    "index_k_block_split_scatter",
     "quantize_mxfp8_rows",
     "quantize_store_kv_mxfp8",
     "store_kv_cache",
@@ -1601,4 +1602,104 @@ def flat_tables_unpack(
         actual_bs,
         TAIL_PAD=tail_pad,
         BLOCK_W=BLOCK_W,
+    )
+
+
+# GLM-5 DSA block-split index-K scatter
+
+
+@triton.jit
+def _index_k_scatter_kernel(
+    fp8_buf_ptr,  # uint8 flat view of buf
+    scale_buf_ptr,  # float32 flat view of buf (aliases fp8_buf_ptr)
+    k_fp8_ptr,  # uint8 [tokens, HD]
+    k_scale_ptr,  # float32 [tokens, NG]
+    page_ptr,
+    slot_ptr,
+    page_bytes,  # fp8 elements per page
+    scale_page_off,  # float32 elements per page (page_bytes // 4)
+    scale_base_off,  # float32 offset of the scale region ((ps*hd)//4)
+    HD: tl.constexpr,
+    NG: tl.constexpr,
+    BLOCK_HD: tl.constexpr,  # next_pow2(HD); masked so HD need not be pow2
+    BLOCK_NG: tl.constexpr,  # next_pow2(NG)
+):
+    t = tl.program_id(0)
+    page = tl.load(page_ptr + t)
+    slot = tl.load(slot_ptr + t)
+
+    d = tl.arange(0, BLOCK_HD)
+    hd_mask = d < HD
+    fp8_dst = page * page_bytes + slot * HD + d
+    tl.store(
+        fp8_buf_ptr + fp8_dst,
+        tl.load(k_fp8_ptr + t * HD + d, mask=hd_mask),
+        mask=hd_mask,
+    )
+
+    g = tl.arange(0, BLOCK_NG)
+    ng_mask = g < NG
+    sc_dst = scale_base_off + page * scale_page_off + slot * NG + g
+    tl.store(
+        scale_buf_ptr + sc_dst,
+        tl.load(k_scale_ptr + t * NG + g, mask=ng_mask),
+        mask=ng_mask,
+    )
+
+
+def index_k_block_split_scatter(
+    buf: torch.Tensor,
+    index_k_fp8: torch.Tensor,
+    index_k_scale: torch.Tensor,
+    page: torch.Tensor,
+    slot_in_page: torch.Tensor,
+    *,
+    page_size: int,
+    head_dim: int,
+    group_size: int,
+) -> None:
+    """Scatter FP8 index-K rows + scales into the block-split paged buffer.
+
+    Byte-exact single-launch equivalent of the two ``index_put`` writes through
+    the block-split ``as_strided`` views (see
+    ``DSATokenToKVPool._index_k_block_views``); sibling of
+    ``fused_fp8_set_kv_buffer`` for the non-block-split cache.
+
+    Args:
+        buf: uint8 ``[num_slots, head_dim + num_groups*4]`` packed buffer.
+        index_k_fp8: ``[tokens, head_dim]`` FP8 values.
+        index_k_scale: ``[tokens, num_groups]`` float32 scales.
+        page, slot_in_page: ``[tokens]`` int write location (page / slot in page).
+        page_size, head_dim, group_size: layout; ``num_groups = head_dim //
+            group_size``.
+
+    Returns:
+        None; ``buf`` is written in place.
+    """
+    tokens = index_k_fp8.shape[0]
+    if tokens == 0:
+        return
+    ng = head_dim // group_size
+    row_bytes = head_dim + ng * 4
+    page_bytes = page_size * row_bytes
+
+    fp8_buf = buf.reshape(-1)  # uint8
+    scale_buf = fp8_buf.view(torch.float32)  # aliases the same storage
+    k_fp8 = index_k_fp8.reshape(-1, head_dim).contiguous().view(torch.uint8)
+    k_scale = index_k_scale.reshape(-1, ng).contiguous()
+
+    _index_k_scatter_kernel[(tokens,)](
+        fp8_buf,
+        scale_buf,
+        k_fp8,
+        k_scale,
+        page.to(torch.int64),
+        slot_in_page.to(torch.int64),
+        page_bytes,
+        page_bytes // 4,
+        (page_size * head_dim) // 4,
+        HD=head_dim,
+        NG=ng,
+        BLOCK_HD=_next_power_of_two(head_dim),
+        BLOCK_NG=_next_power_of_two(ng),
     )

--- a/tokenspeed-kernel/test/ops/test_dsa_topk.py
+++ b/tokenspeed-kernel/test/ops/test_dsa_topk.py
@@ -25,7 +25,11 @@ Covers the per-solution wrappers behind ``deep_gemm_dsa_decode_topk``:
   * ``deterministic_decode_topk`` (flashinfer) pre-masked fallback path.
   * ``cute_dsl_decode_topk`` (CuTe DSL cluster radix): per-row causal-window
     ``torch.topk`` accuracy across batch / next_n / top-k / context length /
-    compression ratio.
+    compression ratio, plus row-aligned (widened) logits equivalence.
+  * ``combine_topk_weights`` (Triton): bit-exactness against the unfused
+    ``weights.float() * q_scale * softmax_scale`` reference chain.
+  * ``_prepare_logits_for_topk``: widening of DeepGEMM's narrowed logits
+    slices plus the in-place NaN/inf -> -inf scrub.
 
 The wrapper-dispatch tests are CPU-only (monkeypatched kernels); the CuTe DSL
 kernel test needs NVIDIA Blackwell (sm_100+) and skips elsewhere.
@@ -42,11 +46,17 @@ from tokenspeed_kernel.ops.attention.cute_dsl.dsa_topk import (
     cute_dsl_decode_topk,
     has_cute_dsl_decode_topk,
 )
+from tokenspeed_kernel.ops.attention.deep_gemm import _prepare_logits_for_topk
 from tokenspeed_kernel.ops.attention.flashinfer import dsa_topk as fi_dsa_topk
+from tokenspeed_kernel.ops.attention.triton.dsa_topk import combine_topk_weights
 
 requires_kernel = pytest.mark.skipif(
     not (torch.cuda.is_available() and has_cute_dsl_decode_topk()),
     reason="CuTe DSL DSA decode top-k requires NVIDIA Blackwell (sm_100+)",
+)
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA"
 )
 
 
@@ -225,3 +235,135 @@ def test_cute_dsl_decode_topk(
     got = _gathered_topk_values(logits, ret, seq_lens, index_topk, next_n)
     ref = _reference_topk_values(logits, seq_lens, index_topk, next_n)
     assert torch.equal(got, ref), "selected top-k values differ from reference"
+
+
+@requires_kernel
+@pytest.mark.parametrize("next_n", [1, 2])
+def test_cute_dsl_decode_topk_widened_rows_match_narrow(next_n):
+    """Row-aligned (widened) logits select identically to the narrow slice.
+
+    DeepGEMM row-aligns the logits allocation; ``deep_gemm_dsa_decode_topk``
+    hands the widened compact view straight to the kernel instead of paying a
+    ``.contiguous()`` copy of the narrow slice. The kernel is length-aware, so
+    the padding columns -- poisoned with NaN here -- must never influence the
+    selection.
+    """
+    batch_size, num_cols, aligned_cols, index_topk = 4, 4992, 5120, 2048
+    num_rows = batch_size * next_n
+    torch.manual_seed(1)
+    buf = torch.full(
+        (num_rows, aligned_cols), float("nan"), device="cuda", dtype=torch.float32
+    )
+    buf[:, :num_cols].normal_()
+    narrow = buf[:, :num_cols]
+    assert not narrow.is_contiguous()
+    seq_lens = torch.randint(
+        index_topk // 4, num_cols + 1, (batch_size,), device="cuda", dtype=torch.int32
+    )
+
+    out_narrow = torch.empty(num_rows, index_topk, device="cuda", dtype=torch.int32)
+    cute_dsl_decode_topk(
+        narrow.contiguous(), seq_lens, index_topk, next_n=next_n, out=out_narrow
+    )
+    out_wide = torch.empty(num_rows, index_topk, device="cuda", dtype=torch.int32)
+    cute_dsl_decode_topk(buf, seq_lens, index_topk, next_n=next_n, out=out_wide)
+
+    got = _gathered_topk_values(narrow, out_wide, seq_lens, index_topk, next_n)
+    ref = _gathered_topk_values(narrow, out_narrow, seq_lens, index_topk, next_n)
+    assert torch.equal(got, ref), "widened-view selection differs from narrow slice"
+
+
+# ---------------------------------------------------------------------------
+# combine_topk_weights (Triton fused weights * q_scale * softmax_scale)
+# ---------------------------------------------------------------------------
+@requires_cuda
+@pytest.mark.parametrize("weights_dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("split_view", [False, True])
+@pytest.mark.parametrize("tokens,heads", [(1, 64), (16, 64), (37, 64), (128, 32)])
+def test_combine_topk_weights_bitexact(weights_dtype, split_view, tokens, heads):
+    """Fused combine is bit-exact with the unfused fp32 reference chain.
+
+    ``split_view=True`` mirrors production: ``weights`` is the trailing
+    column-``split`` view of the fused ``wk_weights_proj`` output, so its rows
+    are unit-stride but not compact.
+    """
+    torch.manual_seed(tokens * heads)
+    softmax_scale = 0.08838834764831845 * (64**-0.5)
+    if split_view:
+        fused = torch.randn(tokens, 128 + heads, device="cuda", dtype=weights_dtype)
+        weights = fused.split([128, heads], dim=-1)[1]
+        # (a [1, heads] slice is trivially "contiguous"; multi-row ones are not)
+        assert weights.stride(-1) == 1
+        assert tokens == 1 or not weights.is_contiguous()
+    else:
+        weights = torch.randn(tokens, heads, device="cuda", dtype=weights_dtype)
+    q_scale = torch.rand(tokens * heads, 1, device="cuda", dtype=torch.float32) + 0.01
+
+    ref = (
+        weights.float().unsqueeze(-1)
+        * q_scale.view(tokens, heads, 1)
+        * float(softmax_scale)
+    ).squeeze(-1)
+    got = combine_topk_weights(weights, q_scale, softmax_scale)
+
+    assert got.dtype == torch.float32 and got.shape == (tokens, heads)
+    assert got.is_contiguous()
+    assert torch.equal(got, ref)
+
+
+@requires_cuda
+def test_combine_topk_weights_empty():
+    out = combine_topk_weights(
+        torch.empty(0, 64, device="cuda", dtype=torch.bfloat16),
+        torch.empty(0, 1, device="cuda", dtype=torch.float32),
+        0.5,
+    )
+    assert out.shape == (0, 64) and out.dtype == torch.float32
+
+
+# ---------------------------------------------------------------------------
+# _prepare_logits_for_topk (DeepGEMM narrowed-logits widening + NaN/inf scrub)
+# ---------------------------------------------------------------------------
+def test_prepare_logits_for_topk_widens_and_scrubs():
+    base = torch.arange(4 * 256, dtype=torch.float32).view(4, 256)
+    expected = base.clone()
+    # Non-finite values inside the window and in the padding columns alike.
+    base[0, 10] = float("nan")
+    base[1, 20] = float("inf")
+    base[2, 200] = float("-inf")  # padding column (>= 192)
+    expected[0, 10] = expected[1, 20] = expected[2, 200] = float("-inf")
+    narrow = base[:, :192]
+    assert not narrow.is_contiguous()
+
+    full = _prepare_logits_for_topk(narrow)
+
+    assert full.shape == (4, 256) and full.is_contiguous()
+    assert torch.equal(full, expected)
+    # The scrub is in place: the narrow slice aliases the cleaned storage.
+    assert narrow[0, 10] == float("-inf") and narrow[1, 20] == float("-inf")
+    # In-place edits through the widened view alias the narrow slice.
+    full[1, 0] = -1.0
+    assert narrow[1, 0] == -1.0
+
+
+def test_prepare_logits_for_topk_passthrough_still_scrubs():
+    # Already-compact logits: same object back, values scrubbed in place.
+    compact = torch.zeros(4, 256)
+    compact[3, 5] = float("nan")
+    assert _prepare_logits_for_topk(compact) is compact
+    assert compact[3, 5] == float("-inf")
+    # Column slices don't own their full rows: no widening, scrub only the
+    # slice (the storage outside the view must stay untouched).
+    owner = torch.full((4, 256), float("nan"))
+    col_slice = owner[:, 64:192]
+    assert _prepare_logits_for_topk(col_slice) is col_slice
+    assert (col_slice == float("-inf")).all()
+    assert owner[:, :64].isnan().all() and owner[:, 192:].isnan().all()
+    # Non-unit column stride: no widening, scrubbed in place.
+    strided = torch.full((4, 256), float("inf"))[:, ::2]
+    assert _prepare_logits_for_topk(strided) is strided
+    assert (strided == float("-inf")).all()
+    # 3-D tensors: no widening, scrubbed in place.
+    cube = torch.full((2, 3, 4), float("nan"))
+    assert _prepare_logits_for_topk(cube) is cube
+    assert (cube == float("-inf")).all()

--- a/tokenspeed-kernel/test/ops/test_kvcache.py
+++ b/tokenspeed-kernel/test/ops/test_kvcache.py
@@ -20,8 +20,10 @@
 
 from __future__ import annotations
 
+import pytest
 import torch
 from tokenspeed_kernel.ops.kvcache.triton import (
+    index_k_block_split_scatter,
     transfer_kv_all_layer,
     transfer_kv_all_layer_mla,
     transfer_kv_per_layer,
@@ -228,3 +230,90 @@ def test_transfer_kv_all_layer_mla(device: str) -> None:
 
     for layer_idx in range(num_layers):
         assert torch.equal(layers_dst[layer_idx], expected[layer_idx])
+
+
+# index_k_block_split_scatter (GLM-5 DSA index-K cache write, 组C)
+
+
+def _index_k_block_views(buf, num_pages, page_size, head_dim, num_groups):
+    row = head_dim + num_groups * 4
+    page_bytes = page_size * row
+    flat = buf.reshape(-1)
+    fp8_view = torch.as_strided(
+        flat.view(torch.float8_e4m3fn),
+        (num_pages, page_size, head_dim),
+        (page_bytes, head_dim, 1),
+    )
+    scale_view = torch.as_strided(
+        flat.view(torch.float32),
+        (num_pages, page_size, num_groups),
+        (page_bytes // 4, num_groups, 1),
+        (page_size * head_dim) // 4,
+    )
+    return fp8_view, scale_view
+
+
+@pytest.mark.parametrize(
+    "head_dim,group_size",
+    [
+        (128, 128),  # NG=1
+        (128, 64),  # NG=2
+        (256, 128),  # NG=2
+        (384, 128),  # NG=3: non-power-of-2 head_dim and NG
+        (384, 64),  # NG=6: non-power-of-2 NG
+    ],
+)
+@pytest.mark.parametrize("tokens", [1, 7, 16, 64])
+def test_index_k_block_split_scatter_matches_index_put(
+    device: str, head_dim: int, group_size: int, tokens: int
+) -> None:
+    torch.manual_seed(head_dim + group_size + tokens)
+    page_size, num_pages = 64, 32
+    num_slots = num_pages * page_size
+    ng = head_dim // group_size
+    row = head_dim + ng * 4
+
+    k_fp8 = torch.randn(tokens, head_dim, device=device).to(torch.float8_e4m3fn)
+    k_scale = torch.rand(tokens, ng, device=device, dtype=torch.float32) + 0.1
+    loc = torch.randperm(num_slots, device=device)[:tokens].to(torch.int64)
+    page, slot = loc // page_size, loc % page_size
+
+    buf_ref = torch.zeros(num_slots, row, dtype=torch.uint8, device=device)
+    buf_k = torch.zeros(num_slots, row, dtype=torch.uint8, device=device)
+
+    fp8_view, scale_view = _index_k_block_views(
+        buf_ref, num_pages, page_size, head_dim, ng
+    )
+    fp8_view[page, slot] = k_fp8.view(-1, head_dim)
+    scale_view[page, slot] = k_scale.view(-1, ng)
+
+    index_k_block_split_scatter(
+        buf_k,
+        k_fp8,
+        k_scale,
+        page,
+        slot,
+        page_size=page_size,
+        head_dim=head_dim,
+        group_size=group_size,
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(buf_ref, buf_k)
+
+
+def test_index_k_block_split_scatter_empty_is_noop(device: str) -> None:
+    buf = torch.zeros(64, 132, dtype=torch.uint8, device=device)
+    empty_fp8 = torch.empty(0, 128, device=device, dtype=torch.float8_e4m3fn)
+    empty_scale = torch.empty(0, 1, device=device, dtype=torch.float32)
+    empty_idx = torch.empty(0, dtype=torch.int64, device=device)
+    index_k_block_split_scatter(
+        buf,
+        empty_fp8,
+        empty_scale,
+        empty_idx,
+        empty_idx,
+        page_size=64,
+        head_dim=128,
+        group_size=128,
+    )
+    assert torch.count_nonzero(buf) == 0

--- a/tokenspeed-kernel/test/ops/test_kvcache.py
+++ b/tokenspeed-kernel/test/ops/test_kvcache.py
@@ -232,7 +232,7 @@ def test_transfer_kv_all_layer_mla(device: str) -> None:
         assert torch.equal(layers_dst[layer_idx], expected[layer_idx])
 
 
-# index_k_block_split_scatter (GLM-5 DSA index-K cache write, 组C)
+# index_k_block_split_scatter (GLM-5 DSA index-K cache write)
 
 
 def _index_k_block_views(buf, num_pages, page_size, head_dim, num_groups):
@@ -264,8 +264,9 @@ def _index_k_block_views(buf, num_pages, page_size, head_dim, num_groups):
     ],
 )
 @pytest.mark.parametrize("tokens", [1, 7, 16, 64])
+@pytest.mark.parametrize("loc_dtype", [torch.int32, torch.int64])
 def test_index_k_block_split_scatter_matches_index_put(
-    device: str, head_dim: int, group_size: int, tokens: int
+    device: str, head_dim: int, group_size: int, tokens: int, loc_dtype: torch.dtype
 ) -> None:
     torch.manual_seed(head_dim + group_size + tokens)
     page_size, num_pages = 64, 32
@@ -275,8 +276,8 @@ def test_index_k_block_split_scatter_matches_index_put(
 
     k_fp8 = torch.randn(tokens, head_dim, device=device).to(torch.float8_e4m3fn)
     k_scale = torch.rand(tokens, ng, device=device, dtype=torch.float32) + 0.1
-    loc = torch.randperm(num_slots, device=device)[:tokens].to(torch.int64)
-    page, slot = loc // page_size, loc % page_size
+    loc = torch.randperm(num_slots, device=device)[:tokens].to(loc_dtype)
+    page, slot = loc.long() // page_size, loc.long() % page_size
 
     buf_ref = torch.zeros(num_slots, row, dtype=torch.uint8, device=device)
     buf_k = torch.zeros(num_slots, row, dtype=torch.uint8, device=device)
@@ -291,8 +292,7 @@ def test_index_k_block_split_scatter_matches_index_put(
         buf_k,
         k_fp8,
         k_scale,
-        page,
-        slot,
+        loc,
         page_size=page_size,
         head_dim=head_dim,
         group_size=group_size,
@@ -305,13 +305,12 @@ def test_index_k_block_split_scatter_empty_is_noop(device: str) -> None:
     buf = torch.zeros(64, 132, dtype=torch.uint8, device=device)
     empty_fp8 = torch.empty(0, 128, device=device, dtype=torch.float8_e4m3fn)
     empty_scale = torch.empty(0, 1, device=device, dtype=torch.float32)
-    empty_idx = torch.empty(0, dtype=torch.int64, device=device)
+    empty_loc = torch.empty(0, dtype=torch.int64, device=device)
     index_k_block_split_scatter(
         buf,
         empty_fp8,
         empty_scale,
-        empty_idx,
-        empty_idx,
+        empty_loc,
         page_size=64,
         head_dim=128,
         group_size=128,


### PR DESCRIPTION
## Summary

### What does this PR do?
Using fusion, refactoring, and other methods to optimize the small kernels in the indexer module.

### Performance
- Before optimization
<img width="841" height="549" alt="image" src="https://github.com/user-attachments/assets/3c28bd47-40b1-45ad-9f51-7b51a569dca6" />

```
                                         Detailed Performance Metrics                                         
┏━━━━━━┳━━━━━━┳━━━━━┳━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┓
┃      ┃      ┃     ┃      ┃     Avg ┃     P99 ┃      Avg ┃      P99 ┃      Avg ┃      P99 ┃   Gen. ┃ Success┃
┃Conc. ┃ Rate ┃ Num ┃  RPS ┃ Lat.(s) ┃ Lat.(s) ┃ TTFT(ms) ┃ TTFT(ms) ┃ TPOT(ms) ┃ TPOT(ms) ┃ toks/s ┃    Rate┃
┡━━━━━━╇━━━━━━╇━━━━━╇━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━┩
│    1 │  INF │  48 │ 0.41 │   2.456 │   7.230 │    765.1 │   5411.3 │      3.4 │      4.8 │ 203.53 │  100.0%│
│    2 │  INF │  97 │ 0.54 │   3.622 │  17.510 │   1102.8 │  12344.8 │      5.0 │     20.4 │ 272.03 │  100.0%│
│    4 │  INF │  86 │ 0.57 │   6.818 │  39.400 │   1983.6 │  35320.3 │      9.7 │     55.0 │ 283.57 │  100.0%│
│    8 │  INF │ 191 │ 0.61 │  12.766 │  86.780 │   2965.4 │  74069.0 │     19.6 │    135.7 │ 303.81 │  100.0%│
│   16 │  INF │ 370 │ 0.74 │  21.045 │ 178.250 │   4619.9 │ 131873.7 │     32.9 │    303.1 │ 369.17 │  100.0%│
└──────┴──────┴─────┴──────┴─────────┴─────────┴──────────┴──────────┴──────────┴──────────┴────────┴────────┘


                                                Request Metrics                                                
┏━━━━━━┳━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━┓
┃      ┃     ┃  Avg In ┃  P99 In ┃ Avg Out ┃ P99 Out ┃       Avg ┃    Approx ┃ Decode ┃  Decoded ┃       Spec.┃
┃Conc. ┃ Num ┃    Toks ┃    Toks ┃    Toks ┃    Toks ┃ Turns/Req ┃ Cache Hit ┃ toks/s ┃ Tok/Iter ┃ Accept Rate┃
┡━━━━━━╇━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━┩
│    1 │  48 │ 56045.2 │ 65202.0 │   500.0 │   500.0 │      6.56 │     90.8% │ 294.99 │     3.24 │       69.1%│
│    2 │  97 │ 55744.3 │ 62610.0 │   500.0 │   500.0 │      6.63 │     91.9% │ 198.02 │     3.30 │       69.7%│
│    4 │  86 │ 54702.4 │ 62065.0 │   500.0 │   500.0 │      5.93 │     90.1% │ 103.20 │     3.29 │       69.6%│
│    8 │ 191 │ 55560.5 │ 65147.0 │   500.0 │   500.0 │      6.56 │     90.8% │  50.92 │     3.24 │       69.1%│
│   16 │ 370 │ 55488.7 │ 64581.0 │   500.0 │   500.0 │      6.38 │     91.4% │  30.38 │     3.27 │       69.4%│
└──────┴─────┴─────────┴─────────┴─────────┴─────────┴───────────┴───────────┴────────┴──────────┴────────────┘
```




- After optimization
<img width="897" height="265" alt="image" src="https://github.com/user-attachments/assets/fdbbab06-1b94-4584-bc8b-ae9919eb0276" />
Before `multi_cta_topk`, there are two `vectorized_elementwise_kernels`, corresponding to `logits.nan_to_num_` and `row_states.zero_()` respectively, which are unavoidable.

```
                                         Detailed Performance Metrics                                         
┏━━━━━━┳━━━━━━┳━━━━━┳━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┓
┃      ┃      ┃     ┃      ┃     Avg ┃     P99 ┃      Avg ┃      P99 ┃      Avg ┃      P99 ┃   Gen. ┃ Success┃
┃Conc. ┃ Rate ┃ Num ┃  RPS ┃ Lat.(s) ┃ Lat.(s) ┃ TTFT(ms) ┃ TTFT(ms) ┃ TPOT(ms) ┃ TPOT(ms) ┃ toks/s ┃    Rate┃
┡━━━━━━╇━━━━━━╇━━━━━╇━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━┩
│    1 │  INF │  48 │ 0.42 │   2.366 │   7.050 │    762.4 │   5406.0 │      3.2 │      4.1 │ 211.24 │  100.0%│
│    2 │  INF │  97 │ 0.56 │   3.548 │  16.890 │   1118.1 │  14755.5 │      4.9 │     20.6 │ 280.06 │  100.0%│
│    4 │  INF │  86 │ 0.57 │   6.845 │  38.500 │   1966.3 │  35176.1 │      9.8 │     55.3 │ 286.64 │  100.0%│
│    8 │  INF │ 191 │ 0.62 │  12.450 │  84.610 │   3100.0 │  71774.6 │     18.7 │    128.6 │ 311.23 │  100.0%│
│   16 │  INF │ 370 │ 0.76 │  20.485 │ 177.190 │   4509.9 │ 133211.1 │     32.0 │    305.5 │ 379.91 │  100.0%│
└──────┴──────┴─────┴──────┴─────────┴─────────┴──────────┴──────────┴──────────┴──────────┴────────┴────────┘


                                                Request Metrics                                                
┏━━━━━━┳━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━┓
┃      ┃     ┃  Avg In ┃  P99 In ┃ Avg Out ┃ P99 Out ┃       Avg ┃    Approx ┃ Decode ┃  Decoded ┃       Spec.┃
┃Conc. ┃ Num ┃    Toks ┃    Toks ┃    Toks ┃    Toks ┃ Turns/Req ┃ Cache Hit ┃ toks/s ┃ Tok/Iter ┃ Accept Rate┃
┡━━━━━━╇━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━┩
│    1 │  48 │ 56754.4 │ 65698.0 │   500.0 │   500.0 │      6.56 │     90.7% │ 311.53 │     3.21 │       68.8%│
│    2 │  97 │ 56194.6 │ 66242.0 │   500.0 │   500.0 │      6.63 │     91.8% │ 205.34 │     3.26 │       69.3%│
│    4 │  86 │ 54915.8 │ 62035.0 │   500.0 │   500.0 │      5.93 │     90.1% │ 102.25 │     3.26 │       69.3%│
│    8 │ 191 │ 55563.4 │ 64175.0 │   500.0 │   500.0 │      6.56 │     90.8% │  53.36 │     3.27 │       69.4%│
│   16 │ 370 │ 55581.4 │ 64094.0 │   500.0 │   500.0 │      6.38 │     91.4% │  31.24 │     3.25 │       69.2%│
└──────┴─────┴─────────┴─────────┴─────────┴─────────┴───────────┴───────────┴────────┴──────────┴────────────┘
```

### Accuracy
- After optimization
```
2026-07-20 07:24:27 - evalscope - INFO: Overall report table: 
+---------------+-----------+----------+----------+-------+---------+---------+
| Model         | Dataset   | Metric   | Subset   |   Num |   Score | Cat.0   |
+===============+===========+==========+==========+=======+=========+=========+
| GLM-5.2-NVFP4 | aime26    | mean_acc | default  |    30 |  0.9333 | default |
+---------------+-----------+----------+----------+-------+---------+---------+ 
```


## Test Plan

<!-- How was this validated? -->
