### PR TITLE
fix(ci): skip apt install if pkg already installed

### DIFF
--- a/test/ci_system/install_deps.sh
+++ b/test/ci_system/install_deps.sh
@@ -117,8 +117,13 @@ echo "FlashInfer architecture: ${FI_ARCH}"
 # ============================================================
 # Step 2: Upgrade base tools
 # ============================================================
-run_as_root apt-get update
-run_as_root apt-get install -y openmpi-bin libopenmpi-dev libssl-dev pkg-config
+if ! dpkg -s openmpi-bin libopenmpi-dev libssl-dev pkg-config > /dev/null 2>&1; then
+    run_as_root apt-get -o DPkg::Lock::Timeout=600 update
+    run_as_root apt-get -o DPkg::Lock::Timeout=600 install -y \
+        openmpi-bin libopenmpi-dev libssl-dev pkg-config
+else
+    echo "apt packages already installed, skipping apt"
+fi
 echo "=== Step 2: Upgrade pip/setuptools/wheel ==="
 python3 -m pip install --upgrade --ignore-installed --break-system-packages \
     pip setuptools wheel


### PR DESCRIPTION
## Summary
This error occurs when running the CI install dependencies task.
```
=== Step 1: Determine CUDA index and architecture ===
PyTorch CUDA version: 13.0
PyTorch wheel index: cu130
FlashInfer architecture: 10.0a
Reading package lists...
E: Could not get lock /var/lib/apt/lists/lock. It is held by process 1520562 (apt-get)
E: Unable to lock directory /var/lib/apt/lists/
[pgm] run: finished pid=1520586 returncode=100 tracked_procs=0
[pgm] terminate_all: runner=ds-20260408-010-014-gb200-2gpu-1 tracked_procs=0
[pgm] terminate_all: no tracked procs but pgid file exists, killing pgids=[1520586]
```
Skip apt-get install if the required packages are already installed, and add a wait time for the dpkg lock to avoid contention.
<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
