### PR TITLE
perf(m3): optimize MiniMax M3 attention module

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/msa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/msa.py
@@ -58,6 +58,7 @@ from tokenspeed.runtime.layers.attention.registry import (
 )
 from tokenspeed.runtime.layers.attention.utils import build_page_table
 from tokenspeed.runtime.utils.common import ceil_div
+from tokenspeed.runtime.utils.pdl import pdl_enabled
 
 if TYPE_CHECKING:
     from tokenspeed.runtime.layers.paged_attention import PagedAttention
@@ -580,6 +581,7 @@ class MSAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
             k_scale=layer.k_scale if self.is_fp8 else None,
             v_scale=layer.v_scale if self.is_fp8 else None,
             score_out=metadata.score_out,
+            enable_pdl=pdl_enabled(),
         )
         return output.reshape(-1, layer.tp_q_head_num * layer.v_head_dim)
 
@@ -691,6 +693,7 @@ class MSAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
                 k_scale=layer.k_scale,
                 v_scale=layer.v_scale,
                 page_size=self.page_size,
+                enable_pdl=pdl_enabled(),
             )
         else:
             token_to_kv_pool.set_kv_buffer(

--- a/python/tokenspeed/runtime/layers/dense/fp8.py
+++ b/python/tokenspeed/runtime/layers/dense/fp8.py
@@ -61,6 +61,7 @@ from tokenspeed.runtime.layers.parameter import (
 from tokenspeed.runtime.layers.quantization.base_config import LinearMethodBase
 from tokenspeed.runtime.layers.quantization.fp8 import Fp8Config
 from tokenspeed.runtime.layers.quantization.utils import convert_to_channelwise
+from tokenspeed.runtime.utils.pdl import pdl_enabled
 
 platform = Platform.get()
 
@@ -379,6 +380,7 @@ class Fp8LinearMethod(LinearMethodBase):
                 quant="mxfp8",
                 block_size=self.quant_config.weight_block_size,
                 override=override,
+                enable_pdl=pdl_enabled(),
             )
             return output.to(dtype=output_dtype).view(*output_shape)
         else:

--- a/python/tokenspeed/runtime/layers/quantization/modelopt_mixed.py
+++ b/python/tokenspeed/runtime/layers/quantization/modelopt_mixed.py
@@ -50,7 +50,7 @@ _MOE_WEIGHT_DTYPES = {
 }
 
 _FUSED_PROJECTION_SHARDS = {
-    "qkv_proj": ("q_proj", "k_proj", "v_proj"),
+    "qkv_proj": ("q_proj", "k_proj", "v_proj", "index_q_proj", "index_k_proj"),
     "gate_up_proj": ("gate_proj", "up_proj"),
 }
 

--- a/python/tokenspeed/runtime/models/minimax_m3.py
+++ b/python/tokenspeed/runtime/models/minimax_m3.py
@@ -41,6 +41,7 @@ from tokenspeed.runtime.configs.minimax_m3_config import (
 from tokenspeed.runtime.configs.paged_cache_spec import FULL_ATTENTION
 from tokenspeed.runtime.distributed.comm_manager import CommManager
 from tokenspeed.runtime.distributed.mapping import Mapping
+from tokenspeed.runtime.distributed.utils import divide
 from tokenspeed.runtime.execution.context import ForwardContext
 from tokenspeed.runtime.execution.cuda_graph_wrapper import get_is_capture_mode
 from tokenspeed.runtime.layers.attention.mm_encoder_attention import VisionAttention
@@ -62,6 +63,10 @@ from tokenspeed.runtime.layers.moe.expert import MoELayer
 from tokenspeed.runtime.layers.moe.topk import TopK
 from tokenspeed.runtime.layers.moe.utils import RoutingMethodType
 from tokenspeed.runtime.layers.paged_attention import PagedAttention
+from tokenspeed.runtime.layers.parameter import (
+    BaseWeightParameter,
+    BlockQuantScaleParameter,
+)
 from tokenspeed.runtime.layers.quantization.base_config import QuantizationConfig
 from tokenspeed.runtime.layers.rotary_embedding import get_rope
 from tokenspeed.runtime.model_loader.weight_utils import default_weight_loader
@@ -297,6 +302,197 @@ class MiniMaxM3SparseMoeBlock(nn.Module):
         return output
 
 
+class MinimaxM3QKVParallelLinearWithIndexer(QKVParallelLinear):
+    """QKV projection fused with a MiniMax-M3 lightning-indexer's index_q/index_k.
+
+    A single column-parallel GEMM emits, per rank::
+
+        [q | k | v | index_q | index_k]
+
+    ``index_q`` must have the same head count as the KV heads
+    (``total_num_index_heads == total_num_kv_heads``), so it shards exactly like
+    K/V -- including the KV-head *replication* path when
+    ``tp_size >= total_num_kv_heads``. ``index_k`` is a single shared head,
+    replicated to every rank. The index head size may differ from the attention
+    head size. MiniMax-M3 specific; it reuses ``QKVParallelLinear``'s sharding /
+    weight-loading machinery.
+
+    Args:
+        hidden_size: input hidden state size of the transformer.
+        head_size: size of each attention head.
+        total_num_heads: total number of attention query heads.
+        total_num_kv_heads: total number of attention key/value heads.
+        total_num_index_heads: total number of indexer query heads (must equal
+            ``total_num_kv_heads``).
+        index_head_size: size of each index head.
+        bias: If true, add bias.
+        quant_config: Quantization config.
+        prefix: The name of the layer in the state dict.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        head_size: int,
+        total_num_heads: int,
+        total_num_kv_heads: int,
+        total_num_index_heads: int,
+        index_head_size: int,
+        bias: bool = False,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        tp_rank: int | None = None,
+        tp_size: int | None = None,
+        tp_group: tuple[int, ...] | None = None,
+    ):
+        if total_num_index_heads != total_num_kv_heads:
+            raise ValueError(
+                "MinimaxM3QKVParallelLinearWithIndexer requires "
+                "total_num_index_heads == total_num_kv_heads; got "
+                f"{total_num_index_heads} vs {total_num_kv_heads}."
+            )
+        self.hidden_size = hidden_size
+        self.head_size = head_size
+        self.total_num_heads = total_num_heads
+        self.total_num_kv_heads = total_num_kv_heads
+        self.total_num_index_heads = total_num_index_heads
+        self.index_head_size = index_head_size
+
+        tp_size = 1 if tp_size is None else tp_size
+        self.num_heads = divide(self.total_num_heads, tp_size)
+        if tp_size >= self.total_num_kv_heads:
+            self.num_kv_heads = 1
+            self.num_kv_head_replicas = divide(tp_size, self.total_num_kv_heads)
+        else:
+            self.num_kv_heads = divide(self.total_num_kv_heads, tp_size)
+            self.num_kv_head_replicas = 1
+        # index_q shards identically to the KV heads.
+        self.num_index_heads = self.num_kv_heads
+
+        q = self.num_heads * self.head_size
+        kv = self.num_kv_heads * self.head_size
+        iq = self.num_index_heads * self.index_head_size
+        ik = self.index_head_size
+        # Global per-group sizes (replicated groups counted x tp_size, matching
+        # the QKVParallelLinear convention). index_k is a single replicated head.
+        output_sizes = [
+            q * tp_size,  # q
+            kv * tp_size,  # k
+            kv * tp_size,  # v
+            iq * tp_size,  # index_q
+            ik * tp_size,  # index_k (replicated)
+        ]
+
+        # Skip QKVParallelLinear.__init__ (3-group layout); build the 5-group
+        # column-parallel weight directly.
+        ColumnParallelLinear.__init__(
+            self,
+            input_size=self.hidden_size,
+            output_size=sum(output_sizes),
+            bias=bias,
+            gather_output=False,
+            quant_config=quant_config,
+            output_sizes=output_sizes,
+            prefix=prefix,
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+            tp_group=tp_group,
+        )
+
+    def _get_shard_offset_mapping(self, loaded_shard_id: str):
+        h, ih = self.head_size, self.index_head_size
+        nq, nkv, nidx = self.num_heads, self.num_kv_heads, self.num_index_heads
+        index_base = (nq + 2 * nkv) * h
+        shard_offset_mapping = {
+            "q": 0,
+            "k": nq * h,
+            "v": (nq + nkv) * h,
+            "index_q": index_base,
+            "index_k": index_base + nidx * ih,
+            "total": index_base + nidx * ih + ih,
+        }
+        return shard_offset_mapping.get(loaded_shard_id)
+
+    def _get_shard_size_mapping(self, loaded_shard_id: str):
+        shard_size_mapping = {
+            "q": self.num_heads * self.head_size,
+            "k": self.num_kv_heads * self.head_size,
+            "v": self.num_kv_heads * self.head_size,
+            "index_q": self.num_index_heads * self.index_head_size,
+            "index_k": self.index_head_size,
+        }
+        return shard_size_mapping.get(loaded_shard_id)
+
+    def weight_loader_v2(
+        self,
+        param: BaseWeightParameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: str | None = None,
+    ):
+        assert loaded_shard_id in ("q", "k", "v", "index_q", "index_k")
+
+        shard_offset = self._get_shard_offset_mapping(loaded_shard_id)
+        shard_size = self._get_shard_size_mapping(loaded_shard_id)
+
+        if isinstance(param, BlockQuantScaleParameter):
+            weight_block_size = self.quant_method.quant_config.weight_block_size
+            block_n = weight_block_size[0]
+            shard_offset = (shard_offset + block_n - 1) // block_n
+            shard_size = (shard_size + block_n - 1) // block_n
+
+        # index_k is fully replicated: num_heads == tp_size makes load_qkv_weight
+        # pick shard 0 on every rank. q/k/v/index_q ride the KV-head replication
+        # factor.
+        num_heads = (
+            self.tp_size if loaded_shard_id == "index_k" else self.num_kv_head_replicas
+        )
+        param.load_qkv_weight(
+            loaded_weight=loaded_weight,
+            num_heads=num_heads,
+            shard_id=loaded_shard_id,
+            shard_offset=shard_offset,
+            shard_size=shard_size,
+            tp_rank=self.tp_rank,
+            use_presharded_weights=self.use_presharded_weights,
+        )
+
+    def weight_loader(
+        self,
+        param: nn.Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: str | None = None,
+    ):
+        # Unquantized (bf16) path; MXFP8 checkpoints use weight_loader_v2. Handles
+        # the plain output_dim layout only (no bitsandbytes/marlin packing, which
+        # MiniMax-M3 does not use).
+        assert loaded_shard_id in ("q", "k", "v", "index_q", "index_k")
+        output_dim = getattr(param, "output_dim", None)
+        assert output_dim is not None
+
+        shard_offset = self._get_shard_offset_mapping(loaded_shard_id)
+        shard_size = self._get_shard_size_mapping(loaded_shard_id)
+
+        if isinstance(param, BlockQuantScaleParameter):
+            weight_block_size = self.quant_method.quant_config.weight_block_size
+            block_n = weight_block_size[0]
+            shard_offset = (shard_offset + block_n - 1) // block_n
+            shard_size = (shard_size + block_n - 1) // block_n
+
+        param_data = param.data.narrow(output_dim, shard_offset, shard_size)
+        if loaded_shard_id == "q":
+            shard_rank = self.tp_rank
+        elif loaded_shard_id == "index_k":
+            shard_rank = 0  # replicated to every rank
+        else:
+            shard_rank = self.tp_rank // self.num_kv_head_replicas
+        if not self.use_presharded_weights:
+            loaded_weight = loaded_weight.narrow(
+                output_dim, shard_rank * shard_size, shard_size
+            )
+        assert param_data.shape == loaded_weight.shape
+        param_data.copy_(loaded_weight)
+
+
 class MiniMaxM3Indexer(nn.Module):
     """MiniMax-M3's lightweight per-GQA-group block indexer."""
 
@@ -304,8 +500,6 @@ class MiniMaxM3Indexer(nn.Module):
         self,
         config: MiniMaxM3VLTextConfig,
         mapping: Mapping,
-        quant_config: QuantizationConfig | None = None,
-        prefix: str = "",
     ) -> None:
         super().__init__()
         total_index_heads = config.index_n_heads
@@ -321,24 +515,9 @@ class MiniMaxM3Indexer(nn.Module):
             )
         self.num_index_heads = total_index_heads // mapping.attn.tp_size
         self.head_dim = config.index_head_dim
-        self.q_size = self.num_index_heads * self.head_dim
-        self.index_q_proj = ColumnParallelLinear(
-            config.hidden_size,
-            total_index_heads * self.head_dim,
-            bias=False,
-            quant_config=quant_config,
-            tp_rank=mapping.attn.tp_rank,
-            tp_size=mapping.attn.tp_size,
-            tp_group=mapping.attn.tp_group,
-            prefix=add_prefix("index_q_proj", prefix),
-        )
-        self.index_k_proj = ReplicatedLinear(
-            config.hidden_size,
-            self.head_dim,
-            bias=False,
-            quant_config=quant_config,
-            prefix=add_prefix("index_k_proj", prefix),
-        )
+        # index_q/index_k projections are fused into the attention's
+        # MinimaxM3QKVParallelLinearWithIndexer; the indexer receives them
+        # pre-projected and only applies norm + RoPE + reshape.
         self.q_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
         self.k_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
 
