### PR TITLE
feat(moe): integrate MoE LoRA into the Triton bf16 MoE kernel

### DIFF
--- a/python/tokenspeed/runtime/layers/moe/expert.py
+++ b/python/tokenspeed/runtime/layers/moe/expert.py
@@ -27,6 +27,7 @@ import torch
 from tokenspeed.runtime.distributed.process_group_manager import (
     process_group_manager as pg_manager,
 )
+from tokenspeed.runtime.execution.context import get_current_lora_manager
 from tokenspeed.runtime.layers.activation import SwigluArg
 from tokenspeed.runtime.layers.moe.topk import TopKOutput, TopKOutputFormat
 from tokenspeed.runtime.layers.moe.types import MoELayerSpec
@@ -272,6 +273,18 @@ class MoELayer(torch.nn.Module):
     def supports_deferred_finalize(self) -> bool:
         return self.plan["supports_deferred_finalize"]
 
+    @property
+    def supports_moe_lora(self) -> bool:
+        """Whether the planned apply kernel exposes the MoE LoRA hook seam.
+
+        The per-expert LoRA deltas have to land on the pre-activation gate/up
+        values and on the routed intermediate, so a kernel can only host them if
+        it exposes both in a layout the LoRA kernels can index. Today that is the
+        precomputed-topk Triton bf16 kernel; vendor-fused kernels and the
+        kernel-routing path return False.
+        """
+        return bool(self.plan.get("supports_moe_lora", False))
+
     def forward_zero_experts(self, topk_output):
         zero_expert_limit = self.num_experts
         if self.ep_num_redundant_experts is not None:
