### PR TITLE
chore: drop unused expand_page_table import in mla.py

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mla.py
@@ -45,7 +45,6 @@ from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.cache_runtime import (
     cache_debug_enabled,
 )
-from tokenspeed.runtime.layers.attention.page_table import expand_page_table
 from tokenspeed.runtime.layers.attention.registry import register_backend
 from tokenspeed.runtime.layers.attention.utils import build_page_table
 from tokenspeed.runtime.utils.common import ceil_div


### PR DESCRIPTION
The attention deadcode cleanup (#978) removed the last use of `expand_page_table` from `mla.py` but left the import, so

```
ruff check --select F401 python/tokenspeed/runtime
```

fails on `main` as of `f01e30fe` — the exact command the Lint workflow runs.

Nothing imports the symbol via `mla` (the module has no `__all__`, and its importers take only `MLAAttnBackend` / `MLADecodeMetadata`), so the import is dead rather than a re-export.

Split out of the LoRA scheduler PR (#976) to keep that one scheduler-only; this is unrelated to LoRA and can land on its own.