### PR TITLE
fix(runtime): fail fast on scheduler startup errors

### DIFF
--- a/python/tokenspeed/runtime/engine/data_parallel_controller.py
+++ b/python/tokenspeed/runtime/engine/data_parallel_controller.py
@@ -26,6 +26,7 @@ import os
 import signal
 import threading
 from collections import deque
+from concurrent.futures import FIRST_EXCEPTION, ThreadPoolExecutor, wait
 from enum import Enum, auto
 
 import psutil
@@ -40,6 +41,7 @@ from tokenspeed.runtime.engine.io_struct import (
     WatchLoadUpdateReq,
 )
 from tokenspeed.runtime.engine.request import Req
+from tokenspeed.runtime.process_startup import wait_for_process_startup
 from tokenspeed.runtime.utils import (
     configure_logger,
     get_colorful_logger,
@@ -47,7 +49,7 @@ from tokenspeed.runtime.utils import (
 )
 from tokenspeed.runtime.utils.dispatch import TypeBasedDispatcher
 from tokenspeed.runtime.utils.exceptions import get_exception_traceback
-from tokenspeed.runtime.utils.process import register_usr_signal
+from tokenspeed.runtime.utils.process import kill_process_tree, register_usr_signal
 from tokenspeed.runtime.utils.server_args import PortArgs, ServerArgs
 
 logger = get_colorful_logger(__name__)
@@ -194,7 +196,6 @@ class DataParallelController:
         self._request_dispatcher.add_fallback_fn(self.send_control_message)
 
     def launch_dp_schedulers(self, server_args, port_args):
-        threads = []
         dp_port_args = []
 
         # Parse dist_init_addr from port_args to create per-dp-rank ports
@@ -249,29 +250,55 @@ class DataParallelController:
                 dp_ranks_per_node * server_args.node_rank,
                 dp_ranks_per_node * (server_args.node_rank + 1),
             )
-        for dp_rank in dp_rank_range:
-            # Create a thread for each worker
-            thread = threading.Thread(
-                target=self.launch_tensor_parallel_group,
-                args=(server_args, dp_port_args[dp_rank], dp_rank),
+        dp_rank_range = list(dp_rank_range)
+        startup_barrier = threading.Barrier(len(dp_rank_range))
+        executor = ThreadPoolExecutor(max_workers=len(dp_rank_range))
+        futures = [
+            executor.submit(
+                self.launch_tensor_parallel_group,
+                server_args,
+                dp_port_args[dp_rank],
+                dp_rank,
+                startup_barrier,
             )
-            threads.append(thread)
-
-        # Start all threads
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
+            for dp_rank in dp_rank_range
+        ]
+        try:
+            # Surface the first failed DP group instead of joining threads in
+            # rank order and losing exceptions raised inside them.
+            done, _ = wait(futures, return_when=FIRST_EXCEPTION)
+            for future in done:
+                future.result()
+            for future in futures:
+                future.result()
+        except BaseException:
+            startup_barrier.abort()
+            self._kill_scheduler_processes(self.scheduler_procs)
+            raise
+        finally:
+            executor.shutdown(wait=True, cancel_futures=True)
 
         return dp_port_args
+
+    @staticmethod
+    def _kill_scheduler_processes(processes: list[mp.Process]) -> None:
+        for process in processes:
+            if process.pid is None or not process.is_alive():
+                continue
+            kill_process_tree(process.pid)
+        for process in processes:
+            if process.pid is not None:
+                process.join(timeout=5)
 
     def launch_tensor_parallel_group(
         self,
         server_args: ServerArgs,
         port_args: PortArgs,
         dp_rank: int,
+        startup_barrier: threading.Barrier | None = None,
     ):
         scheduler_pipe_readers = []
+        scheduler_procs = []
         mapping_template = server_args.mapping
         attn_tp_size = mapping_template.attn.tp_size
 
@@ -301,10 +328,28 @@ class DataParallelController:
                 ),
             )
             proc.start()
+            writer.close()
             self.scheduler_procs.append(proc)
