### PR TITLE
feat(lora): LoRA adapter serving runtime

### DIFF
--- a/python/tokenspeed/bench.py
+++ b/python/tokenspeed/bench.py
@@ -776,7 +776,7 @@ class BenchmarkDataset:
         self,
         index: int,
         max_loras: int | None = None,
-        lora_path: str | None = None,
+        lora_name: str | None = None,
         lora_assignment: str = "random",
     ) -> None:
         return None
@@ -821,7 +821,7 @@ class RandomDataset(BenchmarkDataset):
         output_len: int = DEFAULT_OUTPUT_LEN,
         batchsize: int = 1,
         max_loras: int | None = None,
-        lora_path: str | None = None,
+        lora_name: str | None = None,
         lora_assignment: str = "random",
         **kwargs,
     ) -> list[SampleRequest]:
@@ -879,7 +879,7 @@ class RandomDataset(BenchmarkDataset):
             lora_req = self.get_lora_request(
                 index=i,
                 max_loras=max_loras,
-                lora_path=lora_path,
+                lora_name=lora_name,
                 lora_assignment=lora_assignment,
             )
             requests.append(

--- a/python/tokenspeed/runtime/engine/async_llm.py
+++ b/python/tokenspeed/runtime/engine/async_llm.py
@@ -142,6 +142,8 @@ class AsyncLLM(SchedulerControlClient, EngineClient):
         # Read model args
         self.model_path = server_args.model
         self.served_model_name = server_args.served_model_name
+        # LoRA adapter name → integer lora_id (populated by load_lora_adapter).
+        self._lora_name_to_id: dict[str, int] = {}
         self.model_config = ModelConfig(
             server_args.model,
             trust_remote_code=server_args.trust_remote_code,

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 
 import faulthandler
+import os
 import signal
 import threading
 import time
@@ -417,7 +418,7 @@ class EventLoop:
             disable_prefix_cache=not server_args.enable_prefix_caching,
             paged_cache_groups=paged_cache_groups,
             enable_mixed_prefill_decode=server_args.enable_mixed_batch,
-            max_loras=server_args.max_loras,
+            max_loras=server_args.max_loras if server_args.enable_lora else 0,
         )
         scheduler_cfg.enable_pd_cache = self._pd_cache_enabled
         logger.info(
@@ -525,6 +526,8 @@ class EventLoop:
             pause_controller=self._pause,
             memory_controller=self._memory,
             model_runner=target,
+            load_lora_fn=self.load_lora_adapter,
+            unload_lora_fn=self.unload_lora_adapter,
         )
 
         self.output_processor = OutputProcesser(
@@ -607,6 +610,60 @@ class EventLoop:
             self.kv_transfer = None
             self.epd_admission = None
             self._epd_staged: dict = {}
+
+        # ── LoRA ─────────────────────────────────────────────────────────────
+        self._lora_manager = None  # LoraManager (lazy init)
+        self._lora_name_to_id: dict[str, int] = {}  # name → integer lora_id
+        self._request_lora_ids: dict[str, int] = {}  # rid → lora_id
+
+        if server_args.enable_lora:
+            self._init_lora_manager()
+
+    def _init_lora_manager(self) -> None:
+        """Bind to the LoraManager owned by the model executor.
+
+        The model executor creates the manager during its own ``__init__`` so
+        that the CUDA-graph capture sees a live manager (and bakes the LoRA
+        delta path into the captured graphs).  The event loop only borrows
+        the reference and shares its request-id → lora-id map.
+        """
+        self._lora_manager = self.model_executor.lora_manager
+        if self._lora_manager is None:
+            raise RuntimeError(
+                "Model executor was not configured with --enable-lora; "
+                "cannot initialize LoRA support."
+            )
+        self.model_executor.request_lora_ids = self._request_lora_ids
+        logger.info("LoraManager bound (max_loras=%d)", self.server_args.max_loras)
+
+    def load_lora_adapter(self, lora_name: str, adapter_path: str) -> int:
+        """Load a PEFT LoRA adapter and make it available for serving.
+
+        Returns the integer lora_id assigned to this adapter.
+        """
+        if not self.server_args.enable_lora:
+            raise ValueError(
+                "Server was not started with --enable-lora. "
+                "Restart with --enable-lora to use LoRA adapters."
+            )
+        if self._lora_manager is None:
+            self._init_lora_manager()
+        lora_id = self._lora_manager.load_adapter(lora_name, adapter_path)
+        self._lora_name_to_id[lora_name] = lora_id
+        logger.info("Loaded LoRA adapter '%s' → lora_id=%d", lora_name, lora_id)
+        return lora_id
+
+    def unload_lora_adapter(self, lora_name: str) -> None:
+        """Unload a LoRA adapter and free its GPU slot."""
+        if self._lora_manager is None:
+            raise KeyError(f"No LoRA adapters loaded; '{lora_name}' not found.")
+        lora_id = self._lora_name_to_id.get(lora_name)
+        self._lora_manager.unload_adapter(lora_name)
+        self._lora_name_to_id.pop(lora_name, None)
+        # Proactively evict the KV cache namespace for this adapter so pages
+        # are freed immediately rather than waiting for LRU eviction pressure.
+        if lora_id is not None:
+            self.scheduler.evict_lora_namespace(lora_id)
 
     def _setup_pd_layerwise_transfer(self, interval: int) -> None:
         if not isinstance(self.kv_transfer, DisaggPrefillExecutor):
@@ -1274,6 +1331,20 @@ class EventLoop:
                 self._epd_staged[spec.request_id] = (spec, state, bootstrap)
             else:
                 admitted_specs.append(spec)
+                # Track lora_id per request for forward-pass injection
+                if spec.lora_id != 0:
+                    self._request_lora_ids[spec.request_id] = spec.lora_id
+                    # Async-prefetch the adapter into the CPU pool so the
+                    # disk read is overlapped with the previous forward step
+                    # rather than blocking ``prepare_loras`` of the step that
+                    # actually consumes it.  No-op when already CPU-resident.
+                    if (
+                        self._lora_manager is not None
+                        and os.environ.get("TOKENSPEED_LORA_PREFETCH", "1") == "1"
+                    ):
+                        name = self._lora_manager._id_to_name.get(spec.lora_id)
+                        if name is not None:
+                            self._lora_manager.prefetch(name)
 
         # Pause gate: while paused, withhold new requests from the scheduler
         # (running requests keep stepping); buffered specs are flushed on resume
@@ -1302,6 +1373,26 @@ class EventLoop:
             return
 
         if admitted_specs:
+            # Optional ``pack`` policy: cluster admissions by lora_id so
+            # adapter-shared requests batch together at the C++ scheduler.
+            # Reduces GPU/CPU eviction churn under heavy mixed-adapter
+            # traffic (multiple distinct adapters > max_loras).
+            #
+            # Sort is stable: requests for the same adapter keep their
+            # arrival order, base-model (lora_id == 0) requests stay
+            # together at the front (their slot is the no-op sentinel).
+            #
+            # The benchmark in benchmark/test_lora_eviction_latency.py
+            # shows that CPU↔GPU promotion is essentially free; the
+            # only meaningful eviction cost is CPU→disk re-read (~30 ms).
+            # ``pack`` therefore mainly helps when ``working_set >
+            # max_loras_cpu`` and incoming traffic is bursty enough that
+            # multiple cold requests arrive in one event-loop iteration.
+            if (
+                self._lora_manager is not None
+                and self.server_args.lora_scheduling_policy == "pack"
+            ):
+                admitted_specs.sort(key=lambda s: s.lora_id)
             self.scheduler.submit_requests(admitted_specs)
 
     @nvtx_range("loop:commit", color="rapids")

--- a/python/tokenspeed/runtime/engine/input_processor.py
+++ b/python/tokenspeed/runtime/engine/input_processor.py
@@ -290,6 +290,7 @@ class InputProcessor:
                 input_extra_infos=obj.input_extra_infos,
                 input_ids_unpadded=input_ids_unpadded,
                 multimodal_inputs=multimodal_inputs,
+                lora_id=self._resolve_lora_id(obj),
             )
 
         return TokenizedEmbeddingReqInput(
@@ -299,3 +300,17 @@ class InputProcessor:
             sampling_params=sampling_params,
             created_time=time.time(),
         )
+
+    def _resolve_lora_id(self, obj: "GenerateReqInput") -> int:
+        """Map request LoRA adapter name to an integer lora_id."""
+        lora_name = getattr(obj, "lora_name", None)
+        if lora_name is None:
+            return 0
+        lora_registry: dict = getattr(self.engine, "_lora_name_to_id", {})
+        lora_id = lora_registry.get(lora_name, 0)
+        if lora_id == 0:
+            raise ValueError(
+                f"lora_name={lora_name!r} is not a registered adapter. "
+                "Call load_lora_adapter(name, adapter_path) before using it in a request."
+            )
+        return lora_id

--- a/python/tokenspeed/runtime/engine/io_struct.py
+++ b/python/tokenspeed/runtime/engine/io_struct.py
@@ -178,6 +178,12 @@ class GenerateReqInput:
     bootstrap_port: list[int] | int | None = None
     bootstrap_room: list[int] | int | None = None
 
+    # LoRA adapter to use for this request. Supply the name under which the
+    # adapter was registered via Engine.load_lora_adapter(). None means use the
+    # base model. Requests do not load adapters from disk; adapter filesystem
+    # paths belong to load_lora_adapter().
+    lora_name: list[str | None] | str | None = None
+
     def normalize_batch_and_arguments(self):
         if (
             self.text is None and self.input_ids is None and self.input_embeds is None
@@ -280,6 +286,11 @@ class GenerateReqInput:
                 self.token_ids_logprob = None
             if isinstance(self.input_extra_infos, dict):
                 self.input_extra_infos = [self.input_extra_infos]
+            if isinstance(self.lora_name, list):
+                assert (
+                    len(self.lora_name) == 1
+                ), "lora_name list should have length 1 for single request."
+                self.lora_name = self.lora_name[0]
         else:
             if self.parallel_sample_num == 1:
                 num = self.batch_size
@@ -393,6 +404,15 @@ class GenerateReqInput:
                     "bootstrap_room cannot be a list when n > 1.",
                 )
 
+            if self.lora_name is None:
+                self.lora_name = [None] * num
+            elif not isinstance(self.lora_name, list):
+                self.lora_name = [self.lora_name] * num
+            else:
+                assert (
+                    len(self.lora_name) == num
+                ), "lora_name should be a str or a list of matching length."
+
         # Other checks
         if self.session_params is not None:
             _require(
@@ -450,6 +470,11 @@ class GenerateReqInput:
             ),
             bootstrap_room=(
                 self.bootstrap_room[i] if self.bootstrap_room is not None else None
+            ),
+            lora_name=(
+                self.lora_name[i]
+                if isinstance(self.lora_name, list)
+                else self.lora_name
             ),
         )
         sub.rid = self.rid[i]
@@ -512,6 +537,9 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
     # makes RequestHandler admit the request pre-finished with FINISH_ABORT so
     # the client receives a terminal abort instead of a silent drop.
     validation_error: str | None = None
+
+    # Integer adapter id resolved from lora_name by the registry; 0 = base model.
+    lora_id: int = 0
 
 
 @dataclass
@@ -1049,6 +1077,30 @@ class RpcReqInput(BaseReq, kw_only=True):
 class RpcReqOutput(BaseReq, kw_only=True):
     success: bool
     message: str
+
+
+@dataclass
+class LoadLoraReqInput:
+    lora_name: str
+    adapter_path: str
+
+
+@dataclass
+class LoadLoraReqOutput:
+    success: bool
+    lora_id: int = 0
+    message: str = ""
+
+
+@dataclass
+class UnloadLoraReqInput:
+    lora_name: str
+
+
+@dataclass
+class UnloadLoraReqOutput:
+    success: bool
+    message: str = ""
 
 
 class GetLoadReqInput(BaseReq, kw_only=True):

--- a/python/tokenspeed/runtime/engine/request_handler.py
+++ b/python/tokenspeed/runtime/engine/request_handler.py
@@ -54,6 +54,8 @@ from tokenspeed.runtime.engine.io_struct import (
     InitWeightsUpdateGroupReqOutput,
     IsSchedulerPausedReqInput,
     IsSleepingReqInput,
+    LoadLoraReqInput,
+    LoadLoraReqOutput,
     PauseSchedulerReqInput,
     ProfileReq,
     ProfileReqOutput,
@@ -64,6 +66,8 @@ from tokenspeed.runtime.engine.io_struct import (
     SetInternalStateReq,
     SetInternalStateReqOutput,
     TokenizedGenerateReqInput,
+    UnloadLoraReqInput,
+    UnloadLoraReqOutput,
     UpdateWeightsFromDistributedReqInput,
     UpdateWeightsFromDistributedReqOutput,
 )
@@ -115,6 +119,8 @@ class RequestHandler:
         pause_controller=None,
         memory_controller=None,
         model_runner=None,
+        load_lora_fn=None,
+        unload_lora_fn=None,
     ) -> None:
 
         self.forward_ct = 0
@@ -143,6 +149,8 @@ class RequestHandler:
         self.vocab_size = vocab_size
         self.get_load_fn = get_load_fn
         self.clear_cache_fn = clear_cache_fn
+        self.load_lora_fn = load_lora_fn
+        self.unload_lora_fn = unload_lora_fn
 
         self.tokenizer = get_tokenizer(
             server_args.tokenizer,
@@ -258,6 +266,34 @@ class RequestHandler:
                 self.send_func.send_pyobj(
                     DestroyWeightsUpdateGroupReqOutput(success=ok, message=msg)
                 )
+            elif isinstance(recv_req, LoadLoraReqInput):
+                try:
+                    if self.load_lora_fn is not None:
+                        lora_id = self.load_lora_fn(
+                            recv_req.lora_name, recv_req.adapter_path
+                        )
+                        self.send_func.send_pyobj(
+                            LoadLoraReqOutput(success=True, lora_id=lora_id)
+                        )
+                    else:
+                        self.send_func.send_pyobj(
+                            LoadLoraReqOutput(
+                                success=False, message="LoRA not enabled on this server"
+                            )
+                        )
+                except Exception as e:
+                    self.send_func.send_pyobj(
+                        LoadLoraReqOutput(success=False, message=str(e))
+                    )
+            elif isinstance(recv_req, UnloadLoraReqInput):
+                try:
+                    if self.unload_lora_fn is not None:
+                        self.unload_lora_fn(recv_req.lora_name)
+                    self.send_func.send_pyobj(UnloadLoraReqOutput(success=True))
+                except Exception as e:
+                    self.send_func.send_pyobj(
+                        UnloadLoraReqOutput(success=False, message=str(e))
+                    )
             else:
                 raise NotImplementedError(f"Unsupported request type: {type(recv_req)}")
         return new_req_specs, req_states, bootstrap_infos, abort_rids
@@ -272,6 +308,10 @@ class RequestHandler:
         req_spec = make_spec(
             rid=recv_req.rid,
             tokens=recv_req.input_ids,
+            # This change declares lora_id on TokenizedGenerateReqInput and the
+            # adapter registry resolves it before the request reaches the
+            # scheduler, so a direct read is safe here. 0 means base model.
+            lora_id=recv_req.lora_id,
         )
         req_state = RequestState.from_recv_req(
             recv_req,

--- a/python/tokenspeed/runtime/engine/scheduler_control_client.py
+++ b/python/tokenspeed/runtime/engine/scheduler_control_client.py
@@ -54,6 +54,8 @@ from tokenspeed.runtime.engine.io_struct import (
     IsSchedulerPausedReqOutput,
     IsSleepingReqInput,
     IsSleepingReqOutput,
+    LoadLoraReqInput,
+    LoadLoraReqOutput,
     PauseMode,
     PauseSchedulerReqInput,
     PauseSchedulerReqOutput,
@@ -68,6 +70,8 @@ from tokenspeed.runtime.engine.io_struct import (
     ResumeSchedulerReqOutput,
     SetInternalStateReq,
     SetInternalStateReqOutput,
+    UnloadLoraReqInput,
+    UnloadLoraReqOutput,
     UpdateWeightsFromDistributedReqInput,
     UpdateWeightsFromDistributedReqOutput,
     UpdateWeightsFromTensorReqInput,
@@ -108,7 +112,7 @@ class _Communicator(Generic[T]):
                 raise RuntimeError("Communicator result state was not reset.")
 
         if obj:
-            self._sender.send_pyobj(obj)
+            await self._sender.send_pyobj(obj)
 
         self._result_event = asyncio.Event()
         self._result_values = []
@@ -129,7 +133,7 @@ class _Communicator(Generic[T]):
             self._result_event = asyncio.Event()
 
             if obj:
-                self._sender.send_pyobj(obj)
+                await self._sender.send_pyobj(obj)
 
         await self._result_event.wait()
         result_values = copy.deepcopy(self._result_values)
@@ -207,6 +211,12 @@ class SchedulerControlClient:
             server_args.mapping.attn.dp_size,
             mode="watching",
         )
+        self.load_lora_communicator = _Communicator(
+            self.engine_core_client.send_to_scheduler, server_args.mapping.attn.dp_size
+        )
+        self.unload_lora_communicator = _Communicator(
+            self.engine_core_client.send_to_scheduler, server_args.mapping.attn.dp_size
+        )
 
         self._result_dispatcher += self._get_communicator_dispatcher()
 
@@ -281,8 +291,38 @@ class SchedulerControlClient:
                     GetLoadReqOutput,
                     self.get_load_communicator.handle_recv,
                 ),
+                (
+                    LoadLoraReqOutput,
+                    self.load_lora_communicator.handle_recv,
+                ),
+                (
+                    UnloadLoraReqOutput,
+                    self.unload_lora_communicator.handle_recv,
+                ),
             ]
         )
+
+    async def load_lora_adapter(
+        self: "AsyncLLM",
+        lora_name: str,
+        adapter_path: str,
+    ) -> tuple[bool, int, str]:
+        """Send a LoadLoraReqInput to the scheduler subprocess."""
+        self.auto_create_handle_loop()
+        result = (
+            await self.load_lora_communicator(
+                LoadLoraReqInput(lora_name=lora_name, adapter_path=adapter_path)
+            )
+        )[0]
+        return result.success, result.lora_id, result.message
+
+    async def unload_lora_adapter(self: "AsyncLLM", lora_name: str) -> tuple[bool, str]:
+        """Send an UnloadLoraReqInput to the scheduler subprocess."""
+        self.auto_create_handle_loop()
+        result = (
+            await self.unload_lora_communicator(UnloadLoraReqInput(lora_name=lora_name))
+        )[0]
+        return result.success, result.message
 
     async def flush_cache(self: AsyncLLM) -> FlushCacheReqOutput:
         return (await self.flush_cache_communicator(FlushCacheReqInput()))[0]

--- a/python/tokenspeed/runtime/entrypoints/engine.py
+++ b/python/tokenspeed/runtime/entrypoints/engine.py
@@ -166,6 +166,7 @@ class Engine(EngineBase):
         bootstrap_port: list[int] | int | None = None,
         bootstrap_room: list[int] | int | None = None,
         data_parallel_rank: int | None = None,
+        lora_name: list[str | None] | str | None = None,
     ) -> dict | Iterator[dict]:
         """
         The arguments of this function match
@@ -198,6 +199,7 @@ class Engine(EngineBase):
             bootstrap_host=bootstrap_host,
             bootstrap_port=bootstrap_port,
             bootstrap_room=bootstrap_room,
+            lora_name=lora_name,
         )
         if stream:
             return self.llm.generate_stream(obj)
@@ -228,6 +230,7 @@ class Engine(EngineBase):
         bootstrap_port: list[int] | int | None = None,
         bootstrap_room: list[int] | int | None = None,
         user_rid: list[str] | str | None = None,
+        lora_name: list[str | None] | str | None = None,
     ) -> dict | AsyncIterator[dict]:
         """
         The arguments of this function match
@@ -255,6 +258,7 @@ class Engine(EngineBase):
             bootstrap_port=bootstrap_port,
             bootstrap_room=bootstrap_room,
             user_rid=user_rid,
+            lora_name=lora_name,
         )
         generator = self.tokenizer_manager.generate_request(obj)
 
@@ -448,6 +452,32 @@ class Engine(EngineBase):
             raise TypeError(f"Expected RpcReqOutput, got {type(recv_req).__name__}.")
         if not recv_req.success:
             raise RuntimeError(recv_req.message)
+
+    def load_lora_adapter(
+        self,
+        lora_name: str,
+        adapter_path: str,
+    ) -> int:
+        """Load a PEFT LoRA adapter. Returns the integer lora_id."""
+        success, lora_id, message = self.llm.run(
+            self.tokenizer_manager.load_lora_adapter(lora_name, adapter_path)
+        )
+        if not success:
+            raise RuntimeError(f"Failed to load LoRA adapter '{lora_name}': {message}")
+        # Update the local name→id registry so future requests resolve correctly.
+        self.tokenizer_manager._lora_name_to_id[lora_name] = lora_id
+        return lora_id
+
+    def unload_lora_adapter(self, lora_name: str) -> None:
+        """Unload a previously loaded LoRA adapter."""
+        success, message = self.llm.run(
+            self.tokenizer_manager.unload_lora_adapter(lora_name)
+        )
+        if not success:
+            raise RuntimeError(
+                f"Failed to unload LoRA adapter '{lora_name}': {message}"
+            )
+        self.tokenizer_manager._lora_name_to_id.pop(lora_name, None)
 
     def save_remote_model(self, **kwargs):
         self.collective_rpc("save_remote_model", **kwargs)

--- a/python/tokenspeed/runtime/entrypoints/engine_base.py
+++ b/python/tokenspeed/runtime/entrypoints/engine_base.py
@@ -57,6 +57,7 @@ class EngineBase(ABC):
         bootstrap_port: list[int] | int | None = None,
         bootstrap_room: list[int] | int | None = None,
         data_parallel_rank: int | None = None,
+        lora_name: list[str | None] | str | None = None,
     ) -> dict | Iterator[dict]:
         """Generate outputs based on given inputs."""
 
@@ -88,3 +89,32 @@ class EngineBase(ABC):
     @abstractmethod
     def shutdown(self) -> None:
         """Shutdown the engine and clean up resources."""
+
+    # ------------------------------------------------------------------
+    # LoRA adapter management
+    # ------------------------------------------------------------------
+
+    def load_lora_adapter(
+        self,
+        lora_name: str,
+        adapter_path: str,
+    ) -> int:
+        """Load a PEFT LoRA adapter and make it available for serving.
+
+        Args:
+            lora_name: Short identifier used by request-time lora_name.
+            adapter_path: Filesystem path to the PEFT adapter directory.
+
+        Returns:
+            Integer lora_id assigned to this adapter.
+        """
+        raise NotImplementedError(
+            "load_lora_adapter() is not implemented on this engine type. "
+            "Use the tokenspeed serve engine."
+        )
+
+    def unload_lora_adapter(self, lora_name: str) -> None:
+        """Unload a previously loaded LoRA adapter and free its GPU slot."""
+        raise NotImplementedError(
+            "unload_lora_adapter() is not implemented on this engine type."
+        )

