### PR TITLE
feat(kernel): support small-batch Gluon MLA decode

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/decode.py
@@ -26,7 +26,7 @@ MIT-licensed ``aiter/ops/triton/gluon/mla_gluon.py`` at commit
 ``ae0bae8954110b12655e3232f68262dd63cd694e``. The implementation here retains
 TokenSpeed's paged-cache interface (page IDs plus an arbitrary page size).
 
-The shared kernel supports three regimes:
+The shared kernel supports five fixed regimes:
 
 * ``bh16bn128`` -- BF16/FP8 Q + FP8 KV, BLOCK_H=16, BLOCK_N=128 and
   ``num_q_heads <= 16`` and arbitrary batch sizes.
@@ -34,11 +34,8 @@ The shared kernel supports three regimes:
   ``num_q_heads <= 16``.
 * ``bh64`` -- BLOCK_H=64, BLOCK_N=64, ``num_q_heads in {64, 128}``, 3-D
   XCD-aware grid, ``batch_size`` divisible by 64.
-
-For 64-head small batches, either compute regime can use a 3-D
-(batch, head-block, split) grid. The selected mapping is independent of the
-compute layouts so both variants can be benchmarked without duplicating the
-attention math.
+* ``bh16-multiblock`` -- BF16 Q/KV, BLOCK_H=16, 64 heads, small-batch 3-D grid.
+* ``bh64-small`` -- BF16 Q/KV, BLOCK_H=64, 64 heads, small-batch 3-D grid.
 """
 
 from __future__ import annotations
@@ -67,7 +64,6 @@ class AttentionConfig:
     NHEAD: gl.constexpr
     REGIME: gl.constexpr
     IS_FP8_Q: gl.constexpr
-    GRID_MODE: gl.constexpr
     RETURN_LSE: gl.constexpr
     stride_q_nope_bs: gl.constexpr
     stride_q_nope_h: gl.constexpr
@@ -118,7 +114,6 @@ class AttentionConfig:
         NHEAD,
         REGIME,
         IS_FP8_Q,
-        GRID_MODE,
         RETURN_LSE,
         stride_q_nope_bs,
         stride_q_nope_h,
@@ -523,7 +518,7 @@ class AttentionConfig:
         # V is the latent slice of K, read back transposed for the PV dot.
         # bh64 tiles M across warps (degenerate warp_bases + extra reg bases);
         # bh16bn64 tiles the 64-wide K across warps.
-        if REGIME == "bh64":
+        if BLOCK_H == 64:
             linear_v = gl.DistributedLinearLayout(
                 reg_bases=(
                     (0, 1),
@@ -610,7 +605,6 @@ class AttentionConfig:
         self.NHEAD = gl.constexpr(NHEAD)
         self.REGIME = gl.constexpr(REGIME)
         self.IS_FP8_Q = gl.constexpr(IS_FP8_Q)
-        self.GRID_MODE = gl.constexpr(GRID_MODE)
         self.RETURN_LSE = gl.constexpr(RETURN_LSE)
         self.stride_q_nope_bs = gl.constexpr(stride_q_nope_bs)
         self.stride_q_nope_h = gl.constexpr(stride_q_nope_h)
@@ -721,27 +715,24 @@ class AttentionProgram:
         sm_scale,
         kv_scale,
     ):
-        # Grid modes are independent of compute layout. ``xcd`` distributes
-        # large bh64 batches across XCDs, ``batch_split`` maps bh16 work over
-        # (batch, split), and ``batch_head_split`` adds a head-block axis.
-        if cfg.GRID_MODE == "xcd":
+        if cfg.REGIME == "bh64":
             cur_batch = (
                 gl.program_id(0)
                 + (gl.program_id(2) // cfg.NUM_KV_SPLITS) * cfg.NUM_XCDS
             )
             cur_head_id = gl.program_id(1)
             split_kv_id = gl.program_id(2) % cfg.NUM_KV_SPLITS
-        elif cfg.GRID_MODE == "batch_split":
+        elif cfg.REGIME == "bh16bn64" or cfg.REGIME == "bh16bn128":
             cur_batch = gl.program_id(0)
             split_kv_id = gl.program_id(1)
             # Head-block 0; use a runtime zero (aggregate fields hold tensors).
             cur_head_id = split_kv_id - split_kv_id
-        elif cfg.GRID_MODE == "batch_head_split":
+        elif cfg.REGIME == "bh16-multiblock" or cfg.REGIME == "bh64-small":
             cur_batch = gl.program_id(0)
             cur_head_id = gl.program_id(1)
             split_kv_id = gl.program_id(2)
         else:
-            gl.static_assert(False, "unsupported MLA grid mode")
+            gl.static_assert(False, "unsupported MLA decode regime")
 
         # Paged 2-D view: Req_to_tokens = block_table[batch, max_pages],
         # B_seq_len = cache_seqlens[batch].
@@ -1041,7 +1032,7 @@ def _mla_decode_gluon(
     K_pe_cache,
     Req_to_tokens,
     B_seq_len,
-    O,  # noqa: E741
+    O,
     sm_scale,
     kv_scale,
     stride_q_nope_bs: gl.constexpr,
@@ -1073,7 +1064,6 @@ def _mla_decode_gluon(
     NHEAD: gl.constexpr,
     REGIME: gl.constexpr,
     IS_FP8_Q: gl.constexpr,
-    GRID_MODE: gl.constexpr,
     RETURN_LSE: gl.constexpr,
 ):
     cfg = AttentionConfig(
@@ -1089,7 +1079,6 @@ def _mla_decode_gluon(
         NHEAD,
         REGIME,
         IS_FP8_Q,
-        GRID_MODE,
         RETURN_LSE,
         stride_q_nope_bs,
         stride_q_nope_h,
@@ -1415,7 +1404,7 @@ def _mla_decode_gluon(
 def _mla_softmax_reducev_kernel(
     Logits,
     Mid_lse,
-    O,  # noqa: E741
+    O,
     Final_lse,
     B_seq_len,
     stride_l_b: tl.constexpr,
@@ -1448,7 +1437,7 @@ def _mla_softmax_reducev_kernel(
     e_max = -float("inf")
     acc = tl.zeros([HEAD_DIM_CKV], dtype=tl.float32)
 
-    for split_kv_id in range(0, NUM_KV_SPLITS):
+    for split_kv_id in range(NUM_KV_SPLITS):
         split_valid = split_kv_id * pages_per_split < num_pages
         logits = tl.load(
             Logits + offs_l + split_kv_id * stride_l_s,
@@ -1485,15 +1474,17 @@ _WAVE_WORKGROUPS = 256
 
 _NUM_XCDS = 8
 
-_DEFAULT_SMALL_BATCH_LAUNCH = {
-    1: ("bh16-multiblock", 256),
-    2: ("bh64-small", 128),
-    4: ("bh64-small", 256),
+_DEFAULT_SMALL_BATCH_TARGET_WORKGROUPS = {
+    1: 256,
+    2: 128,
+    4: 256,
 }
 
-_SMALL_BATCH_POLICIES = frozenset({"bh64-small", "bh16-multiblock"})
+_SMALL_BATCH_REGIMES = frozenset({"bh16-multiblock", "bh64-small"})
 
-_SMALL_BATCH_TARGET_WORKGROUPS = frozenset({64, 128, 256, 512})
+_MLA_DECODE_REGIMES = frozenset(
+    {"bh16bn128", "bh16bn64", "bh64", "bh16-multiblock", "bh64-small"}
+)
 
 
 def _select_num_kv_splits_bh16bn64(
@@ -1563,29 +1554,17 @@ def _gluon_mla_decode_gfx950(
     qk_rope_head_dim: int,
     softmax_scale: float,
     *,
+    regime: str,
     logit_cap: float = 0.0,
     return_lse: bool = False,
     out: torch.Tensor | None = None,
-    _launch_policy: str | None = None,
-    _target_workgroups: int | None = None,
-    _num_kv_splits: int | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-    """Absorbed MLA decode over a paged compressed KV cache on gfx950.
-
-    ``q`` is ``[batch, 1, num_q_heads, kv_lora_rank + qk_rope_head_dim]`` and
-    ``kv_cache`` is ``[num_pages, page_size, 1, kv_lora_rank + qk_rope_head_dim]``
-    (first ``kv_lora_rank`` latent, last ``qk_rope_head_dim`` RoPE). Output is
-    BF16 with shape ``[batch, 1, num_q_heads, kv_lora_rank]``.
-
-    BF16 Q/KV selects ``bh16bn64`` (``num_q_heads <= 16``) or ``bh64``
-    (``num_q_heads in {64, 128}``). BF16 Q with FP8 KV selects AITER's
-    ``bh16bn128`` regime (``num_q_heads <= 16``). E4M3 Q with E4M3 KV selects
-    the native FP8 variant. Both FP8-KV variants support arbitrary batch sizes.
-    Batches divisible by 64 use the XCD-aware bh64 grid. H64 batches 1, 2, and
-    4 use a batch-major grid with a tunable private launch policy; the private
-    arguments support kernel qualification and are not exposed through the
-    public TokenSpeed kernel API.
-    """
+    """Launch one fixed absorbed MLA decode regime."""
+    if regime not in _MLA_DECODE_REGIMES:
+        raise ValueError(
+            f"unsupported MLA decode regime {regime!r}; "
+            f"expected one of {sorted(_MLA_DECODE_REGIMES)}"
+        )
     if logit_cap != 0.0:
         raise NotImplementedError("gluon_mla_decode_gfx950 does not support logit_cap")
     if q.dim() != 4 or q.shape[1] != 1:
@@ -1616,88 +1595,63 @@ def _gluon_mla_decode_gfx950(
     is_fp8_kv = kv_cache.dtype != torch.bfloat16
 
     batch_size, _, nhead, _ = q.shape
-    small_batch_h64 = nhead == 64 and batch_size in (1, 2, 4)
-    if small_batch_h64:
+    small_batch_h64 = regime in _SMALL_BATCH_REGIMES
+    if regime == "bh16bn128":
+        if not is_fp8_kv:
+            raise NotImplementedError(
+                "gluon MLA decode (bh16bn128) requires an FP8 kv_cache"
+            )
+        if not 1 <= nhead <= 16:
+            raise NotImplementedError(
+                "gluon MLA decode (bh16bn128) requires num_q_heads in [1, 16], "
+                f"got {nhead}"
+            )
+        block_h = 16
+        block_n = 128
+        num_xcds = 1
+    elif regime == "bh16bn64":
         if q.dtype != torch.bfloat16 or kv_cache.dtype != torch.bfloat16:
             raise NotImplementedError(
-                "gluon MLA small-batch H64 requires bf16 q and kv_cache"
+                "gluon MLA decode (bh16bn64) requires bf16 q and kv_cache"
             )
-        default_policy, default_target_workgroups = _DEFAULT_SMALL_BATCH_LAUNCH[
-            batch_size
-        ]
-        launch_policy = _launch_policy or default_policy
-        if launch_policy not in _SMALL_BATCH_POLICIES:
-            raise ValueError(
-                f"unsupported small-batch MLA launch policy {launch_policy!r}; "
-                f"expected one of {sorted(_SMALL_BATCH_POLICIES)}"
+        if not 1 <= nhead <= 16:
+            raise NotImplementedError(
+                "gluon MLA decode (bh16bn64) requires num_q_heads in [1, 16], "
+                f"got {nhead}"
             )
-        target_workgroups = (
-            _target_workgroups
-            if _target_workgroups is not None
-            else default_target_workgroups
-        )
-        if target_workgroups not in _SMALL_BATCH_TARGET_WORKGROUPS:
-            raise ValueError(
-                "small-batch MLA target workgroups must be one of "
-                f"{sorted(_SMALL_BATCH_TARGET_WORKGROUPS)}, got {target_workgroups}"
-            )
-        if _num_kv_splits is not None and _num_kv_splits <= 0:
-            raise ValueError(
-                f"small-batch MLA num KV splits must be positive, got {_num_kv_splits}"
-            )
-        if launch_policy == "bh64-small":
-            regime = "bh64"
-            block_h = 64
-        else:
-            regime = "bh16bn64"
-            block_h = 16
+        block_h = 16
         block_n = 64
-        grid_mode = "batch_head_split"
         num_xcds = 1
-    elif nhead in (64, 128):
+    elif regime == "bh64":
         if q.dtype != torch.bfloat16 or kv_cache.dtype != torch.bfloat16:
             raise NotImplementedError("gluon MLA bh64 requires bf16 q and kv_cache")
-        if (
-            _launch_policy is not None
-            or _target_workgroups is not None
-            or _num_kv_splits is not None
-        ):
-            raise ValueError(
-                "small-batch MLA launch overrides require H=64 and B in {1, 2, 4}"
+        if nhead not in (64, 128):
+            raise NotImplementedError(
+                "gluon MLA decode (bh64) requires num_q_heads in {64, 128}, "
+                f"got {nhead}"
             )
-        regime = "bh64"
         block_h = 64
         block_n = 64
-        grid_mode = "xcd"
         num_xcds = _NUM_XCDS
         if batch_size % 64 != 0:
             raise NotImplementedError(
                 "gluon MLA decode (bh64) is large-batch only and requires "
                 f"batch_size divisible by 64, got {batch_size}"
             )
-    elif 1 <= nhead <= 16:
-        if (
-            _launch_policy is not None
-            or _target_workgroups is not None
-            or _num_kv_splits is not None
-        ):
-            raise ValueError(
-                "small-batch MLA launch overrides require H=64 and B in {1, 2, 4}"
-            )
-        if is_fp8_kv:
-            regime = "bh16bn128"
-            block_n = 128
-        else:
-            regime = "bh16bn64"
-            block_n = 64
-        block_h = 16
-        grid_mode = "batch_split"
-        num_xcds = 1  # unused by the 2-D (batch, split) grid
     else:
-        raise NotImplementedError(
-            "gluon MLA decode supports num_q_heads in [1, 16] (bh16bn64) or "
-            f"{{64, 128}} (bh64), got {nhead}"
-        )
+        if q.dtype != torch.bfloat16 or kv_cache.dtype != torch.bfloat16:
+            raise NotImplementedError(
+                f"gluon MLA decode ({regime}) requires bf16 q and kv_cache"
+            )
+        if nhead != 64 or batch_size not in _DEFAULT_SMALL_BATCH_TARGET_WORKGROUPS:
+            raise NotImplementedError(
+                f"gluon MLA decode ({regime}) requires num_q_heads=64 and "
+                f"batch_size in {sorted(_DEFAULT_SMALL_BATCH_TARGET_WORKGROUPS)}, "
+                f"got H={nhead}, B={batch_size}"
+            )
+        block_h = 16 if regime == "bh16-multiblock" else 64
+        block_n = 64
+        num_xcds = 1
     if kv_cache.dim() == 4:
         if kv_cache.shape[2] != 1 or kv_cache.shape[3] != qk_dim:
             raise ValueError(
@@ -1743,17 +1697,13 @@ def _gluon_mla_decode_gfx950(
     within_2gb = max_kv_bytes <= 0x80000000
 
     if small_batch_h64:
-        num_kv_splits = (
-            _num_kv_splits
-            if _num_kv_splits is not None
-            else _select_num_kv_splits_small_batch(
-                batch=batch_size,
-                nhead=nhead,
-                block_h=block_h,
-                max_seqlen_k=max_seqlen_k,
-                block_n=64,
-                target_workgroups=target_workgroups,
-            )
+        num_kv_splits = _select_num_kv_splits_small_batch(
+            batch=batch_size,
+            nhead=nhead,
+            block_h=block_h,
+            max_seqlen_k=max_seqlen_k,
+            block_n=64,
+            target_workgroups=_DEFAULT_SMALL_BATCH_TARGET_WORKGROUPS[batch_size],
         )
     elif regime == "bh64":
         num_kv_splits = _select_num_kv_splits_bh64(
@@ -1776,34 +1726,33 @@ def _gluon_mla_decode_gfx950(
         )
 
     def _grid(splits: int) -> tuple[int, ...]:
-        if grid_mode == "xcd":
+        if regime == "bh64":
             # 3-D XCD-aware: (NUM_XCDS, head_block, (batch // NUM_XCDS) * splits).
             return (
                 num_xcds,
                 (nhead + block_h - 1) // block_h,
                 (batch_size // num_xcds) * splits,
             )
-        if grid_mode == "batch_split":
+        if regime == "bh16bn64" or regime == "bh16bn128":
             return (batch_size, splits)
         return (batch_size, (nhead + block_h - 1) // block_h, splits)
 
-    common_kwargs = dict(
-        BLOCK_H=block_h,
-        BLOCK_N=block_n,
-        NUM_KV_SPLITS=num_kv_splits,
-        PAGE_SIZE=page_size,
-        HEAD_DIM_CKV=kv_lora_rank,
-        HEAD_DIM_KPE=qk_rope_head_dim,
-        KV_PE_OFFSET=kv_lora_rank,
-        WITHIN_2GB=within_2gb,
-        NUM_XCDS=num_xcds,
-        NHEAD=nhead,
-        REGIME=regime,
-        IS_FP8_Q=is_fp8_q,
-        GRID_MODE=grid_mode,
-        RETURN_LSE=return_lse,
-        num_warps=4,
-    )
+    common_kwargs = {
+        "BLOCK_H": block_h,
+        "BLOCK_N": block_n,
+        "NUM_KV_SPLITS": num_kv_splits,
+        "PAGE_SIZE": page_size,
+        "HEAD_DIM_CKV": kv_lora_rank,
+        "HEAD_DIM_KPE": qk_rope_head_dim,
+        "KV_PE_OFFSET": kv_lora_rank,
+        "WITHIN_2GB": within_2gb,
+        "NUM_XCDS": num_xcds,
+        "NHEAD": nhead,
+        "REGIME": regime,
+        "IS_FP8_Q": is_fp8_q,
+        "RETURN_LSE": return_lse,
+        "num_warps": 4,
+    }
 
     if num_kv_splits == 1:
         # Fast path: the single split spans the whole sequence, so stage-1
@@ -1912,6 +1861,42 @@ def _gluon_mla_decode_gfx950(
     return out
 
 
+def gluon_mla_decode_bf16xbf16_gfx950_bh16bn64(*args, **kwargs):
+    """Run the fixed BLOCK_H=16, (batch, split) BF16 MLA decode regime."""
+    return _gluon_mla_decode_gfx950(
+        *args,
+        regime="bh16bn64",
+        **kwargs,
+    )
+
+
+def gluon_mla_decode_bf16xbf16_gfx950_bh64(*args, **kwargs):
+    """Run the fixed BLOCK_H=64, XCD-aware BF16 MLA decode regime."""
+    return _gluon_mla_decode_gfx950(
+        *args,
+        regime="bh64",
+        **kwargs,
+    )
+
+
+def gluon_mla_decode_bf16xbf16_gfx950_bh16_multiblock(*args, **kwargs):
+    """Run the fixed BLOCK_H=16 small-batch BF16 MLA decode regime."""
+    return _gluon_mla_decode_gfx950(
+        *args,
+        regime="bh16-multiblock",
+        **kwargs,
+    )
+
+
+def gluon_mla_decode_bf16xbf16_gfx950_bh64_small(*args, **kwargs):
+    """Run the fixed BLOCK_H=64 small-batch BF16 MLA decode regime."""
+    return _gluon_mla_decode_gfx950(
+        *args,
+        regime="bh64-small",
+        **kwargs,
+    )
+
+
 def gluon_mla_decode_bf16xbf16_gfx950(
     q: torch.Tensor,
     kv_cache: torch.Tensor,
@@ -1927,21 +1912,40 @@ def gluon_mla_decode_bf16xbf16_gfx950(
     return_lse: bool = False,
     out: torch.Tensor | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-    """Run the BF16-Q/BF16-KV GFX950 MLA decode regimes."""
+    """Dispatch BF16-Q/BF16-KV MLA decode to a fixed GFX950 regime."""
     if q.dtype != torch.bfloat16 or kv_cache.dtype != torch.bfloat16:
         raise NotImplementedError(
             "gluon_mla_decode_bf16xbf16_gfx950 requires bf16 q and kv_cache"
         )
-    return _gluon_mla_decode_gfx950(
-        q=q,
-        kv_cache=kv_cache,
-        page_table=page_table,
-        cache_seqlens=cache_seqlens,
-        max_seqlen_k=max_seqlen_k,
-        qk_nope_head_dim=qk_nope_head_dim,
-        kv_lora_rank=kv_lora_rank,
-        qk_rope_head_dim=qk_rope_head_dim,
-        softmax_scale=softmax_scale,
+    if q.dim() != 4 or q.shape[1] != 1:
+        raise ValueError(
+            f"q must be [batch, 1, num_q_heads, R + rope], got {tuple(q.shape)}"
+        )
+    batch_size, _, nhead, _ = q.shape
+    if 1 <= nhead <= 16:
+        impl = gluon_mla_decode_bf16xbf16_gfx950_bh16bn64
+    elif nhead == 64 and batch_size == 1:
+        impl = gluon_mla_decode_bf16xbf16_gfx950_bh16_multiblock
+    elif nhead == 64 and batch_size in (2, 4):
+        impl = gluon_mla_decode_bf16xbf16_gfx950_bh64_small
+    elif nhead in (64, 128) and batch_size % 64 == 0:
+        impl = gluon_mla_decode_bf16xbf16_gfx950_bh64
+    else:
+        raise NotImplementedError(
+            "gluon MLA decode supports H in [1, 16], H=64 with B in {1, 2, 4}, "
+            "or H in {64, 128} with B divisible by 64; "
+            f"got H={nhead}, B={batch_size}"
+        )
+    return impl(
+        q,
+        kv_cache,
+        page_table,
+        cache_seqlens,
+        max_seqlen_k,
+        qk_nope_head_dim,
+        kv_lora_rank,
+        qk_rope_head_dim,
+        softmax_scale,
         logit_cap=logit_cap,
         return_lse=return_lse,
         out=out,
@@ -1981,6 +1985,7 @@ def gluon_mla_decode_bf16xfp8_gfx950(
         kv_lora_rank=kv_lora_rank,
         qk_rope_head_dim=qk_rope_head_dim,
         softmax_scale=softmax_scale,
+        regime="bh16bn128",
         logit_cap=logit_cap,
         return_lse=return_lse,
         out=out,
@@ -2022,6 +2027,7 @@ def gluon_mla_decode_fp8xfp8_gfx950(
         kv_lora_rank=kv_lora_rank,
         qk_rope_head_dim=qk_rope_head_dim,
         softmax_scale=softmax_scale,
+        regime="bh16bn128",
         logit_cap=logit_cap,
         return_lse=return_lse,
         out=out,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/decode.py
@@ -34,6 +34,11 @@ The shared kernel supports three regimes:
   ``num_q_heads <= 16``.
 * ``bh64`` -- BLOCK_H=64, BLOCK_N=64, ``num_q_heads in {64, 128}``, 3-D
   XCD-aware grid, ``batch_size`` divisible by 64.
+
+For 64-head small batches, either compute regime can use a 3-D
+(batch, head-block, split) grid. The selected mapping is independent of the
+compute layouts so both variants can be benchmarked without duplicating the
+attention math.
 """
 
 from __future__ import annotations
