### PR TITLE
fix: all-reduce autotune tactic timings across ranks

### DIFF
--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -27,7 +27,11 @@ from typing import TYPE_CHECKING
 
 import torch
 import torch.distributed as dist
-from tokenspeed_kernel.ops.tuning import autotune, set_autotune_max_num_tokens
+from tokenspeed_kernel.ops.tuning import (
+    autotune,
+    set_autotune_max_num_tokens,
+    set_autotune_process_group,
+)
 from tokenspeed_kernel.platform import current_platform
 
 from tokenspeed.runtime.configs.model_config import ModelConfig
@@ -36,6 +40,9 @@ from tokenspeed.runtime.configs.paged_cache_spec import (
     validate_flat_scheduler_config,
 )
 from tokenspeed.runtime.configs.utils import get_rope_parameters
+from tokenspeed.runtime.distributed.process_group_manager import (
+    process_group_manager as pg_manager,
+)
 from tokenspeed.runtime.engine.scheduler_utils import (
     flat_block_tables_from_forward_op,
     paged_cache_block_table_base_offsets_from_forward_op,
@@ -668,15 +675,22 @@ class ModelExecutor:
         carry; the tuner enumerates every smaller shape bucket from it, so no
         decode-sized pass is needed. Must precede capture: a captured graph
         records the tactic chosen while it was recorded, so tuning afterwards
-        cannot change a replay.
+        cannot change a replay. On distributed boots, per-tactic timings are
+        averaged over the world so every rank picks the same tactic.
         """
         num_tokens = int(self.config.chunked_prefill_size)
         if num_tokens <= 0 or self.model_runner is None:
             return
-        set_autotune_max_num_tokens(num_tokens)
+
+        cpu_group = None
+        if self.config.world_size > 1:
+            cpu_group = pg_manager.get_process_group("gloo", self.config.world_group)
+
         logger.info(f"Kernel tuning with a dummy prefill of {num_tokens} tokens")
         ib = self.input_buffers
         tic = time.time()
+        set_autotune_max_num_tokens(num_tokens)
+        set_autotune_process_group(cpu_group)
         with autotune(), maybe_inference_mode():
             ctx = self.prefill_graph.make_dummy_batch(num_tokens, self.forward_step)
             positions = (
@@ -691,6 +705,7 @@ class ModelExecutor:
                     positions=positions,
                     out_cache_loc=ib.out_cache_loc_buf[:num_tokens],
                 )
+        set_autotune_process_group(None)
         torch.cuda.synchronize()
         dist.barrier()
         logger.info(f"Kernel tuning finished in {time.time() - tic:.1f}s")

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/tuning.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/tuning.py
@@ -38,6 +38,10 @@ pre-swept tactic table before the window opens. Entries loaded from the
 table win over live profiling, so covered shapes skip their startup tuning
 pass entirely -- and every rank loading the same table picks the same tactics,
 removing the rank-divergence hazard above for covered shapes.
+
+For shapes the table does not cover, :func:`set_autotune_process_group`
+averages per-tactic timings across ranks during the window, so live-tuned
+shapes converge on one tactic as well.
 """
 
 import contextlib
@@ -52,6 +56,7 @@ __all__ = [
     "load_flashinfer_tuning_cache",
     "load_packaged_flashinfer_tuning_cache",
     "set_autotune_max_num_tokens",
+    "set_autotune_process_group",
 ]
 
 logger = logging.getLogger(__name__)
@@ -101,12 +106,35 @@ def autotune() -> Generator[None]:
         error.
     """
     try:
-        from flashinfer.autotuner import autotune as _flashinfer_autotune
+        import flashinfer.autotuner
     except ImportError:
         yield
         return
-    with _flashinfer_autotune():
+    with flashinfer.autotuner.autotune():
         yield
+
+
+def set_autotune_process_group(process_group) -> None:
+    """Average per-tactic profile timings across ``process_group`` ranks.
+
+    While a group is set, every rank entering :func:`autotune` all-reduces each
+    tactic's measured time over the group before picking the winner, so all
+    ranks converge on the same tactic despite per-GPU timing noise. Requires
+    every rank in the group to profile the same tuned ops in the same order
+    with identical caches at entry; set it before the tuning window opens and
+    clear it (pass ``None``) after the window closes. Like :func:`autotune`, a
+    no-op when the tuning backend is unavailable.
+
+    Args:
+        process_group: A ``torch.distributed`` process group covering the
+            ranks that tune together (prefer a CPU/gloo group), or ``None``
+            to restore independent per-rank tuning.
+    """
+    try:
+        import flashinfer.autotuner
+    except ImportError:
+        return
+    flashinfer.autotuner.set_autotune_process_group(process_group)
 
 
 def load_flashinfer_tuning_cache(path: str) -> bool:

--- a/tokenspeed-kernel/test/test_tuning_cache.py
+++ b/tokenspeed-kernel/test/test_tuning_cache.py
@@ -32,7 +32,10 @@ import json
 from importlib.util import find_spec
 
 import pytest
-from tokenspeed_kernel.ops.tuning import load_flashinfer_tuning_cache
+from tokenspeed_kernel.ops.tuning import (
+    load_flashinfer_tuning_cache,
+    set_autotune_process_group,
+)
 
 requires_flashinfer = pytest.mark.skipif(
     find_spec("flashinfer") is None, reason="requires flashinfer"
@@ -64,6 +67,24 @@ def test_packaged_lookup_miss_returns_false() -> None:
         load_packaged_flashinfer_tuning_cache("no-such-model-unit-test", 999, 1)
         is False
     )
+
+
+@requires_flashinfer
+def test_set_autotune_process_group_sets_and_clears() -> None:
+    import flashinfer.autotuner as fi
+
+    sentinel = object()
+    set_autotune_process_group(sentinel)
+    try:
+        assert fi.get_autotune_process_group() is sentinel
+    finally:
+        set_autotune_process_group(None)
+    assert fi.get_autotune_process_group() is None
+
+
+def test_set_autotune_process_group_tolerates_missing_backend() -> None:
+    # Like autotune(), a no-op without flashinfer installed.
+    set_autotune_process_group(None)
 
 
 @requires_flashinfer


### PR DESCRIPTION
## Summary

Re: https://github.com/lightseekorg/tokenspeed/pull/820#discussion_r3695308355

During the startup tuning window each rank profiled flashinfer tactics independently, so GPU timing noise could make ranks pick different tactics for shapes the pre-swept table does not cover -- and with the installed flashinfer release rejecting the dev-keyed tables, that was every tuned shape. Expose flashinfer's set_autotune_process_group through tokenspeed_kernel.ops.tuning and have ModelExecutor._autotune set the gloo world group around the window, averaging per-tactic timings so every rank converges on the same tactic.
