### PR TITLE
fix(runtime): support DeepSeek V4 Flat KV cache groups

### DIFF
--- a/python/tokenspeed/runtime/cache/executor/flat_memory_executor.py
+++ b/python/tokenspeed/runtime/cache/executor/flat_memory_executor.py
@@ -105,6 +105,16 @@ class FlatMemoryExecutor:
     emits_loadback_acks = True
 
     def __init__(self, device_pool, *, host_ratio: float, host_size_gb: float):
+        if not getattr(device_pool, "supports_flat_host_mirror", False):
+            raise NotImplementedError(
+                "the flat host tier (kvstore L2) does not support this KV "
+                "cache pool; pass --disable-kvstore."
+            )
+        if not hasattr(device_pool, "k_buffer") or not hasattr(device_pool, "v_buffer"):
+            raise TypeError(
+                "a flat-host-mirror-capable KV pool must expose k_buffer and "
+                "v_buffer"
+            )
         self.page_size = int(device_pool.page_size)
         self.layer_num = len(device_pool.k_buffer)
 

--- a/python/tokenspeed/runtime/configs/deepseek_v4_cache_spec.py
+++ b/python/tokenspeed/runtime/configs/deepseek_v4_cache_spec.py
@@ -193,11 +193,22 @@ def build_v4_cache_specs(
     hf_config: Any,
     *,
     layer_ratio: Sequence[int],
+    flat_scheduler: bool = False,
 ) -> list[PagedCacheGroupSpec]:
+    """Build V4 cache groups without changing the legacy Radix geometry.
+
+    A Flat scheduler needs each group's physical child-page geometry to pack
+    pages into its 256-token parent domain.  Radix historically received no
+    per-group block override and must keep using the global page size.
+    """
+    if not isinstance(flat_scheduler, bool):
+        raise ValueError("flat_scheduler must be a bool")
     swa_window = _resolve_sliding_window(hf_config)
     unique_compress_ratios = sorted({int(r) for r in layer_ratio if int(r) > 1})
 
     def _geometry(rows_per_page: int, entry_stride_tokens: int) -> dict[str, int]:
+        if not flat_scheduler:
+            return {}
         block_size = int(rows_per_page) * int(entry_stride_tokens)
         if DEEPSEEK_V4_COMPRESSED_LOGICAL_BLOCK_SIZE % block_size != 0:
             raise ValueError(

--- a/python/tokenspeed/runtime/configs/deepseek_v4_cache_spec.py
+++ b/python/tokenspeed/runtime/configs/deepseek_v4_cache_spec.py
@@ -197,6 +197,20 @@ def build_v4_cache_specs(
     swa_window = _resolve_sliding_window(hf_config)
     unique_compress_ratios = sorted({int(r) for r in layer_ratio if int(r) > 1})
 
+    def _geometry(rows_per_page: int, entry_stride_tokens: int) -> dict[str, int]:
+        block_size = int(rows_per_page) * int(entry_stride_tokens)
+        if DEEPSEEK_V4_COMPRESSED_LOGICAL_BLOCK_SIZE % block_size != 0:
+            raise ValueError(
+                "DeepSeek V4 cache group page tokens must divide "
+                f"{DEEPSEEK_V4_COMPRESSED_LOGICAL_BLOCK_SIZE}, got {block_size}"
+            )
+        return {
+            "block_size": block_size,
+            "cache_blocks_per_lcm_block": (
+                DEEPSEEK_V4_COMPRESSED_LOGICAL_BLOCK_SIZE // block_size
+            ),
+        }
+
     specs: list[PagedCacheGroupSpec] = [
         # SWA kv: trailing window only -> State family.
         PagedCacheGroupSpec(
@@ -206,6 +220,7 @@ def build_v4_cache_specs(
             entry_stride_tokens=1,
             sliding_window_tokens=swa_window,
             family="state",
+            **_geometry(V4_KERNEL_BLOCK_ROWS, 1),
         ),
     ]
     for ratio in unique_compress_ratios:
@@ -220,6 +235,7 @@ def build_v4_cache_specs(
                 entry_stride_tokens=1,
                 sliding_window_tokens=_COMPRESSOR_STATE_WINDOW_TOKENS[ratio],
                 family="state",
+                **_geometry(_COMPRESSOR_STATE_ROWS_PER_PAGE[ratio], 1),
             )
         )
         # Compressed kv: full-history chain (indexer K shares this group).
@@ -231,6 +247,7 @@ def build_v4_cache_specs(
                 entry_stride_tokens=ratio,
                 sliding_window_tokens=None,
                 family="history",
+                **_geometry(_compressed_kernel_block_size(ratio), ratio),
             )
         )
     if 4 in unique_compress_ratios:
@@ -243,6 +260,7 @@ def build_v4_cache_specs(
                 entry_stride_tokens=1,
                 sliding_window_tokens=_COMPRESSOR_STATE_WINDOW_TOKENS[4],
                 family="state",
+                **_geometry(_COMPRESSOR_STATE_ROWS_PER_PAGE[4], 1),
             )
         )
     return specs

--- a/python/tokenspeed/runtime/configs/paged_cache_spec.py
+++ b/python/tokenspeed/runtime/configs/paged_cache_spec.py
@@ -35,8 +35,11 @@ class PagedCacheGroupSpec:
     # History groups form a chain; State groups only need the trailing window.
     family: Family = "history"
     # Per-group logical page tokens; None -> scheduler global block_size. A
-    # finer group must divide the global block and pack the corresponding
-    # number of logical pages into one LCM block.
+    # model-declared finer group must divide the global block and pack the
+    # corresponding number of logical pages into one LCM block. The generic
+    # layer-type helper below only derives equal/coarser groups; finer groups
+    # travel through a model-specific spec or publish_paged_cache_groups'
+    # extra_groups path.
     block_size: int | None = None
     # Physical child CacheBlocks packed into one shared LCM parent.
     cache_blocks_per_lcm_block: int = 1
@@ -555,9 +558,11 @@ def group_specs_from_layer_types(
             positions must be None).
         page_size: Pool page size. Flat treats this as the shared scheduler
             domain; radix retains its legacy GCD resolution.
-        page_sizes: Per-group page sizes keyed by group id (heterogeneous
-            block sizes); values must be positive multiples of page_size.
-            Groups not listed use page_size.
+        page_sizes: Equal or coarser per-group page sizes keyed by group id;
+            values must be positive multiples of page_size. Groups not listed
+            use page_size. Model-specific finer groups must be declared as
+            explicit ``PagedCacheGroupSpec`` values and supplied through
+            ``publish_paged_cache_groups(extra_groups=...)``.
         cache_blocks_per_lcm_block: Per-group physical packing. Omitted groups
             use one CacheBlock per physical parent.
 
