### PR TITLE
feat(pd): allow FlatKV Prefill/Decode with different num_lcm_blocks

### DIFF
--- a/python/tokenspeed/runtime/pd/flatkv.py
+++ b/python/tokenspeed/runtime/pd/flatkv.py
@@ -34,7 +34,7 @@ from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from typing import Any, Literal
 
-FLATKV_PD_PROTOCOL_VERSION = 1
+FLATKV_PD_PROTOCOL_VERSION = 2
 MAX_FLATKV_LAYOUT_WIRE_BYTES = 256 << 10
 MAX_FLATKV_MANIFEST_WIRE_BYTES = 2 << 20
 MAX_FLATKV_GROUPS = 64
@@ -44,7 +44,10 @@ MAX_FLATKV_MANIFEST_PAGES = 1 << 15
 _UINT64_LIMIT = 1 << 64
 _FAMILIES = frozenset(("history", "state"))
 _TRANSFER_POLICIES = frozenset(("full_suffix", "latest_snapshot"))
-_PEER_LAYOUT_KEYS = frozenset(("version", "layout_fingerprint", "num_pages_with_null"))
+_PEER_LAYOUT_KEYS = frozenset(
+    ("version", "layout_fingerprint", "num_pages_with_null", "page_zero_offsets")
+)
+_PEER_OFFSET_KEYS = frozenset(("group_id", "field_id", "page_zero_offset"))
 _MANIFEST_KEYS = frozenset(("version", "prefix_len", "prompt_len", "groups"))
 _MANIFEST_GROUP_KEYS = frozenset(("group_id", "page_ids"))
 
@@ -300,12 +303,31 @@ def _layout_fingerprint(value: object) -> str:
 
 
 @dataclass(frozen=True, slots=True)
+class FlatKVPDPeerOffset:
+    """One peer-local field base offset inside the peer's arena."""
+
+    group_id: str
+    field_id: str
+    page_zero_offset: int
+
+    def __post_init__(self) -> None:
+        _string("peer offset group_id", self.group_id)
+        _string("peer offset field_id", self.field_id)
+        _integer("peer offset page_zero_offset", self.page_zero_offset)
+
+
+@dataclass(frozen=True, slots=True)
 class FlatKVPDPeerLayout:
-    """Peer-local fields that are not committed by the semantic fingerprint."""
+    """Peer-local fields that are not committed by the semantic fingerprint.
+
+    Capacity and per-field ``page_zero_offset`` values may differ across PD
+    peers when arena plane packing scales with ``num_lcm_blocks``.
+    """
 
     version: int
     layout_fingerprint: str
     num_pages_with_null: int
+    page_zero_offsets: tuple[FlatKVPDPeerOffset, ...] = ()
 
     def __post_init__(self) -> None:
         if _integer("layout version", self.version, 1) != FLATKV_PD_PROTOCOL_VERSION:
@@ -314,6 +336,27 @@ class FlatKVPDPeerLayout:
             )
         _layout_fingerprint(self.layout_fingerprint)
         _integer("num_pages_with_null", self.num_pages_with_null, 2)
+        offsets = _sequence(
+            self.page_zero_offsets,
+            name="page_zero_offsets",
+            maximum=MAX_FLATKV_GROUPS * MAX_FLATKV_PHYSICAL_SLOTS,
+            nonempty=False,
+        )
+        if not all(isinstance(offset, FlatKVPDPeerOffset) for offset in offsets):
+            raise FlatKVPDProtocolError(
+                "page_zero_offsets must contain FlatKVPDPeerOffset values"
+            )
+        keys = tuple((offset.group_id, offset.field_id) for offset in offsets)
+        _require(
+            len(keys) == len(set(keys)),
+            "page_zero_offsets repeats a (group_id, field_id) pair",
+        )
+
+    def page_zero_offset_map(self) -> dict[tuple[str, str], int]:
+        return {
+            (offset.group_id, offset.field_id): offset.page_zero_offset
+            for offset in self.page_zero_offsets
+        }
 
     def to_wire_bytes(self) -> bytes:
         return _encode(
@@ -328,10 +371,37 @@ class FlatKVPDPeerLayout:
             raw, name="FlatKV peer layout", maximum=MAX_FLATKV_LAYOUT_WIRE_BYTES
         )
         _exact_keys(payload, _PEER_LAYOUT_KEYS, "FlatKV peer layout")
