### PR TITLE
feat: throttle weight-loading prefetch and enable it by default

### DIFF
--- a/python/tokenspeed/runtime/configs/load_config.py
+++ b/python/tokenspeed/runtime/configs/load_config.py
@@ -67,7 +67,7 @@ class LoadConfig:
     model_loader_extra_config: str | dict | None = field(default_factory=dict)
     ignore_patterns: list[str] | str | None = None
     decryption_key_file: str | None = None
-    weight_loader_prefetch_checkpoints: bool = False
+    weight_loader_prefetch_checkpoints: bool = True
     weight_loader_prefetch_num_threads: int = 4
 
     ext_yaml: str | None = None

--- a/python/tokenspeed/runtime/model_loader/weight_utils.py
+++ b/python/tokenspeed/runtime/model_loader/weight_utils.py
@@ -21,7 +21,6 @@
 
 """Utilities for downloading and initializing model weights."""
 
-import concurrent.futures
 import fnmatch
 import glob
 import hashlib
@@ -32,13 +31,12 @@ import tempfile
 import threading
 import time
 from collections.abc import Callable, Generator, Iterable
-from typing import (
-    Any,
-)
+from typing import Any
 
 import filelock
 import huggingface_hub.constants
 import numpy as np
+import psutil
 import safetensors.torch
 import torch
 from huggingface_hub import HfFileSystem, hf_hub_download, snapshot_download
