### PR TITLE
feat: improve multi-node usability

### DIFF
--- a/docs/serving/parallelism.md
+++ b/docs/serving/parallelism.md
@@ -75,6 +75,44 @@ tokenspeed serve <model> \
 Each node must use the same model, backend, precision, and scheduler settings.
 Only `--node-rank` should differ between nodes.
 
+Run one `tokenspeed serve` per node. Node rank 0 serves the HTTP API; higher
+ranks run the engine only and expose no endpoint.
+
+### Under a launcher
+
+Inside a multi-node Slurm step, `--nnodes`, `--node-rank` and
+`--dist-init-addr` are all derived from the step environment when they are not
+given, so the same command line runs on every node:
+
+```bash
+srun --nodes=2 --ntasks-per-node=1 tokenspeed serve <model> --attn-tp-size 16
+```
+
+| Argument | Derived from |
+| --- | --- |
+| `--nnodes` | `SLURM_NNODES` |
+| `--node-rank` | `SLURM_NODEID` |
+| `--dist-init-addr` | first host of `SLURM_STEP_NODELIST`, port 23456 |
+
+Rules:
+
+- An explicit `--nnodes` or `--node-rank` that contradicts the environment is
+  an error, not an override. Omit the flag to accept the launcher's value.
+- An explicit `--dist-init-addr` is always used as given.
+- Derivation only engages when `SLURM_NNODES` is greater than 1. Outside a
+  launcher, or in a single-node step, behaviour is unchanged.
+- If a multi-node step is detected but the topology cannot be resolved,
+  startup fails with the reason rather than falling back to a single node.
+- The derived address is the one the head node's hostname resolves to. Where
+  that is not the interface you want carrying NCCL bootstrap traffic, set
+  `--dist-init-addr` explicitly; `NCCL_SOCKET_IFNAME` still has to be set
+  separately.
+- The rendezvous port is a fixed constant, not a function of `--port`. Every
+  node has to arrive at the same port without talking to any other node, and
+  under `tokenspeed serve` the engine's own port is allocated per node. The
+  constant also stays clear of the kernel's ephemeral range, which is checked
+  at startup. Pass `--dist-init-addr` to use a different port.
+
 Apply the same NCCL transport and channel settings on every node as well. In
 particular, do not mix IB and Socket selection or different
 `NCCL_MIN_NCHANNELS` / `NCCL_MAX_NCHANNELS` values across ranks.

--- a/docs/serving/parallelism.md
+++ b/docs/serving/parallelism.md
@@ -104,9 +104,15 @@ Rules:
 - If a multi-node step is detected but the topology cannot be resolved,
   startup fails with the reason rather than falling back to a single node.
 - The derived address is the one the head node's hostname resolves to. Where
-  that is not the interface you want carrying NCCL bootstrap traffic, set
-  `--dist-init-addr` explicitly; `NCCL_SOCKET_IFNAME` still has to be set
-  separately.
+  that is not the interface you want carrying bootstrap traffic, set
+  `--dist-init-addr` explicitly.
+- `GLOO_SOCKET_IFNAME` and `NCCL_SOCKET_IFNAME` are set from the interface that
+  routes to the head node, unless already present in the environment. Gloo
+  needs this: it has no peer-address heuristic and otherwise binds whatever the
+  local hostname resolves to, which is a loopback entry on many hosts. NCCL
+  normally selects correctly on its own; it is set for consistency.
+- `NCCL_IB_HCA` is not set. NCCL's own device selection prefers the
+  higher-bandwidth InfiniBand devices and skips Ethernet-link ones.
 - The rendezvous port is a fixed constant, not a function of `--port`. Every
   node has to arrive at the same port without talking to any other node, and
   under `tokenspeed serve` the engine's own port is allocated per node. The

--- a/docs/serving/parallelism.md
+++ b/docs/serving/parallelism.md
@@ -90,7 +90,7 @@ srun --nodes=2 --ntasks-per-node=1 tokenspeed serve <model> --attn-tp-size 16
 
 | Argument | Derived from |
 | --- | --- |
-| `--nnodes` | `SLURM_NNODES` |
+| `--nnodes` | `SLURM_STEP_NUM_NODES` |
 | `--node-rank` | `SLURM_NODEID` |
 | `--dist-init-addr` | first host of `SLURM_STEP_NODELIST`, port 23456 |
 
@@ -99,8 +99,10 @@ Rules:
 - An explicit `--nnodes` or `--node-rank` that contradicts the environment is
   an error, not an override. Omit the flag to accept the launcher's value.
 - An explicit `--dist-init-addr` is always used as given.
-- Derivation only engages when `SLURM_NNODES` is greater than 1. Outside a
-  launcher, or in a single-node step, behaviour is unchanged.
+- Derivation only engages inside an `srun` step of more than one node. Outside
+  a step — including the batch script of a multi-node `sbatch` — or in a
+  single-node step, behaviour is unchanged: launch the ranks yourself and pass
+  `--nnodes`/`--node-rank`/`--dist-init-addr`.
 - If a multi-node step is detected but the topology cannot be resolved,
   startup fails with the reason rather than falling back to a single node.
 - The derived address is the one the head node's hostname resolves to. Where

--- a/python/tokenspeed/cli/_proc.py
+++ b/python/tokenspeed/cli/_proc.py
@@ -36,15 +36,19 @@ _ENGINE_MODULE_DEFAULT = "smg_grpc_servicer.tokenspeed"
 _PIPE_LINE_LIMIT = 64 * 1024 * 1024
 
 
-async def spawn_engine(
-    args: list[str],
-    *,
-    host: str,
-    port: int,
-) -> asyncio.subprocess.Process:
-    """Spawn the engine subprocess with PIPE stdio."""
+def engine_argv(args: list[str], *, host: str, port: int) -> list[str]:
+    """Build the command line that runs the engine module.
+
+    Args:
+        args: Engine-side arguments to forward verbatim.
+        host: Address the engine binds.
+        port: Port the engine binds.
+
+    Returns:
+        An ``argv`` list whose first element is the Python interpreter.
+    """
     module = os.environ.get("TS_SERVE_ENGINE_MODULE", _ENGINE_MODULE_DEFAULT)
