### PR TITLE
ci: keep dispatch YAML choices complete

### DIFF
--- a/.github/workflows/k8s-dispatch.yml
+++ b/.github/workflows/k8s-dispatch.yml
@@ -32,13 +32,16 @@ on:
           - test/ci/eval/minimax-m3-nvfp4-evalscope-aime25.yaml
           - test/ci/eval/qwen3.5-122b-a10b-nvfp4-epd-1e1p2d-evalscope-ocr-bench.yaml
           - test/ci/eval/qwen3.5-122b-a10b-nvfp4-evalscope-ocr-bench.yaml
+          - test/ci/eval/qwen3.5-35b-a3b-fp8-deepep-tp2dp2ep4-evalscope-gsm8k.yaml
           - test/ci/eval/qwen3.5-397b-a17b-nvfp4-dp4ep4-evalscope-aime25.yaml
           - test/ci/eval/qwen3.5-397b-a17b-nvfp4-evalscope-aime25.yaml
           - test/ci/eval/qwen3.5-397b-a17b-nvfp4-pd-1p1d-evalscope-aime25.yaml
           - test/ci/eval/qwen3.5-397b-a17b-mxfp4-evalscope-aime25.yaml
           - test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi35x.yaml
+          - test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
           - test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
           - test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic-b200-8gpu.yaml
+          - test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic.yaml
           - test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-longctx.yaml
           - test/ci/ut/qwen3.5-122b-a10b-nvfp4-epd-1e1p2d.yaml
           - test/ci/ut/qwen3.5-397b-a17b-nvfp4-pd-1p1d.yaml

--- a/.github/workflows/slurm-dispatch.yml
+++ b/.github/workflows/slurm-dispatch.yml
@@ -29,6 +29,7 @@ on:
           - test/ci/eval/minimax-m3-nvfp4-evalscope-aime25.yaml
           - test/ci/eval/qwen3.5-122b-a10b-nvfp4-epd-1e1p2d-evalscope-ocr-bench.yaml
           - test/ci/eval/qwen3.5-122b-a10b-nvfp4-evalscope-ocr-bench.yaml
+          - test/ci/eval/qwen3.5-35b-a3b-fp8-deepep-tp2dp2ep4-evalscope-gsm8k.yaml
           - test/ci/eval/qwen3.5-397b-a17b-nvfp4-dp4ep4-evalscope-aime25.yaml
           - test/ci/eval/qwen3.5-397b-a17b-nvfp4-evalscope-aime25.yaml
           - test/ci/eval/qwen3.5-397b-a17b-nvfp4-pd-1p1d-evalscope-aime25.yaml
@@ -70,6 +71,7 @@ on:
           - manual
           - nightly
           - debug
+          - per-commit
 
 concurrency:
   group: slurm-dispatch-${{ inputs.pr || 'main' }}-${{ inputs.yaml }}-${{ inputs.runners }}-${{ inputs.match }}

--- a/test/ci_system/test_dispatch_workflows.py
+++ b/test/ci_system/test_dispatch_workflows.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+K8S_RUNNER_PREFIXES = ("b200-", "amd-", "gb200-", "b300-")
+SLURM_RUNNER_PREFIXES = ("b200-", "gb200-")
+
+
+def workflow_dispatch_inputs(name: str) -> dict:
+    path = REPO_ROOT / ".github" / "workflows" / name
+    workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+    triggers = workflow.get("on") or workflow.get(True)
+    return triggers["workflow_dispatch"]["inputs"]
+
+
+def eligible_config_paths(runner_prefixes: tuple[str, ...]) -> set[str]:
+    paths = set()
+    for path in (REPO_ROOT / "test" / "ci").rglob("*.yaml"):
+        task = yaml.safe_load(path.read_text(encoding="utf-8"))
+        labels = task["runner"]["labels"]
+        if any(label.startswith(runner_prefixes) for label in labels):
+            paths.add(path.relative_to(REPO_ROOT).as_posix())
+    return paths
+
+
+def configured_yaml_choices(workflow_name: str) -> set[str]:
+    choices = workflow_dispatch_inputs(workflow_name)["yaml"]["options"]
+    return {choice for choice in choices if choice.startswith("test/ci/")}
+
+
+def test_k8s_dispatch_lists_every_supported_ci_yaml():
+    assert configured_yaml_choices("k8s-dispatch.yml") == eligible_config_paths(
+        K8S_RUNNER_PREFIXES
+    )
+
+
+def test_slurm_dispatch_lists_every_b200_and_gb200_ci_yaml():
+    assert configured_yaml_choices("slurm-dispatch.yml") == eligible_config_paths(
+        SLURM_RUNNER_PREFIXES
+    )
+
+
+def test_slurm_dispatch_lists_every_supported_trigger():
+    choices = workflow_dispatch_inputs("slurm-dispatch.yml")["trigger"]["options"]
+    assert set(choices) == {"all", "per-commit", "manual", "nightly", "debug"}


### PR DESCRIPTION
## Summary

- add the three missing CI YAML choices to the Kubernetes dispatch workflow
- add the missing B200/GB200 YAML and `per-commit` trigger to the Slurm dispatch workflow
- add regression coverage that keeps both workflow choice lists in sync with eligible `test/ci/**/*.yaml` files

## Root cause

The manually maintained `workflow_dispatch` choice lists had drifted from the CI YAML files in the repository. The dispatch backends could handle the configurations, but users could not select every eligible configuration from the GitHub Actions UI.

## Impact

All eligible Kubernetes and Slurm CI configurations are selectable again. The regression test will fail when a future eligible YAML is omitted or a stale path remains in either workflow.

## Validation

- `PYTHONPATH=test/ci_system .venv/bin/python -m pytest -q test/ci_system` — 104 passed
- `pre-commit run --all-files` — passed
- `git diff --check origin/main..HEAD` — passed