### PR TITLE
[WIP] feat(deepseek): land V4 L1 KV cache on heterogeneous flat kv pools

### DIFF
--- a/python/tokenspeed/runtime/cache/deepseek_v4_cache_host.py
+++ b/python/tokenspeed/runtime/cache/deepseek_v4_cache_host.py
@@ -94,6 +94,15 @@ class DeepseekV4TokenToKVPoolHost:
             raise ValueError("DeepSeek V4 KVStore host pool only supports layer_first")
         if host_to_device_ratio <= 0 and host_size_gb <= 0:
             raise ValueError("host_to_device_ratio must be positive")
+        if (
+            device_pool.runtime_contract is not None
+            or device_pool.lcm_pool is not None
+            or not device_pool.supports_hierarchical_kv_cache
+        ):
+            raise NotImplementedError(
+                "DeepSeek V4 Flat LCM cache has no L2 host adapter; use the "
+                "Radix pool or pass --disable-kvstore."
+            )
 
         self.device_pool = device_pool
         self.layout = layout

--- a/python/tokenspeed/runtime/cache/transfer/deepseek_v4_pool.py
+++ b/python/tokenspeed/runtime/cache/transfer/deepseek_v4_pool.py
@@ -150,6 +150,14 @@ class DeepseekV4CachePool:
         host_pool: DeepseekV4TokenToKVPoolHost,
         io_backend: str,
     ) -> None:
+        if (
+            device_pool.runtime_contract is not None
+            or device_pool.lcm_pool is not None
+            or not device_pool.supports_hierarchical_kv_cache
+        ):
+            raise NotImplementedError(
+                "DeepSeek V4 paged L2 transfers require the Radix device pool"
+            )
         if io_backend not in ("kernel", "direct"):
             raise ValueError(
                 f"Unsupported DeepSeek V4 paged-cache io_backend={io_backend}"

--- a/python/tokenspeed/runtime/configs/deepseek_v4_cache_spec.py
+++ b/python/tokenspeed/runtime/configs/deepseek_v4_cache_spec.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import replace
 from typing import Any
 
 from tokenspeed.runtime.configs.paged_cache_spec import PagedCacheGroupSpec
@@ -24,6 +25,7 @@ from tokenspeed.runtime.configs.paged_cache_spec import PagedCacheGroupSpec
 V4_KERNEL_BLOCK_ROWS: int = 64
 V4_SWA_KV_GROUP_ID = "v4.swa_kv"
 V4_INDEXER_COMPRESSOR_STATE_GROUP_ID = "v4.c4a.indexer_compressor_state"
+
 DEEPSEEK_V4_FP8_MAX = 448.0
 DEEPSEEK_V4_FP8_BLOCK_SIZE = 128
 DEEPSEEK_V4_FP8_QUANT_BLOCK = 64
@@ -194,6 +196,17 @@ def build_v4_cache_specs(
     *,
     layer_ratio: Sequence[int],
 ) -> list[PagedCacheGroupSpec]:
+    """Return the V4 logical groups and their page geometry.
+
+    Args:
+        hf_config: Model config containing a positive ``sliding_window``.
+        layer_ratio: Per-layer compression ratios present in this model.
+
+    Returns:
+        The Radix-compatible groups required by the ratios actually present.
+        Flat-only block spans and physical LCM packing are added by the Flat
+        recipe so they cannot change Radix/L2 page units.
+    """
     swa_window = _resolve_sliding_window(hf_config)
     unique_compress_ratios = sorted({int(r) for r in layer_ratio if int(r) > 1})
 
@@ -248,6 +261,21 @@ def build_v4_cache_specs(
     return specs
 
 
+def build_v4_flat_cache_specs(
+    hf_config: Any,
+    *,
+    layer_ratio: Sequence[int],
+) -> list[PagedCacheGroupSpec]:
+    """Add heterogeneous scheduler spans to the V4 Flat-LCM group recipe."""
+    return [
+        replace(
+            spec,
+            block_size=int(spec.rows_per_page) * int(spec.entry_stride_tokens),
+        )
+        for spec in build_v4_cache_specs(hf_config, layer_ratio=layer_ratio)
+    ]
+
+
 __all__ = [
     "DEEPSEEK_V4_FP8_BLOCK_SIZE",
     "DEEPSEEK_V4_COMPRESSED_LOGICAL_BLOCK_SIZE",
@@ -262,6 +290,7 @@ __all__ = [
     "V4_KERNEL_BLOCK_ROWS",
     "V4_SWA_KV_GROUP_ID",
     "build_v4_cache_specs",
+    "build_v4_flat_cache_specs",
     "deepseek_v4_indexer_fp8_layout_from_row_bytes",
     "deepseek_v4_indexer_fp8_row_bytes",
     "deepseek_v4_indexer_fp8_scale_bytes",

--- a/python/tokenspeed/runtime/configs/flat_cache_runtime.py
+++ b/python/tokenspeed/runtime/configs/flat_cache_runtime.py
@@ -22,10 +22,13 @@ from __future__ import annotations
 
 import os
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import MappingProxyType
 
-from tokenspeed.runtime.configs.paged_cache_spec import PagedCacheGroupSpec
+from tokenspeed.runtime.configs.paged_cache_spec import (
+    PagedCacheGroupSpec,
+    full_history_lcm_group_capacities,
+)
 
 
 def flat_cache_debug_enabled() -> bool:
@@ -53,11 +56,24 @@ def require_positive_int(name: str, value: object) -> int:
 
 @dataclass(frozen=True)
 class FlatPagedCacheRuntimeContract:
+    """Immutable runtime geometry for one scheduler-visible FlatKV group union.
+
+    ``block_size`` is the scheduler's base allocation/hash grain. Individual
+    groups may span more raw tokens per child page through
+    ``PagedCacheGroupSpec.block_size``; consumers must use
+    ``group_block_sizes`` rather than assuming the base grain is uniform.
+
+    ``token_capacity`` is the scheduler admission ceiling. It can be smaller
+    than the device pool's physical child-address extent when heterogeneous
+    groups pack different numbers of child pages into each LCM parent.
+    """
+
     block_size: int
     num_lcm_blocks: int
     token_capacity: int
     group_specs: tuple[PagedCacheGroupSpec, ...]
     group_page_counts: Mapping[str, int]
+    group_block_sizes: Mapping[str, int] = field(init=False)
 
     def __post_init__(self) -> None:
         block_size = require_positive_int("block_size", self.block_size)
@@ -85,6 +101,23 @@ class FlatPagedCacheRuntimeContract:
             )
             for group_id in group_ids
         }
+        group_block_sizes = {
+            spec.group_id: require_positive_int(
+                f"block_size for {spec.group_id!r}",
+                spec.block_size if spec.block_size is not None else block_size,
+            )
+            for spec in self.group_specs
+        }
+        non_multiple_groups = {
+            group_id: group_block_size
+            for group_id, group_block_size in group_block_sizes.items()
+            if group_block_size % block_size
+        }
+        if non_multiple_groups:
+            raise ValueError(
+                "group block sizes must be integer multiples of the scheduler "
+                f"base block_size={block_size}: {non_multiple_groups}"
+            )
         expected_counts = {
             spec.group_id: num_lcm_blocks
             * require_positive_int(
@@ -100,9 +133,23 @@ class FlatPagedCacheRuntimeContract:
                 "cache_blocks_per_lcm_block + 1: "
                 f"expected={expected_counts}, got={counts}"
             )
-        max_child_pages = max(counts.values()) - 1
-        if token_capacity > max_child_pages * block_size:
+        full_history_capacities = full_history_lcm_group_capacities(
+            self.group_specs,
+            base_block_size=block_size,
+            num_lcm_blocks=num_lcm_blocks,
+        )
+        if full_history_capacities and token_capacity > min(
+            full_history_capacities.values()
+        ):
             raise ValueError(
-                "token_capacity exceeds the largest group's child-page capacity"
+                "token_capacity exceeds a full-history group's child-page "
+                "capacity: "
+                f"token_capacity={token_capacity}, "
+                f"group_capacities={full_history_capacities}"
             )
         object.__setattr__(self, "group_page_counts", MappingProxyType(counts))
+        object.__setattr__(
+            self,
+            "group_block_sizes",
+            MappingProxyType(group_block_sizes),
+        )

--- a/python/tokenspeed/runtime/configs/lcm_layouts.py
+++ b/python/tokenspeed/runtime/configs/lcm_layouts.py
@@ -25,6 +25,118 @@ from __future__ import annotations
 from tokenspeed.runtime.configs.lcm_memory_plan import LcmFieldSpec
 
 
+def deepseek_v4_lcm_fields(
+    *,
+    layout,
+    group_specs,
+) -> tuple[LcmFieldSpec, ...]:
+    """Describe DeepSeek-V4 history and compressor-state cache fields.
+
+    Every V4 cache consumer receives the field tensor's runtime page stride.
+    Fields can therefore share the ordinal slot planes used by the common LCM
+    layout instead of reserving one plane per cache group.
+    """
+    from tokenspeed.runtime.configs.deepseek_v4_cache_spec import (
+        V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
+        V4_SWA_KV_GROUP_ID,
+        v4_compressed_kv_group_id,
+        v4_compressor_state_group_id,
+    )
+
+    group_specs = tuple(group_specs)
+    specs_by_id = {spec.group_id: spec for spec in group_specs}
+    if len(specs_by_id) != len(group_specs):
+        raise ValueError("DeepSeek V4 cache specs contain duplicate group IDs")
+
+    def rows(group_id: str) -> int:
+        try:
+            return int(specs_by_id[group_id].rows_per_page)
+        except KeyError as exc:
+            raise ValueError(
+                f"DeepSeek V4 LCM recipe is missing group {group_id!r}"
+            ) from exc
+
+    occurrences: dict[str, int] = {}
+
+    def slot(group_id: str) -> int:
+        return occurrences.get(group_id, 0)
+
+    def advance(group_id: str) -> None:
+        occurrences[group_id] = slot(group_id) + 1
+
+    fields = []
+    swa_rows = rows(V4_SWA_KV_GROUP_ID)
+    for layer_id, ratio in enumerate(layout.layer_ratio):
+        swa_plane = f"slot.{slot(V4_SWA_KV_GROUP_ID)}"
+        fields.append(
+            LcmFieldSpec(
+                V4_SWA_KV_GROUP_ID,
+                f"layer.{layer_id}.swa_kv",
+                swa_plane,
+                (layout.swa_block_bytes(swa_rows),),
+                1,
+                exact_page_stride=False,
+            )
+        )
+        advance(V4_SWA_KV_GROUP_ID)
+        if ratio <= 1:
+            continue
+
+        history_group = v4_compressed_kv_group_id(ratio)
+        state_group = v4_compressor_state_group_id(ratio)
+        history_rows = rows(history_group)
+        history_plane = f"slot.{slot(history_group)}"
+        state_plane = f"slot.{slot(state_group)}"
+        fields.extend(
+            (
+                LcmFieldSpec(
+                    history_group,
+                    f"layer.{layer_id}.compressed_kv",
+                    history_plane,
+                    (layout.swa_block_bytes(history_rows),),
+                    1,
+                    exact_page_stride=False,
+                ),
+                LcmFieldSpec(
+                    state_group,
+                    f"layer.{layer_id}.compressor_state",
+                    state_plane,
+                    (rows(state_group), layout.state_width(layer_id) * 2),
+                    4,
+                    exact_page_stride=False,
+                ),
+            )
+        )
+        if ratio == 4:
+            fields.extend(
+                (
+                    LcmFieldSpec(
+                        history_group,
+                        f"layer.{layer_id}.indexer_kv",
+                        history_plane,
+                        (history_rows * layout.indexer_row_bytes,),
+                        1,
+                        exact_page_stride=False,
+                    ),
+                    LcmFieldSpec(
+                        V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
+                        f"layer.{layer_id}.indexer_state",
+                        f"slot.{slot(V4_INDEXER_COMPRESSOR_STATE_GROUP_ID)}",
+                        (
+                            rows(V4_INDEXER_COMPRESSOR_STATE_GROUP_ID),
+                            layout.state_width(layer_id, indexer=True) * 2,
+                        ),
+                        4,
+                        exact_page_stride=False,
+                    ),
+                )
+            )
+            advance(V4_INDEXER_COMPRESSOR_STATE_GROUP_ID)
+        advance(history_group)
+        advance(state_group)
+    return tuple(fields)
+
+
 def mla_history_lcm_fields(
     *,
     layer_group_ids,

--- a/python/tokenspeed/runtime/configs/model_config.py
+++ b/python/tokenspeed/runtime/configs/model_config.py
@@ -485,7 +485,7 @@ class ModelConfig:
         else:
             self.attention_arch = AttentionArch.MHA
 
-        self.use_v4_mtp_paged_metadata = (
+        self.use_target_verify_paged_metadata = (
             getattr(server_args, "speculative_algorithm", None) is not None
             and not is_draft_worker
             and attention_family is not None

--- a/python/tokenspeed/runtime/configs/paged_cache_spec.py
+++ b/python/tokenspeed/runtime/configs/paged_cache_spec.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 Retention = Literal["full_history", "sliding_window"]
 Family = Literal["history", "state"]
@@ -43,6 +43,113 @@ class PagedCacheGroupSpec:
 
 
 _PAGED_CACHE_GROUP_DUMMY_PAGES = 1
+
+
+def full_history_lcm_group_capacities(
+    specs: Sequence[PagedCacheGroupSpec],
+    *,
+    base_block_size: int,
+    num_lcm_blocks: int,
+) -> dict[str, int]:
+    """Return token capacities of full-history groups in one LCM arena.
+
+    Physical child-page packing is group-specific. Admission is therefore
+    bounded by the narrowest history group that must retain every token, not
+    by the largest child-address extent used to allocate the shared arena.
+    """
+    if (
+        isinstance(base_block_size, bool)
+        or not isinstance(base_block_size, int)
+        or base_block_size <= 0
+    ):
+        raise ValueError(
+            f"base_block_size must be a positive integer, got {base_block_size!r}"
+        )
+    if (
+        isinstance(num_lcm_blocks, bool)
+        or not isinstance(num_lcm_blocks, int)
+        or num_lcm_blocks <= 0
+    ):
+        raise ValueError(
+            f"num_lcm_blocks must be a positive integer, got {num_lcm_blocks!r}"
+        )
+
+    capacities: dict[str, int] = {}
+    for spec in specs:
+        if spec.family != "history" or spec.retention != "full_history":
+            continue
+        group_block_size = (
+            spec.block_size if spec.block_size is not None else base_block_size
+        )
+        if (
+            isinstance(group_block_size, bool)
+            or not isinstance(group_block_size, int)
+            or group_block_size <= 0
+        ):
+            raise ValueError(
+                f"block_size for {spec.group_id!r} must be a positive integer, "
+                f"got {group_block_size!r}"
+            )
+        packing = spec.cache_blocks_per_lcm_block
+        if isinstance(packing, bool) or not isinstance(packing, int) or packing <= 0:
+            raise ValueError(
+                "cache_blocks_per_lcm_block for "
+                f"{spec.group_id!r} must be a positive integer, got {packing!r}"
+            )
+        capacities[spec.group_id] = num_lcm_blocks * group_block_size * packing
+    return capacities
+
+
+def legacy_flat_loc_group_id(
+    group_specs: Sequence[PagedCacheGroupSpec],
+    *,
+    legacy_page_size: int,
+) -> str | None:
+    """Return the sole Flat group safe for the legacy scalar location table.
+
+    Runtime-contract consumers are group keyed and bypass this compatibility
+    path. Legacy Flat exports are absolute; their mirror candidate must retain
+    full history at stride one, and its token span must cover an integral
+    number of legacy pages so its table cannot exceed ``req_to_page`` width.
+    Ambiguous or incompatible inputs fail closed by returning ``None``.
+    """
+    if (
+        isinstance(legacy_page_size, bool)
+        or not isinstance(legacy_page_size, int)
+        or legacy_page_size <= 0
+    ):
+        raise ValueError(
+            f"legacy_page_size must be a positive integer, got {legacy_page_size!r}"
+        )
+
+    candidates: list[str] = []
+    for spec in group_specs:
+        if (
+            spec.family != "history"
+            or spec.retention != "full_history"
+            or isinstance(spec.entry_stride_tokens, bool)
+            or spec.entry_stride_tokens != 1
+        ):
+            continue
+        block_span = spec.block_size
+        if block_span is None:
+            if (
+                isinstance(spec.rows_per_page, bool)
+                or not isinstance(spec.rows_per_page, int)
+                or spec.rows_per_page <= 0
+            ):
+                continue
+            block_span = spec.rows_per_page
+        if (
+            isinstance(block_span, bool)
+            or not isinstance(block_span, int)
+            or block_span <= 0
+            or block_span % legacy_page_size
+            or not spec.group_id
+        ):
+            continue
+        candidates.append(spec.group_id)
+    return candidates[0] if len(candidates) == 1 else None
 
 
 _KIMI_K3_ARCHITECTURES = frozenset({"KimiK3ForConditionalGeneration"})
@@ -209,7 +316,7 @@ def validate_flat_scheduler_config(
     flat_kvcache_ext: bool,
     paged_cache_groups: Sequence[object],
     attn_backend: object,
-    kv_pool: object,
+    kv_pool: Any,
     speculative_algorithm: str | None = None,
 ) -> None:
     """Fail fast, before the C++ ``Scheduler`` ctor, when a flat-built ext
@@ -217,7 +324,7 @@ def validate_flat_scheduler_config(
     consume the per-group flat tables, or zero published groups. No-op on a
     radix build.
     """
-    contract = getattr(kv_pool, "runtime_contract", None)
+    contract = kv_pool.runtime_contract
     if contract is not None and not flat_kvcache_ext:
         raise RuntimeError(
             "KV pool publishes a runtime contract and requires a flat scheduler "
@@ -773,8 +880,10 @@ __all__ = [
     "STATE_LAYER_TYPES",
     "compute_max_logical_pages_for_capture",
     "compute_paged_cache_group_page_counts",
+    "full_history_lcm_group_capacities",
     "group_specs_from_layer_types",
     "hybrid_slab_group_size",
+    "legacy_flat_loc_group_id",
     "layer_group_ids",
     "publish_paged_cache_groups",
     "preflight_kimi_k3_flat_consumers",

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -356,20 +356,21 @@ class EventLoop:
             mamba_l2_io_backend=server_args.mamba_l2_io_backend,
         )
         paged_cache_host_group_pages = {}
-        if scheduler_ext_flat_kvcache() and server_args.enable_kvstore:
+        flat_kvcache_ext = scheduler_ext_flat_kvcache()
+        if flat_kvcache_ext and server_args.enable_kvstore:
             if server_args.kvstore_storage_backend is not None:
                 raise NotImplementedError(
                     "flat scheduler build (TOKENSPEED_FLAT_KVCACHE) has no L3 "
                     "storage tier yet; unset --kvstore-storage-backend."
                 )
-            if getattr(token_to_kv_pool, "runtime_contract", None) is not None:
-                # FlatKV contract pools (Kimi-K3) have no host tier yet:
-                # FlatMemoryExecutor mirrors k_buffer/v_buffer layouts the
-                # raw-slab pool does not expose. Reject this unsupported
+            if token_to_kv_pool.runtime_contract is not None:
+                # Shared-LCM/runtime-contract pools do not expose the raw-slab
+                # layout mirrored by FlatMemoryExecutor. Reject this unsupported
                 # combination at startup.
                 raise NotImplementedError(
                     "the flat host tier (kvstore L2) does not support FlatKV "
-                    "contract pools (Kimi-K3) yet; pass --disable-kvstore."
+                    "runtime-contract/shared-LCM pool layouts yet; pass "
+                    "--disable-kvstore."
                 )
             self.memory_executor = FlatMemoryExecutor(
                 device_pool=token_to_kv_pool,
@@ -417,11 +418,11 @@ class EventLoop:
                 f"(ratio={server_args.mamba_full_memory_ratio})."
             )
 
-        # Adjunct is device-side prefix-cache metadata and must stay enabled
-        # under --disable-kvstore to match the non-L2 DeepSeek V4 path.
+        # Adjunct is device-side prefix-cache metadata and remains independent
+        # of the optional host tier selected by --disable-kvstore.
         self._flatkv_pd_enabled = bool(
             server_args.disaggregation_mode in ("prefill", "decode")
-            and getattr(token_to_kv_pool, "supports_disaggregation", False) is True
+            and token_to_kv_pool.supports_disaggregation
         )
         if self._flatkv_pd_enabled:
             unsupported = []
@@ -455,7 +456,7 @@ class EventLoop:
                     "FlatKV PD currently does not support: " + ", ".join(unsupported)
                 )
         validate_flat_scheduler_config(
-            flat_kvcache_ext=scheduler_ext_flat_kvcache(),
+            flat_kvcache_ext=flat_kvcache_ext,
             paged_cache_groups=paged_cache_groups,
             attn_backend=attn_backend,
             kv_pool=token_to_kv_pool,
@@ -507,6 +508,8 @@ class EventLoop:
             paged_cache_host_group_pages=paged_cache_host_group_pages,
             enable_mixed_prefill_decode=server_args.enable_mixed_batch,
             prefix_cache_adjunct=prefix_cache_adjunct,
+            scheduler_backend="flat" if flat_kvcache_ext else "radix",
+            compact_flat_block_tables=self.model_executor.compact_flat_block_tables,
         )
         scheduler_cfg.enable_flatkv_pd = self._flatkv_pd_enabled
         logger.info(
@@ -515,8 +518,9 @@ class EventLoop:
             "overlap_schedule_depth=%s disable_l2_cache=%s "
             "max_batch_size=%s (global max_num_seqs=%s, dp_size=%s) "
             "mamba_pool_total_chunks=%s enable_mamba=%s "
-            "disable_prefix_cache=%s paged_cache_groups=%s "
-            "paged_cache_host_group_pages=%s prefix_cache_adjunct_groups=%s",
+            "disable_prefix_cache=%s compact_flat_block_tables=%s "
+            "paged_cache_groups=%s paged_cache_host_group_pages=%s "
+            "prefix_cache_adjunct_groups=%s",
             scheduler_cfg.block_size,
             scheduler_cfg.num_device_pages,
             scheduler_cfg.num_host_pages,
@@ -530,6 +534,7 @@ class EventLoop:
             mamba_pool_total_chunks,
             has_mamba,
             scheduler_cfg.disable_prefix_cache,
+            scheduler_cfg.compact_flat_block_tables,
             [group.group_id for group in paged_cache_groups],
             paged_cache_host_group_pages,
             (

--- a/python/tokenspeed/runtime/engine/scheduler_utils.py
+++ b/python/tokenspeed/runtime/engine/scheduler_utils.py
@@ -42,6 +42,7 @@ from tokenspeed_scheduler import (
 )
 
 from tokenspeed.runtime.configs.flat_cache_runtime import require_positive_int
+from tokenspeed.runtime.configs.paged_cache_spec import scheduler_ext_flat_kvcache
 
 _CACHE_EVENT_TYPES = {
     "WriteBackDoneEvent": Cache.WriteBackDoneEvent,
@@ -84,42 +85,28 @@ def scheduler_cache_geometry_from_pool(
     fallback_token_capacity: int,
     fallback_page_size: int,
 ) -> SchedulerCacheGeometry:
-    contract = getattr(pool, "runtime_contract", None)
-    num_lcm_blocks = getattr(pool, "num_lcm_blocks", None)
-    if num_lcm_blocks is not None:
-        num_lcm_blocks = require_positive_int("num_lcm_blocks", num_lcm_blocks)
-        if contract is not None and contract.num_lcm_blocks != num_lcm_blocks:
-            raise ValueError("pool and runtime contract disagree on num_lcm_blocks")
+    """Resolve scheduler units from the pool's explicit Flat contract or Radix data.
+
+    Every cache pool publishes ``runtime_contract`` through the base interface;
+    Flat LCM pools provide a contract and Radix pools provide ``None``. Do not
+    infer the backend from unrelated optional geometry properties.
+    """
+
+    runtime_contract = pool.runtime_contract
+    if runtime_contract is not None:
+        num_lcm_blocks = require_positive_int(
+            "contract.num_lcm_blocks", runtime_contract.num_lcm_blocks
+        )
         return SchedulerCacheGeometry(
             page_size=require_positive_int(
-                "contract.block_size" if contract is not None else "fallback_page_size",
-                contract.block_size if contract is not None else fallback_page_size,
+                "contract.block_size", runtime_contract.block_size
             ),
             # Parent 0 is reserved as the null LCM block.
             num_device_pages=num_lcm_blocks + 1,
             num_usable_pages=num_lcm_blocks,
             token_capacity=require_positive_int(
-                (
-                    "contract.token_capacity"
-                    if contract is not None
-                    else "fallback_token_capacity"
-                ),
-                (
-                    contract.token_capacity
-                    if contract is not None
-                    else fallback_token_capacity
-                ),
+                "contract.token_capacity", runtime_contract.token_capacity
             ),
-        )
-    if contract is not None:
-        num_lcm_blocks = require_positive_int(
-            "contract.num_lcm_blocks", contract.num_lcm_blocks
-        )
-        return SchedulerCacheGeometry(
-            page_size=contract.block_size,
-            num_device_pages=num_lcm_blocks + 1,
-            num_usable_pages=num_lcm_blocks,
-            token_capacity=contract.token_capacity,
         )
     if fallback_page_size <= 0 or fallback_token_capacity <= 0:
         raise ValueError("fallback scheduler cache geometry must be positive")
@@ -136,13 +123,39 @@ def scheduler_cache_geometry_from_pool(
     )
 
 
-def resolve_scheduler_block_size(page_size: int, paged_cache_groups) -> int:
-    """Scheduler block_size = hash-grain BASE: gcd of group block sizes, not the KV page geometry."""
-    base = page_size
+def resolve_scheduler_block_size(
+    page_size: int,
+    paged_cache_groups,
+    *,
+    scheduler_backend: str | None = None,
+) -> int:
+    """Resolve the scheduler block grain without changing Radix page units.
+
+    Radix hashes, admission, and host/device page accounting share the physical
+    ``page_size`` ABI. FlatKV instead schedules heterogeneous group pages and
+    therefore uses the greatest common divisor of their raw-token spans.
+    """
+
+    page_size = require_positive_int("page_size", page_size)
+    if scheduler_backend is None:
+        scheduler_backend = "flat" if scheduler_ext_flat_kvcache() else "radix"
+    if scheduler_backend not in ("radix", "flat"):
+        raise ValueError(
+            f"scheduler_backend must be 'radix' or 'flat', got {scheduler_backend!r}"
+        )
+    if scheduler_backend == "radix":
+        return page_size
+
+    base = 0
     for group in paged_cache_groups or ():
-        gb = int(getattr(group, "block_size", 0) or 0) or page_size
-        base = math.gcd(base, gb)
-    return base
+        raw_group_size = group.block_size
+        group_size = (
+            page_size
+            if raw_group_size in (None, 0)
+            else require_positive_int("paged cache group block_size", raw_group_size)
+        )
+        base = math.gcd(base, group_size)
+    return base or page_size
 
 
 def aligned_max_scheduled_tokens(
@@ -220,12 +233,18 @@ def make_config(
     paged_cache_host_group_pages: Mapping[str, int] | None = None,
     enable_mixed_prefill_decode: bool = False,
     prefix_cache_adjunct: "PrefixCacheAdjunctSpec | None" = None,
+    scheduler_backend: str | None = None,
+    compact_flat_block_tables: bool = False,
 ) -> SchedulerConfig:
     cfg = SchedulerConfig()
     cfg.num_device_pages = num_device_pages
     cfg.max_scheduled_tokens = max_scheduled_tokens
     cfg.max_batch_size = max_batch_size
-    cfg.block_size = resolve_scheduler_block_size(page_size, paged_cache_groups)
+    cfg.block_size = resolve_scheduler_block_size(
+        page_size,
+        paged_cache_groups,
+        scheduler_backend=scheduler_backend,
+    )
 
     cfg.num_host_pages = num_host_pages
     cfg.enable_l3_storage = enable_l3_storage
@@ -249,6 +268,9 @@ def make_config(
     cfg.enable_mamba_l2 = enable_mamba_l2
     cfg.mamba_l2_host_slots = mamba_l2_host_slots
     cfg.enable_mixed_prefill_decode = enable_mixed_prefill_decode
+    # Explicit consumer capability. Legacy Flat backends index table columns
+    # absolutely; runtime-contract consumers carry canonical per-row bases.
+    cfg.compact_flat_block_tables = bool(compact_flat_block_tables)
     if paged_cache_groups:
         cfg.paged_cache_groups = list(paged_cache_groups)
     if paged_cache_host_group_pages:
@@ -264,7 +286,7 @@ def make_config(
 
 def pool_to_paged_cache_groups(pool: Any) -> list:
     """Convert authoritative contract specs, or legacy pool properties."""
-    contract = getattr(pool, "runtime_contract", None)
+    contract = pool.runtime_contract
     if contract is not None:
         specs = contract.group_specs
         counts = contract.group_page_counts
@@ -294,11 +316,9 @@ def pool_to_paged_cache_groups(pool: Any) -> list:
             total_pages=int(counts[spec.group_id]),
             retention=retention,
             family=family,
-            cache_blocks_per_lcm_block=int(
-                getattr(spec, "cache_blocks_per_lcm_block", 1)
-            ),
+            cache_blocks_per_lcm_block=int(spec.cache_blocks_per_lcm_block),
         )
-        transfer_policy = getattr(spec, "transfer_policy", None)
+        transfer_policy = spec.transfer_policy
         if transfer_policy is not None:
             mapped_policy = _TRANSFER_POLICY_MAP.get(transfer_policy)
             if mapped_policy is None:
@@ -311,7 +331,7 @@ def pool_to_paged_cache_groups(pool: Any) -> list:
             kwargs["sliding_window_tokens"] = int(spec.sliding_window_tokens)
         cfg = PagedCacheGroupConfig(**kwargs)
         # Ctor default 0 = global base; a spec block_size sets the per-group granularity.
-        if getattr(spec, "block_size", None):
+        if spec.block_size:
             cfg.block_size = int(spec.block_size)
         out.append(cfg)
     return out
@@ -535,17 +555,16 @@ def flat_block_tables_from_forward_op(
     expected_group_ids: tuple[str, ...] | None = None,
     max_page_id: int | None = None,
     max_page_ids: Mapping[str, int] | None = None,
-) -> dict[str, torch.Tensor]:
-    """Bridge the flat per-group block tables to GPU int32 tensors: absolute
-    page indices, null hole = 0 preserved, ragged-row padding -1. No
-    base-offset companion -- the flat path never compacts.
+    _include_base_offsets: bool = False,
+    _required_base_offset_group_ids: frozenset[str] = frozenset(),
+) -> dict[str, torch.Tensor] | tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
+    """Bridge flat per-group block tables to packed GPU int32 tensors.
 
-    All groups stage into ONE pinned buffer and ride ONE H2D copy; the
-    returned per-group views share a single storage, which is the
-    precondition of the backends' one-launch packed replay fill
-    (``_flat_try_packed_unpack``). Per-group uploads would fail its
-    same-storage check and fall back to per-group copy/fill chains
-    (~40 tiny transfers per decode step).
+    All groups stage into one pinned buffer and ride one H2D copy. Contract
+    callers may also include the scheduler's existing per-group paged-table
+    logical bases in that same allocation. This keeps compact Flat tables on
+    the canonical ``paged_cache_block_table_base_offsets`` seam instead of
+    introducing a parallel Flat-only field.
 
     Args:
         forward_op: Scheduler forward operation exporting CPU NumPy tables.
@@ -644,12 +663,55 @@ def flat_block_tables_from_forward_op(
             if max_page_ids is not None and group_max_page_id is None:
                 raise ValueError(f"max_page_ids is missing flat group {group_id!r}")
             if group_max_page_id is not None:
-                invalid = (arr < -1) | (arr > group_max_page_id)
-                if bool(invalid.any()):
+                min_page_id = int(arr.min())
+                max_seen_page_id = int(arr.max())
+                if min_page_id < -1 or max_seen_page_id > group_max_page_id:
                     raise ValueError(
                         f"flat group {group_id!r} contains a page ID outside "
                         f"-1..{group_max_page_id}"
                     )
+    base_arrays_by_id: dict[str, np.ndarray] = {}
+    if _include_base_offsets:
+        base_items = [
+            (str(group_id), value)
+            for group_id, value in forward_op.paged_cache_block_table_base_offsets_arrays().items()
+        ]
+        for group_id, base_array in base_items:
+            if group_id in base_arrays_by_id:
+                raise ValueError(
+                    "flat base-offset group keys collide after string "
+                    f"normalization: {group_id!r}"
+                )
+            if not isinstance(base_array, np.ndarray):
+                raise ValueError(
+                    f"flat group {group_id!r} base offsets must be a NumPy array"
+                )
+            if base_array.dtype != np.int32:
+                raise ValueError(f"flat group {group_id!r} base offsets must use int32")
+            if base_array.ndim != 1:
+                raise ValueError(
+                    f"flat group {group_id!r} base offsets have invalid shape"
+                )
+            if bool((base_array < 0).any()):
+                raise ValueError(
+                    f"flat group {group_id!r} contains a negative logical base"
+                )
+            base_arrays_by_id[group_id] = base_array
+        table_group_ids = {group_id for group_id, _ in ordered_items}
+        extra_base_groups = set(base_arrays_by_id).difference(table_group_ids)
+        if extra_base_groups:
+            raise ValueError(
+                "flat base-offset groups have no matching table: "
+                f"{sorted(extra_base_groups)}"
+            )
+        missing_required = _required_base_offset_group_ids.difference(base_arrays_by_id)
+        if missing_required:
+            raise ValueError(
+                "flat groups are missing logical base offsets required for "
+                "compact tables: "
+                f"{sorted(missing_required)}"
+            )
+
     device = torch.device(device) if isinstance(device, str) else device
     out: dict[str, torch.Tensor] = {}
     packable: list[tuple[str, Any, int]] = []
@@ -669,8 +731,30 @@ def flat_block_tables_from_forward_op(
             continue
         packable.append((key, arr, total))
         total += arr.shape[0] * arr.shape[1]
-    if not packable:
-        return out
+    base_spans: list[tuple[str, np.ndarray, int]] = []
+    if _include_base_offsets:
+        for group_id, arr in ordered_items:
+            rows = int(arr.shape[0])
+            bases = base_arrays_by_id.get(group_id)
+            if bases is None:
+                bases = np.zeros(rows, dtype=np.int32)
+            if bases.shape[0] != rows:
+                raise ValueError(
+                    "paged_cache_block_table_base_offsets_arrays"
+                    f"[{group_id}] has "
+                    f"{bases.shape[0]} rows but its table has {rows}"
+                )
+            if num_reqs is not None and bases.shape[0] != num_reqs:
+                raise ValueError(
+                    "paged_cache_block_table_base_offsets_arrays"
+                    f"[{group_id}] has "
+                    f"{bases.shape[0]} rows but forward op reported "
+                    f"num_reqs={num_reqs}"
+                )
+            base_spans.append((group_id, bases, total))
+            total += rows
+    if not packable and not base_spans:
+        return (out, {}) if _include_base_offsets else out
     # Fresh pinned stage per step (event-fenced; reuse races overlap).
     # arr is a read-only zero-copy view over the C++ buffer; np.copyto
     # reads it into our own writable pinned tensor (never writes back).
@@ -678,10 +762,46 @@ def flat_block_tables_from_forward_op(
     staged_np = staged.numpy()
     for key, arr, offset in packable:
         np.copyto(staged_np[offset : offset + arr.size].reshape(arr.shape), arr)
+    for _, bases, offset in base_spans:
+        np.copyto(staged_np[offset : offset + bases.size], bases)
     packed = staged.to(device, non_blocking=True)
     for key, arr, offset in packable:
         out[key] = packed[offset : offset + arr.size].view(arr.shape[0], arr.shape[1])
-    return out
+    if not _include_base_offsets:
+        return out
+    base_out = {
+        group_id: packed[offset : offset + bases.size]
+        for group_id, bases, offset in base_spans
+    }
+    return out, base_out
+
+
+def flat_cache_batch_from_forward_op(
+    forward_op: Any,
+    device: "torch.device | str",
+    *,
+    num_reqs: int,
+    expected_group_ids: tuple[str, ...],
+    max_page_ids: Mapping[str, int],
+    required_base_offset_group_ids: frozenset[str] = frozenset(),
+) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
+    """Pack one FlatKV table/base batch into a single device allocation.
+
+    Groups named in ``required_base_offset_group_ids`` must publish an exact
+    base. Other groups without an export receive a zero base view.
+    """
+
+    packed = flat_block_tables_from_forward_op(
+        forward_op,
+        device,
+        num_reqs=num_reqs,
+        expected_group_ids=expected_group_ids,
+        max_page_ids=max_page_ids,
+        _include_base_offsets=True,
+        _required_base_offset_group_ids=required_base_offset_group_ids,
+    )
+    assert isinstance(packed, tuple)
+    return packed
 
 
 def paged_cache_block_table_base_offsets_from_forward_op(

--- a/python/tokenspeed/runtime/execution/cache_loc_kernel.py
+++ b/python/tokenspeed/runtime/execution/cache_loc_kernel.py
@@ -256,6 +256,8 @@ def fused_decode_input_prep_kernel(
     seq_lens_out_ptr,  # [batch_size]
     # Scalars
     uniform_input_length,
+    dummy_kv_slot,
+    USE_DUMMY_CACHE_LOC: tl.constexpr,
     page_size: tl.constexpr,
     max_pages: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
@@ -269,8 +271,8 @@ def fused_decode_input_prep_kernel(
       torch.add(input_lengths, valid_cache_lengths, out=seq_lens)
 
     Each program handles one request. We do one GMEM read of
-    `valid_cache_lengths[pool_idx]` and reuse it for the seq_lens write,
-    the position writes, and the out_cache_loc page-table lookup.
+    `valid_cache_lengths[pool_idx]` and reuse it for the seq_lens and position
+    writes plus, in legacy scalar-location mode, the page-table lookup.
     """
     req_idx = tl.program_id(0)
     pool_idx = tl.load(req_pool_indices_ptr + req_idx)
@@ -288,17 +290,23 @@ def fused_decode_input_prep_kernel(
         mask = token_offsets < uniform_input_length
 
         positions_local = cache_start + token_offsets
-        page_indices = positions_local // page_size
-        overflow = page_indices >= max_pages
-        # Clamp to last valid page to avoid OOB GMEM read.
-        page_indices = tl.minimum(page_indices, max_pages - 1)
-        offsets_in_page = positions_local % page_size
+        if USE_DUMMY_CACHE_LOC:
+            # Group-keyed flat KV writers resolve their real destinations from
+            # per-group table/base metadata. The scalar location is a fixed
+            # compatibility sentinel, so do not touch the legacy page table.
+            cache_locs = tl.full((BLOCK_SIZE,), dummy_kv_slot, tl.int32)
+        else:
+            page_indices = positions_local // page_size
+            overflow = page_indices >= max_pages
+            # Clamp to last valid page to avoid OOB GMEM read.
+            page_indices = tl.minimum(page_indices, max_pages - 1)
+            offsets_in_page = positions_local % page_size
 
-        page_ptrs = req_to_pages_ptr + pool_idx * max_pages + page_indices
-        page_ids = tl.load(page_ptrs, mask=mask, other=0)
-        cache_locs = page_ids * page_size + offsets_in_page
-        # Route overflow tokens to slot 0 (fixed safe dummy target).
-        cache_locs = tl.where(overflow, 0, cache_locs)
+            page_ptrs = req_to_pages_ptr + pool_idx * max_pages + page_indices
+            page_ids = tl.load(page_ptrs, mask=mask, other=0)
+            cache_locs = page_ids * page_size + offsets_in_page
+            # Route overflow tokens to slot 0 (fixed safe dummy target).
+            cache_locs = tl.where(overflow, 0, cache_locs)
 
         tl.store(
             out_cache_loc_ptr + output_offset + token_offsets,
@@ -321,6 +329,9 @@ def fused_decode_input_prep(
     uniform_input_length: int,
     req_to_pages: torch.Tensor,  # [req_pool_size+1, max_pages]
     page_size: int,
+    *,
+    use_dummy_cache_loc: bool = False,
+    dummy_kv_slot: int = 0,
 ) -> None:
     """Decode-only fast path: one Triton launch writes out_cache_loc,
     positions, and seq_lens, reading `valid_cache_lengths[pool_idx]`
@@ -338,6 +349,8 @@ def fused_decode_input_prep(
         positions_ptr,
         seq_lens_out_ptr,
         uniform_input_length,
+        dummy_kv_slot,
+        USE_DUMMY_CACHE_LOC=use_dummy_cache_loc,
         page_size=page_size,
         max_pages=max_pages,
         BLOCK_SIZE=BLOCK_SIZE,

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -196,6 +196,8 @@ class CudaGraphWrapper:
         config: ModelExecutorConfig,
         draft_attn_backend: AttentionBackend | None = None,
         draft_token_to_kv_pool: BaseTokenToKVPool | None = None,
+        compact_flat_block_tables: bool = False,
+        use_flat_cache_tables: bool = False,
         drafter: BaseDrafter | None = None,
         capturable_grammar=None,
         eager_grammar_buffers=None,
@@ -207,6 +209,10 @@ class CudaGraphWrapper:
         self.draft_attn_backend = draft_attn_backend
         self.draft_token_to_kv_pool = draft_token_to_kv_pool
         self.token_to_kv_pool = token_to_kv_pool
+        self.compact_flat_block_tables = bool(compact_flat_block_tables)
+        self.use_flat_cache_tables = bool(
+            use_flat_cache_tables and attn_backend.uses_flat_cache_groups
+        )
         self.drafter = drafter
         self.sampling_backend = sampling_backend
         self.input_buffers = input_buffers
@@ -228,7 +234,7 @@ class CudaGraphWrapper:
             config.spec_num_tokens if config.spec_algo is not None else 1
         )
         self.overlap_schedule_depth = config.overlap_schedule_depth
-        self.use_v4_mtp_paged_metadata = config.use_v4_mtp_paged_metadata
+        self.use_target_verify_paged_metadata = config.use_target_verify_paged_metadata
         self.dp_size = config.data_parallel_size
         self.world_size = config.world_size
         self.disable = config.enforce_eager
@@ -618,7 +624,7 @@ class CudaGraphWrapper:
         """Group ids for flat per-group CUDA-graph capture: real tables only
         arrive at replay, so capture needs just the ids to allocate its
         persistent per-group buffers."""
-        if not getattr(self.attn_backend, "uses_flat_cache_groups", False):
+        if not self.use_flat_cache_tables:
             return ()
         return tuple(str(spec.group_id) for spec in pool.paged_cache_group_specs)
 
@@ -633,12 +639,15 @@ class CudaGraphWrapper:
         set by construction (same label vocabulary, same window). Older
         draft paths without a separate pool keep the full-history fallback.
         """
-        if self.draft_attn_backend is None or not getattr(
-            self.draft_attn_backend, "uses_flat_cache_groups", False
+        if (
+            not self.use_flat_cache_tables
+            or self.draft_attn_backend is None
+            or not self.draft_attn_backend.uses_flat_cache_groups
         ):
             return ()
-        if self.draft_token_to_kv_pool is not None and getattr(
-            self.draft_token_to_kv_pool, "paged_cache_group_specs", ()
+        if (
+            self.draft_token_to_kv_pool is not None
+            and self.draft_token_to_kv_pool.paged_cache_group_specs
         ):
             return tuple(
                 str(spec.group_id)
@@ -679,6 +688,8 @@ class CudaGraphWrapper:
         flat_cache_group_ids = self._flat_cache_group_ids(self.token_to_kv_pool)
         if flat_cache_group_ids:
             capture_kwargs["flat_cache_group_ids"] = flat_cache_group_ids
+        if self.compact_flat_block_tables:
+            capture_kwargs["compact_flat_block_tables"] = True
         self.attn_backend.init_forward_metadata_capture_cuda_graph(
             bs,
             self.input_buffers.req_pool_indices_buf[:bs],
@@ -704,6 +715,8 @@ class CudaGraphWrapper:
             draft_flat_ids = self._draft_flat_group_ids()
             if draft_flat_ids:
                 draft_kwargs["flat_cache_group_ids"] = draft_flat_ids
+            if self.compact_flat_block_tables:
+                draft_kwargs["compact_flat_block_tables"] = True
             # Drafter mutates seq_lens_buf in place per step; backends alias.
             self.draft_attn_backend.init_forward_metadata_capture_cuda_graph(
                 bs,
@@ -717,6 +730,8 @@ class CudaGraphWrapper:
         """Minimal per-group tables for the bs==0 idle replay: all rows are
         dummy rows, so one column of page-0 entries per group is valid.
         None when the pool publishes no groups."""
+        if not self.use_flat_cache_tables:
+            return None
         specs = tuple(self.token_to_kv_pool.paged_cache_group_specs)
         if not specs:
             return None
@@ -731,9 +746,10 @@ class CudaGraphWrapper:
         padded_bs: int,
         pad_value: int = -1,
     ) -> dict:
-        """Pad each table with dummy ROWS up to padded_bs. Flat passes
-        pad_value=0, radix/V4 keeps -1 — see the padding contract at the MHA
-        backend's replay guard (backends/mha.py).
+        """Pad each table with dummy rows up to ``padded_bs``.
+
+        Flat group tables pass ``pad_value=0``; legacy paged tables retain
+        ``-1`` according to the MHA replay padding contract.
         """
         if padded_bs <= actual_bs:
             return block_tables
@@ -796,6 +812,11 @@ class CudaGraphWrapper:
             "paged_cache_block_table_base_offsets", None
         )
         flat_block_tables = kwargs.pop("flat_block_tables", None)
+        draft_flat_cache_metadata = kwargs.pop(
+            "draft_flat_cache_metadata",
+            None,
+        )
+        flat_cache_forward_op = kwargs.get("flat_cache_forward_op")
         target_uses_paged_groups = getattr(
             self.attn_backend,
             "uses_paged_cache_groups",
@@ -832,9 +853,7 @@ class CudaGraphWrapper:
                     kwargs["paged_cache_block_table_base_offsets"] = (
                         paged_cache_block_table_base_offsets
                     )
-        if flat_block_tables is not None and getattr(
-            self.attn_backend, "uses_flat_cache_groups", False
-        ):
+        if flat_block_tables is not None and self.use_flat_cache_tables:
             flat_table_bs = next(
                 (
                     int(table.shape[0])
@@ -846,6 +865,10 @@ class CudaGraphWrapper:
             if getattr(self.attn_backend, "flat_tables_self_padding", False):
                 # Backend pads dummy rows itself; F.pad would reallocate tables and break storage sharing.
                 kwargs["flat_block_tables"] = flat_block_tables
+                if paged_cache_block_table_base_offsets is not None:
+                    kwargs["paged_cache_block_table_base_offsets"] = (
+                        paged_cache_block_table_base_offsets
+                    )
             else:
                 kwargs["flat_block_tables"] = self._pad_block_tables_to_padded_bs(
                     flat_block_tables,
@@ -853,6 +876,14 @@ class CudaGraphWrapper:
                     padded_bs=padded_bs,
                     pad_value=0,
                 )
+                if paged_cache_block_table_base_offsets is not None:
+                    kwargs["paged_cache_block_table_base_offsets"] = (
+                        self._pad_offsets_to_padded_bs(
+                            paged_cache_block_table_base_offsets,
+                            actual_bs=actual_bs,
+                            padded_bs=padded_bs,
+                        )
+                    )
         if self.attn_backend.uses_padded_decode_token_mask:
             kwargs["actual_bs"] = actual_bs
         if target_uses_paged_groups and getattr(self, "drafter", None) is not None:
@@ -875,9 +906,23 @@ class CudaGraphWrapper:
                     )
             if getattr(self.draft_attn_backend, "uses_padded_decode_token_mask", False):
                 draft_attn_kwargs["actual_bs"] = actual_bs
-            draft_flat = self._draft_flat_tables(kwargs.get("flat_block_tables"))
-            if draft_flat is not None:
-                draft_attn_kwargs["flat_block_tables"] = draft_flat
+            if draft_flat_cache_metadata is not None:
+                draft_attn_kwargs["flat_cache_metadata"] = draft_flat_cache_metadata
+                draft_attn_kwargs["flat_cache_forward_op"] = flat_cache_forward_op
+                draft_attn_kwargs["flat_block_tables"] = (
+                    draft_flat_cache_metadata.tables(
+                        active_forward_op=flat_cache_forward_op
+                    )
+                )
+                draft_attn_kwargs["paged_cache_block_table_base_offsets"] = (
+                    draft_flat_cache_metadata.base_offsets(
+                        active_forward_op=flat_cache_forward_op
+                    )
+                )
+            else:
+                draft_flat = self._draft_flat_tables(kwargs.get("flat_block_tables"))
+                if draft_flat is not None:
+                    draft_attn_kwargs["flat_block_tables"] = draft_flat
             draft_forward_mode = ForwardMode.DECODE
             if draft_uses_paged_groups:
                 draft_attn_kwargs["num_tokens"] = padded_bs * self.max_tokens_per_req
@@ -904,6 +949,11 @@ class CudaGraphWrapper:
         **kwargs,
     ):
         """Eager path — allocate/refresh metadata for the upcoming forward."""
+        draft_flat_cache_metadata = kwargs.pop(
+            "draft_flat_cache_metadata",
+            None,
+        )
+        flat_cache_forward_op = kwargs.get("flat_cache_forward_op")
         if (
             getattr(self.attn_backend, "uses_paged_cache_groups", False)
             and self.drafter is not None
@@ -929,31 +979,41 @@ class CudaGraphWrapper:
                     value = kwargs.get(key)
                     if value is not None:
                         draft_kwargs[key] = value
-            draft_flat = self._draft_flat_tables(kwargs.get("flat_block_tables"))
-            if draft_flat is not None:
-                draft_kwargs["flat_block_tables"] = draft_flat
+            if draft_flat_cache_metadata is not None:
+                draft_kwargs["flat_cache_metadata"] = draft_flat_cache_metadata
+                draft_kwargs["flat_cache_forward_op"] = flat_cache_forward_op
+                draft_kwargs["flat_block_tables"] = draft_flat_cache_metadata.tables(
+                    active_forward_op=flat_cache_forward_op
+                )
+                draft_kwargs["paged_cache_block_table_base_offsets"] = (
+                    draft_flat_cache_metadata.base_offsets(
+                        active_forward_op=flat_cache_forward_op
+                    )
+                )
+            else:
+                draft_flat = self._draft_flat_tables(kwargs.get("flat_block_tables"))
+                if draft_flat is not None:
+                    draft_kwargs["flat_block_tables"] = draft_flat
 
             # The drafter mutates draft_seq_lens_buf between MTP draft steps;
             # decode metadata must alias that buffer.
             draft_seq_lens = self.drafter.draft_seq_lens_buf[:padded_bs]
             draft_seq_lens.copy_(seq_lens[:padded_bs])
             if forward_mode.is_extend_or_mixed():
-                # Non-V4 draft backends follow the legacy contract: a single
+                # Ordinary draft backends use one
                 # EXTEND/MIXED metadata init fills both first-step prefill
                 # metadata and step 1+ decode metadata, with seq_lens aliased
-                # to the drafter-owned mutable buffer. V4 additionally needs
-                # the accepted-prefix view for first-step grouped-cache
-                # metadata, then a separate decode init to prepare the draft
-                # decode metadata from that first-step state.
+                # to the drafter-owned mutable buffer. Target-verify backends
+                # need the accepted-prefix view for first-step grouped-cache
+                # metadata, then a separate decode init for later draft steps.
                 draft_prefill_seq_lens = (
-                    seq_lens if self.use_v4_mtp_paged_metadata else draft_seq_lens
+                    seq_lens
+                    if self.use_target_verify_paged_metadata
+                    else draft_seq_lens
                 )
-                # Drafter consumes its own groups' tables (see _draft_flat_tables).
-                draft_extend_kwargs = (
-                    {**kwargs, "flat_block_tables": draft_flat}
-                    if kwargs.get("flat_block_tables") is not None
-                    else kwargs
-                )
+                # Replace target-owned group views with the draft projection
+                # while retaining model-agnostic batch metadata.
+                draft_extend_kwargs = {**kwargs, **draft_kwargs}
                 self.draft_attn_backend.init_forward_metadata(
                     bs=padded_bs,
                     num_extends=num_extends,
@@ -963,7 +1023,7 @@ class CudaGraphWrapper:
                     forward_mode=forward_mode,
                     **draft_extend_kwargs,
                 )
-                if self.use_v4_mtp_paged_metadata:
+                if self.use_target_verify_paged_metadata:
                     self.draft_attn_backend.init_forward_metadata(
                         bs=padded_bs,
                         num_extends=0,
@@ -979,7 +1039,9 @@ class CudaGraphWrapper:
                 if isinstance(self.drafter, DFlash):
                     return
                 draft_metadata_seq_lens = (
-                    seq_lens if self.use_v4_mtp_paged_metadata else draft_seq_lens
+                    seq_lens
+                    if self.use_target_verify_paged_metadata
+                    else draft_seq_lens
                 )
                 draft_forward_mode = ForwardMode.DECODE
                 if getattr(self.draft_attn_backend, "uses_paged_cache_groups", False):
@@ -1085,6 +1147,7 @@ class CudaGraphWrapper:
         paged_cache_block_table_base_offsets: dict | None = None,
         flat_block_tables: dict | None = None,
         flat_cache_metadata=None,
+        draft_flat_cache_metadata=None,
         flat_cache_forward_op=None,
     ):
         """
@@ -1094,6 +1157,19 @@ class CudaGraphWrapper:
         eager forward_func otherwise.  The caller does not need to know which
         path was taken.
         """
+        if flat_cache_metadata is not None:
+            if flat_cache_forward_op is None:
+                raise RuntimeError(
+                    "Flat cache metadata requires its active forward operation"
+                )
+            # Bind one operation-provenanced target view. Tables and canonical
+            # paged logical bases share the metadata's single packed transfer.
+            flat_block_tables = flat_cache_metadata.tables(
+                active_forward_op=flat_cache_forward_op
+            )
+            paged_cache_block_table_base_offsets = flat_cache_metadata.base_offsets(
+                active_forward_op=flat_cache_forward_op
+            )
         use_graph = self._can_use_graph(bs, ctx)
         padded_bs = self._padded_bs(bs, ctx) if use_graph else bs
         active_req_pool_indices = self.input_buffers.req_pool_indices_buf[:bs]
@@ -1151,6 +1227,7 @@ class CudaGraphWrapper:
         flat_kwargs = (
             {
                 "flat_cache_metadata": flat_cache_metadata,
+                "draft_flat_cache_metadata": draft_flat_cache_metadata,
                 "flat_cache_forward_op": flat_cache_forward_op,
             }
             if flat_cache_metadata is not None
@@ -1169,11 +1246,7 @@ class CudaGraphWrapper:
                 )
             # The backend's stale-table guard also covers the bs==0 idle
             # replay: synthesize minimal valid tables for it.
-            if (
-                bs == 0
-                and not flat_block_tables
-                and getattr(self.attn_backend, "uses_flat_cache_groups", False)
-            ):
+            if bs == 0 and not flat_block_tables and self.use_flat_cache_tables:
                 flat_block_tables = self._idle_flat_block_tables(padded_bs)
             self._init_replay_metadata(
                 padded_bs,
@@ -1226,7 +1299,7 @@ class CudaGraphWrapper:
                 bs > 0
                 and not ctx.forward_mode.is_idle()
                 and not flat_block_tables
-                and getattr(self.attn_backend, "uses_flat_cache_groups", False)
+                and self.use_flat_cache_tables
                 and len(self.token_to_kv_pool.paged_cache_group_specs) > 1
             ):
                 raise RuntimeError(
@@ -1271,9 +1344,7 @@ class CudaGraphWrapper:
                     else None
                 ),
                 flat_block_tables=(
-                    flat_block_tables
-                    if self.attn_backend.uses_flat_cache_groups
-                    else None
+                    flat_block_tables if self.use_flat_cache_tables else None
                 ),
                 **flat_kwargs,
                 **mamba_kwargs,

--- a/python/tokenspeed/runtime/execution/drafter/dflash.py
+++ b/python/tokenspeed/runtime/execution/drafter/dflash.py
@@ -118,6 +118,12 @@ class DFlash(BaseDrafter):
     def _init_native_buffers(self) -> None:
         if self.input_buffers is None:
             raise ValueError("Native DFLASH requires input buffers.")
+        if self.input_buffers.uses_group_keyed_cache_locs:
+            raise RuntimeError(
+                "DFLASH does not support group-keyed flat cache locations; "
+                "a scalar req_to_page/out_cache_loc cannot represent the "
+                "draft owner's per-group page domains"
+            )
         if self.req_to_page is None:
             raise ValueError("Native DFLASH requires req_to_page.")
         if self.attn_backend is None or self.token_to_kv_pool is None:

--- a/python/tokenspeed/runtime/execution/drafter/eagle.py
+++ b/python/tokenspeed/runtime/execution/drafter/eagle.py
@@ -119,8 +119,9 @@ class Eagle(BaseDrafter):
         self.draft_seq_lens_buf = torch.zeros_like(self.input_buffers.seq_lens_buf)
 
         # Persistent output buffer for the draft step's compute_out_cache_loc.
-        self.draft_out_cache_loc_buf = torch.empty(
+        self.draft_out_cache_loc_buf = torch.full(
             (self.input_buffers.max_bs * (spec_num_steps - 1),),
+            self.input_buffers.dummy_kv_slot,
             dtype=torch.int32,
             device=self.device,
         )
@@ -135,7 +136,9 @@ class Eagle(BaseDrafter):
             - 1
         )
 
-        # VLM placeholder ids plumbed by ModelExecutor; empty for text-only targets.
+        # In-vocab media tokens plumbed by ModelExecutor. The content-derived
+        # prefix-cache pad IDs retain a modality tag and are restored here before
+        # the text-only speculative draft performs its embedding lookup.
         self.mm_pad_substitute_ids: dict[Modality, int] = {}
         hf_config = getattr(draft_model_runner.model_config, "hf_config", None)
         self._dsa_reuse_mtp_topk = bool(
@@ -365,14 +368,18 @@ class Eagle(BaseDrafter):
 
         # Write cache slots for steps 1..N-1.
         cache_locs = self.draft_out_cache_loc_buf[: bs * (self.spec_num_steps - 1)]
-        compute_out_cache_loc_uniform(
-            out_cache_loc_ptr=cache_locs,
-            req_pool_indices=req_pool_indices,
-            uniform_input_length=self.spec_num_steps - 1,
-            cache_start=cache_start,
-            req_to_pages=self.req_to_page,
-            page_size=self.page_size,
-        )
+        if not self.input_buffers.uses_group_keyed_cache_locs:
+            compute_out_cache_loc_uniform(
+                out_cache_loc_ptr=cache_locs,
+                req_pool_indices=req_pool_indices,
+                uniform_input_length=self.spec_num_steps - 1,
+                cache_start=cache_start,
+                req_to_pages=self.req_to_page,
+                page_size=self.page_size,
+            )
+        # Group-keyed flat draft writes are resolved by already-initialized
+        # owner-local metadata. Their persistent scalar buffer remains the
+        # page-0 sentinel installed at construction, avoiding a per-step fill.
         cache_locs = cache_locs.view(bs, self.spec_num_steps - 1)
         # +1 is the kernel's read-inclusive convention; advanced per iter.
         draft_seq_lens = self.draft_seq_lens_buf[:bs]

--- a/python/tokenspeed/runtime/execution/drafter/mtp.py
+++ b/python/tokenspeed/runtime/execution/drafter/mtp.py
@@ -342,8 +342,9 @@ class Mtp(BaseDrafter):
         self.draft_seq_lens_buf = torch.zeros_like(self.input_buffers.seq_lens_buf)
 
         # Persistent output buffer for the draft step's compute_out_cache_loc.
-        self.draft_out_cache_loc_buf = torch.empty(
+        self.draft_out_cache_loc_buf = torch.full(
             (self.input_buffers.max_bs * (spec_num_steps - 1),),
+            self.input_buffers.dummy_kv_slot,
             dtype=torch.int32,
             device=self.device,
         )
@@ -707,14 +708,15 @@ class Mtp(BaseDrafter):
         ).clamp_min(0)
         step_positions = torch.cat([lb_positions, positions.view(bs, k)], 1).reshape(-1)
         lb_cache_loc = self.draft_out_cache_loc_buf[: bs * lb]
-        compute_out_cache_loc_uniform(
-            out_cache_loc_ptr=lb_cache_loc,
-            req_pool_indices=buffers.req_pool_indices_buf[:bs],
-            uniform_input_length=lb,
-            cache_start=(first_pos - lb).clamp_min(0).to(torch.int32),
-            req_to_pages=self.req_to_page,
-            page_size=self.page_size,
-        )
+        if not self.input_buffers.uses_group_keyed_cache_locs:
+            compute_out_cache_loc_uniform(
+                out_cache_loc_ptr=lb_cache_loc,
+                req_pool_indices=buffers.req_pool_indices_buf[:bs],
+                uniform_input_length=lb,
+                cache_start=(first_pos - lb).clamp_min(0).to(torch.int32),
+                req_to_pages=self.req_to_page,
+                page_size=self.page_size,
+            )
         out_cache_loc = torch.cat(
             [
                 lb_cache_loc.view(bs, lb),

--- a/python/tokenspeed/runtime/execution/input_buffer.py
+++ b/python/tokenspeed/runtime/execution/input_buffer.py
@@ -56,6 +56,7 @@ class InputBuffers:
         state_write_padding_pool_index: int,
         device: str = "cuda",
         has_mamba: bool = False,
+        uses_group_keyed_cache_locs: bool = False,
     ):
         self.device = device
         self.page_size = page_size
@@ -65,6 +66,7 @@ class InputBuffers:
         self.max_bs = max_bs
         self.all_extends_mid_chunk = False
         self.has_mamba = has_mamba
+        self.uses_group_keyed_cache_locs = uses_group_keyed_cache_locs
 
         with torch.device(device):
             # Initialise buffers to the *padding* values the captured graph
@@ -268,24 +270,28 @@ class InputBuffers:
                 uniform_input_length=total_tokens // batch_size,
                 req_to_pages=req_to_page,
                 page_size=self.page_size,
+                use_dummy_cache_loc=self.uses_group_keyed_cache_locs,
+                dummy_kv_slot=self.dummy_kv_slot,
             )
             # Decode path's seq_lens / positions / out_cache_loc are done.
             valid_cache_lengths = None
         else:
-            # Mixed / pure-prefill: keep the per-kernel pipeline. indexSelect
-            # for valid_cache_lengths is required because compute_position and
-            # the seq_lens add use it.
+            # Mixed / pure-prefill keep the per-kernel position pipeline. A
+            # group-keyed cache has no scalar page domain: its persistent
+            # out_cache_loc is already the page-0 sentinel, while every real KV
+            # writer consumes table/base metadata from the attention backend.
             valid_cache_lengths = runtime_states.valid_cache_lengths.index_select(
                 0, req_pool_indices_device
             )
-            compute_out_cache_loc(
-                out_cache_loc_ptr=self.out_cache_loc_buf[:total_tokens],
-                req_pool_indices=req_pool_indices_device,
-                input_lengths=input_lengths_device,
-                cache_start=valid_cache_lengths,
-                req_to_pages=req_to_page,
-                page_size=self.page_size,
-            )
+            if not self.uses_group_keyed_cache_locs:
+                compute_out_cache_loc(
+                    out_cache_loc_ptr=self.out_cache_loc_buf[:total_tokens],
+                    req_pool_indices=req_pool_indices_device,
+                    input_lengths=input_lengths_device,
+                    cache_start=valid_cache_lengths,
+                    req_to_pages=req_to_page,
+                    page_size=self.page_size,
+                )
 
             # Compute positions. In mixed batches, prefill rows use their extend
             # prefix lengths while decode rows use the current valid cache lengths.
@@ -399,7 +405,8 @@ class InputBuffers:
         # (cheap tail-only fills; the active prefix was written above).
         if total_tokens < self.max_num_tokens:
             self.input_ids_buf[total_tokens:].fill_(1)
-            self.out_cache_loc_buf[total_tokens:].fill_(self.dummy_kv_slot)
+            if not self.uses_group_keyed_cache_locs:
+                self.out_cache_loc_buf[total_tokens:].fill_(self.dummy_kv_slot)
             self.positions_buf[total_tokens:].fill_(0)
             self.mrope_positions_buf[:, total_tokens:].zero_()
         if batch_size < self.max_bs:
@@ -462,7 +469,8 @@ class InputBuffers:
         """Prepare padded decode graph inputs for a rank with no real tokens."""
         if total_tokens > 0:
             self.input_ids_buf[:total_tokens].fill_(1)
-            self.out_cache_loc_buf[:total_tokens].fill_(self.dummy_kv_slot)
+            if not self.uses_group_keyed_cache_locs:
+                self.out_cache_loc_buf[:total_tokens].fill_(self.dummy_kv_slot)
             self.positions_buf[:total_tokens].fill_(0)
             self.mrope_positions_buf[:, :total_tokens].zero_()
         if batch_size > 0:

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -31,6 +31,7 @@ from tokenspeed_kernel.platform import current_platform
 
 from tokenspeed.runtime.configs.model_config import ModelConfig
 from tokenspeed.runtime.configs.paged_cache_spec import (
+    legacy_flat_loc_group_id,
     scheduler_ext_flat_kvcache,
     validate_flat_scheduler_config,
 )
@@ -59,6 +60,7 @@ from tokenspeed.runtime.execution.types import ModelExecutionResult
 from tokenspeed.runtime.grammar.capturable_grammar import setup_grammar_step
 from tokenspeed.runtime.layers.attention.backends.flat_cache_metadata import (
     FlatCacheBatchMetadata,
+    resolve_flat_runtime_contracts,
 )
 from tokenspeed.runtime.layers.logits_processor import LogitsProcessorOutput
 from tokenspeed.runtime.layers.paged_attention import (
@@ -97,7 +99,7 @@ def _get_drafter_impl(spec_algo: str, model: torch.nn.Module):
     DRAFTER_MAPPING = {"EAGLE3": Eagle, "MTP": Eagle, "DFLASH": DFlash}
 
     # "MTP" covers two algorithms:
-    # (1) Eagle-like MTP (e.g. DeepSeek) stays on Eagle in eagle.py;
+    # (1) Eagle-like MTP stays on Eagle in eagle.py;
     # (2) Vanilla MTP (e.g. Inkling) with multi-layer weights stays on Mtp in mtp.py.
     if spec_algo == "MTP" and isinstance(model, InklingForConditionalGenerationNextN):
         return Mtp
@@ -185,7 +187,7 @@ class ModelExecutorConfig:
     overlap_schedule_depth: int = 0
     dp_sampling: bool = False
     dp_sampling_min_bs: int | None = None
-    use_v4_mtp_paged_metadata: bool = False
+    use_target_verify_paged_metadata: bool = False
 
     # ====== GRAMMAR =========
     # "none" disables all grammar handling; otherwise the backend name
@@ -252,7 +254,9 @@ class ModelExecutorConfig:
             dp_sampling=server_args.dp_sampling,
             dp_sampling_min_bs=server_args.dp_sampling_min_bs,
             enable_nan_detection=server_args.enable_nan_detection,
-            use_v4_mtp_paged_metadata=model_config.use_v4_mtp_paged_metadata,
+            use_target_verify_paged_metadata=(
+                model_config.use_target_verify_paged_metadata
+            ),
             grammar_backend=server_args.grammar_backend,
             disable_capturable_grammar=server_args.disable_capturable_grammar,
         )
@@ -281,24 +285,57 @@ class ModelExecutor:
         self.sampling_backend = sampling_backend
         self.attn_backend = attn_backend
         self.token_to_kv_pool = token_to_kv_pool
-        # FlatKV contract pools publish a runtime
-        # contract; on that path per-step tables travel as
-        # FlatCacheBatchMetadata and the legacy req_to_page mirror is
-        # forbidden.
-        self._flat_runtime_contract = getattr(
-            token_to_kv_pool, "runtime_contract", None
+        flat_kvcache_ext = scheduler_ext_flat_kvcache()
+        # Bind the scheduler transport once. Backend capability describes what
+        # a backend can consume; it does not select Radix versus Flat for this
+        # executor instance.
+        self._use_flat_cache_tables = bool(flat_kvcache_ext)
+        (
+            self._flat_runtime_contract,
+            active_draft_runtime_contract,
+            self.compact_flat_block_tables,
+        ) = resolve_flat_runtime_contracts(
+            target_pool=token_to_kv_pool,
+            target_backend=attn_backend,
+            draft_pool=draft_token_to_kv_pool,
+            draft_backend=draft_attn_backend,
+            flat_kvcache_ext=flat_kvcache_ext,
         )
-        # Full-attention group mirrored into req_to_page each step (flat+spec).
-        _group_specs = getattr(token_to_kv_pool, "paged_cache_group_specs", ()) or ()
-        self._flat_full_group_id = next(
-            (
-                str(spec.group_id)
-                for spec in _group_specs
-                if getattr(spec, "family", "history") != "state"
-                and getattr(spec, "retention", None) == "full_history"
-            ),
-            None,
+        self._flat_target_group_ids = (
+            tuple(
+                str(spec.group_id) for spec in self._flat_runtime_contract.group_specs
+            )
+            if self._flat_runtime_contract is not None
+            else ()
         )
+        self._flat_draft_group_ids = (
+            tuple(
+                str(spec.group_id) for spec in active_draft_runtime_contract.group_specs
+            )
+            if active_draft_runtime_contract is not None
+            else ()
+        )
+        self._uses_group_keyed_cache_locs = self._flat_runtime_contract is not None
+        _group_specs = token_to_kv_pool.paged_cache_group_specs
+        self._legacy_flat_loc_group_id = (
+            None
+            if self._uses_group_keyed_cache_locs
+            else legacy_flat_loc_group_id(
+                _group_specs,
+                legacy_page_size=config.logical_page_size,
+            )
+        )
+        if (
+            flat_kvcache_ext
+            and config.spec_algo is not None
+            and not self._uses_group_keyed_cache_locs
+            and self._legacy_flat_loc_group_id is None
+        ):
+            raise RuntimeError(
+                "legacy Flat speculative cache locations require exactly one "
+                "stride-1 full-history group whose block span is compatible "
+                "with the scalar req_to_page page size"
+            )
         self._mirror_idx_cpu: torch.Tensor | None = None
         self._mirror_idx_dev: torch.Tensor | None = None
         self._mirror_row_buf: torch.Tensor | None = None
@@ -310,14 +347,17 @@ class ModelExecutor:
         # (e.g. spec on a backend without flat_spec_capable) would otherwise
         # die on a capture-path assert instead of this actionable error.
         validate_flat_scheduler_config(
-            flat_kvcache_ext=scheduler_ext_flat_kvcache(),
+            flat_kvcache_ext=flat_kvcache_ext,
             paged_cache_groups=_group_specs,
             attn_backend=attn_backend,
             kv_pool=token_to_kv_pool,
             speculative_algorithm=config.spec_algo,
         )
 
-        if config.spec_algo is not None:
+        if self._uses_group_keyed_cache_locs:
+            # Contract consumers never dereference the radix scalar table.
+            max_num_pages_per_req = 1
+        elif config.spec_algo is not None:
             # The DFLASH overlap scheduler reserves a fresh draft block per
             # decode step a request stays scheduled, including the few steps it
             # lingers between finishing and eviction, so peak page count runs
@@ -368,6 +408,7 @@ class ModelExecutor:
             state_write_padding_pool_index=config.max_req_pool_size,
             device=self.device,
             has_mamba=(mamba_pool is not None),
+            uses_group_keyed_cache_locs=self._uses_group_keyed_cache_locs,
         )
         self.runtime_states = RuntimeStates(
             req_pool_size=config.max_req_pool_size,
@@ -562,6 +603,8 @@ class ModelExecutor:
             drafter=self.drafter,
             draft_attn_backend=draft_attn_backend,
             draft_token_to_kv_pool=draft_token_to_kv_pool,
+            compact_flat_block_tables=self.compact_flat_block_tables,
+            use_flat_cache_tables=self._use_flat_cache_tables,
             capturable_grammar=self.capturable_grammar,
             eager_grammar_buffers=self.eager_grammar_buffers,
             sampling_backend=self.sampling_backend,
@@ -583,6 +626,8 @@ class ModelExecutor:
             input_buffers=self.input_buffers,
             config=config,
             req_to_page=self.req_to_page,
+            compact_flat_block_tables=self.compact_flat_block_tables,
+            use_flat_cache_tables=self._use_flat_cache_tables,
             drafter=self.drafter,
             decode_wrapper=self.forward_step,
         )
@@ -698,7 +743,7 @@ class ModelExecutor:
     def _mirror_flat_full_table_into_req_to_page(
         self, forward_op, flat_block_tables
     ) -> None:
-        """Flat + spec: scatter the full-attention group's per-batch table
+        """Flat + spec: scatter the validated history group's per-batch table
         into req_to_page rows, restoring the radix contract for every
         legacy consumer (input prep's out_cache_loc kernels, the drafter's
         per-step location chains). The flat scheduler never populates
@@ -709,15 +754,18 @@ class ModelExecutor:
         req_to_page would resurrect the forbidden legacy path.
         """
         if (
-            self._flat_runtime_contract is not None
-            or self.drafter is None
+            self.drafter is None
             or not flat_block_tables
-            or self._flat_full_group_id is None
+            or self._legacy_flat_loc_group_id is None
         ):
             return
-        table = flat_block_tables.get(self._flat_full_group_id)
+        table = flat_block_tables.get(self._legacy_flat_loc_group_id)
         if table is None:
-            return
+            raise RuntimeError(
+                "legacy Flat req_to_page mirror is missing its validated group "
+                f"{self._legacy_flat_loc_group_id!r}; delivered groups="
+                f"{sorted(flat_block_tables)}"
+            )
         bs = len(forward_op.request_pool_indices)
         if self._mirror_idx_cpu is None or self._mirror_idx_cpu.shape[0] < bs:
             cap = max(bs, self.input_buffers.max_bs)
@@ -732,6 +780,12 @@ class ModelExecutor:
         idx = self._mirror_idx_dev[:bs]
         width = table.shape[1]
         max_width = self.req_to_page.shape[1]
+        if width > max_width:
+            raise RuntimeError(
+                "legacy Flat mirror table exceeds req_to_page width: "
+                f"group={self._legacy_flat_loc_group_id!r}, "
+                f"table_width={width}, req_to_page_width={max_width}"
+            )
         if self._mirror_row_buf is None:
             self._mirror_row_buf = torch.zeros(
                 (self.input_buffers.max_bs, max_width),
@@ -1798,21 +1852,32 @@ class ModelExecutor:
             # Outside the graph: in-graph sites only OR into the flag buffer.
             self.nan_guard.reset(bs)
             flat_cache_metadata = None
+            draft_flat_cache_metadata = None
             if self._flat_runtime_contract is not None and bs > 0:
                 # FlatKV contract path: validate + pack the per-group tables
                 # once, bound to this forward operation. The MLA backend
                 # consumes the full-attention table through this bridge;
                 # req_to_page is never populated.
-                flat_cache_metadata = FlatCacheBatchMetadata.from_forward_op(
+                scheduler_flat_metadata = FlatCacheBatchMetadata.from_forward_op(
                     forward_op,
                     device=self.device,
                     contract=self._flat_runtime_contract,
                     num_requests=bs,
+                    compact_tables=self.compact_flat_block_tables,
                 )
-                flat_block_tables = dict(
-                    flat_cache_metadata.tables(active_forward_op=forward_op)
+                flat_cache_metadata = scheduler_flat_metadata.for_groups(
+                    self._flat_target_group_ids,
+                    owner="target",
                 )
-            else:
+                if self._flat_draft_group_ids:
+                    draft_flat_cache_metadata = scheduler_flat_metadata.for_groups(
+                        self._flat_draft_group_ids,
+                        owner="draft",
+                    )
+                # CudaGraphWrapper binds the operation-provenanced target and
+                # draft views exactly once at the eager/replay boundary.
+                flat_block_tables = None
+            elif self._use_flat_cache_tables:
                 # Mirror the full group's flat table into req_to_page
                 # (flat+spec legacy consumers only).
                 flat_block_tables = flat_block_tables_from_forward_op(
@@ -1823,6 +1888,10 @@ class ModelExecutor:
                 self._mirror_flat_full_table_into_req_to_page(
                     forward_op, flat_block_tables
                 )
+            else:
+                # A dual-capable backend still consumes the Radix paged-table
+                # transport when paired with a Radix scheduler build.
+                flat_block_tables = None
             decode_input_ids = self.input_buffers.fill_input_buffers(
                 forward_op=forward_op,
                 runtime_states=self.runtime_states,
@@ -1997,20 +2066,27 @@ class ModelExecutor:
                         if self.input_buffers.has_mamba
                         else {}
                     )
-                    paged_cache_block_tables = paged_cache_block_tables_from_forward_op(
-                        forward_op,
-                        device=self.device,
-                        num_reqs=bs,
-                    )
-                    # flat_block_tables computed once in pre_fill above.
-                    (
-                        paged_cache_block_table_base_offsets,
-                        _paged_cache_block_table_base_offset_max,
-                    ) = paged_cache_block_table_base_offsets_from_forward_op(
-                        forward_op,
-                        device=self.device,
-                        num_reqs=bs,
-                    )
+                    if flat_cache_metadata is None:
+                        paged_cache_block_tables = (
+                            paged_cache_block_tables_from_forward_op(
+                                forward_op,
+                                device=self.device,
+                                num_reqs=bs,
+                            )
+                        )
+                        (
+                            paged_cache_block_table_base_offsets,
+                            _paged_cache_block_table_base_offset_max,
+                        ) = paged_cache_block_table_base_offsets_from_forward_op(
+                            forward_op,
+                            device=self.device,
+                            num_reqs=bs,
+                        )
+                    else:
+                        # Contract tables and their canonical paged logical
+                        # bases already share one packed H2D allocation.
+                        paged_cache_block_tables = None
+                        paged_cache_block_table_base_offsets = None
                     self._log_dp_sampling_route(bs, ctx)
                     forward_step_start = 0.0
                     if timing_enabled:
@@ -2045,6 +2121,7 @@ class ModelExecutor:
                         ),
                         flat_block_tables=flat_block_tables,
                         flat_cache_metadata=flat_cache_metadata,
+                        draft_flat_cache_metadata=draft_flat_cache_metadata,
                         flat_cache_forward_op=(
                             forward_op if flat_cache_metadata is not None else None
                         ),

--- a/python/tokenspeed/runtime/execution/prefill_graph.py
+++ b/python/tokenspeed/runtime/execution/prefill_graph.py
@@ -205,6 +205,10 @@ class PrefillGraph:
         input_buffers: The shared static input buffers the graphs read from.
         config: Model-executor config (buckets, DP/world topology, device).
         req_to_page: Request page table; row 0 backs the dummy capture request.
+        compact_flat_block_tables: Whether capture metadata uses compact tables
+            with exact logical bases instead of legacy absolute tables.
+        use_flat_cache_tables: Whether this executor instance receives the
+            Flat scheduler's grouped-table transport.
         drafter: If present, aux-hidden capture (EAGLE3/MTP) is baked into the
             captured graphs.
     """
@@ -217,6 +221,8 @@ class PrefillGraph:
         input_buffers: InputBuffers,
         config: ModelExecutorConfig,
         req_to_page: torch.Tensor | None,
+        compact_flat_block_tables: bool = False,
+        use_flat_cache_tables: bool = False,
         drafter=None,
         decode_wrapper: CudaGraphWrapper | None = None,
         num_warmup: int = 3,
@@ -238,6 +244,10 @@ class PrefillGraph:
         self.input_buffers = input_buffers
         self.config = config
         self.req_to_page = req_to_page
+        self.compact_flat_block_tables = bool(compact_flat_block_tables)
+        self.use_flat_cache_tables = bool(
+            use_flat_cache_tables and attn_backend.uses_flat_cache_groups
+        )
         self.drafter = drafter
         self.num_warmup = num_warmup
         self.dp_size = config.data_parallel_size
@@ -435,13 +445,11 @@ class PrefillGraph:
     def _dummy_flat_tables(self, num_tokens: int) -> dict[str, "torch.Tensor"]:
         """Build capture tables: null KV pages and one writable state page."""
         backend = self.attn_backend
-        if not getattr(backend, "uses_flat_cache_groups", False):
+        if not self.use_flat_cache_tables:
             return {}
-        specs = tuple(getattr(self.token_to_kv_pool, "paged_cache_group_specs", ()))
+        specs = self.token_to_kv_pool.paged_cache_group_specs
         state_group_ids = {
-            str(spec.group_id)
-            for spec in specs
-            if getattr(spec, "family", "history") == "state"
+            str(spec.group_id) for spec in specs if spec.family == "state"
         }
         if not state_group_ids:
             state_group_ids = set(getattr(backend, "flat_state_group_ids", frozenset()))
@@ -475,11 +483,10 @@ class PrefillGraph:
         The prefill analogue of decode's ``_init_capture_metadata``. KV writes
         go to the reserved dummy slot and the page table points at page 0, so
         the forward runs (producing discarded garbage) without touching real
-        cache state. Backends with extra paged caches (DeepSeek-V4 DSA: SWA +
-        compressor + indexer state) also need per-cache block tables, or their
-        extend metadata comes up incomplete and the eager attention break
-        aborts the capture -- reuse the decode wrapper's dummy-table builder
-        (all zeros, the safe page 0) for those.
+        cache state. Backends with extra grouped caches also need one table per
+        cache group, or their extend metadata comes up incomplete and the eager
+        attention break aborts the capture -- reuse the decode wrapper's
+        dummy-table builder (all zeros, the safe page 0) for those.
         """
         ib = self.input_buffers
         ib.input_ids_buf[:num_tokens].fill_(1)
@@ -526,7 +533,7 @@ class PrefillGraph:
             extra_metadata_kwargs["positions"] = ib.positions_buf[:num_tokens]
         flat_tables = self._dummy_flat_tables(num_tokens)
         if flat_tables:
-            contract = getattr(self.token_to_kv_pool, "runtime_contract", None)
+            contract = self.token_to_kv_pool.runtime_contract
             if contract is not None:
                 arrays = {
                     group_id: table.cpu().numpy()
@@ -535,17 +542,32 @@ class PrefillGraph:
                 dummy_forward_op = SimpleNamespace(
                     flat_block_tables_arrays=lambda: arrays
                 )
+                if self.compact_flat_block_tables:
+                    base_arrays = {
+                        group_id: torch.zeros(1, dtype=torch.int32).numpy()
+                        for group_id in arrays
+                    }
+                    dummy_forward_op.paged_cache_block_table_base_offsets_arrays = (
+                        lambda: base_arrays
+                    )
                 flat_cache_metadata = FlatCacheBatchMetadata.from_forward_op(
                     dummy_forward_op,
                     device=self.config.device,
                     contract=contract,
                     num_requests=1,
+                    compact_tables=self.compact_flat_block_tables,
                 )
                 flat_tables = dict(
                     flat_cache_metadata.tables(active_forward_op=dummy_forward_op)
                 )
                 extra_metadata_kwargs["flat_cache_metadata"] = flat_cache_metadata
                 extra_metadata_kwargs["flat_cache_forward_op"] = dummy_forward_op
+                if self.compact_flat_block_tables:
+                    extra_metadata_kwargs["paged_cache_block_table_base_offsets"] = (
+                        flat_cache_metadata.base_offsets(
+                            active_forward_op=dummy_forward_op
+                        )
+                    )
             extra_metadata_kwargs["flat_block_tables"] = flat_tables
         self.attn_backend.init_forward_metadata(
             bs=1,

--- a/python/tokenspeed/runtime/layers/attention/backends/base.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/base.py
@@ -28,9 +28,9 @@ from typing import TYPE_CHECKING
 import torch
 
 from tokenspeed.runtime.execution.breakable_cuda_graph import break_point
+from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 
 if TYPE_CHECKING:
-    from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
     from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
     from tokenspeed.runtime.layers.attention.kv_cache.base import BaseTokenToKVPool
     from tokenspeed.runtime.layers.paged_attention import PagedAttention
@@ -67,6 +67,11 @@ class AttentionBackend(ABC):
     # different hole/index semantics; a group-aware flat backend (Phase 4) sets
     # this True. Default False keeps every existing backend on today's path.
     uses_flat_cache_groups: bool = False
+    # The backend can consume compact per-request Flat block-table rows together
+    # with their canonical logical base offsets. Keep this separate from
+    # uses_flat_cache_groups: legacy Flat consumers require absolute columns
+    # even when their pool publishes a runtime contract.
+    supports_compact_flat_block_tables: bool = False
     # False for flat-capable backends whose spec-verify path is not wired yet.
     flat_spec_capable: bool = True
     uses_padded_decode_token_mask: bool = False
@@ -165,6 +170,7 @@ class AttentionBackend(ABC):
         forward_mode: ForwardMode = None,
         req_to_page: torch.Tensor = None,
         flat_block_tables: dict[str, torch.Tensor] | None = None,
+        flat_block_table_base_offsets: dict[str, torch.Tensor] | None = None,
         **kwargs,
     ):
         """Update pre-allocated CUDA-graph metadata buffers in-place before replay.
@@ -172,9 +178,11 @@ class AttentionBackend(ABC):
         Called instead of init_forward_metadata when use_cuda_graph=True, so
         that the captured kernels (which hold pointers into the pre-allocated
         buffers) see the current batch's data without any new allocations.
-        ``flat_block_tables`` carries the per-group flat page tables
-        (group_id -> [>=bs, cols]) for flat-capable backends; a backend that
-        captured flat buffers must be handed non-empty tables whenever bs > 0.
+        ``flat_block_tables`` and ``flat_block_table_base_offsets`` carry the
+        atomic per-group flat page-table ABI (group_id -> [>=bs, cols] and
+        group_id -> [>=bs]); their group keys and row counts must match. A
+        backend that captured flat buffers must be handed non-empty tables and
+        bases whenever bs > 0.
         Default: fall back to init_forward_metadata (correct but may not work
         for all backends that use separate cuda-graph buffer pools).
         """

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -62,6 +62,23 @@ from tokenspeed.runtime.utils.nvtx import nvtx_range
 DEEPSEEK_V4_DEFAULT_PREFILL_CHUNK_SIZE = 4
 
 
+def _pop_grouped_cache_views(
+    kwargs: dict,
+) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor], bool]:
+    """Consume the common grouped-table ABI, preferring Flat table views."""
+
+    paged_tables = kwargs.pop("paged_cache_block_tables", None) or {}
+    flat_tables = kwargs.pop("flat_block_tables", None)
+    base_offsets = kwargs.pop("paged_cache_block_table_base_offsets", None) or {}
+    # Metadata provenance is validated once by CudaGraphWrapper when it binds
+    # these views. Backends consume tensors only; no second resolve/copy.
+    kwargs.pop("flat_cache_metadata", None)
+    kwargs.pop("flat_cache_forward_op", None)
+    if not flat_tables:
+        return paged_tables, base_offsets, False
+    return flat_tables, base_offsets, True
+
+
 def _compressed_block_table_base_offsets(
     metadata: DeepseekV4ForwardMetadata,
     compress_ratio: int,
@@ -239,6 +256,10 @@ class DeepseekV4AttentionBackend(AttentionBackend):
     """Metadata owner for the model-local DeepSeek V4 attention path."""
 
     uses_paged_cache_groups = True
+    uses_flat_cache_groups = True
+    flat_cache_consumer_families = frozenset({"history", "state"})
+    supports_compact_flat_block_tables = True
+    flat_tables_self_padding = True
     uses_padded_decode_token_mask = True
 
     def __init__(self, config) -> None:
@@ -284,6 +305,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         )
         self._draft_decode_step = 0
         self._draft_decode_base_seq_lens: torch.Tensor | None = None
+        self._eager_draft_decode_metadata: DeepseekV4ForwardMetadata | None = None
         self._draft_decode_metadata: DeepseekV4ForwardMetadata | None = None
         self._cuda_graph_draft_decode_metadata = {}
         self._cuda_graph_query_start_by_tokens_per_req: dict[int, torch.Tensor] = {}
@@ -397,8 +419,6 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         extend_seq_lens_cpu: torch.Tensor | None,
         extend_prefix_lens_cpu: torch.Tensor | None,
     ) -> torch.Tensor | None:
-        if forward_mode is not None and forward_mode.is_decode_or_idle():
-            return torch.ones(bs, dtype=torch.int32)
         if forward_mode is not None and forward_mode.is_mixed():
             verify_width = max(1, int(self.speculative_num_draft_tokens))
             lens = torch.full((bs,), verify_width, dtype=torch.int32)
@@ -416,6 +436,32 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         if extend_prefix_lens_cpu is not None:
             return None
         return None
+
+    @staticmethod
+    def _query_start_offsets_from_cpu(
+        query_lens_cpu: torch.Tensor | None,
+        bs: int,
+    ) -> tuple[int, ...] | None:
+        """Build immutable host offsets without reading a device tensor."""
+
+        if query_lens_cpu is None:
+            return None
+        if query_lens_cpu.device.type != "cpu":
+            raise RuntimeError("DeepSeek V4 query_lens_cpu must reside on CPU")
+        if query_lens_cpu.numel() < bs:
+            raise RuntimeError(
+                "DeepSeek V4 query_lens_cpu is shorter than the request batch: "
+                f"{query_lens_cpu.numel()} < {bs}"
+            )
+        offsets = [0]
+        for length in query_lens_cpu[:bs].tolist():
+            value = int(length)
+            if value < 0:
+                raise RuntimeError(
+                    f"DeepSeek V4 query length must be non-negative, got {value}"
+                )
+            offsets.append(offsets[-1] + value)
+        return tuple(offsets)
 
     def _draft_decode_is_valid_token(
         self,
@@ -450,7 +496,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         metadata = (
             self._cuda_graph_draft_decode_metadata.get(bs)
             if is_cuda_graph_metadata
-            else self._draft_decode_metadata
+            else self._eager_draft_decode_metadata
         )
         is_valid_token = self._draft_decode_is_valid_token(prefill_metadata)
         if (
@@ -488,6 +534,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             )
             if is_cuda_graph_metadata:
                 self._cuda_graph_draft_decode_metadata[bs] = metadata
+            else:
+                self._eager_draft_decode_metadata = metadata
             self._draft_decode_metadata = metadata
             return
 
@@ -521,6 +569,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             max_context_len=self.context_len,
         )
         _refresh_decode_indexer_schedule_metadata(metadata)
+        if not is_cuda_graph_metadata:
+            self._eager_draft_decode_metadata = metadata
         self._draft_decode_metadata = metadata
 
     def _select_decode_metadata(
@@ -549,10 +599,11 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         extend_prefix_lens: torch.Tensor | None = None,
         **kwargs,
     ) -> None:
-        paged_cache_block_tables = kwargs.pop("paged_cache_block_tables", None) or {}
-        paged_cache_block_table_base_offsets = (
-            kwargs.pop("paged_cache_block_table_base_offsets", None) or {}
-        )
+        (
+            paged_cache_block_tables,
+            paged_cache_block_table_base_offsets,
+            from_flat,
+        ) = _pop_grouped_cache_views(kwargs)
         num_tokens_arg = kwargs.pop("num_tokens", None)
         positions = kwargs.get("positions")
         num_extends_arg = kwargs.pop("num_extends", None)
@@ -587,26 +638,29 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             num_prefill_reqs = bs
         else:
             num_prefill_reqs = 0
-        query_lens_cpu = self._query_lens_cpu(
-            bs,
-            forward_mode,
-            num_extends,
-            extend_seq_lens_cpu,
-            extend_prefix_lens_cpu,
-        )
+        query_lens_cpu = None
+        query_start_offsets = None
+        if num_prefill_reqs:
+            query_lens_cpu = self._query_lens_cpu(
+                bs,
+                forward_mode,
+                num_extends,
+                extend_seq_lens_cpu,
+                extend_prefix_lens_cpu,
+            )
+            query_start_offsets = self._query_start_offsets_from_cpu(query_lens_cpu, bs)
         seq_lens_cpu = None
         if extend_prefix_lens_cpu is not None and query_lens_cpu is not None:
-            seq_lens_cpu = seq_lens[:bs].to(dtype=torch.int32, device="cpu")
             prefix_count = min(
                 int(extend_prefix_lens_cpu.numel()),
-                (
-                    num_prefill_reqs
-                    if forward_mode is not None and forward_mode.is_mixed()
-                    else bs
-                ),
+                int(query_lens_cpu.numel()),
+                num_prefill_reqs,
             )
             if prefix_count:
-                seq_lens_cpu[:prefix_count] = (
+                # Mixed metadata retains only the prefill rows. The decode
+                # suffix has no host total-length mirror, so do not turn an
+                # unknown value into a zero or synchronize it from the device.
+                seq_lens_cpu = (
                     extend_prefix_lens_cpu[:prefix_count].to(
                         dtype=torch.int32,
                         device="cpu",
@@ -614,27 +668,38 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                     + query_lens_cpu[:prefix_count]
                 )
         elif extend_seq_lens_cpu is not None and forward_mode is not None:
-            if forward_mode.is_extend():
+            if forward_mode.is_extend() and extend_prefix_lens is None:
+                # With no prefix, query length is also total sequence length.
+                # A device-only prefix cannot safely produce a CPU total here.
                 seq_lens_cpu = extend_seq_lens_cpu[:bs].to(
                     dtype=torch.int32,
                     device="cpu",
                 )
-            elif forward_mode.is_mixed():
-                seq_lens_cpu = seq_lens[:bs].to(dtype=torch.int32, device="cpu")
-        max_seq_len = int(seq_lens.max().item()) if bs else 0
-        if forward_mode is not None and forward_mode.is_extend():
-            max_seq_len += max(self.speculative_num_steps - 1, 0)
-        if is_packed_decode:
-            max_seq_len += max(int(query_lens.max().item()) - 1, 0)
-        max_pages = (max_seq_len + self.page_size - 1) // self.page_size
-        if req_to_page is None:
-            block_table = torch.zeros(
-                (bs, max(max_pages, 1)),
-                dtype=torch.int32,
-                device=device,
+            # Mixed batches need prefix+query CPU mirrors to reconstruct total
+            # lengths. Do not fall back to a device-to-host copy here.
+        if from_flat:
+            # Group-keyed tables are authoritative. Keep only a one-column
+            # compatibility table and avoid GPU reductions/D2H on the hot path.
+            block_table = (
+                req_to_page[:bs, :1]
+                if req_to_page is not None
+                else torch.zeros((bs, 1), dtype=torch.int32, device=device)
             )
         else:
-            block_table = req_to_page[req_pool_indices, : max(max_pages, 1)]
+            max_seq_len = int(seq_lens.max().item()) if bs else 0
+            if forward_mode is not None and forward_mode.is_extend():
+                max_seq_len += max(self.speculative_num_steps - 1, 0)
+            if is_packed_decode:
+                max_seq_len += max(int(query_lens.max().item()) - 1, 0)
+            max_pages = (max_seq_len + self.page_size - 1) // self.page_size
+            if req_to_page is None:
+                block_table = torch.zeros(
+                    (bs, max(max_pages, 1)),
+                    dtype=torch.int32,
+                    device=device,
+                )
+            else:
+                block_table = req_to_page[req_pool_indices, : max(max_pages, 1)]
         paged_cache_block_tables = {
             str(gid): table[:bs].to(device=device, dtype=torch.int32)
             for gid, table in paged_cache_block_tables.items()
@@ -678,9 +743,19 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                     f"query_lens describe {metadata_tokens} tokens, packed input has "
                     f"{num_tokens}"
                 )
-        num_prefill_tokens = (
-            int(query_lens[:num_prefill_reqs].sum().item()) if num_prefill_reqs else 0
-        )
+        if num_prefill_reqs and from_flat and query_start_offsets is None:
+            raise RuntimeError(
+                "DeepSeek V4 flat prefill metadata requires CPU query lengths; "
+                "a CUDA query_start_loc fallback would synchronize every layer"
+            )
+        if not num_prefill_reqs:
+            num_prefill_tokens = 0
+        elif query_start_offsets is not None:
+            num_prefill_tokens = query_start_offsets[num_prefill_reqs]
+        else:
+            # Compatibility fallback for direct Radix callers that omit CPU
+            # mirrors. Production prefill/mixed execution supplies them.
+            num_prefill_tokens = int(query_lens[:num_prefill_reqs].sum().item())
         query_start_loc = torch.nn.functional.pad(
             torch.cumsum(query_lens.to(torch.int32), dim=0, dtype=torch.int32),
             (1, 0),
@@ -688,6 +763,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         cache_metadata = DeepseekV4CacheMetadata(
             page_size=self.page_size,
             block_table=block_table,
+            allow_legacy_block_table=not from_flat,
             paged_cache_block_tables=paged_cache_block_tables,
             paged_cache_block_table_base_offsets=base_offsets_on_device,
             swa_block_table=swa_block_table,
@@ -706,6 +782,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             cache=cache_metadata,
             seq_lens_cpu=seq_lens_cpu,
             query_lens_cpu=query_lens_cpu,
+            query_start_offsets=query_start_offsets,
             num_prefill_reqs=num_prefill_reqs,
             num_prefill_tokens=num_prefill_tokens,
             forward_mode=metadata_forward_mode,
@@ -1221,15 +1298,50 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         if cache_metadata.swa_block_table is None:
             raise RuntimeError("DeepSeek V4 missing paged-cache block table for SWA KV")
         swa_block_table = cache_metadata.swa_block_table
-        max_gather_len = int(gather_lens.max().item()) if num_reqs else 1
+        have_cpu_lengths = (
+            metadata.seq_lens_cpu is not None
+            and metadata.query_lens_cpu is not None
+            and metadata.seq_lens_cpu.numel() >= num_reqs
+            and metadata.query_lens_cpu.numel() >= num_reqs
+        )
+        if num_reqs and have_cpu_lengths:
+            seq_lens_cpu = metadata.seq_lens_cpu[:num_reqs].to(torch.int64)
+            query_lens_cpu = metadata.query_lens_cpu[:num_reqs].to(torch.int64)
+            prefix_lens_cpu = seq_lens_cpu - query_lens_cpu
+            gather_lens_cpu = query_lens_cpu + torch.minimum(
+                prefix_lens_cpu,
+                torch.full_like(prefix_lens_cpu, max(window_size - 1, 0)),
+            )
+            max_gather_len = int(gather_lens_cpu.max().item())
+        else:
+            if num_reqs and not cache_metadata.has_legacy_block_table:
+                raise RuntimeError(
+                    "DeepSeek V4 Flat prefill workspace requires CPU sequence/query "
+                    "length mirrors"
+                )
+            # Preserve legacy Radix/direct-call compatibility. Production
+            # callers supply mirrors and avoid this device synchronization.
+            max_gather_len = int(gather_lens.max().item()) if num_reqs else 1
         compressed_lens = (
             torch.div(metadata.seq_lens, compress_ratio, rounding_mode="floor")
             if compress_ratio > 1
             else torch.zeros_like(metadata.seq_lens)
         )
-        compressed_base = (
-            int(compressed_lens.max().item()) if compress_ratio > 1 and num_reqs else 0
-        )
+        if compress_ratio > 1 and num_reqs:
+            if have_cpu_lengths:
+                compressed_base = int(
+                    torch.div(
+                        seq_lens_cpu,
+                        compress_ratio,
+                        rounding_mode="floor",
+                    )
+                    .max()
+                    .item()
+                )
+            else:
+                compressed_base = int(compressed_lens.max().item())
+        else:
+            compressed_base = 0
         workspace_width = max(1, compressed_base + max_gather_len)
         kv_workspace = self._get_prefill_workspace(
             num_reqs=num_reqs,
@@ -1379,6 +1491,13 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             )
         }
         query_lens = metadata.query_lens[req_start:req_end]
+        query_start_offsets = None
+        if metadata.query_start_offsets is not None:
+            base = metadata.query_start_offsets[req_start]
+            query_start_offsets = tuple(
+                offset - base
+                for offset in metadata.query_start_offsets[req_start : req_end + 1]
+            )
         req_count = max(0, req_end - req_start)
         token_count = max(0, token_end - token_start)
         num_prefill_reqs = req_count if forward_mode.is_extend_or_mixed() else 0
@@ -1390,6 +1509,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         sliced_cache = DeepseekV4CacheMetadata(
             page_size=cache_metadata.page_size,
             block_table=cache_metadata.block_table[req_start:req_end],
+            allow_legacy_block_table=cache_metadata.allow_legacy_block_table,
             paged_cache_block_tables=paged_cache_block_tables,
             paged_cache_block_table_base_offsets=paged_cache_block_table_base_offsets,
             swa_block_table=(
@@ -1437,6 +1557,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                 if metadata.query_lens_cpu is not None
                 else None
             ),
+            query_start_offsets=query_start_offsets,
             num_prefill_reqs=num_prefill_reqs,
             num_prefill_tokens=num_prefill_tokens,
             forward_mode=forward_mode,
@@ -1558,10 +1679,21 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                 topk_indices=topk_indices,
             )
 
-        token_offsets = [
-            int(x)
-            for x in metadata.query_start_loc[: num_reqs + 1].detach().cpu().tolist()
-        ]
+        token_offsets = metadata.query_start_offsets
+        if token_offsets is None:
+            if not metadata.cache.has_legacy_block_table:
+                raise RuntimeError(
+                    "DeepSeek V4 Flat prefill chunking requires cached CPU query "
+                    "offsets; query_start_loc must not be synchronized once per layer"
+                )
+            # Preserve legacy Radix/direct-call compatibility. Production
+            # callers provide CPU mirrors and take the cached branch above.
+            token_offsets = tuple(
+                int(x)
+                for x in (
+                    metadata.query_start_loc[: num_reqs + 1].detach().cpu().tolist()
+                )
+            )
         out = q.new_empty((q.shape[0], num_local_heads, head_dim))
         saved_metadata = self.forward_metadata
         try:
@@ -1709,11 +1841,12 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             table = paged_cache_block_tables.get(group_id)
             buf[:bs].fill_(pad_value)
             if table is not None:
-                if int(table.shape[0]) != bs:
+                rows = int(table.shape[0])
+                if rows > bs:
                     raise RuntimeError(
                         "DeepSeek V4 CUDA graph paged cache table row count "
-                        f"mismatch for {group_id!r}: got {int(table.shape[0])}, "
-                        f"expected padded bs {bs}"
+                        f"mismatch for {group_id!r}: got {rows}, "
+                        f"padded bs is {bs}"
                     )
                 cols = int(table.shape[1])
                 if cols > int(buf.shape[1]):
@@ -1722,8 +1855,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                         f"mismatch for {group_id!r}: got {cols}, capture "
                         f"buffer has {int(buf.shape[1])}"
                     )
-                if cols > 0:
-                    buf[:bs, :cols].copy_(table[:bs, :cols].to(torch.int32))
+                if rows > 0 and cols > 0:
+                    buf[:rows, :cols].copy_(table[:rows, :cols].to(torch.int32))
             out[group_id] = buf[:bs]
         return out
 
@@ -1743,12 +1876,13 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             src = base_offsets.get(gid)
             if src is not None and bs > 0:
                 rows = int(src.shape[0])
-                if rows < bs:
+                if rows > bs:
                     raise RuntimeError(
                         "DeepSeek V4 CUDA-graph replay base-offsets row count "
-                        f"{rows} < bs={bs} for group {gid!r}"
+                        f"{rows} > padded bs={bs} for group {gid!r}"
                     )
-                buf[:bs].copy_(src[:bs].to(torch.int32))
+                if rows > 0:
+                    buf[:rows].copy_(src[:rows].to(torch.int32))
             out[gid] = buf[:bs]
         return out
 
@@ -1811,10 +1945,12 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         forward_mode: ForwardMode,
         **kwargs,
     ):
-        paged_cache_block_tables = kwargs.pop("paged_cache_block_tables", None) or {}
-        paged_cache_block_table_base_offsets = (
-            kwargs.pop("paged_cache_block_table_base_offsets", None) or {}
-        )
+        (
+            paged_cache_block_tables,
+            paged_cache_block_table_base_offsets,
+            _,
+        ) = _pop_grouped_cache_views(kwargs)
+        compact_flat_block_tables = bool(kwargs.pop("compact_flat_block_tables", False))
         num_tokens_arg = kwargs.pop("num_tokens", None)
         del kwargs
         if forward_mode is not None and not forward_mode.is_decode_or_idle():
@@ -1882,6 +2018,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         cache_metadata = DeepseekV4CacheMetadata(
             page_size=self.page_size,
             block_table=self._cuda_graph_block_table[:bs, : self.max_num_pages],
+            allow_legacy_block_table=not compact_flat_block_tables,
             paged_cache_block_tables=metadata_paged,
             paged_cache_block_table_base_offsets=metadata_base_offsets,
             swa_block_table=swa_block_table,
@@ -1936,10 +2073,11 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         req_to_page: torch.Tensor = None,
         **kwargs,
     ):
-        paged_cache_block_tables = kwargs.pop("paged_cache_block_tables", None) or {}
-        paged_cache_block_table_base_offsets = (
-            kwargs.pop("paged_cache_block_table_base_offsets", None) or {}
-        )
+        (
+            paged_cache_block_tables,
+            paged_cache_block_table_base_offsets,
+            from_flat,
+        ) = _pop_grouped_cache_views(kwargs)
         actual_bs = max(0, min(int(kwargs.pop("actual_bs", bs)), bs))
         num_tokens_arg = kwargs.pop("num_tokens", None)
         del kwargs
@@ -1961,38 +2099,45 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             tokens_per_req=tokens_per_req,
         )
         metadata = self._cuda_graph_metadata[bs]
+        if from_flat:
+            expected_groups = set(self._cuda_graph_paged_cache_block_tables)
+            actual_groups = set(paged_cache_block_tables)
+            if actual_groups != expected_groups:
+                raise RuntimeError(
+                    "DeepSeek V4 Flat CUDA-graph replay group mismatch: "
+                    f"missing={sorted(expected_groups - actual_groups)}, "
+                    f"extra={sorted(actual_groups - expected_groups)}"
+                )
+            missing_bases = set(self._cuda_graph_paged_cache_base_offsets).difference(
+                paged_cache_block_table_base_offsets
+            )
+            if missing_bases and actual_bs > 0:
+                raise RuntimeError(
+                    "DeepSeek V4 Flat CUDA-graph replay is missing sliding "
+                    f"group base offsets: {sorted(missing_bases)}"
+                )
         self._cuda_graph_req_pool_indices[:bs].copy_(req_pool_indices[:bs])
         self._cuda_graph_seq_lens[:bs].copy_(seq_lens[:bs].to(torch.int32))
-        if req_to_page is not None:
+        if req_to_page is not None and not from_flat:
             self._cuda_graph_block_table[:bs, : self.max_num_pages].copy_(
                 req_to_page[req_pool_indices[:bs], : self.max_num_pages]
             )
+        tables_on_device = {
+            str(group_id): table.to(device=self.device, dtype=torch.int32)
+            for group_id, table in paged_cache_block_tables.items()
+        }
         offsets_on_device = {
             str(gid): off.to(device=self.device, dtype=torch.int32)
             for gid, off in paged_cache_block_table_base_offsets.items()
         }
-        metadata_paged = self._refresh_cuda_graph_paged_cache_block_tables(
+        self._refresh_cuda_graph_paged_cache_block_tables(
             bs,
-            {
-                str(group_id): table.to(device=self.device, dtype=torch.int32)
-                for group_id, table in paged_cache_block_tables.items()
-            },
+            tables_on_device,
             pad_value=-1,
         )
-        metadata_base_offsets = self._refresh_cuda_graph_base_offsets(
+        self._refresh_cuda_graph_base_offsets(
             bs,
             offsets_on_device,
-        )
-        (
-            swa_block_table,
-            compressor_state_block_tables,
-            indexer_state_block_table,
-            swa_base,
-            compressor_state_base,
-            indexer_state_base,
-        ) = _split_paged_cache_block_tables_into_v4_metadata(
-            metadata_paged,
-            metadata_base_offsets,
         )
         metadata_forward_mode = forward_mode
         is_decode = (
@@ -2001,21 +2146,10 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         metadata.forward_mode = metadata_forward_mode
         metadata.token_to_req_indices = self._cuda_graph_token_to_req[:total_tokens]
         metadata.is_valid_token = self._cuda_graph_is_valid_token[:total_tokens]
-        metadata.cache = DeepseekV4CacheMetadata(
-            page_size=self.page_size,
-            block_table=self._cuda_graph_block_table[:bs, : self.max_num_pages],
-            paged_cache_block_tables=metadata_paged,
-            paged_cache_block_table_base_offsets=metadata_base_offsets,
-            swa_block_table=swa_block_table,
-            swa_base_logical_page=swa_base,
-            compressor_state_block_tables=compressor_state_block_tables,
-            compressor_state_base_logical_pages=compressor_state_base,
-            indexer_state_block_table=indexer_state_block_table,
-            indexer_state_base_logical_page=indexer_state_base,
-            decode_compressed_slot_mappings=(
-                metadata.cache.decode_compressed_slot_mappings
-            ),
-        )
+        # Capture bound cache metadata to persistent table/base views for this
+        # batch size. Replay only refreshes their contents above; replacing the
+        # mappings or dataclass here would allocate on every decode and change
+        # the object identity used by CUDA-graph consumers.
         metadata.num_prefill_reqs = 0
         metadata.num_prefill_tokens = 0
         if is_packed_decode and getattr(self, "is_draft", False):

--- a/python/tokenspeed/runtime/layers/attention/backends/flat_cache_metadata.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/flat_cache_metadata.py
@@ -33,7 +33,106 @@ from tokenspeed.runtime.configs.flat_cache_runtime import (
 )
 from tokenspeed.runtime.engine.scheduler_utils import (
     flat_block_tables_from_forward_op,
+    flat_cache_batch_from_forward_op,
 )
+
+
+def resolve_flat_runtime_contracts(
+    *,
+    target_pool: Any,
+    target_backend: Any,
+    draft_pool: Any = None,
+    draft_backend: Any = None,
+    flat_kvcache_ext: bool,
+) -> tuple[
+    FlatPagedCacheRuntimeContract | None,
+    FlatPagedCacheRuntimeContract | None,
+    bool,
+]:
+    """Resolve metadata contracts and the union-wide compact table decision.
+
+    Runtime contracts alone select the metadata transport. Backend capability
+    only selects whether a Flat scheduler may trim leading holes and publish
+    logical bases. A target/draft pair shares one scheduler representation, so
+    its common groups and compact capability must agree.
+    """
+
+    target_contract = target_pool.runtime_contract
+    draft_contract = draft_pool.runtime_contract if draft_pool is not None else None
+    target_capable = bool(target_backend.supports_compact_flat_block_tables)
+    draft_capable = bool(
+        draft_backend.supports_compact_flat_block_tables
+        if draft_backend is not None
+        else False
+    )
+
+    if draft_contract is not None and target_contract is None:
+        raise RuntimeError(
+            "a FlatKV draft runtime contract requires a target runtime "
+            "contract for the scheduler-owned group union"
+        )
+    if target_contract is not None and draft_contract is not None:
+        if target_contract.block_size != draft_contract.block_size:
+            raise RuntimeError(
+                "target and draft FlatKV contracts disagree on base block_size: "
+                f"target={target_contract.block_size}, "
+                f"draft={draft_contract.block_size}"
+            )
+        target_specs = {spec.group_id: spec for spec in target_contract.group_specs}
+        draft_specs = {spec.group_id: spec for spec in draft_contract.group_specs}
+        missing = set(draft_specs).difference(target_specs)
+        if missing:
+            raise RuntimeError(
+                "draft FlatKV contract is not a subset of the target scheduler "
+                f"union: missing={sorted(missing)}"
+            )
+        for group_id, draft_spec in draft_specs.items():
+            target_spec = target_specs[group_id]
+            fields = {
+                "group_block_size": (
+                    target_contract.group_block_sizes[group_id],
+                    draft_contract.group_block_sizes[group_id],
+                ),
+                "retention": (target_spec.retention, draft_spec.retention),
+                "family": (target_spec.family, draft_spec.family),
+                "cache_blocks_per_lcm_block": (
+                    target_spec.cache_blocks_per_lcm_block,
+                    draft_spec.cache_blocks_per_lcm_block,
+                ),
+                "group_page_count": (
+                    target_contract.group_page_counts[group_id],
+                    draft_contract.group_page_counts[group_id],
+                ),
+            }
+            mismatches = {
+                field: {"target": target, "draft": draft}
+                for field, (target, draft) in fields.items()
+                if target != draft
+            }
+            if mismatches:
+                raise RuntimeError(
+                    "target and draft FlatKV contracts disagree for common "
+                    f"group {group_id!r}: {mismatches}"
+                )
+
+    if flat_kvcache_ext:
+        if target_capable and target_contract is None:
+            raise RuntimeError(
+                "compact FlatKV target backend requires a runtime contract"
+            )
+        if draft_backend is not None and draft_capable and draft_contract is None:
+            raise RuntimeError(
+                "compact FlatKV draft backend requires a runtime contract"
+            )
+        if draft_backend is not None and target_capable != draft_capable:
+            raise RuntimeError(
+                "target and draft FlatKV backends disagree on compact "
+                "block-table capability; the scheduler publishes one union "
+                "table representation"
+            )
+
+    compact_tables = bool(flat_kvcache_ext and target_capable and target_contract)
+    return target_contract, draft_contract, compact_tables
 
 
 @dataclass(frozen=True, init=False)
@@ -44,18 +143,24 @@ class FlatCacheBatchMetadata:
         group_ids: Cache group IDs in runtime-contract order.
         num_requests: Number of request rows in each group table.
         max_page_ids: Inclusive maximum page ID accepted for each group.
-        block_size: Tokens per flat page (uniform across contract groups).
+        block_size: Scheduler base grain retained for uniform legacy consumers.
         full_attention_group_id: The unique ``family="history"`` +
             ``retention="full_history"`` group ID, or ``None`` when the
             contract does not contain exactly one such group.
+        compact_tables: Whether group tables use row-local logical bases.
     """
 
     group_ids: tuple[str, ...]
     _group_tables: Mapping[str, torch.Tensor] = field(repr=False, compare=False)
+    _group_base_offsets: Mapping[str, torch.Tensor] = field(
+        repr=False,
+        compare=False,
+    )
     num_requests: int
     max_page_ids: Mapping[str, int]
     block_size: int
     full_attention_group_id: str | None
+    compact_tables: bool
     _forward_op: Any = field(repr=False, compare=False)
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -69,6 +174,7 @@ class FlatCacheBatchMetadata:
         device: torch.device | str,
         contract: FlatPagedCacheRuntimeContract,
         num_requests: int,
+        compact_tables: bool,
     ) -> FlatCacheBatchMetadata:
         """Validate CPU exports, pack once, and retain operation provenance."""
         if forward_op is None:
@@ -96,25 +202,39 @@ class FlatCacheBatchMetadata:
         full_attention_ids = tuple(
             spec.group_id
             for spec in contract.group_specs
-            if getattr(spec, "family", "history") == "history"
-            and getattr(spec, "retention", None) == "full_history"
+            if spec.family == "history" and spec.retention == "full_history"
         )
-        tables = flat_block_tables_from_forward_op(
-            forward_op,
-            device,
-            num_reqs=num_requests,
-            expected_group_ids=group_ids,
-            max_page_ids=max_page_ids,
-        )
+        if compact_tables:
+            tables, base_offsets = flat_cache_batch_from_forward_op(
+                forward_op,
+                device,
+                num_reqs=num_requests,
+                expected_group_ids=group_ids,
+                max_page_ids=max_page_ids,
+                required_base_offset_group_ids=frozenset(group_ids),
+            )
+        else:
+            tables = flat_block_tables_from_forward_op(
+                forward_op,
+                device,
+                num_reqs=num_requests,
+                expected_group_ids=group_ids,
+                max_page_ids=max_page_ids,
+            )
+            if not isinstance(tables, dict):
+                raise TypeError("absolute Flat table bridge returned invalid metadata")
+            base_offsets = {}
         return cls._from_validated_tables(
             group_ids=group_ids,
             group_tables=tables,
+            group_base_offsets=base_offsets,
             num_requests=num_requests,
             max_page_ids=max_page_ids,
             block_size=block_size,
             full_attention_group_id=(
                 full_attention_ids[0] if len(full_attention_ids) == 1 else None
             ),
+            compact_tables=compact_tables,
             forward_op=forward_op,
         )
 
@@ -124,18 +244,27 @@ class FlatCacheBatchMetadata:
         *,
         group_ids: tuple[str, ...],
         group_tables: Mapping[str, torch.Tensor],
+        group_base_offsets: Mapping[str, torch.Tensor],
         num_requests: int,
         max_page_ids: Mapping[str, int],
         block_size: int,
         full_attention_group_id: str | None,
+        compact_tables: bool,
         forward_op: Any,
     ) -> FlatCacheBatchMetadata:
         if tuple(group_tables) != group_ids:
             raise ValueError(
                 "flat group table mapping must exactly match contract order"
             )
+        if compact_tables and tuple(group_base_offsets) != group_ids:
+            raise ValueError(
+                "flat group base-offset mapping must exactly match contract order"
+            )
+        if not compact_tables and group_base_offsets:
+            raise ValueError("absolute flat metadata must not carry base offsets")
         table_device: torch.device | None = None
         ordered = dict(group_tables)
+        ordered_bases = dict(group_base_offsets)
         for group_id, table in ordered.items():
             if not isinstance(table, torch.Tensor):
                 raise ValueError(f"flat group {group_id!r} must be a tensor")
@@ -147,28 +276,101 @@ class FlatCacheBatchMetadata:
                 raise ValueError(f"flat group {group_id!r} has zero width")
             if table.device.type not in ("cpu", "cuda"):
                 raise ValueError(f"flat group {group_id!r} must be on CPU or CUDA")
+            if compact_tables:
+                bases = ordered_bases[group_id]
+                if not isinstance(bases, torch.Tensor):
+                    raise ValueError(
+                        f"flat group {group_id!r} base offsets must be a tensor"
+                    )
+                if bases.dtype != torch.int32:
+                    raise ValueError(
+                        f"flat group {group_id!r} base offsets must use int32"
+                    )
+                if bases.ndim != 1 or bases.shape[0] != num_requests:
+                    raise ValueError(f"flat group {group_id!r} has invalid base shape")
+                if bases.device != table.device:
+                    raise ValueError(
+                        f"flat group {group_id!r} table/base devices disagree"
+                    )
             if table_device is None:
                 table_device = table.device
             elif table.device != table_device:
                 raise ValueError("flat group tables must use one CPU/CUDA device")
-        nonempty = [table for table in ordered.values() if table.numel()]
-        pointers = {table.untyped_storage().data_ptr() for table in nonempty}
+        nonempty = [tensor for tensor in ordered.values() if tensor.numel()]
+        if compact_tables:
+            nonempty.extend(
+                tensor for tensor in ordered_bases.values() if tensor.numel()
+            )
+        pointers = {tensor.untyped_storage().data_ptr() for tensor in nonempty}
         if len(pointers) != 1:
-            raise ValueError("flat group tables must share packed storage")
+            suffix = " and bases" if compact_tables else ""
+            raise ValueError(f"flat group tables{suffix} must share packed storage")
 
         metadata = object.__new__(cls)
         object.__setattr__(metadata, "group_ids", group_ids)
         object.__setattr__(metadata, "_group_tables", MappingProxyType(ordered))
+        object.__setattr__(
+            metadata,
+            "_group_base_offsets",
+            MappingProxyType(ordered_bases),
+        )
         object.__setattr__(metadata, "num_requests", num_requests)
         object.__setattr__(
             metadata, "max_page_ids", MappingProxyType(dict(max_page_ids))
         )
         object.__setattr__(metadata, "block_size", block_size)
         object.__setattr__(metadata, "full_attention_group_id", full_attention_group_id)
+        object.__setattr__(metadata, "compact_tables", bool(compact_tables))
         # A strong reference makes Python/nanobind object identity safe against
         # id reuse until all metadata views become unreachable.
         object.__setattr__(metadata, "_forward_op", forward_op)
         return metadata
+
+    def for_groups(
+        self,
+        group_ids: tuple[str, ...],
+        *,
+        owner: str,
+    ) -> FlatCacheBatchMetadata:
+        """Return one zero-copy owner view over this validated scheduler union."""
+
+        group_ids = tuple(group_ids)
+        if not group_ids:
+            raise ValueError(f"{owner} flat cache group projection must not be empty")
+        if len(group_ids) != len(set(group_ids)):
+            raise ValueError(f"{owner} flat cache group projection has duplicates")
+        missing = set(group_ids).difference(self.group_ids)
+        if missing:
+            raise ValueError(
+                f"{owner} flat cache groups are absent from the scheduler union: "
+                f"{sorted(missing)}"
+            )
+        if group_ids == self.group_ids:
+            return self
+        full_attention_group_id = (
+            self.full_attention_group_id
+            if self.full_attention_group_id in group_ids
+            else None
+        )
+        return self._from_validated_tables(
+            group_ids=group_ids,
+            group_tables={
+                group_id: self._group_tables[group_id] for group_id in group_ids
+            },
+            group_base_offsets=(
+                {group_id: self._group_base_offsets[group_id] for group_id in group_ids}
+                if self.compact_tables
+                else {}
+            ),
+            num_requests=self.num_requests,
+            max_page_ids={
+                group_id: self.max_page_ids[group_id] for group_id in group_ids
+            },
+            block_size=self.block_size,
+            full_attention_group_id=full_attention_group_id,
+            compact_tables=self.compact_tables,
+            forward_op=self._forward_op,
+        )
 
     def _validate_active_forward_op(self, active_forward_op: Any) -> None:
         if active_forward_op is not self._forward_op:
@@ -181,6 +383,16 @@ class FlatCacheBatchMetadata:
         self._validate_active_forward_op(active_forward_op)
         return self._group_tables
 
+    def base_offsets(
+        self,
+        *,
+        active_forward_op: Any,
+    ) -> Mapping[str, torch.Tensor]:
+        """Return row-aligned logical bases after freshness validation."""
+
+        self._validate_active_forward_op(active_forward_op)
+        return self._group_base_offsets
+
     def require_table(
         self,
         group_id: str,
@@ -191,6 +403,20 @@ class FlatCacheBatchMetadata:
         self._validate_active_forward_op(active_forward_op)
         try:
             return self._group_tables[group_id]
+        except KeyError:
+            raise KeyError(f"missing flat cache group {group_id!r}") from None
+
+    def require_base_offsets(
+        self,
+        group_id: str,
+        *,
+        active_forward_op: Any,
+    ) -> torch.Tensor:
+        """Return one group's row-aligned logical bases."""
+
+        self._validate_active_forward_op(active_forward_op)
+        try:
+            return self._group_base_offsets[group_id]
         except KeyError:
             raise KeyError(f"missing flat cache group {group_id!r}") from None
 

--- a/python/tokenspeed/runtime/layers/attention/backends/flat_groups.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/flat_groups.py
@@ -70,8 +70,10 @@ class FlatCacheGroupsMixin:
     # Wrapper-owned (Inkling conv) groups: mixin skips their write-loc math and capture buffers
     flat_engine_owned_group_ids: frozenset[str] = frozenset()
 
-    # Per-group page size in tokens (hetero block sizes); groups absent here use self.page_size
+    # Per-group page size in tokens (heterogeneous block sizes).
     flat_group_page_sizes: dict[str, int] = {}
+    # False is the Radix/legacy state before any Flat specs are published.
+    flat_group_specs_published: bool = False
 
     # Draft decode-window lookback rows (Inkling MTP): armed by the conv
     # wrapper's configure_draft_lookback BEFORE graph init, so the lookback
@@ -174,19 +176,27 @@ class FlatCacheGroupsMixin:
         flat_state_group_ids) and per-group page sizes (heterogeneous block
         sizes); called from init_cuda_graph_state, the one place the pool's
         specs reach every backend."""
+        specs = tuple(paged_cache_group_specs)
+        self.flat_group_specs_published = bool(specs)
         self.flat_state_group_ids = frozenset(
-            str(spec.group_id)
-            for spec in paged_cache_group_specs
-            if spec.family == "state"
+            str(spec.group_id) for spec in specs if spec.family == "state"
         )
         self.flat_group_page_sizes = {
             str(spec.group_id): int(spec.rows_per_page) * int(spec.entry_stride_tokens)
-            for spec in paged_cache_group_specs
+            for spec in specs
             if spec.family != "state"
         }
 
     def _group_page_size(self, gid: str) -> int:
-        return self.flat_group_page_sizes.get(gid, self.page_size)
+        page_size = self.flat_group_page_sizes.get(gid)
+        if page_size is not None:
+            return page_size
+        if not self.flat_group_specs_published:
+            return self.page_size
+        raise RuntimeError(
+            f"flat group {gid!r} is absent from the backend cache specs: "
+            f"{sorted(self.flat_group_page_sizes)}"
+        )
 
     def _layer_page_size(self, layer) -> int:
         """Page size of the layer's cache group (uniform when unknown)."""

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -337,8 +337,22 @@ class LayerMappedKVPool:
             global_id: pool_idx
             for pool_idx, global_id in enumerate(full_attention_layer_ids)
         }
-        # Expose page_size from inner pool for the scheduler
-        self.page_size = getattr(inner_pool, "page_size", 1)
+        self.page_size = inner_pool.page_size
+
+    @property
+    def runtime_contract(self):
+        """Forward the explicit FlatKV geometry contract."""
+        return self.inner.runtime_contract
+
+    @property
+    def paged_cache_group_specs(self):
+        """Forward scheduler-visible group geometry without dynamic probing."""
+        return self.inner.paged_cache_group_specs
+
+    @property
+    def paged_cache_group_page_counts(self):
+        """Forward the published per-group page counts."""
+        return self.inner.paged_cache_group_page_counts
 
     def _map(self, layer_id: int) -> int:
         return self.layer_map.get(layer_id, layer_id)
@@ -779,12 +793,10 @@ class MambaAttnBackend(AttentionBackend):
           delivered (radix ext / spec decode never publish).
         """
         self.kv_pool = kv_pool
-        contract = getattr(kv_pool, "runtime_contract", None)
+        contract = kv_pool.runtime_contract
         if contract is not None:
             state_group_ids = tuple(
-                spec.group_id
-                for spec in contract.group_specs
-                if getattr(spec, "family", "history") == "state"
+                spec.group_id for spec in contract.group_specs if spec.family == "state"
             )
             if not state_group_ids:
                 raise RuntimeError(
@@ -807,7 +819,7 @@ class MambaAttnBackend(AttentionBackend):
             return
         self._flat_contract_bound = False
         self._flat_state_group_ids = ()
-        specs = getattr(kv_pool, "paged_cache_group_specs", ())
+        specs = kv_pool.paged_cache_group_specs
         layer_types = tuple(getattr(kv_pool, "_layer_types", ()))
         layer_group_ids = tuple(getattr(kv_pool, "layer_cache_group_ids", ()))
         if layer_group_ids and len(layer_group_ids) != len(layer_types):

--- a/python/tokenspeed/runtime/layers/attention/backends/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mha.py
@@ -169,6 +169,7 @@ class MHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
         self.flat_state_group_ids: frozenset[str] = frozenset()
         # Per-group page sizes (heterogeneous block sizes), learned with them.
         self.flat_group_page_sizes: dict[str, int] = {}
+        self.flat_group_specs_published = False
 
     # ------------------------------------------------------------------
     # Metadata initialization

--- a/python/tokenspeed/runtime/layers/attention/deepseek_v4/metadata.py
+++ b/python/tokenspeed/runtime/layers/attention/deepseek_v4/metadata.py
@@ -145,6 +145,10 @@ class DeepseekV4ForwardMetadata:
     # forcing another device-to-host sync in the model path.
     seq_lens_cpu: torch.Tensor | None = None
     query_lens_cpu: torch.Tensor | None = None
+    # Host prefix sums derived once from query_lens_cpu. Per-layer prefill
+    # chunking consumes this immutable tuple instead of synchronizing the CUDA
+    # query_start_loc tensor back to the host.
+    query_start_offsets: tuple[int, ...] | None = None
     # Cached split boundary derived from scheduler num_extends/query_lens.
     num_prefill_reqs: int = 0
     num_prefill_tokens: int = 0

--- a/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
+++ b/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
@@ -243,7 +243,7 @@ def dequantize_deepseek_v4_fp8_ds_mla_cache(
     if slot_mapping.numel() == 0:
         return torch.empty(out_shape, device=cache_2d.device, dtype=torch.bfloat16)
 
-    flat_cache = cache_2d.reshape(-1)
+    cache_pages = cache_2d
     num_nope_blocks = nope_dim // DEEPSEEK_V4_FP8_QUANT_BLOCK
 
     slots = slot_mapping.to(torch.int64)
@@ -251,15 +251,14 @@ def dequantize_deepseek_v4_fp8_ds_mla_cache(
     safe_slots = torch.where(valid, slots, torch.zeros_like(slots))
     pages = torch.div(safe_slots, block_size, rounding_mode="floor")
     pos = safe_slots % block_size
-    page_base = pages * cache_2d.stride(0)
-    value_base = page_base + pos * token_stride
-    scale_base = page_base + block_size * token_stride + pos * scale_dim
+    value_base = pos * token_stride
+    scale_base = block_size * token_stride + pos * scale_dim
 
     value_offsets = (
         value_base[:, None]
         + torch.arange(token_stride, device=cache_2d.device, dtype=torch.int64)[None, :]
     )
-    row_bytes = flat_cache[value_offsets]
+    row_bytes = cache_pages[pages[:, None], value_offsets]
     nope = row_bytes[:, :nope_dim].contiguous().view(torch.float8_e4m3fn)
 
     scale_offsets = (
@@ -268,7 +267,10 @@ def dequantize_deepseek_v4_fp8_ds_mla_cache(
             None, :
         ]
     )
-    scales = torch.pow(2.0, flat_cache[scale_offsets].to(torch.int32) - 127)
+    scales = torch.pow(
+        2.0,
+        cache_pages[pages[:, None], scale_offsets].to(torch.int32) - 127,
+    )
     scales = scales.float().repeat_interleave(DEEPSEEK_V4_FP8_QUANT_BLOCK, dim=1)
 
     rope = row_bytes[:, nope_dim:token_stride].contiguous()
@@ -404,16 +406,13 @@ def _write_fp8_ds_mla_cache_rows_capturable(
     safe_slots = torch.where(valid, slots, torch.zeros_like(slots))
     block_idx = torch.div(safe_slots, kv_cache_block_size, rounding_mode="floor")
     pos_in_block = safe_slots % kv_cache_block_size
-    block_base = block_idx * kv_cache_2d.stride(0)
-    token_base = block_base + pos_in_block * token_stride
-    scale_base = (
-        block_base + kv_cache_block_size * token_stride + pos_in_block * scale_dim
-    )
+    token_base = pos_in_block * token_stride
+    scale_base = kv_cache_block_size * token_stride + pos_in_block * scale_dim
 
     value_bytes, scale_bytes, rope_bytes = _fp8_ds_mla_cache_rows(
         normed[:num_rows], positions[:num_rows], cos_sin_cache, compress_ratio
     )
-    flat_cache = kv_cache_2d.reshape(-1)
+    cache_pages = kv_cache_2d
     value_offsets = (
         token_base[:, None]
         + torch.arange(
@@ -439,9 +438,10 @@ def _write_fp8_ds_mla_cache_rows_capturable(
             dtype=torch.int64,
         )[None, :]
     )
-    flat_cache[value_offsets] = value_bytes
-    flat_cache[scale_offsets] = scale_bytes
-    flat_cache[rope_offsets] = rope_bytes
+    page_indices = block_idx[:, None]
+    cache_pages[page_indices, value_offsets] = value_bytes
+    cache_pages[page_indices, scale_offsets] = scale_bytes
+    cache_pages[page_indices, rope_offsets] = rope_bytes
 
 
 def save_deepseek_v4_compressor_state(
@@ -526,11 +526,10 @@ def write_deepseek_v4_indexer_fp8_cache(
     min_stride = block_size * row_bytes
     if cache_2d.dim() != 2 or cache_2d.shape[1] < min_stride:
         raise ValueError(
-            f"cache_2d must be [pages, >= {min_stride}], "
-            f"got {tuple(cache_2d.shape)}"
+            f"cache_2d must be [pages, >= {min_stride}], got {tuple(cache_2d.shape)}"
         )
 
-    flat_cache = cache_2d.reshape(-1)
+    cache_pages = cache_2d
     num_actual = min(slot_mapping.numel(), index_k.shape[0])
     for token_idx in range(num_actual):
         slot = int(slot_mapping[token_idx].item())
@@ -538,12 +537,11 @@ def write_deepseek_v4_indexer_fp8_cache(
             continue
         page = slot // block_size
         pos = slot % block_size
-        page_base = page * cache_2d.stride(0)
-        value_base = page_base + pos * index_head_dim
-        scale_base = page_base + block_size * index_head_dim + pos * scale_bytes
+        value_base = pos * index_head_dim
+        scale_base = block_size * index_head_dim + pos * scale_bytes
         q_bytes, scale = _fp8_e4m3_pow2_bytes(index_k[token_idx].float())
-        flat_cache[value_base : value_base + index_head_dim].copy_(q_bytes)
-        flat_cache[scale_base : scale_base + scale_bytes].copy_(
+        cache_pages[page, value_base : value_base + index_head_dim].copy_(q_bytes)
+        cache_pages[page, scale_base : scale_base + scale_bytes].copy_(
             scale.reshape(1).view(torch.uint8)
         )
 
@@ -625,11 +623,10 @@ def _write_deepseek_v4_indexer_fp8_cache_capturable(
     safe_slots = torch.where(valid, slots, torch.zeros_like(slots))
     pages = torch.div(safe_slots, block_size, rounding_mode="floor")
     pos = safe_slots % block_size
-    page_base = pages * cache_2d.stride(0)
-    value_base = page_base + pos * index_head_dim
-    scale_base = page_base + block_size * index_head_dim + pos * scale_bytes
+    value_base = pos * index_head_dim
+    scale_base = block_size * index_head_dim + pos * scale_bytes
 
-    flat_cache = cache_2d.reshape(-1)
+    cache_pages = cache_2d
     value_offsets = (
         value_base[:, None]
         + torch.arange(
@@ -642,8 +639,12 @@ def _write_deepseek_v4_indexer_fp8_cache_capturable(
         scale_base[:, None]
         + torch.arange(scale_bytes, device=cache_2d.device, dtype=torch.int64)[None, :]
     )
-    flat_cache[value_offsets] = value_bytes
-    flat_cache[scale_offsets] = scale.view(torch.uint8).reshape(num_rows, scale_bytes)
+    page_indices = pages[:, None]
+    cache_pages[page_indices, value_offsets] = value_bytes
+    cache_pages[page_indices, scale_offsets] = scale.view(torch.uint8).reshape(
+        num_rows,
+        scale_bytes,
+    )
 
 
 def read_deepseek_v4_indexer_mxfp4_cache(
@@ -668,15 +669,14 @@ def read_deepseek_v4_indexer_mxfp4_cache(
     if slot_mapping.numel() == 0:
         return torch.empty(out_shape, device=cache_2d.device, dtype=torch.float32)
 
-    flat_cache = cache_2d.reshape(-1)
+    cache_pages = cache_2d
     slots = slot_mapping.to(torch.int64)
     valid = slots >= 0
     safe_slots = torch.where(valid, slots, torch.zeros_like(slots))
     pages = torch.div(safe_slots, block_size, rounding_mode="floor")
     pos = safe_slots % block_size
-    page_base = pages * cache_2d.stride(0)
-    value_base = page_base + pos * value_bytes
-    scale_base = page_base + block_size * value_bytes + pos * scale_bytes
+    value_base = pos * value_bytes
+    scale_base = block_size * value_bytes + pos * scale_bytes
 
     value_offsets = (
         value_base[:, None]
@@ -686,7 +686,7 @@ def read_deepseek_v4_indexer_mxfp4_cache(
             dtype=torch.int64,
         )[None, :]
     )
-    packed = flat_cache[value_offsets]
+    packed = cache_pages[pages[:, None], value_offsets]
 
     scale_offsets = (
         scale_base[:, None]
@@ -696,7 +696,10 @@ def read_deepseek_v4_indexer_mxfp4_cache(
             dtype=torch.int64,
         )[None, :]
     )
-    scales = torch.pow(2.0, flat_cache[scale_offsets].to(torch.int32) - 127)
+    scales = torch.pow(
+        2.0,
+        cache_pages[pages[:, None], scale_offsets].to(torch.int32) - 127,
+    )
     byte_scales = scales.float().repeat_interleave(
         DEEPSEEK_V4_MXFP4_BLOCK_SIZE // 2, dim=1
     )
@@ -731,18 +734,19 @@ def read_deepseek_v4_indexer_fp8_cache(
         device=cache_2d.device,
         dtype=torch.float32,
     )
-    flat_cache = cache_2d.reshape(-1)
+    cache_pages = cache_2d
     for token_idx, raw_slot in enumerate(slot_mapping.tolist()):
         slot = int(raw_slot)
         if slot < 0:
             continue
         page = slot // block_size
         pos = slot % block_size
-        page_base = page * cache_2d.stride(0)
-        value_base = page_base + pos * index_head_dim
-        scale_base = page_base + block_size * index_head_dim + pos * scale_bytes
-        scale = flat_cache[scale_base : scale_base + scale_bytes].view(torch.float32)[0]
-        values = flat_cache[value_base : value_base + index_head_dim].view(
+        value_base = pos * index_head_dim
+        scale_base = block_size * index_head_dim + pos * scale_bytes
+        scale = cache_pages[page, scale_base : scale_base + scale_bytes].view(
+            torch.float32
+        )[0]
+        values = cache_pages[page, value_base : value_base + index_head_dim].view(
             torch.float8_e4m3fn
         )
         out[token_idx].copy_(values.float() * scale)

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
@@ -30,6 +30,9 @@ from tokenspeed.runtime.utils import get_colorful_logger
 
 if TYPE_CHECKING:
     from tokenspeed.runtime.cache.kvstore_controller import LayerDoneCounter
+    from tokenspeed.runtime.configs.flat_cache_runtime import (
+        FlatPagedCacheRuntimeContract,
+    )
 
 logger = get_colorful_logger(__name__)
 
@@ -37,9 +40,14 @@ logger = get_colorful_logger(__name__)
 class BaseTokenToKVPool:
     """A memory pool that maps a token location to its kv cache data."""
 
+    # Flat LCM pools publish their scheduler/runtime geometry here. Radix pools
+    # inherit the explicit None value; callers must not probe optional pool
+    # properties to infer the allocation backend.
+    runtime_contract: FlatPagedCacheRuntimeContract | None = None
     paged_cache_group_specs: tuple[PagedCacheGroupSpec, ...] = ()
     paged_cache_group_page_counts: dict[str, int] = {}
     supports_hierarchical_kv_cache: bool = True
+    supports_disaggregation: bool = False
     # Flat-cache pools that alias recurrent-state bytes and KV in one slab must
     # zero physical pages on reuse to avoid poisoned tails. Pure-attention
     # pools do not alias state, so reused pages need no sanitization.

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
@@ -13,10 +13,11 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from fractions import Fraction
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
@@ -27,6 +28,7 @@ from tokenspeed.runtime.configs.deepseek_v4_cache_spec import (
     V4_KERNEL_BLOCK_ROWS,
     V4_SWA_KV_GROUP_ID,
     build_v4_cache_specs,
+    build_v4_flat_cache_specs,
     deepseek_v4_indexer_fp8_row_bytes,
     deepseek_v4_indexer_mxfp4_row_bytes,
     deepseek_v4_swa_scale_dim,
@@ -34,6 +36,9 @@ from tokenspeed.runtime.configs.deepseek_v4_cache_spec import (
     parse_v4_compressor_state_group_id,
     v4_compressed_kv_group_id,
     v4_compressor_state_group_id,
+)
+from tokenspeed.runtime.configs.flat_cache_runtime import (
+    FlatPagedCacheRuntimeContract,
 )
 from tokenspeed.runtime.configs.paged_cache_spec import (
     PagedCacheGroupSpec,
@@ -43,9 +48,13 @@ from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (
     deepseek_v4_compressed_slot_mapping,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.base import BaseTokenToKVPool
+from tokenspeed.runtime.layers.attention.kv_cache.lcm import LcmCachePool
 from tokenspeed.runtime.utils import get_colorful_logger
 from tokenspeed.runtime.utils.common import ceil_div
 from tokenspeed.runtime.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.layers.attention.lcm_setup import LcmPoolSpec
 
 logger = get_colorful_logger(__name__)
 
@@ -71,10 +80,10 @@ class DeepseekV4CacheLayout:
     def swa_row_bytes(self) -> int:
         return self.swa_token_stride + self.swa_scale_dim
 
-    def swa_block_bytes(self, page_size: int | None = None) -> int:
-        if page_size is None:
-            page_size = self.page_size
-        block_bytes = page_size * self.swa_row_bytes
+    def swa_block_bytes(self, rows_per_page: int | None = None) -> int:
+        if rows_per_page is None:
+            rows_per_page = self.page_size
+        block_bytes = rows_per_page * self.swa_row_bytes
         alignment = self.swa_token_stride
         return ((block_bytes + alignment - 1) // alignment) * alignment
 
@@ -143,88 +152,26 @@ def _deepseek_v4_cache_group_page_bytes(
     specs: Sequence[PagedCacheGroupSpec],
     layer_num: int,
 ) -> dict[str, int]:
+    """Return legacy per-group page bytes from the shared V4 field recipe."""
+    from tokenspeed.runtime.configs.lcm_layouts import deepseek_v4_lcm_fields
+
     if layer_num > len(layout.layer_ratio):
         raise ValueError(
             "DeepSeek V4 cache layout has fewer layer ratios "
             f"({len(layout.layer_ratio)}) than requested layers ({layer_num})"
         )
-
-    group_rows = {spec.group_id: int(spec.rows_per_page) for spec in specs}
+    profile_layout = (
+        layout
+        if layer_num == len(layout.layer_ratio)
+        else replace(layout, layer_ratio=layout.layer_ratio[:layer_num])
+    )
     page_bytes = {spec.group_id: 0 for spec in specs}
-    fp32_size = torch._utils._element_size(torch.float32)
-
-    swa_block_bytes = layout.swa_block_bytes(
-        group_rows.get(V4_SWA_KV_GROUP_ID, V4_KERNEL_BLOCK_ROWS)
-    )
-    for layer_id, ratio in enumerate(layout.layer_ratio[:layer_num]):
-        page_bytes[V4_SWA_KV_GROUP_ID] += swa_block_bytes
-        if ratio <= 1:
-            continue
-
-        compressed_group_id = v4_compressed_kv_group_id(ratio)
-        compressed_block_size = layout.storage_block_size(ratio)
-        page_bytes[compressed_group_id] += layout.swa_block_bytes(compressed_block_size)
-
-        state_group_id = v4_compressor_state_group_id(ratio)
-        state_block_size = group_rows.get(state_group_id, layout.page_size)
-        page_bytes[state_group_id] += (
-            state_block_size * layout.state_width(layer_id) * 2 * fp32_size
-        )
-
-        if ratio == 4:
-            indexer_block_size = max(V4_KERNEL_BLOCK_ROWS, compressed_block_size)
-            page_bytes[compressed_group_id] += (
-                indexer_block_size * layout.indexer_row_bytes
-            )
-
-            indexer_state_block_size = group_rows.get(
-                V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
-                layout.compressor_state_block_size(ratio),
-            )
-            page_bytes[V4_INDEXER_COMPRESSOR_STATE_GROUP_ID] += (
-                indexer_state_block_size
-                * layout.state_width(layer_id, indexer=True)
-                * 2
-                * fp32_size
-            )
-
+    for field_spec in deepseek_v4_lcm_fields(
+        layout=profile_layout,
+        group_specs=specs,
+    ):
+        page_bytes[field_spec.group_id] += field_spec.payload_bytes
     return page_bytes
-
-
-def _estimate_deepseek_v4_cache_bytes(
-    *,
-    layout: DeepseekV4CacheLayout,
-    hf_config: Any,
-    layer_num: int,
-    max_total_tokens: int,
-    max_live_requests: int,
-    max_scheduled_tokens: int,
-    max_context_len: int,
-) -> int:
-    """Estimate bytes allocated by DeepseekV4TokenToKVPool for a token budget."""
-    if layer_num > len(layout.layer_ratio):
-        raise ValueError(
-            "DeepSeek V4 cache layout has fewer layer ratios "
-            f"({len(layout.layer_ratio)}) than requested layers ({layer_num})"
-        )
-    if max_total_tokens < 0:
-        raise ValueError(f"max_total_tokens must be >= 0, got {max_total_tokens}")
-
-    specs = tuple(build_v4_cache_specs(hf_config, layer_ratio=layout.layer_ratio))
-    page_bytes = _deepseek_v4_cache_group_page_bytes(layout, specs, layer_num)
-    counts = compute_paged_cache_group_page_counts(
-        specs,
-        max_live_requests=max_live_requests,
-        max_scheduled_tokens=max(0, int(max_scheduled_tokens)),
-        max_total_tokens=max_total_tokens,
-        max_context_len=max_context_len,
-    )
-    return int(
-        sum(
-            int(counts[gid]) * bytes_per_page
-            for gid, bytes_per_page in page_bytes.items()
-        )
-    )
 
 
 def profile_deepseek_v4_max_num_pages(
@@ -431,11 +378,14 @@ def _group_slot_mapping_from_raw(
     rows_per_page: int,
     entry_stride_tokens: int = 1,
     base_offsets: torch.Tensor | None = None,
+    capacity_pages: int | None = None,
 ) -> torch.Tensor:
     if rows_per_page <= 0:
         raise ValueError(f"rows_per_page must be > 0, got {rows_per_page}")
     if entry_stride_tokens <= 0:
         raise ValueError(f"entry_stride_tokens must be > 0, got {entry_stride_tokens}")
+    if capacity_pages is not None and capacity_pages < 0:
+        raise ValueError(f"capacity_pages must be >= 0, got {capacity_pages}")
     pos_i64 = positions.to(torch.int64)
     logical_row = torch.div(pos_i64, entry_stride_tokens, rounding_mode="floor")
     logical_page = torch.div(logical_row, rows_per_page, rounding_mode="floor")
@@ -461,7 +411,16 @@ def _group_slot_mapping_from_raw(
             table_page = torch.where(valid_req, logical_page - base, -1)
     page_ids = _safe_page_ids(block_table, req_indices, table_page)
     slots = page_ids * rows_per_page + offsets
-    return torch.where(page_ids >= 0, slots, torch.full_like(slots, -1))
+    # Page 0 is the zero-initialized null page. It may be read by padded rows,
+    # but no V4 producer is ever allowed to write through it. The upper bound is
+    # the actual owner/component allocation, not a scheduler-global page count.
+    # Flat CPU staging already rejects out-of-pool IDs before H2D; this mask is
+    # the device-side defense for stale graph buffers and direct/legacy metadata,
+    # and keeps every writer kernel safe without a hot-path host sync.
+    valid_pages = page_ids > 0
+    if capacity_pages is not None:
+        valid_pages &= page_ids < capacity_pages
+    return torch.where(valid_pages, slots, torch.full_like(slots, -1))
 
 
 def _mask_invalid_graph_tokens(
@@ -494,10 +453,10 @@ def _compressed_boundary_mask(
 class DeepseekV4CacheMetadata:
     page_size: int
     block_table: torch.Tensor
+    allow_legacy_block_table: bool = True
     paged_cache_block_tables: dict[str, torch.Tensor] = field(default_factory=dict)
-    # Per-sliding-group [num_reqs] int32 base logical-page offset that
-    # accompanies each compact block table. Consumers index sliding tables as
-    # logical_page - base_offset; full-history groups omit the key (base 0).
+    # Per-group [num_reqs] int32 logical-page bases accompanying compact tables.
+    # Sliding consumers index logical_page - base; full-history bases stay zero.
     paged_cache_block_table_base_offsets: dict[str, torch.Tensor] = field(
         default_factory=dict
     )
@@ -512,6 +471,18 @@ class DeepseekV4CacheMetadata:
     decode_compressed_slot_mappings: dict[tuple[int, int], torch.Tensor] = field(
         default_factory=dict
     )
+    decode_compressed_capacity_pages: dict[tuple[int, int], int] = field(
+        default_factory=dict
+    )
+
+    @property
+    def has_legacy_block_table(self) -> bool:
+        """Whether the radix-compatible single-table fallback is available."""
+        return (
+            self.allow_legacy_block_table
+            and self.block_table.ndim == 2
+            and self.block_table.shape[1] > 0
+        )
 
     def compressed_block_table(
         self,
@@ -520,6 +491,11 @@ class DeepseekV4CacheMetadata:
     ) -> torch.Tensor:
         del kv_cache_block_size
         if compress_ratio <= 1:
+            if not self.has_legacy_block_table:
+                raise RuntimeError(
+                    "DeepSeek V4 flat cache metadata cannot use the legacy "
+                    "single block_table fallback for an uncompressed group"
+                )
             return self.block_table
         table = self.paged_cache_block_tables.get(
             v4_compressed_kv_group_id(compress_ratio)
@@ -547,6 +523,7 @@ class DeepseekV4CacheMetadata:
         seq_lens: torch.Tensor,
         compress_ratio: int,
         kv_cache_block_size: int,
+        capacity_pages: int | None,
         is_valid_token: torch.Tensor | None = None,
     ) -> torch.Tensor:
         num_tokens = token_to_req_indices.shape[0]
@@ -597,7 +574,10 @@ class DeepseekV4CacheMetadata:
                     )[req_idx]
                 )
             page_ids = _safe_page_ids(block_table, req_idx, page_indices)
-            valid_slots = (page_ids >= 0) & _compressed_boundary_mask(
+            valid_pages = page_ids > 0
+            if capacity_pages is not None:
+                valid_pages &= page_ids < capacity_pages
+            valid_slots = valid_pages & _compressed_boundary_mask(
                 positions,
                 compress_ratio,
             )
@@ -618,6 +598,12 @@ class DeepseekV4CacheMetadata:
             compress_ratio=compress_ratio,
             out=out,
         )
+        if capacity_pages is not None:
+            capacity_slots = capacity_pages * kv_cache_block_size
+            valid_slots = (mapping >= kv_cache_block_size) & (mapping < capacity_slots)
+            mapping.copy_(
+                torch.where(valid_slots, mapping, torch.full_like(mapping, -1))
+            )
         if is_valid_token is not None:
             mapping.copy_(_mask_invalid_graph_tokens(mapping, is_valid_token))
         return mapping
@@ -633,12 +619,14 @@ class DeepseekV4CacheMetadata:
         for compress_ratio, kv_cache_block_size in list(
             self.decode_compressed_slot_mappings
         ):
+            key = (compress_ratio, kv_cache_block_size)
             self._update_decode_compressed_slot_mapping(
                 token_to_req_indices=token_to_req_indices,
                 query_start_loc=query_start_loc,
                 seq_lens=seq_lens,
                 compress_ratio=compress_ratio,
                 kv_cache_block_size=kv_cache_block_size,
+                capacity_pages=self.decode_compressed_capacity_pages.get(key),
                 is_valid_token=is_valid_token,
             )
 
@@ -651,20 +639,45 @@ class DeepseekV4CacheMetadata:
         query_start_loc: torch.Tensor,
         seq_lens: torch.Tensor,
         kv_cache_block_size: int | None = None,
+        capacity_pages: int | None = None,
         use_decode_cache: bool = False,
         is_valid_token: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if kv_cache_block_size is None:
             kv_cache_block_size = self.page_size
+        if capacity_pages is not None and capacity_pages < 0:
+            raise ValueError(f"capacity_pages must be >= 0, got {capacity_pages}")
+        if not self.has_legacy_block_table and capacity_pages is None:
+            raise RuntimeError(
+                "DeepSeek V4 flat compressed slot mapping requires the owner "
+                "component page capacity"
+            )
+        key = (compress_ratio, kv_cache_block_size)
+        ratio_capacities = {
+            existing_capacity
+            for (existing_ratio, _), existing_capacity in (
+                self.decode_compressed_capacity_pages.items()
+            )
+            if existing_ratio == compress_ratio
+        }
+        if capacity_pages is not None and any(
+            existing_capacity != capacity_pages
+            for existing_capacity in ratio_capacities
+        ):
+            raise RuntimeError(
+                "DeepSeek V4 co-indexed compressed components disagree on page "
+                f"capacity for ratio={compress_ratio}: "
+                f"first={min(ratio_capacities)}, current={capacity_pages}"
+            )
+        if capacity_pages is not None:
+            self.decode_compressed_capacity_pages[key] = capacity_pages
         block_table = self.compressed_block_table(compress_ratio, kv_cache_block_size)
         if (
             use_decode_cache
             and positions.is_cuda
             and (block_table.is_cuda or self.block_table.is_cuda)
         ):
-            cached = self.decode_compressed_slot_mappings.get(
-                (compress_ratio, kv_cache_block_size)
-            )
+            cached = self.decode_compressed_slot_mappings.get(key)
             if (
                 cached is not None
                 and cached.shape[0] >= positions.numel()
@@ -677,6 +690,7 @@ class DeepseekV4CacheMetadata:
                 seq_lens=seq_lens,
                 compress_ratio=compress_ratio,
                 kv_cache_block_size=kv_cache_block_size,
+                capacity_pages=capacity_pages,
                 is_valid_token=is_valid_token,
             )
             return mapping[: positions.numel()]
@@ -704,7 +718,10 @@ class DeepseekV4CacheMetadata:
                 )
             page_ids = _safe_page_ids(block_table, req_idx, page_indices.long())
         slots = page_ids.to(torch.int64) * kv_cache_block_size + offsets
-        valid_slots = (page_ids >= 0) & _compressed_boundary_mask(
+        valid_pages = page_ids > 0
+        if capacity_pages is not None:
+            valid_pages &= page_ids < capacity_pages
+        valid_slots = valid_pages & _compressed_boundary_mask(
             positions,
             compress_ratio,
         )
@@ -754,15 +771,12 @@ def deepseek_v4_cache_layout_from_config(
 class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
     """DeepSeek V4 fp8_ds_mla cache pool.
 
-    TokenSpeed keeps SWA, compressed, compressor-state, and CSA indexer caches
-    in dedicated per-group paged pools (see PagedCacheGroup* on the scheduler
-    side and ``build_v4_cache_specs`` here), keeping ordinary MLA models on
-    their existing single-pool contract. The ``indexer_kv_buffer`` shares its
-    page table and page-count budget with the ``v4.c{ratio}a.compressed_kv``
-    group rather than owning a separate group of its own.
+    SWA, compressed, compressor-state, and CSA indexer caches are exposed as
+    scheduler-visible logical groups. Radix uses distinct group buffers; Flat
+    binds the same logical contract to one shared LCM arena. The indexer KV
+    field shares the ``v4.c{ratio}a.compressed_kv`` group rather than owning a
+    separate page table.
     """
-
-    supports_hierarchical_kv_cache = True
 
     def __init__(
         self,
@@ -780,6 +794,7 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
         max_scheduled_tokens: int,
         decode_input_tokens: int = 1,
         overlap_schedule_depth: int = 0,
+        lcm_spec: LcmPoolSpec | None = None,
     ) -> None:
         if size <= 0:
             raise ValueError(f"DeepSeek V4 KV pool size must be positive, got {size}")
@@ -797,8 +812,6 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
             page_size=page_size,
             rank=rank,
         )
-        # Tag KV allocations as "kv_cache" (no CPU backup: discarded on sleep)
-        # so release/resume_memory_occupation frees them. See memory_occupation.py.
         self.memory_saver_adapter = TorchMemorySaverAdapter.create(
             enable=enable_memory_saver
         )
@@ -807,164 +820,293 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
         self.layer_num = layer_num
         self.max_batch_size = max_batch_size
         self.max_context_len = max_context_len
-        self.num_pages = (size + page_size - 1) // page_size + 1
-        self.paged_cache_group_specs = tuple(
-            build_v4_cache_specs(hf_config, layer_ratio=layout.layer_ratio)
+        self._lcm_memory_plan = lcm_spec.memory_plan if lcm_spec is not None else None
+        self.lcm_pool: LcmCachePool | None = None
+        self.runtime_contract: FlatPagedCacheRuntimeContract | None = None
+        self.supports_hierarchical_kv_cache = lcm_spec is None
+        self.flat_kv_requires_page_zeroing = lcm_spec is not None
+
+        spec_builder = (
+            build_v4_flat_cache_specs if lcm_spec is not None else build_v4_cache_specs
         )
+        expected_specs = tuple(spec_builder(hf_config, layer_ratio=layout.layer_ratio))
+        if lcm_spec is None:
+            group_specs = expected_specs
+            group_counts = compute_paged_cache_group_page_counts(
+                group_specs,
+                max_live_requests=max_batch_size,
+                max_scheduled_tokens=max(0, int(max_scheduled_tokens)),
+                max_total_tokens=size,
+                max_context_len=max_context_len,
+                decode_input_tokens=decode_input_tokens,
+                overlap_schedule_depth=overlap_schedule_depth,
+            )
+            self.num_pages = (size + page_size - 1) // page_size + 1
+        else:
+            plan = lcm_spec.memory_plan
+            if size != lcm_spec.pool_size:
+                raise ValueError(
+                    "DeepSeek V4 LCM pool size must equal its child-address "
+                    f"geometry: size={size}, geometry={lcm_spec.pool_size}"
+                )
+            group_specs = tuple(lcm_spec.extra_paged_groups)
+            expected_by_id = {spec.group_id: spec for spec in expected_specs}
+            actual_by_id = {spec.group_id: spec for spec in group_specs}
+            if actual_by_id.keys() != expected_by_id.keys():
+                raise ValueError(
+                    "DeepSeek V4 LCM groups disagree with the model layout: "
+                    f"expected={sorted(expected_by_id)}, "
+                    f"actual={sorted(actual_by_id)}"
+                )
+            groups_by_id = {group.group_id: group for group in plan.groups}
+            if groups_by_id.keys() != actual_by_id.keys():
+                raise ValueError(
+                    "DeepSeek V4 LCM plan and published groups disagree: "
+                    f"plan={sorted(groups_by_id)}, "
+                    f"published={sorted(actual_by_id)}"
+                )
+            for group_id, spec in actual_by_id.items():
+                expected = expected_by_id[group_id]
+                if (
+                    spec.retention != expected.retention
+                    or spec.rows_per_page != expected.rows_per_page
+                    or spec.entry_stride_tokens != expected.entry_stride_tokens
+                    or spec.sliding_window_tokens != expected.sliding_window_tokens
+                    or spec.family != expected.family
+                    or spec.block_size != expected.block_size
+                ):
+                    raise ValueError(
+                        "DeepSeek V4 LCM group geometry disagrees with the "
+                        f"model layout for {group_id!r}"
+                    )
+                if (
+                    spec.cache_blocks_per_lcm_block
+                    != groups_by_id[group_id].cache_blocks_per_lcm_block
+                ):
+                    raise ValueError(
+                        "DeepSeek V4 LCM group packing disagrees with the "
+                        f"memory plan for {group_id!r}"
+                    )
+            group_counts = {group.group_id: group.page_count for group in plan.groups}
+            self.num_pages = max(group_counts.values())
+            with self.memory_saver_adapter.region(
+                tag="kv_cache",
+                enable_cpu_backup=False,
+            ):
+                self.lcm_pool = LcmCachePool(plan, device)
+            self.runtime_contract = FlatPagedCacheRuntimeContract(
+                block_size=plan.logical_block_tokens,
+                num_lcm_blocks=plan.num_lcm_blocks,
+                token_capacity=lcm_spec.token_capacity,
+                group_specs=group_specs,
+                group_page_counts=group_counts,
+            )
+
+        self.paged_cache_group_specs = tuple(group_specs)
+        self.paged_cache_group_page_counts = dict(group_counts)
         self._paged_cache_group_specs_by_id = {
             spec.group_id: spec for spec in self.paged_cache_group_specs
         }
-        self.paged_cache_group_page_counts = compute_paged_cache_group_page_counts(
-            self.paged_cache_group_specs,
-            max_live_requests=max_batch_size,
-            max_scheduled_tokens=max(0, int(max_scheduled_tokens)),
-            max_total_tokens=size,
-            max_context_len=max_context_len,
-            decode_input_tokens=decode_input_tokens,
-            overlap_schedule_depth=overlap_schedule_depth,
+        self._paged_cache_scheduler: object | None = None
+        self._paged_cache_state_group_ids = tuple(
+            str(spec.group_id)
+            for spec in self.paged_cache_group_specs
+            if spec.family == "state"
         )
 
-        def _group_rows(group_id: str, default: int) -> int:
-            spec = self._paged_cache_group_specs_by_id.get(group_id)
-            return int(spec.rows_per_page) if spec is not None else int(default)
+        def group_rows(group_id: str) -> int:
+            try:
+                return int(self._paged_cache_group_specs_by_id[group_id].rows_per_page)
+            except KeyError as exc:
+                raise ValueError(
+                    f"DeepSeek V4 cache layout is missing group {group_id!r}"
+                ) from exc
 
-        self.swa_block_size = _group_rows(V4_SWA_KV_GROUP_ID, V4_KERNEL_BLOCK_ROWS)
-        self.state_block_size = page_size
+        is_lcm = self.lcm_pool is not None
+        self.swa_block_size = group_rows(V4_SWA_KV_GROUP_ID)
+        self._legacy_state_block_size = page_size
         self.swa_block_bytes = layout.swa_block_bytes(self.swa_block_size)
         self.compressed_block_sizes = tuple(
-            layout.storage_block_size(ratio) if ratio > 1 else page_size
+            (
+                group_rows(v4_compressed_kv_group_id(ratio))
+                if is_lcm and ratio > 1
+                else layout.storage_block_size(ratio) if ratio > 1 else page_size
+            )
             for ratio in layout.layer_ratio
         )
         self.indexer_block_sizes = tuple(
             (
-                max(V4_KERNEL_BLOCK_ROWS, self.compressed_block_sizes[layer_id])
-                if ratio == 4
-                else 0
+                group_rows(v4_compressed_kv_group_id(ratio))
+                if is_lcm and ratio == 4
+                else (
+                    max(V4_KERNEL_BLOCK_ROWS, self.compressed_block_sizes[layer_id])
+                    if ratio == 4
+                    else 0
+                )
             )
             for layer_id, ratio in enumerate(layout.layer_ratio)
         )
         self.compressor_state_block_sizes = tuple(
             (
-                _group_rows(v4_compressor_state_group_id(ratio), page_size)
+                group_rows(v4_compressor_state_group_id(ratio))
                 if ratio > 1
                 else page_size
             )
             for ratio in layout.layer_ratio
         )
         self.indexer_state_block_sizes = tuple(
-            (
-                _group_rows(
-                    V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
-                    layout.compressor_state_block_size(ratio),
-                )
-                if ratio == 4
-                else 0
-            )
+            (group_rows(V4_INDEXER_COMPRESSOR_STATE_GROUP_ID) if ratio == 4 else 0)
             for ratio in layout.layer_ratio
         )
-        self.compressed_block_size = (
-            self.compressed_block_sizes[0] if self.compressed_block_sizes else page_size
-        )
-
-        swa_pages = self.paged_cache_group_page_counts.get(
-            V4_SWA_KV_GROUP_ID,
-            self.num_pages,
-        )
-        with self.memory_saver_adapter.region(tag="kv_cache", enable_cpu_backup=False):
-            self.swa_kv_buffer = [
-                torch.zeros(
-                    (swa_pages, self.swa_block_bytes),
-                    dtype=torch.uint8,
-                    device=device,
-                )
-                for _ in range(layer_num)
-            ]
-            self.compressed_kv_buffer: list[torch.Tensor | None] = []
-            self.compressor_state_buffer: list[torch.Tensor | None] = []
-            self.indexer_kv_buffer: list[torch.Tensor | None] = []
-            self.indexer_state_buffer: list[torch.Tensor | None] = []
+        if self.lcm_pool is not None:
+            self.swa_kv_buffer = tuple(
+                self.lcm_pool.field(f"layer.{layer_id}.swa_kv", torch.uint8)
+                for layer_id in range(layer_num)
+            )
+            compressed_buffers: list[torch.Tensor | None] = []
+            compressor_state_buffers: list[torch.Tensor | None] = []
+            indexer_buffers: list[torch.Tensor | None] = []
+            indexer_state_buffers: list[torch.Tensor | None] = []
             for layer_id, ratio in enumerate(layout.layer_ratio):
-                has_compressed = ratio > 1
-                has_indexer = ratio == 4
-                compressed_block_size = self.compressed_block_sizes[layer_id]
-                compressed_group_id = v4_compressed_kv_group_id(ratio)
-                compressed_pages = self.num_pages
-                if has_compressed:
-                    compressed_pages = self.paged_cache_group_page_counts.get(
-                        compressed_group_id,
-                        self.num_pages,
+                if ratio > 1:
+                    compressed_buffers.append(
+                        self.lcm_pool.field(
+                            f"layer.{layer_id}.compressed_kv",
+                            torch.uint8,
+                        )
                     )
-                self.compressed_kv_buffer.append(
+                    compressor_state_buffers.append(
+                        self.lcm_pool.field(
+                            f"layer.{layer_id}.compressor_state",
+                            torch.float32,
+                        )
+                    )
+                else:
+                    compressed_buffers.append(None)
+                    compressor_state_buffers.append(None)
+                if ratio == 4:
+                    indexer_buffers.append(
+                        self.lcm_pool.field(
+                            f"layer.{layer_id}.indexer_kv",
+                            torch.uint8,
+                        )
+                    )
+                    indexer_state_buffers.append(
+                        self.lcm_pool.field(
+                            f"layer.{layer_id}.indexer_state",
+                            torch.float32,
+                        )
+                    )
+                else:
+                    indexer_buffers.append(None)
+                    indexer_state_buffers.append(None)
+            self.compressed_kv_buffer = tuple(compressed_buffers)
+            self.compressor_state_buffer = tuple(compressor_state_buffers)
+            self.indexer_kv_buffer = tuple(indexer_buffers)
+            self.indexer_state_buffer = tuple(indexer_state_buffers)
+        else:
+            swa_pages = self.paged_cache_group_page_counts.get(
+                V4_SWA_KV_GROUP_ID,
+                self.num_pages,
+            )
+            with self.memory_saver_adapter.region(
+                tag="kv_cache",
+                enable_cpu_backup=False,
+            ):
+                self.swa_kv_buffer = [
                     torch.zeros(
-                        (
-                            compressed_pages,
-                            layout.swa_block_bytes(compressed_block_size),
-                        ),
+                        (swa_pages, self.swa_block_bytes),
                         dtype=torch.uint8,
                         device=device,
                     )
-                    if has_compressed
-                    else None
-                )
-                compressor_state_block_size = self.compressor_state_block_sizes[
-                    layer_id
+                    for _ in range(layer_num)
                 ]
-                compressor_state_group_id = v4_compressor_state_group_id(ratio)
-                compressor_state_pages = self.num_pages
-                if has_compressed:
-                    compressor_state_pages = self.paged_cache_group_page_counts.get(
-                        compressor_state_group_id,
-                        self.num_pages,
+                self.compressed_kv_buffer: list[torch.Tensor | None] = []
+                self.compressor_state_buffer: list[torch.Tensor | None] = []
+                self.indexer_kv_buffer: list[torch.Tensor | None] = []
+                self.indexer_state_buffer: list[torch.Tensor | None] = []
+                for layer_id, ratio in enumerate(layout.layer_ratio):
+                    has_compressed = ratio > 1
+                    has_indexer = ratio == 4
+                    compressed_block_size = self.compressed_block_sizes[layer_id]
+                    compressed_group_id = v4_compressed_kv_group_id(ratio)
+                    compressed_pages = self.num_pages
+                    if has_compressed:
+                        compressed_pages = self.paged_cache_group_page_counts.get(
+                            compressed_group_id,
+                            self.num_pages,
+                        )
+                    self.compressed_kv_buffer.append(
+                        torch.zeros(
+                            (
+                                compressed_pages,
+                                layout.swa_block_bytes(compressed_block_size),
+                            ),
+                            dtype=torch.uint8,
+                            device=device,
+                        )
+                        if has_compressed
+                        else None
                     )
-                self.compressor_state_buffer.append(
-                    torch.empty(
-                        (
-                            compressor_state_pages,
-                            compressor_state_block_size,
-                            layout.state_width(layer_id) * 2,
-                        ),
-                        dtype=torch.float32,
-                        device=device,
+                    state_block_size = self.compressor_state_block_sizes[layer_id]
+                    state_group_id = v4_compressor_state_group_id(ratio)
+                    state_pages = self.num_pages
+                    if has_compressed:
+                        state_pages = self.paged_cache_group_page_counts.get(
+                            state_group_id,
+                            self.num_pages,
+                        )
+                    self.compressor_state_buffer.append(
+                        torch.empty(
+                            (
+                                state_pages,
+                                state_block_size,
+                                layout.state_width(layer_id) * 2,
+                            ),
+                            dtype=torch.float32,
+                            device=device,
+                        )
+                        if has_compressed
+                        else None
                     )
-                    if has_compressed
-                    else None
-                )
-                indexer_block_size = self.indexer_block_sizes[layer_id]
-                self.indexer_kv_buffer.append(
-                    torch.zeros(
-                        (
-                            compressed_pages,
-                            indexer_block_size * layout.indexer_row_bytes,
-                        ),
-                        dtype=torch.uint8,
-                        device=device,
+                    indexer_block_size = self.indexer_block_sizes[layer_id]
+                    self.indexer_kv_buffer.append(
+                        torch.zeros(
+                            (
+                                compressed_pages,
+                                indexer_block_size * layout.indexer_row_bytes,
+                            ),
+                            dtype=torch.uint8,
+                            device=device,
+                        )
+                        if has_indexer
+                        else None
                     )
-                    if has_indexer
-                    else None
-                )
-                indexer_state_block_size = self.indexer_state_block_sizes[layer_id]
-                indexer_state_pages = self.num_pages
-                if has_indexer:
-                    indexer_state_pages = self.paged_cache_group_page_counts.get(
-                        V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
-                        self.num_pages,
+                    index_state_block_size = self.indexer_state_block_sizes[layer_id]
+                    index_state_pages = self.num_pages
+                    if has_indexer:
+                        index_state_pages = self.paged_cache_group_page_counts.get(
+                            V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
+                            self.num_pages,
+                        )
+                    self.indexer_state_buffer.append(
+                        torch.empty(
+                            (
+                                index_state_pages,
+                                index_state_block_size,
+                                layout.state_width(layer_id, indexer=True) * 2,
+                            ),
+                            dtype=torch.float32,
+                            device=device,
+                        )
+                        if has_indexer
+                        else None
                     )
-                self.indexer_state_buffer.append(
-                    torch.empty(
-                        (
-                            indexer_state_pages,
-                            indexer_state_block_size,
-                            layout.state_width(layer_id, indexer=True) * 2,
-                        ),
-                        dtype=torch.float32,
-                        device=device,
-                    )
-                    if has_indexer
-                    else None
-                )
 
         logger.info(
-            "Initialized DeepSeek V4 KV pool: %d pages, %d layers, fp4 indexer=%s, compressed block sizes=%s",
+            "Initialized DeepSeek V4 %s KV pool: %d max group pages, %d layers, "
+            "fp4 indexer=%s, compressed block sizes=%s",
+            "LCM" if is_lcm else "radix",
             self.num_pages,
             layer_num,
             layout.use_fp4_indexer_cache,
@@ -979,8 +1121,32 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
             if spec.family == "history"
         )
 
+    def bind_paged_cache_scheduler(self, scheduler: object) -> None:
+        self._paged_cache_scheduler = scheduler
+
+    def maybe_log_paged_cache_group_pages(self) -> None:
+        scheduler = self._paged_cache_scheduler
+        if self.rank != 0 or scheduler is None or not self._paged_cache_state_group_ids:
+            return
+        if not logger.isEnabledFor(logging.DEBUG):
+            return
+
+        parts = []
+        for group_id in self._paged_cache_state_group_ids:
+            total = scheduler.paged_cache_group_total_pages(group_id)
+            available = scheduler.paged_cache_group_available_pages(group_id)
+            failed = scheduler.paged_cache_group_failed_alloc_count(group_id)
+            parts.append(
+                f"{group_id}: used={total - available}/{total}, "
+                f"available={available}, failed_alloc={failed}"
+            )
+        logger.debug("DeepSeek V4 paged-cache state group pages. %s", "; ".join(parts))
+
     def _require(
-        self, buffers: list[torch.Tensor | None], layer_id: int, name: str
+        self,
+        buffers: Sequence[torch.Tensor | None],
+        layer_id: int,
+        name: str,
     ) -> torch.Tensor:
         self._wait_for_layer_loadback(layer_id)
         buf = buffers[layer_id]
@@ -998,6 +1164,24 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
         return self.swa_kv_buffer[layer_id]
 
     @property
+    def state_block_size(self) -> int:
+        """Legacy/radix state-block fallback; Flat requires a group table."""
+        if self.runtime_contract is not None:
+            raise RuntimeError(
+                "DeepSeek V4 Flat KV state geometry requires its group-specific "
+                "block table"
+            )
+        return self._legacy_state_block_size
+
+    @property
+    def swa_capacity_pages(self) -> int:
+        """Writable owner-local SWA capacity shared by every layer, in pages."""
+
+        if not self.swa_kv_buffer:
+            return 0
+        return int(self.swa_kv_buffer[0].shape[0])
+
+    @property
     def swa_capacity_slots(self) -> int:
         """Writable SWA cache capacity shared by every layer, in token slots.
 
@@ -1006,9 +1190,7 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
         mapping shared across layers. Returns 0 when no SWA buffers exist;
         callers must then mask all slots rather than skip the bounds check.
         """
-        if not self.swa_kv_buffer:
-            return 0
-        return int(self.swa_kv_buffer[0].shape[0]) * int(self.swa_block_size)
+        return self.swa_capacity_pages * int(self.swa_block_size)
 
     def get_compressed_kv_buffer_2d(self, layer_id: int) -> torch.Tensor:
         return self._require(self.compressed_kv_buffer, layer_id, "compressed KV")
@@ -1036,7 +1218,9 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
     def get_compressor_state_view(self, layer_id: int) -> torch.Tensor:
         buf = self.get_compressor_state_buffer(layer_id)
         block_size = self.get_compressor_state_block_size(layer_id)
-        return buf.view(-1, block_size, buf.shape[-1])
+        if buf.shape[1] != block_size:
+            raise ValueError("compressor-state buffer disagrees with its block size")
+        return buf
 
     def get_indexer_kv_buffer_2d(self, layer_id: int) -> torch.Tensor:
         return self._require(self.indexer_kv_buffer, layer_id, "indexer KV")
@@ -1053,7 +1237,9 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
     def get_indexer_state_view(self, layer_id: int) -> torch.Tensor:
         buf = self.get_indexer_state_buffer(layer_id)
         block_size = self.get_indexer_state_block_size(layer_id)
-        return buf.view(-1, block_size, buf.shape[-1])
+        if buf.shape[1] != block_size:
+            raise ValueError("indexer-state buffer disagrees with its block size")
+        return buf
 
     def get_key_buffer(self, layer_id: int) -> torch.Tensor:
         return self.get_swa_kv_buffer(layer_id)
@@ -1079,14 +1265,13 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
     ) -> None:
         if tgt_loc.numel() == 0:
             return
-        flat = buf.reshape(-1)
+        pages = buf.flatten(start_dim=1)
         tgt = tgt_loc.to(torch.int64)
         src = src_loc.to(torch.int64)
         tgt_page = torch.div(tgt, block_size, rounding_mode="floor")
         src_page = torch.div(src, block_size, rounding_mode="floor")
         tgt_pos = tgt % block_size
         src_pos = src % block_size
-        block_stride = buf.stride(0)
         token_stride = self.layout.swa_token_stride
         scale_dim = self.layout.swa_scale_dim
 
@@ -1095,18 +1280,10 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
             dtype=torch.int64,
             device=buf.device,
         )
-        tgt_value = (
-            tgt_page[:, None] * block_stride
-            + tgt_pos[:, None] * token_stride
-            + value_offsets[None, :]
-        )
-        src_value = (
-            src_page[:, None] * block_stride
-            + src_pos[:, None] * token_stride
-            + value_offsets[None, :]
-        )
-        value_rows = flat[src_value].clone()
-        flat[tgt_value] = value_rows
+        tgt_value = tgt_pos[:, None] * token_stride + value_offsets[None, :]
+        src_value = src_pos[:, None] * token_stride + value_offsets[None, :]
+        value_rows = pages[src_page[:, None], src_value].clone()
+        pages[tgt_page[:, None], tgt_value] = value_rows
 
         scale_offsets = torch.arange(
             scale_dim,
@@ -1114,20 +1291,10 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
             device=buf.device,
         )
         scale_base = block_size * token_stride
-        tgt_scale = (
-            tgt_page[:, None] * block_stride
-            + scale_base
-            + tgt_pos[:, None] * scale_dim
-            + scale_offsets[None, :]
-        )
-        src_scale = (
-            src_page[:, None] * block_stride
-            + scale_base
-            + src_pos[:, None] * scale_dim
-            + scale_offsets[None, :]
-        )
-        scale_rows = flat[src_scale].clone()
-        flat[tgt_scale] = scale_rows
+        tgt_scale = scale_base + tgt_pos[:, None] * scale_dim + scale_offsets[None, :]
+        src_scale = scale_base + src_pos[:, None] * scale_dim + scale_offsets[None, :]
+        scale_rows = pages[src_page[:, None], src_scale].clone()
+        pages[tgt_page[:, None], tgt_scale] = scale_rows
 
     def _move_rows(
         self,
@@ -1137,8 +1304,16 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
         src_loc: torch.Tensor,
         block_size: int,
     ) -> None:
-        rows = buf.view(-1, block_size, row_bytes).reshape(-1, row_bytes)
-        rows[tgt_loc.long()] = rows[src_loc.long()]
+        pages = buf.flatten(start_dim=1)
+        offsets = torch.arange(row_bytes, dtype=torch.int64, device=buf.device)
+        tgt = tgt_loc.to(torch.int64)
+        src = src_loc.to(torch.int64)
+        tgt_page = torch.div(tgt, block_size, rounding_mode="floor")
+        src_page = torch.div(src, block_size, rounding_mode="floor")
+        tgt_offsets = (tgt % block_size)[:, None] * row_bytes + offsets[None, :]
+        src_offsets = (src % block_size)[:, None] * row_bytes + offsets[None, :]
+        rows = pages[src_page[:, None], src_offsets].clone()
+        pages[tgt_page[:, None], tgt_offsets] = rows
 
     def _compressed_locs_from_token_locs(
         self,
@@ -1152,6 +1327,11 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
         return page * block_size + torch.div(pos, ratio, rounding_mode="floor")
 
     def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor) -> None:
+        if self.lcm_pool is not None:
+            raise RuntimeError(
+                "DeepSeek V4 LCM pages are relocated by the shared parent "
+                "allocator, not the radix token compactor"
+            )
         if tgt_loc.numel() == 0:
             return
         for layer_id in range(self.layer_num):
@@ -1196,8 +1376,13 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
             for buffers in (self.compressor_state_buffer, self.indexer_state_buffer):
                 buf = buffers[layer_id]
                 if buf is not None:
-                    rows = buf.view(-1, buf.shape[-1])
-                    rows[tgt_loc.long()] = rows[src_loc.long()]
+                    self._move_rows(
+                        buf,
+                        buf.shape[-1],
+                        tgt_loc,
+                        src_loc,
+                        buf.shape[1],
+                    )
 
     def _all_buffers(self) -> list[torch.Tensor]:
         out: list[torch.Tensor] = []
@@ -1214,12 +1399,29 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
                     out.append(buf)
         return out
 
+    def zero_new_pages(self, new_page_ids: dict[str, list[int]]) -> None:
+        if new_page_ids:
+            if self.lcm_pool is None:
+                raise RuntimeError("page zeroing is only valid for V4 LCM cache")
+            self.lcm_pool.zero_pages(new_page_ids)
+
+    @torch.no_grad()
+    def clear_kv_buffers(self) -> None:
+        if self.lcm_pool is not None:
+            self.lcm_pool.backing.zero_()
+            return
+        super().clear_kv_buffers()
+
     def get_kv_size_bytes(self) -> int:
+        if self.lcm_pool is not None:
+            return int(self.lcm_pool.backing.nbytes)
         return int(
             sum(np.prod(buf.shape) * buf.dtype.itemsize for buf in self._all_buffers())
         )
 
     def get_contiguous_buf_infos(self):
+        if self.lcm_pool is not None:
+            raise RuntimeError("DeepSeek V4 LCM cache does not support legacy transfer")
         buffers = self._all_buffers()
         return (
             [buf.data_ptr() for buf in buffers],

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/lcm_mha.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/lcm_mha.py
@@ -49,6 +49,7 @@ class LcmMHATokenToKVPool(MHATokenToKVPool):
         *,
         memory_plan: LcmMemoryPlan,
         layer_group_ids: tuple[str, ...],
+        token_capacity: int,
         state_field_dtypes: Mapping[str, torch.dtype] | None = None,
         **kwargs,
     ):
@@ -69,7 +70,7 @@ class LcmMHATokenToKVPool(MHATokenToKVPool):
         if len(self.layer_cache_group_ids) != kwargs["layer_num"]:
             raise ValueError("LCM cache group ids must cover every model layer")
 
-        super().__init__(**kwargs)
+        super().__init__(admission_token_capacity=token_capacity, **kwargs)
 
         # Boundary checkpoints default to BF16. Direct FP8-E5M2 storage is an
         # explicit capacity mode because its restore error affects model output.
@@ -81,7 +82,7 @@ class LcmMHATokenToKVPool(MHATokenToKVPool):
         self.runtime_contract = FlatPagedCacheRuntimeContract(
             block_size=self.page_size,
             num_lcm_blocks=memory_plan.num_lcm_blocks,
-            token_capacity=self.size,
+            token_capacity=token_capacity,
             group_specs=self.paged_cache_group_specs,
             group_page_counts=self.paged_cache_group_page_counts,
         )

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/mha.py
@@ -67,6 +67,7 @@ class MHATokenToKVPool(BaseTokenToKVPool):
         layer_types: tuple[str, ...] = (),
         sliding_window_tokens: int | tuple[int | None, ...] | None = None,
         max_scheduled_tokens: int = 0,
+        admission_token_capacity: int | None = None,
         pd_disaggregation_enabled: bool = False,
         enable_kv_cache_copy: bool = False,
         enable_alt_stream: bool = True,
@@ -76,6 +77,20 @@ class MHATokenToKVPool(BaseTokenToKVPool):
         layer_kv_head_counts: tuple[int, ...] | None = None,
         kv_alloc_head_count: int | None = None,
     ):
+        if admission_token_capacity is None:
+            admission_token_capacity = size
+        elif (
+            isinstance(admission_token_capacity, bool)
+            or not isinstance(admission_token_capacity, int)
+            or admission_token_capacity <= 0
+            or admission_token_capacity > size
+        ):
+            raise ValueError(
+                "admission_token_capacity must be a positive integer no greater "
+                f"than the physical pool size ({size}), got "
+                f"{admission_token_capacity!r}"
+            )
+
         super().__init__(
             size, dtype, device, max_batch_size, max_context_len, page_size, rank
         )
@@ -152,7 +167,7 @@ class MHATokenToKVPool(BaseTokenToKVPool):
             extra_groups=extra_paged_groups,
             max_live_requests=max_batch_size,
             max_scheduled_tokens=max_scheduled_tokens,
-            max_total_tokens=size,
+            max_total_tokens=admission_token_capacity,
             max_context_len=max_context_len,
         )
         if published is None:

--- a/python/tokenspeed/runtime/layers/attention/lcm_setup.py
+++ b/python/tokenspeed/runtime/layers/attention/lcm_setup.py
@@ -22,14 +22,16 @@
 
 from __future__ import annotations
 
+import math
 import os
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal
 
 import torch
 
 from tokenspeed.runtime.configs.lcm_layouts import (
+    deepseek_v4_lcm_fields,
     draft_history_lcm_fields,
     inkling_lcm_fields,
     mla_history_lcm_fields,
@@ -43,6 +45,9 @@ from tokenspeed.runtime.configs.paged_cache_spec import (
     FULL_ATTENTION,
     LINEAR_ATTENTION,
     PagedCacheGroupSpec,
+    compute_paged_cache_group_page_counts,
+    full_history_lcm_group_capacities,
+    group_specs_from_layer_types,
     split_recurrent_state_groups,
 )
 from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
@@ -50,15 +55,26 @@ from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.kv_cache.base import BaseTokenToKVPool
 
-LcmModelFamily = Literal["qwen_gdn", "inkling", "kimi_k3"]
+LcmModelFamily = Literal["qwen_gdn", "inkling", "kimi_k3", "deepseek_v4"]
 
 _LOGICAL_BLOCK_TOKENS = 128
 _MAX_PADDING_FRACTION = 1.0
+# The production 43-layer V4 target peaks below 2.6x per-group parent slack:
+# the c4 history tenant is intentionally overlaid with wider state tenants.
+# Keep finite 8x headroom so new layouts fail closed instead of silently
+# degenerating to one physical plane set per group.
+_DEEPSEEK_V4_MAX_PADDING_FRACTION = 8.0
+_DEEPSEEK_V4_LCM_ALIGNMENT = 256
 
 
 @dataclass(frozen=True)
 class LcmPoolSpec:
-    """Everything needed to bind one model's compute views to an LCM arena."""
+    """Everything needed to bind one model's compute views to an LCM arena.
+
+    ``pool_size`` is the physical child-address extent. ``token_capacity`` is
+    independently bounded by the narrowest full-history group and is the only
+    value scheduler admission may consume.
+    """
 
     memory_plan: LcmMemoryPlan
     layer_types: tuple[str, ...]
@@ -70,6 +86,7 @@ class LcmPoolSpec:
 
     @property
     def pool_size(self) -> int:
+        """Return child-address extent; admission uses ``token_capacity``."""
         max_packing = max(
             group.cache_blocks_per_lcm_block for group in self.memory_plan.groups
         )
@@ -92,6 +109,85 @@ def _packing(plan: LcmMemoryPlan) -> dict[str, int]:
     return {
         group.group_id: int(group.cache_blocks_per_lcm_block) for group in plan.groups
     }
+
+
+def _deepseek_v4_base_block_size(
+    specs: tuple[PagedCacheGroupSpec, ...],
+) -> int:
+    return math.gcd(*(int(spec.block_size) for spec in specs))
+
+
+def _deepseek_v4_lcm_blocks_needed(
+    specs: tuple[PagedCacheGroupSpec, ...],
+    packing: Mapping[str, int],
+    *,
+    token_capacity: int,
+    max_scheduled_tokens: int,
+    max_live_requests: int,
+    max_context_len: int,
+    decode_input_tokens: int,
+    overlap_schedule_depth: int,
+) -> int:
+    counts = compute_paged_cache_group_page_counts(
+        specs,
+        max_live_requests=max_live_requests,
+        max_scheduled_tokens=max_scheduled_tokens,
+        max_total_tokens=token_capacity,
+        max_context_len=max_context_len,
+        decode_input_tokens=decode_input_tokens,
+        overlap_schedule_depth=overlap_schedule_depth,
+    )
+    return sum(
+        (max(0, counts[spec.group_id] - 1) + packing[spec.group_id] - 1)
+        // packing[spec.group_id]
+        for spec in specs
+    )
+
+
+def _deepseek_v4_token_capacity(
+    specs: tuple[PagedCacheGroupSpec, ...],
+    packing: Mapping[str, int],
+    *,
+    num_lcm_blocks: int,
+    upper_bound_tokens: int | None,
+    max_scheduled_tokens: int,
+    max_live_requests: int,
+    max_context_len: int,
+    decode_input_tokens: int,
+    overlap_schedule_depth: int,
+) -> int:
+    sizing = dict(
+        max_scheduled_tokens=max_scheduled_tokens,
+        max_live_requests=max_live_requests,
+        max_context_len=max_context_len,
+        decode_input_tokens=decode_input_tokens,
+        overlap_schedule_depth=overlap_schedule_depth,
+    )
+    if upper_bound_tokens is None:
+        upper_bound_tokens = num_lcm_blocks * max(
+            packing[spec.group_id] * int(spec.block_size) for spec in specs
+        )
+    low, high = 0, upper_bound_tokens
+    while low < high:
+        candidate = (low + high + 1) // 2
+        if (
+            _deepseek_v4_lcm_blocks_needed(
+                specs,
+                packing,
+                token_capacity=candidate,
+                **sizing,
+            )
+            <= num_lcm_blocks
+        ):
+            low = candidate
+        else:
+            high = candidate - 1
+    if low == 0:
+        raise ValueError(
+            f"num_lcm_blocks={num_lcm_blocks} cannot admit one token with "
+            "the configured DeepSeek V4 Flat KV scheduler limits"
+        )
+    return low
 
 
 def _token_limit(server_args) -> int | None:
@@ -378,6 +474,178 @@ def _prepare_kimi_k3(
     )
 
 
+def _deepseek_v4_pool_spec(
+    *,
+    layout,
+    specs: tuple[PagedCacheGroupSpec, ...],
+    fields,
+    num_lcm_blocks: int,
+    packing: Mapping[str, int],
+    logical_block_tokens: int,
+    token_capacity: int,
+) -> LcmPoolSpec:
+    group_ids = {field.group_id for field in fields}
+    group_packing = {group_id: packing[group_id] for group_id in group_ids}
+    plan = plan_lcm_fields(
+        fields,
+        logical_block_tokens=logical_block_tokens,
+        num_lcm_blocks=num_lcm_blocks,
+        cache_blocks_per_lcm_block=group_packing,
+        alignment=_DEEPSEEK_V4_LCM_ALIGNMENT,
+        max_padding_fraction=_DEEPSEEK_V4_MAX_PADDING_FRACTION,
+    )
+    packed_specs = tuple(
+        replace(
+            spec,
+            cache_blocks_per_lcm_block=group_packing[spec.group_id],
+        )
+        for spec in specs
+    )
+    return LcmPoolSpec(
+        memory_plan=plan,
+        layer_types=("deepseek_v4",) * len(layout.layer_ratio),
+        layer_group_ids=("deepseek_v4",) * len(layout.layer_ratio),
+        state_field_dtypes={},
+        token_capacity=token_capacity,
+        extra_paged_groups=packed_specs,
+    )
+
+
+def _prepare_deepseek_v4(
+    *,
+    server_args,
+    model_config,
+    draft_model_config,
+    target_layout,
+    draft_layout,
+    cache_budget_bytes: int,
+    max_scheduled_tokens: int,
+    max_live_requests: int,
+    max_context_len: int,
+    decode_input_tokens: int,
+    overlap_schedule_depth: int,
+) -> LcmSetup:
+    from tokenspeed.runtime.configs.deepseek_v4_cache_spec import (
+        build_v4_flat_cache_specs,
+    )
+
+    target_specs = tuple(
+        build_v4_flat_cache_specs(
+            model_config.hf_config,
+            layer_ratio=target_layout.layer_ratio,
+        )
+    )
+    target_fields = deepseek_v4_lcm_fields(
+        layout=target_layout,
+        group_specs=target_specs,
+    )
+    base_block_size = _deepseek_v4_base_block_size(target_specs)
+    reference_plan = plan_lcm_fields(
+        target_fields,
+        logical_block_tokens=base_block_size,
+        num_lcm_blocks=1,
+        alignment=_DEEPSEEK_V4_LCM_ALIGNMENT,
+        max_padding_fraction=_DEEPSEEK_V4_MAX_PADDING_FRACTION,
+    )
+    target_packing = _packing(reference_plan)
+
+    draft_specs: tuple[PagedCacheGroupSpec, ...] = ()
+    draft_fields = ()
+    draft_parent_bytes = 0
+    draft_packing: dict[str, int] = {}
+    if draft_layout is not None:
+        if draft_model_config is None:
+            raise ValueError("DeepSeek V4 draft layout requires a draft model")
+        draft_specs = tuple(
+            build_v4_flat_cache_specs(
+                draft_model_config.hf_config,
+                layer_ratio=draft_layout.layer_ratio,
+            )
+        )
+        draft_fields = deepseek_v4_lcm_fields(
+            layout=draft_layout,
+            group_specs=draft_specs,
+        )
+        draft_groups = {field.group_id for field in draft_fields}
+        unknown = draft_groups - target_packing.keys()
+        if unknown:
+            raise ValueError(
+                "DeepSeek V4 draft cache groups are absent from the target "
+                f"LCM plan: {sorted(unknown)}"
+            )
+        draft_packing = {
+            group_id: target_packing[group_id] for group_id in draft_groups
+        }
+        draft_parent_bytes = plan_lcm_fields(
+            draft_fields,
+            logical_block_tokens=base_block_size,
+            num_lcm_blocks=1,
+            cache_blocks_per_lcm_block=draft_packing,
+            alignment=_DEEPSEEK_V4_LCM_ALIGNMENT,
+            max_padding_fraction=_DEEPSEEK_V4_MAX_PADDING_FRACTION,
+        ).lcm_block_bytes
+
+    parent_bytes = reference_plan.lcm_block_bytes + draft_parent_bytes
+    num_lcm_blocks = cache_budget_bytes // parent_bytes - 1
+    if num_lcm_blocks < 1:
+        raise ValueError(
+            "DeepSeek V4 cache budget must hold a null parent and one usable LCM parent"
+        )
+
+    token_limit = _token_limit(server_args)
+    sizing = dict(
+        max_scheduled_tokens=max_scheduled_tokens,
+        max_live_requests=max_live_requests,
+        max_context_len=max_context_len,
+        decode_input_tokens=decode_input_tokens,
+        overlap_schedule_depth=overlap_schedule_depth,
+    )
+    if token_limit is not None:
+        num_lcm_blocks = min(
+            num_lcm_blocks,
+            _deepseek_v4_lcm_blocks_needed(
+                target_specs,
+                target_packing,
+                token_capacity=token_limit,
+                **sizing,
+            ),
+        )
+    admitted_tokens = _deepseek_v4_token_capacity(
+        target_specs,
+        target_packing,
+        num_lcm_blocks=num_lcm_blocks,
+        upper_bound_tokens=token_limit,
+        **sizing,
+    )
+
+    target_spec = _deepseek_v4_pool_spec(
+        layout=target_layout,
+        specs=target_specs,
+        fields=target_fields,
+        num_lcm_blocks=num_lcm_blocks,
+        packing=target_packing,
+        logical_block_tokens=base_block_size,
+        token_capacity=admitted_tokens,
+    )
+    draft_spec = None
+    if draft_layout is not None:
+        draft_spec = _deepseek_v4_pool_spec(
+            layout=draft_layout,
+            specs=draft_specs,
+            fields=draft_fields,
+            num_lcm_blocks=num_lcm_blocks,
+            packing=draft_packing,
+            logical_block_tokens=base_block_size,
+            token_capacity=admitted_tokens,
+        )
+    return LcmSetup(
+        target=target_spec,
+        draft=draft_spec,
+        cache_budget_bytes=cache_budget_bytes,
+        fixed_workspace_bytes=0,
+    )
+
+
 def _prepare_mha(
     *,
     family: LcmModelFamily,
@@ -519,14 +787,34 @@ def _prepare_mha(
             "cache budget must hold a null parent and one usable LCM parent"
         )
 
-    max_packing = max(target_packing.values())
+    layer_group_packings = {
+        group_id: target_packing[group_id] for group_id in set(group_ids)
+    }
+    layer_group_specs = group_specs_from_layer_types(
+        layer_types=layer_types,
+        group_ids=group_ids,
+        sliding_window_tokens=attn_config.sliding_window_tokens,
+        page_size=_LOGICAL_BLOCK_TOKENS,
+        cache_blocks_per_lcm_block=layer_group_packings,
+    )
+    full_history_capacities = full_history_lcm_group_capacities(
+        layer_group_specs,
+        base_block_size=_LOGICAL_BLOCK_TOKENS,
+        num_lcm_blocks=1,
+    )
+    if not full_history_capacities:
+        raise ValueError(
+            "MHA LCM cache requires at least one full-history history group "
+            "to define scheduler admission capacity"
+        )
+    admission_tokens_per_parent = min(full_history_capacities.values())
     token_limit = _token_limit(server_args)
     if token_limit is not None:
-        requested = token_limit // _LOGICAL_BLOCK_TOKENS // max_packing
+        requested = token_limit // admission_tokens_per_parent
         if requested < 1:
             raise ValueError(
                 "the configured token limit must hold at least one LCM parent "
-                f"({_LOGICAL_BLOCK_TOKENS * max_packing} child tokens)"
+                f"({admission_tokens_per_parent} admitted tokens)"
             )
         num_lcm_blocks = min(num_lcm_blocks, requested)
 
@@ -543,7 +831,7 @@ def _prepare_mha(
         layer_types=layer_types,
         layer_group_ids=group_ids,
         state_field_dtypes=state_dtypes,
-        token_capacity=(num_lcm_blocks * max_packing * _LOGICAL_BLOCK_TOKENS),
+        token_capacity=num_lcm_blocks * admission_tokens_per_parent,
         layer_kv_head_counts=layer_kv_head_counts,
         extra_paged_groups=(
             _inkling_checkpoint_groups(target_plan) if family == "inkling" else ()
@@ -586,8 +874,26 @@ def prepare_lcm_setup(
     cache_budget_bytes: int,
     decode_input_tokens: int,
     overlap_schedule_depth: int,
+    deepseek_v4_layout=None,
+    draft_deepseek_v4_layout=None,
 ) -> LcmSetup:
     """Apply one model recipe and size target/draft arenas from one budget."""
+    if family == "deepseek_v4":
+        if deepseek_v4_layout is None:
+            raise ValueError("DeepSeek V4 LCM setup requires its cache layout")
+        return _prepare_deepseek_v4(
+            server_args=server_args,
+            model_config=model_config,
+            draft_model_config=draft_model_config,
+            target_layout=deepseek_v4_layout,
+            draft_layout=draft_deepseek_v4_layout,
+            cache_budget_bytes=cache_budget_bytes,
+            max_scheduled_tokens=server_args.chunked_prefill_size,
+            max_live_requests=attn_config.max_bs,
+            max_context_len=attn_config.context_len,
+            decode_input_tokens=decode_input_tokens,
+            overlap_schedule_depth=overlap_schedule_depth,
+        )
     if family == "kimi_k3":
         return _prepare_kimi_k3(
             server_args=server_args,
@@ -650,6 +956,7 @@ def create_lcm_pool(
             kv_alloc_head_count=config.num_kv_heads,
             memory_plan=plan,
             layer_group_ids=spec.layer_group_ids,
+            token_capacity=spec.token_capacity,
             state_field_dtypes=spec.state_field_dtypes,
         )
     if isinstance(config, MLAConfig):

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import logging
 import math
 import os
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 import torch
@@ -154,10 +155,8 @@ def _validate_shared_lcm_geometry(pool, draft_pool) -> None:
                 "do not share page-id geometry"
             )
 
-    target_specs = {
-        spec.group_id: spec for spec in getattr(pool, "paged_cache_group_specs", ())
-    }
-    for draft_spec in getattr(draft_pool, "paged_cache_group_specs", ()):
+    target_specs = {spec.group_id: spec for spec in pool.paged_cache_group_specs}
+    for draft_spec in draft_pool.paged_cache_group_specs:
         target_spec = target_specs.get(draft_spec.group_id)
         if target_spec is None:
             raise RuntimeError(
@@ -1027,10 +1026,15 @@ def create_attn_components(
     use_lcm_gdn = is_hybrid_gdn and has_flat_state and flat_kvcache
     use_lcm_k3 = is_hybrid_mla_kda and flat_kvcache
     use_lcm_inkling = is_inkling and flat_kvcache
+    use_lcm_v4 = is_deepseek_v4_model and flat_kvcache
     lcm_family = (
-        "qwen_gdn"
-        if use_lcm_gdn
-        else "kimi_k3" if use_lcm_k3 else "inkling" if use_lcm_inkling else None
+        "deepseek_v4"
+        if use_lcm_v4
+        else (
+            "qwen_gdn"
+            if use_lcm_gdn
+            else "kimi_k3" if use_lcm_k3 else "inkling" if use_lcm_inkling else None
+        )
     )
     if has_flat_state and flat_kvcache and lcm_family is None:
         raise RuntimeError(
@@ -1084,14 +1088,18 @@ def create_attn_components(
     draft_deepseek_v4_layout = None
     profile_cache_cell_size = None
     draft_profile_cache_cell_size = None
-    if is_deepseek_v4_model:
+    if is_deepseek_v4_model or is_deepseek_v4_draft_model:
+        from tokenspeed.runtime.configs.deepseek_v4_cache_spec import (
+            V4_KERNEL_BLOCK_ROWS,
+        )
         from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
             deepseek_v4_cache_layout_from_config,
         )
 
+    if is_deepseek_v4_model:
         deepseek_v4_layout = deepseek_v4_cache_layout_from_config(
             model_config.hf_config,
-            page_size=server_args.block_size,
+            page_size=(V4_KERNEL_BLOCK_ROWS if use_lcm_v4 else server_args.block_size),
             use_fp4_indexer_cache=_attention_use_fp4_indexer_cache(
                 server_args, model_config.hf_config
             ),
@@ -1099,15 +1107,11 @@ def create_attn_components(
         )
         profile_cache_cell_size = deepseek_v4_layout.cache_cell_size(num_layers)
     if is_deepseek_v4_draft_model:
-        from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
-            deepseek_v4_cache_layout_from_config,
-        )
-
         draft_layer_start = draft_model_config.num_hidden_layers
         draft_num_layers = draft_model_config.num_attention_layers
         draft_deepseek_v4_layout = deepseek_v4_cache_layout_from_config(
             draft_model_config.hf_config,
-            page_size=server_args.block_size,
+            page_size=(V4_KERNEL_BLOCK_ROWS if use_lcm_v4 else server_args.block_size),
             use_fp4_indexer_cache=_attention_use_fp4_indexer_cache(
                 server_args, draft_model_config.hf_config
             ),
@@ -1119,6 +1123,16 @@ def create_attn_components(
         draft_profile_cache_cell_size = draft_deepseek_v4_layout.cache_cell_size(
             draft_model_config.num_attention_layers
         )
+    if use_lcm_v4:
+        # The V4 scheduler uses heterogeneous group spans, while its kernels
+        # consume the fixed row geometry published by the model cache recipe.
+        # Keep this model-local; do not rewrite ServerArgs or other LCM configs.
+        config = replace(config, page_size=V4_KERNEL_BLOCK_ROWS)
+        if draft_attn_config is not None and is_deepseek_v4_draft_model:
+            draft_attn_config = replace(
+                draft_attn_config,
+                page_size=V4_KERNEL_BLOCK_ROWS,
+            )
 
     hf_config = getattr(model_config, "hf_config", None)
     text_config = getattr(hf_config, "text_config", hf_config) if hf_config else None
@@ -1164,7 +1178,7 @@ def create_attn_components(
         ),
     )
 
-    if is_deepseek_v4_model:
+    if is_deepseek_v4_model and not use_lcm_v4:
         from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
             profile_deepseek_v4_max_num_pages,
         )
@@ -1225,22 +1239,31 @@ def create_attn_components(
             cache_budget_bytes=cache_memory,
             decode_input_tokens=decode_input_tokens,
             overlap_schedule_depth=overlap_schedule_depth,
+            deepseek_v4_layout=deepseek_v4_layout,
+            draft_deepseek_v4_layout=draft_deepseek_v4_layout,
         )
         logical_page_size = lcm_setup.target.memory_plan.logical_block_tokens
-        _validate_lcm_page_size(
-            config,
-            logical_page_size=logical_page_size,
-        )
-        if draft_attn_config is not None:
+        # Generic Kimi/Qwen LCM tables are expanded from one logical page size
+        # to the kernel page size. V4 publishes already-resolved child tables
+        # with a distinct span per group, so the uniform validator is not its
+        # interface.
+        if lcm_family != "deepseek_v4":
             _validate_lcm_page_size(
-                draft_attn_config,
+                config,
                 logical_page_size=logical_page_size,
             )
+            if draft_attn_config is not None:
+                _validate_lcm_page_size(
+                    draft_attn_config,
+                    logical_page_size=logical_page_size,
+                )
         cache_budget_bytes = lcm_setup.cache_budget_bytes
         fixed_workspace_bytes = lcm_setup.fixed_workspace_bytes
-        max_num_tokens = lcm_setup.target.pool_size
+        max_num_tokens = lcm_setup.target.token_capacity
         draft_max_num_tokens = (
-            lcm_setup.draft.pool_size if lcm_setup.draft is not None else max_num_tokens
+            lcm_setup.draft.token_capacity
+            if lcm_setup.draft is not None
+            else max_num_tokens
         )
         max_total_num_pages = lcm_setup.target.memory_plan.num_lcm_blocks
         logger.info(
@@ -1372,7 +1395,11 @@ def create_attn_components(
 
         backend = _create_attn_backend(arch, config)
         pool = DeepseekV4TokenToKVPool(
-            size=max_num_tokens,
+            size=(
+                lcm_setup.target.pool_size
+                if use_lcm_v4 and lcm_setup is not None
+                else max_num_tokens
+            ),
             model_dtype=model_config.dtype,
             layout=deepseek_v4_layout,
             layer_num=num_layers,
@@ -1380,12 +1407,13 @@ def create_attn_components(
             enable_memory_saver=enable_memory_saver,
             max_batch_size=config.max_bs,
             max_context_len=config.context_len,
-            page_size=server_args.block_size,
+            page_size=deepseek_v4_layout.page_size,
             rank=rank,
             hf_config=model_config.hf_config,
             max_scheduled_tokens=server_args.chunked_prefill_size,
             decode_input_tokens=decode_input_tokens,
             overlap_schedule_depth=overlap_schedule_depth,
+            lcm_spec=lcm_setup.target if use_lcm_v4 else None,
         )
     elif is_hybrid_linear:
         backend, pool, mamba_pool = _create_hybrid_linear_attn(
@@ -1468,7 +1496,13 @@ def create_attn_components(
                 draft_model_config.attention_arch, draft_attn_config
             )
             draft_pool = DeepseekV4TokenToKVPool(
-                size=draft_max_num_tokens,
+                size=(
+                    lcm_setup.draft.pool_size
+                    if use_lcm_v4
+                    and lcm_setup is not None
+                    and lcm_setup.draft is not None
+                    else draft_max_num_tokens
+                ),
                 model_dtype=draft_model_config.dtype,
                 layout=draft_deepseek_v4_layout,
                 layer_num=draft_model_config.num_attention_layers,
@@ -1476,12 +1510,15 @@ def create_attn_components(
                 enable_memory_saver=enable_memory_saver,
                 max_batch_size=draft_attn_config.max_bs,
                 max_context_len=draft_attn_config.context_len,
-                page_size=server_args.block_size,
+                page_size=draft_deepseek_v4_layout.page_size,
                 rank=rank,
                 hf_config=draft_model_config.hf_config,
                 max_scheduled_tokens=server_args.chunked_prefill_size,
                 decode_input_tokens=decode_input_tokens,
                 overlap_schedule_depth=overlap_schedule_depth,
+                lcm_spec=(
+                    lcm_setup.draft if use_lcm_v4 and lcm_setup is not None else None
+                ),
             )
         elif draft_is_hybrid_gdn:
             draft_attn_backend, draft_pool, _ = _create_hybrid_linear_attn(

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -748,8 +748,7 @@ def _deepseek_v4_indexer_topk_from_logits(
         )
     if topk_tokens not in (512, 1024, 2048):
         raise RuntimeError(
-            "DeepSeek V4 decode indexer top-k supports topk_tokens in "
-            "{512, 1024, 2048}"
+            "DeepSeek V4 decode indexer top-k supports topk_tokens in {512, 1024, 2048}"
         )
 
     if (
@@ -2090,11 +2089,20 @@ def _deepseek_v4_swa_slot_mapping(
     cache_metadata = metadata.cache
     token_to_req_indices = metadata.token_to_req_indices[: positions.numel()]
     if cache_metadata.swa_block_table is None:
+        if not cache_metadata.has_legacy_block_table:
+            raise RuntimeError(
+                "DeepSeek V4 flat cache metadata is missing the SWA group table"
+            )
         slot_mapping = out_cache_loc
     elif token_to_req_indices.numel() != positions.numel() and (
         token_to_req_indices.numel() <= 0
         or positions.numel() % token_to_req_indices.numel() != 0
     ):
+        if not cache_metadata.has_legacy_block_table:
+            raise RuntimeError(
+                "DeepSeek V4 flat SWA slot mapping has incompatible token/request "
+                "metadata; generic out_cache_loc fallback is forbidden"
+            )
         slot_mapping = out_cache_loc
     else:
         slot_mapping = _group_slot_mapping_from_raw(
@@ -2103,6 +2111,7 @@ def _deepseek_v4_swa_slot_mapping(
             cache_metadata.swa_block_table,
             ctx.token_to_kv_pool.swa_block_size,
             base_offsets=cache_metadata.swa_base_logical_page,
+            capacity_pages=ctx.token_to_kv_pool.swa_capacity_pages,
         )
     is_valid_token = getattr(metadata, "is_valid_token", None)
     if is_valid_token is not None:
@@ -2868,6 +2877,7 @@ class DeepseekV4Compressor(nn.Module):
         kv, score = kv_score.split([self.coff * self.head_dim] * 2, dim=-1)
         if state_cache is None:
             state_cache = pool.get_compressor_state_buffer(layer_index)
+        state_capacity_pages = int(state_cache.shape[0])
         cache_metadata = metadata.cache
         # state/compressed slot mappings depend only on (per-step state, ratio), so reuse
         # them across layers of the same ratio within a step. Attn-compressor path only:
@@ -2898,7 +2908,18 @@ class DeepseekV4Compressor(nn.Module):
                 memo.get(("state", self.compress_ratio)) if memo is not None else None
             )
             if state_hit is not None:
-                state_slot_mapping, state_block_table = state_hit
+                (
+                    state_slot_mapping,
+                    state_block_table,
+                    cached_state_capacity_pages,
+                ) = state_hit
+                if cached_state_capacity_pages != state_capacity_pages:
+                    raise RuntimeError(
+                        "DeepSeek V4 co-indexed compressor-state components "
+                        "disagree on page capacity: "
+                        f"first={cached_state_capacity_pages}, "
+                        f"current={state_capacity_pages}"
+                    )
             else:
                 if state_block_table is None:
                     raise RuntimeError(
@@ -2911,6 +2932,7 @@ class DeepseekV4Compressor(nn.Module):
                     state_block_table,
                     state_block_size,
                     base_offsets=state_base_logical_page,
+                    capacity_pages=state_capacity_pages,
                 )
                 state_slot_mapping = _mask_invalid_graph_tokens(
                     state_slot_mapping,
@@ -2920,6 +2942,7 @@ class DeepseekV4Compressor(nn.Module):
                     memo[("state", self.compress_ratio)] = (
                         state_slot_mapping,
                         state_block_table,
+                        state_capacity_pages,
                     )
         with nvtx_range(f"{profile_prefix}_save_state"):
             save_deepseek_v4_compressor_state(
@@ -2936,6 +2959,8 @@ class DeepseekV4Compressor(nn.Module):
             return kv, score
 
         kv_cache_block_size = pool.get_compressed_block_size(layer_index)
+        compressed_cache = pool.get_compressed_kv_buffer_2d(layer_index)
+        compressed_capacity_pages = int(compressed_cache.shape[0])
         insert_token_to_req_indices = metadata.token_to_req_indices[: positions.numel()]
         direct_active_token_indices = None
         if self.compress_ratio == 128:
@@ -2948,9 +2973,9 @@ class DeepseekV4Compressor(nn.Module):
                 direct_active_token_indices = active_hit
             else:
                 active_metadata = metadata
-                forward_mode = getattr(ctx, "forward_mode", None)
+                forward_mode = ctx.forward_mode
                 if forward_mode is not None and forward_mode.is_mixed():
-                    full_metadata = getattr(ctx.attn_backend, "forward_metadata", None)
+                    full_metadata = ctx.attn_backend.forward_metadata
                     if full_metadata is not None:
                         active_metadata = full_metadata
                 active_indices = _deepseek_v4_hca_active_token_indices(
@@ -2976,7 +3001,14 @@ class DeepseekV4Compressor(nn.Module):
             memo.get(("compressed", self.compress_ratio)) if memo is not None else None
         )
         if compressed_hit is not None:
-            compressed_slots = compressed_hit
+            compressed_slots, cached_compressed_capacity_pages = compressed_hit
+            if cached_compressed_capacity_pages != compressed_capacity_pages:
+                raise RuntimeError(
+                    "DeepSeek V4 co-indexed compressed components disagree on "
+                    "page capacity: "
+                    f"first={cached_compressed_capacity_pages}, "
+                    f"current={compressed_capacity_pages}"
+                )
         else:
             with nvtx_range(f"{profile_prefix}_compressed_slot_mapping"):
                 compressed_slots = cache_metadata.compressed_slot_mapping(
@@ -2986,13 +3018,17 @@ class DeepseekV4Compressor(nn.Module):
                     query_start_loc=metadata.query_start_loc,
                     seq_lens=metadata.seq_lens,
                     kv_cache_block_size=kv_cache_block_size,
+                    capacity_pages=compressed_capacity_pages,
                     use_decode_cache=(
                         ctx.forward_mode is not None and ctx.forward_mode.is_decode()
                     ),
                     is_valid_token=valid_token,
                 )
             if memo is not None:
-                memo[("compressed", self.compress_ratio)] = compressed_slots
+                memo[("compressed", self.compress_ratio)] = (
+                    compressed_slots,
+                    compressed_capacity_pages,
+                )
         with nvtx_range(f"{profile_prefix}_cache_insert"):
             if self.compress_ratio == 4:
                 deepseek_v4_csa_compress_kv_cache_insert(
@@ -3006,7 +3042,7 @@ class DeepseekV4Compressor(nn.Module):
                     rms_norm_weight=self.norm.weight,
                     rms_norm_eps=self.norm.variance_epsilon,
                     cos_sin_cache=cos_sin_cache,
-                    kv_cache_2d=pool.get_compressed_kv_buffer_2d(layer_index),
+                    kv_cache_2d=compressed_cache,
                     kv_slot_mapping=compressed_slots,
                     kv_cache_block_size=kv_cache_block_size,
                     compress_ratio=self.compress_ratio,
@@ -3029,7 +3065,7 @@ class DeepseekV4Compressor(nn.Module):
                         rms_norm_weight=self.norm.weight,
                         rms_norm_eps=self.norm.variance_epsilon,
                         cos_sin_cache=cos_sin_cache,
-                        kv_cache_2d=pool.get_compressed_kv_buffer_2d(layer_index),
+                        kv_cache_2d=compressed_cache,
                         kv_slot_mapping=compressed_slots,
                         kv_cache_block_size=kv_cache_block_size,
                         active_token_indices=direct_active_token_indices,
@@ -3047,7 +3083,7 @@ class DeepseekV4Compressor(nn.Module):
                         rms_norm_weight=self.norm.weight,
                         rms_norm_eps=self.norm.variance_epsilon,
                         cos_sin_cache=cos_sin_cache,
-                        kv_cache_2d=pool.get_compressed_kv_buffer_2d(layer_index),
+                        kv_cache_2d=compressed_cache,
                         kv_slot_mapping=compressed_slots,
                         kv_cache_block_size=kv_cache_block_size,
                         compress_ratio=self.compress_ratio,
@@ -3372,6 +3408,7 @@ class DeepseekV4Indexer(nn.Module):
             raise RuntimeError("DeepSeek V4 indexer requires forward metadata")
         cache_metadata = metadata.cache
         indexer_state = pool.get_indexer_state_buffer(layer_index)
+        indexer_state_capacity_pages = int(indexer_state.shape[0])
         valid_token = (
             metadata.is_valid_token[: positions.numel()]
             if getattr(metadata, "is_valid_token", None) is not None
@@ -3388,7 +3425,15 @@ class DeepseekV4Indexer(nn.Module):
                 indexer_state_block_table,
                 indexer_state_block_size,
                 indexer_state_base_logical_page,
+                cached_indexer_state_capacity_pages,
             ) = idx_hit
+            if cached_indexer_state_capacity_pages != indexer_state_capacity_pages:
+                raise RuntimeError(
+                    "DeepSeek V4 co-indexed indexer-state components disagree "
+                    "on page capacity: "
+                    f"first={cached_indexer_state_capacity_pages}, "
+                    f"current={indexer_state_capacity_pages}"
+                )
         else:
             indexer_state_block_table = cache_metadata.indexer_state_block_table
             indexer_state_base_logical_page = (
@@ -3406,6 +3451,7 @@ class DeepseekV4Indexer(nn.Module):
                 indexer_state_block_table,
                 indexer_state_block_size,
                 base_offsets=indexer_state_base_logical_page,
+                capacity_pages=indexer_state_capacity_pages,
             )
             indexer_state_slot_mapping = _mask_invalid_graph_tokens(
                 indexer_state_slot_mapping,
@@ -3417,6 +3463,7 @@ class DeepseekV4Indexer(nn.Module):
                     indexer_state_block_table,
                     indexer_state_block_size,
                     indexer_state_base_logical_page,
+                    indexer_state_capacity_pages,
                 )
         with nvtx_range("indexer_compressor_total"):
             self.compressor(
@@ -3436,6 +3483,8 @@ class DeepseekV4Indexer(nn.Module):
             )
         with nvtx_range("indexer_compressed_slot_mapping"):
             indexer_block_size = pool.get_indexer_block_size(layer_index)
+            indexer_cache = pool.get_indexer_kv_buffer_2d(layer_index)
+            indexer_capacity_pages = int(indexer_cache.shape[0])
             compressed_slots = cache_metadata.compressed_slot_mapping(
                 positions,
                 self.compress_ratio,
@@ -3443,6 +3492,7 @@ class DeepseekV4Indexer(nn.Module):
                 query_start_loc=metadata.query_start_loc,
                 seq_lens=metadata.seq_lens,
                 kv_cache_block_size=indexer_block_size,
+                capacity_pages=indexer_capacity_pages,
                 use_decode_cache=(
                     ctx.forward_mode is not None and ctx.forward_mode.is_decode()
                 ),
@@ -3460,7 +3510,7 @@ class DeepseekV4Indexer(nn.Module):
                 rms_norm_weight=self.compressor.norm.weight,
                 rms_norm_eps=self.compressor.norm.variance_epsilon,
                 cos_sin_cache=cos_sin_cache,
-                kv_cache_2d=pool.get_indexer_kv_buffer_2d(layer_index),
+                kv_cache_2d=indexer_cache,
                 kv_slot_mapping=compressed_slots,
                 kv_cache_block_size=indexer_block_size,
                 use_fp4_cache=self.use_fp4_cache,
@@ -3472,7 +3522,7 @@ class DeepseekV4Indexer(nn.Module):
             positions=positions,
             metadata=metadata,
             ctx=ctx,
-            indexer_cache=pool.get_indexer_kv_buffer_2d(layer_index),
+            indexer_cache=indexer_cache,
             indexer_block_size=indexer_block_size,
             cos_sin_cache=cos_sin_cache,
         )

--- a/python/tokenspeed/runtime/pd/factory.py
+++ b/python/tokenspeed/runtime/pd/factory.py
@@ -40,7 +40,7 @@ def _get_contiguous_buf_unit_lens(pool, item_lens):
 
 
 def _get_flatkv_contract(pool):
-    if getattr(pool, "supports_disaggregation", False) is not True:
+    if not pool.supports_disaggregation:
         return None
 
     contract_getter = getattr(pool, "get_flatkv_pd_contract", None)

--- a/test/ci/eval/deepseek-v4-flash-flat-mtp-evalscope-gsm8k.yaml
+++ b/test/ci/eval/deepseek-v4-flash-flat-mtp-evalscope-gsm8k.yaml
@@ -1,0 +1,55 @@
+api_version: ci.tokenspeed.io/v1
+name: eval-deepseek-v4-flash-flat-mtp-gsm8k
+type: eval
+triggers:
+  - per-commit
+  - manual
+runner:
+  labels:
+    - b200-4gpu
+env:
+  CI: "true"
+  TOKENSPEED_FLAT_KV: "ON"
+install:
+  - bash test/ci_system/install_deps.sh
+  - CUDA_VISIBLE_DEVICES=0 python3 -m pytest -q test/runtime/test_deepseek_v4_lcm.py
+server:
+  command: >-
+    ts serve
+    --model deepseek-ai/DeepSeek-V4-Flash
+    --tensor-parallel-size 4
+    --enable-expert-parallel
+    --kv-cache-dtype fp8_e4m3
+    --moe-backend mega_moe
+    --attention-use-fp4-indexer-cache
+    --max-model-len 4096
+    --max-total-tokens 16384
+    --chunked-prefill-size 8192
+    --gpu-memory-utilization 0.9
+    --disable-kvstore
+    --trust-remote-code
+    --speculative-algorithm MTP
+    --speculative-num-steps 3
+    --disable-overlap-schedule
+    --no-enable-prefix-caching
+    --host 127.0.0.1
+    --port 8000
+  ready:
+    url: http://127.0.0.1:8000/readiness
+    timeout: 1800
+    interval: 10
+eval:
+  install:
+    - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]'
+  command: >-
+    python3 -c "import urllib.request,json;urllib.request.urlopen(urllib.request.Request('http://127.0.0.1:8000/v1/completions',json.dumps({'model':'deepseek-ai/DeepSeek-V4-Flash','prompt':' '.join(['hello']*300),'max_tokens':2}).encode(),{'Content-Type':'application/json'}),timeout=120).read()" &&
+    /tmp/evalscope-perf/bin/evalscope eval
+    --model deepseek-ai/DeepSeek-V4-Flash
+    --api-url http://127.0.0.1:8000/v1
+    --api-key EMPTY_TOKEN
+    --datasets gsm8k
+    --eval-batch-size 16
+    --generation-config '{"do_sample":false,"temperature":0.0,"max_tokens":256}'
+report:
+  github_step_summary: true
+score_threshold: 0.90

--- a/test/runtime/conftest.py
+++ b/test/runtime/conftest.py
@@ -130,7 +130,14 @@ def kda_layer_id(pool) -> int:
     )
 
 
-def flat_metadata_for(contract, tables, device, *, filler_page: int = 1):
+def flat_metadata_for(
+    contract,
+    tables,
+    device,
+    *,
+    filler_page: int = 1,
+    compact_tables: bool = False,
+):
     from tokenspeed.runtime.layers.attention.backends.flat_cache_metadata import (
         FlatCacheBatchMetadata,
     )
@@ -144,7 +151,11 @@ def flat_metadata_for(contract, tables, device, *, filler_page: int = 1):
             arrays[spec.group_id] = np.full((bs, 1), filler_page, dtype=np.int32)
     forward_op = SimpleNamespace(flat_block_tables_arrays=lambda: arrays)
     metadata = FlatCacheBatchMetadata.from_forward_op(
-        forward_op, device=device, contract=contract, num_requests=bs
+        forward_op,
+        device=device,
+        contract=contract,
+        num_requests=bs,
+        compact_tables=compact_tables,
     )
     return metadata, forward_op
 

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -81,6 +81,7 @@ from tokenspeed.runtime.layers.layernorm import FusedRMSNorm, RMSNorm
 from tokenspeed.runtime.layers.quantization import QUANTIZATION_METHODS
 from tokenspeed.runtime.models import deepseek_v4 as deepseek_v4_model
 from tokenspeed.runtime.models.deepseek_v4 import (
+    DeepseekV4Compressor,
     DeepseekV4Indexer,
     DeepseekV4MLP,
     DeepseekV4MoE,
@@ -118,6 +119,13 @@ from tokenspeed.runtime.utils.hf_transformers_utils import (
     prefers_deepseek_v4_tokenizer,
 )
 from tokenspeed.runtime.utils.server_args import ServerArgs
+
+
+def _configure_wrapper_test_state(wrapper):
+    """Set constructor fields bypassed by focused wrapper tests."""
+
+    wrapper.use_target_verify_paged_metadata = False
+    wrapper.use_flat_cache_tables = False
 
 
 def _make_deepseek_v4_forward_metadata(
@@ -683,6 +691,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         wrapper.attn_backend = FakeBackend()
         wrapper.draft_attn_backend = None
         wrapper.max_tokens_per_req = 1
+        _configure_wrapper_test_state(wrapper)
 
         wrapper._init_replay_metadata(
             padded_bs=4,
@@ -726,7 +735,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             draft_seq_lens_buf=torch.zeros(4, dtype=torch.int32),
         )
         wrapper.max_tokens_per_req = 4
-        wrapper.use_v4_mtp_paged_metadata = True
+        _configure_wrapper_test_state(wrapper)
 
         table = torch.tensor([[7], [8]], dtype=torch.int32)
         offsets = {"v4.swa": torch.tensor([1, 2], dtype=torch.int64)}
@@ -787,7 +796,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
         )
 
-    def test_cuda_graph_eager_draft_prefill_uses_single_non_v4_metadata_init(self):
+    def test_cuda_graph_eager_draft_prefill_uses_single_legacy_metadata_init(self):
         captured = {"target": [], "draft": []}
 
         class FakeBackend:
@@ -807,7 +816,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             req_to_page=torch.zeros((1, 1), dtype=torch.int32),
             draft_seq_lens_buf=torch.tensor([0, 0], dtype=torch.int32),
         )
-        wrapper.use_v4_mtp_paged_metadata = False
+        _configure_wrapper_test_state(wrapper)
 
         seq_lens = torch.tensor([21, 22], dtype=torch.int32)
         wrapper._init_forward_metadata(
@@ -829,7 +838,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
         self.assertEqual(wrapper.drafter.draft_seq_lens_buf.tolist(), [21, 22])
 
-    def test_cuda_graph_eager_draft_decode_preserves_non_v4_seq_lens_alias(self):
+    def test_cuda_graph_eager_draft_decode_preserves_legacy_seq_lens_alias(self):
         captured = {"target": [], "draft": []}
 
         class FakeBackend:
@@ -849,9 +858,9 @@ class TestDeepseekV4Config(unittest.TestCase):
             req_to_page=torch.zeros((1, 1), dtype=torch.int32),
             draft_seq_lens_buf=torch.tensor([11, 12], dtype=torch.int32),
         )
+        _configure_wrapper_test_state(wrapper)
 
         seq_lens = torch.tensor([21, 22], dtype=torch.int32)
-        wrapper.use_v4_mtp_paged_metadata = False
         wrapper._init_forward_metadata(
             padded_bs=2,
             num_extends=0,
@@ -861,26 +870,12 @@ class TestDeepseekV4Config(unittest.TestCase):
             forward_mode=ForwardMode.DECODE,
         )
 
-        _, non_v4_kwargs = captured["draft"][-1]
+        _, legacy_kwargs = captured["draft"][-1]
         self.assertEqual(
-            non_v4_kwargs["seq_lens"].data_ptr(),
+            legacy_kwargs["seq_lens"].data_ptr(),
             wrapper.drafter.draft_seq_lens_buf.data_ptr(),
         )
-        self.assertEqual(non_v4_kwargs["forward_mode"], ForwardMode.DECODE)
-
-        wrapper.use_v4_mtp_paged_metadata = True
-        wrapper._init_forward_metadata(
-            padded_bs=2,
-            num_extends=0,
-            req_pool_indices=torch.zeros(2, dtype=torch.int32),
-            seq_lens=seq_lens,
-            req_to_page=torch.zeros((1, 1), dtype=torch.int32),
-            forward_mode=ForwardMode.DECODE,
-        )
-
-        _, v4_kwargs = captured["draft"][-1]
-        self.assertEqual(v4_kwargs["seq_lens"].data_ptr(), seq_lens.data_ptr())
-        self.assertEqual(v4_kwargs["forward_mode"], ForwardMode.DECODE)
+        self.assertEqual(legacy_kwargs["forward_mode"], ForwardMode.DECODE)
 
     def test_deepseek_v4_tokenizer_wrapper_uses_model_encoder(self):
         calls = []
@@ -1465,6 +1460,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             max_scheduled_tokens=1,
         )
 
+        self.assertIsNone(pool.runtime_contract)
         self.assertEqual(tuple(pool.get_swa_kv_buffer(0).shape), (8, 37440))
         self.assertIsNone(pool.compressed_kv_buffer[0])
         self.assertEqual(tuple(pool.get_compressed_kv_buffer_2d(1).shape), (4, 37440))
@@ -1564,6 +1560,12 @@ class TestDeepseekV4Config(unittest.TestCase):
 
         self.assertTrue(
             torch.equal(slots, torch.tensor([640, 641, 642, 1280, 1281, 1282]))
+        )
+
+    def test_deepseek_v4_backend_declares_flat_consumer_families(self):
+        self.assertEqual(
+            DeepseekV4AttentionBackend.flat_cache_consumer_families,
+            frozenset({"history", "state"}),
         )
 
     def test_deepseek_v4_backend_preserves_compact_paged_cache_contract(self):
@@ -1812,6 +1814,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                     retention="sliding_window",
                     rows_per_page=64,
                     entry_stride_tokens=1,
+                    block_size=64,
                     sliding_window_tokens=128,
                 ),
             ),
@@ -2042,6 +2045,31 @@ class TestDeepseekV4Config(unittest.TestCase):
                 max_scheduled_tokens=1,
             )
 
+    def test_flat_cache_metadata_never_treats_sentinel_as_legacy_table(self):
+        cases = (
+            ("legacy table", True, (2, 1), True),
+            ("flat one-column sentinel", False, (2, 1), False),
+            ("flat wide sentinel", False, (2, 4), False),
+            ("invalid rank", True, (2,), False),
+            ("zero width", True, (2, 0), False),
+        )
+        for name, allow_legacy, shape, expected in cases:
+            with self.subTest(name=name):
+                metadata = DeepseekV4CacheMetadata(
+                    page_size=64,
+                    block_table=torch.zeros(shape, dtype=torch.int32),
+                    allow_legacy_block_table=allow_legacy,
+                )
+                self.assertIs(metadata.has_legacy_block_table, expected)
+
+        sentinel = DeepseekV4CacheMetadata(
+            page_size=64,
+            block_table=torch.zeros((2, 1), dtype=torch.int32),
+            allow_legacy_block_table=False,
+        )
+        with self.assertRaisesRegex(RuntimeError, "cannot use the legacy"):
+            sentinel.compressed_block_table(1)
+
     def test_deepseek_v4_metadata_maps_compressed_slots(self):
         compressed_table = torch.tensor([[10, 11], [20, 21]], dtype=torch.int32)
         metadata = _make_deepseek_v4_forward_metadata(
@@ -2143,32 +2171,52 @@ class TestDeepseekV4Config(unittest.TestCase):
             seq_lens=grouped_metadata.seq_lens,
             compress_ratio=4,
             kv_cache_block_size=64,
+            capacity_pages=64,
         )
         self.assertTrue(
             torch.equal(decode_slots[:5], torch.tensor([-1, -1, 1354, -1, -1]))
         )
 
     def test_deepseek_v4_group_slot_mapping_from_raw(self):
-        block_table = torch.tensor([[10, 11], [20, -1]], dtype=torch.int32)
-        slots = _group_slot_mapping_from_raw(
-            positions=torch.tensor([0, 63, 64, 9, 10], dtype=torch.int64),
-            req_indices=torch.tensor([0, 0, 0, 1, 1], dtype=torch.int32),
-            block_table=block_table,
-            rows_per_page=64,
-            entry_stride_tokens=1,
+        cases = (
+            (
+                "plain token rows",
+                [0, 63, 64, 9, 10],
+                [0, 0, 0, 1, 1],
+                [[10, 11], [20, -1]],
+                {"entry_stride_tokens": 1},
+                [640, 703, 704, 1289, 1290],
+            ),
+            (
+                "compressed token stride",
+                [0, 255, 256, 511],
+                [0, 0, 0, 1],
+                [[10, 11], [20, -1]],
+                {"entry_stride_tokens": 4},
+                [640, 703, 704, -1],
+            ),
+            (
+                "bounded owner capacity",
+                [0, 64, 128, 192],
+                [0, 0, 0, 0],
+                [[0, 3, 4, -1]],
+                {"capacity_pages": 4},
+                [-1, 192, -1, -1],
+            ),
         )
-        self.assertTrue(torch.equal(slots, torch.tensor([640, 703, 704, 1289, 1290])))
 
-        compressed_slots = _group_slot_mapping_from_raw(
-            positions=torch.tensor([0, 255, 256, 511], dtype=torch.int64),
-            req_indices=torch.tensor([0, 0, 0, 1], dtype=torch.int32),
-            block_table=block_table,
-            rows_per_page=64,
-            entry_stride_tokens=4,
-        )
-        self.assertTrue(
-            torch.equal(compressed_slots, torch.tensor([640, 703, 704, -1]))
-        )
+        for name, positions, req_indices, block_table, options, expected in cases:
+            with self.subTest(name=name):
+                call_kwargs = {
+                    "positions": torch.tensor(positions, dtype=torch.int64),
+                    "req_indices": torch.tensor(req_indices, dtype=torch.int32),
+                    "block_table": torch.tensor(block_table, dtype=torch.int32),
+                    "rows_per_page": 64,
+                    **options,
+                }
+                slots = _group_slot_mapping_from_raw(**call_kwargs)
+                expected_slots = torch.tensor(expected)
+                self.assertTrue(torch.equal(slots, expected_slots))
 
     def test_deepseek_v4_slot_mapping_masks_invalid_tokens(self):
         slots = _mask_invalid_graph_tokens(
@@ -2218,7 +2266,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertTrue(
             torch.equal(
                 metadata.seq_lens_cpu,
-                torch.tensor([5, 9, 12], dtype=torch.int32),
+                torch.tensor([5], dtype=torch.int32),
             )
         )
         self.assertTrue(
@@ -2227,6 +2275,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 torch.tensor([3, 1, 1], dtype=torch.int32),
             )
         )
+        self.assertEqual(metadata.query_start_offsets, (0, 3, 4, 5))
 
         prefill = backend._metadata_slice(
             metadata,
@@ -2265,6 +2314,8 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertTrue(
             torch.equal(decode.query_lens_cpu, torch.tensor([1, 1], dtype=torch.int32))
         )
+        self.assertEqual(prefill.query_start_offsets, (0, 3))
+        self.assertEqual(decode.query_start_offsets, (0, 1, 2))
 
     def test_deepseek_v4_mixed_metadata_accepts_prefill_prefix_lens_only(self):
         backend = DeepseekV4AttentionBackend(
@@ -2301,7 +2352,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertTrue(
             torch.equal(
                 metadata.seq_lens_cpu,
-                torch.tensor([5, 9, 12, 6], dtype=torch.int32),
+                torch.tensor([5, 9, 12], dtype=torch.int32),
             )
         )
         self.assertTrue(
@@ -2310,6 +2361,154 @@ class TestDeepseekV4Config(unittest.TestCase):
                 torch.tensor([3, 4, 1, 1], dtype=torch.int32),
             )
         )
+        self.assertEqual(metadata.query_start_offsets, (0, 3, 7, 8, 9))
+
+    def test_deepseek_v4_flat_prefill_chunking_uses_cached_cpu_offsets(self):
+        backend = DeepseekV4AttentionBackend(
+            SimpleNamespace(
+                page_size=64,
+                device="cpu",
+                num_attention_heads=8,
+                num_kv_heads=1,
+                attn_tp_size=1,
+                dtype=torch.bfloat16,
+                is_draft=False,
+                speculative_num_draft_tokens=1,
+                head_dim=576,
+                context_len=256,
+            )
+        )
+        backend.prefill_chunk_size = 1
+        backend.init_forward_metadata(
+            bs=3,
+            req_pool_indices=torch.tensor([0, 1, 2], dtype=torch.int32),
+            seq_lens=torch.tensor([2, 1, 3], dtype=torch.int32),
+            forward_mode=ForwardMode.EXTEND,
+            flat_block_tables={
+                "v4.swa_kv": torch.tensor([[10], [20], [30]], dtype=torch.int32)
+            },
+            paged_cache_block_table_base_offsets={
+                "v4.swa_kv": torch.zeros(3, dtype=torch.int32)
+            },
+            extend_seq_lens_cpu=torch.tensor([2, 1, 3], dtype=torch.int32),
+        )
+        metadata = backend.forward_metadata
+        self.assertIsNotNone(metadata)
+        self.assertFalse(metadata.cache.has_legacy_block_table)
+
+        class DeviceOffsetsMustNotBeRead:
+            def __getitem__(self, key):
+                raise AssertionError(
+                    "chunked prefill must not read query_start_loc from the device"
+                )
+
+        metadata.query_start_loc = DeviceOffsetsMustNotBeRead()
+        chunk_sizes = []
+
+        def fake_prefill_chunk(**kwargs):
+            q = kwargs["q"]
+            chunk_sizes.append(q.shape[0])
+            return q.new_zeros((q.shape[0], 1, 2))
+
+        backend._forward_deepseek_v4_prefill_chunk = fake_prefill_chunk
+        out = backend.forward_deepseek_v4_prefill(
+            q=torch.empty((6, 1, 2), dtype=torch.bfloat16),
+            positions=torch.arange(6, dtype=torch.int64),
+            token_to_kv_pool=SimpleNamespace(),
+            layer_id=0,
+            kind="test",
+            compress_ratio=1,
+            num_local_heads=1,
+            padded_heads=1,
+            head_dim=2,
+            window_size=64,
+            softmax_scale=1.0,
+            attn_sink=torch.empty((1,), dtype=torch.float32),
+            topk_indices=None,
+        )
+
+        self.assertEqual(chunk_sizes, [2, 1, 3])
+        self.assertEqual(tuple(out.shape), (6, 1, 2))
+
+    def test_deepseek_v4_flat_prefill_workspace_uses_cpu_lengths(self):
+        backend = DeepseekV4AttentionBackend(
+            SimpleNamespace(
+                page_size=64,
+                device="cpu",
+                num_attention_heads=8,
+                num_kv_heads=1,
+                attn_tp_size=1,
+                dtype=torch.bfloat16,
+                is_draft=False,
+                speculative_num_draft_tokens=1,
+                head_dim=576,
+                context_len=256,
+            )
+        )
+        backend.init_forward_metadata(
+            bs=2,
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int32),
+            seq_lens=torch.tensor([5, 9], dtype=torch.int32),
+            forward_mode=ForwardMode.EXTEND,
+            flat_block_tables={
+                "v4.swa_kv": torch.tensor([[10], [20]], dtype=torch.int32)
+            },
+            paged_cache_block_table_base_offsets={
+                "v4.swa_kv": torch.zeros(2, dtype=torch.int32)
+            },
+            extend_seq_lens_cpu=torch.tensor([3, 4], dtype=torch.int32),
+            extend_prefix_lens_cpu=torch.tensor([2, 5], dtype=torch.int32),
+        )
+        metadata = backend.forward_metadata
+        self.assertIsNotNone(metadata)
+        # Device-side values intentionally imply a much larger workspace. The
+        # allocation must use the scheduler's existing CPU mirrors instead.
+        metadata.seq_lens = torch.tensor([100, 100], dtype=torch.int32)
+        metadata.query_lens = torch.tensor([1, 1], dtype=torch.int32)
+        workspace_widths = []
+
+        def fake_workspace(**kwargs):
+            workspace_widths.append(kwargs["workspace_width"])
+            return torch.empty(
+                (kwargs["num_reqs"], kwargs["workspace_width"], kwargs["head_dim"])
+            )
+
+        backend._get_prefill_workspace = fake_workspace
+        with self.assertRaisesRegex(RuntimeError, "requires top-k indices"):
+            backend._prefill_workspace(
+                positions=torch.arange(7, dtype=torch.int64),
+                token_to_kv_pool=SimpleNamespace(),
+                layer_id=0,
+                compress_ratio=4,
+                window_size=4,
+                head_dim=2,
+                topk_indices=None,
+            )
+
+        self.assertEqual(workspace_widths, [9])
+        backend.init_forward_metadata(
+            bs=1,
+            req_pool_indices=torch.tensor([0], dtype=torch.int32),
+            seq_lens=torch.tensor([100], dtype=torch.int32),
+            forward_mode=ForwardMode.EXTEND,
+            flat_block_tables={"v4.swa_kv": torch.tensor([[10]], dtype=torch.int32)},
+            paged_cache_block_table_base_offsets={
+                "v4.swa_kv": torch.zeros(1, dtype=torch.int32)
+            },
+            extend_seq_lens_cpu=torch.tensor([10], dtype=torch.int32),
+            extend_prefix_lens=torch.tensor([90], dtype=torch.int32),
+        )
+        self.assertIsNone(backend.forward_metadata.seq_lens_cpu)
+        with self.assertRaisesRegex(RuntimeError, "requires CPU sequence/query"):
+            backend._prefill_workspace(
+                positions=torch.arange(10, dtype=torch.int64),
+                token_to_kv_pool=SimpleNamespace(),
+                layer_id=0,
+                compress_ratio=4,
+                window_size=4,
+                head_dim=2,
+                topk_indices=None,
+            )
 
     def test_deepseek_v4_mixed_backend_slices_prefill_and_decode(self):
         backend = DeepseekV4AttentionBackend(
@@ -2594,13 +2793,18 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
         )
 
-        backend.init_forward_metadata(
-            bs=2,
-            req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
-            seq_lens=torch.tensor([70, 3], dtype=torch.int32),
-            forward_mode=ForwardMode.DECODE,
-            req_to_page=torch.tensor([[10, 11], [20, 21]], dtype=torch.int32),
-        )
+        with patch.object(
+            backend,
+            "_query_lens_cpu",
+            side_effect=AssertionError("decode must not build CPU query lengths"),
+        ):
+            backend.init_forward_metadata(
+                bs=2,
+                req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+                seq_lens=torch.tensor([70, 3], dtype=torch.int32),
+                forward_mode=ForwardMode.DECODE,
+                req_to_page=torch.tensor([[10, 11], [20, 21]], dtype=torch.int32),
+            )
 
         self.assertTrue(
             torch.equal(
@@ -2608,6 +2812,8 @@ class TestDeepseekV4Config(unittest.TestCase):
                 torch.tensor([1, 1], dtype=torch.int32),
             )
         )
+        self.assertIsNone(backend.forward_metadata.query_lens_cpu)
+        self.assertIsNone(backend.forward_metadata.query_start_offsets)
         self.assertEqual(backend.forward_metadata.forward_mode, ForwardMode.DECODE)
         self.assertEqual(backend.forward_metadata.decode_token_count(), 2)
 
@@ -2694,6 +2900,73 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
         )
         self.assertEqual(backend.forward_metadata.decode_token_count(), 2)
+
+    def test_deepseek_v4_flat_graph_capture_uses_plan_without_live_tables(self):
+        backend = DeepseekV4AttentionBackend(
+            SimpleNamespace(
+                page_size=64,
+                device="cpu",
+                num_attention_heads=64,
+                num_kv_heads=1,
+                attn_tp_size=1,
+                dtype=torch.bfloat16,
+                is_draft=False,
+                head_dim=512,
+                context_len=4096,
+                speculative_num_draft_tokens=1,
+            )
+        )
+        backend.init_cuda_graph_state(
+            max_bs=2,
+            paged_cache_group_specs=(
+                SimpleNamespace(
+                    group_id="v4.swa_kv",
+                    retention="sliding_window",
+                    rows_per_page=64,
+                    entry_stride_tokens=1,
+                    block_size=64,
+                    sliding_window_tokens=128,
+                ),
+            ),
+        )
+
+        backend.init_forward_metadata_capture_cuda_graph(
+            bs=2,
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int32),
+            seq_lens=torch.tensor([1, 1], dtype=torch.int32),
+            forward_mode=ForwardMode.DECODE,
+            paged_cache_block_tables={
+                "v4.swa_kv": torch.zeros((2, 2), dtype=torch.int32)
+            },
+            paged_cache_block_table_base_offsets={
+                "v4.swa_kv": torch.zeros(2, dtype=torch.int32)
+            },
+            compact_flat_block_tables=True,
+        )
+
+        captured_cache = backend.forward_metadata.cache
+        self.assertFalse(captured_cache.has_legacy_block_table)
+        backend.init_forward_metadata_replay_cuda_graph(
+            bs=2,
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int32),
+            seq_lens=torch.tensor([1, 1], dtype=torch.int32),
+            forward_mode=ForwardMode.DECODE,
+            flat_block_tables={"v4.swa_kv": torch.tensor([[0, 1]], dtype=torch.int32)},
+            paged_cache_block_table_base_offsets={
+                "v4.swa_kv": torch.tensor([3], dtype=torch.int32)
+            },
+            actual_bs=1,
+        )
+        self.assertIs(backend.forward_metadata.cache, captured_cache)
+        self.assertFalse(backend.forward_metadata.cache.has_legacy_block_table)
+        self.assertEqual(
+            captured_cache.paged_cache_block_tables["v4.swa_kv"].tolist(),
+            [[0, 1], [-1, -1]],
+        )
+        self.assertEqual(
+            captured_cache.paged_cache_block_table_base_offsets["v4.swa_kv"].tolist(),
+            [3, 0],
+        )
 
     def test_deepseek_v4_decode_backend_maps_compressed_slots_batched(self):
         backend = DeepseekV4AttentionBackend(
@@ -3373,7 +3646,7 @@ class TestDeepseekV4Config(unittest.TestCase):
 
         self.assertIs(_deepseek_v4_forward_metadata(ctx), decode_metadata)
 
-    def test_deepseek_v4_eager_draft_decode_refreshes_stale_graph_metadata(self):
+    def test_deepseek_v4_eager_draft_decode_does_not_reuse_graph_metadata(self):
         backend = DeepseekV4AttentionBackend(
             SimpleNamespace(
                 page_size=64,
@@ -3396,22 +3669,23 @@ class TestDeepseekV4Config(unittest.TestCase):
             seq_lens=torch.ones(4, dtype=torch.int32),
             forward_mode=ForwardMode.DECODE,
         )
-        self.assertEqual(backend._draft_decode_metadata.token_to_req_indices.numel(), 4)
+        graph_metadata = backend._cuda_graph_draft_decode_metadata[4]
+        graph_seq_lens = graph_metadata.seq_lens.clone()
 
-        req_pool_indices = torch.tensor([0], dtype=torch.int32)
-        seq_lens = torch.tensor([6], dtype=torch.int32)
-        req_to_page = torch.tensor([[10]], dtype=torch.int32)
+        req_pool_indices = torch.arange(4, dtype=torch.int32)
+        seq_lens = torch.full((4,), 6, dtype=torch.int32)
+        req_to_page = torch.tensor([[10], [20], [30], [40]], dtype=torch.int32)
         backend.init_forward_metadata(
-            bs=1,
-            num_tokens=6,
+            bs=4,
+            num_tokens=24,
             req_pool_indices=req_pool_indices,
             seq_lens=seq_lens,
             forward_mode=ForwardMode.EXTEND,
             req_to_page=req_to_page,
         )
         backend.init_forward_metadata(
-            bs=1,
-            num_tokens=1,
+            bs=4,
+            num_tokens=4,
             req_pool_indices=req_pool_indices,
             seq_lens=seq_lens,
             forward_mode=ForwardMode.DECODE,
@@ -3420,13 +3694,16 @@ class TestDeepseekV4Config(unittest.TestCase):
         backend.advance_draft_forward_metadata()
 
         metadata = backend.forward_metadata
+        self.assertIsNot(metadata, graph_metadata)
+        self.assertIs(metadata, backend._eager_draft_decode_metadata)
+        self.assertTrue(torch.equal(graph_metadata.seq_lens, graph_seq_lens))
         self.assertEqual(metadata.forward_mode, ForwardMode.DECODE)
-        self.assertEqual(metadata.token_to_req_indices.numel(), 1)
-        self.assertEqual(metadata.decode_token_count(), 1)
+        self.assertEqual(metadata.token_to_req_indices.numel(), 4)
+        self.assertEqual(metadata.decode_token_count(), 4)
         self.assertTrue(
             torch.equal(
                 metadata.token_to_req_indices,
-                torch.tensor([0], dtype=torch.int32),
+                torch.arange(4, dtype=torch.int32),
             )
         )
 
@@ -3741,30 +4018,37 @@ class TestDeepseekV4Config(unittest.TestCase):
             max_context_len=1,
         )
 
-        with patch.object(
-            deepseek_v4_model,
-            "deepseek_v4_prepare_indexer_q_mxfp4",
-            side_effect=fake_prepare_mxfp4,
-        ), patch.object(
-            deepseek_v4_model,
-            "_deepseek_v4_deepgemm_fp4_indexer_available",
-            return_value=True,
-        ), patch.object(
-            deepseek_v4_model,
-            "_deepseek_v4_indexer_prefill_metadata",
-            return_value=empty_prefill_metadata,
-        ), patch.object(
-            deepseek_v4_model,
-            "_deepseek_v4_indexer_decode_plan",
-            return_value=decode_metadata,
-        ), patch.object(
-            deepseek_v4_model,
-            "_deepseek_v4_indexer_decode_schedule_metadata",
-            return_value=None,
-        ), patch.object(
-            deepseek_v4_model,
-            "_deepseek_v4_sparse_attn_indexer",
-            side_effect=fake_sparse_indexer,
+        with (
+            patch.object(
+                deepseek_v4_model,
+                "deepseek_v4_prepare_indexer_q_mxfp4",
+                side_effect=fake_prepare_mxfp4,
+            ),
+            patch.object(
+                deepseek_v4_model,
+                "_deepseek_v4_deepgemm_fp4_indexer_available",
+                return_value=True,
+            ),
+            patch.object(
+                deepseek_v4_model,
+                "_deepseek_v4_indexer_prefill_metadata",
+                return_value=empty_prefill_metadata,
+            ),
+            patch.object(
+                deepseek_v4_model,
+                "_deepseek_v4_indexer_decode_plan",
+                return_value=decode_metadata,
+            ),
+            patch.object(
+                deepseek_v4_model,
+                "_deepseek_v4_indexer_decode_schedule_metadata",
+                return_value=None,
+            ),
+            patch.object(
+                deepseek_v4_model,
+                "_deepseek_v4_sparse_attn_indexer",
+                side_effect=fake_sparse_indexer,
+            ),
         ):
             actual = DeepseekV4Indexer._forward_sparse_indexer_custom_op(
                 self_obj,
@@ -3884,12 +4168,16 @@ class TestDeepseekV4Config(unittest.TestCase):
             captured["indexer_cache"] = kwargs["indexer_cache"]
             return torch.full((2, 2), 3, dtype=torch.int32)
 
+        def fake_cache_insert(**kwargs):
+            captured["indexer_state_slots"] = kwargs["compressor_slot_mapping"].clone()
+            captured["indexer_kv_slots"] = kwargs["kv_slot_mapping"].clone()
+
         self_obj._forward_sparse_indexer_custom_op = fake_custom_op
 
         with patch.object(
             deepseek_v4_model,
             "deepseek_v4_csa_indexer_cache_insert",
-            return_value=None,
+            side_effect=fake_cache_insert,
         ):
             topk = DeepseekV4Indexer.forward(
                 self_obj,
@@ -3905,7 +4193,87 @@ class TestDeepseekV4Config(unittest.TestCase):
 
         self.assertEqual(captured["indexer_block_size"], 4)
         self.assertEqual(captured["indexer_cache"].shape, (8, 128))
+        self.assertTrue(
+            torch.equal(captured["indexer_state_slots"], torch.tensor([-1, -1]))
+        )
+        self.assertTrue(
+            torch.equal(captured["indexer_kv_slots"], torch.tensor([-1, 29]))
+        )
         self.assertTrue(torch.equal(topk, torch.full((2, 2), 3, dtype=torch.int32)))
+
+    def test_deepseek_v4_compressor_writers_mask_owner_out_of_range_pages(self):
+        captured = {}
+        state_cache = torch.empty((2, 4, 2), dtype=torch.float32)
+        compressed_cache = torch.empty((3, 16), dtype=torch.uint8)
+        pool = SimpleNamespace(
+            state_block_size=4,
+            get_compressor_state_buffer=lambda layer_id: state_cache,
+            get_compressor_state_block_size=lambda layer_id: 4,
+            get_compressed_block_size=lambda layer_id: 2,
+            get_compressed_kv_buffer_2d=lambda layer_id: compressed_cache,
+        )
+        metadata = _make_deepseek_v4_forward_metadata(
+            page_size=4,
+            req_pool_indices=torch.tensor([0], dtype=torch.int32),
+            block_table=torch.tensor([[1, 1]], dtype=torch.int32),
+            seq_lens=torch.tensor([8], dtype=torch.int32),
+            query_lens=torch.tensor([2], dtype=torch.int32),
+            query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+            token_to_req_indices=torch.tensor([0, 0], dtype=torch.int32),
+            paged_cache_block_tables={
+                "v4.c4a.compressor_state": torch.tensor([[2, 1]], dtype=torch.int32),
+                "v4.c4a.compressed_kv": torch.tensor([[3]], dtype=torch.int32),
+            },
+        )
+        ctx = SimpleNamespace(
+            token_to_kv_pool=pool,
+            attn_backend=SimpleNamespace(forward_metadata=metadata),
+            forward_mode=ForwardMode.MIXED,
+        )
+        self_obj = SimpleNamespace(
+            compress_ratio=4,
+            coff=1,
+            head_dim=1,
+            ape=torch.empty(0),
+            norm=SimpleNamespace(weight=torch.ones(1), variance_epsilon=1e-6),
+        )
+
+        def fake_save_state(**kwargs):
+            captured["state_slots"] = kwargs["slot_mapping"].clone()
+
+        def fake_compressed_insert(**kwargs):
+            captured["compressed_slots"] = kwargs["kv_slot_mapping"].clone()
+            captured["compressed_cache"] = kwargs["kv_cache_2d"]
+
+        with (
+            patch.object(
+                deepseek_v4_model,
+                "save_deepseek_v4_compressor_state",
+                side_effect=fake_save_state,
+            ),
+            patch.object(
+                deepseek_v4_model,
+                "deepseek_v4_csa_compress_kv_cache_insert",
+                side_effect=fake_compressed_insert,
+            ),
+        ):
+            DeepseekV4Compressor.forward(
+                self_obj,
+                hidden_states=torch.zeros((2, 1)),
+                positions=torch.tensor([3, 7], dtype=torch.int64),
+                ctx=ctx,
+                out_cache_loc=torch.zeros(2, dtype=torch.int64),
+                layer_index=0,
+                cos_sin_cache=torch.empty((1, 1)),
+                compressor_slot_cache={},
+                kv_score=torch.zeros((2, 2)),
+            )
+
+        self.assertTrue(torch.equal(captured["state_slots"], torch.tensor([-1, 7])))
+        self.assertTrue(
+            torch.equal(captured["compressed_slots"], torch.tensor([-1, -1]))
+        )
+        self.assertIs(captured["compressed_cache"], compressed_cache)
 
     def test_deepseek_v4_indexer_prefill_request_chunks_match_reference(self):
         chunks = _deepseek_v4_indexer_prefill_request_chunks(

--- a/test/runtime/test_deepseek_v4_lcm.py
+++ b/test/runtime/test_deepseek_v4_lcm.py
@@ -1,0 +1,420 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY.
+
+"""Focused DeepSeek V4 contracts on the shared LCM planner and arena."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from tokenspeed.runtime.configs.deepseek_v4_cache_spec import (  # noqa: E402
+    build_v4_cache_specs,
+    build_v4_flat_cache_specs,
+)
+from tokenspeed.runtime.configs.lcm_layouts import (  # noqa: E402
+    deepseek_v4_lcm_fields,
+)
+from tokenspeed.runtime.configs.lcm_memory_plan import (  # noqa: E402
+    plan_lcm_fields,
+)
+from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (  # noqa: E402
+    read_deepseek_v4_indexer_fp8_cache,
+    write_deepseek_v4_indexer_fp8_cache,
+)
+from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (  # noqa: E402
+    DeepseekV4CacheLayout,
+    DeepseekV4TokenToKVPool,
+    deepseek_v4_cache_layout_from_config,
+)
+from tokenspeed.runtime.layers.attention.lcm_setup import (  # noqa: E402
+    LcmPoolSpec,
+    _deepseek_v4_lcm_blocks_needed,
+    _deepseek_v4_token_capacity,
+)
+
+# Snapshot of deepseek-ai/DeepSeek-V4-Flash config.json. The production layout
+# builder normalizes 0 to SWA, assigns indices [0, 43) to the target, and index
+# 43 to the MTP draft. Keep the raw serialized order here so this regression
+# cannot accidentally size one synthetic 44-layer target.
+_PRODUCTION_RAW_RATIOS = (0, 0) + (4, 128) * 20 + (4, 0)
+_PRODUCTION_HF_CONFIG = SimpleNamespace(
+    compress_ratios=_PRODUCTION_RAW_RATIOS,
+    head_dim=512,
+    qk_rope_head_dim=64,
+    index_head_dim=128,
+    sliding_window=128,
+    num_hidden_layers=43,
+    num_nextn_predict_layers=1,
+)
+
+
+def _production_layouts(
+    *,
+    use_fp4_indexer_cache=True,
+) -> tuple[DeepseekV4CacheLayout, DeepseekV4CacheLayout]:
+    target_end = _PRODUCTION_HF_CONFIG.num_hidden_layers
+    draft_end = target_end + _PRODUCTION_HF_CONFIG.num_nextn_predict_layers
+    kwargs = dict(
+        hf_config=_PRODUCTION_HF_CONFIG,
+        page_size=64,
+        use_fp4_indexer_cache=use_fp4_indexer_cache,
+    )
+    return (
+        deepseek_v4_cache_layout_from_config(
+            **kwargs,
+            layer_indices=range(target_end),
+        ),
+        deepseek_v4_cache_layout_from_config(
+            **kwargs,
+            layer_indices=range(target_end, draft_end),
+        ),
+    )
+
+
+_PRODUCTION_TARGET_RATIOS = _production_layouts()[0].layer_ratio
+# These are byte-derived planner outputs, not model constants. They lock the
+# shared ordinal-plane overlay and prevent regressions to equal-token packing
+# or one independent plane set per cache group.
+_PRODUCTION_TARGET_PARENT_BYTES = 3_073_536
+_PRODUCTION_DRAFT_PARENT_BYTES = 37_632
+_PRODUCTION_TARGET_PACKING = {
+    "v4.swa_kv": 1,
+    "v4.c4a.compressor_state": 2,
+    "v4.c4a.compressed_kv": 1,
+    "v4.c128a.compressor_state": 2,
+    "v4.c128a.compressed_kv": 46,
+    "v4.c4a.indexer_compressor_state": 9,
+}
+
+
+def _hf_config() -> SimpleNamespace:
+    return SimpleNamespace(sliding_window=128)
+
+
+def _layout(
+    ratios=(1, 4, 128),
+    *,
+    use_fp4_indexer_cache=True,
+) -> DeepseekV4CacheLayout:
+    return DeepseekV4CacheLayout(
+        layer_ratio=tuple(ratios),
+        head_dim=512,
+        rope_head_dim=64,
+        page_size=64,
+        use_fp4_indexer_cache=use_fp4_indexer_cache,
+        index_head_dim=128,
+    )
+
+
+def _lcm_spec(*, ratios=(1, 4, 128), num_lcm_blocks=2) -> LcmPoolSpec:
+    layout = _layout(ratios)
+    specs = tuple(
+        build_v4_flat_cache_specs(_hf_config(), layer_ratio=layout.layer_ratio)
+    )
+    fields = deepseek_v4_lcm_fields(layout=layout, group_specs=specs)
+    reference = plan_lcm_fields(
+        fields,
+        logical_block_tokens=math.gcd(*(int(spec.block_size) for spec in specs)),
+        num_lcm_blocks=1,
+        alignment=256,
+        max_padding_fraction=8.0,
+    )
+    packing = {
+        group.group_id: group.cache_blocks_per_lcm_block for group in reference.groups
+    }
+    plan = plan_lcm_fields(
+        fields,
+        logical_block_tokens=reference.logical_block_tokens,
+        num_lcm_blocks=num_lcm_blocks,
+        cache_blocks_per_lcm_block=packing,
+        alignment=256,
+        max_padding_fraction=8.0,
+    )
+    packed_specs = tuple(
+        replace(
+            spec,
+            cache_blocks_per_lcm_block=packing[spec.group_id],
+        )
+        for spec in specs
+    )
+    return LcmPoolSpec(
+        memory_plan=plan,
+        layer_types=("deepseek_v4",) * len(ratios),
+        layer_group_ids=("deepseek_v4",) * len(ratios),
+        state_field_dtypes={},
+        token_capacity=max(1, num_lcm_blocks * reference.logical_block_tokens),
+        extra_paged_groups=packed_specs,
+    )
+
+
+@pytest.mark.parametrize(
+    ("group_id", "block_size"),
+    (
+        ("v4.swa_kv", 64),
+        ("v4.c4a.compressor_state", 4),
+        ("v4.c4a.compressed_kv", 256),
+        ("v4.c128a.compressor_state", 8),
+        ("v4.c128a.compressed_kv", 256),
+        ("v4.c4a.indexer_compressor_state", 4),
+    ),
+)
+def test_v4_lcm_preserves_heterogeneous_page_spans(group_id, block_size) -> None:
+    spec = _lcm_spec()
+    groups = {group.group_id: group for group in spec.memory_plan.groups}
+    published = {group.group_id: group for group in spec.extra_paged_groups}
+    radix = {
+        group.group_id: group
+        for group in build_v4_cache_specs(
+            _hf_config(),
+            layer_ratio=_layout().layer_ratio,
+        )
+    }
+
+    assert spec.memory_plan.logical_block_tokens == 4
+    assert radix[group_id].block_size is None
+    assert published[group_id].block_size == block_size
+    assert (
+        published[group_id].cache_blocks_per_lcm_block
+        == groups[group_id].cache_blocks_per_lcm_block
+    )
+
+
+def test_v4_production_config_splits_target_and_mtp_before_planning() -> None:
+    target_layout, draft_layout = _production_layouts()
+
+    assert len(target_layout.layer_ratio) == 43
+    assert target_layout.layer_ratio == tuple(
+        max(1, ratio) for ratio in _PRODUCTION_RAW_RATIOS[:43]
+    )
+    assert draft_layout.layer_ratio == (1,)
+
+    draft_specs = tuple(
+        build_v4_flat_cache_specs(
+            _PRODUCTION_HF_CONFIG,
+            layer_ratio=draft_layout.layer_ratio,
+        )
+    )
+    draft_fields = deepseek_v4_lcm_fields(
+        layout=draft_layout,
+        group_specs=draft_specs,
+    )
+    draft_packing = {
+        spec.group_id: _PRODUCTION_TARGET_PACKING[spec.group_id] for spec in draft_specs
+    }
+    draft_plan = plan_lcm_fields(
+        draft_fields,
+        logical_block_tokens=4,
+        num_lcm_blocks=1,
+        cache_blocks_per_lcm_block=draft_packing,
+        alignment=256,
+        max_padding_fraction=8.0,
+    )
+
+    assert draft_plan.lcm_block_bytes == _PRODUCTION_DRAFT_PARENT_BYTES
+    assert draft_packing == {"v4.swa_kv": 1}
+
+
+@pytest.mark.parametrize(
+    (
+        "ratios",
+        "use_fp4_indexer_cache",
+        "expected_parent_bytes",
+        "expected_packing",
+    ),
+    (
+        ((1, 4, 128), True, None, None),
+        (
+            _PRODUCTION_TARGET_RATIOS,
+            True,
+            _PRODUCTION_TARGET_PARENT_BYTES,
+            _PRODUCTION_TARGET_PACKING,
+        ),
+        (
+            _PRODUCTION_TARGET_RATIOS,
+            False,
+            _PRODUCTION_TARGET_PARENT_BYTES,
+            _PRODUCTION_TARGET_PACKING,
+        ),
+    ),
+    ids=("minimal-mixed", "production-fp4-indexer", "production-fp8-indexer"),
+)
+def test_v4_lcm_uses_shared_slot_planes_and_bounded_padding(
+    ratios,
+    use_fp4_indexer_cache,
+    expected_parent_bytes,
+    expected_packing,
+) -> None:
+    layout = _layout(
+        ratios,
+        use_fp4_indexer_cache=use_fp4_indexer_cache,
+    )
+    specs = tuple(build_v4_flat_cache_specs(_hf_config(), layer_ratio=ratios))
+    fields = deepseek_v4_lcm_fields(layout=layout, group_specs=specs)
+    plan = plan_lcm_fields(
+        fields,
+        logical_block_tokens=math.gcd(*(int(spec.block_size) for spec in specs)),
+        num_lcm_blocks=1,
+        alignment=256,
+        max_padding_fraction=8.0,
+    )
+    packing = {
+        group.group_id: group.cache_blocks_per_lcm_block for group in plan.groups
+    }
+    raw_by_group = {}
+    for field in fields:
+        raw_by_group[field.group_id] = (
+            raw_by_group.get(field.group_id, 0) + field.payload_bytes
+        )
+
+    unshared_bytes = sum(
+        packing[field.group_id] * field.payload_bytes for field in fields
+    )
+    padding = {
+        group_id: (plan.lcm_block_bytes // packing[group_id] - payload_bytes)
+        / payload_bytes
+        for group_id, payload_bytes in raw_by_group.items()
+    }
+
+    assert len(plan.planes) == len(ratios)
+    if expected_parent_bytes is not None:
+        assert plan.lcm_block_bytes == expected_parent_bytes
+        assert packing == expected_packing
+    assert plan.lcm_block_bytes < unshared_bytes
+    assert max(padding.values()) <= 8.0
+    assert all(field.page_stride_bytes >= field.payload_bytes for field in plan.fields)
+    assert any(
+        field.page_stride_bytes > field.payload_bytes
+        and field.field_id.endswith(("swa_kv", "compressed_kv", "indexer_kv"))
+        for field in plan.fields
+    )
+
+
+def test_v4_admitted_capacity_accounts_for_all_group_parent_demand() -> None:
+    num_lcm_blocks = 256
+    spec = _lcm_spec(
+        ratios=_PRODUCTION_TARGET_RATIOS,
+        num_lcm_blocks=num_lcm_blocks,
+    )
+    groups = {group.group_id: group for group in spec.memory_plan.groups}
+    unpacked_specs = tuple(
+        replace(group, cache_blocks_per_lcm_block=1)
+        for group in spec.extra_paged_groups
+    )
+    packing = {
+        group_id: group.cache_blocks_per_lcm_block for group_id, group in groups.items()
+    }
+    sizing = dict(
+        max_scheduled_tokens=64,
+        max_live_requests=2,
+        max_context_len=4096,
+        decode_input_tokens=1,
+        overlap_schedule_depth=0,
+    )
+    capacity = _deepseek_v4_token_capacity(
+        unpacked_specs,
+        packing,
+        num_lcm_blocks=num_lcm_blocks,
+        upper_bound_tokens=None,
+        **sizing,
+    )
+
+    assert (
+        _deepseek_v4_lcm_blocks_needed(
+            unpacked_specs,
+            packing,
+            token_capacity=capacity,
+            **sizing,
+        )
+        <= num_lcm_blocks
+    )
+    assert (
+        _deepseek_v4_lcm_blocks_needed(
+            unpacked_specs,
+            packing,
+            token_capacity=capacity + 1,
+            **sizing,
+        )
+        > num_lcm_blocks
+    )
+
+
+def test_v4_fp8_fallback_honors_padded_lcm_page_stride() -> None:
+    block_size = 4
+    index_head_dim = 128
+    payload_bytes = block_size * (index_head_dim + 4)
+    padded_stride = payload_bytes + 256
+    backing = torch.zeros((3, padded_stride), dtype=torch.uint8)
+    padded = backing[:, :payload_bytes]
+    contiguous = torch.zeros((3, payload_bytes), dtype=torch.uint8)
+    keys = torch.linspace(-2, 2, 2 * index_head_dim, dtype=torch.float32).view(
+        2,
+        index_head_dim,
+    )
+    slots = torch.tensor([block_size, 2 * block_size + 1], dtype=torch.int64)
+
+    write_deepseek_v4_indexer_fp8_cache(keys, padded, slots, block_size)
+    write_deepseek_v4_indexer_fp8_cache(keys, contiguous, slots, block_size)
+
+    assert torch.equal(padded, contiguous)
+    assert torch.equal(
+        read_deepseek_v4_indexer_fp8_cache(padded, slots, block_size),
+        read_deepseek_v4_indexer_fp8_cache(contiguous, slots, block_size),
+    )
+    assert not backing[:, payload_bytes:].any()
+
+
+def test_v4_pool_binds_all_fields_to_one_lcm_backing() -> None:
+    layout = _layout()
+    spec = _lcm_spec()
+    pool = DeepseekV4TokenToKVPool(
+        size=spec.pool_size,
+        model_dtype=torch.bfloat16,
+        layout=layout,
+        layer_num=len(layout.layer_ratio),
+        device="cpu",
+        enable_memory_saver=False,
+        max_batch_size=2,
+        max_context_len=4096,
+        page_size=layout.page_size,
+        rank=0,
+        hf_config=_hf_config(),
+        max_scheduled_tokens=64,
+        lcm_spec=spec,
+    )
+
+    assert pool.runtime_contract is not None
+    assert pool.runtime_contract.block_size == 4
+    assert pool.runtime_contract.token_capacity == spec.token_capacity
+    assert pool.size == spec.pool_size
+    assert pool.runtime_contract.num_lcm_blocks == spec.memory_plan.num_lcm_blocks
+    backing = pool.lcm_pool.backing.untyped_storage().data_ptr()
+    assert {tensor.untyped_storage().data_ptr() for tensor in pool._all_buffers()} == {
+        backing
+    }
+
+    pool.lcm_pool.backing.fill_(1)
+    pool.clear_kv_buffers()
+    assert not pool.lcm_pool.backing.any()
+    with pytest.raises(RuntimeError, match="shared parent allocator"):
+        pool.move_kv_cache(
+            torch.tensor([1], dtype=torch.int64),
+            torch.tensor([2], dtype=torch.int64),
+        )

--- a/test/runtime/test_deepseek_v4_mtp_prefix_cache.py
+++ b/test/runtime/test_deepseek_v4_mtp_prefix_cache.py
@@ -49,7 +49,11 @@ def test_deepseek_v4_swa_slot_mapping_expands_mtp_decode_requests():
     )
     ctx = SimpleNamespace(
         attn_backend=SimpleNamespace(forward_metadata=metadata),
-        token_to_kv_pool=SimpleNamespace(swa_block_size=2, swa_capacity_slots=1024),
+        token_to_kv_pool=SimpleNamespace(
+            swa_block_size=2,
+            swa_capacity_pages=512,
+            swa_capacity_slots=1024,
+        ),
     )
     positions = torch.tensor([0, 1, 2, 3], dtype=torch.int32)
     out_cache_loc = torch.tensor([100, 101, 102, 103], dtype=torch.int32)
@@ -85,7 +89,11 @@ def test_deepseek_v4_swa_slot_mapping_prefers_draft_prefill_metadata():
             forward_metadata=decode_metadata,
             forward_prefill_metadata=prefill_metadata,
         ),
-        token_to_kv_pool=SimpleNamespace(swa_block_size=2, swa_capacity_slots=1024),
+        token_to_kv_pool=SimpleNamespace(
+            swa_block_size=2,
+            swa_capacity_pages=512,
+            swa_capacity_slots=1024,
+        ),
     )
     positions = torch.tensor([0, 1, 2, 0, 1], dtype=torch.int32)
     out_cache_loc = torch.tensor([100, 101, 102, 103, 104], dtype=torch.int32)
@@ -114,7 +122,11 @@ def test_deepseek_v4_swa_slot_mapping_masks_invalid_and_overflow_slots():
     )
     ctx = SimpleNamespace(
         attn_backend=SimpleNamespace(forward_metadata=metadata),
-        token_to_kv_pool=SimpleNamespace(swa_block_size=2, swa_capacity_slots=43),
+        token_to_kv_pool=SimpleNamespace(
+            swa_block_size=2,
+            swa_capacity_pages=22,
+            swa_capacity_slots=43,
+        ),
     )
     positions = torch.tensor([0, 1, 2, 3], dtype=torch.int32)
     out_cache_loc = torch.tensor([100, 101, 102, 103], dtype=torch.int32)
@@ -124,6 +136,32 @@ def test_deepseek_v4_swa_slot_mapping_masks_invalid_and_overflow_slots():
     # Raw mapping is [20, 21, 42, 43]: index 2 is masked by is_valid_token,
     # index 3 exceeds the 43-slot capacity.
     assert slot_mapping.tolist() == [20, 21, -1, -1]
+
+
+def test_deepseek_v4_swa_slot_mapping_masks_out_of_range_page_ids():
+    metadata = SimpleNamespace(
+        token_to_req_indices=torch.tensor([0, 0, 0], dtype=torch.int32),
+        cache=SimpleNamespace(
+            swa_block_table=torch.tensor([[0, 511, 512]], dtype=torch.int32),
+            swa_base_logical_page=None,
+        ),
+    )
+    ctx = SimpleNamespace(
+        attn_backend=SimpleNamespace(forward_metadata=metadata),
+        token_to_kv_pool=SimpleNamespace(
+            swa_block_size=2,
+            swa_capacity_pages=512,
+            swa_capacity_slots=1024,
+        ),
+    )
+
+    slot_mapping = _deepseek_v4_swa_slot_mapping(
+        ctx,
+        positions=torch.tensor([0, 2, 4], dtype=torch.int32),
+        out_cache_loc=torch.zeros(3, dtype=torch.int32),
+    )
+
+    assert slot_mapping.tolist() == [-1, 1022, -1]
 
 
 def test_deepseek_v4_swa_slot_mapping_fails_closed_without_capacity():
@@ -148,7 +186,11 @@ def test_deepseek_v4_swa_slot_mapping_fails_closed_without_capacity():
 
     zero_capacity_ctx = SimpleNamespace(
         attn_backend=SimpleNamespace(forward_metadata=metadata),
-        token_to_kv_pool=SimpleNamespace(swa_block_size=2, swa_capacity_slots=0),
+        token_to_kv_pool=SimpleNamespace(
+            swa_block_size=2,
+            swa_capacity_pages=0,
+            swa_capacity_slots=0,
+        ),
     )
     slot_mapping = _deepseek_v4_swa_slot_mapping(
         zero_capacity_ctx, positions, out_cache_loc
@@ -157,7 +199,7 @@ def test_deepseek_v4_swa_slot_mapping_fails_closed_without_capacity():
 
     no_capacity_ctx = SimpleNamespace(
         attn_backend=SimpleNamespace(forward_metadata=metadata),
-        token_to_kv_pool=SimpleNamespace(swa_block_size=2),
+        token_to_kv_pool=SimpleNamespace(swa_block_size=2, swa_capacity_pages=512),
     )
     with pytest.raises(AttributeError, match="swa_capacity_slots"):
         _deepseek_v4_swa_slot_mapping(no_capacity_ctx, positions, out_cache_loc)
@@ -175,13 +217,18 @@ def test_deepseek_v4_swa_slot_mapping_falls_back_for_incompatible_draft_metadata
                 dtype=torch.int32,
             ),
             swa_base_logical_page=None,
+            has_legacy_block_table=True,
         ),
     )
     ctx = SimpleNamespace(
         forward_mode=ForwardMode.DECODE,
         input_num_tokens=5,
         attn_backend=SimpleNamespace(forward_metadata=metadata),
-        token_to_kv_pool=SimpleNamespace(swa_block_size=2, swa_capacity_slots=1024),
+        token_to_kv_pool=SimpleNamespace(
+            swa_block_size=2,
+            swa_capacity_pages=512,
+            swa_capacity_slots=1024,
+        ),
     )
     positions = torch.arange(5, dtype=torch.int32)
     out_cache_loc = torch.tensor([100, 101, 102, 103, 104], dtype=torch.int32)

--- a/test/runtime/test_flat_block_tables_bridge.py
+++ b/test/runtime/test_flat_block_tables_bridge.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import os
 import sys
 import unittest
+from dataclasses import replace
+from types import SimpleNamespace
+
+import numpy as np
 
 # CI Registration (parsed via AST, runtime no-op)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -11,113 +15,492 @@ from ci_system.ci_register import register_cuda_ci
 register_cuda_ci(est_time=10, suite="runtime-1gpu")
 
 
-def _import_bridge():
-    """Import the bridge; skip if torch / tokenspeed_scheduler ext absent."""
-    from tokenspeed.runtime.engine.scheduler_utils import (
-        flat_block_tables_from_forward_op,
+def _op(tables, bases=None):
+    table_arrays = {
+        group_id: (
+            np.asarray(rows, dtype=np.int32)
+            if len(rows) > 0
+            else np.empty((0, 0), dtype=np.int32)
+        )
+        for group_id, rows in tables.items()
+    }
+    base_arrays = {
+        group_id: np.asarray(rows, dtype=np.int32)
+        for group_id, rows in (bases or {}).items()
+    }
+    return SimpleNamespace(
+        flat_block_tables=tables,
+        flat_block_tables_arrays=lambda: table_arrays,
+        paged_cache_block_table_base_offsets_arrays=lambda: base_arrays,
     )
-
-    return flat_block_tables_from_forward_op
 
 
 class FlatBlockTablesBridgeTest(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         try:
-            self.bridge = _import_bridge()
-        except (ImportError, ModuleNotFoundError) as exc:
-            self.skipTest(
-                f"flat bridge unavailable (needs torch + tokenspeed_scheduler "
-                f"ext): {exc}"
+            from tokenspeed.runtime.engine.scheduler_utils import (
+                flat_block_tables_from_forward_op,
+                flat_cache_batch_from_forward_op,
             )
+        except (ImportError, ModuleNotFoundError) as exc:
+            raise unittest.SkipTest(
+                f"flat bridge unavailable (needs scheduler extension): {exc}"
+            ) from exc
+        cls.tables_bridge = staticmethod(flat_block_tables_from_forward_op)
+        cls.batch_bridge = staticmethod(flat_cache_batch_from_forward_op)
+
+    def test_legacy_table_bridge_preserves_values_and_packs_groups(self):
+        out = self.tables_bridge(
+            _op({"full": [[11, 12], [13, 0]], "swa": [[21], [0]]}),
+            "cpu",
+            num_reqs=2,
+        )
+        self.assertEqual(out["full"].tolist(), [[11, 12], [13, 0]])
+        self.assertEqual(out["swa"].tolist(), [[21], [0]])
+        self.assertEqual(
+            out["full"].untyped_storage().data_ptr(),
+            out["swa"].untyped_storage().data_ptr(),
+        )
+
+    def test_contract_batch_uses_canonical_paged_bases_in_one_storage(self):
+        tables, bases = self.batch_bridge(
+            _op(
+                {"full": [[11], [12]], "swa": [[21, 22], [31, 0]]},
+                {"swa": [7, 19]},
+            ),
+            "cpu",
+            num_reqs=2,
+            expected_group_ids=("full", "swa"),
+            max_page_ids={"full": 32, "swa": 32},
+            required_base_offset_group_ids=frozenset({"swa"}),
+        )
+        self.assertEqual(bases["full"].tolist(), [0, 0])
+        self.assertEqual(bases["swa"].tolist(), [7, 19])
+        pointers = {
+            tensor.untyped_storage().data_ptr()
+            for tensor in (*tables.values(), *bases.values())
+        }
+        self.assertEqual(len(pointers), 1)
+
+    def test_invalid_compact_base_contract_fails_closed(self):
+        cases = (
+            (
+                "missing sliding base",
+                _op({"swa": [[1], [2]]}),
+                frozenset({"swa"}),
+                r"missing logical base offsets.*swa",
+            ),
+            (
+                "negative base",
+                _op({"swa": [[1]]}, {"swa": [-1]}),
+                frozenset({"swa"}),
+                "negative logical base",
+            ),
+            (
+                "row mismatch",
+                _op({"swa": [[1], [2]]}, {"swa": [3]}),
+                frozenset({"swa"}),
+                r"swa.*1 rows",
+            ),
+        )
+        for name, op, required, error in cases:
+            with self.subTest(name=name), self.assertRaisesRegex(ValueError, error):
+                self.batch_bridge(
+                    op,
+                    "cpu",
+                    num_reqs=len(op.flat_block_tables["swa"]),
+                    expected_group_ids=("swa",),
+                    max_page_ids={"swa": 8},
+                    required_base_offset_group_ids=required,
+                )
+
+    def test_table_row_shape_contract(self):
+        failure_cases = (
+            ("row count mismatch", {"full": [[1, 2]]}, r"full.*1 rows.*num_reqs=2"),
+            (
+                "empty group on live batch",
+                {"full": [[1, 2], [3, 4]], "swa": []},
+                r"swa.*0 rows.*num_reqs=2",
+            ),
+        )
+        for name, tables, error in failure_cases:
+            with self.subTest(name=name), self.assertRaisesRegex(ValueError, error):
+                self.tables_bridge(_op(tables), "cpu", num_reqs=2)
+
+        empty_op = _op({"full": [], "swa": []})
+        for num_reqs in (0, None):
+            with self.subTest(name="empty operation", num_reqs=num_reqs):
+                self.assertEqual(
+                    self.tables_bridge(empty_op, "cpu", num_reqs=num_reqs),
+                    {},
+                )
+
+    def test_radix_operation_without_flat_export_remains_empty(self):
+        self.assertEqual(self.tables_bridge(SimpleNamespace(), "cpu"), {})
+
+
+class FlatCacheBatchMetadataTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            from tokenspeed.runtime.configs.flat_cache_runtime import (
+                FlatPagedCacheRuntimeContract,
+            )
+            from tokenspeed.runtime.configs.paged_cache_spec import (
+                PagedCacheGroupSpec,
+            )
+            from tokenspeed.runtime.execution.cuda_graph_wrapper import (
+                CudaGraphWrapper,
+            )
+            from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
+            from tokenspeed.runtime.layers.attention.backends.flat_cache_metadata import (
+                FlatCacheBatchMetadata,
+                resolve_flat_runtime_contracts,
+            )
+        except (ImportError, ModuleNotFoundError) as exc:
+            raise unittest.SkipTest(f"flat metadata unavailable: {exc}") from exc
+        cls.Contract = FlatPagedCacheRuntimeContract
+        cls.Spec = PagedCacheGroupSpec
+        cls.Metadata = FlatCacheBatchMetadata
+        cls.resolve_contracts = staticmethod(resolve_flat_runtime_contracts)
+        cls.Wrapper = CudaGraphWrapper
+        cls.ForwardMode = ForwardMode
+
+    def _specs(self):
+        return (
+            self.Spec(
+                group_id="full",
+                retention="full_history",
+                rows_per_page=16,
+                entry_stride_tokens=4,
+                sliding_window_tokens=None,
+                block_size=64,
+            ),
+            self.Spec(
+                group_id="swa",
+                retention="sliding_window",
+                rows_per_page=4,
+                entry_stride_tokens=1,
+                sliding_window_tokens=8,
+                family="state",
+                block_size=4,
+                cache_blocks_per_lcm_block=2,
+            ),
+        )
+
+    def _contract(
+        self,
+        *,
+        specs=None,
+        block_size=4,
+        num_lcm_blocks=4,
+        token_capacity=256,
+    ):
+        specs = tuple(specs or self._specs())
+        return self.Contract(
+            block_size=block_size,
+            num_lcm_blocks=num_lcm_blocks,
+            token_capacity=token_capacity,
+            group_specs=specs,
+            group_page_counts={
+                spec.group_id: (num_lcm_blocks * spec.cache_blocks_per_lcm_block + 1)
+                for spec in specs
+            },
+        )
+
+    def test_heterogeneous_spans_projection_and_forward_provenance(self):
+        op = _op(
+            {"full": [[1], [2]], "swa": [[3, 4], [5, 0]]},
+            {"full": [0, 0], "swa": [7, 9]},
+        )
+        metadata = self.Metadata.from_forward_op(
+            op,
+            device="cpu",
+            contract=self._contract(),
+            num_requests=2,
+            compact_tables=True,
+        )
+        owner = metadata.for_groups(("swa",), owner="draft")
+        self.assertIs(
+            owner.require_table("swa", active_forward_op=op),
+            metadata.require_table("swa", active_forward_op=op),
+        )
+        self.assertIs(
+            owner.require_base_offsets("swa", active_forward_op=op),
+            metadata.require_base_offsets("swa", active_forward_op=op),
+        )
+        with self.assertRaisesRegex(RuntimeError, "stale flat cache metadata"):
+            owner.tables(active_forward_op=SimpleNamespace())
+
+    def test_runtime_contract_selects_transport_and_capability_selects_compaction(
+        self,
+    ):
+        target_contract = self._contract()
+        draft_contract = self._contract(specs=(self._specs()[0],))
+        target_pool = SimpleNamespace(runtime_contract=target_contract)
+        draft_pool = SimpleNamespace(runtime_contract=draft_contract)
+        capable = SimpleNamespace(supports_compact_flat_block_tables=True)
+        legacy = SimpleNamespace(supports_compact_flat_block_tables=False)
+
+        for name, kwargs, expected in (
+            (
+                "legacy consumer keeps contract metadata with absolute tables",
+                dict(target_pool=target_pool, target_backend=legacy),
+                (target_contract, None, False),
+            ),
+            (
+                "compact target",
+                dict(target_pool=target_pool, target_backend=capable),
+                (target_contract, None, True),
+            ),
+            (
+                "compact target and draft",
+                dict(
+                    target_pool=target_pool,
+                    target_backend=capable,
+                    draft_pool=draft_pool,
+                    draft_backend=capable,
+                ),
+                (target_contract, draft_contract, True),
+            ),
+            (
+                "radix build keeps metadata but disables compaction",
+                dict(target_pool=target_pool, target_backend=capable),
+                (target_contract, None, False),
+            ),
+        ):
+            with self.subTest(name=name):
+                actual = self.resolve_contracts(
+                    **kwargs,
+                    flat_kvcache_ext=name
+                    != "radix build keeps metadata but disables compaction",
+                )
+                self.assertIs(actual[0], expected[0])
+                self.assertIs(actual[1], expected[1])
+                self.assertIs(actual[2], expected[2])
+
+    def test_compact_capability_contract_errors_fail_closed(self):
+        contract = self._contract()
+        contract_pool = SimpleNamespace(runtime_contract=contract)
+        no_contract_pool = SimpleNamespace(runtime_contract=None)
+        capable = SimpleNamespace(supports_compact_flat_block_tables=True)
+        legacy = SimpleNamespace(supports_compact_flat_block_tables=False)
+
+        cases = (
+            (
+                "target compact draft legacy",
+                dict(
+                    target_pool=contract_pool,
+                    target_backend=capable,
+                    draft_pool=SimpleNamespace(
+                        runtime_contract=self._contract(specs=(self._specs()[0],))
+                    ),
+                    draft_backend=legacy,
+                ),
+                "disagree on compact",
+            ),
+            (
+                "target legacy draft compact",
+                dict(
+                    target_pool=contract_pool,
+                    target_backend=legacy,
+                    draft_pool=SimpleNamespace(
+                        runtime_contract=self._contract(specs=(self._specs()[0],))
+                    ),
+                    draft_backend=capable,
+                ),
+                "disagree on compact",
+            ),
+            (
+                "compact target has no contract",
+                dict(
+                    target_pool=no_contract_pool,
+                    target_backend=capable,
+                ),
+                "target backend requires a runtime contract",
+            ),
+            (
+                "compact draft has no contract",
+                dict(
+                    target_pool=contract_pool,
+                    target_backend=capable,
+                    draft_pool=no_contract_pool,
+                    draft_backend=capable,
+                ),
+                "draft backend requires a runtime contract",
+            ),
+        )
+        for name, kwargs, error in cases:
+            with self.subTest(name=name), self.assertRaisesRegex(RuntimeError, error):
+                self.resolve_contracts(
+                    **kwargs,
+                    flat_kvcache_ext=True,
+                )
+
+    def test_target_draft_contract_geometry_must_match(self):
+        target = self._contract()
+        full = self._specs()[0]
+        cases = (
+            (
+                "base block size",
+                self._contract(
+                    specs=(full,),
+                    block_size=8,
+                ),
+                "base block_size",
+            ),
+            (
+                "draft group subset",
+                self._contract(specs=(replace(full, group_id="other"),)),
+                "not a subset",
+            ),
+            (
+                "group block size",
+                self._contract(specs=(replace(full, block_size=68),)),
+                "group_block_size",
+            ),
+            (
+                "retention",
+                self._contract(
+                    specs=(
+                        replace(
+                            full,
+                            retention="sliding_window",
+                            sliding_window_tokens=64,
+                        ),
+                    )
+                ),
+                "retention",
+            ),
+            (
+                "family",
+                self._contract(specs=(replace(full, family="state"),)),
+                "family",
+            ),
+            (
+                "cache blocks per LCM block",
+                self._contract(specs=(replace(full, cache_blocks_per_lcm_block=2),)),
+                "cache_blocks_per_lcm_block",
+            ),
+            (
+                "group page count",
+                self._contract(
+                    specs=(full,),
+                    num_lcm_blocks=3,
+                    token_capacity=192,
+                ),
+                "group_page_count",
+            ),
+        )
+        capable = SimpleNamespace(supports_compact_flat_block_tables=True)
+        for name, draft, error in cases:
+            with self.subTest(name=name), self.assertRaisesRegex(RuntimeError, error):
+                self.resolve_contracts(
+                    target_pool=SimpleNamespace(runtime_contract=target),
+                    target_backend=capable,
+                    draft_pool=SimpleNamespace(runtime_contract=draft),
+                    draft_backend=capable,
+                    flat_kvcache_ext=True,
+                )
+
+    def test_absolute_contract_metadata_does_not_read_or_transfer_bases(self):
+        op = _op({"full": [[1], [2]], "swa": [[3, 4], [5, 0]]})
+
+        def fail_if_bases_are_read():
+            raise AssertionError("absolute table transport must not read bases")
+
+        op.paged_cache_block_table_base_offsets_arrays = fail_if_bases_are_read
+        metadata = self.Metadata.from_forward_op(
+            op,
+            device="cpu",
+            contract=self._contract(),
+            num_requests=2,
+            compact_tables=False,
+        )
+        self.assertFalse(metadata.compact_tables)
+        self.assertEqual(metadata.base_offsets(active_forward_op=op), {})
+        self.assertEqual(
+            set(metadata.tables(active_forward_op=op)),
+            {"full", "swa"},
+        )
+
+    def test_compact_contract_metadata_requires_every_group_base(self):
+        op = _op(
+            {"full": [[1], [2]], "swa": [[3, 4], [5, 0]]},
+            {"swa": [7, 9]},
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            r"missing logical base offsets.*full",
+        ):
+            self.Metadata.from_forward_op(
+                op,
+                device="cpu",
+                contract=self._contract(),
+                num_requests=2,
+                compact_tables=True,
+            )
+
+    def test_graph_replay_keeps_target_and_draft_owner_views_distinct(self):
         import torch
 
-        self.torch = torch
+        op = _op(
+            {"full": [[1], [2]], "swa": [[3, 4], [5, 0]]},
+            {"full": [0, 0], "swa": [7, 9]},
+        )
+        target = self.Metadata.from_forward_op(
+            op,
+            device="cpu",
+            contract=self._contract(),
+            num_requests=2,
+            compact_tables=True,
+        )
+        draft = target.for_groups(("full",), owner="draft")
+        captured = {}
 
-    def _make_op(self, flat_block_tables):
-        from types import SimpleNamespace
+        class Backend:
+            uses_paged_cache_groups = True
+            uses_flat_cache_groups = True
+            uses_padded_decode_token_mask = False
+            flat_tables_self_padding = True
 
-        import numpy as np
+            def __init__(self, owner):
+                self.owner = owner
 
-        def rect(v):
-            a = np.asarray(v, dtype=np.int32)
-            return a if a.ndim == 2 else a.reshape(len(v), 0)
+            def init_forward_metadata_replay_cuda_graph(self, *args, **kwargs):
+                captured[self.owner] = kwargs
 
-        arrays = {k: rect(v) for k, v in flat_block_tables.items()}
-        return SimpleNamespace(
-            flat_block_tables=flat_block_tables,
-            flat_block_tables_arrays=lambda: arrays,
+        wrapper = self.Wrapper.__new__(self.Wrapper)
+        wrapper.attn_backend = Backend("target")
+        wrapper.draft_attn_backend = Backend("draft")
+        wrapper.drafter = SimpleNamespace(
+            draft_seq_lens_buf=torch.zeros(2, dtype=torch.int32),
+            req_to_page=torch.zeros((2, 1), dtype=torch.int32),
+        )
+        wrapper.max_tokens_per_req = 1
+        wrapper._init_replay_metadata(
+            padded_bs=2,
+            actual_bs=2,
+            req_pool_indices=torch.arange(2, dtype=torch.int32),
+            seq_lens=torch.ones(2, dtype=torch.int32),
+            req_to_page=torch.zeros((2, 1), dtype=torch.int32),
+            forward_mode=self.ForwardMode.DECODE,
+            flat_block_tables=target.tables(active_forward_op=op),
+            paged_cache_block_table_base_offsets=target.base_offsets(
+                active_forward_op=op
+            ),
+            flat_cache_metadata=target,
+            draft_flat_cache_metadata=draft,
+            flat_cache_forward_op=op,
         )
 
-    def test_two_groups_shape_and_null_hole_preserved(self):
-        op = self._make_op(
-            {
-                "full": [[11, 12], [13, 0]],
-                "swa": [[21], [0]],
-            }
+        self.assertEqual(set(captured["target"]["flat_block_tables"]), {"full", "swa"})
+        self.assertEqual(set(captured["draft"]["flat_block_tables"]), {"full"})
+        self.assertEqual(
+            set(captured["draft"]["paged_cache_block_table_base_offsets"]),
+            {"full"},
         )
-        out = self.bridge(op, device="cpu", num_reqs=2)
-        self.assertEqual(set(out.keys()), {"full", "swa"})
-
-        full = out["full"]
-        self.assertEqual(tuple(full.shape), (2, 2))
-        self.assertEqual(full.dtype, self.torch.int32)
-        self.assertEqual(full.tolist(), [[11, 12], [13, 0]])
-
-        swa = out["swa"]
-        self.assertEqual(tuple(swa.shape), (2, 1))
-        self.assertEqual(swa.tolist(), [[21], [0]])
-
-    def test_radix_op_without_flat_attrs_returns_empty(self):
-        from types import SimpleNamespace
-
-        op = SimpleNamespace()
-        self.assertEqual(self.bridge(op, device="cpu"), {})
-
-    def test_attribute_name_is_pinned(self):
-        # The bridge reads exactly `flat_block_tables`; a renamed payload
-        # yields {} like a radix op, so a rename must be caught here.
-        from types import SimpleNamespace
-
-        renamed = SimpleNamespace(flat_page_tables={"full": [[1]]})
-        self.assertEqual(self.bridge(renamed, device="cpu", num_reqs=1), {})
-        op = self._make_op({"full": [[1]]})
-        out = self.bridge(op, device="cpu", num_reqs=1)
-        self.assertEqual(out["full"].tolist(), [[1]])
-
-    def test_row_count_mismatch_raises(self):
-        op = self._make_op({"full": [[1, 2]]})
-        with self.assertRaises(ValueError):
-            self.bridge(op, device="cpu", num_reqs=2)
-
-    def test_empty_rows_group_on_live_batch_raises(self):
-        # An empty row list may not silently vanish on a live op: downstream
-        # replay would see a per-group hole over stale pages.
-        op = self._make_op({"full": [[1, 2], [3, 4]], "swa": []})
-        with self.assertRaisesRegex(ValueError, r"swa.*0 rows"):
-            self.bridge(op, device="cpu", num_reqs=2)
-
-    def test_empty_rows_group_on_zero_req_op_dropped(self):
-        # bs==0 replay/idle paths treat the resulting {} as "no tables".
-        op = self._make_op({"full": [], "swa": []})
-        self.assertEqual(self.bridge(op, device="cpu", num_reqs=0), {})
-        self.assertEqual(self.bridge(op, device="cpu"), {})
-
-
-class FlatFlagGatingTest(unittest.TestCase):
-    """uses_flat_cache_groups must default to False so every existing
-    backend stays on today's path; needs torch, skips otherwise."""
-
-    def setUp(self):
-        try:
-            from tokenspeed.runtime.layers.attention.backends.base import (
-                AttentionBackend,
-            )
-        except (ImportError, ModuleNotFoundError) as exc:
-            self.skipTest(f"needs torch + backend base: {exc}")
-        self.AttentionBackend = AttentionBackend
-
-    def test_default_backend_does_not_use_flat_groups(self):
-        self.assertFalse(self.AttentionBackend.uses_flat_cache_groups)
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_flat_cudagraph_per_group.py
+++ b/test/runtime/test_flat_cudagraph_per_group.py
@@ -1,17 +1,13 @@
-"""M10: flat per-group CUDA-graph pad / capture / replay core-logic tests.
-
-CPU-only (plain tensors, no graph capture): covers the wrapper's flat
-placeholder + padding helpers and the MHA backend's flat capture/replay
-branches. Graph runtime semantics (pointer-fixed replay) are validated
-separately on GPU via the P0 probe.
-"""
+"""Focused flat CUDA-graph contracts: null padding, aliasing, and refresh."""
 
 from __future__ import annotations
 
 import os
 import sys
-import unittest
 from types import SimpleNamespace
+from unittest import mock
+
+import pytest
 
 # CI Registration (parsed via AST, runtime no-op)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -19,499 +15,271 @@ from ci_system.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=10, suite="runtime-1gpu")
 
+torch = pytest.importorskip("torch")
+
+from tokenspeed.runtime.configs.paged_cache_spec import (  # noqa: E402
+    PagedCacheGroupSpec,
+)
+from tokenspeed.runtime.execution.cuda_graph_wrapper import (  # noqa: E402
+    CudaGraphWrapper,
+)
+
 MAX_BS = 4
 MAX_NUM_PAGES = 6
+GROUP_IDS = ("sliding_attention", "full_attention")
 
 
-def _decode_forward_mode():
+def _decode_mode() -> SimpleNamespace:
     return SimpleNamespace(is_extend_or_mixed=lambda: False)
 
 
-class _TorchCase(unittest.TestCase):
-    def setUp(self):
-        try:
-            import torch
-        except (ImportError, ModuleNotFoundError) as exc:
-            self.skipTest(f"needs torch: {exc}")
-        self.torch = torch
+def _history_spec(group_id: str) -> PagedCacheGroupSpec:
+    return PagedCacheGroupSpec(
+        group_id=group_id,
+        retention="full_history",
+        rows_per_page=2,
+        entry_stride_tokens=1,
+        sliding_window_tokens=None,
+        block_size=2,
+    )
 
 
-class PadBlockTablesTest(_TorchCase):
-    def setUp(self):
-        super().setUp()
-        from tokenspeed.runtime.execution.cuda_graph_wrapper import (
-            CudaGraphWrapper,
+def _backend(*, draft_lookback: int = 0):
+    mha = pytest.importorskip("tokenspeed.runtime.layers.attention.backends.mha")
+    backend = mha.MHAAttnBackend.__new__(mha.MHAAttnBackend)
+    backend.spec_num_tokens = 1
+    backend.is_draft = False
+    backend.draft_block_decode = False
+    backend.flat_draft_lookback = draft_lookback
+    backend.max_num_pages = MAX_NUM_PAGES
+    backend.max_context_len = MAX_NUM_PAGES * 2
+    backend.page_size = 2
+    backend.device = "cpu"
+    backend.forward_decode_metadata = None
+    backend.forward_extend_metadata = None
+    backend.init_cuda_graph_state(
+        max_bs=MAX_BS,
+        seq_lens_buf=torch.ones(MAX_BS, dtype=torch.int32),
+        paged_cache_group_specs=tuple(_history_spec(gid) for gid in GROUP_IDS),
+    )
+    return backend
+
+
+def _capture(backend, bs: int = 2):
+    backend.init_forward_metadata_capture_cuda_graph(
+        bs,
+        torch.arange(bs, dtype=torch.int64),
+        torch.ones(bs, dtype=torch.int32),
+        _decode_mode(),
+        flat_cache_group_ids=GROUP_IDS,
+    )
+    return backend.forward_decode_metadata
+
+
+def _wrapper(backend):
+    wrapper = CudaGraphWrapper.__new__(CudaGraphWrapper)
+    wrapper.attn_backend = backend
+    wrapper.draft_attn_backend = None
+    wrapper.token_to_kv_pool = SimpleNamespace(
+        paged_cache_group_specs=tuple(_history_spec(gid) for gid in GROUP_IDS)
+    )
+    wrapper.device = "cpu"
+    wrapper.compact_flat_block_tables = False
+    wrapper.use_flat_cache_tables = True
+    return wrapper
+
+
+def test_replay_padding_zero_fills_base_offsets() -> None:
+    bases = {
+        group_id: torch.tensor([3, 4], dtype=torch.int32) for group_id in GROUP_IDS
+    }
+    padded_bases = CudaGraphWrapper._pad_offsets_to_padded_bs(
+        bases,
+        actual_bs=2,
+        padded_bs=4,
+    )
+
+    for base_offsets in padded_bases.values():
+        assert base_offsets.tolist() == [3, 4, 0, 0]
+
+
+def test_replay_wrapper_pads_flat_dummy_rows_with_page_zero() -> None:
+    captured = {}
+    backend = SimpleNamespace(
+        uses_paged_cache_groups=False,
+        uses_flat_cache_groups=True,
+        flat_tables_self_padding=False,
+        uses_padded_decode_token_mask=False,
+        init_forward_metadata_replay_cuda_graph=(
+            lambda *args, **kwargs: captured.update(kwargs)
+        ),
+    )
+    tables = {
+        group_id: torch.tensor([[3, 4], [5, 6]], dtype=torch.int32)
+        for group_id in GROUP_IDS
+    }
+
+    _wrapper(backend)._init_replay_metadata(
+        padded_bs=4,
+        actual_bs=2,
+        req_pool_indices=torch.arange(4, dtype=torch.int64),
+        seq_lens=torch.ones(4, dtype=torch.int32),
+        req_to_page=torch.zeros((4, MAX_NUM_PAGES), dtype=torch.int32),
+        forward_mode=_decode_mode(),
+        flat_block_tables=tables,
+    )
+
+    for group_id, table in captured["flat_block_tables"].items():
+        assert torch.equal(table[:2], tables[group_id])
+        assert table[2:].tolist() == [[0, 0], [0, 0]]
+
+
+def test_capture_wrapper_passes_pool_group_ids() -> None:
+    captured = {}
+    backend = SimpleNamespace(
+        uses_paged_cache_groups=False,
+        uses_flat_cache_groups=True,
+        init_forward_metadata_capture_cuda_graph=(
+            lambda *args, **kwargs: captured.update(kwargs)
+        ),
+    )
+    wrapper = _wrapper(backend)
+    wrapper.input_buffers = SimpleNamespace(
+        has_mamba=False,
+        req_pool_indices_buf=torch.arange(MAX_BS, dtype=torch.int64),
+        seq_lens_buf=torch.ones(MAX_BS, dtype=torch.int32),
+    )
+
+    wrapper._init_capture_metadata(2)
+
+    assert captured["flat_cache_group_ids"] == GROUP_IDS
+
+
+def test_radix_transport_does_not_capture_flat_group_tables() -> None:
+    backend = SimpleNamespace(uses_flat_cache_groups=True)
+    wrapper = _wrapper(backend)
+    wrapper.use_flat_cache_tables = False
+
+    assert wrapper._flat_cache_group_ids(wrapper.token_to_kv_pool) == ()
+    assert wrapper._idle_flat_block_tables(padded_bs=3) is None
+
+
+def test_idle_wrapper_uses_one_page_zero_column_per_group() -> None:
+    tables = _wrapper(SimpleNamespace())._idle_flat_block_tables(padded_bs=3)
+
+    assert set(tables) == set(GROUP_IDS)
+    for table in tables.values():
+        assert table.dtype == torch.int32
+        assert table.tolist() == [[0], [0], [0]]
+
+
+def test_capture_metadata_aliases_persistent_group_buffers() -> None:
+    backend = _backend()
+    metadata = _capture(backend)
+
+    assert metadata.page_table is None
+    assert set(metadata.page_tables) == set(GROUP_IDS)
+    for group_id in GROUP_IDS:
+        table_buffer = backend.cuda_graph_flat_page_tables[group_id]
+        base_buffer = backend.cuda_graph_flat_block_table_base_offsets[group_id]
+        assert metadata.page_tables[group_id].data_ptr() == table_buffer.data_ptr()
+        assert (
+            metadata.block_table_base_offsets[group_id].data_ptr()
+            == base_buffer.data_ptr()
         )
 
-        self.pad = CudaGraphWrapper._pad_block_tables_to_padded_bs
 
-    def _tables(self):
-        torch = self.torch
-        return {
-            "full_attention": torch.arange(6, dtype=torch.int32).reshape(2, 3),
-            "sliding_attention": torch.ones((2, 3), dtype=torch.int32),
-        }
-
-    def test_default_pads_tail_rows_with_minus_one(self):
-        # Radix/V4 path keeps -1 dummy rows: the backend masks dummy tokens
-        # via is_valid_token before any block-table read.
-        tables = self._tables()
-        out = self.pad(tables, actual_bs=2, padded_bs=4)
-        for gid, src in tables.items():
-            self.assertEqual(tuple(out[gid].shape), (4, 3))
-            self.assertTrue((out[gid][:2] == src).all())
-            self.assertTrue((out[gid][2:] == -1).all())
-
-    def test_flat_pads_tail_rows_with_zero(self):
-        # Flat path passes pad_value=0: dummy rows replay with seq_lens=1 and
-        # ARE dereferenced, so they must land on the zero-init dummy page 0.
-        tables = self._tables()
-        out = self.pad(tables, actual_bs=2, padded_bs=4, pad_value=0)
-        for gid, src in tables.items():
-            self.assertEqual(tuple(out[gid].shape), (4, 3))
-            self.assertTrue((out[gid][:2] == src).all())
-            self.assertTrue((out[gid][2:] == 0).all())
-
-    def test_noop_when_bs_equal(self):
-        torch = self.torch
-        tables = {"full_attention": torch.ones((3, 2), dtype=torch.int32)}
-        out = self.pad(tables, actual_bs=3, padded_bs=3)
-        self.assertIs(out["full_attention"], tables["full_attention"])
+def _mha_capture_backend():
+    mha = pytest.importorskip("tokenspeed.runtime.layers.attention.backends.mha")
+    return mha.MHAAttnBackend.__new__(mha.MHAAttnBackend)
 
 
-class FlatCacheGroupIdsTest(_TorchCase):
-    """Wrapper-side capture contract: group ids only, no fabricated tensors."""
+def _msa_capture_backend():
+    msa = pytest.importorskip("tokenspeed.runtime.layers.attention.backends.msa")
+    backend = msa.MSAAttnBackend.__new__(msa.MSAAttnBackend)
+    backend.decode_score_buffer = torch.empty(
+        (MAX_BS, 1, MAX_NUM_PAGES), dtype=torch.float32
+    )
+    return backend
 
-    def setUp(self):
-        super().setUp()
-        from tokenspeed.runtime.execution.cuda_graph_wrapper import (
-            CudaGraphWrapper,
-        )
 
-        self.group_ids = CudaGraphWrapper._flat_cache_group_ids
+@pytest.mark.parametrize(
+    "make_backend",
+    (_mha_capture_backend, _msa_capture_backend),
+    ids=("mha", "msa"),
+)
+def test_repeated_capture_reuses_metadata_object(make_backend) -> None:
+    backend = make_backend()
+    backend.spec_num_tokens = 1
+    backend.is_draft = False
+    backend.draft_block_decode = False
+    backend.max_num_pages = MAX_NUM_PAGES
+    backend.max_context_len = MAX_NUM_PAGES * 2
+    backend.page_size = 2
+    backend.device = "cpu"
+    backend.forward_decode_metadata = None
+    backend.forward_extend_metadata = None
+    backend.init_cuda_graph_state(
+        max_bs=MAX_BS,
+        seq_lens_buf=torch.ones(MAX_BS, dtype=torch.int32),
+        paged_cache_group_specs=tuple(_history_spec(gid) for gid in GROUP_IDS),
+    )
 
-    def _wrapper(self, uses_flat=True):
-        return SimpleNamespace(
-            attn_backend=SimpleNamespace(uses_flat_cache_groups=uses_flat),
-        )
+    first = _capture(backend)
+    second = _capture(backend)
 
-    def _pool(self, group_ids):
-        return SimpleNamespace(
-            paged_cache_group_specs=tuple(
-                SimpleNamespace(group_id=gid) for gid in group_ids
+    assert second is first
+    assert second is backend.cuda_graph_decode_metadata[2]
+    assert set(second.block_table_base_offsets) == set(GROUP_IDS)
+
+
+def test_capture_init_restores_main_locs_after_lookback() -> None:
+    backend = _backend(draft_lookback=2)
+    metadata = _capture(backend)
+    main_locs = dict(metadata.out_cache_locs)
+
+    assert backend.flat_enter_draft_lookback(2)
+    assert backend.forward_decode_metadata is metadata
+    assert _capture(backend) is metadata
+    for group_id, locs in main_locs.items():
+        assert metadata.out_cache_locs[group_id].is_set_to(locs)
+
+
+def test_replay_refreshes_persistent_tables_without_rebinding_metadata() -> None:
+    flat_groups = pytest.importorskip(
+        "tokenspeed.runtime.layers.attention.backends.flat_groups"
+    )
+    backend = _backend()
+    metadata = _capture(backend)
+    backend._flat_try_packed_unpack = lambda bs, tables: False
+
+    with mock.patch.object(flat_groups, "flat_decode_locs") as fill_locs:
+        for value, width, bases in ((10, 2, (0, 1)), (20, 3, (2, 3))):
+            tables = {
+                group_id: torch.full((2, width), value, dtype=torch.int32)
+                for group_id in GROUP_IDS
+            }
+            base_offsets = {
+                group_id: torch.tensor(bases, dtype=torch.int32)
+                for group_id in GROUP_IDS
+            }
+            backend.init_forward_metadata_replay_cuda_graph(
+                2,
+                torch.arange(MAX_BS, dtype=torch.int64),
+                torch.tensor([3, 4, 1, 1], dtype=torch.int32),
+                torch.zeros((MAX_BS, MAX_NUM_PAGES), dtype=torch.int32),
+                _decode_mode(),
+                flat_block_tables=tables,
+                flat_block_table_base_offsets=base_offsets,
             )
-        )
 
-    def test_ids_in_spec_order(self):
-        out = self.group_ids(
-            self._wrapper(),
-            self._pool(["sliding_attention", "full_attention"]),
-        )
-        self.assertEqual(out, ("sliding_attention", "full_attention"))
+            for group_id in GROUP_IDS:
+                persistent = backend.cuda_graph_flat_page_tables[group_id]
+                assert torch.equal(persistent[:2, :width], tables[group_id])
+                assert (persistent[:2, width:] == -1).all()
+                assert backend.cuda_graph_flat_block_table_base_offsets[group_id][
+                    :2
+                ].tolist() == list(bases)
+            assert backend.forward_decode_metadata is metadata
 
-    def test_empty_without_specs(self):
-        self.assertEqual(self.group_ids(self._wrapper(), self._pool([])), ())
-
-    def test_empty_when_backend_not_flat(self):
-        out = self.group_ids(
-            self._wrapper(uses_flat=False), self._pool(["full_attention"])
-        )
-        self.assertEqual(out, ())
-
-
-class WrapperReplayFlatTest(_TorchCase):
-    """Call-site wiring: the real _init_replay_metadata must row-pad flat
-    tables with 0 (not the -1 default) before handing them to the backend."""
-
-    def _run_replay(self, flat_block_tables, padded_bs, actual_bs):
-        torch = self.torch
-        from tokenspeed.runtime.execution.cuda_graph_wrapper import (
-            CudaGraphWrapper,
-        )
-
-        recorded = {}
-
-        def record(bs, req_pool_indices, seq_lens, **kwargs):
-            recorded["bs"] = bs
-            recorded.update(kwargs)
-
-        mock = SimpleNamespace(
-            attn_backend=SimpleNamespace(
-                uses_flat_cache_groups=True,
-                uses_paged_cache_groups=False,
-                uses_padded_decode_token_mask=False,
-                init_forward_metadata_replay_cuda_graph=record,
-            ),
-            draft_attn_backend=None,
-            # Production helper, so the pinned pad_value is the real one.
-            _pad_block_tables_to_padded_bs=(
-                CudaGraphWrapper._pad_block_tables_to_padded_bs
-            ),
-        )
-        CudaGraphWrapper._init_replay_metadata(
-            mock,
-            padded_bs,
-            actual_bs,
-            torch.arange(padded_bs, dtype=torch.int64),
-            torch.ones(padded_bs, dtype=torch.int32),
-            torch.zeros((MAX_BS, MAX_NUM_PAGES), dtype=torch.int32),
-            _decode_forward_mode(),
-            flat_block_tables=flat_block_tables,
-        )
-        return recorded
-
-    def test_flat_replay_path_pads_with_zero(self):
-        torch = self.torch
-        src = {
-            "sliding_attention": torch.tensor([[3, 4], [5, 6]], dtype=torch.int32),
-            "full_attention": torch.tensor([[7, 8], [9, 1]], dtype=torch.int32),
-        }
-        recorded = self._run_replay(src, padded_bs=4, actual_bs=2)
-        self.assertEqual(recorded["bs"], 4)
-        out = recorded["flat_block_tables"]
-        self.assertEqual(set(out), set(src))
-        for gid, table in out.items():
-            self.assertEqual(tuple(table.shape), (4, 2))
-            self.assertTrue((table[:2] == src[gid]).all())
-            # Dummy rows must land on the zero-init dummy page 0, never -1:
-            # they replay with seq_lens=1 and their col-0 IS dereferenced.
-            self.assertTrue((table[2:] == 0).all())
-
-    def test_flat_replay_path_noop_without_padding(self):
-        torch = self.torch
-        src = {"full_attention": torch.ones((2, 2), dtype=torch.int32)}
-        recorded = self._run_replay(src, padded_bs=2, actual_bs=2)
-        self.assertIs(
-            recorded["flat_block_tables"]["full_attention"],
-            src["full_attention"],
-        )
-
-
-class WrapperCaptureFlatGroupIdsTest(_TorchCase):
-    """Call-site wiring: the real _init_capture_metadata must derive
-    flat_cache_group_ids from the pool's published specs and pass them to
-    the backend capture hook."""
-
-    def _run_capture(self, bs, group_ids, uses_flat=True):
-        torch = self.torch
-        from types import MethodType
-
-        from tokenspeed.runtime.execution.cuda_graph_wrapper import (
-            CudaGraphWrapper,
-        )
-
-        recorded = {}
-
-        def record(bs, req_pool_indices, seq_lens, forward_mode, **kwargs):
-            recorded["bs"] = bs
-            recorded["kwargs"] = kwargs
-
-        mock = SimpleNamespace(
-            input_buffers=SimpleNamespace(
-                has_mamba=False,
-                req_pool_indices_buf=torch.arange(MAX_BS, dtype=torch.int64),
-                seq_lens_buf=torch.ones(MAX_BS, dtype=torch.int32),
-            ),
-            attn_backend=SimpleNamespace(
-                uses_paged_cache_groups=False,
-                uses_flat_cache_groups=uses_flat,
-                init_forward_metadata_capture_cuda_graph=record,
-            ),
-            token_to_kv_pool=SimpleNamespace(
-                paged_cache_group_specs=tuple(
-                    SimpleNamespace(group_id=gid) for gid in group_ids
-                )
-            ),
-            drafter=None,
-            use_target_verify_forward_mode=False,
-            draft_attn_backend=None,
-        )
-        mock._flat_cache_group_ids = MethodType(
-            CudaGraphWrapper._flat_cache_group_ids, mock
-        )
-        CudaGraphWrapper._init_capture_metadata(mock, bs)
-        return recorded
-
-    def test_capture_passes_group_ids_from_pool_specs(self):
-        recorded = self._run_capture(2, ["sliding_attention", "full_attention"])
-        self.assertEqual(recorded["bs"], 2)
-        self.assertEqual(
-            recorded["kwargs"]["flat_cache_group_ids"],
-            ("sliding_attention", "full_attention"),
-        )
-
-    def test_capture_omits_group_ids_when_backend_not_flat(self):
-        recorded = self._run_capture(
-            2, ["sliding_attention", "full_attention"], uses_flat=False
-        )
-        self.assertNotIn("flat_cache_group_ids", recorded["kwargs"])
-
-    def test_capture_omits_group_ids_without_specs(self):
-        recorded = self._run_capture(2, [])
-        self.assertNotIn("flat_cache_group_ids", recorded["kwargs"])
-
-
-class WrapperEagerFlatGuardTest(_TorchCase):
-    """Eager parity guard: a multi-group flat pool + flat-consuming backend
-    must not reach the backend's single-table fallback without tables."""
-
-    def _call(self, group_ids, flat_block_tables=None):
-        torch = self.torch
-        from tokenspeed.runtime.execution.cuda_graph_wrapper import (
-            CudaGraphWrapper,
-        )
-        from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
-
-        calls = {}
-
-        def init_forward_metadata(*args, **kwargs):
-            calls["init_kwargs"] = kwargs
-
-        mock = SimpleNamespace(
-            input_buffers=SimpleNamespace(
-                seq_lens_buf=torch.ones(MAX_BS, dtype=torch.int32),
-                req_pool_indices_buf=torch.arange(MAX_BS, dtype=torch.int64),
-            ),
-            config=SimpleNamespace(),
-            attn_backend=SimpleNamespace(
-                uses_flat_cache_groups=True,
-                uses_paged_cache_groups=False,
-            ),
-            token_to_kv_pool=SimpleNamespace(
-                paged_cache_group_specs=tuple(
-                    SimpleNamespace(group_id=gid) for gid in group_ids
-                )
-            ),
-            drafter=None,
-            _can_use_graph=lambda bs, ctx: False,
-            _init_forward_metadata=init_forward_metadata,
-            _forward_func=lambda **kwargs: (None, None, None),
-        )
-        ctx = SimpleNamespace(
-            forward_mode=ForwardMode.EXTEND,
-            num_extends=2,
-            global_num_tokens=None,
-            all_decode_or_idle=False,
-            capture_hidden_mode=None,
-        )
-        CudaGraphWrapper.__call__(
-            mock,
-            bs=2,
-            ctx=ctx,
-            sampling_info=None,
-            req_to_page=torch.zeros((MAX_BS, MAX_NUM_PAGES), dtype=torch.int32),
-            flat_block_tables=flat_block_tables,
-        )
-        return calls
-
-    def test_multi_group_eager_without_tables_raises(self):
-        with self.assertRaisesRegex(RuntimeError, "flat_block_tables"):
-            self._call(["sliding_attention", "full_attention"])
-
-    def test_multi_group_eager_with_tables_passes(self):
-        torch = self.torch
-        tables = {
-            "sliding_attention": torch.ones((2, 2), dtype=torch.int32),
-            "full_attention": torch.ones((2, 2), dtype=torch.int32),
-        }
-        calls = self._call(
-            ["sliding_attention", "full_attention"], flat_block_tables=tables
-        )
-        self.assertIs(calls["init_kwargs"]["flat_block_tables"], tables)
-
-    def test_single_group_eager_without_tables_falls_back(self):
-        # Documented fallback: with one published group the backend's single
-        # table IS that group's table, so no tables are required.
-        calls = self._call(["full_attention"])
-        self.assertIsNone(calls["init_kwargs"]["flat_block_tables"])
-
-
-class IdleFlatBlockTablesTest(_TorchCase):
-    """bs==0 idle replay tables: one col-0 page-0 entry per dummy row."""
-
-    def setUp(self):
-        super().setUp()
-        from tokenspeed.runtime.execution.cuda_graph_wrapper import (
-            CudaGraphWrapper,
-        )
-
-        self.idle = CudaGraphWrapper._idle_flat_block_tables
-
-    def _wrapper(self, group_ids):
-        return SimpleNamespace(
-            token_to_kv_pool=SimpleNamespace(
-                paged_cache_group_specs=tuple(
-                    SimpleNamespace(group_id=gid) for gid in group_ids
-                )
-            ),
-            device="cpu",
-        )
-
-    def test_page_zero_single_column_per_group(self):
-        out = self.idle(self._wrapper(["sliding_attention", "full_attention"]), 3)
-        self.assertEqual(set(out), {"sliding_attention", "full_attention"})
-        for table in out.values():
-            self.assertEqual(tuple(table.shape), (3, 1))
-            self.assertEqual(table.dtype, self.torch.int32)
-            self.assertTrue((table == 0).all())
-
-    def test_none_without_specs(self):
-        self.assertIsNone(self.idle(self._wrapper([]), 3))
-
-
-class _BackendCase(_TorchCase):
-    """Real MHAAttnBackend methods on a __init__-bypassed instance."""
-
-    def setUp(self):
-        super().setUp()
-        try:
-            from tokenspeed.runtime.layers.attention.backends.mha import (
-                MHAAttnBackend,
-            )
-        except (ImportError, ModuleNotFoundError) as exc:
-            self.skipTest(f"needs tokenspeed_kernel: {exc}")
-        torch = self.torch
-        backend = MHAAttnBackend.__new__(MHAAttnBackend)
-        backend.spec_num_tokens = 1
-        backend.is_draft = False
-        backend.draft_block_decode = False
-        backend.flat_state_group_ids = frozenset()
-        backend.max_num_pages = MAX_NUM_PAGES
-        backend.page_size = 2
-        backend.device = "cpu"
-        backend.cuda_graph_decode_metadata = {}
-        backend.cuda_graph_page_table = torch.zeros(
-            (MAX_BS, MAX_NUM_PAGES), dtype=torch.int32
-        )
-        # seq_lens 1 (never 0): flat replay recomputes write locs from these
-        # (M11), and seq_len 0 would gather at position -1.
-        backend.cuda_graph_seq_lens = torch.ones(MAX_BS, dtype=torch.int32)
-        backend.cuda_graph_flat_page_tables = {}
-        backend.cuda_graph_flat_out_cache_locs = {}
-        backend._cuda_graph_max_bs = MAX_BS
-        self.backend = backend
-
-    def _capture(self, bs, flat_cache_group_ids=()):
-        torch = self.torch
-        self.backend.init_forward_metadata_capture_cuda_graph(
-            bs,
-            torch.arange(bs, dtype=torch.int64),
-            torch.ones(bs, dtype=torch.int32),
-            _decode_forward_mode(),
-            flat_cache_group_ids=flat_cache_group_ids,
-        )
-        return self.backend.cuda_graph_decode_metadata[bs]
-
-    def _replay(self, bs, flat_block_tables=None):
-        torch = self.torch
-        kwargs = {}
-        if flat_block_tables is not None:
-            kwargs["flat_block_tables"] = flat_block_tables
-        self.backend.init_forward_metadata_replay_cuda_graph(
-            bs,
-            torch.arange(MAX_BS, dtype=torch.int64),
-            torch.ones(MAX_BS, dtype=torch.int32),
-            torch.zeros((MAX_BS, MAX_NUM_PAGES), dtype=torch.int32),
-            _decode_forward_mode(),
-            **kwargs,
-        )
-
-
-_GROUP_IDS = ("sliding_attention", "full_attention")
-
-
-class BackendCaptureFlatTest(_BackendCase):
-    def test_page_tables_none_without_group_ids(self):
-        metadata = self._capture(2)
-        self.assertIsNone(metadata.page_tables)
-        self.assertEqual(self.backend.cuda_graph_flat_page_tables, {})
-
-    def test_radix_capture_keeps_single_page_table(self):
-        # Radix/single-table capture: page_table stays a live slice of the
-        # persistent buffer (replay fills it via the gather path).
-        metadata = self._capture(2)
-        self.assertIsNotNone(metadata.page_table)
-        self.assertEqual(tuple(metadata.page_table.shape), (2, MAX_NUM_PAGES))
-        self.assertEqual(
-            metadata.page_table.data_ptr(),
-            self.backend.cuda_graph_page_table.data_ptr(),
-        )
-
-    def test_flat_with_dflash_block_decode_asserts(self):
-        self.backend.spec_num_tokens = 2
-        self.backend.draft_block_decode = True
-        torch = self.torch
-        self.backend.cuda_graph_page_table = torch.zeros(
-            (MAX_BS * 2, MAX_NUM_PAGES), dtype=torch.int32
-        )
-        self.backend.cuda_graph_seq_lens = torch.zeros(MAX_BS * 2, dtype=torch.int32)
-        with self.assertRaisesRegex(AssertionError, "DFLASH"):
-            self._capture(2, _GROUP_IDS)
-
-
-class BackendStateGroupShedTest(_BackendCase):
-    """family="state" groups (GDN/mamba pages) must never reach MHA's flat
-    buffers, table copies, or write-loc math; the hybrid router still hands
-    the FULL dict to the mamba backend (see test_gdn_flat_state_paging)."""
-
-    _HYBRID_IDS = ("full_attention", "linear_attention")
-
-    def setUp(self):
-        super().setUp()
-        self.backend.flat_state_group_ids = frozenset({"linear_attention"})
-
-    def test_capture_state_only_yields_no_flat_metadata(self):
-        metadata = self._capture(2, ("linear_attention",))
-        self.assertIsNone(metadata.page_tables)
-        self.assertIsNone(metadata.out_cache_locs)
-        self.assertEqual(self.backend.cuda_graph_flat_page_tables, {})
-
-    def test_eager_decode_metadata_sheds_state_group(self):
-        torch = self.torch
-        forward_mode = SimpleNamespace(
-            is_mixed=lambda: False,
-            is_extend_or_mixed=lambda: False,
-        )
-        self.backend.init_forward_metadata(
-            bs=2,
-            num_extends=0,
-            req_pool_indices=torch.arange(2, dtype=torch.int64),
-            seq_lens=torch.tensor([3, 4], dtype=torch.int32),
-            req_to_page=torch.zeros((MAX_BS, MAX_NUM_PAGES), dtype=torch.int32),
-            forward_mode=forward_mode,
-            flat_block_tables={
-                "full_attention": torch.tensor([[1, 2], [3, 4]], dtype=torch.int32),
-                "linear_attention": torch.tensor([[0, 5], [0, 6]], dtype=torch.int32),
-            },
-        )
-        metadata = self.backend.forward_decode_metadata
-        self.assertEqual(set(metadata.page_tables), {"full_attention"})
-        self.assertEqual(set(metadata.out_cache_locs), {"full_attention"})
-        # seq_lens [3, 4], page_size 2 -> last pos 2, 3 -> page col 1 ->
-        # pages 2, 4 -> locs 2*2+0=4, 4*2+1=9.
-        self.assertEqual(metadata.out_cache_locs["full_attention"].tolist(), [4, 9])
-
-
-class BackendReplayNoFlatBuffersTest(_BackendCase):
-    def _replay_with_recorded_gather(self, bs, flat_block_tables=None):
-        # The radix single-table fill is a GPU Triton kernel; record the call
-        # instead of launching it on this test's CPU tensors.
-        from unittest import mock
-
-        import tokenspeed.runtime.layers.attention.backends.mha as mha_mod
-
-        with mock.patch.object(mha_mod, "gather_page_table_with_padding") as gather:
-            self._replay(bs, flat_block_tables)
-        return gather
-
-    def test_replay_without_flat_capture_needs_no_tables(self):
-        # No flat buffers captured (radix/single-table path): replay without
-        # tables stays valid and fills the radix single table.
-        self._capture(2)
-        gather = self._replay_with_recorded_gather(2)
-        gather.assert_called_once()
-        self.assertEqual(self.backend.cuda_graph_flat_page_tables, {})
-
-
-if __name__ == "__main__":
-    unittest.main()
+    assert fill_locs.call_count == 2

--- a/test/runtime/test_flat_group_write_locs.py
+++ b/test/runtime/test_flat_group_write_locs.py
@@ -63,9 +63,45 @@ class _MHACase(_TorchCase):
         self.backend = MHAAttnBackend.__new__(MHAAttnBackend)
         self.backend.page_size = PAGE
         self.backend.flat_group_page_sizes = {}
+        self.backend.flat_group_specs_published = False
 
 
 class ComputeFlatOutCacheLocsTest(_MHACase):
+    def test_group_page_size_falls_back_only_without_flat_specs(self):
+        for group_id in ("", "radix-layer-label"):
+            with self.subTest(legacy_group_id=group_id):
+                self.assertEqual(self.backend._group_page_size(group_id), PAGE)
+
+        self.backend._learn_flat_state_groups(
+            (
+                SimpleNamespace(
+                    group_id="full",
+                    family="history",
+                    rows_per_page=4,
+                    entry_stride_tokens=1,
+                ),
+            )
+        )
+        self.assertEqual(self.backend._group_page_size("full"), 4)
+        for group_id in ("", "unknown"):
+            with self.subTest(flat_group_id=group_id), self.assertRaisesRegex(
+                RuntimeError, "absent from.*cache specs"
+            ):
+                self.backend._group_page_size(group_id)
+
+        self.backend._learn_flat_state_groups(
+            (
+                SimpleNamespace(
+                    group_id="state",
+                    family="state",
+                    rows_per_page=4,
+                    entry_stride_tokens=1,
+                ),
+            )
+        )
+        with self.assertRaisesRegex(RuntimeError, "absent from.*cache specs"):
+            self.backend._group_page_size("unknown")
+
     def test_decode_locs_formula(self):
         torch = self.torch
         # 2 reqs, page_size=2. r0: seq_len 5 -> pos 4 -> page_idx 2, off 0.

--- a/test/runtime/test_flat_host_executor.py
+++ b/test/runtime/test_flat_host_executor.py
@@ -356,8 +356,12 @@ class FlatMemoryExecutorTest(unittest.TestCase):
             max_padding_fraction=1.0,
         )
         max_packing = max(group.cache_blocks_per_lcm_block for group in plan.groups)
+        full_attention_packing = plan.group("full_attention").cache_blocks_per_lcm_block
         kwargs = dict(
             size=plan.num_lcm_blocks * max_packing * plan.logical_block_tokens,
+            token_capacity=(
+                plan.num_lcm_blocks * full_attention_packing * plan.logical_block_tokens
+            ),
             dtype=self.torch.bfloat16,
             head_num=1,
             head_dim=8,

--- a/test/runtime/test_flat_prefill_graph.py
+++ b/test/runtime/test_flat_prefill_graph.py
@@ -72,11 +72,12 @@ class DummyFlatTablesTest(unittest.TestCase):
             self.skipTest(f"needs torch + runtime deps: {exc}")
         self.PrefillGraph = PrefillGraph
 
-    def _bare(self, backend, pool):
+    def _bare(self, backend, pool, *, use_flat_cache_tables=True):
         pg = self.PrefillGraph.__new__(self.PrefillGraph)
         pg.attn_backend = backend
         pg.token_to_kv_pool = pool
         pg.config = SimpleNamespace(device="cpu")
+        pg.use_flat_cache_tables = use_flat_cache_tables
         return pg
 
     def test_flat_backend_gets_writable_state_tables(self):
@@ -88,9 +89,12 @@ class DummyFlatTablesTest(unittest.TestCase):
         )
         pool = SimpleNamespace(
             paged_cache_group_specs=(
-                SimpleNamespace(group_id="full_attention"),
-                SimpleNamespace(group_id="sliding_attention"),
-                SimpleNamespace(group_id="linear_attention"),  # state: included
+                SimpleNamespace(group_id="full_attention", family="history"),
+                SimpleNamespace(group_id="sliding_attention", family="history"),
+                SimpleNamespace(
+                    group_id="linear_attention",
+                    family="state",
+                ),
             )
         )
         tables = self._bare(backend, pool)._dummy_flat_tables(100)
@@ -117,7 +121,9 @@ class DummyFlatTablesTest(unittest.TestCase):
             flat_state_group_ids=frozenset(),
         )
         pool = SimpleNamespace(
-            paged_cache_group_specs=(SimpleNamespace(group_id="full_attention"),)
+            paged_cache_group_specs=(
+                SimpleNamespace(group_id="full_attention", family="history"),
+            )
         )
         tables = self._bare(backend, pool)._dummy_flat_tables(100)
         self.assertEqual(tables["full_attention"].shape, (1, 2500))
@@ -132,8 +138,8 @@ class DummyFlatTablesTest(unittest.TestCase):
         wrapper = SimpleNamespace(uses_flat_cache_groups=True, full_attn_backend=child)
         pool = SimpleNamespace(
             paged_cache_group_specs=(
-                SimpleNamespace(group_id="full_attention"),
-                SimpleNamespace(group_id="linear_attention"),
+                SimpleNamespace(group_id="full_attention", family="history"),
+                SimpleNamespace(group_id="linear_attention", family="state"),
             )
         )
         tables = self._bare(wrapper, pool)._dummy_flat_tables(64)
@@ -144,6 +150,17 @@ class DummyFlatTablesTest(unittest.TestCase):
         backend = SimpleNamespace(uses_flat_cache_groups=False)
         pool = SimpleNamespace(paged_cache_group_specs=())
         self.assertEqual(self._bare(backend, pool)._dummy_flat_tables(64), {})
+
+    def test_radix_transport_keeps_dual_capable_backend_on_paged_tables(self):
+        backend = SimpleNamespace(uses_flat_cache_groups=True)
+        pool = SimpleNamespace(
+            paged_cache_group_specs=(
+                SimpleNamespace(group_id="full_attention", family="history"),
+            )
+        )
+        graph = self._bare(backend, pool, use_flat_cache_tables=False)
+
+        self.assertEqual(graph._dummy_flat_tables(64), {})
 
     def test_runtime_contract_pool_is_eligible_for_capture(self):
         from unittest import mock
@@ -169,7 +186,7 @@ class DummyFlatTablesTest(unittest.TestCase):
         ):
             graph = self.PrefillGraph(
                 model_runner=model_runner,
-                attn_backend=object(),
+                attn_backend=SimpleNamespace(uses_flat_cache_groups=False),
                 token_to_kv_pool=pool,
                 input_buffers=object(),
                 config=config,

--- a/test/runtime/test_flat_scheduler_config_guard.py
+++ b/test/runtime/test_flat_scheduler_config_guard.py
@@ -1,8 +1,8 @@
 """Flat-scheduler config guard (validate_flat_scheduler_config, called from
 engine/event_loop before the C++ Scheduler ctor).
 
-On a flat-built ext: a radix-populate-only backend (uses_paged_cache_groups
-without uses_flat_cache_groups, DeepSeek V4/MLA-style) is rejected loudly;
+On a flat-built ext: any radix-populate-only backend (uses_paged_cache_groups
+without uses_flat_cache_groups) is rejected loudly;
 zero published groups is rejected with the actual cause named; a
 flat-capable backend with >=1 group passes. On a radix-built ext the guard
 is a no-op. The validator is pure and torch-free, so this file runs on a
@@ -15,6 +15,7 @@ import importlib.util
 import os
 import sys
 import unittest
+from unittest import mock
 
 # CI Registration (parsed via AST, runtime no-op)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -42,12 +43,15 @@ def _load_paged_cache_spec():
             "configs",
             "paged_cache_spec.py",
         )
-        spec = importlib.util.spec_from_file_location("_paged_cache_spec_guard", path)
-        module = importlib.util.module_from_spec(spec)
-        # dataclass processing resolves cls.__module__ through sys.modules, so
-        # the module must be registered before exec.
-        sys.modules[spec.name] = module
-        spec.loader.exec_module(module)
+        with mock.patch.dict(sys.modules):
+            spec = importlib.util.spec_from_file_location(
+                "_paged_cache_spec_guard", path
+            )
+            module = importlib.util.module_from_spec(spec)
+            # dataclass processing resolves cls.__module__ through sys.modules, so
+            # the module must be registered before exec.
+            sys.modules[spec.name] = module
+            spec.loader.exec_module(module)
         return module
 
 
@@ -55,10 +59,18 @@ _pcs = _load_paged_cache_spec()
 
 
 class FakeV4StyleBackend:
-    """DeepSeek V4/MLA shape: radix-populate consumer, not flat-capable."""
+    """Legacy V4-like shape: radix-populate consumer, not flat-capable."""
 
     uses_paged_cache_groups = True
     uses_flat_cache_groups = False
+
+
+class FakeV4FlatBackend:
+    """Migrated V4 shape: exactly-one radix/flat source selected by its pool."""
+
+    uses_paged_cache_groups = True
+    uses_flat_cache_groups = True
+    flat_spec_capable = True
 
 
 class FakeFlatMHABackend:
@@ -78,15 +90,15 @@ class FakeSpecIncapableBackend:
 
 
 class FakeV4Pool:
-    pass
+    runtime_contract = None
 
 
 class FakeMHAPool:
-    pass
+    runtime_contract = None
 
 
 class FakeMambaPool:
-    pass
+    runtime_contract = None
 
 
 class FakeGroup:
@@ -149,6 +161,15 @@ class ValidateFlatSchedulerConfigTest(unittest.TestCase):
             attn_backend=FakeFlatMHABackend(),
             kv_pool=FakeMHAPool(),
             speculative_algorithm=None,
+        )
+
+    def test_flat_ext_migrated_v4_groups_passes_with_spec(self):
+        _pcs.validate_flat_scheduler_config(
+            flat_kvcache_ext=True,
+            paged_cache_groups=[FakeGroup(), FakeGroup()],
+            attn_backend=FakeV4FlatBackend(),
+            kv_pool=FakeV4Pool(),
+            speculative_algorithm="EAGLE3",
         )
 
     def test_radix_ext_is_a_noop_regardless(self):

--- a/test/runtime/test_gdn_flat_state_paging.py
+++ b/test/runtime/test_gdn_flat_state_paging.py
@@ -162,6 +162,7 @@ class PoollessFlatMetadataTest(unittest.TestCase):
         )
         backend = MambaAttnBackend(config)
         stub_pool = SimpleNamespace(
+            runtime_contract=None,
             state_slabs=[(object(), object())],
             paged_cache_group_specs=(SimpleNamespace(group_id="linear_attention"),),
             _layer_types=("linear_attention",),
@@ -275,6 +276,7 @@ class LegacyLcmVerifyMetadataTest(unittest.TestCase):
             for layer_id in range(2)
         }
         stub_pool = SimpleNamespace(
+            runtime_contract=None,
             state_slabs=tuple(self.state_buffers.values()),
             paged_cache_group_specs=(
                 SimpleNamespace(group_id="linear_attention_0"),
@@ -392,6 +394,7 @@ class GDNFlatStatePagingGPUTest(unittest.TestCase):
             )
         )
         stub_pool = SimpleNamespace(
+            runtime_contract=None,
             state_slabs=[(conv_slab, ssm_slab)],
             paged_cache_group_specs=(SimpleNamespace(group_id="linear_attention"),),
             _layer_types=("linear_attention",),

--- a/test/runtime/test_group_specs_from_layer_types.py
+++ b/test/runtime/test_group_specs_from_layer_types.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import sys
 import unittest
+from unittest import mock
 
 # CI Registration (parsed via AST, runtime no-op)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -32,8 +33,11 @@ def _load(mod_name: str, file_name: str):
     return mod
 
 
-_pcs = _load("paged_cache_spec_under_test", "paged_cache_spec.py")
+with mock.patch.dict(sys.modules):
+    _pcs = _load("paged_cache_spec_under_test", "paged_cache_spec.py")
 group_specs_from_layer_types = _pcs.group_specs_from_layer_types
+full_history_lcm_group_capacities = _pcs.full_history_lcm_group_capacities
+legacy_flat_loc_group_id = _pcs.legacy_flat_loc_group_id
 layer_group_ids = _pcs.layer_group_ids
 PagedCacheGroupSpec = _pcs.PagedCacheGroupSpec
 
@@ -44,6 +48,91 @@ class GroupSpecsFromLayerTypesTest(unittest.TestCase):
             "materializes_all_boundaries",
             PagedCacheGroupSpec.__dataclass_fields__,
         )
+
+    def test_full_history_lcm_capacity_uses_each_groups_geometry(self):
+        specs = (
+            PagedCacheGroupSpec(
+                group_id="full",
+                retention="full_history",
+                rows_per_page=256,
+                entry_stride_tokens=1,
+                sliding_window_tokens=None,
+                block_size=256,
+                cache_blocks_per_lcm_block=2,
+            ),
+            PagedCacheGroupSpec(
+                group_id="state",
+                retention="full_history",
+                rows_per_page=4,
+                entry_stride_tokens=1,
+                sliding_window_tokens=None,
+                family="state",
+                block_size=4,
+                cache_blocks_per_lcm_block=64,
+            ),
+        )
+
+        self.assertEqual(
+            full_history_lcm_group_capacities(
+                specs,
+                base_block_size=4,
+                num_lcm_blocks=3,
+            ),
+            {"full": 1536},
+        )
+
+    def test_legacy_flat_location_mirror_requires_one_compatible_group(self):
+        def spec(
+            group_id,
+            *,
+            retention="full_history",
+            family="history",
+            block_size=64,
+            entry_stride_tokens=1,
+        ):
+            return PagedCacheGroupSpec(
+                group_id=group_id,
+                retention=retention,
+                rows_per_page=block_size,
+                entry_stride_tokens=entry_stride_tokens,
+                sliding_window_tokens=(128 if retention == "sliding_window" else None),
+                family=family,
+                block_size=block_size,
+            )
+
+        compatible = spec("full", block_size=128)
+        cases = (
+            (
+                "one compatible amid heterogeneous groups",
+                (
+                    spec("sliding", retention="sliding_window"),
+                    spec("state", family="state"),
+                    compatible,
+                ),
+                "full",
+            ),
+            ("no compatible history", (spec("state", family="state"),), None),
+            (
+                "ambiguous histories",
+                (compatible, spec("other")),
+                None,
+            ),
+            (
+                "non-unit stride",
+                (spec("stride", entry_stride_tokens=2),),
+                None,
+            ),
+            ("span below legacy page", (spec("small", block_size=32),), None),
+        )
+        for name, specs, expected in cases:
+            with self.subTest(name=name):
+                self.assertEqual(
+                    legacy_flat_loc_group_id(specs, legacy_page_size=64),
+                    expected,
+                )
+
+        with self.assertRaisesRegex(ValueError, "legacy_page_size"):
+            legacy_flat_loc_group_id((compatible,), legacy_page_size=0)
 
     def test_gpt_oss_mixed_shape_yields_two_groups(self):
         layer_types = [
@@ -362,22 +451,52 @@ class PoolToPagedCacheGroupsIntegrationTest(unittest.TestCase):
     scheduler config. Needs torch + the tokenspeed_scheduler ext; skips
     where those are absent."""
 
-    def _import_converter(self):
+    def _import_scheduler_utils(self):
         try:
-            from tokenspeed.runtime.engine.scheduler_utils import (
-                pool_to_paged_cache_groups,
-            )
+            from tokenspeed.runtime.engine import scheduler_utils
         except (ImportError, ModuleNotFoundError) as exc:
             self.skipTest(
-                f"pool_to_paged_cache_groups unavailable (needs torch + "
+                f"scheduler_utils unavailable (needs torch + "
                 f"tokenspeed_scheduler ext): {exc}"
             )
-        return pool_to_paged_cache_groups
+        return scheduler_utils
+
+    def _heterogeneous_groups(self):
+        from types import SimpleNamespace
+
+        scheduler_utils = self._import_scheduler_utils()
+        specs = (
+            PagedCacheGroupSpec(
+                group_id="full_attention",
+                retention="full_history",
+                rows_per_page=256,
+                entry_stride_tokens=1,
+                sliding_window_tokens=None,
+                block_size=256,
+            ),
+            PagedCacheGroupSpec(
+                group_id="state_c4",
+                retention="sliding_window",
+                rows_per_page=4,
+                entry_stride_tokens=1,
+                sliding_window_tokens=8,
+                family="state",
+                block_size=4,
+            ),
+        )
+        pool = SimpleNamespace(
+            runtime_contract=None,
+            paged_cache_group_specs=specs,
+            paged_cache_group_page_counts={spec.group_id: 4096 for spec in specs},
+        )
+        return scheduler_utils, scheduler_utils.pool_to_paged_cache_groups(pool)
 
     def test_two_group_specs_convert_to_two_scheduler_groups(self):
         from types import SimpleNamespace
 
-        pool_to_paged_cache_groups = self._import_converter()
+        pool_to_paged_cache_groups = (
+            self._import_scheduler_utils().pool_to_paged_cache_groups
+        )
 
         specs = group_specs_from_layer_types(
             layer_types=["full_attention", "sliding_attention"],
@@ -386,6 +505,7 @@ class PoolToPagedCacheGroupsIntegrationTest(unittest.TestCase):
         )
         # Duck-typed stand-in: only the two attributes the converter reads.
         fake_pool = SimpleNamespace(
+            runtime_contract=None,
             paged_cache_group_specs=specs,
             paged_cache_group_page_counts={s.group_id: 1024 for s in specs},
         )
@@ -397,15 +517,83 @@ class PoolToPagedCacheGroupsIntegrationTest(unittest.TestCase):
         self.assertEqual(group_ids, {"full_attention", "sliding_attention"})
 
     def test_empty_specs_convert_to_no_groups(self):
-        pool_to_paged_cache_groups = self._import_converter()
+        pool_to_paged_cache_groups = (
+            self._import_scheduler_utils().pool_to_paged_cache_groups
+        )
 
         from types import SimpleNamespace
 
         fake_pool = SimpleNamespace(
+            runtime_contract=None,
             paged_cache_group_specs=(),
             paged_cache_group_page_counts={},
         )
         self.assertEqual(pool_to_paged_cache_groups(fake_pool), [])
+
+    def test_scheduler_block_size_is_selected_by_backend(self):
+        scheduler_utils, groups = self._heterogeneous_groups()
+        self.assertEqual([group.block_size for group in groups], [256, 4])
+
+        for scheduler_backend, expected in (("radix", 256), ("flat", 4)):
+            with self.subTest(scheduler_backend=scheduler_backend):
+                self.assertEqual(
+                    scheduler_utils.resolve_scheduler_block_size(
+                        256,
+                        groups,
+                        scheduler_backend=scheduler_backend,
+                    ),
+                    expected,
+                )
+
+    def test_radix_config_retains_metadata_and_admits_300_token_request(self):
+        scheduler_utils, groups = self._heterogeneous_groups()
+        try:
+            import tokenspeed_scheduler as ts
+        except (ImportError, ModuleNotFoundError) as exc:
+            self.skipTest(f"tokenspeed_scheduler unavailable: {exc}")
+        if ts.FLAT_KVCACHE:
+            self.skipTest("admission regression is specific to the radix scheduler")
+
+        config = scheduler_utils.make_config(
+            num_device_pages=64,
+            max_scheduled_tokens=8192,
+            max_batch_size=1,
+            page_size=256,
+            scheduler_backend="radix",
+            num_host_pages=0,
+            disable_l2_cache=True,
+            enable_l3_storage=False,
+            prefetch_threshold=0,
+            role="null",
+            disable_prefix_cache=False,
+            paged_cache_groups=groups,
+            prefix_cache_adjunct=scheduler_utils.pool_to_prefix_cache_adjunct_spec(
+                ["full_attention"]
+            ),
+        )
+        self.assertEqual(config.block_size, 256)
+        self.assertEqual(config.num_device_pages, 64)
+        self.assertEqual(
+            [group.group_id for group in config.paged_cache_groups],
+            ["full_attention", "state_c4"],
+        )
+        self.assertEqual(
+            config.prefix_cache_adjunct.required_groups,
+            ["full_attention"],
+        )
+
+        scheduler = ts.Scheduler(config)
+        scheduler.submit_requests(
+            [scheduler_utils.make_spec("request", list(range(300)))]
+        )
+
+        plan = scheduler.next_execution_plan()
+        scheduled = {
+            request_id: input_length
+            for op in plan.forward
+            for request_id, input_length in zip(op.request_ids, op.input_lengths)
+        }
+        self.assertEqual(scheduled, {"request": 300})
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_hybrid_mla_kv_nan_sanitize.py
+++ b/test/runtime/test_hybrid_mla_kv_nan_sanitize.py
@@ -33,6 +33,7 @@ the cache never stores NaN without allocating temporary tensors.
 
 from __future__ import annotations
 
+import pytest
 import torch
 
 from tokenspeed.runtime.layers.attention.backends.hybrid_linear_attn import (
@@ -61,6 +62,31 @@ class _RecordingInnerPool:
 class _Layer:
     def __init__(self, layer_id: int):
         self.layer_id = layer_id
+
+
+@pytest.mark.parametrize(
+    ("contract", "specs", "page_counts"),
+    (
+        (object(), (object(),), {"history": 3}),
+        (None, (), {}),
+    ),
+    ids=("flat", "radix"),
+)
+def test_layer_mapped_pool_explicitly_forwards_cache_geometry(
+    contract,
+    specs,
+    page_counts,
+):
+    inner = _RecordingInnerPool()
+    inner.runtime_contract = contract
+    inner.paged_cache_group_specs = specs
+    inner.paged_cache_group_page_counts = page_counts
+    pool = LayerMappedKVPool(inner, [3, 7, 11])
+
+    assert pool.page_size == inner.page_size
+    assert pool.runtime_contract is contract
+    assert pool.paged_cache_group_specs is specs
+    assert pool.paged_cache_group_page_counts is page_counts
 
 
 def test_set_mla_kv_buffer_remaps_layer_and_forwards_untouched():

--- a/test/runtime/test_lcm_scheduler_geometry.py
+++ b/test/runtime/test_lcm_scheduler_geometry.py
@@ -3,34 +3,33 @@ from types import SimpleNamespace
 from tokenspeed.runtime.engine.scheduler_utils import scheduler_cache_geometry_from_pool
 
 
-def test_lcm_scheduler_geometry_counts_parents_not_child_pages():
-    pool = SimpleNamespace(runtime_contract=None, num_lcm_blocks=37)
-
+def test_radix_scheduler_geometry_uses_physical_page_units():
     geometry = scheduler_cache_geometry_from_pool(
-        pool,
-        fallback_token_capacity=37 * 8 * 128,
-        fallback_page_size=128,
+        SimpleNamespace(runtime_contract=None),
+        fallback_token_capacity=16_384,
+        fallback_page_size=256,
     )
 
-    assert geometry.page_size == 128
-    assert geometry.num_device_pages == 38
-    assert geometry.num_usable_pages == 37
-    assert geometry.token_capacity == 37 * 8 * 128
+    assert geometry.page_size == 256
+    assert geometry.num_device_pages == 64
+    assert geometry.num_usable_pages == 64
+    assert geometry.token_capacity == 16_384
 
 
-def test_lcm_scheduler_geometry_uses_contract_token_capacity():
+def test_lcm_scheduler_geometry_counts_parent_blocks_and_reserves_null():
     contract = SimpleNamespace(
         num_lcm_blocks=37,
         block_size=128,
         token_capacity=10_000,
     )
-    pool = SimpleNamespace(runtime_contract=contract, num_lcm_blocks=37)
 
     geometry = scheduler_cache_geometry_from_pool(
-        pool,
+        SimpleNamespace(runtime_contract=contract),
         fallback_token_capacity=37 * 12 * 128,
-        fallback_page_size=128,
+        fallback_page_size=256,
     )
 
+    assert geometry.page_size == 128
+    assert geometry.num_device_pages == 38
     assert geometry.num_usable_pages == 37
     assert geometry.token_capacity == 10_000

--- a/test/runtime/test_lcm_setup.py
+++ b/test/runtime/test_lcm_setup.py
@@ -99,6 +99,13 @@ def test_qwen_recipe_preserves_backend_kernel_page_size() -> None:
         "layer.0.conv": torch.bfloat16,
         "layer.0.ssm": torch.float32,
     }
+    full_history_tokens = (
+        setup.target.memory_plan.num_lcm_blocks
+        * setup.target.memory_plan.group(FULL_ATTENTION).cache_blocks_per_lcm_block
+        * setup.target.memory_plan.logical_block_tokens
+    )
+    assert setup.target.token_capacity == full_history_tokens
+    assert setup.target.token_capacity < setup.target.pool_size
     assert not hasattr(attn_config, "lcm_memory_plan")
     with mock.patch(_FLAT_PROBE, return_value=True):
         pool = create_lcm_pool(
@@ -109,3 +116,5 @@ def test_qwen_recipe_preserves_backend_kernel_page_size() -> None:
             enable_memory_saver=False,
         )
     assert isinstance(pool, LcmMHATokenToKVPool)
+    assert pool.size == setup.target.pool_size
+    assert pool.runtime_contract.token_capacity == setup.target.token_capacity

--- a/test/runtime/test_unified_kv_slab_pool.py
+++ b/test/runtime/test_unified_kv_slab_pool.py
@@ -586,6 +586,7 @@ class LcmPoolFieldBindingTest(unittest.TestCase):
                 max_batch_size=2,
                 max_context_len=32,
                 page_size=4,
+                token_capacity=4,
                 rank=0,
                 layer_types=("linear_attention", "full_attention"),
                 state_field_dtypes={

--- a/test/runtime/test_v4_sliding_window_groups_smoke.py
+++ b/test/runtime/test_v4_sliding_window_groups_smoke.py
@@ -40,11 +40,14 @@ def _load(mod_name: str, file_name: str):
     return mod
 
 
-_generic = _load("tokenspeed.runtime.configs.paged_cache_spec", "paged_cache_spec.py")
-_v4 = _load(
-    "tokenspeed_runtime_configs_deepseek_v4_cache_spec_smoke",
-    "deepseek_v4_cache_spec.py",
-)
+with patch.dict(sys.modules):
+    _generic = _load(
+        "tokenspeed.runtime.configs.paged_cache_spec", "paged_cache_spec.py"
+    )
+    _v4 = _load(
+        "tokenspeed_runtime_configs_deepseek_v4_cache_spec_smoke",
+        "deepseek_v4_cache_spec.py",
+    )
 
 build_v4_cache_specs = _v4.build_v4_cache_specs
 compute_max_logical_pages_for_capture = _generic.compute_max_logical_pages_for_capture
@@ -128,6 +131,7 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
                 sliding_window_tokens=window,
             )
             context_len = 5 * raw_per_page + 1
+            max_prefill_tokens = 2 * raw_per_page + 1
             for verify_width in (1, 2, 4, 8):
                 for overlap_depth in (0, 1):
                     with self.subTest(
@@ -139,6 +143,7 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
                             full,
                             max_context_len=context_len,
                             max_tokens_per_req=verify_width,
+                            max_prefill_tokens_per_req=max_prefill_tokens,
                             overlap_schedule_depth=overlap_depth,
                         )
                         self.assertEqual(
@@ -153,12 +158,17 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
                             sliding,
                             max_context_len=context_len,
                             max_tokens_per_req=verify_width,
+                            max_prefill_tokens_per_req=max_prefill_tokens,
                             overlap_schedule_depth=overlap_depth,
                         )
                         self.assertEqual(
                             sliding_pages,
                             math.ceil(
-                                (window + (overlap_depth + 1) * verify_width)
+                                (
+                                    window
+                                    + overlap_depth * max_prefill_tokens
+                                    + (overlap_depth + 1) * verify_width
+                                )
                                 / raw_per_page
                             )
                             + 1,
@@ -238,6 +248,10 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
         for overrides, message in (
             ({"max_context_len": -1}, "max_context_len"),
             ({"max_tokens_per_req": 0}, "max_tokens_per_req"),
+            (
+                {"max_prefill_tokens_per_req": -1},
+                "max_prefill_tokens_per_req",
+            ),
             ({"overlap_schedule_depth": 2}, "overlap_schedule_depth"),
         ):
             with self.subTest(function="capture_width", overrides=overrides):

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
@@ -1791,13 +1791,14 @@ def flat_decode_locs(
 @triton.jit
 def _flat_tables_unpack_kernel(
     src_ptr,  # packed int32 device buffer (bridge upload)
-    meta_ptr,  # [G, 3] int32: (src element offset, cols, page ratio) per group
+    meta_ptr,  # [G, 2|3]: source offset/cols and optional page ratio
     dst_ptr,  # [G, max_bs, Wmax] int32 stacked graph tables
     stride_g,
     stride_b,
     wmax,
     actual_bs,
     TAIL_PAD: tl.constexpr,
+    META_COLS: tl.constexpr,
     BLOCK_W: tl.constexpr,
 ):
     """Fill every group's graph-table rows from the packed upload in one
@@ -1808,9 +1809,10 @@ def _flat_tables_unpack_kernel(
     tail fill (+ F.pad row padding) per decode step."""
     g = tl.program_id(0)
     b = tl.program_id(1)  # grid axis 1 is exactly bs, no bounds check needed
-    off = tl.load(meta_ptr + g * 3).to(tl.int64)
-    cols = tl.load(meta_ptr + g * 3 + 1).to(tl.int64)
-    ratio = tl.load(meta_ptr + g * 3 + 2).to(tl.int64)
+    row = meta_ptr + g * META_COLS
+    off = tl.load(row).to(tl.int64)
+    cols = tl.load(row + 1).to(tl.int64)
+    ratio = tl.load(row + 2).to(tl.int64) if META_COLS == 3 else 1
     w_off = tl.arange(0, BLOCK_W)
     real = b < actual_bs
     for w0 in range(0, wmax, BLOCK_W):
@@ -1835,6 +1837,46 @@ def _flat_tables_unpack_kernel(
         )
 
 
+@triton.jit
+def _flat_tables_unpack_ragged_kernel(
+    src_ptr,  # packed int32 device buffer (header + active table/base payload)
+    meta_ptr,  # [G, 6]: src table off/cols, dst table off/cols, src/dst base off
+    dst_ptr,  # exact-width packed graph table/base destination
+    actual_bs,
+    TAIL_PAD: tl.constexpr,
+    MAX_COLS: tl.constexpr,
+    BLOCK_W: tl.constexpr,
+):
+    """Unpack one group's table and base vector per program row."""
+    g = tl.program_id(0)
+    b = tl.program_id(1)
+    row = meta_ptr + g * 6
+    src_table_off = tl.load(row).to(tl.int64)
+    src_cols = tl.load(row + 1).to(tl.int64)
+    dst_table_off = tl.load(row + 2).to(tl.int64)
+    dst_cols = tl.load(row + 3).to(tl.int64)
+    src_base_off = tl.load(row + 4).to(tl.int64)
+    dst_base_off = tl.load(row + 5).to(tl.int64)
+    real = b < actual_bs
+    w_off = tl.arange(0, BLOCK_W)
+    for w0 in range(0, MAX_COLS, BLOCK_W):
+        w = w0 + w_off
+        in_row = real & (w < src_cols)
+        vals = tl.load(
+            src_ptr + src_table_off + b * src_cols + w,
+            mask=in_row & (w < dst_cols),
+            other=0,
+        )
+        vals = tl.where(in_row, vals, tl.where(real, TAIL_PAD, 0))
+        tl.store(
+            dst_ptr + dst_table_off + b * dst_cols + w,
+            vals,
+            mask=w < dst_cols,
+        )
+    base = tl.load(src_ptr + src_base_off + b, mask=real, other=0)
+    tl.store(dst_ptr + dst_base_off + b, base)
+
+
 def flat_tables_unpack(
     src: torch.Tensor,
     meta: torch.Tensor,
@@ -1842,29 +1884,76 @@ def flat_tables_unpack(
     bs: int,
     actual_bs: int | None = None,
     tail_pad: int = -1,
+    *,
+    max_cols: int | None = None,
 ) -> None:
-    """Unpack the bridge's packed table upload into the stacked graph
-    buffers (all groups, one launch).
+    """Unpack one packed table upload into graph buffers in one launch.
 
     Args:
         src: 1-D int32 device buffer holding every group's rows
             back-to-back (rows x cols per group).
-        meta: [G, 3] int32 device tensor of
-            (element offset, logical columns, kernel pages per logical page).
-            A ratio greater than one expands page ``p`` to
-            ``p * ratio + [0, ratio)`` while unpacking.
-        dst: [G, max_bs, Wmax] int32 stacked destination.
+        meta: ``[G, 2]`` source offset/width rows for a stacked destination;
+            ``[G, 3]`` adds kernel pages per logical page; ``[G, 6]`` carries
+            source/destination table offsets/widths plus
+            source/destination base offsets for an exact-width packed
+            destination.
+        dst: ``[G, max_bs, Wmax]`` stacked destination, or one exact-width
+            packed 1-D table/base destination.
         bs: rows to fill per group (padded batch size).
         actual_bs: live batch size; rows [actual_bs, bs) are written all-0
             (the flat dummy-page row contract). Defaults to bs (no padded
             rows).
         tail_pad: value for columns past the group's width.
+        max_cols: Maximum destination table width. Required for a packed
+            1-D destination and ignored for a stacked destination.
     """
-    g, _, wmax = dst.shape
-    if bs == 0 or g == 0:
-        return
+    if isinstance(bs, bool) or not isinstance(bs, int) or bs < 0:
+        raise ValueError("flat unpack bs must be an integer >= 0")
     if actual_bs is None:
         actual_bs = bs
+    if (
+        isinstance(actual_bs, bool)
+        or not isinstance(actual_bs, int)
+        or actual_bs < 0
+        or actual_bs > bs
+    ):
+        raise ValueError("flat unpack actual_bs must be an integer in [0, bs]")
+    if dst.ndim == 1:
+        if meta.ndim != 2 or meta.shape[1] != 6:
+            raise ValueError("ragged flat unpack meta must have shape [G, 6]")
+        if isinstance(max_cols, bool) or not isinstance(max_cols, int) or max_cols <= 0:
+            raise ValueError("ragged flat unpack requires max_cols > 0")
+        g = int(meta.shape[0])
+        if bs == 0 or g == 0:
+            return
+        BLOCK_W = 128 if max_cols >= 128 else 64
+        _flat_tables_unpack_ragged_kernel[(g, bs)](
+            src,
+            meta,
+            dst,
+            actual_bs,
+            TAIL_PAD=tail_pad,
+            MAX_COLS=max_cols,
+            BLOCK_W=BLOCK_W,
+        )
+        return
+    if dst.ndim != 3:
+        raise ValueError("flat unpack destination must be rank 1 or rank 3")
+    if meta.ndim != 2 or meta.shape[1] not in (2, 3):
+        raise ValueError("stacked flat unpack meta must have shape [G, 2] or [G, 3]")
+    g, _, wmax = dst.shape
+    if int(meta.shape[0]) != g:
+        raise ValueError(
+            "stacked flat unpack group count mismatch: "
+            f"meta={int(meta.shape[0])}, destination={g}"
+        )
+    if bs > int(dst.shape[1]):
+        raise ValueError(
+            "stacked flat unpack row count exceeds destination: "
+            f"bs={bs}, destination={int(dst.shape[1])}"
+        )
+    if bs == 0 or g == 0:
+        return
     BLOCK_W = 128 if wmax >= 128 else 64
     grid = (g, bs)
     _flat_tables_unpack_kernel[grid](
@@ -1876,6 +1965,7 @@ def flat_tables_unpack(
         wmax,
         actual_bs,
         TAIL_PAD=tail_pad,
+        META_COLS=int(meta.shape[1]),
         BLOCK_W=BLOCK_W,
     )
 

--- a/tokenspeed-kernel/test/ops/test_flat_tables_unpack.py
+++ b/tokenspeed-kernel/test/ops/test_flat_tables_unpack.py
@@ -106,6 +106,81 @@ def test_unpack_expands_logical_pages_per_group():
     ]
 
 
+@pytest.mark.parametrize("actual_bs,bs", [(5, 8), (1, 1)])
+def test_ragged_unpack_copies_tables_and_bases_into_exact_storage(actual_bs, bs):
+    torch.manual_seed(1)
+    dev = "cuda"
+    source_widths = [3, 9, 2]
+    destination_widths = [5, 9, 4]
+    max_bs = 8
+    source_parts = []
+    meta_rows = []
+    source_offset = 0
+    destination_offset = 0
+    references = []
+    for source_width, destination_width in zip(
+        source_widths, destination_widths, strict=True
+    ):
+        table = torch.randint(1, 5000, (actual_bs, source_width), dtype=torch.int32)
+        bases = torch.randint(0, 30, (actual_bs,), dtype=torch.int32)
+        table_source_offset = source_offset
+        source_parts.append(table.reshape(-1))
+        source_offset += table.numel()
+        base_source_offset = source_offset
+        source_parts.append(bases)
+        source_offset += bases.numel()
+
+        table_destination_offset = destination_offset
+        destination_offset += max_bs * destination_width
+        base_destination_offset = destination_offset
+        destination_offset += max_bs
+        meta_rows.append(
+            [
+                table_source_offset,
+                source_width,
+                table_destination_offset,
+                destination_width,
+                base_source_offset,
+                base_destination_offset,
+            ]
+        )
+        references.append(
+            (
+                table,
+                bases,
+                table_destination_offset,
+                base_destination_offset,
+                destination_width,
+            )
+        )
+
+    source = torch.cat(source_parts).to(dev)
+    meta = torch.tensor(meta_rows, dtype=torch.int32, device=dev)
+    destination = torch.full((destination_offset,), 7, dtype=torch.int32, device=dev)
+    flat_tables_unpack(
+        source,
+        meta,
+        destination,
+        bs,
+        actual_bs=actual_bs,
+        tail_pad=-1,
+        max_cols=max(destination_widths),
+    )
+
+    for table, bases, table_offset, base_offset, destination_width in references:
+        table_view = destination[
+            table_offset : table_offset + max_bs * destination_width
+        ].view(max_bs, destination_width)
+        base_view = destination[base_offset : base_offset + max_bs]
+        assert torch.equal(table_view[:actual_bs, : table.shape[1]], table.to(dev))
+        assert (table_view[:actual_bs, table.shape[1] :] == -1).all()
+        assert torch.equal(base_view[:actual_bs], bases.to(dev))
+        assert (table_view[actual_bs:bs] == 0).all()
+        assert (base_view[actual_bs:bs] == 0).all()
+        assert (table_view[bs:] == 7).all()
+        assert (base_view[bs:] == 7).all()
+
+
 @pytest.mark.parametrize("n", [1, 3, 4])
 def test_locs_multiquery(n):
     """tokens_per_req > 1 (spec verify): token t of request b lands at

--- a/tokenspeed-scheduler/bindings/python_module.cpp
+++ b/tokenspeed-scheduler/bindings/python_module.cpp
@@ -254,6 +254,7 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .def_rw("overlap_schedule_depth", &tokenspeed::SchedulerConfig::overlap_schedule_depth)
         .def_rw("role", &tokenspeed::SchedulerConfig::role)
         .def_rw("enable_flatkv_pd", &tokenspeed::SchedulerConfig::enable_flatkv_pd)
+        .def_rw("compact_flat_block_tables", &tokenspeed::SchedulerConfig::compact_flat_block_tables)
         .def_prop_rw(
             "num_device_pages", [](const tokenspeed::SchedulerConfig& c) { return c.device_allocator.total_pages; },
             [](tokenspeed::SchedulerConfig& c, std::int32_t v) { c.device_allocator.total_pages = v; })
@@ -378,6 +379,19 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
                 return op.paged_cache_block_table_base_offsets;
             },
             nb::rv_policy::reference_internal)
+        .def("paged_cache_block_table_base_offsets_arrays",
+             [](nb::handle self) {
+                 // Zero-copy 1-D int32 views. The same owner and lexical map
+                 // ordering as flat_block_tables_arrays make the two exports
+                 // safe to pin and pack together.
+                 auto& op = nb::cast<tokenspeed::FlatForwardOperation&>(self);
+                 nb::dict out;
+                 for (auto& [gid, offsets] : op.paged_cache_block_table_base_offsets) {
+                     out[nb::str(gid.c_str())] = nb::ndarray<nb::numpy, const std::int32_t, nb::ndim<1>>(
+                         offsets.data(), {offsets.size()}, self);
+                 }
+                 return out;
+             })
         .def_prop_ro(
             "flat_block_tables",
             [](const tokenspeed::FlatForwardOperation& op)

--- a/tokenspeed-scheduler/csrc/cache/cache_types.h
+++ b/tokenspeed-scheduler/csrc/cache/cache_types.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -64,6 +65,9 @@ struct CacheKeyHash {
 
 struct KvCacheSpec {
     AttnKind kind;
+    // Logical token span of one block in this group. Zero inherits the
+    // coordinator's base hash grain for legacy/equal-grain callers.
+    std::int32_t block_size{0};
     // Only kSlidingWindow uses this value. Mamba's one-checkpoint lookback is
     // an internal Manager policy rather than a model window.
     std::int32_t sliding_window;
@@ -77,27 +81,93 @@ class BlockTable {
 public:
     std::span<const CacheBlockRef> Blocks() const noexcept { return blocks_; }
     std::int32_t NumBlocks() const { return static_cast<std::int32_t>(blocks_.size()); }
+    // Logical index of the first owned block, or NumBlocks() when the table
+    // contains only null holes. Maintained by every table mutation so compact
+    // row publication does not rescan the reclaimed prefix.
+    std::int32_t FirstLiveBlock() const noexcept { return first_live_block_; }
     std::int32_t AvailableTokens() const { return available_tokens_; }
 
     CacheBlockRef EvictToNull(std::int32_t index) {
         _assert(0 <= index && index < static_cast<std::int32_t>(blocks_.size()), "EvictToNull index out of range");
-        return std::exchange(blocks_[static_cast<std::size_t>(index)], {});
+        CacheBlockRef old = std::exchange(blocks_[static_cast<std::size_t>(index)], {});
+        if (old && index == first_live_block_) {
+            advanceFirstLiveBlock();
+        }
+        return old;
     }
 
 private:
     friend class KvCacheManager;
 
+    void replaceBlocks(std::vector<CacheBlockRef> blocks) {
+        blocks_ = std::move(blocks);
+        first_live_block_ = 0;
+        advanceFirstLiveBlock();
+    }
+
+    void appendBlock(CacheBlockRef block) {
+        const std::int32_t index = NumBlocks();
+        const bool had_live_block = first_live_block_ < index;
+        const bool appending_live_block = static_cast<bool>(block);
+        blocks_.push_back(std::move(block));
+        if (!had_live_block) {
+            first_live_block_ = appending_live_block ? index : NumBlocks();
+        }
+    }
+
+    void appendLiveBlocks(std::vector<CacheBlockRef> blocks) {
+        const std::int32_t first_new_block = NumBlocks();
+        const bool had_live_block = first_live_block_ < first_new_block;
+        blocks_.reserve(blocks_.size() + blocks.size());
+        for (CacheBlockRef& block : blocks) {
+            blocks_.push_back(std::move(block));
+        }
+        if (!had_live_block && NumBlocks() > first_new_block) {
+            first_live_block_ = first_new_block;
+        }
+    }
+
+    void resizeWithNullBlocks(std::int32_t size) {
+        _assert(size >= NumBlocks(), "BlockTable cannot shrink through resizeWithNullBlocks");
+        const bool had_live_block = first_live_block_ < NumBlocks();
+        blocks_.resize(static_cast<std::size_t>(size));
+        if (!had_live_block) {
+            first_live_block_ = NumBlocks();
+        }
+    }
+
+    void setLiveBlock(std::int32_t index, CacheBlockRef block) {
+        _assert(0 <= index && index < NumBlocks(), "setLiveBlock index out of range");
+        _assert(static_cast<bool>(block), "setLiveBlock requires an owned block");
+        _assert(!blocks_[static_cast<std::size_t>(index)], "setLiveBlock requires a null slot");
+        blocks_[static_cast<std::size_t>(index)] = std::move(block);
+        first_live_block_ = std::min(first_live_block_, index);
+    }
+
+    void clearBlocks() {
+        blocks_.clear();
+        first_live_block_ = 0;
+    }
+
+    void advanceFirstLiveBlock() noexcept {
+        while (first_live_block_ < NumBlocks() && !blocks_[static_cast<std::size_t>(first_live_block_)]) {
+            ++first_live_block_;
+        }
+    }
+
     std::vector<CacheBlockRef> blocks_{};
+    std::int32_t first_live_block_{0};
     // Unconsumed capacity at the logical tail. This may span multiple blocks
     // when admission preallocates a later decode/MTP step.
     std::int32_t available_tokens_{0};
 };
 
 // Per-group input for one admission. page_hashes is the request's cumulative
-// completed-page history; first_new_page_slot splits the newly completed
-// suffix used by prefix-closed groups. Non-closed groups select the trailing
-// pages required to resume num_computed_tokens. The request owns table and
-// the storage behind page_hashes.
+// completed base-grain hash history; first_new_page_slot is also measured in
+// base-grain slots and splits the newly completed suffix. Managers translate
+// it to their group-local logical block span. Non-closed groups select the
+// trailing pages required to resume num_computed_tokens. The request owns
+// table and the storage behind page_hashes.
 struct GroupDemand {
     BlockTable* table{nullptr};
     std::int32_t num_tokens{0};
@@ -106,9 +176,10 @@ struct GroupDemand {
     CacheBoundaryKind boundary_kind{CacheBoundaryKind::kChunk};
     std::int32_t num_computed_tokens{-1};
     std::int32_t reserve_tokens{0};
-    // -1 materializes the ordinary dense suffix. A non-negative value keeps
-    // earlier logical slots as null holes and materializes only this suffix.
-    // Decode-side PD uses this for latest-snapshot state groups.
+    // -1 materializes the ordinary dense suffix. A non-negative input is a
+    // base-grain slot; the coordinator translates it to each group's logical
+    // slot before admission. Earlier slots remain null holes. Decode-side PD
+    // uses this for latest-snapshot state groups.
     std::int32_t materialized_suffix_start{-1};
 };
 

--- a/tokenspeed-scheduler/csrc/cache/forward_cache_ops.cpp
+++ b/tokenspeed-scheduler/csrc/cache/forward_cache_ops.cpp
@@ -53,8 +53,18 @@ std::vector<KvCacheSpec> MakeSpecsFromConfig(const SchedulerConfig& config) {
     specs.reserve(config.paged_cache_groups.size());
     for (const PagedCacheGroupConfig& group : config.paged_cache_groups) {
         _assert(group.cache_blocks_per_lcm_block > 0, "cache_blocks_per_lcm_block must be > 0");
-        _assert(group.block_size == 0 || group.block_size == config.block_size,
-                "per-group block_size cannot override the shared cache_block_tokens");
+        _assert(group.block_size >= 0, "group block_size must be >= 0");
+        const std::int32_t block_size = group.block_size > 0 ? group.block_size : config.block_size;
+        _assert(block_size % config.block_size == 0, "group block_size must be a multiple of the base hash grain");
+        // Legacy/Radix configs may leave block_size unset while carrying a
+        // physical paged-cache geometry unrelated to the Flat hash grain.
+        // Cross-check only an explicit group-local logical span.
+        if (group.block_size > 0 && group.rows_per_page > 0 && group.entry_stride_tokens > 0) {
+            const std::int64_t raw_tokens_per_page =
+                static_cast<std::int64_t>(group.rows_per_page) * group.entry_stride_tokens;
+            _assert(raw_tokens_per_page == block_size,
+                    "group block_size must equal rows_per_page * entry_stride_tokens");
+        }
         // family=State marks trailing-window prefix reuse and covers both SWA and
         // linear-attention groups; only a State group WITHOUT SlidingWindow
         // retention is a mamba-style state group.
@@ -76,6 +86,7 @@ std::vector<KvCacheSpec> MakeSpecsFromConfig(const SchedulerConfig& config) {
         if (final_state_manager) {
             specs.push_back(KvCacheSpec{
                 .kind = AttnKind::kMambaState,
+                .block_size = block_size,
                 .sliding_window = 0,
                 .cache_blocks_per_lcm_block = group.cache_blocks_per_lcm_block,
             });
@@ -88,6 +99,7 @@ std::vector<KvCacheSpec> MakeSpecsFromConfig(const SchedulerConfig& config) {
         }
         specs.push_back(KvCacheSpec{
             .kind = is_swa ? AttnKind::kSlidingWindow : AttnKind::kFull,
+            .block_size = block_size,
             .sliding_window = is_swa ? *group.sliding_window_tokens : 0,
             .cache_blocks_per_lcm_block = group.cache_blocks_per_lcm_block,
         });
@@ -102,16 +114,31 @@ void FreeRequest(KvCacheCoordinator& coordinator, std::vector<BlockTable>& table
     coordinator.Free(tables);
 }
 
-std::map<std::string, std::vector<std::int32_t>> BuildFlatBlockTables(const KvCacheCoordinator& coordinator,
-                                                                      const std::vector<BlockTable>& tables,
-                                                                      std::span<const std::string> group_ids) {
-    _assert(tables.size() == group_ids.size(), "BuildFlatBlockTables: tables/group_ids size mismatch");
+FlatBlockTableRows BuildFlatBlockTableRows(const KvCacheCoordinator& coordinator, const std::vector<BlockTable>& tables,
+                                           std::span<const std::string> group_ids, bool compact_flat_block_tables) {
+    _assert(tables.size() == group_ids.size(), "BuildFlatBlockTableRows: tables/group_ids size mismatch");
     _assert(tables.size() == static_cast<std::size_t>(coordinator.NumGroups()),
-            "BuildFlatBlockTables: tables/coordinator size mismatch");
-    std::map<std::string, std::vector<std::int32_t>> out;
+            "BuildFlatBlockTableRows: tables/coordinator size mismatch");
+
+    FlatBlockTableRows out;
     for (std::size_t i = 0; i < tables.size(); ++i) {
-        out.emplace(group_ids[i], coordinator.GroupManager(static_cast<std::int32_t>(i)).BlockTablePageIds(tables[i]));
+        const KvCacheManager& manager = coordinator.GroupManager(static_cast<std::int32_t>(i));
+        const std::span<const CacheBlockRef> blocks = tables[i].Blocks();
+        const std::size_t base = compact_flat_block_tables ? static_cast<std::size_t>(tables[i].FirstLiveBlock()) : 0;
+        _assert(base <= blocks.size(), "BlockTable first-live offset exceeds its logical size");
+        std::vector<std::int32_t> page_ids;
+        page_ids.reserve(blocks.size() - base);
+        for (const CacheBlockRef& block_ref : blocks.subspan(base)) {
+            page_ids.push_back(block_ref ? manager.ResolveKernelPageId(block_ref->Location()) : 0);
+        }
+        out.tables.emplace(group_ids[i], std::move(page_ids));
+        if (compact_flat_block_tables) {
+            out.base_offsets.emplace(group_ids[i], static_cast<std::int32_t>(base));
+        }
     }
+    _assert(out.tables.size() == tables.size(), "Flat block tables require the exact configured group key set");
+    _assert(!compact_flat_block_tables || out.base_offsets.size() == out.tables.size(),
+            "Compact Flat block tables and base offsets require the same group key set");
     return out;
 }
 

--- a/tokenspeed-scheduler/csrc/cache/forward_cache_ops.h
+++ b/tokenspeed-scheduler/csrc/cache/forward_cache_ops.h
@@ -32,7 +32,8 @@ namespace tokenspeed {
 
 struct SchedulerConfig;
 
-// One KvCacheSpec per config paged_cache_group (group_id = index); all groups share config.block_size.
+// One KvCacheSpec per config paged_cache_group (group_id = index).
+// config.block_size is the base hash grain; each spec carries its group span.
 std::vector<KvCacheSpec> MakeSpecsFromConfig(const SchedulerConfig& config);
 
 std::int32_t AlignFlatPrefillChunk(std::int32_t first_pos, std::int32_t unscheduled, std::int32_t token_budget,
@@ -40,10 +41,17 @@ std::int32_t AlignFlatPrefillChunk(std::int32_t first_pos, std::int32_t unschedu
 
 void FreeRequest(KvCacheCoordinator& coordinator, std::vector<BlockTable>& tables);
 
-// One row per config group_id. Each manager resolves the group's LCM placement
-// to the kernel-visible page id.
-std::map<std::string, std::vector<std::int32_t>> BuildFlatBlockTables(const KvCacheCoordinator& coordinator,
-                                                                      const std::vector<BlockTable>& tables,
-                                                                      std::span<const std::string> group_ids);
+struct FlatBlockTableRows {
+    std::map<std::string, std::vector<std::int32_t>> tables;
+    // Exact same key set as tables. Column c addresses absolute logical block
+    // base_offsets[group] + c.
+    std::map<std::string, std::int32_t> base_offsets;
+};
+
+// Canonical runtime export. The default preserves absolute rows. When the
+// consumer explicitly supports offsets, every group may omit leading null
+// holes and carries its logical origin in base_offsets.
+FlatBlockTableRows BuildFlatBlockTableRows(const KvCacheCoordinator& coordinator, const std::vector<BlockTable>& tables,
+                                           std::span<const std::string> group_ids, bool compact_flat_block_tables);
 
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/csrc/cache/kv_cache_admission.cpp
+++ b/tokenspeed-scheduler/csrc/cache/kv_cache_admission.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <span>
 #include <tuple>
@@ -287,16 +288,28 @@ std::optional<AdmissionPlan> planAdmission(const std::vector<CacheGroup>& groups
 
 std::optional<KvCacheCoordinator::AdmissionResult> KvCacheCoordinator::Admit(
     PrefixProbe&& prefix, std::span<const GroupDemand> demands, std::optional<std::uint64_t> request_access_epoch) {
-    std::optional<AdmissionPlan> candidate = planAdmission(groups_, pool_, std::move(prefix), demands);
+    _assert(demands.size() == groups_.size(), "demands/groups size mismatch");
+    std::vector<GroupDemand> group_demands{demands.begin(), demands.end()};
+    for (std::size_t i = 0; i < group_demands.size(); ++i) {
+        GroupDemand& demand = group_demands[i];
+        _assert(demand.table != nullptr, "group demand requires a block table");
+        if (demand.materialized_suffix_start < 0) {
+            continue;
+        }
+        const std::int64_t suffix_token =
+            static_cast<std::int64_t>(demand.materialized_suffix_start) * cache_block_tokens_;
+        const std::int32_t group_block_tokens = groups_[i].Manager().CacheBlockTokens();
+        _assert(suffix_token <= std::numeric_limits<std::int32_t>::max(),
+                "materialized suffix token offset exceeds int32");
+        _assert(suffix_token % group_block_tokens == 0, "materialized suffix must be aligned to the group block span");
+        demand.materialized_suffix_start = static_cast<std::int32_t>(suffix_token / group_block_tokens);
+    }
+
+    std::optional<AdmissionPlan> candidate = planAdmission(groups_, pool_, std::move(prefix), group_demands);
     if (!candidate) {
         return std::nullopt;
     }
     AdmissionPlan plan = std::move(*candidate);
-
-    _assert(demands.size() == groups_.size(), "demands/groups size mismatch");
-    for (const GroupDemand& demand : demands) {
-        _assert(demand.table != nullptr, "group demand requires a block table");
-    }
 
     if (request_access_epoch.has_value()) {
         _assert(*request_access_epoch > 0 && *request_access_epoch <= next_access_epoch_,
@@ -317,7 +330,8 @@ std::optional<KvCacheCoordinator::AdmissionResult> KvCacheCoordinator::Admit(
     };
     if (acquired_prefix.device.num_common_tokens > 0) {
         for (std::size_t i = 0; i < groups_.size(); ++i) {
-            groups_[i].Manager().ClaimHitBlocks(*demands[i].table, std::move(acquired_prefix.device.per_group[i]));
+            groups_[i].Manager().ClaimHitBlocks(*group_demands[i].table,
+                                                std::move(acquired_prefix.device.per_group[i]));
         }
     }
     std::vector<std::pair<GroupId, CacheBlockLocation>> prospective_victims;
@@ -332,7 +346,7 @@ std::optional<KvCacheCoordinator::AdmissionResult> KvCacheCoordinator::Admit(
         }
     }
     for (std::size_t i = 0; i < groups_.size(); ++i) {
-        const GroupDemand& demand = demands[i];
+        const GroupDemand& demand = group_demands[i];
         if (!demand.page_hashes.empty()) {
             cacheCompletedBlocksForGroup(i, demand, access_epoch);
         }
@@ -347,7 +361,7 @@ std::optional<KvCacheCoordinator::AdmissionResult> KvCacheCoordinator::Admit(
     }
 
     for (std::size_t i = 0; i < groups_.size(); ++i) {
-        const GroupDemand& demand = demands[i];
+        const GroupDemand& demand = group_demands[i];
         if (!acquired_prefix.host.per_group.empty() && !acquired_prefix.host.per_group[i].blocks.empty()) {
             groups_[i].Manager().AppendHostExtension(
                 pool_, *demand.table, std::move(acquired_prefix.host.per_group[i].blocks), result.load_pairs);

--- a/tokenspeed-scheduler/csrc/cache/kv_cache_coordinator.cpp
+++ b/tokenspeed-scheduler/csrc/cache/kv_cache_coordinator.cpp
@@ -23,25 +23,42 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <numeric>
 #include <optional>
 
 #include "cache/full_attn_manager.h"
 #include "cache/mamba_state_manager.h"
 #include "cache/swa_manager.h"
+#include "scheduler/page_hasher.h"
 #include "utils.h"
 
 namespace tokenspeed {
+namespace {
+
+std::int32_t CheckedLcm(std::int32_t lhs, std::int32_t rhs) {
+    _assert(lhs > 0 && rhs > 0, "block alignment inputs must be positive");
+    const std::int32_t quotient = lhs / std::gcd(lhs, rhs);
+    _assert(quotient <= std::numeric_limits<std::int32_t>::max() / rhs, "block alignment exceeds int32");
+    return quotient * rhs;
+}
+
+}  // namespace
 
 KvCacheCoordinator::KvCacheCoordinator(std::vector<CacheGroup> groups, std::int32_t cache_block_tokens, BlockPool& pool,
                                        BlockPool* host_pool)
     : groups_{std::move(groups)}, pool_{pool}, host_pool_{host_pool}, cache_block_tokens_{cache_block_tokens} {
     _assert(cache_block_tokens_ > 0, "coordinator needs positive cache_block_tokens");
+    prefix_alignment_tokens_ = cache_block_tokens_;
     for (std::size_t i = 0; i < groups_.size(); ++i) {
         _assert(groups_[i].Id() == static_cast<GroupId>(i), "cache manager group id must equal its group index");
-        _assert(groups_[i].Manager().CacheBlockTokens() == cache_block_tokens_,
-                "every cache manager must use the domain cache_block_tokens");
+        const std::int32_t group_block_tokens = groups_[i].Manager().CacheBlockTokens();
+        _assert(group_block_tokens > 0 && group_block_tokens % cache_block_tokens_ == 0,
+                "every group block span must be a positive multiple of the base hash grain");
+        _assert(groups_[i].Spec().block_size == group_block_tokens,
+                "cache manager block span must match its group spec");
         _assert(groups_[i].Manager().CacheBlocksPerLcmBlock() == groups_[i].Spec().cache_blocks_per_lcm_block,
                 "cache manager packing must match its group spec");
+        prefix_alignment_tokens_ = CheckedLcm(prefix_alignment_tokens_, group_block_tokens);
         if (groups_[i].Manager().MatchIsPrefixClosed()) {
             match_order_.push_back(i);
         }
@@ -58,12 +75,20 @@ bool KvCacheCoordinator::HasMambaStateGroup() const {
                                [](const CacheGroup& group) { return group.Spec().kind == AttnKind::kMambaState; });
 }
 
-std::vector<CacheKey> KvCacheCoordinator::keysForGroup(std::span<const std::string> content_hashes,
-                                                       GroupId group_id) const {
+std::vector<CacheKey> KvCacheCoordinator::keysForGroup(std::span<const std::string> content_hashes, GroupId group_id,
+                                                       std::int32_t first_base_slot) const {
+    _assert(group_id < groups_.size(), "cache key group id out of range");
+    const std::int32_t fold = groups_[group_id].Manager().CacheBlockTokens() / cache_block_tokens_;
+    // Base hashes are cumulative rolling digests, so a group key is the digest
+    // at its block-end boundary; no second hash fold is required.
     std::vector<CacheKey> keys;
-    keys.reserve(content_hashes.size());
-    for (const std::string& content_hash : content_hashes) {
-        keys.push_back(CacheKey{.group_id = group_id, .content_hash = content_hash});
+    keys.reserve(content_hashes.size() / static_cast<std::size_t>(fold) + 1);
+    for (std::int32_t index = FirstProjectedBaseHashOffset(first_base_slot, fold);
+         index < static_cast<std::int32_t>(content_hashes.size()); index += fold) {
+        keys.push_back(CacheKey{
+            .group_id = group_id,
+            .content_hash = content_hashes[static_cast<std::size_t>(index)],
+        });
     }
     return keys;
 }
@@ -81,7 +106,7 @@ struct ConvergedBoundary {
 // under the current bound and only a further bound drop can lift it back above, so
 // re-matches are finite; the result is the greatest boundary every group supports.
 //
-// Bounds align down to the shared logical CacheBlock granularity P.
+// Bounds align down to the raw-token boundary shared by every group grid.
 template <typename MatchGroup, typename ExtentTokens>
 ConvergedBoundary SweepThenConverge(std::span<const std::size_t> order, const std::vector<CacheGroup>& groups,
                                     std::int32_t bound_tokens, std::int32_t align_tokens, const MatchGroup& match,
@@ -124,38 +149,40 @@ std::vector<std::vector<CacheKey>> KvCacheCoordinator::buildGroupKeys(
     return group_keys;
 }
 
-// The one tier matcher: slots below floor_tokens are assumed valid in a lower tier; per_group
-// blocks are relative to the floor, num_common_tokens is the absolute converged boundary (in
-// TOKENS). num_cache_blocks = content_hashes.size(); every group has one key per
-// logical CacheBlock.
+// The one tier matcher: slots below floor_tokens are assumed valid in a lower
+// tier. num_base_blocks is the number of base-grain content hashes; group keys,
+// probe bounds, and extents use each manager's local block span.
 KvCacheCoordinator::PrefixProbe::Tier KvCacheCoordinator::probeTierWithKeys(
     const BlockPool& pool, std::span<const std::vector<CacheKey>> group_keys, std::span<const std::size_t> match_order,
-    std::int32_t num_cache_blocks, std::int32_t floor_tokens) const {
+    std::int32_t num_base_blocks, std::int32_t floor_tokens) const {
     PrefixProbe::Tier out;
     out.per_group.resize(groups_.size());
     if (match_order.empty()) {
         return out;
     }
     const ConvergedBoundary boundary = SweepThenConverge(
-        match_order, groups_, num_cache_blocks * cache_block_tokens_, cache_block_tokens_,
+        match_order, groups_, num_base_blocks * cache_block_tokens_, prefix_alignment_tokens_,
         [&](std::size_t i, std::int32_t bound_tokens) {
-            out.per_group[i] = groups_[i].Manager().Probe(pool, group_keys[i], floor_tokens / cache_block_tokens_,
-                                                          bound_tokens / cache_block_tokens_);
+            const std::int32_t group_block_tokens = groups_[i].Manager().CacheBlockTokens();
+            out.per_group[i] = groups_[i].Manager().Probe(pool, group_keys[i], floor_tokens / group_block_tokens,
+                                                          bound_tokens / group_block_tokens);
         },
         [&](std::size_t i) {
-            return (floor_tokens / cache_block_tokens_ + static_cast<std::int32_t>(out.per_group[i].hits.size())) *
-                   cache_block_tokens_;
+            const std::int32_t group_block_tokens = groups_[i].Manager().CacheBlockTokens();
+            return (floor_tokens / group_block_tokens + static_cast<std::int32_t>(out.per_group[i].hits.size())) *
+                   group_block_tokens;
         });
 
     // Truncate closed probes to the converged boundary.
     // Non-closed groups were re-probed against the settled bound and are already at or below it.
-    const std::int32_t floor_blocks = floor_tokens / cache_block_tokens_;
     for (std::size_t i = 0; i < groups_.size(); ++i) {
+        const std::int32_t group_block_tokens = groups_[i].Manager().CacheBlockTokens();
+        const std::int32_t floor_blocks = floor_tokens / group_block_tokens;
         GroupPrefixProbe& probe = out.per_group[i];
-        if ((floor_blocks + static_cast<std::int32_t>(probe.hits.size())) * cache_block_tokens_ >
+        if ((floor_blocks + static_cast<std::int32_t>(probe.hits.size())) * group_block_tokens >
             boundary.common_tokens) {
             _assert(groups_[i].Manager().MatchIsPrefixClosed(), "window group left above the converged boundary");
-            probe.hits.resize(static_cast<std::size_t>(boundary.common_tokens / cache_block_tokens_ - floor_blocks));
+            probe.hits.resize(static_cast<std::size_t>(boundary.common_tokens / group_block_tokens - floor_blocks));
         }
     }
     out.num_common_tokens = boundary.common_tokens;
@@ -170,8 +197,8 @@ CoordinatorMatch KvCacheCoordinator::acquireTierWithKeys(BlockPool& pool,
     CoordinatorMatch out;
     out.num_common_tokens = probe.num_common_tokens;
     out.per_group.resize(groups_.size());
-    const std::int32_t floor_blocks = floor_tokens / cache_block_tokens_;
     for (std::size_t i = 0; i < groups_.size(); ++i) {
+        const std::int32_t floor_blocks = floor_tokens / groups_[i].Manager().CacheBlockTokens();
         out.per_group[i] = groups_[i].Manager().AcquireMatchedBlocks(pool, group_keys[i], floor_blocks,
                                                                      probe.per_group[i], access_epoch);
     }
@@ -214,13 +241,14 @@ KvCacheCoordinator::PrefixProbe KvCacheCoordinator::ProbeDecodeDestinationPrefix
             probeTierWithKeys(pool, out.group_keys, history_match_order, num_cache_blocks, floor_tokens);
         const std::int64_t covered_tokens =
             static_cast<std::int64_t>(tier.num_common_tokens) - static_cast<std::int64_t>(floor_tokens);
-        const std::int64_t num_holes = covered_tokens / cache_block_tokens_;
-        _assert(covered_tokens >= 0 && num_holes <= num_cache_blocks,
-                "decode destination state hole count is outside the probed range");
-        const std::size_t hole_count =
-            static_cast<std::size_t>(std::clamp<std::int64_t>(num_holes, 0, num_cache_blocks));
+        _assert(covered_tokens >= 0, "decode destination state coverage precedes the tier floor");
         for (std::size_t i = 0; i < groups_.size(); ++i) {
             if (groups_[i].Spec().kind == AttnKind::kMambaState) {
+                const std::int32_t group_block_tokens = groups_[i].Manager().CacheBlockTokens();
+                const std::int64_t num_holes = covered_tokens / group_block_tokens;
+                _assert(num_holes <= static_cast<std::int64_t>(out.group_keys[i].size()),
+                        "decode destination state hole count is outside the probed range");
+                const std::size_t hole_count = static_cast<std::size_t>(num_holes);
                 tier.per_group[i].hits.resize(hole_count);
             }
         }
@@ -270,9 +298,11 @@ void KvCacheCoordinator::CacheFullBlocks(std::span<BlockTable> tables, std::span
 void KvCacheCoordinator::cacheFullBlocksForGroup(std::size_t group_index, BlockTable& table,
                                                  std::span<const std::string> content_hashes, std::int32_t first_slot,
                                                  std::uint64_t access_epoch, CacheBoundaryKind boundary_kind) {
-    std::vector<CacheKey> keys = keysForGroup(content_hashes, groups_[group_index].Id());
+    const std::int32_t fold = groups_[group_index].Manager().CacheBlockTokens() / cache_block_tokens_;
+    std::vector<CacheKey> keys = keysForGroup(content_hashes, groups_[group_index].Id(), first_slot);
+    const std::int32_t group_first_slot = FirstProjectedGroupSlot(first_slot, fold);
     std::vector<std::pair<CacheKey, CacheBlockRef>> newly_cached;
-    groups_[group_index].Manager().CacheFullBlocks(pool_, table, keys, access_epoch, first_slot, boundary_kind,
+    groups_[group_index].Manager().CacheFullBlocks(pool_, table, keys, access_epoch, group_first_slot, boundary_kind,
                                                    host_pool_ != nullptr ? &newly_cached : nullptr);
     for (auto& [key, block_ref] : newly_cached) {
         pending_stores_.push_back(StoreCandidate{
@@ -292,27 +322,30 @@ void KvCacheCoordinator::cacheCompletedBlocksForGroup(std::size_t group_index, c
     }
 
     const KvCacheManager& manager = groups_[group_index].Manager();
+    const std::int32_t group_block_tokens = manager.CacheBlockTokens();
+    const std::int32_t fold = group_block_tokens / cache_block_tokens_;
     if (manager.MatchIsPrefixClosed()) {
         cacheFullBlocksForGroup(group_index, *demand.table,
                                 demand.page_hashes.subspan(static_cast<std::size_t>(demand.first_new_page_slot)),
                                 demand.first_new_page_slot, access_epoch, demand.boundary_kind);
         return;
     }
-    if (demand.num_computed_tokens < 0 || demand.num_computed_tokens % cache_block_tokens_ != 0) {
+    if (demand.num_computed_tokens < 0 || demand.num_computed_tokens % group_block_tokens != 0) {
         return;
     }
 
-    const std::int32_t boundary_slot = demand.num_computed_tokens / cache_block_tokens_;
-    _assert(boundary_slot == static_cast<std::int32_t>(demand.page_hashes.size()),
+    const std::int32_t boundary_slot = demand.num_computed_tokens / group_block_tokens;
+    _assert(static_cast<std::int64_t>(boundary_slot) * fold == static_cast<std::int64_t>(demand.page_hashes.size()),
             "non-closed boundary must end at the hash history tail");
     const std::int32_t lookback = std::min(manager.BoundaryLookbackBlocks(), boundary_slot);
     if (lookback == 0) {
         return;
     }
-    const std::int32_t first_slot = boundary_slot - lookback;
+    const std::int32_t first_group_slot = boundary_slot - lookback;
+    const std::int32_t first_base_slot = first_group_slot * fold;
     cacheFullBlocksForGroup(group_index, *demand.table,
-                            demand.page_hashes.subspan(static_cast<std::size_t>(first_slot)), first_slot, access_epoch,
-                            demand.boundary_kind);
+                            demand.page_hashes.subspan(static_cast<std::size_t>(first_base_slot)), first_base_slot,
+                            access_epoch, demand.boundary_kind);
 }
 
 void KvCacheCoordinator::ReclaimExpired(std::span<BlockTable> tables, std::int32_t num_computed_tokens) {
@@ -389,17 +422,22 @@ KvCacheCoordinator MakeCoordinator(std::span<const KvCacheSpec> specs, std::int3
     std::vector<CacheGroup> groups;
     groups.reserve(specs.size());
     for (std::size_t i = 0; i < specs.size(); ++i) {
-        const KvCacheSpec& spec = specs[i];
+        KvCacheSpec spec = specs[i];
         const GroupId group_id = static_cast<GroupId>(i);
+        _assert(spec.block_size >= 0, "group block_size must be >= 0");
+        const std::int32_t group_block_tokens = spec.block_size > 0 ? spec.block_size : cache_block_tokens;
+        _assert(group_block_tokens % cache_block_tokens == 0,
+                "group block_size must be a multiple of cache_block_tokens");
         _assert(spec.cache_blocks_per_lcm_block > 0, "cache_blocks_per_lcm_block must be > 0");
+        spec.block_size = group_block_tokens;
         std::unique_ptr<KvCacheManager> manager;
         if (spec.kind == AttnKind::kFull) {
-            manager = std::make_unique<FullAttnManager>(cache_block_tokens, spec.cache_blocks_per_lcm_block, group_id);
+            manager = std::make_unique<FullAttnManager>(group_block_tokens, spec.cache_blocks_per_lcm_block, group_id);
         } else if (spec.kind == AttnKind::kMambaState) {
             manager =
-                std::make_unique<MambaStateManager>(cache_block_tokens, spec.cache_blocks_per_lcm_block, group_id);
+                std::make_unique<MambaStateManager>(group_block_tokens, spec.cache_blocks_per_lcm_block, group_id);
         } else {
-            manager = std::make_unique<SwaManager>(cache_block_tokens, spec.cache_blocks_per_lcm_block,
+            manager = std::make_unique<SwaManager>(group_block_tokens, spec.cache_blocks_per_lcm_block,
                                                    spec.sliding_window, group_id);
         }
         groups.emplace_back(spec, std::move(manager));

--- a/tokenspeed-scheduler/csrc/cache/kv_cache_coordinator.h
+++ b/tokenspeed-scheduler/csrc/cache/kv_cache_coordinator.h
@@ -36,8 +36,8 @@ namespace tokenspeed {
 
 struct KvCacheCoordinatorTestAccess;
 
-// num_common_tokens is in tokens at the one shared CacheBlock granularity P.
-// per_group[i] is group i's PrefixMatch at exactly that length.
+// num_common_tokens is a raw-token boundary shared by every group.
+// per_group[i] is expressed in that group's logical block span.
 struct CoordinatorMatch {
     std::int32_t num_common_tokens{0};
     std::vector<PrefixMatch> per_group;
@@ -53,7 +53,10 @@ public:
 
     std::int32_t NumGroups() const { return static_cast<std::int32_t>(groups_.size()); }
 
+    // The base GCD is the request hash-chain grain, not every group's block
+    // span. GroupManager(i).CacheBlockTokens() reports the latter.
     std::int32_t CacheBlockTokens() const noexcept { return cache_block_tokens_; }
+    std::int32_t PrefixAlignmentTokens() const noexcept { return prefix_alignment_tokens_; }
     bool HasMambaStateGroup() const;
 
     KvCacheManager& GroupManager(std::int32_t i) { return groups_[static_cast<std::size_t>(i)].Manager(); }
@@ -130,7 +133,8 @@ private:
         CoordinatorMatch host;
     };
 
-    std::vector<CacheKey> keysForGroup(std::span<const std::string> content_hashes, GroupId group_id) const;
+    std::vector<CacheKey> keysForGroup(std::span<const std::string> content_hashes, GroupId group_id,
+                                       std::int32_t first_base_slot = 0) const;
     std::vector<std::vector<CacheKey>> buildGroupKeys(std::span<const std::string> content_hashes) const;
     PrefixProbe::Tier probeTierWithKeys(const BlockPool& pool, std::span<const std::vector<CacheKey>> group_keys,
                                         std::span<const std::size_t> match_order, std::int32_t num_cache_blocks,
@@ -148,12 +152,16 @@ private:
     std::vector<std::size_t> match_order_;
     BlockPool& pool_;
     BlockPool* host_pool_{nullptr};
+    // Base hash-chain grain. Every group block span is a positive multiple.
     std::int32_t cache_block_tokens_{0};
+    // Common raw-token boundary on which all group-local block grids meet.
+    std::int32_t prefix_alignment_tokens_{0};
     std::uint64_t next_access_epoch_{0};
     std::vector<StoreCandidate> pending_stores_;
 };
 
-// One CacheGroup per spec (group_id = index), all sharing cache_block_tokens.
+// One CacheGroup per spec (group_id = index). cache_block_tokens is the base
+// hash-chain grain; a spec's positive block_size overrides the manager span.
 KvCacheCoordinator MakeCoordinator(std::span<const KvCacheSpec> specs, std::int32_t cache_block_tokens, BlockPool& pool,
                                    BlockPool* host_pool = nullptr);
 

--- a/tokenspeed-scheduler/csrc/cache/kv_cache_manager.h
+++ b/tokenspeed-scheduler/csrc/cache/kv_cache_manager.h
@@ -137,7 +137,7 @@ public:
 
     void ClaimHitBlocks(BlockTable& table, PrefixMatch&& hit) {
         _assert(table.blocks_.empty(), "ClaimHitBlocks requires a fresh (empty) table");
-        table.blocks_ = std::move(hit.blocks);
+        table.replaceBlocks(std::move(hit.blocks));
     }
 
     bool Acquire(BlockPool& pool, BlockTable& table, std::int32_t num_tokens, std::int32_t reserve_tokens = 0) {
@@ -147,7 +147,6 @@ public:
             table.available_tokens_ -= num_tokens;
             return true;
         }
-        table.blocks_.reserve(table.blocks_.size() + static_cast<std::size_t>(num_pages));
         std::vector<CacheBlockRef> new_block_refs =
             pool.AcquireBlocks(group_id_, cache_blocks_per_lcm_block_, num_pages);
         if (static_cast<std::int32_t>(new_block_refs.size()) < num_pages) {
@@ -170,11 +169,11 @@ public:
         auto destination_it = destination_refs.begin();
         for (CacheBlockRef& host_block_ref : host_block_refs) {
             if (!host_block_ref) {
-                table.blocks_.emplace_back();
+                table.appendBlock({});
                 continue;
             }
             _assert(destination_it != destination_refs.end(), "missing host extension destination");
-            table.blocks_.push_back(std::move(*destination_it));
+            table.appendBlock(std::move(*destination_it));
             ++destination_it;
             load_pairs.push_back(BlockTransfer{
                 .group_id = group_id_,
@@ -230,9 +229,10 @@ public:
         const std::int64_t extent = static_cast<std::int64_t>(demand.num_tokens) + demand.reserve_tokens;
         const std::int32_t logical_blocks =
             static_cast<std::int32_t>((extent + cache_block_tokens_ - 1) / cache_block_tokens_);
-        table.blocks_.resize(static_cast<std::size_t>(logical_blocks));
+        table.resizeWithNullBlocks(logical_blocks);
         for (std::size_t i = 0; i < block_refs.size(); ++i) {
-            table.blocks_[static_cast<std::size_t>(demand.materialized_suffix_start) + i] = std::move(block_refs[i]);
+            table.setLiveBlock(demand.materialized_suffix_start + static_cast<std::int32_t>(i),
+                               std::move(block_refs[i]));
         }
         table.available_tokens_ = logical_blocks * cache_block_tokens_ - demand.num_tokens;
         return true;
@@ -403,7 +403,7 @@ public:
         for (auto it = table.blocks_.rbegin(); it != table.blocks_.rend(); ++it) {
             it->reset();
         }
-        table.blocks_.clear();
+        table.clearBlocks();
         table.available_tokens_ = 0;
     }
 
@@ -452,9 +452,7 @@ private:
         const std::int32_t added_tokens = static_cast<std::int32_t>(block_refs.size()) * cache_block_tokens_;
         _assert(num_tokens <= table.available_tokens_ + added_tokens,
                 "allocated blocks do not cover the immediate token demand");
-        for (CacheBlockRef& block_ref : block_refs) {
-            table.blocks_.push_back(std::move(block_ref));
-        }
+        table.appendLiveBlocks(std::move(block_refs));
         table.available_tokens_ += added_tokens - num_tokens;
     }
 

--- a/tokenspeed-scheduler/csrc/resource/allocator/paged_cache_group.h
+++ b/tokenspeed-scheduler/csrc/resource/allocator/paged_cache_group.h
@@ -64,9 +64,9 @@ struct PagedCacheGroupConfig {
     std::int32_t rows_per_page{};
     std::int32_t entry_stride_tokens{};
     std::int32_t total_pages{};
-    // Legacy serialization field. Flat prefix-cache configurations may leave
-    // it unset or set it equal to SchedulerConfig::block_size, but may not use
-    // it to define a different logical prefix granularity.
+    // Logical token span of one cache block in this group. Zero inherits
+    // SchedulerConfig::block_size; otherwise it must be a positive multiple
+    // of that base hash grain.
     std::int32_t block_size{0};
     // Fixed-byte placement recipe: how many logical CacheBlocks from this
     // group fit in one physical LCM block.

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -97,12 +97,20 @@ void AddUniqueNode(std::vector<TreeNode*>& nodes, TreeNode* node) {
 
 template <typename Op>
 static void maybeFillFlatBlockTables(Op& op, Request* request, const KvCacheCoordinator& coordinator,
-                                     std::span<const std::string> flat_group_ids) {
+                                     std::span<const std::string> flat_group_ids, bool compact_flat_block_tables) {
     if (!request->FlatBlockTablesEmpty()) {
-        op.flat_block_tables = BuildFlatBlockTables(coordinator, request->FlatBlockTablesRef(), flat_group_ids);
-        // occupied_pages is the legacy single-table bridge. It must expose the
-        // same kernel page ids as the first Flat group, never LCM parent ids.
-        op.occupied_pages = op.flat_block_tables.at(flat_group_ids.front());
+        const std::vector<BlockTable>& block_tables = request->FlatBlockTablesRef();
+        FlatBlockTableRows rows =
+            BuildFlatBlockTableRows(coordinator, block_tables, flat_group_ids, compact_flat_block_tables);
+        op.flat_block_tables = std::move(rows.tables);
+        // Reuse the model-agnostic compact-table offset seam already consumed
+        // by runtime backends; Flat and radix never populate an op together.
+        op.paged_cache_page_base_offsets = std::move(rows.base_offsets);
+        // occupied_pages is the legacy single-table bridge. A group-keyed
+        // consumer has no use for that absolute duplicate or its update slice.
+        if (!compact_flat_block_tables) {
+            op.occupied_pages = op.flat_block_tables.at(flat_group_ids.front());
+        }
     }
 }
 
@@ -984,16 +992,19 @@ void Scheduler::finalizeRadixPageTableEmission(Request* request, ForwardOperatio
 template <typename Event>
     requires(std::same_as<Event, fsm::SchedulePrefillFirstChunkEvent> || std::same_as<Event, fsm::SchedulePrefillEvent>)
 static PrefillOperation applyPrefillEvent(Request* request, Event& event, const KvCacheCoordinator* coordinator,
-                                          std::span<const std::string> flat_group_ids) {
+                                          std::span<const std::string> flat_group_ids, bool compact_flat_block_tables) {
     // begin/size are PAGE-space: the req_to_page refresh slice for this operation.
     // The builder starts with appended pages; radix finalization may move begin
     // backward when publication canonicalizes an already-emitted physical page.
     // A first-chunk prefix hit enters during the event, so begin stays 0 and size counts the hit rows too;
     // the op's token-space INPUT window intentionally starts past the hit.
-    std::int32_t begin = static_cast<std::int32_t>(request->GetOccupiedPages().size());
+    std::int32_t begin = compact_flat_block_tables ? 0 : static_cast<std::int32_t>(request->GetOccupiedPages().size());
     request->Apply(event);
-    std::vector<std::int32_t> all_pages = request->GetOccupiedPages();
-    std::int32_t sz = static_cast<std::int32_t>(all_pages.size()) - begin;
+    std::vector<std::int32_t> all_pages;
+    if (!compact_flat_block_tables) {
+        all_pages = request->GetOccupiedPages();
+    }
+    const std::int32_t sz = static_cast<std::int32_t>(all_pages.size()) - begin;
 
     auto info = request->GetPrefillInfo();
     auto op = PrefillOperation{{
@@ -1019,7 +1030,7 @@ static PrefillOperation applyPrefillEvent(Request* request, Event& event, const 
 
 #if TOKENSPEED_FLAT_KVCACHE
     _assert(coordinator != nullptr, "flat operation requires a cache coordinator");
-    maybeFillFlatBlockTables(op, request, *coordinator, flat_group_ids);
+    maybeFillFlatBlockTables(op, request, *coordinator, flat_group_ids, compact_flat_block_tables);
 #else
     (void)coordinator;
     (void)flat_group_ids;
@@ -1035,9 +1046,9 @@ PrefillOperation Scheduler::applyEventAndGenerateOp(Request* request, fsm::Sched
     auto match = event.GetMatchResult();
 #endif
 #if TOKENSPEED_FLAT_KVCACHE
-    auto op = applyPrefillEvent(request, event, &coordinator_, FlatGroupIds());
+    auto op = applyPrefillEvent(request, event, &coordinator_, FlatGroupIds(), config_.compact_flat_block_tables);
 #else
-    auto op = applyPrefillEvent(request, event, nullptr, FlatGroupIds());
+    auto op = applyPrefillEvent(request, event, nullptr, FlatGroupIds(), /*compact_flat_block_tables=*/false);
 #endif
 #if TOKENSPEED_FLAT_KVCACHE
     // Host-loaded pages ride the same LoadBackOperation channel as radix loadbacks.
@@ -1083,9 +1094,9 @@ PrefillOperation Scheduler::applyEventAndGenerateOp(Request* request, fsm::Sched
 
 PrefillOperation Scheduler::applyEventAndGenerateOp(Request* request, fsm::SchedulePrefillEvent event) {
 #if TOKENSPEED_FLAT_KVCACHE
-    auto op = applyPrefillEvent(request, event, &coordinator_, FlatGroupIds());
+    auto op = applyPrefillEvent(request, event, &coordinator_, FlatGroupIds(), config_.compact_flat_block_tables);
 #else
-    auto op = applyPrefillEvent(request, event, nullptr, FlatGroupIds());
+    auto op = applyPrefillEvent(request, event, nullptr, FlatGroupIds(), /*compact_flat_block_tables=*/false);
 #endif
 #if !TOKENSPEED_FLAT_KVCACHE
     if (hybrid_prefix_cache_) {
@@ -1104,11 +1115,14 @@ template <typename Event>
              std::same_as<Event, fsm::ScheduleDecodeFromRetractedEvent>)
 static DecodeOperation applyDecodeEvent(Request* request, Event event, std::int32_t decode_input_tokens,
                                         const KvCacheCoordinator* coordinator,
-                                        std::span<const std::string> flat_group_ids) {
-    std::int32_t begin = static_cast<std::int32_t>(request->GetOccupiedPages().size());
+                                        std::span<const std::string> flat_group_ids, bool compact_flat_block_tables) {
+    std::int32_t begin = compact_flat_block_tables ? 0 : static_cast<std::int32_t>(request->GetOccupiedPages().size());
     request->Apply(std::move(event));
-    std::vector<std::int32_t> all_pages = request->GetOccupiedPages();
-    std::int32_t sz = static_cast<std::int32_t>(all_pages.size()) - begin;
+    std::vector<std::int32_t> all_pages;
+    if (!compact_flat_block_tables) {
+        all_pages = request->GetOccupiedPages();
+    }
+    const std::int32_t sz = static_cast<std::int32_t>(all_pages.size()) - begin;
 
     auto op = DecodeOperation{{
         .request_id = request->Id(),
@@ -1130,7 +1144,7 @@ static DecodeOperation applyDecodeEvent(Request* request, Event event, std::int3
 
 #if TOKENSPEED_FLAT_KVCACHE
     _assert(coordinator != nullptr, "flat operation requires a cache coordinator");
-    maybeFillFlatBlockTables(op, request, *coordinator, flat_group_ids);
+    maybeFillFlatBlockTables(op, request, *coordinator, flat_group_ids, compact_flat_block_tables);
 #else
     (void)coordinator;
     (void)flat_group_ids;
@@ -1148,9 +1162,11 @@ DecodeOperation Scheduler::applyEventAndGenerateOp(Request* request, fsm::Schedu
 #endif
 
 #if TOKENSPEED_FLAT_KVCACHE
-    auto op = applyDecodeEvent(request, std::move(event), config_.decode_input_tokens, &coordinator_, FlatGroupIds());
+    auto op = applyDecodeEvent(request, std::move(event), config_.decode_input_tokens, &coordinator_, FlatGroupIds(),
+                               config_.compact_flat_block_tables);
 #else
-    auto op = applyDecodeEvent(request, std::move(event), config_.decode_input_tokens, nullptr, FlatGroupIds());
+    auto op = applyDecodeEvent(request, std::move(event), config_.decode_input_tokens, nullptr, FlatGroupIds(),
+                               /*compact_flat_block_tables=*/false);
 #endif
     if (need_bootstrap_token) {
         op.decode_input_id = bootstrap_token;
@@ -1182,8 +1198,15 @@ DecodeOperation Scheduler::applyEventAndGenerateOp(Request* request, fsm::Schedu
             "Scheduler::applyEventAndGenerateOp: expected state=Decoding after loadback recovery; got state=" +
             request->StateName());
     }
-    std::vector<std::int32_t> all_pages = request->GetOccupiedPages();
-    std::int32_t sz = static_cast<std::int32_t>(all_pages.size());
+    std::vector<std::int32_t> all_pages;
+#if TOKENSPEED_FLAT_KVCACHE
+    if (!config_.compact_flat_block_tables) {
+        all_pages = request->GetOccupiedPages();
+    }
+#else
+    all_pages = request->GetOccupiedPages();
+#endif
+    const std::int32_t sz = static_cast<std::int32_t>(all_pages.size());
     DecodeOperation op{{
         .request_id = request->Id(),
         .request_pool_index = request->GetReqPoolIndex(),
@@ -1222,7 +1245,7 @@ DecodeOperation Scheduler::applyEventAndGenerateOp(Request* request, fsm::Schedu
 #endif
 
 #if TOKENSPEED_FLAT_KVCACHE
-    maybeFillFlatBlockTables(op, request, coordinator_, FlatGroupIds());
+    maybeFillFlatBlockTables(op, request, coordinator_, FlatGroupIds(), config_.compact_flat_block_tables);
 #endif
 
     return op;

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.h
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.h
@@ -36,7 +36,8 @@ struct ForwardOperationBase {
     std::string request_id;
     std::int32_t request_pool_index;
     std::int32_t input_length;
-    // All pages currently occupied by this request (existing + newly allocated).
+    // All pages currently occupied by this request for the legacy scalar page
+    // table. Empty when a group-keyed compact table is the authoritative ABI.
     std::vector<int32_t> occupied_pages;
     // Index into occupied_pages where the emitted page-table refresh begins.
     // On the radix path this may precede newly allocated pages when publishing
@@ -54,13 +55,13 @@ struct ForwardOperationBase {
     // base_offset + c. For full-history groups base_offset is implicitly 0
     // and the key may be omitted from paged_cache_page_base_offsets.
     std::map<std::string, std::vector<std::int32_t>> paged_cache_pages;
-    // Per-request, per-sliding-group base logical-page offset.
+    // Per-request logical-page origin for compact paged/Flat rows.
     std::map<std::string, std::int32_t> paged_cache_page_base_offsets;
 
-    // flat KV-cache per-group block table. key = group_id, value = that group's
-    // physical page-id row (null hole = 0, absolute logical-page index, NOT
-    // compacted). Filled only on the flat path; empty on the radix path. Does
-    // not share a contract with paged_cache_pages (radix: compact + offset).
+    // Flat KV-cache per-group block table. Rows are absolute by default. An
+    // offset-capable runtime may opt in to omitting leading null holes;
+    // paged_cache_page_base_offsets then carries the row's logical origin.
+    // Internal null holes remain 0.
     std::map<std::string, std::vector<std::int32_t>> flat_block_tables;
 
     // Mamba extension (default: inactive)
@@ -114,13 +115,16 @@ struct FlatForwardOperation {
     // logical-page indexing. For full-history groups rows are absolute and
     // the offset is implicitly 0 (key omitted from the offsets map).
     std::map<std::string, std::vector<std::vector<std::int32_t>>> paged_cache_block_tables;
-    // Per-group [num_reqs] base logical-page offsets, only present for
-    // sliding-window groups. Missing key ⇔ offset is 0 for every row.
+    // Per-group [num_reqs] base logical-page offsets. Radix may omit
+    // all-zero full-history groups; Flat publishes the exact table key set so
+    // tables and offsets can be packed atomically by the runtime.
     std::map<std::string, std::vector<std::int32_t>> paged_cache_block_table_base_offsets;
 
-    // flat KV-cache per-group block table, batched: dict[group_id] =
-    // [num_reqs, max_pages_in_batch] padded with -1. Each row is absolute
-    // (null hole = 0, no compaction); there is no base-offset companion.
+    // Flat KV-cache per-group block table, batched: dict[group_id] =
+    // [num_reqs, max_live_pages_in_batch] padded with -1. Rows are absolute by
+    // default; an offset-capable runtime may compact leading reclaimed holes.
+    // Pair with paged_cache_block_table_base_offsets to recover logical block
+    // indices. Internal null holes remain 0.
     std::map<std::string, std::vector<std::vector<std::int32_t>>> flat_block_tables;
     // Contiguous row-major copy of flat_block_tables ([rows * cols], -1
     // padded), exposed zero-copy to Python as a 2-D ndarray -- the nested

--- a/tokenspeed-scheduler/csrc/scheduler/page_hasher.h
+++ b/tokenspeed-scheduler/csrc/scheduler/page_hasher.h
@@ -146,4 +146,15 @@ inline std::vector<std::string> AdvancePagedHashes(std::span<const std::span<con
                               prior);
 }
 
+// Local offset of the first cumulative base hash that ends a group block.
+inline std::int32_t FirstProjectedBaseHashOffset(std::int32_t first_base, std::int32_t fold) {
+    _assert(first_base >= 0, "first_base must be >= 0");
+    _assert(fold >= 1, "fold factor must be >= 1");
+    return (fold - 1 - first_base % fold + fold) % fold;
+}
+
+inline std::int32_t FirstProjectedGroupSlot(std::int32_t first_base, std::int32_t fold) {
+    return (first_base + FirstProjectedBaseHashOffset(first_base, fold)) / fold;
+}
+
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/csrc/scheduler/types.h
+++ b/tokenspeed-scheduler/csrc/scheduler/types.h
@@ -117,6 +117,9 @@ struct SchedulerConfig {
     // Explicit opt-in for the Flat KV Prefill/Decode lifecycle. This keeps
     // legacy non-flat PD and Flat standalone scheduling unchanged.
     bool enable_flatkv_pd{false};
+    // Runtime capability opt-in for Flat groups to omit leading null holes and
+    // publish their logical origins beside the tables.
+    bool compact_flat_block_tables{false};
 
     bool disable_prefix_cache{false};
     bool enable_mamba{false};

--- a/tokenspeed-scheduler/tests/cpp/flat_cache_test_access.h
+++ b/tokenspeed-scheduler/tests/cpp/flat_cache_test_access.h
@@ -37,6 +37,12 @@ struct KvCacheCoordinatorTestAccess {
     }
 
     static std::uint64_t NextAccessEpoch(KvCacheCoordinator& coordinator) { return ++coordinator.next_access_epoch_; }
+
+    static std::vector<CacheKey> KeysForGroup(const KvCacheCoordinator& coordinator,
+                                              std::span<const std::string> content_hashes, GroupId group_id,
+                                              std::int32_t first_base_slot = 0) {
+        return coordinator.keysForGroup(content_hashes, group_id, first_base_slot);
+    }
 };
 
 inline auto MatchPrefixForTest(KvCacheCoordinator& coordinator, std::span<const std::string> content_hashes) {

--- a/tokenspeed-scheduler/tests/cpp/test_flat_forward_operation.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_flat_forward_operation.cpp
@@ -66,6 +66,7 @@ TEST(FlatForwardOperation, EmptyOpsProducesEmpty) {
     EXPECT_EQ(flat_op.num_extends(), 0u);
     EXPECT_TRUE(flat_op.request_ids.empty());
     EXPECT_TRUE(flat_op.flat_block_tables.empty());
+    EXPECT_TRUE(flat_op.paged_cache_block_table_base_offsets.empty());
 }
 
 TEST(FlatForwardOperation, MultiRequestPadsRaggedRowsWithMinusOne) {
@@ -80,6 +81,7 @@ TEST(FlatForwardOperation, MultiRequestPadsRaggedRowsWithMinusOne) {
     ASSERT_EQ(full.size(), 2u);
     EXPECT_EQ(full.at(0), (std::vector<std::int32_t>{10, 11, 12}));
     EXPECT_EQ(full.at(1), (std::vector<std::int32_t>{20, -1, -1}));
+    EXPECT_TRUE(flat_op.paged_cache_block_table_base_offsets.empty());
 }
 
 // Flat contract: 0 = real null-block hole, -1 = absent (pad) column.
@@ -98,22 +100,25 @@ TEST(FlatForwardOperation, NullHoleZeroDistinctFromPadMinusOne) {
     EXPECT_EQ(swa.at(1).at(1), -1);
 }
 
-TEST(FlatForwardOperation, PrefillBeforeDecodeKeepsRowsAlignedWithRequests) {
+TEST(FlatForwardOperation, PrefillBeforeDecodeKeepsRowsAndOffsetsAligned) {
     std::vector<ForwardOperation> ops;
-    ops.emplace_back(MakeDecode("d", FlatTable{{"full", {20}}}, /*decode_input_id=*/99));
-    ops.emplace_back(MakePrefill("p", FlatTable{{"full", {10, 11}}}, /*input_ids=*/{7, 8}));
+    DecodeOperation decode = MakeDecode("d", FlatTable{{"full", {20}}, {"state", {30}}},
+                                        /*decode_input_id=*/99);
+    decode.paged_cache_page_base_offsets = {{"full", 0}, {"state", 7}};
+    PrefillOperation prefill = MakePrefill("p", FlatTable{{"full", {10, 11}}, {"state", {12}}}, /*input_ids=*/{7, 8});
+    prefill.paged_cache_page_base_offsets = {{"full", 0}, {"state", 3}};
+    ops.emplace_back(std::move(decode));
+    ops.emplace_back(std::move(prefill));
 
     FlatForwardOperation flat_op{std::move(ops)};
 
     ASSERT_EQ(flat_op.request_ids.size(), 2u);
     EXPECT_EQ(flat_op.request_ids.at(0), "p");
     EXPECT_EQ(flat_op.request_ids.at(1), "d");
-
-    const auto& full = flat_op.flat_block_tables.at("full");
-    ASSERT_EQ(full.size(), 2u);
-    EXPECT_EQ(full.at(0), (std::vector<std::int32_t>{10, 11}));
-    EXPECT_EQ(full.at(1), (std::vector<std::int32_t>{20, -1}));
-
+    EXPECT_EQ(flat_op.flat_block_tables.at("full").at(0), (std::vector<std::int32_t>{10, 11}));
+    EXPECT_EQ(flat_op.flat_block_tables.at("full").at(1), (std::vector<std::int32_t>{20, -1}));
+    EXPECT_EQ(flat_op.paged_cache_block_table_base_offsets.at("full"), (std::vector<std::int32_t>{0, 0}));
+    EXPECT_EQ(flat_op.paged_cache_block_table_base_offsets.at("state"), (std::vector<std::int32_t>{3, 7}));
     EXPECT_EQ(flat_op.num_extends(), 1u);
     EXPECT_EQ(flat_op.input_ids, (std::vector<std::int32_t>{7, 8}));
     EXPECT_EQ(flat_op.decode_input_ids, (std::vector<std::int32_t>{99}));
@@ -128,16 +133,15 @@ TEST(FlatForwardOperation, GroupKeyUnionAcrossRequestsPadsMissingGroup) {
 
     ASSERT_EQ(flat_op.flat_block_tables.count("full"), 1u);
     ASSERT_EQ(flat_op.flat_block_tables.count("swa"), 1u);
-
     const auto& full = flat_op.flat_block_tables.at("full");
     const auto& swa = flat_op.flat_block_tables.at("swa");
     ASSERT_EQ(full.size(), 2u);
     ASSERT_EQ(swa.size(), 2u);
-
     EXPECT_EQ(full.at(0), (std::vector<std::int32_t>{10, 11}));
     EXPECT_EQ(full.at(1), (std::vector<std::int32_t>{-1, -1}));
     EXPECT_EQ(swa.at(0), (std::vector<std::int32_t>{-1, -1, -1}));
     EXPECT_EQ(swa.at(1), (std::vector<std::int32_t>{20, 21, 22}));
+    EXPECT_TRUE(flat_op.paged_cache_block_table_base_offsets.empty());
 }
 
 TEST(FlatForwardOperation, ScalarFieldsTrackPerRequestRows) {

--- a/tokenspeed-scheduler/tests/cpp/test_flat_kvcache_lifecycle.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_flat_kvcache_lifecycle.cpp
@@ -69,6 +69,15 @@ protected:
     }
 };
 
+class CompactFlatKvCacheLifecycleTestSuite : public FlatKvCacheLifecycleTestSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        SchedulerConfig cfg = FlatKvCacheLifecycleTestSuite::MakeConfig();
+        cfg.compact_flat_block_tables = true;
+        return cfg;
+    }
+};
+
 TEST_F(FlatKvCacheLifecycleTestSuite, Construct_AndSubmit_Waiting) {
     Submit(MakeRequestSpec("r1", /*num_pages=*/2));
     EXPECT_EQ(scheduler_->WaitingSize(), 1u);
@@ -127,6 +136,37 @@ TEST_F(FlatKvCacheLifecycleTestSuite, SingleRequest_PrefillDecodeFinish) {
     PlanOnce();
     EXPECT_EQ(scheduler_->DecodingSize(), 0u);
     EXPECT_EQ(scheduler_->FlatPoolFreeBlocks(), free_at_start);
+}
+
+TEST_F(CompactFlatKvCacheLifecycleTestSuite, GroupKeyedRowsDoNotPublishLegacyScalarTable) {
+    Submit(MakeRequestSpec("r1", /*num_pages=*/2));
+    ExecutionPlan prefill_plan = PlanOnce();
+    const FlatForwardOperation* prefill = FindFlatOp(prefill_plan);
+    ASSERT_NE(prefill, nullptr);
+    ASSERT_EQ(prefill->occupied_pages.size(), 1u);
+    EXPECT_TRUE(prefill->occupied_pages.front().empty());
+    EXPECT_EQ(prefill->begins, std::vector<std::int32_t>{0});
+    EXPECT_EQ(prefill->sizes, std::vector<std::int32_t>{0});
+    EXPECT_EQ(prefill->paged_cache_block_table_base_offsets.at("full"), std::vector<std::int32_t>{0});
+    EXPECT_EQ(prefill->paged_cache_block_table_base_offsets.at("swa"), std::vector<std::int32_t>{0});
+
+    SendForwardDone("r1", {42});
+    std::optional<ExecutionPlan> last_plan;
+    for (std::int32_t token = 43; token < 47; ++token) {
+        last_plan = PlanOnce();
+        SendForwardDone("r1", {token});
+    }
+
+    const FlatForwardOperation* last_decode = FindFlatOp(*last_plan);
+    ASSERT_NE(last_decode, nullptr);
+    ASSERT_EQ(last_decode->occupied_pages.size(), 1u);
+    EXPECT_TRUE(last_decode->occupied_pages.front().empty());
+    EXPECT_EQ(last_decode->begins, std::vector<std::int32_t>{0});
+    EXPECT_EQ(last_decode->sizes, std::vector<std::int32_t>{0});
+    ASSERT_EQ(last_decode->flat_block_tables.at("swa").size(), 1u);
+    EXPECT_GT(last_decode->paged_cache_block_table_base_offsets.at("swa").front(), 0);
+    EXPECT_TRUE(std::ranges::all_of(last_decode->flat_block_tables.at("swa").front(),
+                                    [](std::int32_t page_id) { return page_id > 0; }));
 }
 
 // AvailableKvPages() must report the flat shared BlockPool, not the radix

--- a/tokenspeed-scheduler/tests/cpp/test_forward_cache_ops.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_forward_cache_ops.cpp
@@ -40,7 +40,7 @@ namespace {
 template <class T>
 concept HasLogicalBlockSize = requires(T value) { value.block_size; };
 
-static_assert(!HasLogicalBlockSize<KvCacheSpec>);
+static_assert(HasLogicalBlockSize<KvCacheSpec>);
 
 KvCacheCoordinator MakeTwoGroup(BlockPool& pool) {
     std::vector<KvCacheSpec> specs{
@@ -371,11 +371,56 @@ TEST(MakeSpecsFromConfigTest, TranslatesPagedCacheGroups) {
     std::vector<KvCacheSpec> specs = MakeSpecsFromConfig(config);
     ASSERT_EQ(specs.size(), 2u);
     EXPECT_EQ(specs[0].kind, AttnKind::kFull);
+    EXPECT_EQ(specs[0].block_size, 16);
     EXPECT_EQ(specs[0].sliding_window, 0);
     EXPECT_EQ(specs[0].cache_blocks_per_lcm_block, 1);
     EXPECT_EQ(specs[1].kind, AttnKind::kSlidingWindow);
+    EXPECT_EQ(specs[1].block_size, 16);
     EXPECT_EQ(specs[1].sliding_window, 128);
     EXPECT_EQ(specs[1].cache_blocks_per_lcm_block, 1);
+}
+
+TEST(MakeSpecsFromConfigTest, PreservesHeterogeneousGroupBlockSpansAboveBaseGrain) {
+    SchedulerConfig config;
+    config.block_size = 4;
+    PagedCacheGroupConfig state;
+    state.group_id = "state";
+    state.rows_per_page = 8;
+    state.entry_stride_tokens = 1;
+    state.block_size = 8;
+    state.retention = PagedCacheGroupConfig::Retention::SlidingWindow;
+    state.sliding_window_tokens = 16;
+    state.family = PagedCacheGroupFamily::State;
+    PagedCacheGroupConfig history;
+    history.group_id = "history";
+    history.rows_per_page = 64;
+    history.entry_stride_tokens = 4;
+    history.block_size = 256;
+    config.paged_cache_groups = {state, history};
+
+    const std::vector<KvCacheSpec> specs = MakeSpecsFromConfig(config);
+
+    ASSERT_EQ(specs.size(), 2u);
+    EXPECT_EQ(specs[0].block_size, 8);
+    EXPECT_EQ(specs[0].kind, AttnKind::kSlidingWindow);
+    EXPECT_EQ(specs[1].block_size, 256);
+    EXPECT_EQ(specs[1].kind, AttnKind::kFull);
+}
+
+TEST(MakeSpecsFromConfigTest, RejectsGroupSpanOffBaseGridOrRawPageGeometry) {
+    SchedulerConfig config;
+    config.block_size = 4;
+    PagedCacheGroupConfig group;
+    group.group_id = "bad";
+    group.block_size = 10;
+    config.paged_cache_groups = {group};
+    EXPECT_THROW(MakeSpecsFromConfig(config), std::runtime_error);
+
+    group.block_size = 8;
+    group.rows_per_page = 4;
+    group.entry_stride_tokens = 4;
+    config.paged_cache_groups = {group};
+    EXPECT_THROW(MakeSpecsFromConfig(config), std::runtime_error);
 }
 
 TEST(MakeSpecsFromConfigTest, StateFamilyMapsToMambaStateKind) {
@@ -491,129 +536,70 @@ TEST(MakeSpecsFromConfigTest, PagedCacheGroupConfigRejectsNonPositivePacking) {
     EXPECT_THROW(group.Validate(), std::invalid_argument);
 }
 
-TEST(MakeSpecsFromConfigTest, RejectsLegacyPerGroupLogicalPThatDiffersFromGlobalP) {
+TEST(MakeSpecsFromConfigTest, AcceptsGroupLogicalSpanThatIsAMultipleOfBaseGrain) {
     SchedulerConfig config;
     config.block_size = 128;
     config.paged_cache_groups.resize(1);
     config.paged_cache_groups[0].block_size = 1024;
-    EXPECT_THROW(MakeSpecsFromConfig(config), std::runtime_error);
+    const std::vector<KvCacheSpec> specs = MakeSpecsFromConfig(config);
+    ASSERT_EQ(specs.size(), 1u);
+    EXPECT_EQ(specs[0].block_size, 1024);
 }
 
-TEST(ForwardCacheOpsBuildFlatBlockTables, TwoGroupsRowsAndIds) {
-    BlockPool pool(/*num_lcm_blocks=*/32);
-    KvCacheCoordinator coordinator = MakeTwoGroup(pool);
-    std::vector<BlockTable> tables(coordinator.NumGroups());
-    // 6 tokens, block_size 2 -> 3 pages per group.
-    ASSERT_TRUE(AdmitForTest(coordinator, tables, /*num_tokens=*/6));
-
-    std::vector<std::string> group_ids{"full", "swa"};
-    auto built = BuildFlatBlockTables(coordinator, tables, group_ids);
-
-    ASSERT_EQ(built.size(), 2u);
-    ASSERT_TRUE(built.count("full"));
-    ASSERT_TRUE(built.count("swa"));
-    EXPECT_EQ(built.at("full").size(), 3u);
-    EXPECT_EQ(built.at("swa").size(), 3u);
-    for (std::int32_t id : built.at("full")) {
-        EXPECT_GT(id, 0);
-    }
-    // Rows match the source span verbatim: no compaction, null hole = 0 in its slot.
-    const std::vector<std::int32_t> expected_full = coordinator.GroupManager(0).BlockTablePageIds(tables[0]);
-    const std::vector<std::int32_t> expected_swa = coordinator.GroupManager(1).BlockTablePageIds(tables[1]);
-    EXPECT_EQ(built.at("full"), expected_full);
-    EXPECT_EQ(built.at("swa"), expected_swa);
-}
-
-TEST(ForwardCacheOpsBuildFlatBlockTables, SwaRowGetsNullHoleAfterAdvance) {
-    BlockPool pool(/*num_lcm_blocks=*/32);
-    KvCacheCoordinator coordinator = MakeTwoGroup(pool);
-    std::vector<BlockTable> tables(coordinator.NumGroups());
-    // Window = 4 tokens = 2 pages, so 8 tokens leave earlier pages out of window.
-    ASSERT_TRUE(AdmitForTest(coordinator, tables, /*num_tokens=*/8));  // 4 pages/group
-    for (std::int32_t g = 0; g < coordinator.NumGroups(); ++g) {
-        coordinator.GroupManager(g).ReclaimExpired(pool, tables[static_cast<std::size_t>(g)],
-                                                   /*num_computed_tokens=*/8);
-    }
-
-    std::vector<std::string> group_ids{"full", "swa"};
-    auto built = BuildFlatBlockTables(coordinator, tables, group_ids);
-    for (std::int32_t id : built.at("full")) {
-        EXPECT_GT(id, 0);
-    }
-    const auto& swa = built.at("swa");
-    EXPECT_NE(std::find(swa.begin(), swa.end(), 0), swa.end());
-    const std::vector<std::int32_t> expected_swa = coordinator.GroupManager(1).BlockTablePageIds(tables[1]);
-    EXPECT_EQ(swa, expected_swa);
-}
-
-TEST(ForwardCacheOpsBuildFlatBlockTables, FreshTablesProduceEmptyRows) {
-    BlockPool pool(/*num_lcm_blocks=*/32);
-    KvCacheCoordinator coordinator = MakeTwoGroup(pool);
-    std::vector<BlockTable> tables(coordinator.NumGroups());
-
-    std::vector<std::string> group_ids{"full", "swa"};
-    auto built = BuildFlatBlockTables(coordinator, tables, group_ids);
-
-    ASSERT_EQ(built.size(), 2u);
-    EXPECT_TRUE(built.at("full").empty());
-    EXPECT_TRUE(built.at("swa").empty());
-}
-
-TEST(ForwardCacheOpsBuildFlatBlockTables, SingleGroupRowMatchesSource) {
-    BlockPool pool(/*num_lcm_blocks=*/32);
-    std::vector<KvCacheSpec> specs{
-        KvCacheSpec{.kind = AttnKind::kFull, .sliding_window = 0, .cache_blocks_per_lcm_block = 1},
-    };
-    KvCacheCoordinator coordinator = MakeCoordinator(specs, 2, pool);
-    std::vector<BlockTable> tables(coordinator.NumGroups());
-    ASSERT_TRUE(AdmitForTest(coordinator, tables, /*num_tokens=*/4));  // 2 pages
-
-    std::vector<std::string> group_ids{"only"};
-    auto built = BuildFlatBlockTables(coordinator, tables, group_ids);
-
-    ASSERT_EQ(built.size(), 1u);
-    const std::vector<std::int32_t> expected = coordinator.GroupManager(0).BlockTablePageIds(tables[0]);
-    EXPECT_EQ(built.at("only"), expected);
-    // Sanity: keyed by the supplied group_id, not a bare index.
-    EXPECT_EQ(built.count("0"), 0u);
-}
-
-TEST(ForwardCacheOpsBuildFlatBlockTables, KeyMatchesSuppliedGroupIdStrings) {
-    BlockPool pool(/*num_lcm_blocks=*/32);
-    KvCacheCoordinator coordinator = MakeTwoGroup(pool);
-    std::vector<BlockTable> tables(coordinator.NumGroups());
-    ASSERT_TRUE(AdmitForTest(coordinator, tables, /*num_tokens=*/4));
-
-    std::vector<std::string> group_ids{"alpha", "beta"};
-    auto built = BuildFlatBlockTables(coordinator, tables, group_ids);
-
-    ASSERT_EQ(built.size(), 2u);
-    EXPECT_TRUE(built.count("alpha"));
-    EXPECT_TRUE(built.count("beta"));
-    const std::vector<std::int32_t> expected_alpha = coordinator.GroupManager(0).BlockTablePageIds(tables[0]);
-    EXPECT_EQ(built.at("alpha"), expected_alpha);
-}
-
-TEST(ForwardCacheOpsBuildFlatBlockTables, ChildSlotsWithinOneParentHaveDistinctKernelPageIds) {
-    BlockPool pool(/*num_lcm_blocks=*/4);
+TEST(ForwardCacheOpsBuildFlatBlockTableRows, CapabilityControlsHeterogeneousLongHoleCompaction) {
+    BlockPool pool(/*num_lcm_blocks=*/256);
     const std::vector<KvCacheSpec> specs{
-        {.kind = AttnKind::kFull, .sliding_window = 0, .cache_blocks_per_lcm_block = 2},
+        {.kind = AttnKind::kFull, .block_size = 2, .sliding_window = 0, .cache_blocks_per_lcm_block = 1},
+        {.kind = AttnKind::kSlidingWindow, .block_size = 4, .sliding_window = 4, .cache_blocks_per_lcm_block = 1},
     };
     KvCacheCoordinator coordinator = MakeCoordinator(specs, /*cache_block_tokens=*/2, pool);
     std::vector<BlockTable> tables(coordinator.NumGroups());
-    ASSERT_TRUE(AdmitForTest(coordinator, tables, /*num_tokens=*/4));
+    ASSERT_TRUE(AdmitForTest(coordinator, tables, /*num_tokens=*/260));
+    coordinator.ReclaimExpired(tables, /*num_computed_tokens=*/260);
+    ASSERT_EQ(tables[0].NumBlocks(), 130);
+    ASSERT_EQ(tables[1].NumBlocks(), 65);
+    ASSERT_FALSE(tables[1].Blocks()[0]);
+    ASSERT_FALSE(tables[1].Blocks()[1]);
+    ASSERT_EQ(tables[1].FirstLiveBlock(), 64);
 
-    const std::vector<std::int32_t> parent_ids = BlockTableLcmBlockIds(tables[0]);
-    ASSERT_EQ(parent_ids.size(), 2u);
-    EXPECT_EQ(parent_ids[0], parent_ids[1]);
-
-    const auto built = BuildFlatBlockTables(coordinator, tables, std::vector<std::string>{"full"});
-    ASSERT_EQ(built.at("full").size(), 2u);
-    EXPECT_EQ(built.at("full"), (std::vector<std::int32_t>{1, 2}));
-    EXPECT_NE(built.at("full"), parent_ids);
+    const std::vector<std::string> group_ids{"full", "swa"};
+    struct Case {
+        bool compact;
+        std::int32_t expected_base;
+        std::size_t expected_columns;
+    };
+    for (const Case test_case : {Case{false, 0, 65}, Case{true, 64, 1}}) {
+        const FlatBlockTableRows built = BuildFlatBlockTableRows(coordinator, tables, group_ids, test_case.compact);
+        SCOPED_TRACE(test_case.compact ? "capability enabled" : "capability disabled");
+        EXPECT_EQ(built.tables.size(), group_ids.size());
+        EXPECT_EQ(built.tables.at("full"), coordinator.GroupManager(0).BlockTablePageIds(tables[0]));
+        ASSERT_EQ(built.tables.at("swa").size(), test_case.expected_columns);
+        if (test_case.compact) {
+            EXPECT_EQ(built.base_offsets.size(), built.tables.size());
+            EXPECT_EQ(built.base_offsets.at("full"), 0);
+            EXPECT_EQ(built.base_offsets.at("swa"), test_case.expected_base);
+            EXPECT_TRUE(std::ranges::all_of(built.tables.at("swa"), [](std::int32_t page_id) { return page_id > 0; }));
+        } else {
+            EXPECT_TRUE(built.base_offsets.empty());
+            EXPECT_EQ(built.tables.at("swa"), coordinator.GroupManager(1).BlockTablePageIds(tables[1]));
+        }
+    }
 }
 
-TEST(ForwardCacheOpsBuildFlatBlockTables, ResolvesEachGroupsPackingRecipe) {
+TEST(ForwardCacheOpsBuildFlatBlockTableRows, FreshTablesProduceExactEmptyKeys) {
+    BlockPool pool(/*num_lcm_blocks=*/32);
+    KvCacheCoordinator coordinator = MakeTwoGroup(pool);
+    std::vector<BlockTable> tables(coordinator.NumGroups());
+
+    const std::vector<std::string> group_ids{"alpha", "beta"};
+    const FlatBlockTableRows built =
+        BuildFlatBlockTableRows(coordinator, tables, group_ids, /*compact_flat_block_tables=*/false);
+
+    EXPECT_EQ(built.tables, (std::map<std::string, std::vector<std::int32_t>>{{"alpha", {}}, {"beta", {}}}));
+    EXPECT_TRUE(built.base_offsets.empty());
+}
+
+TEST(ForwardCacheOpsBuildFlatBlockTableRows, ResolvesEachGroupsPackingRecipe) {
     BlockPool pool(/*num_lcm_blocks=*/16);
     const std::vector<KvCacheSpec> specs{
         {.kind = AttnKind::kFull, .sliding_window = 0, .cache_blocks_per_lcm_block = 2},
@@ -624,16 +610,17 @@ TEST(ForwardCacheOpsBuildFlatBlockTables, ResolvesEachGroupsPackingRecipe) {
     ASSERT_TRUE(AdmitForTest(coordinator, tables, /*num_tokens=*/4));
 
     const std::vector<std::string> group_ids{"packed", "single"};
-    const auto built = BuildFlatBlockTables(coordinator, tables, group_ids);
+    const FlatBlockTableRows built =
+        BuildFlatBlockTableRows(coordinator, tables, group_ids, /*compact_flat_block_tables=*/false);
 
     ASSERT_EQ(tables[0].NumBlocks(), 2);
     ASSERT_EQ(tables[1].NumBlocks(), 2);
-    EXPECT_EQ(built.at("packed"),
+    EXPECT_EQ(built.tables.at("packed"),
               (std::vector<std::int32_t>{
                   coordinator.GroupManager(0).ResolveKernelPageId(tables[0].Blocks()[0]->Location()),
                   coordinator.GroupManager(0).ResolveKernelPageId(tables[0].Blocks()[1]->Location()),
               }));
-    EXPECT_EQ(built.at("single"),
+    EXPECT_EQ(built.tables.at("single"),
               (std::vector<std::int32_t>{
                   coordinator.GroupManager(1).ResolveKernelPageId(tables[1].Blocks()[0]->Location()),
                   coordinator.GroupManager(1).ResolveKernelPageId(tables[1].Blocks()[1]->Location()),

--- a/tokenspeed-scheduler/tests/cpp/test_kv_cache_coordinator.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_kv_cache_coordinator.cpp
@@ -73,6 +73,35 @@ CacheKey Key(const std::string& content_hash, GroupId group_id) {
     return CacheKey{.group_id = group_id, .content_hash = content_hash};
 }
 
+std::vector<KvCacheSpec> V4HeterogeneousSpecs() {
+    return {
+        {.kind = AttnKind::kSlidingWindow, .block_size = 64, .sliding_window = 128, .cache_blocks_per_lcm_block = 1},
+        {.kind = AttnKind::kSlidingWindow, .block_size = 4, .sliding_window = 8, .cache_blocks_per_lcm_block = 19},
+        {.kind = AttnKind::kSlidingWindow, .block_size = 8, .sliding_window = 16, .cache_blocks_per_lcm_block = 2},
+        {.kind = AttnKind::kFull, .block_size = 256, .sliding_window = 0, .cache_blocks_per_lcm_block = 70},
+    };
+}
+
+std::vector<std::string> BaseHashes(std::int32_t count) {
+    std::vector<std::string> hashes;
+    hashes.reserve(static_cast<std::size_t>(count));
+    for (std::int32_t i = 0; i < count; ++i) {
+        hashes.push_back("base-" + std::to_string(i));
+    }
+    return hashes;
+}
+
+std::vector<std::string> GroupContentHashes(const KvCacheCoordinator& coordinator,
+                                            std::span<const std::string> base_hashes, GroupId group_id) {
+    const std::vector<CacheKey> keys = KvCacheCoordinatorTestAccess::KeysForGroup(coordinator, base_hashes, group_id);
+    std::vector<std::string> hashes;
+    hashes.reserve(keys.size());
+    for (const CacheKey& key : keys) {
+        hashes.push_back(key.content_hash);
+    }
+    return hashes;
+}
+
 // Cache then free, so the block is prefix-hittable via MatchPrefix.
 std::int32_t CacheForGroup(KvCacheCoordinator& coordinator, BlockPool& pool, const std::string& content_hash,
                            std::uint32_t group_id) {
@@ -160,6 +189,91 @@ TEST(MakeCoordinatorTest, Qwen35UsesUniformLogicalPWithDifferentPacking) {
     for (const PrefixMatch& group_match : match.per_group) {
         EXPECT_EQ(group_match.blocks.size(), 1u);
     }
+}
+
+TEST(MakeCoordinatorTest, HeterogeneousGroupsProjectBaseHashesAndSlotsOnTheirOwnGrid) {
+    BlockPool pool(/*num_lcm_blocks=*/32);
+    const std::vector<KvCacheSpec> specs = V4HeterogeneousSpecs();
+    KvCacheCoordinator coordinator = MakeCoordinator(specs, /*cache_block_tokens=*/4, pool);
+
+    EXPECT_EQ(coordinator.CacheBlockTokens(), 4);
+    EXPECT_EQ(coordinator.PrefixAlignmentTokens(), 256);
+    EXPECT_EQ(coordinator.GroupManager(0).CacheBlockTokens(), 64);
+    EXPECT_EQ(coordinator.GroupManager(1).CacheBlockTokens(), 4);
+    EXPECT_EQ(coordinator.GroupManager(2).CacheBlockTokens(), 8);
+    EXPECT_EQ(coordinator.GroupManager(3).CacheBlockTokens(), 256);
+
+    std::vector<BlockTable> tables(coordinator.NumGroups());
+    ASSERT_TRUE(AdmitForTest(coordinator, tables, /*num_tokens=*/256));
+    EXPECT_EQ(tables[0].NumBlocks(), 4);
+    EXPECT_EQ(tables[1].NumBlocks(), 64);
+    EXPECT_EQ(tables[2].NumBlocks(), 32);
+    EXPECT_EQ(tables[3].NumBlocks(), 1);
+
+    const std::vector<std::string> hashes = BaseHashes(/*count=*/64);
+    CacheFullBlocksForTest(coordinator, tables, hashes);
+    for (std::size_t group = 0; group < specs.size(); ++group) {
+        const std::vector<std::string> folded = GroupContentHashes(coordinator, hashes, static_cast<GroupId>(group));
+        ASSERT_EQ(folded.size(), static_cast<std::size_t>(tables[group].NumBlocks()));
+        EXPECT_TRUE(coordinator.GroupManager(static_cast<std::int32_t>(group))
+                        .ContainsCachedBlock(pool, Key(folded.back(), static_cast<GroupId>(group))));
+    }
+    coordinator.Free(tables);
+
+    const KvCacheCoordinator::PrefixProbe probe = coordinator.ProbePrefix(hashes);
+    EXPECT_EQ(probe.device.num_common_tokens, 256);
+    ASSERT_EQ(probe.device.per_group.size(), specs.size());
+    EXPECT_EQ(probe.device.per_group[0].hits.size(), 4u);
+    EXPECT_EQ(probe.device.per_group[1].hits.size(), 64u);
+    EXPECT_EQ(probe.device.per_group[2].hits.size(), 32u);
+    EXPECT_EQ(probe.device.per_group[3].hits.size(), 1u);
+}
+
+TEST(KvCacheCoordinatorTest, ContinuationMissConvergesAtSharedRawTokenBoundary) {
+    BlockPool pool(/*num_lcm_blocks=*/8);
+    const std::vector<KvCacheSpec> specs = V4HeterogeneousSpecs();
+    KvCacheCoordinator coordinator = MakeCoordinator(specs, /*cache_block_tokens=*/4, pool);
+    const std::vector<std::string> hashes = BaseHashes(/*count=*/64);
+    std::array<std::vector<std::string>, 4> folded{
+        GroupContentHashes(coordinator, hashes, /*group_id=*/0),
+        GroupContentHashes(coordinator, hashes, /*group_id=*/1),
+        GroupContentHashes(coordinator, hashes, /*group_id=*/2),
+        GroupContentHashes(coordinator, hashes, /*group_id=*/3),
+    };
+
+    CacheForGroup(coordinator, pool, folded[0][2], /*group_id=*/0);
+    CacheForGroup(coordinator, pool, folded[0][3], /*group_id=*/0);
+    CacheForGroup(coordinator, pool, folded[1][62], /*group_id=*/1);
+    CacheForGroup(coordinator, pool, folded[1][63], /*group_id=*/1);
+    CacheForGroup(coordinator, pool, folded[2][29], /*group_id=*/2);
+    CacheForGroup(coordinator, pool, folded[2][30], /*group_id=*/2);
+    CacheForGroup(coordinator, pool, folded[3][0], /*group_id=*/3);
+
+    EXPECT_EQ(coordinator.ProbePrefix(hashes).device.num_common_tokens, 0);
+
+    CacheForGroup(coordinator, pool, folded[2][31], /*group_id=*/2);
+    EXPECT_EQ(coordinator.ProbePrefix(hashes).device.num_common_tokens, 256);
+}
+
+TEST(KvCacheCoordinatorTest, UnalignedNewBaseSlicePublishesNextCompletedGroupBlockOnce) {
+    BlockPool pool(/*num_lcm_blocks=*/2);
+    const std::vector<KvCacheSpec> specs{
+        {.kind = AttnKind::kFull, .block_size = 256, .sliding_window = 0, .cache_blocks_per_lcm_block = 1},
+    };
+    KvCacheCoordinator coordinator = MakeCoordinator(specs, /*cache_block_tokens=*/4, pool);
+    std::vector<BlockTable> tables(coordinator.NumGroups());
+    ASSERT_TRUE(AdmitForTest(coordinator, tables, /*num_tokens=*/256));
+    const std::vector<std::string> hashes = BaseHashes(/*count=*/64);
+    std::vector<GroupDemand> demands{{
+        .table = &tables[0],
+        .page_hashes = hashes,
+        .first_new_page_slot = 62,
+    }};
+
+    ASSERT_TRUE(coordinator.Admit(coordinator.ProbePrefix({}), demands));
+    EXPECT_EQ(coordinator.GroupManager(0).NumCachedBlocks(pool), 1);
+    EXPECT_TRUE(coordinator.GroupManager(0).ContainsCachedBlock(pool, Key(hashes[63], /*group_id=*/0)));
+    coordinator.Free(tables);
 }
 
 TEST(MakeCoordinatorTest, RejectsNonPositiveLogicalPOrPacking) {

--- a/tokenspeed-scheduler/tests/cpp/test_swa_manager.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_swa_manager.cpp
@@ -20,6 +20,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <optional>
 #include <span>
 #include <string>
@@ -78,6 +79,14 @@ std::int32_t CacheOnePage(SwaManager& manager, BlockPool& pool, const CacheKey& 
     manager.RegisterCachedBlock(pool, got, key);
     got.reset();
     return id;
+}
+
+void ExpectFirstLiveBlockInvariant(const BlockTable& table, std::int32_t expected) {
+    const std::span<const CacheBlockRef> blocks = table.Blocks();
+    const auto first_live =
+        std::find_if(blocks.begin(), blocks.end(), [](const CacheBlockRef& block) { return static_cast<bool>(block); });
+    EXPECT_EQ(table.FirstLiveBlock(), expected);
+    EXPECT_EQ(table.FirstLiveBlock(), static_cast<std::int32_t>(first_live - blocks.begin()));
 }
 
 TEST(SwaManagerTest, ConstructsWithWindow) {
@@ -347,6 +356,56 @@ TEST(BlockTableTest, EvictToNullIsIdempotentOnNullSlot) {
     CacheBlockRef again = table.EvictToNull(0);
     EXPECT_FALSE(again);  // empty on already-null
     EXPECT_FALSE(table.Blocks()[0]);
+}
+
+TEST(BlockTableTest, FirstLiveBlockTracksEveryLivenessMutation) {
+    BlockPool device_pool(/*num_lcm_blocks=*/512);
+    BlockPool host_pool(/*num_lcm_blocks=*/128);
+    SwaManager mgr(/*block_size=*/4, /*sliding_window=*/4);
+    BlockTable table;
+    ExpectFirstLiveBlockInvariant(table, 0);
+
+    ASSERT_TRUE(mgr.Acquire(device_pool, table, /*num_tokens=*/160));
+    ExpectFirstLiveBlockInvariant(table, 0);
+
+    mgr.ReclaimExpired(device_pool, table, /*num_computed_tokens=*/160);
+    ExpectFirstLiveBlockInvariant(table, 39);
+    mgr.ReclaimExpired(device_pool, table, /*num_computed_tokens=*/1000);
+    ExpectFirstLiveBlockInvariant(table, 40);
+    ASSERT_TRUE(mgr.Acquire(device_pool, table, /*num_tokens=*/4));
+    ExpectFirstLiveBlockInvariant(table, 40);
+
+    mgr.Free(table);
+    ExpectFirstLiveBlockInvariant(table, 0);
+
+    PrefixMatch hit;
+    hit.blocks.resize(129);
+    std::vector<CacheBlockRef> hit_blocks =
+        device_pool.AcquireBlocks(/*group_id=*/0, /*cache_blocks_per_lcm_block=*/1, /*num=*/2);
+    ASSERT_EQ(hit_blocks.size(), 2u);
+    hit.blocks[64] = std::move(hit_blocks[0]);
+    hit.blocks[128] = std::move(hit_blocks[1]);
+    mgr.ClaimHitBlocks(table, std::move(hit));
+    ExpectFirstLiveBlockInvariant(table, 64);
+
+    mgr.Free(table);
+    GroupDemand sparse{
+        .table = &table,
+        .num_tokens = 520,
+        .materialized_suffix_start = 128,
+    };
+    ASSERT_TRUE(mgr.Acquire(device_pool, table, sparse));
+    ExpectFirstLiveBlockInvariant(table, 128);
+
+    mgr.Free(table);
+    std::vector<CacheBlockRef> host_blocks(65);
+    host_blocks.back() = host_pool.AcquireBlock(/*group_id=*/0, /*cache_blocks_per_lcm_block=*/1);
+    std::vector<BlockTransfer> transfers;
+    mgr.AppendHostExtension(device_pool, table, std::move(host_blocks), transfers);
+    ExpectFirstLiveBlockInvariant(table, 64);
+
+    mgr.Free(table);
+    ExpectFirstLiveBlockInvariant(table, 0);
 }
 
 TEST(SwaManagerTest, ReclaimExpiredMirrorsVllmBoundarySequence) {


### PR DESCRIPTION
## Summary

Migrate DeepSeek V4 L1/device KV cache management to heterogeneous flat block pools while preserving the radix path as a compatibility and differential oracle.

The new design makes the cache plan the single authority for group geometry, physical pools, target/draft ownership, table layout, and device metadata. Model-agnostic runtime components consume only generic cache capabilities and table/lifecycle interfaces.

## Key Changes

- Added canonical V4 Flat KV memory planning for heterogeneous groups and target/draft union.
- Added atomic multi-pool allocation, prefix reuse, reclaim, retract, and release through `BlockPoolSet` and `KvCacheCoordinator`.
- Replaced the general structured-completion mechanism with a request-owned fixed FIFO that publishes accepted cache only after the GPU fence retires.
- Bound Flat/Radix table sources at initialization and refreshed grouped tables correctly for eager and CUDA Graph execution.
- Preserved MTP rewind, terminal deferred release, stale-generation rejection, and sleep/wake repair.
- Removed duplicate validation, dead abstractions, hot-path snapshot allocation, and redundant tests.
- Documented the final architecture and B200 validation procedure in [the migration design](docs/serving/deepseek-v4-flat-kv-cache-migration.md).

## Scope

This PR covers device-side/L1 KV cache management only. It does not add L2/CPU offload, kvstore integration, group-aware PD transfer, or global radix removal.