### PR TITLE
feat(dspark): Add DSpark support

### DIFF
--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -738,7 +738,7 @@ class EventLoop:
         local_has_work = bool(
             self._num_inflight_cache_ops != 0 or self._pending_cache_event_payloads
         )
-        if self.server_args.speculative_algorithm == "DFLASH":
+        if self.server_args.speculative_algorithm in ("DFLASH", "DSPARK"):
             if not self._cache_group_has_work(local_has_work):
                 return
         else:

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -1060,7 +1060,7 @@ class CudaGraphWrapper:
         pad = padded_bs - active_req_pool_indices.shape[0]
         if pad <= 0:
             return active_req_pool_indices
-        if self.config.spec_algo == "DFLASH":
+        if self.config.spec_algo in ("DFLASH", "DSPARK"):
             # Route padding rows to the sentinel req-pool slot
             # (max_req_pool_size), not slot 0. The DFLASH draft derives each
             # row's block seq_len from valid_cache_lengths[req_pool], so

--- a/python/tokenspeed/runtime/execution/drafter/dflash.py
+++ b/python/tokenspeed/runtime/execution/drafter/dflash.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 import torch
 
@@ -235,6 +235,16 @@ class DFlash(BaseDrafter):
         hidden_states: torch.Tensor,
         out: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        return self._greedy_argmax_vocab_parallel(hidden_states, out=out)
+
+    def _greedy_argmax_vocab_parallel(
+        self,
+        hidden_states: torch.Tensor,
+        out: torch.Tensor | None = None,
+        bias_fn: "Callable[[int, int], torch.Tensor] | None" = None,
+    ) -> torch.Tensor:
+        """Shared vocab-parallel greedy argmax primitive.
+        """
         if not hasattr(self.lm_head, "weight") or not hasattr(
             self.lm_head, "shard_indices"
         ):
@@ -242,6 +252,8 @@ class DFlash(BaseDrafter):
             logits = self.logits_processor._get_logits(
                 hidden_states, self.lm_head, metadata
             )
+            if bias_fn is not None:
+                logits = logits + bias_fn(0, int(logits.shape[-1])).to(logits.dtype)
             argmax = torch.argmax(logits, dim=-1)
             if out is not None:
                 out.copy_(argmax.view_as(out))
@@ -261,6 +273,10 @@ class DFlash(BaseDrafter):
         chunk_len = int(hidden_states.shape[0])
         if num_org > 0:
             base_logits = torch.matmul(hidden_states, weight[:num_org].T)