+        offsets = []
+        for position, entry in enumerate(
+            _sequence(
+                payload["page_zero_offsets"],
+                name="FlatKV peer layout page_zero_offsets",
+                maximum=MAX_FLATKV_GROUPS * MAX_FLATKV_PHYSICAL_SLOTS,
+                nonempty=False,
+            )
+        ):
+            if not isinstance(entry, dict):
+                raise FlatKVPDProtocolError(
+                    f"FlatKV peer layout page_zero_offsets[{position}] "
+                    "must be an object"
+                )
+            _exact_keys(
+                entry,
+                _PEER_OFFSET_KEYS,
+                f"FlatKV peer layout page_zero_offsets[{position}]",
+            )
+            offsets.append(
+                FlatKVPDPeerOffset(
+                    group_id=entry["group_id"],
+                    field_id=entry["field_id"],
+                    page_zero_offset=entry["page_zero_offset"],
+                )
+            )
         layout = cls(
             version=payload["version"],
             layout_fingerprint=payload["layout_fingerprint"],
             num_pages_with_null=payload["num_pages_with_null"],
+            page_zero_offsets=tuple(offsets),
         )
         _canonical_round_trip(
             raw,
@@ -428,10 +498,20 @@ class FlatKVPDLayout:
 
     @property
     def peer(self) -> FlatKVPDPeerLayout:
+        offsets = tuple(
+            FlatKVPDPeerOffset(
+                group_id=group.group_id,
+                field_id=segment.field_id,
+                page_zero_offset=segment.page_zero_offset,
+            )
+            for group in self.groups
+            for segment in group.transfer_segments
+        )
         return FlatKVPDPeerLayout(
             version=self.version,
             layout_fingerprint=self.layout_fingerprint,
             num_pages_with_null=self.num_pages_with_null,
+            page_zero_offsets=offsets,
         )
 
 
@@ -578,6 +658,20 @@ def validate_flatkv_peer_layout(
     if layout.layout_fingerprint != peer_layout.layout_fingerprint:
         raise FlatKVPDProtocolError(
             "FlatKV P/D layout ABI mismatch: layout_fingerprint"
+        )
+    local_keys = {
+        (group.group_id, segment.field_id)
+        for group in layout.groups
+        for segment in group.transfer_segments
+    }
+    peer_keys = {
+        (offset.group_id, offset.field_id) for offset in peer_layout.page_zero_offsets
+    }
+    if local_keys != peer_keys:
+        raise FlatKVPDProtocolError(
+            "FlatKV P/D layout ABI mismatch: page_zero_offsets "
+            f"missing={sorted(local_keys - peer_keys)} "
+            f"extra={sorted(peer_keys - local_keys)}"
         )
 
 
@@ -930,11 +1024,12 @@ def build_lcm_flatkv_pd_contract(
             }
             for order, spec in enumerate(specs)
         ],
+        # Omit arena_offset_bytes: plane-major packing scales those offsets with
+        # num_lcm_blocks, which is peer-local capacity rather than shared ABI.
         "planes": [
             {
                 "plane_id": plane.plane_id,
                 "bytes_per_lcm_block": plane.bytes_per_lcm_block,
-                "arena_offset_bytes": plane.arena_offset_bytes,
             }
             for plane in planes
         ],

--- a/python/tokenspeed/runtime/pd/mooncake/prefill.py
+++ b/python/tokenspeed/runtime/pd/mooncake/prefill.py
@@ -24,6 +24,7 @@ import socket
 import threading
 import time
 from collections import defaultdict
+from collections.abc import Mapping
 
 import numpy as np
 import numpy.typing as npt
@@ -432,6 +433,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         src_flat_manifest: FlatKVPDPageManifest | None = None,
         dst_flat_manifest: FlatKVPDPageManifest | None = None,
         dst_flat_num_pages_with_null: int | None = None,
+        dst_page_zero_offsets: Mapping[tuple[str, str], int] | None = None,
     ):
         if (src_flat_manifest is None) != (dst_flat_manifest is None):
             raise ValueError(
@@ -455,10 +457,13 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                 src_manifest=src_flat_manifest,
                 dst_manifest=dst_flat_manifest,
                 dst_num_pages_with_null=dst_flat_num_pages_with_null,
+                dst_page_zero_offsets=dst_page_zero_offsets,
             )
             return self._transfer_data(mooncake_session_id, transfer_blocks)
         if dst_flat_num_pages_with_null is not None:
             raise ValueError("legacy Mooncake transfer received FlatKV capacity")
