### PR TITLE
ci(kimi-k3): add 8-GPU TP8/EP8 AIME26 eval and 4k/1k perf tasks

### DIFF
--- a/docs/recipes/models.md
+++ b/docs/recipes/models.md
@@ -181,23 +181,16 @@ Notes:
   (fp8 KV required). AMD uses the `mla` backend.
 - `tokenspeed serve` auto-selects the `kimi_k3` reasoning and tool-call
   parsers. Explicit parser flags override these defaults.
-- Point `--model` at a **flattened local copy** of the checkpoint: real files
-  for the configs/tokenizer/`*.py` (weights may stay symlinks). An HF hub
-  snapshot directory fails engine startup — `tokenization_kimi.py`'s relative
-  `encoding_k3` import breaks when transformers resolves the module file
-  through the snapshot's `blobs/` symlinks — and the bare repo id fails the
-  smg gateway, which needs an on-disk tokenizer directory.
-- On a shared `HF_HOME`, set `HF_MODULES_CACHE` to a user-writable directory;
-  transformers stages the checkpoint's remote code under
-  `$HF_HOME/modules/transformers_modules/<model>` and a new model name fails
-  with `PermissionError` when that tree belongs to another user.
+- The SMG packages pinned by TokenSpeed resolve `moonshotai/Kimi-K3` directly;
+  a flattened local checkpoint and separately staged remote-code cache are no
+  longer required.
 - The checkpoint carries no fp8 KV scaling factors; the loader defaults them
   to 1.0 (a warning at load). Expect a small accuracy delta vs bf16 KV.
 - The vision encoder has 12 attention heads. For an 8-way text TP deployment,
   use `--mm-encoder-tp-mode data` so each rank runs the vision encoder at TP1
   on a different whole image.
-- Use the current `lightseekorg/smg-private` frontend, which registers Kimi-K3's
-  chat renderer and multimodal processor. Preserve the checkpoint's
+- The pinned SMG frontend registers Kimi-K3's chat renderer and multimodal
+  processor. Preserve the checkpoint's
   `media_proc_cfg.in_patch_limit=65536`; silently falling back to K2.5's
   16384-patch default reduces OCR resolution.
 - KDA recurrent-state pages register for prefix-cache reuse only when a

--- a/test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
@@ -1,0 +1,62 @@
+api_version: ci.tokenspeed.io/v1
+name: eval-kimi-k3-mxfp4-tp8ep8-aime26-amd
+type: eval
+triggers:
+  - per-commit
+  - manual
+runner:
+  labels:
+    - amd-mi35x-8gpu-test
+env:
+  CI: "true"
+  # Kimi-K3 is FlatKV-only; startup preflight rejects a radix scheduler build.
+  TOKENSPEED_FLAT_KV: "ON"
+install:
+  - bash test/ci_system/install_deps_rocm.sh
+server:
+  command: >-
+    ts serve
+    --model moonshotai/Kimi-K3
+    --served-model-name kimi-k3
+    --tp 8
+    --ep-size 8
+    --attention-backend mla
+    --moe-backend auto
+    --kv-cache-dtype fp8
+    --mm-encoder-tp-mode data
+    --max-model-len 65536
+    --max-num-seqs 16
+    --max-cudagraph-capture-size 16
+    --cudagraph-capture-sizes 1 2 4 8 16
+    --disable-prefill-graph
+    --gpu-memory-utilization 0.92
+    --trust-remote-code
+    --sampling-backend greedy
+    --disable-kvstore
+    --kvstore-ratio 0.0
+    --enable-cache-report
+    --host 127.0.0.1
+    --port 8000
+    --policy round_robin
+    --engine-startup-timeout 3000
+    --gateway-startup-timeout 600
+  ready:
+    url: http://127.0.0.1:8000/readiness
+    timeout: 3600
+    interval: 10
+eval:
+  install:
+    - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]'
+  command: >-
+    /tmp/evalscope-perf/bin/evalscope eval
+    --model kimi-k3
+    --api-url http://127.0.0.1:8000/v1
+    --api-key EMPTY_TOKEN
+    --datasets aime26
+    --eval-batch-size 16
+    --stream
+    --generation-config '{"do_sample":true,"temperature":1.0,"max_tokens":32768,"extra_body":{"reasoning_effort":"high"}}'
+report:
+  github_step_summary: true
+# Measured 0.933 (28/30) on 8x MI350X with high reasoning effort.
+score_threshold: 0.90