+            scheduler_procs.append(proc)
             scheduler_pipe_readers.append(reader)
-        # Wait for model to finish loading
-        scheduler_info = [reader.recv() for reader in scheduler_pipe_readers]
+        try:
+            # Do not let one DP group enter its wait before every peer group has
+            # finished spawning; this makes cross-group failure cleanup complete.
+            if startup_barrier is not None:
+                startup_barrier.wait()
+            scheduler_info = wait_for_process_startup(
+                scheduler_pipe_readers,
+                scheduler_procs,
+                description=f"DP {dp_rank} scheduler rank",
+            )
+        except BaseException:
+            if startup_barrier is not None:
+                startup_barrier.abort()
+            self._kill_scheduler_processes(scheduler_procs)
+            raise
+        finally:
+            for reader in scheduler_pipe_readers:
+                reader.close()
 
         self.max_total_num_tokens = scheduler_info[0]["max_total_num_tokens"]
         self.max_req_input_len = scheduler_info[0]["max_req_input_len"]
@@ -354,6 +399,7 @@ def run_data_parallel_controller_process(
     configure_logger(server_args)
     parent_process = psutil.Process().parent()
     register_usr_signal()
+    startup_complete = False
 
     try:
         controller = DataParallelController(server_args, port_args)
@@ -368,6 +414,7 @@ def run_data_parallel_controller_process(
                 "cache_storage": controller.cache_storage,
             }
         )
+        startup_complete = True
         if server_args.node_rank == 0:
             controller.event_loop()
         for proc in controller.scheduler_procs:
@@ -380,4 +427,11 @@ def run_data_parallel_controller_process(
     except Exception:
         traceback = get_exception_traceback()
         logger.error("DataParallelController hit an exception: %s", traceback)
-        parent_process.send_signal(signal.SIGUSR1)
+        if startup_complete:
+            parent_process.send_signal(signal.SIGUSR1)
+        else:
+            try:
+                pipe_writer.send({"status": "error", "error": traceback})
+            except (BrokenPipeError, EOFError, OSError):
+                parent_process.send_signal(signal.SIGUSR1)
+        raise

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -2099,6 +2099,7 @@ def run_event_loop(
     configure_logger(server_args, prefix=prefix)
 
     event_loop = None
+    startup_complete = False
     shutdown_event = threading.Event()
     previous_sigterm_handler = None
     try:
@@ -2141,6 +2142,7 @@ def run_event_loop(
                 "cache_storage": getattr(event_loop, "cache_storage", None),
             }
         )
+        startup_complete = True
 
         if event_loop.has_dp:
             # All DP schedulers must finish initialization before any rank enters
@@ -2155,7 +2157,19 @@ def run_event_loop(
     except Exception:
         traceback = get_exception_traceback()
         logger.error("Scheduler hit an exception: %s", traceback)
-        parent_process.send_signal(signal.SIGUSR1)
+        if startup_complete:
+            # The launch pipe is no longer monitored after readiness. Preserve
+            # the existing runtime-failure propagation path.
+            parent_process.send_signal(signal.SIGUSR1)
+        else:
+            # Startup supervision monitors every pipe concurrently, so report
+            # the concrete error there instead of relying on an inherited
+            # signal disposition to interrupt a rank-ordered blocking recv.
+            try:
+                pipe_writer.send({"status": "error", "error": traceback})
+            except (BrokenPipeError, EOFError, OSError):
+                parent_process.send_signal(signal.SIGUSR1)
+        raise
     finally:
         if event_loop is not None:
             try:

--- a/python/tokenspeed/runtime/entrypoints/engine.py
+++ b/python/tokenspeed/runtime/entrypoints/engine.py
@@ -74,6 +74,7 @@ from tokenspeed.runtime.engine.io_struct import (
     UpdateWeightsFromTensorReqInput,
 )
 from tokenspeed.runtime.entrypoints.engine_base import EngineBase
+from tokenspeed.runtime.process_startup import wait_for_process_startup
 from tokenspeed.runtime.utils import (
     MultiprocessingSerializer,
     configure_logger,
@@ -518,6 +519,17 @@ def _set_envs_and_config(server_args: ServerArgs):
     mp.set_start_method("spawn", force=True)
 
 
+def _kill_scheduler_processes(processes: list[mp.Process]) -> None:
+    """Force-stop and reap scheduler trees after a startup failure."""
+    for process in processes:
+        if process.pid is None or not process.is_alive():
+            continue
+        kill_process_tree(process.pid)
+    for process in processes:
+        if process.pid is not None:
+            process.join(timeout=5)
+
+
 def _launch_subprocesses(
     server_args: ServerArgs, port_args: PortArgs | None = None
 ) -> tuple[AsyncLLM, None, dict]:
@@ -566,6 +578,10 @@ def _launch_subprocesses(
             )
             with memory_saver_adapter.configure_subprocess():
                 proc.start()
+            # Only the child writes startup status. Keeping the parent's copy
+            # open prevents reader.recv() from ever seeing EOF if that child
+            # dies before sending a payload.
+            writer.close()
             scheduler_procs.append(proc)
             scheduler_pipe_readers.append(reader)
     else:
@@ -577,18 +593,38 @@ def _launch_subprocesses(
             args=(server_args, port_args, writer),
         )
         proc.start()
+        writer.close()
         scheduler_procs.append(proc)
+
+    # The rank-zero frontend must exist while schedulers initialize because it
+    # owns IPC endpoints that scheduler startup connects to.
+    tokenizer_manager = None
+    if server_args.node_rank == 0:
+        tokenizer_manager = AsyncLLM(server_args, port_args)
+
+    # Wait on every readiness pipe and process sentinel concurrently. A fixed
+    # rank-order recv can otherwise hide rank N's immediate failure behind rank
+    # 0 waiting in a distributed rendezvous.
+    try:
+        scheduler_infos = wait_for_process_startup(
+            scheduler_pipe_readers,
+            scheduler_procs,
+            description=(
+                "DataParallelController"
+                if server_args.mapping.attn.has_dp
+                else "scheduler rank"
+            ),
+        )
+    except BaseException:
+        _kill_scheduler_processes(scheduler_procs)
+        raise
+    finally:
+        for reader in scheduler_pipe_readers:
+            reader.close()
 
     if server_args.node_rank >= 1:
         # In multi-node cases, non-zero rank nodes do not need to run tokenizer or detokenizer,
         # so they can just wait here.
-
-        for reader in scheduler_pipe_readers:
-            data = reader.recv()
-            if data.get("status") != "ready":
-                raise RuntimeError(
-                    "Initialization failed. Please see the error messages above."
-                )
 
         if not envs.TOKENSPEED_BLOCK_NONZERO_RANK_CHILDREN.get():
             # When using `Engine` as a Python API, we don't want to block here.
@@ -607,29 +643,7 @@ def _launch_subprocesses(
             )
         return None, None, None
 
-    # Launch the main-process async frontend. The detokenizer runs
-    # inline inside AsyncLLM — no separate subprocess.
-    tokenizer_manager = AsyncLLM(server_args, port_args)
-
-    # Wait for the model to finish loading
-    scheduler_infos = []
-    for i in range(len(scheduler_pipe_readers)):
-        try:
-            data = scheduler_pipe_readers[i].recv()
-        except EOFError:
-            logger.error(
-                "Rank %s scheduler is dead. Please check if there are relevant logs.", i
-            )
-            scheduler_procs[i].join()
-            logger.error("Exit code: %s", scheduler_procs[i].exitcode)
-            raise
-
-        if data["status"] != "ready":
-            raise RuntimeError(
-                "Initialization failed. Please see the error messages above."
-            )
-        scheduler_infos.append(data)
-
+    assert tokenizer_manager is not None
     # Assume all schedulers have the same scheduler_info
     scheduler_info = scheduler_infos[0]
     tokenizer_manager.max_req_input_len = scheduler_info["max_req_input_len"]

--- a/python/tokenspeed/runtime/process_startup.py
+++ b/python/tokenspeed/runtime/process_startup.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Helpers for supervising multiprocessing workers during startup."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from multiprocessing.connection import Connection, wait
+from multiprocessing.process import BaseProcess
+from typing import Any
+
+
+def _failure_detail(message: Any) -> str:
+    if isinstance(message, dict):
+        return str(message.get("error") or message)
+    return repr(message)
+
+
+def wait_for_process_startup(
+    readers: Sequence[Connection],
+    processes: Sequence[BaseProcess],
+    *,
+    description: str,
+) -> list[dict[str, Any]]:
+    """Wait for all workers to report ready, failing on the first bad worker.
+
+    Every worker is monitored through both its readiness pipe and process
+    sentinel. This avoids rank-ordered ``recv`` calls hiding a later rank's
+    failure while an earlier rank remains blocked in distributed rendezvous.
+
+    Args:
+        readers: One receive-only readiness pipe per worker.
+        processes: The corresponding started multiprocessing workers.
+        description: Human-readable worker name used in errors.
+
+    Returns:
+        Readiness payloads in the same order as ``processes``.
+
+    Raises:
+        ValueError: If the reader/process counts differ or are empty.
+        RuntimeError: If a worker reports failure, closes its pipe, or exits
+            before every worker has become ready.
+    """
+    if not readers or len(readers) != len(processes):
+        raise ValueError("readers and processes must have the same non-zero length")
+
+    pending = set(range(len(processes)))
+    results: list[dict[str, Any] | None] = [None] * len(processes)
+
+    while pending:
+        waitables = [readers[index] for index in pending]
+        waitables.extend(process.sentinel for process in processes)
+        ready = set(wait(waitables))
+
+        # Consume pipe payloads first. A worker can send its failure and exit
+        # close enough together for both the connection and sentinel to fire.
+        for index in list(pending):
+            reader = readers[index]
+            sentinel_ready = processes[index].sentinel in ready
+            if reader not in ready and not (sentinel_ready and reader.poll()):
+                continue
+            try:
+                message = reader.recv()
+            except EOFError as exc:
+                processes[index].join(timeout=0)
+                raise RuntimeError(
+                    f"{description} {index} exited before reporting readiness "
+                    f"(exit code {processes[index].exitcode})"
+                ) from exc
+
+            if not isinstance(message, dict) or message.get("status") != "ready":
+                raise RuntimeError(
+                    f"{description} {index} failed during startup:\n"
+                    f"{_failure_detail(message)}"
+                )
+            results[index] = message
+            pending.remove(index)
+
+        # A process that exits while any peer is still starting is always a
+        # startup failure, even if it managed to report ready just beforehand.
+        for index, process in enumerate(processes):
+            if process.sentinel not in ready:
+                continue
+            process.join(timeout=0)
+            state = (
+                "before reporting readiness"
+                if index in pending
+                else "while peer processes were still starting"
+            )
+            raise RuntimeError(
+                f"{description} {index} exited {state} "
+                f"(exit code {process.exitcode})"
+            )
+
+    return [result for result in results if result is not None]

--- a/test/test_process_startup.py
+++ b/test/test_process_startup.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import multiprocessing as mp
+import threading
+import time
+
+import pytest
+
+from tokenspeed.runtime.process_startup import wait_for_process_startup
+
+
+def _wait_without_reporting(writer, stop) -> None:
+    stop.wait()
+    writer.close()
+
+
+def _report_error(writer, error: str) -> None:
+    writer.send({"status": "error", "error": error})
+    writer.close()
+    raise SystemExit(3)
+
+
+def _report_ready(writer, rank: int, stop) -> None:
+    writer.send({"status": "ready", "rank": rank})
+    writer.close()
+    stop.wait()
+
+
+def _exit_without_reporting() -> None:
+    raise SystemExit(4)
+
+
+def _stop_processes(processes, stop=None) -> None:
+    if stop is not None:
+        stop.set()
+    for process in processes:
+        process.join(timeout=2)
+        if process.is_alive():
+            process.kill()
+            process.join(timeout=2)
+
+
+def test_later_rank_failure_is_not_hidden_by_silent_first_rank():
+    ctx = mp.get_context("spawn")
+    stop = ctx.Event()
+    silent_reader, silent_writer = ctx.Pipe(duplex=False)
+    failed_reader, failed_writer = ctx.Pipe(duplex=False)
+    processes = [
+        ctx.Process(target=_wait_without_reporting, args=(silent_writer, stop)),
+        ctx.Process(
+            target=_report_error,
+            args=(failed_writer, "DistNetworkError: EADDRINUSE"),
+        ),
+    ]
+    for process in processes:
+        process.start()
+    silent_writer.close()
+    failed_writer.close()
+
+    # Bound the regression case: a rank-ordered recv would only unblock when
+    # the silent first rank exits and closes its writer five seconds later.
+    fallback_stop = threading.Timer(5, stop.set)
+    fallback_stop.start()
+    started = time.monotonic()
+    try:
+        with pytest.raises(RuntimeError, match="EADDRINUSE"):
+            wait_for_process_startup(
+                [silent_reader, failed_reader],
+                processes,
+                description="scheduler rank",
+            )
+        assert time.monotonic() - started < 5
+    finally:
+        fallback_stop.cancel()
+        silent_reader.close()
+        failed_reader.close()
+        _stop_processes(processes, stop)
+
+
+def test_process_exit_is_detected_even_if_parent_writer_stays_open():
+    ctx = mp.get_context("spawn")
+    reader, writer = ctx.Pipe(duplex=False)
+    process = ctx.Process(target=_exit_without_reporting)
+    process.start()
+
+    try:
+        with pytest.raises(RuntimeError, match="exited before reporting readiness"):
+            wait_for_process_startup([reader], [process], description="scheduler rank")
+    finally:
+        # Deliberately keep this open until after supervision returns: the
+        # process sentinel, rather than pipe EOF, must surface the failure.
+        writer.close()
+        reader.close()
+        _stop_processes([process])
+
+
+def test_readiness_results_preserve_process_order():
+    ctx = mp.get_context("spawn")
+    stop = ctx.Event()
+    pairs = [ctx.Pipe(duplex=False) for _ in range(2)]
+    processes = [
+        ctx.Process(target=_report_ready, args=(writer, rank, stop))
+        for rank, (_, writer) in enumerate(pairs)
+    ]
+    for process in reversed(processes):
+        process.start()
+    for _, writer in pairs:
+        writer.close()
+
+    try:
+        results = wait_for_process_startup(
+            [reader for reader, _ in pairs],
+            processes,
+            description="scheduler rank",
+        )
+        assert [result["rank"] for result in results] == [0, 1]
+    finally:
+        for reader, _ in pairs:
+            reader.close()
+        _stop_processes(processes, stop)


### PR DESCRIPTION
## Summary

- monitor every scheduler startup pipe and process sentinel concurrently
- close the parent copy of each startup pipe writer after spawning
- report initialization tracebacks over the startup pipe and terminate/reap all sibling scheduler trees on the first failure
- propagate startup failures through data-parallel controller groups as well
- add CPU-only regression coverage for a later rank failing while the first rank remains blocked

## Root cause

Scheduler readiness was consumed with rank-ordered blocking `recv()` calls. The parent also retained its copy of every pipe writer, so a failed child could not produce EOF on the corresponding reader. If a later rank failed with an error such as `DistNetworkError: EADDRINUSE` while an earlier rank remained in distributed rendezvous, engine startup stayed blocked and CI waited for its outer timeout. Failure propagation also depended on `SIGUSR1` interrupting the parent.

The new supervisor watches readiness connections and process sentinels together, preserves the concrete child traceback, and force-cleans all peer scheduler processes before raising to `ts serve` and CI.

## Validation

- `PYTHONPATH=python pytest -q test/test_process_startup.py` (3 passed)
- `python -m py_compile python/tokenspeed/runtime/process_startup.py python/tokenspeed/runtime/entrypoints/engine.py python/tokenspeed/runtime/engine/event_loop.py python/tokenspeed/runtime/engine/data_parallel_controller.py`
- `pre-commit run --all-files`