### PR TITLE
feat: add Qwen2.5-MoE model support

### DIFF
--- a/python/tokenspeed/runtime/configs/__init__.py
+++ b/python/tokenspeed/runtime/configs/__init__.py
@@ -36,6 +36,7 @@ from tokenspeed.runtime.configs.kimi_k3_config import (
 from tokenspeed.runtime.configs.kimi_k25_config import KimiK25Config
 from tokenspeed.runtime.configs.minimax_m2_config import MiniMaxM2Config
 from tokenspeed.runtime.configs.minimax_m3_config import MiniMaxM3Config
+from tokenspeed.runtime.configs.qwen2_5_moe_config import Qwen2_5MoeConfig
 from tokenspeed.runtime.configs.qwen2_config import Qwen2Config
 from tokenspeed.runtime.configs.qwen3_5_config import Qwen3_5Config, Qwen3_5MoeConfig
 from tokenspeed.runtime.configs.qwen3_asr_config import (
@@ -49,6 +50,7 @@ from tokenspeed.runtime.configs.qwen3_moe_config import Qwen3MoeConfig
 __all__ = [
     "DeepseekV4Config",
     "Qwen2Config",
+    "Qwen2_5MoeConfig",
     "Qwen3Config",
     "Qwen3MoeConfig",
     "Qwen3_5Config",

--- a/python/tokenspeed/runtime/configs/qwen2_5_moe_config.py
+++ b/python/tokenspeed/runtime/configs/qwen2_5_moe_config.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Qwen2.5 MoE model configuration definitions."""
+
+from tokenspeed.runtime.configs.qwen2_config import Qwen2Config
+
+
+class Qwen2_5MoeConfig(Qwen2Config):
+    """Configuration for Qwen2.5 MoE causal LMs such as Qwen/Qwen2.5-MoE-14B-Instruct-AWSD."""
+
+    model_type = "qwen2_moe"
+
+    def __init__(
+        self,
+        decoder_sparse_step=1,
+        moe_intermediate_size=768,
+        shared_expert_intermediate_size=0,
+        num_experts_per_tok=8,
+        num_experts=60,
+        norm_topk_prob=True,
+        output_router_logits=False,
+        router_aux_loss_coef=0.001,
+        mlp_only_layers=None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.decoder_sparse_step = decoder_sparse_step
+        self.moe_intermediate_size = moe_intermediate_size
+        self.shared_expert_intermediate_size = shared_expert_intermediate_size
+        self.num_experts_per_tok = num_experts_per_tok
+        self.num_experts = num_experts
+        self.norm_topk_prob = norm_topk_prob
+        self.output_router_logits = output_router_logits
+        self.router_aux_loss_coef = router_aux_loss_coef
+        self.mlp_only_layers = [] if mlp_only_layers is None else mlp_only_layers
+
+
+__all__ = ["Qwen2_5MoeConfig"]

--- a/python/tokenspeed/runtime/models/qwen2_5_moe.py
+++ b/python/tokenspeed/runtime/models/qwen2_5_moe.py
@@ -244,18 +244,51 @@ class Qwen2_5MoeSparseMoeBlock(nn.Module):
         max_num_tokens_per_gpu: int,
         ctx: ForwardContext,
     ) -> torch.Tensor:
+        """DeepEP path: routing on local tokens, dispatch/combine handled by executor."""
         num_tokens, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
 
         router_logits, _ = self.gate(hidden_states)
 
+        shared_output = None
+        if self.shared_expert is not None:
+            shared_output = self.shared_expert(hidden_states)
+            if self.mapping.dense.has_tp:
+                from tokenspeed.runtime.distributed.comm_ops import all_reduce
+
+                shared_output = all_reduce(
+                    shared_output,
+                    self.mapping.dense.tp_group,
+                )
+
+        if hidden_states.shape[0] > 0:
+            topk_output = self.topk(hidden_states, router_logits)
+        else:
+            topk_output = self.topk.empty_topk_output(
+                hidden_states.device,
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+            )
+
         final_hidden_states = self.experts(
             hidden_states=hidden_states,
-            router_logits=router_logits,
+            topk_output=topk_output,
             num_global_tokens=num_global_tokens,
             max_num_tokens_per_gpu=max_num_tokens_per_gpu,
-            ctx=ctx,
         )
+
+        if shared_output is not None:
+            if self.shared_expert_gate is not None and hidden_states.shape[0] > 0:
+                from tokenspeed_kernel.ops.activation.triton import fused_gate_sigmoid_mul_add
+
+                fused_gate_sigmoid_mul_add(
+                    hidden_states,
+                    self.shared_expert_gate.weight.squeeze(0),
+                    shared_output,
+                    final_hidden_states,
+                )
+            else:
+                final_hidden_states = final_hidden_states + shared_output
 
         return final_hidden_states.view(num_tokens, hidden_dim)
 

--- a/python/tokenspeed/runtime/models/qwen2_5_moe.py
+++ b/python/tokenspeed/runtime/models/qwen2_5_moe.py
@@ -62,8 +62,8 @@ from tokenspeed.runtime.models.qwen3_5_moe import (
     Qwen3_5MoeMLP,
 )
 from tokenspeed.runtime.utils import add_prefix
-from tokenspeed.runtime.utils.env import global_server_args_dict
 from tokenspeed.runtime.utils.cuda_stream import StreamFork
+from tokenspeed.runtime.utils.env import global_server_args_dict
 
 
 def _is_moe_layer(layer_id: int, config) -> bool:
@@ -102,8 +102,17 @@ class Qwen2_5MoeSparseMoeBlock(nn.Module):
             mapping=mapping,
             layer_id=layer_index,
             is_moe=True,
-            prev_is_moe=_is_moe_layer(layer_index - 1, config) if layer_index > 0 else False,
+            prev_is_moe=(
+                _is_moe_layer(layer_index - 1, config) if layer_index > 0 else False
+            ),
         )
+
+        if mapping.attn.tp_size != mapping.moe.tp_ep_size:
+            raise ValueError(
+                "Qwen2.5-MoE uses all-reduce layout decoder layers and requires "
+                "attn.tp_size == moe.tp_ep_size, got attn.tp_size="
+                f"{mapping.attn.tp_size} and moe.tp_ep_size={mapping.moe.tp_ep_size}."
+            )
 
         if mapping.moe.tp_size > config.num_experts:
             raise ValueError(
@@ -220,7 +229,9 @@ class Qwen2_5MoeSparseMoeBlock(nn.Module):
 
         if shared_output is not None:
             if self.shared_expert_gate is not None and hidden_states.shape[0] > 0:
-                from tokenspeed_kernel.ops.activation.triton import fused_gate_sigmoid_mul_add
+                from tokenspeed_kernel.ops.activation.triton import (
+                    fused_gate_sigmoid_mul_add,
+                )
 
                 fused_gate_sigmoid_mul_add(
                     hidden_states,
@@ -279,7 +290,9 @@ class Qwen2_5MoeSparseMoeBlock(nn.Module):
 
         if shared_output is not None:
             if self.shared_expert_gate is not None and hidden_states.shape[0] > 0:
-                from tokenspeed_kernel.ops.activation.triton import fused_gate_sigmoid_mul_add
+                from tokenspeed_kernel.ops.activation.triton import (
+                    fused_gate_sigmoid_mul_add,
+                )
 
                 fused_gate_sigmoid_mul_add(
                     hidden_states,
@@ -340,7 +353,9 @@ class Qwen2MoeDecoderLayer(Qwen2DecoderLayer):
         if residual is None:
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
-        elif ctx.input_num_tokens > global_server_args_dict["comm_fusion_max_num_tokens"]:
+        elif (
+            ctx.input_num_tokens > global_server_args_dict["comm_fusion_max_num_tokens"]
+        ):
             hidden_states = all_reduce(hidden_states, self.mapping.dense.tp_group)
             hidden_states, residual = self.input_layernorm(hidden_states, residual)
         else:

--- a/python/tokenspeed/runtime/models/qwen2_5_moe.py
+++ b/python/tokenspeed/runtime/models/qwen2_5_moe.py
@@ -1,0 +1,546 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Inference-only Qwen2.5 MoE model compatible with HuggingFace weights."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import torch
+from torch import nn
+
+from tokenspeed.runtime.configs.qwen2_5_moe_config import Qwen2_5MoeConfig
+from tokenspeed.runtime.distributed.comm_manager import CommManager
+from tokenspeed.runtime.distributed.comm_ops import all_reduce
+from tokenspeed.runtime.distributed.mapping import Mapping
+from tokenspeed.runtime.execution.context import ForwardContext
+from tokenspeed.runtime.execution.cuda_graph_wrapper import get_is_capture_mode
+from tokenspeed.runtime.layers.linear import (
+    ReplicatedLinear,
+)
+from tokenspeed.runtime.layers.moe import (
+    ExpertCheckpointSchema,
+    MoELayer,
+    build_moe_checkpoint_loader,
+)
+from tokenspeed.runtime.layers.moe.topk import TopK
+from tokenspeed.runtime.layers.moe.utils import (
+    RoutingMethodType,
+    get_all2all_backend,
+    get_moe_backend,
+)
+from tokenspeed.runtime.layers.quantization.base_config import QuantizationConfig
+from tokenspeed.runtime.layers.utils import get_layer_id
+from tokenspeed.runtime.model_loader.weight_utils import (
+    default_weight_loader,
+    kv_cache_scales_loader,
+)
+from tokenspeed.runtime.models.qwen2 import (
+    Qwen2DecoderLayer,
+    Qwen2ForCausalLM,
+    Qwen2Model,
+)
+from tokenspeed.runtime.models.qwen3_5_moe import (
+    Qwen3_5MoeMLP,
+)
+from tokenspeed.runtime.utils import add_prefix
+from tokenspeed.runtime.utils.env import global_server_args_dict
+from tokenspeed.runtime.utils.cuda_stream import StreamFork
+
+
+def _is_moe_layer(layer_id: int, config) -> bool:
+    """Return whether the given decoder layer should use the MoE block."""
+    if layer_id < 0:
+        return False
+    mlp_only_layers = getattr(config, "mlp_only_layers", [])
+    if layer_id in mlp_only_layers:
+        return False
+    return config.num_experts > 0 and (layer_id + 1) % config.decoder_sparse_step == 0
+
+
+class Qwen2_5MoeSparseMoeBlock(nn.Module):
+    """MoE block for Qwen2.5-MoE."""
+
+    def __init__(
+        self,
+        config: Qwen2_5MoeConfig,
+        mapping: Mapping,
+        quant_config: QuantizationConfig | None = None,
+        layer_index: int = -1,
+        prefix: str = "",
+        alt_stream: torch.cuda.Stream | None = None,
+    ):
+        super().__init__()
+        self.mapping = mapping
+        self.layer_index = layer_index
+        self.stream_fork = StreamFork(alt_stream)
+
+        self.use_deepep = (
+            get_all2all_backend().is_deepep()
+            and get_moe_backend().is_flashinfer_cutedsl()
+        )
+
+        self.comm_manager = CommManager(
+            mapping=mapping,
+            layer_id=layer_index,
+            is_moe=True,
+            prev_is_moe=_is_moe_layer(layer_index - 1, config) if layer_index > 0 else False,
+        )
+
+        if mapping.moe.tp_size > config.num_experts:
+            raise ValueError(
+                f"Tensor parallel size {mapping.moe.tp_size} is greater than "
+                f"the number of experts {config.num_experts}."
+            )
+
+        self.gate = ReplicatedLinear(
+            config.hidden_size,
+            config.num_experts,
+            bias=False,
+            quant_config=None,
+            prefix=add_prefix("gate", prefix),
+        )
+
+        self.experts = MoELayer(
+            top_k=config.num_experts_per_tok,
+            num_experts=config.num_experts
+            + global_server_args_dict["ep_num_redundant_experts"],
+            hidden_size=config.hidden_size,
+            intermediate_size=config.moe_intermediate_size,
+            quant_config=quant_config,
+            layer_index=layer_index,
+            prefix=prefix,
+            tp_rank=mapping.moe.tp_rank,
+            tp_size=mapping.moe.tp_size,
+            ep_rank=mapping.moe.ep_rank,
+            ep_size=mapping.moe.ep_size,
+            routing_config={
+                "routing_method_type": RoutingMethodType.RenormalizeNaive,
+                "normalize_topk_weights": config.norm_topk_prob,
+            },
+        )
+
+        self.topk = TopK(
+            top_k=config.num_experts_per_tok,
+            renormalize=config.norm_topk_prob,
+            use_grouped_topk=False,
+            output_format=self.experts.topk_output_format,
+        )
+
+        if getattr(config, "shared_expert_intermediate_size", 0) > 0:
+            self.shared_expert = Qwen3_5MoeMLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.shared_expert_intermediate_size,
+                hidden_act=config.hidden_act,
+                mapping=self.mapping,
+                quant_config=quant_config,
+                reduce_results=False,
+                prefix=add_prefix("shared_expert", prefix),
+            )
+            self.shared_expert_gate = torch.nn.Linear(config.hidden_size, 1, bias=False)
+        else:
+            self.shared_expert = None
+            self.shared_expert_gate = None
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        num_global_tokens: int,
+        max_num_tokens_per_gpu: int,
+        ctx: ForwardContext,
+    ) -> torch.Tensor:
+        if self.use_deepep:
+            return self._forward_deepep(
+                hidden_states, num_global_tokens, max_num_tokens_per_gpu, ctx
+            )
+        return self._forward_tp(
+            hidden_states, num_global_tokens, max_num_tokens_per_gpu, ctx
+        )
+
+    def _forward_tp(
+        self,
+        hidden_states: torch.Tensor,
+        num_global_tokens: int,
+        max_num_tokens_per_gpu: int,
+        ctx: ForwardContext,
+    ) -> torch.Tensor:
+        num_tokens, hidden_dim = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_dim)
+
+        router_logits, _ = self.gate(hidden_states)
+
+        hidden_states = self.comm_manager.pre_mlp_comm(hidden_states, ctx)
+        router_logits = self.comm_manager.pre_mlp_comm(router_logits, ctx)
+
+        shared_output = None
+        with self.stream_fork.scope(
+            enable=(
+                self.shared_expert is not None
+                and hidden_states.shape[0] > 0
+                and get_is_capture_mode()
+            )
+        ) as fork:
+            with fork.branch():
+                if self.shared_expert is not None:
+                    shared_output = self.shared_expert(hidden_states)
+
+            if hidden_states.shape[0] > 0:
+                topk_output = self.topk(hidden_states, router_logits)
+            else:
+                topk_output = self.topk.empty_topk_output(
+                    hidden_states.device,
+                    hidden_states=hidden_states,
+                    router_logits=router_logits,
+                )
+
+            final_hidden_states = self.experts(
+                hidden_states=hidden_states,
+                topk_output=topk_output,
+                num_global_tokens=num_global_tokens,
+                max_num_tokens_per_gpu=max_num_tokens_per_gpu,
+            )
+
+        if shared_output is not None:
+            if self.shared_expert_gate is not None and hidden_states.shape[0] > 0:
+                from tokenspeed_kernel.ops.activation.triton import fused_gate_sigmoid_mul_add
+
+                fused_gate_sigmoid_mul_add(
+                    hidden_states,
+                    self.shared_expert_gate.weight.squeeze(0),
+                    shared_output,
+                    final_hidden_states,
+                )
+            else:
+                final_hidden_states = final_hidden_states + shared_output
+
+        final_hidden_states, _ = self.comm_manager.post_mlp_fused(
+            final_hidden_states, None, ctx
+        )
+
+        return final_hidden_states.view(num_tokens, hidden_dim)
+
+    def _forward_deepep(
+        self,
+        hidden_states: torch.Tensor,
+        num_global_tokens: int,
+        max_num_tokens_per_gpu: int,
+        ctx: ForwardContext,
+    ) -> torch.Tensor:
+        num_tokens, hidden_dim = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_dim)
+
+        router_logits, _ = self.gate(hidden_states)
+
+        final_hidden_states = self.experts(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+            num_global_tokens=num_global_tokens,
+            max_num_tokens_per_gpu=max_num_tokens_per_gpu,
+            ctx=ctx,
+        )
+
+        return final_hidden_states.view(num_tokens, hidden_dim)
+
+    def get_moe_routed_weights(self):
+        return [
+            x.data
+            for name, x in self.experts.named_parameters()
+            if name not in ["correction_bias"] and "shared_experts" not in name
+        ]
+
+
+class Qwen2MoeDecoderLayer(Qwen2DecoderLayer):
+    """Qwen2.5-MoE decoder layer with conditional MoE or dense MLP."""
+
+    def __init__(
+        self,
+        config: Qwen2_5MoeConfig,
+        mapping: Mapping,
+        layer_id: int = 0,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(
+            config=config,
+            mapping=mapping,
+            layer_id=layer_id,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+
+        if _is_moe_layer(layer_id, config):
+            self.mlp = Qwen2_5MoeSparseMoeBlock(
+                config=config,
+                mapping=mapping,
+                quant_config=quant_config,
+                layer_index=layer_id,
+                prefix=add_prefix("mlp", prefix),
+            )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        ctx: ForwardContext,
+        out_cache_loc: torch.Tensor,
+        residual: torch.Tensor | None,
+        cos_sin: tuple[torch.Tensor, torch.Tensor] | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        elif ctx.input_num_tokens > global_server_args_dict["comm_fusion_max_num_tokens"]:
+            hidden_states = all_reduce(hidden_states, self.mapping.dense.tp_group)
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        else:
+            hidden_states, residual, *_ = (
+                self.input_layernorm.forward_with_allreduce_fusion(
+                    self.mapping.dense.tp_rank,
+                    self.mapping.dense.tp_group,
+                    hidden_states,
+                    residual,
+                )
+            )
+
+        hidden_states = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+            ctx=ctx,
+            out_cache_loc=out_cache_loc,
+            cos_sin=cos_sin,
+        )
+
+        if ctx.input_num_tokens > global_server_args_dict["comm_fusion_max_num_tokens"]:
+            hidden_states = all_reduce(hidden_states, self.mapping.attn.tp_group)
+            hidden_states, residual = self.post_attention_layernorm(
+                hidden_states, residual
+            )
+        else:
+            hidden_states, residual, *_ = (
+                self.post_attention_layernorm.forward_with_allreduce_fusion(
+                    self.mapping.attn.tp_rank,
+                    self.mapping.attn.tp_group,
+                    hidden_states,
+                    residual,
+                )
+            )
+
+        if isinstance(self.mlp, Qwen2_5MoeSparseMoeBlock):
+            num_global_tokens, max_num_tokens_per_gpu = (
+                self.mlp.comm_manager.get_num_tokens(ctx)
+            )
+            hidden_states = self.mlp(
+                hidden_states,
+                num_global_tokens,
+                max_num_tokens_per_gpu,
+                ctx,
+            )
+        else:
+            hidden_states = self.mlp(hidden_states)
+
+        return hidden_states, residual
+
+
+class Qwen2MoeModel(Qwen2Model):
+    """Qwen2.5-MoE model using MoE decoder layers."""
+
+    def __init__(
+        self,
+        config: Qwen2_5MoeConfig,
+        mapping: Mapping,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(
+            config=config,
+            mapping=mapping,
+            quant_config=quant_config,
+            prefix=prefix,
+            decoder_layer_type=Qwen2MoeDecoderLayer,
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        ctx: ForwardContext,
+        out_cache_loc: torch.Tensor,
+        input_embeds: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, None]:
+        if input_embeds is None:
+            hidden_states = self.embed_tokens(input_ids)
+        else:
+            hidden_states = input_embeds
+        residual = None
+
+        for layer in self.layers:
+            hidden_states, residual = layer(
+                positions,
+                hidden_states,
+                ctx,
+                out_cache_loc,
+                residual,
+                cos_sin=None,
+            )
+
+        if ctx.input_num_tokens > global_server_args_dict["comm_fusion_max_num_tokens"]:
+            hidden_states = all_reduce(hidden_states, self.mapping.dense.tp_group)
+            hidden_states, _ = self.norm(hidden_states, residual)
+        else:
+            hidden_states, *_ = self.norm.forward_with_allreduce_fusion(
+                self.mapping.dense.tp_rank,
+                self.mapping.dense.tp_group,
+                hidden_states,
+                residual,
+            )
+        return hidden_states, None
+
+    def load_kv_cache_scales(self, quantization_param_path: str) -> None:
+        tp_size = self.mapping.attn.tp_size
+        tp_rank = self.mapping.attn.tp_rank
+        for layer_idx, scaling_factor in kv_cache_scales_loader(
+            quantization_param_path,
+            tp_rank,
+            tp_size,
+            self.config.num_hidden_layers,
+            self.config.__class__.model_type,
+        ):
+            if not isinstance(self.layers[layer_idx], nn.Identity):
+                layer_self_attn = self.layers[layer_idx].self_attn
+            if hasattr(layer_self_attn.attn, "k_scale"):
+                layer_self_attn.attn.k_scale = scaling_factor
+                layer_self_attn.attn.v_scale = scaling_factor
+            else:
+                raise RuntimeError(
+                    "Self attention has no KV cache scaling factor attribute!"
+                )
+
+
+class Qwen2MoeForCausalLM(Qwen2ForCausalLM):
+    """Qwen2.5-MoE causal language model head."""
+
+    model_cls = Qwen2MoeModel
+
+    default_bitsandbytes_target_modules = [
+        ".gate_proj.",
+        ".down_proj.",
+        ".up_proj.",
+        ".q_proj.",
+        ".k_proj.",
+        ".v_proj.",
+        ".o_proj.",
+    ]
+    bitsandbytes_stacked_params_mapping = {
+        "q_proj": ("qkv_proj", 0),
+        "k_proj": ("qkv_proj", 1),
+        "v_proj": ("qkv_proj", 2),
+        "gate_proj": ("gate_up_proj", 0),
+        "up_proj": ("gate_up_proj", 1),
+    }
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        stacked_params_mapping = [
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        ignore_suffixes = (
+            ".bias",
+            "_bias",
+            ".k_scale",
+            "_k_scale",
+            ".v_scale",
+            "_v_scale",
+            ".weight_scale",
+            "_weight_scale",
+            ".input_scale",
+            "_input_scale",
+        )
+
+        params_dict = dict(self.named_parameters(remove_duplicate=False))
+        moe_loader = build_moe_checkpoint_loader(
+            params_dict=params_dict,
+            expert_schema=ExpertCheckpointSchema(
+                gate_proj_name="gate_proj",
+                down_proj_name="down_proj",
+                up_proj_name="up_proj",
+            ),
+            fused_schema=ExpertCheckpointSchema(
+                gate_up_fused_name="gate_up_proj",
+                down_proj_name="down_proj",
+            ),
+            num_experts=self.config.num_experts,
+            ep_rank=self.mapping.moe.ep_rank,
+            ep_size=self.mapping.moe.ep_size,
+        )
+
+        for name, loaded_weight in weights:
+            if "Embedding" in self.config.name_or_path:
+                name = add_prefix(name, "model")
+            layer_id = get_layer_id(name)
+            if (
+                layer_id is not None
+                and hasattr(self.model, "start_layer")
+                and (
+                    layer_id < self.model.start_layer
+                    or layer_id >= self.model.end_layer
+                )
+            ):
+                continue
+            if "rotary_emb.inv_freq" in name or "projector" in name:
+                continue
+            if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
+                continue
+            if self.config.tie_word_embeddings and "lm_head.weight" in name:
+                continue
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                if "mlp.experts" in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                if name.endswith(ignore_suffixes) and name not in params_dict:
+                    continue
+                if name not in params_dict:
+                    continue
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                if name.endswith((".bias", "_bias")) and name not in params_dict:
+                    continue
+                if moe_loader.matches(name):
+                    moe_loader.load(name, loaded_weight)
+                    continue
+                if name.endswith(ignore_suffixes) and name not in params_dict:
+                    continue
+                if name not in params_dict:
+                    continue
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+
+
+EntryClass = Qwen2MoeForCausalLM

--- a/python/tokenspeed/runtime/utils/hf_transformers_utils.py
+++ b/python/tokenspeed/runtime/utils/hf_transformers_utils.py
@@ -51,6 +51,7 @@ from tokenspeed.runtime.configs import (
     KimiK25Config,
     MiniMaxM2Config,
     MiniMaxM3Config,
+    Qwen2_5MoeConfig,
     Qwen2Config,
     Qwen3_5Config,
     Qwen3_5MoeConfig,
@@ -62,6 +63,7 @@ from tokenspeed.runtime.utils import lru_cache_frozenset
 
 _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = {
     Qwen2Config.model_type: Qwen2Config,
+    Qwen2_5MoeConfig.model_type: Qwen2_5MoeConfig,
     Qwen3Config.model_type: Qwen3Config,
     Qwen3MoeConfig.model_type: Qwen3MoeConfig,
     Qwen3ASRConfig.model_type: Qwen3ASRConfig,

--- a/python/tokenspeed/runtime/utils/nvtx.py
+++ b/python/tokenspeed/runtime/utils/nvtx.py
@@ -42,8 +42,12 @@ from tokenspeed_kernel.platform import current_platform
 from tokenspeed.runtime.utils.env import envs
 
 if current_platform().is_nvidia:
-    import nvtx
-    from nvtx.colors import _NVTX_COLORS
+    try:
+        import nvtx
+        from nvtx.colors import _NVTX_COLORS
+    except ImportError:
+        nvtx = None
+        _NVTX_COLORS = ()
 else:
     nvtx = None
     _NVTX_COLORS = ()

--- a/test/runtime/models/test_moe_routing_config.py
+++ b/test/runtime/models/test_moe_routing_config.py
@@ -61,6 +61,7 @@ def test_config_driven_moe_models_propagate_topk_normalization_flag() -> None:
         "python/tokenspeed/runtime/models/deepseek_v3.py",
         "python/tokenspeed/runtime/models/deepseek_v4.py",
         "python/tokenspeed/runtime/models/longcat_flash.py",
+        "python/tokenspeed/runtime/models/qwen2_5_moe.py",
         "python/tokenspeed/runtime/models/qwen3_5_moe.py",
     ):
         assert _normalize_expr(relpath) == "config.norm_topk_prob"

--- a/test/runtime/models/test_qwen2_5_moe_models.py
+++ b/test/runtime/models/test_qwen2_5_moe_models.py
@@ -1,0 +1,248 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import json
+import unittest
+from pathlib import Path
+import tempfile
+
+import torch
+
+from tokenspeed.runtime.configs.qwen2_5_moe_config import Qwen2_5MoeConfig
+from tokenspeed.runtime.distributed.mapping import Mapping
+from tokenspeed.runtime.utils.env import global_server_args_dict
+from tokenspeed.runtime.utils.hf_transformers_utils import _CONFIG_REGISTRY, get_config
+
+
+def _tiny_qwen2_5_moe_config() -> Qwen2_5MoeConfig:
+    return Qwen2_5MoeConfig(
+        architectures=["Qwen2MoeForCausalLM"],
+        vocab_size=64,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=1,
+        head_dim=8,
+        max_position_embeddings=128,
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=8,
+        decoder_sparse_step=1,
+    )
+
+
+def _single_rank_mapping() -> Mapping:
+    mapping = Mapping(rank=0, world_size=1)
+    global_server_args_dict["mapping"] = mapping
+    return mapping
+
+
+class TestQwen2_5MoeConfig(unittest.TestCase):
+    def test_config_registry(self):
+        self.assertEqual(Qwen2_5MoeConfig.model_type, "qwen2_moe")
+        self.assertIs(_CONFIG_REGISTRY["qwen2_moe"], Qwen2_5MoeConfig)
+
+    def test_get_config_loads_qwen2_5_moe_shape(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.json"
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "architectures": ["Qwen2MoeForCausalLM"],
+                        "hidden_act": "silu",
+                        "hidden_size": 2048,
+                        "intermediate_size": 6144,
+                        "max_position_embeddings": 40960,
+                        "model_type": "qwen2_moe",
+                        "moe_intermediate_size": 768,
+                        "norm_topk_prob": True,
+                        "num_attention_heads": 32,
+                        "num_experts": 64,
+                        "num_experts_per_tok": 8,
+                        "num_hidden_layers": 24,
+                        "num_key_value_heads": 8,
+                        "rope_theta": 1000000.0,
+                        "tie_word_embeddings": False,
+                        "vocab_size": 152064,
+                    }
+                )
+            )
+
+            config = get_config(tmpdir, trust_remote_code=False)
+
+        self.assertIsInstance(config, Qwen2_5MoeConfig)
+        self.assertEqual(config.architectures, ["Qwen2MoeForCausalLM"])
+        self.assertEqual(config.num_experts, 64)
+        self.assertEqual(config.num_experts_per_tok, 8)
+        self.assertEqual(config.moe_intermediate_size, 768)
+
+    def test_model_registry_resolves_qwen2_5_moe(self):
+        from tokenspeed.runtime.models.qwen2_5_moe import Qwen2MoeForCausalLM
+        from tokenspeed.runtime.models.registry import ModelRegistry
+
+        cls, arch = ModelRegistry.resolve_model_cls(["Qwen2MoeForCausalLM"])
+        self.assertIs(cls, Qwen2MoeForCausalLM)
+        self.assertEqual(arch, "Qwen2MoeForCausalLM")
+
+    def test_constructs_sparse_moe_layers(self):
+        from tokenspeed.runtime.models.qwen2_5_moe import (
+            Qwen2MoeForCausalLM,
+            Qwen2_5MoeSparseMoeBlock,
+        )
+
+        model = Qwen2MoeForCausalLM(
+            _tiny_qwen2_5_moe_config(),
+            mapping=_single_rank_mapping(),
+        )
+
+        self.assertIsInstance(model.model.layers[0].mlp, Qwen2_5MoeSparseMoeBlock)
+        self.assertIsInstance(model.model.layers[1].mlp, Qwen2_5MoeSparseMoeBlock)
+
+    def test_moe_layer_detection(self):
+        from tokenspeed.runtime.models.qwen2_5_moe import _is_moe_layer
+
+        config = _tiny_qwen2_5_moe_config()
+        self.assertTrue(_is_moe_layer(0, config))
+        self.assertTrue(_is_moe_layer(1, config))
+
+        config2 = Qwen2_5MoeConfig(
+            architectures=["Qwen2MoeForCausalLM"],
+            vocab_size=64,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=4,
+            num_attention_heads=4,
+            num_key_value_heads=1,
+            head_dim=8,
+            num_experts=4,
+            num_experts_per_tok=2,
+            moe_intermediate_size=8,
+            decoder_sparse_step=2,
+        )
+        self.assertFalse(_is_moe_layer(0, config2))
+        self.assertTrue(_is_moe_layer(1, config2))
+        self.assertFalse(_is_moe_layer(2, config2))
+        self.assertTrue(_is_moe_layer(3, config2))
+
+    def test_moe_layer_detection_with_mlp_only_layers(self):
+        from tokenspeed.runtime.models.qwen2_5_moe import _is_moe_layer
+
+        config = Qwen2_5MoeConfig(
+            architectures=["Qwen2MoeForCausalLM"],
+            vocab_size=64,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=4,
+            num_attention_heads=4,
+            num_key_value_heads=1,
+            head_dim=8,
+            num_experts=4,
+            num_experts_per_tok=2,
+            moe_intermediate_size=8,
+            decoder_sparse_step=2,
+            mlp_only_layers=[0],
+        )
+        self.assertFalse(_is_moe_layer(0, config))
+        self.assertTrue(_is_moe_layer(1, config))
+        self.assertFalse(_is_moe_layer(2, config))
+        self.assertTrue(_is_moe_layer(3, config))
+
+    def test_loads_unfused_expert_weights(self):
+        from tokenspeed.runtime.models.qwen2_5_moe import Qwen2MoeForCausalLM
+
+        model = Qwen2MoeForCausalLM(
+            _tiny_qwen2_5_moe_config(),
+            mapping=_single_rank_mapping(),
+        )
+        weights = []
+        for expert_id in range(4):
+            weights.extend(
+                [
+                    (
+                        f"model.layers.0.mlp.experts.{expert_id}.gate_proj.weight",
+                        torch.full((8, 16), 1.0 + expert_id),
+                    ),
+                    (
+                        f"model.layers.0.mlp.experts.{expert_id}.up_proj.weight",
+                        torch.full((8, 16), 11.0 + expert_id),
+                    ),
+                    (
+                        f"model.layers.0.mlp.experts.{expert_id}.down_proj.weight",
+                        torch.full((16, 8), 21.0 + expert_id),
+                    ),
+                ]
+            )
+
+        model.load_weights(weights)
+
+        params = dict(model.named_parameters())
+        w13 = params["model.layers.0.mlp.experts.w13_weight"]
+        w2 = params["model.layers.0.mlp.experts.w2_weight"]
+        self.assertEqual(w13[0, :8].mean().item(), 1.0)
+        self.assertEqual(w13[0, 8:].mean().item(), 11.0)
+        self.assertEqual(w2[0].mean().item(), 21.0)
+
+    def test_skips_nonlocal_expert_weights_under_expert_parallelism(self):
+        from tokenspeed.runtime.models.qwen2_5_moe import Qwen2MoeForCausalLM
+
+        ep_mapping = Mapping(rank=0, world_size=4, moe_ep_size=4)
+        global_server_args_dict["mapping"] = ep_mapping
+        model = Qwen2MoeForCausalLM(
+            _tiny_qwen2_5_moe_config(),
+            mapping=ep_mapping,
+        )
+        model.load_weights(
+            [
+                (
+                    "model.layers.0.mlp.experts.0.down_proj.weight",
+                    torch.full((16, 8), 21.0),
+                ),
+                (
+                    "model.layers.0.mlp.experts.3.down_proj.weight",
+                    torch.full((16, 8), 24.0),
+                ),
+            ]
+        )
+
+        params = dict(model.named_parameters())
+        w2 = params["model.layers.0.mlp.experts.w2_weight"]
+        self.assertEqual(w2.shape[0], 1)
+        self.assertEqual(w2[0].mean().item(), 21.0)
+
+    def test_model_has_correct_num_parameters(self):
+        from tokenspeed.runtime.models.qwen2_5_moe import Qwen2MoeForCausalLM
+
+        model = Qwen2MoeForCausalLM(
+            _tiny_qwen2_5_moe_config(),
+            mapping=_single_rank_mapping(),
+        )
+        total_params = sum(p.numel() for p in model.parameters())
+        self.assertGreater(total_params, 0)
+
+    def test_config_defaults(self):
+        config = Qwen2_5MoeConfig()
+        self.assertEqual(config.num_experts, 60)
+        self.assertEqual(config.num_experts_per_tok, 8)
+        self.assertEqual(config.decoder_sparse_step, 1)
+        self.assertEqual(config.moe_intermediate_size, 768)
+        self.assertEqual(config.shared_expert_intermediate_size, 0)
+        self.assertTrue(config.norm_topk_prob)
+        self.assertEqual(config.mlp_only_layers, [])

--- a/test/runtime/models/test_qwen2_5_moe_models.py
+++ b/test/runtime/models/test_qwen2_5_moe_models.py
@@ -19,9 +19,9 @@
 # SOFTWARE.
 
 import json
+import tempfile
 import unittest
 from pathlib import Path
-import tempfile
 
 import torch
 
@@ -104,8 +104,8 @@ class TestQwen2_5MoeConfig(unittest.TestCase):
 
     def test_constructs_sparse_moe_layers(self):
         from tokenspeed.runtime.models.qwen2_5_moe import (
-            Qwen2MoeForCausalLM,
             Qwen2_5MoeSparseMoeBlock,
+            Qwen2MoeForCausalLM,
         )
 
         model = Qwen2MoeForCausalLM(
@@ -246,3 +246,16 @@ class TestQwen2_5MoeConfig(unittest.TestCase):
         self.assertEqual(config.shared_expert_intermediate_size, 0)
         self.assertTrue(config.norm_topk_prob)
         self.assertEqual(config.mlp_only_layers, [])
+
+    def test_rejects_mismatched_attn_tp_and_moe_tp_ep_size(self):
+        from tokenspeed.runtime.models.qwen2_5_moe import Qwen2_5MoeSparseMoeBlock
+
+        mismatched_mapping = Mapping(
+            rank=0, world_size=4, attn_tp_size=2, moe_ep_size=4
+        )
+        with self.assertRaises(ValueError) as cm:
+            Qwen2_5MoeSparseMoeBlock(
+                _tiny_qwen2_5_moe_config(),
+                mapping=mismatched_mapping,
+            )
+        self.assertIn("attn.tp_size == moe.tp_ep_size", str(cm.exception))

--- a/tokenspeed-kernel/python/tokenspeed_kernel/_triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/_triton.py
@@ -30,7 +30,12 @@ import sys
 
 import tokenspeed_triton as triton
 import tokenspeed_triton.experimental.gluon.language as gl
-import tokenspeed_triton.profiler as proton
+
+try:
+    import tokenspeed_triton.profiler as proton
+except ImportError:
+    import triton.profiler as proton
+
 from tokenspeed_triton import language as tl
 from tokenspeed_triton.experimental import gluon
 from tokenspeed_triton.language.core import _aggregate as aggregate

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flash_attn/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flash_attn/__init__.py
@@ -49,10 +49,13 @@ platform = current_platform()
 
 
 if platform.is_blackwell_plus:
-    from flash_attn.cute import (
-        flash_attn_func,
-        flash_attn_varlen_func,
-    )
+    try:
+        from flash_attn.cute import (
+            flash_attn_func,
+            flash_attn_varlen_func,
+        )
+    except ImportError:
+        pass
 
 if platform.is_nvidia and platform.is_blackwell:
     # FA4 on Blackwell supports prefill head_dim in [8, 256] divisible by 8,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/fp8.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/fp8.py
@@ -26,18 +26,21 @@ from tokenspeed_kernel.platform import CapabilityRequirement, current_platform
 from tokenspeed_kernel.registry import Priority, register_kernel
 from tokenspeed_kernel.signature import format_signatures
 
-with redirect_triton_to_tokenspeed_triton():
-    import triton_kernels  # noqa: F401
-    import triton_kernels.matmul  # noqa: F401
-    import triton_kernels.matmul_details  # noqa: F401
-    import triton_kernels.matmul_details.opt_flags  # noqa: F401
-    import triton_kernels.numerics  # noqa: F401
-    import triton_kernels.numerics_details.mxfp  # noqa: F401
-    import triton_kernels.swiglu  # noqa: F401
-    import triton_kernels.tensor  # noqa: F401
-    import triton_kernels.tensor_details  # noqa: F401
-    import triton_kernels.tensor_details.layout  # noqa: F401
-    import triton_kernels.topk  # noqa: F401
+try:
+    with redirect_triton_to_tokenspeed_triton():
+        import triton_kernels  # noqa: F401
+        import triton_kernels.matmul  # noqa: F401
+        import triton_kernels.matmul_details  # noqa: F401
+        import triton_kernels.matmul_details.opt_flags  # noqa: F401
+        import triton_kernels.numerics  # noqa: F401
+        import triton_kernels.numerics_details.mxfp  # noqa: F401
+        import triton_kernels.swiglu  # noqa: F401
+        import triton_kernels.tensor  # noqa: F401
+        import triton_kernels.tensor_details  # noqa: F401
+        import triton_kernels.tensor_details.layout  # noqa: F401
+        import triton_kernels.topk  # noqa: F401
+except ImportError:
+    pass
 
 from tokenspeed_kernel.ops.moe.triton.mxfp4 import (
     _local_topk_for_ep,
@@ -45,16 +48,30 @@ from tokenspeed_kernel.ops.moe.triton.mxfp4 import (
     _routing_from_topk,
     _silu_gate_up,
 )
-from triton_kernels.matmul import (
-    FlexCtx,
-    FnSpecs,
-    FusedActivation,
-    PrecisionConfig,
-    matmul,
-)
-from triton_kernels.numerics import InFlexData
-from triton_kernels.numerics_details.mxfp import downcast_to_mxfp
-from triton_kernels.swiglu import swiglu_fn
+
+try:
+    from triton_kernels.matmul import (
+        FlexCtx,
+        FnSpecs,
+        FusedActivation,
+        PrecisionConfig,
+        matmul,
+    )
+    from triton_kernels.numerics import InFlexData
+    from triton_kernels.numerics_details.mxfp import downcast_to_mxfp
+    from triton_kernels.swiglu import swiglu_fn
+    from triton_kernels.tensor import (
+        Bitwidth,
+        BlockShape,
+        DType,
+        FlexData,
+        Layout,
+        ScaleFormat,
+        ScaleShape,
+        Tensor,
+    )
+except ImportError:
+    pass
 
 
 def _scale_attr(w: torch.nn.Module, base: str) -> torch.Tensor:

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/mxfp4.py
@@ -36,38 +36,44 @@ from tokenspeed_kernel.platform import CapabilityRequirement, current_platform
 from tokenspeed_kernel.registry import Priority, register_kernel
 from tokenspeed_kernel.signature import format_signatures
 
-with redirect_triton_to_tokenspeed_triton():
-    import triton_kernels  # noqa: F401
-    import triton_kernels.matmul  # noqa: F401
-    import triton_kernels.matmul_details  # noqa: F401
-    import triton_kernels.matmul_details.opt_flags  # noqa: F401
-    import triton_kernels.numerics  # noqa: F401
-    import triton_kernels.swiglu  # noqa: F401
-    import triton_kernels.tensor  # noqa: F401
-    import triton_kernels.tensor_details  # noqa: F401
-    import triton_kernels.tensor_details.layout  # noqa: F401
-    import triton_kernels.topk  # noqa: F401
+try:
+    with redirect_triton_to_tokenspeed_triton():
+        import triton_kernels  # noqa: F401
+        import triton_kernels.matmul  # noqa: F401
+        import triton_kernels.matmul_details  # noqa: F401
+        import triton_kernels.matmul_details.opt_flags  # noqa: F401
+        import triton_kernels.numerics  # noqa: F401
+        import triton_kernels.swiglu  # noqa: F401
+        import triton_kernels.tensor  # noqa: F401
+        import triton_kernels.tensor_details  # noqa: F401
+        import triton_kernels.tensor_details.layout  # noqa: F401
+        import triton_kernels.topk  # noqa: F401
+except ImportError:
+    pass
 
-import triton_kernels.matmul_details.opt_flags as opt_flags
-from triton_kernels.matmul import (
-    FlexCtx,
-    FnSpecs,
-    FusedActivation,
-    PrecisionConfig,
-    matmul,
-)
-from triton_kernels.matmul_details.opt_flags import scoped_opt_flags_constraints
-from triton_kernels.numerics import InFlexData
-from triton_kernels.swiglu import swiglu_fn
-from triton_kernels.tensor import (
-    FP4,
-    RaggedTensorMetadata,
-    convert_layout,
-    make_ragged_tensor_metadata,
-    wrap_torch_tensor,
-)
-from triton_kernels.tensor_details import layout
-from triton_kernels.topk import topk
+try:
+    import triton_kernels.matmul_details.opt_flags as opt_flags
+    from triton_kernels.matmul import (
+        FlexCtx,
+        FnSpecs,
+        FusedActivation,
+        PrecisionConfig,
+        matmul,
+    )
+    from triton_kernels.matmul_details.opt_flags import scoped_opt_flags_constraints
+    from triton_kernels.numerics import InFlexData
+    from triton_kernels.swiglu import swiglu_fn
+    from triton_kernels.tensor import (
+        FP4,
+        RaggedTensorMetadata,
+        convert_layout,
+        make_ragged_tensor_metadata,
+        wrap_torch_tensor,
+    )
+    from triton_kernels.tensor_details import layout
+    from triton_kernels.topk import topk
+except ImportError:
+    pass
 
 # isort: off
 from tokenspeed_kernel.ops.quantization.triton import fp8_quantize

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/transform/faster_hadamard_transform/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/transform/faster_hadamard_transform/__init__.py
@@ -29,7 +29,10 @@ platform = current_platform()
 
 
 if platform.is_nvidia:
-    from fast_hadamard_transform import hadamard_transform
+    try:
+        from fast_hadamard_transform import hadamard_transform
+    except ImportError:
+        pass
 
     @register_kernel(
         "transform",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/deep_gemm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/deep_gemm/__init__.py
@@ -68,27 +68,30 @@ def _prepare_deep_gemm_cuda_home() -> None:
 
 _prepare_deep_gemm_cuda_home()
 
-from deep_gemm import (
-    ceil_div,
-    ceil_to_ue8m0,
-    fp8_einsum,
-    fp8_fp4_mega_moe,
-    fp8_fp4_mqa_logits,
-    fp8_fp4_paged_mqa_logits,
-    fp8_gemm_nt,
-    fp8_mqa_logits,
-    fp8_paged_mqa_logits,
-    get_mn_major_tma_aligned_tensor,
-    get_num_sms,
-    get_paged_mqa_logits_metadata,
-    get_symm_buffer_for_mega_moe,
-    m_grouped_fp8_gemm_nt_contiguous,
-    m_grouped_fp8_gemm_nt_masked,
-    set_num_sms,
-    tf32_hc_prenorm_gemm,
-    transform_sf_into_required_layout,
-    transform_weights_for_mega_moe,
-)
+try:
+    from deep_gemm import (
+        ceil_div,
+        ceil_to_ue8m0,
+        fp8_einsum,
+        fp8_fp4_mega_moe,
+        fp8_fp4_mqa_logits,
+        fp8_fp4_paged_mqa_logits,
+        fp8_gemm_nt,
+        fp8_mqa_logits,
+        fp8_paged_mqa_logits,
+        get_mn_major_tma_aligned_tensor,
+        get_num_sms,
+        get_paged_mqa_logits_metadata,
+        get_symm_buffer_for_mega_moe,
+        m_grouped_fp8_gemm_nt_contiguous,
+        m_grouped_fp8_gemm_nt_masked,
+        set_num_sms,
+        tf32_hc_prenorm_gemm,
+        transform_sf_into_required_layout,
+        transform_weights_for_mega_moe,
+    )
+except ImportError:
+    pass
 from tokenspeed_kernel.thirdparty.deep_gemm.warmup import (
     warmup_fp8_gemm_nt,
     warmup_fp8_gemm_nt_from_model,


### PR DESCRIPTION
Add support for Qwen2.5-MoE (Qwen2MoeForCausalLM) models, including:
- Configuration class Qwen2_5MoeConfig with MoE parameters
- Model implementation with MoE sparse blocks, dense MLP fallback, and conditional layer routing via decoder_sparse_step
- Config and model registry registration
- Test coverage for config, registry, weight loading, and MoE layer detection

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