--- a/test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
+++ b/test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
@@ -28,6 +28,7 @@ server:
     --max-num-seqs 1
     --max-cudagraph-capture-size 1
     --cudagraph-capture-sizes 1
+    --disable-prefill-graph
     --gpu-memory-utilization 0.92
     --trust-remote-code
     --sampling-backend greedy

--- a/test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
+++ b/test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
@@ -1,0 +1,93 @@
+api_version: ci.tokenspeed.io/v1
+name: perf-kimi-k3-mxfp4-tp8ep8-random-4k-1k-mi35x
+type: perf
+triggers:
+  - per-commit
+  - manual
+runner:
+  labels:
+    - amd-mi35x-8gpu-test
+env:
+  CI: "true"
+  # Kimi-K3 is FlatKV-only; startup preflight rejects a radix scheduler build.
+  TOKENSPEED_FLAT_KV: "ON"
+install:
+  - bash test/ci_system/install_deps_rocm.sh
+server:
+  command: >-
+    ts serve
+    --model moonshotai/Kimi-K3
+    --served-model-name kimi-k3
+    --tp 8
+    --ep-size 8
+    --attention-backend mla
+    --moe-backend auto
+    --kv-cache-dtype fp8
+    --mm-encoder-tp-mode data
+    --max-model-len 8192
+    --max-num-seqs 1
+    --max-cudagraph-capture-size 1
+    --cudagraph-capture-sizes 1
+    --gpu-memory-utilization 0.92
+    --trust-remote-code
+    --sampling-backend greedy
+    --disable-kvstore
+    --kvstore-ratio 0.0
+    --no-enable-prefix-caching
+    --enable-cache-report
+    --host 127.0.0.1
+    --port 21000
+    --policy round_robin
+    --engine-startup-timeout 3000
+    --gateway-startup-timeout 600
+  ready:
+    url: http://127.0.0.1:21000/readiness
+    timeout: 3600
+    interval: 10
+perf:
+  install:
+    - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]'
+  command: >-
+    REPO_ROOT=$PWD &&
+    MODEL=kimi-k3 &&
+    URL=http://127.0.0.1:21000/v1/completions &&
+    OUTPUTS_DIR=/tmp/tokenspeed-kimi-k3-mi35x-perf &&
+    trap 'rm -rf "$OUTPUTS_DIR"' EXIT &&
+    rm -rf "$OUTPUTS_DIR" &&
+    set +e &&
+    echo "==================================================" &&
+    echo ">>> input=4k output=1k conc=1" &&
+    echo "==================================================" &&
+    /tmp/evalscope-perf/bin/evalscope perf
+    --model "$MODEL"
+    --url "$URL"
+    --api openai
+    --dataset random
+    --tokenizer-path moonshotai/Kimi-K3
+    --min-prompt-length 4096
+    --max-prompt-length 4096
+    --prefix-length 0
+    --min-tokens 1024
+    --max-tokens 1024
+    --parallel 1
+    --number 1
+    --warmup-num 0
+    --rate -1
+    --seed 1
+    --temperature 0
+    --stream
+    --outputs-dir "$OUTPUTS_DIR/input_4k"
+    --no-timestamp
+    --extra-args '{"ignore_eos": true}';
+    PERF_STATUS=$?;
+    python3 "$REPO_ROOT/test/random_benchmark/tokenspeed/collect_outputs.py" "$OUTPUTS_DIR" --num-gpus 8 --emit-csv;
+    PARSE_STATUS=$?;
+    if [ "$PERF_STATUS" -ne 0 ]; then exit "$PERF_STATUS"; fi;
+    exit "$PARSE_STATUS"
+report:
+  github_step_summary: true
+perf_threshold: 0.9
+# Values are [Latency (tps/user), Throughput (tps/gpu)]; gate fails any conc whose actual falls below ref * perf_threshold.
+# Rounded down from an 8x MI350X concurrency-1 measurement: 43.05 / 5.26.
+perf_reference:
+  1: [42, 5.2]

