### PR TITLE
fix(glm5.2): dsa with bf16 kv cache on amd

### DIFF
--- a/python/tokenspeed/runtime/models/glm5.py
+++ b/python/tokenspeed/runtime/models/glm5.py
@@ -988,7 +988,7 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
         attn_output = self.attn_mqa(
             Q,
             K,
-            K[..., : self.kv_lora_rank],
+            K[..., : self.kv_lora_rank] if K is not None else None,
             ctx,
             out_cache_loc,
             save_kv_cache=need_save_kv,


### PR DESCRIPTION
## Summary

Fix GLM DSA inference with BF16 KV cache on AMD.

AMD’s fused BF16 MLA RoPE path writes KV directly into the paged cache and returns `K=None`. GLM’s DSA attention override incorrectly assumed K was always materialized and sliced it when constructing the value argument, causing CUDA-graph warmup to fail.