@@ -62,6 +67,7 @@ class AttentionConfig:
     NHEAD: gl.constexpr
     REGIME: gl.constexpr
     IS_FP8_Q: gl.constexpr
+    GRID_MODE: gl.constexpr
     RETURN_LSE: gl.constexpr
     stride_q_nope_bs: gl.constexpr
     stride_q_nope_h: gl.constexpr
@@ -112,6 +118,7 @@ class AttentionConfig:
         NHEAD,
         REGIME,
         IS_FP8_Q,
+        GRID_MODE,
         RETURN_LSE,
         stride_q_nope_bs,
         stride_q_nope_h,
@@ -603,6 +610,7 @@ class AttentionConfig:
         self.NHEAD = gl.constexpr(NHEAD)
         self.REGIME = gl.constexpr(REGIME)
         self.IS_FP8_Q = gl.constexpr(IS_FP8_Q)
+        self.GRID_MODE = gl.constexpr(GRID_MODE)
         self.RETURN_LSE = gl.constexpr(RETURN_LSE)
         self.stride_q_nope_bs = gl.constexpr(stride_q_nope_bs)
         self.stride_q_nope_h = gl.constexpr(stride_q_nope_h)
@@ -713,21 +721,27 @@ class AttentionProgram:
         sm_scale,
         kv_scale,
     ):
