### PR TITLE
fix(kimi-k3): complete one-shot Lamport AR at end on the latent-norm …

### DIFF
--- a/python/tokenspeed/runtime/distributed/comm_ops.py
+++ b/python/tokenspeed/runtime/distributed/comm_ops.py
@@ -211,12 +211,6 @@ def all_reduce_latent_norm(
         eps=eps,
         max_token_num=max_token_num,
         launch_with_pdl=pdl_enabled(),
-        # One-shot Lamport must complete at the end: with PDL, an early
-        # cudaTriggerProgrammaticLaunchCompletion lets the next kernel read
-        # the lamport buffer before this kernel commits it (vLLM fixed the
-        # same defect in its allreduce_rms_fusion pass; see also
-        # flashinfer-ai/flashinfer#1223). The plain lamport path
-        # (_lamport_allreduce) already passes True.
         trigger_completion_at_end=True,
     )
 

--- a/python/tokenspeed/runtime/distributed/comm_ops.py
+++ b/python/tokenspeed/runtime/distributed/comm_ops.py
@@ -211,6 +211,13 @@ def all_reduce_latent_norm(
         eps=eps,
         max_token_num=max_token_num,
         launch_with_pdl=pdl_enabled(),
+        # One-shot Lamport must complete at the end: with PDL, an early
+        # cudaTriggerProgrammaticLaunchCompletion lets the next kernel read
+        # the lamport buffer before this kernel commits it (vLLM fixed the
+        # same defect in its allreduce_rms_fusion pass; see also
+        # flashinfer-ai/flashinfer#1223). The plain lamport path
+        # (_lamport_allreduce) already passes True.
+        trigger_completion_at_end=True,
     )
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/__init__.py
@@ -99,6 +99,7 @@ def allreduce_lane_latent_norm(
     eps: float,
     max_token_num: int,
     launch_with_pdl: bool = False,
+    trigger_completion_at_end: bool = False,
 ) -> torch.Tensor:
     """Reduce a routed/shared lane and normalize its routed prefix."""
 
@@ -111,6 +112,7 @@ def allreduce_lane_latent_norm(
         eps=eps,
         max_token_num=max_token_num,
         launch_with_pdl=launch_with_pdl,
+        trigger_completion_at_end=trigger_completion_at_end,
     )
 
 


### PR DESCRIPTION
…path

all_reduce_latent_norm never forwarded trigger_completion_at_end, so the fused all-reduce + latent RMSNorm ran with the kernel default (False) while the plain Lamport path (trtllm_allreduce.py) passes True.

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
