### PR TITLE
fix: use global rank for attention DP broadcast

### DIFF
--- a/python/tokenspeed/runtime/distributed/comm_backend/trtllm_allreduce.py
+++ b/python/tokenspeed/runtime/distributed/comm_backend/trtllm_allreduce.py
@@ -154,6 +154,8 @@ class TrtllmAllReduceBackend(CommBackend):
         token_num, hidden_dim = tensor_2d.shape
         if hidden_dim > res["hidden_dim"] or token_num > res["max_token_num"]:
             return None
+        if token_num == 0:
+            return tensor
 
         from tokenspeed.runtime.utils.pdl import pdl_enabled
 

--- a/python/tokenspeed/runtime/engine/request_handler.py
+++ b/python/tokenspeed/runtime/engine/request_handler.py
@@ -130,6 +130,7 @@ class RequestHandler:
         mapping = server_args.mapping
         self.attn_tp_size = mapping.attn.tp_size
         self.attn_tp_rank = mapping.attn.tp_rank
+        self.attn_global_rank = mapping.attn.rank
         self.attn_tp_cpu_group = pg_manager.get_process_group(
             "gloo", mapping.attn.tp_group
         )
@@ -179,7 +180,7 @@ class RequestHandler:
         if self.attn_tp_size != 1:
             recv_reqs = broadcast_pyobj(
                 recv_reqs,
-                self.attn_tp_rank,
+                self.attn_global_rank,
                 self.attn_tp_cpu_group,
                 src=self.attn_tp_src_rank,
             )

--- a/python/tokenspeed/runtime/epd/encode_loop.py
+++ b/python/tokenspeed/runtime/epd/encode_loop.py
@@ -243,6 +243,7 @@ def run_encode_loop(server_args, port_args, pipe_writer, gpu_id, global_rank):
     # ZMQ; it broadcasts each drained batch to the TP group so all ranks submit
     # the same requests and step together. (TP=1 -> rank 0 only, no broadcast.)
     attn_tp_rank = server_args.mapping.attn.tp_rank
+    attn_global_rank = server_args.mapping.attn.rank
     attn_tp_size = server_args.attn_tp_size or server_args.mapping.attn.tp_size
     tp_cpu_group = None
     broadcast_pyobj = None
@@ -294,7 +295,7 @@ def run_encode_loop(server_args, port_args, pipe_writer, gpu_id, global_rank):
             # Unconditional every iteration: this is the TP rendezvous that keeps
             # all ranks stepping the (collective) vision tower in lockstep.
             new_reqs = broadcast_pyobj(
-                new_reqs, attn_tp_rank, tp_cpu_group, src=attn_tp_src_rank
+                new_reqs, attn_global_rank, tp_cpu_group, src=attn_tp_src_rank
             )
 
         for request in new_reqs:

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -522,6 +522,77 @@ class CudaGraphWrapper:
 
         return graph, out
 
+    def prewarm_comm_states(self, batch_sizes: tuple[int, ...] = (1,)) -> None:
+        """Initialize lazy comm state with capture-style dummy forwards."""
+        if self._forward_func is None:
+            return
+
+        global _is_cuda_graph_phase
+        old_cuda_graph_phase = _is_cuda_graph_phase
+        _is_cuda_graph_phase = True
+        try:
+            for bs in batch_sizes:
+                ctx = ForwardContext(
+                    attn_backend=self.attn_backend,
+                    token_to_kv_pool=self.token_to_kv_pool,
+                    bs=bs,
+                    num_extends=0,
+                    input_num_tokens=bs * self.max_tokens_per_req,
+                    forward_mode=ForwardMode.DECODE,
+                    capture_hidden_mode=(
+                        CaptureHiddenMode.FULL
+                        if self.drafter is not None
+                        else CaptureHiddenMode.NULL
+                    ),
+                )
+                if self.dp_size > 1:
+                    ctx.global_num_tokens = [
+                        bs * self.max_tokens_per_req
+                    ] * self.world_size
+                    ctx.global_bs = [bs] * self.world_size
+
+                sampling_info = SamplingBatchInfo(
+                    req_pool_indices=self.input_buffers.req_pool_indices_buf[:bs],
+                    valid_cache_lengths=(
+                        self.runtime_states.valid_cache_lengths
+                        if self.runtime_states is not None
+                        else None
+                    ),
+                    is_all_greedy=False,
+                    vocab_size=self.vocab_size,
+                    device=self.device,
+                )
+
+                from tokenspeed.runtime.grammar.capturable_grammar import (
+                    bind_grammar_mask_buf,
+                )
+
+                bind_grammar_mask_buf(
+                    sampling_info,
+                    self.eager_grammar_buffers,
+                    bs,
+                    spec=self.drafter is not None,
+                    capturable=self.capturable_grammar,
+                    grammar_backend=self.grammar_backend,
+                )
+
+                torch.cuda.synchronize()
+                dist.barrier()
+                self._prepare_sampling_capture(
+                    bs=bs,
+                    variant=CUDA_GRAPH_VARIANT_DEFAULT,
+                )
+                self.input_buffers.seq_lens_buf[:bs].fill_(self.max_tokens_per_req)
+                self._init_capture_metadata(bs)
+                self._forward_func(bs=bs, ctx=ctx, sampling_info=sampling_info)
+                torch.cuda.synchronize()
+                dist.barrier()
+
+                if self.sampling_backend is not None:
+                    self.sampling_backend.reset_capture_state()
+        finally:
+            _is_cuda_graph_phase = old_cuda_graph_phase
+
     def _capture_paged_cache_block_tables(self, bs: int, pool) -> dict | None:
         specs = tuple(pool.paged_cache_group_specs)
         if not specs:

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -555,6 +555,11 @@ class ModelExecutor:
             sampling_backend=self.sampling_backend,
             runtime_states=self.runtime_states,
         )
+        # Eager warmup can be DP-asymmetric; prewarm RSAG under uniform dummy inputs.
+        if config.enforce_eager:
+            logger.info("Prewarming Triton RSAG communication states")
+            self.forward_step.prewarm_comm_states(batch_sizes=(1,))
+            logger.info("Finished prewarming Triton RSAG communication states")
 
         # Breakable prefill (extend) CUDA graphs, the extend-mode analogue of
         # the decode wrapper above; captures in __init__, borrowing the decode


### PR DESCRIPTION
## Summary
This PR includes the following fixes:
- When testing the attention DP2+TP4 configuration, the attention DP hang was caused by passing a TP-local rank into `broadcast_pyobj` while `src` was a global rank, so the rank namespaces did not match. For DP1,  requests reached global rank 4, but the broadcast compared TP-local rank 0 against global `src=4` and treated the source process as a non-source rank, causing the request to be dropped or stall within the TP group. Fix: pass global rank in `broadcast_pyobj`.
- Add eager pre-warmup in RSAG init. In some attention DP+TP case, when enable eager-mode, server will hang at single request warmup stage, so this PR add a pre-warmup step like CUDA graph capture stage to prevent hang issue.
- TRT-LLM's allreduce fails when token_nums is 0, this PR let DP ranks return early during idle forward steps in DP+TP configurations.

## Test Plan

<!-- How was this validated? -->
