### PR TITLE
perf: fuse MiniMax sparse cache insertion

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/msa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/msa.py
@@ -32,6 +32,7 @@ from tokenspeed_kernel import (
     msa_decode_with_kvcache,
     msa_extend_with_kvcache,
 )
+from tokenspeed_kernel.ops.attention import MinimaxSparseCacheInsertArgs
 from tokenspeed_kernel.ops.kvcache.triton import (
     fused_fp8_set_kv_buffer,
     gather_page_table_with_padding,
@@ -534,14 +535,7 @@ class MSAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
         assert (
             index_q is not None and index_k is not None
         ), "MSA requires index_q and index_k from the model layer."
-        assert save_kv_cache, (
-            "MSA does not support KV-cache prewrite because its "
-            "index-key side cache is backend-owned."
-        )
-        assert k is not None and v is not None, "MSA requires K/V inputs on every call."
         q = q.view(-1, layer.tp_q_head_num, layer.qk_head_dim)
-        k = k.view(-1, layer.tp_k_head_num, layer.qk_head_dim)
-        v = v.view(-1, layer.tp_v_head_num, layer.v_head_dim)
 
         out_cache_loc = self._select_out_cache_loc(
             layer,
@@ -551,7 +545,17 @@ class MSAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
         page_table = self._select_page_table(layer, metadata)
         if page_table is None:
             raise RuntimeError("MSA decode requires a page table.")
-        self._save_kv_cache(layer, out_cache_loc, token_to_kv_pool, k, v)
+        if save_kv_cache:
+            assert (
+                k is not None and v is not None
+            ), "MSA requires K/V inputs when the cache is not prewritten."
+            self._save_kv_cache(
+                layer,
+                out_cache_loc,
+                token_to_kv_pool,
+                k.view(-1, layer.tp_k_head_num, layer.qk_head_dim),
+                v.view(-1, layer.tp_v_head_num, layer.v_head_dim),
+            )
         k_cache, v_cache, index_k_cache = self._get_sparse_caches(
             layer, token_to_kv_pool
         )
@@ -582,6 +586,7 @@ class MSAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
             v_scale=layer.v_scale if self.is_fp8 else None,
             score_out=metadata.score_out,
             enable_pdl=pdl_enabled(),
+            index_k_cache_prewritten=not save_kv_cache,
         )
         return output.reshape(-1, layer.tp_q_head_num * layer.v_head_dim)
 
@@ -835,6 +840,35 @@ class MSAHybridAttnBackend(AttentionBackend):
         # A single model-wide answer must be safe for sparse layers too.
         del forward_mode
         return False
+
+    def create_fused_decode_cache_insert_args(
+        self,
+        layer: PagedAttention,
+        out_cache_loc: torch.Tensor,
+        token_to_kv_pool,
+        forward_mode: ForwardMode,
+    ) -> MinimaxSparseCacheInsertArgs | None:
+        scales = (layer.k_scale, layer.v_scale)
+        if (
+            not forward_mode.is_decode()
+            or layer.layer_id not in self.sparse_layer_ids
+            or any(
+                isinstance(scale, torch.Tensor)
+                or (scale is not None and float(scale) != 1.0)
+                for scale in scales
+            )
+        ):
+            return None
+        return MinimaxSparseCacheInsertArgs(
+            slot_mapping=self.sparse_attn_backend.select_out_cache_loc(
+                layer,
+                out_cache_loc,
+                forward_mode,
+            ),
+            k_cache=token_to_kv_pool.get_key_buffer(layer.layer_id),
+            v_cache=token_to_kv_pool.get_value_buffer(layer.layer_id),
+            index_k_cache=token_to_kv_pool.get_index_k_buffer(layer.layer_id),
+        )
 
     def init_forward_metadata(self, *args, **kwargs):
         self.full_attn_backend.init_forward_metadata(*args, **kwargs)

--- a/python/tokenspeed/runtime/models/minimax_m3.py
+++ b/python/tokenspeed/runtime/models/minimax_m3.py
@@ -27,13 +27,14 @@ from collections.abc import Iterable, Sequence
 
 import torch
 from tokenspeed_kernel.ops.activation.triton import swiglu_oai
+from tokenspeed_kernel.ops.attention import (
+    MinimaxSparseCacheInsertArgs,
+    minimax_sparse_qknorm_rope,
+)
 from tokenspeed_kernel.ops.gemm.cuda import dsv3_router_gemm
 from tokenspeed_kernel.ops.layernorm.triton import qk_rmsnorm
 from tokenspeed_kernel.ops.moe.cuda import moe_finalize_fuse_shared
 from tokenspeed_kernel.platform import current_platform
-from tokenspeed_kernel.thirdparty.cuda.minimax_m3_fused import (
-    fused_qknorm_rope_kv_insert,
-)
 from torch import nn
 from transformers import MiniMaxM3VLTextConfig
 
@@ -47,6 +48,7 @@ from tokenspeed.runtime.distributed.mapping import Mapping
 from tokenspeed.runtime.distributed.utils import divide
 from tokenspeed.runtime.execution.context import ForwardContext
 from tokenspeed.runtime.execution.cuda_graph_wrapper import get_is_capture_mode
+from tokenspeed.runtime.layers.attention.backends.msa import MSAHybridAttnBackend
 from tokenspeed.runtime.layers.attention.mm_encoder_attention import VisionAttention
 from tokenspeed.runtime.layers.conv import Conv3dLayer
 from tokenspeed.runtime.layers.layernorm import GemmaRMSNorm
@@ -578,7 +580,7 @@ class MiniMaxM3Attention(nn.Module):
         self.is_sparse = config.layer_types[layer_id] == "minimax_m3_sparse"
         self.use_fused_qknorm_rope = (
             self.is_sparse
-            and current_platform().is_nvidia
+            and current_platform().is_hopper_plus
             and self.head_dim == 128
             and config.index_head_dim == 128
         )
@@ -662,8 +664,23 @@ class MiniMaxM3Attention(nn.Module):
 
         qkv, _ = self.qkv_proj(hidden_states)
 
+        cache_insert = None
+        if self.use_fused_qknorm_rope and isinstance(
+            ctx.attn_backend, MSAHybridAttnBackend
+        ):
+            cache_insert = ctx.attn_backend.create_fused_decode_cache_insert_args(
+                self.attn,
+                out_cache_loc,
+                ctx.token_to_kv_pool,
+                ctx.forward_mode,
+            )
+
         if self.use_fused_qknorm_rope:
-            q, k, v, attn_kwargs = self.fused_qknorm_rope(qkv, positions)
+            q, k, v, attn_kwargs = self.fused_qknorm_rope(
+                qkv,
+                positions,
+                cache_insert,
+            )
         else:
             q, k, v, attn_kwargs = self.qknorm_rope(qkv, positions)
 
@@ -673,6 +690,7 @@ class MiniMaxM3Attention(nn.Module):
             v,
             ctx=ctx,
             out_cache_loc=out_cache_loc,
+            save_kv_cache=cache_insert is None,
             **attn_kwargs,
         )
         output, _ = self.o_proj(attn_output)
