### PR TITLE
fix(epd): install all encoder graph wrappers

### DIFF
--- a/python/tokenspeed/runtime/epd/encode_executor.py
+++ b/python/tokenspeed/runtime/epd/encode_executor.py
@@ -147,12 +147,11 @@ class DisaggEncodeExecutor:
         # IMAGE dispatches through the model's ``image_encoder`` seam, NOT
         # ``get_image_feature`` directly: that seam is what the encoder CUDA-graph
         # wrapper overrides (see _maybe_install_encoder_cudagraph). When the graph
-        # is disabled the model leaves ``image_encoder = get_image_feature`` (eager);
-        # VIDEO has no captured graph -> always eager.
+        # is disabled the model leaves these seams on their eager defaults.
         if modality == Modality.IMAGE:
             return self.model.image_encoder
         if modality == Modality.VIDEO:
-            return self.model.get_video_feature
+            return self.model.video_encoder
         raise ValueError(f"unsupported modality for encode: {modality}")
 
     def execute(self, request_items: list[tuple[str, MultimodalDataItem]]) -> None:

--- a/python/tokenspeed/runtime/epd/encode_loop.py
+++ b/python/tokenspeed/runtime/epd/encode_loop.py
@@ -120,28 +120,45 @@ def _build_manager_args(server_args, mapping):
 
 
 def _maybe_install_encoder_cudagraph(model, server_args) -> bool:
-    """Install the vision-encoder CUDA-graph wrapper as ``model.image_encoder``,
+    """Install encoder CUDA-graph wrappers on their model attributes,
     mirroring the aggregated path's hook in ``execution/model_executor.py``.
 
     The encode loop never builds a ModelExecutor, so this is where the encode
     worker opts into capture/replay of the tower instead of running it eager. Same
     gate as the aggregated install: the model exposes the builder, multimodal is
     active, the env flag is on, and the attention backend is graph-capturable. The
-    wrapper IS the model's ``image_encoder`` seam (lazy capture on first encode);
-    the executor's IMAGE path dispatches through ``model.image_encoder`` and falls
-    back to eager ``get_image_feature`` (the default) when this returns False.
+    Each wrapper replaces its modality encoder seam (lazy capture on first encode);
+    the executor dispatches through that seam and falls back to the eager encoder
+    when this returns False.
     Returns whether the wrapper was installed.
     """
     if not (
-        hasattr(model, "make_encoder_cudagraph_wrapper")
+        hasattr(model, "make_encoder_cudagraph_wrappers")
         and getattr(model, "is_multimodal_active", True)
         and envs.TOKENSPEED_MM_ENABLE_ENCODER_CUDA_GRAPH.get()
         and server_args.mm_attention_backend != "flashinfer_cudnn"
     ):
         return False
-    model.image_encoder = model.make_encoder_cudagraph_wrapper(model.mapping)
-    logger.info("EPD encode worker: vision-encoder CUDA graph installed")
-    return True
+
+    installed = []
+    for encoder_attr, wrapper in model.make_encoder_cudagraph_wrappers(
+        model.mapping
+    ).items():
+        if not hasattr(model, encoder_attr):
+            logger.warning(
+                "Skipping EPD encoder CUDA graph wrapper for missing attribute %s",
+                encoder_attr,
+            )
+            continue
+        setattr(model, encoder_attr, wrapper)
+        installed.append(encoder_attr)
+
+    if installed:
+        logger.info(
+            "EPD encode worker: encoder CUDA graphs installed for %s",
+            ", ".join(installed),
+        )
+    return bool(installed)
 
 
 def _build_encode_worker(server_args, port_args, gpu_id, global_rank):

--- a/test/runtime/distributed/test_epd_encode.py
+++ b/test/runtime/distributed/test_epd_encode.py
@@ -413,7 +413,8 @@ class _FeatureFnModel:
         # use a distinct sentinel so the test proves IMAGE routes via the seam.
         self.image_encoder = lambda items: "via-image_encoder-seam"
         self.get_image_feature = lambda items: "eager-get_image_feature"
-        self.get_video_feature = lambda items: "video"
+        self.video_encoder = lambda items: "via-video_encoder-seam"
+        self.get_video_feature = lambda items: "eager-get_video_feature"
 
 
 def test_feature_fn_image_routes_through_image_encoder_seam():
@@ -427,8 +428,8 @@ def test_feature_fn_image_routes_through_image_encoder_seam():
     # get_image_feature directly -- else the captured graph would be bypassed.
     assert exe._feature_fn(Modality.IMAGE) is model.image_encoder
     assert exe._feature_fn(Modality.IMAGE) is not model.get_image_feature
-    # VIDEO has no captured graph and stays on the eager entry point.
-    assert exe._feature_fn(Modality.VIDEO) is model.get_video_feature
+    assert exe._feature_fn(Modality.VIDEO) is model.video_encoder
+    assert exe._feature_fn(Modality.VIDEO) is not model.get_video_feature
 
 
 def _sched_item(rid: str, idx: int, cost: int) -> PendingEncodeItem:
@@ -523,14 +524,22 @@ class _FakeModel:
         # The model leaves image_encoder == get_image_feature by default; the
         # wrapper install overrides it.
         self.image_encoder = self.get_image_feature
+        self.video_encoder = self.get_video_feature
         self.built_with = None
 
     def get_image_feature(self, items):
         return "eager"
 
-    def make_encoder_cudagraph_wrapper(self, mapping):
+    def get_video_feature(self, items):
+        return "eager-video"
+
+    def make_encoder_cudagraph_wrappers(self, mapping):
         self.built_with = mapping
-        return _WRAPPER
+        return {
+            "image_encoder": _WRAPPER,
+            "video_encoder": _WRAPPER,
+            "missing_encoder": object(),
+        }
 
 
 class _FakeServerArgs:
@@ -551,4 +560,12 @@ def test_encoder_cudagraph_installed_when_enabled(monkeypatch):
     m = _FakeModel()
     assert _maybe_install_encoder_cudagraph(m, _FakeServerArgs()) is True
     assert m.image_encoder is _WRAPPER
+    assert m.video_encoder is _WRAPPER
     assert m.built_with is m.mapping
+
+
+def test_encoder_cudagraph_empty_wrapper_map_is_not_installed(monkeypatch):
+    _set_graph_flag(monkeypatch, True)
+    m = _FakeModel()
+    m.make_encoder_cudagraph_wrappers = lambda mapping: {}
+    assert _maybe_install_encoder_cudagraph(m, _FakeServerArgs()) is False


### PR DESCRIPTION
## Summary
- consume multimodal models’ existing encoder CUDA-graph wrapper maps in EPD
- install each available modality wrapper instead of calling the obsolete singular builder
- route video through its capturable encoder seam

## Validation
- `pre-commit run --all-files`
- Python byte-compilation
- focused install and modality-routing tests added

Focused pytest collection is blocked locally by missing `pyzmq`.