### PR TITLE
fix(ci): fix non-empty dir on gb200 work dir cleanup

### DIFF
--- a/.github/workflows/run-pr-test-stage.yml
+++ b/.github/workflows/run-pr-test-stage.yml
@@ -106,4 +106,8 @@ jobs:
 
       - name: Cleanup work directory
         if: always()
-        run: rm -rf "${{ env.WORK_DIR }}"
+        run: |
+          case "${{ matrix.runner }}" in
+            gb200*) python3 "${{ env.WORK_DIR }}/test/ci_system/process_group_manager.py" cleanup-stale || true ;;
+          esac
+          rm -rf "${{ env.WORK_DIR }}"

--- a/test/ci_system/pipeline.py
+++ b/test/ci_system/pipeline.py
@@ -57,6 +57,11 @@ STALE_PROCESS_PATTERNS = [
     r"smg_grpc_servicer\.tokenspeed",
     r"run_ci_suite",
 ]
+JIT_CACHE_ENV_SUBDIRS = {
+    "TRITON_CACHE_DIR": "triton",
+    "CUTE_DSL_CACHE_DIR": "cute_dsl",
+    "TORCHINDUCTOR_CACHE_DIR": "torchinductor",
+}
 RUNNER_SM_PREFIXES = (
     (("h100", "h200"), "sm90"),
     (("b200", "gb200"), "sm100"),
@@ -420,6 +425,25 @@ def create_ci_venv_name(runner_name: str | None = None) -> str:
     run_id = os.environ.get("GITHUB_RUN_ID", "local")
     run_attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "0")
     return f"/tmp/ci-env-{run_id}-{run_attempt}-{os.getpid()}"
+
+
+def create_ci_jit_cache_root(runner_name: str | None = None) -> str:
+    if runner_name:
+        safe_name = re.sub(r"[^A-Za-z0-9_-]", "_", runner_name)
+        return f"/tmp/ci-jit-cache-{safe_name}"
+    return "/tmp/ci-jit-cache-local"
+
+
+def get_jit_cache_env(env: Dict[str, str]) -> Dict[str, str]:
+    runner_name = (
+        env.get("RUNNER_NAME") or env.get("CI_RUNNER_NAME") or env.get("HOSTNAME")
+    )
+    root = create_ci_jit_cache_root(runner_name)
+    return {
+        variable: os.path.join(root, subdir)
+        for variable, subdir in JIT_CACHE_ENV_SUBDIRS.items()
+        if not env.get(variable)
+    }
 
 
 def _pkill(
@@ -1548,6 +1572,12 @@ def execute_task(
     env["CI_RUNNER_LABEL"] = runner
     env.update(get_default_runner_env(runner))
     env.update(get_runner_specific_env(task, runner))
+
+    jit_cache_env = get_jit_cache_env(env) if is_gb200_runner(runner) else {}
+    env.update(jit_cache_env)
+    if not dry_run:
+        for cache_dir in jit_cache_env.values():
+            Path(cache_dir).mkdir(parents=True, exist_ok=True)
 
     stages = filter_stage_commands(
         get_stage_commands(task),

--- a/test/ci_system/process_group_manager.py
+++ b/test/ci_system/process_group_manager.py
@@ -406,3 +406,14 @@ def make_manager(term_timeout: float = 10.0) -> ProcessGroupManager:
         flush=True,
     )
     return ProcessGroupManager(runner_id=runner_id, term_timeout=term_timeout)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["cleanup-stale"])
+    args = parser.parse_args()
+    if args.command == "cleanup-stale":
+        # Survivors of cancelled/timed-out jobs hold WORK_DIR files open, so rm -rf fails on NFS.
+        make_manager().cleanup_stale()

--- a/test/ci_system/test_pipeline.py
+++ b/test/ci_system/test_pipeline.py
@@ -19,6 +19,7 @@ from pipeline import (
     format_perf_reference_markdown_table,
     format_perf_reference_table,
     get_excluded_runner_labels,
+    get_jit_cache_env,
     get_runner_specific_env,
     get_stage_commands,
     is_amd_runner,
@@ -1065,3 +1066,18 @@ def test_slurm_server_command_inherits_readiness_timeout():
     explicit = "ts serve --model example --engine-startup-timeout 300"
     assert configure_slurm_server_command(explicit, 7200) == explicit
     assert configure_slurm_server_command("python serve.py", 7200) == "python serve.py"
+
+
+def test_jit_caches_are_redirected_off_the_work_dir():
+    env = {"RUNNER_NAME": "gb200-1gpu-0"}
+    resolved = get_jit_cache_env(env)
+    assert resolved == {
+        "TRITON_CACHE_DIR": "/tmp/ci-jit-cache-gb200-1gpu-0/triton",
+        "CUTE_DSL_CACHE_DIR": "/tmp/ci-jit-cache-gb200-1gpu-0/cute_dsl",
+        "TORCHINDUCTOR_CACHE_DIR": "/tmp/ci-jit-cache-gb200-1gpu-0/torchinductor",
+    }
+
+
+def test_jit_cache_env_keeps_explicit_overrides():
+    env = {"RUNNER_NAME": "gb200-1gpu-0", "TRITON_CACHE_DIR": "/mnt/triton"}
+    assert "TRITON_CACHE_DIR" not in get_jit_cache_env(env)


### PR DESCRIPTION
## Summary
The "Cleanup work directory" step on gb200 frequently fails with "Directory not empty": the work dir lives on NFS, and tokenspeed-kernel writes its JIT caches inside the source tree, so deleting files still held open by leftover processes leaves `.nfs*` silly-rename entries behind.
- `pipeline.py`: on gb200, redirect the Triton/CuTe-DSL/Inductor cache env vars to local disk (`/tmp/ci-jit-cache-<runner>/`) so caches never land in the NFS work dir.
- `process_group_manager.py`: add a `cleanup-stale` CLI entry reusing the existing persisted-pgid mechanism to reap orphaned process groups.
- `run-pr-test-stage.yml`: on gb200, run `cleanup-stale` before `rm -rf` to cover cancelled/timed-out jobs where pipeline's finally never runs and survivors still hold work-dir files open.