### PR TITLE
perf(m3): avoid per-layer D2H sync in MSA prefill

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -295,10 +295,10 @@ def msa_extend_with_kvcache(
     attention_scale: float,
     init_blocks: int,
     local_blocks: int,
+    seq_lens_cpu: Sequence[int],
     k_scale: float | torch.Tensor | None = None,
     v_scale: float | torch.Tensor | None = None,
     query_lens_cpu: Sequence[int] | None = None,
-    seq_lens_cpu: Sequence[int] | None = None,
     override: str | None = None,
     solution: str | None = None,
 ) -> torch.Tensor:
@@ -335,7 +335,7 @@ def msa_extend_with_kvcache(
         query_lens_cpu: Optional host-side per-request new-token counts;
             with ``seq_lens_cpu`` this lets the indexer plan its fmha
             OnlyScore path without a device sync.
-        seq_lens_cpu: Optional host-side per-request total sequence lengths.
+        seq_lens_cpu: Host-side per-request total sequence lengths.
         override: Optional kernel override name.
         solution: Optional kernel solution to force through normal selection.
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/msa.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/msa.py
@@ -122,10 +122,10 @@ if platform.is_nvidia and platform.is_blackwell and _fmha_sm100_importable():
         attention_scale: float,
         init_blocks: int,
         local_blocks: int,
+        seq_lens_cpu: Sequence[int],
         k_scale: float | torch.Tensor | None = None,
         v_scale: float | torch.Tensor | None = None,
         query_lens_cpu: Sequence[int] | None = None,
-        seq_lens_cpu: Sequence[int] | None = None,
     ) -> torch.Tensor:
         """Run MiniMax sparse-attention extend with the CuTe attend kernel."""
 
@@ -197,11 +197,9 @@ if platform.is_nvidia and platform.is_blackwell and _fmha_sm100_importable():
         cu_seqlens_k = torch.nn.functional.pad(
             torch.cumsum(seqused_k, dim=0, dtype=torch.int32), (1, 0)
         )