+        if dst_page_zero_offsets is not None:
+            raise ValueError("legacy Mooncake transfer received FlatKV offsets")
 
         # Group by indices
         prefill_kv_blocks, dst_kv_blocks = group_concurrent_contiguous(
@@ -492,6 +497,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         src_manifest: FlatKVPDPageManifest,
         dst_manifest: FlatKVPDPageManifest,
         dst_num_pages_with_null: int,
+        dst_page_zero_offsets: Mapping[tuple[str, str], int] | None = None,
     ) -> list[tuple[int, int, int]]:
         layout = self.kv_args.flat_layout
         if layout is None:
@@ -502,6 +508,11 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
             layout,
             dst_num_pages_with_null=dst_num_pages_with_null,
         )
+        needs_dst_offsets = any(group.transfer_segments for group in layout.groups)
+        if needs_dst_offsets and dst_page_zero_offsets is None:
+            raise ValueError(
+                "FlatKV segmented transfer requires destination page_zero_offsets"
+            )
 
         transfer_blocks = []
         page_offset = 0
@@ -520,6 +531,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
             ):
                 raise ValueError("FlatKV manifest and Mooncake page vector disagree")
             if layout_group.transfer_segments:
+                assert dst_page_zero_offsets is not None
                 for segment in layout_group.transfer_segments:
                     physical_slot = segment.physical_slot
                     src_ptr = self.kv_args.kv_data_ptrs[physical_slot]
@@ -531,6 +543,15 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                         raise ValueError(
                             "FlatKV Mooncake parent size disagrees with layout"
                         )
+                    key = (layout_group.group_id, segment.field_id)
+                    try:
+                        dst_page_zero_offset = dst_page_zero_offsets[key]
+                    except KeyError as exc:
+                        raise ValueError(
+                            "FlatKV destination is missing page_zero_offset for "
+                            f"group {layout_group.group_id!r} field "
+                            f"{segment.field_id!r}"
+                        ) from exc
                     for src_page, dst_page in zip(
                         group_src_indices, group_dst_indices, strict=True
                     ):
@@ -540,7 +561,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                                 + segment.page_zero_offset
                                 + int(src_page) * segment.page_stride_bytes,
                                 dst_ptr
-                                + segment.page_zero_offset
+                                + dst_page_zero_offset
                                 + int(dst_page) * segment.page_stride_bytes,
                                 segment.payload_bytes,
                             )
@@ -992,6 +1013,11 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                                 dst_flat_manifest=req.flat_manifest,
                                 dst_flat_num_pages_with_null=(
                                     req.flat_peer_layout.num_pages_with_null
+                                    if req.flat_peer_layout is not None
+                                    else None
+                                ),
+                                dst_page_zero_offsets=(
+                                    req.flat_peer_layout.page_zero_offset_map()
                                     if req.flat_peer_layout is not None
                                     else None
                                 ),

