### PR TITLE
feat(scheduler): LoRA adapter identity, max_loras batch cap, and per-adapter KV namespace

### DIFF
--- a/docs/configuration/compatible-parameters.md
+++ b/docs/configuration/compatible-parameters.md
@@ -54,6 +54,7 @@ TokenSpeed-specific behavior explicitly.
 | `--tensor-parallel-size`, `--tp` | `--attn-tp-size` | The familiar alias maps to attention TP. TokenSpeed can split attention, dense, and MoE TP. |
 | `--expert-parallel-size` | `--expert-parallel-size`, `--ep-size` | TokenSpeed supports the familiar name and its existing short form. |
 | `--attention-backend` | `--attention-backend` | Name is aligned; available backend values are TokenSpeed-specific. |
+| `--max-loras` | `--max-loras` | Same meaning — the cap on distinct LoRA adapters per batch — but TokenSpeed treats `0` (the default) as "LoRA scheduling disabled" rather than as a batch that admits no adapters, and has no separate enable flag for the scheduler cap. |
 | `--moe-backend` | `--moe-backend` | Name is aligned; available backend values are TokenSpeed-specific. |
 
 ## Recipe Translation Notes

--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -79,6 +79,7 @@ and `GET /model_info` to read the model path and version together.
 | `--max-total-tokens` | Override the automatically calculated token pool size. |
 | `--block-size` | KV cache block size. |
 | `--enable-prefix-caching` / `--no-enable-prefix-caching` | Enable or disable prefix cache reuse. |
+| `--max-loras` | Maximum number of *distinct* LoRA adapters the scheduler may place in one batch. A request that would introduce a further adapter is deferred to a later step; requests reusing an adapter already in the batch are never deferred, and base-model requests never count against the limit. Defaults to `0`, which disables LoRA scheduling entirely rather than admitting zero adapters. |
 | `--enforce-eager` | Disable CUDA graph execution. |
 | `--max-cudagraph-capture-size` | Largest batch size to capture with CUDA graphs. |
 | `--cudagraph-capture-sizes` | Explicit CUDA graph capture sizes. |

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -417,6 +417,7 @@ class EventLoop:
             disable_prefix_cache=not server_args.enable_prefix_caching,
             paged_cache_groups=paged_cache_groups,
             enable_mixed_prefill_decode=server_args.enable_mixed_batch,
