### PR TITLE
perf(kimi-k3): re-sweep MoE tactic tables for flashinfer 0.6.16, warn on stale tables

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/tactics/kimi-k3,ep=1,tp=8,device_name=NVIDIA_B300_SXM6_AC,flashinfer=0.6.16.json
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/tactics/kimi-k3,ep=1,tp=8,device_name=NVIDIA_B300_SXM6_AC,flashinfer=0.6.16.json
@@ -1,6 +1,6 @@
 {
   "_metadata": {
-    "flashinfer_version": "0.6.16.dev20260730",
+    "flashinfer_version": "0.6.16",
     "cuda_version": "13.0",
     "cublas_version": "13.1.0",
     "cudnn_version": "91900",
@@ -10,148 +10,148 @@
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1, 3584), (0,), (1, 16), (1, 16), (1, 3584), (1, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
-      16,
-      680
+      8,
+      43
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1024, 3584), (0,), (1024, 16), (1024, 16), (1024, 3584), (1024, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      2
+      11
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((128, 3584), (0,), (128, 16), (128, 16), (128, 3584), (128, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      1
+      3
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1280, 3584), (0,), (1280, 16), (1280, 16), (1280, 3584), (1280, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      0
+      3
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1536, 3584), (0,), (1536, 16), (1536, 16), (1536, 3584), (1536, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      0
+      3
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((16, 3584), (0,), (16, 16), (16, 16), (16, 3584), (16, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       16,
-      593
+      67
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1792, 3584), (0,), (1792, 16), (1792, 16), (1792, 3584), (1792, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      0
+      11
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2, 3584), (0,), (2, 16), (2, 16), (2, 3584), (2, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       16,
-      732
+      200
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2048, 3584), (0,), (2048, 16), (2048, 16), (2048, 3584), (2048, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      0
+      3
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((256, 3584), (0,), (256, 16), (256, 16), (256, 3584), (256, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      0
+      3
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2560, 3584), (0,), (2560, 16), (2560, 16), (2560, 3584), (2560, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      8
+      3
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((3072, 3584), (0,), (3072, 16), (3072, 16), (3072, 3584), (3072, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      2
+      3
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((32, 3584), (0,), (32, 16), (32, 16), (32, 3584), (32, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       16,
-      349
+      766
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((3584, 3584), (0,), (3584, 16), (3584, 16), (3584, 3584), (3584, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
-      128,
-      2
+      64,
+      3
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((4, 3584), (0,), (4, 16), (4, 16), (4, 3584), (4, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
-      8,
-      86
+      32,
+      478
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((4096, 3584), (0,), (4096, 16), (4096, 16), (4096, 3584), (4096, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
-      128,
-      20
+      64,
+      11
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((512, 3584), (0,), (512, 16), (512, 16), (512, 3584), (512, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      2
+      11
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((64, 3584), (0,), (64, 16), (64, 16), (64, 3584), (64, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
-      64,
-      15
+      16,
+      375
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((768, 3584), (0,), (768, 16), (768, 16), (768, 3584), (768, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      0
+      3
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((8, 3584), (0,), (8, 16), (8, 16), (8, 3584), (8, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       16,
-      593
+      587
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((8192, 3584), (0,), (8192, 16), (8192, 16), (8192, 3584), (8192, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       192,
-      12
+      15
     ]
   ]
 }

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/tactics/kimi-k3,ep=8,tp=1,device_name=NVIDIA_B300_SXM6_AC,flashinfer=0.6.16.json
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/tactics/kimi-k3,ep=8,tp=1,device_name=NVIDIA_B300_SXM6_AC,flashinfer=0.6.16.json
@@ -1,6 +1,6 @@
 {
   "_metadata": {
-    "flashinfer_version": "0.6.16.dev20260730",
+    "flashinfer_version": "0.6.16",
     "cuda_version": "13.0",
     "cublas_version": "13.1.0",
     "cudnn_version": "91900",
@@ -10,148 +10,148 @@
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1, 3584), (0,), (1, 16), (1, 16), (1, 3584), (1, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
-      8,
-      43
+      32,
+      57
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1024, 3584), (0,), (1024, 16), (1024, 16), (1024, 3584), (1024, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      3
+      10
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((128, 3584), (0,), (128, 16), (128, 16), (128, 3584), (128, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
-      16,
-      346
+      64,
+      8
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1280, 3584), (0,), (1280, 16), (1280, 16), (1280, 3584), (1280, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      3
+      10
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1536, 3584), (0,), (1536, 16), (1536, 16), (1536, 3584), (1536, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      3
+      10
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((16, 3584), (0,), (16, 16), (16, 16), (16, 3584), (16, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       16,
-      470
+      390
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1792, 3584), (0,), (1792, 16), (1792, 16), (1792, 3584), (1792, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      11
+      8
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2, 3584), (0,), (2, 16), (2, 16), (2, 3584), (2, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
-      16,
-      536
+      8,
+      392
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2048, 3584), (0,), (2048, 16), (2048, 16), (2048, 3584), (2048, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      3
+      0
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((256, 3584), (0,), (256, 16), (256, 16), (256, 3584), (256, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      11
+      1
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2560, 3584), (0,), (2560, 16), (2560, 16), (2560, 3584), (2560, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      3
+      0
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((3072, 3584), (0,), (3072, 16), (3072, 16), (3072, 3584), (3072, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      10
+      0
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((32, 3584), (0,), (32, 16), (32, 16), (32, 3584), (32, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       16,
-      763
+      741
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((3584, 3584), (0,), (3584, 16), (3584, 16), (3584, 3584), (3584, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
-      64,
-      11
+      128,
+      2
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((4, 3584), (0,), (4, 16), (4, 16), (4, 3584), (4, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
-      16,
-      194
+      8,
+      86
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((4096, 3584), (0,), (4096, 16), (4096, 16), (4096, 3584), (4096, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
-      64,
-      11
+      128,
+      22
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((512, 3584), (0,), (512, 16), (512, 16), (512, 3584), (512, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      3
+      10
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((64, 3584), (0,), (64, 16), (64, 16), (64, 3584), (64, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
-      16,
-      375
+      32,
+      575
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((768, 3584), (0,), (768, 16), (768, 16), (768, 3584), (768, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       64,
-      3
+      0
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((8, 3584), (0,), (8, 16), (8, 16), (8, 3584), (8, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
-      8,
-      196
+      16,
+      599
     ]
   ],
   "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((8192, 3584), (0,), (8192, 16), (8192, 16), (8192, 3584), (8192, 112), (0,), (0,)), ())": [
     "MoERunner",
     [
       192,
-      11
+      14
     ]
   ]
 }

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/tuning.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/tuning.py
@@ -233,13 +233,35 @@ def load_packaged_flashinfer_tuning_cache(
         f"{model},ep={ep_size},tp={tp_size},"
         f"device_name={device_name},flashinfer={fi_version}.json"
     )
-    path = os.path.join(os.path.dirname(_fi_pkg.__file__), "tactics", name)
+    tactics_dir = os.path.join(os.path.dirname(_fi_pkg.__file__), "tactics")
+    path = os.path.join(tactics_dir, name)
     if not os.path.exists(path):
-        logger.info(
-            f"no packaged flashinfer tuning cache for this environment "
-            f"(looked for {name}); the startup autotune window will tune "
-            "instead. Sweep one with benchmark/moe_tactic_sweep to pin "
-            "tactics."
+        # A table swept for this exact model/layout/device but a different
+        # flashinfer version means a pin bump orphaned it: tactic indices
+        # don't survive version changes, so it must be re-swept, and the
+        # fallback is a silent perf regression nobody sees in an INFO line.
+        stale_prefix = (
+            f"{model},ep={ep_size},tp={tp_size},device_name={device_name},flashinfer="
         )
+        stale = [
+            f
+            for f in (os.listdir(tactics_dir) if os.path.isdir(tactics_dir) else [])
+            if f.startswith(stale_prefix) and f != name
+        ]
+        if stale:
+            logger.warning(
+                f"stale flashinfer tuning cache: {stale[0]} was swept on a "
+                f"different flashinfer version (installed: {fi_version}) and "
+                f"will not be loaded. Re-sweep with benchmark/moe_tactic_sweep "
+                "to restore pinned tactics; until then the startup autotune "
+                "window tunes these shapes."
+            )
+        else:
+            logger.info(
+                f"no packaged flashinfer tuning cache for this environment "
+                f"(looked for {name}); the startup autotune window will tune "
+                "instead. Sweep one with benchmark/moe_tactic_sweep to pin "
+                "tactics."
+            )
         return False
     return load_flashinfer_tuning_cache(path)


### PR DESCRIPTION
## Summary

The flashinfer 0.6.16 pin bump (#869) silently orphaned the packaged Kimi-K3 MoE tactic tables: filenames embed the swept flashinfer version (`0.6.16.dev20260730`), the loader correctly refuses a version mismatch, and every K3 launch since has fallen back to the startup autotune window — whose native picks lose 16–83% on prefill-sized buckets. This PR re-sweeps both layout tables on 0.6.16 stable and makes the failure mode visible.

### Changes

- **Re-swept tables** for `ep=8,tp=1` and `ep=1,tp=8` (B300, flashinfer 0.6.16, `tune_max=8192`, 21 buckets each). Tactic indices do not survive version changes — the trtllm-gen kernel enumeration reorders between builds, so 17/21 (ep=8) and 12/21 (tp=8) buckets map to different indices for the same tile families. Tables must be re-swept on every pin bump, never renamed.
- **Stale-table warning** in `load_packaged_flashinfer_tuning_cache`: a lookup miss that finds a same-model/layout/device table swept on a *different* flashinfer version now logs a WARNING naming the orphaned file and the re-sweep command (previously a generic INFO). The next pin bump that forgets the tables shows up in serving logs instead of being a silent perf regression.

### Measured (B300 ×8, K3 w4a8, flashinfer 0.6.16)

**Kernel level** (`moe_tactic_sweep`, table tactic vs autotune-window native pick, cold-L2):

| layout | bucket | table | native | native slower by |
|---|---|---|---|---|
| ep=8,tp=1 | 512 | 349 µs | 636 µs | +82% |
| ep=8,tp=1 | 2048 | 390 µs | 714 µs | +83% |
| ep=8,tp=1 | 8192 | 761 µs | 902 µs | +19% |
| ep=1,tp=8 | 1024 | 409 µs | 496 µs | +21% |
| ep=1,tp=8 | 4096 | 734 µs | 893 µs | +22% |
| ep=1,tp=8 | 8192 | 962 µs | 1118 µs | +16% |

**End-to-end A/B** (same commit, same TP8 serve config, only variable = table file present; evalscope, 8×~4k-token prompts for prefill, 32-way × 256-token generations for decode):

| metric | with table | without (autotune) | delta |
|---|---|---|---|
| prefill total throughput | 13478 tok/s | 12238 tok/s | **+10.1%** |
| prefill TTFT (mean) | 1757 ms | 2017 ms | **−12.9%** |
| decode output throughput | 1163 tok/s | 1152 tok/s | +0.9% (noise) |
| startup autotune window | **13 s** | 5 min 31 s | **25×** |

Decode parity is expected: decode buckets (≤32 rows) are where the native heuristic is already near-optimal, and attention/comm dilute the MoE share.

Both tables load-verified on current main (post-#820: table load seeds the startup window; seeded shapes are skipped at zero cost). Note the sweep is keyed to `tune_max=8192` — serving with `chunked_prefill_size > 8192` changes the bucket ladder and misses the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