--- a/test/runtime/distributed/test_flatkv_pd_executors.py
+++ b/test/runtime/distributed/test_flatkv_pd_executors.py
@@ -17,6 +17,7 @@ from ci_system.ci_register import register_cuda_ci  # noqa: E402
 register_cuda_ci(est_time=10, suite="runtime-1gpu")
 
 from tokenspeed.runtime.pd.flatkv import (  # noqa: E402
+    FLATKV_PD_PROTOCOL_VERSION,
     FlatKVPDGroup,
     FlatKVPDGroupPages,
     FlatKVPDLayout,
@@ -32,7 +33,7 @@ from tokenspeed.runtime.pd.mooncake.entities import (  # noqa: E402
 
 def _layout(*, capacity: int = 16) -> FlatKVPDLayout:
     return FlatKVPDLayout(
-        version=1,
+        version=FLATKV_PD_PROTOCOL_VERSION,
         layout_fingerprint="a" * 64,
         block_size=2,
         num_pages_with_null=capacity,
@@ -327,15 +328,18 @@ def test_shared_manager_transfers_only_group_bound_slabs() -> None:
     ]
 
 
-def test_shared_manager_resolves_lcm_group_segments() -> None:
-    from tokenspeed.runtime.pd.mooncake.prefill import MooncakeKVManagerPrefill
-
-    layout = FlatKVPDLayout(
-        version=1,
+def _segmented_layout(
+    *,
+    capacity: int,
+    history_k_offset: int,
+    history_v_offset: int,
+    state_offset: int,
+) -> FlatKVPDLayout:
+    return FlatKVPDLayout(
+        version=FLATKV_PD_PROTOCOL_VERSION,
         layout_fingerprint="b" * 64,
         block_size=2,
-        # Null parent plus four usable parents.
-        num_pages_with_null=5,
+        num_pages_with_null=capacity,
         physical_buffer_ids=("lcm_arena",),
         physical_page_bytes=1024,
         groups=(
@@ -350,7 +354,7 @@ def test_shared_manager_resolves_lcm_group_segments() -> None:
                         physical_slot=0,
                         field_id="layer.0.k",
                         dtype="bfloat16",
-                        page_zero_offset=768,
+                        page_zero_offset=history_k_offset,
                         page_stride_bytes=256,
                         payload_bytes=256,
                     ),
@@ -358,7 +362,7 @@ def test_shared_manager_resolves_lcm_group_segments() -> None:
                         physical_slot=0,
                         field_id="layer.0.v",
                         dtype="bfloat16",
-                        page_zero_offset=2816,
+                        page_zero_offset=history_v_offset,
                         page_stride_bytes=256,
                         payload_bytes=256,
                     ),
@@ -375,13 +379,24 @@ def test_shared_manager_resolves_lcm_group_segments() -> None:
                         physical_slot=0,
                         field_id="layer.1.ssm",
                         dtype="float32",
-                        page_zero_offset=512,
+                        page_zero_offset=state_offset,
                         page_stride_bytes=512,
                         payload_bytes=384,
                     ),
                 ),
             ),
         ),
+    )
+
+
+def test_shared_manager_resolves_lcm_group_segments() -> None:
+    from tokenspeed.runtime.pd.mooncake.prefill import MooncakeKVManagerPrefill
+
+    layout = _segmented_layout(
+        capacity=5,
+        history_k_offset=768,
+        history_v_offset=2816,
+        state_offset=512,
     )
     source_manifest = FlatKVPDPageManifest(
         groups=(
@@ -422,6 +437,7 @@ def test_shared_manager_resolves_lcm_group_segments() -> None:
             src_flat_manifest=source_manifest,
             dst_flat_manifest=destination_manifest,
             dst_flat_num_pages_with_null=layout.num_pages_with_null,
+            dst_page_zero_offsets=layout.peer.page_zero_offset_map(),
         )
         == 0
     )
