### PR TITLE
feat: support torchspec training

### DIFF
--- a/python/tokenspeed/runtime/engine/output_processor.py
+++ b/python/tokenspeed/runtime/engine/output_processor.py
@@ -167,6 +167,13 @@ class OutputProcessor:
             if getattr(recv_obj, "output_hidden_states", None):
                 meta_info["hidden_states"] = recv_obj.output_hidden_states[i]
 
+            if (
+                self.engine.server_args.enable_spec_training_mooncake
+                and getattr(state.obj, "return_hidden_states", False)
+                and recv_obj.finished_reasons[i] is not None
+            ):
+                meta_info["spec_training_mooncake_store_keys"] = [rid]
+
             if isinstance(recv_obj, BatchStrOut):
                 if len(recv_obj.batch_accept_draft_tokens) > 0:
                     meta_info.update(

--- a/python/tokenspeed/runtime/execution/context.py
+++ b/python/tokenspeed/runtime/execution/context.py
@@ -53,6 +53,11 @@ class ForwardContext:
     capture_hidden_mode: CaptureHiddenMode | None = CaptureHiddenMode.NULL
     # Normalized explicit decode input overrides for this forward, if any.
     decode_input_ids: list[int] | None = None
+    # CPU request metadata used only by hidden state capture.
+    request_ids: list[str] | None = None
+    input_ids_cpu: list[int] | None = None
+    input_lengths_cpu: list[int] | None = None
+    extend_prefix_lens_cpu: list[int] | None = None
 
     # --- dp attention ---
     global_num_tokens: list[int] | None = None

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -182,6 +182,8 @@ class ModelExecutorConfig:
     dp_sampling: bool = False
     dp_sampling_min_bs: int | None = None
     use_v4_mtp_paged_metadata: bool = False
+    enable_spec_training_mooncake: bool = False
+    spec_training_aux_layer_ids: list[int] | None = None
 
     # ====== GRAMMAR =========
     # "none" disables all grammar handling; otherwise the backend name
@@ -248,6 +250,8 @@ class ModelExecutorConfig:
             dp_sampling_min_bs=server_args.dp_sampling_min_bs,
             enable_nan_detection=server_args.enable_nan_detection,
             use_v4_mtp_paged_metadata=model_config.use_v4_mtp_paged_metadata,
+            enable_spec_training_mooncake=server_args.enable_spec_training_mooncake,
+            spec_training_aux_layer_ids=server_args.eagle3_layers_to_capture,
             grammar_backend=server_args.grammar_backend,
             disable_capturable_grammar=server_args.disable_capturable_grammar,
         )
@@ -424,6 +428,26 @@ class ModelExecutor:
                 )
         else:
             self.drafter = None
+
+        self.spec_training_exporter = None
+        if config.enable_spec_training_mooncake:
+            if self.drafter is not None:
+                raise ValueError(
+                    "Offline spec-training Mooncake capture cannot run with a drafter"
+                )
+            if not hasattr(self.model_runner.model, "set_eagle3_layers_to_capture"):
+                raise ValueError(
+                    "The target model does not support auxiliary hidden-state capture"
+                )
+            self.model_runner.model.set_eagle3_layers_to_capture(
+                config.spec_training_aux_layer_ids
+            )
+            if config.global_rank == 0:
+                from tokenspeed.runtime.execution.spec_training_mooncake import (
+                    SpecTrainingMooncakeExporter,
+                )
+
+                self.spec_training_exporter = SpecTrainingMooncakeExporter()
 
         # Single grammar handle: CapturableGrammarExecutor on CUDA (uses
         # cudaLaunchHostFunc on a side stream so the xgrammar fill +
@@ -971,6 +995,8 @@ class ModelExecutor:
             )
 
         logits_output = self._run_target_forward(bs, ctx, req_pool_indices)
+        if self.spec_training_exporter is not None and ctx.forward_mode.is_extend():
+            self.spec_training_exporter.export(ctx, logits_output)
 
         if self.drafter is not None and getattr(
             self.drafter, "_incremental_proj_enabled", False
@@ -1837,6 +1863,24 @@ class ModelExecutor:
                             - 1
                         )
 
