### PR TITLE
docs: clarify control-server port for weight-version endpoints

### DIFF
--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -63,9 +63,19 @@ The RL control plane updates the version only when the trainer supplies one:
   version.
 - Omitting `weight_version` preserves the current value.
 
+These routes are served by the **control HTTP server**, not the OpenAI-compatible
+gateway. With the default `tokenspeed serve` / `ts serve` layout the control
+server listens on `--port + 1` (for example `http://localhost:8001` when
+`--port 8000`). Override the bind port with `--control-port` if needed.
+
 Use `GET /get_weight_version` to read the current value,
 `POST /update_weight_version` with `{"new_version": "..."}` to set it directly,
-and `GET /model_info` to read the model path and version together.
+and `GET /model_info` to read the model path and version together:
+
+```bash
+curl http://localhost:8001/get_weight_version
+curl http://localhost:8001/model_info
+```
 
 ## Scheduler And Memory
 


### PR DESCRIPTION
## Summary
- Document that `/get_weight_version`, `/update_weight_version`, and `/model_info` are served by the control HTTP server, not the OpenAI gateway.
- Note the default bind port is `--port + 1` (e.g. 8001 when `--port 8000`) and that `--control-port` overrides it.

## Why
The current server-parameter docs list these paths without a host/port, which leads operators to query `:8000` and get 404s.

## Test plan
- [x] Cross-checked against `serve_smg.py` / control server startup messaging