@@ -444,6 +460,80 @@ def test_shared_manager_resolves_lcm_group_segments() -> None:
             ],
             [256, 256, 256, 256, 384],
         )
+    ]
+
+
+def test_shared_manager_uses_destination_page_zero_offsets() -> None:
+    from tokenspeed.runtime.pd.mooncake.prefill import MooncakeKVManagerPrefill
+
+    source_layout = _segmented_layout(
+        capacity=5,
+        history_k_offset=768,
+        history_v_offset=2816,
+        state_offset=512,
+    )
+    destination_layout = _segmented_layout(
+        capacity=7,
+        history_k_offset=768,
+        history_v_offset=3840,
+        state_offset=512,
+    )
+    source_manifest = FlatKVPDPageManifest(
+        groups=(
+            FlatKVPDGroupPages("history", (1, 2)),
+            FlatKVPDGroupPages("state", (4,)),
+        ),
+        prefix_len=0,
+        prompt_len=4,
+    )
+    destination_manifest = FlatKVPDPageManifest(
+        groups=(
+            FlatKVPDGroupPages("history", (5, 6)),
+            FlatKVPDGroupPages("state", (3,)),
+        ),
+        prefix_len=0,
+        prompt_len=4,
+    )
+    calls = []
+    manager = object.__new__(MooncakeKVManagerPrefill)
+    manager.kv_args = SimpleNamespace(
+        flat_layout=source_layout,
+        kv_data_ptrs=[0x10000],
+        kv_item_lens=[1024],
+    )
+    manager.engine = SimpleNamespace(
+        batch_transfer_sync=lambda session, src, dst, lengths: (
+            calls.append((session, src, dst, lengths)) or 0
+        )
+    )
+
+    assert (
+        manager.send_kvcache(
+            "session",
+            np.asarray([1, 2, 4], dtype=np.int64),
+            [0x20000],
+            np.asarray([5, 6, 3], dtype=np.int64),
+            None,
+            src_flat_manifest=source_manifest,
+            dst_flat_manifest=destination_manifest,
+            dst_flat_num_pages_with_null=destination_layout.num_pages_with_null,
+            dst_page_zero_offsets=destination_layout.peer.page_zero_offset_map(),
+        )
+        == 0
+    )
+    assert calls[0][1] == [
+        0x10000 + 768 + 1 * 256,
+        0x10000 + 768 + 2 * 256,
+        0x10000 + 2816 + 1 * 256,
+        0x10000 + 2816 + 2 * 256,
+        0x10000 + 512 + 4 * 512,
+    ]
+    assert calls[0][2] == [
+        0x20000 + 768 + 5 * 256,
+        0x20000 + 768 + 6 * 256,
+        0x20000 + 3840 + 5 * 256,
+        0x20000 + 3840 + 6 * 256,
+        0x20000 + 512 + 3 * 512,
     ]
 
 

--- a/test/runtime/distributed/test_flatkv_pd_manifest.py
+++ b/test/runtime/distributed/test_flatkv_pd_manifest.py
@@ -257,6 +257,7 @@ def test_layout_and_manifest_wire_encoding_is_canonical_and_strict() -> None:
     assert json.loads(layout_wire) == {
         "layout_fingerprint": layout.layout_fingerprint,
         "num_pages_with_null": layout.num_pages_with_null,
+        "page_zero_offsets": [],
         "version": FLATKV_PD_PROTOCOL_VERSION,
     }
     assert FlatKVPDPeerLayout.from_wire_bytes(layout_wire) == layout.peer