+                if self.config.enable_spec_training_mooncake:
+                    capture_hidden_mode = CaptureHiddenMode.FULL
+                    request_ids = list(forward_op.request_ids)
+                    input_ids_cpu = list(forward_op.input_ids)
+                    input_lengths_cpu = list(forward_op.input_lengths)
+                    extend_prefix_lens_cpu = list(forward_op.extend_prefix_lens)
+                else:
+                    capture_hidden_mode = (
+                        CaptureHiddenMode.FULL
+                        if self.drafter is not None
+                        else CaptureHiddenMode.NULL
+                    )
+                    # Unused if hidden state is not captured
+                    request_ids = None
+                    input_ids_cpu = None
+                    input_lengths_cpu = None
+                    extend_prefix_lens_cpu = None
+
                 ctx = ForwardContext(
                     attn_backend=self.attn_backend,
                     token_to_kv_pool=self.token_to_kv_pool,
@@ -1845,13 +1889,13 @@ class ModelExecutor:
                     num_extends=num_extends,
                     input_num_tokens=total_tokens,
                     forward_mode=forward_mode,
-                    capture_hidden_mode=(
-                        CaptureHiddenMode.FULL
-                        if self.drafter is not None
-                        else CaptureHiddenMode.NULL
-                    ),
+                    capture_hidden_mode=capture_hidden_mode,
                     gather_ids=gather_ids,
                     decode_input_ids=decode_input_ids,
+                    request_ids=request_ids,
+                    input_ids_cpu=input_ids_cpu,
+                    input_lengths_cpu=input_lengths_cpu,
+                    extend_prefix_lens_cpu=extend_prefix_lens_cpu,
                 )
                 if self.config.data_parallel_size > 1:
                     if dp_global_num_tokens is None:

--- a/python/tokenspeed/runtime/execution/spec_training_mooncake.py
+++ b/python/tokenspeed/runtime/execution/spec_training_mooncake.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""TorchSpec-compatible hidden-state export for offline TokenSpeed prefill."""
+
+from __future__ import annotations
+
+import os
+import socket
+import time
+
+import torch
+
+from tokenspeed.runtime.execution.context import ForwardContext
+from tokenspeed.runtime.layers.logits_processor import LogitsProcessorOutput
+from tokenspeed.runtime.utils import get_colorful_logger
+
+logger = get_colorful_logger(__name__)
+
+
+def _parse_size(value: str, default: int) -> int:
+    if not value:
+        return default
+    normalized = value.strip().upper()
+    multipliers = {
+        "KB": 1024,
+        "MB": 1024**2,
+        "GB": 1024**3,
+        "TB": 1024**4,
+    }
+    for suffix, multiplier in multipliers.items():
+        if normalized.endswith(suffix):
+            return int(float(normalized[: -len(suffix)]) * multiplier)
+    return int(normalized)
+
+
+def _tensor_bytes(tensor: torch.Tensor, dtype: torch.dtype) -> bytes:
+    cpu = tensor.detach().to(device="cpu", dtype=dtype).contiguous()
+    return cpu.view(torch.uint8).numpy().tobytes()
+
+
+class SpecTrainingMooncakeExporter:
+    """Synchronously publish one whole-prompt prefill batch to Mooncake."""
+
+    def __init__(self) -> None:
+        try:
+            from mooncake.store import MooncakeDistributedStore
+        except ImportError as exc:
+            raise RuntimeError(
+                "--enable-spec-training-mooncake requires the mooncake Python package"
+            ) from exc
+
+        master = os.getenv("MOONCAKE_MASTER_SERVER")
+        metadata = os.getenv("MOONCAKE_METADATA_SERVER")
+        if not master or not metadata:
+            raise RuntimeError(
+                "--enable-spec-training-mooncake requires "
+                "MOONCAKE_MASTER_SERVER and MOONCAKE_METADATA_SERVER"
+            )
+
+        protocol = os.getenv("MOONCAKE_PROTOCOL", "tcp")
+        if protocol.lower() == "tcp":
+            os.environ.setdefault("MC_STORE_MEMCPY", "0")
+
+        self._store = MooncakeDistributedStore()
+        result = self._store.setup(
+            local_hostname=os.getenv("MOONCAKE_LOCAL_HOSTNAME", socket.gethostname()),
+            metadata_server=metadata,
+            global_segment_size=_parse_size(
+                os.getenv("MOONCAKE_GLOBAL_SEGMENT_SIZE", ""),
+                4 * 1024**3,
+            ),
+            local_buffer_size=_parse_size(
+                os.getenv("MOONCAKE_LOCAL_BUFFER_SIZE", ""),
+                512 * 1024**2,
+            ),
+            protocol=protocol,
+            rdma_devices=os.getenv("MOONCAKE_DEVICE_NAME", ""),
+            master_server_addr=master,
+        )
+        if result not in (None, 0):
+            raise RuntimeError(f"Mooncake setup failed with error code {result}")
+
+        self._store_full_codes = {
+            int(code)
+            for code in os.getenv("MOONCAKE_STORE_FULL_ERROR_CODES", "-200").split(",")
+            if code.strip()
+        }
+        self._retry_wait = float(os.getenv("MOONCAKE_STORE_FULL_WAIT_SECONDS", "0.5"))
+        self._max_wait = float(os.getenv("MOONCAKE_STORE_FULL_MAX_WAIT_SECONDS", "0"))
+        logger.info("Initialized TorchSpec-compatible Mooncake hidden-state exporter")
+
+    def export(self, ctx: ForwardContext, output: LogitsProcessorOutput) -> None:
+        if not ctx.forward_mode.is_extend() or ctx.num_extends != ctx.bs:
+            raise RuntimeError(
+                "Spec-training Mooncake export only supports pure prefill batches"
+            )
+        if not ctx.request_ids or len(ctx.request_ids) != ctx.bs:
+            raise RuntimeError("Missing request IDs for spec-training export")
+        if not ctx.input_lengths_cpu or len(ctx.input_lengths_cpu) != ctx.bs:
+            raise RuntimeError("Missing input lengths for spec-training export")
+        if any(ctx.extend_prefix_lens_cpu or []):
+            raise RuntimeError(
+                "Spec-training Mooncake export does not support cached prefixes"
+            )
+        if output.hidden_states is None or output.last_hidden_states is None:
+            raise RuntimeError(
+                "Target model did not return auxiliary and final hidden states"
+            )
+
+        total_tokens = sum(ctx.input_lengths_cpu)
+        if len(ctx.input_ids_cpu or []) != total_tokens:
+            raise RuntimeError(
+                "Prompt ID count does not match the captured prefill token count"
+            )
+        if output.hidden_states.shape[0] != total_tokens:
+            raise RuntimeError(
+                "Auxiliary hidden-state rows do not match the prompt token count"
+            )
+        if output.last_hidden_states.shape[0] != total_tokens:
+            raise RuntimeError(
+                "Final hidden-state rows do not match the prompt token count"
+            )
+
+        offset = 0
+        for rid, length in zip(ctx.request_ids, ctx.input_lengths_cpu):
+            end = offset + length
+            ids = torch.tensor(
+                ctx.input_ids_cpu[offset:end],
+                dtype=torch.int64,
+            )
+            keys = [f"{rid}_hs", f"{rid}_ids", f"{rid}_lhs"]
+            values = [
+                _tensor_bytes(output.hidden_states[offset:end], torch.bfloat16),
+                _tensor_bytes(ids, torch.int64),
+                _tensor_bytes(output.last_hidden_states[offset:end], torch.bfloat16),
+            ]
+            self._put_batch(keys, values)
+            offset = end
+
+    def _put_batch(self, keys: list[str], values: list[bytes]) -> None:
+        started = time.monotonic()
+        while True:
+            result = self._store.put_batch(keys, values)
+            if result in (None, 0):
+                return
+            try:
+                self._store.batch_remove(keys, force=True)
+            except RuntimeError:
+                logger.warning("Failed to clean up partial Mooncake export: %s", keys)
+            if result not in self._store_full_codes:
+                raise RuntimeError(
+                    f"Mooncake put_batch failed for {keys} with error code {result}"
+                )
+            if self._max_wait > 0 and time.monotonic() - started >= self._max_wait:
+                raise RuntimeError(f"Mooncake remained full while publishing {keys}")
+            time.sleep(self._retry_wait)
+
+    def close(self) -> None:
+        if self._store is not None:
+            self._store.close()
+            self._store = None

--- a/python/tokenspeed/runtime/layers/logits_processor.py
+++ b/python/tokenspeed/runtime/layers/logits_processor.py
@@ -68,6 +68,8 @@ class LogitsProcessorOutput:
     # Used by speculative decoding.
     # The last hidden layers
     hidden_states: torch.Tensor | None = None
+    # Full, post-final-norm target hidden states.
+    last_hidden_states: torch.Tensor | None = None
     logits_layout_plan: LogitsLayoutPlan | None = None
 
     ## Part 2: Populated by the active SamplingBackend during sample()/verify().
@@ -423,8 +425,10 @@ class LogitsProcessor(nn.Module):
         )
 
         hidden_states_to_store: torch.Tensor | None = None
+        last_hidden_states_to_store: torch.Tensor | None = None
         if logits_metadata.capture_hidden_mode.need_capture():
             if logits_metadata.capture_hidden_mode.is_full():
+                last_hidden_states_to_store = hidden_states
                 if aux_hidden_states is not None:
                     aux_hidden_states = (
                         aux_hidden_states[0]
@@ -466,6 +470,7 @@ class LogitsProcessor(nn.Module):
                 next_token_logits=sampled_logits,
                 next_token_ids=next_token_ids,
                 hidden_states=hidden_states_to_store,
+                last_hidden_states=last_hidden_states_to_store,
                 logits_layout_plan=logits_layout_plan,
             )
         else:
@@ -520,6 +525,7 @@ class LogitsProcessor(nn.Module):
                 input_top_logprobs_val=input_top_logprobs_val,
                 input_top_logprobs_idx=input_top_logprobs_idx,
                 hidden_states=hidden_states_to_store,
+                last_hidden_states=last_hidden_states_to_store,
                 input_token_ids_logprobs_val=input_token_ids_logprobs_val,
                 input_token_ids_logprobs_idx=input_token_ids_logprobs_idx,
             )

--- a/python/tokenspeed/runtime/models/qwen3.py
+++ b/python/tokenspeed/runtime/models/qwen3.py
@@ -279,6 +279,50 @@ class Qwen3DecoderLayer(nn.Module):
         residual: torch.Tensor | None,
         cos_sin: tuple[torch.Tensor, torch.Tensor] | None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        hidden_states, residual, _ = self._forward(
+            positions,
+            hidden_states,
+            ctx,
+            out_cache_loc,
+            residual,
+            cos_sin,
+            capture_input_residual=False,
+        )
+        return hidden_states, residual
+
+    def forward_with_input_residual(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        ctx: ForwardContext,
+        out_cache_loc: torch.Tensor,
+        residual: torch.Tensor | None,
+        cos_sin: tuple[torch.Tensor, torch.Tensor] | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Forward the layer and return its complete TP-reduced input residual."""
+        hidden_states, residual, input_residual = self._forward(
+            positions,
+            hidden_states,
+            ctx,
+            out_cache_loc,
+            residual,
+            cos_sin,
+            capture_input_residual=True,
+        )
+        assert input_residual is not None
+        return hidden_states, residual, input_residual
+
+    def _forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        ctx: ForwardContext,
+        out_cache_loc: torch.Tensor,
+        residual: torch.Tensor | None,
+        cos_sin: tuple[torch.Tensor, torch.Tensor] | None,
+        *,
+        capture_input_residual: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         # Self Attention
         if residual is None:
             residual = hidden_states
