### PR TITLE
deps: test TensorRT-LLM rc22 kernel wheel

### DIFF
--- a/tokenspeed-kernel/python/requirements/cuda-thirdparty.txt
+++ b/tokenspeed-kernel/python/requirements/cuda-thirdparty.txt
@@ -9,4 +9,4 @@ tokenspeed-fa4==4.0.0.post20260710
 nvidia-cutlass-dsl[cu13]==4.6.0
 quack-kernels>=0.6.1
 tokenspeed-triton-kernels==1.0.0.post20260510
-tokenspeed-trtllm-kernel==1.2.1.post20260427
+tokenspeed-trtllm-kernel==1.3.0rc22.post20260723


### PR DESCRIPTION
## Summary

- update the shared `tokenspeed-trtllm-kernel` pin from
  `1.2.1.post20260427` to `1.3.0rc22.post20260723`
- use the full TokenSpeed CI matrix to evaluate whether the new cu130 wheel is
  ready to become the shared dependency

This is a dependency-only compatibility probe. It does not change runtime or
kernel code.

## Context

The rc22 cu130 wheel has been published after passing the B200 standalone gates
and a TokenSpeed TP8 E2E run with 49/49 successful requests.

The currently published rc22 artifact covers CPython 3.12 on x86_64. Keep this
PR as Draft until the CI results establish the impact on the repository's CUDA,
architecture, and Python matrix. In particular, do not merge the shared pin
until cu129 and aarch64/non-3.12 behavior is understood.

## Validation

- `pre-commit run --all-files`
- published wheel:
  `tokenspeed-trtllm-kernel==1.3.0rc22.post20260723`
- frozen wheel SHA-256:
  `343fef81489ddd5818a541e106a8f9827f922787dc29ddcd42afa862766d95bc`