@@ -329,7 +330,7 @@ def test_manifest_pair_rejects_layout_and_logical_mismatch() -> None:
 
 def test_lcm_group_capacity_uses_its_cache_blocks_per_parent() -> None:
     layout = FlatKVPDLayout(
-        version=1,
+        version=FLATKV_PD_PROTOCOL_VERSION,
         layout_fingerprint=_FINGERPRINT,
         block_size=4,
         # Null parent plus three usable parents.
@@ -448,14 +449,16 @@ def test_registration_validation_rejects_bad_extents() -> None:
         FlatKVPDSLabRegistration(0, "slab.0", (1 << 64) - extent + 1, extent)
 
 
-def test_lcm_contract_registers_one_arena_and_preserves_group_geometry() -> None:
+def _lcm_backing(nbytes: int, data_ptr: int = 0x10000):
     class _Dtype:
         def __str__(self):
             return "torch.uint8"
 
     class _Backing:
         dtype = _Dtype()
-        nbytes = 4096
+
+        def __init__(self):
+            self.nbytes = nbytes
 
         @staticmethod
         def is_contiguous():
@@ -465,14 +468,79 @@ def test_lcm_contract_registers_one_arena_and_preserves_group_geometry() -> None
         def storage_offset():
             return 0
 
-        @staticmethod
-        def data_ptr():
-            return 0x10000
+        def data_ptr(self):
+            return data_ptr
 
-        @staticmethod
-        def untyped_storage():
-            return SimpleNamespace(data_ptr=lambda: 0x10000)
+        def untyped_storage(self):
+            return SimpleNamespace(data_ptr=lambda: data_ptr)
 
+    return _Backing()
+
+
+def _two_plane_lcm_plan(num_lcm_blocks: int):
+    plane_bytes = 512
+    lcm_block_bytes = 1024
+    return SimpleNamespace(
+        logical_block_tokens=4,
+        lcm_block_bytes=lcm_block_bytes,
+        num_lcm_blocks=num_lcm_blocks,
+        arena_bytes=(num_lcm_blocks + 1) * lcm_block_bytes,
+        groups=(
+            SimpleNamespace(
+                group_id="history",
+                cache_blocks_per_lcm_block=2,
+                page_count=1 + num_lcm_blocks * 2,
+            ),
+        ),
+        planes=(
+            SimpleNamespace(
+                plane_id="k",
+                bytes_per_lcm_block=plane_bytes,
+                arena_offset_bytes=0,
+            ),
+            SimpleNamespace(
+                plane_id="v",
+                bytes_per_lcm_block=plane_bytes,
+                arena_offset_bytes=(num_lcm_blocks + 1) * plane_bytes,
+            ),
+        ),
+        fields=(
+            SimpleNamespace(
+                group_id="history",
+                field_id="layer.0.k",
+                plane_id="k",
+                shape=(4, 8),
+                element_size=2,
+                field_offset_bytes=0,
+                page_stride_bytes=256,
+                payload_bytes=64,
+            ),
+            SimpleNamespace(
+                group_id="history",
+                field_id="layer.0.v",
+                plane_id="v",
+                shape=(4, 8),
+                element_size=2,
+                field_offset_bytes=0,
+                page_stride_bytes=256,
+                payload_bytes=64,
+            ),
+        ),
+    )
+
+
+_LCM_SPECS = (
+    SimpleNamespace(
+        group_id="history",
+        family="history",
+        transfer_policy="full_suffix",
+        retention="full_history",
+        sliding_window_tokens=None,
+    ),
+)
+
+
+def test_lcm_contract_registers_one_arena_and_preserves_group_geometry() -> None:
     plan = SimpleNamespace(
         logical_block_tokens=4,
         lcm_block_bytes=1024,
@@ -505,20 +573,11 @@ def test_lcm_contract_registers_one_arena_and_preserves_group_geometry() -> None
             ),
         ),
     )
