### PR TITLE
perf(kimi-k3): enable fp8 prefill for nope mla

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -1843,6 +1843,10 @@ class HybridLinearAttnBackend(AttentionBackend):
     def chunked_prefill_metadata(self):
         return self.full_attn_backend.chunked_prefill_metadata
 
+    @property
+    def data_type(self):
+        return self.full_attn_backend.data_type
+
     def override_num_extends(self, num_extends: int):
         return self.full_attn_backend.override_num_extends(num_extends)
 

--- a/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
@@ -1003,7 +1003,10 @@ class CuteDSLMLABackend(AttentionBackend):
             v = v.to(torch.float8_e4m3fn)
 
         if not CuteDSLMLABackend._logged_prefill:
-            logger.info("CuteDSL MLA prefill kernel invoked (tokenspeed_mla_prefill)")
+            logger.info(
+                "CuteDSL MLA prefill kernel invoked (tokenspeed_mla_prefill, "
+                f"q_dtype={q.dtype})"
+            )
             CuteDSLMLABackend._logged_prefill = True
 
         result = tokenspeed_mla_prefill(

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -1031,31 +1031,28 @@ class DeepseekV3AttentionMLA(nn.Module):
         )
 
         if use_fp8_prefill:
-            if self.rotary_emb is not None:
-                # Expand k_pe from [tokens,1,rope] to [tokens,heads,rope] for GQA
-                k_pe_expanded = k_pe.expand(-1, self.num_local_heads, -1)
 
-                q_fp8, k_fp8 = apply_rope_mla(
-                    positions=positions,
-                    q_rope=q_pe,
-                    k_rope=k_pe_expanded,
-                    q_nope=q_nope,
-                    k_nope=k_nope,
-                    cos_sin_cache=self.rotary_emb.cos_sin_cache,
-                    is_neox=getattr(self.rotary_emb, "is_neox_style", True),
-                    quant_scale_q=1.0,
-                    quant_scale_kv=k_scale,
-                    enable_pdl=pdl_enabled(),
-                )
+            if self.rotary_emb is not None:
+                k_rope = k_pe.expand(-1, self.num_local_heads, -1)
+                cos_sin_cache = self.rotary_emb.cos_sin_cache
+                is_neox = self.rotary_emb.is_neox_style
             else:
-                # Assemble exactly like the BF16 path, then quantize with the
-                # same scales the fused kernel would use (1.0 per the gate).
-                q[..., self.qk_nope_head_dim :] = q_pe
-                k = torch.empty_like(q)
-                k[..., : self.qk_nope_head_dim] = k_nope
-                k[..., self.qk_nope_head_dim :] = k_pe
-                q_fp8 = fp8_quantize(q, enable_pdl=pdl_enabled())
-                k_fp8 = fp8_quantize(k, enable_pdl=pdl_enabled())
+                k_rope = k_pe
+                cos_sin_cache = None
+                is_neox = False
+
+            q_fp8, k_fp8 = apply_rope_mla(
+                positions=positions,
+                q_rope=q_pe,
+                k_rope=k_rope,
+                q_nope=q_nope,
+                k_nope=k_nope,
+                cos_sin_cache=cos_sin_cache,
+                is_neox=is_neox,
+                quant_scale_q=1.0,
+                quant_scale_kv=k_scale,
+                enable_pdl=pdl_enabled(),
+            )
 
             v_fp8 = fp8_quantize(v, enable_pdl=pdl_enabled())
 

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -1019,30 +1019,43 @@ class DeepseekV3AttentionMLA(nn.Module):
 
         # FP8 prefill: fused RoPE + FP8 quantize, direct FP8 KV cache write.
         # Disabled when k_scale != 1.0; mla_fp8_utils.py documents the current limitation.
+        # NoPE models (rotary_emb is None, e.g. Kimi-K3) quantize standalone:
+        # the quantize is otherwise fused into the RoPE kernel, and leaving
+        # them on the BF16 kernel meant a JIT compile of a variant the backend
+        # never pre-warms.
         k_scale = getattr(self.attn_mha, "k_scale_float", 1.0)
         use_fp8_prefill = (
             self.attention_backend in self._MLA_KERNEL_BACKENDS
             and getattr(ctx.attn_backend, "data_type", None) == torch.float8_e4m3fn
-            and self.rotary_emb is not None
             and k_scale == 1.0
         )
 
         if use_fp8_prefill:
-            # Expand k_pe from [tokens,1,rope] to [tokens,heads,rope] for GQA
-            k_pe_expanded = k_pe.expand(-1, self.num_local_heads, -1)
+            if self.rotary_emb is not None:
+                # Expand k_pe from [tokens,1,rope] to [tokens,heads,rope] for GQA
+                k_pe_expanded = k_pe.expand(-1, self.num_local_heads, -1)
 
-            q_fp8, k_fp8 = apply_rope_mla(
-                positions=positions,
-                q_rope=q_pe,
-                k_rope=k_pe_expanded,
-                q_nope=q_nope,
-                k_nope=k_nope,
-                cos_sin_cache=self.rotary_emb.cos_sin_cache,
-                is_neox=getattr(self.rotary_emb, "is_neox_style", True),
-                quant_scale_q=1.0,
-                quant_scale_kv=k_scale,
-                enable_pdl=pdl_enabled(),
-            )
+                q_fp8, k_fp8 = apply_rope_mla(
+                    positions=positions,
+                    q_rope=q_pe,
+                    k_rope=k_pe_expanded,
+                    q_nope=q_nope,
+                    k_nope=k_nope,
+                    cos_sin_cache=self.rotary_emb.cos_sin_cache,
+                    is_neox=getattr(self.rotary_emb, "is_neox_style", True),
+                    quant_scale_q=1.0,
+                    quant_scale_kv=k_scale,
+                    enable_pdl=pdl_enabled(),
+                )
+            else:
+                # Assemble exactly like the BF16 path, then quantize with the
+                # same scales the fused kernel would use (1.0 per the gate).
+                q[..., self.qk_nope_head_dim :] = q_pe
+                k = torch.empty_like(q)
+                k[..., : self.qk_nope_head_dim] = k_nope
+                k[..., self.qk_nope_head_dim :] = k_pe
+                q_fp8 = fp8_quantize(q, enable_pdl=pdl_enabled())
+                k_fp8 = fp8_quantize(k, enable_pdl=pdl_enabled())
 
             v_fp8 = fp8_quantize(v, enable_pdl=pdl_enabled())
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/__init__.py
@@ -183,7 +183,7 @@ def apply_rope_mla(
     k_rope: torch.Tensor,
     q_nope: torch.Tensor,
     k_nope: torch.Tensor,
-    cos_sin_cache: torch.Tensor,
+    cos_sin_cache: torch.Tensor | None,
     # embedding options
     is_neox: bool = True,
     quantize_dtype: torch.dtype = torch.float8_e4m3fn,
@@ -199,6 +199,10 @@ def apply_rope_mla(
     override: str | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Apply MLA RoPE and quantize query/key parts to FP8.
+
+    With ``cos_sin_cache=None`` the rotation is skipped (NoPE models such as
+    Kimi-K3): the parts are quantized straight into the combined layout, and
+    a single-head ``k_rope`` broadcasts across the query heads.
 
     Args:
         positions: Token positions. Flattened to [tokens] before dispatch.
@@ -232,7 +236,7 @@ def apply_rope_mla(
     Returns:
         (query_fp8, key_fp8), where the last dimension is concat(nope, rope).
     """
-    positions = positions.flatten()
+    positions = positions.flatten() if cos_sin_cache is not None else positions
     query_fp8 = None
     key_fp8 = None
 
@@ -292,6 +296,7 @@ def apply_rope_mla(
         )
 
     traits = {
+        "has_rope": cos_sin_cache is not None,
         "is_neox": bool(is_neox),
         "quantize_dtype": quantize_dtype,
         "has_scale_q_tensor": isinstance(quant_scale_q, torch.Tensor),

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/flashinfer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/flashinfer.py
@@ -41,6 +41,7 @@ if platform.is_nvidia:
         ),
         priority=Priority.SPECIALIZED,
         traits={
+            "has_rope": frozenset({True}),
             "is_neox": frozenset({True, False}),
             "quantize_dtype": frozenset({torch.float8_e4m3fn}),
             "has_scale_q_tensor": frozenset({False}),

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/triton.py
@@ -611,6 +611,170 @@ def _fp8_quantize(
     )
 
 
+@triton.jit
+def _mla_nope_quantize_fp8_kernel(
+    q_nope,
+    q_rope,
+    k_nope,
+    k_rope,
+    q_nope_out,
+    q_rope_out,
+    k_nope_out,
+    k_rope_out,
+    scale_q,
+    scale_kv,
+    qn_stride_t,
+    qn_stride_h,
+    qr_stride_t,
+    qr_stride_h,
+    kn_stride_t,
+    kn_stride_h,
+    kr_stride_t,
+    kr_stride_h,
+    qno_stride_t,
+    qno_stride_h,
+    qro_stride_t,
+    qro_stride_h,
+    kno_stride_t,
+    kno_stride_h,
+    kro_stride_t,
+    kro_stride_h,
+    nope_dim: tl.constexpr,
+    rope_dim: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+    HAS_SCALE_Q_TENSOR: tl.constexpr,
+    HAS_SCALE_KV_TENSOR: tl.constexpr,
+):
+    token = tl.program_id(0)
+    head = tl.program_id(1)
+    if HAS_SCALE_Q_TENSOR:
+        scale_q = tl.load(scale_q)
+    if HAS_SCALE_KV_TENSOR:
+        scale_kv = tl.load(scale_kv)
+
+    offs_n = tl.arange(0, BLOCK_N)
+    mask_n = offs_n < nope_dim
+    offs_r = tl.arange(0, BLOCK_R)
+    mask_r = offs_r < rope_dim
+
+    qn = tl.load(
+        q_nope + token * qn_stride_t + head * qn_stride_h + offs_n,
+        mask=mask_n,
+        other=0.0,
+    ).to(tl.float32)
+    tl.store(
+        q_nope_out + token * qno_stride_t + head * qno_stride_h + offs_n,
+        (qn * scale_q).to(tl.float8e4nv),
+        mask=mask_n,
+    )
+    qr = tl.load(
+        q_rope + token * qr_stride_t + head * qr_stride_h + offs_r,
+        mask=mask_r,
+        other=0.0,
+    ).to(tl.float32)
+    tl.store(
+        q_rope_out + token * qro_stride_t + head * qro_stride_h + offs_r,
+        (qr * scale_q).to(tl.float8e4nv),
+        mask=mask_r,
+    )
+
+    kn = tl.load(
+        k_nope + token * kn_stride_t + head * kn_stride_h + offs_n,
+        mask=mask_n,
+        other=0.0,
+    ).to(tl.float32)
+    tl.store(
+        k_nope_out + token * kno_stride_t + head * kno_stride_h + offs_n,
+        (kn * scale_kv).to(tl.float8e4nv),
+        mask=mask_n,
+    )
+    kr = tl.load(
+        k_rope + token * kr_stride_t + head * kr_stride_h + offs_r,
+        mask=mask_r,
+        other=0.0,
+    ).to(tl.float32)
+    tl.store(
+        k_rope_out + token * kro_stride_t + head * kro_stride_h + offs_r,
+        (kr * scale_kv).to(tl.float8e4nv),
+        mask=mask_r,
+    )
+
+
+def mla_nope_quantize_fp8_triton(
+    *,
+    q_rope: torch.Tensor,
+    k_rope: torch.Tensor,
+    q_nope: torch.Tensor,
+    k_nope: torch.Tensor,
+    q_rope_out: torch.Tensor,
+    k_rope_out: torch.Tensor,
+    q_nope_out: torch.Tensor,
+    k_nope_out: torch.Tensor,
+    quant_scale_q: float | torch.Tensor = 1.0,
+    quant_scale_kv: float | torch.Tensor = 1.0,
+    enable_pdl: bool = False,
+) -> None:
+    """The no-RoPE tail of apply_rope_mla: quantize the four query/key parts
+    straight into their FP8 output slices in one launch. ``k_rope`` may carry
+    a single head; it broadcasts across the output heads via a zero stride."""
+    num_tokens, num_heads, nope_dim = q_nope.shape
+    rope_dim = q_rope.shape[-1]
+    if k_nope.shape != q_nope.shape:
+        raise ValueError(f"k_nope {k_nope.shape} must match q_nope {q_nope.shape}")
+    if k_rope.shape[1] not in (1, num_heads):
+        raise ValueError(
+            f"k_rope heads must be 1 or {num_heads}, got {k_rope.shape[1]}"
+        )
+    if k_rope_out.shape[1] != num_heads:
+        # A one-head k_rope broadcasts on load, but every output slice must
+        # carry the full head count -- the grid writes all heads.
+        raise ValueError(
+            f"k_rope_out must carry {num_heads} heads, got {k_rope_out.shape[1]}"
+        )
+    if isinstance(quant_scale_q, torch.Tensor):
+        quant_scale_q = quant_scale_q.contiguous()
+    if isinstance(quant_scale_kv, torch.Tensor):
+        quant_scale_kv = quant_scale_kv.contiguous()
+
+    extra_kwargs = {"launch_pdl": True} if enable_pdl else {}
+    _mla_nope_quantize_fp8_kernel[(num_tokens, num_heads)](
+        q_nope,
+        q_rope,
+        k_nope,
+        k_rope,
+        q_nope_out,
+        q_rope_out,
+        k_nope_out,
+        k_rope_out,
+        quant_scale_q,
+        quant_scale_kv,
+        q_nope.stride(0),
+        q_nope.stride(1),
+        q_rope.stride(0),
+        q_rope.stride(1),
+        k_nope.stride(0),
+        k_nope.stride(1),
+        k_rope.stride(0),
+        0 if k_rope.shape[1] == 1 else k_rope.stride(1),
+        q_nope_out.stride(0),
+        q_nope_out.stride(1),
+        q_rope_out.stride(0),
+        q_rope_out.stride(1),
+        k_nope_out.stride(0),
+        k_nope_out.stride(1),
+        k_rope_out.stride(0),
+        k_rope_out.stride(1),
+        nope_dim=nope_dim,
+        rope_dim=rope_dim,
+        BLOCK_N=max(16, _next_power_of_2(nope_dim)),
+        BLOCK_R=max(16, _next_power_of_2(rope_dim)),
+        HAS_SCALE_Q_TENSOR=isinstance(quant_scale_q, torch.Tensor),
+        HAS_SCALE_KV_TENSOR=isinstance(quant_scale_kv, torch.Tensor),
+        **extra_kwargs,
+    )
+
+
 def mla_rope_quantize_fp8_triton(
     *,
     positions: torch.Tensor,
@@ -707,6 +871,59 @@ def triton_embedding_rope(
 @register_kernel(
     "embedding",
     "rope_mla",
+    name="triton_embedding_nope_mla",
+    solution="triton",
+    capability=CapabilityRequirement(vendors=frozenset({"amd", "nvidia"})),
+    signatures=format_signatures(
+        ("q_rope", "k_rope", "q_nope", "k_nope"),
+        "dense",
+        {torch.float16, torch.bfloat16},
+    ),
+    priority=Priority.PORTABLE,
+    traits={
+        "has_rope": frozenset({False}),
+        "is_neox": frozenset({True, False}),
+        "quantize_dtype": frozenset({torch.float8_e4m3fn}),
+        "has_scale_q_tensor": frozenset({True, False}),
+        "has_scale_kv_tensor": frozenset({True, False}),
+    },
+    tags={"portability"},
+)
+def triton_embedding_nope_mla(
+    *,
+    positions: torch.Tensor,
+    q_rope: torch.Tensor,
+    k_rope: torch.Tensor,
+    q_nope: torch.Tensor,
+    k_nope: torch.Tensor,
+    cos_sin_cache: torch.Tensor | None,
+    q_rope_out: torch.Tensor,
+    k_rope_out: torch.Tensor,
+    q_nope_out: torch.Tensor,
+    k_nope_out: torch.Tensor,
+    is_neox: bool = True,
+    quant_scale_q: float | torch.Tensor = 1.0,
+    quant_scale_kv: float | torch.Tensor = 1.0,
+    enable_pdl: bool = False,
+) -> None:
+    mla_nope_quantize_fp8_triton(
+        q_rope=q_rope,
+        k_rope=k_rope,
+        q_nope=q_nope,
+        k_nope=k_nope,
+        q_rope_out=q_rope_out,
+        k_rope_out=k_rope_out,
+        q_nope_out=q_nope_out,
+        k_nope_out=k_nope_out,
+        quant_scale_q=quant_scale_q,
+        quant_scale_kv=quant_scale_kv,
+        enable_pdl=enable_pdl,
+    )
+
+
+@register_kernel(
+    "embedding",
+    "rope_mla",
     name="triton_embedding_rope_mla",
     solution="triton",
     capability=CapabilityRequirement(vendors=frozenset({"amd", "nvidia"})),
@@ -717,6 +934,7 @@ def triton_embedding_rope(
     ),
     priority=Priority.PORTABLE,
     traits={
+        "has_rope": frozenset({True}),
         "is_neox": frozenset({True, False}),
         "quantize_dtype": frozenset({torch.float8_e4m3fn}),
         "has_scale_q_tensor": frozenset({True, False}),


### PR DESCRIPTION
## Summary

FP8 prefill is currently disabled on `main`. This PR adds a NoPE kernel for the `apply_rope_mla` entry point.

## Test Plan

<!-- How was this validated? -->
