### PR TITLE
feat(kernel): Triton LoRA shrink/expand kernels

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/__init__.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Triton kernels for segment-grouped LoRA matmuls.
+
+Adapted from sglang ``python/sglang/srt/lora/triton_ops/`` (Apache-2.0):
+https://github.com/sgl-project/sglang/tree/main/python/sglang/srt/lora/triton_ops.
+sglang's kernels in turn descend from the Punica S-LoRA design
+(https://github.com/punica-ai/punica).  Each batch is a sequence of
+segments where each segment uses a single adapter; the kernels fuse the
+per-segment GEMMs into a single launch and keep per-segment state
+(rank, scaling) on-device.  See each kernel module for file-level
+provenance.
+"""
+
+from tokenspeed_kernel.ops.lora.triton.lora_expand import lora_expand_fwd
+from tokenspeed_kernel.ops.lora.triton.lora_expand_grouped_v2 import (
+    lora_expand_grouped_v2_fwd,
+)
+from tokenspeed_kernel.ops.lora.triton.lora_expand_prefill import (
+    lora_expand_prefill_fwd,
+)
+from tokenspeed_kernel.ops.lora.triton.lora_gate_up_expand import (
+    lora_gate_up_expand_fwd,
+)
+from tokenspeed_kernel.ops.lora.triton.lora_qkv_expand import lora_qkv_expand_fwd
+from tokenspeed_kernel.ops.lora.triton.lora_shrink import lora_shrink_fwd
+from tokenspeed_kernel.ops.lora.triton.lora_shrink_prefill import (
+    lora_shrink_prefill_fwd,
+)
+
+__all__ = [
+    "lora_shrink_fwd",
+    "lora_shrink_prefill_fwd",
+    "lora_expand_fwd",
+    "lora_expand_grouped_v2_fwd",
+    "lora_qkv_expand_fwd",
+    "lora_gate_up_expand_fwd",
+    "lora_expand_prefill_fwd",
+]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/configs/H100_80GB_HBM3/_lora_expand_kernel.json
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/configs/H100_80GB_HBM3/_lora_expand_kernel.json
@@ -1,0 +1,178 @@
+{
+  "(24576, 128, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 64,
+      "BLOCK_S": 8
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 3,
+    "num_warps": 4
+  },
+  "(24576, 16, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 16,
+      "BLOCK_N": 128,
+      "BLOCK_S": 8
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(24576, 32, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 16,
+      "BLOCK_N": 32,
+      "BLOCK_S": 8
+    },
+    "maxnreg": 160,
+    "num_ctas": 1,
+    "num_stages": 2,
+    "num_warps": 4
+  },
+  "(24576, 64, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 64,
+      "BLOCK_S": 8
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 2,
+    "num_warps": 4
+  },
+  "(4096, 128, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(4096, 16, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 16,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 2,
+    "num_warps": 4
+  },
+  "(4096, 32, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 32,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(4096, 64, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(6144, 128, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 64,
+      "BLOCK_S": 8
+    },
+    "maxnreg": 160,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(6144, 16, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 16,
+      "BLOCK_N": 128,
+      "BLOCK_S": 8
+    },
+    "maxnreg": 160,
+    "num_ctas": 1,
+    "num_stages": 3,
+    "num_warps": 4
+  },
+  "(6144, 32, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 32,
+      "BLOCK_N": 128,
+      "BLOCK_S": 8
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(6144, 64, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 16,
+      "BLOCK_N": 32,
+      "BLOCK_S": 8
+    },
+    "maxnreg": 160,
+    "num_ctas": 1,
+    "num_stages": 3,
+    "num_warps": 4
+  },
+  "(8192, 128, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(8192, 16, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 16,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 2,
+    "num_warps": 4
+  },
+  "(8192, 32, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 32,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(8192, 64, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  }
+}

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/configs/H100_80GB_HBM3/_lora_gate_up_expand_kernel.json
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/configs/H100_80GB_HBM3/_lora_gate_up_expand_kernel.json
@@ -1,0 +1,266 @@
+{
+  "(12288, 128, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(12288, 16, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 16,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 2,
+    "num_warps": 4
+  },
+  "(12288, 32, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 32,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(12288, 64, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(14336, 128, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(14336, 16, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 16,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 2,
+    "num_warps": 4
+  },
+  "(14336, 32, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 32,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(14336, 64, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(3072, 128, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(3072, 16, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 16,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 2,
+    "num_warps": 4
+  },
+  "(3072, 32, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 32,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(3072, 64, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(3584, 128, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(3584, 16, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 16,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 2,
+    "num_warps": 4
+  },
+  "(3584, 32, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 32,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(3584, 64, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(6144, 128, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(6144, 16, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 16,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 2,
+    "num_warps": 4
+  },
+  "(6144, 32, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 32,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(6144, 64, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(7168, 128, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(7168, 16, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 16,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 2,
+    "num_warps": 4
+  },
+  "(7168, 32, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 32,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(7168, 64, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  }
+}

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/configs/H100_80GB_HBM3/_lora_qkv_expand_kernel.json
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/configs/H100_80GB_HBM3/_lora_qkv_expand_kernel.json
@@ -1,0 +1,134 @@
+{
+  "(1024, 128, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(1024, 16, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 16,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 2,
+    "num_warps": 4
+  },
+  "(1024, 32, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 32,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(1024, 64, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(2048, 128, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(2048, 16, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 16,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 2,
+    "num_warps": 4
+  },
+  "(2048, 32, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 32,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(2048, 64, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(4096, 128, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(4096, 16, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 16,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 2,
+    "num_warps": 4
+  },
+  "(4096, 32, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 32,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  },
+  "(4096, 64, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.float32')": {
+    "kwargs": {
+      "BLOCK_K": 64,
+      "BLOCK_N": 128,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 1,
+    "num_warps": 4
+  }
+}

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/configs/H100_80GB_HBM3/_lora_shrink_kernel.json
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/configs/H100_80GB_HBM3/_lora_shrink_kernel.json
@@ -1,0 +1,541 @@
+{
+  "(128, 1024, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 128,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(128, 12288, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 128,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(128, 14336, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 128,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(128, 2048, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 128,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(128, 3072, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 128,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(128, 3584, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 128,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(128, 4096, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 128,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(128, 6144, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 128,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(128, 7168, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 128,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(128, 8192, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 128,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(16, 1024, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 128,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(16, 12288, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(16, 14336, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(16, 2048, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 128,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(16, 3072, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(16, 3584, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(16, 4096, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(16, 6144, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(16, 7168, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(192, 4096, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 128,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(192, 8192, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(256, 4096, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 128,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(256, 8192, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(32, 1024, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 3,
+    "num_warps": 4
+  },
+  "(32, 12288, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(32, 14336, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(32, 2048, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 128,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(32, 3072, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(32, 3584, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(32, 4096, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(32, 6144, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(32, 7168, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(32, 8192, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(384, 4096, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 3,
+    "num_warps": 4
+  },
+  "(384, 8192, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(48, 4096, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(48, 8192, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(64, 1024, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 3,
+    "num_warps": 4
+  },
+  "(64, 12288, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(64, 14336, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(64, 2048, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(64, 3072, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(64, 3584, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(64, 4096, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(64, 6144, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(64, 7168, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(64, 8192, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 16,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(96, 4096, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 256,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  },
+  "(96, 8192, 'torch.bfloat16', 'torch.bfloat16', 'torch.bfloat16', 'torch.int32', 'torch.int32', 'torch.int32', 'torch.int32')": {
+    "kwargs": {
+      "BLOCK_K": 128,
+      "BLOCK_N": 32,
+      "BLOCK_S": 16
+    },
+    "maxnreg": null,
+    "num_ctas": 1,
+    "num_stages": 4,
+    "num_warps": 4
+  }
+}

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/kernel_utils.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/kernel_utils.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Shared Triton helpers for the LoRA segmented matmul kernels.
+
+Adapted from sglang ``python/sglang/srt/lora/triton_ops/kernel_utils.py``
+(Apache-2.0): https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/lora/triton_ops/kernel_utils.py.
+"""
+
+from tokenspeed_kernel._triton import tl, triton
+
+
+@triton.jit
+def _resolve_token_positions(
+    sorted_token_ids, seg_start, s_offset, seg_len, SORTED_BY_ADAPTER: tl.constexpr
+):
+    """Map logical segment offsets to physical token positions.
+
+    When ``SORTED_BY_ADAPTER`` is True the segment is a sorted slice of the
+    real token grid and ``sorted_token_ids[seg_start + s_offset]`` gives the
+    physical row index.  Otherwise tokens in this segment occupy a
+    contiguous range starting at ``seg_start``.
+    """
+    if SORTED_BY_ADAPTER:
+        return tl.load(
+            sorted_token_ids + seg_start + s_offset, mask=s_offset < seg_len
+        ).to(tl.int64)
+    return (seg_start + s_offset).to(tl.int64)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/lora_expand.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/lora_expand.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Segmented LoRA-B matmul (expand: r → out_dim) with fused scale + add.
+
+Adapted from sglang ``python/sglang/srt/lora/triton_ops/sgemm_lora_b.py``
+(Apache-2.0): https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/lora/triton_ops/sgemm_lora_b.py.
+sglang's kernel is descended from the Punica S-LoRA design
+(https://github.com/punica-ai/punica).  Local changes mirror those in
+``lora_shrink.py`` (autotune + on-disk cache, constexpr ordering).
+"""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel._triton import tl, triton
+from tokenspeed_kernel.ops.lora.triton.kernel_utils import _resolve_token_positions
+from tokenspeed_kernel.ops.lora.triton.tuning import load_kernel_cache
+
+# Expand kernel: N = out_dim (large, 4096+), K = max_rank (tiny, 16–128).
+# Tile space targets "large N, small K, small S".  Mirrors sglang's
+# csgmv-expand grid (PR #20391); maxnreg helped with occupancy there.
+#
+# Profiling (2026-05-19) showed the kernel is instruction/overhead-bound
+# (0% memory bandwidth utilisation).  Two improvements over the original
+# k ∈ {16, 32} space:
+#  • k=64, 128: when BLOCK_K == rank the inner K-loop runs exactly once,
+#    eliminating loop overhead and the k-mask predicate entirely.
+#  • BLOCK_N=128 with num_warps=4: halves CTA count vs BLOCK_N=64, which
+#    amortises per-CTA fixed cost without increasing register pressure.
+_EXPAND_CONFIGS = [
+    triton.Config(
+        {"BLOCK_S": s, "BLOCK_N": n, "BLOCK_K": k},
+        num_warps=w,
+        num_stages=stages,
+        maxnreg=mr,
+    )
+    for s in (8, 16, 32)
+    for n in (32, 64, 128)
+    for k in (16, 32, 64, 128)
+    for w in (4, 8)
+    for stages in (1, 2, 3)
+    for mr in (None, 128, 160)
+]
+
+
+@triton.autotune(configs=_EXPAND_CONFIGS, key=["N", "K"], restore_value=["output"])
+@triton.jit
+def _lora_expand_kernel(
+    x,
+    weights,
+    output,
+    N,  # out_dim
+    K,  # max_rank
+    x_stride_0,
+    x_stride_1,
+    w_stride_0,
+    w_stride_1,
+    w_stride_2,
+    output_stride_0,
+    output_stride_1,
+    seg_lens,
+    seg_indptr,
+    weight_indices,
+    lora_ranks,
+    sorted_token_ids,
+    scalings,
+    SORTED_BY_ADAPTER: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    batch_id = tl.program_id(axis=1)
+    w_index = tl.load(weight_indices + batch_id)
+    if w_index < 0:
+        return
+    rank = tl.load(lora_ranks + w_index)
+
+    # rank == 0 is defensive: leave the base output unchanged.
+    if rank == 0:
+        return
+
+    pid = tl.program_id(axis=0)
+    seg_len = tl.load(seg_lens + batch_id)
+    if seg_len == 0:
+        return
+    seg_start = tl.load(seg_indptr + batch_id)
+    scaling = tl.load(scalings + w_index)
+    K = tl.minimum(K, rank)
+
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+    pid_s = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    if pid_s * BLOCK_S >= seg_len:
+        return
+
+    s_offset = tl.arange(0, BLOCK_S) + pid_s * BLOCK_S
+    n_offset = tl.arange(0, BLOCK_N) + pid_n * BLOCK_N
+    k_offset = tl.max_contiguous(tl.arange(0, BLOCK_K), BLOCK_K)
+    s_physical = _resolve_token_positions(
+        sorted_token_ids, seg_start, s_offset, seg_len, SORTED_BY_ADAPTER
+    )
+    x_ptrs = x + (s_physical[:, None] * x_stride_0 + k_offset[None, :] * x_stride_1)
+    w_ptrs = (weights + w_index * w_stride_0) + (
+        k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
+    )
+
+    s_mask = s_offset[:, None] < seg_len  # hoisted: loop-invariant
+    n_mask = n_offset[None, :] < N  # hoisted: loop-invariant (already was)
+    partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
+    for k in range(tl.cdiv(K, BLOCK_K)):
+        k_remaining = K - k * BLOCK_K
+        x_tile = tl.load(
+            x_ptrs,
+            mask=s_mask & (k_offset[None, :] < k_remaining),
+            other=0.0,
+            eviction_policy="evict_first",
+        )
+        w_tile = tl.load(
+            w_ptrs,
+            mask=(k_offset[:, None] < k_remaining) & n_mask,
+            other=0.0,
+            eviction_policy="evict_last",
+        )
+        partial_sum += tl.dot(x_tile, w_tile)
+
+        x_ptrs += BLOCK_K * x_stride_1
+        w_ptrs += BLOCK_K * w_stride_2
+
+    partial_sum *= scaling
+    partial_sum = partial_sum.to(x.dtype.element_ty)
+    output_ptr = output + (
+        s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1
+    )
+    output_mask = s_mask & n_mask
+    partial_sum += tl.load(output_ptr, mask=output_mask, other=0.0)
+    tl.store(output_ptr, partial_sum, mask=output_mask)
+
+
+def lora_expand_fwd(
+    x: torch.Tensor,
+    weights: torch.Tensor,
+    batch_info,
+    base_output: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run the LoRA-B expand and fuse-add into ``base_output``.
+
+    Args:
+        x: ``(s, max_rank)`` activations from lora_shrink.
+        weights: ``(num_lora, out_dim, max_rank)``, contiguous.
+        batch_info: :class:`LoraBatchInfo` describing the segment layout.
+        base_output: optional ``(s, out_dim)`` to add into.  When ``None``,
+            allocates a fresh zero-filled output.
+
+    Returns:
+        ``(s, out_dim)`` (same buffer as ``base_output`` when supplied).
+    """
+    assert x.is_contiguous()
+    assert weights.is_contiguous()
+    assert x.dim() == 2
+    assert weights.dim() == 3
+
+    S = x.shape[0]
+    N = weights.shape[-2]
+    R = weights.shape[-1]
+    assert x.shape[-1] == R
+
+    max_len = batch_info.max_len
+
+    def grid(meta):
+        return (
+            triton.cdiv(max_len, meta["BLOCK_S"]) * triton.cdiv(N, meta["BLOCK_N"]),
+            batch_info.bs,
+        )
+
+    if base_output is None:
+        output = torch.zeros((S, N), device=x.device, dtype=x.dtype)
+    else:
+        output = base_output
+
+    sorted_by_adapter = batch_info.permutation is not None
+    _lora_expand_kernel[grid](
+        x,
+        weights,
+        output,
+        N,
+        R,
+        x.stride(0),
+        x.stride(1),
+        weights.stride(0),
+        weights.stride(1),
+        weights.stride(2),
+        output.stride(0),
+        output.stride(1),
+        batch_info.seg_lens,
+        batch_info.seg_indptr,
+        batch_info.weight_indices,
+        batch_info.lora_ranks,
+        batch_info.permutation,
+        batch_info.scalings,
+        sorted_by_adapter,
+    )
+    return output
+
+
+load_kernel_cache(_lora_expand_kernel)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/lora_expand_grouped_v2.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/lora_expand_grouped_v2.py
@@ -1,0 +1,236 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Adapter-grouped LoRA-B expand without gather/scatter overhead.
+
+Adapts vLLM's token-sorted dispatch pattern (PR vllm-project/vllm#...,
+Apache-2.0) to our kernel infrastructure.
+
+This kernel reads ``x`` and writes ``output`` directly at the original
+  (unsorted) token positions using ``token_indices`` loaded inside the kernel.
+  No gather/scatter needed — only a cheap pointer indirection per tile.
+
+Grid: ``(cdiv(N, BLOCK_N), num_groups)``  — axis 1 = unique adapter count.
+Within each CTA, groups of ``BLOCK_S`` tokens are processed; each group loads
+``BLOCK_S`` scattered rows from ``x`` via ``token_indices``.
+
+Adapted from vLLM ``vllm/lora/ops/triton_ops/lora_expand_op.py`` (Apache-2.0):
+https://github.com/vllm-project/vllm/blob/main/vllm/lora/ops/triton_ops/lora_expand_op.py
+Local changes: removed SPLIT_K / PDL / CAST_TYPE / multi-slice indirection;
+added BLOCK_K ∈ {16,32,64,128} + tl.multiple_of EVEN_K; adopted our
+eviction-policy hints and autotune + on-disk cache infrastructure.
+"""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel._triton import tl, triton
+from tokenspeed_kernel.ops.lora.triton.tuning import load_kernel_cache
+
+_GROUPED_V2_CONFIGS = [
+    triton.Config(
+        {"BLOCK_S": s, "BLOCK_N": n, "BLOCK_K": k},
+        num_warps=w,
+        num_stages=stages,
+        maxnreg=mr,
+    )
+    for s in (16, 32)
+    for n in (32, 64, 128)
+    for k in (16, 32, 64, 128)
+    for w in (4, 8)
+    for stages in (1, 2, 3)
+    for mr in (None, 128, 160)
+]
+
+
+@triton.autotune(
+    configs=_GROUPED_V2_CONFIGS,
+    key=["N", "MAX_RANK"],
+    restore_value=["output"],
+)
+@triton.jit(do_not_specialize=["output_stride_0", "output_stride_1"])
+def _lora_expand_grouped_v2_kernel(
+    x,  # (M, MAX_RANK)  original unsorted token order
+    weights,  # (n_slots, N, MAX_RANK)
+    output,  # (M, N)  written at original token positions
+    group_slots,  # (num_groups,) int32 — weight-slot index per group
+    group_starts,  # (num_groups,) int32 — start in token_indices
+    group_sizes,  # (num_groups,) int32 — tokens per group
+    token_indices,  # (M,) int32  — token positions sorted by adapter
+    scalings,  # (n_slots,) float32
+    lora_ranks,  # (n_slots,) int32
+    output_stride_0,
+    output_stride_1,
+    N: tl.constexpr,
+    MAX_RANK: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    # Constexpr strides — x and weights are always contiguous.
+    x_stride_0: tl.constexpr = MAX_RANK
+    x_stride_1: tl.constexpr = 1
+    w_stride_0: tl.constexpr = N * MAX_RANK
+    w_stride_1: tl.constexpr = MAX_RANK  # row stride inside (N, MAX_RANK) slice
+    w_stride_2: tl.constexpr = 1
+
+    group_id = tl.program_id(axis=1)
+    # axis=0 encodes both the within-group M-tile and the N-tile.
+    # Grid: (cdiv(M, BLOCK_S) * cdiv(N, BLOCK_N), num_groups) — mirrors vLLM's
+    # (M_tiles × N_tiles, num_active_loras) layout.  CTAs whose M-tile exceeds
+    # the group size exit immediately (same early-exit pattern as vLLM).
+    pid_flat = tl.program_id(axis=0)
+    cta_n_num = tl.cdiv(N, BLOCK_N)
+    pid_m = pid_flat // cta_n_num
+    pid_n = pid_flat % cta_n_num
+
+    w_index = tl.load(group_slots + group_id)
+    if w_index < 0:
+        return
+    g_size = tl.load(group_sizes + group_id)
+    if g_size == 0:
+        return
+    rank = tl.load(lora_ranks + w_index)
+    if rank == 0:
+        return
+
+    m_off = pid_m * BLOCK_S
+    if m_off >= g_size:
+        return  # early exit for M-tiles beyond this group's token count
+
+    g_start = tl.load(group_starts + group_id)
+    scaling = tl.load(scalings + w_index)
+    K = tl.minimum(MAX_RANK, rank)
+
+    n_offset = tl.arange(0, BLOCK_N) + pid_n * BLOCK_N
+    k_offset = tl.max_contiguous(tl.arange(0, BLOCK_K), BLOCK_K)
+    n_mask = n_offset[None, :] < N
+
+    # Load physical token positions for this M-tile.
+    s_offset = tl.arange(0, BLOCK_S)
+    m_valid = s_offset < g_size - m_off
+    tok_ptrs = token_indices + g_start + m_off + s_offset
+    ram = tl.load(tok_ptrs, mask=m_valid, other=0)
+    s_valid = m_valid[:, None]
+
+    # Scattered read of x — no pre-gather needed.
+    x_ptrs = x + ram[:, None] * x_stride_0 + k_offset[None, :] * x_stride_1
+    w_ptrs = (weights + w_index * w_stride_0) + (
+        k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
+    )
+
+    partial = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
+    for k in range(tl.cdiv(K, BLOCK_K)):
+        k_rem = K - k * BLOCK_K
+        x_tile = tl.load(
+            x_ptrs,
+            mask=s_valid & (k_offset[None, :] < k_rem),
+            other=0.0,
+            eviction_policy="evict_first",
+        )
+        w_tile = tl.load(
+            w_ptrs,
+            mask=(k_offset[:, None] < k_rem) & n_mask,
+            other=0.0,
+            eviction_policy="evict_last",
+        )
+        partial += tl.dot(x_tile, w_tile)
+        x_ptrs += BLOCK_K * x_stride_1
+        w_ptrs += BLOCK_K * w_stride_2
+
+    partial *= scaling
+    partial = partial.to(x.dtype.element_ty)
+
+    # Scattered write — no post-scatter needed.
+    out_ptrs = (
+        output + ram[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1
+    )
+    out_mask = s_valid & n_mask
+    partial += tl.load(out_ptrs, mask=out_mask, other=0.0)
+    tl.store(out_ptrs, partial, mask=out_mask)
+
+
+def lora_expand_grouped_v2_fwd(
+    x: torch.Tensor,
+    weights: torch.Tensor,
+    batch_info,
+    base_output: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Adapter-grouped expand without gather/scatter.
+
+    Reads ``x`` and writes ``output`` at original token positions using
+    ``batch_info.token_indices`` (sorted by adapter).  Requires batch_info to
+    have the adapter-group metadata populated by ``prepare_loras``:
+    ``token_indices``, ``group_slots``, ``group_starts``, ``group_sizes``,
+    ``num_groups``.
+
+    Drops in for :func:`lora_expand_fwd` when ``batch_info.num_groups > 0``
+    and ``batch_info.bs // batch_info.num_groups >= 8``.
+    """
+    assert x.is_contiguous()
+    assert weights.is_contiguous()
+
+    S, R = x.shape
+    N = weights.shape[-2]
+    dev, dt = x.device, x.dtype
+
+    num_groups = batch_info.num_groups
+
+    # Use the largest group size for the M dimension, not the total batch size.
+    # This makes the grid tight for both extremes:
+    #   • n_unique = n  (all different): max_group_size = 1
+    #     → grid = (1 × cdiv(N,BLOCK_N), n) ≡ segmented layout, zero wasted CTAs
+    #   • n_unique = 1  (all same):      max_group_size = n
+    #     → grid = (n/BLOCK_S × cdiv(N,BLOCK_N), 1) ≡ grpv2 layout
+    # max_group_size is pre-computed on CPU in prepare_loras — no GPU sync here.
+    max_group_size = batch_info.max_group_size
+
+    def grid(meta):
+        return (
+            triton.cdiv(max_group_size, meta["BLOCK_S"])
+            * triton.cdiv(N, meta["BLOCK_N"]),
+            num_groups,
+        )
+
+    output = (
+        torch.zeros((S, N), device=dev, dtype=dt)
+        if base_output is None
+        else base_output
+    )
+
+    _lora_expand_grouped_v2_kernel[grid](
+        x,
+        weights,
+        output,
+        batch_info.group_slots[:num_groups],
+        batch_info.group_starts[:num_groups],
+        batch_info.group_sizes[:num_groups],
+        batch_info.sort_order[: batch_info.bs],  # token_indices sorted by adapter
+        batch_info.scalings,
+        batch_info.lora_ranks,
+        output.stride(0),
+        output.stride(1),
+        N=N,
+        MAX_RANK=R,
+    )
+    return output
+
+
+load_kernel_cache(_lora_expand_grouped_v2_kernel)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/lora_expand_prefill.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/lora_expand_prefill.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Unified LoRA-B expand for prefill batches (chunked-SGMV style).
+
+Replaces the three separate ``lora_expand`` / ``lora_qkv_expand`` /
+``lora_gate_up_expand`` kernels for the prefill path.  A single kernel
+handles any number of output slices via the ``NUM_SLICES`` constexpr and a
+``slice_offsets`` boundary tensor — the same trick as sglang's
+``chunked_sgmv_expand`` (PR sgl-project/sglang#20391).
+
+Key structural difference from the decode-path expand kernels:
+* ``OUTPUT_DIM``, ``MAX_RANK``, ``NUM_SLICES`` are **constexpr** — the
+  compiler specialises the K-loop trip count and all strides at compile
+  time, which gives 2–3× speedup over runtime-stride kernels at prefill
+  with rank ≥ 64.
+* x strides are derived as compile-time constants:
+  ``x_stride_0 = NUM_SLICES * MAX_RANK``, ``x_stride_1 = 1``.
+
+Use :func:`lora_expand_fwd` / :func:`lora_qkv_expand_fwd` /
+:func:`lora_gate_up_expand_fwd` for decode (``max_len ≤ 32``); switch to
+:func:`lora_expand_prefill_fwd` for prefill.
+
+Adapted from sglang ``python/sglang/srt/lora/triton_ops/chunked_sgmv_expand.py``
+(previously ``chunked_sgmv_expand.py`` in this repo)
+(Apache-2.0): https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/lora/triton_ops/chunked_sgmv_expand.py.
+Local changes: merged SORTED_BY_ADAPTER from our decode kernels (avoids
+permutation overhead for unsorted batches), replaced fixed configs with
+``@triton.autotune`` + on-disk cache, constexpr ordering.
+"""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel._triton import tl, triton
+from tokenspeed_kernel.ops.lora.triton.kernel_utils import _resolve_token_positions
+from tokenspeed_kernel.ops.lora.triton.tuning import load_kernel_cache
+
+_PREFILL_EXPAND_CONFIGS = [
+    triton.Config(
+        {"BLOCK_S": s, "BLOCK_N": n, "BLOCK_K": k},
+        num_warps=w,
+        num_stages=stages,
+        maxnreg=mr,
+    )
+    for s in (16, 32)
+    for n in (32, 64, 128)
+    for k in (16, 32)
+    for w in (4, 8)
+    for stages in (1, 2, 3)
+    for mr in (None, 128, 160)
+]
+
+
+@triton.autotune(
+    configs=_PREFILL_EXPAND_CONFIGS,
+    key=["OUTPUT_DIM", "MAX_RANK", "NUM_SLICES"],
+    restore_value=["output"],
+)
+@triton.jit(do_not_specialize=["output_stride_0", "output_stride_1"])
+def _lora_expand_prefill_kernel(
+    x,
+    weights,
+    output,
+    output_stride_0,
+    output_stride_1,
+    seg_lens,
+    seg_indptr,
+    weight_indices,
+    lora_ranks,
+    sorted_token_ids,
+    scalings,
+    slice_offsets,
+    NUM_SLICES: tl.constexpr,
+    OUTPUT_DIM: tl.constexpr,
+    MAX_RANK: tl.constexpr,
+    SORTED_BY_ADAPTER: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    # Constexpr strides — compiler eliminates all stride multiplications.
+    x_stride_0: tl.constexpr = NUM_SLICES * MAX_RANK
+    x_stride_1: tl.constexpr = 1
+    w_stride_0: tl.constexpr = OUTPUT_DIM * MAX_RANK
+    w_stride_1: tl.constexpr = MAX_RANK
+    w_stride_2: tl.constexpr = 1
+
+    batch_id = tl.program_id(axis=2)
+    w_index = tl.load(weight_indices + batch_id)
+    if w_index < 0:
+        return
+    rank = tl.load(lora_ranks + w_index)
+    if rank == 0:
+        return
+
+    slice_id = tl.program_id(axis=1)
+    pid = tl.program_id(axis=0)
+    seg_len = tl.load(seg_lens + batch_id)
+    if seg_len == 0:
+        return
+    seg_start = tl.load(seg_indptr + batch_id)
+    slice_start = tl.load(slice_offsets + slice_id)
+    slice_end = tl.load(slice_offsets + slice_id + 1)
+    n_size = slice_end - slice_start
+    scaling = tl.load(scalings + w_index)
+    K = tl.minimum(MAX_RANK, rank)
+
+    num_pid_n = tl.cdiv(n_size, BLOCK_N)
+    pid_s = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    if pid_s * BLOCK_S >= seg_len:
+        return
+
+    s_offset = tl.arange(0, BLOCK_S) + pid_s * BLOCK_S
+    n_offset = tl.arange(0, BLOCK_N) + pid_n * BLOCK_N
+    k_offset = tl.arange(0, BLOCK_K)
+
+    s_physical = _resolve_token_positions(
+        sorted_token_ids, seg_start, s_offset, seg_len, SORTED_BY_ADAPTER
+    )
+
+    # x: slice i starts at column i * K (actual rank, not MAX_RANK).
+    x_ptrs = (
+        x
+        + slice_id * K * x_stride_1
+        + (s_physical[:, None] * x_stride_0 + k_offset[None, :] * x_stride_1)
+    )
+    w_ptrs = (weights + w_index * w_stride_0 + slice_start * w_stride_1) + (
+        k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
+    )
+
+    n_mask = n_offset[None, :] < n_size
+    partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
+    for k in range(tl.cdiv(K, BLOCK_K)):
+        x_tile = tl.load(
+            x_ptrs,
+            mask=(s_offset[:, None] < seg_len) & (k_offset[None, :] < K - k * BLOCK_K),
+            other=0.0,
+        )
+        w_tile = tl.load(
+            w_ptrs,
+            mask=(k_offset[:, None] < K - k * BLOCK_K) & n_mask,
+            other=0.0,
+        )
+        partial_sum += tl.dot(x_tile, w_tile)
+        x_ptrs += BLOCK_K * x_stride_1
+        w_ptrs += BLOCK_K * w_stride_2
+
+    partial_sum *= scaling
+    partial_sum = partial_sum.to(x.dtype.element_ty)
+
+    output_ptr = output + (
+        s_physical[:, None] * output_stride_0
+        + (slice_start + n_offset)[None, :] * output_stride_1
+    )
+    output_mask = (s_offset[:, None] < seg_len) & n_mask
+    partial_sum += tl.load(output_ptr, mask=output_mask, other=0.0)
+    tl.store(output_ptr, partial_sum, mask=output_mask)
+
+
+def lora_expand_prefill_fwd(
+    x: torch.Tensor,
+    weights: torch.Tensor,
+    batch_info,
+    slice_offsets: torch.Tensor,
+    max_slice_size: int,
+    base_output: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Prefill-optimised LoRA-B expand for one or more output slices.
+
+    Covers all projection types via ``slice_offsets``:
+    * plain expand (o/down):  ``slice_offsets = [0, out_dim]``
+    * gate/up:                ``slice_offsets = [0, inter, 2*inter]``
+    * QKV:                    ``slice_offsets = [0, q, q+kv, q+2*kv]``
+
+    Args:
+        x:             ``(s, num_slices * max_rank)`` from lora_shrink.
+        weights:       ``(num_lora, out_dim, max_rank)``, contiguous.
+        batch_info:    :class:`LoraBatchInfo`.
+        slice_offsets: ``(num_slices + 1,)`` int32 boundary tensor.
+        max_slice_size: largest ``slice_offsets[i+1] - slice_offsets[i]``.
+        base_output:   ``(s, out_dim)`` to fuse-add into; allocated if None.
+
+    Returns:
+        ``(s, out_dim)`` (same buffer as ``base_output`` when supplied).
+    """
+    assert x.is_contiguous()
+    assert weights.is_contiguous()
+    assert x.dim() == 2
+    assert weights.dim() == 3
+
+    S = x.shape[0]
+    OUT_DIM = weights.shape[-2]
+    MAX_RANK = weights.shape[-1]
+    num_slices = len(slice_offsets) - 1
+    assert x.shape[1] == num_slices * MAX_RANK
+
+    max_len = batch_info.max_len
+    sorted_by_adapter = batch_info.permutation is not None
+
+    def grid(meta):
+        return (
+            triton.cdiv(max_len, meta["BLOCK_S"])
+            * triton.cdiv(max_slice_size, meta["BLOCK_N"]),
+            num_slices,
+            batch_info.bs,
+        )
+
+    output = (
+        torch.zeros((S, OUT_DIM), device=x.device, dtype=x.dtype)
+        if base_output is None
+        else base_output
+    )
+    _lora_expand_prefill_kernel[grid](
+        x,
+        weights,
+        output,
+        output.stride(0),
+        output.stride(1),
+        batch_info.seg_lens,
+        batch_info.seg_indptr,
+        batch_info.weight_indices,
+        batch_info.lora_ranks,
+        batch_info.permutation,
+        batch_info.scalings,
+        slice_offsets,
+        NUM_SLICES=num_slices,
+        OUTPUT_DIM=OUT_DIM,
+        MAX_RANK=MAX_RANK,
+        SORTED_BY_ADAPTER=sorted_by_adapter,
+    )
+    return output
+
+
+load_kernel_cache(_lora_expand_prefill_kernel)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/lora_gate_up_expand.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/lora_gate_up_expand.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Fused LoRA-B expand for stacked gate/up projections (MLP).
+
+The MLP gate_up linear is fused into a single matmul with output layout
+``[gate_per_tp, up_per_tp]`` (each of size ``intermediate_per_tp``).
+This kernel packs the two B projections into one launch: each program
+instance picks ``gate`` (axis=1, id=0) or ``up`` (id=1) and writes its
+tile into the matching half of the fused output.
+
+Adapted from sglang ``python/sglang/srt/lora/triton_ops/gate_up_lora_b.py``
+(Apache-2.0): https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/lora/triton_ops/gate_up_lora_b.py.
+Local changes: autotune + on-disk cache, constexpr ordering.
+"""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel._triton import tl, triton
+from tokenspeed_kernel.ops.lora.triton.kernel_utils import _resolve_token_positions
+from tokenspeed_kernel.ops.lora.triton.tuning import load_kernel_cache
+
+_GATE_UP_EXPAND_CONFIGS = [
+    triton.Config(
+        {"BLOCK_S": s, "BLOCK_N": n, "BLOCK_K": k},
+        num_warps=w,
+        num_stages=stages,
+        maxnreg=mr,
+    )
+    for s in (16, 32)
+    for n in (32, 64, 128)
+    for k in (16, 32, 64, 128)
+    for w in (4, 8)
+    for stages in (1, 2, 3)
+    for mr in (None, 128, 160)
+]
+
+
+@triton.autotune(
+    configs=_GATE_UP_EXPAND_CONFIGS,
+    key=["output_dim", "K"],
+    restore_value=["output"],
+)
+@triton.jit
+def _lora_gate_up_expand_kernel(
+    x,
+    weights,
+    output,
+    K,  # max_rank
+    output_dim,  # intermediate_per_tp
+    x_stride_0,
+    x_stride_1,
+    w_stride_0,
+    w_stride_1,
+    w_stride_2,
+    output_stride_0,
+    output_stride_1,
+    seg_lens,
+    seg_indptr,
+    weight_indices,
+    lora_ranks,
+    sorted_token_ids,
+    scalings,
+    SORTED_BY_ADAPTER: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    batch_id = tl.program_id(axis=2)
+    w_index = tl.load(weight_indices + batch_id)
+    if w_index < 0:
+        return
+    rank = tl.load(lora_ranks + w_index)
+    if rank == 0:
+        return
+
+    gate_up_id = tl.program_id(axis=1)
+    pid = tl.program_id(axis=0)
+    seg_len = tl.load(seg_lens + batch_id)
+    if seg_len == 0:
+        return
+    seg_start = tl.load(seg_indptr + batch_id)
+    n_start = gate_up_id * output_dim
+    scaling = tl.load(scalings + w_index)
+    K = tl.minimum(K, rank)
+
+    num_pid_n = tl.cdiv(output_dim, BLOCK_N)
+    pid_s = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    if pid_s * BLOCK_S >= seg_len:
+        return
+
+    s_offset = tl.arange(0, BLOCK_S) + pid_s * BLOCK_S
+    n_offset = tl.arange(0, BLOCK_N) + pid_n * BLOCK_N
+    k_offset = tl.arange(0, BLOCK_K)
+
+    s_physical = _resolve_token_positions(
+        sorted_token_ids, seg_start, s_offset, seg_len, SORTED_BY_ADAPTER
+    )
+    x_ptrs = (
+        x
+        + (gate_up_id * K) * x_stride_1
+        + (s_physical[:, None] * x_stride_0 + k_offset[None, :] * x_stride_1)
+    )
+    w_ptrs = (weights + w_index * w_stride_0 + n_start * w_stride_1) + (
+        k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
+    )
+
+    s_mask = s_offset[:, None] < seg_len
+    n_mask = n_offset[None, :] < output_dim
+    partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
+    for k in range(tl.cdiv(K, BLOCK_K)):
+        k_remaining = K - k * BLOCK_K
+        x_tile = tl.load(
+            x_ptrs,
+            mask=s_mask & (k_offset[None, :] < k_remaining),
+            other=0.0,
+            eviction_policy="evict_first",
+        )
+        w_tile = tl.load(
+            w_ptrs,
+            mask=(k_offset[:, None] < k_remaining) & n_mask,
+            other=0.0,
+            eviction_policy="evict_last",
+        )
+        partial_sum += tl.dot(x_tile, w_tile)
+
+        x_ptrs += BLOCK_K * x_stride_1
+        w_ptrs += BLOCK_K * w_stride_2
+
+    partial_sum *= scaling
+    partial_sum = partial_sum.to(x.dtype.element_ty)
+    output_ptr = (
+        output
+        + n_start * output_stride_1
+        + (s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1)
+    )
+    output_mask = s_mask & n_mask
+    partial_sum += tl.load(output_ptr, mask=output_mask, other=0.0)
+    tl.store(output_ptr, partial_sum, mask=output_mask)
+
+
+def lora_gate_up_expand_fwd(
+    x: torch.Tensor,
+    gate_up_lora_b: torch.Tensor,
+    batch_info,
+    output_dim: int,
+    base_output: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Apply LoRA-B for the fused gate_up MLP linear, fuse-add into ``base_output``.
+
+    Args:
+        x: ``(s, 2 * max_rank)`` from ``lora_shrink_fwd(stack_num=2)`` —
+           gate's lora_a in cols ``[:, :r]``, up's in ``[:, r:]``.
+        gate_up_lora_b: ``(num_lora, 2 * intermediate_per_tp, max_rank)``
+           — gate's B in rows ``[:, :out, :]``, up's in ``[:, out:, :]``.
+        batch_info: :class:`LoraBatchInfo`.
+        output_dim: ``intermediate_per_tp``.
+        base_output: ``(s, 2 * intermediate_per_tp)`` to fuse-add into.
+    """
+    s = x.shape[0]
+    input_dim = x.shape[1]
+    r = gate_up_lora_b.shape[-1]
+    assert input_dim == 2 * r
+
+    max_len = batch_info.max_len
+
+    def grid(meta):
+        return (
+            triton.cdiv(max_len, meta["BLOCK_S"])
+            * triton.cdiv(output_dim, meta["BLOCK_N"]),
+            2,
+            batch_info.bs,
+        )
+
+    if base_output is None:
+        output = torch.zeros((s, 2 * output_dim), device=x.device, dtype=x.dtype)
+    else:
+        output = base_output
+
+    sorted_by_adapter = batch_info.permutation is not None
+    _lora_gate_up_expand_kernel[grid](
+        x,
+        gate_up_lora_b,
+        output,
+        r,
+        output_dim,
+        x.stride(0),
+        x.stride(1),
+        gate_up_lora_b.stride(0),
+        gate_up_lora_b.stride(1),
+        gate_up_lora_b.stride(2),
+        output.stride(0),
+        output.stride(1),
+        batch_info.seg_lens,
+        batch_info.seg_indptr,
+        batch_info.weight_indices,
+        batch_info.lora_ranks,
+        batch_info.permutation,
+        batch_info.scalings,
+        sorted_by_adapter,
+    )
+
+    return output
+
+
+load_kernel_cache(_lora_gate_up_expand_kernel)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/lora_qkv_expand.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/lora_qkv_expand.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Fused LoRA-B expand for stacked Q/K/V projections.
+
+The QKV linear is fused into a single matmul with output layout
+``[q_per_tp, k_per_tp, v_per_tp]``.  This kernel packs the three B
+projections into one launch: each program instance picks ``q``, ``k``, or
+``v`` via ``program_id(1)`` and writes its tile into the matching slice of
+the fused output.
+
+Adapted from sglang ``python/sglang/srt/lora/triton_ops/qkv_lora_b.py``
+(Apache-2.0): https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/lora/triton_ops/qkv_lora_b.py.
+Local changes: autotune + on-disk cache, constexpr ordering.
+"""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel._triton import tl, triton
+from tokenspeed_kernel.ops.lora.triton.kernel_utils import _resolve_token_positions
+from tokenspeed_kernel.ops.lora.triton.tuning import load_kernel_cache
+
+_QKV_EXPAND_CONFIGS = [
+    triton.Config(
+        {"BLOCK_S": s, "BLOCK_N": n, "BLOCK_K": k},
+        num_warps=w,
+        num_stages=stages,
+        maxnreg=mr,
+    )
+    for s in (16, 32)
+    for n in (32, 64, 128)
+    for k in (16, 32, 64, 128)
+    for w in (4, 8)
+    for stages in (1, 2, 3)
+    for mr in (None, 128, 160)
+]
+
+
+@triton.autotune(
+    configs=_QKV_EXPAND_CONFIGS,
+    key=["max_qkv_out_dim", "K"],
+    restore_value=["output"],
+)
+@triton.jit
+def _lora_qkv_expand_kernel(
+    x,
+    weights,
+    output,
+    K,  # max_rank
+    max_qkv_out_dim,  # max(q_per_tp, kv_per_tp)
+    x_stride_0,
+    x_stride_1,
+    w_stride_0,
+    w_stride_1,
+    w_stride_2,
+    output_stride_0,
+    output_stride_1,
+    seg_lens,
+    seg_indptr,
+    weight_indices,
+    lora_ranks,
+    n_offs,  # (4,) cumulative offsets into the fused QKV output
+    sorted_token_ids,
+    scalings,
+    SORTED_BY_ADAPTER: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    batch_id = tl.program_id(axis=2)
+    w_index = tl.load(weight_indices + batch_id)
+    if w_index < 0:
+        return
+    rank = tl.load(lora_ranks + w_index)
+    if rank == 0:
+        return
+
+    qkv_id = tl.program_id(axis=1)
+    pid = tl.program_id(axis=0)
+    seg_len = tl.load(seg_lens + batch_id)
+    if seg_len == 0:
+        return
+    seg_start = tl.load(seg_indptr + batch_id)
+    n_start = tl.load(n_offs + qkv_id)
+    n_size = tl.load(n_offs + qkv_id + 1) - n_start
+    scaling = tl.load(scalings + w_index)
+    K = tl.minimum(K, rank)
+
+    num_pid_n = tl.cdiv(max_qkv_out_dim, BLOCK_N)
+    pid_s = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    if pid_s * BLOCK_S >= seg_len:
+        return
+
+    s_offset = tl.arange(0, BLOCK_S) + pid_s * BLOCK_S
+    n_offset = tl.arange(0, BLOCK_N) + pid_n * BLOCK_N
+    k_offset = tl.arange(0, BLOCK_K)
+
+    s_physical = _resolve_token_positions(
+        sorted_token_ids, seg_start, s_offset, seg_len, SORTED_BY_ADAPTER
+    )
+    x_ptrs = (
+        x
+        + (qkv_id * K) * x_stride_1
+        + (s_physical[:, None] * x_stride_0 + k_offset[None, :] * x_stride_1)
+    )
+    w_ptrs = (weights + w_index * w_stride_0 + n_start * w_stride_1) + (
+        k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
+    )
+
+    s_mask = s_offset[:, None] < seg_len
+    n_mask = n_offset[None, :] < n_size
+    partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
+    for k in range(tl.cdiv(K, BLOCK_K)):
+        k_remaining = K - k * BLOCK_K
+        x_tile = tl.load(
+            x_ptrs,
+            mask=s_mask & (k_offset[None, :] < k_remaining),
+            other=0.0,
+            eviction_policy="evict_first",
+        )
+        w_tile = tl.load(
+            w_ptrs,
+            mask=(k_offset[:, None] < k_remaining) & n_mask,
+            other=0.0,
+            eviction_policy="evict_last",
+        )
+        partial_sum += tl.dot(x_tile, w_tile)
+
+        x_ptrs += BLOCK_K * x_stride_1
+        w_ptrs += BLOCK_K * w_stride_2
+
+    partial_sum *= scaling
+    partial_sum = partial_sum.to(x.dtype.element_ty)
+    output_ptr = (
+        output
+        + n_start * output_stride_1
+        + (s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1)
+    )
+    output_mask = s_mask & n_mask
+    partial_sum += tl.load(output_ptr, mask=output_mask, other=0.0)
+    tl.store(output_ptr, partial_sum, mask=output_mask)
+
+
+def lora_qkv_expand_fwd(
+    x: torch.Tensor,
+    qkv_lora_b: torch.Tensor,
+    batch_info,
+    output_offset: torch.Tensor,
+    max_qkv_out_dim: int,
+    base_output: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Apply LoRA-B for the fused QKV linear, fused-add into ``base_output``.
+
+    Args:
+        x: ``(s, 3 * max_rank)`` from ``lora_shrink_fwd(stack_num=3)``.
+        qkv_lora_b: ``(num_lora, q_per_tp + 2 * kv_per_tp, max_rank)``.
+        batch_info: :class:`LoraBatchInfo`.
+        output_offset: ``(4,)`` cumulative offsets ``[0, q, q+kv, q+2*kv]``.
+        max_qkv_out_dim: ``max(q_per_tp, kv_per_tp)`` — used to size the grid.
+        base_output: ``(s, q_per_tp + 2 * kv_per_tp)`` to fuse-add into.
+    """
+    s = x.shape[0]
+    input_dim = x.shape[1]
+    r = qkv_lora_b.shape[-1]
+    output_dim = qkv_lora_b.shape[-2]
+    assert input_dim == 3 * r
+    assert output_offset.shape[0] == 4
+
+    max_len = batch_info.max_len
+
+    def grid(meta):
+        return (
+            triton.cdiv(max_len, meta["BLOCK_S"])
+            * triton.cdiv(max_qkv_out_dim, meta["BLOCK_N"]),
+            3,
+            batch_info.bs,
+        )
+
+    if base_output is None:
+        output = torch.zeros((s, output_dim), device=x.device, dtype=x.dtype)
+    else:
+        output = base_output
+
+    sorted_by_adapter = batch_info.permutation is not None
+    _lora_qkv_expand_kernel[grid](
+        x,
+        qkv_lora_b,
+        output,
+        r,
+        max_qkv_out_dim,
+        x.stride(0),
+        x.stride(1),
+        qkv_lora_b.stride(0),
+        qkv_lora_b.stride(1),
+        qkv_lora_b.stride(2),
+        output.stride(0),
+        output.stride(1),
+        batch_info.seg_lens,
+        batch_info.seg_indptr,
+        batch_info.weight_indices,
+        batch_info.lora_ranks,
+        output_offset,
+        batch_info.permutation,
+        batch_info.scalings,
+        sorted_by_adapter,
+    )
+    return output
+
+
+load_kernel_cache(_lora_qkv_expand_kernel)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/lora_shrink.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/lora_shrink.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Segmented LoRA-A matmul (shrink: in_dim → r).
+
+For each segment ``b`` in the batch the kernel computes
+``output[seg_b] = x[seg_b] @ A[wi_b].T`` where ``A[wi_b]`` has shape
+``(stack_num * r, in_dim)``.  No-adapter segments use a negative slot
+sentinel; the kernel returns immediately for that slot, leaving the output
+rows untouched.  Real slots may have varying real ranks up to
+``max_rank``; ``output[..., :rank * stack_num]`` stores the real product
+and ``output[..., rank * stack_num:]`` is irrelevant — the consumer
+(``lora_expand`` / ``lora_qkv_expand``) reads only the first ``rank * stack_num``
+columns.
+
+Adapted from sglang ``python/sglang/srt/lora/triton_ops/sgemm_lora_a.py``
+(Apache-2.0): https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/lora/triton_ops/sgemm_lora_a.py.
+sglang's kernel is in turn descended from the Punica S-LoRA design
+(https://github.com/punica-ai/punica).  Local changes: ported to
+``tokenspeed_kernel._triton``, added ``@triton.autotune`` over the
+``(N, K)`` shape with an on-disk config cache, and reshuffled the
+constexpr params so block sizes come last.
+"""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel._triton import tl, triton
+from tokenspeed_kernel.ops.lora.triton.kernel_utils import _resolve_token_positions
+from tokenspeed_kernel.ops.lora.triton.tuning import load_kernel_cache
+
+# Shrink kernel: N = stack_num * rank (tiny, 16–192), K = in_dim (large,
+# 4096+).  Decode-step segments are short (S = 1–32 per segment), so the
+# right tile shape is "small N, large K, small S".  Sweep matches the
+# sglang csgmv-shrink space (PR sgl-project/sglang#20391) plus a BLOCK_S
+# axis since our kernel exposes it.  72 configs.
+_SHRINK_CONFIGS = [
+    triton.Config(
+        {"BLOCK_S": s, "BLOCK_N": n, "BLOCK_K": k}, num_warps=w, num_stages=stages
+    )
+    for s in (8, 16, 32)
+    for n in (16, 32, 64)
+    for k in (64, 128, 256)
+    for w in (4, 8)
+    for stages in (2, 3, 4)
+]
+
+
+@triton.autotune(configs=_SHRINK_CONFIGS, key=["N", "K"])
+@triton.jit
+def _lora_shrink_kernel(
+    x,
+    weights,
+    output,
+    N,  # stack_num * max_rank
+    K,  # in_dim
+    stack_num,
+    x_stride_0,
+    x_stride_1,
+    w_stride_0,
+    w_stride_1,
+    w_stride_2,
+    output_stride_0,
+    output_stride_1,
+    seg_lens,
+    seg_indptr,
+    weight_indices,
+    lora_ranks,
+    sorted_token_ids,
+    SORTED_BY_ADAPTER: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    batch_id = tl.program_id(axis=1)
+    w_index = tl.load(weight_indices + batch_id)
+    if w_index < 0:
+        return
+    rank = tl.load(lora_ranks + w_index)
+
+    # rank == 0 is defensive: skip and leave the output untouched
+    # (downstream lora_expand / lora_qkv_expand is also a no-op for rank == 0
+    # so the leftover values never feed into the base-output add).
+    if rank == 0:
+        return
+
+    pid = tl.program_id(axis=0)
+    seg_start = tl.load(seg_indptr + batch_id)
+    seg_len = tl.load(seg_lens + batch_id)
+    if seg_len == 0:
+        return
+
+    # Cap N to the real ``stack_num * rank`` for this adapter.
+    N = tl.minimum(N, rank * stack_num)
+
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+    pid_s = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    if pid_s * BLOCK_S >= seg_len:
+        return
+
+    s_offset = tl.arange(0, BLOCK_S) + pid_s * BLOCK_S
+    n_offset = tl.arange(0, BLOCK_N) + pid_n * BLOCK_N
+    k_offset = tl.max_contiguous(tl.arange(0, BLOCK_K), BLOCK_K)
+    s_physical = _resolve_token_positions(
+        sorted_token_ids, seg_start, s_offset, seg_len, SORTED_BY_ADAPTER
+    )
+    x_ptrs = x + (s_physical[:, None] * x_stride_0 + k_offset[None, :] * x_stride_1)
+    w_ptrs = (weights + w_index * w_stride_0) + (
+        k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
+    )
+
+    # Hoist loop-invariant masks — s_mask and n_mask don't change across K
+    # iterations so computing them once saves instructions in the hot loop.
+    s_mask = s_offset[:, None] < seg_len  # (BLOCK_S, 1)
+    n_mask = n_offset[None, :] < N  # (1, BLOCK_N)
+
+    K = tl.multiple_of(K, BLOCK_K)
+    partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
+    for k in range(K // BLOCK_K):
+        x_tile = tl.load(
+            x_ptrs,
+            mask=s_mask,
+            other=0.0,
+            eviction_policy="evict_first",
+        )
+        w_tile = tl.load(
+            w_ptrs,
+            mask=n_mask,
+            other=0.0,
+            eviction_policy="evict_last",
+        )
+        partial_sum += tl.dot(x_tile, w_tile)
+
+        x_ptrs += BLOCK_K * x_stride_1
+        w_ptrs += BLOCK_K * w_stride_2
+
+    partial_sum = partial_sum.to(x.dtype.element_ty)
+    output_mask = s_mask & n_mask
+    output_ptr = output + (
+        s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1
+    )
+    tl.store(output_ptr, partial_sum, mask=output_mask)
+
+
+def lora_shrink_fwd(
+    x: torch.Tensor,
+    weights: torch.Tensor,
+    batch_info,
+    stack_num: int = 1,
+) -> torch.Tensor:
+    """Run the LoRA-A shrink for an arbitrary batch.
+
+    Args:
+        x:        ``(s, in_dim)`` activations, contiguous.
+        weights:  ``(num_lora, stack_num * max_rank, in_dim)``, contiguous.
+        batch_info: :class:`LoraBatchInfo` describing the segment layout.
+        stack_num: 1 for single projection, 3 for fused QKV, 2 for gate-up.
+
+    Returns:
+        ``(s, stack_num * max_rank)`` tensor.  Rows of segments whose adapter
+        is the no-op slot are unwritten — callers must not consume them
+        (the matching lora_expand kernel is also a no-op for those segments).
+    """
+    assert x.is_contiguous()
+    assert weights.is_contiguous()
+    assert x.dim() == 2
+    assert weights.dim() == 3
+
+    S = x.shape[0]
+    N = weights.shape[-2]
+    K = weights.shape[-1]
+    assert x.shape[-1] == K
+
+    max_len = batch_info.max_len
+
+    def grid(meta):
+        return (
+            triton.cdiv(max_len, meta["BLOCK_S"]) * triton.cdiv(N, meta["BLOCK_N"]),
+            batch_info.bs,
+        )
+
+    sorted_by_adapter = batch_info.permutation is not None
+
+    output = torch.empty((S, N), device=x.device, dtype=x.dtype)
+    _lora_shrink_kernel[grid](
+        x,
+        weights,
+        output,
+        N,
+        K,
+        stack_num,
+        x.stride(0),
+        x.stride(1),
+        weights.stride(0),
+        weights.stride(1),
+        weights.stride(2),
+        output.stride(0),
+        output.stride(1),
+        batch_info.seg_lens,
+        batch_info.seg_indptr,
+        batch_info.weight_indices,
+        batch_info.lora_ranks,
+        batch_info.permutation,
+        sorted_by_adapter,
+    )
+    return output
+
+
+# Eager pre-population from disk happens lazily inside the autotuner cache
+# (see `tokenspeed_kernel.ops.lora.triton.__init__`).
+load_kernel_cache(_lora_shrink_kernel)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/lora_shrink_prefill.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/lora_shrink_prefill.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Prefill-optimised LoRA-A matmul (shrink: in_dim → r).
+
+Drop-in replacement for :func:`lora_shrink_fwd` on prefill batches
+(``max_len > 32``).  Identical algorithm; the structural difference is that
+``K`` (= in_dim, 4096+), ``N`` (= stack_num * max_rank), and all strides are
+**constexpr** — the compiler specialises the K-loop trip count at compile
+time and eliminates all stride multiplications.
+
+Benchmarked gain on H100 vs the decode shrink kernel at s=512, rank=64:
+  QKV  stack=3  (K=4096, N=192): 23 µs → 17 µs  (1.3×)
+  g/up stack=2  (K=4096, N=128): 19 µs → 16 µs  (1.2×)
+  single        (K=4096, N=64):  18 µs → 17 µs  (~1.0×)
+
+Adapted from sglang ``python/sglang/srt/lora/triton_ops/chunked_sgmv_shrink.py``
+(Apache-2.0): https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/lora/triton_ops/chunked_sgmv_shrink.py.
+Local changes: kept SORTED_BY_ADAPTER + S-tiling from our decode kernel
+(``lora_shrink.py``), replaced fixed configs with ``@triton.autotune`` +
+on-disk cache.
+"""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel._triton import tl, triton
+from tokenspeed_kernel.ops.lora.triton.kernel_utils import _resolve_token_positions
+from tokenspeed_kernel.ops.lora.triton.tuning import load_kernel_cache
+
+# Same config space as the decode shrink kernel.
+_PREFILL_SHRINK_CONFIGS = [
+    triton.Config(
+        {"BLOCK_S": s, "BLOCK_N": n, "BLOCK_K": k}, num_warps=w, num_stages=stages
+    )
+    for s in (16, 32)
+    for n in (16, 32, 64)
+    for k in (64, 128, 256)
+    for w in (4, 8)
+    for stages in (2, 3, 4)
+]
+
+
+@triton.autotune(configs=_PREFILL_SHRINK_CONFIGS, key=["N", "K", "NUM_SLICES"])
+@triton.jit
+def _lora_shrink_prefill_kernel(
+    x,
+    weights,
+    output,
+    seg_lens,
+    seg_indptr,
+    weight_indices,
+    lora_ranks,
+    sorted_token_ids,
+    N: tl.constexpr,  # stack_num * max_rank
+    K: tl.constexpr,  # in_dim
+    NUM_SLICES: tl.constexpr,  # stack_num
+    SORTED_BY_ADAPTER: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    # Constexpr strides — compiler eliminates all stride multiplications.
+    x_stride_0: tl.constexpr = K
+    x_stride_1: tl.constexpr = 1
+    w_stride_0: tl.constexpr = N * K
+    w_stride_1: tl.constexpr = K  # row stride of the (N, K) weight matrix
+    w_stride_2: tl.constexpr = 1
+    output_stride_0: tl.constexpr = N
+    output_stride_1: tl.constexpr = 1
+
+    batch_id = tl.program_id(axis=1)
+    w_index = tl.load(weight_indices + batch_id)
+    if w_index < 0:
+        return
+    rank = tl.load(lora_ranks + w_index)
+    if rank == 0:
+        return
+
+    pid = tl.program_id(axis=0)
+    seg_start = tl.load(seg_indptr + batch_id)
+    seg_len = tl.load(seg_lens + batch_id)
+    if seg_len == 0:
+        return
+
+    cur_n = tl.minimum(N, rank * NUM_SLICES)
+
+    num_pid_n = tl.cdiv(cur_n, BLOCK_N)
+    pid_s = pid // num_pid_n
+    pid_n = pid % num_pid_n
+    if pid_s * BLOCK_S >= seg_len:
+        return
+
+    s_offset = tl.arange(0, BLOCK_S) + pid_s * BLOCK_S
+    n_offset = tl.arange(0, BLOCK_N) + pid_n * BLOCK_N
+    k_offset = tl.arange(0, BLOCK_K)
+
+    s_physical = _resolve_token_positions(
+        sorted_token_ids, seg_start, s_offset, seg_len, SORTED_BY_ADAPTER
+    )
+
+    x_ptrs = x + (s_physical[:, None] * x_stride_0 + k_offset[None, :] * x_stride_1)
+    w_ptrs = (weights + w_index * w_stride_0) + (
+        k_offset[:, None] * w_stride_2 + n_offset[None, :] * w_stride_1
+    )
+
+    s_mask = s_offset[:, None] < seg_len
+    n_mask = n_offset[None, :] < cur_n
+    partial_sum = tl.zeros((BLOCK_S, BLOCK_N), dtype=tl.float32)
+    for k in range(K // BLOCK_K):
+        x_tile = tl.load(
+            x_ptrs,
+            mask=s_mask,
+            other=0.0,
+            eviction_policy="evict_first",
+        )
+        w_tile = tl.load(
+            w_ptrs,
+            mask=n_mask,
+            other=0.0,
+            eviction_policy="evict_last",
+        )
+        partial_sum += tl.dot(x_tile, w_tile)
+        x_ptrs += BLOCK_K * x_stride_1
+        w_ptrs += BLOCK_K * w_stride_2
+
+    partial_sum = partial_sum.to(x.dtype.element_ty)
+    output_mask = s_mask & n_mask
+    output_ptr = output + (
+        s_physical[:, None] * output_stride_0 + n_offset[None, :] * output_stride_1
+    )
+    tl.store(output_ptr, partial_sum, mask=output_mask)
+
+
+def lora_shrink_prefill_fwd(
+    x: torch.Tensor,
+    weights: torch.Tensor,
+    batch_info,
+    stack_num: int = 1,
+) -> torch.Tensor:
+    """Prefill-optimised LoRA-A shrink.  Same signature as :func:`lora_shrink_fwd`.
+
+    Args:
+        x:        ``(s, in_dim)`` activations, contiguous.
+        weights:  ``(num_lora, stack_num * max_rank, in_dim)``, contiguous.
+        batch_info: :class:`LoraBatchInfo`.
+        stack_num: 1 for single projection, 3 for fused QKV, 2 for gate-up.
+
+    Returns:
+        ``(s, stack_num * max_rank)`` tensor.
+    """
+    assert x.is_contiguous()
+    assert weights.is_contiguous()
+    assert x.dim() == 2
+    assert weights.dim() == 3
+
+    S = x.shape[0]
+    N = weights.shape[-2]  # stack_num * max_rank
+    K = weights.shape[-1]  # in_dim
+    assert x.shape[-1] == K
+
+    max_len = batch_info.max_len
+    sorted_by_adapter = batch_info.permutation is not None
+
+    def grid(meta):
+        return (
+            triton.cdiv(max_len, meta["BLOCK_S"]) * triton.cdiv(N, meta["BLOCK_N"]),
+            batch_info.bs,
+        )
+
+    output = torch.empty((S, N), device=x.device, dtype=x.dtype)
+    _lora_shrink_prefill_kernel[grid](
+        x,
+        weights,
+        output,
+        batch_info.seg_lens,
+        batch_info.seg_indptr,
+        batch_info.weight_indices,
+        batch_info.lora_ranks,
+        batch_info.permutation,
+        N=N,
+        K=K,
+        NUM_SLICES=stack_num,
+        SORTED_BY_ADAPTER=sorted_by_adapter,
+    )
+    return output
+
+
+load_kernel_cache(_lora_shrink_prefill_kernel)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/tune.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/tune.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Offline autotune driver for the LoRA Triton kernels.
+
+Builds synthetic ``LoraBatchInfo`` batches for a few representative
+segment shapes, calls each kernel once (triggering ``triton.autotune``
+to benchmark all candidate configs and pick the fastest per ``(N, K)``
+key), and then writes the picked configs to JSON via
+:func:`tokenspeed_kernel.ops.lora.triton.tuning.save_kernel_cache`.
+
+Usage::
+
+    python -m tokenspeed_kernel.ops.lora.triton.tune \\
+        --hidden 4096 --intermediate 12288 \\
+        --q-per-tp 2048 --kv-per-tp 1024 \\
+        --rank 16 --max-rank 64 --tp-size 2
+
+The defaults match Qwen3-8B at attn_tp_size=2.  Shapes only affect which
+``(N, K)`` keys get tuned; the actual launch parameters are independent
+of which model the cache is shipped against.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from dataclasses import dataclass
+
+import torch
+from tokenspeed_kernel.ops.lora.triton.lora_expand import (
+    _lora_expand_kernel,
+    lora_expand_fwd,
+)
+from tokenspeed_kernel.ops.lora.triton.lora_gate_up_expand import (
+    _lora_gate_up_expand_kernel,
+    lora_gate_up_expand_fwd,
+)
+from tokenspeed_kernel.ops.lora.triton.lora_qkv_expand import (
+    _lora_qkv_expand_kernel,
+    lora_qkv_expand_fwd,
+)
+from tokenspeed_kernel.ops.lora.triton.lora_shrink import (
+    _lora_shrink_kernel,
+    lora_shrink_fwd,
+)
+from tokenspeed_kernel.ops.lora.triton.tuning import save_kernel_cache
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _BatchInfo:
+    """Minimal stand-in for ``runtime.lora.lora_manager.LoraBatchInfo``."""
+
+    bs: int
+    max_len: int
+    seg_lens: torch.Tensor
+    seg_indptr: torch.Tensor
+    weight_indices: torch.Tensor
+    lora_ranks: torch.Tensor
+    scalings: torch.Tensor
+    permutation: torch.Tensor | None = None
+
+
+def _make_batch(
+    s_per_seg: int, n_segs: int, rank: int, device: str = "cuda"
+) -> _BatchInfo:
+    seg_lens = torch.full((n_segs,), s_per_seg, dtype=torch.int32, device=device)
+    seg_indptr = torch.tensor(
+        [i * s_per_seg for i in range(n_segs + 1)], dtype=torch.int32, device=device
+    )
+    # weight_indices: route every segment to real adapter slot 0.
+    weight_indices = torch.zeros(n_segs, dtype=torch.int32, device=device)
+    lora_ranks = torch.tensor([rank], dtype=torch.int32, device=device)
+    scalings = torch.tensor([1.0], dtype=torch.float32, device=device)
+    return _BatchInfo(
+        bs=n_segs,
+        max_len=s_per_seg,
+        seg_lens=seg_lens,
+        seg_indptr=seg_indptr,
+        weight_indices=weight_indices,
+        lora_ranks=lora_ranks,
+        scalings=scalings,
+    )
+
+
+def tune_shrink(*, in_dim: int, stack_num: int, rank: int, max_rank: int) -> None:
+    """Drive ``_lora_shrink_kernel`` for one ``(stack_num, in_dim)`` shape.
+
+    Uses a decode-shaped batch (``bs=32, max_len=1``) because that is where
+    LoRA latency dominates the e2e (every decode step pays the kernel cost;
+    prefill is amortized).  Tuning at prefill shapes picks block tiles that
+    waste threads at decode-time.
+    """
+    device = "cuda"
+    dtype = torch.bfloat16
+    n_segs = 32
+    s_per_seg = 1
+    s = n_segs * s_per_seg
+    x = torch.randn((s, in_dim), device=device, dtype=dtype)
+    weights = torch.randn((2, stack_num * max_rank, in_dim), device=device, dtype=dtype)
+    bi = _make_batch(s_per_seg, n_segs, rank=rank, device=device)
+    lora_shrink_fwd(x, weights, bi, stack_num=stack_num)
+    torch.cuda.synchronize()
+    print(
+        f"  shrink in_dim={in_dim} stack={stack_num}  →  best={_lora_shrink_kernel.best_config}"
+    )
+
+
+def tune_expand(*, out_dim: int, max_rank: int, rank: int) -> None:
+    device = "cuda"
+    dtype = torch.bfloat16
+    n_segs = 32
+    s_per_seg = 1
+    s = n_segs * s_per_seg
+    x = torch.randn((s, max_rank), device=device, dtype=dtype)
+    weights = torch.randn((2, out_dim, max_rank), device=device, dtype=dtype)
+    bi = _make_batch(s_per_seg, n_segs, rank=rank, device=device)
+    out = torch.zeros((s, out_dim), device=device, dtype=dtype)
+    lora_expand_fwd(x, weights, bi, base_output=out)
+    torch.cuda.synchronize()
+    print(
+        f"  expand out_dim={out_dim} R={max_rank}  →  best={_lora_expand_kernel.best_config}"
+    )
+
+
+def tune_qkv(*, q_per_tp: int, kv_per_tp: int, max_rank: int, rank: int) -> None:
+    device = "cuda"
+    dtype = torch.bfloat16
+    n_segs = 32
+    s_per_seg = 1
+    s = n_segs * s_per_seg
+    x = torch.randn((s, 3 * max_rank), device=device, dtype=dtype)
+    out_dim = q_per_tp + 2 * kv_per_tp
+    weights = torch.randn((2, out_dim, max_rank), device=device, dtype=dtype)
+    max_qkv = max(q_per_tp, kv_per_tp)
+    output_offset = torch.tensor(
+        [0, q_per_tp, q_per_tp + kv_per_tp, q_per_tp + 2 * kv_per_tp],
+        dtype=torch.int32,
+        device=device,
+    )
+    bi = _make_batch(s_per_seg, n_segs, rank=rank, device=device)
+    out = torch.zeros((s, out_dim), device=device, dtype=dtype)
+    lora_qkv_expand_fwd(x, weights, bi, output_offset, max_qkv, base_output=out)
+    torch.cuda.synchronize()
+    print(
+        f"  qkv_expand max_qkv={max_qkv} R={max_rank}  →  best={_lora_qkv_expand_kernel.best_config}"
+    )
+
+
+def tune_gate_up(*, intermediate_per_tp: int, max_rank: int, rank: int) -> None:
+    device = "cuda"
+    dtype = torch.bfloat16
+    n_segs = 32
+    s_per_seg = 1
+    s = n_segs * s_per_seg
+    x = torch.randn((s, 2 * max_rank), device=device, dtype=dtype)
+    weights = torch.randn(
+        (2, 2 * intermediate_per_tp, max_rank), device=device, dtype=dtype
+    )
+    bi = _make_batch(s_per_seg, n_segs, rank=rank, device=device)
+    out = torch.zeros((s, 2 * intermediate_per_tp), device=device, dtype=dtype)
+    lora_gate_up_expand_fwd(x, weights, bi, intermediate_per_tp, base_output=out)
+    torch.cuda.synchronize()
+    print(
+        f"  gate_up_expand out={intermediate_per_tp} R={max_rank}  →  best={_lora_gate_up_expand_kernel.best_config}"
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--hidden", type=int, default=4096)
+    p.add_argument(
+        "--intermediate",
+        type=int,
+        default=12288,
+        help="Full (un-sharded) intermediate_size",
+    )
+    p.add_argument("--q-per-tp", type=int, default=2048)
+    p.add_argument("--kv-per-tp", type=int, default=512)
+    p.add_argument("--rank", type=int, default=16)
+    p.add_argument("--max-rank", type=int, default=64)
+    p.add_argument("--tp-size", type=int, default=2)
+    args = p.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    intermediate_per_tp = args.intermediate // args.tp_size
+
+    print("=== Tuning shrink (lora_shrink) ===")
+    # Attention shrink: stack=3 (QKV) on hidden, stack=1 (o) on q_per_tp.
+    tune_shrink(in_dim=args.hidden, stack_num=3, rank=args.rank, max_rank=args.max_rank)
+    tune_shrink(
+        in_dim=args.q_per_tp, stack_num=1, rank=args.rank, max_rank=args.max_rank
+    )
+    # MLP shrink: stack=2 (gate/up) on hidden, stack=1 (down) on intermediate_per_tp.
+    tune_shrink(in_dim=args.hidden, stack_num=2, rank=args.rank, max_rank=args.max_rank)
+    tune_shrink(
+        in_dim=intermediate_per_tp, stack_num=1, rank=args.rank, max_rank=args.max_rank
+    )
+
+    print("\n=== Tuning expand (lora_expand) ===")
+    # o_proj uses lora_expand directly (out_dim = hidden).
+    tune_expand(out_dim=args.hidden, max_rank=args.max_rank, rank=args.rank)
+    # down_proj also uses lora_expand (out_dim = hidden).
+    # Same shape — autotune cache hit on the second call.
+
+    print("\n=== Tuning qkv_expand (lora_qkv_expand) ===")
+    tune_qkv(
+        q_per_tp=args.q_per_tp,
+        kv_per_tp=args.kv_per_tp,
+        max_rank=args.max_rank,
+        rank=args.rank,
+    )
+
+    print("\n=== Tuning gate_up_expand (lora_gate_up_expand) ===")
+    tune_gate_up(
+        intermediate_per_tp=intermediate_per_tp,
+        max_rank=args.max_rank,
+        rank=args.rank,
+    )
+
+    print("\n=== Saving caches ===")
+    for kern in (
+        _lora_shrink_kernel,
+        _lora_expand_kernel,
+        _lora_qkv_expand_kernel,
+        _lora_gate_up_expand_kernel,
+    ):
+        path = save_kernel_cache(kern)
+        print(f"  wrote {path} ({len(kern.cache)} entries)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/tune_sweep.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/tune_sweep.py
@@ -1,0 +1,137 @@
+"""Comprehensive autotune sweep for LoRA decode kernels across common shapes.
+
+Covers the (N, K) pairs seen in production for the major model families and
+TP configurations, across max_rank values of 16 / 32 / 64 / 128.  Saves all
+picked configs to the on-disk JSON caches so fresh processes skip the sweep.
+
+Usage::
+
+    python -m tokenspeed_kernel.ops.lora.triton.tune_sweep
+
+Estimated runtime: ~5 min on H100 (all shapes × all kernels).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from tokenspeed_kernel.ops.lora.triton.lora_expand import _lora_expand_kernel
+from tokenspeed_kernel.ops.lora.triton.lora_gate_up_expand import (
+    _lora_gate_up_expand_kernel,
+)
+from tokenspeed_kernel.ops.lora.triton.lora_qkv_expand import _lora_qkv_expand_kernel
+from tokenspeed_kernel.ops.lora.triton.lora_shrink import _lora_shrink_kernel
+from tokenspeed_kernel.ops.lora.triton.tune import (
+    tune_expand,
+    tune_gate_up,
+    tune_qkv,
+    tune_shrink,
+)
+from tokenspeed_kernel.ops.lora.triton.tuning import save_kernel_cache
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+@dataclass
+class _ModelTP:
+    name: str
+    hidden: int
+    intermediate_per_tp: int
+    q_per_tp: int
+    kv_per_tp: int
+
+
+# ── Representative (model, TP) configs ──────────────────────────────────────
+# Each entry represents one serving configuration: hidden size, per-rank
+# intermediate, and per-rank Q / KV sizes after tensor parallelism sharding.
+# Source model sizes:
+#   Llama-3-8B:  hidden=4096, intermediate=14336, heads=32/8, head_dim=128
+#   Llama-3-70B: hidden=8192, intermediate=28672, heads=64/8, head_dim=128
+#   Qwen3-8B:    hidden=4096, intermediate=12288, heads=32/8, head_dim=128
+_CONFIGS: list[_ModelTP] = [
+    # ── Llama-3-8B ──────────────────────────────────────────────────────────
+    _ModelTP("llama3-8b  TP=1", 4096, 14336, 4096, 1024),
+    _ModelTP("llama3-8b  TP=2", 4096, 7168, 2048, 512),
+    _ModelTP("llama3-8b  TP=4", 4096, 3584, 1024, 256),
+    # ── Qwen3-8B ────────────────────────────────────────────────────────────
+    _ModelTP("qwen3-8b   TP=1", 4096, 12288, 4096, 1024),
+    _ModelTP("qwen3-8b   TP=2", 4096, 6144, 2048, 512),
+    _ModelTP("qwen3-8b   TP=4", 4096, 3072, 1024, 256),
+    # ── Llama-3-70B ─────────────────────────────────────────────────────────
+    _ModelTP("llama3-70b TP=4", 8192, 7168, 2048, 256),
+    _ModelTP("llama3-70b TP=8", 8192, 3584, 1024, 128),
+]
+
+# Max-rank values to cover — N in the shrink key is stack_num * max_rank.
+_MAX_RANKS = [16, 32, 64, 128]
+
+
+def _sweep_shrink(cfg: _ModelTP, max_rank: int) -> None:
+    rank = max_rank  # tune at full rank so the K-loop is fully exercised
+    # Attention shrink
+    tune_shrink(in_dim=cfg.hidden, stack_num=3, rank=rank, max_rank=max_rank)
+    tune_shrink(in_dim=cfg.q_per_tp, stack_num=1, rank=rank, max_rank=max_rank)
+    # MLP shrink
+    tune_shrink(in_dim=cfg.hidden, stack_num=2, rank=rank, max_rank=max_rank)
+    tune_shrink(
+        in_dim=cfg.intermediate_per_tp, stack_num=1, rank=rank, max_rank=max_rank
+    )
+
+
+def _sweep_expand(cfg: _ModelTP, max_rank: int) -> None:
+    # Clear in-process cache so the autotuner sweeps all configs fresh
+    # rather than reusing entries loaded from the on-disk JSON.
+    for k in _lora_expand_kernel, _lora_qkv_expand_kernel, _lora_gate_up_expand_kernel:
+        k.cache.clear()
+    rank = max_rank
+    # o_proj / down_proj
+    tune_expand(out_dim=cfg.hidden, max_rank=max_rank, rank=rank)
+    # QKV
+    tune_qkv(
+        q_per_tp=cfg.q_per_tp,
+        kv_per_tp=cfg.kv_per_tp,
+        max_rank=max_rank,
+        rank=rank,
+    )
+    # gate/up
+    tune_gate_up(
+        intermediate_per_tp=cfg.intermediate_per_tp,
+        max_rank=max_rank,
+        rank=rank,
+    )
+
+
+def main() -> int:
+    total_shrink = len(_CONFIGS) * len(_MAX_RANKS)
+    total_expand = total_shrink
+    done = 0
+
+    for max_rank in _MAX_RANKS:
+        for cfg in _CONFIGS:
+            done += 1
+            print(f"\n[{done}/{total_shrink}] shrink  {cfg.name}  max_rank={max_rank}")
+            _sweep_shrink(cfg, max_rank)
+
+    done = 0
+    for max_rank in _MAX_RANKS:
+        for cfg in _CONFIGS:
+            done += 1
+            print(f"\n[{done}/{total_expand}] expand  {cfg.name}  max_rank={max_rank}")
+            _sweep_expand(cfg, max_rank)
+
+    print("\n=== Saving caches ===")
+    for kern in (
+        _lora_shrink_kernel,
+        _lora_expand_kernel,
+        _lora_qkv_expand_kernel,
+        _lora_gate_up_expand_kernel,
+    ):
+        path = save_kernel_cache(kern)
+        print(f"  wrote {path}  ({len(kern.cache)} entries)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/tuning.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/lora/triton/tuning.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""On-disk cache for LoRA Triton autotune picks.
+
+Triton's ``@triton.autotune`` caches the best config per ``key`` tuple in
+``Autotuner.cache``, but only for the current process — every fresh Python
+process re-runs the sweep on the first call to each unique shape.  This
+module persists that cache as JSON next to the kernels so the picks
+survive process restarts and ship in the repo.
+
+Layout: ``configs/<gpu_label>/<kernel_name>.json``.  When a kernel runs
+for the first time on a shape that has no saved entry, Triton falls back
+to the candidate-config sweep (slow) and the result can be saved by a
+follow-up call to :func:`save_kernel_cache`.
+
+Config JSON format::
+
+    {
+      "(N, K, 'torch.bfloat16')": {
+        "kwargs": {"BLOCK_S": 16, "BLOCK_N": 64, "BLOCK_K": 64},
+        "num_warps": 4,
+        "num_stages": 3,
+        "num_ctas": 1,
+        "maxnreg": null
+      },
+      ...
+    }
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import torch
+from tokenspeed_kernel._triton import triton
+
+logger = logging.getLogger(__name__)
+
+CONFIG_DIR = Path(__file__).parent / "configs"
+
+
+def _gpu_label() -> str:
+    """Compact identifier for the active GPU — partitions config files."""
+    if not torch.cuda.is_available():
+        return "cpu"
+    name = torch.cuda.get_device_name(0)
+    # Strip vendor prefix and whitespace: "NVIDIA H100 80GB HBM3" → "H100_80GB_HBM3".
+    name = name.replace("NVIDIA ", "").strip()
+    return name.replace(" ", "_")
+
+
+def _config_path(kernel_name: str) -> Path:
+    return CONFIG_DIR / _gpu_label() / f"{kernel_name}.json"
+
+
+def _key_to_str(key: tuple) -> str:
+    # ``repr(tuple)`` round-trips through ``ast.literal_eval`` provided the
+    # tuple only holds primitives and str dtypes — which it does here.
+    return repr(tuple(key))
+
+
+def _str_to_key(s: str) -> tuple:
+    return tuple(ast.literal_eval(s))
+
+
+def _config_to_dict(cfg: triton.Config) -> dict:
+    return {
+        "kwargs": dict(cfg.kwargs),
+        "num_warps": cfg.num_warps,
+        "num_stages": cfg.num_stages,
+        "num_ctas": cfg.num_ctas,
+        "maxnreg": cfg.maxnreg,
+    }
+
+
+def _dict_to_config(d: dict) -> triton.Config:
+    return triton.Config(
+        d["kwargs"],
+        num_warps=d["num_warps"],
+        num_stages=d["num_stages"],
+        num_ctas=d.get("num_ctas", 1),
+        maxnreg=d.get("maxnreg"),
+    )
+
+
+def load_kernel_cache(kernel) -> int:
+    """Populate ``kernel.cache`` from the on-disk JSON for the active GPU.
+
+    ``kernel`` is the ``Autotuner`` wrapper produced by
+    ``@triton.autotune``.  Returns the number of entries loaded (0 when
+    no config file exists for this GPU, which is the normal first-run
+    case).
+    """
+    name = kernel.base_fn.__name__
+    path = _config_path(name)
+    if not path.exists():
+        logger.debug("no autotune cache for %s at %s", name, path)
+        return 0
+    with open(path) as f:
+        raw = json.load(f)
+    loaded = 0
+    for k, v in raw.items():
+        kernel.cache[_str_to_key(k)] = _dict_to_config(v)
+        loaded += 1
+    logger.info("loaded %d autotune picks for %s from %s", loaded, name, path)
+    return loaded
+
+
+def save_kernel_cache(kernel) -> Path:
+    """Dump ``kernel.cache`` to JSON next to the kernel module."""
+    name = kernel.base_fn.__name__
+    path = _config_path(name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    blob: dict[str, Any] = {}
+    for key, cfg in kernel.cache.items():
+        blob[_key_to_str(key)] = _config_to_dict(cfg)
+    with open(path, "w") as f:
+        json.dump(blob, f, indent=2, sort_keys=True)
+    logger.info("saved %d autotune picks for %s to %s", len(blob), name, path)
+    return path

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe_lora/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe_lora/__init__.py
@@ -1,0 +1,1085 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Fused Triton kernels for MoE LoRA applied to sorted expert outputs.
+
+Targets the sglang_shared adapter format (shared outer A, per-expert inner B
+for gate/up; per-expert A, shared outer B for down), operating directly on the
+sorted token-expert buffers produced by the MoE dispatcher.
+
+Gate/up expand replaces: all-experts B GEMM (m×R × R×E·I) + candidates.gather +
+_add_route_delta with a single per-sorted-position GEMV kernel.
+
+Down shrink replaces: _route_rows_from_cache + _select_expert_weights + einsum
+with a per-sorted-position GEMV kernel; the caller then runs one shared-B GEMM
+and scatter_add_ to accumulate into the token-ordered down output.
+
+Both kernels tile over the rank dimension in BLOCK_R chunks so that register
+pressure stays bounded regardless of adapter rank (r=16 to r=256).
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+# ── Gate/Up Expand ───────────────────────────────────────────────────────────
+#
+# For each sorted position s:
+#   exp    = safe_ids[flat_j // K, flat_j % K]  where flat_j = sorted_token_ids[s]
+#   delta  = lora_a_m[flat_j // K, :] @ w13_B[exp, offs_i, :].T * scaling
+#   gate_up_output[s, offs_i] += delta
+#
+# Rank dimension is reduced in BLOCK_R tiles to bound register usage.
+# Grid: (cdiv(I2, BLOCK_I), padded)
+
+
+@triton.jit
+def _sorted_gate_up_b_expand_kernel(
+    lora_a_m,  # (m, MAX_R)
+    w13_B,  # (E, I2, MAX_R) — contiguous
+    safe_ids,  # (m, K) int64
+    sorted_token_ids,  # (padded,) int64  — sorted pos → flat pair
+    gate_up_output,  # output — in-place add
+    scaling_ptr,  # float32 scalar on device
+    route_count,  # int32 — m*K
+    K,  # int32
+    I2: tl.constexpr,
+    MAX_R: tl.constexpr,
+    BLOCK_I: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+    SCATTER: tl.constexpr,  # True: write to flat_j (flat-pair output); False: write to pid_s (sorted output)
+):
+    pid_i = tl.program_id(0)
+    pid_s = tl.program_id(1)
+
+    flat_j = tl.load(sorted_token_ids + pid_s)
+    if flat_j < 0:
+        return
+    if flat_j >= route_count:
+        return
+
+    tok = flat_j // K
+    topk_v = flat_j % K
+    exp = tl.load(safe_ids + tok * K + topk_v).to(tl.int32)
+
+    offs_i = pid_i * BLOCK_I + tl.arange(0, BLOCK_I)
+    i_mask = offs_i < I2
+
+    scaling = tl.load(scaling_ptr).to(tl.float32)
+    acc = tl.zeros((BLOCK_I,), dtype=tl.float32)
+
+    for r_start in range(0, MAX_R, BLOCK_R):
+        kr = r_start + tl.arange(0, BLOCK_R)
+        la = tl.load(lora_a_m + tok * MAX_R + kr).to(tl.float32)  # (BLOCK_R,)
+        B_ptr = w13_B + (exp * I2 + offs_i[:, None]) * MAX_R + kr[None, :]
+        B = tl.load(B_ptr, mask=i_mask[:, None], other=0.0).to(
+            tl.float32
+        )  # (BLOCK_I, BLOCK_R)
+        acc += tl.sum(B * la[None, :], axis=1)
+
+    # SCATTER=True: write to flat-pair position flat_j (non-TMA, flat-pair output).
+    # SCATTER=False: write to sorted position pid_s (TMA sorted output).
+    out_row = flat_j if SCATTER else pid_s
+    out_ptr = gate_up_output + out_row * I2 + offs_i
+    old = tl.load(out_ptr, mask=i_mask, other=0.0).to(tl.float32)
+    tl.store(out_ptr, old + acc * scaling, mask=i_mask)
+
+
+def _choose_block_r(max_r: int) -> int:
+    """Largest power-of-2 ≤ 32 that divides max_r."""
+    block_r = min(32, max_r)
+    while max_r % block_r != 0:
+        block_r //= 2
+    return max(block_r, 1)
+
+
+def sorted_gate_up_b_expand(
+    lora_a_m: torch.Tensor,  # (m, R) — already computed
+    w13_B: torch.Tensor,  # (E, I2, R) — per-expert B, contiguous
+    safe_ids: torch.Tensor,  # (m, K) int64
+    sorted_token_ids: torch.Tensor,  # (padded,) int64
+    gate_up_output: torch.Tensor,  # (padded, I2) — in-place add
+    scaling: torch.Tensor,  # () or (1,) float32 device tensor
+    route_count: int,  # = m*K
+    K: int,
+    BLOCK_I: int = 64,
+) -> None:
+    """Fused gate/up expand: lora_a_m @ B[expert].T, add directly to sorted output.
+
+    For TMA-sorted dispatch: output is in sorted expert order (SCATTER=False).
+    """
+    padded, I2 = gate_up_output.shape
+    MAX_R = w13_B.shape[2]
+    BLOCK_R = _choose_block_r(MAX_R)
+    assert w13_B.is_contiguous(), "w13_B must be contiguous for fused kernel"
+
+    grid = (triton.cdiv(I2, BLOCK_I), padded)
+    _sorted_gate_up_b_expand_kernel[grid](
+        lora_a_m,
+        w13_B,
+        safe_ids.to(torch.int64),
+        sorted_token_ids.to(torch.int64),
+        gate_up_output,
+        scaling,
+        route_count,
+        K,
+        I2=I2,
+        MAX_R=MAX_R,
+        BLOCK_I=BLOCK_I,
+        BLOCK_R=BLOCK_R,
+        SCATTER=False,
+        num_warps=4,
+        num_stages=3,
+    )
+
+
+# ── Flat Gate/Up Expand (decode path) ────────────────────────────────────────
+#
+# No sorted_token_ids needed — computes tok = pid_s // K inside the kernel.
+# One block per flat-pair position, processes all m*K positions directly.
+# Replaces: all-experts B GEMM + candidates.gather + route_delta (3 → 1 kernel).
+# Active-expert reads: only the ~51 unique experts' B rows, not all 128.
+
+
+@triton.jit
+def _gate_up_b_expand_kernel(
+    lora_a_m,  # (m, MAX_R)
+    w13_B_buffer,  # full buffer: n_slots × E × I2 × MAX_R (contiguous)
+    slot_ptr,  # (1,) int32 — GPU scalar, dynamic at CUDA-graph replay
+    n_slot_stride,  # int — E × I2 × MAX_R (stride between slots)
+    safe_ids,  # (m, K) int64
+    gate_up_output,  # (m*K, I2) — flat-pair order, in-place add
+    scaling_ptr,  # float32 scalar on device
+    K,  # int32 — topk count
+    I2: tl.constexpr,
+    MAX_R: tl.constexpr,
+    BLOCK_I: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+):
+    pid_i = tl.program_id(0)
+    pid_s = tl.program_id(1)  # flat-pair index [0 .. m*K-1]
+
+    tok = pid_s // K
+    topk_v = pid_s % K
+    exp = tl.load(safe_ids + tok * K + topk_v).to(tl.int32)
+
+    offs_i = pid_i * BLOCK_I + tl.arange(0, BLOCK_I)
+    i_mask = offs_i < I2
+
+    # Load slot index dynamically (changes at CUDA-graph replay without re-capture).
+    slot = tl.load(slot_ptr).to(tl.int32)
+    # Load scaling from buffer at [slot] — avoids a separate scalings[slot_idx] gather.
+    scaling = tl.load(scaling_ptr + slot).to(tl.float32)
+    acc = tl.zeros((BLOCK_I,), dtype=tl.float32)
+
+    for r_start in range(0, MAX_R, BLOCK_R):
+        kr = r_start + tl.arange(0, BLOCK_R)
+        la = tl.load(lora_a_m + tok * MAX_R + kr).to(tl.float32)
+        # Compute B pointer directly into the full buffer using the slot offset,
+        # avoiding a separate gather copy: buffer[slot, exp, offs_i, kr].
+        B_ptr = (
+            w13_B_buffer
+            + slot * n_slot_stride
+            + (exp * I2 + offs_i[:, None]) * MAX_R
+            + kr[None, :]
+        )
+        B = tl.load(B_ptr, mask=i_mask[:, None], other=0.0).to(tl.float32)
+        acc += tl.sum(B * la[None, :], axis=1)
+
+    out_ptr = gate_up_output + pid_s * I2 + offs_i
+    old = tl.load(out_ptr, mask=i_mask, other=0.0).to(tl.float32)
+    tl.store(out_ptr, old + acc * scaling, mask=i_mask)
+
+
+def gate_up_b_expand(
+    lora_a_m: torch.Tensor,  # (m, R) — already computed
+    w13_B_buffer: torch.Tensor,  # (n_slots, E, I2, R) — full buffer, contiguous
+    slot_idx: torch.Tensor,  # (1,) int32 — GPU tensor; dynamic at CUDA-graph replay
+    safe_ids: torch.Tensor,  # (m, K) int64 — expert assignments
+    gate_up_output: torch.Tensor,  # (m*K, I2) — flat-pair order, in-place add
+    scalings: torch.Tensor,  # (n_slots,) float32 — full scalings buffer; kernel loads [slot]
+    BLOCK_I: int = 64,
+) -> None:
+    """Flat per-expert GEMV for decode (no TMA, no sorted_token_ids needed).
+
+    Accepts the FULL (n_slots, E, I2, R) buffer, slot_idx, and the full scalings
+    buffer — the kernel loads both w13_B and scalings via the slot offset, eliminating
+    the separate w13_B gather (~38 µs) and scalings gather (~19 µs) per layer.
+
+    One block per flat-pair position; computes tok = pid_s // K directly.
+    Replaces: all-experts B GEMM + candidates.gather + route_delta (3 → 1 kernel).
+    """
+    m_k, I2 = gate_up_output.shape
+    K = safe_ids.shape[1]
+    # Buffer layout: (n_slots, E, I2, MAX_R).
+    _n_slots, E, _I2, MAX_R = w13_B_buffer.shape
+    n_slot_stride = E * I2 * MAX_R  # elements between consecutive slots
+    BLOCK_R = _choose_block_r(MAX_R)
+    assert (
+        w13_B_buffer.is_contiguous()
+    ), "w13_B_buffer must be contiguous for fused kernel"
+
+    grid = (triton.cdiv(I2, BLOCK_I), m_k)
+    _gate_up_b_expand_kernel[grid](
+        lora_a_m,
+        w13_B_buffer,
+        slot_idx.to(torch.int32),
+        n_slot_stride,
+        safe_ids.to(torch.int64),
+        gate_up_output,
+        scalings,
+        K,
+        I2=I2,
+        MAX_R=MAX_R,
+        BLOCK_I=BLOCK_I,
+        BLOCK_R=BLOCK_R,
+        num_warps=4,
+        num_stages=3,
+    )
+
+
+# ── Down Shrink ───────────────────────────────────────────────────────────────
+#
+# For each sorted position s, for each rank tile pid_r:
+#   exp           = safe_ids[flat_j // K, flat_j % K]
+#   lora_a_out[s, pid_r*BLOCK_R : (pid_r+1)*BLOCK_R]
+#     = intermediate[s, :] @ down_A[exp, pid_r*BLOCK_R : ..., :].T
+#
+# Grid: (padded, cdiv(MAX_R, BLOCK_R))
+# Splitting over rank tiles keeps (BLOCK_R × BLOCK_H) loads bounded in size.
+
+
+@triton.jit
+def _sorted_a_down_shrink_kernel(
+    intermediate,  # (padded, INTER)
+    down_A,  # (E, MAX_R, INTER) — per-expert A, contiguous
+    safe_ids,  # (m, K) int64
+    sorted_token_ids,  # (padded,) int64
+    lora_a_out,  # (padded, MAX_R)
+    route_count,  # int32
+    K,  # int32
+    INTER: tl.constexpr,
+    MAX_R: tl.constexpr,
+    BLOCK_R: tl.constexpr,  # rank output tile; MAX_R divisible by BLOCK_R
+    BLOCK_H: tl.constexpr,  # INTER tile; INTER divisible by BLOCK_H
+):
+    pid_s = tl.program_id(0)
+    pid_r = tl.program_id(1)
+
+    flat_j = tl.load(sorted_token_ids + pid_s)
+    valid = (flat_j >= 0) & (flat_j < route_count)
+
+    kr = pid_r * BLOCK_R + tl.arange(0, BLOCK_R)
+
+    if not valid:
+        tl.store(
+            lora_a_out + pid_s * MAX_R + kr,
+            tl.zeros((BLOCK_R,), dtype=intermediate.dtype.element_ty),
+        )
+        return
+
+    tok = flat_j // K
+    topk_v = flat_j % K
+    exp = tl.load(safe_ids + tok * K + topk_v).to(tl.int32)
+
+    acc = tl.zeros((BLOCK_R,), dtype=tl.float32)
+
+    for h_start in range(0, INTER, BLOCK_H):
+        kh = h_start + tl.arange(0, BLOCK_H)
+        x = tl.load(intermediate + pid_s * INTER + kh).to(tl.float32)  # (BLOCK_H,)
+        A_ptr = down_A + (exp * MAX_R + kr[:, None]) * INTER + kh[None, :]
+        A = tl.load(A_ptr).to(tl.float32)  # (BLOCK_R, BLOCK_H)
+        acc += tl.sum(A * x[None, :], axis=1)
+
+    tl.store(
+        lora_a_out + pid_s * MAX_R + kr,
+        acc.to(intermediate.dtype.element_ty),
+    )
+
+
+def _choose_block_h(inter: int) -> int:
+    """Largest power-of-2 ≤ 128 that divides inter."""
+    block_h = min(128, inter)
+    while inter % block_h != 0:
+        block_h //= 2
+    return max(block_h, 1)
+
+
+def sorted_a_down_shrink(
+    intermediate: torch.Tensor,  # (padded, INTER)
+    down_A: torch.Tensor,  # (E, MAX_R, INTER)
+    safe_ids: torch.Tensor,  # (m, K) int64
+    sorted_token_ids: torch.Tensor,  # (padded,) int64
+    route_count: int,
+    K: int,
+) -> torch.Tensor:
+    """Fused down shrink: intermediate[s] @ down_A[expert].T for each sorted pos."""
+    padded, INTER = intermediate.shape
+    MAX_R = down_A.shape[1]
+    BLOCK_R = _choose_block_r(MAX_R)
+    BLOCK_H = _choose_block_h(INTER)
+    assert down_A.is_contiguous(), "down_A must be contiguous for fused kernel"
+
+    lora_a = torch.empty(
+        (padded, MAX_R), dtype=intermediate.dtype, device=intermediate.device
+    )
+    grid = (padded, MAX_R // BLOCK_R)
+    _sorted_a_down_shrink_kernel[grid](
+        intermediate,
+        down_A,
+        safe_ids.to(torch.int64),
+        sorted_token_ids.to(torch.int64),
+        lora_a,
+        route_count,
+        K,
+        INTER=INTER,
+        MAX_R=MAX_R,
+        BLOCK_R=BLOCK_R,
+        BLOCK_H=BLOCK_H,
+        num_warps=4,
+        num_stages=2,
+    )
+    return lora_a
+
+
+# ── Flat Down Shrink (decode path) ────────────────────────────────────────────
+#
+# No sorted_token_ids needed — computes tok = pid_s // K inside the kernel.
+# One block per (flat-pair, rank-tile), replaces: select_A gather + einsum.
+# Avoids the (m*K, r, INTER) intermediate created by _select_expert_weights.
+# Grid: (m*K, MAX_R // BLOCK_R)
+
+
+@triton.jit
+def _per_expert_a_shrink_kernel(
+    route_input,  # (m*K, INTER)
+    down_A_buffer,  # full buffer: n_slots × E × MAX_R × INTER (contiguous)
+    slot_ptr,  # (1,) int32 — GPU scalar, dynamic at CUDA-graph replay
+    n_slot_stride,  # int — E × MAX_R × INTER (stride between slots)
+    safe_ids,  # (m, K) int64
+    lora_a_out,  # (m*K, MAX_R)
+    K,  # int32
+    INTER: tl.constexpr,
+    MAX_R: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    pid_s = tl.program_id(0)  # flat-pair index
+    pid_r = tl.program_id(1)  # rank tile
+
+    tok = pid_s // K
+    topk_v = pid_s % K
+    exp = tl.load(safe_ids + tok * K + topk_v).to(tl.int32)
+
+    # Load slot index dynamically (changes at CUDA-graph replay without re-capture).
+    slot = tl.load(slot_ptr).to(tl.int32)
+
+    kr = pid_r * BLOCK_R + tl.arange(0, BLOCK_R)
+    acc = tl.zeros((BLOCK_R,), dtype=tl.float32)
+
+    for h_start in range(0, INTER, BLOCK_H):
+        kh = h_start + tl.arange(0, BLOCK_H)
+        x = tl.load(route_input + pid_s * INTER + kh).to(tl.float32)
+        # Compute A pointer directly into the full buffer using the slot offset,
+        # avoiding a separate gather copy: buffer[slot, exp, kr, kh].
+        A_ptr = (
+            down_A_buffer
+            + slot * n_slot_stride
+            + (exp * MAX_R + kr[:, None]) * INTER
+            + kh[None, :]
+        )
+        A = tl.load(A_ptr).to(tl.float32)
+        acc += tl.sum(A * x[None, :], axis=1)
+
+    tl.store(lora_a_out + pid_s * MAX_R + kr, acc.to(route_input.dtype.element_ty))
+
+
+def per_expert_a_shrink(
+    route_input: torch.Tensor,  # (m*K, INTER) — flat-pair intermediate
+    down_A_buffer: torch.Tensor,  # (n_slots, E, MAX_R, INTER) — full buffer, contiguous
+    slot_idx: torch.Tensor,  # (1,) int32 — GPU tensor; dynamic at CUDA-graph replay
+    safe_ids: torch.Tensor,  # (m, K) int64
+    out: torch.Tensor | None = None,  # optional pre-allocated (m*K, MAX_R) output
+) -> torch.Tensor:
+    """Flat per-expert shrink for decode: route_input[j] @ down_A_buffer[slot, exp[j]].T.
+
+    Accepts the FULL (n_slots, E, MAX_R, INTER) buffer and a GPU scalar slot_idx,
+    computing the slot offset inside the kernel.  This eliminates the separate
+    gather copy ``down_A = buffer[slot_idx].squeeze(0)`` (saves ~64 µs/layer).
+
+    Replaces _select_expert_weights gather + einsum without any sorted_token_ids.
+    Returns lora_a (m*K, MAX_R) for the subsequent shared-B GEMM or shared_b_down_expand.
+    """
+    m_k, INTER = route_input.shape
+    # Buffer layout: (n_slots, E, MAX_R, INTER).
+    _n_slots, E, MAX_R, _INTER = down_A_buffer.shape
+    n_slot_stride = E * MAX_R * INTER  # elements between consecutive slots
+    BLOCK_R = _choose_block_r(MAX_R)
+    BLOCK_H = _choose_block_h(INTER)
+    assert down_A_buffer.is_contiguous(), "down_A_buffer must be contiguous"
+
+    if out is None:
+        lora_a = torch.empty(
+            (m_k, MAX_R), dtype=route_input.dtype, device=route_input.device
+        )
+    else:
+        lora_a = out
+    grid = (m_k, MAX_R // BLOCK_R)
+    _per_expert_a_shrink_kernel[grid](
+        route_input,
+        down_A_buffer,
+        slot_idx.to(torch.int32),
+        n_slot_stride,
+        safe_ids.to(torch.int64),
+        lora_a,
+        safe_ids.shape[1],
+        INTER=INTER,
+        MAX_R=MAX_R,
+        BLOCK_R=BLOCK_R,
+        BLOCK_H=BLOCK_H,
+        num_warps=4,
+        num_stages=2,
+    )
+    return lora_a
+
+
+# ── Flat Down Expand (decode path) ────────────────────────────────────────────
+#
+# Fused kernel that takes the lora_a output from per_expert_a_shrink and performs
+# the shared-B GEMM + topk scaling + accumulation in a single pass.
+# Avoids: separate down_B gather copy + standalone GEMM + scale + add.
+#
+# For each (token, topk_v) pair and each hidden chunk:
+#   lora_a_row  = lora_a[tok*K + topk_v, :]               — (MAX_R,)
+#   B_row       = down_B_buffer[slot, 0, offs_h, :]        — (BLOCK_H, MAX_R)
+#   delta_h     = lora_a_row @ B_row.T                     — (BLOCK_H,)
+#   out[tok, topk_v, offs_h] += delta_h * topk_weights[tok, topk_v] * scaling
+#
+# Grid: (m*K, cdiv(H, BLOCK_H))
+
+
+@triton.jit
+def _shared_b_down_expand_kernel(
+    lora_a,  # (m*K, MAX_R)
+    down_B_buffer,  # full buffer: n_slots × 1 × H × MAX_R (contiguous)
+    slot_ptr,  # (1,) int32 — GPU scalar, dynamic at CUDA-graph replay
+    n_slot_stride_B,  # int — H × MAX_R (stride between slots; shared-B has dim0=1)
+    topk_weights,  # (m, K) — topk routing weights
+    scaling_ptr,  # float32 scalar on device
+    down_output,  # (m, K, H) — in-place add
+    K,  # int32 — topk count
+    H: tl.constexpr,  # hidden dimension (constexpr for tl.arange)
+    MAX_R: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+):
+    pid_s = tl.program_id(0)  # flat-pair index [0 .. m*K-1]
+    pid_h = tl.program_id(1)  # hidden chunk index
+
+    tok = pid_s // K
+    topk_v = pid_s % K
+
+    offs_h = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
+    h_mask = offs_h < H
+
+    # Load slot index dynamically (changes at CUDA-graph replay without re-capture).
+    slot = tl.load(slot_ptr).to(tl.int32)
+    # Load scaling from buffer at [slot] — avoids a separate scalings[slot_idx] gather.
+    scaling = tl.load(scaling_ptr + slot).to(tl.float32)
+    weight = tl.load(topk_weights + tok * K + topk_v).to(tl.float32)
+
+    acc = tl.zeros((BLOCK_H,), dtype=tl.float32)
+
+    for r_start in range(0, MAX_R, BLOCK_R):
+        kr = r_start + tl.arange(0, BLOCK_R)
+        # Load lora_a row tile: lora_a[pid_s, kr].
+        la = tl.load(lora_a + pid_s * MAX_R + kr).to(tl.float32)  # (BLOCK_R,)
+        # Load B tile directly from buffer: buffer[slot, 0, offs_h, kr].
+        # n_slot_stride_B = H × MAX_R (shared-B has expert-dim=1 so no expert offset).
+        B_ptr = (
+            down_B_buffer
+            + slot * n_slot_stride_B
+            + offs_h[:, None] * MAX_R
+            + kr[None, :]
+        )
+        B = tl.load(B_ptr, mask=h_mask[:, None], other=0.0).to(
+            tl.float32
+        )  # (BLOCK_H, BLOCK_R)
+        # delta_h += B @ la  (contract over rank dimension)
+        acc += tl.sum(B * la[None, :], axis=1)
+
+    # Scale by topk weight and adapter scaling, then accumulate.
+    out_ptr = down_output + (tok * K + topk_v) * H + offs_h
+    old = tl.load(out_ptr, mask=h_mask, other=0.0).to(tl.float32)
+    tl.store(out_ptr, old + acc * weight * scaling, mask=h_mask)
+
+
+def _choose_block_h_expand(h: int) -> int:
+    """Largest power-of-2 ≤ 64 that divides h (or is the largest divisor ≤ 64)."""
+    block_h = min(64, h)
+    while h % block_h != 0:
+        block_h //= 2
+    return max(block_h, 1)
+
+
+def shared_b_down_expand(
+    lora_a: torch.Tensor,  # (m*K, MAX_R) — output of per_expert_a_shrink
+    down_B_buffer: torch.Tensor,  # (n_slots, 1, H, MAX_R) — full buffer, contiguous
+    slot_idx: torch.Tensor,  # (1,) int32 — GPU tensor; dynamic at CUDA-graph replay
+    down_output: torch.Tensor,  # (m, K, H) or (m*K, H) — in-place add
+    topk_weights: torch.Tensor,  # (m, K) routing weights
+    scalings: torch.Tensor,  # (n_slots,) float32 — full scalings buffer; kernel loads [slot]
+    K: int,
+) -> None:
+    """Fused down expand for decode: lora_a @ down_B[slot, 0].T × weight × scaling.
+
+    Accepts the FULL (n_slots, 1, H, MAX_R) buffer, slot_idx, and the full scalings
+    buffer — eliminates the separate down_B gather and scalings gather per layer.
+
+    Performs the shared-B GEMM, topk-weight scaling, and accumulation into
+    down_output in a single fused kernel.
+    """
+    m_k, MAX_R = lora_a.shape
+    # Buffer layout: (n_slots, 1, H, MAX_R).
+    _n_slots, _one, H, _MAX_R = down_B_buffer.shape
+    # Stride between slots: only 1 expert-slot for shared B, so stride = 1 × H × MAX_R.
+    n_slot_stride_B = H * MAX_R
+    BLOCK_H = _choose_block_h_expand(H)
+    BLOCK_R = _choose_block_r(MAX_R)
+    assert (
+        down_B_buffer.is_contiguous()
+    ), "down_B_buffer must be contiguous for fused kernel"
+
+    # Reshape output to (m*K, H) so the kernel can use a flat pid_s index.
+    out_flat = down_output.view(m_k, H)
+
+    grid = (m_k, triton.cdiv(H, BLOCK_H))
+    _shared_b_down_expand_kernel[grid](
+        lora_a,
+        down_B_buffer,
+        slot_idx.to(torch.int32),
+        n_slot_stride_B,
+        topk_weights,
+        scalings,
+        out_flat,
+        K,
+        H=H,
+        MAX_R=MAX_R,
+        BLOCK_H=BLOCK_H,
+        BLOCK_R=BLOCK_R,
+        num_warps=4,
+        num_stages=3,
+    )
+
+
+# ── Flat A GEMM (decode path) ─────────────────────────────────────────────────
+#
+# Computes lora_a_m = hidden @ w13_A[slot, 0, :, :].T for each token,
+# reading directly from the buffer without a prior gather copy.
+# Replaces: w13_A gather (22 µs) + cuBLAS GEMM (25 µs) → ~5-8 µs per layer.
+#
+# Grid: (m, MAX_R // BLOCK_R)  — one block per (token, rank-tile)
+
+
+@triton.jit
+def _shared_a_shrink_kernel(
+    hidden,  # (m, H)
+    w13_A_buffer,  # full buffer: n_slots × 1 × MAX_R × H (contiguous)
+    slot_ptr,  # (1,) int32 — GPU scalar, dynamic at CUDA-graph replay
+    n_slot_stride_A,  # int — MAX_R × H (stride between slots; shared outer has 1 row)
+    lora_a_out,  # (m, MAX_R)
+    H: tl.constexpr,
+    MAX_R: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    pid_m = tl.program_id(0)  # token index
+    pid_r = tl.program_id(1)  # rank tile
+
+    slot = tl.load(slot_ptr).to(tl.int32)
+    kr = pid_r * BLOCK_R + tl.arange(0, BLOCK_R)
+    acc = tl.zeros((BLOCK_R,), dtype=tl.float32)
+
+    for h_start in range(0, H, BLOCK_H):
+        kh = h_start + tl.arange(0, BLOCK_H)
+        x = tl.load(hidden + pid_m * H + kh).to(tl.float32)  # (BLOCK_H,)
+        # buffer[slot, 0, kr, kh]: stride = slot * n_slot_stride_A + kr * H + kh
+        A_ptr = w13_A_buffer + slot * n_slot_stride_A + kr[:, None] * H + kh[None, :]
+        A = tl.load(A_ptr).to(tl.float32)  # (BLOCK_R, BLOCK_H)
+        acc += tl.sum(A * x[None, :], axis=1)
+
+    tl.store(lora_a_out + pid_m * MAX_R + kr, acc.to(hidden.dtype.element_ty))
+
+
+def shared_a_shrink(
+    hidden: torch.Tensor,  # (m, H)
+    w13_A_buffer: torch.Tensor,  # (n_slots, 1, MAX_R, H) — full buffer
+    slot_idx: torch.Tensor,  # (1,) int32 GPU tensor
+    BLOCK_H: int = 128,
+) -> torch.Tensor:
+    """Compute lora_a_m = hidden @ w13_A_buffer[slot, 0, :, :].T without gather.
+
+    Replaces: w13_A gather (22 µs) + cuBLAS GEMM (25 µs) = 47 µs per layer
+    With: single Triton kernel (~5-8 µs), saving ~40 µs × 48 = 1.9 ms.
+    """
+    m, H = hidden.shape
+    _n_slots, _one, MAX_R, _H = w13_A_buffer.shape
+    n_slot_stride_A = MAX_R * H  # stride between slots (1 × MAX_R × H)
+    BLOCK_R = _choose_block_r(MAX_R)
+
+    lora_a = torch.empty((m, MAX_R), dtype=hidden.dtype, device=hidden.device)
+    grid = (m, MAX_R // BLOCK_R)
+    _shared_a_shrink_kernel[grid](
+        hidden,
+        w13_A_buffer,
+        slot_idx.to(torch.int32),
+        n_slot_stride_A,
+        lora_a,
+        H=H,
+        MAX_R=MAX_R,
+        BLOCK_R=BLOCK_R,
+        BLOCK_H=BLOCK_H,
+        num_warps=4,
+        num_stages=2,
+    )
+    return lora_a
+
+
+# ── Per-Expert Gate/Up Expand ─────────────────────────────────────────────────
+#
+# Like gate_up_b_expand but reads lora_a_flat[pid_s] (per flat-pair position)
+# instead of lora_a_m[tok] (shared per token).  Required for per_expert adapters
+# where each expert has its own A matrix → lora_a differs per (token, topk_v) pair.
+#
+# Grid: (cdiv(I2, BLOCK_I), m*K)
+
+
+@triton.jit
+def _per_expert_gate_up_b_expand_kernel(
+    lora_a_flat,  # (m*K, MAX_R) — per flat-pair lora_a (from per_expert_a_shrink w/ hidden)
+    w13_B_buffer,  # full buffer: n_slots × E × I2 × MAX_R (contiguous)
+    slot_ptr,  # (1,) int32
+    n_slot_stride,  # E × I2 × MAX_R
+    safe_ids,  # (m, K) int64
+    gate_up_output,  # (m*K, I2) — in-place add
+    scaling_ptr,  # (n_slots,) float32
+    K,
+    I2: tl.constexpr,
+    MAX_R: tl.constexpr,
+    BLOCK_I: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+):
+    pid_i = tl.program_id(0)
+    pid_s = tl.program_id(1)  # flat-pair index [0 .. m*K-1]
+
+    tok = pid_s // K
+    topk_v = pid_s % K
+    exp = tl.load(safe_ids + tok * K + topk_v).to(tl.int32)
+
+    offs_i = pid_i * BLOCK_I + tl.arange(0, BLOCK_I)
+    i_mask = offs_i < I2
+
+    slot = tl.load(slot_ptr).to(tl.int32)
+    scaling = tl.load(scaling_ptr + slot).to(tl.float32)
+    acc = tl.zeros((BLOCK_I,), dtype=tl.float32)
+
+    for r_start in range(0, MAX_R, BLOCK_R):
+        kr = r_start + tl.arange(0, BLOCK_R)
+        # Per-position lora_a: lora_a_flat[pid_s] instead of lora_a_m[tok]
+        la = tl.load(lora_a_flat + pid_s * MAX_R + kr).to(tl.float32)
+        B_ptr = (
+            w13_B_buffer
+            + slot * n_slot_stride
+            + (exp * I2 + offs_i[:, None]) * MAX_R
+            + kr[None, :]
+        )
+        B = tl.load(B_ptr, mask=i_mask[:, None], other=0.0).to(tl.float32)
+        acc += tl.sum(B * la[None, :], axis=1)
+
+    out_ptr = gate_up_output + pid_s * I2 + offs_i
+    old = tl.load(out_ptr, mask=i_mask, other=0.0).to(tl.float32)
+    tl.store(out_ptr, old + acc * scaling, mask=i_mask)
+
+
+def per_expert_gate_up_b_expand(
+    lora_a_flat: torch.Tensor,  # (m*K, MAX_R) — from per_expert_a_shrink(hidden_flat, w13_A_buf, ...)
+    w13_B_buffer: torch.Tensor,  # (n_slots, E, I2, MAX_R) — full buffer
+    slot_idx: torch.Tensor,  # (1,) int32 GPU tensor
+    safe_ids: torch.Tensor,  # (m, K) int64
+    gate_up_output: torch.Tensor,  # (m*K, I2) — in-place add
+    scalings: torch.Tensor,  # (n_slots,) float32
+    BLOCK_I: int = 64,
+) -> None:
+    """Per-expert gate/up expand for decode: lora_a_flat[j] @ w13_B[slot, e_j].T.
+
+    Replaces the gather-then-einsum path for per_expert adapters.  Accepts the FULL
+    (n_slots, E, I2, MAX_R) buffer and reads the expert offset directly using safe_ids,
+    eliminating the two gather copies (w13_B gather + expert-select gather).
+    """
+    m_k, MAX_R = lora_a_flat.shape
+    _n_slots, E, I2, _MAX_R = w13_B_buffer.shape
+    n_slot_stride = E * I2 * MAX_R
+    BLOCK_R = _choose_block_r(MAX_R)
+    K = safe_ids.shape[1]
+    assert w13_B_buffer.is_contiguous(), "w13_B_buffer must be contiguous"
+
+    grid = (triton.cdiv(I2, BLOCK_I), m_k)
+    _per_expert_gate_up_b_expand_kernel[grid](
+        lora_a_flat,
+        w13_B_buffer,
+        slot_idx.to(torch.int32),
+        n_slot_stride,
+        safe_ids.to(torch.int64),
+        gate_up_output,
+        scalings,
+        K,
+        I2=I2,
+        MAX_R=MAX_R,
+        BLOCK_I=BLOCK_I,
+        BLOCK_R=BLOCK_R,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+# ── Per-Expert Down Expand ────────────────────────────────────────────────────
+#
+# Like shared_b_down_expand but reads per-expert B: down_B_buffer[slot, e_j, offs_h, :].
+# Required for per_expert adapters where down_B is per-expert (not shared).
+# Eliminates the two gather copies (down_B buffer copy + expert select gather).
+#
+# Grid: (m*K, cdiv(H, BLOCK_H))
+
+
+@triton.jit
+def _per_expert_b_down_expand_kernel(
+    lora_a,  # (m*K, MAX_R)
+    down_B_buffer,  # full buffer: n_slots × E × H × MAX_R (contiguous)
+    slot_ptr,  # (1,) int32
+    n_slot_stride_B,  # E × H × MAX_R
+    safe_ids,  # (m, K) int64
+    topk_weights,  # (m, K)
+    scaling_ptr,  # (n_slots,) float32
+    down_output,  # (m, K, H) — in-place add
+    K,
+    H: tl.constexpr,
+    MAX_R: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+):
+    pid_s = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    tok = pid_s // K
+    topk_v = pid_s % K
+    exp = tl.load(safe_ids + tok * K + topk_v).to(tl.int32)
+
+    offs_h = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
+    h_mask = offs_h < H
+
+    slot = tl.load(slot_ptr).to(tl.int32)
+    scaling = tl.load(scaling_ptr + slot).to(tl.float32)
+    weight = tl.load(topk_weights + tok * K + topk_v).to(tl.float32)
+
+    acc = tl.zeros((BLOCK_H,), dtype=tl.float32)
+
+    for r_start in range(0, MAX_R, BLOCK_R):
+        kr = r_start + tl.arange(0, BLOCK_R)
+        la = tl.load(lora_a + pid_s * MAX_R + kr).to(tl.float32)
+        # Per-expert B: buffer[slot, exp, offs_h, kr]
+        B_ptr = (
+            down_B_buffer
+            + slot * n_slot_stride_B
+            + (exp * H + offs_h[:, None]) * MAX_R
+            + kr[None, :]
+        )
+        B = tl.load(B_ptr, mask=h_mask[:, None], other=0.0).to(tl.float32)
+        acc += tl.sum(B * la[None, :], axis=1)
+
+    out_ptr = down_output + (tok * K + topk_v) * H + offs_h
+    old = tl.load(out_ptr, mask=h_mask, other=0.0).to(tl.float32)
+    tl.store(out_ptr, old + acc * weight * scaling, mask=h_mask)
+
+
+def per_expert_b_down_expand(
+    lora_a: torch.Tensor,  # (m*K, MAX_R) — from per_expert_a_shrink
+    down_B_buffer: torch.Tensor,  # (n_slots, E, H, MAX_R) — full buffer
+    slot_idx: torch.Tensor,  # (1,) int32 GPU tensor
+    safe_ids: torch.Tensor,  # (m, K) int64
+    down_output: torch.Tensor,  # (m, K, H) or (m*K, H) — in-place add
+    topk_weights: torch.Tensor,  # (m, K)
+    scalings: torch.Tensor,  # (n_slots,) float32
+    K: int,
+) -> None:
+    """Per-expert down expand for decode: lora_a[j] @ down_B[slot, e_j].T × weight.
+
+    Eliminates the two gather copies (down_B buffer copy + expert select gather)
+    for per_expert adapters where down_B is per-expert (not shared).
+    """
+    m_k, MAX_R = lora_a.shape
+    _n_slots, E, H, _MAX_R = down_B_buffer.shape
+    n_slot_stride_B = E * H * MAX_R
+    BLOCK_H = _choose_block_h_expand(H)
+    BLOCK_R = _choose_block_r(MAX_R)
+    assert down_B_buffer.is_contiguous(), "down_B_buffer must be contiguous"
+
+    out_flat = down_output.view(m_k, H)
+    grid = (m_k, triton.cdiv(H, BLOCK_H))
+    _per_expert_b_down_expand_kernel[grid](
+        lora_a,
+        down_B_buffer,
+        slot_idx.to(torch.int32),
+        n_slot_stride_B,
+        safe_ids.to(torch.int64),
+        topk_weights,
+        scalings,
+        out_flat,
+        K,
+        H=H,
+        MAX_R=MAX_R,
+        BLOCK_H=BLOCK_H,
+        BLOCK_R=BLOCK_R,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+# ── Fused A+B Gate/Up (eliminates shared_a_shrink + gate_up_b_expand) ──────
+#
+# Combines hidden @ w13_A + lora_a @ w13_B in one kernel, removing a separate
+# shared_a_shrink launch.  Lora_a is computed per flat-pair block (redundant for
+# k>1 per token) but w13_A fits in L1 so cache hits make this negligible.
+# Grid: (cdiv(I2, BLOCK_I), m*K)
+
+
+@triton.jit
+def _fused_shared_a_b_gate_up_kernel(
+    hidden,  # (m, H)
+    w13_A_buffer,  # (n_slots, 1, MAX_R, H) — contiguous
+    w13_B_buffer,  # (n_slots, E, I2, MAX_R) — contiguous
+    safe_ids,  # (m, K) int64
+    gate_up_output,  # (m*K, I2) — in-place add
+    scalings,  # (n_slots,) float32
+    slot_ptr,  # (1,) int32
+    K,
+    n_A_stride,  # = MAX_R * H
+    n_B_stride,  # = E * I2 * MAX_R
+    H: tl.constexpr,
+    I2: tl.constexpr,
+    MAX_R: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_I: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+):
+    pid_i = tl.program_id(0)  # I2 chunk
+    pid_s = tl.program_id(1)  # flat-pair index
+
+    slot = tl.load(slot_ptr).to(tl.int32)
+    tok = pid_s // K
+    topk_v = pid_s % K
+    exp = tl.load(safe_ids + tok * K + topk_v).to(tl.int32)
+    scaling = tl.load(scalings + slot).to(tl.float32)
+
+    offs_i = pid_i * BLOCK_I + tl.arange(0, BLOCK_I)
+    i_mask = offs_i < I2
+    acc = tl.zeros((BLOCK_I,), dtype=tl.float32)
+
+    # Outer loop over BLOCK_R chunks of rank: compute lora_a[r:r+BLOCK_R] then expand.
+    # This avoids storing the full lora_a vector when BLOCK_R < MAX_R.
+    for r_start in range(0, MAX_R, BLOCK_R):
+        kr = r_start + tl.arange(0, BLOCK_R)
+
+        # Phase 1 (for this rank chunk): la = hidden[tok] @ w13_A[slot, 0, kr, :].T
+        la = tl.zeros((BLOCK_R,), dtype=tl.float32)
+        for h_start in range(0, H, BLOCK_H):
+            kh = h_start + tl.arange(0, BLOCK_H)
+            x = tl.load(hidden + tok * H + kh).to(tl.float32)
+            A_ptr = w13_A_buffer + slot * n_A_stride + kr[:, None] * H + kh[None, :]
+            A = tl.load(A_ptr).to(tl.float32)
+            la += tl.sum(A * x[None, :], axis=1)
+
+        # Phase 2 (for this rank chunk): acc += la @ w13_B[slot, exp, offs_i, kr].T
+        B_ptr = (
+            w13_B_buffer
+            + slot * n_B_stride
+            + (exp * I2 + offs_i[:, None]) * MAX_R
+            + kr[None, :]
+        )
+        B = tl.load(B_ptr, mask=i_mask[:, None], other=0.0).to(tl.float32)
+        acc += tl.sum(B * la[None, :], axis=1)
+
+    out_ptr = gate_up_output + pid_s * I2 + offs_i
+    old = tl.load(out_ptr, mask=i_mask, other=0.0).to(tl.float32)
+    tl.store(out_ptr, old + acc * scaling, mask=i_mask)
+
+
+def fused_shared_a_b_gate_up_expand(
+    hidden: torch.Tensor,  # (m, H)
+    w13_A_buffer: torch.Tensor,  # (n_slots, 1, MAX_R, H)
+    w13_B_buffer: torch.Tensor,  # (n_slots, E, I2, MAX_R)
+    safe_ids: torch.Tensor,  # (m, K) int64
+    gate_up_output: torch.Tensor,  # (m*K, I2) — in-place add
+    scalings: torch.Tensor,  # (n_slots,) float32
+    slot_idx: torch.Tensor,  # (1,) int32
+    BLOCK_I: int = 64,
+    BLOCK_H: int = 128,
+) -> None:
+    """Fused A+B gate/up: eliminates the separate shared_a_shrink kernel launch."""
+    m_k, I2 = gate_up_output.shape
+    m, H = hidden.shape
+    K = safe_ids.shape[1]
+    _ns, _one, MAX_R, _H = w13_A_buffer.shape
+    _ns2, E, _I2, _MAX_R = w13_B_buffer.shape
+    n_A_stride = MAX_R * H
+    n_B_stride = E * I2 * MAX_R
+    BLOCK_R = _choose_block_r(MAX_R)
+    assert w13_A_buffer.is_contiguous() and w13_B_buffer.is_contiguous()
+
+    grid = (triton.cdiv(I2, BLOCK_I), m_k)
+    _fused_shared_a_b_gate_up_kernel[grid](
+        hidden,
+        w13_A_buffer,
+        w13_B_buffer,
+        safe_ids.to(torch.int64),
+        gate_up_output,
+        scalings,
+        slot_idx.to(torch.int32),
+        K,
+        n_A_stride,
+        n_B_stride,
+        H=H,
+        I2=I2,
+        MAX_R=MAX_R,
+        BLOCK_H=BLOCK_H,
+        BLOCK_I=BLOCK_I,
+        BLOCK_R=BLOCK_R,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+# ── Fused Shrink+Expand Down (eliminates per_expert_a_shrink + shared_b_down_expand) ─
+#
+# Combines ri @ down_A + lora_a @ down_B in one kernel per (flat-pair, H-chunk).
+# Grid: (m*K, cdiv(H, BLOCK_H))
+
+
+@triton.jit
+def _fused_a_b_down_expand_kernel(
+    route_input,  # (m*K, INTER)
+    down_A_buffer,  # (n_slots, E, MAX_R, INTER) — contiguous
+    down_B_buffer,  # (n_slots, 1, H, MAX_R) — contiguous
+    safe_ids,  # (m, K) int64
+    topk_weights,  # (m, K)
+    scalings,  # (n_slots,) float32
+    slot_ptr,  # (1,) int32
+    down_output,  # (m*K, H) — in-place add
+    K,
+    n_A_stride,  # = E * MAX_R * INTER
+    n_B_stride,  # = H * MAX_R
+    INTER: tl.constexpr,
+    H: tl.constexpr,
+    MAX_R: tl.constexpr,
+    BLOCK_H_S: tl.constexpr,  # shrink tile over INTER
+    BLOCK_H_E: tl.constexpr,  # expand tile over H
+):
+    pid_s = tl.program_id(0)  # flat-pair index
+    pid_h = tl.program_id(1)  # H chunk
+
+    slot = tl.load(slot_ptr).to(tl.int32)
+    tok = pid_s // K
+    topk_v = pid_s % K
+    exp = tl.load(safe_ids + tok * K + topk_v).to(tl.int32)
+    weight = tl.load(topk_weights + tok * K + topk_v).to(tl.float32)
+    scaling = tl.load(scalings + slot).to(tl.float32)
+
+    offs_h = pid_h * BLOCK_H_E + tl.arange(0, BLOCK_H_E)
+    h_mask = offs_h < H
+    kr = tl.arange(0, MAX_R)
+
+    # Phase 1: lora_a = ri[pid_s] @ down_A[slot, exp, :, :].T
+    lora_a = tl.zeros((MAX_R,), dtype=tl.float32)
+    for h_start in range(0, INTER, BLOCK_H_S):
+        kh = h_start + tl.arange(0, BLOCK_H_S)
+        x = tl.load(route_input + pid_s * INTER + kh).to(tl.float32)
+        A_ptr = (
+            down_A_buffer
+            + slot * n_A_stride
+            + (exp * MAX_R + kr[:, None]) * INTER
+            + kh[None, :]
+        )
+        A = tl.load(A_ptr).to(tl.float32)
+        lora_a += tl.sum(A * x[None, :], axis=1)
+
+    # Phase 2: delta = lora_a @ down_B[slot, 0, offs_h, :].T * weight * scaling
+    B_ptr = down_B_buffer + slot * n_B_stride + offs_h[:, None] * MAX_R + kr[None, :]
+    B = tl.load(B_ptr, mask=h_mask[:, None], other=0.0).to(tl.float32)
+    delta = tl.sum(B * lora_a[None, :], axis=1) * weight * scaling
+
+    out_ptr = down_output + pid_s * H + offs_h
+    old = tl.load(out_ptr, mask=h_mask, other=0.0).to(tl.float32)
+    tl.store(out_ptr, old + delta, mask=h_mask)
+
+
+def fused_a_b_down_expand(
+    route_input: torch.Tensor,  # (m*K, INTER)
+    down_A_buffer: torch.Tensor,  # (n_slots, E, MAX_R, INTER)
+    down_B_buffer: torch.Tensor,  # (n_slots, 1, H, MAX_R)
+    safe_ids: torch.Tensor,  # (m, K) int64
+    topk_weights: torch.Tensor,  # (m, K)
+    scalings: torch.Tensor,  # (n_slots,) float32
+    slot_idx: torch.Tensor,  # (1,) int32
+    down_output: torch.Tensor,  # (m*K, H) or (m, K, H) — in-place add
+    BLOCK_H_E: int = 64,
+) -> None:
+    """Fused shrink+expand down: eliminates per_expert_a_shrink + shared_b_down_expand launches."""
+    m_k, INTER = route_input.shape
+    _ns, E, MAX_R, _INTER = down_A_buffer.shape
+    _ns2, _one, H, _MAX_R = down_B_buffer.shape
+    K = safe_ids.shape[1]
+    n_A_stride = E * MAX_R * INTER
+    n_B_stride = H * MAX_R
+    BLOCK_H_S = _choose_block_h(INTER)
+    assert down_A_buffer.is_contiguous() and down_B_buffer.is_contiguous()
+
+    out_flat = down_output.view(m_k, H)
+    grid = (m_k, triton.cdiv(H, BLOCK_H_E))
+    _fused_a_b_down_expand_kernel[grid](
+        route_input,
+        down_A_buffer,
+        down_B_buffer,
+        safe_ids.to(torch.int64),
+        topk_weights,
+        scalings,
+        slot_idx.to(torch.int32),
+        out_flat,
+        K,
+        n_A_stride,
+        n_B_stride,
+        INTER=INTER,
+        H=H,
+        MAX_R=MAX_R,
+        BLOCK_H_S=BLOCK_H_S,
+        BLOCK_H_E=BLOCK_H_E,
+        num_warps=4,
+        num_stages=2,
+    )


### PR DESCRIPTION
## Summary

Standalone Triton LoRA kernels, split out of the serving runtime so they can be reviewed on their own.

**Nothing in-tree calls them yet** — the runtime that does is the next PR in this stack (#980). They are split in this direction because `lora_manager` imports them *unguarded*, so kernels-first is what keeps the stack bisectable.

- `ops/lora/triton` — shrink (`x @ Aᵀ`) and expand (`@ B`) kernels, with fused variants for the qkv and gate/up projections, separate prefill paths, plus the autotuning harness and pre-tuned H100 configs.
- `ops/moe_lora` — per-expert and shared-A/B variants for routed MoE, including the sorted-layout down-projection shrink.

Ported from the closed #738 (written against a `main` 191 commits back). The kernels themselves needed no reconciliation — only the lint fixes below.

## Lint

Removed unused imports in `tune_sweep.py` and `tuning.py`, and dropped two redundant `range()` start arguments — all flagged by ruff on the ported files.

## Testing — validated on H100 80GB (sm_90a)

Checked against a torch reference in bf16:

| Kernel | Result |
|---|---|
| `lora_shrink_fwd` | matches `x @ A[slot]ᵀ` — max abs err **7.8e-3** |
| `lora_expand_fwd` | matches `base + scaling * (a @ B[slot]ᵀ)` incl. fused add — max abs err **1.3e-2** |
| `NO_LORA_SLOT` segment | leaves `base_output` **bit-identical** (delta 0.0) — a base-model request in a mixed batch cannot be perturbed |

**Still unverified:** the fused qkv/gate-up expand variants, the prefill paths, the grouped decode kernel, and whether the pre-tuned H100 configs are actually well-tuned (numerics were checked, tuning quality was not).

Lint: `ruff`, `pre-commit` clean.