@@ -713,25 +731,23 @@ class MiniMaxM3Attention(nn.Module):
         return q, k, v, attn_kwargs
 
     def fused_qknorm_rope(
-        self, qkv: torch.Tensor, positions: torch.Tensor
+        self,
+        qkv: torch.Tensor,
+        positions: torch.Tensor,
+        cache_insert: MinimaxSparseCacheInsertArgs | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, dict]:
-        q_out = qkv.new_empty(qkv.size(0), self.q_size)
-        index_q_out = qkv.new_empty(qkv.size(0), self.index_q_size)
-        fused_qknorm_rope_kv_insert(
-            qkv,
-            self.q_norm.weight,
-            self.k_norm.weight,
-            self.rotary_emb.cos_sin_cache,
-            positions,
-            self.num_heads,
-            self.num_kv_heads,
-            self.rotary_emb.rotary_dim,
-            self.q_norm.variance_epsilon,
+        q_out, index_q_out = minimax_sparse_qknorm_rope(
+            qkv=qkv,
+            q_norm_weight=self.q_norm.weight,
+            k_norm_weight=self.k_norm.weight,
             index_q_norm_weight=self.indexer.q_norm.weight,
             index_k_norm_weight=self.indexer.k_norm.weight,
-            num_index_heads=self.indexer.num_index_heads,
-            q_out=q_out,
-            index_q_out=index_q_out,
+            cos_sin_cache=self.rotary_emb.cos_sin_cache,
+            positions=positions,
+            num_heads=self.num_heads,
+            num_kv_heads=self.num_kv_heads,
+            eps=self.q_norm.variance_epsilon,
+            cache_insert=cache_insert,
             enable_pdl=pdl_enabled(),
         )
         _, k, v, _, index_k = qkv.split(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 # Backend registration (side-effect imports)
 import tokenspeed_kernel.ops.attention.cuda  # noqa: F401
@@ -63,6 +64,17 @@ from tokenspeed_kernel.signature import (
 )
 
 AttentionResult = torch.Tensor | tuple[torch.Tensor, torch.Tensor | None]
+
+
+@dataclass(frozen=True)
+class MinimaxSparseCacheInsertArgs:
+    """Destination buffers for the fused MiniMax sparse-attention producer."""
+
+    slot_mapping: torch.Tensor
+    k_cache: torch.Tensor
+    v_cache: torch.Tensor
+    index_k_cache: torch.Tensor
+
 
 # One UE8M0 scale per 32 consecutive head_dim elements (MXFP8).
 MXFP8_ATTENTION_BLOCK_SCALE = MXFP8_BLOCK_SCALE
@@ -139,6 +151,8 @@ __all__ = [
     "dsa_prefill_topk",
     "dsa_decode_topk",
     "dsa_plan",
+    "MinimaxSparseCacheInsertArgs",
+    "minimax_sparse_qknorm_rope",
     "msa_decode_with_kvcache",
     "msa_extend_with_kvcache",
     "attn_merge_state",
@@ -146,6 +160,112 @@ __all__ = [
 ]
 
 LSE_LN = math.log2(math.e)
+
+
+def minimax_sparse_qknorm_rope(
+    qkv: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    index_q_norm_weight: torch.Tensor,
+    index_k_norm_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    eps: float,
+    cache_insert: MinimaxSparseCacheInsertArgs | None = None,
+    enable_pdl: bool = False,
+    override: str | None = None,
+    solution: str | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Normalize and rotate MiniMax sparse Q/K and optionally insert caches.
+
+    Args:
+        qkv: Packed ``[Q | K | V | index-Q | index-K]`` projection output.
+        q_norm_weight: Main-query Gemma RMSNorm weight.
+        k_norm_weight: Main-key Gemma RMSNorm weight.
+        index_q_norm_weight: Index-query Gemma RMSNorm weight.
+        index_k_norm_weight: Index-key Gemma RMSNorm weight.
+        cos_sin_cache: Packed FP32 rotary-embedding cache.
+        positions: Int64 token positions.
+        num_heads: Number of local main-query heads.
+        num_kv_heads: Number of local K/V heads.
+        eps: RMSNorm epsilon.
+        cache_insert: Optional complete K/V/index-K cache insertion target.
+        enable_pdl: Request Programmatic Dependent Launch where supported.
+        override: Optional exact kernel-name override.
+        solution: Optional kernel solution override.
+
+    Returns:
+        Contiguous normalized and rotated main-query and index-query tensors.
+    """
+    if not qkv.is_contiguous():
+        raise ValueError("qkv must be contiguous")
+    head_dim = q_norm_weight.numel()
+    index_head_dim = index_q_norm_weight.numel()
+    index_width = qkv.shape[-1] - (num_heads + 2 * num_kv_heads) * head_dim
+    num_index_heads = index_width // index_head_dim - 1
+    rotary_dim = cos_sin_cache.shape[-1]
+    q_out = qkv.new_empty(qkv.shape[0], num_heads * head_dim)
+    index_q_out = qkv.new_empty(qkv.shape[0], num_index_heads * index_head_dim)
+    signature = format_signature(qkv=dense_tensor_format(qkv.dtype))
+    traits = {
+        "head_dim": head_dim,
+        "index_head_dim": index_head_dim,
+        "rotary_dim": rotary_dim,
+        "cache_dtype": cache_insert.k_cache.dtype if cache_insert else None,
+    }
+    kernel = select_kernel(
+        "attention",
+        "minimax_sparse_qknorm_rope",
+        signature,
+        traits=traits,
+        solution=solution,
+        override=override,
+    )
+    shape_params = {
+        "num_tokens": qkv.shape[0],
+        "num_heads": num_heads,
+        "num_kv_heads": num_kv_heads,
+        "num_index_heads": num_index_heads,
+        "head_dim": head_dim,
+        "rotary_dim": rotary_dim,
+        "has_cache_insert": cache_insert is not None,
+    }
+    ShapeCapture.get().record(
+        "attention",
+        "minimax_sparse_qknorm_rope",
+        kernel.name,
+        qkv.dtype,
+        shape_params,
+    )
+    with kernel_scope(
+        "attention",
+        "minimax_sparse_qknorm_rope",
+        qkv.dtype,
+        kernel_name=kernel.name,
+        **shape_params,
+    ):
+        kernel(
+            qkv=qkv,
+            q_norm_weight=q_norm_weight,
+            k_norm_weight=k_norm_weight,
+            index_q_norm_weight=index_q_norm_weight,
+            index_k_norm_weight=index_k_norm_weight,
+            cos_sin_cache=cos_sin_cache,
+            positions=positions,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            num_index_heads=num_index_heads,
+            rotary_dim=rotary_dim,
+            eps=eps,
+            q_out=q_out,
+            index_q_out=index_q_out,
+            cache_insert=cache_insert,
+            enable_pdl=enable_pdl,
+        )
+    return q_out, index_q_out
 
 
 def msa_decode_with_kvcache(
@@ -171,6 +291,7 @@ def msa_decode_with_kvcache(
     v_scale: float | torch.Tensor | None = None,
     score_out: torch.Tensor | None = None,
     enable_pdl: bool = False,
+    index_k_cache_prewritten: bool = False,
     override: str | None = None,
     solution: str | None = None,
 ) -> torch.Tensor:
@@ -207,6 +328,8 @@ def msa_decode_with_kvcache(
             accept it or when its shape does not match.
         enable_pdl: Request Programmatic Dependent Launch (SM90+) for the
             indexer's index-key store; forwarded to the kernel.
+        index_k_cache_prewritten: Skip the index-key store because the current
+            tokens were inserted by an earlier producer on the same stream.
         override: Optional kernel override name.
         solution: Optional kernel solution to force through normal selection.
 
@@ -289,6 +412,7 @@ def msa_decode_with_kvcache(
             v_scale=v_scale,
             score_out=score_out,
             enable_pdl=enable_pdl,
+            index_k_cache_prewritten=index_k_cache_prewritten,
         )
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cuda/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cuda/__init__.py
@@ -12,6 +12,7 @@ from tokenspeed_kernel.signature import format_signatures
 platform = current_platform()
 
 if platform.is_nvidia and platform.is_hopper_plus:
+    import tokenspeed_kernel.ops.attention.cuda.minimax_sparse  # noqa: F401
     from tokenspeed_kernel.thirdparty.cuda.merge_state import merge_state
 
     @register_kernel(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cuda/minimax_sparse.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cuda/minimax_sparse.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Copyright (c) 2026 LightSeek Foundation
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel.platform import ArchVersion, CapabilityRequirement
+from tokenspeed_kernel.registry import Priority, register_kernel
+from tokenspeed_kernel.signature import format_signatures
+from tokenspeed_kernel.thirdparty.cuda.minimax_m3_fused import (
+    fused_qknorm_rope_kv_insert,
+)
+
+
+@register_kernel(
+    "attention",
+    "minimax_sparse_qknorm_rope",
+    name="cuda_minimax_sparse_qknorm_rope",
+    solution="cuda",
+    capability=CapabilityRequirement(
+        min_arch_version=ArchVersion(9, 0),
+        vendors=frozenset({"nvidia"}),
+    ),
+    signatures=format_signatures(("qkv",), "dense", {torch.float16, torch.bfloat16}),
+    traits={
+        "head_dim": frozenset({128}),
+        "index_head_dim": frozenset({128}),
+        "rotary_dim": frozenset({8, 16, 32, 64, 128}),
+        "cache_dtype": frozenset(
+            {None, torch.float16, torch.bfloat16, torch.float8_e4m3fn}
+        ),
+    },
+    priority=Priority.SPECIALIZED,
+    tags={"latency"},
+)
+def cuda_minimax_sparse_qknorm_rope(
+    *,
+    qkv: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    index_q_norm_weight: torch.Tensor,
+    index_k_norm_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+    num_heads: int,
+    num_kv_heads: int,
+    num_index_heads: int,
+    rotary_dim: int,
+    eps: float,
+    q_out: torch.Tensor,
+    index_q_out: torch.Tensor,
+    cache_insert=None,
+    enable_pdl: bool = False,
+) -> None:
+    slot_mapping = k_cache = v_cache = index_k_cache = None
+    kv_cache_dtype = "auto"
+    if cache_insert is not None:
+        slot_mapping = cache_insert.slot_mapping
+        k_cache = cache_insert.k_cache
+        v_cache = cache_insert.v_cache
+        index_k_cache = cache_insert.index_k_cache
+        if v_cache.dtype != k_cache.dtype:
+            raise TypeError("K and V caches must have the same dtype")
+        if index_k_cache.dtype != qkv.dtype:
+            raise TypeError(
+                "MiniMax sparse index cache must match the projection dtype"
+            )
+        if k_cache.dtype == torch.float8_e4m3fn:
+            k_cache = k_cache.view(torch.uint8)
+            v_cache = v_cache.view(torch.uint8)
+            kv_cache_dtype = "fp8_e4m3"
+
+    fused_qknorm_rope_kv_insert(
+        qkv,
+        q_norm_weight,
+        k_norm_weight,
+        cos_sin_cache,
+        positions,
+        num_heads,
+        num_kv_heads,
+        rotary_dim,
+        eps,
+        index_q_norm_weight=index_q_norm_weight,
+        index_k_norm_weight=index_k_norm_weight,
+        num_index_heads=num_index_heads,
+        slot_mapping=slot_mapping,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        index_cache=index_k_cache,
+        q_out=q_out,
+        index_q_out=index_q_out,
+        kv_cache_dtype=kv_cache_dtype,
+        enable_pdl=enable_pdl,
+    )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_indexer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_indexer.py
@@ -327,6 +327,7 @@ def minimax_indexer(
     seq_lens_cpu: Sequence[int] | None = None,
     score_out: torch.Tensor | None = None,
     enable_pdl: bool = False,
+    index_k_cache_prewritten: bool = False,
 ) -> torch.Tensor:
     """Write index keys, score visible 128-token blocks, and select Top-K.
 
@@ -360,6 +361,8 @@ def minimax_indexer(
             fp32 buffer, pre-filled with ``-inf`` and reused across layers in
             place of a fresh per-call allocation. Honored only on the decode
             path when its shape/dtype match; otherwise a buffer is allocated.
+        index_k_cache_prewritten: Skip the current-token index-key store
+            because an earlier producer inserted it on the same stream.
 
     Returns:
         Selected logical block ids shaped ``[tokens, local_index_heads, topk]``.
@@ -401,20 +404,21 @@ def minimax_indexer(
     block_d = triton.next_power_of_2(head_dim)
     use_pdl = bool(enable_pdl and _is_nvidia)
     pdl_kwargs = {"launch_pdl": True} if use_pdl else {}
-    _store_index_k_kernel[(tokens,)](
-        index_k,
-        index_k_cache,
-        slot_mapping,
-        index_k.stride(0),
-        index_k.stride(1),
-        index_k_cache.stride(0),
-        index_k_cache.stride(1),
-        head_dim=head_dim,
-        BLOCK_D=block_d,
-        ENABLE_PDL=use_pdl,
-        num_warps=4,
-        **pdl_kwargs,
-    )
+    if not index_k_cache_prewritten:
+        _store_index_k_kernel[(tokens,)](
+            index_k,
+            index_k_cache,
+            slot_mapping,
+            index_k.stride(0),
+            index_k.stride(1),
+            index_k_cache.stride(0),
+            index_k_cache.stride(1),
+            head_dim=head_dim,
+            BLOCK_D=block_d,
+            ENABLE_PDL=use_pdl,
+            num_warps=4,
+            **pdl_kwargs,
+        )
 
     max_blocks = block_table.shape[1] if max_blocks is None else int(max_blocks)
     if not 0 < max_blocks <= block_table.shape[1]:

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_sparse_attention.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/minimax_sparse_attention.py
@@ -687,6 +687,7 @@ def triton_minimax_msa_decode_with_kvcache(
     v_scale: float | torch.Tensor | None = None,
     score_out: torch.Tensor | None = None,
     enable_pdl: bool = False,
+    index_k_cache_prewritten: bool = False,
 ) -> torch.Tensor:
     """Run MiniMax sparse-attention decode over paged caches."""
 
@@ -709,6 +710,7 @@ def triton_minimax_msa_decode_with_kvcache(
         max_blocks=max_blocks,
         score_out=score_out,
         enable_pdl=enable_pdl,
+        index_k_cache_prewritten=index_k_cache_prewritten,
     )
     return minimax_sparse_attention(
         q,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_minimax_m3_qknorm_rope_kv_insert.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_minimax_m3_qknorm_rope_kv_insert.cu
@@ -218,13 +218,16 @@ __device__ __forceinline__ void storeCacheElems(
     // model dtype directly. FP8 cache dtypes use the conversion path below.
     storeElems<scalar_t>(reinterpret_cast<scalar_t*>(dst), elems);
   } else {
-    // fp8 cache (identity scale 1.0): direct float -> e4m3/e5m2 byte.
+    // Match the unfused path, which materializes K in the model dtype before
+    // the paged-cache store converts it to FP8.
     constexpr __nv_fp8_interpretation_t kInterp =
         (kv_dt == Fp8KVCacheDataType::kFp8E4M3) ? __NV_E4M3 : __NV_E5M2;
 #pragma unroll
     for (int i = 0; i < kElemsPerLane; i++) {
+      float const rounded =
+          elemToFloat<scalar_t>(floatToElem<scalar_t>(elems[i]));
       dst[i] = static_cast<cache_t>(
-          __nv_cvt_float_to_fp8(elems[i], __NV_SATFINITE, kInterp));
+          __nv_cvt_float_to_fp8(rounded, __NV_SATFINITE, kInterp));
     }
   }
 }
@@ -290,8 +293,8 @@ __global__ void fusedMiniMaxM3QNormRopeKVInsertKernel(
     scalar_t const* __restrict__ ik_norm_w,
     float const* __restrict__ cos_sin_cache,  // fp32 [max_pos, rotary_dim]
     int64_t const* __restrict__ positions,       // [N] i64
-    int64_t const* __restrict__ slot_mapping,    // main K/V slots or nullptr
-    int64_t const* __restrict__ index_slot_mapping,  // index K slots/nullptr
+    int32_t const* __restrict__ slot_mapping,    // main K/V slots or nullptr
+    int32_t const* __restrict__ index_slot_mapping,  // index K slots/nullptr
     cache_t* __restrict__ k_cache,        // [num_slots, nkv, 128] or nullptr
     cache_t* __restrict__ v_cache,        // [num_slots, nkv, 128] or nullptr
     out_idx_t* __restrict__ index_cache,  // [nb*bs, 128]; scalar_t or e4m3 byte
@@ -469,8 +472,8 @@ void launchFusedMiniMaxM3(
     scalar_t* qkv, scalar_t* q_out, void* index_q_out, scalar_t const* q_norm_w,
     scalar_t const* k_norm_w, scalar_t const* iq_norm_w,
     scalar_t const* ik_norm_w, float const* cos_sin_cache,
-    int64_t const* positions, int64_t const* slot_mapping,
-    int64_t const* index_slot_mapping, cache_t* k_cache, cache_t* v_cache,
+    int64_t const* positions, int32_t const* slot_mapping,
+    int32_t const* index_slot_mapping, cache_t* k_cache, cache_t* v_cache,
     void* index_cache, float const eps, int const rotary_dim,
     int const num_tokens, int const nq, int const nkv, int const niq,
     int const block_size, int64_t const kv_s_slot, int64_t const kv_s_head,
@@ -635,8 +638,8 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
   int64_t kv_s_slot = 0, kv_s_head = 0, kv_s_dim = 0;
   if (insert_kv) {
     TVM_FFI_ICHECK(slot_mapping.has_value() &&
-                   slot_mapping.value().dtype() == dl_int64)
-        << "insert mode requires int64 slot_mapping";
+                   slot_mapping.value().dtype() == dl_int32)
+        << "insert mode requires int32 slot_mapping";
     TVM_FFI_ICHECK(v_cache.has_value()) << "insert mode requires v_cache";
     TensorView kc = k_cache.value();
     TensorView vc = v_cache.value();
@@ -682,12 +685,12 @@ void fused_minimax_m3_qknorm_rope_kv_insert(
       process_index ? index_k_norm_weight.value().data_ptr() : nullptr;
   void const* csc_ptr = cos_sin_cache.data_ptr();
   int64_t const* pos_ptr = static_cast<int64_t const*>(positions.data_ptr());
-  int64_t const* slot_ptr =
-      insert_kv ? static_cast<int64_t const*>(slot_mapping.value().data_ptr())
+  int32_t const* slot_ptr =
+      insert_kv ? static_cast<int32_t const*>(slot_mapping.value().data_ptr())
                 : nullptr;
-  int64_t const* idx_slot_ptr = nullptr;
+  int32_t const* idx_slot_ptr = nullptr;
   if (insert_kv && process_index)
-    idx_slot_ptr = static_cast<int64_t const*>(
+    idx_slot_ptr = static_cast<int32_t const*>(
         (index_slot_mapping.has_value() ? index_slot_mapping.value()
                                         : slot_mapping.value())
             .data_ptr());

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/minimax_m3_fused.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/minimax_m3_fused.py
@@ -65,8 +65,8 @@ def fused_qknorm_rope_kv_insert(
     (dense layers pass ``[q | k | v]`` with ``num_index_heads == 0``). q/k and,
     on the sparse path, index_q/index_k are rewritten in place; when given,
     contiguous ``q_out`` / ``index_q_out`` receive the de-interleaved outputs.
-    Norm weights are the folded Gemma weights (``1 + w``). ``cos_sin_cache`` is
-    ``[max_pos, rotary_dim]`` ([cos | sin] halves) in the qkv dtype.
+    Norm weights are the raw Gemma parameters; the kernel applies ``1 + w``.
+    ``cos_sin_cache`` is ``[max_pos, rotary_dim]`` ([cos | sin] halves) in FP32.
 
     ``enable_pdl`` requests Programmatic Dependent Launch (SM90+); when False the
     kernel launches without the stream-serialization attribute (its in-body
@@ -79,10 +79,12 @@ def fused_qknorm_rope_kv_insert(
         raise ValueError(f"unsupported kv_cache_dtype {kv_cache_dtype!r}")
     if positions.dtype != torch.int64:
         positions = positions.to(torch.int64)
-    if slot_mapping is not None and slot_mapping.dtype != torch.int64:
-        slot_mapping = slot_mapping.to(torch.int64)
-    if index_slot_mapping is not None and index_slot_mapping.dtype != torch.int64:
-        index_slot_mapping = index_slot_mapping.to(torch.int64)
+    if slot_mapping is not None and slot_mapping.dtype != torch.int32:
+        raise TypeError(f"slot_mapping must be int32, got {slot_mapping.dtype}")
+    if index_slot_mapping is not None and index_slot_mapping.dtype != torch.int32:
+        raise TypeError(
+            f"index_slot_mapping must be int32, got {index_slot_mapping.dtype}"
+        )
 
     _load_module().fused_minimax_m3_qknorm_rope_kv_insert(
         qkv,

--- a/tokenspeed-kernel/test/ops/test_attention_msa.py
+++ b/tokenspeed-kernel/test/ops/test_attention_msa.py
@@ -202,9 +202,10 @@ def test_msa_prefill_and_decode_after_2048() -> None:
         decode_seq_lens = torch.tensor(
             [prefill_len + 1], dtype=torch.int32, device="cuda"
         )
+        index_key_cache[decode_slot.long()] = decode_index_key
         decode_selected = minimax_indexer(
             decode_index_query,
-            decode_index_key,
+            torch.zeros_like(decode_index_key),
             index_key_cache,
             decode_slot,
             block_table,
@@ -215,6 +216,11 @@ def test_msa_prefill_and_decode_after_2048() -> None:
             local_blocks=1,
             decode_query_len=1,
             max_blocks=num_blocks,
+            index_k_cache_prewritten=True,
+        )
+        torch.testing.assert_close(
+            index_key_cache[decode_slot.long()],
+            decode_index_key,
         )
         all_index_keys = torch.cat([index_key, decode_index_key], dim=0)
         decode_expected = _reference_selected_blocks(

--- a/tokenspeed-kernel/test/ops/test_minimax_m3_fused_qknorm_rope_kv_insert.py
+++ b/tokenspeed-kernel/test/ops/test_minimax_m3_fused_qknorm_rope_kv_insert.py
@@ -5,7 +5,7 @@ Validates against an independent torch golden (Gemma RMSNorm with the raw weight
 -- the kernel adds ``1 + w`` internally -- then partial-NeoX RoPE) across:
   * norm+RoPE only (no cache insert),
   * K/V + index-K insert into TokenSpeed's separate flat slot-indexed buffers,
-  * fp8 KV cache + fp8 index cache / index_q output.
+  * production mixed cache dtypes: FP8 K/V and BF16 index state.
 
 Requires an NVIDIA GPU and the built ``minimax_m3_fused`` kernel module.
 """
@@ -14,14 +14,18 @@ from __future__ import annotations
 
 import pytest
 import torch
+from tokenspeed_kernel.ops.attention import (
+    MinimaxSparseCacheInsertArgs,
+    minimax_sparse_qknorm_rope,
+)
 from tokenspeed_kernel.platform import current_platform
 from tokenspeed_kernel.thirdparty.cuda.minimax_m3_fused import (
     fused_qknorm_rope_kv_insert,
 )
 
 pytestmark = pytest.mark.skipif(
-    not current_platform().is_nvidia,
-    reason="minimax_m3_fused kernel is NVIDIA-only",
+    not current_platform().is_hopper_plus,
+    reason="minimax_m3_fused kernel requires NVIDIA Hopper or newer",
 )
 
 HD, RD, EPS = 128, 64, 1e-6
@@ -70,24 +74,17 @@ def test_norm_rope_only():
     dev = "cuda"
     qkv, w, positions, csc, cos, sin = _fixtures(dev, 0)
     qkv_in = qkv.clone()
-    q_out = torch.empty(T, NQ * HD, device=dev, dtype=torch.bfloat16)
-    iq_out = torch.empty(T, NIQ * HD, device=dev, dtype=torch.bfloat16)
-
-    fused_qknorm_rope_kv_insert(
-        qkv,
-        w["q"],
-        w["k"],
-        csc,
-        positions,
-        NQ,
-        NKV,
-        RD,
-        EPS,
+    q_out, iq_out = minimax_sparse_qknorm_rope(
+        qkv=qkv,
+        q_norm_weight=w["q"],
+        k_norm_weight=w["k"],
         index_q_norm_weight=w["iq"],
         index_k_norm_weight=w["ik"],
-        num_index_heads=NIQ,
-        q_out=q_out,
-        index_q_out=iq_out,
+        cos_sin_cache=csc,
+        positions=positions,
+        num_heads=NQ,
+        num_kv_heads=NKV,
+        eps=EPS,
     )
 
     g_q = _golden_norm_rope(_slice(qkv_in, "q", NQ), w["q"], cos, sin)
@@ -109,11 +106,10 @@ def test_kv_and_index_insert_bf16():
     dev = "cuda"
     qkv, w, positions, csc, cos, sin = _fixtures(dev, 1)
     qkv_in = qkv.clone()
-    slots = torch.randperm(NUM_SLOTS, device=dev)[:T].to(torch.int64)
+    slots = torch.randperm(NUM_SLOTS, device=dev)[:T].to(torch.int32)
     k_cache = torch.zeros(NUM_SLOTS, NKV, HD, device=dev, dtype=torch.bfloat16)
     v_cache = torch.zeros(NUM_SLOTS, NKV, HD, device=dev, dtype=torch.bfloat16)
     index_cache = torch.zeros(NUM_SLOTS, HD, device=dev, dtype=torch.bfloat16)
-
     fused_qknorm_rope_kv_insert(
         qkv,
         w["q"],
@@ -152,54 +148,48 @@ def test_kv_and_index_insert_bf16():
     torch.testing.assert_close(index_cache, gidx, atol=2e-2, rtol=0)
 
 
-def test_fp8_kv_and_index():
+def test_fp8_kv_and_bf16_index():
     dev = "cuda"
     qkv, w, positions, csc, cos, sin = _fixtures(dev, 2)
     qkv_in = qkv.clone()
-    slots = torch.randperm(NUM_SLOTS, device=dev)[:T].to(torch.int64)
-    k_cache = torch.zeros(NUM_SLOTS, NKV, HD, device=dev, dtype=torch.uint8)
-    v_cache = torch.zeros(NUM_SLOTS, NKV, HD, device=dev, dtype=torch.uint8)
-    index_cache = torch.zeros(NUM_SLOTS, HD, device=dev, dtype=E4M3)
-    iq_out = torch.empty(T, NIQ * HD, device=dev, dtype=E4M3)
-
-    fused_qknorm_rope_kv_insert(
-        qkv,
-        w["q"],
-        w["k"],
-        csc,
-        positions,
-        NQ,
-        NKV,
-        RD,
-        EPS,
+    slots = torch.randperm(NUM_SLOTS, device=dev)[:T].to(torch.int32)
+    k_cache = torch.zeros(NUM_SLOTS, NKV, HD, device=dev, dtype=E4M3)
+    v_cache = torch.zeros(NUM_SLOTS, NKV, HD, device=dev, dtype=E4M3)
+    index_cache = torch.zeros(NUM_SLOTS, HD, device=dev, dtype=torch.bfloat16)
+    _, iq_out = minimax_sparse_qknorm_rope(
+        qkv=qkv,
+        q_norm_weight=w["q"],
+        k_norm_weight=w["k"],
         index_q_norm_weight=w["iq"],
         index_k_norm_weight=w["ik"],
-        num_index_heads=NIQ,
-        slot_mapping=slots,
-        k_cache=k_cache,
-        v_cache=v_cache,
-        index_cache=index_cache,
-        index_q_out=iq_out,
-        block_size=1,
-        kv_cache_dtype="fp8_e4m3",
+        cos_sin_cache=csc,
+        positions=positions,
+        num_heads=NQ,
+        num_kv_heads=NKV,
+        eps=EPS,
+        cache_insert=MinimaxSparseCacheInsertArgs(
+            slot_mapping=slots,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            index_k_cache=index_cache,
+        ),
     )
 
     gk = torch.zeros(NUM_SLOTS, NKV, HD, device=dev, dtype=E4M3)
     gv = torch.zeros(NUM_SLOTS, NKV, HD, device=dev, dtype=E4M3)
-    gidx = torch.zeros(NUM_SLOTS, HD, device=dev, dtype=E4M3)
-    gk[slots] = _golden_norm_rope(_slice(qkv_in, "k", NKV), w["k"], cos, sin).to(E4M3)
+    gidx = torch.zeros_like(index_cache)
+    gk[slots] = _slice(qkv, "k", NKV).to(E4M3)
     gv[slots] = _slice(qkv_in, "v", NKV).to(E4M3)
-    gidx[slots] = (
-        _golden_norm_rope(_slice(qkv_in, "ik", 1), w["ik"], cos, sin)
-        .to(E4M3)
-        .view(T, HD)
-    )
-    g_iq = _golden_norm_rope(_slice(qkv_in, "iq", NIQ), w["iq"], cos, sin).to(E4M3)
+    gidx[slots] = _slice(qkv, "ik", 1).view(T, HD)
 
-    # Compare decoded fp8 (identity scale) -- expected bit-identical rounding.
-    torch.testing.assert_close(k_cache.view(E4M3).float(), gk.float(), atol=0, rtol=0)
-    torch.testing.assert_close(v_cache.view(E4M3).float(), gv.float(), atol=0, rtol=0)
-    torch.testing.assert_close(index_cache.float(), gidx.float(), atol=0, rtol=0)
+    # The fused cache writes match the original two-step path bit for bit:
+    # qk-norm/RoPE materializes BF16 before the paged-cache FP8 conversion.
+    torch.testing.assert_close(k_cache.float(), gk.float(), atol=0, rtol=0)
+    torch.testing.assert_close(v_cache.float(), gv.float(), atol=0, rtol=0)
+    torch.testing.assert_close(index_cache, gidx, atol=0, rtol=0)
     torch.testing.assert_close(
-        iq_out.view(T, NIQ, HD).float(), g_iq.float(), atol=0, rtol=0
+        iq_out.view(T, NIQ, HD).float(),
+        _golden_norm_rope(_slice(qkv_in, "iq", NIQ), w["iq"], cos, sin),
+        atol=2e-2,
+        rtol=0,
     )


### PR DESCRIPTION
## Summary

Fuse MiniMax sparse Q/K normalization, RoPE, and K/V/index-K cache insertion into the existing CUDA producer.

The MSA backend now receives an atomic cache target for eligible decode calls and skips its redundant K/V and index-K stores after the producer has written all three cache components. Dense layers, prefill, non-identity scales, and unsupported platforms retain the existing path.

The fused producer is exposed through TokenSpeed Kernel's normal registry, selection, shape-capture, and profiling boundary rather than imported directly from runtime model code.

## Motivation

MiniMax M3 has 57 sparse-attention layers. Before this change, each decode step launched the fused QK-norm/RoPE producer and then separately launched one K/V cache store and one index-K cache store per sparse layer. This change removes those 114 redundant store launches per decode step while preserving the standard hybrid-attention breakpoint and dispatch path.

The FP8 cache conversion explicitly rounds through the model dtype so the result remains bit-equivalent to the previous two-stage path. Flat-cache slot mappings stay int32 end to end.

Inspired by NVIDIA/TensorRT-LLM#16755.

## Performance

B200 TP4, MiniMax-M3-NVFP4, FP8 KV cache, ShareGPT, 20 prompts, 64 output tokens, concurrency 1, A-B-B-A:

| Variant | Mean TPOT |
| --- | ---: |
| Baseline A1 | 4.3261 ms |
| Candidate B1 | 4.0597 ms |
| Candidate B2 | 4.0500 ms |
| Baseline A2 | 4.2098 ms |

The two-run averages improve from 4.2679 ms to 4.0548 ms (**4.99% lower TPOT**). Averaging run medians gives **3.90% lower TPOT**, so the conservative expected improvement is about 4%. No TTFT improvement is claimed.

## Validation

- `pre-commit run --all-files`
- `CUDA_VISIBLE_DEVICES=0 pytest -q test/runtime/models/test_minimax_m3.py test/runtime/test_minimax_m3_fused_qkv_indexer.py` — 16 passed
- `CUDA_VISIBLE_DEVICES=1 pytest -q tokenspeed-kernel/test/ops/test_minimax_m3_fused_qknorm_rope_kv_insert.py tokenspeed-kernel/test/ops/test_attention_msa.py` — 19 passed
- Rebuilt the native `minimax_m3_fused` extension successfully
- TP2 B200 server smoke with CUDA graphs enabled completed a real decode request with coherent output
- Production FP8 K/V plus BF16 index-cache writes match the prior path bit for bit