### PR TITLE
fix(ci): pass thinking config through per-request

### DIFF
--- a/test/ci_system/pd_http_worker.py
+++ b/test/ci_system/pd_http_worker.py
@@ -53,7 +53,9 @@ def _model_id() -> str:
 
 
 def _messages_to_text(
-    messages: list[dict[str, Any]], continue_final_message: bool = False
+    messages: list[dict[str, Any]],
+    continue_final_message: bool = False,
+    chat_template_kwargs: dict[str, Any] | None = None,
 ) -> str:
     tokenizer = getattr(async_llm, "tokenizer", None)
     if tokenizer is not None and hasattr(tokenizer, "apply_chat_template"):
@@ -62,7 +64,7 @@ def _messages_to_text(
                 messages,
                 tokenize=False,
                 add_generation_prompt=not continue_final_message,
-                enable_thinking=False,
+                **(chat_template_kwargs or {}),
             )
         except TypeError:
             try:
@@ -141,6 +143,7 @@ def _request_to_generate_input(data: dict[str, Any], *, rid: str) -> GenerateReq
         text = _messages_to_text(
             data["messages"],
             continue_final_message=bool(data.get("continue_final_message", False)),
+            chat_template_kwargs=data.get("chat_template_kwargs"),
         )
         input_ids = None
     else:

--- a/test/runtime/distributed/test_qwen35_pd_1p1d.py
+++ b/test/runtime/distributed/test_qwen35_pd_1p1d.py
@@ -84,6 +84,7 @@ def _chat(port: int, messages, max_tokens=64, temperature=0):
             "messages": messages,
             "max_tokens": max_tokens,
             "temperature": temperature,
+            "chat_template_kwargs": {"enable_thinking": False},
         },
         timeout=300,
     )


### PR DESCRIPTION
## Summary
Previously, `pd_http_worker` forcibly passed `enable_thinking=False`, which disabled the thinking mode for all requests. This caused low scores on the AIME25 benchmark. This PR moves the thinking-disable logic to be applied per-request via the chat template args, allowing thinking mode to be controlled on a per-request basis.

## Test Plan

<!-- How was this validated? -->
