### PR TITLE
feat(m3): NVFP4 mixed-precision checkpoint support

### DIFF
--- a/docs/recipes/models.md
+++ b/docs/recipes/models.md
@@ -72,17 +72,22 @@ attention layers automatically; select the dense backend with
 `--attention-backend` and run with `--disable-kvstore`.
 
 ```bash
-tokenspeed serve MiniMaxAI/MiniMax-M3-MXFP8 \
-  --trust-remote-code \
-  --tensor-parallel-size 4 \
-  --max-model-len 1048576 \
-  --max-total-tokens 1048576 \
-  --block-size 128 \
-  --attention-backend trtllm \
-  --moe-backend triton \
-  --disable-kvstore \
-  --host 0.0.0.0 \
-  --port 8000
+tokenspeed serve nvidia/MiniMax-M3-NVFP4 \
+    --tensor-parallel-size 4 \
+    --max-model-len 81920 \
+    --max-num-seqs 16 \
+    --max-prefill-tokens 8192 \
+    --chunked-prefill-size 8192 \
+    --gpu-memory-utilization 0.95 \
+    --disable-cuda-graph-padding \
+    --attention-backend trtllm \
+    --moe-backend flashinfer_trtllm \
+    --disable-prefill-graph \
+    --disable-kvstore \
+    --block-size 128 \
+    --trust-remote-code \
+    --host 0.0.0.0 \
+    --port 8000
 ```
 
 ## Kimi K2.5 / K2.6

--- a/python/tokenspeed/runtime/configs/model_config.py
+++ b/python/tokenspeed/runtime/configs/model_config.py
@@ -581,6 +581,7 @@ class ModelConfig:
             "fp8",
             "nvfp4",
             "mxfp4",
+            "modelopt_mixed",
             "compressed_tensors",
             "compressed-tensors",
             "w8a8_fp8",

--- a/python/tokenspeed/runtime/layers/linear.py
+++ b/python/tokenspeed/runtime/layers/linear.py
@@ -45,6 +45,7 @@ from tokenspeed.runtime.layers.parameter import (
 )
 from tokenspeed.runtime.layers.quantization import (
     Fp8Config,
+    ModelOptMixedConfig,
     Mxfp4Config,
     Nvfp4Config,
     W8A8Fp8Config,
@@ -188,6 +189,8 @@ class LinearBase(torch.nn.Module):
                 # remain unquantized unless the checkpoint stores dense MXFP4.
                 self.quant_method = UnquantizedLinearMethod()
         elif isinstance(quant_config, CompressedTensorsConfig):
+            self.quant_method = quant_config.get_quant_method(self, prefix)
+        elif isinstance(quant_config, ModelOptMixedConfig):
             self.quant_method = quant_config.get_quant_method(self, prefix)
         else:
             if isinstance(quant_config, Fp8Config):

--- a/python/tokenspeed/runtime/layers/moe/expert.py
+++ b/python/tokenspeed/runtime/layers/moe/expert.py
@@ -157,7 +157,7 @@ class MoELayer(torch.nn.Module):
                 f"{self.prefix}.experts", quant_config.exclude_modules
             )
         ):
-            self._quant_kind = quant_config.moe_weight_dtype()
+            self._quant_kind = quant_config.moe_weight_dtype(self.prefix)
 
         fp8_scale_block_shape = None
         internal_activation_dtype = "input"

--- a/python/tokenspeed/runtime/layers/quantization/__init__.py
+++ b/python/tokenspeed/runtime/layers/quantization/__init__.py
@@ -28,6 +28,7 @@ from tokenspeed.runtime.layers.quantization.compressed_tensors.compressed_tensor
     CompressedTensorsConfig,
 )
 from tokenspeed.runtime.layers.quantization.fp8 import Fp8Config, Mxfp8Config
+from tokenspeed.runtime.layers.quantization.modelopt_mixed import ModelOptMixedConfig
 from tokenspeed.runtime.layers.quantization.mxfp4 import Mxfp4Config
 from tokenspeed.runtime.layers.quantization.nvfp4 import Nvfp4Config
 from tokenspeed.runtime.layers.quantization.w8a8_fp8 import W8A8Fp8Config
@@ -39,6 +40,7 @@ BASE_QUANTIZATION_METHODS: dict[str, type[QuantizationConfig]] = {
     "compressed-tensors": CompressedTensorsConfig,
     "nvfp4": Nvfp4Config,
     "mxfp4": Mxfp4Config,
+    "modelopt_mixed": ModelOptMixedConfig,
 }
 
 

--- a/python/tokenspeed/runtime/layers/quantization/base_config.py
+++ b/python/tokenspeed/runtime/layers/quantization/base_config.py
@@ -69,15 +69,27 @@ class QuantizationConfig(ABC):
         """Name of the quantization method."""
         raise NotImplementedError
 