--- a/python/tokenspeed/runtime/execution/context.py
+++ b/python/tokenspeed/runtime/execution/context.py
@@ -20,7 +20,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -34,6 +36,24 @@ from tokenspeed.runtime.execution.forward_batch_info import (
 if TYPE_CHECKING:
     from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
     from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
+    from tokenspeed.runtime.lora.lora_manager import LoraManager
+
+_CURRENT_LORA_MANAGER: ContextVar["LoraManager" | None] = ContextVar(
+    "tokenspeed_current_lora_manager", default=None
+)
+
+
+def get_current_lora_manager() -> "LoraManager" | None:
+    return _CURRENT_LORA_MANAGER.get()
+
+
+@contextmanager
+def bind_forward_context(ctx: "ForwardContext") -> Iterator[None]:
+    token = _CURRENT_LORA_MANAGER.set(ctx.lora_manager)
+    try:
+        yield
+    finally:
+        _CURRENT_LORA_MANAGER.reset(token)
 
 
 @dataclass
@@ -81,6 +101,14 @@ class ForwardContext:
     # DSA SWA slot mapping + compressor memo, computed once per forward, shared across layers.
     dsa_swa_slot_mapping: torch.Tensor | None = None
     dsa_compressor_slot_cache: Any | None = None
+
+    # --- LoRA ---
+    # Reference to the LoraManager.  When set, forward layers call
+    # ``lora_manager.apply_qkv_lora`` / ``apply_o_lora`` which read from
+    # the manager's persistent batch_info.  Set at capture time when
+    # ``--enable-lora`` is on so the LoRA path is recorded into the graph
+    # (NO_LORA_SLOT = no adapter), otherwise None.
+    lora_manager: "LoraManager" | None = None
 
 
 @contextmanager

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
     from tokenspeed.runtime.execution.runtime_states import RuntimeStates
     from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
     from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
+    from tokenspeed.runtime.lora.lora_manager import LoraManager
     from tokenspeed.runtime.sampling.backends.base import SamplingBackend
 
 logger = get_colorful_logger(__name__)
@@ -201,6 +202,7 @@ class CudaGraphWrapper:
         eager_grammar_buffers=None,
         sampling_backend: SamplingBackend | None = None,
         runtime_states: RuntimeStates | None = None,
+        lora_manager: LoraManager | None = None,
     ):
         self.config = config
         self.attn_backend = attn_backend
@@ -213,6 +215,7 @@ class CudaGraphWrapper:
         self.capturable_grammar = capturable_grammar
         self.eager_grammar_buffers = eager_grammar_buffers
         self.runtime_states = runtime_states
+        self.lora_manager = lora_manager
         self.enable_torch_compile = getattr(config, "enable_torch_compile", False)
         self.disable_padding = config.disable_cuda_graph_padding
         self.enable_cudagraph_gc = getattr(config, "enable_cudagraph_gc", True)
@@ -319,6 +322,11 @@ class CudaGraphWrapper:
     def capture(self):
         """
         Capture CUDA graphs for all configured batch sizes.
+
+        When a ``lora_manager`` is attached, the captured graph records the
+        per-layer LoRA Triton kernels and feeds them from the manager's
+        persistent batch_info.  Base-model requests reuse the same graph via
+        NO_LORA_SLOT, so no separate no-LoRA graph is captured.
 
         Args:
             forward_func: ModelExecutor.forward_step(bs, ctx, sampling_info).
@@ -438,6 +446,43 @@ class CudaGraphWrapper:
             # uniform dummy.
             ctx.global_bs = [bs] * self.world_size
 
+        # Bind the LoRA manager into the captured graph so the per-layer
+        # Triton LoRA kernels are recorded.  Base-model requests are served
+        # from the same graph via NO_LORA_SLOT (weight_indices resolve to the
+        # all-zero slot at replay), so a single graph covers both cases.
+        if self.lora_manager is not None:
+            ctx.lora_manager = self.lora_manager
+            # Pre-fill batch_info so the captured kernels see a stable
+            # set of pointers; runtime updates the same tensors before
+            # each ``graph.replay()`` and the kernels re-read seg_lens /
+            # weight_indices / lora_ranks.
+            #
+            # Use lora_id=0 (base model) which resolves to NO_LORA_SLOT, BUT
+            # force has_active_lora=True so LoRA kernels ARE captured in the
+            # graph.  With dynamic GPU-tensor weight indexing (w13_A_buffers
+            # etc.) the captured kernels read weight_indices at replay time,
+            # so the correct adapter slot is used regardless of what was set
+            # during capture.  Slot 0 weights are all-zero at capture time
+            # (no adapter loaded yet), so the model output is unaffected.
+            self.lora_manager.prepare_loras(
+                [0] * bs, per_request_token_counts=self.max_tokens_per_req
+            )
+            # Force has_active_lora and single_lora_slot so ALL LoRA kernels
+            # (MoE, attention, MLP) are included in the captured graph.
+            # This applies to any enabled LoRA type — without this, kernels that
+            # check has_active_lora (e.g. apply_qkv_lora) return early during
+            # capture, recording a no-op that is then replayed at every decode step.
+            if (
+                self.lora_manager.enable_moe_lora
+                or self.lora_manager.enable_attn_lora
+                or self.lora_manager.enable_mlp_lora
+            ):
+                self.lora_manager.has_active_lora = True
+                bi = self.lora_manager._batch_info
+                bi.single_lora_slot = 0
+                bi.single_lora_rank = self.lora_manager.max_lora_rank
+                bi.weight_indices[:bs].fill_(0)
+
         # Capture with is_all_greedy=False so the graph records the full
         # top_k_top_p_sampling path (greedy-only requests are served by the
         # same path with top_k=1 in the buffer, which effectively argmaxes).
@@ -456,6 +501,7 @@ class CudaGraphWrapper:
             device=self.device,
         )
 
+        from tokenspeed.runtime.execution.context import bind_forward_context
         from tokenspeed.runtime.grammar.capturable_grammar import (
             bind_grammar_mask_buf,
         )
@@ -481,7 +527,8 @@ class CudaGraphWrapper:
                 self.capturable_grammar.add_batch(
                     grammars=[None] * bs, bs=bs, has_candidates=False
                 )
-            return self._forward_func(bs=bs, ctx=ctx, sampling_info=sampling_info)
+            with bind_forward_context(ctx):
+                return self._forward_func(bs=bs, ctx=ctx, sampling_info=sampling_info)
 
         global _is_cuda_graph_phase
         _is_cuda_graph_phase = True
@@ -1332,7 +1379,10 @@ class CudaGraphWrapper:
                 **cache_kwargs,
             )
 
-            result = self._forward_func(bs=bs, ctx=ctx, sampling_info=sampling_info)
+            from tokenspeed.runtime.execution.context import bind_forward_context
+
+            with bind_forward_context(ctx):
+                result = self._forward_func(bs=bs, ctx=ctx, sampling_info=sampling_info)
 
         if use_graph and padded_bs != bs:
             ctx.bs = bs

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -193,6 +193,18 @@ class ModelExecutorConfig:
     # Explicit bucket list overriding the ladder (see get_prefill_token_buckets).
     prefill_graph_capture_sizes: list[int] | None = None
 
+    # ====== LORA =========
+    enable_lora: bool = False
+    max_loras: int = 4
+    max_lora_rank: int = 64
+    # Tiered residence: at most ``max_loras`` adapters in GPU buffers,
+    # at most ``max_loras_cpu`` cached in pinned host memory; beyond
+    # that adapters fall back to their disk_path on next use.
+    max_loras_cpu: int = 16
+    lora_buffer_groups: str = "attn,mlp,moe"
+    lora_moe_compressed_shared_outer: bool = False
+    lora_scheduling_policy: str = "lru"
+
     @staticmethod
     def from_server_args(
         server_args: ServerArgs,
@@ -281,6 +293,16 @@ class ModelExecutorConfig:
             use_v4_mtp_paged_metadata=model_config.use_v4_mtp_paged_metadata,
             grammar_backend=server_args.grammar_backend,
             disable_capturable_grammar=server_args.disable_capturable_grammar,
+            enable_lora=server_args.enable_lora,
+            max_loras=server_args.max_loras,
+            max_lora_rank=server_args.max_lora_rank,
+            max_loras_cpu=server_args.max_loras_cpu or 4 * server_args.max_loras,
+            lora_buffer_groups=server_args.lora_buffer_groups,
+            lora_moe_compressed_shared_outer=(
+                server_args.lora_moe_compressed_shared_outer
+            ),
+            lora_scheduling_policy=server_args.lora_scheduling_policy,
+            mamba_cache_chunk_size=server_args.mamba_cache_chunk_size,
         )
 
 
@@ -336,6 +358,12 @@ class ModelExecutor:
         self._logical_page_size = int(
             getattr(draft_token_to_kv_pool, "page_size", 0) or config.logical_page_size
         )
+
+        # LoRA - created before CudaGraphWrapper so captured graphs include
+        # the LoRA delta path (NO_LORA_SLOT = no adapter).
+        self.lora_manager = None
+        self.request_lora_ids: dict[str, int] = {}
+
         self._draft_page_size = int(
             getattr(draft_attn_backend, "page_size", 0) or self._logical_page_size
         )
@@ -487,6 +515,39 @@ class ModelExecutor:
         self._active_multimodal_context = None
         self._active_positions_override = None
 
+        if config.enable_lora:
+            from tokenspeed.runtime.lora.lora_manager import LoraManager
+
+            model = self.model_runner.model
+            lora_dtype = next(model.parameters()).dtype
+            lora_device = next(model.parameters()).device
+            attn_mapping = model_runner.mapping.attn
+            tp_size = attn_mapping.tp_size
+            tp_rank = attn_mapping.tp_rank
+            # ``tp_group`` is the rank-tuple expected by comm_ops.all_reduce
+            # (it routes through the codebase's graph-capturable backend).
+            tp_group = attn_mapping.tp_group if tp_size > 1 else None
+            self.lora_manager = LoraManager(
+                model_config=model_runner.model_config.hf_config,
+                max_loras=config.max_loras,
+                max_lora_rank=config.max_lora_rank,
+                max_num_tokens=config.chunked_prefill_size,
+                max_loras_cpu=config.max_loras_cpu,
+                dtype=lora_dtype,
+                device=lora_device,
+                tp_rank=tp_rank,
+                tp_size=tp_size,
+                tp_group=tp_group,
+                lora_buffer_groups={
+                    group.strip()
+                    for group in config.lora_buffer_groups.split(",")
+                    if group.strip()
+                },
+                lora_moe_compressed_shared_outer=(
+                    config.lora_moe_compressed_shared_outer
+                ),
+            )
+
         self.forward_step = CudaGraphWrapper(
             forward_func=self._forward_step,
             attn_backend=attn_backend,
@@ -500,6 +561,7 @@ class ModelExecutor:
             eager_grammar_buffers=self.eager_grammar_buffers,
             sampling_backend=self.sampling_backend,
             runtime_states=self.runtime_states,
+            lora_manager=self.lora_manager,
         )
         # Eager warmup can be DP-asymmetric; prewarm RSAG under uniform dummy inputs.
         if config.enforce_eager:
@@ -1412,6 +1474,21 @@ class ModelExecutor:
                     gather_ids=gather_ids,
                     decode_input_ids=decode_input_ids,
                 )
+                # Bind LoRA when adapters are active.  ``prepare_loras``
+                # writes per-segment metadata into the manager's persistent
+                # ``batch_info`` (the captured graph already references
+                # those tensors); we set ``ctx.lora_manager`` so the
+                # forward layers call into the LoRA delta path.
+                if self.lora_manager is not None and bs > 0:
+                    lora_ids = [
+                        self.request_lora_ids.get(rid, 0)
+                        for rid in forward_op.request_ids
+                    ]
+                    self.lora_manager.prepare_loras(
+                        lora_ids, list(forward_op.input_lengths)
+                    )
+                    if any(lid != 0 for lid in lora_ids):
+                        ctx.lora_manager = self.lora_manager
                 if self.config.data_parallel_size > 1:
                     if dp_global_num_tokens is None:
                         raise RuntimeError(

--- a/python/tokenspeed/runtime/execution/model_runner.py
+++ b/python/tokenspeed/runtime/execution/model_runner.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from tokenspeed.runtime.execution.context import bind_forward_context
 from tokenspeed.runtime.execution.multimodal_runtime import MultimodalRuntime
 from tokenspeed.runtime.execution.weight_loader import WeightLoader
 from tokenspeed.runtime.layers.moe.utils import initialize_moe_config
@@ -220,13 +221,14 @@ class ModelRunner:
         if kv_sync_event is not None:
             kwargs["kv_sync_event"] = kv_sync_event
 
-        return self.model.forward(
-            ctx,
-            input_ids,
-            positions,
-            out_cache_loc,
-            **kwargs,
-        )
+        with bind_forward_context(ctx):
+            return self.model.forward(
+                ctx,
+                input_ids,
+                positions,
+                out_cache_loc,
+                **kwargs,
+            )
 
     # ------------------------------------------------------------------ #
     # RL online weight sync: receive NCCL-broadcast weights from a trainer.

--- a/python/tokenspeed/runtime/layers/logits_processor.py
+++ b/python/tokenspeed/runtime/layers/logits_processor.py
@@ -41,7 +41,10 @@ from tokenspeed.runtime.distributed.comm_ops import all_gather_into_tensor
 from tokenspeed.runtime.distributed.process_group_manager import (
     process_group_manager as pg_manager,
 )
-from tokenspeed.runtime.execution.context import ForwardContext
+from tokenspeed.runtime.execution.context import (
+    ForwardContext,
+    get_current_lora_manager,
+)
 from tokenspeed.runtime.execution.forward_batch_info import (
     CaptureHiddenMode,
     ForwardMode,
@@ -598,6 +601,10 @@ class LogitsProcessor(nn.Module):
 
         if self.logit_scale is not None:
             logits.mul_(self.logit_scale)
+
+        lora_manager = get_current_lora_manager()
+        if lora_manager is not None and lora_manager.enable_head_lora:
+            logits = lora_manager.apply_lm_head_lora(hidden_states, logits)
 
         if dp_sampling and not self.skip_all_gather:
             if self._logits_layout_executor is None:

--- a/python/tokenspeed/runtime/lora/__init__.py
+++ b/python/tokenspeed/runtime/lora/__init__.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""LoRA adapter serving runtime."""
+
+from tokenspeed.runtime.lora.lora_config import LoraConfig
+
+__all__ = ["LoraConfig", "LoraRegistry"]
+
+
+def __getattr__(name: str):
+    if name == "LoraRegistry":
+        from tokenspeed.runtime.lora.lora_registry import LoraRegistry
+
+        return LoraRegistry
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/tokenspeed/runtime/lora/adapter_io.py
+++ b/python/tokenspeed/runtime/lora/adapter_io.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""PEFT LoRA adapter loading and metadata helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+
+import torch
+
+PEFT_ATTN_MODULES = ("q_proj", "k_proj", "v_proj", "o_proj")
+PEFT_MLP_MODULES = ("gate_proj", "up_proj", "down_proj")
+PEFT_EXPERT_MODULES = PEFT_MLP_MODULES
+PEFT_HEAD_MODULE = "lm_head"
+PEFT_MODULES = (*PEFT_ATTN_MODULES, *PEFT_MLP_MODULES)
+
+# Sentinel layer_id used for model-global modules (e.g. lm_head) that have no
+# per-layer index in AdapterWeights.
+LORA_HEAD_LAYER_ID = -1
+
+AdapterWeights = dict[int, dict[str, tuple[torch.Tensor, torch.Tensor]]]
+
+
+def resolve_adapter_weight_path(adapter_path: str) -> str:
+    safetensors_path = os.path.join(adapter_path, "adapter_model.safetensors")
+    return safetensors_path if os.path.exists(safetensors_path) else adapter_path
+
+
+def load_adapter_weights(adapter_path: str) -> AdapterWeights:
+    return parse_adapter_weights(
+        load_safetensors(resolve_adapter_weight_path(adapter_path))
+    )
+
+
+def load_safetensors(path: str) -> dict[str, torch.Tensor]:
+    from safetensors import safe_open
+
+    tensors: dict[str, torch.Tensor] = {}
+    with safe_open(path, framework="pt", device="cpu") as f:
+        for key in f.keys():
+            tensors[key] = f.get_tensor(key)
+    return tensors
+
+
+def parse_adapter_weights(tensors: dict[str, torch.Tensor]) -> AdapterWeights:
+    """Return ``{layer_id: {module_name: (lora_A, lora_B)}}``.
+
+    Matches attention (``self_attn.{q,k,v,o}_proj``), MLP
+    (``mlp.{gate,up,down}_proj``), and lm_head PEFT module names.
+    lm_head weights are stored under ``LORA_HEAD_LAYER_ID`` (-1).
+    """
+    dense_pattern = re.compile(
+        r"base_model\.model\.model\.layers\.(\d+)\."
+        r"(?:self_attn|mlp)\."
+        r"(q_proj|k_proj|v_proj|o_proj|gate_proj|up_proj|down_proj)\."
+        r"lora_(A|B)\.weight"
+    )
+    expert_pattern = re.compile(
+        r"base_model\.model\.model\.layers\.(\d+)\."
+        r"mlp\.experts\.(\d+)\."
+        r"(gate_proj|up_proj|down_proj)\."
+        r"lora_(A|B)\.weight"
+    )
+    expert_3d_pattern = re.compile(
+        r"base_model\.model\.model\.layers\.(\d+)\."
+        r"mlp\.experts\."
+        r"(w1|w2|w3)\."
+        r"lora_(A|B)\.weight"
+    )
+    # PEFT uses ``lora_embedding_A/B`` (no ``.weight`` suffix) for modules
+    # treated as embedding tables (lm_head, embed_tokens).
+    head_pattern = re.compile(
+        r"base_model\.model\.lm_head\." r"(?:lora_(A|B)\.weight|lora_embedding_(A|B))"
+    )
+    weights: dict[int, dict[str, dict[str, torch.Tensor]]] = {}
+    for key, tensor in tensors.items():
+        m = dense_pattern.match(key)
+        if m:
+            layer_id, module, ab = int(m.group(1)), m.group(2), m.group(3)
+        else:
+            m = expert_pattern.match(key)
+            if m:
+                layer_id = int(m.group(1))
+                module = f"experts.{int(m.group(2))}.{m.group(3)}"
+                ab = m.group(4)
+            else:
+                m = expert_3d_pattern.match(key)
+                if m:
+                    layer_id = int(m.group(1))
+                    module = f"experts.{m.group(2)}"
+                    ab = m.group(3)
+                else:
+                    m = head_pattern.match(key)
+                    if not m:
+                        continue
+                    layer_id = LORA_HEAD_LAYER_ID
+                    module = PEFT_HEAD_MODULE
+                    ab = m.group(1) or m.group(2)
+        weights.setdefault(layer_id, {}).setdefault(module, {})[ab] = tensor
+
+    result: AdapterWeights = {}
+    for layer_id, modules in weights.items():
+        result[layer_id] = {}
+        for module, ab_dict in modules.items():
+            result[layer_id][module] = (ab_dict["A"], ab_dict["B"])
+    return result
+
+
+def read_adapter_scaling(adapter_path: str | None, rank: int) -> float:
+    if adapter_path is None:
+        return 1.0
+    config_file = os.path.join(adapter_path, "adapter_config.json")
+    if not os.path.exists(config_file):
+        return 1.0
+    try:
+        with open(config_file) as f:
+            cfg = json.load(f)
+        alpha = float(cfg.get("lora_alpha", rank))
+        r = int(cfg.get("r", rank))
+        return alpha / r if r > 0 else 1.0
+    except Exception:
+        return 1.0

--- a/python/tokenspeed/runtime/lora/lora_batch.py
+++ b/python/tokenspeed/runtime/lora/lora_batch.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Batch metadata structures for segmented LoRA kernels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+NO_LORA_SLOT = -1
+
+
+@dataclass
+class LoraBatchInfo:
+    """Per-step segment metadata read by the LoRA kernels.
+
+    All tensors live on the LoRA device.  When the captured CUDA graph needs
+    persistent storage, :class:`LoraManager` pre-allocates these tensors with
+    maximum sizes; runtime fills the prefix and updates ``bs`` / ``max_len``.
+    """
+
+    bs: int
+    num_segments: int
+    max_len: int
+    seg_lens: torch.Tensor  # (num_segments,) int32
+    seg_indptr: torch.Tensor  # (num_segments + 1,) int32
+    weight_indices: torch.Tensor  # (num_segments,) int32
+    lora_ranks: torch.Tensor  # (n_slots,) int32; NO_LORA_SLOT means base model
+    scalings: torch.Tensor  # (n_slots,) float32
+    permutation: torch.Tensor | None = None  # unused (no sort by adapter yet)
+    # Adapter-group metadata for lora_expand_grouped_v2_fwd (decode path only).
+    # Populated by prepare_loras when max_len == 1.
+    sort_order: torch.Tensor | None = None  # (bs,) int64
+    group_slots: torch.Tensor | None = None  # (num_groups,) int32
+    group_starts: torch.Tensor | None = None  # (num_groups,) int32
+    group_sizes: torch.Tensor | None = None  # (num_groups,) int32
+    num_groups: int = 0
+    # Largest group size; pre-computed on CPU so the kernel grid avoids a
+    # GPU-CPU sync.  Equals max(group_sizes) when num_groups > 0, else 0.
+    max_group_size: int = 0
+    # Host-only fast-path metadata. Non-negative iff every segment in this step
+    # uses the same real adapter slot; NO_LORA_SLOT means mixed/base-only.
+    single_lora_slot: int = NO_LORA_SLOT
+    # Host-only active rank for ``single_lora_slot``. Zero when no single
+    # nonzero adapter slot is active.
+    single_lora_rank: int = 0
+    # Host-only metadata for the multi-adapter batched CuTeDSL fast path.
+    # Non-negative iff segments are equal-length, slots are consecutive, and
+    # all participating slots share rank/scaling.
+    multi_lora_start_slot: int = NO_LORA_SLOT
+    multi_lora_count: int = 0
+    multi_lora_segment_len: int = 0
+    multi_lora_rank: int = 0
+
+
+def build_decode_lora_groups(
+    per_request_slots: list[int],
+) -> tuple[list[int], list[int], list[int], list[int]]:
+    """Group decode requests by adapter slot for the grouped expand kernel.
+
+    Returns ``(sort_order, group_slots, group_starts, group_sizes)``.
+    ``group_starts`` are offsets into ``sort_order``.
+    """
+    sort_order = sorted(
+        (i for i, slot in enumerate(per_request_slots) if slot != NO_LORA_SLOT),
+        key=lambda i: per_request_slots[i],
+    )
+    group_slots: list[int] = []
+    group_starts: list[int] = []
+    group_sizes: list[int] = []
+    for pos, orig in enumerate(sort_order):
+        slot = per_request_slots[orig]
+        if not group_slots or group_slots[-1] != slot:
+            group_slots.append(slot)
+            group_starts.append(pos)
+            group_sizes.append(1)
+        else:
+            group_sizes[-1] += 1
+    return sort_order, group_slots, group_starts, group_sizes

