### PR TITLE
fix(qwen3.5): allow MTP to be quantized

### DIFF
--- a/python/tokenspeed/runtime/models/qwen3_5_nextn.py
+++ b/python/tokenspeed/runtime/models/qwen3_5_nextn.py
@@ -163,10 +163,6 @@ class Qwen3_5ForConditionalGenerationNextN(nn.Module):
         if self.is_multimodal:
             config = config.text_config
 
-        # The MTP model is unquantized in the nvfp4 checkpoint.
-        if quant_config and quant_config.get_name() == "nvfp4":
-            quant_config = None
-
         self.config = config
         self.mapping = mapping
         self.quant_config = quant_config


### PR DESCRIPTION
## Summary
For some quantized checkpoints, the MTP part may also be quantized; this PR aims to remove the constraint that forces MTP to remain unquantized.
<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