-    def moe_weight_dtype(self) -> str:
+    def moe_weight_dtype(self, prefix: str = "") -> str:
         """Logical MoE weight dtype fed to ``moe_plan`` as the ``weight_dtype`` trait.
 
         Must name a concrete dtype the kernels register against (``fp8``,
         ``nvfp4``, ``mxfp4``), not the quant method. Configs whose name already
         is the dtype need no override; container formats (compressed-tensors)
-        resolve it from the parsed scheme.
+        resolve it from the parsed scheme. Mixed-precision configs resolve it
+        per layer from ``prefix`` (the MoE experts module); single-algorithm
+        configs ignore the argument.
         """
         return self.get_name()
+
+    def apply_checkpoint_name_replacements(
+        self, replacements: tuple[tuple[str, str], ...]
+    ) -> None:
+        """Rewrite checkpoint module names in this config to runtime naming.
+
+        Called by the model loader with the model's ordered (old, new)
+        substring table. Only configs keyed by checkpoint module names
+        (mixed precision) need to override; the default is a no-op.
+        """
 
     @abstractmethod
     def get_supported_act_dtypes(self) -> list[torch.dtype]:

--- a/python/tokenspeed/runtime/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/tokenspeed/runtime/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -123,7 +123,7 @@ class CompressedTensorsConfig(QuantizationConfig):
     def get_name(self) -> str:
         return "compressed_tensors"
 
-    def moe_weight_dtype(self) -> str:
+    def moe_weight_dtype(self, prefix: str = "") -> str:
         # Container format: resolve the routed-expert scheme to a concrete MoE
         # kernel dtype. Only INT4 group-32 symmetric pack-quantized weights
         # (Kimi-K2.5 / K2.6 / K2.7, weight-only + bf16 group scales) are wired.

--- a/python/tokenspeed/runtime/layers/quantization/fp8.py
+++ b/python/tokenspeed/runtime/layers/quantization/fp8.py
@@ -122,5 +122,5 @@ class Mxfp8Config(Fp8Config):
             config["scale_fmt"] = "ue8m0"
         return super().from_config(config)
 
-    def moe_weight_dtype(self) -> str:
+    def moe_weight_dtype(self, prefix: str = "") -> str:
         return "fp8"

