### PR TITLE
feat(m3): support MSA index-K offload in radix and flat CPU L2 cache

### DIFF
--- a/docs/recipes/models.md
+++ b/docs/recipes/models.md
@@ -69,7 +69,10 @@ ts serve \
 
 MiniMax M3 uses 128-token MSA blocks. TokenSpeed configures its dense and sparse
 attention layers automatically; select the dense backend with
-`--attention-backend` and run with `--disable-kvstore`.
+`--attention-backend`. On a flat-scheduler build, non-speculative serving can
+enable KVStore: the flat host tier mirrors K/V together with the sparse
+index-K side cache. The EAGLE3 example below keeps `--disable-kvstore` because
+the flat host tier does not yet mirror a separate speculative draft pool.
 
 ```bash
 tokenspeed serve nvidia/MiniMax-M3-NVFP4 \

--- a/python/tokenspeed/runtime/cache/executor/flat_memory_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/flat_memory_executor.py
@@ -144,20 +144,10 @@ class FlatMemoryExecutor:
         # the same wait_until(layer_id) machinery.
         self._counter = LayerDoneCounter(self.layer_num)
         device_pool.register_layer_transfer_counter(self._counter)
-        # _start_loading maps layer -> mirror V-tensor event and relies on
-        # load_events[-1] (LayerLoadingEvent.finish_event, reuse fence in
-        # update_producer) covering EVERY copy: it pins the last layer to
-        # the op's last per-tensor event, which without state slabs is the
-        # last layer's V event only if that V mirror is the last KV tensor
-        # pair. Holds for both layouts (legacy: identity; slab: last layer
-        # is the last occurrence of its group). A state last layer has no
-        # KV mirror at all -- its copies (state slabs trail every KV
-        # tensor) are covered by the events[-1] pin in _start_loading.
-        assert (
-            self.mirror.state_tensor_indices_of_layer(self.layer_num - 1) is not None
-            or self.mirror.tensor_index_of_layer(self.layer_num - 1)
-            == self.mirror.num_k_tensors - 1
-        ), "flat host tier: last layer's V mirror is not the last KV tensor pair"
+        # _start_loading maps each layer to its latest required mirror event
+        # (V, optional index-K, or state SSM). It also pins load_events[-1]
+        # (LayerLoadingEvent.finish_event, the producer reuse fence) to the
+        # op's final tensor event so optional trailing mirrors are covered.
 
         write_priority, load_priority = _cache_stream_priorities()
         self.write_stream = _new_cache_stream(write_priority)
@@ -307,28 +297,18 @@ class FlatMemoryExecutor:
         producer_event.start_event.wait(self.load_stream)
 
         events = self.mirror.load_pages_with_events(pairs, self.load_stream)
-        # Layer fence: layer L is readable once its V mirror copy lands; the
-        # load stream is serial (all K copies precede all V copies), so the
-        # V-tensor event also covers L's K copy. Paired slab layers share the
-        # slab event -- correct by design. State layers instead fence on
-        # their ssm event: conv precedes ssm in tensor_pairs order (and both
-        # follow every KV tensor), so on the serial stream the ssm event
-        # covers the conv copy and the layer's KV copies -- the same
-        # K-before-V reasoning as above.
-        num_k = self.mirror.num_k_tensors
+        # Layer fence: dense layers fence on V (after K), MSA sparse layers
+        # fence on index-K (after K/V), and state layers fence on SSM (after
+        # conv). The load stream is serial in tensor_pairs order, so the
+        # selected event covers every earlier tensor required by that layer.
+        # Paired slab layers may intentionally share the same ready event.
         for layer_id in range(self.layer_num):
-            state_indices = self.mirror.state_tensor_indices_of_layer(layer_id)
-            if state_indices is not None:
-                producer_event.load_events[layer_id] = events[state_indices[1]]
-            else:
-                producer_event.load_events[layer_id] = events[
-                    num_k + self.mirror.tensor_index_of_layer(layer_id)
-                ]
+            event_index = self.mirror.ready_tensor_index_of_layer(layer_id)
+            producer_event.load_events[layer_id] = events[event_index]
         # finish_event (== load_events[-1]) is the producer-slot reuse fence
-        # in update_producer and must cover EVERY copy of the op; state
-        # tensors copy after all KV tensors, so pin the last layer to the
-        # op's last per-tensor event. A no-op without state slabs: events[-1]
-        # is then the last layer's V event (ctor assert).
+        # in update_producer and must cover EVERY copy of the op. Pin the last
+        # layer to the op's final per-tensor event whether it belongs to V,
+        # index-K, or state.
         producer_event.load_events[self.layer_num - 1] = events[-1]
         # events[-1] is also the reassigned finish_event, so the ack covers
         # every copy.

--- a/python/tokenspeed/runtime/cache/executor/memory_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/memory_executor.py
@@ -37,6 +37,7 @@ from tokenspeed.runtime.cache.kv_cache_host import (
     DSATokenToKVPoolHost,
     MHATokenToKVPoolHost,
     MLATokenToKVPoolHost,
+    MSATokenToKVPoolHost,
     get_available_host_memory_bytes,
 )
 from tokenspeed.runtime.cache.mamba_cache_host import MambaPoolHost
@@ -50,6 +51,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
 from tokenspeed.runtime.layers.attention.kv_cache.dsa import DSATokenToKVPool
 from tokenspeed.runtime.layers.attention.kv_cache.mha import MHATokenToKVPool
 from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
+from tokenspeed.runtime.layers.attention.kv_cache.msa import MSATokenToKVPool
 from tokenspeed.runtime.utils import get_colorful_logger
 
 logger = get_colorful_logger(__name__)
@@ -115,6 +117,13 @@ def _pool_size_per_token(pool) -> int:
             (pool.kv_lora_rank + pool.qk_rope_head_dim) * dtype_size * pool.layer_num
         )
         return latent_size + pool.index_k_row_bytes * pool.layer_num
+    if isinstance(pool, MSATokenToKVPool):
+        return (
+            pool.head_dim * pool.head_num * pool.layer_num * dtype_size * 2
+            + pool.index_head_dim
+            * len(pool.indexed_layer_ids)
+            * pool.index_dtype.itemsize
+        )
     if isinstance(pool, MHATokenToKVPool):
         return pool.head_dim * pool.head_num * pool.layer_num * dtype_size * 2
     if isinstance(pool, MLATokenToKVPool):
@@ -268,6 +277,15 @@ class MemoryExecutor:
                     config.host_layout,
                     host_size_tokens=host_size_tokens,
                 )
+            elif isinstance(actual_pool, MSATokenToKVPool):
+                self.host_pool = MSATokenToKVPoolHost(
+                    actual_pool,
+                    config.host_ratio,
+                    config.host_size_gb,
+                    config.page_size,
+                    config.host_layout,
+                    host_size_tokens=host_size_tokens,
+                )
             elif isinstance(actual_pool, MHATokenToKVPool):
                 self.host_pool = MHATokenToKVPoolHost(
                     actual_pool,
@@ -288,7 +306,7 @@ class MemoryExecutor:
                 )
             else:
                 raise ValueError(
-                    "host_pool only supports DSA, MHA, MLA, and DeepSeek V4, "
+                    "host_pool only supports DSA, MSA, MHA, MLA, and DeepSeek V4, "
                     f"got {type(actual_pool)} from module {type(actual_pool).__module__}"
                 )
 
@@ -298,6 +316,15 @@ class MemoryExecutor:
         if actual_draft_pool is not None and self.paged_cache_pool is None:
             if isinstance(actual_draft_pool, DSATokenToKVPool):
                 self.draft_host_pool = DSATokenToKVPoolHost(
+                    actual_draft_pool,
+                    config.host_ratio,
+                    config.host_size_gb,
+                    config.page_size,
+                    config.host_layout,
+                    host_size_tokens=self.host_pool.size,
+                )
+            elif isinstance(actual_draft_pool, MSATokenToKVPool):
+                self.draft_host_pool = MSATokenToKVPoolHost(
                     actual_draft_pool,
                     config.host_ratio,
                     config.host_size_gb,

--- a/python/tokenspeed/runtime/cache/flat_host_mirror.py
+++ b/python/tokenspeed/runtime/cache/flat_host_mirror.py
@@ -24,7 +24,7 @@ tier (M15 Phase D). Transport mechanism only; scheduler/engine wiring is D2.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 
 import torch
 
@@ -47,38 +47,89 @@ def _state_slabs(device_kv_pool) -> list[tuple[torch.Tensor, torch.Tensor]]:
     return list(getattr(device_kv_pool, "state_slabs", None) or ())
 
 
+def _index_k_tensors_by_layer(device_kv_pool) -> list[tuple[int, torch.Tensor]]:
+    """Optional key-only side-cache tensors keyed by logical layer id.
+
+    MSA pools expose ``index_k_buffer`` as a mapping because only sparse
+    layers own an index-K tensor. Other pools either omit the attribute or
+    use a different representation, in which case their flat mirror layout
+    stays unchanged.
+    """
+    buffers = getattr(device_kv_pool, "index_k_buffer", None)
+    indexed_layer_ids = getattr(device_kv_pool, "indexed_layer_ids", None)
+    if not isinstance(buffers, Mapping) or indexed_layer_ids is None:
+        return []
+
+    num_layers = len(device_kv_pool.k_buffer)
+    declared_layer_ids = {int(layer_id) for layer_id in indexed_layer_ids}
+    buffer_layer_ids = {int(layer_id) for layer_id in buffers}
+    if buffer_layer_ids != declared_layer_ids:
+        raise ValueError(
+            "flat host mirror: index-K buffer layers do not match "
+            f"indexed_layer_ids (buffers={sorted(buffer_layer_ids)}, "
+            f"declared={sorted(declared_layer_ids)})"
+        )
+
+    tensors: list[tuple[int, torch.Tensor]] = []
+    for raw_layer_id, tensor in buffers.items():
+        layer_id = int(raw_layer_id)
+        if not 0 <= layer_id < num_layers:
+            raise ValueError(
+                "flat host mirror: index-K layer id out of range: "
+                f"{layer_id} not in [0, {num_layers})"
+            )
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(
+                "flat host mirror: index-K buffer must contain tensors, "
+                f"got {type(tensor).__name__} for layer {layer_id}"
+            )
+        tensors.append((layer_id, tensor))
+    tensors.sort(key=lambda item: item[0])
+    return tensors
+
+
 def flat_bytes_per_host_page(device_kv_pool) -> int:
     """Bytes one host page occupies across all mirrors, computed from the
     device pool alone (no mirror allocation) -- the sizing side of
     ``FlatHostMirror.bytes_per_host_page`` for host-budget arithmetic.
     """
-    tensors = _identity_dedup(device_kv_pool.k_buffer) + _identity_dedup(
-        device_kv_pool.v_buffer
+    token_tensors = (
+        _identity_dedup(device_kv_pool.k_buffer)
+        + _identity_dedup(device_kv_pool.v_buffer)
+        + _identity_dedup(
+            [tensor for _, tensor in _index_k_tensors_by_layer(device_kv_pool)]
+        )
     )
     page_size = int(device_kv_pool.page_size)
-    kv_bytes = sum(t.element_size() * t[0].numel() * page_size for t in tensors)
+    token_bytes = sum(
+        tensor.element_size() * tensor[0].numel() * page_size
+        for tensor in token_tensors
+    )
     # State slabs are page-indexed: one constant row per page id.
     state_bytes = sum(
         t.element_size() * t[0].numel()
         for pair in _state_slabs(device_kv_pool)
         for t in pair
     )
-    return kv_bytes + state_bytes
+    return token_bytes + state_bytes
 
 
 class FlatHostMirror:
-    """One pinned CPU mirror per DISTINCT device KV tensor plus one per
-    state slab tensor; a (device_page, host_page) pair copies that page's
-    row range on every mirror pair.
+    """Pinned CPU mirrors for device K/V, optional index-K, and state tensors.
+
+    A ``(device_page, host_page)`` pair copies that page's row range on every
+    mirror pair. Optional index-K mirrors are discovered from a mapping-valued
+    ``index_k_buffer``; pools without one retain the original K/V/state layout.
 
     Slab tensors are enumerated once each -- a page's rows are exactly its
     owner group's layers, so byte copies are group-safe by id-exclusivity.
 
     ``tensor_pairs`` order (PINNED, D2 fencing indexes into it): K*, V*,
-    then state tensors flattened in slab order (conv0, ssm0, conv1, ...).
-    KV mirrors span ``page_size`` token rows per page; state slabs are
-    page-indexed (one snapshot row per page id), so their mirrors span 1
-    row per page -- ``row_spans[i]`` carries each pair's span.
+    index-K* in ascending layer-id order, then state tensors flattened in slab
+    order (conv0, ssm0, conv1, ...). K/V and index-K mirrors span
+    ``page_size`` token rows per page; state slabs are page-indexed (one
+    snapshot row per page id), so their mirrors span 1 row per page --
+    ``row_spans[i]`` carries each pair's span.
     """
 
     def __init__(self, device_kv_pool, num_host_pages: int):
@@ -105,6 +156,16 @@ class FlatHostMirror:
             None if t is None else v_index[id(t)] for t in device_kv_pool.v_buffer
         ], "flat host mirror: K/V dedup orders diverge"
 
+        index_k_by_layer = _index_k_tensors_by_layer(device_kv_pool)
+        index_k_tensors = _identity_dedup([tensor for _, tensor in index_k_by_layer])
+        self.num_index_k_tensors = len(index_k_tensors)
+        index_k_base = 2 * self.num_k_tensors
+        index_k_index = {id(tensor): i for i, tensor in enumerate(index_k_tensors)}
+        self._layer_to_index_k_index = {
+            layer_id: index_k_base + index_k_index[id(tensor)]
+            for layer_id, tensor in index_k_by_layer
+        }
+
         state_slabs = _state_slabs(device_kv_pool)
         state_tensors = [t for pair in state_slabs for t in pair]
 
@@ -121,7 +182,7 @@ class FlatHostMirror:
                 self._layer_to_state_pair[layer_id] = pair_of_conv[id(conv)]
 
         pin = torch.cuda.is_available()
-        kv_pairs = [
+        token_pairs = [
             (
                 dev,
                 torch.zeros(
@@ -130,7 +191,7 @@ class FlatHostMirror:
                     pin_memory=pin,
                 ),
             )
-            for dev in k_tensors + v_tensors
+            for dev in k_tensors + v_tensors + index_k_tensors
         ]
         state_pairs = [
             (
@@ -144,11 +205,11 @@ class FlatHostMirror:
             for dev in state_tensors
         ]
         self.tensor_pairs: tuple[tuple[torch.Tensor, torch.Tensor], ...] = tuple(
-            kv_pairs + state_pairs
+            token_pairs + state_pairs
         )
-        # Rows one page spans on each pair: page_size token rows for KV,
-        # one page-indexed snapshot row for state slabs.
-        self.row_spans: tuple[int, ...] = (self.page_size,) * len(kv_pairs) + (
+        # Rows one page spans on each pair: page_size token rows for K/V and
+        # index-K, one page-indexed snapshot row for state slabs.
+        self.row_spans: tuple[int, ...] = (self.page_size,) * len(token_pairs) + (
             1,
         ) * len(state_pairs)
 
@@ -162,6 +223,10 @@ class FlatHostMirror:
             raise ValueError(f"layer {layer_id} is a state layer; it has no KV mirror")
         return index
 
+    def index_k_tensor_index_of_layer(self, layer_id: int) -> int | None:
+        """Absolute index of ``layer_id``'s index-K mirror, when present."""
+        return self._layer_to_index_k_index.get(layer_id)
+
     def state_tensor_indices_of_layer(self, layer_id: int) -> tuple[int, int] | None:
         """(conv_idx, ssm_idx) of layer_id's state slab pair in tensor_pairs
         (conv immediately precedes its ssm), or None for layers without
@@ -169,8 +234,23 @@ class FlatHostMirror:
         pair = self._layer_to_state_pair.get(layer_id)
         if pair is None:
             return None
-        base = 2 * self.num_k_tensors + 2 * pair
+        base = 2 * self.num_k_tensors + self.num_index_k_tensors + 2 * pair
         return base, base + 1
+
+    def ready_tensor_index_of_layer(self, layer_id: int) -> int:
+        """Tensor event after which all mirrored data for a layer is readable.
+
+        The copy stream follows ``tensor_pairs`` order. A state layer fences on
+        SSM (after conv); an MSA sparse layer fences on index-K (after K/V);
+        every other attention layer fences on V (after K).
+        """
+        state_indices = self.state_tensor_indices_of_layer(layer_id)
+        if state_indices is not None:
+            return state_indices[1]
+        index_k_index = self.index_k_tensor_index_of_layer(layer_id)
+        if index_k_index is not None:
+            return index_k_index
+        return self.num_k_tensors + self.tensor_index_of_layer(layer_id)
 
     def bytes_per_host_page(self) -> int:
         return sum(

--- a/python/tokenspeed/runtime/cache/kv_cache_host.py
+++ b/python/tokenspeed/runtime/cache/kv_cache_host.py
@@ -157,7 +157,7 @@ class HostKVCache(abc.ABC):
         self.page_num = self.size // self.page_size + 1
         self.size = self.page_num * self.page_size
 
-        if self.size > device_pool.size:
+        if self.size < device_pool.size:
             logger.warning(
                 "The host memory is less than the device memory with the current protocol"
             )

--- a/python/tokenspeed/runtime/cache/kv_cache_host.py
+++ b/python/tokenspeed/runtime/cache/kv_cache_host.py
@@ -35,6 +35,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.base import BaseTokenToKVPool
 from tokenspeed.runtime.layers.attention.kv_cache.dsa import DSATokenToKVPool
 from tokenspeed.runtime.layers.attention.kv_cache.mha import MHATokenToKVPool
 from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
+from tokenspeed.runtime.layers.attention.kv_cache.msa import MSATokenToKVPool
 from tokenspeed.runtime.utils import get_colorful_logger
 
 logger = get_colorful_logger(__name__)
@@ -968,6 +969,156 @@ class DSATokenToKVPoolHost(MLATokenToKVPoolHost):
             transfer_kv_direct(
                 src_layers=list(device_pool.index_k_buffer),
                 dst_layers=self.index_k_refs,
+                src_indices=device_indices,
+                dst_indices=host_indices,
+                page_size=self.page_size,
+            )
+        else:
+            raise ValueError(f"Unsupported IO backend: {io_backend}")
+
+
+class MSATokenToKVPoolHost(MHATokenToKVPoolHost):
+    """MHA host pool with index-K side cache for MiniMax sparse attention."""
+
+    device_pool: MSATokenToKVPool
+
+    def __init__(
+        self,
+        device_pool,
+        host_to_device_ratio,
+        host_size,
+        page_size,
+        layout,
+        device="cpu",
+        host_size_tokens=0,
+    ):
+        super().__init__(
+            device_pool,
+            host_to_device_ratio,
+            host_size,
+            page_size,
+            layout,
+            device,
+            host_size_tokens,
+        )
+
+        self.index_k_host_buffer: dict[int, torch.Tensor] = {}
+        for layer_id in sorted(device_pool.indexed_layer_ids):
+            buf = torch.empty(
+                (self.size, device_pool.index_head_dim),
+                dtype=device_pool.index_dtype,
+                device=self.device,
+            )
+            current_platform().register_host_tensor_for_gpu_access(buf)
+            self.index_k_host_buffer[layer_id] = buf
+
+        self.index_k_row_bytes = (
+            device_pool.index_head_dim * device_pool.index_dtype.itemsize
+        )
+
+        self.index_k_data_refs = [
+            self.index_k_host_buffer[layer_id]
+            for layer_id in sorted(device_pool.indexed_layer_ids)
+        ]
+        self.index_k_data_ptrs = torch.tensor(
+            [
+                current_platform().device_visible_data_ptr(x)
+                for x in self.index_k_data_refs
+            ],
+            dtype=torch.uint64,
+            device=self.device_pool.device,
+        )
+
+    def get_size_per_token(self):
+        base = super().get_size_per_token()
+        index_k_bytes = (
+            self.device_pool.index_head_dim
+            * self.device_pool.index_dtype.itemsize
+            * len(self.device_pool.indexed_layer_ids)
+        )
+        return base + index_k_bytes
+
+    def get_ksize_per_token(self):
+        # K-only bytes: MHA K + index-K (index-K is key-side)
+        base = super().get_size_per_token() // 2
+        index_k_bytes = (
+            self.device_pool.index_head_dim
+            * self.device_pool.index_dtype.itemsize
+            * len(self.device_pool.indexed_layer_ids)
+        )
+        return base + index_k_bytes
+
+    def load_to_device_per_layer(
+        self,
+        device_pool,
+        host_indices,
+        device_indices,
+        layer_id,
+        io_backend,
+    ):
+        # Parent handles K/V transfer.
+        super().load_to_device_per_layer(
+            device_pool, host_indices, device_indices, layer_id, io_backend
+        )
+        # Transfer index-K for sparse layers (CPU → GPU).
+        if layer_id not in self.index_k_host_buffer:
+            return
+        if io_backend == "kernel":
+            transfer_kv_per_layer_mla(
+                src=self.index_k_host_buffer[layer_id],
+                dst=device_pool.index_k_buffer[layer_id],
+                src_indices=host_indices,
+                dst_indices=device_indices,
+                item_size=self.index_k_row_bytes,
+                block_quota=MLA_KVSTORE_LOADBACK_BLOCK_QUOTA,
+            )
+        elif io_backend == "direct":
+            transfer_kv_direct(
+                src_layers=[self.index_k_host_buffer[layer_id]],
+                dst_layers=[device_pool.index_k_buffer[layer_id]],
+                src_indices=host_indices,
+                dst_indices=device_indices,
+                page_size=self.page_size,
+            )
+        else:
+            raise ValueError(f"Unsupported IO backend: {io_backend}")
+
+    def backup_from_device_all_layer(
+        self,
+        device_pool,
+        host_indices,
+        device_indices,
+        io_backend,
+        block_quota: int | None = None,
+    ):
+        super().backup_from_device_all_layer(
+            device_pool,
+            host_indices,
+            device_indices,
+            io_backend,
+            block_quota=block_quota,
+        )
+        if not self.index_k_host_buffer:
+            return
+        if io_backend == "kernel":
+            if block_quota is None:
+                block_quota = MLA_KVSTORE_WRITEBACK_BLOCK_QUOTA
+            transfer_kv_all_layer_mla(
+                src_layers=device_pool.index_k_data_ptrs,
+                dst_layers=self.index_k_data_ptrs,
+                src_indices=device_indices,
+                dst_indices=host_indices,
+                item_size=self.index_k_row_bytes,
+                num_layers=len(self.index_k_data_refs),
+                block_quota=block_quota,
+            )
+        elif io_backend == "direct":
+            transfer_kv_direct(
+                src_layers=[
+                    device_pool.index_k_buffer[layer_id]
+                    for layer_id in sorted(device_pool.indexed_layer_ids)
+                ],
+                dst_layers=self.index_k_data_refs,
                 src_indices=device_indices,
                 dst_indices=host_indices,
                 page_size=self.page_size,

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/msa.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/msa.py
@@ -13,8 +13,6 @@ from tokenspeed.runtime.layers.attention.kv_cache.mha import MHATokenToKVPool
 class MSATokenToKVPool(MHATokenToKVPool):
     """MHA K/V cache plus a key-only sparse-index side cache."""
 
-    supports_hierarchical_kv_cache = False
-
     def __init__(
         self,
         *,
@@ -70,6 +68,15 @@ class MSATokenToKVPool(MHATokenToKVPool):
                 )
                 for layer_id in sorted(self.indexed_layer_ids)
             }
+        # Device-side pointer table for index-K host offload transfers.
+        self.index_k_data_ptrs = torch.tensor(
+            [
+                self.index_k_buffer[layer_id].data_ptr()
+                for layer_id in sorted(self.indexed_layer_ids)
+            ],
+            dtype=torch.uint64,
+            device=self.device,
+        )
 
     def get_index_k_buffer(self, layer_id: int) -> torch.Tensor:
         if self.layer_transfer_counter is not None:

--- a/test/runtime/cache/test_msa_kvstore_host.py
+++ b/test/runtime/cache/test_msa_kvstore_host.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+import torch
+
+from tokenspeed.runtime.cache.kv_cache_host import MSATokenToKVPoolHost
+from tokenspeed.runtime.layers.attention.kv_cache.msa import MSATokenToKVPool
+
+PAGE_SIZE = 128
+HEAD_NUM = 1
+HEAD_DIM = 128
+INDEX_HEAD_DIM = 128
+LAYER_NUM = 4
+INDEXED_LAYER_IDS = frozenset({0, 2})
+SIZE = 2 * PAGE_SIZE
+KV_DTYPE = torch.float8_e4m3fn
+INDEX_DTYPE = torch.bfloat16
+
+_PKG_FLAT_PROBE = (
+    "tokenspeed.runtime.configs.paged_cache_spec.scheduler_ext_flat_kvcache"
+)
+
+cuda_only = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="MSA KVStore transfer requires CUDA"
+)
+
+
+def _make_device_pool() -> MSATokenToKVPool:
+    # This test exercises the radix host pool. Force the legacy per-layer
+    # device layout even when pytest runs with a flat scheduler extension.
+    with mock.patch(_PKG_FLAT_PROBE, return_value=False):
+        return MSATokenToKVPool(
+            size=SIZE,
+            dtype=KV_DTYPE,
+            head_num=HEAD_NUM,
+            head_dim=HEAD_DIM,
+            layer_num=LAYER_NUM,
+            device="cuda",
+            enable_memory_saver=False,
+            max_batch_size=8,
+            max_context_len=4 * PAGE_SIZE,
+            page_size=PAGE_SIZE,
+            rank=0,
+            index_head_dim=INDEX_HEAD_DIM,
+            index_dtype=INDEX_DTYPE,
+            indexed_layer_ids=INDEXED_LAYER_IDS,
+        )
+
+
+def _make_host_pool(device_pool: MSATokenToKVPool) -> MSATokenToKVPoolHost:
+    return MSATokenToKVPoolHost(
+        device_pool=device_pool,
+        host_to_device_ratio=2.0,
+        host_size=0,
+        page_size=PAGE_SIZE,
+        layout="layer_first",
+        device="cpu",
+    )
+
+
+@pytest.fixture(scope="module")
+def msa_pools():
+    # cudaHostRegister-backed host memory is not released between pools in one
+    # process, so register a single device/host pool pair and share it.
+    device_pool = _make_device_pool()
+    host_pool = _make_host_pool(device_pool)
+    return device_pool, host_pool
+
+
+def _assert_same_bytes(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    assert torch.equal(actual.view(torch.uint8), expected.view(torch.uint8))
+
+
+def _fill_page_byte_pattern(tensor: torch.Tensor, rows: slice, *, seed: int) -> None:
+    page_bytes = tensor[rows].view(torch.uint8).reshape(rows.stop - rows.start, -1)
+    row_ids = torch.arange(
+        rows.start,
+        rows.stop,
+        dtype=torch.int64,
+        device=tensor.device,
+    ).unsqueeze(1)
+    column_ids = torch.arange(
+        page_bytes.shape[1],
+        dtype=torch.int64,
+        device=tensor.device,
+    ).unsqueeze(0)
+    pattern = (row_ids * 17 + column_ids * 29 + seed) % 256
+    page_bytes.copy_(pattern.to(torch.uint8))
+
+
+@cuda_only
+def test_msa_host_pool_sizing_and_sparse_layer_mapping(msa_pools):
+    from tokenspeed.runtime.cache.executor.memory_executor import (
+        _pool_size_per_token,
+    )
+
+    device_pool, host_pool = msa_pools
+
+    kv_bytes = HEAD_NUM * HEAD_DIM * LAYER_NUM * KV_DTYPE.itemsize * 2
+    index_k_bytes = INDEX_HEAD_DIM * INDEX_DTYPE.itemsize * len(INDEXED_LAYER_IDS)
+
+    assert host_pool.size_per_token == kv_bytes + index_k_bytes
+    assert _pool_size_per_token(device_pool) == host_pool.size_per_token
+    assert host_pool.get_ksize_per_token() == kv_bytes // 2 + index_k_bytes
+    assert tuple(device_pool.index_k_buffer) == tuple(sorted(INDEXED_LAYER_IDS))
+    assert tuple(host_pool.index_k_host_buffer) == tuple(sorted(INDEXED_LAYER_IDS))
+    assert len(host_pool.index_k_data_refs) == len(INDEXED_LAYER_IDS)
+    assert host_pool.index_k_data_ptrs.numel() == len(INDEXED_LAYER_IDS)
+    assert host_pool.index_k_row_bytes == INDEX_HEAD_DIM * INDEX_DTYPE.itemsize
+
+    for layer_id in INDEXED_LAYER_IDS:
+        buffer = host_pool.index_k_host_buffer[layer_id]
+        assert buffer.shape == (host_pool.size, INDEX_HEAD_DIM)
+        assert buffer.dtype == INDEX_DTYPE
+
+
+@cuda_only
+@pytest.mark.parametrize("io_backend", ["direct", "kernel"])
+def test_msa_host_pool_roundtrip_preserves_kv_and_index_k(msa_pools, io_backend):
+    device_pool, host_pool = msa_pools
+
+    if io_backend == "direct" and getattr(torch.version, "hip", None) is not None:
+        pytest.skip("direct KVStore transfer is only available on NVIDIA")
+
+    device_rows = slice(PAGE_SIZE, 3 * PAGE_SIZE)
+    host_rows = slice(0, 2 * PAGE_SIZE)
+
+    # Make every byte depend on its source row and byte column. Layer- and
+    # buffer-specific seeds additionally catch layer, K/V, and index-K pointer
+    # mixups; non-contiguous sparse layers exercise the actual layer-id mapping.
+    for layer_id in range(LAYER_NUM):
+        for page_id in (1, 2):
+            rows = slice(page_id * PAGE_SIZE, (page_id + 1) * PAGE_SIZE)
+            _fill_page_byte_pattern(
+                device_pool.k_buffer[layer_id],
+                rows,
+                seed=layer_id * 37 + 3,
+            )
+            _fill_page_byte_pattern(
+                device_pool.v_buffer[layer_id],
+                rows,
+                seed=layer_id * 37 + 101,
+            )
+            if layer_id in INDEXED_LAYER_IDS:
+                _fill_page_byte_pattern(
+                    device_pool.index_k_buffer[layer_id],
+                    rows,
+                    seed=layer_id * 37 + 199,
+                )
+
+    # Transfer device pages [1, 2] into host pages [0, 1] (skip padded page 0).
+    # Match HostExecutor._prepare_indices: kernel consumes CUDA indices, while
+    # direct sorts and consumes CPU indices.
+    indices_device = "cuda" if io_backend == "kernel" else "cpu"
+    device_indices = torch.arange(
+        PAGE_SIZE, 3 * PAGE_SIZE, dtype=torch.int64, device=indices_device
+    )
+    host_indices = torch.arange(
+        0, 2 * PAGE_SIZE, dtype=torch.int64, device=indices_device
+    )
+
+    orig_k = {
+        layer_id: device_pool.k_buffer[layer_id][device_rows].clone()
+        for layer_id in range(LAYER_NUM)
+    }
+    orig_v = {
+        layer_id: device_pool.v_buffer[layer_id][device_rows].clone()
+        for layer_id in range(LAYER_NUM)
+    }
+    orig_index_k = {
+        layer_id: device_pool.index_k_buffer[layer_id][device_rows].clone()
+        for layer_id in INDEXED_LAYER_IDS
+    }
+
+    # The module-scoped pool is reused by both backend parameters. Poison the
+    # destination before every writeback so a missing D2H copy cannot pass by
+    # observing data left behind by the preceding backend.
+    for layer_id in range(LAYER_NUM):
+        host_pool.k_buffer[layer_id][host_rows].view(torch.uint8).fill_(0xA5)
+        host_pool.v_buffer[layer_id][host_rows].view(torch.uint8).fill_(0x5A)
+    for layer_id in INDEXED_LAYER_IDS:
+        host_pool.index_k_host_buffer[layer_id][host_rows].view(torch.uint8).fill_(0x3C)
+
+    host_pool.backup_from_device_all_layer(
+        device_pool, host_indices, device_indices, io_backend
+    )
+    torch.cuda.synchronize()
+
+    # Check D2H independently, so matching mistakes in writeback and loadback
+    # cannot cancel each other out and make the final roundtrip look correct.
+    for layer_id in range(LAYER_NUM):
+        _assert_same_bytes(
+            host_pool.k_buffer[layer_id][host_rows], orig_k[layer_id].cpu()
+        )
+        _assert_same_bytes(
+            host_pool.v_buffer[layer_id][host_rows], orig_v[layer_id].cpu()
+        )
+    for layer_id in INDEXED_LAYER_IDS:
+        _assert_same_bytes(
+            host_pool.index_k_host_buffer[layer_id][host_rows],
+            orig_index_k[layer_id].cpu(),
+        )
+
+    for layer_id in range(LAYER_NUM):
+        device_pool.k_buffer[layer_id][device_rows].zero_()
+        device_pool.v_buffer[layer_id][device_rows].zero_()
+        if layer_id in INDEXED_LAYER_IDS:
+            device_pool.index_k_buffer[layer_id][device_rows].zero_()
+
+    for layer_id in range(LAYER_NUM):
+        host_pool.load_to_device_per_layer(
+            device_pool,
+            host_indices,
+            device_indices,
+            layer_id,
+            io_backend,
+        )
+    torch.cuda.synchronize()
+
+    for layer_id in range(LAYER_NUM):
+        _assert_same_bytes(
+            device_pool.k_buffer[layer_id][device_rows], orig_k[layer_id]
+        )
+        _assert_same_bytes(
+            device_pool.v_buffer[layer_id][device_rows], orig_v[layer_id]
+        )
+    for layer_id in INDEXED_LAYER_IDS:
+        _assert_same_bytes(
+            device_pool.index_k_buffer[layer_id][device_rows],
+            orig_index_k[layer_id],
+        )

--- a/test/runtime/test_flat_host_executor.py
+++ b/test/runtime/test_flat_host_executor.py
@@ -47,6 +47,25 @@ class _StubPool:
         self.v_buffer = [v_slabs[0], v_slabs[0], v_slabs[1], v_slabs[1]]
 
 
+class _StubMSAPool(_StubPool):
+    """MiniMax MSA's per-layer K/V plus index-K on layers 0/2."""
+
+    def __init__(self, torch):
+        super().__init__(torch)
+        rows = self.size + self.page_size
+        self.k_buffer = [
+            torch.zeros((rows, 1, 8), dtype=torch.bfloat16) for _ in range(4)
+        ]
+        self.v_buffer = [
+            torch.zeros((rows, 1, 8), dtype=torch.bfloat16) for _ in range(4)
+        ]
+        self.indexed_layer_ids = frozenset({0, 2})
+        self.index_k_buffer = {
+            layer_id: torch.zeros((rows, 8), dtype=torch.bfloat16)
+            for layer_id in sorted(self.indexed_layer_ids)
+        }
+
+
 class FlatHostPageSizingTest(unittest.TestCase):
     """num_host_pages budget arithmetic; no CUDA, no scheduler ext."""
 
@@ -161,6 +180,75 @@ class LoadBackDonePayloadTest(unittest.TestCase):
         self.assertEqual(self.pop_common([[payload], []]), [])
         both = self.pop_common([[payload], [dict(payload)]])
         self.assertEqual(both, [payload])
+
+
+class FlatMemoryExecutorMSAEventMappingTest(unittest.TestCase):
+    """CPU-only pin of _start_loading's MSA layer -> tensor event mapping."""
+
+    def setUp(self):
+        try:
+            import torch
+
+            from tokenspeed.runtime.cache.executor.flat_memory_executor import (
+                FlatMemoryExecutor,
+            )
+            from tokenspeed.runtime.cache.flat_host_mirror import FlatHostMirror
+        except (ImportError, ModuleNotFoundError) as exc:
+            self.skipTest(f"needs torch + scheduler ext: {exc}")
+        self.torch = torch
+        self.FlatHostMirror = FlatHostMirror
+        self.FlatMemoryExecutor = FlatMemoryExecutor
+
+    def test_sparse_layers_fence_on_index_k_and_finish_covers_last_copy(self):
+        pool = _StubMSAPool(self.torch)
+        with mock.patch(
+            "tokenspeed.runtime.cache.flat_host_mirror.torch.cuda.is_available",
+            return_value=False,
+        ):
+            mirror = self.FlatHostMirror(pool, num_host_pages=2)
+
+        # Bypass __init__ so this unit test can pin orchestration without a
+        # CUDA stream. The mirror returns one sentinel per tensor in its fixed
+        # K*, V*, index-K* order.
+        executor = self.FlatMemoryExecutor.__new__(self.FlatMemoryExecutor)
+        executor.layer_num = 4
+        executor.mirror = mirror
+        executor.load_stream = object()
+        executor._pending_load_op_ids = [31]
+        executor._pending_load_pairs = [(1, 0)]
+        executor._immediate_load_op_ids = []
+        executor.ack_load_queue = []
+        executor._producer_map = {}
+        executor._producer_map_limit = 1024
+
+        events = [object() for _ in mirror.tensor_pairs]
+        mirror.load_pages_with_events = mock.Mock(return_value=events)
+        producer_event = mock.Mock()
+        producer_event.start_event = mock.Mock()
+        producer_event.load_events = [None] * executor.layer_num
+        executor._counter = mock.Mock()
+        executor._counter.update_producer.return_value = 0
+        executor._counter.events = [producer_event]
+
+        with mock.patch(
+            "tokenspeed.runtime.cache.executor.flat_memory_executor."
+            "get_is_capture_mode",
+            return_value=False,
+        ):
+            executor._start_loading()
+
+        # Mirror ready mapping before the final producer-slot fence:
+        # sparse 0 -> index-K[0] event 8; dense 1 -> V event 5;
+        # sparse 2 -> index-K[2] event 9; dense 3 -> V event 7.
+        # _start_loading then pins the final layer to events[-1], ensuring
+        # finish_event/slot reuse/ack cover the later index-K copies.
+        self.assertIs(producer_event.load_events[0], events[8])
+        self.assertIs(producer_event.load_events[1], events[5])
+        self.assertIs(producer_event.load_events[2], events[9])
+        self.assertIs(producer_event.load_events[3], events[-1])
+        self.assertIs(executor.ack_load_queue[0].finish_event, events[-1])
+        self.assertEqual(executor.ack_load_queue[0].op_ids, [31])
+        self.assertEqual(executor._producer_map, {31: 0})
 
 
 class FlatMemoryExecutorTest(unittest.TestCase):

--- a/test/runtime/test_flat_host_mirror.py
+++ b/test/runtime/test_flat_host_mirror.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import os
 import sys
+import types
 import unittest
+from contextlib import nullcontext
 from unittest import mock
 
 # CI Registration (parsed via AST, runtime no-op)
@@ -359,12 +361,304 @@ class FlatHostMirrorStateSlabTest(unittest.TestCase):
         # the 4 KV mirrors; conv immediately precedes its ssm.
         self.assertEqual(mirror.state_tensor_indices_of_layer(0), (4, 5))
         self.assertEqual(mirror.state_tensor_indices_of_layer(2), (6, 7))
+        self.assertEqual(mirror.ready_tensor_index_of_layer(0), 5)
+        self.assertEqual(mirror.ready_tensor_index_of_layer(2), 7)
         self.assertIsNone(mirror.state_tensor_indices_of_layer(1))
         self.assertIsNone(mirror.state_tensor_indices_of_layer(3))
+        self.assertEqual(mirror.ready_tensor_index_of_layer(1), 2)
+        self.assertEqual(mirror.ready_tensor_index_of_layer(3), 3)
         # Pools without state slabs expose no state indices for any layer.
         kv_only = self.FlatHostMirror(self._pool(with_state=False), num_host_pages=2)
         for layer_id in range(4):
             self.assertIsNone(kv_only.state_tensor_indices_of_layer(layer_id))
+
+
+class FlatHostMirrorMSAIndexKTest(unittest.TestCase):
+    """CPU stub for MiniMax MSA's optional index-K side cache.
+
+    Sparse layers are deliberately non-contiguous and share K/V slabs with
+    dense layers. This pins both the index-K layer mapping and the fact that a
+    sparse layer must fence after index-K rather than after its shared V slab.
+    """
+
+    INDEXED_LAYER_IDS = (0, 2)
+
+    def setUp(self):
+        try:
+            import torch
+
+            from tokenspeed.runtime.cache.flat_host_mirror import (
+                FlatHostMirror,
+                flat_bytes_per_host_page,
+            )
+        except (ImportError, ModuleNotFoundError) as exc:
+            self.skipTest(f"needs torch: {exc}")
+        self.torch = torch
+        self.FlatHostMirror = FlatHostMirror
+        self.flat_bytes_per_host_page = flat_bytes_per_host_page
+
+    def _stub_pool(
+        self,
+        *,
+        with_index_k: bool = True,
+        alias_index_k: bool = False,
+        alias_kv: bool = True,
+        with_state: bool = False,
+    ):
+        torch = self.torch
+        page_size = 4
+        size = 8
+        rows = size + page_size
+        kv_tensor_count = 2 if alias_kv else 4
+        k_slabs = [
+            torch.zeros((rows, 1, 8), dtype=torch.bfloat16)
+            for _ in range(kv_tensor_count)
+        ]
+        v_slabs = [
+            torch.zeros((rows, 1, 8), dtype=torch.bfloat16)
+            for _ in range(kv_tensor_count)
+        ]
+        if alias_kv:
+            k_buffer = [k_slabs[0], k_slabs[0], k_slabs[1], k_slabs[1]]
+            v_buffer = [v_slabs[0], v_slabs[0], v_slabs[1], v_slabs[1]]
+        else:
+            k_buffer = k_slabs
+            v_buffer = v_slabs
+        pool = types.SimpleNamespace(
+            page_size=page_size,
+            size=size,
+            k_buffer=k_buffer,
+            v_buffer=v_buffer,
+        )
+        if with_index_k:
+            pool.indexed_layer_ids = frozenset(self.INDEXED_LAYER_IDS)
+            # Match MSATokenToKVPool: dict insertion order is sorted layer id.
+            pool.index_k_buffer = {
+                layer_id: torch.zeros((rows, 8), dtype=torch.bfloat16)
+                for layer_id in sorted(pool.indexed_layer_ids)
+            }
+            if alias_index_k:
+                pool.index_k_buffer[2] = pool.index_k_buffer[0]
+        if with_state:
+            conv = torch.zeros((4, 2), dtype=torch.bfloat16)
+            ssm = torch.zeros((4, 4), dtype=torch.bfloat16)
+            pool.state_slabs = [(conv, ssm)]
+
+            def get_state_buffers(layer_id):
+                if layer_id == 0:
+                    return conv, ssm
+                raise ValueError(f"layer {layer_id} is not a state layer")
+
+            pool.get_state_buffers = get_state_buffers
+        return pool
+
+    def _mirror(self, pool, num_host_pages: int = 3):
+        # Keep this stub test CPU-only even when it runs on a CUDA worker.
+        with mock.patch(
+            "tokenspeed.runtime.cache.flat_host_mirror.torch.cuda.is_available",
+            return_value=False,
+        ):
+            return self.FlatHostMirror(pool, num_host_pages=num_host_pages)
+
+    def _fill_page_byte_pattern(self, tensor, rows: slice, *, seed: int) -> None:
+        page_bytes = (
+            tensor[rows].view(self.torch.uint8).reshape(rows.stop - rows.start, -1)
+        )
+        row_ids = self.torch.arange(
+            rows.start,
+            rows.stop,
+            dtype=self.torch.int64,
+            device=tensor.device,
+        ).unsqueeze(1)
+        column_ids = self.torch.arange(
+            page_bytes.shape[1],
+            dtype=self.torch.int64,
+            device=tensor.device,
+        ).unsqueeze(0)
+        pattern = (row_ids * 17 + column_ids * 29 + seed) % 256
+        page_bytes.copy_(pattern.to(self.torch.uint8))
+
+    def test_capacity_and_non_contiguous_sparse_layer_mapping(self):
+        pool = self._stub_pool()
+        # K/V: 4 mirrors * 4 rows * 16 B = 256 B.
+        # index-K: 2 sparse layers * 4 rows * 16 B = 128 B.
+        self.assertEqual(self.flat_bytes_per_host_page(pool), 384)
+
+        mirror = self._mirror(pool)
+        self.assertEqual(mirror.num_k_tensors, 2)
+        self.assertEqual(mirror.num_index_k_tensors, 2)
+        self.assertEqual(len(mirror.tensor_pairs), 6)
+        self.assertEqual(mirror.row_spans, (4,) * 6)
+        self.assertEqual(mirror.bytes_per_host_page(), 384)
+
+        # PINNED order: K*, V*, then index-K* sorted by sparse layer id.
+        self.assertIs(mirror.tensor_pairs[4][0], pool.index_k_buffer[0])
+        self.assertIs(mirror.tensor_pairs[5][0], pool.index_k_buffer[2])
+        self.assertEqual(mirror.index_k_tensor_index_of_layer(0), 4)
+        self.assertIsNone(mirror.index_k_tensor_index_of_layer(1))
+        self.assertEqual(mirror.index_k_tensor_index_of_layer(2), 5)
+        self.assertIsNone(mirror.index_k_tensor_index_of_layer(3))
+
+        # Dense layers fence on V; sparse layers fence on their later index-K.
+        self.assertEqual(
+            [mirror.ready_tensor_index_of_layer(i) for i in range(4)],
+            [4, 2, 5, 3],
+        )
+
+    def test_per_layer_kv_layout_matches_m3(self):
+        pool = self._stub_pool(alias_kv=False)
+        mirror = self._mirror(pool)
+
+        # M3 uses per-layer K/V tensors: 8 K/V mirrors plus two sparse index-K
+        # mirrors. Each mirror contributes 4 rows * 16 bytes per host page.
+        self.assertEqual(self.flat_bytes_per_host_page(pool), 640)
+        self.assertEqual(mirror.num_k_tensors, 4)
+        self.assertEqual(mirror.num_index_k_tensors, 2)
+        self.assertEqual(len(mirror.tensor_pairs), 10)
+        self.assertEqual(mirror.row_spans, (4,) * 10)
+        self.assertEqual(mirror.bytes_per_host_page(), 640)
+        self.assertEqual(
+            [mirror.ready_tensor_index_of_layer(i) for i in range(4)],
+            [8, 5, 9, 7],
+        )
+
+    def test_index_k_identity_alias_is_mirrored_once(self):
+        pool = self._stub_pool(alias_index_k=True)
+        mirror = self._mirror(pool)
+
+        self.assertEqual(mirror.num_index_k_tensors, 1)
+        self.assertEqual(len(mirror.tensor_pairs), 5)
+        self.assertEqual(mirror.bytes_per_host_page(), 320)
+        self.assertEqual(mirror.index_k_tensor_index_of_layer(0), 4)
+        self.assertEqual(mirror.index_k_tensor_index_of_layer(2), 4)
+        self.assertEqual(
+            [mirror.ready_tensor_index_of_layer(i) for i in range(4)],
+            [4, 2, 4, 3],
+        )
+
+    def test_state_offsets_include_index_k_and_state_ready_wins(self):
+        pool = self._stub_pool(with_state=True)
+        mirror = self._mirror(pool)
+
+        # K*/V* occupy [0, 4), index-K occupies [4, 6), so state starts at
+        # 6 rather than the old KV-only base 4. Layer 0 deliberately has both
+        # state and index-K: its SSM event is the final readiness fence.
+        self.assertEqual(mirror.state_tensor_indices_of_layer(0), (6, 7))
+        self.assertEqual(mirror.index_k_tensor_index_of_layer(0), 4)
+        self.assertEqual(mirror.ready_tensor_index_of_layer(0), 7)
+        self.assertEqual(mirror.ready_tensor_index_of_layer(2), 5)
+
+    def test_store_load_roundtrip_preserves_index_k(self):
+        # Exercise M3's real per-layer K/V topology here. The aliased-slab
+        # layout remains covered by the layout/dedup tests above.
+        pool = self._stub_pool(alias_kv=False)
+        mirror = self._mirror(pool)
+        store_pairs = [(1, 2), (2, 0)]
+        source_device_pages = [device_page for device_page, _ in store_pairs]
+
+        before = []
+        for tensor_idx, ((dev, _), span) in enumerate(
+            zip(mirror.tensor_pairs, mirror.row_spans)
+        ):
+            pages = {}
+            for device_page in source_device_pages:
+                rows = slice(device_page * span, (device_page + 1) * span)
+                self._fill_page_byte_pattern(
+                    dev,
+                    rows,
+                    seed=tensor_idx * 41 + device_page * 13 + 7,
+                )
+                pages[device_page] = dev[rows].clone()
+            before.append(pages)
+
+        for tensor_idx, ((_, host), span) in enumerate(
+            zip(mirror.tensor_pairs, mirror.row_spans)
+        ):
+            for _, host_page in store_pairs:
+                host_rows = host[host_page * span : (host_page + 1) * span]
+                host_rows.view(self.torch.uint8).fill_((0xA5 + tensor_idx) % 256)
+
+        # _copy_pages only needs a stream context; CPU copy_ exercises the
+        # same row-span/index ordering without requiring a CUDA worker.
+        with mock.patch(
+            "tokenspeed.runtime.cache.flat_host_mirror.torch.cuda.stream",
+            side_effect=lambda _stream: nullcontext(),
+        ):
+            mirror.store_pages(store_pairs, stream=None)
+
+            # Validate D2H independently. Otherwise matching addressing bugs in
+            # store_pages and load_pages could cancel in the final roundtrip.
+            for tensor_idx, ((_, host), span) in enumerate(
+                zip(mirror.tensor_pairs, mirror.row_spans)
+            ):
+                for device_page, host_page in store_pairs:
+                    self.assertTrue(
+                        self.torch.equal(
+                            host[host_page * span : (host_page + 1) * span].view(
+                                self.torch.uint8
+                            ),
+                            before[tensor_idx][device_page].view(self.torch.uint8),
+                        ),
+                        f"tensor {tensor_idx} host page {host_page} D2H mismatch",
+                    )
+
+            # Reload the two host pages into reversed device destinations so
+            # H2D addressing is tested independently from the D2H mapping.
+            load_pairs = [(2, 2), (1, 0)]
+            for (dev, _), span in zip(mirror.tensor_pairs, mirror.row_spans):
+                for device_page, _ in load_pairs:
+                    dev[device_page * span : (device_page + 1) * span].zero_()
+            mirror.load_pages(load_pairs, stream=None)
+
+        source_page_by_host_page = {
+            host_page: device_page for device_page, host_page in store_pairs
+        }
+        for tensor_idx, ((dev, _), span) in enumerate(
+            zip(mirror.tensor_pairs, mirror.row_spans)
+        ):
+            for destination_page, host_page in load_pairs:
+                source_page = source_page_by_host_page[host_page]
+                self.assertTrue(
+                    self.torch.equal(
+                        dev[
+                            destination_page * span : (destination_page + 1) * span
+                        ].view(self.torch.uint8),
+                        before[tensor_idx][source_page].view(self.torch.uint8),
+                    ),
+                    f"tensor {tensor_idx} device page {destination_page} "
+                    "not byte-exact",
+                )
+
+    def test_pool_without_index_k_keeps_original_layout_and_sizing(self):
+        pool = self._stub_pool(with_index_k=False)
+        mirror = self._mirror(pool)
+
+        self.assertEqual(self.flat_bytes_per_host_page(pool), 256)
+        self.assertEqual(mirror.bytes_per_host_page(), 256)
+        self.assertEqual(mirror.num_k_tensors, 2)
+        self.assertEqual(mirror.num_index_k_tensors, 0)
+        self.assertEqual(len(mirror.tensor_pairs), 4)
+        self.assertEqual(mirror.row_spans, (4,) * 4)
+        self.assertEqual(
+            [mirror.ready_tensor_index_of_layer(i) for i in range(4)],
+            [2, 2, 3, 3],
+        )
+        for layer_id in range(4):
+            self.assertIsNone(mirror.index_k_tensor_index_of_layer(layer_id))
+
+    def test_non_mapping_index_cache_keeps_original_layout(self):
+        pool = self._stub_pool(with_index_k=False)
+        pool.indexed_layer_ids = frozenset(range(4))
+        pool.index_k_buffer = [
+            self.torch.zeros((12, 8), dtype=self.torch.uint8) for _ in range(4)
+        ]
+        mirror = self._mirror(pool)
+
+        # DSA-style packed/list side caches are outside the MSA mapping
+        # contract and keep the pre-existing flat mirror behavior.
+        self.assertEqual(self.flat_bytes_per_host_page(pool), 256)
+        self.assertEqual(mirror.num_index_k_tensors, 0)
+        self.assertEqual(len(mirror.tensor_pairs), 4)
 
 
 class FlatHostMirrorNoneKVTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Add CPU L2 KVStore support for MiniMax M3's MSA index-K cache.

- Support MSA K/V and index-K offload on radix scheduler builds.
- Support target K/V and index-K offload on flat scheduler builds.
- Include index-K in host memory sizing and loadback synchronization.
- Support radix target and speculative draft host pools.
- Fix the reversed host-memory-size warning condition.
- Add radix and flat cache tests.
- Update the MiniMax M3 recipe.

## Limitations

- Flat CPU L2 does not yet mirror speculative draft pools. Flat speculative runs must use `--disable-kvstore`.
- MSA L3 storage offload is outside the scope of this PR.