### PR TITLE
Support MiniMax M3 CPU KVStore

### DIFF
--- a/docs/recipes/models.md
+++ b/docs/recipes/models.md
@@ -68,8 +68,8 @@ ts serve \
 ## MiniMax M3
 
 MiniMax M3 uses 128-token MSA blocks. TokenSpeed configures its dense and sparse
-attention layers automatically; select the dense backend with
-`--attention-backend` and run with `--disable-kvstore`.
+attention layers automatically. The flat scheduler build also supports CPU
+KVStore; select the dense backend with `--attention-backend`.
 
 ```bash
 tokenspeed serve nvidia/MiniMax-M3-NVFP4 \
@@ -83,7 +83,6 @@ tokenspeed serve nvidia/MiniMax-M3-NVFP4 \
     --attention-backend trtllm \
     --moe-backend flashinfer_trtllm \
     --disable-prefill-graph \
-    --disable-kvstore \
     --block-size 128 \
     --trust-remote-code \
     --host 0.0.0.0 \

--- a/python/tokenspeed/runtime/cache/executor/flat_memory_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/flat_memory_executor.py
@@ -144,20 +144,6 @@ class FlatMemoryExecutor:
         # the same wait_until(layer_id) machinery.
         self._counter = LayerDoneCounter(self.layer_num)
         device_pool.register_layer_transfer_counter(self._counter)
-        # _start_loading maps layer -> mirror V-tensor event and relies on
-        # load_events[-1] (LayerLoadingEvent.finish_event, reuse fence in
-        # update_producer) covering EVERY copy: it pins the last layer to
-        # the op's last per-tensor event, which without state slabs is the
-        # last layer's V event only if that V mirror is the last KV tensor
-        # pair. Holds for both layouts (legacy: identity; slab: last layer
-        # is the last occurrence of its group). A state last layer has no
-        # KV mirror at all -- its copies (state slabs trail every KV
-        # tensor) are covered by the events[-1] pin in _start_loading.
-        assert (
-            self.mirror.state_tensor_indices_of_layer(self.layer_num - 1) is not None
-            or self.mirror.tensor_index_of_layer(self.layer_num - 1)
-            == self.mirror.num_k_tensors - 1
-        ), "flat host tier: last layer's V mirror is not the last KV tensor pair"
 
         write_priority, load_priority = _cache_stream_priorities()
         self.write_stream = _new_cache_stream(write_priority)
@@ -307,28 +293,17 @@ class FlatMemoryExecutor:
         producer_event.start_event.wait(self.load_stream)
 
         events = self.mirror.load_pages_with_events(pairs, self.load_stream)
-        # Layer fence: layer L is readable once its V mirror copy lands; the
-        # load stream is serial (all K copies precede all V copies), so the
-        # V-tensor event also covers L's K copy. Paired slab layers share the
-        # slab event -- correct by design. State layers instead fence on
-        # their ssm event: conv precedes ssm in tensor_pairs order (and both
-        # follow every KV tensor), so on the serial stream the ssm event
-        # covers the conv copy and the layer's KV copies -- the same
-        # K-before-V reasoning as above.
-        num_k = self.mirror.num_k_tensors
+        # The serial load stream orders K, V, auxiliary pages, then state
+        # slabs. Each layer fences on the last tensor it needs, so dense
+        # layers can start after V while layers with auxiliary or recurrent
+        # state wait for those copies as well.
         for layer_id in range(self.layer_num):
-            state_indices = self.mirror.state_tensor_indices_of_layer(layer_id)
-            if state_indices is not None:
-                producer_event.load_events[layer_id] = events[state_indices[1]]
-            else:
-                producer_event.load_events[layer_id] = events[
-                    num_k + self.mirror.tensor_index_of_layer(layer_id)
-                ]
+            tensor_index = self.mirror.completion_tensor_index_of_layer(layer_id)
+            producer_event.load_events[layer_id] = events[tensor_index]
         # finish_event (== load_events[-1]) is the producer-slot reuse fence
-        # in update_producer and must cover EVERY copy of the op; state
-        # tensors copy after all KV tensors, so pin the last layer to the
-        # op's last per-tensor event. A no-op without state slabs: events[-1]
-        # is then the last layer's V event (ctor assert).
+        # in update_producer and must cover EVERY copy of the op. Pin the last
+        # layer to the op's last per-tensor event even when an auxiliary or
+        # state tensor belonging to an earlier layer trails its own data.
         producer_event.load_events[self.layer_num - 1] = events[-1]
         # events[-1] is also the reassigned finish_event, so the ack covers
         # every copy.

--- a/python/tokenspeed/runtime/cache/flat_host_mirror.py
+++ b/python/tokenspeed/runtime/cache/flat_host_mirror.py
@@ -47,38 +47,48 @@ def _state_slabs(device_kv_pool) -> list[tuple[torch.Tensor, torch.Tensor]]:
     return list(getattr(device_kv_pool, "state_slabs", None) or ())
 
 
+def _auxiliary_page_buffers(device_kv_pool) -> list[torch.Tensor | None]:
+    """Per-layer auxiliary page tensors, [] on ordinary KV pools."""
+    return list(getattr(device_kv_pool, "flat_auxiliary_page_buffers", None) or ())
+
+
 def flat_bytes_per_host_page(device_kv_pool) -> int:
     """Bytes one host page occupies across all mirrors, computed from the
     device pool alone (no mirror allocation) -- the sizing side of
     ``FlatHostMirror.bytes_per_host_page`` for host-budget arithmetic.
     """
-    tensors = _identity_dedup(device_kv_pool.k_buffer) + _identity_dedup(
-        device_kv_pool.v_buffer
+    page_tensors = (
+        _identity_dedup(device_kv_pool.k_buffer)
+        + _identity_dedup(device_kv_pool.v_buffer)
+        + _identity_dedup(_auxiliary_page_buffers(device_kv_pool))
     )
     page_size = int(device_kv_pool.page_size)
-    kv_bytes = sum(t.element_size() * t[0].numel() * page_size for t in tensors)
+    page_bytes = sum(t.element_size() * t[0].numel() * page_size for t in page_tensors)
     # State slabs are page-indexed: one constant row per page id.
     state_bytes = sum(
         t.element_size() * t[0].numel()
         for pair in _state_slabs(device_kv_pool)
         for t in pair
     )
-    return kv_bytes + state_bytes
+    return page_bytes + state_bytes
 
 
 class FlatHostMirror:
-    """One pinned CPU mirror per DISTINCT device KV tensor plus one per
-    state slab tensor; a (device_page, host_page) pair copies that page's
-    row range on every mirror pair.
+    """One pinned CPU mirror per distinct device page or state tensor.
+
+    A ``(device_page, host_page)`` pair copies that page's row range on
+    every mirror pair. Auxiliary page tensors are optional, aligned to
+    ``k_buffer`` / ``v_buffer`` by layer, and share the physical page ids.
 
     Slab tensors are enumerated once each -- a page's rows are exactly its
     owner group's layers, so byte copies are group-safe by id-exclusivity.
 
     ``tensor_pairs`` order (PINNED, D2 fencing indexes into it): K*, V*,
-    then state tensors flattened in slab order (conv0, ssm0, conv1, ...).
-    KV mirrors span ``page_size`` token rows per page; state slabs are
-    page-indexed (one snapshot row per page id), so their mirrors span 1
-    row per page -- ``row_spans[i]`` carries each pair's span.
+    auxiliary*, then state tensors flattened in slab order (conv0, ssm0,
+    conv1, ...). KV and auxiliary mirrors span ``page_size`` token rows
+    per page; state slabs are page-indexed (one snapshot row per page id),
+    so their mirrors span 1 row per page -- ``row_spans[i]`` carries each
+    pair's span.
     """
 
     def __init__(self, device_kv_pool, num_host_pages: int):
@@ -92,6 +102,16 @@ class FlatHostMirror:
         v_tensors = _identity_dedup(device_kv_pool.v_buffer)
         self.num_k_tensors = len(k_tensors)
 
+        auxiliary_by_layer = _auxiliary_page_buffers(device_kv_pool)
+        if auxiliary_by_layer:
+            assert len(auxiliary_by_layer) == len(
+                device_kv_pool.k_buffer
+            ), "flat host mirror: auxiliary page buffers must align with layers"
+        else:
+            auxiliary_by_layer = [None] * len(device_kv_pool.k_buffer)
+        auxiliary_tensors = _identity_dedup(auxiliary_by_layer)
+        self.num_auxiliary_tensors = len(auxiliary_tensors)
+
         k_index = {id(t): i for i, t in enumerate(k_tensors)}
         v_index = {id(t): i for i, t in enumerate(v_tensors)}
         # None entries (flat GDN state layers, no KV) map to None: those
@@ -104,6 +124,13 @@ class FlatHostMirror:
         assert self._layer_to_k_index == [
             None if t is None else v_index[id(t)] for t in device_kv_pool.v_buffer
         ], "flat host mirror: K/V dedup orders diverge"
+
+        auxiliary_base = 2 * self.num_k_tensors
+        auxiliary_index = {id(t): i for i, t in enumerate(auxiliary_tensors)}
+        self._layer_to_auxiliary_index = [
+            None if tensor is None else auxiliary_base + auxiliary_index[id(tensor)]
+            for tensor in auxiliary_by_layer
+        ]
 
         state_slabs = _state_slabs(device_kv_pool)
         state_tensors = [t for pair in state_slabs for t in pair]
@@ -121,7 +148,7 @@ class FlatHostMirror:
                 self._layer_to_state_pair[layer_id] = pair_of_conv[id(conv)]
 
         pin = torch.cuda.is_available()
-        kv_pairs = [
+        page_pairs = [
             (
                 dev,
                 torch.zeros(
@@ -130,7 +157,7 @@ class FlatHostMirror:
                     pin_memory=pin,
                 ),
             )
-            for dev in k_tensors + v_tensors
+            for dev in k_tensors + v_tensors + auxiliary_tensors
         ]
         state_pairs = [
             (
@@ -144,11 +171,11 @@ class FlatHostMirror:
             for dev in state_tensors
         ]
         self.tensor_pairs: tuple[tuple[torch.Tensor, torch.Tensor], ...] = tuple(
-            kv_pairs + state_pairs
+            page_pairs + state_pairs
         )
-        # Rows one page spans on each pair: page_size token rows for KV,
-        # one page-indexed snapshot row for state slabs.
-        self.row_spans: tuple[int, ...] = (self.page_size,) * len(kv_pairs) + (
+        # Rows one page spans on each pair: page_size token rows for KV and
+        # auxiliary tensors, one page-indexed snapshot row for state slabs.
+        self.row_spans: tuple[int, ...] = (self.page_size,) * len(page_pairs) + (
             1,
         ) * len(state_pairs)
 
@@ -169,8 +196,22 @@ class FlatHostMirror:
         pair = self._layer_to_state_pair.get(layer_id)
         if pair is None:
             return None
-        base = 2 * self.num_k_tensors + 2 * pair
+        base = 2 * self.num_k_tensors + self.num_auxiliary_tensors + 2 * pair
         return base, base + 1
+
+    def auxiliary_tensor_index_of_layer(self, layer_id: int) -> int | None:
+        """Auxiliary tensor index for ``layer_id``, if the layer has one."""
+        return self._layer_to_auxiliary_index[layer_id]
+
+    def completion_tensor_index_of_layer(self, layer_id: int) -> int:
+        """Last tensor event required before ``layer_id`` can run."""
+        state_indices = self.state_tensor_indices_of_layer(layer_id)
+        if state_indices is not None:
+            return state_indices[1]
+        auxiliary_index = self.auxiliary_tensor_index_of_layer(layer_id)
+        if auxiliary_index is not None:
+            return auxiliary_index
+        return self.num_k_tensors + self.tensor_index_of_layer(layer_id)
 
     def bytes_per_host_page(self) -> int:
         return sum(

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/msa.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/msa.py
@@ -78,6 +78,13 @@ class MSATokenToKVPool(MHATokenToKVPool):
             raise RuntimeError(f"Layer {layer_id} has no index-key cache.")
         return self.index_k_buffer[layer_id]
 
+    @property
+    def flat_auxiliary_page_buffers(self) -> tuple[torch.Tensor | None, ...]:
+        """Index-key pages mirrored alongside K/V by the flat host tier."""
+        return tuple(
+            self.index_k_buffer.get(layer_id) for layer_id in range(self.layer_num)
+        )
+
     def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor) -> None:
         super().move_kv_cache(tgt_loc, src_loc)
         if tgt_loc.numel() == 0:

--- a/test/runtime/test_flat_host_executor.py
+++ b/test/runtime/test_flat_host_executor.py
@@ -164,7 +164,7 @@ class LoadBackDonePayloadTest(unittest.TestCase):
 
 
 class FlatMemoryExecutorTest(unittest.TestCase):
-    """Real (tiny) MHATokenToKVPool on GPU driving the flat executor."""
+    """Real tiny MHA/MSA pools on GPU driving the flat executor."""
 
     def setUp(self):
         try:
@@ -178,6 +178,9 @@ class FlatMemoryExecutorTest(unittest.TestCase):
             from tokenspeed.runtime.layers.attention.kv_cache.mha import (
                 MHATokenToKVPool,
             )
+            from tokenspeed.runtime.layers.attention.kv_cache.msa import (
+                MSATokenToKVPool,
+            )
         except (ImportError, ModuleNotFoundError) as exc:
             self.skipTest(f"needs torch + tokenspeed_kernel + scheduler ext: {exc}")
         if not hasattr(Cache, "LoadBackDoneEvent"):
@@ -189,6 +192,7 @@ class FlatMemoryExecutorTest(unittest.TestCase):
         self.CacheKind = CacheKind
         self.FlatMemoryExecutor = FlatMemoryExecutor
         self.MHATokenToKVPool = MHATokenToKVPool
+        self.MSATokenToKVPool = MSATokenToKVPool
 
     def _pool(self):
         kwargs = dict(
@@ -209,6 +213,25 @@ class FlatMemoryExecutorTest(unittest.TestCase):
         )
         with mock.patch(_PKG_FLAT_PROBE, return_value=True):
             return self.MHATokenToKVPool(**kwargs)
+
+    def _msa_pool(self):
+        with mock.patch(_PKG_FLAT_PROBE, return_value=True):
+            return self.MSATokenToKVPool(
+                size=32,
+                dtype=self.torch.bfloat16,
+                head_num=1,
+                head_dim=8,
+                layer_num=4,
+                device="cuda",
+                enable_memory_saver=False,
+                max_batch_size=2,
+                max_context_len=64,
+                page_size=4,
+                rank=0,
+                index_head_dim=6,
+                index_dtype=self.torch.bfloat16,
+                indexed_layer_ids=frozenset({1, 3}),
+            )
 
     def _executor(self, pool):
         return self.FlatMemoryExecutor(device_pool=pool, host_ratio=2.0, host_size_gb=0)
@@ -321,6 +344,36 @@ class FlatMemoryExecutorTest(unittest.TestCase):
         self.assertIsNot(producer_event.load_events[0], producer_event.load_events[2])
         self.torch.cuda.synchronize()
         self.assertTrue(producer_event.finish_event.query())
+        self._drain(executor, 1)
+
+    def test_auxiliary_page_event_mapping(self):
+        pool = self._msa_pool()
+        executor = self._executor(pool)
+        mirror = executor.mirror
+
+        captured = {}
+        original_load = mirror.load_pages_with_events
+
+        def capture_events(pairs, stream):
+            events = original_load(pairs, stream)
+            captured["events"] = events
+            return events
+
+        mirror.load_pages_with_events = capture_events
+        executor.submit_loadback([33], [[0]], [[3]])
+        executor.flush()
+
+        events = captured["events"]
+        producer_idx = executor.get_producer_index(self.CacheKind.KV, 33)
+        producer_event = executor._counter.events[producer_idx]
+        for layer_id in (0, 2):
+            v_index = mirror.num_k_tensors + mirror.tensor_index_of_layer(layer_id)
+            self.assertIs(producer_event.load_events[layer_id], events[v_index])
+        for layer_id in (1, 3):
+            auxiliary_index = mirror.auxiliary_tensor_index_of_layer(layer_id)
+            self.assertIs(producer_event.load_events[layer_id], events[auxiliary_index])
+
+        self.torch.cuda.synchronize()
         self._drain(executor, 1)
 
     def _state_pool(self):

--- a/test/runtime/test_flat_host_mirror.py
+++ b/test/runtime/test_flat_host_mirror.py
@@ -1,7 +1,7 @@
 """FlatHostMirror (M15 Phase D1): byte-blind pinned-CPU slab mirror.
 
 Pins the transport contract only (no engine wiring): one mirror per
-distinct device KV tensor, whole-page row-range copies both directions,
+distinct device page tensor, whole-page row-range copies both directions,
 per-tensor load events, and the layer -> tensor-index mapping D2 fences on.
 """
 
@@ -31,7 +31,7 @@ GDN_LAYER_TYPES = ("linear_attention", "full_attention") * 2
 
 
 class FlatHostMirrorTest(unittest.TestCase):
-    """Real (tiny) MHATokenToKVPool on GPU, slab and legacy layouts."""
+    """Real tiny MHA/MSA pools on GPU, slab and legacy layouts."""
 
     def setUp(self):
         try:
@@ -39,9 +39,13 @@ class FlatHostMirrorTest(unittest.TestCase):
 
             from tokenspeed.runtime.cache.flat_host_mirror import (
                 FlatHostMirror,
+                flat_bytes_per_host_page,
             )
             from tokenspeed.runtime.layers.attention.kv_cache.mha import (
                 MHATokenToKVPool,
+            )
+            from tokenspeed.runtime.layers.attention.kv_cache.msa import (
+                MSATokenToKVPool,
             )
         except (ImportError, ModuleNotFoundError) as exc:
             self.skipTest(f"needs torch + tokenspeed_kernel: {exc}")
@@ -49,7 +53,9 @@ class FlatHostMirrorTest(unittest.TestCase):
             self.skipTest("needs a CUDA device")
         self.torch = torch
         self.FlatHostMirror = FlatHostMirror
+        self.flat_bytes_per_host_page = flat_bytes_per_host_page
         self.MHATokenToKVPool = MHATokenToKVPool
+        self.MSATokenToKVPool = MSATokenToKVPool
 
     def _pool(self, *, flat_ext: bool = True):
         kwargs = dict(
@@ -70,6 +76,25 @@ class FlatHostMirrorTest(unittest.TestCase):
         )
         with mock.patch(_PKG_FLAT_PROBE, return_value=flat_ext):
             return self.MHATokenToKVPool(**kwargs)
+
+    def _msa_pool(self):
+        with mock.patch(_PKG_FLAT_PROBE, return_value=True):
+            return self.MSATokenToKVPool(
+                size=32,
+                dtype=self.torch.bfloat16,
+                head_num=1,
+                head_dim=8,
+                layer_num=4,
+                device="cuda",
+                enable_memory_saver=False,
+                max_batch_size=2,
+                max_context_len=64,
+                page_size=4,
+                rank=0,
+                index_head_dim=6,
+                index_dtype=self.torch.bfloat16,
+                indexed_layer_ids=frozenset({1, 3}),
+            )
 
     def _fill_device_pages(self, mirror, device_pages):
         # Sentinels distinct per (tensor, page); bf16-exact small ints.
@@ -137,6 +162,24 @@ class FlatHostMirrorTest(unittest.TestCase):
         mirror = self.FlatHostMirror(pool, num_host_pages=8)
         self.assertEqual(len(mirror.tensor_pairs), 8)
         self._roundtrip_assert(mirror, [(1, 3), (2, 4)])
+
+    def test_auxiliary_page_roundtrip(self):
+        pool = self._msa_pool()
+        mirror = self.FlatHostMirror(pool, num_host_pages=8)
+
+        # 4 K + 4 V mirrors use 512 B per host page. The two sparse layers
+        # add 2 x page_size 4 x index width 6 bf16 rows = 96 B.
+        self.assertEqual(mirror.num_auxiliary_tensors, 2)
+        self.assertEqual(len(mirror.tensor_pairs), 10)
+        self.assertEqual(self.flat_bytes_per_host_page(pool), 608)
+        self.assertEqual(mirror.bytes_per_host_page(), 608)
+        for layer_id in (0, 2):
+            self.assertIsNone(mirror.auxiliary_tensor_index_of_layer(layer_id))
+        for layer_id in (1, 3):
+            index = mirror.auxiliary_tensor_index_of_layer(layer_id)
+            self.assertIs(mirror.tensor_pairs[index][0], pool.index_k_buffer[layer_id])
+
+        self._roundtrip_assert(mirror, [(1, 5), (2, 6)])
 
     def test_events_and_layer_mapping(self):
         torch = self.torch


### PR DESCRIPTION
## Summary

- mirror MSA index-key pages through the flat CPU L2 tier
- include auxiliary page buffers in host-page sizing and D2H/H2D transfers
- fence sparse layers on their index-cache load event while dense layers remain fenced on V
- enable KVStore in the MiniMax M3 recipe

## Why

MiniMax M3 stores an additional `index_k_buffer` for each sparse-attention layer. The flat host mirror previously transferred only K/V and recurrent state, so an L2 loadback restored K/V but left the MSA index cache stale. Host-page sizing also omitted roughly 47.5% of M3's per-rank cache bytes.

The flat mirror now supports a model-neutral, layer-aligned auxiliary page-buffer protocol. M3 publishes its index-key pages through that protocol; the generic executor does not contain a MiniMax-specific branch.

## Validation

- `pre-commit run --all-files`
- `CUDA_VISIBLE_DEVICES=4 PYTHONPATH=python:tokenspeed-kernel/python .venv/bin/python -m pytest -q test/runtime/test_flat_host_mirror.py test/runtime/test_flat_host_executor.py test/runtime/models/test_minimax_m3.py`
  - `26 passed`
- TP4 MiniMax-M3-MXFP8 flat-L2 eviction/loadback smoke on 4×B200:
  - `--max-total-tokens 8192 --max-model-len 4096 --block-size 128 --kvstore-ratio 2.0 --enforce-eager`
  - host allocation: `129` pages × `5,799,936` bytes/page per rank
  - round 1: `0 / 12,288` cached tokens
  - round 2: `2,944 / 3,072` cached tokens for each of four prompts (`95.83%`)
  - observed both `WriteBackDoneEvent` and `LoadBackDoneEvent`
  - greedy output matched byte-for-byte for all four prompts across cold prefill and L2 loadback
