### PR TITLE
perf(epd): parallelize encoder items across ranks

### DIFF
--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -73,7 +73,7 @@ issue budget, while `--max-total-tokens` controls the global token pool.
 | `--dense-tp-size` | Tensor parallel size for dense layers. |
 | `--moe-tp-size` | Tensor parallel size for MoE layers. |
 | `--data-parallel-size` | Number of data-parallel replicas. |
-| `--mm-encoder-tp-mode` | Multimodal encoder parallelism: `weights` shards encoder weights with attention TP; `data` uses TP1 whole-item DP and currently requires aggregate serving, one node, and no attention context parallelism. |
+| `--mm-encoder-tp-mode` | Multimodal encoder parallelism: `weights` shards encoder weights with attention TP; `data` uses TP1 whole-item DP for aggregate serving or the EPD encode role and currently requires one node and no attention context parallelism. |
 | `--enable-expert-parallel` | Set expert parallelism across the selected world size. |
 | `--expert-parallel-size`, `--ep-size` | Explicit expert parallel size. |
 | `--world-size` | Total worker process count across all nodes. |

--- a/docs/serving/parallelism.md
+++ b/docs/serving/parallelism.md
@@ -35,7 +35,7 @@ tokenspeed serve <model> \
 | `--dense-tp-size` | Dense layer tensor parallel size. |
 | `--moe-tp-size` | MoE layer tensor parallel size. |
 | `--data-parallel-size` | Replicated data-parallel groups. |
-| `--mm-encoder-tp-mode` | `weights` (default), or TP1 whole-item DP within each attention TP group (`data`). |
+| `--mm-encoder-tp-mode` | `weights` (default), or TP1 whole-item DP within each attention TP group (`data`). Item DP supports aggregate serving and the EPD encode role. |
 | `--enable-expert-parallel` | Expert parallelism across the selected world size. |
 | `--expert-parallel-size` | Explicit expert parallel size. |
 

--- a/python/tokenspeed/runtime/epd/encode_executor.py
+++ b/python/tokenspeed/runtime/epd/encode_executor.py
@@ -31,7 +31,11 @@ import torch
 from tokenspeed.runtime.epd.mooncake.sender import (
     MooncakeEmbeddingSender,
 )
-from tokenspeed.runtime.multimodal.embedder import _item_token_count
+from tokenspeed.runtime.multimodal.embedder import (
+    EncoderSpec,
+    MultimodalEmbedder,
+    _item_token_count,
+)
 from tokenspeed.runtime.multimodal.inputs import Modality, MultimodalDataItem
 from tokenspeed.runtime.pd.base.status import TransferPoll
 from tokenspeed.runtime.utils.env import envs
@@ -68,15 +72,24 @@ def assign_encoded_embeddings(
             f"{total} post-merge tokens; check the token-count / grid contract"
         )
 
-    has_deepstack = getattr(model, "num_deepstack_embeddings", 0) > 0
     per_item_embeds = torch.split(output, per_item_tokens, dim=0)
+    assign_per_item_encoded_embeddings(items, per_item_embeds, model)
+
+
+def assign_per_item_encoded_embeddings(items, per_item_embeds, model) -> None:
+    """Store already-split encoder outputs without repacking the full batch."""
+    if len(items) != len(per_item_embeds):
+        raise ValueError(
+            f"received {len(per_item_embeds)} encoder outputs for {len(items)} items"
+        )
+    has_deepstack = getattr(model, "num_deepstack_embeddings", 0) > 0
     for item, emb in zip(items, per_item_embeds):
         if has_deepstack:
             main, deep = model.separate_deepstack_embeds(emb)
-            item.encoded = main.contiguous()
-            item.encoded_deepstack = deep.contiguous()
+            item.encoded = main.clone(memory_format=torch.contiguous_format)
+            item.encoded_deepstack = deep.clone(memory_format=torch.contiguous_format)
         else:
-            item.encoded = emb.contiguous()
+            item.encoded = emb.clone(memory_format=torch.contiguous_format)
             item.encoded_deepstack = None
 
 