--- a/python/tokenspeed/runtime/lora/lora_buffers.py
+++ b/python/tokenspeed/runtime/lora/lora_buffers.py
@@ -1,0 +1,332 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""GPU-resident LoRA weight buffer layout and slot loading."""
+
+from __future__ import annotations
+
+import torch
+
+from tokenspeed.runtime.lora.adapter_io import (
+    LORA_HEAD_LAYER_ID,
+    PEFT_HEAD_MODULE,
+    AdapterWeights,
+)
+
+LORA_BUFFER_GROUPS = frozenset({"attn", "mlp", "moe", "lm_head"})
+
+
+class LoraWeightBuffers:
+    def __init__(
+        self,
+        *,
+        n_layers: int,
+        n_slots: int,
+        max_lora_rank: int,
+        hidden_size: int,
+        q_size_per_tp: int,
+        kv_size_per_tp: int,
+        o_in_per_tp: int,
+        intermediate_per_tp: int,
+        vocab_per_tp: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        tp_rank: int,
+        tp_size: int,
+        buffer_groups: set[str] | frozenset[str] = LORA_BUFFER_GROUPS,
+    ) -> None:
+        self.n_layers = n_layers
+        self.n_slots = n_slots
+        self.max_lora_rank = max_lora_rank
+        self.hidden_size = hidden_size
+        self.q_size_per_tp = q_size_per_tp
+        self.kv_size_per_tp = kv_size_per_tp
+        self.o_in_per_tp = o_in_per_tp
+        self.intermediate_per_tp = intermediate_per_tp
+        self.vocab_per_tp = vocab_per_tp
+        self.dtype = dtype
+        self.device = device
+        self.tp_rank = tp_rank
+        self.tp_size = tp_size
+        unknown_groups = set(buffer_groups) - LORA_BUFFER_GROUPS
+        if unknown_groups:
+            raise ValueError(f"Unknown LoRA buffer groups: {sorted(unknown_groups)}")
+        self.buffer_groups = frozenset(buffer_groups)
+        self.enable_attn = "attn" in self.buffer_groups
+        self.enable_mlp = "mlp" in self.buffer_groups
+        self.enable_head = "lm_head" in self.buffer_groups
+
+        self.qkv_A_buffers: list[torch.Tensor] = []
+        self.qkv_B_buffers: list[torch.Tensor] = []
+        self.o_A_buffers: list[torch.Tensor] = []
+        self.o_B_buffers: list[torch.Tensor] = []
+        self.gate_up_A_buffers: list[torch.Tensor] = []
+        self.gate_up_B_buffers: list[torch.Tensor] = []
+        self.down_A_buffers: list[torch.Tensor] = []
+        self.down_B_buffers: list[torch.Tensor] = []
+        # lm_head LoRA — single pair of buffers (not per-layer).
+        # A: (n_slots, r, hidden)  — replicated across TP ranks.
+        # B: (n_slots, vocab_per_tp, r) — column-parallel shard.
+        self.lm_head_A_buffer: torch.Tensor
+        self.lm_head_B_buffer: torch.Tensor
+
+        self.qkv_output_offset = torch.tensor(
+            [
+                0,
+                q_size_per_tp,
+                q_size_per_tp + kv_size_per_tp,
+                q_size_per_tp + 2 * kv_size_per_tp,
+            ],
+            dtype=torch.int32,
+            device=device,
+        )
+        self.max_qkv_out_dim = max(q_size_per_tp, kv_size_per_tp)
+
+        self.o_slice_offsets = torch.tensor(
+            [0, hidden_size], dtype=torch.int32, device=device
+        )
+        self.gate_up_slice_offsets = torch.tensor(
+            [0, intermediate_per_tp, 2 * intermediate_per_tp],
+            dtype=torch.int32,
+            device=device,
+        )
+        self.down_slice_offsets = torch.tensor(
+            [0, hidden_size], dtype=torch.int32, device=device
+        )
+
+        self._alloc()
+
+    def _alloc(self) -> None:
+        r = self.max_lora_rank
+        h = self.hidden_size
+        q = self.q_size_per_tp
+        kv = self.kv_size_per_tp
+        o_in = self.o_in_per_tp
+        i = self.intermediate_per_tp
+        v = self.vocab_per_tp
+        n = self.n_slots
+
+        for _ in range(self.n_layers):
+            if self.enable_attn:
+                self.qkv_A_buffers.append(
+                    torch.zeros((n, 3 * r, h), dtype=self.dtype, device=self.device)
+                )
+                self.qkv_B_buffers.append(
+                    torch.zeros(
+                        (n, q + 2 * kv, r), dtype=self.dtype, device=self.device
+                    )
+                )
+                self.o_A_buffers.append(
+                    torch.zeros((n, r, o_in), dtype=self.dtype, device=self.device)
+                )
+                self.o_B_buffers.append(
+                    torch.zeros((n, h, r), dtype=self.dtype, device=self.device)
+                )
+            if self.enable_mlp:
+                self.gate_up_A_buffers.append(
+                    torch.zeros((n, 2 * r, h), dtype=self.dtype, device=self.device)
+                )
+                self.gate_up_B_buffers.append(
+                    torch.zeros((n, 2 * i, r), dtype=self.dtype, device=self.device)
+                )
+                self.down_A_buffers.append(
+                    torch.zeros((n, r, i), dtype=self.dtype, device=self.device)
+                )
+                self.down_B_buffers.append(
+                    torch.zeros((n, h, r), dtype=self.dtype, device=self.device)
+                )
+        if self.enable_head:
+            self.lm_head_A_buffer = torch.zeros(
+                (n, r, h), dtype=self.dtype, device=self.device
+            )
+            self.lm_head_B_buffer = torch.zeros(
+                (n, v, r), dtype=self.dtype, device=self.device
+            )
+
+    def load_adapter_to_slot(
+        self,
+        cpu_weights: AdapterWeights,
+        slot: int,
+        rank: int,
+    ) -> None:
+        for layer_id, modules in cpu_weights.items():
+            if layer_id == LORA_HEAD_LAYER_ID:
+                if PEFT_HEAD_MODULE in modules:
+                    self._load_lm_head_to_slot(modules[PEFT_HEAD_MODULE], slot, rank)
+                continue
+            for mod, (lora_A_full, lora_B_full) in modules.items():
+                if mod.startswith("experts."):
+                    continue
+                self._check_module_enabled(mod)
+                lora_A_shard_cpu, lora_B_shard_cpu = self.shard_weights(
+                    mod, lora_A_full, lora_B_full
+                )
+                r = min(lora_A_shard_cpu.shape[0], rank)
+                lora_A_shard = lora_A_shard_cpu[:r].to(
+                    device=self.device,
+                    dtype=self.dtype,
+                    non_blocking=True,
+                )
+                lora_B_shard = lora_B_shard_cpu[:, :r].to(
+                    device=self.device,
+                    dtype=self.dtype,
+                    non_blocking=True,
+                )
+
+                if mod in ("q_proj", "k_proj", "v_proj"):
+                    qkv_idx = ("q_proj", "k_proj", "v_proj").index(mod)
+                    rank_off = qkv_idx * r
+                    out_off, out_size = self.qkv_b_slice(mod)
+                    self.qkv_A_buffers[layer_id][
+                        slot, rank_off : rank_off + r, :
+                    ].copy_(lora_A_shard, non_blocking=True)
+                    self.qkv_B_buffers[layer_id][
+                        slot, out_off : out_off + out_size, :r
+                    ].copy_(lora_B_shard, non_blocking=True)
+                elif mod == "o_proj":
+                    self.o_A_buffers[layer_id][slot, :r, :].copy_(
+                        lora_A_shard, non_blocking=True
+                    )
+                    self.o_B_buffers[layer_id][slot, :, :r].copy_(
+                        lora_B_shard, non_blocking=True
+                    )
+                elif mod in ("gate_proj", "up_proj"):
+                    gate_up_idx = 0 if mod == "gate_proj" else 1
+                    rank_off = gate_up_idx * r
+                    out_off = gate_up_idx * self.intermediate_per_tp
+                    self.gate_up_A_buffers[layer_id][
+                        slot, rank_off : rank_off + r, :
+                    ].copy_(lora_A_shard, non_blocking=True)
+                    self.gate_up_B_buffers[layer_id][
+                        slot, out_off : out_off + self.intermediate_per_tp, :r
+                    ].copy_(lora_B_shard, non_blocking=True)
+                else:
+                    self.down_A_buffers[layer_id][slot, :r, :].copy_(
+                        lora_A_shard, non_blocking=True
+                    )
+                    self.down_B_buffers[layer_id][slot, :, :r].copy_(
+                        lora_B_shard, non_blocking=True
+                    )
+
+    def _load_lm_head_to_slot(
+        self,
+        ab: tuple[torch.Tensor, torch.Tensor],
+        slot: int,
+        rank: int,
+    ) -> None:
+        if not self.enable_head:
+            raise ValueError(
+                "Adapter targets lm_head, but LoRA buffer group 'head' is disabled."
+            )
+        lora_A_full, lora_B_full = ab
+        lora_A_cpu, lora_B_cpu = self.shard_weights(
+            PEFT_HEAD_MODULE, lora_A_full, lora_B_full
+        )
+        r = min(lora_A_cpu.shape[0], rank)
+        self.lm_head_A_buffer[slot, :r, :].copy_(
+            lora_A_cpu[:r].to(device=self.device, dtype=self.dtype, non_blocking=True),
+            non_blocking=True,
+        )
+        self.lm_head_B_buffer[slot, :, :r].copy_(
+            lora_B_cpu[:, :r].to(
+                device=self.device, dtype=self.dtype, non_blocking=True
+            ),
+            non_blocking=True,
+        )
+
+    def zero_slot(self, slot: int) -> None:
+        if self.enable_attn:
+            for layer_id in range(self.n_layers):
+                self.qkv_A_buffers[layer_id][slot].zero_()
+                self.qkv_B_buffers[layer_id][slot].zero_()
+                self.o_A_buffers[layer_id][slot].zero_()
+                self.o_B_buffers[layer_id][slot].zero_()
+        if self.enable_mlp:
+            for layer_id in range(self.n_layers):
+                self.gate_up_A_buffers[layer_id][slot].zero_()
+                self.gate_up_B_buffers[layer_id][slot].zero_()
+                self.down_A_buffers[layer_id][slot].zero_()
+                self.down_B_buffers[layer_id][slot].zero_()
+        if self.enable_head:
+            self.lm_head_A_buffer[slot].zero_()
+            self.lm_head_B_buffer[slot].zero_()
+
+    def _check_module_enabled(self, module: str) -> None:
+        if module in ("q_proj", "k_proj", "v_proj", "o_proj"):
+            if not self.enable_attn:
+                raise ValueError(
+                    f"Adapter targets {module}, but LoRA buffer group 'attn' "
+                    "is disabled."
+                )
+            return
+        if module in ("gate_proj", "up_proj", "down_proj"):
+            if not self.enable_mlp:
+                raise ValueError(
+                    f"Adapter targets {module}, but LoRA buffer group 'mlp' "
+                    "is disabled."
+                )
+            return
+        if module == PEFT_HEAD_MODULE:
+            if not self.enable_head:
+                raise ValueError(
+                    "Adapter targets lm_head, but LoRA buffer group 'head' "
+                    "is disabled."
+                )
+            return
+        raise ValueError(f"Unsupported dense LoRA module: {module}")
+
+    def qkv_b_slice(self, module: str) -> tuple[int, int]:
+        """Return ``(offset, size)`` of a projection inside fused QKV B."""
+        if module == "q_proj":
+            return 0, self.q_size_per_tp
+        if module == "k_proj":
+            return self.q_size_per_tp, self.kv_size_per_tp
+        return self.q_size_per_tp + self.kv_size_per_tp, self.kv_size_per_tp
+
+    def shard_weights(
+        self,
+        module: str,
+        lora_A: torch.Tensor,
+        lora_B: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.tp_size == 1:
+            return lora_A, lora_B
+        # Column-parallel (attn q/k/v, MLP gate/up, lm_head): shard B along output dim.
+        if module in (
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "gate_proj",
+            "up_proj",
+            PEFT_HEAD_MODULE,
+        ):
+            out_total = lora_B.shape[0]
+            out_per = out_total // self.tp_size
+            return (
+                lora_A,
+                lora_B[self.tp_rank * out_per : (self.tp_rank + 1) * out_per],
+            )
+        # Row-parallel (attn o_proj, MLP down_proj): shard A along input dim.
+        in_total = lora_A.shape[1]
+        in_per = in_total // self.tp_size
+        return (
+            lora_A[:, self.tp_rank * in_per : (self.tp_rank + 1) * in_per],
+            lora_B,
+        )

--- a/python/tokenspeed/runtime/lora/lora_cache.py
+++ b/python/tokenspeed/runtime/lora/lora_cache.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tier-2 CPU LoRA adapter cache with async disk prefetch."""
+
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+
+import torch
+
+from tokenspeed.runtime.lora.adapter_io import AdapterWeights, load_adapter_weights
+from tokenspeed.runtime.utils import get_colorful_logger
+
+logger = get_colorful_logger(__name__)
+
+
+class LoraCpuCache:
+    def __init__(
+        self,
+        *,
+        capacity: int,
+        is_gpu_resident: Callable[[str], bool],
+    ) -> None:
+        self.capacity = capacity
+        self.is_gpu_resident = is_gpu_resident
+        self.cache: dict[str, AdapterWeights] = {}
+        self.lru: OrderedDict[str, None] = OrderedDict()
+        self.adapter_paths: dict[str, str] = {}
+        self.loader_executor = ThreadPoolExecutor(
+            max_workers=2, thread_name_prefix="lora-loader"
+        )
+        self.lock = threading.Lock()
+        self.pending_loads: dict[str, Future] = {}
+
+    def set_path(self, name: str, adapter_path: str) -> None:
+        self.adapter_paths[name] = adapter_path
+
+    def remove(self, name: str) -> None:
+        self.evict(name)
+        self.adapter_paths.pop(name, None)
+        with self.lock:
+            self.pending_loads.pop(name, None)
+
+    def prefetch(self, name: str) -> None:
+        """Best-effort async warm of the CPU pool for *name*."""
+        with self.lock:
+            if name in self.cache:
+                self.lru.move_to_end(name)
+                return
+            if name in self.pending_loads:
+                return
+            adapter_path = self.adapter_paths.get(name)
+            if adapter_path is None:
+                return
+            fut = self.loader_executor.submit(
+                self._async_load_weights, name, adapter_path
+            )
+            self.pending_loads[name] = fut
+
+    def ensure(
+        self,
+        name: str,
+        weights: AdapterWeights | None = None,
+    ) -> None:
+        """Synchronously ensure *name* is CPU-resident."""
+        with self.lock:
+            if name in self.cache:
+                self.lru.move_to_end(name)
+                return
+            pending = self.pending_loads.get(name)
+
+        if pending is not None:
+            pending.result()
+            with self.lock:
+                if name in self.cache:
+                    self.lru.move_to_end(name)
+                    return
+
+        if weights is None:
+            adapter_path = self.adapter_paths.get(name)
+            if adapter_path is None:
+                raise KeyError(f"Adapter '{name}' has no recorded disk path.")
+            weights = load_adapter_weights(adapter_path)
+
+        with self.lock:
+            if name in self.cache:
+                self.lru.move_to_end(name)
+                return
+            self._install_locked(name, weights)
+
+    def evict(self, name: str) -> None:
+        with self.lock:
+            self._evict_locked(name)
+
+    def _async_load_weights(self, name: str, adapter_path: str) -> None:
+        try:
+            weights = load_adapter_weights(adapter_path)
+        except Exception:
+            logger.exception("Async LoRA load failed for '%s'", name)
+            with self.lock:
+                self.pending_loads.pop(name, None)
+            return
+        with self.lock:
+            try:
+                if name not in self.cache:
+                    self._install_locked(name, weights)
+            finally:
+                self.pending_loads.pop(name, None)
+
+    def _install_locked(self, name: str, weights: AdapterWeights) -> None:
+        while len(self.cache) >= self.capacity:
+            evicted = False
+            # Prefer evicting non-GPU-resident entries first: they cost a disk
+            # read to bring back, while GPU-resident ones cost nothing until
+            # their GPU slot is also evicted.
+            for stage in ("non_gpu", "gpu_resident"):
+                for candidate in list(self.lru.keys()):
+                    if candidate == name:
+                        continue
+                    is_gpu = self.is_gpu_resident(candidate)
+                    if stage == "non_gpu" and is_gpu:
+                        continue
+                    self._evict_locked(candidate)
+                    evicted = True
+                    break
+                if evicted:
+                    break
+            if not evicted:
+                raise RuntimeError(
+                    f"CPU LoRA pool is full ({len(self.cache)}/{self.capacity}) "
+                    "and no evictable entry was found. "
+                    f"cpu_lru={list(self.lru.keys())}. "
+                    "Increase max_loras_cpu."
+                )
+        self.cache[name] = self._pin_weights(weights)
+        self.lru[name] = None
+
+    def _evict_locked(self, name: str) -> None:
+        if name in self.cache:
+            del self.cache[name]
+            self.lru.pop(name, None)
+            logger.debug(
+                "Evicted '%s' from CPU pool (now %d/%d)",
+                name,
+                len(self.cache),
+                self.capacity,
+            )
+
+    def _pin_weights(self, weights: AdapterWeights) -> AdapterWeights:
+        return {
+            layer_id: {
+                module: (
+                    self._pin_tensor(lora_A),
+                    self._pin_tensor(lora_B),
+                )
+                for module, (lora_A, lora_B) in modules.items()
+            }
+            for layer_id, modules in weights.items()
+        }
+
+    @staticmethod
+    def _pin_tensor(tensor: torch.Tensor) -> torch.Tensor:
+        if tensor.device.type != "cpu" or tensor.is_pinned():
+            return tensor
+        try:
+            return tensor.pin_memory()
+        except RuntimeError:
+            return tensor

--- a/python/tokenspeed/runtime/lora/lora_config.py
+++ b/python/tokenspeed/runtime/lora/lora_config.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""LoRA adapter configuration and metadata."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+
+
+@dataclass
+class LoraConfig:
+    """Configuration for a single LoRA adapter.
+
+    Loaded from the adapter's ``adapter_config.json`` (PEFT format).
+    """
+
+    # Identifier used at request time (e.g. "sql-expert")
+    name: str
+
+    # Filesystem path to the adapter directory or file
+    path: str
+
+    # LoRA rank (r)
+    r: int = 16
+
+    # LoRA alpha scaling factor
+    lora_alpha: int = 16
+
+    # Target modules (e.g. ["q_proj", "v_proj"])
+    target_modules: list[str] = field(default_factory=list)
+
+    # Base model name for compatibility checking
+    base_model_name_or_path: str | None = None
+
+    @classmethod
+    def from_path(cls, name: str, path: str) -> "LoraConfig":
+        """Load LoraConfig from a PEFT adapter directory."""
+        config_file = os.path.join(path, "adapter_config.json")
+        if not os.path.exists(config_file):
+            raise FileNotFoundError(
+                f"adapter_config.json not found at {config_file}. "
+                "The path must point to a PEFT-format adapter directory."
+            )
+        with open(config_file) as f:
+            raw = json.load(f)
+
+        return cls(
+            name=name,
+            path=path,
+            r=raw.get("r", 16),
+            lora_alpha=raw.get("lora_alpha", 16),
+            target_modules=raw.get("target_modules") or [],
+            base_model_name_or_path=raw.get("base_model_name_or_path"),
+        )
+
+    @property
+    def scaling(self) -> float:
+        return self.lora_alpha / self.r if self.r > 0 else 1.0

