### PR TITLE
refactor: backend seq_lens ownership and fix dsv3

### DIFF
--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -236,7 +236,6 @@ class CudaGraphWrapper:
         init_backend_cuda_graph_state(
             attn_backend,
             self.max_bs,
-            self.input_buffers.seq_lens_buf,
             paged_cache_group_specs=tuple(token_to_kv_pool.paged_cache_group_specs),
             max_tokens_per_req=self.max_tokens_per_req,
             overlap_schedule_depth=self.overlap_schedule_depth,
@@ -245,7 +244,6 @@ class CudaGraphWrapper:
             init_backend_cuda_graph_state(
                 draft_attn_backend,
                 self.max_bs,
-                self.drafter.draft_seq_lens_buf,
                 paged_cache_group_specs=tuple(
                     draft_token_to_kv_pool.paged_cache_group_specs
                 ),

--- a/python/tokenspeed/runtime/execution/distributed_initializer.py
+++ b/python/tokenspeed/runtime/execution/distributed_initializer.py
@@ -21,7 +21,6 @@
 from dataclasses import dataclass
 
 import torch
-from tokenspeed_kernel.platform import current_platform
 
 from tokenspeed.runtime.distributed.process_group_manager import (
     process_group_manager as pg_manager,
@@ -150,12 +149,10 @@ class DistributedInitializer:
         else:
             dist_init_method = f"tcp://127.0.0.1:{config.nccl_port}"
 
-        # Device-scoped NCCL init is only required and tested on AMD.
-        device_id = (
-            torch.device(config.device, config.gpu_id)
-            if current_platform().is_amd
-            else None
-        )
+        # Pass the device so PyTorch binds the process group to it (eager NCCL
+        # init) instead of inferring it later — this also mutes the c10d
+        # "barrier(): using the device under current context" warning.
+        device_id = torch.device(config.device, config.gpu_id)
 
         # Initialize distributed via the mapping-based process group manager
         pg_manager.init_distributed(

--- a/python/tokenspeed/runtime/layers/attention/backends/base.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/base.py
@@ -70,6 +70,8 @@ class AttentionBackend(ABC):
     # False for flat-capable backends whose spec-verify path is not wired yet.
     flat_spec_capable: bool = True
     uses_padded_decode_token_mask: bool = False
+    # Backend-owned cuda-graph cache-seqlens buffer the decode metadata views.
+    draft_seq_lens_attr: str = "cuda_graph_seq_lens"
 
     def __init__(self, config: BaseAttnConfig) -> None:
         self.device = config.device
@@ -124,6 +126,18 @@ class AttentionBackend(ABC):
         """Init the global shared states for cuda graph. Backends own their
         cache-seqlens buffer and copy the live lengths in at replay time."""
         raise NotImplementedError()
+
+    def advance_draft_forward_metadata(self, seq_lens: torch.Tensor) -> None:
+        """Publish the drafter's in-graph seq_lens edits into our own buffer.
+
+        Copies into ``draft_seq_lens_attr``; backends with distinct draft
+        metadata or an inner backend override this.
+        """
+        buf = getattr(self, self.draft_seq_lens_attr, None)
+        if buf is None:
+            return
+        bs = seq_lens.shape[0]
+        buf[:bs].copy_(seq_lens[:bs])
 
     def init_forward_metadata_capture_cuda_graph(
         self,

--- a/python/tokenspeed/runtime/layers/attention/backends/base.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/base.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
 def init_backend_cuda_graph_state(
     backend: "AttentionBackend",
     max_bs: int,
-    seq_lens_buf: torch.Tensor,
     **extras,
 ) -> None:
     """Call ``backend.init_cuda_graph_state`` with only the kwargs its
@@ -56,7 +55,7 @@ def init_backend_cuda_graph_state(
     params = inspect.signature(backend.init_cuda_graph_state).parameters
     if not any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):
         extras = {k: v for k, v in extras.items() if k in params}
-    backend.init_cuda_graph_state(max_bs, seq_lens_buf, **extras)
+    backend.init_cuda_graph_state(max_bs, **extras)
 
 
 class AttentionBackend(ABC):
@@ -121,10 +120,9 @@ class AttentionBackend(ABC):
         """
         raise NotImplementedError()
 
-    def init_cuda_graph_state(self, max_bs: int, seq_lens_buf: torch.Tensor):
-        """Init the global shared states for cuda graph. `seq_lens_buf` is
-        the controller-owned per-request seq_lens; backends should reference
-        (alias) it rather than copy, and must not mutate the contents."""
+    def init_cuda_graph_state(self, max_bs: int):
+        """Init the global shared states for cuda graph. Backends own their
+        cache-seqlens buffer and copy the live lengths in at replay time."""
         raise NotImplementedError()
 
     def init_forward_metadata_capture_cuda_graph(

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -1606,12 +1606,10 @@ class DeepseekV4AttentionBackend(AttentionBackend):
     def init_cuda_graph_state(
         self,
         max_bs: int,
-        seq_lens_buf: torch.Tensor | None = None,
         paged_cache_group_specs=(),
         max_tokens_per_req: int = 1,
         overlap_schedule_depth: int = 0,
     ):
-        del seq_lens_buf
         self._decode_tile_metadata = {}
         self._cuda_graph_max_tokens_per_req = max(
             1,

--- a/python/tokenspeed/runtime/layers/attention/backends/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/dsa.py
@@ -120,8 +120,8 @@ class DSABackend(AttentionBackend):
     def override_num_extends(self, num_extends: int):
         return self._dense_backend.override_num_extends(num_extends)
 
-    def init_cuda_graph_state(self, max_bs: int, seq_lens_buf: torch.Tensor):
-        self._dense_backend.init_cuda_graph_state(max_bs, seq_lens_buf)
+    def init_cuda_graph_state(self, max_bs: int):
+        self._dense_backend.init_cuda_graph_state(max_bs)
 
     def init_forward_metadata_capture_cuda_graph(
         self,

--- a/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
@@ -173,11 +173,9 @@ class FlashMLABackend(AttentionBackend):
         # fresh object every step; under CUDA graph a fresh object is created at
         # capture time (see init_forward_metadata_capture_cuda_graph) so the
         # schedule build is recorded into the graph and recomputed from the live
-        # cache_seqlens buffer on each replay. This dict (keyed by bs) holds the
-        # captured objects so replay can look them up and so they stay alive.
-        self._decode_tile_metadata: dict[int, object] = {}
-        # Strong refs to every sched captured into a graph, so none is GC'd while
-        # its graph is alive (multiple sampling variants may capture the same bs).
+        # cache_seqlens buffer on each replay. Strong refs to every sched captured
+        # into a graph, so none is GC'd while its graph is alive (multiple sampling
+        # variants may capture the same bs).
         self._decode_tile_metadata_keepalive: list[object] = []
 
     # ------------------------------------------------------------------
@@ -245,28 +243,13 @@ class FlashMLABackend(AttentionBackend):
 
         Must be called *inside* graph capture: a fresh (uninitialized) object is
         created so the schedule build is captured and re-executed from the live
-        cache_seqlens buffer on every replay. The object is stored per-bs (and
-        kept alive) so the replay hook binds the exact same object the graph
-        recorded.
+        cache_seqlens buffer on every replay. The object is kept alive for the
+        lifetime of the graph that recorded it (a graph replays the recorded
+        schedule-build kernel against this object's tensors).
         """
         tile_metadata = get_mla_metadata()[0]
-        self._decode_tile_metadata[bs] = tile_metadata
         self._decode_tile_metadata_keepalive.append(tile_metadata)
         return tile_metadata
-
-    # Best practice: Shared _impl between the eager and cuda-graph decode metadata paths
-    def _init_decode_metadata_impl(
-        self,
-        global_table: torch.Tensor,
-        seq_lens: torch.Tensor,
-    ):
-        """Return this batch's ``(block_table, cache_seqlens)`` for decode.
-
-        Shared by the eager and cuda-graph-replay metadata paths so both derive
-        the page table / cache lengths identically from the gathered global page
-        table.
-        """
-        return global_table, seq_lens
 
     def _init_decode_metadata(
         self,
@@ -276,14 +259,11 @@ class FlashMLABackend(AttentionBackend):
         seq_lens: torch.Tensor,
         req_to_page: torch.Tensor,
     ):
-        block_table, base_seq_lens = self._init_decode_metadata_impl(
-            req_to_page[req_pool_indices], seq_lens
-        )
         self.forward_decode_metadata = FlashMLADecodeMetadata(
             num_extends=num_extends,
             flashmla_metadata=self._new_eager_tile_metadata(),
-            block_table=block_table,
-            seq_lens_k=base_seq_lens,
+            block_table=req_to_page[req_pool_indices],
+            seq_lens_k=seq_lens,
         )
 
     def _init_prefill_metadata(
@@ -417,21 +397,10 @@ class FlashMLABackend(AttentionBackend):
         if forward_mode is None or not forward_mode.is_decode_or_idle():
             raise RuntimeError(f"Not supported forward mode: {forward_mode}")
 
-        block_table, base_seq_lens = self._init_decode_metadata_impl(
-            req_to_page[req_pool_indices[:bs]], seq_lens[:bs]
-        )
+        block_table = req_to_page[req_pool_indices[:bs]]
 
-        # Same (block_table, base_seq_lens) as the eager path, but copied into the
-        # persistent buffers the captured kernel reads from.
         self.cuda_graph_kv_indices[:bs, : block_table.shape[1]].copy_(block_table)
-        self.cuda_graph_seq_lens_k[:bs].copy_(base_seq_lens)
-
-        # Bind the exact sched object the graph recorded at capture; the captured
-        # schedule-build kernel writes into this object's tensors on replay.
-        self.forward_decode_metadata.num_extends = 0
-        self.forward_decode_metadata.flashmla_metadata = self._decode_tile_metadata[bs]
-        self.forward_decode_metadata.block_table = self.cuda_graph_kv_indices[:bs]
-        self.forward_decode_metadata.seq_lens_k = self.cuda_graph_seq_lens_k[:bs]
+        self.cuda_graph_seq_lens_k[:bs].copy_(seq_lens[:bs])
 
     def get_cuda_graph_seq_len_fill_value(self):
         return 1

--- a/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
@@ -96,6 +96,8 @@ class FlashMLABackend(AttentionBackend):
     prefill wrappers for the EXTEND path.
     """
 
+    draft_seq_lens_attr: str = "cuda_graph_seq_lens_k"
+
     def __init__(self, config: MLAConfig):
         super().__init__(config)
 
@@ -378,6 +380,9 @@ class FlashMLABackend(AttentionBackend):
         if not (decode_no_spec or is_target_verify or is_draft_extend):
             raise RuntimeError(f"Not supported forward mode: {forward_mode}")
 
+        # Seed before building the tile schedule: it is recorded against these
+        # lengths, and the capture run reads them before any replay.
+        self.cuda_graph_seq_lens_k[:bs].copy_(seq_lens[:bs])
         self.forward_decode_metadata = FlashMLADecodeMetadata(
             num_extends=0,
             flashmla_metadata=self._capture_decode_tile_metadata(bs),

--- a/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
@@ -58,9 +58,9 @@ if TYPE_CHECKING:
 @dataclass
 class FlashMLADecodeMetadata:
     num_extends: int = 0
-    flashmla_metadata: tuple | None = None
-    num_splits: torch.Tensor | None = None
+    flashmla_metadata: object | None = None
     block_table: torch.Tensor | None = None
+    seq_lens_k: torch.Tensor | None = None
 
 
 @dataclass
@@ -165,6 +165,20 @@ class FlashMLABackend(AttentionBackend):
         self.forward_prefill_metadata: _PrefillMetadata | None = None
         self.chunked_prefill_metadata: _ChunkedPrefillMetadata | None = None
         self.last_seq_lens_sum: int | None = None
+        # FlashMLA builds its tile schedule lazily inside the FIRST
+        # flash_mla_with_kvcache call (from that call's cache_seqlens) and then
+        # freezes it on the FlashMLASchedMeta object. So a sched object must not
+        # be reused across calls whose cache_seqlens differ, or the kernel keeps
+        # attending the stale (first-seen) sequence length. Eager decode takes a
+        # fresh object every step; under CUDA graph a fresh object is created at
+        # capture time (see init_forward_metadata_capture_cuda_graph) so the
+        # schedule build is recorded into the graph and recomputed from the live
+        # cache_seqlens buffer on each replay. This dict (keyed by bs) holds the
+        # captured objects so replay can look them up and so they stay alive.
+        self._decode_tile_metadata: dict[int, object] = {}
+        # Strong refs to every sched captured into a graph, so none is GC'd while
+        # its graph is alive (multiple sampling variants may capture the same bs).
+        self._decode_tile_metadata_keepalive: list[object] = []
 
     # ------------------------------------------------------------------
     # Metadata init
@@ -216,6 +230,44 @@ class FlashMLABackend(AttentionBackend):
         finally:
             self.forward_decode_metadata.num_extends = prev
 
+    def _new_eager_tile_metadata(self):
+        """Return a fresh (uninitialized) FlashMLASchedMeta for one eager decode.
+
+        FlashMLA freezes its tile schedule from the FIRST kernel call's
+        cache_seqlens, so eager decode must hand the kernel a fresh object every
+        step — reusing one would keep attending the first step's sequence length.
+        The object itself is cheap; the schedule build happens inside the kernel.
+        """
+        return get_mla_metadata()[0]
+
+    def _capture_decode_tile_metadata(self, bs: int):
+        """Return the FlashMLASchedMeta to record into the CUDA graph for ``bs``.
+
+        Must be called *inside* graph capture: a fresh (uninitialized) object is
+        created so the schedule build is captured and re-executed from the live
+        cache_seqlens buffer on every replay. The object is stored per-bs (and
+        kept alive) so the replay hook binds the exact same object the graph
+        recorded.
+        """
+        tile_metadata = get_mla_metadata()[0]
+        self._decode_tile_metadata[bs] = tile_metadata
+        self._decode_tile_metadata_keepalive.append(tile_metadata)
+        return tile_metadata
+
+    # Best practice: Shared _impl between the eager and cuda-graph decode metadata paths
+    def _init_decode_metadata_impl(
+        self,
+        global_table: torch.Tensor,
+        seq_lens: torch.Tensor,
+    ):
+        """Return this batch's ``(block_table, cache_seqlens)`` for decode.
+
+        Shared by the eager and cuda-graph-replay metadata paths so both derive
+        the page table / cache lengths identically from the gathered global page
+        table.
+        """
+        return global_table, seq_lens
+
     def _init_decode_metadata(
         self,
         bs: int,
@@ -224,31 +276,14 @@ class FlashMLABackend(AttentionBackend):
         seq_lens: torch.Tensor,
         req_to_page: torch.Tensor,
     ):
-        if req_to_page is not None:
-            block_table = req_to_page[req_pool_indices]
-        else:
-            block_table = None
-
-        # When spec-dec is active (self.spec_num_tokens > 1), advance per-row
-        # seq_lens by the worst-case verify width so the tile planner covers
-        # the longest path.
-        if self.spec_num_tokens > 1:
-            plan_seq_lens = seq_lens + self.draft_token_num
-            num_heads_plan = self.draft_token_num * self.num_q_heads
-        else:
-            plan_seq_lens = seq_lens
-            num_heads_plan = self.num_q_heads
-
-        mla_metadata, num_splits = get_mla_metadata(
-            plan_seq_lens.to(torch.int32),
-            num_heads_plan,
-            1,
+        block_table, base_seq_lens = self._init_decode_metadata_impl(
+            req_to_page[req_pool_indices], seq_lens
         )
         self.forward_decode_metadata = FlashMLADecodeMetadata(
             num_extends=num_extends,
-            flashmla_metadata=mla_metadata,
-            num_splits=num_splits,
+            flashmla_metadata=self._new_eager_tile_metadata(),
             block_table=block_table,
+            seq_lens_k=base_seq_lens,
         )
 
     def _init_prefill_metadata(
@@ -328,40 +363,19 @@ class FlashMLABackend(AttentionBackend):
     # CUDA graph (decode only, any q_len)
     # ------------------------------------------------------------------
 
-    def init_cuda_graph_state(self, max_bs: int, seq_lens_buf: torch.Tensor):
-        del seq_lens_buf  # flashmla allocates its own buffers.
+    def init_cuda_graph_state(self, max_bs: int):
         max_context_len = self.max_context_len + PAGE_SIZE - 1
         # 4 PAGES are reserved for speculation
-        cuda_graph_kv_indices = torch.full(
+        self.cuda_graph_kv_indices = torch.full(
             (max_bs, (max_context_len + 4 * PAGE_SIZE) // PAGE_SIZE),
             1,
             dtype=torch.int32,
             device="cuda",
         )
-
-        if self.draft_token_num:
-            (
-                self.cuda_graph_mla_metadata,
-                self.cuda_graph_num_splits,
-            ) = get_mla_metadata(
-                torch.ones(
-                    max_bs, dtype=torch.int32, device=cuda_graph_kv_indices.device
-                ),
-                self.draft_token_num * self.num_q_heads,
-                1,
-            )
-        else:
-            (
-                self.cuda_graph_mla_metadata,
-                self.cuda_graph_num_splits,
-            ) = get_mla_metadata(
-                torch.ones(
-                    max_bs, dtype=torch.int32, device=cuda_graph_kv_indices.device
-                ),
-                self.num_q_heads,
-                1,
-            )
-        self.cuda_graph_kv_indices = cuda_graph_kv_indices
+        # Own the persistent cache_seqlens buffer the captured decode kernel reads from
+        self.cuda_graph_seq_lens_k = torch.zeros(
+            max_bs, dtype=torch.int32, device="cuda"
+        )
 
     def init_forward_metadata_capture_cuda_graph(
         self,
@@ -370,7 +384,7 @@ class FlashMLABackend(AttentionBackend):
         seq_lens: torch.Tensor,
         forward_mode: ForwardMode,
     ):
-        block_table = self.cuda_graph_kv_indices[:bs]
+        decode_no_spec = forward_mode.is_decode_or_idle() and self.spec_num_tokens == 1
         is_target_verify = (
             forward_mode.is_decode_or_idle()
             and not self.is_draft
@@ -381,86 +395,43 @@ class FlashMLABackend(AttentionBackend):
             and self.is_draft
             and self.spec_num_tokens > 1
         )
-
-        if forward_mode.is_decode_or_idle() and self.spec_num_tokens == 1:
-            mla_metadata, num_splits = get_mla_metadata(
-                seq_lens.to(torch.int32),
-                self.num_q_heads,
-                1,
-            )
-            self.cuda_graph_mla_metadata.copy_(mla_metadata)
-            self.cuda_graph_num_splits[: bs + 1].copy_(num_splits)
-            self.cuda_graph_kv_indices[:bs].copy_(block_table)
-            self.forward_decode_metadata = FlashMLADecodeMetadata(
-                num_extends=0,
-                flashmla_metadata=self.cuda_graph_mla_metadata,
-                num_splits=self.cuda_graph_num_splits[: bs + 1],
-                block_table=self.cuda_graph_kv_indices[:bs, :],
-            )
-        elif is_target_verify or is_draft_extend:
-            seq_lens = seq_lens + self.draft_token_num
-            mla_metadata, num_splits = get_mla_metadata(
-                seq_lens.to(torch.int32),
-                self.draft_token_num * self.num_q_heads,
-                1,
-            )
-            self.cuda_graph_mla_metadata.copy_(mla_metadata)
-            self.cuda_graph_num_splits[: bs + 1].copy_(num_splits)
-            self.cuda_graph_kv_indices[:bs].copy_(block_table)
-            self.forward_decode_metadata = FlashMLADecodeMetadata(
-                num_extends=0,
-                flashmla_metadata=self.cuda_graph_mla_metadata,
-                num_splits=self.cuda_graph_num_splits[: bs + 1],
-                block_table=self.cuda_graph_kv_indices[:bs],
-            )
-        else:
+        if not (decode_no_spec or is_target_verify or is_draft_extend):
             raise RuntimeError(f"Not supported forward mode: {forward_mode}")
+
+        self.forward_decode_metadata = FlashMLADecodeMetadata(
+            num_extends=0,
+            flashmla_metadata=self._capture_decode_tile_metadata(bs),
+            block_table=self.cuda_graph_kv_indices[:bs],
+            seq_lens_k=self.cuda_graph_seq_lens_k[:bs],
+        )
 
     def init_forward_metadata_replay_cuda_graph(
         self,
         bs: int,
         req_pool_indices: torch.Tensor,
         seq_lens: torch.Tensor,
-        forward_mode: ForwardMode = None,
-        req_to_page: torch.Tensor = None,
+        forward_mode: ForwardMode,
+        req_to_page: torch.Tensor,
         **kwargs,
     ):
         if forward_mode is None or not forward_mode.is_decode_or_idle():
             raise RuntimeError(f"Not supported forward mode: {forward_mode}")
 
-        req_pool_indices = req_pool_indices[:bs]
-        if req_to_page is not None:
-            block_table = req_to_page[req_pool_indices]
-        else:
-            block_table = self.cuda_graph_kv_indices[:bs]
-        seq_lens = seq_lens[:bs]
+        block_table, base_seq_lens = self._init_decode_metadata_impl(
+            req_to_page[req_pool_indices[:bs]], seq_lens[:bs]
+        )
 
-        is_target_verify = not self.is_draft and self.spec_num_tokens > 1
-        is_draft_extend = self.is_draft and self.spec_num_tokens > 1
+        # Same (block_table, base_seq_lens) as the eager path, but copied into the
+        # persistent buffers the captured kernel reads from.
+        self.cuda_graph_kv_indices[:bs, : block_table.shape[1]].copy_(block_table)
+        self.cuda_graph_seq_lens_k[:bs].copy_(base_seq_lens)
 
-        if self.spec_num_tokens == 1:
-            mla_metadata, num_splits = get_mla_metadata(
-                seq_lens.to(torch.int32),
-                self.num_q_heads,
-                1,
-            )
-        elif is_target_verify or is_draft_extend:
-            seq_lens = seq_lens + self.draft_token_num
-            mla_metadata, num_splits = get_mla_metadata(
-                seq_lens.to(torch.int32),
-                self.draft_token_num * self.num_q_heads,
-                1,
-            )
-        else:
-            raise RuntimeError(f"Not supported forward mode: {forward_mode}")
-
-        self.cuda_graph_mla_metadata.copy_(mla_metadata)
-        self.cuda_graph_num_splits[: bs + 1].copy_(num_splits)
-        self.cuda_graph_kv_indices[:bs].copy_(block_table)
+        # Bind the exact sched object the graph recorded at capture; the captured
+        # schedule-build kernel writes into this object's tensors on replay.
         self.forward_decode_metadata.num_extends = 0
-        self.forward_decode_metadata.flashmla_metadata = self.cuda_graph_mla_metadata
-        self.forward_decode_metadata.num_splits = self.cuda_graph_num_splits[: bs + 1]
+        self.forward_decode_metadata.flashmla_metadata = self._decode_tile_metadata[bs]
         self.forward_decode_metadata.block_table = self.cuda_graph_kv_indices[:bs]
+        self.forward_decode_metadata.seq_lens_k = self.cuda_graph_seq_lens_k[:bs]
 
     def get_cuda_graph_seq_len_fill_value(self):
         return 1
@@ -478,72 +449,25 @@ class FlashMLABackend(AttentionBackend):
         out_cache_loc: torch.Tensor,
         token_to_kv_pool,
         bs: int,
-        save_kv_cache: bool = True,
-        seq_lens: torch.Tensor | None = None,
-        forward_mode: ForwardMode | None = None,
+        save_kv_cache: bool,
+        forward_mode: ForwardMode,
         **kwargs,
     ):
-        q_len_per_req = q.shape[0] // bs if bs > 0 else 1
-        is_target_verify = (
-            forward_mode is not None
-            and forward_mode.is_decode_or_idle()
-            and not self.is_draft
-            and q_len_per_req > 1
-        )
-        is_draft_extend = (
-            forward_mode is not None
-            and forward_mode.is_decode_or_idle()
-            and self.is_draft
-            and q_len_per_req > 1
-        )
+        assert forward_mode is not None and forward_mode.is_extend()
 
-        if forward_mode is None or forward_mode.is_extend():
-            # Prefill: dispatch to ragged (MHA-style) or absorbed (MQA) path.
-            if self.forward_prefill_metadata.use_ragged:
-                return self._forward_normal_extend(q, k, v, layer, save_kv_cache)
-            else:
-                return self._forward_absorbed_extend(
-                    q,
-                    k,
-                    v,
-                    layer,
-                    out_cache_loc,
-                    token_to_kv_pool,
-                    save_kv_cache,
-                )
-
-        assert is_target_verify or is_draft_extend
-        if k is not None:
-            assert v is not None
-            if save_kv_cache:
-                token_to_kv_pool.set_kv_buffer(layer, out_cache_loc, k, v)
-
-        metadata = self.forward_decode_metadata
-        num_extends = metadata.num_extends
-        bs = (
-            q.shape[0]
-            if is_draft_extend
-            else metadata.block_table.shape[0] - num_extends
-        )
-        k_cache = token_to_kv_pool.get_key_buffer(layer.layer_id)
-
-        assert (
-            layer.tp_q_head_num == self.num_q_heads
-        ), f"{layer.tp_q_head_num=} != {self.num_q_heads=}"
-        reshape_q = q.view(bs, -1, self.num_q_heads, layer.head_dim)
-
-        o, _ = flash_mla_with_kvcache(
-            q=reshape_q,
-            k_cache=k_cache.view(-1, PAGE_SIZE, 1, self.kv_cache_dim),
-            block_table=metadata.block_table[num_extends : num_extends + bs],
-            cache_seqlens=seq_lens.to(torch.int32) + self.draft_token_num,
-            head_dim_v=self.kv_lora_rank,
-            tile_scheduler_metadata=metadata.flashmla_metadata,
-            num_splits=metadata.num_splits,
-            softmax_scale=layer.scaling,
-            causal=True,
-        )
-        return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
+        # Prefill: dispatch to ragged (MHA-style) or absorbed (MQA) path.
+        if self.forward_prefill_metadata.use_ragged:
+            return self._forward_normal_extend(q, k, v, layer, save_kv_cache)
+        else:
+            return self._forward_absorbed_extend(
+                q,
+                k,
+                v,
+                layer,
+                out_cache_loc,
+                token_to_kv_pool,
+                save_kv_cache,
+            )
 
     def forward_extend_chunked(
         self,
@@ -596,57 +520,31 @@ class FlashMLABackend(AttentionBackend):
         out_cache_loc: torch.Tensor,
         token_to_kv_pool,
         bs: int,
-        save_kv_cache: bool = True,
-        seq_lens: torch.Tensor | None = None,
+        save_kv_cache: bool,
         **kwargs,
     ) -> torch.Tensor:
         # Multi-token decode (target verify or drafter compound) reuses
         # the multi-token kernel path in forward_extend.
         q_len_per_req = q.shape[0] // bs if bs > 0 else 1
         if q_len_per_req > 1:
-            return self.forward_extend(
-                q,
-                k,
-                v,
-                layer,
-                out_cache_loc,
-                token_to_kv_pool,
-                bs,
-                save_kv_cache=save_kv_cache,
-                seq_lens=seq_lens,
-                forward_mode=ForwardMode.DECODE,
-                **kwargs,
+            metadata = self.forward_decode_metadata
+            num_extends = metadata.num_extends
+            bs = (
+                q.shape[0]
+                if self.is_draft
+                else metadata.block_table.shape[0] - num_extends
             )
 
-        if k is not None:
-            assert v is not None
-            if save_kv_cache:
-                token_to_kv_pool.set_kv_buffer(
-                    layer,
-                    out_cache_loc,
-                    k,
-                    v,
-                )
-        bs = q.shape[0]
-        metadata = self.forward_decode_metadata
-        num_extends = metadata.num_extends
-        k_cache = token_to_kv_pool.get_key_buffer(layer.layer_id)
-        assert (
-            layer.tp_q_head_num == self.num_q_heads
-        ), f"{layer.tp_q_head_num=} != {self.num_q_heads=}"
-        reshape_q = q.view(bs, -1, self.num_q_heads, layer.head_dim)
-        cache_lens = seq_lens
-
-        o, _ = flash_mla_with_kvcache(
-            q=reshape_q,
-            k_cache=k_cache.view(-1, PAGE_SIZE, 1, self.kv_cache_dim),
-            block_table=metadata.block_table[num_extends : num_extends + bs],
-            cache_seqlens=cache_lens.to(torch.int32),
-            head_dim_v=self.kv_lora_rank,
-            tile_scheduler_metadata=metadata.flashmla_metadata,
-            num_splits=metadata.num_splits,
-            softmax_scale=layer.scaling,
-            causal=True,
+        o, _ = self._run_flash_mla_decode(
+            q,
+            k,
+            v,
+            layer,
+            out_cache_loc,
+            token_to_kv_pool,
+            bs,
+            save_kv_cache=save_kv_cache,
+            cache_seqlens_offset=self.draft_token_num,
         )
 
         return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
@@ -712,6 +610,43 @@ class FlashMLABackend(AttentionBackend):
             out=o,
         )
         return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
+
+    def _run_flash_mla_decode(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: PagedAttention,
+        out_cache_loc: torch.Tensor,
+        token_to_kv_pool,
+        bs: int,
+        *,
+        save_kv_cache: bool,
+        cache_seqlens_offset: int,
+    ):
+        if k is not None:
+            assert v is not None
+            if save_kv_cache:
+                token_to_kv_pool.set_kv_buffer(layer, out_cache_loc, k, v)
+
+        metadata = self.forward_decode_metadata
+        num_extends = metadata.num_extends
+        k_cache = token_to_kv_pool.get_key_buffer(layer.layer_id)
+        assert (
+            layer.tp_q_head_num == self.num_q_heads
+        ), f"{layer.tp_q_head_num=} != {self.num_q_heads=}"
+        reshape_q = q.view(bs, -1, self.num_q_heads, layer.head_dim)
+
+        return flash_mla_with_kvcache(
+            q=reshape_q,
+            k_cache=k_cache.view(-1, PAGE_SIZE, 1, self.kv_cache_dim),
+            block_table=metadata.block_table[num_extends : num_extends + bs],
+            cache_seqlens=metadata.seq_lens_k.to(torch.int32) + cache_seqlens_offset,
+            head_dim_v=self.kv_lora_rank,
+            tile_scheduler_metadata=metadata.flashmla_metadata,
+            softmax_scale=layer.scaling,
+            causal=True,
+        )
 
 
 class _PrefillIndicesUpdater:

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -2630,6 +2630,10 @@ class HybridLinearAttnBackend(AttentionBackend):
     def forward_extend_chunked(self, *args, **kwargs):
         return self.full_attn_backend.forward_extend_chunked(*args, **kwargs)
 
+    def advance_draft_forward_metadata(self, seq_lens: torch.Tensor) -> None:
+        # Composite: the full-attention child owns the seq_lens the draft reads.
+        self.full_attn_backend.advance_draft_forward_metadata(seq_lens)
+
     @property
     def flat_cache_consumer_families(self) -> frozenset[str]:
         """FlatKV contract families this composite can consume: the union of

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -1449,10 +1449,7 @@ class MambaAttnBackend(AttentionBackend):
 
     # ---- CUDA graph state ----
 
-    def init_cuda_graph_state(
-        self, max_num_tokens: int, seq_lens_buf: torch.Tensor = None
-    ):
-        del seq_lens_buf  # mamba doesn't use seq_lens_buf.
+    def init_cuda_graph_state(self, max_num_tokens: int):
         for i in range(max_num_tokens):
             self.state_indices_list.append(
                 torch.full(
@@ -2693,18 +2690,14 @@ class HybridLinearAttnBackend(AttentionBackend):
         self.full_attn_backend.init_forward_metadata(*args, **common_kw)
         self.linear_attn_backend.init_forward_metadata(*args, **common_kw, **mamba_kw)
 
-    def init_cuda_graph_state(self, max_bs: int, seq_lens_buf: torch.Tensor, **kwargs):
+    def init_cuda_graph_state(self, max_bs: int, **kwargs):
         # kwargs (e.g. paged_cache_group_specs, so the full backend sheds
         # state-family groups) are forwarded through the shared signature
         # filter: the full backend is user-selectable and may have a narrow
-        # signature (e.g. TRTLLM MHA takes only (max_bs, seq_lens_buf)), and
-        # the mamba backend keeps its narrow signature today.
-        init_backend_cuda_graph_state(
-            self.full_attn_backend, max_bs, seq_lens_buf, **kwargs
-        )
-        init_backend_cuda_graph_state(
-            self.linear_attn_backend, max_bs, seq_lens_buf, **kwargs
-        )
+        # signature (e.g. TRTLLM MHA takes only (max_bs,)), and the mamba
+        # backend keeps its narrow signature today.
+        init_backend_cuda_graph_state(self.full_attn_backend, max_bs, **kwargs)
+        init_backend_cuda_graph_state(self.linear_attn_backend, max_bs, **kwargs)
 
     def register_step_counter(self, step_counter):
         # Hybrid layerwise transfer needs one global step per model layer,

--- a/python/tokenspeed/runtime/layers/attention/backends/inkling.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/inkling.py
@@ -1058,11 +1058,14 @@ class InklingAttnBackend(AttentionBackend):
             tables[g] = buf
         return tables
 
-    def init_cuda_graph_state(self, max_bs: int, seq_lens_buf: torch.Tensor, **kwargs):
-        init_backend_cuda_graph_state(self.inner, max_bs, seq_lens_buf, **kwargs)
+    def init_cuda_graph_state(self, max_bs: int, **kwargs):
+        init_backend_cuda_graph_state(self.inner, max_bs, **kwargs)
         device = self.conv_pool.conv_state.device
         self._decode_qsl = torch.arange(max_bs + 1, dtype=torch.int32, device=device)
-        self._graph_seq_lens = seq_lens_buf
+        # Own the cache-seqlens buffer instead of aliasing the controller's
+        # seq_lens_buf; replay copies the live lengths in, so graph state does
+        # not depend on the controller mutating a shared tensor in place.
+        self._graph_seq_lens = torch.zeros(max_bs, dtype=torch.int32, device=device)
         if getattr(self, "conv_columns", None) is not None:
             # Adopted stacked views are filled by the mixin's packed unpack; pad rows hit dummy slot 0.
             inner_tabs = getattr(self.inner, "cuda_graph_flat_page_tables", {})
@@ -1137,6 +1140,7 @@ class InklingAttnBackend(AttentionBackend):
             **kwargs,
         )
         assert self._graph_cache_indices is not None
+        self._graph_seq_lens[:bs].copy_(seq_lens[:bs])
         self._graph_cache_indices[:bs].copy_(req_pool_indices[:bs].to(torch.int32))
         if actual_bs is not None and actual_bs < bs:
             # Pad rows may carry stale indices aliasing LIVE slots; PAD_SLOT_ID keeps writes off them.

--- a/python/tokenspeed/runtime/layers/attention/backends/inkling.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/inkling.py
@@ -1115,6 +1115,9 @@ class InklingAttnBackend(AttentionBackend):
             bs, req_pool_indices, seq_lens, forward_mode, **kwargs
         )
         assert self._graph_cache_indices is not None
+        # Seed the owned buffer: paged conv reads pos = seq_len - 1, so an
+        # unseeded (zero) length would address position -1 during capture.
+        self._graph_seq_lens[:bs].copy_(seq_lens[:bs])
         if self.conv_spec_num_tokens > 1:
             # k-token spec chunk; drafter capture swaps to 1-token steps via advance_draft_forward_metadata.
             self.conv_metadata = self._spec_conv_metadata(bs)

--- a/python/tokenspeed/runtime/layers/attention/backends/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mha.py
@@ -328,7 +328,6 @@ class MHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
     def init_cuda_graph_state(
         self,
         max_bs: int,
-        seq_lens_buf: torch.Tensor,
         paged_cache_group_specs: Sequence = (),
         **kwargs,
     ):
@@ -336,14 +335,6 @@ class MHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
         # learn their ids from the pool's specs so every flat table/loc path
         # here (eager, capture, replay) sheds them.
         self._learn_flat_state_groups(paged_cache_group_specs)
-        assert (
-            seq_lens_buf.dtype == torch.int32
-            and seq_lens_buf.dim() == 1
-            and seq_lens_buf.shape[0] >= max_bs
-        ), (
-            f"seq_lens_buf must be int32 with shape[0] >= {max_bs}, "
-            f"got {seq_lens_buf.dtype} {tuple(seq_lens_buf.shape)}"
-        )
 
         self.cuda_graph_decode_metadata = {}
         # Flat per-group persistent buffers. TODO(radix-removal): parallels
@@ -366,13 +357,12 @@ class MHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
         self.cuda_graph_page_table = torch.zeros(
             (max_bs, self.max_num_pages), dtype=torch.int32, device=self.device
         )
-        if self.spec_num_tokens > 1 and not self.is_draft:
-            self.cuda_graph_seq_lens = torch.empty(
-                (max_bs,), dtype=torch.int32, device=self.device
-            )
-        else:
-            # Alias controller's seq_lens_buf — backend never mutates it.
-            self.cuda_graph_seq_lens = seq_lens_buf
+        # Own the cache-seqlens buffer in all non-DFLASH cases; replay copies the
+        # live lengths in (verify clamps, plain decode/draft copies), so graph
+        # state does not depend on the controller mutating a shared tensor.
+        self.cuda_graph_seq_lens = torch.zeros(
+            (max_bs,), dtype=torch.int32, device=self.device
+        )
 
     def init_forward_metadata_capture_cuda_graph(
         self,
@@ -478,8 +468,10 @@ class MHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
             self.cuda_graph_page_table[: bs * self.spec_num_tokens, :].view(
                 bs, self.spec_num_tokens, self.max_num_pages
             ).copy_(base_page_table[:, None, :])
-
-        # cuda_graph_seq_lens is filled by input prep / the spec copy above.
+        else:
+            # Plain decode / plain draft: copy the live lengths into our own
+            # buffer (previously aliased the controller's seq_lens_buf).
+            self.cuda_graph_seq_lens[:bs].copy_(seq_lens[:bs])
         if flat_block_tables:
             self._flat_replay_fill(
                 bs,

--- a/python/tokenspeed/runtime/layers/attention/backends/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mha.py
@@ -421,6 +421,9 @@ class MHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
             )
             if self.spec_num_tokens > 1 and not self.is_draft:
                 metadata.seq_lens.copy_(seq_lens[:bs].clamp_min(self.spec_num_tokens))
+            else:
+                # Seed the owned buffer: the capture run reads it before replay.
+                metadata.seq_lens.copy_(seq_lens[:bs])
         self.cuda_graph_decode_metadata[bs] = metadata
         self.forward_decode_metadata = metadata
 

--- a/python/tokenspeed/runtime/layers/attention/backends/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mla.py
@@ -537,6 +537,8 @@ class MLAAttnBackend(AttentionBackend):
             seq_lens=self.cuda_graph_seq_lens[:bs],
             flat_out_cache_loc=flat_out_cache_loc,
         )
+        # Seed the owned buffer: the capture run reads it before replay.
+        metadata.seq_lens.copy_(seq_lens[:bs])
         self.decode_cuda_graph_metadata[bs] = metadata
         self.forward_decode_metadata = metadata
 

--- a/python/tokenspeed/runtime/layers/attention/backends/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mla.py
@@ -482,19 +482,15 @@ class MLAAttnBackend(AttentionBackend):
             )
         return locs
 
-    def init_cuda_graph_state(self, max_bs: int, seq_lens_buf: torch.Tensor):
-        assert (
-            seq_lens_buf.dtype == torch.int32
-            and seq_lens_buf.dim() == 1
-            and seq_lens_buf.shape[0] >= max_bs
-        ), (
-            f"seq_lens_buf must be int32 with shape[0] >= {max_bs}, "
-            f"got {seq_lens_buf.dtype} {tuple(seq_lens_buf.shape)}"
-        )
+    def init_cuda_graph_state(self, max_bs: int):
         self.cuda_graph_page_table = torch.zeros(
             (max_bs, self.max_num_pages), dtype=torch.int32, device=self.device
         )
-        self.cuda_graph_seq_lens = seq_lens_buf
+        # Own the cache-seqlens buffer; replay copies the live lengths in, so
+        # graph state does not depend on the controller mutating a shared tensor.
+        self.cuda_graph_seq_lens = torch.zeros(
+            max_bs, dtype=torch.int32, device=self.device
+        )
         self.decode_cuda_graph_metadata = {}
         if self._flat_contract_bound:
             self.decode_cuda_graph_flat_out_cache_loc = torch.zeros(
@@ -559,6 +555,9 @@ class MLAAttnBackend(AttentionBackend):
             )
 
         metadata = self.decode_cuda_graph_metadata[bs]
+        # Copy the live lengths into our own cache-seqlens buffer (metadata.seq_lens
+        # views it); both the flat and legacy paths read it at replay.
+        self.cuda_graph_seq_lens[:bs].copy_(seq_lens[:bs])
         if metadata.flat_out_cache_loc is not None:
             self._flat_replay_refresh_decode(
                 bs,

--- a/python/tokenspeed/runtime/layers/attention/backends/msa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/msa.py
@@ -329,7 +329,6 @@ class MSAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
     def init_cuda_graph_state(
         self,
         max_bs: int,
-        seq_lens_buf: torch.Tensor,
         paged_cache_group_specs: Sequence = (),
         **kwargs,
     ):
@@ -337,14 +336,6 @@ class MSAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
         # learn their ids from the pool's specs so every flat table/loc path
         # here (eager, capture, replay) sheds them.
         self._learn_flat_state_groups(paged_cache_group_specs)
-        assert (
-            seq_lens_buf.dtype == torch.int32
-            and seq_lens_buf.dim() == 1
-            and seq_lens_buf.shape[0] >= max_bs
-        ), (
-            f"seq_lens_buf must be int32 with shape[0] >= {max_bs}, "
-            f"got {seq_lens_buf.dtype} {tuple(seq_lens_buf.shape)}"
-        )
 
         self.cuda_graph_decode_metadata = {}
         # Flat per-group persistent buffers, lazily allocated at first
@@ -367,13 +358,10 @@ class MSAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
         self.cuda_graph_page_table = torch.zeros(
             (max_bs, self.max_num_pages), dtype=torch.int32, device=self.device
         )
-        if self.spec_num_tokens > 1 and not self.is_draft:
-            self.cuda_graph_seq_lens = torch.empty(
-                (max_bs,), dtype=torch.int32, device=self.device
-            )
-        else:
-            # Alias controller's seq_lens_buf — backend never mutates it.
-            self.cuda_graph_seq_lens = seq_lens_buf
+        # Own the cache-seqlens buffer; replay copies the live lengths in.
+        self.cuda_graph_seq_lens = torch.zeros(
+            (max_bs,), dtype=torch.int32, device=self.device
+        )
 
     def init_forward_metadata_capture_cuda_graph(
         self,
@@ -433,6 +421,9 @@ class MSAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
             )
             if self.spec_num_tokens > 1 and not self.is_draft:
                 metadata.seq_lens.copy_(seq_lens[:bs].clamp_min(self.spec_num_tokens))
+        if not (self.draft_block_decode and self.spec_num_tokens > 1):
+            # Seed the owned buffer: the capture run reads it before replay.
+            metadata.seq_lens.copy_(seq_lens[:bs])
         self.cuda_graph_decode_metadata[bs] = metadata
         self.forward_decode_metadata = metadata
 
@@ -475,8 +466,10 @@ class MSAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
             self.cuda_graph_page_table[: bs * self.spec_num_tokens, :].view(
                 bs, self.spec_num_tokens, self.max_num_pages
             ).copy_(base_page_table[:, None, :])
+        else:
+            # Plain decode / plain draft: copy live lengths into our buffer.
+            self.cuda_graph_seq_lens[:bs].copy_(seq_lens[:bs])
 
-        # cuda_graph_seq_lens is filled by input prep / the spec copy above.
         if flat_block_tables:
             self._flat_replay_fill(
                 bs,
@@ -843,15 +836,10 @@ class MSAHybridAttnBackend(AttentionBackend):
     def init_cuda_graph_state(
         self,
         max_bs: int,
-        seq_lens_buf: torch.Tensor,
         **kwargs,
     ) -> None:
-        init_backend_cuda_graph_state(
-            self.full_attn_backend, max_bs, seq_lens_buf, **kwargs
-        )
-        init_backend_cuda_graph_state(
-            self.sparse_attn_backend, max_bs, seq_lens_buf, **kwargs
-        )
+        init_backend_cuda_graph_state(self.full_attn_backend, max_bs, **kwargs)
+        init_backend_cuda_graph_state(self.sparse_attn_backend, max_bs, **kwargs)
 
     def init_forward_metadata_capture_cuda_graph(self, *args, **kwargs):
         self.full_attn_backend.init_forward_metadata_capture_cuda_graph(*args, **kwargs)
@@ -864,6 +852,10 @@ class MSAHybridAttnBackend(AttentionBackend):
         self.sparse_attn_backend.init_forward_metadata_replay_cuda_graph(
             *args, **kwargs
         )
+
+    def advance_draft_forward_metadata(self, seq_lens: torch.Tensor) -> None:
+        self.full_attn_backend.advance_draft_forward_metadata(seq_lens)
+        self.sparse_attn_backend.advance_draft_forward_metadata(seq_lens)
 
     def configure_runtime(self, **kwargs) -> None:
         self.full_attn_backend.configure_runtime(**kwargs)

--- a/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
@@ -671,17 +671,12 @@ class CuteDSLMLABackend(AttentionBackend):
 
     # ---- CUDA Graph ----
 
-    def init_cuda_graph_state(self, max_bs: int, seq_lens_buf: torch.Tensor):
-        assert (
-            seq_lens_buf.dtype == torch.int32
-            and seq_lens_buf.dim() == 1
-            and seq_lens_buf.shape[0] >= max_bs
-        ), (
-            f"seq_lens_buf must be int32 with shape[0] >= {max_bs}, "
-            f"got {seq_lens_buf.dtype} {tuple(seq_lens_buf.shape)}"
+    def init_cuda_graph_state(self, max_bs: int):
+        # Own the cache-seqlens buffer; replay copies the live lengths in, so
+        # graph state does not depend on the controller mutating a shared tensor.
+        self.cuda_graph_seq_lens_buf = torch.zeros(
+            max_bs, dtype=torch.int32, device=self.device
         )
-        # Alias controller's seq_lens_buf — backend never mutates it.
-        self.cuda_graph_seq_lens_buf = seq_lens_buf
         max_blocks = self._calc_padded_blocks(self.max_context_len)
         self.decode_cuda_graph_kv_indices = torch.zeros(
             (max_bs, max_blocks), dtype=torch.int32, device=self.device
@@ -800,10 +795,11 @@ class CuteDSLMLABackend(AttentionBackend):
             self.forward_decode_metadata = metadata
             return
 
-        # seq_lens_k aliases seq_lens_buf; only block indices need refresh.
-        # When the buffer is aliased to a peer backend (e.g. drafter aliasing
-        # the target's kv_indices), the peer's replay has already populated it
-        # with identical content.
+        # Copy the live cache lengths into our own buffer (metadata.seq_lens_k
+        # views it). Block indices are refreshed separately; when the block
+        # table is aliased to a peer backend, that peer's replay already
+        # populated it with identical content.
+        self.cuda_graph_seq_lens_buf[:bs].copy_(seq_lens[:bs])
         if req_to_page is not None and not self._block_table_aliased:
             self._create_block_kv_indices(
                 bs,

--- a/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
@@ -127,6 +127,7 @@ class CuteDSLMLABackend(AttentionBackend):
     # FlatKV contract capability: this backend consumes only history-family
     # (full-attention) tables; state groups belong to the linear sub-backend.
     flat_cache_consumer_families = frozenset({"history"})
+    draft_seq_lens_attr: str = "cuda_graph_seq_lens_buf"
 
     def __init__(self, config: MLAConfig):
         super().__init__(config)
@@ -757,6 +758,8 @@ class CuteDSLMLABackend(AttentionBackend):
                 seq_lens_k=self.cuda_graph_seq_lens_buf[:bs],
                 num_extends=0,
             )
+        # Seed the owned buffer: the capture run reads it before replay.
+        metadata.seq_lens_k.copy_(seq_lens[:bs])
         self.decode_cuda_graph_metadata[bs] = metadata
         self.forward_decode_metadata = metadata
 
@@ -784,6 +787,10 @@ class CuteDSLMLABackend(AttentionBackend):
                 "tokenspeed_mla draft worker does not take the FlatKV path"
             )
 
+        # Copy the live cache lengths into our own buffer (metadata.seq_lens_k
+        # views it) on both paths -- the flat helper only refreshes tables.
+        self.cuda_graph_seq_lens_buf[:bs].copy_(seq_lens[:bs])
+
         if flat:
             self._flat_replay_refresh_decode(
                 bs,
@@ -795,11 +802,8 @@ class CuteDSLMLABackend(AttentionBackend):
             self.forward_decode_metadata = metadata
             return
 
-        # Copy the live cache lengths into our own buffer (metadata.seq_lens_k
-        # views it). Block indices are refreshed separately; when the block
-        # table is aliased to a peer backend, that peer's replay already
-        # populated it with identical content.
-        self.cuda_graph_seq_lens_buf[:bs].copy_(seq_lens[:bs])
+        # Block indices are refreshed separately; when the block table is
+        # aliased to a peer backend, that peer's replay already populated it.
         if req_to_page is not None and not self._block_table_aliased:
             self._create_block_kv_indices(
                 bs,

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -113,6 +113,7 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
     # Graph-buffer column tails pad with the zero-init dummy page, matching
     # the radix replay contract (gather_page_table_with_padding dummy_slot=0).
     flat_table_tail_pad: int = 0
+    draft_seq_lens_attr: str = "cuda_graph_cache_seqlens"
 
     def support_kv_cache_prewrite(
         self, forward_mode: ForwardMode | None = None
@@ -795,6 +796,8 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
             return
 
         if self.spec_num_tokens > 1:
+            # Seed the owned buffer first: it is the clamp source below.
+            self.cuda_graph_cache_seqlens[:bs].copy_(seq_lens[:bs])
             self._init_multi_token_metadata_capture(
                 bs, self.spec_num_tokens, page_tables, out_cache_locs
             )
@@ -849,6 +852,8 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
             page_tables=page_tables,
             out_cache_locs=out_cache_locs,
         )
+        # Seed the owned buffer: the capture run reads it before replay.
+        metadata.cache_seqlens_int32.copy_(seq_lens[:bs])
         self.cuda_graph_decode_metadata[bs] = metadata
         self.forward_decode_metadata = metadata
 
@@ -935,8 +940,7 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
                 dummy_slot=0,
             )
         if flat_block_tables:
-            # cuda_graph_cache_seqlens aliases the controller's seq_lens_buf,
-            # filled by input prep BEFORE this call.
+            # cuda_graph_cache_seqlens was refreshed from live seq_lens above.
             self._flat_replay_fill(
                 bs,
                 flat_block_tables,

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -730,18 +730,9 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
     def init_cuda_graph_state(
         self,
         max_bs: int,
-        seq_lens_buf: torch.Tensor,
         paged_cache_group_specs: Sequence = (),
         **kwargs,
     ):
-        assert (
-            seq_lens_buf.dtype == torch.int32
-            and seq_lens_buf.dim() == 1
-            and seq_lens_buf.shape[0] >= max_bs
-        ), (
-            f"seq_lens_buf must be int32 with shape[0] >= {max_bs}, "
-            f"got {seq_lens_buf.dtype} {tuple(seq_lens_buf.shape)}"
-        )
         self.cuda_graph_prefill_metadata = {}
         self.cuda_graph_decode_metadata = {}
         # Flat per-group persistent buffers + state-group shed; before the
@@ -764,11 +755,15 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
                 device=self.device,
             )
             return
-        # Alias controller's seq_lens_buf — backend never mutates it.
+        # Own the cache-seqlens buffer instead of aliasing the controller's
+        # seq_lens_buf; replay copies the live lengths in, so graph state does
+        # not depend on the controller mutating a shared tensor in place.
         self.cuda_graph_page_table = torch.zeros(
             (max_bs, self.max_num_pages), dtype=torch.int32, device=self.device
         )
-        self.cuda_graph_cache_seqlens = seq_lens_buf
+        self.cuda_graph_cache_seqlens = torch.zeros(
+            max_bs, dtype=torch.int32, device=self.device
+        )
 
     def init_forward_metadata_capture_cuda_graph(
         self,
@@ -838,7 +833,8 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
         page_tables: dict[str, torch.Tensor] | None = None,
         out_cache_locs: dict[str, torch.Tensor] | None = None,
     ):
-        # cache_seqlens aliases seq_lens_buf (set in init_cuda_graph_state).
+        # cache_seqlens views the backend-owned cuda_graph_cache_seqlens (set in
+        # init_cuda_graph_state).
         # Flat captures route reads through the per-group buffer views and
         # replay never fills the radix single table, so record page_table=None
         # instead of a slice of the never-filled zero buffer.
@@ -918,7 +914,12 @@ class TRTLLMMHAAttnBackend(FlatCacheGroupsMixin, AttentionBackend):
                 self.forward_decode_metadata = self.cuda_graph_decode_metadata[bs]
             return
 
-        # cache_seqlens aliases seq_lens_buf; only page tables need refresh.
+        # Copy the live cache lengths into our own buffer (the plain-decode and
+        # draft-decode metadata view cuda_graph_cache_seqlens); the spec>1 verify
+        # path instead reads spec_cache_seqlens_buf via _clamped_spec_seqlens.
+        self.cuda_graph_cache_seqlens[:bs].copy_(seq_lens[:bs])
+
+        # Only page tables need refresh beyond that.
         # Flat captures read only the per-group buffers; the radix single
         # table would be dead work there (and req_to_page is unpopulated on
         # a flat scheduler build).

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
@@ -312,17 +312,12 @@ class TRTLLMMLABackend(AttentionBackend):
 
     # ---- CUDA Graph ----
 
-    def init_cuda_graph_state(self, max_bs: int, seq_lens_buf: torch.Tensor):
-        assert (
-            seq_lens_buf.dtype == torch.int32
-            and seq_lens_buf.dim() == 1
-            and seq_lens_buf.shape[0] >= max_bs
-        ), (
-            f"seq_lens_buf must be int32 with shape[0] >= {max_bs}, "
-            f"got {seq_lens_buf.dtype} {tuple(seq_lens_buf.shape)}"
+    def init_cuda_graph_state(self, max_bs: int):
+        # Own the cache-seqlens buffer; replay copies the live lengths in, so
+        # graph state does not depend on the controller mutating a shared tensor.
+        self.cuda_graph_seq_lens_buf = torch.zeros(
+            max_bs, dtype=torch.int32, device=self.device
         )
-        # Alias controller's seq_lens_buf — backend never mutates it.
-        self.cuda_graph_seq_lens_buf = seq_lens_buf
         max_blocks = self._calc_padded_blocks(self.max_context_len)
         self.decode_cuda_graph_kv_indices = torch.zeros(
             (max_bs, max_blocks), dtype=torch.int32, device=self.device
@@ -344,8 +339,8 @@ class TRTLLMMLABackend(AttentionBackend):
         block_kv_indices = self.decode_cuda_graph_kv_indices[:bs, :max_blocks]
 
         # For capture we don't have req_to_page yet; just zero-fill the block indices.
-        # The actual indices will be filled on replay. seq_lens_k aliases
-        # seq_lens_buf (set in init_cuda_graph_state).
+        # The actual indices will be filled on replay. seq_lens_k views the
+        # backend-owned cuda_graph_seq_lens_buf (set in init_cuda_graph_state).
         metadata = TRTLLMMLADecodeMetadata(
             num_extends=0,
             block_kv_indices=block_kv_indices,
@@ -372,10 +367,11 @@ class TRTLLMMLABackend(AttentionBackend):
 
         metadata = self.decode_cuda_graph_metadata[bs]
 
-        # seq_lens_k aliases seq_lens_buf; only block indices need refresh.
-        # When the buffer is aliased to a peer backend (e.g. drafter aliasing
-        # the target's kv_indices), the peer's replay has already populated it
-        # with identical content.
+        # Copy the live cache lengths into our own buffer (metadata.seq_lens_k
+        # views it). Block indices are refreshed separately; when the block
+        # table is aliased to a peer backend, that peer's replay already
+        # populated it with identical content.
+        self.cuda_graph_seq_lens_buf[:bs].copy_(seq_lens[:bs])
         if req_to_page is not None and not self._block_table_aliased:
             self._create_block_kv_indices(
                 bs,

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
@@ -112,6 +112,8 @@ class TRTLLMMLADecodeMetadata:
 class TRTLLMMLABackend(AttentionBackend):
     """trtllm_mla attention backend using fused kernels."""
 
+    draft_seq_lens_attr: str = "cuda_graph_seq_lens_buf"
+
     def __init__(self, config: MLAConfig):
         super().__init__(config)
 
@@ -348,6 +350,8 @@ class TRTLLMMLABackend(AttentionBackend):
             seq_lens_k=self.cuda_graph_seq_lens_buf[:bs],
         )
 
+        # Seed the owned buffer: the capture run reads it before replay.
+        metadata.seq_lens_k.copy_(seq_lens[:bs])
         self.decode_cuda_graph_metadata[bs] = metadata
         self.forward_decode_metadata = metadata
 

--- a/python/tokenspeed/runtime/layers/logits_processor.py
+++ b/python/tokenspeed/runtime/layers/logits_processor.py
@@ -31,6 +31,9 @@ from tokenspeed_kernel.ops.sampling.cute_dsl import (
     create_dist_argmax_state,
     distributed_argmax,
 )
+from tokenspeed_kernel.ops.sampling.cute_dsl import (
+    is_available as dist_argmax_available,
+)
 from tokenspeed_kernel.platform import current_platform
 from torch import nn
 
@@ -326,6 +329,11 @@ class LogitsProcessor(nn.Module):
 
     def _init_dist_argmax_state(self, lm_head: VocabParallelEmbedding):
         if not current_platform().is_nvidia or _force_deterministic_rsag():
+            return None
+
+        # CuTe DSL argmax is unavailable on some SKUs (e.g. H20 lacks TMA
+        # cluster launch). Fall back to the plain all-gather + argmax path.
+        if not dist_argmax_available():
             return None
 
         if (

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -1232,6 +1232,8 @@ class DeepseekV3DraftAttentionMLA(DeepseekV3AttentionMLA):
             ctx.attn_backend.spec_num_tokens - ctx.accept_lengths[num_extends:]
         ).to(seq_lens_buf.dtype)
         seq_lens_buf[num_extends : ctx.bs].sub_(correction).clamp_(min=1)
+        # Publish: the backend owns its buffer, so in-graph edits need a copy.
+        ctx.attn_backend.advance_draft_forward_metadata(seq_lens_buf[: ctx.bs])
 
 
 class DeepseekV3DecoderLayer(nn.Module):

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -997,7 +997,9 @@ class DeepseekV3AttentionMLA(nn.Module):
 
         q = q.view(-1, self.num_local_heads, self.qk_head_dim)
         q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
-        kv = self.kv_b_proj(kv_a)[0]
+        # kv_a is a split view of latent_cache (non-contiguous); the fp8 online-quant
+        # GEMM in kv_b_proj asserts contiguous input.
+        kv = self.kv_b_proj(kv_a.contiguous())[0]
         kv = kv.view(-1, self.num_local_heads, self.qk_nope_head_dim + self.v_head_dim)
         k_nope = kv[..., : self.qk_nope_head_dim]
         v = kv[..., self.qk_nope_head_dim :]

--- a/python/tokenspeed/runtime/models/llama_eagle3.py
+++ b/python/tokenspeed/runtime/models/llama_eagle3.py
@@ -135,6 +135,8 @@ class LlamaAttention(BaseLlamaAttention):
             ctx.attn_backend.spec_num_tokens - ctx.accept_lengths[num_extends:]
         ).to(seq_lens_buf.dtype)
         seq_lens_buf[num_extends : ctx.bs].sub_(correction).clamp_(min=1)
+        # Publish: the backend owns its buffer, so in-graph edits need a copy.
+        ctx.attn_backend.advance_draft_forward_metadata(seq_lens_buf[: ctx.bs])
 
 
 # ---------------------------------------------------------------------------

--- a/python/tokenspeed/runtime/models/qwen3_5_nextn.py
+++ b/python/tokenspeed/runtime/models/qwen3_5_nextn.py
@@ -111,6 +111,8 @@ class Qwen3_5DraftAttentionDecoderLayer(Qwen3_5AttentionDecoderLayer):
             ctx.attn_backend.spec_num_tokens - ctx.accept_lengths[num_extends:]
         ).to(seq_lens_buf.dtype)
         seq_lens_buf[num_extends : ctx.bs].sub_(correction).clamp_(min=1)
+        # Publish: the backend owns its buffer, so in-graph edits need a copy.
+        ctx.attn_backend.advance_draft_forward_metadata(seq_lens_buf[: ctx.bs])
 
     def _maybe_narrow_residual(
         self,

--- a/test/runtime/test_draft_advance_seqlens.py
+++ b/test/runtime/test_draft_advance_seqlens.py
@@ -1,0 +1,254 @@
+"""Draft seq_lens must stay visible to the backend now that it owns the buffer.
+
+The drafter edits ``draft_seq_lens_buf`` in place inside the captured graph --
+``add_(1)`` per multi-step iteration, and ``_apply_correction`` trimming the
+rejected tail at step 0. Backends read their own buffer, so both edits must be
+published via ``advance_draft_forward_metadata`` or the draft attends over a
+stale prefix and the accept rate silently drops. CPU-only: drives the metadata
+builders and the hook directly, no GPU or KV pool.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
+from tokenspeed.runtime.layers.attention.backends.base import (
+    init_backend_cuda_graph_state,
+)
+from tokenspeed.runtime.layers.attention.backends.mha import MHAAttnBackend
+from tokenspeed.runtime.layers.attention.backends.msa import MSAAttnBackend
+from tokenspeed.runtime.layers.attention.backends.trtllm import (
+    TRTLLMMHAAttnBackend,
+)
+from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
+from tokenspeed.runtime.layers.attention.configs.msa import MSAConfig
+
+
+def _cfg() -> MHAConfig:
+    return MHAConfig(
+        device="cpu",
+        backend_name="mha",
+        num_attention_heads=8,
+        num_kv_heads=8,
+        head_dim=128,
+        attn_tp_size=1,
+        dtype=torch.bfloat16,
+        kv_cache_dtype=torch.bfloat16,
+        page_size=64,
+        context_len=4096,
+        max_bs=8,
+        max_graph_bs=8,
+        kv_cache_quant_method="none",
+        speculative_num_steps=3,
+        speculative_num_draft_tokens=4,
+        is_draft=True,
+    )
+
+
+def _seqlens_field(be, metadata):
+    # The KV cache-seqlens field differs by backend; both alias the owned buffer.
+    if isinstance(be, TRTLLMMHAAttnBackend):
+        return metadata.cache_seqlens_int32
+    return metadata.seq_lens
+
+
+@pytest.mark.parametrize("backend_cls", [MHAAttnBackend, TRTLLMMHAAttnBackend])
+def test_advance_updates_draft_decode_metadata(backend_cls):
+    be = backend_cls(_cfg())
+    max_bs, bs = 8, 4
+    be.init_cuda_graph_state(max_bs)
+
+    # Capture single-token decode metadata (plain draft path, is_draft=True).
+    req_pool_indices = torch.arange(1, bs + 1, dtype=torch.int32)
+    capture_seq_lens = torch.full((max_bs,), 5, dtype=torch.int32)
+    be.init_forward_metadata_capture_cuda_graph(
+        bs, req_pool_indices, capture_seq_lens, ForwardMode.DECODE
+    )
+    field = _seqlens_field(be, be.forward_decode_metadata)
+
+    # The metadata field must be a view of the owned buffer.
+    owned = (
+        be.cuda_graph_cache_seqlens
+        if isinstance(be, TRTLLMMHAAttnBackend)
+        else be.cuda_graph_seq_lens
+    )
+    assert field.data_ptr() == owned[:bs].data_ptr()
+
+    # Simulate the drafter advancing lengths in-graph across draft steps.
+    for step_len in (11, 12, 13):
+        draft_seq_lens = torch.full((bs,), step_len, dtype=torch.int32)
+        be.advance_draft_forward_metadata(draft_seq_lens)
+        got = _seqlens_field(be, be.forward_decode_metadata)[:bs]
+        assert torch.equal(got, draft_seq_lens), (
+            f"{backend_cls.__name__}: draft decode seqlens did not advance to "
+            f"{step_len}; got {got.tolist()}"
+        )
+
+
+def test_advance_does_not_mutate_caller_tensor():
+    be = MHAAttnBackend(_cfg())
+    be.init_cuda_graph_state(8)
+    draft_seq_lens = torch.tensor([7, 8, 9, 10], dtype=torch.int32)
+    original = draft_seq_lens.clone()
+    be.advance_draft_forward_metadata(draft_seq_lens)
+    # advance copies OUT of the caller tensor; it must not be written to.
+    assert torch.equal(draft_seq_lens, original)
+    assert torch.equal(be.cuda_graph_seq_lens[:4], original)
+
+
+def _msa_backend() -> MSAAttnBackend:
+    return MSAAttnBackend(
+        MSAConfig(
+            device="cpu",
+            backend_name="msa",
+            num_attention_heads=8,
+            num_kv_heads=8,
+            head_dim=128,
+            attn_tp_size=1,
+            dtype=torch.bfloat16,
+            kv_cache_dtype=torch.bfloat16,
+            page_size=64,
+            context_len=4096,
+            max_bs=8,
+            max_graph_bs=8,
+            kv_cache_quant_method="none",
+            speculative_num_steps=3,
+            speculative_num_draft_tokens=4,
+            is_draft=True,
+        )
+    )
+
+
+def test_msa_init_cuda_graph_state_matches_helper_signature():
+    """msa must take the post-ownership signature (no seq_lens_buf).
+
+    It was left on the old signature while the shared parameter was dropped
+    from init_backend_cuda_graph_state, so every MiniMax cuda-graph startup
+    raised TypeError: missing 1 required positional argument: 'seq_lens_buf'.
+    """
+    be = _msa_backend()
+    init_backend_cuda_graph_state(be, 8, paged_cache_group_specs=())
+    # And it must own the buffer rather than alias a controller tensor.
+    assert be.cuda_graph_seq_lens.shape[0] == 8
+    assert be.cuda_graph_seq_lens.dtype == torch.int32
+
+
+def test_msa_inherits_default_advance():
+    """msa's buffer uses the default name, so the base implementation applies."""
+    be = _msa_backend()
+    init_backend_cuda_graph_state(be, 8, paged_cache_group_specs=())
+    seq_lens = torch.tensor([11, 12, 13, 14], dtype=torch.int32)
+    be.advance_draft_forward_metadata(seq_lens)
+    assert torch.equal(be.cuda_graph_seq_lens[:4], seq_lens)
+
+
+def test_default_advance_is_a_noop_before_graph_state_exists():
+    """The hook may fire before init_cuda_graph_state (eager runs); it must not
+    raise, just do nothing."""
+    be = MHAAttnBackend(_cfg())
+    be.advance_draft_forward_metadata(torch.tensor([5, 6], dtype=torch.int32))
+
+
+@pytest.mark.parametrize("backend_cls", [MHAAttnBackend, TRTLLMMHAAttnBackend])
+def test_capture_seeds_owned_seqlens(backend_cls):
+    """Capture must seed the owned buffer: the capture run reads it.
+
+    The buffer is zero-initialized and only replay copies live lengths in, so
+    without seeding the warmup/capture forward attends over seq_len 0 (empty
+    causal span -> NaN, or a schedule recorded against zero lengths).
+    """
+    be = backend_cls(_cfg())
+    max_bs, bs = 8, 4
+    be.init_cuda_graph_state(max_bs)
+    capture_seq_lens = torch.full((max_bs,), 37, dtype=torch.int32)
+    be.init_forward_metadata_capture_cuda_graph(
+        bs,
+        torch.arange(1, bs + 1, dtype=torch.int32),
+        capture_seq_lens,
+        ForwardMode.DECODE,
+    )
+    got = _seqlens_field(be, be.forward_decode_metadata)[:bs]
+    assert torch.equal(
+        got, torch.full((bs,), 37, dtype=torch.int32)
+    ), f"{backend_cls.__name__}: capture left seqlens at {got.tolist()}"
+
+
+def test_hybrid_composite_forwards_advance_to_full_attn_child():
+    """Composite backends own no buffer; they must forward to the child."""
+    from tokenspeed.runtime.layers.attention.backends.hybrid_linear_attn import (
+        HybridLinearAttnBackend,
+    )
+
+    full = MHAAttnBackend(_cfg())
+    full.init_cuda_graph_state(8)
+    hybrid = object.__new__(HybridLinearAttnBackend)
+    hybrid.full_attn_backend = full
+    hybrid.linear_attn_backend = None
+
+    seq_lens = torch.tensor([21, 22, 23, 24], dtype=torch.int32)
+    hybrid.advance_draft_forward_metadata(seq_lens)
+    assert torch.equal(full.cuda_graph_seq_lens[:4], seq_lens)
+
+
+# Step 0: `_apply_correction` trims the rejected tail (vc + N -> vc + a).
+
+
+def _correction_models():
+    from tokenspeed.runtime.models.deepseek_v3 import DeepseekV3DraftAttentionMLA
+    from tokenspeed.runtime.models.glm5_nextn import GlmMoeDsaForCausalLMNextN
+    from tokenspeed.runtime.models.llama_eagle3 import LlamaAttention
+    from tokenspeed.runtime.models.qwen3_5_nextn import (
+        Qwen3_5DraftAttentionDecoderLayer,
+    )
+
+    return [
+        ("llama_eagle3", LlamaAttention._apply_correction),
+        ("qwen3_5_nextn", Qwen3_5DraftAttentionDecoderLayer._apply_correction),
+        ("deepseek_v3", DeepseekV3DraftAttentionMLA._apply_correction),
+        ("glm5_nextn", GlmMoeDsaForCausalLMNextN._apply_first_step_correction),
+    ]
+
+
+@pytest.mark.parametrize("name,correction", _correction_models())
+def test_first_step_correction_reaches_backend(name, correction):
+    from types import SimpleNamespace
+
+    be = MHAAttnBackend(_cfg())
+    max_bs, bs = 8, 4
+    be.init_cuda_graph_state(max_bs)
+
+    # Target verify left seq_lens at vc + N (vc=100, N=4).
+    draft_seq_lens = torch.full((bs,), 104, dtype=torch.int32)
+    be.init_forward_metadata_capture_cuda_graph(
+        bs,
+        torch.arange(1, bs + 1, dtype=torch.int32),
+        draft_seq_lens,
+        ForwardMode.DECODE,
+    )
+
+    accept_lengths = torch.tensor([2, 1, 4, 3], dtype=torch.int32)
+    ctx = SimpleNamespace(
+        draft_seq_lens_buf=draft_seq_lens,
+        accept_lengths=accept_lengths,
+        num_extends=0,
+        bs=bs,
+        attn_backend=be,
+    )
+    # Bound methods on the class need an explicit (unused) self.
+    try:
+        correction(ctx)
+    except TypeError:
+        correction(None, ctx)
+
+    expected = torch.tensor([102, 101, 104, 103], dtype=torch.int32)  # vc + a
+    assert torch.equal(draft_seq_lens, expected), f"{name}: correction wrong"
+    assert torch.equal(be.forward_decode_metadata.seq_lens[:bs], expected), (
+        f"{name}: trimmed seqlens never reached the backend; draft step 0 "
+        f"would attend over the rejected tail"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/runtime/test_flat_group_write_locs.py
+++ b/test/runtime/test_flat_group_write_locs.py
@@ -432,10 +432,13 @@ class GraphLocBuffersTest(_MHACase):
 
     def _replay(self, bs, flat_block_tables=None, seq_lens=None):
         torch = self.torch
+        # Wrapper contract: the step's lens (dummy tail = 1) are passed in and
+        # the backend copies them into its own buffer.
+        live_seq_lens = torch.ones(
+            MAX_BS, dtype=torch.int32, device=self.backend.device
+        )
         if seq_lens is not None:
-            # Wrapper contract: input prep writes the step's lens (dummy
-            # tail = 1) into seq_lens_buf BEFORE replay runs.
-            self.backend.cuda_graph_seq_lens[: len(seq_lens)] = torch.tensor(
+            live_seq_lens[: len(seq_lens)] = torch.tensor(
                 seq_lens, dtype=torch.int32, device=self.backend.device
             )
         kwargs = {}
@@ -444,7 +447,7 @@ class GraphLocBuffersTest(_MHACase):
         self.backend.init_forward_metadata_replay_cuda_graph(
             bs,
             torch.arange(MAX_BS, dtype=torch.int64, device=self.backend.device),
-            torch.ones(MAX_BS, dtype=torch.int32, device=self.backend.device),
+            live_seq_lens,
             torch.zeros(
                 (MAX_BS, MAX_NUM_PAGES),
                 dtype=torch.int32,

--- a/test/runtime/test_hybrid_cudagraph_kwargs.py
+++ b/test/runtime/test_hybrid_cudagraph_kwargs.py
@@ -2,10 +2,9 @@
 
 The hybrid backend's full-attention sub-backend is user-selectable and may
 have a narrow ``init_cuda_graph_state`` signature (e.g. TRTLLM MHA takes only
-``(max_bs, seq_lens_buf)``); the shared ``init_backend_cuda_graph_state``
-helper must drop unaccepted extras before forwarding, hand the full extras to
-``**kwargs`` backends, and never swallow TypeErrors raised inside a backend
-body.
+``(max_bs,)``); the shared ``init_backend_cuda_graph_state`` helper must drop
+unaccepted extras before forwarding, hand the full extras to ``**kwargs``
+backends, and never swallow TypeErrors raised inside a backend body.
 """
 
 from __future__ import annotations
@@ -29,8 +28,8 @@ class _NarrowBackend:
     def __init__(self):
         self.calls = []
 
-    def init_cuda_graph_state(self, max_bs, seq_lens_buf):
-        self.calls.append((max_bs, seq_lens_buf))
+    def init_cuda_graph_state(self, max_bs):
+        self.calls.append((max_bs,))
 
 
 class _VarKwBackend:
@@ -41,8 +40,8 @@ class _VarKwBackend:
     def __init__(self):
         self.calls = []
 
-    def init_cuda_graph_state(self, max_bs, seq_lens_buf, **kwargs):
-        self.calls.append((max_bs, seq_lens_buf, kwargs))
+    def init_cuda_graph_state(self, max_bs, **kwargs):
+        self.calls.append((max_bs, kwargs))
 
 
 class _NamedExtraBackend:
@@ -53,8 +52,8 @@ class _NamedExtraBackend:
     def __init__(self):
         self.calls = []
 
-    def init_cuda_graph_state(self, max_bs, seq_lens_buf, paged_cache_group_specs=None):
-        self.calls.append((max_bs, seq_lens_buf, paged_cache_group_specs))
+    def init_cuda_graph_state(self, max_bs, paged_cache_group_specs=None):
+        self.calls.append((max_bs, paged_cache_group_specs))
 
 
 class _RaisingBackend:
@@ -63,7 +62,7 @@ class _RaisingBackend:
 
     device = "cpu"
 
-    def init_cuda_graph_state(self, max_bs, seq_lens_buf, **kwargs):
+    def init_cuda_graph_state(self, max_bs, **kwargs):
         raise TypeError("from inside the backend body")
 
 
@@ -88,28 +87,25 @@ class InitBackendCudaGraphStateHelperTest(unittest.TestCase):
 
     def test_narrow_backend_receives_positional_only(self):
         backend = _NarrowBackend()
-        buf = object()
-        self.helper(backend, 4, buf, **_EXTRAS)
-        self.assertEqual(backend.calls, [(4, buf)])
+        self.helper(backend, 4, **_EXTRAS)
+        self.assertEqual(backend.calls, [(4,)])
 
     def test_var_kw_backend_receives_all_extras(self):
         backend = _VarKwBackend()
-        buf = object()
-        self.helper(backend, 4, buf, **_EXTRAS)
-        self.assertEqual(backend.calls, [(4, buf, _EXTRAS)])
+        self.helper(backend, 4, **_EXTRAS)
+        self.assertEqual(backend.calls, [(4, _EXTRAS)])
 
     def test_named_extra_backend_receives_only_matching_kwarg(self):
         backend = _NamedExtraBackend()
-        buf = object()
-        self.helper(backend, 4, buf, **_EXTRAS)
+        self.helper(backend, 4, **_EXTRAS)
         self.assertEqual(
             backend.calls,
-            [(4, buf, _EXTRAS["paged_cache_group_specs"])],
+            [(4, _EXTRAS["paged_cache_group_specs"])],
         )
 
     def test_type_error_from_backend_body_propagates(self):
         with self.assertRaisesRegex(TypeError, "from inside the backend body"):
-            self.helper(_RaisingBackend(), 4, object(), **_EXTRAS)
+            self.helper(_RaisingBackend(), 4, **_EXTRAS)
 
 
 class HybridInitCudaGraphStateForwardingTest(unittest.TestCase):
@@ -131,27 +127,24 @@ class HybridInitCudaGraphStateForwardingTest(unittest.TestCase):
     def test_narrow_full_backend_with_extras_succeeds(self):
         full = _NarrowBackend()
         mamba = _NarrowBackend()
-        buf = object()
-        self._hybrid(full, mamba).init_cuda_graph_state(4, buf, **_EXTRAS)
-        self.assertEqual(full.calls, [(4, buf)])
-        self.assertEqual(mamba.calls, [(4, buf)])
+        self._hybrid(full, mamba).init_cuda_graph_state(4, **_EXTRAS)
+        self.assertEqual(full.calls, [(4,)])
+        self.assertEqual(mamba.calls, [(4,)])
 
     def test_var_kw_full_backend_receives_extras(self):
         full = _VarKwBackend()
         mamba = _NarrowBackend()
-        buf = object()
-        self._hybrid(full, mamba).init_cuda_graph_state(4, buf, **_EXTRAS)
-        self.assertEqual(full.calls, [(4, buf, _EXTRAS)])
+        self._hybrid(full, mamba).init_cuda_graph_state(4, **_EXTRAS)
+        self.assertEqual(full.calls, [(4, _EXTRAS)])
         # The narrow mamba sub-backend is covered by the same filter.
-        self.assertEqual(mamba.calls, [(4, buf)])
+        self.assertEqual(mamba.calls, [(4,)])
 
     def test_var_kw_mamba_backend_receives_extras(self):
         full = _NarrowBackend()
         mamba = _VarKwBackend()
-        buf = object()
-        self._hybrid(full, mamba).init_cuda_graph_state(4, buf, **_EXTRAS)
-        self.assertEqual(full.calls, [(4, buf)])
-        self.assertEqual(mamba.calls, [(4, buf, _EXTRAS)])
+        self._hybrid(full, mamba).init_cuda_graph_state(4, **_EXTRAS)
+        self.assertEqual(full.calls, [(4,)])
+        self.assertEqual(mamba.calls, [(4, _EXTRAS)])
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_kimi_k3_flat_cudagraph.py
+++ b/test/runtime/test_kimi_k3_flat_cudagraph.py
@@ -104,8 +104,7 @@ class _StubFullAttnMeta:
 
 def test_replay_refreshes_buffers_in_place_and_pads_page_zero() -> None:
     backend = _bare_mla_backend(flat_contract=True)
-    seq_buf = torch.ones(2, dtype=torch.int32)
-    backend.init_cuda_graph_state(max_bs=2, seq_lens_buf=seq_buf)
+    backend.init_cuda_graph_state(max_bs=2)
     backend.init_forward_metadata_capture_cuda_graph(
         bs=2,
         req_pool_indices=torch.tensor([0, 1], dtype=torch.int32),
@@ -153,7 +152,7 @@ def test_replay_refreshes_buffers_in_place_and_pads_page_zero() -> None:
 def test_amd_mla_flat_graph_replay_is_pointer_stable_and_null_padded() -> None:
     backend = _bare_amd_mla_backend(flat_contract=True)
     seq_buf = torch.ones(2, dtype=torch.int32)
-    backend.init_cuda_graph_state(max_bs=2, seq_lens_buf=seq_buf)
+    backend.init_cuda_graph_state(max_bs=2)
     backend.init_forward_metadata_capture_cuda_graph(
         bs=2,
         req_pool_indices=torch.tensor([0, 1], dtype=torch.int32),

--- a/test/runtime/test_trtllm_spec_seqlen_clamp.py
+++ b/test/runtime/test_trtllm_spec_seqlen_clamp.py
@@ -135,31 +135,30 @@ def test_cuda_graph_capture_builder_clamps():
     """CUDA-graph capture builder points cache_seqlens at the clamped buffer."""
     be = _make_backend()
     max_bs = 8
-    seq_lens_buf = torch.ones((max_bs,), dtype=torch.int32)  # all padded -> 1
-    be.init_cuda_graph_state(max_bs, seq_lens_buf)
+    be.init_cuda_graph_state(max_bs)
 
     bs = 4
     be._init_multi_token_metadata_capture(bs, SPEC_NUM_TOKENS)
     cache_seqlens = be.forward_prefill_metadata.cache_seqlens_int32
 
     assert int(cache_seqlens.min()) >= SPEC_NUM_TOKENS
-    # Must be the dedicated clamped buffer, not the shared seq_lens_buf.
+    # Must be the dedicated clamped buffer, not the plain cache-seqlens buffer.
     assert cache_seqlens.data_ptr() == be.spec_cache_seqlens_buf.data_ptr()
-    assert cache_seqlens.data_ptr() != seq_lens_buf.data_ptr()
+    assert cache_seqlens.data_ptr() != be.cuda_graph_cache_seqlens.data_ptr()
 
 
 def test_draft_replay_refreshes_spec_cache_seqlens_buf():
     """Draft replay must refresh spec_cache_seqlens_buf (draft step 1 is multi-token)."""
     be = _make_backend(is_draft=True)
     max_bs = 8
-    # At capture time, seq_lens_buf is all 1s (padded rows).
-    seq_lens_buf = torch.ones((max_bs,), dtype=torch.int32)
-    be.init_cuda_graph_state(max_bs, seq_lens_buf)
+    be.init_cuda_graph_state(max_bs)
 
     bs = 4
+    # At capture time, seq_lens are all 1s (padded rows).
+    capture_seq_lens = torch.ones((max_bs,), dtype=torch.int32)
     # Capture: multi-token metadata (step 1) + decode metadata (steps 2+).
     be._init_multi_token_metadata_capture(bs, SPEC_NUM_TOKENS)
-    be._init_decode_metadata_capture(bs, seq_lens_buf)
+    be._init_decode_metadata_capture(bs, capture_seq_lens)
 
     # At capture, spec_cache_seqlens_buf was seeded from all-ones → clamped to 4.
     capture_vals = be.spec_cache_seqlens_buf[:bs].clone()

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flashinfer/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flashinfer/__init__.py
@@ -62,7 +62,7 @@ if platform.is_nvidia:
         trtllm_ragged_attention_deepseek,
     )
 
-if platform.is_blackwell:
+if platform.is_blackwell or platform.is_hopper:
     from flashinfer.mla import (
         BatchMLAPagedAttentionWrapper,
         trtllm_batch_decode_with_kv_cache_mla,


### PR DESCRIPTION
- Drop the shared seq_lens_buf parameter from every backend's init_cuda_graph_state; each backend now owns its cache-seqlens buffer and copies the live lengths in at replay, removing the dependency on the controller mutating a shared tensor. Updates base/mha/mla/trtllm/trtllm_mla/ tokenspeed_mla/dsa/inkling/hybrid_linear_attn/deepseek_v4 and the cuda-graph wrapper + affected tests.
- Fall back to plain all-gather + torch.argmax when CuTe DSL distributed argmax is unavailable (e.g. H20 lacks TMA cluster launch), fixing the spec-decode logits_processor assertion crash.
- Pass device_id to init_process_group on CUDA so PyTorch binds the process group eagerly and stops emitting the c10d barrier() device warning.
- Keep the FlashMLA new-API compatibility (drop num_splits, lazy tile sched meta) and the fp8 contiguous kv_a fix; 

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
