### PR TITLE
fix(qwen3.5): Fix Qwen3.5 FP8 weight loading

### DIFF
--- a/python/tokenspeed/runtime/models/qwen3_5.py
+++ b/python/tokenspeed/runtime/models/qwen3_5.py
@@ -198,9 +198,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         ba_unquant = _gdn_group_unquantized(
             prefix, ("in_proj_b", "in_proj_a"), ignored_layers
         )
-        self._split_in_proj = quant_config is not None and (
-            qkvz_unquant != ba_unquant
-        )
+        self._split_in_proj = quant_config is not None and (qkvz_unquant != ba_unquant)
         if self._split_in_proj:
             self.in_proj_qkvz = MergedColumnParallelLinear(
                 input_size=self.hidden_size,
@@ -486,7 +484,6 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 lambda x: x.reshape(x.shape[0], -1), (query, key, value)
             )
             mixed_qkv = torch.cat((query, key, value), dim=-1)
-
 
         kwargs = {
             "mixed_qkv": mixed_qkv,

--- a/python/tokenspeed/runtime/models/qwen3_5.py
+++ b/python/tokenspeed/runtime/models/qwen3_5.py
@@ -74,6 +74,7 @@ from tokenspeed.runtime.layers.parameter import (
     PerTensorScaleParameter,
 )
 from tokenspeed.runtime.layers.quantization.base_config import QuantizationConfig
+from tokenspeed.runtime.layers.quantization.utils import check_equal_or_regex_match
 from tokenspeed.runtime.layers.rotary_embedding import get_rope
 from tokenspeed.runtime.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from tokenspeed.runtime.model_loader.weight_utils import (
@@ -114,6 +115,38 @@ from tokenspeed.runtime.utils import (
 from tokenspeed.runtime.utils.env import envs
 
 logger = logging.getLogger(__name__)
+
+
+def _gdn_group_unquantized(prefix, shard_names, ignored_layers) -> bool:
+    if not ignored_layers:
+        return False
+    targets = list(ignored_layers)
+    norm_targets = [t.replace("language_model.", "") for t in targets]
+    for shard in shard_names:
+        full = f"{prefix}.{shard}"
+        norm = full.replace("language_model.", "")
+        if not (
+            check_equal_or_regex_match(full, targets)
+            or check_equal_or_regex_match(norm, norm_targets)
+        ):
+            return False
+    return True
+
+
+def _gdn_in_proj_stacked_mapping(param_names) -> list:
+    if any(name.endswith(".in_proj_qkvz.weight") for name in param_names):
+        return [
+            ("in_proj_qkvz.", "in_proj_qkv.", (0, 1, 2)),
+            ("in_proj_qkvz.", "in_proj_z.", 3),
+            ("in_proj_ba.", "in_proj_b.", 0),
+            ("in_proj_ba.", "in_proj_a.", 1),
+        ]
+    return [
+        ("in_proj_qkvzba.", "in_proj_qkv.", (0, 1, 2)),
+        ("in_proj_qkvzba.", "in_proj_z.", 3),
+        ("in_proj_qkvzba.", "in_proj_b.", 4),
+        ("in_proj_qkvzba.", "in_proj_a.", 5),
+    ]
 
 
 class Qwen3_5GatedDeltaNet(nn.Module):
@@ -158,30 +191,72 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         )
         self.conv1d.weight.data = self.conv1d.weight.data.unsqueeze(1)
 
-        self.in_proj_qkvzba = MergedColumnParallelLinear(
-            input_size=self.hidden_size,
-            output_sizes=[
-                self.key_dim,
-                self.key_dim,
-                self.value_dim,
-                self.value_dim,
-                self.num_v_heads,
-                self.num_v_heads,
-            ],
-            bias=False,
-            quant_config=quant_config,
-            tp_rank=self.attn_tp_rank,
-            tp_size=self.attn_tp_size,
-            tp_group=self.attn_tp_group,
-            prefix=add_prefix("in_proj_qkvzba", prefix),
+        ignored_layers = getattr(quant_config, "ignored_layers", None) or []
+        qkvz_unquant = _gdn_group_unquantized(
+            prefix, ("in_proj_qkv", "in_proj_z"), ignored_layers
         )
-        self._qkvz_dim = (self.key_dim * 2 + self.value_dim * 2) // self.attn_tp_size
-        self._ba_dim = (self.num_v_heads * 2) // self.attn_tp_size
-
-        # Override weight loaders for packed checkpoint format.
-        # Important: for FP8, this must cover not only `.weight` but also
-        # `weight_scale_inv` / `weight_scale` / `input_scale` if present.
-        self._bind_packed_weight_loaders(self.in_proj_qkvzba)
+        ba_unquant = _gdn_group_unquantized(
+            prefix, ("in_proj_b", "in_proj_a"), ignored_layers
+        )
+        self._split_in_proj = quant_config is not None and (
+            qkvz_unquant != ba_unquant
+        )
+        if self._split_in_proj:
+            self.in_proj_qkvz = MergedColumnParallelLinear(
+                input_size=self.hidden_size,
+                output_sizes=[
+                    self.key_dim,
+                    self.key_dim,
+                    self.value_dim,
+                    self.value_dim,
+                ],
+                bias=False,
+                quant_config=None if qkvz_unquant else quant_config,
+                tp_rank=self.attn_tp_rank,
+                tp_size=self.attn_tp_size,
+                tp_group=self.attn_tp_group,
+                prefix=add_prefix("in_proj_qkvz", prefix),
+            )
+            self.in_proj_ba = MergedColumnParallelLinear(
+                input_size=self.hidden_size,
+                output_sizes=[
+                    self.num_v_heads,
+                    self.num_v_heads,
+                ],
+                bias=False,
+                quant_config=None if ba_unquant else quant_config,
+                tp_rank=self.attn_tp_rank,
+                tp_size=self.attn_tp_size,
+                tp_group=self.attn_tp_group,
+                prefix=add_prefix("in_proj_ba", prefix),
+            )
+            self._bind_packed_weight_loaders(self.in_proj_qkvz)
+            self._bind_packed_weight_loaders(self.in_proj_ba)
+        else:
+            # Both groups share the same quantization; a single fused linear is
+            # safe. qkvz_unquant == ba_unquant here.
+            self.in_proj_qkvzba = MergedColumnParallelLinear(
+                input_size=self.hidden_size,
+                output_sizes=[
+                    self.key_dim,
+                    self.key_dim,
+                    self.value_dim,
+                    self.value_dim,
+                    self.num_v_heads,
+                    self.num_v_heads,
+                ],
+                bias=False,
+                quant_config=None if qkvz_unquant else quant_config,
+                tp_rank=self.attn_tp_rank,
+                tp_size=self.attn_tp_size,
+                tp_group=self.attn_tp_group,
+                prefix=add_prefix("in_proj_qkvzba", prefix),
+            )
+            self._qkvz_dim = (
+                self.key_dim * 2 + self.value_dim * 2
+            ) // self.attn_tp_size
+            self._ba_dim = (self.num_v_heads * 2) // self.attn_tp_size
+            self._bind_packed_weight_loaders(self.in_proj_qkvzba)
 
         # Conv1d weight loader setup
         query_key_settings = (self.key_dim, 0, False)
@@ -310,7 +385,8 @@ class Qwen3_5GatedDeltaNet(nn.Module):
     @classmethod
     def _make_packed_weight_loader(cls, module, original_weight_loader):
         """Wrap the param's original loader so split checkpoints:
-          - in_proj_qkv + in_proj_z + in_proj_b + in_proj_a -> merged in_proj_qkvzba
+          - in_proj_qkv + in_proj_z -> merged in_proj_qkvz
+          - in_proj_b   + in_proj_a -> merged in_proj_ba
         can load correctly for both normal and FP8 params.
         """
 
@@ -372,6 +448,10 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         return query, key, value, z, b, a
 
     def _forward_input_proj(self, hidden_states: torch.Tensor):
+        if self._split_in_proj:
+            projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
+            projected_states_ba, _ = self.in_proj_ba(hidden_states)
+            return projected_states_qkvz, projected_states_ba
         projected_all, _ = self.in_proj_qkvzba(hidden_states)
         projected_states_qkvz, projected_states_ba = projected_all.split(
             [self._qkvz_dim, self._ba_dim], dim=-1
@@ -406,6 +486,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 lambda x: x.reshape(x.shape[0], -1), (query, key, value)
             )
             mixed_qkv = torch.cat((query, key, value), dim=-1)
+
 
         kwargs = {
             "mixed_qkv": mixed_qkv,
@@ -465,13 +546,8 @@ class Qwen3_5LinearDecoderLayer(nn.Module):
         self.mapping = mapping
         self.layer_id = layer_id
 
-        linear_attn_quant_config = (
-            None
-            if quant_config and quant_config.get_name() in ("fp8", "nvfp4")
-            else quant_config
-        )
         self.linear_attn = Qwen3_5GatedDeltaNet(
-            config, mapping, layer_id, linear_attn_quant_config, prefix=prefix
+            config, mapping, layer_id, quant_config, prefix=prefix
         )
 
         #  Determine the MLP type based on the model type
@@ -1008,16 +1084,10 @@ class Qwen3_5ForCausalLM(nn.Module):
             ("qkv_proj", "v_proj", "v"),
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
-            # GDN (GatedDeltaNet) linear attention projections
-            # Split checkpoint format (separate qkv/z/b/a files)
-            ("in_proj_qkvzba.", "in_proj_qkv.", (0, 1, 2)),
-            ("in_proj_qkvzba.", "in_proj_z.", 3),
-            ("in_proj_qkvzba.", "in_proj_b.", 4),
-            ("in_proj_qkvzba.", "in_proj_a.", 5),
-            # Pre-packed checkpoint format (already merged qkvz and ba)
-            ("in_proj_qkvzba.", "in_proj_qkvz.", (0, 1, 2, 3)),
-            ("in_proj_qkvzba.", "in_proj_ba.", (4, 5)),
         ]
+        stacked_params_mapping += _gdn_in_proj_stacked_mapping(
+            name for name, _ in self.named_parameters(remove_duplicate=False)
+        )
 
         loaded_params: set[str] = set()
         params_dict = dict(self.named_parameters(remove_duplicate=False))
@@ -1085,16 +1155,10 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLM):
             ("qkv_proj", "v_proj", "v"),
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
-            # GDN (GatedDeltaNet) linear attention projections
-            # Split checkpoint format (separate qkv/z/b/a files)
-            ("in_proj_qkvzba.", "in_proj_qkv.", (0, 1, 2)),
-            ("in_proj_qkvzba.", "in_proj_z.", 3),
-            ("in_proj_qkvzba.", "in_proj_b.", 4),
-            ("in_proj_qkvzba.", "in_proj_a.", 5),
-            # Pre-packed checkpoint format (already merged qkvz and ba)
-            ("in_proj_qkvzba.", "in_proj_qkvz.", (0, 1, 2, 3)),
-            ("in_proj_qkvzba.", "in_proj_ba.", (4, 5)),
         ]
+        stacked_params_mapping += _gdn_in_proj_stacked_mapping(
+            name for name, _ in self.named_parameters(remove_duplicate=False)
+        )
 
         # Skip loading extra parameters for GPTQ/nvfp4 models.
         ignore_suffixes = (
@@ -1461,16 +1525,10 @@ class Qwen3_5ForConditionalGeneration(BaseCausalLM):
             ("qkv_proj", "v_proj", "v"),
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
-            # GDN (GatedDeltaNet) linear attention projections
-            # Split checkpoint format (separate qkv/z/b/a files)
-            ("in_proj_qkvzba.", "in_proj_qkv.", (0, 1, 2)),
-            ("in_proj_qkvzba.", "in_proj_z.", 3),
-            ("in_proj_qkvzba.", "in_proj_b.", 4),
-            ("in_proj_qkvzba.", "in_proj_a.", 5),
-            # Pre-packed checkpoint format (already merged qkvz and ba)
-            ("in_proj_qkvzba.", "in_proj_qkvz.", (0, 1, 2, 3)),
-            ("in_proj_qkvzba.", "in_proj_ba.", (4, 5)),
         ]
+        stacked_params_mapping += _gdn_in_proj_stacked_mapping(
+            name for name, _ in self.named_parameters(remove_duplicate=False)
+        )
 
         loaded_params: set[str] = set()
         params_dict = dict(self.named_parameters(remove_duplicate=False))
@@ -1557,16 +1615,10 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5ForConditionalGeneration):
             ("qkv_proj", "v_proj", "v"),
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
-            # GDN (GatedDeltaNet) linear attention projections
-            # Split checkpoint format (separate qkv/z/b/a files)
-            ("in_proj_qkvzba.", "in_proj_qkv.", (0, 1, 2)),
-            ("in_proj_qkvzba.", "in_proj_z.", 3),
-            ("in_proj_qkvzba.", "in_proj_b.", 4),
-            ("in_proj_qkvzba.", "in_proj_a.", 5),
-            # Pre-packed checkpoint format (already merged qkvz and ba)
-            ("in_proj_qkvzba.", "in_proj_qkvz.", (0, 1, 2, 3)),
-            ("in_proj_qkvzba.", "in_proj_ba.", (4, 5)),
         ]
