### PR TITLE
fix(runtime): reject ambiguous prompt sources

### DIFF
--- a/python/tokenspeed/runtime/engine/io_struct.py
+++ b/python/tokenspeed/runtime/engine/io_struct.py
@@ -179,15 +179,13 @@ class GenerateReqInput:
     bootstrap_room: list[int] | int | None = None
 
     def normalize_batch_and_arguments(self):
-        if (
-            self.text is None and self.input_ids is None and self.input_embeds is None
-        ) or (
-            self.text is not None
-            and self.input_ids is not None
-            and self.input_embeds is not None
-        ):
+        provided_sources = sum(
+            source is not None
+            for source in (self.text, self.input_ids, self.input_embeds)
+        )
+        if provided_sources != 1:
             raise ValueError(
-                "Either text, input_ids or input_embeds should be provided."
+                "Exactly one of text, input_ids, or input_embeds should be provided."
             )
 
         # Derive the batch size

--- a/test/runtime/test_io_struct.py
+++ b/test/runtime/test_io_struct.py
@@ -1,0 +1,18 @@
+import pytest
+
+from tokenspeed.runtime.engine.io_struct import GenerateReqInput
+
+
+@pytest.mark.parametrize(
+    "request_kwargs",
+    [
+        {"text": "prompt", "input_ids": [1]},
+        {"text": "prompt", "input_embeds": [[0.0]]},
+        {"input_ids": [1], "input_embeds": [[0.0]]},
+    ],
+)
+def test_multiple_prompt_sources_are_rejected(request_kwargs):
+    with pytest.raises(
+        ValueError, match="Exactly one of text, input_ids, or input_embeds"
+    ):
+        GenerateReqInput(**request_kwargs).normalize_batch_and_arguments()


### PR DESCRIPTION
## Summary

Reject requests that specify more than one prompt source rather than silently discarding one.

## Root cause

The request normalizer only rejected zero and three prompt sources. Any pair of text, input_ids, and input_embeds reached runtime with one value ignored.

## Testing

- Full repository pre-commit suite.
- Python syntax compilation.
- Direct validation of each pairwise conflicting prompt-source combination.