@@ -297,6 +341,8 @@ class Qwen3DecoderLayer(nn.Module):
                     residual,
                 )
             )
+
+        input_residual = residual.clone() if capture_input_residual else None
 
         hidden_states = self.self_attn(
             positions=positions,
@@ -322,7 +368,7 @@ class Qwen3DecoderLayer(nn.Module):
                 )
             )
         hidden_states = self.mlp(hidden_states)
-        return hidden_states, residual
+        return hidden_states, residual, input_residual
 
 
 class Qwen3Model(nn.Module):
@@ -358,6 +404,7 @@ class Qwen3Model(nn.Module):
             ),
         )
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.layers_to_capture: set[int] = set()
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         if hasattr(self.config, "scale_emb"):
@@ -371,23 +418,39 @@ class Qwen3Model(nn.Module):
         ctx: ForwardContext,
         out_cache_loc: torch.Tensor,
         input_embeds: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, None]:
+    ) -> tuple[torch.Tensor, list[torch.Tensor] | None]:
         if input_embeds is None:
             hidden_states = self.embed_tokens(input_ids)
         else:
             hidden_states = input_embeds
         residual = None
+        aux_hidden_states = [] if self.layers_to_capture else None
 
         for i in range(len(self.layers)):
             layer = self.layers[i]
