### PR TITLE
feat(K3): Support K3 On H200

### DIFF
--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -52,6 +52,7 @@ from tokenspeed.runtime.engine.scheduler_utils import (
     cache_event_key,
     cache_event_to_payload,
     cache_sync_debug_enabled,
+    log_gpu_memory_summary,
     make_config,
     pool_to_paged_cache_groups,
     pop_common_cache_event_payloads,
@@ -299,6 +300,19 @@ class EventLoop:
             draft_attn_backend=draft_attn_backend,
             draft_token_to_kv_pool=draft_token_to_kv_pool,
         )
+
+        # Per-rank GPU memory breakdown (weights by group, KV/graph/non-torch).
+        # rank0 only; best-effort, never fails startup.
+        if attn_tp_rank == 0:
+            log_gpu_memory_summary(
+                target.model,
+                gpu_id,
+                global_rank,
+                logger,
+                draft_model=draft.model if draft is not None else None,
+                kv_pool=token_to_kv_pool,
+                draft_kv_pool=draft_token_to_kv_pool,
+            )
 
         self.max_model_len = self.model_config.context_len
         self.max_single_request_tokens = self.model_config.context_len

--- a/python/tokenspeed/runtime/engine/scheduler_utils.py
+++ b/python/tokenspeed/runtime/engine/scheduler_utils.py
@@ -542,3 +542,172 @@ def block_tables_from_forward_op(
     for key, arr, offset in packable:
         out[key] = packed[offset : offset + arr.size].view(arr.shape[0], arr.shape[1])
     return out
+
+
+def _classify_param(name: str) -> str:
+    """Bucket a parameter/buffer name into a weight group for the memory
+    summary. Names follow the Kimi-K3 / DeepSeek module layout."""
+    if "self_attn" in name or ".attn." in name or "kv_a" in name or "q_a" in name:
+        return "attention_weights"
+    if (
+        "experts" in name
+        or "block_sparse_moe" in name
+        or "routed_expert" in name
+        or "gate" in name
+    ) and "shared_experts" not in name:
+        return "moe_weights"
+    if (
+        "mlp" in name
+        or "shared_experts" in name
+        or "down_proj" in name
+        or "up_proj" in name
+        or "gate_proj" in name
+    ):
+        return "dense_mlp_weights"
+    return "other_weights"
+
+
+def _kv_pool_bytes(*pools) -> int:
+    """Best-effort total KV-buffer bytes across the given pools, deduped.
+
+    A draft pool is a ``LayerMappedKVPool`` view of the target's merged pool
+    (draft KV lives in the target arena), and its ``get_kv_size_bytes`` forwards
+    to that same inner pool -- so counting target + draft naively would double
+    the KV. Dedupe by the underlying (unwrapped) pool identity first.
+
+    Return types differ (int, or a tuple like MSA's (kv, index); a hybrid pool
+    may nest several) -- sum any numeric leaves.
+    """
+    seen: set[int] = set()
+    total = 0
+    for pool in pools:
+        if pool is None:
+            continue
+        underlying = getattr(pool, "inner", pool)
+        if id(underlying) in seen:
+            continue
+        seen.add(id(underlying))
+        getter = getattr(pool, "get_kv_size_bytes", None)
+        if getter is None:
+            continue
+        try:
+            result = getter()
+        except Exception:
+            continue
+
+        def _sum(x):
+            if isinstance(x, (int, float)):
+                return int(x)
+            if isinstance(x, (tuple, list)):
+                return sum(_sum(e) for e in x)
+            return 0
+
+        total += _sum(result)
+    return total
+
+
+def log_gpu_memory_summary(
+    model,
+    gpu_id: int,
+    rank: int,
+    logger,
+    draft_model=None,
+    kv_pool=None,
+    draft_kv_pool=None,
+) -> None:
+    """Log a per-rank GPU memory breakdown after model + KV pool are built.
+
+    Weight groups are summed from the model's parameters and buffers (deduped
+    by storage pointer). A draft model (speculative decoding) is summed
+    separately into its own row. KV cache / CUDA graphs / non-torch (context,
+    NCCL, DeepEP) are derived from the torch allocator and driver views, so the
+    summary is backend-agnostic. Best-effort: never raises into startup.
+    """
+    try:
+        GB = 1024**3
+        groups = {
+            "attention_weights": 0,
+            "moe_weights": 0,
+            "dense_mlp_weights": 0,
+            "other_weights": 0,
+        }
+        seen: set[int] = set()
+
+        def _accumulate(name, tensor, sink):
+            if tensor is None or not tensor.is_cuda:
+                return
+            ptr = tensor.data_ptr()
+            if ptr in seen:
+                return
+            seen.add(ptr)
+            sink[_classify_param(name)] += tensor.numel() * tensor.element_size()
+
+        for n, p in model.named_parameters():
+            _accumulate(n, p, groups)
+        for n, b in model.named_buffers():
+            _accumulate(n, b, groups)
+
+        weights_total = sum(groups.values()) / GB
+
+        # Draft model (MTP / DSpark) weights, deduped against target: shared
+        # tensors (e.g. embed/lm_head lent from the target) are already in
+        # ``seen`` and won't be double-counted.
+        draft_total = 0
+        if draft_model is not None:
+            draft_sink = {k: 0 for k in groups}
+            for n, p in draft_model.named_parameters():
+                _accumulate(n, p, draft_sink)
+            for n, b in draft_model.named_buffers():
+                _accumulate(n, b, draft_sink)
+            draft_total = sum(draft_sink.values())
+        draft_gb = draft_total / GB
+
+        free_bytes, total_bytes = torch.cuda.mem_get_info(gpu_id)
+        allocated = torch.cuda.memory_allocated(gpu_id) / GB
+        reserved = torch.cuda.memory_reserved(gpu_id) / GB
+        device_total = total_bytes / GB
+        device_free = free_bytes / GB
+        device_used = device_total - device_free
+        # KV pool bytes read straight from the pool buffers. Draft KV lives in
+        # the target's merged arena (its pool is a view), so dedupe to count once.
+        kv_cache_gb = _kv_pool_bytes(kv_pool, draft_kv_pool) / GB
+        # Allocated beyond the classified target+draft weights and the KV pool is
+        # activations + captured-graph private pools; non-torch is
+        # context/NCCL/DeepEP.
+        activations_and_graphs = max(
+            0.0, allocated - weights_total - draft_gb - kv_cache_gb
+        )
+        non_torch = max(0.0, device_used - reserved)
+
+        rows = [
+            ("Attention weights", groups["attention_weights"] / GB),
+            ("MoE weights", groups["moe_weights"] / GB),
+            ("Dense/MLP weights", groups["dense_mlp_weights"] / GB),
+            ("Other weights (embed/head/norm)", groups["other_weights"] / GB),
+        ]
+        if draft_model is not None:
+            rows.append(("Draft model weights", draft_gb))
+        rows += [
+            ("KV cache", kv_cache_gb),
+            ("Activations + CUDA graphs", activations_and_graphs),
+            ("Torch allocated (total)", allocated),
+            ("Torch reserved (allocator pool)", reserved),
+            ("Non-torch (context/NCCL/DeepEP)", non_torch),
+            ("Device used (nvidia-smi view)", device_used),
+            ("Device free", device_free),
+            ("Device total", device_total),
+        ]
+        name_width = max(len(n) for n, _ in rows)
+        sep = "+" + "-" * (name_width + 2) + "+" + "-" * 12 + "+"
+        lines = [
+            f"GPU memory summary (rank {rank}, gpu {gpu_id}, GB):",
+            sep,
+            f"| {'Component'.ljust(name_width)} | {'GB'.rjust(10)} |",
+            sep,
+        ]
+        for n, v in rows:
+            lines.append(f"| {n.ljust(name_width)} | {v:10.2f} |")
+        lines.append(sep)
+        logger.info("\n".join(lines))
+    except Exception:
+        logger.warning("Failed to log GPU memory summary", exc_info=True)

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -660,10 +660,12 @@ class CudaGraphWrapper:
         """Per-group page tables consumed by the drafter.
 
         DFLASH block decode owns an independent draft page table and must stay
-        on that single-table path. Other draft heads share the target's page-id
-        space (EAGLE writes its own pool tensors at the same indices), so each
-        draft group consumes the target tables for the cache families declared
-        by its backend.
+        on that single-table path. MLA drafts likewise read only the staged
+        batch-ordered draft page table (single history group), so they opt out
+        via ``reads_staged_draft_page_table``. Other draft heads share the
+        target's page-id space (EAGLE writes its own pool tensors at the same
+        indices), so each draft group consumes the target tables for the cache
+        families declared by its backend.
 
         A draft pool that publishes its own specs (Inkling MTP: mixed full/SWA
         depths) names exactly the groups its layers carry. Older draft paths
@@ -674,6 +676,8 @@ class CudaGraphWrapper:
         ):
             return ()
         if getattr(self.draft_attn_backend, "draft_block_decode", False):
+            return ()
+        if getattr(self.draft_attn_backend, "reads_staged_draft_page_table", False):
             return ()
         families = frozenset(
             getattr(

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -344,25 +344,10 @@ class ModelExecutor:
                 f"logical page size {self._logical_page_size} is not a multiple "
                 f"of the draft kernel page size {self._draft_page_size}"
             )
-        draft_page_ratio = self._logical_page_size // self._draft_page_size
-        # The published table is already in kernel pages, so a draft backend
-        # that recorded a logical size (mark_cache_contract) would expand it a
-        # second time: ids land ratio× too deep in the pool and the draft
-        # attends garbage. Backends that consume kernel pages directly must
-        # not record (tokenspeed_mla), or the ratio must be 1 (flashmla @64).
-        backend_logical = getattr(draft_attn_backend, "_cache_logical_page_size", None)
-        if (
-            draft_page_ratio > 1
-            and backend_logical is not None
-            and int(backend_logical) != self._draft_page_size
-        ):
-            raise ValueError(
-                f"draft backend {type(draft_attn_backend).__name__} records "
-                f"logical page size {backend_logical} and would re-expand the "
-                f"draft page table that is already published in "
-                f"{self._draft_page_size}-token kernel pages "
-                f"(ratio {draft_page_ratio})"
-            )
+        # DraftPageStaging.publish expands the target full-history table into the
+        # draft backend's kernel pages once, and every draft backend reads that
+        # staged table as-is (identity). No backend re-expands with a logical
+        # size, so there is no double-expansion to guard against here.
 
         # physical_context_len already covers the spec-verify overshoot of a
         # finished request lingering one overlap step, including the lingering

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -252,7 +252,6 @@ class DeepseekV4AttentionBackend(AttentionBackend):
     def __init__(self, config) -> None:
         super().__init__(config)
         self.page_size = config.page_size
-        self.logical_page_size: int | None = None
         self.swa_storage_rows = int(
             getattr(config, "sliding_window_tokens", V4_KERNEL_BLOCK_ROWS * 2)
         )
@@ -861,8 +860,6 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         # compressed-KV full-history group's table (row i == batch position i).
         base_block_table = None
         if cache_metadata is not None:
-            logical_page_size = int(cache_metadata.block_size)
-            self.logical_page_size = logical_page_size
             scheduler_tables = dict(
                 cache_metadata.tables(active_forward_op=forward_batch)
             )
@@ -1946,8 +1943,9 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         max_tokens_per_req: int = 1,
         overlap_schedule_depth: int = 0,
     ):
-        if logical_page_size is not None:
-            self.logical_page_size = int(logical_page_size)
+        # logical_page_size accepted for signature uniformity with other
+        # backends; DSA derives its page geometry from cache metadata per step.
+        del logical_page_size
         self._decode_tile_metadata = {}
         self._cuda_graph_max_tokens_per_req = max(
             1,

--- a/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
@@ -153,6 +153,10 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
 
         # FlashMLA-specific
         self.draft_token_num = 0
+        # A block drafter (DFLASH/DSpark) drafts a whole block per pass; its
+        # captured decode graph seeds block-end lengths via
+        # ``fill_block_decode_seq_lens`` (see the drafter's is_capturing path).
+        self.draft_block_decode = bool(getattr(config, "draft_block_decode", False))
 
         if self.kv_cache_quant_method == "per_token_head":
             raise NotImplementedError(
@@ -230,9 +234,7 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
     ):
         cache_metadata = kwargs.pop("cache_metadata", None)
         forward_batch = kwargs.pop("forward_batch", None)
-        draft_group_table = self._resolve_draft_group_table(
-            kwargs.pop("block_tables", None)
-        )
+        kwargs.pop("block_tables", None)
         group_table = None
         logical_page_size = None
         if cache_metadata is not None:
@@ -240,19 +242,16 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
             group_table, logical_page_size = self._resolve_full_history_table(
                 cache_metadata, forward_batch, bs
             )
-        elif draft_group_table is not None:
-            group_table, logical_page_size = self._bind_draft_group_table(
-                draft_group_table, bs
-            )
         elif self._draft_reads_batch_pages(bs, forward_mode):
             # The drafter drives this draft backend directly and passes no cache
             # metadata; it hands over the batch-ordered draft page table (row i
-            # is batch position i), which the executor fills from the target's
-            # full-history table. Those ids are scheduler pages, expanded to
-            # kernel pages with the recorded logical size.
+            # is batch position i). DraftPageStaging.publish already expanded the
+            # target's full-history scheduler pages into this backend's kernel
+            # pages (ratio logical/kernel), so the ids are ALREADY in kernel-page
+            # units here. Read them as kernel pages (identity expand).
             self._cache_groups_bound = True
             group_table = page_table[:bs]
-            logical_page_size = self._cache_logical_page_size
+            logical_page_size = self.page_size
         elif self._cache_groups_bound and bs > 0 and not forward_mode.is_idle():
             raise RuntimeError(
                 "FlashMLABackend is bound to Paged cache but received no paged "
@@ -674,30 +673,13 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
                 ].zero_()
             return
 
-        draft_group_table = self._resolve_draft_group_table(kwargs.get("block_tables"))
-        if draft_group_table is not None:
-            # Already padded to the replay bs by the wrapper.
-            group_table, logical_page_size = self._bind_draft_group_table(
-                draft_group_table, bs
-            )
-            expanded = self._expand_group_page_table(
-                group_table,
-                batch_size=bs,
-                logical_page_size=logical_page_size,
-            )
-            self.cuda_graph_kv_indices[:bs, : expanded.shape[1]].copy_(expanded)
-            return
-
         if self._draft_reads_batch_pages(bs, forward_mode):
-            # Draft replay: the batch-ordered draft page table holds scheduler
-            # pages; expand to kernel pages the same way eager draft does.
-            table = page_table[:bs]
-            expanded = self._expand_group_page_table(
-                table,
-                batch_size=bs,
-                logical_page_size=self._cache_logical_page_size,
-            )
-            self.cuda_graph_kv_indices[:bs, : expanded.shape[1]].copy_(expanded)
+            # Draft replay: DraftPageStaging.publish already expanded the target
+            # full-history table into this backend's kernel pages, so the
+            # batch-ordered draft page table holds kernel-page ids. Copy them
+            # as-is (identity), matching the eager draft path.
+            block_table = page_table[:bs]
+            self.cuda_graph_kv_indices[:bs, : block_table.shape[1]].copy_(block_table)
             return
 
         # Idle/warmup replay before the backend binds: page_table is an empty
@@ -705,6 +687,21 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
         # above.
         block_table = page_table[:bs]
         self.cuda_graph_kv_indices[:bs, : block_table.shape[1]].copy_(block_table)
+
+    def fill_block_decode_seq_lens(self, bs: int, block_seq_lens: torch.Tensor) -> None:
+        """Publish block-end cache lengths inside a captured draft graph.
+
+        A block drafter runs its multi-token pass inside the captured graph and
+        writes the per-request block-end length here (one row per request; the
+        block's ``draft_query_width`` queries share it, non-causal). ``forward_decode``
+        repeats each row across the block's queries, so the graph keeps ``bs``
+        rows -- mirrors ``TRTLLMMLABackend.fill_block_decode_seq_lens``.
+        """
+        if not self.draft_block_decode:
+            raise RuntimeError("Block decode sequence lengths require DFLASH mode.")
+        self.cuda_graph_seq_lens_k[:bs].copy_(
+            block_seq_lens[:bs].clamp(self.spec_num_tokens, self.max_context_len)
+        )
 
     # ------------------------------------------------------------------
     # Forward
@@ -907,11 +904,26 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
         ), f"{layer.tp_q_head_num=} != {self.num_q_heads=}"
         reshape_q = q.view(bs, -1, self.num_q_heads, layer.head_dim)
 
+        block_table = metadata.block_table[num_extends : num_extends + bs]
+        cache_seqlens = metadata.seq_lens_k.to(torch.int32) + cache_seqlens_offset
+        # Draft block-decode: forward_decode flattened q to one kernel row per
+        # drafted block position (bs == bs_orig * draft_query_width), but the
+        # group table and seq_lens carry one entry per request. Repeat each
+        # request's row across its block positions so every block query attends
+        # the whole block (block-diffusion), mirroring tokenspeed_mla's
+        # _expand_block_decode_metadata; the FlashMLA kernel requires
+        # cache_seqlens to be shape (num_kernel_rows).
+        src_rows = block_table.shape[0]
+        if self.is_draft and 0 < src_rows < bs and bs % src_rows == 0:
+            width = bs // src_rows
+            block_table = block_table.repeat_interleave(width, dim=0)
+            cache_seqlens = cache_seqlens.repeat_interleave(width)
+
         return flash_mla_with_kvcache(
             q=reshape_q,
             k_cache=k_cache.view(-1, PAGE_SIZE, 1, self.kv_cache_dim),
-            block_table=metadata.block_table[num_extends : num_extends + bs],
-            cache_seqlens=metadata.seq_lens_k.to(torch.int32) + cache_seqlens_offset,
+            block_table=block_table,
+            cache_seqlens=cache_seqlens,
             head_dim_v=self.kv_lora_rank,
             tile_scheduler_metadata=metadata.flashmla_metadata,
             softmax_scale=layer.scaling,

--- a/python/tokenspeed/runtime/layers/attention/backends/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mla.py
@@ -108,8 +108,6 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
 
         self._cache_groups_bound = False
         self._cache_contract_bound = False
-        # Set by mark_cache_contract for a draft driven without cache metadata.
-        self._cache_logical_page_size: int | None = None
         self.max_context_len = config.context_len
         self.page_size = config.page_size
         self.max_num_pages = ceil_div(self.max_context_len, self.page_size)
@@ -646,7 +644,7 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
             return
         if (
             self._cache_groups_bound
-            and self._cache_logical_page_size is not None
+            and self._cache_contract_bound
             and page_table is not None
         ):
             # Draft replay receives the already-expanded batch table published

--- a/python/tokenspeed/runtime/layers/attention/backends/mla_cache_groups.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mla_cache_groups.py
@@ -46,9 +46,11 @@ class MlaCacheGroupMixin:
     # MLA backends consume only the history (full-attention) cache family.
     cache_consumer_families = frozenset({"history"})
 
-    # Scheduler page size recorded for validating the draft cache contract;
-    # None until mark_cache_contract records it. See _draft_reads_batch_pages.
-    _cache_logical_page_size: int | None = None
+    # A draft MLA backend always reads the batch-ordered draft page table that
+    # DraftPageStaging publishes (single history group, already in kernel
+    # pages), never the wrapper's per-group table dispatch. This flag tells the
+    # CUDA-graph wrapper to skip that dispatch for MLA drafts.
+    reads_staged_draft_page_table = True
 
     def mark_cache_contract(self, logical_page_size: int | None = None) -> None:
         """Flag this backend as an LCM cache-group contract sub-backend.
@@ -56,71 +58,27 @@ class MlaCacheGroupMixin:
         Called by the registry before graph-state allocation. Eager forwards
         bind the group tables automatically once cache metadata arrives; this
         flag lets CUDA-graph capture size its per-group write-location buffer up
-        front.
-
-        ``logical_page_size`` is the pool's scheduler page size. A target learns
-        it per step from ``cache_metadata``, but a draft is driven directly by
-        the drafter, which passes no metadata -- it hands over a batch-ordered
-        draft page table that ``ModelExecutor`` has already translated into the
-        draft backend's kernel-page units.
+        front. ``logical_page_size`` is accepted for call-site uniformity with
+        other backends but unused: every MLA draft reads the batch-ordered draft
+        page table published by ``DraftPageStaging`` (already in kernel pages),
+        so no logical size ever needs to be recorded here.
         """
+        del logical_page_size
         self._cache_contract_bound = True
-        if logical_page_size is not None:
-            self._cache_logical_page_size = int(logical_page_size)
-
-    def _resolve_draft_group_table(self, block_tables) -> torch.Tensor | None:
-        """Full-history table when the wrapper hands the draft its group tables.
-
-        The wrapper subsets the batch's per-group tables to this backend's
-        consumer families (history only for MLA), so exactly one table is
-        expected. Ids are scheduler pages in the contract's logical size
-        recorded by :meth:`mark_cache_contract`.
-        """
-        if not block_tables or not self.is_draft:
-            return None
-        if self._cache_logical_page_size is None:
-            raise RuntimeError(
-                "draft received group tables before mark_cache_contract "
-                "recorded the scheduler's logical page size"
-            )
-        if len(block_tables) != 1:
-            raise RuntimeError(
-                "MLA draft consumes exactly one history group table, got "
-                f"{sorted(block_tables)}"
-            )
-        return next(iter(block_tables.values()))
-
-    def _bind_draft_group_table(
-        self, draft_group_table: torch.Tensor, bs: int
-    ) -> tuple[torch.Tensor, int]:
-        """Adopt the wrapper-distributed draft history table for this step.
-
-        Rows are batch-ordered scheduler pages; the logical size to expand
-        with is the one recorded by :meth:`mark_cache_contract`.
-        """
-        self._cache_groups_bound = True
-        return draft_group_table[:bs], self._cache_logical_page_size
 
     def _draft_reads_batch_pages(self, bs: int, forward_mode) -> bool:
         """True when this draft reads the published draft page table directly.
 
-        A contract-bound draft with a recorded logical page size is driven by
-        the drafter (no cache_metadata); the executor publishes the target's
+        A contract-bound MLA draft is always driven this way: the drafter runs
+        without cache_metadata, and ``ModelExecutor`` publishes the target's
         full-history table into the batch-ordered draft page table (row i ==
         batch position i), expanding scheduler pages into draft kernel pages
-        exactly once while publishing it.
-
-        This path is NOT redundant with the wrapper's group-table
-        distribution (:meth:`_bind_draft_group_table`): the wrapper drives
-        MTP/Eagle metadata inits and hands over group tables, but a
-        block-drafting drafter (DFLASH) initializes its backend directly
-        mid-step with only the staged draft page table — this fallback is
-        that mode's delivery path.
+        exactly once at publish time. The backend then reads those ids as-is
+        (identity expand); it never needs the scheduler's logical page size.
         """
         return (
             self.is_draft
             and self._cache_contract_bound
-            and self._cache_logical_page_size is not None
             and bs > 0
             and not forward_mode.is_idle()
         )

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
@@ -176,17 +176,6 @@ class TRTLLMMLABackend(MlaCacheGroupMixin, AttentionBackend):
             blocks = triton.cdiv(blocks, constraint) * constraint
         return blocks
 
-    def mark_cache_contract(self, logical_page_size: int | None = None) -> None:
-        """Record the scheduler page size used by an LCM-backed draft pool."""
-        if logical_page_size is not None:
-            logical_page_size = int(logical_page_size)
-            if logical_page_size <= 0 or logical_page_size % self.page_size:
-                raise ValueError(
-                    f"logical page size {logical_page_size} is not a positive multiple "
-                    f"of the trtllm_mla kernel page size {self.page_size}"
-                )
-        super().mark_cache_contract(logical_page_size)
-
     def _create_block_kv_indices(
         self,
         batch_size: int,
@@ -230,9 +219,7 @@ class TRTLLMMLABackend(MlaCacheGroupMixin, AttentionBackend):
     ):
         cache_metadata = kwargs.pop("cache_metadata", None)
         forward_batch = kwargs.pop("forward_batch", None)
-        draft_group_table = self._resolve_draft_group_table(
-            kwargs.pop("block_tables", None)
-        )
+        kwargs.pop("block_tables", None)
         group_table = None
         logical_page_size = None
         if cache_metadata is not None:
@@ -240,14 +227,10 @@ class TRTLLMMLABackend(MlaCacheGroupMixin, AttentionBackend):
             group_table, logical_page_size = self._resolve_full_history_table(
                 cache_metadata, forward_batch, bs
             )
-        elif draft_group_table is not None:
-            group_table, logical_page_size = self._bind_draft_group_table(
-                draft_group_table, bs
-            )
         elif self._draft_reads_batch_pages(bs, forward_mode):
             # The drafter drives this backend directly and passes no cache
             # metadata; the batch-ordered draft page table (row i is batch
-            # position i) carries the scheduler pages.
+            # position i) carries kernel pages published by DraftPageStaging.
             self._cache_groups_bound = True
         if forward_mode.is_extend_or_mixed():
             self._init_prefill_metadata(
@@ -540,23 +523,19 @@ class TRTLLMMLABackend(MlaCacheGroupMixin, AttentionBackend):
             self.cuda_graph_seq_lens_buf[:bs].copy_(seq_lens[:bs])
 
         cache_metadata = kwargs.get("cache_metadata")
-        draft_group_table = self._resolve_draft_group_table(kwargs.get("block_tables"))
         group_table = None
         logical_page_size = None
         if self._cache_groups_bound and cache_metadata is not None:
             group_table, logical_page_size = self._resolve_full_history_table(
                 cache_metadata, kwargs.get("forward_batch"), 0
             )
-        elif draft_group_table is not None:
-            # Already padded to the replay bs by the wrapper.
-            group_table, logical_page_size = self._bind_draft_group_table(
-                draft_group_table, bs
-            )
         elif self._draft_reads_batch_pages(bs, forward_mode) and (
             page_table is not None
         ):
+            # DraftPageStaging.publish already expanded into kernel pages, so
+            # the staged table is read with an identity expand (logical==kernel).
             group_table = page_table[:bs]
-            logical_page_size = self._cache_logical_page_size
+            logical_page_size = self.page_size
         if group_table is not None:
             real_bs = min(int(group_table.shape[0]), bs)
             if real_bs > 0 and not self._block_table_aliased:

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
@@ -441,7 +441,7 @@ class LayerMappedKVPool:
     # so the global id must be mapped to its pool slot first (mirrors
     # ``set_kv_buffer``). Reached via the DeepseekV3-style MLA chunked-prefill
     # path (Kimi-K3).
-    def set_mla_kv_buffer(self, layer, loc, cache_k_nope, cache_k_rope):
+    def set_mla_kv_buffer(self, layer, loc, cache_k_nope, cache_k_rope, sanitize=True):
         # Prefill breakable-graph padding contract: the dummy-batch capture (and
         # bucket-padding rows) whose ``out_cache_loc`` is the reserved
         # ``dummy_kv_slot`` can carry NaN into this fp8 KV write. The paged MLA
@@ -459,7 +459,7 @@ class LayerMappedKVPool:
                 loc,
                 cache_k_nope,
                 cache_k_rope,
-                sanitize=True,
+                sanitize=sanitize,
             )
 
     def get_mla_kv_buffer(self, layer, loc, dst_dtype=None):

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/kimi_k3.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/kimi_k3.py
@@ -188,8 +188,16 @@ def build_kimi_k3_cache_fields(
 ) -> tuple[CacheFieldSpec, ...]:
     """Build target fields from the Kimi-K3 model configuration."""
     tp_size = _require_positive_int("tp_size", tp_size)
-    if mla_cache_dtype != torch.float8_e4m3fn:
-        raise ValueError("Kimi-K3 cache requires mla_cache_dtype=torch.float8_e4m3fn")
+    # fp8_e4m3 is the memory-lean default (matches the Blackwell tokenspeed_mla
+    # kernels). bf16 is the Hopper path: FlashMLA has no SM90 dense-fp8 MLA
+    # kernel, so on SM90 the MLA layers run bf16 (flashinfer ragged prefill +
+    # bf16 FlashMLA decode), mirroring how vLLM/sglang serve K3 on Hopper.
+    if mla_cache_dtype not in (torch.float8_e4m3fn, torch.bfloat16):
+        raise ValueError(
+            "Kimi-K3 cache requires mla_cache_dtype in "
+            "{torch.float8_e4m3fn, torch.bfloat16}, got "
+            f"{mla_cache_dtype}"
+        )
     if mla_quant_method == "per_token_head":
         raise ValueError("Kimi-K3 cache does not support per_token_head MLA cache")
     if getattr(text_config, "mla_use_nope", None) is not True:
@@ -268,11 +276,14 @@ def solve_kimi_k3_cache_layout(
         f"{LINEAR_ATTENTION}_1": linear_packing,
         f"{LINEAR_ATTENTION}_2": linear_packing,
     }
+
+    max_padding_fraction = float("inf") if num_draft_layers else 0.25
     layout = solve_cache_layout(
         fields,
         logical_block_tokens=_KIMI_K3_LOGICAL_BLOCK_TOKENS,
         cache_blocks_per_lcm_block=packing,
         alignment=256,
+        max_padding_fraction=max_padding_fraction,
     )
     if dict(layout.group_packing) != packing:
         raise ValueError(

--- a/python/tokenspeed/runtime/layers/moe/latent.py
+++ b/python/tokenspeed/runtime/layers/moe/latent.py
@@ -59,6 +59,19 @@ InputProjector = Callable[
 _SUPPORTED_EP_SIZES = {1, 2, 4, 8}
 
 
+def _marlin_moe_available() -> bool:
+    """Whether the Marlin W4A16 MXFP4 MoE path can run here (NVIDIA SM90+)."""
+    from tokenspeed_kernel.platform import ArchVersion, current_platform
+    from tokenspeed_kernel.thirdparty.cuda.marlin_moe import is_marlin_moe_available
+
+    platform = current_platform()
+    return (
+        platform.is_nvidia
+        and platform.arch_version >= ArchVersion(9, 0)
+        and is_marlin_moe_available()
+    )
+
+
 def kimi3_join_reduce_moe(
     routed_partial: torch.Tensor,
     shared_partial: torch.Tensor,
@@ -133,13 +146,14 @@ class Kimi3MoEExecutionPlan:
     use_trtllm: bool
     overlap_shared_experts: bool
     joint_moe_reduce: bool
+    use_marlin: bool = False
     fused_moe_ar: bool = False
     lane_latent_norm_ar: bool = False
     comm_fusion_max_num_tokens: int = 0
 
     @property
     def use_precomputed_topk(self) -> bool:
-        return self.use_native or self.use_trtllm
+        return self.use_native or self.use_trtllm or self.use_marlin
 
     @classmethod
     def build(
@@ -153,12 +167,24 @@ class Kimi3MoEExecutionPlan:
         """Select orchestration without exposing platform policy to the model."""
 
         use_native = native_latent_moe_available()
-        use_trtllm = not use_native and (
-            moe_backend.is_auto() or moe_backend.is_flashinfer_trtllm()
+        # Hopper (SM90) has no native FP4 tensor cores and no flashinfer SiTU
+        # cubin, so K3's MXFP4 SiTU MoE runs weight-only through the Marlin
+        # W4A16 GEMM with a fused Triton SiTU epilogue. AUTO picks it whenever
+        # neither the AMD-native nor the (Blackwell) TRT-LLM path is available;
+        # it can also be forced with ``--moe-backend marlin``.
+        use_marlin = not use_native and (
+            moe_backend.is_marlin()
+            or (moe_backend.is_auto() and _marlin_moe_available())
+        )
+        use_trtllm = (
+            not use_native
+            and not use_marlin
+            and (moe_backend.is_auto() or moe_backend.is_flashinfer_trtllm())
         )
         return cls(
             use_native=use_native,
             use_trtllm=use_trtllm,
+            use_marlin=use_marlin,
             overlap_shared_experts=(
                 use_native
                 and enforce_eager

--- a/python/tokenspeed/runtime/layers/moe/utils.py
+++ b/python/tokenspeed/runtime/layers/moe/utils.py
@@ -73,6 +73,7 @@ class MoeBackend(Enum):
     AUTO = "auto"
     TRITON = "triton"
     GLUON = "gluon"
+    MARLIN = "marlin"
     FLASHINFER_TRTLLM = "flashinfer_trtllm"
     FLASHINFER_CUTLASS = "flashinfer_cutlass"
     FLASHINFER_CUTEDSL = "flashinfer_cutedsl"
@@ -89,6 +90,9 @@ class MoeBackend(Enum):
 
     def is_gluon(self):
         return self == MoeBackend.GLUON
+
+    def is_marlin(self):
+        return self == MoeBackend.MARLIN
 
     def is_flashinfer_trtllm(self):
         return self == MoeBackend.FLASHINFER_TRTLLM

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -965,12 +965,14 @@ class KimiLinearMoE(nn.Module):
         # AUTO intentionally requests the flashinfer-backed SiTU plan when it was
         # registered at import time; AUTO cannot override MoELayer per model.
         self.use_trtllm_situ_moe = self.execution_plan.use_trtllm
-        if not self.execution_plan.use_native:
+        self.use_marlin_situ_moe = self.execution_plan.use_marlin
+        if not self.execution_plan.use_native and not self.use_marlin_situ_moe:
             if not self.use_trtllm_situ_moe:
                 raise RuntimeError(
-                    "Kimi-K3 MXFP4 SiTU MoE requires the native backend or the "
-                    "FlashInfer TRT-LLM backend; no portable SiTU Triton fallback "
-                    f"exists (selected MoE backend: {moe_backend.value!r})."
+                    "Kimi-K3 MXFP4 SiTU MoE requires the native, FlashInfer "
+                    "TRT-LLM, or Marlin (Hopper W4A16) backend; no portable SiTU "
+                    f"Triton fallback exists (selected MoE backend: "
+                    f"{moe_backend.value!r})."
                 )
             # Fail here with the actual reason instead of letting MoELayer's
             # kernel selection miss the (never-registered) SiTU kernel.
@@ -989,6 +991,10 @@ class KimiLinearMoE(nn.Module):
             load_packaged_flashinfer_tuning_cache(
                 "kimi-k3", mapping.moe.ep_size, mapping.moe.tp_size
             )
+        if not self.execution_plan.use_native:
+            # Both the TRT-LLM and Marlin SiTU paths currently require a
+            # replicated-token all-reduce topology (attn TP == MoE TP*EP);
+            # Attn-DP/MoE-EP RSAG is not wired for either.
             if mapping.moe.has_tp_ep and mapping.attn.tp_size != mapping.moe.tp_ep_size:
                 raise ValueError(
                     "Kimi-K3's SiTU MoE currently requires a "
@@ -1041,11 +1047,11 @@ class KimiLinearMoE(nn.Module):
                 "activation_situ_linear_beta": situ_linear_beta,
             },
             routing_mode="precomputed_topk",
-            # Native gfx950 runs A16W4; FlashInfer's SiTU cubins require
-            # MXFP4 weights with MXFP8 activations.
+            # Native gfx950 and Hopper Marlin both run A16W4 (bf16 activations);
+            # FlashInfer's SiTU cubins require MXFP4 weights with MXFP8 acts.
             internal_activation_dtype_override=(
                 "input"
-                if self.execution_plan.use_native
+                if self.execution_plan.use_native or self.execution_plan.use_marlin
                 else "fp8" if self.execution_plan.use_trtllm else None
             ),
         )
@@ -1205,11 +1211,11 @@ class KimiLinearMoE(nn.Module):
         max_num_tokens_per_gpu: int,
         skip_reduce: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Run flashinfer's fused TRT-LLM SiTU MoE."""
-        if not self.use_trtllm_situ_moe:
+        """Run the precomputed-TopK SiTU MoE (TRT-LLM cubin or Hopper Marlin)."""
+        if not self.use_trtllm_situ_moe and not self.use_marlin_situ_moe:
             raise RuntimeError(
-                "Kimi-K3 has no portable SiTU Triton fallback; use the native "
-                "or FlashInfer TRT-LLM SiTU MoE path."
+                "Kimi-K3 has no portable SiTU Triton fallback; use the native, "
+                "FlashInfer TRT-LLM, or Marlin SiTU MoE path."
             )
         out = self.experts(
             hidden_states=routed_in,

--- a/python/tokenspeed/runtime/models/kimi_k3_dspark.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_dspark.py
@@ -51,6 +51,7 @@ from tokenspeed.runtime.distributed.comm_ops import all_reduce
 from tokenspeed.runtime.distributed.mapping import Mapping
 from tokenspeed.runtime.execution.context import ForwardContext
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import FULL_ATTENTION
 from tokenspeed.runtime.layers.layernorm import RMSNorm
 from tokenspeed.runtime.layers.linear import ReplicatedLinear
 from tokenspeed.runtime.layers.logits_processor import LogitsProcessorOutput
@@ -199,6 +200,14 @@ class K3DSparkDecoderLayer(nn.Module):
             layer_id=layer_id,
             prefix=add_prefix("self_attn", prefix),
         )
+        # The draft's MLA layers join the target's full_attention paged-cache
+        # group (K3 publishes 4 groups: full_attention + 3 KDA linear). The
+        # inherited attn_mqa/attn_mha are built without a group_id; tag them so
+        # validate_paged_cache_group_ids binds them to the full_attention table
+        # instead of failing on an empty group_id. Mirrors the target
+        # (kimi_k3.py MLA layer construction).
+        self.self_attn.attn_mqa.group_id = FULL_ATTENTION
+        self.self_attn.attn_mha.group_id = FULL_ATTENTION
         self.layer_id = layer_id
         self.post_attention_layernorm = RMSNorm(hidden_size, eps=eps)
         self.mlp = DFlashMLP(

--- a/test/runtime/test_cudagraph_per_group.py
+++ b/test/runtime/test_cudagraph_per_group.py
@@ -144,11 +144,18 @@ class DraftCacheGroupIdsTest(_TorchCase):
 
         self.group_ids = CudaGraphWrapper._draft_cache_group_ids
 
-    def _wrapper(self, *, draft_block_decode, families=("history",)):
+    def _wrapper(
+        self,
+        *,
+        draft_block_decode,
+        families=("history",),
+        reads_staged_draft_page_table=False,
+    ):
         return SimpleNamespace(
             draft_attn_backend=SimpleNamespace(
                 uses_cache_groups=True,
                 draft_block_decode=draft_block_decode,
+                reads_staged_draft_page_table=reads_staged_draft_page_table,
                 cache_consumer_families=frozenset(families),
             ),
             draft_token_to_kv_pool=SimpleNamespace(
@@ -162,6 +169,19 @@ class DraftCacheGroupIdsTest(_TorchCase):
     def test_dflash_does_not_capture_target_group_tables(self):
         self.assertEqual(
             self.group_ids(self._wrapper(draft_block_decode=True)),
+            (),
+        )
+
+    def test_mla_draft_reads_staged_page_table(self):
+        # MLA drafts consume only the batch-ordered staged draft page table, so
+        # the wrapper must not dispatch per-group tables to them.
+        self.assertEqual(
+            self.group_ids(
+                self._wrapper(
+                    draft_block_decode=False,
+                    reads_staged_draft_page_table=True,
+                )
+            ),
             (),
         )
 

--- a/test/runtime/test_kimi_k3_cudagraph.py
+++ b/test/runtime/test_kimi_k3_cudagraph.py
@@ -138,7 +138,6 @@ def _bare_amd_mla_backend(
     backend.draft_block_decode = False
     backend._cache_groups_bound = False
     backend._cache_contract_bound = False
-    backend._cache_logical_page_size = None
     backend.decode_cuda_graph_metadata = {}
     backend.cuda_graph_page_table = None
     backend.cuda_graph_seq_lens = None

--- a/test/runtime/test_mla_block_decode.py
+++ b/test/runtime/test_mla_block_decode.py
@@ -197,7 +197,6 @@ def test_contract_draft_replay_does_not_expand_published_pages_twice() -> None:
     backend = _backend(spec_num_tokens=4, max_num_pages=4)
     backend._cache_contract_bound = True
     backend._cache_groups_bound = True
-    backend._cache_logical_page_size = 128
     backend.page_size = 64
     backend.init_cuda_graph_state(max_bs=1)
     backend._capture_block_decode_graph(bs=1, seq_lens=torch.tensor([10]))
@@ -219,7 +218,6 @@ def test_contract_draft_eager_does_not_expand_published_pages_twice() -> None:
     backend = _backend(spec_num_tokens=4, max_num_pages=4)
     backend._cache_contract_bound = True
     backend._cache_groups_bound = True
-    backend._cache_logical_page_size = 128
     backend.page_size = 64
 
     published = torch.tensor([[6, 7, 0, 1, 99]], dtype=torch.int32)

--- a/test/runtime/test_trtllm_mla_block_decode.py
+++ b/test/runtime/test_trtllm_mla_block_decode.py
@@ -21,7 +21,6 @@ def _backend(*, draft_block_decode: bool) -> TRTLLMMLABackend:
     backend.spec_num_tokens = 4
     backend.max_context_len = 64
     backend.page_size = 2
-    backend._cache_logical_page_size = backend.page_size
     backend.kv_lora_rank = 2
     backend.qk_nope_head_dim = 2
     backend.qk_rope_head_dim = 2
@@ -62,7 +61,7 @@ def test_eager_draft_page_table_is_not_expanded_twice() -> None:
 
 def test_graph_replay_draft_page_table_is_not_expanded_twice() -> None:
     backend = _backend(draft_block_decode=True)
-    backend.mark_cache_contract(logical_page_size=4)
+    backend.mark_cache_contract()
     backend.init_cuda_graph_state(max_bs=2)
     backend.init_forward_metadata_capture_cuda_graph(
         bs=2,
@@ -74,10 +73,12 @@ def test_graph_replay_draft_page_table_is_not_expanded_twice() -> None:
         [[6, 7, 10, 11], [14, 15, 18, 19]], dtype=torch.int32
     )
 
+    # DraftPageStaging publishes kernel pages; the replay must copy them as-is
+    # (identity), never re-expand. seq_lens fit the 4-page (page_size=2) table.
     backend.init_forward_metadata_replay_cuda_graph(
         bs=2,
         req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
-        seq_lens=torch.tensor([12, 12], dtype=torch.int32),
+        seq_lens=torch.tensor([8, 8], dtype=torch.int32),
         forward_mode=ForwardMode.DECODE,
         page_table=kernel_page_table,
     )
@@ -85,13 +86,6 @@ def test_graph_replay_draft_page_table_is_not_expanded_twice() -> None:
     block_table = backend.forward_decode_metadata.block_kv_indices
     assert block_table[:, :4].tolist() == kernel_page_table.tolist()
     assert block_table[:, 4:].eq(0).all()
-
-
-def test_cache_contract_rejects_incompatible_page_size() -> None:
-    backend = _backend(draft_block_decode=True)
-
-    with pytest.raises(ValueError, match="positive multiple"):
-        backend.mark_cache_contract(logical_page_size=3)
 
 
 def _layer() -> SimpleNamespace:

--- a/tokenspeed-kernel/python/setup.py
+++ b/tokenspeed-kernel/python/setup.py
@@ -362,6 +362,22 @@ KERNEL_GROUPS = [
         [],
     ),
     (
+        "marlin_moe",
+        [
+            CUDA_CSRC_DIR / "marlin_moe" / "marlin_moe_binding.cu",
+        ],
+        [],
+        # -I marlin_moe/include first: the vendored Marlin GEMM only needs a
+        # tiny scalar_type.hpp + dtype-alias prelude (a trimmed drop-in), not
+        # the full sgl_kernel stack. -std=c++20 for scalar_type's constexpr;
+        # nvcc keeps the last -std, overriding the global c++17.
+        [
+            f"-I{CUDA_CSRC_DIR / 'marlin_moe' / 'include'}",
+            "-std=c++20",
+            "-Wno-deprecated-gpu-targets",
+        ],
+    ),
+    (
         "routing",
         [
             CUDA_CSRC_DIR / "routing_flash.cu",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/__init__.py
@@ -24,6 +24,7 @@ from typing import Any
 import tokenspeed_kernel.ops.moe.deep_gemm  # noqa: F401
 import tokenspeed_kernel.ops.moe.flashinfer  # noqa: F401
 import tokenspeed_kernel.ops.moe.gluon  # noqa: F401
+import tokenspeed_kernel.ops.moe.marlin  # noqa: F401
 import tokenspeed_kernel.ops.moe.triton  # noqa: F401
 import torch
 from tokenspeed_kernel.registry import KernelRegistry

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/marlin/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/marlin/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from tokenspeed_kernel.ops.moe.marlin import mxfp4  # noqa: F401

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/marlin/mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/marlin/mxfp4.py
@@ -1,0 +1,297 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Marlin W4A16 MXFP4 MoE apply for SM90 (Hopper).
+
+Weight-only 4-bit experts: MXFP4 (E2M1 packed, E8M0 group-32 scales) weights
+are dequantized inside the Marlin grouped GEMM; activations stay bf16, so no
+FP4 tensor cores are required. This is the Hopper path for Kimi-K3, whose
+routed experts use the SiTU gated activation (applied as a fused Triton
+epilogue between the two GEMMs). Routing is precomputed upstream (the K3 gate
+the fused kernels cannot reproduce).
+
+The kernel and its weight repack use the vendored Marlin MoE; the grouped GEMM
+lives in ``thirdparty/cuda/csrc/marlin_moe`` and is pre-compiled.
+"""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel.ops.activation.triton import situ_and_mul
+from tokenspeed_kernel.platform import ArchVersion, CapabilityRequirement
+from tokenspeed_kernel.registry import Priority, register_kernel
+from tokenspeed_kernel.signature import format_signatures
+from tokenspeed_kernel.thirdparty.cuda.marlin import gptq_marlin_repack
+from tokenspeed_kernel.thirdparty.cuda.marlin_moe import (
+    marlin_make_workspace,
+    marlin_permute_scales,
+    moe_align_block_size,
+    moe_wna16_marlin_gemm,
+    mxfp4_marlin_process_scales,
+)
+
+MXFP4_BLOCK = 32
+
+
+def _block_size_m(num_tokens: int, top_k: int, num_experts: int) -> int:
+    """Pick the token block granularity Marlin schedules over.
+
+    Grow the block until each expert holds under ~0.9 blocks of routed tokens,
+    keeping small batches on tight blocks and large batches on wide ones.
+    """
+    block = 8
+    for candidate in (8, 16, 32, 48, 64):
+        block = candidate
+        if num_tokens * top_k / num_experts / candidate < 0.9:
+            break
+    return block
+
+
+def marlin_mxfp4_moe_weights(plan: dict, w: torch.nn.Module) -> None:
+    """Repack loader-format MXFP4 experts into the Marlin layout, once.
+
+    Input (from the mxfp4 weight loader): ``w13_weight``/``w2_weight`` packed
+    E2M1 as uint8 ``[E, N, K//2]`` and ``w13_weight_scale``/``w2_weight_scale``
+    raw E8M0 as uint8 ``[E, N, K//32]``. Output: Marlin-repacked int32 weights
+    and permuted float8_e8m0fnu scales, written back onto the module. K3's
+    shapes are already aligned (hidden 7168%256, ispp 3072%128), so no padding.
+    """
+    names = ("w13_weight", "w13_weight_scale", "w2_weight", "w2_weight_scale")
+    if any(not hasattr(w, name) for name in names):
+        raise ValueError("MXFP4 MoE weights are incomplete for Marlin repack")
+    if getattr(w, "_marlin_repacked", False):
+        return
+
+    activation = plan.get("activation") or getattr(w, "activation", "silu")
+    if activation not in {"silu", "situ", "swiglu"}:
+        raise ValueError(f"Marlin MXFP4 MoE does not support activation {activation!r}")
+
+    w13 = w.w13_weight.data
+    w2 = w.w2_weight.data
+    w13_scale = w.w13_weight_scale.data
+    w2_scale = w.w2_weight_scale.data
+    num_experts = w13.shape[0]
+    # w13 is [E, 2*ispp, hidden//2] packed; w2 is [E, hidden, ispp//2] packed.
+    two_ispp = w13.shape[1]
+    hidden = w13.shape[2] * 2
+    ispp = w2.shape[2] * 2
+    if two_ispp != 2 * ispp:
+        raise ValueError(
+            f"w13/w2 intermediate mismatch: w13 {two_ispp} vs 2*ispp {2 * ispp}"
+        )
+    if hidden % 256 != 0 or ispp % MXFP4_BLOCK != 0:
+        raise ValueError(
+            f"Marlin MXFP4 needs hidden%256==0 and ispp%32==0, got "
+            f"hidden={hidden}, ispp={ispp}"
+        )
+
+    device = w13.device
+    perm = torch.empty(0, dtype=torch.int, device=device)
+
+    def _repack(weight: torch.Tensor, size_n: int, size_k: int) -> torch.Tensor:
+        # gptq_marlin_repack wants int32 [size_k/pack, size_n]; the packed
+        # uint8 [E, size_n, size_k/2] view transposes to that per expert.
+        out = []
+        for e in range(num_experts):
+            qw = weight[e].view(torch.int32).T.contiguous()
+            out.append(
+                gptq_marlin_repack(qw, perm, size_k=size_k, size_n=size_n, num_bits=4)
+            )
+        return torch.stack(out)
+
+    def _permute(scale: torch.Tensor, size_n: int, size_k: int) -> torch.Tensor:
+        out = []
+        for e in range(num_experts):
+            s = scale[e].T.contiguous()
+            permuted = marlin_permute_scales(
+                s, size_k=size_k, size_n=size_n, group_size=MXFP4_BLOCK
+            )
+            out.append(mxfp4_marlin_process_scales(permuted))
+        return torch.stack(out)
+
+    w13_marlin = _repack(w13, size_n=2 * ispp, size_k=hidden)
+    w2_marlin = _repack(w2, size_n=hidden, size_k=ispp)
+    w13_scale_marlin = _permute(w13_scale, size_n=2 * ispp, size_k=hidden)
+    w2_scale_marlin = _permute(w2_scale, size_n=hidden, size_k=ispp)
+
+    w.w13_weight = torch.nn.Parameter(w13_marlin, requires_grad=False)
+    w.w2_weight = torch.nn.Parameter(w2_marlin, requires_grad=False)
+    w.w13_weight_scale = torch.nn.Parameter(w13_scale_marlin, requires_grad=False)
+    w.w2_weight_scale = torch.nn.Parameter(w2_scale_marlin, requires_grad=False)
+    w._marlin_hidden_size = hidden
+    w._marlin_ispp = ispp
+    w._marlin_repacked = True
+
+
+@register_kernel(
+    "moe",
+    "apply",
+    name="marlin_mxfp4_precomputed_moe_apply",
+    solution="marlin",
+    weight_preprocessor=marlin_mxfp4_moe_weights,
+    capability=CapabilityRequirement(
+        vendors=frozenset({"nvidia"}),
+        min_arch_version=ArchVersion(9, 0),
+    ),
+    signatures=format_signatures("x", "dense", {torch.bfloat16}),
+    traits={
+        "weight_dtype": frozenset({"mxfp4"}),
+        "activation": frozenset({"silu", "situ", "swiglu"}),
+        "routing_mode": frozenset({"precomputed_topk"}),
+        "supports_deferred_finalize": frozenset({False}),
+        "supports_ep": frozenset({True}),
+        "supports_all_to_all_ep": frozenset({False}),
+        "ispp_alignment": frozenset({MXFP4_BLOCK}),
+        "internal_activation_dtype": frozenset({"input"}),
+        "supports_bias": frozenset({False}),
+    },
+    priority=Priority.PORTABLE,
+)
+def marlin_mxfp4_precomputed_moe_apply(
+    plan: dict,
+    x: torch.Tensor,
+    w: torch.nn.Module,
+    router_logits: torch.Tensor,
+    topk_weights: torch.Tensor | None = None,
+    topk_ids: torch.Tensor | None = None,
+    num_tokens_global: int | None = None,
+    max_num_tokens_per_gpu: int | None = None,
+    do_finalize: bool = True,
+    enable_pdl: bool = False,
+) -> torch.Tensor:
+    """Apply a Marlin W4A16 MXFP4 MoE with precomputed routing.
+
+    Args:
+        plan: MoE plan; ``activation`` selects the GEMM1 epilogue.
+        x: bf16 hidden states ``[tokens, hidden]``.
+        w: Module holding Marlin-repacked ``w13_weight``/``w2_weight`` (int32)
+            and permuted ``w13_weight_scale``/``w2_weight_scale``
+            (float8_e8m0fnu), plus ``num_local_experts``/``ep_rank`` for EP.
+        router_logits: Unused; routing is precomputed.
+        topk_weights: Route weights ``[tokens, top_k]``.
+        topk_ids: Global expert ids ``[tokens, top_k]``. In EP they are remapped
+            to local ids; non-local ids become -1 and contribute zero.
+        num_tokens_global: Unused; distributed EP dispatch is not owned here.
+        max_num_tokens_per_gpu: Unused capacity hint.
+        do_finalize: Must be true (no deferred finalize).
+        enable_pdl: Unused launch hint.
+
+    Returns:
+        Finalized hidden states ``[tokens, hidden]`` in the dtype of ``x``.
+    """
+    del router_logits, num_tokens_global, max_num_tokens_per_gpu, enable_pdl
+    if not do_finalize:
+        raise ValueError("Marlin MXFP4 MoE cannot defer finalization")
+    if topk_weights is None or topk_ids is None:
+        raise ValueError("Marlin MXFP4 MoE requires precomputed top-k")
+    if x.dtype != torch.bfloat16:
+        raise TypeError(f"Marlin MXFP4 MoE requires bf16 activations, got {x.dtype}")
+
+    activation = plan.get("activation") or getattr(w, "activation", "silu")
+    hidden = int(getattr(w, "_marlin_hidden_size", x.shape[1]))
+    ispp = int(getattr(w, "_marlin_ispp", w.w2_weight.shape[1] * 16))
+    num_local_experts = int(getattr(w, "num_local_experts", w.w13_weight.shape[0]))
+    ep_size = int(getattr(w, "ep_size", 1))
+    ep_rank = int(getattr(w, "ep_rank", 0))
+    global_num_experts = num_local_experts * ep_size
+
+    topk_ids = topk_ids.to(torch.int32)
+    topk_weights = topk_weights.to(torch.float32)
+    is_ep = ep_size > 1
+    if is_ep:
+        # Global -> local id remap: [expert_start, +num_local) -> [0, num_local),
+        # everything else -> -1 (the align kernel parks these in the extra lane
+        # and the EP GEMM skips those blocks).
+        expert_start = ep_rank * num_local_experts
+        mapping = torch.full(
+            (global_num_experts,), -1, dtype=torch.int32, device=topk_ids.device
+        )
+        mapping[expert_start : expert_start + num_local_experts] = torch.arange(
+            num_local_experts, dtype=torch.int32, device=topk_ids.device
+        )
+        local_topk_ids = mapping[topk_ids.long()]
+        align_num_experts = num_local_experts
+    else:
+        local_topk_ids = topk_ids
+        align_num_experts = num_local_experts
+
+    num_tokens, top_k = topk_ids.shape
+    block_m = _block_size_m(num_tokens, top_k, align_num_experts)
+    sorted_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
+        local_topk_ids, block_m, align_num_experts
+    )
+
+    workspace = marlin_make_workspace(x.device)
+
+    gemm1_n = 2 * ispp
+    intermediate1 = moe_wna16_marlin_gemm(
+        x,
+        None,
+        w.w13_weight,
+        w.w13_weight_scale,
+        workspace,
+        sorted_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        topk_weights,
+        moe_block_size=block_m,
+        top_k=top_k,
+        mul_topk_weights=False,
+        is_ep=is_ep,
+        size_m=num_tokens,
+        size_n=gemm1_n,
+        size_k=hidden,
+    ).view(-1, gemm1_n)
+
+    beta = float(getattr(w, "activation_situ_beta", 1.0))
+    linear_beta = getattr(w, "activation_situ_linear_beta", None)
+    if activation == "situ":
+        intermediate2 = situ_and_mul(
+            intermediate1,
+            beta=beta,
+            linear_beta=None if linear_beta is None else float(linear_beta),
+        )
+    else:
+        from tokenspeed_kernel.ops.activation.triton import silu_and_mul
+
+        intermediate2 = silu_and_mul(intermediate1)
+
+    # GEMM2: fold the route weights in (mul_topk_weights) so finalize is a
+    # plain sum over top_k. EP-masked routes wrote nothing, so zero-init c.
+    intermediate3 = moe_wna16_marlin_gemm(
+        intermediate2,
+        torch.zeros(num_tokens * top_k, hidden, dtype=x.dtype, device=x.device),
+        w.w2_weight,
+        w.w2_weight_scale,
+        workspace,
+        sorted_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        topk_weights,
+        moe_block_size=block_m,
+        top_k=1,
+        mul_topk_weights=True,
+        is_ep=is_ep,
+        size_m=num_tokens * top_k,
+        size_n=hidden,
+        size_k=ispp,
+    ).view(num_tokens, top_k, hidden)
+
+    return intermediate3.sum(dim=1)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/__init__.py
@@ -33,6 +33,12 @@ from tokenspeed_kernel.thirdparty.cuda.fused_topk_topp import (
     prepare_for_device as fused_topk_topp_prepare,
 )
 from tokenspeed_kernel.thirdparty.cuda.marlin import gptq_marlin_repack
+from tokenspeed_kernel.thirdparty.cuda.marlin_moe import (
+    is_marlin_moe_available,
+    marlin_make_workspace,
+    moe_align_block_size,
+    moe_wna16_marlin_gemm,
+)
 from tokenspeed_kernel.thirdparty.cuda.moe import moe_finalize_fuse_shared
 from tokenspeed_kernel.thirdparty.cuda.rmsnorm import rmsnorm_fused_parallel
 from tokenspeed_kernel.thirdparty.cuda.rope import apply_rope_with_cos_sin_cache_inplace
@@ -55,7 +61,11 @@ __all__ = [
     "fused_topk_topp_workspace_size",
     "gptq_marlin_repack",
     "hash_softplus_sqrt_topk_flash",
+    "is_marlin_moe_available",
+    "marlin_make_workspace",
+    "moe_align_block_size",
     "moe_finalize_fuse_shared",
+    "moe_wna16_marlin_gemm",
     "rmsnorm_fused_parallel",
     "routing_flash",
     "silu_and_mul_fuse_block_quant",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin/dequant.h
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin/dequant.h
@@ -1,0 +1,504 @@
+/*
+Fast Dequantization (Converting INT4/INT8/FP4/FP8 to FP16/BF16)
+
+The process of fast dequantization can be summarized as a combination
+of bitwise operations and floating-point computations:
+
+weight =>(bit_op / bitwise operations)=>
+f16_value =>(flop / floating-point computation)=>
+dequantized_weight
+
+Since the dequantized weights typically require subtracting the zero point and
+applying a scale factor, the floating-point computation step can be fused with
+the zero-point subtraction and scaling operations.
+
+The following are the parts that need to be modified for the fused operation
+of zero-point subtraction and scaling.
+
+## INT4 => FP16/BF16 or INT8 => FP16
+
+The floating-point computation is `__hsub2`
+
+If has zero points:
+
+    flop(bit_op(weight)) - flop(bit_op(zp))
+  = sub(bit_op(weight), bias) - sub(bit_op(zp), bias)
+  = bit_op(weight) - bit_op(zp)
+
+so we don't need additional modification.
+
+If has float zero points:
+
+    flop(bit_op(weight)) - fzp
+  = sub(bit_op(weight), bias) - fzp
+  = bit_op(weight) - (fzp + bias)
+
+where the `fzp + bias` can be computed at weight loading. But this
+may have accuracy issue, so we should not use this in most cases.
+
+If has not zero points:
+
+    scale(flop(bit_op(weight)))
+  = scale(sub(bit_op(weight), bias))
+  = scale(bit_op(weight)) - scale(bias)
+  = fma(bit_op(weight), scale_factor, scale(bias))
+
+where the `scale(bias)` can be cached. But this may have accuracy issue,
+so we should not use this in most cases.
+
+
+## INT8 => BF16
+
+INT8 => BF16 is a special case, it use byte_perm instead of flop.
+We cannot fused byte_perm with scaling.
+
+
+## FP4/FP8 => FP16/BF16
+
+    scale(flop(bit_op(weight)))
+  = scale(mul(bit_op(weight), multiplier))
+  = mul(bit_op(weight), scale_factor * multiplier)
+
+where `scale_factor * multiplier` can be computed at weight loading.
+
+*/
+
+#include "marlin_dtypes.cuh"
+
+namespace device::marlin {
+
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 800
+// Lookup-table based 3-input logical operation; explicitly used for
+// dequantization as the compiler does not seem to automatically recognize it in
+// all cases.
+template <int lut>
+__device__ inline int lop3(int a, int b, int c) {
+  int res;
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(res) : "r"(a), "r"(b), "r"(c), "n"(lut));
+  return res;
+}
+
+// Constructs destination register by taking bytes from 2 sources (based on
+// mask)
+template <int start_byte, int mask>
+__device__ inline uint32_t prmt(uint32_t a) {
+  uint32_t res;
+  asm volatile("prmt.b32 %0, %1, %2, %3;\n" : "=r"(res) : "r"(a), "n"(start_byte), "n"(mask));
+  return res;
+}
+
+template <typename scalar_t2, host::ScalarTypeId w_type_id, bool skip_flop = false>
+__device__ inline void dequant(int q, scalar_t2* frag_b);
+
+//
+// Efficiently dequantize 4bit values packed in an int32 value into a full
+// B-fragment of 4 fp16 values. We mostly follow the strategy in the link below,
+// with some small changes:
+// - FP16:
+// https://github.com/NVIDIA/FasterTransformer/blob/release/v5.3_tag/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h#L215-L287
+// - BF16:
+// https://github.com/NVIDIA/FasterTransformer/blob/release/v5.3_tag/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h#L327-L385
+//
+template <>
+__device__ inline void dequant<half2, host::kU4B8.id(), true>(int q, half2* frag_b) {
+  const int MASK = 0x000f000f;
+  const int EX = 0x64006400;
+  // Guarantee that the `(a & b) | c` operations are LOP3s.
+  int lo = lop3<(0xf0 & 0xcc) | 0xaa>(q, MASK, EX);
+  q >>= 4;
+  int hi = lop3<(0xf0 & 0xcc) | 0xaa>(q, MASK, EX);
+
+  frag_b[0] = *reinterpret_cast<half2*>(&lo);
+  frag_b[1] = *reinterpret_cast<half2*>(&hi);
+}
+
+template <>
+__device__ inline void dequant<half2, host::kU4B8.id(), false>(int q, half2* frag_b) {
+  const int LO = 0x000f000f;
+  const int HI = 0x00f000f0;
+  const int EX = 0x64006400;
+  // Guarantee that the `(a & b) | c` operations are LOP3s.
+  // clang-format off
+  int lo = lop3<(0xf0 & 0xcc) | 0xaa>(q, LO, EX);
+  int hi = lop3<(0xf0 & 0xcc) | 0xaa>(q, HI, EX);
+  // clang-format on
+  // We want signed int4 outputs, hence we fuse the `-8` symmetric zero point
+  // directly into `SUB` and `ADD`.
+  const int SUB = 0x64086408;
+  const int MUL = 0x2c002c00;
+  const int ADD = 0xd480d480;
+  frag_b[0] = __hsub2(*reinterpret_cast<half2*>(&lo), *reinterpret_cast<const half2*>(&SUB));
+  frag_b[1] = __hfma2(
+      *reinterpret_cast<half2*>(&hi), *reinterpret_cast<const half2*>(&MUL), *reinterpret_cast<const half2*>(&ADD));
+}
+
+template <>
+__device__ inline void dequant<half2, host::kU4.id(), true>(int q, half2* frag_b) {
+  dequant<half2, host::kU4B8.id(), true>(q, frag_b);
+}
+
+template <>
+__device__ inline void dequant<half2, host::kU4.id(), false>(int q, half2* frag_b) {
+  const int LO = 0x000f000f;
+  const int HI = 0x00f000f0;
+  const int EX = 0x64006400;
+  // Guarantee that the `(a & b) | c` operations are LOP3s.
+  // clang-format off
+  int lo = lop3<(0xf0 & 0xcc) | 0xaa>(q, LO, EX);
+  int hi = lop3<(0xf0 & 0xcc) | 0xaa>(q, HI, EX);
+  // clang-format on
+  // We want signed int4 outputs, hence we fuse the `-8` symmetric zero point
+  // directly into `SUB` and `ADD`.
+  const int SUB = 0x64006400;
+  const int MUL = 0x2c002c00;
+  const int ADD = 0xd400d400;
+  frag_b[0] = __hsub2(*reinterpret_cast<half2*>(&lo), *reinterpret_cast<const half2*>(&SUB));
+  frag_b[1] = __hfma2(
+      *reinterpret_cast<half2*>(&hi), *reinterpret_cast<const half2*>(&MUL), *reinterpret_cast<const half2*>(&ADD));
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, host::kU4B8.id(), true>(int q, nv_bfloat162* frag_b) {
+  static constexpr uint32_t MASK = 0x000f000f;
+  static constexpr uint32_t EX = 0x43004300;
+
+  // Guarantee that the `(a & b) | c` operations are LOP3s.
+  // clang-format off
+  int lo = lop3<(0xf0 & 0xcc) | 0xaa>(q, MASK, EX);
+  q >>= 4;
+  int hi = lop3<(0xf0 & 0xcc) | 0xaa>(q, MASK, EX);
+  // clang-format on
+
+  frag_b[0] = *reinterpret_cast<nv_bfloat162*>(&lo);
+  frag_b[1] = *reinterpret_cast<nv_bfloat162*>(&hi);
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, host::kU4B8.id(), false>(int q, nv_bfloat162* frag_b) {
+  dequant<nv_bfloat162, host::kU4B8.id(), true>(q, frag_b);
+
+  static constexpr uint32_t SUB = 0x43084308;
+
+  frag_b[0] = __hsub2(frag_b[0], *reinterpret_cast<const nv_bfloat162*>(&SUB));
+  frag_b[1] = __hsub2(frag_b[1], *reinterpret_cast<const nv_bfloat162*>(&SUB));
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, host::kU4.id(), true>(int q, nv_bfloat162* frag_b) {
+  dequant<nv_bfloat162, host::kU4B8.id(), true>(q, frag_b);
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, host::kU4.id(), false>(int q, nv_bfloat162* frag_b) {
+  dequant<nv_bfloat162, host::kU4.id(), true>(q, frag_b);
+
+  static constexpr uint32_t SUB = 0x43004300;
+
+  frag_b[0] = __hsub2(frag_b[0], *reinterpret_cast<const nv_bfloat162*>(&SUB));
+  frag_b[1] = __hsub2(frag_b[1], *reinterpret_cast<const nv_bfloat162*>(&SUB));
+}
+
+//
+// Fast Int8ToFp16/Int8ToBf16: Efficiently dequantize 8bit int values to fp16 or
+// bf16 Reference:
+// - FP16:
+// https://github.com/NVIDIA/FasterTransformer/blob/release/v5.3_tag/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h#L53-L85
+// - BF16:
+// https://github.com/NVIDIA/FasterTransformer/blob/release/v5.3_tag/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h#L125-L175
+//
+template <>
+__device__ inline void dequant<half2, host::kU8B128.id(), true>(int q, half2* frag_b) {
+  static constexpr uint32_t mask_for_elt_01 = 0x5250;
+  static constexpr uint32_t mask_for_elt_23 = 0x5351;
+  static constexpr uint32_t start_byte_for_fp16 = 0x64646464;
+
+  uint32_t lo = prmt<start_byte_for_fp16, mask_for_elt_01>(q);
+  uint32_t hi = prmt<start_byte_for_fp16, mask_for_elt_23>(q);
+
+  frag_b[0] = *reinterpret_cast<half2*>(&lo);
+  frag_b[1] = *reinterpret_cast<half2*>(&hi);
+}
+
+template <>
+__device__ inline void dequant<half2, host::kU8B128.id(), false>(int q, half2* frag_b) {
+  dequant<half2, host::kU8B128.id(), true>(q, frag_b);
+
+  static constexpr uint32_t I8s_TO_F16s_MAGIC_NUM = 0x64806480;
+  frag_b[0] = __hsub2(frag_b[0], *reinterpret_cast<const half2*>(&I8s_TO_F16s_MAGIC_NUM));
+  frag_b[1] = __hsub2(frag_b[1], *reinterpret_cast<const half2*>(&I8s_TO_F16s_MAGIC_NUM));
+}
+
+template <>
+__device__ inline void dequant<half2, host::kU8.id(), true>(int q, half2* frag_b) {
+  dequant<half2, host::kU8B128.id(), true>(q, frag_b);
+}
+
+template <>
+__device__ inline void dequant<half2, host::kU8.id(), false>(int q, half2* frag_b) {
+  dequant<half2, host::kU8.id(), true>(q, frag_b);
+
+  static constexpr uint32_t I8s_TO_F16s_MAGIC_NUM = 0x64006400;
+  frag_b[0] = __hsub2(frag_b[0], *reinterpret_cast<const half2*>(&I8s_TO_F16s_MAGIC_NUM));
+  frag_b[1] = __hsub2(frag_b[1], *reinterpret_cast<const half2*>(&I8s_TO_F16s_MAGIC_NUM));
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, host::kU8B128.id(), false>(int q, nv_bfloat162* frag_b) {
+  float fp32_intermediates[4];
+  uint32_t* fp32_intermediates_casted = reinterpret_cast<uint32_t*>(fp32_intermediates);
+
+  static constexpr uint32_t fp32_base = 0x4B000000;
+  fp32_intermediates_casted[0] = __byte_perm(q, fp32_base, 0x7650);
+  fp32_intermediates_casted[1] = __byte_perm(q, fp32_base, 0x7652);
+  fp32_intermediates_casted[2] = __byte_perm(q, fp32_base, 0x7651);
+  fp32_intermediates_casted[3] = __byte_perm(q, fp32_base, 0x7653);
+
+  fp32_intermediates[0] -= 8388736.f;
+  fp32_intermediates[1] -= 8388736.f;
+  fp32_intermediates[2] -= 8388736.f;
+  fp32_intermediates[3] -= 8388736.f;
+
+  uint32_t* bf16_result_ptr = reinterpret_cast<uint32_t*>(frag_b);
+  bf16_result_ptr[0] = __byte_perm(fp32_intermediates_casted[0], fp32_intermediates_casted[1], 0x7632);
+  bf16_result_ptr[1] = __byte_perm(fp32_intermediates_casted[2], fp32_intermediates_casted[3], 0x7632);
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, host::kU8.id(), false>(int q, nv_bfloat162* frag_b) {
+  float fp32_intermediates[4];
+  uint32_t* fp32_intermediates_casted = reinterpret_cast<uint32_t*>(fp32_intermediates);
+
+  static constexpr uint32_t fp32_base = 0x4B000000;
+  fp32_intermediates_casted[0] = __byte_perm(q, fp32_base, 0x7650);
+  fp32_intermediates_casted[1] = __byte_perm(q, fp32_base, 0x7652);
+  fp32_intermediates_casted[2] = __byte_perm(q, fp32_base, 0x7651);
+  fp32_intermediates_casted[3] = __byte_perm(q, fp32_base, 0x7653);
+
+  fp32_intermediates[0] -= 8388608.f;
+  fp32_intermediates[1] -= 8388608.f;
+  fp32_intermediates[2] -= 8388608.f;
+  fp32_intermediates[3] -= 8388608.f;
+
+  uint32_t* bf16_result_ptr = reinterpret_cast<uint32_t*>(frag_b);
+  bf16_result_ptr[0] = __byte_perm(fp32_intermediates_casted[0], fp32_intermediates_casted[1], 0x7632);
+  bf16_result_ptr[1] = __byte_perm(fp32_intermediates_casted[2], fp32_intermediates_casted[3], 0x7632);
+}
+
+template <>
+__device__ inline void dequant<half2, host::kFE4M3fn.id(), true>(int q, half2* frag_b) {
+  // Constants for FP8 (E4M3) and FP16 formats
+  constexpr int FP8_EXPONENT = 4, FP16_EXPONENT = 5;
+  constexpr int RIGHT_SHIFT = FP16_EXPONENT - FP8_EXPONENT;
+  constexpr int MASK = 0x7F007F00;
+
+  // Extract and shift FP8 values to FP16 format
+  int Out1 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+  q <<= 8;
+  int Out2 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+
+  // Note: reverse indexing is intentional because weights are permuted
+  frag_b[1] = *reinterpret_cast<const half2*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const half2*>(&Out2);
+}
+
+template <>
+__device__ inline void dequant<half2, host::kFE4M3fn.id(), false>(int q, half2* frag_b) {
+  dequant<half2, host::kFE4M3fn.id(), true>(q, frag_b);
+
+  // Constants for FP8 (E4M3) and FP16 formats
+  constexpr int FP8_EXPONENT = 4, FP16_EXPONENT = 5;
+
+  // Construct and apply exponent bias
+  constexpr int BIAS_OFFSET = (1 << (FP16_EXPONENT - 1)) - (1 << (FP8_EXPONENT - 1));
+  const half2 bias_reg = __float2half2_rn(float(1 << BIAS_OFFSET));
+
+  // Convert to half2 and apply bias
+  frag_b[1] = __hmul2(frag_b[1], bias_reg);
+  frag_b[0] = __hmul2(frag_b[0], bias_reg);
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, host::kFE4M3fn.id(), true>(int q, nv_bfloat162* frag_b) {
+  // Constants for FP8 (E4M3) and BF16 formats
+  constexpr int FP8_EXPONENT = 4, BF16_EXPONENT = 8;
+  constexpr int RIGHT_SHIFT = BF16_EXPONENT - FP8_EXPONENT;
+
+  constexpr int MASK = 0x7F007F00;
+
+  // Extract and shift FP8 values to BF16 format
+  int Out1 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+  q <<= 8;
+  int Out2 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+
+  // Note: reverse indexing is intentional because weights are permuted
+  frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, host::kFE4M3fn.id(), false>(int q, nv_bfloat162* frag_b) {
+  dequant<nv_bfloat162, host::kFE4M3fn.id(), true>(q, frag_b);
+
+  // Constants for FP8 (E4M3) and BF16 formats
+  constexpr int FP8_EXPONENT = 4, BF16_EXPONENT = 8;
+
+  // Construct and apply exponent bias
+  constexpr int BIAS_OFFSET = (1 << (BF16_EXPONENT - 1)) - (1 << (FP8_EXPONENT - 1));
+  // Add 127 (float exponent bias) to BIAS_OFFSET and shift to float exponent
+  // position
+  constexpr uint32_t BIAS = (BIAS_OFFSET + 127) << 23;
+  const nv_bfloat162 bias_reg = __float2bfloat162_rn(*reinterpret_cast<const float*>(&BIAS));
+
+  // Convert to bfloat162 and apply bias
+  frag_b[1] = __hmul2(frag_b[1], bias_reg);
+  frag_b[0] = __hmul2(frag_b[0], bias_reg);
+}
+
+template <>
+__device__ inline void dequant<half2, host::kFE2M1f.id(), true>(int q, half2* frag_b) {
+  // Constants for FP4 (E2M1) and FP16 formats
+  constexpr int FP4_EXPONENT = 2, FP16_EXPONENT = 5;
+  constexpr int RIGHT_SHIFT = FP16_EXPONENT - FP4_EXPONENT;
+  constexpr int MASK = 0x70007000;
+
+  // Extract and shift FP4 values to FP16 format
+  int Out1 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+  q <<= 4;
+  int Out2 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+
+  // Note: reverse indexing is intentional because weights are permuted
+  frag_b[1] = *reinterpret_cast<const half2*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const half2*>(&Out2);
+}
+
+template <>
+__device__ inline void dequant<half2, host::kFE2M1f.id(), false>(int q, half2* frag_b) {
+  dequant<half2, host::kFE2M1f.id(), true>(q, frag_b);
+
+  // Constants for FP4 (E2M1) and FP16 formats
+  constexpr int FP4_EXPONENT = 2, FP16_EXPONENT = 5;
+
+  // Construct and apply exponent bias
+  constexpr int BIAS_OFFSET = (1 << (FP16_EXPONENT - 1)) - (1 << (FP4_EXPONENT - 1));
+  const half2 bias_reg = __float2half2_rn(float(1 << BIAS_OFFSET));
+
+  // Convert to half2 and apply bias
+  frag_b[1] = __hmul2(frag_b[1], bias_reg);
+  frag_b[0] = __hmul2(frag_b[0], bias_reg);
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, host::kFE2M1f.id(), true>(int q, nv_bfloat162* frag_b) {
+  // Constants for FP4 (E2M1) and FP16 formats
+  constexpr int FP4_EXPONENT = 2, BF16_EXPONENT = 8;
+  constexpr int RIGHT_SHIFT = BF16_EXPONENT - FP4_EXPONENT;
+  constexpr int MASK = 0x70007000;
+
+  // Extract and shift FP4 values to FP16 format
+  int Out1 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+  q <<= 4;
+  int Out2 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+
+  // Note: reverse indexing is intentional because weights are permuted
+  frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, host::kFE2M1f.id(), false>(int q, nv_bfloat162* frag_b) {
+  dequant<nv_bfloat162, host::kFE2M1f.id(), true>(q, frag_b);
+
+  // Constants for FP4 (E2M1) and BF16 formats
+  constexpr int FP4_EXPONENT = 2, BF16_EXPONENT = 8;
+
+  // Construct and apply exponent bias
+  constexpr int BIAS_OFFSET = (1 << (BF16_EXPONENT - 1)) - (1 << (FP4_EXPONENT - 1));
+  // Add 127 (float exponent bias) to BIAS_OFFSET and shift to float exponent
+  // position
+  constexpr uint32_t BIAS = (BIAS_OFFSET + 127) << 23;
+  const nv_bfloat162 bias_reg = __float2bfloat162_rn(*reinterpret_cast<const float*>(&BIAS));
+
+  // Convert to half2 and apply bias
+  frag_b[1] = __hmul2(frag_b[1], bias_reg);
+  frag_b[0] = __hmul2(frag_b[0], bias_reg);
+}
+
+template <typename scalar_t2>
+__device__ inline void dequant_fp8_scales(int q, scalar_t2* frag_b);
+
+template <>
+__device__ inline void dequant_fp8_scales<half2>(int q, half2* frag_b) {
+  int Out1 = (q & 0xFF00FF00) >> 1;
+  ;
+  q <<= 8;
+  int Out2 = (q & 0xFF00FF00) >> 1;
+
+  // Note: reverse indexing is intentional because weights are permuted
+  frag_b[1] = *reinterpret_cast<const half2*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const half2*>(&Out2);
+};
+
+template <>
+__device__ inline void dequant_fp8_scales<nv_bfloat162>(int q, nv_bfloat162* frag_b) {
+  constexpr int FP8_EXPONENT = 4, BF16_EXPONENT = 8;
+  constexpr int RIGHT_SHIFT = BF16_EXPONENT - FP8_EXPONENT;
+  constexpr int MASK = 0x7F007F00;
+
+  // Extract and shift FP8 values to BF16 format
+  int Out1 = ((q & 0x80008000) >> 1) | ((q & MASK) >> RIGHT_SHIFT);
+  q <<= 8;
+  int Out2 = ((q & 0x80008000) >> 1) | ((q & MASK) >> RIGHT_SHIFT);
+
+  // Note: reverse indexing is intentional because weights are permuted
+  frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
+};
+
+// New version with s_type_id parameter for marlin_moe_wna16_v2
+template <typename scalar_t2, host::ScalarTypeId s_type_id>
+__device__ inline void dequant_fp8_scales(int q, scalar_t2* frag_b);
+
+template <>
+__device__ inline void dequant_fp8_scales<half2, host::kFE4M3fn.id()>(int q, half2* frag_b) {
+  int Out1 = (q & 0xFF00FF00) >> 1;
+  ;
+  q <<= 8;
+  int Out2 = (q & 0xFF00FF00) >> 1;
+
+  // Note: reverse indexing is intentional because weights are permuted
+  frag_b[1] = *reinterpret_cast<const half2*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const half2*>(&Out2);
+};
+
+template <>
+__device__ inline void dequant_fp8_scales<nv_bfloat162, host::kFE4M3fn.id()>(int q, nv_bfloat162* frag_b) {
+  constexpr int FP8_EXPONENT = 4, BF16_EXPONENT = 8;
+  constexpr int RIGHT_SHIFT = BF16_EXPONENT - FP8_EXPONENT;
+  constexpr int MASK = 0x7F007F00;
+
+  // Extract and shift FP8 values to BF16 format
+  int Out1 = ((q & 0x80008000) >> 1) | ((q & MASK) >> RIGHT_SHIFT);
+  q <<= 8;
+  int Out2 = ((q & 0x80008000) >> 1) | ((q & MASK) >> RIGHT_SHIFT);
+
+  // Note: reverse indexing is intentional because weights are permuted
+  frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
+}
+
+template <>
+__device__ inline void dequant_fp8_scales<nv_bfloat162, host::kFE8M0fnu.id()>(int q, nv_bfloat162* frag_b) {
+  // In this conversion, 2 ** -127 in FP8E8M0 would become 0 in BF16,
+  // but we assume that such a extreme value would not occur in real models.
+  int Out1 = (q & 0xFF00FF00) >> 1;
+  q <<= 7;
+  int Out2 = q & 0x7F807F80;
+
+  // Note: reverse indexing is intentional because weights are permuted
+  frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
+}
+
+#endif
+
+}  // namespace device::marlin

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin/marlin.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin/marlin.cuh
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <sgl_kernel/utils.cuh>
+
+#include <iostream>
+
+namespace device::marlin {
+// Marlin params
+
+// 8 warps are a good choice since every SM has 4 schedulers and having more
+// than 1 warp per schedule allows some more latency hiding. At the same time,
+// we want relatively few warps to have many registers per warp and small tiles.
+static constexpr int default_threads = 256;
+
+static constexpr int pipe_stages = 4;  // 4 pipeline stages fit into shared memory
+
+static constexpr int min_thread_n = 64;
+static constexpr int min_thread_k = 64;
+static constexpr int max_thread_n = 256;
+
+static constexpr int tile_size = 16;
+static constexpr int max_par = 16;
+
+// Repack params
+static constexpr int repack_stages = 8;
+
+static constexpr int repack_threads = 256;
+
+static constexpr int tile_k_size = tile_size;
+static constexpr int tile_n_size = tile_k_size * 4;
+
+// Helpers
+template <typename T, int n>
+struct Vec {
+  T elems[n];
+  __device__ T& operator[](int i) {
+    return elems[i];
+  }
+};
+
+using I4 = Vec<int, 4>;
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+// No support for async
+#else
+
+__device__ inline void cp_async4_pred(void* smem_ptr, const void* glob_ptr, bool pred = true) {
+  const int BYTES = 16;
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+      "{\n"
+      "   .reg .pred p;\n"
+      "   setp.ne.b32 p, %0, 0;\n"
+      "   @p cp.async.cg.shared.global [%1], [%2], %3;\n"
+      "}\n" ::"r"((int)pred),
+      "r"(smem),
+      "l"(glob_ptr),
+      "n"(BYTES));
+}
+
+__device__ inline void cp_async4(void* smem_ptr, const void* glob_ptr) {
+  const int BYTES = 16;
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+      "{\n"
+      "   cp.async.cg.shared.global [%0], [%1], %2;\n"
+      "}\n" ::"r"(smem),
+      "l"(glob_ptr),
+      "n"(BYTES));
+}
+
+__device__ inline void cp_async_fence() {
+  asm volatile("cp.async.commit_group;\n" ::);
+}
+
+template <int n>
+__device__ inline void cp_async_wait() {
+  asm volatile("cp.async.wait_group %0;\n" ::"n"(n));
+}
+
+#endif
+
+}  // namespace device::marlin

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin/marlin.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin/marlin.cuh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <sgl_kernel/utils.cuh>
+#include <utils.cuh>
 
 #include <iostream>
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin/marlin_dtypes.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin/marlin_dtypes.cuh
@@ -1,0 +1,77 @@
+#ifndef _data_types_cuh
+#define _data_types_cuh
+#include <sgl_kernel/utils.cuh>
+
+#include "marlin.cuh"
+
+namespace device::marlin {
+
+template <typename scalar_t>
+class ScalarType {};
+
+template <>
+class ScalarType<fp16_t> {
+ public:
+  using scalar_t = fp16_t;
+  using scalar_t2 = fp16x2_t;
+
+  // Matrix fragments for tensor core instructions; their precise layout is
+  // documented here:
+  // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#matrix-fragments-for-mma-m16n8k16-with-floating-point-type
+  using FragA = Vec<fp16x2_t, 4>;
+  using FragB = Vec<fp16x2_t, 2>;
+  using FragC = Vec<float, 4>;
+  using FragS = Vec<fp16x2_t, 1>;
+  using FragZP = Vec<fp16x2_t, 4>;
+
+  static __device__ float inline num2float(const fp16_t x) {
+    return __half2float(x);
+  }
+
+  static __device__ fp16x2_t inline num2num2(const fp16_t x) {
+    return __half2half2(x);
+  }
+
+  static __device__ fp16x2_t inline nums2num2(const fp16_t x1, const fp16_t x2) {
+    return __halves2half2(x1, x2);
+  }
+
+  static __host__ __device__ fp16_t inline float2num(const float x) {
+    return __float2half(x);
+  }
+};
+
+template <>
+class ScalarType<bf16_t> {
+ public:
+  using scalar_t = bf16_t;
+  using scalar_t2 = bf16x2_t;
+
+  using FragA = Vec<bf16x2_t, 4>;
+  using FragB = Vec<bf16x2_t, 2>;
+  using FragC = Vec<float, 4>;
+  using FragS = Vec<bf16x2_t, 1>;
+  using FragZP = Vec<bf16x2_t, 4>;
+
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 800
+  static __device__ float inline num2float(const bf16_t x) {
+    return __bfloat162float(x);
+  }
+
+  static __device__ bf16x2_t inline num2num2(const bf16_t x) {
+    return __bfloat162bfloat162(x);
+  }
+
+  static __device__ bf16x2_t inline nums2num2(const bf16_t x1, const bf16_t x2) {
+    return __halves2bfloat162(x1, x2);
+  }
+
+  static __host__ __device__ bf16_t inline float2num(const float x) {
+    return __float2bfloat16(x);
+  }
+#endif
+};
+
+}  // namespace device::marlin
+
+#endif

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin/marlin_dtypes.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin/marlin_dtypes.cuh
@@ -1,6 +1,6 @@
 #ifndef _data_types_cuh
 #define _data_types_cuh
-#include <sgl_kernel/utils.cuh>
+#include <utils.cuh>
 
 #include "marlin.cuh"
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/include/scalar_type.hpp
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/include/scalar_type.hpp
@@ -1,0 +1,334 @@
+#pragma once
+
+#include <cassert>
+#include <stdexcept>
+#ifndef __CUDACC__
+#include <variant>
+#endif
+
+namespace host {
+
+//
+//  ScalarType can represent a wide range of floating point and integer types,
+//  in particular it can be used to represent sub-byte data types (something
+//  that torch.dtype currently does not support).
+//
+//  The type definitions on the Python side can be found in: vllm/scalar_type.py
+//  these type definitions should be kept up to date with any Python API changes
+//  here.
+//
+class ScalarType {
+ public:
+  enum NanRepr : uint8_t {
+    NAN_NONE = 0,                // nans are not supported
+    NAN_IEEE_754 = 1,            // nans are: exp all 1s, mantissa not all 0s
+    NAN_EXTD_RANGE_MAX_MIN = 2,  // nans are: exp all 1s, mantissa all 1s
+
+    NAN_REPR_ID_MAX
+  };
+
+  constexpr ScalarType(
+      uint8_t exponent,
+      uint8_t mantissa,
+      bool signed_,
+      int32_t bias,
+      bool finite_values_only = false,
+      NanRepr nan_repr = NAN_IEEE_754)
+      : exponent(exponent),
+        mantissa(mantissa),
+        signed_(signed_),
+        bias(bias),
+        finite_values_only(finite_values_only),
+        nan_repr(nan_repr) {};
+
+  static constexpr ScalarType int_(uint8_t size_bits, int32_t bias = 0) {
+    return ScalarType(0, size_bits - 1, true, bias);
+  }
+
+  static constexpr ScalarType uint(uint8_t size_bits, int32_t bias = 0) {
+    return ScalarType(0, size_bits, false, bias);
+  }
+
+  // IEEE 754 compliant floating point type
+  static constexpr ScalarType float_IEEE754(uint8_t exponent, uint8_t mantissa) {
+    assert(mantissa > 0 && exponent > 0);
+    return ScalarType(exponent, mantissa, true, 0, false, NAN_IEEE_754);
+  }
+
+  // IEEE 754 non-compliant floating point type
+  static constexpr ScalarType float_(uint8_t exponent, uint8_t mantissa, bool finite_values_only, NanRepr nan_repr) {
+    assert(nan_repr < NAN_REPR_ID_MAX);
+    assert(mantissa > 0 && exponent > 0);
+    assert(nan_repr != NAN_IEEE_754);
+    return ScalarType(exponent, mantissa, true, 0, finite_values_only, nan_repr);
+  }
+
+  uint8_t const exponent;  // size of the exponent field (0 for integer types)
+  uint8_t const mantissa;  // size of the mantissa field (size of the integer
+                           // excluding the sign bit for integer types)
+  bool const signed_;      // flag if the type supports negative numbers (i.e. has a
+                           // sign bit)
+  int32_t const bias;      // stored values equal value + bias,
+                           // used for quantized type
+
+  // Extra Floating point info
+  bool const finite_values_only;  // i.e. no +/-inf if true
+  NanRepr const nan_repr;         // how NaNs are represented
+                                  // (not applicable for integer types)
+
+  using Id = int64_t;
+
+ private:
+  // Field size in id
+  template <typename T_>
+  static constexpr size_t member_id_field_width() {
+    using T = std::decay_t<T_>;
+    return std::is_same_v<T, bool> ? 1 : sizeof(T) * 8;
+  }
+
+  template <typename Fn, typename Init, typename Member, typename... Rest>
+  static constexpr auto reduce_members_helper(Fn f, Init val, Member member, Rest... rest) {
+    auto new_val = f(val, member);
+    if constexpr (sizeof...(rest) > 0) {
+      return reduce_members_helper(f, new_val, rest...);
+    } else {
+      return new_val;
+    };
+  }
+
+  template <typename Fn, typename Init>
+  constexpr auto reduce_members(Fn f, Init init) const {
+    // Should be in constructor order for `from_id`
+    return reduce_members_helper(f, init, exponent, mantissa, signed_, bias, finite_values_only, nan_repr);
+  };
+
+  template <typename Fn, typename Init>
+  static constexpr auto reduce_member_types(Fn f, Init init) {
+    constexpr auto dummy_type = ScalarType(0, 0, false, 0, false, NAN_NONE);
+    return dummy_type.reduce_members(f, init);
+  };
+
+  static constexpr auto id_size_bits() {
+    return reduce_member_types(
+        [](int acc, auto member) -> int { return acc + member_id_field_width<decltype(member)>(); }, 0);
+  }
+
+ public:
+  // unique id for this scalar type that can be computed at compile time for
+  //  c++17 template specialization this is not needed once we migrate to
+  //  c++20 and can pass literal classes as template parameters
+  constexpr Id id() const {
+    static_assert(id_size_bits() <= sizeof(Id) * 8, "ScalarType id is too large to be stored");
+
+    auto or_and_advance = [](std::pair<Id, uint32_t> result, auto member) -> std::pair<Id, uint32_t> {
+      auto [id, bit_offset] = result;
+      auto constexpr bits = member_id_field_width<decltype(member)>();
+      return {id | (int64_t(member) & ((uint64_t(1) << bits) - 1)) << bit_offset, bit_offset + bits};
+    };
+    return reduce_members(or_and_advance, std::pair<Id, uint32_t>{}).first;
+  }
+
+  // create a ScalarType from an id, for c++17 template specialization,
+  //  this is not needed once we migrate to c++20 and can pass literal
+  //  classes as template parameters
+  static constexpr ScalarType from_id(Id id) {
+    auto extract_and_advance = [id](auto result, auto member) {
+      using T = decltype(member);
+      auto [tuple, bit_offset] = result;
+      auto constexpr bits = member_id_field_width<T>();
+      auto extracted_val = static_cast<T>((int64_t(id) >> bit_offset) & ((uint64_t(1) << bits) - 1));
+      auto new_tuple = std::tuple_cat(tuple, std::make_tuple(extracted_val));
+      return std::pair<decltype(new_tuple), int>{new_tuple, bit_offset + bits};
+    };
+
+    auto [tuple_args, _] = reduce_member_types(extract_and_advance, std::pair<std::tuple<>, int>{});
+    return std::apply([](auto... args) { return ScalarType(args...); }, tuple_args);
+  }
+
+  constexpr int64_t size_bits() const {
+    return mantissa + exponent + is_signed();
+  }
+  constexpr bool is_signed() const {
+    return signed_;
+  }
+  constexpr bool is_integer() const {
+    return exponent == 0;
+  }
+  constexpr bool is_floating_point() const {
+    return exponent > 0;
+  }
+  constexpr bool is_ieee_754() const {
+    return is_floating_point() && finite_values_only == false && nan_repr == NAN_IEEE_754;
+  }
+  constexpr bool has_nans() const {
+    return is_floating_point() && nan_repr != NAN_NONE;
+  }
+  constexpr bool has_infs() const {
+    return is_floating_point() && finite_values_only == false;
+  }
+  constexpr bool has_bias() const {
+    return bias != 0;
+  }
+
+#ifndef __CUDACC__
+ private:
+  double _floating_point_max() const {
+    assert(mantissa <= 52 && exponent <= 11);
+
+    uint64_t max_mantissa = (uint64_t(1) << mantissa) - 1;
+    if (nan_repr == NAN_EXTD_RANGE_MAX_MIN) {
+      max_mantissa -= 1;
+    }
+
+    uint64_t max_exponent = (uint64_t(1) << exponent) - 2;
+    if (nan_repr == NAN_EXTD_RANGE_MAX_MIN || nan_repr == NAN_NONE) {
+      assert(exponent < 11);
+      max_exponent += 1;
+    }
+
+    // adjust the exponent to match that of a double
+    //  for now we assume the exponent bias is the standard 2^(e-1) -1, (where e
+    //  is the exponent bits), there is some precedent for non-standard biases,
+    //  example `float8_e4m3b11fnuz` here: https://github.com/jax-ml/ml_dtypes
+    //  but to avoid premature over complication we are just assuming the
+    //  standard exponent bias until there is a need to support non-standard
+    //  biases
+    uint64_t exponent_bias = (uint64_t(1) << (exponent - 1)) - 1;
+    uint64_t exponent_bias_double = (uint64_t(1) << 10) - 1;  // double e = 11
+
+    uint64_t max_exponent_double = max_exponent - exponent_bias + exponent_bias_double;
+
+    // shift the mantissa into the position for a double and
+    // the exponent
+    uint64_t double_raw = (max_mantissa << (52 - mantissa)) | (max_exponent_double << 52);
+
+    return *reinterpret_cast<double*>(&double_raw);
+  }
+
+  constexpr std::variant<int64_t, double> _raw_max() const {
+    if (is_floating_point()) {
+      return {_floating_point_max()};
+    } else {
+      assert(size_bits() < 64 || (size_bits() == 64 && is_signed()));
+      return {(int64_t(1) << mantissa) - 1};
+    }
+  }
+
+  constexpr std::variant<int64_t, double> _raw_min() const {
+    if (is_floating_point()) {
+      assert(is_signed());
+      constexpr uint64_t sign_bit_double = (uint64_t(1) << 63);
+
+      double max = _floating_point_max();
+      uint64_t max_raw = *reinterpret_cast<uint64_t*>(&max);
+      uint64_t min_raw = max_raw | sign_bit_double;
+      return {*reinterpret_cast<double*>(&min_raw)};
+    } else {
+      assert(!is_signed() || size_bits() <= 64);
+      if (is_signed()) {
+        // set the top bit to 1 (i.e. INT64_MIN) and the rest to 0
+        // then perform an arithmetic shift right to set all the bits above
+        // (size_bits() - 1) to 1
+        return {INT64_MIN >> (64 - size_bits())};
+      } else {
+        return {int64_t(0)};
+      }
+    }
+  }
+
+ public:
+  // Max representable value for this scalar type.
+  // (accounting for bias if there is one)
+  constexpr std::variant<int64_t, double> max() const {
+    return std::visit([this](auto x) -> std::variant<int64_t, double> { return {x - bias}; }, _raw_max());
+  }
+
+  // Min representable value for this scalar type.
+  // (accounting for bias if there is one)
+  constexpr std::variant<int64_t, double> min() const {
+    return std::visit([this](auto x) -> std::variant<int64_t, double> { return {x - bias}; }, _raw_min());
+  }
+#endif  // __CUDACC__
+
+ public:
+  std::string str() const {
+    /* naming generally follows: https://github.com/jax-ml/ml_dtypes
+     * for floating point types (leading f) the scheme is:
+     *  `float<size_bits>_e<exponent_bits>m<mantissa_bits>[flags]`
+     *  flags:
+     *  - no-flags: means it follows IEEE 754 conventions
+     *  - f: means finite values only (no infinities)
+     *  - n: means nans are supported (non-standard encoding)
+     * for integer types the scheme is:
+     *  `[u]int<size_bits>[b<bias>]`
+     *  - if bias is not present it means its zero
+     */
+    if (is_floating_point()) {
+      auto ret =
+          "float" + std::to_string(size_bits()) + "_e" + std::to_string(exponent) + "m" + std::to_string(mantissa);
+      if (!is_ieee_754()) {
+        if (finite_values_only) {
+          ret += "f";
+        }
+        if (nan_repr != NAN_NONE) {
+          ret += "n";
+        }
+      }
+      return ret;
+    } else {
+      auto ret = ((is_signed()) ? "int" : "uint") + std::to_string(size_bits());
+      if (has_bias()) {
+        ret += "b" + std::to_string(bias);
+      }
+      return ret;
+    }
+  }
+
+  constexpr bool operator==(ScalarType const& other) const {
+    return mantissa == other.mantissa && exponent == other.exponent && bias == other.bias && signed_ == other.signed_ &&
+           finite_values_only == other.finite_values_only && nan_repr == other.nan_repr;
+  }
+};
+
+using ScalarTypeId = ScalarType::Id;
+
+// "rust style" names generally following:
+//   https://github.com/pytorch/pytorch/blob/6d9f74f0af54751311f0dd71f7e5c01a93260ab3/torch/csrc/api/include/torch/types.h#L60-L70
+static inline constexpr auto kS4 = ScalarType::int_(4);
+static inline constexpr auto kU4 = ScalarType::uint(4);
+static inline constexpr auto kU4B8 = ScalarType::uint(4, 8);
+static inline constexpr auto kS8 = ScalarType::int_(8);
+static inline constexpr auto kU8 = ScalarType::uint(8);
+static inline constexpr auto kU8B128 = ScalarType::uint(8, 128);
+
+static inline constexpr auto kFE2M1f = ScalarType::float_(2, 1, true, ScalarType::NAN_NONE);
+static inline constexpr auto kFE3M2f = ScalarType::float_(3, 2, true, ScalarType::NAN_NONE);
+static inline constexpr auto kFE4M3fn = ScalarType::float_(4, 3, true, ScalarType::NAN_EXTD_RANGE_MAX_MIN);
+static inline constexpr auto kFE8M0fnu = ScalarType(8, 0, false, 0, true, ScalarType::NAN_EXTD_RANGE_MAX_MIN);
+static inline constexpr auto kFE5M2 = ScalarType::float_IEEE754(5, 2);
+static inline constexpr auto kFE8M7 = ScalarType::float_IEEE754(8, 7);
+static inline constexpr auto kFE5M10 = ScalarType::float_IEEE754(5, 10);
+
+// Fixed width style names, generally following:
+//  https://github.com/pytorch/pytorch/blob/6d9f74f0af54751311f0dd71f7e5c01a93260ab3/torch/csrc/api/include/torch/types.h#L47-L57
+static inline constexpr auto kInt4 = kS4;
+static inline constexpr auto kUint4 = kU4;
+static inline constexpr auto kUint4b8 = kU4B8;
+static inline constexpr auto kInt8 = kS8;
+static inline constexpr auto kUint8 = kU8;
+static inline constexpr auto kUint8b128 = kU8B128;
+
+static inline constexpr auto kFloat4_e2m1f = kFE2M1f;
+static inline constexpr auto kFloat6_e3m2f = kFE3M2f;
+static inline constexpr auto kFloat8_e4m3fn = kFE4M3fn;
+static inline constexpr auto kFloat8_e5m2 = kFE5M2;
+static inline constexpr auto kFloat16_e8m7 = kFE8M7;
+static inline constexpr auto kFloat16_e5m10 = kFE5M10;
+
+// colloquial names
+static inline constexpr auto kHalf = kFE5M10;
+static inline constexpr auto kFloat16 = kHalf;
+static inline constexpr auto kBFloat16 = kFE8M7;
+
+static inline constexpr auto kFloat16Id = kFloat16.id();
+}  // namespace host

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/include/utils.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/include/utils.cuh
@@ -48,9 +48,6 @@ using bf16x2_t = __nv_bfloat162;
 using fp32x4_t = float4;
 
 namespace device {
-/// Forced-inline device-function qualifier used across the Marlin kernel.
-#define SGL_DEVICE __forceinline__ __device__
-
 /// Ceil-division used across the Marlin GEMM (host + device).
 template <typename T, typename U>
 __host__ __device__ constexpr auto div_ceil(T a, U b) {

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/include/utils.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/include/utils.cuh
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 LightSeek Foundation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Minimal device-side prelude for the vendored Marlin MoE GEMM kernel.
+//
+// The original upstream header pulled in a full Tensor/FFI stack; the Marlin
+// kernel body only needs the scalar dtype aliases and the device qualifier
+// macro, so this trimmed drop-in replaces it.
+#pragma once
+
+#include <tvm/ffi/error.h>
+#include <tvm/ffi/extra/c_env_api.h>
+
+#include <cstdio>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <utility>
+
+// Scalar / packed dtype aliases used by marlin/marlin_dtypes.cuh (global
+// namespace, matching the upstream layout so the kernel refers to them bare).
+using fp32_t = float;
+using fp16_t = __half;
+using bf16_t = __nv_bfloat16;
+using fp8_e4m3_t = __nv_fp8_e4m3;
+using fp8_e5m2_t = __nv_fp8_e5m2;
+using fp32x2_t = float2;
+using fp16x2_t = __half2;
+using bf16x2_t = __nv_bfloat162;
+using fp32x4_t = float4;
+
+namespace device {
+/// Forced-inline device-function qualifier used across the Marlin kernel.
+#define SGL_DEVICE __forceinline__ __device__
+
+/// Ceil-division used across the Marlin GEMM (host + device).
+template <typename T, typename U>
+__host__ __device__ constexpr auto div_ceil(T a, U b) {
+  return (a + b - 1) / b;
+}
+}  // namespace device
+
+// Trimmed host-side helpers the vendored moe_align_kernel.cu still references
+// (RuntimeCheck / RuntimeDeviceCheck / LaunchKernel). Behaviour matches the
+// original versions for the launch shapes marlin uses (no PDL / cluster),
+// routed through TVM-FFI error reporting.
+namespace host {
+
+template <typename Cond, typename... Args>
+inline void RuntimeCheck(Cond&& condition, Args&&...) {
+  TVM_FFI_ICHECK(static_cast<bool>(condition));
+}
+
+inline void RuntimeDeviceCheck(cudaError_t error) {
+  TVM_FFI_ICHECK(error == cudaSuccess) << cudaGetErrorString(error);
+}
+
+// Fatal, never-returns error path (the entry uses it for an unreachable
+// moe_block_size). Routed through TVM-FFI so it surfaces as an FFI error.
+template <typename... Args>
+[[noreturn]] inline void Panic(Args&&...) {
+  TVM_FFI_ICHECK(false) << "marlin_moe: unrecoverable error";
+  __builtin_unreachable();
+}
+
+struct LaunchKernel {
+  dim3 grid_dim;
+  dim3 block_dim;
+  cudaStream_t stream;
+  std::size_t dynamic_shared_mem_bytes;
+
+  explicit LaunchKernel(
+      dim3 grid, dim3 block, cudaStream_t s, std::size_t smem = 0) noexcept
+      : grid_dim(grid), block_dim(block), stream(s), dynamic_shared_mem_bytes(smem) {}
+
+  static cudaStream_t resolve_device(DLDevice device) {
+    return static_cast<cudaStream_t>(
+        ::TVMFFIEnvGetStream(device.device_type, device.device_id));
+  }
+
+  template <typename T, typename... Args>
+  void operator()(T&& kernel, Args&&... args) const {
+    cudaLaunchConfig_t config{};
+    config.gridDim = grid_dim;
+    config.blockDim = block_dim;
+    config.dynamicSmemBytes = dynamic_shared_mem_bytes;
+    config.stream = stream;
+    config.numAttrs = 0;
+    RuntimeDeviceCheck(
+        ::cudaLaunchKernelEx(&config, kernel, std::forward<Args>(args)...));
+  }
+};
+
+}  // namespace host

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/kernel.h
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/kernel.h
@@ -1,0 +1,39 @@
+
+#include <scalar_type.hpp>
+
+#include "../marlin/marlin.cuh"
+#include "../marlin/marlin_dtypes.cuh"
+
+#define MARLIN_KERNEL_PARAMS                                                                                         \
+  const int4 *__restrict__ A, const int4 *__restrict__ B, int4 *__restrict__ C, int4 *__restrict__ C_tmp,            \
+      const int4 *__restrict__ b_bias_ptr, const int4 *__restrict__ scales_ptr,                                      \
+      const uint16_t *__restrict__ scale2_ptr, const int4 *__restrict__ zp_ptr, const int *__restrict__ g_idx,       \
+      const int32_t *__restrict__ sorted_token_ids_ptr, const int32_t *__restrict__ expert_ids_ptr,                  \
+      const int32_t *__restrict__ num_tokens_past_padded_ptr, const float *__restrict__ topk_weights_ptr, int top_k, \
+      bool mul_topk_weights, bool is_ep, int num_groups, int prob_m, int prob_n, int prob_k, int *locks,             \
+      bool has_bias, bool use_atomic_add, bool use_fp32_reduce, int max_shared_mem
+
+namespace device::marlin_moe {
+template <
+    typename scalar_t,                   // compute dtype, half or nv_float16
+    const host::ScalarTypeId w_type_id,  // weight ScalarType id
+    const host::ScalarTypeId s_type_id,  // weight scale ScalarType id
+    const int threads,                   // number of threads in a threadblock
+    const int thread_m_blocks,           // number of 16x16 blocks in the m
+                                         // dimension (batchsize) of the
+                                         // threadblock
+    const int thread_n_blocks,           // same for n dimension (output)
+    const int thread_k_blocks,           // same for k dimension (reduction)
+    const bool m_block_size_8,           // whether m_block_size == 8
+                                         // only works when thread_m_blocks == 1
+    const int stages,                    // number of stages for the async global->shared
+                                         // fetch pipeline
+    const int group_blocks,              // number of consecutive 16x16 blocks
+                                         // with a separate quantization scale
+    const bool is_zp_float,              // is zero point of float16 type?
+    const bool kIsEP,                    // expert parallelism
+    const bool kHasBias                  // has per-expert bias
+    >
+__global__ void Marlin(MARLIN_KERNEL_PARAMS);
+
+}  // namespace device::marlin_moe

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/marlin_moe_binding.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/marlin_moe_binding.cu
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 LightSeek Foundation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Marlin WNA16 MoE GEMM (vendored), pre-compiled with the specializations
+// tokenspeed needs: bf16 activations, no expert bias.
+// MXFP4 (E8M0 group-32 scales) is only numerically valid on the bf16
+// activation path, so no fp16 instantiation is exported.
+
+#include <tvm/ffi/function.h>
+
+#include "moe_align_kernel.cu"
+#include "moe_wna16_marlin.cuh"
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    moe_wna16_marlin_gemm_bf16,
+    (moe_wna16_marlin_gemm<bf16_t, false, false>));
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    moe_wna16_marlin_gemm_bf16_ep,
+    (moe_wna16_marlin_gemm<bf16_t, true, false>));
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    moe_align_block_size,
+    (MoeAlignBlockSizeKernel<int32_t>::run));

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/marlin_template.h
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/marlin_template.h
@@ -1,0 +1,1908 @@
+/*
+ * Modified by Neural Magic
+ * Copyright (C) Marlin.2024 Elias Frantar
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Adapted from https://github.com/IST-DASLab/marlin
+ */
+
+#include <scalar_type.hpp>
+
+#include "../marlin/dequant.h"
+#include "../marlin/marlin.cuh"
+#include "../marlin/marlin_dtypes.cuh"
+#include <type_traits>
+
+#define STATIC_ASSERT_SCALAR_TYPE_VALID(scalar_t)                                        \
+  static_assert(                                                                         \
+      std::is_same<scalar_t, half>::value || std::is_same<scalar_t, nv_bfloat16>::value, \
+      "only float16 and bfloat16 is supported");
+
+namespace device::marlin_moe {
+using namespace device::marlin;
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+
+template <
+    typename scalar_t,                   // compute dtype, half or nv_float16
+    const host::ScalarTypeId w_type_id,  // weight ScalarType id
+    const int threads,                   // number of threads in a threadblock
+    const int thread_m_blocks,           // number of 16x16 blocks in the m
+                                         // dimension (batchsize) of the
+                                         // threadblock
+    const int thread_n_blocks,           // same for n dimension (output)
+    const int thread_k_blocks,           // same for k dimension (reduction)
+    const bool m_block_size_8,           // whether m_block_size == 8
+                                         // only works when thread_m_blocks == 1
+    const int stages,                    // number of stages for the async global->shared
+                                         // fetch pipeline
+    const int group_blocks,              // number of consecutive 16x16 blocks
+                                         // with a separate quantization scale
+    const bool is_zp_float,              // is zero point of float16 type?
+    const bool kIsEP,                    // expert parallelism
+    const bool kHasBias                  // has per-expert bias
+    >
+__global__ void Marlin(
+    const int4* __restrict__ A,                              // fp16 input matrix of shape mxk
+    const int4* __restrict__ B,                              // 4bit quantized weight matrix of shape kxn
+    int4* __restrict__ C,                                    // fp16 output buffer of shape mxn
+    int4* __restrict__ C_tmp,                                // fp32 tmp output buffer (for reduce)
+    const int4* __restrict__ scales_ptr,                     // fp16 quantization scales of shape
+                                                             // (k/groupsize)xn
+    const int4* __restrict__ zp_ptr,                         // 4bit packed zero-points of shape
+                                                             // (k/groupsize)x(n/pack_factor)
+    const int* __restrict__ g_idx,                           // int32 group indices of shape k
+    const int32_t* __restrict__ sorted_token_ids_ptr,        // moe sorted_ids
+    const int32_t* __restrict__ expert_ids_ptr,              // moe expert ids
+    const int32_t* __restrict__ num_tokens_past_padded_ptr,  // moe num tokens
+    const float* __restrict__ topk_weights_ptr,              // moe top weights
+    int top_k,                                               // num of experts per token
+    bool mul_topk_weights,                                   // mul topk weights or not
+    bool is_ep,                                              // expert parallelism
+    int num_groups,                                          // number of scale groups per output channel
+    int prob_m,                                              // batch dimension m
+    int prob_n,                                              // output dimension n
+    int prob_k,                                              // reduction dimension k
+    int* locks,                                              // extra global storage for barrier synchronization
+    bool use_atomic_add,                                     // whether to use atomic add to reduce
+    bool use_fp32_reduce,                                    // whether to use fp32 global reduce
+    int max_shared_mem) {}
+
+}  // namespace device::marlin_moe
+
+#else
+
+// m16n8k16 tensor core mma instruction with fp16 inputs and fp32
+// output/accumulation.
+template <typename scalar_t>
+__device__ inline void
+mma(const typename ScalarType<scalar_t>::FragA& a_frag,
+    const typename ScalarType<scalar_t>::FragB& frag_b,
+    typename ScalarType<scalar_t>::FragC& frag_c) {
+  const uint32_t* a = reinterpret_cast<const uint32_t*>(&a_frag);
+  const uint32_t* b = reinterpret_cast<const uint32_t*>(&frag_b);
+  float* c = reinterpret_cast<float*>(&frag_c);
+  if constexpr (std::is_same<scalar_t, half>::value) {
+    asm volatile(
+        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+        "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+        : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+        : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]), "f"(c[0]), "f"(c[1]), "f"(c[2]), "f"(c[3]));
+  } else if constexpr (std::is_same<scalar_t, nv_bfloat16>::value) {
+    asm volatile(
+        "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+        "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+        : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+        : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]), "f"(c[0]), "f"(c[1]), "f"(c[2]), "f"(c[3]));
+  } else {
+    STATIC_ASSERT_SCALAR_TYPE_VALID(scalar_t);
+  }
+}
+
+template <typename scalar_t>
+__device__ inline void mma_trans(
+    const typename ScalarType<scalar_t>::FragA& a_frag,
+    const typename ScalarType<scalar_t>::FragB& frag_b,
+    const typename ScalarType<scalar_t>::FragB& frag_b2,
+    typename ScalarType<scalar_t>::FragC& frag_c) {
+  const uint32_t* a = reinterpret_cast<const uint32_t*>(&a_frag);
+  const uint32_t* b = reinterpret_cast<const uint32_t*>(&frag_b);
+  const uint32_t* b2 = reinterpret_cast<const uint32_t*>(&frag_b2);
+  float* c = reinterpret_cast<float*>(&frag_c);
+  if constexpr (std::is_same<scalar_t, half>::value) {
+    asm volatile(
+        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+        "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+        : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+        : "r"(b[0]),
+          "r"(b2[0]),
+          "r"(b[1]),
+          "r"(b2[1]),
+          "r"(a[0]),
+          "r"(a[1]),
+          "f"(c[0]),
+          "f"(c[1]),
+          "f"(c[2]),
+          "f"(c[3]));
+  } else if constexpr (std::is_same<scalar_t, nv_bfloat16>::value) {
+    asm volatile(
+        "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+        "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+        : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+        : "r"(b[0]),
+          "r"(b2[0]),
+          "r"(b[1]),
+          "r"(b2[1]),
+          "r"(a[0]),
+          "r"(a[1]),
+          "f"(c[0]),
+          "f"(c[1]),
+          "f"(c[2]),
+          "f"(c[3]));
+  } else {
+    STATIC_ASSERT_SCALAR_TYPE_VALID(scalar_t);
+  }
+}
+
+// Instruction for loading a full 16x16 matrix fragment of operand A from shared
+// memory, directly in tensor core layout.
+template <int count, typename scalar_t>
+__device__ inline void ldsm(typename ScalarType<scalar_t>::FragA& frag_a, const void* smem_ptr) {
+  uint32_t* a = reinterpret_cast<uint32_t*>(&frag_a);
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  if constexpr (count == 4) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+                 : "=r"(a[0]), "=r"(a[1]), "=r"(a[2]), "=r"(a[3])
+                 : "r"(smem));
+  } else if constexpr (count == 2) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0,%1}, [%2];\n" : "=r"(a[0]), "=r"(a[1]) : "r"(smem));
+  } else if constexpr (count == 1) {
+    asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 {%0}, [%1];\n" : "=r"(a[0]) : "r"(smem));
+  } else {
+    static_assert(count == 1 || count == 2 || count == 4, "invalid count");
+  }
+}
+
+// Multiply dequantized values by the corresponding quantization scale; used
+// only for grouped quantization.
+template <typename scalar_t>
+__device__ inline void
+scale(typename ScalarType<scalar_t>::FragB& frag_b, typename ScalarType<scalar_t>::FragS& frag_s, int i) {
+  using scalar_t2 = typename ScalarType<scalar_t>::scalar_t2;
+  scalar_t2 s = ScalarType<scalar_t>::num2num2(reinterpret_cast<scalar_t*>(&frag_s)[i]);
+  frag_b[0] = __hmul2(frag_b[0], s);
+  frag_b[1] = __hmul2(frag_b[1], s);
+}
+
+template <typename scalar_t>
+__device__ inline void scale_and_sub(typename ScalarType<scalar_t>::FragB& frag_b, scalar_t s, scalar_t zp) {
+  using scalar_t2 = typename ScalarType<scalar_t>::scalar_t2;
+  scalar_t2 s2 = ScalarType<scalar_t>::num2num2(s);
+  scalar_t2 zp2 = ScalarType<scalar_t>::num2num2(zp);
+  frag_b[0] = __hfma2(frag_b[0], s2, __hneg2(zp2));
+  frag_b[1] = __hfma2(frag_b[1], s2, __hneg2(zp2));
+}
+
+template <typename scalar_t>
+__device__ inline void
+sub_zp(typename ScalarType<scalar_t>::FragB& frag_b, typename ScalarType<scalar_t>::scalar_t2& frag_zp, int i) {
+  using scalar_t2 = typename ScalarType<scalar_t>::scalar_t2;
+  scalar_t2 zp = ScalarType<scalar_t>::num2num2(reinterpret_cast<scalar_t*>(&frag_zp)[i]);
+  frag_b[0] = __hsub2(frag_b[0], zp);
+  frag_b[1] = __hsub2(frag_b[1], zp);
+}
+
+// Same as above, but for act_order (each K is multiplied individually)
+template <typename scalar_t>
+__device__ inline void scale4(
+    typename ScalarType<scalar_t>::FragB& frag_b,
+    typename ScalarType<scalar_t>::FragS& frag_s_1,
+    typename ScalarType<scalar_t>::FragS& frag_s_2,
+    typename ScalarType<scalar_t>::FragS& frag_s_3,
+    typename ScalarType<scalar_t>::FragS& frag_s_4,
+    int i) {
+  using scalar_t2 = typename ScalarType<scalar_t>::scalar_t2;
+  scalar_t2 s_val_1_2;
+  s_val_1_2.x = reinterpret_cast<scalar_t*>(&frag_s_1)[i];
+  s_val_1_2.y = reinterpret_cast<scalar_t*>(&frag_s_2)[i];
+
+  scalar_t2 s_val_3_4;
+  s_val_3_4.x = reinterpret_cast<scalar_t*>(&frag_s_3)[i];
+  s_val_3_4.y = reinterpret_cast<scalar_t*>(&frag_s_4)[i];
+
+  frag_b[0] = __hmul2(frag_b[0], s_val_1_2);
+  frag_b[1] = __hmul2(frag_b[1], s_val_3_4);
+}
+
+// Given 2 floats multiply by 2 scales (halves)
+template <typename scalar_t>
+__device__ inline void scale_float(float* c, typename ScalarType<scalar_t>::FragS& s) {
+  scalar_t* s_ptr = reinterpret_cast<scalar_t*>(&s);
+  c[0] = __fmul_rn(c[0], ScalarType<scalar_t>::num2float(s_ptr[0]));
+  c[1] = __fmul_rn(c[1], ScalarType<scalar_t>::num2float(s_ptr[1]));
+}
+
+// Wait until barrier reaches `count`, then lock for current threadblock.
+__device__ inline void barrier_acquire(int* lock, int count) {
+  if (threadIdx.x == 0) {
+    int state = -1;
+    do
+      // Guarantee that subsequent writes by this threadblock will be visible
+      // globally.
+      asm volatile("ld.global.acquire.gpu.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));
+    while (state != count);
+  }
+  __syncthreads();
+}
+
+// Release barrier and increment visitation count.
+__device__ inline void barrier_release(int* lock, bool reset = false) {
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    if (reset) {
+      lock[0] = 0;
+      return;
+    }
+    int val = 1;
+    // Make sure that all writes since acquiring this barrier are visible
+    // globally, while releasing the barrier.
+    asm volatile("fence.acq_rel.gpu;\n");
+    asm volatile("red.relaxed.gpu.global.add.s32 [%0], %1;\n" : : "l"(lock), "r"(val));
+  }
+}
+
+// Wait until value of lock to be negative, and then add 1
+__device__ inline void wait_negative_and_add(int* lock) {
+  if (threadIdx.x == 0) {
+    int state = 0;
+    do
+      // Guarantee that subsequent writes by this threadblock will be visible
+      // globally.
+      asm volatile("ld.global.acquire.gpu.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));
+    while (state >= 0);
+    atomicAdd(lock, 1);
+  }
+  __syncthreads();
+}
+
+template <
+    typename scalar_t,                   // compute dtype, half or nv_float16
+    const host::ScalarTypeId w_type_id,  // weight ScalarType id
+    const host::ScalarTypeId s_type_id,  // weight scale ScalarType id
+    const int threads,                   // number of threads in a threadblock
+    const int thread_m_blocks,           // number of 16x16 blocks in the m
+                                         // dimension (batchsize) of the
+                                         // threadblock
+    const int thread_n_blocks,           // same for n dimension (output)
+    const int thread_k_blocks,           // same for k dimension (reduction)
+    const bool m_block_size_8,           // whether m_block_size == 8
+                                         // only works when thread_m_blocks == 1
+    const int stages,                    // number of stages for the async global->shared
+                                         // fetch pipeline
+    const int group_blocks,              // number of consecutive 16x16 blocks
+                                         // with a separate quantization scale
+    const bool is_zp_float,              // is zero point of float16 type?
+    const bool kIsEP,                    // expert parallelism
+    const bool kHasBias                  // has per-expert bias
+    >
+__global__ void Marlin(
+    const int4* __restrict__ A,  // fp16 input matrix of shape mxk
+    const int4* __restrict__ B,  // 4bit quantized weight matrix of shape kxn
+    int4* __restrict__ C,        // fp16 output buffer of shape mxn
+    int4* __restrict__ C_tmp,    // fp32 tmp output buffer (for reduce)
+    const int4* __restrict__ b_bias_ptr,
+    const int4* __restrict__ scales_ptr,                     // fp16 quantization scales of shape
+                                                             // (k/groupsize)xn
+    const uint16_t* __restrict__ scale2_ptr,                 // fp16 global scale (for nvfp4
+                                                             // only)
+    const int4* __restrict__ zp_ptr,                         // 4bit packed zero-points of shape
+                                                             // (k/groupsize)x(n/pack_factor)
+    const int* __restrict__ g_idx,                           // int32 group indices of shape k
+    const int32_t* __restrict__ sorted_token_ids_ptr,        // moe sorted_ids
+    const int32_t* __restrict__ expert_ids_ptr,              // moe expert ids
+    const int32_t* __restrict__ num_tokens_past_padded_ptr,  // moe num tokens
+    const float* __restrict__ topk_weights_ptr,              // moe top weights
+    int top_k,                                               // num of experts per token
+    bool mul_topk_weights,                                   // mul topk weights or not
+    bool is_ep,                                              // expert parallelism
+    int num_groups,                                          // number of scale groups per output channel
+    int prob_m,                                              // batch dimension m
+    int prob_n,                                              // output dimension n
+    int prob_k,                                              // reduction dimension k
+    int* locks,                                              // extra global storage for barrier synchronization
+    bool has_bias,
+    bool use_atomic_add,   // whether to use atomic add to reduce
+    bool use_fp32_reduce,  // whether to use fp32 global reduce
+    int max_shared_mem) {
+  // Each threadblock processes one "stripe" of the B matrix with (roughly) the
+  // same size, which might involve multiple column "slices" (of width 16 *
+  // `thread_n_blocks`). Stripes are defined as shown in the 3x3 matrix 5 SM
+  // example:
+  //   0 1 3
+  //   0 2 3
+  //   1 2 4
+  // While this kind of partitioning makes things somewhat more complicated, it
+  // ensures good utilization of all SMs for many kinds of shape and GPU
+  // configurations, while requiring as few slow global cross-threadblock
+  // reductions as possible.
+  using Dtype = ScalarType<scalar_t>;
+  using scalar_t2 = typename ScalarType<scalar_t>::scalar_t2;
+  using FragA = typename ScalarType<scalar_t>::FragA;
+  using FragB = typename ScalarType<scalar_t>::FragB;
+  using FragC = typename ScalarType<scalar_t>::FragC;
+  using FragS = typename ScalarType<scalar_t>::FragS;
+  using FragZP = typename ScalarType<scalar_t>::FragZP;
+
+  extern __shared__ int4 sh[];
+  static constexpr auto w_type = host::ScalarType::from_id(w_type_id);
+  static constexpr auto s_type = host::ScalarType::from_id(s_type_id);
+  if constexpr (w_type == host::kFE2M1f) {
+    static_assert(s_type == host::kFE4M3fn && group_blocks == 1 || s_type == host::kFE8M0fnu && group_blocks == 2);
+  } else if constexpr (std::is_same<scalar_t, nv_bfloat16>::value) {
+    static_assert(s_type == host::kBFloat16);
+  } else if constexpr (std::is_same<scalar_t, half>::value) {
+    static_assert(s_type == host::kFloat16);
+  }
+
+  constexpr bool has_zp = w_type == host::kU4 || w_type == host::kU8;
+  constexpr bool is_int_type =
+      w_type == host::kU4 || w_type == host::kU8 || w_type == host::kU4B8 || w_type == host::kU8B128;
+  constexpr bool is_8bit_scale = s_type.size_bits() == 8;
+  // see comments of dequant.h for more details
+  constexpr bool dequant_skip_flop = w_type == host::kFE4M3fn || w_type == host::kFE2M1f && s_type == host::kFE4M3fn ||
+                                     has_zp && !is_zp_float && !std::is_same<scalar_t, nv_bfloat16>::value ||
+                                     has_zp && !is_zp_float && !(w_type == host::kU8);
+
+  scalar_t2 global_scale;
+
+  constexpr bool has_act_order = group_blocks == 0;
+
+  constexpr int pack_factor = 32 / w_type.size_bits();
+  static_assert(thread_m_blocks == 1 || !m_block_size_8);
+  constexpr int moe_block_size = m_block_size_8 ? 8 : (16 * thread_m_blocks);
+  const int group_size = (!has_act_order && group_blocks == -1) ? prob_k : prob_k / num_groups;
+  const int scales_expert_stride = prob_n * prob_k / group_size / (is_8bit_scale ? 16 : 8);
+  const int zp_expert_stride =
+      is_zp_float ? prob_n * prob_k / group_size / 8 : prob_n * prob_k / group_size / (pack_factor * 4);
+  const int b_bias_expert_stride = prob_n / 8;
+
+  int num_tokens_past_padded = num_tokens_past_padded_ptr[0];
+  int parallel = num_tokens_past_padded / moe_block_size;
+  int num_valid_blocks = parallel;
+  if constexpr (kIsEP) {
+    for (int i = 0; i < parallel; i++) {
+      if (expert_ids_ptr[i] == -1) num_valid_blocks--;
+    }
+  }
+  int num_invalid_blocks = parallel - num_valid_blocks;
+  parallel = num_valid_blocks;
+
+  int k_tiles = prob_k / 16 / thread_k_blocks;
+  int n_tiles = prob_n / 16 / thread_n_blocks;
+  int iters = div_ceil(k_tiles * n_tiles * parallel, gridDim.x);
+
+  if constexpr (!has_act_order && group_blocks != -1) {
+    if (group_blocks >= thread_k_blocks) {
+      // Ensure that the number of tiles in each stripe is a multiple of the
+      // groupsize; this avoids an annoying special case where a stripe starts
+      // in the middle of group.
+      iters = (group_blocks / thread_k_blocks) * div_ceil(iters, (group_blocks / thread_k_blocks));
+    }
+  }
+
+  int slice_row = (iters * blockIdx.x) % k_tiles;
+  int slice_col_par = (iters * blockIdx.x) / k_tiles;
+  int slice_col = slice_col_par;
+  int slice_iters;      // number of threadblock tiles in the current slice
+  int slice_count = 0;  // total number of active threadblocks in the current slice
+  int slice_idx;        // index of threadblock in current slice; numbered bottom to
+                        // top
+
+  int par_id = 0;
+  int block_id = -1;
+  int64_t expert_id = 0;  // use int64 to avoid computation result overflow
+  int old_expert_id = 0;
+  int64_t B_expert_off = 0;
+
+  int4* sh_block_sorted_ids_int4 = sh;
+  int4* sh_rd_block_sorted_ids_int4 = sh_block_sorted_ids_int4 + moe_block_size / 4;
+  int4* sh_block_topk_weights_int4 = sh_rd_block_sorted_ids_int4 + moe_block_size / 4;
+  // sh_block_topk_weights_int4 only need (moe_block_size / 4);
+  // but we pad to align to 256 bytes
+  int4* sh_new = sh_block_topk_weights_int4 + moe_block_size / 2 + moe_block_size;
+  int32_t* sh_block_sorted_ids = reinterpret_cast<int*>(sh_block_sorted_ids_int4);
+  int32_t* sh_rd_block_sorted_ids = reinterpret_cast<int*>(sh_rd_block_sorted_ids_int4);
+  scalar_t2* sh_block_topk_weights = reinterpret_cast<scalar_t2*>(sh_block_topk_weights_int4);
+
+  int32_t block_num_valid_tokens = 0;
+  int32_t locks_off = 0;
+
+  // We can easily implement parallel problem execution by just remapping
+  // indices and advancing global pointers
+  if (slice_col_par >= n_tiles) {
+    slice_col = slice_col_par % n_tiles;
+    par_id = slice_col_par / n_tiles;
+  }
+  if (parallel * n_tiles >= gridDim.x) {
+    // when parallel * n_tiles >= sms
+    // then there are at most $sms$ conflict tile blocks
+    locks_off = blockIdx.x;
+  } else {
+    locks_off = (iters * blockIdx.x) / k_tiles - 1;
+  }
+
+  int prob_m_top_k = prob_m * top_k;
+  // read moe block data given block_id
+  // block_sorted_ids / block_num_valid_tokens / block_topk_weights
+  auto read_moe_block_data = [&](int block_id) {
+    block_num_valid_tokens = moe_block_size;
+
+    cp_async4_pred(
+        sh_block_sorted_ids_int4 + threadIdx.x,
+        reinterpret_cast<const int4*>(sorted_token_ids_ptr) + (block_id * moe_block_size / 4 + threadIdx.x),
+        threadIdx.x < moe_block_size / 4);
+
+    cp_async_fence();
+    cp_async_wait<0>();
+
+    __syncthreads();
+
+    if (threadIdx.x >= threads - 32) {
+      constexpr int size_per_thread = div_ceil(moe_block_size, 32);
+      int lane_id = threadIdx.x - (threads - 32);
+
+      int local_count = 0;
+#pragma unroll
+      for (int i = 0; i < size_per_thread; i++) {
+        int j = lane_id * size_per_thread + i;
+        if (j < moe_block_size) {
+          int idx = sh_block_sorted_ids[j];
+          if (idx < prob_m_top_k) local_count++;
+        }
+      }
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
+      if constexpr (moe_block_size >= 16) local_count += __shfl_down_sync(0xFFFFFFFF, local_count, 16);
+      if constexpr (moe_block_size >= 8) local_count += __shfl_down_sync(0xFFFFFFFF, local_count, 8);
+      if constexpr (moe_block_size >= 4) local_count += __shfl_down_sync(0xFFFFFFFF, local_count, 4);
+      if constexpr (moe_block_size >= 2) local_count += __shfl_down_sync(0xFFFFFFFF, local_count, 2);
+
+      local_count += __shfl_down_sync(0xFFFFFFFF, local_count, 1);
+      block_num_valid_tokens = local_count;
+#else
+      block_num_valid_tokens = __reduce_add_sync(0xffffffff, local_count);
+#endif
+
+      if (lane_id == 0) reinterpret_cast<int*>(sh_new)[0] = block_num_valid_tokens;
+    }
+
+    if (threadIdx.x < moe_block_size) {
+      int idx = sh_block_sorted_ids[threadIdx.x];
+      sh_rd_block_sorted_ids[threadIdx.x] = idx / top_k;
+
+      if (mul_topk_weights) {
+        idx = idx < prob_m_top_k ? idx : 0;
+        scalar_t topk_weight_tmp = Dtype::float2num(topk_weights_ptr[idx]);
+        if constexpr (w_type == host::kFE2M1f && s_type == host::kFE4M3fn) {
+          sh_block_topk_weights[threadIdx.x] = __hmul2(global_scale, Dtype::num2num2(topk_weight_tmp));
+        } else {
+          sh_block_topk_weights[threadIdx.x] = Dtype::num2num2(topk_weight_tmp);
+        }
+      }
+    }
+
+    __syncthreads();
+
+    block_num_valid_tokens = reinterpret_cast<int*>(sh_new)[0];
+    __syncthreads();
+  };
+
+  // when move to next moe block, find the next block_id and expert_id
+  // and then read moe block data
+  auto update_next_moe_block_data = [&]() {
+    if (par_id >= parallel) return;
+
+    old_expert_id = expert_id;
+    if constexpr (kIsEP) {
+      if (num_invalid_blocks > 0) {
+        int skip_count = block_id == -1 ? par_id : 0;
+        block_id++;
+        for (int i = block_id; i < num_tokens_past_padded / moe_block_size; i++) {
+          expert_id = expert_ids_ptr[i];
+          if (expert_id != -1) {
+            if (skip_count == 0) {
+              block_id = i;
+              break;
+            };
+            skip_count--;
+          };
+        }
+      } else {
+        block_id = par_id;
+        expert_id = expert_ids_ptr[block_id];
+      }
+    } else {
+      block_id = par_id;
+      expert_id = expert_ids_ptr[block_id];
+    }
+
+    if constexpr (w_type == host::kFE2M1f && s_type == host::kFE4M3fn) {
+      uint16_t val = scale2_ptr[expert_id];
+      global_scale = Dtype::num2num2(*reinterpret_cast<scalar_t*>(&val));
+    }
+
+    B_expert_off = expert_id * prob_n * prob_k / (pack_factor * 4);
+    scales_ptr += (expert_id - old_expert_id) * scales_expert_stride;
+    if constexpr (has_zp) {
+      zp_ptr += (expert_id - old_expert_id) * zp_expert_stride;
+    }
+    if constexpr (has_act_order) {
+      g_idx += (expert_id - old_expert_id) * prob_k;
+    }
+    if constexpr (kHasBias) {
+      b_bias_ptr += (expert_id - old_expert_id) * b_bias_expert_stride;
+    }
+
+    read_moe_block_data(block_id);
+  };
+
+  // Compute all information about the current slice which is required for
+  // synchronization.
+  auto init_slice = [&](bool first_init = false) {
+    slice_iters = iters * (blockIdx.x + 1) - (k_tiles * slice_col_par + slice_row);
+    if (slice_iters < 0 || slice_col_par >= n_tiles * parallel) slice_iters = 0;
+    if (slice_iters == 0) return;
+    if (slice_row + slice_iters > k_tiles) slice_iters = k_tiles - slice_row;
+    slice_count = 1;
+    slice_idx = 0;
+    int col_first = iters * div_ceil(k_tiles * slice_col_par, iters);
+    if (col_first <= k_tiles * (slice_col_par + 1)) {
+      int col_off = col_first - k_tiles * slice_col_par;
+      slice_count = div_ceil(k_tiles - col_off, iters);
+      if (col_off > 0) slice_count++;
+      int delta_first = iters * blockIdx.x - col_first;
+      if (delta_first < 0 || (col_off == 0 && delta_first == 0))
+        slice_idx = slice_count - 1;
+      else {
+        slice_idx = slice_count - 1 - delta_first / iters;
+        if (col_off > 0) slice_idx--;
+      }
+    }
+    if (parallel * n_tiles >= gridDim.x) {
+      if (slice_count > 1 && slice_idx == slice_count - 1) {
+        locks_off++;
+      }
+    } else {
+      locks_off++;
+    }
+
+    if (first_init && use_atomic_add && slice_count > 1 && slice_idx == 0) {
+      constexpr int threads_per_m = 16 * thread_n_blocks / 8;
+      int m_per_thread = div_ceil(block_num_valid_tokens, threads / threads_per_m);
+      for (int i = 0; i < m_per_thread; i++) {
+        int row = threads / threads_per_m * i + threadIdx.x / threads_per_m;
+        if (row < block_num_valid_tokens) {
+          int64_t sorted_row = sh_block_sorted_ids[row];
+          int col = slice_col * 16 * thread_n_blocks / 8 + threadIdx.x % threads_per_m;
+          C[sorted_row * prob_n / 8 + col] = {0, 0, 0, 0};
+        }
+      }
+      // After write zero to output, write a negative value to lock.
+      // Every SM that processes the same slice would wait for
+      // the negative value, and then atomicAdd 1 to it.
+      // After all SMs are processed, the lock value would back to 0 again.
+      __syncthreads();
+      if (threadIdx.x == 0) locks[locks_off] = 1 - slice_count;
+    }
+
+    if (slice_col == n_tiles) {
+      slice_col = 0;
+      par_id++;
+      update_next_moe_block_data();
+    }
+  };
+
+  update_next_moe_block_data();
+  init_slice(true);
+
+  // A sizes/strides
+
+  // stride of the A matrix in global memory
+  int a_gl_stride = prob_k / 8;
+  // stride of an A matrix tile in shared memory
+  constexpr int a_sh_stride = 16 * thread_k_blocks / 8;
+  // delta between subsequent A tiles in global memory
+  constexpr int a_gl_rd_delta_o = 16 * thread_k_blocks / 8;
+  // between subsequent accesses within a tile
+  int a_gl_rd_delta_i = a_gl_stride * (threads / a_gl_rd_delta_o);
+  // between shared memory writes
+  constexpr int a_sh_wr_delta = a_sh_stride * (threads / a_gl_rd_delta_o);
+  // between shared memory tile reads
+  constexpr int a_sh_rd_delta_o = 2 * ((threads / 32) / (thread_n_blocks / 4));
+  // within a shared memory tile
+  constexpr int a_sh_rd_delta_i = a_sh_stride * 16;
+  // overall size of a tile
+  constexpr int a_sh_stage = a_sh_stride * (16 * thread_m_blocks);
+  // number of shared write iterations for a tile
+  constexpr int a_sh_wr_iters = div_ceil(a_sh_stage, a_sh_wr_delta);
+
+  // B sizes/strides
+  int b_gl_stride = 16 * prob_n / (pack_factor * 4);
+  constexpr int b_sh_stride = ((thread_n_blocks * 16) * 16 / pack_factor) / 4;
+  constexpr int b_thread_vecs = w_type.size_bits() == 4 ? 1 : 2;
+  constexpr int b_sh_stride_threads = b_sh_stride / b_thread_vecs;
+
+  int b_gl_rd_delta_o = b_gl_stride * thread_k_blocks;
+  int b_gl_rd_delta_i = b_gl_stride * (threads / b_sh_stride_threads);
+  constexpr int b_sh_wr_delta = threads * b_thread_vecs;
+  constexpr int b_sh_rd_delta = threads * b_thread_vecs;
+  constexpr int b_sh_stage = b_sh_stride * thread_k_blocks;
+  constexpr int b_sh_wr_iters = b_sh_stage / b_sh_wr_delta;
+
+  // Scale sizes/strides without act_order
+  int s_gl_stride = prob_n / (is_8bit_scale ? 16 : 8);
+  constexpr int s_sh_stride = 16 * thread_n_blocks / (is_8bit_scale ? 16 : 8);
+  constexpr int s_tb_groups =
+      !has_act_order && group_blocks != -1 && group_blocks < thread_k_blocks ? thread_k_blocks / group_blocks : 1;
+  constexpr int s_sh_stage = s_tb_groups * s_sh_stride;
+  int s_gl_rd_delta = s_gl_stride;
+
+  // Scale size/strides with act_order
+  constexpr int tb_k = 16 * thread_k_blocks;
+  constexpr int g_idx_stage = has_act_order ? (tb_k * sizeof(int)) / 16 : 0;
+  // constexpr int act_s_row_stride      = 1;
+  // int           act_s_col_stride      = act_s_row_stride * num_groups;
+  constexpr int act_s_max_num_groups = 32;
+  int act_s_col_stride = 1;
+  int act_s_col_warp_stride = act_s_col_stride * 8;
+  int tb_n_warps = thread_n_blocks / 4;
+  int act_s_col_tb_stride = act_s_col_warp_stride * tb_n_warps;
+
+  // Zero-points sizes/strides
+  int zp_gl_stride = is_zp_float ? prob_n / 8 : (prob_n / pack_factor) / 4;
+  constexpr int zp_sh_stride = is_zp_float ? 16 * thread_n_blocks / 8 : ((16 * thread_n_blocks) / pack_factor) / 4;
+  constexpr int zp_tb_groups = s_tb_groups;
+  constexpr int zp_sh_stage = has_zp ? zp_tb_groups * zp_sh_stride : 0;
+  int zp_gl_rd_delta = zp_gl_stride;
+
+  // Global A read index of current thread.
+  int a_gl_rd_row = threadIdx.x / a_gl_rd_delta_o;
+  int a_gl_rd_col = a_gl_rd_delta_o * slice_row + threadIdx.x % a_gl_rd_delta_o;
+
+  // Shared write index of current thread.
+  int a_sh_wr = a_sh_stride * (threadIdx.x / a_gl_rd_delta_o) + (threadIdx.x % a_gl_rd_delta_o);
+  // Shared read index.
+  int a_sh_rd = a_sh_stride * ((threadIdx.x % 32) % (16 / (m_block_size_8 ? 2 : 1))) +
+                (threadIdx.x % 32) / (16 / (m_block_size_8 ? 2 : 1));
+  a_sh_rd += 2 * ((threadIdx.x / 32) / (thread_n_blocks / 4));
+
+  int b_gl_rd = b_gl_stride * (threadIdx.x / b_sh_stride_threads) + (threadIdx.x % b_sh_stride_threads) * b_thread_vecs;
+  b_gl_rd += b_sh_stride * slice_col;
+  b_gl_rd += b_gl_rd_delta_o * slice_row;
+  auto b_sh_wr = threadIdx.x * b_thread_vecs;
+  auto b_sh_rd = threadIdx.x * b_thread_vecs;
+
+  // For act_order
+  constexpr int k_iter_size = tb_k / b_sh_wr_iters;
+  int slice_k_start = tb_k * slice_row;
+  int slice_k_finish = slice_k_start + tb_k * slice_iters;
+  int slice_k_start_shared_fetch = slice_k_start;
+  int slice_n_offset = act_s_col_tb_stride * slice_col;
+
+  // No act_order
+  int s_gl_rd;
+  if constexpr (!has_act_order) {
+    if constexpr (group_blocks == -1) {
+      s_gl_rd = s_sh_stride * slice_col + threadIdx.x;
+    } else if constexpr (group_blocks >= thread_k_blocks) {
+      s_gl_rd = s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) + s_sh_stride * slice_col + threadIdx.x;
+    } else {
+      s_gl_rd = s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks + threadIdx.x / s_sh_stride) +
+                s_sh_stride * slice_col + threadIdx.x % s_sh_stride;
+    }
+  }
+  auto s_sh_wr = threadIdx.x;
+  bool s_sh_wr_pred = threadIdx.x < s_sh_stage;
+
+  // Zero-points
+  int zp_gl_rd;
+  if constexpr (has_zp) {
+    if constexpr (group_blocks == -1) {
+      zp_gl_rd = zp_sh_stride * slice_col + threadIdx.x;
+    } else {
+      zp_gl_rd = zp_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) + zp_sh_stride * slice_col + threadIdx.x;
+    }
+  }
+  auto zp_sh_wr = threadIdx.x;
+  bool zp_sh_wr_pred = threadIdx.x < zp_sh_stride;
+
+  // We use a different scale layout for grouped and column-wise quantization as
+  // we scale a `half2` tile in column-major layout in the former and in
+  // row-major in the latter case.
+  int s_sh_rd;
+  if constexpr (group_blocks != -1)
+    s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) + (threadIdx.x % 32) / 4;
+  else if constexpr (group_blocks == -1 && (m_block_size_8 || (has_zp && !dequant_skip_flop)))
+    s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) + (threadIdx.x % 32) / 8;
+  else
+    s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) + (threadIdx.x % 32) % 4;
+
+  int bias_sh_rd;
+  if constexpr (m_block_size_8) {
+    bias_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) + (threadIdx.x % 32) / 8;
+  } else {
+    bias_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) + (threadIdx.x % 32) % 4;
+  }
+
+  int bias_sh_wr = threadIdx.x;
+  int bias_gl_rd = (thread_n_blocks * 16 / 8) * slice_col + threadIdx.x;
+
+  // Zero-points have the same read layout as the scales
+  // (without column-wise case)
+  constexpr int num_col_threads = 8;
+  constexpr int num_row_threads = 4;
+  constexpr int num_ints_per_thread = 8 / pack_factor;
+  int zp_sh_rd;
+  if constexpr (has_zp) {
+    if constexpr (is_zp_float) {
+      if constexpr (group_blocks != -1) {
+        zp_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) + (threadIdx.x % 32) / 4;
+      }
+    } else {
+      zp_sh_rd = num_ints_per_thread * num_col_threads * ((threadIdx.x / 32) % (thread_n_blocks / 4)) +
+                 num_ints_per_thread * ((threadIdx.x % 32) / num_row_threads);
+    }
+  }
+
+  // To ensure that writing and reading A tiles to/from shared memory, the
+  // latter in fragment format, is fully bank conflict free, we need to use a
+  // rather fancy XOR-based layout. The key here is that neither reads nor
+  // writes of the 16-byte `int4` blocks of 8 consecutive threads involve the
+  // same shared memory banks. Further, it seems (based on NSight-Compute) that
+  // each warp must also write a consecutive memory segment?
+  auto transform_a = [&](int i) {
+    int row = i / a_gl_rd_delta_o;
+    return a_gl_rd_delta_o * row + (i % a_gl_rd_delta_o) ^ (row % 8);
+  };
+  // Since the computation of this remapping is non-trivial and, due to our main
+  // loop unrolls, all shared memory accesses are static, we simply precompute
+  // both transformed reads and writes.
+  int a_sh_wr_trans[a_sh_wr_iters];
+#pragma unroll
+  for (int i = 0; i < a_sh_wr_iters; i++)
+    a_sh_wr_trans[i] = transform_a(a_sh_wr_delta * i + a_sh_wr);
+  int a_sh_rd_trans[b_sh_wr_iters][thread_m_blocks];
+#pragma unroll
+  for (int i = 0; i < b_sh_wr_iters; i++) {
+#pragma unroll
+    for (int j = 0; j < thread_m_blocks; j++)
+      a_sh_rd_trans[i][j] = transform_a(a_sh_rd_delta_o * i + a_sh_rd_delta_i * j + a_sh_rd);
+  }
+
+  // Since B-accesses have non-constant stride they have to be computed at
+  // runtime; we break dependencies between subsequent accesses with a tile by
+  // maintining multiple pointers (we have enough registers), a tiny
+  // optimization.
+  const int4* B_ptr[b_sh_wr_iters];
+#pragma unroll
+  for (int i = 0; i < b_sh_wr_iters; i++)
+    B_ptr[i] = B + b_gl_rd_delta_i * i + b_gl_rd;
+
+  // Shared memory storage for global fetch pipelines.
+  constexpr int sh_red_size = (2 * thread_n_blocks + 1) * 16 * thread_m_blocks;
+  constexpr int sh_b_size = stages * b_sh_stage;
+  int4* sh_b = sh_new;
+  int4* sh_red = sh_new;
+
+  constexpr int sh_size_b_red_min = (sh_red_size < sh_b_size ? sh_red_size : sh_b_size);
+  constexpr int sh_size_b_red_max = (sh_red_size > sh_b_size ? sh_red_size : sh_b_size);
+  constexpr int sh_bias_size = (thread_n_blocks * 16 / 8);
+  constexpr int sh_b_red_bias_size =
+      sh_size_b_red_max > (sh_size_b_red_min + sh_bias_size) ? sh_size_b_red_max : (sh_size_b_red_min + sh_bias_size);
+
+  int4* sh_bias = sh_new + sh_size_b_red_min;
+  int4* sh_g_idx = sh_new + sh_b_red_bias_size;
+  int4* sh_zp = sh_g_idx + (stages * g_idx_stage);
+  constexpr int sh_s_size = has_act_order ? (act_s_max_num_groups * s_sh_stride) : (stages * s_sh_stage);
+  int4* sh_s = sh_zp + (stages * zp_sh_stage);
+  // shared memory reused by reduction should be smaller than
+  // shared memory used by weight.
+  static_assert(thread_m_blocks * 16 * thread_n_blocks * 16 / 8 <= stages * b_sh_stage);
+  int4* sh_a = sh_s + sh_s_size;
+  constexpr int shm_size_used = moe_block_size + stages * (g_idx_stage + zp_sh_stage) + sh_s_size + sh_b_red_bias_size;
+
+  // all remaining shared memory is used to cache A (input)
+  // sh_a_max_row is at least ` stages * 16 * thread_m_blocks `
+  int sh_a_max_row = ((max_shared_mem - 1024) / 16 - shm_size_used) / (thread_k_blocks * 2);
+
+  // Register storage for double buffer of shared memory reads.
+  FragA frag_a[2][thread_m_blocks];
+  I4 frag_b_quant[2][b_thread_vecs];
+  FragC frag_c[thread_m_blocks][4][2];
+  FragS frag_s[2][4];  // No act-order
+  FragS frag_bias[2][4];
+  FragS act_frag_s[2][4][4];             // For act-order
+  int frag_qzp[2][num_ints_per_thread];  // Zero-points
+  FragZP frag_zp;                        // Zero-points in fp16
+  FragZP frag_zpf[2];                    // Zero-points in fp16 in HQQ
+
+  // Zero accumulators.
+  auto zero_accums = [&]() {
+#pragma unroll
+    for (int i = 0; i < thread_m_blocks * 4 * 2 * 4; i++)
+      reinterpret_cast<float*>(frag_c)[i] = 0;
+  };
+
+  int sh_first_group_id = -1;
+  int sh_num_groups = -1;
+
+  auto fetch_act_order_scales_to_shared = [&](bool is_async, int first_group_id, int last_group_id) {
+    sh_first_group_id = first_group_id;
+    sh_num_groups = last_group_id - first_group_id + 1;
+
+    if (sh_num_groups > act_s_max_num_groups) {
+      sh_num_groups = act_s_max_num_groups;
+    }
+
+    if (sh_first_group_id + sh_num_groups > num_groups) {
+      sh_num_groups = num_groups - sh_first_group_id;
+    }
+
+    int row_offset = first_group_id * s_gl_stride;
+
+    if (is_async) {
+      for (int i = 0; i < sh_num_groups; i++) {
+        if (threadIdx.x < s_sh_stride) {
+          cp_async4_pred(
+              &sh_s[(i * s_sh_stride) + threadIdx.x],
+              &scales_ptr[row_offset + (i * s_gl_stride) + slice_n_offset + threadIdx.x]);
+        }
+      }
+    } else {
+      for (int i = 0; i < sh_num_groups; i++) {
+        if (threadIdx.x < s_sh_stride) {
+          sh_s[(i * s_sh_stride) + threadIdx.x] =
+              scales_ptr[row_offset + (i * s_gl_stride) + slice_n_offset + threadIdx.x];
+        }
+      }
+    }
+  };
+
+  // Asynchronously fetch the next A, B and s tile from global to the next
+  // shared memory pipeline location.
+  bool should_load_a = true;
+  int max_num_stage_groups = ((sh_a_max_row - moe_block_size) / moe_block_size + 1) / stages;
+  max_num_stage_groups = max(max_num_stage_groups, 1);
+  auto fetch_to_shared = [&](int pipe, int a_off, bool pred = true, int pipe_a = 0) {
+    if (pred) {
+      if (should_load_a) {
+        int4* sh_a_stage = sh_a + moe_block_size * a_sh_stride * pipe_a;
+#pragma unroll
+        for (int i = 0; i < a_sh_wr_iters; i++) {
+          int row = a_gl_rd_delta_i / a_gl_stride * i + a_gl_rd_row;
+          int64_t sorted_row = 0;
+          if (!m_block_size_8 || row < 8) sorted_row = sh_rd_block_sorted_ids[row];
+          int64_t true_idx = sorted_row * a_gl_stride + a_gl_rd_col + a_gl_rd_delta_o * a_off;
+          cp_async4_pred(&sh_a_stage[a_sh_wr_trans[i]], &A[true_idx], row < block_num_valid_tokens);
+        }
+      }
+
+      int4* sh_b_stage = sh_b + b_sh_stage * pipe;
+#pragma unroll
+      for (int i = 0; i < b_sh_wr_iters; i++) {
+#pragma unroll
+        for (int j = 0; j < b_thread_vecs; j++) {
+          cp_async4(&sh_b_stage[b_sh_wr_delta * i + b_sh_wr + j], B_ptr[i] + j + B_expert_off);
+        }
+
+        B_ptr[i] += b_gl_rd_delta_o;
+      }
+
+      if constexpr (has_act_order) {
+        // Fetch g_idx thread-block portion
+        int full_pipe = a_off;
+        int cur_k = slice_k_start_shared_fetch + tb_k * full_pipe;
+        if (cur_k < prob_k && cur_k < slice_k_finish) {
+          int4* sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
+
+          int4 const* cur_g_idx_stage_ptr = reinterpret_cast<int4 const*>(&g_idx[cur_k]);
+
+          if (threadIdx.x < g_idx_stage) {
+            cp_async4_pred(&sh_g_idx_stage[threadIdx.x], &cur_g_idx_stage_ptr[threadIdx.x]);
+          }
+        }
+      } else {
+        if constexpr (group_blocks != -1) {
+          int4* sh_s_stage = sh_s + s_sh_stage * pipe;
+          if (pipe % div_ceil(group_blocks, thread_k_blocks) == 0) {
+            if (s_sh_wr_pred) {
+              cp_async4(&sh_s_stage[s_sh_wr], &scales_ptr[s_gl_rd]);
+            }
+            s_gl_rd += s_gl_rd_delta * s_tb_groups;
+          }
+        }
+
+        if constexpr (has_zp && group_blocks != -1) {
+          int4* sh_zp_stage = sh_zp + zp_sh_stage * pipe;
+          if (pipe % div_ceil(group_blocks, thread_k_blocks) == 0) {
+            if (zp_sh_wr_pred) {
+              cp_async4(&sh_zp_stage[zp_sh_wr], &zp_ptr[zp_gl_rd]);
+            }
+            zp_gl_rd += zp_gl_rd_delta * zp_tb_groups;
+          }
+        }
+      }
+    }
+    // Insert a fence even when we are winding down the pipeline to ensure that
+    // waiting is also correct at this point.
+    cp_async_fence();
+  };
+
+  auto fetch_col_zp_to_shared = [&]() {
+    if (zp_sh_wr_pred) {
+      cp_async4(&sh_zp[zp_sh_wr], &zp_ptr[zp_gl_rd]);
+    }
+  };
+
+  auto fetch_col_scale_to_shared = [&]() {
+    if (s_sh_wr_pred) {
+      cp_async4(&sh_s[s_sh_wr], &scales_ptr[s_gl_rd]);
+    }
+  };
+
+  // Wait until the next thread tile has been loaded to shared memory.
+  auto wait_for_stage = [&]() {
+    // We only have `stages - 2` active fetches since we are double buffering
+    // and can only issue the next fetch when it is guaranteed that the previous
+    // shared memory load is fully complete (as it may otherwise be
+    // overwritten).
+    cp_async_wait<stages - 2>();
+    __syncthreads();
+  };
+
+  // Load the next sub-tile from the current location in the shared memory pipe
+  // into the current register buffer.
+  auto fetch_to_registers = [&](int k, int pipe, int pipe_a = 0) {
+    int4* sh_a_stage = sh_a + moe_block_size * a_sh_stride * pipe_a;
+#pragma unroll
+    for (int i = 0; i < thread_m_blocks; i++)
+      ldsm<m_block_size_8 ? 2 : 4, scalar_t>(frag_a[k % 2][i], &sh_a_stage[a_sh_rd_trans[k % b_sh_wr_iters][i]]);
+    int4* sh_b_stage = sh_b + b_sh_stage * pipe;
+
+#pragma unroll
+    for (int i = 0; i < b_thread_vecs; i++) {
+      frag_b_quant[k % 2][i] = *reinterpret_cast<I4*>(&sh_b_stage[b_sh_rd_delta * (k % b_sh_wr_iters) + b_sh_rd + i]);
+    }
+  };
+
+  bool is_same_group[stages];
+  int same_group_id[stages];
+
+  auto init_same_group = [&](int pipe) {
+    if constexpr (!has_act_order) {
+      return;
+    }
+
+    int4* sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
+    int* sh_g_idx_int_ptr = reinterpret_cast<int*>(sh_g_idx_stage);
+
+    int group_id_1 = sh_g_idx_int_ptr[0];
+    int group_id_2 = sh_g_idx_int_ptr[tb_k - 1];
+
+    is_same_group[pipe] = group_id_1 == group_id_2;
+    same_group_id[pipe] = group_id_1;
+  };
+
+  auto fetch_scales_to_registers = [&](int k, int full_pipe) {
+    int pipe = full_pipe % stages;
+
+    if constexpr (!has_act_order) {
+      // No act-order case
+      if constexpr (group_blocks == -1) {
+        // load only when starting a new slice
+        if (k == 0 && full_pipe == 0) {
+          reinterpret_cast<int4*>(&frag_s)[0] = sh_s[s_sh_rd];
+          reinterpret_cast<int4*>(&frag_s)[1] = sh_s[s_sh_rd + 4];
+        }
+      } else if constexpr (group_blocks != -1) {
+        if constexpr (group_blocks >= thread_k_blocks) {
+          constexpr int g = group_blocks / thread_k_blocks;
+          if (pipe % g == 0) {
+            if (k % b_sh_wr_iters == 0) {
+              int4* sh_s_stage = sh_s + s_sh_stage * (g * (pipe / g));
+              reinterpret_cast<int4*>(&frag_s[k % 2])[0] = sh_s_stage[s_sh_rd];
+            } else {
+              reinterpret_cast<int4*>(&frag_s[1])[0] = reinterpret_cast<int4*>(&frag_s[0])[0];
+            }
+          }
+        } else {
+          auto warp_id = threadIdx.x / 32;
+          int n_warps = thread_n_blocks / 4;
+
+          int warp_row = warp_id / n_warps;
+          int cur_k = warp_row * 16;
+          cur_k += k_iter_size * (k % b_sh_wr_iters);
+          int k_blocks = cur_k / 16;
+          int cur_group_id = k_blocks / group_blocks;
+
+          int4* sh_s_stage = sh_s + s_sh_stage * pipe;
+
+          if constexpr (!is_8bit_scale) {
+            reinterpret_cast<int4*>(&frag_s[k % 2])[0] = sh_s_stage[s_sh_rd + cur_group_id * s_sh_stride];
+          } else {
+            reinterpret_cast<int2*>(&frag_s[k % 2])[0] =
+                reinterpret_cast<int2*>(sh_s_stage)[s_sh_rd + cur_group_id * (2 * s_sh_stride)];
+          }
+        }
+      }
+
+      return;
+    }
+
+    // Act-order case
+
+    // Determine K of the "current" thread-block
+    int cur_k = slice_k_start + tb_k * full_pipe;
+    if (cur_k >= prob_k || cur_k >= slice_k_finish) {
+      return;
+    }
+
+    // Reset (to current thread-block) since we read g_idx portion from the
+    // shared memory
+    cur_k = 0;
+
+    // Progress to current iteration
+    cur_k += k_iter_size * (k % b_sh_wr_iters);
+
+    // Determine "position" inside the thread-block (based on warp and
+    // thread-id)
+    auto warp_id = threadIdx.x / 32;
+    int n_warps = thread_n_blocks / 4;  // Each warp processes 4 16-size tiles over N
+
+    int warp_row = warp_id / n_warps;
+    int warp_col = warp_id % n_warps;
+
+    cur_k += warp_row * 16;
+
+    auto th_id = threadIdx.x % 32;
+    cur_k += (th_id % 4) * 2;  // Due to tensor-core layout for fp16 B matrix
+
+    int s_col_shift =
+        /*slice_n_offset +*/ (act_s_col_warp_stride * warp_col) + (th_id / 4) * act_s_col_stride;
+
+    if (is_same_group[pipe]) {
+      if (k % 2 == 0) {
+        *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][0][0]))) =
+            sh_s[(same_group_id[pipe] - sh_first_group_id) * s_sh_stride + s_col_shift];
+      } else {
+        *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][0][0]))) =
+            *(reinterpret_cast<int4*>(&(act_frag_s[(k - 1) % 2][0][0])));
+      }
+
+      for (int i = 1; i < 4; i++) {
+        *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][i][0]))) = *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][0][0])));
+      }
+      return;
+    }
+
+    int4* sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
+    int* sh_g_idx_int_ptr = reinterpret_cast<int*>(sh_g_idx_stage);
+
+    constexpr int k_frag_offsets[4] = {0, 1, 8, 9};  // Tensor core offsets per thread
+
+#pragma unroll
+    for (int i = 0; i < 4; i++) {
+      int actual_k = cur_k + k_frag_offsets[i];
+
+      int group_id = sh_g_idx_int_ptr[actual_k];
+      int rel_group_id = group_id - sh_first_group_id;
+
+      *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][i][0]))) = sh_s[rel_group_id * s_sh_stride + s_col_shift];
+    }
+  };
+
+  auto fetch_zp_to_registers = [&](int k, int full_pipe) {
+    // This code does not handle group_blocks == 0,
+    // which signifies act_order.
+    // has_zp implies AWQ, which doesn't have act_order,
+    static_assert(!has_zp || group_blocks != 0);
+
+    if constexpr (has_zp && !is_zp_float) {
+      int pipe = full_pipe % stages;
+
+      if constexpr (group_blocks == -1) {
+        // load only when starting a new slice
+        if (k == 0 && full_pipe == 0) {
+#pragma unroll
+          for (int i = 0; i < num_ints_per_thread; i++) {
+            frag_qzp[k % 2][i] = (reinterpret_cast<int*>(sh_zp))[zp_sh_rd + i];
+          }
+        }
+
+      } else if constexpr (group_blocks >= thread_k_blocks) {
+        if (k % b_sh_wr_iters == 0) {
+          int4* sh_zp_stage =
+              sh_zp + zp_sh_stage * ((group_blocks / thread_k_blocks) * (pipe / (group_blocks / thread_k_blocks)));
+#pragma unroll
+          for (int i = 0; i < num_ints_per_thread; i++) {
+            frag_qzp[k % 2][i] = (reinterpret_cast<int*>(sh_zp_stage))[zp_sh_rd + i];
+          }
+        }
+      } else {
+        auto warp_id = threadIdx.x / 32;
+        int n_warps = thread_n_blocks / 4;
+
+        int warp_row = warp_id / n_warps;
+
+        int cur_k = warp_row * 16;
+        cur_k += k_iter_size * (k % b_sh_wr_iters);
+
+        int k_blocks = cur_k / 16;
+        int cur_group_id = 0;
+
+        // Suppress bogus and persistent divide-by-zero warning
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress divide_by_zero
+        cur_group_id = k_blocks / group_blocks;
+#pragma nv_diagnostic pop
+
+        int4* sh_zp_stage = sh_zp + zp_sh_stage * pipe;
+
+        sh_zp_stage += cur_group_id * zp_sh_stride;
+
+#pragma unroll
+        for (int i = 0; i < num_ints_per_thread; i++) {
+          frag_qzp[k % 2][i] = (reinterpret_cast<int*>(sh_zp_stage))[zp_sh_rd + i];
+        }
+      }
+    }
+
+    else if constexpr (has_zp && is_zp_float) {
+      int pipe = full_pipe % stages;
+
+      if constexpr (group_blocks != -1) {
+        if constexpr (group_blocks >= thread_k_blocks) {
+          if (k % b_sh_wr_iters == 0) {
+            int4* sh_zp_stage =
+                sh_zp + zp_sh_stage * ((group_blocks / thread_k_blocks) * (pipe / (group_blocks / thread_k_blocks)));
+            reinterpret_cast<int4*>(&frag_zpf[k % 2])[0] = sh_zp_stage[zp_sh_rd];
+          }
+        } else {
+          auto warp_id = threadIdx.x / 32;
+          int n_warps = thread_n_blocks / 4;
+
+          int warp_row = warp_id / n_warps;
+
+          int cur_k = warp_row * 16;
+          cur_k += k_iter_size * (k % b_sh_wr_iters);
+
+          int k_blocks = cur_k / 16;
+          // Suppress bogus and persistent divide-by-zero warning
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress divide_by_zero
+          int cur_group_id = k_blocks / group_blocks;
+#pragma nv_diagnostic pop
+
+          int4* sh_zp_stage = sh_zp + zp_sh_stage * pipe;
+
+          reinterpret_cast<int4*>(&frag_zpf[k % 2])[0] = sh_zp_stage[zp_sh_rd + cur_group_id * zp_sh_stride];
+        }
+      }
+    }
+  };
+
+  auto dequant_data = [&](int q, scalar_t2* frag_b_ptr) {
+    dequant<scalar_t2, w_type_id, dequant_skip_flop>(q, frag_b_ptr);
+  };
+
+  // Execute the actual tensor core matmul of a sub-tile.
+  bool is_first_matmul_in_slice = true;
+  auto matmul = [&](int k) {
+    int k2 = k % 2;
+    const bool is_new_zp = ((group_blocks != -1) && (group_blocks < thread_k_blocks || k == 0)) ||
+                           (group_blocks == -1 && is_first_matmul_in_slice);
+    if constexpr (has_zp && !is_zp_float) {
+      if (is_new_zp) {
+        if constexpr (group_blocks == -1) is_first_matmul_in_slice = false;
+        int zp_quant_0, zp_quant_1;
+
+        if constexpr (w_type.size_bits() == 4) {
+          zp_quant_0 = frag_qzp[k2][0];
+          zp_quant_1 = zp_quant_0 >> 8;
+        } else {
+          static_assert(w_type.size_bits() == 8);
+          zp_quant_0 = frag_qzp[k2][0];
+          zp_quant_1 = frag_qzp[k2][1];
+        }
+
+        dequant_data(zp_quant_0, reinterpret_cast<scalar_t2*>(&frag_zp));
+        dequant_data(zp_quant_1, reinterpret_cast<scalar_t2*>(&frag_zp) + 2);
+      }
+    }
+    if constexpr (!dequant_skip_flop && has_zp && is_zp_float) {
+      if (is_new_zp) {
+        reinterpret_cast<int4*>(&frag_zp)[0] = reinterpret_cast<int4*>(&frag_zpf[k2])[0];
+      }
+    }
+
+    // FP4/FP8 scale dequantization (E4M3 for NVFP4 and E8M0 for MXFP4).
+    if constexpr (
+        (s_type == host::kFE4M3fn || s_type == host::kFE8M0fnu) &&
+        !(std::is_same<scalar_t2, half2>::value && s_type == host::kFE8M0fnu)) {
+      int s_quant_0 = reinterpret_cast<int*>(frag_s[k2])[0];
+      int s_quant_1 = reinterpret_cast<int*>(frag_s[k2])[1];
+
+      dequant_fp8_scales<scalar_t2, s_type_id>(s_quant_0, reinterpret_cast<scalar_t2*>(&frag_s[k2]));
+      dequant_fp8_scales<scalar_t2, s_type_id>(s_quant_1, reinterpret_cast<scalar_t2*>(&frag_s[k2]) + 2);
+    }
+
+// We have the m dimension as the inner loop in order to encourage overlapping
+// dequantization and matmul operations.
+#pragma unroll
+    for (int j = 0; j < 4; j++) {
+      FragB frag_b0;
+      FragB frag_b1;
+      int b_quant_0, b_quant_1;
+
+      if constexpr (w_type_id == host::kFE2M1f.id()) {
+        b_quant_1 = frag_b_quant[k2][0][j];
+        b_quant_0 = b_quant_1 << 8;
+      } else if constexpr (w_type.size_bits() == 4) {
+        b_quant_0 = frag_b_quant[k2][0][j];
+        b_quant_1 = b_quant_0 >> 8;
+      } else {
+        static_assert(w_type.size_bits() == 8);
+        int* frag_b_quant_ptr = reinterpret_cast<int*>(frag_b_quant[k2]);
+        b_quant_0 = frag_b_quant_ptr[j * 2 + 0];
+        b_quant_1 = frag_b_quant_ptr[j * 2 + 1];
+      }
+
+      dequant_data(b_quant_0, reinterpret_cast<scalar_t2*>(&frag_b0));
+      dequant_data(b_quant_1, reinterpret_cast<scalar_t2*>(&frag_b1));
+
+      if constexpr (dequant_skip_flop && has_zp && !is_zp_float) {
+        sub_zp<scalar_t>(frag_b0, frag_zp[j], 0);
+        sub_zp<scalar_t>(frag_b1, frag_zp[j], 1);
+      }
+
+      // Apply scale to frag_b0
+      if constexpr (has_act_order) {
+        static_assert(group_blocks != -1);
+        scale4<scalar_t>(
+            frag_b0, act_frag_s[k2][0][j], act_frag_s[k2][1][j], act_frag_s[k2][2][j], act_frag_s[k2][3][j], 0);
+        scale4<scalar_t>(
+            frag_b1, act_frag_s[k2][0][j], act_frag_s[k2][1][j], act_frag_s[k2][2][j], act_frag_s[k2][3][j], 1);
+      } else if constexpr (!dequant_skip_flop && has_zp && !is_zp_float && group_blocks == -1) {
+        int idx = (threadIdx.x / 4) % 2;
+        scalar_t2 s2 = Dtype::nums2num2(
+            reinterpret_cast<scalar_t*>(&frag_s[j / 2][j % 2 * 2 + 0])[idx],
+            reinterpret_cast<scalar_t*>(&frag_s[j / 2][j % 2 * 2 + 1])[idx]);
+        if (is_new_zp) frag_zp[j] = __hmul2(frag_zp[j], s2);
+        scale_and_sub<scalar_t>(frag_b0, s2.x, frag_zp[j].x);
+        scale_and_sub<scalar_t>(frag_b1, s2.y, frag_zp[j].y);
+      } else if constexpr (!dequant_skip_flop && has_zp && group_blocks != -1) {
+        if (is_new_zp) frag_zp[j] = __hmul2(frag_zp[j], *reinterpret_cast<scalar_t2*>(&frag_s[k2][j]));
+        scale_and_sub<scalar_t>(frag_b0, frag_s[k2][j][0].x, frag_zp[j].x);
+        scale_and_sub<scalar_t>(frag_b1, frag_s[k2][j][0].y, frag_zp[j].y);
+      } else if constexpr (group_blocks != -1) {
+        scale<scalar_t>(frag_b0, frag_s[k2][j], 0);
+        scale<scalar_t>(frag_b1, frag_s[k2][j], 1);
+      }
+
+#pragma unroll
+      for (int i = 0; i < thread_m_blocks; i++) {
+        if constexpr (m_block_size_8) {
+          mma_trans<scalar_t>(frag_a[k2][i], frag_b0, frag_b1, frag_c[i][j][0]);
+        } else {
+          mma<scalar_t>(frag_a[k2][i], frag_b0, frag_c[i][j][0]);
+          mma<scalar_t>(frag_a[k2][i], frag_b1, frag_c[i][j][1]);
+        }
+      }
+    }
+  };
+
+  // Since we slice across the k dimension of a tile in order to increase the
+  // number of warps while keeping the n dimension of a tile reasonable, we have
+  // multiple warps that accumulate their partial sums of the same output
+  // location; which we have to reduce over in the end. We do in shared memory.
+  auto thread_block_reduce = [&]() {
+    constexpr int red_off = threads / b_sh_stride_threads / 2;
+    if (red_off >= 1) {
+      auto red_idx = threadIdx.x / b_sh_stride_threads;
+      constexpr int red_sh_stride = b_sh_stride_threads * 4 * 2;
+      constexpr int red_sh_delta = b_sh_stride_threads;
+      int red_sh_rd = red_sh_stride * (threadIdx.x / b_sh_stride_threads) + (threadIdx.x % b_sh_stride_threads);
+
+      // Parallel logarithmic shared memory reduction. We make sure to avoid any
+      // unnecessary read or write iterations, e.g., for two warps we write only
+      // once by warp 1 and read only once by warp 0.
+
+#pragma unroll
+      for (int m_block = 0; m_block < thread_m_blocks; m_block++) {
+#pragma unroll
+        for (int i = red_off; i > 0; i /= 2) {
+          if (i <= red_idx && red_idx < 2 * i) {
+#pragma unroll
+            for (int j = 0; j < 4 * 2; j += (m_block_size_8 ? 2 : 1)) {
+              int red_sh_wr = red_sh_delta * j + (red_sh_rd - red_sh_stride * i);
+              if (i < red_off) {
+                float* c_rd = reinterpret_cast<float*>(&sh_red[red_sh_delta * j + red_sh_rd]);
+                float* c_wr = reinterpret_cast<float*>(&sh_red[red_sh_wr]);
+#pragma unroll
+                for (int k = 0; k < 4; k++)
+                  reinterpret_cast<FragC*>(frag_c)[4 * 2 * m_block + j][k] += c_rd[k] + c_wr[k];
+              }
+              sh_red[red_sh_wr] = reinterpret_cast<int4*>(&frag_c)[4 * 2 * m_block + j];
+            }
+          }
+          __syncthreads();
+        }
+        if (red_idx == 0) {
+#pragma unroll
+          for (int i = 0; i < 4 * 2; i += (m_block_size_8 ? 2 : 1)) {
+            float* c_rd = reinterpret_cast<float*>(&sh_red[red_sh_delta * i + red_sh_rd]);
+#pragma unroll
+            for (int j = 0; j < 4; j++)
+              reinterpret_cast<FragC*>(frag_c)[4 * 2 * m_block + i][j] += c_rd[j];
+          }
+        }
+        __syncthreads();
+      }
+    }
+  };
+
+  // Since multiple threadblocks may process parts of the same column slice, we
+  // finally have to globally reduce over the results. As the striped
+  // partitioning minimizes the number of such reductions and our outputs are
+  // usually rather small, we perform this reduction serially in L2 cache.
+  auto global_reduce_fp16 = [&](bool first = false, bool last = false) {
+    // We are very careful here to reduce directly in the output buffer to
+    // maximize L2 cache utilization in this step. To do this, we write out
+    // results in FP16 (but still reduce with FP32 compute).
+    constexpr int active_threads = 32 * thread_n_blocks / 4;
+    bool is_th_active = threadIdx.x < active_threads;
+    if (!is_th_active) {
+      return;
+    }
+
+    int c_gl_stride = prob_n / 8;
+    int c_gl_wr_delta_o = 8 * c_gl_stride;
+    int c_gl_wr_delta_i = 4 * (active_threads / 32);
+    int c_gl_wr;
+    if constexpr (m_block_size_8) {
+      c_gl_wr = c_gl_stride * ((threadIdx.x % 4) * 2) + 4 * (threadIdx.x / 32) + (threadIdx.x % 32) / 8;
+      c_gl_wr += (2 * thread_n_blocks) * slice_col;
+    } else {
+      c_gl_wr = c_gl_stride * ((threadIdx.x % 32) / 4) + 4 * (threadIdx.x / 32) + threadIdx.x % 4;
+      c_gl_wr += (2 * thread_n_blocks) * slice_col;
+    }
+    constexpr int c_sh_wr_delta = active_threads;
+    int c_sh_wr = threadIdx.x;
+
+    if (!first) {
+
+#pragma unroll
+      for (int i = 0; i < (m_block_size_8 ? 2 : thread_m_blocks * 4); i++) {
+        int c_idx;
+        if constexpr (m_block_size_8)
+          c_idx = c_gl_wr + i * c_gl_stride + (threadIdx.x % 8) / 4 * c_gl_wr_delta_i;
+        else
+          c_idx = c_gl_wr + c_gl_wr_delta_o * (i / 2) + c_gl_wr_delta_i * (i % 2);
+        if (c_idx / c_gl_stride < block_num_valid_tokens) {
+          int64_t sorted_row = sh_block_sorted_ids[c_idx / c_gl_stride];
+          int64_t true_idx = sorted_row * c_gl_stride + c_idx % c_gl_stride;
+          sh_red[c_sh_wr + c_sh_wr_delta * i] = C[true_idx];
+        }
+      }
+    }
+
+#pragma unroll
+    for (int i = 0; i < (m_block_size_8 ? 2 : thread_m_blocks * 4); i++) {
+      if (!first) {
+        int4 c_red = sh_red[c_sh_wr + i * c_sh_wr_delta];
+#pragma unroll
+        for (int j = 0; j < 2 * 4; j++) {
+          int delta = 0;
+          if constexpr (m_block_size_8) {
+            delta = j % 2 == 1 ? -2 : 0;
+          }
+          reinterpret_cast<float*>(&frag_c)[4 * 2 * 4 * (i / 4) + 4 * j + (i % 4) + delta] +=
+              Dtype::num2float(reinterpret_cast<scalar_t*>(&c_red)[j]);
+        }
+      }
+      if (!last) {
+        int4 c;
+#pragma unroll
+        for (int j = 0; j < 2 * 4; j++) {
+          int delta = 0;
+          if constexpr (m_block_size_8) {
+            delta = j % 2 == 1 ? -2 : 0;
+          }
+          reinterpret_cast<scalar_t*>(&c)[j] =
+              Dtype::float2num(reinterpret_cast<float*>(&frag_c)[4 * 2 * 4 * (i / 4) + 4 * j + (i % 4) + delta]);
+        }
+
+        int c_idx;
+        if constexpr (m_block_size_8)
+          c_idx = c_gl_wr + i * c_gl_stride + (threadIdx.x % 8) / 4 * c_gl_wr_delta_i;
+        else
+          c_idx = c_gl_wr + c_gl_wr_delta_o * (i / 2) + c_gl_wr_delta_i * (i % 2);
+        if (c_idx / c_gl_stride < block_num_valid_tokens) {
+          int64_t sorted_row = sh_block_sorted_ids[c_idx / c_gl_stride];
+          int64_t true_idx = sorted_row * c_gl_stride + c_idx % c_gl_stride;
+          C[true_idx] = c;
+        }
+      }
+    }
+  };
+
+  // Globally reduce over threadblocks that compute the same column block.
+  // We use a tmp C buffer to reduce in full fp32 precision.
+  auto global_reduce_fp32 = [&](bool first = false, bool last = false) {
+    constexpr int tb_m = thread_m_blocks * 16;
+    constexpr int tb_n = thread_n_blocks * 16;
+
+    constexpr int c_size = tb_m * tb_n * sizeof(float) / 16;
+
+    constexpr int active_threads = 32 * thread_n_blocks / 4;
+    bool is_th_active = threadIdx.x < active_threads;
+
+    constexpr int num_floats = thread_m_blocks * 4 * 2 * 4;
+    constexpr int th_size = num_floats * sizeof(float) / 16;
+
+    int c_cur_offset = locks_off * c_size;
+
+    if (!is_th_active) {
+      return;
+    }
+
+    if (!first) {
+      float* frag_c_ptr = reinterpret_cast<float*>(&frag_c);
+#pragma unroll
+      for (int k = 0; k < th_size; k++) {
+        if constexpr (m_block_size_8) {
+          if (k % 2) continue;
+        } else {
+          if (k / 8 * 16 + (threadIdx.x % 32) / 4 >= block_num_valid_tokens) continue;
+        }
+
+        sh_red[threadIdx.x] = C_tmp[c_cur_offset + active_threads * k + threadIdx.x];
+
+        float* sh_c_ptr = reinterpret_cast<float*>(&sh_red[threadIdx.x]);
+#pragma unroll
+        for (int f = 0; f < 4; f++) {
+          frag_c_ptr[k * 4 + f] += sh_c_ptr[f];
+        }
+      }
+    }
+
+    if (!last) {
+      int4* frag_c_ptr = reinterpret_cast<int4*>(&frag_c);
+#pragma unroll
+      for (int k = 0; k < th_size; k++) {
+        if constexpr (m_block_size_8) {
+          if (k % 2) continue;
+        } else {
+          if (k / 8 * 16 + (threadIdx.x % 32) / 4 >= block_num_valid_tokens) continue;
+        }
+
+        C_tmp[c_cur_offset + active_threads * k + threadIdx.x] = frag_c_ptr[k];
+      }
+    }
+  };
+
+  // Write out the reduce final result in the correct layout. We only actually
+  // reshuffle matrix fragments in this step, the reduction above is performed
+  // in fragment layout.
+  auto write_result = [&](bool last) {
+    int c_gl_stride = prob_n / 8;
+    constexpr int c_sh_stride = 2 * thread_n_blocks + 1;
+    int c_gl_wr_delta = c_gl_stride * (threads / (2 * thread_n_blocks));
+    constexpr int c_sh_rd_delta = c_sh_stride * (threads / (2 * thread_n_blocks));
+
+    int c_gl_wr = c_gl_stride * (threadIdx.x / (2 * thread_n_blocks)) + (threadIdx.x % (2 * thread_n_blocks));
+    c_gl_wr += (2 * thread_n_blocks) * slice_col;
+    int c_sh_wr;
+    if constexpr (m_block_size_8) {
+      c_sh_wr = (8 * c_sh_stride) * ((threadIdx.x % 32) % 4 * 2) + (threadIdx.x % 32) / 4;
+      c_sh_wr += 64 * (threadIdx.x / 32);
+    } else {
+      c_sh_wr = (4 * c_sh_stride) * ((threadIdx.x % 32) / 4) + (threadIdx.x % 32) % 4;
+      c_sh_wr += 32 * (threadIdx.x / 32);
+    }
+
+    int c_sh_rd = c_sh_stride * (threadIdx.x / (2 * thread_n_blocks)) + (threadIdx.x % (2 * thread_n_blocks));
+
+    // We first reorder in shared memory to guarantee the most efficient final
+    // global write patterns
+    auto write = [&](int idx, float c0, float c1, FragS& s, FragS& b_bias) {
+      scalar_t2 res = Dtype::nums2num2(Dtype::float2num(c0), Dtype::float2num(c1));
+
+      // For per-column quantization we finally apply the scale here (only for
+      // 4-bit)
+      if constexpr (
+          !has_act_order && group_blocks == -1 && w_type.size_bits() == 4 && (has_zp && dequant_skip_flop || !has_zp)) {
+        scalar_t2 tmp_scale = s[0];
+        if constexpr (m_block_size_8) {
+          tmp_scale = Dtype::num2num2(reinterpret_cast<scalar_t*>(&s[0])[(threadIdx.x % 8) / 4]);
+        }
+        res = __hmul2(res, tmp_scale);
+      }
+
+      if constexpr (w_type == host::kFE2M1f && s_type == host::kFE4M3fn) {
+        if (!mul_topk_weights) {
+          res = __hmul2(res, global_scale);
+        }
+      }
+      if constexpr (kHasBias) {
+        if (last) {
+          scalar_t2 tmp_bias = b_bias[0];
+          if constexpr (m_block_size_8) {
+            tmp_bias = Dtype::num2num2(reinterpret_cast<scalar_t*>(&b_bias[0])[(threadIdx.x % 8) / 4]);
+          }
+          res = __hadd2(res, tmp_bias);
+        }
+      }
+
+      if constexpr (m_block_size_8) {
+        ((scalar_t*)sh_red)[idx] = res.x;
+        ((scalar_t*)sh_red)[idx + 8 * c_sh_stride] = res.y;
+      } else {
+        ((scalar_t2*)sh_red)[idx] = res;
+      }
+    };
+
+    if (threadIdx.x / 32 < thread_n_blocks / 4) {
+#pragma unroll
+      for (int i = 0; i < thread_m_blocks; i++) {
+#pragma unroll
+        for (int j = 0; j < 4; j++) {
+          if constexpr (m_block_size_8) {
+            int wr = c_sh_wr + 16 * j;
+            write(
+                wr,
+                frag_c[i][j][0][0],
+                frag_c[i][j][0][1],
+                frag_s[j / 2][2 * (j % 2) + 0],
+                frag_bias[j / 2][2 * (j % 2) + 0]);
+            write(
+                wr + 8,
+                frag_c[i][j][0][2],
+                frag_c[i][j][0][3],
+                frag_s[j / 2][2 * (j % 2) + 1],
+                frag_bias[j / 2][2 * (j % 2) + 1]);
+          } else {
+            int wr = c_sh_wr + 8 * j;
+            write(
+                wr + (4 * c_sh_stride) * 0 + 0,
+                frag_c[i][j][0][0],
+                frag_c[i][j][0][1],
+                frag_s[j / 2][2 * (j % 2) + 0],
+                frag_bias[j / 2][2 * (j % 2) + 0]);
+            write(
+                wr + (4 * c_sh_stride) * 8 + 0,
+                frag_c[i][j][0][2],
+                frag_c[i][j][0][3],
+                frag_s[j / 2][2 * (j % 2) + 0],
+                frag_bias[j / 2][2 * (j % 2) + 0]);
+            write(
+                wr + (4 * c_sh_stride) * 0 + 4,
+                frag_c[i][j][1][0],
+                frag_c[i][j][1][1],
+                frag_s[j / 2][2 * (j % 2) + 1],
+                frag_bias[j / 2][2 * (j % 2) + 1]);
+            write(
+                wr + (4 * c_sh_stride) * 8 + 4,
+                frag_c[i][j][1][2],
+                frag_c[i][j][1][3],
+                frag_s[j / 2][2 * (j % 2) + 1],
+                frag_bias[j / 2][2 * (j % 2) + 1]);
+          }
+        }
+        c_sh_wr += 16 * (4 * c_sh_stride);
+      }
+    }
+    __syncthreads();
+
+#pragma unroll
+    for (int i = 0; i < div_ceil(16 * thread_m_blocks, threads / (2 * thread_n_blocks)); i++) {
+      int row = c_gl_wr / c_gl_stride;
+      if (row < block_num_valid_tokens) {
+        int64_t sorted_row = sh_block_sorted_ids[row];
+        int64_t true_idx = sorted_row * c_gl_stride + c_gl_wr % c_gl_stride;
+        scalar_t2 topk_weight_score;
+        if (mul_topk_weights) topk_weight_score = sh_block_topk_weights[row];
+        if (use_atomic_add && slice_count > 1 || mul_topk_weights) {
+          scalar_t2* C_half2 = reinterpret_cast<scalar_t2*>(&C[true_idx]);
+          scalar_t2* sh_red_half2 = reinterpret_cast<scalar_t2*>(&sh_red[c_sh_rd]);
+#pragma unroll
+          for (int a = 0; a < 4; a++) {
+            scalar_t2 res = sh_red_half2[a];
+            if (mul_topk_weights) {
+              res = __hmul2(res, topk_weight_score);
+            }
+
+            if (use_atomic_add && slice_count > 1) {
+              atomicAdd(&C_half2[a], res);
+            } else {
+              C_half2[a] = res;
+            };
+          }
+        } else {
+          C[true_idx] = sh_red[c_sh_rd];
+        }
+        c_gl_wr += c_gl_wr_delta;
+        c_sh_rd += c_sh_rd_delta;
+      }
+    }
+    __syncthreads();
+  };
+
+  // Start global fetch and register load pipelines.
+  auto start_pipes = [&]() {
+
+#pragma unroll
+    for (int i = 0; i < stages - 1; i++) {
+      if (has_act_order && i == 0) {
+        int last_g_idx = slice_k_start + stages * tb_k * 2;
+        if (last_g_idx >= prob_k) {
+          last_g_idx = prob_k - 1;
+        }
+        fetch_act_order_scales_to_shared(true, g_idx[slice_k_start], g_idx[last_g_idx]);
+      }
+
+      if constexpr (has_zp && !is_zp_float && group_blocks == -1) {
+        if (i == 0) {
+          fetch_col_zp_to_shared();
+          if constexpr (!dequant_skip_flop) {
+            fetch_col_scale_to_shared();
+          }
+        }
+      }
+      fetch_to_shared(i, i, i < slice_iters, i);
+    }
+
+    zero_accums();
+    wait_for_stage();
+    init_same_group(0);
+    fetch_to_registers(0, 0);
+    fetch_scales_to_registers(0, 0);
+    fetch_zp_to_registers(0, 0);
+    a_gl_rd_col += a_gl_rd_delta_o * (stages - 1);
+    if constexpr (has_act_order) {
+      slice_k_start_shared_fetch += tb_k * (stages - 1);
+    }
+  };
+  if (slice_iters) {
+    start_pipes();
+  }
+
+  // Main loop.
+  while (slice_iters) {
+    // We unroll over both the global fetch and the register load pipeline to
+    // ensure all shared memory accesses are static. Note that both pipelines
+    // have even length meaning that the next iteration will always start at
+    // index 0.
+
+    for (int stage_group_id = 0; stage_group_id < max_num_stage_groups; stage_group_id++) {
+#pragma unroll
+      for (int pipe = 0; pipe < stages;) {
+#pragma unroll
+        for (int k = 0; k < b_sh_wr_iters; k++) {
+          int idx = (pipe >= stages && stage_group_id == max_num_stage_groups - 1) ? (pipe - stages)
+                                                                                   : (pipe + stage_group_id * stages);
+          fetch_to_registers(k + 1, pipe % stages, idx);
+          fetch_scales_to_registers(k + 1, pipe);
+          fetch_zp_to_registers(k + 1, pipe);
+          if (k == b_sh_wr_iters - 2) {
+            int idx = (pipe >= 1 && stage_group_id == max_num_stage_groups - 1)
+                          ? (pipe - 1)
+                          : (pipe + (stage_group_id + 1) * stages - 1);
+            fetch_to_shared((pipe + stages - 1) % stages, pipe, slice_iters >= stages, idx);
+            pipe++;
+            wait_for_stage();
+            init_same_group(pipe % stages);
+          }
+          matmul(k);
+        }
+        slice_iters--;
+        if (slice_iters == 0) {
+          break;
+        }
+      }
+
+      a_gl_rd_col += a_gl_rd_delta_o * stages;
+
+      if constexpr (has_act_order) {
+        slice_k_start += tb_k * stages;
+
+        if (slice_k_start < prob_k) {
+          slice_k_start_shared_fetch += tb_k * stages;
+          int first_group_id = g_idx[slice_k_start];
+          int last_g_idx = slice_k_start + stages * tb_k * 2;
+          if (last_g_idx >= prob_k) {
+            last_g_idx = prob_k - 1;
+          }
+          int last_group_id = g_idx[last_g_idx];
+          if (last_group_id >= sh_first_group_id + sh_num_groups) {
+            fetch_act_order_scales_to_shared(false, first_group_id, last_group_id);
+            __syncthreads();
+          }
+        }
+      }
+      if (slice_iters == 0) {
+        break;
+      }
+    }
+
+    // Process results and, if necessary, proceed to the next column slice.
+    // While this pattern may not be the most readable, other ways of writing
+    // the loop seemed to noticeably worse performance after compilation.
+    if (slice_iters == 0) {
+      cp_async_wait<0>();
+      bool last = slice_idx == slice_count - 1;
+      // For per-column scales, we only fetch them here in the final step before
+      // write-out
+      if constexpr (!has_act_order && group_blocks == -1 && (has_zp && dequant_skip_flop || !has_zp)) {
+        if (w_type.size_bits() == 8 || (last || use_atomic_add)) {
+          if (s_sh_wr_pred) {
+            cp_async4(&sh_s[s_sh_wr], &scales_ptr[s_gl_rd]);
+          }
+          cp_async_fence();
+        }
+      }
+
+      thread_block_reduce();
+
+      if constexpr (kHasBias) {
+        if (last) {
+          __syncthreads();
+          cp_async4_pred(&sh_bias[bias_sh_wr], &b_bias_ptr[bias_gl_rd], threadIdx.x < 16 * thread_n_blocks / 8);
+          cp_async_fence();
+        }
+      }
+
+      if constexpr (!has_act_order && group_blocks == -1 && (has_zp && dequant_skip_flop || !has_zp)) {
+        if (w_type.size_bits() == 8 || (last || use_atomic_add)) {
+          cp_async_wait<0>();
+          __syncthreads();
+          if (threadIdx.x / 32 < thread_n_blocks / 4) {
+            reinterpret_cast<int4*>(&frag_s)[0] = sh_s[s_sh_rd + 0];
+            reinterpret_cast<int4*>(&frag_s)[1] = sh_s[s_sh_rd + 4];
+            if constexpr (m_block_size_8) {
+              int idx = (threadIdx.x / 4) % 2;
+              scalar_t2* frag_s_half2 = reinterpret_cast<scalar_t2*>(frag_s);
+#pragma unroll
+              for (int i = 0; i < 8; i++) {
+                frag_s_half2[i] = Dtype::num2num2(reinterpret_cast<scalar_t*>(&frag_s_half2[i])[idx]);
+              }
+            }
+          }
+        }
+      }
+
+      // For 8-bit channelwise, we apply the scale before the global reduction
+      // that converts the fp32 results to fp16 (so that we avoid possible
+      // overflow in fp16)
+      if constexpr (
+          !has_act_order && group_blocks == -1 && w_type.size_bits() == 8 && (has_zp && dequant_skip_flop || !has_zp)) {
+        if (threadIdx.x / 32 < thread_n_blocks / 4) {
+#pragma unroll
+          for (int i = 0; i < thread_m_blocks; i++) {
+#pragma unroll
+            for (int j = 0; j < 4; j++) {
+              scale_float<scalar_t>(reinterpret_cast<float*>(&frag_c[i][j][0][0]), frag_s[j / 2][2 * (j % 2) + 0]);
+              scale_float<scalar_t>(
+                  reinterpret_cast<float*>(&frag_c[i][j][0][2]), frag_s[j / 2][2 * (j % 2) + (m_block_size_8 ? 1 : 0)]);
+
+              if constexpr (!m_block_size_8) {
+                scale_float<scalar_t>(reinterpret_cast<float*>(&frag_c[i][j][1][0]), frag_s[j / 2][2 * (j % 2) + 1]);
+                scale_float<scalar_t>(reinterpret_cast<float*>(&frag_c[i][j][1][2]), frag_s[j / 2][2 * (j % 2) + 1]);
+              }
+            }
+          }
+        }
+      }
+
+      if (slice_count > 1 && !use_atomic_add) {
+        // only globally reduce if there is more than one block in a slice
+        barrier_acquire(&locks[locks_off], slice_idx);
+        if (use_fp32_reduce) {
+          global_reduce_fp32(slice_idx == 0, last);
+        } else {
+          global_reduce_fp16(slice_idx == 0, last);
+        }
+        barrier_release(&locks[locks_off], last);
+      }
+
+      if constexpr (kHasBias) {
+        if (last) {
+          cp_async_wait<0>();
+          __syncthreads();
+          reinterpret_cast<int4*>(&frag_bias)[0] = sh_bias[bias_sh_rd];
+          reinterpret_cast<int4*>(&frag_bias)[1] = sh_bias[bias_sh_rd + 4];
+          __syncthreads();
+        }
+      }
+
+      if (use_atomic_add && slice_count > 1 && slice_idx != 0) wait_negative_and_add(&locks[locks_off]);
+      if (last || use_atomic_add)
+        // only the last block in a slice actually writes the result
+        write_result(last);
+      int old_slice_row = slice_row;
+      slice_row = 0;
+      slice_col_par++;
+      slice_col++;
+      is_first_matmul_in_slice = true;
+      init_slice();
+
+      // Should we load A matrix in next slice?
+      // `slice_col == 0`: when move to a new moe block
+      // `old_slice_row > 0`:
+      //    when the last slice is not starting from k_index == 0
+      //    (only happen when it is the first slice of a threadblock)
+      // `prob_k > thread_k_blocks * 16 * stages * max_num_stage_groups`:
+      //    when the required shared memory size is larger than
+      //    the remaining shared memory
+      if (slice_col == 0 || old_slice_row || prob_k > thread_k_blocks * 16 * stages * max_num_stage_groups) {
+        should_load_a = true;
+      } else {
+        should_load_a = false;
+      }
+
+      if (slice_iters) {
+        a_gl_rd_col = (threadIdx.x % a_gl_rd_delta_o);
+#pragma unroll
+        for (int i = 0; i < b_sh_wr_iters; i++)
+          B_ptr[i] += b_sh_stride - b_gl_rd_delta_o * k_tiles;
+        if (slice_col == 0) {
+#pragma unroll
+          for (int i = 0; i < b_sh_wr_iters; i++)
+            B_ptr[i] -= b_gl_stride;
+        }
+
+        bias_gl_rd = (thread_n_blocks * 16 / 8) * slice_col + threadIdx.x;
+        // Update slice k/n for scales loading
+        if constexpr (has_act_order) {
+          slice_k_start = tb_k * slice_row;
+          slice_k_finish = slice_k_start + tb_k * slice_iters;
+          slice_k_start_shared_fetch = slice_k_start;
+          slice_n_offset = act_s_col_tb_stride * slice_col;
+        } else {
+          if constexpr (group_blocks == -1) {
+            s_gl_rd = s_sh_stride * slice_col + threadIdx.x;
+            zp_gl_rd = zp_sh_stride * slice_col + threadIdx.x;
+          } else if constexpr (group_blocks >= thread_k_blocks) {
+            s_gl_rd =
+                s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) + s_sh_stride * slice_col + threadIdx.x;
+            zp_gl_rd =
+                zp_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) + zp_sh_stride * slice_col + threadIdx.x;
+          } else {
+            s_gl_rd = s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks + threadIdx.x / s_sh_stride) +
+                      s_sh_stride * slice_col + threadIdx.x % s_sh_stride;
+            zp_gl_rd = zp_gl_stride * ((thread_k_blocks * slice_row) / group_blocks + threadIdx.x / zp_sh_stride) +
+                       zp_sh_stride * slice_col + threadIdx.x % zp_sh_stride;
+          }
+        }
+        start_pipes();
+      }
+    }
+  }
+}
+
+}  // namespace device::marlin_moe
+
+#endif

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/moe_align_kernel.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/moe_align_kernel.cu
@@ -1,0 +1,579 @@
+/* Copyright 2025 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <utils.cuh>  // trimmed: dtype aliases + host::{RuntimeCheck,LaunchKernel}
+
+#include <tvm/ffi/container/tensor.h>
+
+#include <algorithm>
+
+#ifndef WARP_SIZE
+#define WARP_SIZE 32
+#endif
+
+#define CEILDIV(x, y) (((x) + (y) - 1) / (y))
+
+#define VEC_SIZE 4
+using Vec = int4;
+
+inline uint32_t next_pow2(uint32_t x) noexcept {
+  --x;
+  x |= x >> 1;
+  x |= x >> 2;
+  x |= x >> 4;
+  x |= x >> 8;
+  x |= x >> 16;
+  return x + 1;
+}
+
+namespace moe {
+
+__device__ __forceinline__ int warp_exclusive_scan(int v, unsigned mask = 0xffffffffu) {
+  int original = v;
+#pragma unroll
+  for (int offset = 1; offset < WARP_SIZE; offset <<= 1) {
+    int n = __shfl_up_sync(mask, v, offset);
+    if ((threadIdx.x & (WARP_SIZE - 1)) >= offset) v += n;
+  }
+  return v - original;
+}
+
+template <typename scalar_t>
+__global__ void count_and_sort_expert_tokens_kernel(
+    const scalar_t* __restrict__ topk_ids,
+    int32_t* __restrict__ sorted_token_ids,
+    int32_t* __restrict__ cumsum_buffer,
+    size_t numel) {
+  const size_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const size_t stride = blockDim.x * gridDim.x;
+
+  for (size_t i = tid; i < numel; i += stride) {
+    int32_t expert_id = topk_ids[i] + 1;
+    int32_t rank_post_pad = atomicAdd(&cumsum_buffer[expert_id], 1);
+    sorted_token_ids[rank_post_pad] = i;
+  }
+}
+
+template <typename scalar_t>
+__global__ void moe_align_block_size_kernel(
+    const scalar_t* __restrict__ topk_ids,
+    int32_t* __restrict__ sorted_token_ids,
+    int32_t* __restrict__ expert_ids,
+    int32_t* __restrict__ total_tokens_post_pad,
+    int32_t num_experts,
+    int32_t block_size,
+    size_t numel,
+    int32_t* __restrict__ cumsum,
+    bool pad_sorted_token_ids,
+    const int32_t scan_size,
+    int32_t max_num_tokens_padded) {
+  // Use a separate thread block to populate sorted_token_ids
+  if (blockIdx.x == 1) {
+    if (pad_sorted_token_ids) {
+      Vec fill_vec;
+      fill_vec.x = fill_vec.y = fill_vec.z = fill_vec.w = numel;
+      int32_t total_vecs = (max_num_tokens_padded + VEC_SIZE - 1) / VEC_SIZE;
+      Vec* out_ptr = reinterpret_cast<Vec*>(sorted_token_ids);
+      for (int32_t i = threadIdx.x; i < total_vecs; i += blockDim.x) {
+        out_ptr[i] = fill_vec;
+      }
+    }
+    return;
+  }
+
+  extern __shared__ int32_t smem[];
+  int32_t* shared_counts = smem;                  // [num_experts]
+  int32_t* prefix = shared_counts + num_experts;  // [num_experts + 1]
+  int32_t* scan_buf = prefix + num_experts + 1;   // [scan_size]
+  __shared__ int32_t s_total_tokens_post_pad;
+
+  const size_t tid = threadIdx.x;
+  const size_t stride = blockDim.x;
+
+  if (tid < num_experts) {
+    shared_counts[tid] = 0;
+  }
+
+  __syncthreads();
+
+  for (size_t i = tid; i < numel; i += stride) {
+    int expert_id = topk_ids[i] + 1;
+    atomicAdd(&shared_counts[expert_id], 1);
+  }
+
+  __syncthreads();
+
+  int32_t padded_count = 0;
+  if (tid < num_experts) {
+    int32_t count = shared_counts[tid];
+    padded_count = (count + block_size - 1) / block_size * block_size;
+    scan_buf[tid] = padded_count;
+  }
+
+#ifndef __CUDA_ARCH__  // HIP
+
+  if (tid >= num_experts && tid < scan_size) {
+    scan_buf[tid] = 0;
+  }
+
+  __syncthreads();
+
+  // Blelloch scan
+  int offset = 1;
+#pragma unroll
+  for (int d = scan_size >> 1; d > 0; d >>= 1) {
+    if (tid < d) {
+      int ai = offset * (2 * tid + 1) - 1;
+      int bi = offset * (2 * tid + 2) - 1;
+      scan_buf[bi] += scan_buf[ai];
+    }
+    offset <<= 1;
+    __syncthreads();
+  }
+
+  // down-sweep
+  if (tid == 0) {
+    prefix[num_experts] = scan_buf[scan_size - 1];
+    scan_buf[scan_size - 1] = 0;
+  }
+  __syncthreads();
+
+#pragma unroll
+  for (int d = 1; d < scan_size; d <<= 1) {
+    offset >>= 1;
+    if (tid < d) {
+      int ai = offset * (2 * tid + 1) - 1;
+      int bi = offset * (2 * tid + 2) - 1;
+      if (bi < scan_size) {
+        int temp = scan_buf[ai];
+        scan_buf[ai] = scan_buf[bi];
+        scan_buf[bi] += temp;
+      }
+    }
+    __syncthreads();
+  }
+
+  if (tid < num_experts) {
+    prefix[tid] = scan_buf[tid];
+  }
+
+  if (tid == 0) {
+    s_total_tokens_post_pad = prefix[num_experts];
+    *total_tokens_post_pad = s_total_tokens_post_pad;
+  }
+  __syncthreads();
+
+#else  // CUDA
+
+  // Intra warp prefix sum
+  int32_t* warp_sums = scan_buf + scan_size;  // [<= 32]
+  const int warp_id = tid / WARP_SIZE;
+  const int lane_id = tid & (WARP_SIZE - 1);
+  const int num_warps_for_scan = (scan_size + WARP_SIZE - 1) / WARP_SIZE;
+  const int warp_sum = warp_exclusive_scan(padded_count) + padded_count;
+  if (lane_id == WARP_SIZE - 1) warp_sums[warp_id] = warp_sum;
+  __syncthreads();
+
+  // warp0 accumulate all the block's prefix sum
+  if (tid < WARP_SIZE) {
+    int val = (tid < num_warps_for_scan) ? warp_sums[tid] : 0;
+    int incl = warp_exclusive_scan(val) + val;
+    warp_sums[tid] = incl;
+  }
+  __syncthreads();
+
+  // Every thread obtains the whole block's sum
+  if (tid == 0) {
+    prefix[num_experts] = warp_sums[num_warps_for_scan - 1];
+    s_total_tokens_post_pad = prefix[num_experts];
+    *total_tokens_post_pad = s_total_tokens_post_pad;
+  }
+  __syncthreads();
+
+  // Fill 0 to scan_buf extended area (tid >= num_expert)
+  if (tid >= num_experts && tid < scan_size) scan_buf[tid] = 0;
+  __syncthreads();
+
+  // Perform 2 level exclusive-prefix-sum to scan_buf
+  int v = (tid < scan_size) ? scan_buf[tid] : 0;
+  int pre = warp_exclusive_scan(v);
+  if (lane_id == WARP_SIZE - 1) warp_sums[warp_id] = pre + v;
+  __syncthreads();
+
+  if (warp_id == 0) {
+    int val = (lane_id < num_warps_for_scan) ? warp_sums[lane_id] : 0;
+    warp_sums[lane_id] = warp_exclusive_scan(val);
+  }
+  __syncthreads();
+
+  int offset = warp_sums[warp_id];
+  if (tid < scan_size) scan_buf[tid] = pre + offset;
+  __syncthreads();
+
+  // Write prefix[0..num_experts - 1] and cumsum
+  if (tid < num_experts) prefix[tid] = scan_buf[tid];
+#endif
+
+  if (tid <= num_experts) {
+    cumsum[tid] = prefix[tid];
+  }
+  // fill expert_ids
+  const int32_t num_blocks = s_total_tokens_post_pad / block_size;
+  for (int32_t i = tid; i < num_blocks; i += stride) {
+    int32_t block_start = i * block_size;
+    int left = 0, right = num_experts;
+    while (left < right) {
+      int mid = (left + right) >> 1;
+      if (prefix[mid] <= block_start) {
+        left = mid + 1;
+      } else {
+        right = mid;
+      }
+    }
+    expert_ids[i] = left - 2;
+  }
+}
+
+template <typename scalar_t, int32_t fill_threads>
+__global__ void moe_align_block_size_small_batch_expert_kernel(
+    const scalar_t* __restrict__ topk_ids,
+    int32_t* __restrict__ sorted_token_ids,
+    int32_t* __restrict__ expert_ids,
+    int32_t* __restrict__ total_tokens_post_pad,
+    int32_t num_experts,
+    int32_t block_size,
+    size_t numel,
+    bool pad_sorted_token_ids,
+    int32_t max_num_tokens_padded) {
+  // Adapted from
+  // https://github.com/vllm-project/vllm/pull/29642/files#diff-5647b1413f4ae9aacba904eca8f8a8aee9079321eadff4c10101a2c6962dcc53R226
+  // Use an additional group of threads to fill sorted_token_ids.
+  // Since the kernel will use sorted_token_ids afterward,
+  // we fill sorted_token_ids within the same threadblock to make
+  // synchronization easier.
+  if (threadIdx.x < fill_threads) {
+    // Initialize sorted_token_ids with numel
+    if (pad_sorted_token_ids) {
+      for (int32_t it = threadIdx.x; it < max_num_tokens_padded; it += fill_threads) {
+        sorted_token_ids[it] = numel;
+      }
+    }
+    // Three __syncthreads() corresponding to the other threads
+    __syncthreads();
+    __syncthreads();
+    __syncthreads();
+    return;
+  }
+
+  const size_t tid = threadIdx.x - fill_threads;
+  const size_t stride = blockDim.x - fill_threads;
+
+  extern __shared__ int32_t shared_mem[];
+  int32_t* cumsum = shared_mem;
+  int32_t* tokens_cnts = (int32_t*)(shared_mem + num_experts + 1);
+
+  for (int i = 0; i < num_experts; ++i) {
+    tokens_cnts[(tid + 1) * num_experts + i] = 0;
+  }
+
+  for (size_t i = tid; i < numel; i += stride) {
+    int32_t expert_id = topk_ids[i] + 1;
+    ++tokens_cnts[(tid + 1) * num_experts + expert_id];
+  }
+
+  __syncthreads();
+
+  if (tid < num_experts) {
+    tokens_cnts[tid] = 0;
+    for (int i = 1; i <= stride; ++i) {
+      tokens_cnts[i * num_experts + tid] += tokens_cnts[(i - 1) * num_experts + tid];
+    }
+  }
+
+  __syncthreads();
+
+  if (tid == 0) {
+    cumsum[0] = 0;
+    for (int i = 1; i <= num_experts; ++i) {
+      cumsum[i] = cumsum[i - 1] + CEILDIV(tokens_cnts[stride * num_experts + i - 1], block_size) * block_size;
+    }
+    *total_tokens_post_pad = static_cast<int32_t>(cumsum[num_experts]);
+  }
+
+  __syncthreads();
+
+  if (tid < num_experts) {
+    for (int i = cumsum[tid]; i < cumsum[tid + 1]; i += block_size) {
+      expert_ids[i / block_size] = tid - 1;
+    }
+  }
+
+  for (size_t i = tid; i < numel; i += stride) {
+    int32_t expert_id = topk_ids[i] + 1;
+    int32_t rank_post_pad = tokens_cnts[tid * num_experts + expert_id] + cumsum[expert_id];
+    sorted_token_ids[rank_post_pad] = i;
+    ++tokens_cnts[tid * num_experts + expert_id];
+  }
+}
+
+// v2 kernel: supports >1024 experts via EXPERTS_PER_THREAD templating
+// and a two-level warp scan (no cub dependency). Uses the same +1 offset
+// convention as the original kernel (topk_ids shifted by +1 so -1 maps to 0).
+// Launched with <<<2, 1024>>>: block 1 fills sorted_token_ids in parallel
+// with block 0 doing the alignment compute.
+//
+// With 1024 threads and EXPERTS_PER_THREAD=4, covers at most 4096 expert
+// indices. Since num_experts includes the +1 offset bucket, this supports
+// up to 4095 real experts.
+template <typename scalar_t, int EXPERTS_PER_THREAD>
+__global__ void moe_align_block_size_kernel_v2(
+    const scalar_t* __restrict__ topk_ids,
+    int32_t* __restrict__ sorted_token_ids,
+    int32_t* __restrict__ expert_ids,
+    int32_t* __restrict__ total_tokens_post_pad,
+    int32_t num_experts,
+    int32_t padded_num_experts,
+    int32_t block_size,
+    size_t numel,
+    int32_t* __restrict__ cumsum,
+    bool pad_sorted_token_ids,
+    int32_t max_num_tokens_padded) {
+  // Use a separate thread block to populate sorted_token_ids
+  if (blockIdx.x == 1) {
+    if (pad_sorted_token_ids) {
+      Vec fill_vec;
+      fill_vec.x = fill_vec.y = fill_vec.z = fill_vec.w = numel;
+      int32_t total_vecs = (max_num_tokens_padded + VEC_SIZE - 1) / VEC_SIZE;
+      Vec* out_ptr = reinterpret_cast<Vec*>(sorted_token_ids);
+      for (int32_t i = threadIdx.x; i < total_vecs; i += blockDim.x) {
+        out_ptr[i] = fill_vec;
+      }
+    }
+    return;
+  }
+
+  extern __shared__ int32_t smem[];
+  // Layout: shared_counts[padded_num_experts] | warp_sums[WARP_SIZE]
+  int32_t* shared_counts = smem;
+  int32_t* warp_sums = smem + padded_num_experts;
+
+  const size_t tid = threadIdx.x;
+  const int warp_id = tid / WARP_SIZE;
+  const int lane_id = tid & (WARP_SIZE - 1);
+
+  // Phase 1: Zero shared counts and count tokens per expert
+  const int my_start = tid * EXPERTS_PER_THREAD;
+  for (size_t i = tid; i < padded_num_experts; i += blockDim.x) {
+    shared_counts[i] = 0;
+  }
+
+  __syncthreads();
+
+  for (size_t i = tid; i < numel; i += blockDim.x) {
+    int expert_id = topk_ids[i] + 1;  // +1 offset convention
+    if (expert_id < num_experts) {
+      atomicAdd(&shared_counts[expert_id], 1);
+    }
+  }
+
+  __syncthreads();
+
+  // Phase 2: Compute padded counts and two-level warp exclusive prefix sum
+  int32_t local_padded[EXPERTS_PER_THREAD];
+  int32_t thread_sum = 0;
+  for (int i = 0; i < EXPERTS_PER_THREAD; ++i) {
+    int eid = my_start + i;
+    if (eid < num_experts) {
+      local_padded[i] = CEILDIV(shared_counts[eid], block_size) * block_size;
+    } else {
+      local_padded[i] = 0;
+    }
+    thread_sum += local_padded[i];
+  }
+
+  // Level 1: intra-warp exclusive scan on thread_sum
+  int32_t warp_prefix = warp_exclusive_scan(thread_sum);
+  int32_t warp_total = warp_prefix + thread_sum;
+  if (lane_id == WARP_SIZE - 1) warp_sums[warp_id] = warp_total;
+  __syncthreads();
+
+  // Level 2: warp 0 scans the per-warp totals
+  const int num_warps = (blockDim.x + WARP_SIZE - 1) / WARP_SIZE;
+  if (tid < WARP_SIZE) {
+    int val = (tid < num_warps) ? warp_sums[tid] : 0;
+    warp_sums[tid] = warp_exclusive_scan(val);
+  }
+  __syncthreads();
+
+  // Combine: thread_prefix = warp_sums[warp_id] + warp_prefix
+  int32_t thread_prefix = warp_sums[warp_id] + warp_prefix;
+
+  // Local sequential prefix sum within each thread's expert group
+  int32_t running = 0;
+  for (int i = 0; i < EXPERTS_PER_THREAD; ++i) {
+    int eid = my_start + i;
+    if (eid <= num_experts) {
+      cumsum[eid] = thread_prefix + running;
+    }
+    running += local_padded[i];
+  }
+
+  // Last thread writes total
+  if (tid == blockDim.x - 1) {
+    cumsum[num_experts] = thread_prefix + thread_sum;
+    *total_tokens_post_pad = thread_prefix + thread_sum;
+  }
+
+  __syncthreads();
+
+  // Phase 3: Fill expert_ids (eid - 1 for the 1-based sentinel convention)
+  for (int i = 0; i < EXPERTS_PER_THREAD; ++i) {
+    int eid = my_start + i;
+    if (eid < num_experts) {
+      for (int j = cumsum[eid]; j < cumsum[eid + 1]; j += block_size) {
+        expert_ids[j / block_size] = eid - 1;
+      }
+    }
+  }
+}
+
+}  // namespace moe
+
+namespace {
+
+template <typename scalar_t>
+struct MoeAlignBlockSizeKernel {
+  static void
+  run(tvm::ffi::TensorView topk_ids,
+      int64_t num_experts,
+      int64_t block_size,
+      tvm::ffi::TensorView sorted_token_ids,
+      tvm::ffi::TensorView expert_ids,
+      tvm::ffi::TensorView num_tokens_post_pad,
+      tvm::ffi::TensorView cumsum_buffer,
+      bool pad_sorted_token_ids) {
+    using namespace host;
+
+    auto device = topk_ids.device();
+    const cudaStream_t stream = LaunchKernel::resolve_device(device);
+
+    int threads = 1024;
+    threads = ((threads + WARP_SIZE - 1) / WARP_SIZE) * WARP_SIZE;
+
+    int64_t max_num_tokens_padded = sorted_token_ids.size(0);
+
+    // num_experts from Python is actual_num_experts + 1 (for EP offset convention).
+    // The v2 kernel (>1024 experts) uses 1024 threads with EXPERTS_PER_THREAD up
+    // to 8, covering at most 8192 expert indices. This supports up to 8191 real
+    // experts, sufficient for LoRA virtual experts (num_moe_experts * max_loras).
+    RuntimeCheck(num_experts <= 8192, "moe_align_block_size: num_experts must be <= 8192, got ", num_experts);
+
+    const scalar_t* topk_ids_ptr = static_cast<const scalar_t*>(topk_ids.data_ptr());
+    int32_t* sorted_token_ids_ptr = static_cast<int32_t*>(sorted_token_ids.data_ptr());
+    int32_t* expert_ids_ptr = static_cast<int32_t*>(expert_ids.data_ptr());
+    int32_t* num_tokens_post_pad_ptr = static_cast<int32_t*>(num_tokens_post_pad.data_ptr());
+    int32_t* cumsum_buffer_ptr = static_cast<int32_t*>(cumsum_buffer.data_ptr());
+    size_t numel = topk_ids.numel();
+
+    bool small_batch_expert_mode = (numel < 1024) && (num_experts <= 64);
+
+    if (small_batch_expert_mode) {
+      const int32_t num_thread = std::max((int32_t)num_experts, (int32_t)WARP_SIZE);
+      constexpr int32_t fill_threads = 256;
+      const int32_t shared_mem_size = ((num_thread + 1) * num_experts + (num_experts + 1)) * sizeof(int32_t);
+
+      auto kernel = moe::moe_align_block_size_small_batch_expert_kernel<scalar_t, fill_threads>;
+      LaunchKernel(dim3(1), dim3(fill_threads + num_thread), stream, shared_mem_size)(
+          kernel,
+          topk_ids_ptr,
+          sorted_token_ids_ptr,
+          expert_ids_ptr,
+          num_tokens_post_pad_ptr,
+          (int32_t)num_experts,
+          (int32_t)block_size,
+          numel,
+          pad_sorted_token_ids,
+          (int32_t)max_num_tokens_padded);
+    } else if (num_experts <= 1024) {
+      const size_t scan_size = next_pow2(num_experts);
+      const size_t shared_mem_size = (num_experts + (num_experts + 1) + scan_size + WARP_SIZE) * sizeof(int32_t);
+
+      auto align_kernel = moe::moe_align_block_size_kernel<scalar_t>;
+      LaunchKernel(dim3(2), dim3(threads), stream, shared_mem_size)(
+          align_kernel,
+          topk_ids_ptr,
+          sorted_token_ids_ptr,
+          expert_ids_ptr,
+          num_tokens_post_pad_ptr,
+          (int32_t)num_experts,
+          (int32_t)block_size,
+          numel,
+          cumsum_buffer_ptr,
+          pad_sorted_token_ids,
+          (int32_t)scan_size,
+          (int32_t)max_num_tokens_padded);
+
+      const int block_threads = std::min(256, threads);
+      const int num_blocks = (numel + block_threads - 1) / block_threads;
+      const int max_blocks = 65535;
+      const int actual_blocks = std::min(num_blocks, max_blocks);
+
+      auto sort_kernel = moe::count_and_sort_expert_tokens_kernel<scalar_t>;
+      LaunchKernel(dim3(actual_blocks), dim3(block_threads), stream)(
+          sort_kernel, topk_ids_ptr, sorted_token_ids_ptr, cumsum_buffer_ptr, numel);
+    } else {
+      // v2 path for >1024 experts: two-level warp scan with EXPERTS_PER_THREAD
+      int64_t padded_num_experts = ((num_experts + WARP_SIZE - 1) / WARP_SIZE) * WARP_SIZE;
+      size_t shared_mem_size = (padded_num_experts + WARP_SIZE) * sizeof(int32_t);
+
+      auto launch_v2 = [&](auto ept_tag) {
+        constexpr int EPT = decltype(ept_tag)::value;
+        auto v2_kernel = moe::moe_align_block_size_kernel_v2<scalar_t, EPT>;
+        LaunchKernel(dim3(2), dim3(threads), stream, shared_mem_size)(
+            v2_kernel,
+            topk_ids_ptr,
+            sorted_token_ids_ptr,
+            expert_ids_ptr,
+            num_tokens_post_pad_ptr,
+            (int32_t)num_experts,
+            (int32_t)padded_num_experts,
+            (int32_t)block_size,
+            numel,
+            cumsum_buffer_ptr,
+            pad_sorted_token_ids,
+            (int32_t)max_num_tokens_padded);
+      };
+
+      if (padded_num_experts <= 2048) {
+        launch_v2(std::integral_constant<int, 2>{});
+      } else if (padded_num_experts <= 4096) {
+        launch_v2(std::integral_constant<int, 4>{});
+      } else {
+        launch_v2(std::integral_constant<int, 8>{});
+      }
+
+      const int block_threads = std::min(256, threads);
+      const int num_blocks = (numel + block_threads - 1) / block_threads;
+      const int max_blocks = 65535;
+      const int actual_blocks = std::min(num_blocks, max_blocks);
+
+      auto sort_kernel = moe::count_and_sort_expert_tokens_kernel<scalar_t>;
+      LaunchKernel(dim3(actual_blocks), dim3(block_threads), stream)(
+          sort_kernel, topk_ids_ptr, sorted_token_ids_ptr, cumsum_buffer_ptr, numel);
+    }
+  }
+};
+
+}  // namespace

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/moe_wna16_marlin.cuh
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/moe_wna16_marlin.cuh
@@ -1,0 +1,1113 @@
+/*
+ * Modified by Neural Magic
+ * Copyright (C) Marlin.2024 Elias Frantar
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Adapted from https://github.com/IST-DASLab/marlin
+ */
+
+#pragma once
+
+#include <scalar_type.hpp>
+
+#include "../tvm_ffi_utils.h"
+#include "kernel.h"
+#include "marlin_template.h"
+
+// host::RuntimeCheck / RuntimeDeviceCheck / LaunchKernel come from the trimmed
+// <utils.cuh> (routed through TVM-FFI). The entry pulls them in via
+// ``using namespace host`` below.
+
+namespace device::marlin_moe {
+
+__global__ void MarlinDefault(MARLIN_KERNEL_PARAMS){};
+
+using MarlinFuncPtr = void (*)(MARLIN_KERNEL_PARAMS);
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+
+template <int moe_block_size>
+__global__ void permute_cols_kernel(
+    int4 const* __restrict__ a_int4_ptr,
+    int const* __restrict__ perm_int_ptr,
+    int4* __restrict__ out_int4_ptr,
+    const int32_t* __restrict__ sorted_token_ids_ptr,
+    const int32_t* __restrict__ expert_ids_ptr,
+    const int32_t* __restrict__ num_tokens_past_padded_ptr,
+    int size_m,
+    int size_k,
+    int top_k) {};
+
+#else
+
+// For a given "a" of size [M,K] performs a permutation of the K columns based
+// on the given "perm" indices.
+template <int moe_block_size>
+__global__ void permute_cols_kernel(
+    int4 const* __restrict__ a_int4_ptr,
+    int const* __restrict__ perm_int_ptr,
+    int4* __restrict__ out_int4_ptr,
+    const int32_t* __restrict__ sorted_token_ids_ptr,
+    const int32_t* __restrict__ expert_ids_ptr,
+    const int32_t* __restrict__ num_tokens_past_padded_ptr,
+    int size_m,
+    int size_k,
+    int top_k) {
+  int num_tokens_past_padded = num_tokens_past_padded_ptr[0];
+  int num_moe_blocks = div_ceil(num_tokens_past_padded, moe_block_size);
+  int32_t block_sorted_ids[moe_block_size];
+  int block_num_valid_tokens = 0;
+  int64_t old_expert_id = 0;
+  int64_t expert_id = 0;
+  int row_stride = size_k * sizeof(half) / 16;
+
+  auto read_moe_block_data = [&](int block_id) {
+    block_num_valid_tokens = moe_block_size;
+    int4* tmp_block_sorted_ids = reinterpret_cast<int4*>(block_sorted_ids);
+    for (int i = 0; i < moe_block_size / 4; i++) {
+      tmp_block_sorted_ids[i] = ((int4*)sorted_token_ids_ptr)[block_id * moe_block_size / 4 + i];
+    }
+    for (int i = 0; i < moe_block_size; i++) {
+      if (block_sorted_ids[i] >= size_m * top_k) {
+        block_num_valid_tokens = i;
+        break;
+      };
+    }
+  };
+
+  auto permute_row = [&](int row) {
+    int iters = size_k / default_threads;
+    int rest = size_k % default_threads;
+
+    int in_offset = (row / top_k) * row_stride;
+    int out_offset = row * row_stride;
+
+    half const* a_row_half = reinterpret_cast<half const*>(a_int4_ptr + in_offset);
+    half* out_half = reinterpret_cast<half*>(out_int4_ptr + out_offset);
+
+    int base_k = 0;
+
+    for (int i = 0; i < iters; i++) {
+      auto cur_k = base_k + threadIdx.x;
+      int src_pos = perm_int_ptr[cur_k];
+
+      out_half[cur_k] = a_row_half[src_pos];
+
+      base_k += default_threads;
+    }
+
+    if (rest) {
+      if (threadIdx.x < rest) {
+        auto cur_k = base_k + threadIdx.x;
+        int src_pos = perm_int_ptr[cur_k];
+
+        out_half[cur_k] = a_row_half[src_pos];
+      }
+    }
+  };
+
+  for (int index = blockIdx.x; index < num_moe_blocks; index += gridDim.x) {
+    old_expert_id = expert_id;
+    int tmp_expert_id = expert_ids_ptr[index];
+    if (tmp_expert_id == -1) continue;
+    expert_id = tmp_expert_id;
+    perm_int_ptr += (expert_id - old_expert_id) * size_k;
+    read_moe_block_data(index);
+
+    for (int i = 0; i < block_num_valid_tokens; i++)
+      permute_row(block_sorted_ids[i]);
+  }
+}
+
+typedef struct {
+  int thread_k;
+  int thread_n;
+  int num_threads;
+} thread_config_t;
+
+thread_config_t small_batch_thread_configs[] = {
+    // Ordered by priority
+
+    // thread_k, thread_n, num_threads
+    {128, 128, 256},
+    {64, 128, 128}};
+
+thread_config_t large_batch_thread_configs[] = {
+    // Ordered by priority
+
+    // thread_k, thread_n, num_threads
+    {64, 256, 256},
+    {64, 128, 128}};
+
+typedef struct {
+  int blocks_per_sm;
+  thread_config_t tb_cfg;
+} exec_config_t;
+
+constexpr int kSharedMemoryValidityMargin = 512;
+constexpr int kSharedMemoryLaunchReserve = 1024;
+
+int get_scales_cache_size(
+    thread_config_t const& th_config,
+    int prob_m,
+    int prob_n,
+    int prob_k,
+    int num_bits,
+    int group_size,
+    bool has_act_order,
+    bool is_k_full) {
+  bool cache_scales_chunk = has_act_order && !is_k_full;
+
+  int tb_n = th_config.thread_n;
+  int tb_k = th_config.thread_k;
+
+  // Get max scale groups per thread-block
+  int tb_groups;
+  if (group_size == -1) {
+    tb_groups = 1;
+  } else if (group_size == 0) {
+    tb_groups = div_ceil(tb_k, 32);  // Worst case is 32 group size
+  } else {
+    tb_groups = div_ceil(tb_k, group_size);
+  }
+
+  if (cache_scales_chunk) {
+    int load_groups = tb_groups * pipe_stages * 2;  // Chunk size is 2x pipeline over dim K
+    load_groups = max(load_groups, 32);             // We load at least 32 scale groups
+    return load_groups * tb_n * 2;
+  } else {
+    int tb_scales = tb_groups * tb_n * 2;
+
+    return tb_scales * pipe_stages;
+  }
+}
+
+int get_kernel_cache_size(
+    thread_config_t const& th_config,
+    bool m_block_size_8,
+    int thread_m_blocks,
+    int prob_m,
+    int prob_n,
+    int prob_k,
+    int num_bits,
+    int group_size,
+    bool has_act_order,
+    bool is_k_full,
+    int has_zp,
+    int is_zp_float) {
+  int pack_factor = 32 / num_bits;
+
+  // Get B size
+  int tb_k = th_config.thread_k;
+  int tb_n = th_config.thread_n;
+  int tb_m = thread_m_blocks * 16;
+
+  // shm size for block_sorted_ids/rd_block_sorted_ids/block_topk_weights
+  // both of them requires tb_m * 4 bytes (tb_m * int32 or tb_m * float32)
+  int sh_block_meta_size = tb_m * 4;
+  int sh_a_size = pipe_stages * (tb_m * tb_k) * 2;
+  int sh_b_size = pipe_stages * (tb_k * tb_n / pack_factor) * 4;
+  int sh_red_size = tb_m * (tb_n + 8) * 2;
+  int sh_bias_size = tb_n * 2;
+  int tmp_size = (sh_b_size > sh_red_size ? sh_red_size : sh_b_size) + sh_bias_size;
+  tmp_size = max(max(sh_b_size, sh_red_size), tmp_size);
+
+  int sh_s_size =
+      get_scales_cache_size(th_config, prob_m, prob_n, prob_k, num_bits, group_size, has_act_order, is_k_full);
+  int sh_g_idx_size = has_act_order && !is_k_full ? pipe_stages * tb_k / 4 : 0;
+  int sh_zp_size = 0;
+  if (has_zp) {
+    if (is_zp_float)
+      sh_zp_size = sh_s_size;
+    else if (num_bits == 4)
+      sh_zp_size = sh_s_size / 4;
+    else if (num_bits == 8)
+      sh_zp_size = sh_s_size / 2;
+  }
+
+  int total_size = tmp_size + sh_a_size + sh_s_size + sh_zp_size + sh_g_idx_size + sh_block_meta_size;
+
+  return total_size;
+}
+
+bool is_valid_config(
+    thread_config_t const& th_config,
+    bool m_block_size_8,
+    int thread_m_blocks,
+    int prob_m,
+    int prob_n,
+    int prob_k,
+    int num_bits,
+    int group_size,
+    bool has_act_order,
+    bool is_k_full,
+    int has_zp,
+    int is_zp_float,
+    int max_shared_mem) {
+  // Sanity
+  if (th_config.thread_k == -1 || th_config.thread_n == -1 || th_config.num_threads == -1) {
+    return false;
+  }
+
+  // Verify K/N are divisible by thread K/N
+  if (prob_k % th_config.thread_k != 0 || prob_n % th_config.thread_n != 0) {
+    return false;
+  }
+
+  // Verify min for thread K/N
+  if (th_config.thread_n < min_thread_n || th_config.thread_k < min_thread_k) {
+    return false;
+  }
+
+  // num_threads must be at least 128 (= 4 warps)
+  if (th_config.num_threads < 128) {
+    return false;
+  }
+
+  // Check that pipeline fits into cache
+  int cache_size = get_kernel_cache_size(
+      th_config,
+      m_block_size_8,
+      thread_m_blocks,
+      prob_m,
+      prob_n,
+      prob_k,
+      num_bits,
+      group_size,
+      has_act_order,
+      is_k_full,
+      has_zp,
+      is_zp_float);
+  return cache_size + kSharedMemoryValidityMargin <= max_shared_mem;
+}
+
+#define _GET_IF(                                                                                                       \
+    W_TYPE, THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS, M_BLOCK_SIZE_8, GROUP_BLOCKS, NUM_THREADS, IS_ZP_FLOAT) \
+  else if (                                                                                                            \
+      q_type == W_TYPE && thread_m_blocks == THREAD_M_BLOCKS && thread_n_blocks == THREAD_N_BLOCKS &&                  \
+      thread_k_blocks == THREAD_K_BLOCKS && m_block_size_8 == M_BLOCK_SIZE_8 && group_blocks == GROUP_BLOCKS &&        \
+      num_threads == NUM_THREADS && is_zp_float == IS_ZP_FLOAT) {                                                      \
+    constexpr auto S_TYPE = W_TYPE == host::kFE2M1f                                                                    \
+                                ? (GROUP_BLOCKS == 1 ? host::kFE4M3fn : host::kFE8M0fnu)                               \
+                                : (std::is_same<scalar_t, half>::value ? host::kFloat16 : host::kBFloat16);            \
+    kernel = Marlin<                                                                                                   \
+        scalar_t,                                                                                                      \
+        W_TYPE.id(),                                                                                                   \
+        S_TYPE.id(),                                                                                                   \
+        NUM_THREADS,                                                                                                   \
+        THREAD_M_BLOCKS,                                                                                               \
+        THREAD_N_BLOCKS,                                                                                               \
+        THREAD_K_BLOCKS,                                                                                               \
+        M_BLOCK_SIZE_8,                                                                                                \
+        pipe_stages,                                                                                                   \
+        GROUP_BLOCKS,                                                                                                  \
+        IS_ZP_FLOAT,                                                                                                   \
+        kIsEP,                                                                                                         \
+        kHasBias>;                                                                                                     \
+  }
+
+// COMMON: cases for (group_blocks in [-1, 2, 4, 8] and is_zp_float == false)
+//         this is the most common cases
+// BIGGROUP: cases for big group size (group_blocks in [-1, 8])
+// FZP: cases for float-zero-point (is_zp_float = true)
+// ACT: cases for act order case (group_blocks == 0)
+// NVFP4: cases for nvfp4(e2m1) (group_blocks == 1)
+// MXFP4: cases for mxfp4(e2m1) (group_blocks == 2)
+#define COMMON_GET_IF_M1(W_TYPE, N_BLOCKS, K_BLOCKS, NUM_THREADS)       \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, true, -1, NUM_THREADS, false)  \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, true, 2, NUM_THREADS, false)   \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, true, 4, NUM_THREADS, false)   \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, true, 8, NUM_THREADS, false)   \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, false, -1, NUM_THREADS, false) \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, false, 2, NUM_THREADS, false)  \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, false, 4, NUM_THREADS, false)  \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, false, 8, NUM_THREADS, false)
+
+#define COMMON_GET_IF_M234(W_TYPE, N_BLOCKS, K_BLOCKS, NUM_THREADS)     \
+  _GET_IF(W_TYPE, 2, N_BLOCKS, K_BLOCKS, false, -1, NUM_THREADS, false) \
+  _GET_IF(W_TYPE, 2, N_BLOCKS, K_BLOCKS, false, 2, NUM_THREADS, false)  \
+  _GET_IF(W_TYPE, 2, N_BLOCKS, K_BLOCKS, false, 4, NUM_THREADS, false)  \
+  _GET_IF(W_TYPE, 2, N_BLOCKS, K_BLOCKS, false, 8, NUM_THREADS, false)  \
+                                                                        \
+  _GET_IF(W_TYPE, 3, N_BLOCKS, K_BLOCKS, false, -1, NUM_THREADS, false) \
+  _GET_IF(W_TYPE, 3, N_BLOCKS, K_BLOCKS, false, 2, NUM_THREADS, false)  \
+  _GET_IF(W_TYPE, 3, N_BLOCKS, K_BLOCKS, false, 4, NUM_THREADS, false)  \
+  _GET_IF(W_TYPE, 3, N_BLOCKS, K_BLOCKS, false, 8, NUM_THREADS, false)  \
+                                                                        \
+  _GET_IF(W_TYPE, 4, N_BLOCKS, K_BLOCKS, false, -1, NUM_THREADS, false) \
+  _GET_IF(W_TYPE, 4, N_BLOCKS, K_BLOCKS, false, 2, NUM_THREADS, false)  \
+  _GET_IF(W_TYPE, 4, N_BLOCKS, K_BLOCKS, false, 4, NUM_THREADS, false)  \
+  _GET_IF(W_TYPE, 4, N_BLOCKS, K_BLOCKS, false, 8, NUM_THREADS, false)
+
+#define COMMON_GET_IF(W_TYPE)            \
+  COMMON_GET_IF_M1(W_TYPE, 8, 8, 256)    \
+  COMMON_GET_IF_M1(W_TYPE, 8, 4, 128)    \
+  COMMON_GET_IF_M234(W_TYPE, 16, 4, 256) \
+  COMMON_GET_IF_M234(W_TYPE, 8, 4, 128)
+
+#define BIGGROUP_GET_IF_M1(W_TYPE, N_BLOCKS, K_BLOCKS, NUM_THREADS)     \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, true, -1, NUM_THREADS, false)  \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, true, 8, NUM_THREADS, false)   \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, false, -1, NUM_THREADS, false) \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, false, 8, NUM_THREADS, false)
+
+#define BIGGROUP_GET_IF_M234(W_TYPE, N_BLOCKS, K_BLOCKS, NUM_THREADS)   \
+  _GET_IF(W_TYPE, 2, N_BLOCKS, K_BLOCKS, false, -1, NUM_THREADS, false) \
+  _GET_IF(W_TYPE, 2, N_BLOCKS, K_BLOCKS, false, 8, NUM_THREADS, false)  \
+  _GET_IF(W_TYPE, 3, N_BLOCKS, K_BLOCKS, false, -1, NUM_THREADS, false) \
+  _GET_IF(W_TYPE, 3, N_BLOCKS, K_BLOCKS, false, 8, NUM_THREADS, false)  \
+  _GET_IF(W_TYPE, 4, N_BLOCKS, K_BLOCKS, false, -1, NUM_THREADS, false) \
+  _GET_IF(W_TYPE, 4, N_BLOCKS, K_BLOCKS, false, 8, NUM_THREADS, false)
+
+#define BIGGROUP_GET_IF(W_TYPE)            \
+  BIGGROUP_GET_IF_M1(W_TYPE, 8, 8, 256)    \
+  BIGGROUP_GET_IF_M1(W_TYPE, 8, 4, 128)    \
+  BIGGROUP_GET_IF_M234(W_TYPE, 16, 4, 256) \
+  BIGGROUP_GET_IF_M234(W_TYPE, 8, 4, 128)
+
+#define NVFP4_GET_IF_M1(W_TYPE, N_BLOCKS, K_BLOCKS, NUM_THREADS)      \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, true, 1, NUM_THREADS, false) \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, false, 1, NUM_THREADS, false)
+
+#define NVFP4_GET_IF_M234(W_TYPE, N_BLOCKS, K_BLOCKS, NUM_THREADS)     \
+  _GET_IF(W_TYPE, 2, N_BLOCKS, K_BLOCKS, false, 1, NUM_THREADS, false) \
+  _GET_IF(W_TYPE, 3, N_BLOCKS, K_BLOCKS, false, 1, NUM_THREADS, false) \
+  _GET_IF(W_TYPE, 4, N_BLOCKS, K_BLOCKS, false, 1, NUM_THREADS, false)
+
+#define NVFP4_GET_IF(W_TYPE)            \
+  NVFP4_GET_IF_M1(W_TYPE, 8, 8, 256)    \
+  NVFP4_GET_IF_M1(W_TYPE, 8, 4, 128)    \
+  NVFP4_GET_IF_M234(W_TYPE, 16, 4, 256) \
+  NVFP4_GET_IF_M234(W_TYPE, 8, 4, 128)
+
+#define MXFP4_GET_IF_M1(W_TYPE, N_BLOCKS, K_BLOCKS, NUM_THREADS)      \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, true, 2, NUM_THREADS, false) \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, false, 2, NUM_THREADS, false)
+
+#define MXFP4_GET_IF_M234(W_TYPE, N_BLOCKS, K_BLOCKS, NUM_THREADS)     \
+  _GET_IF(W_TYPE, 2, N_BLOCKS, K_BLOCKS, false, 2, NUM_THREADS, false) \
+  _GET_IF(W_TYPE, 3, N_BLOCKS, K_BLOCKS, false, 2, NUM_THREADS, false) \
+  _GET_IF(W_TYPE, 4, N_BLOCKS, K_BLOCKS, false, 2, NUM_THREADS, false)
+
+#define MXFP4_GET_IF(W_TYPE)            \
+  MXFP4_GET_IF_M1(W_TYPE, 8, 8, 256)    \
+  MXFP4_GET_IF_M1(W_TYPE, 8, 4, 128)    \
+  MXFP4_GET_IF_M234(W_TYPE, 16, 4, 256) \
+  MXFP4_GET_IF_M234(W_TYPE, 8, 4, 128)
+
+// We currently have 4-bit models only with group_blocks == 4
+#define FZP_GET_IF_M1(W_TYPE, N_BLOCKS, K_BLOCKS, NUM_THREADS)       \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, true, 4, NUM_THREADS, true) \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, false, 4, NUM_THREADS, true)
+
+#define FZP_GET_IF_M234(W_TYPE, N_BLOCKS, K_BLOCKS, NUM_THREADS)      \
+  _GET_IF(W_TYPE, 2, N_BLOCKS, K_BLOCKS, false, 4, NUM_THREADS, true) \
+  _GET_IF(W_TYPE, 3, N_BLOCKS, K_BLOCKS, false, 4, NUM_THREADS, true) \
+  _GET_IF(W_TYPE, 4, N_BLOCKS, K_BLOCKS, false, 4, NUM_THREADS, true)
+
+#define FZP_GET_IF(W_TYPE)            \
+  FZP_GET_IF_M1(W_TYPE, 8, 8, 256)    \
+  FZP_GET_IF_M1(W_TYPE, 8, 4, 128)    \
+  FZP_GET_IF_M234(W_TYPE, 16, 4, 256) \
+  FZP_GET_IF_M234(W_TYPE, 8, 4, 128)
+
+// We currently have 4-bit models only with group_blocks == 4
+#define ACT_GET_IF_M1(W_TYPE, N_BLOCKS, K_BLOCKS, NUM_THREADS)        \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, true, 0, NUM_THREADS, false) \
+  _GET_IF(W_TYPE, 1, N_BLOCKS, K_BLOCKS, false, 0, NUM_THREADS, false)
+
+#define ACT_GET_IF_M234(W_TYPE, N_BLOCKS, K_BLOCKS, NUM_THREADS)       \
+  _GET_IF(W_TYPE, 2, N_BLOCKS, K_BLOCKS, false, 0, NUM_THREADS, false) \
+  _GET_IF(W_TYPE, 3, N_BLOCKS, K_BLOCKS, false, 0, NUM_THREADS, false) \
+  _GET_IF(W_TYPE, 4, N_BLOCKS, K_BLOCKS, false, 0, NUM_THREADS, false)
+
+#define ACT_GET_IF(W_TYPE)            \
+  ACT_GET_IF_M1(W_TYPE, 8, 8, 256)    \
+  ACT_GET_IF_M1(W_TYPE, 8, 4, 128)    \
+  ACT_GET_IF_M234(W_TYPE, 16, 4, 256) \
+  ACT_GET_IF_M234(W_TYPE, 8, 4, 128)
+
+template <typename scalar_t, bool kIsEP, bool kHasBias>
+MarlinFuncPtr get_marlin_kernel(
+    const host::ScalarType q_type,
+    int thread_m_blocks,
+    int thread_n_blocks,
+    int thread_k_blocks,
+    bool m_block_size_8,
+    bool has_act_order,
+    bool has_zp,
+    int group_blocks,
+    int num_threads,
+    bool is_zp_float) {
+  int num_bits = q_type.size_bits();
+  auto kernel = MarlinDefault;
+  if (false) {
+  }
+
+  COMMON_GET_IF(host::kU4)
+  COMMON_GET_IF(host::kU4B8)
+  COMMON_GET_IF(host::kU8B128)
+
+  NVFP4_GET_IF(host::kFE2M1f)
+
+  BIGGROUP_GET_IF(host::kFE4M3fn)
+
+  ACT_GET_IF(host::kU4B8)
+  ACT_GET_IF(host::kU8B128)
+  if (std::is_same<scalar_t, nv_bfloat16>::value) {
+    if (false) {
+    }
+    MXFP4_GET_IF(host::kFE2M1f)
+  }
+
+  return kernel;
+}
+
+template <typename scalar_t, bool kIsEP, bool kHasBias>
+exec_config_t determine_exec_config(
+    const host::ScalarType& q_type,
+    int prob_m,
+    int prob_n,
+    int prob_k,
+    int top_k,
+    int thread_m_blocks,
+    bool m_block_size_8,
+    int num_bits,
+    int group_size,
+    bool has_act_order,
+    bool is_k_full,
+    bool has_zp,
+    bool is_zp_float,
+    int max_shared_mem,
+    int sms) {
+  exec_config_t exec_cfg = exec_config_t{1, thread_config_t{-1, -1, -1}};
+  thread_config_t* thread_configs = thread_m_blocks > 1 ? large_batch_thread_configs : small_batch_thread_configs;
+  int thread_configs_size = thread_m_blocks > 1 ? sizeof(large_batch_thread_configs) / sizeof(thread_config_t)
+                                                : sizeof(small_batch_thread_configs) / sizeof(thread_config_t);
+
+  int count = 0;
+  constexpr int device_max_reg_size = 255 * 1024;
+  for (int i = 0; i < thread_configs_size; i++) {
+    thread_config_t th_config = thread_configs[i];
+
+    if (!is_valid_config(
+            th_config,
+            m_block_size_8,
+            thread_m_blocks,
+            prob_m,
+            prob_n,
+            prob_k,
+            num_bits,
+            group_size,
+            has_act_order,
+            is_k_full,
+            has_zp,
+            is_zp_float,
+            max_shared_mem)) {
+      continue;
+    }
+
+    int cache_size = get_kernel_cache_size(
+        th_config,
+        m_block_size_8,
+        thread_m_blocks,
+        prob_m,
+        prob_n,
+        prob_k,
+        num_bits,
+        group_size,
+        has_act_order,
+        is_k_full,
+        has_zp,
+        is_zp_float);
+
+    int group_blocks = 0;
+    if (!has_act_order) {
+      group_blocks = group_size == -1 ? -1 : (group_size / 16);
+    }
+
+    auto kernel = get_marlin_kernel<scalar_t, kIsEP, kHasBias>(
+        q_type,
+        thread_m_blocks,
+        th_config.thread_n / 16,
+        th_config.thread_k / 16,
+        m_block_size_8,
+        has_act_order,
+        has_zp,
+        group_blocks,
+        th_config.num_threads,
+        is_zp_float);
+
+    if (kernel == MarlinDefault) continue;
+
+    cudaFuncAttributes attr;
+    cudaFuncGetAttributes(&attr, kernel);
+    int reg_size = max(attr.numRegs, 1) * th_config.num_threads * 4;
+    int allow_count =
+        min(device_max_reg_size / reg_size,
+            max_shared_mem / (cache_size + kSharedMemoryValidityMargin + kSharedMemoryLaunchReserve));
+    allow_count = max(min(allow_count, thread_m_blocks == 1 ? 4 : 2), 1);
+
+    if (thread_m_blocks > 1) {
+      int problem_blocks = prob_n / th_config.thread_n * prob_m * top_k * 4;
+      if (problem_blocks < sms * allow_count) {
+        allow_count = max(problem_blocks / sms, 1);
+      }
+    }
+
+    if (allow_count > count) {
+      count = allow_count;
+      exec_cfg = {count, th_config};
+    }
+  }
+
+  return exec_cfg;
+}
+
+template <typename scalar_t, bool kIsEP, bool kHasBias>
+void marlin_mm(
+    const void* A,
+    const void* B,
+    void* C,
+    void* C_tmp,
+    void* b_bias,
+    void* s,
+    void* s2,
+    void* zp,
+    void* g_idx,
+    void* perm,
+    void* a_tmp,
+    void* sorted_token_ids,
+    void* expert_ids,
+    void* num_tokens_past_padded,
+    void* topk_weights,
+    int moe_block_size,
+    int top_k,
+    bool mul_topk_weights,
+    bool is_ep,
+    int prob_m,
+    int prob_n,
+    int prob_k,
+    void* workspace,
+    host::ScalarType const& q_type,
+    bool has_bias,
+    bool has_act_order,
+    bool is_k_full,
+    bool has_zp,
+    int num_groups,
+    int group_size,
+    int dev,
+    cudaStream_t stream,
+    int thread_k,
+    int thread_n,
+    int sms,
+    bool use_atomic_add,
+    bool use_fp32_reduce,
+    bool is_zp_float) {
+  int thread_m_blocks = div_ceil(moe_block_size, 16);
+  bool m_block_size_8 = moe_block_size == 8;
+
+  if (has_zp) {
+    host::RuntimeCheck(
+        q_type == host::kU4 || q_type == host::kU8, "q_type must be u4 or u8 when has_zp = True. Got = ", q_type.str());
+  } else {
+    host::RuntimeCheck(
+        q_type == host::kU4B8 || q_type == host::kU8B128 || q_type == host::kFE4M3fn || q_type == host::kFE2M1f,
+        "q_type must be uint4b8, uint8b128, float8_e4m3fn or float4_e2m1f when "
+        "has_zp = False. Got = ",
+        q_type.str());
+  }
+
+  host::RuntimeCheck(
+      prob_m > 0 && prob_n > 0 && prob_k > 0, "Invalid MNK = [", prob_m, ", ", prob_n, ", ", prob_k, "]");
+
+  int group_blocks = 0;
+  if (has_act_order) {
+    if (is_k_full) {
+      host::RuntimeCheck(group_size != -1);
+      group_blocks = group_size / 16;
+      host::RuntimeCheck(
+          prob_k % group_blocks == 0, "prob_k = ", prob_k, " is not divisible by group_blocks = ", group_blocks);
+    } else {
+      host::RuntimeCheck(group_size == 0);
+      group_blocks = 0;
+    }
+  } else {
+    if (group_size == -1) {
+      group_blocks = -1;
+    } else {
+      group_blocks = group_size / 16;
+      host::RuntimeCheck(
+          prob_k % group_blocks == 0, "prob_k = ", prob_k, " is not divisible by group_blocks = ", group_blocks);
+    }
+  }
+
+  int num_bits = q_type.size_bits();
+  const int4* A_ptr = (const int4*)A;
+  const int4* B_ptr = (const int4*)B;
+  int4* C_ptr = (int4*)C;
+  int4* C_tmp_ptr = (int4*)C_tmp;
+  const int4* bias_ptr = (const int4*)b_bias;
+  const int4* s_ptr = (const int4*)s;
+  const uint16_t* s2_ptr = (const uint16_t*)s2;
+  const int4* zp_ptr = (const int4*)zp;
+  const int* g_idx_ptr = (const int*)g_idx;
+  const int* perm_ptr = (const int*)perm;
+  int4* a_tmp_ptr = (int4*)a_tmp;
+  const int32_t* sorted_token_ids_ptr = (const int32_t*)sorted_token_ids;
+  const int32_t* expert_ids_ptr = (const int32_t*)expert_ids;
+  const int32_t* num_tokens_past_padded_ptr = (const int32_t*)num_tokens_past_padded;
+  const float* topk_weights_ptr = (const float*)topk_weights;
+  int* locks = (int*)workspace;
+
+  if (has_act_order) {
+    // Permute A columns
+    auto perm_kernel = permute_cols_kernel<8>;
+    if (moe_block_size == 8) {
+    } else if (moe_block_size == 16)
+      perm_kernel = permute_cols_kernel<16>;
+    else if (moe_block_size == 32)
+      perm_kernel = permute_cols_kernel<32>;
+    else if (moe_block_size == 48)
+      perm_kernel = permute_cols_kernel<48>;
+    else if (moe_block_size == 64)
+      perm_kernel = permute_cols_kernel<64>;
+    else
+      host::Panic("unsupported moe_block_size ", moe_block_size);
+
+    // clang-format off
+    perm_kernel<<<sms, default_threads, 0, stream>>>(
+        A_ptr, perm_ptr, a_tmp_ptr, sorted_token_ids_ptr, expert_ids_ptr,
+        num_tokens_past_padded_ptr, prob_m, prob_k, top_k);
+    // clang-format on
+    A_ptr = a_tmp_ptr;
+    prob_m = prob_m * top_k;
+    top_k = 1;
+
+    // If we have a full K, then we can run the non-act-order version of Marlin
+    // (since the weight rows are reordered by increasing group ids, and by
+    // having a full K, we have full original groups)
+    if (is_k_full) has_act_order = false;
+  }
+
+  int max_shared_mem = 0;
+  host::RuntimeDeviceCheck(cudaDeviceGetAttribute(&max_shared_mem, cudaDevAttrMaxSharedMemoryPerBlockOptin, dev));
+  host::RuntimeCheck(max_shared_mem > 0);
+
+  // Set thread config
+  exec_config_t exec_cfg;
+  thread_config_t thread_tfg;
+  if (thread_k != -1 && thread_n != -1) {
+    thread_tfg = thread_config_t{thread_k, thread_n, default_threads};
+    exec_cfg = exec_config_t{1, thread_tfg};
+    host::RuntimeCheck(prob_n % thread_n == 0, "prob_n = ", prob_n, " is not divisible by thread_n = ", thread_n);
+    host::RuntimeCheck(prob_k % thread_k == 0, "prob_k = ", prob_k, " is not divisible by thread_k = ", thread_k);
+  } else {
+    // Auto config
+    exec_cfg = determine_exec_config<scalar_t, kIsEP, kHasBias>(
+        q_type,
+        prob_m,
+        prob_n,
+        prob_k,
+        top_k,
+        thread_m_blocks,
+        m_block_size_8,
+        num_bits,
+        group_size,
+        has_act_order,
+        is_k_full,
+        has_zp,
+        is_zp_float,
+        max_shared_mem,
+        sms);
+    thread_tfg = exec_cfg.tb_cfg;
+  }
+
+  int num_threads = thread_tfg.num_threads;
+  thread_k = thread_tfg.thread_k;
+  thread_n = thread_tfg.thread_n;
+  int blocks = sms * exec_cfg.blocks_per_sm;
+  if (exec_cfg.blocks_per_sm > 1) max_shared_mem = max_shared_mem / exec_cfg.blocks_per_sm - kSharedMemoryLaunchReserve;
+
+  int thread_k_blocks = thread_k / 16;
+  int thread_n_blocks = thread_n / 16;
+
+  host::RuntimeCheck(
+      is_valid_config(
+          thread_tfg,
+          m_block_size_8,
+          thread_m_blocks,
+          prob_m,
+          prob_n,
+          prob_k,
+          num_bits,
+          group_size,
+          has_act_order,
+          is_k_full,
+          has_zp,
+          is_zp_float,
+          max_shared_mem),
+      "Invalid thread config: thread_m_blocks = ",
+      thread_m_blocks,
+      ", thread_k = ",
+      thread_tfg.thread_k,
+      ", thread_n = ",
+      thread_tfg.thread_n,
+      ", num_threads = ",
+      thread_tfg.num_threads,
+      " for MKN = [",
+      prob_m,
+      ", ",
+      prob_k,
+      ", ",
+      prob_n,
+      "] and num_bits = ",
+      num_bits,
+      ", group_size = ",
+      group_size,
+      ", has_act_order = ",
+      has_act_order,
+      ", is_k_full = ",
+      is_k_full,
+      ", has_zp = ",
+      has_zp,
+      ", is_zp_float = ",
+      is_zp_float,
+      ", max_shared_mem = ",
+      max_shared_mem);
+
+  auto kernel = get_marlin_kernel<scalar_t, kIsEP, kHasBias>(
+      q_type,
+      thread_m_blocks,
+      thread_n_blocks,
+      thread_k_blocks,
+      m_block_size_8,
+      has_act_order,
+      has_zp,
+      group_blocks,
+      num_threads,
+      is_zp_float);
+
+  if (kernel == MarlinDefault) {
+    host::Panic(
+        "Unsupported shapes: MNK = [",
+        prob_m,
+        ", ",
+        prob_n,
+        ", ",
+        prob_k,
+        "]",
+        ", has_act_order = ",
+        has_act_order,
+        ", num_groups = ",
+        num_groups,
+        ", group_size = ",
+        group_size,
+        ", thread_m_blocks = ",
+        thread_m_blocks,
+        ", thread_n_blocks = ",
+        thread_n_blocks,
+        ", thread_k_blocks = ",
+        thread_k_blocks,
+        ", num_bits = ",
+        num_bits);
+  }
+
+  host::RuntimeDeviceCheck(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, max_shared_mem));
+  // clang-format off
+  kernel<<<blocks, num_threads, max_shared_mem, stream>>>(
+      A_ptr, B_ptr, C_ptr, C_tmp_ptr, bias_ptr, s_ptr, s2_ptr, zp_ptr, g_idx_ptr,
+      sorted_token_ids_ptr, expert_ids_ptr, num_tokens_past_padded_ptr,
+      topk_weights_ptr, top_k, mul_topk_weights, is_ep, num_groups, prob_m,
+      prob_n, prob_k, locks, has_bias, use_atomic_add, use_fp32_reduce, max_shared_mem);
+  // clang-format on
+}
+
+#endif
+
+}  // namespace device::marlin_moe
+
+template <typename scalar_t, bool kIsEP, bool kHasBias>
+void moe_wna16_marlin_gemm(
+    tvm::ffi::TensorView a,
+    tvm::ffi::TensorView c,
+    tvm::ffi::TensorView b_q_weight,
+    tvm::ffi::TensorView b_bias,
+    tvm::ffi::TensorView b_scales,
+    tvm::ffi::TensorView global_scale,
+    tvm::ffi::TensorView b_zeros,
+    tvm::ffi::TensorView g_idx,
+    tvm::ffi::TensorView perm,
+    tvm::ffi::TensorView workspace,
+    tvm::ffi::TensorView sorted_token_ids,
+    tvm::ffi::TensorView expert_ids,
+    tvm::ffi::TensorView num_tokens_post_padded,
+    tvm::ffi::TensorView topk_weights,
+    tvm::ffi::TensorView a_tmp,
+    tvm::ffi::TensorView c_tmp,
+    int64_t moe_block_size,
+    int64_t top_k,
+    bool mul_topk_weights,
+    bool is_ep,
+    int64_t b_q_type_id,
+    int64_t size_m,
+    int64_t size_n,
+    int64_t size_k,
+    bool has_act_order,
+    bool has_bias,
+    bool is_k_full,
+    bool has_zp,
+    int64_t num_groups,
+    int64_t group_size,
+    bool use_atomic_add,
+    bool use_fp32_reduce,
+    bool is_zp_float) {
+  using namespace host;
+
+  RuntimeCheck(is_ep == kIsEP, "is_ep does not match the compiled Marlin MoE specialization");
+  RuntimeCheck(has_bias == kHasBias, "has_bias does not match the compiled Marlin MoE specialization");
+
+  ScalarType const b_q_type = ScalarType::from_id(b_q_type_id);
+  int pack_factor = 32 / b_q_type.size_bits();
+
+  if (moe_block_size != 8) {
+    RuntimeCheck(moe_block_size % 16 == 0, "unsupported moe_block_size=", moe_block_size);
+    RuntimeCheck(moe_block_size >= 16 && moe_block_size <= 64, "unsupported moe_block_size=", moe_block_size);
+  }
+
+  // Verify A
+  RuntimeCheck(a.size(0) == size_m, "Shape mismatch: a.size(0) = ", a.size(0), ", size_m = ", size_m);
+  RuntimeCheck(a.size(1) == size_k, "Shape mismatch: a.size(1) = ", a.size(1), ", size_k = ", size_k);
+
+  // Verify B
+  RuntimeCheck(
+      size_k % device::marlin::tile_size == 0,
+      "size_k = ",
+      size_k,
+      " is not divisible by tile_size = ",
+      device::marlin::tile_size);
+  RuntimeCheck(
+      (size_k / device::marlin::tile_size) == b_q_weight.size(1),
+      "Shape mismatch: b_q_weight.size(1) = ",
+      b_q_weight.size(1),
+      ", size_k = ",
+      size_k,
+      ", tile_size = ",
+      device::marlin::tile_size);
+  RuntimeCheck(
+      b_q_weight.size(2) % device::marlin::tile_size == 0,
+      "b_q_weight.size(2) = ",
+      b_q_weight.size(2),
+      " is not divisible by tile_size = ",
+      device::marlin::tile_size);
+  int64_t actual_size_n = (b_q_weight.size(2) / device::marlin::tile_size) * pack_factor;
+  RuntimeCheck(size_n == actual_size_n, "size_n = ", size_n, ", actual_size_n = ", actual_size_n);
+
+  // Verify device and strides. The tensors all live on the same CUDA device
+  // (allocated together in Python); resolve it from ``a`` and use TVM-FFI's
+  // ambient stream, mirroring the other tokenspeed marlin bindings.
+  DLDevice dl_device = a.device();
+  int dev = dl_device.device_id;
+  cudaStream_t stream = get_stream(dl_device);
+  RuntimeCheck(b_q_weight.is_contiguous(), "b_q_weight is not contiguous");
+  RuntimeCheck(b_scales.is_contiguous(), "b_scales is not contiguous");
+
+  // thread_k, thread_n, sms
+  int thread_k = -1;
+  int thread_n = -1;
+  int sms = -1;
+  RuntimeDeviceCheck(cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, dev));
+
+  // Verify c (allocation done in Python)
+  RuntimeCheck(c.is_contiguous(), "c is not contiguous");
+  RuntimeCheck(
+      c.size(0) == size_m * top_k, "Shape mismatch: c.size(0) = ", c.size(0), ", size_m * topk = ", size_m * top_k);
+  RuntimeCheck(c.size(1) == size_n, "Shape mismatch: c.size(1) = ", c.size(1), ", size_n = ", size_n);
+
+  // Alloc c_tmp: SKIP, done in Python
+
+  // Detect groupsize: b_scales rank and dims
+  RuntimeCheck(b_scales.dim() == 3, "b_scales rank = ", b_scales.dim(), " is not 3");
+  RuntimeCheck(b_scales.size(2) == size_n, "b_scales dim 2 = ", b_scales.size(2), " is not size_n = ", size_n);
+  RuntimeCheck(
+      b_scales.size(1) == num_groups, "b_scales dim 1 = ", b_scales.size(1), " is not num_groups = ", num_groups);
+
+  // Validate g_idx, perm (Optional unwrap done in Python; empty tensors when absent)
+  if (g_idx.size(g_idx.dim() - 1) > 0 && perm.size(perm.dim() - 1) > 0) {
+    // device co-located (resolved from a);
+    RuntimeCheck(g_idx.is_contiguous(), "g_idx is not contiguous");
+    // device co-located (resolved from a);
+    RuntimeCheck(perm.is_contiguous(), "perm is not contiguous");
+
+    int64_t g_idx_last = g_idx.size(g_idx.dim() - 1);
+    int64_t perm_last = perm.size(perm.dim() - 1);
+    RuntimeCheck(
+        (g_idx_last == 0 && perm_last == 0) || (g_idx_last == size_k && perm_last == size_k),
+        "Unexpected g_idx.size(-1) = ",
+        g_idx_last,
+        " and perm.size(-1) = ",
+        perm_last,
+        ", where size_k = ",
+        size_k);
+  }
+  // has_act_order derivation: SKIP (passed as param)
+
+  // Verify group_size consistency
+  if (has_act_order) {
+    // SKIP: a_tmp allocation done in Python
+    if (is_k_full) {
+      RuntimeCheck(num_groups > 1, "For act_order, num_groups must be > 1");
+      RuntimeCheck(size_k % num_groups == 0, "size_k = ", size_k, ", is not divisible by num_groups = ", num_groups);
+    }
+  } else {
+    if (num_groups > 1) {
+      RuntimeCheck(
+          size_k % num_groups == 0, "size_k = ", size_k, ", is not divisible by b_scales.size(1) = ", num_groups);
+    }
+  }
+
+  // Verify global_scale (Optional unwrap done in Python)
+  int64_t global_scale_size = global_scale.size(0);
+  if (global_scale_size > 0) {
+    RuntimeCheck(b_q_type == kFE2M1f && group_size == 16, "global_scale can only be used for nvfp4 format.");
+  } else {
+    RuntimeCheck(
+        !(b_q_type == kFE2M1f && group_size == 16), "the global_scale parameter must be passed for nvfp4 format.");
+  }
+
+  // Verify b_bias (Optional unwrap done in Python)
+  if (has_bias) {
+    // device co-located (resolved from a);
+    RuntimeCheck(b_bias.is_contiguous(), "b_bias is not contiguous");
+    RuntimeCheck(b_bias.size(1) == size_n, "b_bias.size(0) != size_n");
+    RuntimeCheck(b_bias.stride(1) == 1, "b_bias.stride(1) != 1");
+  }
+
+  // b_zeros Optional unwrap + has_zp derivation: SKIP (done in Python)
+
+  // Verify b_q_type vs has_zp
+  if (has_zp) {
+    // device co-located (resolved from a);
+    RuntimeCheck(b_zeros.is_contiguous(), "b_zeros is not contiguous");
+    RuntimeCheck(
+        b_q_type == kU4 || b_q_type == kU8, "b_q_type must be u4 or u8 when has_zp = True. Got = ", b_q_type.str());
+  } else {
+    RuntimeCheck(
+        b_q_type == kU4B8 || b_q_type == kU8B128 || b_q_type == kFE4M3fn || b_q_type == kFE2M1f,
+        "b_q_type must be uint4b8, uint8b128, float8_e4m3fn or "
+        "float4_e2m1f when "
+        "has_zp = False. Got = ",
+        b_q_type.str());
+  }
+
+  if (has_zp && is_zp_float) {
+    RuntimeCheck(
+        std::is_same<scalar_t, fp16_t>::value,
+        "Computation type must be float16 (half) when using float zero "
+        "points.");
+  }
+
+  if (b_q_type == kFE2M1f) {
+    RuntimeCheck(
+        group_size == 16 || group_size == 32,
+        "float4_e2m1f only supports group_size == 16 (NVFP4) or group_size == 32 (MXFP4). Got group_size = ",
+        group_size);
+    RuntimeCheck(
+        group_size != 32 || std::is_same<scalar_t, nv_bfloat16>::value,
+        "MXFP4 Marlin with E8M0 scales is only instantiated for bfloat16 activations.");
+  }
+
+  // Verify b_zeros
+  if (has_zp) {
+    RuntimeCheck(b_zeros.dim() == 3, "b_zeros rank = ", b_zeros.dim(), " is not 3");
+    if (is_zp_float) {
+      RuntimeCheck(b_zeros.size(2) == size_n, "b_zeros dim 2 = ", b_zeros.size(2), " is not size_n = ", size_n);
+      RuntimeCheck(
+          num_groups == b_zeros.size(1), "b_zeros dim 1 = ", b_zeros.size(1), " is not num_groups = ", num_groups);
+      RuntimeCheck(num_groups != -1, "num_groups must be != -1");
+    } else {
+      RuntimeCheck(
+          b_zeros.size(1) == num_groups, "b_zeros dim 1 = ", b_zeros.size(1), " is not num_groups = ", num_groups);
+      RuntimeCheck(
+          b_zeros.size(2) == size_n / pack_factor,
+          "b_zeros dim 2 = ",
+          b_zeros.size(2),
+          " is not size_n / pack_factor = ",
+          size_n / pack_factor);
+    }
+  }
+
+  // Verify workspace size
+  RuntimeCheck(
+      size_n % device::marlin::min_thread_n == 0,
+      "size_n = ",
+      size_n,
+      ", is not divisible by min_thread_n = ",
+      device::marlin::min_thread_n);
+
+  int64_t max_n_tiles = size_n / device::marlin::min_thread_n;
+  int64_t min_workspace_size =
+      std::min(max_n_tiles * (sorted_token_ids.size(0) / moe_block_size), static_cast<int64_t>(sms) * 4);
+  RuntimeCheck(
+      workspace.size(0) >= min_workspace_size,
+      "workspace.numel = ",
+      workspace.size(0),
+      " is below min_workspace_size = ",
+      min_workspace_size);
+
+  // Early return for zero-size M (moved after all validation)
+  if (size_m == 0) return;
+
+  device::marlin_moe::marlin_mm<scalar_t, kIsEP, kHasBias>(
+      a.data_ptr(),
+      b_q_weight.data_ptr(),
+      c.data_ptr(),
+      c_tmp.data_ptr(),
+      b_bias.data_ptr(),
+      b_scales.data_ptr(),
+      global_scale.data_ptr(),
+      b_zeros.data_ptr(),
+      g_idx.data_ptr(),
+      perm.data_ptr(),
+      a_tmp.data_ptr(),
+      sorted_token_ids.data_ptr(),
+      expert_ids.data_ptr(),
+      num_tokens_post_padded.data_ptr(),
+      topk_weights.data_ptr(),
+      static_cast<int>(moe_block_size),
+      static_cast<int>(top_k),
+      mul_topk_weights,
+      is_ep,
+      static_cast<int>(size_m),
+      static_cast<int>(size_n),
+      static_cast<int>(size_k),
+      workspace.data_ptr(),
+      b_q_type,
+      has_bias,
+      has_act_order,
+      is_k_full,
+      has_zp,
+      static_cast<int>(num_groups),
+      static_cast<int>(group_size),
+      dev,
+      stream,
+      thread_k,
+      thread_n,
+      sms,
+      use_atomic_add,
+      use_fp32_reduce,
+      is_zp_float);
+}

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/marlin_moe.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/marlin_moe.py
@@ -1,0 +1,294 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Marlin WNA16 MoE GEMM (weight-only 4-bit, grouped experts).
+
+Wraps the pre-compiled vendored Marlin MoE kernel (see csrc/marlin_moe/). Only
+the bf16-activation specializations are exported: MXFP4 with E8M0 group-32
+scales is numerically valid only on the bf16 path.
+"""
+
+from __future__ import annotations
+
+import functools
+from pathlib import Path
+
+import torch
+
+# ScalarType id for float4_e2m1f, matching the C++ ScalarType bit encoding
+# (exponent=2:8b | mantissa=1:8b | signed=1:1b | bias=0:32b |
+# finite_values_only=1:1b | nan_repr=NONE(0):8b). Keep in sync with
+# csrc/marlin_moe/include/scalar_type.hpp (kFE2M1f).
+FLOAT4_E2M1F_ID = (2) | (1 << 8) | (1 << 16) | (0 << 17) | (1 << 49) | (0 << 50)
+
+# Max thread_n across kernel configs; sizes the fp32-reduce scratch. Matches
+# device::marlin_moe in csrc/marlin_moe/moe_wna16_marlin.cuh.
+_MAX_THREAD_N = 256
+
+
+def _objs_dir() -> Path:
+    return Path(__file__).resolve().parent / "objs"
+
+
+@functools.cache
+def _load_marlin_moe_module():
+    """Load the pre-compiled marlin_moe shared library via TVM FFI."""
+    import tvm_ffi
+
+    so_path = _objs_dir() / "marlin_moe" / "marlin_moe.so"
+    if not so_path.exists():
+        raise RuntimeError(
+            f"tokenspeed_kernel marlin_moe library not found at {so_path}. "
+            "Run `pip install -e tokenspeed_kernel/python/` to build."
+        )
+    return tvm_ffi.load_module(str(so_path))
+
+
+def is_marlin_moe_available() -> bool:
+    """Report whether the pre-compiled marlin_moe library is present."""
+    return (_objs_dir() / "marlin_moe" / "marlin_moe.so").exists()
+
+
+def _empty(device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+    return torch.empty(0, device=device, dtype=dtype)
+
+
+def marlin_make_workspace(
+    device: torch.device, max_blocks_per_sm: int = 4
+) -> torch.Tensor:
+    """Allocate the zero-initialized inter-block sync workspace.
+
+    Args:
+        device: CUDA device to allocate on.
+        max_blocks_per_sm: Upper bound of resident blocks per SM used to size
+            the lock array.
+
+    Returns:
+        int32 zeros ``[sms * max_blocks_per_sm]``. Allocate per call when
+        capturing CUDA graphs: captured graphs must not alias another graph's
+        locks, or replay can deadlock on stale lock state.
+    """
+    sms = torch.cuda.get_device_properties(device).multi_processor_count
+    return torch.zeros(
+        sms * max_blocks_per_sm, dtype=torch.int, device=device, requires_grad=False
+    )
+
+
+def _get_scale_perms() -> tuple[list[int], list[int]]:
+    scale_perm: list[int] = []
+    for i in range(8):
+        scale_perm.extend([i + 8 * j for j in range(8)])
+    scale_perm_single: list[int] = []
+    for i in range(4):
+        scale_perm_single.extend([2 * i + j for j in [0, 1, 8, 9, 16, 17, 24, 25]])
+    return scale_perm, scale_perm_single
+
+
+def marlin_permute_scales(
+    s: torch.Tensor, size_k: int, size_n: int, group_size: int
+) -> torch.Tensor:
+    """Permute a 2D scale tensor ``[size_k/group, size_n]`` into Marlin order.
+
+    Matches the layout the Marlin GEMM expects for its dequant path. When the
+    group spans fewer rows than ``size_k`` (grouped quant, e.g. MXFP4 g32) the
+    interleaved 8x8 perm is used; otherwise the per-channel single perm.
+    """
+    scale_perm, scale_perm_single = _get_scale_perms()
+    if group_size < size_k and group_size != -1:
+        s = s.reshape((-1, len(scale_perm)))[:, scale_perm]
+    else:
+        s = s.reshape((-1, len(scale_perm_single)))[:, scale_perm_single]
+    return s.reshape((-1, size_n)).contiguous()
+
+
+def mxfp4_marlin_process_scales(marlin_scales: torch.Tensor) -> torch.Tensor:
+    """Reorder + retype permuted MXFP4 scales for the bf16 Marlin path.
+
+    The bf16 kernel consumes E8M0 scales in a 4-lane [0,2,1,3] order. Input is
+    the ``marlin_permute_scales`` output as uint8 (raw E8M0 bytes).
+    """
+    marlin_scales = marlin_scales.view(-1, 4)[:, [0, 2, 1, 3]].view(
+        marlin_scales.size(0), -1
+    )
+    return marlin_scales.view(torch.float8_e8m0fnu)
+
+
+def moe_align_block_size(
+    topk_ids: torch.Tensor,
+    block_size: int,
+    num_experts: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Sort routes by expert and pad each expert's routes to ``block_size``.
+
+    Args:
+        topk_ids: int32 ``[tokens, top_k]`` global expert ids. Out-of-range
+            ids (EP-masked experts) still get slots; the Marlin kernel skips
+            blocks whose expert id falls outside the local range.
+        block_size: Token block granularity of the downstream grouped GEMM.
+        num_experts: Global expert count.
+
+    Returns:
+        ``(sorted_token_ids, expert_ids, num_tokens_post_padded)`` — flat
+        route ids padded per expert, the expert id of each block, and the
+        total padded route count (device scalar).
+    """
+    device = topk_ids.device
+    if topk_ids.numel() < num_experts + 1:
+        max_num_tokens_padded = topk_ids.numel() * block_size
+    else:
+        max_num_tokens_padded = topk_ids.numel() + (num_experts + 1) * (block_size - 1)
+    sorted_ids = torch.empty(max_num_tokens_padded, dtype=torch.int32, device=device)
+    max_num_m_blocks = (max_num_tokens_padded + block_size - 1) // block_size
+    expert_ids = torch.empty(max_num_m_blocks, dtype=torch.int32, device=device)
+    num_tokens_post_pad = torch.empty(1, dtype=torch.int32, device=device)
+    # One extra lane holds EP-invalid routes; expert ids are emitted as
+    # ``eid - 1`` so real experts land back on [0, num_experts).
+    cumsum_buffer = torch.empty(num_experts + 2, dtype=torch.int32, device=device)
+
+    _load_marlin_moe_module().moe_align_block_size(
+        topk_ids,
+        num_experts + 1,
+        block_size,
+        sorted_ids,
+        expert_ids,
+        num_tokens_post_pad,
+        cumsum_buffer,
+        True,  # pad_sorted_token_ids
+    )
+    return sorted_ids, expert_ids, num_tokens_post_pad
+
+
+def moe_wna16_marlin_gemm(
+    a: torch.Tensor,
+    c: torch.Tensor | None,
+    b_q_weight: torch.Tensor,
+    b_scales: torch.Tensor,
+    workspace: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    topk_weights: torch.Tensor,
+    *,
+    moe_block_size: int,
+    top_k: int,
+    mul_topk_weights: bool,
+    is_ep: bool,
+    size_m: int,
+    size_n: int,
+    size_k: int,
+    use_fp32_reduce: bool = True,
+) -> torch.Tensor:
+    """Run one grouped Marlin W4A16 GEMM over routed expert tokens.
+
+    Computes ``c[route] = a[token(route)] @ dequant(b_q_weight[expert(route)])``
+    for every route produced by ``moe_align_block_size``-style scheduling.
+    MXFP4 weights only (E2M1 packed, E8M0 group-32 scales); activation stays
+    bf16 (W4A16 -- no FP4 tensor cores needed, runs on SM90).
+
+    Args:
+        a: bf16 activations ``[size_m, size_k]``.
+        c: Optional output ``[size_m * top_k, size_n]``; allocated when None.
+            Must be zero-filled by the caller if experts can be masked (EP).
+        b_q_weight: Marlin-repacked weights ``[E, size_k/16, size_n*2]`` int32.
+        b_scales: Marlin-permuted scales ``[E, size_k/32, size_n]``
+            float8_e8m0fnu.
+        workspace: int32 lock array from :func:`marlin_make_workspace`.
+        sorted_token_ids: Routes padded per expert to ``moe_block_size``.
+        expert_ids: Expert id per scheduled block.
+        num_tokens_post_padded: Total scheduled routes after padding.
+        topk_weights: ``[size_m, top_k]`` float32 route weights.
+        moe_block_size: Token block size used by the alignment step (8-64).
+        top_k: Routes per token.
+        mul_topk_weights: Scale outputs by ``topk_weights`` (GEMM2 finalize).
+        is_ep: Expert-parallel mode; out-of-range expert ids are skipped.
+        size_m/size_n/size_k: GEMM problem shape.
+        use_fp32_reduce: Reduce partial tiles in fp32 scratch (recommended).
+
+    Returns:
+        ``c`` with dtype of ``a``.
+    """
+    device = a.device
+    if c is None:
+        c = torch.zeros((size_m * top_k, size_n), dtype=a.dtype, device=device)
+    if size_m == 0:
+        return c
+
+    num_groups = b_scales.size(1)
+    group_size = size_k // num_groups if num_groups > 1 else -1
+
+    # fp32 partial-tile reduction scratch (no atomic-add on the mxfp4 path:
+    # E8M0 bf16 atomics accumulate in bf16 and lose precision).
+    if use_fp32_reduce:
+        sms = torch.cuda.get_device_properties(device).multi_processor_count
+        max_c_tmp_size = min(
+            size_n * sorted_token_ids.size(0),
+            sms * 4 * moe_block_size * _MAX_THREAD_N,
+        )
+        if moe_block_size == 8:
+            max_c_tmp_size *= 2
+        c_tmp = torch.empty(max_c_tmp_size, dtype=torch.float32, device=device)
+    else:
+        c_tmp = torch.empty(0, dtype=torch.float32, device=device)
+
+    empty_a = _empty(device, a.dtype)
+    empty_i32 = _empty(device, torch.int32)
+
+    module = _load_marlin_moe_module()
+    fn = (
+        module.moe_wna16_marlin_gemm_bf16_ep
+        if is_ep
+        else module.moe_wna16_marlin_gemm_bf16
+    )
+    fn(
+        a,
+        c,
+        b_q_weight,
+        empty_a,  # b_bias
+        b_scales,
+        empty_a,  # global_scale
+        empty_a,  # b_zeros
+        empty_i32,  # g_idx
+        empty_i32,  # perm
+        workspace,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        topk_weights,
+        empty_a,  # a_tmp (act_order only)
+        c_tmp,
+        moe_block_size,
+        top_k,
+        mul_topk_weights,
+        is_ep,
+        FLOAT4_E2M1F_ID,
+        size_m,
+        size_n,
+        size_k,
+        False,  # has_act_order
+        False,  # has_bias
+        True,  # is_k_full
+        False,  # has_zp
+        num_groups,
+        group_size,
+        False,  # use_atomic_add
+        use_fp32_reduce,
+        False,  # is_zp_float
+    )
+    return c

--- a/tokenspeed-kernel/test/ops/moe/test_marlin_mxfp4_apply.py
+++ b/tokenspeed-kernel/test/ops/moe/test_marlin_mxfp4_apply.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Numerical check: Marlin W4A16 MXFP4 MoE apply vs a bf16 dequant reference.
+
+Marlin dequantizes the packed E2M1 weights inside the GEMM, so the kernel
+output must track a plain bf16 reference that dequantizes the same weights and
+runs the two linear layers with the SiTU epilogue. Runs on SM90+.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from kimi3_reference import a16w4_mxfp4_moe_reference
+from tokenspeed_kernel.ops.moe.marlin.mxfp4 import (
+    marlin_mxfp4_moe_weights,
+    marlin_mxfp4_precomputed_moe_apply,
+)
+from tokenspeed_kernel.platform import current_platform
+from utils import make_mxfp4_moe_weights
+
+
+def _requires_sm90():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    if not current_platform().is_nvidia:
+        pytest.skip("NVIDIA required")
+    if current_platform().arch_version < type(current_platform().arch_version)(9, 0):
+        pytest.skip("SM90+ required")
+
+
+class _Weights(torch.nn.Module):
+    """Minimal module carrying MXFP4 expert params for the apply kernel."""
+
+    def __init__(self, raw, num_local_experts, ep_size, ep_rank, beta, linear_beta):
+        super().__init__()
+        self.w13_weight = torch.nn.Parameter(raw["w13_weight"], requires_grad=False)
+        self.w13_weight_scale = torch.nn.Parameter(
+            raw["w13_scale"], requires_grad=False
+        )
+        self.w2_weight = torch.nn.Parameter(raw["w2_weight"], requires_grad=False)
+        self.w2_weight_scale = torch.nn.Parameter(raw["w2_scale"], requires_grad=False)
+        self.num_local_experts = num_local_experts
+        self.ep_size = ep_size
+        self.ep_rank = ep_rank
+        self.activation = "situ"
+        self.activation_situ_beta = beta
+        self.activation_situ_linear_beta = linear_beta
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 64])
+def test_marlin_mxfp4_situ_matches_reference(num_tokens: int) -> None:
+    _requires_sm90()
+    generator = torch.Generator(device="cuda").manual_seed(11)
+    num_experts, top_k = 8, 2
+    hidden_size, intermediate_size = 256, 128
+    beta, linear_beta = 4.0, 25.0
+
+    x = (
+        torch.randn(num_tokens, hidden_size, generator=generator, device="cuda") * 0.2
+    ).to(torch.bfloat16)
+    raw = make_mxfp4_moe_weights(
+        num_experts, hidden_size, intermediate_size, generator, device="cuda"
+    )
+    # topk ids/weights: round-robin ids, normalized random weights.
+    topk_ids = (
+        torch.arange(num_tokens * top_k, device="cuda").reshape(num_tokens, top_k)
+        % num_experts
+    ).to(torch.int32)
+    topk_weights = torch.rand(
+        num_tokens, top_k, generator=generator, device="cuda", dtype=torch.float32
+    )
+    topk_weights = topk_weights / topk_weights.sum(-1, keepdim=True)
+
+    expected = a16w4_mxfp4_moe_reference(
+        x,
+        raw["w13_weight"],
+        raw["w13_scale"],
+        raw["w2_weight"],
+        raw["w2_scale"],
+        topk_ids,
+        topk_weights,
+        situ_beta=beta,
+        situ_linear_beta=linear_beta,
+    )
+
+    # Repack in place, then apply (no EP: one rank owns all experts).
+    w = _Weights(
+        {k: v.clone() for k, v in raw.items()},
+        num_local_experts=num_experts,
+        ep_size=1,
+        ep_rank=0,
+        beta=beta,
+        linear_beta=linear_beta,
+    )
+    plan = {"activation": "situ"}
+    marlin_mxfp4_moe_weights(plan, w)
+    actual = marlin_mxfp4_precomputed_moe_apply(
+        plan, x, w, None, topk_weights=topk_weights, topk_ids=topk_ids
+    )
+
+    torch.testing.assert_close(actual.float(), expected.float(), atol=5e-2, rtol=5e-2)
+
+
+def test_marlin_mxfp4_ep_masks_nonlocal_experts() -> None:
+    """EP: each rank owns half the experts; summed ranks == full reference."""
+    _requires_sm90()
+    generator = torch.Generator(device="cuda").manual_seed(23)
+    num_experts, top_k = 8, 2
+    hidden_size, intermediate_size = 256, 128
+    num_tokens = 16
+    beta, linear_beta = 4.0, 25.0
+    ep_size = 2
+    num_local = num_experts // ep_size
+
+    x = (
+        torch.randn(num_tokens, hidden_size, generator=generator, device="cuda") * 0.2
+    ).to(torch.bfloat16)
+    raw = make_mxfp4_moe_weights(
+        num_experts, hidden_size, intermediate_size, generator, device="cuda"
+    )
+    topk_ids = (
+        torch.arange(num_tokens * top_k, device="cuda").reshape(num_tokens, top_k)
+        % num_experts
+    ).to(torch.int32)
+    topk_weights = torch.rand(
+        num_tokens, top_k, generator=generator, device="cuda", dtype=torch.float32
+    )
+    topk_weights = topk_weights / topk_weights.sum(-1, keepdim=True)
+
+    expected = a16w4_mxfp4_moe_reference(
+        x,
+        raw["w13_weight"],
+        raw["w13_scale"],
+        raw["w2_weight"],
+        raw["w2_scale"],
+        topk_ids,
+        topk_weights,
+        situ_beta=beta,
+        situ_linear_beta=linear_beta,
+    )
+
+    acc = torch.zeros_like(x, dtype=torch.float32)
+    plan = {"activation": "situ"}
+    for ep_rank in range(ep_size):
+        lo = ep_rank * num_local
+        shard = {
+            "w13_weight": raw["w13_weight"][lo : lo + num_local].clone(),
+            "w13_scale": raw["w13_scale"][lo : lo + num_local].clone(),
+            "w2_weight": raw["w2_weight"][lo : lo + num_local].clone(),
+            "w2_scale": raw["w2_scale"][lo : lo + num_local].clone(),
+        }
+        w = _Weights(
+            shard,
+            num_local_experts=num_local,
+            ep_size=ep_size,
+            ep_rank=ep_rank,
+            beta=beta,
+            linear_beta=linear_beta,
+        )
+        marlin_mxfp4_moe_weights(plan, w)
+        acc += marlin_mxfp4_precomputed_moe_apply(
+            plan, x, w, None, topk_weights=topk_weights, topk_ids=topk_ids
+        ).float()
+
+    torch.testing.assert_close(acc, expected.float(), atol=5e-2, rtol=5e-2)


### PR DESCRIPTION
### Summary

MLA-family draft backends (`mla`, `flashmla`, `trtllm_mla`) had **two** page-table delivery paths: the CUDA-graph wrapper's per-group table dispatch, and the executor's `DraftPageStaging`. Since MLA drafts are always single-group (history), the wrapper path was redundant. This PR routes all MLA drafts through staging — the backend reads the already-expanded batch-ordered table as kernel pages (identity) — and removes:

- the `_cache_logical_page_size` field and the two group-table helpers (`_resolve_draft_group_table`, `_bind_draft_group_table`),
- the `draft_reads_published_kernel_pages` flag and the double-expansion guard in `ModelExecutor`,
- DeepseekV4's write-only `logical_page_size` field.

It also adds **`FlashMLABackend.fill_block_decode_seq_lens`** so a block drafter (DSpark) can run under **CUDA graph** on SM90 — previously only the eager path worked.

Finally, the startup GPU memory summary now breaks out **KV cache** as its own row and dedupes the draft pool's KV bytes (the draft pool is a view of the target arena, so it was double-counted).

### Kimi-K3 speculative decode (DSpark) on Hopper with CUDA graphs

DSpark is a block-diffusion speculator for Kimi-K3: a 5-layer dense MLA backbone with a rank-256 Markov head supplying intra-block token dependence, drafting 7 tokens in one parallel pass. It shares Kimi-K3's 576-element MLA latent KV layout, so the draft's pages unify with the target's cache arena (one plan, one pool) — which is what lets the speculator run under CUDA graphs on SM90.

#### Launch

Two-node TP16/EP16 (8×H20 per node). Speculative flags on top of the base Kimi-K3 serve command:

```bash
tokenspeed serve <KIMI-K3> \
  --served-model-name Kimi-K3 \
  --moe-backend marlin \
  --attention-backend flashmla \
  --mm-encoder-tp-mode data \
  --speculative-algorithm DSPARK \
  --speculative-draft-model-path <DSPARK> \
  --speculative-num-draft-tokens 8 \
  --speculative-num-steps 7 \
  --disable-weight-loader-prefetch-checkpoints \
  --gpu-memory-utilization 0.85 \
  --max-num-seqs 32 \
  --prefill-graph-max-tokens 0 \
  --nnodes 2 --node-rank <0|1> --dist-init-addr <HOST>:<PORT>
```

Notes:
- **`--speculative-algorithm DSPARK`** (not `DFLASH`): DSPARK runs the Markov-head semi-autoregressive block sampler. Using DFLASH loads the weights but skips the Markov head, collapsing acceptance to ~1.1.
- **CUDA graphs are on** (no `--enforce-eager`); decode graphs are captured, prefill graphs disabled (`--prefill-graph-max-tokens 0`) to fit the bf16 MLA KV under the memory budget.
- `--gpu-memory-utilization 0.85` leaves headroom for the draft model + activations; 0.90 OOMs during target forward.

#### Acceptance (measured: K3 + DSpark, CUDA graph, bs=1, temperature=0)

| Workload | Accept length |
|---|---|
| Low-entropy arithmetic (block-friendly) | **6.5** |
| Ordinary generation (counting / short answers) | **2.6 – 3.8** |

CUDA-graph and eager acceptance match exactly (6.5 on the same probe) and align with the published DSpark reference (mean acceptance ~2.6 on 7 speculative tokens, higher on low-entropy reasoning). Greedy decode is bit-equivalent to the non-speculative baseline (gsm8k 0.99, unchanged).

### Test plan
- [x] `pytest test/runtime/test_cudagraph_per_group.py test/runtime/test_mla_block_decode.py test/runtime/test_trtllm_mla_block_decode.py test/runtime/test_kimi_k3_cudagraph.py test/runtime/test_deepseek_v4_config.py` — 203 passed
- [x] Kimi-K3 + DSpark end-to-end on 2×H20 (TP16/EP16), CUDA graph **and** eager
- [x] DeepSeek MTP regression, CUDA graph **and** eager
- [x] `pre-commit run --all-files`