### PR TITLE
ci: add ROCm 7.2 tokenspeed-kernel release workflow

### DIFF
--- a/.github/workflows/release-tokenspeed-kernel-rocm.yml
+++ b/.github/workflows/release-tokenspeed-kernel-rocm.yml
@@ -31,7 +31,6 @@ concurrency:
 
 env:
   ROCM_VARIANT: rocm72
-  TORCH_INDEX_URL: https://download.pytorch.org/whl/rocm7.2
 
 jobs:
   metadata:
@@ -106,7 +105,6 @@ jobs:
           mkdir -p dist
           docker run --rm \
             -e PYTHON_TAG=${{ matrix.python.tag }} \
-            -e PIP_EXTRA_INDEX_URL=$TORCH_INDEX_URL \
             -e TOKENSPEED_KERNEL_BACKEND=rocm \
             -e TOKENSPEED_KERNEL_VERSION_DATE=${{ needs.metadata.outputs.version_date }} \
             -e TOKENSPEED_KERNEL_GIT_SHA=$GITHUB_SHA \
@@ -164,7 +162,6 @@ jobs:
           }
           expected = {
               "tokenspeed-kernel-amd": ">=0.1.3",
-              "torch": "==2.11.0+rocm7.2",
           }
           for name, specifier in expected.items():
               actual = requirements.get(name)

