### PR TITLE
Update(docs & config): Add Qwen3.8-max in model recipe and update default config

### DIFF
--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -93,7 +93,7 @@ issue budget, while `--max-total-tokens` controls the global token pool.
 | --- | --- |
 | `--tensor-parallel-size`, `--tp` | Familiar alias for setting attention tensor parallel size. |
 | `--attn-tp-size` | Tensor parallel size for attention. |
-| `--dense-tp-size` | Tensor parallel size for dense layers. |
+| `--dense-tp-size` | Tensor parallel size for dense layers. Defaults to the attention replica width (attn TP x CP): the full world without DP attention, one replica with it. |
 | `--moe-tp-size` | Tensor parallel size for MoE layers. |
 | `--data-parallel-size` | Number of data-parallel replicas. |
 | `--mm-encoder-tp-mode` | Multimodal encoder parallelism: `weights` shards encoder weights with attention TP; `data` uses TP1 whole-item DP and currently requires aggregate serving, one node, and no attention context parallelism. |

--- a/docs/recipes/models.md
+++ b/docs/recipes/models.md
@@ -288,6 +288,127 @@ tokenspeed serve Qwen/Qwen3-30B-A3B \
   --port 8000
 ```
 
+## Qwen3.8-max
+
+Qwen3.8-max needs 16 GPUs, so it runs on two 8-GPU nodes. Launch
+`tokenspeed serve` on every node with the same command, changing only
+`--node-rank`; every node points `--dist-init-addr` at node 0, which is the only
+rank that serves the HTTP API. See [Parallelism](../serving/parallelism.md) for
+the multi-node rules.
+
+This family has no parser auto-selection, so set `--reasoning-parser` and
+`--tool-call-parser` explicitly. `--speculative-algorithm MTP` without
+`--speculative-draft-model-path` drafts from the base checkpoint. Set
+`--dist-init-addr` to node 0's own address and port throughout
+(`<node0-host>:25000` below).
+
+### TP16
+
+One replica across both nodes. `--ep-size` defaults to 1, so the experts stay
+tensor-parallel over the full world and all-to-all stays out of the path. Keep
+`--moe-backend auto`: the block-scale FP8 `deep_gemm` experts implement only the
+DeepEP legs and are unavailable without `--all2all-backend deepep`.
+
+```bash
+# node 0 (serves the HTTP API)
+tokenspeed serve /path/to/qwen3.8-max-fp8 \
+  --served-model-name qwen3.8-max \
+  --nnodes 2 --node-rank 0 --nprocs-per-node 8 --world-size 16 \
+  --dist-init-addr <node0-host>:25000 \
+  --attn-tp-size 16 \
+  --moe-backend auto \
+  --quantization fp8 --kv-cache-dtype fp8 \
+  --attention-backend trtllm \
+  --chunked-prefill-size 8192 \
+  --gpu-memory-utilization 0.95 --max-num-seqs 128 \
+  --disable-kvstore \
+  --speculative-algorithm MTP --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
+  --reasoning-parser qwen3_thinking --tool-call-parser qwen_coder \
+  --host 0.0.0.0 --port 8000
+
+# node 1 (same command, --node-rank 1)
+tokenspeed serve /path/to/qwen3.8-max-fp8 \
+  --served-model-name qwen3.8-max \
+  --nnodes 2 --node-rank 1 --nprocs-per-node 8 --world-size 16 \
+  --dist-init-addr <node0-host>:25000 \
+  --attn-tp-size 16 \
+  --moe-backend auto \
+  --quantization fp8 --kv-cache-dtype fp8 \
+  --attention-backend trtllm \
+  --chunked-prefill-size 8192 \
+  --gpu-memory-utilization 0.95 --max-num-seqs 128 \
+  --disable-kvstore \
+  --speculative-algorithm MTP --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
+  --reasoning-parser qwen3_thinking --tool-call-parser qwen_coder \
+  --host 0.0.0.0 --port 8000
+```
+
+### TP8 DP2 EP16 (DeepEP)
+
+Two TP8 attention replicas, experts sharded across all 16 ranks, and expert
+routing on DeepEP dispatch/combine instead of all-gather:
+
+```bash
+# node 0 (serves the HTTP API)
+tokenspeed serve /path/to/qwen3.8-max-fp8 \
+  --served-model-name qwen3.8-max \
+  --nnodes 2 --node-rank 0 --nprocs-per-node 8 --world-size 16 \
+  --dist-init-addr <node0-host>:25000 \
+  --attn-tp-size 8 --data-parallel-size 2 --ep-size 16 \
+  --moe-backend deep_gemm \
+  --all2all-backend deepep --deepep-mode auto \
+  --low-latency-max-num-tokens-per-gpu 64 \
+  --quantization fp8 --kv-cache-dtype fp8 \
+  --attention-backend trtllm \
+  --chunked-prefill-size 8192 \
+  --gpu-memory-utilization 0.95 --max-num-seqs 128 \
+  --disable-kvstore \
+  --speculative-algorithm MTP --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
+  --reasoning-parser qwen3_thinking --tool-call-parser qwen_coder \
+  --host 0.0.0.0 --port 8000
+
+# node 1 (same command, --node-rank 1)
+tokenspeed serve /path/to/qwen3.8-max-fp8 \
+  --served-model-name qwen3.8-max \
+  --nnodes 2 --node-rank 1 --nprocs-per-node 8 --world-size 16 \
+  --dist-init-addr <node0-host>:25000 \
+  --attn-tp-size 8 --data-parallel-size 2 --ep-size 16 \
+  --moe-backend deep_gemm \
+  --all2all-backend deepep --deepep-mode auto \
+  --low-latency-max-num-tokens-per-gpu 64 \
+  --quantization fp8 --kv-cache-dtype fp8 \
+  --attention-backend trtllm \
+  --chunked-prefill-size 8192 \
+  --gpu-memory-utilization 0.95 --max-num-seqs 128 \
+  --disable-kvstore \
+  --speculative-algorithm MTP --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
+  --reasoning-parser qwen3_thinking --tool-call-parser qwen_coder \
+  --host 0.0.0.0 --port 8000
+```
+
+Notes:
+- `--low-latency-max-num-tokens-per-gpu` sizes DeepEP's NVSHMEM heap (roughly
+  2.0 GB at 64, 8.1 GB at 256), and that heap is claimed after the KV pool is
+  profiled. An oversized value therefore fails late, when the first dispatch
+  runs out of fabric memory. Size it to the real per-rank decode token bound
+  and no lower: a batch above the capacity is rejected, not truncated.
+- Internode DeepEP rides NVSHMEM IBGDA. On a RoCE fabric, mirror the NCCL
+  values into `NVSHMEM_IB_GID_INDEX`, `NVSHMEM_IB_TRAFFIC_CLASS`, and
+  `NVSHMEM_IB_SL`, and point `NVSHMEM_BOOTSTRAP_UID_SOCK_IFNAME` at the same
+  interface as `NCCL_SOCKET_IFNAME`.
+
+### Choosing a layout
+
+- TP16 has the lower TTFT and TPOT at batch 1-2: no dispatch/combine hop, and
+  the single replica owns the whole batch.
+- The DeepEP layout pulls ahead from mid batch up, where its expert kernels and
+  the second attention replica both pay off.
+
+
 ## GPT-OSS 20B / 120B
 
 Small GPT-OSS launches can start simple. Large GPT-OSS launches usually tune

--- a/docs/serving/parallelism.md
+++ b/docs/serving/parallelism.md
@@ -32,7 +32,7 @@ tokenspeed serve <model> \
 | `--world-size` | Total worker processes across all nodes. |
 | `--nprocs-per-node` | Worker processes launched on each node. |
 | `--attn-tp-size` | Attention tensor parallel size. |
-| `--dense-tp-size` | Dense layer tensor parallel size. |
+| `--dense-tp-size` | Dense layer tensor parallel size. Defaults to the attention replica width (attn TP x CP): the full world without DP attention, one replica with it. |
 | `--moe-tp-size` | MoE layer tensor parallel size. |
 | `--data-parallel-size` | Replicated data-parallel groups. |
 | `--mm-encoder-tp-mode` | `weights` (default), or TP1 whole-item DP within each attention TP group (`data`). |

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -540,12 +540,15 @@ class ServerArgs:
             world_size, attn_tp_size, attn_cp_size, attn_dp_size
         )
 
-        # Dense layers still default to full TP participation when no
-        # dedicated dense_tp_size is provided.
+        # Dense layers default to the attention replica's TP width
+        # (attn_tp_size x attn_cp_size == world_size // attn_dp_size). Without
+        # DP attention this is the full world, unchanged from before; with DP
+        # attention it keeps each dense all-reduce inside one replica (matching
+        # attn) instead of spanning the whole world, which would otherwise cross
+        # nodes and force attn_tp != dense_tp. Pass --dense-tp-size to override.
         dense_tp_size = self.dense_tp_size
         if self.dense_tp_size is None:
-            # dense always do tp now.
-            dense_tp_size = world_size
+            dense_tp_size = attn_tp_size * attn_cp_size
         dense_dp_size = None
 
         # --enable-expert-parallel auto-sets ep_size = world_size
@@ -1840,7 +1843,9 @@ class ServerArgs:
             "--dense-tp-size",
             type=int,
             default=ServerArgs.dense_tp_size,
-            help="Specify tp size for dense part, default equals nprocs-per-node, if non dp_attn && combine_dense mode, this parameter will be overridden by attn_tp_size",
+            help="Specify tp size for dense part. Defaults to the attention "
+            "replica width (attn_tp_size x attn_cp_size): the full world without "
+            "DP attention, one replica with it.",
         )
         parser.add_argument(
             "--moe-tp-size",

--- a/test/runtime/test_cli_config_compat.py
+++ b/test/runtime/test_cli_config_compat.py
@@ -151,6 +151,74 @@ class TestCLIConfigCompat(unittest.TestCase):
         sa = self._from_cli_args_no_init(args)
         self.assertFalse(sa.enable_expert_parallel)
 
+    # ---- Dense TP default ----
+
+    def test_dense_tp_defaults_to_full_world_without_dp(self):
+        # No DP attention: attn_tp == world, so the dense default is unchanged
+        # (still the full world). This is the no-op case for the new default.
+        world, attn_tp = self._parallelism_snapshot(
+            ["--model", "test/model", "--attn-tp-size", "8"]
+        )[:2]
+        dense_tp = self._parallelism_snapshot(
+            ["--model", "test/model", "--attn-tp-size", "8"]
+        )[4]
+        self.assertEqual((world, attn_tp), (8, 8))
+        self.assertEqual(dense_tp, 8)
+
+    def test_dense_tp_defaults_to_attn_replica_width_with_dp(self):
+        # DP attention: the dense default follows the attention replica width
+        # (attn_tp), not the full world, keeping each dense all-reduce local.
+        snap = self._parallelism_snapshot(
+            [
+                "--model",
+                "test/model",
+                "--attn-tp-size",
+                "4",
+                "--data-parallel-size",
+                "2",
+            ]
+        )
+        world, attn_tp, _attn_cp, attn_dp, dense_tp = snap[:5]
+        self.assertEqual((world, attn_tp, attn_dp), (8, 4, 2))
+        self.assertEqual(dense_tp, 4)
+
+    def test_dense_tp_explicit_override_is_respected_under_dp(self):
+        # An explicit --dense-tp-size still wins over the replica-width default.
+        dense_tp = self._parallelism_snapshot(
+            [
+                "--model",
+                "test/model",
+                "--attn-tp-size",
+                "4",
+                "--data-parallel-size",
+                "2",
+                "--dense-tp-size",
+                "8",
+            ]
+        )[4]
+        self.assertEqual(dense_tp, 8)
+
+    def test_dense_tp_default_tracks_replica_width_under_cp(self):
+        # Under ENABLE_CP the attention TP size is reinterpreted as CP, so the
+        # replica width is attn_tp x attn_cp; the dense default must use the
+        # product, not the post-swap attn_tp (which is 1 here).
+        import tokenspeed.runtime.utils.server_args as server_args_mod
+
+        with patch.object(server_args_mod, "ENABLE_CP", True):
+            snap = self._parallelism_snapshot(
+                [
+                    "--model",
+                    "test/model",
+                    "--attn-tp-size",
+                    "4",
+                    "--data-parallel-size",
+                    "2",
+                ]
+            )
+        world, attn_tp, attn_cp, attn_dp, dense_tp = snap[:5]
+        self.assertEqual((world, attn_tp, attn_cp, attn_dp), (8, 1, 4, 2))
+        self.assertEqual(dense_tp, 4)
+
     # ---- vLLM config names ----
 
     def test_tokenizer_arg(self):


### PR DESCRIPTION
## Summary
- Two-node Qwen3.8-max recipe in `docs/recipes/models.md` (TP16 and TP8DP2EP16 DeepEP), using a `<node0-host>` placeholder instead of a literal IP.
- Default `--dense-tp-size` to the attention replica width (`attn_tp_size x attn_cp_size`, i.e. `world_size // attn_dp_size`) instead of the full `world_size`.
- New default documented in `docs/configuration/server.md` and `docs/serving/parallelism.md`.
- ServerArgs tests covering the no-DP, DP, explicit-override, and CP cases.

## Verification
- `test/runtime/test_cli_config_compat.py` — 60 passed.
- `pre-commit run --all-files` clean.
