### PR TITLE
fix(mla): disable unsafe prefill PDL chain

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
@@ -37,6 +37,7 @@ import torch
 import triton
 from tokenspeed_kernel.ops.attention.tokenspeed_mla import (
     get_num_sm,
+    mla_prefill_pdl_enabled,
     tokenspeed_mla_decode,
     tokenspeed_mla_prefill,
     warmup_compile_prefill,
@@ -174,7 +175,7 @@ class CuteDSLMLABackend(AttentionBackend):
             q_dtype=torch.float8_e4m3fn,
             d_qk=d_qk,
             d_v=self.v_head_dim,
-            enable_pdl=pdl_enabled(),
+            enable_pdl=mla_prefill_pdl_enabled(pdl_enabled()),
         )
 
         # Validate page_size
@@ -1039,7 +1040,7 @@ class CuteDSLMLABackend(AttentionBackend):
             return_lse=True,
             cum_seq_lens_q=cum_seq_lens_q,
             max_seq_len_q=max_q_len,
-            enable_pdl=pdl_enabled(),
+            enable_pdl=mla_prefill_pdl_enabled(pdl_enabled()),
             out=out,
         )
 

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -35,7 +35,10 @@ from tokenspeed_kernel.ops.attention import (
     attn_merge_state,
     mla_project_value,
 )
-from tokenspeed_kernel.ops.attention.tokenspeed_mla import mla_kv_pack_quantize_fp8
+from tokenspeed_kernel.ops.attention.tokenspeed_mla import (
+    mla_kv_pack_quantize_fp8,
+    mla_prefill_pdl_enabled,
+)
 from tokenspeed_kernel.ops.attention.triton.mla_query_assemble import (
     mla_nope_query_fp8,
 )
@@ -1086,14 +1089,16 @@ class DeepseekV3AttentionMLA(nn.Module):
                 is_neox=is_neox,
                 quant_scale_q=1.0,
                 quant_scale_kv=k_scale,
-                enable_pdl=pdl_enabled(),
+                enable_pdl=mla_prefill_pdl_enabled(pdl_enabled()),
             )
 
-            v_fp8 = fp8_quantize(v, enable_pdl=pdl_enabled())
+            v_fp8 = fp8_quantize(v, enable_pdl=mla_prefill_pdl_enabled(pdl_enabled()))
 
             # Write FP8 KV cache directly (skip BF16→FP8 conversion in pool)
             k_pe_for_cache = k_fp8[:, 0:1, self.qk_nope_head_dim :]
-            kv_a_fp8 = fp8_quantize(kv_a, enable_pdl=pdl_enabled())
+            kv_a_fp8 = fp8_quantize(
+                kv_a, enable_pdl=mla_prefill_pdl_enabled(pdl_enabled())
+            )
             ctx.token_to_kv_pool.set_mla_kv_buffer(
                 self.attn_mha,
                 out_cache_loc,
@@ -1191,7 +1196,11 @@ class DeepseekV3AttentionMLA(nn.Module):
             if q.dtype == torch.float8_e4m3fn:
                 # FP8 Attention
                 k, v = mla_kv_pack_quantize_fp8(
-                    k_nope, k_pe, v, k_scale_inv=1.0 / k_scale, enable_pdl=pdl_enabled()
+                    k_nope,
+                    k_pe,
+                    v,
+                    k_scale_inv=1.0 / k_scale,
+                    enable_pdl=mla_prefill_pdl_enabled(pdl_enabled()),
                 )
             else:
                 # BF16 Attention
@@ -1220,7 +1229,7 @@ class DeepseekV3AttentionMLA(nn.Module):
                 chunk_output,
                 lse,
                 inplace=True,
-                enable_pdl=pdl_enabled(),
+                enable_pdl=mla_prefill_pdl_enabled(pdl_enabled()),
             )
 
         return output

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/tokenspeed_mla/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/tokenspeed_mla/__init__.py
@@ -22,6 +22,26 @@
 
 from tokenspeed_kernel.registry import error_fn
 
+# The prefill FMHA kernel accepts PDL, but enabling it across the Q/K/V FP8
+# producers and FMHA consumer can intermittently expose incomplete inputs on
+# Blackwell and make the FMHA output NaN. Keep the producers, consumer, merge,
+# and warmup on non-PDL variants until that cross-kernel dependency is fixed.
+MLA_PREFILL_PDL_SUPPORTED = False
+
+
+def mla_prefill_pdl_enabled(requested: bool) -> bool:
+    """Resolve PDL for the MLA FP8-input and prefill pipeline.
+
+    Args:
+        requested: Whether the runtime and device would otherwise enable PDL.
+
+    Returns:
+        ``True`` only when PDL was requested and the complete producer/consumer
+        pipeline is known to support it safely.
+    """
+    return requested and MLA_PREFILL_PDL_SUPPORTED
+
+
 try:
     from tokenspeed_mla import (
         get_num_sm,
@@ -38,8 +58,10 @@ except ImportError:
     warmup_compile_prefill = error_fn
 
 __all__ = [
+    "MLA_PREFILL_PDL_SUPPORTED",
     "get_num_sm",
     "mla_kv_pack_quantize_fp8",
+    "mla_prefill_pdl_enabled",
     "tokenspeed_mla_decode",
     "tokenspeed_mla_prefill",
     "warmup_compile_prefill",

--- a/tokenspeed-mla/README.md
+++ b/tokenspeed-mla/README.md
@@ -119,6 +119,10 @@ What it supports:
 - Causal and non-causal execution
 - Optional LSE return (`return_lse=True`)
 - PDL enable/disable (`enable_pdl`)
+- TokenSpeed serving currently keeps PDL disabled across the Q/K/V FP8-input
+  producers and prefill-FMHA pipeline because that cross-kernel dependency can
+  intermittently expose incomplete inputs on Blackwell. Standalone kernel
+  callers can still select the PDL variant explicitly.
 - Kernel compile cache keyed by static config (`dtype`, `d_qk`, `d_v`, causal, LSE, PDL, etc.)
 - Skip-correction is enabled in the wrapped FMHA path.
 - ex2-emulation (disabled by default on B200, and not supported on B300)


### PR DESCRIPTION
## Summary

Tests have found that when the prefill FMHA kernel enables PDL, NaN will appear. Temporarily disable it