@@ -105,6 +118,10 @@ class DisaggEncodeExecutor:
         self.manager = manager
         self.model = multimodal_model
         self.device = device
+        mapping = getattr(multimodal_model, "mapping", None)
+        self._encoder_embedder = MultimodalEmbedder(
+            encoder_mapping=mapping.vision if mapping is not None else None
+        )
         self.senders = {}
         # RDMA requires every transferred buffer to be a registered memory region,
         # and mooncake rejects OVERLAPPING registrations -- registering each
@@ -161,8 +178,37 @@ class DisaggEncodeExecutor:
             by_modality.setdefault(item.modality, []).append(item)
         with torch.inference_mode():
             for modality, items in by_modality.items():
-                output = self._feature_fn(modality)(items)
-                assign_encoded_embeddings(items, output, self.model)
+                try:
+                    feature_fn = self._feature_fn(modality)
+                    spec = EncoderSpec(feature_fn, deepstack=False)
+                    if self._encoder_embedder.has_encoder_dp:
+                        num_deepstack = getattr(
+                            self.model, "num_deepstack_embeddings", 0
+                        )
+                        output_width = self.model.config.hidden_size * (
+                            1 + num_deepstack
+                        )
+                        tower = (
+                            getattr(self.model, "visual", None)
+                            or self.model.vision_tower
+                        )
+                        spec = EncoderSpec(feature_fn, deepstack=num_deepstack > 0)
+                        per_item = self._encoder_embedder.encode_data_parallel(
+                            items,
+                            spec,
+                            torch.device(self.device),
+                            output_width,
+                            tower.dtype,
+                        )
+                        assign_per_item_encoded_embeddings(items, per_item, self.model)
+                    else:
+                        output = self._encoder_embedder.run_encoder(
+                            items, spec, torch.device(self.device)
+                        )
+                        assign_encoded_embeddings(items, output, self.model)
+                finally:
+                    for item in items:
+                        self._encoder_embedder._drop_raw_feature(item)
         # Stage every embedding into its ring slot, then issue the async
         # Mooncake sends. See _stage_and_send for the copy/RDMA
         # overwrite-safety invariant (one CUDA event gates each transfer).
@@ -218,6 +264,22 @@ class DisaggEncodeExecutor:
                 if not mgr.is_parked(room):
                     return slot
         return None
+
+    def available_ring_slots(self) -> int:
+        """Return reusable slot count without reserving or blocking."""
+        available = 0
+        for room in self._slot_rooms:
+            if room is None:
+                available += 1
+                continue
+            status = self.manager.room_status(room)
+            if status is None or status in (
+                TransferPoll.Success,
+                TransferPoll.Failed,
+            ):
+                if not self.manager.is_parked(room):
+                    available += 1
+        return available
 
     def _stage_and_send(self, items: list[tuple[str, MultimodalDataItem]]) -> None:
         """Lease a ring slot per item and ship it; items that cannot lease a free

--- a/python/tokenspeed/runtime/epd/encode_loop.py
+++ b/python/tokenspeed/runtime/epd/encode_loop.py
@@ -33,18 +33,18 @@ on ``port_args.scheduler_input_ipc_name``. The smg grpc_servicer's TokenSpeedEnc
 handler sends an :class:`EncodeRequest` (pickled) over that channel; the loop
 drains them into ``EncodeWorker.submit`` and runs ``step`` to encode + transfer.
 
-TP: the vision tower is TP-sharded, so all encode ranks run each batch in lockstep
--- rank 0 owns the gateway ZMQ and broadcasts every batch to the TP group. The
-embedding transport is a 1->N broadcast: prefill_tp must be a multiple of
-encode_tp. Data-parallel encode workers inside one server are not supported;
-horizontal scale comes from multiple independent encode servers selected by the
-gateway.
+All encode ranks run each batch in lockstep. In weight mode the vision tower is
+TP-sharded; in data mode ranks own whole items and replicate the gathered output
+before transfer. Rank 0 owns the gateway ZMQ and broadcasts every request batch.
+The embedding transport is a 1->N broadcast: prefill_tp must be a multiple of
+the encode execution width.
 """
 
 from __future__ import annotations
 
 import time
 