-    specs = (
-        SimpleNamespace(
-            group_id="history",
-            family="history",
-            transfer_policy="full_suffix",
-            retention="full_history",
-            sliding_window_tokens=None,
-        ),
-    )
 
     layout, registrations = build_lcm_flatkv_pd_contract(
         plan=plan,
-        backing=_Backing(),
-        group_specs=specs,
+        backing=_lcm_backing(4096),
+        group_specs=_LCM_SPECS,
         field_dtypes={"layer.0.k": "bfloat16"},
     )
 
@@ -526,6 +585,44 @@ def test_lcm_contract_registers_one_arena_and_preserves_group_geometry() -> None
     assert layout.groups[0].cache_blocks_per_lcm_block == 2
     assert layout.groups[0].transfer_segments[0].page_zero_offset == 256
     assert registrations == (FlatKVPDSLabRegistration(0, "lcm_arena", 0x10000, 4096),)
+    assert layout.peer.page_zero_offsets[0].page_zero_offset == 256
+
+
+def test_fingerprint_ignores_num_lcm_blocks_but_peer_offsets_differ() -> None:
+    small, _ = build_lcm_flatkv_pd_contract(
+        plan=_two_plane_lcm_plan(3),
+        backing=_lcm_backing(4096),
+        group_specs=_LCM_SPECS,
+        field_dtypes={"layer.0.k": "bfloat16", "layer.0.v": "bfloat16"},
+    )
+    large, _ = build_lcm_flatkv_pd_contract(
+        plan=_two_plane_lcm_plan(5),
+        backing=_lcm_backing(6144, data_ptr=0x20000),
+        group_specs=_LCM_SPECS,
+        field_dtypes={"layer.0.k": "bfloat16", "layer.0.v": "bfloat16"},
+    )
+
+    assert small.layout_fingerprint == large.layout_fingerprint
+    assert small.num_pages_with_null != large.num_pages_with_null
+    assert (
+        small.groups[0].transfer_segments[1].page_zero_offset
+        != large.groups[0].transfer_segments[1].page_zero_offset
+    )
+    validate_flatkv_peer_layout(small, large.peer)
+    assert [offset.field_id for offset in large.peer.page_zero_offsets] == [
+        "layer.0.k",
+        "layer.0.v",
+    ]
+    wire = large.peer.to_wire_bytes()
+    assert FlatKVPDPeerLayout.from_wire_bytes(wire) == large.peer
+
+
+def test_peer_layout_rejects_unsupported_version() -> None:
+    peer = _layout().peer
+    with pytest.raises(
+        FlatKVPDProtocolError, match="unsupported FlatKV layout version"
+    ):
+        replace(peer, version=1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Drop arena_offset from the layout fingerprint (protocol v2) and carry peer-local page_zero_offsets so Mooncake transfers remain correct when P and D size LCM arenas independently.

## Summary
  - Bump FlatKV PD protocol to v2 and drop `arena_offset_bytes` from the layout fingerprint, so Prefill/Decode no
  longer require identical `num_lcm_blocks`.
  - Extend `FlatKVPDPeerLayout` with peer-local `page_zero_offsets`, and make Mooncake transfers use src local offsets
  + dst peer offsets.
  - Add/update unit tests for mismatched N fingerprint compatibility, wire format, and transfer address calculation.
 
 ## Motivation
  In 1P1D serving, Prefill (often eager) and Decode (CUDA graph) commonly end up with different free GPU memory and
  thus different LCM arena sizes. Forcing `min(N)` at startup wastes capacity on the larger side. Capacity pressure
  should surface at request handshake/allocation instead of requiring equal N at process start.

 ## Test plan
  - [x] Unit tests: `test_flatkv_pd_manifest.py`, `test_flatkv_pd_executors.py` (including different-N cases)
  - [x] Deployed Kimi-K3 1P1D with intentional capacity skew (`parents=459` vs `376`) and verified bootstrap +
  Mooncake transfer + chat completion succeed
  - [x] Confirmed no fingerprint/layout mismatch with protocol v2 under mismatched `num_lcm_blocks`