-        # Grid mapping: bh64 uses a 3-D XCD-aware multi-batch grid
-        # (NUM_XCDS, head_block, (batch // NUM_XCDS) * NUM_KV_SPLITS); bh16bn64 uses
-        # a 2-D (batch, split) grid (for batch_size=1 this is (1, NUM_KV_SPLITS)).
-        if cfg.REGIME == "bh64":
+        # Grid modes are independent of compute layout. ``xcd`` distributes
+        # large bh64 batches across XCDs, ``batch_split`` maps bh16 work over
+        # (batch, split), and ``batch_head_split`` adds a head-block axis.
+        if cfg.GRID_MODE == "xcd":
             cur_batch = (
                 gl.program_id(0)
                 + (gl.program_id(2) // cfg.NUM_KV_SPLITS) * cfg.NUM_XCDS
             )
             cur_head_id = gl.program_id(1)
             split_kv_id = gl.program_id(2) % cfg.NUM_KV_SPLITS
-        else:
+        elif cfg.GRID_MODE == "batch_split":
             cur_batch = gl.program_id(0)
             split_kv_id = gl.program_id(1)
             # Head-block 0; use a runtime zero (aggregate fields hold tensors).
             cur_head_id = split_kv_id - split_kv_id
+        elif cfg.GRID_MODE == "batch_head_split":
+            cur_batch = gl.program_id(0)
+            cur_head_id = gl.program_id(1)
+            split_kv_id = gl.program_id(2)
+        else:
+            gl.static_assert(False, "unsupported MLA grid mode")
 
         # Paged 2-D view: Req_to_tokens = block_table[batch, max_pages],
         # B_seq_len = cache_seqlens[batch].
@@ -1059,6 +1073,7 @@ def _mla_decode_gluon(
     NHEAD: gl.constexpr,
     REGIME: gl.constexpr,
     IS_FP8_Q: gl.constexpr,
+    GRID_MODE: gl.constexpr,
     RETURN_LSE: gl.constexpr,
 ):
     cfg = AttentionConfig(
@@ -1074,6 +1089,7 @@ def _mla_decode_gluon(
         NHEAD,
         REGIME,
         IS_FP8_Q,
+        GRID_MODE,
         RETURN_LSE,
         stride_q_nope_bs,
         stride_q_nope_h,
@@ -1469,6 +1485,16 @@ _WAVE_WORKGROUPS = 256
 
 _NUM_XCDS = 8
 
+_DEFAULT_SMALL_BATCH_LAUNCH = {
+    1: ("bh16-multiblock", 256),
+    2: ("bh64-small", 128),
+    4: ("bh64-small", 256),
+}
+
+_SMALL_BATCH_POLICIES = frozenset({"bh64-small", "bh16-multiblock"})
+
+_SMALL_BATCH_TARGET_WORKGROUPS = frozenset({64, 128, 256, 512})
+
 
 def _select_num_kv_splits_bh16bn64(
     *, batch: int, max_seqlen_k: int, block_n: int
@@ -1510,6 +1536,22 @@ def _select_num_kv_splits_bh64(
     return max(1, triton.next_power_of_2(triton.cdiv(_WAVE_WORKGROUPS, base_grid)))
 
 
+def _select_num_kv_splits_small_batch(
+    *,
+    batch: int,
+    nhead: int,
+    block_h: int,
+    max_seqlen_k: int,
+    block_n: int,
+    target_workgroups: int,
+) -> int:
+    head_blocks = (nhead + block_h - 1) // block_h
+    base_grid = batch * head_blocks
+    occupancy_splits = (target_workgroups + base_grid - 1) // base_grid
+    blocks = (max_seqlen_k + block_n - 1) // block_n
+    return max(1, min(occupancy_splits, blocks))
+
+
 def _gluon_mla_decode_gfx950(
     q: torch.Tensor,
     kv_cache: torch.Tensor,
@@ -1524,6 +1566,9 @@ def _gluon_mla_decode_gfx950(
     logit_cap: float = 0.0,
     return_lse: bool = False,
     out: torch.Tensor | None = None,
+    _launch_policy: str | None = None,
+    _target_workgroups: int | None = None,
+    _num_kv_splits: int | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """Absorbed MLA decode over a paged compressed KV cache on gfx950.
 
@@ -1536,6 +1581,10 @@ def _gluon_mla_decode_gfx950(
     (``num_q_heads in {64, 128}``). BF16 Q with FP8 KV selects AITER's
     ``bh16bn128`` regime (``num_q_heads <= 16``). E4M3 Q with E4M3 KV selects
     the native FP8 variant. Both FP8-KV variants support arbitrary batch sizes.
+    Batches divisible by 64 use the XCD-aware bh64 grid. H64 batches 1, 2, and
+    4 use a batch-major grid with a tunable private launch policy; the private
+    arguments support kernel qualification and are not exposed through the
+    public TokenSpeed kernel API.
     """
     if logit_cap != 0.0:
         raise NotImplementedError("gluon_mla_decode_gfx950 does not support logit_cap")
@@ -1567,12 +1616,59 @@ def _gluon_mla_decode_gfx950(
     is_fp8_kv = kv_cache.dtype != torch.bfloat16
 
     batch_size, _, nhead, _ = q.shape
-    if nhead in (64, 128):
-        if kv_cache.dtype != torch.bfloat16:
+    small_batch_h64 = nhead == 64 and batch_size in (1, 2, 4)
+    if small_batch_h64:
+        if q.dtype != torch.bfloat16 or kv_cache.dtype != torch.bfloat16:
+            raise NotImplementedError(
+                "gluon MLA small-batch H64 requires bf16 q and kv_cache"
+            )
+        default_policy, default_target_workgroups = _DEFAULT_SMALL_BATCH_LAUNCH[
+            batch_size
+        ]
+        launch_policy = _launch_policy or default_policy
+        if launch_policy not in _SMALL_BATCH_POLICIES:
+            raise ValueError(
+                f"unsupported small-batch MLA launch policy {launch_policy!r}; "
+                f"expected one of {sorted(_SMALL_BATCH_POLICIES)}"
+            )
+        target_workgroups = (
+            _target_workgroups
+            if _target_workgroups is not None
+            else default_target_workgroups
+        )
+        if target_workgroups not in _SMALL_BATCH_TARGET_WORKGROUPS:
+            raise ValueError(
+                "small-batch MLA target workgroups must be one of "
+                f"{sorted(_SMALL_BATCH_TARGET_WORKGROUPS)}, got {target_workgroups}"
+            )
+        if _num_kv_splits is not None and _num_kv_splits <= 0:
+            raise ValueError(
+                f"small-batch MLA num KV splits must be positive, got {_num_kv_splits}"
+            )
+        if launch_policy == "bh64-small":
+            regime = "bh64"
+            block_h = 64
+        else:
+            regime = "bh16bn64"
+            block_h = 16
+        block_n = 64
+        grid_mode = "batch_head_split"
+        num_xcds = 1
+    elif nhead in (64, 128):
+        if q.dtype != torch.bfloat16 or kv_cache.dtype != torch.bfloat16:
             raise NotImplementedError("gluon MLA bh64 requires bf16 q and kv_cache")
+        if (
+            _launch_policy is not None
+            or _target_workgroups is not None
+            or _num_kv_splits is not None
+        ):
+            raise ValueError(
+                "small-batch MLA launch overrides require H=64 and B in {1, 2, 4}"
+            )
         regime = "bh64"
         block_h = 64
         block_n = 64
+        grid_mode = "xcd"
         num_xcds = _NUM_XCDS
         if batch_size % 64 != 0:
             raise NotImplementedError(
@@ -1580,6 +1676,14 @@ def _gluon_mla_decode_gfx950(
                 f"batch_size divisible by 64, got {batch_size}"
             )
     elif 1 <= nhead <= 16:
+        if (
+            _launch_policy is not None
+            or _target_workgroups is not None
+            or _num_kv_splits is not None
+        ):
+            raise ValueError(
+                "small-batch MLA launch overrides require H=64 and B in {1, 2, 4}"
+            )
         if is_fp8_kv:
             regime = "bh16bn128"
             block_n = 128
@@ -1587,6 +1691,7 @@ def _gluon_mla_decode_gfx950(
             regime = "bh16bn64"
             block_n = 64
         block_h = 16
+        grid_mode = "batch_split"
         num_xcds = 1  # unused by the 2-D (batch, split) grid
     else:
         raise NotImplementedError(
@@ -1637,7 +1742,20 @@ def _gluon_mla_decode_gfx950(
     max_kv_bytes = kv_c.shape[0] * kv_c.stride(0) * kv_c.element_size()
     within_2gb = max_kv_bytes <= 0x80000000
 
-    if regime == "bh64":
+    if small_batch_h64:
+        num_kv_splits = (
+            _num_kv_splits
+            if _num_kv_splits is not None
+            else _select_num_kv_splits_small_batch(
+                batch=batch_size,
+                nhead=nhead,
+                block_h=block_h,
+                max_seqlen_k=max_seqlen_k,
+                block_n=64,
+                target_workgroups=target_workgroups,
+            )
+        )
+    elif regime == "bh64":
         num_kv_splits = _select_num_kv_splits_bh64(
             batch=batch_size, nhead=nhead, num_xcds=num_xcds, block_h=block_h
         )
@@ -1658,14 +1776,16 @@ def _gluon_mla_decode_gfx950(
         )
 
     def _grid(splits: int) -> tuple[int, ...]:
-        if regime == "bh64":
+        if grid_mode == "xcd":
             # 3-D XCD-aware: (NUM_XCDS, head_block, (batch // NUM_XCDS) * splits).
             return (
                 num_xcds,
                 (nhead + block_h - 1) // block_h,
                 (batch_size // num_xcds) * splits,
             )
-        return (batch_size, splits)
+        if grid_mode == "batch_split":
+            return (batch_size, splits)
+        return (batch_size, (nhead + block_h - 1) // block_h, splits)
 
     common_kwargs = dict(
         BLOCK_H=block_h,
@@ -1680,6 +1800,7 @@ def _gluon_mla_decode_gfx950(
         NHEAD=nhead,
         REGIME=regime,
         IS_FP8_Q=is_fp8_q,
+        GRID_MODE=grid_mode,
         RETURN_LSE=return_lse,
         num_warps=4,
     )

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/decode.py
@@ -34,8 +34,10 @@ The shared kernel supports five fixed regimes:
   ``num_q_heads <= 16``.
 * ``bh64`` -- BLOCK_H=64, BLOCK_N=64, ``num_q_heads in {64, 128}``, 3-D
   XCD-aware grid, ``batch_size`` divisible by 64.
-* ``bh16-multiblock`` -- BF16 Q/KV, BLOCK_H=16, 64 heads, small-batch 3-D grid.
-* ``bh64-small`` -- BF16 Q/KV, BLOCK_H=64, 64 heads, small-batch 3-D grid.
+* ``bh16-multiblock`` -- BF16 Q/KV, BLOCK_H=16,
+  ``num_q_heads == 64``, ``batch_size == 1``, 3-D grid.
+* ``bh64-small`` -- BF16 Q/KV, BLOCK_H=64,
+  ``num_q_heads == 64``, ``batch_size in {2, 4}``, 3-D grid.
 """
 
 from __future__ import annotations

--- a/tokenspeed-kernel-amd/test/ops/attention/test_mla_launch_tuning.py
+++ b/tokenspeed-kernel-amd/test/ops/attention/test_mla_launch_tuning.py
@@ -22,18 +22,19 @@
 from __future__ import annotations
 
 import pytest
+import torch
 
 mla_decode = pytest.importorskip(
-    "tokenspeed_kernel_amd.ops.attention.gluon.mla_decode_gfx950",
+    "tokenspeed_kernel_amd.ops.gfx950.attention.mla.decode",
     reason="tokenspeed-kernel-amd is required for MLA launch tuning tests",
 )
 
 
-def test_small_batch_launch_defaults_match_measured_winners() -> None:
-    assert mla_decode._DEFAULT_SMALL_BATCH_LAUNCH == {
-        1: ("bh16-multiblock", 256),
-        2: ("bh64-small", 128),
-        4: ("bh64-small", 256),
+def test_small_batch_target_workgroup_defaults_match_measured_winners() -> None:
+    assert mla_decode._DEFAULT_SMALL_BATCH_TARGET_WORKGROUPS == {
+        1: 256,
+        2: 128,
+        4: 256,
     }
 
 
@@ -90,3 +91,59 @@ def test_small_batch_split_selection_caps_at_available_kv_blocks() -> None:
         )
         == 2
     )
+
+
+@pytest.mark.parametrize(
+    "entrypoint,batch,num_heads",
+    [
+        pytest.param(
+            "gluon_mla_decode_bf16xbf16_gfx950_bh16_multiblock",
+            1,
+            16,
+            id="bh16-multiblock-invalid-heads",
+        ),
+        pytest.param(
+            "gluon_mla_decode_bf16xbf16_gfx950_bh16_multiblock",
+            3,
+            64,
+            id="bh16-multiblock-invalid-batch",
+        ),
+        pytest.param(
+            "gluon_mla_decode_bf16xbf16_gfx950_bh64_small",
+            1,
+            16,
+            id="bh64-small-invalid-heads",
+        ),
+        pytest.param(
+            "gluon_mla_decode_bf16xbf16_gfx950_bh64_small",
+            3,
+            64,
+            id="bh64-small-invalid-batch",
+        ),
+    ],
+)
+def test_small_batch_fixed_entrypoints_reject_unsupported_shapes(
+    entrypoint: str,
+    batch: int,
+    num_heads: int,
+) -> None:
+    q = torch.empty((batch, 1, num_heads, 576), dtype=torch.bfloat16)
+    kv_cache = torch.empty((batch, 64, 1, 576), dtype=torch.bfloat16)
+    page_table = torch.arange(batch, dtype=torch.int32).view(batch, 1)
+    cache_seqlens = torch.full((batch,), 64, dtype=torch.int32)
+
+    with pytest.raises(
+        NotImplementedError,
+        match="requires num_q_heads=64 and batch_size",
+    ):
+        getattr(mla_decode, entrypoint)(
+            q=q,
+            kv_cache=kv_cache,
+            page_table=page_table,
+            cache_seqlens=cache_seqlens,
+            max_seqlen_k=64,
+            qk_nope_head_dim=128,
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            softmax_scale=1.0,
+        )

--- a/tokenspeed-kernel-amd/test/ops/test_gluon_mla_decode_launch_tuning.py
+++ b/tokenspeed-kernel-amd/test/ops/test_gluon_mla_decode_launch_tuning.py
@@ -22,9 +22,6 @@
 from __future__ import annotations
 
 import pytest
-from tokenspeed_kernel.ops.attention import gluon as _gluon_registrations  # noqa: F401
-from tokenspeed_kernel.registry import KernelRegistry
-from tokenspeed_kernel.selection import spec_matches_traits
 
 mla_decode = pytest.importorskip(
     "tokenspeed_kernel_amd.ops.attention.gluon.mla_decode_gfx950",
@@ -93,37 +90,3 @@ def test_small_batch_split_selection_caps_at_available_kv_blocks() -> None:
         )
         == 2
     )
-
-
-@pytest.mark.parametrize(
-    "batch,expected",
-    [
-        pytest.param(1, True, id="b1"),
-        pytest.param(2, True, id="b2"),
-        pytest.param(3, False, id="b3"),
-        pytest.param(4, True, id="b4"),
-        pytest.param(64, False, id="b64"),
-    ],
-)
-def test_small_batch_registration_matches_only_supported_batches(
-    batch: int,
-    expected: bool,
-) -> None:
-    spec = KernelRegistry.get().get_by_name(
-        "gluon_mla_decode_bf16xbf16_gfx950_h64_small_batch"
-    )
-    if spec is None:
-        pytest.skip("gfx950 Gluon MLA registrations are unavailable")
-
-    traits = {
-        "batch_size": batch,
-        "batch_size_div_64": batch % 64 == 0,
-        "q_len": 1,
-        "num_q_heads": 64,
-        "page_size": 64,
-        "kv_lora_rank": 512,
-        "qk_rope_head_dim": 64,
-        "support_logit_cap": False,
-        "return_lse": False,
-    }
-    assert spec_matches_traits(spec, traits) is expected

--- a/tokenspeed-kernel-amd/test/ops/test_gluon_mla_decode_launch_tuning.py
+++ b/tokenspeed-kernel-amd/test/ops/test_gluon_mla_decode_launch_tuning.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Launch-tuning tests for the GFX950 Gluon MLA decode kernel."""
+
+from __future__ import annotations
+
+import pytest
+from tokenspeed_kernel.ops.attention import gluon as _gluon_registrations  # noqa: F401
+from tokenspeed_kernel.registry import KernelRegistry
+from tokenspeed_kernel.selection import spec_matches_traits
+
+mla_decode = pytest.importorskip(
+    "tokenspeed_kernel_amd.ops.attention.gluon.mla_decode_gfx950",
+    reason="tokenspeed-kernel-amd is required for MLA launch tuning tests",
+)
+
+
+def test_small_batch_launch_defaults_match_measured_winners() -> None:
+    assert mla_decode._DEFAULT_SMALL_BATCH_LAUNCH == {
+        1: ("bh16-multiblock", 256),
+        2: ("bh64-small", 128),
+        4: ("bh64-small", 256),
+    }
+
+
+@pytest.mark.parametrize(
+    "batch,block_h,target_workgroups,expected_splits",
+    [
+        pytest.param(1, 16, 256, 64, id="bh16-b1-w256"),
+        pytest.param(2, 64, 64, 32, id="bh64-b2-w64"),
+        pytest.param(2, 64, 128, 64, id="bh64-b2-w128"),
+        pytest.param(2, 64, 256, 128, id="bh64-b2-w256"),
+        pytest.param(2, 64, 512, 256, id="bh64-b2-w512"),
+        pytest.param(4, 64, 64, 16, id="bh64-b4-w64"),
+        pytest.param(4, 64, 128, 32, id="bh64-b4-w128"),
+        pytest.param(4, 64, 256, 64, id="bh64-b4-w256"),
+        pytest.param(4, 64, 512, 128, id="bh64-b4-w512"),
+        pytest.param(2, 16, 64, 8, id="bh16-b2-w64"),
+        pytest.param(2, 16, 128, 16, id="bh16-b2-w128"),
+        pytest.param(2, 16, 256, 32, id="bh16-b2-w256"),
+        pytest.param(2, 16, 512, 64, id="bh16-b2-w512"),
+        pytest.param(4, 16, 64, 4, id="bh16-b4-w64"),
+        pytest.param(4, 16, 128, 8, id="bh16-b4-w128"),
+        pytest.param(4, 16, 256, 16, id="bh16-b4-w256"),
+        pytest.param(4, 16, 512, 32, id="bh16-b4-w512"),
+    ],
+)
+def test_small_batch_split_selection_hits_target_workgroups(
+    batch: int,
+    block_h: int,
+    target_workgroups: int,
+    expected_splits: int,
+) -> None:
+    assert (
+        mla_decode._select_num_kv_splits_small_batch(
+            batch=batch,
+            nhead=64,
+            block_h=block_h,
+            max_seqlen_k=80_000,
+            block_n=64,
+            target_workgroups=target_workgroups,
+        )
+        == expected_splits
+    )
+
+
+def test_small_batch_split_selection_caps_at_available_kv_blocks() -> None:
+    assert (
+        mla_decode._select_num_kv_splits_small_batch(
+            batch=2,
+            nhead=64,
+            block_h=64,
+            max_seqlen_k=65,
+            block_n=64,
+            target_workgroups=512,
+        )
+        == 2
+    )
+
+
+@pytest.mark.parametrize(
+    "batch,expected",
+    [
+        pytest.param(1, True, id="b1"),
+        pytest.param(2, True, id="b2"),
+        pytest.param(3, False, id="b3"),
+        pytest.param(4, True, id="b4"),
+        pytest.param(64, False, id="b64"),
+    ],
+)
+def test_small_batch_registration_matches_only_supported_batches(
+    batch: int,
+    expected: bool,
+) -> None:
+    spec = KernelRegistry.get().get_by_name(
+        "gluon_mla_decode_bf16xbf16_gfx950_h64_small_batch"
+    )
+    if spec is None:
+        pytest.skip("gfx950 Gluon MLA registrations are unavailable")
+
+    traits = {
+        "batch_size": batch,
+        "batch_size_div_64": batch % 64 == 0,
+        "q_len": 1,
+        "num_q_heads": 64,
+        "page_size": 64,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 64,
+        "support_logit_cap": False,
+        "return_lse": False,
+    }
+    assert spec_matches_traits(spec, traits) is expected

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
@@ -64,7 +64,16 @@ if current_platform().is_amd:
         gluon_mha_prefill_gfx950 as _prefill_impl,
     )
     from tokenspeed_kernel_amd.ops.gfx950.attention.mla.decode import (
-        gluon_mla_decode_bf16xbf16_gfx950 as _mla_decode_bf16xbf16_impl,
+        gluon_mla_decode_bf16xbf16_gfx950_bh16_multiblock as _mla_decode_bf16xbf16_bh16_multiblock_impl,
+    )
+    from tokenspeed_kernel_amd.ops.gfx950.attention.mla.decode import (
+        gluon_mla_decode_bf16xbf16_gfx950_bh16bn64 as _mla_decode_bf16xbf16_bh16bn64_impl,
+    )
+    from tokenspeed_kernel_amd.ops.gfx950.attention.mla.decode import (
+        gluon_mla_decode_bf16xbf16_gfx950_bh64 as _mla_decode_bf16xbf16_bh64_impl,
+    )
+    from tokenspeed_kernel_amd.ops.gfx950.attention.mla.decode import (
+        gluon_mla_decode_bf16xbf16_gfx950_bh64_small as _mla_decode_bf16xbf16_bh64_small_impl,
     )
     from tokenspeed_kernel_amd.ops.gfx950.attention.mla.decode import (
         gluon_mla_decode_bf16xfp8_gfx950 as _mla_decode_bf16xfp8_impl,
@@ -314,12 +323,12 @@ if current_platform().is_amd:
         },
     )
     def gluon_mla_decode_bf16xbf16_gfx950_bh16bn64(*args, **kwargs):
-        return _mla_decode_bf16xbf16_impl(*args, **kwargs)
+        return _mla_decode_bf16xbf16_bh16bn64_impl(*args, **kwargs)
 
     @register_kernel(
         "attention",
         "mla_decode_with_kvcache",
-        name="gluon_mla_decode_bf16xbf16_gfx950_h64_small_batch",
+        name="gluon_mla_decode_bf16xbf16_gfx950_bh16_multiblock",
         solution="gluon",
         capability=CapabilityRequirement(
             min_arch_version=ArchVersion(9, 5),
@@ -333,7 +342,7 @@ if current_platform().is_amd:
         ),
         priority=Priority.SPECIALIZED,
         traits={
-            "batch_size": frozenset({1, 2, 4}),
+            "batch_size": frozenset({1}),
             "q_len": frozenset({1}),
             "num_q_heads": frozenset({64}),
             "batch_size_div_64": frozenset({False}),
@@ -344,8 +353,39 @@ if current_platform().is_amd:
             "return_lse": frozenset({False, True}),
         },
     )
-    def gluon_mla_decode_bf16xbf16_gfx950_h64_small_batch(*args, **kwargs):
-        return _mla_decode_bf16xbf16_impl(*args, **kwargs)
+    def gluon_mla_decode_bf16xbf16_gfx950_bh16_multiblock(*args, **kwargs):
+        return _mla_decode_bf16xbf16_bh16_multiblock_impl(*args, **kwargs)
+
+    @register_kernel(
+        "attention",
+        "mla_decode_with_kvcache",
+        name="gluon_mla_decode_bf16xbf16_gfx950_bh64_small",
+        solution="gluon",
+        capability=CapabilityRequirement(
+            min_arch_version=ArchVersion(9, 5),
+            max_arch_version=ArchVersion(9, 5),
+            vendors=frozenset({"amd"}),
+        ),
+        signatures=format_signatures(
+            ("q", "kv_cache"),
+            "dense",
+            {torch.bfloat16},
+        ),
+        priority=Priority.SPECIALIZED,
+        traits={
+            "batch_size": frozenset({2, 4}),
+            "q_len": frozenset({1}),
+            "num_q_heads": frozenset({64}),
+            "batch_size_div_64": frozenset({False}),
+            "page_size": frozenset({64}),
+            "kv_lora_rank": frozenset({512}),
+            "qk_rope_head_dim": frozenset({64}),
+            "support_logit_cap": frozenset({False}),
+            "return_lse": frozenset({False, True}),
+        },
+    )
+    def gluon_mla_decode_bf16xbf16_gfx950_bh64_small(*args, **kwargs):
+        return _mla_decode_bf16xbf16_bh64_small_impl(*args, **kwargs)
 
     @register_kernel(
         "attention",
@@ -441,7 +481,7 @@ if current_platform().is_amd:
         },
     )
     def gluon_mla_decode_bf16xbf16_gfx950_bh64(*args, **kwargs):
-        return _mla_decode_bf16xbf16_impl(*args, **kwargs)
+        return _mla_decode_bf16xbf16_bh64_impl(*args, **kwargs)
 
     @register_kernel(
         "attention",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
@@ -319,6 +319,37 @@ if current_platform().is_amd:
     @register_kernel(
         "attention",
         "mla_decode_with_kvcache",
+        name="gluon_mla_decode_bf16xbf16_gfx950_h64_small_batch",
+        solution="gluon",
+        capability=CapabilityRequirement(
+            min_arch_version=ArchVersion(9, 5),
+            max_arch_version=ArchVersion(9, 5),
+            vendors=frozenset({"amd"}),
+        ),
+        signatures=format_signatures(
+            ("q", "kv_cache"),
+            "dense",
+            {torch.bfloat16},
+        ),
+        priority=Priority.SPECIALIZED,
+        traits={
+            "batch_size": frozenset({1, 2, 4}),
+            "q_len": frozenset({1}),
+            "num_q_heads": frozenset({64}),
+            "batch_size_div_64": frozenset({False}),
+            "page_size": frozenset({64}),
+            "kv_lora_rank": frozenset({512}),
+            "qk_rope_head_dim": frozenset({64}),
+            "support_logit_cap": frozenset({False}),
+            "return_lse": frozenset({False, True}),
+        },
+    )
+    def gluon_mla_decode_bf16xbf16_gfx950_h64_small_batch(*args, **kwargs):
+        return _mla_decode_bf16xbf16_impl(*args, **kwargs)
+
+    @register_kernel(
+        "attention",
+        "mla_decode_with_kvcache",
         name="gluon_mla_decode_bf16xfp8_gfx950_bh16bn128",
         solution="gluon",
         capability=CapabilityRequirement(

--- a/tokenspeed-kernel/test/ops/test_attention_mla.py
+++ b/tokenspeed-kernel/test/ops/test_attention_mla.py
@@ -245,6 +245,39 @@ def test_mla_prefill(
             64,
             id="gluon-bh64",
         ),
+        pytest.param(
+            "gluon",
+            torch.bfloat16,
+            torch.bfloat16,
+            64,
+            512,
+            64,
+            1,
+            64,
+            id="gluon-h64-small-b1",
+        ),
+        pytest.param(
+            "gluon",
+            torch.bfloat16,
+            torch.bfloat16,
+            64,
+            512,
+            64,
+            2,
+            64,
+            id="gluon-h64-small-b2",
+        ),
+        pytest.param(
+            "gluon",
+            torch.bfloat16,
+            torch.bfloat16,
+            64,
+            512,
+            64,
+            4,
+            64,
+            id="gluon-h64-small-b4",
+        ),
     ],
 )
 def test_mla_decode_with_kvcache(
@@ -278,6 +311,14 @@ def test_mla_decode_with_kvcache(
         # selects 256 split-K workgroups and exercises the empty-split
         # sanitization used by production long-context decode.
         max_seqlen_k = 300_000
+    elif (
+        solution == "gluon"
+        and q_dtype == torch.bfloat16
+        and kv_dtype == torch.bfloat16
+        and num_heads == 64
+        and batch_size in (1, 2, 4)
+    ):
+        max_seqlen_k = 80_000
     max_pages = (visible_max_seqlen_k + page_size - 1) // page_size
     num_pages = batch_size * max_pages
 

--- a/tokenspeed-kernel/test/ops/test_attention_mla.py
+++ b/tokenspeed-kernel/test/ops/test_attention_mla.py
@@ -469,3 +469,259 @@ def test_mla_extend_with_kvcache_bf16(device: str, require) -> None:
         q_start += q_len
 
     torch.testing.assert_close(out.float(), torch.stack(refs), rtol=8e-2, atol=8e-2)
+
+
+def _run_fixed_bf16_mla_decode_case(
+    *,
+    device: str,
+    override: str,
+    cache_seqlens_list: list[int],
+    return_lse: bool,
+    comparison_override: str | None = None,
+    use_out: bool = False,
+) -> None:
+    batch_size = len(cache_seqlens_list)
+    num_heads = 64
+    page_size = 64
+    max_seqlen_k = 80_000
+    kv_lora_rank = 512
+    qk_rope_head_dim = 64
+    qk_nope_head_dim = 128
+    qk_head_dim = kv_lora_rank + qk_rope_head_dim
+    live_max_seqlen_k = max(cache_seqlens_list)
+    live_max_pages = (live_max_seqlen_k + page_size - 1) // page_size
+
+    q = torch.randn(
+        batch_size,
+        1,
+        num_heads,
+        qk_head_dim,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    kv_cache = torch.randn(
+        batch_size * live_max_pages,
+        page_size,
+        1,
+        qk_head_dim,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    cache_seqlens = torch.tensor(
+        cache_seqlens_list,
+        device=device,
+        dtype=torch.int32,
+    )
+    page_table = torch.zeros(
+        batch_size,
+        (max_seqlen_k + page_size - 1) // page_size,
+        device=device,
+        dtype=torch.int32,
+    )
+    for batch_idx, seqlen in enumerate(cache_seqlens_list):
+        page_count = (seqlen + page_size - 1) // page_size
+        page_start = batch_idx * live_max_pages
+        page_table[batch_idx, :page_count] = torch.arange(
+            page_start,
+            page_start + page_count,
+            device=device,
+            dtype=torch.int32,
+        )
+    softmax_scale = 1.0 / math.sqrt(qk_nope_head_dim + qk_rope_head_dim)
+    out_buffer = None
+    if use_out:
+        out_buffer = torch.full(
+            (batch_size, 1, num_heads, kv_lora_rank),
+            float("nan"),
+            device=device,
+            dtype=torch.bfloat16,
+        )
+
+    result = mla_decode_with_kvcache(
+        q=q,
+        kv_cache=kv_cache,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        max_seqlen_k=max_seqlen_k,
+        qk_nope_head_dim=qk_nope_head_dim,
+        kv_lora_rank=kv_lora_rank,
+        qk_rope_head_dim=qk_rope_head_dim,
+        softmax_scale=softmax_scale,
+        return_lse=return_lse,
+        out=out_buffer,
+        override=override,
+    )
+    if return_lse:
+        out, lse = result
+    else:
+        assert isinstance(result, torch.Tensor)
+        out = result
+        lse = None
+    if out_buffer is not None:
+        assert out is out_buffer
+
+    if comparison_override is not None:
+        comparison = mla_decode_with_kvcache(
+            q=q,
+            kv_cache=kv_cache,
+            page_table=page_table,
+            cache_seqlens=cache_seqlens,
+            max_seqlen_k=max_seqlen_k,
+            qk_nope_head_dim=qk_nope_head_dim,
+            kv_lora_rank=kv_lora_rank,
+            qk_rope_head_dim=qk_rope_head_dim,
+            softmax_scale=softmax_scale,
+            return_lse=return_lse,
+            override=comparison_override,
+        )
+        if return_lse:
+            comparison_out, comparison_lse = comparison
+        else:
+            assert isinstance(comparison, torch.Tensor)
+            comparison_out = comparison
+            comparison_lse = None
+        torch.testing.assert_close(
+            comparison_out.float(),
+            out.float(),
+            rtol=2e-2,
+            atol=2e-2,
+        )
+        if return_lse:
+            assert lse is not None
+            assert comparison_lse is not None
+            torch.testing.assert_close(
+                comparison_lse,
+                lse,
+                rtol=2e-2,
+                atol=2e-2,
+            )
+
+    refs = []
+    ref_lses = []
+    for batch_idx in range(batch_size):
+        kv_rows = []
+        for pos in range(int(cache_seqlens[batch_idx].item())):
+            page = page_table[batch_idx, pos // page_size]
+            kv_rows.append(kv_cache[page, pos % page_size, 0])
+        kv = torch.stack(kv_rows).float()
+        scores = torch.einsum("hd,kd->hk", q[batch_idx, 0].float(), kv)
+        scores = scores * softmax_scale
+        probs = torch.softmax(scores, dim=-1)
+        refs.append(torch.matmul(probs, kv[:, :kv_lora_rank]).unsqueeze(0))
+        ref_lses.append(torch.logsumexp(scores, dim=-1).unsqueeze(0))
+    out_ref = torch.stack(refs, dim=0)
+
+    assert out.shape == (batch_size, 1, num_heads, kv_lora_rank)
+    torch.testing.assert_close(out.float(), out_ref, rtol=8e-2, atol=8e-2)
+    if return_lse:
+        assert lse is not None
+        lse_ref = torch.stack(ref_lses, dim=0)
+        assert lse.shape == (batch_size, 1, num_heads)
+        torch.testing.assert_close(lse, lse_ref, rtol=8e-2, atol=8e-2)
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        pytest.param(
+            "gluon_mla_decode_bf16xbf16_gfx950_bh16_multiblock",
+            id="bh16-multiblock",
+        ),
+        pytest.param(
+            "gluon_mla_decode_bf16xbf16_gfx950_bh64_small",
+            id="bh64-small",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "cache_seqlens_list",
+    [
+        pytest.param([64], id="b1"),
+        pytest.param([63, 65], id="b2"),
+        pytest.param([1, 64, 65, 129], id="b4"),
+    ],
+)
+@pytest.mark.parametrize("return_lse", [False, True], ids=["output", "lse"])
+def test_mla_decode_small_batch_fixed_entrypoints_match_reference(
+    device: str,
+    override: str,
+    cache_seqlens_list: list[int],
+    return_lse: bool,
+    require,
+) -> None:
+    require(
+        "attention",
+        "mla_decode_with_kvcache",
+        "gluon",
+        torch.bfloat16,
+        "q",
+    )
+    _run_fixed_bf16_mla_decode_case(
+        device=device,
+        override=override,
+        cache_seqlens_list=cache_seqlens_list,
+        return_lse=return_lse,
+    )
+
+
+@pytest.mark.parametrize(
+    "cache_seqlens_list",
+    [
+        pytest.param([64], id="b1"),
+        pytest.param([63, 65], id="b2"),
+        pytest.param([1, 64, 65, 129], id="b4"),
+    ],
+)
+def test_mla_decode_small_batch_fixed_entrypoints_match_each_other(
+    device: str,
+    cache_seqlens_list: list[int],
+    require,
+) -> None:
+    require(
+        "attention",
+        "mla_decode_with_kvcache",
+        "gluon",
+        torch.bfloat16,
+        "q",
+    )
+    _run_fixed_bf16_mla_decode_case(
+        device=device,
+        override="gluon_mla_decode_bf16xbf16_gfx950_bh16_multiblock",
+        comparison_override="gluon_mla_decode_bf16xbf16_gfx950_bh64_small",
+        cache_seqlens_list=cache_seqlens_list,
+        return_lse=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        pytest.param(
+            "gluon_mla_decode_bf16xbf16_gfx950_bh16_multiblock",
+            id="bh16-multiblock",
+        ),
+        pytest.param(
+            "gluon_mla_decode_bf16xbf16_gfx950_bh64_small",
+            id="bh64-small",
+        ),
+    ],
+)
+def test_mla_decode_small_batch_fixed_entrypoints_use_out(
+    device: str,
+    override: str,
+    require,
+) -> None:
+    require(
+        "attention",
+        "mla_decode_with_kvcache",
+        "gluon",
+        torch.bfloat16,
+        "q",
+    )
+    _run_fixed_bf16_mla_decode_case(
+        device=device,
+        override=override,
+        cache_seqlens_list=[63, 65],
+        return_lse=True,
+        use_out=True,
+    )

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -106,7 +106,7 @@ from tokenspeed_kernel.ops.moe.triton import fp8 as _moe_triton_fp8
 from tokenspeed_kernel.ops.moe.triton import mxfp4 as _moe_triton_mxfp4
 from tokenspeed_kernel.platform import ArchVersion, Platform, PlatformInfo
 from tokenspeed_kernel.registry import KernelRegistry
-from tokenspeed_kernel.selection import SelectedKernel
+from tokenspeed_kernel.selection import SelectedKernel, spec_matches_traits
 
 _RELOAD_MODULES = [
     # Attention registration modules.
@@ -2772,6 +2772,30 @@ def test_attn_merge_state_routes_to_triton_on_cdna4(
     finally:
         Platform.override(real_platform)
         registry.clear_cache()
+
+
+@pytest.mark.parametrize("batch", [1, 2, 3, 4, 64])
+def test_gluon_mla_h64_small_batch_registration_matches_supported_batches(
+    batch: int,
+) -> None:
+    spec = KernelRegistry.get().get_by_name(
+        "gluon_mla_decode_bf16xbf16_gfx950_h64_small_batch"
+    )
+    if spec is None:
+        pytest.skip("gfx950 Gluon MLA registrations are unavailable")
+
+    traits = {
+        "batch_size": batch,
+        "batch_size_div_64": batch % 64 == 0,
+        "q_len": 1,
+        "num_q_heads": 64,
+        "page_size": 64,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 64,
+        "support_logit_cap": False,
+        "return_lse": False,
+    }
+    assert spec_matches_traits(spec, traits) is (batch in {1, 2, 4})
 
 
 _CASE_PLATFORM_PARAMS = [

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -32,8 +32,8 @@ import-guarded on missing optional backend packages are skipped.
 from __future__ import annotations
 
 import importlib
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
 import pytest
 import tokenspeed_kernel
@@ -795,6 +795,29 @@ def _attention_decode() -> object:
         cache_seqlens,
         max_seqlen_k=128,
         max_seqlen_q=1,
+    )
+
+
+def _attention_mla_decode(
+    batch_size: int,
+    *,
+    override: str | None = None,
+) -> object:
+    q = torch.empty((batch_size, 1, 64, 576), dtype=torch.bfloat16)
+    kv_cache = torch.empty((batch_size, 64, 1, 576), dtype=torch.bfloat16)
+    page_table = torch.arange(batch_size, dtype=torch.int32).view(batch_size, 1)
+    cache_seqlens = torch.full((batch_size,), 64, dtype=torch.int32)
+    return tokenspeed_kernel.mla_decode_with_kvcache(
+        q=q,
+        kv_cache=kv_cache,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        max_seqlen_k=64,
+        qk_nope_head_dim=128,
+        kv_lora_rank=512,
+        qk_rope_head_dim=64,
+        softmax_scale=1.0,
+        override=override,
     )
 
 
@@ -2774,15 +2797,50 @@ def test_attn_merge_state_routes_to_triton_on_cdna4(
         registry.clear_cache()
 
 
+_GLUON_MLA_FIXED_KERNELS = (
+    "gluon_mla_decode_bf16xbf16_gfx950_bh16bn64",
+    "gluon_mla_decode_bf16xbf16_gfx950_bh64",
+    "gluon_mla_decode_bf16xbf16_gfx950_bh16_multiblock",
+    "gluon_mla_decode_bf16xbf16_gfx950_bh64_small",
+)
+
+
+def _require_gluon_mla_fixed_kernel(name: str):
+    registry = KernelRegistry.get()
+    if registry.get_by_name(_GLUON_MLA_FIXED_KERNELS[0]) is None:
+        pytest.skip("gfx950 Gluon MLA registrations are unavailable")
+    spec = registry.get_by_name(name)
+    assert spec is not None
+    return spec
+
+
+@pytest.mark.parametrize("name", _GLUON_MLA_FIXED_KERNELS)
+def test_gluon_mla_fixed_entrypoints_are_registered(name: str) -> None:
+    _require_gluon_mla_fixed_kernel(name)
+
+
+@pytest.mark.parametrize(
+    "name,expected_batches",
+    [
+        pytest.param(
+            "gluon_mla_decode_bf16xbf16_gfx950_bh16_multiblock",
+            frozenset({1}),
+            id="bh16-multiblock",
+        ),
+        pytest.param(
+            "gluon_mla_decode_bf16xbf16_gfx950_bh64_small",
+            frozenset({2, 4}),
+            id="bh64-small",
+        ),
+    ],
+)
 @pytest.mark.parametrize("batch", [1, 2, 3, 4, 64])
-def test_gluon_mla_h64_small_batch_registration_matches_supported_batches(
+def test_gluon_mla_small_batch_registrations_have_disjoint_traits(
+    name: str,
+    expected_batches: frozenset[int],
     batch: int,
 ) -> None:
-    spec = KernelRegistry.get().get_by_name(
-        "gluon_mla_decode_bf16xbf16_gfx950_h64_small_batch"
-    )
-    if spec is None:
-        pytest.skip("gfx950 Gluon MLA registrations are unavailable")
+    spec = _require_gluon_mla_fixed_kernel(name)
 
     traits = {
         "batch_size": batch,
@@ -2795,7 +2853,62 @@ def test_gluon_mla_h64_small_batch_registration_matches_supported_batches(
         "support_logit_cap": False,
         "return_lse": False,
     }
-    assert spec_matches_traits(spec, traits) is (batch in {1, 2, 4})
+    assert spec_matches_traits(spec, traits) is (batch in expected_batches)
+
+
+@pytest.mark.parametrize(
+    "batch,expected",
+    [
+        pytest.param(
+            1,
+            "gluon_mla_decode_bf16xbf16_gfx950_bh16_multiblock",
+            id="b1-bh16-multiblock",
+        ),
+        pytest.param(
+            2,
+            "gluon_mla_decode_bf16xbf16_gfx950_bh64_small",
+            id="b2-bh64-small",
+        ),
+        pytest.param(
+            4,
+            "gluon_mla_decode_bf16xbf16_gfx950_bh64_small",
+            id="b4-bh64-small",
+        ),
+        pytest.param(
+            64,
+            "gluon_mla_decode_bf16xbf16_gfx950_bh64",
+            id="b64-bh64",
+        ),
+    ],
+)
+def test_gluon_mla_fixed_regime_auto_selection(
+    batch: int,
+    expected: str,
+    mi350_platform: PlatformInfo,
+    selected_kernel_spy,
+) -> None:
+    _require_gluon_mla_fixed_kernel(expected)
+    case = _case(
+        _is_cdna4,
+        "cdna4",
+        "attention",
+        "mla_decode_with_kvcache",
+        expected,
+        lambda: _attention_mla_decode(batch),
+    )
+    host_platform = Platform.get()
+    active_case, calls = selected_kernel_spy
+    active_case["case"] = case
+    registry = KernelRegistry.get()
+    try:
+        Platform.override(mi350_platform)
+        registry.clear_cache()
+        case.invoke()
+    finally:
+        Platform.override(host_platform)
+        registry.clear_cache()
+
+    assert calls == [expected]
 
 
 _CASE_PLATFORM_PARAMS = [


### PR DESCRIPTION
## Summary

A new specialization is added for gluon mla_decode_with_kvcache targeting small batch sizes. This kernel is needed for data parallel Kimi 2.5 configurations. With data parallelism, each rank gets either 1 or 2 requests (depending on concurrency), which can become a batch of 1, 2, or 4 with speculative decoding.

The new specialization relies on splitting along kv for parallelism rather than splitting along the head dim. This strategy performed better during benchmark experiments.

## Test Plan

Validated by running the agentic benchmark on Kimi 2.5 using the attn_dp8-moe_tp8 configuration. Without the new specialization, the triton MLA kernel is selected, and MLA takes up 95% of model runtime. With the specialization, MLA is only 10%, and the agentic benchmark is able to complete in a reasonable amount of time.

New unit test cases are also added, and a new test is added to verify the specialization cases selected by the kernel.
