### PR TITLE
fix(ci): update EvalScope summary metric names

### DIFF
--- a/test/agentic_benchmark/kimi_k2.5/tokenspeed/agentic_bench.sh
+++ b/test/agentic_benchmark/kimi_k2.5/tokenspeed/agentic_bench.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Prepare dataset
-EVALSCOPE_COMMIT=acd09b44384d53174768bb1063f675420f76fae9
+EVALSCOPE_COMMIT=9d052ca0240ebf8b603c053fa44727b863ff3933
 pip install "evalscope[perf] @ git+https://github.com/modelscope/evalscope.git@${EVALSCOPE_COMMIT}"
 
 [ -f build_swe_smith_dataset.py ] || wget https://raw.githubusercontent.com/modelscope/evalscope/${EVALSCOPE_COMMIT}/examples/perf/build_swe_smith_dataset.py \

--- a/test/agentic_benchmark/kimi_k2.5/tokenspeed/collect_outputs.py
+++ b/test/agentic_benchmark/kimi_k2.5/tokenspeed/collect_outputs.py
@@ -35,7 +35,7 @@ def collect(sweep_dir: Path):
             if not summary_path.is_file():
                 continue
             s = json.loads(summary_path.read_text())
-            tpot_ms = s["TPOT (ms)"]
+            tpot_ms = s["Avg TPOT (ms)"]
             decode_tps_user = 1000.0 / tpot_ms if tpot_ms else 0.0
             tps_gpu = s["Total Throughput (tok/s)"] / n_gpus
             rows.append(
@@ -45,7 +45,7 @@ def collect(sweep_dir: Path):
                     "Latency (tps/user)": round(decode_tps_user, 2),
                     "Throughput (tps/gpu)": round(tps_gpu, 2),
                     "Approx Cache Hit": round(s["KV Cache Hit Rate (%)"], 2),
-                    "Decoded Tok/Iter": round(s["Decoded Tok/Iter"], 4),
+                    "Decoded Tok/Iter": round(s["Avg Decoded Tok/Iter"], 4),
                 }
             )
     rows.sort(key=lambda r: (r["config"], r["Conc."]))


### PR DESCRIPTION
## Summary

The agentic performance CI installs `evalscope[perf]` without a version pin, so it began resolving to EvalScope 1.10.0 after the new release. EvalScope 1.10 renamed the summary JSON fields from `TPOT (ms)` and `Decoded Tok/Iter` to `Avg TPOT (ms)` and `Avg Decoded Tok/Iter`.

The benchmark itself completed successfully, but `collect_outputs.py` still accessed the old field names and failed with `KeyError: 'TPOT (ms)'`.

Update the collector to use the EvalScope 1.10 field names while keeping the existing CSV output and performance calculations unchanged. Update the adjacent tokenspeed agentic benchmark pin to EvalScope v1.10.0 as well, so manual sweeps produce the same summary schema as CI.