-            hidden_states, residual = layer(
-                positions,
-                hidden_states,
-                ctx,
-                out_cache_loc,
-                residual,
-                cos_sin=None,
-            )
+            if aux_hidden_states is not None and i in self.layers_to_capture:
+                (
+                    hidden_states,
+                    residual,
+                    input_residual,
+                ) = layer.forward_with_input_residual(
+                    positions,
+                    hidden_states,
+                    ctx,
+                    out_cache_loc,
+                    residual,
+                    cos_sin=None,
+                )
+                aux_hidden_states.append(input_residual)
+            else:
+                hidden_states, residual = layer(
+                    positions,
+                    hidden_states,
+                    ctx,
+                    out_cache_loc,
+                    residual,
+                    cos_sin=None,
+                )
         if ctx.input_num_tokens > global_server_args_dict["comm_fusion_max_num_tokens"]:
             hidden_states = all_reduce(hidden_states, self.mapping.dense.tp_group)
             hidden_states, _ = self.norm(hidden_states, residual)
@@ -398,7 +461,7 @@ class Qwen3Model(nn.Module):
                 hidden_states,
                 residual,
             )
-        return hidden_states, None
+        return hidden_states, aux_hidden_states
 
     def load_kv_cache_scales(self, quantization_param_path: str) -> None:
         tp_size = self.mapping.attn.tp_size
@@ -417,7 +480,7 @@ class Qwen3Model(nn.Module):
                 layer_self_attn.attn.v_scale = scaling_factor
             else:
                 raise RuntimeError(
-                    "Self attention has no KV cache scaling " "factor attribute!"
+                    "Self attention has no KV cache scaling factor attribute!"
                 )
 
 

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -234,6 +234,8 @@ class ServerArgs:
     speculative_eagle_topk: int = 1
     speculative_num_draft_tokens: int | None = None
     eagle3_layers_to_capture: str | None = None
+    # Capture target-model hidden states and publish them to Mooncake.
+    enable_spec_training_mooncake: bool = False
     # Logprob support flags — all OFF by default. Enabling extends the
     # captured CUDA-graph footprint; requests asking for logprobs on a
     # server started without the matching flag will receive empty logprobs.
@@ -310,6 +312,7 @@ class ServerArgs:
         self.resolve_parallelism()
         self.resolve_memory_and_scheduling()
         self.resolve_kernel_backends()
+        self.resolve_spec_training()
         self.resolve_cache()
         self.resolve_speculative_decoding()
         self.resolve_communication()
@@ -553,6 +556,25 @@ class ServerArgs:
         # Handle KVStore settings.
         self._handle_kvstore()
         self.validate_cache_options()
+
+    def resolve_spec_training(self):
+        if not self.enable_spec_training_mooncake:
+            return
+
+        self.enforce_eager = True
+        self.disable_prefill_graph = True
+        self.disable_overlap_schedule = True
+        self.enable_prefix_caching = False
+        self.disable_kvstore = True
+        self.enable_mixed_batch = False
+        if self.kvstore_size == 0:
+            self.kvstore_size = 1
+        self.chunked_prefill_size = self.max_prefill_tokens
+        self.skip_server_warmup = True
+        logger.info(
+            "Enabled offline spec-training Mooncake capture: eager whole-prompt "
+            "prefill, prefix/KV caching, overlap scheduling, and warmup disabled"
+        )
 
     def resolve_speculative_decoding(self):
         # Keep drafter backend consistent with the main model unless explicitly set.
