### PR TITLE
feat(engine): add msgpack ZMQ mode for direct SMG scheduler drive

### DIFF
--- a/python/tokenspeed/cli/__main__.py
+++ b/python/tokenspeed/cli/__main__.py
@@ -67,6 +67,19 @@ def main() -> None:
     serve_parser = subparsers.add_parser(
         "serve",
         help="Launch the TokenSpeed inference server.",
+        description="Launch the TokenSpeed inference server: the full serving "
+        "stack by default (currently an smg gateway fronting a gRPC engine), "
+        "or the engine alone with --headless.",
+    )
+    serve_parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="Run the engine only, without a frontend. An external frontend "
+        "— e.g. `smg serve --backend tokenspeed --connection-mode zmq` — "
+        "binds the msgpack ZMQ sockets and this engine dials in at "
+        "--data-parallel-address/--data-parallel-rpc-port (default "
+        "tcp://127.0.0.1:30500). Implies --zmq-msgpack and "
+        "--skip-tokenizer-init.",
     )
     serve_parser.set_defaults(func=_serve)
 

--- a/python/tokenspeed/cli/_argsplit.py
+++ b/python/tokenspeed/cli/_argsplit.py
@@ -24,6 +24,10 @@ A leading positional argument is treated as the model (vllm-style
 ``ts serve <model> [flags...]``) and rewritten to ``--model <model>``
 before routing.
 
+``--headless`` short-circuits the split entirely (see
+``split_headless_argv``): the engine is the only process, so every
+remaining flag is a ServerArgs flag and no engine/gateway routing applies.
+
 Routing precedence is top-down. The first matching rule wins:
 
 1. Orchestrator-only flags (consumed, never forwarded)