-        # Exact packed KV-block row count for the CSR builder; the host read is
-        # a sync, acceptable on the eager extend path (vLLM computes the same
-        # value host-side in its metadata builder).
-        total_rows = int(torch.sum((seqused_k + page_size - 1) // page_size).item())
-
+        total_rows = sum(
+            (int(length) + page_size - 1) // page_size for length in seq_lens_cpu
+        )
         k2q_row_ptr, k2q_q_indices, schedule = build_k2q_csr(
             selected_blocks.transpose(0, 1),
             cu_seqlens_q,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_sparse_attention.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_sparse_attention.py
@@ -757,10 +757,10 @@ def triton_minimax_msa_extend_with_kvcache(
     attention_scale: float,
     init_blocks: int,
     local_blocks: int,
+    seq_lens_cpu: Sequence[int],
     k_scale: float | torch.Tensor | None = None,
     v_scale: float | torch.Tensor | None = None,
     query_lens_cpu: Sequence[int] | None = None,
-    seq_lens_cpu: Sequence[int] | None = None,
 ) -> torch.Tensor:
     """Run MiniMax sparse-attention extend over paged caches."""
 

--- a/tokenspeed-kernel/test/ops/test_attention_msa.py
+++ b/tokenspeed-kernel/test/ops/test_attention_msa.py
@@ -524,6 +524,7 @@ def test_msa_fp8_kv_descale_matches_dequant_reference(phase: str) -> None:
                 ),
                 max_seqlen_q=new_tokens,
                 max_seqlen_k=total_len,
+                seq_lens_cpu=[total_len],
             )
 
         got = op(
@@ -575,8 +576,11 @@ def _two_request_extend_case(kv_cache_dtype: torch.dtype):
     new_tokens = [7, 129]
     total_lens = [p + n for p, n in zip(prefix_lens, new_tokens)]
     num_blocks = [math.ceil(total / _BLOCK_SIZE) for total in total_lens]
+    total_kv_blocks = sum(num_blocks)
+    assert total_kv_blocks == 25
+    assert math.ceil(sum(total_lens) / _BLOCK_SIZE) == 24
     max_blocks = max(num_blocks)
-    num_pages = 1 + sum(num_blocks)  # Physical page zero is the dummy page.
+    num_pages = 1 + total_kv_blocks  # Physical page zero is the dummy page.
 
     block_table = torch.zeros((2, max_blocks), dtype=torch.int32, device="cuda")
     next_page = 1
@@ -641,6 +645,8 @@ def _two_request_extend_case(kv_cache_dtype: torch.dtype):
         attention_scale=_HEAD_DIM**-0.5,
         init_blocks=0,
         local_blocks=1,
+        query_lens_cpu=new_tokens,
+        seq_lens_cpu=total_lens,
     )
     return kwargs
 


### PR DESCRIPTION
## Summary

- require host-side total sequence lengths across the public MSA extend API and both registered implementations
- compute the CuTe MSA CSR `total_rows` from that host metadata
- cover ragged batches where `sum(ceil(seq_len / block))` differs from `ceil(sum(seq_len) / block)`

## Root cause

The CuTe MSA extend path calculated its packed KV-block row count with a CUDA reduction followed by `.item()`. MiniMax M3 executes this once per sparse layer during prefill, so the host waited for the device repeatedly before launching the sparse attention CSR builder.

The runtime always provides per-request `seq_lens_cpu` from the same metadata used to build device `cache_seqlens`. MSA extend now requires that host metadata, making the sync-free planning contract explicit instead of retaining a device fallback.

## Performance

Measured with MiniMax-M3-NVFP4 on 4x NVIDIA B200, TP4, random 8K input / 32 output, concurrency 1, 20 prompts, three rounds. The first round was excluded for compilation/autotune.

| Metric | main | patch | Delta |
| --- | ---: | ---: | ---: |
| Median TTFT, stable-round average | 218.53 ms | 207.77 ms | -10.76 ms (-4.92%) |
| Median TPOT, stable-round average | 3.625 ms | 3.645 ms | +0.020 ms (+0.54%, noise) |

Per-rank prefill traces changed as follows:

- 8-byte D2H transfers: 57 -> 0
- `cudaStreamSynchronize`: 58 -> 1
- target int32 ceil-div/reduction kernels: 57 -> 0

Decode is unchanged, so TPOT is expected to remain flat.

## Reproduction

Server:

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3 tokenspeed serve nvidia/MiniMax-M3-NVFP4 \
  --tensor-parallel-size 4 \
  --max-model-len 81920 \
  --max-prefill-tokens 8192 \
  --chunked-prefill-size 8192 \
  --block-size 128 \
  --attention-backend trtllm \
  --moe-backend flashinfer_trtllm \
  --disable-prefill-graph \
  --disable-cuda-graph-padding \
  --disable-kvstore \
  --no-enable-prefix-caching \
  --trust-remote-code
```

Benchmark (run three times and compare rounds 2-3):

```bash
tokenspeed bench serve \
  --backend openai \
  --model nvidia/MiniMax-M3-NVFP4 \
  --dataset-name random \
  --random-input-len 8192 \
  --random-output-len 32 \
  --random-range-ratio 0 \
  --num-prompts 20 \
  --max-concurrency 1 \
  --seed 0 \
  --ignore-eos \
  --extra-body '{"temperature": 0}'
```

## Correctness and validation

- host and previous GPU formulas matched exactly across 100,000 randomized ragged batches
- same-input output from the host-derived path was bitwise identical to the previous device-derived path for BF16 and FP8-E4M3 KV caches
- latest-main versus patch BF16 MSA extend output was bitwise identical
- `tokenspeed-kernel/test/ops/test_attention_msa.py`: 16 passed
- `test/runtime/models/test_minimax_m3.py`: 7 passed
- `pre-commit run --all-files`: passed