@@ -1574,6 +1596,13 @@ class ServerArgs:
             type=str,
             help="The layers of Eagle3 to capture.",
             default=ServerArgs.eagle3_layers_to_capture,
+        )
+        parser.add_argument(
+            "--enable-spec-training-mooncake",
+            action="store_true",
+            default=ServerArgs.enable_spec_training_mooncake,
+            help="Capture full-sequence auxiliary and final hidden states during "
+            "offline prefill and publish them to Mooncake for TorchSpec.",
         )
 
         # Runtime options

--- a/test/runtime/models/test_qwen3_hidden_capture.py
+++ b/test/runtime/models/test_qwen3_hidden_capture.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+
+from tokenspeed.runtime.models.qwen3 import Qwen3DecoderLayer
+from tokenspeed.runtime.utils.env import global_server_args_dict
+
+
+class _InputNorm(nn.Module):
+    def forward(self, hidden_states, residual=None):
+        if residual is None:
+            return hidden_states
+        complete_residual = hidden_states + residual + 10
+        return torch.zeros_like(hidden_states), complete_residual
+
+    def forward_with_allreduce_fusion(
+        self,
+        tp_rank,
+        tp_group,
+        hidden_states,
+        residual,
+    ):
+        del tp_rank, tp_group
+        complete_residual = hidden_states + residual + 10
+        return torch.zeros_like(hidden_states), complete_residual, None
+
+
+class _PostAttentionNorm(nn.Module):
+    def forward_with_allreduce_fusion(
+        self,
+        tp_rank,
+        tp_group,
+        hidden_states,
+        residual,
+    ):
+        del tp_rank, tp_group
+        return hidden_states, residual, None
+
+
+class _IdentityAttention(nn.Module):
+    def forward(self, *, hidden_states, **kwargs):
+        del kwargs
+        return hidden_states
+
+
+def _decoder_layer() -> Qwen3DecoderLayer:
+    layer = Qwen3DecoderLayer.__new__(Qwen3DecoderLayer)
+    nn.Module.__init__(layer)
+    parallel = SimpleNamespace(tp_rank=0, tp_group=(0, 1))
+    layer.mapping = SimpleNamespace(dense=parallel, attn=parallel)
+    layer.input_layernorm = _InputNorm()
+    layer.post_attention_layernorm = _PostAttentionNorm()
+    layer.self_attn = _IdentityAttention()
+    layer.mlp = nn.Identity()
+    return layer
+
+
+def test_capture_uses_tp_reduced_input_residual(monkeypatch):
+    monkeypatch.setitem(global_server_args_dict, "comm_fusion_max_num_tokens", 1024)
+    layer = _decoder_layer()
+    hidden_states = torch.tensor([[1.0, 2.0]])
+    residual = torch.tensor([[3.0, 4.0]])
+
+    _, _, captured = layer.forward_with_input_residual(
+        positions=torch.tensor([0]),
+        hidden_states=hidden_states,
+        ctx=SimpleNamespace(input_num_tokens=1),
+        out_cache_loc=torch.tensor([0]),
+        residual=residual,
+        cos_sin=None,
+    )
+
+    torch.testing.assert_close(captured, hidden_states + residual + 10)


### PR DESCRIPTION
## Summary

Add hidden state capture & speculative decoding training via TorchSpec support [(PR)](https://github.com/lightseekorg/TorchSpec/pull/146) to Tokenspeed.

## Test Plan

Currently tested on Qwen3-8B for simplicity over 1000 hidden states, both offline and online training is done.

<img width="1080" height="631" alt="image" src="https://github.com/user-attachments/assets/aa7ba792-d9d2-4504-a513-9a3538cb081f" />

2 Qwen3-8B instances with TP=2 (stress testing the distributed path) can handle around 75 samples per second.

<img width="1062" height="635" alt="image" src="https://github.com/user-attachments/assets/a71b885a-e9a2-4380-90cb-bfa1c7fe7518" />

TODO: Will report actual runs with the 1000 step trained EAGLE3 model with Tokenspeed to validate trained model is actually compatible with tokenspeed.
