### PR TITLE
ci: add 2-stage workflow

### DIFF
--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -16,6 +16,7 @@ on:
       - ".github/workflows/pr-test-amd.yml"
       - ".github/workflows/pr-test-nvidia.yml"
       - ".github/workflows/pr-test-nvidia-arm.yml"
+      - ".github/workflows/run-pr-test-stage.yml"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
@@ -30,6 +31,7 @@ on:
       - ".github/workflows/pr-test-amd.yml"
       - ".github/workflows/pr-test-nvidia.yml"
       - ".github/workflows/pr-test-nvidia-arm.yml"
+      - ".github/workflows/run-pr-test-stage.yml"
   workflow_dispatch:
     inputs:
       trigger:
@@ -60,8 +62,12 @@ jobs:
       github.repository == vars.TOKENSPEED_CI_REPOSITORY
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.scan.outputs.matrix }}
-      has_tasks: ${{ steps.scan.outputs.has_tasks }}
+      kernel_matrix: ${{ steps.scan.outputs.kernel_matrix }}
+      kernel_has_tasks: ${{ steps.scan.outputs.kernel_has_tasks }}
+      runtime_matrix: ${{ steps.scan.outputs.runtime_matrix }}
+      runtime_has_tasks: ${{ steps.scan.outputs.runtime_has_tasks }}
+      model_matrix: ${{ steps.scan.outputs.model_matrix }}
+      model_has_tasks: ${{ steps.scan.outputs.model_has_tasks }}
       install_tokenspeed_mla_from_source: ${{ steps.detect_mla.outputs.changed }}
     steps:
       - name: Checkout code
@@ -83,16 +89,24 @@ jobs:
         env:
           TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS: ${{ vars.TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS }}
         run: |
-          MATRIX=$(python3 test/ci_system/pipeline.py scan \
-            --root test/ci \
-            --trigger "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.trigger || 'per-commit' }}" \
-            --runner-group "amd")
-          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
-          printf '%s' "$MATRIX" | python3 -c "import json, sys; print('has_tasks=' + ('true' if json.load(sys.stdin).get('include') else 'false'))" >> "$GITHUB_OUTPUT"
+          for stage in \
+            kernel:kernel-test \
+            runtime:runtime-test \
+            model:model-test; do
+            output=${stage%%:*}
+            workflow_stage=${stage#*:}
+            matrix=$(python3 test/ci_system/pipeline.py scan \
+              --root test/ci \
+              --trigger "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.trigger || 'per-commit' }}" \
+              --runner-group "amd" \
+              --workflow-stage "$workflow_stage")
+            echo "${output}_matrix=${matrix}" >> "$GITHUB_OUTPUT"
+            printf '%s' "$matrix" | python3 -c "import json, sys; print('${output}_has_tasks=' + ('true' if json.load(sys.stdin).get('include') else 'false'))" >> "$GITHUB_OUTPUT"
+          done
 
       # Compute this once on the hosted runner (where `gh` is pre-installed)
       # and propagate the result to every matrix job via job output. The
-      # downstream unit-test job reads it as an env var and `install_deps.sh`
+      # downstream stage jobs read it as an env var and `install_deps.sh`
       # gates its in-tree `tokenspeed-mla` reinstall on it. Without this
       # detection, CI would always exercise the pinned PyPI wheel and edits
       # under `tokenspeed-mla/` would be silently uncovered.
@@ -125,10 +139,10 @@ jobs:
             echo "changed=0" >> "$GITHUB_OUTPUT"
           fi
 
-  unit-test:
+  kernel-test:
     needs: scan
     if: |
-      needs.scan.outputs.has_tasks == 'true' &&
+      needs.scan.outputs.kernel_has_tasks == 'true' &&
       (github.event_name != 'pull_request' || github.event.action != 'closed') &&
       (
         github.event_name == 'pull_request' ||
@@ -139,88 +153,52 @@ jobs:
         github.event_name != 'pull_request' ||
         github.event.pull_request.draft == false
       )
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.scan.outputs.matrix) }}
-    name: ${{ matrix.name }} (${{ matrix.runner }})
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
-    continue-on-error: ${{ matrix.optional }}
-    env:
-      # When the scan job determined that this run touched `tokenspeed-mla/`,
-      # `install_deps.sh` will reinstall the in-tree source on top of the
-      # pinned PyPI wheel. See the matching detect step in the `scan` job.
-      INSTALL_TOKENSPEED_MLA_FROM_SOURCE: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
-      # Authenticate Hugging Face Hub downloads so checkpoint pulls during
-      # `ts serve` startup are not throttled by the anonymous rate limit. The
-      # 600s per-file `runtime-1gpu` timeout is otherwise exceeded on cold
-      # runners (e.g. `amd-mi35x-1gpu-test` loading `openai/gpt-oss-120b` +
-      # EAGLE3 draft).
-      HF_TOKEN: ${{ secrets.HF_TOKEN }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          path: run-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}-${{ matrix.runner }}
+    uses: ./.github/workflows/run-pr-test-stage.yml
+    with:
+      matrix: ${{ needs.scan.outputs.kernel_matrix }}
+      install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
+      b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL }}
+    secrets: inherit
 
-      - name: Set work directory
-        run: |
-          echo "WORK_DIR=${{ github.workspace }}/run-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}-${{ matrix.runner }}" >> "$GITHUB_ENV"
+  runtime-test:
+    needs: [scan, kernel-test]
+    if: |
+      !cancelled() &&
+      needs.scan.result == 'success' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (
+        needs.kernel-test.result == 'success' ||
+        needs.scan.outputs.kernel_has_tasks != 'true'
+      ) &&
+      needs.scan.outputs.runtime_has_tasks == 'true'
+    uses: ./.github/workflows/run-pr-test-stage.yml
+    with:
+      matrix: ${{ needs.scan.outputs.runtime_matrix }}
+      install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
+      b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL }}
+    secrets: inherit
 
-      - name: Install pipeline dependency
-        # See note in the scan job — pypi.org "Content-Type: Unknown" flake.
-        run: |
-          for i in 1 2 3 4 5; do
-            python3 -m pip install pyyaml && exit 0
-            echo "pyyaml install attempt $i failed, retrying in 10s..."
-            sleep 10
-          done
-          exit 1
-
-      # When the diff touches `tokenspeed-mla/`, ask install_deps.sh to
-      # rebuild + install that package from the in-tree source after the
-      # pinned PyPI wheel has been installed (transitively via
-      # tokenspeed-kernel). Without this, CI keeps testing whichever
-      # `tokenspeed-mla` version is pinned in
-      # `tokenspeed-kernel/python/requirements/cuda-thirdparty.txt`, not
-      # the code on the PR/branch. When the diff doesn't touch
-      # `tokenspeed-mla/` we keep using the pinned PyPI wheel.
-      - name: Install CI task
-        run: |
-          cd "${{ env.WORK_DIR }}"
-          mkdir -p .ci-artifacts
-          python3 test/ci_system/pipeline.py execute \
-            --config "${{ matrix.config }}" \
-            --runner "${{ matrix.runner }}" \
-            --work-dir "${{ env.WORK_DIR }}" \
-            --print-plan \
-            --only-stage install \
-            --keep-runner-state \
-            --result-json .ci-artifacts/result.json
-
-      - name: Execute CI task
-        run: |
-          cd "${{ env.WORK_DIR }}"
-          mkdir -p .ci-artifacts
-          python3 test/ci_system/pipeline.py execute \
-            --config "${{ matrix.config }}" \
-            --runner "${{ matrix.runner }}" \
-            --work-dir "${{ env.WORK_DIR }}" \
-            --print-plan \
-            --skip-stage install \
-            --reuse-runner-state \
-            --result-json .ci-artifacts/result.json
-
-      - name: Upload task result
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: pr-test-${{ matrix.name }}-${{ matrix.runner }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ env.WORK_DIR }}/.ci-artifacts/result.json
-
-      - name: Cleanup work directory
-        if: always()
-        run: rm -rf "${{ env.WORK_DIR }}"
+  model-test:
+    needs: [scan, kernel-test, runtime-test]
+    if: |
+      !cancelled() &&
+      needs.scan.result == 'success' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (
+        needs.kernel-test.result == 'success' ||
+        needs.scan.outputs.kernel_has_tasks != 'true'
+      ) &&
+      (
+        needs.runtime-test.result == 'success' ||
+        needs.scan.outputs.runtime_has_tasks != 'true'
+      ) &&
+      needs.scan.outputs.model_has_tasks == 'true'
+    uses: ./.github/workflows/run-pr-test-stage.yml
+    with:
+      matrix: ${{ needs.scan.outputs.model_matrix }}
+      install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
+      b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL }}
+    secrets: inherit
 
   finish:
     if: |
@@ -231,7 +209,7 @@ jobs:
         github.repository == 'lightseekorg/tokenspeed' ||
         github.repository == vars.TOKENSPEED_CI_REPOSITORY
       )
-    needs: [unit-test]
+    needs: [kernel-test, runtime-test, model-test]
     runs-on: ubuntu-latest
     steps:
       - name: Finish

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -62,10 +62,8 @@ jobs:
       github.repository == vars.TOKENSPEED_CI_REPOSITORY
     runs-on: ubuntu-latest
     outputs:
-      kernel_matrix: ${{ steps.scan.outputs.kernel_matrix }}
-      kernel_has_tasks: ${{ steps.scan.outputs.kernel_has_tasks }}
-      runtime_matrix: ${{ steps.scan.outputs.runtime_matrix }}
-      runtime_has_tasks: ${{ steps.scan.outputs.runtime_has_tasks }}
+      unit_matrix: ${{ steps.scan.outputs.unit_matrix }}
+      unit_has_tasks: ${{ steps.scan.outputs.unit_has_tasks }}
       model_matrix: ${{ steps.scan.outputs.model_matrix }}
       model_has_tasks: ${{ steps.scan.outputs.model_has_tasks }}
       install_tokenspeed_mla_from_source: ${{ steps.detect_mla.outputs.changed }}
@@ -90,8 +88,7 @@ jobs:
           TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS: ${{ vars.TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS }}
         run: |
           for stage in \
-            kernel:kernel-test \
-            runtime:runtime-test \
+            unit:unit-test \
             model:model-test; do
             output=${stage%%:*}
             workflow_stage=${stage#*:}
@@ -139,10 +136,10 @@ jobs:
             echo "changed=0" >> "$GITHUB_OUTPUT"
           fi
 
-  kernel-test:
+  unit-test:
     needs: scan
     if: |
-      needs.scan.outputs.kernel_has_tasks == 'true' &&
+      needs.scan.outputs.unit_has_tasks == 'true' &&
       (github.event_name != 'pull_request' || github.event.action != 'closed') &&
       (
         github.event_name == 'pull_request' ||
@@ -155,42 +152,20 @@ jobs:
       )
     uses: ./.github/workflows/run-pr-test-stage.yml
     with:
-      matrix: ${{ needs.scan.outputs.kernel_matrix }}
-      install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
-      b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL }}
-    secrets: inherit
-
-  runtime-test:
-    needs: [scan, kernel-test]
-    if: |
-      !cancelled() &&
-      needs.scan.result == 'success' &&
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      (
-        needs.kernel-test.result == 'success' ||
-        needs.scan.outputs.kernel_has_tasks != 'true'
-      ) &&
-      needs.scan.outputs.runtime_has_tasks == 'true'
-    uses: ./.github/workflows/run-pr-test-stage.yml
-    with:
-      matrix: ${{ needs.scan.outputs.runtime_matrix }}
+      matrix: ${{ needs.scan.outputs.unit_matrix }}
       install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
       b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL }}
     secrets: inherit
 
   model-test:
-    needs: [scan, kernel-test, runtime-test]
+    needs: [scan, unit-test]
     if: |
       !cancelled() &&
       needs.scan.result == 'success' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       (
-        needs.kernel-test.result == 'success' ||
-        needs.scan.outputs.kernel_has_tasks != 'true'
-      ) &&
-      (
-        needs.runtime-test.result == 'success' ||
-        needs.scan.outputs.runtime_has_tasks != 'true'
+        needs.unit-test.result == 'success' ||
+        needs.scan.outputs.unit_has_tasks != 'true'
       ) &&
       needs.scan.outputs.model_has_tasks == 'true'
     uses: ./.github/workflows/run-pr-test-stage.yml
@@ -209,7 +184,7 @@ jobs:
         github.repository == 'lightseekorg/tokenspeed' ||
         github.repository == vars.TOKENSPEED_CI_REPOSITORY
       )
-    needs: [kernel-test, runtime-test, model-test]
+    needs: [unit-test, model-test]
     runs-on: ubuntu-latest
     steps:
       - name: Finish

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -18,7 +18,7 @@ on:
       - ".github/workflows/pr-test-nvidia-arm.yml"
       - ".github/workflows/run-pr-test-stage.yml"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
     branches: [main]
     paths:
       - "python/pyproject.toml"
@@ -57,15 +57,19 @@ jobs:
     # Run jobs for pull requests, or for push/manual events in the official
     # repository or a repository whose full name matches TOKENSPEED_CI_REPOSITORY.
     if: |
-      github.event_name == 'pull_request' ||
-      github.repository == 'lightseekorg/tokenspeed' ||
-      github.repository == vars.TOKENSPEED_CI_REPOSITORY
+      (github.event.action != 'labeled' || github.event.label.name == 'high priority') &&
+      (
+        github.event_name == 'pull_request' ||
+        github.repository == 'lightseekorg/tokenspeed' ||
+        github.repository == vars.TOKENSPEED_CI_REPOSITORY
+      )
     runs-on: ubuntu-latest
     outputs:
       unit_matrix: ${{ steps.scan.outputs.unit_matrix }}
       unit_has_tasks: ${{ steps.scan.outputs.unit_has_tasks }}
       model_matrix: ${{ steps.scan.outputs.model_matrix }}
       model_has_tasks: ${{ steps.scan.outputs.model_has_tasks }}
+      eager_model: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'high priority') }}
       install_tokenspeed_mla_from_source: ${{ steps.detect_mla.outputs.changed }}
     steps:
       - name: Checkout code
@@ -163,10 +167,24 @@ jobs:
       !cancelled() &&
       needs.scan.result == 'success' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      needs.scan.outputs.eager_model != 'true' &&
       (
         needs.unit-test.result == 'success' ||
         needs.scan.outputs.unit_has_tasks != 'true'
       ) &&
+      needs.scan.outputs.model_has_tasks == 'true'
+    uses: ./.github/workflows/run-pr-test-stage.yml
+    with:
+      matrix: ${{ needs.scan.outputs.model_matrix }}
+      install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
+      b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL }}
+    secrets: inherit
+
+  model-test-eager:
+    needs: scan
+    if: |
+      needs.scan.outputs.eager_model == 'true' &&
+      github.event.pull_request.draft == false &&
       needs.scan.outputs.model_has_tasks == 'true'
     uses: ./.github/workflows/run-pr-test-stage.yml
     with:
@@ -183,8 +201,9 @@ jobs:
         github.event_name == 'pull_request' ||
         github.repository == 'lightseekorg/tokenspeed' ||
         github.repository == vars.TOKENSPEED_CI_REPOSITORY
-      )
-    needs: [unit-test, model-test]
+      ) &&
+      (github.event.action != 'labeled' || github.event.label.name == 'high priority')
+    needs: [unit-test, model-test, model-test-eager]
     runs-on: ubuntu-latest
     steps:
       - name: Finish

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -49,7 +49,7 @@ env:
   TOKENSPEED_B200_RUNNER_LABEL: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL }}
 
 concurrency:
-  group: pr-test-amd-${{ github.event.pull_request.number || github.ref }}
+  group: pr-test-amd-${{ github.event.pull_request.number || github.ref }}${{ github.event.action == 'labeled' && github.event.label.name != 'high priority' && format('-ignored-label-{0}', github.run_id) || '' }}
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:

--- a/.github/workflows/pr-test-nvidia-arm.yml
+++ b/.github/workflows/pr-test-nvidia-arm.yml
@@ -16,6 +16,7 @@ on:
       - ".github/workflows/pr-test-amd.yml"
       - ".github/workflows/pr-test-nvidia.yml"
       - ".github/workflows/pr-test-nvidia-arm.yml"
+      - ".github/workflows/run-pr-test-stage.yml"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
@@ -30,6 +31,7 @@ on:
       - ".github/workflows/pr-test-amd.yml"
       - ".github/workflows/pr-test-nvidia.yml"
       - ".github/workflows/pr-test-nvidia-arm.yml"
+      - ".github/workflows/run-pr-test-stage.yml"
   workflow_dispatch:
     inputs:
       trigger:
@@ -60,8 +62,12 @@ jobs:
       github.repository == vars.TOKENSPEED_CI_REPOSITORY
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.scan.outputs.matrix }}
-      has_tasks: ${{ steps.scan.outputs.has_tasks }}
+      kernel_matrix: ${{ steps.scan.outputs.kernel_matrix }}
+      kernel_has_tasks: ${{ steps.scan.outputs.kernel_has_tasks }}
+      runtime_matrix: ${{ steps.scan.outputs.runtime_matrix }}
+      runtime_has_tasks: ${{ steps.scan.outputs.runtime_has_tasks }}
+      model_matrix: ${{ steps.scan.outputs.model_matrix }}
+      model_has_tasks: ${{ steps.scan.outputs.model_has_tasks }}
       install_tokenspeed_mla_from_source: ${{ steps.detect_mla.outputs.changed }}
     steps:
       - name: Checkout code
@@ -83,16 +89,24 @@ jobs:
         env:
           TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS: ${{ vars.TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS }}
         run: |