+            max_loras=server_args.max_loras,
         )
         scheduler_cfg.enable_pd_cache = self._pd_cache_enabled
         logger.info(

--- a/python/tokenspeed/runtime/engine/scheduler_utils.py
+++ b/python/tokenspeed/runtime/engine/scheduler_utils.py
@@ -187,11 +187,19 @@ def aligned_max_scheduled_tokens(
     return max_scheduled_tokens - max_scheduled_tokens % grain
 
 
-def make_spec(rid: str, tokens: list[int], max_new_tokens: int = 0) -> RequestSpec:
+def make_spec(
+    rid: str,
+    tokens: list[int],
+    max_new_tokens: int = 0,
+    lora_id: str | None = None,
+) -> RequestSpec:
     spec = RequestSpec()
     spec.request_id = rid
     spec.tokens = tokens
     spec.max_new_tokens = max_new_tokens
+    # The scheduler spells "no adapter" as the empty string; the front-end
+    # spells it None.
+    spec.lora_id = lora_id or ""
     return spec
 
 
@@ -210,11 +218,13 @@ def make_config(
     disable_prefix_cache: bool = False,
     paged_cache_groups: Sequence["PagedCacheGroupConfig"] | None = None,
     enable_mixed_prefill_decode: bool = False,
+    max_loras: int = 0,
 ) -> SchedulerConfig:
     cfg = SchedulerConfig()
     cfg.num_device_pages = num_device_pages
     cfg.max_scheduled_tokens = max_scheduled_tokens
     cfg.max_batch_size = max_batch_size
+    cfg.max_loras = max_loras
     cfg.block_size = page_size
 
     cfg.num_host_pages = num_host_pages

--- a/python/tokenspeed/runtime/engine/scheduler_utils.py
+++ b/python/tokenspeed/runtime/engine/scheduler_utils.py
@@ -191,15 +191,15 @@ def make_spec(
     rid: str,
     tokens: list[int],
     max_new_tokens: int = 0,
-    lora_id: str | None = None,
+    lora_id: int = 0,
 ) -> RequestSpec:
     spec = RequestSpec()
     spec.request_id = rid
     spec.tokens = tokens
     spec.max_new_tokens = max_new_tokens
-    # The scheduler spells "no adapter" as the empty string; the front-end
-    # spells it None.
-    spec.lora_id = lora_id or ""
+    # 0 is the base model on both sides of the boundary; tolerate None from
+    # callers that have not resolved an adapter.
+    spec.lora_id = lora_id or 0
     return spec
 
 

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -135,6 +135,8 @@ class ServerArgs:
     chunked_prefill_size: int | None = None
     max_prefill_tokens: int = 8192
     enable_mixed_batch: bool = False
+    # Cap on distinct LoRA adapters per batch. 0 disables LoRA scheduling.
+    max_loras: int = 0
     # Kernel page size. Flat scheduler logical pages come from the LCM
     # runtime contract and must not overwrite this value.
     block_size: int = 64
@@ -1089,6 +1091,17 @@ class ServerArgs:
             type=int,
             default=ServerArgs.max_num_seqs,
             help="Maximum number of sequences to process concurrently.",
+        )
+        parser.add_argument(
+            "--max-loras",
+            metavar="MAX_LORAS",
+            type=int,
+            default=ServerArgs.max_loras,
+            help=(
+                "Maximum number of distinct LoRA adapters in a single batch. "
+                "Requests that would exceed it are deferred to a later step. "
+                "0 disables LoRA scheduling."
+            ),
         )
         parser.add_argument(
             "--max-total-tokens",

--- a/test/runtime/test_lora_scheduler_plumbing.py
+++ b/test/runtime/test_lora_scheduler_plumbing.py
@@ -2,41 +2,41 @@
 
 The scheduling behaviour itself is covered by the C++ suite
 (tests/cpp/test_lora_namespace.cpp); these tests only pin the translation at
-the boundary, where the front-end's ``None``-for-base-model convention meets
-the scheduler's empty-string one.
+the boundary, where an unresolved adapter (``None``) must arrive at the
+scheduler as the base-model id 0.
 """
 
 from __future__ import annotations
 
 from tokenspeed.runtime.engine.scheduler_utils import make_config, make_spec
 
-BASE_CONFIG_KWARGS = dict(
-    num_device_pages=8,
-    max_scheduled_tokens=64,
-    max_batch_size=4,
-    page_size=2,
-    num_host_pages=8,
-    disable_l2_cache=True,
-    enable_l3_storage=False,
-    role="fused",
-)
+BASE_CONFIG_KWARGS = {
+    "num_device_pages": 8,
+    "max_scheduled_tokens": 64,
+    "max_batch_size": 4,
+    "page_size": 2,
+    "num_host_pages": 8,
+    "disable_l2_cache": True,
+    "enable_l3_storage": False,
+    "role": "fused",
+}
 
 
 def test_make_spec_forwards_lora_id():
-    spec = make_spec("r1", [1, 2, 3], lora_id="adapter-a")
-    assert spec.lora_id == "adapter-a"
+    spec = make_spec("r1", [1, 2, 3], lora_id=7)
+    assert spec.lora_id == 7
 
 
 def test_make_spec_defaults_to_base_model():
     # Callers that predate LoRA must keep producing base-model requests.
-    assert make_spec("r1", [1, 2, 3]).lora_id == ""
+    assert make_spec("r1", [1, 2, 3]).lora_id == 0
 
 
-def test_make_spec_maps_none_to_empty_string():
-    # The front-end spells "no adapter" as None; the scheduler spells it "".
-    # An accidental "None" string here would silently create an adapter
-    # namespace shared by every base-model request.
-    assert make_spec("r1", [1, 2, 3], lora_id=None).lora_id == ""
+def test_make_spec_maps_none_to_base_model():
+    # A caller that has not resolved an adapter passes None; that must land as
+    # 0, not raise and not become some non-zero id that would silently give
+    # base-model requests their own adapter namespace.
+    assert make_spec("r1", [1, 2, 3], lora_id=None).lora_id == 0
 
 
 def test_make_config_forwards_max_loras():

--- a/test/runtime/test_lora_scheduler_plumbing.py
+++ b/test/runtime/test_lora_scheduler_plumbing.py
@@ -1,0 +1,47 @@
+"""LoRA plumbing between the Python front-end and the C++ scheduler.
+
+The scheduling behaviour itself is covered by the C++ suite
+(tests/cpp/test_lora_namespace.cpp); these tests only pin the translation at
+the boundary, where the front-end's ``None``-for-base-model convention meets
+the scheduler's empty-string one.
+"""
+
+from __future__ import annotations
+
+from tokenspeed.runtime.engine.scheduler_utils import make_config, make_spec
+
+BASE_CONFIG_KWARGS = dict(
+    num_device_pages=8,
+    max_scheduled_tokens=64,
+    max_batch_size=4,
+    page_size=2,
+    num_host_pages=8,
+    disable_l2_cache=True,
+    enable_l3_storage=False,
+    role="fused",
+)
+
+
+def test_make_spec_forwards_lora_id():
+    spec = make_spec("r1", [1, 2, 3], lora_id="adapter-a")
+    assert spec.lora_id == "adapter-a"
+
+
+def test_make_spec_defaults_to_base_model():
+    # Callers that predate LoRA must keep producing base-model requests.
+    assert make_spec("r1", [1, 2, 3]).lora_id == ""
+
+
+def test_make_spec_maps_none_to_empty_string():
+    # The front-end spells "no adapter" as None; the scheduler spells it "".
+    # An accidental "None" string here would silently create an adapter
+    # namespace shared by every base-model request.
+    assert make_spec("r1", [1, 2, 3], lora_id=None).lora_id == ""
+
+
+def test_make_config_forwards_max_loras():
+    assert make_config(**BASE_CONFIG_KWARGS, max_loras=3).max_loras == 3
+
+
+def test_make_config_defaults_max_loras_to_disabled():
+    assert make_config(**BASE_CONFIG_KWARGS).max_loras == 0

--- a/tokenspeed-scheduler/CMakeLists.txt
+++ b/tokenspeed-scheduler/CMakeLists.txt
@@ -105,6 +105,7 @@ if(TOKENSPEED_SCHEDULER_BUILD_TESTS)
 
     add_executable(tokenspeed_scheduler_tests
         tests/cpp/test_page_hasher.cpp
+        tests/cpp/test_lora_namespace.cpp
         tests/cpp/test_max_loras.cpp
         tests/cpp/test_block_pool.cpp
         tests/cpp/test_cache_block_ref.cpp

--- a/tokenspeed-scheduler/CMakeLists.txt
+++ b/tokenspeed-scheduler/CMakeLists.txt
@@ -105,6 +105,7 @@ if(TOKENSPEED_SCHEDULER_BUILD_TESTS)
 
     add_executable(tokenspeed_scheduler_tests
         tests/cpp/test_page_hasher.cpp
+        tests/cpp/test_max_loras.cpp
         tests/cpp/test_block_pool.cpp
         tests/cpp/test_cache_block_ref.cpp
         tests/cpp/test_full_attn_manager.cpp

--- a/tokenspeed-scheduler/bindings/python_module.cpp
+++ b/tokenspeed-scheduler/bindings/python_module.cpp
@@ -143,6 +143,7 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .def_rw("block_size", &tokenspeed::SchedulerConfig::block_size)
         .def_rw("max_scheduled_tokens", &tokenspeed::SchedulerConfig::max_scheduled_tokens)
         .def_rw("max_batch_size", &tokenspeed::SchedulerConfig::max_batch_size)
+        .def_rw("max_loras", &tokenspeed::SchedulerConfig::max_loras)
         .def_rw("decode_input_tokens", &tokenspeed::SchedulerConfig::decode_input_tokens)
         .def_rw("overlap_schedule_depth", &tokenspeed::SchedulerConfig::overlap_schedule_depth)
         .def_rw("role", &tokenspeed::SchedulerConfig::role)
@@ -164,7 +165,8 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .def(nb::init<>())
         .def_rw("request_id", &tokenspeed::RequestSpec::request_id)
         .def_rw("tokens", &tokenspeed::RequestSpec::tokens)
-        .def_rw("max_new_tokens", &tokenspeed::RequestSpec::max_new_tokens);
+        .def_rw("max_new_tokens", &tokenspeed::RequestSpec::max_new_tokens)
+        .def_rw("lora_id", &tokenspeed::RequestSpec::lora_id);
 
     nb::module_ forward_event = m.def_submodule("ForwardEvent");
     nb::class_<tokenspeed::forward::ExtendResult>(forward_event, "ExtendResult")

--- a/tokenspeed-scheduler/csrc/scheduler/kv_cache_events.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/kv_cache_events.cpp
@@ -51,7 +51,8 @@ void MixInt32(std::uint64_t& hash, std::int32_t value) {
 
 }  // namespace
 
-std::uint64_t HashKvBlock(std::span<const std::int32_t> token_ids, std::optional<std::uint64_t> parent_hash) {
+std::uint64_t HashKvBlock(std::span<const std::int32_t> token_ids, std::optional<std::uint64_t> parent_hash,
+                          std::span<const std::string> namespace_keys) {
     std::uint64_t hash = kFnvOffsetBasis;
     MixByte(hash, parent_hash.has_value() ? 1 : 0);
     if (parent_hash.has_value()) {
@@ -60,6 +61,19 @@ std::uint64_t HashKvBlock(std::span<const std::int32_t> token_ids, std::optional
     MixUint64(hash, static_cast<std::uint64_t>(token_ids.size()));
     for (std::int32_t token_id : token_ids) {
         MixInt32(hash, token_id);
+    }
+    // Terminal block, so an empty list can be skipped outright and leave the
+    // digest byte-identical to the un-namespaced form. A non-empty list writes
+    // its count and each key's length first, so no two distinct key lists can
+    // mix the same byte sequence.
+    if (!namespace_keys.empty()) {
+        MixUint64(hash, static_cast<std::uint64_t>(namespace_keys.size()));
+        for (const std::string& key : namespace_keys) {
+            MixUint64(hash, static_cast<std::uint64_t>(key.size()));
+            for (char c : key) {
+                MixByte(hash, static_cast<std::uint8_t>(c));
+            }
+        }
     }
     return hash;
 }

--- a/tokenspeed-scheduler/csrc/scheduler/kv_cache_events.h
+++ b/tokenspeed-scheduler/csrc/scheduler/kv_cache_events.h
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <optional>
 #include <span>
+#include <string>
 #include <variant>
 #include <vector>
 
@@ -46,7 +47,14 @@ struct KvBlockRemovedEvent {
 
 using KvCacheEvent = std::variant<KvBlockStoredEvent, KvBlockRemovedEvent>;
 
+// namespace_keys qualifies the block the same way the prefix cache's page
+// hashes are qualified, so two LoRA adapters sharing a token prefix publish
+// distinct block hashes. It must carry the same keys as the page hash for the
+// block, or an event consumer's view of what is cached diverges from the
+// scheduler's. An empty list leaves the hash byte-identical to a build without
+// namespacing, which is what keeps base-model event streams unchanged.
 std::uint64_t HashKvBlock(std::span<const std::int32_t> token_ids,
-                          std::optional<std::uint64_t> parent_hash = std::nullopt);
+                          std::optional<std::uint64_t> parent_hash = std::nullopt,
+                          std::span<const std::string> namespace_keys = {});
 
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -67,11 +67,12 @@ std::vector<GroupDemand> makeGroupDemands(std::vector<BlockTable>& tables, Group
 
 void appendCompletedPageHashes(std::vector<std::string>& page_hashes,
                                const std::vector<std::span<const std::int32_t>>& paged_tokens,
-                               std::int32_t filled_pages) {
+                               std::int32_t filled_pages, std::span<const std::string> namespace_keys) {
     const std::int32_t first_new_page = static_cast<std::int32_t>(page_hashes.size());
     _assert(filled_pages > first_new_page, "caller must pre-check page-hash progress");
     const std::string previous_hash = page_hashes.empty() ? std::string{} : page_hashes.back();
-    std::vector<std::string> new_hashes = AdvancePagedHashes(paged_tokens, first_new_page, previous_hash, filled_pages);
+    std::vector<std::string> new_hashes =
+        AdvancePagedHashes(paged_tokens, first_new_page, previous_hash, filled_pages, namespace_keys);
     page_hashes.insert(page_hashes.end(), std::make_move_iterator(new_hashes.begin()),
                        std::make_move_iterator(new_hashes.end()));
 }
@@ -114,7 +115,8 @@ CompletedCachePages updateCompletedPageHashes(Request& request, fsm::CacheProgre
     };
     const std::int32_t filled_pages = num_computed_tokens / cache_block_tokens;
     if (filled_pages > static_cast<std::int32_t>(cache_progress.page_hashes.size())) {
-        appendCompletedPageHashes(cache_progress.page_hashes, request.FullPagedTokens(false), filled_pages);
+        appendCompletedPageHashes(cache_progress.page_hashes, request.FullPagedTokens(false), filled_pages,
+                                  request.CacheNamespaceKeys());
     }
     if (completed.first_new_page < static_cast<std::int32_t>(cache_progress.page_hashes.size())) {
         completed.boundary_kind =
@@ -176,7 +178,7 @@ Scheduler::AdmissionMatch Scheduler::matchPrefixAtAdmission(Request* request) {
     const std::int32_t cacheable_pages = std::max((request->PrefillSize() - 1) / cache_block_tokens, 0);
     std::vector<std::span<const std::int32_t>> paged_tokens = request->FullPagedTokens(false);
     paged_tokens.resize(std::min(paged_tokens.size(), static_cast<std::size_t>(cacheable_pages)));
-    std::vector<std::string> hashes = ComputePagedHashes(paged_tokens, "");
+    std::vector<std::string> hashes = ComputeNamespacedPagedHashes(paged_tokens, "", request->CacheNamespaceKeys());
 
     AdmissionMatch match;
     match.candidate_page_hashes = hashes;

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -26,6 +26,7 @@
 #include <iterator>
 #include <optional>
 #include <ranges>
+#include <set>
 #include <span>
 #include <string>
 #include <tuple>
@@ -563,7 +564,13 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
     std::int32_t token_budget = config_.max_scheduled_tokens;
     bool pushed_prefill = false;
     bool pushed_decode = false;
-    auto push_operation = [&](auto operation) {
+    // Distinct adapters already in this batch, tracked so the batch never
+    // presents the runtime with more than max_loras of them.
+    std::set<std::string> batch_lora_ids;
+    auto push_operation = [&](const Request* request, auto operation) {
+        if (!request->LoraId().empty()) {
+            batch_lora_ids.insert(request->LoraId());
+        }
         if (recovery_barrier_ && operation.request_id == *recovery_barrier_) {
             recovery_barrier_.reset();
         }
@@ -578,7 +585,20 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
         if constexpr (std::is_same_v<std::decay_t<decltype(operation)>, DecodeOperation>) {
             pushed_decode = true;
         }
+        if (!request->LoraId().empty()) {
+            batch_lora_ids.insert(request->LoraId());
+        }
         operations.push_back(std::move(operation));
+    };
+    // A request whose adapter is already in the batch is always admissible --
+    // it costs no additional slot. Only one that would introduce a *new*
+    // adapter can hit the cap.
+    const auto loraAdmits = [&](const Request* request) {
+        if (config_.max_loras <= 0 || request->LoraId().empty()) {
+            return true;
+        }
+        return batch_lora_ids.size() < static_cast<std::size_t>(config_.max_loras) ||
+               batch_lora_ids.contains(request->LoraId());
     };
     const auto trackPendingForwardResult = [&](const Request* request) {
         // Intermediate prefill and D-side cache admission do not produce a
@@ -593,6 +613,13 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
             break;
         }
 
+        // Defer rather than break: the adapter budget is exhausted for this
+        // request, but a later candidate may reuse an adapter already in the
+        // batch and still belongs in this step.
+        if (!loraAdmits(request)) {
+            continue;
+        }
+
         if (request->Is<fsm::Prefilling>() &&
             (config_.role != Role::kD || request->PrefillSource() == fsm::PrefillSource::kLocal)) {
             if (config_.role == Role::kD && pushed_decode) {
@@ -600,7 +627,7 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
             }
             const std::int32_t reserve = config_.role == Role::kP ? 0 : config_.decode_input_tokens;
             if (auto event = schedulePrefill(context, request, token_budget, reserve)) {
-                push_operation(applyEventAndBuildOperation(request, std::move(*event)));
+                push_operation(request, applyEventAndBuildOperation(request, std::move(*event)));
                 // P-side pages stay pinned until the PD transfer completes.
                 // D-side local recovery has no corresponding PD ACK; its
                 // Host/Device lifetime is already owned by the L2 load ticket.
@@ -630,7 +657,8 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
                 break;
             }
             if (auto event = schedulePrefillFirstChunk(context, request, token_budget, config_.decode_input_tokens)) {
-                push_operation(applyEventAndBuildOperation(request, std::move(*event), load_back_operations));
+                push_operation(request,
+                               applyEventAndBuildOperation(request, std::move(*event), load_back_operations));
                 trackPendingForwardResult(request);
                 if (config_.role == Role::kD || request->Is<fsm::Prefilling>()) {
                     // Keep a Decode-side recovery batch local-only.
@@ -648,7 +676,8 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
             const std::int32_t decode_input_tokens = config_.role == Role::kP ? 0 : config_.decode_input_tokens;
             const std::int32_t prefill_budget = config_.role == Role::kD ? request->PrefillSize() : token_budget;
             if (auto event = schedulePrefillFirstChunk(context, request, prefill_budget, decode_input_tokens)) {
-                push_operation(applyEventAndBuildOperation(request, std::move(*event), load_back_operations));
+                push_operation(request,
+                               applyEventAndBuildOperation(request, std::move(*event), load_back_operations));
                 if (config_.enable_pd_cache) {
                     pd_transfer_pins_.insert(request->Id());
                 }
@@ -668,7 +697,7 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
                 continue;
             }
             if (auto event = scheduleDecode(context, request)) {
-                push_operation(applyEventAndBuildOperation(request, std::move(*event)));
+                push_operation(request, applyEventAndBuildOperation(request, std::move(*event)));
                 trackPendingForwardResult(request);
             }
         }

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -568,11 +568,8 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
     bool pushed_decode = false;
     // Distinct adapters already in this batch, tracked so the batch never
     // presents the runtime with more than max_loras of them.
-    std::set<std::string> batch_lora_ids;
+    std::set<std::int32_t> batch_lora_ids;
     auto push_operation = [&](const Request* request, auto operation) {
-        if (!request->LoraId().empty()) {
-            batch_lora_ids.insert(request->LoraId());
-        }
         if (recovery_barrier_ && operation.request_id == *recovery_barrier_) {
             recovery_barrier_.reset();
         }
@@ -587,7 +584,7 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
         if constexpr (std::is_same_v<std::decay_t<decltype(operation)>, DecodeOperation>) {
             pushed_decode = true;
         }
-        if (!request->LoraId().empty()) {
+        if (request->LoraId() != 0) {
             batch_lora_ids.insert(request->LoraId());
         }
         operations.push_back(std::move(operation));
@@ -596,7 +593,7 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
     // it costs no additional slot. Only one that would introduce a *new*
     // adapter can hit the cap.
     const auto loraAdmits = [&](const Request* request) {
-        if (config_.max_loras <= 0 || request->LoraId().empty()) {
+        if (config_.max_loras <= 0 || request->LoraId() == 0) {
             return true;
         }
         return batch_lora_ids.size() < static_cast<std::size_t>(config_.max_loras) ||
@@ -659,8 +656,7 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
                 break;
             }
             if (auto event = schedulePrefillFirstChunk(context, request, token_budget, config_.decode_input_tokens)) {
-                push_operation(request,
-                               applyEventAndBuildOperation(request, std::move(*event), load_back_operations));
+                push_operation(request, applyEventAndBuildOperation(request, std::move(*event), load_back_operations));
                 trackPendingForwardResult(request);
                 if (config_.role == Role::kD || request->Is<fsm::Prefilling>()) {
                     // Keep a Decode-side recovery batch local-only.
@@ -678,8 +674,7 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
             const std::int32_t decode_input_tokens = config_.role == Role::kP ? 0 : config_.decode_input_tokens;
             const std::int32_t prefill_budget = config_.role == Role::kD ? request->PrefillSize() : token_budget;
             if (auto event = schedulePrefillFirstChunk(context, request, prefill_budget, decode_input_tokens)) {
-                push_operation(request,
-                               applyEventAndBuildOperation(request, std::move(*event), load_back_operations));
+                push_operation(request, applyEventAndBuildOperation(request, std::move(*event), load_back_operations));
                 if (config_.enable_pd_cache) {
                     pd_transfer_pins_.insert(request->Id());
                 }

--- a/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
@@ -109,7 +109,7 @@ void Scheduler::publishCompletedPages(Request& request) {
 
     const std::string previous_hash = progress.page_hashes.empty() ? std::string{} : progress.page_hashes.back();
     std::vector<std::string> new_hashes =
-        AdvancePagedHashes(stable_pages, first_new_page, previous_hash, num_stable_pages);
+        AdvancePagedHashes(stable_pages, first_new_page, previous_hash, num_stable_pages, request.CacheNamespaceKeys());
     progress.page_hashes.insert(progress.page_hashes.end(), std::make_move_iterator(new_hashes.begin()),
                                 std::make_move_iterator(new_hashes.end()));
 

--- a/tokenspeed-scheduler/csrc/scheduler/page_hasher.h
+++ b/tokenspeed-scheduler/csrc/scheduler/page_hasher.h
@@ -133,17 +133,45 @@ inline std::vector<std::string> ComputePagedHashes(
     return hashes;
 }
 
+// Applies one set of keys to *every* page, rather than the per-page lists
+// ComputePagedHashes takes. This is what cache namespacing wants: the key
+// identifies the owner of the whole request (e.g. a LoRA adapter), not one page.
+//
+// Chaining alone would make a page-0 key sufficient -- every later page folds in
+// prior_hash -- but callers may start a chain mid-request (see
+// AdvancePagedHashes), and such a chain would then carry no key at all. Keying
+// every page makes isolation independent of where the chain starts.
+//
+// An empty key list is byte-identical to ComputePagedHashes with no extra keys,
+// so un-namespaced requests hash exactly as they did before this overload existed.
+inline std::vector<std::string> ComputeNamespacedPagedHashes(
+    std::span<const std::span<const std::int32_t>> paged_tokens, const std::string& prior,
+    std::span<const std::string> namespace_keys) {
+    std::vector<std::string> hashes;
+    hashes.reserve(paged_tokens.size());
+    std::string current_prior = prior;
+    for (std::span<const std::int32_t> page : paged_tokens) {
+        current_prior = HashPage(page, current_prior, namespace_keys);
+        hashes.push_back(current_prior);
+    }
+    return hashes;
+}
+
 // Continues an existing hash chain and returns only [first_page, past_end_page).
+//
+// namespace_keys must match the keys the chain was seeded with; passing them is
+// what keeps an extended page in the same namespace as the pages before it.
 inline std::vector<std::string> AdvancePagedHashes(std::span<const std::span<const std::int32_t>> paged_tokens,
                                                    std::int32_t first_page, const std::string& prior,
-                                                   std::int32_t past_end_page) {
+                                                   std::int32_t past_end_page,
+                                                   std::span<const std::string> namespace_keys = {}) {
     _assert(first_page >= 0, "first_page must be >= 0");
     _assert(past_end_page > first_page, "hash range must be non-empty");
     _assert(past_end_page <= static_cast<std::int32_t>(paged_tokens.size()),
             "hash range exceeds the available full pages");
-    return ComputePagedHashes(paged_tokens.subspan(static_cast<std::size_t>(first_page),
-                                                   static_cast<std::size_t>(past_end_page - first_page)),
-                              prior);
+    return ComputeNamespacedPagedHashes(paged_tokens.subspan(static_cast<std::size_t>(first_page),
+                                                             static_cast<std::size_t>(past_end_page - first_page)),
+                                        prior, namespace_keys);
 }
 
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/csrc/scheduler/request.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/request.cpp
@@ -29,6 +29,7 @@ namespace tokenspeed {
 Request::Request(const RequestSpec& spec, std::int32_t page_size, Role role)
     : id_{spec.request_id},
       lora_id_{spec.lora_id},
+      lora_hash_keys_{spec.lora_id.empty() ? std::vector<std::string>{} : std::vector<std::string>{spec.lora_id}},
       token_container_{spec.tokens},
       page_size_{page_size},
       state_{role == Role::kFused ? fsm::State{fsm::Submitted{&token_container_, page_size}}

--- a/tokenspeed-scheduler/csrc/scheduler/request.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/request.cpp
@@ -28,6 +28,7 @@ namespace tokenspeed {
 
 Request::Request(const RequestSpec& spec, std::int32_t page_size, Role role)
     : id_{spec.request_id},
+      lora_id_{spec.lora_id},
       token_container_{spec.tokens},
       page_size_{page_size},
       state_{role == Role::kFused ? fsm::State{fsm::Submitted{&token_container_, page_size}}

--- a/tokenspeed-scheduler/csrc/scheduler/request.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/request.cpp
@@ -29,7 +29,8 @@ namespace tokenspeed {
 Request::Request(const RequestSpec& spec, std::int32_t page_size, Role role)
     : id_{spec.request_id},
       lora_id_{spec.lora_id},
-      lora_hash_keys_{spec.lora_id.empty() ? std::vector<std::string>{} : std::vector<std::string>{spec.lora_id}},
+      lora_hash_keys_{spec.lora_id == 0 ? std::vector<std::string>{}
+                                        : std::vector<std::string>{std::to_string(spec.lora_id)}},
       token_container_{spec.tokens},
       page_size_{page_size},
       state_{role == Role::kFused ? fsm::State{fsm::Submitted{&token_container_, page_size}}

--- a/tokenspeed-scheduler/csrc/scheduler/request.h
+++ b/tokenspeed-scheduler/csrc/scheduler/request.h
@@ -47,6 +47,12 @@ public:
     // Resolved LoRA adapter id, or empty for a base-model request.
     const std::string& LoraId() const { return lora_id_; }
 
+    // Keys that namespace this request's KV pages, for the page hasher. Holds
+    // the adapter id for a LoRA request and nothing for a base-model one, whose
+    // pages therefore hash exactly as they do in a build without LoRA support --
+    // base-model requests keep sharing one prefix-cache namespace.
+    std::span<const std::string> CacheNamespaceKeys() const { return lora_hash_keys_; }
+
     template <typename Event>
     void Apply(Event&& event) {
         state_ = std::visit(
@@ -140,6 +146,10 @@ private:
 
     std::string id_;
     std::string lora_id_;
+    // Same value as lora_id_, held as a 0-or-1 element vector so
+    // CacheNamespaceKeys() can hand out a span without materializing a
+    // temporary on every hash call.
+    std::vector<std::string> lora_hash_keys_;
     TokenContainer token_container_;
     std::int32_t page_size_{};
     fsm::State state_;

--- a/tokenspeed-scheduler/csrc/scheduler/request.h
+++ b/tokenspeed-scheduler/csrc/scheduler/request.h
@@ -44,8 +44,8 @@ public:
 
     const std::string& Id() const { return id_; }
 
-    // Resolved LoRA adapter id, or empty for a base-model request.
-    const std::string& LoraId() const { return lora_id_; }
+    // Resolved LoRA adapter id; 0 means base model.
+    std::int32_t LoraId() const { return lora_id_; }
 
     // Keys that namespace this request's KV pages, for the page hasher. Holds
     // the adapter id for a LoRA request and nothing for a base-model one, whose
@@ -145,10 +145,10 @@ private:
     const fsm::ForwardState& forwardState(const char* operation) const;
 
     std::string id_;
-    std::string lora_id_;
-    // Same value as lora_id_, held as a 0-or-1 element vector so
-    // CacheNamespaceKeys() can hand out a span without materializing a
-    // temporary on every hash call.
+    std::int32_t lora_id_{0};
+    // lora_id_ rendered once, held as a 0-or-1 element vector so
+    // CacheNamespaceKeys() can hand out a span without re-formatting the id on
+    // every hash call.
     std::vector<std::string> lora_hash_keys_;
     TokenContainer token_container_;
     std::int32_t page_size_{};

--- a/tokenspeed-scheduler/csrc/scheduler/request.h
+++ b/tokenspeed-scheduler/csrc/scheduler/request.h
@@ -44,6 +44,9 @@ public:
 
     const std::string& Id() const { return id_; }
 
+    // Resolved LoRA adapter id, or empty for a base-model request.
+    const std::string& LoraId() const { return lora_id_; }
+
     template <typename Event>
     void Apply(Event&& event) {
         state_ = std::visit(
@@ -136,6 +139,7 @@ private:
     const fsm::ForwardState& forwardState(const char* operation) const;
 
     std::string id_;
+    std::string lora_id_;
     TokenContainer token_container_;
     std::int32_t page_size_{};
     fsm::State state_;

--- a/tokenspeed-scheduler/csrc/scheduler/request_spec.h
+++ b/tokenspeed-scheduler/csrc/scheduler/request_spec.h
@@ -31,6 +31,10 @@ struct RequestSpec {
     std::string request_id;
     std::vector<std::int32_t> tokens;
     std::int32_t max_new_tokens{0};
+    // Resolved LoRA adapter id, or empty for a base-model request. Opaque to the
+    // scheduler: it only ever compares it for equality and folds it into page
+    // hashes, so the front-end is free to change how it mints the value.
+    std::string lora_id;
 };
 
 struct PrefillInfo {

--- a/tokenspeed-scheduler/csrc/scheduler/request_spec.h
+++ b/tokenspeed-scheduler/csrc/scheduler/request_spec.h
@@ -31,10 +31,10 @@ struct RequestSpec {
     std::string request_id;
     std::vector<std::int32_t> tokens;
     std::int32_t max_new_tokens{0};
-    // Resolved LoRA adapter id, or empty for a base-model request. Opaque to the
-    // scheduler: it only ever compares it for equality and folds it into page
-    // hashes, so the front-end is free to change how it mints the value.
-    std::string lora_id;
+    // Resolved LoRA adapter id from the front-end registry; 0 means base model.
+    // Opaque to the scheduler: it only ever compares ids for equality and folds
+    // them into page hashes, never interpreting the value itself.
+    std::int32_t lora_id{0};
 };
 
 struct PrefillInfo {

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -260,7 +260,7 @@ std::vector<CacheKey> Scheduler::registerKvEventPages(const Request& request, st
     for (std::size_t i = progress.block_hashes.size(); i < page_hashes.size(); ++i) {
         const std::optional<std::uint64_t> parent_hash =
             i == 0 ? std::nullopt : std::optional<std::uint64_t>{progress.block_hashes[i - 1]};
-        progress.block_hashes.push_back(HashKvBlock(token_pages[i], parent_hash));
+        progress.block_hashes.push_back(HashKvBlock(token_pages[i], parent_hash, request.CacheNamespaceKeys()));
     }
 
     std::vector<CacheKey> registered_keys;

--- a/tokenspeed-scheduler/csrc/scheduler/types.h
+++ b/tokenspeed-scheduler/csrc/scheduler/types.h
@@ -49,6 +49,10 @@ struct SchedulerConfig {
 
     std::int32_t max_scheduled_tokens{};
     std::int32_t max_batch_size{};
+    // Cap on the number of *distinct* LoRA adapters in one batch; the runtime
+    // materializes one adapter slot per unique id, so exceeding it would
+    // overrun that fixed pool. 0 disables the cap (and LoRA serving with it).
+    std::int32_t max_loras{0};
     std::int32_t decode_input_tokens{1};
     // Number of scheduler iterations that may be dispatched before the
     // accepted decode length is committed. The current event loop supports

--- a/tokenspeed-scheduler/tests/cpp/integration_test_helper.h
+++ b/tokenspeed-scheduler/tests/cpp/integration_test_helper.h
@@ -68,7 +68,7 @@ protected:
     const SchedulerConfig& Config() const { return config_; }
     std::int32_t PageSize() const { return config_.block_size; }
     RequestSpec MakeRequestSpec(const std::string& id, std::int32_t num_pages, std::int32_t start = 1,
-                                const std::string& lora_id = "") {
+                                std::int32_t lora_id = 0) {
         auto tokens = MakeAlignedTokens(num_pages, PageSize(), start);
         return RequestSpec{
             .request_id = id,

--- a/tokenspeed-scheduler/tests/cpp/integration_test_helper.h
+++ b/tokenspeed-scheduler/tests/cpp/integration_test_helper.h
@@ -67,11 +67,13 @@ protected:
 
     const SchedulerConfig& Config() const { return config_; }
     std::int32_t PageSize() const { return config_.block_size; }
-    RequestSpec MakeRequestSpec(const std::string& id, std::int32_t num_pages, std::int32_t start = 1) {
+    RequestSpec MakeRequestSpec(const std::string& id, std::int32_t num_pages, std::int32_t start = 1,
+                                const std::string& lora_id = "") {
         auto tokens = MakeAlignedTokens(num_pages, PageSize(), start);
         return RequestSpec{
             .request_id = id,
             .tokens = tokens,
+            .lora_id = lora_id,
         };
     }
 

--- a/tokenspeed-scheduler/tests/cpp/test_lora_namespace.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_lora_namespace.cpp
@@ -21,10 +21,12 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <optional>
 #include <span>
 #include <string>
 #include <vector>
 
+#include "scheduler/kv_cache_events.h"
 #include "scheduler/page_hasher.h"
 
 namespace tokenspeed::test {
@@ -131,6 +133,46 @@ TEST(LoraNamespaceHashTest, AdvanceFromMidChainStaysIsolated) {
 
     EXPECT_NE(AdvancePagedHashes(spans, /*first_page=*/0, "", /*past_end_page=*/1, Keys(key)),
               AdvancePagedHashes(spans, /*first_page=*/0, "", /*past_end_page=*/1));
+}
+
+// ---- published KV-cache event hashes --------------------------------------
+// The event stream carries its own block hash lineage, separate from the page
+// hashes above. Namespacing only the page hashes would leave two adapters
+// publishing identical block hashes for the same prefix, so a cache-aware
+// consumer could hand one adapter's block to the other.
+
+TEST(LoraNamespaceKvEventTest, NoKeysIsByteIdenticalToUnnamespacedBlockHash) {
+    const std::vector<std::int32_t> tokens = {1, 2, 3, 4};
+    EXPECT_EQ(HashKvBlock(Tokens(tokens), std::nullopt, {}), HashKvBlock(Tokens(tokens), std::nullopt));
+    EXPECT_EQ(HashKvBlock(Tokens(tokens), std::optional<std::uint64_t>{7}, {}),
+              HashKvBlock(Tokens(tokens), std::optional<std::uint64_t>{7}));
+}
+
+TEST(LoraNamespaceKvEventTest, DifferentAdaptersPublishDifferentBlockHashes) {
+    const std::vector<std::int32_t> tokens = {1, 2, 3, 4};
+    const std::vector<std::string> key_a = {"1"};
+    const std::vector<std::string> key_b = {"2"};
+
+    const std::uint64_t base = HashKvBlock(Tokens(tokens), std::nullopt);
+    const std::uint64_t a = HashKvBlock(Tokens(tokens), std::nullopt, Keys(key_a));
+    const std::uint64_t b = HashKvBlock(Tokens(tokens), std::nullopt, Keys(key_b));
+
+    EXPECT_NE(a, b) << "adapters collide in the published event stream";
+    EXPECT_NE(a, base) << "adapter collides with the base model";
+    EXPECT_NE(b, base) << "adapter collides with the base model";
+}
+
+TEST(LoraNamespaceKvEventTest, NamespaceSurvivesTheParentChain) {
+    // The lineage is chained like the page hashes, so a divergence at the first
+    // block must keep later blocks apart even though their tokens match.
+    const std::vector<std::int32_t> first = {1, 2};
+    const std::vector<std::int32_t> second = {3, 4};
+    const std::vector<std::string> key_a = {"1"};
+    const std::vector<std::string> key_b = {"2"};
+
+    const std::uint64_t a0 = HashKvBlock(Tokens(first), std::nullopt, Keys(key_a));
+    const std::uint64_t b0 = HashKvBlock(Tokens(first), std::nullopt, Keys(key_b));
+    EXPECT_NE(HashKvBlock(Tokens(second), a0, Keys(key_a)), HashKvBlock(Tokens(second), b0, Keys(key_b)));
 }
 
 }  // namespace

--- a/tokenspeed-scheduler/tests/cpp/test_lora_namespace.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_lora_namespace.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 LightSeek Foundation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "scheduler/page_hasher.h"
+
+namespace tokenspeed::test {
+namespace {
+
+using token_span = std::span<const std::int32_t>;
+using key_span = std::span<const std::string>;
+
+token_span Tokens(const std::vector<std::int32_t>& v) {
+    return token_span(v.data(), v.size());
+}
+key_span Keys(const std::vector<std::string>& v) {
+    return key_span(v.data(), v.size());
+}
+
+std::vector<token_span> Pages(const std::vector<std::vector<std::int32_t>>& pages) {
+    std::vector<token_span> spans;
+    spans.reserve(pages.size());
+    for (const std::vector<std::int32_t>& page : pages) {
+        spans.push_back(Tokens(page));
+    }
+    return spans;
+}
+
+TEST(LoraNamespaceHashTest, NoKeysIsByteIdenticalToUnnamespacedChain) {
+    // The whole design rests on this: a base-model request must hash exactly as
+    // it did before namespacing existed, or enabling LoRA would invalidate every
+    // cache entry already on disk.
+    const std::vector<std::vector<std::int32_t>> pages = {{1, 2}, {3, 4}, {5, 6}};
+    const std::vector<token_span> spans = Pages(pages);
+
+    EXPECT_EQ(ComputeNamespacedPagedHashes(spans, "", {}), ComputePagedHashes(spans, ""));
+}
+
+TEST(LoraNamespaceHashTest, DifferentAdaptersDiverge) {
+    const std::vector<std::vector<std::int32_t>> pages = {{1, 2}, {3, 4}};
+    const std::vector<token_span> spans = Pages(pages);
+    const std::vector<std::string> key_a = {"adapter-a"};
+    const std::vector<std::string> key_b = {"adapter-b"};
+
+    const std::vector<std::string> hashes_a = ComputeNamespacedPagedHashes(spans, "", Keys(key_a));
+    const std::vector<std::string> hashes_b = ComputeNamespacedPagedHashes(spans, "", Keys(key_b));
+    const std::vector<std::string> hashes_base = ComputeNamespacedPagedHashes(spans, "", {});
+
+    ASSERT_EQ(hashes_a.size(), 2u);
+    for (std::size_t i = 0; i < hashes_a.size(); ++i) {
+        EXPECT_NE(hashes_a[i], hashes_b[i]) << "page " << i << " collides across adapters";
+        EXPECT_NE(hashes_a[i], hashes_base[i]) << "page " << i << " collides with the base model";
+    }
+}
+
+TEST(LoraNamespaceHashTest, EveryPageCarriesTheKeyNotJustPageZero) {
+    // Chaining would make a page-0 key enough for a chain that starts at page 0.
+    // Keying every page is what makes a chain that starts *mid-request* isolated
+    // too -- see AdvanceFromMidChainStaysIsolated below.
+    const std::vector<std::vector<std::int32_t>> pages = {{1, 2}};
+    const std::vector<token_span> spans = Pages(pages);
+    const std::vector<std::string> key = {"adapter-a"};
+
+    // Same tokens, same non-empty prior: only the key can distinguish them.
+    const std::string prior = ComputePagedHashes(Pages({{9, 9}}), "").back();
+    EXPECT_NE(ComputeNamespacedPagedHashes(spans, prior, Keys(key)), ComputeNamespacedPagedHashes(spans, prior, {}));
+}
+
+TEST(LoraNamespaceHashTest, IncrementalExtensionMatchesOneShot) {
+    const std::vector<std::vector<std::int32_t>> pages = {{1, 2}, {3, 4}, {5, 6}};
+    const std::vector<token_span> spans = Pages(pages);
+    const std::vector<std::string> key = {"adapter-a"};
+
+    const std::vector<std::string> one_shot = ComputeNamespacedPagedHashes(spans, "", Keys(key));
+
+    // Seed pages [0,1), then extend to page 3 the way appendCompletedPageHashes does.
+    std::vector<std::string> incremental = ComputeNamespacedPagedHashes(Pages({{1, 2}}), "", Keys(key));
+    const std::vector<std::string> extended =
+        AdvancePagedHashes(spans, /*first_page=*/1, incremental.back(), /*past_end_page=*/3, Keys(key));
+    incremental.insert(incremental.end(), extended.begin(), extended.end());
+
+    EXPECT_EQ(incremental, one_shot);
+}
+
+TEST(LoraNamespaceHashTest, AdvanceDroppingKeysBreaksIsolation) {
+    // Guards the regression this change exists to prevent: if AdvancePagedHashes
+    // is called without the adapter keys, the extended pages fall back into the
+    // base-model namespace even though the request owns an adapter.
+    const std::vector<std::vector<std::int32_t>> pages = {{1, 2}, {3, 4}};
+    const std::vector<token_span> spans = Pages(pages);
+    const std::vector<std::string> key = {"adapter-a"};
+
+    const std::string prior = ComputeNamespacedPagedHashes(Pages({{1, 2}}), "", Keys(key)).back();
+    const std::vector<std::string> with_keys = AdvancePagedHashes(spans, 1, prior, 2, Keys(key));
+    const std::vector<std::string> without_keys = AdvancePagedHashes(spans, 1, prior, 2);
+
+    EXPECT_NE(with_keys, without_keys);
+}
+
+TEST(LoraNamespaceHashTest, AdvanceFromMidChainStaysIsolated) {
+    // A chain can start at page 0 with an empty prior on the incremental path:
+    // a prompt shorter than one page produces no admission-time hashes, so the
+    // first hash a LoRA request ever computes comes from AdvancePagedHashes.
+    // That page must still be namespaced.
+    const std::vector<std::vector<std::int32_t>> pages = {{1, 2}};
+    const std::vector<token_span> spans = Pages(pages);
+    const std::vector<std::string> key = {"adapter-a"};
+
+    EXPECT_NE(AdvancePagedHashes(spans, /*first_page=*/0, "", /*past_end_page=*/1, Keys(key)),
+              AdvancePagedHashes(spans, /*first_page=*/0, "", /*past_end_page=*/1));
+}
+
+}  // namespace
+}  // namespace tokenspeed::test

--- a/tokenspeed-scheduler/tests/cpp/test_max_loras.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_max_loras.cpp
@@ -47,10 +47,10 @@ protected:
 };
 
 TEST_F(MaxLorasSuite, BatchNeverExceedsDistinctAdapterCap) {
-    Submit(MakeRequestSpec("r1", 2, 100, "adapter-a"));
-    Submit(MakeRequestSpec("r2", 2, 200, "adapter-b"));
-    Submit(MakeRequestSpec("r3", 2, 300, "adapter-c"));
-    Submit(MakeRequestSpec("r4", 2, 400, "adapter-d"));
+    Submit(MakeRequestSpec("r1", 2, 100, 1));
+    Submit(MakeRequestSpec("r2", 2, 200, 2));
+    Submit(MakeRequestSpec("r3", 2, 300, 3));
+    Submit(MakeRequestSpec("r4", 2, 400, 4));
 
     const std::vector<std::string> ids = BatchRequestIds(PlanOnce());
     ASSERT_FALSE(ids.empty());
@@ -61,10 +61,10 @@ TEST_F(MaxLorasSuite, BatchNeverExceedsDistinctAdapterCap) {
 
 TEST_F(MaxLorasSuite, RepeatedAdapterCostsNoAdditionalSlot) {
     // Four requests but only two distinct adapters: nothing should be deferred.
-    Submit(MakeRequestSpec("r1", 2, 100, "adapter-a"));
-    Submit(MakeRequestSpec("r2", 2, 200, "adapter-a"));
-    Submit(MakeRequestSpec("r3", 2, 300, "adapter-b"));
-    Submit(MakeRequestSpec("r4", 2, 400, "adapter-b"));
+    Submit(MakeRequestSpec("r1", 2, 100, 1));
+    Submit(MakeRequestSpec("r2", 2, 200, 1));
+    Submit(MakeRequestSpec("r3", 2, 300, 2));
+    Submit(MakeRequestSpec("r4", 2, 400, 2));
 
     const std::vector<std::string> ids = BatchRequestIds(PlanOnce());
     EXPECT_EQ(ids, (std::vector<std::string>{"r1", "r2", "r3", "r4"}));
@@ -73,8 +73,8 @@ TEST_F(MaxLorasSuite, RepeatedAdapterCostsNoAdditionalSlot) {
 TEST_F(MaxLorasSuite, BaseModelRequestsAreNotCharged) {
     // Base-model requests hold no adapter slot, so they coexist with a full
     // adapter budget rather than being deferred behind it.
-    Submit(MakeRequestSpec("r1", 2, 100, "adapter-a"));
-    Submit(MakeRequestSpec("r2", 2, 200, "adapter-b"));
+    Submit(MakeRequestSpec("r1", 2, 100, 1));
+    Submit(MakeRequestSpec("r2", 2, 200, 2));
     Submit(MakeRequestSpec("r3", 2, 300));
     Submit(MakeRequestSpec("r4", 2, 400));
 
@@ -94,9 +94,9 @@ protected:
 TEST_F(LorasDisabledSuite, ZeroMaxLorasEnforcesNoCap) {
     // max_loras == 0 means LoRA scheduling is off, not "admit zero adapters":
     // the cap simply is not applied, matching the pre-LoRA scheduler exactly.
-    Submit(MakeRequestSpec("r1", 2, 100, "adapter-a"));
-    Submit(MakeRequestSpec("r2", 2, 200, "adapter-b"));
-    Submit(MakeRequestSpec("r3", 2, 300, "adapter-c"));
+    Submit(MakeRequestSpec("r1", 2, 100, 1));
+    Submit(MakeRequestSpec("r2", 2, 200, 2));
+    Submit(MakeRequestSpec("r3", 2, 300, 3));
 
     const std::vector<std::string> ids = BatchRequestIds(PlanOnce());
     EXPECT_EQ(ids, (std::vector<std::string>{"r1", "r2", "r3"}));

--- a/tokenspeed-scheduler/tests/cpp/test_max_loras.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_max_loras.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 LightSeek Foundation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "integration_test_helper.h"
+
+namespace tokenspeed::test {
+namespace {
+
+std::vector<std::string> BatchRequestIds(const ExecutionPlan& plan) {
+    for (const auto& op : plan.Operations()) {
+        if (auto* fwd = std::get_if<ForwardBatch>(&op)) {
+            return fwd->request_ids;
+        }
+    }
+    return {};
+}
+
+class MaxLorasSuite : public SchedulerTestSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        SchedulerConfig cfg = SchedulerTestSuite::MakeConfig();
+        cfg.max_loras = 2;
+        return cfg;
+    }
+};
+
+TEST_F(MaxLorasSuite, BatchNeverExceedsDistinctAdapterCap) {
+    Submit(MakeRequestSpec("r1", 2, 100, "adapter-a"));
+    Submit(MakeRequestSpec("r2", 2, 200, "adapter-b"));
+    Submit(MakeRequestSpec("r3", 2, 300, "adapter-c"));
+    Submit(MakeRequestSpec("r4", 2, 400, "adapter-d"));
+
+    const std::vector<std::string> ids = BatchRequestIds(PlanOnce());
+    ASSERT_FALSE(ids.empty());
+    // Candidates are visited in request-id order, so the two admitted adapters
+    // are a and b; c and d are deferred to a later step.
+    EXPECT_EQ(ids, (std::vector<std::string>{"r1", "r2"}));
+}
+
+TEST_F(MaxLorasSuite, RepeatedAdapterCostsNoAdditionalSlot) {
+    // Four requests but only two distinct adapters: nothing should be deferred.
+    Submit(MakeRequestSpec("r1", 2, 100, "adapter-a"));
+    Submit(MakeRequestSpec("r2", 2, 200, "adapter-a"));
+    Submit(MakeRequestSpec("r3", 2, 300, "adapter-b"));
+    Submit(MakeRequestSpec("r4", 2, 400, "adapter-b"));
+
+    const std::vector<std::string> ids = BatchRequestIds(PlanOnce());
+    EXPECT_EQ(ids, (std::vector<std::string>{"r1", "r2", "r3", "r4"}));
+}
+
+TEST_F(MaxLorasSuite, BaseModelRequestsAreNotCharged) {
+    // Base-model requests hold no adapter slot, so they coexist with a full
+    // adapter budget rather than being deferred behind it.
+    Submit(MakeRequestSpec("r1", 2, 100, "adapter-a"));
+    Submit(MakeRequestSpec("r2", 2, 200, "adapter-b"));
+    Submit(MakeRequestSpec("r3", 2, 300));
+    Submit(MakeRequestSpec("r4", 2, 400));
+
+    const std::vector<std::string> ids = BatchRequestIds(PlanOnce());
+    EXPECT_EQ(ids, (std::vector<std::string>{"r1", "r2", "r3", "r4"}));
+}
+
+class LorasDisabledSuite : public SchedulerTestSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        SchedulerConfig cfg = SchedulerTestSuite::MakeConfig();
+        cfg.max_loras = 0;
+        return cfg;
+    }
+};
+
+TEST_F(LorasDisabledSuite, ZeroMaxLorasEnforcesNoCap) {
+    // max_loras == 0 means LoRA scheduling is off, not "admit zero adapters":
+    // the cap simply is not applied, matching the pre-LoRA scheduler exactly.
+    Submit(MakeRequestSpec("r1", 2, 100, "adapter-a"));
+    Submit(MakeRequestSpec("r2", 2, 200, "adapter-b"));
+    Submit(MakeRequestSpec("r3", 2, 300, "adapter-c"));
+
+    const std::vector<std::string> ids = BatchRequestIds(PlanOnce());
+    EXPECT_EQ(ids, (std::vector<std::string>{"r1", "r2", "r3"}));
+}
+
+}  // namespace
+}  // namespace tokenspeed::test


### PR DESCRIPTION
Makes the tokenspeed scheduler LoRA-aware. Scheduler only — no kernels, no adapter runtime, no model code.

Two independent changes, one commit each, plus a small wire-format change.

---

## 1 — Per-adapter KV prefix-cache namespace

Without isolation, tokens cached under adapter A can be served to adapter B or to the base model: a page hash derives only from its tokens and the chain before it, so identical prompt prefixes collide across adapters.

`page_hasher.h` already accepted per-page `extra_keys` — documented upstream for exactly this ("e.g. LoRA name"). This adds `ComputeNamespacedPagedHashes`, which applies one key set to *every* page rather than a per-page list, and threads the request's adapter id through it.

**Why every page, not just page 0.** Chaining would make a page-0 key sufficient — each later page folds in `prior_hash`. But `appendCompletedPageHashes` starts a *fresh* chain with an empty prior whenever `page_hashes` is empty, which happens for any prompt shorter than one page: such a request produces no hashes at admission, so the first hash it ever computes comes from the incremental path. With a page-0-only key that page would silently land in the base-model namespace. Keying every page makes isolation independent of where the chain starts.

**`AdvancePagedHashes` silently dropped keys.** It neither accepted nor forwarded `extra_keys`, so two of the three hash sites would have lost the adapter id on every extension. It now takes `namespace_keys`. All three sites pass the request's keys: admission (`matchPrefixAtAdmission`), incremental extension (`appendCompletedPageHashes`), and stable-page publication (`publishCompletedPages`).

## 2 — `max_loras` batch cap

`SchedulerConfig::max_loras` (0 = disabled) bounds the number of *distinct* adapters in one batch, because the runtime materializes one adapter slot per unique id and exceeding the cap would overrun that fixed pool.

`buildForwardOperations` tracks the adapters already pushed and **defers** a request that would introduce a new one past the cap — deferring rather than breaking out of the loop, because a later candidate may reuse an adapter already in the batch and still belongs in this step. A request whose adapter is already present costs no additional slot; base-model requests are never charged.

---

## Existing functionality is unchanged

This is the property the PR is built around, and it is asserted rather than argued:

| Concern | Why it holds |
|---|---|
| **Page hashes** | An empty key list is *byte-identical* to the previous two-argument hash form. `NoKeysIsByteIdenticalToUnnamespacedChain` asserts it directly, so existing cache entries stay valid and enabling LoRA invalidates nothing. |
| **Batch composition** | `max_loras == 0` means LoRA scheduling is off, not "admit zero adapters" — the cap is simply not applied. `ZeroMaxLorasEnforcesNoCap` pins it. |
| **Defaults** | `RequestSpec::lora_id` defaults to 0 (base model) and `max_loras` to 0, so a build that never sets either behaves exactly as before. |
| **IPC wire format** | Untouched. See below. |
| **Request handling** | `request_handler` reads the id with `getattr(..., 0)`, so it cannot raise on a request input that has no such field. |

### On the IPC wire format

`request_handler` reads `lora_id` defensively rather than directly, and this PR deliberately does **not** add the field to `TokenizedGenerateReqInput`.

That struct is a positionally-encoded `msgspec.Struct` (`array_like=True`) whose own docstring states that *declaration order IS the wire contract — append only*. Adding a field changes the tuple the frontend decodes; `test_zmq_msgpack.py` pins the arity precisely to catch that, and inserting anywhere but the end also shifts existing fields' positions. An earlier revision of this branch did exactly that and the test caught it.

That contract belongs to the front-end, so the field is declared by the LoRA front-end change that also populates it. Until then every request resolves to `lora_id = 0` and scheduling is byte-for-byte what it was before this PR.

## Relationship to #735

Supersedes #735, which was written against the radix prefix cache that #864 removed. Every core file that PR touched — `csrc/resource/kv_prefix_cache/`, `hybrid_prefix_cache/`, `radix_tree/`, `resource/types.h` — is gone from `main`, and `tests/check_no_radix_cache_sources.py` now hard-fails if those directories or the symbols `RadixTree` / `KVPrefixCache` / `HybridPrefixCache` reappear. This is a rewrite against the hash-chain cache, not a rebase.

## Testing

- **368/368 C++ scheduler tests pass**, including 10 new ones across `test_lora_namespace.cpp` and `test_max_loras.cpp`.
- **5/5 Python plumbing tests**, against a freshly rebuilt scheduler extension.
- **102/102** IPC codec and request-construction tests (`test_io_struct_codec.py`, `test_zmq_msgpack.py`, `test_max_new_tokens_context_cap.py`) — the wire-format guard.
- `check_no_radix_cache_sources.py` guard passes.
- `pre-commit`, `ruff` (CI's select list), `clang-format`, `clang-tidy` (0 diagnostics): clean.

No GPU path is involved in this PR.