--- a/python/tokenspeed/runtime/layers/quantization/modelopt_mixed.py
+++ b/python/tokenspeed/runtime/layers/quantization/modelopt_mixed.py
@@ -1,0 +1,265 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Per-layer mixed-precision quantization for ModelOpt MIXED_PRECISION exports.
+
+Such checkpoints (e.g. nvidia/MiniMax-M3-NVFP4) declare a per-module
+``quant_algo`` in the ``quantized_layers`` dict of their quantization config,
+plus ``exclude_modules`` for unquantized modules. This config resolves each
+runtime layer to the matching algorithm and delegates weight handling to the
+corresponding single-algorithm config (MXFP8, NVFP4).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import torch
+
+from tokenspeed.runtime.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+from tokenspeed.runtime.layers.quantization.fp8 import Mxfp8Config
+from tokenspeed.runtime.layers.quantization.nvfp4 import Nvfp4Config
+from tokenspeed.runtime.layers.quantization.utils import should_exclude_quant_module
+
+logger = logging.getLogger(__name__)
+
+_MOE_WEIGHT_DTYPES = {
+    "NVFP4": "nvfp4",
+    "MXFP8": "fp8",
+}
+
+_FUSED_PROJECTION_SHARDS = {
+    "qkv_proj": ("q_proj", "k_proj", "v_proj"),
+    "gate_up_proj": ("gate_proj", "up_proj"),
+}
+
+
+class ModelOptMixedConfig(QuantizationConfig):
+    """Config for ModelOpt MIXED_PRECISION checkpoints.
+
+    Args:
+        quantized_layers: Checkpoint module name -> upper-cased quant_algo
+            (``"NVFP4"`` or ``"MXFP8"``). Keys use checkpoint naming until
+            :meth:`apply_checkpoint_name_replacements` rewrites them to
+            runtime naming.
+        exclude_modules: Checkpoint module names left unquantized.
+        kv_cache_quant_algo: KV-cache quantization algorithm, if any.
+        group_size: NVFP4 weight group size.
+    """
+
+    def __init__(
+        self,
+        quantized_layers: dict[str, str],
+        exclude_modules: list[str] | None = None,
+        kv_cache_quant_algo: str | None = None,
+        group_size: int = 16,
+    ) -> None:
+        super().__init__(exclude_modules=exclude_modules)
+        self.quantized_layers = quantized_layers
+        self.kv_cache_quant_algo = kv_cache_quant_algo
+        self.group_size = group_size
+        self.mxfp8_config = Mxfp8Config(
+            is_checkpoint_fp8_serialized=True,
+            activation_scheme="dynamic",
+            weight_block_size=[1, 32],
+            scale_fmt="ue8m0",
+        )
+        self.nvfp4_config = Nvfp4Config(
+            kv_cache_quant_algo=kv_cache_quant_algo,
+            group_size=group_size,
+        )
+        # MoE layers read this when their experts resolve to an fp8 algo.
+        self.weight_block_size = self.mxfp8_config.weight_block_size
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "modelopt_mixed"
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> list[torch.dtype]:
+        return [torch.bfloat16, torch.half]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 100  # NVFP4 members require Blackwell
+
+    @staticmethod
+    def get_config_filenames() -> list[str]:
+        return ["hf_quant_config.json"]
+
+    @staticmethod
+    def _quantization_section(config: dict[str, Any]) -> dict[str, Any]:
+        # hf_quant_config.json nests under "quantization"; config.json's
+        # quantization_config is flat.
+        section = config.get("quantization", config)
+        return section if isinstance(section, dict) else config
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "ModelOptMixedConfig":
+        section = cls._quantization_section(config)
+        quant_algo = section.get("quant_algo", "")
+        if quant_algo != "MIXED_PRECISION":
+            raise ValueError(
+                f"ModelOptMixedConfig only supports MIXED_PRECISION, got {quant_algo!r}"
+            )
+        raw_layers = section.get("quantized_layers", {})
+        if not raw_layers:
+            raise ValueError(
+                "MIXED_PRECISION requires a non-empty 'quantized_layers' "
+                "mapping in the quantization config."
+            )
+
+        quantized_layers: dict[str, str] = {}
+        group_size: int | None = None
+        unknown: set[str] = set()
+        for name, info in raw_layers.items():
+            algo = str(info.get("quant_algo", "")).upper()
+            if algo not in _MOE_WEIGHT_DTYPES:
+                unknown.add(algo)
+                continue
+            quantized_layers[name] = algo
+            if algo == "NVFP4" and group_size is None:
+                group_size = int(info.get("group_size", 16))
+        if unknown:
+            raise ValueError(
+                f"Unsupported quant_algo values in quantized_layers: {sorted(unknown)}. "
+                f"Supported: {sorted(_MOE_WEIGHT_DTYPES)}."
+            )
+
+        return cls(
+            quantized_layers=quantized_layers,
+            exclude_modules=section.get("exclude_modules", []),
+            kv_cache_quant_algo=section.get("kv_cache_quant_algo"),
+            group_size=group_size if group_size is not None else 16,
+        )
+
+    @classmethod
+    def override_quantization_method(cls, hf_quant_cfg, user_quant) -> str | None:
+        if not isinstance(hf_quant_cfg, dict):
+            return None
+        section = cls._quantization_section(hf_quant_cfg)
+        if section.get("quant_algo") == "MIXED_PRECISION":
+            return "modelopt_mixed"
+        return None
+
+    def apply_checkpoint_name_replacements(
+        self, replacements: tuple[tuple[str, str], ...]
+    ) -> None:
+        """Rewrite checkpoint module names to runtime module prefixes.
+
+        ``replacements`` is the model's ordered (old, new) substring table
+        (``quant_module_name_replacements``). After this, layer lookups are
+        direct string matches against construction-time prefixes.
+        """
+
+        def rename(name: str) -> str:
+            for old, new in replacements:
+                name = name.replace(old, new)
+            return name
+
+        self.quantized_layers = {
+            rename(name): algo for name, algo in self.quantized_layers.items()
+        }
+        self.exclude_modules = [rename(name) for name in self.exclude_modules]
+
+    def _resolve_quant_algo(self, prefix: str) -> str | None:
+        """Resolve the quant_algo for a runtime module prefix.
+
+        Lookup order: direct hit; fused-projection unfuse (members must
+        agree); child-prefix scan (a parent module such as fused experts
+        matches its children's entries).
+        """
+        if prefix in self.quantized_layers:
+            return self.quantized_layers[prefix]
+
+        leaf = prefix.rsplit(".", 1)[-1]
+        shards = _FUSED_PROJECTION_SHARDS.get(leaf)
+        if shards is not None:
+            base = prefix.rsplit(".", 1)[0]
+            algos = {
+                self.quantized_layers[f"{base}.{shard}"]
+                for shard in shards
+                if f"{base}.{shard}" in self.quantized_layers
+            }
+            if len(algos) > 1:
+                raise ValueError(
+                    f"Mixed quant_algo within fused layer {prefix}: {sorted(algos)}. "
+                    "All members must use the same quantization."
+                )
+            if algos:
+                return algos.pop()
+
+        child_prefix = prefix + "."
+        child_algos = {
+            algo
+            for name, algo in self.quantized_layers.items()
+            if name.startswith(child_prefix)
+        }
+        if len(child_algos) > 1:
+            raise ValueError(
+                f"Module {prefix} has children with mixed quant_algo "
+                f"{sorted(child_algos)}; resolve a more specific prefix."
+            )
+        if child_algos:
+            return child_algos.pop()
+
+        return None
+
+    def get_quant_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> QuantizeMethodBase:
+        from tokenspeed.runtime.layers.dense import (
+            Fp8LinearMethod,
+            Nvfp4LinearMethod,
+            UnquantizedLinearMethod,
+        )
+
+        if should_exclude_quant_module(prefix, self.exclude_modules):
+            return UnquantizedLinearMethod()
+        algo = self._resolve_quant_algo(prefix)
+        if algo is None:
+            return UnquantizedLinearMethod()
+        if algo == "MXFP8":
+            return Fp8LinearMethod(self.mxfp8_config)
+        if algo == "NVFP4":
+            return Nvfp4LinearMethod(self.nvfp4_config)
+        raise ValueError(f"Unsupported quant_algo {algo!r} for layer {prefix!r}")
+
+    def moe_weight_dtype(self, prefix: str = "") -> str:
+        # Prefer the experts subtree: a MoE block prefix (e.g. "...mlp") can
+        # also contain differently-quantized shared experts.
+        candidates = (
+            (prefix,) if prefix.endswith(".experts") else (f"{prefix}.experts", prefix)
+        )
+        for candidate in candidates:
+            algo = self._resolve_quant_algo(candidate)
+            if algo is not None:
+                return _MOE_WEIGHT_DTYPES[algo]
+        raise ValueError(
+            f"No quantized_layers entry resolves the MoE prefix {prefix!r}; "
+            "cannot infer the experts' weight dtype."
+        )
+
+    def get_scaled_act_names(self) -> list[str]:
+        return []

