### PR TITLE
perf(loader): skip safetensors shards without MTP weights

### DIFF
--- a/python/tokenspeed/runtime/model_loader/loader.py
+++ b/python/tokenspeed/runtime/model_loader/loader.py
@@ -29,7 +29,7 @@ import dataclasses
 import glob
 import os
 from abc import ABC, abstractmethod
-from collections.abc import Generator, Iterable, Iterator
+from collections.abc import Callable, Generator, Iterable, Iterator
 from contextlib import contextmanager
 from typing import Any, cast
 
@@ -53,6 +53,7 @@ from tokenspeed.runtime.model_loader.weight_utils import (
     download_weights_from_hf,
     filter_duplicate_safetensors_files,
     filter_files_not_needed_for_inference,
+    filter_safetensors_files_by_weight_names,
     get_quant_config,
     initialize_dummy_weights,
     np_cache_weights_iterator,
@@ -318,12 +319,32 @@ class DefaultModelLoader(BaseModelLoader):
         return hf_folder, hf_weights_files, use_safetensors
 
     def _get_weights_iterator(
-        self, source: "Source"
+        self,
+        source: "Source",
+        weight_name_filter: Callable[[str], bool] | None = None,
     ) -> Generator[tuple[str, torch.Tensor], None, None]:
-        """Get an iterator for the model weights based on the load format."""
+        """Get an iterator for the model weights based on the load format.
+
+        When ``weight_name_filter`` is given, safetensors shards whose index
+        entries contain no accepted weight name are skipped entirely (not
+        read or prefetched). The predicate sees names as yielded to the
+        consumer, i.e. with ``source.prefix`` applied.
+        """
         hf_folder, hf_weights_files, use_safetensors = self._prepare_weights(
             source.model_or_path, source.revision, source.fall_back_to_pt
         )
+        if use_safetensors and weight_name_filter is not None:
+            index_file = (
+                "consolidated.safetensors.index.json"
+                if self.load_config.load_format == LoadFormat.MISTRAL
+                else SAFE_WEIGHTS_INDEX_NAME
+            )
+            hf_weights_files = filter_safetensors_files_by_weight_names(
+                hf_weights_files,
+                hf_folder,
+                index_file,
+                lambda name: weight_name_filter(source.prefix + name),
+            )
         if self.load_config.load_format == LoadFormat.NPCACHE:
             # Currently np_cache only support *.bin checkpoints
             if use_safetensors:
@@ -351,6 +372,10 @@ class DefaultModelLoader(BaseModelLoader):
         model_config: ModelConfig,
         model: nn.Module,
     ) -> Generator[tuple[str, torch.Tensor], None, None]:
+        # Draft (NextN/MTP) models embedded in the target checkpoint expose
+        # ``checkpoint_weight_name_filter`` so only the shards holding their
+        # weights are read instead of the whole checkpoint.
+        weight_name_filter = getattr(model, "checkpoint_weight_name_filter", None)
 
         primary_weights = DefaultModelLoader.Source(
             model_config.model_path,
@@ -358,13 +383,13 @@ class DefaultModelLoader(BaseModelLoader):
             prefix="",
             fall_back_to_pt=getattr(model, "fall_back_to_pt_during_load", False),
         )
-        yield from self._get_weights_iterator(primary_weights)
+        yield from self._get_weights_iterator(primary_weights, weight_name_filter)
 
         secondary_weights = cast(
             Iterable[DefaultModelLoader.Source], getattr(model, "secondary_weights", ())
         )
         for source in secondary_weights:
-            yield from self._get_weights_iterator(source)
+            yield from self._get_weights_iterator(source, weight_name_filter)
 
     def download_model(self, model_config: ModelConfig) -> None:
         self._prepare_weights(

--- a/python/tokenspeed/runtime/model_loader/weight_utils.py
+++ b/python/tokenspeed/runtime/model_loader/weight_utils.py
@@ -270,6 +270,62 @@ def filter_duplicate_safetensors_files(
     return hf_weights_files
 
 
+def filter_safetensors_files_by_weight_names(
+    hf_weights_files: list[str],
+    hf_folder: str,
+    index_file: str,
+    weight_name_filter: Callable[[str], bool],
+) -> list[str]:
+    """Keep only the safetensors shards holding weights the consumer wants.
+
+    Used for draft (NextN/MTP) models whose weights are embedded in the
+    target checkpoint: their loaders consume a small name subset, so most
+    shards need not be read (or prefetched) at all.
+
+    Args:
+        hf_weights_files: Candidate shard paths.
+        hf_folder: Checkpoint directory containing ``index_file``.
+        index_file: Safetensors index file name mapping weight names to
+            shard file names.
+        weight_name_filter: Predicate on checkpoint weight names; a shard is
+            kept if it holds at least one accepted name.
+
+    Returns:
+        The filtered shard list, input order preserved. Shards absent from
+        the index are kept, and the full list is returned when the index is
+        missing or nothing matches, so a wrong predicate degrades to reading
+        extra shards instead of breaking the load.
+    """
+    index_file_name = os.path.join(hf_folder, index_file)
+    if not os.path.isfile(index_file_name):
+        return hf_weights_files
+
+    with open(index_file_name) as f:
+        weight_map = json.load(f)["weight_map"]
+    needed_files = set()
+    for weight_name, shard_name in weight_map.items():
+        if weight_name_filter(weight_name):
+            needed_files.add(os.path.join(hf_folder, shard_name))
+    indexed_files = {
+        os.path.join(hf_folder, shard_name) for shard_name in weight_map.values()
+    }
+    filtered = [
+        f for f in hf_weights_files if f in needed_files or f not in indexed_files
+    ]
+    if not filtered:
+        logger.warning(
+            f"Weight-name shard filter matched nothing in {index_file_name}; "
+            f"falling back to loading all {len(hf_weights_files)} shards."
+        )
+        return hf_weights_files
+    if len(filtered) < len(hf_weights_files):
+        logger.info(
+            f"Loading {len(filtered)} of {len(hf_weights_files)} checkpoint "
+            "shards; the others hold no weights needed by this model."
+        )
+    return filtered
+
+
 def filter_files_not_needed_for_inference(hf_weights_files: list[str]) -> list[str]:
     """
     Exclude files that are not needed for inference.

--- a/python/tokenspeed/runtime/models/deepseek_nextn.py
+++ b/python/tokenspeed/runtime/models/deepseek_nextn.py
@@ -306,6 +306,27 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
         # EAGLE3-only optimization (see deepseek_v3.py:2063, llama_eagle3.py).
         return None
 
+    def checkpoint_weight_name_filter(self, name: str) -> bool:
+        """Shard preselection for ``load_weights`` (see DefaultModelLoader).
+
+        Accepts a superset of the checkpoint names ``load_weights`` consumes:
+        the NextN layer(s) stored at/after ``num_hidden_layers``, or the
+        whole checkpoint when it is a standalone draft.
+        """
+        num_nextn_layers = getattr(self.config, "num_nextn_predict_layers", None)
+        if num_nextn_layers == self.config.num_hidden_layers:
+            # Standalone draft checkpoint: every shard holds draft weights.
+            return True
+        if not name.startswith("model.layers."):
+            return False
+        name_list = name.split(".")
+        if len(name_list) < 3:
+            return False
+        try:
+            return int(name_list[2]) >= self.config.num_hidden_layers
+        except ValueError:
+            return False
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)

--- a/python/tokenspeed/runtime/models/deepseek_v4_mtp.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_mtp.py
@@ -453,6 +453,14 @@ class DeepseekV4ForCausalLMNextN(nn.Module):
             ("compressor.fused_wkv_wgate", "compressor.wgate", 1),
         ]
 
+    def checkpoint_weight_name_filter(self, name: str) -> bool:
+        """Shard preselection for ``load_weights`` (see DefaultModelLoader).
+
+        Accepts exactly the checkpoint names ``load_weights`` consumes:
+        those ``_map_checkpoint_name`` resolves to a draft parameter.
+        """
+        return self._map_checkpoint_name(name) is not None
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         stacked_params_mapping = self.get_stacked_params_mapping()
         params_dict = dict(self.named_parameters())

--- a/python/tokenspeed/runtime/models/glm5_nextn.py
+++ b/python/tokenspeed/runtime/models/glm5_nextn.py
@@ -345,6 +345,14 @@ class GlmMoeDsaForCausalLMNextN(GlmMoeDsaForCausalLM):
             return None
         return f"model.layers.{layer_id}"
 
+    def checkpoint_weight_name_filter(self, name: str) -> bool:
+        """Shard preselection for ``load_weights`` (see DefaultModelLoader).
+
+        Accepts a superset of the checkpoint names ``load_weights`` consumes:
+        everything under the NextN layer prefix.
+        """
+        return self._nextn_layer_prefix(name) is not None
+
     def _map_checkpoint_name(self, raw_name: str) -> str | None:
         nextn_layer_prefix = self._nextn_layer_prefix(raw_name)
         if nextn_layer_prefix is None:

--- a/python/tokenspeed/runtime/models/inkling_nextn.py
+++ b/python/tokenspeed/runtime/models/inkling_nextn.py
@@ -331,6 +331,15 @@ class InklingForConditionalGenerationNextN(nn.Module):
     # local_layer_ids resolve each depth's ckpt/served head counts.
     _replicate_kv_heads = InklingForConditionalGeneration._replicate_kv_heads
 
+    def checkpoint_weight_name_filter(self, name: str) -> bool:
+        """Shard preselection for ``load_weights`` (see DefaultModelLoader).
+
+        Accepts a superset of the checkpoint names ``load_weights`` consumes:
+        the ``model.mtp.*`` tensors plus the base embedding norm.
+        """
+        name = name.removeprefix("model.")
+        return name.startswith("mtp.") or name == "llm.embed_norm.weight"
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         """Load the ``model.mtp.*`` tensors (all BF16).
 

--- a/python/tokenspeed/runtime/models/kimi_k3_nextn.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_nextn.py
@@ -355,6 +355,14 @@ class KimiK3NextNForCausalLM(nn.Module):
             input_ids, hidden_states, self.lm_head, logits_metadata
         )
 
+    def checkpoint_weight_name_filter(self, name: str) -> bool:
+        """Shard preselection for ``load_weights`` (see DefaultModelLoader).
+
+        Accepts a superset of the checkpoint names ``load_weights`` consumes:
+        everything under the NextN layer prefix.
+        """
+        return name.startswith(f"model.layers.{self.config.num_hidden_layers}.")
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> None:
         config = self.config
         nextn_prefix = f"model.layers.{config.num_hidden_layers}."
@@ -485,6 +493,13 @@ class KimiK3ForConditionalGenerationNextN(nn.Module):
 
     def forward(self, *args, **kwargs):
         return self.language_model.forward(*args, **kwargs)
+
+    def checkpoint_weight_name_filter(self, name: str) -> bool:
+        """Shard preselection for ``load_weights`` (see DefaultModelLoader)."""
+        lm_prefix = "language_model."
+        if not name.startswith(lm_prefix):
+            return False
+        return self.language_model.checkpoint_weight_name_filter(name[len(lm_prefix) :])
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> None:
         lm_prefix = "language_model."

--- a/python/tokenspeed/runtime/models/qwen3_5_nextn.py
+++ b/python/tokenspeed/runtime/models/qwen3_5_nextn.py
@@ -277,6 +277,15 @@ class Qwen3_5ForConditionalGenerationNextN(nn.Module):
             input_ids, hidden_states, self.lm_head, logits_metadata
         )
 
