### PR TITLE
perf(kimi-k3): warm up the 4k benchmark shape

### DIFF
--- a/test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
+++ b/test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
@@ -71,7 +71,7 @@ perf:
     --max-tokens 1024
     --parallel 1
     --number 1
-    --warmup-num 0
+    --warmup-num 1
     --rate -1
     --seed 1
     --temperature 0


### PR DESCRIPTION
## Why

This benchmark reports one 4k/1k request with no shape-matched warmup. On an empty Triton/compiler cache, lazy setup adds about 2.7 seconds to that request’s TTFT and lowers the headline rate from ~43 to ~39 tok/s even though decode remains ~44.5 tok/s. Self-hosted runner cache state therefore changes what the one-request test measures.

The same cold behavior reproduces at current main and three older passing SHAs, so this is not a regression from the recent MLA kernel commit. The newer passing job 91852725294 also shows a partially warm signature: 1.01 s TTFT and 40.32 tok/s.

## What

Run one unscored request with the exact 4096-input/1024-output benchmark shape before the scored request.

This does not change the server configuration, inference kernels, graph/IRIS settings, performance reference, or threshold. It only keeps first-shape compiler state out of the steady-state performance measurement.

## Validation

Rebuilt current main and launched it with empty XDG, Triton, and TorchInductor caches:

- first scored run after warmup: 43.31 output tok/s, 44.50 decode tok/s, 656 ms TTFT
- repeat: 43.01 output tok/s, 44.50 decode tok/s, 824 ms TTFT
- prior no-warmup empty-cache runs: 38.95–39.12 output tok/s, 44.64–44.80 decode tok/s, 3.34–3.40 s TTFT
- `pre-commit run --all-files` passed