--- a/python/tokenspeed/runtime/model_loader/loader.py
+++ b/python/tokenspeed/runtime/model_loader/loader.py
@@ -143,6 +143,10 @@ def _initialize_model(
     """Initialize a model with the given configurations."""
     model_class, _ = get_model_architecture(model_config)
     quant_config = _get_quantization_config(model_config, load_config)
+    if quant_config is not None:
+        replacements = getattr(model_class, "quant_module_name_replacements", None)
+        if replacements:
+            quant_config.apply_checkpoint_name_replacements(replacements)
     mapping = model_config.mapping
     # Only VLM wrappers accept these kwargs.
     extra_kwargs: dict = {}

--- a/python/tokenspeed/runtime/models/minimax_m3.py
+++ b/python/tokenspeed/runtime/models/minimax_m3.py
@@ -578,13 +578,28 @@ class MiniMaxM3SparseForCausalLM(BaseCausalLM):
     model_cls = MiniMaxM3Model
     fall_back_to_pt_during_load = False
 
+    # Ordered checkpoint->parameter-dict renames applied by load_weights.
+    checkpoint_name_replacements = (
+        ("language_model.", ""),
+        (".block_sparse_moe", ".mlp"),
+        (".e_score_correction_bias", ".routing_bias"),
+        (".self_attn.index_q_proj", ".self_attn.indexer.index_q_proj"),
+        (".self_attn.index_k_proj", ".self_attn.indexer.index_k_proj"),
+        (".self_attn.index_q_norm", ".self_attn.indexer.q_norm"),
+        (".self_attn.index_k_norm", ".self_attn.indexer.k_norm"),
+    )
+    # Checkpoint->module-prefix renames for per-layer quantization lookups
+    # (mixed-precision checkpoints). Construction prefixes keep the
+    # checkpoint module tree (block_sparse_moe, flat indexer projections);
+    # only the language_model wrapper is stripped.
+    quant_module_name_replacements = (("language_model.", ""),)
+
     def _load_non_language_weight(
         self,
         checkpoint_name: str,
         loaded_weight: torch.Tensor,
         params_dict: dict[str, nn.Parameter],
     ) -> str | None:
-        del checkpoint_name, loaded_weight, params_dict
         return None
 
     def load_weights(
@@ -592,7 +607,6 @@ class MiniMaxM3SparseForCausalLM(BaseCausalLM):
         weights: Iterable[tuple[str, torch.Tensor]],
         **kwargs,
     ) -> set[str]:
-        del kwargs
         stacked_params_mapping = [
             (".qkv_proj", ".q_proj", "q"),
             (".qkv_proj", ".k_proj", "k"),
@@ -615,9 +629,7 @@ class MiniMaxM3SparseForCausalLM(BaseCausalLM):
 
         loaded_params: set[str] = set()
         for checkpoint_name, loaded_weight in weights:
-            if checkpoint_name.startswith("language_model."):
-                name = checkpoint_name.removeprefix("language_model.")
-            elif checkpoint_name.startswith(
+            if checkpoint_name.startswith(
                 ("vision_tower.", "multi_modal_projector.", "patch_merge_mlp.")
             ):
                 loaded_name = self._load_non_language_weight(
@@ -628,24 +640,15 @@ class MiniMaxM3SparseForCausalLM(BaseCausalLM):
                 if loaded_name is not None:
                     loaded_params.add(loaded_name)
                 continue
-            else:
-                name = checkpoint_name
+
+            name = checkpoint_name
+            for old, new in self.checkpoint_name_replacements:
+                name = name.replace(old, new)
 
             if name.startswith("model.mtp."):
                 continue
             if "rotary_emb.inv_freq" in name:
                 continue
-
-            name = name.replace(".block_sparse_moe", ".mlp")
-            name = name.replace(".e_score_correction_bias", ".routing_bias")
-            name = name.replace(
-                ".self_attn.index_q_proj", ".self_attn.indexer.index_q_proj"
-            )
-            name = name.replace(
-                ".self_attn.index_k_proj", ".self_attn.indexer.index_k_proj"
-            )
-            name = name.replace(".self_attn.index_q_norm", ".self_attn.indexer.q_norm")
-            name = name.replace(".self_attn.index_k_norm", ".self_attn.indexer.k_norm")
 
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in name or ".mlp.experts." in name:

--- a/test/runtime/models/test_minimax_m3.py
+++ b/test/runtime/models/test_minimax_m3.py
@@ -191,6 +191,81 @@ def test_minimax_m3_tp4_meta_layout_and_loader(monkeypatch: pytest.MonkeyPatch) 
     }
 
 
+def _mixed_precision_config() -> "ModelOptMixedConfig":
+    from tokenspeed.runtime.layers.quantization.modelopt_mixed import (
+        ModelOptMixedConfig,
+    )
+
+    layers: dict = {}
+    for i in range(4):
+        for proj in ("q_proj", "k_proj", "v_proj", "o_proj"):
+            layers[f"language_model.model.layers.{i}.self_attn.{proj}"] = {
+                "quant_algo": "MXFP8"
+            }
+    for i in range(3):
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            layers[f"language_model.model.layers.{i}.mlp.{proj}"] = {
+                "quant_algo": "MXFP8"
+            }
+    for proj in ("index_q_proj", "index_k_proj"):
+        layers[f"language_model.model.layers.3.self_attn.{proj}"] = {
+            "quant_algo": "MXFP8"
+        }
+    for proj in ("gate_proj", "up_proj", "down_proj"):
+        layers[
+            "language_model.model.layers.3.block_sparse_moe." f"shared_experts.{proj}"
+        ] = {"quant_algo": "MXFP8"}
+    for expert in range(8):
+        for proj in ("w1", "w2", "w3"):
+            layers[
+                "language_model.model.layers.3.block_sparse_moe."
+                f"experts.{expert}.{proj}"
+            ] = {"quant_algo": "NVFP4", "group_size": 16}
+
+    config = ModelOptMixedConfig.from_config(
+        {
+            "quant_algo": "MIXED_PRECISION",
+            "quant_method": "modelopt",
+            "exclude_modules": [
+                "lm_head",
+                "model.embed_tokens",
+                "language_model.model.layers.3.block_sparse_moe.gate",
+            ],
+            "quantized_layers": layers,
+        }
+    )
+    config.apply_checkpoint_name_replacements(
+        MiniMaxM3SparseForConditionalGeneration.quant_module_name_replacements
+    )
+    return config
+
+
+def test_minimax_m3_mixed_precision_quant_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tokenspeed.runtime.layers.dense import Fp8LinearMethod
+
+    model = _build_model(monkeypatch, quant_config=_mixed_precision_config())
+
+    attn = model.model.layers[3].self_attn
+    assert isinstance(attn.qkv_proj.quant_method, Fp8LinearMethod)
+    assert isinstance(attn.o_proj.quant_method, Fp8LinearMethod)
+    assert isinstance(attn.indexer.index_q_proj.quant_method, Fp8LinearMethod)
+    assert isinstance(attn.indexer.index_k_proj.quant_method, Fp8LinearMethod)
+
+    assert isinstance(
+        model.model.layers[0].mlp.gate_up_proj.quant_method, Fp8LinearMethod
+    )
+
+    moe = model.model.layers[3].mlp
+    assert isinstance(moe.shared_experts.gate_up_proj.quant_method, Fp8LinearMethod)
+    experts = moe.experts
+    assert experts._quant_kind == "nvfp4"
+    assert experts.w13_weight.dtype == torch.uint8
+    assert experts.w13_weight_scale.dtype == torch.float8_e4m3fn
+    assert experts.w13_weight_scale_2.shape == (8, 2)
+
+
 def test_minimax_m3_active_multimodal_layout_and_loader(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/test/runtime/test_modelopt_mixed_config.py
+++ b/test/runtime/test_modelopt_mixed_config.py
@@ -1,0 +1,145 @@
+"""CPU-only coverage for the ModelOpt MIXED_PRECISION quantization config."""
+
+from __future__ import annotations
+
+import pytest
+
+from tokenspeed.runtime.layers.quantization import QUANTIZATION_METHODS
+from tokenspeed.runtime.layers.quantization.modelopt_mixed import ModelOptMixedConfig
+
+_RENAMES = (("language_model.", ""),)
+
+
+def _mixed_quant_config(extra_layers: dict | None = None) -> dict:
+    """Minimal MIXED_PRECISION quantization_config in checkpoint naming."""
+    layers = {
+        "language_model.model.layers.3.self_attn.q_proj": {"quant_algo": "MXFP8"},
+        "language_model.model.layers.3.self_attn.k_proj": {"quant_algo": "MXFP8"},
+        "language_model.model.layers.3.self_attn.v_proj": {"quant_algo": "MXFP8"},
+        "language_model.model.layers.3.self_attn.o_proj": {"quant_algo": "MXFP8"},
+        "language_model.model.layers.3.self_attn.index_q_proj": {"quant_algo": "MXFP8"},
+        "language_model.model.layers.3.block_sparse_moe.shared_experts.gate_proj": {
+            "quant_algo": "MXFP8"
+        },
+        "language_model.model.layers.3.block_sparse_moe.shared_experts.up_proj": {
+            "quant_algo": "MXFP8"
+        },
+        "language_model.model.layers.3.block_sparse_moe.experts.0.w1": {
+            "quant_algo": "NVFP4",
+            "group_size": 16,
+        },
+        "language_model.model.layers.3.block_sparse_moe.experts.0.w2": {
+            "quant_algo": "NVFP4",
+            "group_size": 16,
+        },
+    }
+    layers.update(extra_layers or {})
+    return {
+        "quant_algo": "MIXED_PRECISION",
+        "kv_cache_quant_algo": None,
+        "quant_method": "modelopt",
+        "exclude_modules": [
+            "lm_head",
+            "language_model.model.layers.3.block_sparse_moe.gate",
+        ],
+        "quantized_layers": layers,
+    }
+
+
+def _renamed_config(extra_layers: dict | None = None) -> ModelOptMixedConfig:
+    config = ModelOptMixedConfig.from_config(_mixed_quant_config(extra_layers))
+    config.apply_checkpoint_name_replacements(_RENAMES)
+    return config
+
+
+def test_override_detects_mixed_precision():
+    hf_cfg = _mixed_quant_config()
+    detected = None
+    for method in QUANTIZATION_METHODS.values():
+        detected = method.override_quantization_method(hf_cfg, None)
+        if detected:
+            break
+    assert detected == "modelopt_mixed"
+
+
+def test_override_detects_nested_hf_quant_config():
+    nested = {"producer": {"name": "modelopt"}, "quantization": _mixed_quant_config()}
+    assert (
+        ModelOptMixedConfig.override_quantization_method(nested, None)
+        == "modelopt_mixed"
+    )
+    config = ModelOptMixedConfig.from_config(nested)
+    assert config.group_size == 16
+
+
+def test_from_config_rejects_unknown_algo():
+    with pytest.raises(ValueError, match="Unsupported quant_algo"):
+        ModelOptMixedConfig.from_config(
+            _mixed_quant_config(
+                {"language_model.model.layers.3.mlp.up_proj": {"quant_algo": "INT8"}}
+            )
+        )
+
+
+def test_from_config_rejects_missing_quantized_layers():
+    cfg = _mixed_quant_config()
+    cfg["quantized_layers"] = {}
+    with pytest.raises(ValueError, match="quantized_layers"):
+        ModelOptMixedConfig.from_config(cfg)
+
+
+def test_resolution_after_renames():
+    config = _renamed_config()
+    # Fused projections unfuse to their checkpoint members.
+    assert config._resolve_quant_algo("model.layers.3.self_attn.qkv_proj") == "MXFP8"
+    assert (
+        config._resolve_quant_algo(
+            "model.layers.3.block_sparse_moe.shared_experts.gate_up_proj"
+        )
+        == "MXFP8"
+    )
+    # Construction prefixes keep the flat checkpoint indexer naming.
+    assert (
+        config._resolve_quant_algo("model.layers.3.self_attn.index_q_proj") == "MXFP8"
+    )
+    # Parent module resolves through its children.
+    assert (
+        config._resolve_quant_algo("model.layers.3.block_sparse_moe.experts") == "NVFP4"
+    )
+    # Unlisted modules resolve to None (unquantized).
+    assert config._resolve_quant_algo("model.layers.3.block_sparse_moe.gate") is None
+    assert config._resolve_quant_algo("lm_head") is None
+
+
+def test_fused_members_must_agree():
+    config = _renamed_config(
+        {"language_model.model.layers.3.self_attn.v_proj": {"quant_algo": "NVFP4"}}
+    )
+    with pytest.raises(ValueError, match="Mixed quant_algo within fused layer"):
+        config._resolve_quant_algo("model.layers.3.self_attn.qkv_proj")
+
+
+def test_ambiguous_child_scan_raises():
+    config = _renamed_config()
+    with pytest.raises(ValueError, match="mixed quant_algo"):
+        config._resolve_quant_algo("model.layers.3.block_sparse_moe")
+
+
+def test_moe_weight_dtype_prefers_experts_subtree():
+    config = _renamed_config()
+    assert config.moe_weight_dtype("model.layers.3.block_sparse_moe.experts") == "nvfp4"
+    # A MoE block prefix must not be captured by the MXFP8 shared experts.
+    assert config.moe_weight_dtype("model.layers.3.block_sparse_moe") == "nvfp4"
+    with pytest.raises(ValueError, match="MoE prefix"):
+        config.moe_weight_dtype("model.layers.99.block_sparse_moe")
+
+
+def test_minimax_m3_quant_rename_table_matches_module_prefixes():
+    from tokenspeed.runtime.models.minimax_m3 import MiniMaxM3SparseForCausalLM
+
+    replacements = MiniMaxM3SparseForCausalLM.quant_module_name_replacements
+    name = "language_model.model.layers.3.self_attn.index_q_proj"
+    for old, new in replacements:
+        name = name.replace(old, new)
+    # Construction prefixes keep the checkpoint module tree.
+    assert name == "model.layers.3.self_attn.index_q_proj"

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/cutedsl_deepep_nvfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/cutedsl_deepep_nvfp4.py
@@ -121,7 +121,7 @@ if platform.is_nvidia:
         ),
         traits={
             "weight_dtype": frozenset({"nvfp4"}),
-            "activation": frozenset({"silu", "swiglu"}),
+            "activation": frozenset({"silu"}),
             "routing_mode": frozenset({"precomputed_topk"}),
             "supports_deferred_finalize": frozenset({False}),
             "supports_ep": frozenset({True}),

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/cutlass_nvfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/cutlass_nvfp4.py
@@ -65,6 +65,29 @@ if platform.is_nvidia:
             requires_grad=False,
         )
 
+        swiglu_arg = getattr(w, "swiglu_arg", None)
+        if swiglu_arg is not None:
+            # The cutlass gated activation runs post-dequant, so alpha/beta/
+            # limit are passed in the actual-value domain (SwigluBias adaptor).
+            num_experts = w.w13_weight.shape[0]
+            device = w.w13_weight.device
+
+            def _per_expert(value: float) -> torch.nn.Parameter:
+                return torch.nn.Parameter(
+                    torch.full(
+                        (num_experts,), float(value), dtype=torch.float32, device=device
+                    ),
+                    requires_grad=False,
+                )
+
+            alpha = swiglu_arg.alpha if swiglu_arg.alpha is not None else 1.0
+            beta = getattr(w, "swiglu_beta", None)
+            w.swiglu_alpha_t = _per_expert(alpha)
+            if beta is not None:
+                w.swiglu_beta_t = _per_expert(beta)
+            if swiglu_arg.limit is not None:
+                w.swiglu_limit_t = _per_expert(swiglu_arg.limit)
+
         scales = w.w13_weight_scale
         scale_ndim = scales.ndim
         if scale_ndim == 2:
@@ -158,6 +181,10 @@ if platform.is_nvidia:
         output = torch.empty(
             x.shape[0], x.shape[1], dtype=torch.bfloat16, device=x.device
         )
+        swiglu_alpha = getattr(w, "swiglu_alpha_t", None)
+        activation_type = (
+            ActivationType.Swiglu if swiglu_alpha is None else ActivationType.SwigluBias
+        )
         return cutlass_fused_moe(
             output=output,
             input=x,
@@ -180,5 +207,8 @@ if platform.is_nvidia:
             tp_size=getattr(w, "tp_size", 1),
             tp_rank=getattr(w, "tp_rank", 0),
             tune_max_num_tokens=next_power_of_2(x.shape[0]),
-            activation_type=ActivationType.Swiglu,
+            activation_type=activation_type,
+            swiglu_alpha=swiglu_alpha,
+            swiglu_beta=getattr(w, "swiglu_beta_t", None),
+            swiglu_limit=getattr(w, "swiglu_limit_t", None),
         )[0]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_nvfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_nvfp4.py
@@ -200,6 +200,35 @@ if platform.is_nvidia:
             w2_input_scale_quant * (w13_input_scale * up_ws2).to(torch.float32),
             requires_grad=False,
         )
+
+        swiglu_arg = getattr(w, "swiglu_arg", None)
+        if swiglu_arg is not None:
+            # The fused gated activation runs on pre-dequant accumulators
+            # (actual = raw * g1_alphas), so beta and the clamp limit must be
+            # expressed in the raw domain; alpha passes through unchanged.
+            # Folding the gate dequant scale is only exact when the gate and
+            # up halves share one global scale.
+            if not torch.equal(gate_ws2, up_ws2):
+                raise RuntimeError(
+                    "NVFP4 swiglu alpha/limit requires equal gate/up "
+                    "weight_scale_2 per expert."
+                )
+            alpha = swiglu_arg.alpha if swiglu_arg.alpha is not None else 1.0
+            beta = getattr(w, "swiglu_beta", None)
+            w.gemm1_alpha = torch.nn.Parameter(
+                torch.full_like(w.g1_alphas.data, float(alpha)),
+                requires_grad=False,
+            )
+            if beta is not None:
+                w.gemm1_beta = torch.nn.Parameter(
+                    float(beta) / w.g1_alphas.data, requires_grad=False
+                )
+            if swiglu_arg.limit is not None:
+                w.gemm1_clamp_limit = torch.nn.Parameter(
+                    float(swiglu_arg.limit) / w.g1_alphas.data,
+                    requires_grad=False,
+                )
+
         # Store intermediate_size_per_partition for the executor
         w.intermediate_size_per_partition = intermediate_size
 
@@ -263,9 +292,9 @@ if platform.is_nvidia:
                 torch.float8_e4m3fn
             ),
             gemm1_bias=None,
-            gemm1_alpha=None,
-            gemm1_beta=None,
-            gemm1_clamp_limit=None,
+            gemm1_alpha=getattr(w, "gemm1_alpha", None),
+            gemm1_beta=getattr(w, "gemm1_beta", None),
+            gemm1_clamp_limit=getattr(w, "gemm1_clamp_limit", None),
             gemm2_weights=w.gemm2_weights_fp4_shuffled.data,
             gemm2_weights_scale=w.gemm2_scales_fp4_shuffled.data.view(
                 torch.float8_e4m3fn

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -1495,7 +1495,7 @@ def _moe_apply_nvfp4_deepep_cutedsl() -> object:
     plan = tokenspeed_kernel.moe_plan(
         "nvfp4",
         input_dtype=torch.bfloat16,
-        activation="swiglu",
+        activation="silu",
         a2a_backend="deepep",
         ep_size=2,
         ispp=128,


### PR DESCRIPTION
## Summary

Serves `nvidia/MiniMax-M3-NVFP4` (ModelOpt `MIXED_PRECISION`: NVFP4 routed experts,
MXFP8 linears, unquantized gates/embeddings, bf16 KV). Format is auto-detected —
no `--quantization` flag.

```bash
tokenspeed serve nvidia/MiniMax-M3-NVFP4 \
  --tensor-parallel-size 4 --block-size 128 \
  --attention-backend trtllm --moe-backend flashinfer_trtllm \
  --disable-kvstore --disable-prefill-graph --trust-remote-code
```

### Changes

- **fix(moe)**: flashinfer NVFP4 MoE kernels claimed the `swiglu` trait but computed
  plain silu-gating — silently wrong outputs for swiglu-oai models like M3 (root
  cause of earlier accuracy issues). trtllm now derives per-expert
  `gemm1_alpha/beta/clamp_limit` from `swiglu_arg` (beta/limit folded by
  `1/g1_alphas`, matching vLLM); cutlass passes unscaled args with
  `ActivationType.SwigluBias`; cutedsl trait narrowed to `silu`. Silu models
  (Kimi/DeepSeek) unaffected.
- **feat(quant)**: `ModelOptMixedConfig` (modeled on vLLM) — detects
  `MIXED_PRECISION`, parses `quantized_layers`, and dispatches per layer via
  `Mxfp8Config`/`Nvfp4Config` sub-configs. Lookup: loader rewrites keys to runtime
  prefixes via the model's rename table, then direct match + fused-projection
  unfuse + child-prefix scan (conflicts raise). Unknown algos raise at parse time.
  MXFP8 path unchanged.

### Validation

- Kernel A/B vs fp32 dequant references (real checkpoint): fixed kernels match the
  swiglu-oai reference at fp4-noise level (rel L2 0.135, cos 0.991); trtllm/cutlass
  agree at cos 0.9996.
- 9 CPU unit tests + meta-device dispatch test; existing MXFP8/mxfp4 tests pass.
- E2E on 4×B200 (TP4): **GSM8K 0.945** exact_match (200 samples, 8-shot).

### Known limitations

- `--disable-prefill-graph` required for now (prefill graph capture hits a CUDA
  illegal memory access; decode graphs work). Follow-up issue.