+import torch
 import zmq
 
 from tokenspeed.runtime.cache.embedding_cache import (
@@ -238,10 +238,8 @@ def run_encode_loop(server_args, port_args, pipe_writer, gpu_id, global_rank):
         server_args, port_args, gpu_id, global_rank
     )
 
-    # TP coordination: the vision tower is TP-sharded (collective ops), so every
-    # encode rank must run each batch in lockstep. Only rank 0 owns the gateway
-    # ZMQ; it broadcasts each drained batch to the TP group so all ranks submit
-    # the same requests and step together. (TP=1 -> rank 0 only, no broadcast.)
+    # Encode-rank coordination: weight TP and item DP both require lockstep
+    # batches. Only rank 0 owns the gateway ZMQ and broadcasts requests.
     attn_tp_rank = server_args.mapping.attn.tp_rank
     attn_tp_size = server_args.attn_tp_size or server_args.mapping.attn.tp_size
     tp_cpu_group = None
@@ -257,6 +255,15 @@ def run_encode_loop(server_args, port_args, pipe_writer, gpu_id, global_rank):
         tp_cpu_group = pg_manager.get_process_group(
             "gloo", server_args.mapping.attn.tp_group
         )
+
+    def min_available_slots(local_slots: int) -> int:
+        if attn_tp_size == 1:
+            return local_slots
+        available = torch.tensor(local_slots, dtype=torch.int32)
+        torch.distributed.all_reduce(
+            available, op=torch.distributed.ReduceOp.MIN, group=tp_cpu_group
+        )
+        return int(available.item())
 
     context = zmq.Context(2)
     recv_from_gateway = None
@@ -279,11 +286,17 @@ def run_encode_loop(server_args, port_args, pipe_writer, gpu_id, global_rank):
     )
 
     while True:
+        available_slots = min_available_slots(worker.prepare_step())
         # Rank 0 drains the gateway ZMQ without blocking; other ranks get the
         # same batch by broadcast below.
         new_reqs = []
-        if attn_tp_rank == 0:
-            while True:
+        if (
+            attn_tp_rank == 0
+            and available_slots > 0
+            and not worker.has_pending()
+            and not worker.has_deferred()
+        ):
+            while len(new_reqs) < server_args.max_num_seqs:
                 try:
                     request = recv_from_gateway.recv_pyobj(flags=zmq.NOBLOCK)
                 except zmq.Again:
@@ -297,13 +310,33 @@ def run_encode_loop(server_args, port_args, pipe_writer, gpu_id, global_rank):
                 new_reqs, attn_tp_rank, tp_cpu_group, src=attn_tp_src_rank
             )
 
+        if new_reqs:
+            from tokenspeed.runtime.multimodal.shm_transport import (
+                ShmTensorHandle,
+                sync_shm_handles,
+            )
+
+            sync_shm_handles(
+                (
+                    item.feature
+                    for request in new_reqs
+                    for item in request.items
+                    if isinstance(item.feature, ShmTensorHandle)
+                ),
+                tp_cpu_group,
+                attn_tp_size,
+            )
+
         for request in new_reqs:
             worker.submit(request)
         drained = len(new_reqs) > 0
 
+        if drained:
+            available_slots = min_available_slots(worker.prepare_step())
+
         # Encode + ship one scheduler batch. step() returns 0 when idle. All ranks
         # hold the same pending set, so they make the same step decision together.
-        did = worker.step()
+        did = worker.step(available_slots=available_slots) if available_slots else 0
 
         # Yield the GIL when there is no fresh ZMQ work, OR when sends are deferred
         # on a full ring. The daemon transfer-workers that free ring slots are

--- a/python/tokenspeed/runtime/epd/encode_scheduler.py
+++ b/python/tokenspeed/runtime/epd/encode_scheduler.py
@@ -93,18 +93,23 @@ class EncodeScheduler:
         # Sort by (request_id, item_index) for cross-rank determinism.
         return [self._pending[k] for k in sorted(self._pending.keys())]
 
