### PR TITLE
feat: support EAGLE3.1 for Deepseek EAGLE MLA / Kimi K2.7 Code

### DIFF
--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -1973,6 +1973,17 @@ class Eagle3MlaModel(nn.Module):
         )
 
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.fc_norm = (
+            nn.ModuleList(
+                [
+                    RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+                    for _ in range(self.num_fc_input_dim)
+                ]
+            )
+            if getattr(config, "fc_norm", False)
+            else None
+        )
+        self.norm_output = getattr(config, "norm_output", False)
 
     def forward(
         self,
@@ -1992,6 +2003,15 @@ class Eagle3MlaModel(nn.Module):
 
         hidden_states = captured_hidden_states
         if hidden_states.size(-1) != embeds.size(-1):
+            if self.fc_norm is not None:
+                chunks = hidden_states.chunk(self.num_fc_input_dim, dim=-1)
+                hidden_states = torch.cat(
+                    [
+                        norm(chunk)
+                        for norm, chunk in zip(self.fc_norm, chunks, strict=True)
+                    ],
+                    dim=-1,
+                )
             hidden_states, _ = self.fc(hidden_states)
 
         residual = None
@@ -2024,6 +2044,10 @@ class Eagle3MlaModel(nn.Module):
             hidden_states_to_aux, _ = comm_manager.post_final_norm_comm(
                 hidden_states_to_aux, None, ctx
             )
+
+        if self.norm_output:
+            hidden_states_to_aux = hidden_states_to_logits
+
         return hidden_states_to_logits, [hidden_states_to_aux]
 
 


### PR DESCRIPTION
## Summary

Support EAGLE 3.1 for MLA backbone + Kimi K2.7 speculator.

https://huggingface.co/lightseekorg/kimi-k2.7-coder-eagle3.1-mla

Tested on 4xGB200 with Kimi K2.7 NVFP4 checkpoint by NVIDIA with 1-3-4 config with concurrency 16.

| Category | Baseline output tok/s | EAGLE output tok/s (speedup) | EAGLE output tok/s/user | Mean acceptance length |
|---|---:|---:|---:|---:|
| coding | 1237.55 | 1728.14 (1.40×) | 134.43 | 2.82 |
| humanities | 1266.41 | 1746.88 (1.38×) | 116.80 | 2.42 |
| math | 1275.36 | 1780.37 (1.40×) | 140.67 | 2.82 |
| multilingual | 1166.44 | 1750.98 (1.50×) | 135.91 | 2.85 |
| qa | 1041.65 | 1483.92 (1.42×) | 123.42 | 2.57 |
| rag | 856.49 | 1544.37 (1.80×) | 121.21 | 2.95 |
| reasoning | 909.07 | 1341.23 (1.48×) | 119.64 | 2.80 |
| roleplay | 1024.34 | 1396.63 (1.36×) | 102.12 | 2.26 |
| stem | 1271.89 | 1788.95 (1.41×) | 120.89 | 2.48 |
| summarization | 880.14 | 1683.93 (1.91×) | 116.05 | 2.85 |


## Test Plan

Launch command,

```bash
docker exec -d --user 1001:2002 tokenspeed-dev bash -lc '
  cd /home/runner/tokenspeed
  export HF_HOME=/home/runner/.cache/huggingface
  export HF_HUB_CACHE="${HF_HOME}/hub"
  export TORCH_NCCL_ASYNC_ERROR_HANDLING=1
  export TORCH_NCCL_TRACE_BUFFER_SIZE=1048576
  export TORCH_NCCL_DUMP_ON_TIMEOUT=1

  exec tokenspeed serve nvidia/Kimi-K2.7-Code-NVFP4 \
    --served-model-name kimi-k2.7-code \
    --trust-remote-code \
    --language-model-only \
    --max-model-len 65536 \
    --max-total-tokens 65536 \
    --gpu-memory-utilization 0.95 \
    --kv-cache-dtype fp8 \
    --quantization nvfp4 \
    --tensor-parallel-size 4 \
    --enable-expert-parallel \
    --chunked-prefill-size 8192 \
    --max-num-seqs 16 \
    --attention-backend trtllm_mla \
    --drafter-attention-backend trtllm_mla \
    --moe-backend flashinfer_trtllm \
    --disable-custom-all-reduce \
    --speculative-algorithm EAGLE3 \
    --speculative-draft-model-path lightseekorg/kimi-k2.7-coder-eagle3.1-mla \
    --speculative-num-steps 3 \
    --speculative-num-draft-tokens 4 \
    --speculative-eagle-topk 1 \
    --reasoning-parser kimi_thinking \
    --tool-call-parser kimik2 \
    --host 0.0.0.0 \
    --port 30500 \
    --enable-metrics \
    --prometheus-port 30502 \
    --enable-log-request-stats \
    > /home/runner/kimi-k27-tp4-eagle31.log 2>&1
'
```

Benchmark command,

```bash
CATEGORIES="coding humanities math multilingual qa rag reasoning roleplay stem summarization writing"
for cat in $CATEGORIES; do
  echo "=== Running category: $cat ==="
  aiperf profile \
      --model kimi-k2.7-code \
      --endpoint-type chat \
      --streaming \
      --url localhost:30500 \
      --custom-dataset-type speed_bench_${cat} \
      --input-file ${SPEED_BENCH_DIR}/qualitative.jsonl \
      --server-metrics http://localhost:30500/metrics \
      --osl 4096 \
      --extra-inputs temperature:0 \
      --concurrency 16 \
      --no-gpu-telemetry \
      --tokenizer nvidia/Kimi-K2.7-Code-NVFP4 \
      --request-count 100 \
      --output-artifact-dir "./artifacts/speed_bench_${cat}"
done
```