+        stacked_params_mapping += _gdn_in_proj_stacked_mapping(
+            name for name, _ in self.named_parameters(remove_duplicate=False)
+        )
 
         ignore_suffixes = (
             ".bias",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_fp8.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_fp8.py
@@ -148,6 +148,8 @@ if platform.is_nvidia:
         routed_scaling_factor = _routing_value(w, "routed_scaling_factor", None)
         routing_method_type = _routing_value(w, "routing_method_type", 1)
 
+        intermediate_size = w.w2_weight.shape[-1]
+
         result = trtllm_fp8_block_scale_moe(
             routing_logits=router_logits.to(torch.float32),
             routing_bias=routing_bias,
@@ -161,7 +163,7 @@ if platform.is_nvidia:
             top_k=getattr(w, "top_k"),
             n_group=n_group,
             topk_group=topk_group,
-            intermediate_size=getattr(w, "intermediate_size"),
+            intermediate_size=intermediate_size,
             local_expert_offset=getattr(w, "ep_rank", 0) * local_experts,
             local_num_experts=local_experts,
             routed_scaling_factor=routed_scaling_factor,


### PR DESCRIPTION
## Summary
Fix garbled output for Qwen3.5 MoE FP8 checkpoints, caused by the GatedDeltaNet (linear attention) input projection.
- **GDN input projection**: The Qwen3.5-35B-A3B-FP8 checkpoint quantizes in_proj_qkv/in_proj_z (FP8) but leaves in_proj_b/in_proj_a unquantized (in modules_to_not_convert). Now when they differ, they split into in_proj_qkvz (FP8) + in_proj_ba (bf16). The decision is derived from the checkpoint's not-convert list, so bf16 checkpoints and future all-quantized cases still take the fused path.
- **FP8 MoE under TP**: flashinfer_trtllm_fp8_moe_apply passed the full (unsharded) w.intermediate_size to the kernel, which mismatched the TP-sharded gemm1_weights_scale. Now derived from the already-sharded w2_weight.shape[-1], which is correct for TP, EP, and hybrid.

## Test Plan
Test Qwen3.5-35B-A3B-FP8 on TP2/DP4EP4; both configurations produce correct output.
<!-- How was this validated? -->