+    def checkpoint_weight_name_filter(self, name: str) -> bool:
+        """Shard preselection for ``load_weights`` (see DefaultModelLoader).
+
+        Accepts a superset of the checkpoint names ``load_weights`` consumes
+        (it only processes MTP-branch weights), so shards without any MTP
+        tensor are skipped entirely.
+        """
+        return "mtp" in name
+
     def load_weights(
         self, weights: Iterable[tuple[str, torch.Tensor]], is_mtp: bool = False
     ):

--- a/test/runtime/test_nextn_shard_filter.py
+++ b/test/runtime/test_nextn_shard_filter.py
@@ -1,0 +1,240 @@
+"""Tests for NextN/MTP draft shard preselection.
+
+Draft models embedded in the target checkpoint expose
+``checkpoint_weight_name_filter``; the loader uses it with the safetensors
+index to skip shards holding no draft weights (see DefaultModelLoader).
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+# CI Registration (parsed via AST, runtime no-op)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, suite="runtime-1gpu")
+
+import torch
+
+from tokenspeed.runtime.configs.load_config import LoadConfig
+from tokenspeed.runtime.model_loader.loader import DefaultModelLoader
+from tokenspeed.runtime.model_loader.weight_utils import (
+    filter_safetensors_files_by_weight_names,
+)
+
+
+class TestFilterSafetensorsFilesByWeightNames(unittest.TestCase):
+    def _write_index(self, tmpdir, weight_map):
+        index_path = os.path.join(tmpdir, "model.safetensors.index.json")
+        with open(index_path, "w") as f:
+            json.dump({"weight_map": weight_map}, f)
+        return index_path
+
+    def _touch(self, tmpdir, *names):
+        paths = []
+        for name in names:
+            path = os.path.join(tmpdir, name)
+            with open(path, "wb"):
+                pass
+            paths.append(path)
+        return paths
+
+    def test_keeps_only_matching_shards_in_order(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            files = self._touch(tmpdir, "a.safetensors", "b.safetensors")
+            self._write_index(
+                tmpdir,
+                {
+                    "model.layers.0.w": "a.safetensors",
+                    "mtp.fc.weight": "b.safetensors",
+                    "mtp.norm.weight": "b.safetensors",
+                },
+            )
+            kept = filter_safetensors_files_by_weight_names(
+                files, tmpdir, "model.safetensors.index.json", lambda n: "mtp" in n
+            )
+            self.assertEqual(kept, files[1:])
+
+    def test_keeps_shards_absent_from_index(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            files = self._touch(tmpdir, "a.safetensors", "extra.safetensors")
+            self._write_index(tmpdir, {"mtp.fc.weight": "a.safetensors"})
+            kept = filter_safetensors_files_by_weight_names(
+                files, tmpdir, "model.safetensors.index.json", lambda n: "mtp" in n
+            )
+            self.assertEqual(kept, files)
+
+    def test_missing_index_returns_input(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            files = self._touch(tmpdir, "a.safetensors")
+            kept = filter_safetensors_files_by_weight_names(
+                files, tmpdir, "model.safetensors.index.json", lambda n: False
+            )
+            self.assertEqual(kept, files)
+
+    def test_no_match_falls_back_to_all_shards(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            files = self._touch(tmpdir, "a.safetensors")
+            self._write_index(tmpdir, {"model.layers.0.w": "a.safetensors"})
+            kept = filter_safetensors_files_by_weight_names(
+                files, tmpdir, "model.safetensors.index.json", lambda n: "mtp" in n
+            )
+            self.assertEqual(kept, files)
+
+
+class TestLoaderSkipsFilteredShards(unittest.TestCase):
+    def test_get_all_weights_reads_only_draft_shards(self):
+        from safetensors.torch import save_file
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_file(
+                {"model.layers.0.w": torch.zeros(2)},
+                os.path.join(tmpdir, "model-00001-of-00002.safetensors"),
+            )
+            save_file(
+                {"model.mtp.fc.weight": torch.zeros(2)},
+                os.path.join(tmpdir, "model-00002-of-00002.safetensors"),
+            )
+            with open(os.path.join(tmpdir, "model.safetensors.index.json"), "w") as f:
+                json.dump(
+                    {
+                        "weight_map": {
+                            "model.layers.0.w": "model-00001-of-00002.safetensors",
+                            "model.mtp.fc.weight": "model-00002-of-00002.safetensors",
+                        }
+                    },
+                    f,
+                )
+
+            loader = DefaultModelLoader(LoadConfig())
+            model = SimpleNamespace(
+                checkpoint_weight_name_filter=lambda name: "mtp" in name,
+                fall_back_to_pt_during_load=False,
+                secondary_weights=(),
+            )
+            model_config = SimpleNamespace(model_path=tmpdir, revision=None)
+
+            names = [name for name, _ in loader._get_all_weights(model_config, model)]
+            self.assertEqual(names, ["model.mtp.fc.weight"])
+
+    def test_target_model_without_filter_reads_everything(self):
+        from safetensors.torch import save_file
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_file(
+                {"model.layers.0.w": torch.zeros(2)},
+                os.path.join(tmpdir, "model.safetensors"),
+            )
+            loader = DefaultModelLoader(LoadConfig())
+            model = SimpleNamespace(
+                fall_back_to_pt_during_load=False,
+                secondary_weights=(),
+            )
+            model_config = SimpleNamespace(model_path=tmpdir, revision=None)
+
+            names = [name for name, _ in loader._get_all_weights(model_config, model)]
+            self.assertEqual(names, ["model.layers.0.w"])
+
+
+class TestNextNModelFilters(unittest.TestCase):
+    """The predicates must accept every name each ``load_weights`` consumes."""
+
+    def test_qwen3_5_nextn(self):
+        from tokenspeed.runtime.models.qwen3_5_nextn import (
+            Qwen3_5ForConditionalGenerationNextN,
+        )
+
+        model = object.__new__(Qwen3_5ForConditionalGenerationNextN)
+        self.assertTrue(model.checkpoint_weight_name_filter("mtp.fc.weight"))
+        self.assertTrue(
+            model.checkpoint_weight_name_filter("model.mtp.self_attn.q_proj.weight")
+        )
+        self.assertFalse(
+            model.checkpoint_weight_name_filter("model.layers.0.mlp.gate.weight")
+        )
+
+    def test_deepseek_nextn(self):
+        from tokenspeed.runtime.models.deepseek_nextn import DeepseekV3ForCausalLMNextN
+
+        model = object.__new__(DeepseekV3ForCausalLMNextN)
+        model.config = SimpleNamespace(num_nextn_predict_layers=1, num_hidden_layers=61)
+        self.assertTrue(
+            model.checkpoint_weight_name_filter("model.layers.61.eh_proj.weight")
+        )
+        self.assertFalse(
+            model.checkpoint_weight_name_filter("model.layers.60.mlp.gate.weight")
+        )
+        self.assertFalse(
+            model.checkpoint_weight_name_filter("model.embed_tokens.weight")
+        )
+
+        # Standalone draft checkpoint keeps everything.
+        model.config = SimpleNamespace(num_nextn_predict_layers=1, num_hidden_layers=1)
+        self.assertTrue(
+            model.checkpoint_weight_name_filter("model.layers.0.eh_proj.weight")
+        )
+
+    def test_glm5_nextn(self):
+        from tokenspeed.runtime.models.glm5_nextn import GlmMoeDsaForCausalLMNextN
+
+        model = object.__new__(GlmMoeDsaForCausalLMNextN)
+        model.config = SimpleNamespace(num_nextn_predict_layers=1, num_hidden_layers=92)
+        self.assertTrue(
+            model.checkpoint_weight_name_filter("model.layers.92.eh_proj.weight")
+        )
+        self.assertFalse(
+            model.checkpoint_weight_name_filter("model.layers.10.mlp.gate.weight")
+        )
+        self.assertFalse(model.checkpoint_weight_name_filter("lm_head.weight"))
+
+    def test_kimi_k3_nextn(self):
+        from tokenspeed.runtime.models.kimi_k3_nextn import (
+            KimiK3ForConditionalGenerationNextN,
+            KimiK3NextNForCausalLM,
+        )
+
+        inner = object.__new__(KimiK3NextNForCausalLM)
+        inner.config = SimpleNamespace(num_hidden_layers=48)
+        self.assertTrue(
+            inner.checkpoint_weight_name_filter("model.layers.48.eh_proj.weight")
+        )
+        self.assertFalse(
+            inner.checkpoint_weight_name_filter("model.layers.47.mlp.gate.weight")
+        )
+
+        wrapper = object.__new__(KimiK3ForConditionalGenerationNextN)
+        # Bypass nn.Module.__setattr__: the wrapper is deliberately not
+        # initialized as a module here.
+        object.__setattr__(wrapper, "language_model", inner)
+        self.assertTrue(
+            wrapper.checkpoint_weight_name_filter(
+                "language_model.model.layers.48.eh_proj.weight"
+            )
+        )
+        self.assertFalse(
+            wrapper.checkpoint_weight_name_filter("model.layers.48.eh_proj.weight")
+        )
+
+    def test_inkling_nextn(self):
+        from tokenspeed.runtime.models.inkling_nextn import (
+            InklingForConditionalGenerationNextN,
+        )
+
+        model = object.__new__(InklingForConditionalGenerationNextN)
+        self.assertTrue(
+            model.checkpoint_weight_name_filter("model.mtp.layers.0.qkv.weight")
+        )
+        self.assertTrue(
+            model.checkpoint_weight_name_filter("model.llm.embed_norm.weight")
+        )
+        self.assertFalse(
+            model.checkpoint_weight_name_filter("model.layers.5.qkv.weight")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

## Summary
Add checkpoint_weight_name_filter to NextN/MTP draft models (DeepSeek V3/V4, GLM5, Inkling, Kimi K3, Qwen3.5) so DefaultModelLoader can use the safetensors index to preselect shards, skipping files that hold no draft weights instead of reading and prefetching every shard.

- loader: accept an optional weight_name_filter in _get_weights_iterator and wire it from the model's checkpoint_weight_name_filter
- weight_utils: add filter_safetensors_files_by_weight_names to filter shard files via the safetensors index
- also includes a black formatting fix in hybrid_linear_attn.py from pre-commit run --all-files
<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