-          MATRIX=$(python3 test/ci_system/pipeline.py scan \
-            --root test/ci \
-            --trigger "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.trigger || 'per-commit' }}" \
-            --runner-group "nvidia-arm")
-          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
-          printf '%s' "$MATRIX" | python3 -c "import json, sys; print('has_tasks=' + ('true' if json.load(sys.stdin).get('include') else 'false'))" >> "$GITHUB_OUTPUT"
+          for stage in \
+            kernel:kernel-test \
+            runtime:runtime-test \
+            model:model-test; do
+            output=${stage%%:*}
+            workflow_stage=${stage#*:}
+            matrix=$(python3 test/ci_system/pipeline.py scan \
+              --root test/ci \
+              --trigger "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.trigger || 'per-commit' }}" \
+              --runner-group "nvidia-arm" \
+              --workflow-stage "$workflow_stage")
+            echo "${output}_matrix=${matrix}" >> "$GITHUB_OUTPUT"
+            printf '%s' "$matrix" | python3 -c "import json, sys; print('${output}_has_tasks=' + ('true' if json.load(sys.stdin).get('include') else 'false'))" >> "$GITHUB_OUTPUT"
+          done
 
       # Compute this once on the hosted runner (where `gh` is pre-installed)
       # and propagate the result to every matrix job via job output. The
-      # downstream unit-test job reads it as an env var and `install_deps.sh`
+      # downstream stage jobs read it as an env var and `install_deps.sh`
       # gates its in-tree `tokenspeed-mla` reinstall on it. Without this
       # detection, CI would always exercise the pinned PyPI wheel and edits
       # under `tokenspeed-mla/` would be silently uncovered.
@@ -125,10 +139,10 @@ jobs:
             echo "changed=0" >> "$GITHUB_OUTPUT"
           fi
 
-  unit-test:
+  kernel-test:
     needs: scan
     if: |
-      needs.scan.outputs.has_tasks == 'true' &&
+      needs.scan.outputs.kernel_has_tasks == 'true' &&
       (github.event_name != 'pull_request' || github.event.action != 'closed') &&
       (
         github.event_name == 'pull_request' ||
@@ -139,88 +153,52 @@ jobs:
         github.event_name != 'pull_request' ||
         github.event.pull_request.draft == false
       )
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.scan.outputs.matrix) }}
-    name: ${{ matrix.name }} (${{ matrix.runner }})
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
-    continue-on-error: ${{ matrix.optional }}
-    env:
-      # When the scan job determined that this run touched `tokenspeed-mla/`,
-      # `install_deps.sh` will reinstall the in-tree source on top of the
-      # pinned PyPI wheel. See the matching detect step in the `scan` job.
-      INSTALL_TOKENSPEED_MLA_FROM_SOURCE: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
-      # Authenticate Hugging Face Hub downloads so checkpoint pulls during
-      # `ts serve` startup are not throttled by the anonymous rate limit. The
-      # 600s per-file `runtime-1gpu` timeout is otherwise exceeded on cold
-      # runners (e.g. `amd-mi35x-1gpu-test` loading `openai/gpt-oss-120b` +
-      # EAGLE3 draft).
-      HF_TOKEN: ${{ secrets.HF_TOKEN }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          path: run-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}-${{ matrix.runner }}
+    uses: ./.github/workflows/run-pr-test-stage.yml
+    with:
+      matrix: ${{ needs.scan.outputs.kernel_matrix }}
+      install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
+      b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL }}
+    secrets: inherit
 
-      - name: Set work directory
-        run: |
-          echo "WORK_DIR=${{ github.workspace }}/run-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}-${{ matrix.runner }}" >> "$GITHUB_ENV"
+  runtime-test:
+    needs: [scan, kernel-test]
+    if: |
+      !cancelled() &&
+      needs.scan.result == 'success' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (
+        needs.kernel-test.result == 'success' ||
+        needs.scan.outputs.kernel_has_tasks != 'true'
+      ) &&
+      needs.scan.outputs.runtime_has_tasks == 'true'
+    uses: ./.github/workflows/run-pr-test-stage.yml
+    with:
+      matrix: ${{ needs.scan.outputs.runtime_matrix }}
+      install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
+      b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL }}
+    secrets: inherit
 
-      - name: Install pipeline dependency
-        # See note in the scan job — pypi.org "Content-Type: Unknown" flake.
-        run: |
-          for i in 1 2 3 4 5; do
-            python3 -m pip install pyyaml && exit 0
-            echo "pyyaml install attempt $i failed, retrying in 10s..."
-            sleep 10
-          done
-          exit 1
-
-      # When the diff touches `tokenspeed-mla/`, ask install_deps.sh to
-      # rebuild + install that package from the in-tree source after the
-      # pinned PyPI wheel has been installed (transitively via
-      # tokenspeed-kernel). Without this, CI keeps testing whichever
-      # `tokenspeed-mla` version is pinned in
-      # `tokenspeed-kernel/python/requirements/cuda-thirdparty.txt`, not
-      # the code on the PR/branch. When the diff doesn't touch
-      # `tokenspeed-mla/` we keep using the pinned PyPI wheel.
-      - name: Install CI task
-        run: |
-          cd "${{ env.WORK_DIR }}"
-          mkdir -p .ci-artifacts
-          python3 test/ci_system/pipeline.py execute \
-            --config "${{ matrix.config }}" \
-            --runner "${{ matrix.runner }}" \
-            --work-dir "${{ env.WORK_DIR }}" \
-            --print-plan \
-            --only-stage install \
-            --keep-runner-state \
-            --result-json .ci-artifacts/result.json
-
-      - name: Execute CI task
-        run: |
-          cd "${{ env.WORK_DIR }}"
-          mkdir -p .ci-artifacts
-          python3 test/ci_system/pipeline.py execute \
-            --config "${{ matrix.config }}" \
-            --runner "${{ matrix.runner }}" \
-            --work-dir "${{ env.WORK_DIR }}" \
-            --print-plan \
-            --skip-stage install \
-            --reuse-runner-state \
-            --result-json .ci-artifacts/result.json
-
-      - name: Upload task result
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: pr-test-${{ matrix.name }}-${{ matrix.runner }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ env.WORK_DIR }}/.ci-artifacts/result.json
-
-      - name: Cleanup work directory
-        if: always()
-        run: rm -rf "${{ env.WORK_DIR }}"
+  model-test:
+    needs: [scan, kernel-test, runtime-test]
+    if: |
+      !cancelled() &&
+      needs.scan.result == 'success' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (
+        needs.kernel-test.result == 'success' ||
+        needs.scan.outputs.kernel_has_tasks != 'true'
+      ) &&
+      (
+        needs.runtime-test.result == 'success' ||
+        needs.scan.outputs.runtime_has_tasks != 'true'
+      ) &&
+      needs.scan.outputs.model_has_tasks == 'true'
+    uses: ./.github/workflows/run-pr-test-stage.yml
+    with:
+      matrix: ${{ needs.scan.outputs.model_matrix }}
+      install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
+      b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL }}
+    secrets: inherit
 
   finish:
     if: |
@@ -231,7 +209,7 @@ jobs:
         github.repository == 'lightseekorg/tokenspeed' ||
         github.repository == vars.TOKENSPEED_CI_REPOSITORY
       )
-    needs: [unit-test]
+    needs: [kernel-test, runtime-test, model-test]
     runs-on: ubuntu-latest
     steps:
       - name: Finish

--- a/.github/workflows/pr-test-nvidia-arm.yml
+++ b/.github/workflows/pr-test-nvidia-arm.yml
@@ -62,10 +62,8 @@ jobs:
       github.repository == vars.TOKENSPEED_CI_REPOSITORY
     runs-on: ubuntu-latest
     outputs:
-      kernel_matrix: ${{ steps.scan.outputs.kernel_matrix }}
-      kernel_has_tasks: ${{ steps.scan.outputs.kernel_has_tasks }}
-      runtime_matrix: ${{ steps.scan.outputs.runtime_matrix }}
-      runtime_has_tasks: ${{ steps.scan.outputs.runtime_has_tasks }}
+      unit_matrix: ${{ steps.scan.outputs.unit_matrix }}
+      unit_has_tasks: ${{ steps.scan.outputs.unit_has_tasks }}
       model_matrix: ${{ steps.scan.outputs.model_matrix }}
       model_has_tasks: ${{ steps.scan.outputs.model_has_tasks }}
       install_tokenspeed_mla_from_source: ${{ steps.detect_mla.outputs.changed }}
@@ -90,8 +88,7 @@ jobs:
           TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS: ${{ vars.TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS }}
         run: |
           for stage in \
-            kernel:kernel-test \
-            runtime:runtime-test \
+            unit:unit-test \
             model:model-test; do
             output=${stage%%:*}
             workflow_stage=${stage#*:}
@@ -139,10 +136,10 @@ jobs:
             echo "changed=0" >> "$GITHUB_OUTPUT"
           fi
 
-  kernel-test:
+  unit-test:
     needs: scan
     if: |
-      needs.scan.outputs.kernel_has_tasks == 'true' &&
+      needs.scan.outputs.unit_has_tasks == 'true' &&
       (github.event_name != 'pull_request' || github.event.action != 'closed') &&
       (
         github.event_name == 'pull_request' ||
@@ -155,42 +152,20 @@ jobs:
       )
     uses: ./.github/workflows/run-pr-test-stage.yml
     with:
-      matrix: ${{ needs.scan.outputs.kernel_matrix }}
-      install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
-      b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL }}
-    secrets: inherit
-
-  runtime-test:
-    needs: [scan, kernel-test]
-    if: |
-      !cancelled() &&
-      needs.scan.result == 'success' &&
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      (
-        needs.kernel-test.result == 'success' ||
-        needs.scan.outputs.kernel_has_tasks != 'true'
-      ) &&
-      needs.scan.outputs.runtime_has_tasks == 'true'
-    uses: ./.github/workflows/run-pr-test-stage.yml
-    with:
-      matrix: ${{ needs.scan.outputs.runtime_matrix }}
+      matrix: ${{ needs.scan.outputs.unit_matrix }}
       install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
       b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL }}
     secrets: inherit
 
   model-test:
-    needs: [scan, kernel-test, runtime-test]
+    needs: [scan, unit-test]
     if: |
       !cancelled() &&
       needs.scan.result == 'success' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       (
-        needs.kernel-test.result == 'success' ||
-        needs.scan.outputs.kernel_has_tasks != 'true'
-      ) &&
-      (
-        needs.runtime-test.result == 'success' ||
-        needs.scan.outputs.runtime_has_tasks != 'true'
+        needs.unit-test.result == 'success' ||
+        needs.scan.outputs.unit_has_tasks != 'true'
       ) &&
       needs.scan.outputs.model_has_tasks == 'true'
     uses: ./.github/workflows/run-pr-test-stage.yml
@@ -209,7 +184,7 @@ jobs:
         github.repository == 'lightseekorg/tokenspeed' ||
         github.repository == vars.TOKENSPEED_CI_REPOSITORY
       )
-    needs: [kernel-test, runtime-test, model-test]
+    needs: [unit-test, model-test]
     runs-on: ubuntu-latest
     steps:
       - name: Finish

--- a/.github/workflows/pr-test-nvidia-arm.yml
+++ b/.github/workflows/pr-test-nvidia-arm.yml
@@ -49,7 +49,7 @@ env:
   TOKENSPEED_B200_RUNNER_LABEL: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL }}
 
 concurrency:
-  group: pr-test-nvidia-arm-${{ github.event.pull_request.number || github.ref }}
+  group: pr-test-nvidia-arm-${{ github.event.pull_request.number || github.ref }}${{ github.event.action == 'labeled' && github.event.label.name != 'high priority' && format('-ignored-label-{0}', github.run_id) || '' }}
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:

--- a/.github/workflows/pr-test-nvidia-arm.yml
+++ b/.github/workflows/pr-test-nvidia-arm.yml
@@ -18,7 +18,7 @@ on:
       - ".github/workflows/pr-test-nvidia-arm.yml"
       - ".github/workflows/run-pr-test-stage.yml"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
     branches: [main]
     paths:
       - "python/pyproject.toml"
@@ -57,15 +57,19 @@ jobs:
     # Run jobs for pull requests, or for push/manual events in the official
     # repository or a repository whose full name matches TOKENSPEED_CI_REPOSITORY.
     if: |
-      github.event_name == 'pull_request' ||
-      github.repository == 'lightseekorg/tokenspeed' ||
-      github.repository == vars.TOKENSPEED_CI_REPOSITORY
+      (github.event.action != 'labeled' || github.event.label.name == 'high priority') &&
+      (
+        github.event_name == 'pull_request' ||
+        github.repository == 'lightseekorg/tokenspeed' ||
+        github.repository == vars.TOKENSPEED_CI_REPOSITORY
+      )
     runs-on: ubuntu-latest
     outputs:
       unit_matrix: ${{ steps.scan.outputs.unit_matrix }}
       unit_has_tasks: ${{ steps.scan.outputs.unit_has_tasks }}
       model_matrix: ${{ steps.scan.outputs.model_matrix }}
       model_has_tasks: ${{ steps.scan.outputs.model_has_tasks }}
+      eager_model: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'high priority') }}
       install_tokenspeed_mla_from_source: ${{ steps.detect_mla.outputs.changed }}
     steps:
       - name: Checkout code
@@ -163,10 +167,24 @@ jobs:
       !cancelled() &&
       needs.scan.result == 'success' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      needs.scan.outputs.eager_model != 'true' &&
       (
         needs.unit-test.result == 'success' ||
         needs.scan.outputs.unit_has_tasks != 'true'
       ) &&
+      needs.scan.outputs.model_has_tasks == 'true'
+    uses: ./.github/workflows/run-pr-test-stage.yml
+    with:
+      matrix: ${{ needs.scan.outputs.model_matrix }}
+      install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
+      b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL }}
+    secrets: inherit
+
+  model-test-eager:
+    needs: scan
+    if: |
+      needs.scan.outputs.eager_model == 'true' &&
+      github.event.pull_request.draft == false &&
       needs.scan.outputs.model_has_tasks == 'true'
     uses: ./.github/workflows/run-pr-test-stage.yml
     with:
@@ -183,8 +201,9 @@ jobs:
         github.event_name == 'pull_request' ||
         github.repository == 'lightseekorg/tokenspeed' ||
         github.repository == vars.TOKENSPEED_CI_REPOSITORY
-      )
-    needs: [unit-test, model-test]
+      ) &&
+      (github.event.action != 'labeled' || github.event.label.name == 'high priority')
+    needs: [unit-test, model-test, model-test-eager]
     runs-on: ubuntu-latest
     steps:
       - name: Finish

--- a/.github/workflows/pr-test-nvidia.yml
+++ b/.github/workflows/pr-test-nvidia.yml
@@ -49,7 +49,7 @@ env:
   TOKENSPEED_B200_RUNNER_LABEL: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL || 'b200v2' }}
 
 concurrency:
-  group: pr-test-nvidia-${{ github.event.pull_request.number || github.ref }}
+  group: pr-test-nvidia-${{ github.event.pull_request.number || github.ref }}${{ github.event.action == 'labeled' && github.event.label.name != 'high priority' && format('-ignored-label-{0}', github.run_id) || '' }}
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:

--- a/.github/workflows/pr-test-nvidia.yml
+++ b/.github/workflows/pr-test-nvidia.yml
@@ -62,10 +62,8 @@ jobs:
       github.repository == vars.TOKENSPEED_CI_REPOSITORY
     runs-on: ubuntu-latest
     outputs:
-      kernel_matrix: ${{ steps.scan.outputs.kernel_matrix }}
-      kernel_has_tasks: ${{ steps.scan.outputs.kernel_has_tasks }}
-      runtime_matrix: ${{ steps.scan.outputs.runtime_matrix }}
-      runtime_has_tasks: ${{ steps.scan.outputs.runtime_has_tasks }}
+      unit_matrix: ${{ steps.scan.outputs.unit_matrix }}
+      unit_has_tasks: ${{ steps.scan.outputs.unit_has_tasks }}
       model_matrix: ${{ steps.scan.outputs.model_matrix }}
       model_has_tasks: ${{ steps.scan.outputs.model_has_tasks }}
       install_tokenspeed_mla_from_source: ${{ steps.detect_mla.outputs.changed }}
@@ -90,8 +88,7 @@ jobs:
           TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS: h100,${{ vars.TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS }}
         run: |
           for stage in \
-            kernel:kernel-test \
-            runtime:runtime-test \
+            unit:unit-test \
             model:model-test; do
             output=${stage%%:*}
             workflow_stage=${stage#*:}
@@ -139,10 +136,10 @@ jobs:
             echo "changed=0" >> "$GITHUB_OUTPUT"
           fi
 
-  kernel-test:
+  unit-test:
     needs: scan
     if: |
-      needs.scan.outputs.kernel_has_tasks == 'true' &&
+      needs.scan.outputs.unit_has_tasks == 'true' &&
       (github.event_name != 'pull_request' || github.event.action != 'closed') &&
       (
         github.event_name == 'pull_request' ||
@@ -155,42 +152,20 @@ jobs:
       )
     uses: ./.github/workflows/run-pr-test-stage.yml
     with:
-      matrix: ${{ needs.scan.outputs.kernel_matrix }}
-      install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
-      b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL || 'b200v2' }}
-    secrets: inherit
-
-  runtime-test:
-    needs: [scan, kernel-test]
-    if: |
-      !cancelled() &&
-      needs.scan.result == 'success' &&
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      (
-        needs.kernel-test.result == 'success' ||
-        needs.scan.outputs.kernel_has_tasks != 'true'
-      ) &&
-      needs.scan.outputs.runtime_has_tasks == 'true'
-    uses: ./.github/workflows/run-pr-test-stage.yml
-    with:
-      matrix: ${{ needs.scan.outputs.runtime_matrix }}
+      matrix: ${{ needs.scan.outputs.unit_matrix }}
       install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
       b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL || 'b200v2' }}
     secrets: inherit
 
   model-test:
-    needs: [scan, kernel-test, runtime-test]
+    needs: [scan, unit-test]
     if: |
       !cancelled() &&
       needs.scan.result == 'success' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       (
-        needs.kernel-test.result == 'success' ||
-        needs.scan.outputs.kernel_has_tasks != 'true'
-      ) &&
-      (
-        needs.runtime-test.result == 'success' ||
-        needs.scan.outputs.runtime_has_tasks != 'true'
+        needs.unit-test.result == 'success' ||
+        needs.scan.outputs.unit_has_tasks != 'true'
       ) &&
       needs.scan.outputs.model_has_tasks == 'true'
     uses: ./.github/workflows/run-pr-test-stage.yml
