### PR TITLE
ci: disable thinking and allow longer context for qwen3.5 eval/pd cases

### DIFF
--- a/.github/workflows/pr-test-nvidia-arm.yml
+++ b/.github/workflows/pr-test-nvidia-arm.yml
@@ -92,8 +92,6 @@ jobs:
 
       - name: Build task matrix
         id: scan
-        env:
-          TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS: ${{ vars.TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS }}
         run: |
           MATRIX=$(python3 test/ci_system/pipeline.py scan \
             --root test/ci \

--- a/.github/workflows/pr-test-nvidia-arm.yml
+++ b/.github/workflows/pr-test-nvidia-arm.yml
@@ -92,6 +92,8 @@ jobs:
 
       - name: Build task matrix
         id: scan
+        env:
+          TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS: ${{ vars.TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS }}
         run: |
           MATRIX=$(python3 test/ci_system/pipeline.py scan \
             --root test/ci \

--- a/test/ci/eval/qwen3.5-397b-a17b-nvfp4-dp4ep4-evalscope-aime25.yaml
+++ b/test/ci/eval/qwen3.5-397b-a17b-nvfp4-dp4ep4-evalscope-aime25.yaml
@@ -9,6 +9,7 @@ runner:
     - gb200-4gpu
 env:
   CI: "true"
+  TOKENSPEED_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN: "1"
 install:
   - bash test/ci_system/install_deps.sh
 server:

--- a/test/ci/eval/qwen3.5-397b-a17b-nvfp4-evalscope-aime25.yaml
+++ b/test/ci/eval/qwen3.5-397b-a17b-nvfp4-evalscope-aime25.yaml
@@ -10,6 +10,7 @@ runner:
     - b300-4gpu
 env:
   CI: "true"
+  TOKENSPEED_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN: "1"
 install:
   - bash test/ci_system/install_deps.sh
 server:

--- a/test/ci_system/pd_http_worker.py
+++ b/test/ci_system/pd_http_worker.py
@@ -62,6 +62,7 @@ def _messages_to_text(
                 messages,
                 tokenize=False,
                 add_generation_prompt=not continue_final_message,
+                enable_thinking=False,
             )
         except TypeError:
             try:


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
