### PR TITLE
fix(kimi3): correct AMD KDA safe gate

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/kda.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/kda.py
@@ -64,11 +64,12 @@ def _kda_prepare_gate_beta_kernel(
         other=0.0,
     ).to(tl.float32)
     x += bias
-    softplus = tl.maximum(x, 0.0) + tl.log(1.0 + tl.exp(-tl.abs(x)))
     a = tl.load(a_log + head_idx).to(tl.float32)
-    g = -tl.exp(a) * softplus
     if HAS_LOWER_BOUND:
-        g = tl.maximum(g, LOWER_BOUND)
+        g = LOWER_BOUND * tl.sigmoid(tl.exp(a) * x)
+    else:
+        softplus = tl.maximum(x, 0.0) + tl.log(1.0 + tl.exp(-tl.abs(x)))
+        g = -tl.exp(a) * softplus
     tl.store(gate + linear, g, mask=mask)
 
     raw_b = tl.load(raw_beta + token_idx * H + head_idx).to(tl.float32)
@@ -411,10 +412,14 @@ def _kda_recurrent_decode_kernel(
     gate_value += tl.load(
         dt_bias + head_idx * K + key_offsets, mask=key_mask, other=0.0
     ).to(tl.float32)
-    softplus = tl.maximum(gate_value, 0.0) + tl.log(1.0 + tl.exp(-tl.abs(gate_value)))
-    log_decay = -tl.exp(tl.load(a_log + head_idx).to(tl.float32)) * softplus
+    a = tl.load(a_log + head_idx).to(tl.float32)
     if HAS_LOWER_BOUND:
-        log_decay = tl.maximum(log_decay, LOWER_BOUND)
+        log_decay = LOWER_BOUND * tl.sigmoid(tl.exp(a) * gate_value)
+    else:
+        softplus = tl.maximum(gate_value, 0.0) + tl.log(
+            1.0 + tl.exp(-tl.abs(gate_value))
+        )
+        log_decay = -tl.exp(a) * softplus
     beta_value = tl.sigmoid(tl.load(raw_beta + token_idx * H + head_idx).to(tl.float32))
 
     scale: tl.constexpr = K**-0.5

--- a/tokenspeed-kernel/test/kimi3_reference.py
+++ b/tokenspeed-kernel/test/kimi3_reference.py
@@ -37,6 +37,74 @@ def situ_and_mul(
     return (gate * up).to(x.dtype)
 
 
+def kda_gate(
+    raw_g: torch.Tensor,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    *,
+    lower_bound: float | None = -5.0,
+) -> torch.Tensor:
+    """Reference KDA log-decay gate."""
+
+    if raw_g.ndim != 3:
+        raise ValueError("raw_g must be [T, H, D]")
+    heads = raw_g.shape[1]
+    if a_log.shape != (heads,):
+        raise ValueError("a_log must have one value per local head")
+    if dt_bias.shape != raw_g.shape[1:]:
+        raise ValueError("dt_bias must be [H, D]")
+
+    gate_input = raw_g.float() + dt_bias.float()[None, :, :]
+    if lower_bound is not None:
+        return lower_bound * torch.sigmoid(
+            torch.exp(a_log.float())[None, :, None] * gate_input
+        )
+    return -torch.exp(a_log.float())[None, :, None] * F.softplus(gate_input)
+
+
+def kda_recurrent(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_g: torch.Tensor,
+    beta: torch.Tensor,
+    state: torch.Tensor,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    *,
+    lower_bound: float | None = -5.0,
+    eps: float = 1e-6,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Sequential KDA oracle for both prefill and decode."""
+
+    if q.shape != k.shape or q.shape != v.shape or q.shape != raw_g.shape:
+        raise ValueError("q, k, v, and raw_g must have matching shapes")
+    tokens, heads, key_dim = q.shape
+    value_dim = v.shape[-1]
+    if state.shape != (heads, value_dim, key_dim):
+        raise ValueError("invalid KDA state shape")
+    if beta.shape != (tokens, heads):
+        raise ValueError("beta must be [T, H]")
+
+    gates = kda_gate(raw_g, a_log, dt_bias, lower_bound=lower_bound)
+    running = state.float().clone()
+    outputs = []
+    scale = key_dim**-0.5
+    for token_idx in range(tokens):
+        q_t = F.normalize(q[token_idx].float(), dim=-1, eps=eps) * scale
+        k_t = F.normalize(k[token_idx].float(), dim=-1, eps=eps)
+        v_t = v[token_idx].float()
+        beta_t = torch.sigmoid(beta[token_idx].float())
+
+        running = running * torch.exp(gates[token_idx])[:, None, :]
+        prediction = torch.einsum("hvk,hk->hv", running, k_t)
+        delta = beta_t[:, None] * (v_t - prediction)
+        running = running + torch.einsum("hv,hk->hvk", delta, k_t)
+        outputs.append(torch.einsum("hvk,hk->hv", running, q_t))
+
+    return torch.stack(outputs).to(q.dtype), running.to(state.dtype)
+
+
 _E2M1_VALUES = torch.tensor(
     [
         0.0,

--- a/tokenspeed-kernel/test/ops/test_kda_recurrent.py
+++ b/tokenspeed-kernel/test/ops/test_kda_recurrent.py
@@ -4,12 +4,79 @@ from __future__ import annotations
 
 import pytest
 import torch
+from kimi3_reference import kda_gate
+from kimi3_reference import kda_recurrent as reference_kda_recurrent
 from tokenspeed_kernel.ops.attention import (
     kda_paged_decode,
     kda_recurrent,
     kda_recurrent_decode,
 )
 from tokenspeed_kernel.platform import current_platform
+
+
+def test_k3_safe_gate_reference_matches_sigmoid_contract() -> None:
+    """Distinguish K3's safe sigmoid gate from a clamped softplus gate."""
+    raw_g = torch.tensor([[[-2.0, 0.0, 2.0]]])
+    a_log = torch.tensor([0.25])
+    dt_bias = torch.tensor([[0.5, -0.5, 1.0]])
+    lower_bound = -5.0
+
+    gate_input = raw_g + dt_bias
+    expected = lower_bound * torch.sigmoid(torch.exp(a_log)[None, :, None] * gate_input)
+    actual = kda_gate(raw_g, a_log, dt_bias, lower_bound=lower_bound)
+    torch.testing.assert_close(actual, expected)
+
+    legacy = torch.clamp_min(
+        -torch.exp(a_log)[None, :, None] * torch.nn.functional.softplus(gate_input),
+        lower_bound,
+    )
+    assert not torch.allclose(actual, legacy)
+
+
+def test_kda_recurrent_matches_safe_gate_reference() -> None:
+    """Packed recurrence must use K3's safe sigmoid decay gate."""
+    device = "cuda"
+    torch.manual_seed(5)
+    tokens, heads, dim = 3, 2, 8
+    q = torch.randn(tokens, heads, dim, device=device, dtype=torch.bfloat16)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    raw_g = torch.randn_like(q)
+    beta = torch.randn(tokens, heads, device=device, dtype=torch.bfloat16)
+    state = torch.randn(1, heads, dim, dim, device=device, dtype=torch.float32)
+    a_log = torch.randn(heads, device=device, dtype=torch.float32)
+    dt_bias = torch.randn(heads, dim, device=device, dtype=torch.float32)
+    lower_bound = -5.0
+
+    expected_out, expected_state = reference_kda_recurrent(
+        q,
+        k,
+        v,
+        raw_g,
+        beta,
+        state[0],
+        a_log,
+        dt_bias,
+        lower_bound=lower_bound,
+    )
+    actual_out, actual_state = kda_recurrent(
+        q,
+        k,
+        v,
+        raw_g,
+        beta,
+        state,
+        a_log,
+        dt_bias,
+        lower_bound=lower_bound,
+        cu_seqlens=torch.tensor([0, tokens], device=device, dtype=torch.int32),
+        state_indices=torch.tensor([0], device=device, dtype=torch.int32),
+    )
+
+    torch.testing.assert_close(
+        actual_out.float(), expected_out.float(), atol=5e-2, rtol=5e-2
+    )
+    torch.testing.assert_close(actual_state[0], expected_state, atol=5e-2, rtol=5e-2)
 
 
 def test_kda_recurrent_zeroes_invalid_and_empty_graph_rows() -> None:


### PR DESCRIPTION
  ## Summary

  Fix the Kimi K3 safe-gate calculation in the AMD Triton KDA prefill and decode paths.

  The kernel previously applied the standard softplus gate and clamped it to the lower bound. K3 instead uses:

  ```python
  lower_bound * sigmoid(exp(A_log) * gate_input)
```
  This now matches the FLA reference implementation (https://github.com/fla-org/flash-linear-attention/blob/0f0f0c97af39343855b43bbbaddcedfda5cb9d77/fla/ops/kda/gate.py#L58-L70).

  ## Tests

  - Added PyTorch references for the K3 safe gate and recurrent KDA update.
  - Added coverage that distinguishes the safe gate from the old clamped-softplus calculation.
  - Compared the AMD recurrent kernel output and final state against the reference.