@@ -570,7 +575,9 @@ def group_specs_from_layer_types(
         if ps <= 0 or ps % page_size:
             raise ValueError(
                 f"page_sizes[{gid!r}] = {ps} must be a positive "
-                f"multiple of page_size {page_size}"
+                f"multiple of page_size {page_size}; layer-derived groups "
+                "do not accept finer page sizes (use an explicit "
+                "PagedCacheGroupSpec via extra_groups)"
             )
     packing = dict(cache_blocks_per_lcm_block or {})
     for gid, count in packing.items():
@@ -657,6 +664,9 @@ def publish_paged_cache_groups(
             full-history group).
         sliding_window_tokens / page_size: Forwarded to
             group_specs_from_layer_types.
+        extra_groups: Explicit model-declared groups outside the layer-type
+            vocabulary. This is also the supported route for finer Flat page
+            sizes that divide the shared scheduler domain.
         max_live_requests / max_scheduled_tokens / max_total_tokens /
             max_context_len: Sizing inputs for
             compute_paged_cache_group_page_counts.

--- a/python/tokenspeed/runtime/configs/paged_cache_spec.py
+++ b/python/tokenspeed/runtime/configs/paged_cache_spec.py
@@ -553,7 +553,8 @@ def group_specs_from_layer_types(
         sliding_window_tokens: One window for all sliding layers (today's HF
             scalar), or a per-layer sequence (multi-window models; full-layer
             positions must be None).
-        page_size: Tokens per page (the scheduler's base block size).
+        page_size: Pool page size. Flat treats this as the shared scheduler
+            domain; radix retains its legacy GCD resolution.
         page_sizes: Per-group page sizes keyed by group id (heterogeneous
             block sizes); values must be positive multiples of page_size.
             Groups not listed use page_size.
@@ -613,7 +614,8 @@ def group_specs_from_layer_types(
                 entry_stride_tokens=1,
                 sliding_window_tokens=window,
                 family=family,
-                # Always explicit: unset groups inherit the C++ gcd base, which a finer extra group silently lowers.
+                # Always explicit so this group's geometry does not silently
+                # inherit a value changed by another group.
                 block_size=ps,
                 cache_blocks_per_lcm_block=group_packing,
             )
@@ -685,7 +687,8 @@ def publish_paged_cache_groups(
     for spec in extra_groups:
         if any(sp.group_id == spec.group_id for sp in specs):
             raise ValueError(f"extra_groups: duplicate group id {spec.group_id!r}")
-        # Smaller extra-group blocks lower the gcd base by design; MakeCoordinator asserts divisibility.
+        # Flat derives a GCD hash grain and validates domain divisibility;
+        # radix retains its legacy group handling.
         if spec.block_size is not None and spec.block_size <= 0:
             raise ValueError(f"extra_groups[{spec.group_id!r}]: block_size must be > 0")
         if spec.cache_blocks_per_lcm_block <= 0:

--- a/python/tokenspeed/runtime/configs/paged_cache_spec.py
+++ b/python/tokenspeed/runtime/configs/paged_cache_spec.py
@@ -34,12 +34,11 @@ class PagedCacheGroupSpec:
     sliding_window_tokens: int | None
     # History groups form a chain; State groups only need the trailing window.
     family: Family = "history"
-    # Per-group logical page tokens; None -> scheduler global block_size. A
-    # model-declared finer group must divide the global block and pack the
-    # corresponding number of logical pages into one LCM block. The generic
-    # layer-type helper below only derives equal/coarser groups; finer groups
-    # travel through a model-specific spec or publish_paged_cache_groups'
-    # extra_groups path.
+    # Per-group logical page tokens; None -> scheduler global block_size. Flat
+    # requires the effective size to divide its shared scheduler domain; a
+    # finer group must pack the corresponding number of logical pages into one
+    # LCM block. The generic layer-type helper below is scheduler-agnostic, but
+    # Flat publication validates this stricter contract before returning specs.
     block_size: int | None = None
     # Physical child CacheBlocks packed into one shared LCM parent.
     cache_blocks_per_lcm_block: int = 1
@@ -556,13 +555,14 @@ def group_specs_from_layer_types(
         sliding_window_tokens: One window for all sliding layers (today's HF
             scalar), or a per-layer sequence (multi-window models; full-layer
             positions must be None).
-        page_size: Pool page size. Flat treats this as the shared scheduler
-            domain; radix retains its legacy GCD resolution.
+        page_size: Reference pool page size for this structural helper.
         page_sizes: Equal or coarser per-group page sizes keyed by group id;
             values must be positive multiples of page_size. Groups not listed
-            use page_size. Model-specific finer groups must be declared as
-            explicit ``PagedCacheGroupSpec`` values and supplied through
-            ``publish_paged_cache_groups(extra_groups=...)``.
+            use page_size. This helper is scheduler-agnostic: Flat publication
+            rejects coarser groups because its shared domain must be divisible
+            by every group size. Model-specific finer Flat groups must be
+            declared as explicit ``PagedCacheGroupSpec`` values and supplied
+            through ``publish_paged_cache_groups(extra_groups=...)``.
         cache_blocks_per_lcm_block: Per-group physical packing. Omitted groups
             use one CacheBlock per physical parent.
 
@@ -663,7 +663,8 @@ def publish_paged_cache_groups(
         layer_types: Per-layer paged-cache labels (empty -> single
             full-history group).
         sliding_window_tokens / page_size: Forwarded to
-            group_specs_from_layer_types.
+            group_specs_from_layer_types. For Flat publication, layer-derived
+            page sizes must equal page_size.
         extra_groups: Explicit model-declared groups outside the layer-type
             vocabulary. This is also the supported route for finer Flat page
             sizes that divide the shared scheduler domain.
@@ -707,6 +708,23 @@ def publish_paged_cache_groups(
                 "cache_blocks_per_lcm_block must be > 0"
             )
         specs.append(spec)
+    for spec in specs:
+        group_block_size = int(spec.block_size or page_size)
+        if page_size % group_block_size:
+            raise ValueError(
+                f"paged cache group {spec.group_id!r} block_size "
+                f"{group_block_size} must divide Flat scheduler domain "
+                f"{page_size}"
+            )
+        if group_block_size != page_size:
+            expected_packing = page_size // group_block_size
+            if spec.cache_blocks_per_lcm_block != expected_packing:
+                raise ValueError(
+                    f"paged cache group {spec.group_id!r} packing "
+                    f"{spec.cache_blocks_per_lcm_block} does not cover Flat "
+                    f"scheduler domain {page_size}; expected "
+                    f"{expected_packing}"
+                )
     counts = compute_paged_cache_group_page_counts(
         specs,
         max_live_requests=max_live_requests,

--- a/python/tokenspeed/runtime/configs/paged_cache_spec.py
+++ b/python/tokenspeed/runtime/configs/paged_cache_spec.py
@@ -34,7 +34,9 @@ class PagedCacheGroupSpec:
     sliding_window_tokens: int | None
     # History groups form a chain; State groups only need the trailing window.
     family: Family = "history"
-    # Per-group page tokens; None -> scheduler global block_size, else a multiple of it.
+    # Per-group logical page tokens; None -> scheduler global block_size. A
+    # finer group must divide the global block and pack the corresponding
+    # number of logical pages into one LCM block.
     block_size: int | None = None
     # Physical child CacheBlocks packed into one shared LCM parent.
     cache_blocks_per_lcm_block: int = 1

--- a/python/tokenspeed/runtime/configs/paged_cache_spec.py
+++ b/python/tokenspeed/runtime/configs/paged_cache_spec.py
@@ -560,9 +560,12 @@ def group_specs_from_layer_types(
             values must be positive multiples of page_size. Groups not listed
             use page_size. This helper is scheduler-agnostic: Flat publication
             rejects coarser groups because its shared domain must be divisible
-            by every group size. Model-specific finer Flat groups must be
-            declared as explicit ``PagedCacheGroupSpec`` values and supplied
-            through ``publish_paged_cache_groups(extra_groups=...)``.
+            by every group size. Byte-heterogeneous Flat arenas keep their
+            logical block sizes at the shared domain and express byte ratios
+            through LCM child-page packing instead. Model-specific finer Flat
+            groups must be declared as explicit ``PagedCacheGroupSpec`` values
+            and supplied through
+            ``publish_paged_cache_groups(extra_groups=...)``.
         cache_blocks_per_lcm_block: Per-group physical packing. Omitted groups
             use one CacheBlock per physical parent.
 

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -66,6 +66,7 @@ from tokenspeed.runtime.engine.scheduler_utils import (
     pop_common_cache_event_payloads,
     scheduler_cache_geometry_from_pool,
     should_use_overlap_schedule,
+    validate_scheduler_page_domain_contract,
 )
 from tokenspeed.runtime.execution.distributed_initializer import (
     DistributedConfig,
@@ -514,6 +515,12 @@ class EventLoop:
             paged_cache_host_group_pages=paged_cache_host_group_pages,
             enable_mixed_prefill_decode=server_args.enable_mixed_batch,
             prefix_cache_adjunct=prefix_cache_adjunct,
+        )
+        validate_scheduler_page_domain_contract(
+            pool=token_to_kv_pool,
+            geometry=geometry,
+            scheduler_config=scheduler_cfg,
+            model_executor_config=model_executor_config,
         )
         scheduler_cfg.enable_flatkv_pd = self._flatkv_pd_enabled
         logger.info(

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -128,6 +128,21 @@ def _validate_grouped_kvstore_draft_pool(
         )
 
 
+def _validate_flat_host_tier_pool(token_to_kv_pool) -> None:
+    if getattr(token_to_kv_pool, "runtime_contract", None) is not None:
+        # FlatKV contract pools have no host tier yet: FlatMemoryExecutor
+        # mirrors ordinary k_buffer/v_buffer layouts, not raw LCM arenas.
+        raise NotImplementedError(
+            "the flat host tier (kvstore L2) does not support FlatKV "
+            "contract pools yet; pass --disable-kvstore."
+        )
+    if not getattr(token_to_kv_pool, "supports_flat_host_mirror", False):
+        raise NotImplementedError(
+            "the flat host tier (kvstore L2) does not support this KV cache "
+            "pool; pass --disable-kvstore."
+        )
+
+
 def calc_l3_query_hashes(scheduler, tokens: list[int]) -> list[str]:
     return scheduler.calc_rolling_hash(tokens, apply_match=True)
 
@@ -362,15 +377,7 @@ class EventLoop:
                     "flat scheduler build (TOKENSPEED_FLAT_KVCACHE) has no L3 "
                     "storage tier yet; unset --kvstore-storage-backend."
                 )
-            if getattr(token_to_kv_pool, "runtime_contract", None) is not None:
-                # FlatKV contract pools (Kimi-K3) have no host tier yet:
-                # FlatMemoryExecutor mirrors k_buffer/v_buffer layouts the
-                # raw-slab pool does not expose. Reject this unsupported
-                # combination at startup.
-                raise NotImplementedError(
-                    "the flat host tier (kvstore L2) does not support FlatKV "
-                    "contract pools (Kimi-K3) yet; pass --disable-kvstore."
-                )
+            _validate_flat_host_tier_pool(token_to_kv_pool)
             self.memory_executor = FlatMemoryExecutor(
                 device_pool=token_to_kv_pool,
                 host_ratio=server_args.kvstore_ratio,

--- a/python/tokenspeed/runtime/engine/scheduler_utils.py
+++ b/python/tokenspeed/runtime/engine/scheduler_utils.py
@@ -157,7 +157,11 @@ def resolve_scheduler_block_size(page_size: int, paged_cache_groups) -> int:
                 )
             packing = int(group.cache_blocks_per_lcm_block)
             expected_packing = page_size // gb
-            if packing != expected_packing:
+            # Match MakeSpecsFromConfig in the scheduler extension: packing
+            # is fixed by logical granularity only for a finer-grained group.
+            # A same-granularity group may pack multiple physical cache blocks
+            # into one scheduler-domain parent because of its byte layout.
+            if gb != page_size and packing != expected_packing:
                 raise ValueError(
                     f"paged cache group {group.group_id!r} packing {packing} "
                     f"does not cover Flat scheduler domain {page_size}; "

--- a/python/tokenspeed/runtime/engine/scheduler_utils.py
+++ b/python/tokenspeed/runtime/engine/scheduler_utils.py
@@ -29,6 +29,7 @@ from typing import Any
 import numpy as np
 import torch
 from tokenspeed_scheduler import (
+    FLAT_KVCACHE,
     Cache,
     ExecutionEvent,
     ForwardEvent,
@@ -137,12 +138,32 @@ def scheduler_cache_geometry_from_pool(
 
 
 def resolve_scheduler_block_size(page_size: int, paged_cache_groups) -> int:
-    """Scheduler block_size = hash-grain BASE: gcd of group block sizes, not the KV page geometry."""
+    """Resolve the scheduler's request/FSM block domain.
+
+    Radix keeps its legacy GCD block size.  Flat uses the pool's page domain;
+    the C++ coordinator derives a separate GCD hash grain from the group specs.
+    """
+    require_positive_int("page_size", page_size)
     base = page_size
     for group in paged_cache_groups or ():
         gb = int(getattr(group, "block_size", 0) or 0) or page_size
+        require_positive_int(f"paged cache group {group.group_id!r} block_size", gb)
         base = math.gcd(base, gb)
-    return base
+        if FLAT_KVCACHE:
+            if page_size % gb:
+                raise ValueError(
+                    f"paged cache group {group.group_id!r} block_size {gb} "
+                    f"must divide Flat scheduler domain {page_size}"
+                )
+            packing = int(group.cache_blocks_per_lcm_block)
+            expected_packing = page_size // gb
+            if packing != expected_packing:
+                raise ValueError(
+                    f"paged cache group {group.group_id!r} packing {packing} "
+                    f"does not cover Flat scheduler domain {page_size}; "
+                    f"expected {expected_packing}"
+                )
+    return page_size if FLAT_KVCACHE else base
 
 
 def aligned_max_scheduled_tokens(

--- a/python/tokenspeed/runtime/engine/scheduler_utils.py
+++ b/python/tokenspeed/runtime/engine/scheduler_utils.py
@@ -170,6 +170,49 @@ def resolve_scheduler_block_size(page_size: int, paged_cache_groups) -> int:
     return page_size if FLAT_KVCACHE else base
 
 
+def validate_scheduler_page_domain_contract(
+    *,
+    pool: Any,
+    geometry: SchedulerCacheGeometry,
+    scheduler_config: Any,
+    model_executor_config: Any,
+) -> None:
+    """Fail closed when a pool requires one shared scheduler page domain."""
+    if not getattr(pool, "requires_scheduler_page_domain_match", False):
+        return
+
+    pool_page_size = require_positive_int("geometry.page_size", geometry.page_size)
+    scheduler_page_size = require_positive_int(
+        "scheduler_config.block_size", scheduler_config.block_size
+    )
+    executor_page_size = require_positive_int(
+        "model_executor_config.logical_page_size",
+        model_executor_config.logical_page_size,
+    )
+    if len({pool_page_size, scheduler_page_size, executor_page_size}) != 1:
+        raise ValueError(
+            "scheduler page-domain mismatch: "
+            f"pool={pool_page_size}, scheduler={scheduler_page_size}, "
+            f"model_executor={executor_page_size}"
+        )
+
+    scheduler_pages = require_positive_int(
+        "scheduler_config.num_device_pages", scheduler_config.num_device_pages
+    )
+    if scheduler_pages != geometry.num_device_pages:
+        raise ValueError(
+            "scheduler page-count mismatch: "
+            f"geometry={geometry.num_device_pages}, scheduler={scheduler_pages}"
+        )
+    physical_token_capacity = geometry.num_usable_pages * scheduler_page_size
+    if physical_token_capacity < geometry.token_capacity:
+        raise ValueError(
+            "scheduler physical page domain cannot cover the advertised token "
+            f"capacity: physical={physical_token_capacity}, "
+            f"advertised={geometry.token_capacity}"
+        )
+
+
 def aligned_max_scheduled_tokens(
     max_scheduled_tokens: int,
     paged_cache_groups,

--- a/python/tokenspeed/runtime/engine/scheduler_utils.py
+++ b/python/tokenspeed/runtime/engine/scheduler_utils.py
@@ -620,8 +620,8 @@ def flat_block_tables_from_forward_op(
         device: Destination device for the packed tensor.
         num_reqs: Optional expected row count for every group.
         expected_group_ids: Optional contract order and exact key set.
-        max_page_id: Optional common inclusive upper bound for page IDs.
-        max_page_ids: Optional per-group inclusive upper bounds.
+        max_page_id: Optional authoritative common inclusive upper bound for page IDs.
+        max_page_ids: Optional authoritative per-group inclusive upper bounds.
 
     Returns:
         Per-group tensor views in ``expected_group_ids`` order when supplied,
@@ -711,13 +711,16 @@ def flat_block_tables_from_forward_op(
             )
             if max_page_ids is not None and group_max_page_id is None:
                 raise ValueError(f"max_page_ids is missing flat group {group_id!r}")
+            invalid_below = arr < -1
             if group_max_page_id is not None:
-                invalid = (arr < -1) | (arr > group_max_page_id)
+                invalid = invalid_below | (arr > group_max_page_id)
                 if bool(invalid.any()):
                     raise ValueError(
                         f"flat group {group_id!r} contains a page ID outside "
                         f"-1..{group_max_page_id}"
                     )
+            elif bool(invalid_below.any()):
+                raise ValueError(f"flat group {group_id!r} contains a page ID below -1")
     device = torch.device(device) if isinstance(device, str) else device
     out: dict[str, torch.Tensor] = {}
     packable: list[tuple[str, Any, int]] = []

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -238,6 +238,9 @@ class CudaGraphWrapper:
             attn_backend,
             self.max_bs,
             paged_cache_group_specs=tuple(token_to_kv_pool.paged_cache_group_specs),
+            paged_cache_group_page_counts=dict(
+                getattr(token_to_kv_pool, "paged_cache_group_page_counts", {}) or {}
+            ),
             max_tokens_per_req=self.max_tokens_per_req,
             overlap_schedule_depth=self.overlap_schedule_depth,
         )
@@ -247,6 +250,14 @@ class CudaGraphWrapper:
                 self.max_bs,
                 paged_cache_group_specs=tuple(
                     draft_token_to_kv_pool.paged_cache_group_specs
+                ),
+                paged_cache_group_page_counts=dict(
+                    getattr(
+                        draft_token_to_kv_pool,
+                        "paged_cache_group_page_counts",
+                        {},
+                    )
+                    or {}
                 ),
                 max_tokens_per_req=self.max_tokens_per_req,
                 overlap_schedule_depth=self.overlap_schedule_depth,

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -635,18 +635,25 @@ class CudaGraphWrapper:
             self.draft_attn_backend, "uses_flat_cache_groups", False
         ):
             return ()
+        supported_families = frozenset(
+            getattr(
+                self.draft_attn_backend,
+                "flat_cache_consumer_families",
+                frozenset({"history"}),
+            )
+        )
         if self.draft_token_to_kv_pool is not None and getattr(
             self.draft_token_to_kv_pool, "paged_cache_group_specs", ()
         ):
             return tuple(
                 str(spec.group_id)
                 for spec in self.draft_token_to_kv_pool.paged_cache_group_specs
-                if spec.family != "state"
+                if spec.family in supported_families
             )
         return tuple(
             str(spec.group_id)
             for spec in self.token_to_kv_pool.paged_cache_group_specs
-            if spec.family != "state" and spec.retention == "full_history"
+            if spec.family in supported_families and spec.retention == "full_history"
         )
 
     def _draft_flat_tables(self, flat_block_tables):
@@ -654,10 +661,13 @@ class CudaGraphWrapper:
         gids = self._draft_flat_group_ids()
         if not gids or not flat_block_tables:
             return None
-        subset = {
-            gid: flat_block_tables[gid] for gid in gids if gid in flat_block_tables
-        }
-        return subset or None
+        missing = tuple(gid for gid in gids if gid not in flat_block_tables)
+        if missing:
+            raise RuntimeError(
+                "CudaGraphWrapper draft Flat KV tables are incomplete: "
+                f"missing={list(missing)}"
+            )
+        return {gid: flat_block_tables[gid] for gid in gids}
 
     def _init_capture_metadata(self, bs: int):
         capture_kwargs = {}
@@ -665,15 +675,17 @@ class CudaGraphWrapper:
             capture_kwargs["mamba_pool_indices"] = (
                 self.input_buffers.mamba_pool_indices_buf[:bs]
             )
-        if self.attn_backend.uses_paged_cache_groups:
+        if self.attn_backend.uses_paged_cache_groups and not getattr(
+            self.attn_backend, "uses_flat_cache_groups", False
+        ):
             paged_cache_block_tables = self._capture_paged_cache_block_tables(
                 bs,
                 self.token_to_kv_pool,
             )
             if paged_cache_block_tables is not None:
                 capture_kwargs["paged_cache_block_tables"] = paged_cache_block_tables
-                if self.drafter is not None:
-                    capture_kwargs["num_tokens"] = bs * self.max_tokens_per_req
+        if self.attn_backend.uses_paged_cache_groups and self.drafter is not None:
+            capture_kwargs["num_tokens"] = bs * self.max_tokens_per_req
         flat_cache_group_ids = self._flat_cache_group_ids(self.token_to_kv_pool)
         if flat_cache_group_ids:
             capture_kwargs["flat_cache_group_ids"] = flat_cache_group_ids
@@ -689,6 +701,9 @@ class CudaGraphWrapper:
             if (
                 self.draft_token_to_kv_pool is not None
                 and self.draft_attn_backend.uses_paged_cache_groups
+                and not getattr(
+                    self.draft_attn_backend, "uses_flat_cache_groups", False
+                )
             ):
                 draft_paged_cache_block_tables = self._capture_paged_cache_block_tables(
                     bs,
@@ -698,7 +713,8 @@ class CudaGraphWrapper:
                     draft_kwargs["paged_cache_block_tables"] = (
                         draft_paged_cache_block_tables
                     )
-                    draft_kwargs["num_tokens"] = bs * self.max_tokens_per_req
+            if self.draft_attn_backend.uses_paged_cache_groups:
+                draft_kwargs["num_tokens"] = bs * self.max_tokens_per_req
             draft_flat_ids = self._draft_flat_group_ids()
             if draft_flat_ids:
                 draft_kwargs["flat_cache_group_ids"] = draft_flat_ids

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -300,6 +300,14 @@ class ModelExecutor:
         # Full-attention group mirrored into req_to_page each step (flat+spec).
         _group_specs = getattr(token_to_kv_pool, "paged_cache_group_specs", ()) or ()
         self._flat_group_ids = tuple(str(spec.group_id) for spec in _group_specs)
+        _group_page_counts = dict(
+            getattr(token_to_kv_pool, "paged_cache_group_page_counts", {}) or {}
+        )
+        self._flat_max_page_ids = {
+            group_id: int(_group_page_counts[group_id]) - 1
+            for group_id in self._flat_group_ids
+            if group_id in _group_page_counts
+        }
         self._flat_full_group_id = next(
             (
                 str(spec.group_id)
@@ -1868,6 +1876,13 @@ class ModelExecutor:
                     num_reqs=bs,
                     expected_group_ids=(
                         self._flat_group_ids
+                        if bs > 0
+                        and self._flat_group_ids
+                        and getattr(self.attn_backend, "uses_flat_cache_groups", False)
+                        else None
+                    ),
+                    max_page_ids=(
+                        self._flat_max_page_ids
                         if bs > 0
                         and self._flat_group_ids
                         and getattr(self.attn_backend, "uses_flat_cache_groups", False)

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -300,14 +300,6 @@ class ModelExecutor:
         # Full-attention group mirrored into req_to_page each step (flat+spec).
         _group_specs = getattr(token_to_kv_pool, "paged_cache_group_specs", ()) or ()
         self._flat_group_ids = tuple(str(spec.group_id) for spec in _group_specs)
-        _group_page_counts = dict(
-            getattr(token_to_kv_pool, "paged_cache_group_page_counts", {}) or {}
-        )
-        self._flat_max_page_ids = {
-            group_id: int(_group_page_counts[group_id]) - 1
-            for group_id in self._flat_group_ids
-            if group_id in _group_page_counts
-        }
         self._flat_full_group_id = next(
             (
                 str(spec.group_id)
@@ -1876,13 +1868,6 @@ class ModelExecutor:
                     num_reqs=bs,
                     expected_group_ids=(
                         self._flat_group_ids
-                        if bs > 0
-                        and self._flat_group_ids
-                        and getattr(self.attn_backend, "uses_flat_cache_groups", False)
-                        else None
-                    ),
-                    max_page_ids=(
-                        self._flat_max_page_ids
                         if bs > 0
                         and self._flat_group_ids
                         and getattr(self.attn_backend, "uses_flat_cache_groups", False)

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -299,6 +299,7 @@ class ModelExecutor:
         )
         # Full-attention group mirrored into req_to_page each step (flat+spec).
         _group_specs = getattr(token_to_kv_pool, "paged_cache_group_specs", ()) or ()
+        self._flat_group_ids = tuple(str(spec.group_id) for spec in _group_specs)
         self._flat_full_group_id = next(
             (
                 str(spec.group_id)
@@ -1865,6 +1866,13 @@ class ModelExecutor:
                     forward_op,
                     device=self.device,
                     num_reqs=bs,
+                    expected_group_ids=(
+                        self._flat_group_ids
+                        if bs > 0
+                        and self._flat_group_ids
+                        and getattr(self.attn_backend, "uses_flat_cache_groups", False)
+                        else None
+                    ),
                 )
                 self._mirror_flat_full_table_into_req_to_page(
                     forward_op, flat_block_tables

--- a/python/tokenspeed/runtime/execution/prefill_graph.py
+++ b/python/tokenspeed/runtime/execution/prefill_graph.py
@@ -457,7 +457,7 @@ class PrefillGraph:
             # absolute logical columns.
             group_width = max(
                 width,
-                (num_tokens + raw_tokens_per_page - 1) // raw_tokens_per_page,
+                (req_tokens + raw_tokens_per_page - 1) // raw_tokens_per_page,
             )
             group_id = str(spec.group_id)
             out[group_id] = torch.full(

--- a/python/tokenspeed/runtime/execution/prefill_graph.py
+++ b/python/tokenspeed/runtime/execution/prefill_graph.py
@@ -441,15 +441,39 @@ class PrefillGraph:
         # ALL groups, state included: hybrid wrappers forward the dict to the
         # mamba child, which requires its state group; KV children shed state
         # groups themselves (_shed_state_groups).
-        return {
-            str(spec.group_id): torch.full(
-                (bs, width),
-                1 if str(spec.group_id) in state_group_ids else 0,
+        out = {}
+        for spec in specs:
+            raw_tokens_per_page = int(
+                getattr(spec, "rows_per_page", backend.page_size)
+            ) * int(getattr(spec, "entry_stride_tokens", 1))
+            if raw_tokens_per_page <= 0:
+                raise RuntimeError(
+                    "PrefillGraph Flat KV group has invalid geometry: "
+                    f"group={str(spec.group_id)!r}"
+                )
+            # V4 state groups can have much finer page geometry than the
+            # backend's legacy page_size. Keep the legacy minimum width for
+            # backends that index the full row, but never under-size a group's
+            # absolute logical columns.
+            group_width = max(
+                width,
+                (num_tokens + raw_tokens_per_page - 1) // raw_tokens_per_page,
+            )
+            group_id = str(spec.group_id)
+            out[group_id] = torch.full(
+                (bs, group_width),
+                1 if group_id in state_group_ids else 0,
                 dtype=torch.int32,
                 device=self.config.device,
             )
-            for spec in specs
-        }
+        return out
+
+    @staticmethod
+    def _capture_uses_radix_group_tables(backend) -> bool:
+        """Whether capture needs compact radix group-table placeholders."""
+        return bool(getattr(backend, "uses_paged_cache_groups", False)) and not bool(
+            getattr(backend, "uses_flat_cache_groups", False)
+        )
 
     def make_dummy_batch(
         self, num_tokens: int, decode_wrapper: CudaGraphWrapper | None
@@ -517,7 +541,7 @@ class PrefillGraph:
             ctx.global_bs = [bs] * self.config.world_size
         extra_metadata_kwargs: dict = {}
         if (
-            getattr(self.attn_backend, "uses_paged_cache_groups", False)
+            self._capture_uses_radix_group_tables(self.attn_backend)
             and decode_wrapper is not None
         ):
             tables = decode_wrapper._capture_paged_cache_block_tables(
@@ -525,6 +549,7 @@ class PrefillGraph:
             )
             if tables is not None:
                 extra_metadata_kwargs["paged_cache_block_tables"] = tables
+        if getattr(self.attn_backend, "uses_paged_cache_groups", False):
             extra_metadata_kwargs["num_tokens"] = num_tokens
             extra_metadata_kwargs["positions"] = ib.positions_buf[:num_tokens]
         flat_tables = self._dummy_flat_tables(max(seq_lens), bs)

--- a/python/tokenspeed/runtime/execution/prefill_graph.py
+++ b/python/tokenspeed/runtime/execution/prefill_graph.py
@@ -418,7 +418,7 @@ class PrefillGraph:
             self._input_embeds_buf[num_tokens:bucket].zero_()
 
     def _dummy_flat_tables(self, req_tokens: int, bs: int) -> dict[str, "torch.Tensor"]:
-        """Build capture tables: null KV pages and one writable state page."""
+        """Build capture tables using each backend's active-page contract."""
         backend = self.attn_backend
         if not getattr(backend, "uses_flat_cache_groups", False):
             return {}
@@ -433,6 +433,9 @@ class PrefillGraph:
         # Composite wrappers (hybrid) hold the flat KV consumer as a child.
         if not hasattr(backend, "page_size") and hasattr(backend, "full_attn_backend"):
             backend = backend.full_attn_backend
+        require_real_active_pages = bool(
+            getattr(backend, "flat_active_pages_must_be_real", False)
+        )
         # Full width: backends that derive the row stride from max_kv_len
         # (trtllm) index the whole row even when the bucket is small.
         width = getattr(backend, "max_num_pages", 0) or -(
@@ -462,7 +465,7 @@ class PrefillGraph:
             group_id = str(spec.group_id)
             out[group_id] = torch.full(
                 (bs, group_width),
-                1 if group_id in state_group_ids else 0,
+                1 if require_real_active_pages or group_id in state_group_ids else 0,
                 dtype=torch.int32,
                 device=self.config.device,
             )
@@ -489,13 +492,12 @@ class PrefillGraph:
         a multi-request batch, never as one sequence.
 
         The prefill analogue of decode's ``_init_capture_metadata``. KV writes
-        go to the reserved dummy slot and the page table points at page 0, so
-        the forward runs (producing discarded garbage) without touching real
-        cache state. Backends with extra paged caches (DeepSeek-V4 DSA: SWA +
-        compressor + indexer state) also need per-cache block tables, or their
-        extend metadata comes up incomplete and the eager attention break
-        aborts the capture -- reuse the decode wrapper's dummy-table builder
-        (all zeros, the safe page 0) for those.
+        go to the reserved dummy slot. Per-group Flat tables use page 0 when a
+        backend permits the null page for capture and page 1 when its active
+        metadata requires a real writable page. Backends with extra paged
+        caches (DeepSeek-V4 DSA: SWA + compressor + indexer state) need every
+        table, or their extend metadata comes up incomplete and the eager
+        attention break aborts capture.
         """
         ib = self.input_buffers
         max_req_tokens = max(1, int(self.config.context_len))

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -279,6 +279,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         self._cuda_graph_metadata = {}
         self._cuda_graph_paged_cache_block_tables: dict[str, torch.Tensor] = {}
         self._expected_flat_cache_group_ids: tuple[str, ...] | None = None
+        self._flat_group_raw_tokens_per_page: dict[str, int] = {}
+        self._flat_group_max_page_ids: dict[str, int] = {}
         self._cuda_graph_flat_group_ids: tuple[str, ...] = ()
         # Per-sliding-group [max_bs] int32 buffers mirroring the block-table
         # buffers; populated by init_cuda_graph_state.
@@ -357,9 +359,21 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         flat_block_tables: Mapping[object, object],
         *,
         bs: int,
+        actual_bs: int,
+        seq_lens: torch.Tensor,
         device: torch.device,
         phase: str,
     ) -> dict[str, torch.Tensor]:
+        if actual_bs < 0 or actual_bs > bs:
+            raise RuntimeError(
+                f"DeepSeek V4 Flat KV {phase} actual_bs={actual_bs} must be "
+                f"within 0..{bs}"
+            )
+        if seq_lens.ndim != 1 or int(seq_lens.shape[0]) < actual_bs:
+            raise RuntimeError(
+                f"DeepSeek V4 Flat KV {phase} seq_lens has shape "
+                f"{tuple(seq_lens.shape)}, expected at least {actual_bs} entries"
+            )
         if not isinstance(flat_block_tables, Mapping):
             raise RuntimeError(
                 f"DeepSeek V4 Flat KV {phase} tables must be a mapping, got "
@@ -403,7 +417,86 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                     f"DeepSeek V4 Flat KV {phase} table {group_id!r} has zero width"
                 )
             out[group_id] = table
+        self._assert_flat_table_contract(
+            out,
+            seq_lens=seq_lens,
+            actual_bs=actual_bs,
+            phase=phase,
+        )
         return out
+
+    def _assert_flat_table_contract(
+        self,
+        tables: Mapping[str, torch.Tensor],
+        *,
+        seq_lens: torch.Tensor,
+        actual_bs: int,
+        phase: str,
+    ) -> None:
+        """Fail closed on page capacity and active-sequence table coverage.
+
+        The scheduler export is already on CPU when ModelExecutor checks page
+        IDs before H2D. This second check protects direct backend callers and,
+        critically, proves that each active row still contains the absolute
+        logical page selected by its live sequence length. CUDA assertions are
+        stream ordered and capture-safe, so replay cannot silently consume the
+        ``-1`` ragged padding from a short or stale source table.
+        """
+        if actual_bs == 0:
+            return
+        live_seq_lens = seq_lens[:actual_bs].to(dtype=torch.int64)
+        if self.is_draft:
+            # MTP advances this metadata in-place without another scheduler
+            # table delivery. Prove the delivered absolute table also covers
+            # every possible draft step, including a page-boundary crossing.
+            live_seq_lens = live_seq_lens + int(self.speculative_num_draft_tokens)
+        for group_id, table in tables.items():
+            raw_tokens_per_page = self._flat_group_raw_tokens_per_page.get(group_id)
+            max_page_id = self._flat_group_max_page_ids.get(group_id)
+            if raw_tokens_per_page is None or max_page_id is None:
+                raise RuntimeError(
+                    "DeepSeek V4 Flat KV cache group contract is incomplete for "
+                    f"{group_id!r}"
+                )
+            live = table[:actual_bs]
+            page_ids_valid = ((live >= -1) & (live <= max_page_id)).all()
+            required_page = torch.div(
+                live_seq_lens.clamp_min(1) - 1,
+                raw_tokens_per_page,
+                rounding_mode="floor",
+            )
+            width = int(table.shape[1])
+            in_bounds = required_page < width
+            safe_page = required_page.clamp(min=0, max=width - 1)
+            row_indices = torch.arange(
+                actual_bs,
+                dtype=torch.int64,
+                device=table.device,
+            )
+            required_entries_present = (
+                in_bounds & live[row_indices, safe_page].ne(-1)
+            ).all()
+            if table.device.type == "cpu":
+                if not bool(page_ids_valid.item()):
+                    raise RuntimeError(
+                        f"DeepSeek V4 Flat KV {phase} table {group_id!r} contains "
+                        f"a page ID outside -1..{max_page_id}"
+                    )
+                if not bool(required_entries_present.item()):
+                    raise RuntimeError(
+                        f"DeepSeek V4 Flat KV {phase} table {group_id!r} is too "
+                        "short for an active sequence"
+                    )
+            else:
+                torch._assert_async(
+                    page_ids_valid,
+                    f"DeepSeek V4 Flat KV {phase} page ID exceeds group capacity",
+                )
+                torch._assert_async(
+                    required_entries_present,
+                    f"DeepSeek V4 Flat KV {phase} table is too short for an "
+                    "active sequence",
+                )
 
     def _get_prefill_workspace(
         self,
@@ -705,6 +798,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                 paged_cache_block_tables = self._validated_flat_block_tables(
                     flat_block_tables,
                     bs=bs,
+                    actual_bs=bs,
+                    seq_lens=seq_lens,
                     device=device,
                     phase="eager",
                 )
@@ -1757,6 +1852,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         self,
         max_bs: int,
         paged_cache_group_specs=(),
+        paged_cache_group_page_counts=None,
         max_tokens_per_req: int = 1,
         overlap_schedule_depth: int = 0,
     ):
@@ -1830,6 +1926,32 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             raise RuntimeError(
                 "DeepSeek V4 Flat KV runtime requires at least one cache group spec"
             )
+        page_counts = dict(paged_cache_group_page_counts or {})
+        if self.uses_flat_cache_groups:
+            if set(page_counts) != set(group_ids):
+                raise RuntimeError(
+                    "DeepSeek V4 Flat KV page-count contract disagrees with cache "
+                    f"group specs: missing={sorted(set(group_ids) - set(page_counts))} "
+                    f"extra={sorted(set(page_counts) - set(group_ids))}"
+                )
+            invalid_counts = {
+                group_id: page_counts[group_id]
+                for group_id in group_ids
+                if not isinstance(page_counts[group_id], int)
+                or isinstance(page_counts[group_id], bool)
+                or page_counts[group_id] <= 1
+            }
+            if invalid_counts:
+                raise RuntimeError(
+                    "DeepSeek V4 Flat KV page counts must reserve page 0 and at "
+                    f"least one live page: {invalid_counts!r}"
+                )
+        self._flat_group_raw_tokens_per_page = {}
+        self._flat_group_max_page_ids = (
+            {group_id: int(page_counts[group_id]) - 1 for group_id in group_ids}
+            if self.uses_flat_cache_groups
+            else {}
+        )
         self._cuda_graph_paged_cache_base_offsets = {}
         for spec, gid in zip(specs, group_ids, strict=True):
             sliding = str(getattr(spec, "retention", "")) == "sliding_window"
@@ -1843,6 +1965,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                         f"group={gid!r} rows_per_page={rows_per_page} "
                         f"entry_stride_tokens={entry_stride_tokens}"
                     )
+                self._flat_group_raw_tokens_per_page[gid] = raw_tokens_per_page
                 capture_tokens = (
                     int(self.context_len)
                     + (int(overlap_schedule_depth) + 1)
@@ -2152,7 +2275,12 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         paged_cache_block_table_base_offsets = (
             kwargs.pop("paged_cache_block_table_base_offsets", None) or {}
         )
-        actual_bs = max(0, min(int(kwargs.pop("actual_bs", bs)), bs))
+        actual_bs = int(kwargs.pop("actual_bs", bs))
+        if actual_bs < 0 or actual_bs > bs:
+            raise RuntimeError(
+                f"DeepSeek V4 CUDA graph replay actual_bs={actual_bs} must be "
+                f"within 0..{bs}"
+            )
         num_tokens_arg = kwargs.pop("num_tokens", None)
         del kwargs
         if forward_mode is not None and not forward_mode.is_decode_or_idle():
@@ -2203,6 +2331,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             validated_flat = self._validated_flat_block_tables(
                 flat_block_tables,
                 bs=bs,
+                actual_bs=actual_bs,
+                seq_lens=seq_lens,
                 device=seq_lens.device,
                 phase="replay",
             )

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -13,6 +13,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
+
 import torch
 from tokenspeed_kernel.ops.attention.flash_mla import (
     flash_mla_sparse_fwd,
@@ -37,6 +39,7 @@ from tokenspeed.runtime.configs.deepseek_v4_cache_spec import (
 from tokenspeed.runtime.configs.model_config import AttentionArch
 from tokenspeed.runtime.configs.paged_cache_spec import (
     compute_max_logical_pages_for_capture,
+    scheduler_ext_flat_kvcache,
 )
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
@@ -239,10 +242,17 @@ class DeepseekV4AttentionBackend(AttentionBackend):
     """Metadata owner for the model-local DeepSeek V4 attention path."""
 
     uses_paged_cache_groups = True
+    uses_flat_cache_groups = True
+    flat_spec_capable = True
+    flat_cache_consumer_families = frozenset({"history", "state"})
     uses_padded_decode_token_mask = True
 
     def __init__(self, config) -> None:
         super().__init__(config)
+        # The class attribute advertises the completed capability to startup
+        # validation. V4 publishes group specs on both scheduler variants, so
+        # per-step routing must be active only for a Flat-built extension.
+        self.uses_flat_cache_groups = scheduler_ext_flat_kvcache()
         self.page_size = config.page_size
         self.context_len = config.context_len
         rope_head_dim = getattr(config, "qk_rope_head_dim", None)
@@ -268,6 +278,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         self._decode_tile_metadata = {}
         self._cuda_graph_metadata = {}
         self._cuda_graph_paged_cache_block_tables: dict[str, torch.Tensor] = {}
+        self._expected_flat_cache_group_ids: tuple[str, ...] | None = None
+        self._cuda_graph_flat_group_ids: tuple[str, ...] = ()
         # Per-sliding-group [max_bs] int32 buffers mirroring the block-table
         # buffers; populated by init_cuda_graph_state.
         self._cuda_graph_paged_cache_base_offsets: dict[str, torch.Tensor] = {}
@@ -288,6 +300,110 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         self._cuda_graph_draft_decode_metadata = {}
         self._cuda_graph_query_start_by_tokens_per_req: dict[int, torch.Tensor] = {}
         self._cuda_graph_token_to_req_by_tokens_per_req: dict[int, torch.Tensor] = {}
+
+    @staticmethod
+    def _normalized_group_ids(
+        values: Sequence[object],
+        *,
+        source: str,
+    ) -> tuple[str, ...]:
+        group_ids: list[str] = []
+        seen: set[str] = set()
+        duplicates: set[str] = set()
+        for value in values:
+            if not isinstance(value, str) or not value:
+                raise RuntimeError(
+                    f"DeepSeek V4 {source} group ids must be non-empty strings, "
+                    f"got {value!r}"
+                )
+            if value in seen:
+                duplicates.add(value)
+            seen.add(value)
+            group_ids.append(value)
+        if duplicates:
+            raise RuntimeError(
+                f"DeepSeek V4 {source} contains duplicate group ids: "
+                f"{sorted(duplicates)}"
+            )
+        return tuple(group_ids)
+
+    def _require_flat_group_ids(
+        self,
+        group_ids: Sequence[object],
+        *,
+        phase: str,
+    ) -> tuple[str, ...]:
+        delivered = self._normalized_group_ids(group_ids, source=f"Flat KV {phase}")
+        expected = self._expected_flat_cache_group_ids
+        if expected is None:
+            raise RuntimeError(
+                "DeepSeek V4 Flat KV group specs were not initialized before "
+                f"{phase}"
+            )
+        if delivered != expected:
+            delivered_set = set(delivered)
+            expected_set = set(expected)
+            detail = (
+                f"missing={sorted(expected_set - delivered_set)} "
+                f"extra={sorted(delivered_set - expected_set)}"
+            )
+            if delivered_set == expected_set:
+                detail = f"wrong order: got={delivered!r} expected={expected!r}"
+            raise RuntimeError(f"DeepSeek V4 Flat KV {phase} group mismatch: {detail}")
+        return delivered
+
+    def _validated_flat_block_tables(
+        self,
+        flat_block_tables: Mapping[object, object],
+        *,
+        bs: int,
+        device: torch.device,
+        phase: str,
+    ) -> dict[str, torch.Tensor]:
+        if not isinstance(flat_block_tables, Mapping):
+            raise RuntimeError(
+                f"DeepSeek V4 Flat KV {phase} tables must be a mapping, got "
+                f"{type(flat_block_tables).__name__}"
+            )
+        items = list(flat_block_tables.items())
+        group_ids = self._require_flat_group_ids(
+            [group_id for group_id, _ in items],
+            phase=phase,
+        )
+        expected_device = torch.device(device)
+        out: dict[str, torch.Tensor] = {}
+        for group_id, (_, table) in zip(group_ids, items, strict=True):
+            if not isinstance(table, torch.Tensor):
+                raise RuntimeError(
+                    f"DeepSeek V4 Flat KV {phase} table {group_id!r} must be "
+                    f"torch.Tensor, got {type(table).__name__}"
+                )
+            if table.dtype != torch.int32:
+                raise RuntimeError(
+                    f"DeepSeek V4 Flat KV {phase} table {group_id!r} must use "
+                    f"torch.int32, got {table.dtype}"
+                )
+            if table.device != expected_device:
+                raise RuntimeError(
+                    f"DeepSeek V4 Flat KV {phase} table {group_id!r} is on "
+                    f"{table.device}, expected {expected_device}"
+                )
+            if table.ndim != 2:
+                raise RuntimeError(
+                    f"DeepSeek V4 Flat KV {phase} table {group_id!r} must be "
+                    f"rank 2, got shape={tuple(table.shape)}"
+                )
+            if int(table.shape[0]) != int(bs):
+                raise RuntimeError(
+                    f"DeepSeek V4 Flat KV {phase} table {group_id!r} has "
+                    f"{int(table.shape[0])} rows, expected bs={int(bs)}"
+                )
+            if int(table.shape[1]) <= 0:
+                raise RuntimeError(
+                    f"DeepSeek V4 Flat KV {phase} table {group_id!r} has zero width"
+                )
+            out[group_id] = table
+        return out
 
     def _get_prefill_workspace(
         self,
@@ -550,6 +666,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         **kwargs,
     ) -> None:
         paged_cache_block_tables = kwargs.pop("paged_cache_block_tables", None) or {}
+        flat_block_tables = kwargs.pop("flat_block_tables", None) or {}
         paged_cache_block_table_base_offsets = (
             kwargs.pop("paged_cache_block_table_base_offsets", None) or {}
         )
@@ -565,6 +682,38 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             num_tokens = bs
         del kwargs
         device = seq_lens.device
+        if self.uses_flat_cache_groups:
+            if paged_cache_block_tables:
+                raise RuntimeError(
+                    "DeepSeek V4 Flat KV eager forward received radix "
+                    "paged-cache block tables"
+                )
+            if paged_cache_block_table_base_offsets:
+                raise RuntimeError(
+                    "DeepSeek V4 Flat KV eager forward received radix compact-table "
+                    "base offsets"
+                )
+            idle = forward_mode is not None and forward_mode.is_idle()
+            if not flat_block_tables:
+                if bs > 0 and not idle:
+                    raise RuntimeError(
+                        "DeepSeek V4 Flat KV eager forward is missing live "
+                        "flat_block_tables"
+                    )
+                paged_cache_block_tables = {}
+            else:
+                paged_cache_block_tables = self._validated_flat_block_tables(
+                    flat_block_tables,
+                    bs=bs,
+                    device=device,
+                    phase="eager",
+                )
+            paged_cache_block_table_base_offsets = {}
+        elif flat_block_tables:
+            raise RuntimeError(
+                "DeepSeek V4 received Flat KV eager tables while the runtime "
+                "scheduler is not Flat-built"
+            )
         req_pool_indices = req_pool_indices[:bs]
         seq_lens = seq_lens[:bs].to(torch.int32)
         query_lens = self._query_lens(
@@ -635,10 +784,11 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             )
         else:
             block_table = req_to_page[req_pool_indices, : max(max_pages, 1)]
-        paged_cache_block_tables = {
-            str(gid): table[:bs].to(device=device, dtype=torch.int32)
-            for gid, table in paged_cache_block_tables.items()
-        }
+        if not self.uses_flat_cache_groups:
+            paged_cache_block_tables = {
+                str(gid): table[:bs].to(device=device, dtype=torch.int32)
+                for gid, table in paged_cache_block_tables.items()
+            }
         base_offsets_on_device: dict[str, torch.Tensor] = {}
         for gid, off in paged_cache_block_table_base_offsets.items():
             if not isinstance(off, torch.Tensor):
@@ -1668,22 +1818,53 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             )
         self._cuda_graph_max_bs = max_bs
         self._cuda_graph_paged_cache_block_tables = {}
-        self._cuda_graph_paged_cache_base_offsets = {}
-        for spec in tuple(paged_cache_group_specs or ()):
-            gid = str(spec.group_id)
-            sliding = str(getattr(spec, "retention", "")) == "sliding_window"
-            max_pages = compute_max_logical_pages_for_capture(
-                spec,
-                max_context_len=self.context_len,
-                max_tokens_per_req=max_tokens_per_req,
-                overlap_schedule_depth=overlap_schedule_depth,
+        self._cuda_graph_flat_group_ids = ()
+        specs = tuple(paged_cache_group_specs or ())
+        raw_group_ids = tuple(getattr(spec, "group_id", None) for spec in specs)
+        group_ids = self._normalized_group_ids(
+            raw_group_ids,
+            source="cache group specs",
+        )
+        self._expected_flat_cache_group_ids = group_ids
+        if self.uses_flat_cache_groups and not group_ids:
+            raise RuntimeError(
+                "DeepSeek V4 Flat KV runtime requires at least one cache group spec"
             )
+        self._cuda_graph_paged_cache_base_offsets = {}
+        for spec, gid in zip(specs, group_ids, strict=True):
+            sliding = str(getattr(spec, "retention", "")) == "sliding_window"
+            if self.uses_flat_cache_groups:
+                rows_per_page = int(getattr(spec, "rows_per_page", 0))
+                entry_stride_tokens = int(getattr(spec, "entry_stride_tokens", 0))
+                raw_tokens_per_page = rows_per_page * entry_stride_tokens
+                if raw_tokens_per_page <= 0:
+                    raise RuntimeError(
+                        "DeepSeek V4 Flat KV cache group has invalid geometry: "
+                        f"group={gid!r} rows_per_page={rows_per_page} "
+                        f"entry_stride_tokens={entry_stride_tokens}"
+                    )
+                capture_tokens = (
+                    int(self.context_len)
+                    + (int(overlap_schedule_depth) + 1)
+                    * self._cuda_graph_max_tokens_per_req
+                )
+                max_pages = max(
+                    1,
+                    (capture_tokens + raw_tokens_per_page - 1) // raw_tokens_per_page,
+                )
+            else:
+                max_pages = compute_max_logical_pages_for_capture(
+                    spec,
+                    max_context_len=self.context_len,
+                    max_tokens_per_req=max_tokens_per_req,
+                    overlap_schedule_depth=overlap_schedule_depth,
+                )
             self._cuda_graph_paged_cache_block_tables[gid] = torch.zeros(
                 (max_bs, max_pages),
                 dtype=torch.int32,
                 device=self.device,
             )
-            if sliding:
+            if sliding and not self.uses_flat_cache_groups:
                 self._cuda_graph_paged_cache_base_offsets[gid] = torch.zeros(
                     (max_bs,),
                     dtype=torch.int32,
@@ -1812,6 +1993,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         **kwargs,
     ):
         paged_cache_block_tables = kwargs.pop("paged_cache_block_tables", None) or {}
+        flat_cache_group_ids = tuple(kwargs.pop("flat_cache_group_ids", None) or ())
         paged_cache_block_table_base_offsets = (
             kwargs.pop("paged_cache_block_table_base_offsets", None) or {}
         )
@@ -1846,22 +2028,51 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         is_decode = (
             metadata_forward_mode is not None and metadata_forward_mode.is_decode()
         )
-        offsets_on_device = {
-            str(gid): off.to(device=self.device, dtype=torch.int32)
-            for gid, off in paged_cache_block_table_base_offsets.items()
-        }
-        metadata_paged = self._refresh_cuda_graph_paged_cache_block_tables(
-            bs,
-            {
-                str(group_id): table.to(device=self.device, dtype=torch.int32)
-                for group_id, table in paged_cache_block_tables.items()
-            },
-            pad_value=0,
-        )
-        metadata_base_offsets = self._refresh_cuda_graph_base_offsets(
-            bs,
-            offsets_on_device,
-        )
+        if self.uses_flat_cache_groups:
+            if paged_cache_block_tables:
+                raise RuntimeError(
+                    "DeepSeek V4 Flat KV graph capture received radix "
+                    "paged-cache block tables"
+                )
+            if paged_cache_block_table_base_offsets:
+                raise RuntimeError(
+                    "DeepSeek V4 Flat KV graph capture received radix compact-table "
+                    "base offsets"
+                )
+            self._cuda_graph_flat_group_ids = self._require_flat_group_ids(
+                flat_cache_group_ids,
+                phase="capture",
+            )
+            # Live scheduler tables do not exist during capture. Bind views of
+            # the persistent buffers; replay refreshes every one in-place.
+            metadata_paged = {
+                group_id: self._cuda_graph_paged_cache_block_tables[group_id][:bs]
+                for group_id in self._cuda_graph_flat_group_ids
+            }
+            metadata_base_offsets = {}
+        else:
+            if flat_cache_group_ids:
+                raise RuntimeError(
+                    "DeepSeek V4 received Flat KV graph capture groups while the "
+                    "runtime scheduler is not Flat-built"
+                )
+            self._cuda_graph_flat_group_ids = ()
+            offsets_on_device = {
+                str(gid): off.to(device=self.device, dtype=torch.int32)
+                for gid, off in paged_cache_block_table_base_offsets.items()
+            }
+            metadata_paged = self._refresh_cuda_graph_paged_cache_block_tables(
+                bs,
+                {
+                    str(group_id): table.to(device=self.device, dtype=torch.int32)
+                    for group_id, table in paged_cache_block_tables.items()
+                },
+                pad_value=0,
+            )
+            metadata_base_offsets = self._refresh_cuda_graph_base_offsets(
+                bs,
+                offsets_on_device,
+            )
         (
             swa_block_table,
             compressor_state_block_tables,
@@ -1937,6 +2148,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         **kwargs,
     ):
         paged_cache_block_tables = kwargs.pop("paged_cache_block_tables", None) or {}
+        flat_block_tables = kwargs.pop("flat_block_tables", None) or {}
         paged_cache_block_table_base_offsets = (
             kwargs.pop("paged_cache_block_table_base_offsets", None) or {}
         )
@@ -1967,22 +2179,61 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             self._cuda_graph_block_table[:bs, : self.max_num_pages].copy_(
                 req_to_page[req_pool_indices[:bs], : self.max_num_pages]
             )
-        offsets_on_device = {
-            str(gid): off.to(device=self.device, dtype=torch.int32)
-            for gid, off in paged_cache_block_table_base_offsets.items()
-        }
-        metadata_paged = self._refresh_cuda_graph_paged_cache_block_tables(
-            bs,
-            {
-                str(group_id): table.to(device=self.device, dtype=torch.int32)
-                for group_id, table in paged_cache_block_tables.items()
-            },
-            pad_value=-1,
-        )
-        metadata_base_offsets = self._refresh_cuda_graph_base_offsets(
-            bs,
-            offsets_on_device,
-        )
+        if self._cuda_graph_flat_group_ids:
+            if not self.uses_flat_cache_groups:
+                raise RuntimeError(
+                    "DeepSeek V4 Flat KV graph was captured but Flat runtime "
+                    "routing is inactive"
+                )
+            if paged_cache_block_tables:
+                raise RuntimeError(
+                    "DeepSeek V4 Flat KV graph replay received radix paged-cache "
+                    "block tables"
+                )
+            if paged_cache_block_table_base_offsets:
+                raise RuntimeError(
+                    "DeepSeek V4 Flat KV graph replay received radix compact-table "
+                    "base offsets"
+                )
+            if not flat_block_tables:
+                raise RuntimeError(
+                    "DeepSeek V4 Flat KV graph replay is missing live "
+                    "flat_block_tables; captured placeholders cannot be replayed"
+                )
+            validated_flat = self._validated_flat_block_tables(
+                flat_block_tables,
+                bs=bs,
+                device=seq_lens.device,
+                phase="replay",
+            )
+            metadata_paged = self._refresh_cuda_graph_paged_cache_block_tables(
+                bs,
+                validated_flat,
+                pad_value=-1,
+            )
+            metadata_base_offsets = {}
+        else:
+            if flat_block_tables:
+                raise RuntimeError(
+                    "DeepSeek V4 received Flat KV replay tables without a matching "
+                    "Flat KV graph capture"
+                )
+            offsets_on_device = {
+                str(gid): off.to(device=self.device, dtype=torch.int32)
+                for gid, off in paged_cache_block_table_base_offsets.items()
+            }
+            metadata_paged = self._refresh_cuda_graph_paged_cache_block_tables(
+                bs,
+                {
+                    str(group_id): table.to(device=self.device, dtype=torch.int32)
+                    for group_id, table in paged_cache_block_tables.items()
+                },
+                pad_value=-1,
+            )
+            metadata_base_offsets = self._refresh_cuda_graph_base_offsets(
+                bs,
+                offsets_on_device,
+            )
         (
             swa_block_table,
             compressor_state_block_tables,

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -448,12 +448,11 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         """
         if actual_bs == 0:
             return
+        # V4 MTP receives the target's post-verify seq_lens.  Every draft
+        # depth replays that same verify window (positions and cache slots are
+        # deliberately reused), so the delivered value already names the
+        # exclusive logical end for target and draft alike.
         live_seq_lens = seq_lens[:actual_bs].to(dtype=torch.int64)
-        if self.is_draft:
-            # MTP advances this metadata in-place without another scheduler
-            # table delivery. Prove the delivered absolute table also covers
-            # every possible draft step, including a page-boundary crossing.
-            live_seq_lens = live_seq_lens + int(self.speculative_num_draft_tokens)
         for group_id, table in tables.items():
             raw_tokens_per_page = self._flat_group_raw_tokens_per_page.get(group_id)
             max_page_id = self._flat_group_max_page_ids.get(group_id)

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -245,6 +245,10 @@ class DeepseekV4AttentionBackend(AttentionBackend):
     uses_flat_cache_groups = True
     flat_spec_capable = True
     flat_cache_consumer_families = frozenset({"history", "state"})
+    # Active V4 metadata must never resolve its current logical page to the
+    # scheduler's null page. PrefillGraph uses this contract to choose a real,
+    # writable dummy page for warmup/capture without weakening live checks.
+    flat_active_pages_must_be_real = True
     uses_padded_decode_token_mask = True
 
     def __init__(self, config) -> None:
@@ -473,8 +477,11 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                 dtype=torch.int64,
                 device=table.device,
             )
+            # Page 0 is the scheduler's reserved null page.  It is valid in
+            # fully-slid-out SWA columns, but never for the logical page that
+            # contains an active sequence's current token.
             required_entries_present = (
-                in_bounds & live[row_indices, safe_page].ne(-1)
+                in_bounds & live[row_indices, safe_page].gt(0)
             ).all()
             if table.device.type == "cpu":
                 if not bool(page_ids_valid.item()):
@@ -484,8 +491,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                     )
                 if not bool(required_entries_present.item()):
                     raise RuntimeError(
-                        f"DeepSeek V4 Flat KV {phase} table {group_id!r} is too "
-                        "short for an active sequence"
+                        f"DeepSeek V4 Flat KV {phase} table {group_id!r} is "
+                        "missing a real page for an active sequence"
                     )
             else:
                 torch._assert_async(
@@ -494,8 +501,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                 )
                 torch._assert_async(
                     required_entries_present,
-                    f"DeepSeek V4 Flat KV {phase} table is too short for an "
-                    "active sequence",
+                    f"DeepSeek V4 Flat KV {phase} table is missing a real page "
+                    "for an active sequence",
                 )
 
     def _get_prefill_workspace(

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -437,14 +437,16 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         actual_bs: int,
         phase: str,
     ) -> None:
-        """Fail closed on page capacity and active-sequence table coverage.
+        """Fail closed on active-sequence table coverage.
 
         The scheduler export is already on CPU when ModelExecutor checks page
-        IDs before H2D. This second check protects direct backend callers and,
-        critically, proves that each active row still contains the absolute
-        logical page selected by its live sequence length. CUDA assertions are
-        stream ordered and capture-safe, so replay cannot silently consume the
-        ``-1`` ragged padding from a short or stale source table.
+        IDs before H2D. Keep the complete range scan for CPU/direct backend
+        callers, but do not repeat it over every GPU table on each eager step
+        or graph replay. The GPU check gathers only the logical page selected
+        by each active sequence and verifies both presence and capacity. CUDA
+        assertions are stream ordered and capture-safe, so replay cannot
+        silently consume ``-1`` ragged padding from a short or stale source
+        table.
         """
         if actual_bs == 0:
             return
@@ -462,7 +464,6 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                     f"{group_id!r}"
                 )
             live = table[:actual_bs]
-            page_ids_valid = ((live >= -1) & (live <= max_page_id)).all()
             required_page = torch.div(
                 live_seq_lens.clamp_min(1) - 1,
                 raw_tokens_per_page,
@@ -479,10 +480,14 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             # Page 0 is the scheduler's reserved null page.  It is valid in
             # fully-slid-out SWA columns, but never for the logical page that
             # contains an active sequence's current token.
+            required_entries = live[row_indices, safe_page]
             required_entries_present = (
-                in_bounds & live[row_indices, safe_page].gt(0)
+                in_bounds & required_entries.gt(0) & required_entries.le(max_page_id)
             ).all()
             if table.device.type == "cpu":
+                # Direct CPU callers do not necessarily travel through the
+                # scheduler-export bridge, so preserve its full range check.
+                page_ids_valid = ((live >= -1) & (live <= max_page_id)).all()
                 if not bool(page_ids_valid.item()):
                     raise RuntimeError(
                         f"DeepSeek V4 Flat KV {phase} table {group_id!r} contains "
@@ -495,13 +500,9 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                     )
             else:
                 torch._assert_async(
-                    page_ids_valid,
-                    f"DeepSeek V4 Flat KV {phase} page ID exceeds group capacity",
-                )
-                torch._assert_async(
                     required_entries_present,
                     f"DeepSeek V4 Flat KV {phase} table is missing a real page "
-                    "for an active sequence",
+                    "for an active sequence or its page ID exceeds group capacity",
                 )
 
     def _get_prefill_workspace(

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -454,7 +454,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         # depth replays that same verify window (positions and cache slots are
         # deliberately reused), so the delivered value already names the
         # exclusive logical end for target and draft alike.
-        live_seq_lens = seq_lens[:actual_bs].to(dtype=torch.int64)
+        live_last_token = seq_lens[:actual_bs].to(dtype=torch.int64).clamp_min(1) - 1
         for group_id, table in tables.items():
             raw_tokens_per_page = self._flat_group_raw_tokens_per_page.get(group_id)
             max_page_id = self._flat_group_max_page_ids.get(group_id)
@@ -465,22 +465,17 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                 )
             live = table[:actual_bs]
             required_page = torch.div(
-                live_seq_lens.clamp_min(1) - 1,
+                live_last_token,
                 raw_tokens_per_page,
                 rounding_mode="floor",
             )
             width = int(table.shape[1])
             in_bounds = required_page < width
             safe_page = required_page.clamp(min=0, max=width - 1)
-            row_indices = torch.arange(
-                actual_bs,
-                dtype=torch.int64,
-                device=table.device,
-            )
             # Page 0 is the scheduler's reserved null page.  It is valid in
             # fully-slid-out SWA columns, but never for the logical page that
             # contains an active sequence's current token.
-            required_entries = live[row_indices, safe_page]
+            required_entries = live.gather(1, safe_page.unsqueeze(1)).squeeze(1)
             required_entries_present = (
                 in_bounds & required_entries.gt(0) & required_entries.le(max_page_id)
             ).all()

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
@@ -40,6 +40,10 @@ class BaseTokenToKVPool:
     paged_cache_group_specs: tuple[PagedCacheGroupSpec, ...] = ()
     paged_cache_group_page_counts: dict[str, int] = {}
     supports_hierarchical_kv_cache: bool = True
+    # The flat host mirror has a narrower storage ABI than the generic
+    # hierarchical cache: it can only mirror ordinary per-layer K/V tensors
+    # (plus the explicitly supported state-slab surface). Pools must opt in.
+    supports_flat_host_mirror: bool = False
     # Flat-cache pools that alias recurrent-state bytes and KV in one slab must
     # zero physical pages on reuse to avoid poisoned tails. Pure-attention
     # pools do not alias state, so reused pages need no sanitization.

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
@@ -342,7 +342,11 @@ def profile_deepseek_v4_flat_cache(
 ) -> DeepseekV4FlatCachePlan:
     """Plan V4 FlatKV buffers in the scheduler's absolute page-ID domain."""
     target_specs = tuple(
-        build_v4_cache_specs(hf_config, layer_ratio=layout.layer_ratio)
+        build_v4_cache_specs(
+            hf_config,
+            layer_ratio=layout.layer_ratio,
+            flat_scheduler=True,
+        )
     )
     target_page_bytes = _deepseek_v4_cache_group_page_bytes(
         layout, target_specs, layer_num
@@ -359,6 +363,7 @@ def profile_deepseek_v4_flat_cache(
             build_v4_cache_specs(
                 draft_hf_config,
                 layer_ratio=draft_layout.layer_ratio,
+                flat_scheduler=True,
             )
         )
         target_by_id = {spec.group_id: spec for spec in target_specs}
@@ -975,6 +980,10 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
     """
 
     supports_hierarchical_kv_cache = True
+    # V4 kernels and req_to_page use the pool's logical page domain.  Radix
+    # must not reinterpret Flat-only child-page granularity as its global
+    # allocator block size.
+    requires_scheduler_page_domain_match = True
 
     def __init__(
         self,
@@ -1022,7 +1031,11 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
         self.max_context_len = max_context_len
         self.num_pages = (size + page_size - 1) // page_size + 1
         self.paged_cache_group_specs = tuple(
-            build_v4_cache_specs(hf_config, layer_ratio=layout.layer_ratio)
+            build_v4_cache_specs(
+                hf_config,
+                layer_ratio=layout.layer_ratio,
+                flat_scheduler=flat_num_lcm_blocks is not None,
+            )
         )
         self._paged_cache_group_specs_by_id = {
             spec.group_id: spec for spec in self.paged_cache_group_specs

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
@@ -49,6 +49,8 @@ from tokenspeed.runtime.utils.torch_memory_saver_adapter import TorchMemorySaver
 
 logger = get_colorful_logger(__name__)
 
+_MAX_FLAT_KERNEL_PAGE_ID = (1 << 31) - 1
+
 
 @dataclass(frozen=True)
 class DeepseekV4FlatCachePlan:
@@ -247,18 +249,40 @@ def deepseek_v4_flat_group_page_counts(
         raise ValueError("num_lcm_blocks must be a positive integer")
     if num_lcm_blocks <= 0:
         raise ValueError("num_lcm_blocks must be a positive integer")
-    group_ids = tuple(str(spec.group_id) for spec in specs)
-    if not group_ids or len(group_ids) != len(set(group_ids)):
-        raise ValueError("Flat V4 cache specs must have unique nonempty group IDs")
+    geometry = _validate_deepseek_v4_flat_group_geometry(specs)
     counts: dict[str, int] = {}
-    for spec in specs:
-        packing = int(spec.cache_blocks_per_lcm_block)
-        if packing <= 0:
+    for group_id, packing in geometry:
+        max_page_id = num_lcm_blocks * packing
+        if max_page_id > _MAX_FLAT_KERNEL_PAGE_ID:
             raise ValueError(
-                f"Flat V4 cache group {spec.group_id!r} has invalid packing {packing}"
+                f"Flat V4 cache group {group_id!r} page ID exceeds "
+                f"{_MAX_FLAT_KERNEL_PAGE_ID}"
             )
-        counts[str(spec.group_id)] = num_lcm_blocks * packing + 1
+        counts[group_id] = max_page_id + 1
     return counts
+
+
+def _validate_deepseek_v4_flat_group_geometry(
+    specs: Sequence[PagedCacheGroupSpec],
+) -> tuple[tuple[str, int], ...]:
+    geometry: list[tuple[str, int]] = []
+    seen: set[str] = set()
+    for spec in specs:
+        group_id = spec.group_id
+        if not isinstance(group_id, str) or not group_id:
+            raise ValueError("Flat V4 cache specs must have nonempty string group IDs")
+        if group_id in seen:
+            raise ValueError("Flat V4 cache specs must have unique group IDs")
+        seen.add(group_id)
+        packing = spec.cache_blocks_per_lcm_block
+        if isinstance(packing, bool) or not isinstance(packing, int) or packing <= 0:
+            raise ValueError(
+                f"Flat V4 cache group {group_id!r} has invalid packing {packing!r}"
+            )
+        geometry.append((group_id, packing))
+    if not geometry:
+        raise ValueError("Flat V4 cache specs must not be empty")
+    return tuple(geometry)
 
 
 def deepseek_v4_flat_lcm_blocks_needed(
@@ -281,6 +305,7 @@ def deepseek_v4_flat_lcm_blocks_needed(
         raise ValueError("token_capacity must be a positive integer")
     if token_capacity <= 0:
         raise ValueError("token_capacity must be a positive integer")
+    geometry = _validate_deepseek_v4_flat_group_geometry(specs)
     compact_counts = compute_paged_cache_group_page_counts(
         specs,
         max_live_requests=max_live_requests,
@@ -291,15 +316,10 @@ def deepseek_v4_flat_lcm_blocks_needed(
         overlap_schedule_depth=overlap_schedule_depth,
     )
     parents = 0
-    for spec in specs:
-        packing = int(spec.cache_blocks_per_lcm_block)
-        if packing <= 0:
-            raise ValueError(
-                f"Flat V4 cache group {spec.group_id!r} has invalid packing {packing}"
-            )
+    for group_id, packing in geometry:
         # Page zero is a per-group null page and does not occupy a scheduler
         # parent.  Every remaining child page consumes one packed slot.
-        child_pages = int(compact_counts[spec.group_id]) - 1
+        child_pages = int(compact_counts[group_id]) - 1
         parents += ceil_div(child_pages, packing)
     return int(parents)
 

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/deepseek_v4.py
@@ -51,6 +51,16 @@ logger = get_colorful_logger(__name__)
 
 
 @dataclass(frozen=True)
+class DeepseekV4FlatCachePlan:
+    """Physical FlatKV parent geometry shared by target and MTP pools."""
+
+    num_lcm_blocks: int
+    token_capacity: int
+    bytes_per_lcm_block: int
+    dummy_page_bytes: int
+
+
+@dataclass(frozen=True)
 class DeepseekV4CacheLayout:
     layer_ratio: tuple[int, ...]
     head_dim: int
@@ -224,6 +234,188 @@ def _estimate_deepseek_v4_cache_bytes(
             int(counts[gid]) * bytes_per_page
             for gid, bytes_per_page in page_bytes.items()
         )
+    )
+
+
+def deepseek_v4_flat_group_page_counts(
+    specs: Sequence[PagedCacheGroupSpec],
+    *,
+    num_lcm_blocks: int,
+) -> dict[str, int]:
+    """Return each group's complete absolute child-page ID namespace."""
+    if isinstance(num_lcm_blocks, bool) or not isinstance(num_lcm_blocks, int):
+        raise ValueError("num_lcm_blocks must be a positive integer")
+    if num_lcm_blocks <= 0:
+        raise ValueError("num_lcm_blocks must be a positive integer")
+    group_ids = tuple(str(spec.group_id) for spec in specs)
+    if not group_ids or len(group_ids) != len(set(group_ids)):
+        raise ValueError("Flat V4 cache specs must have unique nonempty group IDs")
+    counts: dict[str, int] = {}
+    for spec in specs:
+        packing = int(spec.cache_blocks_per_lcm_block)
+        if packing <= 0:
+            raise ValueError(
+                f"Flat V4 cache group {spec.group_id!r} has invalid packing {packing}"
+            )
+        counts[str(spec.group_id)] = num_lcm_blocks * packing + 1
+    return counts
+
+
+def deepseek_v4_flat_lcm_blocks_needed(
+    specs: Sequence[PagedCacheGroupSpec],
+    *,
+    token_capacity: int,
+    max_live_requests: int,
+    max_scheduled_tokens: int,
+    max_context_len: int,
+    decode_input_tokens: int = 1,
+    overlap_schedule_depth: int = 0,
+) -> int:
+    """Return global physical parents needed for the V4 group demands.
+
+    A FlatKV parent is bound to exactly one cache group while occupied.  The
+    compact per-group page counts therefore have to be converted to parent
+    counts per group and summed, not maximized.
+    """
+    if isinstance(token_capacity, bool) or not isinstance(token_capacity, int):
+        raise ValueError("token_capacity must be a positive integer")
+    if token_capacity <= 0:
+        raise ValueError("token_capacity must be a positive integer")
+    compact_counts = compute_paged_cache_group_page_counts(
+        specs,
+        max_live_requests=max_live_requests,
+        max_scheduled_tokens=max_scheduled_tokens,
+        max_total_tokens=token_capacity,
+        max_context_len=max_context_len,
+        decode_input_tokens=decode_input_tokens,
+        overlap_schedule_depth=overlap_schedule_depth,
+    )
+    parents = 0
+    for spec in specs:
+        packing = int(spec.cache_blocks_per_lcm_block)
+        if packing <= 0:
+            raise ValueError(
+                f"Flat V4 cache group {spec.group_id!r} has invalid packing {packing}"
+            )
+        # Page zero is a per-group null page and does not occupy a scheduler
+        # parent.  Every remaining child page consumes one packed slot.
+        child_pages = int(compact_counts[spec.group_id]) - 1
+        parents += ceil_div(child_pages, packing)
+    return int(parents)
+
+
+def profile_deepseek_v4_flat_cache(
+    *,
+    layout: DeepseekV4CacheLayout,
+    hf_config: Any,
+    layer_num: int,
+    max_live_requests: int,
+    max_scheduled_tokens: int,
+    max_context_len: int,
+    available_cache_memory_bytes: int,
+    token_limit: int | None,
+    draft_layout: DeepseekV4CacheLayout | None = None,
+    draft_hf_config: Any | None = None,
+    draft_layer_num: int = 0,
+    decode_input_tokens: int = 1,
+    overlap_schedule_depth: int = 0,
+) -> DeepseekV4FlatCachePlan:
+    """Plan V4 FlatKV buffers in the scheduler's absolute page-ID domain."""
+    target_specs = tuple(
+        build_v4_cache_specs(hf_config, layer_ratio=layout.layer_ratio)
+    )
+    target_page_bytes = _deepseek_v4_cache_group_page_bytes(
+        layout, target_specs, layer_num
+    )
+
+    draft_specs: tuple[PagedCacheGroupSpec, ...] = ()
+    draft_page_bytes: dict[str, int] = {}
+    if draft_layout is not None:
+        if draft_hf_config is None or draft_layer_num <= 0:
+            raise ValueError(
+                "draft_hf_config and draft_layer_num are required with draft_layout"
+            )
+        draft_specs = tuple(
+            build_v4_cache_specs(
+                draft_hf_config,
+                layer_ratio=draft_layout.layer_ratio,
+            )
+        )
+        target_by_id = {spec.group_id: spec for spec in target_specs}
+        for spec in draft_specs:
+            target_spec = target_by_id.get(spec.group_id)
+            if target_spec is None or spec != target_spec:
+                raise ValueError(
+                    f"draft Flat V4 cache group {spec.group_id!r} does not share "
+                    "the target scheduler geometry"
+                )
+        draft_page_bytes = _deepseek_v4_cache_group_page_bytes(
+            draft_layout, draft_specs, draft_layer_num
+        )
+    elif draft_hf_config is not None or draft_layer_num:
+        raise ValueError("draft layout/config/layer count must be provided together")
+
+    dummy_page_bytes = sum(target_page_bytes.values()) + sum(draft_page_bytes.values())
+    bytes_per_lcm_block = sum(
+        target_page_bytes[spec.group_id] * int(spec.cache_blocks_per_lcm_block)
+        for spec in target_specs
+    ) + sum(
+        draft_page_bytes[spec.group_id] * int(spec.cache_blocks_per_lcm_block)
+        for spec in draft_specs
+    )
+    if bytes_per_lcm_block <= 0:
+        raise ValueError("Flat V4 cache plan has no physical payload")
+    available_cache_memory_bytes = int(available_cache_memory_bytes)
+    max_memory_parents = (available_cache_memory_bytes - int(dummy_page_bytes)) // int(
+        bytes_per_lcm_block
+    )
+    if max_memory_parents < 1:
+        raise ValueError(
+            "DeepSeek V4 FlatKV cache budget cannot hold null pages and one "
+            "physical parent"
+        )
+
+    if token_limit is None:
+        upper_bound_tokens = (
+            max_memory_parents * DEEPSEEK_V4_COMPRESSED_LOGICAL_BLOCK_SIZE
+        )
+    else:
+        if isinstance(token_limit, bool) or not isinstance(token_limit, int):
+            raise ValueError("token_limit must be a positive integer or None")
+        if token_limit <= 0:
+            raise ValueError("token_limit must be a positive integer or None")
+        upper_bound_tokens = token_limit
+
+    def _parents_needed(tokens: int) -> int:
+        return deepseek_v4_flat_lcm_blocks_needed(
+            target_specs,
+            token_capacity=tokens,
+            max_live_requests=max_live_requests,
+            max_scheduled_tokens=max_scheduled_tokens,
+            max_context_len=max_context_len,
+            decode_input_tokens=decode_input_tokens,
+            overlap_schedule_depth=overlap_schedule_depth,
+        )
+
+    low, high = 0, int(upper_bound_tokens)
+    while low < high:
+        candidate = (low + high + 1) // 2
+        if _parents_needed(candidate) <= max_memory_parents:
+            low = candidate
+        else:
+            high = candidate - 1
+    if low <= 0:
+        raise ValueError(
+            "DeepSeek V4 FlatKV cache budget cannot admit one token with the "
+            "configured request and scheduling limits"
+        )
+    token_capacity = int(low)
+    num_lcm_blocks = _parents_needed(token_capacity)
+    return DeepseekV4FlatCachePlan(
+        num_lcm_blocks=num_lcm_blocks,
+        token_capacity=token_capacity,
+        bytes_per_lcm_block=int(bytes_per_lcm_block),
+        dummy_page_bytes=int(dummy_page_bytes),
     )
 
 
@@ -780,6 +972,7 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
         max_scheduled_tokens: int,
         decode_input_tokens: int = 1,
         overlap_schedule_depth: int = 0,
+        flat_num_lcm_blocks: int | None = None,
     ) -> None:
         if size <= 0:
             raise ValueError(f"DeepSeek V4 KV pool size must be positive, got {size}")
@@ -814,15 +1007,49 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
         self._paged_cache_group_specs_by_id = {
             spec.group_id: spec for spec in self.paged_cache_group_specs
         }
-        self.paged_cache_group_page_counts = compute_paged_cache_group_page_counts(
-            self.paged_cache_group_specs,
-            max_live_requests=max_batch_size,
-            max_scheduled_tokens=max(0, int(max_scheduled_tokens)),
-            max_total_tokens=size,
-            max_context_len=max_context_len,
-            decode_input_tokens=decode_input_tokens,
-            overlap_schedule_depth=overlap_schedule_depth,
-        )
+        if flat_num_lcm_blocks is None:
+            # Radix tables use independently allocated, compact per-group page
+            # IDs.  Keep their historical sizing and buffers byte-for-byte.
+            self.paged_cache_group_page_counts = compute_paged_cache_group_page_counts(
+                self.paged_cache_group_specs,
+                max_live_requests=max_batch_size,
+                max_scheduled_tokens=max(0, int(max_scheduled_tokens)),
+                max_total_tokens=size,
+                max_context_len=max_context_len,
+                decode_input_tokens=decode_input_tokens,
+                overlap_schedule_depth=overlap_schedule_depth,
+            )
+        else:
+            required_parents = deepseek_v4_flat_lcm_blocks_needed(
+                self.paged_cache_group_specs,
+                token_capacity=size,
+                max_live_requests=max_batch_size,
+                max_scheduled_tokens=max(0, int(max_scheduled_tokens)),
+                max_context_len=max_context_len,
+                decode_input_tokens=decode_input_tokens,
+                overlap_schedule_depth=overlap_schedule_depth,
+            )
+            if flat_num_lcm_blocks < required_parents:
+                raise ValueError(
+                    "DeepSeek V4 FlatKV parent capacity is smaller than the "
+                    "published token/scheduler capacity: "
+                    f"available={flat_num_lcm_blocks}, required={required_parents}"
+                )
+            # Scheduler child IDs are absolute:
+            #   1 + (parent_id - 1) * packing + slot.
+            # Allocate every group's complete namespace, including page zero,
+            # even though only a subset of parents can be bound to that group
+            # at one time.
+            self.num_lcm_blocks = int(flat_num_lcm_blocks)
+            self.paged_cache_group_page_counts = deepseek_v4_flat_group_page_counts(
+                self.paged_cache_group_specs,
+                num_lcm_blocks=self.num_lcm_blocks,
+            )
+            # The FlatMemoryExecutor branch is selected explicitly when L2 is
+            # enabled.  When it is disabled, do not fall through to the legacy
+            # host mirror: duplicating every sparse absolute page-ID namespace
+            # in host RAM is unnecessary and can exhaust the node.
+            self.supports_hierarchical_kv_cache = False
 
         def _group_rows(group_id: str, default: int) -> int:
             spec = self._paged_cache_group_specs_by_id.get(group_id)
@@ -964,11 +1191,13 @@ class DeepseekV4TokenToKVPool(BaseTokenToKVPool):
                 )
 
         logger.info(
-            "Initialized DeepSeek V4 KV pool: %d pages, %d layers, fp4 indexer=%s, compressed block sizes=%s",
+            "Initialized DeepSeek V4 KV pool: %d pages, %d layers, fp4 indexer=%s, "
+            "compressed block sizes=%s, flat parents=%s",
             self.num_pages,
             layer_num,
             layout.use_fp4_indexer_cache,
             self.compressed_block_sizes,
+            flat_num_lcm_blocks,
         )
 
     @property

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/mha.py
@@ -51,6 +51,8 @@ GB = 1024 * 1024 * 1024
 
 
 class MHATokenToKVPool(BaseTokenToKVPool):
+    supports_flat_host_mirror = True
+
     def __init__(
         self,
         size: int,
@@ -661,6 +663,8 @@ class MHATokenToKVPoolMXFP8(MHATokenToKVPool):
     """
 
     MXFP8_SCALE_BLOCK_SIZE = 32
+    # FlatHostMirror does not mirror the MXFP8 scale tensors.
+    supports_flat_host_mirror = False
 
     def _create_buffers(self):
         assert self.head_dim % self.MXFP8_SCALE_BLOCK_SIZE == 0

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/msa.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/msa.py
@@ -14,6 +14,8 @@ class MSATokenToKVPool(MHATokenToKVPool):
     """MHA K/V cache plus a key-only sparse-index side cache."""
 
     supports_hierarchical_kv_cache = False
+    # FlatHostMirror does not mirror the sparse index side cache.
+    supports_flat_host_mirror = False
 
     def __init__(
         self,

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -1203,6 +1203,7 @@ def create_attn_components(
     mamba_pool = None
     draft_max_num_tokens = None
     lcm_setup = None
+    deepseek_v4_flat_plan = None
 
     _profile_kwargs = dict(
         attn_config=config,
@@ -1220,46 +1221,98 @@ def create_attn_components(
 
     if is_deepseek_v4_model:
         from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
+            profile_deepseek_v4_flat_cache,
             profile_deepseek_v4_max_num_pages,
         )
 
-        draft_cache_cell_size = _resolve_draft_cache_cell_size_for_profile(
-            draft_attn_config,
-            draft_model_config,
-            draft_profile_cache_cell_size,
+        available_cache_memory_bytes = profile_available_cache_memory_bytes(
+            attn_config=config,
+            gpu_id=gpu_id,
+            tp_size=server_args.mapping.world_size,
+            gpu_memory_utilization=server_args.gpu_memory_utilization,
+            total_gpu_memory=gpu_memory,
+            world_group=server_args.mapping.world_group,
         )
-        max_total_num_pages = profile_deepseek_v4_max_num_pages(
-            layout=deepseek_v4_layout,
-            hf_config=model_config.hf_config,
-            layer_num=num_layers,
-            max_live_requests=config.max_bs,
-            max_scheduled_tokens=server_args.chunked_prefill_size,
-            max_context_len=config.context_len,
-            available_cache_memory_bytes=profile_available_cache_memory_bytes(
-                attn_config=config,
-                gpu_id=gpu_id,
-                tp_size=server_args.mapping.world_size,
-                gpu_memory_utilization=server_args.gpu_memory_utilization,
-                total_gpu_memory=gpu_memory,
-                world_group=server_args.mapping.world_group,
-            ),
-            draft_cache_cell_size=draft_cache_cell_size,
-            decode_input_tokens=decode_input_tokens,
-            overlap_schedule_depth=overlap_schedule_depth,
-        )
-        logger.info(
-            "DeepSeek V4 grouped KV profile: max_live_requests=%s "
-            "(attn config max_bs=%s, attn_dp_size=%s), max_total_num_pages=%s",
-            config.max_bs,
-            config.max_bs,
-            server_args.mapping.attn.dp_size,
-            max_total_num_pages,
-        )
-        max_num_tokens = _resolve_max_num_tokens(
-            max_total_num_pages,
-            server_args.block_size,
-            server_args.max_total_tokens,
-        )
+        if flat_kvcache:
+            if draft_attn_config is not None and not is_deepseek_v4_draft_model:
+                raise NotImplementedError(
+                    "DeepSeek V4 FlatKV requires a DeepSeek V4 MTP draft pool"
+                )
+            token_limit = server_args.max_total_tokens
+            if _CI_SMALL_KV_SIZE is not None and int(_CI_SMALL_KV_SIZE) > 0:
+                ci_limit = int(_CI_SMALL_KV_SIZE)
+                token_limit = (
+                    ci_limit if token_limit is None else min(token_limit, ci_limit)
+                )
+            deepseek_v4_flat_plan = profile_deepseek_v4_flat_cache(
+                layout=deepseek_v4_layout,
+                hf_config=model_config.hf_config,
+                layer_num=num_layers,
+                max_live_requests=config.max_bs,
+                max_scheduled_tokens=server_args.chunked_prefill_size,
+                max_context_len=config.context_len,
+                available_cache_memory_bytes=available_cache_memory_bytes,
+                token_limit=token_limit,
+                draft_layout=(
+                    draft_deepseek_v4_layout if is_deepseek_v4_draft_model else None
+                ),
+                draft_hf_config=(
+                    draft_model_config.hf_config if is_deepseek_v4_draft_model else None
+                ),
+                draft_layer_num=(
+                    draft_model_config.num_attention_layers
+                    if is_deepseek_v4_draft_model
+                    else 0
+                ),
+                decode_input_tokens=decode_input_tokens,
+                overlap_schedule_depth=overlap_schedule_depth,
+            )
+            max_total_num_pages = deepseek_v4_flat_plan.num_lcm_blocks
+            max_num_tokens = deepseek_v4_flat_plan.token_capacity
+            draft_max_num_tokens = max_num_tokens
+            logger.info(
+                "DeepSeek V4 FlatKV profile: max_live_requests=%s "
+                "(attn config max_bs=%s, attn_dp_size=%s), parents=%s, "
+                "token_capacity=%s, bytes_per_parent=%s",
+                config.max_bs,
+                config.max_bs,
+                server_args.mapping.attn.dp_size,
+                deepseek_v4_flat_plan.num_lcm_blocks,
+                deepseek_v4_flat_plan.token_capacity,
+                deepseek_v4_flat_plan.bytes_per_lcm_block,
+            )
+        else:
+            draft_cache_cell_size = _resolve_draft_cache_cell_size_for_profile(
+                draft_attn_config,
+                draft_model_config,
+                draft_profile_cache_cell_size,
+            )
+            max_total_num_pages = profile_deepseek_v4_max_num_pages(
+                layout=deepseek_v4_layout,
+                hf_config=model_config.hf_config,
+                layer_num=num_layers,
+                max_live_requests=config.max_bs,
+                max_scheduled_tokens=server_args.chunked_prefill_size,
+                max_context_len=config.context_len,
+                available_cache_memory_bytes=available_cache_memory_bytes,
+                draft_cache_cell_size=draft_cache_cell_size,
+                decode_input_tokens=decode_input_tokens,
+                overlap_schedule_depth=overlap_schedule_depth,
+            )
+            logger.info(
+                "DeepSeek V4 grouped KV profile: max_live_requests=%s "
+                "(attn config max_bs=%s, attn_dp_size=%s), "
+                "max_total_num_pages=%s",
+                config.max_bs,
+                config.max_bs,
+                server_args.mapping.attn.dp_size,
+                max_total_num_pages,
+            )
+            max_num_tokens = _resolve_max_num_tokens(
+                max_total_num_pages,
+                server_args.block_size,
+                server_args.max_total_tokens,
+            )
     elif lcm_family is not None:
         cache_memory = profile_available_cache_memory_bytes(
             attn_config=config,
@@ -1406,6 +1459,7 @@ def create_attn_components(
 
     if (
         lcm_setup is None
+        and deepseek_v4_flat_plan is None
         and _CI_SMALL_KV_SIZE is not None
         and int(_CI_SMALL_KV_SIZE) > 0
     ):
@@ -1440,6 +1494,11 @@ def create_attn_components(
             max_scheduled_tokens=server_args.chunked_prefill_size,
             decode_input_tokens=decode_input_tokens,
             overlap_schedule_depth=overlap_schedule_depth,
+            flat_num_lcm_blocks=(
+                deepseek_v4_flat_plan.num_lcm_blocks
+                if deepseek_v4_flat_plan is not None
+                else None
+            ),
         )
     elif is_hybrid_linear:
         backend, pool, mamba_pool = _create_hybrid_linear_attn(
@@ -1536,6 +1595,11 @@ def create_attn_components(
                 max_scheduled_tokens=server_args.chunked_prefill_size,
                 decode_input_tokens=decode_input_tokens,
                 overlap_schedule_depth=overlap_schedule_depth,
+                flat_num_lcm_blocks=(
+                    deepseek_v4_flat_plan.num_lcm_blocks
+                    if deepseek_v4_flat_plan is not None
+                    else None
+                ),
             )
         elif draft_is_hybrid_gdn:
             draft_attn_backend, draft_pool, _ = _create_hybrid_linear_attn(

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -192,6 +192,60 @@ def _validate_shared_lcm_geometry(pool, draft_pool) -> None:
         raise RuntimeError("target and draft LCM arenas must not share backing")
 
 
+def _validate_shared_flat_group_geometry(pool, draft_pool) -> None:
+    """Prove that target-owned Flat page ids are valid in the draft pool."""
+    if draft_pool is None:
+        return
+
+    target_specs = tuple(getattr(pool, "paged_cache_group_specs", ()) or ())
+    draft_specs = tuple(getattr(draft_pool, "paged_cache_group_specs", ()) or ())
+    target_ids = tuple(str(spec.group_id) for spec in target_specs)
+    draft_ids = tuple(str(spec.group_id) for spec in draft_specs)
+    if len(set(target_ids)) != len(target_ids):
+        raise RuntimeError("target Flat cache group specs contain duplicate ids")
+    if len(set(draft_ids)) != len(draft_ids):
+        raise RuntimeError("draft Flat cache group specs contain duplicate ids")
+
+    target_by_id = dict(zip(target_ids, target_specs, strict=True))
+    target_counts = dict(getattr(pool, "paged_cache_group_page_counts", {}) or {})
+    draft_counts = dict(getattr(draft_pool, "paged_cache_group_page_counts", {}) or {})
+    shared_policy = (
+        "retention",
+        "rows_per_page",
+        "entry_stride_tokens",
+        "sliding_window_tokens",
+        "family",
+        "block_size",
+        "cache_blocks_per_lcm_block",
+    )
+    for draft_id, draft_spec in zip(draft_ids, draft_specs, strict=True):
+        target_spec = target_by_id.get(draft_id)
+        if target_spec is None:
+            raise RuntimeError(
+                f"draft Flat cache group {draft_id!r} is absent from target"
+            )
+        if any(
+            getattr(draft_spec, field) != getattr(target_spec, field)
+            for field in shared_policy
+        ):
+            raise RuntimeError(
+                f"target and draft Flat cache group {draft_id!r} do not share "
+                "scheduler semantics"
+            )
+        target_pages = target_counts.get(draft_id)
+        draft_pages = draft_counts.get(draft_id)
+        if target_pages is None or draft_pages is None:
+            raise RuntimeError(
+                f"target and draft Flat cache group {draft_id!r} must publish "
+                "page counts"
+            )
+        if int(target_pages) != int(draft_pages):
+            raise RuntimeError(
+                f"target and draft Flat cache group {draft_id!r} do not share "
+                "page-id capacity"
+            )
+
+
 def _cache_storage_report(
     *,
     configured_cache_bytes: int,
@@ -1577,6 +1631,8 @@ def create_attn_components(
             )
 
     _validate_shared_lcm_geometry(pool, draft_pool)
+    if flat_kvcache and is_deepseek_v4_model and is_deepseek_v4_draft_model:
+        _validate_shared_flat_group_geometry(pool, draft_pool)
     if use_lcm_gdn and fixed_workspace_bytes:
         actual_workspace_bytes = (
             backend.linear_attn_backend.preallocate_flat_verify_workspace(

--- a/test/runtime/cache/test_deepseek_v4_l2_offload.py
+++ b/test/runtime/cache/test_deepseek_v4_l2_offload.py
@@ -33,6 +33,15 @@ def test_grouped_kvstore_rejects_only_paged_draft_pool(
         )
 
 
+def test_flat_v4_target_only_kvstore_fails_closed():
+    from tokenspeed.runtime.engine.event_loop import _validate_flat_host_tier_pool
+
+    pool = _make_v4_pool(flat=True)
+    assert not pool.supports_flat_host_mirror
+    with pytest.raises(NotImplementedError, match="--disable-kvstore"):
+        _validate_flat_host_tier_pool(pool)
+
+
 def test_deepseek_v4_scheduler_host_pages_follow_kvstore_mode():
     from tokenspeed.runtime.engine.event_loop import (
         _paged_cache_host_group_pages_for_scheduler,
@@ -74,10 +83,14 @@ def test_deepseek_v4_scheduler_host_pages_follow_kvstore_mode():
     assert enabled_config.paged_cache_host_group_pages == {"v4.swa_kv": 1}
 
 
-def _make_v4_pool():
+def _make_v4_pool(*, flat: bool = False):
+    from tokenspeed.runtime.configs.deepseek_v4_cache_spec import (
+        build_v4_cache_specs,
+    )
     from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
         DeepseekV4TokenToKVPool,
         deepseek_v4_cache_layout_from_config,
+        deepseek_v4_flat_lcm_blocks_needed,
     )
 
     hf_config = SimpleNamespace(
@@ -92,6 +105,16 @@ def _make_v4_pool():
         page_size=64,
         use_fp4_indexer_cache=True,
     )
+    flat_num_lcm_blocks = None
+    if flat:
+        specs = tuple(build_v4_cache_specs(hf_config, layer_ratio=layout.layer_ratio))
+        flat_num_lcm_blocks = deepseek_v4_flat_lcm_blocks_needed(
+            specs,
+            token_capacity=512,
+            max_live_requests=2,
+            max_scheduled_tokens=64,
+            max_context_len=512,
+        )
     return DeepseekV4TokenToKVPool(
         size=512,
         model_dtype=torch.bfloat16,
@@ -105,6 +128,7 @@ def _make_v4_pool():
         rank=0,
         hf_config=hf_config,
         max_scheduled_tokens=64,
+        flat_num_lcm_blocks=flat_num_lcm_blocks,
     )
 
 

--- a/test/runtime/cache/test_deepseek_v4_l2_offload.py
+++ b/test/runtime/cache/test_deepseek_v4_l2_offload.py
@@ -107,7 +107,13 @@ def _make_v4_pool(*, flat: bool = False):
     )
     flat_num_lcm_blocks = None
     if flat:
-        specs = tuple(build_v4_cache_specs(hf_config, layer_ratio=layout.layer_ratio))
+        specs = tuple(
+            build_v4_cache_specs(
+                hf_config,
+                layer_ratio=layout.layer_ratio,
+                flat_scheduler=True,
+            )
+        )
         flat_num_lcm_blocks = deepseek_v4_flat_lcm_blocks_needed(
             specs,
             token_capacity=512,

--- a/test/runtime/test_deepseek_v4_flat_groups.py
+++ b/test/runtime/test_deepseek_v4_flat_groups.py
@@ -1,0 +1,644 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from collections import OrderedDict
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+# CI Registration (parsed via AST, runtime no-op)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, suite="runtime-1gpu")
+
+from tokenspeed.runtime.configs.deepseek_v4_cache_spec import build_v4_cache_specs
+from tokenspeed.runtime.configs.paged_cache_spec import validate_flat_scheduler_config
+from tokenspeed.runtime.execution.cuda_graph_wrapper import CudaGraphWrapper
+from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
+from tokenspeed.runtime.layers.attention.backends import deepseek_v4 as v4_backend
+from tokenspeed.runtime.layers.attention.backends.deepseek_v4 import (
+    DeepseekV4AttentionBackend,
+)
+from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
+    _group_slot_mapping_from_raw,
+)
+from tokenspeed.runtime.layers.attention.registry import (
+    _validate_shared_flat_group_geometry,
+)
+
+
+def _config(
+    *,
+    device: str,
+    is_draft: bool = False,
+    context_len: int = 4096,
+    speculative_tokens: int = 4,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        page_size=64,
+        device=device,
+        num_attention_heads=64,
+        num_kv_heads=1,
+        attn_tp_size=1,
+        dtype=torch.bfloat16,
+        is_draft=is_draft,
+        speculative_num_draft_tokens=speculative_tokens,
+        speculative_num_steps=1,
+        head_dim=512,
+        qk_rope_head_dim=64,
+        context_len=context_len,
+    )
+
+
+def _backend(
+    *,
+    flat: bool,
+    device: str = "cpu",
+    is_draft: bool = False,
+    context_len: int = 4096,
+    speculative_tokens: int = 4,
+) -> DeepseekV4AttentionBackend:
+    with patch.object(v4_backend, "scheduler_ext_flat_kvcache", return_value=flat):
+        return DeepseekV4AttentionBackend(
+            _config(
+                device=device,
+                is_draft=is_draft,
+                context_len=context_len,
+                speculative_tokens=speculative_tokens,
+            )
+        )
+
+
+def _target_specs():
+    return tuple(
+        build_v4_cache_specs(
+            SimpleNamespace(sliding_window=128),
+            layer_ratio=(1, 4, 128),
+        )
+    )
+
+
+def _draft_specs():
+    return tuple(
+        build_v4_cache_specs(
+            SimpleNamespace(sliding_window=128),
+            layer_ratio=(1,),
+        )
+    )
+
+
+def _tables(specs, *, rows: int = 2, cols: int = 2, device: str = "cpu"):
+    return OrderedDict(
+        (
+            str(spec.group_id),
+            torch.full(
+                (rows, cols),
+                index + 1,
+                dtype=torch.int32,
+                device=device,
+            ),
+        )
+        for index, spec in enumerate(specs)
+    )
+
+
+class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
+    def test_cache_spec_identity_and_order_are_deterministic(self):
+        first = _target_specs()
+        second = _target_specs()
+        expected = (
+            "v4.swa_kv",
+            "v4.c4a.compressor_state",
+            "v4.c4a.compressed_kv",
+            "v4.c128a.compressor_state",
+            "v4.c128a.compressed_kv",
+            "v4.c4a.indexer_compressor_state",
+        )
+        self.assertEqual(tuple(spec.group_id for spec in first), expected)
+        self.assertEqual(first, second)
+
+    def test_eager_flat_maps_all_target_groups_in_decode_extend_and_mixed(self):
+        specs = _target_specs()
+        tables = _tables(specs)
+        cases = (
+            (
+                ForwardMode.DECODE,
+                dict(num_tokens=2),
+            ),
+            (
+                ForwardMode.EXTEND,
+                dict(
+                    num_tokens=4,
+                    extend_seq_lens_cpu=torch.tensor([2, 2], dtype=torch.int32),
+                ),
+            ),
+            (
+                ForwardMode.MIXED,
+                dict(
+                    num_tokens=3,
+                    num_extends=1,
+                    extend_seq_lens_cpu=torch.tensor([2], dtype=torch.int32),
+                ),
+            ),
+        )
+        for mode, extras in cases:
+            with self.subTest(mode=mode):
+                backend = _backend(flat=True, speculative_tokens=1)
+                backend.init_cuda_graph_state(2, paged_cache_group_specs=specs)
+                backend.init_forward_metadata(
+                    bs=2,
+                    req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+                    seq_lens=torch.tensor([2, 2], dtype=torch.int32),
+                    forward_mode=mode,
+                    req_to_page=torch.full((2, 4), 999, dtype=torch.int32),
+                    flat_block_tables=tables,
+                    **extras,
+                )
+                metadata = backend.forward_metadata
+                assert metadata is not None
+                self.assertEqual(
+                    tuple(metadata.cache.paged_cache_block_tables), tuple(tables)
+                )
+                self.assertEqual(
+                    metadata.cache.paged_cache_block_table_base_offsets,
+                    {},
+                )
+                self.assertIs(
+                    metadata.cache.swa_block_table,
+                    metadata.cache.paged_cache_block_tables["v4.swa_kv"],
+                )
+                self.assertIs(
+                    metadata.cache.compressor_state_block_tables[4],
+                    metadata.cache.paged_cache_block_tables["v4.c4a.compressor_state"],
+                )
+                self.assertIs(
+                    metadata.cache.compressor_state_block_tables[128],
+                    metadata.cache.paged_cache_block_tables[
+                        "v4.c128a.compressor_state"
+                    ],
+                )
+                self.assertIs(
+                    metadata.cache.indexer_state_block_table,
+                    metadata.cache.paged_cache_block_tables[
+                        "v4.c4a.indexer_compressor_state"
+                    ],
+                )
+
+    def test_flat_absolute_swa_crosses_pages_without_radix_base_offsets(self):
+        absolute = _group_slot_mapping_from_raw(
+            positions=torch.tensor([63, 64, 127, 128], dtype=torch.int64),
+            req_indices=torch.tensor([0, 0, 0, 0], dtype=torch.int32),
+            block_table=torch.tensor([[10, 11, 0]], dtype=torch.int32),
+            rows_per_page=64,
+            base_offsets=None,
+        )
+        self.assertTrue(torch.equal(absolute, torch.tensor([703, 704, 767, 0])))
+        compressed = _group_slot_mapping_from_raw(
+            positions=torch.tensor([255, 256, 511, 512], dtype=torch.int64),
+            req_indices=torch.tensor([0, 0, 0, 0], dtype=torch.int32),
+            block_table=torch.tensor([[10, 11, 0]], dtype=torch.int32),
+            rows_per_page=64,
+            entry_stride_tokens=4,
+            base_offsets=None,
+        )
+        self.assertTrue(torch.equal(compressed, torch.tensor([703, 704, 767, 0])))
+        compact = _group_slot_mapping_from_raw(
+            positions=torch.tensor([128, 129], dtype=torch.int64),
+            req_indices=torch.tensor([0, 0], dtype=torch.int32),
+            block_table=torch.tensor([[10, 11]], dtype=torch.int32),
+            rows_per_page=64,
+            base_offsets=torch.tensor([2], dtype=torch.int32),
+        )
+        self.assertTrue(torch.equal(compact, torch.tensor([640, 641])))
+
+    def test_flat_payload_validation_fails_closed(self):
+        specs = _target_specs()
+        backend = _backend(flat=True)
+        backend.init_cuda_graph_state(2, paged_cache_group_specs=specs)
+        valid = _tables(specs)
+        common = dict(
+            bs=2,
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+            seq_lens=torch.tensor([2, 2], dtype=torch.int32),
+            forward_mode=ForwardMode.DECODE,
+            req_to_page=torch.zeros((2, 4), dtype=torch.int32),
+        )
+
+        malformed = []
+        missing = OrderedDict(valid)
+        missing.pop(next(iter(missing)))
+        malformed.append((missing, "group mismatch"))
+        extra = OrderedDict(valid)
+        extra["v4.unknown"] = torch.zeros((2, 1), dtype=torch.int32)
+        malformed.append((extra, "group mismatch"))
+        reordered = OrderedDict(reversed(tuple(valid.items())))
+        malformed.append((reordered, "wrong order"))
+        wrong_rows = OrderedDict(valid)
+        wrong_rows[next(iter(wrong_rows))] = torch.zeros((1, 2), dtype=torch.int32)
+        malformed.append((wrong_rows, "rows"))
+        wrong_rank = OrderedDict(valid)
+        wrong_rank[next(iter(wrong_rank))] = torch.zeros(2, dtype=torch.int32)
+        malformed.append((wrong_rank, "rank 2"))
+        wrong_width = OrderedDict(valid)
+        wrong_width[next(iter(wrong_width))] = torch.zeros((2, 0), dtype=torch.int32)
+        malformed.append((wrong_width, "zero width"))
+        wrong_dtype = OrderedDict(valid)
+        wrong_dtype[next(iter(wrong_dtype))] = torch.zeros((2, 2), dtype=torch.int64)
+        malformed.append((wrong_dtype, "torch.int32"))
+        wrong_device = OrderedDict(valid)
+        wrong_device[next(iter(wrong_device))] = torch.zeros(
+            (2, 2), dtype=torch.int32, device="meta"
+        )
+        malformed.append((wrong_device, "expected cpu"))
+
+        for tables, error in malformed:
+            with self.subTest(error=error):
+                with self.assertRaisesRegex(RuntimeError, error):
+                    backend.init_forward_metadata(
+                        **common,
+                        flat_block_tables=tables,
+                    )
+
+        with self.assertRaisesRegex(RuntimeError, "radix paged-cache"):
+            backend.init_forward_metadata(
+                **common,
+                flat_block_tables=valid,
+                paged_cache_block_tables=valid,
+            )
+        with self.assertRaisesRegex(RuntimeError, "base offsets"):
+            backend.init_forward_metadata(
+                **common,
+                flat_block_tables=valid,
+                paged_cache_block_table_base_offsets={
+                    "v4.swa_kv": torch.zeros(2, dtype=torch.int32)
+                },
+            )
+
+    def test_duplicate_specs_and_capture_ids_fail_closed(self):
+        spec = _draft_specs()[0]
+        backend = _backend(flat=True, is_draft=True)
+        with self.assertRaisesRegex(RuntimeError, "duplicate"):
+            backend.init_cuda_graph_state(
+                2,
+                paged_cache_group_specs=(spec, spec),
+            )
+
+        backend = _backend(flat=True, is_draft=True)
+        backend.init_cuda_graph_state(2, paged_cache_group_specs=(spec,))
+        with self.assertRaisesRegex(RuntimeError, "duplicate"):
+            backend.init_forward_metadata_capture_cuda_graph(
+                bs=2,
+                req_pool_indices=torch.tensor([0, 1], dtype=torch.int32),
+                seq_lens=torch.ones(2, dtype=torch.int32),
+                forward_mode=ForwardMode.DECODE,
+                flat_cache_group_ids=(spec.group_id, spec.group_id),
+            )
+
+    def test_idle_zero_batch_and_padded_replay_are_safe(self):
+        specs = _draft_specs()
+        group_ids = tuple(spec.group_id for spec in specs)
+        backend = _backend(flat=True, is_draft=True, speculative_tokens=1)
+        backend.init_cuda_graph_state(
+            2,
+            paged_cache_group_specs=specs,
+            max_tokens_per_req=1,
+        )
+        backend.init_forward_metadata(
+            bs=0,
+            req_pool_indices=torch.empty(0, dtype=torch.int32),
+            seq_lens=torch.empty(0, dtype=torch.int32),
+            forward_mode=ForwardMode.IDLE,
+            req_to_page=torch.zeros((1, 2), dtype=torch.int32),
+        )
+        assert backend.forward_metadata is not None
+        self.assertEqual(backend.forward_metadata.seq_lens.numel(), 0)
+
+        common = dict(
+            bs=2,
+            req_pool_indices=torch.tensor([0, 0], dtype=torch.int32),
+            seq_lens=torch.ones(2, dtype=torch.int32),
+            forward_mode=ForwardMode.DECODE,
+        )
+        backend.init_forward_metadata_capture_cuda_graph(
+            **common,
+            flat_cache_group_ids=group_ids,
+        )
+        idle_tables = OrderedDict(
+            ((group_ids[0], torch.zeros((2, 1), dtype=torch.int32)),)
+        )
+        backend.init_forward_metadata_replay_cuda_graph(
+            **common,
+            actual_bs=0,
+            req_to_page=torch.zeros((1, 64), dtype=torch.int32),
+            flat_block_tables=idle_tables,
+        )
+        assert backend.forward_metadata is not None
+        self.assertFalse(bool(backend.forward_metadata.is_valid_token.any()))
+
+        backend.init_forward_metadata_replay_cuda_graph(
+            **common,
+            actual_bs=1,
+            req_to_page=torch.zeros((1, 64), dtype=torch.int32),
+            flat_block_tables=idle_tables,
+        )
+        self.assertEqual(
+            backend.forward_metadata.is_valid_token.tolist(),
+            [True, False],
+        )
+
+    def test_target_and_mtp_route_same_identity_including_state(self):
+        wrapper = object.__new__(CudaGraphWrapper)
+        wrapper.draft_attn_backend = SimpleNamespace(
+            uses_flat_cache_groups=True,
+            flat_cache_consumer_families=frozenset({"history", "state"}),
+        )
+        wrapper.draft_token_to_kv_pool = SimpleNamespace(
+            paged_cache_group_specs=_draft_specs()
+        )
+        wrapper.token_to_kv_pool = SimpleNamespace(
+            paged_cache_group_specs=_target_specs()
+        )
+        self.assertEqual(wrapper._draft_flat_group_ids(), ("v4.swa_kv",))
+
+        target_tables = _tables(_target_specs())
+        draft_tables = wrapper._draft_flat_tables(target_tables)
+        assert draft_tables is not None
+        self.assertEqual(tuple(draft_tables), ("v4.swa_kv",))
+        self.assertIs(draft_tables["v4.swa_kv"], target_tables["v4.swa_kv"])
+        with self.assertRaisesRegex(RuntimeError, "incomplete"):
+            wrapper._draft_flat_tables(
+                {
+                    key: value
+                    for key, value in target_tables.items()
+                    if key != "v4.swa_kv"
+                }
+            )
+
+    def test_target_and_mtp_share_flat_page_id_geometry(self):
+        target_specs = _target_specs()
+        draft_specs = _draft_specs()
+        target = SimpleNamespace(
+            paged_cache_group_specs=target_specs,
+            paged_cache_group_page_counts={spec.group_id: 17 for spec in target_specs},
+        )
+        draft = SimpleNamespace(
+            paged_cache_group_specs=draft_specs,
+            paged_cache_group_page_counts={"v4.swa_kv": 17},
+        )
+        _validate_shared_flat_group_geometry(target, draft)
+
+        draft.paged_cache_group_page_counts = {"v4.swa_kv": 16}
+        with self.assertRaisesRegex(RuntimeError, "page-id capacity"):
+            _validate_shared_flat_group_geometry(target, draft)
+
+    def test_flat_graph_refreshes_every_group_for_ten_replays(self):
+        specs = _target_specs()
+        group_ids = tuple(spec.group_id for spec in specs)
+        backend = _backend(flat=True, context_len=4096, speculative_tokens=4)
+        backend.init_cuda_graph_state(
+            2,
+            paged_cache_group_specs=specs,
+            max_tokens_per_req=4,
+        )
+        common = dict(
+            bs=2,
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int32),
+            seq_lens=torch.tensor([64, 128], dtype=torch.int32),
+            forward_mode=ForwardMode.DECODE,
+            num_tokens=8,
+        )
+        backend.init_forward_metadata_capture_cuda_graph(
+            **common,
+            flat_cache_group_ids=group_ids,
+        )
+        for step in range(10):
+            live = OrderedDict(
+                (
+                    group_id,
+                    torch.full((2, 2), step + index + 1, dtype=torch.int32),
+                )
+                for index, group_id in enumerate(group_ids)
+            )
+            backend.init_forward_metadata_replay_cuda_graph(
+                **common,
+                actual_bs=1,
+                req_to_page=torch.zeros((2, 128), dtype=torch.int32),
+                flat_block_tables=live,
+            )
+            metadata = backend.forward_metadata
+            assert metadata is not None
+            for group_id, table in live.items():
+                self.assertTrue(
+                    torch.equal(
+                        metadata.cache.paged_cache_block_tables[group_id][:, :2],
+                        table,
+                    )
+                )
+        with self.assertRaisesRegex(RuntimeError, "missing live"):
+            backend.init_forward_metadata_replay_cuda_graph(
+                **common,
+                req_to_page=torch.zeros((2, 128), dtype=torch.int32),
+            )
+
+    def test_flat_graph_width_is_absolute_but_radix_stays_compact(self):
+        spec = _draft_specs()[0]
+        flat = _backend(flat=True, is_draft=True, context_len=4096)
+        flat.init_cuda_graph_state(
+            1,
+            paged_cache_group_specs=(spec,),
+            max_tokens_per_req=4,
+        )
+        self.assertEqual(
+            flat._cuda_graph_paged_cache_block_tables[spec.group_id].shape,
+            (1, 65),
+        )
+        self.assertEqual(flat._cuda_graph_paged_cache_base_offsets, {})
+
+        radix = _backend(flat=False, is_draft=True, context_len=4096)
+        radix.init_cuda_graph_state(
+            1,
+            paged_cache_group_specs=(spec,),
+            max_tokens_per_req=4,
+        )
+        self.assertEqual(
+            radix._cuda_graph_paged_cache_block_tables[spec.group_id].shape,
+            (1, 4),
+        )
+        self.assertEqual(
+            tuple(radix._cuda_graph_paged_cache_base_offsets),
+            (spec.group_id,),
+        )
+
+    def test_radix_capture_and_replay_keep_base_offsets(self):
+        spec = _draft_specs()[0]
+        backend = _backend(flat=False, is_draft=True, speculative_tokens=1)
+        backend.init_cuda_graph_state(
+            2,
+            paged_cache_group_specs=(spec,),
+            max_tokens_per_req=1,
+        )
+        table = {spec.group_id: torch.tensor([[10, 11], [20, -1]], dtype=torch.int32)}
+        offsets = {spec.group_id: torch.tensor([2, 3], dtype=torch.int32)}
+        common = dict(
+            bs=2,
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int32),
+            seq_lens=torch.tensor([200, 80], dtype=torch.int32),
+            forward_mode=ForwardMode.DECODE,
+        )
+        backend.init_forward_metadata_capture_cuda_graph(
+            **common,
+            paged_cache_block_tables=table,
+            paged_cache_block_table_base_offsets=offsets,
+        )
+        backend.init_forward_metadata_replay_cuda_graph(
+            **common,
+            req_to_page=torch.zeros((2, 64), dtype=torch.int32),
+            paged_cache_block_tables=table,
+            paged_cache_block_table_base_offsets=offsets,
+        )
+        metadata = backend.forward_metadata
+        assert metadata is not None
+        self.assertTrue(
+            torch.equal(metadata.cache.swa_block_table[:, :2], table[spec.group_id])
+        )
+        self.assertTrue(
+            torch.equal(metadata.cache.swa_base_logical_page, offsets[spec.group_id])
+        )
+
+    def test_startup_gate_accepts_completed_v4_flat_backend(self):
+        specs = _target_specs()
+        backend = _backend(flat=True)
+        validate_flat_scheduler_config(
+            flat_kvcache_ext=True,
+            paged_cache_groups=specs,
+            attn_backend=backend,
+            kv_pool=SimpleNamespace(),
+            speculative_algorithm="MTP",
+        )
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+class DeepseekV4FlatCudaGraphTest(unittest.TestCase):
+    def test_target_mtp_graph_replay_refresh_and_memory_stability(self):
+        device = "cuda"
+        target_specs = _target_specs()
+        draft_specs = _draft_specs()
+        target_ids = tuple(spec.group_id for spec in target_specs)
+        draft_ids = tuple(spec.group_id for spec in draft_specs)
+        target = _backend(
+            flat=True,
+            device=device,
+            context_len=128,
+            speculative_tokens=4,
+        )
+        draft = _backend(
+            flat=True,
+            device=device,
+            is_draft=True,
+            context_len=128,
+            speculative_tokens=4,
+        )
+        target.init_cuda_graph_state(
+            2,
+            paged_cache_group_specs=target_specs,
+            max_tokens_per_req=4,
+        )
+        draft.init_cuda_graph_state(
+            2,
+            paged_cache_group_specs=draft_specs,
+            max_tokens_per_req=4,
+        )
+        common = dict(
+            bs=2,
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int32, device=device),
+            seq_lens=torch.tensor([64, 1], dtype=torch.int32, device=device),
+            forward_mode=ForwardMode.DECODE,
+            num_tokens=8,
+        )
+        target.init_forward_metadata_capture_cuda_graph(
+            **common,
+            flat_cache_group_ids=target_ids,
+        )
+        draft.init_forward_metadata_capture_cuda_graph(
+            **common,
+            flat_cache_group_ids=draft_ids,
+        )
+        target_metadata = target.forward_metadata
+        draft_metadata = draft.forward_metadata
+        assert target_metadata is not None
+        assert draft_metadata is not None
+
+        observed = torch.empty(len(target_ids) + 1, dtype=torch.int32, device=device)
+        graph = torch.cuda.CUDAGraph()
+        torch.cuda.synchronize()
+        with torch.cuda.graph(graph):
+            for index, group_id in enumerate(target_ids):
+                observed[index].copy_(
+                    target_metadata.cache.paged_cache_block_tables[group_id][0, 0]
+                )
+            observed[-1].copy_(draft_metadata.cache.swa_block_table[0, 0])
+
+        live = OrderedDict(
+            (
+                group_id,
+                torch.zeros(
+                    (
+                        2,
+                        target._cuda_graph_paged_cache_block_tables[group_id].shape[1],
+                    ),
+                    dtype=torch.int32,
+                    device=device,
+                ),
+            )
+            for group_id in target_ids
+        )
+        req_to_page = torch.zeros((2, 8), dtype=torch.int32, device=device)
+
+        def replay(step: int) -> None:
+            for index, table in enumerate(live.values()):
+                table[0].fill_(step + index + 1)
+                table[1].zero_()
+            target.init_forward_metadata_replay_cuda_graph(
+                **common,
+                actual_bs=1,
+                req_to_page=req_to_page,
+                flat_block_tables=live,
+            )
+            draft.init_forward_metadata_replay_cuda_graph(
+                **common,
+                actual_bs=1,
+                req_to_page=req_to_page,
+                flat_block_tables=OrderedDict((("v4.swa_kv", live["v4.swa_kv"]),)),
+            )
+            graph.replay()
+
+        for step in range(10):
+            replay(step)
+            torch.cuda.synchronize()
+            expected = [step + index + 1 for index in range(len(target_ids))]
+            expected.append(step + 1)
+            self.assertEqual(observed.cpu().tolist(), expected)
+        self.assertEqual(
+            target.forward_metadata.is_valid_token.tolist(),
+            [True, True, True, True, False, False, False, False],
+        )
+        self.assertEqual(
+            draft.forward_metadata.is_valid_token.tolist(),
+            [True, True, True, True, False, False, False, False],
+        )
+
+        torch.cuda.synchronize()
+        reserved_before = torch.cuda.memory_reserved()
+        for step in range(50):
+            replay(step + 100)
+        torch.cuda.synchronize()
+        reserved_after = torch.cuda.memory_reserved()
+        self.assertLessEqual(reserved_after, reserved_before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/runtime/test_deepseek_v4_flat_groups.py
+++ b/test/runtime/test_deepseek_v4_flat_groups.py
@@ -25,6 +25,7 @@ from tokenspeed.runtime.engine.scheduler_utils import (
     make_config,
     pool_to_paged_cache_groups,
     resolve_scheduler_block_size,
+    scheduler_cache_geometry_from_pool,
 )
 from tokenspeed.runtime.execution.cuda_graph_wrapper import CudaGraphWrapper
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
@@ -33,7 +34,12 @@ from tokenspeed.runtime.layers.attention.backends.deepseek_v4 import (
     DeepseekV4AttentionBackend,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.deepseek_v4 import (
+    DeepseekV4TokenToKVPool,
     _group_slot_mapping_from_raw,
+    deepseek_v4_cache_layout_from_config,
+    deepseek_v4_flat_group_page_counts,
+    deepseek_v4_flat_lcm_blocks_needed,
+    profile_deepseek_v4_flat_cache,
 )
 from tokenspeed.runtime.layers.attention.registry import (
     _validate_shared_flat_group_geometry,
@@ -120,6 +126,145 @@ def _page_counts(specs, count: int = 4096):
 
 
 class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
+    def test_flat_pool_allocates_complete_absolute_page_id_namespaces(self):
+        hf_config = SimpleNamespace(
+            compress_ratios=(1, 4, 128),
+            head_dim=512,
+            qk_rope_head_dim=64,
+            index_head_dim=128,
+            sliding_window=128,
+        )
+        layout = deepseek_v4_cache_layout_from_config(
+            hf_config,
+            page_size=256,
+            use_fp4_indexer_cache=True,
+        )
+        specs = tuple(build_v4_cache_specs(hf_config, layer_ratio=layout.layer_ratio))
+        sizing = dict(
+            token_capacity=1,
+            max_live_requests=1,
+            max_scheduled_tokens=1,
+            max_context_len=1,
+        )
+        parents = deepseek_v4_flat_lcm_blocks_needed(specs, **sizing)
+        pool = DeepseekV4TokenToKVPool(
+            size=1,
+            model_dtype=torch.bfloat16,
+            layout=layout,
+            layer_num=3,
+            device="cpu",
+            enable_memory_saver=False,
+            max_batch_size=1,
+            max_context_len=1,
+            page_size=256,
+            rank=0,
+            hf_config=hf_config,
+            max_scheduled_tokens=1,
+            flat_num_lcm_blocks=parents,
+        )
+
+        expected_counts = deepseek_v4_flat_group_page_counts(
+            specs,
+            num_lcm_blocks=parents,
+        )
+        self.assertEqual(pool.num_lcm_blocks, parents)
+        self.assertEqual(pool.paged_cache_group_page_counts, expected_counts)
+        self.assertFalse(pool.supports_hierarchical_kv_cache)
+        self.assertEqual(
+            pool.get_indexer_state_buffer(1).shape[0],
+            parents * 64 + 1,
+        )
+        geometry = scheduler_cache_geometry_from_pool(
+            pool,
+            fallback_token_capacity=pool.size,
+            fallback_page_size=pool.page_size,
+        )
+        self.assertEqual(geometry.num_device_pages, parents + 1)
+        self.assertEqual(geometry.num_usable_pages, parents)
+        self.assertEqual(geometry.token_capacity, 1)
+
+        with self.assertRaisesRegex(ValueError, "parent capacity"):
+            DeepseekV4TokenToKVPool(
+                size=1,
+                model_dtype=torch.bfloat16,
+                layout=layout,
+                layer_num=3,
+                device="cpu",
+                enable_memory_saver=False,
+                max_batch_size=1,
+                max_context_len=1,
+                page_size=256,
+                rank=0,
+                hf_config=hf_config,
+                max_scheduled_tokens=1,
+                flat_num_lcm_blocks=parents - 1,
+            )
+
+    def test_flat_profile_charges_target_and_mtp_absolute_geometry(self):
+        target_hf = SimpleNamespace(
+            compress_ratios=(1, 4, 128),
+            head_dim=512,
+            qk_rope_head_dim=64,
+            index_head_dim=128,
+            sliding_window=128,
+        )
+        draft_hf = SimpleNamespace(
+            compress_ratios=(1,),
+            head_dim=512,
+            qk_rope_head_dim=64,
+            index_head_dim=128,
+            sliding_window=128,
+        )
+        target_layout = deepseek_v4_cache_layout_from_config(
+            target_hf,
+            page_size=256,
+            use_fp4_indexer_cache=True,
+        )
+        draft_layout = deepseek_v4_cache_layout_from_config(
+            draft_hf,
+            page_size=256,
+            use_fp4_indexer_cache=True,
+        )
+        target_specs = tuple(
+            build_v4_cache_specs(
+                target_hf,
+                layer_ratio=target_layout.layer_ratio,
+            )
+        )
+        sizing = dict(
+            token_capacity=128,
+            max_live_requests=2,
+            max_scheduled_tokens=128,
+            max_context_len=128,
+            decode_input_tokens=4,
+            overlap_schedule_depth=1,
+        )
+        required = deepseek_v4_flat_lcm_blocks_needed(target_specs, **sizing)
+        plan = profile_deepseek_v4_flat_cache(
+            layout=target_layout,
+            hf_config=target_hf,
+            layer_num=3,
+            max_live_requests=2,
+            max_scheduled_tokens=128,
+            max_context_len=128,
+            available_cache_memory_bytes=100 * (1 << 30),
+            token_limit=128,
+            draft_layout=draft_layout,
+            draft_hf_config=draft_hf,
+            draft_layer_num=1,
+            decode_input_tokens=4,
+            overlap_schedule_depth=1,
+        )
+
+        self.assertEqual(plan.token_capacity, 128)
+        self.assertEqual(plan.num_lcm_blocks, required)
+        self.assertGreater(plan.bytes_per_lcm_block, 0)
+        self.assertGreater(plan.dummy_page_bytes, 0)
+        self.assertLessEqual(
+            plan.dummy_page_bytes + plan.num_lcm_blocks * plan.bytes_per_lcm_block,
+            100 * (1 << 30),
+        )
+
     def test_scheduler_block_size_matches_extension_contract(self):
         groups = pool_to_paged_cache_groups(
             SimpleNamespace(

--- a/test/runtime/test_deepseek_v4_flat_groups.py
+++ b/test/runtime/test_deepseek_v4_flat_groups.py
@@ -17,7 +17,10 @@ from ci_system.ci_register import register_cuda_ci
 register_cuda_ci(est_time=20, suite="runtime-1gpu")
 
 from tokenspeed.runtime.configs.deepseek_v4_cache_spec import build_v4_cache_specs
-from tokenspeed.runtime.configs.paged_cache_spec import validate_flat_scheduler_config
+from tokenspeed.runtime.configs.paged_cache_spec import (
+    PagedCacheGroupSpec,
+    validate_flat_scheduler_config,
+)
 from tokenspeed.runtime.engine.scheduler_utils import (
     make_config,
     pool_to_paged_cache_groups,
@@ -149,6 +152,50 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
         groups[0].cache_blocks_per_lcm_block = 3
         with self.assertRaisesRegex(ValueError, "does not cover Flat scheduler domain"):
             resolve_scheduler_block_size(256, groups)
+
+    @unittest.skipUnless(
+        scheduler_ext.FLAT_KVCACHE,
+        "requires a Flat KV scheduler extension",
+    )
+    def test_flat_same_granularity_allows_physical_packing(self):
+        spec = PagedCacheGroupSpec(
+            group_id="same-granularity-history",
+            retention="full_history",
+            rows_per_page=128,
+            entry_stride_tokens=1,
+            sliding_window_tokens=None,
+            block_size=128,
+            cache_blocks_per_lcm_block=12,
+        )
+        usable_domain_pages = 8
+        groups = pool_to_paged_cache_groups(
+            SimpleNamespace(
+                paged_cache_group_specs=(spec,),
+                paged_cache_group_page_counts={
+                    spec.group_id: (
+                        usable_domain_pages * spec.cache_blocks_per_lcm_block + 1
+                    )
+                },
+            )
+        )
+        cfg = make_config(
+            num_device_pages=usable_domain_pages + 1,
+            max_scheduled_tokens=256,
+            max_batch_size=2,
+            page_size=128,
+            num_host_pages=0,
+            disable_l2_cache=True,
+            enable_l3_storage=False,
+            prefetch_threshold=4,
+            role="null",
+            disable_prefix_cache=True,
+            paged_cache_groups=groups,
+        )
+
+        self.assertEqual(cfg.block_size, 128)
+        self.assertEqual(cfg.paged_cache_groups[0].block_size, 128)
+        self.assertEqual(cfg.paged_cache_groups[0].cache_blocks_per_lcm_block, 12)
+        scheduler_ext.Scheduler(cfg)
 
     @unittest.skipUnless(
         scheduler_ext.FLAT_KVCACHE,

--- a/test/runtime/test_deepseek_v4_flat_groups.py
+++ b/test/runtime/test_deepseek_v4_flat_groups.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import tokenspeed_scheduler as scheduler_ext
 import torch
 
 # CI Registration (parsed via AST, runtime no-op)
@@ -17,6 +18,11 @@ register_cuda_ci(est_time=20, suite="runtime-1gpu")
 
 from tokenspeed.runtime.configs.deepseek_v4_cache_spec import build_v4_cache_specs
 from tokenspeed.runtime.configs.paged_cache_spec import validate_flat_scheduler_config
+from tokenspeed.runtime.engine.scheduler_utils import (
+    make_config,
+    pool_to_paged_cache_groups,
+    resolve_scheduler_block_size,
+)
 from tokenspeed.runtime.execution.cuda_graph_wrapper import CudaGraphWrapper
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends import deepseek_v4 as v4_backend
@@ -111,6 +117,99 @@ def _page_counts(specs, count: int = 4096):
 
 
 class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
+    def test_scheduler_block_size_matches_extension_contract(self):
+        groups = pool_to_paged_cache_groups(
+            SimpleNamespace(
+                paged_cache_group_specs=_target_specs(),
+                paged_cache_group_page_counts=_page_counts(_target_specs()),
+            )
+        )
+        self.assertEqual(
+            resolve_scheduler_block_size(256, groups),
+            256 if scheduler_ext.FLAT_KVCACHE else 4,
+        )
+
+    @unittest.skipUnless(
+        scheduler_ext.FLAT_KVCACHE,
+        "requires a Flat KV scheduler extension",
+    )
+    def test_flat_scheduler_domain_rejects_invalid_group_geometry(self):
+        specs = _target_specs()
+        pool = SimpleNamespace(
+            paged_cache_group_specs=specs,
+            paged_cache_group_page_counts=_page_counts(specs),
+        )
+
+        groups = pool_to_paged_cache_groups(pool)
+        groups[0].block_size = 63
+        with self.assertRaisesRegex(ValueError, "must divide Flat scheduler domain"):
+            resolve_scheduler_block_size(256, groups)
+
+        groups = pool_to_paged_cache_groups(pool)
+        groups[0].cache_blocks_per_lcm_block = 3
+        with self.assertRaisesRegex(ValueError, "does not cover Flat scheduler domain"):
+            resolve_scheduler_block_size(256, groups)
+
+    @unittest.skipUnless(
+        scheduler_ext.FLAT_KVCACHE,
+        "requires a Flat KV scheduler extension",
+    )
+    def test_production_group_pipeline_constructs_scheduler(self):
+        specs = _target_specs()
+        usable_domain_pages = 64
+        pool = SimpleNamespace(
+            paged_cache_group_specs=specs,
+            paged_cache_group_page_counts={
+                spec.group_id: (
+                    usable_domain_pages * spec.cache_blocks_per_lcm_block + 1
+                )
+                for spec in specs
+            },
+        )
+        groups = pool_to_paged_cache_groups(pool)
+        cfg = make_config(
+            num_device_pages=usable_domain_pages + 1,
+            max_scheduled_tokens=512,
+            max_batch_size=4,
+            page_size=256,
+            num_host_pages=0,
+            disable_l2_cache=True,
+            enable_l3_storage=False,
+            prefetch_threshold=4,
+            role="null",
+            disable_prefix_cache=True,
+            paged_cache_groups=groups,
+        )
+
+        self.assertEqual(cfg.block_size, 256)
+        self.assertEqual(
+            tuple(group.block_size for group in cfg.paged_cache_groups),
+            (64, 4, 256, 8, 256, 4),
+        )
+        scheduler = scheduler_ext.Scheduler(cfg)
+        request = scheduler_ext.RequestSpec()
+        request.request_id = "v4-production-pipeline"
+        request.tokens = list(range(143))
+        scheduler.submit_requests([request])
+        op = next(
+            operation
+            for operation in scheduler.next_execution_plan().forward
+            if dict(operation.flat_block_tables)
+        )
+        tables = dict(op.flat_block_tables)
+        self.assertEqual(set(tables), {spec.group_id for spec in specs})
+        self.assertEqual(
+            {group_id: len(rows[0]) for group_id, rows in tables.items()},
+            {
+                "v4.swa_kv": 3,
+                "v4.c4a.compressor_state": 36,
+                "v4.c4a.compressed_kv": 1,
+                "v4.c128a.compressor_state": 18,
+                "v4.c128a.compressed_kv": 1,
+                "v4.c4a.indexer_compressor_state": 36,
+            },
+        )
+
     def test_cache_spec_identity_and_order_are_deterministic(self):
         first = _target_specs()
         second = _target_specs()

--- a/test/runtime/test_deepseek_v4_flat_groups.py
+++ b/test/runtime/test_deepseek_v4_flat_groups.py
@@ -106,6 +106,10 @@ def _tables(specs, *, rows: int = 2, cols: int = 2, device: str = "cpu"):
     )
 
 
+def _page_counts(specs, count: int = 4096):
+    return {str(spec.group_id): count for spec in specs}
+
+
 class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
     def test_cache_spec_identity_and_order_are_deterministic(self):
         first = _target_specs()
@@ -148,7 +152,11 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
         for mode, extras in cases:
             with self.subTest(mode=mode):
                 backend = _backend(flat=True, speculative_tokens=1)
-                backend.init_cuda_graph_state(2, paged_cache_group_specs=specs)
+                backend.init_cuda_graph_state(
+                    2,
+                    paged_cache_group_specs=specs,
+                    paged_cache_group_page_counts=_page_counts(specs),
+                )
                 backend.init_forward_metadata(
                     bs=2,
                     req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
@@ -218,7 +226,11 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
     def test_flat_payload_validation_fails_closed(self):
         specs = _target_specs()
         backend = _backend(flat=True)
-        backend.init_cuda_graph_state(2, paged_cache_group_specs=specs)
+        backend.init_cuda_graph_state(
+            2,
+            paged_cache_group_specs=specs,
+            paged_cache_group_page_counts=_page_counts(specs),
+        )
         valid = _tables(specs)
         common = dict(
             bs=2,
@@ -263,6 +275,24 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
                         flat_block_tables=tables,
                     )
 
+        out_of_capacity = OrderedDict(valid)
+        out_of_capacity[next(iter(out_of_capacity))] = torch.tensor(
+            [[4096, -1], [1, -1]], dtype=torch.int32
+        )
+        with self.assertRaisesRegex(RuntimeError, "outside -1..4095"):
+            backend.init_forward_metadata(
+                **common,
+                flat_block_tables=out_of_capacity,
+            )
+
+        too_short = OrderedDict(valid)
+        too_short[next(iter(too_short))] = torch.ones((2, 1), dtype=torch.int32)
+        with self.assertRaisesRegex(RuntimeError, "too short"):
+            backend.init_forward_metadata(
+                **{**common, "seq_lens": torch.tensor([65, 2], dtype=torch.int32)},
+                flat_block_tables=too_short,
+            )
+
         with self.assertRaisesRegex(RuntimeError, "radix paged-cache"):
             backend.init_forward_metadata(
                 **common,
@@ -285,10 +315,15 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
             backend.init_cuda_graph_state(
                 2,
                 paged_cache_group_specs=(spec, spec),
+                paged_cache_group_page_counts=_page_counts((spec,)),
             )
 
         backend = _backend(flat=True, is_draft=True)
-        backend.init_cuda_graph_state(2, paged_cache_group_specs=(spec,))
+        backend.init_cuda_graph_state(
+            2,
+            paged_cache_group_specs=(spec,),
+            paged_cache_group_page_counts=_page_counts((spec,)),
+        )
         with self.assertRaisesRegex(RuntimeError, "duplicate"):
             backend.init_forward_metadata_capture_cuda_graph(
                 bs=2,
@@ -305,6 +340,7 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
         backend.init_cuda_graph_state(
             2,
             paged_cache_group_specs=specs,
+            paged_cache_group_page_counts=_page_counts(specs),
             max_tokens_per_req=1,
         )
         backend.init_forward_metadata(
@@ -349,6 +385,15 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
             backend.forward_metadata.is_valid_token.tolist(),
             [True, False],
         )
+        for invalid_actual_bs in (-1, 3):
+            with self.subTest(actual_bs=invalid_actual_bs):
+                with self.assertRaisesRegex(RuntimeError, "within 0..2"):
+                    backend.init_forward_metadata_replay_cuda_graph(
+                        **common,
+                        actual_bs=invalid_actual_bs,
+                        req_to_page=torch.zeros((1, 64), dtype=torch.int32),
+                        flat_block_tables=idle_tables,
+                    )
 
     def test_target_and_mtp_route_same_identity_including_state(self):
         wrapper = object.__new__(CudaGraphWrapper)
@@ -402,6 +447,7 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
         backend.init_cuda_graph_state(
             2,
             paged_cache_group_specs=specs,
+            paged_cache_group_page_counts=_page_counts(specs),
             max_tokens_per_req=4,
         )
         common = dict(
@@ -419,7 +465,16 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
             live = OrderedDict(
                 (
                     group_id,
-                    torch.full((2, 2), step + index + 1, dtype=torch.int32),
+                    torch.full(
+                        (
+                            2,
+                            backend._cuda_graph_paged_cache_block_tables[
+                                group_id
+                            ].shape[1],
+                        ),
+                        step + index + 1,
+                        dtype=torch.int32,
+                    ),
                 )
                 for index, group_id in enumerate(group_ids)
             )
@@ -434,7 +489,9 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
             for group_id, table in live.items():
                 self.assertTrue(
                     torch.equal(
-                        metadata.cache.paged_cache_block_tables[group_id][:, :2],
+                        metadata.cache.paged_cache_block_tables[group_id][
+                            :, : table.shape[1]
+                        ],
                         table,
                     )
                 )
@@ -450,6 +507,7 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
         flat.init_cuda_graph_state(
             1,
             paged_cache_group_specs=(spec,),
+            paged_cache_group_page_counts=_page_counts((spec,)),
             max_tokens_per_req=4,
         )
         self.assertEqual(
@@ -479,6 +537,7 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
         backend.init_cuda_graph_state(
             2,
             paged_cache_group_specs=(spec,),
+            paged_cache_group_page_counts=_page_counts((spec,)),
             max_tokens_per_req=1,
         )
         table = {spec.group_id: torch.tensor([[10, 11], [20, -1]], dtype=torch.int32)}
@@ -545,11 +604,13 @@ class DeepseekV4FlatCudaGraphTest(unittest.TestCase):
         target.init_cuda_graph_state(
             2,
             paged_cache_group_specs=target_specs,
+            paged_cache_group_page_counts=_page_counts(target_specs),
             max_tokens_per_req=4,
         )
         draft.init_cuda_graph_state(
             2,
             paged_cache_group_specs=draft_specs,
+            paged_cache_group_page_counts=_page_counts(draft_specs),
             max_tokens_per_req=4,
         )
         common = dict(

--- a/test/runtime/test_deepseek_v4_flat_groups.py
+++ b/test/runtime/test_deepseek_v4_flat_groups.py
@@ -124,6 +124,10 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
         )
         self.assertEqual(tuple(spec.group_id for spec in first), expected)
         self.assertEqual(first, second)
+        self.assertEqual(
+            tuple((spec.block_size, spec.cache_blocks_per_lcm_block) for spec in first),
+            ((64, 4), (4, 64), (256, 1), (8, 32), (256, 1), (4, 64)),
+        )
 
     def test_eager_flat_maps_all_target_groups_in_decode_extend_and_mixed(self):
         specs = _target_specs()

--- a/test/runtime/test_deepseek_v4_flat_groups.py
+++ b/test/runtime/test_deepseek_v4_flat_groups.py
@@ -4,6 +4,7 @@ import os
 import sys
 import unittest
 from collections import OrderedDict
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -126,6 +127,33 @@ def _page_counts(specs, count: int = 4096):
 
 
 class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
+    def test_flat_page_namespace_rejects_ambiguous_or_unrepresentable_geometry(
+        self,
+    ):
+        spec = _target_specs()[0]
+        with self.assertRaisesRegex(ValueError, "must not be empty"):
+            deepseek_v4_flat_group_page_counts((), num_lcm_blocks=1)
+        with self.assertRaisesRegex(ValueError, "nonempty string"):
+            deepseek_v4_flat_group_page_counts(
+                (replace(spec, group_id=""),), num_lcm_blocks=1
+            )
+        with self.assertRaisesRegex(ValueError, "nonempty string"):
+            deepseek_v4_flat_group_page_counts(
+                (replace(spec, group_id=7),), num_lcm_blocks=1
+            )
+        with self.assertRaisesRegex(ValueError, "unique group IDs"):
+            deepseek_v4_flat_group_page_counts((spec, spec), num_lcm_blocks=1)
+        with self.assertRaisesRegex(ValueError, "invalid packing"):
+            deepseek_v4_flat_group_page_counts(
+                (replace(spec, cache_blocks_per_lcm_block=True),),
+                num_lcm_blocks=1,
+            )
+        with self.assertRaisesRegex(ValueError, "page ID exceeds"):
+            deepseek_v4_flat_group_page_counts(
+                (replace(spec, cache_blocks_per_lcm_block=64),),
+                num_lcm_blocks=((1 << 31) - 1) // 64 + 1,
+            )
+
     def test_flat_pool_allocates_complete_absolute_page_id_namespaces(self):
         hf_config = SimpleNamespace(
             compress_ratios=(1, 4, 128),
@@ -263,6 +291,77 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
         self.assertLessEqual(
             plan.dummy_page_bytes + plan.num_lcm_blocks * plan.bytes_per_lcm_block,
             100 * (1 << 30),
+        )
+
+        target_pool = DeepseekV4TokenToKVPool(
+            size=plan.token_capacity,
+            model_dtype=torch.bfloat16,
+            layout=target_layout,
+            layer_num=3,
+            device="cpu",
+            enable_memory_saver=False,
+            max_batch_size=2,
+            max_context_len=128,
+            page_size=256,
+            rank=0,
+            hf_config=target_hf,
+            max_scheduled_tokens=128,
+            decode_input_tokens=4,
+            overlap_schedule_depth=1,
+            flat_num_lcm_blocks=plan.num_lcm_blocks,
+        )
+        draft_pool = DeepseekV4TokenToKVPool(
+            size=plan.token_capacity,
+            model_dtype=torch.bfloat16,
+            layout=draft_layout,
+            layer_num=1,
+            device="cpu",
+            enable_memory_saver=False,
+            max_batch_size=2,
+            max_context_len=128,
+            page_size=256,
+            rank=0,
+            hf_config=draft_hf,
+            max_scheduled_tokens=128,
+            decode_input_tokens=4,
+            overlap_schedule_depth=1,
+            flat_num_lcm_blocks=plan.num_lcm_blocks,
+        )
+        self.assertEqual(
+            target_pool.get_kv_size_bytes() + draft_pool.get_kv_size_bytes(),
+            plan.dummy_page_bytes + plan.num_lcm_blocks * plan.bytes_per_lcm_block,
+        )
+
+        target_only_under_budget = profile_deepseek_v4_flat_cache(
+            layout=target_layout,
+            hf_config=target_hf,
+            layer_num=3,
+            max_live_requests=2,
+            max_scheduled_tokens=0,
+            max_context_len=4096,
+            available_cache_memory_bytes=1 << 30,
+            token_limit=None,
+            decode_input_tokens=4,
+            overlap_schedule_depth=1,
+        )
+        target_and_mtp_under_budget = profile_deepseek_v4_flat_cache(
+            layout=target_layout,
+            hf_config=target_hf,
+            layer_num=3,
+            max_live_requests=2,
+            max_scheduled_tokens=0,
+            max_context_len=4096,
+            available_cache_memory_bytes=1 << 30,
+            token_limit=None,
+            draft_layout=draft_layout,
+            draft_hf_config=draft_hf,
+            draft_layer_num=1,
+            decode_input_tokens=4,
+            overlap_schedule_depth=1,
+        )
+        self.assertLess(
+            target_and_mtp_under_budget.token_capacity,
+            target_only_under_budget.token_capacity,
         )
 
     def test_scheduler_block_size_matches_extension_contract(self):
@@ -636,6 +735,40 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
                 seq_lens=torch.ones(2, dtype=torch.int32),
                 forward_mode=ForwardMode.DECODE,
                 flat_cache_group_ids=(spec.group_id, spec.group_id),
+            )
+
+    def test_draft_flat_coverage_does_not_double_count_verify_window(self):
+        spec = _draft_specs()[0]
+        backend = _backend(flat=True, is_draft=True, speculative_tokens=4)
+        backend.init_cuda_graph_state(
+            1,
+            paged_cache_group_specs=(spec,),
+            paged_cache_group_page_counts=_page_counts((spec,)),
+        )
+        one_page = OrderedDict(
+            ((spec.group_id, torch.tensor([[1]], dtype=torch.int32)),)
+        )
+        common = dict(
+            bs=1,
+            req_pool_indices=torch.tensor([0], dtype=torch.int32),
+            forward_mode=ForwardMode.DECODE,
+            req_to_page=torch.zeros((1, 2), dtype=torch.int32),
+            flat_block_tables=one_page,
+        )
+
+        # seq_lens is already the exclusive end of the four-token target
+        # verify window.  Position 60 therefore fits in logical page 0.
+        backend.init_forward_metadata(
+            **common,
+            seq_lens=torch.tensor([61], dtype=torch.int32),
+        )
+        self.assertIsNotNone(backend.forward_metadata)
+
+        # Crossing the real 64-token boundary still fails closed.
+        with self.assertRaisesRegex(RuntimeError, "missing a real page"):
+            backend.init_forward_metadata(
+                **common,
+                seq_lens=torch.tensor([65], dtype=torch.int32),
             )
 
     def test_idle_zero_batch_and_padded_replay_are_safe(self):

--- a/test/runtime/test_deepseek_v4_flat_groups.py
+++ b/test/runtime/test_deepseek_v4_flat_groups.py
@@ -27,6 +27,7 @@ from tokenspeed.runtime.engine.scheduler_utils import (
     pool_to_paged_cache_groups,
     resolve_scheduler_block_size,
     scheduler_cache_geometry_from_pool,
+    validate_scheduler_page_domain_contract,
 )
 from tokenspeed.runtime.execution.cuda_graph_wrapper import CudaGraphWrapper
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
@@ -94,6 +95,7 @@ def _target_specs():
         build_v4_cache_specs(
             SimpleNamespace(sliding_window=128),
             layer_ratio=(1, 4, 128),
+            flat_scheduler=True,
         )
     )
 
@@ -103,6 +105,7 @@ def _draft_specs():
         build_v4_cache_specs(
             SimpleNamespace(sliding_window=128),
             layer_ratio=(1,),
+            flat_scheduler=True,
         )
     )
 
@@ -167,7 +170,13 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
             page_size=256,
             use_fp4_indexer_cache=True,
         )
-        specs = tuple(build_v4_cache_specs(hf_config, layer_ratio=layout.layer_ratio))
+        specs = tuple(
+            build_v4_cache_specs(
+                hf_config,
+                layer_ratio=layout.layer_ratio,
+                flat_scheduler=True,
+            )
+        )
         sizing = dict(
             token_capacity=1,
             max_live_requests=1,
@@ -257,6 +266,7 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
             build_v4_cache_specs(
                 target_hf,
                 layer_ratio=target_layout.layer_ratio,
+                flat_scheduler=True,
             )
         )
         sizing = dict(
@@ -364,17 +374,77 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
             target_only_under_budget.token_capacity,
         )
 
-    def test_scheduler_block_size_matches_extension_contract(self):
-        groups = pool_to_paged_cache_groups(
-            SimpleNamespace(
-                paged_cache_group_specs=_target_specs(),
-                paged_cache_group_page_counts=_page_counts(_target_specs()),
+    def test_radix_specs_preserve_legacy_scheduler_geometry(self):
+        specs = tuple(
+            build_v4_cache_specs(
+                SimpleNamespace(sliding_window=128),
+                layer_ratio=(1, 4, 128),
             )
         )
-        self.assertEqual(
-            resolve_scheduler_block_size(256, groups),
-            256 if scheduler_ext.FLAT_KVCACHE else 4,
+        self.assertTrue(all(spec.block_size is None for spec in specs))
+        self.assertTrue(all(spec.cache_blocks_per_lcm_block == 1 for spec in specs))
+        groups = pool_to_paged_cache_groups(
+            SimpleNamespace(
+                paged_cache_group_specs=specs,
+                paged_cache_group_page_counts=_page_counts(specs),
+            )
         )
+        self.assertTrue(all(group.block_size == 0 for group in groups))
+        self.assertEqual(resolve_scheduler_block_size(256, groups), 256)
+        cfg = make_config(
+            num_device_pages=32,
+            max_scheduled_tokens=256,
+            max_batch_size=2,
+            page_size=256,
+            num_host_pages=0,
+            disable_l2_cache=True,
+            enable_l3_storage=False,
+            prefetch_threshold=4,
+            role="null",
+            disable_prefix_cache=True,
+            paged_cache_groups=groups,
+        )
+        geometry = SimpleNamespace(
+            page_size=256,
+            num_device_pages=32,
+            num_usable_pages=32,
+            token_capacity=8192,
+        )
+        pool = SimpleNamespace(requires_scheduler_page_domain_match=True)
+        executor = SimpleNamespace(logical_page_size=256)
+        validate_scheduler_page_domain_contract(
+            pool=pool,
+            geometry=geometry,
+            scheduler_config=cfg,
+            model_executor_config=executor,
+        )
+
+        cfg.block_size = 4
+        with self.assertRaisesRegex(ValueError, "scheduler page-domain mismatch"):
+            validate_scheduler_page_domain_contract(
+                pool=pool,
+                geometry=geometry,
+                scheduler_config=cfg,
+                model_executor_config=executor,
+            )
+
+        cfg.block_size = 256
+        geometry.token_capacity = 8193
+        with self.assertRaisesRegex(ValueError, "advertised token capacity"):
+            validate_scheduler_page_domain_contract(
+                pool=pool,
+                geometry=geometry,
+                scheduler_config=cfg,
+                model_executor_config=executor,
+            )
+
+    def test_cache_specs_reject_non_boolean_scheduler_mode(self):
+        with self.assertRaisesRegex(ValueError, "flat_scheduler must be a bool"):
+            build_v4_cache_specs(
+                SimpleNamespace(sliding_window=128),
+                layer_ratio=(1, 4, 128),
+                flat_scheduler=1,
+            )
 
     @unittest.skipUnless(
         scheduler_ext.FLAT_KVCACHE,

--- a/test/runtime/test_deepseek_v4_flat_groups.py
+++ b/test/runtime/test_deepseek_v4_flat_groups.py
@@ -287,10 +287,20 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
 
         too_short = OrderedDict(valid)
         too_short[next(iter(too_short))] = torch.ones((2, 1), dtype=torch.int32)
-        with self.assertRaisesRegex(RuntimeError, "too short"):
+        with self.assertRaisesRegex(RuntimeError, "missing a real page"):
             backend.init_forward_metadata(
                 **{**common, "seq_lens": torch.tensor([65, 2], dtype=torch.int32)},
                 flat_block_tables=too_short,
+            )
+
+        null_current_page = OrderedDict(valid)
+        null_current_page[next(iter(null_current_page))] = torch.tensor(
+            [[1, 0], [2, 3]], dtype=torch.int32
+        )
+        with self.assertRaisesRegex(RuntimeError, "missing a real page"):
+            backend.init_forward_metadata(
+                **{**common, "seq_lens": torch.tensor([65, 2], dtype=torch.int32)},
+                flat_block_tables=null_current_page,
             )
 
         with self.assertRaisesRegex(RuntimeError, "radix paged-cache"):
@@ -364,7 +374,7 @@ class DeepseekV4FlatGroupUnitTest(unittest.TestCase):
             flat_cache_group_ids=group_ids,
         )
         idle_tables = OrderedDict(
-            ((group_ids[0], torch.zeros((2, 1), dtype=torch.int32)),)
+            ((group_ids[0], torch.tensor([[1], [0]], dtype=torch.int32)),)
         )
         backend.init_forward_metadata_replay_cuda_graph(
             **common,

--- a/test/runtime/test_flat_block_tables_bridge.py
+++ b/test/runtime/test_flat_block_tables_bridge.py
@@ -102,6 +102,19 @@ class FlatBlockTablesBridgeTest(unittest.TestCase):
         self.assertEqual(self.bridge(op, device="cpu", num_reqs=0), {})
         self.assertEqual(self.bridge(op, device="cpu"), {})
 
+    def test_strict_bridge_rejects_invalid_id_outside_active_page(self):
+        # The scheduler-export bridge owns the complete range scan before H2D;
+        # backend replay only needs to gather each active row's current page.
+        op = self._make_op({"full": [[1, 99]]})
+        with self.assertRaisesRegex(ValueError, "outside -1..8"):
+            self.bridge(
+                op,
+                device="cpu",
+                num_reqs=1,
+                expected_group_ids=("full",),
+                max_page_ids={"full": 8},
+            )
+
 
 class FlatFlagGatingTest(unittest.TestCase):
     """uses_flat_cache_groups must default to False so every existing

--- a/test/runtime/test_flat_block_tables_bridge.py
+++ b/test/runtime/test_flat_block_tables_bridge.py
@@ -115,6 +115,28 @@ class FlatBlockTablesBridgeTest(unittest.TestCase):
                 max_page_ids={"full": 8},
             )
 
+    def test_strict_legacy_bridge_accepts_absolute_ids_without_upper_bound(self):
+        # Legacy MHA group counts size admission, not the shared scheduler's
+        # absolute page-ID domain. They must not be supplied as upper bounds.
+        op = self._make_op({"full": [[1, 609, 142822, -1]]})
+        out = self.bridge(
+            op,
+            device="cpu",
+            num_reqs=1,
+            expected_group_ids=("full",),
+        )
+        self.assertEqual(out["full"].tolist(), [[1, 609, 142822, -1]])
+
+    def test_strict_legacy_bridge_rejects_id_below_minus_one(self):
+        op = self._make_op({"full": [[1, -2]]})
+        with self.assertRaisesRegex(ValueError, "page ID below -1"):
+            self.bridge(
+                op,
+                device="cpu",
+                num_reqs=1,
+                expected_group_ids=("full",),
+            )
+
 
 class FlatFlagGatingTest(unittest.TestCase):
     """uses_flat_cache_groups must default to False so every existing

--- a/test/runtime/test_flat_host_executor.py
+++ b/test/runtime/test_flat_host_executor.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import os
 import sys
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 # CI Registration (parsed via AST, runtime no-op)
@@ -107,6 +108,18 @@ class FlatHostPageSizingTest(unittest.TestCase):
                 page_size=4,
                 host_ratio=2.0,
                 host_size_gb=0.5,
+            )
+
+    def test_executor_rejects_pool_without_flat_host_mirror_capability(self):
+        from tokenspeed.runtime.cache.executor.flat_memory_executor import (
+            FlatMemoryExecutor,
+        )
+
+        with self.assertRaisesRegex(NotImplementedError, "--disable-kvstore"):
+            FlatMemoryExecutor(
+                device_pool=SimpleNamespace(supports_flat_host_mirror=False),
+                host_ratio=2.0,
+                host_size_gb=0,
             )
 
 
@@ -219,6 +232,7 @@ class FlatMemoryExecutorTest(unittest.TestCase):
             return self.MHATokenToKVPool(**kwargs)
 
     def _executor(self, pool):
+        self.assertTrue(pool.supports_flat_host_mirror)
         return self.FlatMemoryExecutor(device_pool=pool, host_ratio=2.0, host_size_gb=0)
 
     def _fill_device_pages(self, mirror, device_pages):

--- a/test/runtime/test_flat_prefill_graph.py
+++ b/test/runtime/test_flat_prefill_graph.py
@@ -14,6 +14,7 @@ import os
 import sys
 import unittest
 from types import SimpleNamespace
+from unittest import mock
 
 # CI Registration (parsed via AST, runtime no-op)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -175,6 +176,86 @@ class DummyFlatTablesTest(unittest.TestCase):
             (2, 1024),
         )
 
+    def test_v4_dummy_batch_satisfies_active_real_page_contract(self):
+        import torch
+
+        from tokenspeed.runtime.configs.deepseek_v4_cache_spec import (
+            build_v4_cache_specs,
+        )
+        from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
+        from tokenspeed.runtime.layers.attention.backends import deepseek_v4
+        from tokenspeed.runtime.layers.attention.backends.deepseek_v4 import (
+            DeepseekV4AttentionBackend,
+        )
+
+        config = SimpleNamespace(
+            page_size=64,
+            device="cpu",
+            num_attention_heads=64,
+            num_kv_heads=1,
+            attn_tp_size=1,
+            dtype=torch.bfloat16,
+            is_draft=False,
+            speculative_num_draft_tokens=4,
+            speculative_num_steps=1,
+            head_dim=512,
+            qk_rope_head_dim=64,
+            context_len=4096,
+            world_size=1,
+        )
+        specs = tuple(
+            build_v4_cache_specs(
+                SimpleNamespace(sliding_window=128),
+                layer_ratio=(1, 4, 128),
+            )
+        )
+        with mock.patch.object(
+            deepseek_v4, "scheduler_ext_flat_kvcache", return_value=True
+        ):
+            backend = DeepseekV4AttentionBackend(config)
+        backend.init_cuda_graph_state(
+            2,
+            paged_cache_group_specs=specs,
+            paged_cache_group_page_counts={spec.group_id: 4096 for spec in specs},
+        )
+        pool = SimpleNamespace(
+            paged_cache_group_specs=specs,
+            runtime_contract=None,
+        )
+        input_buffers = SimpleNamespace(
+            seq_lens_buf=torch.zeros(2, dtype=torch.int32),
+            input_ids_buf=torch.zeros(256, dtype=torch.int32),
+            out_cache_loc_buf=torch.zeros(256, dtype=torch.int32),
+            positions_buf=torch.zeros(256, dtype=torch.int64),
+            req_pool_indices_buf=torch.zeros(2, dtype=torch.int32),
+            extend_seq_lens_buf=torch.zeros(2, dtype=torch.int32),
+            extend_seq_lens_cpu=torch.zeros(2, dtype=torch.int32),
+            extend_prefix_lens_buf=torch.zeros(2, dtype=torch.int32),
+            extend_prefix_lens_cpu=torch.zeros(2, dtype=torch.int32),
+            dummy_kv_slot=0,
+        )
+        graph = self.PrefillGraph.__new__(self.PrefillGraph)
+        graph.attn_backend = backend
+        graph.token_to_kv_pool = pool
+        graph.config = config
+        graph.input_buffers = input_buffers
+        graph.req_to_page = torch.zeros((2, 64), dtype=torch.int32)
+        graph.dp_size = 1
+        graph.drafter = None
+
+        context = graph.make_dummy_batch(130, decode_wrapper=None)
+
+        self.assertEqual(context.forward_mode, ForwardMode.EXTEND)
+        metadata = backend.forward_metadata
+        self.assertIsNotNone(metadata)
+        assert metadata is not None
+        self.assertEqual(
+            tuple(metadata.cache.paged_cache_block_tables),
+            tuple(spec.group_id for spec in specs),
+        )
+        for table in metadata.cache.paged_cache_block_tables.values():
+            self.assertTrue(bool((table > 0).all()))
+
     def test_dual_capable_backend_selects_one_capture_contract(self):
         flat = SimpleNamespace(
             uses_paged_cache_groups=True,
@@ -188,8 +269,6 @@ class DummyFlatTablesTest(unittest.TestCase):
         self.assertTrue(self.PrefillGraph._capture_uses_radix_group_tables(radix))
 
     def test_runtime_contract_pool_is_eligible_for_capture(self):
-        from unittest import mock
-
         inner_model = SimpleNamespace(embed_tokens=object())
         model_runner = SimpleNamespace(
             model=SimpleNamespace(model=inner_model),
@@ -243,8 +322,6 @@ class TrtllmPrefillGraphSeamsTest(unittest.TestCase):
         return b
 
     def test_prewrite_disabled_during_breakable_capture(self):
-        from unittest import mock
-
         b = self._bare_backend()
         self.assertTrue(b.support_kv_cache_prewrite(None))
         with mock.patch.object(

--- a/test/runtime/test_flat_prefill_graph.py
+++ b/test/runtime/test_flat_prefill_graph.py
@@ -145,6 +145,48 @@ class DummyFlatTablesTest(unittest.TestCase):
         pool = SimpleNamespace(paged_cache_group_specs=())
         self.assertEqual(self._bare(backend, pool)._dummy_flat_tables(64, 1), {})
 
+    def test_v4_state_group_uses_absolute_logical_width(self):
+        backend = SimpleNamespace(
+            uses_flat_cache_groups=True,
+            page_size=64,
+            max_num_pages=64,
+            flat_state_group_ids=frozenset({"v4.c4a.compressor_state"}),
+        )
+        pool = SimpleNamespace(
+            paged_cache_group_specs=(
+                SimpleNamespace(
+                    group_id="v4.swa_kv",
+                    family="state",
+                    rows_per_page=64,
+                    entry_stride_tokens=1,
+                ),
+                SimpleNamespace(
+                    group_id="v4.c4a.compressor_state",
+                    family="state",
+                    rows_per_page=4,
+                    entry_stride_tokens=1,
+                ),
+            )
+        )
+        tables = self._bare(backend, pool)._dummy_flat_tables(4096)
+        self.assertEqual(tables["v4.swa_kv"].shape, (1, 64))
+        self.assertEqual(
+            tables["v4.c4a.compressor_state"].shape,
+            (1, 1024),
+        )
+
+    def test_dual_capable_backend_selects_one_capture_contract(self):
+        flat = SimpleNamespace(
+            uses_paged_cache_groups=True,
+            uses_flat_cache_groups=True,
+        )
+        radix = SimpleNamespace(
+            uses_paged_cache_groups=True,
+            uses_flat_cache_groups=False,
+        )
+        self.assertFalse(self.PrefillGraph._capture_uses_radix_group_tables(flat))
+        self.assertTrue(self.PrefillGraph._capture_uses_radix_group_tables(radix))
+
     def test_runtime_contract_pool_is_eligible_for_capture(self):
         from unittest import mock
 

--- a/test/runtime/test_flat_prefill_graph.py
+++ b/test/runtime/test_flat_prefill_graph.py
@@ -207,6 +207,7 @@ class DummyFlatTablesTest(unittest.TestCase):
             build_v4_cache_specs(
                 SimpleNamespace(sliding_window=128),
                 layer_ratio=(1, 4, 128),
+                flat_scheduler=True,
             )
         )
         with mock.patch.object(

--- a/test/runtime/test_flat_prefill_graph.py
+++ b/test/runtime/test_flat_prefill_graph.py
@@ -168,11 +168,11 @@ class DummyFlatTablesTest(unittest.TestCase):
                 ),
             )
         )
-        tables = self._bare(backend, pool)._dummy_flat_tables(4096)
-        self.assertEqual(tables["v4.swa_kv"].shape, (1, 64))
+        tables = self._bare(backend, pool)._dummy_flat_tables(4096, 2)
+        self.assertEqual(tables["v4.swa_kv"].shape, (2, 64))
         self.assertEqual(
             tables["v4.c4a.compressor_state"].shape,
-            (1, 1024),
+            (2, 1024),
         )
 
     def test_dual_capable_backend_selects_one_capture_contract(self):

--- a/test/runtime/test_group_specs_from_layer_types.py
+++ b/test/runtime/test_group_specs_from_layer_types.py
@@ -182,6 +182,16 @@ class GroupSpecsFromLayerTypesTest(unittest.TestCase):
         self.assertEqual(by_id["linear_attention"].family, "state")
         self.assertIsNone(by_id["linear_attention"].sliding_window_tokens)
 
+    def test_layer_helper_rejects_finer_page_sizes_with_explicit_route(self):
+        with self.assertRaisesRegex(ValueError, "explicit PagedCacheGroupSpec"):
+            group_specs_from_layer_types(
+                layer_types=["full_attention"],
+                sliding_window_tokens=None,
+                page_size=256,
+                page_sizes={"full_attention": 64},
+                cache_blocks_per_lcm_block={"full_attention": 4},
+            )
+
 
 class LayerGroupIdsTest(unittest.TestCase):
     def test_single_window_ids_equal_layer_types(self):

--- a/test/runtime/test_group_specs_from_layer_types.py
+++ b/test/runtime/test_group_specs_from_layer_types.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import sys
 import unittest
+from unittest import mock
 
 # CI Registration (parsed via AST, runtime no-op)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -191,6 +192,67 @@ class GroupSpecsFromLayerTypesTest(unittest.TestCase):
                 page_sizes={"full_attention": 64},
                 cache_blocks_per_lcm_block={"full_attention": 4},
             )
+
+    def test_structural_helper_allows_coarser_page_sizes(self):
+        specs = group_specs_from_layer_types(
+            layer_types=["full_attention"],
+            sliding_window_tokens=None,
+            page_size=128,
+            page_sizes={"full_attention": 256},
+        )
+        self.assertEqual(specs[0].block_size, 256)
+
+    def test_flat_publication_rejects_coarser_page_size_early(self):
+        with mock.patch.object(
+            _pcs,
+            "scheduler_ext_flat_kvcache",
+            return_value=True,
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "must divide Flat scheduler domain 128",
+            ):
+                _pcs.publish_paged_cache_groups(
+                    layer_types=["full_attention"],
+                    sliding_window_tokens=None,
+                    page_size=128,
+                    page_sizes={"full_attention": 256},
+                    max_live_requests=2,
+                    max_scheduled_tokens=128,
+                    max_total_tokens=1024,
+                    max_context_len=1024,
+                )
+
+    def test_flat_publication_rejects_incomplete_finer_group_packing(self):
+        finer = PagedCacheGroupSpec(
+            group_id="fine_state",
+            retention="full_history",
+            rows_per_page=64,
+            entry_stride_tokens=1,
+            sliding_window_tokens=None,
+            family="state",
+            block_size=64,
+            cache_blocks_per_lcm_block=3,
+        )
+        with mock.patch.object(
+            _pcs,
+            "scheduler_ext_flat_kvcache",
+            return_value=True,
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "does not cover Flat scheduler domain 256; expected 4",
+            ):
+                _pcs.publish_paged_cache_groups(
+                    layer_types=["full_attention"],
+                    sliding_window_tokens=None,
+                    page_size=256,
+                    extra_groups=[finer],
+                    max_live_requests=2,
+                    max_scheduled_tokens=256,
+                    max_total_tokens=2048,
+                    max_context_len=2048,
+                )
 
 
 class LayerGroupIdsTest(unittest.TestCase):

--- a/test/runtime/test_mxfp8_kv_pool.py
+++ b/test/runtime/test_mxfp8_kv_pool.py
@@ -18,16 +18,24 @@
 """MXFP8 KV pool: quantize -> store -> verify layout and roundtrip error.
 
 Covers both scale layouts (interleaved for page 128, flat otherwise), the
-size accounting, and an end-to-end quantize_mxfp8 -> set_kv_buffer ->
-manual dequant roundtrip against the original bf16 K/V.
+size accounting, the Flat LCM heterogeneous-group layout, and an end-to-end
+quantize_mxfp8 -> set_kv_buffer -> manual dequant roundtrip against the
+original bf16 K/V.
 """
 
 from __future__ import annotations
 
+import os
+import sys
 from types import SimpleNamespace
 
 import pytest
 import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=120, suite="runtime-1gpu")
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="needs a CUDA device"
@@ -142,86 +150,117 @@ def test_size_accounting_includes_scales():
 
 
 # -----------------------------------------------------------------------------
-# Hybrid-slab mode (flat ext): fp8 data slabs + parallel SF slabs
+# LCM arena mode (flat ext): heterogeneous groups share byte-uniform planes
 # -----------------------------------------------------------------------------
 
-SLAB_LAYER_TYPES = (
+LCM_LAYER_TYPES = (
     "full_attention",
     "sliding_attention_0",
     "full_attention",
     "sliding_attention_0",
 )
-# Byte-uniform hetero slots: full layers serve half the heads at twice the
-# tokens per page (slot bytes equal).
-SLAB_KV_HEADS = (2, 4, 2, 4)
+# A byte-uniform LCM parent: full layers serve half the heads, so the parent
+# packs twice as many 128-token child pages for that group.
+LCM_KV_HEADS = (2, 4, 2, 4)
 
 
-def _make_slab_pool(size: int = 512):
+def _make_lcm_pool(num_lcm_blocks: int = 4):
     from unittest import mock
 
     from tokenspeed.runtime.configs import paged_cache_spec
-    from tokenspeed.runtime.layers.attention.kv_cache import mha as mha_mod
-    from tokenspeed.runtime.layers.attention.kv_cache.mha import (
-        MHATokenToKVPoolMXFP8,
+    from tokenspeed.runtime.configs.lcm_layouts import draft_history_lcm_fields
+    from tokenspeed.runtime.configs.lcm_memory_plan import plan_lcm_fields
+    from tokenspeed.runtime.layers.attention.kv_cache.lcm_mha import (
+        LcmMHATokenToKVPoolMXFP8,
     )
 
+    fields = draft_history_lcm_fields(
+        layer_group_ids=LCM_LAYER_TYPES,
+        enabled_layer_ids=range(len(LCM_LAYER_TYPES)),
+        logical_block_tokens=128,
+        layer_kv_heads=LCM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        kv_element_size=1,
+        kv_scale_block_size=32,
+        kv_scale_element_size=1,
+    )
+    plan = plan_lcm_fields(
+        fields,
+        logical_block_tokens=128,
+        num_lcm_blocks=num_lcm_blocks,
+        alignment=256,
+        max_padding_fraction=1.0,
+    )
+    max_packing = max(group.cache_blocks_per_lcm_block for group in plan.groups)
+    size = num_lcm_blocks * max_packing * plan.logical_block_tokens
     with mock.patch.object(
         paged_cache_spec, "scheduler_ext_flat_kvcache", return_value=True
-    ), mock.patch.object(
-        mha_mod.paged_cache_spec, "scheduler_ext_flat_kvcache", return_value=True
     ):
-        return MHATokenToKVPoolMXFP8(
+        return LcmMHATokenToKVPoolMXFP8(
             size=size,
             dtype=torch.float8_e4m3fn,
             head_num=HEADS,
             head_dim=HEAD_DIM,
-            layer_num=len(SLAB_LAYER_TYPES),
+            layer_num=len(LCM_LAYER_TYPES),
             device="cuda",
             enable_memory_saver=False,
-            max_batch_size=8,
+            max_batch_size=1,
             max_context_len=size,
             page_size=128,
             rank=0,
-            layer_types=SLAB_LAYER_TYPES,
+            layer_types=LCM_LAYER_TYPES,
             sliding_window_tokens=512,
-            max_scheduled_tokens=size,
-            slot_tokens=256,
-            group_page_sizes={"full_attention": 256},
-            layer_kv_head_counts=SLAB_KV_HEADS,
+            max_scheduled_tokens=128,
+            layer_kv_head_counts=LCM_KV_HEADS,
+            kv_alloc_head_count=HEADS,
+            memory_plan=plan,
+            layer_group_ids=LCM_LAYER_TYPES,
+            state_field_dtypes={},
         )
 
 
-def test_slab_geometry_and_aliasing():
-    pool = _make_slab_pool()
-    num_ids = (pool.size + pool._slot_tokens) // pool.page_size
+def test_lcm_geometry_and_aliasing():
+    pool = _make_lcm_pool()
+    by_group = {group.group_id: group for group in pool._lcm_memory_plan.groups}
 
-    # Paired layers alias data AND scale slabs.
-    assert pool.k_buffer[0] is pool.k_buffer[1]
-    assert pool.k_scale_buffer[0] is pool.k_scale_buffer[1]
-    assert pool.k_buffer[0] is not pool.k_buffer[2]
-    assert pool.k_scale_buffer[0] is not pool.k_scale_buffer[2]
+    # Both groups use the scheduler's 128-token logical page domain. Their
+    # byte ratio is expressed by child-page packing, not a coarser group page.
+    assert by_group["full_attention"].cache_blocks_per_lcm_block == 2
+    assert by_group["sliding_attention_0"].cache_blocks_per_lcm_block == 1
+    assert all(spec.block_size == 128 for spec in pool.paged_cache_group_specs)
+    assert pool.paged_cache_group_page_counts == {
+        "full_attention": 9,
+        "sliding_attention_0": 5,
+    }
+
     assert pool.k_buffer[0].dtype == torch.float8_e4m3fn
 
-    # One byte-uniform SF slot per id: slot_bytes / 32 e8m0 each.
-    slot_sf = 128 * HEADS * HEAD_DIM // 32
-    assert pool.k_scale_buffer[0].shape == (num_ids, slot_sf)
-
-    # Layer views factorize the same bytes: full (h/2, k=2), swa (h, k=1).
+    # Every child page represents 128 tokens; the narrow full-attention group
+    # gets twice as many child page IDs from each LCM parent.
     k_full, _ = pool.get_kv_scale_buffer(0)
     k_swa, _ = pool.get_kv_scale_buffer(1)
-    assert k_full.shape == (num_ids, 2, 2, 32, SF_DIM, SF_DIM)
-    assert k_swa.shape == (num_ids, 4, 1, 32, SF_DIM, SF_DIM)
+    full_rows = pool.get_key_buffer(0)
+    swa_rows = pool.get_key_buffer(1)
+    assert k_full.shape == (9, 2, 1, 32, SF_DIM, SF_DIM)
+    assert k_swa.shape == (5, 4, 1, 32, SF_DIM, SF_DIM)
+    assert full_rows.shape == (9 * 128, 2, HEAD_DIM)
+    assert swa_rows.shape == (5 * 128, 4, HEAD_DIM)
+
+    # Paired group fields overlay the same LCM parent at page 1 while the
+    # second occurrence of the group is assigned a separate plane.
+    assert full_rows[128].data_ptr() == swa_rows[128].data_ptr()
+    assert k_full[1].data_ptr() == k_swa[1].data_ptr()
+    assert full_rows[128].data_ptr() != pool.get_key_buffer(2)[128].data_ptr()
+    assert k_full[1].data_ptr() != pool.get_kv_scale_buffer(2)[0][1].data_ptr()
 
 
 @pytest.mark.parametrize("layer_id, heads_l", [(0, 2), (1, 4)])
-def test_slab_store_matches_standalone_scatter(layer_id: int, heads_l: int):
-    """set_kv_buffer on a slab layer must land data in the layer's hetero
-    row view and scales exactly where a standalone store_sf_interleaved at
-    the layer's page size puts them."""
+def test_lcm_store_matches_standalone_scatter(layer_id: int, heads_l: int):
+    """LCM child-page writes match an independent interleaved SF scatter."""
     from tokenspeed_kernel.ops.kvcache.triton import store_sf_interleaved
 
     torch.manual_seed(2)
-    pool = _make_slab_pool()
+    pool = _make_lcm_pool()
     layer = SimpleNamespace(layer_id=layer_id)
     page_tokens = pool._layer_page_tokens(layer_id)
     num_ids = pool.k_scale_buffer[layer_id].shape[0]
@@ -253,31 +292,6 @@ def test_slab_store_matches_standalone_scatter(layer_id: int, heads_l: int):
     store_sf_interleaved(k_sf, ref, loc, page_size=page_tokens)
     k_view, _ = pool.get_kv_scale_buffer(layer_id)
     assert torch.equal(k_view.view(torch.uint8), ref.view(torch.uint8))
-
-
-def test_slab_conv_views_are_bf16_over_fp8_slots():
-    """bf16 conv columns over fp8 slots: half the token capacity, zero-copy,
-    and writes through the view land in the slab's leading slot bytes."""
-    pool = _make_slab_pool()
-    swa_layer = 1
-
-    # 64-token kvconv block fills the 64 KB fp8 slot byte-exactly at the
-    # swa width; 128 no longer fits.
-    ch = HEADS * HEAD_DIM
-    k_cols, v_cols = pool.kvconv_slot_views_for_layer(swa_layer, 64)
-    assert k_cols.dtype == torch.bfloat16 and k_cols.shape[1:] == (64, ch)
-    with pytest.raises(AssertionError):
-        pool.kvconv_slot_views_for_layer(swa_layer, 128)
-
-    # Zero-copy: writing via the view mutates the slab's slot bytes.
-    k_cols[3].fill_(1.0)
-    slot_bytes = 128 * HEADS * HEAD_DIM  # fp8: 1 byte/elem
-    slab_bytes = pool.k_buffer[swa_layer].view(torch.uint8).reshape(-1, slot_bytes)
-    assert slab_bytes[3, : 64 * ch * 2].view(torch.bfloat16).eq(1.0).all()
-
-    # Hetero full layer: half-width columns, leading half of the slot.
-    k_full, _ = pool.kvconv_slot_views_for_layer(0, 64)
-    assert k_full.shape[1:] == (64, ch // 2)
 
 
 def _make_config(page_size: int):

--- a/tokenspeed-scheduler/csrc/cache/cache_types.h
+++ b/tokenspeed-scheduler/csrc/cache/cache_types.h
@@ -70,6 +70,9 @@ struct KvCacheSpec {
     // Number of this group's logical cache blocks packed into one physical
     // LCM block. It affects placement only, never prefix-match granularity.
     std::int32_t cache_blocks_per_lcm_block;
+    // Tokens represented by one logical block in this group. Zero inherits
+    // the coordinator's domain block size for legacy/uniform configurations.
+    std::int32_t block_size{0};
 };
 
 // Per-request logical-page -> physical-page mapping.
@@ -94,10 +97,10 @@ private:
 };
 
 // Per-group input for one admission. page_hashes is the request's cumulative
-// completed-page history; first_new_page_slot splits the newly completed
-// suffix used by prefix-closed groups. Non-closed groups select the trailing
-// pages required to resume num_computed_tokens. The request owns table and
-// the storage behind page_hashes.
+// completed base-page history; first_new_page_slot is in that same base-page
+// unit. Managers fold those hashes to their own logical block size before
+// registration. Non-closed groups select the trailing logical pages required
+// to resume num_computed_tokens. The request owns table and page_hashes.
 struct GroupDemand {
     BlockTable* table{nullptr};
     std::int32_t num_tokens{0};

--- a/tokenspeed-scheduler/csrc/cache/forward_cache_ops.cpp
+++ b/tokenspeed-scheduler/csrc/cache/forward_cache_ops.cpp
@@ -53,8 +53,13 @@ std::vector<KvCacheSpec> MakeSpecsFromConfig(const SchedulerConfig& config) {
     specs.reserve(config.paged_cache_groups.size());
     for (const PagedCacheGroupConfig& group : config.paged_cache_groups) {
         _assert(group.cache_blocks_per_lcm_block > 0, "cache_blocks_per_lcm_block must be > 0");
-        _assert(group.block_size == 0 || group.block_size == config.block_size,
-                "per-group block_size cannot override the shared cache_block_tokens");
+        const std::int32_t group_block_size = group.block_size > 0 ? group.block_size : config.block_size;
+        _assert(group_block_size > 0 && config.block_size % group_block_size == 0,
+                "per-group block_size must be a positive divisor of the scheduler block_size");
+        if (group_block_size != config.block_size) {
+            _assert(group.cache_blocks_per_lcm_block == config.block_size / group_block_size,
+                    "fine-grained cache groups must pack one scheduler block of logical pages per LCM block");
+        }
         // family=State marks trailing-window prefix reuse and covers both SWA and
         // linear-attention groups; only a State group WITHOUT SlidingWindow
         // retention is a mamba-style state group.
@@ -78,6 +83,7 @@ std::vector<KvCacheSpec> MakeSpecsFromConfig(const SchedulerConfig& config) {
                 .kind = AttnKind::kMambaState,
                 .sliding_window = 0,
                 .cache_blocks_per_lcm_block = group.cache_blocks_per_lcm_block,
+                .block_size = group_block_size,
             });
             continue;
         }
@@ -90,6 +96,7 @@ std::vector<KvCacheSpec> MakeSpecsFromConfig(const SchedulerConfig& config) {
             .kind = is_swa ? AttnKind::kSlidingWindow : AttnKind::kFull,
             .sliding_window = is_swa ? *group.sliding_window_tokens : 0,
             .cache_blocks_per_lcm_block = group.cache_blocks_per_lcm_block,
+            .block_size = group_block_size,
         });
     }
     return specs;

--- a/tokenspeed-scheduler/csrc/cache/kv_cache_coordinator.cpp
+++ b/tokenspeed-scheduler/csrc/cache/kv_cache_coordinator.cpp
@@ -23,11 +23,13 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <numeric>
 #include <optional>
 
 #include "cache/full_attn_manager.h"
 #include "cache/mamba_state_manager.h"
 #include "cache/swa_manager.h"
+#include "scheduler/page_hasher.h"
 #include "utils.h"
 
 namespace tokenspeed {
@@ -36,12 +38,23 @@ KvCacheCoordinator::KvCacheCoordinator(std::vector<CacheGroup> groups, std::int3
                                        BlockPool* host_pool)
     : groups_{std::move(groups)}, pool_{pool}, host_pool_{host_pool}, cache_block_tokens_{cache_block_tokens} {
     _assert(cache_block_tokens_ > 0, "coordinator needs positive cache_block_tokens");
+    base_block_tokens_ = cache_block_tokens_;
     for (std::size_t i = 0; i < groups_.size(); ++i) {
+        const std::int32_t group_block_tokens = groups_[i].Manager().CacheBlockTokens();
         _assert(groups_[i].Id() == static_cast<GroupId>(i), "cache manager group id must equal its group index");
-        _assert(groups_[i].Manager().CacheBlockTokens() == cache_block_tokens_,
-                "every cache manager must use the domain cache_block_tokens");
+        _assert(group_block_tokens > 0 && cache_block_tokens_ % group_block_tokens == 0,
+                "every cache manager block size must divide the domain cache_block_tokens");
+        const std::int32_t expected_group_block_tokens =
+            groups_[i].Spec().block_size > 0 ? groups_[i].Spec().block_size : cache_block_tokens_;
+        _assert(group_block_tokens == expected_group_block_tokens,
+                "cache manager block size must match its group spec");
         _assert(groups_[i].Manager().CacheBlocksPerLcmBlock() == groups_[i].Spec().cache_blocks_per_lcm_block,
                 "cache manager packing must match its group spec");
+        if (group_block_tokens != cache_block_tokens_) {
+            _assert(groups_[i].Manager().CacheBlocksPerLcmBlock() == cache_block_tokens_ / group_block_tokens,
+                    "fine-grained cache manager packing must cover one domain block");
+        }
+        base_block_tokens_ = std::gcd(base_block_tokens_, group_block_tokens);
         if (groups_[i].Manager().MatchIsPrefixClosed()) {
             match_order_.push_back(i);
         }
@@ -58,12 +71,18 @@ bool KvCacheCoordinator::HasMambaStateGroup() const {
                                [](const CacheGroup& group) { return group.Spec().kind == AttnKind::kMambaState; });
 }
 
-std::vector<CacheKey> KvCacheCoordinator::keysForGroup(std::span<const std::string> content_hashes,
-                                                       GroupId group_id) const {
+std::vector<CacheKey> KvCacheCoordinator::keysForGroup(std::span<const std::string> content_hashes, GroupId group_id,
+                                                       std::int32_t first_base) const {
+    _assert(group_id < groups_.size(), "cache key group id out of range");
+    const std::int32_t group_block_tokens = groups_[group_id].Manager().CacheBlockTokens();
+    _assert(group_block_tokens % base_block_tokens_ == 0,
+            "group block size must be a multiple of the base block size");
+    std::vector<std::string> folded =
+        FoldBaseHashes(content_hashes, first_base, group_block_tokens / base_block_tokens_);
     std::vector<CacheKey> keys;
-    keys.reserve(content_hashes.size());
-    for (const std::string& content_hash : content_hashes) {
-        keys.push_back(CacheKey{.group_id = group_id, .content_hash = content_hash});
+    keys.reserve(folded.size());
+    for (std::string& content_hash : folded) {
+        keys.push_back(CacheKey{.group_id = group_id, .content_hash = std::move(content_hash)});
     }
     return keys;
 }
@@ -127,7 +146,7 @@ std::vector<std::vector<CacheKey>> KvCacheCoordinator::buildGroupKeys(
 // The one tier matcher: slots below floor_tokens are assumed valid in a lower tier; per_group
 // blocks are relative to the floor, num_common_tokens is the absolute converged boundary (in
 // TOKENS). num_cache_blocks = content_hashes.size(); every group has one key per
-// logical CacheBlock.
+// base logical page. group_keys[i] is folded to group i's block size.
 KvCacheCoordinator::PrefixProbe::Tier KvCacheCoordinator::probeTierWithKeys(
     const BlockPool& pool, std::span<const std::vector<CacheKey>> group_keys, std::span<const std::size_t> match_order,
     std::int32_t num_cache_blocks, std::int32_t floor_tokens) const {
@@ -137,25 +156,28 @@ KvCacheCoordinator::PrefixProbe::Tier KvCacheCoordinator::probeTierWithKeys(
         return out;
     }
     const ConvergedBoundary boundary = SweepThenConverge(
-        match_order, groups_, num_cache_blocks * cache_block_tokens_, cache_block_tokens_,
+        match_order, groups_, num_cache_blocks * base_block_tokens_, cache_block_tokens_,
         [&](std::size_t i, std::int32_t bound_tokens) {
-            out.per_group[i] = groups_[i].Manager().Probe(pool, group_keys[i], floor_tokens / cache_block_tokens_,
-                                                          bound_tokens / cache_block_tokens_);
+            const std::int32_t group_block_tokens = groups_[i].Manager().CacheBlockTokens();
+            out.per_group[i] = groups_[i].Manager().Probe(pool, group_keys[i], floor_tokens / group_block_tokens,
+                                                          bound_tokens / group_block_tokens);
         },
         [&](std::size_t i) {
-            return (floor_tokens / cache_block_tokens_ + static_cast<std::int32_t>(out.per_group[i].hits.size())) *
-                   cache_block_tokens_;
+            const std::int32_t group_block_tokens = groups_[i].Manager().CacheBlockTokens();
+            return (floor_tokens / group_block_tokens + static_cast<std::int32_t>(out.per_group[i].hits.size())) *
+                   group_block_tokens;
         });
 
     // Truncate closed probes to the converged boundary.
     // Non-closed groups were re-probed against the settled bound and are already at or below it.
-    const std::int32_t floor_blocks = floor_tokens / cache_block_tokens_;
     for (std::size_t i = 0; i < groups_.size(); ++i) {
+        const std::int32_t group_block_tokens = groups_[i].Manager().CacheBlockTokens();
+        const std::int32_t floor_blocks = floor_tokens / group_block_tokens;
         GroupPrefixProbe& probe = out.per_group[i];
-        if ((floor_blocks + static_cast<std::int32_t>(probe.hits.size())) * cache_block_tokens_ >
+        if ((floor_blocks + static_cast<std::int32_t>(probe.hits.size())) * group_block_tokens >
             boundary.common_tokens) {
             _assert(groups_[i].Manager().MatchIsPrefixClosed(), "window group left above the converged boundary");
-            probe.hits.resize(static_cast<std::size_t>(boundary.common_tokens / cache_block_tokens_ - floor_blocks));
+            probe.hits.resize(static_cast<std::size_t>(boundary.common_tokens / group_block_tokens - floor_blocks));
         }
     }
     out.num_common_tokens = boundary.common_tokens;
@@ -170,8 +192,8 @@ CoordinatorMatch KvCacheCoordinator::acquireTierWithKeys(BlockPool& pool,
     CoordinatorMatch out;
     out.num_common_tokens = probe.num_common_tokens;
     out.per_group.resize(groups_.size());
-    const std::int32_t floor_blocks = floor_tokens / cache_block_tokens_;
     for (std::size_t i = 0; i < groups_.size(); ++i) {
+        const std::int32_t floor_blocks = floor_tokens / groups_[i].Manager().CacheBlockTokens();
         out.per_group[i] = groups_[i].Manager().AcquireMatchedBlocks(pool, group_keys[i], floor_blocks,
                                                                      probe.per_group[i], access_epoch);
     }
@@ -180,7 +202,7 @@ CoordinatorMatch KvCacheCoordinator::acquireTierWithKeys(BlockPool& pool,
 
 KvCacheCoordinator::PrefixProbe KvCacheCoordinator::ProbePrefix(std::span<const std::string> content_hashes) const {
     _assert(content_hashes.size() <=
-                static_cast<std::size_t>(std::numeric_limits<std::int32_t>::max() / cache_block_tokens_),
+                static_cast<std::size_t>(std::numeric_limits<std::int32_t>::max() / base_block_tokens_),
             "prefix length exceeds int32 token range");
     const std::int32_t num_cache_blocks = static_cast<std::int32_t>(content_hashes.size());
     PrefixProbe out;
@@ -196,7 +218,7 @@ KvCacheCoordinator::PrefixProbe KvCacheCoordinator::ProbePrefix(std::span<const 
 KvCacheCoordinator::PrefixProbe KvCacheCoordinator::ProbeDecodeDestinationPrefix(
     std::span<const std::string> content_hashes) const {
     _assert(content_hashes.size() <=
-                static_cast<std::size_t>(std::numeric_limits<std::int32_t>::max() / cache_block_tokens_),
+                static_cast<std::size_t>(std::numeric_limits<std::int32_t>::max() / base_block_tokens_),
             "prefix length exceeds int32 token range");
     const std::int32_t num_cache_blocks = static_cast<std::int32_t>(content_hashes.size());
     std::vector<std::size_t> history_match_order;
@@ -214,13 +236,16 @@ KvCacheCoordinator::PrefixProbe KvCacheCoordinator::ProbeDecodeDestinationPrefix
             probeTierWithKeys(pool, out.group_keys, history_match_order, num_cache_blocks, floor_tokens);
         const std::int64_t covered_tokens =
             static_cast<std::int64_t>(tier.num_common_tokens) - static_cast<std::int64_t>(floor_tokens);
-        const std::int64_t num_holes = covered_tokens / cache_block_tokens_;
-        _assert(covered_tokens >= 0 && num_holes <= num_cache_blocks,
-                "decode destination state hole count is outside the probed range");
-        const std::size_t hole_count =
-            static_cast<std::size_t>(std::clamp<std::int64_t>(num_holes, 0, num_cache_blocks));
+        _assert(covered_tokens >= 0, "decode destination state hole count underflow");
         for (std::size_t i = 0; i < groups_.size(); ++i) {
             if (groups_[i].Spec().kind == AttnKind::kMambaState) {
+                const std::int32_t group_block_tokens = groups_[i].Manager().CacheBlockTokens();
+                _assert(covered_tokens % group_block_tokens == 0,
+                        "decode destination boundary must align to every state group");
+                const std::int64_t num_holes = covered_tokens / group_block_tokens;
+                _assert(num_holes <= static_cast<std::int64_t>(out.group_keys[i].size()),
+                        "decode destination state hole count exceeds group key range");
+                const std::size_t hole_count = static_cast<std::size_t>(num_holes);
                 tier.per_group[i].hits.resize(hole_count);
             }
         }
@@ -270,7 +295,17 @@ void KvCacheCoordinator::CacheFullBlocks(std::span<BlockTable> tables, std::span
 void KvCacheCoordinator::cacheFullBlocksForGroup(std::size_t group_index, BlockTable& table,
                                                  std::span<const std::string> content_hashes, std::int32_t first_slot,
                                                  std::uint64_t access_epoch, CacheBoundaryKind boundary_kind) {
-    std::vector<CacheKey> keys = keysForGroup(content_hashes, groups_[group_index].Id());
+    const std::int32_t group_block_tokens = groups_[group_index].Manager().CacheBlockTokens();
+    const std::int32_t fold = group_block_tokens / base_block_tokens_;
+    std::vector<CacheKey> keys = keysForGroup(content_hashes, groups_[group_index].Id(), first_slot);
+    const std::int32_t group_first_slot = (first_slot + fold - 1) / fold;
+    cacheLogicalBlocksForGroup(group_index, table, keys, group_first_slot, access_epoch, boundary_kind);
+}
+
+void KvCacheCoordinator::cacheLogicalBlocksForGroup(std::size_t group_index, BlockTable& table,
+                                                    std::span<const CacheKey> keys, std::int32_t first_slot,
+                                                    std::uint64_t access_epoch,
+                                                    CacheBoundaryKind boundary_kind) {
     std::vector<std::pair<CacheKey, CacheBlockRef>> newly_cached;
     groups_[group_index].Manager().CacheFullBlocks(pool_, table, keys, access_epoch, first_slot, boundary_kind,
                                                    host_pool_ != nullptr ? &newly_cached : nullptr);
@@ -293,26 +328,32 @@ void KvCacheCoordinator::cacheCompletedBlocksForGroup(std::size_t group_index, c
 
     const KvCacheManager& manager = groups_[group_index].Manager();
     if (manager.MatchIsPrefixClosed()) {
+        const std::int32_t fold = manager.CacheBlockTokens() / base_block_tokens_;
+        const std::int32_t first_fold_base = demand.first_new_page_slot - demand.first_new_page_slot % fold;
         cacheFullBlocksForGroup(group_index, *demand.table,
-                                demand.page_hashes.subspan(static_cast<std::size_t>(demand.first_new_page_slot)),
-                                demand.first_new_page_slot, access_epoch, demand.boundary_kind);
+                                demand.page_hashes.subspan(static_cast<std::size_t>(first_fold_base)), first_fold_base,
+                                access_epoch, demand.boundary_kind);
         return;
     }
     if (demand.num_computed_tokens < 0 || demand.num_computed_tokens % cache_block_tokens_ != 0) {
         return;
     }
 
-    const std::int32_t boundary_slot = demand.num_computed_tokens / cache_block_tokens_;
-    _assert(boundary_slot == static_cast<std::int32_t>(demand.page_hashes.size()),
+    const std::int32_t boundary_base_slot = demand.num_computed_tokens / base_block_tokens_;
+    _assert(boundary_base_slot == static_cast<std::int32_t>(demand.page_hashes.size()),
             "non-closed boundary must end at the hash history tail");
-    const std::int32_t lookback = std::min(manager.BoundaryLookbackBlocks(), boundary_slot);
+    std::vector<CacheKey> keys = keysForGroup(demand.page_hashes, groups_[group_index].Id());
+    const std::int32_t boundary_group_slot = demand.num_computed_tokens / manager.CacheBlockTokens();
+    _assert(boundary_group_slot == static_cast<std::int32_t>(keys.size()),
+            "non-closed folded hash history must end at the group boundary");
+    const std::int32_t lookback = std::min(manager.BoundaryLookbackBlocks(), boundary_group_slot);
     if (lookback == 0) {
         return;
     }
-    const std::int32_t first_slot = boundary_slot - lookback;
-    cacheFullBlocksForGroup(group_index, *demand.table,
-                            demand.page_hashes.subspan(static_cast<std::size_t>(first_slot)), first_slot, access_epoch,
-                            demand.boundary_kind);
+    const std::int32_t first_slot = boundary_group_slot - lookback;
+    cacheLogicalBlocksForGroup(group_index, *demand.table,
+                               std::span<const CacheKey>{keys}.subspan(static_cast<std::size_t>(first_slot)),
+                               first_slot, access_epoch, demand.boundary_kind);
 }
 
 void KvCacheCoordinator::ReclaimExpired(std::span<BlockTable> tables, std::int32_t num_computed_tokens) {
@@ -391,15 +432,23 @@ KvCacheCoordinator MakeCoordinator(std::span<const KvCacheSpec> specs, std::int3
     for (std::size_t i = 0; i < specs.size(); ++i) {
         const KvCacheSpec& spec = specs[i];
         const GroupId group_id = static_cast<GroupId>(i);
+        const std::int32_t group_block_tokens = spec.block_size > 0 ? spec.block_size : cache_block_tokens;
+        _assert(group_block_tokens > 0 && cache_block_tokens % group_block_tokens == 0,
+                "group block size must be a positive divisor of cache_block_tokens");
         _assert(spec.cache_blocks_per_lcm_block > 0, "cache_blocks_per_lcm_block must be > 0");
+        if (group_block_tokens != cache_block_tokens) {
+            _assert(spec.cache_blocks_per_lcm_block == cache_block_tokens / group_block_tokens,
+                    "fine-grained group packing must cover one cache_block_tokens domain");
+        }
         std::unique_ptr<KvCacheManager> manager;
         if (spec.kind == AttnKind::kFull) {
-            manager = std::make_unique<FullAttnManager>(cache_block_tokens, spec.cache_blocks_per_lcm_block, group_id);
+            manager =
+                std::make_unique<FullAttnManager>(group_block_tokens, spec.cache_blocks_per_lcm_block, group_id);
         } else if (spec.kind == AttnKind::kMambaState) {
             manager =
-                std::make_unique<MambaStateManager>(cache_block_tokens, spec.cache_blocks_per_lcm_block, group_id);
+                std::make_unique<MambaStateManager>(group_block_tokens, spec.cache_blocks_per_lcm_block, group_id);
         } else {
-            manager = std::make_unique<SwaManager>(cache_block_tokens, spec.cache_blocks_per_lcm_block,
+            manager = std::make_unique<SwaManager>(group_block_tokens, spec.cache_blocks_per_lcm_block,
                                                    spec.sliding_window, group_id);
         }
         groups.emplace_back(spec, std::move(manager));

--- a/tokenspeed-scheduler/csrc/cache/kv_cache_coordinator.cpp
+++ b/tokenspeed-scheduler/csrc/cache/kv_cache_coordinator.cpp
@@ -75,8 +75,7 @@ std::vector<CacheKey> KvCacheCoordinator::keysForGroup(std::span<const std::stri
                                                        std::int32_t first_base) const {
     _assert(group_id < groups_.size(), "cache key group id out of range");
     const std::int32_t group_block_tokens = groups_[group_id].Manager().CacheBlockTokens();
-    _assert(group_block_tokens % base_block_tokens_ == 0,
-            "group block size must be a multiple of the base block size");
+    _assert(group_block_tokens % base_block_tokens_ == 0, "group block size must be a multiple of the base block size");
     std::vector<std::string> folded =
         FoldBaseHashes(content_hashes, first_base, group_block_tokens / base_block_tokens_);
     std::vector<CacheKey> keys;
@@ -304,8 +303,7 @@ void KvCacheCoordinator::cacheFullBlocksForGroup(std::size_t group_index, BlockT
 
 void KvCacheCoordinator::cacheLogicalBlocksForGroup(std::size_t group_index, BlockTable& table,
                                                     std::span<const CacheKey> keys, std::int32_t first_slot,
-                                                    std::uint64_t access_epoch,
-                                                    CacheBoundaryKind boundary_kind) {
+                                                    std::uint64_t access_epoch, CacheBoundaryKind boundary_kind) {
     std::vector<std::pair<CacheKey, CacheBlockRef>> newly_cached;
     groups_[group_index].Manager().CacheFullBlocks(pool_, table, keys, access_epoch, first_slot, boundary_kind,
                                                    host_pool_ != nullptr ? &newly_cached : nullptr);
@@ -442,8 +440,7 @@ KvCacheCoordinator MakeCoordinator(std::span<const KvCacheSpec> specs, std::int3
         }
         std::unique_ptr<KvCacheManager> manager;
         if (spec.kind == AttnKind::kFull) {
-            manager =
-                std::make_unique<FullAttnManager>(group_block_tokens, spec.cache_blocks_per_lcm_block, group_id);
+            manager = std::make_unique<FullAttnManager>(group_block_tokens, spec.cache_blocks_per_lcm_block, group_id);
         } else if (spec.kind == AttnKind::kMambaState) {
             manager =
                 std::make_unique<MambaStateManager>(group_block_tokens, spec.cache_blocks_per_lcm_block, group_id);

--- a/tokenspeed-scheduler/csrc/cache/kv_cache_coordinator.h
+++ b/tokenspeed-scheduler/csrc/cache/kv_cache_coordinator.h
@@ -36,7 +36,7 @@ namespace tokenspeed {
 
 struct KvCacheCoordinatorTestAccess;
 
-// num_common_tokens is in tokens at the one shared CacheBlock granularity P.
+// num_common_tokens is in tokens at a boundary shared by every group.
 // per_group[i] is group i's PrefixMatch at exactly that length.
 struct CoordinatorMatch {
     std::int32_t num_common_tokens{0};
@@ -53,7 +53,11 @@ public:
 
     std::int32_t NumGroups() const { return static_cast<std::int32_t>(groups_.size()); }
 
+    // The scheduler domain is the common prefix/reclamation boundary. Base is
+    // the GCD used for request page hashes; each manager owns its declared
+    // logical block size between those two bounds.
     std::int32_t CacheBlockTokens() const noexcept { return cache_block_tokens_; }
+    std::int32_t BaseBlockTokens() const noexcept { return base_block_tokens_; }
     bool HasMambaStateGroup() const;
 
     KvCacheManager& GroupManager(std::int32_t i) { return groups_[static_cast<std::size_t>(i)].Manager(); }
@@ -130,7 +134,8 @@ private:
         CoordinatorMatch host;
     };
 
-    std::vector<CacheKey> keysForGroup(std::span<const std::string> content_hashes, GroupId group_id) const;
+    std::vector<CacheKey> keysForGroup(std::span<const std::string> content_hashes, GroupId group_id,
+                                       std::int32_t first_base = 0) const;
     std::vector<std::vector<CacheKey>> buildGroupKeys(std::span<const std::string> content_hashes) const;
     PrefixProbe::Tier probeTierWithKeys(const BlockPool& pool, std::span<const std::vector<CacheKey>> group_keys,
                                         std::span<const std::size_t> match_order, std::int32_t num_cache_blocks,
@@ -142,6 +147,9 @@ private:
     void cacheFullBlocksForGroup(std::size_t group_index, BlockTable& table,
                                  std::span<const std::string> content_hashes, std::int32_t first_slot,
                                  std::uint64_t access_epoch, CacheBoundaryKind boundary_kind);
+    void cacheLogicalBlocksForGroup(std::size_t group_index, BlockTable& table, std::span<const CacheKey> keys,
+                                    std::int32_t first_slot, std::uint64_t access_epoch,
+                                    CacheBoundaryKind boundary_kind);
     void cacheCompletedBlocksForGroup(std::size_t group_index, const GroupDemand& demand, std::uint64_t access_epoch);
     std::vector<CacheGroup> groups_;
     // Closed groups first, so non-closed groups match against a settled bound.
@@ -149,11 +157,13 @@ private:
     BlockPool& pool_;
     BlockPool* host_pool_{nullptr};
     std::int32_t cache_block_tokens_{0};
+    std::int32_t base_block_tokens_{0};
     std::uint64_t next_access_epoch_{0};
     std::vector<StoreCandidate> pending_stores_;
 };
 
-// One CacheGroup per spec (group_id = index), all sharing cache_block_tokens.
+// One CacheGroup per spec (group_id = index). A zero spec.block_size inherits
+// cache_block_tokens; explicit sizes must divide the shared domain.
 KvCacheCoordinator MakeCoordinator(std::span<const KvCacheSpec> specs, std::int32_t cache_block_tokens, BlockPool& pool,
                                    BlockPool* host_pool = nullptr);
 

--- a/tokenspeed-scheduler/csrc/resource/allocator/paged_cache_group.h
+++ b/tokenspeed-scheduler/csrc/resource/allocator/paged_cache_group.h
@@ -64,9 +64,9 @@ struct PagedCacheGroupConfig {
     std::int32_t rows_per_page{};
     std::int32_t entry_stride_tokens{};
     std::int32_t total_pages{};
-    // Legacy serialization field. Flat prefix-cache configurations may leave
-    // it unset or set it equal to SchedulerConfig::block_size, but may not use
-    // it to define a different logical prefix granularity.
+    // Logical tokens represented by one page. Zero inherits
+    // SchedulerConfig::block_size. A finer explicit value must divide the
+    // scheduler domain and use matching LCM packing.
     std::int32_t block_size{0};
     // Fixed-byte placement recipe: how many logical CacheBlocks from this
     // group fit in one physical LCM block.

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -198,9 +198,10 @@ Scheduler::FlatAdmissionMatch Scheduler::matchFlatPrefixAtAdmission(Request* req
     }
     // Hash input must be byte-identical to the REGISTRATION form (GetFullPagedTokens(false)); radix's
     // except_last rule (last prompt token recomputed for logits) becomes the page cap, also bounding SWA.
-    const std::int32_t cache_block_tokens = coordinator_.CacheBlockTokens();
-    const std::int32_t cap_pages = std::max((request->PrefillSize() - 1) / cache_block_tokens, 0);
-    std::vector<std::span<const std::int32_t>> paged_tokens = request->GetFullPagedTokens(/*except_last=*/false);
+    const std::int32_t base_block_tokens = coordinator_.BaseBlockTokens();
+    const std::int32_t cap_pages = std::max((request->PrefillSize() - 1) / base_block_tokens, 0);
+    std::vector<std::span<const std::int32_t>> paged_tokens =
+        request->GetFullPagedTokens(base_block_tokens, /*except_last=*/false);
     if (static_cast<std::size_t>(cap_pages) < paged_tokens.size()) {
         paged_tokens.resize(cap_pages);
     }
@@ -208,12 +209,12 @@ Scheduler::FlatAdmissionMatch Scheduler::matchFlatPrefixAtAdmission(Request* req
     FlatAdmissionMatch match;
     match.probe = probe_prefix(flat_hashes);
     const std::int32_t hit_pages =
-        std::max(match.probe.device.num_common_tokens, match.probe.host.num_common_tokens) / cache_block_tokens;
+        std::max(match.probe.device.num_common_tokens, match.probe.host.num_common_tokens) / base_block_tokens;
     match.page_hashes.assign(flat_hashes.begin(), flat_hashes.begin() + hit_pages);
     // Boundaries are in tokens; extension offsets are in logical CacheBlocks.
     const std::int32_t ext_pages =
-        std::max(match.probe.host.num_common_tokens - match.probe.device.num_common_tokens, 0) / cache_block_tokens;
-    const auto ext_begin = flat_hashes.begin() + match.probe.device.num_common_tokens / cache_block_tokens;
+        std::max(match.probe.host.num_common_tokens - match.probe.device.num_common_tokens, 0) / base_block_tokens;
+    const auto ext_begin = flat_hashes.begin() + match.probe.device.num_common_tokens / base_block_tokens;
     match.ext_hashes.assign(ext_begin, ext_begin + ext_pages);
     return match;
 }
@@ -441,13 +442,14 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
                                                                               .reserve_tokens = flat_decode_reserve,
                                                                           });
     if (config_.enable_flatkv_pd && config_.role == Role::kD) {
-        const std::int32_t final_prompt_block = (request->PrefillSize() - 1) / coordinator_.CacheBlockTokens();
         for (std::size_t i = 0; i < flat_demands.size(); ++i) {
             if (config_.paged_cache_groups[i].transfer_policy == PagedCacheTransferPolicy::LatestSnapshot) {
                 // State prefix slots are null alignment holes. The only live
                 // state suffix is the prompt endpoint plus decode reserve.
                 flat_demands[i].num_tokens = request->PrefillSize();
-                flat_demands[i].materialized_suffix_start = final_prompt_block;
+                flat_demands[i].materialized_suffix_start =
+                    (request->PrefillSize() - 1) /
+                    coordinator_.GroupManager(static_cast<std::int32_t>(i)).CacheBlockTokens();
             }
         }
     }
@@ -461,7 +463,7 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
     if (!flat_match.ext_hashes.empty()) {
         coordinator_.CacheFullBlocks(
             flat_tables, flat_match.ext_hashes, flat_admission.access_epoch,
-            /*first_slot=*/flat_admission.device_prefix_tokens / coordinator_.CacheBlockTokens());
+            /*first_slot=*/flat_admission.device_prefix_tokens / coordinator_.BaseBlockTokens());
     }
     if (config_.enable_flatkv_pd && config_.role == Role::kD && flat_decode_reserve > 0) {
         // The destination admission reserves the bootstrap decode token, while
@@ -552,9 +554,10 @@ std::optional<fsm::SchedulePrefillEvent> Scheduler::schedulePrefill(
     PrefillInfo previous = request->GetPrefillInfo();
     const std::int32_t flat_num_computed = previous.already_scheduled_len + previous.extend_len;
     const std::int32_t first_new_page_slot = static_cast<std::int32_t>(flat_cache_progress.page_hashes.size());
-    const std::int32_t filled_pages = flat_num_computed / coordinator_.CacheBlockTokens();
+    const std::int32_t filled_pages = flat_num_computed / coordinator_.BaseBlockTokens();
     if (filled_pages > static_cast<std::int32_t>(flat_cache_progress.page_hashes.size())) {
-        advancePageHashes(flat_cache_progress.page_hashes, request->GetFullPagedTokens(false), filled_pages);
+        advancePageHashes(flat_cache_progress.page_hashes,
+                          request->GetFullPagedTokens(coordinator_.BaseBlockTokens(), false), filled_pages);
     }
     std::vector<BlockTable>& flat_tables = request->FlatBlockTablesRef();
     std::vector<GroupDemand> flat_demands = makeGroupDemands(
@@ -632,9 +635,10 @@ Scheduler::ScheduleAttempt<fsm::ScheduleDecodeEvent> Scheduler::scheduleDecode(
         num_computed_tokens = request->TokenSize() - config_.decode_input_tokens;
     }
     const std::int32_t first_new_page_slot = static_cast<std::int32_t>(flat_cache_progress.page_hashes.size());
-    const std::int32_t filled_pages = num_computed_tokens / coordinator_.CacheBlockTokens();
+    const std::int32_t filled_pages = num_computed_tokens / coordinator_.BaseBlockTokens();
     if (filled_pages > static_cast<std::int32_t>(flat_cache_progress.page_hashes.size())) {
-        advancePageHashes(flat_cache_progress.page_hashes, request->GetFullPagedTokens(false), filled_pages);
+        advancePageHashes(flat_cache_progress.page_hashes,
+                          request->GetFullPagedTokens(coordinator_.BaseBlockTokens(), false), filled_pages);
     }
     if (first_new_page_slot == static_cast<std::int32_t>(flat_cache_progress.page_hashes.size()) &&
         canConsumeAvailable(coordinator_, flat_tables, reserve_tokens, num_computed_tokens)) {

--- a/tokenspeed-scheduler/csrc/scheduler/page_hasher.h
+++ b/tokenspeed-scheduler/csrc/scheduler/page_hasher.h
@@ -20,10 +20,12 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <span>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <openssl/sha.h>
@@ -144,6 +146,32 @@ inline std::vector<std::string> AdvancePagedHashes(std::span<const std::span<con
     return ComputePagedHashes(paged_tokens.subspan(static_cast<std::size_t>(first_page),
                                                    static_cast<std::size_t>(past_end_page - first_page)),
                               prior);
+}
+
+// Fold m consecutive base-page hashes into a stable coarse-page key. The
+// caller supplies the global index of base_hashes[0], so a range beginning in
+// the middle of a coarse page skips that incomplete prefix. m == 1 preserves
+// the original hash byte-for-byte.
+inline std::vector<std::string> FoldBaseHashes(std::span<const std::string> base_hashes, std::int32_t first_base,
+                                               std::int32_t m) {
+    _assert(first_base >= 0, "first base-page index must be non-negative");
+    _assert(m >= 1, "fold factor must be >= 1");
+    if (m == 1) {
+        return {base_hashes.begin(), base_hashes.end()};
+    }
+    std::vector<std::string> out;
+    out.reserve(base_hashes.size() / static_cast<std::size_t>(m) + 1);
+    std::int32_t index = (m - first_base % m) % m;
+    for (; index + m <= static_cast<std::int32_t>(base_hashes.size()); index += m) {
+        std::string running;
+        for (std::int32_t offset = 0; offset < m; ++offset) {
+            const std::string& base_hash = base_hashes[static_cast<std::size_t>(index + offset)];
+            const std::array<std::string, 1> extra{base_hash};
+            running = HashPage(std::span<const std::int32_t>{}, running, extra);
+        }
+        out.push_back(std::move(running));
+    }
+    return out;
 }
 
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/csrc/scheduler/request.h
+++ b/tokenspeed-scheduler/csrc/scheduler/request.h
@@ -91,6 +91,12 @@ public:
         return token_container_.GetFullPagedTokens(page_size_, except_last);
     }
 
+#if TOKENSPEED_FLAT_KVCACHE
+    std::vector<std::span<const std::int32_t>> GetFullPagedTokens(std::int32_t page_size, bool except_last) const {
+        return token_container_.GetFullPagedTokens(page_size, except_last);
+    }
+#endif
+
     std::int32_t TokenSize() const { return token_container_.Size(); }
     std::int32_t GetLastToken() const { return token_container_.LastToken(); }
 

--- a/tokenspeed-scheduler/python/tests/test_flat_kvcache.py
+++ b/tokenspeed-scheduler/python/tests/test_flat_kvcache.py
@@ -80,6 +80,67 @@ def _make_spec(
     return _spec(request_id, list(range(start, start + num_pages * page_size)))
 
 
+def _make_v4_geometry_config() -> ts.SchedulerConfig:
+    cfg = ts.SchedulerConfig()
+    cfg.block_size = 256
+    cfg.num_device_pages = 65
+    cfg.num_host_pages = 0
+    cfg.max_scheduled_tokens = 512
+    cfg.max_batch_size = 4
+    cfg.disable_l2_cache = True
+    cfg.disable_prefix_cache = True
+
+    geometries = (
+        ("v4.swa_kv", 64, 1, 4, ts.PagedCacheRetention.SlidingWindow, 128),
+        (
+            "v4.c4a.compressor_state",
+            4,
+            1,
+            64,
+            ts.PagedCacheRetention.SlidingWindow,
+            8,
+        ),
+        ("v4.c4a.compressed_kv", 64, 4, 1, ts.PagedCacheRetention.FullHistory, None),
+        (
+            "v4.c128a.compressor_state",
+            8,
+            1,
+            32,
+            ts.PagedCacheRetention.SlidingWindow,
+            128,
+        ),
+        ("v4.c128a.compressed_kv", 2, 128, 1, ts.PagedCacheRetention.FullHistory, None),
+        (
+            "v4.c4a.indexer_compressor_state",
+            4,
+            1,
+            64,
+            ts.PagedCacheRetention.SlidingWindow,
+            8,
+        ),
+    )
+    groups = []
+    for group_id, rows, stride, packing, retention, window in geometries:
+        group = ts.PagedCacheGroupConfig(
+            group_id=group_id,
+            rows_per_page=rows,
+            entry_stride_tokens=stride,
+            total_pages=1 + (cfg.num_device_pages - 1) * packing,
+            retention=retention,
+            sliding_window_tokens=window,
+            family=(
+                ts.PagedCacheGroupFamily.History
+                if retention == ts.PagedCacheRetention.FullHistory
+                else ts.PagedCacheGroupFamily.State
+            ),
+            cache_blocks_per_lcm_block=packing,
+        )
+        group.block_size = rows * stride
+        groups.append(group)
+    cfg.paged_cache_groups = groups
+    return cfg
+
+
 def _abort(scheduler, request_id: str) -> None:
     event = ts.ForwardEvent.Abort()
     event.request_id = request_id
@@ -121,6 +182,28 @@ def test_decode_slides_swa_window_to_null_hole():
     assert (
         0 in swa_row
     ), "swa row should contain a null hole after the sliding window slides"
+
+
+def test_v4_143_token_prefill_exports_every_group_at_its_logical_page_width():
+    scheduler = ts.Scheduler(_make_v4_geometry_config())
+    scheduler.submit_requests([_spec("v4", list(range(143)))])
+
+    op = _find_flat_op(scheduler.next_execution_plan())
+    assert op is not None
+    tables = dict(op.flat_block_tables)
+    expected_widths = {
+        "v4.swa_kv": 3,
+        "v4.c4a.compressor_state": 36,
+        "v4.c4a.compressed_kv": 1,
+        "v4.c128a.compressor_state": 18,
+        "v4.c128a.compressed_kv": 1,
+        "v4.c4a.indexer_compressor_state": 36,
+    }
+    assert set(tables) == set(expected_widths)
+    for group_id, width in expected_widths.items():
+        row = list(tables[group_id][0])
+        assert len(row) == width, (group_id, row)
+        assert all(page_id > 0 for page_id in row), (group_id, row)
 
 
 def test_k3_four_groups_share_one_global_id_namespace() -> None:

--- a/tokenspeed-scheduler/tests/cpp/test_forward_cache_ops.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_forward_cache_ops.cpp
@@ -40,7 +40,7 @@ namespace {
 template <class T>
 concept HasLogicalBlockSize = requires(T value) { value.block_size; };
 
-static_assert(!HasLogicalBlockSize<KvCacheSpec>);
+static_assert(HasLogicalBlockSize<KvCacheSpec>);
 
 KvCacheCoordinator MakeTwoGroup(BlockPool& pool) {
     std::vector<KvCacheSpec> specs{
@@ -419,6 +419,38 @@ TEST(MakeSpecsFromConfigTest, Qwen35Fp8UsesOneLogicalPAndPerGroupPacking) {
     EXPECT_EQ(specs[1].cache_blocks_per_lcm_block, 1);
     EXPECT_EQ(specs[2].cache_blocks_per_lcm_block, 1);
     EXPECT_EQ(specs[3].cache_blocks_per_lcm_block, 1);
+}
+
+TEST(MakeSpecsFromConfigTest, AcceptsFineGrainedGroupWithMatchingDomainPacking) {
+    SchedulerConfig config;
+    config.block_size = 256;
+    PagedCacheGroupConfig group;
+    group.group_id = "fine_state";
+    group.block_size = 4;
+    group.cache_blocks_per_lcm_block = 64;
+    group.retention = PagedCacheGroupConfig::Retention::SlidingWindow;
+    group.sliding_window_tokens = 8;
+    config.paged_cache_groups = {group};
+
+    const std::vector<KvCacheSpec> specs = MakeSpecsFromConfig(config);
+
+    ASSERT_EQ(specs.size(), 1u);
+    EXPECT_EQ(specs[0].block_size, 4);
+    EXPECT_EQ(specs[0].cache_blocks_per_lcm_block, 64);
+}
+
+TEST(MakeSpecsFromConfigTest, RejectsFineGrainedGroupWithMismatchedDomainPacking) {
+    SchedulerConfig config;
+    config.block_size = 256;
+    PagedCacheGroupConfig group;
+    group.group_id = "fine_state";
+    group.block_size = 4;
+    group.cache_blocks_per_lcm_block = 1;
+    group.retention = PagedCacheGroupConfig::Retention::SlidingWindow;
+    group.sliding_window_tokens = 8;
+    config.paged_cache_groups = {group};
+
+    EXPECT_THROW(MakeSpecsFromConfig(config), std::runtime_error);
 }
 
 TEST(MakeSpecsFromConfigTest, RejectsNonPositiveGlobalP) {

--- a/tokenspeed-scheduler/tests/cpp/test_kv_cache_coordinator.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_kv_cache_coordinator.cpp
@@ -166,14 +166,8 @@ TEST(MakeCoordinatorTest, FineGrainedGroupsAllocateAndMatchAtTheirOwnLogicalPage
     BlockPool pool(32);
     const std::vector<KvCacheSpec> specs = {
         {.kind = AttnKind::kFull, .sliding_window = 0, .cache_blocks_per_lcm_block = 1, .block_size = 256},
-        {.kind = AttnKind::kSlidingWindow,
-         .sliding_window = 128,
-         .cache_blocks_per_lcm_block = 4,
-         .block_size = 64},
-        {.kind = AttnKind::kMambaState,
-         .sliding_window = 0,
-         .cache_blocks_per_lcm_block = 64,
-         .block_size = 4},
+        {.kind = AttnKind::kSlidingWindow, .sliding_window = 128, .cache_blocks_per_lcm_block = 4, .block_size = 64},
+        {.kind = AttnKind::kMambaState, .sliding_window = 0, .cache_blocks_per_lcm_block = 64, .block_size = 4},
     };
     KvCacheCoordinator coordinator = MakeCoordinator(specs, /*cache_block_tokens=*/256, pool);
 
@@ -191,8 +185,8 @@ TEST(MakeCoordinatorTest, FineGrainedGroupsAllocateAndMatchAtTheirOwnLogicalPage
 
     coordinator.Free(tables);
     ASSERT_TRUE(AdmitForTest(coordinator, tables, /*num_tokens=*/256));
-    const std::vector<std::string> hashes = ContentHashes(
-        std::vector<std::vector<std::int32_t>>(64, std::vector<std::int32_t>(4, 7)));
+    const std::vector<std::string> hashes =
+        ContentHashes(std::vector<std::vector<std::int32_t>>(64, std::vector<std::int32_t>(4, 7)));
     ASSERT_TRUE(AdmitForTest(coordinator, tables,
                              GroupDemand{
                                  .num_tokens = 0,

--- a/tokenspeed-scheduler/tests/cpp/test_kv_cache_coordinator.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_kv_cache_coordinator.cpp
@@ -162,6 +162,54 @@ TEST(MakeCoordinatorTest, Qwen35UsesUniformLogicalPWithDifferentPacking) {
     }
 }
 
+TEST(MakeCoordinatorTest, FineGrainedGroupsAllocateAndMatchAtTheirOwnLogicalPageSizes) {
+    BlockPool pool(32);
+    const std::vector<KvCacheSpec> specs = {
+        {.kind = AttnKind::kFull, .sliding_window = 0, .cache_blocks_per_lcm_block = 1, .block_size = 256},
+        {.kind = AttnKind::kSlidingWindow,
+         .sliding_window = 128,
+         .cache_blocks_per_lcm_block = 4,
+         .block_size = 64},
+        {.kind = AttnKind::kMambaState,
+         .sliding_window = 0,
+         .cache_blocks_per_lcm_block = 64,
+         .block_size = 4},
+    };
+    KvCacheCoordinator coordinator = MakeCoordinator(specs, /*cache_block_tokens=*/256, pool);
+
+    EXPECT_EQ(coordinator.CacheBlockTokens(), 256);
+    EXPECT_EQ(coordinator.BaseBlockTokens(), 4);
+    EXPECT_EQ(coordinator.GroupManager(0).CacheBlockTokens(), 256);
+    EXPECT_EQ(coordinator.GroupManager(1).CacheBlockTokens(), 64);
+    EXPECT_EQ(coordinator.GroupManager(2).CacheBlockTokens(), 4);
+
+    std::vector<BlockTable> tables(coordinator.NumGroups());
+    ASSERT_TRUE(AdmitForTest(coordinator, tables, /*num_tokens=*/143));
+    EXPECT_EQ(tables[0].NumBlocks(), 1);
+    EXPECT_EQ(tables[1].NumBlocks(), 3);
+    EXPECT_EQ(tables[2].NumBlocks(), 36);
+
+    coordinator.Free(tables);
+    ASSERT_TRUE(AdmitForTest(coordinator, tables, /*num_tokens=*/256));
+    const std::vector<std::string> hashes = ContentHashes(
+        std::vector<std::vector<std::int32_t>>(64, std::vector<std::int32_t>(4, 7)));
+    ASSERT_TRUE(AdmitForTest(coordinator, tables,
+                             GroupDemand{
+                                 .num_tokens = 0,
+                                 .page_hashes = hashes,
+                                 .first_new_page_slot = 35,
+                                 .num_computed_tokens = 256,
+                             }));
+    coordinator.Free(tables);
+
+    CoordinatorMatch match = MatchPrefixForTest(coordinator, hashes).device;
+    EXPECT_EQ(match.num_common_tokens, 256);
+    ASSERT_EQ(match.per_group.size(), specs.size());
+    EXPECT_EQ(match.per_group[0].blocks.size(), 1u);
+    EXPECT_EQ(match.per_group[1].blocks.size(), 4u);
+    EXPECT_EQ(match.per_group[2].blocks.size(), 64u);
+}
+
 TEST(MakeCoordinatorTest, RejectsNonPositiveLogicalPOrPacking) {
     BlockPool pool(8);
     const std::vector<KvCacheSpec> valid = {


### PR DESCRIPTION
## Summary

DeepSeek V4 attention previously consumed Radix compact paged tables, while the Flat KV scheduler provides absolute per-group block tables. This change adds the complete Flat KV consumer for both target and MTP execution.

- map Flat tables by stable cache-spec identity and validate the complete group contract
- refresh per-group metadata for eager execution and every CUDA Graph replay, including padding and idle batches
- fail closed on missing, duplicate, partial, malformed, or incompatible tables
- preserve the existing Radix scheduler page domain and behavior

## Test Plan

- `pre-commit run --all-files`
- Flat KV and Radix unit and regression suites
- DeepSeek V4 target + MTP correctness on ARM64 GB200 in TP4 and TP8
- eager and CUDA Graph execution with p1 and p4 request shapes
- dynamic page-table replay and CUDA memory-stability coverage