### PR TITLE
[WIP] perf(kimi3): retile warp decode

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a16w4_situ_decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/moe/gluon_a16w4_situ_decode.py
@@ -43,12 +43,18 @@ from tokenspeed_kernel_amd.ops.moe.gluon_a4w4_gfx950.decode_kernels import (
 _LANES = gl.constexpr(64)
 # Kimi K3's packed K dimensions exactly fit these maximum tiles. Smaller
 # supported shapes step down to the largest exact 128-byte multiple below.
-WARP_DECODE_STAGE1_BLOCK_N = 4
-WARP_DECODE_STAGE1_BLOCK_KB = 256
-WARP_DECODE_STAGE1_NUM_WARPS = 4
-WARP_DECODE_STAGE2_BLOCK_N = 8
-WARP_DECODE_STAGE2_BLOCK_KB = 512
-WARP_DECODE_STAGE2_NUM_WARPS = 8
+# BLOCK_N, BLOCK_KB, NUM_WARPS, N_LANES. Wider N tiles reduce route-grid
+# overhead, while four N lanes produce contiguous 16-byte packed-K loads.
+WARP_DECODE_STAGE1_DEFAULT_CONFIG = (4, 256, 4, 1)
+WARP_DECODE_STAGE1_CONFIGS = {
+    2: (16, 256, 4, 4),
+    4: (32, 256, 4, 4),
+    8: (32, 256, 8, 4),
+    17: (64, 256, 8, 4),
+}
+# BLOCK_N, BLOCK_KB, NUM_WARPS.
+WARP_DECODE_STAGE2_DEFAULT_CONFIG = (8, 512, 8)
+WARP_DECODE_STAGE2_CONFIGS = {17: (16, 512, 8)}
 _MIN_WARP_DECODE_BLOCK_KB = 128
 
 
@@ -94,6 +100,7 @@ def _stage1_a16w4_situ_warp_gemv(
     BLOCK_N: gl.constexpr,
     BLOCK_KB: gl.constexpr,
     NUM_WARPS: gl.constexpr,
+    N_LANES: gl.constexpr,
 ):
     pid = gl.program_id(0)
     route = pid // NUM_PID_N
@@ -109,17 +116,24 @@ def _stage1_a16w4_situ_warp_gemv(
         return
 
     # Warps span output neurons while each wave's lanes reduce packed K bytes.
+    k_lanes: gl.constexpr = _LANES // N_LANES
     layout: gl.constexpr = gl.BlockedLayout(
-        [(BLOCK_N + NUM_WARPS - 1) // NUM_WARPS, BLOCK_KB // _LANES],
-        [1, _LANES],
+        [
+            (BLOCK_N + NUM_WARPS * N_LANES - 1) // (NUM_WARPS * N_LANES),
+            BLOCK_KB // k_lanes,
+        ],
+        [N_LANES, k_lanes],
         [NUM_WARPS, 1],
         [1, 0],
     )
     n_layout: gl.constexpr = gl.SliceLayout(1, layout)
     k_layout: gl.constexpr = gl.SliceLayout(0, layout)
     expanded_layout: gl.constexpr = gl.BlockedLayout(
-        [(BLOCK_N + NUM_WARPS - 1) // NUM_WARPS, (2 * BLOCK_KB) // _LANES],
-        [1, _LANES],
+        [
+            (BLOCK_N + NUM_WARPS * N_LANES - 1) // (NUM_WARPS * N_LANES),
+            (2 * BLOCK_KB) // k_lanes,
+        ],
+        [N_LANES, k_lanes],
         [NUM_WARPS, 1],
         [1, 0],
     )
@@ -470,12 +484,13 @@ def gluon_a16w4_situ_warp_decode_ep_gfx950(
         dtype=torch.bfloat16,
         device=hidden_states.device,
     )
-    stage1_block_n = WARP_DECODE_STAGE1_BLOCK_N
+    stage1_block_n, stage1_max_block_kb, stage1_warps, stage1_n_lanes = (
+        WARP_DECODE_STAGE1_CONFIGS.get(num_tokens, WARP_DECODE_STAGE1_DEFAULT_CONFIG)
+    )
     stage1_block_kb = _largest_exact_block_kb(
         packed_hidden,
-        WARP_DECODE_STAGE1_BLOCK_KB,
+        stage1_max_block_kb,
     )
-    stage1_warps = WARP_DECODE_STAGE1_NUM_WARPS
     if intermediate_dim % stage1_block_n or packed_hidden % stage1_block_kb:
         raise ValueError("unmasked stage1 requires exact N and packed-K tiles")
     stage1_grid = num_tokens * top_k * triton.cdiv(intermediate_dim, stage1_block_n)
@@ -511,17 +526,19 @@ def gluon_a16w4_situ_warp_decode_ep_gfx950(
         BLOCK_N=stage1_block_n,
         BLOCK_KB=stage1_block_kb,
         NUM_WARPS=stage1_warps,
+        N_LANES=stage1_n_lanes,
         num_warps=stage1_warps,
     )
 
     out = torch.empty_like(hidden_states)
-    stage2_block_n = WARP_DECODE_STAGE2_BLOCK_N
+    stage2_block_n, stage2_max_block_kb, stage2_warps = WARP_DECODE_STAGE2_CONFIGS.get(
+        num_tokens, WARP_DECODE_STAGE2_DEFAULT_CONFIG
+    )
     packed_intermediate = intermediate_dim // 2
     stage2_block_kb = _largest_exact_block_kb(
         packed_intermediate,
-        WARP_DECODE_STAGE2_BLOCK_KB,
+        stage2_max_block_kb,
     )
-    stage2_warps = WARP_DECODE_STAGE2_NUM_WARPS
     if hidden_dim % stage2_block_n or packed_intermediate % stage2_block_kb:
         raise ValueError("unmasked stage2 requires exact N and packed-K tiles")
     stage2_grid = num_tokens * triton.cdiv(hidden_dim, stage2_block_n)

--- a/tokenspeed-kernel/test/ops/moe/test_triton_mxfp4_situ_gfx950.py
+++ b/tokenspeed-kernel/test/ops/moe/test_triton_mxfp4_situ_gfx950.py
@@ -252,6 +252,104 @@ def test_ep_decode_matches_kimi_k3_shape_gfx950(
     torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
 
 
+@pytest.mark.parametrize("num_tokens", [8, 17])
+def test_gluon_warp_decode_tuned_shapes_match_kimi_k3_gfx950(
+    num_tokens: int,
+) -> None:
+    from tokenspeed_kernel_amd.ops.moe.gluon_a16w4_situ_decode import (
+        gluon_a16w4_situ_warp_decode_ep_gfx950,
+    )
+
+    generator = torch.Generator(device="cuda").manual_seed(20260728 + num_tokens)
+    num_local_experts = 2
+    num_experts = 16
+    ep_rank = 3
+    top_k = 16
+    latent_size = 3584
+    intermediate_size = 3072
+    module, raw = _make_mxfp4_module(
+        num_experts=num_local_experts,
+        latent_size=latent_size,
+        intermediate_size=intermediate_size,
+        top_k=top_k,
+        generator=generator,
+    )
+    module.num_experts = num_experts
+    module.num_local_experts = num_local_experts
+    module.ep_size = 8
+    module.ep_rank = ep_rank
+    hidden_states = (
+        torch.randn(
+            (num_tokens, latent_size),
+            dtype=torch.bfloat16,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.1
+    )
+    expert_ids = torch.arange(num_experts, dtype=torch.int32, device="cuda")
+    topk_ids = torch.stack(
+        [torch.roll(expert_ids, token) for token in range(num_tokens)]
+    )
+    topk_weights = torch.softmax(
+        torch.randn(
+            (num_tokens, top_k),
+            dtype=torch.float32,
+            device="cuda",
+            generator=generator,
+        ),
+        dim=-1,
+    )
+    plan = tokenspeed_kernel.moe_plan(
+        "mxfp4",
+        input_dtype=torch.bfloat16,
+        activation="situ",
+        routing_mode="precomputed_topk",
+        ep_size=8,
+        ispp=intermediate_size,
+        internal_activation_dtype="input",
+        solution="gluon",
+    )
+    tokenspeed_kernel.moe_process_weights(plan, module)
+    expert_start = ep_rank * num_local_experts
+    actual = gluon_a16w4_situ_warp_decode_ep_gfx950(
+        hidden_states,
+        module.w13_weight,
+        module.w13_weight_scale,
+        module.w2_weight,
+        module.w2_weight_scale,
+        topk_weights,
+        topk_ids,
+        situ_beta=4.0,
+        situ_linear_beta=25.0,
+        expert_start=expert_start,
+        linear_weights=True,
+        w13_interleaved=False,
+    )
+
+    local_ids = topk_ids - expert_start
+    local_mask = (local_ids >= 0) & (local_ids < num_local_experts)
+    local_ids = torch.where(local_mask, local_ids, torch.full_like(local_ids, -1))
+    local_weights = torch.where(
+        local_mask, topk_weights, torch.zeros_like(topk_weights)
+    )
+    expected = a16w4_mxfp4_moe_reference(
+        hidden_states,
+        raw["w13_weight"],
+        raw["w13_scale"],
+        raw["w2_weight"],
+        raw["w2_scale"],
+        local_ids,
+        local_weights,
+        situ_beta=4.0,
+        situ_linear_beta=25.0,
+    )
+
+    assert actual.shape == (num_tokens, latent_size)
+    assert actual.dtype == torch.bfloat16
+    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+
+
 @pytest.mark.parametrize("num_tokens", [1, 2, 4, 8])
 @pytest.mark.parametrize("solution", ["triton", "gluon"])
 def test_ep_decode_all_remote_routes_return_zero_gfx950(


### PR DESCRIPTION
## Summary

  - Add compact stage-specific configuration tables for Kimi K3 warp decode.
  - Use BLOCK_N=16, N_LANES=4 at M=2 and BLOCK_N=32, N_LANES=4 at M=4.
  - Tune M=8 with stage 1 (BLOCK_N=32, BLOCK_KB=256, NUM_WARPS=8, N_LANES=4).
  - Tune M=17 with stage 1 (BLOCK_N=64, BLOCK_KB=256, NUM_WARPS=8, N_LANES=4) and stage 2 (BLOCK_N=16, BLOCK_KB=512, NUM_WARPS=8).
  - Preserve the existing M=1 configuration and larger-batch fallback.
  - Widen packed-K accesses to 16-byte buffer_load_dwordx4 operations.
  - Add direct-kernel correctness coverage for the tuned M=8 and M=16 shapes.
  - Preserve byte-exact output across the tested routing seeds while improving warp-decode latency by 9.3% at M=8 and 19.6% at M=16.
