### PR TITLE
perf(m3): integrate CuTeDSL MSA block-score kernels

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/msa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/msa.py
@@ -84,6 +84,9 @@ class MSAExtendMetadata:
     extend_prefix_lens: torch.Tensor
     extend_seq_lens_cpu: list[int]
     cu_extend_seq_lens_cpu: list[int]
+    # Per-request total lengths (prefix + new tokens) on the host, so kernels
+    # can plan host-side without a device sync.
+    seq_lens_cpu: list[int]
     max_extend_seq_len: int
     max_extend_prefix_len: int = 0
     # Flat per-group page tables (group_id -> [num_reqs, max_pages]); None on
@@ -239,7 +242,9 @@ class MSAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
             )
             extend_prefix_lens = extend_prefix_lens[:bs]
             max_extend_seq_len = max(extend_seq_lens_cpu)
-            max_extend_prefix_len = int(extend_prefix_lens_cpu[:bs].max().item())
+            prefix_lens_cpu = [int(x) for x in extend_prefix_lens_cpu[:bs].tolist()]
+            max_extend_prefix_len = max(prefix_lens_cpu)
+            seq_lens_cpu = [p + e for p, e in zip(prefix_lens_cpu, extend_seq_lens_cpu)]
 
             self.forward_extend_metadata = MSAExtendMetadata(
                 page_table=page_table,
@@ -250,6 +255,7 @@ class MSAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
                 extend_prefix_lens=extend_prefix_lens,
                 extend_seq_lens_cpu=extend_seq_lens_cpu,
                 cu_extend_seq_lens_cpu=cu_extend_seq_lens_cpu,
+                seq_lens_cpu=seq_lens_cpu,
                 max_extend_seq_len=max_extend_seq_len,
                 max_extend_prefix_len=max_extend_prefix_len,
                 page_tables=flat_page_tables,
@@ -631,6 +637,8 @@ class MSAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
             local_blocks=self.index_local_blocks,
             k_scale=layer.k_scale if self.is_fp8 else None,
             v_scale=layer.v_scale if self.is_fp8 else None,
+            query_lens_cpu=metadata.extend_seq_lens_cpu,
+            seq_lens_cpu=metadata.seq_lens_cpu,
         )
         return self._reshape_and_pad_output(output, total_tokens, layer)
 

--- a/tokenspeed-kernel/python/setup.py
+++ b/tokenspeed-kernel/python/setup.py
@@ -889,6 +889,12 @@ setup(
             "cute/**/*.cu",
             "cute/README.md",
             "cute/requirements.txt",
+            # nvcc-JIT FMHA sources: compiled at runtime by jit.py, so the
+            # kernel sources and headers must ship with the wheel.
+            "csrc/*.cu",
+            "csrc/*.h",
+            "csrc/*.jinja",
+            "csrc/include/*",
         ],
     },
     cmdclass={

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 
 # Backend registration (side-effect imports)
 import tokenspeed_kernel.ops.attention.cuda  # noqa: F401
@@ -286,6 +287,8 @@ def msa_extend_with_kvcache(
     local_blocks: int,
     k_scale: float | torch.Tensor | None = None,
     v_scale: float | torch.Tensor | None = None,
+    query_lens_cpu: Sequence[int] | None = None,
+    seq_lens_cpu: Sequence[int] | None = None,
     override: str | None = None,
     solution: str | None = None,
 ) -> torch.Tensor:
@@ -319,6 +322,10 @@ def msa_extend_with_kvcache(
             divided by this scale before quantization. None means 1.0.
         v_scale: Optional scalar descale for an FP8 ``v_cache``, with the
             same convention as ``k_scale``.
+        query_lens_cpu: Optional host-side per-request new-token counts;
+            with ``seq_lens_cpu`` this lets the indexer plan its fmha
+            OnlyScore path without a device sync.
+        seq_lens_cpu: Optional host-side per-request total sequence lengths.
         override: Optional kernel override name.
         solution: Optional kernel solution to force through normal selection.
 
@@ -401,6 +408,8 @@ def msa_extend_with_kvcache(
             local_blocks=local_blocks,
             k_scale=k_scale,
             v_scale=v_scale,
+            query_lens_cpu=query_lens_cpu,
+            seq_lens_cpu=seq_lens_cpu,
         )
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cute_dsl/cute_utils.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cute_dsl/cute_utils.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""CuTe-DSL helpers adapted from vLLM's ``vllm/cute_utils`` package."""
+
+import torch
+from cutlass import (
+    BFloat16,
+    Float8E4M3FN,
+    Float16,
+    Float32,
+    Int32,
+    Int64,
+    Uint32,
+    cute,
+)
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import llvm, vector
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cutlass_dsl import T, dsl_user_op
+
+_TORCH_TO_CUTE_DTYPE = {
+    torch.bfloat16: BFloat16,
+    torch.float8_e4m3fn: Float8E4M3FN,
+}
+
+_CUTE_TO_PTX_DTYPE = {
+    BFloat16: "bf16",
+    Float16: "f16",
+    Float8E4M3FN: "e4m3",
+    Float32: "f32",
+}
+
+# https://github.com/NVIDIA/cutlass/blob/v4.3.2/include/cute/arch/copy_sm90_desc.hpp#L193-L197
+EVICT_FIRST = Int64(0x12F0000000000000)
+
+
+def simple_tma_copy(atom, src, dst, mbar=None, cache_policy=None):
+    """A simple helper that wraps group_modes() and tma_partition().
+
+    NOTE: this should be called WITHOUT cute.elect_one().
+    """
+    if isinstance(atom.op, cpasync.CopyBulkTensorTileG2SOp):
+        gmem = src
+        smem = dst
+    elif isinstance(atom.op, cpasync.CopyBulkTensorTileS2GOp):
+        smem = src
+        gmem = dst
+    else:
+        raise ValueError
+
+    s_part, g_part = cpasync.tma_partition(
+        atom,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(smem, 0),
+        cute.group_modes(gmem, 0),
+    )
+
+    if isinstance(atom.op, cpasync.CopyBulkTensorTileG2SOp):
+        cute.copy(atom, g_part, s_part, tma_bar_ptr=mbar, cache_policy=cache_policy)
+    elif isinstance(atom.op, cpasync.CopyBulkTensorTileS2GOp):
+        cute.copy(atom, s_part, g_part, cache_policy=cache_policy)
+    else:
+        raise ValueError
+
+
+@dsl_user_op
+def mma_sync(a, b, c: cute.Tensor, *, loc=None, ip=None):
+    a_ty = _CUTE_TO_PTX_DTYPE[a.element_type]
+    b_ty = _CUTE_TO_PTX_DTYPE[b.element_type]
+    c_ty = _CUTE_TO_PTX_DTYPE[c.element_type]
+    mlir_ty = c.element_type.mlir_type
+    K = 256 // a.element_type.width  # 32B
+
+    # Recast expects tensor-backed fragments; materialize SSA fragments here so
+    # callsites can pass converted FP8 fragments directly.
+    if isinstance(a, cute.TensorSSA):
+        a_ = cute.make_rmem_tensor_like(a)
+        a_.store(a, loc=loc, ip=ip)
+        a = a_
+    if isinstance(b, cute.TensorSSA):
+        b_ = cute.make_rmem_tensor_like(b)
+        b_.store(b, loc=loc, ip=ip)
+        b = b_
+
+    a = cute.recast_tensor(a, Int32, loc=loc, ip=ip)
+    b = cute.recast_tensor(b, Int32, loc=loc, ip=ip)
+    out = llvm.inline_asm(
+        llvm.StructType.get_literal([mlir_ty] * 4),
+        [a[i].ir_value(loc=loc, ip=ip) for i in range(4)]
+        + [b[i].ir_value(loc=loc, ip=ip) for i in range(2)]
+        + [c[i].ir_value(loc=loc, ip=ip) for i in range(4)],
+        f"mma.sync.aligned.m16n8k{K}.row.col.{c_ty}.{a_ty}.{b_ty}.{c_ty} "
+        "{$0, $1, $2, $3}, "
+        "{$4, $5, $6, $7}, "
+        "{$8, $9}, "
+        "{$10, $11, $12, $13};",
+        "=f,=f,=f,=f,r,r,r,r,r,r,f,f,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        loc=loc,
+        ip=ip,
+    )
+    vec = vector.from_elements(
+        ir.VectorType.get([4], mlir_ty, loc=loc),
+        [llvm.extractvalue(mlir_ty, out, [i], loc=loc, ip=ip) for i in range(4)],
+        loc=loc,
+        ip=ip,
+    )
+    return cute.TensorSSA(vec, 4, c.element_type)
+
+
+@dsl_user_op
+def fp8x4_to_fp16x4(x: Uint32, *, loc=None, ip=None) -> cute.TensorSSA:
+    out = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32()] * 2),
+        [x.ir_value(loc=loc, ip=ip)],
+        "{\n\t"
+        ".reg .b16 lo, hi;\n\t"
+        "mov.b32 {lo, hi}, $2;\n\t"
+        "cvt.rn.f16x2.e4m3x2 $0, lo;\n\t"
+        "cvt.rn.f16x2.e4m3x2 $1, hi;\n\t"
+        "}\n",
+        "=r,=r,r",
+        has_side_effects=False,
+        is_align_stack=False,
+        loc=loc,
+        ip=ip,
+    )
+    vec = vector.from_elements(
+        ir.VectorType.get([2], T.i32(), loc=loc),
+        [llvm.extractvalue(T.i32(), out, [i], loc=loc, ip=ip) for i in range(2)],
+        loc=loc,
+        ip=ip,
+    )
+    return cute.TensorSSA(vec, 2, Uint32)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cute_dsl/minimax_index_decode_score.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cute_dsl/minimax_index_decode_score.py
@@ -1,0 +1,556 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""CuteDSL MiniMax M3 index decode score kernel.
+
+The kernel computes decode-time index block scores with TMA + ``mma.sync``.
+``mma.sync`` is used instead of tcgen05 because this score GEMM has a very
+small N dimension and benefits more from higher CTA occupancy than from a
+deeper single-CTA tcgen05 pipeline.
+
+Adapted from vLLM's ``vllm/models/minimax_m3/nvidia/ops/index_decode_score.py``
+to TokenSpeed's indexer contract: the score scale and the forced init/local
+block selection (written as ``+inf``) are applied in the epilogue, so the
+output is a drop-in replacement for the Triton ``_decode_block_score_kernel``
+and the downstream top-k needs no changes.
+
+Validated on SM100 only.
+"""
+
+from functools import cache
+
+import cutlass
+import torch
+from cuda.bindings.driver import CUstream
+from cutlass import Float8E4M3FN, Float16, Float32, Int32, Int64, Uint32, cute
+from cutlass.cute.nvgpu import cpasync, warp
+from quack.compile_utils import make_fake_tensor
+from tokenspeed_kernel.ops.attention.cute_dsl.cute_utils import (
+    _TORCH_TO_CUTE_DTYPE,
+    EVICT_FIRST,
+    fp8x4_to_fp16x4,
+    mma_sync,
+    simple_tma_copy,
+)
+
+
+@cute.jit
+def _fp8_to_f16_mma_fragments(src: cute.Tensor):
+    src_elems = cute.size(src)
+    src_u32 = cute.recast_tensor(src, Uint32)
+    src_f16 = cute.make_rmem_tensor(src_elems, Float16)
+    src_f16_u32 = cute.recast_tensor(src_f16, Uint32)
+    # This packed conversion is faster and emits fewer SASS instructions than
+    # src.load().to(Float16).
+    for i in cutlass.range_constexpr(src_elems // 4):
+        converted = fp8x4_to_fp16x4(src_u32[i])
+        src_f16_u32[i * 2] = converted[0]
+        src_f16_u32[i * 2 + 1] = converted[1]
+    lower = cute.make_rmem_tensor(src_elems // 2, Float16)
+    upper = cute.make_rmem_tensor(src_elems // 2, Float16)
+
+    # FP8 ldmatrix gives four consecutive values along K. Split each group
+    # into the lower two and upper two values for two FP16 MMA k-fragments.
+    for i in cutlass.range_constexpr(src_elems // 2):
+        lower[i] = src_f16[(i // 2) * 4 + i % 2]
+        upper[i] = src_f16[(i // 2) * 4 + 2 + i % 2]
+    return lower, upper
+
+
+class IndexDecodeScoreKernel:
+    BLOCK_K = 128
+    BAR_MMA = 1
+    num_stages = 2
+
+    def __init__(
+        self,
+        dtype: type[cutlass.Numeric],
+        num_heads: int,
+        max_decode_query_len: int,
+        split_k: int,
+        head_dim: int,
+        scale: float,
+        init_blocks: int,
+        local_blocks: int,
+    ):
+        self.dtype = dtype
+        self.num_heads = num_heads
+        self.max_decode_query_len = max_decode_query_len
+        self.split_k = split_k
+        self.head_dim = head_dim
+        self.scale = scale
+        self.init_blocks = init_blocks
+        self.local_blocks = local_blocks
+
+    @cute.jit
+    def __call__(
+        self,
+        gQ: cute.Tensor,  # [bs * runtime_decode_query_len, num_heads, head_dim]
+        gK_cache: cute.Tensor,  # [num_pages, page_size, head_dim]
+        block_table: cute.Tensor,  # [bs, max_pages]
+        score: cute.Tensor,  # [num_heads, bs * runtime_decode_query_len, max_pages]
+        seq_lens: cute.Tensor,  # [bs]
+        stream: CUstream,
+    ):
+        dtype = self.dtype
+        num_heads = self.num_heads
+        head_dim = self.head_dim
+        num_stages = self.num_stages
+        MAX_DQL = self.max_decode_query_len
+        BLOCK_Q = num_heads * MAX_DQL
+        assert BLOCK_Q <= 32
+
+        batch = seq_lens.shape[0]
+        decode_query_len = gQ.shape[0] // batch
+        grid = (batch, self.split_k, 1)
+        block = (32 * 5, 1, 1)
+
+        tma_g2s = cpasync.CopyBulkTensorTileG2SOp()
+        swizzle_128B = cute.make_swizzle(3, 4, 3)
+        elems = 128 * 8 // dtype.width
+
+        sQ_layout = cute.make_layout(
+            (MAX_DQL, num_heads, (elems, head_dim // elems)),
+            stride=(elems, MAX_DQL * elems, (1, BLOCK_Q * elems)),
+        )
+        sQ_layout = cute.make_composed_layout(swizzle_128B, 0, sQ_layout)
+        Q_tma = cpasync.make_tiled_tma_atom(
+            tma_g2s,
+            cute.logical_divide(gQ, (None, None, elems)),
+            sQ_layout,
+            cta_tiler=(MAX_DQL, num_heads, head_dim),
+        )
+
+        sK_layout = cute.make_layout(
+            (1, self.BLOCK_K, (elems, head_dim // elems), num_stages),
+            stride=(0, elems, (1, self.BLOCK_K * elems), self.BLOCK_K * head_dim),
+        )
+        sK_layout = cute.make_composed_layout(swizzle_128B, 0, sK_layout)
+        K_tma = cpasync.make_tiled_tma_atom(
+            tma_g2s,
+            cute.logical_divide(gK_cache, (None, None, elems)),
+            sK_layout,
+            cta_tiler=(1, self.BLOCK_K, head_dim),
+        )
+
+        self.kernel(
+            Q_tma,
+            K_tma,
+            block_table,
+            score,
+            seq_lens,
+            decode_query_len,
+        ).launch(grid=grid, block=block, stream=stream, use_pdl=True)
+
+    @cute.kernel
+    def kernel(
+        self,
+        Q_tma: cpasync.TmaInfo,
+        K_tma: cpasync.TmaInfo,
+        block_table: cute.Tensor,
+        score: cute.Tensor,
+        seq_lens: cute.Tensor,
+        decode_query_len,
+    ):
+        tid, _, _ = cute.arch.thread_idx()
+        batch_id, split_id, _ = cute.arch.block_idx()
+        _, split_k, _ = cute.arch.grid_dim()
+        warp_id = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        lane_id = cute.arch.lane_idx()
+
+        NUM_HEADS = self.num_heads
+        MAX_DQL = self.max_decode_query_len
+        BLOCK_Q = NUM_HEADS * MAX_DQL
+        BLOCK_K = self.BLOCK_K
+        head_dim = self.head_dim
+        dtype = self.dtype
+        MMA_N = 8
+        num_stages = self.num_stages
+        Q_TILES = cute.ceil_div(BLOCK_Q, MMA_N)
+        EPI_Q = Q_TILES * MMA_N
+
+        smem = cutlass.utils.SmemAllocator()
+        sK = smem.allocate_tensor(
+            dtype,
+            K_tma.smem_layout.outer,
+            byte_alignment=128,
+            swizzle=K_tma.smem_layout.inner,
+        )[0, None, None, None]
+        # alias sQ with the 1st stage of sK
+        sQ_tma = cute.make_tensor(
+            sK[None, None, 0].iterator, layout=Q_tma.smem_layout.outer
+        )
+        # TMA sees Q as (query, head, dim), while ldmatrix consumes a
+        # flattened Q column mode. The target profile keeps the rank-2 view even
+        # for degenerate shapes like DQL1.
+        q_tma_elems = 128 * 8 // dtype.width
+        sQ = cute.coalesce(
+            cute.group_modes(sQ_tma, 0, 2),
+            target_profile=(BLOCK_Q, (q_tma_elems, head_dim // q_tma_elems)),
+        )
+        epi_buffer = smem.allocate_tensor(Float32, cute.make_layout((EPI_Q, 4)))
+
+        tma_full_mbar = smem.allocate_array(Int64, num_stages)
+        tma_empty_mbar = smem.allocate_array(Int64, num_stages)
+
+        seqlen = seq_lens[batch_id]
+        num_blocks = cute.ceil_div(seqlen, BLOCK_K)
+
+        if split_id < num_blocks:
+            if warp_id == 0:
+                with cute.arch.elect_one():
+                    for i in cutlass.range_constexpr(num_stages):
+                        cute.arch.mbarrier_init(tma_full_mbar + i, 1)
+                        cute.arch.mbarrier_init(tma_empty_mbar + i, 128)
+                    cute.arch.mbarrier_init_fence()
+            elif warp_id == 1:
+                cpasync.prefetch_descriptor(Q_tma.atom)
+                cpasync.prefetch_descriptor(K_tma.atom)
+            cute.arch.sync_threads()
+
+            cute.arch.griddepcontrol_wait()
+            cute.arch.griddepcontrol_launch_dependents()
+
+            if warp_id == 4:
+                # TMA warp
+                tma_stage = 0
+                tma_parity = 1
+
+                gQ_tile = cute.local_tile(
+                    cute.domain_offset(
+                        (batch_id * decode_query_len, 0, 0),
+                        Q_tma.tma_tensor,
+                    ),
+                    tiler=(MAX_DQL, NUM_HEADS, head_dim),
+                    coord=(0, 0, 0),
+                )
+                cute.arch.mbarrier_wait(tma_empty_mbar, tma_parity)
+                with cute.arch.elect_one():
+                    Q_size = BLOCK_Q * head_dim * (dtype.width // 8)
+                    cute.arch.mbarrier_arrive_and_expect_tx(tma_full_mbar, Q_size)
+                # TMA bounds-checks rows when runtime decode_query_len is smaller
+                # than MAX_DQL; padded Q columns are masked before global stores.
+                simple_tma_copy(Q_tma.atom, gQ_tile, sQ_tma, tma_full_mbar)
+
+                tma_stage = (tma_stage + 1) % num_stages
+                if tma_stage == 0:
+                    tma_parity ^= 1
+
+                for block_id in range(split_id, num_blocks, split_k):
+                    page_id = block_table[batch_id, block_id]
+                    gK_tile = K_tma.tma_tensor[page_id, None, None]
+                    k_mbar = tma_full_mbar + tma_stage
+
+                    cute.arch.mbarrier_wait(tma_empty_mbar + tma_stage, tma_parity)
+                    with cute.arch.elect_one():
+                        K_size = BLOCK_K * head_dim * (dtype.width // 8)
+                        cute.arch.mbarrier_arrive_and_expect_tx(k_mbar, K_size)
+                    simple_tma_copy(
+                        K_tma.atom,
+                        gK_tile,
+                        sK[None, None, tma_stage],
+                        k_mbar,
+                        cache_policy=EVICT_FIRST,
+                    )
+
+                    tma_stage = (tma_stage + 1) % num_stages
+                    if tma_stage == 0:
+                        tma_parity ^= 1
+
+            else:
+                # MMA warps
+                # each warp handles K[32, head_dim] @ Q[BLOCK_Q, head_dim].T
+                sK_warp = cute.local_tile(
+                    sK, (32, head_dim, num_stages), (warp_id, 0, 0)
+                )
+                q_start = seqlen - decode_query_len
+
+                elems = 128 // dtype.width  # 16B
+                MMA_K = 32 * 8 // dtype.width  # 32B
+
+                # Pre-compute ldmatrix address.
+                # sK loads a [16 x 16B] tile:
+                #   ((16, (16B, 2), 1), (32 / 16, head_dim / 32B, num_stages))
+                # sQ loads an [8 x 32B] tile:
+                #   ((8, (16B, 4)), (BLOCK_Q / MMA_N, head_dim / 64B))
+                sK_ldsm = cute.zipped_divide(
+                    sK_warp, (16, cute.make_layout((elems, 2)), 1)
+                )
+                sQ_ldsm = cute.zipped_divide(sQ, (MMA_N, cute.make_layout((elems, 4))))
+
+                # sK: (16B, (32 / 16, head_dim / 32B, num_stages))
+                # sQ: (16B, (BLOCK_Q / MMA_N, head_dim / 64B))
+                sK_ldsm = sK_ldsm[(lane_id % 16, (None, lane_id // 16), 0), None]
+                sQ_ldsm = sQ_ldsm[(lane_id % MMA_N, (None, lane_id // 8)), None]
+
+                ldsm_op = warp.LdMatrix8x8x16bOp(num_matrices=4)
+                ldsm_atom = cute.make_copy_atom(ldsm_op, dtype)
+
+                rQ = cute.make_rmem_tensor(
+                    ((elems // 2, 2), head_dim // (MMA_K * 2), Q_TILES), dtype
+                )
+                rK = cute.make_rmem_tensor((elems, 2, head_dim // MMA_K), dtype)
+                rC = cute.make_rmem_tensor((4, 2, Q_TILES), Float32)
+
+                if warp_id == 0:
+                    cute.arch.mbarrier_wait(tma_full_mbar, 0)
+                cute.arch.barrier(barrier_id=self.BAR_MMA, number_of_threads=128)
+                for q in cutlass.range_constexpr(Q_TILES):
+                    cute.copy(ldsm_atom, sQ_ldsm[None, (q, None)], rQ[None, None, q])
+                cute.arch.mbarrier_arrive(tma_empty_mbar)
+
+                tma_stage = 1 % self.num_stages
+                tma_parity = 0
+                if tma_stage == 0:
+                    tma_parity ^= 1
+
+                # sm100 doesn't have native mma.sync.f8. ptxas lowers mma.sync.f8
+                # to F2FP.F16.E4M3 + HMMA; doing the conversion explicitly gives
+                # better codegen while keeping the two FP16 k-fragments visible.
+                if cutlass.const_expr(dtype is Float8E4M3FN):
+                    rQ_f16 = cute.make_rmem_tensor(
+                        (4, head_dim // MMA_K, Q_TILES, 2), Float16
+                    )
+                    q_lower, q_upper = _fp8_to_f16_mma_fragments(rQ)
+                    rQ_f16[None, None, None, 0].store(q_lower.load())
+                    rQ_f16[None, None, None, 1].store(q_upper.load())
+
+                for block_id in range(split_id, num_blocks, split_k):
+                    rC.fill(0.0)
+
+                    if warp_id == 0:
+                        cute.arch.mbarrier_wait(tma_full_mbar + tma_stage, tma_parity)
+                    cute.arch.barrier(barrier_id=self.BAR_MMA, number_of_threads=128)
+
+                    for k in cutlass.range_constexpr(head_dim // MMA_K):
+                        cute.copy(
+                            ldsm_atom,
+                            sK_ldsm[None, (None, k, tma_stage)],
+                            rK[None, None, k],
+                        )
+                        for m in cutlass.range_constexpr(2):
+                            if cutlass.const_expr(dtype is Float8E4M3FN):
+                                rK_lower, rK_upper = _fp8_to_f16_mma_fragments(
+                                    rK[None, m, k]
+                                )
+                                for n in cutlass.range_constexpr(Q_TILES):
+                                    rC[None, m, n] = mma_sync(
+                                        rK_lower,
+                                        rQ_f16[None, k, n, 0],
+                                        rC[None, m, n],
+                                    )
+                                    rC[None, m, n] = mma_sync(
+                                        rK_upper,
+                                        rQ_f16[None, k, n, 1],
+                                        rC[None, m, n],
+                                    )
+                            else:
+                                for n in cutlass.range_constexpr(Q_TILES):
+                                    rC[None, m, n] = mma_sync(
+                                        rK[None, m, k],
+                                        rQ[(None, k % 2), k // 2, n],
+                                        rC[None, m, n],
+                                    )
+
+                    cute.arch.mbarrier_arrive(tma_empty_mbar + tma_stage)
+
+                    k_start = block_id * BLOCK_K + warp_id * 32
+
+                    # causal mask
+                    for q in cutlass.range_constexpr(Q_TILES):
+                        for i in cutlass.range_constexpr(4):
+                            for j in cutlass.range_constexpr(2):
+                                col = q * 8 + (lane_id % 4) * 2 + j
+                                q_local_pos = col % MAX_DQL
+                                q_pos = q_start + q_local_pos
+                                k_pos = k_start + i * 8 + lane_id // 4
+                                rC[q * 8 + i * 2 + j] = (
+                                    rC[q * 8 + i * 2 + j]
+                                    if q_pos >= k_pos
+                                    else float("-inf")
+                                )
+
+                    for q in cutlass.range_constexpr(Q_TILES):
+                        # thread-reduction along BLOCK_K dim
+                        rScore = cute.make_rmem_tensor(2, Float32)
+                        rScore.fill(float("-inf"))
+                        for i in cutlass.range_constexpr(4):
+                            rScore[0] = cute.arch.fmax(rScore[0], rC[i * 2 + 0 + q * 8])
+                            rScore[1] = cute.arch.fmax(rScore[1], rC[i * 2 + 1 + q * 8])
+
+                        # warp-reduction among lanes 0,4,8,12,...
+                        for i in cutlass.range_constexpr(3):
+                            offset = 4 << i
+                            other0 = cute.arch.shuffle_sync_bfly(
+                                rScore[0], offset=offset, mask=-1, mask_and_clamp=31
+                            )
+                            other1 = cute.arch.shuffle_sync_bfly(
+                                rScore[1], offset=offset, mask=-1, mask_and_clamp=31
+                            )
+                            rScore[0] = cute.arch.fmax(rScore[0], other0)
+                            rScore[1] = cute.arch.fmax(rScore[1], other1)
+
+                        # store to smem for 4-warp reduction
+                        if lane_id * 2 < MMA_N:
+                            epi_buffer[q * MMA_N + lane_id * 2 + 0, warp_id] = rScore[0]
+                            epi_buffer[q * MMA_N + lane_id * 2 + 1, warp_id] = rScore[1]
+                    cute.arch.barrier(barrier_id=self.BAR_MMA, number_of_threads=128)
+
+                    head_id = lane_id // MAX_DQL
+                    q_local_pos = lane_id - head_id * MAX_DQL
+                    valid_q = head_id < NUM_HEADS and q_local_pos < decode_query_len
+                    if lane_id < BLOCK_Q and valid_q:
+                        final_score = epi_buffer[lane_id, 0]
+                        for i in cutlass.range_constexpr(1, 4):
+                            final_score = cute.arch.fmax(
+                                final_score, epi_buffer[lane_id, i]
+                            )
+                        final_score = final_score * self.scale
+
+                        # Forced init/local blocks are written as +inf so the
+                        # shared top-k always selects them (TokenSpeed indexer
+                        # contract; the visibility bound keeps future blocks
+                        # at their masked -inf).
+                        q_pos = q_start + q_local_pos
+                        visible_blocks = (q_pos + BLOCK_K) // BLOCK_K
+                        local_start = visible_blocks - self.local_blocks
+                        forced = block_id < self.init_blocks or (
+                            block_id >= local_start and block_id < visible_blocks
+                        )
+                        final_score = float("inf") if forced else final_score
+
+                        t = batch_id * decode_query_len + q_local_pos
+                        score[head_id, t, block_id] = final_score
+
+                    tma_stage = (tma_stage + 1) % self.num_stages
+                    if tma_stage == 0:
+                        tma_parity ^= 1
+
+    @cache
+    @staticmethod
+    def compile(
+        dtype: type[cutlass.Numeric],
+        num_heads: int,
+        max_decode_query_len: int,
+        split_k: int,
+        head_dim: int,
+        scale: float,
+        init_blocks: int,
+        local_blocks: int,
+    ):
+        bs = cute.sym_int()
+        total_tokens = cute.sym_int()
+        BLOCK_K = IndexDecodeScoreKernel.BLOCK_K
+
+        q = make_fake_tensor(
+            dtype, (total_tokens, num_heads, head_dim), divisibility=16
+        )
+        k_cache = make_fake_tensor(
+            dtype, (cute.sym_int(), BLOCK_K, head_dim), divisibility=16
+        )
+        block_table = make_fake_tensor(Int32, (bs, cute.sym_int()), divisibility=1)
+        score = make_fake_tensor(
+            Float32, (num_heads, total_tokens, cute.sym_int()), divisibility=4
+        )
+        seq_lens = make_fake_tensor(Int32, (bs,), divisibility=1)
+        kernel = IndexDecodeScoreKernel(
+            dtype,
+            num_heads,
+            max_decode_query_len,
+            split_k,
+            head_dim,
+            scale,
+            init_blocks,
+            local_blocks,
+        )
+        stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+        return cute.compile(
+            kernel,
+            q,
+            k_cache,
+            block_table,
+            score,
+            seq_lens,
+            stream,
+            options="--enable-tvm-ffi",
+        )
+
+
+def minimax_index_decode_score(
+    index_q: torch.Tensor,
+    cache_pages: torch.Tensor,
+    scores: torch.Tensor,
+    block_table: torch.Tensor,
+    seq_lens: torch.Tensor,
+    *,
+    scale: float,
+    init_blocks: int,
+    local_blocks: int,
+    decode_query_len: int,
+) -> None:
+    """Score visible 128-token blocks for decode via the CuteDSL kernel.
+
+    Args:
+        index_q: ``[tokens, heads, head_dim]`` BF16 or FP8-E4M3 index queries;
+            ``tokens == requests * decode_query_len``.
+        cache_pages: ``[pages, 128, head_dim]`` index-key cache, same dtype as
+            ``index_q``.
+        scores: ``[tokens, heads, max_blocks]`` fp32 buffer pre-filled with
+            ``-inf``; visible blocks are written in place, forced init/local
+            blocks as ``+inf``.
+        block_table: ``[requests, pages]`` int32 page table.
+        seq_lens: ``[requests]`` int32 total lengths after this step.
+        scale: Index score scale applied to the written scores.
+        init_blocks: Leading blocks forced into the selection.
+        local_blocks: Most-recent blocks forced into the selection.
+        decode_query_len: Uniform queries per request.
+
+    Returns:
+        None; ``scores`` is written in place.
+    """
+    tokens, num_heads, head_dim = index_q.shape
+    kernel = IndexDecodeScoreKernel.compile(
+        _TORCH_TO_CUTE_DTYPE[index_q.dtype],
+        num_heads,
+        decode_query_len,
+        256,
+        head_dim,
+        float(scale),
+        int(init_blocks),
+        int(local_blocks),
+    )
+    kernel(
+        index_q,
+        cache_pages,
+        block_table,
+        scores.permute(1, 0, 2),
+        seq_lens,
+    )
+
+
+def decode_score_supported(
+    index_q: torch.Tensor,
+    cache_pages: torch.Tensor,
+    decode_query_len: int,
+    max_blocks: int,
+) -> bool:
+    """Whether the CuteDSL decode score kernel can serve this call.
+
+    Args:
+        index_q: ``[tokens, heads, head_dim]`` index queries.
+        cache_pages: ``[pages, 128, head_dim]`` index-key cache view.
+        decode_query_len: Uniform queries per request.
+        max_blocks: Number of logical block columns being scored.
+
+    Returns:
+        True when the kernel supports the shape/dtype combination on this
+        platform.
+    """
+    return (
+        index_q.dtype == cache_pages.dtype
+        and index_q.dtype in _TORCH_TO_CUTE_DTYPE
+        and index_q.shape[-1] == 128
+        and index_q.shape[1] * decode_query_len <= 32
+        and max_blocks % 4 == 0
+        and cache_pages.is_contiguous()
+    )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/msa.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/msa.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import functools
 import importlib.util
+from collections.abc import Sequence
 
 import torch
 from tokenspeed_kernel.ops.attention.triton.minimax_indexer import (
@@ -123,6 +124,8 @@ if platform.is_nvidia and platform.is_blackwell and _fmha_sm100_importable():
         local_blocks: int,
         k_scale: float | torch.Tensor | None = None,
         v_scale: float | torch.Tensor | None = None,
+        query_lens_cpu: Sequence[int] | None = None,
+        seq_lens_cpu: Sequence[int] | None = None,
     ) -> torch.Tensor:
         """Run MiniMax sparse-attention extend with the CuTe attend kernel."""
 
@@ -155,6 +158,8 @@ if platform.is_nvidia and platform.is_blackwell and _fmha_sm100_importable():
                 local_blocks=local_blocks,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                query_lens_cpu=query_lens_cpu,
+                seq_lens_cpu=seq_lens_cpu,
             )
         if q.shape[0] == 0:
             return torch.empty_like(q)
@@ -180,6 +185,8 @@ if platform.is_nvidia and platform.is_blackwell and _fmha_sm100_importable():
             prefix_lens=prefix_lens,
             max_query_len=max_seqlen_q,
             max_blocks=max_blocks,
+            query_lens_cpu=query_lens_cpu,
+            seq_lens_cpu=seq_lens_cpu,
         )
 
         q = q.contiguous()

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/msa_score.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/msa_score.py
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Copyright (c) 2026 LightSeek Foundation
+
+"""MiniMax MSA prefill block-score + top-k on the fmha_sm100 OnlyScore path.
+
+Wraps the vendored ``thirdparty/msa`` nvcc-JIT dense FMHA in score-only mode
+(``output_maxscore=True, output_o=False``) plus its ``sparse_topk_select``
+kernel as a drop-in replacement for the Triton ``_prefill_block_score_kernel``
++ ``_topk_with_padding`` pair inside ``minimax_indexer``.  SM100 only.
+
+The fmha ``max_score`` is the raw QK row max (``sm_scale`` only feeds the
+softmax path), so scores here are unscaled relative to the Triton path;
+rankings are identical and the buffer is consumed only by the top-k.  Forced
+init/local blocks are applied by ``sparse_topk_select`` rather than written
+into the score buffer.
+
+Kernel variants JIT-compile with nvcc on first use (~45 s each, disk-cached
+under ``~/.cache/minfer/fmha_sm100``).  Compilation runs on a background
+thread; until it finishes ``prefill_score_supported`` returns False and
+callers keep the Triton path, so serving never stalls on nvcc.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import math
+import threading
+from collections.abc import Sequence
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+_PAGE_SIZE = 128
+_TOPK = 16
+# Below ~128 pages the upstream top-k kernel's fixed per-row cost outweighs
+# the OnlyScore kernel's win over the Triton scorer (measured crossover).
+_MIN_BLOCKS = 129
+# Upstream sparse_topk_select only implements the insertion-sort path.
+_MAX_K_TILES_LIMIT = 12288
+# fmha_sm100_plan disables max_score output beyond 2^31 elements.
+_MAX_SCORE_ELEMS = 1 << 31
+
+_jit_state: dict = {"thread": None, "ready": False, "failed": False}
+_jit_lock = threading.Lock()
+
+
+@functools.lru_cache(maxsize=1)
+def _load_api():
+    from tokenspeed_kernel.thirdparty.msa.api import (
+        _fmha_sm100,
+        _fmha_sm100_plan,
+        sparse_topk_select,
+    )
+
+    return _fmha_sm100, _fmha_sm100_plan, sparse_topk_select
+
+
+def _compile_variants() -> None:
+    try:
+        from tokenspeed_kernel.thirdparty.msa import jit as msa_jit
+
+        msa_jit.get_plan_fn()
+        msa_jit.get_sparse_topk_module()
+        bf16 = msa_jit._dlpack_dtype_code(torch.bfloat16)
+        # All OnlyScore/paged/no-split/pack-1 variants reachable from this
+        # wrapper: (qo_tile, single_wg) keyed off the batch's max query length.
+        for qo_tile, single_wg in ((128, True), (128, False), (256, False)):
+            msa_jit.get_fmha_variant(bf16, qo_tile, single_wg, 2, _PAGE_SIZE, False, 1)
+        _load_api()
+        _jit_state["ready"] = True
+        logger.info("MSA fmha OnlyScore prefill scorer ready")
+    except Exception:
+        _jit_state["failed"] = True
+        logger.exception(
+            "MSA fmha OnlyScore JIT failed; prefill keeps the Triton scorer"
+        )
+
+
+def ensure_prefill_score_ready(timeout: float | None = 0.0) -> bool:
+    """Start (and optionally wait for) the fmha OnlyScore JIT compilation.
+
+    Args:
+        timeout: Seconds to block waiting for compilation. ``0.0`` returns
+            immediately after kicking off the background compile; ``None``
+            blocks until it finishes.
+
+    Returns:
+        True once every kernel variant is compiled and loadable.
+    """
+    if _jit_state["ready"]:
+        return True
+    if _jit_state["failed"]:
+        return False
+    with _jit_lock:
+        if _jit_state["thread"] is None:
+            thread = threading.Thread(
+                target=_compile_variants, name="msa-score-jit", daemon=True
+            )
+            _jit_state["thread"] = thread
+            thread.start()
+    if timeout != 0.0:
+        _jit_state["thread"].join(timeout)
+    return _jit_state["ready"]
+
+
+def prefill_score_supported(
+    index_q: torch.Tensor,
+    cache_pages: torch.Tensor,
+    topk: int,
+    max_blocks: int,
+    query_lens_cpu: Sequence[int] | None,
+    seq_lens_cpu: Sequence[int] | None,
+) -> bool:
+    """Return True when the fmha OnlyScore prefill path applies.
+
+    Args:
+        index_q: Index queries shaped ``[tokens, heads, 128]``.
+        cache_pages: Index-key cache pages shaped ``[pages, 128, 128]``.
+        topk: Number of selected blocks (must be 16 upstream).
+        max_blocks: Logical block columns scored for this batch.
+        query_lens_cpu: Host-side per-request new-token counts.
+        seq_lens_cpu: Host-side per-request total sequence lengths.
+
+    Returns:
+        Whether ``minimax_prefill_score_topk`` can serve this batch.
+    """
+    if query_lens_cpu is None or seq_lens_cpu is None:
+        return False
+    if topk != _TOPK:
+        return False
+    if index_q.dtype != torch.bfloat16 or cache_pages.dtype != torch.bfloat16:
+        return False
+    if index_q.shape[-1] != 128 or cache_pages.shape[-1] != 128:
+        return False
+    if cache_pages.shape[1] != _PAGE_SIZE or not cache_pages.is_contiguous():
+        return False
+    if max_blocks < _MIN_BLOCKS:
+        return False
+    max_k_tiles = math.ceil(max_blocks / 128) * 128
+    if max_k_tiles >= _MAX_K_TILES_LIMIT:
+        return False
+    tokens, heads = index_q.shape[0], index_q.shape[1]
+    if tokens * heads * max_k_tiles >= _MAX_SCORE_ELEMS:
+        return False
+    if torch.cuda.is_current_stream_capturing():
+        return False
+    return ensure_prefill_score_ready(0.0)
+
+
+@functools.lru_cache(maxsize=8)
+def _plan_for_batch(
+    query_lens: tuple[int, ...],
+    seq_lens: tuple[int, ...],
+    num_heads: int,
+    device: torch.device,
+):
+    _, _fmha_sm100_plan, _ = _load_api()
+    qo_t = torch.tensor(query_lens, dtype=torch.int32)
+    kv_t = torch.tensor(seq_lens, dtype=torch.int32)
+    # num_kv_heads=-1 pins pack_factor to 1 so only the three precompiled
+    # variants are ever dispatched (a packed variant would nvcc-JIT inline).
+    plan = _fmha_sm100_plan(
+        qo_t,
+        kv_t,
+        num_heads,
+        num_kv_heads=-1,
+        qo_offset=kv_t - qo_t,
+        page_size=_PAGE_SIZE,
+        output_maxscore=True,
+        causal=True,
+        num_kv_splits=1,
+        device=device,
+    )
+    assert plan["max_k_tiles"] > 0, "planner disabled max_score output"
+    positions = torch.cat(
+        [
+            torch.arange(k - q, k, dtype=torch.int32)
+            for q, k in zip(query_lens, seq_lens)
+        ]
+    )
+    num_valid_pages_tok = (positions // _PAGE_SIZE + 1).to(device)
+    num_pages_req = torch.tensor(
+        [(k + _PAGE_SIZE - 1) // _PAGE_SIZE for k in seq_lens],
+        dtype=torch.int32,
+        device=device,
+    )
+    return plan, num_valid_pages_tok, num_pages_req
+
+
+def minimax_prefill_score_topk(
+    index_q: torch.Tensor,
+    cache_pages: torch.Tensor,
+    block_table: torch.Tensor,
+    *,
+    scale: float,
+    init_blocks: int,
+    local_blocks: int,
+    topk: int,
+    query_lens_cpu: Sequence[int],
+    seq_lens_cpu: Sequence[int],
+) -> torch.Tensor:
+    """Score visible blocks with fmha OnlyScore and select Top-K per token.
+
+    Args:
+        index_q: Index queries shaped ``[tokens, heads, 128]``, BF16.
+        cache_pages: Index-key cache shaped ``[pages, 128, 128]``, BF16.
+        block_table: Logical-to-physical page table ``[requests, pages]``.
+        scale: Index score scale (forwarded as ``sm_scale``; the emitted
+            scores stay in raw QK units — see the module docstring).
+        init_blocks: Leading blocks forced into the selection.
+        local_blocks: Most-recent blocks forced into the selection.
+        topk: Number of selected blocks per token (16).
+        query_lens_cpu: Host-side per-request new-token counts.
+        seq_lens_cpu: Host-side per-request total sequence lengths.
+
+    Returns:
+        Selected logical block ids ``[tokens, heads, topk]`` int32, ascending
+        per row with ``-1`` padding past each token's visible block count.
+    """
+    _fmha_sm100, _, sparse_topk_select = _load_api()
+    tokens, num_heads, head_dim = index_q.shape
+    device = index_q.device
+    plan, num_valid_pages_tok, num_pages_req = _plan_for_batch(
+        tuple(int(x) for x in query_lens_cpu),
+        tuple(int(x) for x in seq_lens_cpu),
+        num_heads,
+        device,
+    )
+    max_k_tiles = plan["max_k_tiles"]
+
+    cols = torch.arange(block_table.shape[1], device=device)
+    flat_page_table = block_table[cols[None, :] < num_pages_req[:, None]]
+
+    scores = torch.full(
+        (tokens, num_heads, max_k_tiles),
+        -float("inf"),
+        dtype=torch.float32,
+        device=device,
+    )
+    k_pages = cache_pages.view(cache_pages.shape[0], 1, _PAGE_SIZE, head_dim)
+    _fmha_sm100(
+        index_q,
+        k_pages,
+        k_pages,  # V placeholder; never read in OnlyScore mode
+        plan,
+        kv_indices=flat_page_table,
+        output_o=False,
+        output_maxscore=True,
+        sm_scale=scale,
+        max_score=scores,
+    )
+
+    selected = torch.empty((tokens, num_heads, topk), dtype=torch.int32, device=device)
+    sparse_topk_select(
+        scores,
+        topk,
+        num_valid_pages=num_valid_pages_tok,
+        force_begin_blocks=init_blocks,
+        force_end_blocks=local_blocks,
+        output=selected,
+        max_score_layout="THK",
+    )
+    return selected
+
+
+__all__ = [
+    "ensure_prefill_score_ready",
+    "minimax_prefill_score_topk",
+    "prefill_score_supported",
+]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_indexer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_indexer.py
@@ -14,8 +14,24 @@ from __future__ import annotations
 import torch
 from tokenspeed_kernel._triton import tl, triton
 from tokenspeed_kernel.ops.attention.triton.dsa_topk import _topk_with_padding
+from tokenspeed_kernel.platform import current_platform
 
 SPARSE_BLOCK_SIZE = 128
+
+if current_platform().is_blackwell:
+    try:
+        from tokenspeed_kernel.ops.attention.cute_dsl.minimax_index_decode_score import (
+            decode_score_supported as _cutedsl_decode_score_supported,
+        )
+        from tokenspeed_kernel.ops.attention.cute_dsl.minimax_index_decode_score import (
+            minimax_index_decode_score as _cutedsl_decode_score,
+        )
+    except ImportError:
+        _cutedsl_decode_score = None
+        _cutedsl_decode_score_supported = None
+else:
+    _cutedsl_decode_score = None
+    _cutedsl_decode_score_supported = None
 
 
 @triton.jit
@@ -382,37 +398,52 @@ def minimax_indexer(
                 f"tokens={tokens}, requests={seq_lens.numel()}, "
                 f"decode_query_len={decode_query_len}"
             )
-        num_chunks = 64
-        block_q = triton.next_power_of_2(decode_query_len)
-        _decode_block_score_kernel[(seq_lens.numel(), num_chunks)](
-            index_q,
-            cache_pages,
-            scores,
-            block_table,
-            seq_lens,
-            num_index_heads=num_heads,
-            scale=float(scale),
-            init_blocks=int(init_blocks),
-            local_blocks=int(local_blocks),
-            decode_query_len=decode_query_len,
-            max_blocks=max_blocks,
-            num_chunks=num_chunks,
-            stride_q_n=index_q.stride(0),
-            stride_q_h=index_q.stride(1),
-            stride_q_d=index_q.stride(2),
-            stride_k_page=cache_pages.stride(0),
-            stride_k_pos=cache_pages.stride(1),
-            stride_k_d=cache_pages.stride(2),
-            stride_s_n=scores.stride(0),
-            stride_s_h=scores.stride(1),
-            stride_s_b=scores.stride(2),
-            stride_bt_b=block_table.stride(0),
-            head_dim=head_dim,
-            BLOCK_Q=block_q,
-            BLOCK_K=SPARSE_BLOCK_SIZE,
-            num_warps=4,
-            num_stages=2,
-        )
+        if _cutedsl_decode_score is not None and _cutedsl_decode_score_supported(
+            index_q, cache_pages, decode_query_len, max_blocks
+        ):
+            _cutedsl_decode_score(
+                index_q,
+                cache_pages,
+                scores,
+                block_table,
+                seq_lens,
+                scale=float(scale),
+                init_blocks=int(init_blocks),
+                local_blocks=int(local_blocks),
+                decode_query_len=decode_query_len,
+            )
+        else:
+            num_chunks = 64
+            block_q = triton.next_power_of_2(decode_query_len)
+            _decode_block_score_kernel[(seq_lens.numel(), num_chunks)](
+                index_q,
+                cache_pages,
+                scores,
+                block_table,
+                seq_lens,
+                num_index_heads=num_heads,
+                scale=float(scale),
+                init_blocks=int(init_blocks),
+                local_blocks=int(local_blocks),
+                decode_query_len=decode_query_len,
+                max_blocks=max_blocks,
+                num_chunks=num_chunks,
+                stride_q_n=index_q.stride(0),
+                stride_q_h=index_q.stride(1),
+                stride_q_d=index_q.stride(2),
+                stride_k_page=cache_pages.stride(0),
+                stride_k_pos=cache_pages.stride(1),
+                stride_k_d=cache_pages.stride(2),
+                stride_s_n=scores.stride(0),
+                stride_s_h=scores.stride(1),
+                stride_s_b=scores.stride(2),
+                stride_bt_b=block_table.stride(0),
+                head_dim=head_dim,
+                BLOCK_Q=block_q,
+                BLOCK_K=SPARSE_BLOCK_SIZE,
+                num_warps=4,
+                num_stages=2,
+            )
     else:
         if cu_seqlens_q is None or prefix_lens is None or max_query_len <= 0:
             raise ValueError(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_indexer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_indexer.py
@@ -11,6 +11,8 @@ the selected set.  The code is adapted to TokenSpeed's paged-cache layout.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import torch
 from tokenspeed_kernel._triton import tl, triton
 from tokenspeed_kernel.ops.attention.triton.dsa_topk import _topk_with_padding
@@ -29,9 +31,21 @@ if current_platform().is_blackwell:
     except ImportError:
         _cutedsl_decode_score = None
         _cutedsl_decode_score_supported = None
+    try:
+        from tokenspeed_kernel.ops.attention.msa_score import (
+            minimax_prefill_score_topk as _fmha_prefill_score_topk,
+        )
+        from tokenspeed_kernel.ops.attention.msa_score import (
+            prefill_score_supported as _fmha_prefill_score_supported,
+        )
+    except ImportError:
+        _fmha_prefill_score_topk = None
+        _fmha_prefill_score_supported = None
 else:
     _cutedsl_decode_score = None
     _cutedsl_decode_score_supported = None
+    _fmha_prefill_score_topk = None
+    _fmha_prefill_score_supported = None
 
 
 @triton.jit
@@ -303,6 +317,8 @@ def minimax_indexer(
     prefix_lens: torch.Tensor | None = None,
     max_query_len: int = 0,
     max_blocks: int | None = None,
+    query_lens_cpu: Sequence[int] | None = None,
+    seq_lens_cpu: Sequence[int] | None = None,
 ) -> torch.Tensor:
     """Write index keys, score visible 128-token blocks, and select Top-K.
 
@@ -327,6 +343,11 @@ def minimax_indexer(
         max_blocks: Number of logical block columns to score. Defaults to the
             page-table width; prefill callers should pass the current batch's
             upper bound to avoid allocating scores for the full 1M context.
+        query_lens_cpu: Optional host-side per-request new-token counts. When
+            provided together with ``seq_lens_cpu``, the prefill path may score
+            with the fmha_sm100 OnlyScore kernel instead of Triton.
+        seq_lens_cpu: Optional host-side per-request total sequence lengths;
+            see ``query_lens_cpu``.
 
     Returns:
         Selected logical block ids shaped ``[tokens, local_index_heads, topk]``.
@@ -383,12 +404,6 @@ def minimax_indexer(
         raise ValueError(
             f"max_blocks must be in [1, {block_table.shape[1]}], got {max_blocks}"
         )
-    scores = torch.full(
-        (tokens, num_heads, max_blocks),
-        -float("inf"),
-        dtype=torch.float32,
-        device=index_q.device,
-    )
     cache_pages = index_k_cache.view(-1, SPARSE_BLOCK_SIZE, head_dim)
     if decode_query_len:
         decode_query_len = int(decode_query_len)
@@ -398,6 +413,12 @@ def minimax_indexer(
                 f"tokens={tokens}, requests={seq_lens.numel()}, "
                 f"decode_query_len={decode_query_len}"
             )
+        scores = torch.full(
+            (tokens, num_heads, max_blocks),
+            -float("inf"),
+            dtype=torch.float32,
+            device=index_q.device,
+        )
         if _cutedsl_decode_score is not None and _cutedsl_decode_score_supported(
             index_q, cache_pages, decode_query_len, max_blocks
         ):
@@ -450,6 +471,25 @@ def minimax_indexer(
                 "prefill indexer requires cu_seqlens_q, prefix_lens, and "
                 "positive max_query_len"
             )
+        if _fmha_prefill_score_topk is not None and _fmha_prefill_score_supported(
+            index_q,
+            cache_pages,
+            int(topk),
+            max_blocks,
+            query_lens_cpu,
+            seq_lens_cpu,
+        ):
+            return _fmha_prefill_score_topk(
+                index_q,
+                cache_pages,
+                block_table,
+                scale=float(scale),
+                init_blocks=int(init_blocks),
+                local_blocks=int(local_blocks),
+                topk=int(topk),
+                query_lens_cpu=query_lens_cpu,
+                seq_lens_cpu=seq_lens_cpu,
+            )
         cu_seqlens_q = cu_seqlens_q.to(
             device=index_q.device, dtype=torch.int32
         ).contiguous()
@@ -457,6 +497,12 @@ def minimax_indexer(
             device=index_q.device, dtype=torch.int32
         ).contiguous()
         batch = cu_seqlens_q.numel() - 1
+        scores = torch.full(
+            (tokens, num_heads, max_blocks),
+            -float("inf"),
+            dtype=torch.float32,
+            device=index_q.device,
+        )
         block_q = 64
         _prefill_block_score_kernel[
             (triton.cdiv(int(max_query_len), block_q), batch * num_heads)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_sparse_attention.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_sparse_attention.py
@@ -11,6 +11,8 @@ softmax states, preserving exact attention over the selected tokens.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import torch
 from tokenspeed_kernel._triton import tl, triton
 from tokenspeed_kernel.ops.attention.triton.minimax_indexer import (
@@ -733,6 +735,8 @@ def triton_minimax_msa_extend_with_kvcache(
     local_blocks: int,
     k_scale: float | torch.Tensor | None = None,
     v_scale: float | torch.Tensor | None = None,
+    query_lens_cpu: Sequence[int] | None = None,
+    seq_lens_cpu: Sequence[int] | None = None,
 ) -> torch.Tensor:
     """Run MiniMax sparse-attention extend over paged caches."""
 
@@ -755,6 +759,8 @@ def triton_minimax_msa_extend_with_kvcache(
         prefix_lens=prefix_lens,
         max_query_len=max_seqlen_q,
         max_blocks=max_blocks,
+        query_lens_cpu=query_lens_cpu,
+        seq_lens_cpu=seq_lens_cpu,
     )
     return minimax_sparse_attention(
         q,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/README.md
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/README.md
@@ -15,21 +15,27 @@ for every tracked `thirdparty/` tree.
 
 ## What is vendored
 
-Only the CuTe-DSL sparse-attention stack needed for the block-sparse
-prefill attend:
+The CuTe-DSL sparse-attention stack for the block-sparse prefill attend,
+plus the nvcc-JIT dense FMHA used in score-only mode by the prefill indexer:
 
 - `__init__.py`, `sparse.py` — the public import surface
   (`fmha_sm100.sparse` re-exports `sparse_atten_func`, `build_k2q_csr`, ...).
 - `cute/` — `interface.py`, `sparse_index_utils.py`, `quantize.py`,
   `fp4_indexer_interface.py`, and the `src/` kernel sources
   (upstream tests, examples, and build scaffolding are excluded).
+- `api.py`, `jit.py`, `sparse_fmha_adapter.py`, `csrc/` — the nvcc-JIT dense
+  FMHA / indexer-score / top-k path (`fmha_sm100`, `fmha_sm100_plan`,
+  `sparse_topk_select`). Consumed by
+  `tokenspeed_kernel/ops/attention/msa_score.py` for the prefill indexer's
+  OnlyScore scoring + top-k.
 
-NOT vendored: `api.py`, `jit.py`, `csrc/`, `cutlass/` — the nvcc-JIT dense
-FMHA / indexer-score / top-k path (`fmha_sm100`, `fmha_sm100_plan`,
-`sparse_topk_select`). The package `__init__` degrades gracefully without
-them (its eager `.api` import is wrapped in `except ImportError`); accessing
-those symbols raises. Vendor them if the fmha indexer-score path is ever
-adopted.
+NOT vendored: `cutlass/` — upstream pins the full NVIDIA/CUTLASS repo
+(`eb61c911`, CUTLASS 4.3.4) as a submodule purely for headers. `jit.py`
+carries a local patch (`_find_cutlass_dir`, marked `TokenSpeed patch`)
+that resolves headers from `TOKENSPEED_MSA_CUTLASS_DIR`, a package-local
+`cutlass/` checkout, or the flashinfer wheel's bundled CUTLASS tree, in
+that order. The csrc tree compiles cleanly against flashinfer's CUTLASS
+4.5.0 (validated bitwise against the Triton scorer on SM100).
 
 ## Runtime requirements and behavior
 
@@ -45,12 +51,19 @@ adopted.
   `torch.utils.cpp_extension.load` on first import (needs nvcc; cached in
   `~/.cache/torch_extensions/`). The CuTe kernels JIT-compile per variant
   on first call (cutlass-dsl).
+- The dense FMHA path (`api.py`/`jit.py`) nvcc-JIT-compiles per kernel
+  variant (~45 s each) into `~/.cache/minfer/fmha_sm100/`
+  (`MINFER_FMHA_CACHE_DIR` overrides), loaded through `apache-tvm-ffi`;
+  needs `nvcc`, `ninja`, and `jinja2`. `ops/attention/msa_score.py`
+  compiles its variants on a background thread and keeps the Triton
+  scorer selected until they are ready, so serving never blocks on nvcc.
 - FP8 support is identity-scale only: BF16 Q with FP8-E4M3 K/V stages to
   BF16 in-kernel; there are no k/v descale parameters.
 
 ## Updating
 
 Re-copy from the upstream fork at a newer commit, let `pre-commit run`
-reformat the tree, update the pinned commit above, and re-run
+reformat the tree, re-apply the `TokenSpeed patch` block in `jit.py`,
+update the pinned commit above, and re-run
 `tokenspeed-kernel/test/ops/test_attention_msa.py`. To diff against
 upstream, black/isort-format the upstream side first.

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/api.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/api.py
@@ -1,0 +1,1772 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 MiniMax
+# SPDX-License-Identifier: MIT
+
+"""FMHA varlen attention API: plan + run for SM100.
+
+fmha_sm100_plan and fmha_sm100.
+
+Doc is REPO/docs/fmha_sm100_api.md
+"""
+
+import math
+from typing import Optional, Tuple, Union
+
+__all__ = [
+    "fmha_sm100_plan",
+    "fmha_sm100",
+    "sparse_topk_select",
+    "_fmha_sm100_plan",
+    "_fmha_sm100",
+]
+
+import numpy as np
+import torch
+
+from .jit import (
+    _PACK_FACTORS,
+    _dlpack_dtype_code,
+    get_fmha_variant,
+    get_plan_fn,
+    get_reduction_module,
+    get_sparse_topk_module,
+)
+from .sparse_fmha_adapter import sparse_fmha, sparse_fmha_plan
+
+_np_staging = np.empty(4096 * 1024, dtype=np.int32)
+_np_staging_offset = 0
+
+
+def _reset_np_staging():
+    global _np_staging_offset
+    _np_staging_offset = 0
+
+
+def _plan_buf_from_list(data, device):
+    global _np_staging, _np_staging_offset
+    n = len(data)
+    end = _np_staging_offset + n
+    if end > _np_staging.shape[0]:
+        _np_staging = np.empty(max(end, _np_staging.shape[0] * 2), dtype=np.int32)
+        _np_staging_offset = 0
+        end = n
+    _np_staging[_np_staging_offset:end] = data
+    buf = torch.empty(n, dtype=torch.int32, device=device)
+    buf.copy_(torch.from_numpy(_np_staging[_np_staging_offset:end]), non_blocking=True)
+    _np_staging_offset = end
+    return buf
+
+
+from enum import IntEnum, auto
+
+
+class _BuffTag(IntEnum):
+    fmha_sm100_cutlass_workspace = auto()
+
+    packed_work_range = auto()
+    packed_work_info = auto()
+    kv_tile_begin_indices = auto()
+    kv_tile_end_indices = auto()
+    kv_split_indices = auto()
+    plan_cost = auto()
+    num_kv_splits_per_row = auto()
+    workspace_lse = auto()
+
+    workspace_o = auto()
+
+    sparse_topk_workspace = auto()
+
+    Total = auto()
+
+
+_workspace_cache = [[None] * _BuffTag.Total for _ in range(16)]
+# _workspace_cache_per_plan = []
+
+
+def _new_ws_cache():
+    pass
+    # global _workspace_cache
+    # if len(_workspace_cache) == 0:
+    #     print("new")
+    #     _workspace_cache_per_plan.append([[None] * _BuffTag.Total for _ in range(16)])
+
+
+def _alloc_workspace_buf(tag, size, device, dtype):
+    global _workspace_cache
+    device_id = torch.device(device).index
+    buf = _workspace_cache[device_id][tag]
+    if buf is not None and buf.shape[0] >= size:
+        return buf
+    buf = torch.empty(size, dtype=dtype, device=device)
+    _workspace_cache[device_id][tag] = buf
+    return buf
+
+
+def _get_workspace_buf(tag, device):
+    global _workspace_cache
+    device_id = torch.device(device).index
+    return _workspace_cache[device_id][tag]
+
+
+def _alloc_perplan_buf(tag, size, device, dtype):
+    # global _workspace_cache
+    # device_id = torch.device(device).index
+    # buf = _workspace_cache[-1][device_id][tag]
+    # if buf is not None and buf.shape[0] >= size:
+    #     return buf
+    buf = torch.empty(size, dtype=dtype, device=device)
+    # _workspace_cache[-1][device_id][tag] = buf
+    return buf
+
+
+_NUM_CTA = None
+
+
+def _get_num_cta(device):
+    global _NUM_CTA
+    if _NUM_CTA is None:
+        _NUM_CTA = torch.cuda.get_device_properties(device).multi_processor_count
+    return _NUM_CTA
+
+
+def _compute_pack_factor(max_qo_len, num_qo_heads, num_kv_heads):
+    if num_kv_heads == -1:
+        return 1
+    h_r = num_qo_heads // num_kv_heads
+    if h_r <= 1 or max_qo_len <= 0 or max_qo_len > 32:
+        return 1
+    max_pf = 128 // max_qo_len
+    for pf in reversed(_PACK_FACTORS):
+        if pf <= max_pf and pf <= h_r and h_r % pf == 0:
+            return pf
+    return 1
+
+
+def _to_device(t, d):
+    return t.to(d, non_blocking=True) if t is not None else None
+
+
+def _prefill_qlen_threshold(sparse):
+    return 32 if sparse else 128
+
+
+def _validate_fmha_inputs(
+    q,
+    k,
+    v,
+    qo_segment_lens,
+    kv_segment_lens,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim_qk,
+    head_dim_vo,
+    batch_size,
+    qo_total_len,
+    is_paged,
+    kv_indices,
+    kv_block_indexes,
+    qo_offset,
+    page_size,
+    pack_factor=1,
+    packed_work_range=None,
+    packed_work_info=None,
+    num_kv_splits=1,
+    kv_tile_begin_indices=None,
+    kv_tile_end_indices=None,
+    kv_split_indices=None,
+    qo_segment_offsets=None,
+    kv_page_indptr=None,
+):
+    assert (
+        q.dim() == 3
+    ), f"q must be [total_qo_len, num_qo_heads, head_dim], got {q.shape}"
+    assert (
+        num_qo_heads % num_kv_heads == 0
+    ), f"num_qo_heads ({num_qo_heads}) must be divisible by num_kv_heads ({num_kv_heads})"
+    assert (
+        qo_segment_lens.dim() == 1
+    ), f"qo_segment_lens must be 1D, got {qo_segment_lens.shape}"
+    assert (
+        kv_segment_lens.dim() == 1
+    ), f"kv_segment_lens must be 1D, got {kv_segment_lens.shape}"
+    assert qo_segment_lens.shape[0] == batch_size
+    assert kv_segment_lens.shape[0] == batch_size
+
+    qo_lens_cpu = qo_segment_lens.cpu()
+    kv_lens_cpu = kv_segment_lens.cpu()
+
+    expected_qo_total = qo_total_len * pack_factor if pack_factor > 1 else qo_total_len
+    assert qo_lens_cpu.sum().item() == expected_qo_total, (
+        f"sum(qo_segment_lens)={qo_lens_cpu.sum().item()} != expected={expected_qo_total} "
+        f"(q.shape[0]={qo_total_len}, pack_factor={pack_factor})"
+    )
+
+    if is_paged:
+        assert (
+            k.dim() == 4
+        ), f"paged K must be [total_pages, H_kv, page_size, D], got {k.shape}"
+        assert (
+            v.dim() == 4
+        ), f"paged V must be [total_pages, H_kv, page_size, D], got {v.shape}"
+        total_pages = k.shape[0]
+        assert k.shape[1] == num_kv_heads
+        assert k.shape[2] == page_size
+        assert v.shape[0] == total_pages
+        assert v.shape[1] == num_kv_heads
+        assert v.shape[2] == page_size
+    else:
+        total_kv_len = k.shape[0]
+        assert (
+            kv_lens_cpu.sum().item() == total_kv_len
+        ), f"sum(kv_segment_lens)={kv_lens_cpu.sum().item()} != k.shape[0]={total_kv_len}"
+
+    if qo_offset is not None:
+        assert (
+            qo_offset.dim() == 1 and qo_offset.shape[0] == batch_size
+        ), f"qo_offset must be [batch_size={batch_size}], got {qo_offset.shape}"
+        # off_cpu = qo_offset.cpu()
+        # assert (off_cpu >= 0).all(), (
+        #     f"qo_offset must be non-negative, got min={off_cpu.min().item()}"
+        # )
+        # unpacked_qo_lens = qo_lens_cpu // pack_factor if pack_factor > 1 else qo_lens_cpu
+        # max_offsets = kv_lens_cpu - unpacked_qo_lens
+        # violations = off_cpu > max_offsets
+        # if violations.any():
+        #     b = violations.nonzero()[0].item()
+        #     assert False, (
+        #         f"qo_offset[{b}]={off_cpu[b].item()} > kv_len-qo_len="
+        #         f"{kv_lens_cpu[b].item()}-{qo_lens_cpu[b].item()}={max_offsets[b].item()}"
+        #     )
+
+    if kv_indices is not None and kv_block_indexes is None:
+        assert is_paged, "kv_indices provided but K/V are not paged (4D)"
+        kvi_cpu = kv_indices.cpu()
+        total_pages_in_table = kvi_cpu.shape[0]
+        total_pages_needed = sum(
+            (kv_lens_cpu[b].item() + page_size - 1) // page_size
+            for b in range(batch_size)
+        )
+        assert total_pages_in_table == total_pages_needed, (
+            f"kv_indices length {total_pages_in_table} != "
+            f"sum(ceil(kv_segment_lens/page_size))={total_pages_needed}"
+        )
+        total_pages = k.shape[0]
+        assert (kvi_cpu >= 0).all() and (kvi_cpu < total_pages).all(), (
+            f"kv_indices has values outside [0, {total_pages}): "
+            f"min={kvi_cpu.min().item()}, max={kvi_cpu.max().item()}"
+        )
+
+    if kv_block_indexes is not None:
+        assert is_paged, "sparse mode requires paged KV (kv_indices)"
+        assert kv_indices is not None, "sparse mode requires kv_indices"
+        assert (
+            kv_block_indexes.dim() == 3
+        ), f"kv_block_indexes must be [total_qo_len, H_kv, KVBlockNum], got {kv_block_indexes.shape}"
+        assert (
+            kv_block_indexes.shape[0] == qo_total_len
+        ), f"kv_block_indexes must be [total_qo_len={qo_total_len}, H_kv, KVBlockNum], got {kv_block_indexes.shape}"
+        assert kv_block_indexes.shape[1] == num_kv_heads
+
+        bi_cpu = kv_block_indexes.cpu()
+        valid_mask = bi_cpu != -1
+        assert (
+            (bi_cpu >= 0) | (bi_cpu == -1)
+        ).all(), "kv_block_indexes must contain only non-negative indices or -1"
+        assert (
+            valid_mask[:, :, :-1] >= valid_mask[:, :, 1:]
+        ).all(), "kv_block_indexes: -1 padding must be at the end"
+        unpacked_qo_lens = (
+            qo_lens_cpu // pack_factor if pack_factor > 1 else qo_lens_cpu
+        )
+        batch_of_qtoken = torch.repeat_interleave(
+            torch.arange(batch_size), unpacked_qo_lens
+        )
+        kv_lens_per_qtoken = kv_lens_cpu[batch_of_qtoken]
+        num_pages = ((kv_lens_per_qtoken + page_size - 1) // page_size).view(-1, 1, 1)
+        assert (
+            bi_cpu[valid_mask] < num_pages.expand_as(bi_cpu)[valid_mask]
+        ).all(), "kv_block_indexes: index out of range for batch page count"
+        both_valid = valid_mask[:, :, :-1] & valid_mask[:, :, 1:]
+        if both_valid.any():
+            assert (
+                bi_cpu[:, :, 1:][both_valid] > bi_cpu[:, :, :-1][both_valid]
+            ).all(), "kv_block_indexes: must be strictly ascending"
+
+    if qo_segment_offsets is not None:
+        off_cpu = qo_segment_offsets.cpu()
+        assert (
+            off_cpu.shape[0] == batch_size + 1
+        ), f"qo_segment_offsets must have {batch_size + 1} elements, got {off_cpu.shape[0]}"
+        assert off_cpu[0].item() == 0, f"qo_segment_offsets[0]={off_cpu[0].item()} != 0"
+        assert (
+            off_cpu[-1].item() == expected_qo_total
+        ), f"qo_segment_offsets[-1]={off_cpu[-1].item()} != expected={expected_qo_total}"
+        diffs = off_cpu[1:] - off_cpu[:-1]
+        assert (diffs >= 0).all(), "qo_segment_offsets must be non-decreasing"
+        assert (
+            diffs == qo_lens_cpu
+        ).all(), "qo_segment_offsets must be cumsum of qo_segment_lens"
+
+    if kv_page_indptr is not None:
+        ip_cpu = kv_page_indptr.cpu()
+        assert (
+            ip_cpu.shape[0] == batch_size + 1
+        ), f"kv_page_indptr must have {batch_size + 1} elements, got {ip_cpu.shape[0]}"
+        assert ip_cpu[0].item() == 0, f"kv_page_indptr[0]={ip_cpu[0].item()} != 0"
+        assert (
+            ip_cpu[1:] >= ip_cpu[:-1]
+        ).all(), "kv_page_indptr must be non-decreasing"
+        if kv_indices is not None:
+            assert (
+                ip_cpu[-1].item() <= kv_indices.shape[0]
+            ), f"kv_page_indptr[-1]={ip_cpu[-1].item()} > kv_indices.size={kv_indices.shape[0]}"
+
+    if packed_work_range is not None and packed_work_info is not None:
+        import math
+
+        pwr_cpu = packed_work_range.cpu()
+        pwi_cpu = packed_work_info.cpu()
+        num_ctas = pwr_cpu.shape[0]
+        max_work_idx = pwi_cpu.shape[0]
+
+        packed_num_heads = (
+            num_qo_heads // pack_factor if pack_factor > 1 else num_qo_heads
+        )
+        qo_tile_size = 128 if int(qo_lens_cpu.max()) <= 128 else 256
+        max_tiles_per_batch = [
+            (int(l) + qo_tile_size - 1) // qo_tile_size for l in qo_lens_cpu
+        ]
+
+        for cta in range(num_ctas):
+            r = int(pwr_cpu[cta].item())
+            start = r & 0xFFFFFFFF
+            end = (r >> 32) & 0xFFFFFFFF
+            assert start <= end, f"packed_work_range[{cta}]: start={start} > end={end}"
+            assert (
+                end <= max_work_idx
+            ), f"packed_work_range[{cta}]: end={end} > packed_work_info.size={max_work_idx}"
+            for wi in range(start, end):
+                packed = int(pwi_cpu[wi].item())
+                bi = packed & 0xFFFF
+                hi = (packed >> 16) & 0xFFFF
+                qo_tile = (packed >> 32) & 0xFFFFFFFF
+                assert (
+                    bi < batch_size
+                ), f"packed_work_info[{wi}]: batch_idx={bi} >= batch_size={batch_size}"
+                assert (
+                    hi < packed_num_heads
+                ), f"packed_work_info[{wi}]: head_idx={hi} >= packed_num_heads={packed_num_heads}"
+                assert qo_tile < max_tiles_per_batch[bi], (
+                    f"packed_work_info[{wi}]: qo_tile={qo_tile} >= max_tiles={max_tiles_per_batch[bi]} "
+                    f"for batch {bi} (qo_len={int(qo_lens_cpu[bi])})"
+                )
+
+        # Verify completeness: every (batch, head, qo_tile) must appear exactly once
+        # (for num_kv_splits=1) or exactly num_splits times (for split-KV, each with
+        # a different split index covering the full KV range).
+        expected = set()
+        for bi in range(batch_size):
+            for hi in range(packed_num_heads):
+                for qt in range(max_tiles_per_batch[bi]):
+                    expected.add((bi, hi, qt))
+
+        seen = {}
+        for cta in range(num_ctas):
+            r = int(pwr_cpu[cta].item())
+            start = r & 0xFFFFFFFF
+            end = (r >> 32) & 0xFFFFFFFF
+            for wi in range(start, end):
+                packed = int(pwi_cpu[wi].item())
+                bi = packed & 0xFFFF
+                hi = (packed >> 16) & 0xFFFF
+                qt = (packed >> 32) & 0xFFFFFFFF
+                key = (bi, hi, qt)
+                seen[key] = seen.get(key, 0) + 1
+
+        missing = expected - set(seen.keys())
+        assert (
+            not missing
+        ), f"plan missing {len(missing)} work items, e.g. {list(missing)[:5]}"
+
+        if num_kv_splits <= 1:
+            duplicates = {k: v for k, v in seen.items() if v > 1}
+            assert (
+                not duplicates
+            ), f"plan has {len(duplicates)} duplicated work items (nosplit), e.g. {list(duplicates.items())[:5]}"
+
+        if num_kv_splits > 1 and kv_tile_begin_indices is not None:
+            tb_cpu = kv_tile_begin_indices.cpu()
+            te_cpu = kv_tile_end_indices.cpu()
+            sp_cpu = kv_split_indices.cpu()
+
+            from collections import defaultdict
+
+            tile_splits = defaultdict(list)
+
+            for cta in range(num_ctas):
+                r = int(pwr_cpu[cta].item())
+                start = r & 0xFFFFFFFF
+                end = (r >> 32) & 0xFFFFFFFF
+                for wi in range(start, end):
+                    tb, te = int(tb_cpu[wi].item()), int(te_cpu[wi].item())
+                    assert (
+                        tb <= te
+                    ), f"kv_tile_begin[{wi}]={tb} > kv_tile_end[{wi}]={te}"
+                    sp = int(sp_cpu[wi].item())
+                    assert (
+                        0 <= sp < num_kv_splits
+                    ), f"kv_split_indices[{wi}]={sp} out of range [0, {num_kv_splits})"
+                    packed = int(pwi_cpu[wi].item())
+                    key = (
+                        packed & 0xFFFF,
+                        (packed >> 16) & 0xFFFF,
+                        (packed >> 32) & 0xFFFFFFFF,
+                    )
+                    tile_splits[key].append((tb, te, sp))
+
+            is_sparse = kv_block_indexes is not None
+            kv_tile_size = 256 if qo_tile_size == 128 else 128
+            for key, splits in tile_splits.items():
+                bi, hi, qt = key
+                if is_sparse:
+                    kv_block_num = kv_block_indexes.shape[2]
+                    kl = kv_block_num * page_size
+                    off_q = kl - int(qo_lens_cpu[bi])
+                else:
+                    kl = int(kv_lens_cpu[bi])
+                    off_q = (
+                        int(qo_offset[bi].cpu())
+                        if qo_offset is not None
+                        else (kl - int(qo_lens_cpu[bi]))
+                    )
+                packed_q_end = (qt + 1) * qo_tile_size
+                q_end = (
+                    (packed_q_end - 1) // pack_factor + 1
+                    if pack_factor > 1
+                    else packed_q_end
+                )
+                eff_kv = min(q_end + off_q, kl)
+                expected_iters = max(0, (eff_kv + kv_tile_size - 1) // kv_tile_size)
+                splits_sorted = sorted(splits, key=lambda x: x[0])
+                if expected_iters > 0:
+                    assert (
+                        splits_sorted[0][0] == 0
+                    ), f"tile {key}: first split begins at {splits_sorted[0][0]}, expected 0"
+                    assert (
+                        splits_sorted[-1][1] == expected_iters
+                    ), f"tile {key}: last split ends at {splits_sorted[-1][1]}, expected {expected_iters}"
+                for i in range(1, len(splits_sorted)):
+                    prev_end = splits_sorted[i - 1][1]
+                    curr_begin = splits_sorted[i][0]
+                    assert prev_end == curr_begin, (
+                        f"tile {key}: gap/overlap at split boundary: "
+                        f"prev_end={prev_end}, curr_begin={curr_begin}"
+                    )
+                sub_ids = sorted(s[2] for s in splits_sorted)
+                expected_ids = list(range(len(splits_sorted)))
+                assert (
+                    sub_ids == expected_ids
+                ), f"tile {key}: sub_ids {sub_ids} not contiguous 0..{len(splits_sorted)-1}"
+
+
+def _expand_for_per_token_sparse(qo_lens, kv_lens, qo_offset, page_size, pack_factor=1):
+    B = len(qo_lens)
+    total_q = sum(qo_lens)
+
+    if qo_offset is None:
+        qo_offset = [kv_lens[i] - qo_lens[i] for i in range(B)]
+
+    kv_page_indptr = [0]
+    acc = 0
+    for k in kv_lens:
+        acc += (k + page_size - 1) // page_size
+        kv_page_indptr.append(acc)
+
+    expanded_qo_lens = [pack_factor] * total_q
+    expanded_kv_lens = [0] * total_q
+    expanded_qo_offset = [0] * total_q
+    expanded_kv_page_indptr = [0] * (total_q + 1)
+
+    idx = 0
+    for b in range(B):
+        kv_len_b = kv_lens[b]
+        qo_offset_b = qo_offset[b]
+        kv_page_indptr_b = kv_page_indptr[b]
+        for j in range(qo_lens[b]):
+            expanded_kv_lens[idx] = kv_len_b
+            expanded_qo_offset[idx] = qo_offset_b + j
+            expanded_kv_page_indptr[idx] = kv_page_indptr_b
+            idx += 1
+
+    expanded_kv_page_indptr[total_q] = kv_page_indptr[B]
+
+    return (
+        expanded_qo_lens,
+        expanded_kv_lens,
+        expanded_qo_offset,
+        expanded_kv_page_indptr,
+    )
+
+
+class PlanInfo(dict):
+    """Execution plan returned by the internal dense FMHA planner.
+
+    Users normally receive the public tuple returned by ``fmha_sm100_plan`` and
+    pass it unchanged to ``fmha_sm100``.  The dictionary stores CUDA worklists,
+    sequence metadata, split-KV workspaces, and cached buffers owned by the
+    plan.
+    """
+
+    def __del__(self):
+        pass
+        # print("del")
+        # _workspace_cache_per_plan.append(self["_ws_cache"])
+
+
+def _make_plan_info(
+    packed_work_range,
+    packed_work_info,
+    kv_tile_begin_indices,
+    kv_tile_end_indices,
+    kv_split_indices,
+    num_kv_splits,
+    workspace_o,
+    workspace_lse,
+    max_qo_len,
+    predicted_speedup,
+    num_kv_splits_per_row,
+    qo_segment_offsets,
+    kv_segment_offsets,
+    kv_page_indptr,
+    max_k_tiles,
+    qo_segment_lens,
+    kv_segment_lens,
+    qo_offset,
+    pack_factor,
+    orig_num_qo_heads,
+    qo_len_uniform,
+    cute_workspace_buffer,
+):
+    # ws = _workspace_cache_per_plan.pop()
+    # print("pop")
+    return PlanInfo(
+        {
+            # "_ws_cache" : ws,
+            "packed_work_range": packed_work_range,
+            "packed_work_info": packed_work_info,
+            "kv_tile_begin_indices": kv_tile_begin_indices,
+            "kv_tile_end_indices": kv_tile_end_indices,
+            "kv_split_indices": kv_split_indices,
+            "num_kv_splits": num_kv_splits,
+            "workspace_o": workspace_o,
+            "workspace_lse": workspace_lse,
+            "max_qo_len": max_qo_len,
+            "predicted_speedup": predicted_speedup,
+            "num_kv_splits_per_row": num_kv_splits_per_row,
+            "qo_segment_offsets": qo_segment_offsets,
+            "kv_segment_offsets": kv_segment_offsets,
+            "kv_page_indptr": kv_page_indptr,
+            "max_k_tiles": max_k_tiles,
+            "qo_segment_lens": qo_segment_lens,
+            "kv_segment_lens": kv_segment_lens,
+            "qo_offset": qo_offset,
+            "pack_factor": pack_factor,
+            "orig_num_qo_heads": orig_num_qo_heads,
+            "qo_len_uniform": qo_len_uniform,
+            "cute_workspace_buffer": cute_workspace_buffer,
+            "MM-SA-Nv": False,
+        }
+    )
+
+
+def _call_plan(
+    qo_segment_offsets,
+    qo_segment_lens,
+    kv_segment_lens,
+    packed_work_range,
+    packed_work_info,
+    qo_tile_size,
+    kv_tile_size,
+    num_qo_heads,
+    num_ctas,
+    causal,
+    qo_offset,
+    num_kv_splits,
+    kv_tile_begin_indices,
+    kv_tile_end_indices,
+    kv_split_indices,
+    chunk_size,
+    out_max_sm_cost,
+    num_kv_splits_per_row,
+    workspace_lse,
+    lse_total_size,
+    pack_factor,
+    cuda_stream=None,
+):
+
+    plan_module = get_plan_fn()
+
+    if cuda_stream is None:
+        cuda_stream = torch.cuda.current_stream().cuda_stream
+    plan_module.plan(
+        qo_segment_offsets,
+        qo_segment_lens,
+        kv_segment_lens,
+        packed_work_range,
+        packed_work_info,
+        qo_tile_size,
+        kv_tile_size,
+        num_qo_heads,
+        num_ctas,
+        causal,
+        qo_offset,
+        num_kv_splits,
+        kv_tile_begin_indices,
+        kv_tile_end_indices,
+        kv_split_indices,
+        chunk_size,
+        out_max_sm_cost,
+        num_kv_splits_per_row,
+        cuda_stream,
+        workspace_lse,
+        lse_total_size,
+        pack_factor,
+    )
+
+
+def _fmha_sm100_plan(
+    qo_segment_lens: torch.Tensor,
+    kv_segment_lens: torch.Tensor,
+    num_qo_heads: int,
+    num_kv_heads: int = -1,
+    qo_offset: Optional[Union[int, torch.Tensor]] = None,
+    num_kv_splits: int = -1,
+    page_size: int = -1,
+    output_maxscore: bool = False,
+    kv_block_num: int = -1,
+    usable_SM_count: int = -1,
+    causal: bool = True,
+    sparse_kernel_mode: str = "auto",
+    use_fp8_kvcache: bool = False,
+    device=None,
+    stream=None,
+):
+    device = torch.cuda.current_device() if device is None else device
+    _reset_np_staging()
+
+    qo_lens = qo_segment_lens.tolist()
+    max_qo_len_orig = max(qo_lens) if qo_lens else 0
+
+    if kv_block_num > 0 and (
+        sparse_kernel_mode == "prefill"
+        or (
+            sparse_kernel_mode == "auto"
+            and max_qo_len_orig > _prefill_qlen_threshold(True)
+        )
+    ):
+        # print("Nv-Prefill")
+        qo_segment_lens = qo_segment_lens.to(device)
+        kv_segment_lens = kv_segment_lens.to(device)
+        qo_offset = qo_offset.to(device)
+        return sparse_fmha_plan(
+            qo_segment_lens=qo_segment_lens,
+            kv_segment_lens=kv_segment_lens,
+            num_qo_heads=num_qo_heads,
+            causal=causal,
+            qo_offset=qo_offset,
+            num_kv_splits=num_kv_splits,
+            page_size=page_size,
+            output_maxscore=output_maxscore,
+            kv_block_num=kv_block_num,
+            num_kv_heads=num_kv_heads,
+            usable_SM_count=usable_SM_count,
+            use_fp8_kvcache=use_fp8_kvcache,
+        )
+
+    _new_ws_cache()
+
+    cute_workspace_buffer = _alloc_workspace_buf(
+        _BuffTag.fmha_sm100_cutlass_workspace, 32 * 1024 * 1024, device, torch.uint8
+    )
+
+    cuda_stream = stream
+
+    num_ctas = _get_num_cta(device)
+    if usable_SM_count > 0:
+        num_ctas = min(usable_SM_count, num_ctas)
+
+    orig_num_qo_heads = num_qo_heads
+    pack_factor = _compute_pack_factor(max_qo_len_orig, num_qo_heads, num_kv_heads)
+    qo_len_uniform = len(qo_lens) > 0 and min(qo_lens) == max_qo_len_orig
+    if pack_factor > 1:
+        num_qo_heads = num_qo_heads // pack_factor
+
+    kv_lens = kv_segment_lens.tolist()
+    kv_page_indptr_list = None
+    if kv_block_num > 0 and page_size > 0:
+        total_q = sum(qo_lens)
+        total_q_packed = total_q * pack_factor if pack_factor > 1 else total_q
+        assert total_q_packed * num_qo_heads <= 65536
+        qo_offset_in = qo_offset.tolist() if qo_offset is not None else None
+        qo_lens, kv_lens, qo_offset, kv_page_indptr_list = _expand_for_per_token_sparse(
+            qo_lens, kv_lens, qo_offset_in, page_size, pack_factor
+        )
+    elif kv_block_num > 0 and page_size <= 0:
+        print("[Error] Sparse mode must be used together with paged kv!")
+    else:
+        if pack_factor > 1:
+            qo_lens = [q * pack_factor for q in qo_lens]
+        if page_size > 0:
+            acc = 0
+            kv_page_indptr_list = [0]
+            for k in kv_lens:
+                acc += (k + page_size - 1) // page_size
+                kv_page_indptr_list.append(acc)
+
+    acc = 0
+    qo_offsets = [0]
+    for q in qo_lens:
+        acc += q
+        qo_offsets.append(acc)
+    acc = 0
+    kv_offsets = [0]
+    for k in kv_lens:
+        acc += k
+        kv_offsets.append(acc)
+
+    max_kv_len = max(kv_lens)
+    qo_offset_list = qo_offset if isinstance(qo_offset, list) else qo_offset.tolist()
+    if not causal:
+        qo_offset_list = [max_kv_len] * len(kv_lens)
+
+    qo_segment_offsets = _plan_buf_from_list(qo_offsets, device)
+    kv_segment_offsets = _plan_buf_from_list(kv_offsets, device)
+    qo_offset = _plan_buf_from_list(qo_offset_list, device)
+    kv_segment_lens = _plan_buf_from_list(kv_lens, device)
+    kv_page_indptr = (
+        _plan_buf_from_list(kv_page_indptr_list, device)
+        if kv_page_indptr_list is not None
+        else None
+    )
+
+    plan_kv_lens_list = kv_lens
+    plan_qo_offset = qo_offset
+    if kv_block_num > 0 and page_size > 0:
+        plan_kv_lens_list = [kv_block_num * page_size] * len(kv_lens)
+        plan_qo_offset = None
+
+    max_qo_len = max(qo_lens)
+    qo_tile_size = 128 if max_qo_len <= 128 else 256
+    kv_tile_size = 256 if qo_tile_size == 128 else 128
+
+    total_qo_len = qo_offsets[-1]
+
+    max_k_tiles = (
+        math.ceil(math.ceil(max_kv_len / 128) / 128) * 128 if output_maxscore else -1
+    )
+    maxscore_elems = num_qo_heads * max_k_tiles * total_qo_len
+    if output_maxscore and maxscore_elems > (1 << 31):
+        print(f"Too huge setting to output maxscore!")
+        max_k_tiles = -1
+
+    if num_kv_splits < 1 and qo_tile_size == 128:
+        group_iters = []
+        batch_size = len(qo_lens)
+        for b_idx in range(batch_size):
+            ql_b, kl_b = qo_lens[b_idx], plan_kv_lens_list[b_idx]
+            off_q = kl_b - ql_b
+            for t in range(math.ceil(ql_b / qo_tile_size)):
+                packed_q_end = (t + 1) * qo_tile_size
+                q_end = (
+                    (packed_q_end - 1) // pack_factor + 1
+                    if pack_factor > 1
+                    else packed_q_end
+                )
+                if causal and q_end + off_q <= 0:
+                    continue
+                eff_kv = min(q_end + off_q, kl_b) if causal else kl_b
+                group_iters.append(math.ceil(max(eff_kv, 0) / kv_tile_size))
+
+        if not group_iters:
+            num_kv_splits = 1
+        elif len(group_iters) * num_qo_heads > 4096:
+            # Too many tiles for split-KV smem — fall back to nosplit greedy
+            num_kv_splits = 1
+        else:
+            total_iters = sum(group_iters) * num_qo_heads
+            avg_iters = max(2, (total_iters + num_ctas - 1) // num_ctas + 3)
+            chunk_size = avg_iters
+            max_pieces = max(math.ceil(g / chunk_size) for g in group_iters)
+            max_kv_splits = min(2 * max(max_pieces, 1), 64)
+
+            max_work_items = 131072 * max_kv_splits
+
+            packed_work_range = _alloc_perplan_buf(
+                _BuffTag.packed_work_range, num_ctas, device, torch.int64
+            )
+            packed_work_info = _alloc_perplan_buf(
+                _BuffTag.packed_work_info, max_work_items, device, torch.int64
+            )
+            kv_tile_begin_indices = _alloc_perplan_buf(
+                _BuffTag.kv_tile_begin_indices, max_work_items, device, torch.int32
+            )
+            kv_tile_end_indices = _alloc_perplan_buf(
+                _BuffTag.kv_tile_end_indices, max_work_items, device, torch.int32
+            )
+            kv_split_indices = _alloc_perplan_buf(
+                _BuffTag.kv_split_indices, max_work_items, device, torch.int32
+            )
+            num_kv_splits_per_row = _alloc_perplan_buf(
+                _BuffTag.num_kv_splits_per_row, total_qo_len, device, torch.int32
+            )
+            plan_cost = _alloc_workspace_buf(
+                _BuffTag.plan_cost, 2, device, dtype=torch.float32
+            )
+
+            lse_total_size = max_kv_splits * total_qo_len * num_qo_heads
+            workspace_lse = _alloc_perplan_buf(
+                _BuffTag.workspace_lse, lse_total_size, device, torch.float32
+            )
+
+            qo_segment_lens_gpu = _plan_buf_from_list(qo_lens, device)
+            plan_kv_lens_gpu = _plan_buf_from_list(plan_kv_lens_list, device)
+            _call_plan(
+                qo_segment_offsets,
+                qo_segment_lens_gpu,
+                plan_kv_lens_gpu,
+                packed_work_range,
+                packed_work_info,
+                qo_tile_size,
+                kv_tile_size,
+                num_qo_heads,
+                num_ctas,
+                causal,
+                plan_qo_offset,
+                -max_kv_splits,
+                kv_tile_begin_indices,
+                kv_tile_end_indices,
+                kv_split_indices,
+                chunk_size,
+                plan_cost,
+                num_kv_splits_per_row,
+                workspace_lse,
+                lse_total_size,
+                pack_factor,
+                cuda_stream,
+            )
+
+            _cost = plan_cost.tolist()
+            do_split = _cost[0] > 0
+            predicted_speedup = _cost[1]
+
+            if do_split:
+                workspace_o = _alloc_workspace_buf(
+                    _BuffTag.workspace_o,
+                    total_qo_len * max_kv_splits * num_qo_heads * 128,
+                    device,
+                    dtype=torch.bfloat16,
+                )
+            else:
+                kv_tile_begin_indices = None
+                kv_tile_end_indices = None
+                kv_split_indices = None
+                num_kv_splits_per_row = None
+                workspace_o = None
+                workspace_lse = None
+                max_kv_splits = 1
+
+            return _make_plan_info(
+                packed_work_range=packed_work_range,
+                packed_work_info=packed_work_info,
+                kv_tile_begin_indices=kv_tile_begin_indices,
+                kv_tile_end_indices=kv_tile_end_indices,
+                kv_split_indices=kv_split_indices,
+                num_kv_splits=max_kv_splits,
+                workspace_o=workspace_o,
+                workspace_lse=workspace_lse,
+                max_qo_len=max_qo_len,
+                predicted_speedup=predicted_speedup,
+                num_kv_splits_per_row=num_kv_splits_per_row,
+                qo_segment_offsets=qo_segment_offsets,
+                kv_segment_offsets=kv_segment_offsets,
+                kv_page_indptr=kv_page_indptr,
+                max_k_tiles=max_k_tiles,
+                qo_segment_lens=qo_segment_lens_gpu,
+                kv_segment_lens=kv_segment_lens,
+                qo_offset=qo_offset,
+                pack_factor=pack_factor,
+                orig_num_qo_heads=orig_num_qo_heads,
+                qo_len_uniform=qo_len_uniform,
+                cute_workspace_buffer=cute_workspace_buffer,
+            )
+
+        num_kv_splits = 1
+    elif num_kv_splits < 1:
+        num_kv_splits = 1
+    elif qo_tile_size == 256:
+        num_kv_splits = 1
+
+    packed_work_range = _alloc_perplan_buf(
+        _BuffTag.packed_work_range, num_ctas, device, torch.int64
+    )
+    max_work_items = 131072 * max(num_kv_splits, 1)
+    packed_work_info = _alloc_perplan_buf(
+        _BuffTag.packed_work_info, max_work_items, device, torch.int64
+    )
+    if num_kv_splits > 1:
+        kv_tile_begin_indices = _alloc_perplan_buf(
+            _BuffTag.kv_tile_begin_indices, max_work_items, device, torch.int32
+        )
+        kv_tile_end_indices = _alloc_perplan_buf(
+            _BuffTag.kv_tile_end_indices, max_work_items, device, torch.int32
+        )
+        kv_split_indices = _alloc_perplan_buf(
+            _BuffTag.kv_split_indices, max_work_items, device, torch.int32
+        )
+        num_kv_splits_per_row = _alloc_perplan_buf(
+            _BuffTag.num_kv_splits_per_row, total_qo_len, device, torch.int32
+        )
+        workspace_o = _alloc_workspace_buf(
+            _BuffTag.workspace_o,
+            total_qo_len * num_kv_splits * num_qo_heads * 128,
+            device,
+            dtype=torch.bfloat16,
+        )
+
+        lse_total_size = num_kv_splits * total_qo_len * num_qo_heads
+        workspace_lse = _alloc_perplan_buf(
+            _BuffTag.workspace_lse, lse_total_size, device, torch.float32
+        )
+    else:
+        kv_tile_begin_indices = None
+        kv_tile_end_indices = None
+        kv_split_indices = None
+        num_kv_splits_per_row = None
+        workspace_o = None
+
+        lse_total_size = 0
+        workspace_lse = None
+
+    qo_segment_lens_gpu = _plan_buf_from_list(qo_lens, device)
+    plan_kv_lens_gpu = _plan_buf_from_list(plan_kv_lens_list, device)
+    _call_plan(
+        qo_segment_offsets,
+        qo_segment_lens_gpu,
+        plan_kv_lens_gpu,
+        packed_work_range,
+        packed_work_info,
+        qo_tile_size,
+        kv_tile_size,
+        num_qo_heads,
+        num_ctas,
+        causal,
+        plan_qo_offset,
+        num_kv_splits,
+        kv_tile_begin_indices,
+        kv_tile_end_indices,
+        kv_split_indices,
+        0,
+        None,
+        num_kv_splits_per_row,
+        workspace_lse,
+        lse_total_size,
+        pack_factor,
+        cuda_stream,
+    )
+
+    return _make_plan_info(
+        packed_work_range=packed_work_range,
+        packed_work_info=packed_work_info,
+        kv_tile_begin_indices=kv_tile_begin_indices,
+        kv_tile_end_indices=kv_tile_end_indices,
+        kv_split_indices=kv_split_indices,
+        num_kv_splits=num_kv_splits,
+        workspace_o=workspace_o,
+        workspace_lse=workspace_lse,
+        max_qo_len=max_qo_len,
+        predicted_speedup=1.0,
+        num_kv_splits_per_row=num_kv_splits_per_row,
+        qo_segment_offsets=qo_segment_offsets,
+        kv_segment_offsets=kv_segment_offsets,
+        kv_page_indptr=kv_page_indptr,
+        max_k_tiles=max_k_tiles,
+        qo_segment_lens=qo_segment_lens_gpu,
+        kv_segment_lens=kv_segment_lens,
+        qo_offset=qo_offset,
+        pack_factor=pack_factor,
+        orig_num_qo_heads=orig_num_qo_heads,
+        qo_len_uniform=qo_len_uniform,
+        cute_workspace_buffer=cute_workspace_buffer,
+    )
+
+
+def _fmha_sm100(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    plan_info,
+    kv_indices: Optional[torch.Tensor] = None,
+    kv_block_indexes: Optional[torch.Tensor] = None,
+    q_offset_override: Optional[Union[int, torch.Tensor]] = None,
+    out: Optional[torch.Tensor] = None,
+    max_score: Optional[torch.Tensor] = None,
+    sm_scale: Optional[float] = None,
+    q_scale: Optional[float] = None,
+    k_scale: Optional[float] = None,
+    v_scale: Optional[float] = None,
+    o_scale: Optional[float] = None,
+    output_maxscore: bool = True,
+    output_o: bool = True,
+    check_input_valid: bool = False,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+
+    if plan_info["MM-SA-Nv"]:
+        return sparse_fmha(
+            q=q,
+            k=k,
+            v=v,
+            plan_info=plan_info,
+            out=out,
+            max_score=max_score,
+            sm_scale=sm_scale,
+            q_scale=q_scale,
+            k_scale=k_scale,
+            v_scale=v_scale,
+            o_scale=o_scale,
+            kv_indices=kv_indices,
+            output_maxscore=output_maxscore,
+            output_o=output_o,
+            q_offset_override=q_offset_override,
+            kv_block_indexes=kv_block_indexes,
+            check_input_valid=check_input_valid,
+        )
+
+    nnz_qo, num_qo_heads, head_dim_qk = q.shape
+    if kv_indices is None:
+        nnz_kv, num_kv_heads, head_dim_vo = v.shape
+        is_paged = False
+    else:
+        nnz_kv, num_kv_heads, page_size, head_dim_vo = v.shape
+        is_paged = True
+
+    qo_total_len = nnz_qo
+
+    packed_work_range = plan_info["packed_work_range"]
+    packed_work_info = plan_info["packed_work_info"]
+    kv_tile_begin_indices = plan_info["kv_tile_begin_indices"]
+    kv_tile_end_indices = plan_info["kv_tile_end_indices"]
+    kv_split_indices = plan_info["kv_split_indices"]
+    num_kv_splits = plan_info["num_kv_splits"]
+    workspace_o = plan_info["workspace_o"]
+    workspace_lse = plan_info["workspace_lse"]
+    plan_max_qo_len = plan_info["max_qo_len"]
+    num_kv_splits_per_row = plan_info["num_kv_splits_per_row"]
+    qo_segment_offsets = plan_info["qo_segment_offsets"]
+    kv_segment_offsets = plan_info["kv_segment_offsets"]
+    kv_page_indptr = plan_info["kv_page_indptr"]
+    max_k_tiles = plan_info["max_k_tiles"]
+    qo_segment_lens = plan_info["qo_segment_lens"]
+    kv_segment_lens = plan_info["kv_segment_lens"]
+    qo_offset = (
+        plan_info["qo_offset"] if q_offset_override is None else q_offset_override
+    )
+    pack_factor = plan_info["pack_factor"]
+    orig_num_qo_heads = plan_info["orig_num_qo_heads"]
+    qo_len_uniform = plan_info["qo_len_uniform"]
+    workspace_buffer = plan_info["cute_workspace_buffer"]
+
+    batch_size = qo_segment_lens.shape[0]
+
+    if isinstance(qo_offset, int):
+        qo_offset = torch.full_like(qo_segment_lens, qo_offset)
+    elif qo_offset is not None:
+        assert qo_offset.device == qo_segment_lens.device
+
+    if check_input_valid:
+        _validate_fmha_inputs(
+            q,
+            k,
+            v,
+            qo_segment_lens,
+            kv_segment_lens,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim_qk,
+            head_dim_vo,
+            batch_size,
+            qo_total_len,
+            is_paged,
+            kv_indices,
+            kv_block_indexes,
+            qo_offset,
+            page_size if is_paged else 0,
+            pack_factor=pack_factor,
+            packed_work_range=packed_work_range,
+            packed_work_info=packed_work_info,
+            num_kv_splits=num_kv_splits,
+            kv_tile_begin_indices=kv_tile_begin_indices,
+            kv_tile_end_indices=kv_tile_end_indices,
+            kv_split_indices=kv_split_indices,
+            qo_segment_offsets=qo_segment_offsets,
+            kv_page_indptr=kv_page_indptr,
+        )
+
+    if pack_factor > 1 and orig_num_qo_heads is not None:
+        num_qo_heads = orig_num_qo_heads // pack_factor
+        qo_total_len = nnz_qo * pack_factor
+
+    max_qo_len = plan_max_qo_len
+    qo_tile_size = 128 if max_qo_len <= 128 else 256
+
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(head_dim_qk)
+    if q_scale is None:
+        q_scale = 1.0
+    if k_scale is None:
+        k_scale = 1.0
+    if v_scale is None:
+        v_scale = 1.0
+    if o_scale is None:
+        o_scale = 1.0
+
+    assert output_o or output_maxscore
+
+    use_split_kv = num_kv_splits > 1 and workspace_o is not None
+
+    if not output_maxscore or max_k_tiles == -1:
+        max_score = None
+        output_o = True
+    elif max_score is None and max_k_tiles > 0:
+        max_score = torch.full(
+            (orig_num_qo_heads, max_k_tiles, nnz_qo),
+            -float("inf"),
+            dtype=torch.float32,
+            device=q.device,
+        )
+    elif max_score is not None and max_k_tiles > 0:
+        unpacked_t = nnz_qo
+        unpacked_h = orig_num_qo_heads
+        packed_t = qo_total_len
+        packed_h = num_qo_heads
+        valid_max_score_shapes = {
+            (unpacked_h, max_k_tiles, unpacked_t),  # legacy [H, K, T]
+            (unpacked_t, unpacked_h, max_k_tiles),  # row-contiguous [T, H, K]
+            (packed_h, max_k_tiles, packed_t),
+            (packed_t, packed_h, max_k_tiles),
+        }
+        assert (
+            max_score.dtype == torch.float32
+        ), f"max_score must be float32, got {max_score.dtype}"
+        assert (
+            max_score.device == q.device
+        ), f"max_score must be on {q.device}, got {max_score.device}"
+        assert tuple(max_score.shape) in valid_max_score_shapes, (
+            "max_score must have shape [H,K,T] or [T,H,K]; "
+            f"got {tuple(max_score.shape)}, expected one of "
+            f"{sorted(valid_max_score_shapes)}"
+        )
+
+    if not output_o:
+        out = None
+    elif out is None:
+        out_dtype = torch.bfloat16 if q.dtype.itemsize == 1 else q.dtype
+        out = torch.empty(
+            nnz_qo,
+            orig_num_qo_heads,
+            head_dim_vo,
+            device=q.device,
+            dtype=out_dtype,
+        )
+
+    # Determine variant dispatch parameters
+    dtype_code = _dlpack_dtype_code(q.dtype)
+
+    kv_block_indexes_ptr_exists = kv_block_indexes is not None
+    max_score_exists = max_score is not None
+    o_exists = out is not None
+    if kv_block_indexes_ptr_exists:
+        sparse_mode = 0
+    elif max_score_exists and o_exists:
+        sparse_mode = 1
+    elif max_score_exists:
+        sparse_mode = 2
+    else:
+        sparse_mode = 3
+
+    variant_page_size = k.shape[2] if is_paged else -1
+
+    variant_module = get_fmha_variant(
+        dtype_code,
+        qo_tile_size,
+        (max_qo_len <= 64),
+        sparse_mode,
+        variant_page_size,
+        use_split_kv,
+        pack_factor,
+    )
+
+    variant_module.run(
+        workspace_buffer,
+        q,
+        k,
+        v,
+        qo_segment_lens,
+        kv_segment_lens,
+        qo_segment_offsets,
+        kv_segment_offsets,
+        packed_work_range,
+        packed_work_info,
+        out,
+        sm_scale,
+        q_scale,
+        k_scale,
+        v_scale,
+        o_scale,
+        max_qo_len,
+        qo_offset,
+        num_kv_splits,
+        kv_tile_begin_indices,
+        kv_tile_end_indices,
+        kv_split_indices,
+        workspace_o,
+        workspace_lse,
+        num_kv_splits_per_row,
+        qo_tile_size,
+        kv_indices,
+        kv_page_indptr,
+        max_score,
+        max_k_tiles,
+        kv_block_indexes,
+        pack_factor,
+        bool(qo_len_uniform),
+        torch.cuda.current_stream().cuda_stream,
+    )
+
+    # Split-KV reduction
+    if use_split_kv and out is not None:
+        log2_e = math.log2(math.exp(1.0))
+        scale_softmax_log2 = float(q_scale * k_scale * sm_scale) * log2_e
+        inv_scale_o = float(o_scale)
+
+        reduction_module = get_reduction_module()
+        reduction_module.reduction(
+            workspace_o,
+            out,
+            workspace_lse,
+            num_kv_splits_per_row,
+            scale_softmax_log2,
+            inv_scale_o,
+            num_kv_splits,
+            qo_total_len,
+            num_qo_heads,
+            head_dim_vo,
+            num_qo_heads * head_dim_vo,
+            head_dim_vo,
+            num_qo_heads * head_dim_vo,
+            head_dim_vo,
+            orig_num_qo_heads,
+            num_kv_heads,
+            pack_factor,
+            torch.cuda.current_stream().cuda_stream,
+        )
+
+    return out, max_score
+
+
+def fmha_sm100_plan(
+    qo_segment_lens: torch.Tensor,
+    kv_segment_lens: torch.Tensor,
+    *args,
+    qo_offset: Optional[Union[int, torch.Tensor]] = None,
+    split_prefill_decode=True,
+    **kwargs,
+):
+    """Build a reusable execution plan for ``fmha_sm100``.
+
+    The plan is shape-dependent and can be reused across layers or repeated
+    calls that share the same sequence lengths, head counts, page size, sparse
+    mode, and output mode.  Planning may run CUDA kernels and allocates
+    workspaces, so it should be done outside tight per-layer loops when
+    possible.
+
+    Parameters
+    ----------
+    qo_segment_lens : torch.Tensor
+        Shape ``[batch_size]``, dtype int32/int64.  Per-request Q/O lengths.
+        CPU tensors are accepted for the dense planner; sparse prefill planning
+        moves them to CUDA internally.
+    kv_segment_lens : torch.Tensor
+        Shape ``[batch_size]``, dtype int32/int64.  Per-request KV lengths.
+    *args
+        Positional arguments forwarded to the internal planner.  In normal
+        usage this is ``num_qo_heads`` and optionally ``num_kv_heads``.
+    qo_offset : int or torch.Tensor, optional
+        Per-request causal offset.  If omitted, defaults to
+        ``kv_segment_lens - qo_segment_lens`` for bottom-right causal masking.
+        A tensor must have shape ``[batch_size]``.
+    split_prefill_decode : bool, optional
+        If True, a mixed batch ordered as decode requests followed by prefill
+        requests is split into two sub-plans.  The original order must already
+        group short decode sequences before long prefill sequences.
+    **kwargs
+        Planner options forwarded to ``_fmha_sm100_plan``.  Common options are
+        ``num_kv_heads``, ``num_kv_splits``, ``page_size``,
+        ``output_maxscore``, ``kv_block_num``, ``usable_SM_count``, ``causal``,
+        ``sparse_kernel_mode``, ``use_fp8_kvcache``, ``device``, and ``stream``.
+
+    Returns
+    -------
+    tuple
+        ``(has_mixed_prefill, split, batch_size, decode_plan, prefill_plan)``.
+        Pass this tuple unchanged as ``plan_info`` to ``fmha_sm100``.
+    """
+
+    # assert qo_segment_lens.device.type == 'cpu' \
+    #         and kv_segment_lens.device.type == 'cpu'
+    # assert qo_offset is None or isinstance(qo_offset, int) or qo_offset.device.type == 'cpu'
+
+    if qo_offset is None:
+        qo_offset = kv_segment_lens - qo_segment_lens
+    elif isinstance(qo_offset, int):
+        qo_offset = torch.full_like(qo_segment_lens, qo_offset)
+
+    batch_size = qo_segment_lens.shape[0]
+    has_mixed_prefill = False
+    qmax = qo_segment_lens.max().item()
+    sparse = kwargs.get("kv_block_num", -1) > 0
+    split_threshold = _prefill_qlen_threshold(sparse)
+    if split_prefill_decode and qmax > split_threshold:
+        split = (qo_segment_lens > split_threshold).nonzero(as_tuple=False)[0, 0].item()
+        has_mixed_prefill = split > 0
+    if has_mixed_prefill:
+        # print(f"Split into 2 parts at index {split}")
+        decode_qo_segment_lens = qo_segment_lens[:split]
+        decode_kv_segment_lens = kv_segment_lens[:split]
+        decode_qo_offset = qo_offset[:split]
+        decode = _fmha_sm100_plan(
+            decode_qo_segment_lens,
+            decode_kv_segment_lens,
+            *args,
+            qo_offset=decode_qo_offset,
+            **kwargs,
+        )
+        decode = {
+            k: v.clone() if isinstance(v, torch.Tensor) else v
+            for k, v in decode.items()
+        }
+        prefill_qo_segment_lens = qo_segment_lens[split:]
+        prefill_kv_segment_lens = kv_segment_lens[split:]
+        prefill_qo_offset = qo_offset[split:]
+        prefill = _fmha_sm100_plan(
+            prefill_qo_segment_lens,
+            prefill_kv_segment_lens,
+            *args,
+            qo_offset=prefill_qo_offset,
+            **kwargs,
+        )
+        return (True, split, batch_size, decode, prefill)
+    else:
+        plan = _fmha_sm100_plan(
+            qo_segment_lens, kv_segment_lens, *args, qo_offset=qo_offset, **kwargs
+        )
+        return (False, 0, batch_size, plan, None)
+
+
+def fmha_sm100(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    plan_info,
+    kv_indices: Optional[torch.Tensor] = None,
+    kv_block_indexes: Optional[torch.Tensor] = None,
+    q_offset_override: Optional[Union[int, torch.Tensor]] = None,
+    out: Optional[torch.Tensor] = None,
+    max_score: Optional[torch.Tensor] = None,
+    **kwargs,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    """Run dense, paged, or sparse SM100 FMHA using a precomputed plan.
+
+    Parameters
+    ----------
+    q : torch.Tensor
+        Shape ``[total_qo_len, num_qo_heads, head_dim]``.  Supported dtypes are
+        ``torch.bfloat16`` and ``torch.float8_e4m3fn``.  ``head_dim`` must be
+        128.
+    k : torch.Tensor
+        Dense layout ``[total_kv_len, num_kv_heads, head_dim]`` or paged layout
+        ``[total_pages, num_kv_heads, page_size, head_dim]``.
+    v : torch.Tensor
+        Same layout as ``k``.  The output head dimension follows ``v.shape[-1]``.
+    plan_info : tuple
+        Return value from ``fmha_sm100_plan`` for the same lengths, head layout,
+        page size, and sparse/output mode.
+    kv_indices : torch.Tensor, optional
+        Paged-KV physical page table, flattened across the batch.  Required when
+        ``k`` and ``v`` use paged layout.  Shape is ``[sum_pages]`` and dtype is
+        int32.
+    kv_block_indexes : torch.Tensor, optional
+        Sparse KV block indices from ``sparse_topk_select``.  Shape
+        ``[total_qo_len, num_kv_heads or num_qo_heads, kv_block_num]``, dtype
+        int32, ascending per row with ``-1`` padding at the tail.
+    q_offset_override : int or torch.Tensor, optional
+        Runtime causal-offset override.  Tensor form must have shape
+        ``[batch_size]`` on the same CUDA device as the plan metadata.  The
+        override must stay within the causal range visible to the original
+        plan.
+    out : torch.Tensor, optional
+        Preallocated output buffer with shape
+        ``[total_qo_len, num_qo_heads, head_dim_v]``.
+    max_score : torch.Tensor, optional
+        Preallocated per-KV-tile score buffer with dtype float32.  Accepted
+        layouts are legacy ``[num_qo_heads, max_k_tiles, total_qo_len]`` and
+        row-contiguous ``[total_qo_len, num_qo_heads, max_k_tiles]``.
+    **kwargs
+        Runtime options forwarded to the kernel runner.  Common options are
+        ``sm_scale``, ``q_scale``, ``k_scale``, ``v_scale``, ``o_scale``,
+        ``output_maxscore``, ``output_o``, and ``check_input_valid``.
+
+    Returns
+    -------
+    tuple[torch.Tensor | None, torch.Tensor | None]
+        ``(out, max_score)``.  Either item may be ``None`` if the corresponding
+        output was disabled.  When both decode and prefill sub-plans are used,
+        outputs are concatenated back into the original batch order.
+    """
+    has_mixed_prefill, split, batch_size, decode, prefill = plan_info
+    if not has_mixed_prefill:
+        return _fmha_sm100(
+            q,
+            k,
+            v,
+            decode,
+            out=out,
+            max_score=max_score,
+            kv_indices=kv_indices,
+            kv_block_indexes=kv_block_indexes,
+            q_offset_override=q_offset_override,
+            **kwargs,
+        )
+    else:
+
+        decode_pack = decode.get("pack_factor", 1)
+        decode_nnz = decode["qo_segment_offsets"][-1].item() // decode_pack
+        is_paged = kv_indices is not None
+        nnz_qo = q.shape[0]
+        num_qo_heads = q.shape[1]
+
+        q_decode = q[:decode_nnz]
+        q_prefill = q[decode_nnz:]
+
+        if is_paged:
+            k_decode, v_decode = k, v
+            k_prefill, v_prefill = k, v
+            if "kv_page_indptr" in decode:
+                kv_page_split = decode["kv_page_indptr"][-1].item()
+            else:
+                kv_page_split = decode["total_rows"]
+            decode_kv_indices = kv_indices[:kv_page_split]
+            prefill_kv_indices = kv_indices[kv_page_split:]
+        else:
+            if "kv_segment_offsets" in decode:
+                decode_kv_nnz = decode["kv_segment_offsets"][-1].item()
+            else:
+                decode_kv_nnz = decode["cu_seqlens_k"][-1].item()
+            k_decode, k_prefill = k[:decode_kv_nnz], k[decode_kv_nnz:]
+            v_decode, v_prefill = v[:decode_kv_nnz], v[decode_kv_nnz:]
+            decode_kv_indices = None
+            prefill_kv_indices = None
+
+        decode_block_idx = (
+            kv_block_indexes[:decode_nnz] if kv_block_indexes is not None else None
+        )
+        prefill_block_idx = (
+            kv_block_indexes[decode_nnz:] if kv_block_indexes is not None else None
+        )
+        if isinstance(q_offset_override, int):
+            decode_qo_offset = torch.full(
+                (split,), q_offset_override, dtype=torch.int32, device=q.device
+            )
+            prefill_qo_offset = torch.full(
+                (batch_size - split,),
+                q_offset_override,
+                dtype=torch.int32,
+                device=q.device,
+            )
+        elif q_offset_override is not None:
+            decode_qo_offset = q_offset_override[:split]
+            prefill_qo_offset = q_offset_override[split:]
+        else:
+            decode_qo_offset = None
+            prefill_qo_offset = None
+
+        # ---- Run kernels ----
+        decode_out, decode_ms = _fmha_sm100(
+            q_decode,
+            k_decode,
+            v_decode,
+            decode,
+            out=None,
+            max_score=None,
+            kv_indices=decode_kv_indices,
+            kv_block_indexes=decode_block_idx,
+            q_offset_override=decode_qo_offset,
+            **kwargs,
+        )
+        prefill_out, prefill_ms = _fmha_sm100(
+            q_prefill,
+            k_prefill,
+            v_prefill,
+            prefill,
+            out=None,
+            max_score=None,
+            kv_indices=prefill_kv_indices,
+            kv_block_indexes=prefill_block_idx,
+            q_offset_override=prefill_qo_offset,
+            **kwargs,
+        )
+
+        # ---- Merge out ----
+        if decode_out is not None and prefill_out is not None:
+            combined_out = torch.cat([decode_out, prefill_out], dim=0)
+        else:
+            combined_out = None
+
+        if out is not None and combined_out is not None:
+            out.copy_(combined_out)
+
+        # ---- Merge max_score ----
+        if decode_ms is not None and prefill_ms is not None:
+            d_kt, p_kt = decode_ms.shape[1], prefill_ms.shape[1]
+            max_kt = max(d_kt, p_kt)
+            combined_ms = torch.full(
+                (num_qo_heads, max_kt, nnz_qo),
+                -float("inf"),
+                dtype=torch.float32,
+                device=q.device,
+            )
+            combined_ms[:, :d_kt, :decode_nnz] = decode_ms
+            combined_ms[:, :p_kt, decode_nnz:] = prefill_ms
+        else:
+            combined_ms = decode_ms if decode_ms is not None else prefill_ms
+
+        if max_score is not None and combined_ms is not None:
+            if max_score.shape == combined_ms.shape:
+                max_score.copy_(combined_ms)
+            elif max_score.shape == (nnz_qo, num_qo_heads, combined_ms.shape[1]):
+                max_score.copy_(combined_ms.permute(2, 0, 1).contiguous())
+            else:
+                raise ValueError(
+                    f"max_score shape {tuple(max_score.shape)} is incompatible "
+                    f"with combined max_score shape {tuple(combined_ms.shape)}"
+                )
+
+        return (
+            out if out is not None else combined_out,
+            max_score if max_score is not None else combined_ms,
+        )
+
+
+# ============================================================================
+# Sparse TopK Select
+# ============================================================================
+
+
+def sparse_topk_select(
+    max_score: torch.Tensor,
+    topk: int,
+    num_valid_pages: Optional[Union[int, torch.Tensor]] = None,
+    output: Optional[torch.Tensor] = None,
+    force_begin_blocks: int = 0,
+    force_end_blocks: int = 0,
+    max_score_layout: str = "HKT",
+    block_table: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    r"""Select top-k KV-tile indices per (qo_head, token) row from the FMHA max-score tensor.
+
+    Designed for the MQA proxy-KV sparse attention path where the dense pass uses
+    ``num_kv_heads_dense=1``, so ``max_score.shape[0] == num_kv_heads_real`` and
+    each head row is processed independently (no GQA reduction inside this call).
+
+    Parameters
+    ----------
+    max_score : torch.Tensor
+        Contiguous float32 max-score tensor.  ``max_score_layout="HKT"`` expects
+        shape ``(num_qo_heads, max_k_tiles, total_qo_len)``.  ``"THK"`` expects
+        shape ``(total_qo_len, num_qo_heads, max_k_tiles)`` and skips the
+        internal transpose before top-k.  Slots beyond the actual KV tile count
+        must be pre-filled with ``-inf`` (fmha_sm100 does this automatically via
+        ``torch.full``).
+    topk : int
+        Must be exactly 16.
+    num_valid_pages : int or torch.Tensor, optional
+        Actual number of KV pages in the page table, i.e. ``ceil(kv_len / page_size)``.
+        ``max_k_tiles`` is round-up-aligned and always >= ``num_valid_pages``.
+        The kernel may select tile indices in ``[num_valid_pages, max_k_tiles-1]``
+        (all-``-inf`` padding tiles). Passing ``num_valid_pages`` replaces those
+        out-of-range indices with ``-1`` and sorts them to the tail, matching the
+        sparse FMHA kernel's kv_block_indexes contract.
+        Tensor form must be CUDA int32/int64 with shape ``[total_qo_len]`` and
+        provides a per-query-token page count for mixed-length batches.
+        **Strongly recommended**: omitting this allows OOB page-table accesses in
+        the sparse attention pass.
+    force_begin_blocks : int
+        Number of KV blocks at the beginning of the sequence (indices 0..N-1) to
+        always include in the top-k result, regardless of their scores.  Useful
+        for sink tokens.  Default 0.
+    force_end_blocks : int
+        Number of KV blocks at the end of the valid sequence (indices
+        nvp-N..nvp-1, closest to the current query) to always include.  Useful
+        for local-window attention.  Default 0.
+    block_table : torch.Tensor, optional
+        Optional int32 tensor with shape ``(total_qo_len, num_qo_heads, max_k_tiles)``.
+        The kernel still selects and sorts logical tile indices, but after sorting
+        each logical index ``idx`` is replaced with ``block_table[t, h, idx]`` in
+        the output.  Use this for per-token/per-head physical page-table gathers.
+
+    Returns
+    -------
+    torch.Tensor
+        Shape ``(total_qo_len, num_qo_heads, topk)``, int32.  Without
+        ``block_table``, values are logical tile indices in ascending tile order.
+        With ``block_table``, values are gathered block-table entries after that
+        logical ascending sort.  Out-of-range entries (if any) are ``-1`` at the tail.
+    """
+
+    assert (
+        max_score.dtype == torch.float32
+    ), f"max_score must be float32, got {max_score.dtype}"
+    assert max_score.dim() == 3, f"max_score must be 3D, got {max_score.shape}"
+    assert max_score.is_contiguous(), "max_score must be contiguous"
+    assert topk == 16, f"topk must be 16, got {topk}"
+
+    layout = max_score_layout.upper()
+    assert layout in {
+        "HKT",
+        "THK",
+    }, f"max_score_layout must be 'HKT' or 'THK', got {max_score_layout!r}"
+    if layout == "HKT":
+        num_qo_heads, max_k_tiles, total_qo_len = max_score.shape
+        layout_arg = 0
+    else:
+        total_qo_len, num_qo_heads, max_k_tiles = max_score.shape
+        layout_arg = 1
+
+    if block_table is not None:
+        assert (
+            block_table.dtype == torch.int32
+        ), f"block_table must be int32, got {block_table.dtype}"
+        assert (
+            block_table.device == max_score.device
+        ), f"block_table must be on {max_score.device}, got {block_table.device}"
+        assert block_table.dim() == 3, (
+            f"block_table must be 3D [total_qo_len, num_qo_heads, max_k_tiles], "
+            f"got {tuple(block_table.shape)}"
+        )
+        assert tuple(block_table.shape) == (total_qo_len, num_qo_heads, max_k_tiles), (
+            f"block_table shape must be {(total_qo_len, num_qo_heads, max_k_tiles)}, "
+            f"got {tuple(block_table.shape)}"
+        )
+        assert all(
+            s >= 0 for s in block_table.stride()
+        ), f"block_table must have non-negative strides, got {block_table.stride()}"
+
+    # v2.3 kernel only supports the insertion-sort path (K < 12288).
+    assert max_k_tiles < 12288, (
+        f"max_k_tiles={max_k_tiles} >= 12288: v2.3 kernel only supports K < 12288 "
+        f"(radix-sort path not yet implemented). kv_len must be < {12288 * 128} tokens."
+    )
+
+    nvp_tensor = None
+    if isinstance(num_valid_pages, torch.Tensor):
+        assert (
+            num_valid_pages.dim() == 1
+        ), f"num_valid_pages tensor must be 1D [total_qo_len], got {tuple(num_valid_pages.shape)}"
+        assert num_valid_pages.shape[0] == total_qo_len, (
+            f"num_valid_pages tensor length {num_valid_pages.shape[0]} must match "
+            f"total_qo_len={total_qo_len}"
+        )
+        assert (
+            num_valid_pages.device == max_score.device
+        ), f"num_valid_pages tensor must be on {max_score.device}, got {num_valid_pages.device}"
+        assert num_valid_pages.dtype in (
+            torch.int32,
+            torch.int64,
+        ), f"num_valid_pages tensor must be int32 or int64, got {num_valid_pages.dtype}"
+        nvp_tensor = num_valid_pages.to(dtype=torch.int32).contiguous()
+        nvp_arg = int(max_k_tiles)
+    elif num_valid_pages is not None:
+        nvp_arg = int(num_valid_pages)
+        assert (
+            0 < nvp_arg <= max_k_tiles
+        ), f"num_valid_pages={nvp_arg} must be in (0, max_k_tiles={max_k_tiles}]"
+    else:
+        # v2.5_oob_clamp_in_kernel: kernel takes a unified num_valid_pages arg.
+        # When the caller doesn't supply one, pass max_k_tiles so the in-kernel
+        # `idx >= num_valid_pages` check never triggers (idx is always in
+        # [0, max_k_tiles)).
+        nvp_arg = int(max_k_tiles)
+
+    assert force_begin_blocks >= 0 and force_end_blocks >= 0, (
+        f"force_begin_blocks={force_begin_blocks} and force_end_blocks={force_end_blocks} "
+        f"must be non-negative"
+    )
+    assert force_begin_blocks + force_end_blocks <= topk, (
+        f"force_begin_blocks({force_begin_blocks}) + force_end_blocks({force_end_blocks}) "
+        f"= {force_begin_blocks + force_end_blocks} exceeds topk={topk}"
+    )
+
+    # HKT needs a transpose buffer; THK is already row-contiguous over K and
+    # should not allocate or pass a dummy workspace, especially under CUDA graph
+    # capture.
+    workspace_size = 0 if layout == "THK" else num_qo_heads * max_k_tiles * total_qo_len
+    workspace_buffer = None
+    if workspace_size:
+        workspace_buffer = _alloc_workspace_buf(
+            _BuffTag.sparse_topk_workspace,
+            workspace_size,
+            max_score.device,
+            torch.int32,
+        )
+
+    if output is not None:
+        assert output.dtype == torch.int32, f"output must be int32, got {output.dtype}"
+        assert (
+            output.device == max_score.device
+        ), f"output must be on {max_score.device}, got {output.device}"
+        assert output.dim() == 3, f"output must be 3D, got {tuple(output.shape)}"
+        assert tuple(output.shape) == (total_qo_len, num_qo_heads, topk), (
+            f"output shape must be {(total_qo_len, num_qo_heads, topk)}, "
+            f"got {tuple(output.shape)}"
+        )
+        output_indices = output
+    else:
+        output_indices = torch.empty(
+            total_qo_len,
+            num_qo_heads,
+            topk,
+            dtype=torch.int32,
+            device=max_score.device,
+        )
+
+    module = get_sparse_topk_module()
+    # MQA dense pass: num_kv_heads_dense=1, so h_r=num_qo_heads.
+    # The kernel only uses num_qo_heads = h_r * num_kv_heads as a product;
+    # passing num_kv_heads=1 is equivalent to any other valid factorisation.
+    #
+    # v2.5_oob_clamp_in_kernel: OOB clamp is folded into the kernel — the prior
+    # post-process torch.where + sort + torch.where chain (~84-101 us / call)
+    # is replaced by passing num_valid_pages directly to the kernel.
+    module.sparse_topk_select(
+        max_score,
+        output_indices,
+        workspace_buffer,
+        block_table,
+        topk,
+        nvp_arg,
+        nvp_tensor,
+        int(force_begin_blocks),
+        int(force_end_blocks),
+        layout_arg,
+        torch.cuda.current_stream().cuda_stream,
+    )
+
+    return output_indices

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/fmha_sm100_inst.jinja
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/fmha_sm100_inst.jinja
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 MiniMax
+// SPDX-License-Identifier: MIT
+
+// Auto-generated FMHA variant: {{ variant_name }}
+// DTypeIn={{ dtype_in }}, Tile={{ tile_q }}x{{ tile_kv }}, Sparse={{ sparse_mode }}, Page={{ page_size }}, SplitKV={{ is_split_kv }}
+#include "fmha_cutlass_sm100.cuh"
+#include "mask.cuh"
+#include "cutlass_utils.cuh"
+#include "fmha_sm100_params.h"
+
+using namespace flashinfer;
+using namespace cute;
+
+cudaError_t {{ func_name }}(const FMHACutlassSM100Params& p) {
+  using cutlass_type_in = cutlass_dtype_t<{{ dtype_in }}>;
+  using cutlass_type_out = {{ cutlass_dtype_out }};
+  using TileShapeQK = Shape<{{ tile_q }}, {{ tile_kv }}, cute::Int<128>>;
+  using TileShapePV = Shape<{{ tile_q }}, cute::Int<128>, {{ tile_kv }}>;
+  using FmhaThreadShape = Shape<{{ thread_shape }}>;
+
+{% if is_split_kv == "true" %}
+  auto* out_ptr = static_cast<cutlass_type_out*>(p.workspace_o_ptr);
+  int effective_max_qo_len = p.max_qo_len < 128 ? 128 : p.max_qo_len;
+{% else %}
+  auto* out_ptr = static_cast<cutlass_type_out*>(p.o_ptr);
+  int effective_max_qo_len = p.max_qo_len;
+{% endif %}
+
+  using ActiveMaskType = {% if pack_factor is defined and pack_factor > 1 %}PackedCausalMask<{{ pack_factor }}>{% else %}CausalMask{% endif %};
+
+  return run_fmha_fwd<cutlass_type_in, cutlass_type_out, int32_t,
+                      TileShapeQK, TileShapePV, ActiveMaskType, FmhaThreadShape,
+                      /*IsSplitKV=*/{{ is_split_kv }},
+                      /*SingleSoftmaxWarpGroup=*/{{ single_wg }},
+                      {{ page_size }},
+                      cutlass::fmha::collective::SparseAttnMode::{{ sparse_mode }}>(
+      p.workspace_buffer_ptr,
+      static_cast<cutlass_type_in*>(p.q_ptr),
+      static_cast<cutlass_type_in*>(p.k_ptr),
+      static_cast<cutlass_type_in*>(p.v_ptr),
+      p.qo_segment_lens_ptr, p.kv_segment_lens_ptr,
+      p.qo_segment_offsets_ptr, p.kv_segment_offsets_ptr,
+      p.packed_work_range_ptr, p.packed_work_info_ptr,
+      out_ptr,
+      p.mask_mode_code,
+      p.sm_scale, p.scale_q, p.scale_k, p.scale_v, p.o_scale,
+      p.num_qo_heads, p.num_kv_heads,
+      p.head_dim_qk, p.head_dim_vo,
+      p.q_stride_n, p.q_stride_h,
+      p.k_stride_n, p.k_stride_h,
+      p.v_stride_n, p.v_stride_h,
+      p.batch_size, p.total_qo_len, p.total_kv_len,
+      effective_max_qo_len,
+      p.qo_offsets_ptr, p.stream,
+      p.num_kv_splits,
+      p.kv_tile_begin_ptr, p.kv_tile_end_ptr, p.kv_split_ptr,
+      p.workspace_lse_ptr,
+      p.kv_indices_ptr, p.kv_page_indptr_ptr, p.total_page_num,
+      p.max_score_ptr, p.max_k_tiles,
+      p.max_score_stride_t, p.max_score_stride_h, p.max_score_stride_k,
+      p.kv_block_indexes_ptr, p.kv_block_num,
+      p.pack_factor, p.q_stride_n_original, p.q_stride_h_original, p.h_r_original,
+      flashinfer::PackGQAUnpackParams{p.max_score_direct_ptr, p.total_qo_len_orig,
+                                      p.o_direct_ptr, p.num_qo_heads_orig,
+                                      p.tma_direct_o_enabled
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+                                      , p.gmem_bounds
+#endif
+                                      },
+      p.num_ctas);
+}

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/fmha_sm100_params.h
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/fmha_sm100_params.h
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 MiniMax
+// SPDX-License-Identifier: MIT
+
+#pragma once
+#include <cuda_runtime.h>
+#include <cstdint>
+#include "gmem_bounds_check.h"
+
+struct FMHACutlassSM100Params {
+  void* workspace_buffer_ptr;
+  void* q_ptr;
+  void* k_ptr;
+  void* v_ptr;
+  int* qo_segment_lens_ptr;
+  int* kv_segment_lens_ptr;
+  int* qo_segment_offsets_ptr;
+  int* kv_segment_offsets_ptr;
+  uint64_t* packed_work_range_ptr;
+  uint64_t* packed_work_info_ptr;
+  void* o_ptr;
+  int mask_mode_code;
+  float sm_scale;
+  float scale_q;
+  float scale_k;
+  float scale_v;
+  float o_scale;
+  int num_qo_heads;
+  int num_kv_heads;
+  int head_dim_qk;
+  int head_dim_vo;
+  int q_stride_n;
+  int q_stride_h;
+  int k_stride_n;
+  int k_stride_h;
+  int v_stride_n;
+  int v_stride_h;
+  int batch_size;
+  int total_qo_len;
+  int total_kv_len;
+  int max_qo_len;
+  int* qo_offsets_ptr;
+  cudaStream_t stream;
+  int num_kv_splits;
+  int* kv_tile_begin_ptr;
+  int* kv_tile_end_ptr;
+  int* kv_split_ptr;
+  void* workspace_o_ptr;
+  float* workspace_lse_ptr;
+  int* num_kv_splits_per_row_ptr;
+  int* kv_indices_ptr;
+  int* kv_page_indptr_ptr;
+  int total_page_num;
+  float* max_score_ptr;
+  int max_k_tiles;
+  int max_score_stride_t = 0;
+  int max_score_stride_h = 0;
+  int max_score_stride_k = 0;
+  int* kv_block_indexes_ptr;
+  int kv_block_num;
+  int pack_factor = 1;
+  int h_r_original = 0;
+  int q_stride_n_original = 0;
+  int q_stride_h_original = 0;
+  float* max_score_direct_ptr = nullptr;
+  int total_qo_len_orig = 0;
+  void* o_direct_ptr = nullptr;
+  int num_qo_heads_orig = 0;
+  int num_ctas = 0;
+  // TMA fused direct-O unpack: enabled when pack_factor > 1, ptr_O_direct present,
+  // qo_len uniform across batches, and FMHA_DISABLE_TMA_DIRECT_O env var not set.
+  // When false, epilogue falls back to vec16 software scatter.
+  bool tma_direct_o_enabled = false;
+  GMEM_BOUNDS_FIELD
+};
+
+using FMHAVariantFn = cudaError_t (*)(const FMHACutlassSM100Params&);
+
+cudaError_t fmha_reduction_bf16(const void* ptr_O_partial, void* ptr_O,
+                                const float* ptr_lse,
+                                const int* num_kv_splits_per_row,
+                                float scale_softmax_log2, float inv_scale_o,
+                                int num_kv_splits, int total_qo_len, int num_qo_heads,
+                                int head_dim_vo, int stride_o_n, int stride_o_h,
+                                int stride_partial_n, int stride_partial_h,
+                                cudaStream_t stream);

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/fmha_sm100_plan.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/fmha_sm100_plan.cu
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 MiniMax
+// SPDX-License-Identifier: MIT
+
+#include "plan.cuh"
+
+#include <tvm/ffi/container/tensor.h>
+#include <tvm/ffi/dtype.h>
+#include <tvm/ffi/error.h>
+#include <tvm/ffi/function.h>
+#include <tvm/ffi/reflection/registry.h>
+
+using tvm::ffi::Optional;
+using tvm::ffi::TensorView;
+
+namespace minfer {
+namespace ops {
+
+void fmha_sm100_plan_forward(
+    TensorView qo_segment_offsets,
+    TensorView qo_segment_lens, TensorView kv_segment_lens,
+    TensorView packed_work_range, TensorView packed_work_info,
+    int64_t qo_tile_size, int64_t kv_tile_size,
+    int64_t num_heads, int64_t num_buckets, bool causal,
+    Optional<TensorView> maybe_qo_offsets,
+    int64_t num_kv_splits,
+    Optional<TensorView> maybe_kv_tile_begin_indices,
+    Optional<TensorView> maybe_kv_tile_end_indices,
+    Optional<TensorView> maybe_kv_split_indices,
+    int64_t adaptive_chunk_size,
+    Optional<TensorView> maybe_out_max_sm_cost,
+    Optional<TensorView> maybe_num_kv_splits_per_row,
+    int64_t stream_ptr,
+    Optional<TensorView> maybe_workspace_lse,
+    int64_t lse_total_size,
+    int64_t pack_factor) {
+  const cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
+  int batch_size = qo_segment_lens.size(0);
+
+  int* qo_offsets_ptr = maybe_qo_offsets.has_value()
+                            ? static_cast<int*>(maybe_qo_offsets.value().data_ptr())
+                            : nullptr;
+  int* kv_tile_begin_ptr = maybe_kv_tile_begin_indices.has_value()
+                               ? static_cast<int*>(maybe_kv_tile_begin_indices.value().data_ptr())
+                               : nullptr;
+  int* kv_tile_end_ptr = maybe_kv_tile_end_indices.has_value()
+                             ? static_cast<int*>(maybe_kv_tile_end_indices.value().data_ptr())
+                             : nullptr;
+  int* kv_split_ptr = maybe_kv_split_indices.has_value()
+                          ? static_cast<int*>(maybe_kv_split_indices.value().data_ptr())
+                          : nullptr;
+  float* out_max_sm_cost_ptr = maybe_out_max_sm_cost.has_value()
+                                   ? static_cast<float*>(maybe_out_max_sm_cost.value().data_ptr())
+                                   : nullptr;
+  int* num_kv_splits_per_row_ptr = maybe_num_kv_splits_per_row.has_value()
+                                       ? static_cast<int*>(maybe_num_kv_splits_per_row.value().data_ptr())
+                                       : nullptr;
+  float* workspace_lse_ptr = maybe_workspace_lse.has_value()
+                                 ? static_cast<float*>(maybe_workspace_lse.value().data_ptr())
+                                 : nullptr;
+
+  auto status = flashinfer::plan_kernel_wrapper(
+      static_cast<int*>(qo_segment_offsets.data_ptr()),
+      static_cast<int*>(qo_segment_lens.data_ptr()),
+      static_cast<int*>(kv_segment_lens.data_ptr()),
+      static_cast<uint64_t*>(packed_work_range.data_ptr()),
+      static_cast<uint64_t*>(packed_work_info.data_ptr()),
+      qo_tile_size, kv_tile_size, batch_size,
+      num_heads, num_buckets, causal, qo_offsets_ptr,
+      /*enable_pdl=*/true, stream,
+      num_kv_splits, kv_tile_begin_ptr, kv_tile_end_ptr, kv_split_ptr,
+      adaptive_chunk_size, out_max_sm_cost_ptr,
+      num_kv_splits_per_row_ptr,
+      workspace_lse_ptr, static_cast<int>(lse_total_size),
+      static_cast<int>(pack_factor));
+  if (status != cudaSuccess) {
+    TVM_FFI_THROW(RuntimeError) << "Failed to plan fmha_sm100: " << cudaGetErrorString(status);
+  }
+}
+
+}  // namespace ops
+}  // namespace minfer
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(plan, minfer::ops::fmha_sm100_plan_forward);

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/fmha_sm100_plan.h
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/fmha_sm100_plan.h
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 MiniMax
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+namespace minfer {
+namespace ops {
+
+void fmha_sm100_plan_forward(
+    /* See fmha_sm100_plan.cu for TVM-FFI parameter list */);
+
+}  // namespace ops
+}  // namespace minfer

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/fmha_sm100_reduction.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/fmha_sm100_reduction.cu
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 MiniMax
+// SPDX-License-Identifier: MIT
+
+#include "fmha_cutlass_sm100.cuh"
+
+#include <tvm/ffi/container/tensor.h>
+#include <tvm/ffi/dtype.h>
+#include <tvm/ffi/error.h>
+#include <tvm/ffi/function.h>
+#include <tvm/ffi/reflection/registry.h>
+
+using tvm::ffi::TensorView;
+
+namespace minfer {
+namespace ops {
+
+static cudaError_t fmha_reduction_bf16_impl(
+    const void* ptr_O_partial, void* ptr_O,
+    const float* ptr_lse,
+    const int* num_kv_splits_per_row,
+    float scale_softmax_log2, float inv_scale_o,
+    int num_kv_splits, int total_qo_len, int num_qo_heads,
+    int head_dim_vo, int stride_o_n, int stride_o_h,
+    int stride_partial_n, int stride_partial_h,
+    void* ptr_O_direct, int num_qo_heads_orig,
+    int num_kv_heads, int pack_factor,
+    cudaStream_t stream) {
+  return flashinfer::launch_fmha_reduction<cutlass::bfloat16_t, cutlass::bfloat16_t>(
+      static_cast<const cutlass::bfloat16_t*>(ptr_O_partial),
+      static_cast<cutlass::bfloat16_t*>(ptr_O),
+      ptr_lse, num_kv_splits_per_row,
+      scale_softmax_log2, inv_scale_o,
+      num_kv_splits, total_qo_len, num_qo_heads, head_dim_vo,
+      stride_o_n, stride_o_h, stride_partial_n, stride_partial_h,
+      static_cast<cutlass::bfloat16_t*>(ptr_O_direct),
+      num_qo_heads_orig, num_kv_heads, pack_factor,
+      stream);
+}
+
+void fmha_sm100_reduction_forward(
+    TensorView o_partial, TensorView o,
+    TensorView lse,
+    TensorView num_kv_splits_per_row_tensor,
+    double scale_softmax_log2, double inv_scale_o,
+    int64_t num_kv_splits, int64_t total_qo_len, int64_t num_qo_heads,
+    int64_t head_dim_vo,
+    int64_t stride_o_n, int64_t stride_o_h,
+    int64_t stride_partial_n, int64_t stride_partial_h,
+    int64_t num_qo_heads_orig,
+    int64_t num_kv_heads,
+    int64_t pack_factor,
+    int64_t stream_ptr) {
+  const cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
+
+  // When direct unpack is enabled, route o.data_ptr() to ptr_O_direct and leave
+  // packed ptr_O nullptr. The kernel branches on ptr_O_direct.
+  void* o_data = o.data_ptr();
+  void* o_packed_ptr = (pack_factor > 1) ? nullptr : o_data;
+  void* o_direct_ptr = (pack_factor > 1) ? o_data : nullptr;
+
+  auto status = fmha_reduction_bf16_impl(
+      o_partial.data_ptr(), o_packed_ptr,
+      static_cast<const float*>(lse.data_ptr()),
+      static_cast<const int*>(num_kv_splits_per_row_tensor.data_ptr()),
+      static_cast<float>(scale_softmax_log2),
+      static_cast<float>(inv_scale_o),
+      static_cast<int>(num_kv_splits),
+      static_cast<int>(total_qo_len),
+      static_cast<int>(num_qo_heads),
+      static_cast<int>(head_dim_vo),
+      static_cast<int>(stride_o_n),
+      static_cast<int>(stride_o_h),
+      static_cast<int>(stride_partial_n),
+      static_cast<int>(stride_partial_h),
+      o_direct_ptr,
+      static_cast<int>(num_qo_heads_orig),
+      static_cast<int>(num_kv_heads),
+      static_cast<int>(pack_factor),
+      stream);
+  if (status != cudaSuccess) {
+    TVM_FFI_THROW(RuntimeError)
+        << "FMHA split-KV reduction failed: " << cudaGetErrorString(status);
+  }
+}
+
+}  // namespace ops
+}  // namespace minfer
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(reduction, minfer::ops::fmha_sm100_reduction_forward);

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/fmha_sm100_reduction.h
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/fmha_sm100_reduction.h
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 MiniMax
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+namespace minfer {
+namespace ops {
+
+void fmha_sm100_reduction_forward(
+    /* See fmha_sm100_reduction.cu for TVM-FFI parameter list */);
+
+}  // namespace ops
+}  // namespace minfer

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/fmha_sm100_variant_run.cu.jinja
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/fmha_sm100_variant_run.cu.jinja
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 MiniMax
+// SPDX-License-Identifier: MIT
+
+// Auto-generated per-variant FMHA run binding: {{ variant_name }}
+#include "fmha_sm100_params.h"
+#include "tvm_ffi_utils.h"
+#include <cmath>
+#include <cstdlib>
+
+using tvm::ffi::Optional;
+
+// Forward-declare the variant kernel function (defined in the inst .cu file)
+extern cudaError_t {{ func_name }}(const FMHACutlassSM100Params& p);
+
+void FMHAVariantRun_{{ variant_name }}(ffi::TensorView workspace_buffer, ffi::TensorView q, ffi::TensorView k,
+                    ffi::TensorView v, ffi::TensorView qo_segment_lens,
+                    ffi::TensorView kv_segment_lens,
+                    ffi::TensorView qo_segment_offsets,
+                    ffi::TensorView kv_segment_offsets,
+                    ffi::TensorView packed_work_range,
+                    ffi::TensorView packed_work_info,
+                    Optional<ffi::TensorView> maybe_o,
+                    double sm_scale, double scale_q, double scale_k, double scale_v,
+                    double o_scale, int64_t max_qo_len,
+                    Optional<ffi::TensorView> maybe_qo_offsets,
+                    int64_t num_kv_splits,
+                    Optional<ffi::TensorView> maybe_kv_tile_begin_indices,
+                    Optional<ffi::TensorView> maybe_kv_tile_end_indices,
+                    Optional<ffi::TensorView> maybe_kv_split_indices,
+                    Optional<ffi::TensorView> maybe_workspace_o,
+                    Optional<ffi::TensorView> maybe_workspace_lse,
+                    Optional<ffi::TensorView> maybe_num_kv_splits_per_row,
+                    int64_t qo_tile_size,
+                    Optional<ffi::TensorView> maybe_kv_indices,
+                    Optional<ffi::TensorView> maybe_kv_page_indptr,
+                    Optional<ffi::TensorView> maybe_max_score,
+                    int64_t max_k_tiles,
+                    Optional<ffi::TensorView> maybe_kv_block_indexes,
+                    int64_t pack_factor,
+                    bool qo_len_uniform,
+                    int64_t stream_ptr) {
+  bool is_paged = maybe_kv_indices.has_value();
+  int head_dim_qk = q.size(2);
+  int head_dim_vo = is_paged ? v.size(3) : v.size(2);
+  int num_qo_heads = q.size(1);
+  int num_kv_heads = k.size(1);
+  int page_size = is_paged ? k.size(2) : 0;
+
+  void* o_ptr = maybe_o.has_value() ? maybe_o.value().data_ptr() : nullptr;
+  float* max_score_ptr = maybe_max_score.has_value()
+                             ? static_cast<float*>(maybe_max_score.value().data_ptr())
+                             : nullptr;
+  int* kv_block_indexes_ptr = maybe_kv_block_indexes.has_value()
+                                  ? static_cast<int*>(maybe_kv_block_indexes.value().data_ptr())
+                                  : nullptr;
+
+  const cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
+
+  FMHACutlassSM100Params params;
+  params.workspace_buffer_ptr = workspace_buffer.data_ptr();
+  params.q_ptr = q.data_ptr();
+  params.k_ptr = k.data_ptr();
+  params.v_ptr = v.data_ptr();
+  params.qo_segment_lens_ptr = static_cast<int*>(qo_segment_lens.data_ptr());
+  params.kv_segment_lens_ptr = static_cast<int*>(kv_segment_lens.data_ptr());
+  params.qo_segment_offsets_ptr = static_cast<int*>(qo_segment_offsets.data_ptr());
+  params.kv_segment_offsets_ptr = static_cast<int*>(kv_segment_offsets.data_ptr());
+  params.packed_work_range_ptr = static_cast<uint64_t*>(packed_work_range.data_ptr());
+  params.packed_work_info_ptr = static_cast<uint64_t*>(packed_work_info.data_ptr());
+  params.o_ptr = o_ptr;
+  params.mask_mode_code = 1;  // causal only
+  params.sm_scale = sm_scale;
+  params.scale_q = scale_q;
+  params.scale_k = scale_k;
+  params.scale_v = scale_v;
+  params.o_scale = o_scale;
+  params.num_qo_heads = num_qo_heads;
+  params.num_kv_heads = num_kv_heads;
+  params.head_dim_qk = head_dim_qk;
+  params.head_dim_vo = head_dim_vo;
+  params.q_stride_n = q.stride(0);
+  params.q_stride_h = q.stride(1);
+  params.k_stride_n = k.stride(0);
+  params.k_stride_h = k.stride(1);
+  params.v_stride_n = v.stride(0);
+  params.v_stride_h = v.stride(1);
+  params.batch_size = qo_segment_lens.size(0);
+  params.total_qo_len = q.size(0);
+  params.total_kv_len = is_paged ? 0 : k.size(0);
+  params.max_qo_len = static_cast<int>(max_qo_len);
+  params.qo_offsets_ptr = maybe_qo_offsets.has_value()
+                              ? static_cast<int*>(maybe_qo_offsets.value().data_ptr())
+                              : nullptr;
+  params.stream = stream;
+  params.num_kv_splits = static_cast<int>(num_kv_splits);
+  params.kv_tile_begin_ptr = maybe_kv_tile_begin_indices.has_value()
+                                 ? static_cast<int*>(maybe_kv_tile_begin_indices.value().data_ptr())
+                                 : nullptr;
+  params.kv_tile_end_ptr = maybe_kv_tile_end_indices.has_value()
+                               ? static_cast<int*>(maybe_kv_tile_end_indices.value().data_ptr())
+                               : nullptr;
+  params.kv_split_ptr = maybe_kv_split_indices.has_value()
+                            ? static_cast<int*>(maybe_kv_split_indices.value().data_ptr())
+                            : nullptr;
+  params.workspace_o_ptr = maybe_workspace_o.has_value()
+                               ? maybe_workspace_o.value().data_ptr()
+                               : nullptr;
+  params.workspace_lse_ptr = maybe_workspace_lse.has_value()
+                                     ? static_cast<float*>(maybe_workspace_lse.value().data_ptr())
+                                     : nullptr;
+  params.num_kv_splits_per_row_ptr = maybe_num_kv_splits_per_row.has_value()
+                                         ? static_cast<int*>(maybe_num_kv_splits_per_row.value().data_ptr())
+                                         : nullptr;
+  params.kv_indices_ptr = maybe_kv_indices.has_value()
+                              ? static_cast<int*>(maybe_kv_indices.value().data_ptr())
+                              : nullptr;
+  params.kv_page_indptr_ptr = maybe_kv_page_indptr.has_value()
+                                  ? static_cast<int*>(maybe_kv_page_indptr.value().data_ptr())
+                                  : nullptr;
+  params.total_page_num = is_paged ? k.size(0) : 0;
+  params.max_score_ptr = max_score_ptr;
+  params.max_k_tiles = static_cast<int>(max_k_tiles);
+  int max_score_logical_heads = 0;
+  if (maybe_max_score.has_value()) {
+    const auto& ms = maybe_max_score.value();
+    TVM_FFI_ICHECK(ms.ndim() == 3) << "max_score must be 3D";
+    TVM_FFI_ICHECK(encode_dlpack_dtype(ms.dtype()) == float32_code)
+        << "max_score must be float32";
+
+    const int64_t ms0 = ms.size(0);
+    const int64_t ms1 = ms.size(1);
+    const int64_t ms2 = ms.size(2);
+    const int64_t max_k = max_k_tiles;
+    const int64_t unpacked_t = q.size(0);
+    const int64_t unpacked_h = q.size(1);
+    const int64_t packed_t = q.size(0) * static_cast<int64_t>(pack_factor);
+    const int64_t packed_h = q.size(1) / static_cast<int64_t>(pack_factor);
+
+    const bool thk_unpacked = (ms0 == unpacked_t && ms1 == unpacked_h && ms2 == max_k);
+    const bool hkt_unpacked = (ms0 == unpacked_h && ms1 == max_k && ms2 == unpacked_t);
+    const bool thk_packed = (ms0 == packed_t && ms1 == packed_h && ms2 == max_k);
+    const bool hkt_packed = (ms0 == packed_h && ms1 == max_k && ms2 == packed_t);
+
+    if (thk_unpacked) {
+      params.max_score_stride_t = static_cast<int>(ms.stride(0));
+      params.max_score_stride_h = static_cast<int>(ms.stride(1));
+      params.max_score_stride_k = static_cast<int>(ms.stride(2));
+      params.total_qo_len_orig = static_cast<int>(unpacked_t);
+      max_score_logical_heads = static_cast<int>(unpacked_h);
+    } else if (hkt_unpacked) {
+      params.max_score_stride_t = static_cast<int>(ms.stride(2));
+      params.max_score_stride_h = static_cast<int>(ms.stride(0));
+      params.max_score_stride_k = static_cast<int>(ms.stride(1));
+      params.total_qo_len_orig = static_cast<int>(unpacked_t);
+      max_score_logical_heads = static_cast<int>(unpacked_h);
+    } else if (thk_packed) {
+      params.max_score_stride_t = static_cast<int>(ms.stride(0));
+      params.max_score_stride_h = static_cast<int>(ms.stride(1));
+      params.max_score_stride_k = static_cast<int>(ms.stride(2));
+      params.total_qo_len_orig = static_cast<int>(packed_t);
+      max_score_logical_heads = static_cast<int>(packed_h);
+    } else if (hkt_packed) {
+      params.max_score_stride_t = static_cast<int>(ms.stride(2));
+      params.max_score_stride_h = static_cast<int>(ms.stride(0));
+      params.max_score_stride_k = static_cast<int>(ms.stride(1));
+      params.total_qo_len_orig = static_cast<int>(packed_t);
+      max_score_logical_heads = static_cast<int>(packed_h);
+    } else {
+      TVM_FFI_ICHECK(false)
+          << "max_score must have shape [T,H,K] or [H,K,T]; got ["
+          << ms0 << ", " << ms1 << ", " << ms2 << "], expected unpacked ["
+          << unpacked_t << ", " << unpacked_h << ", " << max_k << "] or ["
+          << unpacked_h << ", " << max_k << ", " << unpacked_t << "]";
+    }
+  }
+  params.kv_block_indexes_ptr = kv_block_indexes_ptr;
+  params.kv_block_num = maybe_kv_block_indexes.has_value()
+                            ? static_cast<int>(maybe_kv_block_indexes.value().size(2))
+                            : 0;
+
+  params.pack_factor = static_cast<int>(pack_factor);
+  params.num_ctas = static_cast<int>(packed_work_range.size(0));
+  if (pack_factor > 1) {
+    params.q_stride_n_original = q.stride(0);
+    params.q_stride_h_original = q.stride(1);
+    params.h_r_original = num_qo_heads / num_kv_heads;
+    int packed_num_qo_heads = num_qo_heads / static_cast<int>(pack_factor);
+    params.num_qo_heads = packed_num_qo_heads;
+    params.total_qo_len = q.size(0) * static_cast<int>(pack_factor);
+    params.q_stride_n = packed_num_qo_heads * head_dim_qk;
+    params.q_stride_h = head_dim_qk;
+
+    // Pack GQA: direct max_score unpack
+    // Activate when max_score is in unpacked shape (size(0) > packed num_qo_heads).
+    if (maybe_max_score.has_value()
+        && max_score_logical_heads > packed_num_qo_heads) {
+      params.max_score_direct_ptr = max_score_ptr;
+    }
+
+    // Pack GQA: direct O unpack
+    // Activated only when caller explicitly opts in (via Python flag) AND O is in unpacked shape.
+    // Caller-allocated unpacked-shape O without opt-in (e.g. legacy bench) MUST go through
+    // the original packed-write + Python _unpack_gqa_o path to keep semantics correct.
+    if (pack_factor > 1
+        && maybe_o.has_value()
+        && static_cast<int>(maybe_o.value().size(1)) > packed_num_qo_heads) {
+      params.o_direct_ptr = o_ptr;
+      params.num_qo_heads_orig = static_cast<int>(maybe_o.value().size(1));
+      params.o_ptr = nullptr;  // skip TMA descriptor for O
+
+      // TMA fused direct-O unpack eligibility:
+      //   1. qo_len uniform across batches (per-CTA tile shape constant)
+      //   2. FMHA_DISABLE_TMA_DIRECT_O env var not set (A/B testing knob)
+      // If ineligible, epilogue falls back to vec16 software scatter loop.
+      static const bool tma_direct_o_disabled =
+          (std::getenv("FMHA_DISABLE_TMA_DIRECT_O") != nullptr);
+      params.tma_direct_o_enabled = qo_len_uniform && !tma_direct_o_disabled
+                                    && (params.max_qo_len > 0);
+      // total_qo_len_orig: unpacked tensor's leading dim
+      // (already set if max_score present; ensure consistent if not)
+      if (params.total_qo_len_orig == 0) {
+        params.total_qo_len_orig =
+            static_cast<int>(maybe_o.value().size(0));
+      }
+    }
+  }
+
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+  params.gmem_bounds.packed_work_range_size = static_cast<int>(packed_work_range.size(0));
+  params.gmem_bounds.packed_work_info_size = static_cast<int>(packed_work_info.size(0));
+  params.gmem_bounds.qo_segment_offsets_size = static_cast<int>(qo_segment_offsets.size(0));
+  params.gmem_bounds.kv_segment_offsets_size = static_cast<int>(kv_segment_offsets.size(0));
+  params.gmem_bounds.segment_lens_size = static_cast<int>(qo_segment_lens.size(0));
+  params.gmem_bounds.kv_page_indptr_size = maybe_kv_page_indptr.has_value()
+      ? static_cast<int>(maybe_kv_page_indptr.value().size(0)) : 0;
+  params.gmem_bounds.kv_indices_size = maybe_kv_indices.has_value()
+      ? static_cast<int>(maybe_kv_indices.value().size(0)) : 0;
+  params.gmem_bounds.max_score_numel = maybe_max_score.has_value()
+      ? static_cast<int>(maybe_max_score.value().size(0)
+                         * maybe_max_score.value().size(1)
+                         * maybe_max_score.value().size(2)) : 0;
+  params.gmem_bounds.kv_block_indexes_numel = maybe_kv_block_indexes.has_value()
+      ? static_cast<int>(maybe_kv_block_indexes.value().size(0)
+                         * maybe_kv_block_indexes.value().size(1)
+                         * maybe_kv_block_indexes.value().size(2)) : 0;
+  params.gmem_bounds.split_kv_size = maybe_kv_tile_begin_indices.has_value()
+      ? static_cast<int>(maybe_kv_tile_begin_indices.value().size(0)) : 0;
+  params.gmem_bounds.qo_offsets_size = maybe_qo_offsets.has_value()
+      ? static_cast<int>(maybe_qo_offsets.value().size(0)) : 0;
+#endif
+
+  cudaError_t status = {{ func_name }}(params);
+  TVM_FFI_ICHECK_EQ(status, cudaSuccess)
+      << "FMHA variant {{ variant_name }} failed: " << cudaGetErrorString(status);
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(run_{{ variant_name }}, FMHAVariantRun_{{ variant_name }});

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/gmem_bounds_check.h
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/gmem_bounds_check.h
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 MiniMax
+// SPDX-License-Identifier: MIT
+
+#pragma once
+// GMEM bounds-checking helpers for FMHA kernel debugging.
+// Activated only when compiled with -DFMHA_GMEM_BOUNDS_CHECK.
+// Usage: set env FMHA_GMEM_CHECK=1 before running Python → JIT adds the flag.
+
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+
+#include <cstdio>
+
+struct GmemBounds {
+  int packed_work_range_size;
+  int packed_work_info_size;
+  int qo_segment_offsets_size;
+  int kv_segment_offsets_size;
+  int segment_lens_size;
+  int kv_page_indptr_size;
+  int kv_indices_size;
+  int max_score_numel;
+  int kv_block_indexes_numel;
+  int split_kv_size;
+  int qo_offsets_size;
+};
+
+template <typename T>
+__device__ __forceinline__ T gmem_load_checked(
+    const T* base, int idx, int size, const char* name) {
+  if (__builtin_expect(idx < 0 || idx >= size, 0)) {
+    printf("GMEM-OOB-LOAD [%s] idx=%d size=%d blk=(%d,%d,%d) thr=%d\n",
+           name, idx, size, blockIdx.x, blockIdx.y, blockIdx.z, threadIdx.x);
+    return T(0);
+  }
+  return base[idx];
+}
+
+__device__ __forceinline__ void gmem_stwt_checked(
+    float* addr, float val, const float* base, int numel, const char* name) {
+  long long offset = (long long)(addr - base);
+  if (__builtin_expect(offset < 0 || offset >= numel, 0)) {
+    printf("GMEM-OOB-STWT [%s] offset=%lld numel=%d blk=(%d,%d,%d) thr=%d val=%f\n",
+           name, offset, numel, blockIdx.x, blockIdx.y, blockIdx.z, threadIdx.x, val);
+    return;
+  }
+  __stwt(addr, val);
+}
+
+__device__ __forceinline__ void gmem_store_f_checked(
+    float* base, int idx, float val, int size, const char* name) {
+  if (__builtin_expect(idx < 0 || idx >= size, 0)) {
+    printf("GMEM-OOB-STORE [%s] idx=%d size=%d blk=(%d,%d,%d) thr=%d val=%f\n",
+           name, idx, size, blockIdx.x, blockIdx.y, blockIdx.z, threadIdx.x, val);
+    return;
+  }
+  base[idx] = val;
+}
+
+// Pointer-range check for cp.async / vec stores where we have (addr, base, numel)
+__device__ __forceinline__ bool gmem_range_ok(
+    const void* addr, int bytes, const void* base, int numel_bytes, const char* name) {
+  long long off = (long long)((const char*)addr - (const char*)base);
+  if (__builtin_expect(off < 0 || off + bytes > numel_bytes, 0)) {
+    printf("GMEM-OOB-RANGE [%s] off=%lld bytes=%d buf_bytes=%d blk=(%d,%d,%d) thr=%d\n",
+           name, off, bytes, numel_bytes, blockIdx.x, blockIdx.y, blockIdx.z, threadIdx.x);
+    return false;
+  }
+  return true;
+}
+
+#define GMEM_BOUNDS_FIELD GmemBounds gmem_bounds;
+
+// Macros for split_kv buffer reads (used at 7+ sites in the kernel)
+#define SPLIT_KV_BEGIN(p, wp) gmem_load_checked((p).kv_tile_begin_indices, (wp), (p).split_kv_buf_size, "kv_tile_begin")
+#define SPLIT_KV_END(p, wp)   gmem_load_checked((p).kv_tile_end_indices,   (wp), (p).split_kv_buf_size, "kv_tile_end")
+#define SPLIT_KV_SPLIT(p, wp) gmem_load_checked((p).kv_split_indices,      (wp), (p).split_kv_buf_size, "kv_split")
+
+// Macros for segment_offsets reads
+#define SEG_OFF_LOAD(vl, idx, sz) gmem_load_checked((vl).segment_offsets, (idx), (sz), "seg_offsets")
+#define SEG_LEN_LOAD(vl, idx, sz) gmem_load_checked((vl).segment_lens,   (idx), (sz), "seg_lens")
+
+// Macros for paged KV reads
+#define KV_INDPTR_LOAD(ptr, idx, sz)  gmem_load_checked((ptr), (idx), (sz), "kv_page_indptr")
+#define KV_INDICES_LOAD(ptr, idx, sz) gmem_load_checked((ptr), (idx), (sz), "kv_indices")
+
+#else  // FMHA_GMEM_BOUNDS_CHECK not defined
+
+#define GMEM_BOUNDS_FIELD
+#define SPLIT_KV_BEGIN(p, wp)  (p).kv_tile_begin_indices[(wp)]
+#define SPLIT_KV_END(p, wp)    (p).kv_tile_end_indices[(wp)]
+#define SPLIT_KV_SPLIT(p, wp)  (p).kv_split_indices[(wp)]
+#define SEG_OFF_LOAD(vl, idx, sz)  (vl).segment_offsets[(idx)]
+#define SEG_LEN_LOAD(vl, idx, sz)  (vl).segment_lens[(idx)]
+#define KV_INDPTR_LOAD(ptr, idx, sz)  __ldg(&(ptr)[(idx)])
+#define KV_INDICES_LOAD(ptr, idx, sz) __ldg(&(ptr)[(idx)])
+
+#endif  // FMHA_GMEM_BOUNDS_CHECK

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/allocator.h
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/allocator.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_ALLOCATOR_H_
+#define FLASHINFER_ALLOCATOR_H_
+
+#include <memory>
+#include <sstream>
+
+#include "exception.h"
+
+namespace flashinfer {
+
+// create a function that returns T* from base pointer and offset
+template <typename T>
+T* GetPtrFromBaseOffset(void* base_ptr, int64_t offset) {
+  return reinterpret_cast<T*>(reinterpret_cast<char*>(base_ptr) + offset);
+}
+
+struct AlignedAllocator {
+  void* base_ptr;
+  void* cur_ptr;
+  size_t remaining_space;
+  AlignedAllocator(void* buf, size_t space) : base_ptr(buf), cur_ptr(buf), remaining_space(space) {}
+  template <typename T>
+  T* aligned_alloc(size_t size, size_t alignment, std::string name) {
+    if (std::align(alignment, size, cur_ptr, remaining_space)) {
+      T* result = reinterpret_cast<T*>(cur_ptr);
+      cur_ptr = (char*)cur_ptr + size;
+      remaining_space -= size;
+      return result;
+    } else {
+      std::ostringstream oss;
+      oss << "Buffer overflow when allocating memory for " << name << " with size " << size
+          << " and alignment " << alignment << ", but only " << remaining_space
+          << " bytes available in AlignedAllocator. Increase the workspace buffer size.";
+      FLASHINFER_ERROR(oss.str());
+    }
+    return nullptr;
+  }
+
+  size_t aligned_alloc_offset(size_t size, size_t alignment, std::string name) {
+    return (char*)aligned_alloc<char>(size, alignment, name) - (char*)base_ptr;
+  }
+
+  size_t num_allocated_bytes() { return (char*)cur_ptr - (char*)base_ptr; }
+};
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_ALLOCATOR_H_

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/cutlass_utils.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/cutlass_utils.cuh
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2024 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_CUTLASS_UTILS_CUH_
+#define FLASHINFER_CUTLASS_UTILS_CUH_
+
+#include <cuda_fp8.h>
+
+#include "cute/tensor.hpp"
+#include "cutlass/cutlass.h"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/default_epilogue.hpp"
+#include "cutlass/epilogue/thread/linear_combination.h"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_grouped.h"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/gemm/group_array_problem_shape.hpp"
+#include "cutlass/gemm/kernel/default_gemm_grouped.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/layout/matrix.h"
+#include "cutlass/numeric_types.h"
+#include "cutlass/tensor_ref.h"
+#include "cutlass/util/command_line.h"
+#include "cutlass/util/distribution.h"
+#include "cutlass/util/host_tensor.h"
+#include "cutlass/util/packed_stride.hpp"
+#include "cutlass/util/reference/device/gemm.h"
+#include "cutlass/util/reference/device/tensor_compare.h"
+#include "cutlass/util/reference/device/tensor_fill.h"
+#include "cutlass/util/tensor_view_io.h"
+#if defined(FLASHINFER_ENABLE_FP4_E2M1)
+#if (__CUDACC_VER_MAJOR__ * 1000 + __CUDACC_VER_MINOR__ * 10 >= 12080)
+#include <cuda_fp4.h>
+#endif
+#endif
+
+namespace flashinfer {
+
+template <typename T>
+struct cutlass_dtype {
+  using type = T;
+};
+
+template <>
+struct cutlass_dtype<half> {
+  using type = cutlass::half_t;
+};
+
+template <>
+struct cutlass_dtype<nv_bfloat16> {
+  using type = cutlass::bfloat16_t;
+};
+
+template <>
+struct cutlass_dtype<__nv_fp8_e4m3> {
+  using type = cutlass::float_e4m3_t;
+};
+
+template <>
+struct cutlass_dtype<__nv_fp8_e5m2> {
+  using type = cutlass::float_e5m2_t;
+};
+
+#if CUDA_VERSION >= 12080
+template <>
+struct cutlass_dtype<__nv_fp8_e8m0> {
+  using type = cutlass::float_ue8m0_t;
+};
+
+#if defined(FLASHINFER_ENABLE_FP4_E2M1)
+template <>
+struct cutlass_dtype<__nv_fp4_e2m1> {
+  using type = cutlass::float_e2m1_t;
+};
+#endif
+#endif
+
+template <typename T>
+using cutlass_dtype_t = typename cutlass_dtype<T>::type;
+
+template <typename T>
+void compileTimeDebug(T&&) {
+  static_assert(sizeof(T) == 0, "Compile time debug");
+}
+
+#define CUTLASS_CHECK(cmd)                                                            \
+  do {                                                                                \
+    auto status = cmd;                                                                \
+    if (status != cutlass::Status::kSuccess) {                                        \
+      std::ostringstream err_msg;                                                     \
+      err_msg << "cutlass " << #cmd << " failed: " << cutlassGetStatusString(status); \
+      FLASHINFER_ERROR(err_msg.str());                                                \
+    }                                                                                 \
+  } while (0)
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_CUTLASS_UTILS_CUH_

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/exception.h
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/exception.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2024 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_EXCEPTION_H_
+#define FLASHINFER_EXCEPTION_H_
+
+#include <exception>
+#include <iostream>
+#include <sstream>
+
+#define FLASHINFER_ERROR(message) throw flashinfer::Error(__FUNCTION__, __FILE__, __LINE__, message)
+
+// Base case for empty arguments
+inline void write_to_stream(std::ostringstream& oss) {
+  // No-op for empty arguments
+}
+
+template <typename T>
+void write_to_stream(std::ostringstream& oss, T&& val) {
+  oss << std::forward<T>(val);
+}
+
+template <typename T, typename... Args>
+void write_to_stream(std::ostringstream& oss, T&& val, Args&&... args) {
+  oss << std::forward<T>(val) << " ";
+  write_to_stream(oss, std::forward<Args>(args)...);
+}
+
+// Helper macro to handle empty __VA_ARGS__
+#define FLASHINFER_CHECK_IMPL(condition, message) \
+  if (!(condition)) {                             \
+    FLASHINFER_ERROR(message);                    \
+  }
+
+// Main macro that handles both cases
+#define FLASHINFER_CHECK(condition, ...)   \
+  do {                                     \
+    if (!(condition)) {                    \
+      std::ostringstream oss;              \
+      write_to_stream(oss, ##__VA_ARGS__); \
+      std::string msg = oss.str();         \
+      if (msg.empty()) {                   \
+        msg = "Check failed: " #condition; \
+      }                                    \
+      FLASHINFER_ERROR(msg);               \
+    }                                      \
+  } while (0)
+
+// Warning macro
+#define FLASHINFER_WARN(...)                                           \
+  do {                                                                 \
+    std::ostringstream oss;                                            \
+    write_to_stream(oss, ##__VA_ARGS__);                               \
+    std::string msg = oss.str();                                       \
+    if (msg.empty()) {                                                 \
+      msg = "Warning triggered";                                       \
+    }                                                                  \
+    flashinfer::Warning(__FUNCTION__, __FILE__, __LINE__, msg).emit(); \
+  } while (0)
+
+namespace flashinfer {
+class Error : public std::exception {
+ private:
+  std::string message_;
+
+ public:
+  Error(const std::string& func, const std::string& file, int line, const std::string& message) {
+    std::ostringstream oss;
+    oss << "Error in function '" << func << "' "
+        << "at " << file << ":" << line << ": " << message;
+    message_ = oss.str();
+  }
+
+  virtual const char* what() const noexcept override { return message_.c_str(); }
+};
+
+class Warning {
+ private:
+  std::string message_;
+
+ public:
+  Warning(const std::string& func, const std::string& file, int line, const std::string& message) {
+    std::ostringstream oss;
+    oss << "Warning in function '" << func << "' "
+        << "at " << file << ":" << line << ": " << message;
+    message_ = oss.str();
+  }
+
+  void emit() const { std::cerr << message_ << std::endl; }
+};
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_EXCEPTION_H_

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/fmha.hpp
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/fmha.hpp
@@ -1,0 +1,251 @@
+/***************************************************************************************************
+ * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+/*!
+  \file
+  \brief An universal device layer for cutlass 3.x-style kernels.
+*/
+
+#pragma once
+
+// common
+#include "cutlass/cutlass.h"
+#include "cutlass/device_kernel.h"
+
+#if !defined(__CUDACC_RTC__)
+#include "cutlass/cluster_launch.hpp"
+#include "cutlass/trace.h"
+#endif  // !defined(__CUDACC_RTC__)
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass::fmha::device {
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////// CUTLASS 3.x API /////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+template <class Kernel_>
+class FMHA {
+ public:
+  using Kernel = Kernel_;
+
+  static int const kThreadCount = Kernel::MaxThreadsPerBlock;
+
+  /// Argument structure: User API
+  using Arguments = typename Kernel::Arguments;
+  /// Argument structure: Kernel API
+  using Params = typename Kernel::Params;
+
+ private:
+  /// Kernel API parameters object
+  Params params_;
+
+  bool is_initialized(bool set = false) {
+    static bool initialized = false;
+    if (set) initialized = true;
+    return initialized;
+  }
+
+ public:
+  /// Access the Params structure
+  Params const& params() const { return params_; }
+
+  /// Determines whether the GEMM can execute the given problem.
+  static Status can_implement(Arguments const& args) {
+    if (Kernel::can_implement(args)) {
+      return Status::kSuccess;
+    } else {
+      return Status::kInvalid;
+    }
+  }
+
+  /// Gets the workspace size
+  static size_t get_workspace_size(Arguments const& args) {
+    size_t workspace_bytes = 0;
+    workspace_bytes += Kernel::get_workspace_size(args);
+    return workspace_bytes;
+  }
+
+  /// Computes the grid shape
+  static dim3 get_grid_shape(Params const& params) { return Kernel::get_grid_shape(params); }
+
+  /// Computes the maximum number of active blocks per multiprocessor
+  static int maximum_active_blocks(int /* smem_capacity */ = -1) {
+    CUTLASS_TRACE_HOST("FMHA::maximum_active_blocks()");
+    int max_active_blocks = -1;
+    int smem_size = Kernel::SharedStorageSize;
+
+    // first, account for dynamic smem capacity if needed
+    cudaError_t result;
+    if (smem_size >= (48 << 10)) {
+      CUTLASS_TRACE_HOST("  Setting smem size to " << smem_size);
+      result = cudaFuncSetAttribute(device_kernel<Kernel>,
+                                    cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+      if (cudaSuccess != result) {
+        result = cudaGetLastError();  // to clear the error bit
+        CUTLASS_TRACE_HOST(
+            "  cudaFuncSetAttribute() returned error: " << cudaGetErrorString(result));
+        return -1;
+      }
+    }
+
+    // query occupancy after setting smem size
+    result = cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &max_active_blocks, device_kernel<Kernel>, Kernel::MaxThreadsPerBlock, smem_size);
+
+    if (cudaSuccess != result) {
+      result = cudaGetLastError();  // to clear the error bit
+      CUTLASS_TRACE_HOST("  cudaOccupancyMaxActiveBlocksPerMultiprocessor() returned error: "
+                         << cudaGetErrorString(result));
+      return -1;
+    }
+
+    CUTLASS_TRACE_HOST("  max_active_blocks: " << max_active_blocks);
+    return max_active_blocks;
+  }
+
+  /// Initializes GEMM state from arguments.
+  Status initialize(Arguments const& args, void* workspace = nullptr,
+                    cudaStream_t stream = nullptr) {
+    CUTLASS_TRACE_HOST("FMHA::initialize() - workspace "
+                       << workspace << ", stream: " << (stream ? "non-null" : "null"));
+
+    // Initialize the workspace
+    Status status = Kernel::initialize_workspace(args, workspace, stream);
+    if (status != Status::kSuccess) {
+      return status;
+    }
+
+    // Initialize the Params structure
+    params_ = Kernel::to_underlying_arguments(args, workspace);
+
+    if (is_initialized()) return Status::kSuccess;
+
+    // account for dynamic smem capacity if needed
+    int smem_size = Kernel::SharedStorageSize;
+    if (smem_size >= (48 << 10)) {
+      CUTLASS_TRACE_HOST("  Setting smem size to " << smem_size);
+      cudaError_t result = cudaFuncSetAttribute(
+          device_kernel<Kernel>, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+      if (cudaSuccess != result) {
+        result = cudaGetLastError();  // to clear the error bit
+        CUTLASS_TRACE_HOST(
+            "  cudaFuncSetAttribute() returned error: " << cudaGetErrorString(result));
+        return Status::kErrorInternal;
+      }
+    }
+
+    is_initialized(true);
+
+    return Status::kSuccess;
+  }
+
+  /// Update API is preserved in 3.0, but does not guarantee a lightweight update of params.
+  Status update(Arguments const& args, void* workspace = nullptr) {
+    CUTLASS_TRACE_HOST("FMHA()::update() - workspace: " << workspace);
+
+    size_t workspace_bytes = get_workspace_size(args);
+    if (workspace_bytes > 0 && nullptr == workspace) {
+      return Status::kErrorWorkspaceNull;
+    }
+
+    params_ = Kernel::to_underlying_arguments(args, workspace);
+    return Status::kSuccess;
+  }
+
+  /// Primary run() entry point API that is static allowing users to create and manage their own
+  /// params. Supplied params struct must be construct by calling Kernel::to_underling_arguments()
+  static Status run(Params& params, cudaStream_t stream = nullptr, bool launch_with_pdl = true) {
+    CUTLASS_TRACE_HOST("FMHA::run()");
+    dim3 const block = Kernel::get_block_shape();
+    dim3 const grid = get_grid_shape(params);
+
+    // configure smem size and carveout
+    int smem_size = Kernel::SharedStorageSize;
+
+    Status launch_result;
+    // Use extended launch API only for mainloops that use it
+    if constexpr (Kernel::ArchTag::kMinComputeCapability >= 90) {
+      dim3 cluster(cute::size<0>(typename Kernel::ClusterShape{}),
+                   cute::size<1>(typename Kernel::ClusterShape{}),
+                   cute::size<2>(typename Kernel::ClusterShape{}));
+      void const* kernel = (void const*)device_kernel<Kernel>;
+      void* kernel_params[] = {&params};
+      launch_result = ClusterLauncher::launch(grid, cluster, block, smem_size, stream, kernel,
+                                              kernel_params, launch_with_pdl);
+    } else {
+      launch_result = Status::kSuccess;
+      device_kernel<Kernel><<<grid, block, smem_size, stream>>>(params);
+    }
+
+    cudaError_t result = cudaGetLastError();
+    if (cudaSuccess == result && Status::kSuccess == launch_result) {
+      return Status::kSuccess;
+    } else {
+      CUTLASS_TRACE_HOST("  Kernel launch failed. Reason: " << result);
+      return Status::kErrorInternal;
+    }
+  }
+
+  //
+  // Non-static launch overloads that first create and set the internal params struct of this kernel
+  // handle.
+  //
+
+  /// Launches the kernel after first constructing Params internal state from supplied arguments.
+  Status run(Arguments const& args, void* workspace = nullptr, cudaStream_t stream = nullptr) {
+    Status status = initialize(args, workspace, stream);
+    if (Status::kSuccess == status) {
+      status = run(params_, stream);
+    }
+    return status;
+  }
+
+  /// Launches the kernel after first constructing Params internal state from supplied arguments.
+  Status operator()(Arguments const& args, void* workspace = nullptr,
+                    cudaStream_t stream = nullptr) {
+    return run(args, workspace, stream);
+  }
+
+  /// Overload that allows a user to re-launch the same kernel without updating internal params
+  /// struct.
+  Status run(cudaStream_t stream = nullptr) { return run(params_, stream); }
+
+  /// Overload that allows a user to re-launch the same kernel without updating internal params
+  /// struct.
+  Status operator()(cudaStream_t stream = nullptr) { return run(params_, stream); }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace cutlass::fmha::device
+
+////////////////////////////////////////////////////////////////////////////////

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/fmha_common.hpp
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/fmha_common.hpp
@@ -1,0 +1,185 @@
+/***************************************************************************************************
+ * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#pragma once
+
+#include "cute/tensor.hpp"
+#include "cutlass/arch/reg_reconfig.h"
+#include "cutlass/kernel_hardware_info.h"
+
+namespace cutlass::fmha::collective {
+
+using namespace cute;
+
+template <typename MTensor, typename Shape>
+CUTLASS_DEVICE auto get_local_tile_tensor(const MTensor& m_tensor, const Shape& tile_shape,
+                                          int head_idx, int offset, int seq_len) {
+  // (N, D, H)
+  auto g_offset = local_tile(m_tensor(_, _, head_idx), cute::make_shape(1, get<1>(tile_shape)),
+                             make_coord(offset, _0{}));
+  auto g_sequence =
+      make_tensor(g_offset.data(),
+                  make_layout(cute::make_shape(seq_len, get<1>(tile_shape)), g_offset.stride()));
+  auto g_tensor = local_tile(g_sequence, tile_shape, make_coord(_, _0{}));
+  return g_tensor;
+}
+
+template <typename MTensor, typename Shape>
+CUTLASS_DEVICE auto get_local_tile_t_tensor(const MTensor& m_tensor, const Shape& tile_shape,
+                                            int head_idx, int offset, int seq_len) {
+  // (D, N, H)
+  auto g_offset = local_tile(m_tensor(_, _, head_idx), cute::make_shape(get<0>(tile_shape), 1),
+                             make_coord(_0{}, offset));
+  auto g_sequence =
+      make_tensor(g_offset.data(),
+                  make_layout(cute::make_shape(get<0>(tile_shape), seq_len), g_offset.stride()));
+  auto g_tensor = local_tile(g_offset, tile_shape, make_coord(_0{}, _));
+  return g_tensor;
+}
+
+template <typename Atom, typename TA, typename TB, typename TC>
+CUTE_DEVICE void gemm_reset_zero_acc(Atom& atom, TA const& tA, TB const& tB, TC&& tC) {
+  constexpr int rA = decltype(rank(tA))::value;
+  constexpr int rB = decltype(rank(tB))::value;
+  constexpr int rC = decltype(rank(tC))::value;
+  static_assert(rA == 3 && rB == 3 && rC == 3);
+
+  CUTLASS_PRAGMA_UNROLL
+  for (int k_block = 0; k_block < size<2>(tA); k_block++) {
+    cute::gemm(atom, tA(_, _, k_block), tB(_, _, k_block), tC);
+    atom.accumulate_ = decltype(atom.accumulate_)::One;
+  }
+}
+
+template <typename Atom, typename TA, typename TB, typename TC>
+CUTE_DEVICE void gemm_zero_acc(Atom& atom, TA const& tA, TB const& tB, TC&& tC) {
+  atom.accumulate_ = decltype(atom.accumulate_)::Zero;
+  gemm_reset_zero_acc(atom, tA, tB, tC);
+}
+
+template <class Layout, class Stages = _1>
+CUTE_DEVICE constexpr auto unstageSmemLayout(Layout const& layout, Stages stages = {}) {
+  return composition(layout, prepend<decltype(rank(layout))::value>(make_layout(stages), _));
+}
+
+template <class T>
+CUTE_DEVICE T warp_uniform(T a) {
+  return __shfl_sync(0xffffffff, a, 0);
+}
+
+template <class a_type, class b_type, class c_type, int M, int N, UMMA::Major a_major,
+          UMMA::Major b_major, UMMA::ScaleIn a_neg, UMMA::ScaleIn b_neg, class... TAs, class... TMs>
+CUTE_HOST_DEVICE constexpr auto to_tiled_mma_sm100_ts(
+    TiledMMA<MMA_Atom<MMA_Traits<SM100_MMA_F8F6F4_SS, a_type, b_type, c_type, cute::C<M>,
+                                 cute::C<N>, cute::integral_constant<UMMA::Major, a_major>,
+                                 cute::integral_constant<UMMA::Major, b_major>,
+                                 cute::integral_constant<UMMA::ScaleIn, a_neg>,
+                                 cute::integral_constant<UMMA::ScaleIn, b_neg>>,
+                      TAs...>,
+             TMs...>) {
+  return TiledMMA<
+      MMA_Atom<MMA_Traits<SM100_MMA_F8F6F4_TS<a_type, b_type, c_type, M, N, a_major, b_major, a_neg,
+                                              b_neg, UMMA::Saturate::False>>,
+               TAs...>,
+      TMs...>{};
+}
+
+template <class a_type, class b_type, class c_type, int M, int N, UMMA::Major a_major,
+          UMMA::Major b_major, UMMA::ScaleIn a_neg, UMMA::ScaleIn b_neg, class... TAs, class... TMs>
+CUTE_HOST_DEVICE constexpr auto to_tiled_mma_sm100_ts(
+    TiledMMA<
+        MMA_Atom<SM100_MMA_F16BF16_SS<a_type, b_type, c_type, M, N, a_major, b_major, a_neg, b_neg>,
+                 TAs...>,
+        TMs...>) {
+  return TiledMMA<MMA_Atom<SM100_MMA_F16BF16_TS<a_type, b_type, c_type, M, N, a_major, b_major,
+                                                a_neg, b_neg, UMMA::Saturate::False>,
+                           TAs...>,
+                  TMs...>{};
+}
+
+template <uint32_t RegCount>
+CUTLASS_DEVICE void warpgroup_reg_set() {
+  if constexpr (RegCount < 128) {
+    cutlass::arch::warpgroup_reg_dealloc<RegCount>();
+  } else {
+    cutlass::arch::warpgroup_reg_alloc<RegCount>();
+  }
+}
+
+// Emulated exp2 using degree-3 polynomial approximation (ported from FA4's e2e_asm2).
+// Uses f32x2 packed PTX instructions to halve instruction count vs scalar version.
+// Reduces SFU pressure by replacing hardware exp2f with FMA-based computation.
+__device__ __forceinline__ void exp2_emulated_2(float& x, float& y) {
+  asm(
+    "{\n\t"
+    ".reg .f32 f1, f2, f3, f4, f5, f6, f7;\n\t"
+    ".reg .b64 l1, l2, l3, l4, l5, l6, l7, l8, l9, l10;\n\t"
+    ".reg .s32 r1, r2, r3, r4, r5, r6, r7, r8;\n\t"
+    // Clamp to [-127, +inf)
+    "max.ftz.f32 f1, %2, 0fC2FE0000;\n\t"       // f1 = max(x, -127.0)
+    "max.ftz.f32 f2, %3, 0fC2FE0000;\n\t"       // f2 = max(y, -127.0)
+    "mov.b64 l1, {f1, f2};\n\t"                  // pack into f32x2
+    // Bias for floor extraction: 2^23 + 2^22 = 12582912.0
+    "mov.f32 f3, 0f4B400000;\n\t"
+    "mov.b64 l2, {f3, f3};\n\t"
+    // Round-down add to extract floor(x) in lower bits
+    "add.rm.ftz.f32x2 l7, l1, l2;\n\t"           // rounded = clamped + bias
+    // Fractional part: frac = clamped - (rounded - bias)
+    "sub.rn.ftz.f32x2 l8, l7, l2;\n\t"           // rounded_back = rounded - bias
+    "sub.rn.ftz.f32x2 l9, l1, l8;\n\t"           // frac = clamped - rounded_back
+    // Degree-3 polynomial coefficients (minimax on [0,1))
+    "mov.f32 f7, 0f3D9DF09D;\n\t"                // c3 = 0.077119...
+    "mov.b64 l6, {f7, f7};\n\t"
+    "mov.f32 f6, 0f3E6906A4;\n\t"                // c2 = 0.227564...
+    "mov.b64 l5, {f6, f6};\n\t"
+    "mov.f32 f5, 0f3F31F519;\n\t"                // c1 = 0.695146...
+    "mov.b64 l4, {f5, f5};\n\t"
+    "mov.f32 f4, 0f3F800000;\n\t"                // c0 = 1.0
+    "mov.b64 l3, {f4, f4};\n\t"
+    // Horner evaluation: ((c3*f + c2)*f + c1)*f + c0
+    "fma.rn.ftz.f32x2 l10, l9, l6, l5;\n\t"     // t = frac * c3 + c2
+    "fma.rn.ftz.f32x2 l10, l10, l9, l4;\n\t"    // t = t * frac + c1
+    "fma.rn.ftz.f32x2 l10, l10, l9, l3;\n\t"    // t = t * frac + c0
+    // Combine integer exponent with polynomial mantissa
+    "mov.b64 {r1, r2}, l7;\n\t"                  // unpack floor values
+    "mov.b64 {r3, r4}, l10;\n\t"                 // unpack polynomial results
+    "shl.b32 r5, r1, 23;\n\t"                    // shift floor to IEEE 754 exponent
+    "add.s32 r7, r5, r3;\n\t"                    // result_x = 2^floor * poly
+    "shl.b32 r6, r2, 23;\n\t"
+    "add.s32 r8, r6, r4;\n\t"                    // result_y = 2^floor * poly
+    "mov.b32 %0, r7;\n\t"
+    "mov.b32 %1, r8;\n\t"
+    "}\n"
+    : "=f"(x), "=f"(y)
+    : "f"(x), "f"(y)
+  );
+}
+
+}  // namespace cutlass::fmha::collective

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/fmha_cutlass_sm100.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/fmha_cutlass_sm100.cuh
@@ -1,0 +1,513 @@
+/*
+ * Copyright (c) 2023 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cstdint>
+
+#include "allocator.h"
+#include "fmha_fusion.hpp"
+#include "gpu_trace.h"
+#include "sm100_fmha_fwd_epilogue_tma_warpspecialized.hpp"
+#include "sm100_fmha_fwd_mainloop_tma_warpspecialized.hpp"
+#include "cute/tensor.hpp"
+#include "cutlass/cutlass.h"
+#include "cutlass/kernel_hardware_info.h"
+#include "cutlass/util/command_line.h"
+#include "cutlass/util/device_memory.h"
+#include "cutlass/util/distribution.h"
+#include "cutlass/util/reference/device/tensor_fill.h"
+#include "fmha.hpp"
+#include "fmha_tile_scheduler.hpp"
+#include "sm100_fmha_fwd_kernel_tma_warpspecialized.hpp"
+#include "sm100_fmha_reduction.hpp"
+
+namespace flashinfer {
+
+using namespace cute;
+using namespace cutlass::fmha::collective;
+using namespace cutlass::fmha::kernel;
+using namespace cutlass::fmha::device;
+
+struct PackGQAUnpackParams {
+  float* max_score_direct = nullptr;
+  int total_qo_len_orig = 0;
+  void* o_direct = nullptr;
+  int num_qo_heads_orig = 0;
+  bool tma_direct_o_enabled = false;
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+  GmemBounds gmem_bounds = {};
+#endif
+};
+
+template <typename DTypeIn, typename DTypeOut, typename IdType, class TileShapeQK,
+          class TileShapePV, class ActiveMask,
+          class ThreadShape = Shape<_2, _1, _1>,
+          bool IsSplitKV = false,
+          bool SingleSoftmaxWarpGroup = false,
+          int KVPageSize = -1,
+          cutlass::fmha::collective::SparseAttnMode kSparseAttnMode =
+              cutlass::fmha::collective::SparseAttnMode::Off>
+struct FwdRunner {
+  using Element = DTypeIn;
+  using ElementAccumulatorQK = float;
+  using ElementAccumulatorPV = float;
+  using ElementOut = DTypeOut;
+
+  // Q K D ((H_R, H_KV), B)
+  using ProblemShapeVarlen =
+      cute::tuple<VariableLength, VariableLength, int, cute::tuple<cute::tuple<int, int>, int>,
+                  PerBatchOffset>;
+
+  using StrideQ = cute::tuple<int, _1, cute::tuple<int, int>>;  // Q D (H_G H_R)
+  // Paged: 4-mode flat (entry, dim, head, page). Non-paged: 3-mode with GQA broadcast
+  using StrideK = std::conditional_t<(KVPageSize > 0),
+      cute::tuple<int, _1, int, int>,
+      cute::tuple<int, _1, cute::tuple<_0, int>>>;
+  using StrideV = std::conditional_t<(KVPageSize > 0),
+      cute::tuple<_1, int, int, int>,
+      cute::tuple<_1, int, cute::tuple<_0, int>>>;
+  // NOTE(Zihao): use markus's trick for tma store
+  using StrideO =
+      cute::tuple<int, _1, cute::tuple<cute::tuple<int, int>, int>>;  // Q D (H_G H_R) CUMULATIVE_Q
+  using StrideLSE = cute::tuple<int, cute::tuple<_1, int>>;           // Q (H_G H_R)
+
+  // NumQStages: 2 for Q-split (2,1,1), 1 for K-split (1,2,1)
+  static constexpr int NumQStages = cute::size<0>(ThreadShape{});
+  static constexpr bool bNeedOutput = kSparseAttnMode != cutlass::fmha::collective::SparseAttnMode::OnlyScore;
+  static constexpr int kPackFactor = cutlass::fmha::collective::pack_factor_of<ActiveMask>::value;
+
+  using Mainloop = cutlass::fmha::collective::Sm100FmhaFwdMainloopTmaWarpspecialized<
+      Element, ElementAccumulatorQK, ElementAccumulatorPV, TileShapeQK, TileShapePV, StrideQ,
+      StrideK, StrideV, ActiveMask, ThreadShape, IsSplitKV, KVPageSize, kSparseAttnMode>;
+  using Epilogue = cutlass::fmha::collective::Sm100FmhaFwdEpilogueTmaWarpspecialized<
+      ElementOut, ElementAccumulatorPV, typename Mainloop::TileShapePV, NumQStages, IsSplitKV, bNeedOutput, kPackFactor>;
+  using Operation =
+      cutlass::fmha::device::FMHA<cutlass::fmha::kernel::Sm100FmhaFwdKernelTmaWarpspecialized<
+          ProblemShapeVarlen, Mainloop, Epilogue,
+          cutlass::fmha::kernel::HostPrecomputedTileScheduler,
+          cutlass::fmha::kernel::Sm100FmhaCtxKernelWarpspecializedSchedule<SingleSoftmaxWarpGroup>>>;
+  using LayoutQ = typename Mainloop::LayoutQ;
+  using LayoutK = typename Mainloop::LayoutK;
+  using LayoutV = typename Mainloop::LayoutV;
+  using LayoutO = typename Epilogue::LayoutO;
+  using LayoutLSE = typename Epilogue::LayoutLSE;
+
+  static cudaError_t run(void* workspace_buffer, DTypeIn* q, DTypeIn* k, DTypeIn* v,
+                         IdType* qo_segment_lens, IdType* kv_segment_lens,
+                         IdType* qo_segment_offsets, IdType* kv_segment_offsets,
+                         uint64_t* packed_work_range, uint64_t* packed_work_info,
+                         DTypeOut* o, int mask_mode_code,
+                         float sm_scale, float q_scale, float k_scale, float v_scale,
+                         float o_scale, int num_qo_heads, int num_kv_heads, int head_dim_qk,
+                         int head_dim_vo, int q_stride_n, int q_stride_h, int k_stride_n,
+                         int k_stride_h, int v_stride_n, int v_stride_h, int batch_size,
+                         int total_qo_len, int total_kv_len, int max_qo_len, int* qo_offsets,
+                         cudaStream_t stream,
+                         int num_kv_splits = 1,
+                         int* kv_tile_begin_indices = nullptr,
+                         int* kv_tile_end_indices = nullptr,
+                         int* kv_split_indices = nullptr,
+                         float* ptr_lse_accum = nullptr,
+                         int* kv_indices = nullptr,
+                         int* kv_page_indptr = nullptr,
+                         int total_page_num = 0,
+                         float* maybe_max_score = nullptr,
+                         int max_k_tiles = 0,
+                         int max_score_stride_t = 0,
+                         int max_score_stride_h = 0,
+                         int max_score_stride_k = 0,
+                         int* kv_block_indexes = nullptr,
+                         int kv_block_num = 0,
+                         int pack_factor = 1,
+                         int q_stride_n_original = 0,
+                         int q_stride_h_original = 0,
+                         int h_r_original = 0,
+                         PackGQAUnpackParams pack_gqa = {},
+                         int num_ctas = 0) {
+    cutlass::KernelHardwareInfo hw_info;
+    hw_info.device_id = 0;
+    hw_info.sm_count = (num_ctas > 0)
+        ? num_ctas
+        : cutlass::KernelHardwareInfo::query_device_multiprocessor_count(hw_info.device_id);
+
+    [[maybe_unused]] auto sched_args = typename cutlass::fmha::kernel::HostPrecomputedTileScheduler::Arguments{
+        packed_work_range, packed_work_info};
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+    sched_args.packed_work_info_size = pack_gqa.gmem_bounds.packed_work_info_size;
+#endif
+
+    StrideQ stride_Q;
+    StrideK stride_K;
+    StrideV stride_V;
+    StrideO stride_O;
+    StrideLSE stride_LSE;
+
+    int h_r = num_qo_heads / num_kv_heads;
+    assert(num_qo_heads % num_kv_heads == 0);
+    ProblemShapeVarlen problem_shape = cute::make_tuple(
+        VariableLength{qo_segment_lens, qo_segment_offsets},
+        VariableLength{kv_segment_lens, kv_segment_offsets}, head_dim_qk,
+        cute::make_tuple(cute::make_tuple(h_r, num_kv_heads), batch_size),
+        PerBatchOffset{qo_offsets});
+
+    stride_Q = make_stride(q_stride_n, _1{}, make_stride(q_stride_h, h_r * q_stride_h));
+    stride_O = make_stride(
+        num_qo_heads * head_dim_vo, _1{},
+        make_stride(make_stride(head_dim_vo, h_r * head_dim_vo), num_qo_heads * head_dim_vo));
+    stride_LSE = make_stride(num_qo_heads, make_stride(_1{}, h_r));
+
+    if constexpr (KVPageSize > 0) {
+      int k_stride_page = k_stride_n;
+      int k_stride_head = k_stride_h;
+      int v_stride_page = v_stride_n;
+      int v_stride_head = v_stride_h;
+      stride_K = make_stride(head_dim_qk, _1{}, k_stride_head, k_stride_page);
+      stride_V = make_stride(_1{}, head_dim_vo, v_stride_head, v_stride_page);
+      auto shape_K = make_shape(KVPageSize, head_dim_qk, num_kv_heads, total_page_num);
+      auto shape_V = make_shape(head_dim_vo, KVPageSize, num_kv_heads, total_page_num);
+
+      LayoutK layout_K = make_layout(shape_K, stride_K);
+      LayoutV layout_V = make_layout(shape_V, stride_V);
+      auto shape_Q = make_shape(total_qo_len, head_dim_qk, make_shape(h_r, num_kv_heads));
+      auto shape_O = make_shape(max_qo_len, head_dim_vo,
+                                make_shape(make_shape(h_r, num_kv_heads),
+                                           max_qo_len + total_qo_len * num_kv_splits));
+      LayoutQ layout_Q = make_layout(shape_Q, stride_Q);
+      LayoutO layout_O = make_layout(shape_O, stride_O);
+
+      auto shape_MaxScore = make_shape(total_qo_len, make_shape(h_r, num_kv_heads), max_k_tiles);
+      auto stride_MaxScore = make_stride(
+          max_score_stride_t,
+          make_stride(max_score_stride_h, h_r * max_score_stride_h),
+          max_score_stride_k);
+      typename Epilogue::LayoutMaxScore layout_MaxScore = make_layout(shape_MaxScore, stride_MaxScore);
+
+      typename Epilogue::Arguments epi_args;
+      epi_args.ptr_O = o ? (o - max_qo_len * get<0>(stride_O)) : nullptr;
+      epi_args.layout_O = layout_O;
+      epi_args.max_qo_len = max_qo_len;
+      epi_args.ptr_MaxScore = maybe_max_score;
+      epi_args.layout_MaxScore = layout_MaxScore;
+      epi_args.ptr_MaxScore_direct = pack_gqa.max_score_direct;
+      epi_args.total_qo_len_orig = pack_gqa.total_qo_len_orig;
+      epi_args.max_score_stride_t = max_score_stride_t;
+      epi_args.max_score_stride_h = max_score_stride_h;
+      epi_args.max_score_stride_k = max_score_stride_k;
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+      epi_args.max_score_numel = pack_gqa.gmem_bounds.max_score_numel;
+#endif
+      // Direct-O unpack is incompatible with split-KV: epilogue would overwrite
+      // user O with per-split partials, racing with the reduction kernel.
+      if constexpr (IsSplitKV) {
+        epi_args.ptr_O_direct = nullptr;
+      } else {
+        epi_args.ptr_O_direct = static_cast<ElementOut*>(pack_gqa.o_direct);
+        if (epi_args.ptr_O_direct) {
+          epi_args.ptr_O = nullptr;
+        }
+      }
+      epi_args.num_qo_heads_orig = pack_gqa.num_qo_heads_orig;
+      epi_args.head_dim_vo = head_dim_vo;
+      epi_args.remaining_h_r = h_r;
+      // TMA fused direct-O unpack: enabled only when host eligibility check passes
+      // AND non-split-KV path. max_qo_len_orig is derived in epilogue from
+      // max_qo_len / kPackFactor_ (compile-time constant).
+      epi_args.qo_len_uniform = pack_gqa.tma_direct_o_enabled;
+
+      typename Operation::Arguments arguments;
+      if constexpr (IsSplitKV) {
+        arguments = {
+          {problem_shape,
+           {{q, layout_Q, k, layout_K, v, layout_V, kv_indices, kv_page_indptr, kv_block_indexes, kv_block_num,
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+             pack_gqa.gmem_bounds.kv_page_indptr_size, pack_gqa.gmem_bounds.kv_indices_size, pack_gqa.gmem_bounds.kv_block_indexes_numel,
+#endif
+             pack_factor, q_stride_n_original, q_stride_h_original, h_r_original},
+            sm_scale, q_scale, k_scale, v_scale, o_scale},
+           epi_args,
+           sched_args,
+           hw_info},
+          {static_cast<float>(v_scale),
+           static_cast<float>(v_scale * o_scale),
+           ptr_lse_accum,
+           kv_tile_begin_indices, kv_tile_end_indices, kv_split_indices,
+           total_qo_len, num_qo_heads
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+           , pack_gqa.gmem_bounds.split_kv_size
+#endif
+           }};
+      } else {
+        arguments = {
+          problem_shape,
+          {{q, layout_Q, k, layout_K, v, layout_V, kv_indices, kv_page_indptr, kv_block_indexes, kv_block_num,
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+            pack_gqa.gmem_bounds.kv_page_indptr_size, pack_gqa.gmem_bounds.kv_indices_size, pack_gqa.gmem_bounds.kv_block_indexes_numel,
+#endif
+            pack_factor, q_stride_n_original, q_stride_h_original, h_r_original},
+           sm_scale, q_scale, k_scale, v_scale, o_scale},
+          epi_args,
+          sched_args,
+          hw_info};
+      }
+
+      Operation op;
+      size_t workspace_size = Operation::get_workspace_size(arguments);
+      AlignedAllocator allocator(workspace_buffer, workspace_size);
+      uint8_t* workspace_ptr =
+          allocator.aligned_alloc<uint8_t>(workspace_size, 16, "fmha_cutlass_sm100_workspace");
+
+      cutlass::Status status = op.can_implement(arguments);
+      if (status != cutlass::Status::kSuccess) {
+        cudaError_t err = cudaGetLastError();
+        std::cerr << "This kernel is not supported. Last CUDA error is: "
+                  << cudaGetErrorString(err) << std::endl;
+        return err != cudaSuccess ? err : cudaErrorNotSupported;
+      }
+      status = op.initialize(arguments, workspace_ptr);
+      if (status != cutlass::Status::kSuccess) {
+        cudaError_t err = cudaGetLastError();
+        std::cerr << "Failed to initialize the CUTLASS kernel. Last CUDA error is: "
+                  << cudaGetErrorString(err) << std::endl;
+        return err != cudaSuccess ? err : cudaErrorLaunchFailure;
+      }
+      GPUTraceParam _gt_param;
+      gpu_trace::setup_from_env(_gt_param, stream);
+      status = op.run(stream);
+      if (status != cutlass::Status::kSuccess) {
+        cudaError_t err = cudaGetLastError();
+        std::cerr << "Failed to launch the CUTLASS kernel. Last CUDA error is: "
+                  << cudaGetErrorString(err) << std::endl;
+        gpu_trace::teardown(_gt_param, stream);
+        return err != cudaSuccess ? err : cudaErrorLaunchFailure;
+      }
+      gpu_trace::teardown(_gt_param, stream);
+      return cudaSuccess;
+    } else {
+      stride_K = make_stride(k_stride_n, _1{}, make_stride(_0{}, k_stride_h));
+      stride_V = make_stride(_1{}, v_stride_n, make_stride(_0{}, v_stride_h));
+
+      auto shape_Q = make_shape(total_qo_len, head_dim_qk, make_shape(h_r, num_kv_heads));
+      auto shape_O = make_shape(max_qo_len, head_dim_vo,
+                                make_shape(make_shape(h_r, num_kv_heads),
+                                           max_qo_len + total_qo_len * num_kv_splits));
+      auto shape_K = make_shape(total_kv_len, head_dim_qk, make_shape(h_r, num_kv_heads));
+      auto shape_V = make_shape(head_dim_vo, total_kv_len, make_shape(h_r, num_kv_heads));
+
+      LayoutQ layout_Q = make_layout(shape_Q, stride_Q);
+      LayoutK layout_K = make_layout(shape_K, stride_K);
+      LayoutV layout_V = make_layout(shape_V, stride_V);
+      LayoutO layout_O = make_layout(shape_O, stride_O);
+
+      auto shape_MaxScore = make_shape(total_qo_len, make_shape(h_r, num_kv_heads), max_k_tiles);
+      auto stride_MaxScore = make_stride(
+          max_score_stride_t,
+          make_stride(max_score_stride_h, h_r * max_score_stride_h),
+          max_score_stride_k);
+      typename Epilogue::LayoutMaxScore layout_MaxScore = make_layout(shape_MaxScore, stride_MaxScore);
+
+      typename Epilogue::Arguments epi_args;
+      epi_args.ptr_O = o ? (o - max_qo_len * get<0>(stride_O)) : nullptr;
+      epi_args.layout_O = layout_O;
+      epi_args.max_qo_len = max_qo_len;
+      epi_args.ptr_MaxScore = maybe_max_score;
+      epi_args.layout_MaxScore = layout_MaxScore;
+      epi_args.ptr_MaxScore_direct = pack_gqa.max_score_direct;
+      epi_args.total_qo_len_orig = pack_gqa.total_qo_len_orig;
+      epi_args.max_score_stride_t = max_score_stride_t;
+      epi_args.max_score_stride_h = max_score_stride_h;
+      epi_args.max_score_stride_k = max_score_stride_k;
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+      epi_args.max_score_numel = pack_gqa.gmem_bounds.max_score_numel;
+#endif
+      // Direct-O unpack is incompatible with split-KV: epilogue would overwrite
+      // user O with per-split partials, racing with the reduction kernel.
+      if constexpr (IsSplitKV) {
+        epi_args.ptr_O_direct = nullptr;
+      } else {
+        epi_args.ptr_O_direct = static_cast<ElementOut*>(pack_gqa.o_direct);
+        if (epi_args.ptr_O_direct) {
+          epi_args.ptr_O = nullptr;
+        }
+      }
+      epi_args.num_qo_heads_orig = pack_gqa.num_qo_heads_orig;
+      epi_args.head_dim_vo = head_dim_vo;
+      epi_args.remaining_h_r = h_r;
+      // TMA fused direct-O unpack: enabled only when host eligibility check passes
+      // AND non-split-KV path. max_qo_len_orig is derived in epilogue from
+      // max_qo_len / kPackFactor_ (compile-time constant).
+      epi_args.qo_len_uniform = pack_gqa.tma_direct_o_enabled;
+
+      typename Operation::Arguments arguments;
+      if constexpr (IsSplitKV) {
+        arguments = {
+          {problem_shape,
+           {{q, layout_Q, k, layout_K, v, layout_V, nullptr, nullptr, nullptr, 0,
+             pack_factor, q_stride_n_original, q_stride_h_original, h_r_original},
+            sm_scale, q_scale, k_scale, v_scale, o_scale},
+           epi_args,
+           sched_args,
+           hw_info},
+          {static_cast<float>(v_scale),
+           static_cast<float>(v_scale * o_scale),
+           ptr_lse_accum,
+           kv_tile_begin_indices, kv_tile_end_indices, kv_split_indices,
+           total_qo_len, num_qo_heads
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+           , pack_gqa.gmem_bounds.split_kv_size
+#endif
+           }};
+      } else {
+        arguments = {
+          problem_shape,
+          {{q, layout_Q, k, layout_K, v, layout_V, nullptr, nullptr, nullptr, 0,
+            pack_factor, q_stride_n_original, q_stride_h_original, h_r_original},
+           sm_scale, q_scale, k_scale, v_scale, o_scale},
+          epi_args,
+          sched_args,
+          hw_info};
+      }
+
+      Operation op;
+      size_t workspace_size = Operation::get_workspace_size(arguments);
+      AlignedAllocator allocator(workspace_buffer, workspace_size);
+      uint8_t* workspace_ptr =
+          allocator.aligned_alloc<uint8_t>(workspace_size, 16, "fmha_cutlass_sm100_workspace");
+
+      cutlass::Status status = op.can_implement(arguments);
+      if (status != cutlass::Status::kSuccess) {
+        cudaError_t err = cudaGetLastError();
+        std::cerr << "This kernel is not supported. Last CUDA error is: "
+                  << cudaGetErrorString(err) << std::endl;
+        return err != cudaSuccess ? err : cudaErrorNotSupported;
+      }
+      status = op.initialize(arguments, workspace_ptr);
+      if (status != cutlass::Status::kSuccess) {
+        cudaError_t err = cudaGetLastError();
+        std::cerr << "Failed to initialize the CUTLASS kernel. Last CUDA error is: "
+                  << cudaGetErrorString(err) << std::endl;
+        return err != cudaSuccess ? err : cudaErrorLaunchFailure;
+      }
+      GPUTraceParam _gt_param;
+      gpu_trace::setup_from_env(_gt_param, stream);
+      status = op.run(stream);
+      if (status != cutlass::Status::kSuccess) {
+        cudaError_t err = cudaGetLastError();
+        std::cerr << "Failed to launch the CUTLASS kernel. Last CUDA error is: "
+                  << cudaGetErrorString(err) << std::endl;
+        gpu_trace::teardown(_gt_param, stream);
+        return err != cudaSuccess ? err : cudaErrorLaunchFailure;
+      }
+      gpu_trace::teardown(_gt_param, stream);
+      return cudaSuccess;
+    }
+  }
+};
+
+template <typename DTypeIn, typename DTypeOut, typename IdType, class TileShapeQK,
+          class TileShapePV, class ActiveMask,
+          class ThreadShape = Shape<_2, _1, _1>,
+          bool IsSplitKV = false,
+          bool SingleSoftmaxWarpGroup = false,
+          int KVPageSize = -1,
+          cutlass::fmha::collective::SparseAttnMode kSparseAttnMode =
+              cutlass::fmha::collective::SparseAttnMode::Off>
+cudaError_t run_fmha_fwd(void* workspace_buffer, DTypeIn* q, DTypeIn* k, DTypeIn* v,
+                         IdType* qo_segment_lens, IdType* kv_segment_lens,
+                         IdType* qo_segment_offsets, IdType* kv_segment_offsets,
+                         uint64_t* packed_work_range, uint64_t* packed_work_info,
+                         DTypeOut* o, int mask_mode_code,
+                         double sm_scale, double q_scale, double k_scale, double v_scale,
+                         double o_scale, int num_qo_heads, int num_kv_heads, int head_dim_qk,
+                         int head_dim_vo, int q_stride_n, int q_stride_h, int k_stride_n,
+                         int k_stride_h, int v_stride_n, int v_stride_h, int batch_size,
+                         int total_qo_len, int total_kv_len, int max_qo_len, int* qo_offsets,
+                         cudaStream_t stream,
+                         int num_kv_splits = 1,
+                         int* kv_tile_begin_indices = nullptr,
+                         int* kv_tile_end_indices = nullptr,
+                         int* kv_split_indices = nullptr,
+                         float* ptr_lse_accum = nullptr,
+                         int* kv_indices = nullptr,
+                         int* kv_page_indptr = nullptr,
+                         int total_page_num = 0,
+                         float* maybe_max_score = nullptr,
+                         int max_k_tiles = 0,
+                         int max_score_stride_t = 0,
+                         int max_score_stride_h = 0,
+                         int max_score_stride_k = 0,
+                         int* kv_block_indexes = nullptr,
+                         int kv_block_num = 0,
+                         int pack_factor = 1,
+                         int q_stride_n_original = 0,
+                         int q_stride_h_original = 0,
+                         int h_r_original = 0,
+                         PackGQAUnpackParams pack_gqa = {},
+                         int num_ctas = 0) {
+  return FwdRunner<DTypeIn, DTypeOut, IdType, TileShapeQK, TileShapePV, ActiveMask,
+                   ThreadShape, IsSplitKV, SingleSoftmaxWarpGroup, KVPageSize, kSparseAttnMode>::run(
+      workspace_buffer, q, k, v, qo_segment_lens, kv_segment_lens,
+      qo_segment_offsets, kv_segment_offsets, packed_work_range,
+      packed_work_info, o, mask_mode_code, sm_scale,
+      q_scale, k_scale, v_scale, o_scale, num_qo_heads, num_kv_heads, head_dim_qk, head_dim_vo,
+      q_stride_n, q_stride_h, k_stride_n, k_stride_h, v_stride_n, v_stride_h, batch_size,
+      total_qo_len, total_kv_len, max_qo_len, qo_offsets, stream,
+      num_kv_splits, kv_tile_begin_indices, kv_tile_end_indices, kv_split_indices,
+      ptr_lse_accum,
+      kv_indices, kv_page_indptr, total_page_num,
+      maybe_max_score, max_k_tiles,
+      max_score_stride_t, max_score_stride_h, max_score_stride_k,
+      kv_block_indexes, kv_block_num,
+      pack_factor, q_stride_n_original, q_stride_h_original, h_r_original,
+      pack_gqa, num_ctas);
+}
+
+};  // namespace flashinfer
+
+namespace flashinfer {
+
+// Launch the split-KV reduction kernel
+template <typename ElementPartial, typename ElementOut>
+__global__ void fmha_reduction_kernel(
+    typename Sm100FmhaReductionKernel<ElementPartial, ElementOut>::Params params) {
+  Sm100FmhaReductionKernel<ElementPartial, ElementOut> kernel;
+  kernel(params, nullptr);
+}
+
+template <typename ElementPartial, typename ElementOut>
+cudaError_t launch_fmha_reduction(
+    const ElementPartial* ptr_O_partial, ElementOut* ptr_O,
+    const float* ptr_lse,
+    const int* num_kv_splits_per_row,
+    float scale_softmax_log2, float inv_scale_o,
+    int num_kv_splits, int total_qo_len, int num_qo_heads, int head_dim_vo,
+    int stride_o_n, int stride_o_h, int stride_partial_n, int stride_partial_h,
+    ElementOut* ptr_O_direct, int num_qo_heads_orig,
+    int num_kv_heads, int pack_factor,
+    cudaStream_t stream) {
+  if (total_qo_len <= 0) return cudaSuccess;
+  using ReductionKernel = Sm100FmhaReductionKernel<ElementPartial, ElementOut>;
+  typename ReductionKernel::Params params{
+      ptr_O_partial, ptr_O, ptr_lse,
+      num_kv_splits_per_row,
+      scale_softmax_log2, inv_scale_o,
+      num_kv_splits, total_qo_len, num_qo_heads, head_dim_vo,
+      stride_o_n, stride_o_h, stride_partial_n, stride_partial_h,
+      ptr_O_direct, num_qo_heads_orig, num_kv_heads, pack_factor};
+  dim3 grid = ReductionKernel::get_grid_shape(params);
+  dim3 block = ReductionKernel::get_block_shape();
+  fmha_reduction_kernel<ElementPartial, ElementOut><<<grid, block, 0, stream>>>(params);
+  return cudaGetLastError();
+}
+
+}  // namespace flashinfer

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/fmha_fusion.hpp
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/fmha_fusion.hpp
@@ -1,0 +1,407 @@
+/***************************************************************************************************
+ * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#pragma once
+
+#include "cute/tensor.hpp"
+#include "cutlass/cutlass.h"
+
+namespace cutlass::fmha::collective {
+
+using namespace cute;
+
+enum class SparseAttnMode {
+  Off,
+  OnlyScore,
+  Full,
+  Sparse
+};
+
+struct NoMask {
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                    ProblemSize const& problem_size) {
+    return ceil_div(get<1>(problem_size), get<1>(tile_shape));
+  }
+
+  template <class ProblemSize>
+  CUTLASS_DEVICE static int sparse_causal_bound(int q_s, ProblemSize const&) {
+    return INT_MAX / 4;
+  }
+
+  // Per-warp: trip count doesn't depend on Q range for NoMask.
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                    ProblemSize const& problem_size,
+                                    int sub_q_offset, int sub_q_size) {
+    return get_trip_count(blk_coord, tile_shape, problem_size);
+  }
+
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_masked_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                           ProblemSize const& problem_size) {
+    return 0;
+  }
+
+  // Per-warp: sub_q_offset/sub_q_size describe the Q sub-range within the tile.
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_masked_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                           ProblemSize const& problem_size,
+                                           int sub_q_offset, int sub_q_size) {
+    return 0;
+  }
+
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_unmasked_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                             ProblemSize const& problem_size) {
+    return get_trip_count(blk_coord, tile_shape, problem_size);
+  }
+
+  template <class AccQK, class IndexQK, class ProblemSize>
+  CUTLASS_DEVICE void apply_mask(AccQK& acc_qk, IndexQK const& index_qk,
+                                 ProblemSize const& problem_size) {
+    return;
+  }
+};
+
+struct ResidualMask : NoMask {
+  using Base = NoMask;
+
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_masked_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                           ProblemSize const& problem_size) {
+    if (get<1>(problem_size) % get<1>(tile_shape) != 0) {
+      return 1;
+    }
+    return 0;
+  }
+
+  // Per-warp: residual mask doesn't depend on Q range.
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_masked_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                           ProblemSize const& problem_size,
+                                           int sub_q_offset, int sub_q_size) {
+    return get_masked_trip_count(blk_coord, tile_shape, problem_size);
+  }
+
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_unmasked_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                             ProblemSize const& problem_size) {
+    // if the sequence length does not divide the tile size evenly
+    if (get<1>(problem_size) % get<1>(tile_shape) != 0) {
+      return get_trip_count(blk_coord, tile_shape, problem_size) - 1;
+    }
+    return get_trip_count(blk_coord, tile_shape, problem_size);
+  }
+
+  template <class AccQK, class IndexQK, class ProblemSize>
+  CUTLASS_DEVICE void apply_mask(AccQK& acc_qk, IndexQK const& index_qk,
+                                 ProblemSize const& problem_size) {
+    // This is useful is seqlen_k % kBlockN != 0 since it masks
+    // the remaining elements out from softmax.
+    // d % kHeadDim != 0 or seqlen_q % kBlockM do not suffer from similar
+    // issues as they are transparently taken care of by TMA and the
+    // epilogue, if it is instantiated with predication support.
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < size(acc_qk); i++) {
+      auto pos = index_qk(i);
+      if (get<1>(pos) >= get<1>(problem_size)) {
+        acc_qk(i) = -INFINITY;
+      }
+    }
+  }
+};
+
+struct CausalMask : NoMask {
+  using Base = NoMask;
+
+  // Read qo_offset from 5th element of problem_size if available,
+  // otherwise fall back to kv_len - qo_len (Q aligned to end of KV).
+  template <class ProblemSize>
+  CUTLASS_DEVICE static int get_qo_offset(ProblemSize const& problem_size) {
+    if constexpr (cute::tuple_size_v<ProblemSize> > 4) {
+      int offset = int(get<4>(problem_size));
+      if (offset >= 0) return offset;
+    }
+    return int(get<1>(problem_size)) - int(get<0>(problem_size));
+  }
+
+  template <class ProblemSize>
+  CUTLASS_DEVICE static int sparse_causal_bound(int q_s, ProblemSize const& ps) {
+    return q_s + get_qo_offset(ps);
+  }
+
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                    ProblemSize const& problem_size) {
+    int offset_q = get_qo_offset(problem_size);
+    int max_blocks_k = Base::get_trip_count(blk_coord, tile_shape, problem_size);
+    int max_blocks_q =
+        ceil_div((get<0>(blk_coord) + 1) * get<0>(tile_shape) + offset_q, get<1>(tile_shape));
+    return std::min(max_blocks_k, max_blocks_q);
+  }
+
+  // Per-warp: trip count based on the last Q row of the sub-tile.
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                    ProblemSize const& problem_size,
+                                    int sub_q_offset, int sub_q_size) {
+    int offset_q = get_qo_offset(problem_size);
+    int n = int(get<1>(tile_shape));
+    int max_blocks_k = Base::get_trip_count(blk_coord, tile_shape, problem_size);
+    int q_end = int(get<0>(blk_coord)) * int(get<0>(tile_shape)) + sub_q_offset + sub_q_size;
+    return std::min(max_blocks_k, ceil_div(q_end + offset_q, n));
+  }
+
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_masked_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                           ProblemSize const& problem_size) {
+    int offset_q = get_qo_offset(problem_size);
+    int n = int(get<1>(tile_shape));
+    int offset_tile_q = ((offset_q % n) + n) % n;
+    return min(get_trip_count(blk_coord, tile_shape, problem_size),
+               int(ceil_div(int(get<0>(tile_shape)) + offset_tile_q, n)));
+  }
+
+  // Per-warp refinement: each warp handles sub_q_size Q rows starting at sub_q_offset
+  // within the tile, so tiles fully below this warp's causal diagonal are unmasked.
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_masked_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                           ProblemSize const& problem_size,
+                                           int sub_q_offset, int sub_q_size) {
+    int offset_q = get_qo_offset(problem_size);
+    int n = int(get<1>(tile_shape));
+    int total_trip = get_trip_count(blk_coord, tile_shape, problem_size);
+
+    // Per-warp trip count based on the last Q row of this sub-tile
+    int q_end = int(get<0>(blk_coord)) * int(get<0>(tile_shape)) + sub_q_offset + sub_q_size;
+    int max_blocks_k = Base::get_trip_count(blk_coord, tile_shape, problem_size);
+    int sub_trip = min(max_blocks_k, ceil_div(q_end + offset_q, n));
+
+    // Per-warp masked count
+    int q_start = q_end - sub_q_size;
+    int sub_offset_tile_q = (((q_start + offset_q) % n) + n) % n;
+    int sub_masked = min(sub_trip, ceil_div(sub_q_size + sub_offset_tile_q, n));
+
+    return total_trip - (sub_trip - sub_masked);
+  }
+
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_unmasked_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                             ProblemSize const& problem_size) {
+    return get_trip_count(blk_coord, tile_shape, problem_size) -
+           get_masked_trip_count(blk_coord, tile_shape, problem_size);
+  }
+
+  template <class AccQK, class IndexQK, class ProblemSize>
+  CUTLASS_DEVICE void apply_mask(AccQK& acc_qk, IndexQK const& index_qk,
+                                 ProblemSize const& problem_size) {
+    int offset_q = get_qo_offset(problem_size);
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < size(acc_qk); i++) {
+      auto pos = index_qk(i);
+      if ((get<0>(pos) + offset_q < get<1>(pos)) || (get<1>(pos) >= get<1>(problem_size))) {
+        acc_qk(i) = -INFINITY;
+      }
+    }
+  }
+};
+
+template <class M> struct pack_factor_of { static constexpr int value = 1; };
+
+template <int PackFactor>
+struct PackedCausalMask : NoMask {
+  using Base = NoMask;
+
+  template <class ProblemSize>
+  CUTLASS_DEVICE static int get_qo_offset(ProblemSize const& problem_size) {
+    return CausalMask::get_qo_offset(problem_size);
+  }
+
+  template <class ProblemSize>
+  CUTLASS_DEVICE static int sparse_causal_bound(int q_s, ProblemSize const& ps) {
+    return logical_q(q_s) + get_qo_offset(ps);
+  }  CUTLASS_DEVICE static int logical_q(int packed_q) {
+    return packed_q / PackFactor;
+  }
+
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                    ProblemSize const& problem_size) {
+    int offset_q = get_qo_offset(problem_size);
+    int max_blocks_k = Base::get_trip_count(blk_coord, tile_shape, problem_size);
+    int packed_q_end = (int(get<0>(blk_coord)) + 1) * int(get<0>(tile_shape));
+    int q_end = logical_q(packed_q_end - 1) + 1;
+    return std::min(max_blocks_k, ceil_div(q_end + offset_q, int(get<1>(tile_shape))));
+  }
+
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                    ProblemSize const& problem_size,
+                                    int sub_q_offset, int sub_q_size) {
+    int offset_q = get_qo_offset(problem_size);
+    int n = int(get<1>(tile_shape));
+    int max_blocks_k = Base::get_trip_count(blk_coord, tile_shape, problem_size);
+    int packed_q_end = int(get<0>(blk_coord)) * int(get<0>(tile_shape)) + sub_q_offset + sub_q_size;
+    int q_end = logical_q(packed_q_end - 1) + 1;
+    return std::min(max_blocks_k, ceil_div(q_end + offset_q, n));
+  }
+
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_masked_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                           ProblemSize const& problem_size) {
+    int offset_q = get_qo_offset(problem_size);
+    int n = int(get<1>(tile_shape));
+    int packed_tile_start = int(get<0>(blk_coord)) * int(get<0>(tile_shape));
+    int q_start = logical_q(packed_tile_start);
+    int offset_tile_q = (((q_start + offset_q) % n) + n) % n;
+    int packed_q_end = packed_tile_start + int(get<0>(tile_shape));
+    int q_end = logical_q(packed_q_end - 1) + 1;
+    int logical_tile_q = q_end - q_start;
+    return min(get_trip_count(blk_coord, tile_shape, problem_size),
+               int(ceil_div(logical_tile_q + offset_tile_q, n)));
+  }
+
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_masked_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                           ProblemSize const& problem_size,
+                                           int sub_q_offset, int sub_q_size) {
+    int offset_q = get_qo_offset(problem_size);
+    int n = int(get<1>(tile_shape));
+    int total_trip = get_trip_count(blk_coord, tile_shape, problem_size);
+
+    int packed_q_end = int(get<0>(blk_coord)) * int(get<0>(tile_shape)) + sub_q_offset + sub_q_size;
+    int q_end = logical_q(packed_q_end - 1) + 1;
+    int max_blocks_k = Base::get_trip_count(blk_coord, tile_shape, problem_size);
+    int sub_trip = min(max_blocks_k, ceil_div(q_end + offset_q, n));
+
+    int packed_q_start = packed_q_end - sub_q_size;
+    int q_start = logical_q(packed_q_start);
+    int sub_offset_tile_q = (((q_start + offset_q) % n) + n) % n;
+    int logical_sub_q = q_end - q_start;
+    int sub_masked = min(sub_trip, ceil_div(logical_sub_q + sub_offset_tile_q, n));
+
+    return total_trip - (sub_trip - sub_masked);
+  }
+
+  template <class BlkCoord, class TileShape, class ProblemSize>
+  CUTLASS_DEVICE int get_unmasked_trip_count(BlkCoord const& blk_coord, TileShape const& tile_shape,
+                                             ProblemSize const& problem_size) {
+    return get_trip_count(blk_coord, tile_shape, problem_size) -
+           get_masked_trip_count(blk_coord, tile_shape, problem_size);
+  }
+
+  template <class AccQK, class IndexQK, class ProblemSize>
+  CUTLASS_DEVICE void apply_mask(AccQK& acc_qk, IndexQK const& index_qk,
+                                 ProblemSize const& problem_size) {
+    int offset_q = get_qo_offset(problem_size);
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < size(acc_qk); i++) {
+      auto pos = index_qk(i);
+      int q_logical = logical_q(int(get<0>(pos)));
+      if ((q_logical + offset_q < int(get<1>(pos))) || (int(get<1>(pos)) >= int(get<1>(problem_size)))) {
+        acc_qk(i) = -INFINITY;
+      }
+    }
+  }
+};
+
+template <int PF>
+struct pack_factor_of<PackedCausalMask<PF>> { static constexpr int value = PF; };
+
+struct VariableLength {
+  int* segment_lens = nullptr;
+  int* segment_offsets = nullptr;
+};
+
+// Per-batch offset for causal mask. Resolves to offsets[batch_idx] per batch,
+// or -1 (sentinel for default kv_len - qo_len) if offsets is nullptr.
+struct PerBatchOffset {
+  int* offsets = nullptr;
+};
+
+template <class T>
+struct is_variable_length : std::false_type {};
+template <>
+struct is_variable_length<VariableLength> : std::true_type {};
+template <class T>
+constexpr bool is_variable_length_v = is_variable_length<T>::value;
+
+template <class T>
+struct is_per_batch_offset : std::false_type {};
+template <>
+struct is_per_batch_offset<PerBatchOffset> : std::true_type {};
+template <class T>
+constexpr bool is_per_batch_offset_v = is_per_batch_offset<T>::value;
+
+template <class Shape, class Idx>
+CUTE_HOST_DEVICE constexpr auto apply_variable_length(Shape const& shape, Idx const& idx) {
+  return transform_leaf(shape, [&](auto const& s) {
+    if constexpr (is_variable_length_v<remove_cvref_t<decltype(s)>>) {
+      return s.segment_lens[idx];
+    } else if constexpr (is_per_batch_offset_v<remove_cvref_t<decltype(s)>>) {
+      return s.offsets ? s.offsets[idx] : -1;
+    } else {
+      return s;
+    }
+  });
+}
+
+template <class Shape, class Coord, class Idx>
+CUTE_HOST_DEVICE constexpr auto apply_variable_length(Shape const& shape, Coord const& coord,
+                                                      Idx const& idx) {
+  auto new_shape = apply_variable_length(shape, idx);
+  auto new_coord = transform_leaf(shape, coord, [&](auto const& s, auto const& c) {
+    if constexpr (is_variable_length_v<remove_cvref_t<decltype(s)>>) {
+      return cute::make_tuple(c, s.segment_offsets[idx]);
+    } else {
+      return c;
+    }
+  });
+  return cute::make_tuple(new_shape, new_coord);
+}
+
+}  // namespace cutlass::fmha::collective
+
+namespace cute {
+
+template <>
+struct is_integral<cutlass::fmha::collective::VariableLength> : true_type {};
+
+template <>
+struct is_integral<cutlass::fmha::collective::PerBatchOffset> : true_type {};
+
+CUTE_HOST_DEVICE
+void print(cutlass::fmha::collective::VariableLength a) { printf("Varlen<lens=%p,offs=%p>", a.segment_lens, a.segment_offsets); }
+
+CUTE_HOST_DEVICE
+void print(cutlass::fmha::collective::PerBatchOffset a) { printf("PerBatchOffset<%p>", a.offsets); }
+
+}  // namespace cute

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/fmha_options.hpp
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/fmha_options.hpp
@@ -1,0 +1,78 @@
+/***************************************************************************************************
+ * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+#pragma once
+
+#include "cutlass/cutlass.h"
+
+namespace cutlass::fmha::kernel {
+
+template <auto kTag, typename Default, typename... Options>
+struct find_option;
+
+template <auto kTag, typename Default>
+struct find_option<kTag, Default> {
+  using option_value = Default;
+};
+
+template <auto kTag, typename Default, typename Option, typename... Options>
+struct find_option<kTag, Default, Option, Options...>
+    : std::conditional_t<Option::tag == kTag, Option, find_option<kTag, Default, Options...> > {};
+
+template <auto kTag, typename Default, typename... Options>
+using find_option_t = typename find_option<kTag, Default, Options...>::option_value;
+
+enum class Tag {
+  kIsPersistent,
+  kNumMmaWarpGroups,
+  kLoadsQSeparately,
+
+  kIsMainloopLocked,
+  kIsEpilogueLocked,
+
+  kStagesQ,
+  kStagesKV,
+
+  kEpilogueKind,
+
+  kBlocksPerSM,
+  kClusterM,
+
+  kAccQK
+};
+
+template <auto kTag, class Value>
+struct Option {
+  static constexpr auto tag = kTag;
+  using option_value = Value;
+};
+
+}  // namespace cutlass::fmha::kernel

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/fmha_tile_scheduler.hpp
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/fmha_tile_scheduler.hpp
@@ -1,0 +1,152 @@
+/***************************************************************************************************
+ * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+#pragma once
+
+#include <climits>
+
+#include "cutlass/cutlass.h"
+#include "cutlass/fast_math.h"
+#include "cutlass/kernel_hardware_info.h"
+#include "gmem_bounds_check.h"
+
+namespace cutlass::fmha::kernel {
+
+struct HostPrecomputedTileScheduler {
+  // Packed layout (uint64_t):
+  //   packed_work_info[i]:  [63:32] qo_tile_idx | [31:16] qo_head_idx | [15:0] batch_idx
+  //   packed_work_range[i]: [63:32] work_ptr_end | [31:0] work_ptr
+  // Widened from uint32_t so per-token sparse decode (batch_size = total_q, up to 65536)
+  // and large prefill (qo_tile_idx can exceed 256 when q ≥ 64K) both fit without wrap.
+  // See bug_sparse_decode_qo256.md.
+  struct Arguments {
+    uint64_t* packed_work_range;
+    uint64_t* packed_work_info;
+    int* kv_tile_begin_indices = nullptr;
+    int* kv_tile_end_indices = nullptr;
+    int* kv_split_indices = nullptr;
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+    int packed_work_info_size = 0;
+#endif
+  };
+
+  struct Params {
+    uint64_t* packed_work_range;
+    uint64_t* packed_work_info;
+    int num_sm;
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+    int packed_work_range_size;
+    int packed_work_info_size;
+#endif
+  };
+
+  Params params;
+  int work_ptr;
+  int work_ptr_end;
+  int qo_tile_idx;
+  int batch_idx;
+  int qo_head_idx;
+  bool is_valid_;
+
+  CUTLASS_DEVICE
+  void load_work_item() {
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+    uint64_t packed = gmem_load_checked(params.packed_work_info, work_ptr,
+                                         params.packed_work_info_size, "packed_work_info");
+#else
+    uint64_t packed = params.packed_work_info[work_ptr];
+#endif
+    qo_tile_idx = static_cast<int>(packed >> 32);
+    qo_head_idx = static_cast<int>((packed >> 16) & 0xFFFF);
+    batch_idx   = static_cast<int>(packed & 0xFFFF);
+  }
+
+  CUTLASS_DEVICE
+  HostPrecomputedTileScheduler(Params const& params) {
+    this->params = params;
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+    uint64_t range = gmem_load_checked(params.packed_work_range, (int)blockIdx.x,
+                                        params.packed_work_range_size, "packed_work_range");
+#else
+    uint64_t range = params.packed_work_range[blockIdx.x];
+#endif
+    work_ptr     = static_cast<int>(range & 0xFFFFFFFF);
+    work_ptr_end = static_cast<int>(range >> 32);
+    if (work_ptr < work_ptr_end) {
+      is_valid_ = true;
+      load_work_item();
+    } else {
+      qo_tile_idx = 0;
+      batch_idx = 0;
+      qo_head_idx = 0;
+      is_valid_ = false;
+    }
+  }
+
+  static Params to_underlying_arguments(Arguments const& args, KernelHardwareInfo hw_info) {
+    Params p{};
+    p.packed_work_range = args.packed_work_range;
+    p.packed_work_info = args.packed_work_info;
+    p.num_sm = hw_info.sm_count;
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+    p.packed_work_range_size = hw_info.sm_count;
+    p.packed_work_info_size = args.packed_work_info_size;
+#endif
+    return p;
+  }
+
+  static dim3 get_grid_shape(Params const& params) {
+    dim3 grid(params.num_sm);
+    return grid;
+  }
+
+  CUTLASS_DEVICE
+  bool is_valid() const { return is_valid_; }
+
+  CUTLASS_DEVICE
+  auto get_block_coord() {
+    return make_coord(qo_tile_idx, _0{}, make_coord(qo_head_idx, batch_idx));
+  }
+
+  CUTLASS_DEVICE int get_work_ptr() const { return work_ptr; }
+
+  CUTLASS_DEVICE
+  HostPrecomputedTileScheduler& operator++() {
+    work_ptr++;
+    is_valid_ = work_ptr < work_ptr_end;
+    if (is_valid_) {
+      load_work_item();
+    }
+    return *this;
+  }
+};
+
+}  // namespace cutlass::fmha::kernel

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/gather_tensor.hpp
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/gather_tensor.hpp
@@ -1,0 +1,190 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#pragma once
+
+#include "cute/layout.hpp"
+#include "cute/tensor.hpp"
+#include "cute/util/print.hpp"
+
+namespace example {
+
+using namespace cute;
+
+// Empty type used to disable gather/scatter for a GEMM argument
+struct NoGather {
+  template <class... Ts>
+  NoGather(Ts...){};
+};
+
+/// Function object that applies an index to its argument
+template <class Index>
+struct IndexedGather {
+  CUTE_HOST_DEVICE constexpr IndexedGather(Index const* indices = {}) : indices_(indices) {}
+
+  template <typename I>
+  CUTE_HOST_DEVICE constexpr Index operator()(I i) const {
+    return indices_[i];
+  }
+
+  CUTE_HOST_DEVICE friend void print(IndexedGather const& s) { cute::print("Indexed"); }
+
+  Index const* indices_;
+};
+
+/// Function object that applies a stride to its argument
+/// Example: StridedFunc<int,_2> gathers every other row/column
+template <class Stride>
+struct StridedGather {
+  CUTE_HOST_DEVICE constexpr StridedGather(Stride stride = {}) : stride_(stride) {}
+
+  template <class I>
+  CUTE_HOST_DEVICE constexpr auto operator()(I i) const {
+    return i * stride_;
+  }
+
+  CUTE_HOST_DEVICE friend void print(StridedGather const& s) {
+    cute::print("Strided{");
+    print(s.stride_);
+    cute::print("}");
+  }
+
+  Stride stride_;
+};
+
+/// Custom stride object that applies a function followed by a stride
+template <class Func, class Stride>
+struct CustomStride {
+  CUTE_HOST_DEVICE constexpr CustomStride(Func const& func, Stride const& stride)
+      : func_(func), stride_(stride) {}
+
+  template <class I>
+  CUTE_HOST_DEVICE constexpr friend auto operator*(I i, CustomStride const& s) {
+    return s.func_(i) * s.stride_;
+  }
+
+  template <class I>
+  CUTE_HOST_DEVICE constexpr friend auto operator*(CustomStride const& s, I i) {
+    return s.func_(i) * s.stride_;
+  }
+
+  CUTE_HOST_DEVICE friend void print(CustomStride const& s) {
+    cute::print("Custom{");
+    print(s.func_);
+    cute::print(",");
+    print(s.stride_);
+    cute::print("}");
+  }
+
+  template <class Div>
+  CUTE_HOST_DEVICE constexpr friend auto safe_div(CustomStride const& s, Div const& div) {
+    return CustomStride<Func, decltype(safe_div(s.stride_, div))>(s.func_,
+                                                                  safe_div(s.stride_, div));
+  }
+
+  // Circumvent the requirement on make_layout that shape and stride are integral
+  template <class Shape>
+  CUTE_HOST_DEVICE constexpr friend auto make_layout(Shape const& shape,
+                                                     CustomStride const& stride) {
+    return Layout<Shape, CustomStride>(shape, stride);
+  }
+
+  Func func_;
+  Stride stride_;
+};
+
+template <class Stride, class Func>
+CUTLASS_HOST_DEVICE auto make_custom_stride_layout(Stride const& stride, Func&& func) {
+  // Use a dummy shape and replace the first non-unit stride with a custom gather stride
+  auto idx = find_if(stride, [](auto x) { return not is_constant<1, decltype(x)>{}; });
+  constexpr int I = decltype(idx)::value;
+  return make_layout(repeat_like(stride, _1{}),
+                     replace<I>(stride, CustomStride{static_cast<Func&&>(func), get<I>(stride)}));
+}
+
+/// Helper function to optionally create a gather tensor
+template <class Iterator, class Shape, class Stride, class Func>
+CUTLASS_HOST_DEVICE auto make_gather_tensor(Iterator iter, Shape const& shape, Stride const& stride,
+                                            Func&& func) {
+  if constexpr (not cutlass::platform::is_same<remove_cvref_t<Func>, NoGather>::value) {
+    Layout matrix_layout = make_identity_layout(shape);
+    auto offset = as_arithmetic_tuple(repeat_like(shape, _0{}));
+    Layout gather_layout = make_custom_stride_layout(stride, static_cast<Func&&>(func));
+    return make_tensor(iter, ComposedLayout{gather_layout, offset, matrix_layout});
+  } else {
+    return make_tensor(iter, shape, stride);
+  }
+}
+
+}  // namespace example
+
+namespace cute {
+
+template <int N, int I, class Shape, class Stride>
+CUTE_HOST_DEVICE constexpr auto upcast(Shape const& shape, Stride const& stride) {
+  if constexpr (is_tuple<Shape>::value) {
+    return transform_layout(shape, stride,
+                            [](auto const& s, auto const& d) { return upcast<N, I>(s, d); });
+  } else if constexpr (is_scaled_basis<Stride>::value) {
+    if constexpr (Stride::mode() == I) {
+      return make_layout(ceil_div(shape, Int<N>{}), ceil_div(stride, Int<N>{}));
+    } else {
+      return make_layout(shape, stride);
+    }
+  } else {
+    return upcast<N>(shape, stride);
+  }
+
+  CUTE_GCC_UNREACHABLE;
+}
+
+template <int N, class OuterShape, class OuterStride, class Offset, class Shape, class Stride>
+CUTE_HOST_DEVICE constexpr auto upcast(
+    ComposedLayout<Layout<OuterShape, OuterStride>, Offset, Layout<Shape, Stride>> const& layout) {
+  // Find index of the stride-1 mode - that is the only one that requires updating inner shape and
+  // offset
+  auto idx =
+      find_if(layout.layout_a().stride(), [](auto x) { return is_constant<1, decltype(x)>{}; });
+  constexpr int I = decltype(idx)::value;
+
+  // Upcast the outer layout (works as expected)
+  auto outer = upcast<N>(layout.layout_a());
+
+  // Upcast the accumulated offset along stride-1 mode
+  auto offset =
+      as_arithmetic_tuple(replace<I>(layout.offset(), upcast<N>(get<I>(layout.offset()))));
+
+  // Upcast the inner layout's shape along stride-1 mode
+  auto inner = upcast<N, I>(layout.layout_b().shape(), layout.layout_b().stride());
+
+  return composition(outer, offset, inner);
+}
+
+}  // namespace cute

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/gpu_trace.h
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/gpu_trace.h
@@ -1,0 +1,623 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 MiniMax
+// SPDX-License-Identifier: MIT
+
+
+#pragma once
+#include <cstdint>
+
+namespace gpu_trace {
+
+/* ===== Compile-time FNV-1a hash (always available, CPU + GPU) ============= */
+
+constexpr uint32_t hash(const char* s) {
+    uint32_t h = 2166136261u;
+    for (; *s; ++s) h = (h ^ (uint8_t)*s) * 16777619u;
+    return h;
+}
+
+static constexpr int RECORD_INTS = 4;
+static constexpr int MAX_WARP_PER_BLOCK = 32;
+static constexpr int MAX_SM_NUN = 256;
+static constexpr int DATA_OFFSET = MAX_WARP_PER_BLOCK + MAX_SM_NUN * 4;
+
+
+}  // namespace gpu_trace
+
+/* ===== Scope registration (host-side, compile-time auto-register) ========= */
+
+#ifdef GPU_TRACE_ENABLED
+
+#include <algorithm>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace gpu_trace {
+namespace detail {
+
+// One 8-bit scope id may map to multiple compile-time scope names (hash collision).
+inline std::unordered_map<uint32_t, std::vector<std::string>>& scope_registry() {
+    static std::unordered_map<uint32_t, std::vector<std::string>> reg;
+    return reg;
+}
+
+inline bool do_register(uint32_t id, const char* name) {
+    std::string s(name);
+    auto& v = scope_registry()[id];
+    if (std::find(v.begin(), v.end(), s) == v.end())
+        v.push_back(std::move(s));
+    return true;
+}
+
+/** Resolved label for Chrome trace: single name, or "A/B/C" when id collides. */
+inline std::string scope_label_for_id(uint32_t id) {
+    auto& reg = scope_registry();
+    auto it = reg.find(id);
+    if (it == reg.end() || it->second.empty())
+        return "unknown";
+    const auto& names = it->second;
+    if (names.size() == 1)
+        return names[0];
+    std::vector<std::string> sorted(names.begin(), names.end());
+    std::sort(sorted.begin(), sorted.end());
+    std::string out = sorted[0];
+    for (size_t i = 1; i < sorted.size(); ++i) {
+        out.push_back('/');
+        out += sorted[i];
+    }
+    return out;
+}
+
+}  // namespace detail
+}  // namespace gpu_trace
+
+#define GPU_TRACE_REGISTER_IMPL_(name, name_str)       \
+    [[maybe_unused]] inline const bool _gtreg_##name = \
+        ::gpu_trace::detail::do_register(::gpu_trace::hash(name_str), name_str)
+
+#else
+#define GPU_TRACE_REGISTER_IMPL_(name, name_str)
+#endif
+
+/* ===== GPU_TRACE_SCOPE_DEC ================================================ */
+
+#ifdef GPU_TRACE_ENABLED
+
+#define GPU_TRACE_SCOPE_DEC(name)                                      \
+    static constexpr uint32_t GTEVT_##name = ::gpu_trace::hash(#name); \
+    GPU_TRACE_REGISTER_IMPL_(name, #name)
+
+GPU_TRACE_SCOPE_DEC(GPU_TRACE_TEST_SCOPE);
+GPU_TRACE_SCOPE_DEC(GPU_TRACE_TEST);
+
+#else
+
+#define GPU_TRACE_SCOPE_DEC(name) static constexpr uint32_t GTEVT_##name = 0
+
+#endif
+
+/* ========================================================================== */
+#ifndef GPU_TRACE_ENABLED
+/* ===== Disabled: zero-overhead stubs ====================================== */
+
+struct GPUTraceParam {};
+
+namespace gpu_trace {
+struct Recorder {};
+template <typename S>
+inline bool setup_from_env(GPUTraceParam&, S, const char* = nullptr, int = 0) {
+    return false;
+}
+template <typename S>
+inline void teardown(GPUTraceParam&, S, const char* = nullptr) {}
+}  // namespace gpu_trace
+
+#define GPU_TRACE_INIT
+#define GET_GPU_TRACE(cond)
+#define RELEASE_GPU_TRACE
+#define GPU_TRACE_SCOPE(name)
+#define GPU_TRACE_SCOPE_BEGIN(name)
+#define GPU_TRACE_SCOPE_END(name)
+#define GPU_TRACE_EXIT
+
+#else /* GPU_TRACE_ENABLED */
+/* ===== Enabled ============================================================ */
+
+struct GPUTraceParam {
+    uint32_t* buf = nullptr;
+    int capacity = 0;
+    int target_block = -1;
+};
+
+__constant__ GPUTraceParam g_gputraceParam;
+
+/* ---- Device-side Recorder & Scope ---------------------------------------- */
+#ifdef __CUDACC__
+
+namespace gpu_trace {
+
+__device__ __forceinline__ unsigned lane_id() {
+    unsigned id;
+    asm("mov.u32 %0, %%laneid;" : "=r"(id));
+    return id;
+}
+
+__device__ __forceinline__ unsigned warp_id() {
+    return (threadIdx.x + threadIdx.y * blockDim.x +
+            threadIdx.z * blockDim.x * blockDim.y) >>
+           5;
+}
+
+struct Recorder {
+    uint32_t* cur;
+    uint32_t remaining;
+
+    __device__ __forceinline__ bool init() {
+        cur = nullptr;
+        remaining = 0;
+        const auto& p = g_gputraceParam;
+        bool active = p.buf &&
+                      (p.target_block < 0 || blockIdx.x == (unsigned)p.target_block) &&
+                      (lane_id() == 0);
+        if (!active)
+            return false;
+        remaining = p.capacity;
+        cur = p.buf + DATA_OFFSET + warp_id() * p.capacity * RECORD_INTS;
+        return true;
+    }
+
+    __device__ __forceinline__ void write_v4(uint32_t d0,
+                                             uint32_t d1,
+                                             uint32_t d2,
+                                             uint32_t d3) {
+        uint32_t active = (remaining != 0);
+        asm volatile(
+            "{\n\t"
+            "  .reg .pred p;\n\t"
+            "  setp.ne.u32 p, %0, 0;\n\t"
+            "  @p st.global.cs.v4.b32 [%1], {%2, %3, %4, %5};\n\t"
+            "}" ::"r"(active),
+            "l"(cur), "r"(d0), "r"(d1), "r"(d2), "r"(d3)
+            : "memory");
+        cur += active * RECORD_INTS;
+        remaining -= active;
+    }
+
+    __device__ __forceinline__ void load();
+    __device__ __forceinline__ void save(bool force = false);
+};
+
+__device__ __forceinline__ uint32_t recorder_remaining_load() {
+    uint32_t val;
+    asm volatile("ld.global.ca.b32 %0, [%1];"
+                 : "=r"(val)
+                 : "l"(g_gputraceParam.buf + warp_id())
+                 : "memory");
+    return val;
+}
+
+__device__ __forceinline__ void recorder_remaining_store(uint32_t val) {
+    uint32_t* ptr = g_gputraceParam.buf;
+    if (ptr == nullptr)
+        return;
+    asm volatile("st.global.wb.b32 [%0], %1;" ::"l"(ptr + warp_id()), "r"(val)
+                 : "memory");
+}
+
+__device__ __forceinline__ void Recorder::load() {
+    if (lane_id() != 0)
+        return;
+    if (!init())
+        return;
+    uint32_t ar = recorder_remaining_load();
+    cur += (remaining - ar) * RECORD_INTS;
+    remaining = ar;
+}
+
+__device__ __forceinline__ void Recorder::save(bool force) {
+    if (!force && !this->cur)
+        return;
+    recorder_remaining_store(remaining);
+}
+
+/*
+ * v4 record layout (4 × uint32_t per event, zero GPU-side computation):
+ *   Word 0 : begin_clk  (raw 32-bit clock from CS2R)
+ *   Word 1 : end_clk    (raw 32-bit clock from CS2R)
+ *   Word 2 : scope_id   (compile-time constant, 8-bit hash)
+ *   Word 3 : reserved   (0)
+ *
+ * All packing / duration / timestamp computation is deferred to the CPU
+ * in teardown().  GPU critical path: CS2R → SHF → STG.v4 (2 levels).
+ */
+template <uint32_t ScopeId>
+struct Scope {
+    static constexpr int scope_id = ScopeId;
+    uint32_t begin_clk_;
+    const uint32_t data_;
+
+    __device__ __forceinline__ Scope(uint32_t data = 0) : begin_clk_(0), data_(data) {}
+
+    __device__ __forceinline__ static uint32_t read_clock() {
+        uint32_t clk;
+        asm volatile("{ mov.u32 %0, %%clock; }" : "=r"(clk)::"memory");
+        return clk;
+    }
+
+    __device__ __forceinline__ void begin() {
+        begin_clk_ = read_clock();
+    }
+
+    __device__ __forceinline__ void end(Recorder& rec) {
+        uint32_t end_clk = read_clock();
+        rec.write_v4(begin_clk_, end_clk, (uint32_t)ScopeId, data_);
+    }
+
+    Scope(const Scope&) = delete;
+    Scope& operator=(const Scope&) = delete;
+};
+
+template <uint32_t ScopeId>
+struct ScopeGuard : Scope<ScopeId> {
+    Recorder& rec_;
+
+    __device__ __forceinline__ ScopeGuard(Recorder& rec) : rec_(rec) {
+        this->begin();
+    }
+
+    __device__ __forceinline__ ~ScopeGuard() {
+        this->end(rec_);
+    }
+};
+
+}  // namespace gpu_trace
+
+#define GPU_TRACE_INIT                \
+    {                                 \
+        gpu_trace::Recorder _gt_r; \
+        _gt_r.init();                 \
+        _gt_r.save();                 \
+        __syncthreads();              \
+        if (threadIdx.x == 0)         \
+        {                             \
+            uint64_t c = clock64();   \
+            g_gputraceParam.buf[gpu_trace::MAX_WARP_PER_BLOCK + blockIdx.x * 4] = uint32_t(c & 0xFFFFFFFF); \
+            g_gputraceParam.buf[gpu_trace::MAX_WARP_PER_BLOCK + blockIdx.x * 4 + 1] = uint32_t(c >> 32); \
+        }                             \
+    }
+
+#define GPU_TRACE_EXIT                \
+        if (threadIdx.x == 0)         \
+        {                             \
+            uint64_t c = clock64();   \
+            g_gputraceParam.buf[gpu_trace::MAX_WARP_PER_BLOCK + blockIdx.x * 4 + 2] = uint32_t(c & 0xFFFFFFFF); \
+            g_gputraceParam.buf[gpu_trace::MAX_WARP_PER_BLOCK + blockIdx.x * 4 + 3] = uint32_t(c >> 32); \
+        }                             \
+
+#define GET_GPU_TRACE(cond)  \
+    gpu_trace::Recorder _gt_rec{}; \
+    if (cond)                                   \
+    _gt_rec.load()
+
+#define RELEASE_GPU_TRACE _gt_rec.save()
+
+#define GPU_TRACE_SCOPE(name)                                                        \
+    gpu_trace::ScopeGuard<GTEVT_##name> _gtscp_##name( \
+        _gt_rec)
+
+#define GPU_TRACE_SCOPE_BEGIN(name)               \
+    gpu_trace::Scope<GTEVT_##name> _gtevt_##name; \
+    _gtevt_##name.begin()
+
+#define GPU_TRACE_SCOPE_END(name) _gtevt_##name.end(_gt_rec)
+
+#endif /* __CUDACC__ */
+
+/* ---- Host-side helpers --------------------------------------------------- */
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <set>
+#include <vector>
+
+namespace gpu_trace {
+
+inline int64_t buf_total_ints(int per_thread_capacity) {
+    return DATA_OFFSET + MAX_WARP_PER_BLOCK * per_thread_capacity * RECORD_INTS;
+}
+
+inline bool setup_from_env(GPUTraceParam& p,
+                           cudaStream_t stream,
+                           const char* env_var = "GPU_TRACE",
+                           int per_thread_capacity = 65536) {
+    const char* val = std::getenv(env_var);
+    if (!val)
+        return false;
+
+    p.target_block = std::atoi(val);
+    p.capacity = per_thread_capacity;
+
+    int64_t total = buf_total_ints(p.capacity);
+    int64_t bytes = total * (int64_t)sizeof(uint32_t);
+    cudaMalloc(&p.buf, bytes);
+    cudaMemsetAsync(p.buf, 0, bytes, stream);
+
+    cudaMemcpyToSymbolAsync(g_gputraceParam, &p, sizeof(GPUTraceParam), 0,
+                            cudaMemcpyHostToDevice, stream);
+    return true;
+}
+
+/**
+ * Synchronize, read back trace data, write Chrome trace JSON.
+ *
+ * v4 record layout (4 × uint32_t per event):
+ *   Word 0 : begin_clk  (raw 32-bit clock)
+ *   Word 1 : end_clk    (raw 32-bit clock)
+ *   Word 2 : scope_id   (8-bit hash, stored as uint32_t)
+ *   Word 3 : reserved   (0)
+ *
+ * Duration and timestamps are computed on the CPU from raw clocks.
+ */
+inline void teardown(GPUTraceParam& p,
+                     cudaStream_t stream,
+                     const char* default_path = "/tmp/gpu_trace.json") {
+    if (!p.buf)
+        return;
+
+    cudaStreamSynchronize(stream);
+
+    int device = 0;
+    cudaGetDevice(&device);
+    int clock_rate_khz = 0;
+    cudaDeviceGetAttribute(&clock_rate_khz, cudaDevAttrClockRate, device);
+    double scale = (clock_rate_khz > 0) ? (1e3 / (double)clock_rate_khz) : 1e-3;
+
+    int64_t total = buf_total_ints(p.capacity);
+    std::vector<uint32_t> h_buf(total);
+    cudaMemcpy(h_buf.data(), p.buf, total * sizeof(uint32_t), cudaMemcpyDeviceToHost);
+    cudaFree(p.buf);
+    p.buf = nullptr;
+
+    GPUTraceParam empty{};
+    cudaMemcpyToSymbol(g_gputraceParam, &empty, sizeof(GPUTraceParam));
+
+    // --- Extract per-SM timing (clock64 stored as 4 × uint32_t per SM) ---
+    struct SmTiming {
+        int id;
+        uint64_t start, end, dur;
+    };
+    std::vector<SmTiming> sm_timings;
+    for (int i = 0; i < MAX_SM_NUN; ++i) {
+        int base = MAX_WARP_PER_BLOCK + i * 4;
+        uint64_t s = (uint64_t)h_buf[base + 1] << 32 | h_buf[base + 0];
+        uint64_t e = (uint64_t)h_buf[base + 3] << 32 | h_buf[base + 2];
+        if (s == 0 && e == 0)
+            continue;
+        sm_timings.push_back({i, 0, e - s, e - s});
+    }
+
+
+    std::string out(default_path);
+    const char* env = std::getenv("GPU_TRACE");
+    if (env) {
+        const char* colon = std::strchr(env, ':');
+        if (colon && colon[1])
+            out = colon + 1;
+    }
+
+    struct Rec {
+        int tid;
+        std::string name;
+        int64_t tb, te;
+    };
+    std::vector<Rec> records;
+    int64_t t_origin = INT64_MAX;
+
+    for (int t = 0; t < MAX_WARP_PER_BLOCK; ++t) {
+        int remain = (int)h_buf[t];
+        int used = p.capacity - remain;
+        if (used <= 0)
+            continue;
+        int64_t warp_base = DATA_OFFSET + (int64_t)t * p.capacity * RECORD_INTS;
+        for (int i = 0; i < used; ++i) {
+            int64_t off = warp_base + (int64_t)i * RECORD_INTS;
+            uint32_t begin_clk = h_buf[off + 0];
+            uint32_t end_clk = h_buf[off + 1];
+            uint32_t eid = h_buf[off + 2];
+            if (begin_clk == 0 && end_clk == 0)
+                break;
+
+            int64_t dur = (int64_t)(uint32_t)(end_clk - begin_clk);
+            int64_t tb = (int64_t)begin_clk;
+            int64_t te = tb + dur;
+
+            records.push_back({t, detail::scope_label_for_id(eid), tb, te});
+            if (tb < t_origin)
+                t_origin = tb;
+        }
+    }
+
+    if (records.empty() && sm_timings.empty())
+        return;
+
+    std::map<int, std::vector<size_t>> by_tid;
+    for (size_t i = 0; i < records.size(); ++i) by_tid[records[i].tid].push_back(i);
+
+    for (auto& [tid, idx] : by_tid) {
+        std::sort(idx.begin(), idx.end(),
+                  [&](size_t a, size_t b) { return records[a].tb < records[b].tb; });
+    }
+
+    FILE* f = std::fopen(out.c_str(), "w");
+    if (!f)
+        return;
+
+    std::fprintf(f, "{\"traceEvents\":[\n");
+    bool first = true;
+    auto comma = [&]() {
+        if (!first)
+            std::fprintf(f, ",\n");
+        first = false;
+    };
+
+    int vpid = 0;
+    for (auto& [tid, idx] : by_tid) {
+        int pid = vpid++;
+
+        comma();
+        std::fprintf(f,
+                     "{\"name\":\"process_name\",\"ph\":\"M\","
+                     "\"pid\":%d,\"tid\":0,"
+                     "\"args\":{\"name\":\"Block %d / Warp %d\"}}",
+                     pid, p.target_block, tid);
+        comma();
+        std::fprintf(f,
+                     "{\"name\":\"process_sort_index\",\"ph\":\"M\","
+                     "\"pid\":%d,\"tid\":0,"
+                     "\"args\":{\"sort_index\":%d}}",
+                     pid, pid);
+
+        std::set<std::string> name_set;
+        for (size_t ri : idx) name_set.insert(records[ri].name);
+        std::vector<std::string> lane_names(name_set.begin(), name_set.end());
+        std::map<std::string, int> name_to_lane;
+        for (int lane = 0; lane < (int)lane_names.size(); ++lane)
+            name_to_lane[lane_names[lane]] = lane;
+
+        for (int lane = 0; lane < (int)lane_names.size(); ++lane) {
+            comma();
+            std::fprintf(f,
+                         "{\"name\":\"thread_name\",\"ph\":\"M\","
+                         "\"pid\":%d,\"tid\":%d,"
+                         "\"args\":{\"name\":\"%s\"}}",
+                         pid, lane, lane_names[lane].c_str());
+            comma();
+            std::fprintf(f,
+                         "{\"name\":\"sort_index\",\"ph\":\"M\","
+                         "\"pid\":%d,\"tid\":%d,"
+                         "\"args\":{\"sort_index\":%d}}",
+                         pid, lane, lane);
+        }
+
+        for (size_t ri : idx) {
+            auto& rec = records[ri];
+            int lane = name_to_lane[rec.name];
+            int64_t dur = rec.te - rec.tb;
+            comma();
+            std::fprintf(f,
+                         "{\"name\":\"%s\",\"ph\":\"X\","
+                         "\"ts\":%.3f,\"dur\":%.3f,"
+                         "\"pid\":%d,\"tid\":%d,"
+                         "\"args\":{\"cycles\":%lld}}",
+                         rec.name.c_str(), (double)(rec.tb - t_origin) * scale,
+                         (double)dur * scale, pid, lane, (long long)dur);
+        }
+    }
+
+    // --- SM timing events in Chrome trace (separate process group) ---
+    if (!sm_timings.empty()) {
+        uint64_t sm_origin = sm_timings[0].start;
+        uint64_t sum = 0;
+        uint64_t min_dur = UINT64_MAX, max_dur = 0;
+        int min_sm = 0, max_sm = 0;
+        for (auto& t : sm_timings) {
+            sum += t.dur;
+            if (t.start < sm_origin) sm_origin = t.start;
+            if (t.dur < min_dur) { min_dur = t.dur; min_sm = t.id; }
+            if (t.dur > max_dur) { max_dur = t.dur; max_sm = t.id; }
+        }
+        double mean = (double)sum / sm_timings.size();
+        double var = 0;
+        for (auto& t : sm_timings) {
+            double d = (double)t.dur - mean;
+            var += d * d;
+        }
+        double stdev = std::sqrt(var / sm_timings.size());
+        double imbalance = min_dur > 0 ? (double)max_dur / min_dur : 0.0;
+
+        int sm_pid = vpid++;
+        comma();
+        std::fprintf(f,
+                     "{\"name\":\"process_name\",\"ph\":\"M\","
+                     "\"pid\":%d,\"tid\":0,"
+                     "\"args\":{\"name\":\"SM Timing (%zu SMs)\"}}",
+                     sm_pid, sm_timings.size());
+        comma();
+        std::fprintf(f,
+                     "{\"name\":\"process_sort_index\",\"ph\":\"M\","
+                     "\"pid\":%d,\"tid\":0,"
+                     "\"args\":{\"sort_index\":%d}}",
+                     sm_pid, sm_pid);
+
+        // e2e thread at tid=MAX_SM_NUN, sort to top
+        int e2e_tid = MAX_SM_NUN;
+        comma();
+        std::fprintf(f,
+                     "{\"name\":\"thread_name\",\"ph\":\"M\","
+                     "\"pid\":%d,\"tid\":%d,"
+                     "\"args\":{\"name\":\"E2E\"}}",
+                     sm_pid, e2e_tid);
+        comma();
+        std::fprintf(f,
+                     "{\"name\":\"thread_sort_index\",\"ph\":\"M\","
+                     "\"pid\":%d,\"tid\":%d,"
+                     "\"args\":{\"sort_index\":-1}}",
+                     sm_pid, e2e_tid);
+
+        uint64_t max_end = 0;
+        for (auto& t : sm_timings)
+            if (t.end > max_end) max_end = t.end;
+        uint64_t e2e_dur = max_end - sm_origin;
+
+        comma();
+        std::fprintf(f,
+                     "{\"name\":\"E2E\",\"ph\":\"X\","
+                     "\"ts\":0,\"dur\":%.3f,"
+                     "\"pid\":%d,\"tid\":%d,"
+                     "\"args\":{\"cycles\":%llu,\"us\":%.3f,"
+                     "\"min_cycles\":%llu,\"min_us\":%.3f,\"min_sm\":%d,"
+                     "\"max_cycles\":%llu,\"max_us\":%.3f,\"max_sm\":%d,"
+                     "\"mean_cycles\":%.0f,\"mean_us\":%.3f,"
+                     "\"stdev_cycles\":%.0f,\"stdev_us\":%.3f,"
+                     "\"imbalance\":%.4f}}",
+                     (double)e2e_dur * scale,
+                     sm_pid, e2e_tid,
+                     (unsigned long long)e2e_dur, (double)e2e_dur * scale,
+                     (unsigned long long)min_dur, (double)min_dur * scale, min_sm,
+                     (unsigned long long)max_dur, (double)max_dur * scale, max_sm,
+                     mean, mean * scale,
+                     stdev, stdev * scale,
+                     imbalance);
+
+        for (auto& t : sm_timings) {
+            comma();
+            std::fprintf(f,
+                         "{\"name\":\"SM %d\",\"ph\":\"X\","
+                         "\"ts\":%.3f,\"dur\":%.3f,"
+                         "\"pid\":%d,\"tid\":%d,"
+                         "\"args\":{\"cycles\":%llu,\"start\":%llu,\"end\":%llu}}",
+                         t.id,
+                         (double)(t.start - sm_origin) * scale,
+                         (double)t.dur * scale,
+                         sm_pid, t.id,
+                         (unsigned long long)t.dur,
+                         (unsigned long long)t.start,
+                         (unsigned long long)t.end);
+        }
+    }
+
+    std::fprintf(f, "\n]}");
+    std::fclose(f);
+    std::fprintf(stderr, "[GPUTrace] %zu records -> %s  (SM clock %d kHz)\n",
+                 records.size(), out.c_str(), clock_rate_khz);
+}
+
+}  // namespace gpu_trace
+
+#endif /* GPU_TRACE_ENABLED */

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/mask.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/mask.cuh
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_ATTENTION_MASK_CUH_
+#define FLASHINFER_ATTENTION_MASK_CUH_
+
+namespace flashinfer {
+
+enum class MaskMode {
+  kNone = 0U,    // No mask
+  kCausal = 1U,  // Causal mask
+  kCustom = 2U,  // Custom mask
+  kMultiItemScoring = 3U,
+};
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_ATTENTION_MASK_CUH_

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/plan.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/plan.cuh
@@ -1,0 +1,1056 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <cub/block/block_scan.cuh>
+#include "utils.cuh"
+
+namespace flashinfer {
+
+// ============================================================================
+// Cost model constants
+// ============================================================================
+
+constexpr float kPerIterOverhead = 43;
+constexpr float kTileGlobalOverhead = 110;
+constexpr float kSMGlobalOverhead = 165;
+constexpr float kSplitExtraOverhead = 150;
+
+
+// ============================================================================
+// Plan kernel constants
+// ============================================================================
+
+constexpr int MAX_SMS = 256;
+constexpr int MAX_TASKS_PER_SM = 96;
+constexpr int MAX_UNSPLIT = 4096;
+constexpr int MAX_REBALANCE_ITERS = 1024;
+constexpr int MIN_ITERS_PER_SPLIT = 4;
+
+// ============================================================================
+// Shared memory state
+// ============================================================================
+
+struct PlanSharedState {
+  int     sm_cost[MAX_SMS];
+  int16_t sm_task_count[MAX_SMS];
+
+  int16_t task_kv_begin[MAX_SMS][MAX_TASKS_PER_SM];
+  int16_t task_kv_end[MAX_SMS][MAX_TASKS_PER_SM];
+  int16_t task_unsplit_id[MAX_SMS][MAX_TASKS_PER_SM];
+  int8_t  task_sub_id[MAX_SMS][MAX_TASKS_PER_SM];
+
+  int16_t unsplit_qo_tile[MAX_UNSPLIT];
+  int8_t  unsplit_head[MAX_UNSPLIT];
+  int16_t unsplit_batch[MAX_UNSPLIT];
+  int16_t unsplit_kv_iters[MAX_UNSPLIT];
+  int     unsplit_sub_counter[MAX_UNSPLIT];
+  int     num_unsplit;
+
+  uint     warp_scratch[8];  // for block reduce
+  typename cub::BlockScan<int, MAX_SMS>::TempStorage scan_temp;
+};
+
+// ============================================================================
+// Parallel min/max cost SM: pack (cost, idx) into int32
+// cost in upper 24 bits, idx in lower 8 bits → min/max on int32 works
+// ============================================================================
+
+__device__ __forceinline__ uint pack_cost_idx(uint cost, uint idx) {
+  return (cost << 8) | (idx & 0xff);
+}
+__device__ __forceinline__ uint unpack_idx(uint packed) { return packed & 0xff; }
+
+// Layout: [63:32] qo_tile_idx (32b) | [31:16] qo_head_idx (16b) | [15:0] batch_idx (16b)
+// 64-bit so per-token sparse decode (batch_size = total_q, up to 65536) can address batch
+// without wrap, while large prefill keeps qo_tile_idx headroom (max_qo_len / qo_tile_size
+// can exceed 256 for q ≥ 64K). See bug_sparse_decode_qo256.md.
+__device__ __forceinline__ uint64_t pack_work_info(int qo_tile, int head, int batch) {
+  return (static_cast<uint64_t>(static_cast<uint32_t>(qo_tile)) << 32) |
+         (static_cast<uint64_t>(head & 0xFFFF) << 16) |
+         static_cast<uint64_t>(batch & 0xFFFF);
+}
+
+__device__ __forceinline__ uint64_t pack_work_range(int start, int end) {
+  return (static_cast<uint64_t>(static_cast<uint32_t>(end)) << 32) |
+         static_cast<uint64_t>(static_cast<uint32_t>(start));
+}
+
+template <bool IsMin>
+__device__ __forceinline__ int block_reduce_cost(PlanSharedState& s, int n) {
+  int tid = static_cast<int>(threadIdx.x);
+  uint val = (tid < n)
+      ? pack_cost_idx(s.sm_cost[tid], tid)
+      : pack_cost_idx(IsMin ? 0x7fffff : 0, tid);
+
+  #pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    uint other = __shfl_xor_sync(0xffffffff, val, offset);
+    val = IsMin ? ::min(val, other) : ::max(val, other);
+  }
+
+  if (tid % 32 == 0) s.warp_scratch[tid / 32] = val;
+  __syncthreads();
+
+  if (tid < 8) {
+    val = (tid * 32 < n) ? s.warp_scratch[tid]
+        : pack_cost_idx(IsMin ? 0x7fffff : 0, tid * 32);
+    #pragma unroll
+    for (int offset = 4; offset > 0; offset >>= 1) {
+      uint other = __shfl_xor_sync(0xff, val, offset);
+      val = IsMin ? ::min(val, other) : ::max(val, other);
+    }
+    if (tid == 0) s.warp_scratch[0] = val;
+  }
+  __syncthreads();
+  return s.warp_scratch[0];
+}
+
+__device__ __forceinline__ int find_min_cost_sm(PlanSharedState& s, int n) {
+  return unpack_idx(block_reduce_cost<true>(s, n));
+}
+
+__device__ __forceinline__ int find_max_cost_sm(PlanSharedState& s, int n) {
+  return unpack_idx(block_reduce_cost<false>(s, n));
+}
+
+// ============================================================================
+// Helpers (thread 0 only)
+// ============================================================================
+
+__device__ __forceinline__ int compute_kv_iters(
+    int batch_idx, int qo_tile_idx, int* qo_lens, int* kv_lens,
+    int* qo_offsets, int qo_tile_size, int kv_tile_size, bool causal,
+    int pack_factor = 1) {
+  int kv_len = kv_lens[batch_idx];
+  if (!causal) return (kv_len + kv_tile_size - 1) / kv_tile_size;
+  int offset_q = qo_offsets ? qo_offsets[batch_idx] : (kv_len - qo_lens[batch_idx]);
+  int packed_q_end = (qo_tile_idx + 1) * qo_tile_size;
+  int q_end = (pack_factor > 1) ? (packed_q_end - 1) / pack_factor + 1 : packed_q_end;
+  int eff_kv = q_end + offset_q;
+  if (eff_kv > kv_len) eff_kv = kv_len;
+  if (eff_kv <= 0) return 0;
+  return (eff_kv + kv_tile_size - 1) / kv_tile_size;
+}
+
+__device__ __forceinline__ void add_task(
+    PlanSharedState& s, int sm,
+    int16_t kv_begin, int16_t kv_end, int16_t unsplit_id, int8_t sub_id) {
+  int idx = s.sm_task_count[sm]++;
+  s.task_kv_begin[sm][idx] = kv_begin;
+  s.task_kv_end[sm][idx] = kv_end;
+  s.task_unsplit_id[sm][idx] = unsplit_id;
+  s.task_sub_id[sm][idx] = sub_id;
+}
+
+__device__ __forceinline__ bool split_task(
+    PlanSharedState& s, int sm, int task_idx, int keep_iters, int target_sm, int max_splits) {
+  int16_t uid = s.task_unsplit_id[sm][task_idx];
+
+  int old_count = atomicAdd(&s.unsplit_sub_counter[uid], 1);
+  if (old_count >= max_splits) {
+    atomicAdd(&s.unsplit_sub_counter[uid], -1);
+    return false;
+  }
+
+  int16_t orig_begin = s.task_kv_begin[sm][task_idx];
+  int16_t split_point = orig_begin + keep_iters;
+  int16_t orig_end = s.task_kv_end[sm][task_idx];
+  s.task_kv_end[sm][task_idx] = split_point;
+
+  add_task(s, target_sm, split_point, orig_end, uid, (int8_t)old_count);
+  return true;
+}
+
+__device__ __forceinline__ int find_best_fit_task(
+    PlanSharedState& s, int sm, int target_iters, int max_splits) {
+  int n = s.sm_task_count[sm];
+  int best_fit = -1, best_fit_iters = 0x7fff;
+  int largest = -1, largest_iters = 0;
+  int min_needed = target_iters + MIN_ITERS_PER_SPLIT;
+
+  for (int t = 0; t < n; t++) {
+    int iters = s.task_kv_end[sm][t] - s.task_kv_begin[sm][t];
+    int16_t uid = s.task_unsplit_id[sm][t];
+    if (s.unsplit_sub_counter[uid] >= max_splits) continue;
+    if (iters < 2 * MIN_ITERS_PER_SPLIT) continue;
+
+    if (iters >= min_needed && iters < best_fit_iters) {
+      best_fit = t;
+      best_fit_iters = iters;
+    }
+    if (iters > largest_iters) {
+      largest = t;
+      largest_iters = iters;
+    }
+  }
+  return best_fit >= 0 ? best_fit : largest;
+}
+
+// ============================================================================
+// Parallel output writing: each thread writes its own SM's tasks
+// All threads participate (prefix sum for write offsets)
+// ============================================================================
+
+__device__ void parallel_write_output(
+    PlanSharedState& s, int num_buckets,
+    uint64_t* packed_work_range, uint64_t* packed_work_info,
+    int* kv_tile_begin_indices = nullptr,
+    int* kv_tile_end_indices = nullptr,
+    int* kv_split_indices = nullptr) {
+
+  int tid = static_cast<int>(threadIdx.x);
+  int my_count = (tid < num_buckets) ? static_cast<int>(s.sm_task_count[tid]) : 0;
+
+  int my_offset;
+  cub::BlockScan<int, MAX_SMS>(s.scan_temp).ExclusiveSum(my_count, my_offset);
+  __syncthreads();
+
+  if (tid < num_buckets) {
+    packed_work_range[tid] = pack_work_range(my_offset, my_offset + my_count);
+    for (int t = 0; t < my_count; t++) {
+      int pos = my_offset + t;
+      int16_t uid = s.task_unsplit_id[tid][t];
+      packed_work_info[pos] = pack_work_info(
+          s.unsplit_qo_tile[uid], s.unsplit_head[uid], s.unsplit_batch[uid]);
+      if (kv_tile_begin_indices) kv_tile_begin_indices[pos] = s.task_kv_begin[tid][t];
+      if (kv_tile_end_indices) kv_tile_end_indices[pos] = s.task_kv_end[tid][t];
+      if (kv_split_indices) kv_split_indices[pos] = s.task_sub_id[tid][t];
+    }
+  }
+  __syncthreads();
+}
+
+// ============================================================================
+// Direct nosplit: enumerate tiles + greedy assign + write output in one pass
+// No smem unsplit table needed — for large tile counts (>MAX_UNSPLIT)
+// ============================================================================
+
+__device__ int direct_greedy(
+    PlanSharedState& s, int num_buckets,
+    int* qo_lens, int* kv_lens, int* qo_offsets,
+    int qo_tile_size, int kv_tile_size, int batch_size, int num_heads, bool causal,
+    int num_kv_splits,
+    uint64_t* packed_work_range, uint64_t* packed_work_info,
+    int* kv_tile_begin_indices = nullptr, int* kv_tile_end_indices = nullptr,
+    int* kv_split_indices = nullptr,
+    int* num_kv_splits_per_row = nullptr, int* qo_segment_offsets = nullptr,
+    int pack_factor = 1) {
+
+  int tid = static_cast<int>(threadIdx.x);
+
+  __shared__ int _max_qo_tiles;
+  if (tid == 0) {
+    int mq = 0;
+    for (int b = 0; b < batch_size; b++) {
+      int nt = ceil_div(qo_lens[b], qo_tile_size);
+      if (nt > mq) mq = nt;
+    }
+    _max_qo_tiles = mq;
+  }
+  __syncthreads();
+  int max_qo_tiles = _max_qo_tiles;
+
+  if (tid < num_buckets) {
+    s.sm_cost[tid] = kSMGlobalOverhead;
+    s.sm_task_count[tid] = 0;
+  }
+  __syncthreads();
+
+  // Pass 1: batch-assign heads in reverse QO tile order
+  for (int qt = max_qo_tiles - 1; qt >= 0; qt--) {
+    for (int b = 0; b < batch_size; b++) {
+      if (qt >= ceil_div(qo_lens[b], qo_tile_size)) continue;
+      int total_ki = compute_kv_iters(b, qt, qo_lens, kv_lens, qo_offsets,
+                                       qo_tile_size, kv_tile_size, causal, pack_factor);
+      if (total_ki <= 0) continue;
+      int actual_splits = (num_kv_splits <= 1) ? 1
+          : ::min(num_kv_splits, ::max(1, total_ki / MIN_ITERS_PER_SPLIT));
+      for (int sp = 0; sp < actual_splits; sp++) {
+        int kb = sp * ((total_ki + actual_splits - 1) / actual_splits);
+        int ke = ::min(kb + (total_ki + actual_splits - 1) / actual_splits, total_ki);
+        int piece_ki = ke - kb;
+        int tile_cost = static_cast<int>(kPerIterOverhead * piece_ki + kTileGlobalOverhead);
+
+        for (int h_off = 0; h_off < num_heads; ) {
+          int batch_count = num_heads - h_off;
+          if (batch_count > num_buckets) batch_count = num_buckets;
+
+          int my_cost = (tid < num_buckets) ? s.sm_cost[tid] : 0x7fffffff;
+          int my_rank = 0;
+          if (tid < num_buckets) {
+            for (int i = 0; i < num_buckets; i++) {
+              int oc = s.sm_cost[i];
+              if (oc < my_cost || (oc == my_cost && i < tid))
+                my_rank++;
+            }
+          }
+          bool i_get = (tid < num_buckets) && (my_rank < batch_count);
+          __syncthreads();
+
+          if (i_get) {
+            s.sm_cost[tid] += tile_cost;
+            s.sm_task_count[tid]++;
+          }
+          __syncthreads();
+          h_off += batch_count;
+        }
+      }
+    }
+  }
+
+  int max_sm = find_max_cost_sm(s, num_buckets);
+  int max_cost = s.sm_cost[max_sm];
+
+  // Compute work_indptr, reset for pass 2
+  __shared__ int _work_offsets[MAX_SMS + 1];
+  if (threadIdx.x == 0) {
+    int pos = 0;
+    for (int sm = 0; sm < num_buckets; sm++) {
+      _work_offsets[sm] = pos;
+      pos += s.sm_task_count[sm];
+    }
+    _work_offsets[num_buckets] = pos;
+    for (int sm = 0; sm < num_buckets; sm++)
+      s.sm_task_count[sm] = 0;
+  }
+  __syncthreads();
+
+  // Pass 2: same order, batch-assign + write tile info
+  if (tid < num_buckets) s.sm_cost[tid] = kSMGlobalOverhead;
+  __syncthreads();
+
+  for (int qt = max_qo_tiles - 1; qt >= 0; qt--) {
+    for (int b = 0; b < batch_size; b++) {
+      if (qt >= ceil_div(qo_lens[b], qo_tile_size)) continue;
+      int total_ki = compute_kv_iters(b, qt, qo_lens, kv_lens, qo_offsets,
+                                       qo_tile_size, kv_tile_size, causal, pack_factor);
+      if (total_ki <= 0) continue;
+      int actual_splits = (num_kv_splits <= 1) ? 1
+          : ::min(num_kv_splits, ::max(1, total_ki / MIN_ITERS_PER_SPLIT));
+      if (threadIdx.x == 0 && num_kv_splits_per_row && qo_segment_offsets) {
+        int seg_off = qo_segment_offsets[b];
+        int qo_len = qo_lens[b];
+        int row_start = qt * qo_tile_size;
+        int row_end = row_start + qo_tile_size < qo_len ? row_start + qo_tile_size : qo_len;
+        for (int r = row_start; r < row_end; r++)
+          num_kv_splits_per_row[seg_off + r] = actual_splits;
+      }
+      for (int sp = 0; sp < actual_splits; sp++) {
+        int kb = sp * ((total_ki + actual_splits - 1) / actual_splits);
+        int ke = ::min(kb + (total_ki + actual_splits - 1) / actual_splits, total_ki);
+        int piece_ki = ke - kb;
+        int tile_cost = static_cast<int>(kPerIterOverhead * piece_ki + kTileGlobalOverhead);
+
+        for (int h_off = 0; h_off < num_heads; ) {
+          int batch_count = num_heads - h_off;
+          if (batch_count > num_buckets) batch_count = num_buckets;
+
+          int my_cost = (tid < num_buckets) ? s.sm_cost[tid] : 0x7fffffff;
+          int my_rank = 0;
+          if (tid < num_buckets) {
+            for (int i = 0; i < num_buckets; i++) {
+              int oc = s.sm_cost[i];
+              if (oc < my_cost || (oc == my_cost && i < tid))
+                my_rank++;
+            }
+          }
+          bool i_get = (tid < num_buckets) && (my_rank < batch_count);
+          __syncthreads();
+
+          if (i_get) {
+            s.sm_cost[tid] += tile_cost;
+            int pos = _work_offsets[tid] + s.sm_task_count[tid]++;
+            packed_work_info[pos] = pack_work_info(qt, h_off + my_rank, b);
+            if (kv_tile_begin_indices) kv_tile_begin_indices[pos] = kb;
+            if (kv_tile_end_indices) kv_tile_end_indices[pos] = ke;
+            if (kv_split_indices) kv_split_indices[pos] = sp;
+          }
+          __syncthreads();
+          h_off += batch_count;
+        }
+      }
+    }
+  }
+  __syncthreads();
+  if (tid < num_buckets) {
+    packed_work_range[tid] = pack_work_range(
+        _work_offsets[tid], _work_offsets[tid] + s.sm_task_count[tid]);
+  }
+  __syncthreads();
+  return max_cost;
+}
+
+// ============================================================================
+// Enumerate unsplit tiles — all threads participate (parallel over heads)
+// ============================================================================
+
+__device__ void enumerate_unsplit_tiles(
+    PlanSharedState& s, int* qo_lens, int* kv_lens, int* qo_offsets,
+    int qo_tile_size, int kv_tile_size, int batch_size, int num_heads, bool causal,
+    int pack_factor = 1) {
+  int tid = static_cast<int>(threadIdx.x);
+  int max_qt = 0;
+  for (int b = 0; b < batch_size; b++) {
+    int nt = ceil_div(qo_lens[b], qo_tile_size);
+    if (nt > max_qt) max_qt = nt;
+  }
+  int uid = 0;
+  for (int qt = max_qt - 1; qt >= 0; qt--) {
+    for (int b = 0; b < batch_size; b++) {
+      if (qt >= ceil_div(qo_lens[b], qo_tile_size)) continue;
+      int ki = compute_kv_iters(b, qt, qo_lens, kv_lens, qo_offsets,
+                                 qo_tile_size, kv_tile_size, causal, pack_factor);
+      if (ki <= 0) continue;
+      int count = num_heads;
+      if (uid + count > MAX_UNSPLIT) count = MAX_UNSPLIT - uid;
+      for (int h = tid; h < count; h += static_cast<int>(blockDim.x)) {
+        s.unsplit_qo_tile[uid + h] = qt;
+        s.unsplit_head[uid + h] = h;
+        s.unsplit_batch[uid + h] = b;
+        s.unsplit_kv_iters[uid + h] = ki;
+        s.unsplit_sub_counter[uid + h] = 0;
+      }
+      uid += count;
+    }
+  }
+  if (tid == 0) s.num_unsplit = uid;
+}
+
+// ============================================================================
+// LPT sort: insertion sort unsplit tiles by kv_iters descending (thread 0 only)
+// After reverse-order enumeration the table is nearly sorted, so O(n) expected.
+// ============================================================================
+
+__device__ void sort_unsplit_descending(PlanSharedState& s) {
+  int n = s.num_unsplit;
+  for (int i = 1; i < n; i++) {
+    int16_t ki = s.unsplit_kv_iters[i];
+    if (ki <= s.unsplit_kv_iters[i - 1]) continue;
+    int16_t qt = s.unsplit_qo_tile[i];
+    int8_t  h  = s.unsplit_head[i];
+    int16_t b  = s.unsplit_batch[i];
+    int j = i - 1;
+    while (j >= 0 && s.unsplit_kv_iters[j] < ki) {
+      s.unsplit_kv_iters[j + 1] = s.unsplit_kv_iters[j];
+      s.unsplit_qo_tile[j + 1] = s.unsplit_qo_tile[j];
+      s.unsplit_head[j + 1]    = s.unsplit_head[j];
+      s.unsplit_batch[j + 1]   = s.unsplit_batch[j];
+      j--;
+    }
+    s.unsplit_kv_iters[j + 1] = ki;
+    s.unsplit_qo_tile[j + 1]  = qt;
+    s.unsplit_head[j + 1]     = h;
+    s.unsplit_batch[j + 1]    = b;
+  }
+}
+
+// ============================================================================
+// Phase 0: Nosplit greedy with batch assignment
+// Tiles with same kv_iters are assigned in bulk via parallel rank computation.
+// AssignTasks: populate smem task arrays (for subsequent rebalance)
+// WriteGlobal: write final output to global memory
+// ============================================================================
+
+template <bool AssignTasks, bool WriteGlobal>
+__device__ int phase0_nosplit_greedy(
+    PlanSharedState& s, int num_buckets, int num_heads,
+    uint64_t* packed_work_range, uint64_t* packed_work_info) {
+
+  int tid = static_cast<int>(threadIdx.x);
+  if (tid < num_buckets) {
+    s.sm_cost[tid] = kSMGlobalOverhead;
+    s.sm_task_count[tid] = 0;
+  }
+  __syncthreads();
+
+  int n = s.num_unsplit;
+  int step = num_heads > 0 ? num_heads : 1;
+  int u = 0;
+  while (u < n) {
+    int ki = s.unsplit_kv_iters[u];
+    int group_end = u + step;
+    while (group_end < n && s.unsplit_kv_iters[group_end] == ki)
+      group_end += step;
+    if (group_end > n) group_end = n;
+    int tile_cost = static_cast<int>(kPerIterOverhead * ki + kTileGlobalOverhead);
+
+    while (u < group_end) {
+      int batch_count = group_end - u;
+      if (batch_count > num_buckets) batch_count = num_buckets;
+
+      int my_cost = (tid < num_buckets) ? s.sm_cost[tid] : 0x7fffffff;
+      int my_rank = 0;
+      if (tid < num_buckets) {
+        for (int i = 0; i < num_buckets; i++) {
+          int oc = s.sm_cost[i];
+          if (oc < my_cost || (oc == my_cost && i < tid))
+            my_rank++;
+        }
+      }
+
+      bool i_get_tile = (tid < num_buckets) && (my_rank < batch_count);
+      __syncthreads();
+
+      if (i_get_tile) {
+        s.sm_cost[tid] += tile_cost;
+        if constexpr (AssignTasks) {
+          int tile_u = u + my_rank;
+          add_task(s, tid, 0, ki, tile_u, 0);
+          s.unsplit_sub_counter[tile_u] = 1;
+        }
+      }
+      __syncthreads();
+      u += batch_count;
+    }
+  }
+
+  int max_sm = find_max_cost_sm(s, num_buckets);
+  int max_cost = s.sm_cost[max_sm];
+
+  if constexpr (WriteGlobal) {
+    parallel_write_output(s, num_buckets,
+        packed_work_range, packed_work_info);
+  }
+  __syncthreads();
+  return max_cost;
+}
+
+// ============================================================================
+// Phase 1: Linear scan fill with LPT-sorted input (thread 0 only)
+// ============================================================================
+
+__device__ void phase1_linear_fill(
+    PlanSharedState& s, int num_buckets, int max_splits) {
+
+  int tid = static_cast<int>(threadIdx.x);
+  if (tid < num_buckets) {
+    s.sm_cost[tid] = kSMGlobalOverhead;
+    s.sm_task_count[tid] = 0;
+  }
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    int n = s.num_unsplit;
+    int total_iters = 0;
+    for (int u = 0; u < n; u++)
+      total_iters += s.unsplit_kv_iters[u];
+
+    int avg_iters = (total_iters + num_buckets - 1) / num_buckets;
+    int target_budget = kTileGlobalOverhead + avg_iters * kPerIterOverhead * 1.02;
+    int cur_sm = 0;
+    int sm_budget = target_budget;
+    int min_piece_cost = kTileGlobalOverhead + MIN_ITERS_PER_SPLIT * kPerIterOverhead;
+
+    for (int u = 0; u < n; u++) {
+      int tile_iters = s.unsplit_kv_iters[u];
+      if (tile_iters <= 0) { s.unsplit_sub_counter[u] = 1; continue; }
+
+      int tile_pos = 0;
+      int sub_id = 0;
+
+      while (tile_pos < tile_iters) {
+        while (cur_sm < num_buckets && s.sm_task_count[cur_sm] >= MAX_TASKS_PER_SM) {
+          cur_sm++;
+          sm_budget = target_budget;
+        }
+        if (cur_sm >= num_buckets) {
+          int best_sm = 0;
+          for (int i = 1; i < num_buckets; i++)
+            if (s.sm_task_count[i] < s.sm_task_count[best_sm]) best_sm = i;
+          if (s.sm_task_count[best_sm] >= MAX_TASKS_PER_SM) break;
+          cur_sm = best_sm;
+          sm_budget = 0x7fffffff;
+        }
+
+        int avail = tile_iters - tile_pos;
+        int max_iters = (sm_budget - kTileGlobalOverhead) / kPerIterOverhead;
+        if (max_iters < MIN_ITERS_PER_SPLIT) max_iters = MIN_ITERS_PER_SPLIT;
+        if (sub_id + 1 >= max_splits) max_iters = avail;
+        int take = avail < max_iters ? avail : max_iters;
+
+        add_task(s, cur_sm, tile_pos, tile_pos + take, u, sub_id++);
+        int piece_cost = kPerIterOverhead * take + kTileGlobalOverhead;
+        s.sm_cost[cur_sm] += piece_cost;
+        sm_budget -= piece_cost;
+        tile_pos += take;
+
+        if (sm_budget < min_piece_cost) {
+          cur_sm++;
+          sm_budget = target_budget;
+        }
+      }
+      s.unsplit_sub_counter[u] = sub_id;
+    }
+  }
+  __syncthreads();
+}
+
+// ============================================================================
+// Phase 1b: Proportional fill — each tile gets SMs proportional to its iters
+// Avoids tile-boundary crossings (1 task per SM), near-optimal balance.
+// ============================================================================
+
+__device__ void phase1_proportional_fill(
+    PlanSharedState& s, int num_buckets, int max_splits) {
+
+  int tid = static_cast<int>(threadIdx.x);
+  if (tid < num_buckets) {
+    s.sm_cost[tid] = kSMGlobalOverhead;
+    s.sm_task_count[tid] = 0;
+  }
+  __syncthreads();
+
+  if (threadIdx.x == 0) {
+    int n = s.num_unsplit;
+    int total_iters = 0;
+    for (int u = 0; u < n; u++)
+      total_iters += s.unsplit_kv_iters[u];
+
+    if (total_iters == 0) { __syncthreads(); return; }
+
+    int sm_pos = 0;
+    long long cumul_iters = 0;
+
+    for (int u = 0; u < n; u++) {
+      int tile_iters = s.unsplit_kv_iters[u];
+      if (tile_iters <= 0) { s.unsplit_sub_counter[u] = 1; continue; }
+
+      cumul_iters += tile_iters;
+      int target_end = (u == n - 1) ? num_buckets
+          : static_cast<int>(cumul_iters * num_buckets / total_iters);
+      int tile_sms = target_end - sm_pos;
+      if (tile_sms < 1) tile_sms = 1;
+      if (sm_pos + tile_sms > num_buckets) tile_sms = num_buckets - sm_pos;
+      int actual_splits = tile_sms < max_splits ? tile_sms : max_splits;
+
+      int base = tile_iters / actual_splits;
+      int extra = tile_iters % actual_splits;
+      int kv_pos = 0;
+      for (int j = 0; j < actual_splits; j++) {
+        int take = base + (j < extra ? 1 : 0);
+        int sm = sm_pos + (j < actual_splits ? (long long)j * tile_sms / actual_splits : j);
+        add_task(s, sm, kv_pos, kv_pos + take, u, j);
+        s.sm_cost[sm] += kPerIterOverhead * take + kTileGlobalOverhead;
+        kv_pos += take;
+      }
+      s.unsplit_sub_counter[u] = actual_splits;
+      sm_pos += tile_sms;
+    }
+  }
+  __syncthreads();
+}
+
+// ============================================================================
+// Phase 2: Iterative rebalance
+// ============================================================================
+
+__device__ void phase2_rebalance(
+    PlanSharedState& s, int num_buckets, int max_splits) {
+
+  for (int iter = 0; iter < MAX_REBALANCE_ITERS; iter++) {
+    int max_sm = find_max_cost_sm(s, num_buckets);
+    int min_sm = find_min_cost_sm(s, num_buckets);
+
+    __shared__ int _done;
+    if (threadIdx.x == 0) {
+      _done = 0;
+      int gap = s.sm_cost[max_sm] - s.sm_cost[min_sm];
+      if (gap <= kTileGlobalOverhead) { _done = 1; }
+      else {
+        int n = s.sm_task_count[max_sm];
+
+        // Strategy 1: move a whole task if it reduces gap
+        int best_move = -1;
+        int best_new_gap = gap;
+        for (int t = 0; t < n; t++) {
+          int iters = s.task_kv_end[max_sm][t] - s.task_kv_begin[max_sm][t];
+          int task_cost = kPerIterOverhead * iters + kTileGlobalOverhead;
+          int new_max = s.sm_cost[max_sm] - task_cost;
+          int new_min = s.sm_cost[min_sm] + task_cost;
+          if (new_max >= new_min) {
+            int new_gap = new_max - new_min;
+            if (new_gap < best_new_gap) {
+              best_move = t;
+              best_new_gap = new_gap;
+            }
+          }
+        }
+
+        if (best_move >= 0) {
+          // Move entire task
+          int16_t kb = s.task_kv_begin[max_sm][best_move];
+          int16_t ke = s.task_kv_end[max_sm][best_move];
+          int16_t uid = s.task_unsplit_id[max_sm][best_move];
+          int8_t sid = s.task_sub_id[max_sm][best_move];
+          int iters = ke - kb;
+          int task_cost = kPerIterOverhead * iters + kTileGlobalOverhead;
+
+          // Remove from max_sm (swap with last)
+          int last = s.sm_task_count[max_sm] - 1;
+          if (best_move != last) {
+            s.task_kv_begin[max_sm][best_move] = s.task_kv_begin[max_sm][last];
+            s.task_kv_end[max_sm][best_move] = s.task_kv_end[max_sm][last];
+            s.task_unsplit_id[max_sm][best_move] = s.task_unsplit_id[max_sm][last];
+            s.task_sub_id[max_sm][best_move] = s.task_sub_id[max_sm][last];
+          }
+          s.sm_task_count[max_sm]--;
+          add_task(s, min_sm, kb, ke, uid, sid);
+          s.sm_cost[max_sm] -= task_cost;
+          s.sm_cost[min_sm] += task_cost;
+        } else {
+          // Strategy 2: split — target half the gap
+          int move_iters = (gap - kTileGlobalOverhead) / (2 * kPerIterOverhead);
+          if (move_iters < MIN_ITERS_PER_SPLIT) { _done = 1; }
+          else {
+            int best = find_best_fit_task(s, max_sm, move_iters, max_splits);
+            if (best < 0) { _done = 1; }
+            else {
+              int task_iters = s.task_kv_end[max_sm][best] - s.task_kv_begin[max_sm][best];
+              int keep = task_iters - move_iters;
+              if (keep < MIN_ITERS_PER_SPLIT) keep = MIN_ITERS_PER_SPLIT;
+              int actual_move = task_iters - keep;
+              if (actual_move < MIN_ITERS_PER_SPLIT) { _done = 1; }
+              else {
+                if (!split_task(s, max_sm, best, keep, min_sm, max_splits)) { _done = 1; }
+                else {
+                s.sm_cost[max_sm] -= actual_move * kPerIterOverhead;
+                s.sm_cost[min_sm] += actual_move * kPerIterOverhead + kTileGlobalOverhead;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    __syncthreads();
+    if (_done) break;
+  }
+}
+
+// ============================================================================
+// Phase 2 (parallel): all threads participate, each handles its own SM
+// Excess/deficit SMs paired via prefix sum, all splits happen simultaneously
+// ============================================================================
+
+__device__ void phase2_rebalance_parallel(
+    PlanSharedState& s, int num_buckets, int max_splits) {
+
+  int tid = static_cast<int>(threadIdx.x);
+  __shared__ int16_t _deficit_sms[MAX_SMS];
+  __shared__ int _n_deficit;
+  __shared__ int _gap;
+
+  constexpr int MAX_PARALLEL_ITERS = 8;
+  for (int iter = 0; iter < MAX_PARALLEL_ITERS; iter++) {
+    int max_sm = find_max_cost_sm(s, num_buckets);
+    int min_sm = find_min_cost_sm(s, num_buckets);
+    if (tid == 0) _gap = s.sm_cost[max_sm] - s.sm_cost[min_sm];
+    __syncthreads();
+    if (_gap <= kTileGlobalOverhead) break;
+
+    // Parallel sum → average cost
+    int my_cost = (tid < num_buckets) ? s.sm_cost[tid] : 0;
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+      my_cost += __shfl_xor_sync(0xffffffff, my_cost, offset);
+    if (tid % 32 == 0) s.warp_scratch[tid / 32] = my_cost;
+    __syncthreads();
+    if (tid < 8) {
+      int v = (tid * 32 < num_buckets) ? (int)s.warp_scratch[tid] : 0;
+      #pragma unroll
+      for (int offset = 4; offset > 0; offset >>= 1)
+        v += __shfl_xor_sync(0xff, v, offset);
+      if (tid == 0) s.warp_scratch[0] = v / num_buckets;
+    }
+    __syncthreads();
+    int avg_cost = (int)s.warp_scratch[0];
+
+    // Parallel deficit collection via prefix sum
+    int is_deficit = (tid < num_buckets && s.sm_cost[tid] < avg_cost) ? 1 : 0;
+    int deficit_idx;
+    cub::BlockScan<int, MAX_SMS>(s.scan_temp).ExclusiveSum(is_deficit, deficit_idx);
+    __syncthreads();
+    if (is_deficit) _deficit_sms[deficit_idx] = tid;
+    if (tid == num_buckets - 1) _n_deficit = deficit_idx + is_deficit;
+    __syncthreads();
+    if (_n_deficit == 0) break;
+
+    // Each above-average SM gets a unique index via prefix sum
+    int is_excess = (tid < num_buckets && s.sm_cost[tid] > avg_cost) ? 1 : 0;
+    int excess_idx;
+    cub::BlockScan<int, MAX_SMS>(s.scan_temp).ExclusiveSum(is_excess, excess_idx);
+    __syncthreads();
+
+    // Each excess thread independently splits/moves to its unique deficit target
+    if (is_excess && excess_idx < _n_deficit) {
+      int sm = tid;
+      int target_sm = _deficit_sms[excess_idx];
+      int n_tasks = s.sm_task_count[sm];
+      int sm_gap = s.sm_cost[sm] - s.sm_cost[target_sm];
+
+      // Strategy 1: move a whole task if it reduces the pair gap
+      int best_move = -1;
+      int best_new_gap = sm_gap;
+      for (int t = 0; t < n_tasks; t++) {
+        int iters = s.task_kv_end[sm][t] - s.task_kv_begin[sm][t];
+        int task_cost = static_cast<int>(kPerIterOverhead * iters + kTileGlobalOverhead);
+        int new_src = s.sm_cost[sm] - task_cost;
+        int new_dst = s.sm_cost[target_sm] + task_cost;
+        if (new_src >= new_dst && (new_src - new_dst) < best_new_gap) {
+          best_move = t;
+          best_new_gap = new_src - new_dst;
+        }
+      }
+
+      if (best_move >= 0) {
+        int16_t kb = s.task_kv_begin[sm][best_move];
+        int16_t ke = s.task_kv_end[sm][best_move];
+        int16_t uid = s.task_unsplit_id[sm][best_move];
+        int8_t sid = s.task_sub_id[sm][best_move];
+        int task_cost = static_cast<int>(kPerIterOverhead * (ke - kb) + kTileGlobalOverhead);
+        int last = s.sm_task_count[sm] - 1;
+        if (best_move != last) {
+          s.task_kv_begin[sm][best_move] = s.task_kv_begin[sm][last];
+          s.task_kv_end[sm][best_move] = s.task_kv_end[sm][last];
+          s.task_unsplit_id[sm][best_move] = s.task_unsplit_id[sm][last];
+          s.task_sub_id[sm][best_move] = s.task_sub_id[sm][last];
+        }
+        s.sm_task_count[sm]--;
+        add_task(s, target_sm, kb, ke, uid, sid);
+        s.sm_cost[sm] -= task_cost;
+        s.sm_cost[target_sm] += task_cost;
+      } else {
+        // Strategy 2: split
+        int move_iters = static_cast<int>((sm_gap - kTileGlobalOverhead) / (2 * kPerIterOverhead));
+        if (move_iters >= MIN_ITERS_PER_SPLIT) {
+          int best = find_best_fit_task(s, sm, move_iters, max_splits);
+          if (best >= 0) {
+            int task_iters = s.task_kv_end[sm][best] - s.task_kv_begin[sm][best];
+            int keep = task_iters - move_iters;
+            if (keep < MIN_ITERS_PER_SPLIT) keep = MIN_ITERS_PER_SPLIT;
+            int actual_move = task_iters - keep;
+            if (actual_move >= MIN_ITERS_PER_SPLIT) {
+              if (split_task(s, sm, best, keep, target_sm, max_splits)) {
+              s.sm_cost[sm] -= static_cast<int>(actual_move * kPerIterOverhead);
+              s.sm_cost[target_sm] += static_cast<int>(actual_move * kPerIterOverhead + kTileGlobalOverhead);
+              }
+            }
+          }
+        }
+      }
+    }
+    __syncthreads();
+  }
+}
+
+// ============================================================================
+// Phase 3: Write split output (all threads for parallel write, thread 0 for num_kv_splits_per_row)
+// ============================================================================
+
+__device__ void phase3_write_output(
+    PlanSharedState& s, int num_buckets,
+    uint64_t* packed_work_range, uint64_t* packed_work_info,
+    int* kv_tile_begin_indices, int* kv_tile_end_indices,
+    int* kv_split_indices, int* num_kv_splits_per_row,
+    int* qo_segment_offsets, int* qo_lens, int qo_tile_size) {
+
+  parallel_write_output(s, num_buckets,
+      packed_work_range, packed_work_info,
+      kv_tile_begin_indices, kv_tile_end_indices, kv_split_indices);
+
+  if (threadIdx.x == 0 && num_kv_splits_per_row && qo_segment_offsets && qo_lens) {
+    int n = s.num_unsplit;
+    for (int u = 0; u < n; u++) {
+      int b = s.unsplit_batch[u];
+      int qt = s.unsplit_qo_tile[u];
+      int splits = s.unsplit_sub_counter[u];
+      int seg_off = qo_segment_offsets[b];
+      int qo_len = qo_lens[b];
+      int row_start = qt * qo_tile_size;
+      int row_end = row_start + qo_tile_size;
+      if (row_end > qo_len) row_end = qo_len;
+      for (int r = row_start; r < row_end; r++) {
+        // Take max across heads for same (batch, qo_tile) row
+        int cur = num_kv_splits_per_row[seg_off + r];
+        if (splits > cur) num_kv_splits_per_row[seg_off + r] = splits;
+      }
+    }
+  }
+  __syncthreads();
+}
+
+// ============================================================================
+// Main plan kernel
+// ============================================================================
+
+__global__ void plan_kernel(
+    int* qo_segment_offsets, int* qo_lens, int* kv_lens,
+    uint64_t* packed_work_range, uint64_t* packed_work_info,
+    int qo_tile_size, int kv_tile_size, int batch_size, int num_heads,
+    int num_buckets, bool causal, int* qo_offsets,
+    int num_kv_splits, int* kv_tile_begin_indices, int* kv_tile_end_indices,
+    int* kv_split_indices, int adaptive_chunk_size, float* out_max_sm_cost,
+    int* num_kv_splits_per_row,
+    float* workspace_lse = nullptr, int lse_total_size = 0,
+    int pack_factor = 1) {
+
+  extern __shared__ char __plan_smem[];
+  PlanSharedState& state = *reinterpret_cast<PlanSharedState*>(__plan_smem);
+
+  if (num_kv_splits_per_row && qo_segment_offsets) {
+    int total_rows = qo_segment_offsets[batch_size];
+    for (int i = static_cast<int>(threadIdx.x); i < total_rows; i += static_cast<int>(blockDim.x))
+      num_kv_splits_per_row[i] = 1;
+    __syncthreads();
+  }
+
+  if (workspace_lse) {
+    for (int i = static_cast<int>(threadIdx.x); i < lse_total_size; i += static_cast<int>(blockDim.x))
+      workspace_lse[i] = -INFINITY;
+  }
+
+#ifdef SM_TIMING_ENABLED
+  long long __plan_start = clock64();
+#endif
+
+  bool adaptive_mode = (num_kv_splits < 0);
+  int max_splits = adaptive_mode ? -num_kv_splits : num_kv_splits;
+
+  if (!adaptive_mode) {
+    int cost = direct_greedy(state, num_buckets,
+        qo_lens, kv_lens, qo_offsets, qo_tile_size, kv_tile_size,
+        batch_size, num_heads, causal, num_kv_splits,
+        packed_work_range, packed_work_info,
+        kv_tile_begin_indices, kv_tile_end_indices, kv_split_indices,
+        num_kv_splits_per_row, qo_segment_offsets, pack_factor);
+    if (threadIdx.x == 0 && out_max_sm_cost) {
+      out_max_sm_cost[0] = static_cast<float>(cost);
+      out_max_sm_cost[1] = static_cast<float>(cost);
+    }
+  } else {
+#ifdef SM_TIMING_ENABLED
+    long long _t0 = clock64();
+#endif
+    // Adaptive split path
+    enumerate_unsplit_tiles(state, qo_lens, kv_lens, qo_offsets,
+                            qo_tile_size, kv_tile_size, batch_size, num_heads, causal,
+                            pack_factor);
+    __syncthreads();
+
+#ifdef SM_TIMING_ENABLED
+    long long _t1 = clock64();
+#endif
+    // Greedy nosplit: assign tasks + write nosplit output + return cost
+    int nosplit_cost = phase0_nosplit_greedy<true, true>(
+        state, num_buckets, num_heads,
+        packed_work_range, packed_work_info);
+
+#ifdef SM_TIMING_ENABLED
+    long long _t2 = clock64();
+#endif
+    // Quick check: can split possibly beat nosplit?
+    // Best-case split cost = total_cost/M + kSplitExtraOverhead
+    // If that already >= nosplit_cost * threshold, skip rebalance entirely
+    int min_sm = find_min_cost_sm(state, num_buckets);
+    int min_cost = state.sm_cost[min_sm];
+    int gap = nosplit_cost - min_cost;
+
+    bool skip_rebalance = (gap <= kSplitExtraOverhead);
+    if (!skip_rebalance) {
+      // phase1_proportional_fill(state, num_buckets, max_splits);
+      if (state.num_unsplit < num_buckets * 0.8)
+        phase1_linear_fill(state, num_buckets, max_splits);
+      phase2_rebalance_parallel(state, num_buckets, max_splits);
+    }
+
+#ifdef SM_TIMING_ENABLED
+    long long _t3 = clock64();
+#endif
+    int split_max_sm = find_max_cost_sm(state, num_buckets);
+    int split_cost = state.sm_cost[split_max_sm] + kSplitExtraOverhead;
+
+    bool split = false;
+    if (split_cost < nosplit_cost * 0.99) {
+      phase3_write_output(state, num_buckets,
+                          packed_work_range, packed_work_info,
+                          kv_tile_begin_indices, kv_tile_end_indices, kv_split_indices,
+                          num_kv_splits_per_row, qo_segment_offsets, qo_lens, qo_tile_size);
+      split = true;
+    }
+    if (threadIdx.x == 0 && out_max_sm_cost) {
+      out_max_sm_cost[0] = split ? 1 : 0;
+      out_max_sm_cost[1] = nosplit_cost / float(split_cost);
+    }
+#ifdef SM_TIMING_ENABLED
+    long long _t4 = clock64();
+    if (threadIdx.x == 0)
+      printf("SM_PLAN_PHASES enumerate=%lld phase0=%lld rebalance=%lld decide+write=%lld n=%d\n",
+             _t1-_t0, _t2-_t1, _t3-_t2, _t4-_t3, state.num_unsplit);
+#endif
+  }
+
+#ifdef SM_TIMING_ENABLED
+  if (threadIdx.x == 0) {
+    long long __plan_end = clock64();
+    printf("SM_PLAN_TIME duration=%lld\n", __plan_end - __plan_start);
+    for (int sm = 0; sm < num_buckets; sm++) {
+      if (state.sm_task_count[sm] > 0)
+        printf("SM_PLAN sm=%d model_cost=%d num_tiles=%d kv_iters=0\n",
+               sm, state.sm_cost[sm], static_cast<int>(state.sm_task_count[sm]));
+    }
+  }
+#endif
+}
+
+// ============================================================================
+// Host wrapper (unchanged signature)
+// ============================================================================
+
+cudaError_t plan_kernel_wrapper(int* qo_segment_offsets, int* qo_lens,
+                                int* kv_lens, uint64_t* packed_work_range,
+                                uint64_t* packed_work_info, int qo_tile_size,
+                                int kv_tile_size, int batch_size, int num_heads, int num_buckets,
+                                bool causal, int* qo_offsets, bool enable_pdl,
+                                cudaStream_t stream,
+                                int num_kv_splits = 1,
+                                int* kv_tile_begin_indices = nullptr,
+                                int* kv_tile_end_indices = nullptr,
+                                int* kv_split_indices = nullptr,
+                                int adaptive_chunk_size = 0,
+                                float* out_max_sm_cost = nullptr,
+                                int* num_kv_splits_per_row = nullptr,
+                                float* workspace_lse = nullptr,
+                                int lse_total_size = 0,
+                                int pack_factor = 1) {
+  int smem_size = sizeof(PlanSharedState);
+  static bool smem_attr_set = false;
+  if (!smem_attr_set && smem_size >= (48 << 10)) {
+    cudaFuncSetAttribute(plan_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+    smem_attr_set = true;
+  }
+  plan_kernel<<<1, MAX_SMS, smem_size, stream>>>(
+      qo_segment_offsets, qo_lens, kv_lens,
+      packed_work_range, packed_work_info,
+      qo_tile_size, kv_tile_size, batch_size, num_heads,
+      num_buckets, causal, qo_offsets, num_kv_splits,
+      kv_tile_begin_indices, kv_tile_end_indices, kv_split_indices,
+      adaptive_chunk_size, out_max_sm_cost, num_kv_splits_per_row,
+      workspace_lse, lse_total_size, pack_factor);
+  FLASHINFER_CUDA_CALL(cudaGetLastError());
+  return cudaSuccess;
+}
+
+}  // namespace flashinfer

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/pow_2.hpp
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/pow_2.hpp
@@ -1,0 +1,89 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <cute/config.hpp>
+#include <cute/numeric/integral_constant.hpp>
+
+namespace cutlass::fmha {
+
+struct Pow2 {
+  int n;
+  int log2_n;
+
+  explicit CUTE_DEVICE Pow2(int n) : n(n) {
+#ifdef __CUDA_ARCH__
+    log2_n = __ffs(n) - 1;
+#endif
+  }
+
+  template <class T>
+  CUTE_HOST_DEVICE T operator*(T const& b) const {
+    return n * b;
+  }
+
+  template <int N>
+  CUTE_HOST_DEVICE auto operator*(Int<N> const&) const {
+    if constexpr (N & (N - 1) == 0) {
+      return Pow2{n * N};
+    }
+    return n * N;
+  }
+};
+
+template <class T>
+CUTE_HOST_DEVICE auto operator/(T const& a, Pow2 const& b) {
+  return a >> b.log2_n;
+}
+
+template <class T>
+CUTE_HOST_DEVICE auto operator%(T const& a, Pow2 const& b) {
+  return a & (b.n - 1);
+}
+
+template <class T>
+CUTE_HOST_DEVICE bool operator<(T const& a, Pow2 const& b) {
+  return a < b.n;
+}
+
+CUTE_HOST_DEVICE void print(Pow2 const& a) { printf("2^%d", a.log2_n); }
+
+}  // end namespace cutlass::fmha
+
+namespace cute {
+
+template <>
+struct is_integral<cutlass::fmha::Pow2> : true_type {};
+
+}  // end namespace cute

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/sm100_fmha_fwd_epilogue_tma_warpspecialized.hpp
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/sm100_fmha_fwd_epilogue_tma_warpspecialized.hpp
@@ -1,0 +1,620 @@
+/***************************************************************************************************
+ * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#pragma once
+
+#include <cuda.h>  // CUtensorMap, cuTensorMapEncodeTiled
+#include "cute/layout.hpp"
+#include "cute/swizzle.hpp"
+#include "cutlass/cutlass.h"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "fmha_common.hpp"
+#include "gpu_trace.h"
+
+GPU_TRACE_SCOPE_DEC(EPILOGUE);
+
+namespace cutlass::fmha::collective {
+
+namespace detail {
+
+// constexpr cute::Swizzle<B,M,S> → CUtensorMapSwizzle
+// Mirrors cute::TMA::to_CUtensorMapSwizzle but is usable in compile-time contexts.
+// Only the swizzle patterns produced by sm100_smem_selector for K-major atoms.
+template <int B, int M, int S>
+constexpr CUtensorMapSwizzle to_cu_tensor_map_swizzle(cute::Swizzle<B, M, S>) {
+  if constexpr (B == 0)                          return CU_TENSOR_MAP_SWIZZLE_NONE;
+  else if constexpr (B == 1 && M == 4 && S == 3) return CU_TENSOR_MAP_SWIZZLE_32B;
+  else if constexpr (B == 2 && M == 4 && S == 3) return CU_TENSOR_MAP_SWIZZLE_64B;
+  else if constexpr (B == 3 && M == 4 && S == 3) return CU_TENSOR_MAP_SWIZZLE_128B;
+  else {
+    // Dependent-name static_assert so it only fires on bad instantiations.
+    static_assert(B + M + S < 0,
+                  "Unsupported cute::Swizzle pattern for TMA descriptor "
+                  "(only SW128/SW64/SW32/NONE produced by sm100_smem_selector "
+                  "are mapped).");
+    return CU_TENSOR_MAP_SWIZZLE_NONE;
+  }
+}
+
+// constexpr dtype → CUtensorMapDataType for our supported epilogue outputs.
+// Production paths only ever instantiate Element = bf16, but keep bf16/fp16/fp8
+// branches so fallback / future use stay sound.
+template <class T>
+constexpr CUtensorMapDataType to_cu_tensor_map_dtype() {
+  if constexpr (cute::is_same_v<T, cutlass::bfloat16_t>) return CU_TENSOR_MAP_DATA_TYPE_BFLOAT16;
+  else if constexpr (cute::is_same_v<T, cutlass::half_t>) return CU_TENSOR_MAP_DATA_TYPE_FLOAT16;
+  else if constexpr (cute::is_same_v<T, cutlass::float_e4m3_t>) return CU_TENSOR_MAP_DATA_TYPE_UINT8;
+  else if constexpr (cute::is_same_v<T, cutlass::float_e5m2_t>) return CU_TENSOR_MAP_DATA_TYPE_UINT8;
+  else if constexpr (sizeof(T) == 1) return CU_TENSOR_MAP_DATA_TYPE_UINT8;
+  else if constexpr (sizeof(T) == 2) return CU_TENSOR_MAP_DATA_TYPE_FLOAT16;
+  else {
+    static_assert(sizeof(T) < 0, "Unsupported epilogue Element type for TMA fused unpack");
+    return CU_TENSOR_MAP_DATA_TYPE_UINT8;
+  }
+}
+
+}  // namespace detail
+
+template <class Element, class ElementAcc, class TileShape, int NumQStages_ = 2, bool IsSplitKV_ = false, bool NeedOutput_ = true, int kPackFactor_ = 1>
+struct Sm100FmhaFwdEpilogueTmaWarpspecialized {
+  static constexpr bool IsSplitKV = IsSplitKV_;
+  static constexpr int  kPackFactor = kPackFactor_;
+  // Direct-O unpack lives in this epilogue ONLY for non-split path. Split-KV
+  // routes unpack into the reduction kernel, so split variants must elide this
+  // entire codepath at compile time.
+  static constexpr bool kEnableDirectO = !IsSplitKV_ && (kPackFactor_ > 1);
+  using ElementOut = Element;
+  using Pipeline = cutlass::PipelineAsync<NumQStages_>;
+  // using ShapeT = cute::Shape<int32_t, int32_t, cute::Shape<int32_t, int32_t>>;
+  // using StrideO = cute::Shape<int32_t, _1, cute::Shape<int32_t, int32_t>>;
+  // using LayoutO = cute::Layout<ShapeT, StrideO>;
+  using ShapeT = cute::Shape<int32_t, int32_t, cute::Shape<cute::Shape<int32_t, int32_t>, int32_t>>;
+  using StrideO = cute::Shape<int32_t, _1, cute::Shape<cute::Shape<int32_t, int32_t>, int32_t>>;
+  using LayoutO = cute::Layout<ShapeT, StrideO>;
+
+  using ShapeLSE = cute::Shape<int32_t, cute::Shape<int32_t, int32_t>>;
+  using StrideLSE = cute::Shape<int32_t, cute::Shape<_1, int32_t>>;
+  using LayoutLSE = cute::Layout<ShapeLSE, StrideLSE>;
+
+  using ShapeMaxScore = cute::Shape<int32_t, cute::Shape<int32_t, int32_t>, int32_t>;
+  using StrideMaxScore = cute::Shape<int32_t, cute::Shape<int32_t, int32_t>, int32_t>;
+  using LayoutMaxScore = cute::Layout<ShapeMaxScore, StrideMaxScore>;
+
+  //  using SmemLayoutO = decltypa(make_layout(append<3>(select<0,1>(TileShape_WG{}), _2{})));
+  using SmemLayoutAtomO = decltype(cutlass::gemm::collective::detail::sm100_smem_selector<
+                                   cute::UMMA::Major::K, Element, tuple_element_t<0, TileShape>,
+                                   tuple_element_t<1, TileShape>>());
+  //  using SmemLayoutAtomO = decltype(make_ordered_layout(select<0,1>(TileShape{}), Step<_1,
+  //  _0>{}));
+  using SmemLayoutO =
+      decltype(tile_to_shape(SmemLayoutAtomO{}, replace<2>(TileShape{}, cute::Int<NumQStages_>{}), Step<_2, _1, _3>{}));
+  using SmemLayoutO_ = SmemLayoutO;
+  static constexpr size_t kSmemOCosize = cute::cosize_v<SmemLayoutO>;
+
+  static constexpr int kQRows = cute::size<0>(TileShape{});
+
+  // ---- Compile-time atom + swizzle extraction (TMA fused unpack path) ----
+  // SmemLayoutAtomO is cute::ComposedLayout<Swizzle, Offset, InnerLayout>.
+  // InnerLayout shape is (atom_rows, atom_cols); Swizzle is e.g. Swizzle<3,4,3> (SW128).
+  using AtomInnerLayout = decltype(cute::get_nonswizzle_portion(SmemLayoutAtomO{}));
+  using AtomSwizzle     = decltype(cute::get_swizzle_portion(SmemLayoutAtomO{}));
+  static constexpr int kAtomRows = cute::size<0>(AtomInnerLayout{});
+  static constexpr int kAtomCols = cute::size<1>(AtomInnerLayout{});
+
+  struct TensorStorageBase {
+    using SmemLayoutO = SmemLayoutO_;
+    // NeedOutput_=false (OnlyScore mode): all real smem_o accesses (TMA store
+    // at 549/561, direct-O PTX at 395/417) are gated by `if constexpr (NeedOutput_)`
+    // or `if constexpr (kEnableDirectO && NeedOutput_)`. Line 520 `make_tensor`
+    // and partition_S/D only need a valid pointer + shape, no byte access, so
+    // a 1-byte placeholder is safe and frees ~32-64KB SMEM for K-pipeline.
+    cute::array_aligned<Element, NeedOutput_ ? cute::cosize_v<SmemLayoutO> : 1> smem_o;
+  };
+
+  struct TensorStorageSplitKV : TensorStorageBase {
+    float smem_lse[kQRows];
+  };
+
+  using TensorStorage = std::conditional_t<IsSplitKV, TensorStorageSplitKV, TensorStorageBase>;
+  struct Arguments {
+    Element* ptr_O;
+    LayoutO layout_O;
+
+    int max_qo_len;
+    ElementAcc* ptr_MaxScore = nullptr;
+    LayoutMaxScore layout_MaxScore;
+
+    ElementAcc* ptr_MaxScore_direct = nullptr;
+    int total_qo_len_orig = 0;
+    int max_score_stride_t = 0;
+    int max_score_stride_h = 0;
+    int max_score_stride_k = 0;
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+    int max_score_numel = 0;
+#endif
+
+    Element* ptr_O_direct = nullptr;
+    int num_qo_heads_orig = 0;
+    int head_dim_vo = 0;
+    int remaining_h_r = 0;
+
+    // TMA fused direct-O unpack: host eligibility flag (qo_len equal across
+    // batches + env var ok). Per-batch unpacked qo_len is derived as
+    // max_qo_len / kPackFactor_ at descriptor build time (kPackFactor_ is a
+    // compile-time template constant, max_qo_len is the packed length).
+    bool qo_len_uniform = false;
+  };
+
+  using TMA_O = decltype(make_tma_copy(
+      SM90_TMA_STORE{}, make_tensor((Element*)nullptr, repeat_like(StrideO{}, 0), StrideO{}),
+      SmemLayoutO{}(_, _, _0{})));
+
+  // ---- TMA fused direct-O unpack (Phase 2: hand-rolled CUtensorMap + PTX) ----
+  // Replaces cuTe TMA descriptor (which had unsolvable composition + partition
+  // contract issues) with raw NVIDIA driver API + PTX. The hardware path is
+  // identical; we just skip the cuTe layout abstraction layer.
+  //
+  // Descriptor encoded host-side via cuTensorMapEncodeTiled with a 5D box that
+  // mirrors SMEM atom tiling exactly:
+  //   GMEM rank 5 = (atom_cols, num_heads_orig, num_horiz_atoms,
+  //                  num_vert_atoms_per_tok, total_qo_len_orig)
+  //   Box        = (atom_cols, atom_rows, num_horiz_atoms,
+  //                 num_vert_atoms_per_tok, max_qo_len/kPackFactor)
+  //   Swizzle    = matches SmemLayoutAtomO (e.g. K-major SW128 for bf16 hd=128)
+  //
+  // Device-side: single PTX cp.async.bulk.tensor.5d.
+  static constexpr int kNumActualTokMax = (kPackFactor_ > 0) ? (kQRows / kPackFactor_) : kQRows;
+  static constexpr int kHeadDimCT = cute::size<1>(TileShape{});
+
+  // 5D split parameters derived purely from atom shape + (pf, head_dim, dtype).
+  // - kNumHorizAtoms: head_dim spans this many atom-cols-wide tiles
+  // - kNumVertAtomsPerTok: one actual_tok covers pf packed_rows = this many atom-rows tiles
+  static constexpr int kNumHorizAtoms       = (kAtomCols > 0) ? (kHeadDimCT / kAtomCols) : 0;
+  static constexpr int kNumVertAtomsPerTok  = (kAtomRows > 0) ? (kPackFactor_ / kAtomRows) : 0;
+
+  // Compile-time TMA path eligibility. If any condition fails the entire host
+  // descriptor build and device PTX path are pruned and we silently fall back
+  // to the vec16 software scatter loop. Conditions:
+  //   1) pf > 1                              -- pf=1 has no pack to unpack
+  //   2) IsSplitKV_ = false                  -- split-KV routes unpack elsewhere
+  //   3) pf % atom_rows == 0                 -- avoids fractional vert atoms
+  //   4) head_dim % atom_cols == 0           -- avoids fractional horiz atoms
+  //   5) pf >= atom_rows                     -- ensures >=1 vert atom per actual_tok
+  //   6) atom_cols * sizeof(Element) == 128  -- SW128 inner == 128 bytes
+  static constexpr bool kTmaPathCompileEligible =
+      kEnableDirectO &&
+      (kAtomRows > 0) && (kAtomCols > 0) &&
+      (kPackFactor_ % kAtomRows == 0) &&
+      (kHeadDimCT  % kAtomCols == 0) &&
+      (kPackFactor_ >= kAtomRows) &&
+      (kAtomCols * (int)sizeof(Element) == 128);
+
+  struct Params {
+    TMA_O tma_store_o;
+    LayoutO layout_O;
+    ElementAcc* ptr_LSE = nullptr;
+    LayoutLSE layout_LSE;
+    int max_qo_len;
+    ElementAcc* ptr_MaxScore = nullptr;
+    LayoutMaxScore layout_MaxScore;
+
+    ElementAcc* ptr_MaxScore_direct = nullptr;
+    int total_qo_len_orig = 0;
+    int max_score_stride_t = 0;
+    int max_score_stride_h = 0;
+    int max_score_stride_k = 0;
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+    int max_score_numel = 0;
+#endif
+
+    Element* ptr_O_direct = nullptr;
+    int num_qo_heads_orig = 0;
+    int head_dim_vo = 0;
+    int remaining_h_r = 0;
+
+    // Hand-rolled TMA descriptor for unpacked O write. Always 128 bytes / 16 QWORDs.
+    // valid=true means descriptor was successfully built host-side.
+    CUtensorMap tma_desc_o_direct;
+    bool tma_store_o_direct_valid = false;
+  };
+
+  template <class ProblemShape>
+  static Params to_underlying_arguments(ProblemShape const& problem_shape, Arguments const& args,
+                                        void* workspace = nullptr) {
+    static_assert(is_variable_length_v<tuple_element_t<0, ProblemShape>>);
+    auto ptr_O = args.ptr_O;
+    LayoutO layout_O = args.layout_O;
+
+    TMA_O tma_store_o;
+    if (ptr_O != nullptr) {
+      tma_store_o =
+          make_tma_copy(SM90_TMA_STORE{}, make_tensor(ptr_O, layout_O), SmemLayoutO{}(_, _, _0{}));
+    }
+
+    // Phase 2: construct TMA descriptor via NVIDIA driver API cuTensorMapEncodeTiled.
+    //
+    // CRITICAL: SmemLayoutO uses tile_to_shape with atom (kAtomRows × kAtomCols).
+    // SMEM bytes are NOT laid out as (packed_row, head_dim) row-major. Atom tiling
+    // order (with Step<_2,_1,_3> meaning head_dim innermost, kQRows next):
+    //   atom 0: rows 0..kAtomRows-1, cols 0..kAtomCols-1
+    //   atom 1: rows 0..kAtomRows-1, cols kAtomCols..2*kAtomCols-1
+    //   atom 2: rows kAtomRows..2*kAtomRows-1, cols 0..kAtomCols-1
+    //   ... so on
+    //
+    // To make TMA descriptor match this SMEM byte order, the box must be 5D:
+    //   dim 0 (innermost): kAtomCols head_dim cols within atom row    → GMEM stride 1 elem
+    //   dim 1:             kAtomRows atom rows                         → GMEM stride head_dim (1 head)
+    //   dim 2:             kNumHorizAtoms horizontal atom halves       → GMEM stride kAtomCols elem
+    //   dim 3:             kNumVertAtomsPerTok vertical atom halves    → GMEM stride kAtomRows * head_dim (kAtomRows heads)
+    //   dim 4:             max_qo_len/kPackFactor (num actual_tok)      → GMEM stride num_heads_orig * head_dim (1 token)
+    //
+    // 5D total elements = kAtomCols * kAtomRows * kNumHorizAtoms * kNumVertAtomsPerTok * kNumActualTokMax
+    //                   = kQRows * kHeadDimCT = one CTA's SMEM smem_o size.
+    CUtensorMap tma_desc_o_direct{};
+    bool tma_store_o_direct_valid = false;
+    if constexpr (kTmaPathCompileEligible) {
+      // max_qo_len is the packed length; unpacked per-batch length is
+      // max_qo_len / kPackFactor_. Require >= kPackFactor_ so the unpacked
+      // length is at least 1.
+      if (args.ptr_O_direct != nullptr
+          && args.qo_len_uniform
+          && args.max_qo_len >= kPackFactor_
+          && args.num_qo_heads_orig > 0
+          && args.head_dim_vo == kHeadDimCT
+          && args.total_qo_len_orig > 0) {
+        constexpr CUtensorMapDataType tma_dtype = detail::to_cu_tensor_map_dtype<Element>();
+        constexpr CUtensorMapSwizzle  tma_swizzle = detail::to_cu_tensor_map_swizzle(AtomSwizzle{});
+
+        cuuint64_t global_dim[5] = {
+            (cuuint64_t)kAtomCols,                                // dim 0 = atom inner head_dim cols
+            (cuuint64_t)args.num_qo_heads_orig,                   // dim 1 = full num_heads
+            (cuuint64_t)kNumHorizAtoms,                           // dim 2 = head_dim outer atoms
+            (cuuint64_t)kNumVertAtomsPerTok,                      // dim 3 = vertical atom halves per actual_tok
+            (cuuint64_t)args.total_qo_len_orig};                  // dim 4 = full token count
+        cuuint64_t global_stride[4] = {
+            (cuuint64_t)args.head_dim_vo * sizeof(Element),                                  // dim 0 → dim 1 : 1 head row
+            (cuuint64_t)kAtomCols * sizeof(Element),                                         // dim 1 → dim 2 : kAtomCols elems
+            (cuuint64_t)kAtomRows * args.head_dim_vo * sizeof(Element),                      // dim 2 → dim 3 : kAtomRows heads
+            (cuuint64_t)args.num_qo_heads_orig * args.head_dim_vo * sizeof(Element)};        // dim 3 → dim 4 : 1 token
+        cuuint32_t box_dim[5] = {
+            (cuuint32_t)kAtomCols,
+            (cuuint32_t)kAtomRows,
+            (cuuint32_t)kNumHorizAtoms,
+            (cuuint32_t)kNumVertAtomsPerTok,
+            (cuuint32_t)(args.max_qo_len / kPackFactor_)};
+        cuuint32_t element_stride[5] = {1, 1, 1, 1, 1};
+        CUresult result = cuTensorMapEncodeTiled(
+            &tma_desc_o_direct,
+            tma_dtype,
+            /*tensorRank=*/5,
+            args.ptr_O_direct,
+            global_dim, global_stride,
+            box_dim, element_stride,
+            CU_TENSOR_MAP_INTERLEAVE_NONE,
+            tma_swizzle,
+            CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
+            CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+        tma_store_o_direct_valid = (result == CUDA_SUCCESS);
+        if (!tma_store_o_direct_valid) {
+          std::cerr << "[fmha_sm100] cuTensorMapEncodeTiled failed (code=" << result
+                    << "), falling back to vec16 scatter." << std::endl;
+        }
+      }
+    }
+
+    Params p = {tma_store_o, layout_O, nullptr, {}, args.max_qo_len,
+            args.ptr_MaxScore, args.layout_MaxScore,
+            args.ptr_MaxScore_direct, args.total_qo_len_orig,
+            args.max_score_stride_t, args.max_score_stride_h, args.max_score_stride_k,
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+            args.max_score_numel,
+#endif
+            args.ptr_O_direct, args.num_qo_heads_orig, args.head_dim_vo,
+            args.remaining_h_r,
+            tma_desc_o_direct, tma_store_o_direct_valid};
+    return p;
+  }
+
+  CUTLASS_DEVICE
+  static void prefetch_tma_descriptors(Params const& params) {
+    // P4 (v3): OnlyScore mode (NeedOutput_=false) never uses tma_store_o
+    // (all consumers are gated under NeedOutput_), so the descriptor prefetch
+    // is dead — skip it. Saves one prefetch_tma_descriptor PTX hint per CTA.
+    if constexpr (!NeedOutput_) return;
+    bool prefetch = true;
+    if constexpr (kEnableDirectO) {
+      if (params.ptr_O_direct != nullptr) prefetch = false;
+    }
+    if (prefetch) {
+      cute::prefetch_tma_descriptor(params.tma_store_o.get_tma_descriptor());
+    }
+  }
+
+  const Params& params;
+
+  CUTLASS_DEVICE Sm100FmhaFwdEpilogueTmaWarpspecialized(const Params& params) : params(params) {}
+
+  template <class BlkCoord, class ProblemShape, class ParamsProblemShape>
+  CUTLASS_DEVICE auto store(BlkCoord const& blk_coord, ProblemShape const& problem_shape,
+                            Params const& params, ParamsProblemShape const& params_problem_shape,
+                            TensorStorage& shared_storage, Pipeline& pipeline,
+                            typename Pipeline::PipelineState& pipeline_consumer_state,
+                            int kv_split_idx = 0, int total_qo_len_splitkv = 0,
+                            float* ptr_lse_accum = nullptr,
+                            int split_kv_num_qo_heads = 0) {
+    GET_GPU_TRACE(true);
+    int qo_tile_idx = get<0>(blk_coord);
+    int qo_head_idx = get<2, 0>(blk_coord);
+    int batch_idx = get<2, 1>(blk_coord);
+    int qo_len = get<0>(problem_shape);
+    int qo_segment_offset = get<0>(params_problem_shape).segment_offsets[batch_idx];
+    uint32_t lane_predicate = cute::elect_one_sync();
+
+    // Direct O write: read from smem (written by correction warpgroup),
+    // write to unpacked global O layout. Runs in epilogue warpgroup,
+    // overlapping with next tile's mainloop. Decode-only path: pack_factor>1
+    // implies max_qo_len<=32, which forces tile_q=128 / NumQStages_=1.
+    if constexpr (kEnableDirectO && NeedOutput_ && !IsSplitKV) {
+    static_assert(NumQStages_ == 1,
+                  "Direct-O unpack only supports NumQStages_=1 (decode path with tile_q=128)");
+    // Hot path: pack>1 + non-split + production env always has ptr_O_direct.
+    // The nullptr fallback exists only for FMHA_DISABLE_DIRECT_O_UNPACK=1.
+    if (__builtin_expect(params.ptr_O_direct != nullptr, 1)) {
+      static constexpr int pf = kPackFactor;
+
+      int rem_hr = params.remaining_h_r;
+      int kv_head = qo_head_idx / rem_hr;
+      int rhr_idx = qo_head_idx % rem_hr;
+      int h_r_orig = rem_hr * pf;
+      int seg_off_orig = qo_segment_offset / pf;
+      int head_dim = params.head_dim_vo;
+      int num_heads_orig = params.num_qo_heads_orig;
+      int base_head = kv_head * h_r_orig + rhr_idx * pf;
+
+      // ---- Phase 2 TMA fused direct-O fast path (5D hand-rolled PTX) ----
+      // 5D tensor layout matches SMEM atom tiling exactly:
+      //   dim 0: kAtomCols head_dim cols within atom (innermost)
+      //   dim 1: kAtomRows atom rows (packed_rows)
+      //   dim 2: kNumHorizAtoms horizontal atoms (head_dim halves)
+      //   dim 3: kNumVertAtomsPerTok vertical atoms per actual_tok (pf_idx halves)
+      //   dim 4: actual_tok (token index)
+      //
+      // CTA writes box at coord (0, base_head, 0, 0, seg_off_orig).
+      // base_head maps onto dim 1 (stride = 1 head); dim 3 then advances by
+      // kAtomRows heads, covering pf = kAtomRows * kNumVertAtomsPerTok heads
+      // for the current CTA.
+      if constexpr (kTmaPathCompileEligible) {
+        if (params.tma_store_o_direct_valid) {
+          pipeline.consumer_wait(pipeline_consumer_state);
+          {
+            GPU_TRACE_SCOPE(EPILOGUE);
+            if (cute::elect_one_sync()) {
+              uint64_t desc_addr = reinterpret_cast<uint64_t>(&params.tma_desc_o_direct);
+              uint32_t smem_int = cute::cast_smem_ptr_to_uint(shared_storage.smem_o.data());
+              int32_t crd0 = 0;
+              int32_t crd1 = base_head;
+              int32_t crd2 = 0;
+              int32_t crd3 = 0;
+              int32_t crd4 = seg_off_orig;
+              asm volatile(
+                  "cp.async.bulk.tensor.5d.global.shared::cta.bulk_group [%0, {%2, %3, %4, %5, %6}], [%1];\n"
+                  "cp.async.bulk.commit_group;\n"
+                  "cp.async.bulk.wait_group 0;\n"
+                  :: "l"(desc_addr), "r"(smem_int),
+                     "r"(crd0), "r"(crd1), "r"(crd2), "r"(crd3), "r"(crd4)
+                  : "memory");
+            }
+          }
+          pipeline.consumer_release(pipeline_consumer_state);
+          ++pipeline_consumer_state;
+          RELEASE_GPU_TRACE;
+          return;
+        }
+      }
+
+      Tensor sO = make_tensor(make_smem_ptr(shared_storage.smem_o.data()), SmemLayoutO{});
+      int tid = threadIdx.x % 32;
+
+      pipeline.consumer_wait(pipeline_consumer_state);
+      {
+        GPU_TRACE_SCOPE(EPILOGUE);
+        if constexpr (kQRows % pf == 0) {
+        // Vec16 fast path: kQRows splits cleanly into pf-row segments.
+        // For each actual_tok the pf rows map to a contiguous (pf * head_dim)
+        // byte segment in unpacked GMEM. K-major SMEM atom guarantees
+        // head_dim direction is byte-contiguous within a row, so each
+        // thread does one uint4 load (within a row) + one uint4 store.
+        static constexpr int num_segs = kQRows / pf;
+        int base_head = kv_head * h_r_orig + rhr_idx * pf;
+        using VecT = uint4;
+        static constexpr int VEC = sizeof(VecT);  // 16 bytes
+        // sizeof(Element) is 1 for fp8 / 2 for bf16; operate on bytes.
+        int vec_per_row = (head_dim * (int)sizeof(Element)) / VEC;
+        int vecs_per_seg = pf * vec_per_row;
+
+        int tile_base = qo_tile_idx * kQRows;
+        int tile_base_tok = tile_base / pf;
+
+        CUTLASS_PRAGMA_NO_UNROLL
+        for (int seg = 0; seg < num_segs; seg++) {
+          int seg_first_packed_row = tile_base + seg * pf;
+          if (seg_first_packed_row >= qo_len) break;
+
+          int actual_tok = tile_base_tok + seg;
+          int64_t base_offset =
+              (int64_t)(seg_off_orig + actual_tok) * num_heads_orig * head_dim
+              + (int64_t)base_head * head_dim;
+          VecT* dst_seg = reinterpret_cast<VecT*>(params.ptr_O_direct + base_offset);
+
+          for (int v = tid; v < vecs_per_seg; v += 32) {
+            int r_local = v / vec_per_row;
+            int d_chunk = v % vec_per_row;
+            int r_global = seg * pf + r_local;
+            if (seg_first_packed_row + r_local >= qo_len) continue;
+            VecT data = *reinterpret_cast<const VecT*>(
+                &sO(r_global, d_chunk * (VEC / (int)sizeof(Element)), _0{}));
+            dst_seg[v] = data;
+          }
+        }
+      } else {
+        // Per-row fallback: kQRows not divisible by pf (e.g. pack_factor=6
+        // with tile_q=128 → kQRows=128, 128 % 6 != 0). Each thread handles
+        // its own packed row, computes unpacked head with pf_idx, and
+        // scalar-stores head_dim elements.
+        int tile_base = qo_tile_idx * kQRows;
+        for (int r = tid; r < kQRows; r += 32) {
+          int packed_row = tile_base + r;
+          if (packed_row >= qo_len) break;
+          int pf_idx = packed_row % pf;
+          int actual_tok = packed_row / pf;
+          int unpacked_head = kv_head * h_r_orig + rhr_idx * pf + pf_idx;
+          Element* dst = params.ptr_O_direct
+                       + (int64_t)(seg_off_orig + actual_tok) * num_heads_orig * head_dim
+                       + (int64_t)unpacked_head * head_dim;
+          for (int d = 0; d < head_dim; d++) {
+            dst[d] = sO(r, d, _0{});
+          }
+        }
+        pipeline.consumer_release(pipeline_consumer_state);
+        ++pipeline_consumer_state;
+        RELEASE_GPU_TRACE;
+        return;
+      }
+      }  // close GPU_TRACE_SCOPE block
+      pipeline.consumer_release(pipeline_consumer_state);
+      ++pipeline_consumer_state;
+      RELEASE_GPU_TRACE;
+      return;
+    }
+    }  // if constexpr (kEnableDirectO)
+
+    // Fallthrough = packed TMA store path. Reached when:
+    //   - kEnableDirectO=false (pack=1 or split-KV), OR
+    //   - kEnableDirectO=true but ptr_O_direct==nullptr (disable env).
+    // In all cases, host-side (fmha_cutlass_sm100.cuh:182,197-199) guarantees
+    // params.tma_store_o is constructed from a valid ptr_O whenever
+    // NeedOutput_ is true. Contract: ptr_O nulled iff ptr_O_direct provided.
+
+    using X = Underscore;
+
+    int o0_index = NumQStages_ * get<0>(blk_coord);
+    int o1_index = NumQStages_ * get<0>(blk_coord) + 1;
+
+    int offs_0 = params.max_qo_len - qo_len;
+    int offs_2_1 = qo_segment_offset + qo_len;
+    if (total_qo_len_splitkv > 0 && kv_split_idx > 0) {
+      offs_2_1 += kv_split_idx * total_qo_len_splitkv;
+    }
+    BlkCoord blk_coord_updated = blk_coord;
+    get<2, 1>(blk_coord_updated) = 0;
+
+    Tensor mO = params.tma_store_o.get_tma_tensor(params.layout_O.shape());
+
+    Tensor mO_qdl = domain_offset(make_coord(offs_0, _0{}, make_coord(_0{}, offs_2_1)), mO);
+
+    Tensor gO_qdl = local_tile(mO_qdl, TileShape{}, make_coord(_, _, _), Step<_1, _1, X>{});
+    Tensor gO = gO_qdl(_, _, _, _0{}, get<2>(blk_coord_updated));
+
+    Tensor sO = make_tensor(make_smem_ptr(shared_storage.smem_o.data()), SmemLayoutO{});
+    auto block_tma = params.tma_store_o.get_slice(0);
+    Tensor tOsO = block_tma.partition_S(sO);
+    Tensor tOgO = block_tma.partition_D(gO);
+
+    auto pipeline_release_state = pipeline_consumer_state;
+
+    // O1 O2
+    // one pipeline: O
+    // wait from corr, issue tma store on smem
+    pipeline.consumer_wait(pipeline_consumer_state);
+    ++pipeline_consumer_state;
+
+    // Write split-KV stats from smem to global memory
+    if constexpr (IsSplitKV) {
+      int tile_row_base = qo_tile_idx * kQRows;
+      int lane = threadIdx.x % 32;
+      for (int r = lane; r < kQRows; r += 32) {
+        int row_idx = tile_row_base + r;
+        if (row_idx < qo_len) {
+          int abs_row = qo_segment_offset + row_idx;
+          int actual_split = kv_split_idx < 0 ? 0 : kv_split_idx;
+          int stats_offset = actual_split * total_qo_len_splitkv * split_kv_num_qo_heads
+                           + abs_row * split_kv_num_qo_heads + qo_head_idx;
+          ptr_lse_accum[stats_offset] = shared_storage.smem_lse[r];
+        }
+      }
+    }
+
+    if constexpr (NeedOutput_) {
+      if (lane_predicate) {
+        GPU_TRACE_SCOPE(EPILOGUE);
+        copy(params.tma_store_o, tOsO(_, _, _, _0{}), tOgO(_, _, _, o0_index));
+      }
+      tma_store_arrive();
+    }
+
+    if constexpr (NumQStages_ > 1) {
+      pipeline.consumer_wait(pipeline_consumer_state);
+      ++pipeline_consumer_state;
+
+      if constexpr (NeedOutput_) {
+        if (lane_predicate) {
+          GPU_TRACE_SCOPE(EPILOGUE);
+          copy(params.tma_store_o, tOsO(_, _, _, _1{}), tOgO(_, _, _, o1_index));
+        }
+        tma_store_arrive();
+
+        tma_store_wait<1>();
+      }
+
+      pipeline.consumer_release(pipeline_release_state);
+      ++pipeline_release_state;
+
+      if constexpr (NeedOutput_) {
+        tma_store_wait<0>();
+      }
+    } else {
+      if constexpr (NeedOutput_) {
+        tma_store_wait<0>();
+      }
+
+      pipeline.consumer_release(pipeline_release_state);
+      ++pipeline_release_state;
+    }
+
+    if constexpr (NumQStages_ > 1) {
+      pipeline.consumer_release(pipeline_release_state);
+      ++pipeline_release_state;
+    }
+    RELEASE_GPU_TRACE;
+  }
+};
+
+}  // namespace cutlass::fmha::collective

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/sm100_fmha_fwd_kernel_tma_warpspecialized.hpp
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/sm100_fmha_fwd_kernel_tma_warpspecialized.hpp
@@ -1,0 +1,716 @@
+/***************************************************************************************************
+ * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+#include "fmha_common.hpp"
+#include "fmha_fusion.hpp"
+#include "gmem_bounds_check.h"
+#include "gpu_trace.h"
+#include "cute/arch/tmem_allocator_sm100.hpp"
+#include "cute/layout.hpp"
+#include "cutlass/arch/arch.h"
+#include "cutlass/cutlass.h"
+#include "cutlass/kernel_hardware_info.h"
+#include "cutlass/pipeline/pipeline.hpp"
+#include "fmha_options.hpp"
+#include "fmha_tile_scheduler.hpp"
+
+GPU_TRACE_SCOPE_DEC(KERNEL_LAUNCHED);
+
+namespace cutlass::fmha::kernel {
+
+using namespace cute;
+using namespace cutlass::fmha::collective;
+
+template <bool SingleSoftmaxWarpGroup_ = false>
+struct Sm100FmhaCtxKernelWarpspecializedSchedule {
+  static constexpr bool SingleSoftmaxWarpGroup = SingleSoftmaxWarpGroup_;
+  enum class WarpRole { Softmax0, Softmax1, Correction, MMA, Load, Epilogue, Empty };
+
+  static constexpr WarpRole warp_idx_to_WarpRole(int warp_idx) {
+    if (warp_idx == 0) return WarpRole::Load;
+    if (warp_idx == 1) return WarpRole::MMA;
+    if (warp_idx == 2) return WarpRole::Epilogue;
+    if (warp_idx == 3) return WarpRole::Empty;
+    if constexpr (SingleSoftmaxWarpGroup) {
+      // Merged: warps 0-1 = Softmax0, 2-3 = Softmax1, no separate warpgroups
+      if (warp_idx < 6) return WarpRole::Softmax0;
+      if (warp_idx < 8) return WarpRole::Softmax1;
+      if (warp_idx < 12) return WarpRole::Correction;
+    } else {
+      int wg_idx = warp_idx / 4;
+      if (wg_idx == 1) return WarpRole::Softmax0;
+      if (wg_idx == 2) return WarpRole::Softmax1;
+      if (wg_idx == 3) return WarpRole::Correction;
+    }
+    return WarpRole::Empty;
+  }
+
+  static const int NumWarpsSoftmaxPerStage = SingleSoftmaxWarpGroup ? 2 : 4;
+  static const int NumWarpsCorrection = 4;
+  static const int NumWarpsEpilogue = 1;
+  static const int NumWarpsLoad = 1;
+
+  static const bool kDebugUsingPrintf = false;
+  static const int NumRegsSoftmax = SingleSoftmaxWarpGroup ? 232 : 192;
+  static const int NumRegsCorrection = SingleSoftmaxWarpGroup ? 96 : 64;
+  static const int NumRegsOther = SingleSoftmaxWarpGroup ? 72 : 64;
+
+  static const int NumWarps = SingleSoftmaxWarpGroup ? 12 : 16;
+};
+
+template <class ProblemShapeIn, class CollectiveMainloop, class CollectiveEpilogue,
+          class TileScheduler, class KernelSchedule = Sm100FmhaCtxKernelWarpspecializedSchedule<false>>
+struct Sm100FmhaFwdKernelTmaWarpspecialized {
+  using TileShape = typename CollectiveMainloop::TileShape;
+  using ProblemShape = ProblemShapeIn;
+
+  using WarpRole = typename KernelSchedule::WarpRole;
+
+  constexpr WarpRole warp_idx_to_WarpRole(int warp_idx) {
+    return KernelSchedule::warp_idx_to_WarpRole(warp_idx);
+  }
+
+  static const int NumWarpsCorrection = KernelSchedule::NumWarpsCorrection;
+  static const int NumWarpsEpilogue = KernelSchedule::NumWarpsEpilogue;
+  static const int NumWarpsLoad = KernelSchedule::NumWarpsLoad;
+
+  static const int NumRegsSoftmax = KernelSchedule::NumRegsSoftmax;
+  static const int NumRegsCorrection = KernelSchedule::NumRegsCorrection;
+  static const int NumRegsOther = KernelSchedule::NumRegsOther;
+
+  static const int NumWarps = KernelSchedule::NumWarps;
+
+  static constexpr bool kSingleSoftmaxWarpGroup = KernelSchedule::SingleSoftmaxWarpGroup;
+  static constexpr int kNumWarpsSoftmaxPerStage = KernelSchedule::NumWarpsSoftmaxPerStage;
+
+  using ClusterShape = typename CollectiveMainloop::ClusterShape;
+
+  // No smem_v padding needed — K/V share smem_kv which is separate from epilogue smem_o
+  using MainloopTensorStorage = typename CollectiveMainloop::TensorStorage;
+
+  using TmemAllocator = cute::TMEM::Allocator1Sm;
+
+  struct SharedStorage {
+    // FA4 style: mainloop and epilogue are independent (no union)
+    MainloopTensorStorage mainloop;
+    typename CollectiveEpilogue::TensorStorage epilogue;
+
+    struct PipelineStorage {
+      alignas(16) typename CollectiveMainloop::PipelineQ::SharedStorage load_q;
+      alignas(16) typename CollectiveMainloop::PipelineKV::SharedStorage load_kv;
+      alignas(16) typename CollectiveMainloop::PipelineS::SharedStorage mma_s0;
+      alignas(16) typename CollectiveMainloop::PipelineS::SharedStorage mma_s1;
+      alignas(16) typename CollectiveMainloop::PipelineC::SharedStorage s0_corr;
+      alignas(16) typename CollectiveMainloop::PipelineC::SharedStorage s1_corr;
+      alignas(16) typename CollectiveMainloop::PipelineO::SharedStorage mma_corr;
+      alignas(16) typename CollectiveMainloop::PipelineE::SharedStorage corr_epi;
+    } pipelines;
+
+    uint32_t tmem_base_ptr;
+  };
+
+  static constexpr int SharedStorageSize = sizeof(SharedStorage);
+  static constexpr bool IsSplitKV = CollectiveMainloop::IsSplitKV;
+
+  using SplitKVParams = typename CollectiveMainloop::SplitKVParams;
+
+  struct ArgumentsBase {
+    ProblemShape problem_shape;
+    typename CollectiveMainloop::Arguments mainloop;
+    typename CollectiveEpilogue::Arguments epilogue;
+    typename TileScheduler::Arguments tile_scheduler;
+    cutlass::KernelHardwareInfo hw_info;
+  };
+
+  struct ArgumentsSplitKV : ArgumentsBase {
+    SplitKVParams split_kv{};
+  };
+
+  using Arguments = std::conditional_t<IsSplitKV, ArgumentsSplitKV, ArgumentsBase>;
+
+  struct ParamsBase {
+    ProblemShape problem_shape;
+    typename CollectiveMainloop::Params mainloop;
+    typename CollectiveEpilogue::Params epilogue;
+    typename TileScheduler::Params tile_scheduler;
+  };
+
+  struct ParamsSplitKV : ParamsBase {
+    SplitKVParams split_kv;
+  };
+
+  using Params = std::conditional_t<IsSplitKV, ParamsSplitKV, ParamsBase>;
+
+  static const int MinBlocksPerMultiprocessor = 1;
+  static const int MaxThreadsPerBlock = NumWarps * cutlass::NumThreadsPerWarp;
+  using ArchTag = cutlass::arch::Sm100;
+
+  static size_t get_workspace_size(Arguments const& args) { return 0; }
+  static cutlass::Status initialize_workspace(Arguments const&, void*, cudaStream_t) {
+    return cutlass::Status::kSuccess;
+  }
+
+  static bool can_implement(Arguments const& args) {
+    return CollectiveMainloop::can_implement(args.problem_shape, args.mainloop);
+  }
+
+  static dim3 get_grid_shape(Params const& params) {
+    return TileScheduler::get_grid_shape(params.tile_scheduler);
+  }
+
+  static dim3 get_block_shape() {
+    dim3 block(MaxThreadsPerBlock, 1, 1);
+    return block;
+  }
+
+  static Params to_underlying_arguments(Arguments const& args, void* workspace) {
+    if constexpr (IsSplitKV) {
+      return Params{
+          {args.problem_shape,
+           CollectiveMainloop::to_underlying_arguments(args.problem_shape, args.mainloop, workspace),
+           CollectiveEpilogue::to_underlying_arguments(args.problem_shape, args.epilogue, workspace),
+           TileScheduler::to_underlying_arguments(args.tile_scheduler, args.hw_info)},
+          args.split_kv};
+    } else {
+      return Params{
+          args.problem_shape,
+          CollectiveMainloop::to_underlying_arguments(args.problem_shape, args.mainloop, workspace),
+          CollectiveEpilogue::to_underlying_arguments(args.problem_shape, args.epilogue, workspace),
+          TileScheduler::to_underlying_arguments(args.tile_scheduler, args.hw_info)};
+    }
+  }
+
+  CUTLASS_DEVICE auto apply_batch(const Params& params, ProblemShape const& problem_shape,
+                                  int batch_idx) {
+    return apply_variable_length(params.problem_shape, batch_idx);
+  }
+
+  CUTLASS_DEVICE void operator()(const Params& params, char* smem) {
+// #if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+//     asm volatile("griddepcontrol.wait;");
+// #endif
+
+    GPU_TRACE_INIT;
+
+
+    int warp_idx = cutlass::canonical_warp_idx_sync();
+    auto role = warp_idx_to_WarpRole(warp_idx);
+    uint32_t lane_predicate = cute::elect_one_sync();
+
+    GET_GPU_TRACE(role == WarpRole::MMA || role == WarpRole::Load);
+    {GPU_TRACE_SCOPE(KERNEL_LAUNCHED);}
+    TileScheduler tile_scheduler{params.tile_scheduler};
+
+#ifdef SM_TIMING_ENABLED
+    long long __sm_start_clock = clock64();
+#endif
+
+    if (role == WarpRole::Load && lane_predicate) {
+      CollectiveMainloop::prefetch_tma_descriptors(params.mainloop);
+    }
+
+    SharedStorage& shared_storage = *reinterpret_cast<SharedStorage*>(smem);
+
+    typename CollectiveMainloop::PipelineQ::Params pipeline_load_q_params;
+    if (role == WarpRole::Load) {
+      pipeline_load_q_params.role = CollectiveMainloop::PipelineQ::ThreadCategory::Producer;
+    }
+    if (role == WarpRole::MMA) {
+      pipeline_load_q_params.role = CollectiveMainloop::PipelineQ::ThreadCategory::Consumer;
+    }
+    pipeline_load_q_params.is_leader = lane_predicate && (role == WarpRole::Load);
+    pipeline_load_q_params.transaction_bytes = CollectiveMainloop::TransactionBytesLoadQ;
+    pipeline_load_q_params.initializing_warp = 1;
+    typename CollectiveMainloop::PipelineQ pipeline_load_q(
+        shared_storage.pipelines.load_q, pipeline_load_q_params, ClusterShape{}, cute::true_type{},
+        /*mask calc*/ cute::false_type{});
+
+    typename CollectiveMainloop::PipelineKV::Params pipeline_load_kv_params;
+    if (role == WarpRole::Load) {
+      pipeline_load_kv_params.role = CollectiveMainloop::PipelineKV::ThreadCategory::Producer;
+    }
+    if (role == WarpRole::MMA) {
+      pipeline_load_kv_params.role = CollectiveMainloop::PipelineKV::ThreadCategory::Consumer;
+    }
+    pipeline_load_kv_params.is_leader = lane_predicate && (role == WarpRole::Load);
+    pipeline_load_kv_params.transaction_bytes = CollectiveMainloop::TransactionBytesLoadKV;
+    pipeline_load_kv_params.initializing_warp = 1;
+    typename CollectiveMainloop::PipelineKV pipeline_load_kv(
+        shared_storage.pipelines.load_kv, pipeline_load_kv_params, ClusterShape{},
+        /*barrier init*/ cute::true_type{}, /*mask calc*/ cute::false_type{});
+
+    __syncthreads();
+
+    pipeline_load_q.init_masks(ClusterShape{});
+    pipeline_load_kv.init_masks(ClusterShape{});
+
+    typename CollectiveMainloop::PipelineQ::PipelineState pipeline_load_q_consumer_state;
+    typename CollectiveMainloop::PipelineQ::PipelineState pipeline_load_q_producer_state =
+        cutlass::make_producer_start_state<typename CollectiveMainloop::PipelineQ>();
+
+    typename CollectiveMainloop::PipelineKV::PipelineState pipeline_load_kv_consumer_state;
+    typename CollectiveMainloop::PipelineKV::PipelineState pipeline_load_kv_producer_state =
+        cutlass::make_producer_start_state<typename CollectiveMainloop::PipelineKV>();
+
+    CollectiveMainloop mainloop;
+
+    if (role == WarpRole::Load) {
+      warpgroup_reg_set<NumRegsOther>();
+
+      int work_idx = 0;
+
+      CUTLASS_PRAGMA_NO_UNROLL
+      for (; tile_scheduler.is_valid(); ++tile_scheduler) {
+        auto blk_coord = tile_scheduler.get_block_coord();
+
+        auto logical_problem_shape =
+            apply_batch(params, params.problem_shape, get<2, 1>(blk_coord));
+
+        if (get<0>(blk_coord) * get<0>(TileShape{}) >= get<0>(logical_problem_shape)) {
+          continue;
+        }
+
+        if (get<1>(logical_problem_shape) == 0) {  // kv_len == 0
+          work_idx++;
+          continue;
+        }
+
+        if constexpr (IsSplitKV) {
+          int wp = tile_scheduler.get_work_ptr();
+          int kv_tile_begin = SPLIT_KV_BEGIN(params.split_kv, wp);
+          int kv_tile_end = SPLIT_KV_END(params.split_kv, wp);
+          if (CollectiveMainloop::get_effective_trip_count(
+                  blk_coord, logical_problem_shape,
+                  kv_tile_begin, kv_tile_end, params.mainloop.load.kv_block_num) <= 0) { work_idx++; continue; }
+          mainloop.load(blk_coord, logical_problem_shape, params.mainloop, params.problem_shape,
+                        work_idx, shared_storage.mainloop,
+                        pipeline_load_q, pipeline_load_q_producer_state,
+                        pipeline_load_kv, pipeline_load_kv_producer_state
+                        #ifdef GPU_TRACE_ENABLED
+                          , _gt_rec
+                        #endif
+                        , kv_tile_begin, kv_tile_end
+                      );
+        } else {
+          mainloop.load(blk_coord, logical_problem_shape, params.mainloop, params.problem_shape,
+                        work_idx, shared_storage.mainloop,
+                        pipeline_load_q, pipeline_load_q_producer_state,
+                        pipeline_load_kv, pipeline_load_kv_producer_state
+                        #ifdef GPU_TRACE_ENABLED
+                          , _gt_rec
+                        #endif
+                      );
+        }
+
+        work_idx++;
+      }
+    }
+
+    // Dynamic: how many warps per stage are actually needed (based on max Q length)
+    int active_warps_per_stage = kNumWarpsSoftmaxPerStage;
+    if constexpr (CollectiveMainloop::kEnablePaddingSkip) {
+      int active_q = min(params.epilogue.max_qo_len, (int)get<0>(TileShape{}));
+      active_warps_per_stage = min((int)kNumWarpsSoftmaxPerStage, (active_q + 31) / 32);
+      if (active_warps_per_stage < 1) active_warps_per_stage = 1;
+    }
+    int softmax_arv_count = warp_uniform(active_warps_per_stage * cutlass::NumThreadsPerWarp);
+
+    typename CollectiveMainloop::PipelineS::Params pipeline_mma_s0_params;
+    if (role == WarpRole::MMA) {
+      pipeline_mma_s0_params.role = CollectiveMainloop::PipelineS::ThreadCategory::Producer;
+    }
+    if (role == WarpRole::Softmax0) {
+      pipeline_mma_s0_params.role = CollectiveMainloop::PipelineS::ThreadCategory::Consumer;
+    }
+    pipeline_mma_s0_params.consumer_arv_count = softmax_arv_count;
+    pipeline_mma_s0_params.initializing_warp = 1;
+    typename CollectiveMainloop::PipelineS pipeline_mma_s0(
+        shared_storage.pipelines.mma_s0, pipeline_mma_s0_params, ClusterShape{},
+        /*barrier init*/ cute::true_type{}, /*mask calc*/ cute::false_type{});
+
+    typename CollectiveMainloop::PipelineS::Params pipeline_mma_s1_params;
+    if (role == WarpRole::MMA) {
+      pipeline_mma_s1_params.role = CollectiveMainloop::PipelineS::ThreadCategory::Producer;
+    }
+    if (role == WarpRole::Softmax1) {
+      pipeline_mma_s1_params.role = CollectiveMainloop::PipelineS::ThreadCategory::Consumer;
+    }
+    pipeline_mma_s1_params.consumer_arv_count = softmax_arv_count;
+    pipeline_mma_s1_params.initializing_warp = 1;
+    typename CollectiveMainloop::PipelineS pipeline_mma_s1(
+        shared_storage.pipelines.mma_s1, pipeline_mma_s1_params, ClusterShape{},
+        /*barrier init*/ cute::true_type{}, /*mask calc*/ cute::false_type{});
+
+    typename CollectiveMainloop::PipelineC::Params pipeline_s0_corr_params;
+    if (role == WarpRole::Softmax0) {
+      pipeline_s0_corr_params.role = CollectiveMainloop::PipelineC::ThreadCategory::Producer;
+    }
+    if (role == WarpRole::Correction) {
+      pipeline_s0_corr_params.role = CollectiveMainloop::PipelineC::ThreadCategory::Consumer;
+    }
+    pipeline_s0_corr_params.producer_arv_count = softmax_arv_count;
+    pipeline_s0_corr_params.consumer_arv_count = NumWarpsCorrection * cutlass::NumThreadsPerWarp;
+    pipeline_s0_corr_params.initializing_warp = 1;
+    typename CollectiveMainloop::PipelineC pipeline_s0_corr(shared_storage.pipelines.s0_corr,
+                                                            pipeline_s0_corr_params,
+                                                            /*barrier init*/ cute::true_type{});
+
+    typename CollectiveMainloop::PipelineC::Params pipeline_s1_corr_params;
+    if (role == WarpRole::Softmax1) {
+      pipeline_s1_corr_params.role = CollectiveMainloop::PipelineC::ThreadCategory::Producer;
+    }
+    if (role == WarpRole::Correction) {
+      pipeline_s1_corr_params.role = CollectiveMainloop::PipelineC::ThreadCategory::Consumer;
+    }
+    pipeline_s1_corr_params.producer_arv_count = softmax_arv_count;
+    pipeline_s1_corr_params.consumer_arv_count = NumWarpsCorrection * cutlass::NumThreadsPerWarp;
+    pipeline_s1_corr_params.initializing_warp = 1;
+    typename CollectiveMainloop::PipelineC pipeline_s1_corr(shared_storage.pipelines.s1_corr,
+                                                            pipeline_s1_corr_params,
+                                                            /*barrier init*/ cute::true_type{});
+
+    typename CollectiveMainloop::PipelineO::Params pipeline_mma_corr_params;
+    if (role == WarpRole::MMA) {
+      if constexpr (CollectiveMainloop::kNeedMaxScore) {
+        // consumer role to wait for writing out of MaxScore
+        pipeline_mma_corr_params.role = CollectiveMainloop::PipelineO::ThreadCategory::Consumer;
+      }
+      else{
+        pipeline_mma_corr_params.role = CollectiveMainloop::PipelineO::ThreadCategory::Producer;
+      }
+    }
+    if (role == WarpRole::Correction) {
+        pipeline_mma_corr_params.role = CollectiveMainloop::PipelineO::ThreadCategory::Consumer;
+    }
+    pipeline_mma_corr_params.consumer_arv_count = NumWarpsCorrection * cutlass::NumThreadsPerWarp;
+    pipeline_mma_corr_params.initializing_warp = 1;
+    typename CollectiveMainloop::PipelineO pipeline_corr(
+        shared_storage.pipelines.mma_corr, pipeline_mma_corr_params);
+
+    typename CollectiveMainloop::PipelineE::Params pipeline_corr_epi_params;
+    if (role == WarpRole::Correction) {
+      pipeline_corr_epi_params.role = CollectiveMainloop::PipelineE::ThreadCategory::Producer;
+    }
+    if (role == WarpRole::Epilogue) {
+      pipeline_corr_epi_params.role = CollectiveMainloop::PipelineE::ThreadCategory::Consumer;
+    }
+    pipeline_corr_epi_params.producer_arv_count = NumWarpsCorrection * cutlass::NumThreadsPerWarp;
+    pipeline_corr_epi_params.consumer_arv_count = NumWarpsEpilogue * cutlass::NumThreadsPerWarp;
+    pipeline_corr_epi_params.initializing_warp = 1;
+    typename CollectiveMainloop::PipelineE pipeline_corr_epi(shared_storage.pipelines.corr_epi,
+                                                             pipeline_corr_epi_params,
+                                                             /*barrier init*/ cute::true_type{});
+
+    if (role != WarpRole::Load) {
+      if constexpr (kSingleSoftmaxWarpGroup)
+        asm volatile("bar.sync 8, 352;");
+      else
+        asm volatile("bar.sync 8, 480;");
+
+      pipeline_mma_s0.init_masks(ClusterShape{});
+      pipeline_mma_s1.init_masks(ClusterShape{});
+    }
+
+    TmemAllocator tmem_allocator;
+    bool has_work = tile_scheduler.is_valid();
+
+    if (role == WarpRole::Epilogue && lane_predicate) {
+      CollectiveEpilogue::prefetch_tma_descriptors(params.epilogue);
+    }
+
+
+    typename CollectiveMainloop::PipelineS::PipelineState pipeline_mma_s0_consumer_state;
+    typename CollectiveMainloop::PipelineS::PipelineState pipeline_mma_s0_producer_state =
+        cutlass::make_producer_start_state<typename CollectiveMainloop::PipelineS>();
+
+    typename CollectiveMainloop::PipelineS::PipelineState pipeline_mma_s1_consumer_state;
+    typename CollectiveMainloop::PipelineS::PipelineState pipeline_mma_s1_producer_state =
+        cutlass::make_producer_start_state<typename CollectiveMainloop::PipelineS>();
+
+    typename CollectiveMainloop::PipelineC::PipelineState pipeline_s0_corr_consumer_state;
+    typename CollectiveMainloop::PipelineC::PipelineState pipeline_s0_corr_producer_state =
+        cutlass::make_producer_start_state<typename CollectiveMainloop::PipelineC>();
+
+    typename CollectiveMainloop::PipelineC::PipelineState pipeline_s1_corr_consumer_state;
+    typename CollectiveMainloop::PipelineC::PipelineState pipeline_s1_corr_producer_state =
+        cutlass::make_producer_start_state<typename CollectiveMainloop::PipelineC>();
+
+    typename CollectiveMainloop::PipelineE::PipelineState pipeline_corr_epi_consumer_state;
+    typename CollectiveMainloop::PipelineE::PipelineState pipeline_corr_epi_producer_state =
+        cutlass::make_producer_start_state<typename CollectiveMainloop::PipelineE>();
+
+    RELEASE_GPU_TRACE;
+
+    CollectiveEpilogue epilogue{params.epilogue};
+
+    if (role == WarpRole::Softmax0 || role == WarpRole::Softmax1) {
+      warpgroup_reg_set<NumRegsSoftmax>();
+
+      // Idle warps within a stage: early return, don't touch pipelines
+      int warp_in_stage = cutlass::canonical_warp_idx_sync() % kNumWarpsSoftmaxPerStage;
+      if (warp_in_stage >= active_warps_per_stage) return;
+
+      bool is_softmax_0 = (role == WarpRole::Softmax0);
+      int q_offset_correction = 0;
+      if constexpr (kSingleSoftmaxWarpGroup) {
+        if (!is_softmax_0) q_offset_correction = -64;
+      }
+
+      CUTLASS_PRAGMA_NO_UNROLL
+      for (; tile_scheduler.is_valid(); ++tile_scheduler) {
+        auto blk_coord = tile_scheduler.get_block_coord();
+
+        auto logical_problem_shape =
+            apply_batch(params, params.problem_shape, get<2, 1>(blk_coord));
+
+        if (get<0>(blk_coord) * get<0>(TileShape{}) >= get<0>(logical_problem_shape)) {
+          continue;
+        }
+
+        if (get<1>(logical_problem_shape) == 0) {
+          continue;
+        }
+
+        if constexpr (IsSplitKV) {
+          int wp = tile_scheduler.get_work_ptr();
+          int kv_tile_begin = SPLIT_KV_BEGIN(params.split_kv, wp);
+          int kv_tile_end = SPLIT_KV_END(params.split_kv, wp);
+          if (CollectiveMainloop::get_effective_trip_count(
+                  blk_coord, logical_problem_shape,
+                  kv_tile_begin, kv_tile_end, params.mainloop.load.kv_block_num) <= 0) {
+            continue;
+          }
+          mainloop.template softmax<kSingleSoftmaxWarpGroup>(
+              is_softmax_0 ? 0 : 1, blk_coord, params.mainloop,
+              params.problem_shape, logical_problem_shape, epilogue,
+              is_softmax_0 ? pipeline_mma_s0 : pipeline_mma_s1,
+              is_softmax_0 ? pipeline_mma_s0_consumer_state : pipeline_mma_s1_consumer_state,
+              is_softmax_0 ? pipeline_s0_corr : pipeline_s1_corr,
+              is_softmax_0 ? pipeline_s0_corr_producer_state : pipeline_s1_corr_producer_state,
+              kv_tile_begin, kv_tile_end, q_offset_correction);
+        } else {
+          mainloop.template softmax<kSingleSoftmaxWarpGroup>(
+              is_softmax_0 ? 0 : 1, blk_coord, params.mainloop,
+              params.problem_shape, logical_problem_shape, epilogue,
+              is_softmax_0 ? pipeline_mma_s0 : pipeline_mma_s1,
+              is_softmax_0 ? pipeline_mma_s0_consumer_state : pipeline_mma_s1_consumer_state,
+              is_softmax_0 ? pipeline_s0_corr : pipeline_s1_corr,
+              is_softmax_0 ? pipeline_s0_corr_producer_state : pipeline_s1_corr_producer_state,
+              0, INT_MAX, q_offset_correction);
+        }
+      }
+    } else if (role == WarpRole::Correction) {
+      cutlass::arch::warpgroup_reg_dealloc<NumRegsCorrection>();
+      CUTLASS_PRAGMA_NO_UNROLL
+      for (; tile_scheduler.is_valid(); ++tile_scheduler) {
+        auto blk_coord = tile_scheduler.get_block_coord();
+
+        auto logical_problem_shape =
+            apply_batch(params, params.problem_shape, get<2, 1>(blk_coord));
+
+        if (get<0>(blk_coord) * get<0>(TileShape{}) >= get<0>(logical_problem_shape)) {
+          continue;
+        }
+
+        if (get<1>(logical_problem_shape) == 0) {
+          mainloop.correction_empty(blk_coord, params.mainloop, logical_problem_shape,
+                                    params.problem_shape, shared_storage.epilogue,
+                                    pipeline_corr_epi, pipeline_corr_epi_producer_state, epilogue);
+          continue;
+        }
+
+        if constexpr (IsSplitKV) {
+          int wp = tile_scheduler.get_work_ptr();
+          int kv_tile_begin = SPLIT_KV_BEGIN(params.split_kv, wp);
+          int kv_tile_end = SPLIT_KV_END(params.split_kv, wp);
+          int kv_split_idx = SPLIT_KV_SPLIT(params.split_kv, wp);
+          if (CollectiveMainloop::get_effective_trip_count(
+                  blk_coord, logical_problem_shape,
+                  kv_tile_begin, kv_tile_end, params.mainloop.load.kv_block_num) <= 0) {
+            mainloop.correction_empty(blk_coord, params.mainloop, logical_problem_shape,
+                                      params.problem_shape, shared_storage.epilogue,
+                                      pipeline_corr_epi, pipeline_corr_epi_producer_state, epilogue);
+            continue;
+          }
+          mainloop.template correction<kSingleSoftmaxWarpGroup>(blk_coord, params.mainloop, params.problem_shape,
+                              logical_problem_shape, shared_storage.epilogue, pipeline_s0_corr,
+                              pipeline_s0_corr_consumer_state, pipeline_s1_corr,
+                              pipeline_s1_corr_consumer_state, pipeline_corr,
+                              pipeline_corr_epi, pipeline_corr_epi_producer_state, epilogue,
+                              kv_tile_begin, kv_tile_end, kv_split_idx, params.split_kv);
+        } else {
+          mainloop.template correction<kSingleSoftmaxWarpGroup>(blk_coord, params.mainloop, params.problem_shape,
+                              logical_problem_shape, shared_storage.epilogue, pipeline_s0_corr,
+                              pipeline_s0_corr_consumer_state, pipeline_s1_corr,
+                              pipeline_s1_corr_consumer_state, pipeline_corr,
+                              pipeline_corr_epi, pipeline_corr_epi_producer_state, epilogue);
+        }
+      }
+
+      if constexpr (NumWarpsEpilogue == 0) {
+        static_assert(NumWarpsCorrection == 1);
+        if (has_work) {
+          uint32_t free_stage_ptr = shared_storage.tmem_base_ptr;
+          tmem_allocator.free(free_stage_ptr, TmemAllocator::Sm100TmemCapacityColumns);
+        }
+      }
+
+    } else if (role == WarpRole::MMA) {
+      warpgroup_reg_set<NumRegsOther>();
+      // Only allocate TMEM if this SM has work to do
+      if (has_work) {
+        tmem_allocator.allocate(TmemAllocator::Sm100TmemCapacityColumns,
+                                &shared_storage.tmem_base_ptr);
+      }
+
+      CUTLASS_PRAGMA_NO_UNROLL
+      for (; tile_scheduler.is_valid(); ++tile_scheduler) {
+        auto blk_coord = tile_scheduler.get_block_coord();
+
+        auto logical_problem_shape =
+            apply_batch(params, params.problem_shape, get<2, 1>(blk_coord));
+
+        if (get<0>(blk_coord) * get<0>(TileShape{}) >= get<0>(logical_problem_shape)) {
+          continue;
+        }
+
+        if (get<1>(logical_problem_shape) == 0) {
+          continue;
+        }
+
+        if constexpr (IsSplitKV) {
+          int wp = tile_scheduler.get_work_ptr();
+          int kv_tile_begin = SPLIT_KV_BEGIN(params.split_kv, wp);
+          int kv_tile_end = SPLIT_KV_END(params.split_kv, wp);
+          if (CollectiveMainloop::get_effective_trip_count(
+                  blk_coord, logical_problem_shape,
+                  kv_tile_begin, kv_tile_end, params.mainloop.load.kv_block_num) <= 0) {
+            continue;
+          }
+          mainloop.template mma<kSingleSoftmaxWarpGroup>(
+              blk_coord, params.mainloop, logical_problem_shape, shared_storage.mainloop,
+              pipeline_load_q, pipeline_load_q_consumer_state, pipeline_load_kv,
+              pipeline_load_kv_consumer_state,
+              pipeline_mma_s0, pipeline_mma_s0_producer_state, pipeline_mma_s1,
+              pipeline_mma_s1_producer_state, pipeline_corr,
+              kv_tile_begin, kv_tile_end);
+        } else {
+          mainloop.template mma<kSingleSoftmaxWarpGroup>(
+              blk_coord, params.mainloop, logical_problem_shape, shared_storage.mainloop,
+              pipeline_load_q, pipeline_load_q_consumer_state, pipeline_load_kv,
+              pipeline_load_kv_consumer_state,
+              pipeline_mma_s0, pipeline_mma_s0_producer_state, pipeline_mma_s1,
+              pipeline_mma_s1_producer_state, pipeline_corr);
+        }
+      }
+    } else if (role == WarpRole::Epilogue) {
+      warpgroup_reg_set<NumRegsOther>();
+
+      int work_idx = 0;
+      CUTLASS_PRAGMA_NO_UNROLL
+      for (; tile_scheduler.is_valid(); ++tile_scheduler) {
+        auto blk_coord = tile_scheduler.get_block_coord();
+
+        auto logical_problem_shape =
+            apply_batch(params, params.problem_shape, get<2, 1>(blk_coord));
+
+        if (get<0>(blk_coord) * get<0>(TileShape{}) >= get<0>(logical_problem_shape)) {
+          continue;
+        }
+
+        if constexpr (IsSplitKV) {
+          int wp = tile_scheduler.get_work_ptr();
+          int kv_split_idx = SPLIT_KV_SPLIT(params.split_kv, wp);
+          epilogue.store(blk_coord, logical_problem_shape, params.epilogue, params.problem_shape,
+                         shared_storage.epilogue, pipeline_corr_epi,
+                         pipeline_corr_epi_consumer_state, kv_split_idx,
+                         params.split_kv.total_qo_len,
+                         params.split_kv.ptr_lse_accum,
+                         params.split_kv.num_qo_heads);
+        } else {
+          epilogue.store(blk_coord, logical_problem_shape, params.epilogue, params.problem_shape,
+                         shared_storage.epilogue, pipeline_corr_epi,
+                         pipeline_corr_epi_consumer_state);
+        }
+
+        work_idx++;
+      }
+
+      static_assert(NumWarpsEpilogue <= 1);
+      if constexpr (NumWarpsEpilogue == 1) {
+        if (has_work) {
+          uint32_t free_stage_ptr = shared_storage.tmem_base_ptr;
+          tmem_allocator.free(free_stage_ptr, TmemAllocator::Sm100TmemCapacityColumns);
+        }
+      }
+
+    } else if (role == WarpRole::Empty) {
+      warpgroup_reg_set<NumRegsOther>();
+
+      /* no-op, donate regs and exit */
+    }
+
+    GPU_TRACE_EXIT;
+#ifdef SM_TIMING_ENABLED
+    long long __sm_end_clock = clock64();
+    long long __sm_duration = __sm_end_clock - __sm_start_clock;
+    if (threadIdx.x % 32 == 0 && role == WarpRole::Epilogue) {
+      TileScheduler tile_scheduler_out{params.tile_scheduler};
+      int num_tiles = tile_scheduler_out.work_ptr_end - tile_scheduler_out.work_ptr;
+      printf("SM_TIMING block=%d duration=%lld start=%lld end=%lld num_tiles=%d\n",
+             blockIdx.x, __sm_duration, __sm_start_clock, __sm_end_clock, num_tiles);
+      for (; tile_scheduler_out.is_valid(); ++tile_scheduler_out) {
+        auto blk_coord = tile_scheduler_out.get_block_coord();
+        auto logical_problem_shape =
+            apply_batch(params, params.problem_shape, get<2, 1>(blk_coord));
+        int q_len = get<0>(logical_problem_shape);
+        int kv_len = get<1>(logical_problem_shape);
+        int kv_iters;
+        if constexpr (IsSplitKV) {
+          int wp = tile_scheduler_out.get_work_ptr();
+          int kb = SPLIT_KV_BEGIN(params.split_kv, wp);
+          int ke = SPLIT_KV_END(params.split_kv, wp);
+          kv_iters = CollectiveMainloop::get_effective_trip_count(
+              blk_coord, logical_problem_shape, kb, ke, params.mainloop.load.kv_block_num);
+        } else {
+          kv_iters = CollectiveMainloop::get_full_trip_count(
+              blk_coord, logical_problem_shape, params.mainloop.load.kv_block_num);
+        }
+        printf("  SM_TILE block=%d qo_tile=%d batch=%d head=%d q_len=%d kv_len=%d kv_iters=%d\n",
+               blockIdx.x, get<0>(blk_coord), get<2, 1>(blk_coord), get<2, 0>(blk_coord),
+               q_len, kv_len, kv_iters);
+      }
+    }
+#endif
+  }
+};
+
+}  // namespace cutlass::fmha::kernel

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/sm100_fmha_fwd_mainloop_tma_warpspecialized.hpp
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/sm100_fmha_fwd_mainloop_tma_warpspecialized.hpp
@@ -1,0 +1,2255 @@
+/***************************************************************************************************
+ * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#pragma once
+
+#include <climits>
+
+#include "gmem_bounds_check.h"
+#include "cute/arch/simd_sm100.hpp"
+#include "cute/layout.hpp"
+#include "cute/tensor.hpp"
+#include "cutlass/arch/memory_sm80.h"
+#include "cutlass/cutlass.h"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "fmha_common.hpp"
+#include "fmha_fusion.hpp"
+#include "gpu_trace.h"
+#include "sm100_fmha_load_tma_warpspecialized.hpp"
+
+GPU_TRACE_SCOPE_DEC(SOFTMAX_Mask);
+GPU_TRACE_SCOPE_DEC(SOFTMAX_GetMax);
+GPU_TRACE_SCOPE_DEC(SOFTMAX_Exp);
+GPU_TRACE_SCOPE_DEC(SOFTMAX_Sum);
+GPU_TRACE_SCOPE_DEC(GEMM_QK0);
+GPU_TRACE_SCOPE_DEC(GEMM_QK1);
+GPU_TRACE_SCOPE_DEC(GEMM_PV0);
+GPU_TRACE_SCOPE_DEC(GEMM_PV1);
+GPU_TRACE_SCOPE_DEC(CORRECTION);
+GPU_TRACE_SCOPE_DEC(CORRECTION_MRG);
+GPU_TRACE_SCOPE_DEC(CORRECTION_EPI);
+GPU_TRACE_SCOPE_DEC(WAIT_Q);
+GPU_TRACE_SCOPE_DEC(DUP_Q);
+
+GPU_TRACE_SCOPE_DEC(WAIT_QK);
+GPU_TRACE_SCOPE_DEC(WAIT_K);
+GPU_TRACE_SCOPE_DEC(WAIT_V);
+
+GPU_TRACE_SCOPE_DEC(RELEASE_Q);
+
+#define TRACE_MMA 1
+#define TRACE_SOFTMAX 0
+#define TRACE_CORR 0
+
+namespace cutlass::fmha::collective {
+
+using namespace cute;
+
+// Unidirectional async pipeline: only consumer→producer direction (empty barrier).
+// Producer calls wait(), consumer calls arrive(). Index auto-advances internally.
+// Saves shared memory and initialization cost vs bidirectional PipelineAsync/PipelineUmmaAsync
+// when producer_commit/consumer_wait are unused.
+template <int Stages_>
+class PipelineAsyncWaitArrive {
+public:
+  static constexpr uint32_t Stages = Stages_;
+  using BarrierType = cutlass::arch::ClusterBarrier;
+
+  enum class ThreadCategory {
+    NonParticipant,
+    Producer,
+    Consumer,
+    ProducerConsumer
+  };
+
+  struct Params {
+    ThreadCategory role = ThreadCategory::NonParticipant;
+    uint32_t consumer_arv_count = 1;
+    uint32_t dst_blockid = cute::block_rank_in_cluster();
+    int initializing_warp = 0;
+  };
+
+  struct SharedStorage {
+    BarrierType barrier_[Stages];
+  };
+
+  CUTLASS_DEVICE
+  PipelineAsyncWaitArrive(SharedStorage& storage, Params const& params,
+                          cute::true_type /*init_barriers*/ = {})
+      : params_(params)
+      , barrier_ptr_(&storage.barrier_[0])
+      , index_(0)
+      , phase_((params.role == ThreadCategory::Producer ||
+                params.role == ThreadCategory::ProducerConsumer) ? 1u : 0u) {
+    int warp_idx = cutlass::canonical_warp_idx_sync();
+    if (warp_idx == params_.initializing_warp) {
+      if (cute::elect_one_sync()) {
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < Stages; i++) {
+          storage.barrier_[i].init(params_.consumer_arv_count);
+        }
+      }
+    }
+    cutlass::arch::fence_barrier_init();
+  }
+
+  // Producer waits for consumer to release a stage
+  CUTLASS_DEVICE
+  void wait() {
+    barrier_ptr_[index_].wait(phase_);
+    advance();
+  }
+
+  // Consumer signals that a stage is available for the producer
+  CUTLASS_DEVICE
+  void arrive() {
+    barrier_ptr_[index_].arrive(params_.dst_blockid);
+    advance();
+  }
+
+private:
+  Params params_;
+  BarrierType* barrier_ptr_;
+  int index_;
+  uint32_t phase_;
+
+  CUTLASS_DEVICE
+  void advance() {
+    if (++index_ == Stages) {
+      index_ = 0;
+      phase_ ^= 1;
+    }
+  }
+};
+
+template <class Element_, class ElementQK_, class ElementPV_, class TileShapeQK_,
+          class TileShapePV_, class StrideQ_, class StrideK_, class StrideV_, class Mask_,
+          // shape here is QG K H
+          // and referes to the two softmax warps
+          // (2, 1, 1) means that they are stacked (best for large Q since it loads the least K/V)
+          // (1, 2, 1) means they sit side by side (best for small Q / large K)
+          class ThreadShape = Shape<_2, _1, _1>,
+          bool IsSplitKV_ = false,
+          int KVPageSize_ = -1,
+          SparseAttnMode kSparseAttnMode = SparseAttnMode::Off>
+struct Sm100FmhaFwdMainloopTmaWarpspecialized {
+  static constexpr bool IsSplitKV = IsSplitKV_;
+  static constexpr int KVPageSize = KVPageSize_;
+
+  static constexpr bool kNeedMaxScore = (kSparseAttnMode == SparseAttnMode::OnlyScore || kSparseAttnMode == SparseAttnMode::Full);
+  static constexpr bool kNeedOutput = kSparseAttnMode != SparseAttnMode::OnlyScore;
+  static constexpr bool kNeedSparse = kSparseAttnMode == SparseAttnMode::Sparse;
+  // OnlyScore mode: correction's only real work is writing max_score to GMEM
+  // (rescale paths are kNeedOutput-gated). Let softmax do the GMEM write
+  // directly from its tile_max register, and have correction skip its own
+  // GMEM write. All TMEM round-trip and PipelineC handshakes are preserved
+  // for safety (no sync elision in v1 — those are TODO for v2).
+  static constexpr bool kFuseMaxScoreIntoSoftmax =
+      (kSparseAttnMode == SparseAttnMode::OnlyScore);
+
+  struct SplitKVParams {
+    float scale_output_splitkv = 1.0f;
+    float scale_output_nosplit = 1.0f;
+    float* ptr_lse_accum = nullptr;
+    int* kv_tile_begin_indices = nullptr;
+    int* kv_tile_end_indices = nullptr;
+    int* kv_split_indices = nullptr;
+    int total_qo_len = 0;
+    int num_qo_heads = 0;
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+    int split_kv_buf_size = 0;
+#endif
+  };
+
+  using Element = Element_;
+  using ElementQK = ElementQK_;
+  using ElementPV = ElementPV_;
+  using TileShape = decltype(select<0, 1>(TileShapeQK_{}));
+  using TileShapeQK = decltype(shape_div(TileShapeQK_{}, ThreadShape{}));
+  // PV has dims (Q, D_VO, KV) — KV is at index 2, not 1.
+  // Swap ThreadShape indices 1,2 so division falls on KV (index 2), not D_VO (index 1).
+  using ThreadShapePV = decltype(select<0, 2, 1>(ThreadShape{}));
+  using TileShapePV = decltype(shape_div(TileShapePV_{}, ThreadShapePV{}));
+  using StrideQ = StrideQ_;
+  using StrideK = StrideK_;
+  using StrideV = StrideV_;
+  using Mask = Mask_;
+
+  static constexpr bool AggressiveLoopInvariantCodeMotionOfSoftmax = true;//get<1>(ThreadShape{}) == 1; // meet compiler error in decode
+  static constexpr bool EnableEmuExp2 = true;
+  // exp2 emulation tuning: replace a fraction of hardware exp2f with FMA polynomial.
+  //   Freq: period length (in elements, step=2). Must divide fragment size.
+  //   Res: how many elements at the end of each period use emulation.
+  //   StartFrg: first eligible fragment (0-based). SkipLastFrg: skip last fragment.
+  // Replacement rate ≈ (Res/Freq) × (eligible_frags/total_frags).
+  // Current: (4/16) × (2/4) = 12.5%.  Try Res=8 for 25%, or StartFrg=0 for 18.75%.
+  static constexpr int kExp2EmuFreq = 16;
+  static constexpr int kExp2EmuRes = 4;
+  static constexpr int kExp2EmuStartFrg = 1;
+  static constexpr bool kExp2EmuSkipLastFrg = true;
+  // Q-split (2,1,1): 2 Q stages (Q0 and Q1 in smem pipeline)
+  // K-split (1,2,1): 1 Q stage (only Q0 needed, same Q for both stages)
+  static constexpr int StageCountQ = (get<0>(ThreadShape{}) > 1) ? 2 : 1;
+  // static constexpr int StageCountQ = (get<0>(ThreadShape{}) > 1) ? 2 : (sizeof(Element_) == 1 ? 2 : 1);
+  // K-split uses dynamic softmax warp count (controlled by kernel-level warp guard)
+  static constexpr bool kEnablePaddingSkip = (get<0>(ThreadShape{}) == 1);
+
+  template <class BlkCoord, class ProblemShape>
+  CUTLASS_DEVICE static int get_full_trip_count(BlkCoord const& blk_coord,
+                                                 ProblemShape const& problem_shape,
+                                                 int kv_block_num = 0) {
+    if constexpr (kNeedSparse) {
+      constexpr int tile_kv = get<1>(TileShape{});
+      return (kv_block_num * KVPageSize + tile_kv - 1) / tile_kv;
+    } else {
+      return Mask{}.get_trip_count(blk_coord, TileShape{}, problem_shape);
+    }
+  }
+
+  template <class BlkCoord, class ProblemShape>
+  CUTLASS_DEVICE static int get_effective_trip_count(BlkCoord const& blk_coord,
+                                                      ProblemShape const& problem_shape,
+                                                      int kv_tile_begin, int kv_tile_end,
+                                                      int kv_block_num = 0) {
+    int full = get_full_trip_count(blk_coord, problem_shape, kv_block_num);
+    int eff_end = full < kv_tile_end ? full : kv_tile_end;
+    int count = eff_end - kv_tile_begin;
+    return count > 0 ? count : 0;
+  }
+
+  // Compute StageCountKV dynamically based on smem budget (FA4 style).
+  // For FP8 d=128: (224KB - Q_smem - O_smem) / KV_per_stage ≈ 8 stages (vs hardcoded 4).
+  // Fallback to the original formula if dynamic computation is not feasible for a config.
+  static constexpr int StageCountKV_base =
+      (sizeof(Element_) == 1)
+          ? (get<2>(TileShapeQK{}) == 128 ? 4 : 2)
+          : (get<2>(TileShapeQK{}) == 128 || get<2>(TileShapeQK{}) == 64 ? 2 : 1);
+  // For dynamic: estimate smem per KV stage, Q total, O total, then maximize stages
+  static constexpr int SmemPerStageKV_bytes =
+      get<1>(TileShapeQK{}) * get<2>(TileShapeQK{}) * sizeof(Element_);  // N * D * element_size
+  static constexpr int SmemQ_bytes =
+      StageCountQ * get<0>(TileShapeQK{}) * get<2>(TileShapeQK{}) * sizeof(Element_);  // stages * M * D
+  // OnlyScore mode: epilogue's smem_o is trimmed to 1 byte (NeedOutput_ gate),
+  // so we don't pay the StageCountQ * kQRows * D output buffer cost.
+  static constexpr int SmemO_bytes =
+      kNeedOutput
+          ? (StageCountQ * get<0>(TileShapeQK{}) * get<2>(TileShapeQK{}) *
+             ((sizeof(Element_) == 1) ? 2 : (int)sizeof(Element_)))
+          : 0;
+  static constexpr int SmemBudget = 224 * 1024;
+  static constexpr int StageCountKV_dynamic =
+      (SmemBudget - SmemQ_bytes - SmemO_bytes) / SmemPerStageKV_bytes;
+  // Use dynamic if it gives more stages, otherwise use base
+  static constexpr int StageCountKV = // values was found by profiling
+      sizeof(Element_) == 1 ?
+        ( (get<0>(ThreadShape{}) == 1) ? 8 : 2 )
+        : ( (get<0>(ThreadShape{}) == 1) ? 4 : 2 );
+      // (StageCountKV_dynamic > StageCountKV_base) ? StageCountKV_dynamic : StageCountKV_base;
+
+  using StagesQ = cutlass::gemm::collective::StageCount<StageCountQ>;
+  using StagesKV = cutlass::gemm::collective::StageCount<StageCountKV>;
+
+  static_assert(StageCountKV_dynamic >= StageCountKV);
+
+  using ClusterShape = Shape<_1, _1, _1>;
+
+  static const int Alignment = 128 / sizeof_bits_v<Element>;
+
+  using CollectiveMmaQK = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp, Element, StrideQ, Alignment, Element,
+      StrideK, Alignment, ElementQK, TileShapeQK, ClusterShape,
+      cutlass::gemm::collective::StageCount<3> /* we change it later anyways*/,
+      cutlass::gemm::KernelTmaWarpSpecialized1SmSm100>::CollectiveOp;
+
+  using CollectiveMmaPV = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm100, cutlass::arch::OpClassTensorOp,
+      // the stride for A does not matter since we do not load from smem at all
+      Element, StrideK, Alignment, Element, StrideV, Alignment, ElementPV, TileShapePV,
+      ClusterShape, cutlass::gemm::collective::StageCount<3> /* we change it later anyways*/,
+      cutlass::gemm::KernelTmaWarpSpecialized1SmSm100>::CollectiveOp;
+
+  using SmemLayoutQ =
+      decltype(unstageSmemLayout(typename CollectiveMmaQK::SmemLayoutA{}, Int<StageCountQ>{}));
+  using SmemLayoutK =
+      decltype(unstageSmemLayout(typename CollectiveMmaQK::SmemLayoutB{}, Int<StageCountKV>{}));
+  using SmemLayoutV =
+      decltype(unstageSmemLayout(typename CollectiveMmaPV::SmemLayoutB{}, Int<StageCountKV>{}));
+
+  // K and V share the same physical smem buffer (FA4 style).
+  // Use the larger cosize for the shared buffer.
+  static constexpr size_t kSmemKCosize = cute::cosize_v<SmemLayoutK>;
+  static constexpr size_t kSmemVCosize = cute::cosize_v<SmemLayoutV>;
+  static constexpr size_t kSmemKVCosize = (kSmemKCosize > kSmemVCosize) ? kSmemKCosize : kSmemVCosize;
+
+  // TensorStorage: shared K/V smem buffer + Q (no separate smem_v or smem_k)
+  // smem_o is allocated separately in the kernel (no union overlap)
+  struct TensorStorage {
+    cute::array_aligned<Element, kSmemKVCosize> smem_kv;
+    cute::array_aligned<Element, cute::cosize_v<SmemLayoutQ>> smem_q;
+  };
+
+  enum class TmemAllocation : uint32_t {
+    kSizeS = 128,
+    kSizeO = 128,
+    kSizeP = 32,
+    S0 = 0,
+    S1 = S0 + kSizeS,   // 128
+    V0 = S0,            // 0   // stats storage from softmax to correction
+    V1 = S1,            // 128
+    P0 = S0 + kSizeP,   // 32
+    P1 = S1 + kSizeP,   // 160
+    O0 = S1 + kSizeS,   // 256
+    O1 = O0 + kSizeO,   // 384
+    kEnd = O1 + kSizeO  // 512
+  };
+
+  // indices for V0 / V1
+  enum : int { kIdxOldRowMax = 0, kIdxNewRowMax = 1, kIdxFinalRowSum = 0, kIdxFinalRowMax = 1 };
+  static constexpr int kVStatsWidth = 2;
+
+  // from load to mma warp, protects q in smem
+  using PipelineQ =
+      cutlass::PipelineTmaUmmaAsync<StageCountQ, typename CollectiveMmaQK::AtomThrShapeMNK>;
+
+  // from load to mma warp, protects k/v in smem (merged: K and V share one pipeline)
+  using PipelineKV =
+      cutlass::PipelineTmaUmmaAsync<StageCountKV, typename CollectiveMmaQK::AtomThrShapeMNK>;
+
+  // from mma to softmax0/1 warp, protects S in tmem
+  // (not sure yet about the reverse direction)
+  // there is one pipe per softmax warp, and the mma warp alternates between them
+  using PipelineS = cutlass::PipelineUmmaAsync<1>;
+
+  // from softmax0/1/ to correction wg
+  using PipelineC = cutlass::PipelineAsync<1>;
+
+  // from correction to mma
+  using PipelineO = PipelineAsyncWaitArrive<2>;
+
+  // from corr to epilogue
+  // Use num_q_sub stages: Q-split (2,1,1) → 2, K-split (1,2,1) → 1
+  // K-split only writes smem_o[0], so PipelineAsync<2> would allow producer to
+  // overwrite smem_o[0] before consumer reads it. PipelineAsync<1> prevents this.
+  static constexpr int NumQSub = get<0>(ThreadShape{});
+  using PipelineE = cutlass::PipelineAsync<NumQSub>;
+
+  static const int TransactionBytesLoadQ =
+      cutlass::bits_to_bytes(cosize(take<0, 3>(SmemLayoutQ{})) * cute::sizeof_bits_v<Element>);
+
+  static const int TransactionBytesLoadK =
+      cutlass::bits_to_bytes(cosize(take<0, 3>(SmemLayoutK{})) * cute::sizeof_bits_v<Element>);
+
+  static const int TransactionBytesLoadV =
+      cutlass::bits_to_bytes(cosize(take<0, 3>(SmemLayoutV{})) * cute::sizeof_bits_v<Element>);
+
+  // For interleaved KV pipeline, each stage holds only K or V (not both)
+  // transaction_bytes = K bytes (K and V are same size for FP8 d=128)
+  static const int TransactionBytesLoadKV = TransactionBytesLoadK;
+
+  using Load = Sm100FmhaLoadTmaWarpspecialized<Element, CollectiveMmaQK, CollectiveMmaPV,
+                                               SmemLayoutQ, SmemLayoutK, SmemLayoutV, TensorStorage,
+                                               PipelineQ, PipelineKV, Mask, TileShape, KVPageSize,
+                                               kSparseAttnMode>;
+  using LayoutQ = typename Load::LayoutQ;
+  using LayoutK = typename Load::LayoutK;
+  using LayoutV = typename Load::LayoutV;
+
+  struct Arguments {
+    typename Load::Arguments load;
+
+    float scale_softmax;
+
+    // scaling factors to dequantize QKV
+    float scale_q = 1.0f;
+    float scale_k = 1.0f;
+    float scale_v = 1.0f;
+
+    // scaling factor to quantize O
+    float inv_scale_o = 1.0f;
+  };
+
+  struct Params {
+    typename Load::Params load;
+
+    float scale_softmax;
+    float scale_softmax_log2;
+
+    float scale_output;
+  };
+
+  template <class ProblemShape>
+  static bool can_implement(ProblemShape const& problem_shape, Arguments const& args) {
+    return true;
+  }
+
+  template <class ProblemShape>
+  static Params to_underlying_arguments(ProblemShape const& problem_shape, Arguments const& args,
+                                        void* workspace) {
+    float scale_softmax = args.scale_softmax;
+    float log2_e = static_cast<float>(std::log2(std::exp(1.0)));
+
+    return Params{Load::to_underlying_arguments(problem_shape, args.load, workspace),
+                  args.scale_q * args.scale_k * scale_softmax,
+                  args.scale_q * args.scale_k * log2_e * scale_softmax,
+                  args.scale_v * args.inv_scale_o};
+  }
+
+  CUTLASS_DEVICE
+  static void prefetch_tma_descriptors(Params const& params) {
+    Load::prefetch_tma_descriptors(params.load);
+  }
+
+  template <class BlkCoord, class ProblemShape, class ParamsProblemShape, class TensorStorageType>
+  CUTLASS_DEVICE void load(BlkCoord const& blk_coord, ProblemShape const& problem_shape,
+                           Params const& params, ParamsProblemShape const& params_problem_shape,
+                           int const& work_idx,
+                           TensorStorageType& storage, PipelineQ& pipeline_q,
+                           typename PipelineQ::PipelineState& pipeline_q_producer_state,
+                           PipelineKV& pipeline_kv,
+                           typename PipelineKV::PipelineState& pipeline_kv_producer_state
+                           #ifdef GPU_TRACE_ENABLED
+                             , gpu_trace::Recorder& _gt_rec
+                           #endif
+                           , int kv_tile_begin = 0, int kv_tile_end = INT_MAX
+                          ) {
+    Load load_impl;
+    load_impl.template load<IsSplitKV, kNeedOutput>(blk_coord, problem_shape, params.load, params_problem_shape, work_idx,
+              storage, pipeline_q, pipeline_q_producer_state, pipeline_kv,
+              pipeline_kv_producer_state, kv_tile_begin, kv_tile_end
+              #ifdef GPU_TRACE_ENABLED
+                , _gt_rec
+              #endif
+            );
+  }
+
+  template <bool kSingleWG = false, class BlkCoord, class ProblemShape, class TensorStorageType>
+  CUTLASS_DEVICE auto mma(
+      BlkCoord const& blk_coord, Params const& params, ProblemShape const& problem_shape,
+      TensorStorageType& storage, PipelineQ& pipeline_q,
+      typename PipelineQ::PipelineState& pipeline_q_consumer_state, PipelineKV& pipeline_kv,
+      typename PipelineKV::PipelineState& pipeline_kv_consumer_state, PipelineS& pipeline_s0,
+      typename PipelineS::PipelineState& pipeline_s0_producer_state, PipelineS& pipeline_s1,
+      typename PipelineS::PipelineState& pipeline_s1_producer_state, PipelineO& pipeline_corr,
+      int kv_tile_begin = 0, int kv_tile_end = INT_MAX) {
+    GET_GPU_TRACE(TRACE_MMA);
+
+    auto pipeline_q_release_state = pipeline_q_consumer_state;
+    auto pipeline_kv_release_state = pipeline_kv_consumer_state;
+
+    int mask_tile_count;
+    if constexpr (IsSplitKV || kNeedSparse) {
+      mask_tile_count = get_effective_trip_count(blk_coord, problem_shape,
+                                                 kv_tile_begin, kv_tile_end, params.load.kv_block_num);
+    } else {
+      mask_tile_count = Mask{}.get_trip_count(blk_coord, TileShape{}, problem_shape);
+    }
+
+    typename CollectiveMmaQK::TiledMma mma_qk;
+    ThrMMA thr_mma_qk = mma_qk.get_slice(0);
+
+    typename CollectiveMmaPV::TiledMma mma_pv;
+    TiledMMA mma_pv_ts = to_tiled_mma_sm100_ts(mma_pv);
+    ThrMMA thr_mma_pv = mma_pv_ts.get_slice(0);
+
+    Tensor sQ = make_tensor(make_smem_ptr(storage.smem_q.data()), SmemLayoutQ{});
+    // K and V share the same physical smem buffer (smem_kv), interpreted with different layouts
+    Tensor sK = make_tensor(make_smem_ptr(storage.smem_kv.data()), SmemLayoutK{});
+    Tensor sV = make_tensor(make_smem_ptr(storage.smem_kv.data()), SmemLayoutV{});
+
+    Tensor tSrQ = thr_mma_qk.make_fragment_A(sQ);
+    Tensor tSrK = thr_mma_qk.make_fragment_B(sK);
+    Tensor tOrV = thr_mma_pv.make_fragment_B(sV);
+
+    Tensor tStS = partition_fragment_C(mma_qk, select<0, 1>(TileShapeQK{}));
+    Tensor tOtO = partition_fragment_C(mma_pv_ts, select<0, 1>(TileShapePV{}));
+
+    Tensor tStS0 = tStS;
+    tStS0.data() = tStS.data().get() + uint32_t(TmemAllocation::S0);
+    Tensor tStS1 = tStS;
+    tStS1.data() = tStS.data().get() + uint32_t(TmemAllocation::S1);
+
+    Tensor tOtO0 = tOtO;
+    tOtO0.data() = tOtO.data().get() + uint32_t(TmemAllocation::O0);
+    Tensor tOtO1 = tOtO;
+    tOtO1.data() = tOtO.data().get() + uint32_t(TmemAllocation::O1);
+
+    Tensor sP =
+        make_tensor(make_smem_ptr((Element*)nullptr), typename CollectiveMmaPV::SmemLayoutA{});
+    Tensor tOrP = thr_mma_pv.make_fragment_A(sP)(_, _, _, _0{});
+
+    Tensor tOrP0 = tOrP;
+    tOrP0.data() = tOrP0.data().get() + uint32_t(TmemAllocation::P0);
+    Tensor tOrP1 = tOrP;
+    tOrP1.data() = tOrP1.data().get() + uint32_t(TmemAllocation::P1);
+
+    int k_index = 0;
+    int v_index = 0;
+    int v_odd_index = 0;  // K-split: V index for odd KV tile (used by PV→O1)
+    int q_index = 0;
+
+    // =========== Init: QK0, QK1, then consume first V ===========
+
+    // wait for Q0
+    {GPU_TRACE_SCOPE(WAIT_Q);
+    q_index = pipeline_q_consumer_state.index();
+    pipeline_q.consumer_wait(pipeline_q_consumer_state);
+    ++pipeline_q_consumer_state;
+    }
+
+    // duplicate Q[0:64] → Q[64:128] in SMEM
+    // Row r and row r+64 occupy the same column positions in SMEM but are offset
+    // by a fixed physical byte distance (the "segment size"). This distance is
+    // derived at compile time from SmemLayoutQ: ql(row=64,col=0) - ql(row=0,col=0).
+    // For SW128 swizzle this equals 4096 elems = 8192 bytes; for other swizzle
+    // modes the layout auto-adapts.
+    // When stage_bytes > 2*seg_bytes, the stage contains N pairs of segments
+    // (row 0..63 in even segments, row 64..127 in odd segments); each pair is
+    // copied independently.
+    if constexpr (kSingleWG) {
+      GPU_TRACE_SCOPE(DUP_Q);
+      constexpr int kSegElems = int(SmemLayoutQ{}(
+          cute::make_tuple(cute::make_tuple(cute::Int<64>{}, cute::Int<0>{}),
+                           cute::Int<0>{}, cute::Int<0>{}, cute::Int<0>{})));
+      constexpr int kSegBytes = kSegElems * int(sizeof(Element));
+      constexpr int kSegU4 = kSegBytes / 16;
+      constexpr int kStageBytes =
+          int(cute::cosize_v<SmemLayoutQ>) * int(sizeof(Element)) / int(StageCountQ);
+      constexpr int kNumPairs = kStageBytes / (2 * kSegBytes);
+      static_assert(kSegBytes > 0 && kSegBytes % 16 == 0,
+                    "DUP_Q segment size must be positive and uint4-aligned");
+      static_assert(kStageBytes % (2 * kSegBytes) == 0,
+                    "stage byte size must be multiple of 2 * segment size");
+      int lane = threadIdx.x % cutlass::NumThreadsPerWarp;
+      auto* q_base = reinterpret_cast<uint4*>(storage.smem_q.data())
+                     + q_index * (kStageBytes / 16);
+      CUTLASS_PRAGMA_UNROLL
+      for (int p = 0; p < kNumPairs; p++) {
+        int base = p * 2 * kSegU4;
+        for (int i = lane; i < kSegU4; i += cutlass::NumThreadsPerWarp) {
+          q_base[base + kSegU4 + i] = q_base[base + i];
+        }
+      }
+      cutlass::arch::fence_view_async_shared();
+    }
+    Tensor tSrQ0 = tSrQ(_, _, _, q_index);
+
+    // wait for K0 (stage 0 in interleaved pipeline)
+    {GPU_TRACE_SCOPE(WAIT_K);
+    k_index = pipeline_kv_consumer_state.index();
+    pipeline_kv.consumer_wait(pipeline_kv_consumer_state);
+    ++pipeline_kv_consumer_state;
+    }
+
+    // QK_s0: Q0 * K0 -> S0
+    pipeline_s0.producer_acquire(pipeline_s0_producer_state);
+    {
+      // GPU_TRACE_SCOPE(GEMM_QK0);
+      gemm_zero_acc(mma_qk, tSrQ0, tSrK(_, _, _, k_index), tStS0);
+    }
+    pipeline_s0.producer_commit(pipeline_s0_producer_state);
+    ++pipeline_s0_producer_state;
+
+    // K-split: release K_even, consume K_odd
+    if constexpr (get<1>(ThreadShape{}) > 1) {
+      pipeline_kv.consumer_release(pipeline_kv_release_state);
+      ++pipeline_kv_release_state;
+      GPU_TRACE_SCOPE(WAIT_K);
+      k_index = pipeline_kv_consumer_state.index();
+      pipeline_kv.consumer_wait(pipeline_kv_consumer_state);
+      ++pipeline_kv_consumer_state;
+    }
+
+    if constexpr (get<0>(ThreadShape{}) > 1 || get<2>(ThreadShape{}) > 1) {
+      q_index = pipeline_q_consumer_state.index();
+      pipeline_q.consumer_wait(pipeline_q_consumer_state);
+      ++pipeline_q_consumer_state;
+    }
+    Tensor tSrQ1 = tSrQ(_, _, _, q_index);
+
+    // QK_s1: Q-split: Q1 * K0 -> S1; K-split: Q0 * K1 -> S1
+    pipeline_s1.producer_acquire(pipeline_s1_producer_state);
+    {//GPU_TRACE_SCOPE(GEMM_QK1);
+    gemm_zero_acc(mma_qk, tSrQ1, tSrK(_, _, _, k_index), tStS1);
+    }
+    pipeline_s1.producer_commit(pipeline_s1_producer_state);
+    ++pipeline_s1_producer_state;
+
+    // release K (Q-split: release K0; K-split: release K1)
+    pipeline_kv.consumer_release(pipeline_kv_release_state);
+    ++pipeline_kv_release_state;
+
+    mma_pv_ts.accumulate_ = UMMA::ScaleOut::Zero;
+
+
+    // =========== Main loop: PV0 → QK0 → PV1 → QK1 ===========
+    // K-split FIFO order: V_even, K_even, V_odd, K_odd per group (matching PV0→QK0→PV1→QK1)
+    // Q-split FIFO order: K, V per group
+    mask_tile_count -= 1;
+    for (; mask_tile_count > 0; mask_tile_count -= 1) {
+
+      // consume V_even
+      if constexpr (kNeedOutput) {
+        GPU_TRACE_SCOPE(WAIT_V);
+        v_index = pipeline_kv_consumer_state.index();
+        pipeline_kv.consumer_wait(pipeline_kv_consumer_state);
+        ++pipeline_kv_consumer_state;
+      }
+
+      // PV0: P0 * V_even -> O0
+      pipeline_corr.wait();
+      pipeline_s0.producer_acquire(pipeline_s0_producer_state);
+      if constexpr(kNeedOutput) {
+        // GPU_TRACE_SCOPE(GEMM_PV0);
+        auto save_acc = mma_pv_ts.accumulate_;
+        gemm_reset_zero_acc(mma_pv_ts, tOrP0, tOrV(_, _, _, v_index), tOtO0);
+        mma_pv_ts.accumulate_ = save_acc;
+      }
+
+      // K-split: V_even only used by PV0, release immediately
+      if constexpr (get<1>(ThreadShape{}) > 1 && kNeedOutput) {
+        pipeline_kv.consumer_release(pipeline_kv_release_state);
+        ++pipeline_kv_release_state;
+      }
+
+      // consume K_even
+      {GPU_TRACE_SCOPE(WAIT_K);
+      k_index = pipeline_kv_consumer_state.index();
+      pipeline_kv.consumer_wait(pipeline_kv_consumer_state);
+      ++pipeline_kv_consumer_state;
+      }
+
+      // QK_s0: Q0 * K_even -> S0
+      {
+        // GPU_TRACE_SCOPE(GEMM_QK0);
+        gemm_zero_acc(mma_qk, tSrQ0, tSrK(_, _, _, k_index), tStS0);
+        pipeline_s0.producer_commit(pipeline_s0_producer_state);
+        ++pipeline_s0_producer_state;
+      }
+
+      // K-split: release K_even, then consume V_odd
+      if constexpr (get<1>(ThreadShape{}) > 1) {
+        pipeline_kv.consumer_release(pipeline_kv_release_state);
+        ++pipeline_kv_release_state;
+
+        if constexpr (kNeedOutput) {
+          GPU_TRACE_SCOPE(WAIT_V);
+          v_odd_index = pipeline_kv_consumer_state.index();
+          pipeline_kv.consumer_wait(pipeline_kv_consumer_state);
+          ++pipeline_kv_consumer_state;
+        }
+      }
+
+      pipeline_corr.wait();
+      pipeline_s1.producer_acquire(pipeline_s1_producer_state);
+      if constexpr(kNeedOutput) {
+        // GPU_TRACE_SCOPE(GEMM_PV1);
+        int pv1_v_index;
+        if constexpr (get<1>(ThreadShape{}) > 1) { pv1_v_index = v_odd_index; }
+        else { pv1_v_index = v_index; }
+        gemm_reset_zero_acc(mma_pv_ts, tOrP1, tOrV(_, _, _, pv1_v_index), tOtO1);
+      }
+
+      // Q-split: release V (after PV1, both PV0 and PV1 used same V)
+      // K-split: release V_odd (after PV1), then consume K_odd
+      if constexpr (kNeedOutput) {
+        pipeline_kv.consumer_release(pipeline_kv_release_state);
+        ++pipeline_kv_release_state;
+      }
+      if constexpr (get<1>(ThreadShape{}) > 1) {
+        GPU_TRACE_SCOPE(WAIT_K);
+        k_index = pipeline_kv_consumer_state.index();
+        pipeline_kv.consumer_wait(pipeline_kv_consumer_state);
+        ++pipeline_kv_consumer_state;
+      }
+
+      // QK_s1: Q-split: Q1 * K_even -> S1; K-split: Q0 * K_odd -> S1
+      // Must happen BEFORE releasing K!
+      {
+        // GPU_TRACE_SCOPE(GEMM_QK1);
+        gemm_zero_acc(mma_qk, tSrQ1, tSrK(_, _, _, k_index), tStS1);
+        pipeline_s1.producer_commit(pipeline_s1_producer_state);
+        ++pipeline_s1_producer_state;
+      }
+
+      // release K (Q-split: K_even after QK1; K-split: K_odd after QK1)
+      pipeline_kv.consumer_release(pipeline_kv_release_state);
+      ++pipeline_kv_release_state;
+    }
+
+    // =========== Tail: final PV0 and PV1 ===========
+
+    // release Q
+    {
+      GPU_TRACE_SCOPE(RELEASE_Q);
+      pipeline_q.consumer_release(pipeline_q_release_state);
+      ++pipeline_q_release_state;
+      if constexpr (get<0>(ThreadShape{}) > 1) {
+        pipeline_q.consumer_release(pipeline_q_release_state);
+        ++pipeline_q_release_state;
+      }
+    }
+
+    // consume V_even for next iteration
+    if constexpr (kNeedOutput) {
+      GPU_TRACE_SCOPE(WAIT_V);
+      v_index = pipeline_kv_consumer_state.index();
+      pipeline_kv.consumer_wait(pipeline_kv_consumer_state);
+      ++pipeline_kv_consumer_state;
+    }
+
+    // final PV0: P0 * V_last_even -> O0
+    pipeline_corr.wait();
+    pipeline_s0.producer_acquire(pipeline_s0_producer_state);
+    if constexpr(kNeedOutput) {
+      GPU_TRACE_SCOPE(GEMM_PV0);
+      auto save_acc = mma_pv_ts.accumulate_;
+      gemm_reset_zero_acc(mma_pv_ts, tOrP0, tOrV(_, _, _, v_index), tOtO0);
+      mma_pv_ts.accumulate_ = save_acc;
+    }
+
+    // K-split: release V_even (PV0 done, PV1 uses separate V_odd), then consume V_odd
+    // Q-split: do NOT release V_even yet — PV1 reuses the same V buffer
+    if constexpr (get<1>(ThreadShape{}) > 1 && kNeedOutput) {
+      pipeline_kv.consumer_release(pipeline_kv_release_state);
+      ++pipeline_kv_release_state;
+      GPU_TRACE_SCOPE(WAIT_V);
+      v_odd_index = pipeline_kv_consumer_state.index();
+      pipeline_kv.consumer_wait(pipeline_kv_consumer_state);
+      ++pipeline_kv_consumer_state;
+    }
+
+    // final PV1: P1 * V_last -> O1
+    pipeline_corr.wait();
+    pipeline_s1.producer_acquire(pipeline_s1_producer_state);
+    if constexpr(kNeedOutput) {
+      GPU_TRACE_SCOPE(GEMM_PV1);
+      int pv1_v_index;
+      if constexpr (get<1>(ThreadShape{}) > 1) { pv1_v_index = v_odd_index; }
+      else { pv1_v_index = v_index; }
+      gemm_reset_zero_acc(mma_pv_ts, tOrP1, tOrV(_, _, _, pv1_v_index), tOtO1);
+    }
+
+    // release last V
+    // Q-split: releases V_even (after both PV0 and PV1 used it)
+    // K-split: releases V_odd (V_even was released above before PV1)
+    if constexpr (kNeedOutput) {
+      pipeline_kv.consumer_release(pipeline_kv_release_state);
+      ++pipeline_kv_release_state;
+    }
+
+    // final S signals for softmax's final_call
+    pipeline_s0.producer_commit(pipeline_s0_producer_state);
+    ++pipeline_s0_producer_state;
+    pipeline_s1.producer_commit(pipeline_s1_producer_state);
+    ++pipeline_s1_producer_state;
+
+    // T0 S00 B1, T0 S10 B1, T0 S00 B2, T0 S01 B1, T0 S10 B2, T0 S11 B1, T0 S01 B2, T1 S00 B1, T0
+    // S11 B2, ... Q1 * K1  , Q2 * K1  , S11 * V1 , Q1 * K2  , S21 * V1  , Q2 * K2 , S12 * V2 , Q1 *
+    // K3  , S22 * K2 , ...
+
+    RELEASE_GPU_TRACE;
+  }
+
+  // Pre-computed TMEM context for softmax, initialized once per tile.
+  // All members including derived ones (thread slices, partitions) are computed
+  // in the constructor using this->, so internal references point to this object's
+  // own members. Must not be copied/moved after construction.
+  struct SoftmaxCtx {
+    // Type helpers: compute types from a dummy construction
+    static auto _dummy_tStS() {
+      return partition_fragment_C(typename CollectiveMmaQK::TiledMma{}, select<0, 1>(TileShapeQK{}));
+    }
+    static auto _dummy_tStS_v() { return _dummy_tStS().compose(make_layout(make_shape(_128{}, Int<kVStatsWidth>{}))); }
+    static constexpr auto _tilePlikeFP32() {
+      return get<1>(TileShapeQK{}) / Int<sizeof(float)>{} * Int<sizeof(Element)>{};
+    }
+    static auto _dummy_tStS_P() { return _dummy_tStS().compose(make_layout(make_shape(_128{}, _tilePlikeFP32()))); }
+
+    using TMEM_LOAD = SM100_TMEM_LOAD_32dp32b32x;
+    using TMEM_STORE = SM100_TMEM_STORE_32dp32b32x;
+    using TMEM_STORE_V = SM100_TMEM_STORE_32dp32b2x;
+
+    static auto _dummy_load() { return make_tmem_copy(TMEM_LOAD{}, _dummy_tStS()); }
+    static auto _dummy_storev() { return make_tmem_copy(TMEM_STORE_V{}, _dummy_tStS_v()); }
+    static auto _dummy_store() { return make_tmem_copy(TMEM_STORE{}, _dummy_tStS_P()); }
+    static auto _dummy_thr_load() { return _dummy_load().get_slice(0); }
+    static auto _dummy_thr_storev() { return _dummy_storev().get_slice(0); }
+    static auto _dummy_thr_store() { return _dummy_store().get_slice(0); }
+
+    // Root members
+    decltype(_dummy_tStS()) tStS;
+    decltype(_dummy_tStS_v()) tStS_v;
+    decltype(_dummy_tStS_P()) tStS_P;
+    decltype(_dummy_load()) tiled_tmem_load;
+    decltype(_dummy_storev()) tiled_tmem_storev;
+    decltype(_dummy_store()) tiled_tmem_store;
+    int thread_idx;
+
+    // Hoisted partitions (Q-split only; K-split triggers nvcc miscompile)
+    decltype(_dummy_thr_load().partition_S(_dummy_tStS())) tTMEM_LOADtS;
+    decltype(_dummy_thr_storev().partition_D(_dummy_tStS_v())) tTMEM_STOREVtS;
+    decltype(_dummy_thr_store().partition_D(_dummy_tStS_P())) tTMEM_STOREtS_x4;
+
+    // Constructor: order matters! compute each region fully before compose
+    template <class Stage>
+    CUTLASS_DEVICE SoftmaxCtx(Stage stage) {
+      thread_idx = threadIdx.x % (4 * cutlass::NumThreadsPerWarp);
+
+      tStS = partition_fragment_C(typename CollectiveMmaQK::TiledMma{}, select<0, 1>(TileShapeQK{}));
+      tStS.data() = warp_uniform(uint32_t(stage == _0{} ? TmemAllocation::S0 : TmemAllocation::S1));
+      tiled_tmem_load = make_tmem_copy(TMEM_LOAD{}, tStS);
+      tTMEM_LOADtS = tiled_tmem_load.get_slice(thread_idx).partition_S(tStS);
+
+      tStS_v = tStS.compose(make_layout(make_shape(_128{}, Int<kVStatsWidth>{})));
+      tStS_v.data() = warp_uniform(uint32_t(stage == _0{} ? TmemAllocation::V0 : TmemAllocation::V1));
+      tiled_tmem_storev = make_tmem_copy(TMEM_STORE_V{}, tStS_v);
+      tTMEM_STOREVtS = tiled_tmem_storev.get_slice(thread_idx).partition_D(tStS_v);
+
+      tStS_P = tStS.compose(make_layout(make_shape(_128{}, _tilePlikeFP32())));
+      tStS_P.data() = warp_uniform(uint32_t(stage == _0{} ? TmemAllocation::P0 : TmemAllocation::P1));
+      tiled_tmem_store = make_tmem_copy(TMEM_STORE{}, tStS_P);
+      tTMEM_STOREtS_x4 = tiled_tmem_store.get_slice(thread_idx).partition_D(tStS_P);
+      tTMEM_STOREtS_x4.data() = warp_uniform(tTMEM_STOREtS_x4.data().get());
+    }
+
+    template <bool need_apply_mask, bool skip_computation = false, class Stage, class BlkCoord,
+              class CountingTensor, class ProblemShape>
+    CUTLASS_DEVICE void step(float& row_max, float& row_sum, Stage stage, bool final_call,
+                             BlkCoord const& blk_coord, CountingTensor const& cS,
+                             Params const& params, ProblemShape const& problem_shape,
+                             PipelineS& pipeline_s,
+                             typename PipelineS::PipelineState& pipeline_s_consumer_state,
+                             PipelineC& pipeline_c,
+                             typename PipelineC::PipelineState& pipeline_c_producer_state,
+                             float* ms_base, int ms_stride_k,
+                             int& k_tile_idx, int k_tile_idx_step
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+                             , const float* ms_check_base, int ms_check_numel
+#endif
+                            #ifdef GPU_TRACE_ENABLED
+                             , gpu_trace::Recorder& _gt_rec
+                            #endif
+                             )
+    {
+      // cS-dependent coordinate partitions (always per-iteration)
+      static constexpr auto kLayoutV = make_layout(make_shape(_128{}, Int<kVStatsWidth>{}));
+      static constexpr auto kLayoutP = make_layout(make_shape(_128{}, _tilePlikeFP32()));
+
+      Tensor tScS = typename CollectiveMmaQK::TiledMma{}.get_slice(0).partition_C(cS);
+      Tensor tTMEM_LOADcS = tiled_tmem_load.get_slice(thread_idx).partition_D(tScS);
+      Tensor tScS_v = tScS.compose(kLayoutV);
+      Tensor tTMEM_STOREVcS = tiled_tmem_storev.get_slice(thread_idx).partition_S(tScS_v);
+      Tensor tScS_P = tScS.compose(kLayoutP);
+      Tensor tTMEM_STOREcS = tiled_tmem_store.get_slice(thread_idx).partition_S(tScS_P);
+
+      // tStS-dependent partitions: hoisted or recomputed based on AggressiveLoopInvariantCodeMotionOfSoftmax
+      auto get_LOADtS = [&]() {
+        if constexpr (!AggressiveLoopInvariantCodeMotionOfSoftmax) {
+          return tiled_tmem_load.get_slice(thread_idx).partition_S(tStS);
+        } else { return tTMEM_LOADtS; }
+      };
+      auto get_STOREVtS = [&]() {
+        if constexpr (!AggressiveLoopInvariantCodeMotionOfSoftmax) {
+          return tiled_tmem_storev.get_slice(thread_idx).partition_D(tStS_v);
+        } else { return tTMEM_STOREVtS; }
+      };
+      auto get_STOREtS_x4 = [&]() {
+        if constexpr (!AggressiveLoopInvariantCodeMotionOfSoftmax) {
+          auto t = tiled_tmem_store.get_slice(thread_idx).partition_D(tStS_P);
+          t.data() = warp_uniform(t.data().get());
+          return t;
+        } else { return tTMEM_STOREtS_x4; }
+      };
+      auto l_tTMEM_LOADtS = get_LOADtS();
+      auto l_tTMEM_STOREVtS = get_STOREVtS();
+      auto l_tTMEM_STOREtS_x4 = get_STOREtS_x4();
+
+      // read all of S from tmem into reg mem
+      Tensor tTMEM_LOADrS = make_tensor<ElementQK>(shape(tTMEM_LOADcS));
+
+      // wait on tensor core pipe
+      pipeline_s.consumer_wait(pipeline_s_consumer_state);
+
+      {GPU_TRACE_SCOPE(SOFTMAX_Mask);
+      if constexpr (!skip_computation) {
+        copy(tiled_tmem_load, l_tTMEM_LOADtS, tTMEM_LOADrS);
+        if constexpr (need_apply_mask) {
+          Mask{}.apply_mask(tTMEM_LOADrS, tTMEM_LOADcS, problem_shape);
+        }
+      }}
+
+      ElementQK old_row_max = row_max;
+      ElementQK tile_max = -INFINITY;
+      {GPU_TRACE_SCOPE(SOFTMAX_GetMax);
+      if constexpr (!skip_computation) {
+        // Off: start from row_max (fused running max, identical to original code)
+        // OnlyScore/Full: start from -inf to get per-tile max separately
+        float init_val;
+        if constexpr (!kNeedMaxScore) {
+          init_val = row_max;
+        } else {
+          init_val = -INFINITY;
+        }
+        float tile_max_0 = init_val;
+        float tile_max_1 = init_val;
+        float tile_max_2 = init_val;
+        float tile_max_3 = init_val;
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < size(tTMEM_LOADrS); i += 4) {
+          tile_max_0 = ::fmax(tile_max_0, tTMEM_LOADrS(i));
+          tile_max_1 = ::fmax(tile_max_1, tTMEM_LOADrS(i + 1));
+          tile_max_2 = ::fmax(tile_max_2, tTMEM_LOADrS(i + 2));
+          tile_max_3 = ::fmax(tile_max_3, tTMEM_LOADrS(i + 3));
+        }
+        tile_max = ::fmax(tile_max_0, tile_max_1);
+        tile_max = ::fmax(tile_max, tile_max_2);
+        tile_max = ::fmax(tile_max, tile_max_3);
+        if constexpr (kNeedMaxScore) {
+          row_max = ::fmax(row_max, tile_max);
+        } else {
+          row_max = tile_max;
+        }
+      }}
+
+      ElementQK row_max_safe = row_max == -INFINITY ? 0 : row_max;
+
+      // OnlyScore fuse: softmax thread already holds tile_max in its register
+      // (matching what correction would have read from V0/V1 TMEM). Write to
+      // GMEM directly here; correction will skip its own write (no double
+      // write, no TMEM round-trip for the value itself — though the V-channel
+      // STSM still happens because correction's loop body unconditionally
+      // reads V0/V1 for the rescale path's old/new max math, which is also
+      // kept for sync safety in v1).
+      if constexpr (kFuseMaxScoreIntoSoftmax) {
+        if (ms_base != nullptr) {
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+          gmem_stwt_checked(ms_base + k_tile_idx * ms_stride_k, tile_max,
+                            ms_check_base, ms_check_numel, "max_score_stwt");
+#else
+          __stwt(ms_base + k_tile_idx * ms_stride_k, tile_max);
+#endif
+        }
+        k_tile_idx += k_tile_idx_step;
+      }
+
+      // P2 (v3): OnlyScore fuse fully retires the V-channel TMEM round-trip in
+      // the main-loop iterations. The correction warp's only consumer of these
+      // STOREV values are (a) write_max_score (now no-op in OnlyScore: GMEM
+      // write fused into softmax, max() update unused), and (b) rescale-path
+      // exp2(old-new) which is kNeedOutput-gated. Both dead, so skip the store
+      // and let DCE remove old_row_max / row_max_safe wiring. final_call's
+      // STOREV (kIdxFinalRowMax/Sum) is preserved below for splitKV merge.
+      if constexpr (!kFuseMaxScoreIntoSoftmax) {
+        Tensor tTMEM_STOREVrS = make_tensor<ElementQK>(shape(tTMEM_STOREVcS));
+        tTMEM_STOREVrS(kIdxOldRowMax) = old_row_max;
+        if constexpr (kNeedMaxScore) {
+          tTMEM_STOREVrS(kIdxNewRowMax) = tile_max;
+        } else {
+          tTMEM_STOREVrS(kIdxNewRowMax) = row_max_safe;
+        }
+        copy(tiled_tmem_storev, tTMEM_STOREVrS, l_tTMEM_STOREVtS);
+      }
+
+      pipeline_c.producer_commit(pipeline_c_producer_state);
+      ++pipeline_c_producer_state;
+
+      Tensor tTMEM_STORErS_x4 = make_tensor<uint32_t>(shape(tTMEM_STOREcS));
+
+      if constexpr (!skip_computation && kNeedOutput) {
+        ElementQK scale = params.scale_softmax_log2;
+        ElementQK row_max_scale = row_max_safe * scale;
+
+        float2 scale_fp32x2 = make_float2(scale, scale);
+        float2 minus_row_max_scale_fp32x2 = make_float2(-row_max_scale, -row_max_scale);
+
+        constexpr int kConversionsPerStep = 2;
+
+        Tensor tTMEM_STORErS_x4_e = recast<Array<Element, kConversionsPerStep>>(tTMEM_STORErS_x4);
+
+        NumericArrayConverter<Element, ElementQK, kConversionsPerStep> convert;
+
+        {
+          GPU_TRACE_SCOPE(SOFTMAX_Exp);
+          CUTLASS_PRAGMA_UNROLL
+          for (int i = 0; i < size(tTMEM_LOADrS); i += 2) {
+            float2 in = make_float2(tTMEM_LOADrS(i + 0), tTMEM_LOADrS(i + 1));
+            float2 out;
+            cute::fma(out, scale_fp32x2, in, minus_row_max_scale_fp32x2);
+            tTMEM_LOADrS(i + 0) = out.x;
+            tTMEM_LOADrS(i + 1) = out.y;
+
+            if constexpr (EnableEmuExp2 && !need_apply_mask) {
+              constexpr int frg_cnt = decltype(size(tTMEM_LOADrS))::value / 32;
+              if (i >= (kExp2EmuStartFrg * 32) &&
+                  (!kExp2EmuSkipLastFrg || i < (32 * (frg_cnt - 1))) &&
+                  (i % kExp2EmuFreq) >= (kExp2EmuFreq - kExp2EmuRes)) {
+                exp2_emulated_2(tTMEM_LOADrS(i + 0), tTMEM_LOADrS(i + 1));
+              } else {
+                tTMEM_LOADrS(i + 0) = ::exp2f(tTMEM_LOADrS(i + 0));
+                tTMEM_LOADrS(i + 1) = ::exp2f(tTMEM_LOADrS(i + 1));
+              }
+            } else {
+              tTMEM_LOADrS(i + 0) = ::exp2f(tTMEM_LOADrS(i + 0));
+              tTMEM_LOADrS(i + 1) = ::exp2f(tTMEM_LOADrS(i + 1));
+            }
+
+            Array<ElementQK, kConversionsPerStep> in_conv;
+            CUTLASS_PRAGMA_UNROLL
+            for (int j = 0; j < kConversionsPerStep; j++) {
+              in_conv[j] = tTMEM_LOADrS(i + j);
+            }
+            tTMEM_STORErS_x4_e[i / kConversionsPerStep] = convert(in_conv);
+
+            if constexpr (size<2>(tTMEM_STORErS_x4) == _2{}) {
+              if (i == size(tTMEM_LOADrS) - 6) {
+                copy(tiled_tmem_store, tTMEM_STORErS_x4(_, _, 0), l_tTMEM_STOREtS_x4(_, _, 0));
+              }
+            }
+          }
+        }
+      } else if constexpr(kNeedOutput) {
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < size(tTMEM_STORErS_x4); i++) {
+          tTMEM_STORErS_x4(i) = 0u;
+        }
+      }
+
+      CUTE_STATIC_ASSERT_V(size<2>(tTMEM_STORErS_x4) <= _2{});
+      CUTE_STATIC_ASSERT_V(size<1>(tTMEM_STORErS_x4) == _1{});
+      if constexpr (skip_computation) {
+        CUTLASS_PRAGMA_UNROLL
+        for (int k = 0; k < size<2>(tTMEM_STORErS_x4); ++k) {
+          copy(tiled_tmem_store, tTMEM_STORErS_x4(_, _, k), l_tTMEM_STOREtS_x4(_, _, k));
+        }
+      } else if constexpr(kNeedOutput) {
+        copy(tiled_tmem_store, tTMEM_STORErS_x4(_, _, size<2>(tTMEM_STORErS_x4) - 1),
+            l_tTMEM_STOREtS_x4(_, _, size<2>(tTMEM_STORErS_x4) - 1));
+      }
+
+      cutlass::arch::fence_view_async_tmem_store();
+
+      pipeline_s.consumer_release(pipeline_s_consumer_state);
+      ++pipeline_s_consumer_state;
+
+      pipeline_c.producer_acquire(pipeline_c_producer_state);
+
+      {GPU_TRACE_SCOPE(SOFTMAX_Sum);
+      if constexpr (!skip_computation && kNeedOutput) {
+        ElementQK scale = params.scale_softmax_log2;
+        ElementQK acc_scale = 0.5f * ::exp2f(scale * (old_row_max - row_max_safe));
+        row_sum *= acc_scale;
+        float2 local_row_sum_f32x2 = make_float2(row_sum, row_sum);
+        float2 local_row_sum_1 = make_float2(0, 0);
+        float2 local_row_sum_2 = make_float2(0, 0);
+        float2 local_row_sum_3 = make_float2(0, 0);
+
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < size(tTMEM_LOADrS); i += 8) {
+          float2 in = make_float2(tTMEM_LOADrS(i), tTMEM_LOADrS(i + 1));
+          cute::add(local_row_sum_f32x2, local_row_sum_f32x2, in);
+
+          in = make_float2(tTMEM_LOADrS(i + 2), tTMEM_LOADrS(i + 2 + 1));
+          cute::add(local_row_sum_1, local_row_sum_1, in);
+
+          in = make_float2(tTMEM_LOADrS(i + 4), tTMEM_LOADrS(i + 4 + 1));
+          cute::add(local_row_sum_2, local_row_sum_2, in);
+
+          in = make_float2(tTMEM_LOADrS(i + 6), tTMEM_LOADrS(i + 6 + 1));
+          cute::add(local_row_sum_3, local_row_sum_3, in);
+        }
+
+        cute::add(local_row_sum_f32x2, local_row_sum_f32x2, local_row_sum_1);
+        cute::add(local_row_sum_2, local_row_sum_2, local_row_sum_3);
+        cute::add(local_row_sum_f32x2, local_row_sum_f32x2, local_row_sum_2);
+        float local_row_sum = local_row_sum_f32x2.x + local_row_sum_f32x2.y;
+
+        row_sum = local_row_sum;
+      }
+
+      if (final_call) {
+        pipeline_s.consumer_wait(pipeline_s_consumer_state);
+
+        Tensor tTMEM_STOREVrS = make_tensor<ElementQK>(shape(tTMEM_STOREVcS));
+        if constexpr (!skip_computation && kNeedOutput) {
+          tTMEM_STOREVrS(kIdxFinalRowMax) = row_max;
+          tTMEM_STOREVrS(kIdxFinalRowSum) = row_sum;
+        } else {
+          tTMEM_STOREVrS(kIdxFinalRowMax) = 0;
+          tTMEM_STOREVrS(kIdxFinalRowSum) = 0;
+        }
+        copy(tiled_tmem_storev, tTMEM_STOREVrS, l_tTMEM_STOREVtS);
+      }}
+    }  // end step()
+  };
+
+  template <bool kSingleWG = false, class Stage, class BlkCoord, class ProblemShape,
+            class ParamsProblemShape, class CollectiveEpilogue>
+  CUTLASS_DEVICE auto softmax(Stage stage, BlkCoord const& blk_coord, Params const& params,
+                              ParamsProblemShape const& params_problem_shape,
+                              ProblemShape const& problem_shape,
+                              CollectiveEpilogue const& epilogue,
+                              PipelineS& pipeline_s,
+                              typename PipelineS::PipelineState& pipeline_s_consumer_state,
+                              PipelineC& pipeline_c,
+                              typename PipelineC::PipelineState& pipeline_c_producer_state,
+                              int kv_tile_begin = 0, int kv_tile_end = INT_MAX,
+                              int q_offset_correction = 0) {
+    GET_GPU_TRACE(TRACE_SOFTMAX && (kSingleWG ? (cutlass::canonical_warp_idx_sync() % 2 == 0) : (cutlass::canonical_warp_idx_sync() % 4 == 0)));
+
+    int full_trip_count = get_full_trip_count(blk_coord, problem_shape, params.load.kv_block_num);
+
+    int total_trip_count;
+    int sub_q_offset = int(stage % get<0>(ThreadShape{})) * int(get<0>(TileShapeQK{}));
+    int sub_q_size = int(get<0>(TileShapeQK{}));
+    int skip_count, real_masked_count, unmasked_count;
+    int effective_end;
+
+    int kbi_off_s = 0;
+    if constexpr (kNeedSparse) {
+      int h_r_s = get<3, 0, 0>(problem_shape);
+      int num_kv_heads_s = get<3, 0, 1>(problem_shape);
+      int kv_head_idx_s = get<2, 0>(blk_coord) / h_r_s;
+      int batch_idx_s = get<2, 1>(blk_coord);
+      kbi_off_s = batch_idx_s * num_kv_heads_s * params.load.kv_block_num
+                + kv_head_idx_s * params.load.kv_block_num;
+    }
+
+    if constexpr (kNeedSparse) {
+      constexpr int full_tile_kv = get<1>(TileShape{});
+      if constexpr (IsSplitKV) {
+        effective_end = full_trip_count < kv_tile_end ? full_trip_count : kv_tile_end;
+        total_trip_count = effective_end - kv_tile_begin;
+        if (total_trip_count <= 0) total_trip_count = 0;
+      } else {
+        total_trip_count = full_trip_count;
+        effective_end = total_trip_count;
+      }
+
+      // Count padding blocks (backward scan for -1)
+      int valid_blks = params.load.kv_block_num;
+      while (valid_blks > 0 && __ldg(&params.load.kv_block_indexes[kbi_off_s + valid_blks - 1]) < 0)
+        valid_blks--;
+
+      int valid_tiles = (valid_blks * KVPageSize + full_tile_kv - 1) / full_tile_kv;
+      if constexpr (IsSplitKV) {
+        skip_count = max(0, effective_end - max(valid_tiles, kv_tile_begin));
+        real_masked_count = max(0, min(valid_tiles, effective_end) - kv_tile_begin);
+      } else {
+        skip_count = total_trip_count - valid_tiles;
+        real_masked_count = valid_tiles;
+      }
+      unmasked_count = 0;
+    } else if constexpr (IsSplitKV) {
+      effective_end = full_trip_count < kv_tile_end ? full_trip_count : kv_tile_end;
+      int local_trip = effective_end - kv_tile_begin;
+      if (local_trip <= 0) local_trip = 0;
+      total_trip_count = local_trip;
+
+      int full_per_warp = Mask{}.get_trip_count(blk_coord, TileShape{}, problem_shape,
+                                                sub_q_offset, sub_q_size);
+      int full_masked = Mask{}.get_masked_trip_count(blk_coord, TileShape{}, problem_shape,
+                                                      sub_q_offset, sub_q_size);
+      int unmasked_boundary = full_trip_count - full_masked;
+
+      skip_count     = max(0, min(effective_end, full_trip_count) - max(kv_tile_begin, full_per_warp));
+      real_masked_count = max(0, min(effective_end, full_per_warp) - max(kv_tile_begin, unmasked_boundary));
+      unmasked_count = max(0, min(effective_end, unmasked_boundary) - kv_tile_begin);
+    } else {
+      total_trip_count = full_trip_count;
+      effective_end = full_trip_count;
+
+      int per_warp_trip = Mask{}.get_trip_count(blk_coord, TileShape{}, problem_shape,
+                                                sub_q_offset, sub_q_size);
+      int masked_count = Mask{}.get_masked_trip_count(blk_coord, TileShape{}, problem_shape,
+                                                      sub_q_offset, sub_q_size);
+      skip_count = total_trip_count - per_warp_trip;
+      real_masked_count = masked_count - skip_count;
+      unmasked_count = total_trip_count - masked_count;
+    }
+
+    ElementQK row_max = -INFINITY;
+    ElementQK row_sum = 0;
+
+    // Reverse iteration: start cS at the highest KV tile position in our range
+    Tensor cS_base = make_identity_tensor(select<0, 1>(TileShapeQK{}));
+    auto logical_offset = make_coord(get<0>(blk_coord) * get<0>(TileShape{}) +
+                                         (stage % get<0>(ThreadShape{})) * get<0>(TileShapeQK{})
+                                         + (kSingleWG ? q_offset_correction : 0),
+                                     (effective_end - 1) * get<1>(ThreadShape{}) * get<1>(TileShapeQK{})
+                                         + (stage % get<1>(ThreadShape{})) * get<1>(TileShapeQK{}));
+    Tensor cS = domain_offset(logical_offset, cS_base);
+
+    int sparse_tile_counter = 0;
+    // Returns true if tile is fully unmasked (sorted blocks → all remaining are too)
+    auto sparse_update_cS = [&]() -> bool {
+      if constexpr (kNeedSparse) {
+        int tile_from_end = effective_end - 1 - sparse_tile_counter;
+        int q_s = get<0>(blk_coord) * get<0>(TileShape{})
+                + (stage % get<0>(ThreadShape{})) * get<0>(TileShapeQK{})
+                + (kSingleWG ? q_offset_correction : 0);
+        int kv_sub = (stage % get<1>(ThreadShape{})) * get<1>(TileShapeQK{});
+        int sparse_linear_pos = tile_from_end * int(get<1>(TileShape{})) + kv_sub;
+        uint page_idx = uint(sparse_linear_pos / KVPageSize);
+        int offset_in_page = sparse_linear_pos % KVPageSize;
+        sparse_tile_counter++;
+        if (page_idx >= params.load.kv_block_num) {
+          cS = domain_offset(make_coord(q_s, INT_MAX / 2), cS_base);
+          return false;
+        }
+        int pos = __ldg(&params.load.kv_block_indexes[kbi_off_s + page_idx]);
+        if (pos < 0) {
+          cS = domain_offset(make_coord(q_s, INT_MAX / 2), cS_base);
+          return false;
+        }
+        int kv_coord = pos * KVPageSize + offset_in_page;
+        cS = domain_offset(make_coord(q_s, kv_coord), cS_base);
+        int causal_bound = Mask{}.sparse_causal_bound(q_s, problem_shape);
+        constexpr int sub_tile_kv = get<1>(TileShapeQK{});
+        return kv_coord + sub_tile_kv <= causal_bound + 1;
+      }
+      return false;
+    };
+
+    SoftmaxCtx softmax_ctx(stage);
+
+    // OnlyScore fuse v1: precompute per-thread GMEM max_score addr.
+    // Same row→thread mapping as correction (32dp32b2x partition is
+    // symmetric for store and load), so softmax thread t writes the row
+    // correction thread t would have written. v1 keeps all TMEM and
+    // pipeline_c sync intact; correction only skips its own GMEM
+    // write_max_score under kFuseMaxScoreIntoSoftmax.
+    float* ms_base = nullptr;
+    int ms_stride_k = 0;
+    int k_tile_idx = 0;
+    static constexpr int kTilesPerMacro =
+        (get<1>(ThreadShape{}) > 1) ? 2 : 1;
+    int k_tile_idx_step = -kTilesPerMacro;
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+    const float* ms_check_base = nullptr;
+    int ms_check_numel = 0;
+#endif
+    if constexpr (kFuseMaxScoreIntoSoftmax) {
+      int thread_idx_local = threadIdx.x % (4 * cutlass::NumThreadsPerWarp);
+      Tensor cS_for_addr = make_identity_tensor(select<0, 1>(TileShapeQK{}));
+      Tensor tScS_for_addr =
+          typename CollectiveMmaQK::TiledMma{}.get_slice(0).partition_C(cS_for_addr);
+      Tensor tScS_v_for_addr =
+          tScS_for_addr.compose(make_layout(make_shape(_128{}, Int<kVStatsWidth>{})));
+      Tensor tTMEM_STOREVcS_addr =
+          softmax_ctx.tiled_tmem_storev.get_slice(thread_idx_local)
+                                       .partition_S(tScS_v_for_addr);
+      int local_row = get<0>(tTMEM_STOREVcS_addr(_0{}));
+      int abs_row = get<0>(blk_coord) * int(get<0>(TileShape{}))
+                  + (int(stage) % int(get<0>(ThreadShape{}))) * int(get<0>(TileShapeQK{}))
+                  + (kSingleWG ? q_offset_correction : 0)
+                  + local_row;
+
+      uint qo_len = uint(get<0>(problem_shape));
+      if (uint(abs_row) < qo_len) {
+        int qo_head_idx = get<2, 0>(blk_coord);
+        int batch_idx = get<2, 1>(blk_coord);
+        int _seg_off_sz = get<3, 1>(params_problem_shape) + 1;
+        int segment_offset = SEG_OFF_LOAD(get<0>(params_problem_shape), batch_idx, _seg_off_sz);
+
+        static constexpr int kPackFactor = pack_factor_of<Mask>::value;
+        auto packed_maxscore_path = [&]() {
+          Tensor gMaxScore = make_tensor(
+              make_gmem_ptr(epilogue.params.ptr_MaxScore),
+              epilogue.params.layout_MaxScore);
+          ms_stride_k = int(&gMaxScore(0, 0, 1) - &gMaxScore(0, 0, 0));
+          ms_base = &gMaxScore(segment_offset + abs_row, qo_head_idx, 0);
+        };
+
+        if constexpr (kPackFactor > 1) {
+          if (epilogue.params.ptr_MaxScore_direct != nullptr) {
+            int rem_hr = get<3, 0, 0>(params_problem_shape);
+            int h_r_orig = rem_hr * kPackFactor;
+            int kv_head = qo_head_idx / rem_hr;
+            int rem_hr_idx = qo_head_idx % rem_hr;
+            int seg_off_orig = segment_offset / kPackFactor;
+            ms_stride_k = epilogue.params.max_score_stride_k;
+            int actual_tok = abs_row / kPackFactor;
+            int pf_idx = abs_row % kPackFactor;
+            int unpacked_head = kv_head * h_r_orig + rem_hr_idx * kPackFactor + pf_idx;
+            ms_base = epilogue.params.ptr_MaxScore_direct
+                    + unpacked_head * epilogue.params.max_score_stride_h
+                    + (seg_off_orig + actual_tok) * epilogue.params.max_score_stride_t;
+          } else {
+            packed_maxscore_path();
+          }
+        } else {
+          packed_maxscore_path();
+        }
+      }
+
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+      ms_check_base = epilogue.params.ptr_MaxScore_direct
+                        ? epilogue.params.ptr_MaxScore_direct
+                        : epilogue.params.ptr_MaxScore;
+      ms_check_numel = epilogue.params.max_score_numel;
+#endif
+
+      int stage_k_off = int(stage) % int(get<1>(ThreadShape{}));
+      k_tile_idx = (effective_end - 1) * kTilesPerMacro + stage_k_off;
+    }
+
+    pipeline_c.producer_acquire(pipeline_c_producer_state);
+
+    sparse_update_cS();
+
+    // Skip fully-masked tiles (padding in sparse mode, or above causal boundary)
+    CUTLASS_PRAGMA_NO_UNROLL
+    for (int i = 0; i < skip_count; i++) {
+      bool is_last_step = (i == skip_count - 1) && (real_masked_count == 0) && (unmasked_count == 0);
+      softmax_ctx.template step<true, true /* skip_computation */>(
+          row_max, row_sum, stage, is_last_step,
+          blk_coord, cS, params, problem_shape, pipeline_s, pipeline_s_consumer_state, pipeline_c,
+          pipeline_c_producer_state, ms_base, ms_stride_k, k_tile_idx, k_tile_idx_step
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+          , ms_check_base, ms_check_numel
+#endif
+        #ifdef GPU_TRACE_ENABLED
+          , _gt_rec
+        #endif
+        );
+
+      if constexpr (!kNeedSparse) {
+        cS.data() = cS.data() + E<1>{} * (-(int)(get<1>(ThreadShape{}) * get<1>(TileShapeQK{})));
+      }
+      else {
+        sparse_update_cS();
+      }
+    }
+
+    if constexpr (kNeedSparse) {
+      // Masked loop: step<true> for skip-above + near-diagonal tiles.
+      // Blocks are sorted so once we hit cls==1 (unmasked), all remaining are unmasked.
+      int valid_remaining = real_masked_count;
+      CUTLASS_PRAGMA_NO_UNROLL
+      for (; valid_remaining > 0; ) {
+        softmax_ctx.template step<true /* masked */>(
+            row_max, row_sum, stage,
+            (valid_remaining == 1),
+            blk_coord, cS, params, problem_shape, pipeline_s, pipeline_s_consumer_state, pipeline_c,
+            pipeline_c_producer_state, ms_base, ms_stride_k, k_tile_idx, k_tile_idx_step
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+          , ms_check_base, ms_check_numel
+#endif
+          #ifdef GPU_TRACE_ENABLED
+            , _gt_rec
+          #endif
+          );
+          valid_remaining--;
+          if (sparse_update_cS()) break;
+      }
+
+      CUTLASS_PRAGMA_NO_UNROLL
+      for (; valid_remaining > 0; valid_remaining--) {
+        softmax_ctx.template step<false /* unmasked */>(
+            row_max, row_sum, stage,
+            (valid_remaining == 1),
+            blk_coord, cS, params, problem_shape, pipeline_s, pipeline_s_consumer_state, pipeline_c,
+            pipeline_c_producer_state, ms_base, ms_stride_k, k_tile_idx, k_tile_idx_step
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+          , ms_check_base, ms_check_numel
+#endif
+          #ifdef GPU_TRACE_ENABLED
+            , _gt_rec
+          #endif
+          );
+      }
+    } else {
+      // Masked iterations (near causal diagonal, need element-wise masking)
+      int mask_tile_count = real_masked_count;
+      CUTLASS_PRAGMA_NO_UNROLL
+      for (; mask_tile_count > 0; mask_tile_count -= 1) {
+        softmax_ctx.template step<true /* need_apply_mask */>(
+            row_max, row_sum, stage,
+            (mask_tile_count == 1) && (unmasked_count == 0),
+            blk_coord, cS, params, problem_shape, pipeline_s, pipeline_s_consumer_state, pipeline_c,
+            pipeline_c_producer_state, ms_base, ms_stride_k, k_tile_idx, k_tile_idx_step
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+          , ms_check_base, ms_check_numel
+#endif
+          #ifdef GPU_TRACE_ENABLED
+            , _gt_rec
+          #endif
+          );
+
+        cS.data() = cS.data() + E<1>{} * (-(int)(get<1>(ThreadShape{}) * get<1>(TileShapeQK{})));
+      }
+
+      // Unmasked iterations (low KV index, far from diagonal)
+      mask_tile_count = unmasked_count;
+      CUTLASS_PRAGMA_NO_UNROLL
+      for (; mask_tile_count > 0; mask_tile_count -= 1) {
+        softmax_ctx.template step<false /* need_apply_mask */>(
+            row_max, row_sum, stage,
+            mask_tile_count == 1,
+            blk_coord, cS, params, problem_shape, pipeline_s, pipeline_s_consumer_state, pipeline_c,
+            pipeline_c_producer_state, ms_base, ms_stride_k, k_tile_idx, k_tile_idx_step
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+          , ms_check_base, ms_check_numel
+#endif
+          #ifdef GPU_TRACE_ENABLED
+            , _gt_rec
+          #endif
+          );
+
+        cS.data() = cS.data() + E<1>{} * (-(int)(get<1>(ThreadShape{}) * get<1>(TileShapeQK{})));
+      }
+    }
+
+    pipeline_c.producer_commit(pipeline_c_producer_state);
+    ++pipeline_c_producer_state;
+
+    pipeline_c.producer_acquire(pipeline_c_producer_state);
+    // empty step to sync against pipe s
+    pipeline_s.consumer_release(pipeline_s_consumer_state);
+    ++pipeline_s_consumer_state;
+    RELEASE_GPU_TRACE;
+  }
+
+  template <class Stage, class TensorO>
+  CUTLASS_DEVICE auto correction_epilogue(float scale, Stage stage, TensorO const& sO_01) {
+    using ElementOut = typename TensorO::value_type;
+
+    int thread_idx = threadIdx.x % (4 * cutlass::NumThreadsPerWarp);
+
+    Tensor sO = sO_01(_, _, stage);
+
+    // As opposed to the softmax, we do not have enough registers here
+    // to load all of the values (for tile kv = 128), so we loop
+    // good values would be either 32 or 64
+    const int kCorrectionTileSize = 32 / sizeof(ElementOut);
+
+    using TMEM_LOAD =
+        std::conditional_t<kCorrectionTileSize == 32, SM100_TMEM_LOAD_32dp32b32x,
+                           SM100_TMEM_LOAD_32dp32b16x>;  // 4x32 threads with 64 cols of 32b elem
+
+    typename CollectiveMmaPV::TiledMma mma;
+    Tensor cO = make_identity_tensor(select<0, 1>(TileShapePV{}));
+    Tensor tOtO = partition_fragment_C(mma, select<0, 1>(TileShapePV{}));
+    Tensor tOcO = mma.get_slice(0).partition_C(cO);
+    Tensor tOsO = mma.get_slice(0).partition_C(sO);
+
+    Tensor tOtO_i =
+        logical_divide(tOtO, make_layout(make_shape(_128{}, Int<kCorrectionTileSize>{})));
+    Tensor tOcO_i =
+        logical_divide(tOcO, make_layout(make_shape(_128{}, Int<kCorrectionTileSize>{})));
+    Tensor tOsO_i =
+        logical_divide(tOsO, make_layout(make_shape(_128{}, Int<kCorrectionTileSize>{})));
+
+    if constexpr (decltype(stage == _0{})::value) {
+      tOtO_i.data() = tOtO_i.data().get() + uint32_t(TmemAllocation::O0);
+    } else {
+      static_assert(decltype(stage == _1{})::value, "stage is either 0 or 1");
+      tOtO_i.data() = tOtO_i.data().get() + uint32_t(TmemAllocation::O1);
+    }
+
+    auto tiled_tmem_load = make_tmem_copy(TMEM_LOAD{}, tOtO_i(make_coord(_, _), _0{}));
+    auto thr_tmem_load = tiled_tmem_load.get_slice(thread_idx);
+
+    Tensor tTMEM_LOADtO = thr_tmem_load.partition_S(tOtO_i(make_coord(_, _), _));
+    Tensor tTMEM_LOADcO = thr_tmem_load.partition_D(tOcO_i(make_coord(_, _), _));
+    Tensor tTMEM_LOADsO = thr_tmem_load.partition_D(tOsO_i(make_coord(_, _), _));
+
+    float2 scale_f32x2 = make_float2(scale, scale);
+
+    // loop:
+    //   TMEM_LOAD, FMUL2 scale, TMEM_STORE
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < get<1>(TileShapePV{}) / kCorrectionTileSize; i++) {
+      Tensor tTMEM_LOADtO_i = tTMEM_LOADtO(_, _0{}, _0{}, i);
+      Tensor tTMEM_LOADsO_i = tTMEM_LOADsO(_, _0{}, _0{}, i);
+
+      Tensor tTMrO = make_tensor<ElementPV>(shape(tTMEM_LOADcO(_, _0{}, _0{}, i)));
+
+      copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMrO);
+
+#ifndef ONLY_SOFTMAX
+      CUTLASS_PRAGMA_UNROLL
+      for (int j = 0; j < size(tTMrO); j += 2) {
+        float2 in = make_float2(tTMrO(j), tTMrO(j + 1));
+        float2 out;
+        cute::mul(out, scale_f32x2, in);
+        tTMrO(j) = out.x;
+        tTMrO(j + 1) = out.y;
+      }
+#endif
+
+      constexpr int N = 4 / sizeof(ElementOut);
+      NumericArrayConverter<ElementOut, ElementPV, N> convert;
+
+      Tensor tSMrO = make_tensor_like<ElementOut>(tTMrO);
+
+      Tensor tCs = recast<decltype(convert)::source_type>(tTMrO);
+      Tensor tCd = recast<decltype(convert)::result_type>(tSMrO);
+
+      CUTLASS_PRAGMA_UNROLL
+      for (int j = 0; j < size(tCs); j++) {
+        tCd(j) = convert.convert(tCs(j));
+      }
+
+      Tensor tSMsO_i = recast<uint32_t>(tTMEM_LOADsO_i);
+      Tensor tSMrO_i = recast<uint32_t>(tSMrO);
+
+      copy(AutoVectorizingCopyWithAssumedAlignment<128>{}, tSMrO_i, tSMsO_i);
+    }
+
+    cutlass::arch::fence_view_async_shared();
+  }
+
+  CUTLASS_DEVICE auto correction_rescale(float scale, uint32_t tmem_O) {
+    int thread_idx = threadIdx.x % (4 * cutlass::NumThreadsPerWarp);
+
+    // As opposed to the softmax, we do not have enough registers here
+    // to load all of the values (for tile kv = 128), so we loop
+    // good values would be either 32 or 64
+    const int kCorrectionTileSize = 16;
+
+    using TMEM_LOAD = SM100_TMEM_LOAD_32dp32b16x;    // 4x32 threads with 64 cols of 32b elem
+    using TMEM_STORE = SM100_TMEM_STORE_32dp32b16x;  // 4x32 threads with 64 cols of 32b elem
+
+    typename CollectiveMmaPV::TiledMma mma;
+    Tensor cO = make_identity_tensor(select<0, 1>(TileShapePV{}));
+    Tensor tOtO = partition_fragment_C(mma, select<0, 1>(TileShapePV{}));
+    Tensor tOcO = mma.get_slice(0).partition_C(cO);
+
+    Tensor tOtO_i = tOtO.compose(make_layout(make_shape(_128{}, Int<kCorrectionTileSize>{})));
+    Tensor tOcO_i = tOcO.compose(make_layout(make_shape(_128{}, Int<kCorrectionTileSize>{})));
+
+    tOtO_i.data() = tOtO_i.data().get() + tmem_O;
+
+    auto tiled_tmem_load = make_tmem_copy(TMEM_LOAD{}, tOtO_i);
+    auto thr_tmem_load = tiled_tmem_load.get_slice(thread_idx);
+    auto tiled_tmem_store = make_tmem_copy(TMEM_STORE{}, tOtO_i);
+    auto thr_tmem_store = tiled_tmem_store.get_slice(thread_idx);
+
+    Tensor tTMEM_LOADtO = thr_tmem_load.partition_S(tOtO_i);
+    Tensor tTMEM_LOADcO = thr_tmem_load.partition_D(tOcO_i);
+    Tensor tTMEM_STOREtO = thr_tmem_store.partition_D(tOtO_i);
+    Tensor tTMEM_STOREcO = thr_tmem_store.partition_S(tOcO_i);
+    static_assert(shape(tTMEM_STOREcO) == shape(tTMEM_LOADcO));
+
+    float2 scale_f32x2 = make_float2(scale, scale);
+
+    Tensor tTMrO = make_tensor<ElementPV>(
+        make_shape(shape(tTMEM_LOADcO), Int<get<1>(TileShapePV{}) / kCorrectionTileSize>{}));
+
+    auto copy_in = [&](int i) {
+      Tensor tTMEM_LOADtO_i = tTMEM_LOADtO;
+      tTMEM_LOADtO_i.data() = tTMEM_LOADtO_i.data().get() + uint32_t(i * kCorrectionTileSize);
+      Tensor tTMrO_i = tTMrO(_, i).compose(make_layout(shape<0>(tTMrO)));
+      copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMrO_i);
+    };
+
+    auto copy_out = [&](int i) {
+      Tensor tTMEM_STOREtO_i = tTMEM_STOREtO;
+      tTMEM_STOREtO_i.data() = tTMEM_STOREtO_i.data().get() + uint32_t(i * kCorrectionTileSize);
+      Tensor tTMrO_i = tTMrO(_, i).compose(make_layout(shape<0>(tTMrO)));
+      copy(tiled_tmem_store, tTMrO_i, tTMEM_STOREtO_i);
+    };
+
+    // sequence: LLMSLMSLMSS
+
+    // loop:
+    //   TMEM_LOAD, FMUL2 scale, TMEM_STORE
+    copy_in(0);
+
+    int count = get<1>(TileShapePV{}) / kCorrectionTileSize;
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < count; i++) {
+      if (i != count - 1) {
+        copy_in(i + 1);
+      }
+
+      Tensor tTMrO_i = tTMrO(_, i).compose(make_layout(shape<0>(tTMrO)));
+      CUTLASS_PRAGMA_UNROLL
+      for (int j = 0; j < size(tTMrO_i); j += 2) {
+        float2 in = make_float2(tTMrO_i(j), tTMrO_i(j + 1));
+        float2 out;
+        cute::mul(out, scale_f32x2, in);
+        tTMrO_i(j) = out.x;
+        tTMrO_i(j + 1) = out.y;
+      }
+
+      copy_out(i);
+    }
+  }
+
+
+  // K-split: rescale O0/O1 by online softmax factors and accumulate O1 into O0 in TMEM.
+  // Returns total_sum for the final epilogue scaling.
+  template <bool kSingleWG = false, class TensorV>
+  CUTLASS_DEVICE auto correction_merge_ksplit(
+      Params const& params, TensorV const& tTMEM_LOADVrS0, TensorV const& tTMEM_LOADVrS1,
+      float* smem_scratch = nullptr) {
+    ElementPV row_max_0 = tTMEM_LOADVrS0(kIdxFinalRowMax);
+    ElementPV row_sum_0 = tTMEM_LOADVrS0(kIdxFinalRowSum);
+    ElementPV row_max_1 = tTMEM_LOADVrS1(kIdxFinalRowMax);
+    ElementPV row_sum_1 = tTMEM_LOADVrS1(kIdxFinalRowSum);
+
+    // Phase 2: exchange V stats between partner threads via SMEM
+    // Thread k has V0[k], thread k+64 has V1[k+64]. Each needs the partner's stats.
+    if constexpr (kSingleWG) {
+      int tidx = threadIdx.x % (4 * cutlass::NumThreadsPerWarp);
+      bool is_lower = (tidx < 64);
+      int partner = is_lower ? tidx : (tidx - 64);
+      // Correction warpgroup barrier (not CTA-wide — softmax warps may have exited)
+      constexpr int kCorrBarrierId = 8;
+      constexpr int kCorrThreads = 4 * cutlass::NumThreadsPerWarp;
+      auto corr_sync = [&]() { cutlass::arch::NamedBarrier::sync(kCorrThreads, kCorrBarrierId); };
+      // smem_scratch layout: [0..63] lower's V0 max, [64..127] lower's V0 sum,
+      //                      [128..191] upper's V1 max, [192..255] upper's V1 sum
+      if (is_lower) {
+        smem_scratch[partner] = row_max_0;
+        smem_scratch[64 + partner] = row_sum_0;
+      } else {
+        smem_scratch[128 + partner] = row_max_1;
+        smem_scratch[192 + partner] = row_sum_1;
+      }
+      corr_sync();
+      // Each half reads the partner's stats from the OTHER region
+      if (is_lower) {
+        row_max_1 = smem_scratch[128 + tidx];
+        row_sum_1 = smem_scratch[192 + tidx];
+      } else {
+        row_max_0 = smem_scratch[tidx - 64];
+        row_sum_0 = smem_scratch[64 + tidx - 64];
+      }
+      corr_sync();
+    }
+
+    ElementPV total_max = ::fmaxf(row_max_0, row_max_1);
+    // Guard against -inf - (-inf) = NaN when all positions are masked
+    ElementPV rescale_0 = (total_max == -INFINITY) ? 0.f
+        : ::exp2f(params.scale_softmax_log2 * (row_max_0 - total_max));
+    ElementPV rescale_1 = (total_max == -INFINITY) ? 0.f
+        : ::exp2f(params.scale_softmax_log2 * (row_max_1 - total_max));
+    ElementPV total_sum = row_sum_0 * rescale_0 + row_sum_1 * rescale_1;
+
+    // Fused rescale + accumulate: O0 = O0 * rescale_0 + O1 * rescale_1
+    {
+      int thread_idx_corr = threadIdx.x % (4 * cutlass::NumThreadsPerWarp);
+      constexpr int kAccTile = 16;
+      using TMEM_LOAD_ACC = SM100_TMEM_LOAD_32dp32b16x;
+      using TMEM_STORE_ACC = SM100_TMEM_STORE_32dp32b16x;
+      typename CollectiveMmaPV::TiledMma mma_acc;
+      Tensor tOtO_base = partition_fragment_C(mma_acc, select<0, 1>(TileShapePV{}));
+      Tensor tOtO_tile = tOtO_base.compose(make_layout(make_shape(_128{}, Int<kAccTile>{})));
+
+      Tensor tOtO0_tile = tOtO_tile;
+      tOtO0_tile.data() = tOtO0_tile.data().get() + uint32_t(TmemAllocation::O0);
+      Tensor tOtO1_tile = tOtO_tile;
+      tOtO1_tile.data() = tOtO1_tile.data().get() + uint32_t(TmemAllocation::O1);
+
+      auto tmem_load_acc = make_tmem_copy(TMEM_LOAD_ACC{}, tOtO0_tile);
+      auto tmem_store_acc = make_tmem_copy(TMEM_STORE_ACC{}, tOtO0_tile);
+      auto thr_load = tmem_load_acc.get_slice(thread_idx_corr);
+      auto thr_store = tmem_store_acc.get_slice(thread_idx_corr);
+
+      Tensor tSrcO0 = thr_load.partition_S(tOtO0_tile);
+      Tensor tSrcO1 = thr_load.partition_S(tOtO1_tile);
+      Tensor tDstO0 = thr_store.partition_D(tOtO0_tile);
+      Tensor cO_tile = make_identity_tensor(make_shape(_128{}, Int<kAccTile>{}));
+
+      constexpr int n_acc_tiles = get<1>(TileShapePV{}) / kAccTile;
+
+      if constexpr (!kSingleWG) {
+        float2 rescale_0_f2 = make_float2(rescale_0, rescale_0);
+        CUTLASS_PRAGMA_UNROLL
+        for (int t = 0; t < n_acc_tiles; t++) {
+          Tensor src0 = tSrcO0; src0.data() = src0.data().get() + uint32_t(t * kAccTile);
+          Tensor src1 = tSrcO1; src1.data() = src1.data().get() + uint32_t(t * kAccTile);
+          Tensor dst0 = tDstO0; dst0.data() = dst0.data().get() + uint32_t(t * kAccTile);
+
+          auto rO0 = make_tensor<ElementPV>(shape(thr_load.partition_D(cO_tile)));
+          auto rO1 = make_tensor<ElementPV>(shape(rO0));
+          copy(tmem_load_acc, src0, rO0);
+          copy(tmem_load_acc, src1, rO1);
+          CUTLASS_PRAGMA_UNROLL
+          for (int j = 0; j < size(rO0); j += 2) {
+            float2 v0 = make_float2(rO0(j), rO0(j + 1));
+            float2 v1 = make_float2(rO1(j), rO1(j + 1));
+            float2 out;
+            cute::mul(out, rescale_0_f2, v0);
+            out.x = __fmaf_rn(v1.x, rescale_1, out.x);
+            out.y = __fmaf_rn(v1.y, rescale_1, out.y);
+            rO0(j) = out.x;
+            rO0(j + 1) = out.y;
+          }
+          copy(tmem_store_acc, rO0, dst0);
+        }
+      } else {
+        bool is_lower = (thread_idx_corr < 64);
+        int partner = is_lower ? thread_idx_corr : (thread_idx_corr - 64);
+        float* smem_o_xchg = smem_scratch + 256;
+        constexpr int kCorrBarrierId2 = 9;
+        constexpr int kCorrThreads = 4 * cutlass::NumThreadsPerWarp;
+        auto corr_sync = [&]() { cutlass::arch::NamedBarrier::sync(kCorrThreads, kCorrBarrierId2); };
+
+        CUTLASS_PRAGMA_UNROLL
+        for (int t = 0; t < n_acc_tiles; t++) {
+          auto rO = make_tensor<ElementPV>(shape(thr_load.partition_D(cO_tile)));
+          int n_elem = size(rO);
+
+          if (!is_lower) {
+            Tensor src1 = tSrcO1; src1.data() = src1.data().get() + uint32_t(t * kAccTile);
+            copy(tmem_load_acc, src1, rO);
+            CUTLASS_PRAGMA_UNROLL
+            for (int j = 0; j < n_elem; j++) {
+              smem_o_xchg[partner * n_elem + j] = rO(j) * rescale_1;
+            }
+          }
+          corr_sync();
+
+          if (is_lower) {
+            Tensor src0 = tSrcO0; src0.data() = src0.data().get() + uint32_t(t * kAccTile);
+            Tensor dst0 = tDstO0; dst0.data() = dst0.data().get() + uint32_t(t * kAccTile);
+            copy(tmem_load_acc, src0, rO);
+            CUTLASS_PRAGMA_UNROLL
+            for (int j = 0; j < n_elem; j++) {
+              rO(j) = __fmaf_rn(rO(j), rescale_0, smem_o_xchg[thread_idx_corr * n_elem + j]);
+            }
+            copy(tmem_store_acc, rO, dst0);
+          }
+          corr_sync();
+        }
+      }
+
+      cutlass::arch::fence_view_async_tmem_store();
+    }
+
+    struct MergeResult { ElementPV total_sum; ElementPV total_max; };
+    return MergeResult{total_sum, total_max};
+  }
+
+  template <bool kSingleWG = false, class BlkCoord, class ParamsProblemShape, class ProblemShape, class TensorStorageEpi,
+            class CollectiveEpilogue>
+  CUTLASS_DEVICE auto correction(
+      BlkCoord const& blk_coord, Params const& params,
+      ParamsProblemShape const& params_problem_shape, ProblemShape const& problem_shape,
+      TensorStorageEpi& shared_storage_epi, PipelineC& pipeline_s0_c,
+      typename PipelineC::PipelineState& pipeline_s0_c_consumer_state, PipelineC& pipeline_s1_c,
+      typename PipelineC::PipelineState& pipeline_s1_c_consumer_state, PipelineO& pipeline_corr,
+      PipelineE& pipeline_epi,
+      typename PipelineE::PipelineState& pipeline_epi_producer_state,
+      CollectiveEpilogue& epilogue,
+      int kv_tile_begin = 0, int kv_tile_end = INT_MAX,
+      int kv_split_idx = 0,
+      SplitKVParams split_kv = {}) {
+
+    GET_GPU_TRACE(TRACE_CORR && (cutlass::canonical_warp_idx_sync() % 4 == 0));
+
+    int mask_tile_count = get_effective_trip_count(blk_coord, problem_shape,
+                                                   kv_tile_begin, kv_tile_end, params.load.kv_block_num);
+    int effective_end = kv_tile_begin + mask_tile_count;
+
+    int thread_idx = threadIdx.x % (4 * cutlass::NumThreadsPerWarp);
+
+    Tensor tStS =
+        partition_fragment_C(typename CollectiveMmaQK::TiledMma{}, select<0, 1>(TileShapeQK{}));
+
+    Tensor cS = make_identity_tensor(select<0, 1>(TileShapeQK{}));
+    Tensor tScS = typename CollectiveMmaQK::TiledMma{}.get_slice(0).partition_C(cS);
+
+    Tensor tStS_v = tStS.compose(make_layout(make_shape(_128{}, Int<kVStatsWidth>{})));
+    Tensor tScS_v = tScS.compose(make_layout(make_shape(_128{}, Int<kVStatsWidth>{})));
+
+    using TMEM_LOAD_V = SM100_TMEM_LOAD_32dp32b2x;
+
+    auto tiled_tmem_loadv = make_tmem_copy(TMEM_LOAD_V{}, tStS_v);
+    auto thr_tmem_loadv = tiled_tmem_loadv.get_slice(thread_idx);
+
+    Tensor tTMEM_LOADVtS = thr_tmem_loadv.partition_S(tStS_v);
+    Tensor tTMEM_LOADVcS = thr_tmem_loadv.partition_D(tScS_v);
+
+    Tensor tTMEM_LOADVtS0 = tTMEM_LOADVtS;
+    tTMEM_LOADVtS0.data() = tTMEM_LOADVtS0.data().get() + uint32_t(TmemAllocation::V0);
+    Tensor tTMEM_LOADVtS1 = tTMEM_LOADVtS;
+    tTMEM_LOADVtS1.data() = tTMEM_LOADVtS1.data().get() + uint32_t(TmemAllocation::V1);
+
+    // Determine if this correction warp handles all-padding Q rows
+    int corr_warp_in_wg = thread_idx / cutlass::NumThreadsPerWarp;
+    int corr_first_row = corr_warp_in_wg * 32;
+    if constexpr (kSingleWG) {
+      corr_first_row = corr_first_row % 64;  // rows 64-127 are duplicates of 0-63
+    }
+    bool is_padding_corr = (corr_first_row >= int(get<0>(problem_shape)));
+    static constexpr bool kIsKSplit = get<1>(ThreadShape{}) > 1;
+    static constexpr int kS1RowOffset = kIsKSplit ? (kSingleWG ? -64 : 0) : int(get<0>(TileShapeQK{}));
+
+    // K tiles are iterated in REVERSE order (last to first) for causal.
+    static constexpr int kTilesPerMacro = kIsKSplit ? 2 : 1;
+    int k_tile_idx;
+
+    float* ms_base_s0 = nullptr;
+    float* ms_base_s1 = nullptr;
+    int ms_stride_k = 0;
+    if constexpr (kNeedMaxScore) {
+      k_tile_idx = (effective_end - 1) * kTilesPerMacro;
+      int qo_head_idx = get<2, 0>(blk_coord);
+      int batch_idx = get<2, 1>(blk_coord);
+      uint qo_len = uint(get<0>(problem_shape));
+      int segment_offset = get<0>(params_problem_shape).segment_offsets[batch_idx];
+      int row_s0 = get<0>(tTMEM_LOADVcS(_0{})) + get<0>(TileShape{}) * get<0>(blk_coord);
+      int row_s1 = row_s0 + kS1RowOffset;
+
+      static constexpr int kPackFactor = pack_factor_of<Mask>::value;
+
+      auto packed_maxscore_path = [&]() {
+        Tensor gMaxScore = make_tensor(
+            make_gmem_ptr(epilogue.params.ptr_MaxScore),
+            epilogue.params.layout_MaxScore);
+        ms_stride_k = int(&gMaxScore(0, 0, 1) - &gMaxScore(0, 0, 0));
+        if (!is_padding_corr && uint(row_s0) < qo_len)
+          ms_base_s0 = &gMaxScore(segment_offset + row_s0, qo_head_idx, 0);
+        if (!is_padding_corr && uint(row_s1) < qo_len)
+          ms_base_s1 = &gMaxScore(segment_offset + row_s1, qo_head_idx, 0);
+      };
+
+      if constexpr (kPackFactor > 1) {
+        if (epilogue.params.ptr_MaxScore_direct != nullptr) {
+          int rem_hr = get<3, 0, 0>(params_problem_shape);
+          int h_r_orig = rem_hr * kPackFactor;
+          int kv_head = qo_head_idx / rem_hr;
+          int rem_hr_idx = qo_head_idx % rem_hr;
+          int seg_off_orig = segment_offset / kPackFactor;
+
+          ms_stride_k = epilogue.params.max_score_stride_k;
+
+          auto compute_ms_base = [&](int row) -> float* {
+            if (uint(row) >= qo_len) return nullptr;
+            int actual_tok = row / kPackFactor;
+            int pf_idx = row % kPackFactor;
+            int unpacked_head = kv_head * h_r_orig + rem_hr_idx * kPackFactor + pf_idx;
+            return epilogue.params.ptr_MaxScore_direct
+                   + unpacked_head * epilogue.params.max_score_stride_h
+                   + (seg_off_orig + actual_tok) * epilogue.params.max_score_stride_t;
+          };
+
+          if (!is_padding_corr) {
+            ms_base_s0 = compute_ms_base(row_s0);
+            ms_base_s1 = compute_ms_base(row_s1);
+          }
+        } else {
+          packed_maxscore_path();
+        }
+      } else {
+        packed_maxscore_path();
+      }
+    }
+
+    // Inline MaxScore write and correct scale
+    // OnlyScore fuse v1: softmax already __stwt'd this value to GMEM directly
+    // from its tile_max register. Skip correction-side GMEM write to avoid a
+    // redundant store (~1 GMEM transaction per row per tile). The
+    // max_score(kIdxNewRowMax) update below is kept because it feeds the
+    // rescale path under kNeedOutput — dead in OnlyScore but harmless.
+    auto write_max_score = [&](float* ms_base, auto& max_score, int k_idx) {
+      if constexpr (!kFuseMaxScoreIntoSoftmax) {
+        if (ms_base) ms_base[k_idx * ms_stride_k] = max_score(kIdxNewRowMax);
+      }
+      max_score(kIdxNewRowMax) = max(max_score(kIdxOldRowMax), max_score(kIdxNewRowMax));
+      max_score(kIdxNewRowMax) = max_score(kIdxNewRowMax) == -INFINITY ? 0 : max_score(kIdxNewRowMax);
+    };
+
+    pipeline_s0_c.consumer_wait(pipeline_s0_c_consumer_state);
+    if constexpr (kNeedMaxScore) {
+      // P2 (v3): in OnlyScore fuse mode, the V-channel STOREV on the softmax
+      // side is gated off (dead store). Skip the matching LOADV + dead
+      // write_max_score path here. Sync (consumer_wait/arrive/release) is
+      // preserved verbatim — only the per-iteration TMEM round-trip is dropped.
+      if constexpr (!kFuseMaxScoreIntoSoftmax) {
+        Tensor tTMEM_LOADVrS_first = make_tensor<ElementQK>(shape(tTMEM_LOADVcS));
+        if (!is_padding_corr) {
+          copy(tiled_tmem_loadv, tTMEM_LOADVtS0, tTMEM_LOADVrS_first);
+          write_max_score(ms_base_s0, tTMEM_LOADVrS_first, k_tile_idx);
+        }
+      }
+      pipeline_corr.arrive();
+      if constexpr (kIsKSplit) k_tile_idx++;
+    }
+    pipeline_s0_c.consumer_release(pipeline_s0_c_consumer_state);
+    ++pipeline_s0_c_consumer_state;
+
+    pipeline_s1_c.consumer_wait(pipeline_s1_c_consumer_state);
+    if constexpr (kNeedMaxScore) {
+      if constexpr (!kFuseMaxScoreIntoSoftmax) {
+        Tensor tTMEM_LOADVrS_first = make_tensor<ElementQK>(shape(tTMEM_LOADVcS));
+        if (!is_padding_corr) {
+          copy(tiled_tmem_loadv, tTMEM_LOADVtS1, tTMEM_LOADVrS_first);
+          write_max_score(ms_base_s1, tTMEM_LOADVrS_first, k_tile_idx);
+        }
+      }
+      pipeline_corr.arrive();
+      k_tile_idx -= (kTilesPerMacro + (kIsKSplit ? 1 : 0));
+    }
+
+    // handle the last iteration differently (i.e. tmem_load/stsm for epi)
+    mask_tile_count -= 1;
+
+    CUTLASS_PRAGMA_NO_UNROLL
+    for (; mask_tile_count > 0; mask_tile_count -= 1) {
+      pipeline_s0_c.consumer_wait(pipeline_s0_c_consumer_state);
+
+      Tensor tTMEM_LOADVrS = make_tensor<ElementQK>(shape(tTMEM_LOADVcS));
+
+      if (!is_padding_corr) {
+        GPU_TRACE_SCOPE(CORRECTION);
+        // P2 (v3): skip dead LOADV + dead write_max_score in OnlyScore fuse mode.
+        // softmax already wrote max_score to GMEM; rescale path is NeedOutput-gated.
+        if constexpr (!kFuseMaxScoreIntoSoftmax) {
+          // read row_wise new global max
+          copy(tiled_tmem_loadv, tTMEM_LOADVtS0, tTMEM_LOADVrS);
+          if constexpr (kNeedMaxScore) {
+            write_max_score(ms_base_s0, tTMEM_LOADVrS, k_tile_idx);
+            if constexpr (kIsKSplit) k_tile_idx++;
+          }
+        }
+
+        if constexpr (kNeedOutput) {
+          // e^(scale * (old_max - new_max)
+          float scale = ::exp2f(params.scale_softmax_log2 *
+                                (tTMEM_LOADVrS(kIdxOldRowMax) - tTMEM_LOADVrS(kIdxNewRowMax)));
+          bool warp_should_rescale = __any_sync(0xffffffff, scale != 1.f);
+          if (warp_should_rescale) {
+            correction_rescale(scale, uint32_t(TmemAllocation::O0));
+          }
+        }
+      }
+
+      pipeline_s1_c.consumer_release(pipeline_s1_c_consumer_state);
+      ++pipeline_s1_c_consumer_state;
+
+      cutlass::arch::fence_view_async_tmem_store();
+
+      pipeline_corr.arrive();
+
+      pipeline_s1_c.consumer_wait(pipeline_s1_c_consumer_state);
+
+      if (!is_padding_corr) {
+        GPU_TRACE_SCOPE(CORRECTION);
+        if constexpr (!kFuseMaxScoreIntoSoftmax) {
+          copy(tiled_tmem_loadv, tTMEM_LOADVtS1, tTMEM_LOADVrS);
+          if constexpr (kNeedMaxScore) {
+            write_max_score(ms_base_s1, tTMEM_LOADVrS, k_tile_idx);
+            k_tile_idx -= (kTilesPerMacro + (kIsKSplit ? 1 : 0));
+          }
+        }
+
+        if constexpr (kNeedOutput) {
+          float scale = ::exp2f(params.scale_softmax_log2 *
+                          (tTMEM_LOADVrS(kIdxOldRowMax) - tTMEM_LOADVrS(kIdxNewRowMax)));
+          bool warp_should_rescale = __any_sync(0xffffffff, scale != 1.f);
+          if (warp_should_rescale) {
+            correction_rescale(scale, uint32_t(TmemAllocation::O1));
+          }
+        }
+      }
+
+      pipeline_s0_c.consumer_release(pipeline_s0_c_consumer_state);
+      ++pipeline_s0_c_consumer_state;
+
+      cutlass::arch::fence_view_async_tmem_store();
+
+      pipeline_corr.arrive();
+    }
+
+    pipeline_s1_c.consumer_release(pipeline_s1_c_consumer_state);
+    ++pipeline_s1_c_consumer_state;
+
+    // do the final correction to O1
+    // better to somehow special-case it in the loop above
+    // doesn't matter for non-persistent code, but if it were
+    // persistent we do not want to release O too early
+
+    Tensor sO = make_tensor(make_smem_ptr(shared_storage_epi.smem_o.data()),
+                            typename TensorStorageEpi::SmemLayoutO{});
+    Tensor gLSE = make_tensor(make_gmem_ptr(epilogue.params.ptr_LSE), epilogue.params.layout_LSE);
+
+    if constexpr (get<1>(ThreadShape{}) > 1) {
+      // ========== K-split: merge O0+O1 with online softmax combine ==========
+      pipeline_s0_c.consumer_wait(pipeline_s0_c_consumer_state);
+      Tensor tTMEM_LOADVrS = make_tensor<ElementQK>(shape(tTMEM_LOADVcS));
+      if constexpr (kNeedOutput)
+        copy(tiled_tmem_loadv, tTMEM_LOADVtS0, tTMEM_LOADVrS);
+      pipeline_s0_c.consumer_release(pipeline_s0_c_consumer_state);
+      ++pipeline_s0_c_consumer_state;
+
+      pipeline_s1_c.consumer_wait(pipeline_s1_c_consumer_state);
+      Tensor tTMEM_LOADVrS1 = make_tensor<ElementQK>(shape(tTMEM_LOADVcS));
+      if constexpr (kNeedOutput)
+        copy(tiled_tmem_loadv, tTMEM_LOADVtS1, tTMEM_LOADVrS1);
+      pipeline_s1_c.consumer_release(pipeline_s1_c_consumer_state);
+      ++pipeline_s1_c_consumer_state;
+
+      // SingleSoftmaxWarpGroup merge uses smem_o as scratch — must wait for previous epilogue TMA
+      if constexpr (kSingleWG) {
+        pipeline_epi.producer_acquire(pipeline_epi_producer_state);
+      }
+
+      float total_sum = 0;
+      float total_max = 0;
+
+      if constexpr (kNeedOutput)
+      {
+        GPU_TRACE_SCOPE(CORRECTION_MRG);
+        auto merge_result = correction_merge_ksplit<kSingleWG>(
+            params, tTMEM_LOADVrS, tTMEM_LOADVrS1,
+            kSingleWG ? reinterpret_cast<float*>(shared_storage_epi.smem_o.data()) : nullptr);
+        total_sum = merge_result.total_sum;
+        total_max = merge_result.total_max;
+      }
+
+      // Write merged O0 to smem
+      if constexpr (!kSingleWG) {
+        pipeline_epi.producer_acquire(pipeline_epi_producer_state);
+      }
+
+      if constexpr (kNeedOutput)
+      {
+        GPU_TRACE_SCOPE(CORRECTION_EPI);
+        if constexpr (IsSplitKV) {
+          float corr_scale = (total_sum == 0.f) ? 0.f : split_kv.scale_output_splitkv / total_sum;
+          correction_epilogue(corr_scale, _0{}, sO);
+        } else {
+          correction_epilogue(params.scale_output / total_sum, _0{}, sO);
+        }
+        cutlass::arch::fence_view_async_tmem_load();
+      }
+
+      // Release O0 and O1
+      if constexpr (!kNeedMaxScore) {
+        pipeline_corr.arrive();
+        pipeline_corr.arrive();
+      }
+
+      if constexpr (kNeedOutput && IsSplitKV)
+      {
+        // Write per-row LSE to smem; epilogue will flush to global memory
+        int local_row = get<0>(tTMEM_LOADVcS(_0{}));
+        float lse = (total_sum == 0.f) ? -INFINITY
+                    : total_max + __log2f(total_sum) / params.scale_softmax_log2;
+        shared_storage_epi.smem_lse[local_row] = lse;
+      }
+
+      pipeline_epi.producer_commit(pipeline_epi_producer_state);
+      ++pipeline_epi_producer_state;
+
+    } else {
+    // ========== Q-split: write O0 and O1 independently (interleaved) ==========
+
+    pipeline_s0_c.consumer_wait(pipeline_s0_c_consumer_state);
+
+    Tensor tTMEM_LOADVrS = make_tensor<ElementQK>(shape(tTMEM_LOADVcS));
+
+    if constexpr (kNeedOutput)
+      copy(tiled_tmem_loadv, tTMEM_LOADVtS0, tTMEM_LOADVrS);
+
+    pipeline_s0_c.consumer_release(pipeline_s0_c_consumer_state);
+    ++pipeline_s0_c_consumer_state;
+
+    // Wait for O0 and process it immediately
+    pipeline_epi.producer_acquire(pipeline_epi_producer_state);
+    if constexpr (kNeedOutput) {
+      GPU_TRACE_SCOPE(CORRECTION_EPI);
+      correction_epilogue(params.scale_output / tTMEM_LOADVrS(kIdxFinalRowSum), _0{}, sO);
+      if (epilogue.params.ptr_LSE != nullptr) {
+        int qo_tile_idx = get<0>(blk_coord);
+        int qo_head_idx = get<2, 0>(blk_coord);
+        int batch_idx = get<2, 1>(blk_coord);
+        int qo_len = get<0>(problem_shape);
+        int _seg_off_sz = get<3, 1>(params_problem_shape) + 1;
+        int segment_offset = SEG_OFF_LOAD(get<0>(params_problem_shape), batch_idx, _seg_off_sz);
+        int row_idx = get<0>(tTMEM_LOADVcS(_0{})) + get<0>(TileShape{}) * qo_tile_idx;
+
+        ElementPV lse = __log2f(tTMEM_LOADVrS(kIdxFinalRowSum)) +
+                        params.scale_softmax_log2 * tTMEM_LOADVrS(kIdxFinalRowMax);
+
+        if (row_idx < qo_len) {
+          gLSE(segment_offset + row_idx, qo_head_idx) = lse;
+        }
+      }
+      cutlass::arch::fence_view_async_tmem_load();
+    }
+
+    if constexpr (!kNeedMaxScore) {
+      pipeline_corr.arrive();
+    }
+
+    pipeline_epi.producer_commit(pipeline_epi_producer_state);
+    ++pipeline_epi_producer_state;
+
+    // Now read V1 and wait for O1
+    pipeline_s1_c.consumer_wait(pipeline_s1_c_consumer_state);
+
+    if constexpr (kNeedOutput)
+      copy(tiled_tmem_loadv, tTMEM_LOADVtS1, tTMEM_LOADVrS);
+
+    pipeline_s1_c.consumer_release(pipeline_s1_c_consumer_state);
+    ++pipeline_s1_c_consumer_state;
+
+    if constexpr (kNeedOutput) {
+      GPU_TRACE_SCOPE(CORRECTION_EPI);
+      correction_epilogue(params.scale_output / tTMEM_LOADVrS(kIdxFinalRowSum), _1{}, sO);
+      if (epilogue.params.ptr_LSE != nullptr) {
+        int qo_tile_idx = get<0>(blk_coord);
+        int qo_head_idx = get<2, 0>(blk_coord);
+        int batch_idx = get<2, 1>(blk_coord);
+        int qo_len = get<0>(problem_shape);
+        int _seg_off_sz = get<3, 1>(params_problem_shape) + 1;
+        int segment_offset = SEG_OFF_LOAD(get<0>(params_problem_shape), batch_idx, _seg_off_sz);
+        int row_idx =
+            get<0>(tTMEM_LOADVcS(_0{})) + get<0>(TileShape{}) * qo_tile_idx + get<0>(TileShapeQK{});
+
+        ElementPV lse = __log2f(tTMEM_LOADVrS(kIdxFinalRowSum)) +
+                        params.scale_softmax_log2 * tTMEM_LOADVrS(kIdxFinalRowMax);
+
+        if (row_idx < qo_len) {
+          gLSE(segment_offset + row_idx, qo_head_idx) = lse;
+        }
+      }
+      cutlass::arch::fence_view_async_tmem_load();
+    }
+
+    if constexpr (!kNeedMaxScore) {
+      pipeline_corr.arrive();
+    }
+
+    pipeline_epi.producer_commit(pipeline_epi_producer_state);
+    ++pipeline_epi_producer_state;
+    } // end Q-split/K-split
+    RELEASE_GPU_TRACE;
+  }
+
+  template <class BlkCoord, class ProblemShape, class ParamsProblemShape, class TensorStorageEpi,
+            class CollectiveEpilogue>
+  CUTLASS_DEVICE auto correction_empty(
+      BlkCoord const& blk_coord, Params const& params, ProblemShape const& problem_shape,
+      ParamsProblemShape const& params_problem_shape, TensorStorageEpi& shared_storage_epi,
+      PipelineE& pipeline_epi, typename PipelineE::PipelineState& pipeline_epi_producer_state,
+      CollectiveEpilogue& epilogue) {
+    pipeline_epi.producer_acquire(pipeline_epi_producer_state);
+
+    if constexpr (kNeedOutput) {
+      Tensor sO = make_tensor(make_smem_ptr(shared_storage_epi.smem_o.data()),
+                              typename TensorStorageEpi::SmemLayoutO{});
+      int thread_idx = threadIdx.x % (4 * NumThreadsPerWarp);
+
+      using ElementOut = typename CollectiveEpilogue::ElementOut;
+      auto tiled_copy = make_cotiled_copy(
+          Copy_Atom<UniversalCopy<uint32_t>, ElementOut>{},
+          make_ordered_layout(make_shape(_128{}, Int<sizeof(uint32_t) / sizeof(ElementOut)>{}),
+                              Step<_1, _0>{}),
+          sO.layout());
+
+      auto thr_copy = tiled_copy.get_slice(thread_idx);
+      auto tOgO = thr_copy.partition_D(sO);
+      auto tOrO = make_tensor<ElementOut>(shape(tOgO(_, _, _, _0{})));
+      clear(tOrO);
+
+      copy(tiled_copy, tOrO, tOgO(_, _, _, _0{}));
+
+      if (epilogue.params.ptr_LSE != nullptr) {
+        Tensor gLSE = make_tensor(make_gmem_ptr(epilogue.params.ptr_LSE), epilogue.params.layout_LSE);
+        int qo_tile_idx = get<0>(blk_coord);
+        int qo_head_idx = get<2, 0>(blk_coord);
+        int batch_idx = get<2, 1>(blk_coord);
+        int qo_len = get<0>(problem_shape);
+        int _seg_off_sz = get<3, 1>(params_problem_shape) + 1;
+        int segment_offset = SEG_OFF_LOAD(get<0>(params_problem_shape), batch_idx, _seg_off_sz);
+        int row_idx = thread_idx + get<0>(TileShape{}) * qo_tile_idx;
+
+        if (row_idx < qo_len) {
+          gLSE(segment_offset + row_idx, qo_head_idx) = -cuda::std::numeric_limits<float>::infinity();
+        }
+      }
+
+      if constexpr (kNeedOutput && IsSplitKV) {
+        if (thread_idx < int(get<0>(TileShape{}))) {
+          shared_storage_epi.smem_lse[thread_idx] = -INFINITY;
+        }
+      }
+    }
+
+    pipeline_epi.producer_commit(pipeline_epi_producer_state);
+    ++pipeline_epi_producer_state;
+
+    if constexpr (get<1>(ThreadShape{}) <= 1) {
+      if constexpr (kNeedOutput) {
+        Tensor sO = make_tensor(make_smem_ptr(shared_storage_epi.smem_o.data()),
+                                typename TensorStorageEpi::SmemLayoutO{});
+        int thread_idx = threadIdx.x % (4 * NumThreadsPerWarp);
+        using ElementOut = typename CollectiveEpilogue::ElementOut;
+        auto tiled_copy = make_cotiled_copy(
+            Copy_Atom<UniversalCopy<uint32_t>, ElementOut>{},
+            make_ordered_layout(make_shape(_128{}, Int<sizeof(uint32_t) / sizeof(ElementOut)>{}),
+                                Step<_1, _0>{}),
+            sO.layout());
+        auto thr_copy = tiled_copy.get_slice(thread_idx);
+        auto tOgO = thr_copy.partition_D(sO);
+        auto tOrO = make_tensor<ElementOut>(shape(tOgO(_, _, _, _0{})));
+        clear(tOrO);
+        copy(tiled_copy, tOrO, tOgO(_, _, _, _1{}));
+        cutlass::arch::fence_view_async_shared();
+      }
+
+      pipeline_epi.producer_acquire(pipeline_epi_producer_state);
+
+      if constexpr (kNeedOutput) {
+        if (epilogue.params.ptr_LSE != nullptr) {
+          Tensor gLSE = make_tensor(make_gmem_ptr(epilogue.params.ptr_LSE), epilogue.params.layout_LSE);
+          int thread_idx = threadIdx.x % (4 * NumThreadsPerWarp);
+          int qo_tile_idx = get<0>(blk_coord);
+          int qo_head_idx = get<2, 0>(blk_coord);
+          int batch_idx = get<2, 1>(blk_coord);
+          int qo_len = get<0>(problem_shape);
+          int _seg_off_sz = get<3, 1>(params_problem_shape) + 1;
+        int segment_offset = SEG_OFF_LOAD(get<0>(params_problem_shape), batch_idx, _seg_off_sz);
+          int row_idx = thread_idx + get<0>(TileShape{}) * qo_tile_idx
+                      + int(get<0>(TileShapeQK{}));
+          if (row_idx < qo_len) {
+            gLSE(segment_offset + row_idx, qo_head_idx) = -cuda::std::numeric_limits<float>::infinity();
+          }
+        }
+        cutlass::arch::fence_view_async_shared();
+      }
+
+      pipeline_epi.producer_commit(pipeline_epi_producer_state);
+      ++pipeline_epi_producer_state;
+    }
+    // K-split: only 1 epi commit (merged output), skip O1
+  }
+};
+
+}  // namespace cutlass::fmha::collective

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/sm100_fmha_load_tma_warpspecialized.hpp
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/sm100_fmha_load_tma_warpspecialized.hpp
@@ -1,0 +1,648 @@
+/***************************************************************************************************
+ * Copyright (c) 2024 - 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#pragma once
+
+#include <climits>
+
+#include "gmem_bounds_check.h"
+#include "cutlass_utils.cuh"
+#include "cute/layout.hpp"
+#include "cute/tensor.hpp"
+#include "cutlass/arch/memory_sm80.h"
+#include "cutlass/cutlass.h"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "fmha_common.hpp"
+#include "gpu_trace.h"
+#include "fmha_fusion.hpp"
+
+#if (__CUDACC_VER_MAJOR__ >= 12) && !defined(__CUDACC_RTC__)
+#include <cuda.h>
+#endif
+
+GPU_TRACE_SCOPE_DEC(LOAD_Q);
+GPU_TRACE_SCOPE_DEC(LOAD_Q_WAIT);
+GPU_TRACE_SCOPE_DEC(LOAD_K);
+GPU_TRACE_SCOPE_DEC(LOAD_V);
+
+namespace cutlass::fmha::collective {
+
+using namespace cute;
+
+template <typename T>
+struct MaskPackFactor { static constexpr int value = 1; };
+template <int P>
+struct MaskPackFactor<PackedCausalMask<P>> { static constexpr int value = P; };
+
+template <class Element, class CollectiveMmaQK, class CollectiveMmaPV, class SmemLayoutQ,
+          class SmemLayoutK, class SmemLayoutV, class TensorStorage, class PipelineQ,
+          class PipelineKV, class Mask, class TileShape, int KVPageSize = -1,
+          SparseAttnMode kSparseAttnMode = SparseAttnMode::Off>
+struct Sm100FmhaLoadTmaWarpspecialized {
+  // P0: OnlyScore mode never reads V — skip every V slot in the KV pipeline.
+  // mma() gates the matching wait_V/release_V under `kNeedOutput` so producer
+  // (loader) and consumer (mma) stay step-locked on the pipeline state.
+  static constexpr bool kNeedV = (kSparseAttnMode != SparseAttnMode::OnlyScore);
+
+  using TileShapeQK = typename CollectiveMmaQK::TileShape;
+  using TileShapePV = typename CollectiveMmaPV::TileShape;
+
+  using GmemTiledCopyQ = cute::SM90_TMA_LOAD;
+  using GmemTiledCopyKV = cute::SM90_TMA_LOAD;
+  static constexpr uint32_t NumStagesQ = PipelineQ::Stages;
+  static constexpr int kTransactionBytesKV =
+      cutlass::bits_to_bytes(cosize(take<0, 3>(SmemLayoutK{})) * cute::sizeof_bits_v<Element>);
+
+  // (N, D, (H_R, H_G))
+  using ShapeQ = cute::Shape<int32_t, int32_t, cute::Shape<int32_t, int32_t>>;
+  using StrideQ = cute::Shape<int32_t, _1, cute::Shape<int32_t, int32_t>>;
+  using LayoutQ = cute::Layout<ShapeQ, StrideQ>;
+
+  // Paged: (page_size, D, H_kv, total_page_num) — 4-mode flat
+  // Non-paged: (N, D, (H_R, H_G)) — 3-mode hierarchical
+  using ShapeK = std::conditional_t<(KVPageSize > 0),
+      cute::Shape<int32_t, int32_t, int32_t, int32_t>,
+      cute::Shape<int32_t, int32_t, cute::Shape<int32_t, int32_t>>>;
+  using StrideK = std::conditional_t<(KVPageSize > 0),
+      cute::Shape<int32_t, _1, int32_t, int32_t>,
+      cute::Shape<int32_t, _1, cute::Shape<_0, int32_t>>>;
+  using ShapeV = std::conditional_t<(KVPageSize > 0),
+      cute::Shape<int32_t, int32_t, int32_t, int32_t>,
+      cute::Shape<int32_t, int32_t, cute::Shape<int32_t, int32_t>>>;
+  using StrideV = std::conditional_t<(KVPageSize > 0),
+      cute::Shape<_1, int32_t, int32_t, int32_t>,
+      cute::Shape<_1, int32_t, cute::Shape<_0, int32_t>>>;
+  using LayoutK = cute::Layout<ShapeK, StrideK>;
+  using LayoutV = cute::Layout<ShapeV, StrideV>;
+  struct Arguments {
+    const Element* ptr_Q;
+    LayoutQ layout_Q;
+    const Element* ptr_K;
+    LayoutK layout_K;
+    const Element* ptr_V;
+    LayoutV layout_V;
+    int* kv_indices = nullptr;
+    int* kv_page_indptr = nullptr;
+    int* kv_block_indexes = nullptr;
+    int kv_block_num = 0;
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+    int kv_page_indptr_size = 0;
+    int kv_indices_size = 0;
+    int kv_block_indexes_numel = 0;
+#endif
+    int pack_factor = 1;
+    int q_stride_n_original = 0;
+    int q_stride_h_original = 0;
+    int h_r_original = 0;
+  };
+
+  // using ShapeLseT = cute::Shape<int32_t, int32_t>;
+  // using StrideLseT = cute::Shape<_1, int64_t>;
+  // using LayoutLseT = cute::Layout<ShapeLseT, StrideLseT>;
+
+  using ClusterLayout_VMNK =
+      decltype(tiled_divide(make_layout(Shape<_1, _1, _1>{}),
+                            make_tile(typename CollectiveMmaQK::TiledMma::AtomThrID{})));
+  using TMA_Q = typename CollectiveMmaQK::Params::TMA_A;
+  using TMA_K = typename CollectiveMmaQK::Params::TMA_B;
+  using TMA_V = typename CollectiveMmaPV::Params::TMA_B;
+
+  static constexpr int kPackFactor = MaskPackFactor<Mask>::value;
+  static constexpr bool kEnablePackedQTMA = (kPackFactor > 1) && ((kPackFactor & (kPackFactor - 1)) == 0);
+
+  struct Params {
+    TMA_Q tma_load_Q;
+    LayoutQ layout_Q;
+    TMA_K tma_load_K;
+    LayoutK layout_K;
+    TMA_V tma_load_V;
+    LayoutV layout_V;
+    int* kv_indices = nullptr;
+    int* kv_page_indptr = nullptr;
+    int* kv_block_indexes = nullptr;
+    int kv_block_num = 0;
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+    int kv_page_indptr_size = 0;
+    int kv_indices_size = 0;
+    int kv_block_indexes_numel = 0;
+#endif
+    const Element* ptr_Q_orig = nullptr;
+    int q_stride_n_orig = 0;
+    int q_stride_h_orig = 0;
+    int h_r_orig = 0;
+    cute::TmaDescriptor tma_desc_q_pack;
+  };
+
+  template <class ProblemShape>
+  static Params to_underlying_arguments(ProblemShape const& problem_shape, Arguments const& args,
+                                        void* workspace) {
+    static_assert(is_variable_length_v<tuple_element_t<0, ProblemShape>>);
+    static_assert(is_variable_length_v<tuple_element_t<1, ProblemShape>>);
+    auto ptr_Q = args.ptr_Q;
+    auto ptr_K = args.ptr_K;
+    auto ptr_V = args.ptr_V;
+    LayoutQ layout_Q = args.layout_Q;
+    LayoutK layout_K = args.layout_K;
+    LayoutV layout_V = args.layout_V;
+
+    auto mQ = make_tensor(make_gmem_ptr(ptr_Q), layout_Q);
+    auto mK = make_tensor(make_gmem_ptr(ptr_K), layout_K);
+    auto mV = make_tensor(make_gmem_ptr(ptr_V), layout_V);
+
+    auto cluster_layout_vmnk =
+        tiled_divide(make_layout(Shape<_1, _1, _1>{}),
+                     make_tile(typename CollectiveMmaQK::TiledMma::AtomThrID{}));
+    TMA_Q tma_load_Q = make_tma_atom_A_sm100<Element>(
+        GmemTiledCopyQ{}, mQ, SmemLayoutQ{}(_, _, _, _0{}), TileShapeQK{},
+        typename CollectiveMmaQK::TiledMma{}, cluster_layout_vmnk);
+    TMA_K tma_load_K = make_tma_atom_B_sm100<Element>(
+        GmemTiledCopyKV{}, mK, SmemLayoutK{}(_, _, _, _0{}), TileShapeQK{},
+        typename CollectiveMmaQK::TiledMma{}, cluster_layout_vmnk);
+    TMA_V tma_load_V = make_tma_atom_B_sm100<Element>(
+        GmemTiledCopyKV{}, mV, SmemLayoutV{}(_, _, _, _0{}), TileShapePV{},
+        typename CollectiveMmaPV::TiledMma{}, cluster_layout_vmnk);
+
+    cute::TmaDescriptor tma_desc_q_pack{};
+    if constexpr (kEnablePackedQTMA) {
+      constexpr int tile_m = get<0>(TileShapeQK{});
+      constexpr int tile_k = get<2>(TileShapeQK{});
+      int total_seq = get<0>(shape(layout_Q)) / kPackFactor;
+      int total_heads = args.h_r_original * get<1>(get<2>(shape(layout_Q)));
+      int dim = get<1>(shape(layout_Q));
+
+      auto tma_dtype = cute::TMA::to_CUtensorMapDataType<Element>();
+      constexpr int box_dim0 = 128 / (int)sizeof(Element);
+      uint64_t gDim[3] = {(uint64_t)dim, (uint64_t)total_heads, (uint64_t)total_seq};
+      uint64_t gStride[2] = {
+          (uint64_t)(args.q_stride_h_original * (int)sizeof(Element)),
+          (uint64_t)(args.q_stride_n_original * (int)sizeof(Element))};
+      uint32_t bDim[3] = {(uint32_t)box_dim0, (uint32_t)kPackFactor, (uint32_t)(tile_m / kPackFactor)};
+      uint32_t eStride[3] = {1, 1, 1};
+
+      cuTensorMapEncodeTiled(
+          reinterpret_cast<CUtensorMap*>(&tma_desc_q_pack),
+          tma_dtype, 3, (void*)args.ptr_Q,
+          gDim, gStride, bDim, eStride,
+          CU_TENSOR_MAP_INTERLEAVE_NONE,
+          CU_TENSOR_MAP_SWIZZLE_128B,
+          CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
+          CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+    }
+
+    Params p{tma_load_Q, layout_Q, tma_load_K, layout_K, tma_load_V, layout_V,
+                  args.kv_indices, args.kv_page_indptr, args.kv_block_indexes, args.kv_block_num,
+#ifdef FMHA_GMEM_BOUNDS_CHECK
+                  args.kv_page_indptr_size, args.kv_indices_size, args.kv_block_indexes_numel,
+#endif
+                  args.ptr_Q, args.q_stride_n_original, args.q_stride_h_original, args.h_r_original,
+                  tma_desc_q_pack};
+    return p;
+  }
+
+  CUTLASS_DEVICE
+  static void prefetch_tma_descriptors(Params const& params) {
+    if constexpr (kEnablePackedQTMA)
+      cute::prefetch_tma_descriptor(reinterpret_cast<cute::TmaDescriptor const*>(&params.tma_desc_q_pack));
+    else if constexpr (kPackFactor == 1)
+      cute::prefetch_tma_descriptor(params.tma_load_Q.get_tma_descriptor());
+    cute::prefetch_tma_descriptor(params.tma_load_K.get_tma_descriptor());
+    cute::prefetch_tma_descriptor(params.tma_load_V.get_tma_descriptor());
+  }
+
+  static constexpr int kTransactionBytesQ =
+      cutlass::bits_to_bytes(cosize(take<0, 3>(SmemLayoutQ{})) * cute::sizeof_bits_v<Element>);
+
+  CUTLASS_DEVICE
+  static void load_Q_cp_async(
+      int q_tile_index, int qo_head_idx, int qo_segment_offset, int qo_len,
+      Params const& params, auto const& params_problem_shape,
+      TensorStorage& storage, PipelineQ& pipeline_q,
+      typename PipelineQ::PipelineState& pipeline_q_producer_state,
+      uint32_t lane_predicate
+      #ifdef GPU_TRACE_ENABLED
+        , gpu_trace::Recorder& _gt_rec
+      #endif
+      ) {
+
+    constexpr int tile_m = get<0>(TileShapeQK{});
+    constexpr int tile_k = get<2>(TileShapeQK{});
+    int stage = pipeline_q_producer_state.index();
+
+    int h_r_orig = params.h_r_orig;
+    int h_r_packed = h_r_orig / kPackFactor;
+    int kv_head = qo_head_idx / h_r_packed;
+    int rem_h = qo_head_idx % h_r_packed;
+
+    int tile_base = q_tile_index * tile_m;
+
+    Tensor sQ = make_tensor(make_smem_ptr(storage.smem_q.data()), SmemLayoutQ{});
+    auto sQ_grouped = group_modes<0, rank(SmemLayoutQ{}) - 1>(sQ);
+
+    int lane_id = threadIdx.x % 32;
+    int packed_len = qo_segment_offset + qo_len;
+
+    {
+      GPU_TRACE_SCOPE(LOAD_Q);
+      constexpr int kVecElems = 16 / sizeof(Element);
+      constexpr int k_iters = tile_k / kVecElems;
+      int valid_m = min(tile_m, packed_len - (qo_segment_offset + tile_base));
+      if (valid_m < 0) valid_m = 0;
+      int total_ops = valid_m * k_iters;
+
+      for (int idx = lane_id; idx < total_ops; idx += 32) {
+        int m = idx / k_iters;
+        int k = (idx % k_iters) * kVecElems;
+
+        int packed_pos = qo_segment_offset + tile_base + m;
+        int orig_pos = packed_pos / kPackFactor;
+        int pack_idx = packed_pos % kPackFactor;
+        int orig_head = kv_head * h_r_orig + rem_h * kPackFactor + pack_idx;
+
+        const Element* gmem_src = params.ptr_Q_orig
+                                + orig_pos * params.q_stride_n_orig
+                                + orig_head * params.q_stride_h_orig
+                                + k;
+
+        Element* smem_dst = reinterpret_cast<Element*>(&sQ_grouped(m + tile_m * k, stage));
+        cutlass::arch::cp_async<16, cutlass::arch::CacheOperation::Global>(
+            smem_dst, gmem_src);
+      }
+    }
+  }
+
+  CUTLASS_DEVICE
+  static void load_Q_wait(PipelineQ& pipeline_q,
+      typename PipelineQ::PipelineState& pipeline_q_producer_state,
+      uint32_t lane_predicate
+      #ifdef GPU_TRACE_ENABLED
+        , gpu_trace::Recorder& _gt_rec
+      #endif
+      ) {
+
+    GPU_TRACE_SCOPE(LOAD_Q_WAIT);
+    cutlass::arch::cp_async_fence();
+    cutlass::arch::cp_async_wait<0>();
+
+    if (lane_predicate) {
+      auto tma_barrier = pipeline_q.producer_get_barrier(pipeline_q_producer_state);
+      cutlass::arch::ClusterTransactionBarrier::complete_transaction(
+          tma_barrier, cute::block_rank_in_cluster(), kTransactionBytesQ);
+    }
+  }
+
+  template <bool IsSplitKV = false, bool LoadV = true, class BlkCoord, class ProblemShape, class ParamsProblemShape, class TensorStorageType>
+  CUTLASS_DEVICE void load(BlkCoord const& blk_coord, ProblemShape const& problem_shape,
+                           Params const& params, ParamsProblemShape const& params_problem_shape,
+                           int const& work_idx,
+                           TensorStorageType& storage, PipelineQ& pipeline_q,
+                           typename PipelineQ::PipelineState& pipeline_q_producer_state,
+                           PipelineKV& pipeline_kv,
+                           typename PipelineKV::PipelineState& pipeline_kv_producer_state,
+                           int kv_tile_begin, int kv_tile_end
+                           #ifdef GPU_TRACE_ENABLED
+                             , gpu_trace::Recorder& _gt_rec
+                           #endif
+                          ) {
+    // GET_GPU_TRACE(true);
+
+    int qo_tile_idx = get<0>(blk_coord);
+    int qo_head_idx = get<2, 0>(blk_coord);
+    int batch_idx = get<2, 1>(blk_coord);
+    int qo_len = get<0>(problem_shape);
+    int kv_len = get<1>(problem_shape);
+    int qo_segment_offset = get<0>(params_problem_shape).segment_offsets[batch_idx];
+    int kv_segment_offset = get<1>(params_problem_shape).segment_offsets[batch_idx];
+
+    int full_trip;
+    if constexpr (kSparseAttnMode == SparseAttnMode::Sparse) {
+      constexpr int full_tile_kv = get<1>(TileShape{});
+      full_trip = (params.kv_block_num * KVPageSize + full_tile_kv - 1) / full_tile_kv;
+    } else {
+      full_trip = Mask{}.get_trip_count(blk_coord, TileShape{}, problem_shape);
+    }
+    int effective_end = full_trip < kv_tile_end ? full_trip : kv_tile_end;
+    int mask_tile_count = effective_end - kv_tile_begin;
+    if constexpr (IsSplitKV) {
+      if (mask_tile_count <= 0) return;
+    }
+    int start_kv_index = effective_end - 1;
+
+    using X = Underscore;
+
+    Tensor mQ = params.tma_load_Q.get_tma_tensor(params.layout_Q.shape());
+
+    ThrMMA mma_qk = typename CollectiveMmaQK::TiledMma{}.get_slice(0);
+    ThrMMA mma_pv = typename CollectiveMmaPV::TiledMma{}.get_slice(0);
+    Tensor sQ = make_tensor(make_smem_ptr(storage.smem_q.data()), SmemLayoutQ{});
+    Tensor sK = make_tensor(make_smem_ptr(storage.smem_kv.data()), SmemLayoutK{});
+    Tensor sV = make_tensor(make_smem_ptr(storage.smem_kv.data()), SmemLayoutV{});
+
+    auto gQ = get_local_tile_tensor(mQ, select<0, 2>(TileShapeQK{}), qo_head_idx, qo_segment_offset,
+                                    qo_len);
+    Tensor tSgQ_qdl = mma_qk.partition_A(gQ);
+    auto [tQgQ, tQsQ] = tma_partition(params.tma_load_Q, _0{}, Layout<_1>{}, group_modes<0, 3>(sQ),
+                                      group_modes<0, 3>(tSgQ_qdl));
+
+    uint32_t lane_predicate = cute::elect_one_sync();
+
+    static constexpr int num_q_sub = get<0>(TileShape{}) / get<0>(TileShapeQK{});
+    static constexpr int num_kv_sub = get<1>(TileShape{}) / get<1>(TileShapeQK{});
+
+    int q0_index = num_q_sub * get<0>(blk_coord);
+    int q1_index = num_q_sub * get<0>(blk_coord) + 1;
+    int kv_tile_index = start_kv_index * num_kv_sub;
+
+    auto run_loads = [&](auto load_K_tile, auto load_V_tile) {
+
+      if constexpr (kEnablePackedQTMA) {
+        static_assert(num_kv_sub > 1);
+        static_assert(num_q_sub == 1);
+
+        pipeline_q.producer_acquire(pipeline_q_producer_state);
+        {
+          GPU_TRACE_SCOPE(LOAD_Q);
+          if (lane_predicate) {
+            constexpr int tile_m = get<0>(TileShapeQK{});
+            auto tma_barrier = pipeline_q.producer_get_barrier(pipeline_q_producer_state);
+            uint32_t smem_int_mbar = cute::cast_smem_ptr_to_uint(&(*tma_barrier));
+            uint64_t gmem_int_desc = reinterpret_cast<uint64_t>(&params.tma_desc_q_pack);
+
+            int h_r_packed = params.h_r_orig / kPackFactor;
+            int kv_head = qo_head_idx / h_r_packed;
+            int rem_h = qo_head_idx % h_r_packed;
+            int first_head = kv_head * params.h_r_orig + rem_h * kPackFactor;
+            int tile_base = q0_index * tile_m;
+            int orig_token_start = (qo_segment_offset + tile_base) / kPackFactor;
+
+            int stage = pipeline_q_producer_state.index();
+            constexpr int stage_bytes = kTransactionBytesQ;
+            uint32_t smem_base = cute::cast_smem_ptr_to_uint(storage.smem_q.data())
+                                  + stage * stage_bytes;
+
+            constexpr int box_dim0 = 128 / (int)sizeof(Element);
+            constexpr int dim_iters = get<2>(TileShapeQK{}) / box_dim0;
+            constexpr int chunk_bytes = box_dim0 * tile_m * (int)sizeof(Element);
+            for (int di = 0; di < dim_iters; di++) {
+              uint32_t smem_int_ptr = smem_base + di * chunk_bytes;
+              asm volatile(
+#if defined(CUTE_ARCH_TMA_SM120_ENABLED)
+                  "cp.async.bulk.tensor.3d.shared::cta.global.tile"
+#else
+                  "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+#endif
+                  ".mbarrier::complete_tx::bytes.L2::cache_hint"
+                  " [%0], [%1, {%2, %3, %4}], [%5], %6;"
+                  :
+                  : "r"(smem_int_ptr), "l"(gmem_int_desc),
+                    "r"(di * box_dim0), "r"(first_head), "r"(orig_token_start),
+                    "r"(smem_int_mbar), "l"((uint64_t)0)
+                  : "memory");
+            }
+          }
+        }
+        ++pipeline_q_producer_state;
+
+        load_K_tile(kv_tile_index);
+        load_K_tile(kv_tile_index + 1);
+      } else if constexpr (kPackFactor > 1) {
+        static_assert(num_kv_sub > 1);
+        static_assert(num_q_sub == 1);
+
+        load_K_tile(kv_tile_index);
+        pipeline_q.producer_acquire(pipeline_q_producer_state);
+        load_Q_cp_async(q0_index, qo_head_idx, qo_segment_offset, qo_len,
+                        params, params_problem_shape, storage, pipeline_q,
+                        pipeline_q_producer_state, lane_predicate
+                        #ifdef GPU_TRACE_ENABLED
+                          , _gt_rec
+                        #endif
+                        );
+        load_K_tile(kv_tile_index + 1);
+        load_Q_wait(pipeline_q, pipeline_q_producer_state, lane_predicate
+          #ifdef GPU_TRACE_ENABLED
+            , _gt_rec
+          #endif
+          );
+        ++pipeline_q_producer_state;
+      } else {
+        pipeline_q.producer_acquire(pipeline_q_producer_state);
+        {
+          GPU_TRACE_SCOPE(LOAD_Q);
+          if (lane_predicate) {
+            auto tma_barrier = pipeline_q.producer_get_barrier(pipeline_q_producer_state);
+            copy(params.tma_load_Q.with(*tma_barrier, 0), tQgQ(_, q0_index),
+                 tQsQ(_, pipeline_q_producer_state.index()));
+          }
+        }
+        ++pipeline_q_producer_state;
+
+        if constexpr (num_q_sub > 1) {
+          pipeline_q.producer_acquire(pipeline_q_producer_state);
+          GPU_TRACE_SCOPE(LOAD_Q);
+          if (lane_predicate) {
+            auto tma_barrier = pipeline_q.producer_get_barrier(pipeline_q_producer_state);
+            copy(params.tma_load_Q.with(*tma_barrier, 0), tQgQ(_, q1_index),
+                 tQsQ(_, pipeline_q_producer_state.index()));
+          }
+          ++pipeline_q_producer_state;
+        }
+        load_K_tile(kv_tile_index);
+        if constexpr (num_kv_sub > 1) load_K_tile(kv_tile_index + 1);
+      }
+
+      if constexpr (num_kv_sub > 1) {
+        // K-split: pre(KK) already done above; loop body is VKVK; epi is VV
+        int v_tile_index = kv_tile_index;
+        kv_tile_index -= 2;
+
+        mask_tile_count -= 1;
+        for (; mask_tile_count > 0; mask_tile_count -= 1) {
+          if constexpr (kNeedV) load_V_tile(v_tile_index);
+          load_K_tile(kv_tile_index);
+          if constexpr (kNeedV) load_V_tile(v_tile_index + 1);
+          load_K_tile(kv_tile_index + 1);
+          v_tile_index = kv_tile_index;
+          kv_tile_index -= 2;
+        }
+
+        if constexpr (kNeedV) {
+          load_V_tile(v_tile_index);
+          load_V_tile(v_tile_index + 1);
+        }
+      } else {
+        if constexpr (kNeedV) load_V_tile(kv_tile_index);
+        kv_tile_index -= 1;
+
+        mask_tile_count -= 1;
+        for (; mask_tile_count > 0; mask_tile_count -= 1) {
+          load_K_tile(kv_tile_index);
+          if constexpr (kNeedV) load_V_tile(kv_tile_index);
+          kv_tile_index -= 1;
+        }
+      }
+    };
+
+    if constexpr (KVPageSize > 0) {
+      // Paged KV: K/V shape (page_size, D, num_kv_heads, total_page_num)
+      Tensor mK = params.tma_load_K.get_tma_tensor(params.layout_K.shape());
+      Tensor mV = params.tma_load_V.get_tma_tensor(params.layout_V.shape());
+
+      int h_r = get<3, 0, 0>(params_problem_shape);
+      int kv_head_idx = qo_head_idx / h_r;
+      int kv_page_start = KV_INDPTR_LOAD(params.kv_page_indptr, batch_idx, params.kv_page_indptr_size);
+      int num_pages_batch = 0;
+      if constexpr (kSparseAttnMode != SparseAttnMode::Sparse) {
+        int kv_page_end = KV_INDPTR_LOAD(params.kv_page_indptr, batch_idx + 1, params.kv_page_indptr_size);
+        num_pages_batch = kv_page_end - kv_page_start;
+      }
+      constexpr int effective_tile_kv = get<1>(TileShapeQK{});
+      constexpr int tiles_per_page = KVPageSize / effective_tile_kv;
+
+      int kv_block_offset = 0;
+      if constexpr (kSparseAttnMode == SparseAttnMode::Sparse) {
+        int num_kv_heads_val = get<3, 0, 1>(params_problem_shape);
+        kv_block_offset = batch_idx * num_kv_heads_val * params.kv_block_num
+                        + kv_head_idx * params.kv_block_num;
+      }
+
+      // Keep full 4D tensor (page_size, D, H_kv, P) — select head at copy time
+      auto gK = local_tile(mK, select<1, 2>(TileShapeQK{}), make_coord(_, _0{}));
+      auto gV = local_tile(mV, select<1, 2>(TileShapePV{}), make_coord(_0{}, _));
+
+      Tensor tSgK_kdl = mma_qk.partition_B(gK);
+      Tensor tOgV_dkl = mma_pv.partition_B(gV);
+      auto [tKgK, tKsK] = tma_partition(params.tma_load_K, _0{}, Layout<_1>{},
+                                         group_modes<0, 3>(sK), group_modes<0, 3>(tSgK_kdl));
+      auto [tVgV, tVsV] = tma_partition(params.tma_load_V, _0{}, Layout<_1>{},
+                                         group_modes<0, 3>(sV), group_modes<0, 3>(tOgV_dkl));
+
+      auto load_K_tile = [&](int tile_idx) {
+        int logical_page = tile_idx / tiles_per_page;
+        int sub_tile = tile_idx % tiles_per_page;
+        int page_for_lookup;
+        if constexpr (kSparseAttnMode == SparseAttnMode::Sparse) {
+          int sparse_idx = (logical_page < params.kv_block_num)
+              ? __ldg(&params.kv_block_indexes[kv_block_offset + logical_page])
+              : -1;
+          page_for_lookup = (sparse_idx >= 0) ? sparse_idx : 0;
+        } else {
+          page_for_lookup = logical_page;
+          page_for_lookup = min(page_for_lookup, num_pages_batch - 1);
+        }
+        int physical_page = KV_INDICES_LOAD(params.kv_indices, kv_page_start + page_for_lookup, params.kv_indices_size);
+        { GPU_TRACE_SCOPE(LOAD_K); pipeline_kv.producer_acquire(pipeline_kv_producer_state); }
+        if (lane_predicate) {
+          auto tma_barrier = pipeline_kv.producer_get_barrier(pipeline_kv_producer_state);
+          copy(params.tma_load_K.with(*tma_barrier, 0),
+               tKgK(_, sub_tile, kv_head_idx, physical_page),
+               tKsK(_, pipeline_kv_producer_state.index()));
+        }
+        ++pipeline_kv_producer_state;
+      };
+
+      auto load_V_tile = [&](int tile_idx) {
+        int logical_page = tile_idx / tiles_per_page;
+        int sub_tile = tile_idx % tiles_per_page;
+        int page_for_lookup;
+        if constexpr (kSparseAttnMode == SparseAttnMode::Sparse) {
+          int sparse_idx = (logical_page < params.kv_block_num)
+              ? __ldg(&params.kv_block_indexes[kv_block_offset + logical_page])
+              : -1;
+          page_for_lookup = (sparse_idx >= 0) ? sparse_idx : 0;
+        } else {
+          page_for_lookup = logical_page;
+          page_for_lookup = min(page_for_lookup, num_pages_batch - 1);
+        }
+        int physical_page = KV_INDICES_LOAD(params.kv_indices, kv_page_start + page_for_lookup, params.kv_indices_size);
+        { GPU_TRACE_SCOPE(LOAD_V); pipeline_kv.producer_acquire(pipeline_kv_producer_state); }
+        if (lane_predicate) {
+          auto tma_barrier = pipeline_kv.producer_get_barrier(pipeline_kv_producer_state);
+          if constexpr (LoadV) {
+            copy(params.tma_load_V.with(*tma_barrier, 0),
+                 tVgV(_, sub_tile, kv_head_idx, physical_page),
+                 tVsV(_, pipeline_kv_producer_state.index()));
+          } else {
+            cutlass::arch::ClusterTransactionBarrier::complete_transaction(
+                tma_barrier, cute::block_rank_in_cluster(), kTransactionBytesKV);
+          }
+        }
+        ++pipeline_kv_producer_state;
+      };
+
+      run_loads(load_K_tile, load_V_tile);
+    } else {
+      // Non-paged KV
+      Tensor mK = params.tma_load_K.get_tma_tensor(params.layout_K.shape());
+      Tensor mV = params.tma_load_V.get_tma_tensor(params.layout_V.shape());
+
+      auto gK = get_local_tile_tensor(mK, select<1, 2>(TileShapeQK{}), qo_head_idx,
+                                      kv_segment_offset, kv_len);
+      auto gV = get_local_tile_t_tensor(mV, select<1, 2>(TileShapePV{}), qo_head_idx,
+                                        kv_segment_offset, kv_len);
+
+      Tensor tSgK_kdl = mma_qk.partition_B(gK);
+      Tensor tOgV_dkl = mma_pv.partition_B(gV);
+      auto [tKgK, tKsK] = tma_partition(params.tma_load_K, _0{}, Layout<_1>{},
+                                         group_modes<0, 3>(sK), group_modes<0, 3>(tSgK_kdl));
+      auto [tVgV, tVsV] = tma_partition(params.tma_load_V, _0{}, Layout<_1>{},
+                                         group_modes<0, 3>(sV), group_modes<0, 3>(tOgV_dkl));
+
+      auto load_K_tile = [&](int tile_idx) {
+        { GPU_TRACE_SCOPE(LOAD_K); pipeline_kv.producer_acquire(pipeline_kv_producer_state); }
+        if (lane_predicate) {
+          auto tma_barrier = pipeline_kv.producer_get_barrier(pipeline_kv_producer_state);
+          copy(params.tma_load_K.with(*tma_barrier, 0), tKgK(_, tile_idx),
+               tKsK(_, pipeline_kv_producer_state.index()));
+        }
+        ++pipeline_kv_producer_state;
+      };
+
+      auto load_V_tile = [&](int tile_idx) {
+        { GPU_TRACE_SCOPE(LOAD_V); pipeline_kv.producer_acquire(pipeline_kv_producer_state); }
+        if (lane_predicate) {
+          auto tma_barrier = pipeline_kv.producer_get_barrier(pipeline_kv_producer_state);
+          if constexpr (LoadV) {
+            copy(params.tma_load_V.with(*tma_barrier, 0), tVgV(_, tile_idx),
+                 tVsV(_, pipeline_kv_producer_state.index()));
+          } else {
+            cutlass::arch::ClusterTransactionBarrier::complete_transaction(
+                tma_barrier, cute::block_rank_in_cluster(), kTransactionBytesKV);
+          }
+        }
+        ++pipeline_kv_producer_state;
+      };
+
+      run_loads(load_K_tile, load_V_tile);
+    }
+    // RELEASE_GPU_TRACE;
+  }
+};
+
+}  // namespace cutlass::fmha::collective

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/sm100_fmha_reduction.hpp
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/sm100_fmha_reduction.hpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2025 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "cutlass/cutlass.h"
+#include "fmha_common.hpp"
+
+namespace cutlass::fmha::kernel {
+
+// Reduction kernel for split-KV FMHA.
+// Merges partial bf16 O using float32 LSE (log-sum-exp) from multiple KV splits.
+// ptr_lse stores LSE = max + log2(sum) / scale_softmax_log2.
+//
+// Grid:  (num_qo_heads, total_qo_len, 1)
+// Block: 128 threads. Each thread handles one d element.
+template <class ElementPartial,  // bf16 (workspace O type)
+          class ElementOut,      // output dtype (fp8 or bf16)
+          int kMaxSplits = 128>
+struct Sm100FmhaReductionKernel {
+  static const int MaxThreadsPerBlock = 128;
+
+  struct Params {
+    const ElementPartial* ptr_O_partial;  // [total_qo_len * num_splits, num_heads, head_dim]
+    ElementOut* ptr_O;                    // [total_qo_len, num_heads, head_dim]
+    const float* ptr_lse;                // [num_splits, total_qo_len, num_heads]
+    const int* num_kv_splits_per_row;     // [total_qo_len]: actual split count per row
+    float scale_softmax_log2;
+    float inv_scale_o;
+    int num_kv_splits;
+    int total_qo_len;
+    int num_qo_heads;
+    int head_dim_vo;
+    int stride_o_n;       // output: token stride
+    int stride_o_h;       // output: head stride
+    int stride_partial_n; // partial: token stride
+    int stride_partial_h; // partial: head stride
+    // Fused unpack-GQA: when ptr_O_direct != nullptr, write to unpacked layout
+    // [nnz_qo, num_qo_heads_orig, head_dim_vo] instead of packed ptr_O.
+    ElementOut* ptr_O_direct = nullptr;
+    int num_qo_heads_orig = 0;
+    int num_kv_heads = 0;
+    int pack_factor = 1;
+  };
+
+  static dim3 get_grid_shape(Params const& params) {
+    return dim3(params.num_qo_heads, params.total_qo_len, 1);
+  }
+
+  static dim3 get_block_shape() { return dim3(MaxThreadsPerBlock, 1, 1); }
+
+  CUTLASS_DEVICE void operator()(Params const& params, char* /* smem */) {
+    int head_idx = blockIdx.x;
+    int abs_row = blockIdx.y;
+    int d = threadIdx.x;
+
+    if (abs_row >= params.total_qo_len || d >= params.head_dim_vo) return;
+
+    int num_splits = warp_uniform(params.num_kv_splits_per_row[abs_row]);
+    int partial_off = abs_row * params.stride_partial_n +
+                      head_idx * params.stride_partial_h + d;
+
+    // Decide output base + offset. Fused unpack remaps packed (abs_row, head_idx)
+    // to unpacked (actual_tok, unpacked_head); plain path uses packed strides.
+    ElementOut* o_ptr_used;
+    int64_t dst_off;
+    if (params.ptr_O_direct != nullptr) {
+      int pf            = params.pack_factor;
+      int rem_hr        = params.num_qo_heads / params.num_kv_heads;  // packed h_r
+      int kv_head       = head_idx / rem_hr;
+      int rhr_idx       = head_idx % rem_hr;
+      int h_r_orig      = rem_hr * pf;
+      int pf_idx        = abs_row % pf;
+      int actual_tok    = abs_row / pf;
+      int unpacked_head = kv_head * h_r_orig + rhr_idx * pf + pf_idx;
+      dst_off = (int64_t)actual_tok * params.num_qo_heads_orig * params.head_dim_vo
+              + (int64_t)unpacked_head * params.head_dim_vo
+              + d;
+      o_ptr_used = params.ptr_O_direct;
+    } else {
+      dst_off = (int64_t)abs_row * params.stride_o_n
+              + (int64_t)head_idx * params.stride_o_h
+              + d;
+      o_ptr_used = params.ptr_O;
+    }
+
+    // Fast path: single split — just scale and copy, no merge needed
+    if (num_splits == 1) {
+      int stats_base = warp_uniform(abs_row * params.num_qo_heads + head_idx);
+      float lse = params.ptr_lse[stats_base];
+      if (lse == -INFINITY) {
+        o_ptr_used[dst_off] = ElementOut(0.f);
+      } else {
+        float o_s = static_cast<float>(params.ptr_O_partial[partial_off]);
+        o_ptr_used[dst_off] = ElementOut(o_s * params.inv_scale_o);
+      }
+      return;
+    }
+
+    int stats_stride = warp_uniform(params.total_qo_len * params.num_qo_heads);
+    int stats_base = warp_uniform(abs_row * params.num_qo_heads + head_idx);
+
+    float running_lse = -__FLT_MAX__;
+    float running_w = 0.f;
+    float running_o = 0.f;
+
+    int partial_stride = params.total_qo_len * params.stride_partial_n;
+    int stats_off = stats_base;
+
+    // Prologue: load first split
+    float lse_cur = -INFINITY, o_s_cur = 0.f;
+    if (num_splits > 0) {
+      lse_cur = params.ptr_lse[stats_off];
+      o_s_cur = static_cast<float>(params.ptr_O_partial[partial_off]);
+    }
+
+    // Main loop: prefetch next, merge current using LSE-based weights
+    // Empty splits have LSE=-INF, exp2(scale*(-INF - ref)) = 0 → natural no-op
+    #pragma unroll 2
+    for (int s = 0; s < num_splits - 1; ++s) {
+      float lse_s = lse_cur, o_s = o_s_cur;
+      stats_off += stats_stride;
+      partial_off += partial_stride;
+      lse_cur = params.ptr_lse[stats_off];
+      o_s_cur = static_cast<float>(params.ptr_O_partial[partial_off]);
+
+      o_s = (lse_s != -INFINITY) ? o_s : 0.f;
+
+      if (lse_s > running_lse) {
+        float rescale = exp2f(params.scale_softmax_log2 * (running_lse - lse_s));
+        running_o = fmaf(running_o, rescale, o_s);
+        running_w = fmaf(running_w, rescale, 1.f);
+        running_lse = lse_s;
+      } else {
+        float rescale = exp2f(params.scale_softmax_log2 * (lse_s - running_lse));
+        running_o = fmaf(o_s, rescale, running_o);
+        running_w += rescale;
+      }
+    }
+
+    // Epilogue: last split
+    if (num_splits > 0) {
+      float o_last = (lse_cur != -INFINITY) ? o_s_cur : 0.f;
+      if (lse_cur > running_lse) {
+        float rescale = exp2f(params.scale_softmax_log2 * (running_lse - lse_cur));
+        running_o = fmaf(running_o, rescale, o_last);
+        running_w = fmaf(running_w, rescale, 1.f);
+        running_lse = lse_cur;
+      } else {
+        float rescale = exp2f(params.scale_softmax_log2 * (lse_cur - running_lse));
+        running_o = fmaf(o_last, rescale, running_o);
+        running_w += rescale;
+      }
+    }
+
+    if (running_w == 0.f) {
+      o_ptr_used[dst_off] = ElementOut(0.f);
+      return;
+    }
+
+    float inv_w = warp_uniform(1.f / running_w);
+    o_ptr_used[dst_off] = ElementOut(running_o * inv_w * params.inv_scale_o);
+  }
+};
+
+}  // namespace cutlass::fmha::kernel

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/sparse_topk_select.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/sparse_topk_select.cuh
@@ -1,0 +1,1259 @@
+/*
+ * Copyright (c) 2024-2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * ------------------------------------------------------------------------
+ * Portions of this file (indexerTopK histogram-step + final-candidate selection
+ * algorithm) are derived from NVIDIA TensorRT-LLM:
+ *   Copyright (c) 2019-2026 NVIDIA CORPORATION
+ *   Copyright (c) 2021 NAVER Corp. (CLOVA)
+ * licensed under Apache License 2.0.  Original source:
+ *   tensorrt_llm/cpp/tensorrt_llm/kernels/indexerTopK.cu
+ *
+ * Function provenance map (NVIDIA TensorRT-LLM, indexerTopK.cu line ranges):
+ *   extractBinIdx                indexerTopK.cu:43-71
+ *   isPartialMatch               indexerTopK.cu:73-83
+ *   vectorized_process           indexerTopK.cu:99-162
+ *   processHistogramStep         indexerTopK.cu:164-362  (multipleBlocksPerRow /
+ *                                                        mergeBlocks branches dropped;
+ *                                                        stride1!=1 branch dropped)
+ *   topKPerRowJob                indexerTopK.cu:365-595  (insertion-sort branch only;
+ *                                                        radix-sort branch dropped;
+ *                                                        multipleBlocksPerRow /
+ *                                                        mergeBlocks dropped;
+ *                                                        ascending-by-index sort fused)
+ *
+ * v2.0_indexer_topk_qo_outermost fork additions (FlashInfer-original):
+ *   SparseTopKTransposeKernel        — input layout adapter (reused from v1.6.5)
+ *   SparseTopKIdentityFillKernel     — trivial-row fast path  (reused from v1.6.5)
+ *   IndexerTopKWithSortKernel        — wraps topKPerRowJob and fuses an
+ *                                      ascending-by-index cub::BlockRadixSort over
+ *                                      smemOutput before the gmem write, so the
+ *                                      output contract matches the v1.6.5 fork
+ *                                      (qo_outermost layout, asc-by-index)
+ *   SparseTopKSelect                 — top-level dispatcher
+ * ------------------------------------------------------------------------
+ */
+#ifndef FLASHINFER_SPARSE_TOPK_SELECT_CUH_
+#define FLASHINFER_SPARSE_TOPK_SELECT_CUH_
+
+#include <cuda.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cfloat>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <cub/cub.cuh>
+#include <type_traits>
+
+namespace flashinfer {
+namespace sparse_topk {
+
+enum class SparseTopKInputLayout : uint32_t {
+  kHKT = 0,  // input is (num_qo_heads, max_k_tiles, total_qo_len)
+  kTHK = 1,  // input is (total_qo_len, num_qo_heads, max_k_tiles)
+};
+
+__device__ __forceinline__ void SparseTopKWaitOnDependentGrids(uint32_t use_pdl) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  if (use_pdl) {
+    cudaGridDependencySynchronize();
+  }
+#else
+  (void)use_pdl;
+#endif
+}
+
+__device__ __forceinline__ void SparseTopKLaunchDependentGrids(uint32_t use_pdl) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  if (use_pdl) {
+    cudaTriggerProgrammaticLaunchCompletion();
+  }
+#else
+  (void)use_pdl;
+#endif
+}
+
+__device__ __forceinline__ uint32_t LoadRowNumValidPages(
+    const int32_t* __restrict__ num_valid_pages_per_token,
+    uint32_t t, uint32_t scalar_num_valid_pages) {
+  if (num_valid_pages_per_token == nullptr) return scalar_num_valid_pages;
+  const int32_t row_nvp = __ldg(num_valid_pages_per_token + t);
+  if (row_nvp <= 0) return 0u;
+  const uint32_t row_nvp_u = static_cast<uint32_t>(row_nvp);
+  return row_nvp_u < scalar_num_valid_pages ? row_nvp_u : scalar_num_valid_pages;
+}
+
+__device__ __forceinline__ bool IsForcedBlock(uint32_t k, uint32_t force_begin,
+                                              uint32_t force_end_start,
+                                              uint32_t row_num_valid_pages) {
+  return (k < force_begin) || (k >= force_end_start && k < row_num_valid_pages);
+}
+
+__device__ __forceinline__ int32_t GatherBlockTableValue(
+    const int32_t* __restrict__ block_table_row, uint64_t block_table_stride_k,
+    int32_t logical_idx) {
+  if (logical_idx < 0) return -1;
+  if (block_table_row == nullptr) return logical_idx;
+  return __ldg(block_table_row + static_cast<size_t>(logical_idx) * block_table_stride_k);
+}
+
+// =============================================================================
+// v2.0 design overview
+// =============================================================================
+//
+// Replaces the v1.6.5_2cta_per_row_qo_outermost pipeline (transpose +
+// Filtered/Multi-CTA + Merge + SortByIndex = 3-4 kernels) with the
+// indexerTopK algorithm (transpose + indexerTopK-with-fused-sort = 2 kernels).
+//
+// Pipeline:
+//
+//   [in (Hq, K, qo) row-contig fp32]
+//          |
+//          v  SparseTopKTransposeKernel  (per-head 32x32 SMEM tile transpose)
+//          |
+//   [transpose_buf (Hq, qo, K) row-contig fp32 — workspace]
+//          |
+//          v  IndexerTopKWithSortKernel<MAX_TOPK>(grid=num_rows, block=512)
+//          |    Stage 0: 10-bit fp16 hist + cub::BlockScan + threshold + classify
+//          |    Stage 1/2/3: 10+10+10 bit fp32 (only if Stage 0 didn't finish)
+//          |    Final pass: bounded rank-select / warp merge over the staged bin
+//          |    Warp-only bitonic sort on smemOutput (ascending by index)
+//          |    NEW: write gmem with qo_outermost offset
+//          |
+//   [out (qo, num_qo_heads, topk) int32, ascending-by-index]
+//     If block_table is supplied, selected logical indices are sorted first,
+//     then gathered through block_table[t][h][idx] before the write.
+//
+// Trivial path (max_k_tiles <= topk) routes to SparseTopKIdentityFillKernel,
+// same as the v1.6.5 fork — preserves the seamless drop-in contract.
+//
+// Workspace = transpose_buf only (no descriptors / merge_in / unsorted_tmp /
+// counter slabs needed; v1.6.5's workspace formula is preserved as a
+// conservative upper bound so callers that allocated v1.6.5-sized workspaces
+// still work without any change).
+
+// =============================================================================
+// indexerTopK helpers — vendored from TRT-LLM indexerTopK.cu
+// =============================================================================
+
+template <int step>
+__device__ __forceinline__ uint32_t extractBinIdx(float x) {
+  if constexpr (step == 0) {
+    __half hx = __float2half(x);
+    uint16_t bits = __half_as_ushort(hx);
+    bits = (bits & 0x8000) ? bits : ~bits & 0x7fff;
+    return bits >> 6;          // 10-bit fp16 (was >> 5 for 11-bit)
+  } else {
+    uint32_t bits = __float_as_uint(x);
+    bits = (bits & 0x80000000) ? bits : ~bits & 0x7fffffff;
+
+    if constexpr (step == 1) {
+      return bits >> 22;                // high 10 bits (was >> 21)
+    } else if constexpr (step == 2) {
+      return (bits >> 12) & 0x3ff;      // mid 10 bits (was (>> 10) & 0x7ff)
+    } else if constexpr (step == 3) {
+      return (bits >> 2) & 0x3ff;       // next-low 10 bits, drops bits 0-1
+    }
+  }
+}
+
+template <int shift>
+__device__ __forceinline__ bool isPartialMatch(float x, uint32_t pattern) {
+  if constexpr (shift == 0) {
+    return true;
+  }
+  uint32_t bits = __float_as_uint(x);
+  bits = (bits & 0x80000000) ? bits : ~bits & 0x7fffffff;
+  return (bits ^ pattern) >> shift == 0;
+}
+
+// Map Func over the input data, using vectorized float4 loads when possible.
+// stride1==1 only (we always feed transpose_buf, which is row-contig).
+template <typename T, typename idxT, typename Func>
+__device__ void vectorized_process(size_t thread_rank, size_t num_threads, T const* in, idxT len,
+                                   Func f) {
+  constexpr int WARP_SIZE = 32;
+  using WideT = float4;
+  if constexpr (sizeof(T) >= sizeof(WideT)) {
+    for (idxT i = thread_rank; i < len; i += num_threads) {
+      f(in[i], i);
+    }
+  } else {
+    static_assert(sizeof(WideT) % sizeof(T) == 0);
+    constexpr int items_per_scalar = sizeof(WideT) / sizeof(T);
+
+    union {
+      WideT scalar;
+      T array[items_per_scalar];
+    } wide;
+
+    int skip_cnt = (reinterpret_cast<size_t>(in) % sizeof(WideT))
+                       ? ((sizeof(WideT) - reinterpret_cast<size_t>(in) % sizeof(WideT)) /
+                          sizeof(T))
+                       : 0;
+    if (skip_cnt > len) {
+      skip_cnt = len;
+    }
+    WideT const* in_cast = reinterpret_cast<decltype(in_cast)>(in + skip_cnt);
+    idxT const len_cast = (len - skip_cnt) / items_per_scalar;
+
+    for (idxT i = thread_rank; i < len_cast; i += num_threads) {
+      wide.scalar = in_cast[i];
+      idxT const real_i = skip_cnt + i * items_per_scalar;
+#pragma unroll
+      for (int j = 0; j < items_per_scalar; ++j) {
+        f(wide.array[j], real_i + j);
+      }
+    }
+
+    static_assert(WARP_SIZE >= items_per_scalar);
+    if (thread_rank < skip_cnt) {
+      f(in[thread_rank], thread_rank);
+    }
+    idxT const remain_i = skip_cnt + len_cast * items_per_scalar + thread_rank;
+    if (remain_i < len) {
+      f(in[remain_i], remain_i);
+    }
+  }
+}
+
+// =============================================================================
+// processHistogramStep — vendored from indexerTopK.cu (single-block-per-row only)
+// =============================================================================
+//
+// Differences vs upstream:
+//   - Drops `multipleBlocksPerRow` and `mergeBlocks` template branches: v2.0
+//     always processes one row per CTA, no inter-CTA merge.
+//   - Drops `stride1` runtime branch: v2.0 always feeds transpose_buf, so input
+//     is always row-contiguous (stride1 == 1) and we always go through
+//     vectorized_process.
+//   - `indices` arg removed (was only used in mergeBlocks branch).
+template <int step, int kNumThreadsPerBlock, int kNumBins, int kNumFinalItems,
+          typename SmemFinalType, typename SmemOutputType>
+__device__ bool processHistogramStep(float const* logits, int rowEnd, uint32_t& logitPattern,
+                                     int& thresholdBinIdx, SmemOutputType& smemOutput,
+                                     int* smemThresholdBinIdx, int* smemFinalDstIdx,
+                                     int* smemFinalBinSize, int* smemFoundTopKValues,
+                                     SmemFinalType& smemFinal, int rowStart, int topK,
+                                     uint32_t force_begin, uint32_t force_end_start,
+                                     uint32_t row_num_valid_pages) {
+  // Clear the histogram.
+#pragma unroll
+  for (int idx = threadIdx.x; idx < kNumBins; idx += kNumThreadsPerBlock) {
+    smemFinal.histo.data[idx] = 0;
+  }
+  __syncthreads();
+
+  // Update pattern.
+  const int prevThresholdBinIdx = thresholdBinIdx;
+  constexpr auto patternShift = step < 2 ? 0 : step == 2 ? 22 : 12;
+  if constexpr (step == 2) {
+    logitPattern = static_cast<uint32_t>(thresholdBinIdx & 0x3ff) << patternShift;
+  } else if constexpr (step == 3) {
+    logitPattern |= static_cast<uint32_t>(thresholdBinIdx & 0x3ff) << patternShift;
+  }
+
+  auto effective_logit = [&](float logit, int idx) {
+    const uint32_t k = static_cast<uint32_t>(rowStart + idx);
+    return IsForcedBlock(k, force_begin, force_end_start, row_num_valid_pages) ? FLT_MAX : logit;
+  };
+
+  auto matchesCurrentRefinement = [&](float logit) {
+    if constexpr (step == 1) {
+      return extractBinIdx<0>(logit) == static_cast<uint32_t>(prevThresholdBinIdx);
+    } else {
+      return isPartialMatch<patternShift>(logit, logitPattern);
+    }
+  };
+
+  auto distributeToBins = [&](float logit, int idx = 0) {
+    logit = effective_logit(logit, idx);
+    if (matchesCurrentRefinement(logit)) {
+      uint32_t binIdx = extractBinIdx<step>(logit);
+      atomicAdd(&smemFinal.histo.data[binIdx], 1);
+    }
+  };
+
+  // Distribute the elements to the histogram bins.
+  vectorized_process(threadIdx.x, kNumThreadsPerBlock, logits + rowStart, rowEnd - rowStart,
+                     distributeToBins);
+  __syncthreads();
+
+  // Reads the value of the starting position in smemOutput accounting.
+  int lastValue = smemFoundTopKValues[0];
+
+  for (int round = 0; round < kNumBins / kNumThreadsPerBlock; round++) {
+    // Read the values from SMEM.
+    int idx = threadIdx.x + kNumThreadsPerBlock * round;
+    int binCount{0};
+    binCount = smemFinal.histo.data[idx];
+    __syncthreads();
+
+    // Compute the prefix sum.
+    int prefixSum{0}, totalSum{0};
+    using Scan = cub::BlockScan<int, kNumThreadsPerBlock>;
+    Scan(smemFinal.histo.scan).ExclusiveSum(binCount, prefixSum, totalSum);
+
+    prefixSum += lastValue;
+    totalSum += lastValue;
+    smemFinal.histo.data[idx] = prefixSum;
+    __syncthreads();
+
+    bool foundThreshold = false;
+    if (prefixSum < topK) {
+      int nextPrefixSum = threadIdx.x == kNumThreadsPerBlock - 1
+                              ? totalSum
+                              : smemFinal.histo.data[idx + 1];
+      if (nextPrefixSum >= topK) {
+        smemThresholdBinIdx[0] = idx;
+        smemFinalBinSize[0] = nextPrefixSum - prefixSum;
+        foundThreshold = true;
+      }
+    }
+
+    if (__syncthreads_or(foundThreshold)) {
+      break;
+    }
+    lastValue = totalSum;
+  }
+  __syncthreads();
+
+  thresholdBinIdx = smemThresholdBinIdx[0];
+
+  auto processBins = [&](float logit, int idx) {
+    logit = effective_logit(logit, idx);
+    if (matchesCurrentRefinement(logit)) {
+      uint32_t binIdx = extractBinIdx<step>(logit);
+      if (binIdx < thresholdBinIdx) {
+        // The element is part of the top-k selection.
+        int dstIdx = atomicAdd(&smemFoundTopKValues[0], 1);
+        smemOutput[dstIdx] = idx;
+      }
+      if constexpr (step < 3) {
+        // Only fill final items for sorting if the threshold bin fits.
+        if (binIdx == thresholdBinIdx && smemFinalBinSize[0] <= kNumFinalItems) {
+          int dstIdx = atomicAdd(&smemFinalDstIdx[0], 1);
+          smemFinal.items.logits[dstIdx] = logit;
+          smemFinal.items.indices[dstIdx] = idx;
+        }
+      } else {
+        if (binIdx == thresholdBinIdx) {
+          // Elements in the threshold bin share the same 32 bits at step 3.
+          int dstIdx = atomicAdd(&smemFinal.histo.data[binIdx], 1);
+          if (dstIdx < topK) {
+            smemOutput[dstIdx] = idx;
+          }
+        }
+      }
+    }
+  };
+
+  vectorized_process(threadIdx.x, kNumThreadsPerBlock, logits + rowStart, rowEnd - rowStart,
+                     processBins);
+  __syncthreads();
+
+  // Continue to next step if the threshold bin overflows the staging buffer.
+  return smemFinalBinSize[0] > kNumFinalItems;
+}
+
+// =============================================================================
+// Transpose kernel — reused verbatim from v1.6.5_2cta_per_row_qo_outermost
+// =============================================================================
+//
+// Per-head 32x32 SMEM tile transpose.  Source layout has qo as the innermost
+// dim (stride 1, K-stride = qo); dest swaps so K becomes innermost (stride 1,
+// qo-stride = K).  Heads dim stays outermost in both.
+//
+// Block: (32, 8) = 256 threads.  Each thread does 4 elements per pass.
+// Tile : 32x32 floats with [32][33] padding to remove SMEM bank conflicts.
+// Grid : (ceil(qo / 32), ceil(K / 32), num_qo_heads)
+//
+// Fallback used when XorF4 preconditions (qo % TILE == 0 && K % TILE == 0 &&
+// qo % 4 == 0 && K % 4 == 0) are not met.  All decode/spec workloads with
+// qo, K divisible by 32 take the faster TransposeXorF4 path.
+constexpr int kTransposeTile = 32;
+constexpr int kTransposeBlockRows = 8;
+
+__global__ void __launch_bounds__(kTransposeTile* kTransposeBlockRows)
+    SparseTopKTransposeKernel(const float* __restrict__ in, float* __restrict__ out, uint32_t K,
+                              uint32_t qo, uint32_t use_pdl) {
+  __shared__ float tile[kTransposeTile][kTransposeTile + 1];
+
+  const uint32_t q_base = blockIdx.x * kTransposeTile;
+  const uint32_t k_base = blockIdx.y * kTransposeTile;
+  const uint32_t head = blockIdx.z;
+  const uint32_t tx = threadIdx.x;
+  const uint32_t ty = threadIdx.y;
+
+  const float* in_head = in + static_cast<size_t>(head) * K * qo;
+  float* out_head = out + static_cast<size_t>(head) * qo * K;
+
+  SparseTopKWaitOnDependentGrids(use_pdl);
+
+  const uint32_t q_load = q_base + tx;
+#pragma unroll
+  for (int dk = 0; dk < kTransposeTile; dk += kTransposeBlockRows) {
+    const uint32_t k_load = k_base + ty + dk;
+    if (q_load < qo && k_load < K) {
+      tile[ty + dk][tx] = in_head[static_cast<size_t>(k_load) * qo + q_load];
+    }
+  }
+  __syncthreads();
+
+  const uint32_t k_store = k_base + tx;
+#pragma unroll
+  for (int dq = 0; dq < kTransposeTile; dq += kTransposeBlockRows) {
+    const uint32_t q_store = q_base + ty + dq;
+    if (q_store < qo && k_store < K) {
+      out_head[static_cast<size_t>(q_store) * K + k_store] = tile[tx][ty + dq];
+    }
+  }
+  __syncthreads();
+  if (threadIdx.x == 0 && threadIdx.y == 0) {
+    SparseTopKLaunchDependentGrids(use_pdl);
+  }
+}
+
+// =============================================================================
+// SparseTopKTransposeXorF4Kernel — FAST PATH transpose
+// =============================================================================
+//
+// Vendored from paged_attention_doc/sparse_topk_experiments/transpose_bench/
+// benchmark_swizzle.py — XOR-swizzle + float4 GMEM I/O, no SMEM padding.
+//
+// Theory:
+//   Standard +1-padding k32: scalar float GMEM loads/stores.
+//   This kernel: float4 GMEM loads (4 Q values per thread), scalar SMEM
+//   writes (XOR-swizzled), scalar SMEM reads (transposed, conflict-free by
+//   XOR), float4 GMEM stores (4 K values per thread).
+//
+//   The XOR swizzle: value[k][q] stored at S[k * TILE + (q ^ k)].
+//     WRITE bank (q^k): for fixed k, varying q → all different banks → no conflict.
+//     READ bank ((q^k) for varying k, fixed q): all different banks → no conflict.
+//
+// Preconditions (caller must ensure):
+//   - TILE divides qo and K
+//   - qo and K divisible by 4 (for float4 alignment)
+//   - input/output base pointers 16-B aligned (cudaMalloc guarantees this for
+//     the workspace pointer; transpose_buf offset is at the start so aligned)
+//
+// Grid: (qo / TILE, K / TILE, num_qo_heads), Block: TILE * TILE / 4 threads.
+template <int TILE>
+__global__ void __launch_bounds__(TILE * TILE / 4) SparseTopKTransposeXorF4Kernel(
+    const float* __restrict__ in, float* __restrict__ out, uint32_t K, uint32_t qo,
+    uint32_t use_pdl) {
+  constexpr int N_THR = TILE / 4;  // threads along N (qo) direction
+
+  __shared__ float S[TILE * TILE];
+
+  const uint32_t qb = blockIdx.x * TILE;
+  const uint32_t kb = blockIdx.y * TILE;
+  const uint32_t h  = blockIdx.z;
+  const uint32_t tx = threadIdx.x;
+
+  const int tm = tx / N_THR;        // K-tile row index (0..TILE-1)
+  const int tn = tx % N_THR;        // Q-tile col group (0..N_THR-1, covers 4 Q each)
+
+  const float* in_head  = in  + static_cast<size_t>(h) * K * qo;
+  float*       out_head = out + static_cast<size_t>(h) * qo * K;
+
+  SparseTopKWaitOnDependentGrids(use_pdl);
+
+  // ---- LOAD: float4 GMEM → XOR-swizzled SMEM ---------------------------
+  {
+    const float4* in4 = reinterpret_cast<const float4*>(
+        in_head + static_cast<size_t>(kb + tm) * qo + qb + tn * 4);
+    float4 v = *in4;
+
+    const int base = tm * TILE;
+    S[base + ((tn * 4 + 0) ^ tm)] = v.x;
+    S[base + ((tn * 4 + 1) ^ tm)] = v.y;
+    S[base + ((tn * 4 + 2) ^ tm)] = v.z;
+    S[base + ((tn * 4 + 3) ^ tm)] = v.w;
+  }
+  __syncthreads();
+
+  // ---- STORE: scalar swizzled SMEM reads → float4 GMEM -----------------
+  {
+    const int q_out = qb + tm;
+    const int k0    = kb + tn * 4;
+
+    float v0 = S[(tn * 4 + 0) * TILE + (tm ^ (tn * 4 + 0))];
+    float v1 = S[(tn * 4 + 1) * TILE + (tm ^ (tn * 4 + 1))];
+    float v2 = S[(tn * 4 + 2) * TILE + (tm ^ (tn * 4 + 2))];
+    float v3 = S[(tn * 4 + 3) * TILE + (tm ^ (tn * 4 + 3))];
+
+    float4 out_v = {v0, v1, v2, v3};
+    float4* out4 = reinterpret_cast<float4*>(
+        out_head + static_cast<size_t>(q_out) * K + k0);
+    *out4 = out_v;
+  }
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    SparseTopKLaunchDependentGrids(use_pdl);
+  }
+}
+
+// =============================================================================
+// Identity-fill kernel — reused verbatim from v1.6.5_2cta_per_row_qo_outermost
+// =============================================================================
+// Used when max_k_tiles <= topk (trivial row): output = [0, 1, ..., K-1, -1, ..., -1].
+// Skips both transpose + indexerTopK to save VRAM and a kernel launch.
+//
+// v2.5_oob_clamp_in_kernel: also handles num_valid_pages clamp — indices in
+// [num_valid_pages, max_k_tiles) become -1 (already sorted to tail by
+// construction since the trivial fill is ascending). Pass num_valid_pages =
+// max_k_tiles (or any value >= max_k_tiles) to disable clamping.
+__global__ void SparseTopKIdentityFillKernel(int32_t* __restrict__ out,
+                                             const int32_t* __restrict__ block_table,
+                                             uint64_t out_stride_t,
+                                             uint64_t out_stride_h,
+                                             uint64_t out_stride_k,
+                                             uint64_t block_table_stride_t,
+                                             uint64_t block_table_stride_h,
+                                             uint64_t block_table_stride_k,
+                                             uint32_t total_qo_len,
+                                             uint32_t num_qo_heads, uint32_t max_k_tiles,
+                                             uint32_t topk, uint32_t num_valid_pages,
+                                             const int32_t* __restrict__ num_valid_pages_per_token,
+                                             uint32_t use_pdl) {
+  // grid = (num_rows = total_qo_len * num_qo_heads,), block = (min(topk, 256),)
+  // bid encodes (qo_head_idx, t) with t innermost: bid = qo_head_idx * total_qo_len + t
+  // out logical layout: (total_qo_len, num_qo_heads, topk)
+  //   element (t, qo_head_idx, k) at offset = t*out_stride_t + h*out_stride_h + k*out_stride_k
+  const uint32_t bid = blockIdx.x;
+  const uint32_t tx = threadIdx.x;
+  const uint32_t qo_head_idx = bid / total_qo_len;
+  const uint32_t t = bid % total_qo_len;
+  int32_t* row =
+      out + static_cast<size_t>(t) * out_stride_t +
+      static_cast<size_t>(qo_head_idx) * out_stride_h;
+  const int32_t* block_table_row =
+      block_table == nullptr
+          ? nullptr
+          : block_table + static_cast<size_t>(t) * block_table_stride_t +
+                static_cast<size_t>(qo_head_idx) * block_table_stride_h;
+  SparseTopKWaitOnDependentGrids(use_pdl);
+  // valid_count = min(max_k_tiles, num_valid_pages); positions [valid_count, topk) → -1
+  const uint32_t row_num_valid_pages =
+      LoadRowNumValidPages(num_valid_pages_per_token, t, num_valid_pages);
+  const uint32_t valid_count =
+      (row_num_valid_pages < max_k_tiles) ? row_num_valid_pages : max_k_tiles;
+  for (uint32_t i = tx; i < topk; i += blockDim.x) {
+    const int32_t logical_idx = (i < valid_count) ? static_cast<int32_t>(i) : -1;
+    row[static_cast<size_t>(i) * out_stride_k] =
+        GatherBlockTableValue(block_table_row, block_table_stride_k, logical_idx);
+  }
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    SparseTopKLaunchDependentGrids(use_pdl);
+  }
+}
+
+// =============================================================================
+// Warp-only ascending sort (v2.1 fix replacing the heavy cub::BlockRadixSort)
+// =============================================================================
+//
+// v2.0 used cub::BlockRadixSort<uint32_t, 512, 1> over all 512 threads to
+// sort the topk indices ascending — but only ≤64 of the 512 keys are real
+// (rest are sentinel ~0u), so 92%+ of the sort work was wasted, and nsys
+// measured this as ~13 us per kernel call (largest single component of the
+// IndexerTopK kernel duration).
+//
+// v2.1 replaces it with a warp-only bitonic sort (single warp, 32 lanes ×
+// {1, 2} keys depending on MAX_TOPK), modelled on v1.6.5's WarpBitonicSortAsc16.
+// Expected cost: < 1 us, savings ~12 us per kernel call.
+
+constexpr int kFinalCandidateSourceBits = 14;
+constexpr uint64_t kFinalCandidateSourceMask = (1ull << kFinalCandidateSourceBits) - 1;
+
+// Pack score, staging position, and source index into one sortable key.  The
+// high 32 bits preserve numeric float order.  Staging position is next so an
+// equal-score tie follows the legacy rank loop, which preferred larger staged
+// positions (`i < j` incremented i's rank).  The source index is payload in the
+// low 14 bits; max_k_tiles is constrained to < 12288 by the dispatcher.
+__device__ __forceinline__ uint64_t MakeFinalCandidateKey(float logit,
+                                                         int staging_position,
+                                                         int source_index) {
+  // Numeric comparison treats -0.0f and +0.0f as equal, so canonicalize zero
+  // before converting the score to an integer ordering key.
+  const uint32_t raw_bits = __float_as_uint(logit);
+  const uint32_t bits = (raw_bits & 0x7fffffffu) == 0 ? 0u : raw_bits;
+  const uint32_t ordered_bits =
+      (bits & 0x80000000u) ? ~bits : (bits ^ 0x80000000u);
+  return (static_cast<uint64_t>(ordered_bits) << 32) |
+         (static_cast<uint64_t>(staging_position) << kFinalCandidateSourceBits) |
+         static_cast<uint32_t>(source_index);
+}
+
+struct FinalCandidateKeyGreater {
+  __device__ __forceinline__ bool operator()(uint64_t lhs, uint64_t rhs) const {
+    return lhs > rhs;
+  }
+};
+
+// 32-element ascending sort, 32 lanes × 1 key each (for MAX_TOPK ≤ 32).
+// Lanes with no real data should pass key = ~0u sentinel, which sorts to the end.
+__device__ __forceinline__ void WarpBitonicSortAsc32(uint32_t& key, uint32_t lane) {
+  constexpr uint32_t MASK = 0xFFFFFFFFu;
+#pragma unroll
+  for (int k = 2; k <= 32; k *= 2) {
+#pragma unroll
+    for (int j = k / 2; j > 0; j /= 2) {
+      uint32_t partner = __shfl_xor_sync(MASK, key, j);
+      const bool asc_pair = ((lane & k) == 0);
+      const bool I_am_lower = ((lane & j) == 0);
+      if (I_am_lower) {
+        key = asc_pair ? min(key, partner) : max(key, partner);
+      } else {
+        key = asc_pair ? max(key, partner) : min(key, partner);
+      }
+    }
+  }
+}
+
+// 64-element ascending sort, 32 lanes × 2 keys each (for MAX_TOPK == 64).
+// BLOCKED layout: lane L holds positions 2L, 2L+1.
+// Lanes/slots without real data pass ~0u sentinel.
+__device__ __forceinline__ void WarpBitonicSortAsc64(uint32_t* keys, uint32_t lane) {
+  constexpr uint32_t MASK = 0xFFFFFFFFu;
+  constexpr int KPT = 2;
+  constexpr int N = 64;
+#pragma unroll
+  for (int k = 2; k <= N; k *= 2) {
+#pragma unroll
+    for (int j = k / 2; j > 0; j /= 2) {
+      // For BLOCKED KPT=2 layout: position i = 2L + s
+      // (i & k) for k power of 2 ≥ 2: == 0 iff (L & (k/2)) == 0
+      // For k == N: (i & N) == 0 always since i < N → asc_pair = true (final merge)
+      const bool asc_pair = (k < N) ? ((lane & (k / 2)) == 0) : true;
+
+      if (j >= KPT) {
+        // Cross-lane shuffle (mask in lane-space = j / KPT)
+        const int mask = j / KPT;
+        const bool I_am_lower = ((lane & mask) == 0);
+#pragma unroll
+        for (int s = 0; s < KPT; ++s) {
+          uint32_t my = keys[s];
+          uint32_t partner = __shfl_xor_sync(MASK, my, mask);
+          if (I_am_lower) {
+            keys[s] = asc_pair ? min(my, partner) : max(my, partner);
+          } else {
+            keys[s] = asc_pair ? max(my, partner) : min(my, partner);
+          }
+        }
+      } else {
+        // j == 1, within-thread: compare slot 0 vs slot 1 of same lane
+        if (asc_pair) {
+          if (keys[0] > keys[1]) {
+            uint32_t t = keys[0]; keys[0] = keys[1]; keys[1] = t;
+          }
+        } else {
+          if (keys[0] < keys[1]) {
+            uint32_t t = keys[0]; keys[0] = keys[1]; keys[1] = t;
+          }
+        }
+      }
+    }
+  }
+}
+
+// =============================================================================
+// IndexerTopKWithSortKernel — fused indexerTopK + asc-by-index sort + qo_outermost write
+// =============================================================================
+//
+// Per-CTA work (1 CTA per (qo_head, qo_pos) row):
+//   1. Stage 0: 10-bit fp16 histogram (1024 bins) → cub::BlockScan threshold
+//      → classify each element: bin < threshold ⇒ direct emit to smemOutput;
+//        bin == threshold ⇒ stage to smemFinal.items if it fits (≤ 2048).
+//   2. Stage 1/2/3 (only if needed): 10+10+10 bit fp32 histogram refinement
+//      on the elements that landed in the threshold bin.
+//   3. If we never fell through to step 3, the staging buffer has a
+//      well-defined subset of "ties at the boundary".  Small bins use bounded
+//      all-pairs ranking; large bins use a two-level warp merge.
+//   4. Warp-only bitonic sort over smemOutput[0..topk-1] → ascending by index.
+//   5. Write to gmem with qo_outermost strides:
+//        out[t][qo_head_idx][k] at t*out_stride_t + qo_head_idx*out_stride_h + k*out_stride_k
+//
+// Template params:
+//   MAX_TOPK            — round-up template bin (16/32/64), runtime topk ≤ MAX_TOPK
+//   kNumThreadsPerBlock — fixed at 512 (matches trtllm canonical config)
+//   kNumBins            — fixed at 1024 (10-bit fp16 / fp32 hist)
+//   kNumFinalItems      — fixed at 2048 (final-candidate staging capacity)
+//
+// Dynamic SMEM = topk * sizeof(int32_t).  The module configures the kernel's
+// dynamic-SMEM attribute once at load time so graph capture only sees launches.
+constexpr uint32_t kSparseTopkMaxK = 64;
+constexpr int kIndexerNumThreadsPerBlock = 512;
+constexpr int kIndexerNumBins = 1024;  // 10-bit hist (was 2048 / 11-bit)
+constexpr int kIndexerNumFinalItems = 2048;
+constexpr int kIndexerQuadraticSelectionLimit = 416;
+
+template <uint32_t MAX_TOPK>
+__global__ void __launch_bounds__(kIndexerNumThreadsPerBlock) IndexerTopKWithSortKernel(
+    const float* __restrict__ in,        // row-contig fp32: (H, T, K) or (T, H, K)
+    int32_t* __restrict__ out,           // (qo, num_qo_heads, topk) logical int32
+    const int32_t* __restrict__ block_table,
+    uint64_t out_stride_t, uint64_t out_stride_h, uint64_t out_stride_k,
+    uint64_t block_table_stride_t, uint64_t block_table_stride_h,
+    uint64_t block_table_stride_k,
+    uint32_t total_qo_len, uint32_t num_qo_heads, uint32_t max_k_tiles,
+    uint32_t topk,
+    // v2.5_oob_clamp_in_kernel: indices >= num_valid_pages get rewritten to -1
+    // and sorted to the tail.  Pass num_valid_pages = max_k_tiles to disable
+    // (the comparison `idx >= num_valid_pages` will then never trigger because
+    // every valid idx is in [0, max_k_tiles)).
+    uint32_t num_valid_pages,
+    const int32_t* __restrict__ num_valid_pages_per_token,
+    uint32_t force_begin, uint32_t force_end,
+    uint32_t input_qo_outermost, uint32_t use_pdl) {
+  static_assert(MAX_TOPK <= kSparseTopkMaxK, "MAX_TOPK exceeds supported max");
+
+  constexpr int kNumThreadsPerBlock = kIndexerNumThreadsPerBlock;
+  constexpr int kNumBins = kIndexerNumBins;
+  constexpr int kNumFinalItems = kIndexerNumFinalItems;
+  constexpr int kNumWarps = kNumThreadsPerBlock / 32;
+  constexpr int kCandidatesPerThread =
+      (kNumFinalItems + kNumThreadsPerBlock - 1) / kNumThreadsPerBlock;
+  constexpr int kWarpCandidatesPerLane =
+      (kNumWarps * MAX_TOPK + 31) / 32;
+  static_assert(kNumThreadsPerBlock % 32 == 0);
+  static_assert(kCandidatesPerThread * kNumThreadsPerBlock >= kNumFinalItems);
+
+  using Scan = cub::BlockScan<int, kNumThreadsPerBlock>;
+  using CandidateWarpSort = cub::WarpMergeSort<uint64_t, kCandidatesPerThread, 32>;
+  using CandidateGlobalSort = cub::WarpMergeSort<uint64_t, kWarpCandidatesPerLane, 32>;
+
+  struct FinalItems {
+    int indices[kNumFinalItems];
+    float logits[kNumFinalItems];
+  };
+  struct Histogram {
+    typename Scan::TempStorage scan;
+    int data[kNumBins];
+  };
+  struct CandidateWarpSortStorage {
+    typename CandidateWarpSort::TempStorage warps[kNumWarps];
+  };
+
+  // SMEM union — v2.1 dropped the cub::BlockRadixSort sortByIndex member
+  // since the asc-by-index sort is now warp-only.  Final-candidate merge-sort
+  // storage can alias items after every candidate has been packed in registers.
+  __shared__ union {
+    FinalItems items;
+    Histogram histo;
+    CandidateWarpSortStorage candidateWarpSort;
+    typename CandidateGlobalSort::TempStorage candidateGlobalSort;
+  } smemFinal;
+
+  // Dynamic SMEM holds the top-K accumulator (one int32 per slot, sized by topk).
+  extern __shared__ int32_t smemOutput[];
+
+  __shared__ int smemThresholdBinIdx[1];
+  __shared__ int smemFinalDstIdx[1];
+  __shared__ int smemFinalBinSize[1];
+  __shared__ int smemFoundTopKValues[1];
+  __shared__ uint64_t smemWarpTopCandidateKeys[kNumWarps * MAX_TOPK];
+
+  // ---- bid -> row decode ---------------------------------------------------
+  // HKT transpose path: bid = qo_head_idx * total_qo_len + t.
+  // THK direct path:    bid = t * num_qo_heads + qo_head_idx.
+  const uint32_t bid = blockIdx.x;
+  const uint32_t t = input_qo_outermost ? (bid / num_qo_heads) : (bid % total_qo_len);
+  const uint32_t qo_head_idx = input_qo_outermost ? (bid % num_qo_heads) : (bid / total_qo_len);
+  // qo_outermost output offset:
+  //   out (t, qo_head_idx, k) at offset t*out_stride_t + qo_head_idx*out_stride_h + k*out_stride_k
+  const size_t row_offset_out =
+      static_cast<size_t>(t) * out_stride_t +
+      static_cast<size_t>(qo_head_idx) * out_stride_h;
+  const int32_t* block_table_row =
+      block_table == nullptr
+          ? nullptr
+          : block_table + static_cast<size_t>(t) * block_table_stride_t +
+                static_cast<size_t>(qo_head_idx) * block_table_stride_h;
+
+  // Per-row input pointer (row stride = max_k_tiles).
+  const float* logits = in + static_cast<size_t>(bid) * max_k_tiles;
+  const int rowStart = 0;
+  const int topK = static_cast<int>(topk);
+  SparseTopKWaitOnDependentGrids(use_pdl);
+  const uint32_t row_num_valid_pages =
+      LoadRowNumValidPages(num_valid_pages_per_token, t, num_valid_pages);
+  // Padding is always -inf and can never be a useful sparse-attention page.
+  // Restrict every histogram/refinement pass to the valid prefix instead of
+  // repeatedly scanning max_k_tiles for rows with a large padded tail.
+  const int rowEnd = static_cast<int>(
+      row_num_valid_pages < max_k_tiles ? row_num_valid_pages : max_k_tiles);
+  const int rowLen = rowEnd - rowStart;
+  const uint32_t force_end_start =
+      (force_end <= row_num_valid_pages) ? row_num_valid_pages - force_end : 0;
+
+  // If the actual valid page count fits in top-k, every valid page must be
+  // emitted exactly once and the rest of the row is invalid padding.  Bypass the
+  // histogram path so large -inf padding ties cannot manufacture arbitrary
+  // duplicate/OOB selections.
+  if (row_num_valid_pages <= static_cast<uint32_t>(topK)) {
+    int32_t* row_out = out + row_offset_out;
+    const int valid_count = (row_num_valid_pages < static_cast<uint32_t>(rowLen))
+                                ? static_cast<int>(row_num_valid_pages)
+                                : rowLen;
+    for (int rowIt = threadIdx.x; rowIt < valid_count; rowIt += kNumThreadsPerBlock) {
+      row_out[static_cast<size_t>(rowIt) * out_stride_k] =
+          GatherBlockTableValue(block_table_row, block_table_stride_k, rowIt);
+    }
+    for (int rowIt = valid_count + threadIdx.x; rowIt < topK; rowIt += kNumThreadsPerBlock) {
+      row_out[static_cast<size_t>(rowIt) * out_stride_k] = -1;
+    }
+    __syncthreads();
+    if (threadIdx.x == 0) {
+      SparseTopKLaunchDependentGrids(use_pdl);
+    }
+    return;
+  }
+
+  // ---- Trivial path: rowLen <= topK (defensive — host dispatcher already
+  //      catches max_k_tiles <= topk via SparseTopKIdentityFillKernel).
+  if (rowLen <= topK) {
+    int32_t* row_out = out + row_offset_out;
+    // OOB clamp: indices >= num_valid_pages → -1
+    const int valid_count = (static_cast<int>(row_num_valid_pages) < rowLen)
+                                ? static_cast<int>(row_num_valid_pages)
+                                : rowLen;
+    for (int rowIt = threadIdx.x; rowIt < valid_count; rowIt += kNumThreadsPerBlock) {
+      row_out[static_cast<size_t>(rowIt) * out_stride_k] =
+          GatherBlockTableValue(block_table_row, block_table_stride_k, rowIt);
+    }
+    for (int rowIt = valid_count + threadIdx.x; rowIt < topK; rowIt += kNumThreadsPerBlock) {
+      row_out[static_cast<size_t>(rowIt) * out_stride_k] = -1;
+    }
+    __syncthreads();
+    if (threadIdx.x == 0) {
+      SparseTopKLaunchDependentGrids(use_pdl);
+    }
+    return;
+  }
+
+  // ---- Init scalar SMEM counters -----------------------------------------
+  if (threadIdx.x == 0) {
+    smemFinalDstIdx[0] = 0;
+    smemFoundTopKValues[0] = 0;
+  }
+  __syncthreads();
+  int thresholdBinIdx = -1;
+  uint32_t logitPattern = 0;
+
+  // ---- Stage 0: fp16 10-bit hist -----------------------------------------
+  bool continueToNextStep =
+      processHistogramStep<0, kNumThreadsPerBlock, kNumBins, kNumFinalItems>(
+          logits, rowEnd, logitPattern, thresholdBinIdx, smemOutput, smemThresholdBinIdx,
+          smemFinalDstIdx, smemFinalBinSize, smemFoundTopKValues, smemFinal, rowStart, topK,
+          force_begin, force_end_start, row_num_valid_pages);
+
+  if (continueToNextStep) {
+    // Stage 1: fp32 high 10 bits.
+    continueToNextStep =
+        processHistogramStep<1, kNumThreadsPerBlock, kNumBins, kNumFinalItems>(
+            logits, rowEnd, logitPattern, thresholdBinIdx, smemOutput, smemThresholdBinIdx,
+            smemFinalDstIdx, smemFinalBinSize, smemFoundTopKValues, smemFinal, rowStart, topK,
+            force_begin, force_end_start, row_num_valid_pages);
+  }
+  if (continueToNextStep) {
+    // Stage 2: fp32 mid 10 bits.
+    continueToNextStep =
+        processHistogramStep<2, kNumThreadsPerBlock, kNumBins, kNumFinalItems>(
+            logits, rowEnd, logitPattern, thresholdBinIdx, smemOutput, smemThresholdBinIdx,
+            smemFinalDstIdx, smemFinalBinSize, smemFoundTopKValues, smemFinal, rowStart, topK,
+            force_begin, force_end_start, row_num_valid_pages);
+  }
+  if (continueToNextStep) {
+    // Stage 3: fp32 low 10 bits.  After this step every remaining tie shares
+    // the same 32-bit pattern so we just fill the topk window directly.
+    processHistogramStep<3, kNumThreadsPerBlock, kNumBins, kNumFinalItems>(
+        logits, rowEnd, logitPattern, thresholdBinIdx, smemOutput, smemThresholdBinIdx,
+        smemFinalDstIdx, smemFinalBinSize, smemFoundTopKValues, smemFinal, rowStart, topK,
+        force_begin, force_end_start, row_num_valid_pages);
+  }
+
+  if (!continueToNextStep) {
+    // The threshold bin fit within kNumFinalItems.  The all-pairs rank loop is
+    // fastest for small bins, but cap it below the measured crossover to avoid
+    // an overflow -> refinement -> O(n^2) cliff.  Larger bins use a two-level
+    // warp merge: each warp contributes its local top candidates, then warp 0
+    // merges at most kNumWarps * topK keys.
+    const int baseIdx = smemFoundTopKValues[0];
+    const int finalCount = smemFinalDstIdx[0];
+    const int numFinalSelections = topK - baseIdx;
+    const int selectionLane = threadIdx.x & 31;
+    const int selectionWarp = threadIdx.x >> 5;
+
+    if (finalCount <= kIndexerQuadraticSelectionLimit) {
+      for (int i = threadIdx.x; i < finalCount; i += kNumThreadsPerBlock) {
+        int outIndex = 0;
+        const float logit = smemFinal.items.logits[i];
+        for (int j = 0; j < finalCount; ++j) {
+          const float otherLogit = smemFinal.items.logits[j];
+          if (logit < otherLogit || (logit == otherLogit && i < j)) {
+            ++outIndex;
+          }
+        }
+        if (outIndex + baseIdx < topK) {
+          smemOutput[outIndex + baseIdx] = smemFinal.items.indices[i];
+        }
+      }
+      __syncthreads();
+    } else {
+      // Pack all shared-memory candidates into registers before merge-sort
+      // reuses the same union as temporary storage.
+      uint64_t candidateKeys[kCandidatesPerThread];
+#pragma unroll
+      for (int item = 0; item < kCandidatesPerThread; ++item) {
+        const int position = threadIdx.x + item * kNumThreadsPerBlock;
+        candidateKeys[item] =
+            position < finalCount
+                ? MakeFinalCandidateKey(smemFinal.items.logits[position], position,
+                                        smemFinal.items.indices[position])
+                : 0;
+      }
+      __syncthreads();
+
+      CandidateWarpSort(smemFinal.candidateWarpSort.warps[selectionWarp])
+          .Sort(candidateKeys, FinalCandidateKeyGreater{});
+
+#pragma unroll
+      for (int item = 0; item < kCandidatesPerThread; ++item) {
+        const int rank = selectionLane * kCandidatesPerThread + item;
+        if (rank < numFinalSelections) {
+          smemWarpTopCandidateKeys[selectionWarp * numFinalSelections + rank] =
+              candidateKeys[item];
+        }
+      }
+      __syncthreads();
+
+      // Merge the per-warp top keys with warp 0.  No item ranked below R within
+      // its own warp can enter the block-wide top R.
+      if (selectionWarp == 0) {
+        const int numWarpCandidates = kNumWarps * numFinalSelections;
+        uint64_t warpCandidateKeys[kWarpCandidatesPerLane];
+#pragma unroll
+        for (int item = 0; item < kWarpCandidatesPerLane; ++item) {
+          const int position = selectionLane * kWarpCandidatesPerLane + item;
+          warpCandidateKeys[item] =
+              position < numWarpCandidates ? smemWarpTopCandidateKeys[position] : 0;
+        }
+
+        CandidateGlobalSort(smemFinal.candidateGlobalSort)
+            .Sort(warpCandidateKeys, FinalCandidateKeyGreater{});
+
+#pragma unroll
+        for (int item = 0; item < kWarpCandidatesPerLane; ++item) {
+          const int rank = selectionLane * kWarpCandidatesPerLane + item;
+          if (rank < numFinalSelections) {
+            smemOutput[baseIdx + rank] = static_cast<int>(
+                warpCandidateKeys[item] & kFinalCandidateSourceMask);
+          }
+        }
+      }
+    }
+  }
+
+  // ---- v2.1 warp-only fused asc-by-index sort -----------------------------
+  // After final-candidate selection fills smemOutput[0..topk-1] (unsorted by index),
+  // only warp 0 (32 lanes) participates in the sort.  Other 480 threads idle.
+  //
+  // Why warp-only vs cub::BlockRadixSort<512, 1>:
+  //   - cub::BlockRadixSort<uint32_t, 512, 1>.Sort() processes ALL 512 thread
+  //     positions even though only ≤64 are real (rest are sentinel ~0u).
+  //     Per nsys, that variant cost ~13 us per kernel call.
+  //   - WarpBitonicSortAsc{32,64} only sorts the 32/64 real slots.  Estimated
+  //     cost: < 1 us per kernel.  Savings: ~12 us per call = ~50% of the
+  //     v2.0 IndexerTopKWithSortKernel runtime on n1024_K8192.
+  __syncthreads();  // ensure all threads' writes to smemOutput are visible
+  if (threadIdx.x == 0) {
+    SparseTopKLaunchDependentGrids(use_pdl);
+  }
+
+  const uint32_t warp_id = threadIdx.x >> 5;
+  const uint32_t lane = threadIdx.x & 31;
+  if (warp_id != 0) return;  // only warp 0 sorts and writes the output
+
+  int32_t* row_out = out + row_offset_out;
+
+  if constexpr (MAX_TOPK <= 32) {
+    // 32 lanes × 1 key.  Lanes >= topk pad with sentinel ~0u (sorts to end).
+    // v2.5_oob_clamp_in_kernel: also fold OOB clamp here — indices >=
+    // num_valid_pages get rewritten to ~0u, so they sort to the tail and the
+    // existing `(key == ~0u) ? -1` write contract converts them to -1.
+    uint32_t key = ~0u;
+    if (lane < topK) {
+      const int32_t idx = smemOutput[lane];
+      const bool valid = (idx >= 0) && (static_cast<uint32_t>(idx) < row_num_valid_pages);
+      key = valid ? static_cast<uint32_t>(idx) : ~0u;
+    }
+    WarpBitonicSortAsc32(key, lane);
+    if (lane < topK) {
+      const int32_t logical_idx = (key == ~0u) ? -1 : static_cast<int32_t>(key);
+      row_out[static_cast<size_t>(lane) * out_stride_k] =
+          GatherBlockTableValue(block_table_row, block_table_stride_k, logical_idx);
+    }
+  } else {
+    // MAX_TOPK == 64: 32 lanes × 2 keys, BLOCKED layout (lane L holds 2L, 2L+1).
+    uint32_t keys[2];
+#pragma unroll
+    for (int s = 0; s < 2; ++s) {
+      const int pos = static_cast<int>(lane) * 2 + s;
+      if (pos < topK) {
+        const int32_t idx = smemOutput[pos];
+        const bool valid = (idx >= 0) && (static_cast<uint32_t>(idx) < row_num_valid_pages);
+        keys[s] = valid ? static_cast<uint32_t>(idx) : ~0u;
+      } else {
+        keys[s] = ~0u;
+      }
+    }
+    WarpBitonicSortAsc64(keys, lane);
+#pragma unroll
+    for (int s = 0; s < 2; ++s) {
+      const int pos = static_cast<int>(lane) * 2 + s;
+      if (pos < topK) {
+        const uint32_t k = keys[s];
+        const int32_t logical_idx = (k == ~0u) ? -1 : static_cast<int32_t>(k);
+        row_out[static_cast<size_t>(pos) * out_stride_k] =
+            GatherBlockTableValue(block_table_row, block_table_stride_k, logical_idx);
+      }
+    }
+  }
+}
+
+// =============================================================================
+// Host-side dispatcher
+// =============================================================================
+
+inline cudaError_t ConfigureSparseTopKSelect() {
+  static bool s_attr_set = false;
+  if (s_attr_set) return cudaSuccess;
+  auto kernel = IndexerTopKWithSortKernel<16>;
+  constexpr size_t dyn_smem_bytes = 16 * sizeof(int32_t);
+  cudaError_t err = cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                         static_cast<int>(dyn_smem_bytes));
+  if (err != cudaSuccess) return err;
+  s_attr_set = true;
+  return cudaSuccess;
+}
+
+inline cudaError_t LaunchSparseTopKKernel(const void* kernel, dim3 grid, dim3 block,
+                                          void** args, size_t dyn_smem_bytes,
+                                          cudaStream_t stream, bool enable_pdl) {
+  if (!enable_pdl) {
+    return cudaLaunchKernel(kernel, grid, block, args, dyn_smem_bytes, stream);
+  }
+
+#if ((__CUDACC_VER_MAJOR__ >= 12) || \
+     ((__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ >= 8)))
+  cudaLaunchAttribute attrs[1];
+  attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attrs[0].val.programmaticStreamSerializationAllowed = 1;
+
+  cudaLaunchConfig_t config = {};
+  config.gridDim = grid;
+  config.blockDim = block;
+  config.dynamicSmemBytes = dyn_smem_bytes;
+  config.stream = stream;
+  config.attrs = attrs;
+  config.numAttrs = 1;
+  return cudaLaunchKernelExC(&config, kernel, args);
+#else
+  return cudaLaunchKernel(kernel, grid, block, args, dyn_smem_bytes, stream);
+#endif
+}
+
+cudaError_t LaunchIndexerTopK(const float* in_row_contig, int32_t* out,
+                              const int32_t* block_table,
+                              uint64_t out_stride_t, uint64_t out_stride_h,
+                              uint64_t out_stride_k,
+                              uint64_t block_table_stride_t,
+                              uint64_t block_table_stride_h,
+                              uint64_t block_table_stride_k,
+                              uint32_t total_qo_len, uint32_t num_qo_heads,
+                              uint32_t max_k_tiles, uint32_t topk,
+                              uint32_t num_valid_pages,
+                              const int32_t* num_valid_pages_per_token,
+                              uint32_t force_begin, uint32_t force_end,
+                              bool input_qo_outermost,
+                              cudaStream_t stream, bool enable_pdl) {
+  const uint32_t num_rows = total_qo_len * num_qo_heads;
+  if (num_rows == 0) return cudaSuccess;
+
+  auto kernel = IndexerTopKWithSortKernel<16>;
+  const size_t dyn_smem_bytes = static_cast<size_t>(topk) * sizeof(int32_t);
+  const uint32_t input_qo_outermost_u32 = input_qo_outermost ? 1u : 0u;
+  const uint32_t use_pdl = enable_pdl ? 1u : 0u;
+  void* args[] = {(void*)&in_row_contig, (void*)&out, (void*)&block_table,
+                  (void*)&out_stride_t, (void*)&out_stride_h, (void*)&out_stride_k,
+                  (void*)&block_table_stride_t, (void*)&block_table_stride_h,
+                  (void*)&block_table_stride_k,
+                  (void*)&total_qo_len,
+                  (void*)&num_qo_heads, (void*)&max_k_tiles, (void*)&topk,
+                  (void*)&num_valid_pages, (void*)&num_valid_pages_per_token,
+                  (void*)&force_begin, (void*)&force_end, (void*)&input_qo_outermost_u32,
+                  (void*)&use_pdl};
+  dim3 grid(num_rows);
+  dim3 block(kIndexerNumThreadsPerBlock);
+  return LaunchSparseTopKKernel((const void*)kernel, grid, block, args, dyn_smem_bytes,
+                                stream, enable_pdl);
+}
+
+cudaError_t LaunchTransposeAndIndexerTopK(const float* in_strided, float* transposed, int32_t* out,
+                                          const int32_t* block_table,
+                                          uint64_t out_stride_t, uint64_t out_stride_h,
+                                          uint64_t out_stride_k,
+                                          uint64_t block_table_stride_t,
+                                          uint64_t block_table_stride_h,
+                                          uint64_t block_table_stride_k,
+                                          uint32_t total_qo_len, uint32_t num_qo_heads,
+                                          uint32_t max_k_tiles, uint32_t topk,
+                                          uint32_t num_valid_pages,
+                                          const int32_t* num_valid_pages_per_token,
+                                          uint32_t force_begin, uint32_t force_end,
+                                          cudaStream_t stream, bool enable_pdl) {
+  const uint32_t num_rows = total_qo_len * num_qo_heads;
+  if (num_rows == 0) return cudaSuccess;
+  const uint32_t use_pdl = enable_pdl ? 1u : 0u;
+
+  // ---- (1) Transpose: dispatch to TransposeXorF4<32> fast path when
+  //          preconditions are met (qo & K both divisible by 32 and 4),
+  //          otherwise fall back to the original padded-tile transpose.
+  {
+    constexpr int kXorTile = 32;
+    const bool xor_path_ok = (total_qo_len % kXorTile == 0) &&
+                             (max_k_tiles % kXorTile == 0) &&
+                             (total_qo_len % 4 == 0) &&
+                             (max_k_tiles % 4 == 0);
+    if (xor_path_ok) {
+      dim3 grid(total_qo_len / kXorTile, max_k_tiles / kXorTile, num_qo_heads);
+      dim3 block(kXorTile * kXorTile / 4);  // = 256 threads
+      void* tr_args[] = {
+          (void*)&in_strided, (void*)&transposed, (void*)&max_k_tiles, (void*)&total_qo_len,
+          (void*)&use_pdl};
+      cudaError_t err = LaunchSparseTopKKernel(
+          (const void*)SparseTopKTransposeXorF4Kernel<kXorTile>, grid, block, tr_args, 0,
+          stream, enable_pdl);
+      if (err != cudaSuccess) return err;
+    } else {
+      dim3 grid((total_qo_len + kTransposeTile - 1) / kTransposeTile,
+                (max_k_tiles + kTransposeTile - 1) / kTransposeTile, num_qo_heads);
+      dim3 block(kTransposeTile, kTransposeBlockRows);
+      void* tr_args[] = {
+          (void*)&in_strided, (void*)&transposed, (void*)&max_k_tiles, (void*)&total_qo_len,
+          (void*)&use_pdl};
+      cudaError_t err = LaunchSparseTopKKernel((const void*)SparseTopKTransposeKernel, grid,
+                                               block, tr_args, 0, stream, enable_pdl);
+      if (err != cudaSuccess) return err;
+    }
+  }
+
+  // ---- (2) IndexerTopK + fused sort + write to qo_outermost layout -------
+  return LaunchIndexerTopK(transposed, out, block_table,
+                           out_stride_t, out_stride_h, out_stride_k,
+                           block_table_stride_t, block_table_stride_h, block_table_stride_k,
+                           total_qo_len, num_qo_heads, max_k_tiles, topk,
+                           num_valid_pages, num_valid_pages_per_token,
+                           force_begin, force_end,
+                           /*input_qo_outermost=*/false, stream, enable_pdl);
+}
+
+// =============================================================================
+// Workspace size — transpose_buf only: (num_qo_heads, max_k_tiles, total_qo_len) fp32.
+// =============================================================================
+inline size_t SparseTopKWorkspaceSize(uint32_t total_qo_len, uint32_t num_qo_heads,
+                                      uint32_t max_k_tiles, SparseTopKInputLayout input_layout) {
+  if (input_layout == SparseTopKInputLayout::kTHK) return 0;
+  return static_cast<size_t>(num_qo_heads) * max_k_tiles * total_qo_len;
+}
+
+// =============================================================================
+// Top-level dispatcher
+// =============================================================================
+//   in        : (num_qo_heads, max_k_tiles, total_qo_len) contiguous fp32 for kHKT,
+//               or (total_qo_len, num_qo_heads, max_k_tiles) contiguous fp32 for kTHK
+//   out       : (total_qo_len, num_qo_heads, topk=16) int32. Without block_table,
+//               values are logical k_tile indices asc by k_tile index. With
+//               block_table, logical indices are sorted first, then gathered
+//               from block_table[t][h][idx].
+//   workspace : int32, at least SparseTopKWorkspaceSize(...) elements
+//   num_valid_pages : indices >= num_valid_pages are emitted as -1 (sorted to
+//                     tail).  Pass max_k_tiles (or any value >= max_k_tiles)
+//                     to disable clamping.
+//
+//   * max_k_tiles <= 16      → SparseTopKIdentityFillKernel (trivial)
+//   * 16 < max_k_tiles < 12288 and kHKT → Transpose + IndexerTopKWithSortKernel<16>
+//   * 16 < max_k_tiles < 12288 and kTHK → IndexerTopKWithSortKernel<16> directly
+//   * max_k_tiles >= 12288   → cudaErrorNotSupported
+inline cudaError_t SparseTopKSelect(const float* in, int32_t* out, int32_t* workspace,
+                                    const int32_t* block_table,
+                                    uint64_t out_stride_t, uint64_t out_stride_h,
+                                    uint64_t out_stride_k,
+                                    uint64_t block_table_stride_t,
+                                    uint64_t block_table_stride_h,
+                                    uint64_t block_table_stride_k,
+                                    uint32_t total_qo_len, uint32_t num_qo_heads,
+                                    uint32_t max_k_tiles, uint32_t num_valid_pages,
+                                    const int32_t* num_valid_pages_per_token,
+                                    SparseTopKInputLayout input_layout,
+                                    uint32_t force_begin, uint32_t force_end,
+                                    cudaStream_t stream, bool enable_pdl = true) {
+  constexpr uint32_t topk = 16;
+  const uint32_t num_rows = total_qo_len * num_qo_heads;
+  if (num_rows == 0) return cudaSuccess;
+  const uint32_t use_pdl = enable_pdl ? 1u : 0u;
+
+  // ---- Trivial path: max_k_tiles <= topk → identity fill -----------------
+  if (max_k_tiles <= topk) {
+    dim3 grid(num_rows);
+    dim3 block(topk);
+    void* args[] = {(void*)&out, (void*)&block_table,
+                    (void*)&out_stride_t, (void*)&out_stride_h, (void*)&out_stride_k,
+                    (void*)&block_table_stride_t, (void*)&block_table_stride_h,
+                    (void*)&block_table_stride_k,
+                    (void*)&total_qo_len, (void*)&num_qo_heads,
+                    (void*)&max_k_tiles, (void*)&topk, (void*)&num_valid_pages,
+                    (void*)&num_valid_pages_per_token, (void*)&use_pdl};
+    return LaunchSparseTopKKernel((const void*)SparseTopKIdentityFillKernel, grid, block,
+                                  args, 0, stream, enable_pdl);
+  }
+
+  // ---- IndexerTopK insertion-sort path ------------------------------------
+  if (max_k_tiles >= 12288) return cudaErrorNotSupported;
+
+  if (input_layout == SparseTopKInputLayout::kTHK) {
+    return LaunchIndexerTopK(in, out, block_table,
+                             out_stride_t, out_stride_h, out_stride_k,
+                             block_table_stride_t, block_table_stride_h,
+                             block_table_stride_k,
+                             total_qo_len, num_qo_heads, max_k_tiles, topk,
+                             num_valid_pages, num_valid_pages_per_token,
+                             force_begin, force_end,
+                             /*input_qo_outermost=*/true, stream, enable_pdl);
+  }
+
+  float* transpose_buf = reinterpret_cast<float*>(workspace);
+  return LaunchTransposeAndIndexerTopK(in, transpose_buf, out, block_table,
+                                       out_stride_t, out_stride_h, out_stride_k,
+                                       block_table_stride_t, block_table_stride_h,
+                                       block_table_stride_k,
+                                       total_qo_len, num_qo_heads,
+                                       max_k_tiles, topk, num_valid_pages,
+                                       num_valid_pages_per_token,
+                                       force_begin, force_end, stream, enable_pdl);
+}
+
+}  // namespace sparse_topk
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_SPARSE_TOPK_SELECT_CUH_

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/utils.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/utils.cuh
@@ -1,0 +1,523 @@
+/*
+ * Copyright (c) 2023 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_UTILS_CUH_
+#define FLASHINFER_UTILS_CUH_
+#include <cuda_bf16.h>
+#include <cuda_device_runtime_api.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+#include <atomic>
+#include <cstdint>
+#include <iostream>
+#include <type_traits>
+#include <vector>
+
+#include "exception.h"
+
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
+// macro to turn off fp16 qk reduction to reduce binary
+#ifndef FLASHINFER_ALWAYS_DISUSE_FP16_QK_REDUCTION
+#define FLASHINFER_ALWAYS_DISUSE_FP16_QK_REDUCTION 0
+#endif
+
+#ifndef NDEBUG
+#define FLASHINFER_CUDA_CALL(func, ...)                                                     \
+  {                                                                                         \
+    cudaError_t e = (func);                                                                 \
+    if (e != cudaSuccess) {                                                                 \
+      std::cerr << "CUDA Error: " << cudaGetErrorString(e) << " (" << e << ") " << __FILE__ \
+                << ": line " << __LINE__ << " at function " << STR(func) << std::endl;      \
+      return e;                                                                             \
+    }                                                                                       \
+  }
+#else
+#define FLASHINFER_CUDA_CALL(func, ...) \
+  {                                     \
+    cudaError_t e = (func);             \
+    if (e != cudaSuccess) {             \
+      return e;                         \
+    }                                   \
+  }
+#endif
+
+#define FLASHINFER_CUDA_CHECK(func)                                                         \
+  do {                                                                                      \
+    cudaError_t e = (func);                                                                 \
+    FLASHINFER_CHECK(e == cudaSuccess, "CUDA Error: ", cudaGetErrorString(e), " (", int(e), \
+                     ") at ", __FILE__, ":", __LINE__, " in ", STR(func));                  \
+  } while (0)
+
+#define FLASHINFER_CHECK_ALIGNMENT(ptr, size_bytes)                            \
+  FLASHINFER_CHECK(reinterpret_cast<uintptr_t>(ptr) % (size_bytes) == 0, #ptr, \
+                   " must be aligned to ", (size_bytes), " bytes, got address ", (uintptr_t)(ptr))
+
+#define FLASHINFER_CHECK_TMA_ALIGNED(ptr) FLASHINFER_CHECK_ALIGNMENT(ptr, 128)
+
+#define DISPATCH_USE_FP16_QK_REDUCTION(use_fp16_qk_reduction, USE_FP16_QK_REDUCTION, ...) \
+  if (use_fp16_qk_reduction) {                                                            \
+    FLASHINFER_ERROR("FP16_QK_REDUCTION disabled at compile time");                       \
+  } else {                                                                                \
+    constexpr bool USE_FP16_QK_REDUCTION = false;                                         \
+    __VA_ARGS__                                                                           \
+  }
+
+#define DISPATCH_NUM_MMA_Q(num_mma_q, NUM_MMA_Q, ...)  \
+  if (num_mma_q == 1) {                                \
+    constexpr size_t NUM_MMA_Q = 1;                    \
+    __VA_ARGS__                                        \
+  } else if (num_mma_q == 2) {                         \
+    constexpr size_t NUM_MMA_Q = 2;                    \
+    __VA_ARGS__                                        \
+  } else {                                             \
+    std::ostringstream err_msg;                        \
+    err_msg << "Unsupported num_mma_q: " << num_mma_q; \
+    FLASHINFER_ERROR(err_msg.str());                   \
+  }
+
+#define DISPATCH_NUM_MMA_KV(max_mma_kv, NUM_MMA_KV, ...) \
+  if (max_mma_kv >= 8) {                                 \
+    constexpr size_t NUM_MMA_KV = 8;                     \
+    __VA_ARGS__                                          \
+  } else if (max_mma_kv >= 4) {                          \
+    constexpr size_t NUM_MMA_KV = 4;                     \
+    __VA_ARGS__                                          \
+  } else if (max_mma_kv >= 2) {                          \
+    constexpr size_t NUM_MMA_KV = 2;                     \
+    __VA_ARGS__                                          \
+  } else if (max_mma_kv >= 1) {                          \
+    constexpr size_t NUM_MMA_KV = 1;                     \
+    __VA_ARGS__                                          \
+  } else {                                               \
+    std::ostringstream err_msg;                          \
+    err_msg << "Unsupported max_mma_kv: " << max_mma_kv; \
+    FLASHINFER_ERROR(err_msg.str());                     \
+  }
+
+#define DISPATCH_CTA_TILE_Q(cta_tile_q, CTA_TILE_Q, ...)   \
+  switch (cta_tile_q) {                                    \
+    case 128: {                                            \
+      constexpr uint32_t CTA_TILE_Q = 128;                 \
+      __VA_ARGS__                                          \
+      break;                                               \
+    }                                                      \
+    case 64: {                                             \
+      constexpr uint32_t CTA_TILE_Q = 64;                  \
+      __VA_ARGS__                                          \
+      break;                                               \
+    }                                                      \
+    case 16: {                                             \
+      constexpr uint32_t CTA_TILE_Q = 16;                  \
+      __VA_ARGS__                                          \
+      break;                                               \
+    }                                                      \
+    default: {                                             \
+      std::ostringstream err_msg;                          \
+      err_msg << "Unsupported cta_tile_q: " << cta_tile_q; \
+      FLASHINFER_ERROR(err_msg.str());                     \
+    }                                                      \
+  }
+
+#define DISPATCH_GQA_GROUP_SIZE(group_size, GROUP_SIZE, ...) \
+  if (group_size == 1) {                                     \
+    constexpr size_t GROUP_SIZE = 1;                         \
+    __VA_ARGS__                                              \
+  } else if (group_size == 2) {                              \
+    constexpr size_t GROUP_SIZE = 2;                         \
+    __VA_ARGS__                                              \
+  } else if (group_size == 3) {                              \
+    constexpr size_t GROUP_SIZE = 3;                         \
+    __VA_ARGS__                                              \
+  } else if (group_size == 4) {                              \
+    constexpr size_t GROUP_SIZE = 4;                         \
+    __VA_ARGS__                                              \
+  } else if (group_size == 8) {                              \
+    constexpr size_t GROUP_SIZE = 8;                         \
+    __VA_ARGS__                                              \
+  } else {                                                   \
+    std::ostringstream err_msg;                              \
+    err_msg << "Unsupported group_size: " << group_size;     \
+    FLASHINFER_ERROR(err_msg.str());                         \
+  }
+
+#define DISPATCH_MASK_MODE(mask_mode, MASK_MODE, ...)             \
+  switch (mask_mode) {                                            \
+    case MaskMode::kNone: {                                       \
+      constexpr MaskMode MASK_MODE = MaskMode::kNone;             \
+      __VA_ARGS__                                                 \
+      break;                                                      \
+    }                                                             \
+    case MaskMode::kCausal: {                                     \
+      constexpr MaskMode MASK_MODE = MaskMode::kCausal;           \
+      __VA_ARGS__                                                 \
+      break;                                                      \
+    }                                                             \
+    case MaskMode::kCustom: {                                     \
+      constexpr MaskMode MASK_MODE = MaskMode::kCustom;           \
+      __VA_ARGS__                                                 \
+      break;                                                      \
+    }                                                             \
+    case MaskMode::kMultiItemScoring: {                           \
+      constexpr MaskMode MASK_MODE = MaskMode::kMultiItemScoring; \
+      __VA_ARGS__                                                 \
+      break;                                                      \
+    }                                                             \
+    default: {                                                    \
+      std::ostringstream err_msg;                                 \
+      err_msg << "Unsupported mask_mode: " << int(mask_mode);     \
+      FLASHINFER_ERROR(err_msg.str());                            \
+    }                                                             \
+  }
+
+// convert head_dim to compile-time constant
+#define DISPATCH_HEAD_DIM(head_dim, HEAD_DIM, ...)     \
+  switch (head_dim) {                                  \
+    case 64: {                                         \
+      constexpr size_t HEAD_DIM = 64;                  \
+      __VA_ARGS__                                      \
+      break;                                           \
+    }                                                  \
+    case 128: {                                        \
+      constexpr size_t HEAD_DIM = 128;                 \
+      __VA_ARGS__                                      \
+      break;                                           \
+    }                                                  \
+    case 256: {                                        \
+      constexpr size_t HEAD_DIM = 256;                 \
+      __VA_ARGS__                                      \
+      break;                                           \
+    }                                                  \
+    case 512: {                                        \
+      constexpr size_t HEAD_DIM = 512;                 \
+      __VA_ARGS__                                      \
+      break;                                           \
+    }                                                  \
+    default: {                                         \
+      std::ostringstream err_msg;                      \
+      err_msg << "Unsupported head_dim: " << head_dim; \
+      FLASHINFER_ERROR(err_msg.str());                 \
+    }                                                  \
+  }
+
+// convert interleave to compile-time constant
+#define DISPATCH_INTERLEAVE(interleave, INTERLEAVE, ...) \
+  if (interleave) {                                      \
+    constexpr bool INTERLEAVE = true;                    \
+    __VA_ARGS__                                          \
+  } else {                                               \
+    constexpr bool INTERLEAVE = false;                   \
+    __VA_ARGS__                                          \
+  }
+
+#define DISPATCH_ROPE_DIM(rope_dim, ROPE_DIM, ...)           \
+  switch (rope_dim) {                                        \
+    case 16: {                                               \
+      constexpr uint32_t ROPE_DIM = 16;                      \
+      __VA_ARGS__                                            \
+      break;                                                 \
+    }                                                        \
+    case 32: {                                               \
+      constexpr uint32_t ROPE_DIM = 32;                      \
+      __VA_ARGS__                                            \
+      break;                                                 \
+    }                                                        \
+    case 64: {                                               \
+      constexpr uint32_t ROPE_DIM = 64;                      \
+      __VA_ARGS__                                            \
+      break;                                                 \
+    }                                                        \
+    case 128: {                                              \
+      constexpr uint32_t ROPE_DIM = 128;                     \
+      __VA_ARGS__                                            \
+      break;                                                 \
+    }                                                        \
+    case 256: {                                              \
+      constexpr uint32_t ROPE_DIM = 256;                     \
+      __VA_ARGS__                                            \
+      break;                                                 \
+    }                                                        \
+    default: {                                               \
+      std::ostringstream err_msg;                            \
+      err_msg << "Unsupported ROPE_DIM: " << rope_dim;       \
+      err_msg << ". Supported values: 16, 32, 64, 128, 256"; \
+      err_msg << " in DISPATCH_ROPE_DIM";                    \
+      FLASHINFER_ERROR(err_msg.str());                       \
+    }                                                        \
+  }
+
+#define DISPATCH_POS_ENCODING_MODE(pos_encoding_mode, POS_ENCODING_MODE, ...)    \
+  switch (pos_encoding_mode) {                                                   \
+    case PosEncodingMode::kNone: {                                               \
+      constexpr PosEncodingMode POS_ENCODING_MODE = PosEncodingMode::kNone;      \
+      __VA_ARGS__                                                                \
+      break;                                                                     \
+    }                                                                            \
+    case PosEncodingMode::kRoPELlama: {                                          \
+      constexpr PosEncodingMode POS_ENCODING_MODE = PosEncodingMode::kRoPELlama; \
+      __VA_ARGS__                                                                \
+      break;                                                                     \
+    }                                                                            \
+    case PosEncodingMode::kALiBi: {                                              \
+      constexpr PosEncodingMode POS_ENCODING_MODE = PosEncodingMode::kALiBi;     \
+      __VA_ARGS__                                                                \
+      break;                                                                     \
+    }                                                                            \
+    default: {                                                                   \
+      std::ostringstream err_msg;                                                \
+      err_msg << "Unsupported pos_encoding_mode: " << int(pos_encoding_mode);    \
+      FLASHINFER_ERROR(err_msg.str());                                           \
+    }                                                                            \
+  }
+
+#define DISPATCH_ALIGNED_VEC_SIZE(aligned_vec_size, ALIGNED_VEC_SIZE, ...) \
+  switch (aligned_vec_size) {                                              \
+    case 16: {                                                             \
+      constexpr size_t ALIGNED_VEC_SIZE = 16;                              \
+      __VA_ARGS__                                                          \
+      break;                                                               \
+    }                                                                      \
+    case 8: {                                                              \
+      constexpr size_t ALIGNED_VEC_SIZE = 8;                               \
+      __VA_ARGS__                                                          \
+      break;                                                               \
+    }                                                                      \
+    case 4: {                                                              \
+      constexpr size_t ALIGNED_VEC_SIZE = 4;                               \
+      __VA_ARGS__                                                          \
+      break;                                                               \
+    }                                                                      \
+    case 2: {                                                              \
+      constexpr size_t ALIGNED_VEC_SIZE = 2;                               \
+      __VA_ARGS__                                                          \
+      break;                                                               \
+    }                                                                      \
+    case 1: {                                                              \
+      constexpr size_t ALIGNED_VEC_SIZE = 1;                               \
+      __VA_ARGS__                                                          \
+      break;                                                               \
+    }                                                                      \
+    default: {                                                             \
+      std::ostringstream err_msg;                                          \
+      err_msg << "Unsupported aligned_vec_size: " << aligned_vec_size;     \
+      FLASHINFER_ERROR(err_msg.str());                                     \
+    }                                                                      \
+  }
+
+#define DISPATCH_COMPUTE_CAP_DECODE_NUM_STAGES_SMEM(compute_capacity, NUM_STAGES_SMEM, ...) \
+  if (compute_capacity.first >= 8) {                                                        \
+    constexpr uint32_t NUM_STAGES_SMEM = 2;                                                 \
+    __VA_ARGS__                                                                             \
+  } else {                                                                                  \
+    constexpr uint32_t NUM_STAGES_SMEM = 1;                                                 \
+    __VA_ARGS__                                                                             \
+  }
+
+namespace flashinfer {
+
+template <typename T1, typename T2>
+__forceinline__ __device__ __host__ constexpr T1 ceil_div(const T1 x, const T2 y) noexcept {
+  return (x + y - 1) / y;
+}
+
+template <typename T1, typename T2>
+__forceinline__ __device__ __host__ constexpr T1 round_up(const T1 x, const T2 y) noexcept {
+  return ceil_div(x, y) * y;
+}
+
+template <typename T1, typename T2>
+__forceinline__ __device__ __host__ constexpr T1 round_down(const T1 x, const T2 y) noexcept {
+  return (x / y) * y;
+}
+
+inline std::pair<int, int> GetCudaComputeCapability() {
+  int device_id = 0;
+  cudaGetDevice(&device_id);
+  int major = 0, minor = 0;
+  cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device_id);
+  cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device_id);
+  return std::make_pair(major, minor);
+}
+
+// This function is thread-safe and cached the sm_count.
+// But it will only check the current CUDA device, thus assuming each process handles single GPU.
+inline int GetCudaMultiProcessorCount() {
+  static std::atomic<int> sm_count{0};
+  int cached = sm_count.load(std::memory_order_relaxed);
+  if (cached == 0) {
+    int device_id;
+    cudaGetDevice(&device_id);
+    cudaDeviceProp device_prop;
+    cudaGetDeviceProperties(&device_prop, device_id);
+    cached = device_prop.multiProcessorCount;
+    sm_count.store(cached, std::memory_order_relaxed);
+  }
+  return cached;
+}
+
+template <typename T>
+inline void DebugPrintCUDAArray(T* device_ptr, size_t size, std::string prefix = "") {
+  std::vector<T> host_array(size);
+  std::cout << prefix;
+  cudaMemcpy(host_array.data(), device_ptr, size * sizeof(T), cudaMemcpyDeviceToHost);
+  for (size_t i = 0; i < size; ++i) {
+    std::cout << host_array[i] << " ";
+  }
+  std::cout << std::endl;
+}
+
+inline uint32_t FA2DetermineCtaTileQ(int64_t avg_packed_qo_len, uint32_t head_dim) {
+  if (avg_packed_qo_len > 64 && head_dim < 256) {
+    return 128;
+  } else {
+    auto compute_capacity = GetCudaComputeCapability();
+    if (compute_capacity.first >= 8) {
+      // Ampere or newer
+      if (avg_packed_qo_len > 16) {
+        // avg_packed_qo_len <= 64
+        return 64;
+      } else {
+        // avg_packed_qo_len <= 16
+        return 16;
+      }
+    } else {
+      // NOTE(Zihao): not enough shared memory on Turing for 1x4 warp layout
+      return 64;
+    }
+  }
+}
+
+inline int UpPowerOfTwo(int x) {
+  // Returns the smallest power of two greater than or equal to x
+  if (x <= 0) return 1;
+  --x;
+  x |= x >> 1;
+  x |= x >> 2;
+  x |= x >> 4;
+  x |= x >> 8;
+  x |= x >> 16;
+  return x + 1;
+}
+
+#define LOOP_SPLIT_MASK(iter, COND1, COND2, ...)       \
+  {                                                    \
+    _Pragma("unroll 1") for (; (COND1); (iter) -= 1) { \
+      constexpr bool WITH_MASK = true;                 \
+      __VA_ARGS__                                      \
+    }                                                  \
+    _Pragma("unroll 1") for (; (COND2); (iter) -= 1) { \
+      constexpr bool WITH_MASK = false;                \
+      __VA_ARGS__                                      \
+    }                                                  \
+  }
+
+/*!
+ * \brief Return x - y if x > y, otherwise return 0.
+ */
+__device__ __forceinline__ uint32_t sub_if_greater_or_zero(uint32_t x, uint32_t y) {
+  return (x > y) ? x - y : 0U;
+}
+
+// ======================= PTX Memory Utility Functions =======================
+// Non-atomic global memory access with cache streaming hint (cs)
+// These are useful for streaming memory access patterns where data is used once
+
+/*!
+ * \brief Get the lane ID within a warp (0-31)
+ */
+__forceinline__ __device__ int get_lane_id() {
+  int lane_id;
+  asm("mov.u32 %0, %%laneid;" : "=r"(lane_id));
+  return lane_id;
+}
+
+/*!
+ * \brief Non-atomic global load for int (4 bytes) with cache streaming hint
+ */
+__forceinline__ __device__ int ld_na_global_v1(const int* addr) {
+  int val;
+  asm volatile("ld.global.cs.b32 %0, [%1];" : "=r"(val) : "l"(addr));
+  return val;
+}
+
+/*!
+ * \brief Non-atomic global load for int2 (8 bytes) with cache streaming hint
+ */
+__forceinline__ __device__ int2 ld_na_global_v2(const int2* addr) {
+  int2 val;
+  asm volatile("ld.global.cs.v2.b32 {%0, %1}, [%2];" : "=r"(val.x), "=r"(val.y) : "l"(addr));
+  return val;
+}
+
+/*!
+ * \brief Non-atomic global store for int (4 bytes) with cache streaming hint
+ */
+__forceinline__ __device__ void st_na_global_v1(int* addr, int val) {
+  asm volatile("st.global.cs.b32 [%0], %1;" ::"l"(addr), "r"(val));
+}
+
+/*!
+ * \brief Non-atomic global store for int2 (8 bytes) with cache streaming hint
+ */
+__forceinline__ __device__ void st_na_global_v2(int2* addr, int2 val) {
+  asm volatile("st.global.cs.v2.b32 [%0], {%1, %2};" ::"l"(addr), "r"(val.x), "r"(val.y));
+}
+
+/*!
+ * \brief Prefetch data to L2 cache
+ */
+template <typename T>
+__forceinline__ __device__ void prefetch_L2(const T* addr) {
+  asm volatile("prefetch.global.L2 [%0];" ::"l"(addr));
+}
+
+__device__ __forceinline__ void swap(uint32_t& a, uint32_t& b) {
+  uint32_t tmp = a;
+  a = b;
+  b = tmp;
+}
+
+__device__ __forceinline__ uint32_t dim2_offset(const uint32_t& dim_a, const uint32_t& idx_b,
+                                                const uint32_t& idx_a) {
+  return idx_b * dim_a + idx_a;
+}
+
+__device__ __forceinline__ uint32_t dim3_offset(const uint32_t& dim_b, const uint32_t& dim_a,
+                                                const uint32_t& idx_c, const uint32_t& idx_b,
+                                                const uint32_t& idx_a) {
+  return (idx_c * dim_b + idx_b) * dim_a + idx_a;
+}
+
+__device__ __forceinline__ uint32_t dim4_offset(const uint32_t& dim_c, const uint32_t& dim_b,
+                                                const uint32_t& dim_a, const uint32_t& idx_d,
+                                                const uint32_t& idx_c, const uint32_t& idx_b,
+                                                const uint32_t& idx_a) {
+  return ((idx_d * dim_c + idx_c) * dim_b + idx_b) * dim_a + idx_a;
+}
+
+#define DEFINE_HAS_MEMBER(member)                                                              \
+  template <typename T, typename = void>                                                       \
+  struct has_##member : std::false_type {};                                                    \
+  template <typename T>                                                                        \
+  struct has_##member<T, std::void_t<decltype(std::declval<T>().member)>> : std::true_type {}; \
+  template <typename T>                                                                        \
+  inline constexpr bool has_##member##_v = has_##member<T>::value;
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_UTILS_CUH_

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/vec_dtypes.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/include/vec_dtypes.cuh
@@ -1,0 +1,2063 @@
+/*
+ * Copyright (c) 2023 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef VEC_DTYPES_CUH_
+#define VEC_DTYPES_CUH_
+
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#if CUDA_VERSION >= 12080
+#include <cuda_fp4.h>
+#endif
+#include <cuda_runtime.h>
+
+#include <type_traits>
+
+namespace flashinfer {
+
+#if (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 900))
+#define FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+#endif
+
+#define FLASHINFER_INLINE inline __attribute__((always_inline)) __device__
+
+__device__ __forceinline__ void st_global_release(int4 const& val, int4* addr) {
+  asm volatile("st.release.global.sys.v4.b32 [%4], {%0, %1, %2, %3};" ::"r"(val.x), "r"(val.y),
+               "r"(val.z), "r"(val.w), "l"(addr));
+}
+
+__device__ __forceinline__ int4 ld_global_acquire(int4* addr) {
+  int4 val;
+  asm volatile("ld.acquire.global.sys.v4.b32 {%0, %1, %2, %3}, [%4];"
+               : "=r"(val.x), "=r"(val.y), "=r"(val.z), "=r"(val.w)
+               : "l"(addr));
+  return val;
+}
+
+__device__ __forceinline__ void st_global_volatile(int4 const& val, int4* addr) {
+  asm volatile("st.volatile.global.v4.b32 [%4], {%0, %1, %2, %3};" ::"r"(val.x), "r"(val.y),
+               "r"(val.z), "r"(val.w), "l"(addr));
+}
+
+__device__ __forceinline__ int4 ld_global_volatile(int4* addr) {
+  int4 val;
+  asm volatile("ld.volatile.global.v4.b32 {%0, %1, %2, %3}, [%4];"
+               : "=r"(val.x), "=r"(val.y), "=r"(val.z), "=r"(val.w)
+               : "l"(addr));
+  return val;
+}
+
+#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 < 120200) && \
+    (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))
+// CUDA version < 12.2 and GPU architecture < 80
+FLASHINFER_INLINE __nv_bfloat162 make_bfloat162(const __nv_bfloat16 x, const __nv_bfloat16 y) {
+  __nv_bfloat162 t;
+  t.x = x;
+  t.y = y;
+  return t;
+}
+
+FLASHINFER_INLINE __nv_bfloat16 __hmul(const __nv_bfloat16 a, const __nv_bfloat16 b) {
+  __nv_bfloat16 val;
+  const float fa = __bfloat162float(a);
+  const float fb = __bfloat162float(b);
+  // avoid ftz in device code
+  val = __float2bfloat16(__fmaf_ieee_rn(fa, fb, -0.0f));
+  return val;
+}
+
+FLASHINFER_INLINE __nv_bfloat162 __hmul2(const __nv_bfloat162 a, const __nv_bfloat162 b) {
+  __nv_bfloat162 val;
+  val.x = __hmul(a.x, b.x);
+  val.y = __hmul(a.y, b.y);
+  return val;
+}
+
+FLASHINFER_INLINE __nv_bfloat162 __floats2bfloat162_rn(const float a, const float b) {
+  __nv_bfloat162 val;
+  val = __nv_bfloat162(__float2bfloat16_rn(a), __float2bfloat16_rn(b));
+  return val;
+}
+
+FLASHINFER_INLINE __nv_bfloat162 __float22bfloat162_rn(const float2 a) {
+  __nv_bfloat162 val = __floats2bfloat162_rn(a.x, a.y);
+  return val;
+}
+FLASHINFER_INLINE float2 __bfloat1622float2(const __nv_bfloat162 a) {
+  float hi_float;
+  float lo_float;
+  lo_float = __internal_bfloat162float(((__nv_bfloat162_raw)a).x);
+  hi_float = __internal_bfloat162float(((__nv_bfloat162_raw)a).y);
+  return make_float2(lo_float, hi_float);
+}
+#endif
+
+/******************* vec_t type cast *******************/
+
+template <typename dst_t, typename src_t>
+struct vec_cast {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(dst_t* dst, const src_t* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size; ++i) {
+      dst[i] = (dst_t)src[i];
+    }
+  }
+};
+
+template <>
+struct vec_cast<__nv_fp8_e4m3, float> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(__nv_fp8_e4m3* dst, const float* src) {
+    if constexpr (vec_size == 1) {
+      dst[0] = __nv_fp8_e4m3(src[0]);
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        ((__nv_fp8x2_storage_t*)dst)[i] =
+            __nv_cvt_float2_to_fp8x2(((float2*)src)[i], __NV_SATFINITE, __NV_E4M3);
+      }
+    }
+  }
+};
+
+template <>
+struct vec_cast<__nv_fp8_e5m2, float> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(__nv_fp8_e5m2* dst, const float* src) {
+    if constexpr (vec_size == 1) {
+      dst[0] = __nv_fp8_e5m2(src[0]);
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        ((__nv_fp8x2_storage_t*)dst)[i] =
+            __nv_cvt_float2_to_fp8x2(((float2*)src)[i], __NV_SATFINITE, __NV_E5M2);
+      }
+    }
+  }
+};
+
+template <>
+struct vec_cast<float, half> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(float* dst, const half* src) {
+    if constexpr (vec_size == 1) {
+      dst[0] = (float)src[0];
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        ((float2*)dst)[i] = __half22float2(((half2*)src)[i]);
+      }
+    }
+  }
+};
+
+template <>
+struct vec_cast<half, float> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(half* dst, const float* src) {
+    if constexpr (vec_size == 1) {
+      dst[0] = __float2half(src[0]);
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        ((half2*)dst)[i] = __float22half2_rn(((float2*)src)[i]);
+      }
+    }
+  }
+};
+
+template <typename T>
+constexpr FLASHINFER_INLINE int get_exponent_bits() {
+  if constexpr (std::is_same_v<T, __nv_fp8_e4m3>) {
+    return 4;
+  } else if constexpr (std::is_same_v<T, __nv_fp8_e5m2>) {
+    return 5;
+  } else if constexpr (std::is_same_v<T, half>) {
+    return 5;
+  } else if constexpr (std::is_same_v<T, nv_bfloat16>) {
+    return 8;
+  }
+}
+
+template <typename T>
+constexpr FLASHINFER_INLINE int get_mantissa_bits() {
+  if constexpr (std::is_same_v<T, __nv_fp8_e4m3>) {
+    return 3;
+  } else if constexpr (std::is_same_v<T, __nv_fp8_e5m2>) {
+    return 2;
+  } else if constexpr (std::is_same_v<T, half>) {
+    return 11;
+  } else if constexpr (std::is_same_v<T, nv_bfloat16>) {
+    return 7;
+  }
+}
+
+/*!
+ * \brief Fallback to software fast dequant implementation if hardware dequantization is not
+ * available.
+ * \note Inspired by Marlin's fast dequantization, but here we don't have to permute
+ * weights order.
+ * \ref
+ * https://github.com/vllm-project/vllm/blob/6dffa4b0a6120159ef2fe44d695a46817aff65bc/csrc/quantization/fp8/fp8_marlin.cu#L120
+ */
+template <typename fp8_dtype, typename fp16_dtype>
+__device__ void fast_dequant_f8f16x4(uint32_t* input, uint2* output) {
+  uint32_t q = *input;
+  if constexpr (std::is_same_v<fp8_dtype, __nv_fp8_e5m2> && std::is_same_v<fp16_dtype, half>) {
+    output->x = __byte_perm(0U, q, 0x5140);
+    output->y = __byte_perm(0U, q, 0x7362);
+  } else {
+    constexpr int FP8_EXPONENT = get_exponent_bits<fp8_dtype>();
+    constexpr int FP8_MANTISSA = get_mantissa_bits<fp8_dtype>();
+    constexpr int FP16_EXPONENT = get_exponent_bits<fp16_dtype>();
+
+    constexpr int RIGHT_SHIFT = FP16_EXPONENT - FP8_EXPONENT;
+    // Calculate MASK for extracting mantissa and exponent
+    constexpr int MASK1 = 0x80000000;
+    constexpr int MASK2 = MASK1 >> (FP8_EXPONENT + FP8_MANTISSA);
+    constexpr int MASK3 = MASK2 & 0x7fffffff;
+    constexpr int MASK = MASK3 | (MASK3 >> 16);
+    q = __byte_perm(q, q, 0x1302);
+
+    // Extract and shift FP8 values to FP16 format
+    uint32_t Out1 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+    uint32_t Out2 = ((q << 8) & 0x80008000) | (((q << 8) & MASK) >> RIGHT_SHIFT);
+
+    constexpr int BIAS_OFFSET = (1 << (FP16_EXPONENT - 1)) - (1 << (FP8_EXPONENT - 1));
+    // Construct and apply exponent bias
+    if constexpr (std::is_same_v<fp16_dtype, half>) {
+      const half2 bias_reg = __float2half2_rn(float(1 << BIAS_OFFSET));
+
+      // Convert to half2 and apply bias
+      *(half2*)&(output->x) = __hmul2(*reinterpret_cast<const half2*>(&Out1), bias_reg);
+      *(half2*)&(output->y) = __hmul2(*reinterpret_cast<const half2*>(&Out2), bias_reg);
+    } else {
+      constexpr uint32_t BIAS = (BIAS_OFFSET + 127) << 23;
+      const nv_bfloat162 bias_reg = __float2bfloat162_rn(*reinterpret_cast<const float*>(&BIAS));
+      // Convert to bfloat162 and apply bias
+      *(nv_bfloat162*)&(output->x) =
+          __hmul2(*reinterpret_cast<const nv_bfloat162*>(&Out1), bias_reg);
+      *(nv_bfloat162*)&(output->y) =
+          __hmul2(*reinterpret_cast<const nv_bfloat162*>(&Out2), bias_reg);
+    }
+  }
+}
+
+template <>
+struct vec_cast<nv_bfloat16, __nv_fp8_e4m3> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(nv_bfloat16* dst, const __nv_fp8_e4m3* src) {
+    if constexpr (vec_size == 1) {
+      dst[0] = nv_bfloat16(src[0]);
+    } else if constexpr (vec_size == 2) {
+      dst[0] = nv_bfloat16(src[0]);
+      dst[1] = nv_bfloat16(src[1]);
+    } else {
+      static_assert(vec_size % 4 == 0, "vec_size must be a multiple of 4");
+#pragma unroll
+      for (uint32_t i = 0; i < vec_size / 4; ++i) {
+        fast_dequant_f8f16x4<__nv_fp8_e4m3, nv_bfloat16>((uint32_t*)&src[i * 4],
+                                                         (uint2*)&dst[i * 4]);
+      }
+    }
+  }
+};
+
+template <>
+struct vec_cast<nv_bfloat16, __nv_fp8_e5m2> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(nv_bfloat16* dst, const __nv_fp8_e5m2* src) {
+    if constexpr (vec_size == 1) {
+      dst[0] = nv_bfloat16(src[0]);
+    } else if constexpr (vec_size == 2) {
+      dst[0] = nv_bfloat16(src[0]);
+      dst[1] = nv_bfloat16(src[1]);
+    } else {
+      static_assert(vec_size % 4 == 0, "vec_size must be a multiple of 4");
+#pragma unroll
+      for (uint32_t i = 0; i < vec_size / 4; ++i) {
+        fast_dequant_f8f16x4<__nv_fp8_e5m2, nv_bfloat16>((uint32_t*)&src[i * 4],
+                                                         (uint2*)&dst[i * 4]);
+      }
+    }
+  }
+};
+
+template <>
+struct vec_cast<__nv_fp8_e4m3, half> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(__nv_fp8_e4m3* dst, const half* src) {
+#ifdef FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+    if constexpr (vec_size == 1) {
+      dst[0] = __nv_fp8_e4m3(src[0]);
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        uint16_t y;
+        uint32_t x = *(uint32_t*)&src[i * 2];
+        asm volatile("cvt.rn.satfinite.e4m3x2.f16x2 %0, %1;" : "=h"(y) : "r"(x));
+        *(uint16_t*)&dst[i * 2] = y;
+      }
+    }
+#else
+#pragma unroll
+    for (size_t i = 0; i < vec_size; ++i) {
+      dst[i] = __nv_fp8_e4m3(src[i]);
+    }
+#endif  // FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+  }
+};
+
+template <>
+struct vec_cast<__nv_fp8_e5m2, half> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(__nv_fp8_e5m2* dst, const half* src) {
+#ifdef FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+    if constexpr (vec_size == 1) {
+      dst[0] = __nv_fp8_e5m2(src[0]);
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        uint16_t y;
+        uint32_t x = *(uint32_t*)&src[i * 2];
+        asm volatile("cvt.rn.satfinite.e5m2x2.f16x2 %0, %1;" : "=h"(y) : "r"(x));
+        *(uint16_t*)&dst[i * 2] = y;
+      }
+    }
+#else
+#pragma unroll
+    for (size_t i = 0; i < vec_size; ++i) {
+      dst[i] = __nv_fp8_e5m2(src[i]);
+    }
+#endif  // FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+  }
+};
+
+template <>
+struct vec_cast<half, __nv_fp8_e4m3> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(half* dst, const __nv_fp8_e4m3* src) {
+#ifdef FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+    if constexpr (vec_size == 1) {
+      dst[0] = half(src[0]);
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        uint32_t y;
+        uint16_t x = *(uint16_t*)&src[i * 2];
+        asm volatile("cvt.rn.f16x2.e4m3x2 %0, %1;" : "=r"(y) : "h"(x));
+        *(uint32_t*)&dst[i * 2] = y;
+      }
+    }
+#else
+    if constexpr (vec_size == 1) {
+      dst[0] = half(src[0]);
+    } else if constexpr (vec_size == 2) {
+      dst[0] = half(src[0]);
+      dst[1] = half(src[1]);
+    } else {
+      static_assert(vec_size % 4 == 0, "vec_size must be a multiple of 4");
+#pragma unroll
+      for (uint32_t i = 0; i < vec_size / 4; ++i) {
+        fast_dequant_f8f16x4<__nv_fp8_e4m3, half>((uint32_t*)&src[i * 4], (uint2*)&dst[i * 4]);
+      }
+    }
+#endif  // FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+  }
+};
+
+template <>
+struct vec_cast<half, __nv_fp8_e5m2> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(half* dst, const __nv_fp8_e5m2* src) {
+#ifdef FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+    if constexpr (vec_size == 1) {
+      dst[0] = half(src[0]);
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        uint32_t y;
+        uint16_t x = *(uint16_t*)&src[i * 2];
+        asm volatile("cvt.rn.f16x2.e5m2x2 %0, %1;" : "=r"(y) : "h"(x));
+        *(uint32_t*)&dst[i * 2] = y;
+      }
+    }
+#else
+    if constexpr (vec_size == 1) {
+      dst[0] = half(src[0]);
+    } else if constexpr (vec_size == 2) {
+      dst[0] = half(src[0]);
+      dst[1] = half(src[1]);
+    } else {
+      static_assert(vec_size % 4 == 0, "vec_size must be a multiple of 4");
+#pragma unroll
+      for (uint32_t i = 0; i < vec_size / 4; ++i) {
+        fast_dequant_f8f16x4<__nv_fp8_e5m2, half>((uint32_t*)&src[i * 4], (uint2*)&dst[i * 4]);
+      }
+    }
+#endif  // FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
+  }
+};
+
+template <>
+struct vec_cast<float, nv_bfloat16> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(float* dst, const nv_bfloat16* src) {
+    if constexpr (vec_size == 1) {
+      dst[0] = (float)src[0];
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        ((float2*)dst)[i] = __bfloat1622float2(((nv_bfloat162*)src)[i]);
+      }
+    }
+  }
+};
+
+template <>
+struct vec_cast<nv_bfloat16, float> {
+  template <size_t vec_size>
+  FLASHINFER_INLINE static void cast(nv_bfloat16* dst, const float* src) {
+    if constexpr (vec_size == 1) {
+      dst[0] = nv_bfloat16(src[0]);
+    } else {
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 2; ++i) {
+        ((nv_bfloat162*)dst)[i] = __float22bfloat162_rn(((float2*)src)[i]);
+      }
+    }
+  }
+};
+
+template <typename float_t, size_t vec_size>
+struct vec_t {
+  FLASHINFER_INLINE float_t& operator[](size_t i);
+  FLASHINFER_INLINE const float_t& operator[](size_t i) const;
+  FLASHINFER_INLINE void fill(float_t val);
+  FLASHINFER_INLINE void load(const float_t* ptr);
+  FLASHINFER_INLINE void store(float_t* ptr) const;
+  FLASHINFER_INLINE void load_global_acquire(float* addr);
+  FLASHINFER_INLINE void store_global_release(float* addr) const;
+  FLASHINFER_INLINE void load_global_volatile(float* addr);
+  FLASHINFER_INLINE void store_global_volatile(float* addr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src);
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr);
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const;
+  FLASHINFER_INLINE static void memcpy(float_t* dst, const float_t* src);
+  FLASHINFER_INLINE float_t* ptr();
+};
+
+template <typename src_float_t, typename tgt_float_t, size_t vec_size>
+FLASHINFER_INLINE void cast_from_impl(vec_t<tgt_float_t, vec_size>& dst,
+                                      const vec_t<src_float_t, vec_size>& src) {
+  vec_cast<tgt_float_t, src_float_t>::cast<vec_size>(
+      dst.ptr(), const_cast<vec_t<src_float_t, vec_size>*>(&src)->ptr());
+}
+
+template <typename src_float_t, typename tgt_float_t, size_t vec_size>
+FLASHINFER_INLINE void cast_load_impl(vec_t<tgt_float_t, vec_size>& dst,
+                                      const src_float_t* src_ptr) {
+  if constexpr (std::is_same_v<src_float_t, tgt_float_t>) {
+    dst.load(src_ptr);
+  } else {
+    vec_t<src_float_t, vec_size> tmp;
+    tmp.load(src_ptr);
+    dst.cast_from(tmp);
+  }
+}
+
+template <typename src_float_t, typename tgt_float_t, size_t vec_size>
+FLASHINFER_INLINE void cast_store_impl(tgt_float_t* dst_ptr,
+                                       const vec_t<src_float_t, vec_size>& src) {
+  if constexpr (std::is_same_v<src_float_t, tgt_float_t>) {
+    src.store(dst_ptr);
+  } else {
+    vec_t<tgt_float_t, vec_size> tmp;
+    tmp.cast_from(src);
+    tmp.store(dst_ptr);
+  }
+}
+
+/******************* vec_t<__nv_fp8_e4m3> *******************/
+
+// __nv_fp8_e4m3 x 1
+template <>
+struct vec_t<__nv_fp8_e4m3, 1> {
+  __nv_fp8_e4m3 data;
+
+  FLASHINFER_INLINE __nv_fp8_e4m3& operator[](size_t i) { return ((__nv_fp8_e4m3*)(&data))[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e4m3& operator[](size_t i) const {
+    return ((const __nv_fp8_e4m3*)(&data))[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e4m3* ptr() { return reinterpret_cast<__nv_fp8_e4m3*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e4m3 val);
+  FLASHINFER_INLINE void load(const __nv_fp8_e4m3* ptr);
+  FLASHINFER_INLINE void store(__nv_fp8_e4m3* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 1>::fill(__nv_fp8_e4m3 val) { data = val; }
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 1>::load(const __nv_fp8_e4m3* ptr) { data = *ptr; }
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 1>::store(__nv_fp8_e4m3* ptr) const { *ptr = data; }
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 1>::memcpy(__nv_fp8_e4m3* dst,
+                                                       const __nv_fp8_e4m3* src) {
+  *dst = *src;
+}
+
+// __nv_fp8_e4m3 x 2
+template <>
+struct vec_t<__nv_fp8_e4m3, 2> {
+  __nv_fp8x2_e4m3 data;
+
+  FLASHINFER_INLINE __nv_fp8_e4m3& operator[](size_t i) { return ((__nv_fp8_e4m3*)(&data))[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e4m3& operator[](size_t i) const {
+    return ((const __nv_fp8_e4m3*)(&data))[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e4m3* ptr() { return reinterpret_cast<__nv_fp8_e4m3*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e4m3 val);
+  FLASHINFER_INLINE void load(const __nv_fp8_e4m3* ptr);
+  FLASHINFER_INLINE void store(__nv_fp8_e4m3* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 2>::fill(__nv_fp8_e4m3 val) {
+  data.__x = (__nv_fp8x2_storage_t(val.__x) << 8) | __nv_fp8x2_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 2>::load(const __nv_fp8_e4m3* ptr) {
+  data = *((__nv_fp8x2_e4m3*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 2>::store(__nv_fp8_e4m3* ptr) const {
+  *((__nv_fp8x2_e4m3*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 2>::memcpy(__nv_fp8_e4m3* dst,
+                                                       const __nv_fp8_e4m3* src) {
+  *((__nv_fp8x2_e4m3*)dst) = *((__nv_fp8x2_e4m3*)src);
+}
+
+// __nv_fp8_e4m3 x 4
+
+template <>
+struct vec_t<__nv_fp8_e4m3, 4> {
+  __nv_fp8x4_e4m3 data;
+
+  FLASHINFER_INLINE __nv_fp8_e4m3& operator[](size_t i) { return ((__nv_fp8_e4m3*)(&data))[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e4m3& operator[](size_t i) const {
+    return ((const __nv_fp8_e4m3*)(&data))[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e4m3* ptr() { return reinterpret_cast<__nv_fp8_e4m3*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e4m3 val);
+  FLASHINFER_INLINE void load(const __nv_fp8_e4m3* ptr);
+  FLASHINFER_INLINE void store(__nv_fp8_e4m3* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 4>::fill(__nv_fp8_e4m3 val) {
+  data.__x = (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+             (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 4>::load(const __nv_fp8_e4m3* ptr) {
+  data = *((__nv_fp8x4_e4m3*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 4>::store(__nv_fp8_e4m3* ptr) const {
+  *((__nv_fp8x4_e4m3*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 4>::memcpy(__nv_fp8_e4m3* dst,
+                                                       const __nv_fp8_e4m3* src) {
+  *((__nv_fp8x4_e4m3*)dst) = *((__nv_fp8x4_e4m3*)src);
+}
+
+// __nv_fp8_e4m3 x 8
+
+template <>
+struct vec_t<__nv_fp8_e4m3, 8> {
+  uint2 data;
+
+  FLASHINFER_INLINE __nv_fp8_e4m3& operator[](size_t i) { return ((__nv_fp8_e4m3*)(&data))[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e4m3& operator[](size_t i) const {
+    return ((const __nv_fp8_e4m3*)(&data))[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e4m3* ptr() { return reinterpret_cast<__nv_fp8_e4m3*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e4m3 val);
+  FLASHINFER_INLINE void load(const __nv_fp8_e4m3* ptr);
+  FLASHINFER_INLINE void store(__nv_fp8_e4m3* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 8>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 8>::fill(__nv_fp8_e4m3 val) {
+  ((__nv_fp8x4_e4m3*)(&data.x))->__x =
+      (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+      (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+  ((__nv_fp8x4_e4m3*)(&data.y))->__x =
+      (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+      (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 8>::load(const __nv_fp8_e4m3* ptr) {
+  data = *((uint2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 8>::store(__nv_fp8_e4m3* ptr) const {
+  *((uint2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e4m3, 8>::memcpy(__nv_fp8_e4m3* dst,
+                                                       const __nv_fp8_e4m3* src) {
+  *((uint2*)dst) = *((uint2*)src);
+}
+
+// __nv_fp8_e4m3 x 16 or more
+template <size_t vec_size>
+struct vec_t<__nv_fp8_e4m3, vec_size> {
+  static_assert(vec_size % 16 == 0, "Invalid vector size");
+  int4 data[vec_size / 16];
+
+  FLASHINFER_INLINE __nv_fp8_e4m3& operator[](size_t i) { return ((__nv_fp8_e4m3*)data)[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e4m3& operator[](size_t i) const {
+    return ((const __nv_fp8_e4m3*)data)[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e4m3* ptr() { return reinterpret_cast<__nv_fp8_e4m3*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e4m3 val) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((__nv_fp8x4_e4m3*)(&(data[i].x)))->__x =
+          (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+          (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+      ((__nv_fp8x4_e4m3*)(&(data[i].y)))->__x =
+          (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+          (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+      ((__nv_fp8x4_e4m3*)(&(data[i].z)))->__x =
+          (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+          (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+      ((__nv_fp8x4_e4m3*)(&(data[i].w)))->__x =
+          (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+          (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+    }
+  }
+  FLASHINFER_INLINE void load(const __nv_fp8_e4m3* ptr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ((int4*)ptr)[i];
+    }
+  }
+  FLASHINFER_INLINE void store(__nv_fp8_e4m3* ptr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((int4*)ptr)[i] = data[i];
+    }
+  }
+  FLASHINFER_INLINE void load_global_acquire(__nv_fp8_e4m3* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      *((int4*)(data + i)) = ld_global_acquire((int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void store_global_release(__nv_fp8_e4m3* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      st_global_release(data[i], (int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void load_global_volatile(__nv_fp8_e4m3* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ld_global_volatile((int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void store_global_volatile(__nv_fp8_e4m3* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      st_global_volatile(data[i], (int4*)(addr + i * 16));
+    }
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e4m3* dst, const __nv_fp8_e4m3* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((int4*)dst)[i] = ((int4*)src)[i];
+    }
+  }
+};
+
+/******************* vec_t<__nv_fp8_e5m2> *******************/
+
+// __nv_fp8_e5m2 x 1
+template <>
+struct vec_t<__nv_fp8_e5m2, 1> {
+  __nv_fp8_e5m2 data;
+
+  FLASHINFER_INLINE __nv_fp8_e5m2& operator[](size_t i) { return ((__nv_fp8_e5m2*)(&data))[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e5m2& operator[](size_t i) const {
+    return ((const __nv_fp8_e5m2*)(&data))[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e5m2* ptr() { return reinterpret_cast<__nv_fp8_e5m2*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e5m2 val);
+  FLASHINFER_INLINE void load(const __nv_fp8_e5m2* ptr);
+  FLASHINFER_INLINE void store(__nv_fp8_e5m2* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 1>::fill(__nv_fp8_e5m2 val) { data = val; }
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 1>::load(const __nv_fp8_e5m2* ptr) { data = *ptr; }
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 1>::store(__nv_fp8_e5m2* ptr) const { *ptr = data; }
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 1>::memcpy(__nv_fp8_e5m2* dst,
+                                                       const __nv_fp8_e5m2* src) {
+  *dst = *src;
+}
+
+// __nv_fp8_e5m2 x 2
+template <>
+struct vec_t<__nv_fp8_e5m2, 2> {
+  __nv_fp8x2_e5m2 data;
+
+  FLASHINFER_INLINE __nv_fp8_e5m2& operator[](size_t i) { return ((__nv_fp8_e5m2*)(&data))[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e5m2& operator[](size_t i) const {
+    return ((const __nv_fp8_e5m2*)(&data))[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e5m2* ptr() { return reinterpret_cast<__nv_fp8_e5m2*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e5m2 val);
+  FLASHINFER_INLINE void load(const __nv_fp8_e5m2* ptr);
+  FLASHINFER_INLINE void store(__nv_fp8_e5m2* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 2>::fill(__nv_fp8_e5m2 val) {
+  data.__x = (__nv_fp8x2_storage_t(val.__x) << 8) | __nv_fp8x2_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 2>::load(const __nv_fp8_e5m2* ptr) {
+  data = *((__nv_fp8x2_e5m2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 2>::store(__nv_fp8_e5m2* ptr) const {
+  *((__nv_fp8x2_e5m2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 2>::memcpy(__nv_fp8_e5m2* dst,
+                                                       const __nv_fp8_e5m2* src) {
+  *((__nv_fp8x2_e5m2*)dst) = *((__nv_fp8x2_e5m2*)src);
+}
+
+// __nv_fp8_e5m2 x 4
+
+template <>
+struct vec_t<__nv_fp8_e5m2, 4> {
+  __nv_fp8x4_e5m2 data;
+
+  FLASHINFER_INLINE __nv_fp8_e5m2& operator[](size_t i) { return ((__nv_fp8_e5m2*)(&data))[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e5m2& operator[](size_t i) const {
+    return ((const __nv_fp8_e5m2*)(&data))[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e5m2* ptr() { return reinterpret_cast<__nv_fp8_e5m2*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e5m2 val);
+  FLASHINFER_INLINE void load(const __nv_fp8_e5m2* ptr);
+  FLASHINFER_INLINE void store(__nv_fp8_e5m2* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 4>::fill(__nv_fp8_e5m2 val) {
+  data.__x = (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+             (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 4>::load(const __nv_fp8_e5m2* ptr) {
+  data = *((__nv_fp8x4_e5m2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 4>::store(__nv_fp8_e5m2* ptr) const {
+  *((__nv_fp8x4_e5m2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 4>::memcpy(__nv_fp8_e5m2* dst,
+                                                       const __nv_fp8_e5m2* src) {
+  *((__nv_fp8x4_e5m2*)dst) = *((__nv_fp8x4_e5m2*)src);
+}
+
+// __nv_fp8_e5m2 x 8
+
+template <>
+struct vec_t<__nv_fp8_e5m2, 8> {
+  uint2 data;
+
+  FLASHINFER_INLINE __nv_fp8_e5m2& operator[](size_t i) { return ((__nv_fp8_e5m2*)(&data))[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e5m2& operator[](size_t i) const {
+    return ((const __nv_fp8_e5m2*)(&data))[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e5m2* ptr() { return reinterpret_cast<__nv_fp8_e5m2*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e5m2 val);
+  FLASHINFER_INLINE void load(const __nv_fp8_e5m2* ptr);
+  FLASHINFER_INLINE void store(__nv_fp8_e5m2* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 8>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src);
+};
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 8>::fill(__nv_fp8_e5m2 val) {
+  ((__nv_fp8x4_e5m2*)(&data.x))->__x =
+      (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+      (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+  ((__nv_fp8x4_e5m2*)(&data.y))->__x =
+      (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+      (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 8>::load(const __nv_fp8_e5m2* ptr) {
+  data = *((uint2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 8>::store(__nv_fp8_e5m2* ptr) const {
+  *((uint2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<__nv_fp8_e5m2, 8>::memcpy(__nv_fp8_e5m2* dst,
+                                                       const __nv_fp8_e5m2* src) {
+  *((uint2*)dst) = *((uint2*)src);
+}
+
+// __nv_fp8_e5m2 x 16 or more
+
+template <size_t vec_size>
+struct vec_t<__nv_fp8_e5m2, vec_size> {
+  static_assert(vec_size % 16 == 0, "Invalid vector size");
+  int4 data[vec_size / 16];
+
+  FLASHINFER_INLINE __nv_fp8_e5m2& operator[](size_t i) { return ((__nv_fp8_e5m2*)data)[i]; }
+  FLASHINFER_INLINE const __nv_fp8_e5m2& operator[](size_t i) const {
+    return ((const __nv_fp8_e5m2*)data)[i];
+  }
+  FLASHINFER_INLINE __nv_fp8_e5m2* ptr() { return reinterpret_cast<__nv_fp8_e5m2*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp8_e5m2 val) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((__nv_fp8x4_e5m2*)(&(data[i].x)))->__x =
+          (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+          (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+      ((__nv_fp8x4_e5m2*)(&(data[i].y)))->__x =
+          (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+          (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+      ((__nv_fp8x4_e5m2*)(&(data[i].z)))->__x =
+          (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+          (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+      ((__nv_fp8x4_e5m2*)(&(data[i].w)))->__x =
+          (__nv_fp8x4_storage_t(val.__x) << 24) | (__nv_fp8x4_storage_t(val.__x) << 16) |
+          (__nv_fp8x4_storage_t(val.__x) << 8) | __nv_fp8x4_storage_t(val.__x);
+    }
+  }
+  FLASHINFER_INLINE void load(const __nv_fp8_e5m2* ptr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ((int4*)ptr)[i];
+    }
+  }
+  FLASHINFER_INLINE void store(__nv_fp8_e5m2* ptr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((int4*)ptr)[i] = data[i];
+    }
+  }
+  FLASHINFER_INLINE void store_global_release(__nv_fp8_e5m2* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      st_global_release(data[i], (int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void load_global_acquire(__nv_fp8_e5m2* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ld_global_acquire((int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void store_global_volatile(__nv_fp8_e5m2* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      st_global_volatile(data[i], (int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void load_global_volatile(__nv_fp8_e5m2* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ld_global_volatile((int4*)(addr + i * 16));
+    }
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(__nv_fp8_e5m2* dst, const __nv_fp8_e5m2* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((int4*)dst)[i] = ((int4*)src)[i];
+    }
+  }
+};
+
+#if defined(FLASHINFER_ENABLE_FP4_E2M1) && CUDA_VERSION >= 12080
+/******************* vec_t<__nv_fp4_e2m1> *******************/
+
+// __nv_fp4_e2m1 x 2
+template <>
+struct vec_t<__nv_fp4_e2m1, 2> {
+  uint8_t data;
+  // index access is not supported for sub-byte data type
+  FLASHINFER_INLINE __nv_fp4_e2m1* ptr() { return reinterpret_cast<__nv_fp4_e2m1*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp4_e2m1 val) {
+    data = (__nv_fp4x2_storage_t(val.__x) << 4) | __nv_fp4x2_storage_t(val.__x);
+  }
+  FLASHINFER_INLINE void load(const __nv_fp4_e2m1* ptr) { data = *((uint8_t*)ptr); }
+  FLASHINFER_INLINE void store(__nv_fp4_e2m1* ptr) const { *((uint8_t*)ptr) = data; }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(__nv_fp4_e2m1* dst, const __nv_fp4_e2m1* src) {
+    *((uint8_t*)dst) = *((uint8_t*)src);
+  }
+};
+
+// __nv_fp4_e2m1 x 4
+template <>
+struct vec_t<__nv_fp4_e2m1, 4> {
+  uint16_t data;
+
+  FLASHINFER_INLINE __nv_fp4_e2m1* ptr() { return reinterpret_cast<__nv_fp4_e2m1*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp4_e2m1 val) {
+    __nv_fp4x2_storage_t val8 =
+        (__nv_fp4x2_storage_t(val.__x) << 4) | __nv_fp4x2_storage_t(val.__x);
+    data = (uint16_t(val8) << 8) | uint16_t(val8);
+  }
+  FLASHINFER_INLINE void load(const __nv_fp4_e2m1* ptr) { data = *((uint16_t*)ptr); }
+  FLASHINFER_INLINE void store(__nv_fp4_e2m1* ptr) const { *((uint16_t*)ptr) = data; }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(__nv_fp4_e2m1* dst, const __nv_fp4_e2m1* src) {
+    *((uint16_t*)dst) = *((uint16_t*)src);
+  }
+};
+
+// __nv_fp4_e2m1 x 8
+template <>
+struct vec_t<__nv_fp4_e2m1, 8> {
+  uint32_t data;
+
+  FLASHINFER_INLINE __nv_fp4_e2m1* ptr() { return reinterpret_cast<__nv_fp4_e2m1*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp4_e2m1 val) {
+    __nv_fp4x2_storage_t val8 =
+        (__nv_fp4x2_storage_t(val.__x) << 4) | __nv_fp4x2_storage_t(val.__x);
+    uint16_t val16 = (uint16_t(val8) << 8) | uint16_t(val8);
+    data = (uint32_t(val16) << 16) | uint32_t(val16);
+  }
+  FLASHINFER_INLINE void load(const __nv_fp4_e2m1* ptr) { data = *((uint32_t*)ptr); }
+  FLASHINFER_INLINE void store(__nv_fp4_e2m1* ptr) const { *((uint32_t*)ptr) = data; }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 8>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(__nv_fp4_e2m1* dst, const __nv_fp4_e2m1* src) {
+    *((uint32_t*)dst) = *((uint32_t*)src);
+  }
+};
+
+template <>
+struct vec_t<__nv_fp4_e2m1, 16> {
+  uint2 data;
+  FLASHINFER_INLINE __nv_fp4_e2m1* ptr() { return reinterpret_cast<__nv_fp4_e2m1*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp4_e2m1 val) {
+    __nv_fp4x2_storage_t val8 =
+        (__nv_fp4x2_storage_t(val.__x) << 4) | __nv_fp4x2_storage_t(val.__x);
+    uint16_t val16 = (uint16_t(val8) << 8) | uint16_t(val8);
+    uint32_t val32 = (uint32_t(val16) << 16) | uint32_t(val16);
+    data.x = val32;
+    data.y = val32;
+  }
+  FLASHINFER_INLINE void load(const __nv_fp4_e2m1* ptr) { data = *((uint2*)ptr); }
+  FLASHINFER_INLINE void store(__nv_fp4_e2m1* ptr) const { *((uint2*)ptr) = data; }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 16>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(__nv_fp4_e2m1* dst, const __nv_fp4_e2m1* src) {
+    *((uint2*)dst) = *((uint2*)src);
+  }
+};
+
+// __nv_fp4_e2m1 x 32 or more
+template <size_t vec_size>
+struct vec_t<__nv_fp4_e2m1, vec_size> {
+  static_assert(vec_size % 32 == 0, "Invalid vector size");
+  int4 data[vec_size / 32];
+
+  FLASHINFER_INLINE __nv_fp4_e2m1* ptr() { return reinterpret_cast<__nv_fp4_e2m1*>(&data); }
+  FLASHINFER_INLINE void fill(__nv_fp4_e2m1 val) {
+    __nv_fp4x2_storage_t val8 =
+        (__nv_fp4x2_storage_t(val.__x) << 4) | __nv_fp4x2_storage_t(val.__x);
+    uint16_t val16 = (uint16_t(val8) << 8) | uint16_t(val8);
+    uint32_t val32 = (uint32_t(val16) << 16) | uint32_t(val16);
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 32; ++i) {
+      data[i].x = val32;
+      data[i].y = val32;
+      data[i].z = val32;
+      data[i].w = val32;
+    }
+  }
+  FLASHINFER_INLINE void load(const __nv_fp4_e2m1* ptr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 32; ++i) {
+      data[i] = ((int4*)ptr)[i];
+    }
+  }
+  FLASHINFER_INLINE void store(__nv_fp4_e2m1* ptr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 32; ++i) {
+      ((int4*)ptr)[i] = data[i];
+    }
+  }
+  FLASHINFER_INLINE void store_global_release(__nv_fp4_e2m1* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 32; ++i) {
+      st_global_release(*(int4*)&data[i], (int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void load_global_acquire(__nv_fp4_e2m1* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 32; ++i) {
+      *(int4*)&data[i] = ld_global_acquire((int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void store_global_volatile(__nv_fp4_e2m1* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 32; ++i) {
+      st_global_volatile(*(int4*)&data[i], (int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void load_global_volatile(__nv_fp4_e2m1* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 32; ++i) {
+      *(int4*)&data[i] = ld_global_volatile((int4*)(addr + i * 16));
+    }
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(__nv_fp4_e2m1* dst, const __nv_fp4_e2m1* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 32; ++i) {
+      ((int4*)dst)[i] = ((int4*)src)[i];
+    }
+  }
+};
+
+#endif  // FLASHINFER_ENABLE_FP4_E2M1 && CUDA_VERSION >= 12080
+
+/******************* vec_t<half> *******************/
+
+// half x 1
+template <>
+struct vec_t<half, 1> {
+  half data;
+
+  FLASHINFER_INLINE half& operator[](size_t i) { return ((half*)(&data))[i]; }
+  FLASHINFER_INLINE const half& operator[](size_t i) const { return ((const half*)(&data))[i]; }
+  FLASHINFER_INLINE half* ptr() { return reinterpret_cast<half*>(&data); }
+  FLASHINFER_INLINE void fill(half val);
+  FLASHINFER_INLINE void load(const half* ptr);
+  FLASHINFER_INLINE void store(half* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(half* dst, const half* src);
+};
+
+FLASHINFER_INLINE void vec_t<half, 1>::fill(half val) { data = val; }
+
+FLASHINFER_INLINE void vec_t<half, 1>::load(const half* ptr) { data = *ptr; }
+
+FLASHINFER_INLINE void vec_t<half, 1>::store(half* ptr) const { *ptr = data; }
+
+FLASHINFER_INLINE void vec_t<half, 1>::memcpy(half* dst, const half* src) { *dst = *src; }
+
+// half x 2
+template <>
+struct vec_t<half, 2> {
+  half2 data;
+
+  FLASHINFER_INLINE half& operator[](size_t i) { return ((half*)(&data))[i]; }
+  FLASHINFER_INLINE const half& operator[](size_t i) const { return ((const half*)(&data))[i]; }
+  FLASHINFER_INLINE half* ptr() { return reinterpret_cast<half*>(&data); }
+  FLASHINFER_INLINE void fill(half val);
+  FLASHINFER_INLINE void load(const half* ptr);
+  FLASHINFER_INLINE void store(half* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(half* dst, const half* src);
+};
+
+FLASHINFER_INLINE void vec_t<half, 2>::fill(half val) { data = make_half2(val, val); }
+
+FLASHINFER_INLINE void vec_t<half, 2>::load(const half* ptr) { data = *((half2*)ptr); }
+
+FLASHINFER_INLINE void vec_t<half, 2>::store(half* ptr) const { *((half2*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<half, 2>::memcpy(half* dst, const half* src) {
+  *((half2*)dst) = *((half2*)src);
+}
+
+// half x 4
+
+template <>
+struct vec_t<half, 4> {
+  uint2 data;
+
+  FLASHINFER_INLINE half& operator[](size_t i) { return ((half*)(&data))[i]; }
+  FLASHINFER_INLINE const half& operator[](size_t i) const { return ((const half*)(&data))[i]; }
+  FLASHINFER_INLINE half* ptr() { return reinterpret_cast<half*>(&data); }
+  FLASHINFER_INLINE void fill(half val);
+  FLASHINFER_INLINE void load(const half* ptr);
+  FLASHINFER_INLINE void store(half* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(half* dst, const half* src);
+};
+
+FLASHINFER_INLINE void vec_t<half, 4>::fill(half val) {
+  *(half2*)(&data.x) = make_half2(val, val);
+  *(half2*)(&data.y) = make_half2(val, val);
+}
+
+FLASHINFER_INLINE void vec_t<half, 4>::load(const half* ptr) { data = *((uint2*)ptr); }
+
+FLASHINFER_INLINE void vec_t<half, 4>::store(half* ptr) const { *((uint2*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<half, 4>::memcpy(half* dst, const half* src) {
+  *((uint2*)dst) = *((uint2*)src);
+}
+
+// half x 8 or more
+
+template <size_t vec_size>
+struct vec_t<half, vec_size> {
+  static_assert(vec_size % 8 == 0, "Invalid vector size");
+  int4 data[vec_size / 8];
+  FLASHINFER_INLINE half& operator[](size_t i) { return ((half*)data)[i]; }
+  FLASHINFER_INLINE const half& operator[](size_t i) const { return ((const half*)data)[i]; }
+  FLASHINFER_INLINE half* ptr() { return reinterpret_cast<half*>(&data); }
+  FLASHINFER_INLINE void fill(half val) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      *(half2*)(&(data[i].x)) = make_half2(val, val);
+      *(half2*)(&(data[i].y)) = make_half2(val, val);
+      *(half2*)(&(data[i].z)) = make_half2(val, val);
+      *(half2*)(&(data[i].w)) = make_half2(val, val);
+    }
+  }
+  FLASHINFER_INLINE void load(const half* ptr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      data[i] = ((int4*)ptr)[i];
+    }
+  }
+  FLASHINFER_INLINE void store(half* ptr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      ((int4*)ptr)[i] = data[i];
+    }
+  }
+  FLASHINFER_INLINE void load_global_acquire(half* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      data[i] = ld_global_acquire((int4*)(addr + i * 8));
+    }
+  }
+  FLASHINFER_INLINE void store_global_release(half* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      st_global_release(data[i], (int4*)(addr + i * 8));
+    }
+  }
+  FLASHINFER_INLINE void store_global_volatile(half* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      st_global_volatile(data[i], (int4*)(addr + i * 8));
+    }
+  }
+  FLASHINFER_INLINE void load_global_volatile(half* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      data[i] = ld_global_volatile((int4*)(addr + i * 8));
+    }
+  }
+
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(half* dst, const half* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      ((int4*)dst)[i] = ((int4*)src)[i];
+    }
+  }
+};
+
+/******************* vec_t<nv_bfloat16> *******************/
+
+// nv_bfloat16 x 1
+template <>
+struct vec_t<nv_bfloat16, 1> {
+  nv_bfloat16 data;
+  FLASHINFER_INLINE nv_bfloat16& operator[](size_t i) { return ((nv_bfloat16*)(&data))[i]; }
+  FLASHINFER_INLINE const nv_bfloat16& operator[](size_t i) const {
+    return ((const nv_bfloat16*)(&data))[i];
+  }
+  FLASHINFER_INLINE nv_bfloat16* ptr() { return reinterpret_cast<nv_bfloat16*>(&data); }
+  FLASHINFER_INLINE void fill(nv_bfloat16 val);
+  FLASHINFER_INLINE void load(const nv_bfloat16* ptr);
+  FLASHINFER_INLINE void store(nv_bfloat16* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(nv_bfloat16* dst, const nv_bfloat16* src);
+};
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 1>::fill(nv_bfloat16 val) { data = val; }
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 1>::load(const nv_bfloat16* ptr) { data = *ptr; }
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 1>::store(nv_bfloat16* ptr) const { *ptr = data; }
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 1>::memcpy(nv_bfloat16* dst, const nv_bfloat16* src) {
+  *dst = *src;
+}
+
+// nv_bfloat16 x 2
+template <>
+struct vec_t<nv_bfloat16, 2> {
+  nv_bfloat162 data;
+
+  FLASHINFER_INLINE nv_bfloat16& operator[](size_t i) { return ((nv_bfloat16*)(&data))[i]; }
+  FLASHINFER_INLINE const nv_bfloat16& operator[](size_t i) const {
+    return ((const nv_bfloat16*)(&data))[i];
+  }
+  FLASHINFER_INLINE nv_bfloat16* ptr() { return reinterpret_cast<nv_bfloat16*>(&data); }
+  FLASHINFER_INLINE void fill(nv_bfloat16 val);
+  FLASHINFER_INLINE void load(const nv_bfloat16* ptr);
+  FLASHINFER_INLINE void store(nv_bfloat16* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(nv_bfloat16* dst, const nv_bfloat16* src);
+};
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 2>::fill(nv_bfloat16 val) {
+  data = make_bfloat162(val, val);
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 2>::load(const nv_bfloat16* ptr) {
+  data = *((nv_bfloat162*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 2>::store(nv_bfloat16* ptr) const {
+  *((nv_bfloat162*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 2>::memcpy(nv_bfloat16* dst, const nv_bfloat16* src) {
+  *((nv_bfloat162*)dst) = *((nv_bfloat162*)src);
+}
+
+// nv_bfloat16 x 4
+
+template <>
+struct vec_t<nv_bfloat16, 4> {
+  uint2 data;
+
+  FLASHINFER_INLINE nv_bfloat16& operator[](size_t i) { return ((nv_bfloat16*)(&data))[i]; }
+  FLASHINFER_INLINE const nv_bfloat16& operator[](size_t i) const {
+    return ((const nv_bfloat16*)(&data))[i];
+  }
+  FLASHINFER_INLINE nv_bfloat16* ptr() { return reinterpret_cast<nv_bfloat16*>(&data); }
+  FLASHINFER_INLINE void fill(nv_bfloat16 val);
+  FLASHINFER_INLINE void load(const nv_bfloat16* ptr);
+  FLASHINFER_INLINE void store(nv_bfloat16* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(nv_bfloat16* dst, const nv_bfloat16* src);
+};
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 4>::fill(nv_bfloat16 val) {
+  *(nv_bfloat162*)(&data.x) = make_bfloat162(val, val);
+  *(nv_bfloat162*)(&data.y) = make_bfloat162(val, val);
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 4>::load(const nv_bfloat16* ptr) {
+  data = *((uint2*)ptr);
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 4>::store(nv_bfloat16* ptr) const {
+  *((uint2*)ptr) = data;
+}
+
+FLASHINFER_INLINE void vec_t<nv_bfloat16, 4>::memcpy(nv_bfloat16* dst, const nv_bfloat16* src) {
+  *((uint2*)dst) = *((uint2*)src);
+}
+
+// nv_bfloat16 x 8 or more
+
+template <size_t vec_size>
+struct vec_t<nv_bfloat16, vec_size> {
+  static_assert(vec_size % 8 == 0, "Invalid vector size");
+  int4 data[vec_size / 8];
+
+  FLASHINFER_INLINE nv_bfloat16& operator[](size_t i) { return ((nv_bfloat16*)data)[i]; }
+  FLASHINFER_INLINE const nv_bfloat16& operator[](size_t i) const {
+    return ((const nv_bfloat16*)data)[i];
+  }
+  FLASHINFER_INLINE nv_bfloat16* ptr() { return reinterpret_cast<nv_bfloat16*>(&data); }
+  FLASHINFER_INLINE void fill(nv_bfloat16 val) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      *(nv_bfloat162*)(&(data[i].x)) = make_bfloat162(val, val);
+      *(nv_bfloat162*)(&(data[i].y)) = make_bfloat162(val, val);
+      *(nv_bfloat162*)(&(data[i].z)) = make_bfloat162(val, val);
+      *(nv_bfloat162*)(&(data[i].w)) = make_bfloat162(val, val);
+    }
+  }
+  FLASHINFER_INLINE void load(const nv_bfloat16* ptr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      data[i] = ((int4*)ptr)[i];
+    }
+  }
+  FLASHINFER_INLINE void store(nv_bfloat16* ptr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      ((int4*)ptr)[i] = data[i];
+    }
+  }
+  FLASHINFER_INLINE void store_global_release(nv_bfloat16* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      st_global_release(data[i], (int4*)(addr + i * 8));
+    }
+  }
+  FLASHINFER_INLINE void load_global_acquire(nv_bfloat16* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      data[i] = ld_global_acquire((int4*)(addr + i * 8));
+    }
+  }
+  FLASHINFER_INLINE void store_global_volatile(nv_bfloat16* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      st_global_volatile(data[i], (int4*)(addr + i * 8));
+    }
+  }
+  FLASHINFER_INLINE void load_global_volatile(nv_bfloat16* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      data[i] = ld_global_volatile((int4*)(addr + i * 8));
+    }
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(nv_bfloat16* dst, const nv_bfloat16* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 8; ++i) {
+      ((int4*)dst)[i] = ((int4*)src)[i];
+    }
+  }
+};
+
+/******************* vec_t<uint8_t> *******************/
+
+// uint8_t x 1
+template <>
+struct vec_t<uint8_t, 1> {
+  uint8_t data;
+
+  FLASHINFER_INLINE uint8_t& operator[](size_t i) { return ((uint8_t*)(&data))[i]; }
+  FLASHINFER_INLINE const uint8_t& operator[](size_t i) const {
+    return ((const uint8_t*)(&data))[i];
+  }
+  FLASHINFER_INLINE uint8_t* ptr() { return reinterpret_cast<uint8_t*>(&data); }
+  FLASHINFER_INLINE void fill(uint8_t val);
+  FLASHINFER_INLINE void load(const uint8_t* ptr);
+  FLASHINFER_INLINE void store(uint8_t* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(uint8_t* dst, const uint8_t* src);
+};
+
+FLASHINFER_INLINE void vec_t<uint8_t, 1>::fill(uint8_t val) { data = val; }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 1>::load(const uint8_t* ptr) { data = *ptr; }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 1>::store(uint8_t* ptr) const { *ptr = data; }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 1>::memcpy(uint8_t* dst, const uint8_t* src) { *dst = *src; }
+
+// uint8_t x 2
+template <>
+struct vec_t<uint8_t, 2> {
+  uint16_t data;
+
+  FLASHINFER_INLINE uint8_t& operator[](size_t i) { return ((uint8_t*)(&data))[i]; }
+  FLASHINFER_INLINE const uint8_t& operator[](size_t i) const {
+    return ((const uint8_t*)(&data))[i];
+  }
+  FLASHINFER_INLINE uint8_t* ptr() { return reinterpret_cast<uint8_t*>(&data); }
+  FLASHINFER_INLINE void fill(uint8_t val);
+  FLASHINFER_INLINE void load(const uint8_t* ptr);
+  FLASHINFER_INLINE void store(uint8_t* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(uint8_t* dst, const uint8_t* src);
+};
+
+FLASHINFER_INLINE void vec_t<uint8_t, 2>::fill(uint8_t val) {
+  data = (uint16_t(val) << 8) | uint16_t(val);
+}
+
+FLASHINFER_INLINE void vec_t<uint8_t, 2>::load(const uint8_t* ptr) { data = *((uint16_t*)ptr); }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 2>::store(uint8_t* ptr) const { *((uint16_t*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 2>::memcpy(uint8_t* dst, const uint8_t* src) {
+  *((uint16_t*)dst) = *((uint16_t*)src);
+}
+
+// uint8_t x 4
+
+template <>
+struct vec_t<uint8_t, 4> {
+  uint32_t data;
+
+  FLASHINFER_INLINE uint8_t& operator[](size_t i) { return ((uint8_t*)(&data))[i]; }
+  FLASHINFER_INLINE const uint8_t& operator[](size_t i) const {
+    return ((const uint8_t*)(&data))[i];
+  }
+  FLASHINFER_INLINE uint8_t* ptr() { return reinterpret_cast<uint8_t*>(&data); }
+  FLASHINFER_INLINE void fill(uint8_t val);
+  FLASHINFER_INLINE void load(const uint8_t* ptr);
+  FLASHINFER_INLINE void store(uint8_t* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 4>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+
+  FLASHINFER_INLINE static void memcpy(uint8_t* dst, const uint8_t* src);
+};
+
+FLASHINFER_INLINE void vec_t<uint8_t, 4>::fill(uint8_t val) {
+  data = (uint32_t(val) << 24) | (uint32_t(val) << 16) | (uint32_t(val) << 8) | uint32_t(val);
+}
+
+FLASHINFER_INLINE void vec_t<uint8_t, 4>::load(const uint8_t* ptr) { data = *((uint32_t*)ptr); }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 4>::store(uint8_t* ptr) const { *((uint32_t*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 4>::memcpy(uint8_t* dst, const uint8_t* src) {
+  *((uint32_t*)dst) = *((uint32_t*)src);
+}
+
+// uint8_t x 8
+
+template <>
+struct vec_t<uint8_t, 8> {
+  uint2 data;
+
+  FLASHINFER_INLINE uint8_t& operator[](size_t i) { return ((uint8_t*)(&data))[i]; }
+  FLASHINFER_INLINE const uint8_t& operator[](size_t i) const {
+    return ((const uint8_t*)(&data))[i];
+  }
+  FLASHINFER_INLINE uint8_t* ptr() { return reinterpret_cast<uint8_t*>(&data); }
+  FLASHINFER_INLINE void fill(uint8_t val);
+  FLASHINFER_INLINE void load(const uint8_t* ptr);
+  FLASHINFER_INLINE void store(uint8_t* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 8>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(uint8_t* dst, const uint8_t* src);
+};
+
+FLASHINFER_INLINE void vec_t<uint8_t, 8>::fill(uint8_t val) {
+  uint32_t val32 =
+      (uint32_t(val) << 24) | (uint32_t(val) << 16) | (uint32_t(val) << 8) | uint32_t(val);
+  data.x = val32;
+  data.y = val32;
+}
+
+FLASHINFER_INLINE void vec_t<uint8_t, 8>::load(const uint8_t* ptr) { data = *((uint2*)ptr); }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 8>::store(uint8_t* ptr) const { *((uint2*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<uint8_t, 8>::memcpy(uint8_t* dst, const uint8_t* src) {
+  *((uint2*)dst) = *((uint2*)src);
+}
+
+// uint8_t x 16 or more
+
+template <size_t vec_size>
+struct vec_t<uint8_t, vec_size> {
+  static_assert(vec_size % 16 == 0, "Invalid vector size");
+  int4 data[vec_size / 16];
+
+  FLASHINFER_INLINE uint8_t& operator[](size_t i) { return ((uint8_t*)data)[i]; }
+  FLASHINFER_INLINE const uint8_t& operator[](size_t i) const { return ((const uint8_t*)data)[i]; }
+  FLASHINFER_INLINE uint8_t* ptr() { return reinterpret_cast<uint8_t*>(&data); }
+  FLASHINFER_INLINE void fill(uint8_t val) {
+    uint32_t val32 =
+        (uint32_t(val) << 24) | (uint32_t(val) << 16) | (uint32_t(val) << 8) | uint32_t(val);
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i].x = val32;
+      data[i].y = val32;
+      data[i].z = val32;
+      data[i].w = val32;
+    }
+  }
+  FLASHINFER_INLINE void load(const uint8_t* ptr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ((int4*)ptr)[i];
+    }
+  }
+  FLASHINFER_INLINE void store(uint8_t* ptr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((int4*)ptr)[i] = data[i];
+    }
+  }
+  FLASHINFER_INLINE void load_global_acquire(uint8_t* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ld_global_acquire((int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void store_global_release(uint8_t* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      st_global_release(data[i], (int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void load_global_volatile(uint8_t* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      data[i] = ld_global_volatile((int4*)(addr + i * 16));
+    }
+  }
+  FLASHINFER_INLINE void store_global_volatile(uint8_t* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      st_global_volatile(data[i], (int4*)(addr + i * 16));
+    }
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(uint8_t* dst, const uint8_t* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 16; ++i) {
+      ((int4*)dst)[i] = ((int4*)src)[i];
+    }
+  }
+};
+
+/******************* vec_t<float> *******************/
+
+// float x 1
+
+template <>
+struct vec_t<float, 1> {
+  float data;
+
+  FLASHINFER_INLINE float& operator[](size_t i) { return ((float*)(&data))[i]; }
+  FLASHINFER_INLINE const float& operator[](size_t i) const { return ((const float*)(&data))[i]; }
+  FLASHINFER_INLINE float* ptr() { return reinterpret_cast<float*>(&data); }
+  FLASHINFER_INLINE void fill(float val);
+  FLASHINFER_INLINE void load(const float* ptr);
+  FLASHINFER_INLINE void store(float* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 1>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(float* dst, const float* src);
+};
+
+FLASHINFER_INLINE void vec_t<float, 1>::fill(float val) { data = val; }
+
+FLASHINFER_INLINE void vec_t<float, 1>::load(const float* ptr) { data = *ptr; }
+
+FLASHINFER_INLINE void vec_t<float, 1>::store(float* ptr) const { *ptr = data; }
+
+FLASHINFER_INLINE void vec_t<float, 1>::memcpy(float* dst, const float* src) { *dst = *src; }
+
+// float x 2
+
+template <>
+struct vec_t<float, 2> {
+  float2 data;
+
+  FLASHINFER_INLINE float& operator[](size_t i) { return ((float*)(&data))[i]; }
+  FLASHINFER_INLINE const float& operator[](size_t i) const { return ((const float*)(&data))[i]; }
+  FLASHINFER_INLINE float* ptr() { return reinterpret_cast<float*>(&data); }
+  FLASHINFER_INLINE void fill(float val);
+  FLASHINFER_INLINE void load(const float* ptr);
+  FLASHINFER_INLINE void store(float* ptr) const;
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, 2>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(float* dst, const float* src);
+};
+
+FLASHINFER_INLINE void vec_t<float, 2>::fill(float val) { data = make_float2(val, val); }
+
+FLASHINFER_INLINE void vec_t<float, 2>::load(const float* ptr) { data = *((float2*)ptr); }
+
+FLASHINFER_INLINE void vec_t<float, 2>::store(float* ptr) const { *((float2*)ptr) = data; }
+
+FLASHINFER_INLINE void vec_t<float, 2>::memcpy(float* dst, const float* src) {
+  *((float2*)dst) = *((float2*)src);
+}
+
+// float x 4 or more
+template <size_t vec_size>
+struct vec_t<float, vec_size> {
+  static_assert(vec_size % 4 == 0, "Invalid vector size");
+  float4 data[vec_size / 4];
+
+  FLASHINFER_INLINE float& operator[](size_t i) { return ((float*)(data))[i]; }
+  FLASHINFER_INLINE const float& operator[](size_t i) const { return ((const float*)(data))[i]; }
+  FLASHINFER_INLINE float* ptr() { return reinterpret_cast<float*>(&data); }
+  FLASHINFER_INLINE void fill(float val) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 4; ++i) {
+      data[i] = make_float4(val, val, val, val);
+    }
+  }
+  FLASHINFER_INLINE void load(const float* ptr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 4; ++i) {
+      data[i] = ((float4*)ptr)[i];
+    }
+  }
+  FLASHINFER_INLINE void store(float* ptr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 4; ++i) {
+      ((float4*)ptr)[i] = data[i];
+    }
+  }
+  FLASHINFER_INLINE void store_global_release(float* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 4; ++i) {
+      st_global_release(*(int4*)(data + i), (int4*)(addr + i * 4));
+    }
+  }
+  FLASHINFER_INLINE void load_global_acquire(float* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 4; ++i) {
+      *((int4*)(data + i)) = ld_global_acquire((int4*)(addr + i * 4));
+    }
+  }
+  FLASHINFER_INLINE void store_global_volatile(float* addr) const {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 4; ++i) {
+      st_global_volatile(*(int4*)(data + i), (int4*)(addr + i * 4));
+    }
+  }
+  FLASHINFER_INLINE void load_global_volatile(float* addr) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 4; ++i) {
+      *((int4*)(data + i)) = ld_global_volatile((int4*)(addr + i * 4));
+    }
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_from(const vec_t<T, vec_size>& src) {
+    cast_from_impl(*this, src);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_load(const T* ptr) {
+    cast_load_impl(*this, ptr);
+  }
+  template <typename T>
+  FLASHINFER_INLINE void cast_store(T* ptr) const {
+    cast_store_impl(ptr, *this);
+  }
+  FLASHINFER_INLINE static void memcpy(float* dst, const float* src) {
+#pragma unroll
+    for (size_t i = 0; i < vec_size / 4; ++i) {
+      ((float4*)dst)[i] = ((float4*)src)[i];
+    }
+  }
+};
+
+template <typename T>
+struct vec2_dtype {
+  using type = T;
+};
+
+template <>
+struct vec2_dtype<half> {
+  using type = half2;
+};
+
+template <>
+struct vec2_dtype<__nv_bfloat16> {
+  using type = __nv_bfloat162;
+};
+
+template <>
+struct vec2_dtype<__nv_fp8_e4m3> {
+  using type = __nv_fp8x2_e4m3;
+};
+
+template <>
+struct vec2_dtype<__nv_fp8_e5m2> {
+  using type = __nv_fp8x2_e5m2;
+};
+
+template <typename T>
+using vec2_dtype_t = typename vec2_dtype<T>::type;
+
+template <typename T, size_t VEC_SIZE>
+FLASHINFER_INLINE vec2_dtype_t<T> get_vec2_element(vec_t<T, VEC_SIZE>& vec, int i) {
+  static_assert(VEC_SIZE % 2 == 0, "VEC_SIZE must be a multiple of 2");
+  return ((vec2_dtype_t<T>*)&(vec[0]))[i];
+}
+
+}  // namespace flashinfer
+
+#endif  // VEC_DTYPES_CUH_

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/sparse_topk_select.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/sparse_topk_select.cu
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 MiniMax
+// SPDX-License-Identifier: MIT
+
+#include "sparse_topk_select.cuh"
+#include "tvm_ffi_utils.h"
+
+using namespace flashinfer;
+using tvm::ffi::Optional;
+
+template <typename T>
+T* TensorDataPtr(TensorView tensor) {
+  return reinterpret_cast<T*>(static_cast<char*>(tensor.data_ptr()) + tensor.byte_offset());
+}
+
+template <typename T>
+const T* TensorDataPtrConst(TensorView tensor) {
+  return reinterpret_cast<const T*>(static_cast<const char*>(tensor.data_ptr()) +
+                                    tensor.byte_offset());
+}
+
+void sparse_topk_select_init() {
+  cudaError_t status = sparse_topk::ConfigureSparseTopKSelect();
+  TVM_FFI_ICHECK(status == cudaSuccess)
+      << "sparse_topk_select init failed: " << cudaGetErrorString(status);
+}
+
+// v2.5_oob_clamp_in_kernel:
+//   Adds num_valid_pages parameter (between topk and stream_ptr).  When
+//   num_valid_pages < max_k_tiles, indices >= num_valid_pages are emitted as
+//   -1 and sorted to the tail by the kernel — replacing the prod wrapper's
+//   torch.where + sort + torch.where post-processing (~84-101 us measured).
+//
+//   To disable clamping, pass num_valid_pages = max_k_tiles (or any value
+//   >= max_k_tiles).
+void sparse_topk_select(TensorView max_score, TensorView output_indices,
+                        Optional<TensorView> maybe_workspace_buffer,
+                        Optional<TensorView> maybe_block_table,
+                        int64_t topk,
+                        int64_t num_valid_pages,
+                        Optional<TensorView> maybe_num_valid_pages_per_token,
+                        int64_t force_begin_blocks, int64_t force_end_blocks,
+                        int64_t input_layout,
+                        int64_t stream_ptr) {
+  CHECK_INPUT(max_score);
+  CHECK_CUDA(output_indices);
+  CHECK_DIM(3, max_score);
+  CHECK_DIM(3, output_indices);
+
+  TVM_FFI_ICHECK(encode_dlpack_dtype(max_score.dtype()) == float32_code)
+      << "max_score must be float32";
+  TVM_FFI_ICHECK(encode_dlpack_dtype(output_indices.dtype()) == int32_code)
+      << "output_indices must be int32";
+
+  TVM_FFI_ICHECK(input_layout == 0 || input_layout == 1)
+      << "input_layout must be 0 (HKT) or 1 (THK), got " << input_layout;
+  const auto layout = input_layout == 0
+      ? sparse_topk::SparseTopKInputLayout::kHKT
+      : sparse_topk::SparseTopKInputLayout::kTHK;
+
+  const int64_t total_qo_len = input_layout == 0 ? max_score.size(2) : max_score.size(0);
+  const int64_t num_qo_heads = input_layout == 0 ? max_score.size(0) : max_score.size(1);
+  const int64_t max_k_tiles = input_layout == 0 ? max_score.size(1) : max_score.size(2);
+
+  TVM_FFI_ICHECK(output_indices.size(0) == total_qo_len);
+  TVM_FFI_ICHECK(output_indices.size(1) == num_qo_heads);
+  TVM_FFI_ICHECK(output_indices.size(2) == topk);
+  TVM_FFI_ICHECK(output_indices.stride(0) >= 0 && output_indices.stride(1) >= 0 &&
+                 output_indices.stride(2) >= 0)
+      << "output_indices must have non-negative strides";
+  TVM_FFI_ICHECK(topk == 16) << "this kernel only supports topk == 16, got " << topk;
+  TVM_FFI_ICHECK(num_valid_pages > 0)
+      << "num_valid_pages must be > 0, got " << num_valid_pages;
+
+  const int32_t* block_table_ptr = nullptr;
+  uint64_t block_table_stride_t = 0;
+  uint64_t block_table_stride_h = 0;
+  uint64_t block_table_stride_k = 0;
+  if (maybe_block_table.has_value()) {
+    TensorView block_table = maybe_block_table.value();
+    CHECK_CUDA(block_table);
+    CHECK_DIM(3, block_table);
+    TVM_FFI_ICHECK(encode_dlpack_dtype(block_table.dtype()) == int32_code)
+        << "block_table must be int32";
+    TVM_FFI_ICHECK(block_table.size(0) == total_qo_len &&
+                   block_table.size(1) == num_qo_heads &&
+                   block_table.size(2) == max_k_tiles)
+        << "block_table must have shape [total_qo_len=" << total_qo_len
+        << ", num_qo_heads=" << num_qo_heads << ", max_k_tiles=" << max_k_tiles
+        << "], got [" << block_table.size(0) << ", " << block_table.size(1)
+        << ", " << block_table.size(2) << "]";
+    TVM_FFI_ICHECK(block_table.stride(0) >= 0 && block_table.stride(1) >= 0 &&
+                   block_table.stride(2) >= 0)
+        << "block_table must have non-negative strides";
+    CHECK_DEVICE(block_table, max_score);
+    block_table_ptr = TensorDataPtrConst<int32_t>(block_table);
+    block_table_stride_t = static_cast<uint64_t>(block_table.stride(0));
+    block_table_stride_h = static_cast<uint64_t>(block_table.stride(1));
+    block_table_stride_k = static_cast<uint64_t>(block_table.stride(2));
+  }
+
+  const int32_t* num_valid_pages_per_token = nullptr;
+  if (maybe_num_valid_pages_per_token.has_value()) {
+    TensorView nvp = maybe_num_valid_pages_per_token.value();
+    CHECK_INPUT(nvp);
+    CHECK_DIM(1, nvp);
+    TVM_FFI_ICHECK(encode_dlpack_dtype(nvp.dtype()) == int32_code)
+        << "num_valid_pages_per_token must be int32";
+    TVM_FFI_ICHECK(nvp.size(0) == total_qo_len)
+        << "num_valid_pages_per_token must have shape [total_qo_len="
+        << total_qo_len << "], got " << nvp.size(0);
+    num_valid_pages_per_token = TensorDataPtrConst<int32_t>(nvp);
+  }
+
+  const size_t needed_workspace = sparse_topk::SparseTopKWorkspaceSize(
+      static_cast<uint32_t>(total_qo_len), static_cast<uint32_t>(num_qo_heads),
+      static_cast<uint32_t>(max_k_tiles), layout);
+  int32_t* workspace_ptr = nullptr;
+  if (needed_workspace > 0) {
+    TVM_FFI_ICHECK(maybe_workspace_buffer.has_value())
+        << "workspace_buffer is required for sparse_topk_select HKT layout";
+    TensorView workspace_buffer = maybe_workspace_buffer.value();
+    CHECK_INPUT(workspace_buffer);
+    CHECK_DIM(1, workspace_buffer);
+    TVM_FFI_ICHECK(encode_dlpack_dtype(workspace_buffer.dtype()) == int32_code)
+        << "workspace_buffer must be int32";
+    TVM_FFI_ICHECK(static_cast<size_t>(workspace_buffer.size(0)) >= needed_workspace)
+        << "workspace_buffer too small: need " << needed_workspace << " int32 elements";
+    workspace_ptr = TensorDataPtr<int32_t>(workspace_buffer);
+  }
+
+  const cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_ptr);
+
+  cudaError_t status = sparse_topk::SparseTopKSelect(
+      TensorDataPtrConst<float>(max_score),
+      TensorDataPtr<int32_t>(output_indices),
+      workspace_ptr,
+      block_table_ptr,
+      static_cast<uint64_t>(output_indices.stride(0)),
+      static_cast<uint64_t>(output_indices.stride(1)),
+      static_cast<uint64_t>(output_indices.stride(2)),
+      block_table_stride_t,
+      block_table_stride_h,
+      block_table_stride_k,
+      static_cast<uint32_t>(total_qo_len), static_cast<uint32_t>(num_qo_heads),
+      static_cast<uint32_t>(max_k_tiles), static_cast<uint32_t>(num_valid_pages),
+      num_valid_pages_per_token, layout,
+      static_cast<uint32_t>(force_begin_blocks), static_cast<uint32_t>(force_end_blocks),
+      stream, /*enable_pdl=*/true);
+
+  TVM_FFI_ICHECK(status == cudaSuccess)
+      << "sparse_topk_select failed: " << cudaGetErrorString(status);
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sparse_topk_select_init, sparse_topk_select_init);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sparse_topk_select, sparse_topk_select);

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/tvm_ffi_utils.h
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/csrc/tvm_ffi_utils.h
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) 2023 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <tvm/ffi/container/tensor.h>
+#include <tvm/ffi/dtype.h>
+#include <tvm/ffi/error.h>
+#include <tvm/ffi/extra/c_env_api.h>
+#include <tvm/ffi/extra/cuda/device_guard.h>
+#include <tvm/ffi/function.h>
+
+#include "dlpack/dlpack.h"
+
+using tvm::ffi::Tensor;
+using tvm::ffi::TensorView;
+namespace ffi = tvm::ffi;
+
+inline constexpr int64_t encode_dlpack_dtype(DLDataType dtype) {
+  return (dtype.code << 16) | (dtype.bits << 8) | dtype.lanes;
+}
+
+constexpr DLDataType dl_uint8 = DLDataType{kDLUInt, 8, 1};
+constexpr DLDataType dl_uint16 = DLDataType{kDLUInt, 16, 1};
+constexpr DLDataType dl_uint32 = DLDataType{kDLUInt, 32, 1};
+constexpr DLDataType dl_uint64 = DLDataType{kDLUInt, 64, 1};
+constexpr DLDataType dl_int8 = DLDataType{kDLInt, 8, 1};
+constexpr DLDataType dl_int16 = DLDataType{kDLInt, 16, 1};
+constexpr DLDataType dl_int32 = DLDataType{kDLInt, 32, 1};
+constexpr DLDataType dl_int64 = DLDataType{kDLInt, 64, 1};
+constexpr DLDataType dl_float16 = DLDataType{kDLFloat, 16, 1};
+constexpr DLDataType dl_float32 = DLDataType{kDLFloat, 32, 1};
+constexpr DLDataType dl_float64 = DLDataType{kDLFloat, 64, 1};
+constexpr DLDataType dl_float8_e4m3fn = DLDataType{kDLFloat8_e4m3fn, 8, 1};
+constexpr DLDataType dl_float8_e5m2 = DLDataType{kDLFloat8_e5m2, 8, 1};
+constexpr DLDataType dl_float4_e2m1fn = DLDataType{kDLFloat4_e2m1fn, 4, 1};
+constexpr DLDataType dl_float4_e2m1fn_x2 = DLDataType{kDLFloat4_e2m1fn, 4, 2};
+constexpr DLDataType dl_bfloat16 = DLDataType{kDLBfloat, 16, 1};
+constexpr DLDataType dl_bool = DLDataType{kDLBool, 8, 1};
+
+constexpr int64_t float16_code = encode_dlpack_dtype(dl_float16);
+constexpr int64_t bfloat16_code = encode_dlpack_dtype(dl_bfloat16);
+constexpr int64_t float32_code = encode_dlpack_dtype(dl_float32);
+constexpr int64_t uint8_code = encode_dlpack_dtype(dl_uint8);
+constexpr int64_t int32_code = encode_dlpack_dtype(dl_int32);
+constexpr int64_t int64_code = encode_dlpack_dtype(dl_int64);
+constexpr int64_t float8_e4m3fn_code = encode_dlpack_dtype(dl_float8_e4m3fn);
+constexpr int64_t float8_e5m2_code = encode_dlpack_dtype(dl_float8_e5m2);
+constexpr int64_t float4_e2m1fn_code = encode_dlpack_dtype(dl_float4_e2m1fn);
+
+constexpr DLDevice cpu = DLDevice{kDLCPU, 0};
+
+#ifdef FLASHINFER_ENABLE_F16
+#define _DISPATCH_CASE_F16(c_type, ...) \
+  case float16_code: {                  \
+    using c_type = nv_half;             \
+    return __VA_ARGS__();               \
+  }
+#else
+#define _DISPATCH_CASE_F16(c_type, ...)
+#endif
+
+#ifdef FLASHINFER_ENABLE_BF16
+#define _DISPATCH_CASE_BF16(c_type, ...) \
+  case bfloat16_code: {                  \
+    using c_type = nv_bfloat16;          \
+    return __VA_ARGS__();                \
+  }
+#else
+#define _DISPATCH_CASE_BF16(c_type, ...)
+#endif
+
+#define DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(dlpack_dtype, c_type, ...)                   \
+  [&]() -> bool {                                                                        \
+    switch (encode_dlpack_dtype(dlpack_dtype)) {                                         \
+      _DISPATCH_CASE_F16(c_type, __VA_ARGS__)                                            \
+      _DISPATCH_CASE_BF16(c_type, __VA_ARGS__)                                           \
+      default:                                                                           \
+        TVM_FFI_ICHECK(false) << __PRETTY_FUNCTION__ << " failed to dispatch data type " \
+                              << (dlpack_dtype).code << " " << (dlpack_dtype).bits;      \
+        return false;                                                                    \
+    }                                                                                    \
+  }()
+
+// Dispatcher for FP32/FP16/BF16 data types
+#define DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP32_FP16(dlpack_dtype, c_type, ...)              \
+  [&]() -> bool {                                                                        \
+    switch (encode_dlpack_dtype(dlpack_dtype)) {                                         \
+      case float32_code: {                                                               \
+        using c_type = float;                                                            \
+        return __VA_ARGS__();                                                            \
+      }                                                                                  \
+        _DISPATCH_CASE_F16(c_type, __VA_ARGS__)                                          \
+        _DISPATCH_CASE_BF16(c_type, __VA_ARGS__)                                         \
+      default:                                                                           \
+        TVM_FFI_ICHECK(false) << __PRETTY_FUNCTION__ << " failed to dispatch data type " \
+                              << (dlpack_dtype).code << " " << (dlpack_dtype).bits;      \
+        return false;                                                                    \
+    }                                                                                    \
+  }()
+
+#define _DISPATCH_CASE_I32(c_type, ...) \
+  case int32_code: {                    \
+    using c_type = int32_t;             \
+    return __VA_ARGS__();               \
+  }
+
+#define _DISPATCH_CASE_I64(c_type, ...) \
+  case int64_code: {                    \
+    using c_type = int64_t;             \
+    return __VA_ARGS__();               \
+  }
+
+#define DISPATCH_DLPACK_IDTYPE_TO_CTYPE(dlpack_dtype, c_type, ...)                       \
+  [&]() -> bool {                                                                        \
+    switch (encode_dlpack_dtype(dlpack_dtype)) {                                         \
+      _DISPATCH_CASE_I32(c_type, __VA_ARGS__)                                            \
+      _DISPATCH_CASE_I64(c_type, __VA_ARGS__)                                            \
+      default:                                                                           \
+        TVM_FFI_ICHECK(false) << __PRETTY_FUNCTION__ << " failed to dispatch data type " \
+                              << (dlpack_dtype).code << " " << (dlpack_dtype).bits;      \
+        return false;                                                                    \
+    }                                                                                    \
+  }()
+
+#ifdef FLASHINFER_ENABLE_FP8_E4M3
+#define _DISPATCH_CASE_FP8_E4M3(c_type, ...) \
+  case float8_e4m3fn_code: {                 \
+    using c_type = __nv_fp8_e4m3;            \
+    return __VA_ARGS__();                    \
+  }
+#else
+#define _DISPATCH_CASE_FP8_E4M3(c_type, ...)
+#endif
+
+#ifdef FLASHINFER_ENABLE_FP8_E5M2
+#define _DISPATCH_CASE_FP8_E5M2(c_type, ...) \
+  case float8_e5m2_code: {                   \
+    using c_type = __nv_fp8_e5m2;            \
+    return __VA_ARGS__();                    \
+  }
+#else
+#define _DISPATCH_CASE_FP8_E5M2(c_type, ...)
+#endif
+
+#define DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP8(dlpack_dtype, c_type, ...)                    \
+  [&]() -> bool {                                                                        \
+    switch (encode_dlpack_dtype(dlpack_dtype)) {                                         \
+      _DISPATCH_CASE_FP8_E4M3(c_type, __VA_ARGS__)                                       \
+      _DISPATCH_CASE_FP8_E5M2(c_type, __VA_ARGS__)                                       \
+      default:                                                                           \
+        TVM_FFI_ICHECK(false) << __PRETTY_FUNCTION__ << " failed to dispatch data type " \
+                              << (dlpack_dtype).code << " " << (dlpack_dtype).bits;      \
+        return false;                                                                    \
+    }                                                                                    \
+  }()
+
+#ifdef FLASHINFER_ENABLE_F32
+#define _DISPATCH_CASE_F32(c_type, ...) \
+  case float32_code: {                  \
+    using c_type = float;               \
+    return __VA_ARGS__();               \
+  }
+#else
+#define _DISPATCH_CASE_F32(c_type, ...)
+#endif
+
+#if defined(FLASHINFER_ENABLE_FP8_E8M0) && \
+    (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
+#define _DISPATCH_SF_CASE_FP8_E8M0(c_type, ...) \
+  case uint8_code: {                            \
+    using c_type = __nv_fp8_e8m0;               \
+    return __VA_ARGS__();                       \
+  }
+#else
+#define _DISPATCH_SF_CASE_FP8_E8M0(c_type, ...)
+#endif
+
+#if defined(FLASHINFER_ENABLE_FP8_E4M3) && \
+    (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
+#define _DISPATCH_SF_CASE_FP8_UE4M3(c_type, ...) \
+  case uint8_code: {                             \
+    using c_type = __nv_fp8_e4m3;                \
+    return __VA_ARGS__();                        \
+  }
+#else
+#define _DISPATCH_SF_CASE_FP8_UE4M3(c_type, ...)
+#endif
+
+#define DISPATCH_DLPACK_DTYPE_TO_CTYPE_SF(dlpack_dtype, c_type, ...)                \
+  [&]() -> bool {                                                                   \
+    switch (encode_dlpack_dtype(dlpack_dtype)) {                                    \
+      _DISPATCH_CASE_F32(c_type, __VA_ARGS__)                                       \
+      _DISPATCH_SF_CASE_FP8_E8M0(c_type, __VA_ARGS__)                               \
+      default:                                                                      \
+        TVM_FFI_ICHECK(false) << __PRETTY_FUNCTION__                                \
+                              << " failed to dispatch scaling factor data type "    \
+                              << (dlpack_dtype).code << " " << (dlpack_dtype).bits; \
+        return false;                                                               \
+    }                                                                               \
+  }()
+
+// We require a separate definition since both E8M0 and UE4M3 are passed as
+// uint8
+#define DISPATCH_DLPACK_DTYPE_TO_CTYPE_SF_UE4M3(dlpack_dtype, c_type, ...)          \
+  [&]() -> bool {                                                                   \
+    switch (encode_dlpack_dtype(dlpack_dtype)) {                                    \
+      _DISPATCH_CASE_F32(c_type, __VA_ARGS__)                                       \
+      _DISPATCH_SF_CASE_FP8_UE4M3(c_type, __VA_ARGS__)                              \
+      default:                                                                      \
+        TVM_FFI_ICHECK(false) << __PRETTY_FUNCTION__                                \
+                              << " failed to dispatch scaling factor data type "    \
+                              << (dlpack_dtype).code << " " << (dlpack_dtype).bits; \
+        return false;                                                               \
+    }                                                                               \
+  }()
+
+#if defined(FLASHINFER_ENABLE_FP4_E2M1) && \
+    (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120800)
+#define _DISPATCH_CASE_FP4_E2M1(c_type, ...) \
+  case uint8_code: {                         \
+    using c_type = __nv_fp4_e2m1;            \
+    return __VA_ARGS__();                    \
+  }
+#else
+#define _DISPATCH_CASE_FP4_E2M1(c_type, ...)
+#endif
+
+#define DISPATCH_DLPACK_DTYPE_TO_CTYPE(dlpack_dtype, c_type, ...)                        \
+  [&]() -> bool {                                                                        \
+    switch (encode_dlpack_dtype(dlpack_dtype)) {                                         \
+      _DISPATCH_CASE_F16(c_type, __VA_ARGS__)                                            \
+      _DISPATCH_CASE_BF16(c_type, __VA_ARGS__)                                           \
+      _DISPATCH_CASE_FP8_E4M3(c_type, __VA_ARGS__)                                       \
+      _DISPATCH_CASE_FP8_E5M2(c_type, __VA_ARGS__)                                       \
+      _DISPATCH_CASE_FP4_E2M1(c_type, __VA_ARGS__)                                       \
+      default:                                                                           \
+        TVM_FFI_ICHECK(false) << __PRETTY_FUNCTION__ << " failed to dispatch data type " \
+                              << (dlpack_dtype).code << " " << (dlpack_dtype).bits;      \
+        return false;                                                                    \
+    }                                                                                    \
+  }()
+
+#define DISPATCH_BOOL(expr, const_expr, ...) \
+  [&]() -> bool {                            \
+    if (expr) {                              \
+      constexpr bool const_expr = true;      \
+      return __VA_ARGS__();                  \
+    } else {                                 \
+      constexpr bool const_expr = false;     \
+      return __VA_ARGS__();                  \
+    }                                        \
+  }()
+
+inline void check_shape(const tvm::ffi::Tensor& a, const tvm::ffi::Tensor& b, const char* a_name,
+                        const char* b_name) {
+  TVM_FFI_ICHECK_EQ(a.ndim(), b.ndim()) << a_name << ".ndim() and " << b_name << ".ndim() mismatch";
+  for (int i = 0; i < a.ndim(); ++i) {
+    TVM_FFI_ICHECK_EQ(a.size(i), b.size(i))
+        << a_name << ".size(" << i << ") and " << b_name << ".size(" << i << ") mismatch";
+  }
+}
+
+inline void check_shape(const tvm::ffi::TensorView& a, const tvm::ffi::TensorView& b,
+                        const char* a_name, const char* b_name) {
+  TVM_FFI_ICHECK_EQ(a.ndim(), b.ndim()) << a_name << ".ndim() and " << b_name << ".ndim() mismatch";
+  for (int i = 0; i < a.ndim(); ++i) {
+    TVM_FFI_ICHECK_EQ(a.size(i), b.size(i))
+        << a_name << ".size(" << i << ") and " << b_name << ".size(" << i << ") mismatch";
+  }
+}
+
+#define CHECK_CUDA(x) \
+  TVM_FFI_ICHECK_EQ(x.device().device_type, kDLCUDA) << #x " must be a CUDA tensor";
+#define CHECK_CPU(x) \
+  TVM_FFI_ICHECK_EQ(x.device().device_type, kDLCPU) << #x " must be a host tensor";
+#define CHECK_CONTIGUOUS(x) TVM_FFI_ICHECK(x.IsContiguous()) << #x " must be contiguous";
+#define CHECK_LAST_DIM_CONTIGUOUS(x) \
+  TVM_FFI_ICHECK_EQ(x.stride(-1), 1) \
+  #x "must be contiguous at last dimension";
+#define CHECK_INPUT(x) \
+  CHECK_CUDA(x);       \
+  CHECK_CONTIGUOUS(x)
+#define CHECK_INPUT_TYPE(x, st) \
+  TVM_FFI_ICHECK_EQ(x.dtype(), st) << "Inconsistency of Tensor type: " #x;
+#define CHECK_INPUT_AND_TYPE(x, st) \
+  CHECK_CUDA(x);                    \
+  CHECK_CONTIGUOUS(x);              \
+  CHECK_INPUT_TYPE(x, st)
+#define CHECK_MAYBE_INPUT_TYPE(maybe_x, st) \
+  if (maybe_x.has_value()) {                \
+    CHECK_INPUT_TYPE(maybe_x.value(), st);  \
+  }
+#define CHECK_MAYBE_INPUT_TYPES(maybe_x, st1, st2)                                   \
+  if (maybe_x.has_value()) {                                                         \
+    TVM_FFI_ICHECK(maybe_x.value().dtype() == st1 || maybe_x.value().dtype() == st2) \
+        << "Inconsistency of Tensor type: " #maybe_x " must be " #st1 " or " #st2;   \
+  }
+#define CHECK_SAME_DTYPE(x, y)           \
+  TVM_FFI_ICHECK(x.dtype() == y.dtype()) \
+      << "Inconsistency of Tensor type: " #x " dtype must match " #y " dtype";
+#define CHECK_MAYBE_SAME_DTYPE(maybe_x, y) \
+  if (maybe_x.has_value()) {               \
+    CHECK_SAME_DTYPE(maybe_x.value(), y);  \
+  }
+#define CHECK_LAST_DIM_CONTIGUOUS_INPUT(x) \
+  CHECK_CUDA(x);                           \
+  CHECK_LAST_DIM_CONTIGUOUS(x)
+#define CHECK_DIM(d, x) TVM_FFI_ICHECK_EQ(x.ndim(), d) << #x " must be a " #d "D tensor";
+#define CHECK_SHAPE(a, b) check_shape(a, b, #a, #b)
+#define CHECK_DEVICE(a, b)                                           \
+  TVM_FFI_ICHECK_EQ(a.device().device_type, b.device().device_type); \
+  TVM_FFI_ICHECK_EQ(a.device().device_id, b.device().device_id);
+
+inline cudaStream_t get_current_stream() {
+  int device;
+  cudaGetDevice(&device);
+  return static_cast<cudaStream_t>(TVMFFIEnvGetStream(kDLCUDA, device));
+}
+
+inline cudaStream_t get_stream(DLDevice device) {
+  return static_cast<cudaStream_t>(TVMFFIEnvGetStream(device.device_type, device.device_id));
+}
+
+inline int64_t get_element_size(ffi::Tensor x) { return (x.dtype().bits * x.dtype().lanes) / 8; }
+
+inline int64_t get_element_size(ffi::TensorView x) {
+  return (x.dtype().bits * x.dtype().lanes) / 8;
+}
+
+inline ffi::Tensor alloc_tensor(tvm::ffi::Shape shape, DLDataType dtype, DLDevice device) {
+  return ffi::Tensor::FromEnvAlloc(TVMFFIEnvTensorAlloc, shape, dtype, device);
+}

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/jit.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/jit.py
@@ -1,0 +1,759 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 MiniMax
+# SPDX-License-Identifier: MIT
+
+"""Per-variant lazy JIT compilation for FMHA varlen kernels.
+
+Each FMHA variant (dtype x tile x sparse x page x split_kv x pack_factor) is compiled
+independently on first use and cached to ~/.cache/minfer/fmha_sm100/.
+
+To recompile after kernel changes: scripts/clear_fmha_cache.sh
+"""
+
+import fcntl
+import itertools
+import logging
+import os
+import shutil
+import subprocess
+import threading
+from pathlib import Path
+
+import jinja2
+
+logger = logging.getLogger(__name__)
+
+
+def _compute_cache_base():
+    explicit = os.environ.get("MINFER_FMHA_CACHE_DIR")
+    if explicit:
+        return Path(explicit)
+    base = Path(os.path.expanduser("~/.cache/minfer/fmha_sm100"))
+    # Different build configs get separate cache dirs to avoid conflicts
+    suffix = ""
+    if os.environ.get("GPU_TRACE") is not None:
+        suffix += "_gpu_trace"
+    if os.environ.get("SM_TIMING") is not None:
+        suffix += "_sm_timing"
+    if os.environ.get("FMHA_GMEM_CHECK") is not None:
+        suffix += "_gmem_check"
+    if suffix:
+        base = base.parent / (base.name + suffix)
+    return base
+
+
+CACHE_BASE = _compute_cache_base()
+
+
+def _acquire_file_lock(lock_path):
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o666)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    return fd
+
+
+def _release_file_lock(fd):
+    fcntl.flock(fd, fcntl.LOCK_UN)
+    os.close(fd)
+
+
+# Kernel sources and CUTLASS headers are shipped inside the package directory
+# so that JIT compilation works from both editable and wheel installs.
+_PACKAGE_DIR = Path(__file__).resolve().parent
+_FMHA_VARLEN_DIR = _PACKAGE_DIR / "csrc"
+
+
+# TokenSpeed patch: the upstream cutlass/ submodule is not vendored; resolve
+# CUTLASS headers from the env override, a package-local checkout, or the
+# flashinfer wheel's bundled tree (see thirdparty/msa/README.md).
+def _find_cutlass_dir():
+    explicit = os.environ.get("TOKENSPEED_MSA_CUTLASS_DIR")
+    if explicit:
+        return Path(explicit)
+    local = _PACKAGE_DIR / "cutlass"
+    if (local / "include" / "cutlass").is_dir():
+        return local
+    try:
+        import flashinfer
+
+        bundled = Path(flashinfer.__file__).resolve().parent / "data" / "cutlass"
+        if (bundled / "include" / "cutlass").is_dir():
+            return bundled
+    except ImportError:
+        pass
+    raise RuntimeError(
+        "Cannot find CUTLASS headers for the MSA FMHA JIT. Set "
+        "TOKENSPEED_MSA_CUTLASS_DIR to a CUTLASS checkout, or install "
+        "flashinfer (its wheel bundles the headers)."
+    )
+
+
+_PACK_FACTORS = [1, 2, 4, 6, 8, 16]
+# _PACK_FACTORS = [1, 6]
+
+# DLPack dtype codes (must match tvm_ffi_utils.h encode_dlpack_dtype)
+_BFLOAT16_CODE = (4 << 16) | (16 << 8) | 1  # 266241
+_FLOAT8_E4M3FN_CODE = (12 << 16) | (8 << 8) | 1  # 788481
+
+_FMHA_SM100_DISPATCH = [
+    (
+        "int64_t dtype_code",
+        [
+            (
+                _BFLOAT16_CODE,
+                {"dtype_in": "nv_bfloat16", "cutlass_dtype_out": "cutlass::bfloat16_t"},
+            ),
+            (
+                _FLOAT8_E4M3FN_CODE,
+                {
+                    "dtype_in": "__nv_fp8_e4m3",
+                    "cutlass_dtype_out": "cutlass::bfloat16_t",
+                },
+            ),
+        ],
+    ),
+    (
+        "int qo_tile_size",
+        [
+            (128, {"tile_q": "_128", "tile_kv": "_256", "thread_shape": "_1, _2, _1"}),
+            (256, {"tile_q": "_256", "tile_kv": "_128", "thread_shape": "_2, _1, _1"}),
+        ],
+    ),
+    (
+        "bool single_wg",
+        [
+            ("true", {"single_wg": "true"}),
+            ("false", {"single_wg": "false"}),
+        ],
+    ),
+    (
+        "int sparse_mode",
+        [
+            (0, {"sparse_mode": "Sparse"}),
+            (1, {"sparse_mode": "Full"}),
+            (2, {"sparse_mode": "OnlyScore"}),
+            (None, {"sparse_mode": "Off"}),
+        ],
+    ),
+    (
+        "int page_size",
+        [
+            (-1, {"page_size": -1}),
+            (128, {"page_size": 128}),
+            # (256, {"page_size": 256}),
+        ],
+    ),
+    (
+        "bool split_kv",
+        [
+            ("false", {"is_split_kv": "false"}),
+            ("true", {"is_split_kv": "true"}),
+        ],
+    ),
+    ("int pack_factor", [(i, {"pack_factor": i}) for i in _PACK_FACTORS]),
+]
+
+_FMHA_SM100_IMPOSSIBLE = lambda p: (
+    (p.get("tile_q") == "_256" and p.get("single_wg") == "true")
+    or (p.get("tile_q") == "_256" and p.get("is_split_kv") == "true")
+    or (p.get("page_size") == -1 and p.get("sparse_mode") == "Sparse")
+    or (p.get("pack_factor", 1) > 1 and p.get("tile_q") == "_256")
+)
+
+
+def _dlpack_dtype_code(torch_dtype):
+    """Encode a torch dtype as a DLPack int64 code."""
+    import torch
+
+    _map = {
+        torch.float16: (2 << 16) | (16 << 8) | 1,
+        torch.bfloat16: (4 << 16) | (16 << 8) | 1,
+        torch.float32: (2 << 16) | (32 << 8) | 1,
+        torch.float8_e4m3fn: (12 << 16) | (8 << 8) | 1,
+        torch.float8_e5m2: (13 << 16) | (8 << 8) | 1,
+    }
+    return _map[torch_dtype]
+
+
+def _variant_key_from_runtime(
+    dtype_code, qo_tile_size, single_wg, sparse_mode, page_size, split_kv, pack_factor
+):
+    """Compute a variant key string from runtime parameters."""
+    dims = _FMHA_SM100_DISPATCH
+
+    def _match_idx(dim_values, runtime_val):
+        # Convert Python bool to string to match dispatch table ("true"/"false")
+        if isinstance(runtime_val, bool):
+            runtime_val = "true" if runtime_val else "false"
+        for idx, (match_val, _) in enumerate(dim_values):
+            if match_val is None:
+                return idx
+            if match_val == runtime_val:
+                return idx
+        return len(dim_values) - 1
+
+    runtime_vals = [
+        dtype_code,
+        qo_tile_size,
+        single_wg,
+        sparse_mode,
+        page_size,
+        split_kv,
+        pack_factor,
+    ]
+    indices = []
+    params = {}
+    for (_, dim_values), rv in zip(dims, runtime_vals):
+        idx = _match_idx(dim_values, rv)
+        indices.append(idx)
+        _, tparams = dim_values[idx]
+        params.update(tparams)
+
+    if _FMHA_SM100_IMPOSSIBLE(params):
+        raise ValueError(f"Impossible FMHA variant combination: {params}")
+
+    func_name = "fmha_sm100_" + "_".join(str(i) for i in indices)
+    variant_name = "_".join(str(i) for i in indices)
+    params["func_name"] = func_name
+    params["variant_name"] = variant_name
+    return variant_name, params
+
+
+def _get_tvm_ffi_include():
+    """Find TVM-FFI include directory."""
+    try:
+        import tvm_ffi
+
+        tvm_dir = Path(tvm_ffi.__path__[0])
+        inc = tvm_dir / "include"
+        if inc.exists():
+            return str(inc)
+        inc2 = tvm_dir.parent / "include"
+        if inc2.exists():
+            return str(inc2)
+    except ImportError:
+        pass
+    raise RuntimeError("Cannot find TVM-FFI include directory; install apache-tvm-ffi")
+
+
+def _get_cuda_home():
+    """Find CUDA toolkit root."""
+    if "CUDA_HOME" in os.environ:
+        return os.environ["CUDA_HOME"]
+    nvcc = shutil.which("nvcc")
+    if nvcc:
+        return str(Path(nvcc).resolve().parent.parent)
+    for p in ["/usr/local/cuda", "/opt/cuda"]:
+        if os.path.isdir(p):
+            return p
+    raise RuntimeError("Cannot find CUDA toolkit. Set CUDA_HOME.")
+
+
+_ALL_VARIANTS_SO = CACHE_BASE / "_all_variants" / "all_variants.so"
+
+
+def _get_nvcc_flags(cache_dir, fmha=True):
+    tvm_include = _get_tvm_ffi_include()
+    fmha_include = str(_FMHA_VARLEN_DIR / "include")
+    cutlass_dir = _find_cutlass_dir()
+    cutlass_include = str(cutlass_dir / "include")
+    cutlass_util_include = str(cutlass_dir / "tools" / "util" / "include")
+    nvcc_flags = [
+        "-O3",
+        "-std=c++20",
+        "--expt-relaxed-constexpr",
+        "--expt-extended-lambda",
+        "-gencode=arch=compute_100a,code=sm_100a",
+        "-gencode=arch=compute_103a,code=sm_103a",
+        "-static-global-template-stub=false",
+        "-DFLASHINFER_ENABLE_BF16",
+        "-DFLASHINFER_ENABLE_FP8_E4M3",
+        "-DFLASHINFER_ENABLE_FP8_E5M2",
+        "-DFLASHINFER_ENABLE_FP8_E8M0",
+        "-DFLASHINFER_ENABLE_FP4_E2M1",
+        "-DFLASHINFER_ENABLE_F16",
+        "-U__CUDA_NO_HALF_OPERATORS__",
+        "-U__CUDA_NO_HALF_CONVERSIONS__",
+        "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+        "-Xcudafe --diag_suppress=2908",
+        f"-I{fmha_include}",
+        f"-I{cutlass_include}",
+        f"-I{cutlass_util_include}",
+        f"-I{tvm_include}",
+        f"-I{cache_dir}",
+        "-use_fast_math",
+        "-DNDEBUG",
+        "-Xptxas",
+        "-O1" if fmha else "-O3",
+        "-Xcompiler",
+        "-fPIC",
+    ]
+    if os.environ.get("GPU_TRACE") is not None:
+        nvcc_flags.append("-DGPU_TRACE_ENABLED")
+    if os.environ.get("SM_TIMING") is not None:
+        nvcc_flags.append("-DSM_TIMING_ENABLED")
+    if os.environ.get("FMHA_GMEM_CHECK") is not None:
+        nvcc_flags.append("-DFMHA_GMEM_BOUNDS_CHECK")
+    return " ".join(nvcc_flags)
+
+
+class _VariantWrapper:
+    """Wraps a TVM-FFI function to look like a module with .run()."""
+
+    def __init__(self, fn):
+        self._fn = fn
+
+    def run(self, *args):
+        return self._fn(*args)
+
+
+class FMHAVariantManager:
+    """Manages FMHA variant kernels. Loads from all_variants.so or per-variant .so."""
+
+    def __init__(self):
+        self._loaded = {}
+        self._lock = threading.Lock()
+        self._all_module = None
+        self._all_module_checked = False
+        self._inst_template = None
+        self._run_template = None
+
+    def _load_templates(self):
+        if self._inst_template is None:
+            with open(_FMHA_VARLEN_DIR / "fmha_sm100_inst.jinja") as f:
+                self._inst_template = jinja2.Template(f.read())
+            with open(_FMHA_VARLEN_DIR / "fmha_sm100_variant_run.cu.jinja") as f:
+                self._run_template = jinja2.Template(f.read())
+
+    def _ensure_all_module(self):
+        if not self._all_module_checked:
+            self._all_module_checked = True
+            if _ALL_VARIANTS_SO.exists():
+                import tvm_ffi
+
+                self._all_module = tvm_ffi.load_module(str(_ALL_VARIANTS_SO))
+
+    def get_variant(
+        self,
+        dtype_code,
+        qo_tile_size,
+        single_wg,
+        sparse_mode,
+        page_size,
+        split_kv,
+        pack_factor,
+    ):
+        variant_name, params = _variant_key_from_runtime(
+            dtype_code,
+            qo_tile_size,
+            single_wg,
+            sparse_mode,
+            page_size,
+            split_kv,
+            pack_factor,
+        )
+
+        cached = self._loaded.get(variant_name)
+        if cached is not None:
+            return cached
+
+        with self._lock:
+            cached = self._loaded.get(variant_name)
+            if cached is not None:
+                return cached
+
+            fn_name = f"run_{variant_name}"
+
+            # Try all_variants.so
+            self._ensure_all_module()
+            if self._all_module is not None:
+                try:
+                    fn = getattr(self._all_module, fn_name)
+                    self._loaded[variant_name] = _VariantWrapper(fn)
+                    return self._loaded[variant_name]
+                except AttributeError:
+                    pass
+
+            # Try per-variant .so
+            cache_dir = CACHE_BASE / variant_name
+            so_path = cache_dir / f"{variant_name}.so"
+            lock_fd = _acquire_file_lock(cache_dir / ".compile.lock")
+            try:
+                if not so_path.exists():
+                    self._compile_only(variant_name, params)
+
+                import tvm_ffi
+
+                module = tvm_ffi.load_module(str(so_path))
+                fn = getattr(module, fn_name)
+            finally:
+                _release_file_lock(lock_fd)
+            self._loaded[variant_name] = _VariantWrapper(fn)
+            return self._loaded[variant_name]
+
+    def _compile_only(self, variant_name, params):
+        """Compile a variant without loading. Safe to call from subprocesses."""
+        cache_dir = CACHE_BASE / variant_name
+        so_path = cache_dir / f"{variant_name}.so"
+
+        if so_path.exists():
+            return
+
+        logger.info(f"JIT compiling FMHA variant: {variant_name}")
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+        self._load_templates()
+
+        inst_cu = cache_dir / f"fmha_sm100_inst_{variant_name}.cu"
+        run_cu = cache_dir / f"fmha_sm100_run_{variant_name}.cu"
+
+        inst_cu.write_text(self._inst_template.render(**params))
+        run_cu.write_text(self._run_template.render(**params))
+
+        for name in ["fmha_sm100_params.h", "tvm_ffi_utils.h", "gmem_bounds_check.h"]:
+            src = _FMHA_VARLEN_DIR / name
+            dst = cache_dir / name
+            if not dst.exists() or dst.read_text() != src.read_text():
+                shutil.copy2(src, dst)
+
+        self._write_ninja(cache_dir, variant_name, inst_cu, run_cu)
+        self._run_ninja(cache_dir)
+
+    def _write_ninja(self, cache_dir, variant_name, inst_cu, run_cu):
+        cuda_home = _get_cuda_home()
+        nvcc = os.path.join(cuda_home, "bin", "nvcc")
+
+        nvcc_flags = _get_nvcc_flags(cache_dir)
+
+        so_path = cache_dir / f"{variant_name}.so"
+        inst_obj = cache_dir / f"inst_{variant_name}.o"
+        run_obj = cache_dir / f"run_{variant_name}.o"
+
+        ninja_content = f"""ninja_required_version = 1.5
+
+nvcc = {nvcc}
+nvcc_flags = {nvcc_flags}
+
+rule nvcc_compile
+  command = $nvcc $nvcc_flags -c $in -o $out
+  description = Compiling $in
+
+rule nvcc_link
+  command = $nvcc -shared $in -o $out -lcuda
+  description = Linking $out
+
+build {inst_obj}: nvcc_compile {inst_cu}
+build {run_obj}: nvcc_compile {run_cu}
+build {so_path}: nvcc_link {inst_obj} {run_obj}
+"""
+        (cache_dir / "build.ninja").write_text(ninja_content)
+
+    def _run_ninja(self, cache_dir):
+        result = subprocess.run(
+            ["ninja", "-j1"],
+            cwd=str(cache_dir),
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"FMHA variant compilation failed:\n"
+                f"stdout: {result.stdout}\n"
+                f"stderr: {result.stderr}"
+            )
+
+
+_variant_manager = FMHAVariantManager()
+
+
+def get_fmha_variant(
+    dtype_code, qo_tile_size, single_wg, sparse_mode, page_size, split_kv, pack_factor
+):
+    """Get a compiled FMHA variant module. Thread-safe, lazy compilation."""
+    return _variant_manager.get_variant(
+        dtype_code,
+        qo_tile_size,
+        single_wg,
+        sparse_mode,
+        page_size,
+        split_kv,
+        pack_factor,
+    )
+
+
+# ============================================================================
+# Plan kernel JIT (also needs sm_100a, can't be statically compiled)
+# ============================================================================
+
+_plan_module = None
+_plan_lock = threading.Lock()
+
+
+def _do_compile_plan():
+    """Generate and compile plan kernel. No TVM loading."""
+    cache_dir = CACHE_BASE / "plan"
+    so_path = cache_dir / "fmha_sm100_plan.so"
+
+    if so_path.exists():
+        return
+
+    logger.info("JIT compiling FMHA plan module")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    plan_cu = _FMHA_VARLEN_DIR / "fmha_sm100_plan.cu"
+    shutil.copy2(plan_cu, cache_dir / "fmha_sm100_plan.cu")
+
+    cuda_home = _get_cuda_home()
+    nvcc = os.path.join(cuda_home, "bin", "nvcc")
+
+    obj = cache_dir / "fmha_sm100_plan.o"
+
+    nvcc_flags = _get_nvcc_flags(cache_dir, False)
+
+    ninja_content = f"""ninja_required_version = 1.5
+
+nvcc = {nvcc}
+nvcc_flags = {nvcc_flags}
+
+rule nvcc_compile
+  command = $nvcc $nvcc_flags -c $in -o $out
+  description = Compiling $in
+
+rule nvcc_link
+  command = $nvcc -shared $in -o $out -lcuda
+  description = Linking $out
+
+build {obj}: nvcc_compile {cache_dir / "fmha_sm100_plan.cu"}
+build {so_path}: nvcc_link {obj}
+"""
+    (cache_dir / "build.ninja").write_text(ninja_content)
+
+    result = subprocess.run(
+        ["ninja", "-j1"],
+        cwd=str(cache_dir),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"FMHA plan compilation failed:\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+
+
+def _compile_plan_only():
+    """Compile plan kernel without loading. Safe for subprocesses."""
+    _do_compile_plan()
+
+
+def _compile_plan_module():
+    """Compile and load plan kernel."""
+    lock_fd = _acquire_file_lock(CACHE_BASE / "plan.lock")
+    try:
+        _do_compile_plan()
+        import tvm_ffi
+
+        so_path = CACHE_BASE / "plan" / "fmha_sm100_plan.so"
+        return tvm_ffi.load_module(str(so_path))
+    finally:
+        _release_file_lock(lock_fd)
+
+
+def get_plan_fn():
+    """Get the plan function. JIT compiles on first call."""
+    global _plan_module
+    if _plan_module is not None:
+        return _plan_module
+
+    with _plan_lock:
+        if _plan_module is not None:
+            return _plan_module
+        _plan_module = _compile_plan_module()
+        return _plan_module
+
+
+# ============================================================================
+# Sparse TopK Select kernel JIT
+# ============================================================================
+
+_sparse_topk_module = None
+_sparse_topk_lock = threading.Lock()
+
+
+def _do_compile_sparse_topk():
+    cache_dir = CACHE_BASE / "sparse_topk"
+    so_path = cache_dir / "sparse_topk_select.so"
+
+    tracked_sources = [
+        _FMHA_VARLEN_DIR / "sparse_topk_select.cu",
+        _FMHA_VARLEN_DIR / "include" / "sparse_topk_select.cuh",
+        _FMHA_VARLEN_DIR / "tvm_ffi_utils.h",
+    ]
+    needs_rebuild = not so_path.exists()
+    for src in tracked_sources:
+        dst = cache_dir / src.name
+        if not dst.exists() or dst.read_text() != src.read_text():
+            needs_rebuild = True
+
+    if not needs_rebuild:
+        return
+
+    logger.info("JIT compiling sparse_topk_select module")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    src_cu = _FMHA_VARLEN_DIR / "sparse_topk_select.cu"
+    shutil.copy2(src_cu, cache_dir / "sparse_topk_select.cu")
+    shutil.copy2(
+        _FMHA_VARLEN_DIR / "include" / "sparse_topk_select.cuh",
+        cache_dir / "sparse_topk_select.cuh",
+    )
+    shutil.copy2(_FMHA_VARLEN_DIR / "tvm_ffi_utils.h", cache_dir / "tvm_ffi_utils.h")
+
+    cuda_home = _get_cuda_home()
+    nvcc = os.path.join(cuda_home, "bin", "nvcc")
+
+    obj = cache_dir / "sparse_topk_select.o"
+    cached_cu = cache_dir / "sparse_topk_select.cu"
+    cached_cuh = cache_dir / "sparse_topk_select.cuh"
+    cached_ffi_header = cache_dir / "tvm_ffi_utils.h"
+
+    nvcc_flags = _get_nvcc_flags(cache_dir, False)
+
+    ninja_content = f"""ninja_required_version = 1.5
+
+nvcc = {nvcc}
+nvcc_flags = {nvcc_flags}
+
+rule nvcc_compile
+  command = $nvcc $nvcc_flags -c $in -o $out
+  description = Compiling $in
+
+rule nvcc_link
+  command = $nvcc -shared $in -o $out -lcuda
+  description = Linking $out
+
+build {obj}: nvcc_compile {cached_cu} | {cached_cuh} {cached_ffi_header}
+build {so_path}: nvcc_link {obj}
+"""
+    (cache_dir / "build.ninja").write_text(ninja_content)
+
+    result = subprocess.run(
+        ["ninja", "-j1"],
+        cwd=str(cache_dir),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"sparse_topk_select compilation failed:\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+
+
+def get_sparse_topk_module():
+    """Get the sparse_topk_select module. JIT compiles on first call."""
+    global _sparse_topk_module
+    if _sparse_topk_module is not None:
+        return _sparse_topk_module
+
+    with _sparse_topk_lock:
+        if _sparse_topk_module is not None:
+            return _sparse_topk_module
+        lock_fd = _acquire_file_lock(CACHE_BASE / "sparse_topk.lock")
+        try:
+            _do_compile_sparse_topk()
+            import tvm_ffi
+
+            so_path = CACHE_BASE / "sparse_topk" / "sparse_topk_select.so"
+            _sparse_topk_module = tvm_ffi.load_module(str(so_path))
+            _sparse_topk_module.sparse_topk_select_init()
+        finally:
+            _release_file_lock(lock_fd)
+        return _sparse_topk_module
+
+
+# ============================================================================
+# Split-KV reduction kernel JIT
+# ============================================================================
+
+_reduction_module = None
+_reduction_lock = threading.Lock()
+
+
+def _do_compile_reduction():
+    cache_dir = CACHE_BASE / "reduction"
+    so_path = cache_dir / "fmha_sm100_reduction.so"
+
+    if so_path.exists():
+        return
+
+    logger.info("JIT compiling fmha_sm100_reduction module")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    src_cu = _FMHA_VARLEN_DIR / "fmha_sm100_reduction.cu"
+    shutil.copy2(src_cu, cache_dir / "fmha_sm100_reduction.cu")
+    for name in ["gmem_bounds_check.h"]:
+        src = _FMHA_VARLEN_DIR / name
+        dst = cache_dir / name
+        if src.exists() and (not dst.exists() or dst.read_text() != src.read_text()):
+            shutil.copy2(src, dst)
+
+    cuda_home = _get_cuda_home()
+    nvcc = os.path.join(cuda_home, "bin", "nvcc")
+
+    obj = cache_dir / "fmha_sm100_reduction.o"
+
+    nvcc_flags = _get_nvcc_flags(cache_dir, False)
+
+    ninja_content = f"""ninja_required_version = 1.5
+
+nvcc = {nvcc}
+nvcc_flags = {nvcc_flags}
+
+rule nvcc_compile
+  command = $nvcc $nvcc_flags -c $in -o $out
+  description = Compiling $in
+
+rule nvcc_link
+  command = $nvcc -shared $in -o $out -lcuda
+  description = Linking $out
+
+build {obj}: nvcc_compile {cache_dir / "fmha_sm100_reduction.cu"}
+build {so_path}: nvcc_link {obj}
+"""
+    (cache_dir / "build.ninja").write_text(ninja_content)
+
+    result = subprocess.run(
+        ["ninja", "-j1"],
+        cwd=str(cache_dir),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"fmha_sm100_reduction compilation failed:\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+
+
+def get_reduction_module():
+    """Get the split-KV reduction module. JIT compiles on first call."""
+    global _reduction_module
+    if _reduction_module is not None:
+        return _reduction_module
+
+    with _reduction_lock:
+        if _reduction_module is not None:
+            return _reduction_module
+        lock_fd = _acquire_file_lock(CACHE_BASE / "reduction.lock")
+        try:
+            _do_compile_reduction()
+            import tvm_ffi
+
+            so_path = CACHE_BASE / "reduction" / "fmha_sm100_reduction.so"
+            _reduction_module = tvm_ffi.load_module(str(so_path))
+        finally:
+            _release_file_lock(lock_fd)
+        return _reduction_module

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/sparse_fmha_adapter.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/msa/sparse_fmha_adapter.py
@@ -1,0 +1,452 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 MiniMax
+# SPDX-License-Identifier: MIT
+
+"""Drop-in adapter: fmha_sm100 API → sparse_atten_func backend.
+
+Usage:
+    from minfer.ops.sparse_fmha_adapter import sparse_fmha_plan, sparse_fmha
+
+    plan_info = sparse_fmha_plan(qo_lens, kv_lens, num_qo_heads, ...)
+    out, _ = sparse_fmha(q, k, v, plan_info=plan_info,
+                         kv_indices=kv_indices,
+                         kv_block_indexes=kv_block_indexes)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Optional, Tuple
+
+import torch
+
+_MM_SPARSE_DIR = os.path.join(os.path.dirname(__file__), ".", "cute")
+if os.path.isdir(_MM_SPARSE_DIR) and _MM_SPARSE_DIR not in sys.path:
+    sys.path.insert(0, os.path.abspath(_MM_SPARSE_DIR))
+
+from interface import sparse_atten_func
+from sparse_index_utils import build_k2q_csr
+from src.common.aot_cache import _key_to_path
+from src.sm100.prepare_scheduler import SPARSE_SCHEDULE_MODEL
+
+
+def _compute_aot_kernel_paths(
+    head_dim,
+    n_block_size,
+    qhead_per_kv,
+    topk,
+    causal,
+    dtype=torch.bfloat16,
+    partial_dtype=torch.float32,
+):
+    fwd_key = (
+        "sparse_forward_sm100_csr_varlen",
+        head_dim,
+        n_block_size,
+        qhead_per_kv,
+        dtype,
+        partial_dtype,
+        bool(causal),
+        True,
+        True,
+        n_block_size,
+        True,
+        False,
+    )
+    k_block_size = 128 if head_dim > 64 else 64
+    try:
+        import cutlass
+
+        cutlass_partial = cutlass.Float32
+        cutlass_out = cutlass.BFloat16
+    except ImportError:
+        cutlass_partial = partial_dtype
+        cutlass_out = dtype
+    combine_key = (
+        "combine",
+        head_dim,
+        k_block_size,
+        64,
+        topk,
+        cutlass_partial,
+        cutlass_out,
+        True,
+        False,
+        True,
+        False,
+        True,
+        True,
+    )
+    fwd_path = _key_to_path(fwd_key) + ".o"
+    combine_path = _key_to_path(combine_key) + ".o"
+    return {
+        "fwd_kernel_path": fwd_path if os.path.isfile(fwd_path) else "",
+        "combine_kernel_path": combine_path if os.path.isfile(combine_path) else "",
+        "fwd_func_name": str(fwd_key[0]),
+        "combine_func_name": str(combine_key[0]),
+    }
+
+
+def sparse_fmha_plan(
+    qo_segment_lens: torch.Tensor,
+    kv_segment_lens: torch.Tensor,
+    num_qo_heads: int,
+    num_kv_heads: int = -1,
+    qo_offset: Optional[torch.Tensor] = None,
+    num_kv_splits: int = -1,
+    page_size: int = -1,
+    output_maxscore: bool = False,
+    kv_block_num: int = -1,
+    causal: bool = True,
+    usable_SM_count=-1,
+    use_fp8_kvcache: bool = False,
+) -> dict:
+    """Build a reusable sparse-prefill plan for the MM-Sparse backend.
+
+    This is the sparse prefill implementation used behind ``fmha_sm100_plan``
+    when ``kv_block_num > 0`` and the selected sparse mode is prefill.
+
+    Parameters
+    ----------
+    qo_segment_lens : torch.Tensor
+        Shape ``[batch_size]``.  Per-request Q lengths.
+    kv_segment_lens : torch.Tensor
+        Shape ``[batch_size]``.  Per-request KV lengths.
+    num_qo_heads : int
+        Number of Q/O heads.
+    num_kv_heads : int, optional
+        Number of KV heads.  Required for GQA planning; ``num_qo_heads`` must
+        be divisible by this value.
+    qo_offset : torch.Tensor, optional
+        Shape ``[batch_size]``.  Per-request causal offset.  If omitted,
+        ``seqused_k`` is derived from ``kv_segment_lens``.
+    num_kv_splits : int, optional
+        Reserved for API compatibility with dense ``fmha_sm100_plan``.
+    page_size : int, optional
+        KV page/block size.  Sparse prefill requires paged KV, so this must be
+        positive and is normally 128.
+    output_maxscore : bool, optional
+        Sparse prefill backend does not emit max-score tensors; must be False.
+    kv_block_num : int, optional
+        Number of selected KV blocks per query.  Supported values are
+        ``4, 8, 16, 32``.
+    causal : bool, optional
+        Whether to apply causal masking.  Current backend requires True.
+    usable_SM_count : int, optional
+        Maximum number of SMs used by the sparse scheduler.  ``-1`` uses all
+        available SMs.
+    use_fp8_kvcache : bool, optional
+        If True, compute AOT lookup keys for FP8 K/V cache kernels.
+
+    Returns
+    -------
+    dict
+        Plan dictionary consumed by ``sparse_fmha`` and by ``fmha_sm100``'s
+        sparse-prefill path.
+    """
+    assert kv_block_num in {4, 8, 16, 32}, f"kv_block_num={kv_block_num}"
+    assert page_size >= 1, f"page_size={page_size}"
+    assert output_maxscore == False
+    assert causal == True
+
+    batch = qo_segment_lens.shape[0]
+    gpu_device = torch.device("cuda")
+
+    cu_seqlens_q = torch.zeros(batch + 1, dtype=torch.int32, device=gpu_device)
+    cu_seqlens_q[1:] = torch.cumsum(
+        qo_segment_lens.to(torch.int32).to(gpu_device), dim=0
+    )
+
+    cu_seqlens_k = torch.zeros(batch + 1, dtype=torch.int32, device=gpu_device)
+    cu_seqlens_k[1:] = torch.cumsum(
+        kv_segment_lens.to(torch.int32).to(gpu_device), dim=0
+    )
+
+    max_seqlen_q = int(qo_segment_lens.max().item())
+    max_seqlen_k = int(kv_segment_lens.max().item())
+    total_k = int(kv_segment_lens.sum().item())
+    blk_kv = page_size
+
+    kv_lens = kv_segment_lens.tolist()
+    total_rows = sum((int(kl) + blk_kv - 1) // blk_kv for kl in kv_lens)
+
+    if qo_offset is not None:
+        seqused_k = (qo_segment_lens + qo_offset).to(torch.int32).to(gpu_device)
+    else:
+        seqused_k = kv_segment_lens.to(torch.int32).to(gpu_device)
+
+    total_q = int(cu_seqlens_q[-1].item())
+    qhead_per_kv = num_qo_heads // num_kv_heads if num_kv_heads > 0 else 1
+
+    target_q_per_cta = SPARSE_SCHEDULE_MODEL.balanced_target_q_per_cta(
+        total_q=total_q,
+        topk=kv_block_num,
+        blk_kv=page_size,
+        head_kv=num_kv_heads,
+        qhead_per_kv=qhead_per_kv,
+        device=gpu_device,
+        usable_SM_count=usable_SM_count,
+    )
+    scheduler_metadata_capacity = SPARSE_SCHEDULE_MODEL.flat_schedule_capacity(
+        total_rows=total_rows,
+        total_q=total_q,
+        topk=kv_block_num,
+        head_kv=num_kv_heads,
+        target_q_per_cta=target_q_per_cta,
+    )
+
+    return {
+        "qo_segment_lens": qo_segment_lens,
+        "cu_seqlens_q": cu_seqlens_q,
+        "qo_segment_offsets": cu_seqlens_q,
+        "cu_seqlens_k": cu_seqlens_k,
+        "kv_segment_lens": kv_segment_lens.to(torch.int32).to(gpu_device),
+        "seqused_k": seqused_k,
+        "max_seqlen_q": max_seqlen_q,
+        "max_seqlen_k": max_seqlen_k,
+        "total_k": total_k,
+        "total_rows": total_rows,
+        "num_qo_heads": num_qo_heads,
+        "page_size": page_size,
+        "blk_kv": blk_kv,
+        "kv_block_num": kv_block_num,
+        "causal": causal,
+        "batch": batch,
+        "MM-SA-Nv": True,
+        "usable_SM_count": usable_SM_count,
+        "num_kv_heads": num_kv_heads,
+        "qhead_per_kv": qhead_per_kv,
+        "target_q_per_cta": target_q_per_cta,
+        "scheduler_metadata_capacity": scheduler_metadata_capacity,
+        **_compute_aot_kernel_paths(
+            head_dim=128,
+            n_block_size=page_size,
+            qhead_per_kv=qhead_per_kv,
+            topk=kv_block_num,
+            causal=causal,
+            dtype=torch.float8_e4m3fn if use_fp8_kvcache else torch.bfloat16,
+        ),
+    }
+
+
+def _convert_kv_block_indexes_to_q2k(
+    kv_block_indexes: torch.Tensor,
+    num_kv_heads: int,
+    num_qo_heads: int,
+    qhead_per_kv: int,
+) -> torch.Tensor:
+    """kv_block_indexes [total_q, H, topk] → q2k [H_kv, total_q, topk]."""
+    h_dim = kv_block_indexes.shape[1]
+    if h_dim == num_kv_heads:
+        q2k = kv_block_indexes.permute(1, 0, 2).contiguous()
+    elif h_dim == num_qo_heads and num_qo_heads != num_kv_heads:
+        q2k = kv_block_indexes[:, ::qhead_per_kv, :].permute(1, 0, 2).contiguous()
+    else:
+        raise ValueError(
+            f"kv_block_indexes head dim {h_dim} doesn't match "
+            f"num_kv_heads={num_kv_heads} or num_qo_heads={num_qo_heads}"
+        )
+    return q2k.to(torch.int32)
+
+
+def _build_page_table(
+    kv_indices: torch.Tensor,
+    kv_segment_lens: torch.Tensor,
+    page_size: int,
+    batch: int,
+) -> torch.Tensor:
+    """Flat kv_indices → page_table [batch, max_pages_per_seq]."""
+    kv_lens = kv_segment_lens.tolist()
+    pages_per_batch = [(int(kl) + page_size - 1) // page_size for kl in kv_lens]
+    max_pages = max(pages_per_batch)
+    total = batch * max_pages
+    buf = torch.zeros(total + 4, dtype=torch.int32, device=kv_indices.device)
+    shift = ((-buf.data_ptr()) % 16) // 4
+    page_table = buf[shift : shift + total].view(batch, max_pages)
+    assert page_table.data_ptr() % 16 == 0, (
+        f"_build_page_table failed to align: buf=0x{buf.data_ptr():x} "
+        f"shift={shift} page_table=0x{page_table.data_ptr():x}"
+    )
+    offset = 0
+    for b in range(batch):
+        n = pages_per_batch[b]
+        page_table[b, :n] = kv_indices[offset : offset + n].to(torch.int32)
+        offset += n
+    return page_table
+
+
+def sparse_fmha(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    plan_info: dict,
+    out: Optional[torch.Tensor] = None,
+    max_score: Optional[torch.Tensor] = None,
+    sm_scale: Optional[float] = None,
+    q_scale: Optional[float] = None,
+    k_scale: Optional[float] = None,
+    v_scale: Optional[float] = None,
+    o_scale: Optional[float] = None,
+    kv_indices: Optional[torch.Tensor] = None,
+    output_maxscore: bool = True,
+    output_o: bool = True,
+    kv_block_indexes: Optional[torch.Tensor] = None,
+    q_offset_override=None,
+    check_input_valid: bool = False,
+) -> Tuple[torch.Tensor, None]:
+    """Run sparse prefill through ``sparse_atten_func`` using an FMHA-style API.
+
+    Parameters
+    ----------
+    q : torch.Tensor
+        Shape ``[total_q, num_qo_heads, 128]``.  BF16 or FP8 E4M3.
+    k : torch.Tensor
+        Paged KV tensor with shape ``[total_pages, num_kv_heads, page_size, 128]``.
+    v : torch.Tensor
+        Same layout as ``k``.
+    plan_info : dict
+        Plan returned by ``sparse_fmha_plan``.
+    out : torch.Tensor, optional
+        Accepted for compatibility.  If supplied, the result is copied into it.
+    max_score : torch.Tensor, optional
+        Accepted for compatibility.  Sparse prefill does not produce max-score
+        output and returns ``None`` for this slot.
+    sm_scale : float, optional
+        Softmax scale.  Defaults to ``1 / sqrt(head_dim)``.
+    q_scale, k_scale, v_scale, o_scale : float, optional
+        Accepted for FMHA API compatibility; only ``sm_scale`` is used by this
+        backend.
+    kv_indices : torch.Tensor, optional
+        Flattened physical page table with dtype int32.  Required for paged KV.
+    output_maxscore : bool, optional
+        Accepted for compatibility; sparse prefill returns no max-score tensor.
+    output_o : bool, optional
+        Accepted for compatibility.  The sparse backend always computes O.
+    kv_block_indexes : torch.Tensor
+        Shape ``[total_q, num_kv_heads or num_qo_heads, topK]``.  Sparse KV
+        block indices in ascending order with ``-1`` padding.
+    q_offset_override : int or torch.Tensor, optional
+        Runtime causal-offset override.  Tensor form has shape ``[batch_size]``.
+    check_input_valid : bool, optional
+        Reserved for compatibility with ``fmha_sm100``.
+
+    Returns
+    -------
+    tuple[torch.Tensor, None]
+        Output tensor and ``None`` for max-score output.
+    """
+    if kv_block_indexes is None:
+        raise ValueError("sparse_fmha requires kv_block_indexes")
+
+    qo_segment_lens = plan_info["qo_segment_lens"]
+    cu_seqlens_q = plan_info["cu_seqlens_q"]
+    cu_seqlens_k = plan_info["cu_seqlens_k"]
+    num_qo_heads = plan_info["num_qo_heads"]
+    num_kv_heads = k.shape[1]
+    qhead_per_kv = num_qo_heads // num_kv_heads
+    assert qhead_per_kv in {1, 2, 4, 8, 16}, f"qhead_per_kv={qhead_per_kv}"
+    page_size = plan_info["page_size"]
+    blk_kv = plan_info["blk_kv"]
+    topk = plan_info["kv_block_num"]
+    causal = plan_info["causal"]
+    max_seqlen_q = plan_info["max_seqlen_q"]
+    max_seqlen_k = plan_info["max_seqlen_k"]
+    total_k = plan_info["total_k"]
+    total_rows = plan_info["total_rows"]
+    batch = plan_info["batch"]
+    kv_segment_lens = plan_info["kv_segment_lens"]
+    usable_SM_count = int(plan_info.get("usable_SM_count", -1))
+
+    if isinstance(q_offset_override, int):
+        q_offset_override = torch.full_like(qo_segment_lens, q_offset_override)
+    elif q_offset_override is not None:
+        assert q_offset_override.device == qo_segment_lens.device
+
+    if q_offset_override is not None:
+        seqused_k = (
+            (qo_segment_lens + q_offset_override)
+            .to(torch.int32)
+            .to(qo_segment_lens.device)
+        )
+    else:
+        seqused_k = plan_info["seqused_k"]
+
+    q2k = _convert_kv_block_indexes_to_q2k(
+        kv_block_indexes,
+        num_kv_heads,
+        num_qo_heads,
+        qhead_per_kv,
+    )
+
+    is_paged = page_size > 0 and k.ndim == 4
+
+    page_table = None
+    if is_paged:
+
+        if kv_indices is not None:
+            page_table = _build_page_table(
+                kv_indices,
+                kv_segment_lens,
+                page_size,
+                batch,
+            )
+
+    # build_k2q_csr(return_schedule=True) builds schedule using hardware SM count internally
+    # (build_k2q_csr_native.cu), which ignores usable_SM_count. When SM-limited, skip its
+    # schedule and let prepare_scheduler build one that respects usable_SM_count.
+    if usable_SM_count > 0:
+        k2q_row_ptr, k2q_q_indices = build_k2q_csr(
+            q2k,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            blk_kv,
+            total_k=total_k,
+            max_seqlen_k=max_seqlen_k,
+            max_seqlen_q=max_seqlen_q,
+            total_rows=total_rows,
+            qhead_per_kv=qhead_per_kv,
+            return_schedule=False,
+        )
+        schedule = None
+    else:
+        k2q_row_ptr, k2q_q_indices, schedule = build_k2q_csr(
+            q2k,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            blk_kv,
+            total_k=total_k,
+            max_seqlen_k=max_seqlen_k,
+            max_seqlen_q=max_seqlen_q,
+            total_rows=total_rows,
+            qhead_per_kv=qhead_per_kv,
+            return_schedule=True,
+        )
+
+    softmax_scale = sm_scale if sm_scale is not None else q.shape[-1] ** -0.5
+
+    # print(q.shape, k.shape)
+    result = sparse_atten_func(
+        q,
+        k,
+        v,
+        k2q_row_ptr,
+        k2q_q_indices,
+        topk,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        blk_kv=blk_kv,
+        causal=causal,
+        softmax_scale=softmax_scale,
+        return_softmax_lse=False,
+        page_table=page_table,
+        seqused_k=seqused_k,
+        schedule=schedule,
+        usable_SM_count=usable_SM_count,
+    )
+
+    if out is not None:
+        out.copy_(result)
+        return out, None
+    return result, None

--- a/tokenspeed-kernel/test/ops/test_attention_msa.py
+++ b/tokenspeed-kernel/test/ops/test_attention_msa.py
@@ -715,3 +715,141 @@ def test_msa_cute_extend_wins_selection_and_decode_stays_triton() -> None:
         solution="triton", k_scale=0.25, v_scale=0.5, **kwargs
     )
     torch.testing.assert_close(out_default, out_triton, atol=0.0, rtol=0.0)
+
+
+def _cutedsl_decode_score_available() -> bool:
+    from tokenspeed_kernel.platform import current_platform
+
+    if not current_platform().is_blackwell:
+        return False
+    try:
+        from tokenspeed_kernel.ops.attention.cute_dsl import (  # noqa: F401
+            minimax_index_decode_score,
+        )
+    except ImportError:
+        return False
+    return True
+
+
+@pytest.mark.skipif(
+    not _cutedsl_decode_score_available(),
+    reason="CuteDSL index decode score requires SM100 and cutlass-dsl",
+)
+@pytest.mark.parametrize(
+    "decode_query_len,seq_list",
+    [
+        (1, [300, 1000, 129]),
+        (4, [300, 1000, 132]),
+        (1, [70000]),
+    ],
+)
+def test_cutedsl_decode_score_matches_triton(
+    decode_query_len: int, seq_list: list[int]
+) -> None:
+    import tokenspeed_kernel.ops.attention.triton.minimax_indexer as mi
+    import triton
+    from tokenspeed_kernel.ops.attention.cute_dsl.minimax_index_decode_score import (
+        decode_score_supported,
+        minimax_index_decode_score,
+    )
+
+    torch.manual_seed(0)
+    device = "cuda"
+    heads, head_dim, block_k = 4, 128, 128
+    scale = head_dim**-0.5
+    init_blocks, local_blocks = 1, 2
+
+    requests = len(seq_list)
+    tokens = requests * decode_query_len
+    seq_lens = torch.tensor(seq_list, device=device, dtype=torch.int32)
+    max_blocks = ((max(seq_list) + block_k - 1) // block_k + 3) // 4 * 4
+    pages = requests * max_blocks
+    cache_pages = torch.randn(
+        pages, block_k, head_dim, device=device, dtype=torch.bfloat16
+    )
+    block_table = torch.arange(pages, device=device, dtype=torch.int32).view(
+        requests, max_blocks
+    )
+    index_q = torch.randn(tokens, heads, head_dim, device=device, dtype=torch.bfloat16)
+    assert decode_score_supported(index_q, cache_pages, decode_query_len, max_blocks)
+
+    scores_cute = torch.full(
+        (tokens, heads, max_blocks),
+        -float("inf"),
+        dtype=torch.float32,
+        device=device,
+    )
+    minimax_index_decode_score(
+        index_q,
+        cache_pages,
+        scores_cute,
+        block_table,
+        seq_lens,
+        scale=scale,
+        init_blocks=init_blocks,
+        local_blocks=local_blocks,
+        decode_query_len=decode_query_len,
+    )
+
+    scores_triton = torch.full_like(scores_cute, -float("inf"))
+    num_chunks = 64
+    mi._decode_block_score_kernel[(requests, num_chunks)](
+        index_q,
+        cache_pages,
+        scores_triton,
+        block_table,
+        seq_lens,
+        num_index_heads=heads,
+        scale=scale,
+        init_blocks=init_blocks,
+        local_blocks=local_blocks,
+        decode_query_len=decode_query_len,
+        max_blocks=max_blocks,
+        num_chunks=num_chunks,
+        stride_q_n=index_q.stride(0),
+        stride_q_h=index_q.stride(1),
+        stride_q_d=index_q.stride(2),
+        stride_k_page=cache_pages.stride(0),
+        stride_k_pos=cache_pages.stride(1),
+        stride_k_d=cache_pages.stride(2),
+        stride_s_n=scores_triton.stride(0),
+        stride_s_h=scores_triton.stride(1),
+        stride_s_b=scores_triton.stride(2),
+        stride_bt_b=block_table.stride(0),
+        head_dim=head_dim,
+        BLOCK_Q=triton.next_power_of_2(decode_query_len),
+        BLOCK_K=block_k,
+        num_warps=4,
+        num_stages=2,
+    )
+
+    # Forced (+inf) and unwritten (-inf) positions must agree exactly; finite
+    # scores are the same fp32 MMA math on both paths.
+    assert torch.equal(torch.isinf(scores_cute), torch.isinf(scores_triton))
+    assert torch.equal(scores_cute == float("inf"), scores_triton == float("inf"))
+    finite = torch.isfinite(scores_triton)
+    assert finite.any()
+    torch.testing.assert_close(
+        scores_cute[finite], scores_triton[finite], atol=2e-3, rtol=2e-3
+    )
+
+
+@pytest.mark.skipif(
+    not _cutedsl_decode_score_available(),
+    reason="CuteDSL index decode score requires SM100 and cutlass-dsl",
+)
+def test_cutedsl_decode_score_gates() -> None:
+    from tokenspeed_kernel.ops.attention.cute_dsl.minimax_index_decode_score import (
+        decode_score_supported,
+    )
+
+    device = "cuda"
+    q = torch.randn(4, 4, 128, device=device, dtype=torch.bfloat16)
+    pages = torch.randn(8, 128, 128, device=device, dtype=torch.bfloat16)
+    assert decode_score_supported(q, pages, 1, 8)
+    # Flattened Q tile too wide (4 heads x 16 queries > 32).
+    assert not decode_score_supported(q, pages, 16, 8)
+    # Non-4-aligned score tile dim.
+    assert not decode_score_supported(q, pages, 1, 7)
+    # Dtype mismatch between queries and cache.
+    assert not decode_score_supported(q, pages.to(torch.float8_e4m3fn), 1, 8)

--- a/tokenspeed-kernel/test/ops/test_attention_msa.py
+++ b/tokenspeed-kernel/test/ops/test_attention_msa.py
@@ -853,3 +853,146 @@ def test_cutedsl_decode_score_gates() -> None:
     assert not decode_score_supported(q, pages, 1, 7)
     # Dtype mismatch between queries and cache.
     assert not decode_score_supported(q, pages.to(torch.float8_e4m3fn), 1, 8)
+
+
+def _fmha_prefill_score_available() -> bool:
+    from tokenspeed_kernel.platform import current_platform
+
+    if not torch.cuda.is_available() or not current_platform().is_blackwell:
+        return False
+    try:
+        import tokenspeed_kernel.thirdparty.msa.jit  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+requires_fmha_prefill_score = pytest.mark.skipif(
+    not _fmha_prefill_score_available(),
+    reason="fmha OnlyScore prefill scorer requires SM100 and the vendored "
+    "msa JIT stack",
+)
+
+
+def _prefill_indexer_case(
+    qo_lens: list[int],
+    kv_lens: list[int],
+    query_lens_cpu: list[int] | None,
+    seq_lens_cpu: list[int] | None,
+) -> torch.Tensor:
+    device = "cuda"
+    heads, head_dim, block_k = 4, 128, 128
+    requests = len(qo_lens)
+    tokens = sum(qo_lens)
+    max_blocks = (max(kv_lens) + block_k - 1) // block_k
+    pages_per_req = [(k + block_k - 1) // block_k for k in kv_lens]
+    total_pages = sum(pages_per_req)
+    generator = torch.Generator(device=device).manual_seed(7)
+    perm = torch.randperm(total_pages, device=device, generator=generator).to(
+        torch.int32
+    )
+    block_table = torch.zeros(requests, max_blocks, device=device, dtype=torch.int32)
+    offset = 0
+    for request, num_pages in enumerate(pages_per_req):
+        block_table[request, :num_pages] = perm[offset : offset + num_pages]
+        offset += num_pages
+    index_k_cache = torch.randn(
+        total_pages * block_k,
+        head_dim,
+        device=device,
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    index_q = torch.randn(
+        tokens,
+        heads,
+        head_dim,
+        device=device,
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    index_k = torch.randn(
+        tokens, head_dim, device=device, dtype=torch.bfloat16, generator=generator
+    )
+    slots = []
+    for request, (query_len, kv_len) in enumerate(zip(qo_lens, kv_lens)):
+        for position in range(kv_len - query_len, kv_len):
+            page = int(block_table[request, position // block_k].item())
+            slots.append(page * block_k + position % block_k)
+    slot_mapping = torch.tensor(slots, device=device, dtype=torch.int32)
+    seq_lens = torch.tensor(kv_lens, device=device, dtype=torch.int32)
+    cu_seqlens_q = torch.zeros(requests + 1, device=device, dtype=torch.int32)
+    cu_seqlens_q[1:] = torch.cumsum(torch.tensor(qo_lens, device=device), 0)
+    prefix_lens = torch.tensor(
+        [k - q for q, k in zip(qo_lens, kv_lens)], device=device, dtype=torch.int32
+    )
+    return minimax_indexer(
+        index_q,
+        index_k,
+        index_k_cache,
+        slot_mapping,
+        block_table,
+        seq_lens,
+        topk=16,
+        scale=head_dim**-0.5,
+        init_blocks=1,
+        local_blocks=2,
+        cu_seqlens_q=cu_seqlens_q,
+        prefix_lens=prefix_lens,
+        max_query_len=max(qo_lens),
+        max_blocks=max_blocks,
+        query_lens_cpu=query_lens_cpu,
+        seq_lens_cpu=seq_lens_cpu,
+    )
+
+
+@requires_fmha_prefill_score
+@pytest.mark.parametrize(
+    "qo_lens,kv_lens",
+    [
+        ([600], [20000]),
+        ([1024, 512], [50000, 30000]),
+        ([40], [70000]),
+    ],
+)
+def test_fmha_prefill_score_matches_triton(
+    qo_lens: list[int], kv_lens: list[int]
+) -> None:
+    from tokenspeed_kernel.ops.attention import msa_score
+
+    if not msa_score.ensure_prefill_score_ready(None):
+        pytest.skip("fmha OnlyScore JIT compilation failed (nvcc unavailable?)")
+
+    torch.manual_seed(0)
+    plan_cache_before = msa_score._plan_for_batch.cache_info().currsize
+    fmha_selected = _prefill_indexer_case(qo_lens, kv_lens, qo_lens, kv_lens)
+    assert (
+        msa_score._plan_for_batch.cache_info().currsize > plan_cache_before
+        or msa_score._plan_for_batch.cache_info().hits > 0
+    ), "fmha OnlyScore path was not taken"
+    triton_selected = _prefill_indexer_case(qo_lens, kv_lens, None, None)
+
+    # Selections are compared as sets: fmha/sparse_topk_select emits ascending
+    # block ids with -1 padding, the Triton top-k emits score order.
+    assert torch.equal(
+        fmha_selected.sort(dim=-1).values, triton_selected.sort(dim=-1).values
+    )
+
+
+@requires_fmha_prefill_score
+def test_fmha_prefill_score_gates() -> None:
+    from tokenspeed_kernel.ops.attention.msa_score import prefill_score_supported
+
+    device = "cuda"
+    index_q = torch.randn(8, 4, 128, device=device, dtype=torch.bfloat16)
+    pages = torch.randn(256, 128, 128, device=device, dtype=torch.bfloat16)
+    # Host lens are required for sync-free planning.
+    assert not prefill_score_supported(index_q, pages, 16, 256, None, None)
+    # Upstream top-k only supports topk == 16.
+    assert not prefill_score_supported(index_q, pages, 32, 256, [8], [32000])
+    # Below the measured crossover the Triton pair is faster.
+    assert not prefill_score_supported(index_q, pages, 16, 64, [8], [8192])
+    # FP8 index cache is stage 3.
+    assert not prefill_score_supported(
+        index_q, pages.to(torch.float8_e4m3fn), 16, 256, [8], [32000]
+    )


### PR DESCRIPTION
## Acknowledgment

`index_decode_score.py` was adapted from https://github.com/vllm-project/vllm/pull/48582

## Summary

Adds two Blackwell block-score kernels for the MSA indexer, replacing the Triton
scoring paths when supported (Triton stays as automatic fallback). No new flag —
dispatch is capability-gated inside `minimax_indexer()`.

- **Decode** — CuteDSL TMA + `mma.sync` block-score kernel (BF16 / FP8-E4M3),
  scale + forced init/local blocks applied in the epilogue so the existing top-k
  is a drop-in consumer.
- **Prefill** — vendored MSA `fmha_sm100` dense FMHA in OnlyScore mode
  (`output_maxscore=True, output_o=False`) + fused `sparse_topk_select`. Kernel
  variants compile on a background thread; the Triton scorer is used until they
  are ready, so serving never stalls on nvcc-JIT.

Also vendors the `fmha_sm100` JIT stack under `thirdparty/msa/` (from
vllm-project/MSA @ `890aaa1a`, MIT; CUTLASS headers resolved from flashinfer,
submodule not vendored) and threads host-side `query_lens_cpu`/`seq_lens_cpu`
through the indexer (no new device sync).

**Gates (Blackwell-only):** decode requires `num_heads*decode_query_len <= 32`,
head_dim 128, `max_blocks % 4 == 0`. Prefill requires BF16, topk 16, head_dim/page
128, and long context (`max_blocks >= 129`, ~KV > 16.5k) past the measured
crossover; below that it stays on Triton by design.

**Tests:** `test/ops/test_attention_msa.py` — prefill fmha scores match the Triton
scorer bitwise (rank-equivalent) and gating is exercised.