--- a/python/tokenspeed/runtime/lora/lora_manager.py
+++ b/python/tokenspeed/runtime/lora/lora_manager.py
@@ -1,0 +1,1155 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""LoRA adapter weight manager (segment-grouped Triton path).
+
+Adapted from sglang/Punica's S-LoRA design.
+
+Memory layout
+-------------
+For each layer the manager owns:
+
+* ``qkv_A_buffers[layer]``: ``(n_slots, 3 * max_rank, hidden)`` — fused
+  q_proj/k_proj/v_proj A matrices, stack-major (q first, then k, then v).
+* ``qkv_B_buffers[layer]``: ``(n_slots, q_per_tp + 2 * kv_per_tp, max_rank)``
+  — fused output-side, ``[q_per_tp | kv_per_tp | kv_per_tp]`` along dim 1.
+* ``o_A_buffers[layer]``:   ``(n_slots, max_rank, in_per_tp)`` — row-parallel
+  A, sharded along input dim.
+* ``o_B_buffers[layer]``:   ``(n_slots, hidden, max_rank)`` — full B.
+
+No-LoRA requests use ``NO_LORA_SLOT`` (-1), matching vLLM's convention.
+Real adapters occupy slots ``0 .. max_loras - 1``.
+
+Tensor parallelism
+------------------
+* QKV is column-parallel: A is full, B is sharded along output dim
+  (``q_per_tp + 2 * kv_per_tp``).  No collective inside the LoRA path.
+* O is row-parallel: A is sharded along input dim, B is full.  The host
+  module (qwen3 ``o_proj``) runs with ``reduce_results=False`` and has its
+  partial sum all-reduced downstream by ``post_attention_layernorm``; the
+  LoRA delta rides that same reduction (full ``B @ lora_a`` is added to the
+  partial output and the downstream reduce sums it ``tp_size`` times — see
+  ``apply_o_lora`` for the resulting numerical caveat).
+"""
+
+from __future__ import annotations
+
+import os
+from collections import OrderedDict
+
+import torch
+from tokenspeed_kernel.ops.lora.triton import (
+    lora_expand_fwd,
+    lora_expand_grouped_v2_fwd,
+    lora_expand_prefill_fwd,
+    lora_gate_up_expand_fwd,
+    lora_qkv_expand_fwd,
+    lora_shrink_fwd,
+    lora_shrink_prefill_fwd,
+)
+
+from tokenspeed.runtime.lora.adapter_io import (
+    LORA_HEAD_LAYER_ID,
+    PEFT_HEAD_MODULE,
+    PEFT_MODULES,
+    read_adapter_scaling,
+    resolve_adapter_weight_path,
+)
+from tokenspeed.runtime.lora.lora_batch import (
+    NO_LORA_SLOT,
+    LoraBatchInfo,
+    build_decode_lora_groups,
+)
+from tokenspeed.runtime.lora.lora_buffers import LORA_BUFFER_GROUPS, LoraWeightBuffers
+from tokenspeed.runtime.lora.lora_cache import LoraCpuCache
+from tokenspeed.runtime.lora.moe_lora import MoeLoraBuffers, MoeLoraContext
+from tokenspeed.runtime.utils import get_colorful_logger
+
+# Segments longer than this use the prefill (chunked-SGMV) expand kernel,
+# which specialises strides and loop counts at compile time.  Shorter
+# segments (decode) use the decode-tuned kernels.  Threshold chosen from
+# benchmarks: chunked-SGMV wins above ~32 tokens/segment at rank ≥ 64.
+_CHUNKED_THRESHOLD = 32
+
+# With max_group_size-based grid, the kernel degenerates to the segmented
+# layout when every group has 1 token (n_unique = n), so no threshold is
+# needed for correctness.  Keep a minimum of 1 (always use grpv2).
+_TRITON_GROUPED_DECODE_MIN_GROUP_SIZE = 1
+
+logger = get_colorful_logger(__name__)
+
+
+# ── Manager ─────────────────────────────────────────────────────────────────
+
+
+def _use_triton_grouped_decode(bi: LoraBatchInfo) -> bool:
+    """Return whether grouped Triton decode expand should beat basic decode."""
+    return (
+        bi.single_lora_slot == NO_LORA_SLOT
+        and bi.num_groups > 0
+        and bi.bs // bi.num_groups >= _TRITON_GROUPED_DECODE_MIN_GROUP_SIZE
+    )
+
+
+class LoraManager:
+    """Owns GPU-resident LoRA weights and dispatches the segmented-GEMM path.
+
+    Public surface (used by the model + executor):
+
+    * :meth:`load_adapter` / :meth:`unload_adapter` — adapter lifecycle.
+    * :attr:`batch_info` — persistent :class:`LoraBatchInfo` whose tensor
+      pointers are stable across forward steps (so they can be baked into
+      the captured CUDA graph).
+    * :meth:`prepare_loras` — fill the persistent batch_info for one step.
+    * :meth:`apply_qkv_lora` / :meth:`apply_o_lora` — Triton-backed deltas.
+    """
+
+    def __init__(
+        self,
+        model_config,
+        max_loras: int,
+        max_lora_rank: int,
+        max_num_tokens: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        tp_rank: int = 0,
+        tp_size: int = 1,
+        tp_group=None,
+        max_loras_cpu: int | None = None,
+        lora_buffer_groups: set[str] | frozenset[str] = LORA_BUFFER_GROUPS,
+        lora_moe_compressed_shared_outer: bool = False,
+    ) -> None:
+        self.max_loras = max_loras
+        self.max_lora_rank = max_lora_rank
+        self.max_num_tokens = max_num_tokens
+        self.dtype = dtype
+        self.device = device
+        self.tp_rank = tp_rank
+        self.tp_size = tp_size
+        self.tp_group = tp_group
+        unknown_groups = set(lora_buffer_groups) - LORA_BUFFER_GROUPS
+        if unknown_groups:
+            raise ValueError(f"Unknown LoRA buffer groups: {sorted(unknown_groups)}")
+        self.lora_buffer_groups = frozenset(lora_buffer_groups)
+        self.enable_attn_lora = "attn" in self.lora_buffer_groups
+        self.enable_mlp_lora = "mlp" in self.lora_buffer_groups
+        self.enable_moe_lora = "moe" in self.lora_buffer_groups
+        self.enable_head_lora = "lm_head" in self.lora_buffer_groups
+        self.lora_moe_compressed_shared_outer = lora_moe_compressed_shared_outer
+        # Tier-2 CPU cache cap. Defaults to 4× the GPU pool so adapter
+        # spill-out to disk is rare in steady state.
+        self.max_loras_cpu: int = (
+            max_loras_cpu if max_loras_cpu is not None else 4 * max_loras
+        )
+        if self.max_loras_cpu < max_loras:
+            raise ValueError(
+                f"max_loras_cpu ({self.max_loras_cpu}) must be ≥ "
+                f"max_loras ({max_loras}); GPU-resident adapters live in "
+                "the CPU pool too."
+            )
+
+        self.n_layers: int = model_config.num_hidden_layers
+        hidden: int = model_config.hidden_size
+        n_heads: int = model_config.num_attention_heads
+        n_kv: int = model_config.num_key_value_heads
+        # Use the model's explicit head_dim when available (some architectures like
+        # Qwen3.5 decouple head_dim from hidden/n_heads, e.g. hidden=2048, n_heads=16
+        # but head_dim=256).
+        head_dim: int = getattr(model_config, "head_dim", None) or (hidden // n_heads)
+        # attn_output_gate doubles the Q projection size (2× heads in qkv_proj).
+        # The o_proj input is n_heads × head_dim (no doubling).
+        q_multiplier: int = 2 if getattr(model_config, "attn_output_gate", False) else 1
+        q_size_base: int = (n_heads // tp_size) * head_dim
+
+        self.q_size_per_tp: int = q_multiplier * q_size_base
+        self.kv_size_per_tp: int = max(1, n_kv // tp_size) * head_dim
+        self.o_in_per_tp: int = q_size_base  # o_proj reads un-gated heads
+        self.hidden_size: int = hidden
+
+        from tokenspeed.runtime.layers.vocab_parallel_embedding import pad_vocab_size
+
+        vocab_size: int = model_config.vocab_size
+        self.vocab_per_tp: int = pad_vocab_size(vocab_size) // tp_size
+
+        # Qwen3MLP is TP-aware: ``gate_up_proj`` is column-parallel (each rank
+        # holds ``intermediate_size // tp_size`` output cols) and ``down_proj``
+        # is row-parallel (each rank holds ``intermediate_size // tp_size``
+        # input cols).  The LoRA deltas ride the partial outputs of those base
+        # linears, and the existing downstream all-reduce sums per-rank
+        # partials — see ``apply_down_lora``/``apply_gate_up_lora``.
+        self.intermediate_size: int = getattr(
+            model_config, "intermediate_size", 4 * hidden
+        )
+        self.intermediate_per_tp: int = self.intermediate_size // self.tp_size
+        self.moe_intermediate_size: int = getattr(
+            model_config, "moe_intermediate_size", self.intermediate_size
+        )
+        self.moe_intermediate_per_tp: int = self.moe_intermediate_size // self.tp_size
+        self.num_experts: int = int(
+            getattr(
+                model_config,
+                "num_experts",
+                getattr(
+                    model_config,
+                    "num_local_experts",
+                    getattr(model_config, "n_routed_experts", 0),
+                ),
+            )
+        )
+
+        # CPU-side flag: True when at least one segment in the current
+        # batch_info uses a real adapter. CudaGraphWrapper
+        # reads this to pick the with-LoRA vs no-LoRA captured graph.
+        self.has_active_lora: bool = False
+
+        # ── Tier 1: GPU pool ─────────────────────────────────────────────
+        # Real adapters take slots 0 .. max_loras - 1. Base/no-LoRA requests
+        # use NO_LORA_SLOT in batch metadata and do not consume a GPU slot.
+        self._n_slots: int = max_loras
+        self._slot_to_name: list[str | None] = [None] * self._n_slots
+        self._name_to_slot: dict[str, int] = {}
+        self._gpu_lru: OrderedDict[str, None] = OrderedDict()  # alias of _lru
+
+        # Mid-decode unload safety: track which adapter names were active in
+        # the most recent prepare_loras call, and defer GPU weight eviction for
+        # any adapter that is unloaded while still in use.
+        self._active_names: set[str] = set()
+        self._pending_eviction: set[tuple[str, int]] = (
+            set()
+        )  # (name, lora_id) to evict when safe
+
+        # ── Tier 2: pinned CPU pool ─────────────────────────────────────
+        # ``_cpu_cache[name]`` holds parsed weights in pinned host memory.
+        # ``_cpu_lru`` tracks LRU order for CPU eviction back to disk.  An
+        # adapter is "CPU-resident" iff its name is in ``_cpu_cache``.
+        # GPU-resident adapters are also kept in ``_cpu_cache`` (we pay
+        # the host RAM cost once; reload to GPU is cheap and re-evicting
+        # GPU then re-promoting only needs an H2D copy, not a disk read).
+        self._name_to_id: dict[str, int] = {}
+        self._id_to_name: dict[int, str] = {}
+        self._next_id: int = 1
+
+        # ── Tier 2/3: CPU pinned pool + disk source of truth ─────────────
+        self._cpu_store = LoraCpuCache(
+            capacity=self.max_loras_cpu,
+            is_gpu_resident=lambda name: name in self._name_to_slot,
+        )
+        # Compatibility aliases for existing tests/debug tooling.
+        self._cpu_cache = self._cpu_store.cache
+        self._cpu_lru = self._cpu_store.lru
+        self._adapter_paths = self._cpu_store.adapter_paths
+        self._pending_loads = self._cpu_store.pending_loads
+
+        # Per-slot rank + scaling for real adapter slots only.
+        self._lora_ranks: torch.Tensor = torch.zeros(
+            self._n_slots, dtype=torch.int32, device=device
+        )
+        self._slot_ranks: list[int] = [0] * self._n_slots
+        self._slot_scalings: list[float] = [0.0] * self._n_slots
+        self._scalings: torch.Tensor = torch.zeros(
+            self._n_slots, dtype=torch.float32, device=device
+        )
+
+        # ── Persistent batch_info ──────────────────────────────────────────
+        # All tensors are sized for the worst case so their pointers are
+        # stable across forward steps; per-step updates are in-place.
+        # ``num_segments`` may equal ``bs`` (one segment per token in the
+        # current path — no sort-by-adapter yet).
+        self._batch_info = LoraBatchInfo(
+            bs=0,
+            num_segments=0,
+            max_len=0,
+            seg_lens=torch.zeros(max_num_tokens, dtype=torch.int32, device=device),
+            seg_indptr=torch.zeros(
+                max_num_tokens + 1, dtype=torch.int32, device=device
+            ),
+            weight_indices=torch.full(
+                (max_num_tokens,), NO_LORA_SLOT, dtype=torch.int32, device=device
+            ),
+            lora_ranks=self._lora_ranks,
+            scalings=self._scalings,
+            permutation=None,
+        )
+
+        # CPU staging buffers (pinned) for the per-step H2D copy.
+        self._seg_lens_cpu = torch.zeros(
+            max_num_tokens, dtype=torch.int32, pin_memory=True
+        )
+        self._weight_indices_cpu = torch.full(
+            (max_num_tokens,), NO_LORA_SLOT, dtype=torch.int32, pin_memory=True
+        )
+        # Adapter-group buffers for the decode grouped expand kernel.
+        # Computed on CPU in prepare_loras (no GPU sync) and transferred
+        # non-blocking.  Using stable GPU addresses so decode CUDA graphs
+        # can capture the pointers; num_groups on axis=1 changes per step
+        # so the graph grid must be re-evaluated outside the captured region.
+        _mg = self._n_slots  # upper bound: one group per loaded adapter
+        self._sort_order_cpu = torch.zeros(
+            max_num_tokens, dtype=torch.int64, pin_memory=True
+        )
+        self._group_slots_cpu = torch.zeros(_mg, dtype=torch.int32, pin_memory=True)
+        self._group_starts_cpu = torch.zeros(_mg, dtype=torch.int32, pin_memory=True)
+        self._group_sizes_cpu = torch.zeros(_mg, dtype=torch.int32, pin_memory=True)
+        self._sort_order_buf = torch.zeros(
+            max_num_tokens, dtype=torch.int64, device=device
+        )
+        self._group_slots_buf = torch.zeros(_mg, dtype=torch.int32, device=device)
+        self._group_starts_buf = torch.zeros(_mg, dtype=torch.int32, device=device)
+        self._group_sizes_buf = torch.zeros(_mg, dtype=torch.int32, device=device)
+
+        # ── GPU weight buffers ─────────────────────────────────────────────
+        # Attention:
+        #   qkv_A_buffers: (n_slots, 3 * max_rank, hidden) — stacked q/k/v A.
+        #   qkv_B_buffers: (n_slots, q_per_tp + 2 * kv_per_tp, max_rank).
+        #   o_A_buffers:   (n_slots, max_rank, o_in_per_tp).
+        #   o_B_buffers:   (n_slots, hidden, max_rank).
+        # MLP (TP-aware, mirrors qwen3 ``Qwen3MLP``):
+        #   gate_up_A_buffers: (n_slots, 2 * max_rank, hidden)             — A replicated.
+        #   gate_up_B_buffers: (n_slots, 2 * intermediate_per_tp, max_rank) — column-parallel.
+        #   down_A_buffers:    (n_slots, max_rank, intermediate_per_tp)    — row-parallel.
+        #   down_B_buffers:    (n_slots, hidden, max_rank)                 — B replicated.
+        self._weight_buffers = LoraWeightBuffers(
+            n_layers=self.n_layers,
+            n_slots=self._n_slots,
+            max_lora_rank=self.max_lora_rank,
+            hidden_size=self.hidden_size,
+            q_size_per_tp=self.q_size_per_tp,
+            kv_size_per_tp=self.kv_size_per_tp,
+            o_in_per_tp=self.o_in_per_tp,
+            intermediate_per_tp=self.intermediate_per_tp,
+            vocab_per_tp=self.vocab_per_tp,
+            dtype=self.dtype,
+            device=self.device,
+            tp_rank=self.tp_rank,
+            tp_size=self.tp_size,
+            buffer_groups=self.lora_buffer_groups,
+        )
+        self.qkv_A_buffers = self._weight_buffers.qkv_A_buffers
+        self.qkv_B_buffers = self._weight_buffers.qkv_B_buffers
+        self.o_A_buffers = self._weight_buffers.o_A_buffers
+        self.o_B_buffers = self._weight_buffers.o_B_buffers
+        self.gate_up_A_buffers = self._weight_buffers.gate_up_A_buffers
+        self.gate_up_B_buffers = self._weight_buffers.gate_up_B_buffers
+        self.down_A_buffers = self._weight_buffers.down_A_buffers
+        self.down_B_buffers = self._weight_buffers.down_B_buffers
+        self.lm_head_A_buffer = (
+            self._weight_buffers.lm_head_A_buffer if self.enable_head_lora else None
+        )
+        self.lm_head_B_buffer = (
+            self._weight_buffers.lm_head_B_buffer if self.enable_head_lora else None
+        )
+        self._qkv_output_offset = self._weight_buffers.qkv_output_offset
+        self._max_qkv_out_dim = self._weight_buffers.max_qkv_out_dim
+        self._o_slice_offsets = self._weight_buffers.o_slice_offsets
+        self._gate_up_slice_offsets = self._weight_buffers.gate_up_slice_offsets
+        self._down_slice_offsets = self._weight_buffers.down_slice_offsets
+        self._moe_lora_buffers = MoeLoraBuffers(
+            n_layers=self.n_layers,
+            n_slots=self._n_slots,
+            max_lora_rank=self.max_lora_rank,
+            num_experts=self.num_experts,
+            hidden_size=self.hidden_size,
+            intermediate_per_tp=self.moe_intermediate_per_tp,
+            dtype=self.dtype,
+            device=self.device,
+            shard_weights=self._weight_buffers.shard_weights,
+            enabled=self.enable_moe_lora,
+            compressed_shared_outer=self.lora_moe_compressed_shared_outer,
+        )
+        # Compatibility alias for tests/debug tooling that inspected the old
+        # manager-owned storage directly.
+        self._moe_lora_weights = self._moe_lora_buffers.weights_by_layer
+
+        logger.info(
+            "LoraManager initialized: max_loras=%d max_rank=%d "
+            "tp_rank=%d/%d device=%s dtype=%s buffer_groups=%s "
+            "moe_compressed_shared_outer=%s",
+            max_loras,
+            max_lora_rank,
+            tp_rank,
+            tp_size,
+            device,
+            dtype,
+            ",".join(sorted(self.lora_buffer_groups)),
+            self.lora_moe_compressed_shared_outer,
+        )
+
+    # ── Public API ──────────────────────────────────────────────────────────
+
+    @property
+    def batch_info(self) -> LoraBatchInfo:
+        return self._batch_info
+
+    @property
+    def moe_lora_context(self) -> MoeLoraContext:
+        return self._moe_lora_buffers.build_context(
+            batch_info=self._batch_info,
+            scalings=self._scalings,
+            has_active_lora=self.has_active_lora,
+        )
+
+    def load_adapter(self, name: str, path: str) -> int:
+        """Register a PEFT adapter from *path* and warm the CPU pool.
+
+        ``path`` is recorded as the adapter's durable disk path; it must
+        remain accessible for the lifetime of the manager because the CPU
+        pool may evict the adapter back to disk under memory pressure.
+
+        Returns the integer ``lora_id`` to use in subsequent
+        ``prepare_loras`` calls.
+        """
+        if name in self._name_to_id:
+            logger.warning("Adapter '%s' is already loaded; re-loading.", name)
+            self._evict_by_name(name)
+            self._evict_from_cpu(name)
+
+        # Resolve the durable disk path now (used by future re-reads when
+        # the CPU pool evicts these weights).
+        adapter_path = path
+        weight_path = resolve_adapter_weight_path(adapter_path)
+        if not os.path.exists(weight_path):
+            raise FileNotFoundError(
+                f"Adapter weights not found at {weight_path!r} or {path!r}"
+            )
+
+        lora_id = self._next_id
+        self._next_id += 1
+        self._name_to_id[name] = lora_id
+        self._id_to_name[lora_id] = name
+        self._cpu_store.set_path(name, adapter_path)
+
+        # Warm the CPU pool — bounded by ``max_loras_cpu``, may evict
+        # other CPU-resident adapters back to disk.
+        self._cpu_store.ensure(name)
+
+        logger.info(
+            "Registered adapter '%s' (lora_id=%d) from %s; CPU pool: %d/%d",
+            name,
+            lora_id,
+            path,
+            len(self._cpu_cache),
+            self.max_loras_cpu,
+        )
+        return lora_id
+
+    def unload_adapter(self, name: str) -> None:
+        if name not in self._name_to_id:
+            raise KeyError(f"Adapter '{name}' is not loaded.")
+
+        lora_id = self._name_to_id.pop(name)
+        # Keep _id_to_name[lora_id] alive until eviction fires so retracted
+        # requests that resume with this lora_id can still be recognised and
+        # get the correct weights rather than silently falling back to the base
+        # model.  It is cleared when the GPU slot is finally freed below.
+
+        if name in self._active_names:
+            # The adapter was used in the most recent forward step; its GPU
+            # weights may still be needed if the scheduler is mid-decode or has
+            # retracted a request that it will later reschedule.  Defer the
+            # weight zeroing until a batch arrives that does not include this
+            # adapter — at that point the previous step is confirmed complete.
+            logger.warning(
+                "Adapter '%s' (lora_id=%d) unloaded while potentially in-flight; "
+                "GPU slot eviction deferred until next batch that does not use it.",
+                name,
+                lora_id,
+            )
+            # Store (name, lora_id) so the flush can distinguish this entry from
+            # a same-name re-registration that might occur before flushing.
+            self._pending_eviction.add((name, lora_id))
+            # CPU weights kept alive so retracted requests can still reload.
+        else:
+            # Safe to evict immediately — not active in the current batch.
+            del self._id_to_name[lora_id]
+            self._evict_by_name(name)
+            self._cpu_store.remove(name)
+
+        logger.info("Unloaded adapter '%s' (lora_id=%d)", name, lora_id)
+
+    def get_id(self, name: str) -> int | None:
+        return self._name_to_id.get(name)
+
+    def _flush_one_pending(self, name: str, lora_id: int) -> None:
+        """Carry out the deferred GPU+CPU eviction for one (name, lora_id) entry.
+
+        Guards against two edge cases:
+        - Re-registration: the same name was re-loaded after unload; the new
+          slot should NOT be zeroed.  Detected by checking that _id_to_name
+          still maps lora_id → name (the old entry, kept alive for retracted
+          requests) and that the current name→id mapping no longer exists.
+        - Already-evicted slot: LRU pressure may have freed the GPU slot
+          before the deferred flush fires; _evict_by_name is idempotent.
+        """
+        # If the same name was re-registered, _name_to_id[name] exists again
+        # with a NEW lora_id.  Skip GPU eviction — the slot now belongs to the
+        # new adapter.  The CPU copy for the OLD weights was already removed or
+        # never loaded under the new id.
+        if self._name_to_id.get(name) is not None:
+            # Name was re-registered; clear the stale _id_to_name entry for the
+            # old lora_id only if it still points to this name.
+            if self._id_to_name.get(lora_id) == name:
+                del self._id_to_name[lora_id]
+            return
+
+        # Clear the reverse mapping kept alive for retracted-request safety.
+        if self._id_to_name.get(lora_id) == name:
+            del self._id_to_name[lora_id]
+
+        self._evict_by_name(name)  # idempotent if already LRU-evicted
+        self._cpu_store.remove(name)
+
+    def flush_pending_evictions(self) -> None:
+        """Evict all deferred adapter weights immediately.
+
+        Safe to call at any time, including while the GPU is running a forward
+        pass.  Because _reset_slot no longer issues GPU zero operations, the
+        only side effects are CPU-side: removing the slot from _name_to_slot
+        and cleaning up CPU weight caches.  The GPU memory retains stale values
+        until the slot is reused, but no kernel ever reads from an evicted slot
+        (prepare_loras only assigns weight_indices to slots present in
+        _name_to_slot).
+
+        Call this when the server has no pending decode requests and you want
+        to reclaim GPU slots occupied by deferred-unloaded adapters.
+        """
+        for name, lora_id in list(self._pending_eviction):
+            logger.info("Flushing deferred eviction for adapter '%s'.", name)
+            self._flush_one_pending(name, lora_id)
+            self._pending_eviction.discard((name, lora_id))
+
+    def prepare_loras(
+        self,
+        lora_ids: list[int],
+        per_request_token_counts: list[int] | int = 1,
+    ) -> int:
+        """Fill :attr:`batch_info` for the upcoming forward.
+
+        Each request becomes one segment.  Returns the total number of
+        tokens written.  All updates are in place on the persistent
+        batch_info tensors so the captured CUDA graph keeps replaying
+        against the same pointers.
+        """
+        bs = len(lora_ids)
+
+        # Phase 1: resolve all unique adapters and promote them to GPU before
+        # assigning any per-request slots.  A single-pass approach would silently
+        # produce wrong outputs: if the batch needs more adapters than max_loras,
+        # _find_free_slot evicts an already-assigned adapter (e.g. A), then the
+        # later request for A gets NO_LORA_SLOT and runs as the base model.
+        unique_names: dict[int, str] = {}
+        for lid in lora_ids:
+            if lid == 0 or lid in unique_names:
+                continue
+            name = self._id_to_name.get(lid)
+            if name is not None:
+                unique_names[lid] = name
+
+        n_unique = len(unique_names)
+        if n_unique > self.max_loras:
+            raise RuntimeError(
+                f"Batch requires {n_unique} unique LoRA adapters but "
+                f"max_loras={self.max_loras}. Reduce adapter diversity per "
+                "batch (use pack scheduling) or increase max_loras."
+            )
+
+        # The previous forward step is now complete (prepare_loras is called
+        # synchronously before each forward).  Flush any deferred evictions for
+        # adapters that are NOT needed by the current batch.
+        current_batch_names = set(unique_names.values())
+        for pending_name, pending_lora_id in list(self._pending_eviction):
+            if pending_name not in current_batch_names:
+                logger.info(
+                    "Deferred eviction: removing adapter '%s' GPU weights now.",
+                    pending_name,
+                )
+                self._flush_one_pending(pending_name, pending_lora_id)
+                self._pending_eviction.discard((pending_name, pending_lora_id))
+
+        # Track which adapters are active in this batch for mid-decode unload safety.
+        self._active_names = current_batch_names
+
+        # Promote all needed adapters before touching per_request_slots so that
+        # LRU eviction only targets adapters NOT in this batch.  After each
+        # promotion, move the adapter to MRU so subsequent promotions within
+        # this loop don't evict an already-promoted or already-resident batch
+        # adapter (which would be LRU if it was loaded in a previous step).
+        for name in unique_names.values():
+            self._ensure_in_gpu(name)
+            self._gpu_lru.move_to_end(name)  # protect from intra-phase eviction
+
+        # Phase 2: assign per-request slots from the now-stable _name_to_slot
+        # map (no further evictions occur here).
+        per_request_slots: list[int] = []
+        for lid in lora_ids:
+            if lid == 0:
+                per_request_slots.append(NO_LORA_SLOT)
+                continue
+            name = self._id_to_name.get(lid)
+            if name is None:
+                logger.warning("Unknown lora_id %d; treating as base model.", lid)
+                per_request_slots.append(NO_LORA_SLOT)
+                continue
+            slot = self._name_to_slot[name]  # guaranteed present after phase 1
+            per_request_slots.append(slot)
+            self._gpu_lru.move_to_end(name)
+
+        # Per-request seg_lens.
+        if isinstance(per_request_token_counts, int):
+            seg_lens_list = [per_request_token_counts] * bs
+        else:
+            if len(per_request_token_counts) != bs:
+                raise ValueError(
+                    "per_request_token_counts length must match lora_ids length"
+                )
+            seg_lens_list = list(per_request_token_counts)
+
+        total_tokens = sum(seg_lens_list)
+        if total_tokens > self.max_num_tokens:
+            raise ValueError(
+                f"LoRA batch_info overflow: {total_tokens} > {self.max_num_tokens}"
+            )
+        max_len = max(seg_lens_list) if seg_lens_list else 0
+
+        bi = self._batch_info
+
+        # For decode batches (max_len == 1): compute adapter groups on CPU
+        # so the grouped expand kernel can batch same-adapter tokens into a
+        # full BLOCK_S=16 GEMM tile, recovering tensor-core efficiency.
+        if max_len == 1 and bs > 1:
+            sort_order, group_slots, group_starts, group_sizes = (
+                build_decode_lora_groups(per_request_slots)
+            )
+            ng = len(group_slots)
+            active_count = len(sort_order)
+            self._sort_order_cpu[:active_count] = torch.as_tensor(
+                sort_order, dtype=torch.int64
+            )
+            self._group_slots_cpu[:ng] = torch.as_tensor(group_slots, dtype=torch.int32)
+            self._group_starts_cpu[:ng] = torch.as_tensor(
+                group_starts, dtype=torch.int32
+            )
+            self._group_sizes_cpu[:ng] = torch.as_tensor(group_sizes, dtype=torch.int32)
+            bi.sort_order = self._sort_order_buf
+            bi.group_slots = self._group_slots_buf
+            bi.group_starts = self._group_starts_buf
+            bi.group_sizes = self._group_sizes_buf
+            bi.sort_order[:active_count].copy_(
+                self._sort_order_cpu[:active_count], non_blocking=True
+            )
+            bi.group_slots[:ng].copy_(self._group_slots_cpu[:ng], non_blocking=True)
+            bi.group_starts[:ng].copy_(self._group_starts_cpu[:ng], non_blocking=True)
+            bi.group_sizes[:ng].copy_(self._group_sizes_cpu[:ng], non_blocking=True)
+            bi.num_groups = ng
+            bi.max_group_size = max(group_sizes) if group_sizes else 0
+        else:
+            bi.sort_order = bi.group_slots = bi.group_starts = bi.group_sizes = None
+            bi.num_groups = 0
+            bi.max_group_size = 0
+
+        first_slot = per_request_slots[0] if per_request_slots else NO_LORA_SLOT
+        bi.single_lora_slot = (
+            first_slot
+            if first_slot != NO_LORA_SLOT
+            and all(slot == first_slot for slot in per_request_slots)
+            else NO_LORA_SLOT
+        )
+        bi.single_lora_rank = (
+            self._slot_ranks[bi.single_lora_slot]
+            if bi.single_lora_slot != NO_LORA_SLOT
+            else 0
+        )
+        bi.multi_lora_start_slot = NO_LORA_SLOT
+        bi.multi_lora_count = 0
+        bi.multi_lora_segment_len = 0
+        bi.multi_lora_rank = 0
+        if (
+            bs > 1
+            and bi.single_lora_slot == NO_LORA_SLOT
+            and max_len > _CHUNKED_THRESHOLD
+            and len(set(seg_lens_list)) == 1
+            and all(slot != NO_LORA_SLOT for slot in per_request_slots)
+        ):
+            start_slot = per_request_slots[0]
+            consecutive_slots = all(
+                slot == start_slot + i for i, slot in enumerate(per_request_slots)
+            )
+            rank = self._slot_ranks[start_slot]
+            scaling = self._slot_scalings[start_slot]
+            same_rank_and_scaling = all(
+                self._slot_ranks[slot] == rank and self._slot_scalings[slot] == scaling
+                for slot in per_request_slots
+            )
+            if consecutive_slots and rank > 0 and same_rank_and_scaling:
+                bi.multi_lora_start_slot = start_slot
+                bi.multi_lora_count = bs
+                bi.multi_lora_segment_len = seg_lens_list[0]
+                bi.multi_lora_rank = rank
+
+        # Stage on CPU then a single non-blocking H2D.
+        self._seg_lens_cpu[:bs] = torch.as_tensor(seg_lens_list, dtype=torch.int32)
+        self._weight_indices_cpu[:bs] = torch.as_tensor(
+            per_request_slots, dtype=torch.int32
+        )
+
+        self.has_active_lora = any(s != NO_LORA_SLOT for s in per_request_slots)
+
+        bi = self._batch_info
+        bi.bs = bs
+        bi.num_segments = bs
+        bi.max_len = max_len
+
+        # Skip the H2D copies and on-device cumsum when no adapter is active:
+        # the no-LoRA CUDA graph omits all LoRA kernels and never reads
+        # weight_indices / seg_lens / seg_indptr, so updating them is wasted work.
+        if self.has_active_lora:
+            bi.seg_lens[:bs].copy_(self._seg_lens_cpu[:bs], non_blocking=True)
+            bi.weight_indices[:bs].copy_(
+                self._weight_indices_cpu[:bs], non_blocking=True
+            )
+            bi.seg_indptr[0] = 0
+            torch.cumsum(bi.seg_lens[:bs], dim=0, out=bi.seg_indptr[1 : bs + 1])
+
+        return total_tokens
+
+    def apply_qkv_lora(
+        self,
+        hidden_states: torch.Tensor,
+        qkv: torch.Tensor,
+        layer_id: int,
+    ) -> torch.Tensor:
+        """Fused QKV LoRA delta: ``qkv += B @ A @ x * scaling``.
+
+        ``hidden_states``: ``(s, hidden)`` (full input).
+        ``qkv``:           ``(s, q_per_tp + 2 * kv_per_tp)`` (output of qkv_proj
+        on this rank).  Updated in place via the kernel's fused-add.
+        """
+        if hidden_states.shape[0] == 0:
+            return qkv
+        if not self.enable_attn_lora:
+            return qkv
+        bi = self._batch_info
+        if bi.bs == 0 or not self.has_active_lora:
+            return qkv
+
+        A_buf = self.qkv_A_buffers[layer_id]
+        B_buf = self.qkv_B_buffers[layer_id]
+        # lora_a: (s, 3 * max_rank)
+        lora_a = (
+            lora_shrink_prefill_fwd(hidden_states, A_buf, bi, stack_num=3)
+            if bi.max_len > _CHUNKED_THRESHOLD
+            else lora_shrink_fwd(hidden_states, A_buf, bi, stack_num=3)
+        )
+        if bi.max_len > _CHUNKED_THRESHOLD:
+            lora_expand_prefill_fwd(
+                lora_a,
+                B_buf,
+                bi,
+                self._qkv_output_offset,
+                self._max_qkv_out_dim,
+                base_output=qkv,
+            )
+        else:
+            lora_qkv_expand_fwd(
+                lora_a,
+                B_buf,
+                bi,
+                self._qkv_output_offset,
+                self._max_qkv_out_dim,
+                base_output=qkv,
+            )
+        return qkv
+
+    def apply_o_lora(
+        self,
+        attn_output: torch.Tensor,
+        o_output: torch.Tensor,
+        layer_id: int,
+    ) -> torch.Tensor:
+        """Row-parallel O-projection LoRA delta.
+
+        ``attn_output``: ``(s, q_per_tp)`` per-rank attention output (input
+        to o_proj).
+        ``o_output``: ``(s, hidden)`` partial sum from the host o_proj
+        (``reduce_results=False`` on this codebase).  Updated in place.
+
+        Each rank computes ``B @ A_local @ x_local`` — a partial of shape
+        ``(s, hidden)``.  A is sharded along its input dim and B is
+        replicated, so the sum of partials over ranks equals
+        ``B @ A_full @ x_full``.  The host layer's downstream fused
+        all-reduce in ``post_attention_layernorm`` sums the base partial
+        and the LoRA partial together, producing the correct full output.
+        """
+        if attn_output.shape[0] == 0:
+            return o_output
+        if not self.enable_attn_lora:
+            return o_output
+        bi = self._batch_info
+        if bi.bs == 0 or not self.has_active_lora:
+            return o_output
+
+        A_buf = self.o_A_buffers[layer_id]
+        B_buf = self.o_B_buffers[layer_id]
+        # lora_a (partial per rank): (s, max_rank).  No internal all-reduce —
+        # the partial flows into B and the result rides the downstream sum.
+        lora_a = (
+            lora_shrink_prefill_fwd(attn_output, A_buf, bi, stack_num=1)
+            if bi.max_len > _CHUNKED_THRESHOLD
+            else lora_shrink_fwd(attn_output, A_buf, bi, stack_num=1)
+        )
+        if bi.max_len > _CHUNKED_THRESHOLD:
+            lora_expand_prefill_fwd(
+                lora_a,
+                B_buf,
+                bi,
+                self._o_slice_offsets,
+                self.hidden_size,
+                base_output=o_output,
+            )
+        elif _use_triton_grouped_decode(bi):
+            lora_expand_grouped_v2_fwd(lora_a, B_buf, bi, base_output=o_output)
+        else:
+            lora_expand_fwd(lora_a, B_buf, bi, base_output=o_output)
+        return o_output
+
+    def apply_gate_up_lora(
+        self,
+        hidden_states: torch.Tensor,
+        gate_up: torch.Tensor,
+        layer_id: int,
+    ) -> torch.Tensor:
+        """Fused gate/up LoRA delta: ``gate_up += B @ A @ x * scaling``.
+
+        ``hidden_states``: ``(s, hidden)``.
+        ``gate_up``:       ``(s, 2 * intermediate_per_tp)`` — output of the
+        column-parallel ``gate_up_proj`` (each rank holds its own output
+        shard).  Updated in place via the kernel's fused-add.
+        """
+        if hidden_states.shape[0] == 0:
+            return gate_up
+        if not self.enable_mlp_lora:
+            return gate_up
+        bi = self._batch_info
+        if bi.bs == 0 or not self.has_active_lora:
+            return gate_up
+
+        A_buf = self.gate_up_A_buffers[layer_id]
+        B_buf = self.gate_up_B_buffers[layer_id]
+        # lora_a: (s, 2 * max_rank) — gate's lora_a in [:, :r], up's in [:, r:].
+        lora_a = (
+            lora_shrink_prefill_fwd(hidden_states, A_buf, bi, stack_num=2)
+            if bi.max_len > _CHUNKED_THRESHOLD
+            else lora_shrink_fwd(hidden_states, A_buf, bi, stack_num=2)
+        )
+        if bi.max_len > _CHUNKED_THRESHOLD:
+            lora_expand_prefill_fwd(
+                lora_a,
+                B_buf,
+                bi,
+                self._gate_up_slice_offsets,
+                self.intermediate_per_tp,
+                base_output=gate_up,
+            )
+        else:
+            lora_gate_up_expand_fwd(
+                lora_a,
+                B_buf,
+                bi,
+                self.intermediate_per_tp,
+                base_output=gate_up,
+            )
+        return gate_up
+
+    def apply_down_lora(
+        self,
+        x: torch.Tensor,
+        down_output: torch.Tensor,
+        layer_id: int,
+    ) -> torch.Tensor:
+        """Down-projection LoRA delta (row-parallel under MLP TP).
+
+        ``x``:           ``(s, intermediate_per_tp)`` — input to the
+        row-parallel ``down_proj`` (this rank's input shard).
+        ``down_output``: ``(s, hidden)`` — partial output of ``down_proj``
+        before its all-reduce.  Updated in place.
+
+        Each rank's delta is ``B @ A_local @ x_local``: A is sharded along
+        the input dim and B is replicated, so summing per-rank deltas yields
+        the full ``B @ A_full @ x_full``.  The base linear runs with
+        ``reduce_results=False``; the downstream all-reduce that sums the
+        base partial also sums the LoRA partials.
+        """
+        if x.shape[0] == 0:
+            return down_output
+        if not self.enable_mlp_lora:
+            return down_output
+        bi = self._batch_info
+        if bi.bs == 0 or not self.has_active_lora:
+            return down_output
+
+        A_buf = self.down_A_buffers[layer_id]
+        B_buf = self.down_B_buffers[layer_id]
+        lora_a = (
+            lora_shrink_prefill_fwd(x, A_buf, bi, stack_num=1)
+            if bi.max_len > _CHUNKED_THRESHOLD
+            else lora_shrink_fwd(x, A_buf, bi, stack_num=1)
+        )
+        if bi.max_len > _CHUNKED_THRESHOLD:
+            lora_expand_prefill_fwd(
+                lora_a,
+                B_buf,
+                bi,
+                self._down_slice_offsets,
+                self.hidden_size,
+                base_output=down_output,
+            )
+        elif _use_triton_grouped_decode(bi):
+            lora_expand_grouped_v2_fwd(lora_a, B_buf, bi, base_output=down_output)
+        else:
+            lora_expand_fwd(lora_a, B_buf, bi, base_output=down_output)
+        return down_output
+
+    def apply_lm_head_lora(
+        self,
+        hidden_states: torch.Tensor,
+        logits: torch.Tensor,
+    ) -> torch.Tensor:
+        """lm_head LoRA delta: ``logits += B @ A @ x * scaling``.
+
+        ``hidden_states``: ``(s, hidden)`` — one token per request (pruned).
+        ``logits``:        ``(s, vocab_per_tp)`` — pre-all-gather logits shard.
+        Applied before the TP all-gather so each rank contributes its vocab
+        shard correctly.
+
+        Note: when ``extend_return_logprob`` is True the caller may pass more
+        than ``bi.bs`` tokens.  In that case this method is a no-op because
+        the per-token slot mapping is not available here; sampling logits are
+        still correct for the last token of each request.
+        """
+        if hidden_states.shape[0] == 0:
+            return logits
+        if not self.enable_head_lora:
+            return logits
+        bi = self._batch_info
+        if bi.bs == 0 or not self.has_active_lora:
+            return logits
+        if hidden_states.shape[0] != bi.bs:
+            return logits
+
+        slots = bi.weight_indices[: bi.bs]  # (bs,)
+        valid = slots != NO_LORA_SLOT
+        if not valid.any():
+            return logits
+
+        # Fast path: all requests use the same adapter slot.
+        # Use plain matmul to avoid a gather of the B matrix (vocab_per_tp × rank
+        # bytes) for every request.  Guarded from CUDA graph capture because the
+        # Python branch is frozen at capture time — replaying with a different
+        # single_lora_slot would silently use stale weights.
+        if (
+            bi.single_lora_slot != NO_LORA_SLOT
+            and not torch.cuda.is_current_stream_capturing()
+        ):
+            slot = bi.single_lora_slot
+            scaling = self._scalings[slot].item()
+            A = self.lm_head_A_buffer[slot]  # (r, hidden)
+            B = self.lm_head_B_buffer[slot]  # (vocab_per_tp, r)
+            lora_a = hidden_states @ A.T  # (bs, r)
+            delta = lora_a @ B.T  # (bs, vocab_per_tp)
+            return logits + delta * scaling
+
+        valid_slots = slots.clamp(min=0)
+        # A: (bs, r, hidden),  B: (bs, vocab_per_tp, r)
+        A = self.lm_head_A_buffer[valid_slots]
+        B = self.lm_head_B_buffer[valid_slots]
+        # lora_a: (bs, r) = A @ hidden_states[..., None]
+        lora_a = torch.bmm(A, hidden_states.unsqueeze(-1)).squeeze(-1)
+        # delta: (bs, vocab_per_tp)
+        delta = torch.bmm(B, lora_a.unsqueeze(-1)).squeeze(-1)
+        # Zero out requests with no adapter; scale the rest.
+        scale = self._scalings[valid_slots] * valid.to(self._scalings.dtype)
+        return logits + delta * scale.unsqueeze(-1)
+
+    def apply_moe_gate_up_lora(
+        self,
+        layer_id: int,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        gate_up_output: torch.Tensor,
+        *,
+        sorted_token_ids: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Compatibility wrapper; MoE-specific work lives in MoeLoraContext."""
+        if not self.enable_moe_lora:
+            return gate_up_output
+        return self.moe_lora_context.apply_gate_up_lora(
+            layer_id,
+            hidden_states,
+            topk_ids,
+            gate_up_output,
+            sorted_token_ids=sorted_token_ids,
+        )
+
+    def apply_moe_down_lora(
+        self,
+        layer_id: int,
+        intermediate: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+        down_output: torch.Tensor,
+        *,
+        sorted_token_ids: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Compatibility wrapper; MoE-specific work lives in MoeLoraContext."""
+        if not self.enable_moe_lora:
+            return down_output
+        return self.moe_lora_context.apply_down_lora(
+            layer_id,
+            intermediate,
+            topk_ids,
+            topk_weights,
+            down_output,
+            sorted_token_ids=sorted_token_ids,
+        )
+
+    def set_adapter_scaling(self, name: str, scaling: float) -> None:
+        slot = self._name_to_slot.get(name)
+        if slot is not None:
+            self._slot_scalings[slot] = scaling
+            self._scalings[slot] = scaling
+
+    # ── Slot allocation ─────────────────────────────────────────────────────
+
+    def _ensure_in_gpu(self, name: str) -> int:
+        if name in self._name_to_slot:
+            return self._name_to_slot[name]
+        # Tier-2 → Tier-1 promotion; may need to read from disk if the
+        # CPU pool has evicted this adapter since registration.
+        self._cpu_store.ensure(name)
+        slot = self._find_free_slot()
+        self._load_to_slot(name, slot)
+        self._name_to_slot[name] = slot
+        self._slot_to_name[slot] = name
+        self._gpu_lru[name] = None
+        return slot
+
+    def prefetch(self, name: str) -> None:
+        """Best-effort async warm of the CPU pool for *name*.
+
+        Called from the request-admission path: when a request with a
+        non-zero ``lora_id`` arrives the manager kicks off a background
+        disk read so the safetensors I/O is overlapped with the previous
+        forward step rather than blocking ``prepare_loras`` of the step
+        that actually consumes the adapter.
+
+        No-op when the adapter is already CPU-resident or a load is
+        already in flight.  Silently ignores unknown adapters (the
+        request will fall back to base via NO_LORA_SLOT).
+        """
+        self._cpu_store.prefetch(name)
+
+    def _evict_from_cpu(self, name: str) -> None:
+        """Public helper, takes the lock.  Caller must ensure *name* is
+        not currently GPU-resident."""
+        self._cpu_store.evict(name)
+
+    def _find_free_slot(self) -> int:
+        for slot in range(self._n_slots):
+            if self._slot_to_name[slot] is None:
+                return slot
+        for candidate_name in list(self._gpu_lru.keys()):
+            slot = self._name_to_slot[candidate_name]
+            logger.debug("Evicting adapter '%s' from GPU slot %d", candidate_name, slot)
+            self._evict_by_name(candidate_name)
+            return slot
+        raise RuntimeError(
+            "LoRA GPU pool is full and no evictable adapter was found. "
+            f"Increase max_loras (current: {self.max_loras})."
+        )
+
+    def _load_to_slot(self, name: str, slot: int) -> None:
+        cpu_weights = self._cpu_cache[name]
+        rank = self._get_rank_for(name)
+        scaling = self._get_scaling_for(name, rank)
+        self._reset_slot(slot)
+        self._lora_ranks[slot] = rank
+        self._slot_ranks[slot] = rank
+        self._slot_scalings[slot] = scaling
+        self._scalings[slot] = scaling
+        self._weight_buffers.load_adapter_to_slot(cpu_weights, slot, rank)
+        self._moe_lora_buffers.load_adapter_to_slot(cpu_weights, slot, rank)
+
+        logger.debug("Loaded adapter '%s' into GPU slot %d (rank=%d)", name, slot, rank)
+
+    def _get_rank_for(self, name: str) -> int:
+        cpu_weights = self._cpu_cache.get(name, {})
+        if not cpu_weights:
+            return self.max_lora_rank
+        # Check layer 0 first (dense attn/MLP modules).
+        if 0 in cpu_weights:
+            for mod in PEFT_MODULES:
+                if mod in cpu_weights[0]:
+                    return cpu_weights[0][mod][0].shape[0]
+            for mod, tensors in cpu_weights[0].items():
+                if mod.startswith("experts."):
+                    lora_A = tensors[0]
+                    if lora_A.dim() == 3:
+                        return lora_A.shape[1]
+                    return lora_A.shape[0]
+        # Fall back to lm_head (head-only adapters).
+        if LORA_HEAD_LAYER_ID in cpu_weights:
+            head = cpu_weights[LORA_HEAD_LAYER_ID]
+            if PEFT_HEAD_MODULE in head:
+                return head[PEFT_HEAD_MODULE][0].shape[0]
+        return self.max_lora_rank
+
+    def _get_scaling_for(self, name: str, rank: int) -> float:
+        return read_adapter_scaling(self._adapter_paths.get(name), rank)
+
+    def _evict_by_name(self, name: str) -> None:
+        if name in self._name_to_slot:
+            slot = self._name_to_slot.pop(name)
+            self._slot_to_name[slot] = None
+            self._reset_slot(slot)
+        self._gpu_lru.pop(name, None)
+
+    def _reset_slot(self, slot: int) -> None:
+        # GPU weight tensors are intentionally NOT zeroed here.
+        #
+        # Correctness argument: prepare_loras assigns weight_indices[i] only to
+        # slots present in _name_to_slot.  _evict_by_name removes the slot from
+        # _name_to_slot before calling _reset_slot, so no kernel ever reads from
+        # an evicted slot's GPU memory regardless of what values are there.
+        # _load_to_slot overwrites the stale values when the slot is reused.
+        #
+        # Skipping the GPU zeros removes potentially hundreds of kernel launches
+        # per eviction (one zero_() per buffer per layer) and — more critically —
+        # eliminates a CUDA stream race: graph.replay() uses a dedicated stream
+        # while tensor.zero_() runs on the default stream; without explicit
+        # inter-stream synchronisation, an immediate GPU zero could race with an
+        # in-flight graph kernel still reading the old weights.
+        #
+        # MoE buffers: _moe_lora_buffers.clear_slot does both GPU zeroing AND
+        # CPU dict cleanup (weights_by_layer.pop).  Keep the CPU cleanup, skip
+        # the GPU zeros.
+        self._moe_lora_buffers.clear_slot_cpu_only(slot)
+        self._lora_ranks[slot] = 0
+        self._slot_ranks[slot] = 0
+        self._slot_scalings[slot] = 0.0
+        self._scalings[slot] = 0.0

--- a/python/tokenspeed/runtime/lora/lora_registry.py
+++ b/python/tokenspeed/runtime/lora/lora_registry.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""In-process registry that tracks loaded LoRA adapters and maps names to IDs."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from tokenspeed.runtime.lora.lora_config import LoraConfig
+from tokenspeed.runtime.utils import get_colorful_logger
+
+logger = get_colorful_logger(__name__)
+
+# Sentinel value meaning "no adapter" — maps cleanly to int for scheduling.
+NO_LORA_ID: int = 0
+
+
+class LoraRegistry:
+    """Thread-unsafe registry; call from the scheduler/engine main thread only.
+
+    TODO: add locking when multi-threaded engine support is needed.
+    """
+
+    def __init__(self, max_loras: int) -> None:
+        self.max_loras = max_loras
+        self._configs: dict[str, LoraConfig] = {}  # name → config
+        self._name_to_id: dict[str, int] = {}  # name → integer ID
+        self._id_to_name: dict[int, str] = {}  # integer ID → name
+        self._next_id: int = 1  # 0 is reserved for "no lora"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def register(self, config: LoraConfig) -> int:
+        """Register a new adapter and return its integer ID.
+
+        Raises ``ValueError`` if the adapter is already registered or the
+        registry is at capacity.
+        """
+        if config.name in self._name_to_id:
+            raise ValueError(f"LoRA adapter '{config.name}' is already registered.")
+        if len(self._configs) >= self.max_loras:
+            raise ValueError(
+                f"LoRA registry is full ({self.max_loras} adapters). "
+                "Unload an adapter before loading a new one."
+            )
+        lora_id = self._next_id
+        self._next_id += 1
+        self._configs[config.name] = config
+        self._name_to_id[config.name] = lora_id
+        self._id_to_name[lora_id] = config.name
+        logger.info("Registered LoRA adapter '%s' → id=%d", config.name, lora_id)
+        return lora_id
+
+    def unregister(self, name: str) -> None:
+        """Remove an adapter from the registry.
+
+        Raises ``KeyError`` if the name is not registered.
+        """
+        if name not in self._name_to_id:
+            raise KeyError(f"LoRA adapter '{name}' is not registered.")
+        lora_id = self._name_to_id.pop(name)
+        del self._id_to_name[lora_id]
+        del self._configs[name]
+        logger.info("Unregistered LoRA adapter '%s' (id=%d)", name, lora_id)
+
+    def get_id(self, name: str) -> int | None:
+        """Return the integer ID for an adapter name, or None if not found."""
+        return self._name_to_id.get(name)
+
+    def get_config(self, name: str) -> LoraConfig | None:
+        """Return the LoraConfig for a registered adapter name."""
+        return self._configs.get(name)
+
+    def get_config_by_id(self, lora_id: int) -> LoraConfig | None:
+        name = self._id_to_name.get(lora_id)
+        return self._configs.get(name) if name else None
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._name_to_id
+
+    def __len__(self) -> int:
+        return len(self._name_to_id)
+
+    def __iter__(self) -> Iterator[LoraConfig]:
+        return iter(self._configs.values())

--- a/python/tokenspeed/runtime/lora/moe_lora.py
+++ b/python/tokenspeed/runtime/lora/moe_lora.py
@@ -1,0 +1,1440 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import torch
+
+from tokenspeed.runtime.lora.lora_batch import NO_LORA_SLOT, LoraBatchInfo
+
+try:
+    from tokenspeed_kernel.ops.moe_lora import (
+        gate_up_b_expand,
+        per_expert_a_shrink,
+        per_expert_b_down_expand,
+        per_expert_gate_up_b_expand,
+        shared_a_shrink,
+        shared_b_down_expand,
+        sorted_a_down_shrink,
+        sorted_gate_up_b_expand,
+    )
+
+    _FUSED_MOE_LORA_AVAILABLE = True
+except Exception:
+    _FUSED_MOE_LORA_AVAILABLE = False
+
+MoeLayerSlotWeights = dict[int, dict[str, torch.Tensor]]
+MoeWeightsByLayer = dict[int, MoeLayerSlotWeights]
+
+
+@dataclass(frozen=True)
+class MoeLoraContext:
+    """Narrow per-forward view of MoE LoRA state consumed by MoE backends."""
+
+    weights_by_layer: MoeWeightsByLayer
+    batch_info: LoraBatchInfo
+    scalings: torch.Tensor
+    has_active_lora: bool
+    # Per-layer buffer lists for CUDA-graph-compatible dynamic slot indexing.
+    # When set, _apply_*_slot uses GPU tensor indexing via batch_info.weight_indices
+    # instead of Python dict lookup, so the CUDA graph can replay with any adapter.
+    w13_A_buffers: list | None
+    w13_B_buffers: list | None
+    down_A_buffers: list | None
+    down_B_buffers: list | None
+    # Multi-stream prefetch: secondary stream + pre-allocated output buffers.
+    # Shrink ops run on _lora_stream concurrently with the base MoE GEMMs.
+    _lora_stream: object | None = None  # torch.cuda.Stream
+    _lora_a_m_buf: torch.Tensor | None = None  # (max_bs, 2*max_r)
+    _lora_a_flat_buf: torch.Tensor | None = None  # (max_bs*max_topk, max_r)
+    # Mutable flags (list elements are mutable even in frozen dataclass):
+    #   _prefetch_flags[0] = gate_up shrink pending; [1] = down shrink pending.
+    _prefetch_flags: list | None = None
+
+    def apply_gate_up_lora(
+        self,
+        layer_id: int,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        gate_up_output: torch.Tensor,
+        *,
+        sorted_token_ids: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Apply expert-scoped LoRA to routed MoE gate/up output."""
+        if hidden_states.shape[0] == 0 or topk_ids.numel() == 0:
+            return gate_up_output
+        slots, single_slot = self._token_slots(hidden_states.shape[0])
+        if single_slot == NO_LORA_SLOT and slots is None:
+            return gate_up_output
+        if single_slot != NO_LORA_SLOT:
+            self._apply_gate_up_slot(
+                layer_id,
+                single_slot,
+                hidden_states,
+                topk_ids,
+                gate_up_output,
+                sorted_token_ids=sorted_token_ids,
+            )
+            return gate_up_output
+        assert slots is not None
+        for slot_t in torch.unique(slots):
+            slot = int(slot_t.item())
+            if slot == NO_LORA_SLOT:
+                continue
+            self._apply_gate_up_slot(
+                layer_id,
+                slot,
+                hidden_states,
+                topk_ids,
+                gate_up_output,
+                token_mask=slots == slot,
+                sorted_token_ids=sorted_token_ids,
+            )
+        return gate_up_output
+
+    def apply_down_lora(
+        self,
+        layer_id: int,
+        intermediate: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+        down_output: torch.Tensor,
+        *,
+        sorted_token_ids: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Apply expert-scoped LoRA to routed MoE down output."""
+        if intermediate.shape[0] == 0 or topk_ids.numel() == 0:
+            return down_output
+        num_tokens = topk_ids.shape[0]
+        slots, single_slot = self._token_slots(num_tokens)
+        if single_slot == NO_LORA_SLOT and slots is None:
+            return down_output
+        # Sorted-space fast path: work directly on sorted intermediate, skipping
+        # _route_rows_from_cache. Only applies when sorted dispatch is active (TMA
+        # config), since the fused shrink kernel has poor utilization for small
+        # flat-pair batches.
+        if (
+            _FUSED_MOE_LORA_AVAILABLE
+            and sorted_token_ids is not None
+            and single_slot != NO_LORA_SLOT
+            and self.down_A_buffers is not None
+            and self.batch_info.single_lora_slot != -1
+        ):
+            if self._apply_down_sorted(
+                layer_id,
+                single_slot,
+                intermediate,
+                topk_ids,
+                topk_weights,
+                down_output,
+                sorted_token_ids,
+            ):
+                return down_output
+        route_input = self._route_rows_from_cache(
+            intermediate,
+            topk_ids.numel(),
+            sorted_token_ids=sorted_token_ids,
+        ).view(topk_ids.shape[0], topk_ids.shape[1], -1)
+        if single_slot != NO_LORA_SLOT:
+            self._apply_down_slot(
+                layer_id,
+                single_slot,
+                route_input,
+                topk_ids,
+                topk_weights,
+                down_output,
+            )
+            return down_output
+        assert slots is not None
+        for slot_t in torch.unique(slots):
+            slot = int(slot_t.item())
+            if slot == NO_LORA_SLOT:
+                continue
+            self._apply_down_slot(
+                layer_id,
+                slot,
+                route_input,
+                topk_ids,
+                topk_weights,
+                down_output,
+                token_mask=slots == slot,
+            )
+        return down_output
+
+    # ── Ragged (gather/scatter) MoE layout adapters ────────────────────────────
+    # main's Triton MoE kernels run in a *gathered* layout: the base gate/up GEMM
+    # output has one row per (token, top-k slot) sorted by expert, where gathered
+    # row ``i`` maps to the flat-pair slot ``scatter_indx[i] == tok * top_k + k``.
+    # The flat-pair LoRA kernels below index by that flat slot, so these adapters
+    # translate between the two orders with a single gather/scatter and reuse the
+    # existing (sorted_token_ids-free) flat-pair path.
+
+    def apply_gate_up_lora_ragged(
+        self,
+        layer_id: int,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        gate_up_gathered: torch.Tensor,
+        scatter_indx: torch.Tensor,
+    ) -> torch.Tensor:
+        """Add gate/up LoRA into a gathered-layout gate/up buffer, in place.
+
+        Args:
+            layer_id: MoE layer index selecting per-layer LoRA weights.
+            hidden_states: Token-major inputs ``(num_tokens, hidden)`` (the same
+                unquantized activations the base gate/up GEMM consumed).
+            topk_ids: Routing table ``(num_tokens, top_k)``.
+            gate_up_gathered: Base gate/up GEMM output in *gathered* order
+                ``(num_tokens * top_k, 2 * intermediate)``; mutated in place.
+            scatter_indx: ``(num_tokens * top_k,)`` map from gathered row to
+                flat-pair slot (``tok * top_k + k``), as produced by the routing.
+
+        Returns:
+            ``gate_up_gathered`` with the LoRA delta added.
+        """
+        if not self.has_active_lora or topk_ids.numel() == 0:
+            return gate_up_gathered
+        num_tokens, top_k = topk_ids.shape
+        # Compute the delta in flat-pair order, then gather it into the base
+        # buffer's expert-sorted order.
+        delta = torch.zeros(
+            (num_tokens * top_k, gate_up_gathered.shape[-1]),
+            dtype=gate_up_gathered.dtype,
+            device=gate_up_gathered.device,
+        )
+        self.apply_gate_up_lora(
+            layer_id, hidden_states, topk_ids, delta, sorted_token_ids=None
+        )
+        gate_up_gathered.add_(delta.index_select(0, scatter_indx.to(torch.long)))
+        return gate_up_gathered
+
+    def apply_down_lora_ragged(
+        self,
+        layer_id: int,
+        intermediate_gathered: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+        down_output_flat: torch.Tensor,
+        scatter_indx: torch.Tensor,
+    ) -> torch.Tensor:
+        """Add down LoRA into a flat-slot down-output buffer, in place.
+
+        Args:
+            layer_id: MoE layer index selecting per-layer LoRA weights.
+            intermediate_gathered: Post-activation down input in *gathered* order
+                ``(num_tokens * top_k, intermediate)``.
+            topk_ids: Routing table ``(num_tokens, top_k)``.
+            topk_weights: Routing weights ``(num_tokens, top_k)``.
+            down_output_flat: Base down GEMM result in flat-pair slot order
+                ``(num_tokens * top_k, hidden)`` (== ``view(num_tokens, top_k,
+                hidden)``), awaiting the caller's top-k reduction; mutated in place.
+            scatter_indx: ``(num_tokens * top_k,)`` gathered-row -> flat-pair slot.
+
+        Returns:
+            ``down_output_flat`` with the (top-k weighted) LoRA delta added.
+        """
+        if not self.has_active_lora or topk_ids.numel() == 0:
+            return down_output_flat
+        num_tokens, top_k = topk_ids.shape
+        hidden = down_output_flat.shape[-1]
+        # Un-gather the down input into flat-pair order so the flat-pair down
+        # kernels (which recover ``tok = row // top_k``) see the right rows.
+        inter_flat = torch.zeros(
+            (num_tokens * top_k, intermediate_gathered.shape[-1]),
+            dtype=intermediate_gathered.dtype,
+            device=intermediate_gathered.device,
+        )
+        inter_flat.index_copy_(0, scatter_indx.to(torch.long), intermediate_gathered)
+        # The flat-pair down path already applies ``topk_weights``; produce a
+        # token-major ``(num_tokens, top_k, hidden)`` delta and fold it into the
+        # base output before the caller sums over top_k.
+        down_delta = torch.zeros(
+            (num_tokens, top_k, hidden),
+            dtype=down_output_flat.dtype,
+            device=down_output_flat.device,
+        )
+        self.apply_down_lora(
+            layer_id,
+            inter_flat,
+            topk_ids,
+            topk_weights,
+            down_delta,
+            sorted_token_ids=None,
+        )
+        down_output_flat.view(num_tokens, top_k, hidden).add_(down_delta)
+        return down_output_flat
+
+    def _token_slots(self, num_tokens: int) -> tuple[torch.Tensor | None, int]:
+        bi = self.batch_info
+        if bi.bs == 0 or not self.has_active_lora:
+            return None, NO_LORA_SLOT
+        if bi.single_lora_slot != NO_LORA_SLOT:
+            return None, bi.single_lora_slot
+        slots = torch.repeat_interleave(
+            bi.weight_indices[: bi.bs], bi.seg_lens[: bi.bs]
+        )
+        if slots.numel() != num_tokens:
+            # Token ownership changed under TP/EP communication. Mixed LoRA
+            # cannot be applied safely without transforming the slot map too.
+            return None, NO_LORA_SLOT
+        return slots, NO_LORA_SLOT
+
+    # ── Multi-stream prefetch API ──────────────────────────────────────────────
+    # Called from triton_common.py BEFORE each base GEMM to overlap the LoRA
+    # shrink kernel with the base model's gate_up / down computation.
+
+    def launch_gate_up_shrink(
+        self,
+        layer_id: int,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> None:
+        """Fork: launch gate_up LoRA A-shrink on secondary stream.
+
+        Must be called immediately BEFORE gate_up_gemm so that shared_a_shrink
+        (torch.mm) runs concurrently on _lora_stream while gate_up_gemm runs
+        on the main stream.  apply_gate_up_lora will join the stream and use
+        the pre-filled _lora_a_m_buf instead of recomputing.
+        """
+        if self._prefetch_flags is None:
+            return
+        self._prefetch_flags[0] = False  # default: no prefetch
+        bi = self.batch_info
+        if (
+            not self.has_active_lora
+            or bi.single_lora_slot == NO_LORA_SLOT
+            or self.w13_A_buffers is None
+            or self._lora_stream is None
+            or self._lora_a_m_buf is None
+        ):
+            return
+        m = hidden_states.shape[0]
+        w13_A_buf = self.w13_A_buffers[layer_id]
+        if w13_A_buf.shape[1] != 1:  # only sglang_shared format (shared A)
+            return
+        if m > self._lora_a_m_buf.shape[0]:
+            return  # prefill with too many tokens — skip prefetch to avoid OOB
+        # Fork to secondary stream: launch torch.mm concurrently with gate_up_gemm.
+        self._lora_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(self._lora_stream):
+            torch.mm(hidden_states, w13_A_buf[0, 0].T, out=self._lora_a_m_buf[:m])
+        self._prefetch_flags[0] = True
+
+    def launch_down_shrink(
+        self,
+        layer_id: int,
+        intermediate: torch.Tensor,
+        topk_ids: torch.Tensor,
+        m_k: int,
+    ) -> None:
+        """Fork: launch down LoRA A-shrink on secondary stream.
+
+        Must be called immediately BEFORE down_gemm so that per_expert_a_shrink
+        runs concurrently on _lora_stream while down_gemm runs on main stream.
+        intermediate is intermediate_cache2 (silu output), shape (m*topk, INTER).
+        m_k is m_tokens * top_k (non-padded).
+        """
+        if self._prefetch_flags is None:
+            return
+        self._prefetch_flags[1] = False
+        bi = self.batch_info
+        down_A_buf = self.down_A_buffers[layer_id] if self.down_A_buffers else None
+        down_B_buf = self.down_B_buffers[layer_id] if self.down_B_buffers else None
+        if (
+            not self.has_active_lora
+            or bi.single_lora_slot == NO_LORA_SLOT
+            or down_A_buf is None
+            or down_B_buf is None
+            or self._lora_stream is None
+            or self._lora_a_flat_buf is None
+            or not _FUSED_MOE_LORA_AVAILABLE
+            or down_A_buf.shape[1] <= 1  # per-expert A only
+            or down_B_buf.shape[1] != 1  # shared B only
+            or not down_A_buf.is_contiguous()
+        ):
+            return
+        if m_k > self._lora_a_flat_buf.shape[0]:
+            return  # prefill with too many tokens — skip prefetch to avoid OOB
+        ri_flat = intermediate[:m_k].view(m_k, -1)
+        safe_ids = topk_ids.clamp(0, down_A_buf.shape[1] - 1).to(torch.long)
+        slot_idx = bi.weight_indices[:1].clamp(0)
+        self._lora_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(self._lora_stream):
+            per_expert_a_shrink(
+                ri_flat,
+                down_A_buf,
+                slot_idx,
+                safe_ids,
+                out=self._lora_a_flat_buf[:m_k],
+            )
+        self._prefetch_flags[1] = True
+
+    def _apply_gate_up_slot(
+        self,
+        layer_id: int,
+        slot: int,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        gate_up_output: torch.Tensor,
+        *,
+        token_mask: torch.Tensor | None = None,
+        sorted_token_ids: torch.Tensor | None = None,
+    ) -> None:
+        # For the single-slot case (all tokens same adapter), use dynamic GPU tensor
+        # indexing so the CUDA graph can replay with any loaded adapter.
+        # For multi-slot batches, fall back to Python dict lookup (eager only).
+        bi = self.batch_info
+        # Determine if we're on the CUDA-graph buffer path (single slot, all tokens
+        # same adapter). In this path we keep slot_idx as a GPU tensor so the CUDA
+        # graph can replay with any loaded adapter without re-capture.
+        _use_buffer_path = self.w13_A_buffers is not None and bi.single_lora_slot != -1
+        slot_idx = None
+        if _use_buffer_path:
+            slot_idx = bi.weight_indices[:1].clamp(0)
+            w13_B_buf = self.w13_B_buffers[layer_id]  # (n_slots, E, I2, MAX_R)
+            w13_B = None
+            # For the sglang_shared fast path (shared A, per-expert B) with fused kernels
+            # available, skip the w13_A gather entirely — shared_a_shrink reads directly from
+            # the buffer.  For all other paths, gather as before.
+            _w13_A_buf = self.w13_A_buffers[layer_id]
+            _skip_a_gather = (
+                _FUSED_MOE_LORA_AVAILABLE
+                and _w13_A_buf.shape[1] == 1  # shared outer (sglang_shared)
+                and w13_B_buf.shape[1] > 1  # per-expert B
+            )
+            # Also skip the buffer copy for per_expert format (both A and B per-expert):
+            # per_expert_a_shrink + per_expert_gate_up_b_expand read the full buffer
+            # directly, making the 32MB w13_A buffer copy unnecessary.
+            _skip_a_gather_per_expert = (
+                _FUSED_MOE_LORA_AVAILABLE
+                and _w13_A_buf.shape[1] > 1  # per-expert A
+                and w13_B_buf.shape[1] > 1  # per-expert B
+                and token_mask is None
+                and _w13_A_buf.is_contiguous()
+                and w13_B_buf.is_contiguous()
+            )
+            if _skip_a_gather or _skip_a_gather_per_expert:
+                # Use slot-0 view (Python int index = no copy) — correct shape for checks.
+                # Actual compute reads from the full buffers directly.
+                w13_A = _w13_A_buf[0]  # view: (1_or_E, R, H) — no copy!
+            else:
+                w13_A = _w13_A_buf[slot_idx].squeeze(0)
+        else:
+            weights = self.weights_by_layer.get(layer_id, {}).get(slot)
+            if weights is None:
+                return
+            w13_A = weights["w13_A"]
+            w13_B = weights["w13_B"]
+            w13_B_buf = None
+
+        # Determine shapes without materialising w13_B when on the buffer path.
+        if _use_buffer_path:
+            w13_A_experts = w13_A.shape[0]
+            w13_B_experts = w13_B_buf.shape[1]  # E dimension of buffer
+        else:
+            w13_A_experts = w13_A.shape[0]
+            w13_B_experts = w13_B.shape[0]
+        num_experts = max(w13_A_experts, w13_B_experts)
+        safe_ids = topk_ids.clamp(0, num_experts - 1).to(torch.long)
+        m, k = safe_ids.shape
+        # Build the validity mask without torch.any() to avoid GPU→CPU synchronisation.
+        if token_mask is not None:
+            valid = (topk_ids >= 0) & (topk_ids < num_experts) & token_mask[:, None]
+        else:
+            valid = None
+
+        # Check if per_expert fast path is available (avoids the 32MB+16MB gather copies).
+        # Must be determined before the A-shrink so we can skip the expensive gather+einsum.
+        _use_flat_per_expert = (
+            w13_A.shape[0] > 1  # per-expert A
+            and w13_B_buf is not None
+            and w13_B_experts > 1  # per-expert B
+            and _FUSED_MOE_LORA_AVAILABLE
+            and _use_buffer_path
+            and token_mask is None
+            and self.w13_A_buffers[layer_id].is_contiguous()
+            and w13_B_buf.is_contiguous()
+        )
+
+        # Shared A (sglang_shared format): one matmul for all tokens.
+        # lora_a_m (m, r) is only computed here; lora_a (m, k, r) is deferred until
+        # actually needed (not needed for the all-experts or shared-B paths).
+        lora_a_m = None
+        if w13_A.shape[0] == 1:
+            # Skip cuBLAS GEMM when shared_a_shrink will compute it without the gather.
+            if _use_buffer_path and _skip_a_gather:
+                lora_a_m = None  # computed by shared_a_shrink in the fused branch below
+            else:
+                lora_a_m = hidden_states @ w13_A[0].T
+            lora_a = None  # computed lazily below only if per-expert B path is taken
+        elif _use_flat_per_expert:
+            lora_a = (
+                None  # computed inline by per_expert_a_shrink + per_expert_*_b_expand
+            )
+        else:
+            selected_A = self._select_expert_weights(w13_A, safe_ids)
+            lora_a = torch.einsum("mh,mkrh->mkr", hidden_states, selected_A)
+
+        # Compute lora_a only when needed (per-expert B path).
+        # For shared-A + all-experts or shared-A + shared-B, lora_a_m is used directly.
+        # Lazily materialise w13_B for non-fused fallback paths on the buffer path.
+        def _get_w13_B():
+            nonlocal w13_B
+            if w13_B is None:
+                w13_B = w13_B_buf[slot_idx].squeeze(0)
+            return w13_B
+
+        if w13_B_experts == 1:
+            # Shared B: expand lora_a_m to (m*k, r) via repeat_interleave (no contiguous copy).
+            w13_B_local = _get_w13_B()
+            r = lora_a_m.shape[-1] if lora_a_m is not None else lora_a.shape[-1]
+            la_flat = (
+                lora_a_m.repeat_interleave(k, dim=0)
+                if lora_a_m is not None
+                else lora_a.reshape(-1, r)
+            )
+            delta = la_flat @ w13_B_local[0].T  # (m*k, n)
+            delta = delta.view(m, k, -1)
+        elif w13_A.shape[0] == 1:
+            # Shared-A + per-expert B.
+            if _FUSED_MOE_LORA_AVAILABLE and token_mask is None:
+                if sorted_token_ids is not None:
+                    # TMA sorted path: write to sorted output positions (SCATTER=False).
+                    _scaling = (
+                        self.scalings[slot_idx]
+                        if _use_buffer_path
+                        else self.scalings[slot]
+                    )
+                    w13_B_local = _get_w13_B()
+                    assert w13_B_local.is_contiguous(), "w13_B must be contiguous"
+                    sorted_gate_up_b_expand(
+                        lora_a_m,
+                        w13_B_local,
+                        safe_ids,
+                        sorted_token_ids,
+                        gate_up_output,
+                        _scaling,
+                        m * k,
+                        k,
+                    )
+                elif _use_buffer_path:
+                    # Decode path (buffer path): use pre-fetched lora_a_m if available
+                    # (launched on secondary stream before gate_up_gemm), else compute inline.
+                    _gu_prefetched = (
+                        self._prefetch_flags is not None
+                        and self._prefetch_flags[0]
+                        and self._lora_a_m_buf is not None
+                        and self._lora_stream is not None
+                    )
+                    if _gu_prefetched:
+                        # Join secondary stream: wait for torch.mm to complete.
+                        torch.cuda.current_stream().wait_stream(self._lora_stream)
+                        lora_a_m = self._lora_a_m_buf[: hidden_states.shape[0]]
+                        self._prefetch_flags[0] = False
+                    else:
+                        lora_a_m = shared_a_shrink(
+                            hidden_states, self.w13_A_buffers[layer_id], slot_idx
+                        )
+                    gate_up_b_expand(
+                        lora_a_m,
+                        w13_B_buf,
+                        slot_idx,
+                        safe_ids,
+                        gate_up_output,
+                        self.scalings,  # full buffer; kernel loads scalings[slot]
+                    )
+                else:
+                    # Non-buffer decode path (multi-slot eager).
+                    w13_B_local = _get_w13_B()
+                    assert w13_B_local.is_contiguous(), "w13_B must be contiguous"
+                    gate_up_b_expand(
+                        lora_a_m,
+                        w13_B_local.unsqueeze(0),
+                        torch.zeros(1, dtype=torch.int32, device=w13_B_local.device),
+                        safe_ids,
+                        gate_up_output,
+                        self.scalings[slot].unsqueeze(0),  # (1,) for slot 0 of fake buf
+                    )
+                return
+            # Fallback: all-experts GEMM + gather (no expand+copy needed).
+            w13_B_local = _get_w13_B()
+            E_fb, n_out, r = w13_B_local.shape
+            candidates = (
+                lora_a_m @ w13_B_local.permute(2, 0, 1).reshape(r, E_fb * n_out)
+            ).view(m, E_fb, n_out)
+            delta = candidates.gather(1, safe_ids.unsqueeze(-1).expand(-1, -1, n_out))
+        else:
+            # Per-expert A + per-expert B.
+            if _use_flat_per_expert:
+                # Fast flat path: avoid two buffer gather copies (w13_A_buf[slot] = 32MB,
+                # w13_B_buf[slot] = 16MB) by reading directly from the full buffers.
+                # per_expert_a_shrink reused: treats w13_A (n_slots, E, 2r, H) as
+                # down_A (n_slots, E, MAX_R, INTER) with MAX_R=2r, INTER=H.
+                hidden_flat = hidden_states.repeat_interleave(k, dim=0)  # (m*k, H)
+                lora_a_flat = per_expert_a_shrink(
+                    hidden_flat,
+                    self.w13_A_buffers[layer_id],
+                    slot_idx,
+                    safe_ids,
+                )  # (m*k, 2r)
+                per_expert_gate_up_b_expand(
+                    lora_a_flat,
+                    w13_B_buf,
+                    slot_idx,
+                    safe_ids,
+                    gate_up_output,
+                    self.scalings,
+                )
+                return
+            # Fallback: gather + einsum for non-buffer or masked paths.
+            w13_B_local = _get_w13_B()
+            if lora_a is None:
+                lora_a = lora_a_m.unsqueeze(1).expand(-1, k, -1).contiguous()
+            selected_B = self._select_expert_weights(w13_B_local, safe_ids)
+            delta = torch.einsum("mkr,mknr->mkn", lora_a, selected_B)
+
+        # Reuse slot_idx already computed above (avoid extra clamp+gather for scalings).
+        scaling = self.scalings[slot_idx] if _use_buffer_path else self.scalings[slot]
+        delta = delta * scaling
+        if valid is not None:
+            delta = delta.masked_fill(~valid[:, :, None], 0.0)
+        self._add_route_delta(
+            gate_up_output,
+            delta.reshape(-1, delta.shape[-1]),
+            sorted_token_ids=sorted_token_ids,
+        )
+
+    def _apply_down_sorted(
+        self,
+        layer_id: int,
+        slot: int,
+        intermediate: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+        down_output: torch.Tensor,
+        sorted_token_ids: torch.Tensor,
+    ) -> bool:
+        """Sorted-space down LoRA: skip route_from_cache, fuse per-expert shrink.
+
+        Returns True if the fast path was taken (per-expert A + shared B format),
+        False if the format requires the generic path.
+        """
+        bi = self.batch_info
+        slot_idx = bi.weight_indices[:1].clamp(0)
+        down_A = self.down_A_buffers[layer_id][slot_idx].squeeze(0)
+        down_B = self.down_B_buffers[layer_id][slot_idx].squeeze(0)
+        # Only handles per-expert A + shared B (sglang_shared format for down).
+        if down_A.shape[0] <= 1 or down_B.shape[0] != 1:
+            return False
+        if not down_A.is_contiguous():
+            return False
+
+        m, k = topk_ids.shape
+        num_experts = down_A.shape[0]
+        safe_ids = topk_ids.clamp(0, num_experts - 1).to(torch.long)
+        route_count = m * k
+
+        # moe_dispatch pre-allocates sorted_token_ids for all potential experts, which
+        # can exceed the intermediate cache size.  All valid entries (≥0) lie within
+        # the first intermediate.shape[0] rows (bound = m*k + max_active*(BM-1)).
+        inter_flat = intermediate.reshape(intermediate.shape[0], -1)
+        padded = inter_flat.shape[0]
+        sti = sorted_token_ids[:padded]  # truncate to intermediate size
+
+        # Fused per-expert shrink: lora_a[s] = intermediate[s] @ down_A[exp[s]].T
+        lora_a_sorted = sorted_a_down_shrink(
+            inter_flat,  # (padded, INTER)
+            down_A,  # (E, r, INTER)
+            safe_ids,
+            sti,
+            route_count=route_count,
+            K=k,
+        )
+
+        # Shared B GEMM: (padded, r) @ (r, h) → (padded, h)
+        delta = lora_a_sorted @ down_B[0].T
+
+        # Scale each sorted position by its topk_weight * adapter scaling.
+        valid = (sti >= 0) & (sti < route_count)
+        # Clamp to [0, route_count-1]: sorted_token_ids may contain route_count as
+        # a sentinel value, which would be OOB without the upper bound.
+        flat_j_safe = sti.clamp(0, route_count - 1)
+        weights_sorted = topk_weights.reshape(-1)[flat_j_safe].to(delta.dtype)
+        scaling_t = self.scalings[slot_idx].to(delta.dtype)
+        delta = delta * (weights_sorted * scaling_t * valid.to(delta.dtype)).unsqueeze(
+            -1
+        )
+
+        # Scatter-add to token-ordered down_output.
+        h = delta.shape[-1]
+        down_output.view(route_count, h).scatter_add_(
+            0, flat_j_safe.unsqueeze(-1).expand(-1, h), delta
+        )
+        return True
+
+    def _apply_down_slot(
+        self,
+        layer_id: int,
+        slot: int,
+        route_input: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+        down_output: torch.Tensor,
+        *,
+        token_mask: torch.Tensor | None = None,
+    ) -> None:
+        bi = self.batch_info
+        # Determine if we're on the CUDA-graph buffer path (single slot, all tokens
+        # same adapter). In this path we keep slot_idx as a GPU tensor so the CUDA
+        # graph can replay with any loaded adapter without re-capture.
+        _use_buffer_path = self.down_A_buffers is not None and bi.single_lora_slot != -1
+        slot_idx = None
+        if _use_buffer_path:
+            # (1,) GPU tensor — changes at CUDA-graph replay without re-capture.
+            slot_idx = bi.weight_indices[:1].clamp(0)
+            # Keep references to the full buffers; slicing is done lazily or inside kernels.
+            down_A_buf = self.down_A_buffers[layer_id]  # (n_slots, E, MAX_R, INTER)
+            down_B_buf = self.down_B_buffers[layer_id]  # (n_slots, 1_or_E, H, MAX_R)
+            # Sliced views are populated lazily to avoid redundant gathers.
+            down_A = None
+            down_B = None
+        else:
+            weights = self.weights_by_layer.get(layer_id, {}).get(slot)
+            if weights is None:
+                return
+            down_A = weights["down_A"]
+            down_B = weights["down_B"]
+            down_A_buf = None
+            down_B_buf = None
+
+        # Determine shapes without materialising tensors when on the buffer path.
+        if _use_buffer_path:
+            down_A_experts = down_A_buf.shape[1]  # E dimension of buffer
+            down_B_experts = down_B_buf.shape[1]  # 1 for shared-B
+        else:
+            down_A_experts = down_A.shape[0]
+            down_B_experts = down_B.shape[0]
+        num_experts = max(down_A_experts, down_B_experts)
+        safe_ids = topk_ids.clamp(0, num_experts - 1).to(torch.long)
+        m, k = safe_ids.shape
+        if token_mask is not None:
+            valid = (topk_ids >= 0) & (topk_ids < num_experts) & token_mask[:, None]
+        else:
+            valid = None
+
+        # Helpers to lazily materialise sliced tensors for fallback paths.
+        def _get_down_A():
+            nonlocal down_A
+            if down_A is None:
+                down_A = down_A_buf[slot_idx].squeeze(0)
+            return down_A
+
+        def _get_down_B():
+            nonlocal down_B
+            if down_B is None:
+                down_B = down_B_buf[slot_idx].squeeze(0)
+            return down_B
+
+        # Fast fused path: per-expert A + shared B on the CUDA-graph buffer path.
+        # Eliminates both gather copies (down_A gather + down_B gather) and the
+        # separate GEMM + scale + add chain.
+        if (
+            _FUSED_MOE_LORA_AVAILABLE
+            and _use_buffer_path
+            and token_mask is None
+            and down_A_experts > 1
+            and down_B_experts == 1
+            and down_A_buf.is_contiguous()
+            and down_B_buf.is_contiguous()
+        ):
+            _down_prefetched = (
+                self._prefetch_flags is not None
+                and self._prefetch_flags[1]
+                and self._lora_a_flat_buf is not None
+                and self._lora_stream is not None
+            )
+            if _down_prefetched:
+                # Join secondary stream: wait for per_expert_a_shrink to complete.
+                torch.cuda.current_stream().wait_stream(self._lora_stream)
+                lora_a_flat = self._lora_a_flat_buf[: m * k]
+                self._prefetch_flags[1] = False
+            else:
+                ri_flat = route_input.reshape(m * k, -1)  # (m*k, INTER)
+                lora_a_flat = per_expert_a_shrink(
+                    ri_flat, down_A_buf, slot_idx, safe_ids
+                )
+            shared_b_down_expand(
+                lora_a_flat,
+                down_B_buf,
+                slot_idx,
+                down_output.view(m, k, -1),
+                topk_weights,
+                self.scalings,  # full buffer; kernel loads scalings[slot]
+                k,
+            )
+            return
+
+        # Shared A (sglang_shared down_proj): one matmul per token-topk group.
+        if down_A_experts == 1:
+            down_A_local = _get_down_A()
+            ri = route_input.reshape(m * k, -1)  # (m*k, i)
+            lora_a = (ri @ down_A_local[0].T).view(m, k, -1)  # (m, k, r)
+        elif _FUSED_MOE_LORA_AVAILABLE and token_mask is None:
+            # Flat per-expert shrink: avoids the (m*k, r, INTER) gather intermediate
+            # and replaces the batched einsum with a single fused Triton kernel.
+            if _use_buffer_path:
+                # Buffer path: pass full buffer + slot_idx to avoid gather.
+                lora_a = per_expert_a_shrink(
+                    route_input.reshape(m * k, -1), down_A_buf, slot_idx, safe_ids
+                ).view(m, k, -1)
+            else:
+                down_A_local = _get_down_A()
+                assert down_A_local.is_contiguous(), "down_A must be contiguous"
+                lora_a = per_expert_a_shrink(
+                    route_input.reshape(m * k, -1),
+                    down_A_local.unsqueeze(0),  # fake (1, E, MAX_R, INTER) buffer
+                    torch.zeros(1, dtype=torch.int32, device=down_A_local.device),
+                    safe_ids,
+                ).view(m, k, -1)
+        else:
+            down_A_local = _get_down_A()
+            selected_A = self._select_expert_weights(down_A_local, safe_ids)
+            lora_a = torch.einsum("mki,mkri->mkr", route_input, selected_A)
+
+        # Shared B (sglang_shared down_proj): one batched matmul.
+        if down_B_experts == 1:
+            down_B_local = _get_down_B()
+            r = lora_a.shape[-1]
+            delta = lora_a.reshape(-1, r) @ down_B_local[0].T  # (m*k, h)
+            delta = delta.view(m, k, -1)
+        elif (
+            _FUSED_MOE_LORA_AVAILABLE
+            and _use_buffer_path
+            and token_mask is None
+            and down_B_buf.is_contiguous()
+        ):
+            # Per-expert B fast path: avoid the 16MB buffer copy + gather.
+            # lora_a computed via per_expert_a_shrink is already (m*k, r); reshape to flat.
+            lora_a_flat = lora_a.reshape(m * k, -1)
+            per_expert_b_down_expand(
+                lora_a_flat,
+                down_B_buf,
+                slot_idx,
+                safe_ids,
+                down_output.view(m, k, -1),
+                topk_weights,
+                self.scalings,
+                k,
+            )
+            return  # accumulation already done inside the kernel
+        else:
+            down_B_local = _get_down_B()
+            selected_B = self._select_expert_weights(down_B_local, safe_ids)
+            delta = torch.einsum("mkr,mkhr->mkh", lora_a, selected_B)
+
+        delta = delta * topk_weights[:, :, None].to(delta.dtype)
+        # Reuse slot_idx computed above for scalings (avoid extra clamp+gather).
+        scaling = self.scalings[slot_idx] if _use_buffer_path else self.scalings[slot]
+        delta = delta * scaling
+        if valid is not None:
+            delta = delta.masked_fill(~valid[:, :, None], 0.0)
+        down_output.view(topk_ids.shape[0], topk_ids.shape[1], -1).add_(delta)
+
+    @staticmethod
+    def _select_expert_weights(
+        weights: torch.Tensor,
+        safe_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        if weights.shape[0] == 1:
+            return weights[0].expand(*safe_ids.shape, *weights.shape[1:])
+        return weights[safe_ids]
+
+    @staticmethod
+    def _add_route_delta(
+        output: torch.Tensor,
+        route_delta: torch.Tensor,
+        *,
+        sorted_token_ids: torch.Tensor | None,
+    ) -> None:
+        if sorted_token_ids is None:
+            output.view(route_delta.shape[0], -1).add_(route_delta)
+            return
+        # moe_dispatch may pre-allocate sorted_token_ids larger than output.
+        # Truncate: all valid entries lie within the first output.shape[0] rows.
+        padded = output.shape[0]
+        sti = sorted_token_ids[:padded]
+        # Gather route_delta into output-layout, zero invalid (padding) entries,
+        # then add in one vectorised kernel — avoids boolean-index tensor creation.
+        route_count = route_delta.shape[0]
+        clipped = sti.clamp(0, route_count - 1).to(torch.long)
+        reordered = route_delta[clipped]  # (padded, n)
+        invalid = (sti < 0) | (sti >= route_count)
+        reordered.masked_fill_(invalid.unsqueeze(-1), 0)
+        output.add_(reordered)
+
+    @staticmethod
+    def _route_rows_from_cache(
+        cache: torch.Tensor,
+        route_count: int,
+        *,
+        sorted_token_ids: torch.Tensor | None,
+    ) -> torch.Tensor:
+        if sorted_token_ids is None:
+            return cache.view(route_count, -1)
+        # moe_dispatch may pre-allocate sorted_token_ids larger than cache.
+        # Truncate: all valid entries lie within the first cache.shape[0] rows.
+        sti = sorted_token_ids[: cache.shape[0]]
+        # Use scatter_ with an extra dummy row (index 0) for padding positions.
+        # Avoids boolean-index tensor creation; one scatter_ + one slice.
+        n = cache.shape[-1]
+        rows = torch.zeros((route_count + 1, n), dtype=cache.dtype, device=cache.device)
+        # Shift: -1 (padding) → 0 (dummy), valid 0..route_count-1 → 1..route_count.
+        clipped = (sti.clamp(-1, route_count - 1) + 1).to(torch.long)
+        rows.scatter_(0, clipped.unsqueeze(-1).expand(-1, n), cache)
+        return rows[1:]  # drop dummy row → (route_count, n)
+
+
+class MoeLoraBuffers:
+    """Own expert-scoped MoE LoRA weights independently from dense buffers."""
+
+    def __init__(
+        self,
+        *,
+        n_layers: int,
+        n_slots: int,
+        max_lora_rank: int,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_per_tp: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        shard_weights: Callable[
+            [str, torch.Tensor, torch.Tensor], tuple[torch.Tensor, torch.Tensor]
+        ],
+        enabled: bool = True,
+        compressed_shared_outer: bool = False,
+    ) -> None:
+        self.n_layers = n_layers
+        self.n_slots = n_slots
+        self.max_lora_rank = max_lora_rank
+        self.num_experts = num_experts
+        self.hidden_size = hidden_size
+        self.intermediate_per_tp = intermediate_per_tp
+        self.dtype = dtype
+        self.device = device
+        self._shard_weights = shard_weights
+        self.enabled = enabled
+        self.compressed_shared_outer = compressed_shared_outer
+        self.weights_by_layer: MoeWeightsByLayer = {}
+        self.w13_A_buffers: list[torch.Tensor] = []
+        self.w13_B_buffers: list[torch.Tensor] = []
+        self.down_A_buffers: list[torch.Tensor] = []
+        self.down_B_buffers: list[torch.Tensor] = []
+        self._alloc()
+        # Multi-stream prefetch: overlap LoRA shrink ops with base MoE GEMMs.
+        # Shrink kernels run on a secondary stream in parallel with gate_up/down GEMMs.
+        # Pre-allocated output buffers avoid torch.empty inside CUDA graphs.
+        _max_bs = 128
+        _max_topk = 8
+        self._lora_stream: torch.cuda.Stream | None = (
+            torch.cuda.Stream() if torch.cuda.is_available() else None
+        )
+        self._lora_a_m_buf: torch.Tensor | None = None
+        self._lora_a_flat_buf: torch.Tensor | None = None
+        if self.enabled and torch.cuda.is_available():
+            # gate/up shrink: (m, 2*r); down shrink: (m*topk, r)
+            self._lora_a_m_buf = torch.zeros(
+                _max_bs, 2 * max_lora_rank, dtype=dtype, device=device
+            )
+            self._lora_a_flat_buf = torch.zeros(
+                _max_bs * _max_topk, max_lora_rank, dtype=dtype, device=device
+            )
+            # Pre-warm cuBLAS and Triton kernels on _lora_stream before any CUDA graph
+            # capture. torch.mm (cuBLAS) requires its handle to be initialized on each
+            # stream; failing to do so causes CUBLAS_STATUS_NOT_INITIALIZED during capture.
+            if self._lora_stream is not None:
+                _d = torch.zeros(1, dtype=dtype, device=device)
+                with torch.cuda.stream(self._lora_stream):
+                    torch.mm(_d.unsqueeze(0), _d.unsqueeze(1))
+                del _d
+                torch.cuda.synchronize()
+        # Mutable flags shared between MoeLoraBuffers and MoeLoraContext instances:
+        # [0] = gate_up shrink launched; [1] = down shrink launched.
+        self._prefetch_flags: list[bool] = [False, False]
+
+    def _alloc(self) -> None:
+        if not self.enabled:
+            return
+        n = self.n_slots
+        e = max(self.num_experts, 0)
+        r = self.max_lora_rank
+        h = self.hidden_size
+        i = self.intermediate_per_tp
+        w13_a_experts = 1 if self.compressed_shared_outer else e
+        w13_b_experts = e
+        down_a_experts = e
+        down_b_experts = 1 if self.compressed_shared_outer else e
+        for _ in range(self.n_layers):
+            self.w13_A_buffers.append(
+                torch.zeros(
+                    (n, w13_a_experts, 2 * r, h),
+                    dtype=self.dtype,
+                    device=self.device,
+                )
+            )
+            self.w13_B_buffers.append(
+                torch.zeros(
+                    (n, w13_b_experts, 2 * i, 2 * r),
+                    dtype=self.dtype,
+                    device=self.device,
+                )
+            )
+            self.down_A_buffers.append(
+                torch.zeros(
+                    (n, down_a_experts, r, i), dtype=self.dtype, device=self.device
+                )
+            )
+            self.down_B_buffers.append(
+                torch.zeros(
+                    (n, down_b_experts, h, r), dtype=self.dtype, device=self.device
+                )
+            )
+
+    def load_adapter_to_slot(self, cpu_weights, slot: int, rank: int) -> None:
+        has_moe = any(
+            mod.startswith("experts.")
+            for modules in cpu_weights.values()
+            for mod in modules
+        )
+        if has_moe and not self.enabled:
+            raise ValueError(
+                "Adapter contains MoE LoRA weights, but LoRA buffer group 'moe' "
+                "is disabled."
+            )
+        if self.num_experts <= 0:
+            if has_moe:
+                raise ValueError(
+                    "MoE LoRA adapter requires model_config.num_experts or "
+                    "model_config.num_local_experts."
+                )
+            return
+        rank = min(rank, self.max_lora_rank)
+        for layer_id, modules in cpu_weights.items():
+            if not any(mod.startswith("experts.") for mod in modules):
+                continue
+            self._clear_layer_slot(layer_id, slot)
+            if any(
+                mod in modules for mod in ("experts.w1", "experts.w2", "experts.w3")
+            ):
+                self._load_3d_adapter_layer(layer_id, modules, slot, rank)
+            else:
+                self._load_2d_adapter_layer(layer_id, modules, slot, rank)
+
+    def _load_2d_adapter_layer(self, layer_id: int, modules, slot: int, rank: int):
+        expert_ids = [
+            int(mod.split(".")[1]) for mod in modules if mod.startswith("experts.")
+        ]
+        if not expert_ids:
+            return
+        if self.compressed_shared_outer:
+            raise ValueError(
+                "Compressed MoE shared-outer storage only supports 3D "
+                "experts.w1/w2/w3 adapters."
+            )
+        num_experts = max(expert_ids) + 1
+        self._check_num_experts(layer_id, num_experts)
+        w13_A, w13_B, down_A, down_B = self._slot_layer_tensors(layer_id, slot)
+        r = rank
+        for mod, (lora_A_full, lora_B_full) in modules.items():
+            if not mod.startswith("experts."):
+                continue
+            _, expert_id_s, module = mod.split(".", 2)
+            expert_id = int(expert_id_s)
+            # Normalize A/B convention: standard PEFT stores A as (rank, in_features)
+            # and B as (out_features, rank).  Some adapters use the transposed layout
+            # (in_features, rank) and (rank, out_features).  Detect by comparing dims:
+            # if the first dim is larger than the second, A is in (in, rank) format.
+            if lora_A_full.dim() == 2 and lora_A_full.shape[0] > lora_A_full.shape[1]:
+                lora_A_full = lora_A_full.T  # (in, rank) → (rank, in)
+            if lora_B_full.dim() == 2 and lora_B_full.shape[0] < lora_B_full.shape[1]:
+                lora_B_full = lora_B_full.T  # (rank, out) → (out, rank)
+            lora_A_shard_cpu, lora_B_shard_cpu = self._shard_weights(
+                module, lora_A_full, lora_B_full
+            )
+            actual_rank = min(lora_A_shard_cpu.shape[0], r)
+            lora_A_shard = lora_A_shard_cpu[:actual_rank].to(
+                device=self.device,
+                dtype=self.dtype,
+                non_blocking=True,
+            )
+            lora_B_shard = lora_B_shard_cpu[:, :actual_rank].to(
+                device=self.device,
+                dtype=self.dtype,
+                non_blocking=True,
+            )
+            self._copy_projection(
+                module,
+                expert_id,
+                actual_rank,
+                lora_A_shard,
+                lora_B_shard,
+                w13_A,
+                w13_B,
+                down_A,
+                down_B,
+                rank=r,
+            )
+        self.weights_by_layer.setdefault(layer_id, {})[slot] = {
+            "w13_A": w13_A,
+            "w13_B": w13_B,
+            "down_A": down_A,
+            "down_B": down_B,
+        }
+
+    def _load_3d_adapter_layer(self, layer_id: int, modules, slot: int, rank: int):
+        required = ("experts.w1", "experts.w2", "experts.w3")
+        missing = [name for name in required if name not in modules]
+        if missing:
+            raise ValueError(
+                f"3D MoE LoRA layer {layer_id} is missing modules: {missing}"
+            )
+        w1_A, w1_B = modules["experts.w1"]
+        w2_A, w2_B = modules["experts.w2"]
+        w3_A, w3_B = modules["experts.w3"]
+        num_experts = self._infer_3d_num_experts((w1_A, w1_B, w2_A, w2_B, w3_A, w3_B))
+        self._check_num_experts(layer_id, num_experts)
+        if self.compressed_shared_outer:
+            self._check_shared_outer_layer(layer_id, modules, num_experts)
+        w13_A, w13_B, down_A, down_B = self._slot_layer_tensors(layer_id, slot)
+        self._copy_3d_projection(
+            "gate_proj", w1_A, w1_B, w13_A, w13_B, down_A, down_B, rank
+        )
+        self._copy_3d_projection(
+            "up_proj", w3_A, w3_B, w13_A, w13_B, down_A, down_B, rank
+        )
+        self._copy_3d_projection(
+            "down_proj", w2_A, w2_B, w13_A, w13_B, down_A, down_B, rank
+        )
+        E_b, I2, R = w13_B.shape
+        w13_B_T = w13_B.permute(2, 0, 1).reshape(R, E_b * I2).contiguous()
+        self.weights_by_layer.setdefault(layer_id, {})[slot] = {
+            "w13_A": w13_A,
+            "w13_B": w13_B,
+            "w13_B_T": w13_B_T,
+            "down_A": down_A,
+            "down_B": down_B,
+        }
+
+    def _check_num_experts(self, layer_id: int, adapter_num_experts: int) -> None:
+        if adapter_num_experts > self.num_experts:
+            raise ValueError(
+                f"MoE LoRA layer {layer_id} has {adapter_num_experts} experts, "
+                f"but the model has {self.num_experts}."
+            )
+
+    def _slot_layer_tensors(self, layer_id: int, slot: int):
+        return (
+            self.w13_A_buffers[layer_id][slot],
+            self.w13_B_buffers[layer_id][slot],
+            self.down_A_buffers[layer_id][slot],
+            self.down_B_buffers[layer_id][slot],
+        )
+
+    def _clear_layer_slot(self, layer_id: int, slot: int) -> None:
+        self.w13_A_buffers[layer_id][slot].zero_()
+        self.w13_B_buffers[layer_id][slot].zero_()
+        self.down_A_buffers[layer_id][slot].zero_()
+        self.down_B_buffers[layer_id][slot].zero_()
+
+    @staticmethod
+    def _check_shared_outer_layer(
+        layer_id: int,
+        modules,
+        num_experts: int,
+    ) -> None:
+        expected = {
+            "experts.w1": (1, num_experts),
+            "experts.w2": (num_experts, 1),
+            "experts.w3": (1, num_experts),
+        }
+        for module, (expected_a, expected_b) in expected.items():
+            lora_A, lora_B = modules[module]
+            if lora_A.shape[0] != expected_a or lora_B.shape[0] != expected_b:
+                raise ValueError(
+                    "Compressed MoE shared-outer storage expects "
+                    f"{module} A/B dim0=({expected_a}, {expected_b}) for "
+                    f"layer {layer_id}; got {tuple(lora_A.shape)}, "
+                    f"{tuple(lora_B.shape)}."
+                )
+
+    @staticmethod
+    def _infer_3d_num_experts(tensors: tuple[torch.Tensor, ...]) -> int:
+        num_experts = 0
+        for tensor in tensors:
+            if tensor.dim() != 3:
+                raise ValueError(
+                    f"3D MoE LoRA tensors must be rank-3, got shape {tuple(tensor.shape)}"
+                )
+            if tensor.shape[0] != 1:
+                num_experts = max(num_experts, int(tensor.shape[0]))
+        if num_experts <= 0:
+            raise ValueError("3D MoE LoRA layer has no per-expert tensor dimension")
+        for tensor in tensors:
+            if tensor.shape[0] not in (1, num_experts):
+                raise ValueError(
+                    "3D MoE LoRA dim0 must be either 1 (shared) or num_experts "
+                    f"({num_experts}); got {tuple(tensor.shape)}"
+                )
+        return num_experts
+
+    def _copy_3d_projection(
+        self,
+        module: str,
+        lora_A_full: torch.Tensor,
+        lora_B_full: torch.Tensor,
+        w13_A: torch.Tensor,
+        w13_B: torch.Tensor,
+        down_A: torch.Tensor,
+        down_B: torch.Tensor,
+        rank: int,
+    ) -> None:
+        num_experts = max(
+            w13_A.shape[0], w13_B.shape[0], down_A.shape[0], down_B.shape[0]
+        )
+        if self.compressed_shared_outer:
+            self._copy_3d_projection_compressed(
+                module,
+                lora_A_full,
+                lora_B_full,
+                w13_A,
+                w13_B,
+                down_A,
+                down_B,
+                rank,
+                num_experts,
+            )
+            return
+        for expert_id in range(num_experts):
+            lora_A = self._select_3d_expert_tensor(lora_A_full, expert_id)
+            lora_B = self._select_3d_expert_tensor(lora_B_full, expert_id)
+            lora_A_shard_cpu, lora_B_shard_cpu = self._shard_weights(
+                module, lora_A, lora_B
+            )
+            actual_rank = min(lora_A_shard_cpu.shape[0], rank)
+            lora_A_shard = lora_A_shard_cpu[:actual_rank].to(
+                device=self.device,
+                dtype=self.dtype,
+                non_blocking=True,
+            )
+            lora_B_shard = lora_B_shard_cpu[:, :actual_rank].to(
+                device=self.device,
+                dtype=self.dtype,
+                non_blocking=True,
+            )
+            self._copy_projection(
+                module,
+                expert_id,
+                actual_rank,
+                lora_A_shard,
+                lora_B_shard,
+                w13_A,
+                w13_B,
+                down_A,
+                down_B,
+                rank=rank,
+                a_expert_id=self._dst_expert_id(module, "A", expert_id),
+                b_expert_id=self._dst_expert_id(module, "B", expert_id),
+            )
+
+    def _copy_3d_projection_compressed(
+        self,
+        module: str,
+        lora_A_full: torch.Tensor,
+        lora_B_full: torch.Tensor,
+        w13_A: torch.Tensor,
+        w13_B: torch.Tensor,
+        down_A: torch.Tensor,
+        down_B: torch.Tensor,
+        rank: int,
+        num_experts: int,
+    ) -> None:
+        if module in ("gate_proj", "up_proj"):
+            shared_A = self._select_3d_expert_tensor(lora_A_full, 0)
+            first_B = self._select_3d_expert_tensor(lora_B_full, 0)
+            lora_A_shard_cpu, _ = self._shard_weights(module, shared_A, first_B)
+            actual_rank = min(lora_A_shard_cpu.shape[0], rank)
+            lora_A_shard = lora_A_shard_cpu[:actual_rank].to(
+                device=self.device,
+                dtype=self.dtype,
+                non_blocking=True,
+            )
+            if module == "gate_proj":
+                w13_A[0, :actual_rank, :].copy_(lora_A_shard, non_blocking=True)
+            else:
+                w13_A[0, rank : rank + actual_rank, :].copy_(
+                    lora_A_shard, non_blocking=True
+                )
+            for expert_id in range(num_experts):
+                expert_B = self._select_3d_expert_tensor(lora_B_full, expert_id)
+                _, lora_B_shard_cpu = self._shard_weights(module, shared_A, expert_B)
+                b_rank = min(lora_B_shard_cpu.shape[1], rank)
+                lora_B_shard = lora_B_shard_cpu[:, :b_rank].to(
+                    device=self.device,
+                    dtype=self.dtype,
+                    non_blocking=True,
+                )
+                if module == "gate_proj":
+                    w13_B[expert_id, : self.intermediate_per_tp, :b_rank].copy_(
+                        lora_B_shard, non_blocking=True
+                    )
+                else:
+                    w13_B[
+                        expert_id,
+                        self.intermediate_per_tp : 2 * self.intermediate_per_tp,
+                        rank : rank + b_rank,
+                    ].copy_(lora_B_shard, non_blocking=True)
+            return
+
+        if module == "down_proj":
+            first_A = self._select_3d_expert_tensor(lora_A_full, 0)
+            shared_B = self._select_3d_expert_tensor(lora_B_full, 0)
+            _, lora_B_shard_cpu = self._shard_weights(module, first_A, shared_B)
+            b_rank = min(lora_B_shard_cpu.shape[1], rank)
+            lora_B_shard = lora_B_shard_cpu[:, :b_rank].to(
+                device=self.device,
+                dtype=self.dtype,
+                non_blocking=True,
+            )
+            down_B[0, :, :b_rank].copy_(lora_B_shard, non_blocking=True)
+            for expert_id in range(num_experts):
+                expert_A = self._select_3d_expert_tensor(lora_A_full, expert_id)
+                lora_A_shard_cpu, _ = self._shard_weights(module, expert_A, shared_B)
+                actual_rank = min(lora_A_shard_cpu.shape[0], rank)
+                lora_A_shard = lora_A_shard_cpu[:actual_rank].to(
+                    device=self.device,
+                    dtype=self.dtype,
+                    non_blocking=True,
+                )
+                down_A[expert_id, :actual_rank, :].copy_(
+                    lora_A_shard, non_blocking=True
+                )
+            return
+
+        raise ValueError(f"Unsupported MoE LoRA projection: {module}")
+
+    @staticmethod
+    def _select_3d_expert_tensor(tensor: torch.Tensor, expert_id: int) -> torch.Tensor:
+        return tensor[0 if tensor.shape[0] == 1 else expert_id]
+
+    def _copy_projection(
+        self,
+        module: str,
+        expert_id: int,
+        actual_rank: int,
+        lora_A_shard: torch.Tensor,
+        lora_B_shard: torch.Tensor,
+        w13_A: torch.Tensor,
+        w13_B: torch.Tensor,
+        down_A: torch.Tensor,
+        down_B: torch.Tensor,
+        *,
+        rank: int,
+        a_expert_id: int | None = None,
+        b_expert_id: int | None = None,
+    ) -> None:
+        a_expert_id = expert_id if a_expert_id is None else a_expert_id
+        b_expert_id = expert_id if b_expert_id is None else b_expert_id
+        if module == "gate_proj":
+            w13_A[a_expert_id, :actual_rank, :].copy_(lora_A_shard, non_blocking=True)
+            w13_B[
+                b_expert_id,
+                : self.intermediate_per_tp,
+                :actual_rank,
+            ].copy_(lora_B_shard, non_blocking=True)
+        elif module == "up_proj":
+            w13_A[a_expert_id, rank : rank + actual_rank, :].copy_(
+                lora_A_shard, non_blocking=True
+            )
+            w13_B[
+                b_expert_id,
+                self.intermediate_per_tp : 2 * self.intermediate_per_tp,
+                rank : rank + actual_rank,
+            ].copy_(lora_B_shard, non_blocking=True)
+        elif module == "down_proj":
+            down_A[a_expert_id, :actual_rank, :].copy_(lora_A_shard, non_blocking=True)
+            down_B[b_expert_id, :, :actual_rank].copy_(lora_B_shard, non_blocking=True)
+        else:
+            raise ValueError(f"Unsupported MoE LoRA projection: {module}")
+
+    def _dst_expert_id(self, module: str, side: str, expert_id: int) -> int:
+        if not self.compressed_shared_outer:
+            return expert_id
+        if module in ("gate_proj", "up_proj") and side == "A":
+            return 0
+        if module == "down_proj" and side == "B":
+            return 0
+        return expert_id
+
+    def clear_slot(self, slot: int) -> None:
+        if not self.enabled:
+            return
+        for layer_id in range(self.n_layers):
+            self._clear_layer_slot(layer_id, slot)
+        for layer_slots in self.weights_by_layer.values():
+            layer_slots.pop(slot, None)
+
+    def clear_slot_cpu_only(self, slot: int) -> None:
+        """Remove slot from CPU-side tracking without GPU zeroing.
+
+        The GPU weight tensors for this slot are NOT zeroed.  This is safe
+        because prepare_loras only assigns weight_indices[i] to slots present
+        in _name_to_slot, which is cleared before this method is called.
+        No kernel can read from an evicted slot.  Stale GPU values are
+        overwritten when _load_to_slot reuses the slot for a new adapter.
+        """
+        if not self.enabled:
+            return
+        for layer_slots in self.weights_by_layer.values():
+            layer_slots.pop(slot, None)
+
+    def build_context(
+        self,
+        *,
+        batch_info: LoraBatchInfo,
+        scalings: torch.Tensor,
+        has_active_lora: bool,
+    ) -> "MoeLoraContext":
+        return MoeLoraContext(
+            weights_by_layer=self.weights_by_layer,
+            batch_info=batch_info,
+            scalings=scalings,
+            has_active_lora=has_active_lora,
+            w13_A_buffers=self.w13_A_buffers if self.enabled else None,
+            w13_B_buffers=self.w13_B_buffers if self.enabled else None,
+            down_A_buffers=self.down_A_buffers if self.enabled else None,
+            down_B_buffers=self.down_B_buffers if self.enabled else None,
+            _lora_stream=self._lora_stream,
+            _lora_a_m_buf=self._lora_a_m_buf,
+            _lora_a_flat_buf=self._lora_a_flat_buf,
+            _prefetch_flags=self._prefetch_flags,
+        )

--- a/python/tokenspeed/runtime/models/qwen3.py
+++ b/python/tokenspeed/runtime/models/qwen3.py
@@ -63,11 +63,13 @@ class Qwen3MLP(nn.Module):
         intermediate_size: int,
         hidden_act: str,
         quant_config: QuantizationConfig | None = None,
+        layer_id: int = 0,
         tp_rank: int | None = None,
         tp_size: int | None = None,
         tp_group: tuple[int, ...] | None = None,
     ) -> None:
         super().__init__()
+        self.layer_id = layer_id
         self.gate_up_proj = MergedColumnParallelLinear(
             hidden_size,
             [intermediate_size] * 2,
@@ -94,11 +96,17 @@ class Qwen3MLP(nn.Module):
             )
         self.act_fn = SiluAndMul()
 
-    def forward(self, x):
+    def forward(self, x, ctx: ForwardContext | None = None):
         gate_up, _ = self.gate_up_proj(x)
-        x = self.act_fn(gate_up)
-        x, _ = self.down_proj(x)
-        return x
+        # LoRA delta on the fused gate/up output (added before SiluAndMul,
+        # matching PEFT semantics).
+        if ctx is not None and ctx.lora_manager is not None:
+            gate_up = ctx.lora_manager.apply_gate_up_lora(x, gate_up, self.layer_id)
+        intermediate = self.act_fn(gate_up)
+        out, _ = self.down_proj(intermediate)
+        if ctx is not None and ctx.lora_manager is not None:
+            out = ctx.lora_manager.apply_down_lora(intermediate, out, self.layer_id)
+        return out
 
 
 class Qwen3Attention(nn.Module):
@@ -120,6 +128,7 @@ class Qwen3Attention(nn.Module):
         prefix: str = "",
     ) -> None:
         super().__init__()
+        self.layer_id = layer_id
         self.mapping = mapping
         self.hidden_size = hidden_size
         self.tp_rank = self.mapping.attn.tp_rank
@@ -210,6 +219,14 @@ class Qwen3Attention(nn.Module):
         cos_sin: tuple[torch.Tensor, torch.Tensor] | None = None,
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
+
+        # LoRA delta for Q/K/V projections (segment-grouped Triton path).
+        # The manager's batch_info holds persistent buffers, so this call
+        # is safe to record into a CUDA graph: replay updates batch_info
+        # in place before graph.replay().
+        if ctx.lora_manager is not None:
+            qkv = ctx.lora_manager.apply_qkv_lora(hidden_states, qkv, self.layer_id)
+
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         q, k = self._apply_qk_norm(q, k)
         q, k = self.rotary_emb(positions, q, k)
@@ -217,6 +234,11 @@ class Qwen3Attention(nn.Module):
         if len(attn_output.size()) == 3:
             attn_output = attn_output.reshape(attn_output.shape[0], -1)
         output, _ = self.o_proj(attn_output)
+
+        # LoRA delta for O projection
+        if ctx.lora_manager is not None:
+            output = ctx.lora_manager.apply_o_lora(attn_output, output, self.layer_id)
+
         return output
 
 
@@ -261,6 +283,7 @@ class Qwen3DecoderLayer(nn.Module):
             intermediate_size=config.intermediate_size,
             hidden_act=config.hidden_act,
             quant_config=quant_config,
+            layer_id=layer_id,
             tp_rank=self.mapping.dense.tp_rank,
             tp_size=self.mapping.dense.tp_size,
             tp_group=self.mapping.dense.tp_group,
@@ -321,7 +344,7 @@ class Qwen3DecoderLayer(nn.Module):
                     residual,
                 )
             )
-        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.mlp(hidden_states, ctx)
         return hidden_states, residual
 
 

--- a/python/tokenspeed/runtime/models/qwen3_5.py
+++ b/python/tokenspeed/runtime/models/qwen3_5.py
@@ -803,9 +803,16 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
+        ctx: ForwardContext,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
         """qkv_proj + split + rope (+ optional gate). ``gate`` is ``None`` when ``attn_output_gate=False``."""
         qkv, _ = self.qkv_proj(hidden_states)
+
+        # Apply QKV LoRA delta (same as qwen3.py; qkv layout matches the buffer
+        # offsets because q_size_per_tp already accounts for attn_output_gate).
+        if ctx.lora_manager is not None:
+            qkv = ctx.lora_manager.apply_qkv_lora(hidden_states, qkv, self.layer_id)
+
         if self.attn_output_gate:
             q_gate, k, v = qkv.split(
                 [self.q_size * 2, self.kv_size, self.kv_size], dim=-1
@@ -852,9 +859,14 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         out_cache_loc: torch.Tensor,
     ) -> torch.Tensor:
         """Full attention forward pass."""
-        q, k, v, gate = self._project_qkv_rope(positions, hidden_states)
+        q, k, v, gate = self._project_qkv_rope(positions, hidden_states, ctx)
         attn_output = self._attn(q, k, v, gate, ctx, out_cache_loc)
         output, _ = self.o_proj(attn_output)
+
+        # Apply O-projection LoRA delta.
+        if ctx.lora_manager is not None:
+            output = ctx.lora_manager.apply_o_lora(attn_output, output, self.layer_id)
+
         return output
 
     def _maybe_narrow_residual(

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -286,6 +286,30 @@ class ServerArgs:
     # server started without the matching flag will receive empty logprobs.
     enable_output_logprobs: bool = False
 
+    # LoRA adapter serving
+    enable_lora: bool = False
+    # Maximum number of LoRA adapters resident in GPU memory at once.
+    # Adapters beyond this cap are LRU-evicted to the CPU pool.
+    max_loras: int = 4
+    # Maximum LoRA rank supported (caps adapter loading; larger = more GPU memory).
+    max_lora_rank: int = 64
+    # Maximum number of LoRA adapters cached in CPU pinned memory.  When
+    # an adapter is evicted from this pool it falls back to its disk path
+    # (assumed durable) and is reloaded on next use.  ``None`` ⇒ default
+    # to ``4 * max_loras``.
+    max_loras_cpu: int | None = None
+    # Comma-separated coarse GPU buffer families to allocate for LoRA.
+    # Valid groups: attn, mlp, moe, lm_head.
+    lora_buffer_groups: str = "attn,mlp,moe"
+    # Store 3D MoE shared-outer adapters in compressed shared/per-expert
+    # buffers instead of fully expanding all sides to num_experts.
+    lora_moe_compressed_shared_outer: bool = False
+    # Scheduler-side LoRA scheduling policy.  ``"lru"`` (default) just
+    # relies on the manager's LRU; ``"admission"`` (future) gates batches
+    # that don't fit in GPU; ``"pack"`` (future) sorts the queue to reuse
+    # resident adapters.
+    lora_scheduling_policy: str = "lru"
+
     # Runtime options
     disable_pdl: bool = False
     enable_prefix_caching: bool = True
@@ -756,6 +780,43 @@ class ServerArgs:
             )
 
     def resolve_disaggregation(self):
+        if self.enable_lora:
+            # LoRA delta path is baked into the captured graph: the per-token
+            # slot index buffer (LoraManager.weight_indices_buf) is bound at
+            # capture and updated in place at replay. Base/no-LoRA requests
+            # use NO_LORA_SLOT in metadata and do not consume a GPU slot.
+            #
+            # Default the CPU pool to 4× the GPU pool so adapter swap-out
+            # to disk is rare in steady state.
+            if self.max_loras_cpu is None:
+                self.max_loras_cpu = 4 * self.max_loras
+            if self.max_loras_cpu < self.max_loras:
+                raise ValueError(
+                    f"max_loras_cpu ({self.max_loras_cpu}) must be ≥ "
+                    f"max_loras ({self.max_loras}) — every GPU-resident "
+                    "adapter must also fit in the CPU pool."
+                )
+            groups = {
+                group.strip()
+                for group in self.lora_buffer_groups.split(",")
+                if group.strip()
+            }
+            valid_groups = {"attn", "mlp", "moe", "lm_head"}
+            unknown_groups = groups - valid_groups
+            if not groups:
+                raise ValueError("lora_buffer_groups must include at least one group.")
+            if unknown_groups:
+                raise ValueError(
+                    "lora_buffer_groups contains unknown groups: "
+                    f"{sorted(unknown_groups)}. Valid groups: {sorted(valid_groups)}."
+                )
+            self.lora_buffer_groups = ",".join(sorted(groups))
+            if self.lora_moe_compressed_shared_outer and "moe" not in groups:
+                raise ValueError(
+                    "--lora-moe-compressed-shared-outer requires "
+                    "--lora-buffer-groups to include 'moe'."
+                )
+
         # PD disaggregation
         if self.disaggregation_mode == "prefill":
             self.enforce_eager = True
@@ -1736,6 +1797,70 @@ class ServerArgs:
             action="store_true",
             help="Disable PDL launch.",
         )
+        # LoRA adapter serving
+        parser.add_argument(
+            "--enable-lora",
+            action="store_true",
+            default=ServerArgs.enable_lora,
+            help="Enable LoRA adapter serving.",
+        )
+        parser.add_argument(
+            "--max-loras",
+            type=int,
+            default=ServerArgs.max_loras,
+            help="Maximum number of LoRA adapters in GPU memory at once.",
+        )
+        parser.add_argument(
+            "--max-lora-rank",
+            type=int,
+            default=ServerArgs.max_lora_rank,
+            help="Maximum LoRA rank supported across all loaded adapters.",
+        )
+        parser.add_argument(
+            "--max-loras-cpu",
+            type=int,
+            default=ServerArgs.max_loras_cpu,
+            help=(
+                "Maximum number of LoRA adapters cached in CPU pinned "
+                "memory.  Defaults to 4 × --max-loras.  Adapters evicted "
+                "from this pool are reloaded from disk on next use."
+            ),
+        )
+        parser.add_argument(
+            "--lora-buffer-groups",
+            type=str,
+            default=ServerArgs.lora_buffer_groups,
+            help=(
+                "Comma-separated LoRA GPU buffer groups to allocate. "
+                "Valid groups: attn, mlp, moe, lm_head. Loading an adapter that "
+                "targets a disabled group raises an error."
+            ),
+        )
+        parser.add_argument(
+            "--lora-moe-compressed-shared-outer",
+            action="store_true",
+            default=ServerArgs.lora_moe_compressed_shared_outer,
+            help=(
+                "Use compressed MoE storage for 3D shared-outer adapters "
+                "(w1/w3 A shared, w1/w3 B per-expert, w2 A per-expert, "
+                "w2 B shared)."
+            ),
+        )
+        parser.add_argument(
+            "--lora-scheduling-policy",
+            type=str,
+            default=ServerArgs.lora_scheduling_policy,
+            choices=["lru", "pack"],
+            help=(
+                "Scheduler-side LoRA scheduling policy. ``lru`` (default) "
+                "submits requests in arrival order and relies on the "
+                "manager's LRU pool. ``pack`` sorts the admission queue "
+                "by lora_id so adapter-shared requests cluster, reducing "
+                "eviction churn when working_set > max_loras_cpu and "
+                "traffic is bursty."
+            ),
+        )
+
         prefix_cache_group = parser.add_mutually_exclusive_group()
         prefix_cache_group.add_argument(
             "--enable-prefix-caching",


### PR DESCRIPTION
## Summary

Port of the **runtime half** of the closed #738 onto current `main`: adapter registry, GPU slot manager, batch metadata, Triton LoRA shrink/expand kernels, and the load/unload control-plane messages.

> **Stacked on #982.** This PR targets `towillwu/lora-kernels`, so its diff shows only the runtime layer. Review #976 then #982 first; GitHub retargets automatically as each merges.

Ported, not rebased — #738 was written 191 commits back and its scheduler commit has been superseded, so this carries only its runtime commit and reconciles it with what `main` grew since.

## What was dropped and why

| Dropped | Reason |
|---|---|
| #738's **scheduler commit** | Its per-adapter KV namespace + `max_loras` cap targeted the radix prefix cache that #864 deleted. Redone against the hash-chain cache in #976 (the parent of this stack). |
| #738's **MoE commit** (`ef4827ed`) | Hooked MoE LoRA into `ops/moe/triton/fp8.py` and `mxfp4.py`, but #914 rewrote the Triton MoE kernels: `fp8.py` was **deleted** (Triton FP8 MoE now routes through deep_gemm/flashinfer) and `mxfp4.py` was rewritten across 1287 lines with different registration traits. Re-adding a `supports_moe_lora` trait there would assert behavior nobody has verified. Left as a follow-up. |
| `prefix_cache_adjunct` | Belonged to the removed radix path; `tokenspeed-scheduler/python/tests/test_cache_binding.py` now *asserts* `SchedulerConfig` has no such attribute. |

`lora/moe_lora.py` is included but no kernel calls it until the MoE follow-up lands.

## Reconciliation notes

- `BaseTokenToKVPool` → `CachePool` rename applied to the `TYPE_CHECKING` imports.
- #738's `model_executor` hunk carried a `draft_block_reservation_slack` block that no longer exists on `main`; only the LoRA init is kept, leaving main's draft page-size validation intact.
- `max_loras` reaches the scheduler config once, from the parent branch; #738's duplicate assignment is dropped. The `server_args.enable_lora` gate is kept, forcing `max_loras=0` when LoRA is off.
- The adapter id on the request is an `int` (0 = base), matching this runtime's three-tier name → registry id → GPU slot scheme. #976 was adjusted to that wire format rather than the reverse, so the registry layer here is untouched.

## Testing

- Scheduler extension rebuilt against this branch; **368/368 C++ tests** and **5/5 Python plumbing tests** pass on CPU.
- The LoRA kernels this calls are numerically validated on H100 in #982.
- `ruff` (CI select), `pre-commit`: clean.

**Not verified:** no GPU serving path here was exercised. Adapter loading, the slot manager's evict/promote cycle, CUDA-graph capture with the LoRA delta path, and end-to-end generation with a real adapter have **not** been run. Those need a GPU pass with an actual adapter checkpoint.
