### PR TITLE
fix(k3): derive Kimi-K3 KDA page packing from the MLA plane size

### DIFF
--- a/python/tokenspeed/runtime/configs/kimi_k3_cache_spec.py
+++ b/python/tokenspeed/runtime/configs/kimi_k3_cache_spec.py
@@ -41,6 +41,7 @@ _KIMI_K3_KDA_LAYERS = 69
 _KIMI_K3_MLA_LAYERS = 24
 _KIMI_K3_LOGICAL_BLOCK_TOKENS = 128
 _KIMI_K3_STATE_GROUPS = 3
+_KIMI_K3_MLA_PACKING = 12
 
 
 def _require_non_negative_int(name: str, value: int) -> int:
@@ -179,16 +180,28 @@ def plan_kimi_k3_lcm_cache(
         mla_cache_dtype=mla_cache_dtype,
         mla_quant_method=mla_quant_method,
     )
+    # The MLA latent history is TP-invariant while the KDA state shards by
+    # TP, so pack as many KDA pages per MLA-sized plane as fit to keep the
+    # planner's padding fraction bounded at any TP.
+    mla_plane_bytes = _KIMI_K3_MLA_PACKING * next(
+        field.payload_bytes for field in fields if field.group_id == FULL_ATTENTION
+    )
+    linear_plane_bytes = sum(
+        field.payload_bytes
+        for field in fields
+        if field.group_id == f"{LINEAR_ATTENTION}_0" and field.plane_id == "slot.0"
+    )
+    linear_packing = max(1, mla_plane_bytes // linear_plane_bytes)
     plan = plan_lcm_fields(
         fields,
         logical_block_tokens=_KIMI_K3_LOGICAL_BLOCK_TOKENS,
         budget_bytes=cache_budget_bytes,
         num_lcm_blocks=num_lcm_blocks,
         cache_blocks_per_lcm_block={
-            FULL_ATTENTION: 12,
-            f"{LINEAR_ATTENTION}_0": 1,
-            f"{LINEAR_ATTENTION}_1": 1,
-            f"{LINEAR_ATTENTION}_2": 1,
+            FULL_ATTENTION: _KIMI_K3_MLA_PACKING,
+            f"{LINEAR_ATTENTION}_0": linear_packing,
+            f"{LINEAR_ATTENTION}_1": linear_packing,
+            f"{LINEAR_ATTENTION}_2": linear_packing,
         },
         alignment=256,
     )
@@ -196,10 +209,10 @@ def plan_kimi_k3_lcm_cache(
         group.group_id: group.cache_blocks_per_lcm_block for group in plan.groups
     }
     expected_packing = {
-        FULL_ATTENTION: 12,
-        f"{LINEAR_ATTENTION}_0": 1,
-        f"{LINEAR_ATTENTION}_1": 1,
-        f"{LINEAR_ATTENTION}_2": 1,
+        FULL_ATTENTION: _KIMI_K3_MLA_PACKING,
+        f"{LINEAR_ATTENTION}_0": linear_packing,
+        f"{LINEAR_ATTENTION}_1": linear_packing,
+        f"{LINEAR_ATTENTION}_2": linear_packing,
     }
     if packing != expected_packing:
         raise ValueError(

--- a/test/runtime/test_kimi_k3_cache_spec.py
+++ b/test/runtime/test_kimi_k3_cache_spec.py
@@ -58,6 +58,30 @@ def test_lcm_reference_geometry_is_exact() -> None:
         }
 
 
+def test_lcm_geometry_packs_two_kda_pages_at_tp16() -> None:
+    """KDA state halves at TP16; two pages pack per MLA-sized plane."""
+    plan = plan_kimi_k3_lcm_cache(
+        KimiLinearConfig(),
+        flat_kvcache_enabled=True,
+        tp_size=16,
+        mla_cache_dtype=torch.float8_e4m3fn,
+        mla_quant_method=None,
+        num_lcm_blocks=7,
+    )
+
+    assert {
+        group.group_id: group.cache_blocks_per_lcm_block for group in plan.groups
+    } == {
+        "full_attention": 12,
+        "linear_attention_0": 2,
+        "linear_attention_1": 2,
+        "linear_attention_2": 2,
+    }
+    # MLA planes still dominate, so the LCM block geometry matches TP8.
+    assert plan.lcm_block_bytes == TP8_PAGE_SET_BYTES
+    assert len(plan.planes) == 24
+
+
 def test_lcm_parent_demand_uses_per_group_packing() -> None:
     plan = plan_kimi_k3_lcm_cache(
         KimiLinearConfig(),


### PR DESCRIPTION
## Summary

K3 FlatKV planning failed at TP16 (`padding fraction 1.268089 exceeds limit 0.25`): the KDA packing was hard-coded to 1 per LCM block, tuned for TP8, while the KDA state shrinks with TP and the MLA plane doesn't. Derive it as `max(1, mla_plane_bytes // linear_plane_bytes)` instead — TP8 plans stay byte-identical, TP16/TP32 now plan at the same 0.134 padding TP8 has today.