+            if bias_fn is not None:
+                base_logits = base_logits + bias_fn(
+                    org_vocab_start, num_org
+                ).to(base_logits.dtype)
             local_max, local_arg = torch.max(base_logits, dim=-1)
         else:
             local_max = torch.full(
@@ -278,6 +294,10 @@ class DFlash(BaseDrafter):
             added_end = num_org_padded + num_added
             added_weight = weight[added_start:added_end]
             added_logits = torch.matmul(hidden_states, added_weight.T)
+            if bias_fn is not None:
+                added_logits = added_logits + bias_fn(
+                    added_vocab_start, num_added
+                ).to(added_logits.dtype)
             added_max, added_arg = torch.max(added_logits, dim=-1)
             use_added = added_max > local_max
             local_max = torch.where(use_added, added_max, local_max)
@@ -895,6 +915,15 @@ class DFlash(BaseDrafter):
         draft_hidden = draft_hidden.view(bs, self.spec_num_tokens, self.hidden_size)
 
         next_tokens = self.next_tokens_buf[:bs]
+        return self._sample_block(draft_hidden, block_ids, next_tokens)
+
+    def _sample_block(
+        self,
+        draft_hidden: torch.Tensor,
+        block_ids: torch.Tensor,
+        next_tokens: torch.Tensor,
+    ) -> torch.Tensor:
+        """Sample the block draft tokens from the draft hidden states."""
         next_tokens[:, 0] = block_ids[:, 0]
         self._greedy_sample_from_vocab_parallel_head(
             draft_hidden[:, 1:, :].reshape(-1, self.hidden_size),

--- a/python/tokenspeed/runtime/execution/drafter/dflash.py
+++ b/python/tokenspeed/runtime/execution/drafter/dflash.py
@@ -88,16 +88,22 @@ class DFlash(BaseDrafter):
 
         cfg = self.model.config
         dflash_cfg = getattr(cfg, "dflash_config", {}) or {}
-        self.target_layer_ids = [int(x) for x in dflash_cfg.get("target_layer_ids", [])]
+        target_layer_ids = dflash_cfg.get("target_layer_ids") or getattr(
+            cfg, "target_layer_ids", None
+        )
+        self.target_layer_ids = [int(x) for x in (target_layer_ids or [])]
         if not self.target_layer_ids:
             raise ValueError(
                 "DFLASH draft config must define dflash_config.target_layer_ids."
             )
-        if "mask_token_id" not in dflash_cfg:
+        mask_token_id = dflash_cfg.get("mask_token_id")
+        if mask_token_id is None:
+            mask_token_id = getattr(cfg, "mask_token_id", None)
+        if mask_token_id is None:
             raise ValueError(
                 "DFLASH draft config must define dflash_config.mask_token_id."
             )
-        self.mask_token_id = int(dflash_cfg["mask_token_id"])
+        self.mask_token_id = int(mask_token_id)
         self.block_size = int(getattr(cfg, "block_size", spec_num_tokens))
         if self.block_size != int(spec_num_tokens):
             logger.warning(

--- a/python/tokenspeed/runtime/execution/drafter/dflash.py
+++ b/python/tokenspeed/runtime/execution/drafter/dflash.py
@@ -17,7 +17,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import torch
 

--- a/python/tokenspeed/runtime/execution/drafter/dflash.py
+++ b/python/tokenspeed/runtime/execution/drafter/dflash.py
@@ -249,8 +249,7 @@ class DFlash(BaseDrafter):
         out: torch.Tensor | None = None,
         bias_fn: "Callable[[int, int], torch.Tensor] | None" = None,
     ) -> torch.Tensor:
-        """Shared vocab-parallel greedy argmax primitive.
-        """
+        """Shared vocab-parallel greedy argmax primitive."""
         if not hasattr(self.lm_head, "weight") or not hasattr(
             self.lm_head, "shard_indices"
         ):
@@ -280,9 +279,9 @@ class DFlash(BaseDrafter):
         if num_org > 0:
             base_logits = torch.matmul(hidden_states, weight[:num_org].T)
             if bias_fn is not None:
-                base_logits = base_logits + bias_fn(
-                    org_vocab_start, num_org
-                ).to(base_logits.dtype)
+                base_logits = base_logits + bias_fn(org_vocab_start, num_org).to(
+                    base_logits.dtype
+                )
             local_max, local_arg = torch.max(base_logits, dim=-1)
         else:
             local_max = torch.full(
@@ -301,9 +300,9 @@ class DFlash(BaseDrafter):
             added_weight = weight[added_start:added_end]
             added_logits = torch.matmul(hidden_states, added_weight.T)
             if bias_fn is not None:
-                added_logits = added_logits + bias_fn(
-                    added_vocab_start, num_added
-                ).to(added_logits.dtype)
+                added_logits = added_logits + bias_fn(added_vocab_start, num_added).to(
+                    added_logits.dtype
+                )
             added_max, added_arg = torch.max(added_logits, dim=-1)
             use_added = added_max > local_max
             local_max = torch.where(use_added, added_max, local_max)

--- a/python/tokenspeed/runtime/execution/drafter/dspark.py
+++ b/python/tokenspeed/runtime/execution/drafter/dspark.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Static DSpark drafter.
+
+This is the minimal static configuration: greedy sampling, vanilla Markov head,
+fixed verify window (verify-all). No confidence head / SPS-STS / ragged verify.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from tokenspeed.runtime.execution.drafter.dflash import DFlash
+from tokenspeed.runtime.utils import get_colorful_logger
+from tokenspeed.runtime.utils.nvtx import nvtx_range
+
+logger = get_colorful_logger(__name__)
+
+
+class DSpark(DFlash):
+    """DFlash block drafter + a Markov head (semi-autoregressive proposal)."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.markov_head = getattr(self.model, "markov_head", None)
+        if self.markov_head is None:
+            raise ValueError(
+                "DSPARK requires the draft model to define a markov_head "
+                "(use a DSparkDraftModel checkpoint with markov_rank > 0)."
+            )
+
+    @nvtx_range("dspark_sample_block", color="purple")
+    def _sample_block(
+        self,
+        draft_hidden: torch.Tensor,
+        block_ids: torch.Tensor,
+        next_tokens: torch.Tensor,
+    ) -> torch.Tensor:
+        """Semi-autoregressive greedy proposal over the block positions.
+
+        Position 0 is the (known) anchor token. For position ``k`` in
+        ``1 .. spec_num_tokens - 1`` the base logits from the draft hidden state
+        are corrected by the Markov bias conditioned on the previously sampled
+        token ``next_tokens[:, k - 1]``, then argmax'd.
+        """
+        next_tokens[:, 0] = block_ids[:, 0]
+        for k in range(1, self.spec_num_tokens):
+            bias_fn = self._make_step_bias_fn(next_tokens[:, k - 1])
+            self._greedy_argmax_vocab_parallel(
+                draft_hidden[:, k, :],
+                out=next_tokens[:, k],
+                bias_fn=bias_fn,
+            )
+        next_tokens.clamp_(min=0)
+        return next_tokens
+
+    def _make_step_bias_fn(self, prev_tokens: torch.Tensor):
+        """Build the per-position additive-bias hook for the Markov head.
+
+        Returns a closure ``bias_fn(vocab_start, count) -> [rows, count]`` that
+        supplies the Markov correction for a requested global vocab slice.
+
+        The Markov head only spans the original vocab (``markov_w2`` has
+        ``vocab_size`` rows). Any part of a requested slice that falls beyond
+        that range -- i.e. the target LM head's *added* vocab shard -- gets a
+        zero bias, so added tokens keep their plain base logit and only compete
+        unbiased.
+        """
+        latent = self.markov_head.get_prev_latent(prev_tokens)
+        w2_weight = self.markov_head.markov_w2.weight
+        vocab_size = int(w2_weight.shape[0])
+        rows = int(latent.shape[0])
+
+        def bias_fn(vocab_start: int, count: int) -> torch.Tensor:
+            end = vocab_start + count
+            # Fast path: slice fully inside the Markov (org) vocab.
+            if vocab_start >= 0 and end <= vocab_size:
+                w2_slice = w2_weight[vocab_start:end]
+                return torch.matmul(latent.to(w2_slice.dtype), w2_slice.T)
+            # Partial / added-vocab slice: bias only the org intersection,
+            # zero elsewhere.
+            bias = latent.new_zeros((rows, count))
+            lo = max(vocab_start, 0)
+            hi = min(end, vocab_size)
+            if hi > lo:
+                w2_slice = w2_weight[lo:hi]
+                real = torch.matmul(latent.to(w2_slice.dtype), w2_slice.T)
+                bias[:, lo - vocab_start : hi - vocab_start] = real.to(bias.dtype)
+            return bias
+
+        return bias_fn

--- a/python/tokenspeed/runtime/execution/drafter/dspark.py
+++ b/python/tokenspeed/runtime/execution/drafter/dspark.py
@@ -51,18 +51,12 @@ class DSpark(DFlash):
         block_ids: torch.Tensor,
         next_tokens: torch.Tensor,
     ) -> torch.Tensor:
-        """Semi-autoregressive greedy proposal over the block positions.
-
-        Position 0 is the (known) anchor token. For position ``k`` in
-        ``1 .. spec_num_tokens - 1`` the base logits from the draft hidden state
-        are corrected by the Markov bias conditioned on the previously sampled
-        token ``next_tokens[:, k - 1]``, then argmax'd.
-        """
+        """Semi-autoregressive greedy proposal over the block positions."""
         next_tokens[:, 0] = block_ids[:, 0]
         for k in range(1, self.spec_num_tokens):
             bias_fn = self._make_step_bias_fn(next_tokens[:, k - 1])
             self._greedy_argmax_vocab_parallel(
-                draft_hidden[:, k, :],
+                draft_hidden[:, k - 1, :],
                 out=next_tokens[:, k],
                 bias_fn=bias_fn,
             )

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -50,6 +50,7 @@ from tokenspeed.runtime.execution.cache_loc_kernel import update_block_table
 from tokenspeed.runtime.execution.context import ForwardContext
 from tokenspeed.runtime.execution.cuda_graph_wrapper import CudaGraphWrapper
 from tokenspeed.runtime.execution.drafter.dflash import DFlash
+from tokenspeed.runtime.execution.drafter.dspark import DSpark
 from tokenspeed.runtime.execution.drafter.eagle import Eagle
 from tokenspeed.runtime.execution.drafter.mtp import Mtp
 from tokenspeed.runtime.execution.forward_batch_info import (
@@ -100,7 +101,7 @@ def _get_drafter_impl(spec_algo: str, model: torch.nn.Module):
         InklingForConditionalGenerationNextN,
     )
 
-    DRAFTER_MAPPING = {"EAGLE3": Eagle, "MTP": Eagle, "DFLASH": DFlash}
+    DRAFTER_MAPPING = {"EAGLE3": Eagle, "MTP": Eagle, "DFLASH": DFlash, "DSPARK": DSpark}
 
     # "MTP" covers two algorithms:
     # (1) Eagle-like MTP (e.g. DeepSeek) stays on Eagle in eagle.py;
@@ -335,7 +336,9 @@ class ModelExecutor:
             # out of bounds, hanging the attention kernel. Pad generously; a few
             # int32 columns per request. Non-DFLASH algorithms do not need this.
             draft_block_reservation_slack = (
-                config.spec_num_tokens * 64 if config.spec_algo == "DFLASH" else 0
+                config.spec_num_tokens * 64
+                if config.spec_algo in ("DFLASH", "DSPARK")
+                else 0
             )
             max_num_pages_per_req = (
                 config.context_len
@@ -420,7 +423,7 @@ class ModelExecutor:
                     draft_model_runner.model_config.hf_config
                 )
                 self.model_runner.model.set_eagle3_layers_to_capture(aux_layer_ids)
-            if config.spec_algo == "DFLASH":
+            if config.spec_algo in ("DFLASH", "DSPARK"):
                 if not hasattr(self.model_runner.model, "set_dflash_layers_to_capture"):
                     raise ValueError(
                         "DFLASH requires the target model to support "
@@ -916,7 +919,7 @@ class ModelExecutor:
             accept_lengths = self._apply_force_single_token_verify(
                 accept_lengths, 0, num_decodes, ctx.decode_input_ids
             )
-            if self.config.spec_algo == "DFLASH":
+            if self.config.spec_algo in ("DFLASH", "DSPARK"):
                 accept_lengths = self._cap_accept_to_context_len(
                     accept_lengths, sampling_info.req_pool_indices[:num_decodes]
                 )
@@ -934,7 +937,7 @@ class ModelExecutor:
         decode_accept = self._apply_force_single_token_verify(
             decode_accept, num_extends, num_decodes, ctx.decode_input_ids
         )
-        if self.config.spec_algo == "DFLASH":
+        if self.config.spec_algo in ("DFLASH", "DSPARK"):
             decode_accept = self._cap_accept_to_context_len(
                 decode_accept, sampling_info.req_pool_indices[num_extends:]
             )
@@ -1676,7 +1679,7 @@ class ModelExecutor:
                             time.perf_counter() - forward_step_start
                         ) * 1000.0
 
-                if self.config.spec_algo == "DFLASH":
+                if self.config.spec_algo in ("DFLASH", "DSPARK"):
                     # Clamp the committed-length delta so no request grows past
                     # context_len. Done here (outside the graph) so it reaches
                     # both _update_runtime_state and the scheduler page

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -101,7 +101,12 @@ def _get_drafter_impl(spec_algo: str, model: torch.nn.Module):
         InklingForConditionalGenerationNextN,
     )
 
-    DRAFTER_MAPPING = {"EAGLE3": Eagle, "MTP": Eagle, "DFLASH": DFlash, "DSPARK": DSpark}
+    DRAFTER_MAPPING = {
+        "EAGLE3": Eagle,
+        "MTP": Eagle,
+        "DFLASH": DFlash,
+        "DSPARK": DSpark,
+    }
 
     # "MTP" covers two algorithms:
     # (1) Eagle-like MTP (e.g. DeepSeek) stays on Eagle in eagle.py;

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -319,6 +319,7 @@ class ModelExecutor:
         self._mirror_idx_cpu: torch.Tensor | None = None
         self._mirror_idx_dev: torch.Tensor | None = None
         self._mirror_row_buf: torch.Tensor | None = None
+        self._mirror_for_block_draft = config.spec_algo in ("DFLASH", "DSPARK")
         self.draft_attn_backend = draft_attn_backend
         self.draft_token_to_kv_pool = draft_token_to_kv_pool
 
@@ -751,10 +752,14 @@ class ModelExecutor:
     ) -> None:
         """Expose the full-history table to ordinary speculative consumers."""
         if (
-            self._cache_runtime_contract is not None
-            or self.drafter is None
+            self.drafter is None
             or not block_tables
             or self._full_history_group_id is None
+        ):
+            return
+        if (
+            self._cache_runtime_contract is not None
+            and not self._mirror_for_block_draft
         ):
             return
         table = block_tables.get(self._full_history_group_id)
@@ -1507,6 +1512,10 @@ class ModelExecutor:
                     num_requests=bs,
                 )
                 block_tables = dict(cache_metadata.tables(active_forward_op=forward_op))
+                # A block-decode drafter mirrors page tables.
+                self._mirror_full_history_table_into_req_to_page(
+                    forward_op, block_tables
+                )
             else:
                 block_tables = block_tables_from_forward_op(
                     forward_op,

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -559,9 +559,9 @@ class TRTLLMMHAAttnBackend(CacheGroupsMixin, AttentionBackend):
 
     def _reads_mirrored_logical_pages(self) -> bool:
         """True when req_to_page holds mirrored scheduler (logical) page ids."""
-        logical = self._cache_logical_page_size
+        logical = getattr(self, "_cache_logical_page_size", None)
         return (
-            self._cache_contract_bound
+            getattr(self, "_cache_contract_bound", False)
             and logical is not None
             and logical != self.page_size
         )

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -50,6 +50,7 @@ from tokenspeed.runtime.layers.attention.backends.cache_groups import (
     CacheGroupsMixin,
 )
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
+from tokenspeed.runtime.layers.attention.page_table import expand_page_table
 from tokenspeed.runtime.layers.attention.registry import register_backend
 from tokenspeed.runtime.layers.common import fp8_cast_contiguous
 from tokenspeed.runtime.utils import get_colorful_logger
@@ -145,9 +146,13 @@ class TRTLLMMHAAttnBackend(CacheGroupsMixin, AttentionBackend):
 
         self.page_size = config.page_size
         self.group_page_sizes = dict(getattr(config, "group_page_sizes", None) or {})
+        self._cache_contract_bound = False
+        self._cache_logical_page_size: int | None = None
+        self._block_expand_buf: torch.Tensor | None = None
         self.max_context_len = config.context_len
         self.kv_cache_dtype = config.kv_cache_dtype
         max_bs = config.max_bs
+        self._max_bs = max_bs
 
         # Shared workspace buffer (allocated once per process).
         global _global_workspace_buffer
@@ -216,10 +221,17 @@ class TRTLLMMHAAttnBackend(CacheGroupsMixin, AttentionBackend):
         """Build page table in [bs, max_pages] format from req_to_page.
 
         req_to_page is [req_pool_size+1, max_pages] containing page IDs.
+        A paged-cache-contract draft receives mirrored scheduler (logical)
+        page ids instead and expands them into kernel pages first.
         """
-        page_table_buf[:bs].copy_(
-            req_to_page[req_pool_indices[:bs], : self.max_num_pages]
-        )
+        if self._reads_mirrored_logical_pages():
+            page_table_buf[:bs].copy_(
+                self._expand_mirrored_page_table(req_pool_indices, bs, req_to_page)
+            )
+        else:
+            page_table_buf[:bs].copy_(
+                req_to_page[req_pool_indices[:bs], : self.max_num_pages]
+            )
         return page_table_buf[:bs]
 
     # ------------------------------------------------------------------
@@ -539,6 +551,40 @@ class TRTLLMMHAAttnBackend(CacheGroupsMixin, AttentionBackend):
             out_cache_locs=group_out_cache_locs,
         )
 
+    def mark_cache_contract(self, logical_page_size: int | None = None) -> None:
+        """Record that the pool runs on the paged cache contract."""
+        self._cache_contract_bound = True
+        if logical_page_size is not None:
+            self._cache_logical_page_size = int(logical_page_size)
+
+    def _reads_mirrored_logical_pages(self) -> bool:
+        """True when req_to_page holds mirrored scheduler (logical) page ids."""
+        logical = self._cache_logical_page_size
+        return (
+            self._cache_contract_bound
+            and logical is not None
+            and logical != self.page_size
+        )
+
+    def _expand_mirrored_page_table(
+        self, req_pool_indices: torch.Tensor, bs: int, req_to_page: torch.Tensor
+    ) -> torch.Tensor:
+        """Expand mirrored logical page ids into kernel pages ([bs, max_num_pages])."""
+        if self._block_expand_buf is None:
+            with torch.inference_mode(False):
+                self._block_expand_buf = torch.zeros(
+                    (self._max_bs, self.max_num_pages),
+                    dtype=req_to_page.dtype,
+                    device=req_to_page.device,
+                )
+        return expand_page_table(
+            req_to_page[req_pool_indices[:bs]],
+            logical_page_size=self._cache_logical_page_size,
+            kernel_page_size=self.page_size,
+            max_kernel_pages=self.max_num_pages,
+            out=self._block_expand_buf,
+        )
+
     def _replicate_block_page_table(
         self,
         out: torch.Tensor,
@@ -546,14 +592,16 @@ class TRTLLMMHAAttnBackend(CacheGroupsMixin, AttentionBackend):
         bs: int,
         req_to_page: torch.Tensor,
     ) -> None:
-        """Replicate each request's page table to its spec_num_tokens block rows.
-
-        ``out`` is the [bs*spec_num_tokens, max_num_pages] destination. All block
-        rows of a request share its pages (decode only reads KV), so a single
-        broadcast copy suffices.
-        """
+        """Replicate each request's page table to its spec_num_tokens block rows."""
         spec = self.spec_num_tokens
-        base_page_table = req_to_page[req_pool_indices[:bs], : self.max_num_pages]
+
+        if self._reads_mirrored_logical_pages():
+            base_page_table = self._expand_mirrored_page_table(
+                req_pool_indices, bs, req_to_page
+            )
+        else:
+            base_page_table = req_to_page[req_pool_indices[:bs], : self.max_num_pages]
+
         out[: bs * spec, :].view(bs, spec, self.max_num_pages).copy_(
             base_page_table[:, None, :]
         )
@@ -914,12 +962,11 @@ class TRTLLMMHAAttnBackend(CacheGroupsMixin, AttentionBackend):
                 f"trtllm CUDA graph replay not supported for {forward_mode}"
             )
 
-        # Fail loudly instead of replaying over stale/zero page tables.
-        self._replay_stale_guard(bs, block_tables)
-
         if self.draft_block_decode and self.spec_num_tokens > 1:
             # DFLASH draft block: replicate the page table to each request's
             # block rows. seq_lens are re-derived in-graph, so not touched here.
+            # The per-group stale guard doesn't apply: block-decode capture
+            # records only cuda_graph_page_table, refilled right here.
             if req_to_page is not None:
                 self._replicate_block_page_table(
                     self.cuda_graph_page_table, req_pool_indices, bs, req_to_page
@@ -927,6 +974,9 @@ class TRTLLMMHAAttnBackend(CacheGroupsMixin, AttentionBackend):
             if bs in self.cuda_graph_decode_metadata:
                 self.forward_decode_metadata = self.cuda_graph_decode_metadata[bs]
             return
+
+        # Fail loudly instead of replaying over stale/zero page tables.
+        self._replay_stale_guard(bs, block_tables)
 
         # Copy the live cache lengths into our own buffer (the plain-decode and
         # draft-decode metadata view cuda_graph_cache_seqlens); the spec>1 verify

--- a/python/tokenspeed/runtime/layers/attention/configs/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/mha.py
@@ -64,7 +64,7 @@ class MHAConfig(BaseAttnConfig):
             )
         kv_cache_dtype = server_args.kv_cache_dtype
         draft_block_decode = bool(
-            is_draft and server_args.speculative_algorithm == "DFLASH"
+            is_draft and server_args.speculative_algorithm in ("DFLASH", "DSPARK")
         )
         if draft_block_decode and server_args.drafter_attention_backend != "trtllm":
             kv_cache_dtype = "bfloat16"

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -20,6 +20,7 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
 import os
 from typing import TYPE_CHECKING
@@ -1386,6 +1387,18 @@ def create_attn_components(
             )
 
     _validate_shared_lcm_geometry(pool, draft_pool)
+    
+    if (
+        draft_attn_backend is not None
+        and getattr(draft_pool, "_lcm_memory_plan", None) is not None
+    ):
+        draft_mark_contract = getattr(draft_attn_backend, "mark_cache_contract", None)
+        if draft_mark_contract is not None:
+            params = inspect.signature(draft_mark_contract).parameters
+            if "logical_page_size" in params:
+                draft_mark_contract(logical_page_size=int(draft_pool.page_size))
+            else:
+                draft_mark_contract()
     if use_lcm_gdn and fixed_workspace_bytes:
         actual_workspace_bytes = (
             backend.linear_attn_backend.preallocate_verify_workspace(

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -1387,7 +1387,7 @@ def create_attn_components(
             )
 
     _validate_shared_lcm_geometry(pool, draft_pool)
-    
+
     if (
         draft_attn_backend is not None
         and getattr(draft_pool, "_lcm_memory_plan", None) is not None

--- a/python/tokenspeed/runtime/models/dflash.py
+++ b/python/tokenspeed/runtime/models/dflash.py
@@ -380,8 +380,8 @@ class DFlashDraftModel(nn.Module):
         )
         self.norm = RMSNorm(int(config.hidden_size), eps=eps)
         target_layer_ids = (getattr(config, "dflash_config", {}) or {}).get(
-            "target_layer_ids", []
-        )
+            "target_layer_ids"
+        ) or (getattr(config, "target_layer_ids", None) or [])
         self.num_context_features = len(target_layer_ids)
         self.fc = nn.Linear(
             self.num_context_features * int(config.hidden_size),

--- a/python/tokenspeed/runtime/models/dspark.py
+++ b/python/tokenspeed/runtime/models/dspark.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Static DSpark draft model.
+
+The backbone, target-hidden projection, KV injection and block forward are 
+all inherited unchanged from ``DFlashDraftModel``; the only addition is a 
+per-position Markov head that turns the parallel mask-forward proposal into 
+a semi-autoregressive one by adding a bigram-style bias to the base logits before sampling.
+
+This module implements the minimal static configuration: the ``vanilla``
+Markov head only (no confidence head, no gated/rnn heads, no
+confidence-scheduled ragged verify).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from torch import nn
+
+from tokenspeed.runtime.distributed.mapping import Mapping
+from tokenspeed.runtime.layers.quantization.base_config import QuantizationConfig
+from tokenspeed.runtime.models.dflash import DFlashDraftModel
+
+SUPPORTED_MARKOV_HEAD_TYPES = ("vanilla",)
+
+
+class VanillaMarkov(nn.Module):
+
+    markov_head_type = "vanilla"
+
+    def __init__(self, *, vocab_size: int, markov_rank: int) -> None:
+        super().__init__()
+        self.vocab_size = int(vocab_size)
+        self.markov_rank = int(markov_rank)
+        if self.markov_rank <= 0:
+            raise ValueError(
+                f"VanillaMarkov requires markov_rank > 0, got {self.markov_rank}."
+            )
+        self.markov_w1 = nn.Embedding(self.vocab_size, self.markov_rank)
+        self.markov_w2 = nn.Linear(self.markov_rank, self.vocab_size, bias=False)
+
+    def get_prev_latent(self, token_ids: torch.Tensor) -> torch.Tensor:
+        """Look up the rank-space latent for the previous token(s)."""
+        return self.markov_w1(token_ids.long())
+
+    def project_bias(self, latent_states: torch.Tensor) -> torch.Tensor:
+        return self.markov_w2(latent_states)
+
+    def compute_step_bias(self, token_ids: torch.Tensor) -> torch.Tensor:
+        """Full-vocab bias for one block position given the previous token."""
+        return self.project_bias(self.get_prev_latent(token_ids))
+
+
+def _get_markov_params(config: Any) -> tuple[int, str]:
+    dspark_cfg = getattr(config, "dspark_config", None) or {}
+
+    def pick(key: str, default: Any = None) -> Any:
+        if isinstance(dspark_cfg, dict) and key in dspark_cfg:
+            return dspark_cfg[key]
+        return getattr(config, key, default)
+
+    markov_rank = int(pick("markov_rank", 0) or 0)
+    markov_head_type = str(pick("markov_head_type", "vanilla") or "vanilla").lower()
+    return markov_rank, markov_head_type
+
+
+class DSparkDraftModel(DFlashDraftModel):
+    """DFlash draft backbone augmented with a (vanilla) Markov head.
+
+    Everything except the Markov head is inherited from ``DFlashDraftModel``.
+    The Markov head weights (``markov_head.markov_w1`` / ``markov_head.markov_w2``)
+    are plain replicated modules, so the inherited ``load_weights`` loads them
+    via the default weight loader without extra routing.
+    """
+
+    def __init__(
+        self,
+        config,
+        mapping: Mapping,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(
+            config=config,
+            mapping=mapping,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+        markov_rank, markov_head_type = _get_markov_params(config)
+        if markov_rank <= 0:
+            raise ValueError(
+                "DSpark draft requires markov_rank > 0 (the Markov head is the "
+                f"core of the semi-AR draft); got markov_rank={markov_rank}."
+            )
+        if markov_head_type not in SUPPORTED_MARKOV_HEAD_TYPES:
+            raise ValueError(
+                f"Unsupported DSpark markov_head_type={markov_head_type!r}; this "
+                f"static build only supports {SUPPORTED_MARKOV_HEAD_TYPES}."
+            )
+        vocab_size = getattr(config, "vocab_size", None)
+        if vocab_size is None:
+            raise ValueError(
+                "DSpark draft config must define vocab_size for the Markov head."
+            )
+        self.markov_head = VanillaMarkov(
+            vocab_size=int(vocab_size), markov_rank=markov_rank
+        )
+
+
+EntryClass = [DSparkDraftModel]

--- a/python/tokenspeed/runtime/models/dspark.py
+++ b/python/tokenspeed/runtime/models/dspark.py
@@ -20,9 +20,9 @@
 
 """Static DSpark draft model.
 
-The backbone, target-hidden projection, KV injection and block forward are 
-all inherited unchanged from ``DFlashDraftModel``; the only addition is a 
-per-position Markov head that turns the parallel mask-forward proposal into 
+The backbone, target-hidden projection, KV injection and block forward are
+all inherited unchanged from ``DFlashDraftModel``; the only addition is a
+per-position Markov head that turns the parallel mask-forward proposal into
 a semi-autoregressive one by adding a bigram-style bias to the base logits before sampling.
 
 This module implements the minimal static configuration: the ``vanilla``

--- a/python/tokenspeed/runtime/utils/hf_transformers_utils.py
+++ b/python/tokenspeed/runtime/utils/hf_transformers_utils.py
@@ -272,9 +272,17 @@ def get_config(
     if (
         is_draft_worker
         and config.architectures
+        and config.architectures[0].startswith("Qwen3DSparkModel")
+    ):
+        config.architectures[0] = "DSparkDraftModel"
+
+    if (
+        is_draft_worker
+        and config.architectures
         and "NextN" not in config.architectures[0]
         and "Eagle" not in config.architectures[0]
         and "DFlash" not in config.architectures[0]
+        and "DSpark" not in config.architectures[0]
     ):
         if config.architectures[0] == "MiniMaxM2ForCausalLM":
             config.architectures[0] = "LlamaForCausalLMEagle3"

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -390,7 +390,7 @@ class ServerArgs:
             num_speculative_tokens = config.get("num_speculative_tokens")
             if num_speculative_tokens is not None:
                 num_speculative_tokens = int(num_speculative_tokens)
-                if self.speculative_algorithm == "DFLASH":
+                if self.speculative_algorithm in ("DFLASH", "DSPARK"):
                     if self.speculative_num_draft_tokens is None:
                         self.speculative_num_draft_tokens = num_speculative_tokens
                     self.speculative_num_steps = max(num_speculative_tokens - 1, 0)
@@ -643,7 +643,7 @@ class ServerArgs:
         if self.speculative_draft_model_quantization == "unquant":
             self.speculative_draft_model_quantization = None
 
-        if self.speculative_algorithm == "DFLASH":
+        if self.speculative_algorithm in ("DFLASH", "DSPARK"):
             expected_steps = max(int(self.speculative_num_draft_tokens) - 1, 0)
             if self.speculative_num_steps == ServerArgs.speculative_num_steps:
                 self.speculative_num_steps = expected_steps
@@ -1595,7 +1595,7 @@ class ServerArgs:
         parser.add_argument(
             "--speculative-algorithm",
             type=str,
-            choices=["EAGLE3", "MTP", "DFLASH"],
+            choices=["EAGLE3", "MTP", "DFLASH", "DSPARK"],
             help="Speculative algorithm.",
         )
         parser.add_argument(


### PR DESCRIPTION
## Summary
<!-- What changed and why? -->
- Add initial `DSPARK` speculative decoding support for Qwen3.5 draft checkpoints, reusing the DFlash block drafter path with a vanilla Markov head for semi-autoregressive token proposals.
- Introduce `DSparkDraftModel` / `DSpark` runtime wiring, config remapping for `Qwen3DSparkModel`, and `--speculative-algorithm DSPARK` server argument support.
- Extend DFlash-compatible runtime safeguards to DSpark, including draft block page reservation slack and context-length accept/output clamping.
- Refactor shared DFlash greedy vocab-parallel sampling so DSpark can inject per-step Markov logits bias while preserving added-vocab handling.

## Components introduced for DSpark
DSPARK reuses the DFLASH block-draft execution path, but the draft checkpoint has a different proposal head: instead of predicting each masked position independently from the draft hidden states, it adds a lightweight Markov transition bias from the previous draft token. To support this, the runtime needed a small set of new components and wiring:
- `DSparkDraftModel`: a draft-model wrapper built on top of `DFlashDraftModel`. It keeps the same DFLASH backbone, target-hidden projection, KV injection, and block forward path, and adds a replicated vanilla Markov head (`markov_w1` / `markov_w2`) loaded from the DSpark checkpoint.
- `DSpark` drafter: a runtime drafter built on top of `DFlash`. It keeps the same block decode / verify pipeline, but overrides block sampling so each position uses the previous proposed token to compute a Markov logits bias before greedy vocab-parallel selection.
- Shared DFLASH sampling primitive: the DFLASH vocab-parallel greedy sampler was factored so DSpark can reuse the same sharded LM-head logic while injecting a per-vocab-slice bias. This keeps original-vocab and added-vocab handling consistent with DFLASH.
- Config remapping: Qwen3 DSpark draft checkpoints expose `Qwen3DSparkModel`; draft-worker config loading maps that architecture to `DSparkDraftModel`, and also accepts DSpark-style top-level draft fields such as `target_layer_ids`, `mask_token_id`, and Markov-head config.
- Runtime algorithm wiring: `DSPARK` is added as a speculative algorithm choice, mapped to the new `DSpark` drafter, and routed through the DFLASH-compatible setup path for layer capture, draft token/step derivation, page reservation slack, and context-length clamping.

## Validation on GB200
### Accept len and Accuracy
EvalScope GSM8K, Batch Size 1, Greedy sampling
Test first 100 samples using Qwen3.5-35B-A3B-BF16 with Internal DSpark. Using TRTLLM backend.
| KV Cache | Block Size | Accept Length | Score |
|----------|----:|---------:|---------:|
| BF16     | 8          | 5.51                     |0.96     |
| BF16     | 16         | 5.90                     |0.96    |
| FP8      | 8          | 5.49                     |0.97      |
| FP8      | 16         | 5.84                     |0.94     |

<!-- How was this validated? -->

This was validated end-to-end via the accuracy benchmark above. Unit tests will be added in a follow-up PR.