@@ -209,7 +184,7 @@ jobs:
         github.repository == 'lightseekorg/tokenspeed' ||
         github.repository == vars.TOKENSPEED_CI_REPOSITORY
       )
-    needs: [kernel-test, runtime-test, model-test]
+    needs: [unit-test, model-test]
     runs-on: ubuntu-latest
     steps:
       - name: Finish

--- a/.github/workflows/pr-test-nvidia.yml
+++ b/.github/workflows/pr-test-nvidia.yml
@@ -16,6 +16,7 @@ on:
       - ".github/workflows/pr-test-amd.yml"
       - ".github/workflows/pr-test-nvidia.yml"
       - ".github/workflows/pr-test-nvidia-arm.yml"
+      - ".github/workflows/run-pr-test-stage.yml"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
@@ -30,6 +31,7 @@ on:
       - ".github/workflows/pr-test-amd.yml"
       - ".github/workflows/pr-test-nvidia.yml"
       - ".github/workflows/pr-test-nvidia-arm.yml"
+      - ".github/workflows/run-pr-test-stage.yml"
   workflow_dispatch:
     inputs:
       trigger:
@@ -60,8 +62,12 @@ jobs:
       github.repository == vars.TOKENSPEED_CI_REPOSITORY
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.scan.outputs.matrix }}
-      has_tasks: ${{ steps.scan.outputs.has_tasks }}
+      kernel_matrix: ${{ steps.scan.outputs.kernel_matrix }}
+      kernel_has_tasks: ${{ steps.scan.outputs.kernel_has_tasks }}
+      runtime_matrix: ${{ steps.scan.outputs.runtime_matrix }}
+      runtime_has_tasks: ${{ steps.scan.outputs.runtime_has_tasks }}
+      model_matrix: ${{ steps.scan.outputs.model_matrix }}
+      model_has_tasks: ${{ steps.scan.outputs.model_has_tasks }}
       install_tokenspeed_mla_from_source: ${{ steps.detect_mla.outputs.changed }}
     steps:
       - name: Checkout code
@@ -83,16 +89,24 @@ jobs:
         env:
           TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS: h100,${{ vars.TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS }}
         run: |
-          MATRIX=$(python3 test/ci_system/pipeline.py scan \
-            --root test/ci \
-            --trigger "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.trigger || 'per-commit' }}" \
-            --runner-group "nvidia-x86")
-          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
-          printf '%s' "$MATRIX" | python3 -c "import json, sys; print('has_tasks=' + ('true' if json.load(sys.stdin).get('include') else 'false'))" >> "$GITHUB_OUTPUT"
+          for stage in \
+            kernel:kernel-test \
+            runtime:runtime-test \
+            model:model-test; do
+            output=${stage%%:*}
+            workflow_stage=${stage#*:}
+            matrix=$(python3 test/ci_system/pipeline.py scan \
+              --root test/ci \
+              --trigger "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.trigger || 'per-commit' }}" \
+              --runner-group "nvidia-x86" \
+              --workflow-stage "$workflow_stage")
+            echo "${output}_matrix=${matrix}" >> "$GITHUB_OUTPUT"
+            printf '%s' "$matrix" | python3 -c "import json, sys; print('${output}_has_tasks=' + ('true' if json.load(sys.stdin).get('include') else 'false'))" >> "$GITHUB_OUTPUT"
+          done
 
       # Compute this once on the hosted runner (where `gh` is pre-installed)
       # and propagate the result to every matrix job via job output. The
-      # downstream unit-test job reads it as an env var and `install_deps.sh`
+      # downstream stage jobs read it as an env var and `install_deps.sh`
       # gates its in-tree `tokenspeed-mla` reinstall on it. Without this
       # detection, CI would always exercise the pinned PyPI wheel and edits
       # under `tokenspeed-mla/` would be silently uncovered.
@@ -125,10 +139,10 @@ jobs:
             echo "changed=0" >> "$GITHUB_OUTPUT"
           fi
 
-  unit-test:
+  kernel-test:
     needs: scan
     if: |
-      needs.scan.outputs.has_tasks == 'true' &&
+      needs.scan.outputs.kernel_has_tasks == 'true' &&
       (github.event_name != 'pull_request' || github.event.action != 'closed') &&
       (
         github.event_name == 'pull_request' ||
@@ -139,88 +153,52 @@ jobs:
         github.event_name != 'pull_request' ||
         github.event.pull_request.draft == false
       )
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.scan.outputs.matrix) }}
-    name: ${{ matrix.name }} (${{ matrix.runner }})
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
-    continue-on-error: ${{ matrix.optional }}
-    env:
-      # When the scan job determined that this run touched `tokenspeed-mla/`,
-      # `install_deps.sh` will reinstall the in-tree source on top of the
-      # pinned PyPI wheel. See the matching detect step in the `scan` job.
-      INSTALL_TOKENSPEED_MLA_FROM_SOURCE: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
-      # Authenticate Hugging Face Hub downloads so checkpoint pulls during
-      # `ts serve` startup are not throttled by the anonymous rate limit. The
-      # 600s per-file `runtime-1gpu` timeout is otherwise exceeded on cold
-      # runners (e.g. `amd-mi35x-1gpu-test` loading `openai/gpt-oss-120b` +
-      # EAGLE3 draft).
-      HF_TOKEN: ${{ secrets.HF_TOKEN }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          path: run-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}-${{ matrix.runner }}
+    uses: ./.github/workflows/run-pr-test-stage.yml
+    with:
+      matrix: ${{ needs.scan.outputs.kernel_matrix }}
+      install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
+      b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL || 'b200v2' }}
+    secrets: inherit
 
-      - name: Set work directory
-        run: |
-          echo "WORK_DIR=${{ github.workspace }}/run-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}-${{ matrix.runner }}" >> "$GITHUB_ENV"
+  runtime-test:
+    needs: [scan, kernel-test]
+    if: |
+      !cancelled() &&
+      needs.scan.result == 'success' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (
+        needs.kernel-test.result == 'success' ||
+        needs.scan.outputs.kernel_has_tasks != 'true'
+      ) &&
+      needs.scan.outputs.runtime_has_tasks == 'true'
+    uses: ./.github/workflows/run-pr-test-stage.yml
+    with:
+      matrix: ${{ needs.scan.outputs.runtime_matrix }}
+      install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
+      b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL || 'b200v2' }}
+    secrets: inherit
 
-      - name: Install pipeline dependency
-        # See note in the scan job — pypi.org "Content-Type: Unknown" flake.
-        run: |
-          for i in 1 2 3 4 5; do
-            python3 -m pip install pyyaml && exit 0
-            echo "pyyaml install attempt $i failed, retrying in 10s..."
-            sleep 10
-          done
-          exit 1
-
-      # When the diff touches `tokenspeed-mla/`, ask install_deps.sh to
-      # rebuild + install that package from the in-tree source after the
-      # pinned PyPI wheel has been installed (transitively via
-      # tokenspeed-kernel). Without this, CI keeps testing whichever
-      # `tokenspeed-mla` version is pinned in
-      # `tokenspeed-kernel/python/requirements/cuda-thirdparty.txt`, not
-      # the code on the PR/branch. When the diff doesn't touch
-      # `tokenspeed-mla/` we keep using the pinned PyPI wheel.
-      - name: Install CI task
-        run: |
-          cd "${{ env.WORK_DIR }}"
-          mkdir -p .ci-artifacts
-          python3 test/ci_system/pipeline.py execute \
-            --config "${{ matrix.config }}" \
-            --runner "${{ matrix.runner }}" \
-            --work-dir "${{ env.WORK_DIR }}" \
-            --print-plan \
-            --only-stage install \
-            --keep-runner-state \
-            --result-json .ci-artifacts/result.json
-
-      - name: Execute CI task
-        run: |
-          cd "${{ env.WORK_DIR }}"
-          mkdir -p .ci-artifacts
-          python3 test/ci_system/pipeline.py execute \
-            --config "${{ matrix.config }}" \
-            --runner "${{ matrix.runner }}" \
-            --work-dir "${{ env.WORK_DIR }}" \
-            --print-plan \
-            --skip-stage install \
-            --reuse-runner-state \
-            --result-json .ci-artifacts/result.json
-
-      - name: Upload task result
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: pr-test-${{ matrix.name }}-${{ matrix.runner }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ env.WORK_DIR }}/.ci-artifacts/result.json
-
-      - name: Cleanup work directory
-        if: always()
-        run: rm -rf "${{ env.WORK_DIR }}"
+  model-test:
+    needs: [scan, kernel-test, runtime-test]
+    if: |
+      !cancelled() &&
+      needs.scan.result == 'success' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (
+        needs.kernel-test.result == 'success' ||
+        needs.scan.outputs.kernel_has_tasks != 'true'
+      ) &&
+      (
+        needs.runtime-test.result == 'success' ||
+        needs.scan.outputs.runtime_has_tasks != 'true'
+      ) &&
+      needs.scan.outputs.model_has_tasks == 'true'
+    uses: ./.github/workflows/run-pr-test-stage.yml
+    with:
+      matrix: ${{ needs.scan.outputs.model_matrix }}
+      install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
+      b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL || 'b200v2' }}
+    secrets: inherit
 
   finish:
     if: |
