### PR TITLE
fix(pd): fence prefill abort before cache release

### DIFF
--- a/python/tokenspeed/runtime/engine/generation_output_processor.py
+++ b/python/tokenspeed/runtime/engine/generation_output_processor.py
@@ -763,6 +763,11 @@ class OutputProcesser:
             # passive client that still needs a terminating finish streamed.
             if request_state.to_abort and request_state.finished:
                 request_changes.append(make_extend_result_event(rid, new_ids))
+                if is_prefill_instance:
+                    # PD owns these pages until SucceededEvent or FailedEvent
+                    # fences the transfer. Keep the request state alive so the
+                    # prefill handoff can finish before the scheduler releases it.
+                    continue
                 request_changes.append(make_finish_event(rid))
                 if request_state.abort_notify_client:
                     stream_out_rids.append(rid)
@@ -875,7 +880,8 @@ class OutputProcesser:
         # PD prefill node's terminal path (the other finish/abort logging lives in
         # post_process_forward_op). Self-guarded, so a no-op when the flag is off.
         self._log_request_stats(req_id, rs, time.time())
-        self.stream_output([req_id], [rs])
+        if not rs.to_abort or rs.abort_notify_client:
+            self.stream_output([req_id], [rs])
         # SucceededEvent already finishes the C++ FSM; no extra FinishEvent needed
         return []
 

--- a/test/runtime/test_generation_output_processor.py
+++ b/test/runtime/test_generation_output_processor.py
@@ -494,6 +494,7 @@ class _PrefillForwardOp:
     request_ids = ["prefill"]
     request_pool_indices = [3]
     input_lengths = [4]
+    prefill_lengths = [4]
     extend_prefix_lens = [0]
 
     def num_extends(self):
@@ -565,6 +566,30 @@ def test_prefill_first_token_checks_spec_candidate_bootstrap():
             is_prefill_instance=True,
             on_first_token=lambda *args: None,
         )
+
+
+@pytest.mark.parametrize("notify_client", [False, True])
+def test_aborted_prefill_waits_for_pd_transfer_completion(notify_client):
+    sender = _Sender()
+    processor = OutputProcesser(sender, attn_tp_rank=0, metrics=_Metrics())
+    state = _state([1, 2, 3, 4])
+    processor.rid_to_state["prefill"] = state
+    processor.mark_abort("prefill", notify_client=notify_client)
+
+    events = processor.post_process_forward_op(
+        _PrefillForwardOp(),
+        _PrefillExecutionResult(),
+        is_prefill_instance=True,
+        on_first_token=lambda *args: None,
+    )
+
+    assert [type(event).__name__ for event in events] == ["ExtendResult"]
+    assert processor.rid_to_state["prefill"] is state
+    assert sender.items == []
+
+    assert processor.finish_prefill_request("prefill") == []
+    assert "prefill" not in processor.rid_to_state
+    assert len(sender.items) == int(notify_client)
 
 
 def test_pd_one_token_request_finishes_at_remote_prefill_done():


### PR DESCRIPTION
## Summary

- keep an aborted Prefill-side request alive until the PD transfer reports `SucceededEvent` or `FailedEvent`
- prevent `Forward.Finish` from releasing scheduler-owned cache pages before the transfer fence
- suppress duplicate client output for client cancellations while preserving pause-initiated terminal notifications

## Root cause

`post_process_forward_op()` handled `to_abort` before its Prefill-instance path and emitted `Forward.Finish` immediately. The scheduler still held the request's PD transfer pins at that point, so it correctly rejected the premature release with `PD Finish received while transfer pages are pinned`.

## Validation

- added a regression test covering both client- and pause-initiated Prefill cancellation
- verified the test fails before the fix with `ExtendResult, Finish` and passes after the fix with no premature `Finish`
- relevant output-processor tests: 8 passed
- `pre-commit run --all-files`
