### PR TITLE
feat(m3): support Eagle3.1 draft checkpoints

### DIFF
--- a/python/tokenspeed/runtime/models/llama_eagle3.py
+++ b/python/tokenspeed/runtime/models/llama_eagle3.py
@@ -446,6 +446,17 @@ class Eagle3LlamaModel(BaseTransformerModel):
             if getattr(config, "norm_before_fc", False)
             else None
         )
+        self.fc_norm = (
+            nn.ModuleList(
+                [
+                    RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+                    for _ in range(self.num_fc_input_dim)
+                ]
+            )
+            if getattr(config, "fc_norm", False)
+            else None
+        )
+        self.norm_output = getattr(config, "norm_output", False)
 
     def forward(
         self,
@@ -478,6 +489,15 @@ class Eagle3LlamaModel(BaseTransformerModel):
         if hidden_states.size(-1) != embeds.size(-1):
             if self.input_norm is not None:
                 hidden_states = self.input_norm(hidden_states)
+            if self.fc_norm is not None:
+                chunks = hidden_states.chunk(self.num_fc_input_dim, dim=-1)
+                hidden_states = torch.cat(
+                    [
+                        norm(chunk)
+                        for norm, chunk in zip(self.fc_norm, chunks, strict=True)
+                    ],
+                    dim=-1,
+                )
             hidden_states, _ = self.fc(hidden_states)
 
         residual = None
@@ -507,6 +527,9 @@ class Eagle3LlamaModel(BaseTransformerModel):
             hidden_states_to_aux, _ = midlayer.comm_manager.post_final_norm_comm(
                 hidden_states_to_aux, None, ctx
             )
+
+        if self.norm_output:
+            hidden_states_to_aux = hidden_states_to_logits
 
         return hidden_states_to_logits, [hidden_states_to_aux]
 


### PR DESCRIPTION
## Summary

- support per-hidden-state `fc_norm` for Llama-style Eagle3.1 draft checkpoints
- feed post-norm hidden states into the next draft step when `norm_output` is enabled
- preserve existing Eagle3 behavior when either option is absent

This enables the vLLM/TorchSpec-trained `Inferact/MiniMax-M3-EAGLE3` checkpoint without adding MiniMax-specific model code.

## ShareGPT validation

Configuration: 4 x NVIDIA B200, TP=4, 100 ShareGPT prompts, fixed 128-token output, concurrency 4, greedy decoding, and EOS ignored.

| Metric | Result |
| --- | ---: |
| Successful requests | 100 / 100 |
| Input tokens | 50,581 |
| Output tokens | 12,800 |
| Benchmark duration | 214.63 s |
| Output throughput | 59.64 tok/s |
| Total throughput | 295.30 tok/s |
| Mean TTFT | 557.97 ms |
| Mean TPOT | 62.25 ms |
| Global weighted accept length | 2.73 tokens/verify |
| Accepted draft length | 1.73 / 4 tokens |
| Global draft-token acceptance rate | 43.18% |
| Per-request mean accept length | 2.76 tokens/verify |
| Per-request mean acceptance rate | 44.08% |

The global rate is weighted across verifier steps: 8,043 accepted draft tokens out of 18,628 proposed tokens.

## Server command

```bash
CUDA_VISIBLE_DEVICES=4,5,6,7 tokenspeed serve MiniMaxAI/MiniMax-M3-MXFP8 \
  --language-model-only \
  --tensor-parallel-size 4 \
  --max-model-len 8192 \
  --max-total-tokens 8192 \
  --max-num-seqs 4 \
  --max-prefill-tokens 2048 \
  --chunked-prefill-size 2048 \
  --gpu-memory-utilization 0.90 \
  --block-size 128 \
  --attention-backend trtllm \
  --drafter-attention-backend fa4 \
  --moe-backend triton \
  --disable-kvstore \
  --speculative-algorithm EAGLE3 \
  --speculative-draft-model-path Inferact/MiniMax-M3-EAGLE3 \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --enforce-eager \
  --skip-server-warmup \
  --enable-log-request-stats \
  --host 127.0.0.1 \
  --port 18080 \
  --control-port 18081 \
  --engine-startup-timeout 1200
```

## Benchmark command

```bash
tokenspeed bench serve \
  --backend openai \
  --host 127.0.0.1 \
  --port 18080 \
  --endpoint /v1/completions \
  --model MiniMaxAI/MiniMax-M3-MXFP8 \
  --tokenizer MiniMaxAI/MiniMax-M3-MXFP8 \
  --dataset-name sharegpt \
  --num-prompts 100 \
  --sharegpt-output-len 128 \
  --max-model-len 8192 \
  --max-concurrency 4 \
  --request-rate inf \
  --num-warmups 0 \
  --ignore-eos \
  --apply-chat-template \
  --extra-body '{"temperature": 0}'
```

## Checks

- `pre-commit run --all-files`