@@ -231,7 +209,7 @@ jobs:
         github.repository == 'lightseekorg/tokenspeed' ||
         github.repository == vars.TOKENSPEED_CI_REPOSITORY
       )
-    needs: [unit-test]
+    needs: [kernel-test, runtime-test, model-test]
     runs-on: ubuntu-latest
     steps:
       - name: Finish

--- a/.github/workflows/pr-test-nvidia.yml
+++ b/.github/workflows/pr-test-nvidia.yml
@@ -18,7 +18,7 @@ on:
       - ".github/workflows/pr-test-nvidia-arm.yml"
       - ".github/workflows/run-pr-test-stage.yml"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
     branches: [main]
     paths:
       - "python/pyproject.toml"
@@ -57,15 +57,19 @@ jobs:
     # Run jobs for pull requests, or for push/manual events in the official
     # repository or a repository whose full name matches TOKENSPEED_CI_REPOSITORY.
     if: |
-      github.event_name == 'pull_request' ||
-      github.repository == 'lightseekorg/tokenspeed' ||
-      github.repository == vars.TOKENSPEED_CI_REPOSITORY
+      (github.event.action != 'labeled' || github.event.label.name == 'high priority') &&
+      (
+        github.event_name == 'pull_request' ||
+        github.repository == 'lightseekorg/tokenspeed' ||
+        github.repository == vars.TOKENSPEED_CI_REPOSITORY
+      )
     runs-on: ubuntu-latest
     outputs:
       unit_matrix: ${{ steps.scan.outputs.unit_matrix }}
       unit_has_tasks: ${{ steps.scan.outputs.unit_has_tasks }}
       model_matrix: ${{ steps.scan.outputs.model_matrix }}
       model_has_tasks: ${{ steps.scan.outputs.model_has_tasks }}
+      eager_model: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'high priority') }}
       install_tokenspeed_mla_from_source: ${{ steps.detect_mla.outputs.changed }}
     steps:
       - name: Checkout code
@@ -163,10 +167,24 @@ jobs:
       !cancelled() &&
       needs.scan.result == 'success' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      needs.scan.outputs.eager_model != 'true' &&
       (
         needs.unit-test.result == 'success' ||
         needs.scan.outputs.unit_has_tasks != 'true'
       ) &&
+      needs.scan.outputs.model_has_tasks == 'true'
+    uses: ./.github/workflows/run-pr-test-stage.yml
+    with:
+      matrix: ${{ needs.scan.outputs.model_matrix }}
+      install_tokenspeed_mla_from_source: ${{ needs.scan.outputs.install_tokenspeed_mla_from_source }}
+      b200_runner_label: ${{ vars.TOKENSPEED_B200_RUNNER_LABEL || 'b200v2' }}
+    secrets: inherit
+
+  model-test-eager:
+    needs: scan
+    if: |
+      needs.scan.outputs.eager_model == 'true' &&
+      github.event.pull_request.draft == false &&
       needs.scan.outputs.model_has_tasks == 'true'
     uses: ./.github/workflows/run-pr-test-stage.yml
     with:
@@ -183,8 +201,9 @@ jobs:
         github.event_name == 'pull_request' ||
         github.repository == 'lightseekorg/tokenspeed' ||
         github.repository == vars.TOKENSPEED_CI_REPOSITORY
-      )
-    needs: [unit-test, model-test]
+      ) &&
+      (github.event.action != 'labeled' || github.event.label.name == 'high priority')
+    needs: [unit-test, model-test, model-test-eager]
     runs-on: ubuntu-latest
     steps:
       - name: Finish

--- a/.github/workflows/run-pr-test-stage.yml
+++ b/.github/workflows/run-pr-test-stage.yml
@@ -1,0 +1,98 @@
+name: Run PR Test Stage
+
+on:
+  workflow_call:
+    inputs:
+      matrix:
+        description: "JSON matrix for this CI stage"
+        required: true
+        type: string
+      install_tokenspeed_mla_from_source:
+        description: "Whether to install the in-tree tokenspeed-mla package"
+        required: true
+        type: string
+      b200_runner_label:
+        description: "Runner family used to resolve b200 task labels"
+        required: false
+        default: ""
+        type: string
+    secrets:
+      HF_TOKEN:
+        required: false
+
+env:
+  PIP_BREAK_SYSTEM_PACKAGES: 1
+  CUDA_VERSION: 13.0.1
+  TOKENSPEED_B200_RUNNER_LABEL: ${{ inputs.b200_runner_label }}
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(inputs.matrix) }}
+    name: ${{ matrix.name }} (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    continue-on-error: ${{ matrix.optional }}
+    env:
+      INSTALL_TOKENSPEED_MLA_FROM_SOURCE: ${{ inputs.install_tokenspeed_mla_from_source }}
+      # Authenticate model downloads so cold runners do not hit anonymous
+      # Hugging Face rate limits while starting `ts serve`.
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          path: run-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}-${{ matrix.runner }}
+
+      - name: Set work directory
+        run: |
+          echo "WORK_DIR=${{ github.workspace }}/run-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.name }}-${{ matrix.runner }}" >> "$GITHUB_ENV"
+
+      - name: Install pipeline dependency
+        # pypi.org occasionally returns "Content-Type: Unknown" for the simple
+        # index, which strict pip>=22 refuses to parse. Retry a few times.
+        run: |
+          for i in 1 2 3 4 5; do
+            python3 -m pip install pyyaml && exit 0
+            echo "pyyaml install attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
+          exit 1
+
+      - name: Install CI task
+        run: |
+          cd "${{ env.WORK_DIR }}"
+          mkdir -p .ci-artifacts
+          python3 test/ci_system/pipeline.py execute \
+            --config "${{ matrix.config }}" \
+            --runner "${{ matrix.runner }}" \
+            --work-dir "${{ env.WORK_DIR }}" \
+            --print-plan \
+            --only-stage install \
+            --keep-runner-state \
+            --result-json .ci-artifacts/result.json
+
+      - name: Execute CI task
+        run: |
+          cd "${{ env.WORK_DIR }}"
+          mkdir -p .ci-artifacts
+          python3 test/ci_system/pipeline.py execute \
+            --config "${{ matrix.config }}" \
+            --runner "${{ matrix.runner }}" \
+            --work-dir "${{ env.WORK_DIR }}" \
+            --print-plan \
+            --skip-stage install \
+            --reuse-runner-state \
+            --result-json .ci-artifacts/result.json
+
+      - name: Upload task result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-test-${{ matrix.name }}-${{ matrix.runner }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.WORK_DIR }}/.ci-artifacts/result.json
+
+      - name: Cleanup work directory
+        if: always()
+        run: rm -rf "${{ env.WORK_DIR }}"

--- a/test/ci/README.md
+++ b/test/ci/README.md
@@ -8,6 +8,7 @@ Current trigger values:
 - `per-commit`
 - `manual`
 - `nightly`
+- `debug`
 
 Supported task types:
 
@@ -19,7 +20,19 @@ Supported task types:
 Currently configured task directories:
 
 - `eval`
+- `perf`
 - `ut`
+
+Every task declares one `workflow_stage`:
+
+- `kernel-test` for kernel unit tests
+- `runtime-test` for runtime tests
+- `model-test` for model evaluation and performance tests
+
+The PR workflows run these stages in that order. Matrix entries within a stage
+run in parallel, but a later stage starts only after every required job in the
+previous stage succeeds. A stage with no matching tasks is treated as
+successfully satisfied.
 
 Each task expands into one matrix entry per runner label. Add a top-level
 `priority` to a task YAML to bias dispatch order. GitHub Actions starts matrix
