### PR TITLE
perf(kimi): load only encoder checkpoint shards

### DIFF
--- a/python/tokenspeed/runtime/model_loader/loader.py
+++ b/python/tokenspeed/runtime/model_loader/loader.py
@@ -31,7 +31,7 @@ import os
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterable, Iterator
 from contextlib import contextmanager
-from typing import Any, cast
+from typing import Any, Callable, cast
 
 import huggingface_hub
 import torch
@@ -57,6 +57,7 @@ from tokenspeed.runtime.model_loader.weight_utils import (
     initialize_dummy_weights,
     np_cache_weights_iterator,
     pt_weights_iterator,
+    safetensors_files_for_weight_filter,
     safetensors_weights_iterator,
 )
 from tokenspeed.runtime.models.extensible import ExtensibleLM
@@ -202,6 +203,9 @@ class DefaultModelLoader(BaseModelLoader):
         fall_back_to_pt: bool = True
         """Whether .pt weights can be used."""
 
+        weight_name_filter: Callable[[str], bool] | None = None
+        """Optional filter over checkpoint names after ``prefix`` is applied."""
+
     def __init__(self, load_config: LoadConfig) -> None:
         super().__init__(load_config)
         if load_config.model_loader_extra_config:
@@ -238,7 +242,11 @@ class DefaultModelLoader(BaseModelLoader):
         return None
 
     def _prepare_weights(
-        self, model_name_or_path: str, revision: str | None, fall_back_to_pt: bool
+        self,
+        model_name_or_path: str,
+        revision: str | None,
+        fall_back_to_pt: bool,
+        weight_name_filter: Callable[[str], bool] | None = None,
     ) -> tuple[str, list[str], bool]:
         """Prepare weights for the model.
 
@@ -272,6 +280,29 @@ class DefaultModelLoader(BaseModelLoader):
         if fall_back_to_pt:
             allow_patterns += ["*.pt"]
 
+        downloaded_index = None
+        if (
+            not is_local
+            and weight_name_filter is not None
+            and "*.safetensors" in allow_patterns
+        ):
+            downloaded_index = download_safetensors_index_file_from_hf(
+                model_name_or_path,
+                index_file,
+                self.load_config.download_dir,
+                revision,
+            )
+            if downloaded_index is not None:
+                selected_files = safetensors_files_for_weight_filter(
+                    downloaded_index, weight_name_filter
+                )
+                if not selected_files:
+                    raise RuntimeError(
+                        f"No checkpoint weights matched the model filter in {index_file}"
+                    )
+                allow_patterns = sorted(selected_files)
+                use_safetensors = True
+
         if not is_local:
             hf_folder = download_weights_from_hf(
                 model_name_or_path,
@@ -289,7 +320,11 @@ class DefaultModelLoader(BaseModelLoader):
             if len(hf_weights_files) > 0:
                 if pattern == "*.safetensors":
                     use_safetensors = True
-                break
+                # Exact shard names selected from an index are cumulative.
+                # Wildcard entries are format alternatives, so the first
+                # matching format retains the legacy fallback behavior.
+                if downloaded_index is None:
+                    break
 
         if use_safetensors:
             # For models like Mistral-7B-Instruct-v0.3
@@ -297,7 +332,7 @@ class DefaultModelLoader(BaseModelLoader):
             # safetensors file. Using both breaks.
             # Here, we download the `model.safetensors.index.json` and filter
             # any files not found in the index.
-            if not is_local:
+            if not is_local and downloaded_index is None:
                 download_safetensors_index_file_from_hf(
                     model_name_or_path,
                     index_file,
@@ -305,7 +340,10 @@ class DefaultModelLoader(BaseModelLoader):
                     revision,
                 )
             hf_weights_files = filter_duplicate_safetensors_files(
-                hf_weights_files, hf_folder, index_file
+                hf_weights_files,
+                hf_folder,
+                index_file,
+                weight_name_filter=weight_name_filter,
             )
         else:
             hf_weights_files = filter_files_not_needed_for_inference(hf_weights_files)
@@ -321,8 +359,17 @@ class DefaultModelLoader(BaseModelLoader):
         self, source: "Source"
     ) -> Generator[tuple[str, torch.Tensor], None, None]:
         """Get an iterator for the model weights based on the load format."""
+        raw_weight_name_filter = None
+        if source.weight_name_filter is not None:
+            raw_weight_name_filter = lambda name: source.weight_name_filter(
+                source.prefix + name
+            )
+
         hf_folder, hf_weights_files, use_safetensors = self._prepare_weights(
-            source.model_or_path, source.revision, source.fall_back_to_pt
+            source.model_or_path,
+            source.revision,
+            source.fall_back_to_pt,
+            weight_name_filter=raw_weight_name_filter,
         )
         if self.load_config.load_format == LoadFormat.NPCACHE:
             # Currently np_cache only support *.bin checkpoints
@@ -343,6 +390,13 @@ class DefaultModelLoader(BaseModelLoader):
         else:
             weights_iterator = pt_weights_iterator(hf_weights_files)
 
+        # Also filter tensors for mixed shards, non-safetensors checkpoints,
+        # and safetensors checkpoints without an index.
+        if raw_weight_name_filter is not None:
+            weights_iterator = (
+                item for item in weights_iterator if raw_weight_name_filter(item[0])
+            )
+
         # Apply the prefix.
         return ((source.prefix + name, tensor) for (name, tensor) in weights_iterator)
 
@@ -357,6 +411,7 @@ class DefaultModelLoader(BaseModelLoader):
             model_config.revision,
             prefix="",
             fall_back_to_pt=getattr(model, "fall_back_to_pt_during_load", False),
+            weight_name_filter=getattr(model, "checkpoint_weight_name_filter", None),
         )
         yield from self._get_weights_iterator(primary_weights)
 

--- a/python/tokenspeed/runtime/model_loader/weight_utils.py
+++ b/python/tokenspeed/runtime/model_loader/weight_utils.py
@@ -218,7 +218,7 @@ def download_safetensors_index_file_from_hf(
     index_file: str,
     cache_dir: str | None,
     revision: str | None = None,
-) -> None:
+) -> str | None:
     """Download hf safetensors index file from Hugging Face Hub.
 
     Args:
@@ -232,7 +232,7 @@ def download_safetensors_index_file_from_hf(
     with get_lock(model_name_or_path, cache_dir):
         try:
             # Download the safetensors index file.
-            hf_hub_download(
+            return hf_hub_download(
                 repo_id=model_name_or_path,
                 filename=index_file,
                 cache_dir=cache_dir,
@@ -245,6 +245,21 @@ def download_safetensors_index_file_from_hf(
             logger.info("No %s found in remote.", index_file)
         except huggingface_hub.utils.LocalEntryNotFoundError:
             logger.info("No %s found in local cache.", index_file)
+    return None
+
+
+def safetensors_files_for_weight_filter(
+    index_file_name: str,
+    weight_name_filter: Callable[[str], bool],
+) -> set[str]:
+    """Return checkpoint shard names containing at least one matching tensor."""
+    with open(index_file_name) as f:
+        weight_map = json.load(f)["weight_map"]
+    return {
+        weight_file
+        for weight_name, weight_file in weight_map.items()
+        if weight_name_filter(weight_name)
+    }
 
 
 # For models like Mistral-7B-v0.3, there are both sharded
@@ -253,7 +268,10 @@ def download_safetensors_index_file_from_hf(
 # So, we use the index_file to
 # look up which safetensors files should be used.
 def filter_duplicate_safetensors_files(
-    hf_weights_files: list[str], hf_folder: str, index_file: str
+    hf_weights_files: list[str],
+    hf_folder: str,
+    index_file: str,
+    weight_name_filter: Callable[[str], bool] | None = None,
 ) -> list[str]:
     # model.safetensors.index.json is a mapping from keys in the
     # torch state_dict to safetensors file holding that weight.
@@ -263,11 +281,16 @@ def filter_duplicate_safetensors_files(
 
     # Iterate through the weight_map (weight_name: safetensors files)
     # to identify weights that we should use.
-    with open(index_file_name) as f:
-        weight_map = json.load(f)["weight_map"]
-    weight_files_in_index = set()
-    for weight_name in weight_map:
-        weight_files_in_index.add(os.path.join(hf_folder, weight_map[weight_name]))
+    if weight_name_filter is None:
+        with open(index_file_name) as f:
+            selected_files = set(json.load(f)["weight_map"].values())
+    else:
+        selected_files = safetensors_files_for_weight_filter(
+            index_file_name, weight_name_filter
+        )
+    weight_files_in_index = {
+        os.path.join(hf_folder, weight_file) for weight_file in selected_files
+    }
     # Filter out any fields that are not found in the index file.
     hf_weights_files = [f for f in hf_weights_files if f in weight_files_in_index]
     return hf_weights_files

--- a/python/tokenspeed/runtime/models/kimi_k25.py
+++ b/python/tokenspeed/runtime/models/kimi_k25.py
@@ -750,6 +750,11 @@ class KimiK25ForConditionalGeneration(nn.Module):
         self.mapping = mapping
         self.quant_config = quant_config
         self.is_multimodal_active = is_multimodal_active
+        self.checkpoint_weight_name_filter = (
+            self._is_vision_checkpoint_weight
+            if getattr(config, "encoder_only", False)
+            else None
+        )
         if not self.is_multimodal_active:
             self.vision_tower = None
             self.mm_projector = None
@@ -936,10 +941,15 @@ class KimiK25ForConditionalGeneration(nn.Module):
             **kwargs,
         )
 
+    @staticmethod
+    def _is_vision_checkpoint_weight(name: str) -> bool:
+        return "vision_tower" in name or "mm_projector" in name
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         """Load weights for the model, separating vision and language weights"""
         vision_weights = []
         language_weights = []
+        encoder_only = getattr(self.config, "encoder_only", False)
 
         for name, loaded_weight in weights:
             # nvidia/Kimi-K2.5-NVFP4 stores decoder layers under
@@ -956,7 +966,7 @@ class KimiK25ForConditionalGeneration(nn.Module):
                 name = name.replace("mm_projector.proj.0", "mm_projector.linear_1")
                 name = name.replace("mm_projector.proj.2", "mm_projector.linear_2")
                 vision_weights.append((name, loaded_weight))
-            else:
+            elif not encoder_only:
                 name = name.replace("language_model.", "")
                 language_weights.append((name, loaded_weight))
 
@@ -972,7 +982,7 @@ class KimiK25ForConditionalGeneration(nn.Module):
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
 
-        if not getattr(self.config, "encoder_only", False) and language_weights:
+        if language_weights:
             self.language_model.load_weights(language_weights)
 
     @classmethod

--- a/test/runtime/test_weight_loader_prefetch.py
+++ b/test/runtime/test_weight_loader_prefetch.py
@@ -1,7 +1,11 @@
 import argparse
+import json
 import os
 import sys
+import tempfile
 import unittest
+from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 # CI Registration (parsed via AST, runtime no-op)
@@ -12,6 +16,7 @@ register_cuda_ci(est_time=10, suite="runtime-1gpu")
 
 from tokenspeed.runtime.configs.load_config import LoadConfig
 from tokenspeed.runtime.model_loader import weight_utils
+from tokenspeed.runtime.model_loader.loader import DefaultModelLoader
 from tokenspeed.runtime.utils.server_args import ServerArgs
 
 
@@ -60,6 +65,135 @@ class TestWeightLoaderPrefetch(unittest.TestCase):
 
         self.assertFalse(thread.is_alive())
         self.assertEqual(sorted(seen), [files[1], files[4]])
+
+
+class TestWeightNameFilter(unittest.TestCase):
+    def test_index_filter_selects_matching_and_mixed_shards(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            folder = Path(tmp)
+            language = folder / "model-00001.safetensors"
+            vision = folder / "model-00002.safetensors"
+            mixed = folder / "model-00003.safetensors"
+            index = folder / "model.safetensors.index.json"
+            index.write_text(
+                json.dumps(
+                    {
+                        "weight_map": {
+                            "language_model.weight": language.name,
+                            "vision_tower.weight": vision.name,
+                            "language_model.bias": mixed.name,
+                            "mm_projector.weight": mixed.name,
+                        }
+                    }
+                )
+            )
+
+            selected = weight_utils.filter_duplicate_safetensors_files(
+                [str(language), str(vision), str(mixed)],
+                str(folder),
+                index.name,
+                weight_name_filter=lambda name: (
+                    "vision_tower" in name or "mm_projector" in name
+                ),
+            )
+
+        self.assertEqual(selected, [str(vision), str(mixed)])
+
+    def test_tensor_filter_applies_after_source_prefix(self):
+        loader = DefaultModelLoader(LoadConfig())
+        source = DefaultModelLoader.Source(
+            "unused",
+            None,
+            prefix="base.",
+            weight_name_filter=lambda name: name.startswith("base.vision_tower."),
+        )
+        tensors = [
+            ("language_model.weight", object()),
+            ("vision_tower.weight", object()),
+        ]
+
+        with (
+            mock.patch.object(
+                loader,
+                "_prepare_weights",
+                return_value=("unused", ["model.safetensors"], True),
+            ) as prepare,
+            mock.patch(
+                "tokenspeed.runtime.model_loader.loader.safetensors_weights_iterator",
+                return_value=iter(tensors),
+            ),
+        ):
+            loaded = list(loader._get_weights_iterator(source))
+
+        self.assertEqual(loaded, [("base.vision_tower.weight", tensors[1][1])])
+        passed_filter = prepare.call_args.kwargs["weight_name_filter"]
+        self.assertFalse(passed_filter("language_model.weight"))
+        self.assertTrue(passed_filter("vision_tower.weight"))
+
+    def test_remote_filter_downloads_only_matching_safetensors_shards(self):
+        loader = DefaultModelLoader(LoadConfig())
+        with tempfile.TemporaryDirectory() as tmp:
+            folder = Path(tmp)
+            language = folder / "model-00001.safetensors"
+            vision = folder / "model-00002.safetensors"
+            projector = folder / "model-00003.safetensors"
+            language.touch()
+            vision.touch()
+            projector.touch()
+            index = folder / "model.safetensors.index.json"
+            index.write_text(
+                json.dumps(
+                    {
+                        "weight_map": {
+                            "language_model.weight": language.name,
+                            "vision_tower.weight": vision.name,
+                            "mm_projector.weight": projector.name,
+                        }
+                    }
+                )
+            )
+            with (
+                mock.patch(
+                    "tokenspeed.runtime.model_loader.loader.os.path.isdir",
+                    return_value=False,
+                ),
+                mock.patch(
+                    "tokenspeed.runtime.model_loader.loader.download_safetensors_index_file_from_hf",
+                    return_value=str(index),
+                ),
+                mock.patch(
+                    "tokenspeed.runtime.model_loader.loader.download_weights_from_hf",
+                    return_value=str(folder),
+                ) as download,
+            ):
+                _, files, use_safetensors = loader._prepare_weights(
+                    "org/model",
+                    None,
+                    True,
+                    weight_name_filter=lambda name: (
+                        "vision_tower" in name or "mm_projector" in name
+                    ),
+                )
+
+        self.assertTrue(use_safetensors)
+        self.assertEqual(files, [str(vision), str(projector)])
+        self.assertEqual(download.call_args.args[2], [vision.name, projector.name])
+
+    def test_model_filter_is_forwarded_to_primary_source(self):
+        loader = DefaultModelLoader(LoadConfig())
+        weight_filter = lambda name: name.startswith("vision_tower.")
+        model = SimpleNamespace(checkpoint_weight_name_filter=weight_filter)
+        config = SimpleNamespace(model_path="model", revision=None)
+        captured = []
+
+        def capture_source(source):
+            captured.append(source)
+            return iter(())
+
+        with mock.patch.object(loader, "_get_weights_iterator", capture_source):
+            list(loader._get_all_weights(config, model))
+
+        self.assertIs(captured[0].weight_name_filter, weight_filter)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an optional checkpoint weight-name filter to the default loader
- use safetensors indexes to download/open only matching shards
- limit Kimi encoder-only loading to vision tower and projector weights

## Validation
- `pre-commit run --all-files`
- Python byte-compilation
- focused loader coverage added for local, remote, mixed-shard, prefix, and model forwarding paths

Full pytest execution requires runtime dependencies unavailable in the local environment.