### PR TITLE
fix(cache): complete recipe migration across CI models

### DIFF
--- a/python/tokenspeed/runtime/cache/host_mirror.py
+++ b/python/tokenspeed/runtime/cache/host_mirror.py
@@ -29,16 +29,16 @@ from collections.abc import Iterable, Sequence
 import torch
 
 
-def _identity_dedup(
+def _physical_view_dedup(
     tensors: Sequence[torch.Tensor | None],
 ) -> list[torch.Tensor]:
-    """Distinct tensors in first-appearance order; None slots (GDN
+    """Distinct physical views in first-appearance order; None slots (GDN
     state layers carry no KV) are skipped."""
     seen: dict[int, torch.Tensor] = {}
     for t in tensors:
         if t is None:
             continue
-        seen.setdefault(id(t), t)
+        seen.setdefault(t.data_ptr(), t)
     return list(seen.values())
 
 
@@ -52,7 +52,7 @@ def bytes_per_host_page(device_kv_pool) -> int:
     device pool alone (no mirror allocation) -- the sizing side of
     ``HostMirror.bytes_per_host_page`` for host-budget arithmetic.
     """
-    tensors = _identity_dedup(device_kv_pool.k_buffer) + _identity_dedup(
+    tensors = _physical_view_dedup(device_kv_pool.k_buffer) + _physical_view_dedup(
         device_kv_pool.v_buffer
     )
     page_size = int(device_kv_pool.page_size)
@@ -88,21 +88,23 @@ class HostMirror:
         # Slab layout dedups the per-layer entries to one K + one V slab per
         # paired layer set (layers-per-group slabs); legacy layout keeps all
         # per-layer buffers (dead-row copies are harmless).
-        k_tensors = _identity_dedup(device_kv_pool.k_buffer)
-        v_tensors = _identity_dedup(device_kv_pool.v_buffer)
+        k_tensors = _physical_view_dedup(device_kv_pool.k_buffer)
+        v_tensors = _physical_view_dedup(device_kv_pool.v_buffer)
         self.num_k_tensors = len(k_tensors)
 
-        k_index = {id(t): i for i, t in enumerate(k_tensors)}
-        v_index = {id(t): i for i, t in enumerate(v_tensors)}
+        k_index = {t.data_ptr(): i for i, t in enumerate(k_tensors)}
+        v_index = {t.data_ptr(): i for i, t in enumerate(v_tensors)}
         # None entries (GDN state layers, no KV) map to None: those
         # layers fence on state_tensor_indices_of_layer instead.
         self._layer_to_k_index = [
-            None if t is None else k_index[id(t)] for t in device_kv_pool.k_buffer
+            None if t is None else k_index[t.data_ptr()]
+            for t in device_kv_pool.k_buffer
         ]
         # Invariant D2 relies on: a layer's V tensor sits at
         # tensor_index_of_layer(layer) + num_k_tensors.
         assert self._layer_to_k_index == [
-            None if t is None else v_index[id(t)] for t in device_kv_pool.v_buffer
+            None if t is None else v_index[t.data_ptr()]
+            for t in device_kv_pool.v_buffer
         ], "host mirror: K/V dedup orders diverge"
 
         state_slabs = _state_slabs(device_kv_pool)

--- a/python/tokenspeed/runtime/cache/host_mirror.py
+++ b/python/tokenspeed/runtime/cache/host_mirror.py
@@ -38,7 +38,7 @@ def _physical_view_dedup(
     for t in tensors:
         if t is None:
             continue
-        seen.setdefault(t.data_ptr(), t)
+        seen.setdefault((t.data_ptr(), t.nbytes), t)
     return list(seen.values())
 
 
@@ -92,18 +92,18 @@ class HostMirror:
         v_tensors = _physical_view_dedup(device_kv_pool.v_buffer)
         self.num_k_tensors = len(k_tensors)
 
-        k_index = {t.data_ptr(): i for i, t in enumerate(k_tensors)}
-        v_index = {t.data_ptr(): i for i, t in enumerate(v_tensors)}
+        k_index = {(t.data_ptr(), t.nbytes): i for i, t in enumerate(k_tensors)}
+        v_index = {(t.data_ptr(), t.nbytes): i for i, t in enumerate(v_tensors)}
         # None entries (GDN state layers, no KV) map to None: those
         # layers fence on state_tensor_indices_of_layer instead.
         self._layer_to_k_index = [
-            None if t is None else k_index[t.data_ptr()]
+            None if t is None else k_index[(t.data_ptr(), t.nbytes)]
             for t in device_kv_pool.k_buffer
         ]
         # Invariant D2 relies on: a layer's V tensor sits at
         # tensor_index_of_layer(layer) + num_k_tensors.
         assert self._layer_to_k_index == [
-            None if t is None else v_index[t.data_ptr()]
+            None if t is None else v_index[(t.data_ptr(), t.nbytes)]
             for t in device_kv_pool.v_buffer
         ], "host mirror: K/V dedup orders diverge"
 
@@ -114,13 +114,16 @@ class HostMirror:
         # the pool's occurrence-indexed get_state_buffers binding).
         self._layer_to_state_pair: dict[int, int] = {}
         if state_slabs:
-            pair_of_conv = {id(conv): n for n, (conv, _) in enumerate(state_slabs)}
+            pair_of_conv = {
+                (conv.data_ptr(), conv.nbytes): n
+                for n, (conv, _) in enumerate(state_slabs)
+            }
             for layer_id in range(len(device_kv_pool.k_buffer)):
                 try:
                     conv, _ssm = device_kv_pool.get_state_buffers(layer_id)
                 except ValueError:
                     continue  # not a state layer
-                self._layer_to_state_pair[layer_id] = pair_of_conv[id(conv)]
+                self._layer_to_state_pair[layer_id] = pair_of_conv[(conv.data_ptr(), conv.nbytes)]
 
         pin = torch.cuda.is_available()
         kv_pairs = [

--- a/python/tokenspeed/runtime/cache/host_mirror.py
+++ b/python/tokenspeed/runtime/cache/host_mirror.py
@@ -123,7 +123,9 @@ class HostMirror:
                     conv, _ssm = device_kv_pool.get_state_buffers(layer_id)
                 except ValueError:
                     continue  # not a state layer
-                self._layer_to_state_pair[layer_id] = pair_of_conv[(conv.data_ptr(), conv.nbytes)]
+                self._layer_to_state_pair[layer_id] = pair_of_conv[
+                    (conv.data_ptr(), conv.nbytes)
+                ]
 
         pin = torch.cuda.is_available()
         kv_pairs = [

--- a/python/tokenspeed/runtime/execution/drafter/mtp.py
+++ b/python/tokenspeed/runtime/execution/drafter/mtp.py
@@ -389,14 +389,19 @@ class Mtp(BaseDrafter):
         # run inside CUDA graph capture, where allocation is off-limits.
         self._lookback_hidden_buf: torch.Tensor | None = None
         if lookback:
+            if self.runtime_states is None:
+                raise RuntimeError("MTP lookback requires request-pool runtime state")
             model_config = draft_model_runner.model_config
+            # page_table is batch-ordered and may have fewer rows than the
+            # request-pool indices used to address these persistent stashes.
+            request_pool_rows = self.runtime_states.valid_cache_lengths.shape[0]
             self._lookback_tokens_buf = torch.zeros(
-                (page_table.shape[0], lookback),
+                (request_pool_rows, lookback),
                 dtype=torch.int64,
                 device=self.device,
             )
             self._lookback_hidden_buf = torch.zeros(
-                (page_table.shape[0], lookback, model_config.hidden_size),
+                (request_pool_rows, lookback, model_config.hidden_size),
                 dtype=model_config.dtype,
                 device=self.device,
             )

--- a/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
@@ -36,7 +36,10 @@ the null page 0 by the scheduler export.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import replace
+from types import MappingProxyType
+from typing import TYPE_CHECKING
 
 import torch
 from tokenspeed_kernel.ops.kvcache.triton import (
@@ -47,6 +50,9 @@ from tokenspeed_kernel.ops.kvcache.triton import (
 from tokenspeed.runtime.configs.cache_runtime import cache_debug_enabled
 from tokenspeed.runtime.utils import get_colorful_logger
 from tokenspeed.runtime.utils.common import ceil_div
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
 
 logger = get_colorful_logger(__name__)
 
@@ -165,12 +171,13 @@ class CacheGroupsMixin:
             tables = {gid: table for gid, table in tables.items() if gid not in skip}
         return tables or None
 
-    # Defaults until _learn_cache_groups / set_cache_pool run
-    # (init_cuda_graph_state is not reached under --enforce-eager or before
-    # the first capture).
+    # Learned from the pool by _learn_cache_groups / set_cache_pool.
+    # Immutable class-level defaults keep the metadata paths working before
+    # those run -- init_cuda_graph_state is never reached under
+    # --enforce-eager.
     state_group_ids: frozenset[str] = frozenset()
-    group_page_sizes: dict[str, int] = {}
-    cache_pool = None
+    group_page_sizes: Mapping[str, int] = MappingProxyType({})
+    cache_pool: CachePool | None = None
 
     def _learn_cache_groups(self, paged_cache_group_specs) -> None:
         """Record the pool's family="state" group ids (see

--- a/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
@@ -165,6 +165,13 @@ class CacheGroupsMixin:
             tables = {gid: table for gid, table in tables.items() if gid not in skip}
         return tables or None
 
+    # Defaults until _learn_cache_groups / set_cache_pool run
+    # (init_cuda_graph_state is not reached under --enforce-eager or before
+    # the first capture).
+    state_group_ids: frozenset[str] = frozenset()
+    group_page_sizes: dict[str, int] = {}
+    cache_pool = None
+
     def _learn_cache_groups(self, paged_cache_group_specs) -> None:
         """Record the pool's family="state" group ids (see
         state_group_ids) and per-group page sizes (heterogeneous block

--- a/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
@@ -36,9 +36,7 @@ the null page 0 by the scheduler export.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from dataclasses import replace
-from types import MappingProxyType
 from typing import TYPE_CHECKING
 
 import torch
@@ -171,13 +169,14 @@ class CacheGroupsMixin:
             tables = {gid: table for gid, table in tables.items() if gid not in skip}
         return tables or None
 
-    # Learned from the pool by _learn_cache_groups / set_cache_pool.
-    # Immutable class-level defaults keep the metadata paths working before
-    # those run -- init_cuda_graph_state is never reached under
-    # --enforce-eager.
-    state_group_ids: frozenset[str] = frozenset()
-    group_page_sizes: Mapping[str, int] = MappingProxyType({})
-    cache_pool: CachePool | None = None
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        # Learned from the pool by _learn_cache_groups / set_cache_pool;
+        # init_cuda_graph_state is never reached under --enforce-eager, so
+        # establish the empty state at construction.
+        self.state_group_ids: frozenset[str] = frozenset()
+        self.group_page_sizes: dict[str, int] = {}
+        self.cache_pool: CachePool | None = None
 
     def _learn_cache_groups(self, paged_cache_group_specs) -> None:
         """Record the pool's family="state" group ids (see

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -1783,20 +1783,22 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         bs: int,
         paged_cache_block_tables: dict[str, torch.Tensor],
         *,
+        actual_bs: int | None = None,
         pad_value: int,
     ) -> dict[str, torch.Tensor]:
         out: dict[str, torch.Tensor] = {}
         if not self._cuda_graph_paged_cache_block_tables:
             return out
+        active_rows = bs if actual_bs is None else actual_bs
         for group_id, buf in self._cuda_graph_paged_cache_block_tables.items():
             table = paged_cache_block_tables.get(group_id)
             buf[:bs].fill_(pad_value)
             if table is not None:
-                if int(table.shape[0]) != bs:
+                if int(table.shape[0]) < active_rows:
                     raise RuntimeError(
                         "DeepSeek V4 CUDA graph paged cache table row count "
                         f"mismatch for {group_id!r}: got {int(table.shape[0])}, "
-                        f"expected padded bs {bs}"
+                        f"expected at least actual_bs {active_rows}"
                     )
                 cols = int(table.shape[1])
                 if cols > int(buf.shape[1]):
@@ -1805,8 +1807,10 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                         f"mismatch for {group_id!r}: got {cols}, capture "
                         f"buffer has {int(buf.shape[1])}"
                     )
-                if cols > 0:
-                    buf[:bs, :cols].copy_(table[:bs, :cols].to(torch.int32))
+                if active_rows > 0 and cols > 0:
+                    buf[:active_rows, :cols].copy_(
+                        table[:active_rows, :cols].to(torch.int32)
+                    )
             out[group_id] = buf[:bs]
         return out
 
@@ -1814,24 +1818,27 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         self,
         bs: int,
         base_offsets: dict[str, torch.Tensor],
+        *,
+        actual_bs: int | None = None,
     ) -> dict[str, torch.Tensor]:
         """Refresh persistent base-offset buffers from per-step input.
 
         Sliding groups whose key is missing fall back to 0. Returns the [:bs]
         views keyed by gid.
         """
+        active_rows = bs if actual_bs is None else actual_bs
         out: dict[str, torch.Tensor] = {}
         for gid, buf in self._cuda_graph_paged_cache_base_offsets.items():
             buf[:bs].fill_(0)
             src = base_offsets.get(gid)
-            if src is not None and bs > 0:
+            if src is not None and active_rows > 0:
                 rows = int(src.shape[0])
-                if rows < bs:
+                if rows < active_rows:
                     raise RuntimeError(
                         "DeepSeek V4 CUDA-graph replay base-offsets row count "
-                        f"{rows} < bs={bs} for group {gid!r}"
+                        f"{rows} < actual_bs={active_rows} for group {gid!r}"
                     )
-                buf[:bs].copy_(src[:bs].to(torch.int32))
+                buf[:active_rows].copy_(src[:active_rows].to(torch.int32))
             out[gid] = buf[:bs]
         return out
 
@@ -2064,26 +2071,39 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                 base_block_table = block_tables[base_group_id]
         if base_block_table is not None:
             width = min(base_block_table.shape[1], self.max_num_pages)
-            self._cuda_graph_block_table[:bs, :width].copy_(
-                base_block_table[:bs, :width].to(device=self.device, dtype=torch.int32)
-            )
+            if int(base_block_table.shape[0]) < actual_bs:
+                raise RuntimeError(
+                    "DeepSeek V4 CUDA graph base table row count "
+                    f"{int(base_block_table.shape[0])} < actual_bs={actual_bs}"
+                )
+            self._cuda_graph_block_table[:bs].zero_()
+            if actual_bs > 0 and width > 0:
+                self._cuda_graph_block_table[:actual_bs, :width].copy_(
+                    base_block_table[:actual_bs, :width].to(
+                        device=self.device, dtype=torch.int32
+                    )
+                )
         offsets_on_device = {
             str(gid): off.to(device=self.device, dtype=torch.int32)
             for gid, off in paged_cache_block_table_base_offsets.items()
         }
         if block_tables:
-            metadata_paged = self._prepare_cache_group_tables(
+            metadata_paged = self._refresh_cuda_graph_paged_cache_block_tables(
+                bs,
                 block_tables,
-                output_buffers=self._cuda_graph_paged_cache_block_tables,
+                actual_bs=actual_bs,
+                pad_value=-1,
             )
             metadata_base_offsets = {}
         elif cache_metadata is not None:
             scheduler_tables = dict(
                 cache_metadata.tables(active_forward_op=forward_batch)
             )
-            metadata_paged = self._prepare_cache_group_tables(
+            metadata_paged = self._refresh_cuda_graph_paged_cache_block_tables(
+                bs,
                 scheduler_tables,
-                output_buffers=self._cuda_graph_paged_cache_block_tables,
+                actual_bs=actual_bs,
+                pad_value=-1,
             )
             metadata_base_offsets = {}
         else:
@@ -2093,11 +2113,13 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                     str(group_id): table.to(device=self.device, dtype=torch.int32)
                     for group_id, table in paged_cache_block_tables.items()
                 },
+                actual_bs=actual_bs,
                 pad_value=-1,
             )
             metadata_base_offsets = self._refresh_cuda_graph_base_offsets(
                 bs,
                 offsets_on_device,
+                actual_bs=actual_bs,
             )
         (
             swa_block_table,

--- a/python/tokenspeed/runtime/layers/attention/backends/inkling.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/inkling.py
@@ -878,7 +878,11 @@ class InklingAttnBackend(AttentionBackend):
                     -1, -1, old_state.shape[-1]
                 ),
             )
-            packed_rows = x[checkpoints.packed_rows]
+            # Static prefill-graph metadata includes padded requests whose
+            # packed row is the one-past-end sentinel. Gather a safe row first;
+            # packed_row_mask discards it below.
+            safe_packed_rows = checkpoints.packed_rows.clamp(max=x.shape[0] - 1)
+            packed_rows = x[safe_packed_rows]
             rows = torch.where(
                 checkpoints.packed_row_mask[..., None],
                 packed_rows,

--- a/python/tokenspeed/runtime/layers/attention/backends/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mla.py
@@ -82,8 +82,10 @@ class MLADecodeMetadata:
     num_extends: int
     page_table: torch.Tensor
     seq_lens: torch.Tensor
-    # Paged cache only: one absolute latent write location per batch row.
+    # Paged cache only: absolute latent write locations, request-major, with
+    # ``group_q_len_per_req`` entries per row (1 outside target verify).
     group_out_cache_loc: torch.Tensor | None = None
+    group_q_len_per_req: int = 1
 
     @property
     def block_kv_indices(self) -> torch.Tensor:
@@ -160,9 +162,9 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
         group_table = None
         logical_page_size = None
         if cache_metadata is not None:
-            if self.is_draft or self.spec_num_tokens > 1:
+            if self.is_draft:
                 raise NotImplementedError(
-                    "MLA Paged cache does not support speculative decoding"
+                    "MLA draft worker does not take the Paged cache path"
                 )
             self._cache_groups_bound = True
             group_table, logical_page_size = self._resolve_full_history_table(
@@ -202,6 +204,7 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
                 page_table=page_table,
                 group_table=group_table,
                 logical_page_size=logical_page_size,
+                q_len_per_req=self._verify_q_len(forward_mode),
             )
 
     @contextmanager
@@ -329,6 +332,7 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
         page_table: torch.Tensor,
         group_table: torch.Tensor | None = None,
         logical_page_size: int | None = None,
+        q_len_per_req: int = 1,
     ):
         if group_table is not None:
             assert logical_page_size is not None
@@ -343,6 +347,7 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
                 batch_size=bs,
                 logical_page_size=logical_page_size,
                 validate_pages=cache_debug_enabled(),
+                q_len_per_req=q_len_per_req,
             )
         else:
             page_table = build_page_table(
@@ -357,6 +362,7 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
             page_table=page_table,
             seq_lens=seq_lens[:bs],
             group_out_cache_loc=group_out_cache_loc,
+            group_q_len_per_req=q_len_per_req,
         )
 
     def select_out_cache_loc(self, layer, out_cache_loc, forward_mode=None):
@@ -370,7 +376,9 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
             metadata = self.forward_decode_metadata
             if metadata is None or metadata.group_out_cache_loc is None:
                 raise RuntimeError("MLA decode write locations are missing")
-            locs = metadata.group_out_cache_loc[metadata.num_extends :]
+            locs = metadata.group_out_cache_loc[
+                metadata.num_extends * metadata.group_q_len_per_req :
+            ]
         else:
             metadata = self.forward_prefill_metadata
             if metadata is None or metadata.group_out_cache_loc is None:
@@ -395,7 +403,9 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
         self.decode_cuda_graph_metadata = {}
         if self._cache_contract_bound:
             self.decode_cuda_graph_group_out_cache_loc = torch.zeros(
-                max_bs, dtype=torch.int64, device=self.device
+                max_bs * max(1, self.spec_num_tokens),
+                dtype=torch.int64,
+                device=self.device,
             )
         else:
             self.decode_cuda_graph_group_out_cache_loc = None
@@ -415,11 +425,12 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
             )
 
         uses_cache_groups = bool(cache_group_ids) or self._cache_contract_bound
-        if uses_cache_groups and (self.is_draft or self.spec_num_tokens > 1):
+        if uses_cache_groups and self.is_draft:
             raise NotImplementedError(
-                "MLA Paged cache CUDA graph capture does not support speculative decoding"
+                "MLA draft worker does not take the Paged cache path"
             )
         page_table = self.cuda_graph_page_table[:bs, :]
+        capture_q_len = self._graph_verify_q_len()
         if uses_cache_groups:
             self._cache_groups_bound = True
             if self.decode_cuda_graph_group_out_cache_loc is None:
@@ -428,7 +439,9 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
                     "mark_cache_contract must run before init_cuda_graph_state"
                 )
             page_table.zero_()
-            group_out_cache_loc = self.decode_cuda_graph_group_out_cache_loc[:bs]
+            group_out_cache_loc = self.decode_cuda_graph_group_out_cache_loc[
+                : bs * capture_q_len
+            ]
             group_out_cache_loc.zero_()
         else:
             group_out_cache_loc = None
@@ -437,9 +450,14 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
             page_table=page_table,
             seq_lens=self.cuda_graph_seq_lens[:bs],
             group_out_cache_loc=group_out_cache_loc,
+            group_q_len_per_req=capture_q_len,
         )
-        # Seed the owned buffer: the capture run reads it before replay.
-        metadata.seq_lens.copy_(seq_lens[:bs])
+        # Seed the owned buffer: the capture run reads it before replay. Verify
+        # rows span seq-N..seq-1, so a shorter length would start before zero.
+        if capture_q_len > 1:
+            metadata.seq_lens.copy_(seq_lens[:bs].clamp_min(capture_q_len))
+        else:
+            metadata.seq_lens.copy_(seq_lens[:bs])
         self.decode_cuda_graph_metadata[bs] = metadata
         self.forward_decode_metadata = metadata
 
@@ -460,7 +478,11 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
         metadata = self.decode_cuda_graph_metadata[bs]
         # Copy the live lengths into our own cache-seqlens buffer (metadata.seq_lens
         # views it); both metadata paths read it at replay.
-        self.cuda_graph_seq_lens[:bs].copy_(seq_lens[:bs])
+        q_len = metadata.group_q_len_per_req
+        if q_len > 1:
+            self.cuda_graph_seq_lens[:bs].copy_(seq_lens[:bs].clamp_min(q_len))
+        else:
+            self.cuda_graph_seq_lens[:bs].copy_(seq_lens[:bs])
         if metadata.group_out_cache_loc is not None:
             self._replay_refresh_decode(
                 bs,
@@ -487,6 +509,7 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
     ) -> None:
         if metadata.group_out_cache_loc is None:
             raise RuntimeError("MLA graph metadata has no write-location buffer")
+        q_len = metadata.group_q_len_per_req
         real_bs = 0
         if cache_metadata is not None:
             table, logical_page_size = self._resolve_full_history_table(
@@ -507,9 +530,10 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
                     logical_page_size=logical_page_size,
                     validate_pages=cache_debug_enabled(),
                     out=metadata.group_out_cache_loc,
+                    q_len_per_req=q_len,
                 )
         metadata.page_table[real_bs:bs].zero_()
-        metadata.group_out_cache_loc[real_bs:bs].zero_()
+        metadata.group_out_cache_loc[real_bs * q_len : bs * q_len].zero_()
 
     def get_cuda_graph_seq_len_fill_value(self):
         return 1

--- a/python/tokenspeed/runtime/layers/attention/backends/mla_cache_groups.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mla_cache_groups.py
@@ -221,7 +221,11 @@ class MlaCacheGroupMixin:
         """
         if self.spec_num_tokens <= 1:
             return 1
-        if not self.is_draft and forward_mode is not None and forward_mode.is_decode():
+        if (
+            not self.is_draft
+            and forward_mode is not None
+            and (forward_mode.is_decode() or forward_mode.is_mixed())
+        ):
             return self.spec_num_tokens
         return 1
 

--- a/python/tokenspeed/runtime/layers/attention/backends/msa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/msa.py
@@ -822,6 +822,18 @@ class MSAHybridAttnBackend(AttentionBackend):
         return self.full_attn_backend
 
     @property
+    def cache_consumer_families(self) -> frozenset[str]:
+        """Cache families consumed by the dense and sparse children."""
+        return frozenset(
+            getattr(self.full_attn_backend, "cache_consumer_families", ())
+        ) | frozenset(getattr(self.sparse_attn_backend, "cache_consumer_families", ()))
+
+    def set_cache_pool(self, cache_pool) -> None:
+        self.cache_pool = cache_pool
+        self.full_attn_backend.set_cache_pool(cache_pool)
+        self.sparse_attn_backend.set_cache_pool(cache_pool)
+
+    @property
     def sinks_dtype(self) -> torch.dtype:
         return self.full_attn_backend.sinks_dtype
 

--- a/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
@@ -109,9 +109,10 @@ class CuteDSLMLADecodeMetadata:
     block_kv_indices: torch.Tensor | None = None
     max_seq_len_k: int | None = None
     seq_lens_k: torch.Tensor | None = None
-    # Paged cache only: absolute latent write locations, one per batch row
-    # (position seq_len - 1); decode consumers slice [num_extends:].
+    # Paged cache only: absolute latent write locations, group_q_len_per_req
+    # entries per batch row. Mixed-batch decode skips whole prefill windows.
     group_out_cache_loc: torch.Tensor | None = None
+    group_q_len_per_req: int = 1
 
 
 class CuteDSLMLABackend(AttentionBackend):
@@ -213,6 +214,10 @@ class CuteDSLMLABackend(AttentionBackend):
         from the cache metadata each forward.
         """
         del logical_page_size
+        if self.is_draft:
+            # The CuteDSL draft keeps its batch-ordered page table. Only target
+            # forwards consume scheduler cache-group metadata.
+            return
         self._cache_contract_bound = True
 
     def _calc_padded_blocks(self, max_seq_len: int) -> int:
@@ -482,7 +487,7 @@ class CuteDSLMLABackend(AttentionBackend):
                 if (
                     self.spec_num_tokens > 1
                     and not self.is_draft
-                    and forward_mode.is_decode()
+                    and (forward_mode.is_decode() or forward_mode.is_mixed())
                 )
                 else 1
             )
@@ -527,7 +532,9 @@ class CuteDSLMLABackend(AttentionBackend):
                     "MLA decode write locations are missing; "
                     "init_forward_metadata must run with paged cache metadata"
                 )
-            locs = metadata.group_out_cache_loc[metadata.num_extends :]
+            locs = metadata.group_out_cache_loc[
+                metadata.num_extends * metadata.group_q_len_per_req :
+            ]
         else:
             metadata = self.forward_prefill_metadata
             if metadata is None or metadata.group_out_cache_loc is None:
@@ -580,6 +587,7 @@ class CuteDSLMLABackend(AttentionBackend):
             seq_lens_k=seq_lens,
             num_extends=num_extends,
             group_out_cache_loc=group_out_cache_loc,
+            group_q_len_per_req=q_len_per_req,
         )
 
     def _init_prefill_metadata(
@@ -754,6 +762,7 @@ class CuteDSLMLABackend(AttentionBackend):
                 seq_lens_k=self.cuda_graph_seq_lens_buf[:bs],
                 num_extends=0,
                 group_out_cache_loc=group_out_cache_loc,
+                group_q_len_per_req=capture_q_len,
             )
         else:
             metadata = CuteDSLMLADecodeMetadata(
@@ -846,11 +855,7 @@ class CuteDSLMLABackend(AttentionBackend):
             )
         # Target verify graphs are captured with q_len write locations per
         # request (request-major flattened); mirror the capture-time width.
-        replay_q_len = (
-            self.spec_num_tokens
-            if (self.spec_num_tokens > 1 and not self.is_draft)
-            else 1
-        )
+        replay_q_len = metadata.group_q_len_per_req
         max_blocks = metadata.block_kv_indices.shape[1]
         real_bs = 0
         if cache_metadata is not None:

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/factory.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/factory.py
@@ -1,5 +1,8 @@
 """Concrete cache-pool construction from a prepared cache spec."""
 
+from dataclasses import replace
+
+from tokenspeed.runtime.configs.cache_runtime import PagedCacheRuntimeContract
 from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
 from tokenspeed.runtime.layers.attention.configs.dsa import DSAConfig
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
@@ -7,6 +10,35 @@ from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.configs.msa import MSAConfig
 from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
 from tokenspeed.runtime.layers.attention.kv_cache.setup import CachePoolSpec
+
+
+def _publish_runtime_contract(pool: CachePool, spec: CachePoolSpec) -> CachePool:
+    """Attach the scheduler contract derived by the cache recipe."""
+    if getattr(pool, "runtime_contract", None) is None:
+        packing = {
+            group.group_id: group.cache_blocks_per_lcm_block
+            for group in spec.memory_plan.groups
+        }
+        group_specs = tuple(
+            replace(
+                group_spec,
+                cache_blocks_per_lcm_block=packing[group_spec.group_id],
+            )
+            for group_spec in pool.paged_cache_group_specs
+        )
+        group_page_counts = {
+            group.group_id: group.page_count for group in spec.memory_plan.groups
+        }
+        pool.paged_cache_group_specs = group_specs
+        pool.paged_cache_group_page_counts = group_page_counts
+        pool.runtime_contract = PagedCacheRuntimeContract(
+            block_size=spec.memory_plan.logical_block_tokens,
+            num_lcm_blocks=spec.memory_plan.num_lcm_blocks,
+            token_capacity=spec.token_capacity,
+            group_specs=group_specs,
+            group_page_counts=group_page_counts,
+        )
+    return pool
 
 
 def create_cache_pool(
@@ -30,7 +62,7 @@ def create_cache_pool(
         options = spec.pool_options
         if not isinstance(options, DeepseekV4PoolOptions):
             raise TypeError("DeepSeek V4 cache spec is missing pool options")
-        return HybridDeepseekV4TokenToKVPool(
+        pool = HybridDeepseekV4TokenToKVPool(
             size=spec.pool_size,
             model_dtype=config.dtype,
             layout=options.layout,
@@ -45,12 +77,13 @@ def create_cache_pool(
             memory_plan=plan,
             token_capacity=spec.token_capacity,
         )
+        return _publish_runtime_contract(pool, spec)
     if isinstance(config, DSAConfig):
         from tokenspeed.runtime.layers.attention.kv_cache.dsa import (
             DSATokenToKVPool,
         )
 
-        return DSATokenToKVPool(
+        pool = DSATokenToKVPool(
             size=spec.pool_size,
             dtype=config.kv_cache_dtype,
             model_dtype=config.dtype,
@@ -67,12 +100,13 @@ def create_cache_pool(
             index_head_dim=config.index_head_dim,
             memory_plan=plan,
         )
+        return _publish_runtime_contract(pool, spec)
     if isinstance(config, MSAConfig):
         from tokenspeed.runtime.layers.attention.kv_cache.msa import (
             MSATokenToKVPool,
         )
 
-        return MSATokenToKVPool(
+        pool = MSATokenToKVPool(
             size=spec.pool_size,
             dtype=config.kv_cache_dtype,
             head_num=max(config.num_kv_heads // config.attn_tp_size, 1),
@@ -93,6 +127,7 @@ def create_cache_pool(
             pd_disaggregation_enabled=config.pd_disaggregation_enabled,
             memory_plan=plan,
         )
+        return _publish_runtime_contract(pool, spec)
     if isinstance(config, MHAConfig):
         if spec.family == "mha":
             from tokenspeed.runtime.layers.attention.kv_cache.mha import (
@@ -103,7 +138,7 @@ def create_cache_pool(
             pool_cls = (
                 MHATokenToKVPoolMXFP8 if config.kv_cache_mxfp8 else MHATokenToKVPool
             )
-            return pool_cls(
+            pool = pool_cls(
                 size=spec.pool_size,
                 dtype=config.kv_cache_dtype,
                 head_num=max(config.num_kv_heads // config.attn_tp_size, 1),
@@ -122,6 +157,7 @@ def create_cache_pool(
                 extra_paged_groups=spec.extra_paged_groups,
                 memory_plan=plan,
             )
+            return _publish_runtime_contract(pool, spec)
         if spec.family == "inkling":
             from tokenspeed.runtime.layers.attention.kv_cache.hybrid_inkling import (
                 HybridInklingTokenToKVPool,
@@ -148,7 +184,7 @@ def create_cache_pool(
             raise TypeError(
                 f"cache family {spec.family!r} is incompatible with MHAConfig"
             )
-        return pool_cls(
+        pool = pool_cls(
             size=spec.pool_size,
             dtype=config.kv_cache_dtype,
             head_num=max(config.num_kv_heads // config.attn_tp_size, 1),
@@ -172,13 +208,14 @@ def create_cache_pool(
             state_field_dtypes=spec.state_field_dtypes,
             token_capacity=spec.token_capacity,
         )
+        return _publish_runtime_contract(pool, spec)
     if isinstance(config, MLAConfig):
         if spec.family == "mla":
             from tokenspeed.runtime.layers.attention.kv_cache.mla import (
                 MLATokenToKVPool,
             )
 
-            return MLATokenToKVPool(
+            pool = MLATokenToKVPool(
                 size=spec.pool_size,
                 dtype=config.kv_cache_dtype,
                 model_dtype=config.dtype,
@@ -195,6 +232,7 @@ def create_cache_pool(
                 max_scheduled_tokens=config.max_scheduled_tokens,
                 memory_plan=plan,
             )
+            return _publish_runtime_contract(pool, spec)
 
         if spec.family != "kimi_k3":
             raise TypeError(
@@ -205,7 +243,7 @@ def create_cache_pool(
             HybridKDATokenToKVPool,
         )
 
-        return HybridKDATokenToKVPool(
+        pool = HybridKDATokenToKVPool(
             size=spec.pool_size,
             dtype=config.kv_cache_dtype,
             model_dtype=config.dtype,
@@ -227,4 +265,5 @@ def create_cache_pool(
             memory_plan=plan,
             token_capacity=spec.token_capacity,
         )
+        return _publish_runtime_contract(pool, spec)
     raise TypeError(f"cache setup does not support config type {type(config).__name__}")

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/ordinary.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/ordinary.py
@@ -298,13 +298,14 @@ def build_hybrid_cache_setup(
     draft_spec = None
     if draft_layout is not None:
         draft_plan = draft_layout.with_num_lcm_blocks(num_lcm_blocks)
+        draft_max_packing = max(draft_group_packing.values())
         draft_spec = CachePoolSpec(
             family=family,
             memory_plan=draft_plan,
             layer_types=draft_layer_types,
             layer_group_ids=draft_group_ids,
             state_field_dtypes={},
-            token_capacity=target_spec.token_capacity,
+            token_capacity=(num_lcm_blocks * draft_max_packing * logical_block_tokens),
             layer_kv_head_counts=draft_layer_kv_head_counts,
         )
     return CacheSetup(
@@ -373,6 +374,7 @@ def _ordinary_setup(
     draft_attn_config,
     draft_fields,
     draft_group_ids: tuple[str, ...],
+    draft_family: str,
     cache_budget_bytes: int,
 ):
     from tokenspeed.runtime.layers.attention.kv_cache.setup import (
@@ -427,7 +429,7 @@ def _ordinary_setup(
         )
         draft_plan = draft_layout.with_num_lcm_blocks(num_pages)
         draft_spec = CachePoolSpec(
-            family=family,
+            family=draft_family,
             memory_plan=draft_plan,
             layer_types=tuple(getattr(draft_attn_config, "layer_types", ())),
             layer_group_ids=draft_group_ids,
@@ -443,6 +445,34 @@ def _ordinary_setup(
         cache_budget_bytes=cache_budget_bytes,
         fixed_workspace_bytes=0,
     )
+
+
+def _ordinary_fields(config, num_layers: int):
+    """Return the recipe family and fields for one ordinary attention config."""
+    from tokenspeed.runtime.layers.attention.configs.dsa import DSAConfig
+    from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
+    from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
+    from tokenspeed.runtime.layers.attention.configs.msa import MSAConfig
+
+    if isinstance(config, DSAConfig):
+        return (
+            "dsa",
+            _dsa_fields(config, num_layers),
+            ("full_attention",) * num_layers,
+        )
+    if isinstance(config, MSAConfig):
+        fields, group_ids = _msa_fields(config, num_layers)
+        return "msa", fields, group_ids
+    if isinstance(config, MLAConfig):
+        return (
+            "mla",
+            _mla_fields(config, num_layers),
+            ("full_attention",) * num_layers,
+        )
+    if isinstance(config, MHAConfig):
+        fields, group_ids = _mha_fields(config, num_layers)
+        return "mha", fields, group_ids
+    raise TypeError(f"no ordinary cache recipe for {type(config).__name__}")
 
 
 def _mha_fields(config, num_layers: int):
@@ -501,8 +531,9 @@ def prepare_mha_cache(
     )
     draft_fields = None
     draft_group_ids = ()
+    draft_family = "mha"
     if draft_attn_config is not None:
-        draft_fields, draft_group_ids = _mha_fields(
+        draft_family, draft_fields, draft_group_ids = _ordinary_fields(
             draft_attn_config, draft_model_config.num_attention_layers
         )
     return _ordinary_setup(
@@ -516,6 +547,7 @@ def prepare_mha_cache(
         draft_attn_config=draft_attn_config,
         draft_fields=draft_fields,
         draft_group_ids=draft_group_ids,
+        draft_family=draft_family,
         cache_budget_bytes=cache_budget_bytes,
     )
 
@@ -573,9 +605,9 @@ def prepare_mla_cache(
     target_fields = _mla_fields(attn_config, model_config.num_attention_layers)
     draft_fields = None
     draft_group_ids = ()
+    draft_family = "mla"
     if draft_attn_config is not None:
-        draft_group_ids = ("full_attention",) * draft_model_config.num_attention_layers
-        draft_fields = _mla_fields(
+        draft_family, draft_fields, draft_group_ids = _ordinary_fields(
             draft_attn_config, draft_model_config.num_attention_layers
         )
     return _ordinary_setup(
@@ -589,6 +621,7 @@ def prepare_mla_cache(
         draft_attn_config=draft_attn_config,
         draft_fields=draft_fields,
         draft_group_ids=draft_group_ids,
+        draft_family=draft_family,
         cache_budget_bytes=cache_budget_bytes,
     )
 
@@ -629,9 +662,9 @@ def prepare_dsa_cache(
     target_fields = _dsa_fields(attn_config, model_config.num_attention_layers)
     draft_fields = None
     draft_group_ids = ()
+    draft_family = "dsa"
     if draft_attn_config is not None:
-        draft_group_ids = ("full_attention",) * draft_model_config.num_attention_layers
-        draft_fields = _dsa_fields(
+        draft_family, draft_fields, draft_group_ids = _ordinary_fields(
             draft_attn_config, draft_model_config.num_attention_layers
         )
     return _ordinary_setup(
@@ -645,6 +678,7 @@ def prepare_dsa_cache(
         draft_attn_config=draft_attn_config,
         draft_fields=draft_fields,
         draft_group_ids=draft_group_ids,
+        draft_family=draft_family,
         cache_budget_bytes=cache_budget_bytes,
     )
 
@@ -685,8 +719,9 @@ def prepare_msa_cache(
     )
     draft_fields = None
     draft_group_ids = ()
+    draft_family = "msa"
     if draft_attn_config is not None:
-        draft_fields, draft_group_ids = _msa_fields(
+        draft_family, draft_fields, draft_group_ids = _ordinary_fields(
             draft_attn_config, draft_model_config.num_attention_layers
         )
     return _ordinary_setup(
@@ -700,5 +735,6 @@ def prepare_msa_cache(
         draft_attn_config=draft_attn_config,
         draft_fields=draft_fields,
         draft_group_ids=draft_group_ids,
+        draft_family=draft_family,
         cache_budget_bytes=cache_budget_bytes,
     )

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -121,7 +121,6 @@ def _validate_shared_cache_geometry(pool, draft_pool) -> None:
             "entry_stride_tokens",
             "sliding_window_tokens",
             "family",
-            "block_size",
             "cache_blocks_per_lcm_block",
         )
         if any(

--- a/python/tokenspeed/runtime/models/qwen3_5_nextn.py
+++ b/python/tokenspeed/runtime/models/qwen3_5_nextn.py
@@ -42,6 +42,8 @@ from tokenspeed.runtime.layers.moe import (
     ExpertCheckpointSchema,
     build_moe_checkpoint_loader,
 )
+from tokenspeed.runtime.layers.quantization.base_config import QuantizationConfig
+from tokenspeed.runtime.layers.quantization.utils import should_exclude_quant_module
 from tokenspeed.runtime.layers.vocab_parallel_embedding import ParallelLMHead
 from tokenspeed.runtime.model_loader.weight_utils import default_weight_loader
 from tokenspeed.runtime.models.qwen3_5 import (
@@ -51,6 +53,18 @@ from tokenspeed.runtime.models.qwen3_5 import (
 from tokenspeed.runtime.utils import add_prefix
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_mtp_quant_config(
+    quant_config: QuantizationConfig | None,
+) -> QuantizationConfig | None:
+    # ModelOpt recipes may leave the MTP subtree unquantized even when the
+    # target model is NVFP4. Honor that checkpoint contract during construction.
+    if quant_config is not None and should_exclude_quant_module(
+        "mtp.layers.0", quant_config.exclude_modules
+    ):
+        return None
+    return quant_config
 
 
 class Qwen3_5DraftAttentionDecoderLayer(Qwen3_5AttentionDecoderLayer):
@@ -164,6 +178,8 @@ class Qwen3_5ForConditionalGenerationNextN(nn.Module):
         self.is_multimodal = hasattr(config, "text_config")
         if self.is_multimodal:
             config = config.text_config
+
+        quant_config = _resolve_mtp_quant_config(quant_config)
 
         self.config = config
         self.mapping = mapping

--- a/test/runtime/test_cache_setup.py
+++ b/test/runtime/test_cache_setup.py
@@ -7,16 +7,123 @@ import torch
 from tokenspeed.runtime.configs.paged_cache_spec import (
     FULL_ATTENTION,
     LINEAR_ATTENTION,
+    PagedCacheGroupSpec,
 )
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
+from tokenspeed.runtime.layers.attention.configs.msa import MSAConfig
 from tokenspeed.runtime.layers.attention.kv_cache.factory import create_cache_pool
 from tokenspeed.runtime.layers.attention.kv_cache.hybrid_mha import (
     HybridMHATokenToKVPool,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.mha import MHATokenToKVPool
 from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
+from tokenspeed.runtime.layers.attention.kv_cache.plan import CacheFieldSpec
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.ordinary import (
+    build_hybrid_cache_setup,
+)
 from tokenspeed.runtime.layers.attention.kv_cache.setup import prepare_cache_setup
+from tokenspeed.runtime.layers.attention.registry import (
+    _validate_shared_cache_geometry,
+)
+
+
+def _mha_config() -> MHAConfig:
+    return MHAConfig(
+        device="cpu",
+        backend_name="fa2",
+        num_attention_heads=1,
+        layer_types=(),
+        kv_cache_mxfp8=False,
+        num_kv_heads=1,
+        attn_tp_size=1,
+        head_dim=2,
+        dtype=torch.bfloat16,
+        kv_cache_dtype=torch.bfloat16,
+        context_len=1024,
+        max_graph_bs=2,
+        max_bs=2,
+        page_size=64,
+        kv_cache_quant_method="none",
+        max_scheduled_tokens=128,
+    )
+
+
+def _mla_config() -> MLAConfig:
+    return MLAConfig(
+        device="cpu",
+        backend_name="trtllm_mla",
+        num_attention_heads=1,
+        num_kv_heads=1,
+        attn_tp_size=1,
+        head_dim=8,
+        dtype=torch.bfloat16,
+        kv_cache_dtype=torch.bfloat16,
+        context_len=1024,
+        max_graph_bs=2,
+        max_bs=2,
+        page_size=64,
+        kv_cache_quant_method="none",
+        kv_lora_rank=4,
+        qk_nope_head_dim=2,
+        qk_rope_head_dim=2,
+        v_head_dim=4,
+        scaling=1.0,
+        kv_cache_dim=6,
+        max_scheduled_tokens=128,
+    )
+
+
+def _msa_config() -> MSAConfig:
+    return MSAConfig(
+        device="cpu",
+        backend_name="msa",
+        num_attention_heads=1,
+        num_kv_heads=1,
+        attn_tp_size=1,
+        head_dim=2,
+        dtype=torch.bfloat16,
+        kv_cache_dtype=torch.bfloat16,
+        context_len=1024,
+        max_graph_bs=2,
+        max_bs=2,
+        page_size=64,
+        kv_cache_quant_method="none",
+        compute_layer_types=("full_attention", "sparse_attention"),
+        sparse_layer_ids=frozenset({1}),
+        max_scheduled_tokens=128,
+        index_head_dim=4,
+        index_n_heads=1,
+        index_block_size=64,
+        index_topk_blocks=1,
+        index_init_blocks=1,
+        index_local_blocks=1,
+    )
+
+
+def _hybrid_setup_with_narrow_draft():
+    return build_hybrid_cache_setup(
+        family="inkling",
+        server_args=SimpleNamespace(max_total_tokens=None),
+        fields=(
+            CacheFieldSpec("full_attention", "target.full", "shared", (256,), 1),
+            CacheFieldSpec("state", "target.state", "shared", (128,), 1),
+        ),
+        layer_types=("full_attention",),
+        group_ids=("full_attention",),
+        state_dtypes={},
+        layer_kv_head_counts=None,
+        draft_fields=(
+            CacheFieldSpec("full_attention", "draft.full", "shared", (256,), 1),
+        ),
+        draft_layer_types=("full_attention",),
+        draft_group_ids=("full_attention",),
+        draft_layer_kv_head_counts=None,
+        cache_budget_bytes=2_048,
+        fixed_workspace_bytes=0,
+        logical_block_tokens=4,
+        max_padding_fraction=1.0,
+    )
 
 
 def test_attention_configs_do_not_own_cache_setup() -> None:
@@ -116,24 +223,7 @@ def test_ordinary_mha_reserves_null_parent_within_cache_budget() -> None:
         num_attention_layers=2,
         hf_config=SimpleNamespace(),
     )
-    attn_config = MHAConfig(
-        device="cpu",
-        backend_name="fa2",
-        num_attention_heads=1,
-        layer_types=(),
-        kv_cache_mxfp8=False,
-        num_kv_heads=1,
-        attn_tp_size=1,
-        head_dim=2,
-        dtype=torch.bfloat16,
-        kv_cache_dtype=torch.bfloat16,
-        context_len=1024,
-        max_graph_bs=2,
-        max_bs=2,
-        page_size=64,
-        kv_cache_quant_method="none",
-        max_scheduled_tokens=128,
-    )
+    attn_config = _mha_config()
     server_args = SimpleNamespace(max_total_tokens=None)
 
     setup = prepare_cache_setup(
@@ -162,6 +252,7 @@ def test_ordinary_mha_reserves_null_parent_within_cache_budget() -> None:
         enable_memory_saver=False,
     )
     assert type(pool) is MHATokenToKVPool
+    assert pool.runtime_contract.token_capacity == setup.target.token_capacity
     with pytest.raises(TypeError, match="incompatible with MHAConfig"):
         create_cache_pool(
             replace(setup.target, family="kimi_k3"),
@@ -177,28 +268,7 @@ def test_ordinary_mla_reserves_null_parent_within_cache_budget() -> None:
         num_attention_layers=2,
         hf_config=SimpleNamespace(),
     )
-    attn_config = MLAConfig(
-        device="cpu",
-        backend_name="trtllm_mla",
-        num_attention_heads=1,
-        num_kv_heads=1,
-        attn_tp_size=1,
-        head_dim=8,
-        dtype=torch.bfloat16,
-        kv_cache_dtype=torch.bfloat16,
-        context_len=1024,
-        max_graph_bs=2,
-        max_bs=2,
-        page_size=64,
-        kv_cache_quant_method="none",
-        kv_lora_rank=4,
-        qk_nope_head_dim=2,
-        qk_rope_head_dim=2,
-        v_head_dim=4,
-        scaling=1.0,
-        kv_cache_dim=6,
-        max_scheduled_tokens=128,
-    )
+    attn_config = _mla_config()
     server_args = SimpleNamespace(max_total_tokens=None)
 
     setup = prepare_cache_setup(
@@ -227,3 +297,84 @@ def test_ordinary_mla_reserves_null_parent_within_cache_budget() -> None:
         enable_memory_saver=False,
     )
     assert type(pool) is MLATokenToKVPool
+    assert pool.runtime_contract.token_capacity == setup.target.token_capacity
+
+
+@pytest.mark.parametrize(
+    ("family", "target_config"),
+    (("mla", _mla_config), ("msa", _msa_config)),
+)
+def test_ordinary_recipe_uses_the_draft_attention_family(
+    family: str,
+    target_config,
+) -> None:
+    model_config = SimpleNamespace(num_attention_layers=2, hf_config=SimpleNamespace())
+    draft_model_config = SimpleNamespace(
+        num_attention_layers=1, hf_config=SimpleNamespace()
+    )
+    draft_attn_config = _mha_config()
+
+    setup = prepare_cache_setup(
+        family=family,
+        server_args=SimpleNamespace(max_total_tokens=None),
+        model_config=model_config,
+        attn_config=target_config(),
+        draft_model_config=draft_model_config,
+        draft_attn_config=draft_attn_config,
+        cache_budget_bytes=65_536,
+        decode_input_tokens=1,
+        overlap_schedule_depth=0,
+    )
+
+    assert setup.draft is not None
+    assert setup.draft.family == "mha"
+    draft_pool = create_cache_pool(
+        setup.draft,
+        draft_attn_config,
+        num_layers=1,
+        rank=0,
+        enable_memory_saver=False,
+    )
+    assert type(draft_pool) is MHATokenToKVPool
+    assert draft_pool.runtime_contract.token_capacity == setup.draft.token_capacity
+
+
+def test_shared_cache_geometry_uses_current_group_spec_fields() -> None:
+    setup = _hybrid_setup_with_narrow_draft()
+    assert setup.draft is not None
+    target_group = setup.target.memory_plan.group("full_attention")
+    spec = PagedCacheGroupSpec(
+        group_id="full_attention",
+        retention="full_history",
+        rows_per_page=4,
+        entry_stride_tokens=1,
+        sliding_window_tokens=None,
+        cache_blocks_per_lcm_block=target_group.cache_blocks_per_lcm_block,
+    )
+    target_pool = SimpleNamespace(
+        runtime_contract=object(),
+        plan=setup.target.memory_plan,
+        paged_cache_group_specs=(spec,),
+        buffer=torch.empty(1),
+    )
+    draft_pool = SimpleNamespace(
+        runtime_contract=object(),
+        plan=setup.draft.memory_plan,
+        paged_cache_group_specs=(spec,),
+        buffer=torch.empty(1),
+    )
+
+    _validate_shared_cache_geometry(target_pool, draft_pool)
+
+
+def test_hybrid_draft_capacity_uses_its_own_group_packing() -> None:
+    setup = _hybrid_setup_with_narrow_draft()
+
+    assert setup.draft is not None
+    draft_max_packing = max(
+        group.cache_blocks_per_lcm_block for group in setup.draft.memory_plan.groups
+    )
+    assert setup.draft.token_capacity == (
+        setup.draft.memory_plan.num_lcm_blocks * draft_max_packing * 4
+    )
+    assert setup.draft.token_capacity < setup.target.token_capacity

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -1891,7 +1891,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         backend.init_cuda_graph_state(
             2,
             paged_cache_group_specs=(
-                SimpleNamespace(
+                PagedCacheGroupSpec(
                     group_id="v4.swa_kv",
                     retention="sliding_window",
                     rows_per_page=64,

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -47,6 +47,7 @@ from tokenspeed.runtime.configs.model_config import (
     is_deepseek_v4,
     is_deepseek_v4_nextn,
 )
+from tokenspeed.runtime.configs.paged_cache_spec import PagedCacheGroupSpec
 from tokenspeed.runtime.distributed import Mapping
 from tokenspeed.runtime.execution.cuda_graph_wrapper import (
     CudaGraphWrapper,
@@ -3146,6 +3147,57 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
         )
         self.assertEqual(metadata.decode_token_count(), 4)
+
+    def test_deepseek_v4_cuda_graph_replay_pads_actual_batch_cache_tables(self):
+        backend = DeepseekV4AttentionBackend(
+            SimpleNamespace(
+                page_size=64,
+                device="cpu",
+                num_attention_heads=64,
+                num_kv_heads=1,
+                attn_tp_size=1,
+                dtype=torch.bfloat16,
+                is_draft=False,
+                speculative_num_draft_tokens=1,
+                head_dim=512,
+                context_len=512,
+            )
+        )
+        group_id = v4_compressed_kv_group_id(4)
+        backend.init_cuda_graph_state(
+            max_bs=4,
+            paged_cache_group_specs=(
+                PagedCacheGroupSpec(
+                    group_id=group_id,
+                    retention="full_history",
+                    rows_per_page=64,
+                    entry_stride_tokens=4,
+                    sliding_window_tokens=None,
+                ),
+            ),
+        )
+        backend.init_forward_metadata_capture_cuda_graph(
+            bs=4,
+            req_pool_indices=torch.arange(4, dtype=torch.int32),
+            seq_lens=torch.ones(4, dtype=torch.int32),
+            forward_mode=ForwardMode.DECODE,
+        )
+        active_table = torch.tensor([[10, 11], [20, 21]], dtype=torch.int32)
+
+        backend.init_forward_metadata_replay_cuda_graph(
+            bs=4,
+            actual_bs=2,
+            req_pool_indices=torch.arange(4, dtype=torch.int32),
+            seq_lens=torch.tensor([70, 3, 1, 1], dtype=torch.int32),
+            forward_mode=ForwardMode.DECODE,
+            block_tables={group_id: active_table},
+        )
+
+        table = backend.forward_metadata.cache.block_table
+        self.assertTrue(torch.equal(table[:2, :2], active_table))
+        self.assertTrue(
+            torch.equal(table[2:, :2], torch.zeros((2, 2), dtype=torch.int32))
+        )
 
     def test_deepseek_v4_indexer_metadata_refresh_masks_padding_tokens(self):
         key = (4, 4, 3)

--- a/test/runtime/test_draft_advance_seqlens.py
+++ b/test/runtime/test_draft_advance_seqlens.py
@@ -18,7 +18,10 @@ from tokenspeed.runtime.layers.attention.backends.base import (
     init_backend_cuda_graph_state,
 )
 from tokenspeed.runtime.layers.attention.backends.mha import MHAAttnBackend
-from tokenspeed.runtime.layers.attention.backends.msa import MSAAttnBackend
+from tokenspeed.runtime.layers.attention.backends.msa import (
+    MSAAttnBackend,
+    MSAHybridAttnBackend,
+)
 from tokenspeed.runtime.layers.attention.backends.trtllm import (
     TRTLLMMHAAttnBackend,
 )
@@ -142,6 +145,30 @@ def test_msa_inherits_default_advance():
     seq_lens = torch.tensor([11, 12, 13, 14], dtype=torch.int32)
     be.advance_draft_forward_metadata(seq_lens)
     assert torch.equal(be.cuda_graph_seq_lens[:4], seq_lens)
+
+
+def test_msa_hybrid_composes_cache_contract_from_children():
+    class ChildBackend:
+        def __init__(self, families):
+            self.cache_consumer_families = frozenset(families)
+            self.cache_pool = None
+
+        def set_cache_pool(self, cache_pool):
+            self.cache_pool = cache_pool
+
+    dense = ChildBackend({"history"})
+    sparse = ChildBackend({"history"})
+    backend = object.__new__(MSAHybridAttnBackend)
+    backend.full_attn_backend = dense
+    backend.sparse_attn_backend = sparse
+    pool = object()
+
+    backend.set_cache_pool(pool)
+
+    assert backend.cache_consumer_families == frozenset({"history"})
+    assert backend.cache_pool is pool
+    assert dense.cache_pool is pool
+    assert sparse.cache_pool is pool
 
 
 def test_default_advance_is_a_noop_before_graph_state_exists():

--- a/test/runtime/test_drafter_accept_indexing.py
+++ b/test/runtime/test_drafter_accept_indexing.py
@@ -6,6 +6,7 @@ import torch
 from tokenspeed.runtime.execution.drafter.dflash import DFlash
 from tokenspeed.runtime.execution.drafter.eagle import Eagle, EagleDraftInput
 from tokenspeed.runtime.execution.drafter.mtp import (
+    Mtp,
     _committed_tail_update,
     _extend_depth_precompute,
     _extend_depth_shifted_ids_from,
@@ -26,6 +27,38 @@ def _make_eagle(spec_num_tokens: int = 4, max_bs: int = 8) -> Eagle:
 
 
 class TestDrafterAcceptIndexing(unittest.TestCase):
+    def test_mtp_lookback_stash_uses_request_pool_capacity(self):
+        max_bs = 16
+        request_pool_rows = 18
+        input_buffers = SimpleNamespace(
+            max_bs=max_bs,
+            seq_lens_buf=torch.zeros(max_bs, dtype=torch.int32),
+        )
+        model_runner = SimpleNamespace(
+            device="cpu",
+            mapping=SimpleNamespace(attn=SimpleNamespace(dp_size=1)),
+            model=SimpleNamespace(draft_decode_lookback=True),
+            model_config=SimpleNamespace(hidden_size=8, dtype=torch.float32),
+        )
+        runtime_states = SimpleNamespace(
+            valid_cache_lengths=torch.zeros(request_pool_rows, dtype=torch.int32)
+        )
+        backend = SimpleNamespace(configure_draft_lookback=lambda _: True)
+
+        drafter = Mtp(
+            spec_num_tokens=4,
+            spec_num_steps=3,
+            page_size=128,
+            draft_model_runner=model_runner,
+            page_table=torch.zeros((max_bs, 4), dtype=torch.int32),
+            attn_backend=backend,
+            runtime_states=runtime_states,
+            input_buffers=input_buffers,
+        )
+
+        self.assertEqual(drafter._lookback_tokens_buf.shape[0], request_pool_rows)
+        self.assertEqual(drafter._lookback_hidden_buf.shape[0], request_pool_rows)
+
     def test_prepare_draft_input_ids_maps_media_then_clamps_to_vocab(self):
         drafter = _make_eagle()
         drafter.vocab_size = 100

--- a/test/runtime/test_group_write_locations.py
+++ b/test/runtime/test_group_write_locations.py
@@ -214,6 +214,7 @@ class InitForwardMetadataAssemblyTest(_MHACase):
         torch = self.torch
         backend = self.MHAAttnBackend.__new__(self.MHAAttnBackend)
         backend.page_size = PAGE
+        backend.group_page_sizes = {}
         backend.max_context_len = MAX_NUM_PAGES * PAGE
         backend.max_num_pages = MAX_NUM_PAGES
         backend.spec_num_tokens = 1

--- a/test/runtime/test_host_mirror.py
+++ b/test/runtime/test_host_mirror.py
@@ -160,10 +160,13 @@ class HostMirrorTest(unittest.TestCase):
         )
         for layer_id in range(4):
             idx = mirror.tensor_index_of_layer(layer_id)
-            self.assertIs(mirror.tensor_pairs[idx][0], pool.k_buffer[layer_id])
-            self.assertIs(
-                mirror.tensor_pairs[idx + mirror.num_k_tensors][0],
-                pool.v_buffer[layer_id],
+            self.assertEqual(
+                mirror.tensor_pairs[idx][0].data_ptr(),
+                pool.k_buffer[layer_id].data_ptr(),
+            )
+            self.assertEqual(
+                mirror.tensor_pairs[idx + mirror.num_k_tensors][0].data_ptr(),
+                pool.v_buffer[layer_id].data_ptr(),
             )
 
 
@@ -230,6 +233,8 @@ class HostMirrorStateSlabTest(unittest.TestCase):
         )
 
     def _pool(self, *, with_state: bool = True):
+        from cache_pool_test_utils import make_mha_memory_plan
+
         kwargs = {
             "size": 32,
             "dtype": self.torch.bfloat16,
@@ -259,6 +264,17 @@ class HostMirrorStateSlabTest(unittest.TestCase):
                     "linear_attention_0",
                     "full_attention",
                 ),
+            )
+        else:
+            kwargs["memory_plan"] = make_mha_memory_plan(
+                size=kwargs["size"],
+                page_size=kwargs["page_size"],
+                layer_num=kwargs["layer_num"],
+                kv_heads=kwargs["head_num"],
+                head_dim=kwargs["head_dim"],
+                dtype=kwargs["dtype"],
+                layer_types=kwargs["layer_types"],
+                sliding_window_tokens=kwargs["sliding_window_tokens"],
             )
         pool_cls = self.HybridMHATokenToKVPool if with_state else self.MHATokenToKVPool
         return pool_cls(**kwargs)
@@ -301,10 +317,10 @@ class HostMirrorStateSlabTest(unittest.TestCase):
                 self.assertEqual(host.shape, (8 * 4, *dev.shape[1:]))
 
     def test_bytes_per_host_page_includes_state_rows(self):
-        # Without state shapes the grouped GDN predicate is off: all 4 layers
-        # keep KV -> 8 mirrors x page_size 4 x 16 B rows = 512 B.
+        # Without state shapes all layers keep KV, but the two cache groups
+        # share two physical K/V planes -> 4 mirrors total.
         base = self.bytes_per_host_page(self._pool(with_state=False))
-        self.assertEqual(base, 512)
+        self.assertEqual(base, 256)
         # Grouped GDN: state layers carry no KV -> 4 KV mirrors (256 B) plus
         # 2 state layers x (conv 2*4 + ssm 2*8) bf16 page rows (2 x 48 B).
         pool = self._pool()

--- a/test/runtime/test_inkling_mtp_conv_state.py
+++ b/test/runtime/test_inkling_mtp_conv_state.py
@@ -35,6 +35,42 @@ class TestInklingCacheContract(unittest.TestCase):
             frozenset({"history", "state"}),
         )
 
+    def test_checkpoint_publication_masks_padded_rows_before_indexing(self):
+        from tokenspeed.runtime.layers.attention.backends.inkling import (
+            InklingAttnBackend,
+            InklingConvMetadata,
+            ShortConvCheckpointMetadata,
+        )
+
+        x = torch.arange(6, dtype=torch.float32).view(3, 2)
+        state = torch.zeros((2, 2, 2), dtype=torch.float32)
+        checkpoint = torch.full((3, 2, 2), -1, dtype=torch.float32)
+        metadata = InklingConvMetadata(
+            query_start_loc=torch.tensor([0, 3, 3], dtype=torch.int32),
+            cache_indices=torch.tensor([1, -1], dtype=torch.int32),
+            has_initial_state=torch.tensor([True, False]),
+            is_decode=False,
+            checkpoints=ShortConvCheckpointMetadata(
+                restore_pages={"state": torch.zeros(2, dtype=torch.int32)},
+                write_pages={"state": torch.tensor([1, 0], dtype=torch.int32)},
+                write_requests=torch.arange(2),
+                packed_rows=torch.tensor([[1, 2], [3, 3]], dtype=torch.int64),
+                prior_state_rows=torch.tensor([[0, 1], [0, 1]], dtype=torch.int64),
+                packed_row_mask=torch.tensor([[True, True], [False, False]]),
+            ),
+        )
+
+        InklingAttnBackend.publish_shortconv_checkpoints(
+            x,
+            state,
+            (checkpoint,),
+            metadata,
+            "state",
+        )
+
+        self.assertTrue(torch.equal(checkpoint[1], x[1:3]))
+        self.assertTrue(torch.equal(checkpoint[0], torch.zeros_like(checkpoint[0])))
+
 
 @unittest.skipUnless(torch.cuda.is_available(), "needs a CUDA device")
 class TestInklingConvSpecState(unittest.TestCase):

--- a/test/runtime/test_kimi_k3_cudagraph.py
+++ b/test/runtime/test_kimi_k3_cudagraph.py
@@ -33,8 +33,12 @@ from ci_system.ci_register import register_cuda_ci
 
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends.mla import MLAAttnBackend
+from tokenspeed.runtime.layers.attention.backends.mla_cache_groups import (
+    MlaCacheGroupMixin,
+)
 from tokenspeed.runtime.layers.attention.backends.tokenspeed_mla import (
     CuteDSLMLABackend,
+    CuteDSLMLADecodeMetadata,
 )
 
 register_cuda_ci(est_time=10, suite="runtime-1gpu")
@@ -44,15 +48,20 @@ _LOGICAL_P = 128  # logical block size (ratio 2 kernel pages per logical page)
 _MAX_CTX = 256
 
 
-def _bare_mla_backend(*, cache_contract: bool) -> CuteDSLMLABackend:
+def _bare_mla_backend(
+    *,
+    cache_contract: bool,
+    is_draft: bool = False,
+    spec_num_tokens: int = 1,
+) -> CuteDSLMLABackend:
     """A CuteDSLMLABackend with only the attributes the CUDA-graph metadata
     paths touch — the full ctor JIT-compiles CuteDSL kernels (GPU only)."""
     backend = object.__new__(CuteDSLMLABackend)
     backend.device = "cpu"
     backend.page_size = _PAGE_SIZE
     backend.max_context_len = _MAX_CTX
-    backend.is_draft = False
-    backend.spec_num_tokens = 1
+    backend.is_draft = is_draft
+    backend.spec_num_tokens = spec_num_tokens
     backend._block_table_aliased = False
     backend._cache_groups_bound = False
     backend._cache_contract_bound = False
@@ -63,6 +72,42 @@ def _bare_mla_backend(*, cache_contract: bool) -> CuteDSLMLABackend:
     if cache_contract:
         backend.mark_cache_contract()
     return backend
+
+
+def test_target_verify_mixed_batch_skips_complete_prefill_windows() -> None:
+    backend = _bare_mla_backend(cache_contract=False, spec_num_tokens=8)
+    backend._cache_groups_bound = True
+    locations = torch.arange(16, dtype=torch.int64)
+    backend.forward_decode_metadata = CuteDSLMLADecodeMetadata(
+        num_extends=1,
+        group_out_cache_loc=locations,
+        group_q_len_per_req=8,
+    )
+
+    selected = backend.select_out_cache_loc(
+        SimpleNamespace(layer_id=0),
+        torch.full((8,), -1, dtype=torch.int64),
+        ForwardMode.DECODE,
+    )
+
+    assert selected.tolist() == list(range(8, 16))
+
+
+def test_mla_target_verify_width_applies_to_mixed_batches() -> None:
+    backend = object.__new__(MlaCacheGroupMixin)
+    backend.spec_num_tokens = 8
+    backend.is_draft = False
+
+    assert backend._verify_q_len(ForwardMode.DECODE) == 8
+    assert backend._verify_q_len(ForwardMode.MIXED) == 8
+
+
+def test_cutedsl_mla_draft_keeps_classic_page_table_contract() -> None:
+    backend = _bare_mla_backend(cache_contract=False, is_draft=True)
+
+    backend.mark_cache_contract(logical_page_size=_LOGICAL_P)
+
+    assert backend._cache_contract_bound is False
 
 
 def _bare_amd_mla_backend(*, cache_contract: bool) -> MLAAttnBackend:

--- a/test/runtime/test_kimi_k3_cudagraph.py
+++ b/test/runtime/test_kimi_k3_cudagraph.py
@@ -40,12 +40,26 @@ from tokenspeed.runtime.layers.attention.backends.tokenspeed_mla import (
     CuteDSLMLABackend,
     CuteDSLMLADecodeMetadata,
 )
+from tokenspeed.runtime.layers.attention.page_table import expand_page_table
 
 register_cuda_ci(est_time=10, suite="runtime-1gpu")
 
 _PAGE_SIZE = 64  # kernel page
 _LOGICAL_P = 128  # logical block size (ratio 2 kernel pages per logical page)
 _MAX_CTX = 256
+
+
+class _StubCachePool:
+    def expand_block_table(
+        self, _group_id, block_table, *, kernel_block_tokens, max_kernel_blocks, out
+    ):
+        return expand_page_table(
+            block_table,
+            logical_page_size=_LOGICAL_P,
+            kernel_page_size=kernel_block_tokens,
+            max_kernel_pages=max_kernel_blocks,
+            out=out,
+        )
 
 
 def _bare_mla_backend(
@@ -65,6 +79,7 @@ def _bare_mla_backend(
     backend._block_table_aliased = False
     backend._cache_groups_bound = False
     backend._cache_contract_bound = False
+    backend.cache_pool = _StubCachePool()
     backend.decode_cuda_graph_metadata = {}
     backend.decode_cuda_graph_kv_indices = None
     backend.decode_cuda_graph_group_out_cache_loc = None
@@ -110,14 +125,16 @@ def test_cutedsl_mla_draft_keeps_classic_page_table_contract() -> None:
     assert backend._cache_contract_bound is False
 
 
-def _bare_amd_mla_backend(*, cache_contract: bool) -> MLAAttnBackend:
+def _bare_amd_mla_backend(
+    *, cache_contract: bool, spec_num_tokens: int = 1
+) -> MLAAttnBackend:
     backend = object.__new__(MLAAttnBackend)
     backend.device = "cpu"
     backend.page_size = _PAGE_SIZE
     backend.max_context_len = _MAX_CTX
     backend.max_num_pages = _MAX_CTX // _PAGE_SIZE
     backend.is_draft = False
-    backend.spec_num_tokens = 1
+    backend.spec_num_tokens = spec_num_tokens
     backend._cache_groups_bound = False
     backend._cache_contract_bound = False
     backend.decode_cuda_graph_metadata = {}
@@ -125,6 +142,7 @@ def _bare_amd_mla_backend(*, cache_contract: bool) -> MLAAttnBackend:
     backend.cuda_graph_seq_lens = None
     backend.decode_cuda_graph_group_out_cache_loc = None
     backend.forward_decode_metadata = None
+    backend._should_use_absorbed_cached_extend = lambda **_: False
     if cache_contract:
         backend.mark_cache_contract()
     return backend
@@ -233,6 +251,48 @@ def test_amd_mla_grouped_graph_replay_is_pointer_stable_and_null_padded() -> Non
     assert replayed.group_out_cache_loc[1].item() == 0
 
 
+def test_amd_mla_target_verify_graph_refreshes_all_write_locations() -> None:
+    backend = _bare_amd_mla_backend(cache_contract=True, spec_num_tokens=2)
+    backend.init_cuda_graph_state(max_bs=2)
+    backend.init_forward_metadata_capture_cuda_graph(
+        bs=2,
+        req_pool_indices=torch.tensor([0, 1], dtype=torch.int32),
+        seq_lens=torch.tensor([2, 2], dtype=torch.int32),
+        forward_mode=ForwardMode.DECODE,
+        cache_group_ids=("full_attention",),
+    )
+    captured = backend.decode_cuda_graph_metadata[2]
+    page_ptr = captured.page_table.data_ptr()
+    loc_ptr = captured.group_out_cache_loc.data_ptr()
+    assert captured.group_q_len_per_req == 2
+    assert captured.group_out_cache_loc.shape == (4,)
+
+    forward_op = object()
+    metadata = _StubFullAttnMeta(
+        torch.tensor([[3, 5]], dtype=torch.int32),
+        _LOGICAL_P,
+        forward_op,
+    )
+    backend.init_forward_metadata_replay_cuda_graph(
+        bs=2,
+        req_pool_indices=torch.tensor([0, 1], dtype=torch.int32),
+        seq_lens=torch.tensor([70, 1], dtype=torch.int32),
+        forward_mode=ForwardMode.DECODE,
+        page_table=None,
+        cache_metadata=metadata,
+        forward_batch=forward_op,
+    )
+    replayed = backend.forward_decode_metadata
+    assert replayed.page_table.data_ptr() == page_ptr
+    assert replayed.group_out_cache_loc.data_ptr() == loc_ptr
+    assert replayed.group_out_cache_loc.tolist() == [
+        3 * _LOGICAL_P + 68,
+        3 * _LOGICAL_P + 69,
+        0,
+        0,
+    ]
+
+
 def test_amd_mla_eager_decode_uses_group_table_and_refuses_fallback() -> None:
     backend = _bare_amd_mla_backend(cache_contract=True)
     forward_op = object()
@@ -276,6 +336,41 @@ def test_amd_mla_eager_decode_uses_group_table_and_refuses_fallback() -> None:
             page_table=torch.zeros((2, 4), dtype=torch.int32),
             forward_mode=ForwardMode.DECODE,
         )
+
+
+def test_amd_mla_eager_target_verify_writes_the_full_window() -> None:
+    backend = _bare_amd_mla_backend(cache_contract=True, spec_num_tokens=2)
+    forward_op = object()
+    metadata = _StubFullAttnMeta(
+        torch.tensor([[3, 5], [4, 6]], dtype=torch.int32),
+        _LOGICAL_P,
+        forward_op,
+    )
+    backend.init_forward_metadata(
+        bs=2,
+        num_extends=0,
+        req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+        seq_lens=torch.tensor([70, 130], dtype=torch.int32),
+        page_table=torch.zeros((2, 4), dtype=torch.int32),
+        forward_mode=ForwardMode.DECODE,
+        cache_metadata=metadata,
+        forward_batch=forward_op,
+    )
+
+    decode = backend.forward_decode_metadata
+    assert decode.group_q_len_per_req == 2
+    assert decode.group_out_cache_loc.tolist() == [
+        3 * _LOGICAL_P + 68,
+        3 * _LOGICAL_P + 69,
+        6 * _LOGICAL_P,
+        6 * _LOGICAL_P + 1,
+    ]
+    selected = backend.select_out_cache_loc(
+        SimpleNamespace(layer_id=0),
+        torch.full((4,), -1, dtype=torch.int64),
+        ForwardMode.DECODE,
+    )
+    assert torch.equal(selected, decode.group_out_cache_loc)
 
 
 def test_amd_mla_eager_prefill_derives_group_write_locations(monkeypatch) -> None:

--- a/test/runtime/test_kimi_k3_kda.py
+++ b/test/runtime/test_kimi_k3_kda.py
@@ -102,7 +102,6 @@ def _stub_contract(*, block_size: int, usable_pages: int):
             entry_stride_tokens=1,
             sliding_window_tokens=None,
             family="history" if group_id == "full_attention" else "state",
-            block_size=block_size,
         )
         for group_id in group_ids
     )

--- a/test/runtime/test_kimi_k3_mla.py
+++ b/test/runtime/test_kimi_k3_mla.py
@@ -234,7 +234,9 @@ def backend_factory(cuda_env, gpu_pool):
             scaling=192**-0.5,
             kv_cache_dim=_LATENT_DIM,
         )
-        return backend_cls(config)
+        backend = backend_cls(config)
+        backend.set_cache_pool(gpu_pool)
+        return backend
 
     return make
 

--- a/test/runtime/test_qwen35_nextn_quantization.py
+++ b/test/runtime/test_qwen35_nextn_quantization.py
@@ -1,0 +1,14 @@
+from tokenspeed.runtime.layers.quantization.nvfp4 import Nvfp4Config
+from tokenspeed.runtime.models.qwen3_5_nextn import _resolve_mtp_quant_config
+
+
+def test_unquantized_mtp_checkpoint_disables_draft_quantization():
+    quant_config = Nvfp4Config(exclude_modules=["mtp.layers.0*"])
+
+    assert _resolve_mtp_quant_config(quant_config) is None
+
+
+def test_quantized_mtp_checkpoint_keeps_draft_quantization():
+    quant_config = Nvfp4Config()
+
+    assert _resolve_mtp_quant_config(quant_config) is quant_config

--- a/test/runtime/test_trtllm_cache_groups.py
+++ b/test/runtime/test_trtllm_cache_groups.py
@@ -45,16 +45,31 @@ class TRTLLMCacheGroupsTest(unittest.TestCase):
         device="cpu",
         groups=None,
     ):
+        from tokenspeed.runtime.configs.paged_cache_spec import PagedCacheGroupSpec
+        from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
+
         # Bypass __init__: the paths under test read only these attributes.
         # Capture/replay tests pass device="cuda" and declare their groups —
         # replay write locs are triton-only (no python fallback).
         b = self.Backend.__new__(self.Backend)
         b.page_size = page_size
+        b.group_page_sizes = dict(groups or {})
+        b.cache_pool = None
+        if groups:
+            b.cache_pool = CachePool.__new__(CachePool)
+            b.cache_pool.paged_cache_group_specs = tuple(
+                PagedCacheGroupSpec(
+                    group_id=group_id,
+                    retention="full_history",
+                    rows_per_page=group_page_size,
+                    entry_stride_tokens=1,
+                    sliding_window_tokens=None,
+                )
+                for group_id, group_page_size in groups.items()
+            )
         b.max_num_pages = max_num_pages
         b.max_context_len = page_size * max_num_pages
         b.device = device
-        if groups is not None:
-            b.group_page_sizes = groups
         b.spec_num_tokens = spec_num_tokens
         b.is_draft = False
         b.draft_block_decode = False


### PR DESCRIPTION
Fix the cache-recipe migration regressions exposed by the latest Slurm evaluation: ordinary pool runtime contracts, target/draft recipe selection, hybrid draft capacity, shared-geometry validation, and DeepSeek V4 CUDA-graph batch padding.