### PR TITLE
fix(inkling): fuse dMel lookup+sum to bound audio encode memory

### DIFF
--- a/python/tokenspeed/runtime/models/inkling.py
+++ b/python/tokenspeed/runtime/models/inkling.py
@@ -1442,9 +1442,12 @@ class InklingAudioTower(nn.Module):
         bin_offsets = (
             torch.arange(self.n_mel_bins, device=device) * self.mel_vocab_size
         ).unsqueeze(0)
-        hidden_states = self.encoder((bin_offsets + dmel).reshape(-1))
-        hidden_states = hidden_states.reshape(dmel.shape[0], self.n_mel_bins, -1).sum(
-            dim=1
+        # Fused lookup+sum: the unfused form materializes an intermediate of
+        # ``(num_tokens * n_mel_bins, decoder_dmodel)``, i.e. ``n_mel_bins``
+        # (80) times the output, which dominates peak memory on long clips --
+        # ~0.95 MB per audio token at decoder_dmodel=6144.
+        hidden_states = F.embedding_bag(
+            bin_offsets + dmel, self.encoder.weight, mode="sum"
         )
         if self.final_norm is not None:
             hidden_states = self.final_norm(hidden_states)

--- a/test/runtime/models/test_inkling_multimodal.py
+++ b/test/runtime/models/test_inkling_multimodal.py
@@ -234,6 +234,52 @@ class TestInklingAudioTower(unittest.TestCase):
         )
         torch.testing.assert_close(tower(dmel), ref, atol=1e-5, rtol=1e-5)
 
+    def test_peak_memory_does_not_scale_with_n_mel_bins(self):
+        """dMel embedding must fuse lookup+sum.
+
+        The unfused ``encoder(idx).reshape(...).sum(1)`` form materializes an
+        intermediate ``n_mel_bins`` times the size of the output (~0.95 MB per
+        audio token at the released ``decoder_dmodel=6144``), which lets a
+        single long clip OOM the engine. Assert the peak stays within a small
+        multiple of the output instead.
+        """
+        from tokenspeed.runtime.configs.inkling_config import InklingAudioConfig
+        from tokenspeed.runtime.models.inkling import InklingAudioTower
+
+        torch.manual_seed(2)
+        cfg = InklingAudioConfig(
+            decoder_dmodel=512,
+            n_mel_bins=80,
+            mel_vocab_size=16,
+            use_audio_norm=True,
+            audio_mode="dmel",
+        )
+        tower = InklingAudioTower(cfg).cuda().eval()
+        n_tokens = 4096
+        dmel = torch.randint(
+            0, cfg.mel_vocab_size, (n_tokens, cfg.n_mel_bins), device="cuda"
+        )
+
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+        base = torch.cuda.memory_allocated()
+        with torch.no_grad():
+            out = tower(dmel)
+        torch.cuda.synchronize()
+        peak = torch.cuda.max_memory_allocated() - base
+
+        out_bytes = out.numel() * out.element_size()
+        unfused_bytes = out_bytes * cfg.n_mel_bins
+        # Generous ceiling: comfortably above the fused path, far below unfused.
+        self.assertLess(
+            peak,
+            out_bytes * 8,
+            f"peak {peak / 2**20:.1f} MB suggests the unfused lookup+sum is "
+            f"back (unfused would be ~{unfused_bytes / 2**20:.1f} MB, output is "
+            f"{out_bytes / 2**20:.1f} MB)",
+        )
+
 
 @unittest.skipUnless(torch.cuda.is_available(), "runtime RMSNorm kernels need CUDA")
 class TestInklingHMLPPatchEncoder(unittest.TestCase):


### PR DESCRIPTION
InklingAudioTower.forward embedded each (mel-bin, value) pair and then summed over bins, materializing an intermediate of (num_tokens * n_mel_bins, decoder_dmodel) -- n_mel_bins (80) times the size of the output, ~0.95 MB per audio token at the released decoder_dmodel=6144.

The encoder runs over a whole item at once (chunked prefill slices the already-encoded result, it does not chunk the encode) and get_audio_feature concatenates every item in the batch into a single call, so one long clip sizes that intermediate. With no cap on audio length anywhere on the input path, a single request could exhaust the device.

Use F.embedding_bag to fuse the lookup and the cross-bin sum so the intermediate is never materialized.

Measured on the real Inkling-NVFP4 checkpoint (TP4, gpu-memory- utilization 0.95): before, a 5k-token clip died with "OutOfMemoryError: Tried to allocate 4.58 GiB" on all four ranks -- exactly 5000 * 80 * 6144 * 2B -- taking the engine down with it. After, 79k audio tokens complete normally. Tower peak memory drops 41.5x (40k tokens: 38.9 GiB -> 938 MiB).

Numerics are unchanged up to accumulation order: fp32 max diff 1.9e-6, bf16 4e-3 (values of magnitude ~9), CUDA-graph capture and replay match eager exactly, and results are bitwise stable across reruns.

This bounds the per-token cost but the encode is still linear and unbounded in clip length; an explicit cap on encode size is left for a follow-up.

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
