### PR TITLE
perf(router): enable packed key topk for nvidia

### DIFF
--- a/python/tokenspeed/runtime/layers/moe/topk.py
+++ b/python/tokenspeed/runtime/layers/moe/topk.py
@@ -521,7 +521,10 @@ def select_experts(
                 and num_fused_shared_experts == 0
                 and routed_scaling_factor is not None
                 and num_token_non_padded is None
-                and expert_location_dispatch_info is None
+                and (
+                    expert_location_dispatch_info is None
+                    or logical_to_physical_map is not None
+                )
             )
             if use_sigmoid_bias_topk:
                 topk_weights, topk_ids = moe_sigmoid_bias_topk(
@@ -530,6 +533,8 @@ def select_experts(
                     top_k,
                     routed_scaling_factor=float(routed_scaling_factor),
                     normalize_topk_weights=renormalize,
+                    logical_to_physical_map=logical_to_physical_map,
+                    weights_dtype=topk_config.topk_weights_dtype,
                 )
             else:
                 topk_weights, topk_ids = minimax_biased_grouped_topk(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/sigmoid_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/sigmoid_topk.py
@@ -42,6 +42,8 @@ def moe_sigmoid_bias_topk(
     *,
     routed_scaling_factor: float = 1.0,
     normalize_topk_weights: bool = True,
+    logical_to_physical_map: torch.Tensor | None = None,
+    weights_dtype: torch.dtype = torch.float32,
     solution: str | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Select experts using ``sigmoid(logits) + correction_bias``.
@@ -52,11 +54,17 @@ def moe_sigmoid_bias_topk(
         topk: Number of experts selected per token.
         routed_scaling_factor: Scale applied after optional normalization.
         normalize_topk_weights: Normalize selected sigmoid scores when true.
+        logical_to_physical_map: Optional ``[experts]`` integer map applying
+            static expert-location dispatch to the selected ids (fused into
+            the specialized decode kernel; a gather elsewhere).
+        weights_dtype: Output dtype for the route weights (selection always
+            runs in FP32).
         solution: Optional implementation override.
 
     Returns:
         ``(topk_weights, topk_ids)`` with shapes ``[tokens, topk]``. Weights
-        are FP32 and ids are INT32.
+        are ``weights_dtype`` and ids are INT32 (physical ids when a dispatch
+        map is given).
     """
     if router_logits.dim() != 2:
         raise ValueError("router_logits must have shape [tokens, experts]")
@@ -70,22 +78,29 @@ def moe_sigmoid_bias_topk(
     if tokens == 0:
         shape = (0, topk)
         return (
-            torch.empty(shape, device=router_logits.device, dtype=torch.float32),
+            torch.empty(shape, device=router_logits.device, dtype=weights_dtype),
             torch.empty(shape, device=router_logits.device, dtype=torch.int32),
         )
+    platform = Platform.get()
     if (
         solution is None
-        and Platform.get().is_cdna4
+        and (platform.is_cdna4 or platform.is_nvidia)
         and router_logits.shape == (1, 896)
         and router_logits.dtype == torch.float32
         and correction_bias.dtype == torch.float32
         and topk == 16
     ):
+        # The packed-key single-CTA kernel wins on both vendors for the K3
+        # decode shape: one bitonic top-16 instead of the grouped multi-pass
+        # (NVIDIA B300: 3.7us vs 7.0us for the minimax path, bit-identical
+        # selection and weights).
         return kimi3_sigmoid_bias_topk(
             router_logits,
             correction_bias,
             routed_scaling_factor=routed_scaling_factor,
             normalize_topk_weights=normalize_topk_weights,
+            logical_to_physical_map=logical_to_physical_map,
+            weights_dtype=weights_dtype,
         )
     if solution is None and not _gluon_eligible(router_logits, correction_bias, topk):
         solution = "torch"
@@ -96,13 +111,18 @@ def moe_sigmoid_bias_topk(
         format_signature(router_logits=dense_tensor_format(router_logits.dtype)),
         solution=solution,
     )
-    return kernel(
+    topk_weights, topk_ids = kernel(
         router_logits=router_logits,
         correction_bias=correction_bias,
         topk=topk,
         routed_scaling_factor=routed_scaling_factor,
         normalize_topk_weights=normalize_topk_weights,
     )
+    if logical_to_physical_map is not None:
+        topk_ids = logical_to_physical_map[topk_ids.long()].to(torch.int32)
+    if topk_weights.dtype != weights_dtype:
+        topk_weights = topk_weights.to(weights_dtype)
+    return topk_weights, topk_ids
 
 
 @register_kernel(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/kimi3_sigmoid_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/kimi3_sigmoid_topk.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import torch
 from tokenspeed_kernel._triton import tl, triton
-from tokenspeed_kernel.platform import Platform
+from tokenspeed_kernel.platform import Platform, current_platform
 
 
 @triton.jit
@@ -27,12 +27,19 @@ def _kimi3_sigmoid_bias_topk_kernel(
     ROUTED_SCALING_FACTOR: tl.constexpr,
     NORMALIZE_TOPK_WEIGHTS: tl.constexpr,
     HAS_DISPATCH_MAP: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     num_experts: tl.constexpr = 896
     padded_experts: tl.constexpr = 1024
     topk: tl.constexpr = 16
     expert = tl.arange(0, padded_experts)
     valid = expert < num_experts
+
+    if ENABLE_PDL:
+        # ``logits`` is the router GEMV output written by the predecessor
+        # kernel; correction_bias / logical_to_physical are static, but the
+        # very first load below consumes logits, so fence up front.
+        tl.extra.cuda.gdc_wait()
 
     all_logits = tl.load(
         logits + expert,
@@ -73,6 +80,8 @@ def _kimi3_sigmoid_bias_topk_kernel(
     offset = tl.arange(0, topk)
     tl.store(topk_ids + offset, selected_ids)
     tl.store(topk_weights + offset, selected_weights)
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
 
 def kimi3_sigmoid_bias_topk(
@@ -83,6 +92,7 @@ def kimi3_sigmoid_bias_topk(
     normalize_topk_weights: bool,
     logical_to_physical_map: torch.Tensor | None = None,
     weights_dtype: torch.dtype = torch.float32,
+    enable_pdl: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Route one Kimi K3 decode token to its top 16 of 896 experts.
 
@@ -96,6 +106,10 @@ def kimi3_sigmoid_bias_topk(
             to physical ids inside the kernel (static EP dispatch).
         weights_dtype: Output dtype for the route weights (selection and
             normalization always run in FP32; the store casts).
+        enable_pdl: Launch with programmatic dependent launch and fence the
+            router-logits read with ``gdc_wait`` / ``gdc_launch_dependents``
+            (NVIDIA only; ignored elsewhere). Safe only when the router GEMV
+            that writes ``router_logits`` is chained on the same stream/graph.
 
     Returns:
         ``(topk_weights, topk_ids)`` shaped ``[1, 16]`` with ``weights_dtype``
@@ -138,6 +152,9 @@ def kimi3_sigmoid_bias_topk(
     )
     # waves_per_eu is a CDNA-only occupancy hint; NVIDIA Triton rejects it.
     amd_kwargs = {"waves_per_eu": 1} if Platform.get().is_amd else {}
+    pdl_kwargs = (
+        {"launch_pdl": True} if enable_pdl and current_platform().is_nvidia else {}
+    )
     _kimi3_sigmoid_bias_topk_kernel[(1,)](
         router_logits,
         correction_bias,
@@ -147,9 +164,11 @@ def kimi3_sigmoid_bias_topk(
         ROUTED_SCALING_FACTOR=float(routed_scaling_factor),
         NORMALIZE_TOPK_WEIGHTS=normalize_topk_weights,
         HAS_DISPATCH_MAP=logical_to_physical_map is not None,
+        ENABLE_PDL=enable_pdl,
         num_warps=8,
         num_stages=1,
         **amd_kwargs,
+        **pdl_kwargs,
     )
     return topk_weights, topk_ids
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/kimi3_sigmoid_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/kimi3_sigmoid_topk.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import torch
 from tokenspeed_kernel._triton import tl, triton
+from tokenspeed_kernel.platform import Platform
 
 
 @triton.jit
@@ -22,8 +23,10 @@ def _kimi3_sigmoid_bias_topk_kernel(
     correction_bias,
     topk_ids,
     topk_weights,
+    logical_to_physical,
     ROUTED_SCALING_FACTOR: tl.constexpr,
     NORMALIZE_TOPK_WEIGHTS: tl.constexpr,
+    HAS_DISPATCH_MAP: tl.constexpr,
 ):
     num_experts: tl.constexpr = 896
     padded_experts: tl.constexpr = 1024
@@ -62,6 +65,11 @@ def _kimi3_sigmoid_bias_topk_kernel(
         selected_weights /= denominator
     selected_weights *= ROUTED_SCALING_FACTOR
 
+    if HAS_DISPATCH_MAP:
+        # Static expert-location dispatch: route each selected logical expert
+        # to this rank's physical replica inside the same launch.
+        selected_ids = tl.load(logical_to_physical + selected_ids).to(tl.int32)
+
     offset = tl.arange(0, topk)
     tl.store(topk_ids + offset, selected_ids)
     tl.store(topk_weights + offset, selected_weights)
@@ -73,6 +81,8 @@ def kimi3_sigmoid_bias_topk(
     *,
     routed_scaling_factor: float,
     normalize_topk_weights: bool,
+    logical_to_physical_map: torch.Tensor | None = None,
+    weights_dtype: torch.dtype = torch.float32,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Route one Kimi K3 decode token to its top 16 of 896 experts.
 
@@ -81,10 +91,15 @@ def kimi3_sigmoid_bias_topk(
         correction_bias: Contiguous FP32 selection bias shaped ``[896]``.
         routed_scaling_factor: Scale applied to selected route weights.
         normalize_topk_weights: Normalize selected sigmoid scores when true.
+        logical_to_physical_map: Optional contiguous integer map shaped
+            ``[896]``; when given, selected logical expert ids are translated
+            to physical ids inside the kernel (static EP dispatch).
+        weights_dtype: Output dtype for the route weights (selection and
+            normalization always run in FP32; the store casts).
 
     Returns:
-        ``(topk_weights, topk_ids)`` shaped ``[1, 16]`` with FP32 weights and
-        INT32 ids.
+        ``(topk_weights, topk_ids)`` shaped ``[1, 16]`` with ``weights_dtype``
+        weights and INT32 ids (physical ids when a dispatch map is given).
     """
     if (
         router_logits.shape != (1, 896)
@@ -100,6 +115,16 @@ def kimi3_sigmoid_bias_topk(
         or not correction_bias.is_contiguous()
     ):
         raise ValueError("Kimi K3 top-k requires contiguous colocated FP32 bias [896]")
+    if logical_to_physical_map is not None and (
+        logical_to_physical_map.shape != (896,)
+        or logical_to_physical_map.dtype not in (torch.int32, torch.int64)
+        or logical_to_physical_map.device != router_logits.device
+        or not logical_to_physical_map.is_contiguous()
+    ):
+        raise ValueError(
+            "Kimi K3 top-k dispatch map must be a contiguous colocated "
+            "int32/int64 [896] tensor"
+        )
 
     topk_ids = torch.empty(
         (1, 16),
@@ -108,19 +133,23 @@ def kimi3_sigmoid_bias_topk(
     )
     topk_weights = torch.empty(
         (1, 16),
-        dtype=torch.float32,
+        dtype=weights_dtype,
         device=router_logits.device,
     )
+    # waves_per_eu is a CDNA-only occupancy hint; NVIDIA Triton rejects it.
+    amd_kwargs = {"waves_per_eu": 1} if Platform.get().is_amd else {}
     _kimi3_sigmoid_bias_topk_kernel[(1,)](
         router_logits,
         correction_bias,
         topk_ids,
         topk_weights,
+        logical_to_physical_map,
         ROUTED_SCALING_FACTOR=float(routed_scaling_factor),
         NORMALIZE_TOPK_WEIGHTS=normalize_topk_weights,
+        HAS_DISPATCH_MAP=logical_to_physical_map is not None,
         num_warps=8,
         num_stages=1,
-        waves_per_eu=1,
+        **amd_kwargs,
     )
     return topk_weights, topk_ids
 

--- a/tokenspeed-kernel/test/ops/moe/test_sigmoid_bias_topk_nvidia.py
+++ b/tokenspeed-kernel/test/ops/moe/test_sigmoid_bias_topk_nvidia.py
@@ -78,3 +78,69 @@ def test_entry_point_selects_fused_kernel():
     )
     torch.testing.assert_close(got_w, ref_w)
     assert torch.equal(got_i, ref_i)
+
+
+@pytest.mark.parametrize("normalize", [False, True])
+@pytest.mark.parametrize("scale", [1.0, 2.5])
+def test_decode_shape_uses_lean_kernel_and_is_exact(normalize, scale):
+    """The K3 decode shape (1, 896) topk=16 takes the packed-key single-CTA
+    kernel on NVIDIA: exact expert set and weights vs torch, and CUDA-graph
+    capturable (the decode path replays it inside the step graph)."""
+    torch.manual_seed(7)
+    logits = (torch.randn(1, 896, device="cuda") * 0.2).float()
+    bias = (torch.randn(896, device="cuda") * 0.01).float()
+    scores = logits.sigmoid()
+    expected_ids = torch.topk(
+        scores + bias.unsqueeze(0), 16, dim=-1, sorted=False
+    ).indices
+    expected_weights = scores.gather(1, expected_ids)
+    if normalize:
+        expected_weights /= expected_weights.sum(dim=-1, keepdim=True)
+    expected_weights *= scale
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        weights, ids = moe_sigmoid_bias_topk(
+            logits,
+            bias,
+            16,
+            routed_scaling_factor=scale,
+            normalize_topk_weights=normalize,
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert weights.dtype == torch.float32 and ids.dtype == torch.int32
+    assert set(ids[0].tolist()) == set(expected_ids[0].tolist())
+    expected_by_id = dict(
+        zip(expected_ids[0].tolist(), expected_weights[0].tolist(), strict=True)
+    )
+    for expert_id, weight in zip(ids[0].tolist(), weights[0].tolist(), strict=True):
+        assert weight == pytest.approx(expected_by_id[expert_id], abs=1e-5)
+
+
+@pytest.mark.parametrize("tokens", [1, 2])
+def test_static_dispatch_map_and_weights_dtype(tokens):
+    """The optional logical->physical map must translate the selected ids on
+    both the lean decode kernel (tokens=1) and the registry fallback
+    (tokens=2), and bf16 weight output must match the fp32 path."""
+    torch.manual_seed(11)
+    logits = torch.randn(tokens, 896, dtype=torch.float32, device="cuda")
+    bias = torch.randn(896, dtype=torch.float32, device="cuda")
+    dispatch = torch.randperm(896, dtype=torch.int32, device="cuda")
+
+    ref_w, ref_i = moe_sigmoid_bias_topk(
+        logits, bias, 16, routed_scaling_factor=1.0, normalize_topk_weights=True
+    )
+    got_w, got_i = moe_sigmoid_bias_topk(
+        logits,
+        bias,
+        16,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=True,
+        logical_to_physical_map=dispatch,
+        weights_dtype=torch.bfloat16,
+    )
+    assert got_w.dtype == torch.bfloat16 and got_i.dtype == torch.int32
+    assert torch.equal(dispatch[ref_i.long()].to(torch.int32), got_i)
+    torch.testing.assert_close(got_w.float(), ref_w, atol=8e-3, rtol=8e-3)


### PR DESCRIPTION
## Summary

Enable the packed key topk kernel for both amd and nvidia.

## Test Plan

<!-- How was this validated? -->