@@ -54,7 +52,6 @@ from tokenspeed.runtime.layers.quantization import (
 from tokenspeed.runtime.utils import get_colorful_logger
 
 logger = get_colorful_logger(__name__)
-_PREFETCH_BLOCK_SIZE = 16 * 1024 * 1024
 
 # use system-level temp directory for file locks, so that multiple users
 # can share the same lock without error.
@@ -359,86 +356,121 @@ def safetensors_encrypted_weights_iterator(
     raise NotImplementedError()
 
 
-def _get_checkpoint_prefetch_rank_info() -> tuple[int, int]:
-    local_rank = os.getenv("LOCAL_RANK")
-    local_world_size = os.getenv("LOCAL_WORLD_SIZE")
-    if local_rank is not None and local_world_size is not None:
-        try:
-            rank = int(local_rank)
-            world_size = int(local_world_size)
-            if 0 <= rank < world_size:
-                return rank, world_size
-        except ValueError:
-            logger.warning(
-                "Ignoring invalid LOCAL_RANK/LOCAL_WORLD_SIZE for checkpoint prefetch: "
-                "%s/%s",
-                local_rank,
-                local_world_size,
-            )
+class CheckpointPrefetcher:
+    """Sequentially read checkpoint shards a bounded distance ahead of the consumer.
 
-    if torch.distributed.is_available() and torch.distributed.is_initialized():
-        return torch.distributed.get_rank(), torch.distributed.get_world_size()
+    Copying weights out of an mmap'd safetensors shard demand-faults one page
+    at a time; on cold network filesystems the sparse per-rank access pattern
+    defeats readahead and every page fault becomes a synchronous round trip.
+    Reading each shard sequentially first moves the bytes at streaming
+    bandwidth, so the consumer's copies hit the page cache instead.
 
-    return 0, 1
+    The read-ahead window is bounded so shards are consumed before cache
+    pressure evicts them again; an unbounded prefetch of a checkpoint larger
+    than the page cache evicts its own early work. The window defaults to
+    min(80 GiB, 25% of available host memory): it only needs to be much
+    larger than a few shards and much smaller than the page cache, and no
+    cross-rank agreement is needed since it only sizes each rank's
+    independent read-ahead. Every rank reads every shard in consumption
+    order; concurrent readers of the same shard are deduplicated by the page
+    cache, so the shared filesystem sees roughly one read per node.
 
+    Args:
+        files: Shard paths in the exact order the consumer will load them.
+        num_threads: Number of background reader threads.
+    """
 
-def _prefetch_checkpoint_file(file_path: str) -> int:
-    bytes_read = 0
-    with open(file_path, "rb") as f:
-        while True:
-            data = f.read(_PREFETCH_BLOCK_SIZE)
-            if not data:
-                break
-            bytes_read += len(data)
-    return bytes_read
+    _BLOCK_SIZE = 16 * 1024 * 1024
+    _WINDOW_MAX_BYTES = 80 * 1024**3
+    _WINDOW_MEM_FRACTION = 0.25
 
-
-def prefetch_checkpoint_files(
-    hf_weights_files: list[str],
-    num_threads: int = 4,
-) -> threading.Thread:
-    """Prefetch checkpoint shards into the OS page cache in the background."""
-    sorted_files = sorted(hf_weights_files)
-    rank, world_size = _get_checkpoint_prefetch_rank_info()
-    my_files = sorted_files[rank::world_size]
-    num_threads = max(1, num_threads)
-
-    logger.info(
-        "Rank %d: prefetching %d/%d checkpoint shards into OS page cache "
-        "(background, %d local ranks sharing work, %d threads per rank).",
-        rank,
-        len(my_files),
-        len(sorted_files),
-        world_size,
-        num_threads,
-    )
-
-    def _run_prefetch() -> None:
-        start = time.perf_counter()
+    @classmethod
+    def _read_file(cls, file_path: str) -> int:
+        """Sequentially read a file so its pages land in the OS page cache."""
         bytes_read = 0
-        with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
-            futures = [
-                executor.submit(_prefetch_checkpoint_file, path) for path in my_files
-            ]
-            for future in concurrent.futures.as_completed(futures):
-                try:
-                    bytes_read += future.result()
-                except Exception:
-                    logger.warning(
-                        "Failed to prefetch a checkpoint shard.", exc_info=True
-                    )
+        with open(file_path, "rb") as f:
+            while True:
+                data = f.read(cls._BLOCK_SIZE)
+                if not data:
+                    break
+                bytes_read += len(data)
+        return bytes_read
 
-        elapsed = time.perf_counter() - start
-        logger.info(
-            "Rank %d: checkpoint prefetch finished in %.2fs, %.2f GiB read.",
-            rank,
-            elapsed,
-            bytes_read / (1024**3),
+    def __init__(
+        self,
+        files: list[str],
+        num_threads: int = 4,
+    ) -> None:
+        self._files = list(files)
+        self._sizes = [os.path.getsize(path) for path in self._files]
+        self._num_threads = max(1, min(num_threads, max(len(self._files), 1)))
+        self._window_bytes = min(
+            self._WINDOW_MAX_BYTES,
+            int(psutil.virtual_memory().available * self._WINDOW_MEM_FRACTION),
         )
+        self._cond = threading.Condition()
+        self._next_to_read = 0
+        self._files_read = 0
+        self._inflight_bytes = 0  # claimed by a reader, not yet consumed
+        self._ready = [threading.Event() for _ in self._files]
+        self._start_time = 0.0
 
-    thread = threading.Thread(target=_run_prefetch, daemon=True)
-    thread.start()
-    return thread
+    def start(self) -> None:
+        logger.info(
+            f"Prefetching {len(self._files)} checkpoint shards into the OS page "
+            f"cache (window {self._window_bytes / 1024**3:.1f} GiB, "
+            f"{self._num_threads} reader threads)."
+        )
+        self._start_time = time.perf_counter()
+        for _ in range(self._num_threads):
+            threading.Thread(target=self._reader, daemon=True).start()
+
+    def _reader(self) -> None:
+        while True:
+            with self._cond:
+                while True:
+                    if self._next_to_read >= len(self._files):
+                        return
+                    size = self._sizes[self._next_to_read]
+                    # A shard larger than the window may still go alone.
+                    if (
+                        self._inflight_bytes == 0
+                        or self._inflight_bytes + size <= self._window_bytes
+                    ):
+                        break
+                    self._cond.wait()
+                idx = self._next_to_read
+                self._next_to_read += 1
+                self._inflight_bytes += size
+            try:
+                self._read_file(self._files[idx])
+            except Exception:
+                logger.warning(
+                    f"Failed to prefetch checkpoint shard {self._files[idx]}; "
+                    f"the consumer will fall back to demand paging for it.",
+                    exc_info=True,
+                )
+            finally:
+                # Unblock the consumer even on failure.
+                self._ready[idx].set()
+            with self._cond:
+                self._files_read += 1
+                all_read = self._files_read == len(self._files)
+            if all_read:
+                logger.info(
+                    "Checkpoint prefetch finished after "
+                    f"{time.perf_counter() - self._start_time:.2f}s."
+                )
+
+    def wait_file(self, idx: int) -> None:
+        """Block until shard ``idx`` has been prefetched."""
+        self._ready[idx].wait()
+
+    def advance(self, idx: int) -> None:
+        """Tell the prefetcher shard ``idx`` has been consumed, freeing window budget."""
+        with self._cond:
+            self._inflight_bytes -= self._sizes[idx]
+            self._cond.notify_all()
 
 
 def safetensors_weights_iterator(
@@ -452,6 +484,12 @@ def safetensors_weights_iterator(
 
     If is_all_weights_sharded is True, it uses more optimize read by reading an
     entire file instead of reading each tensor one by one.
+
+    If prefetch is True, shards are sequentially read into the OS page cache a
+    bounded window ahead of this iterator (see CheckpointPrefetcher),
+    paced by how fast the caller actually consumes the yielded tensors. The
+    pacing only works if the caller loads weights while iterating instead of
+    draining the iterator into a list first.
     """
     if decryption_key:
         yield from safetensors_encrypted_weights_iterator(
@@ -462,20 +500,28 @@ def safetensors_weights_iterator(
     enable_tqdm = (
         not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
     )
+    prefetcher = None
     if prefetch:
-        prefetch_checkpoint_files(
+        prefetcher = CheckpointPrefetcher(
             hf_weights_files,
             num_threads=prefetch_num_threads,
         )
+        prefetcher.start()
 
-    for st_file in tqdm(
-        hf_weights_files,
-        desc="Loading safetensors checkpoint shards",
-        disable=not enable_tqdm,
-        bar_format=_BAR_FORMAT,
+    for file_idx, st_file in enumerate(
+        tqdm(
+            hf_weights_files,
+            desc="Loading safetensors checkpoint shards",
+            disable=not enable_tqdm,
+            bar_format=_BAR_FORMAT,
+        )
     ):
+        if prefetcher is not None:
+            prefetcher.wait_file(file_idx)
         result = safetensors.torch.load_file(st_file, device="cpu")
         yield from result.items()
+        if prefetcher is not None:
+            prefetcher.advance(file_idx)
 
 
 def pt_weights_iterator(

--- a/python/tokenspeed/runtime/models/kimi_k25.py
+++ b/python/tokenspeed/runtime/models/kimi_k25.py
@@ -26,6 +26,7 @@
 
 from __future__ import annotations
 
+import itertools
 from collections.abc import Iterable
 
 import torch
@@ -203,25 +204,45 @@ class KimiK25ForConditionalGeneration(torch.nn.Module):
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
-        """Load weights for the model, separating vision and language weights."""
+        """Load weights for the model, separating vision and language weights.
+
+        Language weights are streamed to the language model while the
+        checkpoint iterator is being consumed, so mmap-backed tensors are
+        materialised one shard at a time and the checkpoint prefetch window
+        (see CheckpointPrefetcher) can pace itself on real consumption. Only
+        the small vision weights are buffered; they are loaded after the
+        language stream is exhausted.
+        """
         vision_weights = []
-        language_weights = []
 
-        for name, loaded_weight in weights:
-            if name.startswith("language_model.layers."):
-                name = name.replace(
-                    "language_model.layers.", "language_model.model.layers.", 1
-                )
+        def language_weights_stream():
+            for name, loaded_weight in weights:
+                # nvidia/Kimi-K2.5-NVFP4 stores decoder layers under
+                # language_model.layers.*, while TokenSpeed's DeepSeek module
+                # expects model.layers.* after stripping language_model.
+                if name.startswith("language_model.layers."):
+                    name = name.replace(
+                        "language_model.layers.", "language_model.model.layers.", 1
+                    )
 
-            if "vision_tower" in name or "mm_projector" in name:
-                name = name.replace("wqkv.", "attn.qkv_proj.")
-                name = name.replace("wo.", "attn.proj.")
-                name = name.replace("mm_projector.proj.0", "mm_projector.linear_1")
-                name = name.replace("mm_projector.proj.2", "mm_projector.linear_2")
-                vision_weights.append((name, loaded_weight))
-            else:
-                name = name.replace("language_model.", "")
-                language_weights.append((name, loaded_weight))
+                if "vision_tower" in name or "mm_projector" in name:
+                    name = name.replace("wqkv.", "attn.qkv_proj.")
+                    name = name.replace("wo.", "attn.proj.")
+                    name = name.replace("mm_projector.proj.0", "mm_projector.linear_1")
+                    name = name.replace("mm_projector.proj.2", "mm_projector.linear_2")
+                    vision_weights.append((name, loaded_weight))
+                else:
+                    yield name.replace("language_model.", ""), loaded_weight
+
+        stream = language_weights_stream()
+        if getattr(self.config, "encoder_only", False):
+            # Drain to collect vision weights; language weights are unused.
+            for _ in stream:
+                pass
+        else:
+            first = next(stream, None)
+            if first is not None:
+                self.language_model.load_weights(itertools.chain([first], stream))
 
         if self.vision is not None and not getattr(self.config, "language_only", False):
             params_dict = dict(self.vision.named_parameters(remove_duplicate=False))
@@ -231,9 +252,6 @@ class KimiK25ForConditionalGeneration(torch.nn.Module):
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
-
-        if not getattr(self.config, "encoder_only", False) and language_weights:
-            self.language_model.load_weights(language_weights)
 
     @classmethod
     def get_model_config_for_expert_location(cls, config: KimiK25Config):

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -1734,10 +1734,13 @@ class ServerArgs:
         parser.add_argument(
             "--weight-loader-prefetch-checkpoints",
             action="store_true",
+            default=ServerArgs.weight_loader_prefetch_checkpoints,
             help=(
-                "Prefetch safetensors checkpoint shards into OS page cache before "
-                "loading. Local ranks split the shard list to reduce repeated reads "
-                "from shared filesystems."
+                "Sequentially read safetensors checkpoint shards into the OS page "
+                "cache a bounded window ahead of weight loading, so weight copies "
+                "hit the cache at streaming bandwidth instead of demand-faulting "
+                "cold pages from shared filesystems. The window is "
+                "min(80 GiB, 25%% of available host memory)."
             ),
         )
         parser.add_argument(

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -268,7 +268,7 @@ class ServerArgs:
     enable_p2p_check: bool = False
     triton_attention_reduce_in_fp32: bool = False
     delete_ckpt_after_loading: bool = False
-    weight_loader_prefetch_checkpoints: bool = False
+    weight_loader_prefetch_checkpoints: bool = True
     weight_loader_prefetch_num_threads: int = 4
     enable_memory_saver: bool = False
     enable_custom_logit_processor: bool = False
@@ -1732,15 +1732,17 @@ class ServerArgs:
             help="Delete the model checkpoint after loading the model.",
         )
         parser.add_argument(
-            "--weight-loader-prefetch-checkpoints",
-            action="store_true",
+            "--disable-weight-loader-prefetch-checkpoints",
+            dest="weight_loader_prefetch_checkpoints",
+            action="store_false",
             default=ServerArgs.weight_loader_prefetch_checkpoints,
             help=(
-                "Sequentially read safetensors checkpoint shards into the OS page "
-                "cache a bounded window ahead of weight loading, so weight copies "
+                "Disable prefetching safetensors checkpoint shards into the OS "
+                "page cache. Prefetch is enabled by default: shards are read "
+                "sequentially a bounded window ahead of weight loading "
+                "(min(80 GiB, 25%% of available host memory)), so weight copies "
                 "hit the cache at streaming bandwidth instead of demand-faulting "
-                "cold pages from shared filesystems. The window is "
-                "min(80 GiB, 25%% of available host memory)."
+                "cold pages from shared filesystems."
             ),
         )
         parser.add_argument(

--- a/test/ci/eval/glm-5.2-nvfp4-mtp-evalscope-aime26.yaml
+++ b/test/ci/eval/glm-5.2-nvfp4-mtp-evalscope-aime26.yaml
@@ -27,7 +27,6 @@ server:
     --moe-backend flashinfer_trtllm
     --quantization nvfp4
     --kv-cache-dtype fp8
-    --weight-loader-prefetch-checkpoints
     --speculative-algorithm MTP
     --speculative-num-steps 3
     --speculative-eagle-topk 1

--- a/test/ci/eval/inkling-nvfp4-mtp-evalscope-gsm8k.yaml
+++ b/test/ci/eval/inkling-nvfp4-mtp-evalscope-gsm8k.yaml
@@ -25,7 +25,6 @@ server:
     --gpu-memory-utilization 0.95
     --disable-cuda-graph-padding
     --trust-remote-code
-    --weight-loader-prefetch-checkpoints
     --attention-backend fa4
     --moe-backend flashinfer_trtllm
     --enable-prefix-caching

--- a/test/ci/eval/kimi-k2.5-nvfp4-dflash-evalscope-aime25.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-dflash-evalscope-aime25.yaml
@@ -24,7 +24,6 @@ server:
     --moe-backend flashinfer_trtllm
     --quantization nvfp4
     --kv-cache-dtype fp8_e4m3
-    --weight-loader-prefetch-checkpoints
     --speculative-algorithm DFLASH
     --speculative-draft-model-path z-lab/Kimi-K2.5-DFlash
     --speculative-num-steps 7

--- a/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-aime25.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-aime25.yaml
@@ -25,7 +25,6 @@ server:
     --moe-backend flashinfer_trtllm
     --quantization nvfp4
     --kv-cache-dtype fp8
-    --weight-loader-prefetch-checkpoints
     --speculative-algorithm EAGLE3
     --speculative-draft-model-path lightseekorg/kimi-k2.5-eagle3-mla
     --speculative-num-steps 1

--- a/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-gpqa-diamond.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-gpqa-diamond.yaml
@@ -24,7 +24,6 @@ server:
     --moe-backend flashinfer_trtllm
     --quantization nvfp4
     --kv-cache-dtype fp8
-    --weight-loader-prefetch-checkpoints
     --speculative-algorithm EAGLE3
     --speculative-draft-model-path lightseekorg/kimi-k2.5-eagle3-mla
     --speculative-num-steps 1

--- a/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-gsm8k.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-gsm8k.yaml
@@ -24,7 +24,6 @@ server:
     --moe-backend flashinfer_trtllm
     --quantization nvfp4
     --kv-cache-dtype fp8
-    --weight-loader-prefetch-checkpoints
     --speculative-algorithm EAGLE3
     --speculative-draft-model-path lightseekorg/kimi-k2.5-eagle3-mla
     --speculative-num-steps 1

--- a/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-mmlu.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-mmlu.yaml
@@ -24,7 +24,6 @@ server:
     --moe-backend flashinfer_trtllm
     --quantization nvfp4
     --kv-cache-dtype fp8
-    --weight-loader-prefetch-checkpoints
     --speculative-algorithm EAGLE3
     --speculative-draft-model-path lightseekorg/kimi-k2.5-eagle3-mla
     --speculative-num-steps 1

--- a/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-ocr-bench.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-ocr-bench.yaml
@@ -24,7 +24,6 @@ server:
     --moe-backend flashinfer_trtllm
     --quantization nvfp4
     --kv-cache-dtype fp8
-    --weight-loader-prefetch-checkpoints
     --speculative-algorithm EAGLE3
     --speculative-draft-model-path lightseekorg/kimi-k2.5-eagle3-mla
     --speculative-num-steps 1

--- a/test/ci/eval/minimax-m3-nvfp4-evalscope-aime25.yaml
+++ b/test/ci/eval/minimax-m3-nvfp4-evalscope-aime25.yaml
@@ -34,7 +34,6 @@ server:
     --disable-kvstore
     --block-size 128
     --trust-remote-code
-    --weight-loader-prefetch-checkpoints
     --enable-cache-report
     --host 127.0.0.1
     --port 8000

--- a/test/ci/eval/qwen3.5-397b-a17b-mxfp4-evalscope-aime25.yaml
+++ b/test/ci/eval/qwen3.5-397b-a17b-mxfp4-evalscope-aime25.yaml
@@ -20,7 +20,6 @@ server:
     --max-num-seqs 16
     --trust-remote-code
     --quantization mxfp4
-    --weight-loader-prefetch-checkpoints
     --sampling-backend greedy
     --disable-kvstore
     --kvstore-ratio 0.0

--- a/test/ci/eval/qwen3.5-397b-a17b-nvfp4-dp4ep4-evalscope-aime25.yaml
+++ b/test/ci/eval/qwen3.5-397b-a17b-nvfp4-dp4ep4-evalscope-aime25.yaml
@@ -27,7 +27,6 @@ server:
     --moe-backend flashinfer_trtllm
     --quantization nvfp4
     --kv-cache-dtype fp8
-    --weight-loader-prefetch-checkpoints
     --speculative-algorithm MTP
     --speculative-num-steps 3
     --drafter-attention-backend trtllm

--- a/test/ci/eval/qwen3.5-397b-a17b-nvfp4-evalscope-aime25.yaml
+++ b/test/ci/eval/qwen3.5-397b-a17b-nvfp4-evalscope-aime25.yaml
@@ -24,7 +24,6 @@ server:
     --moe-backend flashinfer_trtllm
     --quantization nvfp4
     --kv-cache-dtype fp8
-    --weight-loader-prefetch-checkpoints
     --speculative-algorithm MTP
     --speculative-num-steps 3
     --drafter-attention-backend trtllm

--- a/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
+++ b/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
@@ -35,7 +35,6 @@ server:
     --speculative-num-steps 3
     --drafter-attention-backend tokenspeed_mla
     --enable-cache-report
-    --weight-loader-prefetch-checkpoints
     --engine-startup-timeout 2400
     --host 127.0.0.1
     --port 8000

--- a/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic.yaml
+++ b/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic.yaml
@@ -30,7 +30,6 @@ server:
     --speculative-num-steps 3
     --drafter-attention-backend trtllm
     --enable-cache-report
-    --weight-loader-prefetch-checkpoints
     --host 127.0.0.1
     --port 8000
   ready:

--- a/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-longctx.yaml
+++ b/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-longctx.yaml
@@ -28,7 +28,6 @@ server:
     --speculative-algorithm MTP
     --speculative-num-steps 3
     --enable-cache-report
-    --weight-loader-prefetch-checkpoints
     --host 127.0.0.1
     --port 8000
   ready:

--- a/test/runtime/test_weight_loader_prefetch.py
+++ b/test/runtime/test_weight_loader_prefetch.py
@@ -39,28 +39,30 @@ def _fake_available_memory(available):
 
 
 class TestWeightLoaderPrefetch(unittest.TestCase):
-    def test_cli_flag_maps_to_server_args(self):
+    def _parse_server_args(self, cli):
         parser = argparse.ArgumentParser()
         ServerArgs.add_cli_args(parser)
-        args = parser.parse_args(
-            [
-                "--model",
-                "test/model",
-                "--weight-loader-prefetch-checkpoints",
-                "--weight-loader-prefetch-num-threads",
-                "2",
-            ]
-        )
+        args = parser.parse_args(["--model", "test/model", *cli])
         with mock.patch.object(ServerArgs, "__post_init__"):
-            server_args = ServerArgs.from_cli_args(args)
+            return ServerArgs.from_cli_args(args)
 
+    def test_prefetch_enabled_by_default(self):
+        server_args = self._parse_server_args(
+            ["--weight-loader-prefetch-num-threads", "2"]
+        )
         self.assertTrue(server_args.weight_loader_prefetch_checkpoints)
         self.assertEqual(server_args.weight_loader_prefetch_num_threads, 2)
 
-    def test_load_config_defaults_keep_prefetch_disabled(self):
+    def test_disable_flag_turns_prefetch_off(self):
+        server_args = self._parse_server_args(
+            ["--disable-weight-loader-prefetch-checkpoints"]
+        )
+        self.assertFalse(server_args.weight_loader_prefetch_checkpoints)
+
+    def test_load_config_defaults_enable_prefetch(self):
         load_config = LoadConfig()
 
-        self.assertFalse(load_config.weight_loader_prefetch_checkpoints)
+        self.assertTrue(load_config.weight_loader_prefetch_checkpoints)
         self.assertEqual(load_config.weight_loader_prefetch_num_threads, 4)
 
     def _make_files(self, tmpdir, count, size):

--- a/test/runtime/test_weight_loader_prefetch.py
+++ b/test/runtime/test_weight_loader_prefetch.py
@@ -1,6 +1,8 @@
 import argparse
 import os
 import sys
+import tempfile
+import time
 import unittest
 from unittest import mock
 
@@ -12,7 +14,28 @@ register_cuda_ci(est_time=10, suite="runtime-1gpu")
 
 from tokenspeed.runtime.configs.load_config import LoadConfig
 from tokenspeed.runtime.model_loader import weight_utils
+from tokenspeed.runtime.model_loader.weight_utils import CheckpointPrefetcher
 from tokenspeed.runtime.utils.server_args import ServerArgs
+
+_POLL_TIMEOUT_S = 5.0
+
+
+def _wait_until(predicate, timeout=_POLL_TIMEOUT_S):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+def _fake_available_memory(available):
+    """Patch psutil so the prefetch window computes to available / 4."""
+    return mock.patch.object(
+        weight_utils.psutil,
+        "virtual_memory",
+        return_value=mock.Mock(available=available),
+    )
 
 
 class TestWeightLoaderPrefetch(unittest.TestCase):
@@ -40,26 +63,98 @@ class TestWeightLoaderPrefetch(unittest.TestCase):
         self.assertFalse(load_config.weight_loader_prefetch_checkpoints)
         self.assertEqual(load_config.weight_loader_prefetch_num_threads, 4)
 
-    def test_prefetch_splits_files_by_local_rank(self):
-        files = [f"/tmp/model-{idx}.safetensors" for idx in range(6)]
-        seen = []
+    def _make_files(self, tmpdir, count, size):
+        files = []
+        for idx in range(count):
+            path = os.path.join(tmpdir, f"model-{idx}.safetensors")
+            with open(path, "wb") as f:
+                f.write(b"x" * size)
+            files.append(path)
+        return files
 
-        def record_prefetch(path):
-            seen.append(path)
-            return 1
+    def test_window_clamps_to_available_memory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            files = self._make_files(tmpdir, count=1, size=100)
+            with _fake_available_memory(100 * 1024**3):
+                prefetcher = CheckpointPrefetcher(files)
+            self.assertEqual(prefetcher._window_bytes, 25 * 1024**3)
+            with _fake_available_memory(1000 * 1024**3):
+                prefetcher = CheckpointPrefetcher(files)
+            self.assertEqual(
+                prefetcher._window_bytes, CheckpointPrefetcher._WINDOW_MAX_BYTES
+            )
 
-        env = {"LOCAL_RANK": "1", "LOCAL_WORLD_SIZE": "3"}
-        with (
-            mock.patch.dict(os.environ, env, clear=False),
-            mock.patch.object(
-                weight_utils, "_prefetch_checkpoint_file", side_effect=record_prefetch
-            ),
-        ):
-            thread = weight_utils.prefetch_checkpoint_files(files, num_threads=2)
-            thread.join(timeout=5)
+    def test_window_bounds_read_ahead_and_advances_on_consumption(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            files = self._make_files(tmpdir, count=4, size=100)
+            read_order = []
 
-        self.assertFalse(thread.is_alive())
-        self.assertEqual(sorted(seen), [files[1], files[4]])
+            def record_read(path):
+                read_order.append(path)
+                return 100
+
+            # available=1000 -> window of 250 bytes: fits two 100-byte shards;
+            # the third must wait for the consumer to advance.
+            with (
+                _fake_available_memory(1000),
+                mock.patch.object(
+                    CheckpointPrefetcher, "_read_file", side_effect=record_read
+                ),
+            ):
+                prefetcher = CheckpointPrefetcher(files, num_threads=1)
+                prefetcher.start()
+
+                self.assertTrue(_wait_until(lambda: len(read_order) == 2))
+                prefetcher.wait_file(0)
+                prefetcher.wait_file(1)
+                # Third shard would exceed the window until we consume one.
+                time.sleep(0.05)
+                self.assertEqual(read_order, files[:2])
+
+                prefetcher.advance(0)
+                self.assertTrue(_wait_until(lambda: len(read_order) == 3))
+                self.assertEqual(read_order, files[:3])
+
+                prefetcher.advance(1)
+                prefetcher.advance(2)
+                self.assertTrue(_wait_until(lambda: read_order == files))
+                prefetcher.wait_file(3)
+
+    def test_oversized_shard_still_prefetched_alone(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            files = self._make_files(tmpdir, count=2, size=100)
+            read_order = []
+
+            # available=40 -> window of 10 bytes, smaller than one shard.
+            with (
+                _fake_available_memory(40),
+                mock.patch.object(
+                    CheckpointPrefetcher,
+                    "_read_file",
+                    side_effect=lambda p: read_order.append(p) or 100,
+                ),
+            ):
+                prefetcher = CheckpointPrefetcher(files, num_threads=1)
+                prefetcher.start()
+                prefetcher.wait_file(0)
+                prefetcher.advance(0)
+                prefetcher.wait_file(1)
+                self.assertEqual(read_order, files)
+
+    def test_read_failure_unblocks_consumer(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            files = self._make_files(tmpdir, count=1, size=100)
+
+            def broken_read(path):
+                raise OSError("boom")
+
+            with mock.patch.object(
+                CheckpointPrefetcher, "_read_file", side_effect=broken_read
+            ):
+                prefetcher = CheckpointPrefetcher(files, num_threads=1)
+                prefetcher.start()
+                # Must not hang; the consumer falls back to demand paging.
+                prefetcher.wait_file(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Loading Kimi-K2.5-NVFP4 (551 GB, 119 shards) on GB200 + Lustre took ~25–30 min. Weight copies demand-fault mmap'd safetensors pages, and the sparse per-rank TP-slice access pattern defeats readahead — every 64 KiB page becomes a synchronous filesystem round trip (~0.1–0.2 GiB/s per rank), while the same files read sequentially stream at ~5 GiB/s. The existing prefetch flag didn't help at this scale: it read all shards up front, unbounded, so checkpoints larger than the page cache evicted their own prefetched data before the consumer reached it.

## Changes

- CheckpointPrefetcher: reads shards sequentially in consumption order, bounded to a window of min(80 GiB, 25% of available host memory), advanced as the consumer finishes each shard — prefetched pages are used before cache pressure evicts them.
- Stream KimiK25 language weights while the checkpoint iterator is consumed (the previous drain-into-a-list deferred all copies, breaking prefetch pacing and the progress bar).
- Prefetch is now on by default; opt out with --disable-weight-loader-prefetch-checkpoints. CI serve commands drop the now-redundant enable flag.

## Results

119 shards materialized in 2 min 36 s vs ~25–30 min (GB200 + Lustre, cold client cache), with loading now I/O-bound at streaming bandwidth.