@@ -41,9 +54,9 @@ priority:
   b300-1gpu: low
 ```
 
-Typical use: lower a 1gpu kernel unit-test on `b300-1gpu` so the heavier
-b300-4gpu evals that share the same box claim the runner first, without
-disturbing the same task's ordering on the other GPU families.
+Typical use: adjust one runner instance without disturbing the same task's
+dispatch order on other GPU families. Priority only affects jobs within the
+same workflow stage; later stages cannot contend with earlier ones.
 
 `optional` marks a task or per-label matrix entry as non-blocking.
 Optional entries are emitted with `matrix.optional: true`, and the PR workflows

--- a/test/ci/README.md
+++ b/test/ci/README.md
@@ -33,6 +33,11 @@ run in parallel, but a later stage starts only after every required job in the
 previous stage succeeds. A stage with no matching tasks is treated as
 successfully satisfied.
 
+PRs labeled `high priority` start `unit-test` and `model-test` concurrently.
+Applying the label starts a new CI run immediately and cancels the older run
+through the workflow's concurrency policy. A unit-test failure does not cancel
+model tests that are already running in this mode.
+
 Each task expands into one matrix entry per runner label. Add a top-level
 `priority` to a task YAML to bias dispatch order. GitHub Actions starts matrix
 jobs in include-list order, so `high` entries reach a contended runner pool

--- a/test/ci/README.md
+++ b/test/ci/README.md
@@ -25,8 +25,7 @@ Currently configured task directories:
 
 Every task declares one `workflow_stage`:
 
-- `kernel-test` for kernel unit tests
-- `runtime-test` for runtime tests
+- `unit-test` for kernel and runtime tests
 - `model-test` for model evaluation and performance tests
 
 The PR workflows run these stages in that order. Matrix entries within a stage

--- a/test/ci/eval/deepseek-v4-flash-evalscope-gsm8k.yaml
+++ b/test/ci/eval/deepseek-v4-flash-evalscope-gsm8k.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-deepseek-v4-flash-gsm8k
 type: eval
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/eval/deepseek-v4-flash-mtp-evalscope-gsm8k.yaml
+++ b/test/ci/eval/deepseek-v4-flash-mtp-evalscope-gsm8k.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-deepseek-v4-flash-mtp-gsm8k
 type: eval
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/eval/glm-5.2-nvfp4-mtp-evalscope-aime26.yaml
+++ b/test/ci/eval/glm-5.2-nvfp4-mtp-evalscope-aime26.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-glm-5.2-nvfp4-mtp-aime26
 type: eval
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
+++ b/test/ci/eval/gpt-oss-120b-mxfp4-evalscope-gpqa-diamond.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-gpt-oss-120b-mxfp4-gpqa-diamond
 type: eval
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/eval/inkling-mxfp4-mtp-evalscope-gsm8k.yaml
+++ b/test/ci/eval/inkling-mxfp4-mtp-evalscope-gsm8k.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-inkling-mxfp4-mtp-gsm8k
 type: eval
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/eval/inkling-nvfp4-mtp-evalscope-gsm8k.yaml
+++ b/test/ci/eval/inkling-nvfp4-mtp-evalscope-gsm8k.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-inkling-nvfp4-mtp-gsm8k
 type: eval
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/eval/kimi-k2.5-mxfp4-eagle3-evalscope-aime25-amd.yaml
+++ b/test/ci/eval/kimi-k2.5-mxfp4-eagle3-evalscope-aime25-amd.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-kimi-k2.5-mxfp4-aime25-amd
 type: eval
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/eval/kimi-k2.5-nvfp4-dflash-evalscope-aime25.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-dflash-evalscope-aime25.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-kimi-k2.5-nvfp4-dflash-aime25
 type: eval
+workflow_stage: model-test
 triggers:
   - manual
   - nightly

--- a/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-aime25.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-aime25.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-kimi-k2.5-nvfp4-eagle3-aime25
 type: eval
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-gpqa-diamond.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-gpqa-diamond.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-kimi-k2.5-nvfp4-eagle3-gpqa-diamond
 type: eval
+workflow_stage: model-test
 triggers:
   - manual
   - nightly

--- a/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-gsm8k.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-gsm8k.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-kimi-k2.5-nvfp4-eagle3-gsm8k
 type: eval
+workflow_stage: model-test
 triggers:
   - manual
   - nightly

--- a/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-mmlu.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-mmlu.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-kimi-k2.5-nvfp4-eagle3-mmlu
 type: eval
+workflow_stage: model-test
 triggers:
   - manual
   - nightly

--- a/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-ocr-bench.yaml
+++ b/test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-ocr-bench.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-kimi-k2.5-nvfp4-eagle3-ocr-bench
 type: eval
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-kimi-k3-mxfp4-tp8ep8-aime26-amd
 type: eval
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/eval/minimax-m3-nvfp4-evalscope-aime25.yaml
+++ b/test/ci/eval/minimax-m3-nvfp4-evalscope-aime25.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-minimax-m3-nvfp4-aime25
 type: eval
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/eval/qwen3.5-122b-a10b-nvfp4-epd-1e1p2d-evalscope-ocr-bench.yaml
+++ b/test/ci/eval/qwen3.5-122b-a10b-nvfp4-epd-1e1p2d-evalscope-ocr-bench.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-qwen3.5-122b-a10b-nvfp4-epd-1e1p2d-ocr-bench
 type: eval
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/eval/qwen3.5-122b-a10b-nvfp4-evalscope-ocr-bench.yaml
+++ b/test/ci/eval/qwen3.5-122b-a10b-nvfp4-evalscope-ocr-bench.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-qwen3.5-122b-a10b-nvfp4-ocr-bench
 type: eval
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/eval/qwen3.5-397b-a17b-mxfp4-evalscope-aime25.yaml
+++ b/test/ci/eval/qwen3.5-397b-a17b-mxfp4-evalscope-aime25.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-qwen3.5-397b-a17b-mxfp4-aime25
 type: eval
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/eval/qwen3.5-397b-a17b-nvfp4-dp4ep4-evalscope-aime25.yaml
+++ b/test/ci/eval/qwen3.5-397b-a17b-nvfp4-dp4ep4-evalscope-aime25.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-qwen3.5-397b-a17b-nvfp4-dp4ep4-aime25
 type: eval
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/eval/qwen3.5-397b-a17b-nvfp4-evalscope-aime25.yaml
+++ b/test/ci/eval/qwen3.5-397b-a17b-nvfp4-evalscope-aime25.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-qwen3.5-397b-a17b-nvfp4-aime25
 type: eval
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/eval/qwen3.5-397b-a17b-nvfp4-pd-1p1d-evalscope-aime25.yaml
+++ b/test/ci/eval/qwen3.5-397b-a17b-nvfp4-pd-1p1d-evalscope-aime25.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: eval-qwen3.5-397b-a17b-nvfp4-pd-1p1d-aime25
 type: eval
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi35x.yaml
+++ b/test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi35x.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: perf-gpt-oss-120b-mxfp4-mi35x
 type: perf
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
+++ b/test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: perf-kimi-k2.5-nvfp4-agentic
 type: perf
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
+++ b/test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: perf-kimi-k3-mxfp4-tp8ep8-random-4k-1k-mi35x
 type: perf
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic-b200-8gpu.yaml
+++ b/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic-b200-8gpu.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: perf-qwen3.5-397b-a17b-nvfp4-agentic-b200-8gpu
 type: perf
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic.yaml
+++ b/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: perf-qwen3.5-397b-a17b-nvfp4-agentic
 type: perf
+workflow_stage: model-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-longctx.yaml
+++ b/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-longctx.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: perf-qwen3.5-397b-a17b-nvfp4-longctx
 type: perf
+workflow_stage: model-test
 triggers:
   - manual
 runner:

--- a/test/ci/ut/qwen3.5-122b-a10b-nvfp4-epd-1e1p2d.yaml
+++ b/test/ci/ut/qwen3.5-122b-a10b-nvfp4-epd-1e1p2d.yaml
@@ -1,7 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: ut-runtime-qwen35-epd-1e1p2d
 type: ut
-workflow_stage: runtime-test
+workflow_stage: unit-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/ut/qwen3.5-122b-a10b-nvfp4-epd-1e1p2d.yaml
+++ b/test/ci/ut/qwen3.5-122b-a10b-nvfp4-epd-1e1p2d.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: ut-runtime-qwen35-epd-1e1p2d
 type: ut
+workflow_stage: runtime-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/ut/qwen3.5-397b-a17b-nvfp4-pd-1p1d.yaml
+++ b/test/ci/ut/qwen3.5-397b-a17b-nvfp4-pd-1p1d.yaml
@@ -1,7 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: ut-runtime-qwen35-pd-1p1d
 type: ut
-workflow_stage: runtime-test
+workflow_stage: unit-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/ut/qwen3.5-397b-a17b-nvfp4-pd-1p1d.yaml
+++ b/test/ci/ut/qwen3.5-397b-a17b-nvfp4-pd-1p1d.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: ut-runtime-qwen35-pd-1p1d
 type: ut
+workflow_stage: runtime-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/ut/ut-runtime-1gpu.yaml
+++ b/test/ci/ut/ut-runtime-1gpu.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: ut-runtime-1gpu
 type: ut
+workflow_stage: runtime-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/ut/ut-runtime-1gpu.yaml
+++ b/test/ci/ut/ut-runtime-1gpu.yaml
@@ -1,7 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: ut-runtime-1gpu
 type: ut
-workflow_stage: runtime-test
+workflow_stage: unit-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/ut/ut-runtime-2gpu.yaml
+++ b/test/ci/ut/ut-runtime-2gpu.yaml
@@ -1,7 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: ut-runtime-2gpu
 type: ut
-workflow_stage: runtime-test
+workflow_stage: unit-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/ut/ut-runtime-2gpu.yaml
+++ b/test/ci/ut/ut-runtime-2gpu.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: ut-runtime-2gpu
 type: ut
+workflow_stage: runtime-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/ut/ut-runtime-prefix-cache-e2e.yaml
+++ b/test/ci/ut/ut-runtime-prefix-cache-e2e.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: ut-runtime-prefix-cache-e2e
 type: ut
+workflow_stage: runtime-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/ut/ut-runtime-prefix-cache-e2e.yaml
+++ b/test/ci/ut/ut-runtime-prefix-cache-e2e.yaml
@@ -1,7 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: ut-runtime-prefix-cache-e2e
 type: ut
-workflow_stage: runtime-test
+workflow_stage: unit-test
 triggers:
   - per-commit
   - manual

--- a/test/ci/ut/ut-tokenspeed-kernel.yaml
+++ b/test/ci/ut/ut-tokenspeed-kernel.yaml
@@ -1,15 +1,10 @@
 api_version: ci.tokenspeed.io/v1
 name: ut-tokenspeed-kernel
 type: ut
+workflow_stage: kernel-test
 triggers:
   - per-commit
   - manual
-# b300-1gpu shares the box with b300-4gpu evals
-# (eval-qwen3.5 / eval-kimi-k2.5 / perf-kimi-k2.5). Drop the b300-1gpu
-# slot to `low` so the 4gpu jobs claim the box first. Other labels keep
-# the default `normal` priority.
-priority:
-  b300-1gpu: low
 runner:
   labels:
     - h100-1gpu

--- a/test/ci/ut/ut-tokenspeed-kernel.yaml
+++ b/test/ci/ut/ut-tokenspeed-kernel.yaml
@@ -1,7 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 name: ut-tokenspeed-kernel
 type: ut
-workflow_stage: kernel-test
+workflow_stage: unit-test
 triggers:
   - per-commit
   - manual

--- a/test/ci_system/pipeline.py
+++ b/test/ci_system/pipeline.py
@@ -33,8 +33,7 @@ except ImportError as exc:  # pragma: no cover
 SUPPORTED_TYPES = {"ut", "server_smoke", "eval", "perf"}
 SUPPORTED_TRIGGERS = {"per-commit", "manual", "nightly", "debug"}
 WORKFLOW_STAGE_TYPES = {
-    "kernel-test": {"ut"},
-    "runtime-test": {"ut", "server_smoke"},
+    "unit-test": {"ut", "server_smoke"},
     "model-test": {"eval", "perf"},
 }
 SUPPORTED_WORKFLOW_STAGES = tuple(WORKFLOW_STAGE_TYPES)

--- a/test/ci_system/pipeline.py
+++ b/test/ci_system/pipeline.py
@@ -32,11 +32,16 @@ except ImportError as exc:  # pragma: no cover
 
 SUPPORTED_TYPES = {"ut", "server_smoke", "eval", "perf"}
 SUPPORTED_TRIGGERS = {"per-commit", "manual", "nightly", "debug"}
+WORKFLOW_STAGE_TYPES = {
+    "kernel-test": {"ut"},
+    "runtime-test": {"ut", "server_smoke"},
+    "model-test": {"eval", "perf"},
+}
+SUPPORTED_WORKFLOW_STAGES = tuple(WORKFLOW_STAGE_TYPES)
 SUPPORTED_SETUP_MODES = ("ci", "slurm")
 # Lower sort key = dispatched earlier. GitHub Actions starts matrix jobs in
 # include-list order, so `high` entries reach runner pools first when several
-# jobs contend for the same label (typical case: heavy 4gpu evals beating a
-# 1gpu unit-test for the same b300 box).
+# jobs in the same workflow stage contend for the same hardware.
 SUPPORTED_PRIORITIES = ("high", "normal", "low")
 DEFAULT_PRIORITY = "normal"
 SUPPORTED_RUNNER_GROUPS = ("all", "amd", "nvidia", "nvidia-arm", "nvidia-x86")
@@ -117,6 +122,15 @@ def validate_task(data: Dict[str, Any], path: Path) -> None:
         raise ValueError(f"{path}: unsupported api_version {data['api_version']!r}")
     if data["type"] not in SUPPORTED_TYPES:
         raise ValueError(f"{path}: unsupported type {data['type']!r}")
+    workflow_stage = data.get("workflow_stage")
+    if workflow_stage is not None:
+        if workflow_stage not in WORKFLOW_STAGE_TYPES:
+            raise ValueError(f"{path}: unsupported workflow_stage {workflow_stage!r}")
+        if data["type"] not in WORKFLOW_STAGE_TYPES[workflow_stage]:
+            raise ValueError(
+                f"{path}: type {data['type']!r} is incompatible with "
+                f"workflow_stage {workflow_stage!r}"
+            )
     triggers = data["triggers"]
     if not isinstance(triggers, list) or not triggers:
         raise ValueError(f"{path}: triggers must be a non-empty list")
@@ -287,6 +301,7 @@ def build_matrix(
     repo_root: Path,
     trigger: str | None,
     runner_group: str = "all",
+    workflow_stage: str | None = None,
 ) -> Dict[str, Any]:
     include = []
     excluded_runner_labels = get_excluded_runner_labels()
@@ -294,6 +309,14 @@ def build_matrix(
         task = normalize_task(path, repo_root)
         if trigger and trigger not in task["triggers"]:
             continue
+        task_workflow_stage = task.get("workflow_stage")
+        if workflow_stage:
+            if task_workflow_stage is None:
+                raise ValueError(
+                    f"{path}: workflow_stage is required when filtering by stage"
+                )
+            if workflow_stage != task_workflow_stage:
+                continue
         priority = task.get("priority")
         optional = task.get("optional")
         for label in task["runner"]["labels"]:
@@ -307,16 +330,17 @@ def build_matrix(
                 continue
             if not runner_matches_group(runner, runner_group):
                 continue
-            include.append(
-                {
-                    "name": task["name"],
-                    "type": task["type"],
-                    "config": task["_source_path"],
-                    "runner": runner,
-                    "priority": effective,
-                    "optional": is_optional,
-                }
-            )
+            entry = {
+                "name": task["name"],
+                "type": task["type"],
+                "config": task["_source_path"],
+                "runner": runner,
+                "priority": effective,
+                "optional": is_optional,
+            }
+            if task_workflow_stage is not None:
+                entry["workflow_stage"] = task_workflow_stage
+            include.append(entry)
     # Stable sort: tasks at the same priority keep their file-path / label
     # order, so tasks that omit `priority` see no change from the previous
     # behaviour.
@@ -1740,6 +1764,12 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
         default="all",
         help="Optional runner group filter",
     )
+    scan_parser.add_argument(
+        "--workflow-stage",
+        choices=SUPPORTED_WORKFLOW_STAGES,
+        default=None,
+        help="Optional workflow stage filter",
+    )
 
     execute_parser = subparsers.add_parser("execute", help="Execute one CI task")
     execute_parser.add_argument(
@@ -1795,7 +1825,13 @@ def main(argv: Iterable[str] | None = None) -> int:
     if args.command == "scan":
         repo_root = Path(args.repo_root).resolve()
         root = (repo_root / args.root).resolve()
-        matrix = build_matrix(root, repo_root, args.trigger, args.runner_group)
+        matrix = build_matrix(
+            root,
+            repo_root,
+            args.trigger,
+            args.runner_group,
+            args.workflow_stage,
+        )
         print(json.dumps(matrix, separators=(",", ":")))
         return 0
 

--- a/test/ci_system/test_pipeline.py
+++ b/test/ci_system/test_pipeline.py
@@ -600,6 +600,7 @@ _DEFAULT_BODY_TEMPLATE = """\
 api_version: ci.tokenspeed.io/v1
 name: {name}
 type: ut
+workflow_stage: runtime-test
 triggers:
   - per-commit
 runner:

--- a/test/ci_system/test_pipeline.py
+++ b/test/ci_system/test_pipeline.py
@@ -600,7 +600,7 @@ _DEFAULT_BODY_TEMPLATE = """\
 api_version: ci.tokenspeed.io/v1
 name: {name}
 type: ut
-workflow_stage: runtime-test
+workflow_stage: unit-test
 triggers:
   - per-commit
 runner:

--- a/test/ci_system/test_slurm_submit.py
+++ b/test/ci_system/test_slurm_submit.py
@@ -24,6 +24,7 @@ def write_task(
     task_type: str = "eval",
     model: str = "example/model",
 ) -> str:
+    workflow_stage = "runtime-test" if task_type == "ut" else "model-test"
     relative = Path(f"test/ci/{task_type}/example.yaml")
     path = repo / relative
     path.parent.mkdir(parents=True)
@@ -31,6 +32,7 @@ def write_task(
             api_version: ci.tokenspeed.io/v1
             name: example
             type: {task_type}
+            workflow_stage: {workflow_stage}
             triggers: [manual]
             runner:
               labels: [{runner}]

--- a/test/ci_system/test_slurm_submit.py
+++ b/test/ci_system/test_slurm_submit.py
@@ -24,7 +24,7 @@ def write_task(
     task_type: str = "eval",
     model: str = "example/model",
 ) -> str:
-    workflow_stage = "runtime-test" if task_type == "ut" else "model-test"
+    workflow_stage = "unit-test" if task_type == "ut" else "model-test"
     relative = Path(f"test/ci/{task_type}/example.yaml")
     path = repo / relative
     path.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary

CI previously launched kernel, runtime, and model tests simultaneously. This wasted expensive GPU resources when foundational kernel or runtime tests had already failed. Split each vendor CI workflow into 2 sequential stages:

1. `unit-test`: including kernel tests and runtime test
2. `model-test`

Jobs remain parallel within each stage, while later stages run only after the previous stage succeeds. Shared execution logic is consolidated in a reusable workflow to avoid duplication.

PRs labeled `high priority` start `unit-test` and `model-test` concurrently. Applying the label starts a new CI run immediately and cancels the older run through the workflow's concurrency policy. A unit-test failure does not cancel model tests that are already running in this mode.

<img width="992" height="396" alt="image" src="https://github.com/user-attachments/assets/0e0ebd36-3537-4cd0-a117-8c890056809a" />