-    def next_batch(self) -> list[PendingEncodeItem]:
+    def next_batch(self, max_items: int | None = None) -> list[PendingEncodeItem]:
         """Pop and return the next deterministic batch of items to encode.
 
         Empty when nothing is pending. Removes the returned items from the
-        pending set.
+        pending set. ``max_items`` may impose a smaller transient limit, such as
+        the number of currently available transfer-ring slots.
         """
+        item_limit = self.max_items_per_batch
+        if max_items is not None:
+            if max_items <= 0:
+                return []
+            item_limit = min(item_limit, max_items)
         batch: list[PendingEncodeItem] = []
         used = 0
         for it in self._ordered_pending():
             if batch and (
-                used + it.cost > self.max_tokens_per_batch
-                or len(batch) >= self.max_items_per_batch
+                used + it.cost > self.max_tokens_per_batch or len(batch) >= item_limit
             ):
                 break
             batch.append(it)

--- a/python/tokenspeed/runtime/epd/encode_worker.py
+++ b/python/tokenspeed/runtime/epd/encode_worker.py
@@ -103,16 +103,13 @@ class EncodeWorker:
             cached = self.cache.get(item.hash)
             if isinstance(item.feature, ShmTensorHandle):
                 # EPD pixel-SHM: the servicer published pixels to POSIX SHM and
-                # the ZMQ hop carried only this handle (hash/pad_value were set on
-                # the real tensor before publish). consume() unlinks, so segments
-                # never outlive the item: materialize on a miss, and on a hit still
-                # consume-and-drop to unlink the unused segment.
-                handle, item.feature = item.feature, None
-                handle.attach()
-                if cached is None:
-                    item.feature = handle.consume()
-                else:
-                    handle.consume()
+                # the ZMQ hop carried only this handle. Misses stay lazy so item-DP
+                # materializes pixels only on the owner rank; cache hits release the
+                # already-attached segment without copying it.
+                item.feature.attach()
+                if cached is not None:
+                    item.feature.release()
+                    item.feature = None
             if cached is not None:
                 # Cache hit: tower skipped, but the embedding still must reach
                 # the prefill peer, so ship it directly. Entries are
@@ -134,21 +131,28 @@ class EncodeWorker:
                 )
                 self._pending[(request.request_id, idx)] = item
 
-    def step(self) -> int:
+    def prepare_step(self) -> int:
+        """Poll transfers and return slots available for another encode."""
+        self.executor.reap_concluded_senders({rid for (rid, _idx) in self._pending})
+        self.executor.drain_deferred()
+        if self.executor.has_deferred():
+            return 0
+        return self.executor.available_ring_slots()
+
+    def step(self, *, available_slots: int | None = None) -> int:
         """Run one scheduler batch through the tower + transfer. Returns the
         number of items encoded (0 when nothing is pending)."""
-        self.executor.reap_concluded_senders({rid for (rid, _idx) in self._pending})
-        # Retry sends that couldn't lease a ring slot last tick (non-blocking).
-        self.executor.drain_deferred()
+        if available_slots is None:
+            available_slots = self.prepare_step()
         # Backpressure: if sends are STILL deferred after the drain, the bounce
         # ring is saturated (all slots hold in-flight transfers). Pulling more ViT
         # now would only pile fresh embeddings into _deferred_sends -- each pins a
         # GPU embedding tensor with no slot to ship it, growing an unbounded
         # backlog into an OOM. Skip this tick; the loop yields the GIL (encode_loop
         # sees has_deferred) so the transfer daemons free slots, then we resume.
-        if self.executor.has_deferred():
+        if available_slots <= 0 or self.executor.has_deferred():
             return 0
-        batch = self.scheduler.next_batch()
+        batch = self.scheduler.next_batch(max_items=available_slots)
         if not batch:
             return 0
         request_items = [(p.request_id, self._pending[p.key]) for p in batch]

