### PR TITLE
fix(ci): stabilize Kimi K3 perf metrics

### DIFF
--- a/test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
+++ b/test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
@@ -46,7 +46,9 @@ server:
     interval: 10
 perf:
   install:
-    - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]'
+    # Keep the load generator aligned with the version used to establish the
+    # perf_reference below; EvalScope 1.10 changed its metric semantics.
+    - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]==1.9.1'
   command: >-
     REPO_ROOT=$PWD &&
     MODEL=kimi-k3 &&

--- a/test/ci_system/test_random_benchmark_perf_csv.py
+++ b/test/ci_system/test_random_benchmark_perf_csv.py
@@ -52,3 +52,37 @@ def test_random_benchmark_output_can_be_gated(tmp_path):
         ["perf"],
     )
     assert check["passed"]
+
+
+def test_random_benchmark_accepts_evalscope_1_10_metric_names(tmp_path):
+    run_dir = tmp_path / "input_4k" / "parallel_1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "benchmark_summary.json").write_text(
+        json.dumps(
+            {
+                "Concurrency": 1,
+                "Avg TPOT (ms)": 25.0,
+                "Output Throughput (tok/s)": 32.0,
+                "KV Cache Hit Rate (%)": 0.0,
+                "Avg Decoded Tok/Iter": 2.0,
+            }
+        )
+    )
+
+    collector = (
+        Path(__file__).resolve().parents[1]
+        / "random_benchmark"
+        / "tokenspeed"
+        / "collect_outputs.py"
+    )
+    result = subprocess.run(
+        [sys.executable, collector, tmp_path, "--num-gpus", "8", "--emit-csv"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    rows = extract_perf_summary_rows(result.stdout)
+    assert rows[0]["Latency (tps/user)"] == "40.0"
+    assert rows[0]["Throughput (tps/gpu)"] == "4.0"
+    assert rows[0]["Decoded Tok/Iter"] == "2.0"

--- a/test/random_benchmark/tokenspeed/collect_outputs.py
+++ b/test/random_benchmark/tokenspeed/collect_outputs.py
@@ -52,14 +52,16 @@ def _sort_key(row: dict) -> tuple[int, int]:
     return (INPUT_ORDER.get(config, 0), int(row["Conc."]))
 
 
-def _float(summary: dict, key: str) -> float:
-    value = summary.get(key)
-    if value is None:
-        return 0.0
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return 0.0
+def _float(summary: dict, *keys: str) -> float:
+    for key in keys:
+        value = summary.get(key)
+        if value is None:
+            continue
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            continue
+    return 0.0
 
 
 def collect(sweep_dir: Path, num_gpus: int):
@@ -74,12 +76,17 @@ def collect(sweep_dir: Path, num_gpus: int):
             print(f"[warn] skip {summary_path}: {exc}", file=sys.stderr)
             continue
 
-        tpot_ms = _float(summary, "TPOT (ms)")
+        # EvalScope 1.10 renamed these summary fields. Accept both spellings so
+        # an unpinned CI dependency cannot silently turn real metrics into 0.
+        tpot_ms = _float(summary, "Avg TPOT (ms)", "TPOT (ms)")
         tps_user = 1000.0 / tpot_ms if tpot_ms else 0.0
         output_tps = _float(summary, "Output Throughput (tok/s)")
         cache_hit = _float(summary, "KV Cache Hit Rate (%)")
-        decoded_per_iter = _float(summary, "Decoded Tok/Iter") or _float(
-            summary, "Avg Decoded Tokens/Iter"
+        decoded_per_iter = _float(
+            summary,
+            "Avg Decoded Tok/Iter",
+            "Decoded Tok/Iter",
+            "Avg Decoded Tokens/Iter",
         )
 
         rows.append(


### PR DESCRIPTION
## Summary

- accept both EvalScope 1.9 and 1.10 random-benchmark metric names
- pin the Kimi K3 fixed-reference perf task to EvalScope 1.9.1, the version used to establish its baseline
- retain the existing performance threshold

## Root cause

The CI task installed an unpinned EvalScope dependency. EvalScope 1.10 renamed TPOT and decoded-token summary fields and changed the client-side measurement semantics. The collector therefore emitted a zero latency value, while the fixed reference was no longer being measured with its baseline load-generator version.

## Validation

- `pre-commit run --all-files`
- old/new metric-name compatibility assertions
- full GitHub CI pending