### PR TITLE
Add DeepSeek V4 DSpark decoding and complete Flat KV replay support

### DIFF
--- a/python/THIRDPARTYNOTICES
+++ b/python/THIRDPARTYNOTICES
@@ -48,6 +48,14 @@ Copyright (c) 2025 DeepSeek
 
 Licensed under the MIT License, whose full license text is available in the repository LICENSE file.
 
+Notice for DeepSeek V4 Flash DSpark components
+-------------------------------
+MIT License
+
+Copyright (c) 2023 DeepSeek
+
+Licensed under the MIT License, whose full license text is available in the repository LICENSE file.
+
 Notice for HuggingFace Transformers
 -------------------------------
 Apache License, Version 2.0

--- a/python/tokenspeed/runtime/configs/model_config.py
+++ b/python/tokenspeed/runtime/configs/model_config.py
@@ -48,6 +48,7 @@ logger = get_colorful_logger(__name__)
 _DEEPSEEK_V4_ARCHITECTURES = frozenset(
     {
         "DeepseekV4ForCausalLM",
+        "DeepseekV4ForCausalLMDSpark",
         "DeepseekV4ForCausalLMNextN",
     }
 )
@@ -338,6 +339,11 @@ class ModelConfig:
             revision=revision,
             model_override_args=self.model_override_args,
             is_draft_worker=is_draft_worker,
+            speculative_algorithm=(
+                getattr(server_args, "speculative_algorithm", None)
+                if is_draft_worker
+                else None
+            ),
             **kwargs,
         )
         self.hf_generation_config = get_generation_config(
@@ -348,6 +354,32 @@ class ModelConfig:
         )
 
         self.hf_text_config = get_hf_text_config(self.hf_config)
+        if (
+            is_draft_worker
+            and getattr(server_args, "speculative_algorithm", None) == "DSPARK"
+            and resolve_architecture(self.hf_config) == "DeepseekV4ForCausalLMDSpark"
+        ):
+            from tokenspeed.runtime.models.deepseek_v4_dspark import (
+                count_dspark_stages,
+            )
+
+            dspark_num_stages = count_dspark_stages(model_path)
+            if dspark_num_stages is None:
+                raise ValueError(
+                    "DSPARK requires a safetensors index with mtp.<stage> weights."
+                )
+            self.hf_text_config.dspark_num_stages = dspark_num_stages
+            if self.hf_config is not self.hf_text_config:
+                self.hf_config.dspark_num_stages = dspark_num_stages
+            trained_verify_width = int(self.hf_text_config.dspark_block_size) + 1
+            requested_verify_width = int(server_args.speculative_num_draft_tokens)
+            if requested_verify_width != trained_verify_width:
+                raise ValueError(
+                    "DSPARK target verify width must equal checkpoint block_size + 1; "
+                    f"expected {trained_verify_width}, got {requested_verify_width}."
+                )
+            server_args.speculative_num_steps = trained_verify_width - 1
+            server_args.speculative_num_draft_tokens = trained_verify_width
         if (
             is_draft_worker
             and resolve_architecture(self.hf_config)
@@ -518,8 +550,11 @@ class ModelConfig:
             self.num_hidden_layers,
         )
         if is_draft_worker:
+            dspark_layers = getattr(self.hf_text_config, "dspark_num_stages", None)
             mtp_layers = getattr(self.hf_text_config, "mtp_num_hidden_layers", None)
-            if mtp_layers is not None:
+            if dspark_layers is not None:
+                self.num_attention_layers = int(dspark_layers)
+            elif mtp_layers is not None:
                 self.num_attention_layers = mtp_layers
             else:
                 nextn_layers = getattr(

--- a/python/tokenspeed/runtime/configs/model_config.py
+++ b/python/tokenspeed/runtime/configs/model_config.py
@@ -359,11 +359,19 @@ class ModelConfig:
             and getattr(server_args, "speculative_algorithm", None) == "DSPARK"
             and resolve_architecture(self.hf_config) == "DeepseekV4ForCausalLMDSpark"
         ):
+            if server_args.enable_prefix_caching:
+                raise ValueError(
+                    "DSPARK does not yet preserve its captured-context windows "
+                    "across prefix-cache hits; use --no-enable-prefix-caching."
+                )
             from tokenspeed.runtime.models.deepseek_v4_dspark import (
                 count_dspark_stages,
             )
 