--- a/python/tokenspeed/runtime/multimodal/embedder.py
+++ b/python/tokenspeed/runtime/multimodal/embedder.py
@@ -456,7 +456,7 @@ class MultimodalEmbedder:
                 output_width = embedding_width
                 if spec.deepstack:
                     output_width *= 1 + len(multimodal_model.deepstack_visual_indexes)
-                per_item_embs = self._encode_data_parallel(
+                per_item_embs = self.encode_data_parallel(
                     items,
                     spec,
                     device,
@@ -464,14 +464,14 @@ class MultimodalEmbedder:
                     embedding_dtype,
                 )
             else:
-                output = self._run_encoder(items, spec, device)
+                output = self.run_encoder(items, spec, device)
                 per_item_lens = [_item_token_count(it) for it in items]
                 output = output.reshape(-1, output.shape[-1])
                 per_item_embs = list(torch.split(output, per_item_lens, dim=0))
 
             self._store_encoder_outputs(items, per_item_embs, spec, multimodal_model)
 
-    def _run_encoder(
+    def run_encoder(
         self,
         items: list[MultimodalDataItem],
         spec: EncoderSpec,
@@ -480,7 +480,7 @@ class MultimodalEmbedder:
         self._move_features_to_device(items, device)
         return spec.fn(items)
 
-    def _encode_data_parallel(
+    def encode_data_parallel(
         self,
         items: list[MultimodalDataItem],
         spec: EncoderSpec,
@@ -496,11 +496,37 @@ class MultimodalEmbedder:
         local_rows = assignment.token_counts_by_rank[self._encoder_dp_rank]
 
         local_output = torch.empty((0, output_width), dtype=output_dtype, device=device)
-        if local_items:
-            local_output = self._run_encoder(local_items, spec, device)
-            local_output = local_output.reshape(local_rows, output_width).to(
-                device=device, dtype=output_dtype
+        local_error = None
+        try:
+            if local_items:
+                local_output = self.run_encoder(local_items, spec, device)
+                local_output = local_output.reshape(local_rows, output_width).to(
+                    device=device, dtype=output_dtype
+                )
+        except Exception as exc:
+            local_error = f"{type(exc).__name__}: {exc}"
+
+        # Production initializes both backends for every mapping group. Agree
+        # failures over Gloo before any rank enters the NCCL output broadcasts,
+        # otherwise an owner-only encoder error would strand its peers.
+        if process_group_manager.has_process_group("gloo", self._encoder_dp_group):
+            errors: list[str | None] = [None] * len(self._encoder_dp_group)
+            torch.distributed.all_gather_object(
+                errors,
+                local_error,
+                group=process_group_manager.get_process_group(
+                    "gloo", self._encoder_dp_group
+                ),
             )
+            if any(errors):
+                details = "; ".join(
+                    f"rank {rank}: {error}"
+                    for rank, error in enumerate(errors)
+                    if error is not None
+                )
+                raise RuntimeError(f"encoder item-DP execution failed: {details}")
+        elif local_error is not None:
+            raise RuntimeError(f"encoder item-DP execution failed: {local_error}")
 
         gathered = self._gather_encoder_outputs(
             local_output, assignment.token_counts_by_rank

--- a/python/tokenspeed/runtime/multimodal/shm_transport.py
+++ b/python/tokenspeed/runtime/multimodal/shm_transport.py
@@ -134,6 +134,42 @@ class ShmTensorHandle:
             )
 
 
+def sync_shm_handles(handles, group, group_size: int) -> None:
+    """Attach handles on every rank before any consumer may unlink them."""
+    handles = list(handles)
+    if not handles:
+        return
+    local_error = None
+    try:
+        for handle in handles:
+            handle.attach()
+    except Exception as exc:
+        local_error = f"{type(exc).__name__}: {exc}"
+
+    if group_size > 1:
+        errors: list[str | None] = [None] * group_size
+        torch.distributed.all_gather_object(errors, local_error, group=group)
+        if any(errors):
+            for handle in handles:
+                try:
+                    handle.release()
+                except Exception:
+                    logger.exception("failed to release SHM handle after attach error")
+            details = "; ".join(
+                f"rank {rank}: {error}"
+                for rank, error in enumerate(errors)
+                if error is not None
+            )
+            raise RuntimeError(f"multimodal SHM attach failed: {details}")
+    elif local_error is not None:
+        for handle in handles:
+            try:
+                handle.release()
+            except Exception:
+                logger.exception("failed to release SHM handle after attach error")
+        raise RuntimeError(f"multimodal SHM attach failed: {local_error}")
+
+
 def sync_shm_features(reqs, group, group_size: int) -> None:
     """Attach SHM-backed features in ``reqs`` on every rank.
 
@@ -150,10 +186,16 @@ def sync_shm_features(reqs, group, group_size: int) -> None:
     if not pending:
         return
     started = time.perf_counter() if LOG_MM_TIMING else None
-    for mm in pending:
-        mm.attach_shm_features()
-    if group_size > 1:
-        torch.distributed.barrier(group)
+    sync_shm_handles(
+        (
+            item.feature
+            for mm in pending
+            for item in mm.mm_items
+            if isinstance(item.feature, ShmTensorHandle)
+        ),
+        group,
+        group_size,
+    )
     if LOG_MM_TIMING and started is not None:
         item_count = sum(len(mm.mm_items) for mm in pending)
         logger.info(

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -532,10 +532,10 @@ class ServerArgs:
             raise ValueError("MoE TP and EP cannot be both > 1")
 
         if self.mm_encoder_tp_mode == "data":
-            if self.disaggregation_mode != "null":
+            if self.disaggregation_mode not in ("null", "encode"):
                 raise ValueError(
-                    "--mm-encoder-tp-mode data currently requires "
-                    "--disaggregation-mode null (aggregate serving)"
+                    "--mm-encoder-tp-mode data currently supports aggregate "
+                    "serving or --disaggregation-mode encode"
                 )
             if self.mapping.nnodes != 1:
                 raise ValueError(

--- a/test/runtime/distributed/test_epd_encode.py
+++ b/test/runtime/distributed/test_epd_encode.py
@@ -55,6 +55,7 @@ from tokenspeed.runtime.multimodal.inputs import (
     Modality,
     MultimodalDataItem,
 )
+from tokenspeed.runtime.multimodal.shm_transport import sync_shm_handles
 from tokenspeed.runtime.pd.base.status import TransferPoll
 
 
@@ -63,6 +64,7 @@ class _FakeExecutor:
         self.registered = []
         self.executed_batches = []  # list of [item.hash, ...] the tower ran
         self.sent_direct = []  # cache-hit hashes shipped without the tower
+        self.available_slots = 99
 
     def register(self, rid, host, port, room):
         self.registered.append((rid, room))
@@ -83,6 +85,9 @@ class _FakeExecutor:
 
     def has_deferred(self):
         return False
+
+    def available_ring_slots(self):
+        return self.available_slots
 
 
 def _item(h, tokens=2):
@@ -122,6 +127,16 @@ def test_cache_hit_skips_tower_but_still_ships():
     assert ex.sent_direct == [111]
     assert not w.has_pending()
     assert ex.executed_batches == [[111]]  # tower ran exactly once
+
+
+def test_worker_caps_encode_batch_to_available_ring_slots():
+    ex, w = _worker()
+    ex.available_slots = 1
+    w.submit(_req("r0", [_item(111), _item(222), _item(333)]))
+
+    assert w.step() == 1
+    assert ex.executed_batches == [[111]]
+    assert w.scheduler.pending_size() == 2
 
 
 # --- The encode worker drives the cache through get()/put() only, so it works
@@ -180,6 +195,9 @@ class _RaisingExecutor:
 
     def has_deferred(self):
         return False
+
+    def available_ring_slots(self):
+        return 99
 
     def fail_rooms(self, request_ids, exc):
         rooms = set()
@@ -281,6 +299,22 @@ class _LeaseManager:
     def is_parked(self, room):
         with self._pending_lock:
             return room in self._pending
+
+
+def test_available_ring_slots_excludes_inflight_and_parked_rooms():
+    manager = _LeaseManager(_RecordingEngine())
+    ex = DisaggEncodeExecutor(
+        manager, multimodal_model=None, device="cpu", ring_slots=3, ring_bytes=8
+    )
+    ex._slot_rooms = [1, 2, 3]
+    manager.request_status = {
+        1: TransferPoll.Transferring,
+        2: TransferPoll.Success,
+        3: TransferPoll.Success,
+    }
+    manager._pending[3] = object()
+
+    assert ex.available_ring_slots() == 1
 
 
 # --- Staging errors on the UNGUARDED paths must fail the room, not the worker.
@@ -395,6 +429,9 @@ def test_split_assigns_per_item_rows_and_deepstack():
     assert torch.equal(items[1].encoded_deepstack, output[2:5, 4:])
     assert items[0].encoded.is_contiguous()
     assert items[1].encoded_deepstack.is_contiguous()
+    output.zero_()
+    assert torch.count_nonzero(items[0].encoded) > 0
+    assert torch.count_nonzero(items[1].encoded_deepstack) > 0
 
 
 def test_token_count_mismatch_raises():
@@ -431,6 +468,41 @@ def test_feature_fn_image_routes_through_image_encoder_seam():
     assert exe._feature_fn(Modality.VIDEO) is model.get_video_feature
 
 
+def test_executor_item_dp_reconstructs_full_output_before_send():
+    items = [_exec_item((0, 1)), _exec_item((0, 2))]
+    expected = [torch.full((2, 4), 1.0), torch.full((3, 4), 2.0)]
+
+    class _Tower:
+        dtype = torch.float32
+
+    class _Model(_PlainModel):
+        mapping = None
+        config = type("Config", (), {"hidden_size": 4})()
+        vision_tower = _Tower()
+        image_encoder = staticmethod(lambda batch: None)
+
+    class _DPEmbedder:
+        has_encoder_dp = True
+
+        def encode_data_parallel(self, batch, spec, device, width, dtype):
+            assert batch == items
+            assert spec.fn is _Model.image_encoder
+            assert (device, width, dtype) == (torch.device("cpu"), 4, torch.float32)
+            return expected
+
+        @staticmethod
+        def _drop_raw_feature(item):
+            item.feature = None
+
+    exe = DisaggEncodeExecutor(object(), _Model(), "cpu")
+    exe._encoder_embedder = _DPEmbedder()
+    exe._stage_and_send = lambda request_items: None
+    exe.execute([("r0", items[0]), ("r1", items[1])])
+
+    torch.testing.assert_close(items[0].encoded, expected[0])
+    torch.testing.assert_close(items[1].encoded, expected[1])
+
+
 def _sched_item(rid: str, idx: int, cost: int) -> PendingEncodeItem:
     return PendingEncodeItem(
         request_id=rid,
@@ -460,6 +532,33 @@ def test_scheduler_respects_max_items():
     assert len(s.next_batch()) == 2
     assert len(s.next_batch()) == 2
     assert len(s.next_batch()) == 1
+
+
+def test_scheduler_respects_transient_item_limit():
+    s = EncodeScheduler(max_tokens_per_batch=10_000, max_items_per_batch=5)
+    for i in range(3):
+        s.add(_sched_item("r0", i, 1))
+    assert len(s.next_batch(max_items=1)) == 1
+    assert s.pending_size() == 2
+
+
+def test_partial_shm_attach_failure_releases_every_handle():
+    class _Handle:
+        def __init__(self, fails=False):
+            self.fails = fails
+            self.released = False
+
+        def attach(self):
+            if self.fails:
+                raise FileNotFoundError("missing")
+
+        def release(self):
+            self.released = True
+
+    handles = [_Handle(), _Handle(fails=True), _Handle()]
+    with pytest.raises(RuntimeError, match="SHM attach failed"):
+        sync_shm_handles(handles, group=None, group_size=1)
+    assert all(handle.released for handle in handles)
 
 
 def test_scheduler_oversized_single_item_returned_alone():

--- a/test/runtime/distributed/test_multimodal_encoder_parallelism.py
+++ b/test/runtime/distributed/test_multimodal_encoder_parallelism.py
@@ -30,13 +30,19 @@ from tokenspeed.runtime.utils.server_args import ServerArgs
 
 
 def _mapping_from_cli(
-    mode: str | None = None, *, request_dp_size: int = 1, rank: int = 0
+    mode: str | None = None,
+    *,
+    request_dp_size: int = 1,
+    rank: int = 0,
+    disaggregation_mode: str = "null",
 ) -> Mapping:
     parser = argparse.ArgumentParser()
     ServerArgs.add_cli_args(parser)
     argv = ["--model", "test/model", "--tensor-parallel-size", "2"]
     if mode is not None:
         argv.extend(["--mm-encoder-tp-mode", mode])
+    if disaggregation_mode != "null":
+        argv.extend(["--disaggregation-mode", disaggregation_mode])
     if request_dp_size > 1:
         argv.extend(["--data-parallel-size", str(request_dp_size)])
     args = parser.parse_args(argv)
@@ -156,6 +162,21 @@ def _run_item_dp_case(rank: int, device: torch.device, mapping: Mapping) -> None
     assert idle_calls == (1 if rank == 0 else 0)
     torch.testing.assert_close(idle_item.encoded, _encoded_rows(idle_item, 2, device))
 
+    failing_item = _item(50, 1)
+
+    def failing_encoder(batch):
+        raise ValueError("owner failed")
+
+    with pytest.raises(RuntimeError, match="rank 0: ValueError: owner failed"):
+        embedder._encode(
+            EncodePlan(misses_by_modality={Modality.IMAGE: [failing_item]}),
+            {Modality.IMAGE: EncoderSpec(failing_encoder)},
+            SimpleNamespace(),
+            device,
+            2,
+            torch.float32,
+        )
+
 
 def _item_dp_worker(rank: int, world_size: int, port: int) -> None:
     device = torch.device(f"cuda:{rank}")
@@ -179,9 +200,7 @@ def _item_dp_worker(rank: int, world_size: int, port: int) -> None:
             vision_tp_size=1,
             vision_dp_size=world_size,
         )
-        process_group_manager.init_process_group(
-            mapping.vision.dp_group, backend="nccl"
-        )
+        process_group_manager.init_process_group(mapping.vision.dp_group)
         _run_item_dp_case(rank, device, mapping)
     finally:
         dist.destroy_process_group()
@@ -206,3 +225,16 @@ def test_multimodal_encoder_item_dp() -> None:
         nprocs=world_size,
         join=True,
     )
+
+
+def test_multimodal_encoder_item_dp_is_available_for_epd_encode() -> None:
+    mapping = _mapping_from_cli("data", disaggregation_mode="encode", rank=1)
+    assert (mapping.attn.tp_size, mapping.attn.dp_size) == (2, 1)
+    assert (mapping.vision.tp_size, mapping.vision.dp_size) == (1, 2)
+    assert mapping.vision.dp_group == mapping.attn.tp_group == (0, 1)
+
+
+@pytest.mark.parametrize("mode", ["prefill", "decode"])
+def test_multimodal_encoder_item_dp_rejects_non_encode_disaggregation(mode) -> None:
+    with pytest.raises(ValueError, match="aggregate serving.*encode"):
+        _mapping_from_cli("data", disaggregation_mode=mode)


### PR DESCRIPTION
## Summary
- enable whole-item encoder data parallelism for EPD encode workers
- gather ordered per-item outputs on every encode rank before Mooncake transfer
- synchronize failures, SHM attachment, and transfer-ring admission across ranks
- cap batches to the minimum available ring capacity and isolate cache-owned tensor storage
- document EPD item-DP configuration and add distributed/unit coverage

## Validation
- `pre-commit run --all-files`
- Python byte-compilation
- two-pass static correctness review with no remaining high/medium findings

Focused pytest collection is blocked locally by missing `pyzmq` and `tokenspeed_kernel`; multi-rank GPU validation is planned separately.