@@ -354,10 +533,9 @@ class MiniMaxM3Indexer(nn.Module):
     def forward(
         self,
         positions: torch.Tensor,
-        hidden_states: torch.Tensor,
+        index_q: torch.Tensor,
+        index_k: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        index_q, _ = self.index_q_proj(hidden_states)
-        index_k, _ = self.index_k_proj(hidden_states)
         index_q, index_k = qk_rmsnorm(
             index_q,
             index_k,
@@ -396,18 +574,39 @@ class MiniMaxM3Attention(nn.Module):
         self.kv_size = self.num_kv_heads * self.head_dim
         self.is_sparse = config.layer_types[layer_id] == "minimax_m3_sparse"
 
-        self.qkv_proj = QKVParallelLinear(
-            config.hidden_size,
-            self.head_dim,
-            config.num_attention_heads,
-            config.num_key_value_heads,
-            bias=False,
-            quant_config=quant_config,
-            tp_rank=mapping.attn.tp_rank,
-            tp_size=mapping.attn.tp_size,
-            tp_group=mapping.attn.tp_group,
-            prefix=add_prefix("qkv_proj", prefix),
-        )
+        if self.is_sparse:
+            # Sparse layers fuse the indexer's index_q/index_k into the QKV GEMM:
+            # a single projection emits [q | k | v | index_q | index_k].
+            self.index_head_dim = config.index_head_dim
+            self.index_q_size = self.num_kv_heads * self.index_head_dim
+            self.index_k_size = self.index_head_dim
+            self.qkv_proj = MinimaxM3QKVParallelLinearWithIndexer(
+                config.hidden_size,
+                self.head_dim,
+                config.num_attention_heads,
+                config.num_key_value_heads,
+                config.index_n_heads,
+                config.index_head_dim,
+                bias=False,
+                quant_config=quant_config,
+                tp_rank=mapping.attn.tp_rank,
+                tp_size=mapping.attn.tp_size,
+                tp_group=mapping.attn.tp_group,
+                prefix=add_prefix("qkv_proj", prefix),
+            )
+        else:
+            self.qkv_proj = QKVParallelLinear(
+                config.hidden_size,
+                self.head_dim,
+                config.num_attention_heads,
+                config.num_key_value_heads,
+                bias=False,
+                quant_config=quant_config,
+                tp_rank=mapping.attn.tp_rank,
+                tp_size=mapping.attn.tp_size,
+                tp_group=mapping.attn.tp_group,
+                prefix=add_prefix("qkv_proj", prefix),
+            )
         self.o_proj = RowParallelLinear(
             config.num_attention_heads * self.head_dim,
             config.hidden_size,
@@ -431,14 +630,7 @@ class MiniMaxM3Attention(nn.Module):
             base=int(config.rope_parameters["rope_theta"]),
         )
         self.indexer = (
-            MiniMaxM3Indexer(
-                config=config,
-                mapping=mapping,
-                quant_config=quant_config,
-                prefix=prefix,
-            )
-            if self.is_sparse
-            else None
+            MiniMaxM3Indexer(config=config, mapping=mapping) if self.is_sparse else None
         )
         self.attn = PagedAttention(
             self.num_heads,
@@ -459,7 +651,20 @@ class MiniMaxM3Attention(nn.Module):
         if hidden_states.shape[0] == 0:
             return hidden_states
         qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        if self.is_sparse:
+            # Fused projection emits [q | k | v | index_q | index_k].
+            q, k, v, index_q, index_k = qkv.split(
+                [
+                    self.q_size,
+                    self.kv_size,
+                    self.kv_size,
+                    self.index_q_size,
+                    self.index_k_size,
+                ],
+                dim=-1,
+            )
+        else:
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         q, k = qk_rmsnorm(
             q,
             k,
@@ -473,7 +678,7 @@ class MiniMaxM3Attention(nn.Module):
         v = v.view(-1, self.num_kv_heads, self.head_dim)
         attn_kwargs = {}
         if self.is_sparse:
-            index_q, index_k = self.indexer(positions, hidden_states)
+            index_q, index_k = self.indexer(positions, index_q, index_k)
             attn_kwargs = {"index_q": index_q, "index_k": index_k}
         attn_output = self.attn(
             q,
@@ -651,8 +856,6 @@ class MiniMaxM3SparseForCausalLM(BaseCausalLM):
         ("language_model.", ""),
         (".block_sparse_moe", ".mlp"),
         (".e_score_correction_bias", ".routing_bias"),
-        (".self_attn.index_q_proj", ".self_attn.indexer.index_q_proj"),
-        (".self_attn.index_k_proj", ".self_attn.indexer.index_k_proj"),
         (".self_attn.index_q_norm", ".self_attn.indexer.q_norm"),
         (".self_attn.index_k_norm", ".self_attn.indexer.k_norm"),
     )
@@ -679,6 +882,9 @@ class MiniMaxM3SparseForCausalLM(BaseCausalLM):
             (".qkv_proj", ".q_proj", "q"),
             (".qkv_proj", ".k_proj", "k"),
             (".qkv_proj", ".v_proj", "v"),
+            # Sparse layers fuse the indexer projections into qkv_proj.
+            (".qkv_proj", ".index_q_proj", "index_q"),
+            (".qkv_proj", ".index_k_proj", "index_k"),
             (".gate_up_proj", ".gate_proj", 0),
             (".gate_up_proj", ".up_proj", 1),
         ]

--- a/python/tokenspeed/runtime/models/minimax_m3.py
+++ b/python/tokenspeed/runtime/models/minimax_m3.py
@@ -31,6 +31,9 @@ from tokenspeed_kernel.ops.gemm.cuda import dsv3_router_gemm
 from tokenspeed_kernel.ops.layernorm.triton import qk_rmsnorm
 from tokenspeed_kernel.ops.moe.cuda import moe_finalize_fuse_shared
 from tokenspeed_kernel.platform import current_platform
+from tokenspeed_kernel.thirdparty.cuda.minimax_m3_fused import (
+    fused_qknorm_rope_kv_insert,
+)
 from torch import nn
 from transformers import MiniMaxM3VLTextConfig
 
@@ -573,6 +576,12 @@ class MiniMaxM3Attention(nn.Module):
         self.q_size = self.num_heads * self.head_dim
         self.kv_size = self.num_kv_heads * self.head_dim
         self.is_sparse = config.layer_types[layer_id] == "minimax_m3_sparse"
+        self.use_fused_qknorm_rope = (
+            self.is_sparse
+            and current_platform().is_nvidia
+            and self.head_dim == 128
+            and config.index_head_dim == 128
+        )
 
         if self.is_sparse:
             # Sparse layers fuse the indexer's index_q/index_k into the QKV GEMM:
@@ -650,7 +659,28 @@ class MiniMaxM3Attention(nn.Module):
     ) -> torch.Tensor:
         if hidden_states.shape[0] == 0:
             return hidden_states
+
         qkv, _ = self.qkv_proj(hidden_states)
+
+        if self.use_fused_qknorm_rope:
+            q, k, v, attn_kwargs = self.fused_qknorm_rope(qkv, positions)
+        else:
+            q, k, v, attn_kwargs = self.qknorm_rope(qkv, positions)
+
+        attn_output = self.attn(
+            q,
+            k,
+            v,
+            ctx=ctx,
+            out_cache_loc=out_cache_loc,
+            **attn_kwargs,
+        )
+        output, _ = self.o_proj(attn_output)
+        return output
+
+    def qknorm_rope(
+        self, qkv: torch.Tensor, positions: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, dict]:
         if self.is_sparse:
             # Fused projection emits [q | k | v | index_q | index_k].
             q, k, v, index_q, index_k = qkv.split(
@@ -680,16 +710,47 @@ class MiniMaxM3Attention(nn.Module):
         if self.is_sparse:
             index_q, index_k = self.indexer(positions, index_q, index_k)
             attn_kwargs = {"index_q": index_q, "index_k": index_k}
-        attn_output = self.attn(
-            q,
-            k,
-            v,
-            ctx=ctx,
-            out_cache_loc=out_cache_loc,
-            **attn_kwargs,
+        return q, k, v, attn_kwargs
+
+    def fused_qknorm_rope(
+        self, qkv: torch.Tensor, positions: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, dict]:
+        q_out = qkv.new_empty(qkv.size(0), self.q_size)
+        index_q_out = qkv.new_empty(qkv.size(0), self.index_q_size)
+        fused_qknorm_rope_kv_insert(
+            qkv,
+            self.q_norm.weight,
+            self.k_norm.weight,
+            self.rotary_emb.cos_sin_cache,
+            positions,
+            self.num_heads,
+            self.num_kv_heads,
+            self.rotary_emb.rotary_dim,
+            self.q_norm.variance_epsilon,
+            index_q_norm_weight=self.indexer.q_norm.weight,
+            index_k_norm_weight=self.indexer.k_norm.weight,
+            num_index_heads=self.indexer.num_index_heads,
+            q_out=q_out,
+            index_q_out=index_q_out,
         )
-        output, _ = self.o_proj(attn_output)
-        return output
+        _, k, v, _, index_k = qkv.split(
+            [
+                self.q_size,
+                self.kv_size,
+                self.kv_size,
+                self.index_q_size,
+                self.index_k_size,
+            ],
+            dim=-1,
+        )
+        q = q_out.view(-1, self.num_heads, self.head_dim)
+        k = k.reshape(-1, self.num_kv_heads, self.head_dim)
+        v = v.reshape(-1, self.num_kv_heads, self.head_dim)
+        index_q = index_q_out.view(
+            -1, self.indexer.num_index_heads, self.index_head_dim
+        )
+        index_k = index_k.reshape(-1, self.index_head_dim)
+        return q, k, v, {"index_q": index_q, "index_k": index_k}
 
 
 class MiniMaxM3DecoderLayer(nn.Module):

--- a/python/tokenspeed/runtime/models/minimax_m3.py
+++ b/python/tokenspeed/runtime/models/minimax_m3.py
@@ -732,6 +732,7 @@ class MiniMaxM3Attention(nn.Module):
             num_index_heads=self.indexer.num_index_heads,
             q_out=q_out,
             index_q_out=index_q_out,
+            enable_pdl=pdl_enabled(),
         )
         _, k, v, _, index_k = qkv.split(
             [

--- a/test/runtime/models/test_minimax_m3.py
+++ b/test/runtime/models/test_minimax_m3.py
@@ -295,14 +295,17 @@ def test_minimax_m3_mixed_precision_quant_dispatch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from tokenspeed.runtime.layers.dense import Fp8LinearMethod
+    from tokenspeed.runtime.models.minimax_m3 import (
+        MinimaxM3QKVParallelLinearWithIndexer,
+    )
 
     model = _build_model(monkeypatch, quant_config=_mixed_precision_config())
-
     attn = model.model.layers[3].self_attn
+    # Sparse layers fuse q/k/v/index_q/index_k into one projection; its MXFP8
+    # dispatch confirms the index members resolved to MXFP8 via the qkv unfuse.
+    assert isinstance(attn.qkv_proj, MinimaxM3QKVParallelLinearWithIndexer)
     assert isinstance(attn.qkv_proj.quant_method, Fp8LinearMethod)
     assert isinstance(attn.o_proj.quant_method, Fp8LinearMethod)
-    assert isinstance(attn.indexer.index_q_proj.quant_method, Fp8LinearMethod)
-    assert isinstance(attn.indexer.index_k_proj.quant_method, Fp8LinearMethod)
 
     assert isinstance(
         model.model.layers[0].mlp.gate_up_proj.quant_method, Fp8LinearMethod

--- a/test/runtime/test_minimax_m3_fused_qkv_indexer.py
+++ b/test/runtime/test_minimax_m3_fused_qkv_indexer.py
@@ -1,0 +1,218 @@
+"""CPU-only coverage for MiniMax-M3's fused QKV+indexer projection.
+
+Validates ``MinimaxM3QKVParallelLinearWithIndexer`` -- a single column-parallel
+GEMM emitting ``[q | k | v | index_q | index_k]`` -- against independent
+per-projection references: forward correctness at TP=1, sharding across ranks
+(including the KV-head replication path and the fully-replicated single
+``index_k`` head), and the quantized ``load_qkv_weight`` delegation. Also checks
+that the ``modelopt_mixed`` resolver folds the index members into ``qkv_proj``
+without disturbing dense / non-M3 layers.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from tokenspeed.runtime.layers.parameter import ModelWeightParameter
+from tokenspeed.runtime.layers.quantization.modelopt_mixed import ModelOptMixedConfig
+from tokenspeed.runtime.models.minimax_m3 import (
+    MinimaxM3QKVParallelLinearWithIndexer,
+)
+
+# Small M3-shaped dims: 8 q heads, 2 kv heads, 2 index heads (== kv heads).
+# index_head_size deliberately differs from head_size to cover the general case.
+_NH, _NKV, _NIDX, _HEAD, _IDX_HEAD, _H = 8, 2, 2, 8, 16, 64
+
+
+def _build(tp: int, rank: int) -> MinimaxM3QKVParallelLinearWithIndexer:
+    return MinimaxM3QKVParallelLinearWithIndexer(
+        hidden_size=_H,
+        head_size=_HEAD,
+        total_num_heads=_NH,
+        total_num_kv_heads=_NKV,
+        total_num_index_heads=_NIDX,
+        index_head_size=_IDX_HEAD,
+        bias=False,
+        quant_config=None,
+        prefix="m",
+        tp_rank=rank,
+        tp_size=tp,
+        tp_group=tuple(range(tp)),
+    ).to(torch.float32)
+
+
+def _ref_weights(seed: int = 0):
+    g = torch.Generator().manual_seed(seed)
+    return {
+        "q": torch.randn(_NH * _HEAD, _H, generator=g),
+        "k": torch.randn(_NKV * _HEAD, _H, generator=g),
+        "v": torch.randn(_NKV * _HEAD, _H, generator=g),
+        "index_q": torch.randn(_NIDX * _IDX_HEAD, _H, generator=g),
+        "index_k": torch.randn(_IDX_HEAD, _H, generator=g),
+    }
+
+
+def test_output_sizes_layout():
+    layer = _build(tp=1, rank=0)
+    assert layer.output_sizes == [
+        _NH * _HEAD,
+        _NKV * _HEAD,
+        _NKV * _HEAD,
+        _NIDX * _IDX_HEAD,
+        _IDX_HEAD,
+    ]
+    assert layer.num_index_heads == layer.num_kv_heads
+
+
+def test_forward_matches_independent_projections_tp1():
+    layer = _build(tp=1, rank=0)
+    weights = _ref_weights()
+    param = dict(layer.named_parameters())["weight"]
+    for shard, w in weights.items():
+        layer.weight_loader(param, w, shard)
+
+    x = torch.randn(4, _H)
+    out, _ = layer(x)
+    q, k, v, iq, ik = out.split(
+        [_NH * _HEAD, _NKV * _HEAD, _NKV * _HEAD, _NIDX * _IDX_HEAD, _IDX_HEAD],
+        dim=-1,
+    )
+    got = {"q": q, "k": k, "v": v, "index_q": iq, "index_k": ik}
+    for name, w in weights.items():
+        torch.testing.assert_close(got[name], F.linear(x, w))
+
+
+@pytest.mark.parametrize("tp", [2, 4])
+def test_sharding_across_ranks(tp: int):
+    """tp=2: no replication; tp=4: KV replication factor 2; index_k replicated."""
+    weights = _ref_weights()
+    for rank in range(tp):
+        layer = _build(tp=tp, rank=rank)
+        param = dict(layer.named_parameters())["weight"]
+        for shard, w in weights.items():
+            layer.weight_loader(param, w, shard)
+
+        nh, nkv, nidx, rep = (
+            layer.num_heads,
+            layer.num_kv_heads,
+            layer.num_index_heads,
+            layer.num_kv_head_replicas,
+        )
+        kv_rank = rank // rep
+        expected = {
+            "q": weights["q"].narrow(0, rank * nh * _HEAD, nh * _HEAD),
+            "k": weights["k"].narrow(0, kv_rank * nkv * _HEAD, nkv * _HEAD),
+            "v": weights["v"].narrow(0, kv_rank * nkv * _HEAD, nkv * _HEAD),
+            "index_q": weights["index_q"].narrow(
+                0, kv_rank * nidx * _IDX_HEAD, nidx * _IDX_HEAD
+            ),
+            "index_k": weights["index_k"],  # replicated to every rank
+        }
+        sizes = [
+            ("q", nh * _HEAD),
+            ("k", nkv * _HEAD),
+            ("v", nkv * _HEAD),
+            ("index_q", nidx * _IDX_HEAD),
+            ("index_k", _IDX_HEAD),
+        ]
+        offset = 0
+        for name, size in sizes:
+            got = param.data.narrow(0, offset, size)
+            torch.testing.assert_close(got, expected[name])
+            offset += size
+
+
+def test_quantized_load_qkv_weight_delegation_replicates_index_k():
+    """The MXFP8 path routes through param.load_qkv_weight; index_k passes
+    num_heads=tp_size so every rank picks shard 0 (full replication)."""
+    tp = 4
+    weights = _ref_weights()
+    nh, nkv, nidx, rep = _NH // tp, 1, 1, tp // _NKV
+    sizes = [
+        ("q", nh * _HEAD),
+        ("k", nkv * _HEAD),
+        ("v", nkv * _HEAD),
+        ("index_q", nidx * _IDX_HEAD),
+        ("index_k", _IDX_HEAD),
+    ]
+    total = sum(sz for _, sz in sizes)
+    for rank in range(tp):
+        param = ModelWeightParameter(
+            data=torch.zeros(total, _H), input_dim=1, output_dim=0, weight_loader=None
+        )
+        offsets, offset = {}, 0
+        for name, sz in sizes:
+            offsets[name] = offset
+            offset += sz
+        for name, sz in sizes:
+            num_heads = tp if name == "index_k" else rep
+            param.load_qkv_weight(
+                loaded_weight=weights[name],
+                num_heads=num_heads,
+                shard_id=name,
+                shard_offset=offsets[name],
+                shard_size=sz,
+                tp_rank=rank,
+                use_presharded_weights=False,
+            )
+        kv_rank = rank // rep
+        expected = {
+            "q": weights["q"].narrow(0, rank * nh * _HEAD, nh * _HEAD),
+            "k": weights["k"].narrow(0, kv_rank * nkv * _HEAD, nkv * _HEAD),
+            "v": weights["v"].narrow(0, kv_rank * nkv * _HEAD, nkv * _HEAD),
+            "index_q": weights["index_q"].narrow(
+                0, kv_rank * nidx * _IDX_HEAD, nidx * _IDX_HEAD
+            ),
+            "index_k": weights["index_k"],
+        }
+        for name, sz in sizes:
+            torch.testing.assert_close(
+                param.data.narrow(0, offsets[name], sz), expected[name]
+            )
+
+
+def test_invariants_rejected():
+    with pytest.raises(ValueError, match="total_num_index_heads == total_num_kv_heads"):
+        MinimaxM3QKVParallelLinearWithIndexer(
+            _H, _HEAD, _NH, _NKV, _NKV + 1, _IDX_HEAD, tp_rank=0, tp_size=1
+        )
+
+
+def _mixed(layers: dict[str, str]) -> ModelOptMixedConfig:
+    return ModelOptMixedConfig(
+        quantized_layers=layers, kv_cache_quant_algo=None, group_size=16
+    )
+
+
+def test_resolver_folds_index_members_into_qkv():
+    base = "model.layers.5.self_attn"
+    sparse = _mixed(
+        {
+            f"{base}.{m}": "MXFP8"
+            for m in ("q_proj", "k_proj", "v_proj", "index_q_proj", "index_k_proj")
+        }
+    )
+    assert sparse._resolve_quant_algo(f"{base}.qkv_proj") == "MXFP8"
+
+
+def test_resolver_skips_absent_index_members_for_dense():
+    base = "model.layers.0.self_attn"
+    dense = _mixed({f"{base}.{m}": "MXFP8" for m in ("q_proj", "k_proj", "v_proj")})
+    assert dense._resolve_quant_algo(f"{base}.qkv_proj") == "MXFP8"
+
+
+def test_resolver_raises_on_index_member_disagreement():
+    base = "model.layers.5.self_attn"
+    mixed = _mixed(
+        {
+            f"{base}.q_proj": "MXFP8",
+            f"{base}.k_proj": "MXFP8",
+            f"{base}.v_proj": "MXFP8",
+            f"{base}.index_q_proj": "NVFP4",
+            f"{base}.index_k_proj": "MXFP8",
+        }
+    )
+    with pytest.raises(ValueError, match="Mixed quant_algo within fused layer"):
+        mixed._resolve_quant_algo(f"{base}.qkv_proj")

--- a/tokenspeed-kernel/python/setup.py
+++ b/tokenspeed-kernel/python/setup.py
@@ -317,6 +317,13 @@ KERNEL_GROUPS = [
         [],
     ),
     (
+        "minimax_m3_fused",
+        [
+            CUDA_CSRC_DIR / "fused_minimax_m3_qknorm_rope_kv_insert.cu",
+        ],
+        [],
+    ),
+    (
         "dsv3_gemm",
         [
             CUDA_CSRC_DIR / "dsv3_router_gemm_float_out.cu",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -152,6 +152,7 @@ def msa_decode_with_kvcache(
     k_scale: float | torch.Tensor | None = None,
     v_scale: float | torch.Tensor | None = None,
     score_out: torch.Tensor | None = None,
+    enable_pdl: bool = False,
     override: str | None = None,
     solution: str | None = None,
 ) -> torch.Tensor:
@@ -186,6 +187,8 @@ def msa_decode_with_kvcache(
             ``-inf`` and reused across layers; forwarded to the kernel to avoid
             a per-layer allocation + fill. Ignored by kernels that do not
             accept it or when its shape does not match.
+        enable_pdl: Request Programmatic Dependent Launch (SM90+) for the
+            indexer's index-key store; forwarded to the kernel.
         override: Optional kernel override name.
         solution: Optional kernel solution to force through normal selection.
 
@@ -267,6 +270,7 @@ def msa_decode_with_kvcache(
             k_scale=k_scale,
             v_scale=v_scale,
             score_out=score_out,
+            enable_pdl=enable_pdl,
         )
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cute_dsl/minimax_index_decode_score.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cute_dsl/minimax_index_decode_score.py
@@ -72,6 +72,7 @@ class IndexDecodeScoreKernel:
         scale: float,
         init_blocks: int,
         local_blocks: int,
+        enable_pdl: bool = False,
     ):
         self.dtype = dtype
         self.num_heads = num_heads
@@ -81,6 +82,7 @@ class IndexDecodeScoreKernel:
         self.scale = scale
         self.init_blocks = init_blocks
         self.local_blocks = local_blocks
+        self.enable_pdl = enable_pdl
 
     @cute.jit
     def __call__(
@@ -140,7 +142,7 @@ class IndexDecodeScoreKernel:
             score,
             seq_lens,
             decode_query_len,
-        ).launch(grid=grid, block=block, stream=stream, use_pdl=True)
+        ).launch(grid=grid, block=block, stream=stream, use_pdl=self.enable_pdl)
 
     @cute.kernel
     def kernel(
@@ -437,6 +439,7 @@ class IndexDecodeScoreKernel:
         scale: float,
         init_blocks: int,
         local_blocks: int,
+        enable_pdl: bool = False,
     ):
         bs = cute.sym_int()
         total_tokens = cute.sym_int()
@@ -462,6 +465,7 @@ class IndexDecodeScoreKernel:
             scale,
             init_blocks,
             local_blocks,
+            enable_pdl,
         )
         stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
         return cute.compile(
@@ -487,6 +491,7 @@ def minimax_index_decode_score(
     init_blocks: int,
     local_blocks: int,
     decode_query_len: int,
+    enable_pdl: bool = False,
 ) -> None:
     """Score visible 128-token blocks for decode via the CuteDSL kernel.
 
@@ -504,6 +509,9 @@ def minimax_index_decode_score(
         init_blocks: Leading blocks forced into the selection.
         local_blocks: Most-recent blocks forced into the selection.
         decode_query_len: Uniform queries per request.
+        enable_pdl: Request Programmatic Dependent Launch (SM90+) for the score
+            kernel; when False it launches without the stream-serialization
+            attribute (the in-kernel grid-dependency waits become no-ops).
 
     Returns:
         None; ``scores`` is written in place.
@@ -518,6 +526,7 @@ def minimax_index_decode_score(
         float(scale),
         int(init_blocks),
         int(local_blocks),
+        bool(enable_pdl),
     )
     kernel(
         index_q,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/dsa_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/dsa_topk.py
@@ -22,9 +22,11 @@ from __future__ import annotations
 
 import torch
 from tokenspeed_kernel._triton import tl, triton
-from tokenspeed_kernel.platform import CapabilityRequirement
+from tokenspeed_kernel.platform import CapabilityRequirement, current_platform
 from tokenspeed_kernel.registry import Priority, register_kernel
 from tokenspeed_kernel.signature import dense_tensor_format, format_signature
+
+_is_nvidia = current_platform().is_nvidia
 
 _RADIX_TOPK_MIN_COLS = 65536
 _RADIX_TOPK_BLOCK_N = 4096
@@ -571,10 +573,13 @@ def _dsa_logits_topk_kernel(
     n_cols_padded: tl.constexpr,
     topk: tl.constexpr,
     BLOCK_N: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     row = tl.program_id(0)
     offsets = (n_cols_padded - BLOCK_N) + tl.arange(0, BLOCK_N)
     valid = offsets < n_cols
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
     values = tl.load(
         logits + row * logits_stride + offsets,
         mask=valid,
@@ -612,6 +617,8 @@ def _dsa_logits_topk_kernel(
         tl.where(valid_top, indices, -1),
         mask=top_offsets < topk,
     )
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
 
 @triton.jit
@@ -849,7 +856,9 @@ def _radix_topk(logits: torch.Tensor, topk: int) -> torch.Tensor:
     return out
 
 
-def _topk_with_padding(logits: torch.Tensor, topk: int) -> torch.Tensor:
+def _topk_with_padding(
+    logits: torch.Tensor, topk: int, enable_pdl: bool = False
+) -> torch.Tensor:
     topk = int(topk)
     if topk <= 0:
         raise ValueError(f"topk must be positive, got {topk}")
@@ -875,6 +884,8 @@ def _topk_with_padding(logits: torch.Tensor, topk: int) -> torch.Tensor:
             "DSA Triton top-k requires padded cols divisible by block size, got "
             f"cols={cols}, padded={n_cols_padded}, block={block_n}"
         )
+    use_pdl = bool(enable_pdl and _is_nvidia)
+    pdl_kwargs = {"launch_pdl": True} if use_pdl else {}
     _dsa_logits_topk_kernel[(rows,)](
         logits,
         out,
@@ -884,8 +895,10 @@ def _topk_with_padding(logits: torch.Tensor, topk: int) -> torch.Tensor:
         n_cols_padded=n_cols_padded,
         topk=topk,
         BLOCK_N=block_n,
+        ENABLE_PDL=use_pdl,
         num_warps=8,
         num_stages=1,
+        **pdl_kwargs,
     )
     return out
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_indexer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_indexer.py
@@ -383,13 +383,14 @@ def minimax_indexer(
     if index_k_cache.shape[0] % SPARSE_BLOCK_SIZE:
         raise ValueError("index_k_cache slot count must be divisible by 128")
 
-    index_q = index_q.contiguous()
-    index_k = index_k.contiguous()
-    slot_mapping = slot_mapping.to(
-        device=index_q.device, dtype=torch.int32
-    ).contiguous()
-    block_table = block_table.to(device=index_q.device, dtype=torch.int32).contiguous()
-    seq_lens = seq_lens.to(device=index_q.device, dtype=torch.int32).contiguous()
+    assert index_q.is_contiguous()
+    assert slot_mapping.dtype == torch.int32
+    assert slot_mapping.is_contiguous()
+    assert block_table.dtype == torch.int32
+    assert block_table.is_contiguous()
+    assert seq_lens.dtype == torch.int32
+    assert seq_lens.is_contiguous()
+
     block_d = triton.next_power_of_2(head_dim)
     _store_index_k_kernel[(tokens,)](
         index_k,
@@ -505,12 +506,11 @@ def minimax_indexer(
                 query_lens_cpu=query_lens_cpu,
                 seq_lens_cpu=seq_lens_cpu,
             )
-        cu_seqlens_q = cu_seqlens_q.to(
-            device=index_q.device, dtype=torch.int32
-        ).contiguous()
-        prefix_lens = prefix_lens.to(
-            device=index_q.device, dtype=torch.int32
-        ).contiguous()
+
+        assert cu_seqlens_q.dtype == torch.int32
+        assert cu_seqlens_q.is_contiguous()
+        assert prefix_lens.dtype == torch.int32
+        assert prefix_lens.is_contiguous()
         batch = cu_seqlens_q.numel() - 1
         scores = torch.full(
             (tokens, num_heads, max_blocks),

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_indexer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_indexer.py
@@ -63,9 +63,9 @@ def _store_index_k_kernel(
     ENABLE_PDL: tl.constexpr,
 ):
     token = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
     if ENABLE_PDL:
         tl.extra.cuda.gdc_wait()
-    dims = tl.arange(0, BLOCK_D)
     slot = tl.load(slot_mapping + token).to(tl.int64)
     values = tl.load(
         index_k + token * stride_k_n + dims * stride_k_d,
@@ -562,7 +562,9 @@ def minimax_indexer(
             num_stages=2,
         )
 
-    selected = _topk_with_padding(scores.view(tokens * num_heads, max_blocks), topk)
+    selected = _topk_with_padding(
+        scores.view(tokens * num_heads, max_blocks), topk, enable_pdl=enable_pdl
+    )
     return selected.view(tokens, num_heads, int(topk))
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_indexer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_indexer.py
@@ -459,6 +459,7 @@ def minimax_indexer(
                 init_blocks=int(init_blocks),
                 local_blocks=int(local_blocks),
                 decode_query_len=decode_query_len,
+                enable_pdl=enable_pdl,
             )
         else:
             num_chunks = 64

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_indexer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_indexer.py
@@ -19,6 +19,7 @@ from tokenspeed_kernel.ops.attention.triton.dsa_topk import _topk_with_padding
 from tokenspeed_kernel.platform import current_platform
 
 SPARSE_BLOCK_SIZE = 128
+_is_nvidia = current_platform().is_nvidia
 
 if current_platform().is_blackwell:
     try:
@@ -59,8 +60,11 @@ def _store_index_k_kernel(
     stride_cache_d,
     head_dim: tl.constexpr,
     BLOCK_D: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     token = tl.program_id(0)
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
     dims = tl.arange(0, BLOCK_D)
     slot = tl.load(slot_mapping + token).to(tl.int64)
     values = tl.load(
@@ -73,6 +77,8 @@ def _store_index_k_kernel(
         values,
         mask=dims < head_dim,
     )
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
 
 @triton.jit(do_not_specialize_on_alignment=["seq_lens", "prefix_lens"])
@@ -320,6 +326,7 @@ def minimax_indexer(
     query_lens_cpu: Sequence[int] | None = None,
     seq_lens_cpu: Sequence[int] | None = None,
     score_out: torch.Tensor | None = None,
+    enable_pdl: bool = False,
 ) -> torch.Tensor:
     """Write index keys, score visible 128-token blocks, and select Top-K.
 
@@ -392,6 +399,8 @@ def minimax_indexer(
     assert seq_lens.is_contiguous()
 
     block_d = triton.next_power_of_2(head_dim)
+    use_pdl = bool(enable_pdl and _is_nvidia)
+    pdl_kwargs = {"launch_pdl": True} if use_pdl else {}
     _store_index_k_kernel[(tokens,)](
         index_k,
         index_k_cache,
@@ -402,7 +411,9 @@ def minimax_indexer(
         index_k_cache.stride(1),
         head_dim=head_dim,
         BLOCK_D=block_d,
+        ENABLE_PDL=use_pdl,
         num_warps=4,
+        **pdl_kwargs,
     )
 
     max_blocks = block_table.shape[1] if max_blocks is None else int(max_blocks)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_sparse_attention.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_sparse_attention.py
@@ -19,13 +19,15 @@ from tokenspeed_kernel.ops.attention.triton.minimax_indexer import (
     SPARSE_BLOCK_SIZE,
     minimax_indexer,
 )
-from tokenspeed_kernel.platform import CapabilityRequirement
+from tokenspeed_kernel.platform import CapabilityRequirement, current_platform
 from tokenspeed_kernel.registry import Priority, register_kernel
 from tokenspeed_kernel.signature import (
     dense_tensor_format,
     format_signature,
     format_signatures,
 )
+
+_is_nvidia = current_platform().is_nvidia
 
 
 @triton.heuristics(
@@ -216,6 +218,7 @@ def _sparse_decode_kernel(
     BLOCK_D: tl.constexpr,
     BLOCK_H: tl.constexpr,
     USE_FP8: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     query_chunk = tl.program_id(0)
     kv_head = tl.program_id(1)
@@ -223,6 +226,8 @@ def _sparse_decode_kernel(
     chunk = query_chunk // total_queries
     request = token // decode_query_len
     query_offset = token - request * decode_query_len
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
     seq_len = tl.load(seq_lens + request)
     query_position = seq_len - decode_query_len + query_offset
     visible_blocks = (query_position + BLOCK_K) // BLOCK_K
@@ -318,6 +323,8 @@ def _sparse_decode_kernel(
         lse,
         mask=head_mask,
     )
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
 
 @triton.heuristics({"BLOCK_D": lambda args: triton.next_power_of_2(args["head_dim"])})
@@ -339,11 +346,14 @@ def _merge_decode_kernel(
     stride_out_d,
     NUM_CHUNKS: tl.constexpr,
     BLOCK_D: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     token = tl.program_id(0)
     head = tl.program_id(1)
     chunks = tl.arange(0, NUM_CHUNKS)
     dims = tl.arange(0, BLOCK_D)
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
     lse = tl.load(
         partial_lse + chunks * stride_l_c + token * stride_l_n + head * stride_l_h
     )
@@ -365,6 +375,8 @@ def _merge_decode_kernel(
         merged,
         mask=dims < head_dim,
     )
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
 
 def _validate_inputs(
@@ -412,6 +424,7 @@ def minimax_sparse_attention(
     max_query_len: int = 0,
     k_scale: float | torch.Tensor | None = None,
     v_scale: float | torch.Tensor | None = None,
+    enable_pdl: bool = False,
 ) -> torch.Tensor:
     """Run exact GQA attention over MiniMax's selected KV blocks.
 
@@ -493,6 +506,8 @@ def minimax_sparse_attention(
             dtype=torch.float32,
             device=query.device,
         )
+        use_pdl = bool(enable_pdl and _is_nvidia)
+        pdl_kwargs = {"launch_pdl": True} if use_pdl else {}
         _sparse_decode_kernel[(tokens * num_chunks, num_kv_heads)](
             query,
             key_cache,
@@ -535,8 +550,10 @@ def minimax_sparse_attention(
             NUM_CHUNKS=num_chunks,
             BLOCK_K=SPARSE_BLOCK_SIZE,
             USE_FP8=use_fp8,
+            ENABLE_PDL=use_pdl,
             num_warps=4,
             num_stages=2,
+            **pdl_kwargs,
         )
         _merge_decode_kernel[(tokens, num_heads)](
             partial_output,
@@ -554,7 +571,9 @@ def minimax_sparse_attention(
             output.stride(1),
             output.stride(2),
             NUM_CHUNKS=num_chunks,
+            ENABLE_PDL=use_pdl,
             num_warps=4,
+            **pdl_kwargs,
         )
         return output
 
@@ -702,6 +721,7 @@ def triton_minimax_msa_decode_with_kvcache(
         decode_query_len=max_seqlen_q,
         k_scale=k_scale,
         v_scale=v_scale,
+        enable_pdl=enable_pdl,
     )
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_sparse_attention.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_sparse_attention.py
@@ -667,6 +667,7 @@ def triton_minimax_msa_decode_with_kvcache(
     k_scale: float | torch.Tensor | None = None,
     v_scale: float | torch.Tensor | None = None,
     score_out: torch.Tensor | None = None,
+    enable_pdl: bool = False,
 ) -> torch.Tensor:
     """Run MiniMax sparse-attention decode over paged caches."""
 
@@ -688,6 +689,7 @@ def triton_minimax_msa_decode_with_kvcache(
         decode_query_len=max_seqlen_q,
         max_blocks=max_blocks,
         score_out=score_out,
+        enable_pdl=enable_pdl,
     )
     return minimax_sparse_attention(
         q,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/__init__.py
@@ -164,11 +164,16 @@ def _online_quantize_mxfp8(
     A: torch.Tensor,
     block_size: list[int],
     kernel_name: str,
+    enable_pdl: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Perform online activation quantization for mxfp8 block-scaled GEMM.
 
     The quantization approach is chosen based on the selected kernel's
     name because different backends require different scale layouts.
+
+    Args:
+        enable_pdl: Request Programmatic Dependent Launch for the quantize
+            kernel. Only the flashinfer path honors it; other backends ignore it.
     """
     block_k = block_size[1]
 
@@ -177,7 +182,7 @@ def _online_quantize_mxfp8(
 
         # True = F8_128x4 swizzled scales (the bool form predates the
         # SfLayout enum overload and works on flashinfer 0.6.15).
-        return mxfp8_quantize(A, is_sf_swizzled_layout=True)
+        return mxfp8_quantize(A, is_sf_swizzled_layout=True, enable_pdl=enable_pdl)
 
     if kernel_name == "triton_mm_fp8_blockscale" and block_k == 32:
         from tokenspeed_kernel.ops.quantization import quantize_fp8_with_scale
@@ -393,7 +398,9 @@ def mm(
         assert (
             block_size is not None
         ), "block_size is required for online activation quantization"
-        A, A_scales = _online_quantize_mxfp8(A, block_size, kernel.name)
+        A, A_scales = _online_quantize_mxfp8(
+            A, block_size, kernel.name, enable_pdl=enable_pdl
+        )
 
     kernel_args = (A, B, A_scales, B_scales, out_dtype)
     kernel_kwargs: dict[str, object] = {
@@ -540,7 +547,9 @@ def bmm(
         assert (
             block_size is not None
         ), "block_size is required for online activation quantization"
-        A, A_scales = _online_quantize_mxfp8(A, block_size, kernel.name)
+        A, A_scales = _online_quantize_mxfp8(
+            A, block_size, kernel.name, enable_pdl=enable_pdl
+        )
 
     kernel_args = (A, B, A_scales, B_scales, out_dtype)
     kernel_kwargs: dict[str, object] = {

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
@@ -403,10 +403,14 @@ def _fused_fp8_set_kv_buffer_kernel(
     v_cache_stride_dim: tl.constexpr,
     BLOCK_HEAD: tl.constexpr,
     BLOCK_DIM: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     token_id = tl.program_id(0)
     head_block_id = tl.program_id(1)
     kv_idx = tl.program_id(2)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
 
     cache_loc = tl.load(cache_loc_ptr + token_id).to(tl.int64)
     page_id = cache_loc // page_size
@@ -465,6 +469,9 @@ def _fused_fp8_set_kv_buffer_kernel(
             BLOCK_DIM,
         )
 
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
 
 def fused_fp8_set_kv_buffer(
     k: torch.Tensor,
@@ -475,6 +482,7 @@ def fused_fp8_set_kv_buffer(
     k_scale: float | torch.Tensor | None = None,
     v_scale: float | torch.Tensor | None = None,
     page_size: int = 16,
+    enable_pdl: bool = False,
 ) -> None:
     """Quantize K/V tensors to FP8 and scatter them into a paged KV cache.
 
@@ -493,6 +501,8 @@ def fused_fp8_set_kv_buffer(
         v_scale: Optional scalar V scale. When provided with ``k_scale``, V is
             divided by this scale before FP8 conversion.
         page_size: Number of tokens per cache page.
+        enable_pdl: Request Programmatic Dependent Launch (SM90+); no-op on
+            non-NVIDIA platforms.
     """
     num_tokens = k.shape[0]
     if num_tokens == 0:
@@ -576,6 +586,11 @@ def fused_fp8_set_kv_buffer(
         inv_k_scale_ptr = k_3d
         inv_v_scale_ptr = k_3d
 
+    use_pdl = bool(enable_pdl and _is_nvidia)
+    kwargs = {}
+    if use_pdl:
+        kwargs["launch_pdl"] = True
+
     _fused_fp8_set_kv_buffer_kernel[grid](
         k_3d,
         v_3d,
@@ -604,6 +619,8 @@ def fused_fp8_set_kv_buffer(
         v_cache_stride_dim,
         BLOCK_HEAD=block_head,
         BLOCK_DIM=block_dim,
+        ENABLE_PDL=use_pdl,
+        **kwargs,
     )
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_minimax_m3_qknorm_rope_kv_insert.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_minimax_m3_qknorm_rope_kv_insert.cu
@@ -475,7 +475,8 @@ void launchFusedMiniMaxM3(
     int const num_tokens, int const nq, int const nkv, int const niq,
     int const block_size, int64_t const kv_s_slot, int64_t const kv_s_head,
     int64_t const kv_s_dim, bool const has_index, bool const insert_kv,
-    bool const process_index, bool const fp8_idx, cudaStream_t stream) {
+    bool const process_index, bool const fp8_idx, bool const enable_pdl,
+    cudaStream_t stream) {
   // Index outputs are scalar_t (bf16) or e4m3 bytes (uint8_t); reinterpret the
   // void* pointers per instantiation in the LAUNCH macro.
   // Slot count must match the kernel's compile-time gating.
@@ -492,9 +493,9 @@ void launchFusedMiniMaxM3(
   if (grid == 0) return;
 
 #ifndef USE_ROCM
-  // PDL: enable programmatic stream serialization whenever the hardware
-  // supports it (SM90+).  On pre-Hopper GPUs the attribute is unavailable, so
-  // leave numAttrs = 0 and launch as a regular kernel via cudaLaunchKernelEx.
+  // PDL: enable programmatic stream serialization when the caller requests it
+  // and the hardware supports it (SM90+).  Otherwise leave numAttrs = 0 and
+  // launch as a regular kernel via cudaLaunchKernelEx.
   static int const sm_version = getSMVersion();
   cudaLaunchConfig_t config;
   config.gridDim = dim3(grid);
@@ -505,7 +506,7 @@ void launchFusedMiniMaxM3(
   attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
   attrs[0].val.programmaticStreamSerializationAllowed = 1;
   config.attrs = attrs;
-  config.numAttrs = (sm_version >= 90) ? 1 : 0;
+  config.numAttrs = (enable_pdl && sm_version >= 90) ? 1 : 0;
 
   #define LAUNCH(HAS_INDEX, INSERT, PROCESS_INDEX, FP8, OUT_T)                 \
     cudaLaunchKernelEx(                                                        \
@@ -583,7 +584,7 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
     Optional<TensorView> index_cache,
     int64_t block_size, Optional<TensorView> q_out,
     Optional<TensorView> index_q_out, int64_t kv_cache_dtype,
-    bool skip_index_branch) {
+    bool skip_index_branch, bool enable_pdl) {
   namespace mm = vllm::minimax_m3_fused_ops;
   constexpr int kHeadDim = mm::kHeadDim;
 
@@ -710,7 +711,7 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
       reinterpret_cast<CACHE_T*>(v_cache_ptr), index_cache_ptr,              \
       static_cast<float>(eps), static_cast<int>(rotary_dim), num_tokens, nq,  \
       nkv, niq, static_cast<int>(block_size), kv_s_slot, kv_s_head, kv_s_dim, \
-      has_index, insert_kv, process_index, fp8_idx, stream)
+      has_index, insert_kv, process_index, fp8_idx, enable_pdl, stream)
 
 #define TS_DISPATCH_KV(ST)                                                    \
   if (kv_dt == vllm::Fp8KVCacheDataType::kAuto)                               \

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_minimax_m3_qknorm_rope_kv_insert.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_minimax_m3_qknorm_rope_kv_insert.cu
@@ -1,0 +1,733 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ *
+ * Horizontally-fused MiniMax-M3 attention pre-processing kernel.
+ *
+ * Replaces the per-token Python sequence in
+ * ``MiniMaxM3SparseAttention.forward`` / ``MiniMaxM3Attention.forward``:
+ *
+ *     q  = q_norm(q);  k = k_norm(k);  q, k = rotary_emb(pos, q, k)
+ *     index_q = index_q_norm(index_q);  index_k = index_k_norm(index_k)
+ *     index_q, index_k = rotary_emb(pos, index_q, index_k)
+ *     _insert_kv(k, v, index_k)
+ *
+ * All branches share head_dim=128 and the *same* partial-NeoX RoPE table
+ * (``rotary_dim`` rotated, the trailing dims pass through).  The four norms
+ * are Gemma-style RMSNorm (``x * rsqrt(mean(x^2)+eps) * (1 + weight)``) with
+ * independent weights.
+ *
+ * Everything lives in a single fused ``qkv`` tensor.  The sparse layer's
+ * fused projection (MinimaxM3QKVParallelLinearWithIndexer) emits, per token::
+ *
+ *     [ q | k | v | index_q | index_k ]   (the "5 results")
+ *
+ * while the dense layer emits just ``[ q | k | v ]``.  The kernel reads the
+ * index branch straight out of that packed row -- no separate index tensors.
+ *
+ * One kernel, one grid; each warp owns one (token, head-slot) pair.  Slot
+ * enumeration per token:
+ *     [0, nq)                         Q  heads   -> norm(q_w)  + RoPE, write
+ * qkv [nq, nq+nkv)                    K  heads   -> norm(k_w)  + RoPE, write
+ * qkv
+ *                                                  (+ insert into key cache)
+ *     [nq+nkv, nq+2*nkv)              V  heads   -> insert into value cache
+ *     IQ heads (niq)                             -> norm(iq_w) + RoPE, write iq
+ *     IK       (1)                               -> norm(ik_w) + RoPE
+ *                                                  (+ insert into index cache)
+ *
+ * The IQ/IK warps address the index_q/index_k sub-blocks *inside* qkv at the
+ * fixed physical offsets (nq+2*nkv)*128 and (nq+2*nkv+niq)*128.
+ *
+ * Dense vs sparse row layout and index-branch processing are separate template
+ * choices. Skip-index-topk reuse layers still have sparse rows and insert main
+ * K/V cache entries, but compile away index_q/index_k work and index-cache
+ * writes.
+ *
+ * Q/K and (sparse) index_q/index_k are all rewritten in place inside the fused
+ * ``qkv`` tensor.  Caches (bf16) are scatter-written by slot.
+ */
+
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <type_traits>
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+
+#include "tvm_ffi_utils.h"
+
+// TokenSpeed vendoring note: this kernel is the vLLM
+// fused_minimax_m3_qknorm_rope_kv_insert CUDA kernel, adapted to TokenSpeed's
+// TVM-FFI (no-libtorch) build. The device algorithm is unchanged; only the
+// includes, scalar<->float conversions, the fp8 helpers, and the host binding
+// were ported. NVIDIA-only (ROCm branches are inert).
+
+#ifndef FINAL_MASK
+  #define FINAL_MASK 0xffffffffu
+#endif
+
+namespace vllm {
+
+// Inlined from vLLM quant_utils (identity-scale path only) to avoid pulling in
+// its attention-dtype header tree. Only auto (unquantized) + e4m3/e5m2 used.
+enum class Fp8KVCacheDataType { kAuto = 0, kFp8E4M3 = 1, kFp8E5M2 = 2 };
+
+inline Fp8KVCacheDataType get_fp8_kv_cache_data_type(const std::string& s) {
+  if (s == "auto" || s.empty()) return Fp8KVCacheDataType::kAuto;
+  if (s == "fp8" || s == "fp8_e4m3") return Fp8KVCacheDataType::kFp8E4M3;
+  if (s == "fp8_e5m2") return Fp8KVCacheDataType::kFp8E5M2;
+  TVM_FFI_ICHECK(false) << "unsupported kv_cache_dtype: " << s;
+  return Fp8KVCacheDataType::kAuto;
+}
+
+namespace minimax_m3_fused_ops {
+
+namespace {
+inline int getSMVersion() {
+  int dev = 0;
+  cudaGetDevice(&dev);
+  cudaDeviceProp props;
+  cudaGetDeviceProperties(&props, dev);
+  return props.major * 10 + props.minor;
+}
+}  // namespace
+
+// ────────────────────────────────────────────────────────────────────────────
+// Constants (hard-coded for MiniMax-M3-preview).
+// ────────────────────────────────────────────────────────────────────────────
+constexpr int kHeadDim = 128;
+constexpr int kNumLanes = 32;
+constexpr int kElemsPerLane = kHeadDim / kNumLanes;  // 4
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+__device__ __forceinline__ float warpReduceSum(float val) {
+#pragma unroll
+  for (int mask = 16; mask > 0; mask >>= 1) {
+    val += __shfl_xor_sync(FINAL_MASK, val, mask, 32);
+  }
+  return val;
+}
+
+// Gemma RMSNorm over the full head (no-op when ``weight == nullptr``), rounded
+// back to scalar_t like the materialized unfused norm output, followed by
+// partial NeoX RoPE on the leading ``rotary_dim`` dims. Each lane owns
+// ``kElemsPerLane`` contiguous dims [laneId*4, laneId*4+4).
+template <typename scalar_t>
+__device__ __forceinline__ void normAndRope(
+    float (&elems)[kElemsPerLane], int const laneId, float const eps,
+    scalar_t const* __restrict__ weight,  // [kHeadDim] or nullptr (no norm)
+    bool const do_rope, int const rotary_dim,
+    float const* __restrict__ cos_ptr,  // fp32 cos_sin_cache + pos*rotary_dim
+    bool const apply_norm) {
+  // ── Gemma RMSNorm: x * rsqrt(mean(x^2)+eps) * (1 + w) ──────────────────
+  if (apply_norm) {
+    float sumsq = 0.0f;
+#pragma unroll
+    for (int i = 0; i < kElemsPerLane; i++) sumsq += elems[i] * elems[i];
+    sumsq = warpReduceSum(sumsq);
+    float const rms_rcp = rsqrtf(sumsq / static_cast<float>(kHeadDim) + eps);
+#pragma unroll
+    for (int i = 0; i < kElemsPerLane; i++) {
+      int const dim = laneId * kElemsPerLane + i;
+      float const w = 1.0f + static_cast<float>(weight[dim]);
+      elems[i] = elems[i] * rms_rcp * w;
+    }
+  }
+
+  // ── Partial NeoX RoPE on dims [0, rotary_dim) ──────────────────────────
+  // half = rotary_dim/2.  Pair (i, i+half) for i in [0, half).  Lane L owns
+  // dims [4L, 4L+4); since half is a multiple of 4, a lane lies wholly in the
+  // first half (own=x[i]) or second half (own=x[i+half]); its partner lives
+  // ``half/4`` lanes away (XOR with that distance).
+  if (do_rope) {
+    int const half = rotary_dim / 2;
+    int const dim0 = laneId * kElemsPerLane;
+    bool const in_rope = dim0 < rotary_dim;
+    int const lane_xor = half / kElemsPerLane;  // partner-lane distance
+
+    float partner[kElemsPerLane];
+#pragma unroll
+    for (int i = 0; i < kElemsPerLane; i++) {
+      partner[i] = __shfl_xor_sync(FINAL_MASK, elems[i], lane_xor, 32);
+    }
+    if (in_rope) {
+      bool const first_half = dim0 < half;
+      int const i_base = first_half ? dim0 : (dim0 - half);  // cos/sin index
+      float const* sin_ptr = cos_ptr + half;
+#pragma unroll
+      for (int i = 0; i < kElemsPerLane; i++) {
+        float const c = static_cast<float>(cos_ptr[i_base + i]);
+        float const s = static_cast<float>(sin_ptr[i_base + i]);
+        if (first_half) {
+          elems[i] = elems[i] * c - partner[i] * s;
+        } else {
+          elems[i] = elems[i] * c + partner[i] * s;
+        }
+      }
+    }
+  }
+}
+
+// bf16/fp16 <-> float element converters.
+template <typename scalar_t>
+__device__ __forceinline__ float elemToFloat(scalar_t x) {
+  if constexpr (std::is_same_v<scalar_t, __nv_bfloat16>)
+    return __bfloat162float(x);
+  else
+    return __half2float(x);
+}
+template <typename scalar_t>
+__device__ __forceinline__ scalar_t floatToElem(float x) {
+  if constexpr (std::is_same_v<scalar_t, __nv_bfloat16>)
+    return __float2bfloat16(x);
+  else
+    return __float2half(x);
+}
+
+// Load 4 contiguous bf16/fp16 -> 4 fp32 registers.
+template <typename scalar_t>
+__device__ __forceinline__ void loadElems(scalar_t const* __restrict__ src,
+                                          float (&elems)[kElemsPerLane]) {
+#pragma unroll
+  for (int i = 0; i < kElemsPerLane; i++)
+    elems[i] = elemToFloat<scalar_t>(src[i]);
+}
+
+// Store 4 fp32 registers -> 4 contiguous bf16/fp16.
+template <typename scalar_t>
+__device__ __forceinline__ void storeElems(
+    scalar_t* __restrict__ dst, float const (&elems)[kElemsPerLane]) {
+#pragma unroll
+  for (int i = 0; i < kElemsPerLane; i++)
+    dst[i] = floatToElem<scalar_t>(elems[i]);
+}
+
+// Main K/V cache store. kAuto = unquantized (cache_t == scalar_t); fp8 cache
+// dtypes use the scaled-convert path with identity scale.
+template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt>
+__device__ __forceinline__ void storeCacheElems(
+    cache_t* __restrict__ dst, float const (&elems)[kElemsPerLane]) {
+  if constexpr (kv_dt == Fp8KVCacheDataType::kAuto) {
+    // kAuto means unquantized KV cache here: cache_t == scalar_t, so store the
+    // model dtype directly. FP8 cache dtypes use the conversion path below.
+    storeElems<scalar_t>(reinterpret_cast<scalar_t*>(dst), elems);
+  } else {
+    // fp8 cache (identity scale 1.0): direct float -> e4m3/e5m2 byte.
+    constexpr __nv_fp8_interpretation_t kInterp =
+        (kv_dt == Fp8KVCacheDataType::kFp8E4M3) ? __NV_E4M3 : __NV_E5M2;
+#pragma unroll
+    for (int i = 0; i < kElemsPerLane; i++) {
+      dst[i] = static_cast<cache_t>(
+          __nv_cvt_float_to_fp8(elems[i], __NV_SATFINITE, kInterp));
+    }
+  }
+}
+
+// Store 4 fp32 registers -> 4 contiguous E4M3 FP8 bytes (direct cast,
+// saturating to ±448). Used for the fp8 indexer-Q / index-K outputs; no scale
+// (RMSNorm outputs are O(1) and the score path only needs relative block
+// ordering).
+__device__ __forceinline__ void storeElemsFp8(
+    uint8_t* __restrict__ dst, float const (&elems)[kElemsPerLane]) {
+  constexpr float kFp8Max = 448.0f;
+#ifndef USE_ROCM
+  __nv_fp8x2_storage_t out2[kElemsPerLane / 2];
+  #pragma unroll
+  for (int i = 0; i < kElemsPerLane / 2; i++) {
+    float2 vv = make_float2(elems[2 * i], elems[2 * i + 1]);
+    vv.x = fminf(fmaxf(vv.x, -kFp8Max), kFp8Max);
+    vv.y = fminf(fmaxf(vv.y, -kFp8Max), kFp8Max);
+    out2[i] = __nv_cvt_float2_to_fp8x2(vv, __NV_SATFINITE, __NV_E4M3);
+  }
+  *reinterpret_cast<uint32_t*>(dst) = *reinterpret_cast<uint32_t const*>(out2);
+#else
+  #pragma unroll
+  for (int i = 0; i < kElemsPerLane; i++) {
+    float vv = fminf(fmaxf(elems[i], -kFp8Max), kFp8Max);
+    dst[i] = rocm_cvt_float_to_fp8_e4m3(vv);
+  }
+#endif
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Kernel
+// ────────────────────────────────────────────────────────────────────────────
+// Grid: 1D, ceil(num_tokens * slots_per_token / warps_per_block).
+// Each warp = one (token, slot).
+//
+// `kHasIndex`, `kProcessIndex`, and `kInsertKV` are compile-time template
+// bools, so branch decisions that distinguish the dense layer from the sparse
+// layer (index slots, KV/index inserts, V slots) fold away per instantiation.
+// Slots per token:
+//     Q : nq                            (always — norm+RoPE)
+//     K : nkv                           (always — norm+RoPE; +K-cache insert)
+//     V : nkv  only if kInsertKV        (V-cache insert; no warps in dense)
+//     IQ: niq  only if kProcessIndex    (norm+RoPE)
+//     IK: 1    only if kProcessIndex    (norm+RoPE; +index-cache insert)
+// cache_t/kv_dt: main attention KV-cache dtype (auto/fp8). out_idx_t/kFp8Idx:
+// indexer index-K cache + index-Q output dtype (scalar_t or e4m3 byte).
+// kHasIndex means the qkv row is laid out as sparse [q|k|v|index_q|index_k].
+// kProcessIndex controls whether this launch actually norms/ropes the index
+// branch and writes index_q/index_k outputs. Skip-index-topk reuse layers keep
+// kHasIndex=true but set kProcessIndex=false.
+template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt,
+          typename out_idx_t, bool kHasIndex, bool kInsertKV,
+          bool kProcessIndex,
+          bool kFp8Idx>
+__global__ void fusedMiniMaxM3QNormRopeKVInsertKernel(
+    scalar_t* __restrict__ qkv,  // [N, qkv_row] in/out (packs index if sparse)
+    scalar_t* __restrict__ q_out,         // [N, nq*128] contiguous, or nullptr
+    out_idx_t* __restrict__ index_q_out,  // [N, niq*128]; scalar_t or e4m3 byte
+    scalar_t const* __restrict__ q_norm_w,
+    scalar_t const* __restrict__ k_norm_w,
+    scalar_t const* __restrict__ iq_norm_w,
+    scalar_t const* __restrict__ ik_norm_w,
+    float const* __restrict__ cos_sin_cache,  // fp32 [max_pos, rotary_dim]
+    int64_t const* __restrict__ positions,       // [N] i64
+    int64_t const* __restrict__ slot_mapping,    // main K/V slots or nullptr
+    int64_t const* __restrict__ index_slot_mapping,  // index K slots/nullptr
+    cache_t* __restrict__ k_cache,        // [num_slots, nkv, 128] or nullptr
+    cache_t* __restrict__ v_cache,        // [num_slots, nkv, 128] or nullptr
+    out_idx_t* __restrict__ index_cache,  // [nb*bs, 128]; scalar_t or e4m3 byte
+    float const eps, int const rotary_dim, int const num_tokens, int const nq,
+    int const nkv, int const niq, int const block_size,
+    // TokenSpeed separate flat k_cache/v_cache strides (in elements) for logical
+    // shape [num_slots, nkv, head_dim]. The content (dim) is innermost-contiguous.
+    int64_t const kv_s_slot, int64_t const kv_s_head, int64_t const kv_s_dim) {
+    // (Pre-Ampere bf16 guard removed for the NVIDIA sm90+ vendored build.)
+    int const warpsPerBlock = blockDim.x / 32;
+    int const laneId = threadIdx.x % 32;
+    int const globalWarpIdx = blockIdx.x * warpsPerBlock + (threadIdx.x / 32);
+
+    static_assert(!kProcessIndex || kHasIndex,
+                  "index processing requires sparse row layout");
+
+    // Slot layout (compile-time gated: dense has neither V nor index slots).
+    int const v_slots = kInsertKV ? nkv : 0;
+    int const idx_slots = kProcessIndex ? niq + 1 : 0;
+    int const slots_per_token = nq + nkv + v_slots + idx_slots;
+
+    int const tokenIdx = globalWarpIdx / slots_per_token;
+    int const slot = globalWarpIdx % slots_per_token;
+    if (tokenIdx >= num_tokens) return;
+
+    // Slot boundaries.
+    int const k_begin = nq;
+    int const v_begin = nq + nkv;             // valid only when kInsertKV
+    int const iq_begin = nq + nkv + v_slots;  // index block start
+    int const ik_slot = iq_begin + niq;       // valid only when kProcessIndex
+
+    bool const isQ = slot < k_begin;
+    bool const isK = slot >= k_begin && slot < v_begin;
+    bool isV = false;
+    if constexpr (kInsertKV) isV = slot >= v_begin && slot < v_begin + nkv;
+    bool isIQ = false, isIK = false;
+    if constexpr (kProcessIndex) {
+      isIQ = slot >= iq_begin && slot < ik_slot;
+      isIK = slot == ik_slot;
+    }
+
+    int const dim_base = laneId * kElemsPerLane;
+    // Physical row width of qkv: the dense layer packs [q|k|v]; the sparse
+    // layer additionally packs [index_q (niq heads) | index_k (1 head)].
+    int const qkv_row = (nq + 2 * nkv + (kHasIndex ? (niq + 1) : 0)) * kHeadDim;
+
+    // ── Resolve source pointer + per-branch parameters. ────────────────────
+    scalar_t* row_ptr = nullptr;       // in-place output location
+    scalar_t const* norm_w = nullptr;  // nullptr -> skip norm (V)
+    bool do_rope = true;
+    int head = 0;  // kv head index for inserts
+
+    if (isQ) {
+      row_ptr =
+          qkv + static_cast<int64_t>(tokenIdx) * qkv_row + slot * kHeadDim;
+      norm_w = q_norm_w;
+    } else if (isK) {
+      head = slot - k_begin;
+      row_ptr =
+          qkv + static_cast<int64_t>(tokenIdx) * qkv_row + slot * kHeadDim;
+      norm_w = k_norm_w;
+    } else if (isV) {
+      // qkv V section starts at slot index (nq + nkv): slot * kHeadDim is the
+      // correct in-tensor offset.
+      head = slot - v_begin;
+      row_ptr =
+          qkv + static_cast<int64_t>(tokenIdx) * qkv_row + slot * kHeadDim;
+      norm_w = nullptr;  // V: no norm, no rope
+      do_rope = false;
+    } else if (isIQ) {
+      // index_q sub-block lives at physical offset (nq+2*nkv)*128 in qkv.
+      int const ih = slot - iq_begin;
+      row_ptr = qkv + static_cast<int64_t>(tokenIdx) * qkv_row +
+                (nq + 2 * nkv + ih) * kHeadDim;
+      norm_w = iq_norm_w;
+    } else if (isIK) {
+      // Single shared index key at (nq+2*nkv+niq)*128.
+      row_ptr = qkv + static_cast<int64_t>(tokenIdx) * qkv_row +
+                (nq + 2 * nkv + niq) * kHeadDim;
+      norm_w = ik_norm_w;
+    } else {
+      return;
+    }
+
+    // Store destination.  Q and index_q are gathered into dedicated contiguous
+    // output buffers (when provided) so the downstream SM100 sparse kernel's
+    // flat TMA descriptor can address them as [tokens*heads, head_dim]; this
+    // folds the de-interleaving into the store the kernel already does, instead
+    // of a separate q.contiguous() copy.  Everything else stays in place.
+    scalar_t* store_ptr = row_ptr;
+    if (isQ && q_out != nullptr) {
+      store_ptr = q_out + static_cast<int64_t>(tokenIdx) * nq * kHeadDim +
+                  slot * kHeadDim;
+    } else if (isIQ && index_q_out != nullptr) {
+      // bf16 index_q_out: gather here. fp8: written by the explicit fp8 store.
+      if constexpr (!kFp8Idx) {
+        store_ptr = index_q_out +
+                    static_cast<int64_t>(tokenIdx) * niq * kHeadDim +
+                    (slot - iq_begin) * kHeadDim;
+      }
+    }
+
+    // PDL: wait for the predecessor kernel (the qkv-projection GEMM that
+    // produces ``qkv``) to finish before touching any global memory.  No-op
+    // when PDL is not enabled on the launch.  The CUDA runtime wrapper emits
+    // the griddepcontrol.wait PTX with the required memory clobber internally.
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+    cudaGridDependencySynchronize();
+#endif
+
+    // ── Load -> norm+rope (fp32) -> store back in place. ───────────────────
+    float elems[kElemsPerLane];
+    loadElems<scalar_t>(row_ptr + dim_base, elems);
+
+    if (!isV) {
+      int64_t const pos = positions[tokenIdx];
+      float const* cos_ptr = cos_sin_cache + pos * rotary_dim;
+      normAndRope<scalar_t>(elems, laneId, eps, norm_w, do_rope, rotary_dim,
+                            cos_ptr, /*apply_norm=*/norm_w != nullptr);
+      if constexpr (kFp8Idx) {
+        // index_q is e4m3 bytes; Q/K (and in-place index_k) stay scalar_t.
+        if (isIQ && index_q_out != nullptr) {
+          storeElemsFp8(index_q_out +
+                            static_cast<int64_t>(tokenIdx) * niq * kHeadDim +
+                            (slot - iq_begin) * kHeadDim + dim_base,
+                        elems);
+        } else {
+          storeElems<scalar_t>(store_ptr + dim_base, elems);
+        }
+      } else {
+        storeElems<scalar_t>(store_ptr + dim_base, elems);
+      }
+    }
+
+    // ── Cache inserts (sparse serving only). ───────────────────────────────
+    if constexpr (kInsertKV) {
+      // Guard (not early-return) so every thread reaches the PDL trigger below.
+      int64_t sm = -1;
+      if (isK || isV) {
+        sm = slot_mapping[tokenIdx];
+      } else if constexpr (kProcessIndex) {
+        if (isIK) sm = index_slot_mapping[tokenIdx];
+      }
+      if (sm >= 0) {  // skip padded / unscheduled tokens
+        if (isIK) {
+          if constexpr (kFp8Idx) {
+            storeElemsFp8(index_cache + sm * kHeadDim + dim_base, elems);
+          } else {
+            storeElems<scalar_t>(index_cache + sm * kHeadDim + dim_base, elems);
+          }
+        } else if (isK || isV) {
+          // TokenSpeed: separate flat slot-indexed k_cache / v_cache, logical
+          // shape [num_slots, nkv, head_dim]. ``sm`` is the direct slot row; the
+          // physical layout rides the passed strides (block_size unused here).
+          cache_t* dst = isK ? k_cache : v_cache;
+          int64_t const off =
+              sm * kv_s_slot + head * kv_s_head + dim_base * kv_s_dim;
+          storeCacheElems<scalar_t, cache_t, kv_dt>(dst + off, elems);
+        }
+      }
+    }
+
+    // PDL: signal that this kernel is done so a dependent successor may launch
+    // early.  No-op when PDL is not enabled on the launch.
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+    cudaTriggerProgrammaticLaunchCompletion();
+#endif
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Launch wrapper
+// ────────────────────────────────────────────────────────────────────────────
+template <typename scalar_t, typename cache_t, Fp8KVCacheDataType kv_dt>
+void launchFusedMiniMaxM3(
+    scalar_t* qkv, scalar_t* q_out, void* index_q_out, scalar_t const* q_norm_w,
+    scalar_t const* k_norm_w, scalar_t const* iq_norm_w,
+    scalar_t const* ik_norm_w, float const* cos_sin_cache,
+    int64_t const* positions, int64_t const* slot_mapping,
+    int64_t const* index_slot_mapping, cache_t* k_cache, cache_t* v_cache,
+    void* index_cache, float const eps, int const rotary_dim,
+    int const num_tokens, int const nq, int const nkv, int const niq,
+    int const block_size, int64_t const kv_s_slot, int64_t const kv_s_head,
+    int64_t const kv_s_dim, bool const has_index, bool const insert_kv,
+    bool const process_index, bool const fp8_idx, cudaStream_t stream) {
+  // Index outputs are scalar_t (bf16) or e4m3 bytes (uint8_t); reinterpret the
+  // void* pointers per instantiation in the LAUNCH macro.
+  // Slot count must match the kernel's compile-time gating.
+  int const v_slots = insert_kv ? nkv : 0;
+  int const idx_slots = process_index ? niq + 1 : 0;
+  int const slots_per_token = nq + nkv + v_slots + idx_slots;
+
+  constexpr int kBlockSize = 256;
+  constexpr int kWarpsPerBlock = kBlockSize / 32;
+  int64_t const total_warps =
+      static_cast<int64_t>(num_tokens) * slots_per_token;
+  int const grid =
+      static_cast<int>((total_warps + kWarpsPerBlock - 1) / kWarpsPerBlock);
+  if (grid == 0) return;
+
+#ifndef USE_ROCM
+  // PDL: enable programmatic stream serialization whenever the hardware
+  // supports it (SM90+).  On pre-Hopper GPUs the attribute is unavailable, so
+  // leave numAttrs = 0 and launch as a regular kernel via cudaLaunchKernelEx.
+  static int const sm_version = getSMVersion();
+  cudaLaunchConfig_t config;
+  config.gridDim = dim3(grid);
+  config.blockDim = dim3(kBlockSize);
+  config.dynamicSmemBytes = 0;
+  config.stream = stream;
+  cudaLaunchAttribute attrs[1];
+  attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attrs[0].val.programmaticStreamSerializationAllowed = 1;
+  config.attrs = attrs;
+  config.numAttrs = (sm_version >= 90) ? 1 : 0;
+
+  #define LAUNCH(HAS_INDEX, INSERT, PROCESS_INDEX, FP8, OUT_T)                 \
+    cudaLaunchKernelEx(                                                        \
+        &config,                                                               \
+        fusedMiniMaxM3QNormRopeKVInsertKernel<scalar_t, cache_t, kv_dt, OUT_T, \
+                                              HAS_INDEX, INSERT,               \
+                                              PROCESS_INDEX, FP8>,             \
+        qkv, q_out, reinterpret_cast<OUT_T*>(index_q_out), q_norm_w, k_norm_w, \
+        iq_norm_w, ik_norm_w, cos_sin_cache, positions, slot_mapping,          \
+        index_slot_mapping, k_cache, v_cache,                                  \
+        reinterpret_cast<OUT_T*>(index_cache), eps, rotary_dim, num_tokens,    \
+        nq, nkv, niq, block_size, kv_s_slot, kv_s_head, kv_s_dim)
+#else
+  // ROCm: standard kernel launch syntax (no PDL/stream serialization).
+  // clang-format off
+  #define LAUNCH(HAS_INDEX, INSERT, PROCESS_INDEX, FP8, OUT_T)              \
+    fusedMiniMaxM3QNormRopeKVInsertKernel<                                  \
+        scalar_t, cache_t, kv_dt, OUT_T, HAS_INDEX, INSERT, PROCESS_INDEX,  \
+        FP8><<<grid, kBlockSize, 0, stream>>>(                              \
+        qkv, q_out, reinterpret_cast<OUT_T*>(index_q_out), q_norm_w,        \
+        k_norm_w, iq_norm_w, ik_norm_w, cos_sin_cache, positions,           \
+        slot_mapping, index_slot_mapping, k_cache, v_cache,                 \
+        reinterpret_cast<OUT_T*>(index_cache), eps, rotary_dim, num_tokens, \
+        nq, nkv, niq, block_size, kv_s_slot, kv_s_head, kv_s_dim)
+  // clang-format on
+#endif
+
+  if (has_index) {
+    if (!process_index) {
+      if (insert_kv) {
+        LAUNCH(true, true, false, false, scalar_t);
+      } else {
+        LAUNCH(true, false, false, false, scalar_t);
+      }
+    } else if (insert_kv) {
+      if (fp8_idx) {
+        LAUNCH(true, true, true, true,
+               uint8_t);  // sparse serving, fp8 index outputs
+      } else {
+        LAUNCH(true, true, true, false, scalar_t);  // sparse serving, bf16
+      }
+    } else {
+      if (fp8_idx) {
+        LAUNCH(true, false, true, true,
+               uint8_t);  // sparse profiling, fp8 index_q
+      } else {
+        LAUNCH(true, false, true, false, scalar_t);  // sparse profiling, bf16
+      }
+    }
+  } else {
+    // Dense layer: never has an index branch and never inserts here (the
+    // generic Attention layer owns the KV insert).
+    LAUNCH(false, false, false, false, scalar_t);
+  }
+#undef LAUNCH
+}
+
+}  // namespace minimax_m3_fused_ops
+}  // namespace vllm
+
+// ────────────────────────────────────────────────────────────────────────────
+// TVM-FFI host binding (ported from vLLM's torch::stable wrapper).
+// kv_cache_dtype is passed as an int code: 0=auto, 1=fp8_e4m3, 2=fp8_e5m2.
+// ────────────────────────────────────────────────────────────────────────────
+using tvm::ffi::Optional;
+
+void fused_minimax_m3_qknorm_rope_kv_insert(
+    TensorView qkv, TensorView q_norm_weight, TensorView k_norm_weight,
+    TensorView cos_sin_cache, TensorView positions, int64_t num_heads,
+    int64_t num_kv_heads, int64_t rotary_dim, double eps,
+    Optional<TensorView> index_q_norm_weight,
+    Optional<TensorView> index_k_norm_weight, int64_t num_index_heads,
+    Optional<TensorView> slot_mapping, Optional<TensorView> index_slot_mapping,
+    Optional<TensorView> k_cache, Optional<TensorView> v_cache,
+    Optional<TensorView> index_cache,
+    int64_t block_size, Optional<TensorView> q_out,
+    Optional<TensorView> index_q_out, int64_t kv_cache_dtype,
+    bool skip_index_branch) {
+  namespace mm = vllm::minimax_m3_fused_ops;
+  constexpr int kHeadDim = mm::kHeadDim;
+
+  TVM_FFI_ICHECK(qkv.dtype() == dl_bfloat16 || qkv.dtype() == dl_float16)
+      << "qkv must be float16 or bfloat16";
+  TVM_FFI_ICHECK(positions.dtype() == dl_int64) << "positions must be int64";
+  TVM_FFI_ICHECK(cos_sin_cache.dtype() == dl_float32)
+      << "cos_sin_cache must be float32 (RoPE applied at fp32 precision)";
+  TVM_FFI_ICHECK(cos_sin_cache.ndim() == 2 &&
+                 cos_sin_cache.size(1) == rotary_dim)
+      << "cos_sin_cache shape [max_pos, rotary_dim]";
+  TVM_FFI_ICHECK(q_norm_weight.dtype() == qkv.dtype() &&
+                 k_norm_weight.dtype() == qkv.dtype())
+      << "q/k norm weight dtype must match qkv";
+  TVM_FFI_ICHECK(q_norm_weight.numel() == kHeadDim &&
+                 k_norm_weight.numel() == kHeadDim)
+      << "q/k norm weight must have 128 elements";
+  TVM_FFI_ICHECK(rotary_dim > 0 && rotary_dim % 8 == 0 && rotary_dim <= kHeadDim)
+      << "rotary_dim must be a positive multiple of 8 and <= 128";
+
+  int const num_tokens = static_cast<int>(qkv.size(0));
+  int const nq = static_cast<int>(num_heads);
+  int const nkv = static_cast<int>(num_kv_heads);
+  int const niq = static_cast<int>(num_index_heads);
+  bool const has_index = niq > 0;
+  bool const insert_kv = k_cache.has_value();
+  bool const process_index = has_index && !skip_index_branch;
+  vllm::Fp8KVCacheDataType const kv_dt =
+      static_cast<vllm::Fp8KVCacheDataType>(kv_cache_dtype);
+
+  int const expected_row =
+      (nq + 2 * nkv + (has_index ? niq + 1 : 0)) * kHeadDim;
+  TVM_FFI_ICHECK(qkv.size(1) == expected_row)
+      << "qkv last dim must be (nq + 2*nkv + niq + 1)*128 sparse / (nq+2*nkv)*128 dense";
+  TVM_FFI_ICHECK(!insert_kv || has_index)
+      << "insert mode (kv_cache) requires the index branch (sparse layer)";
+  TVM_FFI_ICHECK(has_index || !skip_index_branch)
+      << "skip_index_branch requires sparse qkv rows";
+  if (process_index) {
+    TVM_FFI_ICHECK(index_q_norm_weight.has_value() &&
+                   index_k_norm_weight.has_value())
+        << "index branch requires both index norm weights";
+    TVM_FFI_ICHECK(index_q_norm_weight.value().numel() == kHeadDim &&
+                   index_k_norm_weight.value().numel() == kHeadDim)
+        << "index norm weights must have 128 elements";
+  }
+
+  int64_t kv_s_slot = 0, kv_s_head = 0, kv_s_dim = 0;
+  if (insert_kv) {
+    TVM_FFI_ICHECK(slot_mapping.has_value() &&
+                   slot_mapping.value().dtype() == dl_int64)
+        << "insert mode requires int64 slot_mapping";
+    TVM_FFI_ICHECK(v_cache.has_value()) << "insert mode requires v_cache";
+    TensorView kc = k_cache.value();
+    TensorView vc = v_cache.value();
+    // TokenSpeed separate flat caches: [num_slots, nkv, head_dim].
+    TVM_FFI_ICHECK(kc.ndim() == 3 && kc.stride(2) == 1)
+        << "k_cache must be [num_slots, nkv, head_dim], contiguous content dim";
+    TVM_FFI_ICHECK(vc.ndim() == 3 && vc.stride(0) == kc.stride(0) &&
+                   vc.stride(1) == kc.stride(1) && vc.stride(2) == kc.stride(2))
+        << "v_cache must share k_cache's [num_slots, nkv, head_dim] layout";
+    if (kv_dt == vllm::Fp8KVCacheDataType::kAuto) {
+      TVM_FFI_ICHECK(kc.dtype() == qkv.dtype() && vc.dtype() == qkv.dtype())
+          << "auto k/v_cache dtype must match qkv";
+    } else {
+      TVM_FFI_ICHECK(kc.dtype() == dl_uint8 && vc.dtype() == dl_uint8)
+          << "fp8 k/v_cache must use uint8 storage";
+    }
+    if (process_index)
+      TVM_FFI_ICHECK(index_cache.has_value() &&
+                     (index_cache.value().dtype() == qkv.dtype() ||
+                      index_cache.value().dtype() == dl_float8_e4m3fn))
+          << "index_cache must match qkv dtype or fp8 e4m3";
+    kv_s_slot = kc.stride(0);
+    kv_s_head = kc.stride(1);
+    kv_s_dim = kc.stride(2);
+  }
+
+  bool const fp8_idx =
+      process_index &&
+      ((index_cache.has_value() &&
+        index_cache.value().dtype() == dl_float8_e4m3fn) ||
+       (index_q_out.has_value() &&
+        index_q_out.value().dtype() == dl_float8_e4m3fn));
+
+  void* qkv_ptr = qkv.data_ptr();
+  void* q_out_ptr = q_out.has_value() ? q_out.value().data_ptr() : nullptr;
+  void* index_q_out_ptr =
+      index_q_out.has_value() ? index_q_out.value().data_ptr() : nullptr;
+  void const* q_norm_ptr = q_norm_weight.data_ptr();
+  void const* k_norm_ptr = k_norm_weight.data_ptr();
+  void const* iq_norm_ptr =
+      process_index ? index_q_norm_weight.value().data_ptr() : nullptr;
+  void const* ik_norm_ptr =
+      process_index ? index_k_norm_weight.value().data_ptr() : nullptr;
+  void const* csc_ptr = cos_sin_cache.data_ptr();
+  int64_t const* pos_ptr = static_cast<int64_t const*>(positions.data_ptr());
+  int64_t const* slot_ptr =
+      insert_kv ? static_cast<int64_t const*>(slot_mapping.value().data_ptr())
+                : nullptr;
+  int64_t const* idx_slot_ptr = nullptr;
+  if (insert_kv && process_index)
+    idx_slot_ptr = static_cast<int64_t const*>(
+        (index_slot_mapping.has_value() ? index_slot_mapping.value()
+                                        : slot_mapping.value())
+            .data_ptr());
+  void* k_cache_ptr = insert_kv ? k_cache.value().data_ptr() : nullptr;
+  void* v_cache_ptr = insert_kv ? v_cache.value().data_ptr() : nullptr;
+  void* index_cache_ptr =
+      (insert_kv && process_index) ? index_cache.value().data_ptr() : nullptr;
+
+  cudaSetDevice(qkv.device().device_id);
+  cudaStream_t stream = get_stream(qkv.device());
+
+#define TS_CALL_MM3(ST, CACHE_T, KV_DTYPE)                                    \
+  mm::launchFusedMiniMaxM3<ST, CACHE_T, KV_DTYPE>(                            \
+      reinterpret_cast<ST*>(qkv_ptr), reinterpret_cast<ST*>(q_out_ptr),       \
+      index_q_out_ptr, reinterpret_cast<ST const*>(q_norm_ptr),               \
+      reinterpret_cast<ST const*>(k_norm_ptr),                                \
+      reinterpret_cast<ST const*>(iq_norm_ptr),                               \
+      reinterpret_cast<ST const*>(ik_norm_ptr),                               \
+      static_cast<float const*>(csc_ptr), pos_ptr, slot_ptr, idx_slot_ptr,   \
+      reinterpret_cast<CACHE_T*>(k_cache_ptr),                                \
+      reinterpret_cast<CACHE_T*>(v_cache_ptr), index_cache_ptr,              \
+      static_cast<float>(eps), static_cast<int>(rotary_dim), num_tokens, nq,  \
+      nkv, niq, static_cast<int>(block_size), kv_s_slot, kv_s_head, kv_s_dim, \
+      has_index, insert_kv, process_index, fp8_idx, stream)
+
+#define TS_DISPATCH_KV(ST)                                                    \
+  if (kv_dt == vllm::Fp8KVCacheDataType::kAuto)                               \
+    TS_CALL_MM3(ST, ST, vllm::Fp8KVCacheDataType::kAuto);                     \
+  else if (kv_dt == vllm::Fp8KVCacheDataType::kFp8E4M3)                       \
+    TS_CALL_MM3(ST, uint8_t, vllm::Fp8KVCacheDataType::kFp8E4M3);             \
+  else                                                                        \
+    TS_CALL_MM3(ST, uint8_t, vllm::Fp8KVCacheDataType::kFp8E5M2)
+
+  if (qkv.dtype() == dl_bfloat16) {
+    TS_DISPATCH_KV(__nv_bfloat16);
+  } else {
+    TS_DISPATCH_KV(__half);
+  }
+#undef TS_DISPATCH_KV
+#undef TS_CALL_MM3
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(fused_minimax_m3_qknorm_rope_kv_insert,
+                              fused_minimax_m3_qknorm_rope_kv_insert);

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/minimax_m3_fused.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/minimax_m3_fused.py
@@ -1,0 +1,105 @@
+"""MiniMax-M3 fused qk-norm + RoPE + KV/index-insert CUDA kernel wrapper.
+
+Loads the vendored ``minimax_m3_fused`` TVM-FFI module and exposes a typed
+wrapper around ``fused_minimax_m3_qknorm_rope_kv_insert``. The device kernel is
+vLLM's; only the build/binding were ported to TokenSpeed.
+"""
+
+from __future__ import annotations
+
+import functools
+from pathlib import Path
+
+import torch
+import tvm_ffi
+
+# kv_cache_dtype int codes (must match the C++ Fp8KVCacheDataType enum).
+_KV_DTYPE_CODE = {"auto": 0, "fp8_e4m3": 1, "fp8": 1, "fp8_e5m2": 2}
+
+
+def _objs_dir() -> Path:
+    return Path(__file__).resolve().parent / "objs"
+
+
+@functools.cache
+def _load_module():
+    so_path = _objs_dir() / "minimax_m3_fused" / "minimax_m3_fused.so"
+    if not so_path.exists():
+        raise RuntimeError(
+            f"tokenspeed_kernel minimax_m3_fused library not found at {so_path}. "
+            "Run `pip install -e tokenspeed-kernel/python/` to build."
+        )
+    return tvm_ffi.load_module(str(so_path))
+
+
+def fused_qknorm_rope_kv_insert(
+    qkv: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    num_heads: int,
+    num_kv_heads: int,
+    rotary_dim: int,
+    eps: float,
+    *,
+    index_q_norm_weight: torch.Tensor | None = None,
+    index_k_norm_weight: torch.Tensor | None = None,
+    num_index_heads: int = 0,
+    slot_mapping: torch.Tensor | None = None,
+    index_slot_mapping: torch.Tensor | None = None,
+    k_cache: torch.Tensor | None = None,
+    v_cache: torch.Tensor | None = None,
+    index_cache: torch.Tensor | None = None,
+    block_size: int = 0,
+    q_out: torch.Tensor | None = None,
+    index_q_out: torch.Tensor | None = None,
+    kv_cache_dtype: str = "auto",
+    skip_index_branch: bool = False,
+) -> None:
+    """Fused Gemma qk-norm + partial-NeoX RoPE (main q/k + index q/k), with
+    optional K/V and index-K cache scatter-insert.
+
+    ``qkv`` is the fused ``[q | k | v | index_q | index_k]`` projection output
+    (dense layers pass ``[q | k | v]`` with ``num_index_heads == 0``). q/k and,
+    on the sparse path, index_q/index_k are rewritten in place; when given,
+    contiguous ``q_out`` / ``index_q_out`` receive the de-interleaved outputs.
+    Norm weights are the folded Gemma weights (``1 + w``). ``cos_sin_cache`` is
+    ``[max_pos, rotary_dim]`` ([cos | sin] halves) in the qkv dtype.
+    """
+    if qkv.dtype not in (torch.float16, torch.bfloat16):
+        raise TypeError(f"qkv must be float16 or bfloat16, got {qkv.dtype}")
+    code = _KV_DTYPE_CODE.get(kv_cache_dtype)
+    if code is None:
+        raise ValueError(f"unsupported kv_cache_dtype {kv_cache_dtype!r}")
+    if positions.dtype != torch.int64:
+        positions = positions.to(torch.int64)
+    if slot_mapping is not None and slot_mapping.dtype != torch.int64:
+        slot_mapping = slot_mapping.to(torch.int64)
+    if index_slot_mapping is not None and index_slot_mapping.dtype != torch.int64:
+        index_slot_mapping = index_slot_mapping.to(torch.int64)
+
+    _load_module().fused_minimax_m3_qknorm_rope_kv_insert(
+        qkv,
+        q_norm_weight,
+        k_norm_weight,
+        cos_sin_cache.contiguous(),
+        positions.contiguous(),
+        int(num_heads),
+        int(num_kv_heads),
+        int(rotary_dim),
+        float(eps),
+        index_q_norm_weight,
+        index_k_norm_weight,
+        int(num_index_heads),
+        None if slot_mapping is None else slot_mapping.contiguous(),
+        None if index_slot_mapping is None else index_slot_mapping.contiguous(),
+        k_cache,
+        v_cache,
+        index_cache,
+        int(block_size),
+        q_out,
+        index_q_out,
+        int(code),
+        bool(skip_index_branch),
+    )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/minimax_m3_fused.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/minimax_m3_fused.py
@@ -56,6 +56,7 @@ def fused_qknorm_rope_kv_insert(
     index_q_out: torch.Tensor | None = None,
     kv_cache_dtype: str = "auto",
     skip_index_branch: bool = False,
+    enable_pdl: bool = False,
 ) -> None:
     """Fused Gemma qk-norm + partial-NeoX RoPE (main q/k + index q/k), with
     optional K/V and index-K cache scatter-insert.
@@ -66,6 +67,10 @@ def fused_qknorm_rope_kv_insert(
     contiguous ``q_out`` / ``index_q_out`` receive the de-interleaved outputs.
     Norm weights are the folded Gemma weights (``1 + w``). ``cos_sin_cache`` is
     ``[max_pos, rotary_dim]`` ([cos | sin] halves) in the qkv dtype.
+
+    ``enable_pdl`` requests Programmatic Dependent Launch (SM90+); when False the
+    kernel launches without the stream-serialization attribute (its in-body
+    grid-dependency intrinsics become no-ops).
     """
     if qkv.dtype not in (torch.float16, torch.bfloat16):
         raise TypeError(f"qkv must be float16 or bfloat16, got {qkv.dtype}")
@@ -102,4 +107,5 @@ def fused_qknorm_rope_kv_insert(
         index_q_out,
         int(code),
         bool(skip_index_branch),
+        bool(enable_pdl),
     )

--- a/tokenspeed-kernel/test/ops/test_minimax_m3_fused_qknorm_rope_kv_insert.py
+++ b/tokenspeed-kernel/test/ops/test_minimax_m3_fused_qknorm_rope_kv_insert.py
@@ -1,0 +1,204 @@
+"""Unit tests for the vendored MiniMax-M3 fused qk-norm + RoPE + KV/index-insert
+CUDA kernel.
+
+Validates against an independent torch golden (Gemma RMSNorm with the raw weight
+-- the kernel adds ``1 + w`` internally -- then partial-NeoX RoPE) across:
+  * norm+RoPE only (no cache insert),
+  * K/V + index-K insert into TokenSpeed's separate flat slot-indexed buffers,
+  * fp8 KV cache + fp8 index cache / index_q output.
+
+Requires an NVIDIA GPU and the built ``minimax_m3_fused`` kernel module.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from tokenspeed_kernel.thirdparty.cuda.minimax_m3_fused import (
+    fused_qknorm_rope_kv_insert,
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="requires CUDA and the built minimax_m3_fused kernel",
+)
+
+HD, RD, EPS = 128, 64, 1e-6
+NQ, NKV, NIQ = 8, 2, 2
+T, NUM_SLOTS = 37, 64
+ROW = (NQ + 2 * NKV + NIQ + 1) * HD
+E4M3 = torch.float8_e4m3fn
+_SLICES = [("q", NQ), ("k", NKV), ("v", NKV), ("iq", NIQ), ("ik", 1)]
+
+
+def _golden_norm_rope(x, w_raw, cos, sin):
+    xf = x.float()
+    var = xf.pow(2).mean(-1, keepdim=True)
+    xn = xf * torch.rsqrt(var + EPS) * (1.0 + w_raw.float())
+    rot, pas = xn[..., :RD], xn[..., RD:]
+    c, s = cos.float().unsqueeze(1), sin.float().unsqueeze(1)
+    x1, x2 = rot[..., : RD // 2], rot[..., RD // 2 :]
+    return torch.cat([x1 * c - x2 * s, x2 * c + x1 * s, pas], dim=-1)
+
+
+def _slice(t, name, n):
+    o = 0
+    for nm, nn in _SLICES:
+        if nm == name:
+            return t[:, o : o + nn * HD].view(T, nn, HD)
+        o += nn * HD
+    raise KeyError(name)
+
+
+def _fixtures(dev, seed):
+    g = torch.Generator(device=dev).manual_seed(seed)
+    qkv = torch.randn(T, ROW, device=dev, dtype=torch.bfloat16, generator=g)
+    weights = {
+        k: (torch.randn(HD, device=dev, generator=g) * 0.1).to(torch.bfloat16)
+        for k in ("q", "k", "iq", "ik")
+    }
+    positions = torch.arange(T, device=dev, dtype=torch.int64)
+    inv = 1.0 / (5_000_000 ** (torch.arange(0, RD, 2, device=dev).float() / RD))
+    ang = torch.arange(4096, device=dev).float()[:, None] * inv[None, :]
+    csc = torch.cat([torch.cos(ang), torch.sin(ang)], dim=-1).float()
+    cos, sin = csc[positions, : RD // 2], csc[positions, RD // 2 :]
+    return qkv, weights, positions, csc, cos, sin
+
+
+def test_norm_rope_only():
+    dev = "cuda"
+    qkv, w, positions, csc, cos, sin = _fixtures(dev, 0)
+    qkv_in = qkv.clone()
+    q_out = torch.empty(T, NQ * HD, device=dev, dtype=torch.bfloat16)
+    iq_out = torch.empty(T, NIQ * HD, device=dev, dtype=torch.bfloat16)
+
+    fused_qknorm_rope_kv_insert(
+        qkv,
+        w["q"],
+        w["k"],
+        csc,
+        positions,
+        NQ,
+        NKV,
+        RD,
+        EPS,
+        index_q_norm_weight=w["iq"],
+        index_k_norm_weight=w["ik"],
+        num_index_heads=NIQ,
+        q_out=q_out,
+        index_q_out=iq_out,
+    )
+
+    g_q = _golden_norm_rope(_slice(qkv_in, "q", NQ), w["q"], cos, sin)
+    g_k = _golden_norm_rope(_slice(qkv_in, "k", NKV), w["k"], cos, sin)
+    g_iq = _golden_norm_rope(_slice(qkv_in, "iq", NIQ), w["iq"], cos, sin)
+    g_ik = _golden_norm_rope(_slice(qkv_in, "ik", 1), w["ik"], cos, sin)
+
+    torch.testing.assert_close(q_out.view(T, NQ, HD).float(), g_q, atol=2e-2, rtol=0)
+    torch.testing.assert_close(_slice(qkv, "k", NKV).float(), g_k, atol=2e-2, rtol=0)
+    torch.testing.assert_close(iq_out.view(T, NIQ, HD).float(), g_iq, atol=2e-2, rtol=0)
+    torch.testing.assert_close(_slice(qkv, "ik", 1).float(), g_ik, atol=2e-2, rtol=0)
+    # V is not inserted here, so it must be untouched.
+    torch.testing.assert_close(
+        _slice(qkv, "v", NKV), _slice(qkv_in, "v", NKV), atol=0, rtol=0
+    )
+
+
+def test_kv_and_index_insert_bf16():
+    dev = "cuda"
+    qkv, w, positions, csc, cos, sin = _fixtures(dev, 1)
+    qkv_in = qkv.clone()
+    slots = torch.randperm(NUM_SLOTS, device=dev)[:T].to(torch.int64)
+    k_cache = torch.zeros(NUM_SLOTS, NKV, HD, device=dev, dtype=torch.bfloat16)
+    v_cache = torch.zeros(NUM_SLOTS, NKV, HD, device=dev, dtype=torch.bfloat16)
+    index_cache = torch.zeros(NUM_SLOTS, HD, device=dev, dtype=torch.bfloat16)
+
+    fused_qknorm_rope_kv_insert(
+        qkv,
+        w["q"],
+        w["k"],
+        csc,
+        positions,
+        NQ,
+        NKV,
+        RD,
+        EPS,
+        index_q_norm_weight=w["iq"],
+        index_k_norm_weight=w["ik"],
+        num_index_heads=NIQ,
+        slot_mapping=slots,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        index_cache=index_cache,
+        block_size=1,
+    )
+
+    gk = torch.zeros_like(k_cache)
+    gv = torch.zeros_like(v_cache)
+    gidx = torch.zeros_like(index_cache)
+    gk[slots] = _golden_norm_rope(_slice(qkv_in, "k", NKV), w["k"], cos, sin).to(
+        torch.bfloat16
+    )
+    gv[slots] = _slice(qkv_in, "v", NKV)  # V inserted raw (no norm/rope)
+    gidx[slots] = (
+        _golden_norm_rope(_slice(qkv_in, "ik", 1), w["ik"], cos, sin)
+        .to(torch.bfloat16)
+        .view(T, HD)
+    )
+
+    torch.testing.assert_close(k_cache, gk, atol=2e-2, rtol=0)
+    torch.testing.assert_close(v_cache, gv, atol=0, rtol=0)
+    torch.testing.assert_close(index_cache, gidx, atol=2e-2, rtol=0)
+
+
+def test_fp8_kv_and_index():
+    dev = "cuda"
+    qkv, w, positions, csc, cos, sin = _fixtures(dev, 2)
+    qkv_in = qkv.clone()
+    slots = torch.randperm(NUM_SLOTS, device=dev)[:T].to(torch.int64)
+    k_cache = torch.zeros(NUM_SLOTS, NKV, HD, device=dev, dtype=torch.uint8)
+    v_cache = torch.zeros(NUM_SLOTS, NKV, HD, device=dev, dtype=torch.uint8)
+    index_cache = torch.zeros(NUM_SLOTS, HD, device=dev, dtype=E4M3)
+    iq_out = torch.empty(T, NIQ * HD, device=dev, dtype=E4M3)
+
+    fused_qknorm_rope_kv_insert(
+        qkv,
+        w["q"],
+        w["k"],
+        csc,
+        positions,
+        NQ,
+        NKV,
+        RD,
+        EPS,
+        index_q_norm_weight=w["iq"],
+        index_k_norm_weight=w["ik"],
+        num_index_heads=NIQ,
+        slot_mapping=slots,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        index_cache=index_cache,
+        index_q_out=iq_out,
+        block_size=1,
+        kv_cache_dtype="fp8_e4m3",
+    )
+
+    gk = torch.zeros(NUM_SLOTS, NKV, HD, device=dev, dtype=E4M3)
+    gv = torch.zeros(NUM_SLOTS, NKV, HD, device=dev, dtype=E4M3)
+    gidx = torch.zeros(NUM_SLOTS, HD, device=dev, dtype=E4M3)
+    gk[slots] = _golden_norm_rope(_slice(qkv_in, "k", NKV), w["k"], cos, sin).to(E4M3)
+    gv[slots] = _slice(qkv_in, "v", NKV).to(E4M3)
+    gidx[slots] = (
+        _golden_norm_rope(_slice(qkv_in, "ik", 1), w["ik"], cos, sin)
+        .to(E4M3)
+        .view(T, HD)
+    )
+    g_iq = _golden_norm_rope(_slice(qkv_in, "iq", NIQ), w["iq"], cos, sin).to(E4M3)
+
+    # Compare decoded fp8 (identity scale) -- expected bit-identical rounding.
+    torch.testing.assert_close(k_cache.view(E4M3).float(), gk.float(), atol=0, rtol=0)
+    torch.testing.assert_close(v_cache.view(E4M3).float(), gv.float(), atol=0, rtol=0)
+    torch.testing.assert_close(index_cache.float(), gidx.float(), atol=0, rtol=0)
+    torch.testing.assert_close(
+        iq_out.view(T, NIQ, HD).float(), g_iq.float(), atol=0, rtol=0
+    )

--- a/tokenspeed-kernel/test/ops/test_minimax_m3_fused_qknorm_rope_kv_insert.py
+++ b/tokenspeed-kernel/test/ops/test_minimax_m3_fused_qknorm_rope_kv_insert.py
@@ -14,13 +14,14 @@ from __future__ import annotations
 
 import pytest
 import torch
+from tokenspeed_kernel.platform import current_platform
 from tokenspeed_kernel.thirdparty.cuda.minimax_m3_fused import (
     fused_qknorm_rope_kv_insert,
 )
 
 pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(),
-    reason="requires CUDA and the built minimax_m3_fused kernel",
+    not current_platform().is_nvidia,
+    reason="minimax_m3_fused kernel is NVIDIA-only",
 )
 
 HD, RD, EPS = 128, 64, 1e-6


### PR DESCRIPTION
## Summary

Three optimizations to the MiniMax-M3 sparse-attention (MSA) path, on top of #779.

## 1. Fuse indexer q/k into the QKV projection
Sparse layers projected q/k/v, index_q and index_k with three separate GEMMs off
the same hidden_states, quantizing the activation to MXFP8 three times. Fused into
a single `MinimaxM3QKVParallelLinearWithIndexer` emitting `[q|k|v|index_q|index_k]`
per rank — index_q rides KV-head sharding, index_k is one replicated head. Removes
two redundant activation quantizations and two GEMM launches per sparse layer.

## 2. Fuse qk-norm + RoPE via a vendored CUDA kernel
Vendored `fused_minimax_m3_qknorm_rope_kv_insert` (adapted from vLLM to the
TVM-FFI / no-libtorch build, retargeted to tokenspeed's separate flat
k_buffer/v_buffer). Replaces the two `qk_rmsnorm` + two RoPE calls with one launch
in `MiniMaxM3Attention.forward`, gated on `is_sparse + is_nvidia + head_dim==128`.
Higher precision than the baseline: norm+RoPE in one fp32 pass instead of rounding
to bf16 between the ops. The indexer's defensive input normalization is replaced
with contract assertions (index_k scatters directly through strides, no bf16
materialization).

## 3. Wire PDL across the decode attention chain
Plumb `enable_pdl` (gated on `pdl_enabled()`) with a real producer→consumer
griddepcontrol handshake at each hop: mxfp8 quantize → fused qk-norm/RoPE/KV-insert
→ KV-set → store-index-k → index decode-score → top-k → sparse-decode → merge.
The MXFP8 GEMM is left unwired — flashinfer's `mm_mxfp8` has no `enable_pdl` yet.