--- a/.github/workflows/release-tokenspeed-kernel-rocm.yml
+++ b/.github/workflows/release-tokenspeed-kernel-rocm.yml
@@ -1,0 +1,285 @@
+name: Build and Release tokenspeed-kernel for ROCm
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Git tag prefix to create or update. Defaults to tokenspeed-kernel-v<version>."
+        required: false
+        type: string
+      version_date:
+        description: "Version date override for development builds, formatted as YYYYMMDD."
+        required: false
+        type: string
+      prerelease:
+        description: "Mark a stable GitHub release as a prerelease. Development versions are always prereleases."
+        required: false
+        default: false
+        type: boolean
+      publish_github:
+        description: "Publish ROCm 7.2 distributions to lightseekorg/whl."
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  ROCM_VARIANT: rocm72
+  TORCH_INDEX_URL: https://download.pytorch.org/whl/rocm7.2
+
+jobs:
+  metadata:
+    name: Resolve release metadata
+    runs-on: ubuntu-24.04-32core-x64
+    outputs:
+      version: ${{ steps.metadata.outputs.version }}
+      version_date: ${{ steps.metadata.outputs.version_date }}
+      tag_name: ${{ steps.metadata.outputs.tag_name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build metadata dependencies
+        run: python -m pip install --upgrade "setuptools<82" wheel packaging
+
+      - name: Resolve release metadata
+        id: metadata
+        run: |
+          version_date="${{ inputs.version_date }}"
+          if [ -z "$version_date" ]; then
+            version_date="$(date -u +%Y%m%d)"
+          fi
+
+          version=$(
+            cd tokenspeed-kernel/python
+            TOKENSPEED_KERNEL_BACKEND=rocm \
+            TOKENSPEED_KERNEL_VERSION_DATE="$version_date" \
+            TOKENSPEED_KERNEL_GIT_SHA="$GITHUB_SHA" \
+            TOKENSPEED_KERNEL_GIT_BRANCH="$GITHUB_REF_NAME" \
+              python setup.py --version
+          )
+
+          tag_name="${{ inputs.tag_name }}"
+          if [ -z "$tag_name" ]; then
+            tag_name="tokenspeed-kernel-v${version}"
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "version_date=${version_date}" >> "$GITHUB_OUTPUT"
+          echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+          echo "Release version: ${version}"
+          echo "Release tag: ${tag_name}-${ROCM_VARIANT}"
+
+  build-wheel:
+    name: Build ROCm 7.2 x64 wheel for Python ${{ matrix.python.version }}
+    needs: metadata
+    runs-on: ubuntu-24.04-32core-x64
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - version: "3.10"
+            tag: cp310-cp310
+          - version: "3.11"
+            tag: cp311-cp311
+          - version: "3.12"
+            tag: cp312-cp312
+          - version: "3.13"
+            tag: cp313-cp313
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build wheel in manylinux
+        run: |
+          mkdir -p dist
+          docker run --rm \
+            -e PYTHON_TAG=${{ matrix.python.tag }} \
+            -e PIP_EXTRA_INDEX_URL=$TORCH_INDEX_URL \
+            -e TOKENSPEED_KERNEL_BACKEND=rocm \
+            -e TOKENSPEED_KERNEL_VERSION_DATE=${{ needs.metadata.outputs.version_date }} \
+            -e TOKENSPEED_KERNEL_GIT_SHA=$GITHUB_SHA \
+            -e TOKENSPEED_KERNEL_GIT_BRANCH=$GITHUB_REF_NAME \
+            -v "$PWD:/workspace" \
+            -v "$PWD/dist:/output" \
+            quay.io/pypa/manylinux_2_28_x86_64 \
+            bash -lc '
+              set -euo pipefail
+
+              PYBIN="/opt/python/${PYTHON_TAG}/bin"
+              cd /workspace/tokenspeed-kernel/python
+
+              "${PYBIN}/python" -m pip install --upgrade \
+                pip "setuptools<82" wheel build twine packaging "apache-tvm-ffi==0.1.12"
+
+              rm -rf build *.egg-info
+              "${PYBIN}/python" -m build --wheel --no-isolation --outdir /output
+
+              python_tag="${PYTHON_TAG%%-*}"
+              abi_tag="${PYTHON_TAG#*-}"
+              "${PYBIN}/python" -m wheel tags \
+                --python-tag "${python_tag}" \
+                --abi-tag "${abi_tag}" \
+                --platform-tag manylinux_2_28_x86_64 \
+                --remove /output/*.whl
+
+              wheels=(/output/*.whl)
+              if [ "${#wheels[@]}" -ne 1 ]; then
+                echo "Expected one wheel, found ${#wheels[@]}" >&2
+                exit 1
+              fi
+
+              "${PYBIN}/python" - "${wheels[0]}" <<PY
+          import sys
+          import zipfile
+          from email.parser import BytesParser
+
+          from packaging.requirements import Requirement
+          from packaging.utils import canonicalize_name
+
+          with zipfile.ZipFile(sys.argv[1]) as wheel:
+              metadata_path = next(
+                  name
+                  for name in wheel.namelist()
+                  if name.endswith(".dist-info/METADATA")
+              )
+              metadata = BytesParser().parsebytes(wheel.read(metadata_path))
+
+          requirements = {
+              canonicalize_name(requirement.name): requirement
+              for requirement in map(
+                  Requirement, metadata.get_all("Requires-Dist", [])
+              )
+          }
+          expected = {
+              "tokenspeed-kernel-amd": ">=0.1.3",
+              "torch": "==2.11.0+rocm7.2",
+          }
+          for name, specifier in expected.items():
+              actual = requirements.get(name)
+              if actual is None or str(actual.specifier) != specifier:
+                  raise SystemExit(
+                      f"{name}: expected {specifier}, found {actual}"
+                  )
+
+          forbidden = {
+              "flashinfer-python",
+              "nvidia-cutlass-dsl",
+              "nvidia-ml-py",
+              "tokenspeed-deepgemm",
+          }
+          present = sorted(forbidden & requirements.keys())
+          if present:
+              raise SystemExit(
+                  f"ROCm wheel contains CUDA dependencies: {present}"
+              )
+          PY
+
+              "${PYBIN}/python" -m twine check "${wheels[0]}"
+            '
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: tokenspeed-kernel-${{ env.ROCM_VARIANT }}-wheel-x64-py${{ matrix.python.version }}
+          path: dist/*.whl
+
+  build-sdist:
+    name: Build source distribution
+    needs: metadata
+    runs-on: ubuntu-24.04-32core-x64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build source distribution
+        run: |
+          python -m pip install --upgrade \
+            build twine "setuptools<82" wheel packaging "apache-tvm-ffi==0.1.12"
+          cd tokenspeed-kernel/python
+          TOKENSPEED_KERNEL_BACKEND=rocm \
+          TOKENSPEED_KERNEL_VERSION_DATE=${{ needs.metadata.outputs.version_date }} \
+          TOKENSPEED_KERNEL_GIT_SHA=$GITHUB_SHA \
+          TOKENSPEED_KERNEL_GIT_BRANCH=$GITHUB_REF_NAME \
+            python -m build --sdist --no-isolation --outdir ../../dist
+          python -m twine check ../../dist/*.tar.gz
+
+      - name: Upload source distribution
+        uses: actions/upload-artifact@v4
+        with:
+          name: tokenspeed-kernel-${{ env.ROCM_VARIANT }}-sdist
+          path: dist/*.tar.gz
+
+  release:
+    name: Create ROCm 7.2 wheelhouse release
+    if: inputs.publish_github
+    needs: [metadata, build-wheel, build-sdist]
+    runs-on: ubuntu-24.04-32core-x64
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: tokenspeed-kernel-rocm72-*
+          merge-multiple: false
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.LIGHTSEEK_BOT_TOKEN }}
+          RELEASE_REPOSITORY: lightseekorg/whl
+          TAG_NAME: ${{ needs.metadata.outputs.tag_name }}
+          VERSION: ${{ needs.metadata.outputs.version }}
+          PRERELEASE: ${{ inputs.prerelease }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          release_tag="${TAG_NAME}-${ROCM_VARIANT}"
+          release_title="tokenspeed-kernel ${VERSION} ROCm 7.2"
+          prerelease_args=()
+          if [ "$PRERELEASE" = "true" ] || [[ "$VERSION" == *.dev* ]] || [[ "$VERSION" == *+* ]]; then
+            prerelease_args+=(--prerelease)
+          fi
+
+          shopt -s nullglob
+          assets=(
+            dist/tokenspeed-kernel-"${ROCM_VARIANT}"-wheel-*/*.whl
+            dist/tokenspeed-kernel-"${ROCM_VARIANT}"-sdist/*.tar.gz
+          )
+          shopt -u nullglob
+
+          if [ "${#assets[@]}" -eq 0 ]; then
+            echo "No distributions found for ${ROCM_VARIANT}" >&2
+            exit 1
+          fi
+
+          if gh release view "$release_tag" --repo "$RELEASE_REPOSITORY" >/dev/null 2>&1; then
+            if [ "${#prerelease_args[@]}" -gt 0 ]; then
+              gh release edit "$release_tag" \
+                --repo "$RELEASE_REPOSITORY" \
+                --prerelease
+            fi
+            gh release upload "$release_tag" "${assets[@]}" \
+              --repo "$RELEASE_REPOSITORY" \
+              --clobber
+          else
+            gh release create "$release_tag" "${assets[@]}" \
+              --repo "$RELEASE_REPOSITORY" \
+              --title "$release_title" \
+              --notes "$release_title built from lightseekorg/tokenspeed@$SOURCE_SHA" \
+              "${prerelease_args[@]}"
+          fi

--- a/tokenspeed-kernel/test/test_setup.py
+++ b/tokenspeed-kernel/test/test_setup.py
@@ -87,12 +87,6 @@ def test_rocm_install_requires_exclude_cuda_dependencies(monkeypatch) -> None:
         specifier.operator
         for specifier in requirements["tokenspeed-kernel-amd"].specifier
     } == {">="}
-    assert str(requirements["tokenspeed-kernel-amd"].specifier) == ">=0.1.3"
-    assert str(requirements["torch"].specifier) == "==2.11.0+rocm7.2"
-    assert (
-        "--extra-index-url https://download.pytorch.org/whl/rocm7.2"
-        in (REQUIREMENTS_DIR / "rocm.txt").read_text(encoding="utf-8").splitlines()
-    )
     assert {
         "flashinfer-python",
         "nvidia-cutlass-dsl",

--- a/tokenspeed-kernel/test/test_setup.py
+++ b/tokenspeed-kernel/test/test_setup.py
@@ -87,6 +87,12 @@ def test_rocm_install_requires_exclude_cuda_dependencies(monkeypatch) -> None:
         specifier.operator
         for specifier in requirements["tokenspeed-kernel-amd"].specifier
     } == {">="}
+    assert str(requirements["tokenspeed-kernel-amd"].specifier) == ">=0.1.3"
+    assert str(requirements["torch"].specifier) == "==2.11.0+rocm7.2"
+    assert (
+        "--extra-index-url https://download.pytorch.org/whl/rocm7.2"
+        in (REQUIREMENTS_DIR / "rocm.txt").read_text(encoding="utf-8").splitlines()
+    )
     assert {
         "flashinfer-python",
         "nvidia-cutlass-dsl",


### PR DESCRIPTION
## Summary

- add a manually dispatched ROCm 7.2 release workflow for `tokenspeed-kernel`
- build manylinux x86-64 wheels for Python 3.10 through 3.13 without requiring a ROCm build container
- validate ROCm dependency metadata and exclude CUDA-only dependencies during the wheel build
- optionally publish versioned ROCm artifacts to the `lightseekorg/whl` wheelhouse

## Test Plan

- `python3 -m pytest --noconftest tokenspeed-kernel/test/test_setup.py -q` (6 passed)
- `pre-commit run --all-files`
- parsed the workflow YAML and checked embedded shell syntax