### PR TITLE
fix(ci): recompute test port to avoid port conflict

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -41,6 +41,7 @@ if is_in_amd_ci():
 if is_blackwell_system():
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH = 3000
 
+
 def _gpu_port_offset() -> int:
     gpu_ids = [
         int(g)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -41,14 +41,18 @@ if is_in_amd_ci():
 if is_blackwell_system():
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH = 3000
 
-if is_in_ci():
-    DEFAULT_PORT_FOR_SRT_TEST_RUNNER = (
-        10000 + int(os.environ.get("CUDA_VISIBLE_DEVICES", "0")[0]) * 2000
-    )
-else:
-    DEFAULT_PORT_FOR_SRT_TEST_RUNNER = (
-        20000 + int(os.environ.get("CUDA_VISIBLE_DEVICES", "0")[0]) * 1000
-    )
+def _gpu_port_offset() -> int:
+    gpu_ids = [
+        int(g)
+        for g in os.environ.get("CUDA_VISIBLE_DEVICES", "0").split(",")
+        if g.strip().isdigit()
+    ]
+    if not gpu_ids:
+        return 0
+    return min(gpu_ids) * 2 + (1 if len(gpu_ids) > 1 else 0)  # 0-15 on 8-GPU hosts
+
+
+DEFAULT_PORT_FOR_SRT_TEST_RUNNER = 16000 + _gpu_port_offset() * 1040
 DEFAULT_URL_FOR_TEST = f"http://127.0.0.1:{DEFAULT_PORT_FOR_SRT_TEST_RUNNER + 1000}"
 
 


### PR DESCRIPTION
## Summary
In some cases, different CI test runners may experience port conflicts, where two ZMQ sockets are mistakenly bound to the same port. This causes  one service to receive HTTP requests intended for another service, resulting in errors such as: `_pickle.UnpicklingError: invalid load key, '\x0d'. `This happens because the receiving end attempts to deserialize data that was never meant for it (e.g., raw HTTP request bytes instead of a valid pickled Python object), leading to a corrupted/invalid pickle stream. This PR tries to use separate ports for different runners to prevent such issues.
<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
