### PR TITLE
fix(communications): allocate amd rsag symmetric mem buffer outside of inference mode 

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/triton.py
@@ -1235,10 +1235,12 @@ def amd_create_rsag_state(
     symm_mem.set_signal_pad_size(max(symm_mem.get_signal_pad_size(), pad_bytes))
 
     free_gpu_memory_begin = _get_available_gpu_memory(torch.cuda.current_device())
-    comm_buff = symm_mem.empty(
-        (max_tokens, hidden_size), dtype=torch.bfloat16, device=device
+    # Allocate outside inference_mode so the persistent comm buffer is not
+    # an inference tensor; this class is often lazily constructed during
+    # forward (which runs under @maybe_inference_mode).
+    comm_buff, symm_mem_hdl = _alloc_symm(
+        (max_tokens, hidden_size), torch.bfloat16, device, group
     )
-    symm_mem_hdl = symm_mem.rendezvous(comm_buff, group=group)
     free_gpu_memory_after = _get_available_gpu_memory(torch.cuda.current_device())
     logger.info(
         f"Custom Triton RSAG AMD symmetric-memory buffer allocated: {free_gpu_memory_begin - free_gpu_memory_after} GB"


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

The AMD rsag state allocated its symmetric comms buffer without ensuring that allocation occured outside of torch inference mode. If we lazily allocate it during inference mode, a later in place mutation outside inference mode fails with 

```
RuntimeError: Inplace update to inference tensor outside InferenceMode is not allowed.
```

Attention DP8 + MoE TP8/EP8 uses token RSAG in Kimi 2.5. During decode graph startup, `forward` runs in inference mode before graph capture and creates the buffer. In later server generation warmup, `DP` ranks assigned `IDLE` execute `forward` outside of inference mode and reuse the same buffer for the `copy` in reduce scatter, hitting the error above. 

Fix by using the existing helper which initializes the symmetric memory outside of inference mode. The Nvidia equivalent already has this check: https://github.com/lightseekorg/tokenspeed/blob/main/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/triton.py#L1018-L1025 .

This minimally enables Attention DP8 + MoE TP8/EP8 configs in Kimi 2.5 on the AMD path. 

## Test Plan

<!-- How was this validated? -->

Agentic benchmark on Kimi 2.5 on 8x MI355x with attn_dp8_moe_tp8 and attn_dp8_moe_ep8.sh