-            dspark_num_stages = count_dspark_stages(model_path)
+            dspark_num_stages = count_dspark_stages(
+                model_path,
+                revision=revision,
+            )
             if dspark_num_stages is None:
                 raise ValueError(
                     "DSPARK requires a safetensors index with mtp.<stage> weights."

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -238,6 +238,11 @@ class CudaGraphWrapper:
             attn_backend,
             self.max_bs,
             paged_cache_group_specs=tuple(token_to_kv_pool.paged_cache_group_specs),
+            paged_cache_group_page_counts=getattr(
+                token_to_kv_pool,
+                "paged_cache_group_page_counts",
+                None,
+            ),
             logical_page_size=getattr(
                 getattr(token_to_kv_pool, "runtime_contract", None),
                 "block_size",
@@ -252,6 +257,11 @@ class CudaGraphWrapper:
                 self.max_bs,
                 paged_cache_group_specs=tuple(
                     draft_token_to_kv_pool.paged_cache_group_specs
+                ),
+                paged_cache_group_page_counts=getattr(
+                    draft_token_to_kv_pool,
+                    "paged_cache_group_page_counts",
+                    None,
                 ),
                 logical_page_size=getattr(
                     getattr(draft_token_to_kv_pool, "runtime_contract", None),
@@ -757,14 +767,26 @@ class CudaGraphWrapper:
         Group-table captures pass page 0; backends using a sentinel tail keep
         -1. See the MHA replay guard for the padding contract.
         """
-        if padded_bs <= actual_bs:
-            return block_tables
+        if actual_bs < 0 or padded_bs < actual_bs:
+            raise RuntimeError(
+                "Grouped cache table batch contract requires "
+                f"0 <= actual_bs <= padded_bs, got {actual_bs=} {padded_bs=}"
+            )
         out = {}
         for key, table in block_tables.items():
             if not isinstance(table, torch.Tensor):
                 out[key] = table
                 continue
+            if table.ndim < 1:
+                raise RuntimeError(
+                    f"Grouped cache table {key!r} must have a batch dimension"
+                )
             rows = int(table.shape[0])
+            if rows not in {actual_bs, padded_bs}:
+                raise RuntimeError(
+                    f"Grouped cache table {key!r} has {rows} rows; expected "
+                    f"actual_bs={actual_bs} or padded_bs={padded_bs}"
+                )
             if rows == padded_bs:
                 out[key] = table
                 continue
@@ -826,6 +848,16 @@ class CudaGraphWrapper:
         draft_uses_paged_groups = self.draft_attn_backend is not None and getattr(
             self.draft_attn_backend, "uses_paged_cache_groups", False
         )
+        target_uses_cache_groups = getattr(
+            self.attn_backend,
+            "uses_cache_groups",
+            False,
+        )
+        draft_uses_cache_groups = self.draft_attn_backend is not None and getattr(
+            self.draft_attn_backend,
+            "uses_cache_groups",
+            False,
+        )
         if paged_cache_block_tables is not None and (
             target_uses_paged_groups or draft_uses_paged_groups
         ):
@@ -854,27 +886,36 @@ class CudaGraphWrapper:
                     kwargs["paged_cache_block_table_base_offsets"] = (
                         paged_cache_block_table_base_offsets
                     )
-        if block_tables is not None and getattr(
-            self.attn_backend, "uses_cache_groups", False
-        ):
-            table_batch_size = next(
-                (
-                    int(table.shape[0])
-                    for table in block_tables.values()
-                    if isinstance(table, torch.Tensor)
-                ),
-                int(req_pool_indices.shape[0]),
+        padded_block_tables = None
+        if block_tables is not None and (
+            (
+                target_uses_cache_groups
+                and not getattr(self.attn_backend, "tables_self_padding", False)
             )
+            or (
+                draft_uses_cache_groups
+                and not getattr(
+                    self.draft_attn_backend,
+                    "tables_self_padding",
+                    False,
+                )
+            )
+        ):
+            # Normalize once so target and draft consume the same authoritative
+            # replay rows. In particular, an actual batch smaller than the
+            # selected graph batch must not reach the draft as an unpadded map.
+            padded_block_tables = self._pad_block_tables_to_padded_bs(
+                block_tables,
+                actual_bs=actual_bs,
+                padded_bs=padded_bs,
+                pad_value=0,
+            )
+        if block_tables is not None and target_uses_cache_groups:
             if getattr(self.attn_backend, "tables_self_padding", False):
                 # Backend pads dummy rows itself; F.pad would reallocate tables and break storage sharing.
                 kwargs["block_tables"] = block_tables
             else:
-                kwargs["block_tables"] = self._pad_block_tables_to_padded_bs(
-                    block_tables,
-                    actual_bs=table_batch_size,
-                    padded_bs=padded_bs,
-                    pad_value=0,
-                )
+                kwargs["block_tables"] = padded_block_tables
         if self.attn_backend.uses_padded_decode_token_mask:
             kwargs["actual_bs"] = actual_bs
         if target_uses_paged_groups and getattr(self, "drafter", None) is not None:
@@ -897,7 +938,16 @@ class CudaGraphWrapper:
                     )
             if getattr(self.draft_attn_backend, "uses_padded_decode_token_mask", False):
                 draft_attn_kwargs["actual_bs"] = actual_bs
-            draft_group_tables = self._draft_group_tables(block_tables)
+            draft_table_source = (
+                block_tables
+                if getattr(
+                    self.draft_attn_backend,
+                    "tables_self_padding",
+                    False,
+                )
+                else padded_block_tables
+            )
+            draft_group_tables = self._draft_group_tables(draft_table_source)
             if draft_group_tables is not None:
                 draft_attn_kwargs["block_tables"] = draft_group_tables
             draft_forward_mode = ForwardMode.DECODE
@@ -976,6 +1026,15 @@ class CudaGraphWrapper:
                     if kwargs.get("block_tables") is not None
                     else kwargs
                 )
+                if self.use_v4_mtp_paged_metadata:
+                    # cache_metadata describes the target pool and exposes all
+                    # target cache groups. The V4 drafter has a narrower cache
+                    # contract, so it must consume only the identity-selected
+                    # subset above instead of rebuilding tables from the target
+                    # metadata.
+                    draft_extend_kwargs = dict(draft_extend_kwargs)
+                    draft_extend_kwargs.pop("cache_metadata", None)
+                    draft_extend_kwargs.pop("forward_batch", None)
                 self.draft_attn_backend.init_forward_metadata(
                     bs=padded_bs,
                     num_extends=num_extends,

--- a/python/tokenspeed/runtime/execution/drafter/deepseek_v4_dspark.py
+++ b/python/tokenspeed/runtime/execution/drafter/deepseek_v4_dspark.py
@@ -1,0 +1,441 @@
+# Copyright (c) 2023 DeepSeek
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from tokenspeed.runtime.execution.context import ForwardContext
+from tokenspeed.runtime.execution.drafter.base import BaseDrafter
+from tokenspeed.runtime.execution.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardMode,
+)
+from tokenspeed.runtime.models.deepseek_v4_dspark_ops.heads import (
+    sample_dspark_block_greedy,
+)
+from tokenspeed.runtime.utils.nvtx import nvtx_range
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.execution.input_buffer import InputBuffers
+    from tokenspeed.runtime.execution.model_runner import ModelRunner
+    from tokenspeed.runtime.execution.runtime_states import RuntimeStates
+    from tokenspeed.runtime.layers.logits_processor import LogitsProcessorOutput
+
+
+def _dspark_decode_position_plan(
+    old_context_lengths: torch.Tensor,
+    accepted: torch.Tensor,
+    block_offsets: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Map target verification rows to official DSpark absolute positions."""
+
+    interim_positions = old_context_lengths.unsqueeze(1) + block_offsets.unsqueeze(0)
+    interim_valid = block_offsets.unsqueeze(0) < (accepted.unsqueeze(1) - 1)
+    main_positions = old_context_lengths + accepted - 1
+    next_context_lengths = main_positions + 1
+    return (
+        interim_positions,
+        interim_valid,
+        main_positions,
+        next_context_lengths,
+    )
+
+
+def _dspark_prefill_position_plan(
+    target_positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Keep target absolute positions and return the next context length."""
+
+    if target_positions.ndim != 2 or target_positions.shape[1] == 0:
+        raise ValueError(
+            "DSpark prefill positions must be a non-empty [batch, tokens] tensor."
+        )
+    return target_positions, target_positions[:, -1] + 1
+
+
+class DeepseekV4DSpark(BaseDrafter):
+    """DeepSeek V4 DSpark block drafter with request-persistent context windows."""
+
+    def __init__(
+        self,
+        spec_num_tokens: int,
+        spec_num_steps: int,
+        page_size: int,
+        draft_model_runner: ModelRunner | None = None,
+        page_table: torch.Tensor | None = None,
+        attn_backend=None,
+        token_to_kv_pool=None,
+        runtime_states: RuntimeStates | None = None,
+        input_buffers: InputBuffers | None = None,
+        vocab_size: int | None = None,
+    ) -> None:
+        super().__init__(
+            spec_num_tokens=spec_num_tokens,
+            spec_num_steps=spec_num_steps,
+            draft_model_runner=draft_model_runner,
+            runtime_states=runtime_states,
+            input_buffers=input_buffers,
+            page_size=page_size,
+            page_table=page_table,
+            attn_backend=attn_backend,
+            token_to_kv_pool=token_to_kv_pool,
+            vocab_size=vocab_size,
+        )
+        if draft_model_runner is None or input_buffers is None:
+            raise ValueError("DSPARK requires a draft model runner and input buffers.")
+        self._validate_tp_only_mapping(draft_model_runner.mapping)
+
+        self.device = torch.device(draft_model_runner.device)
+        self.draft_model = draft_model_runner.model
+        self.model = self.draft_model.model
+        self.block_size = int(self.model.block_size)
+        if int(spec_num_tokens) != self.block_size + 1:
+            raise ValueError(
+                "DSPARK verify width must equal checkpoint block_size + 1; "
+                f"got verify_width={spec_num_tokens}, block_size={self.block_size}."
+            )
+        if int(spec_num_steps) != self.block_size:
+            raise ValueError(
+                "DSPARK speculative steps must equal checkpoint block_size; "
+                f"got steps={spec_num_steps}, block_size={self.block_size}."
+            )
+        self.target_layer_ids = list(self.model.target_layer_ids)
+        self.hidden_width = len(self.target_layer_ids) * int(self.model.hidden_size)
+        self.idle_forward_steps = 1
+        self._init_buffers()
+
+    @staticmethod
+    def _validate_tp_only_mapping(mapping) -> None:
+        dp_size = int(mapping.attn.dp_size)
+        cp_size = int(mapping.attn.cp_size)
+        if dp_size != 1 or cp_size != 1:
+            raise ValueError(
+                "Week-0 DSPARK supports tensor parallelism only; "
+                f"got attention dp_size={dp_size}, cp_size={cp_size}."
+            )
+
+    def _init_buffers(self) -> None:
+        max_bs = int(self.input_buffers.max_bs)
+        first_padding_slot = int(self.input_buffers.state_write_padding_pool_index)
+        self.first_padding_slot = first_padding_slot
+        self.padding_slots = torch.arange(
+            first_padding_slot,
+            first_padding_slot + max_bs,
+            dtype=torch.int64,
+            device=self.device,
+        )
+        self.slot_indices_buf = self.padding_slots.clone()
+        num_window_slots = first_padding_slot + max_bs
+        self.kv_windows = torch.zeros(
+            (
+                num_window_slots,
+                int(self.model.num_stages),
+                int(self.model.window_size),
+                int(self.model.attention_params["head_dim"]),
+            ),
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+        self.context_lengths = torch.zeros(
+            (num_window_slots,), dtype=torch.int64, device=self.device
+        )
+        self._request_by_pool_slot: list[object | None] = [None] * first_padding_slot
+
+        self.next_tokens_buf = torch.empty(
+            (max_bs, self.spec_num_tokens),
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self.draft_tokens_buf = torch.empty(
+            (max_bs, self.block_size),
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self.block_offsets = torch.arange(
+            self.block_size, dtype=torch.int64, device=self.device
+        )
+        self.decode_row_offsets = (
+            torch.arange(max_bs, dtype=torch.int64, device=self.device)
+            * self.spec_num_tokens
+        )
+
+        tp_size = int(self.draft_model.mapping.attn.tp_size)
+        self.gathered_values = torch.empty(
+            (tp_size, max_bs), dtype=torch.float32, device=self.device
+        )
+        self.gathered_ids = torch.empty(
+            (tp_size, max_bs), dtype=torch.int64, device=self.device
+        )
+
+    def bind_target_model(self, target_model) -> None:
+        self.target_model = target_model
+        self.lm_head = target_model.lm_head
+        self.tp_group = target_model.logits_processor.tp_group
+
+    def prepare_request_state(
+        self,
+        request_ids: list[object],
+        request_pool_indices: list[int],
+        num_extends: int,
+    ) -> None:
+        """Refresh request-to-window slots outside CUDA Graph replay."""
+
+        if len(request_ids) != len(request_pool_indices):
+            raise ValueError("DSPARK request IDs and pool indices must align.")
+        if len(set(request_pool_indices)) != len(request_pool_indices):
+            raise ValueError("DSPARK request pool indices must be unique per batch.")
+        changed_slots = []
+        for row, (request_id, pool_slot) in enumerate(
+            zip(request_ids, request_pool_indices)
+        ):
+            pool_slot = int(pool_slot)
+            if pool_slot < 0 or pool_slot >= self.first_padding_slot:
+                raise ValueError(
+                    "DSPARK request pool index is outside the persistent state domain: "
+                    f"{pool_slot}."
+                )
+            starts_new_prefill = (
+                row < num_extends
+                and int(self.input_buffers.extend_prefix_lens_cpu[row]) == 0
+            )
+            if (
+                self._request_by_pool_slot[pool_slot] != request_id
+                or starts_new_prefill
+            ):
+                self._request_by_pool_slot[pool_slot] = request_id
+                changed_slots.append(pool_slot)
+
+        if changed_slots:
+            changed = torch.tensor(changed_slots, dtype=torch.int64, device=self.device)
+            self.kv_windows.index_fill_(0, changed, 0)
+            self.context_lengths.index_fill_(0, changed, 0)
+
+        # CUDA Graph padding rows execute the same captured draft path as live
+        # requests. Reset their persistent state before every replay so an
+        # inactive row cannot accumulate positions or retain window contents.
+        self.kv_windows.index_fill_(0, self.padding_slots, 0)
+        self.context_lengths.index_fill_(0, self.padding_slots, 0)
+
+        active_bs = len(request_pool_indices)
+        self.slot_indices_buf[:active_bs].copy_(
+            self.input_buffers.req_pool_indices_buf[:active_bs]
+        )
+        if active_bs < self.input_buffers.max_bs:
+            self.slot_indices_buf[active_bs:].copy_(self.padding_slots[active_bs:])
+
+    @staticmethod
+    def _bonus_tokens_from_output(
+        output_tokens: torch.Tensor,
+        accept_lengths: torch.Tensor,
+        num_extends: int,
+        verify_width: int,
+        out: torch.Tensor,
+    ) -> torch.Tensor:
+        if num_extends > 0:
+            out[:num_extends].copy_(output_tokens[:num_extends])
+        num_decodes = accept_lengths.shape[0] - num_extends
+        if num_decodes > 0:
+            accepted = (
+                accept_lengths[num_extends:].to(torch.int64).clamp(1, verify_width)
+            )
+            offsets = (
+                torch.arange(
+                    num_decodes,
+                    dtype=torch.int64,
+                    device=output_tokens.device,
+                )
+                * verify_width
+                + num_extends
+            )
+            out[num_extends:].copy_(output_tokens[offsets + accepted - 1])
+        return out
+
+    def get_candidates(self, base_ctx: ForwardContext) -> torch.Tensor | None:
+        num_decodes = base_ctx.bs - base_ctx.num_extends
+        if num_decodes <= 0:
+            return None
+        decode_tokens = num_decodes * self.spec_num_tokens
+        prefill_tokens = base_ctx.input_num_tokens - decode_tokens
+        return self.input_buffers.input_ids_buf[
+            prefill_tokens : base_ctx.input_num_tokens
+        ].reshape(num_decodes, self.spec_num_tokens)
+
+    def _seed_prefill_windows(
+        self,
+        hidden_states: torch.Tensor,
+        num_extends: int,
+    ) -> int:
+        offset = 0
+        for row in range(num_extends):
+            chunk_len = int(self.input_buffers.input_lengths_buf[row].item())
+            if chunk_len <= 0:
+                continue
+            chunk_end = offset + chunk_len
+            keep = min(int(self.model.window_size), chunk_len)
+            kept_hidden = hidden_states[chunk_end - keep : chunk_end].unsqueeze(0)
+            positions, next_context_lengths = _dspark_prefill_position_plan(
+                self.input_buffers.positions_buf[
+                    chunk_end - keep : chunk_end
+                ].unsqueeze(0)
+            )
+            slot = self.slot_indices_buf[row : row + 1]
+            valid = torch.ones_like(positions, dtype=torch.bool)
+            self.model.write_context_windows_batched(
+                kept_hidden,
+                positions,
+                slot,
+                valid,
+                self.kv_windows,
+                self.first_padding_slot,
+            )
+            self.context_lengths[slot] = next_context_lengths
+            offset = chunk_end
+        return offset
+
+    def _draft_decode_rows(
+        self,
+        base_ctx: ForwardContext,
+        hidden_states: torch.Tensor,
+        output_tokens: torch.Tensor,
+        accept_lengths: torch.Tensor,
+        next_tokens: torch.Tensor,
+        prefill_tokens: int,
+    ) -> None:
+        num_extends = base_ctx.num_extends
+        num_decodes = base_ctx.bs - num_extends
+        if num_decodes <= 0:
+            return
+
+        decode_hidden = hidden_states[prefill_tokens:].reshape(
+            num_decodes,
+            self.spec_num_tokens,
+            self.hidden_width,
+        )
+        accepted = (
+            accept_lengths[num_extends:].to(torch.int64).clamp(1, self.spec_num_tokens)
+        )
+        accepted_index = accepted - 1
+        rows = torch.arange(num_decodes, dtype=torch.int64, device=self.device)
+        main_hidden = decode_hidden[rows, accepted_index]
+
+        bonus = next_tokens[num_extends:, 0]
+        slots = self.slot_indices_buf[num_extends : num_extends + num_decodes]
+        old_context_lengths = self.context_lengths.index_select(0, slots)
+        (
+            interim_positions,
+            interim_valid,
+            main_positions,
+            next_context_lengths,
+        ) = _dspark_decode_position_plan(
+            old_context_lengths,
+            accepted,
+            self.block_offsets,
+        )
+        self.model.write_context_windows_batched(
+            decode_hidden[:, : self.block_size],
+            interim_positions,
+            slots,
+            interim_valid,
+            self.kv_windows,
+            self.first_padding_slot,
+        )
+        self.context_lengths.index_copy_(0, slots, next_context_lengths)
+
+        draft_ctx = ForwardContext(
+            attn_backend=base_ctx.attn_backend,
+            token_to_kv_pool=base_ctx.token_to_kv_pool,
+            bs=num_decodes,
+            num_extends=0,
+            input_num_tokens=num_decodes * self.block_size,
+            forward_mode=ForwardMode.DECODE,
+            capture_hidden_mode=CaptureHiddenMode.NULL,
+            all_decode_or_idle=base_ctx.all_decode_or_idle,
+        )
+        draft_hidden = self.model.forward_backbone(
+            main_hidden,
+            bonus,
+            main_positions,
+            self.kv_windows,
+            slots,
+            draft_ctx,
+        )
+        local_logits = self.model.local_base_logits(draft_hidden, self.lm_head)
+        sample_dspark_block_greedy(
+            local_logits,
+            bonus,
+            self.model.markov_head,
+            self.lm_head,
+            self.tp_group,
+            self.gathered_values,
+            self.gathered_ids,
+            self.draft_tokens_buf[:num_decodes],
+        )
+        next_tokens[num_extends:, 1:].copy_(self.draft_tokens_buf[:num_decodes])
+
+    @nvtx_range("drafter:dspark", color="purple")
+    def run(
+        self,
+        base_ctx: ForwardContext,
+        logits_output: LogitsProcessorOutput,
+        output_tokens: torch.Tensor,
+        accept_lengths: torch.Tensor,
+    ) -> torch.Tensor:
+        if not hasattr(self, "target_model"):
+            raise RuntimeError("DSPARK drafter is not bound to the target model.")
+        hidden_states = logits_output.hidden_states
+        if hidden_states is None:
+            raise RuntimeError("DSPARK requires target hidden-state captures.")
+        if hidden_states.ndim != 2 or hidden_states.shape[1] != self.hidden_width:
+            raise RuntimeError(
+                "DSPARK target hidden-state shape mismatch: "
+                f"expected [tokens, {self.hidden_width}], got "
+                f"{tuple(hidden_states.shape)}."
+            )
+
+        next_tokens = self.next_tokens_buf[: base_ctx.bs]
+        self._bonus_tokens_from_output(
+            output_tokens,
+            accept_lengths,
+            base_ctx.num_extends,
+            self.spec_num_tokens,
+            next_tokens[:, 0],
+        )
+        next_tokens[:, 1:].copy_(next_tokens[:, :1])
+        prefill_tokens = self._seed_prefill_windows(
+            hidden_states,
+            base_ctx.num_extends,
+        )
+        self._draft_decode_rows(
+            base_ctx,
+            hidden_states,
+            output_tokens,
+            accept_lengths,
+            next_tokens,
+            prefill_tokens,
+        )
+        next_tokens.clamp_(0, int(self.vocab_size) - 1)
+        return next_tokens
+
+    def draft(self, *args, **kwargs) -> torch.Tensor | None:
+        raise RuntimeError("DSPARK drafts through run() with target captures.")

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -475,10 +475,24 @@ class ModelExecutor:
 
         attn_backend.configure_runtime(
             sliding_window_size=model_runner.sliding_window_size,
+            paged_cache_group_specs=tuple(token_to_kv_pool.paged_cache_group_specs),
+            paged_cache_group_page_counts=getattr(
+                token_to_kv_pool,
+                "paged_cache_group_page_counts",
+                None,
+            ),
         )
         if draft_attn_backend is not None:
             draft_attn_backend.configure_runtime(
                 sliding_window_size=model_runner.sliding_window_size,
+                paged_cache_group_specs=tuple(
+                    getattr(draft_token_to_kv_pool, "paged_cache_group_specs", ())
+                ),
+                paged_cache_group_page_counts=getattr(
+                    draft_token_to_kv_pool,
+                    "paged_cache_group_page_counts",
+                    None,
+                ),
             )
 
         validate_paged_cache_group_ids(
@@ -659,7 +673,12 @@ class ModelExecutor:
         draft indexes it directly by batch row, no page_table round-trip.
         """
         if (
-            self.drafter is None
+            getattr(
+                getattr(self, "attn_backend", None),
+                "cache_group_tables_replace_draft_page_table",
+                False,
+            )
+            or self.drafter is None
             or not block_tables
             or self._full_history_group_id is None
         ):

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -42,6 +42,9 @@ from tokenspeed.runtime.distributed.process_group_manager import (
 from tokenspeed.runtime.execution.breakable_cuda_graph import active_forward
 from tokenspeed.runtime.execution.context import ForwardContext
 from tokenspeed.runtime.execution.cuda_graph_wrapper import CudaGraphWrapper
+from tokenspeed.runtime.execution.drafter.deepseek_v4_dspark import (
+    DeepseekV4DSpark,
+)
 from tokenspeed.runtime.execution.drafter.dflash import DFlash
 from tokenspeed.runtime.execution.drafter.dspark import DSpark
 from tokenspeed.runtime.execution.drafter.eagle import Eagle
@@ -108,6 +111,13 @@ def _get_drafter_impl(spec_algo: str, model: torch.nn.Module):
     # "MTP" covers two algorithms:
     # (1) Eagle-like MTP (e.g. DeepSeek) stays on Eagle in eagle.py;
     # (2) Vanilla MTP (e.g. Inkling) with multi-layer weights stays on Mtp in mtp.py.
+    if spec_algo == "DSPARK":
+        from tokenspeed.runtime.models.deepseek_v4_dspark import (
+            DeepseekV4ForCausalLMDSpark,
+        )
+
+        if isinstance(model, DeepseekV4ForCausalLMDSpark):
+            return DeepseekV4DSpark
     if spec_algo == "MTP" and isinstance(model, InklingForConditionalGenerationNextN):
         return Mtp
     else:
@@ -428,9 +438,11 @@ class ModelExecutor:
             )
             if hasattr(self.drafter, "bind_target_model"):
                 self.drafter.bind_target_model(self.model_runner.model)
-            # EAGLE3/MTP share the target's embed + lm_head; DFLASH ships its
-            # own draft weights, so it must NOT inherit the target's.
-            if config.spec_algo in ("EAGLE3", "MTP"):
+            # The V4 checkpoint-local DSpark path shares the target's embed and
+            # LM head. Generic DSpark and DFlash ship their own draft weights.
+            if config.spec_algo in ("EAGLE3", "MTP") or isinstance(
+                self.drafter, DeepseekV4DSpark
+            ):
                 embed, head = self.model_runner.model.get_embed_and_head()
                 draft_model_runner.model.set_embed_and_head(embed, head)
             MultimodalRuntime.wire_drafter(
@@ -444,7 +456,9 @@ class ModelExecutor:
                     draft_model_runner.model_config.hf_config
                 )
                 self.model_runner.model.set_eagle3_layers_to_capture(aux_layer_ids)
-            if config.spec_algo in ("DFLASH", "DSPARK"):
+            if config.spec_algo in ("DFLASH", "DSPARK") and not isinstance(
+                self.drafter, DeepseekV4DSpark
+            ):
                 if not hasattr(self.model_runner.model, "set_dflash_layers_to_capture"):
                     raise ValueError(
                         "DFLASH requires the target model to support "
@@ -459,6 +473,15 @@ class ModelExecutor:
                     self.drafter.target_layer_ids,
                     incremental_callback=incr_callback,
                     slot_bufs=incr_slot_bufs,
+                )
+            if isinstance(self.drafter, DeepseekV4DSpark):
+                if not hasattr(self.model_runner.model, "set_dspark_layers_to_capture"):
+                    raise ValueError(
+                        "DSPARK requires the target model to support "
+                        "set_dspark_layers_to_capture."
+                    )
+                self.model_runner.model.set_dspark_layers_to_capture(
+                    self.drafter.target_layer_ids
                 )
         else:
             self.drafter = None
@@ -1414,6 +1437,14 @@ class ModelExecutor:
                 total_tokens=total_tokens,
                 page_table=page_table,
             )
+            if self.drafter is not None and hasattr(
+                self.drafter, "prepare_request_state"
+            ):
+                self.drafter.prepare_request_state(
+                    forward_op.request_ids,
+                    forward_op.request_pool_indices,
+                    num_extends,
+                )
             if timing_enabled:
                 input_fill_done = time.perf_counter()
                 input_fill_ms = (input_fill_done - timing_start) * 1000.0

--- a/python/tokenspeed/runtime/execution/prefill_graph.py
+++ b/python/tokenspeed/runtime/execution/prefill_graph.py
@@ -421,7 +421,7 @@ class PrefillGraph:
     def _dummy_group_tables(
         self, req_tokens: int, bs: int
     ) -> dict[str, "torch.Tensor"]:
-        """Build capture tables: null KV pages and one writable state page."""
+        """Build capture tables that honor each backend's active-page contract."""
         backend = self.attn_backend
         if not getattr(backend, "uses_cache_groups", False):
             return {}
@@ -436,6 +436,9 @@ class PrefillGraph:
         # Composite wrappers hold the cache-group consumer as a child.
         if not hasattr(backend, "page_size") and hasattr(backend, "full_attn_backend"):
             backend = backend.full_attn_backend
+        require_real_active_pages = bool(
+            getattr(backend, "cache_active_pages_must_be_real", False)
+        )
         # Full width: backends that derive the row stride from max_kv_len
         # (trtllm) index the whole row even when the bucket is small.
         width = getattr(backend, "max_num_pages", 0) or -(
@@ -444,15 +447,29 @@ class PrefillGraph:
         # ALL groups, state included: hybrid wrappers forward the dict to the
         # mamba child, which requires its state group; KV children shed state
         # groups themselves (_shed_state_groups).
-        return {
-            str(spec.group_id): torch.full(
-                (bs, width),
-                1 if str(spec.group_id) in state_group_ids else 0,
+        out = {}
+        for spec in specs:
+            group_id = str(spec.group_id)
+            group_width = width
+            if require_real_active_pages:
+                raw_tokens_per_page = int(spec.rows_per_page) * int(
+                    spec.entry_stride_tokens
+                )
+                if raw_tokens_per_page <= 0:
+                    raise RuntimeError(
+                        f"cache group {group_id!r} has invalid page geometry"
+                    )
+                group_width = max(
+                    1,
+                    (req_tokens + raw_tokens_per_page - 1) // raw_tokens_per_page,
+                )
+            out[group_id] = torch.full(
+                (bs, group_width),
+                1 if require_real_active_pages or group_id in state_group_ids else 0,
                 dtype=torch.int32,
                 device=self.config.device,
             )
-            for spec in specs
-        }
+        return out
 
     def make_dummy_batch(
         self, num_tokens: int, decode_wrapper: CudaGraphWrapper | None
@@ -468,13 +485,11 @@ class PrefillGraph:
         a multi-request batch, never as one sequence.
 
         The prefill analogue of decode's ``_init_capture_metadata``. KV writes
-        go to the reserved dummy slot and the page table points at page 0, so
-        the forward runs (producing discarded garbage) without touching real
-        cache state. Backends with extra paged caches (DeepSeek-V4 DSA: SWA +
-        compressor + indexer state) also need per-cache block tables, or their
-        extend metadata comes up incomplete and the eager attention break
-        aborts the capture -- reuse the decode wrapper's dummy-table builder
-        (all zeros, the safe page 0) for those.
+        go to the reserved dummy slot. Per-group tables use page 0 when a
+        backend permits the null page for capture and page 1 when active
+        metadata requires a real writable page. Backends with extra paged
+        caches (DeepSeek-V4 DSA: SWA + compressor + indexer state) need every
+        group table, or their extend metadata is incomplete.
         """
         ib = self.input_buffers
         max_req_tokens = max(1, int(self.config.context_len))

--- a/python/tokenspeed/runtime/layers/attention/backends/base.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/base.py
@@ -67,6 +67,13 @@ class AttentionBackend(ABC):
     # different hole/index semantics; a group-aware backend sets
     # this True. Default False keeps every existing backend on today's path.
     uses_cache_groups: bool = False
+    # True when authoritative per-group tables also replace the shared
+    # full-history draft table for this backend. Keep this separate from
+    # uses_cache_groups: generic speculative backends still consume that table.
+    cache_group_tables_replace_draft_page_table: bool = False
+    # Capture helpers use a real writable page for every active group when
+    # the backend rejects the reserved null page for live sequence metadata.
+    cache_active_pages_must_be_real: bool = False
     # False for group-aware backends whose spec-verify path is not wired yet.
     cache_group_spec_capable: bool = True
     uses_padded_decode_token_mask: bool = False

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -13,6 +13,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 import torch
 from tokenspeed_kernel.ops.attention.flash_mla import (
     flash_mla_sparse_fwd,
@@ -242,6 +244,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
 
     uses_paged_cache_groups = True
     uses_cache_groups = True
+    cache_group_tables_replace_draft_page_table = True
+    cache_active_pages_must_be_real = True
     cache_consumer_families = frozenset({"history", "state"})
     uses_padded_decode_token_mask = True
 
@@ -276,6 +280,9 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         self._decode_tile_metadata = {}
         self._cuda_graph_metadata = {}
         self._cuda_graph_paged_cache_block_tables: dict[str, torch.Tensor] = {}
+        self._expected_cache_group_ids: tuple[str, ...] | None = None
+        self._cache_group_raw_tokens_per_page: dict[str, int] = {}
+        self._cache_group_max_page_ids: dict[str, int] = {}
         # Per-sliding-group [max_bs] int32 buffers mirroring the block-table
         # buffers; populated by init_cuda_graph_state.
         self._cuda_graph_paged_cache_base_offsets: dict[str, torch.Tensor] = {}
@@ -297,14 +304,173 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         self._cuda_graph_query_start_by_tokens_per_req: dict[int, torch.Tensor] = {}
         self._cuda_graph_token_to_req_by_tokens_per_req: dict[int, torch.Tensor] = {}
 
+    def _configure_cache_group_contract(
+        self,
+        paged_cache_group_specs=(),
+        paged_cache_group_page_counts=None,
+    ) -> tuple[tuple[object, ...], dict[str, int]]:
+        specs = tuple(paged_cache_group_specs or ())
+        group_ids = tuple(getattr(spec, "group_id", None) for spec in specs)
+        if any(not isinstance(group_id, str) or not group_id for group_id in group_ids):
+            raise RuntimeError(
+                "DeepSeek V4 cache group specs must use nonempty string IDs"
+            )
+        if len(group_ids) != len(set(group_ids)):
+            raise RuntimeError("DeepSeek V4 cache group specs contain duplicate IDs")
+        page_counts = dict(paged_cache_group_page_counts or {})
+        if not group_ids:
+            if page_counts:
+                raise RuntimeError(
+                    "DeepSeek V4 cache page counts require matching group specs"
+                )
+            raw_tokens_per_page: dict[str, int] = {}
+            max_page_ids: dict[str, int] = {}
+        else:
+            if set(page_counts) != set(group_ids):
+                raise RuntimeError(
+                    "DeepSeek V4 cache page counts disagree with group specs: "
+                    f"missing={sorted(set(group_ids) - set(page_counts))} "
+                    f"extra={sorted(set(page_counts) - set(group_ids))}"
+                )
+            invalid_counts = {
+                group_id: page_counts[group_id]
+                for group_id in group_ids
+                if not isinstance(page_counts[group_id], int)
+                or isinstance(page_counts[group_id], bool)
+                or page_counts[group_id] <= 1
+            }
+            if invalid_counts:
+                raise RuntimeError(
+                    "DeepSeek V4 cache groups must reserve page 0 and at least one "
+                    f"live page: {invalid_counts!r}"
+                )
+            raw_tokens_per_page = {}
+            for spec, group_id in zip(specs, group_ids, strict=True):
+                raw_tokens = int(spec.rows_per_page) * int(spec.entry_stride_tokens)
+                if raw_tokens <= 0:
+                    raise RuntimeError(
+                        "DeepSeek V4 cache group has invalid page geometry: "
+                        f"group={group_id!r} rows_per_page={spec.rows_per_page} "
+                        f"entry_stride_tokens={spec.entry_stride_tokens}"
+                    )
+                raw_tokens_per_page[group_id] = raw_tokens
+            max_page_ids = {
+                group_id: int(page_counts[group_id]) - 1 for group_id in group_ids
+            }
+
+        if self._expected_cache_group_ids is not None:
+            if (
+                self._expected_cache_group_ids != group_ids
+                or self._cache_group_raw_tokens_per_page != raw_tokens_per_page
+                or self._cache_group_max_page_ids != max_page_ids
+            ):
+                raise RuntimeError(
+                    "DeepSeek V4 cache group contract changed after initialization"
+                )
+        self._expected_cache_group_ids = group_ids
+        self._cache_group_raw_tokens_per_page = raw_tokens_per_page
+        self._cache_group_max_page_ids = max_page_ids
+        return specs, page_counts
+
+    def configure_runtime(self, **kwargs) -> None:
+        self._configure_cache_group_contract(
+            kwargs.pop("paged_cache_group_specs", ()),
+            kwargs.pop("paged_cache_group_page_counts", None),
+        )
+
     def _prepare_cache_group_tables(
         self,
-        block_tables: dict[str, torch.Tensor],
+        block_tables: Mapping[object, object],
         *,
+        bs: int,
+        actual_bs: int,
+        seq_lens: torch.Tensor,
+        device: torch.device,
+        phase: str,
         output_buffers: dict[str, torch.Tensor] | None = None,
     ) -> dict[str, torch.Tensor]:
-        materialized = {}
-        for group_id, table in block_tables.items():
+        if actual_bs < 0 or actual_bs > bs:
+            raise RuntimeError(
+                f"DeepSeek V4 {phase} actual_bs={actual_bs} must be within 0..{bs}"
+            )
+        if seq_lens.ndim != 1 or int(seq_lens.shape[0]) < actual_bs:
+            raise RuntimeError(
+                f"DeepSeek V4 {phase} seq_lens has shape {tuple(seq_lens.shape)}, "
+                f"expected at least {actual_bs} entries"
+            )
+        if not isinstance(block_tables, Mapping):
+            raise RuntimeError(
+                f"DeepSeek V4 {phase} cache tables must be a mapping, got "
+                f"{type(block_tables).__name__}"
+            )
+        expected = self._expected_cache_group_ids
+        if expected is None:
+            raise RuntimeError(
+                "DeepSeek V4 cache group specs were not initialized before " f"{phase}"
+            )
+        items = list(block_tables.items())
+        delivered: list[str] = []
+        for group_id, _ in items:
+            if not isinstance(group_id, str) or not group_id:
+                raise RuntimeError(
+                    f"DeepSeek V4 {phase} cache group IDs must be nonempty strings"
+                )
+            delivered.append(group_id)
+        delivered_ids = tuple(delivered)
+        if delivered_ids != expected:
+            delivered_set = set(delivered_ids)
+            expected_set = set(expected)
+            if delivered_set == expected_set:
+                detail = f"wrong order: got={delivered_ids!r} expected={expected!r}"
+            else:
+                detail = (
+                    f"missing={sorted(expected_set - delivered_set)} "
+                    f"extra={sorted(delivered_set - expected_set)}"
+                )
+            raise RuntimeError(f"DeepSeek V4 {phase} cache group mismatch: {detail}")
+
+        expected_device = torch.device(device)
+        if expected_device.type == "cuda" and expected_device.index is None:
+            expected_device = torch.device("cuda", torch.cuda.current_device())
+        validated: dict[str, torch.Tensor] = {}
+        for group_id, (_, value) in zip(delivered_ids, items, strict=True):
+            if not isinstance(value, torch.Tensor):
+                raise RuntimeError(
+                    f"DeepSeek V4 {phase} table {group_id!r} must be torch.Tensor"
+                )
+            table = value
+            if table.dtype != torch.int32:
+                raise RuntimeError(
+                    f"DeepSeek V4 {phase} table {group_id!r} must use torch.int32"
+                )
+            if table.device != expected_device:
+                raise RuntimeError(
+                    f"DeepSeek V4 {phase} table {group_id!r} is on "
+                    f"{table.device}, expected {expected_device}"
+                )
+            if table.ndim != 2:
+                raise RuntimeError(
+                    f"DeepSeek V4 {phase} table {group_id!r} must be rank 2"
+                )
+            if int(table.shape[0]) != bs:
+                raise RuntimeError(
+                    f"DeepSeek V4 {phase} table {group_id!r} has "
+                    f"{int(table.shape[0])} rows, expected bs={bs}"
+                )
+            if int(table.shape[1]) <= 0:
+                raise RuntimeError(
+                    f"DeepSeek V4 {phase} table {group_id!r} has zero width"
+                )
+            validated[group_id] = table
+
+        self._assert_active_cache_pages(
+            validated,
+            seq_lens=seq_lens,
+            actual_bs=actual_bs,
+            phase=phase,
+        )
+        materialized: dict[str, torch.Tensor] = {}
+        for group_id, table in validated.items():
             if output_buffers is None:
                 materialized[group_id] = table
                 continue
@@ -322,6 +488,75 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             out[:rows, :columns].copy_(table)
             materialized[group_id] = out[:rows]
         return materialized
+
+    def _assert_active_cache_pages(
+        self,
+        tables: Mapping[str, torch.Tensor],
+        *,
+        seq_lens: torch.Tensor,
+        actual_bs: int,
+        phase: str,
+    ) -> None:
+        """Check only each live row's active page on GPU hot paths."""
+        if actual_bs == 0:
+            return
+        live_seq_lens = seq_lens[:actual_bs].to(dtype=torch.int64)
+        seq_lens_valid = live_seq_lens.ge(0).all()
+        if live_seq_lens.device.type == "cpu":
+            if not bool(seq_lens_valid.item()):
+                raise RuntimeError(
+                    f"DeepSeek V4 {phase} sequence lengths must be nonnegative"
+                )
+        else:
+            torch._assert_async(
+                seq_lens_valid,
+                f"DeepSeek V4 {phase} sequence lengths must be nonnegative",
+            )
+        for group_id, table in tables.items():
+            raw_tokens_per_page = self._cache_group_raw_tokens_per_page.get(group_id)
+            max_page_id = self._cache_group_max_page_ids.get(group_id)
+            if raw_tokens_per_page is None or max_page_id is None:
+                raise RuntimeError(
+                    "DeepSeek V4 cache group contract is incomplete for "
+                    f"{group_id!r}"
+                )
+            live = table[:actual_bs]
+            required_page = torch.div(
+                live_seq_lens.clamp_min(1) - 1,
+                raw_tokens_per_page,
+                rounding_mode="floor",
+            )
+            width = int(table.shape[1])
+            in_bounds = required_page < width
+            safe_page = required_page.clamp(min=0, max=width - 1)
+            required_entries = live.gather(1, safe_page.unsqueeze(1)).squeeze(1)
+            has_tokens = live_seq_lens > 0
+            active_pages_valid = (
+                ~has_tokens
+                | (
+                    in_bounds
+                    & required_entries.gt(0)
+                    & required_entries.le(max_page_id)
+                )
+            ).all()
+            if table.device.type == "cpu":
+                page_ids_valid = ((live >= -1) & (live <= max_page_id)).all()
+                if not bool(page_ids_valid.item()):
+                    raise RuntimeError(
+                        f"DeepSeek V4 {phase} table {group_id!r} contains a page "
+                        f"ID outside -1..{max_page_id}"
+                    )
+                if not bool(active_pages_valid.item()):
+                    raise RuntimeError(
+                        f"DeepSeek V4 {phase} table {group_id!r} is missing a "
+                        "real page for an active sequence"
+                    )
+            else:
+                torch._assert_async(
+                    active_pages_valid,
+                    f"DeepSeek V4 {phase} table is missing a real active page "
+                    "or its page ID exceeds group capacity",
+                )
 
     def _cuda_graph_group_table_width(
         self,
@@ -620,6 +855,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         else:
             num_tokens = bs
         del kwargs
+        device = seq_lens.device
         # Batch-ordered base page table for ratio<=1 (uncompressed/SWA) indexer
         # layers, which have no dedicated group: the first (smallest-ratio)
         # compressed-KV full-history group's table (row i == batch position i).
@@ -634,15 +870,30 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             if base_group_id is not None:
                 base_block_table = scheduler_tables[base_group_id]
             paged_cache_block_tables = self._prepare_cache_group_tables(
-                scheduler_tables
+                scheduler_tables,
+                bs=bs,
+                actual_bs=bs,
+                seq_lens=seq_lens,
+                device=device,
+                phase="eager",
             )
             paged_cache_block_table_base_offsets = {}
         elif block_tables:
             base_group_id = first_v4_compressed_kv_group_id(block_tables)
             if base_group_id is not None:
                 base_block_table = block_tables[base_group_id]
-            paged_cache_block_tables = self._prepare_cache_group_tables(block_tables)
-        device = seq_lens.device
+            paged_cache_block_tables = self._prepare_cache_group_tables(
+                block_tables,
+                bs=bs,
+                actual_bs=bs,
+                seq_lens=seq_lens,
+                device=device,
+                phase="eager",
+            )
+        elif bs > 0 and self._expected_cache_group_ids:
+            raise RuntimeError(
+                "DeepSeek V4 eager metadata is missing live cache group tables"
+            )
         req_pool_indices = req_pool_indices[:bs]
         seq_lens = seq_lens[:bs].to(torch.int32)
         query_lens = self._query_lens(
@@ -1690,6 +1941,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         self,
         max_bs: int,
         paged_cache_group_specs=(),
+        paged_cache_group_page_counts=None,
         logical_page_size: int | None = None,
         max_tokens_per_req: int = 1,
         overlap_schedule_depth: int = 0,
@@ -1754,10 +2006,26 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             )
         self._cuda_graph_max_bs = max_bs
         self._cuda_graph_paged_cache_block_tables = {}
+        specs, page_counts = self._configure_cache_group_contract(
+            paged_cache_group_specs,
+            paged_cache_group_page_counts,
+        )
+        group_ids = self._expected_cache_group_ids
+        assert group_ids is not None
+        if not group_ids:
+            self._cuda_graph_paged_cache_base_offsets = {}
+            self._cuda_graph_is_valid_token = torch.ones(
+                max_tokens,
+                dtype=torch.bool,
+                device=self.device,
+            )
+            return
         self._cuda_graph_paged_cache_base_offsets = {}
-        for spec in tuple(paged_cache_group_specs or ()):
-            gid = str(spec.group_id)
+        for spec, gid in zip(specs, group_ids, strict=True):
             sliding = str(getattr(spec, "retention", "")) == "sliding_window"
+            raw_tokens_per_page = int(spec.rows_per_page) * int(
+                spec.entry_stride_tokens
+            )
             max_pages = self._cuda_graph_group_table_width(
                 spec,
                 max_tokens_per_req=max_tokens_per_req,
@@ -1942,13 +2210,16 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             str(gid): off.to(device=self.device, dtype=torch.int32)
             for gid, off in paged_cache_block_table_base_offsets.items()
         }
-        metadata_paged = self._refresh_cuda_graph_paged_cache_block_tables(
-            bs,
-            {
-                str(group_id): table.to(device=self.device, dtype=torch.int32)
-                for group_id, table in paged_cache_block_tables.items()
-            },
-            pad_value=0,
+        metadata_paged = self._prepare_cache_group_tables(
+            paged_cache_block_tables,
+            bs=bs,
+            # Capture tables are placeholders and may name the null page. The
+            # first replay must replace every live row with authoritative data.
+            actual_bs=0,
+            seq_lens=capture_seq_lens,
+            device=self.device,
+            phase="capture",
+            output_buffers=self._cuda_graph_paged_cache_block_tables,
         )
         metadata_base_offsets = self._refresh_cuda_graph_base_offsets(
             bs,
@@ -2035,7 +2306,11 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         paged_cache_block_table_base_offsets = (
             kwargs.pop("paged_cache_block_table_base_offsets", None) or {}
         )
-        actual_bs = max(0, min(int(kwargs.pop("actual_bs", bs)), bs))
+        actual_bs = int(kwargs.pop("actual_bs", bs))
+        if actual_bs < 0 or actual_bs > bs:
+            raise RuntimeError(
+                f"DeepSeek V4 replay actual_bs={actual_bs} must be within 0..{bs}"
+            )
         num_tokens_arg = kwargs.pop("num_tokens", None)
         del kwargs
         if forward_mode is not None and not forward_mode.is_decode_or_idle():
@@ -2090,24 +2365,35 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             for gid, off in paged_cache_block_table_base_offsets.items()
         }
         if block_tables:
-            metadata_paged = self._refresh_cuda_graph_paged_cache_block_tables(
-                bs,
+            metadata_paged = self._prepare_cache_group_tables(
                 block_tables,
+                bs=bs,
                 actual_bs=actual_bs,
-                pad_value=-1,
+                seq_lens=seq_lens,
+                device=seq_lens.device,
+                phase="replay",
+                output_buffers=self._cuda_graph_paged_cache_block_tables,
             )
             metadata_base_offsets = {}
         elif cache_metadata is not None:
             scheduler_tables = dict(
                 cache_metadata.tables(active_forward_op=forward_batch)
             )
-            metadata_paged = self._refresh_cuda_graph_paged_cache_block_tables(
-                bs,
+            metadata_paged = self._prepare_cache_group_tables(
                 scheduler_tables,
+                bs=bs,
                 actual_bs=actual_bs,
-                pad_value=-1,
+                seq_lens=seq_lens,
+                device=seq_lens.device,
+                phase="replay",
+                output_buffers=self._cuda_graph_paged_cache_block_tables,
             )
             metadata_base_offsets = {}
+        elif actual_bs > 0 and self._expected_cache_group_ids:
+            raise RuntimeError(
+                "DeepSeek V4 replay is missing live cache group tables; "
+                "capture placeholders cannot be reused"
+            )
         else:
             metadata_paged = self._refresh_cuda_graph_paged_cache_block_tables(
                 bs,

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -2023,9 +2023,6 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         self._cuda_graph_paged_cache_base_offsets = {}
         for spec, gid in zip(specs, group_ids, strict=True):
             sliding = str(getattr(spec, "retention", "")) == "sliding_window"
-            raw_tokens_per_page = int(spec.rows_per_page) * int(
-                spec.entry_stride_tokens
-            )
             max_pages = self._cuda_graph_group_table_width(
                 spec,
                 max_tokens_per_req=max_tokens_per_req,

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4.py
@@ -242,12 +242,6 @@ def prepare_deepseek_v4_cache(
         attn_config,
         layer_indices=range(model_config.num_attention_layers),
     )
-    # The c4 ring keeps eight rows: four prior rows plus the four verify rows.
-    if 4 in target_layout.layer_ratio and decode_input_tokens > 4:
-        raise ValueError(
-            "DeepSeek V4 c4 LCM cache supports at most four verify tokens; "
-            f"got {decode_input_tokens}"
-        )
     target_layout_plan = solve_deepseek_v4_memory_layout(target_fields)
     packing = dict(target_layout_plan.group_packing)
 
@@ -290,6 +284,7 @@ def prepare_deepseek_v4_cache(
             model_config.hf_config,
             layer_ratio=target_layout.layer_ratio,
             cache_blocks_per_lcm_block=packing,
+            decode_input_tokens=decode_input_tokens,
         )
     )
     max_packing = max(packing.values())

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4_cache_spec.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4_cache_spec.py
@@ -320,9 +320,23 @@ def build_v4_cache_specs(
     *,
     layer_ratio: Sequence[int],
     cache_blocks_per_lcm_block: Mapping[str, int] | None = None,
+    decode_input_tokens: int = 1,
 ) -> list[PagedCacheGroupSpec]:
+    if (
+        isinstance(decode_input_tokens, bool)
+        or not isinstance(decode_input_tokens, int)
+        or decode_input_tokens <= 0
+    ):
+        raise ValueError("decode_input_tokens must be a positive integer")
     swa_window = _resolve_sliding_window(hf_config)
     unique_compress_ratios = sorted({int(r) for r in layer_ratio if int(r) > 1})
+    # c4 compression consumes the prior four-token state plus every token in
+    # the target verify block. Preserve the historical eight-token window for
+    # verify widths <= 4 and grow it for wider block-speculative decoders.
+    c4_state_window = max(
+        _COMPRESSOR_STATE_WINDOW_TOKENS[4],
+        4 + decode_input_tokens,
+    )
 
     specs: list[PagedCacheGroupSpec] = [
         # SWA kv: trailing window only -> State family.
@@ -345,7 +359,11 @@ def build_v4_cache_specs(
                 retention="sliding_window",
                 rows_per_page=_COMPRESSOR_STATE_ROWS_PER_PAGE[ratio],
                 entry_stride_tokens=1,
-                sliding_window_tokens=_COMPRESSOR_STATE_WINDOW_TOKENS[ratio],
+                sliding_window_tokens=(
+                    c4_state_window
+                    if ratio == 4
+                    else _COMPRESSOR_STATE_WINDOW_TOKENS[ratio]
+                ),
                 family="state",
             )
         )
@@ -368,7 +386,7 @@ def build_v4_cache_specs(
                 retention="sliding_window",
                 rows_per_page=_COMPRESSOR_STATE_ROWS_PER_PAGE[4],
                 entry_stride_tokens=1,
-                sliding_window_tokens=_COMPRESSOR_STATE_WINDOW_TOKENS[4],
+                sliding_window_tokens=c4_state_window,
                 family="state",
             )
         )

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -808,8 +808,19 @@ def create_attn_components(
     # (GDN scalar decay vs KDA per-channel) and the base attn arch (MHA vs MLA).
     is_hybrid_linear = is_hybrid_gdn or is_hybrid_mla_kda
     is_deepseek_v4_model = is_deepseek_v4(model_config.hf_config)
-    is_deepseek_v4_draft_model = draft_model_config is not None and is_deepseek_v4(
-        draft_model_config.hf_config
+    draft_architectures = (
+        getattr(draft_model_config.hf_config, "architectures", None) or []
+        if draft_model_config is not None
+        else []
+    )
+    is_dspark_draft_model = any(
+        architecture == "DeepseekV4ForCausalLMDSpark"
+        for architecture in draft_architectures
+    )
+    is_deepseek_v4_draft_model = (
+        draft_model_config is not None
+        and not is_dspark_draft_model
+        and is_deepseek_v4(draft_model_config.hf_config)
     )
     original_attn_backend = server_args.attention_backend
     if is_deepseek_v4_model:
@@ -884,18 +895,13 @@ def create_attn_components(
     )
     draft_attn_config = (
         _create_attn_config(server_args, draft_model_config, is_draft=True)
-        if draft_model_config
+        if draft_model_config and not is_dspark_draft_model
         else None
     )
     if is_deepseek_v4_draft_model:
         draft_attn_config.sliding_window_tokens = int(
             draft_model_config.hf_config.sliding_window
         )
-    draft_architectures = (
-        getattr(draft_model_config.hf_config, "architectures", None) or []
-        if draft_model_config is not None
-        else []
-    )
     draft_is_hybrid_gdn = any(
         architecture in _HYBRID_GDN_ARCHITECTURES
         for architecture in draft_architectures

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -4053,6 +4053,29 @@ class DeepseekV4Model(nn.Module):
         self.hc_head_scale = nn.Parameter(
             torch.empty(1, dtype=torch.float32), requires_grad=False
         )
+        self.dspark_layers_to_capture: tuple[int, ...] = ()
+
+    def set_dspark_layers_to_capture(self, layer_ids: list[int]) -> None:
+        normalized = tuple(int(layer_id) for layer_id in layer_ids)
+        if not normalized:
+            raise ValueError("DSpark requires at least one target capture layer.")
+        if len(set(normalized)) != len(normalized):
+            raise ValueError("DSpark target capture layer IDs must be unique.")
+        if tuple(sorted(normalized)) != normalized:
+            raise ValueError(
+                "DSpark target capture layer IDs must be strictly increasing."
+            )
+        invalid = [
+            layer_id
+            for layer_id in normalized
+            if layer_id < 0 or layer_id >= len(self.layers)
+        ]
+        if invalid:
+            raise ValueError(
+                "DSpark target capture layer IDs are out of range: "
+                f"{invalid}; target has {len(self.layers)} layers."
+            )
+        self.dspark_layers_to_capture = normalized
 
     def forward(
         self,
@@ -4075,6 +4098,8 @@ class DeepseekV4Model(nn.Module):
         hc_x_prev = None
         hc_post_prev = None
         hc_comb_prev = None
+        dspark_captures = []
+        dspark_capture_set = frozenset(self.dspark_layers_to_capture)
         for layer in self.layers:
             hidden_states, hc_x_prev, hc_post_prev, hc_comb_prev = layer(
                 positions,
@@ -4088,6 +4113,14 @@ class DeepseekV4Model(nn.Module):
                 hc_post_prev,
                 hc_comb_prev,
             )
+            if layer.layer_id in dspark_capture_set:
+                resolved_hidden_states = mhc_post(
+                    hc_x_prev,
+                    hidden_states,
+                    hc_post_prev,
+                    hc_comb_prev,
+                )
+                dspark_captures.append(resolved_hidden_states.mean(dim=1))
         with nvtx_range("hc_ffn_post_final"):
             hidden_states = mhc_post(
                 hc_x_prev, hidden_states, hc_post_prev, hc_comb_prev
@@ -4097,8 +4130,17 @@ class DeepseekV4Model(nn.Module):
             ctx.capture_hidden_mode is not None
             and ctx.capture_hidden_mode.need_capture()
         ):
-            # V4 MTP consumes the pre-hc_head hypercompressed residual.
-            aux_hidden_states = [hidden_states.flatten(1)]
+            if self.dspark_layers_to_capture:
+                if len(dspark_captures) != len(self.dspark_layers_to_capture):
+                    raise RuntimeError(
+                        "DSpark target hidden-state capture is incomplete: "
+                        f"expected {self.dspark_layers_to_capture}, captured "
+                        f"{len(dspark_captures)} tensors."
+                    )
+                aux_hidden_states = dspark_captures
+            else:
+                # V4 MTP consumes the pre-hc_head hypercompressed residual.
+                aux_hidden_states = [hidden_states.flatten(1)]
         with nvtx_range("hc_head"):
             hidden_states = hc_head(
                 hidden_states,
@@ -4115,6 +4157,10 @@ class DeepseekV4Model(nn.Module):
 
 class DeepseekV4ForCausalLM(BaseCausalLM):
     model_cls = DeepseekV4Model
+
+    def set_dspark_layers_to_capture(self, layer_ids: list[int]) -> None:
+        self.capture_aux_hidden_states = True
+        self.model.set_dspark_layers_to_capture(layer_ids)
 
     def get_stacked_params_mapping(self):
         return [

--- a/python/tokenspeed/runtime/models/deepseek_v4_dspark.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_dspark.py
@@ -1,0 +1,801 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 DeepSeek
+# SPDX-FileCopyrightText: Copyright (c) 2026 LightSeek Foundation
+# SPDX-License-Identifier: MIT AND Apache-2.0
+
+"""Inference-only DeepSeek V4 DSpark draft model."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from collections.abc import Iterable
+
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+
+from tokenspeed.runtime.distributed.mapping import Mapping
+from tokenspeed.runtime.execution.context import ForwardContext
+from tokenspeed.runtime.layers.layernorm import RMSNorm
+from tokenspeed.runtime.layers.linear import ReplicatedLinear
+from tokenspeed.runtime.layers.moe import (
+    ExpertCheckpointSchema,
+    build_moe_checkpoint_loader,
+)
+from tokenspeed.runtime.layers.moe.expert import MoELayer
+from tokenspeed.runtime.layers.quantization.base_config import QuantizationConfig
+from tokenspeed.runtime.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from tokenspeed.runtime.model_loader.weight_utils import default_weight_loader
+from tokenspeed.runtime.models.deepseek_v4 import (
+    DeepseekV4Compressor,
+    DeepseekV4DecoderLayer,
+    DeepseekV4MegaMoEExperts,
+    hc_head,
+    mhc_fused_hc,
+    mhc_post,
+    mhc_pre,
+)
+from tokenspeed.runtime.models.deepseek_v4_dspark_ops.attention import (
+    _dspark_fp8_linear,
+    _quantize_dspark_non_rope,
+    _rmsnorm,
+    _rope_last_dims_batched,
+    dspark_attention_forward_batched,
+    precompute_dspark_freqs_cis,
+)
+from tokenspeed.runtime.models.deepseek_v4_dspark_ops.heads import (
+    DSparkConfidenceHead,
+    DSparkVanillaMarkov,
+    sample_dspark_block_greedy,
+)
+from tokenspeed.runtime.utils import add_prefix
+
+logger = logging.getLogger(__name__)
+
+_DSPARK_WEIGHT_RE = re.compile(r"^mtp\.(\d+)\.(.+)$")
+_EXPERT_SCALE_RE = re.compile(r"\.experts\.\d+\.w[123]\.scale$")
+_ATTENTION_TENSORS = frozenset(
+    {
+        "attn_sink",
+        "kv_norm.weight",
+        "q_norm.weight",
+        "wkv.scale",
+        "wkv.weight",
+        "wo_a.scale",
+        "wo_a.weight",
+        "wo_b.scale",
+        "wo_b.weight",
+        "wq_a.scale",
+        "wq_a.weight",
+        "wq_b.scale",
+        "wq_b.weight",
+    }
+)
+_ATTENTION_CHECKPOINT_TENSORS = frozenset(f"attn.{name}" for name in _ATTENTION_TENSORS)
+_STAGE_ZERO_CORE = frozenset(
+    {"main_norm.weight", "main_proj.scale", "main_proj.weight"}
+)
+_STAGE_COMMON_CORE = frozenset(
+    {
+        "attn_norm.weight",
+        "ffn.gate.bias",
+        "ffn.gate.weight",
+        "ffn.shared_experts.w1.scale",
+        "ffn.shared_experts.w1.weight",
+        "ffn.shared_experts.w2.scale",
+        "ffn.shared_experts.w2.weight",
+        "ffn.shared_experts.w3.scale",
+        "ffn.shared_experts.w3.weight",
+        "ffn_norm.weight",
+        "hc_attn_base",
+        "hc_attn_fn",
+        "hc_attn_scale",
+        "hc_ffn_base",
+        "hc_ffn_fn",
+        "hc_ffn_scale",
+    }
+)
+_LAST_STAGE_CORE = frozenset(
+    {
+        "confidence_head.proj.weight",
+        "hc_head_base",
+        "hc_head_fn",
+        "hc_head_scale",
+        "markov_head.markov_w1.weight",
+        "markov_head.markov_w2.weight",
+        "norm.weight",
+    }
+)
+_ZERO_INITIALIZED_EXPERT_BIAS_SUFFIXES = (
+    ".experts.w13_weight_bias",
+    ".experts.w2_weight_bias",
+)
+
+
+def _is_zero_initialized_expert_bias(name: str) -> bool:
+    return name.endswith(_ZERO_INITIALIZED_EXPERT_BIAS_SUFFIXES)
+
+
+def count_dspark_stages(model_path: str) -> int | None:
+    """Count contiguous ``mtp.<stage>`` namespaces in a safetensors index."""
+
+    index_path = os.path.join(model_path, "model.safetensors.index.json")
+    if not os.path.isfile(index_path):
+        return None
+    with open(index_path, encoding="utf-8") as handle:
+        weight_map = json.load(handle).get("weight_map", {})
+    stages = {
+        int(match.group(1))
+        for name in weight_map
+        if (match := _DSPARK_WEIGHT_RE.match(name))
+    }
+    if not stages:
+        return None
+    expected = set(range(max(stages) + 1))
+    if stages != expected:
+        raise ValueError(
+            "DSpark checkpoint stages must be contiguous from zero; "
+            f"found {sorted(stages)}."
+        )
+    return len(stages)
+
+
+def _block_dequant(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    block_size: int = 128,
+) -> torch.Tensor:
+    """Dequantize a DeepSeek block-scaled FP8 matrix to BF16."""
+
+    rows, columns = weight.shape
+    expanded_scale = scale.float().repeat_interleave(block_size, 0)[:rows]
+    expanded_scale = expanded_scale.repeat_interleave(block_size, 1)[:, :columns]
+    return (weight.float() * expanded_scale).to(torch.bfloat16)
+
+
+def _apply_dspark_hc_head(
+    hidden_states: torch.Tensor,
+    hc_fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_norm_eps: float,
+    hc_eps: float,
+) -> torch.Tensor:
+    """Apply the token-wise mHC head while preserving the DSpark block axes."""
+
+    if hidden_states.ndim != 4:
+        raise ValueError(
+            "DSpark mHC head expects [batch, block, streams, hidden], "
+            f"got {tuple(hidden_states.shape)}."
+        )
+    batch_size, block_size, hc_mult, hidden_size = hidden_states.shape
+    output = hc_head(
+        hidden_states.reshape(-1, hc_mult, hidden_size),
+        hc_fn,
+        hc_scale,
+        hc_base,
+        rms_norm_eps,
+        hc_eps,
+    )
+    return output.reshape(batch_size, block_size, hidden_size)
+
+
+class _DSparkStage(nn.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mapping: Mapping,
+        quant_config: QuantizationConfig | None,
+        *,
+        stage_id: int,
+        num_stages: int,
+        num_capture_layers: int,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.stage_id = stage_id
+        self.num_stages = num_stages
+        self.block = DeepseekV4DecoderLayer(
+            config,
+            int(config.num_hidden_layers) + stage_id,
+            mapping,
+            quant_config,
+            add_prefix("block", prefix),
+            cache_layer_index=stage_id,
+        )
+        if stage_id == 0:
+            self.main_proj = ReplicatedLinear(
+                int(config.hidden_size) * num_capture_layers,
+                int(config.hidden_size),
+                bias=False,
+                quant_config=quant_config,
+                prefix=add_prefix("main_proj", prefix),
+            )
+            self.main_norm = RMSNorm(
+                int(config.hidden_size),
+                eps=float(config.rms_norm_eps),
+            )
+        if stage_id == num_stages - 1:
+            self.norm = RMSNorm(
+                int(config.hidden_size),
+                eps=float(config.rms_norm_eps),
+            )
+            hc_mult = int(config.hc_mult)
+            hidden_size = int(config.hidden_size)
+            self.hc_head_fn = nn.Parameter(
+                torch.empty(hc_mult, hc_mult * hidden_size, dtype=torch.float32),
+                requires_grad=False,
+            )
+            self.hc_head_base = nn.Parameter(
+                torch.empty(hc_mult, dtype=torch.float32),
+                requires_grad=False,
+            )
+            self.hc_head_scale = nn.Parameter(
+                torch.empty(1, dtype=torch.float32),
+                requires_grad=False,
+            )
+
+
+class DeepseekV4DSparkModel(nn.Module):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mapping: Mapping,
+        quant_config: QuantizationConfig | None,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.mapping = mapping
+        self.num_stages = int(getattr(config, "dspark_num_stages", 0))
+        if self.num_stages <= 0:
+            raise ValueError(
+                "DSpark requires a positive checkpoint-derived stage count."
+            )
+        self.block_size = int(getattr(config, "dspark_block_size", 0))
+        if self.block_size <= 0:
+            raise ValueError("DSpark checkpoint must define dspark_block_size.")
+        self.target_layer_ids = tuple(
+            int(layer_id) for layer_id in getattr(config, "dspark_target_layer_ids", ())
+        )
+        if not self.target_layer_ids:
+            raise ValueError("DSpark checkpoint must define dspark_target_layer_ids.")
+        if len(set(self.target_layer_ids)) != len(self.target_layer_ids):
+            raise ValueError("DSpark target layer IDs must be unique.")
+        if tuple(sorted(self.target_layer_ids)) != self.target_layer_ids:
+            raise ValueError("DSpark target layer IDs must be strictly increasing.")
+        if self.target_layer_ids[-1] >= int(config.num_hidden_layers):
+            raise ValueError(
+                "DSpark target layer IDs must refer to target decoder layers."
+            )
+
+        self.hidden_size = int(config.hidden_size)
+        self.hc_mult = int(config.hc_mult)
+        self.rms_norm_eps = float(config.rms_norm_eps)
+        self.hc_eps = float(config.hc_eps)
+        self.noise_token_id = int(getattr(config, "dspark_noise_token_id"))
+        self.markov_rank = int(getattr(config, "dspark_markov_rank", 0))
+        if self.markov_rank <= 0:
+            raise ValueError("Week-0 DSpark requires a positive vanilla Markov rank.")
+        markov_kind = getattr(config, "dspark_markov_head_type", None) or "vanilla"
+        if str(markov_kind).lower() != "vanilla":
+            raise ValueError(
+                "Week-0 DSpark supports only the vanilla Markov head; "
+                f"got {markov_kind!r}."
+            )
+
+        self.stages = nn.ModuleList(
+            [
+                _DSparkStage(
+                    config,
+                    mapping,
+                    quant_config,
+                    stage_id=stage_id,
+                    num_stages=self.num_stages,
+                    num_capture_layers=len(self.target_layer_ids),
+                    prefix=add_prefix(f"stages.{stage_id}", prefix),
+                )
+                for stage_id in range(self.num_stages)
+            ]
+        )
+        self.embed_tokens = VocabParallelEmbedding(
+            int(config.vocab_size),
+            self.hidden_size,
+            tp_rank=mapping.attn.tp_rank,
+            tp_size=mapping.attn.tp_size,
+            tp_group=mapping.attn.tp_group,
+            prefix=add_prefix("embed_tokens", prefix),
+        )
+        self.markov_embedding = VocabParallelEmbedding(
+            int(config.vocab_size),
+            self.markov_rank,
+            params_dtype=torch.float32,
+            tp_rank=mapping.attn.tp_rank,
+            tp_size=mapping.attn.tp_size,
+            tp_group=mapping.attn.tp_group,
+            prefix=add_prefix("markov_embedding", prefix),
+        )
+        self.markov_projection = ParallelLMHead(
+            int(config.vocab_size),
+            self.markov_rank,
+            params_dtype=torch.float32,
+            quant_config=None,
+            tp_rank=mapping.attn.tp_rank,
+            tp_size=mapping.attn.tp_size,
+            tp_group=mapping.attn.tp_group,
+            prefix=add_prefix("markov_projection", prefix),
+        )
+        self.markov_head = DSparkVanillaMarkov(
+            self.markov_embedding,
+            self.markov_projection,
+        )
+        self.confidence_projection = ReplicatedLinear(
+            self.hidden_size + self.markov_rank,
+            1,
+            bias=False,
+            params_dtype=torch.float32,
+            quant_config=None,
+            prefix=add_prefix("confidence_projection", prefix),
+        )
+        self.confidence_head = DSparkConfidenceHead(self.confidence_projection)
+
+        head_dim = int(getattr(config, "head_dim"))
+        self.attention_params = {
+            "n_heads": int(config.num_attention_heads),
+            "head_dim": head_dim,
+            "rope_head_dim": int(config.qk_rope_head_dim),
+            "n_groups": int(config.o_groups),
+            "o_lora_rank": int(config.o_lora_rank),
+            "window_size": int(getattr(config, "dspark_window_size", 128)),
+            "eps": self.rms_norm_eps,
+            "softmax_scale": head_dim**-0.5,
+        }
+        frequency_capacity = (
+            int(getattr(config, "max_position_embeddings")) + self.block_size + 2
+        )
+        frequency_device = self.stages[0].block.attn_norm.weight.device
+        self.register_buffer(
+            "freqs_cis",
+            precompute_dspark_freqs_cis(
+                self.attention_params["rope_head_dim"],
+                frequency_capacity,
+                float(getattr(config, "rope_theta", 10000.0)),
+                frequency_device,
+            ),
+            persistent=False,
+        )
+
+    @property
+    def window_size(self) -> int:
+        return int(self.attention_params["window_size"])
+
+    def _forward_stage(
+        self,
+        stage: _DSparkStage,
+        hidden_states: torch.Tensor,
+        main_x: torch.Tensor,
+        start_pos: torch.Tensor,
+        kv_windows: torch.Tensor,
+        slots: torch.Tensor,
+        input_ids: torch.Tensor,
+        ctx: ForwardContext,
+    ) -> torch.Tensor:
+        batch, block_size, _, hidden_size = hidden_states.shape
+        block = stage.block
+        residual = hidden_states
+        layer_input, post, comb = mhc_pre(
+            residual,
+            block.hc_attn_fn,
+            block.hc_attn_scale,
+            block.hc_attn_base,
+            block.rms_norm_eps,
+            block.hc_eps,
+            block.hc_sinkhorn_iters,
+        )
+        layer_input = block.attn_norm(layer_input)
+        attention_output = dspark_attention_forward_batched(
+            layer_input,
+            main_x,
+            start_pos,
+            kv_windows[:, stage.stage_id],
+            slots,
+            freqs_cis=self.freqs_cis,
+            **stage._dspark_attn,
+            **self.attention_params,
+        )
+        residual, layer_input, post, comb = mhc_fused_hc(
+            attention_output,
+            residual,
+            post,
+            comb,
+            block.hc_ffn_fn,
+            block.hc_ffn_scale,
+            block.hc_ffn_base,
+            block.rms_norm_eps,
+            block.hc_eps,
+            block.hc_sinkhorn_iters,
+        )
+        layer_input = block.ffn_norm(layer_input)
+        flat_input = layer_input.reshape(batch * block_size, hidden_size)
+        flat_ids = input_ids.reshape(-1)
+        use_mega_moe = getattr(block.ffn, "use_mega_moe", False)
+        if use_mega_moe:
+            ffn_output = block.ffn(
+                flat_input,
+                flat_ids,
+                batch * block_size,
+                batch * block_size,
+                ctx=ctx,
+                comm_manager=block.comm_manager,
+            )
+        else:
+            flat_input = block.comm_manager.pre_mlp_comm(flat_input, ctx)
+            if block.ffn.gate.is_hash_moe:
+                flat_ids = block._pre_mlp_input_ids_comm(flat_ids, ctx)
+            num_global_tokens, max_num_tokens_per_gpu = (
+                block.comm_manager.get_num_tokens(ctx)
+            )
+            ffn_output = block.ffn(
+                flat_input,
+                flat_ids,
+                num_global_tokens,
+                max_num_tokens_per_gpu,
+            )
+            ffn_output, _ = block.comm_manager.post_mlp_comm(ffn_output, None, ctx)
+        return mhc_post(
+            ffn_output.reshape(batch, block_size, hidden_size),
+            residual,
+            post,
+            comb,
+        )
+
+    def forward_backbone(
+        self,
+        captured_hidden_states: torch.Tensor,
+        bonus_token_ids: torch.Tensor,
+        start_pos: torch.Tensor,
+        kv_windows: torch.Tensor,
+        slots: torch.Tensor,
+        ctx: ForwardContext,
+    ) -> torch.Tensor:
+        expected_width = len(self.target_layer_ids) * self.hidden_size
+        if (
+            captured_hidden_states.ndim != 2
+            or captured_hidden_states.shape[1] != expected_width
+        ):
+            raise ValueError(
+                "DSpark captured hidden-state width mismatch: "
+                f"expected {expected_width}, got {tuple(captured_hidden_states.shape)}."
+            )
+        stage_zero = self.stages[0]
+        main_x, _ = stage_zero.main_proj(captured_hidden_states)
+        main_x = stage_zero.main_norm(main_x).unsqueeze(1)
+        draft_ids = bonus_token_ids.new_full(
+            (bonus_token_ids.shape[0], self.block_size),
+            self.noise_token_id,
+        )
+        draft_ids[:, 0] = bonus_token_ids
+        hidden_states = self.embed_tokens(draft_ids)
+        hidden_states = hidden_states.unsqueeze(-2).repeat(1, 1, self.hc_mult, 1)
+        for stage in self.stages:
+            hidden_states = self._forward_stage(
+                stage,
+                hidden_states,
+                main_x,
+                start_pos,
+                kv_windows,
+                slots,
+                draft_ids,
+                ctx,
+            )
+        last_stage = self.stages[-1]
+        hidden_states = _apply_dspark_hc_head(
+            hidden_states,
+            last_stage.hc_head_fn,
+            last_stage.hc_head_scale,
+            last_stage.hc_head_base,
+            self.rms_norm_eps,
+            self.hc_eps,
+        )
+        return last_stage.norm(hidden_states)
+
+    def local_base_logits(
+        self,
+        hidden_states: torch.Tensor,
+        lm_head: nn.Module,
+    ) -> torch.Tensor:
+        return torch.matmul(hidden_states.float(), lm_head.weight.float().T)
+
+    def write_context_windows_batched(
+        self,
+        captured_hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        slots: torch.Tensor,
+        valid: torch.Tensor,
+        kv_windows: torch.Tensor,
+        dummy_slot: int,
+    ) -> None:
+        del dummy_slot
+        if captured_hidden_states.numel() == 0:
+            return
+        stage_zero = self.stages[0]
+        main_x, _ = stage_zero.main_proj(captured_hidden_states.contiguous())
+        main_x = stage_zero.main_norm(main_x)
+        positions = positions.long()
+        slots = slots.long()
+        frequencies = self.freqs_cis[positions]
+        rows = slots.unsqueeze(1).expand_as(positions)
+        columns = positions % self.window_size
+        valid_values = valid.unsqueeze(-1)
+        for stage in self.stages:
+            attention = stage._dspark_attn
+            projected = _rmsnorm(
+                _dspark_fp8_linear(main_x, attention["wkv"]),
+                attention["kv_norm_w"],
+                self.rms_norm_eps,
+            )
+            projected = _rope_last_dims_batched(
+                projected,
+                self.attention_params["rope_head_dim"],
+                frequencies,
+            )
+            projected = _quantize_dspark_non_rope(
+                projected,
+                self.attention_params["rope_head_dim"],
+            )
+            stage_windows = kv_windows[:, stage.stage_id]
+            current = stage_windows[rows, columns]
+            stage_windows[rows, columns] = torch.where(
+                valid_values,
+                projected.to(stage_windows.dtype),
+                current,
+            )
+
+
+class DeepseekV4ForCausalLMDSpark(nn.Module):
+    """Draft-only DSpark model loaded from the target checkpoint."""
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mapping: Mapping,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.mapping = mapping
+        self.quant_config = quant_config
+        self.model = DeepseekV4DSparkModel(
+            config,
+            mapping,
+            quant_config,
+            add_prefix("model", prefix),
+        )
+        self.lm_head = ParallelLMHead(
+            int(config.vocab_size),
+            int(config.hidden_size),
+            quant_config=quant_config,
+            tp_rank=mapping.attn.tp_rank,
+            tp_size=mapping.attn.tp_size,
+            tp_group=mapping.attn.tp_group,
+            prefix=add_prefix("lm_head", prefix),
+        )
+
+    def get_hot_token_id(self):
+        return None
+
+    def get_embed_and_head(self) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.model.embed_tokens.weight, self.lm_head.weight
+
+    def set_embed_and_head(self, embed: torch.Tensor, head: torch.Tensor) -> None:
+        del self.model.embed_tokens.weight
+        del self.lm_head.weight
+        self.model.embed_tokens.weight = embed
+        self.lm_head.weight = head
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+
+    def checkpoint_weight_name_filter(self, name: str) -> bool:
+        match = _DSPARK_WEIGHT_RE.match(name)
+        return match is not None and int(match.group(1)) < self.model.num_stages
+
+    @staticmethod
+    def _map_stage_name(stage_id: int, suffix: str) -> str:
+        prefix = f"model.stages.{stage_id}."
+        if suffix == "main_norm.weight":
+            return prefix + "main_norm.weight"
+        if suffix.startswith("main_proj."):
+            return prefix + suffix
+        if suffix == "norm.weight":
+            return prefix + "norm.weight"
+        if suffix.startswith("hc_head_"):
+            return prefix + suffix
+        if suffix == "markov_head.markov_w1.weight":
+            return "model.markov_embedding.weight"
+        if suffix == "markov_head.markov_w2.weight":
+            return "model.markov_projection.weight"
+        if suffix == "confidence_head.proj.weight":
+            return "model.confidence_projection.weight"
+        if suffix == "attn_norm.weight":
+            return prefix + "block.attn_norm.weight"
+        if suffix == "ffn_norm.weight":
+            return prefix + "block.ffn_norm.weight"
+        if suffix.startswith(("hc_attn_", "hc_ffn_")):
+            return prefix + "block." + suffix
+        if suffix.startswith("attn."):
+            return prefix + "block." + suffix
+        if suffix.startswith("ffn."):
+            return prefix + "block." + suffix
+        return prefix + suffix
+
+    def _map_checkpoint_name(self, raw_name: str) -> str | None:
+        match = _DSPARK_WEIGHT_RE.match(raw_name)
+        if match is None:
+            return None
+        stage_id = int(match.group(1))
+        if stage_id >= self.model.num_stages:
+            return None
+        name = self._map_stage_name(stage_id, match.group(2))
+        if name.endswith(".scale"):
+            scale_suffix = (
+                ".weight_scale"
+                if _EXPERT_SCALE_RE.search(name)
+                else ".weight_scale_inv"
+            )
+            name = name.removesuffix(".scale") + scale_suffix
+        if ".shared_experts.w2" in name:
+            name = name.replace(".shared_experts.w2", ".shared_experts.down_proj")
+        if ".ffn.gate.bias" in name:
+            name = name.replace(
+                ".ffn.gate.bias",
+                ".ffn.gate.e_score_correction_bias",
+            )
+        return name
+
+    def get_stacked_params_mapping(self):
+        return [
+            ("gate_up_proj", "w1", 0),
+            ("gate_up_proj", "w3", 1),
+            ("attn.fused_wqa_wkv", "attn.wq_a", 0),
+            ("attn.fused_wqa_wkv", "attn.wkv", 1),
+        ]
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        params = dict(self.named_parameters())
+        stacked_mapping = self.get_stacked_params_mapping()
+        moe_loader = build_moe_checkpoint_loader(
+            params_dict=params,
+            expert_schema=ExpertCheckpointSchema(
+                gate_proj_name="w1",
+                down_proj_name="w2",
+                up_proj_name="w3",
+            ),
+            num_experts=int(self.config.n_routed_experts),
+            ep_rank=self.mapping.moe.ep_rank,
+            ep_size=self.mapping.moe.ep_size,
+        )
+        loaded: set[str] = set()
+        suffixes_by_stage = {
+            stage_id: set() for stage_id in range(self.model.num_stages)
+        }
+        raw_attention = {stage_id: {} for stage_id in range(self.model.num_stages)}
+
+        for raw_name, loaded_weight in weights:
+            match = _DSPARK_WEIGHT_RE.match(raw_name)
+            if match is None:
+                continue
+            stage_id = int(match.group(1))
+            suffix = match.group(2)
+            if stage_id >= self.model.num_stages:
+                continue
+            suffixes_by_stage[stage_id].add(suffix)
+            if suffix.startswith("attn."):
+                attention_suffix = suffix.removeprefix("attn.")
+                if attention_suffix in _ATTENTION_TENSORS:
+                    raw_attention[stage_id][attention_suffix] = loaded_weight
+
+            name = self._map_checkpoint_name(raw_name)
+            if name is None:
+                continue
+            for param_name, weight_name, shard_id in stacked_mapping:
+                if weight_name not in name or ".experts." in name:
+                    continue
+                mapped_name = name.replace(weight_name, param_name)
+                param = params.get(mapped_name)
+                if param is None:
+                    break
+                param.weight_loader(param, loaded_weight, shard_id)
+                loaded.add(mapped_name)
+                break
+            else:
+                if moe_loader.matches(name):
+                    loaded.add(moe_loader.load(name, loaded_weight))
+                    continue
+                param = params.get(name)
+                if param is None:
+                    logger.debug("Skipping unmatched DSpark weight: %s", name)
+                    continue
+                loader = getattr(param, "weight_loader", default_weight_loader)
+                loader(param, loaded_weight)
+                loaded.add(name)
+
+        missing_contract: dict[int, list[str]] = {}
+        for stage_id, seen in suffixes_by_stage.items():
+            required = set(_ATTENTION_CHECKPOINT_TENSORS | _STAGE_COMMON_CORE)
+            if stage_id == 0:
+                required.update(_STAGE_ZERO_CORE)
+            if stage_id == self.model.num_stages - 1:
+                required.update(_LAST_STAGE_CORE)
+            missing = sorted(required - seen)
+            expected_expert_tensors = {
+                f"ffn.experts.{expert_id}.{projection}.{tensor_kind}"
+                for expert_id in range(int(self.config.n_routed_experts))
+                for projection in ("w1", "w2", "w3")
+                for tensor_kind in ("scale", "weight")
+            }
+            missing.extend(sorted(expected_expert_tensors - seen))
+            if missing:
+                missing_contract[stage_id] = missing
+        if missing_contract:
+            raise ValueError(
+                "DSpark checkpoint is missing required stage weights: "
+                f"{missing_contract}."
+            )
+
+        shared_parameter_names = {
+            "model.embed_tokens.weight",
+            "lm_head.weight",
+        }
+        missing_parameters = sorted(
+            name
+            for name in params
+            if name not in loaded
+            and name not in shared_parameter_names
+            and not _is_zero_initialized_expert_bias(name)
+        )
+        if missing_parameters:
+            raise ValueError(
+                "DSpark checkpoint did not initialize all draft parameters: "
+                f"{missing_parameters}."
+            )
+
+        for stage_id, source in raw_attention.items():
+            device = self.model.stages[stage_id].block.attn_norm.weight.device
+
+            def dequant(name: str) -> torch.Tensor:
+                return _block_dequant(
+                    source[f"{name}.weight"].to(device),
+                    source[f"{name}.scale"].to(device),
+                )
+
+            self.model.stages[stage_id]._dspark_attn = {
+                "wq_a": dequant("wq_a"),
+                "q_norm_w": source["q_norm.weight"].to(device).to(torch.bfloat16),
+                "wq_b": dequant("wq_b"),
+                "wkv": dequant("wkv"),
+                "kv_norm_w": source["kv_norm.weight"].to(device).to(torch.bfloat16),
+                "wo_a": dequant("wo_a"),
+                "wo_b": dequant("wo_b"),
+                "attn_sink": source["attn_sink"].to(device).float(),
+            }
+
+        self.post_load_weights()
+        return loaded
+
+    def post_load_weights(self) -> None:
+        for module in self.modules():
+            if isinstance(module, DeepseekV4Compressor):
+                module.process_weights_after_loading()
+            elif isinstance(module, DeepseekV4MegaMoEExperts):
+                module.finalize_weights()
+            elif isinstance(module, MoELayer):
+                module.process_weights_after_loading(module)
+
+
+EntryClass = [DeepseekV4ForCausalLMDSpark]

--- a/python/tokenspeed/runtime/models/deepseek_v4_dspark.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_dspark.py
@@ -51,7 +51,6 @@ from tokenspeed.runtime.models.deepseek_v4_dspark_ops.attention import (
 from tokenspeed.runtime.models.deepseek_v4_dspark_ops.heads import (
     DSparkConfidenceHead,
     DSparkVanillaMarkov,
-    sample_dspark_block_greedy,
 )
 from tokenspeed.runtime.utils import add_prefix
 

--- a/python/tokenspeed/runtime/models/deepseek_v4_dspark.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_dspark.py
@@ -120,10 +120,31 @@ def _is_zero_initialized_expert_bias(name: str) -> bool:
     return name.endswith(_ZERO_INITIALIZED_EXPERT_BIAS_SUFFIXES)
 
 
-def count_dspark_stages(model_path: str) -> int | None:
+def count_dspark_stages(
+    model_path: str,
+    revision: str | None = None,
+) -> int | None:
     """Count contiguous ``mtp.<stage>`` namespaces in a safetensors index."""
 
-    index_path = os.path.join(model_path, "model.safetensors.index.json")
+    index_filename = "model.safetensors.index.json"
+    if os.path.isdir(model_path):
+        index_path = os.path.join(model_path, index_filename)
+    else:
+        from huggingface_hub import hf_hub_download
+
+        try:
+            index_path = hf_hub_download(
+                repo_id=model_path,
+                filename=index_filename,
+                revision=revision,
+            )
+        except Exception as exc:  # noqa: BLE001 - fail closed below
+            logger.debug(
+                "Unable to resolve DSpark safetensors index for %s: %s",
+                model_path,
+                exc,
+            )
+            return None
     if not os.path.isfile(index_path):
         return None
     with open(index_path, encoding="utf-8") as handle:

--- a/python/tokenspeed/runtime/models/deepseek_v4_dspark_ops/__init__.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_dspark_ops/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026 LightSeek Foundation

--- a/python/tokenspeed/runtime/models/deepseek_v4_dspark_ops/attention.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_dspark_ops/attention.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 DeepSeek
+# SPDX-FileCopyrightText: Copyright (c) 2026 LightSeek Foundation
+# SPDX-License-Identifier: MIT AND Apache-2.0
+
+"""Pure-PyTorch DSpark captured-context attention.
+
+The math follows the public DeepSeek DSpark reference. The production entry
+point is fixed-shape and tensorized so it can execute inside TokenSpeed's target
+CUDA Graph.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+def dspark_fp8_quant_dequant(
+    x: torch.Tensor,
+    block_size: int,
+) -> torch.Tensor:
+    """Apply the DSpark UE8M0-scaled FP8 quantize/dequantize contract."""
+
+    if x.shape[-1] % block_size != 0:
+        raise ValueError(
+            "DSpark FP8 activation width must be divisible by block_size; "
+            f"got width={x.shape[-1]}, block_size={block_size}."
+        )
+    original_dtype = x.dtype
+    blocks = x.float().unflatten(-1, (-1, block_size))
+    absmax = blocks.abs().amax(dim=-1, keepdim=True).clamp_min(1e-4)
+    scale = torch.exp2(torch.ceil(torch.log2(absmax / 448.0)))
+    quantized = torch.clamp(blocks / scale, -448.0, 448.0).to(torch.float8_e4m3fn)
+    return (quantized.float() * scale).flatten(-2).to(original_dtype)
+
+
+def _dspark_fp8_linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    """Emulate the public DSpark FP8 linear activation contract."""
+
+    return F.linear(dspark_fp8_quant_dequant(x, 128), weight)
+
+
+def _quantize_dspark_non_rope(
+    tensor: torch.Tensor,
+    rope_head_dim: int,
+) -> torch.Tensor:
+    """Quantize/dequantize the non-RoPE KV channels in 64-value groups."""
+
+    non_rope = dspark_fp8_quant_dequant(tensor[..., :-rope_head_dim], 64)
+    return torch.cat([non_rope, tensor[..., -rope_head_dim:]], dim=-1)
+
+
+def _dspark_output_projection(
+    output: torch.Tensor,
+    wo_a: torch.Tensor,
+    wo_b: torch.Tensor,
+    n_groups: int,
+    o_lora_rank: int,
+) -> torch.Tensor:
+    """Apply the BF16 grouped projection followed by the FP8 linear."""
+
+    batch, sequence = output.shape[:2]
+    output = output.reshape(batch, sequence, n_groups, -1)
+    grouped_wo_a = wo_a.view(n_groups, o_lora_rank, -1)
+    output = torch.einsum("bsgd,grd->bsgr", output, grouped_wo_a)
+    return _dspark_fp8_linear(output.flatten(2), wo_b)
+
+
+def precompute_dspark_freqs_cis(
+    rope_head_dim: int,
+    seqlen: int,
+    rope_theta: float = 10000.0,
+    device: torch.device | str = "cpu",
+) -> torch.Tensor:
+    """Return plain-RoPE complex phases for the DSpark draft."""
+
+    freqs = 1.0 / (
+        rope_theta
+        ** (
+            torch.arange(
+                0,
+                rope_head_dim,
+                2,
+                dtype=torch.float32,
+                device=device,
+            )
+            / rope_head_dim
+        )
+    )
+    positions = torch.arange(seqlen, dtype=torch.float32, device=device)
+    phases = torch.outer(positions, freqs)
+    return torch.polar(torch.ones_like(phases), phases)
+
+
+def apply_dspark_rotary_batched(
+    x: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    inverse: bool = False,
+) -> torch.Tensor:
+    """Apply per-request adjacent-pair RoPE phases."""
+
+    original_dtype = x.dtype
+    complex_x = torch.view_as_complex(x.float().unflatten(-1, (-1, 2)))
+    if inverse:
+        freqs_cis = freqs_cis.conj()
+    groups, sequence, half = freqs_cis.shape
+    phases = (
+        freqs_cis.view(groups, sequence, half)
+        if complex_x.ndim == 3
+        else freqs_cis.view(groups, sequence, 1, half)
+    )
+    return torch.view_as_real(complex_x * phases).flatten(-2).to(original_dtype)
+
+
+def get_dspark_topk_idxs_batched(
+    window_size: int,
+    block_size: int,
+    start_pos: torch.Tensor,
+) -> torch.Tensor:
+    """Build fixed-width, masked DSpark context indices."""
+
+    device = start_pos.device
+    groups = start_pos.shape[0]
+    context_columns = torch.arange(window_size, device=device)
+    valid = context_columns.unsqueeze(0) <= start_pos.unsqueeze(1)
+    context_indices = torch.where(
+        valid,
+        context_columns.unsqueeze(0).expand(groups, -1),
+        torch.full_like(valid, -1, dtype=torch.long),
+    )
+    block_indices = window_size + torch.arange(block_size, device=device)
+    block_indices = block_indices.unsqueeze(0).expand(groups, -1)
+    row = torch.cat([context_indices, block_indices], dim=1).to(torch.int32)
+    return row.unsqueeze(1).expand(groups, block_size, -1).contiguous()
+
+
+def dspark_sparse_attn(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_indices: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Run index-gathered MQA with an attention-sink denominator term."""
+
+    batch, queries, heads, dim = q.shape
+    indices = topk_indices.long()
+    valid = indices >= 0
+    safe_indices = indices.clamp_min(0)
+    expanded_kv = kv.unsqueeze(1).expand(batch, queries, kv.shape[1], dim)
+    gathered = torch.gather(
+        expanded_kv,
+        2,
+        safe_indices.unsqueeze(-1).expand(
+            batch,
+            queries,
+            safe_indices.shape[-1],
+            dim,
+        ),
+    ).float()
+    scores = torch.einsum("bmhd,bmkd->bmhk", q.float(), gathered)
+    scores.mul_(softmax_scale)
+    scores.masked_fill_(~valid.unsqueeze(2), float("-inf"))
+    maximum = scores.max(dim=-1, keepdim=True).values
+    maximum = torch.where(torch.isinf(maximum), torch.zeros_like(maximum), maximum)
+    probabilities = torch.exp(scores - maximum)
+    sink = torch.exp(attn_sink.float().view(1, 1, heads) - maximum.squeeze(-1))
+    denominator = probabilities.sum(dim=-1) + sink
+    output = torch.einsum("bmhk,bmkd->bmhd", probabilities, gathered)
+    output.div_(denominator.unsqueeze(-1))
+    return output.to(q.dtype)
+
+
+def _rmsnorm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    original_dtype = x.dtype
+    normalized = x.float()
+    normalized.mul_(torch.rsqrt(normalized.square().mean(-1, keepdim=True) + eps))
+    return (weight.float() * normalized).to(original_dtype)
+
+
+def _rope_last_dims_batched(
+    tensor: torch.Tensor,
+    rope_head_dim: int,
+    freqs_cis: torch.Tensor,
+    inverse: bool = False,
+) -> torch.Tensor:
+    non_rope = tensor[..., :-rope_head_dim]
+    rope = apply_dspark_rotary_batched(
+        tensor[..., -rope_head_dim:],
+        freqs_cis,
+        inverse=inverse,
+    )
+    return torch.cat([non_rope, rope], dim=-1)
+
+
+def dspark_attention_forward_batched(
+    x: torch.Tensor,
+    main_x: torch.Tensor,
+    start_pos: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slots: torch.Tensor,
+    *,
+    wq_a: torch.Tensor,
+    q_norm_w: torch.Tensor,
+    wq_b: torch.Tensor,
+    wkv: torch.Tensor,
+    kv_norm_w: torch.Tensor,
+    wo_a: torch.Tensor,
+    wo_b: torch.Tensor,
+    attn_sink: torch.Tensor,
+    n_heads: int,
+    head_dim: int,
+    rope_head_dim: int,
+    n_groups: int,
+    o_lora_rank: int,
+    window_size: int,
+    eps: float,
+    softmax_scale: float,
+    freqs_cis: torch.Tensor,
+) -> torch.Tensor:
+    """Run graph-safe DSpark attention for a fixed request batch."""
+
+    groups, block_size, _ = x.shape
+    main_freqs = freqs_cis[start_pos].unsqueeze(1)
+    block_positions = (
+        start_pos.unsqueeze(1)
+        + 1
+        + torch.arange(
+            block_size,
+            device=x.device,
+        )
+    )
+    block_freqs = freqs_cis[block_positions]
+
+    main_kv = _rmsnorm(_dspark_fp8_linear(main_x, wkv), kv_norm_w, eps)
+    main_kv = _rope_last_dims_batched(
+        main_kv,
+        rope_head_dim,
+        main_freqs,
+    )
+    main_kv = _quantize_dspark_non_rope(main_kv, rope_head_dim)
+
+    query = _rmsnorm(_dspark_fp8_linear(x, wq_a), q_norm_w, eps)
+    query = _dspark_fp8_linear(query, wq_b).unflatten(-1, (n_heads, head_dim))
+    query.mul_(torch.rsqrt(query.square().mean(-1, keepdim=True) + eps))
+    query = _rope_last_dims_batched(
+        query,
+        rope_head_dim,
+        block_freqs,
+    )
+
+    block_kv = _rmsnorm(_dspark_fp8_linear(x, wkv), kv_norm_w, eps)
+    block_kv = _rope_last_dims_batched(
+        block_kv,
+        rope_head_dim,
+        block_freqs,
+    )
+    block_kv = _quantize_dspark_non_rope(block_kv, rope_head_dim)
+
+    slot_positions = start_pos % window_size
+    kv_cache[slots, slot_positions] = main_kv.squeeze(1).to(kv_cache.dtype)
+    cache_rows = kv_cache[slots]
+    all_kv = torch.cat([cache_rows, block_kv], dim=1)
+    topk_indices = get_dspark_topk_idxs_batched(
+        window_size,
+        block_size,
+        start_pos,
+    )
+    output = dspark_sparse_attn(
+        query,
+        all_kv,
+        attn_sink,
+        topk_indices,
+        softmax_scale,
+    )
+    output = _rope_last_dims_batched(
+        output,
+        rope_head_dim,
+        block_freqs,
+        inverse=True,
+    )
+
+    return _dspark_output_projection(
+        output,
+        wo_a,
+        wo_b,
+        n_groups,
+        o_lora_rank,
+    )

--- a/python/tokenspeed/runtime/models/deepseek_v4_dspark_ops/attention.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_dspark_ops/attention.py
@@ -6,7 +6,11 @@
 
 The math follows the public DeepSeek DSpark reference. The production entry
 point is fixed-shape and tensorized so it can execute inside TokenSpeed's target
-CUDA Graph.
+CUDA Graph. These local primitives intentionally preserve reference-level
+position, FP8, and normalization semantics during correctness bring-up instead
+of mixing in runtime kernels with different contracts. Follow-up performance
+work may replace them with library or fused kernels only after parity and
+endpoint gains are demonstrated.
 """
 
 from __future__ import annotations

--- a/python/tokenspeed/runtime/models/deepseek_v4_dspark_ops/heads.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_dspark_ops/heads.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 DeepSeek
+# SPDX-FileCopyrightText: Copyright (c) 2026 LightSeek Foundation
+# SPDX-License-Identifier: MIT AND Apache-2.0
+
+"""Tensor-parallel DSpark Markov and confidence heads."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from tokenspeed.runtime.distributed.comm_ops import all_gather_into_tensor
+
+
+def _local_vocab_argmax(
+    local_logits: torch.Tensor,
+    lm_head: nn.Module,
+    tp_group,
+    gathered_values: torch.Tensor,
+    gathered_ids: torch.Tensor,
+) -> torch.Tensor:
+    """Return global argmax IDs for vocab-sharded logits."""
+
+    if (
+        gathered_values.ndim != 2
+        or gathered_ids.ndim != 2
+        or gathered_values.shape != gathered_ids.shape
+        or gathered_values.shape[1] < local_logits.shape[0]
+    ):
+        raise ValueError(
+            "DSpark TP gather workspaces must be matching [tp_size, capacity] "
+            "tensors with capacity for every active row."
+        )
+    if not gathered_values.is_contiguous() or not gathered_ids.is_contiguous():
+        raise ValueError("DSpark TP gather workspaces must be contiguous.")
+
+    shard = lm_head.shard_indices
+    num_org = int(shard.num_org_elements)
+    num_org_padded = int(shard.num_org_elements_padded)
+    num_added = int(shard.num_added_elements)
+    org_vocab_start = int(shard.org_vocab_start_index)
+    added_vocab_start = int(shard.added_vocab_start_index)
+    rows = local_logits.shape[0]
+
+    if num_org > 0:
+        local_max, local_arg = torch.max(local_logits[:, :num_org], dim=-1)
+    else:
+        local_max = torch.full(
+            (rows,),
+            torch.finfo(local_logits.dtype).min,
+            dtype=local_logits.dtype,
+            device=local_logits.device,
+        )
+        local_arg = torch.zeros(
+            (rows,),
+            dtype=torch.int64,
+            device=local_logits.device,
+        )
+
+    if num_added > 0:
+        added_logits = local_logits[
+            :,
+            num_org_padded : num_org_padded + num_added,
+        ]
+        added_max, added_arg = torch.max(added_logits, dim=-1)
+        use_added = added_max > local_max
+        local_max = torch.where(use_added, added_max, local_max)
+        local_arg = torch.where(
+            use_added,
+            added_arg.to(local_arg.dtype) + num_org_padded,
+            local_arg,
+        )
+
+    if num_added == 0:
+        global_ids = local_arg + org_vocab_start
+    else:
+        global_ids = torch.empty_like(local_arg)
+        is_base = local_arg < num_org
+        global_ids[is_base] = org_vocab_start + local_arg[is_base]
+        global_ids[~is_base] = added_vocab_start + (
+            local_arg[~is_base] - num_org_padded
+        )
+
+    tp_size = gathered_values.shape[0]
+    if tp_size == 1:
+        return global_ids.to(torch.int32)
+
+    flat_values = gathered_values.reshape(-1)[: tp_size * rows]
+    flat_ids = gathered_ids.reshape(-1)[: tp_size * rows]
+    all_gather_into_tensor(
+        flat_values,
+        local_max.contiguous(),
+        tp_group,
+    )
+    all_gather_into_tensor(
+        flat_ids,
+        global_ids.contiguous(),
+        tp_group,
+    )
+    values = flat_values.view(tp_size, rows)
+    ids = flat_ids.view(tp_size, rows)
+    best_rank = torch.argmax(values, dim=0).unsqueeze(0)
+    return torch.gather(ids, 0, best_rank).squeeze(0).to(torch.int32)
+
+
+class DSparkVanillaMarkov(nn.Module):
+    """Low-rank token-bigram correction over a vocab-sharded output."""
+
+    def __init__(self, embedding: nn.Module, projection: nn.Module) -> None:
+        super().__init__()
+        self.embedding = embedding
+        self.projection = projection
+
+    def local_bias(self, token_ids: torch.Tensor) -> torch.Tensor:
+        hidden = self.embedding(token_ids.long())
+        return torch.matmul(
+            hidden.to(self.projection.weight.dtype),
+            self.projection.weight.T,
+        )
+
+
+class DSparkConfidenceHead(nn.Module):
+    """Per-position acceptance-confidence predictor.
+
+    Week-0 keeps a fixed proposal width, but loads this checkpoint component so
+    malformed DSpark heads fail during startup and future dynamic truncation can
+    be added without changing the weight contract.
+    """
+
+    def __init__(self, projection: nn.Module) -> None:
+        super().__init__()
+        self.projection = projection
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        previous_embeddings: torch.Tensor,
+    ) -> torch.Tensor:
+        features = torch.cat(
+            [hidden_states, previous_embeddings.to(hidden_states.dtype)],
+            dim=-1,
+        )
+        logits, _ = self.projection(features.float())
+        return logits.squeeze(-1)
+
+
+def sample_dspark_block_greedy(
+    local_base_logits: torch.Tensor,
+    bonus_token_ids: torch.Tensor,
+    markov_head: DSparkVanillaMarkov,
+    lm_head: nn.Module,
+    tp_group,
+    gathered_values: torch.Tensor,
+    gathered_ids: torch.Tensor,
+    output: torch.Tensor,
+) -> torch.Tensor:
+    """Apply the trained Markov correction and greedily sample a fixed block."""
+
+    previous = bonus_token_ids.to(torch.int32)
+    for step in range(local_base_logits.shape[1]):
+        corrected = local_base_logits[:, step] + markov_head.local_bias(previous)
+        previous = _local_vocab_argmax(
+            corrected,
+            lm_head,
+            tp_group,
+            gathered_values,
+            gathered_ids,
+        )
+        output[:, step] = previous
+    return output

--- a/python/tokenspeed/runtime/models/deepseek_v4_mtp.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_mtp.py
@@ -60,6 +60,25 @@ logger = logging.getLogger(__name__)
 
 
 _EXPERT_SCALE_RE = re.compile(r"\.experts\.\d+\.w[123]\.scale$")
+_DSPARK_ONLY_WEIGHT_SUFFIXES = frozenset(
+    {
+        "main_norm.weight",
+        "main_proj.scale",
+        "main_proj.weight",
+    }
+)
+_MTP_CORE_WEIGHT_SUFFIXES = frozenset(
+    {
+        "e_proj.weight",
+        "enorm.weight",
+        "h_proj.weight",
+        "hc_head_base",
+        "hc_head_fn",
+        "hc_head_scale",
+        "hnorm.weight",
+        "norm.weight",
+    }
+)
 
 
 def _spec_layer_idx(config: PretrainedConfig, weight_name: str) -> int | None:
@@ -85,6 +104,33 @@ def _find_mtp_layer_idx(name: str) -> int:
         except ValueError:
             continue
     return 0
+
+
+def _mtp_checkpoint_weight(
+    config: PretrainedConfig,
+    name: str,
+) -> tuple[int, str] | None:
+    """Return the local MTP layer and suffix for a draft checkpoint weight."""
+
+    if name.startswith("mtp."):
+        parts = name.split(".", 2)
+        if len(parts) != 3:
+            return None
+        try:
+            return int(parts[1]), parts[2]
+        except ValueError:
+            return None
+
+    layer_idx = _spec_layer_idx(config, name)
+    if layer_idx is None:
+        return None
+    prefix = f"model.layers.{layer_idx}."
+    return layer_idx - int(config.num_hidden_layers), name[len(prefix) :]
+
+
+def _is_dspark_checkpoint_weight(config: PretrainedConfig, name: str) -> bool:
+    parsed = _mtp_checkpoint_weight(config, name)
+    return parsed is not None and parsed[1] in _DSPARK_ONLY_WEIGHT_SUFFIXES
 
 
 class DeepseekV4MTPSharedHead(nn.Module):
@@ -459,6 +505,12 @@ class DeepseekV4ForCausalLMNextN(nn.Module):
         Accepts exactly the checkpoint names ``load_weights`` consumes:
         those ``_map_checkpoint_name`` resolves to a draft parameter.
         """
+        if _is_dspark_checkpoint_weight(self.config, name):
+            raise ValueError(
+                "DeepSeek V4 MTP cannot load a DSpark checkpoint. The checkpoint "
+                f"contains DSpark-only weight {name!r}; use the DSpark runtime or "
+                "a checkpoint with MTP e_proj/h_proj/hc_head weights."
+            )
         return self._map_checkpoint_name(name) is not None
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
@@ -476,7 +528,21 @@ class DeepseekV4ForCausalLMNextN(nn.Module):
             ep_size=self.mapping.moe.ep_size,
         )
         loaded_params: set[str] = set()
+        core_weights_by_layer: dict[int, set[str]] = {
+            layer_idx: set() for layer_idx in range(self.model.num_mtp_layers)
+        }
+        dspark_weights: list[str] = []
         for raw_name, loaded_weight in weights:
+            parsed_weight = _mtp_checkpoint_weight(self.config, raw_name)
+            if parsed_weight is not None:
+                local_layer_idx, suffix = parsed_weight
+                if suffix in _DSPARK_ONLY_WEIGHT_SUFFIXES:
+                    dspark_weights.append(raw_name)
+                if (
+                    local_layer_idx in core_weights_by_layer
+                    and suffix in _MTP_CORE_WEIGHT_SUFFIXES
+                ):
+                    core_weights_by_layer[local_layer_idx].add(suffix)
             name = self._map_checkpoint_name(raw_name)
             if name is None:
                 continue
@@ -503,18 +569,24 @@ class DeepseekV4ForCausalLMNextN(nn.Module):
                 weight_loader(param, loaded_weight)
                 loaded_params.add(name)
 
-        missing_layers = []
-        for layer_idx in range(
-            self.model.mtp_start_layer_idx,
-            self.model.mtp_start_layer_idx + self.model.num_mtp_layers,
-        ):
-            if not any(f"model.layers.{layer_idx}." in name for name in loaded_params):
-                missing_layers.append(layer_idx)
-        if missing_layers:
+        if dspark_weights:
             raise ValueError(
-                "DeepSeek V4 MTP weights missing for speculative layer(s) "
-                f"{missing_layers}. Use a checkpoint that includes `mtp.*` "
-                "weights or disable NEXTN speculative decoding."
+                "DeepSeek V4 MTP cannot load a DSpark checkpoint. The checkpoint "
+                f"contains DSpark-only weight {dspark_weights[0]!r}; use the "
+                "DSpark runtime or a checkpoint with MTP e_proj/h_proj/hc_head "
+                "weights."
+            )
+        missing_core_weights = {
+            self.model.mtp_start_layer_idx
+            + local_layer_idx: sorted(_MTP_CORE_WEIGHT_SUFFIXES - seen)
+            for local_layer_idx, seen in core_weights_by_layer.items()
+            if seen != _MTP_CORE_WEIGHT_SUFFIXES
+        }
+        if missing_core_weights:
+            raise ValueError(
+                "DeepSeek V4 MTP checkpoint is missing required core weights: "
+                f"{missing_core_weights}. Use a complete MTP checkpoint or "
+                "disable NEXTN speculative decoding."
             )
         self.post_load_weights()
         return loaded_params

--- a/python/tokenspeed/runtime/utils/hf_transformers_utils.py
+++ b/python/tokenspeed/runtime/utils/hf_transformers_utils.py
@@ -216,6 +216,7 @@ def get_config(
     revision: str | None = None,
     model_override_args: dict | None = None,
     is_draft_worker: bool | None = False,
+    speculative_algorithm: str | None = None,
     **kwargs,
 ):
     if os.path.isdir(model):
@@ -286,7 +287,12 @@ def get_config(
         and "DFlash" not in config.architectures[0]
         and "DSpark" not in config.architectures[0]
     ):
-        if config.architectures[0] == "MiniMaxM2ForCausalLM":
+        if (
+            speculative_algorithm == "DSPARK"
+            and config.architectures[0] == "DeepseekV4ForCausalLM"
+        ):
+            config.architectures[0] = "DeepseekV4ForCausalLMDSpark"
+        elif config.architectures[0] == "MiniMaxM2ForCausalLM":
             config.architectures[0] = "LlamaForCausalLMEagle3"
         else:
             config.architectures[0] += "NextN"

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -387,12 +387,21 @@ class ServerArgs:
             if draft_model is not None and self.speculative_draft_model_path is None:
                 self.speculative_draft_model_path = str(draft_model)
 
+            dspark_draft_model = self.speculative_draft_model_path
+            dspark_uses_base_model = self.speculative_algorithm == "DSPARK" and (
+                self.draft_model_path_use_base
+                or dspark_draft_model is None
+                or maybe_model_redirect(dspark_draft_model) == self.model
+            )
+            if dspark_uses_base_model:
+                self.draft_model_path_use_base = True
+
             num_speculative_tokens = config.get("num_speculative_tokens")
             if num_speculative_tokens is not None:
                 num_speculative_tokens = int(num_speculative_tokens)
                 if self.speculative_algorithm == "DFLASH" or (
                     self.speculative_algorithm == "DSPARK"
-                    and self.speculative_draft_model_path is not None
+                    and not dspark_uses_base_model
                 ):
                     if self.speculative_num_draft_tokens is None:
                         self.speculative_num_draft_tokens = num_speculative_tokens

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -390,10 +390,17 @@ class ServerArgs:
             num_speculative_tokens = config.get("num_speculative_tokens")
             if num_speculative_tokens is not None:
                 num_speculative_tokens = int(num_speculative_tokens)
-                if self.speculative_algorithm in ("DFLASH", "DSPARK"):
+                if self.speculative_algorithm == "DFLASH" or (
+                    self.speculative_algorithm == "DSPARK"
+                    and self.speculative_draft_model_path is not None
+                ):
                     if self.speculative_num_draft_tokens is None:
                         self.speculative_num_draft_tokens = num_speculative_tokens
                     self.speculative_num_steps = max(num_speculative_tokens - 1, 0)
+                elif self.speculative_algorithm == "DSPARK":
+                    self.speculative_num_steps = num_speculative_tokens
+                    if self.speculative_num_draft_tokens is None:
+                        self.speculative_num_draft_tokens = num_speculative_tokens + 1
                 else:
                     self.speculative_num_steps = num_speculative_tokens
 
@@ -632,7 +639,7 @@ class ServerArgs:
             self.drafter_attention_backend = self.attention_backend
 
         if (
-            self.speculative_algorithm == "MTP"
+            self.speculative_algorithm in ("MTP", "DSPARK")
             and self.speculative_draft_model_path is None
         ):
             self.draft_model_path_use_base = True
@@ -653,6 +660,23 @@ class ServerArgs:
             elif self.speculative_num_steps != expected_steps:
                 raise ValueError(
                     "DFLASH requires speculative_num_steps to equal "
+                    "speculative_num_draft_tokens - 1. "
+                    f"Got {self.speculative_num_steps=} and "
+                    f"{self.speculative_num_draft_tokens=}."
+                )
+
+        if self.speculative_algorithm == "DSPARK" and self.draft_model_path_use_base:
+            if self.enable_prefix_caching:
+                raise ValueError(
+                    "DSPARK does not yet preserve its captured-context windows "
+                    "across prefix-cache hits; use --no-enable-prefix-caching."
+                )
+            expected_steps = max(int(self.speculative_num_draft_tokens) - 1, 0)
+            if self.speculative_num_steps == ServerArgs.speculative_num_steps:
+                self.speculative_num_steps = expected_steps
+            elif self.speculative_num_steps != expected_steps:
+                raise ValueError(
+                    "DSPARK requires speculative_num_steps to equal "
                     "speculative_num_draft_tokens - 1. "
                     f"Got {self.speculative_num_steps=} and "
                     f"{self.speculative_num_draft_tokens=}."
@@ -755,6 +779,15 @@ class ServerArgs:
 
     def validate_cache_options(self):
         if self.enable_kvstore and not self.enable_prefix_caching:
+            if self.speculative_algorithm == "DSPARK" and (
+                self.draft_model_path_use_base
+                or self.speculative_draft_model_path is None
+                or self.speculative_draft_model_path == self.model
+            ):
+                raise ValueError(
+                    "DSPARK currently requires both --disable-kvstore and "
+                    "--no-enable-prefix-caching."
+                )
             raise ValueError(
                 "KVStore and disabled prefix caching are mutually exclusive "
                 "and cannot be used at the same time. Please use only one of them."

--- a/test/runtime/test_block_tables_bridge.py
+++ b/test/runtime/test_block_tables_bridge.py
@@ -91,6 +91,55 @@ class BlockTablesBridgeTest(unittest.TestCase):
         self.assertEqual(self.bridge(op, device="cpu", num_reqs=0), {})
         self.assertEqual(self.bridge(op, device="cpu"), {})
 
+    def test_strict_contract_rejects_missing_extra_and_duplicate_normalized_ids(self):
+        op = self._make_op({"full": [[1]]})
+        with self.assertRaisesRegex(ValueError, "missing=.*swa"):
+            self.bridge(
+                op,
+                device="cpu",
+                num_reqs=1,
+                expected_group_ids=("full", "swa"),
+            )
+
+        op = self._make_op({"full": [[1]], "swa": [[2]], "extra": [[3]]})
+        with self.assertRaisesRegex(ValueError, "extra=.*extra"):
+            self.bridge(
+                op,
+                device="cpu",
+                num_reqs=1,
+                expected_group_ids=("full", "swa"),
+            )
+
+        import numpy as np
+
+        collision = SimpleNamespace(
+            block_tables_arrays=lambda: {
+                1: np.array([[1]], dtype=np.int32),
+                "1": np.array([[2]], dtype=np.int32),
+            }
+        )
+        with self.assertRaisesRegex(ValueError, "collide"):
+            self.bridge(collision, device="cpu", num_reqs=1, max_page_id=8)
+
+    def test_strict_contract_rejects_malformed_and_out_of_range_tables(self):
+        import numpy as np
+
+        wrong_dtype = SimpleNamespace(
+            block_tables_arrays=lambda: {"full": np.array([[1]], dtype=np.int64)}
+        )
+        with self.assertRaisesRegex(ValueError, "int32"):
+            self.bridge(wrong_dtype, device="cpu", num_reqs=1, max_page_id=8)
+
+        out_of_range = self._make_op({"full": [[1, 99]]})
+        with self.assertRaisesRegex(ValueError, "outside -1..8"):
+            self.bridge(
+                out_of_range,
+                device="cpu",
+                num_reqs=1,
+                expected_group_ids=("full",),
+                max_page_ids={"full": 8},
+            )
+
 
 class CacheGroupGatingTest(unittest.TestCase):
     """Backends opt into cache-group metadata explicitly."""
@@ -106,6 +155,9 @@ class CacheGroupGatingTest(unittest.TestCase):
 
     def test_default_backend_does_not_use_cache_groups(self):
         self.assertFalse(self.AttentionBackend.uses_cache_groups)
+        self.assertFalse(
+            self.AttentionBackend.cache_group_tables_replace_draft_page_table
+        )
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_cli_config_compat.py
+++ b/test/runtime/test_cli_config_compat.py
@@ -35,6 +35,13 @@ class TestCLIConfigCompat(unittest.TestCase):
         with patch.object(ServerArgs, "__post_init__"):
             return ServerArgs.from_cli_args(args)
 
+    def _resolve_speculative_config(self, model: str, config: str) -> ServerArgs:
+        args = self._parse_args(["--model", model, "--speculative-config", config])
+        server_args = self._from_cli_args_no_init(args)
+        server_args.resolve_basic_defaults()
+        server_args.resolve_speculative_decoding()
+        return server_args
+
     def _parallelism_snapshot(self, argv: list[str]) -> tuple[int, ...]:
         args = self._parse_args(argv)
         sa = self._from_cli_args_no_init(args)
@@ -546,6 +553,56 @@ class TestCLIConfigCompat(unittest.TestCase):
             config_server_args.speculative_num_draft_tokens,
             explicit_server_args.speculative_num_draft_tokens,
         )
+
+    def test_dspark_same_checkpoint_config_uses_block_plus_bonus_width(self):
+        server_args = self._resolve_speculative_config(
+            "same-checkpoint",
+            (
+                '{"method":"dspark","model":"same-checkpoint",'
+                '"num_speculative_tokens":5}'
+            ),
+        )
+
+        self.assertTrue(server_args.draft_model_path_use_base)
+        self.assertEqual(server_args.speculative_draft_model_path, "same-checkpoint")
+        self.assertEqual(server_args.speculative_num_steps, 5)
+        self.assertEqual(server_args.speculative_num_draft_tokens, 6)
+
+    def test_dspark_redirected_same_checkpoint_uses_block_plus_bonus_width(self):
+        with patch(
+            "tokenspeed.runtime.utils.server_args.maybe_model_redirect",
+            side_effect=lambda model: (
+                "resolved-checkpoint" if model == "model-alias" else model
+            ),
+        ):
+            server_args = self._resolve_speculative_config(
+                "model-alias",
+                (
+                    '{"method":"dspark","model":"model-alias",'
+                    '"num_speculative_tokens":5}'
+                ),
+            )
+
+        self.assertTrue(server_args.draft_model_path_use_base)
+        self.assertEqual(
+            server_args.speculative_draft_model_path, "resolved-checkpoint"
+        )
+        self.assertEqual(server_args.speculative_num_steps, 5)
+        self.assertEqual(server_args.speculative_num_draft_tokens, 6)
+
+    def test_dspark_external_checkpoint_config_uses_verify_width(self):
+        server_args = self._resolve_speculative_config(
+            "target-checkpoint",
+            (
+                '{"method":"dspark","model":"draft-checkpoint",'
+                '"num_speculative_tokens":6}'
+            ),
+        )
+
+        self.assertFalse(server_args.draft_model_path_use_base)
+        self.assertEqual(server_args.speculative_draft_model_path, "draft-checkpoint")
+        self.assertEqual(server_args.speculative_num_steps, 5)
+        self.assertEqual(server_args.speculative_num_draft_tokens, 6)
 
     def test_speculative_config_must_be_json_object(self):
         args = self._parse_args(["--model", "test/model", "--speculative-config", "[]"])

--- a/test/runtime/test_cli_config_compat.py
+++ b/test/runtime/test_cli_config_compat.py
@@ -35,8 +35,18 @@ class TestCLIConfigCompat(unittest.TestCase):
         with patch.object(ServerArgs, "__post_init__"):
             return ServerArgs.from_cli_args(args)
 
-    def _resolve_speculative_config(self, model: str, config: str) -> ServerArgs:
-        args = self._parse_args(["--model", model, "--speculative-config", config])
+    def _resolve_speculative_config(
+        self,
+        model: str,
+        config: str,
+        *,
+        enable_prefix_caching: bool = True,
+    ) -> ServerArgs:
+        argv = ["--model", model]
+        if not enable_prefix_caching:
+            argv.append("--no-enable-prefix-caching")
+        argv.extend(["--speculative-config", config])
+        args = self._parse_args(argv)
         server_args = self._from_cli_args_no_init(args)
         server_args.resolve_basic_defaults()
         server_args.resolve_speculative_decoding()
@@ -561,6 +571,7 @@ class TestCLIConfigCompat(unittest.TestCase):
                 '{"method":"dspark","model":"same-checkpoint",'
                 '"num_speculative_tokens":5}'
             ),
+            enable_prefix_caching=False,
         )
 
         self.assertTrue(server_args.draft_model_path_use_base)
@@ -581,6 +592,7 @@ class TestCLIConfigCompat(unittest.TestCase):
                     '{"method":"dspark","model":"model-alias",'
                     '"num_speculative_tokens":5}'
                 ),
+                enable_prefix_caching=False,
             )
 
         self.assertTrue(server_args.draft_model_path_use_base)

--- a/test/runtime/test_cudagraph_per_group.py
+++ b/test/runtime/test_cudagraph_per_group.py
@@ -335,7 +335,7 @@ class WrapperReplayGroupedTest(_TorchCase):
             ),
             drafter=SimpleNamespace(
                 draft_seq_lens_buf=torch.zeros(4, dtype=torch.int32),
-                req_to_page=torch.zeros((4, MAX_NUM_PAGES), dtype=torch.int32),
+                page_table=torch.zeros((4, MAX_NUM_PAGES), dtype=torch.int32),
             ),
             _draft_group_tables=lambda tables: {
                 "full_attention": tables["full_attention"]
@@ -355,7 +355,7 @@ class WrapperReplayGroupedTest(_TorchCase):
             actual_bs=3,
             req_pool_indices=torch.arange(4, dtype=torch.int64),
             seq_lens=torch.ones(4, dtype=torch.int32),
-            req_to_page=torch.zeros((4, MAX_NUM_PAGES), dtype=torch.int32),
+            page_table=torch.zeros((4, MAX_NUM_PAGES), dtype=torch.int32),
             forward_mode=_decode_forward_mode(),
             block_tables=tables,
         )

--- a/test/runtime/test_cudagraph_per_group.py
+++ b/test/runtime/test_cudagraph_per_group.py
@@ -79,6 +79,18 @@ class PadBlockTablesTest(_TorchCase):
         out = self.pad(tables, actual_bs=3, padded_bs=3)
         self.assertIs(out["full_attention"], tables["full_attention"])
 
+    def test_rejects_partial_or_oversized_batch_rows(self):
+        torch = self.torch
+        for rows in (2, 5):
+            with self.subTest(rows=rows), self.assertRaisesRegex(
+                RuntimeError, "expected actual_bs=3 or padded_bs=4"
+            ):
+                self.pad(
+                    {"full_attention": torch.ones((rows, 2), dtype=torch.int32)},
+                    actual_bs=3,
+                    padded_bs=4,
+                )
+
 
 class CacheGroupIdsTest(_TorchCase):
     """Wrapper-side capture contract: group ids only, no fabricated tensors."""
@@ -238,7 +250,7 @@ class WrapperReplayGroupedTest(_TorchCase):
             src["full_attention"],
         )
 
-    def test_single_table_target_still_routes_group_tables_to_draft(self):
+    def test_single_table_target_pads_group_tables_before_draft_routing(self):
         torch = self.torch
         from tokenspeed.runtime.execution.cuda_graph_wrapper import (
             CudaGraphWrapper,
@@ -267,6 +279,9 @@ class WrapperReplayGroupedTest(_TorchCase):
                 page_table=torch.zeros((2, MAX_NUM_PAGES), dtype=torch.int32),
             ),
             _draft_group_tables=lambda tables: tables,
+            _pad_block_tables_to_padded_bs=(
+                CudaGraphWrapper._pad_block_tables_to_padded_bs
+            ),
         )
         tables = {
             "full_attention": torch.tensor([[3, 4]], dtype=torch.int32),
@@ -283,7 +298,77 @@ class WrapperReplayGroupedTest(_TorchCase):
             block_tables=tables,
         )
 
-        self.assertIs(draft_call["block_tables"], tables)
+        padded = draft_call["block_tables"]
+        self.assertEqual(tuple(padded["full_attention"].shape), (2, 2))
+        self.assertTrue(
+            (padded["full_attention"][:1] == tables["full_attention"]).all()
+        )
+        self.assertTrue((padded["full_attention"][1:] == 0).all())
+
+    def test_target_and_draft_share_padded_replay_tables(self):
+        torch = self.torch
+        from tokenspeed.runtime.execution.cuda_graph_wrapper import (
+            CudaGraphWrapper,
+        )
+
+        calls = {}
+
+        def record_target(bs, req_pool_indices, seq_lens, **kwargs):
+            calls["target"] = kwargs["block_tables"]
+
+        def record_draft(bs, req_pool_indices, seq_lens, **kwargs):
+            calls["draft"] = kwargs["block_tables"]
+
+        backend_contract = {
+            "uses_cache_groups": True,
+            "uses_paged_cache_groups": False,
+            "uses_padded_decode_token_mask": True,
+        }
+        mock = SimpleNamespace(
+            attn_backend=SimpleNamespace(
+                **backend_contract,
+                init_forward_metadata_replay_cuda_graph=record_target,
+            ),
+            draft_attn_backend=SimpleNamespace(
+                **backend_contract,
+                init_forward_metadata_replay_cuda_graph=record_draft,
+            ),
+            drafter=SimpleNamespace(
+                draft_seq_lens_buf=torch.zeros(4, dtype=torch.int32),
+                req_to_page=torch.zeros((4, MAX_NUM_PAGES), dtype=torch.int32),
+            ),
+            _draft_group_tables=lambda tables: {
+                "full_attention": tables["full_attention"]
+            },
+            _pad_block_tables_to_padded_bs=(
+                CudaGraphWrapper._pad_block_tables_to_padded_bs
+            ),
+        )
+        tables = {
+            "full_attention": torch.arange(6, dtype=torch.int32).reshape(3, 2),
+            "state": torch.ones((3, 2), dtype=torch.int32),
+        }
+
+        CudaGraphWrapper._init_replay_metadata(
+            mock,
+            padded_bs=4,
+            actual_bs=3,
+            req_pool_indices=torch.arange(4, dtype=torch.int64),
+            seq_lens=torch.ones(4, dtype=torch.int32),
+            req_to_page=torch.zeros((4, MAX_NUM_PAGES), dtype=torch.int32),
+            forward_mode=_decode_forward_mode(),
+            block_tables=tables,
+        )
+
+        self.assertIs(
+            calls["draft"]["full_attention"],
+            calls["target"]["full_attention"],
+        )
+        self.assertEqual(set(calls["target"]), set(tables))
+        self.assertEqual(set(calls["draft"]), {"full_attention"})
+        for table in calls["target"].values():
+            self.assertEqual(tuple(table.shape), (4, 2))
+            self.assertTrue((table[3:] == 0).all())
 
 
 class WrapperCaptureGroupIdsTest(_TorchCase):

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -1,6 +1,8 @@
 import argparse
+import json
 import os
 import sys
+import tempfile
 import unittest
 from contextlib import redirect_stderr
 from io import StringIO
@@ -39,6 +41,11 @@ from tokenspeed.runtime.distributed import Mapping
 from tokenspeed.runtime.execution.cuda_graph_wrapper import (
     CudaGraphWrapper,
     _should_update_mamba_state_after_mtp_verify,
+)
+from tokenspeed.runtime.execution.drafter.deepseek_v4_dspark import (
+    DeepseekV4DSpark,
+    _dspark_decode_position_plan,
+    _dspark_prefill_position_plan,
 )
 from tokenspeed.runtime.execution.drafter.eagle import (
     _advance_draft_forward_metadata_if_supported,
@@ -93,6 +100,7 @@ from tokenspeed.runtime.models import deepseek_v4 as deepseek_v4_model
 from tokenspeed.runtime.models.deepseek_v4 import (
     DeepseekV4Indexer,
     DeepseekV4MLP,
+    DeepseekV4Model,
     DeepseekV4MoE,
     DeepseekV4MoEGate,
     _deepseek_v4_forward_metadata,
@@ -115,6 +123,21 @@ from tokenspeed.runtime.models.deepseek_v4 import (
     mhc_pre,
     pack_topk_as_router_logits,
 )
+from tokenspeed.runtime.models.deepseek_v4_dspark import (
+    _ATTENTION_CHECKPOINT_TENSORS,
+    DeepseekV4DSparkModel,
+    DeepseekV4ForCausalLMDSpark,
+    _apply_dspark_hc_head,
+    _is_zero_initialized_expert_bias,
+    count_dspark_stages,
+)
+from tokenspeed.runtime.models.deepseek_v4_dspark_ops.attention import (
+    _dspark_output_projection,
+    _quantize_dspark_non_rope,
+    dspark_fp8_quant_dequant,
+    get_dspark_topk_idxs_batched,
+)
+from tokenspeed.runtime.models.deepseek_v4_dspark_ops.heads import _local_vocab_argmax
 from tokenspeed.runtime.models.deepseek_v4_mtp import DeepseekV4ForCausalLMNextN
 from tokenspeed.runtime.utils.cuda_stream import StreamFork
 from tokenspeed.runtime.utils.env import (
@@ -898,7 +921,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         wrapper.draft_attn_backend = FakeBackend("draft")
         wrapper.max_tokens_per_req = 4
         wrapper.drafter = SimpleNamespace(
-            req_to_page=torch.zeros((1, 1), dtype=torch.int32),
+            page_table=torch.zeros((1, 1), dtype=torch.int32),
             draft_seq_lens_buf=torch.zeros(1, dtype=torch.int32),
         )
         wrapper.use_v4_mtp_paged_metadata = True
@@ -919,7 +942,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             num_extends=1,
             req_pool_indices=torch.zeros(1, dtype=torch.int32),
             seq_lens=torch.ones(1, dtype=torch.int32),
-            req_to_page=torch.zeros((1, 1), dtype=torch.int32),
+            page_table=torch.zeros((1, 1), dtype=torch.int32),
             forward_mode=ForwardMode.EXTEND,
             block_tables={"v4.swa_kv": swa_table, "v4.state": state_table},
             cache_metadata=target_cache_metadata,
@@ -1357,6 +1380,11 @@ class TestDeepseekV4Config(unittest.TestCase):
 
         self.assertTrue(is_deepseek_v4(model_config.hf_config))
         self.assertTrue(is_deepseek_v4_nextn(model_config.hf_config))
+        self.assertTrue(
+            is_deepseek_v4(
+                SimpleNamespace(architectures=["DeepseekV4ForCausalLMDSpark"])
+            )
+        )
 
         configure_deepseek_v4_attention(model_config)
 
@@ -1409,6 +1437,499 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertIsNone(model._map_checkpoint_name("mtp.0.head.weight"))
         self.assertIsNone(model._map_checkpoint_name("model.layers.43.head.weight"))
         self.assertIsNone(model._map_checkpoint_name("model.layers.1.attn.wq_a.weight"))
+
+    def test_deepseek_v4_mtp_rejects_dspark_checkpoint_during_shard_filter(self):
+        model = object.__new__(DeepseekV4ForCausalLMNextN)
+        model.config = SimpleNamespace(
+            num_hidden_layers=43,
+            num_nextn_predict_layers=1,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "MTP cannot load a DSpark checkpoint",
+        ):
+            model.checkpoint_weight_name_filter("mtp.0.main_proj.weight")
+
+        self.assertTrue(model.checkpoint_weight_name_filter("mtp.0.e_proj.weight"))
+
+    def test_dspark_stage_count_requires_contiguous_namespaces(self):
+        with tempfile.TemporaryDirectory() as model_path:
+            index_path = os.path.join(model_path, "model.safetensors.index.json")
+            with open(index_path, "w", encoding="utf-8") as handle:
+                json.dump(
+                    {
+                        "weight_map": {
+                            "mtp.0.main_proj.weight": "a.safetensors",
+                            "mtp.1.attn.wq_a.weight": "b.safetensors",
+                            "mtp.2.norm.weight": "c.safetensors",
+                        }
+                    },
+                    handle,
+                )
+            self.assertEqual(count_dspark_stages(model_path), 3)
+
+            with open(index_path, "w", encoding="utf-8") as handle:
+                json.dump(
+                    {
+                        "weight_map": {
+                            "mtp.0.main_proj.weight": "a.safetensors",
+                            "mtp.2.norm.weight": "c.safetensors",
+                        }
+                    },
+                    handle,
+                )
+            with self.assertRaisesRegex(ValueError, "contiguous from zero"):
+                count_dspark_stages(model_path)
+
+    def test_dspark_checkpoint_name_mapping_is_stage_stable(self):
+        model = object.__new__(DeepseekV4ForCausalLMDSpark)
+        model.model = SimpleNamespace(num_stages=3)
+
+        self.assertEqual(
+            model._map_checkpoint_name("mtp.0.main_proj.scale"),
+            "model.stages.0.main_proj.weight_scale_inv",
+        )
+        self.assertEqual(
+            model._map_checkpoint_name("mtp.1.ffn.experts.7.w1.scale"),
+            "model.stages.1.block.ffn.experts.7.w1.weight_scale",
+        )
+        self.assertEqual(
+            model._map_checkpoint_name("mtp.2.markov_head.markov_w1.weight"),
+            "model.markov_embedding.weight",
+        )
+        self.assertIsNone(model._map_checkpoint_name("mtp.3.norm.weight"))
+
+    def test_dspark_attention_contract_uses_checkpoint_namespace(self):
+        self.assertIn("attn.attn_sink", _ATTENTION_CHECKPOINT_TENSORS)
+        self.assertIn("attn.wq_a.weight", _ATTENTION_CHECKPOINT_TENSORS)
+        self.assertIn("attn.wo_b.scale", _ATTENTION_CHECKPOINT_TENSORS)
+        self.assertNotIn("wq_a.weight", _ATTENTION_CHECKPOINT_TENSORS)
+
+    def test_dspark_only_allows_implicit_zero_expert_bias_parameters(self):
+        self.assertTrue(
+            _is_zero_initialized_expert_bias(
+                "model.stages.0.block.ffn.experts.w13_weight_bias"
+            )
+        )
+        self.assertTrue(
+            _is_zero_initialized_expert_bias(
+                "model.stages.2.block.ffn.experts.w2_weight_bias"
+            )
+        )
+        self.assertFalse(
+            _is_zero_initialized_expert_bias(
+                "model.stages.0.block.ffn.experts.w13_weight"
+            )
+        )
+
+    def test_dspark_target_capture_layers_fail_closed(self):
+        model = object.__new__(DeepseekV4Model)
+        model.layers = [SimpleNamespace(layer_id=i) for i in range(4)]
+
+        model.set_dspark_layers_to_capture([1, 3])
+        self.assertEqual(model.dspark_layers_to_capture, (1, 3))
+        with self.assertRaisesRegex(ValueError, "strictly increasing"):
+            model.set_dspark_layers_to_capture([3, 1])
+        with self.assertRaisesRegex(ValueError, "unique"):
+            model.set_dspark_layers_to_capture([1, 1])
+        with self.assertRaisesRegex(ValueError, "out of range"):
+            model.set_dspark_layers_to_capture([1, 4])
+
+    def test_dspark_graph_safe_context_indices_mask_unwritten_slots(self):
+        indices = get_dspark_topk_idxs_batched(
+            window_size=4,
+            block_size=2,
+            start_pos=torch.tensor([0, 2, 8]),
+        )
+
+        self.assertEqual(tuple(indices.shape), (3, 2, 6))
+        self.assertTrue(torch.equal(indices[0, 0], torch.tensor([0, -1, -1, -1, 4, 5])))
+        self.assertTrue(torch.equal(indices[1, 0], torch.tensor([0, 1, 2, -1, 4, 5])))
+        self.assertTrue(torch.equal(indices[2, 0], torch.tensor([0, 1, 2, 3, 4, 5])))
+        self.assertTrue(torch.equal(indices[:, 0], indices[:, 1]))
+
+    def test_dspark_bonus_selection_matches_verify_layout(self):
+        output = torch.tensor(
+            [
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                20,
+                21,
+                22,
+                23,
+                24,
+                25,
+            ],
+            dtype=torch.int32,
+        )
+        out = torch.empty(2, dtype=torch.int32)
+
+        DeepseekV4DSpark._bonus_tokens_from_output(
+            output,
+            torch.tensor([1, 4], dtype=torch.int32),
+            num_extends=0,
+            verify_width=6,
+            out=out,
+        )
+
+        self.assertTrue(torch.equal(out, torch.tensor([9, 23], dtype=torch.int32)))
+
+    def test_dspark_decode_positions_follow_target_absolute_positions(self):
+        (
+            interim_positions,
+            interim_valid,
+            main_positions,
+            next_context_lengths,
+        ) = _dspark_decode_position_plan(
+            old_context_lengths=torch.tensor([128, 128]),
+            accepted=torch.tensor([1, 4]),
+            block_offsets=torch.arange(5),
+        )
+
+        self.assertTrue(
+            torch.equal(
+                interim_positions,
+                torch.tensor(
+                    [
+                        [128, 129, 130, 131, 132],
+                        [128, 129, 130, 131, 132],
+                    ]
+                ),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                interim_valid,
+                torch.tensor(
+                    [
+                        [False, False, False, False, False],
+                        [True, True, True, False, False],
+                    ]
+                ),
+            )
+        )
+        self.assertTrue(torch.equal(main_positions, torch.tensor([128, 131])))
+        self.assertTrue(torch.equal(next_context_lengths, torch.tensor([129, 132])))
+
+    def test_dspark_prefill_positions_are_not_shifted(self):
+        target_positions = torch.tensor([[124, 125, 126, 127]])
+
+        window_positions, next_context_lengths = _dspark_prefill_position_plan(
+            target_positions
+        )
+
+        self.assertTrue(torch.equal(window_positions, target_positions))
+        self.assertTrue(torch.equal(next_context_lengths, torch.tensor([128])))
+
+    def test_dspark_hc_head_preserves_batch_and_block_axes(self):
+        batch_size, block_size, hc_mult, hidden_size = 2, 5, 4, 8
+        hidden_states = torch.randn(
+            batch_size,
+            block_size,
+            hc_mult,
+            hidden_size,
+        )
+        hc_fn = torch.randn(hc_mult, hc_mult * hidden_size)
+        hc_scale = torch.randn(1)
+        hc_base = torch.randn(hc_mult)
+
+        actual = _apply_dspark_hc_head(
+            hidden_states,
+            hc_fn,
+            hc_scale,
+            hc_base,
+            1e-6,
+            1e-6,
+        )
+        expected = torch.stack(
+            [
+                hc_head(
+                    hidden_states[:, step],
+                    hc_fn,
+                    hc_scale,
+                    hc_base,
+                    1e-6,
+                    1e-6,
+                )
+                for step in range(block_size)
+            ],
+            dim=1,
+        )
+
+        self.assertEqual(tuple(actual.shape), (batch_size, block_size, hidden_size))
+        self.assertTrue(torch.allclose(actual, expected))
+
+    def test_dspark_context_projection_materializes_strided_decode_slice(self):
+        captured_hidden_states = torch.arange(48).reshape(2, 3, 8)[:, :2]
+        self.assertFalse(captured_hidden_states.is_contiguous())
+
+        def assert_contiguous(input_):
+            self.assertTrue(input_.is_contiguous())
+            self.assertTrue(torch.equal(input_, captured_hidden_states))
+            raise RuntimeError("projection reached")
+
+        model = SimpleNamespace(
+            stages=[SimpleNamespace(main_proj=assert_contiguous)],
+        )
+        with self.assertRaisesRegex(RuntimeError, "projection reached"):
+            DeepseekV4DSparkModel.write_context_windows_batched(
+                model,
+                captured_hidden_states,
+                torch.zeros((2, 2), dtype=torch.int64),
+                torch.zeros(2, dtype=torch.int64),
+                torch.ones((2, 2), dtype=torch.bool),
+                torch.empty(0),
+                0,
+            )
+
+    def test_dspark_tp_argmax_uses_contiguous_full_workspace_for_partial_batch(self):
+        local_logits = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+        lm_head = SimpleNamespace(
+            shard_indices=SimpleNamespace(
+                num_org_elements=4,
+                num_org_elements_padded=4,
+                num_added_elements=0,
+                org_vocab_start_index=0,
+                added_vocab_start_index=4,
+            )
+        )
+        gathered_values = torch.empty(4, 8)
+        gathered_ids = torch.empty(4, 8, dtype=torch.int64)
+
+        def fake_all_gather(output, input_, group):
+            self.assertTrue(output.is_contiguous())
+            self.assertEqual(output.numel(), 4)
+            output.copy_(input_.repeat(4))
+
+        with patch(
+            "tokenspeed.runtime.models.deepseek_v4_dspark_ops.heads.all_gather_into_tensor",
+            side_effect=fake_all_gather,
+        ) as gather:
+            token_ids = _local_vocab_argmax(
+                local_logits,
+                lm_head,
+                object(),
+                gathered_values,
+                gathered_ids,
+            )
+
+        self.assertEqual(gather.call_count, 2)
+        self.assertTrue(torch.equal(token_ids, torch.tensor([3], dtype=torch.int32)))
+
+        with self.assertRaisesRegex(ValueError, "must be contiguous"):
+            _local_vocab_argmax(
+                local_logits,
+                lm_head,
+                object(),
+                gathered_values[:, :1],
+                gathered_ids[:, :1],
+            )
+
+    def test_dspark_tp_only_contract_uses_resolved_mapping(self):
+        mapping = SimpleNamespace(attn=SimpleNamespace(dp_size=1, cp_size=1))
+        DeepseekV4DSpark._validate_tp_only_mapping(mapping)
+
+        for field in ("dp_size", "cp_size"):
+            invalid = SimpleNamespace(attn=SimpleNamespace(dp_size=1, cp_size=1))
+            setattr(invalid.attn, field, 2)
+            with self.subTest(field=field), self.assertRaisesRegex(
+                ValueError, "tensor parallelism only"
+            ):
+                DeepseekV4DSpark._validate_tp_only_mapping(invalid)
+
+    def test_dspark_padding_slots_reset_before_every_graph_replay(self):
+        drafter = object.__new__(DeepseekV4DSpark)
+        drafter.device = torch.device("cpu")
+        drafter.first_padding_slot = 3
+        drafter.padding_slots = torch.arange(3, 7, dtype=torch.int64)
+        drafter.slot_indices_buf = drafter.padding_slots.clone()
+        drafter.kv_windows = torch.full((7, 2, 4, 8), 7.0)
+        drafter.context_lengths = torch.full((7,), 123, dtype=torch.int64)
+        drafter._request_by_pool_slot = [None, "request-1", None]
+        drafter.input_buffers = SimpleNamespace(
+            max_bs=4,
+            req_pool_indices_buf=torch.tensor([1, 0, 0, 0], dtype=torch.int64),
+            extend_prefix_lens_cpu=torch.zeros(4, dtype=torch.int64),
+        )
+
+        active_window = drafter.kv_windows[1].clone()
+        active_context = drafter.context_lengths[1].clone()
+        for _ in range(10):
+            drafter.kv_windows[3:].fill_(9)
+            drafter.context_lengths[3:].fill_(1048575)
+            drafter.prepare_request_state(["request-1"], [1], num_extends=0)
+            self.assertTrue(
+                torch.equal(
+                    drafter.kv_windows[3:],
+                    torch.zeros_like(drafter.kv_windows[3:]),
+                )
+            )
+            self.assertTrue(
+                torch.equal(
+                    drafter.context_lengths[3:],
+                    torch.zeros_like(drafter.context_lengths[3:]),
+                )
+            )
+            self.assertTrue(
+                torch.equal(
+                    drafter.slot_indices_buf,
+                    torch.tensor([1, 4, 5, 6]),
+                )
+            )
+
+        self.assertTrue(torch.equal(drafter.kv_windows[1], active_window))
+        self.assertTrue(torch.equal(drafter.context_lengths[1], active_context))
+
+        drafter.kv_windows[3:].fill_(11)
+        drafter.context_lengths[3:].fill_(999)
+        drafter.prepare_request_state([], [], num_extends=0)
+        self.assertTrue(torch.equal(drafter.slot_indices_buf, drafter.padding_slots))
+        self.assertTrue(
+            torch.equal(
+                drafter.kv_windows[3:],
+                torch.zeros_like(drafter.kv_windows[3:]),
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                drafter.context_lengths[3:],
+                torch.zeros_like(drafter.context_lengths[3:]),
+            )
+        )
+
+    def test_dspark_fp8_quant_dequant_matches_ue8m0_reference(self):
+        values = torch.linspace(-7.0, 7.0, 256, dtype=torch.float32).reshape(2, 128)
+        actual = dspark_fp8_quant_dequant(values, 64)
+
+        blocks = values.unflatten(-1, (-1, 64))
+        absmax = blocks.abs().amax(dim=-1, keepdim=True).clamp_min(1e-4)
+        scales = torch.exp2(torch.ceil(torch.log2(absmax / 448.0)))
+        expected = (
+            (blocks / scales)
+            .clamp(-448.0, 448.0)
+            .to(torch.float8_e4m3fn)
+            .float()
+            .mul(scales)
+            .flatten(-2)
+        )
+
+        self.assertTrue(torch.equal(actual, expected))
+        with self.assertRaisesRegex(ValueError, "must be divisible"):
+            dspark_fp8_quant_dequant(values[:, :-1], 64)
+
+    def test_dspark_kv_quantizes_only_non_rope_channels(self):
+        tensor = torch.linspace(-8.0, 8.0, 512, dtype=torch.float32).reshape(1, 1, 512)
+
+        actual = _quantize_dspark_non_rope(tensor, rope_head_dim=64)
+
+        self.assertTrue(torch.equal(actual[..., -64:], tensor[..., -64:]))
+        self.assertTrue(
+            torch.equal(
+                actual[..., :-64],
+                dspark_fp8_quant_dequant(tensor[..., :-64], 64),
+            )
+        )
+        self.assertFalse(torch.equal(actual[..., :-64], tensor[..., :-64]))
+
+    def test_dspark_output_projection_keeps_wo_a_input_in_bf16(self):
+        output = torch.linspace(
+            -3.0,
+            3.0,
+            128,
+            dtype=torch.bfloat16,
+        ).reshape(1, 1, 1, 128)
+        wo_a = torch.linspace(
+            -0.5,
+            0.5,
+            128 * 128,
+            dtype=torch.bfloat16,
+        ).reshape(128, 128)
+        wo_b = torch.linspace(
+            -0.25,
+            0.25,
+            4 * 128,
+            dtype=torch.bfloat16,
+        ).reshape(4, 128)
+
+        bf16_intermediate = torch.einsum(
+            "bsgd,grd->bsgr",
+            output,
+            wo_a.view(1, 128, 128),
+        ).flatten(2)
+        with patch(
+            "tokenspeed.runtime.models.deepseek_v4_dspark_ops.attention.dspark_fp8_quant_dequant",
+            wraps=dspark_fp8_quant_dequant,
+        ) as quantize:
+            actual = _dspark_output_projection(
+                output,
+                wo_a,
+                wo_b,
+                n_groups=1,
+                o_lora_rank=128,
+            )
+
+        expected = F.linear(
+            dspark_fp8_quant_dequant(bf16_intermediate, 128),
+            wo_b,
+        )
+        self.assertTrue(torch.equal(actual, expected))
+        self.assertEqual(quantize.call_count, 1)
+        quantize_input, quantize_block_size = quantize.call_args.args
+        self.assertTrue(torch.equal(quantize_input, bf16_intermediate))
+        self.assertEqual(quantize_block_size, 128)
+
+    def test_dspark_base_logits_use_public_fp32_head_math(self):
+        model = object.__new__(DeepseekV4DSparkModel)
+        hidden = torch.tensor([[1.0, -2.0]], dtype=torch.bfloat16)
+        head = SimpleNamespace(
+            weight=torch.tensor([[0.5, 0.25], [-1.0, 2.0]], dtype=torch.bfloat16)
+        )
+
+        logits = model.local_base_logits(hidden, head)
+
+        self.assertEqual(logits.dtype, torch.float32)
+        self.assertTrue(torch.equal(logits, hidden.float() @ head.weight.float().T))
+
+    def test_dspark_speculative_config_uses_block_plus_bonus_width(self):
+        server_args = ServerArgs(
+            model="unused",
+            disable_kvstore=True,
+            enable_prefix_caching=False,
+            speculative_config=json.dumps(
+                {"method": "dspark", "num_speculative_tokens": 5}
+            ),
+        )
+
+        self.assertEqual(server_args.speculative_algorithm, "DSPARK")
+        self.assertEqual(server_args.speculative_num_steps, 5)
+        self.assertEqual(server_args.speculative_num_draft_tokens, 6)
+
+    def test_dspark_rejects_prefix_cache_until_state_reuse_is_supported(self):
+        with self.assertRaisesRegex(ValueError, "--no-enable-prefix-caching"):
+            ServerArgs(
+                model="unused",
+                speculative_config=json.dumps(
+                    {"method": "dspark", "num_speculative_tokens": 5}
+                ),
+            )
+
+    def test_dspark_requires_kvstore_and_prefix_cache_to_be_disabled_together(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "both --disable-kvstore and --no-enable-prefix-caching",
+        ):
+            ServerArgs(
+                model="unused",
+                enable_prefix_caching=False,
+                speculative_config=json.dumps(
+                    {"method": "dspark", "num_speculative_tokens": 5}
+                ),
+            )
 
     def test_deepseek_v4_attention_layout_matches_compressed_cache_contract(self):
         config = SimpleNamespace(
@@ -1781,17 +2302,19 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
         )
         specs = (
-            SimpleNamespace(
+            PagedCacheGroupSpec(
                 group_id="fine",
                 retention="full_history",
                 rows_per_page=4,
                 entry_stride_tokens=1,
+                sliding_window_tokens=None,
             ),
-            SimpleNamespace(
+            PagedCacheGroupSpec(
                 group_id="coarse",
                 retention="full_history",
                 rows_per_page=256,
                 entry_stride_tokens=1,
+                sliding_window_tokens=None,
             ),
         )
         counts = {"fine": 20001, "coarse": 1025}
@@ -1799,7 +2322,6 @@ class TestDeepseekV4Config(unittest.TestCase):
         backend.configure_runtime(
             paged_cache_group_specs=specs,
             paged_cache_group_page_counts=counts,
-            req_to_page=torch.empty(0, dtype=torch.int32),
         )
         tables = {
             "fine": torch.ones((1, 1), dtype=torch.int32),
@@ -2075,7 +2597,6 @@ class TestDeepseekV4Config(unittest.TestCase):
             for group_id, table in target_capture.items()
         }
         draft_live = {group_id: target_live[group_id] for group_id in draft_ids}
-        req_to_page = torch.full((2, 8), 4095, dtype=torch.int32, device=device)
 
         def replay(step: int) -> None:
             for index, table in enumerate(target_live.values()):
@@ -2084,13 +2605,11 @@ class TestDeepseekV4Config(unittest.TestCase):
             target.init_forward_metadata_replay_cuda_graph(
                 **common,
                 actual_bs=1,
-                req_to_page=req_to_page,
                 block_tables=target_live,
             )
             draft.init_forward_metadata_replay_cuda_graph(
                 **common,
                 actual_bs=1,
-                req_to_page=req_to_page,
                 block_tables=draft_live,
             )
             graph.replay()
@@ -2112,7 +2631,21 @@ class TestDeepseekV4Config(unittest.TestCase):
             draft.forward_metadata.is_valid_token.tolist(),
             [True, True, True, True, False, False, False, False],
         )
-        self.assertTrue(bool((target.forward_metadata.cache.block_table == 0).all()))
+        base_group_id = v4_compressed_kv_group_id(4)
+        base_value = 9 + target_ids.index(base_group_id) + 1
+        base_width = target_live[base_group_id].shape[1]
+        self.assertTrue(
+            bool(
+                (
+                    target.forward_metadata.cache.block_table[0, :base_width]
+                    == base_value
+                ).all()
+            )
+        )
+        self.assertTrue(
+            bool((target.forward_metadata.cache.block_table[0, base_width:] == 0).all())
+        )
+        self.assertTrue(bool((target.forward_metadata.cache.block_table[1] == 0).all()))
         self.assertTrue(bool((draft.forward_metadata.cache.block_table == 0).all()))
 
         torch.cuda.synchronize()
@@ -3592,7 +4125,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
         self.assertEqual(metadata.decode_token_count(), 4)
 
-    def test_deepseek_v4_cuda_graph_replay_pads_actual_batch_cache_tables(self):
+    def test_deepseek_v4_cuda_graph_replay_preserves_padded_cache_tables(self):
         backend = DeepseekV4AttentionBackend(
             SimpleNamespace(
                 page_size=64,
@@ -3619,14 +4152,18 @@ class TestDeepseekV4Config(unittest.TestCase):
                     sliding_window_tokens=None,
                 ),
             ),
+            paged_cache_group_page_counts={group_id: 128},
         )
         backend.init_forward_metadata_capture_cuda_graph(
             bs=4,
             req_pool_indices=torch.arange(4, dtype=torch.int32),
             seq_lens=torch.ones(4, dtype=torch.int32),
             forward_mode=ForwardMode.DECODE,
+            paged_cache_block_tables={group_id: torch.ones((4, 2), dtype=torch.int32)},
         )
-        active_table = torch.tensor([[10, 11], [20, 21]], dtype=torch.int32)
+        active_table = torch.tensor(
+            [[10, 11], [20, 21], [0, 0], [0, 0]], dtype=torch.int32
+        )
 
         backend.init_forward_metadata_replay_cuda_graph(
             bs=4,
@@ -3638,7 +4175,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
 
         table = backend.forward_metadata.cache.block_table
-        self.assertTrue(torch.equal(table[:2, :2], active_table))
+        self.assertTrue(torch.equal(table[:2, :2], active_table[:2]))
         self.assertTrue(
             torch.equal(table[2:, :2], torch.zeros((2, 2), dtype=torch.int32))
         )

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -1285,6 +1285,44 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertEqual(build(64).block_size, 256)
         self.assertEqual(build(128).block_size, 128)
 
+    def test_model_config_rejects_prefix_cache_for_external_v4_dspark(self):
+        hf_config = SimpleNamespace(
+            architectures=["DeepseekV4ForCausalLMDSpark"],
+        )
+        server_args = SimpleNamespace(
+            mapping=None,
+            speculative_algorithm="DSPARK",
+            enable_prefix_caching=True,
+        )
+        with (
+            patch(
+                "tokenspeed.runtime.configs.model_config.get_config",
+                return_value=hf_config,
+            ),
+            patch(
+                "tokenspeed.runtime.configs.model_config.get_generation_config",
+                return_value=None,
+            ),
+            patch(
+                "tokenspeed.runtime.configs.model_config.get_hf_text_config",
+                return_value=hf_config,
+            ),
+            patch(
+                "tokenspeed.runtime.models.deepseek_v4_dspark.count_dspark_stages"
+            ) as count_stages,
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "--no-enable-prefix-caching",
+            ):
+                ModelConfig(
+                    "external-draft",
+                    model_override_args="{}",
+                    is_draft_worker=True,
+                    server_args=server_args,
+                )
+        count_stages.assert_not_called()
+
     def test_model_config_keeps_incompatible_user_quantization_error(self):
         model_config = object.__new__(ModelConfig)
         model_config.hf_config = SimpleNamespace(
@@ -1481,6 +1519,41 @@ class TestDeepseekV4Config(unittest.TestCase):
                 )
             with self.assertRaisesRegex(ValueError, "contiguous from zero"):
                 count_dspark_stages(model_path)
+
+    def test_dspark_stage_count_resolves_hub_index(self):
+        with tempfile.TemporaryDirectory() as model_path:
+            index_path = os.path.join(model_path, "model.safetensors.index.json")
+            with open(index_path, "w", encoding="utf-8") as handle:
+                json.dump(
+                    {
+                        "weight_map": {
+                            "mtp.0.main_proj.weight": "a.safetensors",
+                            "mtp.1.norm.weight": "b.safetensors",
+                        }
+                    },
+                    handle,
+                )
+            with patch(
+                "huggingface_hub.hf_hub_download",
+                return_value=index_path,
+            ) as download:
+                self.assertEqual(
+                    count_dspark_stages("public/model", revision="revision-a"),
+                    2,
+                )
+
+        download.assert_called_once_with(
+            repo_id="public/model",
+            filename="model.safetensors.index.json",
+            revision="revision-a",
+        )
+
+    def test_dspark_stage_count_fails_closed_when_hub_index_is_unavailable(self):
+        with patch(
+            "huggingface_hub.hf_hub_download",
+            side_effect=OSError("offline"),
+        ):
+            self.assertIsNone(count_dspark_stages("public/model"))
 
     def test_dspark_checkpoint_name_mapping_is_stage_stable(self):
         model = object.__new__(DeepseekV4ForCausalLMDSpark)
@@ -1737,8 +1810,9 @@ class TestDeepseekV4Config(unittest.TestCase):
         for field in ("dp_size", "cp_size"):
             invalid = SimpleNamespace(attn=SimpleNamespace(dp_size=1, cp_size=1))
             setattr(invalid.attn, field, 2)
-            with self.subTest(field=field), self.assertRaisesRegex(
-                ValueError, "tensor parallelism only"
+            with (
+                self.subTest(field=field),
+                self.assertRaisesRegex(ValueError, "tensor parallelism only"),
             ):
                 DeepseekV4DSpark._validate_tp_only_mapping(invalid)
 

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -875,6 +875,66 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
         self.assertEqual(wrapper.drafter.draft_seq_lens_buf.tolist(), [21, 22])
 
+    def test_cuda_graph_eager_v4_draft_uses_only_its_cache_group_subset(self):
+        captured = {"target": [], "draft": []}
+
+        class FakeBackend:
+            uses_paged_cache_groups = True
+            uses_cache_groups = True
+
+            def __init__(self, key):
+                self.key = key
+
+            def init_forward_metadata(self, *args, **kwargs):
+                captured[self.key].append((args, kwargs))
+
+        target_cache_metadata = object()
+        forward_batch = object()
+        swa_table = torch.ones((1, 1), dtype=torch.int32)
+        state_table = torch.full((1, 1), 2, dtype=torch.int32)
+
+        wrapper = object.__new__(CudaGraphWrapper)
+        wrapper.attn_backend = FakeBackend("target")
+        wrapper.draft_attn_backend = FakeBackend("draft")
+        wrapper.max_tokens_per_req = 4
+        wrapper.drafter = SimpleNamespace(
+            req_to_page=torch.zeros((1, 1), dtype=torch.int32),
+            draft_seq_lens_buf=torch.zeros(1, dtype=torch.int32),
+        )
+        wrapper.use_v4_mtp_paged_metadata = True
+        wrapper.token_to_kv_pool = SimpleNamespace(
+            paged_cache_group_specs=(
+                SimpleNamespace(group_id="v4.swa_kv", family="history"),
+                SimpleNamespace(group_id="v4.state", family="state"),
+            )
+        )
+        wrapper.draft_token_to_kv_pool = SimpleNamespace(
+            paged_cache_group_specs=(
+                SimpleNamespace(group_id="v4.swa_kv", family="history"),
+            )
+        )
+
+        wrapper._init_forward_metadata(
+            padded_bs=1,
+            num_extends=1,
+            req_pool_indices=torch.zeros(1, dtype=torch.int32),
+            seq_lens=torch.ones(1, dtype=torch.int32),
+            req_to_page=torch.zeros((1, 1), dtype=torch.int32),
+            forward_mode=ForwardMode.EXTEND,
+            block_tables={"v4.swa_kv": swa_table, "v4.state": state_table},
+            cache_metadata=target_cache_metadata,
+            forward_batch=forward_batch,
+        )
+
+        self.assertIs(captured["target"][0][1]["cache_metadata"], target_cache_metadata)
+        self.assertIs(captured["target"][0][1]["forward_batch"], forward_batch)
+        self.assertEqual(len(captured["draft"]), 2)
+        draft_prefill_kwargs = captured["draft"][0][1]
+        self.assertNotIn("cache_metadata", draft_prefill_kwargs)
+        self.assertNotIn("forward_batch", draft_prefill_kwargs)
+        self.assertEqual(tuple(draft_prefill_kwargs["block_tables"]), ("v4.swa_kv",))
+        self.assertIs(draft_prefill_kwargs["block_tables"]["v4.swa_kv"], swa_table)
+
     def test_cuda_graph_eager_draft_decode_preserves_non_v4_seq_lens_alias(self):
         captured = {"target": [], "draft": []}
 
@@ -1683,10 +1743,384 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
         )
         table = torch.tensor([[11, 12, 13, 14]], dtype=torch.int32)
+        backend._expected_cache_group_ids = (V4_SWA_KV_GROUP_ID,)
+        backend._cache_group_raw_tokens_per_page = {V4_SWA_KV_GROUP_ID: 64}
+        backend._cache_group_max_page_ids = {V4_SWA_KV_GROUP_ID: 100}
 
-        materialized = backend._prepare_cache_group_tables({V4_SWA_KV_GROUP_ID: table})
+        materialized = backend._prepare_cache_group_tables(
+            {V4_SWA_KV_GROUP_ID: table},
+            bs=1,
+            actual_bs=1,
+            seq_lens=torch.tensor([1], dtype=torch.int32),
+            device=torch.device("cpu"),
+            phase="test",
+        )
 
         self.assertEqual(materialized[V4_SWA_KV_GROUP_ID].tolist(), table.tolist())
+
+    def _make_deepseek_v4_cache_group_contract_backend(self):
+        backend = DeepseekV4AttentionBackend.__new__(DeepseekV4AttentionBackend)
+        backend._expected_cache_group_ids = ("fine", "coarse")
+        backend._cache_group_raw_tokens_per_page = {"fine": 4, "coarse": 256}
+        backend._cache_group_max_page_ids = {"fine": 20000, "coarse": 1024}
+        return backend
+
+    def test_deepseek_v4_runtime_configures_eager_cache_group_contract(self):
+        backend = DeepseekV4AttentionBackend(
+            SimpleNamespace(
+                page_size=64,
+                device="cpu",
+                num_attention_heads=64,
+                num_kv_heads=1,
+                attn_tp_size=1,
+                dtype=torch.bfloat16,
+                is_draft=False,
+                speculative_num_draft_tokens=1,
+                head_dim=512,
+                context_len=4096,
+            )
+        )
+        specs = (
+            SimpleNamespace(
+                group_id="fine",
+                retention="full_history",
+                rows_per_page=4,
+                entry_stride_tokens=1,
+            ),
+            SimpleNamespace(
+                group_id="coarse",
+                retention="full_history",
+                rows_per_page=256,
+                entry_stride_tokens=1,
+            ),
+        )
+        counts = {"fine": 20001, "coarse": 1025}
+
+        backend.configure_runtime(
+            paged_cache_group_specs=specs,
+            paged_cache_group_page_counts=counts,
+            req_to_page=torch.empty(0, dtype=torch.int32),
+        )
+        tables = {
+            "fine": torch.ones((1, 1), dtype=torch.int32),
+            "coarse": torch.ones((1, 1), dtype=torch.int32),
+        }
+        materialized = backend._prepare_cache_group_tables(
+            tables,
+            bs=1,
+            actual_bs=1,
+            seq_lens=torch.ones(1, dtype=torch.int32),
+            device=torch.device("cpu"),
+            phase="eager",
+        )
+        self.assertEqual(tuple(materialized), ("fine", "coarse"))
+
+        # Graph setup may repeat the same contract but must not replace it.
+        backend.init_cuda_graph_state(
+            max_bs=1,
+            paged_cache_group_specs=specs,
+            paged_cache_group_page_counts=counts,
+        )
+        changed = {"fine": 20002, "coarse": 1025}
+        with self.assertRaisesRegex(RuntimeError, "changed after initialization"):
+            backend._configure_cache_group_contract(specs, changed)
+
+    def test_deepseek_v4_cache_group_contract_covers_64k_boundary(self):
+        backend = self._make_deepseek_v4_cache_group_contract_backend()
+        tables = {
+            "fine": torch.ones((1, 16384), dtype=torch.int32),
+            "coarse": torch.ones((1, 256), dtype=torch.int32),
+        }
+
+        materialized = backend._prepare_cache_group_tables(
+            tables,
+            bs=1,
+            actual_bs=1,
+            seq_lens=torch.tensor([65536], dtype=torch.int32),
+            device=torch.device("cpu"),
+            phase="test",
+        )
+        self.assertEqual(tuple(materialized), ("fine", "coarse"))
+
+        with self.assertRaisesRegex(RuntimeError, "missing a real page"):
+            backend._prepare_cache_group_tables(
+                tables,
+                bs=1,
+                actual_bs=1,
+                seq_lens=torch.tensor([65537], dtype=torch.int32),
+                device=torch.device("cpu"),
+                phase="test",
+            )
+
+    def test_deepseek_v4_cache_group_contract_fails_closed(self):
+        backend = self._make_deepseek_v4_cache_group_contract_backend()
+        valid = {
+            "fine": torch.ones((2, 2), dtype=torch.int32),
+            "coarse": torch.ones((2, 2), dtype=torch.int32),
+        }
+        malformed = []
+        malformed.append(({"fine": valid["fine"]}, "group mismatch"))
+        malformed.append(
+            (
+                {
+                    "fine": valid["fine"],
+                    "coarse": valid["coarse"],
+                    "extra": valid["fine"],
+                },
+                "group mismatch",
+            )
+        )
+        malformed.append(
+            (
+                {"coarse": valid["coarse"], "fine": valid["fine"]},
+                "wrong order",
+            )
+        )
+        malformed.append(
+            (
+                {**valid, "fine": valid["fine"].to(torch.int64)},
+                "torch.int32",
+            )
+        )
+        malformed.append(({**valid, "fine": valid["fine"][0]}, "rank 2"))
+        malformed.append(({**valid, "fine": valid["fine"][:1]}, "rows"))
+        malformed.append(
+            (
+                {**valid, "fine": torch.empty((2, 0), dtype=torch.int32)},
+                "zero width",
+            )
+        )
+
+        for tables, error in malformed:
+            with self.subTest(error=error), self.assertRaisesRegex(RuntimeError, error):
+                backend._prepare_cache_group_tables(
+                    tables,
+                    bs=2,
+                    actual_bs=2,
+                    seq_lens=torch.ones(2, dtype=torch.int32),
+                    device=torch.device("cpu"),
+                    phase="test",
+                )
+
+        null_active = {**valid, "fine": valid["fine"].clone()}
+        null_active["fine"][0, 0] = 0
+        with self.assertRaisesRegex(RuntimeError, "missing a real page"):
+            backend._prepare_cache_group_tables(
+                null_active,
+                bs=2,
+                actual_bs=2,
+                seq_lens=torch.ones(2, dtype=torch.int32),
+                device=torch.device("cpu"),
+                phase="test",
+            )
+
+        # A zero-token idle row has no active logical page and may keep the
+        # reserved null entry. Negative lengths are always malformed.
+        idle = {key: torch.zeros_like(table) for key, table in valid.items()}
+        backend._prepare_cache_group_tables(
+            idle,
+            bs=2,
+            actual_bs=2,
+            seq_lens=torch.zeros(2, dtype=torch.int32),
+            device=torch.device("cpu"),
+            phase="idle",
+        )
+        with self.assertRaisesRegex(RuntimeError, "nonnegative"):
+            backend._prepare_cache_group_tables(
+                idle,
+                bs=2,
+                actual_bs=1,
+                seq_lens=torch.tensor([-1, 0], dtype=torch.int32),
+                device=torch.device("cpu"),
+                phase="test",
+            )
+
+    def test_deepseek_v4_cache_group_replay_refreshes_only_live_rows(self):
+        backend = self._make_deepseek_v4_cache_group_contract_backend()
+        output_buffers = {
+            "fine": torch.zeros((2, 4), dtype=torch.int32),
+            "coarse": torch.zeros((2, 4), dtype=torch.int32),
+        }
+
+        for step in range(1, 11):
+            tables = {
+                "fine": torch.tensor([[step], [0]], dtype=torch.int32),
+                "coarse": torch.tensor([[step], [0]], dtype=torch.int32),
+            }
+            materialized = backend._prepare_cache_group_tables(
+                tables,
+                bs=2,
+                actual_bs=1,
+                seq_lens=torch.ones(2, dtype=torch.int32),
+                device=torch.device("cpu"),
+                phase="replay",
+                output_buffers=output_buffers,
+            )
+            for table in materialized.values():
+                self.assertEqual(int(table[0, 0]), step)
+                self.assertTrue(bool((table[:, 1:] == -1).all()))
+
+        zero_tables = {
+            "fine": torch.zeros((2, 1), dtype=torch.int32),
+            "coarse": torch.zeros((2, 1), dtype=torch.int32),
+        }
+        backend._prepare_cache_group_tables(
+            zero_tables,
+            bs=2,
+            actual_bs=0,
+            seq_lens=torch.ones(2, dtype=torch.int32),
+            device=torch.device("cpu"),
+            phase="idle",
+            output_buffers=output_buffers,
+        )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_deepseek_v4_target_mtp_graph_replay_refreshes_flat_tables(self):
+        device = torch.device("cuda")
+        target_specs = tuple(
+            build_v4_cache_specs(
+                SimpleNamespace(sliding_window=128),
+                layer_ratio=(1, 4, 128),
+            )
+        )
+        draft_specs = tuple(
+            build_v4_cache_specs(
+                SimpleNamespace(sliding_window=128),
+                layer_ratio=(1,),
+            )
+        )
+        target_counts = {str(spec.group_id): 4096 for spec in target_specs}
+        draft_counts = {str(spec.group_id): 4096 for spec in draft_specs}
+
+        def make_backend(*, is_draft: bool) -> DeepseekV4AttentionBackend:
+            return DeepseekV4AttentionBackend(
+                SimpleNamespace(
+                    page_size=64,
+                    device="cuda",
+                    num_attention_heads=64,
+                    num_kv_heads=1,
+                    attn_tp_size=1,
+                    dtype=torch.bfloat16,
+                    is_draft=is_draft,
+                    speculative_num_draft_tokens=4,
+                    speculative_num_steps=1,
+                    head_dim=512,
+                    qk_rope_head_dim=64,
+                    context_len=65536,
+                )
+            )
+
+        target = make_backend(is_draft=False)
+        draft = make_backend(is_draft=True)
+        target.init_cuda_graph_state(
+            max_bs=2,
+            paged_cache_group_specs=target_specs,
+            paged_cache_group_page_counts=target_counts,
+            max_tokens_per_req=4,
+        )
+        draft.init_cuda_graph_state(
+            max_bs=2,
+            paged_cache_group_specs=draft_specs,
+            paged_cache_group_page_counts=draft_counts,
+            max_tokens_per_req=4,
+        )
+
+        common = {
+            "bs": 2,
+            "req_pool_indices": torch.tensor([0, 1], dtype=torch.int32, device=device),
+            "seq_lens": torch.tensor([65536, 0], dtype=torch.int32, device=device),
+            "forward_mode": ForwardMode.DECODE,
+            "num_tokens": 8,
+        }
+        target_capture = {
+            group_id: torch.zeros_like(table)
+            for group_id, table in target._cuda_graph_paged_cache_block_tables.items()
+        }
+        draft_capture = {
+            group_id: torch.zeros_like(table)
+            for group_id, table in draft._cuda_graph_paged_cache_block_tables.items()
+        }
+        target.init_forward_metadata_capture_cuda_graph(
+            **common,
+            paged_cache_block_tables=target_capture,
+        )
+        draft.init_forward_metadata_capture_cuda_graph(
+            **common,
+            paged_cache_block_tables=draft_capture,
+        )
+        target_metadata = target.forward_metadata
+        draft_metadata = draft.forward_metadata
+        assert target_metadata is not None
+        assert draft_metadata is not None
+
+        target_ids = tuple(target._expected_cache_group_ids or ())
+        draft_ids = tuple(draft._expected_cache_group_ids or ())
+        observed = torch.empty(
+            len(target_ids) + len(draft_ids), dtype=torch.int32, device=device
+        )
+        graph = torch.cuda.CUDAGraph()
+        torch.cuda.synchronize()
+        with torch.cuda.graph(graph):
+            for index, group_id in enumerate(target_ids):
+                observed[index].copy_(
+                    target_metadata.cache.paged_cache_block_tables[group_id][0, 0]
+                )
+            for index, group_id in enumerate(draft_ids, start=len(target_ids)):
+                observed[index].copy_(
+                    draft_metadata.cache.paged_cache_block_tables[group_id][0, 0]
+                )
+
+        target_live = {
+            group_id: torch.zeros_like(table)
+            for group_id, table in target_capture.items()
+        }
+        draft_live = {group_id: target_live[group_id] for group_id in draft_ids}
+        req_to_page = torch.full((2, 8), 4095, dtype=torch.int32, device=device)
+
+        def replay(step: int) -> None:
+            for index, table in enumerate(target_live.values()):
+                table[0].fill_(step + index + 1)
+                table[1].zero_()
+            target.init_forward_metadata_replay_cuda_graph(
+                **common,
+                actual_bs=1,
+                req_to_page=req_to_page,
+                block_tables=target_live,
+            )
+            draft.init_forward_metadata_replay_cuda_graph(
+                **common,
+                actual_bs=1,
+                req_to_page=req_to_page,
+                block_tables=draft_live,
+            )
+            graph.replay()
+
+        for step in range(10):
+            replay(step)
+            torch.cuda.synchronize()
+            target_expected = [step + index + 1 for index in range(len(target_ids))]
+            draft_expected = [
+                step + target_ids.index(group_id) + 1 for group_id in draft_ids
+            ]
+            self.assertEqual(observed.cpu().tolist(), target_expected + draft_expected)
+
+        self.assertEqual(
+            target.forward_metadata.is_valid_token.tolist(),
+            [True, True, True, True, False, False, False, False],
+        )
+        self.assertEqual(
+            draft.forward_metadata.is_valid_token.tolist(),
+            [True, True, True, True, False, False, False, False],
+        )
+        self.assertTrue(bool((target.forward_metadata.cache.block_table == 0).all()))
+        self.assertTrue(bool((draft.forward_metadata.cache.block_table == 0).all()))
+
+        torch.cuda.synchronize()
+        reserved_before = torch.cuda.memory_reserved()
+        for step in range(50):
+            replay(step + 100)
+        torch.cuda.synchronize()
+        self.assertLessEqual(torch.cuda.memory_reserved(), reserved_before)
 
     def test_deepseek_v4_mixed_metadata_keeps_decode_rows_single_token(self):
         backend = DeepseekV4AttentionBackend(
@@ -1903,6 +2337,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                     sliding_window_tokens=128,
                 ),
             ),
+            paged_cache_group_page_counts={"v4.swa_kv": 1024},
             max_tokens_per_req=1,
         )
         compact = torch.tensor([[10, 11], [20, -1]], dtype=torch.int32)
@@ -2286,18 +2721,24 @@ class TestDeepseekV4Config(unittest.TestCase):
                 context_len=256,
             )
         )
+        backend.configure_runtime(
+            paged_cache_group_specs=(
+                SimpleNamespace(
+                    group_id=V4_SWA_KV_GROUP_ID,
+                    retention="sliding_window",
+                    rows_per_page=64,
+                    entry_stride_tokens=1,
+                ),
+            ),
+            paged_cache_group_page_counts={V4_SWA_KV_GROUP_ID: 128},
+        )
         backend.init_forward_metadata(
             bs=3,
             req_pool_indices=torch.tensor([0, 1, 2], dtype=torch.int32),
             seq_lens=torch.tensor([5, 9, 12], dtype=torch.int32),
             forward_mode=ForwardMode.MIXED,
             block_tables={
-                # Batch-ordered compressed-KV table (row i == batch position i);
-                # the base block_table for ratio<=1 indexer layers resolves from
-                # the smallest-ratio compressed-KV group.
-                "v4.c4a.compressed_kv": torch.tensor(
-                    [[10], [20], [30]], dtype=torch.int32
-                ),
+                V4_SWA_KV_GROUP_ID: torch.tensor([[10], [20], [30]], dtype=torch.int32)
             },
             extend_seq_lens_cpu=torch.tensor([3, 1, 1], dtype=torch.int32),
             extend_prefix_lens_cpu=torch.tensor([2, 8, 11], dtype=torch.int32),
@@ -2357,8 +2798,9 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
         )
         self.assertTrue(
-            torch.equal(decode.cache.block_table[:, 0], torch.tensor([20, 30]))
+            torch.equal(decode.cache.swa_block_table[:, 0], torch.tensor([20, 30]))
         )
+        self.assertTrue(bool((decode.cache.block_table == 0).all()))
         self.assertTrue(
             torch.equal(prefill.seq_lens_cpu, torch.tensor([5], dtype=torch.int32))
         )

--- a/test/runtime/test_prefill_graph.py
+++ b/test/runtime/test_prefill_graph.py
@@ -151,6 +151,36 @@ class DummyGroupTablesTest(unittest.TestCase):
         tables = self._bare(backend, pool)._dummy_group_tables(100, 1)
         self.assertEqual(tables["full_attention"].shape, (1, 2500))
 
+    def test_real_active_page_contract_uses_per_group_geometry(self):
+        backend = SimpleNamespace(
+            uses_cache_groups=True,
+            cache_active_pages_must_be_real=True,
+            page_size=256,
+            max_num_pages=257,
+            state_group_ids=frozenset(),
+        )
+        pool = SimpleNamespace(
+            paged_cache_group_specs=(
+                SimpleNamespace(
+                    group_id="fine",
+                    rows_per_page=4,
+                    entry_stride_tokens=1,
+                ),
+                SimpleNamespace(
+                    group_id="coarse",
+                    rows_per_page=64,
+                    entry_stride_tokens=4,
+                ),
+            )
+        )
+
+        tables = self._bare(backend, pool)._dummy_group_tables(65536, 1)
+
+        self.assertEqual(tables["fine"].shape, (1, 16384))
+        self.assertEqual(tables["coarse"].shape, (1, 256))
+        self.assertTrue(bool((tables["fine"] == 1).all()))
+        self.assertTrue(bool((tables["coarse"] == 1).all()))
+
     def test_composite_wrapper_resolves_grouped_cache_child(self):
         # Hybrid wrappers set the flag but hold the paged KV consumer as
         # full_attn_backend; the helper must not AttributeError (which would

--- a/test/runtime/test_v4_sliding_window_groups_smoke.py
+++ b/test/runtime/test_v4_sliding_window_groups_smoke.py
@@ -392,6 +392,26 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
         self.assertEqual(rows["v4.c4a.compressor_state"], 4)
         self.assertEqual(rows["v4.c128a.compressor_state"], 8)
 
+    def test_c4_state_window_covers_wide_verify_blocks(self):
+        base = build_v4_cache_specs(
+            SimpleNamespace(sliding_window=128),
+            layer_ratio=(4,),
+        )
+        wide = build_v4_cache_specs(
+            SimpleNamespace(sliding_window=128),
+            layer_ratio=(4,),
+            decode_input_tokens=6,
+        )
+
+        base_windows = {spec.group_id: spec.sliding_window_tokens for spec in base}
+        wide_windows = {spec.group_id: spec.sliding_window_tokens for spec in wide}
+        for group_id in (
+            "v4.c4a.compressor_state",
+            "v4.c4a.indexer_compressor_state",
+        ):
+            self.assertEqual(base_windows[group_id], 8)
+            self.assertEqual(wide_windows[group_id], 10)
+
     def test_lcm_capacity_is_the_inverse_of_parent_demand(self):
         packing = {
             "v4.swa_kv": 1,


### PR DESCRIPTION
## Summary

- Complete the DeepSeek V4 consumer path on top of the canonical paged-cache runtime, including strict per-group table validation and graph-safe replay refresh.
- Add checkpoint-specific DeepSeek V4 Flash DSpark speculative decoding while preserving the existing generic DSpark runtime.
- Cover target and draft cache-group mapping, padded and idle graph batches, malformed-table failures, and DSpark checkpoint/runtime contracts.

## Why

The canonical cache runtime already provides the DeepSeek V4 LCM layout and per-group scheduler tables. DeepSeek V4 still needs strict target/draft consumption and replay semantics, while V4 Flash needs a checkpoint-specific DSpark runtime.

## Testing

- Focused DeepSeek V4 Flat KV, CUDA Graph, DSpark, and prefill metadata tests
- DeepSeek V4 sliding-window/cache sizing tests with the current scheduler
- `pre-commit run --all-files`
- `git diff --check`