@@ -312,6 +325,29 @@ class MoELayer(torch.nn.Module):
         """
         if not do_finalize and not self.supports_deferred_finalize:
             raise AssertionError("MoELayer does not support do_finalize=False")
+
+        # Resolve any active MoE LoRA context and stash it on the module, since
+        # the planned apply kernel receives ``self`` as its weight module and
+        # reads the context from there. Raise rather than silently skipping LoRA
+        # on a kernel that has no seam -- a quietly base-model MoE layer inside
+        # an adapted model is far harder to notice than a failed request.
+        self._moe_lora_ctx = None
+        lora_manager = get_current_lora_manager()
+        if lora_manager is not None and getattr(lora_manager, "enable_moe_lora", False):
+            if not self.supports_moe_lora:
+                raise NotImplementedError(
+                    "MoE LoRA is not supported by the selected MoE kernel "
+                    f"({self.plan.get('apply_kernel_name')}); it requires the "
+                    "precomputed-topk Triton bf16 MoE kernel. Select the Triton "
+                    "MoE solution for LoRA-enabled MoE models."
+                )
+            if self.ep_size != 1:
+                raise NotImplementedError(
+                    "MoE LoRA currently supports local/tensor-parallel MoE only; "
+                    "expert-parallel dispatch needs the LoRA slot map dispatched "
+                    "with the tokens."
+                )
+            self._moe_lora_ctx = lora_manager.moe_lora_context
 
         if self.support_routing:
             return tokenspeed_kernel.moe_apply(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/__init__.py
@@ -279,6 +279,9 @@ def moe_plan(
     supports_deferred_finalize = True in apply_spec.traits.get(
         "supports_deferred_finalize", frozenset({False})
     )
+    supports_moe_lora = True in apply_spec.traits.get(
+        "supports_moe_lora", frozenset({False})
+    )
     return {
         "weight_dtype": weight_dtype,
         "activation": activation,
@@ -292,6 +295,7 @@ def moe_plan(
         ),
         "support_routing": support_routing,
         "supports_deferred_finalize": supports_deferred_finalize,
+        "supports_moe_lora": supports_moe_lora,
         "solution": apply_spec.solution,
         "internal_activation_dtype": internal_activation_dtype,
     }

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/bf16.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/bf16.py
@@ -209,6 +209,75 @@ def _validate(
 
 
 @triton.jit
+def _gate_up_activation(
+    gate_acc,
+    up_acc,
+    situ_beta,
+    situ_linear_beta,
+    DTYPE: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    HAS_LINEAR_BETA: tl.constexpr,
+):
+    """Combine pre-activation gate/up accumulators into the intermediate value.
+
+    Shared by the fused stage-1 store and by _activate_kernel, which runs on the
+    un-fused MoE LoRA path. Keeping one definition is the point: the two paths
+    must agree bit for bit, and the situ branch's round trip through DTYPE is
+    easy to drop when the expression is written out twice.
+    """
+    if ACTIVATION == "situ":
+        gate = gate_acc.to(DTYPE).to(tl.float32)
+        up = up_acc.to(DTYPE).to(tl.float32)
+        gate = situ_beta * libdevice.tanh(gate / situ_beta) * tl.sigmoid(gate)
+        if HAS_LINEAR_BETA:
+            up = situ_linear_beta * libdevice.tanh(up / situ_linear_beta)
+        return (gate * up).to(DTYPE)
+    return (gate_acc * tl.sigmoid(gate_acc) * up_acc).to(DTYPE)
+
+
+@triton.jit
+def _activate_kernel(
+    gate_up_ptr,
+    inter_ptr,
+    route_count,
+    intermediate_size: tl.constexpr,
+    situ_beta,
+    situ_linear_beta,
+    DTYPE: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    HAS_LINEAR_BETA: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Activate a (route_count, 2I) gate/up buffer into (route_count, I).
+
+    Only used when MoE LoRA is attached: the LoRA delta has to land on the
+    pre-activation gate/up values, so stage 1 stores them raw and the activation
+    happens here instead.
+    """
+    pid = tl.program_id(0)
+    row = pid // tl.cdiv(intermediate_size, BLOCK)
+    col_block = pid % tl.cdiv(intermediate_size, BLOCK)
+    if row < route_count:
+        cols = col_block * BLOCK + tl.arange(0, BLOCK)
+        col_mask = cols < intermediate_size
+        gate_up_row = gate_up_ptr + row * (2 * intermediate_size)
+        gate_acc = tl.load(gate_up_row + cols, mask=col_mask, other=0.0).to(tl.float32)
+        up_acc = tl.load(
+            gate_up_row + intermediate_size + cols, mask=col_mask, other=0.0
+        ).to(tl.float32)
+        activated = _gate_up_activation(
+            gate_acc,
+            up_acc,
+            situ_beta,
+            situ_linear_beta,
+            DTYPE,
+            ACTIVATION,
+            HAS_LINEAR_BETA,
+        )
+        tl.store(inter_ptr + row * intermediate_size + cols, activated, mask=col_mask)
+
+
+@triton.jit
 def _stage1_kernel(
     x_desc,
     w13_desc,
@@ -222,8 +291,10 @@ def _stage1_kernel(
     top_k: tl.constexpr,
     situ_beta,
     situ_linear_beta,
+    gate_up_ptr,
     ACTIVATION: tl.constexpr,
     HAS_LINEAR_BETA: tl.constexpr,
+    STORE_PREACT: tl.constexpr,
     NUM_PROGRAMS: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
@@ -266,21 +337,42 @@ def _stage1_kernel(
                 gate_acc += tl.dot(x, gate.T)
                 up_acc += tl.dot(x, up.T)
 
-            if ACTIVATION == "situ":
-                gate = gate_acc.to(x_desc.dtype).to(tl.float32)
-                up = up_acc.to(x_desc.dtype).to(tl.float32)
-                gate = situ_beta * libdevice.tanh(gate / situ_beta) * tl.sigmoid(gate)
-                if HAS_LINEAR_BETA:
-                    up = situ_linear_beta * libdevice.tanh(up / situ_linear_beta)
-                activated = (gate * up).to(x_desc.dtype)
+            if STORE_PREACT:
+                # MoE LoRA path: hand the raw gate/up accumulators out so the
+                # LoRA delta can be added before the activation, then let
+                # _activate_kernel finish the job. Gate occupies columns
+                # [0, I) and up [I, 2I), matching w13's [E, 2I, H] layout.
+                gate_up_offsets = (
+                    route_ids[:, None] * (2 * intermediate_size)
+                    + n_offset
+                    + tl.arange(0, BLOCK_N)[None, :]
+                )
+                tl.store(
+                    gate_up_ptr + gate_up_offsets,
+                    gate_acc.to(x_desc.dtype),
+                    mask=row_mask[:, None],
+                )
+                tl.store(
+                    gate_up_ptr + gate_up_offsets + intermediate_size,
+                    up_acc.to(x_desc.dtype),
+                    mask=row_mask[:, None],
+                )
             else:
-                activated = (gate_acc * tl.sigmoid(gate_acc) * up_acc).to(x_desc.dtype)
-            inter_offsets = (
-                route_ids[:, None] * intermediate_size
-                + n_offset
-                + tl.arange(0, BLOCK_N)[None, :]
-            )
-            tl.store(inter_ptr + inter_offsets, activated, mask=row_mask[:, None])
+                activated = _gate_up_activation(
+                    gate_acc,
+                    up_acc,
+                    situ_beta,
+                    situ_linear_beta,
+                    x_desc.dtype,
+                    ACTIVATION,
+                    HAS_LINEAR_BETA,
+                )
+                inter_offsets = (
+                    route_ids[:, None] * intermediate_size
+                    + n_offset
+                    + tl.arange(0, BLOCK_N)[None, :]
+                )
+                tl.store(inter_ptr + inter_offsets, activated, mask=row_mask[:, None])
             tile_idx += NUM_PROGRAMS
 
         problem_start += problem_tiles
@@ -364,6 +456,8 @@ def _moe(
     activation: str,
     situ_beta: float,
     situ_linear_beta: float | None,
+    moe_lora_ctx=None,
+    layer_index: int = 0,
 ) -> torch.Tensor:
     num_tokens, hidden_size = x.shape
     num_experts, twice_intermediate_size, _ = w13.shape
@@ -376,6 +470,17 @@ def _moe(
     route_count = num_tokens * top_k
     intermediate = torch.empty(
         (route_count, intermediate_size), device=x.device, dtype=x.dtype
+    )
+    # With LoRA attached the activation moves out of stage 1 so the delta can be
+    # added to the pre-activation gate/up values. Costs one (route_count, 2I)
+    # buffer and an extra pass; the LoRA-free path is unchanged.
+    apply_lora = moe_lora_ctx is not None
+    gate_up = (
+        torch.empty(
+            (route_count, 2 * intermediate_size), device=x.device, dtype=x.dtype
+        )
+        if apply_lora
+        else None
     )
     # Invalid expert ids are absent from routing; zero their canonical rows.
     route_output = torch.zeros(
@@ -410,8 +515,10 @@ def _moe(
         top_k=top_k,
         situ_beta=situ_beta,
         situ_linear_beta=(1.0 if situ_linear_beta is None else situ_linear_beta),
+        gate_up_ptr=gate_up,
         ACTIVATION=activation,
         HAS_LINEAR_BETA=situ_linear_beta is not None,
+        STORE_PREACT=apply_lora,
         NUM_PROGRAMS=stage1_programs,
         BLOCK_M=block_m,
         BLOCK_N=stage1_block_n,
@@ -419,6 +526,26 @@ def _moe(
         num_warps=4 if block_m == 16 else 8,
         num_stages=3,
     )
+    if apply_lora:
+        # topk_ids is (num_tokens, top_k) and gate_up is indexed by the same
+        # canonical tok * top_k + k slot the LoRA kernels use, so the flat-pair
+        # entry points apply directly -- no gathered-layout bridging needed.
+        moe_lora_ctx.apply_gate_up_lora(layer_index, x, topk_ids, gate_up)
+        activate_block = 256 if intermediate_size >= 256 else 64
+        activate_programs = route_count * triton.cdiv(intermediate_size, activate_block)
+        _activate_kernel[(activate_programs,)](
+            gate_up,
+            intermediate,
+            route_count,
+            intermediate_size=intermediate_size,
+            situ_beta=situ_beta,
+            situ_linear_beta=(1.0 if situ_linear_beta is None else situ_linear_beta),
+            DTYPE=intermediate.dtype,
+            ACTIVATION=activation,
+            HAS_LINEAR_BETA=situ_linear_beta is not None,
+            BLOCK=activate_block,
+            num_warps=4,
+        )
     _stage2_kernel[(stage2_programs,)](
         intermediate,
         w2_desc,
@@ -438,6 +565,12 @@ def _moe(
         num_stages=3,
     )
     _combine(route_output, topk_weights, output)
+    if apply_lora:
+        # Applied after the combine because apply_down_lora does its own top-k
+        # weighting and accumulates straight into the token-major output.
+        moe_lora_ctx.apply_down_lora(
+            layer_index, intermediate, topk_ids, topk_weights, output
+        )
     return output
 
 
@@ -462,6 +595,7 @@ def _moe(
         "ispp_alignment": frozenset({32}),
         "internal_activation_dtype": frozenset({"input"}),
         "supports_bias": frozenset({False}),
+        "supports_moe_lora": frozenset({True}),
     },
     priority=Priority.PORTABLE,
 )
@@ -507,4 +641,7 @@ def triton_bf16_precomputed_moe_apply(
         activation,
         float(getattr(w, "activation_situ_beta", 1.0) or 1.0),
         getattr(w, "activation_situ_linear_beta", None),
+        # Stashed on the module by MoELayer.forward when an adapter is active.
+        moe_lora_ctx=getattr(w, "_moe_lora_ctx", None),
+        layer_index=getattr(w, "layer_index", 0),
     )


### PR DESCRIPTION
## Summary

Re-establishes the MoE LoRA seam #738 built, against the Triton MoE kernels that #914 rewrote underneath it. Top of the LoRA stack — 3 files, +191/−14.

## Why this wasn't a rebase

#738's hooks lived in `ops/moe/triton/fp8.py`, which #914 **deleted outright** (Triton FP8 MoE now routes through deep_gemm/flashinfer). Both surviving Triton MoE kernels were rewritten from the `matmul_ogs`/`FusedActivation` design to a two-stage `_routing`/`_stage1`/`_stage2`/`_combine` design, so the old hook shape — un-fuse the activation, grab `intermediate_cache`, bridge the gathered layout via `scatter_indx` — maps to neither.

**One thing got simpler.** The rewritten kernels index the intermediate by the canonical flat-pair slot (`tok * top_k + k`), which is exactly what the LoRA kernels already index. #738 needed `apply_*_lora_ragged` to bridge the gathered layout; this uses the plain flat-pair entry points, so no bridging at all.

**One thing got harder.** Stage 1 fuses the activation and stores only the `I`-wide result, so there's no pre-activation gate/up buffer to add the delta to. Hence an opt-in un-fused path:

- `_gate_up_activation` — a `@triton.jit` device function holding the activation expression, called by *both* stage 1 and the new `_activate_kernel`, so the fused and un-fused paths can't drift. (The `situ` branch's round trip through the storage dtype is exactly the detail that gets lost when such an expression is written twice.)
- `_stage1_kernel` takes `STORE_PREACT`; when set it stores the raw gate/up accumulators into a `(route_count, 2I)` buffer and skips the activation.
- `_moe` allocates that buffer only when a LoRA context is attached, applies the gate/up delta, activates via `_activate_kernel`, then applies the down delta after `_combine` (`apply_down_lora` does its own top-k weighting and accumulates into the token-major output).

`STORE_PREACT` is a `constexpr`, so **the LoRA-free path keeps its control flow and its arithmetic** — the extra buffer and extra pass exist only when an adapter is active.

## Scope: bf16 only

Only `triton_bf16_precomputed_moe_apply` advertises `supports_moe_lora`.

**mxfp4 is deliberately excluded.** Its stage 1 quantizes the activated intermediate to mxfp4 in-kernel (packed values plus scales), so there's no plain intermediate tensor for the LoRA kernels to read or write, and the gate/up delta would have to land before quantization. #738 could claim the trait there because the pre-#914 kernel had a plain intermediate; that no longer holds.

Vendor-fused kernels (flashinfer) and the kernel-routing path have no Python seam at all. `MoELayer` raises `NotImplementedError` rather than silently running an adapted model as base — a quietly base-model MoE layer is much harder to notice than a failed request. EP (`ep_size > 1`) also raises: the LoRA slot map would need dispatching with the tokens.

## ⚠️ Cannot be validated on H100 — and neither can `main`

**main's Triton bf16 MoE kernel does not run on H100 at all.** `_stage1_kernel` uses the TensorDescriptor gather (`x_desc.gather`), which ptxas lowers to

```
.tile::gather4 with destination state space as .shared::cta
```

and rejects with **`requires .target sm_100 or higher`**. H100 is sm_90a, so the kernel needs Blackwell.

This **reproduces on clean `main` at 4cc20d86** — `tokenspeed-kernel/test/ops/moe/test_triton_bf16_apply.py` fails there exactly as it does here. It is a pre-existing limitation of the kernel this PR extends, not something introduced by it. Triton itself is healthy on the test host: an ordinary Triton kernel compiles and runs on the same GPU.

Consequence: neither the LoRA path added here nor the refactor of the existing fused path could be executed. The activation math is unchanged and now has a single definition, but stage 1's generated code did change shape, so **the LoRA-free MoE path needs a smoke test on sm_100 hardware** alongside the LoRA correctness work.

Verified only: AST parse, `ruff` under CI's select list (clean), `pre-commit` (clean), and zero new ruff-default findings versus the base (`ops/moe/` holds at 88 pre-existing; `expert.py` at 3).