@@ -70,6 +74,8 @@ _GATEWAY_OVERRIDE = {
 _ENGINE_EXPLICIT = {"--tensor-parallel-size"}
 
 _MODEL_FLAG_TOKENS = ("--model", "--model-path")
+
+_HEADLESS_FLAG = "--headless"
 
 _ENGINE_MULTI_VALUE_FLAGS = {
     "--cudagraph-capture-sizes",
@@ -146,6 +152,33 @@ def _append_arg(args: list[str], name: str, value: list[str] | str | None) -> No
         args.extend([name, *value])
     else:
         args.extend([name, value])
+
+
+def split_headless_argv(argv: list[str]) -> list[str] | None:
+    """Extract the ServerArgs argv for ``ts serve --headless``.
+
+    Returns ``None`` when ``--headless`` is absent (default orchestrator
+    mode). Otherwise returns the argv with the flag removed, for
+    ``prepare_server_args`` verbatim: the engine is the only process, so
+    positional-model and alias handling belong to ServerArgs' own parser
+    and no engine/gateway routing applies.
+
+    Raises:
+        ValueError: if an orchestrator-only flag is present. Headless mode
+            has no gateway lifecycle to configure, so rejecting loudly beats
+            silently ignoring the flag.
+    """
+    if _HEADLESS_FLAG not in argv:
+        return None
+    tokens = [token for token in argv if token != _HEADLESS_FLAG]
+    for token in tokens:
+        name = token.partition("=")[0]
+        if name in _ORCH_FLAGS:
+            raise ValueError(
+                f"{name} configures the gateway orchestrator and is not "
+                "valid with --headless (no gateway is spawned)"
+            )
+    return tokens
 
 
 @functools.lru_cache(maxsize=1)

--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -19,7 +19,16 @@
 # SOFTWARE.
 
 """``ts serve`` orchestrator: spawn smg gateway + gRPC engine, tag logs, probe
-readiness, and tear down gateway-first on shutdown."""
+readiness, and tear down gateway-first on shutdown.
+
+``ts serve`` is the full serving command; today its internals are the smg
+gateway plus the gRPC engine servicer. ``ts serve --headless`` is engine-only:
+nothing else is spawned here — an external frontend such as ``smg serve
+--backend tokenspeed --connection-mode zmq`` binds the msgpack ZMQ sockets and
+this engine dials in at ``tcp://{--data-parallel-address}:
+{--data-parallel-rpc-port}`` (default ``tcp://127.0.0.1:30500``). Headless
+mode implies ``--zmq-msgpack`` + ``--skip-tokenizer-init`` (see
+``launch_scheduler_headless``)."""
 
 from __future__ import annotations
 
@@ -34,7 +43,7 @@ from pathlib import Path
 
 from tokenspeed_kernel.platform import current_platform
 
-from tokenspeed.cli._argsplit import OrchestratorOpts, split_argv
+from tokenspeed.cli._argsplit import OrchestratorOpts, split_argv, split_headless_argv
 from tokenspeed.cli._logo import print_logo
 from tokenspeed.cli._logprefix import ENGINE_TAG, GATEWAY_TAG, tag_stream
 from tokenspeed.cli._proc import (
@@ -683,8 +692,35 @@ async def run_smg(
                     pass
 
 
+def _run_headless(argv: list[str]) -> None:
+    """``ts serve --headless``: run the scheduler-only launcher in-process.
+
+    No gateway, gRPC servicer, or control server: the external frontend owns
+    the HTTP surface, binds the ZMQ sockets, and does the (de)tokenization.
+    Reuses the ``python -m tokenspeed.runtime.entrypoints.engine``
+    implementation; ``argv`` is a plain ServerArgs argv.
+    """
+    try:
+        import setproctitle
+
+        setproctitle.setproctitle("ts-serve-headless")
+    except ImportError:
+        pass
+
+    from tokenspeed.runtime.entrypoints.engine import run_scheduler_headless_from_cli
+
+    run_scheduler_headless_from_cli(argv)
+
+
 def run_smg_from_args(args: argparse.Namespace, raw_argv: list[str]) -> None:
     """Entry point called from cli/__main__.py for ``ts serve``."""
+    headless_argv = split_headless_argv(raw_argv)
+    if headless_argv is not None:
+        # Engine-only: skip the orchestrator entirely, including its
+        # gRPC-specific env defaults and bundled-gateway install check.
+        _run_headless(headless_argv)
+        return
+
     _set_default_grpc_max_message_bytes()
 
     try:

--- a/python/tokenspeed/runtime/engine/async_llm.py
+++ b/python/tokenspeed/runtime/engine/async_llm.py
@@ -526,7 +526,7 @@ class AsyncLLM(SchedulerControlClient, EngineClient):
         if rid not in self.rid_to_state:
             return
         del self.rid_to_state[rid]
-        req = AbortReq(rid)
+        req = AbortReq(rid=rid)
         self.engine_core_client.send_to_scheduler.send_pyobj(req)
 
     # ---- RL weight-transfer admission gate ------------------------------

--- a/python/tokenspeed/runtime/engine/core_client.py
+++ b/python/tokenspeed/runtime/engine/core_client.py
@@ -42,6 +42,7 @@ change.
 import zmq
 import zmq.asyncio
 
+from tokenspeed.runtime.engine.io_struct import AsyncIpcReceiver, IpcSender
 from tokenspeed.runtime.utils import get_zmq_socket
 from tokenspeed.runtime.utils.server_args import PortArgs
 
@@ -49,16 +50,19 @@ from tokenspeed.runtime.utils.server_args import PortArgs
 class EngineCoreClient:
     """Owns the scheduler-facing ZMQ sockets for ``AsyncLLM``.
 
-    Instantiated once per ``AsyncLLM`` in the front-end process. Socket
-    attributes are exposed directly so call sites can keep the existing
-    ``send_pyobj`` / ``recv_pyobj`` ergonomics without a wrapper layer.
+    Instantiated once per ``AsyncLLM`` in the front-end process. The sockets
+    are wrapped in the msgpack IPC adapters from ``io_struct``, which keep
+    the existing ``send_pyobj`` / ``recv_pyobj`` call-site ergonomics while
+    switching the serialization off pickle.
     """
 
     def __init__(self, port_args: PortArgs):
         self.context = zmq.asyncio.Context(2)
-        self.recv_from_detokenizer = get_zmq_socket(
-            self.context, zmq.PULL, port_args.tokenizer_ipc_name, True
+        self.recv_from_detokenizer = AsyncIpcReceiver(
+            get_zmq_socket(self.context, zmq.PULL, port_args.tokenizer_ipc_name, True)
         )
-        self.send_to_scheduler = get_zmq_socket(
-            self.context, zmq.PUSH, port_args.scheduler_input_ipc_name, True
+        self.send_to_scheduler = IpcSender(
+            get_zmq_socket(
+                self.context, zmq.PUSH, port_args.scheduler_input_ipc_name, True
+            )
         )

--- a/python/tokenspeed/runtime/engine/data_parallel_controller.py
+++ b/python/tokenspeed/runtime/engine/data_parallel_controller.py
@@ -35,6 +35,8 @@ import zmq
 from tokenspeed.runtime.engine.event_loop import run_event_loop
 from tokenspeed.runtime.engine.io_struct import (
     BlockReqInput,
+    IpcReceiver,
+    IpcSender,
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
     WatchLoadUpdateReq,
@@ -134,8 +136,10 @@ class DataParallelController:
         # Init inter-process communication
         self.context = zmq.Context(1 + server_args.mapping.attn.dp_size)
         if server_args.node_rank == 0:
-            self.recv_from_tokenizer = get_zmq_socket(
-                self.context, zmq.PULL, port_args.scheduler_input_ipc_name, False
+            self.recv_from_tokenizer = IpcReceiver(
+                get_zmq_socket(
+                    self.context, zmq.PULL, port_args.scheduler_input_ipc_name, False
+                )
             )
         # dp_worker for fixed data dispatch can be set by SINGLE_WORKER_ID environment variable
         robin_scheduler = (
@@ -232,11 +236,13 @@ class DataParallelController:
             # Bind to scheduler_input_ipc_name BEFORE starting scheduler threads
             # This ensures the port is available when scheduler tries to connect
             if server_args.node_rank == 0:
-                self.workers[dp_rank] = get_zmq_socket(
-                    self.context,
-                    zmq.PUSH,
-                    tmp_port_args.scheduler_input_ipc_name,
-                    True,  # bind
+                self.workers[dp_rank] = IpcSender(
+                    get_zmq_socket(
+                        self.context,
+                        zmq.PUSH,
+                        tmp_port_args.scheduler_input_ipc_name,
+                        True,  # bind
+                    )
                 )
 
         if not server_args.mapping.attn.has_dp:

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -50,6 +50,7 @@ from tokenspeed.runtime.distributed.process_group_manager import (
     process_group_manager as pg_manager,
 )
 from tokenspeed.runtime.engine.generation_output_processor import OutputProcesser
+from tokenspeed.runtime.engine.io_struct import IpcReceiver, IpcSender
 from tokenspeed.runtime.engine.memory_occupation import MemoryOccupationController
 from tokenspeed.runtime.engine.pause import PauseController
 from tokenspeed.runtime.engine.request_handler import RequestHandler
@@ -160,6 +161,41 @@ class _NullSender:
     @staticmethod
     def send_pyobj(x):
         return None
+
+
+# SMG decodes the ready response's dtype into a fixed enum of these strings, so
+# map tokenspeed's dtype onto the nearest one.
+_WIRE_DTYPE_MAP = {
+    "bfloat16": "bfloat16",
+    "bf16": "bfloat16",
+    "float16": "float16",
+    "half": "float16",
+    "fp16": "float16",
+    "float32": "float32",
+    "float": "float32",
+    "fp32": "float32",
+}
+
+
+def _wire_dtype(dtype) -> str:
+    key = str(dtype).lower().replace("torch.", "")
+    mapped = _WIRE_DTYPE_MAP.get(key)
+    if mapped is None:
+        # Fail at handshake time: misreporting the dtype to the frontend is
+        # worse than refusing to start.
+        raise ValueError(
+            f"dtype {dtype!r} has no SMG wire mapping; extend _WIRE_DTYPE_MAP"
+        )
+    return mapped
+
+
+def _tokenspeed_version() -> str:
+    try:
+        from tokenspeed.version import __version__
+
+        return __version__
+    except Exception:
+        return "unknown"
 
 
 @dataclass(frozen=True)
@@ -1233,15 +1269,68 @@ class EventLoop:
     def _init_interprocess_comm(self):
         context = zmq.Context(2)
         if self.attn_tp_rank == 0:
-            self.recv_from_tokenizer = get_zmq_socket(
-                context, zmq.PULL, self.port_args.scheduler_input_ipc_name, False
-            )
-            self.send_to_tokenizer = get_zmq_socket(
-                context, zmq.PUSH, self.port_args.tokenizer_ipc_name, False
-            )
+            if self.server_args.zmq_msgpack:
+                # SMG drives the scheduler directly: it binds the sockets and
+                # this engine connects in over the msgpack wire (see zmq_msgpack).
+                self.recv_from_tokenizer, self.send_to_tokenizer = (
+                    self._init_msgpack_transport(context)
+                )
+            else:
+                self.recv_from_tokenizer = IpcReceiver(
+                    get_zmq_socket(
+                        context,
+                        zmq.PULL,
+                        self.port_args.scheduler_input_ipc_name,
+                        False,
+                    )
+                )
+                self.send_to_tokenizer = IpcSender(
+                    get_zmq_socket(
+                        context, zmq.PUSH, self.port_args.tokenizer_ipc_name, False
+                    )
+                )
         else:
             self.recv_from_tokenizer = None
             self.send_to_tokenizer = _NullSender()
+
+    def _init_msgpack_transport(self, context):
+        """Complete the SMG startup handshake and return the wrapped msgpack
+        input/output sockets."""
+        from tokenspeed.runtime.engine import zmq_msgpack, zmq_wire
+
+        if self.dp_size > 1:
+            # Shared choke point for every launch path: all DP-rank engines
+            # would connect to SMG's ROUTER with the same zmq_engine_index
+            # identity, so their inputs and outputs would collide.
+            raise NotImplementedError(
+                "--zmq-msgpack does not support data-parallel size > 1 yet"
+            )
+        geometry = self._scheduler_cache_geometry
+        ready_response = zmq_wire.WireEngineCoreReadyResponse(
+            max_model_len=self.model_config.context_len,
+            num_gpu_blocks=geometry.num_device_pages,
+            block_size=geometry.page_size,
+            dtype=_wire_dtype(self.model_config.dtype),
+            vllm_version=f"tokenspeed-{_tokenspeed_version()}",
+            world_size=self.world_size,
+            data_parallel_size=self.dp_size,
+            tensor_parallel_size=self.attn_tp_size,
+            data_parallel_rank=self.dp_rank,
+            max_num_seqs=self.server_args.max_num_seqs,
+            # chunked_prefill_size=-1 means "disabled"; the wire field is a
+            # non-negative integer for the frontend, so clamp to 0 (= no cap).
+            max_num_batched_tokens=max(0, self.server_args.chunked_prefill_size),
+            instance_id=self.server_args.served_model_name or self.server_args.model,
+            kv_cache_size_tokens=self.max_total_num_tokens,
+        )
+        return zmq_msgpack.connect_msgpack_engine(
+            context,
+            self.server_args.zmq_handshake_endpoint(),
+            self.server_args.zmq_engine_index,
+            ready_response,
+            self.model_config.vocab_size,
+            enable_output_logprobs=self.server_args.enable_output_logprobs,
+        )
 
     # ------------------------------------------------------------------
     # Shared step helpers
@@ -2074,6 +2163,12 @@ class EventLoop:
             prev_forward_op = forward_op
 
     def close(self) -> None:
+        # Best-effort: tell an attached SMG frontend this engine is going away
+        # (msgpack mode only; the pickle sender has no such helper) so the
+        # worker is marked dead instead of staying healthy-idle.
+        send_engine_dead = getattr(self.send_to_tokenizer, "send_engine_dead", None)
+        if callable(send_engine_dead):
+            send_engine_dead()
         close_transfer = getattr(self.kv_transfer, "close", None)
         if callable(close_transfer):
             close_transfer()

--- a/python/tokenspeed/runtime/engine/input_processor.py
+++ b/python/tokenspeed/runtime/engine/input_processor.py
@@ -261,15 +261,15 @@ class InputProcessor:
 
         if isinstance(obj, GenerateReqInput):
             return TokenizedGenerateReqInput(
-                obj.rid,
-                input_text,
-                input_ids,
-                sampling_params,
-                return_logprob,
-                logprob_start_len,
-                top_logprobs_num,
-                token_ids_logprob,
-                obj.stream,
+                rid=obj.rid,
+                input_text=input_text,
+                input_ids=input_ids,
+                sampling_params=sampling_params,
+                return_logprob=return_logprob,
+                logprob_start_len=logprob_start_len,
+                top_logprobs_num=top_logprobs_num,
+                token_ids_logprob=token_ids_logprob,
+                stream=obj.stream,
                 bootstrap_host=obj.bootstrap_host,
                 bootstrap_port=obj.bootstrap_port,
                 bootstrap_room=obj.bootstrap_room,
@@ -285,9 +285,9 @@ class InputProcessor:
             )
 
         return TokenizedEmbeddingReqInput(
-            obj.rid,
-            input_text,
-            input_ids,
-            sampling_params,
+            rid=obj.rid,
+            input_text=input_text,
+            input_ids=input_ids,
+            sampling_params=sampling_params,
             created_time=time.time(),
         )

--- a/python/tokenspeed/runtime/engine/io_struct.py
+++ b/python/tokenspeed/runtime/engine/io_struct.py
@@ -20,18 +20,36 @@
 
 """
 The definition of objects transferred between different
-processes (TokenizerManager, DetokenizerManager, Controller).
+processes (frontend, controller, scheduler), plus the msgpack codec
+that carries them over ZMQ.
+
+Every type that crosses engine IPC is a ``msgspec.Struct`` deriving from
+``BaseReq``/``BaseBatchReq`` (tagged, keyword-only, array-encoded), so one
+tagged-union decoder per receiving socket replaces pickle. Tensors ride as
+msgpack ext-typed raw buffers with large payloads moved to out-of-band ZMQ
+frames (see ``MsgpackEncoder``). Pickle IPC remains available as a rollout
+escape hatch via ``TOKENSPEED_USE_PICKLE_IPC=1`` (read once at import).
+
+``GenerateReqInput``/``EmbeddingReqInput`` are the HTTP-layer request shapes
+(pre-tokenization, in-process only) and intentionally stay dataclasses.
 """
 
+from __future__ import annotations
+
 import copy
+import pickle
 import uuid
-from abc import ABC
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Literal
+from typing import Any, Literal, Union
 
-from tokenspeed.runtime.engine.request_types import BaseFinishReason
+import msgspec
+import numpy as np
+import torch
+
+from tokenspeed.runtime.multimodal.inputs import MultimodalInputs
 from tokenspeed.runtime.sampling.sampling_params import SamplingParams
+from tokenspeed.runtime.utils.env import envs
 
 
 def _require(condition: bool, message: str) -> None:
@@ -39,10 +57,20 @@ def _require(condition: bool, message: str) -> None:
         raise ValueError(message)
 
 
-@dataclass
-class BaseReq(ABC):
-    rid: str | list[str] | None = field(default=None)
-    http_worker_ipc: str | None = field(default=None)
+class BaseReq(
+    msgspec.Struct, tag=True, tag_field="_tag", kw_only=True, array_like=True
+):
+    """Base for single-request IPC payloads.
+
+    ``tag=True`` prefixes the class name so a tagged-union decoder can
+    dispatch without pickled type info; ``array_like=True`` encodes fields
+    positionally (declaration order IS the wire contract — append only).
+    ``tag_field`` is renamed off the default so subclasses may declare a
+    field literally named ``type`` (it never appears in the array encoding).
+    """
+
+    rid: str | list[str] | None = None
+    http_worker_ipc: str | None = None
 
     def regenerate_rid(self):
         """Generate a new request ID and return it."""
@@ -53,8 +81,35 @@ class BaseReq(ABC):
         return self.rid
 
 
-@dataclass
-class SessionParams:
+class BaseBatchReq(
+    msgspec.Struct, tag=True, tag_field="_tag", kw_only=True, array_like=True
+):
+    """Base for batched IPC payloads (parallel per-request columns)."""
+
+    rids: list[str] | None = None
+
+
+class PickleWrapper(msgspec.Struct, tag=True, tag_field="_tag", array_like=True):
+    """Explicit escape hatch: an opaque Python object as pickled bytes.
+
+    Only for fields whose values are genuinely arbitrary Python objects.
+    Multimodal payloads must NOT use this — they have typed structs with
+    ext-encoded tensor buffers.
+    """
+
+    data: bytes
+
+    @classmethod
+    def wrap(cls, obj: Any) -> "PickleWrapper | None":
+        if obj is None:
+            return None
+        return cls(pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL))
+
+    def unwrap(self) -> Any:
+        return pickle.loads(self.data)
+
+
+class SessionParams(msgspec.Struct, kw_only=True, array_like=True):
     id: str | None = None
     rid: str | None = None
     offset: int | None = None
@@ -401,31 +456,28 @@ class GenerateReqInput:
         return sub
 
 
-@dataclass
-class TokenizedGenerateReqInput:
-    # The request id
-    rid: str
-    # The input text
-    input_text: str
-    # The input token ids
-    input_ids: list[int]
+class TokenizedGenerateReqInput(BaseReq, kw_only=True):
+    # The input text (None on the token-id-only and input-embeds paths)
+    input_text: str | None = None
+    # The input token ids (None on the input-embeds path)
+    input_ids: list[int] | None = None
     # The sampling parameters
     sampling_params: SamplingParams
     # Whether to return the sampled token's logprob for this request.
-    return_logprob: bool
-    # Internal carry-over fields kept for pipeline/PD compatibility. The vLLM
+    return_logprob: bool = False
+    # Internal carry-over fields kept for pipeline/PD compatibility. The
     # output-logprob API only drives ``return_logprob``; InputProcessor sets
     # these to neutral values (logprob_start_len=-1, top_logprobs_num=0,
     # token_ids_logprob=None) since prompt logprobs, output top-k, and token-id
     # logprobs are not supported.
-    logprob_start_len: int
-    top_logprobs_num: int
-    token_ids_logprob: list[int]
+    logprob_start_len: int = -1
+    top_logprobs_num: int = 0
+    token_ids_logprob: list[int] | None = None
     # Whether to stream output
-    stream: bool
+    stream: bool = False
 
-    # The input embeds
-    input_embeds: list[list[list[float]]] | list[list[float]] | None = None
+    # The input embeds (nested float lists; shape varies by caller)
+    input_embeds: list | None = None
 
     # Session info for continual prompting
     session_params: SessionParams | None = None
@@ -446,12 +498,20 @@ class TokenizedGenerateReqInput:
     bootstrap_port: int | None = None
     bootstrap_room: int | None = None
 
-    input_multi_ids: list[list[int]] = None
+    input_multi_ids: list[list[int]] | None = None
     input_extra_infos: list[dict] | None = None
     # Original prompt ids before multimodal pad/hash replacement. The scheduler
     # uses input_ids, while detokenization must use these tokenizer-valid ids.
     input_ids_unpadded: list[int] | None = None
-    multimodal_inputs: Any | None = None
+    # Typed multimodal payload; tensors ride as ext-encoded raw buffers or
+    # out-of-band frames (or SHM handles on the in-host pickle-era path).
+    multimodal_inputs: MultimodalInputs | None = None
+
+    # Set by a transport that validates requests itself (the msgpack ZMQ path,
+    # which bypasses the tokenizer_manager's input processor). A non-None value
+    # makes RequestHandler admit the request pre-finished with FINISH_ABORT so
+    # the client receives a terminal abort instead of a silent drop.
+    validation_error: str | None = None
 
 
 @dataclass
@@ -547,34 +607,34 @@ class EmbeddingReqInput:
         return sub
 
 
-@dataclass
-class TokenizedEmbeddingReqInput:
-    # The request id
-    rid: str
+class TokenizedEmbeddingReqInput(BaseReq, kw_only=True):
     # The input text
-    input_text: str
+    input_text: str | None = None
     # The input token ids
-    input_ids: list[int]
+    input_ids: list[int] | None = None
     # Placeholder sampling params field so request metadata can share one shape
     # with generation-oriented code paths.
     sampling_params: SamplingParams
     # Time at object instantiated
-    created_time: float
+    created_time: float = 0.0
 
 
-@dataclass
-class BatchTokenIDOut:
-    # The request id
-    rids: list[str]
-    # The finish reason
-    finished_reasons: list[BaseFinishReason]
+# Serialized form of BaseFinishReason.to_json() (or None while streaming) —
+# all values are msgpack-native primitives.
+FinishReasonDict = dict
+
+
+class BatchTokenIDOut(BaseBatchReq, kw_only=True):
+    # The finish reason (``BaseFinishReason.to_json()`` dicts, None mid-stream)
+    finished_reasons: list[FinishReasonDict | None]
     # For incremental decoding
     decoded_texts: list[str]
     decode_ids: list[list[int]]
     read_offsets: list[int]
-    # Only used when `--skip-tokenizer-init` is on
-    output_ids: list[int] | None
-    output_multi_ids: list[int] | None
+    # Only used when `--skip-tokenizer-init` is on. Per-request lists: the
+    # not-yet-sent slice of each request's generated ids (see stream_output).
+    output_ids: list[list[int]] | None
+    output_multi_ids: list[list[int]] | None
     # Detokenization configs
     skip_special_tokens: list[bool]
     spaces_between_special_tokens: list[bool]
@@ -589,8 +649,10 @@ class BatchTokenIDOut:
     # Logprobs
     input_token_logprobs_val: list[float]
     input_token_logprobs_idx: list[int]
-    output_token_logprobs_val: list[float]
-    output_token_logprobs_idx: list[int]
+    # Per-request lists, parallel to rids: the newly-decoded tokens' sampled
+    # logprobs/token ids this step, [] when logprobs are off (see stream_output).
+    output_token_logprobs_val: list[list[float]]
+    output_token_logprobs_idx: list[list[int]]
     input_top_logprobs_val: list[list]
     input_top_logprobs_idx: list[list]
     output_top_logprobs_val: list[list]
@@ -602,20 +664,87 @@ class BatchTokenIDOut:
 
     # Hidden states
     output_hidden_states: list[list[float]]
-    batch_accept_draft_tokens: list[float]
+    # Per-request draft-token acceptance (speculative decoding); None until
+    # the request finishes, empty when spec decoding is off.
+    batch_accept_draft_tokens: list[float | None]
 
     # Store some custom information, such as decoding status in multimodal scenarios, etc.
     output_extra_infos: list[dict[str, Any]]
 
-    generated_time: int
+    generated_time: float
 
 
-@dataclass
-class BatchStrOut:
-    # The request id
-    rids: list[str]
+def _finish_type(finished_reason) -> str:
+    """Reduce an OutputProcesser finish reason to its wire type string."""
+    if not finished_reason:
+        return ""
+    if isinstance(finished_reason, dict):
+        return finished_reason.get("type", "")
+    return str(finished_reason)
+
+
+class BatchTokenIDOutSlim(BaseBatchReq, kw_only=True):
+    """Per-request slice of ``BatchTokenIDOut`` for a frontend that
+    detokenizes itself (the direct ZMQ scheduler drive).
+
+    Carries only what that frontend consumes, so per-step outputs skip the
+    incremental-detokenization columns (decoded_texts, decode_ids, ...) the
+    in-process frontend needs. Field ORDER is a cross-language wire
+    contract — do not reorder.
+    """
+
+    # Newly generated token ids per request this step, sourced from
+    # ``BatchTokenIDOut.output_ids``.
+    output_ids: list[list[int]]
+    # "" (not finished) or the finish-reason type ("stop", "length", "abort").
+    finished_reasons: list[str]
+    prompt_tokens: list[int]
+    completion_tokens: list[int]
+    cached_tokens: list[int]
+    # Sampled-token logprobs, parallel to rids: one inner list per request,
+    # holding the value/token-id of each newly-decoded token this step. Empty []
+    # for a request that did not ask for logprobs, so the columns stay
+    # non-ragged (always length == len(rids)).
+    output_token_logprobs_val: list[list[float]]
+    output_token_logprobs_idx: list[list[int]]
+
+    @classmethod
+    def from_full(cls, out: BatchTokenIDOut) -> "BatchTokenIDOutSlim":
+        # Token source: ``out.output_ids`` — the not-yet-sent slice of each
+        # request's generated ids. NOT ``out.decode_ids``: that is the
+        # incremental-detokenization window, which starts at the prompt tail
+        # for context and would leak prompt tokens to a frontend that
+        # detokenizes from scratch.
+        if out.output_ids is None:
+            # Substituting empty lists here while completion_tokens advances
+            # would silently lose tokens on the frontend; fail loud instead.
+            raise ValueError(
+                "BatchTokenIDOut.output_ids is None; the msgpack wire needs "
+                "the per-request generated token ids"
+            )
+        return cls(
+            rids=list(out.rids),
+            output_ids=[list(ids) for ids in out.output_ids],
+            finished_reasons=[_finish_type(fr) for fr in out.finished_reasons],
+            prompt_tokens=list(out.prompt_tokens),
+            completion_tokens=list(out.completion_tokens),
+            cached_tokens=list(out.cached_tokens),
+            output_token_logprobs_val=(
+                list(out.output_token_logprobs_val)
+                if out.output_token_logprobs_val is not None
+                else [[] for _ in out.rids]
+            ),
+            output_token_logprobs_idx=(
+                list(out.output_token_logprobs_idx)
+                if out.output_token_logprobs_idx is not None
+                else [[] for _ in out.rids]
+            ),
+        )
+
+
+class BatchStrOut(BaseBatchReq, kw_only=True):
     # The finish reason
-    finished_reasons: list[dict]
+    finished_reasons: list[FinishReasonDict | None]
     # The output decoded strings
     output_strs: list[str]
     # The token ids
@@ -643,33 +772,29 @@ class BatchStrOut:
 
     # Hidden states
     output_hidden_states: list[list[float]]
-    batch_accept_draft_tokens: list[float]
+    # See BatchTokenIDOut.batch_accept_draft_tokens (None mid-stream).
+    batch_accept_draft_tokens: list[float | None]
 
     # Store some custom information, such as decoding status in multimodal scenarios, etc.
     output_extra_infos: list[dict[str, Any]]
 
-    generated_time: int
+    generated_time: float
 
 
-@dataclass
-class BatchEmbeddingOut:
-    # The request id
-    rids: list[str]
+class BatchEmbeddingOut(BaseBatchReq, kw_only=True):
     # The finish reason
-    finished_reasons: list[BaseFinishReason]
-    # The output embedding
-    embeddings: list[list[float]] | list[dict]
+    finished_reasons: list[FinishReasonDict | None]
+    # The output embedding (dense rows or sparse dicts)
+    embeddings: list
     # Token counts
     prompt_tokens: list[int]
 
 
-@dataclass
-class FlushCacheReqInput:
+class FlushCacheReqInput(BaseReq, kw_only=True):
     pass
 
 
-@dataclass
-class FlushCacheReqOutput:
+class FlushCacheReqOutput(BaseReq, kw_only=True):
     success: bool
 
 
@@ -680,41 +805,34 @@ class FlushCacheReqOutput:
 PauseMode = Literal["abort", "wait", "keep"]
 
 
-@dataclass
-class PauseSchedulerReqInput:
+class PauseSchedulerReqInput(BaseReq, kw_only=True):
     # See PauseMode for how each mode treats in-flight requests.
     mode: PauseMode = "abort"
 
 
-@dataclass
-class PauseSchedulerReqOutput:
+class PauseSchedulerReqOutput(BaseReq, kw_only=True):
     success: bool
     message: str = ""
 
 
-@dataclass
-class ResumeSchedulerReqInput:
+class ResumeSchedulerReqInput(BaseReq, kw_only=True):
     pass
 
 
-@dataclass
-class ResumeSchedulerReqOutput:
+class ResumeSchedulerReqOutput(BaseReq, kw_only=True):
     success: bool
     message: str = ""
 
 
-@dataclass
-class IsSchedulerPausedReqInput:
+class IsSchedulerPausedReqInput(BaseReq, kw_only=True):
     pass
 
 
-@dataclass
-class IsSchedulerPausedReqOutput:
+class IsSchedulerPausedReqOutput(BaseReq, kw_only=True):
     is_paused: bool
 
 
-@dataclass
-class UpdateWeightFromDiskReqInput:
+class UpdateWeightFromDiskReqInput(BaseReq, kw_only=True):
     # The model path with the new weights
     model_path: str
     # The format to load the weights
@@ -723,8 +841,7 @@ class UpdateWeightFromDiskReqInput:
     weight_version: str | None = None
 
 
-@dataclass
-class UpdateWeightFromDiskReqOutput:
+class UpdateWeightFromDiskReqOutput(BaseReq, kw_only=True):
     success: bool
     message: str
     # Number of paused requests during weight sync.
@@ -737,8 +854,7 @@ DEFAULT_PACKED_BUFFER_SIZE_BYTES = 1024 * 1024 * 1024  # 1 GiB
 DEFAULT_PACKED_NUM_BUFFERS = 2
 
 
-@dataclass
-class UpdateWeightsFromDistributedReqInput:
+class UpdateWeightsFromDistributedReqInput(BaseReq, kw_only=True):
     # Weight-update metadata shared with the trainer's NCCL sender.
     names: list[str]
     dtype_names: list[str]
@@ -755,14 +871,12 @@ class UpdateWeightsFromDistributedReqInput:
     weight_version: str | None = None
 
 
-@dataclass
-class UpdateWeightsFromDistributedReqOutput:
+class UpdateWeightsFromDistributedReqOutput(BaseReq, kw_only=True):
     success: bool
     message: str
 
 
-@dataclass
-class UpdateWeightsFromTensorReqInput:
+class UpdateWeightsFromTensorReqInput(BaseReq, kw_only=True):
     # One serialized ``Dict[str, torch.Tensor]`` per world rank (engine.py fans
     # the payload out across ``mapping.world_size``).
     serialized_named_tensors: list[bytes]
@@ -772,14 +886,12 @@ class UpdateWeightsFromTensorReqInput:
     weight_version: str | None = None
 
 
-@dataclass
-class UpdateWeightsFromTensorReqOutput:
+class UpdateWeightsFromTensorReqOutput(BaseReq, kw_only=True):
     success: bool
     message: str
 
 
-@dataclass
-class InitWeightsUpdateGroupReqInput:
+class InitWeightsUpdateGroupReqInput(BaseReq, kw_only=True):
     # The master address
     master_address: str
     # The master port
@@ -794,104 +906,91 @@ class InitWeightsUpdateGroupReqInput:
     backend: str = "nccl"
 
 
-@dataclass
-class InitWeightsUpdateGroupReqOutput:
+class InitWeightsUpdateGroupReqOutput(BaseReq, kw_only=True):
     success: bool
     message: str
 
 
-@dataclass
-class DestroyWeightsUpdateGroupReqInput:
+class DestroyWeightsUpdateGroupReqInput(BaseReq, kw_only=True):
     # The group name to tear down (must match the init group_name).
     group_name: str = "weight_update_group"
 
 
-@dataclass
-class DestroyWeightsUpdateGroupReqOutput:
+class DestroyWeightsUpdateGroupReqOutput(BaseReq, kw_only=True):
     success: bool
     message: str
 
 
-@dataclass
-class GetWeightsByNameReqInput:
+class GetWeightsByNameReqInput(BaseReq, kw_only=True):
     name: str
     truncate_size: int = 100
 
 
-@dataclass
-class GetWeightsByNameReqOutput:
+class GetWeightsByNameReqOutput(BaseReq, kw_only=True):
     parameter: list
 
 
-@dataclass
-class ReleaseMemoryOccupationReqInput:
+class ReleaseMemoryOccupationReqInput(BaseReq, kw_only=True):
     # Memory regions to release. None ⇒ all ("weights" and "kv_cache").
     tags: list[str] | None = None
 
 
-@dataclass
-class ReleaseMemoryOccupationReqOutput:
+class ReleaseMemoryOccupationReqOutput(BaseReq, kw_only=True):
     success: bool = True
     message: str = ""
 
 
-@dataclass
-class ResumeMemoryOccupationReqInput:
+class ResumeMemoryOccupationReqInput(BaseReq, kw_only=True):
     # Memory regions to resume. None ⇒ all previously released tags.
     tags: list[str] | None = None
 
 
-@dataclass
-class ResumeMemoryOccupationReqOutput:
+class ResumeMemoryOccupationReqOutput(BaseReq, kw_only=True):
     success: bool = True
     message: str = ""
 
 
-@dataclass
-class IsSleepingReqInput:
+class IsSleepingReqInput(BaseReq, kw_only=True):
     pass
 
 
-@dataclass
-class IsSleepingReqOutput:
+class IsSleepingReqOutput(BaseReq, kw_only=True):
     is_sleeping: bool
 
 
-@dataclass
-class AbortReq:
-    # The request id
-    rid: str
-
-
-@dataclass
-class GetInternalStateReq:
+class AbortReq(BaseReq, kw_only=True):
+    # The request id rides in the ``rid`` base field.
     pass
 
 
-@dataclass
-class GetInternalStateReqOutput:
-    internal_state: dict[Any, Any]
+class GetInternalStateReq(BaseReq, kw_only=True):
+    pass
 
 
-@dataclass
-class SetInternalStateReq:
+class GetInternalStateReqOutput(BaseReq, kw_only=True):
+    internal_state: dict[str, Any]
+
+
+class SetInternalStateReq(BaseReq, kw_only=True):
     server_args: dict[str, Any]
 
 
-@dataclass
-class SetInternalStateReqOutput:
+class SetInternalStateReqOutput(BaseReq, kw_only=True):
     updated: bool
     server_args: dict[str, Any]
 
 
-class ExpertDistributionReq(Enum):
+class ExpertDistributionReqType(Enum):
     START_RECORD = 1
     STOP_RECORD = 2
     DUMP_RECORD = 3
 
 
-@dataclass
-class ExpertDistributionReqOutput:
+class ExpertDistributionReq(BaseReq, kw_only=True):
+    action: ExpertDistributionReqType
+
+
+class ExpertDistributionReqOutput(BaseReq, kw_only=True):
     pass
 
 
@@ -900,8 +999,7 @@ class ProfileReqType(Enum):
     STOP_PROFILE = 2
 
 
-@dataclass
-class ProfileReq:
+class ProfileReq(BaseReq, kw_only=True):
     type: ProfileReqType
     output_dir: str | None = None
     start_step: int | None = None
@@ -913,70 +1011,59 @@ class ProfileReq:
     profile_id: str | None = None
 
 
-@dataclass
-class ProfileReqOutput:
+class ProfileReqOutput(BaseReq, kw_only=True):
     success: bool
     message: str
 
 
-@dataclass
-class ConfigureLoggingReq:
+class ConfigureLoggingReq(BaseReq, kw_only=True):
     log_requests: bool | None = None
     log_requests_level: int | None = None
     dump_requests_folder: str | None = None
     dump_requests_threshold: int | None = None
 
 
-@dataclass
-class OpenSessionReqInput:
+class OpenSessionReqInput(BaseReq, kw_only=True):
     capacity_of_str_len: int
     session_id: str | None = None
 
 
-@dataclass
-class CloseSessionReqInput:
+class CloseSessionReqInput(BaseReq, kw_only=True):
     session_id: str
 
 
-@dataclass
-class OpenSessionReqOutput:
+class OpenSessionReqOutput(BaseReq, kw_only=True):
     session_id: str | None
     success: bool
 
 
-@dataclass
-class HealthCheckOutput:
+class HealthCheckOutput(BaseReq, kw_only=True):
     pass
 
 
-@dataclass
-class RpcReqInput:
+class RpcReqInput(BaseReq, kw_only=True):
     method: str
     parameters: dict | None = None
 
 
-@dataclass
-class RpcReqOutput:
+class RpcReqOutput(BaseReq, kw_only=True):
     success: bool
     message: str
 
 
-@dataclass
-class GetLoadReqInput(BaseReq):
+class GetLoadReqInput(BaseReq, kw_only=True):
     pass
 
 
-@dataclass
-class GetLoadReqOutput(BaseReq):
+class GetLoadReqOutput(BaseReq, kw_only=True):
     dp_rank: int = 0
     num_reqs: int = 0
     num_waiting_reqs: int = 0
     num_pages: int = 0
 
 
-@dataclass
-class WatchLoadUpdateReq(BaseReq):
-    loads: list[GetLoadReqOutput] = field(default_factory=list)
+class WatchLoadUpdateReq(BaseReq, kw_only=True):
+    loads: list[GetLoadReqOutput] = []
 
 
 class BlockReqType(Enum):
@@ -984,6 +1071,267 @@ class BlockReqType(Enum):
     UNBLOCK = 2
 
 
-@dataclass
-class BlockReqInput(BaseReq):
-    type: BlockReqType = field(default_factory=BlockReqType.BLOCK)
+class BlockReqInput(BaseReq, kw_only=True):
+    type: BlockReqType = BlockReqType.BLOCK
+
+
+# ============================================================================
+# msgpack codec for engine IPC.
+#
+# Tensor scheme (shared with the SMG Rust engine-side codec): a tensor or
+# ndarray encodes as the tuple ``(dtype, shape, data)`` where ``data`` is
+# either an ext-typed raw byte view (``CUSTOM_TYPE_RAW_VIEW``) for small
+# payloads, or an integer index into the message's out-of-band ZMQ frames
+# (frame 0 is the primary msgpack buffer, so indices are one-based).
+# ============================================================================
+
+# msgpack extension type codes. 1 and 2 are reserved for pickled payloads in
+# the shared cross-codec numbering; this codec never emits them (opaque
+# objects must use an explicit PickleWrapper field instead).
+CUSTOM_TYPE_PICKLE = 1
+CUSTOM_TYPE_CLOUDPICKLE = 2
+CUSTOM_TYPE_RAW_VIEW = 3
+
+# Tensors/ndarrays below this many bytes are inlined in the primary buffer;
+# larger ones become dedicated zero-copy frames.
+MSGPACK_ZERO_COPY_THRESHOLD = 256
+
+# Rollout escape hatch: force the legacy pickle IPC end-to-end. Read once at
+# import; the senders/receivers below all consult it.
+USE_PICKLE_IPC = envs.TOKENSPEED_USE_PICKLE_IPC.get()
+
+
+def _tensor_bytes(tensor: torch.Tensor) -> memoryview:
+    """A flat uint8 view of ``tensor``'s data (CPU, contiguous)."""
+    t = tensor.detach()
+    if t.device.type != "cpu":
+        t = t.cpu()
+    if not t.is_contiguous():
+        t = t.contiguous()
+    return memoryview(t.reshape(-1).view(torch.uint8).numpy()).cast("B")
+
+
+class MsgpackEncoder:
+    """msgpack encoder with tensor/ndarray support and out-of-band buffers.
+
+    ``encode`` returns the list of ZMQ frames to send: the primary msgpack
+    buffer first, then one frame per large tensor (referenced by index from
+    the primary buffer). Not thread-safe while encoding.
+    """
+
+    def __init__(self, size_threshold: int = MSGPACK_ZERO_COPY_THRESHOLD) -> None:
+        self._encoder = msgspec.msgpack.Encoder(enc_hook=self._enc_hook)
+        self._aux_buffers: list | None = None
+        self._size_threshold = size_threshold
+
+    def encode(self, obj: Any) -> list:
+        try:
+            self._aux_buffers = bufs = [b""]
+            bufs[0] = self._encoder.encode(obj)
+            return bufs
+        finally:
+            self._aux_buffers = None
+
+    def _enc_hook(self, obj: Any) -> Any:
+        if isinstance(obj, torch.Tensor):
+            return self._encode_tensor(obj)
+        if isinstance(obj, np.ndarray) and obj.dtype.kind not in ("O", "V"):
+            return self._encode_ndarray(obj)
+        if isinstance(obj, torch.dtype):
+            return str(obj).removeprefix("torch.")
+        if isinstance(obj, np.floating):
+            return float(obj)
+        if isinstance(obj, np.integer):
+            return int(obj)
+        raise TypeError(
+            f"Cannot msgpack-encode object of type {type(obj)}. Give the field "
+            "a precise msgspec-compatible type, or wrap a genuinely opaque "
+            "payload in an explicit PickleWrapper field."
+        )
+
+    def _stash(self, buf) -> "msgspec.msgpack.Ext | int":
+        """Inline small buffers as an ext raw view; frame out large ones."""
+        if buf.nbytes < self._size_threshold:
+            return msgspec.msgpack.Ext(CUSTOM_TYPE_RAW_VIEW, buf)
+        index = len(self._aux_buffers)
+        self._aux_buffers.append(buf)
+        return index
+
+    def _encode_tensor(self, obj: torch.Tensor) -> tuple:
+        assert self._aux_buffers is not None
+        dtype = str(obj.dtype).removeprefix("torch.")
+        return dtype, tuple(obj.shape), self._stash(_tensor_bytes(obj))
+
+    def _encode_ndarray(self, obj: np.ndarray) -> tuple:
+        assert self._aux_buffers is not None
+        arr = np.ascontiguousarray(obj)
+        return obj.dtype.str, obj.shape, self._stash(arr.reshape(-1).view("B").data)
+
+
+class MsgpackDecoder:
+    """msgpack decoder resolving tensors from inline ext views or aux frames.
+
+    ``decode`` accepts either a single buffer or the full frame list (frame 0
+    = primary buffer). Not thread-safe while decoding.
+    """
+
+    def __init__(self, ty: Any = None) -> None:
+        args = () if ty is None else (ty,)
+        self._decoder = msgspec.msgpack.Decoder(
+            *args, dec_hook=self._dec_hook, ext_hook=self._ext_hook
+        )
+        self._aux_buffers: Any = ()
+
+    def decode(self, bufs: Any) -> Any:
+        if isinstance(bufs, (bytes, bytearray, memoryview)):
+            return self._decoder.decode(bufs)
+        self._aux_buffers = bufs
+        try:
+            return self._decoder.decode(bufs[0])
+        finally:
+            self._aux_buffers = ()
+
+    def _dec_hook(self, ty: type, obj: Any) -> Any:
+        if ty is torch.dtype:
+            return getattr(torch, obj)
+        if isinstance(ty, type):
+            if issubclass(ty, torch.Tensor):
+                return self._decode_tensor(obj)
+            if issubclass(ty, np.ndarray):
+                return self._decode_ndarray(obj)
+        raise TypeError(f"Cannot msgpack-decode into unsupported type {ty}.")
+
+    def _ext_hook(self, code: int, data: memoryview) -> Any:
+        if code == CUSTOM_TYPE_RAW_VIEW:
+            return data
+        raise NotImplementedError(f"Extension type code {code} is not supported")
+
+    def _resolve_buffer(self, data) -> memoryview:
+        buf = self._aux_buffers[data] if isinstance(data, int) else data
+        return buf if isinstance(buf, memoryview) else memoryview(buf)
+
+    def _decode_tensor(self, arr: Any) -> torch.Tensor:
+        dtype, shape, data = arr
+        buffer = self._resolve_buffer(data)
+        torch_dtype = getattr(torch, dtype, None)
+        if not isinstance(torch_dtype, torch.dtype):
+            # numpy typestring (a field typed torch.Tensor fed an ndarray).
+            return torch.from_numpy(
+                np.frombuffer(buffer, dtype=np.dtype(dtype)).copy()
+            ).reshape(shape)
+        if not buffer.nbytes:  # torch.frombuffer rejects empty buffers
+            return torch.empty(shape, dtype=torch_dtype)
+        # frombuffer needs a writable buffer; received bytes are read-only, so
+        # copy into a bytearray the tensor then owns.
+        writable = buffer if not buffer.readonly else bytearray(buffer)
+        flat = torch.frombuffer(writable, dtype=torch.uint8)
+        return flat.view(torch_dtype).view(shape)
+
+    def _decode_ndarray(self, arr: Any) -> np.ndarray:
+        dtype, shape, data = arr
+        buffer = self._resolve_buffer(data)
+        return np.frombuffer(buffer, dtype=np.dtype(dtype)).copy().reshape(shape)
+
+
+def _walk_subclasses(base: type) -> list:
+    out = []
+    for sub in base.__subclasses__():
+        out.append(sub)
+        out.extend(_walk_subclasses(sub))
+    return out
+
+
+def ipc_message_union():
+    """The tagged union of every registered IPC message type.
+
+    Computed lazily so process roles that define extra ``BaseReq`` subclasses
+    (e.g. the EPD encode worker) are included as long as the defining module
+    is imported before the receiving socket is constructed.
+    """
+    types = tuple(
+        dict.fromkeys(
+            _walk_subclasses(BaseReq) + _walk_subclasses(BaseBatchReq) + [PickleWrapper]
+        )
+    )
+    return Union[types]  # noqa: UP007 — dynamic union over a runtime tuple
+
+
+class IpcSender:
+    """Engine-IPC sender wrapping a ZMQ PUSH/DEALER socket.
+
+    Exposes ``send_pyobj`` so existing call sites are unchanged; the payload
+    is msgpack (multipart, with out-of-band tensor frames) unless the
+    ``USE_PICKLE_IPC`` escape hatch is on. ``send`` accepts a pre-pickled
+    engine message from legacy off-thread serializers and transcodes it onto
+    the same wire. Works over both sync and asyncio sockets (asyncio sends
+    return the socket's future).
+    """
+
+    def __init__(self, socket) -> None:
+        self._socket = socket
+        self._encoder = MsgpackEncoder()
+
+    def send_pyobj(self, obj: Any, flags: int = 0):
+        if USE_PICKLE_IPC:
+            return self._socket.send_pyobj(obj, flags)
+        return self._socket.send_multipart(self._encoder.encode(obj), flags, copy=False)
+
+    def send(self, data, flags: int = 0):
+        # Legacy raw-frame surface: external callers that serialize an engine
+        # message off-thread hand this seam pickled bytes (the pre-msgpack wire).
+        # Transcode through the shared codec so every receiver on the channel
+        # sees one wire format; under the pickle escape hatch the bytes already
+        # match the wire and pass through untouched.
+        if USE_PICKLE_IPC:
+            return self._socket.send(data, flags)
+        return self.send_pyobj(pickle.loads(data), flags)
+
+    def close(self, linger: int | None = None) -> None:
+        self._socket.close(linger=linger)
+
+    def __getattr__(self, name: str):
+        # Raw socket surface (poll, setsockopt, ...) for callers that bypass
+        # the object codec.
+        return getattr(self._socket, name)
+
+
+class IpcReceiver:
+    """Engine-IPC receiver wrapping a sync ZMQ PULL socket.
+
+    ``recv_pyobj`` preserves the drain-loop contract: ``zmq.Again`` under
+    NOBLOCK when the socket is empty.
+    """
+
+    def __init__(self, socket) -> None:
+        self._socket = socket
+        self._decoder = MsgpackDecoder(ipc_message_union())
+
+    def recv_pyobj(self, flags: int = 0) -> Any:
+        if USE_PICKLE_IPC:
+            return self._socket.recv_pyobj(flags)
+        return self._decoder.decode(self._socket.recv_multipart(flags))
+
+    def close(self, linger: int | None = None) -> None:
+        self._socket.close(linger=linger)
+
+    def __getattr__(self, name: str):
+        return getattr(self._socket, name)
+
+
+class AsyncIpcReceiver:
+    """Engine-IPC receiver wrapping a ``zmq.asyncio`` PULL socket."""
+
+    def __init__(self, socket) -> None:
+        self._socket = socket
+        self._decoder = MsgpackDecoder(ipc_message_union())
+
+    async def recv_pyobj(self, flags: int = 0) -> Any:
+        if USE_PICKLE_IPC:
+            return await self._socket.recv_pyobj(flags)
+        return self._decoder.decode(await self._socket.recv_multipart(flags))
+
+    def close(self, linger: int | None = None) -> None:
+        self._socket.close(linger=linger)
+
+    def __getattr__(self, name: str):
+        return getattr(self._socket, name)

--- a/python/tokenspeed/runtime/engine/parallel_sampling.py
+++ b/python/tokenspeed/runtime/engine/parallel_sampling.py
@@ -47,9 +47,9 @@ from tokenspeed.runtime.engine.io_struct import (
 def _own_multimodal_inputs(tokenized_copy) -> None:
     """Give this fan-out copy its own multimodal feature tensors.
 
-    ``MultimodalInputs.publish_shm_features`` rewrites ``item.feature``
-    in place from tensor to SHM handle, and consumers later unlink the
-    segment. The prefix warmup and each n>1 replica are shallow
+    ``MultimodalInputs.publish_shm_features`` moves ``item.feature`` in
+    place into an ``item.feature_shm`` handle, and consumers later unlink
+    the segment. The prefix warmup and each n>1 replica are shallow
     ``copy.copy`` of the same tokenized payload, so without an independent
     copy they would publish only once (the 2nd+ ``publish`` is a no-op
     because the feature is already a handle) and share the SHM segment.

--- a/python/tokenspeed/runtime/engine/request_handler.py
+++ b/python/tokenspeed/runtime/engine/request_handler.py
@@ -278,6 +278,23 @@ class RequestHandler:
             eos_token_ids=self.hf_eos_token_id,
         )
 
+        # A transport that validates requests itself (msgpack ZMQ) marks
+        # rejected ones instead of dropping them; admit pre-finished so the
+        # client gets a terminal abort rather than a hung stream.
+        if getattr(recv_req, "validation_error", None):
+            req_state.finished_reason = FINISH_ABORT(
+                f"Invalid request: {recv_req.validation_error}"
+            )
+            return (
+                req_spec,
+                req_state,
+                BootstrapInfo(
+                    recv_req.bootstrap_host,
+                    recv_req.bootstrap_port,
+                    recv_req.bootstrap_room,
+                ),
+            )
+
         if (
             recv_req.session_params is not None
             and recv_req.session_params.id is not None

--- a/python/tokenspeed/runtime/engine/scheduler_control_client.py
+++ b/python/tokenspeed/runtime/engine/scheduler_control_client.py
@@ -39,6 +39,7 @@ from tokenspeed.runtime.engine.io_struct import (
     DestroyWeightsUpdateGroupReqOutput,
     ExpertDistributionReq,
     ExpertDistributionReqOutput,
+    ExpertDistributionReqType,
     FlushCacheReqInput,
     FlushCacheReqOutput,
     GetInternalStateReq,
@@ -361,15 +362,21 @@ class SchedulerControlClient:
 
     async def start_expert_distribution_record(self: AsyncLLM):
         self.auto_create_handle_loop()
-        await self.expert_distribution_communicator(ExpertDistributionReq.START_RECORD)
+        await self.expert_distribution_communicator(
+            ExpertDistributionReq(action=ExpertDistributionReqType.START_RECORD)
+        )
 
     async def stop_expert_distribution_record(self: AsyncLLM):
         self.auto_create_handle_loop()
-        await self.expert_distribution_communicator(ExpertDistributionReq.STOP_RECORD)
+        await self.expert_distribution_communicator(
+            ExpertDistributionReq(action=ExpertDistributionReqType.STOP_RECORD)
+        )
 
     async def dump_expert_distribution_record(self: AsyncLLM):
         self.auto_create_handle_loop()
-        await self.expert_distribution_communicator(ExpertDistributionReq.DUMP_RECORD)
+        await self.expert_distribution_communicator(
+            ExpertDistributionReq(action=ExpertDistributionReqType.DUMP_RECORD)
+        )
 
     async def init_weights_update_group(
         self: AsyncLLM,

--- a/python/tokenspeed/runtime/engine/zmq_msgpack.py
+++ b/python/tokenspeed/runtime/engine/zmq_msgpack.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Engine-side ZMQ transport for the direct SMG <-> scheduler msgpack path.
+#
+# In the default (pickle) mode the scheduler BINDS a PULL/PUSH pair and the
+# Python tokenizer_manager connects in. SMG cannot speak that pickle protocol,
+# so this module inverts the topology: SMG (the frontend) BINDS the handshake/
+# input/output sockets and the scheduler CONNECTS in, completing the
+# HELLO -> INIT -> READY handshake and then exchanging the msgpack frames
+# defined in ``zmq_wire``.
+#
+# The adapters below expose ``recv_pyobj``/``send_pyobj`` so the existing
+# RequestHandler and OutputProcesser drive them unchanged; only the wire codec
+# differs. This module is additive and only reached when ``--zmq-msgpack`` is on.
+
+from __future__ import annotations
+
+import collections
+import logging
+import struct
+
+import zmq
+
+from tokenspeed.runtime.engine import zmq_wire
+from tokenspeed.runtime.engine.io_struct import (
+    BatchTokenIDOut,
+    BatchTokenIDOutSlim,
+    MsgpackEncoder,
+    TokenizedGenerateReqInput,
+)
+
+logger = logging.getLogger(__name__)
+
+# SMG allows a registering worker a long connect window (~600 s), so the
+# frontend may start the handshake well after this engine finished model load.
+# Wait for INIT in slices, logging progress, instead of dying at 60 s.
+_INIT_TIMEOUT_MS = 600_000
+_INIT_POLL_SLICE_MS = 30_000
+
+# Raw single-frame sentinel SMG's output loop treats as terminal: the worker
+# is marked dead instead of staying healthy-idle after this engine exits.
+ENGINE_CORE_DEAD = b"ENGINE_CORE_DEAD"
+
+
+def _engine_identity(engine_index: int) -> bytes:
+    """Two-byte little-endian ROUTER identity for this engine (its engine index)."""
+    return struct.pack("<H", engine_index)
+
+
+class MsgpackRecvSocket:
+    """Adapts a DEALER input socket to the ``recv_pyobj`` contract.
+
+    Each ZMQ message is ``[type_byte, msgpack payload]`` (the DEALER strips the
+    routing identity). One ABORT message can expand to several ``AbortReq``, so
+    decoded io_structs are buffered and handed out one per ``recv_pyobj`` call,
+    preserving the "one object per recv, ``zmq.Again`` when empty" contract the
+    RequestHandler's drain loop relies on.
+
+    ``vocab_size`` lets this socket run ``sampling_params.verify`` on each
+    generate request, and ``enable_output_logprobs`` gates ``return_logprob``
+    (the pickle path enforces both in the tokenizer_manager's input processor,
+    which the msgpack path bypasses; the pure wire ``to_io_struct`` has neither
+    value). An invalid request is not dropped — that would hang the frontend's
+    stream with no terminal frame. It is marked via ``validation_error`` so
+    RequestHandler admits it pre-finished (FINISH_ABORT) and OutputProcesser
+    emits a terminal "abort" output.
+    """
+
+    def __init__(
+        self,
+        socket: zmq.Socket,
+        vocab_size: int,
+        enable_output_logprobs: bool = False,
+    ) -> None:
+        self._socket = socket
+        self._vocab_size = vocab_size
+        self._enable_output_logprobs = enable_output_logprobs
+        self._pending: collections.deque = collections.deque()
+
+    def _validation_error(self, obj: TokenizedGenerateReqInput) -> str | None:
+        """Return the reason ``obj`` must be rejected, or None if it is valid."""
+        if obj.return_logprob and not self._enable_output_logprobs:
+            return (
+                "logprobs were requested but the server was started without "
+                "--enable-output-logprobs"
+            )
+        try:
+            obj.sampling_params.verify(self._vocab_size)
+        except ValueError as exc:
+            return str(exc)
+        return None
+
+    def recv_pyobj(self, flags: int = 0):
+        while not self._pending:
+            # Raises zmq.Again (a zmq.ZMQError) under NOBLOCK when idle, which
+            # the caller catches to end the drain loop.
+            frames = self._socket.recv_multipart(flags)
+            try:
+                decoded = zmq_wire.decode_request_frames(frames)
+            except Exception as exc:
+                # A malformed frame (e.g. a version-skewed frontend) must not
+                # escape the RequestHandler's zmq.ZMQError-only catch and kill
+                # the engine; drop the message and keep draining.
+                logger.warning(
+                    "msgpack input: dropping malformed message "
+                    "(%d frames, sizes=%s, head=%s): %s",
+                    len(frames),
+                    [len(frame) for frame in frames],
+                    frames[0][:8].hex() if frames else "",
+                    exc,
+                )
+                continue
+            for obj in decoded:
+                # AbortReq carries no sampling_params; only generate requests
+                # are validated. A rejected request still flows, pre-marked.
+                # The wire layer may have marked it already (e.g. n != 1).
+                if isinstance(obj, TokenizedGenerateReqInput):
+                    reason = obj.validation_error or self._validation_error(obj)
+                    if reason is not None:
+                        logger.warning(
+                            "msgpack input: aborting invalid request %s: %s",
+                            obj.rid,
+                            reason,
+                        )
+                        obj.validation_error = reason
+                self._pending.append(obj)
+        return self._pending.popleft()
+
+    def close(self) -> None:
+        self._socket.close()
+
+
+class MsgpackSendSocket:
+    """Adapts a PUSH output socket to the ``send_pyobj`` contract.
+
+    Only ``BatchTokenIDOut`` is on SMG's output path; it is sliced down to the
+    tagged ``BatchTokenIDOutSlim`` (the frontend detokenizes itself, so the
+    incremental-detokenization columns would be dead weight every step).
+    Control replies (Profile/GetLoad/...) have no SMG consumer in this mode
+    and are dropped with a warning rather than crashing the scheduler.
+    """
+
+    def __init__(self, socket: zmq.Socket) -> None:
+        self._socket = socket
+        self._encoder = MsgpackEncoder()
+
+    def send_pyobj(self, obj) -> None:
+        if isinstance(obj, BatchTokenIDOut):
+            slim = BatchTokenIDOutSlim.from_full(obj)
+            self._socket.send_multipart(self._encoder.encode(slim), copy=False)
+        else:
+            logger.warning(
+                "msgpack output: dropping unsupported control reply %s",
+                type(obj).__name__,
+            )
+
+    def send_engine_dead(self) -> None:
+        """Best-effort ENGINE_CORE_DEAD sentinel on engine shutdown/crash.
+
+        Never raises: this runs on cleanup paths where the socket may already
+        be unusable, and failing to notify must not mask the original error.
+        """
+        try:
+            self._socket.send(ENGINE_CORE_DEAD, zmq.NOBLOCK)
+        except Exception as exc:
+            logger.warning("msgpack output: ENGINE_CORE_DEAD send failed: %s", exc)
+
+    def close(self) -> None:
+        self._socket.close()
+
+
+def _recv_init_with_timeout(socket: zmq.Socket) -> list[bytes]:
+    """Wait for SMG's INIT reply, logging progress each poll slice so operators
+    can tell a still-registering frontend from a wedged one."""
+    waited_ms = 0
+    while waited_ms < _INIT_TIMEOUT_MS:
+        if socket.poll(_INIT_POLL_SLICE_MS, zmq.POLLIN):
+            return socket.recv_multipart()
+        waited_ms += _INIT_POLL_SLICE_MS
+        logger.info(
+            "msgpack handshake: waiting for SMG INIT (%ds elapsed)",
+            waited_ms // 1000,
+        )
+    raise TimeoutError(
+        f"SMG msgpack handshake timed out waiting for INIT after {_INIT_TIMEOUT_MS} ms"
+    )
+
+
+def connect_msgpack_engine(
+    context: zmq.Context,
+    handshake_address: str,
+    engine_index: int,
+    ready_response: "zmq_wire.WireEngineCoreReadyResponse",
+    vocab_size: int,
+    enable_output_logprobs: bool = False,
+) -> tuple[MsgpackRecvSocket, MsgpackSendSocket]:
+    """Run the startup handshake against SMG and return the wrapped
+    data-plane sockets.
+
+    SMG binds ``handshake_address`` (ROUTER) plus the input (ROUTER) and output
+    (PULL) sockets; this engine connects in and drives:
+
+      1. HELLO on the handshake DEALER (identity = engine index).
+      2. recv INIT -> learn SMG's input/output addresses.
+      3. READY on the handshake DEALER.
+      4. connect the input DEALER, register with the ready response.
+      5. connect the output PUSH.
+    """
+    identity = _engine_identity(engine_index)
+
+    handshake = context.socket(zmq.DEALER)
+    handshake.setsockopt(zmq.IDENTITY, identity)
+    handshake.connect(handshake_address)
+    logger.info("msgpack handshake: connected to %s", handshake_address)
+
+    handshake.send(
+        zmq_wire.encode(
+            zmq_wire.WireReadyMessage(status="HELLO", local=True, headless=True)
+        )
+    )
+    init_frames = _recv_init_with_timeout(handshake)
+    init = zmq_wire.decode_init(init_frames[-1])
+    handshake.send(
+        zmq_wire.encode(
+            zmq_wire.WireReadyMessage(status="READY", local=True, headless=True)
+        )
+    )
+
+    if not init.addresses.inputs or not init.addresses.outputs:
+        raise ValueError(
+            "SMG INIT message did not carry both input and output addresses: "
+            f"inputs={init.addresses.inputs} outputs={init.addresses.outputs}"
+        )
+    input_address = init.addresses.inputs[0]
+    output_address = init.addresses.outputs[0]
+    logger.info(
+        "msgpack handshake: INIT input=%s output=%s", input_address, output_address
+    )
+
+    input_socket = context.socket(zmq.DEALER)
+    input_socket.setsockopt(zmq.IDENTITY, identity)
+    input_socket.connect(input_address)
+    # Register on the input socket so SMG learns this engine's post-init config.
+    input_socket.send(zmq_wire.encode(ready_response))
+
+    output_socket = context.socket(zmq.PUSH)
+    output_socket.connect(output_address)
+
+    handshake.close()
+    logger.info("msgpack handshake: complete (engine_index=%s)", engine_index)
+    return (
+        MsgpackRecvSocket(input_socket, vocab_size, enable_output_logprobs),
+        MsgpackSendSocket(output_socket),
+    )

--- a/python/tokenspeed/runtime/engine/zmq_wire.py
+++ b/python/tokenspeed/runtime/engine/zmq_wire.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# msgpack wire format for the direct SMG <-> scheduler ZMQ path.
+#
+# The data plane carries the NATIVE tagged io_struct types (see io_struct):
+# a request frame decodes straight into ``TokenizedGenerateReqInput`` and a
+# per-step output is the slim ``BatchTokenIDOutSlim`` slice, so there is no
+# duplicate wire-struct layer to keep in sync. This module keeps only the
+# transport-level pieces of the contract:
+#
+#   * the single-byte request-type frame (ADD/ABORT) that lets the receiver
+#     dispatch without decoding the payload;
+#   * the map-encoded startup-handshake structs (HELLO/INIT/READY plus the
+#     engine's ready response), which match the frontend's
+#     ``rmp_serde::to_vec_named`` codec and must NOT be positional.
+
+from __future__ import annotations
+
+import msgspec
+
+from tokenspeed.runtime.engine.io_struct import (
+    AbortReq,
+    MsgpackDecoder,
+    TokenizedGenerateReqInput,
+)
+
+# Single-byte request-type frame: sent as a raw ZMQ frame ahead of the msgpack
+# payload so the receiver can dispatch without decoding first.
+REQ_TYPE_ADD = b"\x00"
+REQ_TYPE_ABORT = b"\x01"
+
+
+# ----------------------------------------------------------------------------
+# Startup-handshake structs (SMG <-> engine), encoded as msgpack MAPS with named
+# keys (msgspec's default struct encoding), matching the Rust
+# `rmp_serde::to_vec_named` codec. Do NOT make these ``array_like``; only the
+# request/output data-plane structs are positional tuples.
+# ----------------------------------------------------------------------------
+
+
+class WireReadyMessage(msgspec.Struct):
+    """Engine -> frontend handshake status frame (``status`` = HELLO | READY)."""
+
+    status: str | None = None
+    local: bool | None = None
+    headless: bool | None = None
+    parallel_config_hash: str | None = None
+
+
+class WireHandshakeAddresses(msgspec.Struct):
+    """Frontend-owned data-plane addresses delivered to the engine in INIT."""
+
+    inputs: list[str] = []
+    outputs: list[str] = []
+    coordinator_input: str | None = None
+    coordinator_output: str | None = None
+    frontend_stats_publish_address: str | None = None
+
+
+class WireHandshakeInitMessage(msgspec.Struct):
+    """Frontend -> engine INIT payload (sent in reply to HELLO)."""
+
+    addresses: WireHandshakeAddresses
+    # Opaque to the engine; decoded loosely so unknown keys are ignored.
+    parallel_config: dict = {}
+
+
+class WireEngineCoreReadyResponse(msgspec.Struct):
+    """Engine -> frontend post-init config, sent on the input-socket
+    registration once the HELLO/INIT/READY handshake completes.
+
+    Field names (not order) are the wire contract for this map-encoded struct.
+    """
+
+    max_model_len: int = 0
+    num_gpu_blocks: int = 0
+    block_size: int = 0
+    dp_stats_address: str | None = None
+    dtype: str = "bfloat16"
+    vllm_version: str = ""
+    world_size: int = 1
+    data_parallel_size: int = 1
+    tensor_parallel_size: int = 1
+    pipeline_parallel_size: int = 1
+    decode_context_parallel_size: int = 1
+    data_parallel_rank: int = 0
+    max_num_seqs: int = 0
+    max_num_batched_tokens: int = 0
+    instance_id: str = ""
+    kv_cache_size_tokens: int | None = None
+    kv_cache_max_concurrency: float | None = None
+    kv_events_config: dict | None = None
+
+
+_ENC = msgspec.msgpack.Encoder()
+_DEC_ABORT = msgspec.msgpack.Decoder(list[str])
+_DEC_INIT = msgspec.msgpack.Decoder(WireHandshakeInitMessage)
+# Native tagged request decode, tensor/aux-frame aware for multimodal payloads.
+_DEC_ADD = MsgpackDecoder(TokenizedGenerateReqInput)
+
+
+def encode(obj: msgspec.Struct) -> bytes:
+    """Encode a handshake struct to a msgpack payload."""
+    return _ENC.encode(obj)
+
+
+def decode_abort(payload: bytes) -> list[str]:
+    """Decode an ABORT payload (a msgpack array of request ids)."""
+    return _DEC_ABORT.decode(payload)
+
+
+def decode_init(payload: bytes) -> WireHandshakeInitMessage:
+    return _DEC_INIT.decode(payload)
+
+
+def _finalize_generate_request(io: TokenizedGenerateReqInput) -> None:
+    """Run the request-materialization steps the in-process input processor
+    performs on the pickle-era path, which this transport bypasses.
+
+    ``resolve_seed`` derives a None seed deterministically from the rid so all
+    TP/DP ranks agree on it; ``normalize`` fills the scheduler-required
+    defaults (e.g. stop_strs). The frontend sends token ids and stop_token_ids
+    (never stop strings), so no tokenizer is needed. ``verify(vocab_size)``
+    is also part of that pipeline, but it needs vocab_size, which this pure
+    wire layer does not have; it runs in the transport (MsgpackRecvSocket).
+    """
+    sampling_params = io.sampling_params
+    sampling_params.resolve_seed(io.rid)
+    sampling_params.normalize(tokenizer=None)
+    # The engine does not multiplex one request into n completions (the
+    # frontend fans out n > 1 itself and rejects it on its side). Mark the
+    # request instead of raising so it terminates with an abort output
+    # rather than being dropped as a malformed frame.
+    if sampling_params.n != 1:
+        io.validation_error = (
+            f"n={sampling_params.n} is not supported on the msgpack "
+            "wire; the frontend must fan out n > 1 itself"
+        )
+
+
+def decode_request_frames(frames: list[bytes]) -> list:
+    """Decode a ``[type_byte, payload, *aux]`` request into io_structs.
+
+    Returns a list because a single ABORT frame may carry several request ids;
+    an ADD always yields exactly one ``TokenizedGenerateReqInput``. ADD aux
+    frames hold out-of-band tensor buffers (frame indices are relative to the
+    payload, which is buffer 0).
+    """
+    if len(frames) < 2:
+        raise ValueError(
+            f"msgpack request needs >=2 frames (type, payload), got {len(frames)}"
+        )
+    type_byte = frames[0]
+    if type_byte == REQ_TYPE_ADD:
+        io = _DEC_ADD.decode(frames[1:])
+        _finalize_generate_request(io)
+        return [io]
+    if type_byte == REQ_TYPE_ABORT:
+        return [AbortReq(rid=rid) for rid in decode_abort(frames[1])]
+    raise ValueError(f"unknown msgpack request type byte: {type_byte!r}")

--- a/python/tokenspeed/runtime/entrypoints/engine.py
+++ b/python/tokenspeed/runtime/entrypoints/engine.py
@@ -36,6 +36,7 @@ import dataclasses
 import multiprocessing as mp
 import os
 import signal
+import sys
 import threading
 from collections.abc import AsyncIterator, Iterator
 
@@ -634,3 +635,158 @@ def _launch_subprocesses(
     scheduler_info = scheduler_infos[0]
     tokenizer_manager.max_req_input_len = scheduler_info["max_req_input_len"]
     return tokenizer_manager, None, scheduler_info
+
+
+def launch_scheduler_headless(server_args: ServerArgs) -> None:
+    """Launch scheduler process(es) driven directly by SMG over msgpack ZMQ.
+
+    Headless: no in-process tokenizer_manager and no AsyncLLM detokenizer (SMG
+    owns both). This process only spawns and
+    supervises the scheduler workers, which connect out to the SMG-bound
+    handshake/input/output sockets (see engine.event_loop._init_msgpack_transport),
+    then blocks until they exit.
+
+    Forces ``--zmq-msgpack`` + ``--skip-tokenizer-init`` since SMG passes
+    token ids. The workers dial ``tcp://{--data-parallel-address}:
+    {--data-parallel-rpc-port}`` (defaults ``127.0.0.1:30500``; the frontend
+    binds it). Both flags always carry values — non-emptiness and the u16
+    range are enforced at parse time.
+    """
+    server_args.zmq_msgpack = True
+    server_args.skip_tokenizer_init = True
+    # DP > 1 is rejected in event_loop._init_msgpack_transport, the choke point
+    # shared with the non-headless --zmq-msgpack launch path.
+
+    configure_logger(server_args)
+    _set_envs_and_config(server_args)
+
+    # PortArgs is still derived (nccl_port drives torch.distributed); the pickle
+    # scheduler_input/tokenizer IPC names it carries are unused in msgpack mode.
+    port_args = PortArgs.init_new(server_args)
+    logger.info("headless server_args=%r", server_args)
+
+    server_args.model, server_args.tokenizer = prepare_model_and_tokenizer(
+        server_args.model, server_args.tokenizer
+    )
+
+    scheduler_procs: list[mp.Process] = []
+    scheduler_pipe_readers = []
+
+    # SIGUSR1 is what a scheduler sends its parent on an internal exception
+    # (see run_event_loop) — the child itself then exits 0, so record the
+    # failure here or the supervisor would report success.
+    child_failed = threading.Event()
+
+    def _terminate_schedulers(signum=None, _frame=None):
+        """Forward a shutdown (or child-failure SIGUSR1) to every scheduler."""
+        if signum is not None:
+            logger.info("received signal %s; terminating scheduler(s)", signum)
+        if signum == signal.SIGUSR1:
+            child_failed.set()
+        for proc in scheduler_procs:
+            if proc.is_alive():
+                proc.terminate()
+
+    # Install before spawning so a signal in the launch window is not lost;
+    # an unhandled SIGUSR1 would kill this supervisor without cleanup.
+    signal.signal(signal.SIGTERM, _terminate_schedulers)
+    signal.signal(signal.SIGINT, _terminate_schedulers)
+    signal.signal(signal.SIGUSR1, _terminate_schedulers)
+
+    if not server_args.mapping.attn.has_dp:
+        memory_saver_adapter = TorchMemorySaverAdapter.create(
+            enable=server_args.enable_memory_saver
+        )
+        rank_start = server_args.mapping.nprocs_per_node * server_args.node_rank
+        rank_end = rank_start + server_args.mapping.nprocs_per_node
+        for rank in range(rank_start, rank_end):
+            rank_server_args = copy.copy(server_args)
+            rank_server_args.mapping = copy.deepcopy(server_args.mapping)
+            rank_server_args.mapping.rank = rank
+
+            reader, writer = mp.Pipe(duplex=False)
+            proc = mp.Process(
+                target=run_event_loop,
+                args=(rank_server_args, port_args, writer),
+            )
+            with memory_saver_adapter.configure_subprocess():
+                proc.start()
+            scheduler_procs.append(proc)
+            scheduler_pipe_readers.append(reader)
+    else:
+        reader, writer = mp.Pipe(duplex=False)
+        scheduler_pipe_readers.append(reader)
+        proc = mp.Process(
+            target=run_data_parallel_controller_process,
+            args=(server_args, port_args, writer),
+        )
+        proc.start()
+        scheduler_procs.append(proc)
+
+    try:
+        for i, reader in enumerate(scheduler_pipe_readers):
+            try:
+                data = reader.recv()
+            except EOFError:
+                logger.error(
+                    "Rank %s scheduler is dead. Please check if there are "
+                    "relevant logs.",
+                    i,
+                )
+                scheduler_procs[i].join()
+                logger.error("Exit code: %s", scheduler_procs[i].exitcode)
+                raise
+            if data.get("status") != "ready":
+                raise RuntimeError(
+                    "Scheduler initialization failed. See the error messages above."
+                )
+        logger.info(
+            "headless scheduler(s) ready; SMG handshake endpoint=%s",
+            server_args.zmq_handshake_endpoint(),
+        )
+
+        # Supervise until every scheduler exits. If any rank dies (e.g. OOM
+        # SIGKILL) take the survivors down and exit nonzero instead of
+        # reporting success.
+        failed = False
+        alive = list(scheduler_procs)
+        while alive:
+            for proc in list(alive):
+                proc.join(timeout=1)
+                if proc.exitcode is None:
+                    continue
+                alive.remove(proc)
+                if proc.exitcode == 0:
+                    logger.info(
+                        "scheduler %s exited with code %s", proc.pid, proc.exitcode
+                    )
+                else:
+                    logger.error(
+                        "scheduler %s exited with code %s; terminating the "
+                        "remaining scheduler(s)",
+                        proc.pid,
+                        proc.exitcode,
+                    )
+                    failed = True
+                    _terminate_schedulers()
+        if failed or child_failed.is_set():
+            sys.exit(1)
+    finally:
+        # Backstop: never leak GPU-holding scheduler trees, whichever path
+        # (signal, dead rank, readiness failure) unwound this launcher.
+        _terminate_schedulers()
+        for proc in scheduler_procs:
+            proc.join(timeout=5)
+        kill_process_tree(os.getpid(), include_parent=False)
+
+
+def run_scheduler_headless_from_cli(argv: list[str] | None = None) -> None:
+    """CLI shim: ``python -m tokenspeed.runtime.entrypoints.engine <ServerArgs>``."""
+    from tokenspeed.runtime.utils.server_args import prepare_server_args
+
+    server_args = prepare_server_args(sys.argv[1:] if argv is None else argv)
+    launch_scheduler_headless(server_args)
+
+
+if __name__ == "__main__":
+    run_scheduler_headless_from_cli()

--- a/python/tokenspeed/runtime/epd/encode_loop.py
+++ b/python/tokenspeed/runtime/epd/encode_loop.py
@@ -30,7 +30,7 @@ The assembly is: load the model, stand up the Mooncake encode manager + bootstra
 server, the DisaggEncodeExecutor, and the EncodeWorker, reusing the SAME request
 IPC the LM scheduler uses: a ZMQ PULL
 on ``port_args.scheduler_input_ipc_name``. The smg grpc_servicer's TokenSpeedEncoder
-handler sends an :class:`EncodeRequest` (pickled) over that channel; the loop
+handler sends an :class:`EncodeRequest` (msgpack, tagged) over that channel; the loop
 drains them into ``EncodeWorker.submit`` and runs ``step`` to encode + transfer.
 
 TP: the vision tower is TP-sharded, so all encode ranks run each batch in lockstep
@@ -262,8 +262,10 @@ def run_encode_loop(server_args, port_args, pipe_writer, gpu_id, global_rank):
     context = zmq.Context(2)
     recv_from_gateway = None
     if attn_tp_rank == 0:
-        recv_from_gateway = get_zmq_socket(
-            context, zmq.PULL, port_args.scheduler_input_ipc_name, False
+        from tokenspeed.runtime.engine.io_struct import IpcReceiver
+
+        recv_from_gateway = IpcReceiver(
+            get_zmq_socket(context, zmq.PULL, port_args.scheduler_input_ipc_name, False)
         )
 
     # Unblock the launcher. The encode role has no KV pool, so the token/seq

--- a/python/tokenspeed/runtime/epd/encode_worker.py
+++ b/python/tokenspeed/runtime/epd/encode_worker.py
@@ -34,30 +34,31 @@ orchestrates them, so it is unit-testable with fakes.
 
 from __future__ import annotations
 
-import dataclasses
-
 from tokenspeed.runtime.cache.embedding_cache import (
     EmbeddingCache,
     TieredEmbeddingCache,
 )
+from tokenspeed.runtime.engine.io_struct import BaseReq
 from tokenspeed.runtime.epd.encode_scheduler import (
     EncodeScheduler,
     PendingEncodeItem,
 )
 from tokenspeed.runtime.multimodal.embedder import _item_token_count
 from tokenspeed.runtime.multimodal.inputs import MultimodalDataItem
-from tokenspeed.runtime.multimodal.shm_transport import ShmTensorHandle
 from tokenspeed.runtime.utils import get_colorful_logger
 
 logger = get_colorful_logger(__name__)
 
 
-@dataclasses.dataclass(frozen=True)
-class EncodeRequest:
+class EncodeRequest(BaseReq, kw_only=True):
     """One encode request: a transfer peer plus its vision items.
 
     ``bootstrap_host``/``port``/``room`` identify the prefill peer this
     request's embeddings are shipped to (assigned upstream, per request).
+
+    A tagged IPC struct (``BaseReq``) because it rides the shared
+    scheduler-input ZMQ channel as msgpack; the multimodal items carry their
+    pixels as ext-encoded tensor buffers or SHM handles.
     """
 
     request_id: str
@@ -101,13 +102,13 @@ class EncodeWorker:
         )
         for idx, item in enumerate(request.items):
             cached = self.cache.get(item.hash)
-            if isinstance(item.feature, ShmTensorHandle):
+            if item.feature_shm is not None:
                 # EPD pixel-SHM: the servicer published pixels to POSIX SHM and
                 # the ZMQ hop carried only this handle (hash/pad_value were set on
                 # the real tensor before publish). consume() unlinks, so segments
                 # never outlive the item: materialize on a miss, and on a hit still
                 # consume-and-drop to unlink the unused segment.
-                handle, item.feature = item.feature, None
+                handle, item.feature_shm = item.feature_shm, None
                 handle.attach()
                 if cached is None:
                     item.feature = handle.consume()

--- a/python/tokenspeed/runtime/multimodal/embedder.py
+++ b/python/tokenspeed/runtime/multimodal/embedder.py
@@ -74,7 +74,6 @@ from tokenspeed.runtime.multimodal.inputs import (
     MultimodalForwardContext,
     MultimodalInputs,
 )
-from tokenspeed.runtime.multimodal.shm_transport import ShmTensorHandle
 from tokenspeed.runtime.utils.env import envs
 
 EncoderFn = Callable[[list[MultimodalDataItem]], torch.Tensor]
@@ -654,15 +653,16 @@ class MultimodalEmbedder:
         pending = [
             it
             for it in items
-            if isinstance(it.feature, (torch.Tensor, ShmTensorHandle))
-            and (isinstance(it.feature, ShmTensorHandle) or it.feature.device != device)
+            if it.feature_shm is not None
+            or (isinstance(it.feature, torch.Tensor) and it.feature.device != device)
         ]
         if not pending:
             return
 
         for it in pending:
-            if isinstance(it.feature, ShmTensorHandle):
-                it.feature = it.feature.consume()
+            if it.feature_shm is not None:
+                it.feature = it.feature_shm.consume()
+                it.feature_shm = None
 
         if device.type != "cuda":
             for it in pending:
@@ -683,10 +683,11 @@ class MultimodalEmbedder:
 
     @staticmethod
     def _drop_raw_feature(item: MultimodalDataItem) -> bool:
-        if item.feature is None:
+        if item.feature is None and item.feature_shm is None:
             return False
-        if isinstance(item.feature, ShmTensorHandle):
-            item.feature.release()
+        if item.feature_shm is not None:
+            item.feature_shm.release()
+            item.feature_shm = None
         item.feature = None
         return True
 

--- a/python/tokenspeed/runtime/multimodal/inputs.py
+++ b/python/tokenspeed/runtime/multimodal/inputs.py
@@ -28,7 +28,7 @@ from collections.abc import Mapping
 from enum import Enum, auto
 from typing import Any
 
-import numpy as np
+import msgspec
 import torch
 
 from tokenspeed.runtime.multimodal.hash import hash_feature
@@ -145,21 +145,30 @@ def resolve_mm_pad_substitute_ids(config: Any) -> dict[Modality, int]:
     }
 
 
-# ``eq=False`` on every dataclass below: tensor-valued fields crash the
+# ``eq=False`` on every IPC struct below: tensor-valued fields crash the
 # default element-wise ``__eq__`` and force ``__hash__`` to None.
-@dataclasses.dataclass(eq=False)
-class MultimodalDataItem:
+#
+# ``msgspec.Struct``: these types cross engine IPC nested inside the tokenized
+# request, so they encode as typed msgpack (tensors ride as ext-typed raw
+# buffers via the io_struct codec hooks). Field ORDER is the wire contract —
+# append, never reorder.
+class MultimodalDataItem(msgspec.Struct, eq=False, kw_only=True, array_like=True):
     modality: Modality
     hash: int | None = None
     pad_value: int | None = None
-    offsets: list | None = None
-    feature: torch.Tensor | np.ndarray | ShmTensorHandle | None = None
-    model_specific_data: dict[str, Any] = dataclasses.field(default_factory=dict)
+    offsets: list[tuple[int, int]] | None = None
+    # Inline feature tensor (pixels / mel features / ...). Exactly one of
+    # ``feature`` / ``feature_shm`` is set while the payload is in flight;
+    # msgpack cannot union two hook-decoded types in one field, so the SHM
+    # handle gets its own slot instead of overloading ``feature``.
+    feature: torch.Tensor | None = None
+    feature_shm: ShmTensorHandle | None = None
+    model_specific_data: dict[str, torch.Tensor] = {}
     # Encoder output for this item, populated on first encoder pass and reused
     # across chunked-prefill iterations of the owning request. Lifetime is
     # tied to the request: when the request finishes the item is GC'd and
     # these tensors are released. ``encoded_deepstack`` is set only for
-    # deepstack-enabled modalities.
+    # deepstack-enabled modalities. Scheduler-local: always None on the wire.
     encoded: torch.Tensor | None = None
     encoded_deepstack: torch.Tensor | None = None
     # EPD (encode-prefill-decode): when set, this item's embedding is received
@@ -171,12 +180,26 @@ class MultimodalDataItem:
     # non-EPD items (left to the vision tower).
     encode_handshake: dict | None = None
 
+    def __post_init__(self) -> None:
+        # Compatibility shim for callers that predate the feature/feature_shm
+        # split and pass a SHM handle via ``feature``: re-slot it so the
+        # transport fields stay single-typed.
+        if isinstance(self.feature, ShmTensorHandle):
+            self.feature_shm = self.feature
+            self.feature = None
+
     def __getattr__(self, name: str):
-        if (
-            "model_specific_data" in self.__dict__
-            and name in self.__dict__["model_specific_data"]
-        ):
-            return self.__dict__["model_specific_data"][name]
+        # msgspec structs have no __dict__; read the declared field directly.
+        # Guard underscored names so pickle/copy protocol probes fall through.
+        if not name.startswith("_"):
+            try:
+                model_specific_data = object.__getattribute__(
+                    self, "model_specific_data"
+                )
+            except AttributeError:
+                model_specific_data = None
+            if model_specific_data is not None and name in model_specific_data:
+                return model_specific_data[name]
         raise AttributeError(f"'{self.__class__.__name__}' has no attribute '{name}'")
 
     def ensure_hash(self):
@@ -199,7 +222,7 @@ class MultimodalDataItem:
         if envs.TOKENSPEED_MM_SKIP_COMPUTE_HASH.get():
             self.hash = uuid.uuid4().int
         elif self.hash is None:
-            if isinstance(self.feature, ShmTensorHandle):
+            if self.feature_shm is not None:
                 raise ValueError(
                     "SHM-backed multimodal items must carry content hash or "
                     "pad_value before TokenSpeed consumes them"
@@ -221,14 +244,14 @@ class MultimodalDataItem:
         return self.modality == modality
 
 
-@dataclasses.dataclass(eq=False)
-class MultimodalInputs:
+class MultimodalInputs(msgspec.Struct, eq=False, kw_only=True, array_like=True):
     mm_items: list[MultimodalDataItem]
     im_token_id: int | None = None
     video_token_id: int | None = None
     mrope_positions: torch.Tensor | None = None
     mrope_position_delta: torch.Tensor | None = None
     mrope_position_delta_scalar: int | None = None
+    # Scheduler-local expansion cache; always None on the wire.
     mrope_position_delta_repeated_cache: torch.Tensor | None = None
 
     def ensure_pad_values(self) -> None:
@@ -238,24 +261,25 @@ class MultimodalInputs:
     def publish_shm_features(self) -> None:
         for item in self.mm_items:
             if isinstance(item.feature, torch.Tensor):
-                item.feature = ShmTensorHandle.publish(item.feature)
+                item.feature_shm = ShmTensorHandle.publish(item.feature)
+                item.feature = None
 
     def attach_shm_features(self) -> None:
         """Open every pending handle on this rank. Must run before the
         cross-rank barrier in ``request_handler.recv_reqs``.
         """
         for item in self.mm_items:
-            if isinstance(item.feature, ShmTensorHandle):
-                item.feature.attach()
+            if item.feature_shm is not None:
+                item.feature_shm.attach()
 
     def release_shm_features(self) -> None:
         for item in self.mm_items:
-            if isinstance(item.feature, ShmTensorHandle):
-                item.feature.release()
-                item.feature = None
+            if item.feature_shm is not None:
+                item.feature_shm.release()
+                item.feature_shm = None
 
     def has_pending_shm_features(self) -> bool:
-        return any(isinstance(item.feature, ShmTensorHandle) for item in self.mm_items)
+        return any(item.feature_shm is not None for item in self.mm_items)
 
 
 @dataclasses.dataclass(eq=False)

--- a/python/tokenspeed/runtime/multimodal/shm_transport.py
+++ b/python/tokenspeed/runtime/multimodal/shm_transport.py
@@ -32,9 +32,9 @@ from __future__ import annotations
 
 import logging
 import time
-from dataclasses import dataclass, field
 from multiprocessing import shared_memory
 
+import msgspec
 import torch
 
 from tokenspeed.runtime.utils.env import envs
@@ -43,16 +43,22 @@ logger = logging.getLogger(__name__)
 LOG_MM_TIMING = envs.TOKENSPEED_LOG_MM_TIMING.get()
 
 
-@dataclass
-class ShmTensorHandle:
-    """Pickle-safe handle to a CPU tensor in a POSIX SHM segment."""
+class ShmTensorHandle(msgspec.Struct, eq=False, dict=True):
+    """msgpack/pickle-safe handle to a CPU tensor in a POSIX SHM segment.
+
+    A ``msgspec.Struct`` so the handle rides engine msgpack IPC natively
+    (``dtype`` uses the shared torch.dtype enc/dec hooks in io_struct).
+    ``dict=True`` allows the non-wire ``_segment`` instance attribute that
+    caches this rank's open SHM mapping between ``attach`` and ``consume``.
+    """
 
     shm_name: str
     shape: tuple[int, ...]
     dtype: torch.dtype
-    _segment: shared_memory.SharedMemory | None = field(
-        default=None, init=False, repr=False, compare=False
-    )
+
+    # Per-process open segment; never serialized (class-level default, the
+    # instance attribute is only created by attach()).
+    _segment = None
 
     @classmethod
     def publish(cls, tensor: torch.Tensor) -> ShmTensorHandle:

--- a/python/tokenspeed/runtime/sampling/sampling_params.py
+++ b/python/tokenspeed/runtime/sampling/sampling_params.py
@@ -23,6 +23,8 @@
 import zlib
 from typing import Any
 
+import msgspec
+
 _SAMPLING_EPS = 1e-6
 
 # Sentinel for "top_k is disabled" (sample from whole vocab). We rewrite
@@ -37,79 +39,75 @@ _TOP_K_DISABLED = 1 << 30
 _TOP_K_FUSED_MAX = 128
 
 
-class SamplingParams:
+class SamplingParams(msgspec.Struct, kw_only=True, array_like=True):
     """
     The sampling parameters.
+
+    A ``msgspec.Struct`` so it rides engine IPC as a compact positional
+    msgpack array nested inside the tokenized request. Field ORDER is the
+    wire contract — append new fields at the end, never reorder.
+
+    ``__post_init__`` (run on both construction and msgpack decode) applies
+    the API-input normalization the old ``__init__`` performed; the
+    ``is_normalized`` guard keeps a decode from re-deriving fields that
+    ``normalize()`` already resolved on the sending process.
 
     See docs/backend/sampling_params.md or
     https://docs.tokenspeed.ai/backend/sampling_params.html
     for the documentation.
     """
 
-    def __init__(
-        self,
-        max_new_tokens: int | None = None,
-        stop: str | list[str] | None = None,
-        stop_token_ids: list[int] | None = None,
-        temperature: float = 1.0,
-        top_p: float = 1.0,
-        top_k: int = -1,
-        min_p: float = 0.0,
-        frequency_penalty: float = 0.0,
-        presence_penalty: float = 0.0,
-        repetition_penalty: float = 1.0,
-        min_new_tokens: int = 0,
-        json_schema: str | None = None,
-        regex: str | None = None,
-        ebnf: str | None = None,
-        structural_tag: str | None = None,
-        ignore_eos: bool = False,
-        skip_special_tokens: bool = True,
-        spaces_between_special_tokens: bool = True,
-        no_stop_trim: bool = False,
-        thinking_budget: int | None = None,
-        custom_params: dict[str, Any] | None = None,
-        stream_interval: int | None = None,
-        logit_bias: dict[str, float] | None = None,
-        seed: int | None = None,
-        # vLLM-style output logprobs. None = off; 0 = the sampled (generated)
-        # token's logprob at each output position. Other values are rejected by
-        # verify().
-        logprobs: int | None = None,
-        # OpenAI-compat: `n` is a request-level fanout (number of choices)
-        # that the serving layer forwards on every sampling_params dict.
-        # TokenSpeed does not multiplex a single request into n completions,
-        # so accept and ignore.
-        n: int = 1,
-    ) -> None:
-        self.max_new_tokens = max_new_tokens
-        self.stop_strs = stop
-        if stop_token_ids:
-            self.stop_token_ids = set(stop_token_ids)
+    # --- API parameters (set by callers) ---
+    max_new_tokens: int | None = None
+    # API input alias: copied to ``stop_strs`` by ``__post_init__``.
+    stop: str | list[str] | None = None
+    stop_token_ids: set[int] | None = None
+    temperature: float = 1.0
+    top_p: float = 1.0
+    top_k: int = -1
+    min_p: float = 0.0
+    frequency_penalty: float = 0.0
+    presence_penalty: float = 0.0
+    repetition_penalty: float = 1.0
+    min_new_tokens: int = 0
+    json_schema: str | None = None
+    regex: str | None = None
+    ebnf: str | None = None
+    structural_tag: str | None = None
+    ignore_eos: bool = False
+    skip_special_tokens: bool = True
+    spaces_between_special_tokens: bool = True
+    no_stop_trim: bool = False
+    thinking_budget: int | None = None
+    custom_params: dict[str, Any] | None = None
+    stream_interval: int | None = None
+    logit_bias: dict[str, float] | None = None
+    seed: int | None = None
+    # Output logprobs. None = off; 0 = the sampled (generated) token's
+    # logprob at each output position. Other values are rejected by verify().
+    logprobs: int | None = None
+    # OpenAI-compat: `n` is a request-level fanout (number of choices)
+    # that the serving layer forwards on every sampling_params dict.
+    # TokenSpeed does not multiplex a single request into n completions;
+    # the value is stored (transports validate n == 1) but never acted on.
+    n: int = 1
+
+    # --- Internal fields (populated by __post_init__ / normalize()) ---
+    stop_strs: str | list[str] | None = None  # from ``stop``
+    stop_str_max_len: int = 0  # set by normalize()
+    is_normalized: bool = False  # set by normalize()
+
+    def __post_init__(self) -> None:
+        # Runs after msgpack decode too; once normalize() resolved the
+        # derived fields on the sender, do not re-derive them here.
+        if self.is_normalized:
+            return
+
+        self.stop_strs = self.stop
+        if self.stop_token_ids:
+            self.stop_token_ids = set(self.stop_token_ids)
         else:
             self.stop_token_ids = None
-        self.temperature = temperature
-        self.top_p = top_p
-        self.top_k = top_k
-        self.min_p = min_p
-        self.frequency_penalty = frequency_penalty
-        self.presence_penalty = presence_penalty
-        self.repetition_penalty = repetition_penalty
-        self.min_new_tokens = min_new_tokens
-        self.regex = regex
-        self.json_schema = json_schema
-        self.ebnf = ebnf
-        self.structural_tag = structural_tag
-        self.ignore_eos = ignore_eos
-        self.skip_special_tokens = skip_special_tokens
-        self.spaces_between_special_tokens = spaces_between_special_tokens
-        self.no_stop_trim = no_stop_trim
-        self.custom_params = custom_params
-        self.thinking_budget = thinking_budget
-        self.stream_interval = stream_interval
-        self.logit_bias = logit_bias
-        self.seed = seed
-        self.logprobs = logprobs
 
         # Process some special cases
         if self.temperature < _SAMPLING_EPS:
@@ -200,7 +198,7 @@ class SamplingParams:
         out: set[str] = set()
         if abs(self.temperature - 1.0) > _SAMPLING_EPS:
             out.add("temperature")
-        # top_k=_TOP_K_DISABLED and top_k=1 (greedy short-circuit from __init__) are neutral.
+        # top_k=_TOP_K_DISABLED and top_k=1 (greedy short-circuit from __post_init__) are neutral.
         if self.top_k != _TOP_K_DISABLED and self.top_k != 1:
             out.add("top_k")
         if self.top_p < 1.0:
@@ -241,3 +239,4 @@ class SamplingParams:
                 else:
                     stop_str_max_len = max(stop_str_max_len, len(stop_str))
             self.stop_str_max_len = stop_str_max_len
+        self.is_normalized = True

--- a/python/tokenspeed/runtime/utils/env.py
+++ b/python/tokenspeed/runtime/utils/env.py
@@ -297,6 +297,10 @@ class Envs:
     TOKENSPEED_ENABLE_TORCH_INFERENCE_MODE = EnvBool(True)
     TOKENSPEED_NUMA_AWARE_WORKER_AFFINITY = EnvBool(True)
     TOKENSPEED_REQUEST_CONVERSION_WORKERS = EnvInt(8)
+    # Rollout escape hatch: revert engine IPC (frontend <-> controller <->
+    # scheduler ZMQ hops) from msgpack back to pickle. Read once at import of
+    # engine.io_struct.
+    TOKENSPEED_USE_PICKLE_IPC = EnvBool(False)
 
     # Multimodal / VLM
     TOKENSPEED_LOG_MM_TIMING = EnvBool(False)

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -61,6 +61,21 @@ def str_to_bool(value: str | bool) -> bool:
     raise argparse.ArgumentTypeError(f"invalid boolean value: {value!r}")
 
 
+def _uint16(value: str) -> int:
+    """argparse type for values packed as a two-byte identity (``<H``)."""
+    index = int(value)
+    if not 0 <= index <= 0xFFFF:
+        raise argparse.ArgumentTypeError(f"value must be in [0, 65535], got {value}")
+    return index
+
+
+def _nonempty_str(value: str) -> str:
+    """argparse type for string flags that must not be empty."""
+    if not value.strip():
+        raise argparse.ArgumentTypeError("value must be a non-empty string")
+    return value
+
+
 @dataclasses.dataclass
 class ServerArgs:
     # Model and tokenizer
@@ -80,6 +95,20 @@ class ServerArgs:
     served_model_name: str | None = None
     revision: str | None = None
     language_model_only: bool = False
+
+    # Direct SMG msgpack ZMQ path. When enabled, the scheduler skips the pickle
+    # PULL/PUSH IPC and instead connects to SMG (which binds the handshake/input/
+    # output sockets) over the msgpack wire. Default OFF;
+    # SMG tokenizes/detokenizes, so pair with --skip-tokenizer-init.
+    zmq_msgpack: bool = False
+    # The frontend handshake endpoint the scheduler dials; becomes the
+    # data-parallel rendezvous when DP is supported.
+    data_parallel_address: str = "127.0.0.1"
+    # Default chosen to avoid the 20000-29999 range used for derived
+    # per-worker handshake ports and common rendezvous defaults of
+    # co-located services.
+    data_parallel_rpc_port: int = 30500
+    zmq_engine_index: int = 0
 
     # Port for the HTTP server
     host: str = "127.0.0.1"
@@ -838,6 +867,41 @@ class ServerArgs:
             default=ServerArgs.language_model_only,
             help="Skip vision/audio encoders on a multimodal checkpoint and "
             "run text-only. Multimodal requests are rejected.",
+        )
+        parser.add_argument(
+            "--zmq-msgpack",
+            action=argparse.BooleanOptionalAction,
+            default=ServerArgs.zmq_msgpack,
+            help="Drive the scheduler directly from SMG over the msgpack ZMQ "
+            "wire instead of the Python tokenizer_manager (pickle IPC). SMG "
+            "binds the handshake/input/output sockets; the scheduler connects "
+            "in. Pair with --skip-tokenizer-init.",
+        )
+        parser.add_argument(
+            "--data-parallel-address",
+            type=_nonempty_str,
+            default=ServerArgs.data_parallel_address,
+            help="Host of the frontend-bound handshake ROUTER the scheduler "
+            "connects to under --zmq-msgpack (default "
+            f"{ServerArgs.data_parallel_address}).",
+        )
+        parser.add_argument(
+            "--data-parallel-rpc-port",
+            type=_uint16,
+            default=ServerArgs.data_parallel_rpc_port,
+            help="Port of the frontend-bound handshake ROUTER (default "
+            f"{ServerArgs.data_parallel_rpc_port}, outside the smg frontend's "
+            "derived-port band 20000..=29999). `smg serve --backend "
+            "tokenspeed --connection-mode zmq` passes an explicit port "
+            "derived from the worker's ipc:// URL instead.",
+        )
+        parser.add_argument(
+            "--zmq-engine-index",
+            type=_uint16,
+            default=ServerArgs.zmq_engine_index,
+            help="This engine's index under --zmq-msgpack; used as the two-byte "
+            "little-endian ZMQ routing identity SMG addresses it by "
+            "(0..65535).",
         )
         parser.add_argument("--ext-yaml", type=str, default=None)
         parser.add_argument(
@@ -2035,6 +2099,11 @@ class ServerArgs:
         if is_valid_ipv6_address(self.host):
             return f"http://[{self.host}]:{self.port}"
         return f"http://{self.host}:{self.port}"
+
+    def zmq_handshake_endpoint(self) -> str:
+        """The frontend handshake endpoint dialed under ``--zmq-msgpack``,
+        composed from ``--data-parallel-address``/``--data-parallel-rpc-port``."""
+        return f"tcp://{self.data_parallel_address}:{self.data_parallel_rpc_port}"
 
     def get_weight_transfer_config(self):
         """Parse ``--weight-transfer-config`` JSON into a ``WeightTransferConfig``."""

--- a/test/cli/test_serve_headless.py
+++ b/test/cli/test_serve_headless.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""``ts serve --headless`` CLI routing (engine-only, no gateway spawn)."""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+from argparse import Namespace
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(REPO_ROOT, "python"))
+
+from tokenspeed.cli._argsplit import split_headless_argv
+
+HANDSHAKE = [
+    "--data-parallel-address",
+    "127.0.0.1",
+    "--data-parallel-rpc-port",
+    "25152",
+]
+
+
+class TestSplitHeadlessArgv:
+    def test_absent_returns_none(self):
+        assert split_headless_argv(["--model", "/tmp/m"]) is None
+
+    def test_strips_flag_and_passes_server_args_verbatim(self):
+        argv = [
+            "--headless",
+            "--model",
+            "/tmp/m",
+            *HANDSHAKE,
+            "--zmq-engine-index",
+            "0",
+        ]
+        assert split_headless_argv(argv) == [
+            "--model",
+            "/tmp/m",
+            *HANDSHAKE,
+            "--zmq-engine-index",
+            "0",
+        ]
+
+    def test_flag_position_does_not_matter(self):
+        assert split_headless_argv(["--model", "/tmp/m", "--headless"]) == [
+            "--model",
+            "/tmp/m",
+        ]
+
+    def test_positional_model_left_for_server_args_parser(self):
+        # ServerArgs' own parser accepts the positional model; no rewrite here.
+        assert split_headless_argv(["/tmp/m", "--headless"]) == ["/tmp/m"]
+
+    @pytest.mark.parametrize(
+        "flag",
+        [
+            "--engine-startup-timeout",
+            "--gateway-startup-timeout",
+            "--drain-timeout",
+            "--control-port",
+        ],
+    )
+    def test_orchestrator_flags_rejected(self, flag):
+        with pytest.raises(ValueError, match="not valid with --headless"):
+            split_headless_argv(["--headless", "--model", "/tmp/m", flag, "30"])
+
+    def test_orchestrator_flag_equals_form_rejected(self):
+        with pytest.raises(ValueError, match="not valid with --headless"):
+            split_headless_argv(["--headless", "--drain-timeout=30"])
+
+
+class TestHeadlessDispatch:
+    def test_run_smg_from_args_routes_to_headless(self, monkeypatch):
+        """--headless bypasses the orchestrator (no install check, no run_smg)."""
+        from tokenspeed.cli import serve_smg
+
+        called = {}
+        monkeypatch.setattr(
+            serve_smg, "_run_headless", lambda argv: called.setdefault("argv", argv)
+        )
+
+        def fail(*a, **kw):
+            raise AssertionError("orchestrator path must not run in headless mode")
+
+        monkeypatch.setattr(serve_smg, "_check_serve_extra_installed", fail)
+        monkeypatch.setattr(serve_smg, "split_argv", fail)
+
+        serve_smg.run_smg_from_args(
+            Namespace(), ["--headless", "--model", "/tmp/m", *HANDSHAKE]
+        )
+        assert called["argv"] == ["--model", "/tmp/m", *HANDSHAKE]
+
+    def test_run_headless_calls_engine_entrypoint(self, monkeypatch):
+        """_run_headless reuses runtime.entrypoints.engine and sets the proc title."""
+        from tokenspeed.cli import serve_smg
+
+        calls = {}
+        stub_engine = types.ModuleType("tokenspeed.runtime.entrypoints.engine")
+        stub_engine.run_scheduler_headless_from_cli = lambda argv: calls.setdefault(
+            "argv", list(argv)
+        )
+        monkeypatch.setitem(
+            sys.modules, "tokenspeed.runtime.entrypoints.engine", stub_engine
+        )
+        fake_setproctitle = types.ModuleType("setproctitle")
+        fake_setproctitle.setproctitle = lambda title: calls.setdefault("title", title)
+        monkeypatch.setitem(sys.modules, "setproctitle", fake_setproctitle)
+
+        serve_smg._run_headless(["--model", "/tmp/m", *HANDSHAKE])
+        assert calls["argv"] == ["--model", "/tmp/m", *HANDSHAKE]
+        assert calls["title"] == "ts-serve-headless"
+
+    def test_default_mode_untouched(self, monkeypatch):
+        """Without --headless the orchestrator path runs as before."""
+        from tokenspeed.cli import _argsplit, serve_smg
+
+        called = {}
+        # Keep the test pure-python: the real snapshot imports the full
+        # runtime stack. --model routes via _FANOUT_FLAGS regardless.
+        monkeypatch.setattr(_argsplit, "_engine_recognized_flags", lambda: set())
+        monkeypatch.setattr(serve_smg, "print_logo", lambda: None)
+        monkeypatch.setattr(serve_smg, "_check_serve_extra_installed", lambda: None)
+        monkeypatch.setattr(serve_smg, "_prewarm_hf_tokenizer", lambda _: None)
+
+        def fail(argv):
+            raise AssertionError("headless launcher must not run in default mode")
+
+        monkeypatch.setattr(serve_smg, "_run_headless", fail)
+
+        async def fake_run_smg(**kwargs):
+            called.update(kwargs)
+            return 0
+
+        monkeypatch.setattr(serve_smg, "run_smg", fake_run_smg)
+
+        with pytest.raises(SystemExit) as exc:
+            serve_smg.run_smg_from_args(Namespace(), ["--model", "/tmp/m"])
+        assert exc.value.code == 0
+        assert called["engine_args"] == ["--model", "/tmp/m"]
+
+    def test_headless_works_bare_without_handshake_flags(self, monkeypatch):
+        """`ts serve --headless --model X` alone dials the default endpoint."""
+        from tokenspeed.cli import serve_smg
+
+        called = {}
+        monkeypatch.setattr(
+            serve_smg, "_run_headless", lambda argv: called.setdefault("argv", argv)
+        )
+        serve_smg.run_smg_from_args(Namespace(), ["--headless", "--model", "/tmp/m"])
+        assert called["argv"] == ["--model", "/tmp/m"]
+
+    def test_module_invocation_keeps_headless_in_raw_argv(self, monkeypatch):
+        """`python -m tokenspeed.cli serve --headless ...` forwards the flag.
+
+        --headless is registered on the serve subparser for --help, but the
+        orchestrator receives the raw argv, so the flag must survive parsing.
+        """
+        called = {}
+
+        def fake_smg(args, raw_argv):
+            called["raw"] = list(raw_argv)
+            called["headless_ns"] = args.headless
+
+        monkeypatch.setattr("tokenspeed.cli.serve_smg.run_smg_from_args", fake_smg)
+        monkeypatch.setattr(
+            sys, "argv", ["ts", "serve", "--headless", "--model", "/tmp/m", *HANDSHAKE]
+        )
+        from tokenspeed.cli import main
+
+        main()
+        assert called["raw"] == ["--headless", "--model", "/tmp/m", *HANDSHAKE]
+        assert called["headless_ns"] is True
+
+
+class TestHandshakeEndpointDefaults:
+    """The handshake host/port pair is defaulted, never required."""
+
+    def test_server_args_defaults_and_composition(self):
+        # importorskip(exc_type=ImportError): pulls the full runtime stack,
+        # unimportable in an env with drifted kernel wheels.
+        server_args = pytest.importorskip(
+            "tokenspeed.runtime.utils.server_args", exc_type=ImportError
+        )
+
+        fields = server_args.ServerArgs.__dataclass_fields__
+        assert fields["data_parallel_address"].default == "127.0.0.1"
+        port = fields["data_parallel_rpc_port"].default
+        assert port == 30500
+        # Outside the 20000-29999 range a frontend may use for derived
+        # per-worker handshake ports.
+        assert not 20000 <= port <= 29999
+
+        composed = server_args.ServerArgs.zmq_handshake_endpoint(
+            types.SimpleNamespace(
+                data_parallel_address="127.0.0.1", data_parallel_rpc_port=30500
+            )
+        )
+        assert composed == "tcp://127.0.0.1:30500"
+
+    @pytest.mark.parametrize(
+        "flag, value",
+        [
+            ("--data-parallel-rpc-port", "65536"),  # above u16
+            ("--data-parallel-rpc-port", "-1"),
+            ("--data-parallel-address", ""),
+        ],
+    )
+    def test_parse_rejects_invalid_handshake_values(self, flag, value, capsys):
+        import argparse
+
+        server_args = pytest.importorskip(
+            "tokenspeed.runtime.utils.server_args", exc_type=ImportError
+        )
+
+        parser = argparse.ArgumentParser(allow_abbrev=False)
+        server_args.ServerArgs.add_cli_args(parser)
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--model", "/tmp/m", flag, value])
+        capsys.readouterr()  # swallow argparse usage noise

--- a/test/runtime/distributed/test_epd_encode.py
+++ b/test/runtime/distributed/test_epd_encode.py
@@ -99,7 +99,13 @@ def _worker(max_tokens=10_000, max_items=99, cap_bytes=10**6):
 
 
 def _req(rid, items, room=0):
-    return EncodeRequest(rid, "h", 1, room, items)
+    return EncodeRequest(
+        request_id=rid,
+        bootstrap_host="h",
+        bootstrap_port=1,
+        bootstrap_room=room,
+        items=items,
+    )
 
 
 def test_miss_runs_tower_and_caches():

--- a/test/runtime/test_io_struct_codec.py
+++ b/test/runtime/test_io_struct_codec.py
@@ -1,0 +1,643 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Engine-IPC msgpack codec tests.
+
+Covers the tagged-union roundtrip for every migrated message family, the
+tensor scheme (inline ext raw views vs out-of-band aux frames), the typed
+multimodal payload, the SamplingParams struct semantics, and the pickle
+fallback flag on the socket wrappers.
+"""
+
+from __future__ import annotations
+
+import msgspec
+import pytest
+import zmq
+
+from tokenspeed.runtime.engine import io_struct
+from tokenspeed.runtime.engine.io_struct import (
+    CUSTOM_TYPE_RAW_VIEW,
+    AbortReq,
+    AsyncIpcReceiver,
+    BatchEmbeddingOut,
+    BatchStrOut,
+    BatchTokenIDOut,
+    BatchTokenIDOutSlim,
+    BlockReqInput,
+    BlockReqType,
+    CloseSessionReqInput,
+    ConfigureLoggingReq,
+    DestroyWeightsUpdateGroupReqInput,
+    DestroyWeightsUpdateGroupReqOutput,
+    ExpertDistributionReq,
+    ExpertDistributionReqOutput,
+    ExpertDistributionReqType,
+    FlushCacheReqInput,
+    FlushCacheReqOutput,
+    GetInternalStateReq,
+    GetInternalStateReqOutput,
+    GetLoadReqInput,
+    GetLoadReqOutput,
+    GetWeightsByNameReqInput,
+    GetWeightsByNameReqOutput,
+    HealthCheckOutput,
+    InitWeightsUpdateGroupReqInput,
+    InitWeightsUpdateGroupReqOutput,
+    IpcReceiver,
+    IpcSender,
+    IsSchedulerPausedReqInput,
+    IsSchedulerPausedReqOutput,
+    IsSleepingReqInput,
+    IsSleepingReqOutput,
+    MsgpackDecoder,
+    MsgpackEncoder,
+    OpenSessionReqInput,
+    OpenSessionReqOutput,
+    PauseSchedulerReqInput,
+    PauseSchedulerReqOutput,
+    PickleWrapper,
+    ProfileReq,
+    ProfileReqOutput,
+    ProfileReqType,
+    ReleaseMemoryOccupationReqInput,
+    ReleaseMemoryOccupationReqOutput,
+    ResumeMemoryOccupationReqInput,
+    ResumeMemoryOccupationReqOutput,
+    ResumeSchedulerReqInput,
+    ResumeSchedulerReqOutput,
+    RpcReqInput,
+    RpcReqOutput,
+    SessionParams,
+    SetInternalStateReq,
+    SetInternalStateReqOutput,
+    TokenizedEmbeddingReqInput,
+    TokenizedGenerateReqInput,
+    UpdateWeightFromDiskReqInput,
+    UpdateWeightFromDiskReqOutput,
+    UpdateWeightsFromDistributedReqInput,
+    UpdateWeightsFromDistributedReqOutput,
+    UpdateWeightsFromTensorReqInput,
+    UpdateWeightsFromTensorReqOutput,
+    WatchLoadUpdateReq,
+    ipc_message_union,
+)
+from tokenspeed.runtime.sampling.sampling_params import (
+    _TOP_K_DISABLED,
+    SamplingParams,
+)
+
+torch = pytest.importorskip("torch")
+
+from tokenspeed.runtime.multimodal.inputs import (  # noqa: E402
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from tokenspeed.runtime.multimodal.shm_transport import ShmTensorHandle  # noqa: E402
+
+
+def _roundtrip(obj):
+    enc = MsgpackEncoder()
+    dec = MsgpackDecoder(ipc_message_union())
+    return dec.decode(enc.encode(obj))
+
+
+def _batch_token_id_out(**overrides) -> BatchTokenIDOut:
+    fields = dict(
+        rids=["a", "b"],
+        finished_reasons=[None, {"type": "stop", "matched": 7}],
+        decoded_texts=["", "x"],
+        decode_ids=[[1, 2], [3]],
+        read_offsets=[0, 0],
+        output_ids=[[1, 2], [3]],
+        output_multi_ids=[[], []],
+        skip_special_tokens=[True, True],
+        spaces_between_special_tokens=[True, False],
+        no_stop_trim=[False, False],
+        prompt_tokens=[4, 5],
+        completion_tokens=[2, 1],
+        cached_tokens=[0, 3],
+        spec_verify_ct=[0, 0],
+        input_token_logprobs_val=[],
+        input_token_logprobs_idx=[],
+        output_token_logprobs_val=[[-0.5, -0.25], []],
+        output_token_logprobs_idx=[[1, 2], []],
+        input_top_logprobs_val=[],
+        input_top_logprobs_idx=[],
+        output_top_logprobs_val=[],
+        output_top_logprobs_idx=[],
+        input_token_ids_logprobs_val=[],
+        input_token_ids_logprobs_idx=[],
+        output_token_ids_logprobs_val=[],
+        output_token_ids_logprobs_idx=[],
+        output_hidden_states=[],
+        batch_accept_draft_tokens=[],
+        output_extra_infos=[{"decode_prefix_len": 4}, {}],
+        generated_time=12.5,
+    )
+    fields.update(overrides)
+    return BatchTokenIDOut(**fields)
+
+
+# --------------------------------------------------------------------------
+# Tagged roundtrip: one representative instance per message family
+# --------------------------------------------------------------------------
+
+_MESSAGES = [
+    TokenizedGenerateReqInput(
+        rid="r", input_ids=[1, 2], sampling_params=SamplingParams(), stream=True
+    ),
+    TokenizedEmbeddingReqInput(
+        rid="r", input_text="t", input_ids=[1], sampling_params=SamplingParams()
+    ),
+    AbortReq(rid="r"),
+    FlushCacheReqInput(),
+    FlushCacheReqOutput(success=True),
+    PauseSchedulerReqInput(mode="wait"),
+    PauseSchedulerReqOutput(success=True, message="ok"),
+    ResumeSchedulerReqInput(),
+    ResumeSchedulerReqOutput(success=True),
+    IsSchedulerPausedReqInput(),
+    IsSchedulerPausedReqOutput(is_paused=False),
+    UpdateWeightFromDiskReqInput(model_path="/m"),
+    UpdateWeightFromDiskReqOutput(success=True, message="m", num_paused_requests=2),
+    UpdateWeightsFromDistributedReqInput(
+        names=["w"], dtype_names=["bfloat16"], shapes=[[2, 2]]
+    ),
+    UpdateWeightsFromDistributedReqOutput(success=True, message=""),
+    UpdateWeightsFromTensorReqInput(
+        serialized_named_tensors=[b"\x00\x01"], load_format=None, flush_cache=True
+    ),
+    UpdateWeightsFromTensorReqOutput(success=True, message=""),
+    InitWeightsUpdateGroupReqInput(
+        master_address="h", master_port=1, rank_offset=0, world_size=2
+    ),
+    InitWeightsUpdateGroupReqOutput(success=True, message=""),
+    DestroyWeightsUpdateGroupReqInput(),
+    DestroyWeightsUpdateGroupReqOutput(success=True, message=""),
+    GetWeightsByNameReqInput(name="w"),
+    GetWeightsByNameReqOutput(parameter=[1.0, 2.0]),
+    ReleaseMemoryOccupationReqInput(tags=["weights"]),
+    ReleaseMemoryOccupationReqOutput(),
+    ResumeMemoryOccupationReqInput(),
+    ResumeMemoryOccupationReqOutput(),
+    IsSleepingReqInput(),
+    IsSleepingReqOutput(is_sleeping=False),
+    GetInternalStateReq(),
+    GetInternalStateReqOutput(internal_state={"k": 1}),
+    SetInternalStateReq(server_args={"x": 2}),
+    SetInternalStateReqOutput(updated=False, server_args={}),
+    ExpertDistributionReq(action=ExpertDistributionReqType.DUMP_RECORD),
+    ExpertDistributionReqOutput(),
+    ProfileReq(type=ProfileReqType.START_PROFILE, activities=["CPU"]),
+    ProfileReqOutput(success=True, message="ok"),
+    ConfigureLoggingReq(log_requests=True),
+    OpenSessionReqInput(capacity_of_str_len=8),
+    CloseSessionReqInput(session_id="s"),
+    OpenSessionReqOutput(session_id="s", success=True),
+    HealthCheckOutput(),
+    RpcReqInput(method="save", parameters={"p": 1}),
+    RpcReqOutput(success=True, message=""),
+    GetLoadReqInput(),
+    GetLoadReqOutput(dp_rank=1, num_reqs=2, num_waiting_reqs=1, num_pages=3),
+    WatchLoadUpdateReq(loads=[GetLoadReqOutput(dp_rank=0, num_reqs=5)]),
+    BlockReqInput(type=BlockReqType.UNBLOCK),
+    _batch_token_id_out(),
+    BatchStrOut(
+        rids=["a"],
+        finished_reasons=[{"type": "length"}],
+        output_strs=["hi"],
+        output_ids=[1],
+        prompt_tokens=[1],
+        completion_tokens=[1],
+        cached_tokens=[0],
+        spec_verify_ct=[0],
+        input_token_logprobs_val=[],
+        input_token_logprobs_idx=[],
+        output_token_logprobs_val=[],
+        output_token_logprobs_idx=[],
+        input_top_logprobs_val=[],
+        input_top_logprobs_idx=[],
+        output_top_logprobs_val=[],
+        output_top_logprobs_idx=[],
+        input_token_ids_logprobs_val=[],
+        input_token_ids_logprobs_idx=[],
+        output_token_ids_logprobs_val=[],
+        output_token_ids_logprobs_idx=[],
+        output_hidden_states=[],
+        batch_accept_draft_tokens=[],
+        output_extra_infos=[{}],
+        generated_time=1.0,
+    ),
+    BatchEmbeddingOut(
+        rids=["a"], finished_reasons=[None], embeddings=[[0.5, 0.5]], prompt_tokens=[3]
+    ),
+    PickleWrapper.wrap({"arbitrary": object}),
+]
+
+
+@pytest.mark.parametrize("msg", _MESSAGES, ids=lambda m: type(m).__name__)
+def test_tagged_union_roundtrip(msg):
+    rt = _roundtrip(msg)
+    assert type(rt) is type(msg)
+    # Structs with tensor-free fields must roundtrip exactly.
+    if type(msg) is not PickleWrapper:
+        assert msgspec.structs.asdict(rt).keys() == msgspec.structs.asdict(msg).keys()
+
+
+def test_every_message_tag_is_the_class_name():
+    enc = MsgpackEncoder()
+    for msg in _MESSAGES:
+        raw = msgspec.msgpack.decode(enc.encode(msg)[0])
+        assert raw[0] == type(msg).__name__
+
+
+def test_batch_token_id_out_field_values_roundtrip():
+    rt = _roundtrip(_batch_token_id_out())
+    assert rt.rids == ["a", "b"]
+    assert rt.finished_reasons == [None, {"type": "stop", "matched": 7}]
+    assert rt.output_ids == [[1, 2], [3]]
+    assert rt.output_token_logprobs_val[0] == [
+        pytest.approx(-0.5),
+        pytest.approx(-0.25),
+    ]
+    assert rt.output_extra_infos == [{"decode_prefix_len": 4}, {}]
+    assert rt.generated_time == pytest.approx(12.5)
+
+
+def test_accept_draft_tokens_none_mid_stream_roundtrips():
+    # Speculative decoding reports acceptance only when a request finishes;
+    # mid-stream entries are None and must survive the typed wire.
+    rt = _roundtrip(_batch_token_id_out(batch_accept_draft_tokens=[None, 2.5]))
+    assert rt.batch_accept_draft_tokens == [None, pytest.approx(2.5)]
+
+
+def test_pickle_wrapper_roundtrip():
+    rt = _roundtrip(PickleWrapper.wrap({"a": (1, 2)}))
+    assert rt.unwrap() == {"a": (1, 2)}
+    assert PickleWrapper.wrap(None) is None
+
+
+def test_session_params_nested():
+    req = TokenizedGenerateReqInput(
+        rid="r",
+        input_ids=[1],
+        sampling_params=SamplingParams(),
+        session_params=SessionParams(id="s", offset=3),
+    )
+    rt = _roundtrip(req)
+    assert rt.session_params.id == "s"
+    assert rt.session_params.offset == 3
+
+
+def test_opaque_object_is_rejected_loudly():
+    class Opaque:
+        pass
+
+    req = RpcReqInput(method="m", parameters={"bad": Opaque()})
+    with pytest.raises(TypeError, match="PickleWrapper"):
+        MsgpackEncoder().encode(req)
+
+
+# --------------------------------------------------------------------------
+# Tensor scheme: inline ext raw views vs out-of-band aux frames
+# --------------------------------------------------------------------------
+
+
+def _mm_request(feature: "torch.Tensor") -> TokenizedGenerateReqInput:
+    item = MultimodalDataItem(
+        modality=Modality.IMAGE,
+        hash=0xDEADBEEF,
+        offsets=[(2, 5)],
+        feature=feature,
+        model_specific_data={"grid_thw": torch.tensor([[1, 2, 2]])},
+    )
+    return TokenizedGenerateReqInput(
+        rid="mm",
+        input_ids=[1, 2, 3],
+        sampling_params=SamplingParams(),
+        multimodal_inputs=MultimodalInputs(mm_items=[item], im_token_id=9),
+    )
+
+
+def test_small_tensor_is_inlined_as_raw_view_ext():
+    req = _mm_request(torch.arange(4, dtype=torch.float32))
+    frames = MsgpackEncoder().encode(req)
+    assert len(frames) == 1  # everything inline
+
+    # The tensor slot is (dtype, shape, Ext(CUSTOM_TYPE_RAW_VIEW, bytes)).
+    raw = msgspec.msgpack.decode(frames[0], ext_hook=lambda code, data: (code, data))
+    mm = raw[-2]  # multimodal_inputs (validation_error is last)
+    feature_slot = mm[0][0][4]
+    dtype, shape, data = feature_slot
+    assert dtype == "float32"
+    assert shape == [4]
+    assert data[0] == CUSTOM_TYPE_RAW_VIEW
+    assert bytes(data[1]) == torch.arange(4, dtype=torch.float32).numpy().tobytes()
+
+
+def test_large_tensor_rides_out_of_band_aux_frame():
+    feature = torch.arange(1024, dtype=torch.bfloat16).reshape(4, 256)
+    req = _mm_request(feature)
+    frames = MsgpackEncoder().encode(req)
+    assert len(frames) == 2  # primary + one aux frame for the 2 KiB tensor
+
+    raw = msgspec.msgpack.decode(frames[0], ext_hook=lambda code, data: (code, data))
+    dtype, shape, data = raw[-2][0][0][4]
+    assert dtype == "bfloat16"
+    assert shape == [4, 256]
+    assert data == 1  # one-based aux frame index (frame 0 = primary buffer)
+
+    rt = MsgpackDecoder(ipc_message_union()).decode(frames)
+    item = rt.multimodal_inputs.mm_items[0]
+    assert item.feature.dtype == torch.bfloat16
+    assert torch.equal(item.feature, feature)
+    assert torch.equal(item.grid_thw, torch.tensor([[1, 2, 2]]))
+    assert item.offsets == [(2, 5)]
+    assert item.hash == 0xDEADBEEF
+
+
+def test_mm_struct_field_order_is_pinned():
+    """MM structs are untagged positional arrays nested inside the tokenized
+    request; their declaration order is cross-language wire contract."""
+    assert [f.name for f in msgspec.structs.fields(MultimodalDataItem)] == [
+        "modality",
+        "hash",
+        "pad_value",
+        "offsets",
+        "feature",
+        "feature_shm",
+        "model_specific_data",
+        "encoded",
+        "encoded_deepstack",
+        "encode_handshake",
+    ]
+    assert [f.name for f in msgspec.structs.fields(MultimodalInputs)] == [
+        "mm_items",
+        "im_token_id",
+        "video_token_id",
+        "mrope_positions",
+        "mrope_position_delta",
+        "mrope_position_delta_scalar",
+        "mrope_position_delta_repeated_cache",
+    ]
+
+
+def test_shm_handle_rides_typed_and_consumable():
+    tensor = torch.full((8,), 2.0, dtype=torch.float16)
+    handle = ShmTensorHandle.publish(tensor)
+    item = MultimodalDataItem(modality=Modality.IMAGE, hash=1, feature_shm=handle)
+    req = TokenizedGenerateReqInput(
+        rid="shm",
+        input_ids=[1],
+        sampling_params=SamplingParams(),
+        multimodal_inputs=MultimodalInputs(mm_items=[item]),
+    )
+    rt = _roundtrip(req)
+    rt_handle = rt.multimodal_inputs.mm_items[0].feature_shm
+    assert rt_handle.shm_name == handle.shm_name
+    assert rt_handle.dtype == torch.float16
+    assert tuple(rt_handle.shape) == (8,)
+    rt_handle.attach()
+    assert torch.equal(rt_handle.consume(), tensor)
+
+
+def test_mm_item_reslots_handle_passed_as_feature():
+    # Compatibility: constructors that predate the feature/feature_shm split
+    # may pass a SHM handle via ``feature``.
+    handle = ShmTensorHandle.publish(torch.ones(4))
+    try:
+        item = MultimodalDataItem(modality=Modality.IMAGE, feature=handle)
+        assert item.feature is None
+        assert item.feature_shm is handle
+    finally:
+        handle.release()
+
+
+def test_mrope_tensors_roundtrip():
+    mm = MultimodalInputs(
+        mm_items=[MultimodalDataItem(modality=Modality.IMAGE, hash=1)],
+        mrope_positions=torch.arange(9, dtype=torch.int64).reshape(3, 3),
+        mrope_position_delta_scalar=-2,
+    )
+    req = TokenizedGenerateReqInput(
+        rid="mr", input_ids=[1], sampling_params=SamplingParams(), multimodal_inputs=mm
+    )
+    rt = _roundtrip(req)
+    assert torch.equal(rt.multimodal_inputs.mrope_positions, mm.mrope_positions)
+    assert rt.multimodal_inputs.mrope_position_delta_scalar == -2
+
+
+# --------------------------------------------------------------------------
+# SamplingParams struct semantics
+# --------------------------------------------------------------------------
+
+
+def test_sampling_params_post_init_special_cases():
+    greedy = SamplingParams(temperature=0.0)
+    assert greedy.temperature == 1.0 and greedy.top_k == 1
+
+    disabled = SamplingParams(top_k=-1)
+    assert disabled.top_k == _TOP_K_DISABLED
+
+    listy = SamplingParams(stop="END", stop_token_ids=[3, 3, 5])
+    assert listy.stop_strs == "END"
+    assert listy.stop_token_ids == {3, 5}
+
+
+def test_sampling_params_decode_preserves_normalized_state():
+    # normalize() runs on the sender; decode must not re-derive stop_strs
+    # from the raw ``stop`` alias and lose the resolved fields.
+    sp = SamplingParams(stop=["END"], seed=None)
+    sp.resolve_seed("rid-1")
+    sp.normalize(tokenizer=None)
+    assert sp.is_normalized
+
+    rt = msgspec.msgpack.Decoder(SamplingParams).decode(
+        msgspec.msgpack.Encoder().encode(sp)
+    )
+    assert rt.stop_strs == ["END"]
+    assert rt.stop_str_max_len == 3
+    assert rt.seed == sp.seed
+    assert rt.is_normalized
+
+
+def test_sampling_params_dict_construction_accepts_n():
+    # OpenAI-compat serving layers forward "n" inside sampling params dicts.
+    sp = SamplingParams(**{"temperature": 0.5, "n": 4})
+    assert sp.n == 4
+
+
+# --------------------------------------------------------------------------
+# Socket wrappers + pickle fallback flag
+# --------------------------------------------------------------------------
+
+
+class _LoopbackSocket:
+    """Minimal in-memory socket honoring the multipart + pyobj surfaces."""
+
+    def __init__(self):
+        self.queue = []
+        self.pickled = 0
+
+    def send(self, data, flags=0):
+        self.queue.append(bytes(data))
+
+    def send_multipart(self, frames, flags=0, copy=True):
+        self.queue.append([bytes(f) for f in frames])
+
+    def recv_multipart(self, flags=0):
+        if not self.queue:
+            raise zmq.Again()
+        return self.queue.pop(0)
+
+    def send_pyobj(self, obj, flags=0):
+        import pickle
+
+        self.pickled += 1
+        self.queue.append(pickle.dumps(obj))
+
+    def recv_pyobj(self, flags=0):
+        import pickle
+
+        self.pickled += 1
+        return pickle.loads(self.queue.pop(0))
+
+    def close(self, linger=None):
+        pass
+
+
+def test_ipc_sender_receiver_msgpack_loopback():
+    sock = _LoopbackSocket()
+    sender, receiver = IpcSender(sock), IpcReceiver(sock)
+    sender.send_pyobj(AbortReq(rid="z"))
+    rt = receiver.recv_pyobj()
+    assert isinstance(rt, AbortReq) and rt.rid == "z"
+    assert sock.pickled == 0
+    with pytest.raises(zmq.Again):
+        receiver.recv_pyobj(zmq.NOBLOCK)
+
+
+def test_ipc_wrappers_pickle_fallback_flag(monkeypatch):
+    monkeypatch.setattr(io_struct, "USE_PICKLE_IPC", True)
+    sock = _LoopbackSocket()
+    IpcSender(sock).send_pyobj(AbortReq(rid="p"))
+    rt = IpcReceiver(sock).recv_pyobj()
+    assert isinstance(rt, AbortReq) and rt.rid == "p"
+    assert sock.pickled == 2
+
+
+def test_async_ipc_receiver_decodes_multipart():
+    import asyncio
+
+    class _AsyncSock(_LoopbackSocket):
+        async def recv_multipart(self, flags=0):
+            return self.queue.pop(0)
+
+    sock = _AsyncSock()
+    IpcSender(sock).send_pyobj(GetLoadReqOutput(dp_rank=3))
+    rt = asyncio.run(AsyncIpcReceiver(sock).recv_pyobj())
+    assert isinstance(rt, GetLoadReqOutput) and rt.dp_rank == 3
+
+
+def test_encode_request_joins_the_tagged_union():
+    # Defined in the EPD module, registered by subclassing BaseReq; a decoder
+    # built after the import must accept it over the shared channel.
+    from tokenspeed.runtime.epd.encode_worker import EncodeRequest
+
+    req = EncodeRequest(
+        request_id="e1",
+        bootstrap_host="h",
+        bootstrap_port=1,
+        bootstrap_room=2,
+        items=[
+            MultimodalDataItem(
+                modality=Modality.IMAGE, hash=5, feature=torch.ones(2, 2)
+            )
+        ],
+    )
+    rt = _roundtrip(req)
+    assert type(rt) is EncodeRequest
+    assert rt.request_id == "e1"
+    assert torch.equal(rt.items[0].feature, torch.ones(2, 2))
+
+
+def _gateway_encode_request():
+    """The real struct crossing the gateway->encode ZMQ hop, with a feature
+    tensor large enough to exercise the out-of-band aux-frame path."""
+    from tokenspeed.runtime.epd.encode_worker import EncodeRequest
+
+    return EncodeRequest(
+        request_id="e2",
+        bootstrap_host="h",
+        bootstrap_port=7,
+        bootstrap_room=11,
+        items=[
+            MultimodalDataItem(
+                modality=Modality.IMAGE,
+                hash=9,
+                pad_value=3,
+                offsets=[(0, 4)],
+                feature=torch.arange(128 * 128, dtype=torch.float32).reshape(128, 128),
+            )
+        ],
+    )
+
+
+def test_prepickled_send_transcodes_onto_the_msgpack_wire():
+    # Gateway->encode hop regression: the encode servicer serializes the
+    # EncodeRequest off-thread (pickle) and pushes the raw bytes via ``send``,
+    # while the encode loop decodes with the tagged-union msgpack decoder.
+    # Without transcoding, pickle's PROTO byte (0x80) reads as a msgpack map
+    # and the receiver dies with "Expected `array`, got `object`".
+    import pickle
+
+    from tokenspeed.runtime.epd.encode_worker import EncodeRequest
+
+    req = _gateway_encode_request()
+    sock = _LoopbackSocket()
+    IpcSender(sock).send(pickle.dumps(req, protocol=pickle.DEFAULT_PROTOCOL))
+    rt = IpcReceiver(sock).recv_pyobj()
+    assert type(rt) is EncodeRequest
+    assert (rt.request_id, rt.bootstrap_host, rt.bootstrap_port, rt.bootstrap_room) == (
+        "e2",
+        "h",
+        7,
+        11,
+    )
+    item = rt.items[0]
+    assert item.modality == Modality.IMAGE
+    assert (item.hash, item.pad_value, item.offsets) == (9, 3, [(0, 4)])
+    assert torch.equal(item.feature, req.items[0].feature)
+    assert sock.pickled == 0  # the wire itself stayed msgpack
+
+
+def test_prepickled_send_passes_through_under_pickle_flag(monkeypatch):
+    import pickle
+
+    from tokenspeed.runtime.epd.encode_worker import EncodeRequest
+
+    monkeypatch.setattr(io_struct, "USE_PICKLE_IPC", True)
+    req = _gateway_encode_request()
+    sock = _LoopbackSocket()
+    IpcSender(sock).send(pickle.dumps(req, protocol=pickle.DEFAULT_PROTOCOL))
+    rt = IpcReceiver(sock).recv_pyobj()
+    assert type(rt) is EncodeRequest and rt.bootstrap_room == 11

--- a/test/runtime/test_zmq_msgpack.py
+++ b/test/runtime/test_zmq_msgpack.py
@@ -1,0 +1,632 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""msgpack ZMQ wire + transport tests for the direct frontend <-> scheduler path.
+
+Pure CPU: exercises the ``zmq_wire`` codec (native tagged request/output
+structs, map-encoded handshake structs, request-type dispatch) and a full
+loopback of ``zmq_msgpack.connect_msgpack_engine`` against a hand-rolled
+frontend (ROUTER handshake/input + PULL output), with no model or GPU.
+"""
+
+from __future__ import annotations
+
+import struct
+import tempfile
+import threading
+from pathlib import Path
+
+import msgspec
+import pytest
+import zmq
+
+from tokenspeed.runtime.engine import zmq_msgpack, zmq_wire
+from tokenspeed.runtime.engine.io_struct import (
+    AbortReq,
+    BatchTokenIDOut,
+    BatchTokenIDOutSlim,
+    MsgpackEncoder,
+    TokenizedGenerateReqInput,
+)
+from tokenspeed.runtime.engine.request_types import FINISH_ABORT, FINISH_LENGTH
+from tokenspeed.runtime.sampling.sampling_params import SamplingParams
+
+_ENCODER = MsgpackEncoder()
+
+
+def _make_batch_out(**overrides) -> BatchTokenIDOut:
+    """A minimal single-request BatchTokenIDOut as stream_output builds it."""
+    fields = dict(
+        rids=["r1"],
+        finished_reasons=[FINISH_LENGTH(length=2).to_json()],
+        decoded_texts=[""],
+        decode_ids=[[10, 11]],
+        read_offsets=[0],
+        output_ids=[[10, 11]],
+        output_multi_ids=[[]],
+        skip_special_tokens=[True],
+        spaces_between_special_tokens=[True],
+        no_stop_trim=[False],
+        prompt_tokens=[3],
+        completion_tokens=[2],
+        cached_tokens=[1],
+        spec_verify_ct=[0],
+        input_token_logprobs_val=[],
+        input_token_logprobs_idx=[],
+        # Per-request list[list], parallel to rids; empty inner list when
+        # logprobs are off (OutputProcesser builds it this way).
+        output_token_logprobs_val=[[]],
+        output_token_logprobs_idx=[[]],
+        input_top_logprobs_val=[],
+        input_top_logprobs_idx=[],
+        output_top_logprobs_val=[],
+        output_top_logprobs_idx=[],
+        input_token_ids_logprobs_val=[],
+        input_token_ids_logprobs_idx=[],
+        output_token_ids_logprobs_val=[],
+        output_token_ids_logprobs_idx=[],
+        output_hidden_states=[],
+        batch_accept_draft_tokens=[],
+        output_extra_infos=[{}],
+        generated_time=0.0,
+    )
+    fields.update(overrides)
+    return BatchTokenIDOut(**fields)
+
+
+def _make_request(rid: str = "r1", **overrides) -> TokenizedGenerateReqInput:
+    fields = dict(
+        rid=rid,
+        input_ids=[1, 2, 3],
+        sampling_params=SamplingParams(),
+        stream=True,
+    )
+    fields.update(overrides)
+    return TokenizedGenerateReqInput(**fields)
+
+
+def _encode_payload(obj) -> bytes:
+    frames = _ENCODER.encode(obj)
+    assert len(frames) == 1, "text requests must not need aux frames"
+    return frames[0]
+
+
+# --------------------------------------------------------------------------
+# Codec
+# --------------------------------------------------------------------------
+
+
+def test_generate_request_roundtrip():
+    sp = SamplingParams(
+        temperature=0.7, max_new_tokens=16, stop_token_ids=[2], seed=1234
+    )
+    req = _make_request(sampling_params=sp, return_logprob=True)
+
+    [io] = zmq_wire.decode_request_frames([zmq_wire.REQ_TYPE_ADD, _encode_payload(req)])
+    assert io.rid == "r1"
+    assert io.input_ids == [1, 2, 3]
+    assert io.return_logprob is True
+    assert io.stream is True
+    assert io.sampling_params.temperature == pytest.approx(0.7)
+    assert io.sampling_params.max_new_tokens == 16
+    assert io.sampling_params.stop_token_ids == {2}
+    assert io.sampling_params.seed == 1234
+
+
+def test_decode_resolves_seed_and_normalizes():
+    # The pickle path's input processor runs resolve_seed + normalize; the
+    # msgpack path must do the same after decode. Pin the side effects:
+    # a None seed derives deterministically from crc32(rid) (rank-agreement),
+    # and normalize fills the scheduler-required stop-string defaults.
+    import zlib
+
+    req = _make_request()
+    [io] = zmq_wire.decode_request_frames([zmq_wire.REQ_TYPE_ADD, _encode_payload(req)])
+    assert io.sampling_params.seed == zlib.crc32(b"r1") & 0xFFFFFFFF
+    assert io.sampling_params.stop_strs == []
+    assert io.sampling_params.stop_str_max_len == 0
+    assert io.sampling_params.is_normalized is True
+
+
+def test_decode_marks_parallel_sampling_for_abort():
+    # Belt-and-braces with the frontend, which already rejects n > 1. Marked
+    # via validation_error (terminal abort) rather than raised, so a skewed
+    # frontend gets a terminated stream instead of a dropped message.
+    req = _make_request(sampling_params=SamplingParams(n=2))
+    [io] = zmq_wire.decode_request_frames([zmq_wire.REQ_TYPE_ADD, _encode_payload(req)])
+    assert io.validation_error is not None
+    assert "n=2" in io.validation_error
+
+
+def test_generate_request_is_tagged_positional_tuple():
+    """The wire form is ``[tag, fields...]`` — the frontend's codec depends on
+    the tag name, the arity, and the field order. Pin all three."""
+    req = _make_request(rid="x", input_ids=[9])
+    raw = msgspec.msgpack.decode(_encode_payload(req))
+    assert isinstance(raw, list)
+    assert raw[0] == "TokenizedGenerateReqInput"
+    assert len(raw) == 24  # tag + 23 fields
+    assert raw[1] == "x"  # rid
+    assert raw[2] is None  # http_worker_ipc
+    assert raw[3] is None  # input_text
+    assert raw[4] == [9]  # input_ids
+    assert isinstance(raw[5], list) and len(raw[5]) == 29  # SamplingParams
+    assert raw[6] is False  # return_logprob
+    assert raw[10] is True  # stream
+
+
+def test_sampling_params_wire_order():
+    """SamplingParams rides nested as an UNtagged positional array; its
+    declaration order is cross-language wire contract."""
+    names = [f.name for f in msgspec.structs.fields(SamplingParams)]
+    assert names == [
+        "max_new_tokens",
+        "stop",
+        "stop_token_ids",
+        "temperature",
+        "top_p",
+        "top_k",
+        "min_p",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "min_new_tokens",
+        "json_schema",
+        "regex",
+        "ebnf",
+        "structural_tag",
+        "ignore_eos",
+        "skip_special_tokens",
+        "spaces_between_special_tokens",
+        "no_stop_trim",
+        "thinking_budget",
+        "custom_params",
+        "stream_interval",
+        "logit_bias",
+        "seed",
+        "logprobs",
+        "n",
+        "stop_strs",
+        "stop_str_max_len",
+        "is_normalized",
+    ]
+
+
+def test_generate_request_prefix_decode():
+    """The frontend may omit trailing default fields: an 11-element array
+    (tag through ``stream``) must decode with the rest defaulted."""
+    sp_wire = msgspec.msgpack.decode(msgspec.msgpack.encode(SamplingParams()))
+    raw = msgspec.msgpack.encode(
+        [
+            "TokenizedGenerateReqInput",
+            "p1",  # rid
+            None,  # http_worker_ipc
+            None,  # input_text
+            [5, 6],  # input_ids
+            sp_wire,  # sampling_params
+            False,  # return_logprob
+            -1,  # logprob_start_len
+            0,  # top_logprobs_num
+            None,  # token_ids_logprob
+            True,  # stream
+        ]
+    )
+    [io] = zmq_wire.decode_request_frames([zmq_wire.REQ_TYPE_ADD, raw])
+    assert io.rid == "p1"
+    assert io.input_ids == [5, 6]
+    assert io.stream is True
+    assert io.multimodal_inputs is None
+    assert io.validation_error is None
+
+
+def test_slim_out_from_full_roundtrip():
+    # Logprobs off: the two logprob columns stay non-ragged (one empty inner
+    # list per request).
+    out = _make_batch_out()
+    slim = BatchTokenIDOutSlim.from_full(out)
+    rt = msgspec.msgpack.Decoder(BatchTokenIDOutSlim).decode(_encode_payload(slim))
+    assert rt.rids == ["r1"]
+    assert rt.output_ids == [[10, 11]]
+    assert rt.finished_reasons == ["length"]
+    assert rt.prompt_tokens == [3]
+    assert rt.completion_tokens == [2]
+    assert rt.cached_tokens == [1]
+    assert rt.output_token_logprobs_val == [[]]
+    assert rt.output_token_logprobs_idx == [[]]
+
+
+def test_slim_out_sources_output_ids_not_the_detok_window():
+    # ``decode_ids`` on the io_struct is the incremental-detokenization window,
+    # which starts at the prompt tail for context; ``output_ids`` is the
+    # not-yet-sent slice of generated ids. The wire must carry the latter, or
+    # prompt tokens leak into the frontend's output.
+    out = _make_batch_out(
+        decode_ids=[[7, 8, 9, 10, 11]],  # detok window: prompt tail + output
+        output_ids=[[10, 11]],  # newly generated only
+    )
+    slim = BatchTokenIDOutSlim.from_full(out)
+    assert slim.output_ids == [[10, 11]]
+
+
+def test_slim_out_output_ids_none_is_rejected():
+    # Substituting empty lists while completion_tokens advances would silently
+    # lose tokens on the frontend; from_full must fail loud instead.
+    out = _make_batch_out(output_ids=None)
+    with pytest.raises(ValueError, match="output_ids"):
+        BatchTokenIDOutSlim.from_full(out)
+
+
+def test_slim_out_carries_logprob_columns():
+    # Logprobs on: one value/token-id per newly-decoded token, parallel to rids.
+    out = _make_batch_out(
+        output_token_logprobs_val=[[-0.5, -1.25]],
+        output_token_logprobs_idx=[[10, 11]],
+    )
+    slim = BatchTokenIDOutSlim.from_full(out)
+    rt = msgspec.msgpack.Decoder(BatchTokenIDOutSlim).decode(_encode_payload(slim))
+    assert rt.output_token_logprobs_val == [[pytest.approx(-0.5), pytest.approx(-1.25)]]
+    assert rt.output_token_logprobs_idx == [[10, 11]]
+
+
+def test_slim_out_is_tagged_positional_tuple():
+    """The wire form must be a 9-element tagged array (the frontend's codec
+    depends on the tag and column order)."""
+    out = _make_batch_out(
+        output_token_logprobs_val=[[-0.5]], output_token_logprobs_idx=[[10]]
+    )
+    slim = BatchTokenIDOutSlim.from_full(out)
+    raw = msgspec.msgpack.decode(_encode_payload(slim))
+    assert isinstance(raw, list)
+    assert raw[0] == "BatchTokenIDOutSlim"
+    assert len(raw) == 9
+    assert raw[1] == ["r1"]  # rids
+    assert raw[2] == [[10, 11]]  # output_ids
+    assert raw[3] == ["length"]  # finished_reasons
+    assert raw[7] == [[pytest.approx(-0.5)]]
+    assert raw[8] == [[10]]
+
+
+def test_slim_out_finish_reason_none_maps_to_empty():
+    out = _make_batch_out(finished_reasons=[None])
+    slim = BatchTokenIDOutSlim.from_full(out)
+    assert slim.finished_reasons == [""]
+
+
+def test_decode_request_frames_add_and_abort():
+    add = zmq_wire.decode_request_frames(
+        [zmq_wire.REQ_TYPE_ADD, _encode_payload(_make_request())]
+    )
+    assert len(add) == 1 and add[0].rid == "r1"
+
+    abort_payload = msgspec.msgpack.encode(["a", "b"])
+    aborts = zmq_wire.decode_request_frames([zmq_wire.REQ_TYPE_ABORT, abort_payload])
+    assert [a.rid for a in aborts] == ["a", "b"]
+    assert all(isinstance(a, AbortReq) for a in aborts)
+
+
+def test_decode_request_frames_rejects_unknown_type():
+    with pytest.raises(ValueError):
+        zmq_wire.decode_request_frames([b"\x09", b""])
+
+
+class _FakeInputSocket:
+    """Yields queued frame lists, then raises zmq.Again like a drained socket."""
+
+    def __init__(self, messages: list[list[bytes]]) -> None:
+        self._messages = list(messages)
+
+    def recv_multipart(self, flags: int = 0) -> list[bytes]:
+        if not self._messages:
+            raise zmq.Again()
+        return self._messages.pop(0)
+
+    def close(self) -> None:
+        pass
+
+
+def _add_frames(rid: str, sp: SamplingParams, **overrides) -> list[bytes]:
+    payload = _encode_payload(_make_request(rid=rid, sampling_params=sp, **overrides))
+    return [zmq_wire.REQ_TYPE_ADD, payload]
+
+
+def test_recv_socket_aborts_request_with_invalid_sampling_params():
+    # top_k=0 is out of range: verify() rejects it. Dropping the request would
+    # hang the frontend's stream with no terminal frame, so it still flows —
+    # marked via validation_error, which RequestHandler turns into FINISH_ABORT
+    # and OutputProcesser streams as a terminal "abort" output.
+    bad = _add_frames("bad", SamplingParams(top_k=0))
+    good = _add_frames("good", SamplingParams(top_k=-1))
+    recv = zmq_msgpack.MsgpackRecvSocket(_FakeInputSocket([bad, good]), vocab_size=32)
+
+    io_bad = recv.recv_pyobj()
+    assert io_bad.rid == "bad"
+    assert io_bad.validation_error and "top_k" in io_bad.validation_error
+    io_good = recv.recv_pyobj()
+    assert io_good.rid == "good"
+    assert io_good.validation_error is None
+    with pytest.raises(zmq.Again):
+        recv.recv_pyobj(zmq.NOBLOCK)
+
+    # The marker's terminal frame on the wire: FINISH_ABORT's to_json() dict
+    # reduces to finished_reasons=["abort"], which the frontend treats as
+    # terminal.
+    out = _make_batch_out(
+        finished_reasons=[FINISH_ABORT("Invalid request: bad top_k").to_json()]
+    )
+    slim = BatchTokenIDOutSlim.from_full(out)
+    assert slim.finished_reasons == ["abort"]
+
+
+def test_recv_socket_aborts_logprob_request_when_gate_is_off():
+    # The pickle path rejects return_logprob when the server was started
+    # without --enable-output-logprobs (input_processor); the msgpack path
+    # must enforce the same gate via the terminal-abort marker.
+    def _logprob_frames(rid: str) -> list[bytes]:
+        return _add_frames(rid, SamplingParams(), return_logprob=True)
+
+    recv_off = zmq_msgpack.MsgpackRecvSocket(
+        _FakeInputSocket([_logprob_frames("r1")]),
+        vocab_size=32,
+        enable_output_logprobs=False,
+    )
+    io = recv_off.recv_pyobj()
+    assert io.rid == "r1"
+    assert "--enable-output-logprobs" in io.validation_error
+
+    recv_on = zmq_msgpack.MsgpackRecvSocket(
+        _FakeInputSocket([_logprob_frames("r2")]),
+        vocab_size=32,
+        enable_output_logprobs=True,
+    )
+    assert recv_on.recv_pyobj().validation_error is None
+
+
+def test_recv_socket_drops_malformed_message_and_keeps_draining():
+    # A version-skewed frontend must not kill the engine: a message that fails
+    # to decode is dropped (with a warning) and the drain loop continues.
+    malformed = [zmq_wire.REQ_TYPE_ADD, b"\x00garbage"]
+    short = [b"\x07"]  # unknown type byte AND too few frames
+    good = _add_frames("good", SamplingParams())
+    recv = zmq_msgpack.MsgpackRecvSocket(
+        _FakeInputSocket([malformed, short, good]), vocab_size=32
+    )
+    io = recv.recv_pyobj()
+    assert io.rid == "good"
+    with pytest.raises(zmq.Again):
+        recv.recv_pyobj(zmq.NOBLOCK)
+
+
+def test_recv_socket_verify_does_not_apply_to_abort():
+    abort = [zmq_wire.REQ_TYPE_ABORT, msgspec.msgpack.encode(["a", "b"])]
+    recv = zmq_msgpack.MsgpackRecvSocket(_FakeInputSocket([abort]), vocab_size=32)
+    a1 = recv.recv_pyobj()
+    a2 = recv.recv_pyobj()
+    assert {a1.rid, a2.rid} == {"a", "b"}
+
+
+class _FakeOutputSocket:
+    """Records sends; optionally raises to exercise best-effort paths."""
+
+    def __init__(self, raise_on_send: bool = False) -> None:
+        self.sent: list[list[bytes]] = []
+        self._raise = raise_on_send
+
+    def send(self, payload: bytes, flags: int = 0) -> None:
+        if self._raise:
+            raise zmq.ZMQError()
+        self.sent.append([payload])
+
+    def send_multipart(self, frames, flags: int = 0, copy: bool = True) -> None:
+        if self._raise:
+            raise zmq.ZMQError()
+        self.sent.append([bytes(f) for f in frames])
+
+    def close(self) -> None:
+        pass
+
+
+def test_send_socket_engine_dead_sentinel():
+    # The frontend's output loop treats the raw ENGINE_CORE_DEAD frame as
+    # terminal; the transport sends it on engine shutdown/crash cleanup.
+    sock = _FakeOutputSocket()
+    zmq_msgpack.MsgpackSendSocket(sock).send_engine_dead()
+    assert sock.sent == [[zmq_msgpack.ENGINE_CORE_DEAD]]
+
+    # Best-effort: a dead socket on the cleanup path must not raise.
+    zmq_msgpack.MsgpackSendSocket(
+        _FakeOutputSocket(raise_on_send=True)
+    ).send_engine_dead()
+
+
+def test_handshake_structs_are_map_encoded():
+    """Handshake structs use named-key maps (the frontend decodes named
+    fields, not positions)."""
+    ready = zmq_wire.WireReadyMessage(status="HELLO", local=True, headless=True)
+    raw = msgspec.msgpack.decode(zmq_wire.encode(ready))
+    assert isinstance(raw, dict)
+    assert raw["status"] == "HELLO"
+
+    init = zmq_wire.WireHandshakeInitMessage(
+        addresses=zmq_wire.WireHandshakeAddresses(
+            inputs=["ipc://in"], outputs=["ipc://out"]
+        )
+    )
+    decoded = zmq_wire.decode_init(zmq_wire.encode(init))
+    assert decoded.addresses.inputs == ["ipc://in"]
+    assert decoded.addresses.outputs == ["ipc://out"]
+
+
+def test_init_decode_ignores_unknown_fields():
+    """The frontend may add handshake fields; msgspec must tolerate unknown keys."""
+    payload = msgspec.msgpack.encode(
+        {
+            "addresses": {
+                "inputs": ["ipc://in"],
+                "outputs": ["ipc://out"],
+                "coordinator_input": None,
+                "some_future_field": 42,
+            },
+            "parallel_config": {"tp": 1},
+            "another_future_field": "ok",
+        }
+    )
+    decoded = zmq_wire.decode_init(payload)
+    assert decoded.addresses.inputs == ["ipc://in"]
+
+
+# --------------------------------------------------------------------------
+# Transport loopback (engine CONNECTs; frontend BINDs)
+# --------------------------------------------------------------------------
+
+
+class _FakeSmgFrontend:
+    """Hand-rolled frontend side: binds handshake/input ROUTERs + output PULL
+    and drives HELLO -> INIT -> READY -> input registration."""
+
+    def __init__(self, ctx: zmq.Context, base: Path) -> None:
+        self.handshake = ctx.socket(zmq.ROUTER)
+        self.handshake_addr = f"ipc://{base / 'handshake.sock'}"
+        self.handshake.bind(self.handshake_addr)
+
+        self.input = ctx.socket(zmq.ROUTER)
+        self.input_addr = f"ipc://{base / 'input.sock'}"
+        self.input.bind(self.input_addr)
+
+        self.output = ctx.socket(zmq.PULL)
+        self.output_addr = f"ipc://{base / 'output.sock'}"
+        self.output.bind(self.output_addr)
+
+        self.engine_id: bytes | None = None
+        self._encoder = MsgpackEncoder()
+
+    def run_handshake(self) -> None:
+        # HELLO (the frontend only needs the routing identity here).
+        engine_id, _hello_payload = self.handshake.recv_multipart()
+        self.engine_id = engine_id
+        # INIT with the bound data-plane addresses.
+        init = zmq_wire.WireHandshakeInitMessage(
+            addresses=zmq_wire.WireHandshakeAddresses(
+                inputs=[self.input_addr], outputs=[self.output_addr]
+            )
+        )
+        self.handshake.send_multipart([engine_id, zmq_wire.encode(init)])
+        # READY
+        rid_ready, _ = self.handshake.recv_multipart()
+        assert rid_ready == engine_id
+        # Input-socket registration: [engine_id, EngineCoreReadyResponse].
+        reg_id, reg_payload = self.input.recv_multipart()
+        assert reg_id == engine_id
+        assert len(reg_payload) > 0
+
+    def send_add(self, req: TokenizedGenerateReqInput) -> None:
+        frames = self._encoder.encode(req)
+        self.input.send_multipart([self.engine_id, zmq_wire.REQ_TYPE_ADD, *frames])
+
+    def send_abort(self, rids: list[str]) -> None:
+        self.input.send_multipart(
+            [self.engine_id, zmq_wire.REQ_TYPE_ABORT, msgspec.msgpack.encode(rids)]
+        )
+
+    def recv_output(self) -> BatchTokenIDOutSlim:
+        assert self.output.poll(10_000, zmq.POLLIN), "no output from engine"
+        frames = self.output.recv_multipart()
+        return msgspec.msgpack.Decoder(BatchTokenIDOutSlim).decode(frames[-1])
+
+    def close(self) -> None:
+        for sock in (self.handshake, self.input, self.output):
+            sock.close(linger=0)
+
+
+def test_connect_and_data_plane_roundtrip():
+    ctx = zmq.Context()
+    tmp = tempfile.TemporaryDirectory()
+    base = Path(tmp.name)
+    frontend = _FakeSmgFrontend(ctx, base)
+
+    engine_holder: dict = {}
+    error_holder: dict = {}
+
+    def _engine():
+        try:
+            recv, send = zmq_msgpack.connect_msgpack_engine(
+                ctx,
+                frontend.handshake_addr,
+                engine_index=0,
+                ready_response=zmq_wire.WireEngineCoreReadyResponse(
+                    max_model_len=4096, dtype="bfloat16", vllm_version="tokenspeed-test"
+                ),
+                vocab_size=32000,
+            )
+            engine_holder["recv"] = recv
+            engine_holder["send"] = send
+        except Exception as exc:  # surface into the test thread
+            error_holder["err"] = exc
+
+    engine_thread = threading.Thread(target=_engine)
+    engine_thread.start()
+    frontend.run_handshake()
+    engine_thread.join(timeout=15)
+    assert not error_holder, error_holder.get("err")
+    assert "recv" in engine_holder, "engine handshake did not complete"
+
+    recv = engine_holder["recv"]
+    send = engine_holder["send"]
+    try:
+        # Engine identity is the 2-byte LE index the frontend routes by.
+        assert frontend.engine_id == struct.pack("<H", 0)
+
+        # ADD -> the engine decodes a TokenizedGenerateReqInput.
+        sp = SamplingParams(temperature=0.5, max_new_tokens=8)
+        frontend.send_add(
+            _make_request(rid="req-1", input_ids=[5, 6, 7], sampling_params=sp)
+        )
+        io = recv.recv_pyobj()
+        assert io.rid == "req-1"
+        assert io.input_ids == [5, 6, 7]
+        assert io.sampling_params.max_new_tokens == 8
+
+        # ABORT of two ids -> two AbortReq, one per recv_pyobj call.
+        frontend.send_abort(["req-1", "req-2"])
+        a1 = recv.recv_pyobj()
+        a2 = recv.recv_pyobj()
+        assert isinstance(a1, AbortReq) and isinstance(a2, AbortReq)
+        assert {a1.rid, a2.rid} == {"req-1", "req-2"}
+
+        # NOBLOCK drain contract: zmq.Again once the buffer + socket are empty.
+        with pytest.raises(zmq.Again):
+            recv.recv_pyobj(zmq.NOBLOCK)
+
+        # Output path: BatchTokenIDOut -> slim tagged struct on the PULL socket.
+        send.send_pyobj(_make_batch_out())
+        out = frontend.recv_output()
+        assert out.rids == ["r1"]
+        assert out.output_ids == [[10, 11]]
+        assert out.finished_reasons == ["length"]
+
+        # Non-output control replies are dropped, not crashed on.
+        send.send_pyobj(object())
+        with pytest.raises(zmq.Again):
+            frontend.output.recv(zmq.NOBLOCK)
+    finally:
+        recv.close()
+        send.close()
+        frontend.close()
+        ctx.term()
+        tmp.cleanup()


### PR DESCRIPTION
## Summary

Add an additive, flag-gated msgpack ZMQ mode that lets an external frontend (SMG) drive the scheduler directly, bypassing the Python `tokenizer_manager`. The frontend tokenizes and detokenizes; the scheduler exchanges compact positional-msgpack tuples instead of pickled `io_struct` dataclasses. The default pickle IPC path is untouched — the new mode only activates behind `--zmq-msgpack`.

Topology: the frontend BINDS the handshake/input/output sockets and the scheduler CONNECTS in, completing a HELLO → INIT → READY handshake plus an input-socket registration (engine config: max_model_len, kv blocks, dtype, parallel sizes) before the data plane opens.

- `runtime/engine/zmq_wire.py` — the wire schema: `WireSamplingParams` (13-tuple), `WireTokenizedGenerateReq` (5-tuple), `WireBatchTokenIDOut` (8-tuple, incl. sampled-token logprob columns), map-encoded handshake structs, and conversions to/from `io_struct`. Tokens are sourced from `output_ids` (the not-yet-sent generated slice), never the incremental-detokenization window, so prompt tokens cannot leak to the frontend. The ingress runs the input-processor responsibilities the bypassed `tokenizer_manager` normally owns: `resolve_seed` (rid-derived deterministic seed), `normalize`, and `verify(vocab_size)` — an invalid request is terminated with an abort output rather than dropped, so the frontend stream always ends deterministically.
- `runtime/engine/zmq_msgpack.py` — DEALER/PUSH socket adapters exposing `recv_pyobj`/`send_pyobj` so `RequestHandler` and `OutputProcesser` run unchanged, plus the engine-side handshake driver. Sends the `ENGINE_CORE_DEAD` sentinel on engine shutdown so the frontend marks the worker dead. Malformed frames are logged and dropped without killing the engine.
- `runtime/engine/event_loop.py` — branch to the msgpack transport when `--zmq-msgpack` is set; ready-response reports the resolved model dtype and kv-cache geometry.
- `runtime/utils/server_args.py` — `--zmq-msgpack`, `--zmq-handshake-address`, `--zmq-engine-index` (all default off).
- `runtime/entrypoints/engine.py` — `launch_scheduler_headless` (+ `python -m` shim): scheduler-only launch with no `tokenizer_manager`/`AsyncLLM`, with signal forwarding, child-failure propagation, and readiness diagnostics. Data-parallel size > 1 is rejected until the wire carries per-rank routing.
- `test/runtime/test_zmq_msgpack.py` — wire roundtrips, request-type dispatch, prompt-leak regression tests, verify/abort behavior, and a full transport loopback against a hand-rolled frontend (no GPU needed).

Known limitations (explicit, enforced loudly): one engine per handshake (DP>1 rejected), `n=1` only, no stop strings over the wire (`stop_token_ids` supported), sampled-token logprobs only (no top-k / prompt logprobs), and `--enable-output-logprobs` is required for logprob requests (rejected otherwise, matching the pickle path's gate).

## Test Plan

- `test/runtime/test_zmq_msgpack.py` — CPU-only unit + transport-loopback suite (all green).
- Live e2e on GB300 with Qwen3-0.6B against the SMG ZMQ frontend (`smg-project/smg` `feat/zmq-tokenspeed`): OpenAI chat completions (content + `reasoning_content` via the Qwen3 think block), completions, sampled-token logprobs, and correct rejection of top-k/prompt logprob requests. Launch:

  ```
  python -m tokenspeed.runtime.entrypoints.engine \
      --model <path> --zmq-msgpack \
      --zmq-handshake-address tcp://127.0.0.1:<port> \
      --zmq-engine-index 0 --skip-tokenizer-init --enable-output-logprobs
  ```

Follow-ups (out of scope here): engine-side handshake retry (the dial is currently one-shot), `ts serve --zmq` orchestration (blocked until an SMG release ships ZMQ support; the current pin predates it), DP>1 per-rank routing.