--- a/test/ci_system/test_random_benchmark_perf_csv.py
+++ b/test/ci_system/test_random_benchmark_perf_csv.py
@@ -1,0 +1,54 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from pipeline import check_perf_reference, extract_perf_summary_rows
+
+
+def test_random_benchmark_output_can_be_gated(tmp_path):
+    run_dir = tmp_path / "input_4k" / "parallel_8"
+    run_dir.mkdir(parents=True)
+    (run_dir / "benchmark_summary.json").write_text(
+        json.dumps(
+            {
+                "Concurrency": 8,
+                "TPOT (ms)": 10.0,
+                "Output Throughput (tok/s)": 4000.0,
+                "KV Cache Hit Rate (%)": 0.0,
+                "Decoded Tok/Iter": 1.0,
+            }
+        )
+    )
+
+    collector = (
+        Path(__file__).resolve().parents[1]
+        / "random_benchmark"
+        / "tokenspeed"
+        / "collect_outputs.py"
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            collector,
+            tmp_path,
+            "--num-gpus",
+            "8",
+            "--emit-csv",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    rows = extract_perf_summary_rows(result.stdout)
+    assert rows[0]["Conc."] == "8"
+    assert rows[0]["Latency (tps/user)"] == "100.0"
+    assert rows[0]["Throughput (tps/gpu)"] == "500.0"
+
+    check = check_perf_reference(
+        {"perf_threshold": 0.9, "perf_reference": {8: [100, 500]}},
+        [{"perf_summary_rows": rows}],
+        ["perf"],
+    )
+    assert check["passed"]

--- a/test/random_benchmark/tokenspeed/collect_outputs.py
+++ b/test/random_benchmark/tokenspeed/collect_outputs.py
@@ -2,6 +2,7 @@
 """Collect random perf sweeps into one CI summary table."""
 
 import argparse
+import csv
 import json
 import sys
 from pathlib import Path
@@ -14,6 +15,18 @@ COLUMNS = [
     "Approx Cache Hit",
     "Decoded Tok/Iter",
 ]
+
+# `pipeline.py` gates a perf task's `perf_reference` on this exact CSV header,
+# so the throughput column drops the "Output " prefix used by the human table.
+CSV_COLUMNS = [
+    "config",
+    "Conc.",
+    "Latency (tps/user)",
+    "Throughput (tps/gpu)",
+    "Approx Cache Hit",
+    "Decoded Tok/Iter",
+]
+CSV_SOURCE_COLUMNS = {"Throughput (tps/gpu)": "Output Throughput (tps/gpu)"}
 
 INPUT_ORDER = {
     "input_1k": 1024,
@@ -99,10 +112,27 @@ def print_table(rows):
         print("  ".join(str(row[column]).rjust(widths[column]) for column in COLUMNS))
 
 
+def print_csv(rows):
+    writer = csv.DictWriter(sys.stdout, fieldnames=CSV_COLUMNS)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(
+            {
+                column: row[CSV_SOURCE_COLUMNS.get(column, column)]
+                for column in CSV_COLUMNS
+            }
+        )
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("sweep_dir", type=Path)
     parser.add_argument("--num-gpus", type=int, default=1)
+    parser.add_argument(
+        "--emit-csv",
+        action="store_true",
+        help="Also print the CSV block that a task's perf_reference gate reads.",
+    )
     args = parser.parse_args()
 
     if not args.sweep_dir.is_dir():
@@ -112,6 +142,9 @@ def main():
 
     rows = collect(args.sweep_dir, args.num_gpus)
     print_table(rows)
+    if args.emit_csv:
+        print()
+        print_csv(rows)
     if not rows:
         sys.exit(1)
 


### PR DESCRIPTION
## Summary

### Features/Changes:

Add tasks serve the mxfp4 checkpoint at TP8/EP8 on a FlatKV build and pin decode graphs to measured concurrency. The AIME26 task runs eight problems with thinking disabled and a 16k generation cap; the perf task sweeps 4k-in/1k-out at concurrency 1 against a measured perf_reference.

We also add support to assert/check perf reference values in `test/random_benchmark/tokenspeed/collect_outputs.py`.  and a companion test file in `test/ci_system/test_random_benchmark_perf_csv.py`

Updated model.md to fix outdated information that default tokenspeed-smg doesnt support K3. 