### PR TITLE
ci: prefetch Inkling checkpoint weights

### DIFF
--- a/test/ci/eval/inkling-nvfp4-mtp-evalscope-gsm8k.yaml
+++ b/test/ci/eval/inkling-nvfp4-mtp-evalscope-gsm8k.yaml
@@ -25,6 +25,7 @@ server:
     --gpu-memory-utilization 0.95
     --disable-cuda-graph-padding
     --trust-remote-code
+    --weight-loader-prefetch-checkpoints
     --attention-backend fa4
     --moe-backend flashinfer_trtllm
     --enable-prefix-caching


### PR DESCRIPTION
## Summary

Enable checkpoint prefetching for the Inkling NVFP4 MTP evaluation task.

## Why

The four local ranks currently load 34 checkpoint shards on demand from shared storage. In live Slurm validation this exceeded the default 30-minute engine startup deadline. Prefetching partitions checkpoint shards across local ranks and reads them into the OS page cache in background threads before demand loading.

## Impact

Only the existing Inkling CI YAML changes. Other models, runners, and ROCm paths are unaffected.

## Validation

- `pre-commit run --all-files`
- `pytest -q test/ci_system` (`76 passed`)
- pipeline dry-run for `inkling-nvfp4-mtp-evalscope-gsm8k.yaml`
- live GB200 Slurm validation to follow