### PR TITLE
perf(runtime): avoid Kimi MLA projection layout copies

### DIFF
--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -817,18 +817,11 @@ class DeepseekV3AttentionMLA(nn.Module):
         # latent_cache contains normalized kv_a and k_pe before rotate.
         K = latent_cache.unsqueeze(1)
         q_nope_out_view = Q[..., : self.kv_lora_rank]
-        if _is_amd:
-            q_nope_projected = torch.bmm(
-                q_nope.transpose(0, 1).contiguous(),
-                self.w_kc.contiguous(),
-            )
-            q_nope_out_view.copy_(q_nope_projected.transpose(0, 1))
-        else:
-            torch.bmm(
-                q_nope.transpose(0, 1),
-                self.w_kc,
-                out=q_nope_out_view.transpose(0, 1),
-            )
+        torch.bmm(
+            q_nope.transpose(0, 1),
+            self.w_kc,
+            out=q_nope_out_view.transpose(0, 1),
+        )
         # Model-owned fused FP8 decode: RoPE + quantize + KV cache write
         # all done here, so backend only needs to do attention.
         k_scale = getattr(self.attn_mqa, "k_scale_float", 1.0)
@@ -957,19 +950,12 @@ class DeepseekV3AttentionMLA(nn.Module):
             record_kv_cache=record_kv_cache,
         )
         attn_output = attn_output.view(-1, self.num_local_heads, self.kv_lora_rank)
-        if _is_amd:
-            projected = torch.bmm(
-                attn_output.transpose(0, 1).contiguous(),
-                self.w_vc.contiguous(),
-            )
-            output.copy_(projected.transpose(0, 1).reshape_as(output))
-        else:
-            output_view = output.view(-1, self.num_local_heads, self.v_head_dim)
-            torch.bmm(
-                attn_output.transpose(0, 1),
-                self.w_vc,
-                out=output_view.transpose(0, 1),
-            )
+        output_view = output.view(-1, self.num_local_heads, self.v_head_dim)
+        torch.bmm(
+            attn_output.transpose(0, 1),
+            self.w_vc,
+            out=output_view.transpose(0, 1),
+        )
         return output
 
     def forward_normal_chunked(


### PR DESCRIPTION
Runs the MLA query and value projections directly from their supported transposed activation layouts into the caller-provided strided outputs. This removes the activation materialization and final copy. This also removes an amd-specific specialization that proves to not be necessary based on benchmark performance.

Performance evidence

On 4 MI350X GPUs (attn-tp4 moe-tp4), five baseline Kimi 2.5 runs were compared with three candidate runs. Each run served eight successful requests at concurrency eight with exactly 8,192 input and 8,192 output tokens. EAGLE3 used one draft step and verify width two.

Median TTFT moved from 4405.845 to 4302.860 ms (+2.337%), TPOT from 27.375 to 26.454 ms (+3.364%), E2EL from 228633.556 to 220785.828 ms (+3.432%), and output throughput from 280.960 to 291.261 tok/s (+3.666%). Candidate TPOT ranged from 26.420 to 26.511 ms and output throughput from 290.374 to 291.265 tok/s; the corresponding baseline ranges were 27.249 to 27.430 ms and 280.569 to 281.944 tok/s.

Every run completed 8/8 requests. Generated text, per-request response-event vectors, the 33,016-event total, and the 98.473467% acceptance proxy matched the baseline exactly.