-    cmd = [
+    return [
         sys.executable,
         "-m",
         module,
@@ -54,7 +58,17 @@ async def spawn_engine(
         str(port),
         *args,
     ]
-    logger.info("spawn engine: %s", " ".join(cmd))
+
+
+async def spawn_engine(
+    args: list[str],
+    *,
+    host: str,
+    port: int,
+) -> asyncio.subprocess.Process:
+    """Spawn the engine subprocess with PIPE stdio."""
+    cmd = engine_argv(args, host=host, port=port)
+    logger.info(f"spawn engine: {' '.join(cmd)}")
     return await asyncio.create_subprocess_exec(
         *cmd,
         stdout=asyncio.subprocess.PIPE,
@@ -81,7 +95,7 @@ async def spawn_gateway(
         "--disable-circuit-breaker",
         *args,
     ]
-    logger.info("spawn gateway: %s", " ".join(cmd))
+    logger.info(f"spawn gateway: {' '.join(cmd)}")
     return await asyncio.create_subprocess_exec(
         *cmd,
         stdout=asyncio.subprocess.PIPE,

--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -38,6 +38,7 @@ from tokenspeed.cli._argsplit import OrchestratorOpts, split_argv
 from tokenspeed.cli._logo import print_logo
 from tokenspeed.cli._logprefix import ENGINE_TAG, GATEWAY_TAG, tag_stream
 from tokenspeed.cli._proc import (
+    engine_argv,
     spawn_engine,
     spawn_gateway,
     terminate_then_kill,
@@ -110,22 +111,29 @@ def _check_serve_extra_installed() -> None:
         sys.exit(1)
 
 
-def _user_host_port_from_gateway_args(gateway_args: list[str]) -> tuple[str, int]:
-    """Pull --host / --port out of the gateway-bound argv.
+def _get_from_args(
+    args: list[str], flag: str, default: str | None = None
+) -> str | None:
+    """Return the value following ``flag`` in a split argv.
 
-    Defaults match TokenSpeed's public serving endpoint. The argv MUST
-    be in canonical ``[--flag, value, ...]`` form as produced by
+    The argv MUST be in canonical ``[--flag, value, ...]`` form as produced by
     ``split_argv``; equals-form (``--port=8000``) is not handled here.
+
+    Args:
+        args: Engine- or gateway-side argv.
+        flag: Long-form flag to look up, including the leading dashes.
+        default: Returned when the flag is absent or is the final token.
+
+    Returns:
+        The value following the first occurrence of ``flag``, else ``default``.
     """
-    host = DEFAULT_GATEWAY_HOST
-    port = DEFAULT_GATEWAY_PORT
-    it = iter(gateway_args)
-    for token in it:
-        if token == "--host":
-            host = next(it)
-        elif token == "--port":
-            port = int(next(it))
-    return host, port
+    try:
+        index = args.index(flag)
+    except ValueError:
+        return default
+    if index + 1 >= len(args):
+        return default
+    return args[index + 1]
 
 
 def _gateway_args_with_default_port(gateway_args: list[str]) -> list[str]:
@@ -230,17 +238,6 @@ def _gateway_args_with_default_prometheus_port(gateway_args: list[str]) -> list[
     return [*gateway_args, "--prometheus-port", str(get_free_port())]
 
 
-def _user_model_id(gateway_args: list[str]) -> str | None:
-    """Return the value of ``--model`` from a split gateway argv, or ``None``."""
-    try:
-        idx = gateway_args.index("--model")
-    except ValueError:
-        return None
-    if idx + 1 >= len(gateway_args):
-        return None
-    return gateway_args[idx + 1]
-
-
 def _load_model_config(model_id: str | None) -> dict:
     """Best-effort read of ``<model_id>/config.json`` (empty dict on any miss)."""
     if not model_id:
@@ -325,7 +322,9 @@ def _args_with_default_model_parsers(
     reasoning_content after generation, while the engine uses the same parser
     name to defer json_schema grammars past the reasoning channel.
     """
-    model_id = _user_model_id(gateway_args) or _user_model_id(engine_args)
+    model_id = _get_from_args(gateway_args, "--model") or _get_from_args(
+        engine_args, "--model"
+    )
     engine_result = list(engine_args)
     gateway_result = list(gateway_args)
 
@@ -436,10 +435,9 @@ def _add_rl_control_port(engine_args: list[str]) -> tuple[list[str], str]:
     is present in the engine argv (allocating a free port if the user did not pin
     one) and return the matching ``rl_control_url``.
     """
-    if "--rl-control-port" in engine_args:
-        idx = engine_args.index("--rl-control-port")
-        port = int(engine_args[idx + 1])
-        return engine_args, f"http://127.0.0.1:{port}"
+    pinned = _get_from_args(engine_args, "--rl-control-port")
+    if pinned is not None:
+        return engine_args, f"http://127.0.0.1:{int(pinned)}"
     port = get_free_port()
     return [*engine_args, "--rl-control-port", str(port)], (f"http://127.0.0.1:{port}")
 
@@ -701,18 +699,29 @@ def run_smg_from_args(args: argparse.Namespace, raw_argv: list[str]) -> None:
         split.engine, split.gateway
     )
     gateway_args = _gateway_args_with_defaults(gateway_args)
-    user_host, user_port = _user_host_port_from_gateway_args(gateway_args)
+    user_host = _get_from_args(gateway_args, "--host", DEFAULT_GATEWAY_HOST)
+    user_port = int(_get_from_args(gateway_args, "--port", str(DEFAULT_GATEWAY_PORT)))
 
-    model_id = _user_model_id(gateway_args)
-    if model_id is not None:
-        _prewarm_hf_tokenizer(model_id)
-    rc = asyncio.run(
-        run_smg(
-            engine_args=engine_args,
-            gateway_args=gateway_args,
-            opts=split.opts,
-            user_host=user_host,
-            user_port=user_port,
+    node_rank = int(_get_from_args(engine_args, "--node-rank", "0"))
+    if node_rank == 0:
+        model_id = _get_from_args(gateway_args, "--model")
+        if model_id is not None:
+            _prewarm_hf_tokenizer(model_id)
+        rc = asyncio.run(
+            run_smg(
+                engine_args=engine_args,
+                gateway_args=gateway_args,
+                opts=split.opts,
+                user_host=user_host,
+                user_port=user_port,
+            )
         )
-    )
-    sys.exit(rc)
+        sys.exit(rc)
+    else:
+        # Non-zero-rank nodes never create a gRPC servicer, so they run the
+        # engine directly, skipping the gateway.
+        argv = engine_argv(engine_args, host=user_host, port=user_port)
+        logger.info(f"follower node: exec {' '.join(argv)}")
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os.execv(argv[0], argv)

--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -126,10 +126,12 @@ def _get_from_args(
         default: Returned when the flag is absent or is the final token.
 
     Returns:
-        The value following the first occurrence of ``flag``, else ``default``.
+        The value following the last occurrence of ``flag``, else ``default``.
+        Last-wins matches argparse, so a wrapper can append a flag to override
+        one already in the argv.
     """
     try:
-        index = args.index(flag)
+        index = len(args) - 1 - args[::-1].index(flag)
     except ValueError:
         return default
     if index + 1 >= len(args):

--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -45,6 +45,7 @@ from tokenspeed.cli._proc import (
     wait_grpc_serving,
     wait_http_ready,
 )
+from tokenspeed.runtime.utils.launcher import detect_topology
 from tokenspeed.runtime.utils.network import get_free_port
 from tokenspeed.runtime.utils.process import kill_process_tree
 
@@ -702,7 +703,13 @@ def run_smg_from_args(args: argparse.Namespace, raw_argv: list[str]) -> None:
     user_host = _get_from_args(gateway_args, "--host", DEFAULT_GATEWAY_HOST)
     user_port = int(_get_from_args(gateway_args, "--port", str(DEFAULT_GATEWAY_PORT)))
 
-    node_rank = int(_get_from_args(engine_args, "--node-rank", "0"))
+    node_rank = _get_from_args(engine_args, "--node-rank")
+    if node_rank is None:
+        topology = detect_topology()
+        node_rank = 0 if topology is None else topology.node_rank
+    else:
+        node_rank = int(node_rank)
+
     if node_rank == 0:
         model_id = _get_from_args(gateway_args, "--model")
         if model_id is not None:

--- a/python/tokenspeed/runtime/entrypoints/engine.py
+++ b/python/tokenspeed/runtime/entrypoints/engine.py
@@ -84,6 +84,7 @@ from tokenspeed.runtime.utils import (
     set_ulimit,
 )
 from tokenspeed.runtime.utils.env import envs
+from tokenspeed.runtime.utils.launcher import interface_for_host
 from tokenspeed.runtime.utils.process import kill_process_tree
 from tokenspeed.runtime.utils.server_args import PortArgs, ServerArgs
 from tokenspeed.runtime.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
@@ -454,6 +455,30 @@ class Engine(EngineBase):
         self.collective_rpc("save_sharded_model", **kwargs)
 
 
+def _set_socket_interface(server_args: ServerArgs):
+    """Point gloo and NCCL at the interface that reaches the head node.
+
+    Gloo has no peer-address heuristic: left alone it binds whatever the local
+    hostname resolves to, which is a loopback entry on many hosts, and every
+    cross-node gloo collective then fails to connect.
+    """
+    if server_args.mapping.nnodes <= 1 or not server_args.dist_init_addr:
+        return
+
+    head = server_args.dist_init_addr.rsplit(":", 1)[0]
+    interface = interface_for_host(head)
+    if interface is None:
+        logger.warning(
+            f"cannot tell which interface reaches the head node {head}; set "
+            "GLOO_SOCKET_IFNAME and NCCL_SOCKET_IFNAME explicitly if cross-node setup fails"
+        )
+        return
+
+    for name in ("GLOO_SOCKET_IFNAME", "NCCL_SOCKET_IFNAME"):
+        os.environ.setdefault(name, interface)
+    logger.info(f"socket interface reaching {head}: {interface}")
+
+
 def _set_envs_and_config(server_args: ServerArgs):
     # Set global environments
     os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
@@ -467,6 +492,8 @@ def _set_envs_and_config(server_args: ServerArgs):
         # explicit env wins; --disable-tf32 is the documented opt-out.
         os.environ.setdefault("NVIDIA_TF32_OVERRIDE", "1")
         os.environ.setdefault("TORCH_ALLOW_TF32_CUBLAS_OVERRIDE", "1")
+
+    _set_socket_interface(server_args)
 
     # Set prometheus env vars
     if server_args.enable_metrics:

--- a/python/tokenspeed/runtime/utils/common.py
+++ b/python/tokenspeed/runtime/utils/common.py
@@ -423,10 +423,14 @@ def prepare_model_and_tokenizer(model_path: str, tokenizer_path: str):
         if not os.path.exists(model_path):
             from modelscope import snapshot_download
 
-            model_path = snapshot_download(model_path)
-            tokenizer_path = snapshot_download(
-                tokenizer_path, ignore_patterns=["*.bin", "*.safetensors"]
-            )
+            from tokenspeed.runtime.model_loader.weight_utils import get_lock
+
+            with get_lock(model_path):
+                model_path = snapshot_download(model_path)
+            with get_lock(tokenizer_path):
+                tokenizer_path = snapshot_download(
+                    tokenizer_path, ignore_patterns=["*.bin", "*.safetensors"]
+                )
     return model_path, tokenizer_path
 
 

--- a/python/tokenspeed/runtime/utils/hf_transformers_utils.py
+++ b/python/tokenspeed/runtime/utils/hf_transformers_utils.py
@@ -219,9 +219,12 @@ def get_config(
     if os.path.isdir(model):
         model_path = model
     else:
-        model_path = snapshot_download(
-            model, ignore_patterns=["*.pt", "*.safetensors", "*.bin"]
-        )
+        from tokenspeed.runtime.model_loader.weight_utils import get_lock
+
+        with get_lock(model):
+            model_path = snapshot_download(
+                model, ignore_patterns=["*.pt", "*.safetensors", "*.bin"]
+            )
 
     try:
         with open(os.path.join(model_path, "config.json")) as file:
@@ -546,6 +549,16 @@ def get_tokenizer(
         if kwargs.get("use_fast", False):
             raise ValueError("Cannot use the fast tokenizer in slow tokenizer mode.")
         kwargs["use_fast"] = False
+
+    if not os.path.isdir(tokenizer_name):
+        from tokenspeed.runtime.model_loader.weight_utils import get_lock
+
+        with get_lock(tokenizer_name):
+            snapshot_download(
+                tokenizer_name,
+                revision=tokenizer_revision,
+                ignore_patterns=["*.pt", "*.safetensors", "*.bin"],
+            )
 
     fast_tokenizer = None
     if (

--- a/python/tokenspeed/runtime/utils/launcher.py
+++ b/python/tokenspeed/runtime/utils/launcher.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Cluster topology discovery from the launcher environment."""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import re
+import socket
+
+SLURM_NNODES = "SLURM_NNODES"
+SLURM_NODEID = "SLURM_NODEID"
+SLURM_STEP_NODELIST = "SLURM_STEP_NODELIST"
+SLURM_JOB_NODELIST = "SLURM_JOB_NODELIST"
+
+# Every node must compute the same rendezvous port without talking to any other
+# node, so it is a constant rather than a function of any per-node value.
+# TODO: a constant can still collide on the head node. The clean fix is for rank
+# 0 to bind port 0 and publish the result to the followers, retrying on the
+# close()->bind() race.
+DIST_INIT_DEFAULT_PORT = 23456
+
+_BRACKET_RE = re.compile(r"\[([^\]]*)\]")
+_EPHEMERAL_RANGE_PATH = "/proc/sys/net/ipv4/ip_local_port_range"
+
+
+def _split_top_level(hostlist: str) -> list[str]:
+    """Split a hostlist on commas that are outside ``[...]`` groups."""
+    tokens: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for char in hostlist:
+        if char == "[":
+            depth += 1
+        elif char == "]":
+            depth -= 1
+        if char == "," and depth == 0:
+            tokens.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+    tokens.append("".join(current))
+    return [token.strip() for token in tokens if token.strip()]
+
+
+def first_host(hostlist: str) -> str:
+    """Return the first hostname of a Slurm-compressed hostlist.
+
+    Args:
+        hostlist: A hostlist such as ``cn10``, ``cn[10,15]``, ``cn[01-03,07]``
+            or ``cn[01-02],dgx[1-2]``.
+
+    Returns:
+        The first hostname, with any range notation replaced by its lowest
+        member and zero padding preserved.
+
+    Raises:
+        ValueError: If ``hostlist`` is empty.
+    """
+    tokens = _split_top_level(hostlist)
+    if not tokens:
+        raise ValueError(f"cannot parse an empty hostlist: {hostlist!r}")
+
+    def take_first(match: re.Match[str]) -> str:
+        spec = match.group(1)
+        return spec.split(",")[0].split("-")[0]
+
+    return _BRACKET_RE.sub(take_first, tokens[0])
+
+
+def local_ipv4_addresses() -> set[str]:
+    """Return every IPv4 address bound to a local interface."""
+    import psutil
+
+    return {
+        addr.address
+        for addrs in psutil.net_if_addrs().values()
+        for addr in addrs
+        if addr.family == socket.AF_INET
+    }
+
+
+def _interface_ipv4(iface: str) -> str | None:
+    import psutil
+
+    for addr in psutil.net_if_addrs().get(iface, ()):
+        if addr.family == socket.AF_INET:
+            return addr.address
+    return None
+
+
+def _local_routable_ipv4(env: dict[str, str]) -> str | None:
+    """Return this node's own routable IPv4 address, or ``None``."""
+    iface = env.get("NCCL_SOCKET_IFNAME")
+    if iface:
+        address = _interface_ipv4(iface)
+        if address and not address.startswith("127."):
+            return address
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            # No packet is sent; this only asks the kernel which source
+            # address the default route would use.
+            sock.connect(("8.8.8.8", 80))
+            address = sock.getsockname()[0]
+    except OSError:
+        return None
+    return None if address.startswith("127.") else address
+
+
+def _resolve_head_ipv4(host: str, node_rank: int, env: dict[str, str]) -> str:
+    try:
+        address = socket.gethostbyname(host)
+    except OSError as exc:
+        raise ValueError(
+            f"cannot resolve the head node {host!r} to an address "
+            f"({exc}); pass --dist-init-addr <host>:<port> explicitly"
+        ) from exc
+
+    if address.startswith("127."):
+        if node_rank != 0:
+            raise ValueError(
+                f"the head node {host!r} resolves to loopback ({address}) on this "
+                "node, so it cannot be reached; pass --dist-init-addr "
+                "<host>:<port> explicitly"
+            )
+        address = _local_routable_ipv4(env)
+        if address is None:
+            raise ValueError(
+                f"the head node {host!r} resolves to loopback and no routable "
+                "local address was found; set NCCL_SOCKET_IFNAME or pass "
+                "--dist-init-addr <host>:<port> explicitly"
+            )
+
+    if node_rank == 0 and address not in local_ipv4_addresses():
+        raise ValueError(
+            f"derived head address {address} (from {host!r}) is not bound to any "
+            "local interface, but this is node rank 0; pass --dist-init-addr "
+            "<host>:<port> explicitly"
+        )
+    return address
+
+
+def _ephemeral_port_range() -> tuple[int, int] | None:
+    try:
+        with open(_EPHEMERAL_RANGE_PATH) as handle:
+            low, high = handle.read().split()[:2]
+        return int(low), int(high)
+    except (OSError, ValueError):
+        return None
+
+
+def check_dist_init_port(port: int) -> None:
+    """Reject a rendezvous port the kernel may hand out to something else.
+
+    Args:
+        port: The port the distributed rendezvous would bind.
+
+    Raises:
+        ValueError: If ``port`` lies in the local ephemeral port range.
+    """
+    span = _ephemeral_port_range()
+    if span is None:
+        return
+    low, high = span
+    if low <= port <= high:
+        raise ValueError(
+            f"rendezvous port {port} lies in this host's ephemeral port range "
+            f"({low}-{high}) and may be taken by an unrelated connection; pass "
+            "--dist-init-addr <host>:<port> with a port outside that range"
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class LauncherTopology:
+    """Multi-node topology as reported by the launcher."""
+
+    nnodes: int
+    node_rank: int
+    head_host: str
+    dist_init_port: int
+    source: str
+
+    @property
+    def dist_init_addr(self) -> str:
+        return f"{self.head_host}:{self.dist_init_port}"
+
+
+def _require_int(env: dict[str, str], name: str) -> int:
+    raw = env.get(name)
+    if raw is None:
+        raise ValueError(
+            f"{name} is unset but a multi-node step was detected; pass "
+            "--nnodes/--node-rank/--dist-init-addr explicitly"
+        )
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name}={raw!r} is not an integer") from exc
+
+
+def detect_topology(env: dict[str, str] | None = None) -> LauncherTopology | None:
+    """Derive the multi-node topology from the launcher environment.
+
+    Args:
+        env: Environment mapping to read; defaults to ``os.environ``.
+
+    Returns:
+        A :class:`LauncherTopology`, or ``None`` when the environment shows no
+        evidence of a multi-node launch.
+
+    Raises:
+        ValueError: If a multi-node launch is detected but the topology cannot
+            be resolved from it.
+    """
+    env = os.environ if env is None else env
+
+    if env.get(SLURM_NNODES) is None:
+        return None
+    nnodes = _require_int(env, SLURM_NNODES)
+    if nnodes <= 1:
+        return None
+
+    node_rank = _require_int(env, SLURM_NODEID)
+    if not 0 <= node_rank < nnodes:
+        raise ValueError(
+            f"{SLURM_NODEID}={node_rank} is out of range for {SLURM_NNODES}={nnodes}"
+        )
+
+    nodelist = env.get(SLURM_STEP_NODELIST) or env.get(SLURM_JOB_NODELIST)
+    if not nodelist:
+        raise ValueError(
+            f"{SLURM_STEP_NODELIST} is unset but a multi-node step was detected; "
+            "pass --dist-init-addr <host>:<port> explicitly"
+        )
+
+    check_dist_init_port(DIST_INIT_DEFAULT_PORT)
+    return LauncherTopology(
+        nnodes=nnodes,
+        node_rank=node_rank,
+        head_host=_resolve_head_ipv4(first_host(nodelist), node_rank, env),
+        dist_init_port=DIST_INIT_DEFAULT_PORT,
+        source="Slurm",
+    )

--- a/python/tokenspeed/runtime/utils/launcher.py
+++ b/python/tokenspeed/runtime/utils/launcher.py
@@ -29,10 +29,9 @@ import socket
 
 import psutil
 
-SLURM_NNODES = "SLURM_NNODES"
+SLURM_STEP_NUM_NODES = "SLURM_STEP_NUM_NODES"
 SLURM_NODEID = "SLURM_NODEID"
 SLURM_STEP_NODELIST = "SLURM_STEP_NODELIST"
-SLURM_JOB_NODELIST = "SLURM_JOB_NODELIST"
 
 # Every node must compute the same rendezvous port without talking to any other
 # node, so it is a constant rather than a function of any per-node value.
@@ -257,26 +256,25 @@ def detect_topology(env: dict[str, str] | None = None) -> LauncherTopology | Non
     """
     env = os.environ if env is None else env
 
-    if env.get(SLURM_NNODES) is None:
+    if env.get(SLURM_STEP_NUM_NODES) is None:
         return None
-    nnodes = _require_int(env, SLURM_NNODES)
+    nnodes = _require_int(env, SLURM_STEP_NUM_NODES)
     if nnodes <= 1:
         return None
 
     node_rank = _require_int(env, SLURM_NODEID)
     if not 0 <= node_rank < nnodes:
         raise ValueError(
-            f"{SLURM_NODEID}={node_rank} is out of range for {SLURM_NNODES}={nnodes}"
+            f"{SLURM_NODEID}={node_rank} is out of range for {SLURM_STEP_NUM_NODES}={nnodes}"
         )
 
-    nodelist = env.get(SLURM_STEP_NODELIST) or env.get(SLURM_JOB_NODELIST)
+    nodelist = env.get(SLURM_STEP_NODELIST)
     if not nodelist:
         raise ValueError(
             f"{SLURM_STEP_NODELIST} is unset but a multi-node step was detected; "
             "pass --dist-init-addr <host>:<port> explicitly"
         )
 
-    check_dist_init_port(DIST_INIT_DEFAULT_PORT)
     return LauncherTopology(
         nnodes=nnodes,
         node_rank=node_rank,

--- a/python/tokenspeed/runtime/utils/launcher.py
+++ b/python/tokenspeed/runtime/utils/launcher.py
@@ -27,6 +27,8 @@ import os
 import re
 import socket
 
+import psutil
+
 SLURM_NNODES = "SLURM_NNODES"
 SLURM_NODEID = "SLURM_NODEID"
 SLURM_STEP_NODELIST = "SLURM_STEP_NODELIST"
@@ -89,8 +91,6 @@ def first_host(hostlist: str) -> str:
 
 def local_ipv4_addresses() -> set[str]:
     """Return every IPv4 address bound to a local interface."""
-    import psutil
-
     return {
         addr.address
         for addrs in psutil.net_if_addrs().values()
@@ -100,8 +100,6 @@ def local_ipv4_addresses() -> set[str]:
 
 
 def _interface_ipv4(iface: str) -> str | None:
-    import psutil
-
     for addr in psutil.net_if_addrs().get(iface, ()):
         if addr.family == socket.AF_INET:
             return addr.address
@@ -124,6 +122,32 @@ def _local_routable_ipv4(env: dict[str, str]) -> str | None:
     except OSError:
         return None
     return None if address.startswith("127.") else address
+
+
+def interface_for_host(host: str) -> str | None:
+    """Return the local interface that carries the route to ``host``.
+
+    Args:
+        host: Address or hostname of the peer to be reached.
+
+    Returns:
+        The interface name, or ``None`` if no local interface owns the source
+        address the kernel would use.
+    """
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            # No packet is sent; this only asks the kernel which source
+            # address it would route from.
+            sock.connect((host, 9))
+            source = sock.getsockname()[0]
+    except OSError:
+        return None
+
+    for name, addrs in psutil.net_if_addrs().items():
+        for addr in addrs:
+            if addr.family == socket.AF_INET and addr.address == source:
+                return name
+    return None
 
 
 def _resolve_head_ipv4(host: str, node_rank: int, env: dict[str, str]) -> str:

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -25,6 +25,7 @@ import dataclasses
 import json
 import os
 import random
+import socket
 from typing import Literal
 
 from tokenspeed_kernel.ops.attention.triton.linear.chunk_delta_h import (
@@ -41,6 +42,7 @@ from tokenspeed.runtime.utils import (
     maybe_model_redirect,
     nullable_str,
 )
+from tokenspeed.runtime.utils.launcher import detect_topology
 from tokenspeed.runtime.utils.network import is_port_available
 
 logger = get_colorful_logger(__name__)
@@ -195,10 +197,11 @@ class ServerArgs:
     kvstore_storage_backend_extra_config: str | None = None
     enable_mla_l1_5_cache: bool = False
 
-    # Multi-node distributed serving
+    # Multi-node distributed serving. ``None`` means "not given by the user",
+    # which is what lets the launcher environment fill them in.
     dist_init_addr: str | None = None
-    nnodes: int = 1
-    node_rank: int = 0
+    nnodes: int | None = None
+    node_rank: int | None = None
 
     # Hugging Face model config overrides in JSON
     hf_overrides: str = "{}"
@@ -315,6 +318,7 @@ class ServerArgs:
 
     def __post_init__(self):
         self.resolve_basic_defaults()
+        self.resolve_launcher_topology()
         self.resolve_parallelism()
         self.resolve_memory_and_scheduling()
         self.resolve_kernel_backends()
@@ -444,6 +448,41 @@ class ServerArgs:
                 self.sampling_backend = "flashinfer"
             else:
                 self.sampling_backend = "greedy"
+
+    def resolve_launcher_topology(self):
+        """Fill in unset multi-node arguments from the launcher environment."""
+        topology = detect_topology()
+        if topology is None:
+            self.nnodes = 1 if self.nnodes is None else self.nnodes
+            self.node_rank = 0 if self.node_rank is None else self.node_rank
+            return
+
+        for flag, given, found in (
+            ("--nnodes", self.nnodes, topology.nnodes),
+            ("--node-rank", self.node_rank, topology.node_rank),
+        ):
+            if given is not None and given != found:
+                raise ValueError(
+                    f"{flag}={given} contradicts the {topology.source} environment, "
+                    f"which reports {found}. Drop the flag to use the launcher's "
+                    f"value, or correct the launch."
+                )
+
+        derived = []
+        if self.nnodes is None:
+            self.nnodes = topology.nnodes
+            derived.append(f"--nnodes {self.nnodes}")
+        if self.node_rank is None:
+            self.node_rank = topology.node_rank
+            derived.append(f"--node-rank {self.node_rank}")
+        if self.dist_init_addr is None:
+            self.dist_init_addr = topology.dist_init_addr
+            derived.append(f"--dist-init-addr {self.dist_init_addr}")
+        if derived:
+            logger.info(
+                f"node {self.node_rank}/{self.nnodes} on {socket.gethostname()}: "
+                f"derived from {topology.source}: {' '.join(derived)}"
+            )
 
     def resolve_parallelism(self):
         world_size = self.world_size
@@ -1334,13 +1373,20 @@ class ServerArgs:
         parser.add_argument(
             "--dist-init-addr",
             type=str,
-            help="The host address for initializing distributed backend (e.g., `192.168.0.2:25000`).",
+            help="The host address for initializing distributed backend (e.g., `192.168.0.2:25000`). "
+            "Derived from the launcher environment under a multi-node Slurm step.",
         )
         parser.add_argument(
-            "--nnodes", type=int, default=ServerArgs.nnodes, help="The number of nodes."
+            "--nnodes",
+            type=int,
+            default=ServerArgs.nnodes,
+            help="The number of nodes. Derived from SLURM_NNODES when unset.",
         )
         parser.add_argument(
-            "--node-rank", type=int, default=ServerArgs.node_rank, help="The node rank."
+            "--node-rank",
+            type=int,
+            default=ServerArgs.node_rank,
+            help="The node rank. Derived from SLURM_NODEID when unset.",
         )
 
         # Model override args
@@ -2058,6 +2104,12 @@ class PortArgs:
                     f"Example: --dist-init-addr 127.0.0.1:4000"
                 )
             dist_init_addr = ("127.0.0.1", server_args.port + ZMQ_TCP_PORT_DELTA)
+        elif server_args.dist_init_addr is None:
+            raise ValueError(
+                f"--dist-init-addr is required for nnodes={server_args.mapping.nnodes} "
+                "and could not be derived from the launcher environment. "
+                "Example: --dist-init-addr <head-node-ip>:20000"
+            )
         else:
             dist_init_addr = server_args.dist_init_addr.split(":")
         if len(dist_init_addr) != 2:

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -2120,12 +2120,18 @@ class PortArgs:
         dist_init_host, dist_init_port = dist_init_addr
         dist_init_port = int(dist_init_port)
 
-        # Scan forward until we find a port cluster where all derived ports are free.
-        # This handles the case where a previous engine instance left ports in
-        # TIME_WAIT or its child processes haven't fully terminated yet.
-        # Note: the port at offset +1 (formerly detokenizer_port) is intentionally
-        # skipped so the rest of the port layout stays stable for any external
-        # tooling that indexed off the historical port cluster.
+        # Scan forward until we find a port cluster where all derived ports are
+        # free. This handles the case where a previous engine instance left
+        # ports in TIME_WAIT or its child processes haven't fully terminated
+        # yet. Note: the port at offset +1 (formerly detokenizer_port) is
+        # intentionally skipped so the rest of the port layout stays stable for
+        # any external tooling that indexed off the historical port cluster.
+        #
+        # The whole cluster is bound on node 0 alone, so scanning is only
+        # meaningful there: is_port_available binds the local wildcard, and a
+        # follower moving its own base would simply address ports the head
+        # never bound. Multi-node therefore takes the cluster as derived and
+        # reports a conflict instead of relocating it.
         while True:
             port_base = dist_init_port + 1
             rpc_port = port_base + 2
@@ -2136,17 +2142,26 @@ class PortArgs:
             else:
                 scheduler_input_port = port_base + 2 + 1 + dp_rank
             rpc_ipc_port = scheduler_input_port + 1
-            if all(
-                is_port_available(p)
-                for p in [
-                    dist_init_port,
-                    port_base,
-                    rpc_port,
-                    metrics_ipc_port,
-                    scheduler_input_port,
-                    rpc_ipc_port,
-                ]
-            ):
+            cluster = [
+                dist_init_port,
+                port_base,
+                rpc_port,
+                metrics_ipc_port,
+                scheduler_input_port,
+                rpc_ipc_port,
+            ]
+            if server_args.mapping.nnodes > 1:
+                if server_args.node_rank == 0:
+                    busy = [p for p in cluster if not is_port_available(p)]
+                    if busy:
+                        raise ValueError(
+                            f"control-plane ports {busy} are already in use on the "
+                            "head node. Every node derives this cluster from "
+                            "--dist-init-addr, so it cannot be moved on one node "
+                            "alone; restart with a different --dist-init-addr port."
+                        )
+                break
+            if all(is_port_available(p) for p in cluster):
                 break
             dist_init_port += 10
 

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -42,7 +42,7 @@ from tokenspeed.runtime.utils import (
     maybe_model_redirect,
     nullable_str,
 )
-from tokenspeed.runtime.utils.launcher import detect_topology
+from tokenspeed.runtime.utils.launcher import check_dist_init_port, detect_topology
 from tokenspeed.runtime.utils.network import is_port_available
 
 logger = get_colorful_logger(__name__)
@@ -476,6 +476,7 @@ class ServerArgs:
             self.node_rank = topology.node_rank
             derived.append(f"--node-rank {self.node_rank}")
         if self.dist_init_addr is None:
+            check_dist_init_port(topology.dist_init_port)
             self.dist_init_addr = topology.dist_init_addr
             derived.append(f"--dist-init-addr {self.dist_init_addr}")
         if derived:
@@ -1380,7 +1381,7 @@ class ServerArgs:
             "--nnodes",
             type=int,
             default=ServerArgs.nnodes,
-            help="The number of nodes. Derived from SLURM_NNODES when unset.",
+            help="The number of nodes. Derived from SLURM_STEP_NUM_NODES when unset.",
         )
         parser.add_argument(
             "--node-rank",

--- a/test/cli/test_serve_smg_unit.py
+++ b/test/cli/test_serve_smg_unit.py
@@ -260,6 +260,11 @@ def test_get_from_args_returns_none_when_flag_lacks_value():
     assert _get_from_args(["--model"], "--model") is None
 
 
+def test_get_from_args_takes_the_last_occurrence():
+    """Last-wins matches argparse, so appending a flag overrides an earlier one."""
+    assert _get_from_args(["--port", "8000", "--port", "8413"], "--port") == "8413"
+
+
 def test_deepseek_v4_model_id_gets_default_parsers():
     model = "deepseek-ai/DeepSeek-V4-Flash"
 

--- a/test/cli/test_serve_smg_unit.py
+++ b/test/cli/test_serve_smg_unit.py
@@ -55,13 +55,12 @@ from tokenspeed.cli.serve_smg import (
     _gateway_args_with_default_reasoning_parser,
     _gateway_args_with_defaults,
     _gateway_args_with_smg_disable_defaults,
+    _get_from_args,
     _is_deepseek_v4_model,
     _is_inkling_model,
     _is_kimi_k3_model,
     _prewarm_hf_tokenizer,
     _set_default_grpc_max_message_bytes,
-    _user_host_port_from_gateway_args,
-    _user_model_id,
     run_smg,
 )
 
@@ -99,14 +98,14 @@ def test_gateway_args_default_port_is_8000():
     gateway_args = _gateway_args_with_default_port(["--model", "/tmp/x"])
 
     assert gateway_args == ["--model", "/tmp/x", "--port", "8000"]
-    assert _user_host_port_from_gateway_args(gateway_args) == ("0.0.0.0", 8000)
+    assert _get_from_args(gateway_args, "--port") == "8000"
 
 
 def test_gateway_args_preserve_user_port():
     gateway_args = _gateway_args_with_default_port(["--port", "8413"])
 
     assert gateway_args == ["--port", "8413"]
-    assert _user_host_port_from_gateway_args(gateway_args) == ("0.0.0.0", 8413)
+    assert _get_from_args(gateway_args, "--port") == "8413"
 
 
 def test_gateway_args_default_reasoning_parser_is_passthrough():
@@ -244,19 +243,21 @@ def test_smg_disable_flag_set_covers_both():
     )
 
 
-def test_user_model_id_extracts_value():
+def test_get_from_args_extracts_value():
     assert (
-        _user_model_id(["--model", "nvidia/Qwen3.5-397B-A17B-NVFP4", "--port", "8000"])
+        _get_from_args(
+            ["--model", "nvidia/Qwen3.5-397B-A17B-NVFP4", "--port", "8000"], "--model"
+        )
         == "nvidia/Qwen3.5-397B-A17B-NVFP4"
     )
 
 
-def test_user_model_id_returns_none_when_absent():
-    assert _user_model_id(["--port", "8000"]) is None
+def test_get_from_args_returns_none_when_absent():
+    assert _get_from_args(["--port", "8000"], "--model") is None
 
 
-def test_user_model_id_returns_none_when_model_lacks_value():
-    assert _user_model_id(["--model"]) is None
+def test_get_from_args_returns_none_when_flag_lacks_value():
+    assert _get_from_args(["--model"], "--model") is None
 
 
 def test_deepseek_v4_model_id_gets_default_parsers():

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -950,6 +950,10 @@ class TestDeepseekV4Config(unittest.TestCase):
 
         with (
             patch(
+                "tokenspeed.runtime.utils.hf_transformers_utils.snapshot_download",
+                return_value="/nonexistent/tokenizer-snapshot",
+            ),
+            patch(
                 "tokenspeed.runtime.utils.hf_transformers_utils.AutoTokenizer.from_pretrained",
                 return_value=DummyTokenizer(),
             ),

--- a/test/runtime/test_launcher_topology.py
+++ b/test/runtime/test_launcher_topology.py
@@ -53,7 +53,7 @@ def test_first_host_rejects_empty():
 
 def _multi_node_env(**overrides):
     env = {
-        launcher.SLURM_NNODES: "2",
+        launcher.SLURM_STEP_NUM_NODES: "2",
         launcher.SLURM_NODEID: "1",
         launcher.SLURM_STEP_NODELIST: "inkwell-iron-cn[15-16]",
     }
@@ -72,7 +72,21 @@ def test_no_launcher_environment_returns_none():
 
 
 def test_single_node_step_returns_none():
-    assert launcher.detect_topology(_multi_node_env(SLURM_NNODES="1")) is None
+    assert launcher.detect_topology(_multi_node_env(SLURM_STEP_NUM_NODES="1")) is None
+
+
+def test_batch_script_environment_is_not_a_multi_node_step():
+    """A bare `ts serve` in a multi-node sbatch is a deliberate single-node run."""
+    assert (
+        launcher.detect_topology(
+            {
+                "SLURM_NNODES": "2",
+                launcher.SLURM_NODEID: "0",
+                "SLURM_JOB_NODELIST": "inkwell-iron-cn[02-03]",
+            }
+        )
+        is None
+    )
 
 
 def test_detects_multi_node_step(resolvable_head):
@@ -108,29 +122,11 @@ def test_port_check_is_skipped_without_a_known_range(monkeypatch):
     launcher.check_dist_init_port(60486)
 
 
-def test_step_nodelist_wins_over_job_nodelist(monkeypatch):
-    seen = []
-
-    def fake_gethostbyname(host):
-        seen.append(host)
-        return HEAD_IP
-
-    monkeypatch.setattr(launcher.socket, "gethostbyname", fake_gethostbyname)
-    monkeypatch.setattr(launcher, "local_ipv4_addresses", lambda: {HEAD_IP})
-    launcher.detect_topology(
-        _multi_node_env(
-            SLURM_STEP_NODELIST="cn15,cn16",
-            SLURM_JOB_NODELIST="cn01,cn02",
-        )
-    )
-    assert seen == ["cn15"]
-
-
-def test_falls_back_to_job_nodelist(resolvable_head):
-    env = _multi_node_env()
-    del env[launcher.SLURM_STEP_NODELIST]
-    env[launcher.SLURM_JOB_NODELIST] = "inkwell-iron-cn[15-16]"
-    assert launcher.detect_topology(env).head_host == HEAD_IP
+def test_detection_does_not_check_the_rendezvous_port(monkeypatch, resolvable_head):
+    """The port only has to be usable where the derived address is adopted."""
+    monkeypatch.setattr(launcher, "_ephemeral_port_range", lambda: (1024, 60999))
+    topology = launcher.detect_topology(_multi_node_env())
+    assert topology.dist_init_port == launcher.DIST_INIT_DEFAULT_PORT
 
 
 def test_missing_node_id_is_an_error():
@@ -149,7 +145,7 @@ def test_missing_nodelist_is_an_error():
 
 def test_non_integer_nnodes_is_an_error():
     with pytest.raises(ValueError, match="not an integer"):
-        launcher.detect_topology(_multi_node_env(SLURM_NNODES="two"))
+        launcher.detect_topology(_multi_node_env(SLURM_STEP_NUM_NODES="two"))
 
 
 def test_node_id_out_of_range_is_an_error():

--- a/test/runtime/test_launcher_topology.py
+++ b/test/runtime/test_launcher_topology.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Unit tests for launcher-environment topology discovery."""
+
+import pytest
+
+from tokenspeed.runtime.utils import launcher
+
+HEAD_IP = "10.40.1.228"
+
+
+@pytest.mark.parametrize(
+    "hostlist,expected",
+    [
+        ("cn10", "cn10"),
+        ("cn10,cn15", "cn10"),
+        ("inkwell-iron-cn[15-16]", "inkwell-iron-cn15"),
+        ("cn[10,15]", "cn10"),
+        ("cn[01-03,07]", "cn01"),
+        ("cn[07,01-03]", "cn07"),
+        ("cn[01-02],dgx[1-2]", "cn01"),
+        ("rack[1-2]node[3-4]", "rack1node3"),
+        ("cn[001-100]-ib", "cn001-ib"),
+        ("  cn[5-9]  ", "cn5"),
+    ],
+)
+def test_first_host(hostlist, expected):
+    assert launcher.first_host(hostlist) == expected
+
+
+def test_first_host_rejects_empty():
+    with pytest.raises(ValueError, match="empty hostlist"):
+        launcher.first_host("")
+
+
+def _multi_node_env(**overrides):
+    env = {
+        launcher.SLURM_NNODES: "2",
+        launcher.SLURM_NODEID: "1",
+        launcher.SLURM_STEP_NODELIST: "inkwell-iron-cn[15-16]",
+    }
+    env.update(overrides)
+    return env
+
+
+@pytest.fixture
+def resolvable_head(monkeypatch):
+    monkeypatch.setattr(launcher.socket, "gethostbyname", lambda host: HEAD_IP)
+    monkeypatch.setattr(launcher, "local_ipv4_addresses", lambda: {HEAD_IP})
+
+
+def test_no_launcher_environment_returns_none():
+    assert launcher.detect_topology({}) is None
+
+
+def test_single_node_step_returns_none():
+    assert launcher.detect_topology(_multi_node_env(SLURM_NNODES="1")) is None
+
+
+def test_detects_multi_node_step(resolvable_head):
+    topology = launcher.detect_topology(_multi_node_env())
+    assert (topology.nnodes, topology.node_rank) == (2, 1)
+    assert topology.head_host == HEAD_IP
+    assert topology.source == "Slurm"
+    assert topology.dist_init_addr == f"{HEAD_IP}:{launcher.DIST_INIT_DEFAULT_PORT}"
+
+
+def test_dist_init_port_is_a_constant(resolvable_head):
+    """Every node must reach the same port without coordinating."""
+    ports = {
+        launcher.detect_topology(_multi_node_env(SLURM_NODEID=rank)).dist_init_port
+        for rank in ("0", "1")
+    }
+    assert ports == {launcher.DIST_INIT_DEFAULT_PORT}
+
+
+def test_dist_init_port_is_outside_the_ephemeral_range():
+    """A port the kernel hands out to others is not usable for a rendezvous."""
+    launcher.check_dist_init_port(launcher.DIST_INIT_DEFAULT_PORT)
+
+
+def test_ephemeral_dist_init_port_is_rejected(monkeypatch):
+    monkeypatch.setattr(launcher, "_ephemeral_port_range", lambda: (32768, 60999))
+    with pytest.raises(ValueError, match="ephemeral port range"):
+        launcher.check_dist_init_port(60486)
+
+
+def test_port_check_is_skipped_without_a_known_range(monkeypatch):
+    monkeypatch.setattr(launcher, "_ephemeral_port_range", lambda: None)
+    launcher.check_dist_init_port(60486)
+
+
+def test_step_nodelist_wins_over_job_nodelist(monkeypatch):
+    seen = []
+
+    def fake_gethostbyname(host):
+        seen.append(host)
+        return HEAD_IP
+
+    monkeypatch.setattr(launcher.socket, "gethostbyname", fake_gethostbyname)
+    monkeypatch.setattr(launcher, "local_ipv4_addresses", lambda: {HEAD_IP})
+    launcher.detect_topology(
+        _multi_node_env(
+            SLURM_STEP_NODELIST="cn15,cn16",
+            SLURM_JOB_NODELIST="cn01,cn02",
+        )
+    )
+    assert seen == ["cn15"]
+
+
+def test_falls_back_to_job_nodelist(resolvable_head):
+    env = _multi_node_env()
+    del env[launcher.SLURM_STEP_NODELIST]
+    env[launcher.SLURM_JOB_NODELIST] = "inkwell-iron-cn[15-16]"
+    assert launcher.detect_topology(env).head_host == HEAD_IP
+
+
+def test_missing_node_id_is_an_error():
+    env = _multi_node_env()
+    del env[launcher.SLURM_NODEID]
+    with pytest.raises(ValueError, match="SLURM_NODEID is unset"):
+        launcher.detect_topology(env)
+
+
+def test_missing_nodelist_is_an_error():
+    env = _multi_node_env()
+    del env[launcher.SLURM_STEP_NODELIST]
+    with pytest.raises(ValueError, match="SLURM_STEP_NODELIST is unset"):
+        launcher.detect_topology(env)
+
+
+def test_non_integer_nnodes_is_an_error():
+    with pytest.raises(ValueError, match="not an integer"):
+        launcher.detect_topology(_multi_node_env(SLURM_NNODES="two"))
+
+
+def test_node_id_out_of_range_is_an_error():
+    with pytest.raises(ValueError, match="out of range"):
+        launcher.detect_topology(_multi_node_env(SLURM_NODEID="2"))
+
+
+def test_unresolvable_head_is_an_error(monkeypatch):
+    def boom(host):
+        raise OSError("no such host")
+
+    monkeypatch.setattr(launcher.socket, "gethostbyname", boom)
+    with pytest.raises(ValueError, match="cannot resolve the head node"):
+        launcher.detect_topology(_multi_node_env())
+
+
+def test_loopback_head_on_follower_is_an_error(monkeypatch):
+    monkeypatch.setattr(launcher.socket, "gethostbyname", lambda host: "127.0.1.1")
+    with pytest.raises(ValueError, match="resolves to loopback"):
+        launcher.detect_topology(_multi_node_env(SLURM_NODEID="1"))
+
+
+def test_loopback_head_on_rank_zero_uses_local_address(monkeypatch):
+    monkeypatch.setattr(launcher.socket, "gethostbyname", lambda host: "127.0.1.1")
+    monkeypatch.setattr(launcher, "_interface_ipv4", lambda iface: HEAD_IP)
+    monkeypatch.setattr(launcher, "local_ipv4_addresses", lambda: {HEAD_IP})
+    topology = launcher.detect_topology(
+        _multi_node_env(SLURM_NODEID="0", NCCL_SOCKET_IFNAME="enP6p9s0np0")
+    )
+    assert topology.head_host == HEAD_IP
+
+
+def test_rank_zero_rejects_a_non_local_head(monkeypatch):
+    monkeypatch.setattr(launcher.socket, "gethostbyname", lambda host: HEAD_IP)
+    monkeypatch.setattr(launcher, "local_ipv4_addresses", lambda: {"10.40.1.235"})
+    with pytest.raises(ValueError, match="not bound to any local interface"):
+        launcher.detect_topology(_multi_node_env(SLURM_NODEID="0"))
+
+
+def test_follower_accepts_a_non_local_head(monkeypatch):
+    monkeypatch.setattr(launcher.socket, "gethostbyname", lambda host: HEAD_IP)
+    monkeypatch.setattr(launcher, "local_ipv4_addresses", lambda: {"10.40.1.235"})
+    assert launcher.detect_topology(_multi_node_env()).head_host == HEAD_IP


### PR DESCRIPTION
## Summary

Multi-node `tokenspeed serve` needed three topology flags, `NCCL_*`/`GLOO_*`
exports, and a different entrypoint on followers. This PR removes all of it —
under a Slurm step the same command works on every node:

```bash
srun --nodes=2 --ntasks-per-node=1 tokenspeed serve \
    --model <model> --attn-tp-size 8 --moe-tp-size 8 ...
```

### Commits

- `ea44c05` — `ts serve` runs the engine directly on `node_rank >= 1` instead
  of parking on a dummy HTTP server the gRPC gateway can never probe.
- `f89fc6d` — new `runtime/utils/launcher.py` derives `nnodes`, `node_rank`,
  `dist_init_addr` from the Slurm step env. Flags win but must agree; a
  contradiction is a hard error.
- `15c31cf` — no control-plane port scan when `nnodes > 1`; every node was
  probing its own wildcard address for ports that exist only on rank 0.
- `78d0e82` — derives `GLOO_SOCKET_IFNAME`/`NCCL_SOCKET_IFNAME` from the route
  to the head node.
- `c260baa` — locks the `snapshot_download` calls in `get_config` /
  `get_tokenizer` / `prepare_model_and_tokenizer`.

### Notes

- Slurm-only, evidence-gated: no MPI/PMI fallback chain. Engages only when
  `SLURM_NNODES > 1`; unresolvable topology fails loudly rather than falling
  back to single-node.
- Measurement corrected the assumption: `NCCL_SOCKET_IFNAME` and `NCCL_IB_HCA`
  are *not* needed — NCCL selects correctly unaided. `GLOO_SOCKET_IFNAME` is,
  and no prior note mentioned it: gloo binds whatever the hostname resolves to
  (`127.0.1.1` here), so cross-node gloo fails without it.
- `c260baa` is hardening, not a bug fix — the tree-cache race was reported but
  never reproduced. It does close a gap: `get_lock` previously wrapped only
  weight downloads, while vLLM also locks tokenizer resolution.
- Rendezvous port is the constant 23456. Deriving it from `--port` is wrong:
  under `ts serve` that is a per-node `get_free_port()`.