### PR TITLE
fix(pd): support DeepSeek V4 grouped layerwise cache handoff

### DIFF
--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -366,14 +366,16 @@ class EventLoop:
             unsupported = []
             if self.has_dp:
                 unsupported.append("data-parallel attention")
-            if server_args.enable_mixed_batch:
-                unsupported.append("mixed prefill/decode batches")
             if server_args.speculative_algorithm is not None:
                 unsupported.append("speculative/MTP decoding")
             if server_args.enable_mla_l1_5_cache:
                 unsupported.append("MLA L1.5 cache transfer")
             if server_args.disaggregation_layerwise_interval > 0:
-                unsupported.append("layerwise cache transfer")
+                cache_layout, _ = token_to_kv_pool.get_pd_cache_contract()
+                if not cache_layout.supports_layerwise_transfer:
+                    unsupported.append(
+                        "layerwise cache transfer without per-layer segments"
+                    )
             if server_args.enable_memory_saver:
                 unsupported.append("memory saver/release")
             if server_args.enable_kvstore:

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -366,6 +366,8 @@ class EventLoop:
             unsupported = []
             if self.has_dp:
                 unsupported.append("data-parallel attention")
+            if server_args.enable_mixed_batch:
+                unsupported.append("mixed prefill/decode batches")
             if server_args.speculative_algorithm is not None:
                 unsupported.append("speculative/MTP decoding")
             if server_args.enable_mla_l1_5_cache:

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_deepseek_v4.py
@@ -673,6 +673,17 @@ class HybridDeepseekV4TokenToKVPool(CachePool):
     def zero_new_pages(self, new_page_ids: dict[str, list[int]]) -> None:
         self.zero_blocks(new_page_ids)
 
+    @property
+    def supports_disaggregation(self) -> bool:
+        return bool(self.paged_cache_group_specs) and all(
+            spec.transfer_policy is not None for spec in self.paged_cache_group_specs
+        )
+
+    def get_pd_cache_contract(self):
+        if not self.supports_disaggregation:
+            raise RuntimeError("DeepSeek V4 cache PD is not enabled")
+        return self.pd_contract(self.paged_cache_group_specs)
+
     def get_contiguous_buf_infos(self):
         raise RuntimeError("DeepSeek V4 transfer uses the cache contract")
 

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4.py
@@ -271,6 +271,7 @@ def prepare_deepseek_v4_cache(
             layer_ratio=merged_layout.layer_ratio,
             cache_blocks_per_lcm_block=packing,
             decode_input_tokens=decode_input_tokens,
+            pd_disaggregation_enabled=attn_config.pd_disaggregation_enabled,
         )
     )
     max_packing = max(packing.values())

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4.py
@@ -131,6 +131,7 @@ def deepseek_v4_cache_fields(
                 1,
                 exact_page_stride=False,
                 page_stride_alignment_bytes=kv_page_stride_alignment_bytes,
+                layer_id=layer_id,
             )
         )
         if ratio == 1:
@@ -157,6 +158,7 @@ def deepseek_v4_cache_fields(
                     1,
                     exact_page_stride=False,
                     page_stride_alignment_bytes=kv_page_stride_alignment_bytes,
+                    layer_id=layer_id,
                 ),
                 CacheFieldSpec(
                     state_group,
@@ -165,6 +167,7 @@ def deepseek_v4_cache_fields(
                     state_shape,
                     4,
                     exact_page_stride=False,
+                    layer_id=layer_id,
                 ),
             )
         )
@@ -182,6 +185,7 @@ def deepseek_v4_cache_fields(
                     tuple(indexer_kv_shape),
                     1,
                     exact_page_stride=False,
+                    layer_id=layer_id,
                 ),
                 CacheFieldSpec(
                     indexer_state_group,
@@ -190,6 +194,7 @@ def deepseek_v4_cache_fields(
                     tuple(indexer_state_shape),
                     4,
                     exact_page_stride=False,
+                    layer_id=layer_id,
                 ),
             )
         )

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4_cache_spec.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4_cache_spec.py
@@ -22,7 +22,6 @@ from typing import Any
 
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
     PagedCacheGroupSpec,
-    apply_pd_transfer_policies,
     compute_paged_cache_group_page_counts,
 )
 
@@ -412,7 +411,10 @@ def build_v4_cache_specs(
             for spec in specs
         ]
     if pd_disaggregation_enabled:
-        specs = apply_pd_transfer_policies(specs)
+        # Every DeepSeek V4 group uses scheduler-managed history or a sliding
+        # destination table. Neither is a recurrent final-state snapshot, so
+        # Decode allocates the complete missing suffix for every group.
+        specs = [replace(spec, transfer_policy="full_suffix") for spec in specs]
     return specs
 
 

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4_cache_spec.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4_cache_spec.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
     PagedCacheGroupSpec,
+    apply_pd_transfer_policies,
     compute_paged_cache_group_page_counts,
 )
 
@@ -321,6 +322,7 @@ def build_v4_cache_specs(
     layer_ratio: Sequence[int],
     cache_blocks_per_lcm_block: Mapping[str, int] | None = None,
     decode_input_tokens: int = 1,
+    pd_disaggregation_enabled: bool = False,
 ) -> list[PagedCacheGroupSpec]:
     if (
         isinstance(decode_input_tokens, bool)
@@ -390,27 +392,28 @@ def build_v4_cache_specs(
                 family="state",
             )
         )
-    if cache_blocks_per_lcm_block is None:
-        return specs
-
-    packing = dict(cache_blocks_per_lcm_block)
-    group_ids = {spec.group_id for spec in specs}
-    if set(packing) != group_ids:
-        raise ValueError(
-            "DeepSeek V4 LCM packing must contain exactly the cache groups"
-        )
-    if any(
-        isinstance(count, bool) or not isinstance(count, int) or count <= 0
-        for count in packing.values()
-    ):
-        raise ValueError("DeepSeek V4 LCM packing values must be positive integers")
-    return [
-        replace(
-            spec,
-            cache_blocks_per_lcm_block=packing[spec.group_id],
-        )
-        for spec in specs
-    ]
+    if cache_blocks_per_lcm_block is not None:
+        packing = dict(cache_blocks_per_lcm_block)
+        group_ids = {spec.group_id for spec in specs}
+        if set(packing) != group_ids:
+            raise ValueError(
+                "DeepSeek V4 LCM packing must contain exactly the cache groups"
+            )
+        if any(
+            isinstance(count, bool) or not isinstance(count, int) or count <= 0
+            for count in packing.values()
+        ):
+            raise ValueError("DeepSeek V4 LCM packing values must be positive integers")
+        specs = [
+            replace(
+                spec,
+                cache_blocks_per_lcm_block=packing[spec.group_id],
+            )
+            for spec in specs
+        ]
+    if pd_disaggregation_enabled:
+        specs = apply_pd_transfer_policies(specs)
+    return specs
 
 
 def deepseek_v4_lcm_blocks_needed(

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/plan.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/plan.py
@@ -57,6 +57,7 @@ class CacheFieldLayout:
     element_size: int
     field_offset_bytes: int
     page_stride_bytes: int
+    layer_id: int | None = None
 
     @property
     def payload_bytes(self) -> int:
@@ -208,6 +209,7 @@ class CacheFieldSpec:
     # stride to satisfy an alignment constraint (for example, a TMA row
     # stride). The planner applies this in bytes after group packing.
     page_stride_alignment_bytes: int = 1
+    layer_id: int | None = None
 
     @property
     def payload_bytes(self) -> int:
@@ -351,6 +353,9 @@ def continue_layer_fields(fields, *, first_layer_id: int) -> tuple[CacheFieldSpe
             field.element_size,
             exact_page_stride=field.exact_page_stride,
             page_stride_alignment_bytes=field.page_stride_alignment_bytes,
+            layer_id=(
+                None if field.layer_id is None else field.layer_id + first_layer_id
+            ),
         )
         for field in fields
     )
@@ -670,6 +675,7 @@ def solve_cache_layout(
                 field_offset_bytes=field_offsets[field.field_id],
                 page_stride_bytes=plane_bytes[field.plane_id]
                 // packing[field.group_id],
+                layer_id=field.layer_id,
             )
         )
 

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -3746,59 +3746,66 @@ class DeepseekV4Attention(nn.Module):
         forward_mode = ctx.forward_mode
         if forward_mode is None:
             raise RuntimeError("DeepSeek V4 attention requires forward mode")
-        if forward_mode.is_mixed():
-            with nvtx_range(f"{profile_prefix}_mixed_backend"):
-                attn_output = ctx.attn_backend.forward_deepseek_v4_mixed(
-                    q=q,
-                    positions=positions,
-                    token_to_kv_pool=pool,
-                    layer_id=self.cache_layer_index,
-                    kind=self.attention_kind,
-                    compress_ratio=self.compress_ratio,
-                    num_local_heads=self.num_local_heads,
-                    padded_heads=self.padded_heads,
-                    head_dim=self.head_dim,
-                    window_size=self.swa_window,
-                    softmax_scale=self.scale,
-                    attn_sink=self.attn_sink,
-                    topk_indices=topk_indices,
+        with ctx.attn_backend.record_pd_cache_step(
+            forward_mode,
+            save_kv_cache=False,
+            record_kv_cache=None,
+        ):
+            if forward_mode.is_mixed():
+                with nvtx_range(f"{profile_prefix}_mixed_backend"):
+                    attn_output = ctx.attn_backend.forward_deepseek_v4_mixed(
+                        q=q,
+                        positions=positions,
+                        token_to_kv_pool=pool,
+                        layer_id=self.cache_layer_index,
+                        kind=self.attention_kind,
+                        compress_ratio=self.compress_ratio,
+                        num_local_heads=self.num_local_heads,
+                        padded_heads=self.padded_heads,
+                        head_dim=self.head_dim,
+                        window_size=self.swa_window,
+                        softmax_scale=self.scale,
+                        attn_sink=self.attn_sink,
+                        topk_indices=topk_indices,
+                    )
+            elif forward_mode.is_decode():
+                with nvtx_range(f"{profile_prefix}_decode_backend"):
+                    attn_output = ctx.attn_backend.forward_deepseek_v4_decode(
+                        q=q,
+                        positions=positions,
+                        token_to_kv_pool=pool,
+                        layer_id=self.cache_layer_index,
+                        kind=self.attention_kind,
+                        compress_ratio=self.compress_ratio,
+                        num_local_heads=self.num_local_heads,
+                        padded_heads=self.padded_heads,
+                        head_dim=self.head_dim,
+                        window_size=self.swa_window,
+                        softmax_scale=self.scale,
+                        attn_sink=self.attn_sink,
+                        topk_indices=topk_indices,
+                    )
+            elif forward_mode.is_extend_or_mixed():
+                with nvtx_range(f"{profile_prefix}_prefill_backend"):
+                    attn_output = ctx.attn_backend.forward_deepseek_v4_prefill(
+                        q=q,
+                        positions=positions,
+                        token_to_kv_pool=pool,
+                        layer_id=self.cache_layer_index,
+                        kind=self.attention_kind,
+                        compress_ratio=self.compress_ratio,
+                        num_local_heads=self.num_local_heads,
+                        padded_heads=self.padded_heads,
+                        head_dim=self.head_dim,
+                        window_size=self.swa_window,
+                        softmax_scale=self.scale,
+                        attn_sink=self.attn_sink,
+                        topk_indices=topk_indices,
+                    )
+            else:
+                raise RuntimeError(
+                    f"Unsupported DeepSeek V4 forward mode: {forward_mode}"
                 )
-        elif forward_mode.is_decode():
-            with nvtx_range(f"{profile_prefix}_decode_backend"):
-                attn_output = ctx.attn_backend.forward_deepseek_v4_decode(
-                    q=q,
-                    positions=positions,
-                    token_to_kv_pool=pool,
-                    layer_id=self.cache_layer_index,
-                    kind=self.attention_kind,
-                    compress_ratio=self.compress_ratio,
-                    num_local_heads=self.num_local_heads,
-                    padded_heads=self.padded_heads,
-                    head_dim=self.head_dim,
-                    window_size=self.swa_window,
-                    softmax_scale=self.scale,
-                    attn_sink=self.attn_sink,
-                    topk_indices=topk_indices,
-                )
-        elif forward_mode.is_extend_or_mixed():
-            with nvtx_range(f"{profile_prefix}_prefill_backend"):
-                attn_output = ctx.attn_backend.forward_deepseek_v4_prefill(
-                    q=q,
-                    positions=positions,
-                    token_to_kv_pool=pool,
-                    layer_id=self.cache_layer_index,
-                    kind=self.attention_kind,
-                    compress_ratio=self.compress_ratio,
-                    num_local_heads=self.num_local_heads,
-                    padded_heads=self.padded_heads,
-                    head_dim=self.head_dim,
-                    window_size=self.swa_window,
-                    softmax_scale=self.scale,
-                    attn_sink=self.attn_sink,
-                    topk_indices=topk_indices,
-                )
-        else:
-            raise RuntimeError(f"Unsupported DeepSeek V4 forward mode: {forward_mode}")
         with nvtx_range(f"{profile_prefix}_output_proj"):
             return self._project_attention_output(
                 attn_output,

--- a/python/tokenspeed/runtime/pd/cache_protocol.py
+++ b/python/tokenspeed/runtime/pd/cache_protocol.py
@@ -209,6 +209,7 @@ class CachePDTransferSegment:
     page_zero_offset: int
     page_stride_bytes: int
     payload_bytes: int
+    layer_id: int | None = None
 
     def __post_init__(self) -> None:
         _integer("segment physical_slot", self.physical_slot)
@@ -217,6 +218,8 @@ class CachePDTransferSegment:
         _integer("segment page_zero_offset", self.page_zero_offset)
         _integer("segment page_stride_bytes", self.page_stride_bytes, 1)
         _integer("segment payload_bytes", self.payload_bytes, 1)
+        if self.layer_id is not None:
+            _integer("segment layer_id", self.layer_id)
         _require(
             self.payload_bytes <= self.page_stride_bytes,
             f"segment {self.field_id!r} payload exceeds its page stride",
@@ -452,6 +455,10 @@ class CachePDLayout:
             raise CachePDProtocolError("layout contains duplicate group IDs")
         covered: set[int] = set()
         for group in groups:
+            _require(
+                self.block_size % group.cache_blocks_per_lcm_block == 0,
+                f"group {group.group_id!r} packing must divide block_size",
+            )
             for slot in group.physical_slots:
                 if slot >= self.physical_slot_count:
                     raise CachePDProtocolError(
@@ -491,6 +498,14 @@ class CachePDLayout:
     @property
     def physical_slot_count(self) -> int:
         return len(self.physical_buffer_ids)
+
+    @property
+    def supports_layerwise_transfer(self) -> bool:
+        return all(
+            group.transfer_segments
+            and all(segment.layer_id is not None for segment in group.transfer_segments)
+            for group in self.groups
+        )
 
     @property
     def peer(self) -> CachePDPeerLayout:
@@ -633,6 +648,10 @@ def _logical_slots(
     raise CachePDProtocolError(f"unsupported transfer policy {policy!r}")
 
 
+def _group_block_size(layout: CachePDLayout, group: CachePDGroup) -> int:
+    return layout.block_size // group.cache_blocks_per_lcm_block
+
+
 def _group_page_count(group: CachePDGroup, num_pages_with_null: int) -> int:
     """Resolve one group's child-page capacity from the registered parents."""
     return 1 + (num_pages_with_null - 1) * group.cache_blocks_per_lcm_block
@@ -690,7 +709,7 @@ def validate_cache_manifest(
             layout_group.transfer_policy,
             manifest.prefix_len,
             manifest.prompt_len,
-            layout.block_size,
+            _group_block_size(layout, layout_group),
         )
         if len(group.page_ids) != len(required):
             raise CachePDProtocolError(
@@ -754,6 +773,64 @@ def cache_manifest_page_ids(
     return tuple(page_id for group in manifest.groups for page_id in group.page_ids)
 
 
+def project_cache_destination_manifest(
+    manifest: CachePDPageManifest,
+    *,
+    layout: CachePDLayout,
+    prefix_len: int,
+    prompt_len: int,
+    num_pages_with_null: int,
+) -> CachePDPageManifest:
+    """Project a full Decode allocation onto one Prefill transfer chunk."""
+    validate_cache_manifest(
+        manifest,
+        layout=layout,
+        num_pages_with_null=num_pages_with_null,
+        peer="destination",
+    )
+    if (
+        prefix_len < manifest.prefix_len
+        or prompt_len > manifest.prompt_len
+        or prefix_len >= prompt_len
+    ):
+        raise CachePDProtocolError(
+            "layerwise transfer window must be inside the destination manifest"
+        )
+    if prefix_len % layout.block_size:
+        raise CachePDProtocolError("layerwise transfer prefix_len must be page aligned")
+
+    groups = []
+    for layout_group, group in zip(layout.groups, manifest.groups, strict=True):
+        if layout_group.transfer_policy == "latest_snapshot":
+            pages = group.page_ids
+        else:
+            full_slots = _logical_slots(
+                layout_group.transfer_policy,
+                manifest.prefix_len,
+                manifest.prompt_len,
+                _group_block_size(layout, layout_group),
+            )
+            pages_by_slot = dict(zip(full_slots, group.page_ids, strict=True))
+            chunk_slots = _logical_slots(
+                layout_group.transfer_policy,
+                prefix_len,
+                prompt_len,
+                _group_block_size(layout, layout_group),
+            )
+            try:
+                pages = tuple(pages_by_slot[slot] for slot in chunk_slots)
+            except KeyError as exc:
+                raise CachePDProtocolError(
+                    "layerwise transfer window is outside the destination suffix"
+                ) from exc
+        groups.append(CachePDGroupPages(group.group_id, pages))
+    return CachePDPageManifest(
+        groups=tuple(groups),
+        prefix_len=prefix_len,
+        prompt_len=prompt_len,
+    )
+
+
 def build_cache_page_manifest(
     forward_op: object,
     *,
@@ -814,7 +891,7 @@ def build_cache_page_manifest(
             layout_group.transfer_policy,
             prefix_len,
             prompt_len,
-            layout.block_size,
+            _group_block_size(layout, layout_group),
         )
         if logical_slots[-1] >= table.shape[1]:
             raise CachePDProtocolError(
@@ -851,7 +928,7 @@ def build_cache_page_manifest(
                 layout_group.transfer_policy,
                 manifest.prefix_len,
                 manifest.prompt_len,
-                layout.block_size,
+                _group_block_size(layout, layout_group),
             ),
             strict=True,
         )
@@ -985,6 +1062,7 @@ def build_lcm_pd_cache_contract(
                     ),
                     page_stride_bytes=field.page_stride_bytes,
                     payload_bytes=field.payload_bytes,
+                    layer_id=field.layer_id,
                 )
             )
         transfer_groups.append(
@@ -1035,6 +1113,7 @@ def build_lcm_pd_cache_contract(
                 "element_size": field.element_size,
                 "field_offset_bytes": field.field_offset_bytes,
                 "page_stride_bytes": field.page_stride_bytes,
+                "layer_id": field.layer_id,
             }
             for field in fields
         ],

--- a/python/tokenspeed/runtime/pd/decode_executor.py
+++ b/python/tokenspeed/runtime/pd/decode_executor.py
@@ -76,7 +76,11 @@ class DisaggDecodeExecutor:
     def _cache_prefill(self, op) -> None:
         pending = []
         num_extends = op.num_extends()
-        for index, request_id in enumerate(op.request_ids[:num_extends]):
+        if num_extends != len(op.request_ids):
+            raise RuntimeError(
+                "Paged cache decode destination admission does not support mixed batches"
+            )
+        for index, request_id in enumerate(op.request_ids):
             receiver = self.receivers.get(request_id)
             if receiver is None:
                 continue

--- a/python/tokenspeed/runtime/pd/decode_executor.py
+++ b/python/tokenspeed/runtime/pd/decode_executor.py
@@ -76,11 +76,7 @@ class DisaggDecodeExecutor:
     def _cache_prefill(self, op) -> None:
         pending = []
         num_extends = op.num_extends()
-        if num_extends != len(op.request_ids):
-            raise RuntimeError(
-                "Paged cache decode destination admission does not support mixed batches"
-            )
-        for index, request_id in enumerate(op.request_ids):
+        for index, request_id in enumerate(op.request_ids[:num_extends]):
             receiver = self.receivers.get(request_id)
             if receiver is None:
                 continue

--- a/python/tokenspeed/runtime/pd/factory.py
+++ b/python/tokenspeed/runtime/pd/factory.py
@@ -59,6 +59,15 @@ def get_kv_args(
     token_to_kv_pool,
     draft_token_to_kv_pool,
 ):
+    total_layer_num = token_to_kv_pool.layer_num
+    kv_layer_ids = list(getattr(token_to_kv_pool, "layer_ids", range(total_layer_num)))
+    draft_layer_num = (
+        len(draft_token_to_kv_pool.layer_ids)
+        if draft_token_to_kv_pool is not None
+        else 0
+    )
+    target_layer_num = total_layer_num - draft_layer_num
+
     cache_contract = _get_cache_contract(token_to_kv_pool)
     if cache_contract is not None:
         # One big model, one arena: the draft's continuation-layer planes
@@ -78,9 +87,9 @@ def get_kv_args(
             kv_data_ptrs=[registration.base_addr for registration in registrations],
             kv_data_lens=[registration.length for registration in registrations],
             kv_item_lens=item_lens,
-            target_layer_num=physical_slot_count,
-            draft_layer_num=0,
-            kv_layer_ids=list(range(physical_slot_count)),
+            target_layer_num=target_layer_num,
+            draft_layer_num=draft_layer_num,
+            kv_layer_ids=kv_layer_ids,
             # One logical Mooncake unit is one complete raw-slab page. This
             # makes equal-TP cache-contract routes identity routes and prevents the
             # generic heterogeneous-TP planner from splitting a raw page.
@@ -111,15 +120,6 @@ def get_kv_args(
     kv_unit_lens = _get_contiguous_buf_unit_lens(token_to_kv_pool, kv_item_lens)
     # [[layer0buf0, layer0buf1...], [layer1buf0, layer1buf1...], ...]
     offsets = token_to_kv_pool.get_layerwise_buf_info_offsets()
-    total_layer_num = token_to_kv_pool.layer_num
-    kv_layer_ids = list(getattr(token_to_kv_pool, "layer_ids", range(total_layer_num)))
-    draft_layer_num = (
-        len(draft_token_to_kv_pool.layer_ids)
-        if draft_token_to_kv_pool is not None
-        else 0
-    )
-    target_layer_num = total_layer_num - draft_layer_num
-
     state_data_ptrs = []
     state_data_lens = []
     state_item_lens = []

--- a/python/tokenspeed/runtime/pd/factory.py
+++ b/python/tokenspeed/runtime/pd/factory.py
@@ -168,7 +168,7 @@ def create_kv_transfer(
             )
         if args.enable_mla_l1_5_cache:
             raise NotImplementedError(
-                "Paged-cache PD does not support MLA L1.5 or layerwise cache transfer"
+                "Paged-cache PD does not support MLA L1.5 cache transfer"
             )
     if mode == "prefill":
         return DisaggPrefillExecutor(backend, args, kv_args, gloo_group, page_size)

--- a/python/tokenspeed/runtime/pd/mooncake/entities.py
+++ b/python/tokenspeed/runtime/pd/mooncake/entities.py
@@ -97,6 +97,7 @@ class TransferKVChunk:
     wait_for_bootstrap_token: bool = False
     spec_candidate_ids: list[int] | None = None
     page_manifest: CachePDPageManifest | None = None
+    destination_page_manifest: CachePDPageManifest | None = None
 
 
 @dataclasses.dataclass

--- a/python/tokenspeed/runtime/pd/mooncake/prefill.py
+++ b/python/tokenspeed/runtime/pd/mooncake/prefill.py
@@ -256,6 +256,32 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         req: TransferInfo,
     ) -> TransferIndexResolution:
         self._validate_cache_transfer(kv_chunk, req)
+        layout = getattr(self.kv_args, "cache_layout", None)
+        if layout is not None:
+            destination_manifest = (
+                kv_chunk.destination_page_manifest or req.page_manifest
+            )
+            if kv_chunk.page_manifest is None or destination_manifest is None:
+                raise ValueError("Paged cache transfer is missing a manifest")
+            return TransferIndexResolution(
+                src_indices=np.asarray(
+                    cache_manifest_page_ids(
+                        kv_chunk.page_manifest,
+                        layout=layout,
+                        peer="source",
+                    ),
+                    dtype=np.int64,
+                ),
+                dst_indices=np.asarray(
+                    cache_manifest_page_ids(
+                        destination_manifest,
+                        layout=layout,
+                        num_pages_with_null=req.peer_cache_layout.num_pages_with_null,
+                        peer="destination",
+                    ),
+                    dtype=np.int64,
+                ),
+            )
         src_indices = kv_chunk.prefill_kv_indices
         dst_indices = req.dst_kv_indices[kv_chunk.index_slice]
 
@@ -360,6 +386,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
             value is not None
             for value in (
                 kv_chunk.page_manifest,
+                kv_chunk.destination_page_manifest,
                 req.page_manifest,
                 req.peer_cache_layout,
             )
@@ -383,25 +410,11 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
             raise ValueError(
                 "Paged cache raw-slab transfer requires an identity TP route"
             )
-        if not kv_chunk.is_last:
-            raise ValueError(
-                "Paged cache transfer must be submitted as one final chunk"
-            )
-        if kv_chunk.index_slice.start not in (
-            None,
-            0,
-        ) or kv_chunk.index_slice.step not in (
-            None,
-            1,
-        ):
-            raise ValueError(
-                "Paged cache transfer page vector must start at offset zero"
-            )
-
         validate_cache_peer_layout(layout, req.peer_cache_layout)
+        destination_manifest = kv_chunk.destination_page_manifest or req.page_manifest
         validate_cache_manifest_pair(
             kv_chunk.page_manifest,
-            req.page_manifest,
+            destination_manifest,
             layout,
             dst_num_pages_with_null=req.peer_cache_layout.num_pages_with_null,
         )
@@ -411,17 +424,20 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
             peer="source",
         )
         expected_dst = cache_manifest_page_ids(
-            req.page_manifest,
+            destination_manifest,
             layout=layout,
             num_pages_with_null=req.peer_cache_layout.num_pages_with_null,
             peer="destination",
         )
         actual_src = tuple(int(page) for page in kv_chunk.prefill_kv_indices)
-        actual_dst = tuple(int(page) for page in req.dst_kv_indices)
-        if actual_src != expected_src or actual_dst != expected_dst:
+        if actual_src != expected_src:
             raise ValueError("Paged cache manifest and Mooncake page vector disagree")
-        if kv_chunk.index_slice.stop != len(expected_src):
-            raise ValueError("Paged cache transfer page slice is incomplete")
+        if kv_chunk.destination_page_manifest is None:
+            actual_dst = tuple(int(page) for page in req.dst_kv_indices)
+            if actual_dst != expected_dst:
+                raise ValueError(
+                    "Paged cache manifest and Mooncake page vector disagree"
+                )
 
     def _transfer_data(self, mooncake_session_id, transfer_blocks):
         if not transfer_blocks:
@@ -508,6 +524,8 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         dst_manifest: CachePDPageManifest,
         dst_num_pages_with_null: int,
         dst_page_zero_offsets: Mapping[tuple[str, str], int] | None = None,
+        begin_layer_id: int | None = None,
+        end_layer_id: int | None = None,
     ) -> list[tuple[int, int, int]]:
         layout = self.kv_args.cache_layout
         if layout is None:
@@ -545,6 +563,11 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
             if layout_group.transfer_segments:
                 assert dst_page_zero_offsets is not None
                 for segment in layout_group.transfer_segments:
+                    if begin_layer_id is not None and (
+                        segment.layer_id is None
+                        or not begin_layer_id <= segment.layer_id < end_layer_id
+                    ):
+                        continue
                     physical_slot = segment.physical_slot
                     src_ptr = self.kv_args.kv_data_ptrs[physical_slot]
                     dst_ptr = dst_ptrs[physical_slot]
@@ -813,10 +836,26 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         prefill_mamba_indices: npt.NDArray[np.int64] | None = None,
         dst_mamba_indices: npt.NDArray[np.int64] | None = None,
         transfer_fragments: tuple[TransferFragment, ...] = (),
+        src_page_manifest: CachePDPageManifest | None = None,
+        dst_page_manifest: CachePDPageManifest | None = None,
+        dst_num_pages_with_null: int | None = None,
+        dst_page_zero_offsets: Mapping[tuple[str, str], int] | None = None,
     ) -> int:
-        prefill_kv_blocks, dst_kv_blocks = group_concurrent_contiguous(
-            prefill_kv_indices, dst_kv_indices
-        )
+        uses_cache_contract = src_page_manifest is not None
+        if uses_cache_contract:
+            if dst_page_manifest is None or dst_num_pages_with_null is None:
+                raise ValueError(
+                    "Paged cache layerwise transfer requires both manifests and capacity"
+                )
+            if transfer_fragments:
+                raise ValueError(
+                    "Paged cache raw-slab transfer cannot use TP transfer fragments"
+                )
+            prefill_kv_blocks = dst_kv_blocks = ()
+        else:
+            prefill_kv_blocks, dst_kv_blocks = group_concurrent_contiguous(
+                prefill_kv_indices, dst_kv_indices
+            )
 
         interval = max(int(interval), 1)
         log_layerwise = getattr(self, "layerwise_debug", False)
@@ -835,7 +874,21 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
             self._wait_until_cache_step(target_step)
 
             transfer_blocks = []
-            if prefill_kv_blocks:
+            if uses_cache_contract:
+                transfer_blocks.extend(
+                    self._cache_transfer_blocks(
+                        dst_ptrs=dst_kv_ptrs,
+                        src_indices=prefill_kv_indices,
+                        dst_indices=dst_kv_indices,
+                        src_manifest=src_page_manifest,
+                        dst_manifest=dst_page_manifest,
+                        dst_num_pages_with_null=dst_num_pages_with_null,
+                        dst_page_zero_offsets=dst_page_zero_offsets,
+                        begin_layer_id=begin_layer_id,
+                        end_layer_id=end_layer_id,
+                    )
+                )
+            elif prefill_kv_blocks:
                 for global_layer_id in range(begin_layer_id, end_layer_id):
                     kv_layer_index = self._kv_layer_to_index.get(global_layer_id)
                     if kv_layer_index is None:
@@ -1037,6 +1090,9 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                                 ),
                             )
                         else:
+                            destination_manifest = (
+                                kv_chunk.destination_page_manifest or req.page_manifest
+                            )
                             ret = self.send_kvcache_layerwise(
                                 req.mooncake_session_id,
                                 resolved.src_indices,
@@ -1048,6 +1104,18 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                                 kv_chunk.prefill_mamba_indices,
                                 req.dst_mamba_indices,
                                 req.transfer_fragments,
+                                src_page_manifest=kv_chunk.page_manifest,
+                                dst_page_manifest=destination_manifest,
+                                dst_num_pages_with_null=(
+                                    req.peer_cache_layout.num_pages_with_null
+                                    if req.peer_cache_layout is not None
+                                    else None
+                                ),
+                                dst_page_zero_offsets=(
+                                    req.peer_cache_layout.page_zero_offset_map()
+                                    if req.peer_cache_layout is not None
+                                    else None
+                                ),
                             )
                         if ret == 0 and kv_chunk.is_last:
                             if kv_chunk.wait_for_bootstrap_token:
@@ -1249,6 +1317,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         mamba_indices: npt.NDArray[np.int64] | None = None,
         spec_candidate_ids: list[int] | None = None,
         page_manifest: CachePDPageManifest | None = None,
+        destination_page_manifest: CachePDPageManifest | None = None,
     ):
         if self.disaggregation_mode != DisaggregationMode.PREFILL:
             raise RuntimeError("Transfer requests can only be added in prefill mode.")
@@ -1291,6 +1360,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                 prefill_mamba_indices=mamba_indices,
                 spec_candidate_ids=spec_candidate_ids,
                 page_manifest=page_manifest,
+                destination_page_manifest=destination_page_manifest,
             )
         )
 

--- a/python/tokenspeed/runtime/pd/mooncake/sender.py
+++ b/python/tokenspeed/runtime/pd/mooncake/sender.py
@@ -125,6 +125,8 @@ class MooncakeKVSender:
         wait_for_bootstrap_token: bool = False,
         spec_candidate_ids: list[int] | None = None,
         mamba_indices: npt.NDArray[np.int64] | None = None,
+        page_manifest: CachePDPageManifest | None = None,
+        destination_page_manifest: CachePDPageManifest | None = None,
     ):
         self._layerwise_transfer_started = True
         self.curr_idx = max(self.curr_idx, index_slice.stop)
@@ -156,6 +158,8 @@ class MooncakeKVSender:
             wait_for_bootstrap_token=wait_for_bootstrap_token,
             spec_candidate_ids=spec_candidate_ids,
             mamba_indices=mamba_indices,
+            page_manifest=page_manifest,
+            destination_page_manifest=destination_page_manifest,
         )
 
     def poll(self) -> TransferPoll:

--- a/python/tokenspeed/runtime/pd/prefill_executor.py
+++ b/python/tokenspeed/runtime/pd/prefill_executor.py
@@ -357,9 +357,16 @@ class DisaggPrefillExecutor:
 
     def _cache_decode(self, op) -> None:
         pending = []
+        layerwise_pending = []
         for index, request_id in enumerate(op.request_ids):
             sender = self.senders.get(request_id)
             if sender is None:
+                continue
+            token = self._request_token.get(request_id)
+            if isinstance(token, bool) or not isinstance(token, int) or token < 0:
+                raise RuntimeError("Paged cache bootstrap token is unavailable")
+            if sender.has_layerwise_transfer():
+                layerwise_pending.append((request_id, sender, token))
                 continue
             transfer_infos = self.kv_manager.transfer_infos.get(
                 sender.bootstrap_room, {}
@@ -392,9 +399,6 @@ class DisaggPrefillExecutor:
                     destination.peer_cache_layout.num_pages_with_null
                 ),
             )
-            token = self._request_token.get(request_id)
-            if isinstance(token, bool) or not isinstance(token, int) or token < 0:
-                raise RuntimeError("Paged cache bootstrap token is unavailable")
             page_ids = np.asarray(
                 cache_manifest_page_ids(
                     manifest,
@@ -414,17 +418,17 @@ class DisaggPrefillExecutor:
                 )
             )
 
+        for request_id, sender, token in layerwise_pending:
+            if request_id not in self._layerwise_token_published:
+                self.kv_manager.set_prefill_metadata(
+                    sender.bootstrap_room,
+                    token,
+                    None,
+                )
+            self._layerwise_token_published.discard(request_id)
+            self._request_token.pop(request_id, None)
+
         for request_id, sender, aux_index, token, manifest, page_ids in pending:
-            if sender.has_layerwise_transfer():
-                if request_id not in self._layerwise_token_published:
-                    self.kv_manager.set_prefill_metadata(
-                        sender.bootstrap_room,
-                        token,
-                        None,
-                    )
-                self._layerwise_token_published.discard(request_id)
-                self._request_token.pop(request_id, None)
-                continue
             sender.send(
                 page_ids,
                 aux_index,

--- a/python/tokenspeed/runtime/pd/prefill_executor.py
+++ b/python/tokenspeed/runtime/pd/prefill_executor.py
@@ -31,6 +31,7 @@ from tokenspeed.runtime.pd.base.status import TransferPoll
 from tokenspeed.runtime.pd.cache_protocol import (
     build_cache_page_manifest,
     cache_manifest_page_ids,
+    project_cache_destination_manifest,
     validate_cache_manifest_pair,
 )
 from tokenspeed.runtime.pd.mooncake.prefill import (
@@ -74,6 +75,7 @@ class DisaggPrefillExecutor:
         self._request_token: dict[str, int] = {}
         self._request_spec_candidate_ids: dict[str, list[int]] = {}
         self._layerwise_token_published = set()
+        self._cache_transfer_progress: dict[str, int] = {}
 
     def store_prefill_token(
         self,
@@ -110,9 +112,12 @@ class DisaggPrefillExecutor:
             self._layerwise_token_published.add(request_id)
 
     def register_layerwise_step_counter(self, step_counter, interval: int) -> None:
-        if self.uses_cache_contract:
+        if (
+            self.uses_cache_contract
+            and not self.cache_layout.supports_layerwise_transfer
+        ):
             raise NotImplementedError(
-                "Paged cache PD does not support layerwise cache transfer"
+                "Paged cache layout does not publish per-layer transfer segments"
             )
         self._layerwise_enabled = True
         self._layerwise_interval = max(int(interval), 1)
@@ -139,6 +144,7 @@ class DisaggPrefillExecutor:
         self._request_token.pop(req_id, None)
         self._request_spec_candidate_ids.pop(req_id, None)
         self._layerwise_token_published.discard(req_id)
+        self._cache_transfer_progress.pop(req_id, None)
 
     def _decode_prefix_len(self, bootstrap_room: int) -> int:
         transfer_info = next(
@@ -186,6 +192,7 @@ class DisaggPrefillExecutor:
 
     def prepare_prefill(self, op) -> None:
         if self.uses_cache_contract:
+            self._cache_prepare_prefill(op)
             return
         if not self._layerwise_enabled or op.num_extends() == 0:
             return
@@ -215,6 +222,79 @@ class DisaggPrefillExecutor:
                 wait_for_bootstrap_token=is_last,
                 mamba_indices=None,
             )
+
+    def _cache_prepare_prefill(self, op) -> None:
+        if not self._layerwise_enabled or op.num_extends() == 0:
+            return
+        begin_cache_step = self.kv_manager.reserve_layerwise_cache_steps()
+        for index, request_id in enumerate(op.request_ids[: op.num_extends()]):
+            sender = self.senders.get(request_id)
+            if sender is None:
+                continue
+            transfer_infos = self.kv_manager.transfer_infos.get(
+                sender.bootstrap_room, {}
+            )
+            destinations = [
+                info for info in transfer_infos.values() if not info.is_dummy
+            ]
+            if len(destinations) != 1:
+                raise RuntimeError(
+                    "Paged cache PD requires exactly one identity-routed destination"
+                )
+            destination = destinations[0]
+            if (
+                destination.page_manifest is None
+                or destination.peer_cache_layout is None
+            ):
+                raise RuntimeError("Paged cache destination metadata is unavailable")
+
+            chunk_end = int(op.extend_prefix_lens[index]) + int(op.input_lengths[index])
+            is_last = chunk_end >= destination.page_manifest.prompt_len
+            transfer_begin = self._cache_transfer_progress.get(
+                request_id, destination.page_manifest.prefix_len
+            )
+            transfer_end = (
+                destination.page_manifest.prompt_len
+                if is_last
+                else chunk_end - chunk_end % self.cache_layout.block_size
+            )
+            if transfer_end <= transfer_begin:
+                continue
+            source_manifest = build_cache_page_manifest(
+                op,
+                layout=self.cache_layout,
+                request_row=index,
+                prefix_len=transfer_begin,
+                prompt_len=transfer_end,
+            )
+            destination_manifest = project_cache_destination_manifest(
+                destination.page_manifest,
+                layout=self.cache_layout,
+                prefix_len=transfer_begin,
+                prompt_len=transfer_end,
+                num_pages_with_null=(destination.peer_cache_layout.num_pages_with_null),
+            )
+            page_ids = np.asarray(
+                cache_manifest_page_ids(
+                    source_manifest,
+                    layout=self.cache_layout,
+                    peer="source",
+                ),
+                dtype=np.int64,
+            )
+            sender.send_layerwise(
+                page_ids,
+                slice(0, len(page_ids)),
+                op.request_pool_indices[index],
+                is_last,
+                begin_cache_step=begin_cache_step,
+                layerwise_interval=self._layerwise_interval,
+                wait_for_bootstrap_token=is_last,
+                mamba_indices=None,
+                page_manifest=source_manifest,
+                destination_page_manifest=destination_manifest,
+            )
+            self._cache_transfer_progress[request_id] = transfer_end
 
     def _decode(self, op):
         if self.uses_cache_contract:
@@ -335,6 +415,16 @@ class DisaggPrefillExecutor:
             )
 
         for request_id, sender, aux_index, token, manifest, page_ids in pending:
+            if sender.has_layerwise_transfer():
+                if request_id not in self._layerwise_token_published:
+                    self.kv_manager.set_prefill_metadata(
+                        sender.bootstrap_room,
+                        token,
+                        None,
+                    )
+                self._layerwise_token_published.discard(request_id)
+                self._request_token.pop(request_id, None)
+                continue
             sender.send(
                 page_ids,
                 aux_index,

--- a/test/runtime/distributed/test_cache_pd_executors.py
+++ b/test/runtime/distributed/test_cache_pd_executors.py
@@ -215,6 +215,29 @@ def test_decode_publishes_manifest_through_legacy_receiver() -> None:
     assert executor._request_pool_indices == {"request-0": 7}
 
 
+def test_decode_publishes_only_extend_rows_from_mixed_batch() -> None:
+    import tokenspeed.runtime.pd.decode_executor as decode_module
+
+    calls = []
+    receiver = SimpleNamespace(
+        prefill=lambda *args, **kwargs: calls.append((args, kwargs))
+    )
+    executor = object.__new__(decode_module.DisaggDecodeExecutor)
+    executor.cache_layout = _layout()
+    executor.receivers = {"request-0": receiver}
+    executor._request_pool_indices = {}
+    op = _op()
+    op.request_ids.append("decode-0")
+    op.request_pool_indices.append(8)
+    op.extend_prefix_lens.append(5)
+    op.prefill_lengths.append(5)
+
+    executor._cache_prefill(op)
+
+    assert len(calls) == 1
+    assert executor._request_pool_indices == {"request-0": 7}
+
+
 def test_prefill_submits_manifest_through_legacy_sender() -> None:
     import tokenspeed.runtime.pd.prefill_executor as prefill_module
 
@@ -227,6 +250,9 @@ def test_prefill_submits_manifest_through_legacy_sender() -> None:
 
         def send(self, *args, **kwargs):
             calls.append((args, kwargs))
+
+        def has_layerwise_transfer(self):
+            return False
 
     executor = object.__new__(prefill_module.DisaggPrefillExecutor)
     executor.cache_layout = layout
@@ -245,6 +271,44 @@ def test_prefill_submits_manifest_through_legacy_sender() -> None:
     assert kwargs["bootstrap_token"] == 42
     assert kwargs["page_manifest"].prompt_len == 5
     assert executor._request_token == {}
+
+
+def test_prefill_submits_typed_manifest_through_layerwise_sender() -> None:
+    import tokenspeed.runtime.pd.prefill_executor as prefill_module
+
+    layout = _layout()
+    destination = _destination_transfer_info(layout)
+    calls = []
+
+    class _Sender:
+        bootstrap_room = 9
+
+        def send_layerwise(self, *args, **kwargs):
+            calls.append((args, kwargs))
+
+    executor = object.__new__(prefill_module.DisaggPrefillExecutor)
+    executor.cache_layout = layout
+    executor._layerwise_enabled = True
+    executor._layerwise_interval = 2
+    executor._cache_transfer_progress = {}
+    executor.senders = {"request-0": _Sender()}
+    executor.kv_manager = SimpleNamespace(
+        transfer_infos={9: {destination.mooncake_session_id: destination}},
+        reserve_layerwise_cache_steps=lambda: 100,
+    )
+    op = _op()
+    op.input_lengths = [3]
+
+    executor._cache_prepare_prefill(op)
+
+    assert len(calls) == 1
+    args, kwargs = calls[0]
+    assert args[0].tolist() == [2, 3, 6]
+    assert args[1:] == (slice(0, 3), 7, True)
+    assert kwargs["begin_cache_step"] == 100
+    assert kwargs["layerwise_interval"] == 2
+    assert kwargs["page_manifest"].groups[0].page_ids == (2, 3)
+    assert kwargs["destination_page_manifest"] == _destination_manifest()
 
 
 def test_cache_contract_epd_abort_notifies_decode() -> None:
@@ -356,7 +420,7 @@ def _segmented_layout(
     return CachePDLayout(
         version=CACHE_PD_PROTOCOL_VERSION,
         layout_fingerprint="b" * 64,
-        block_size=2,
+        block_size=4,
         num_pages_with_null=capacity,
         physical_buffer_ids=("lcm_arena",),
         physical_page_bytes=1024,
@@ -375,6 +439,7 @@ def _segmented_layout(
                         page_zero_offset=history_k_offset,
                         page_stride_bytes=256,
                         payload_bytes=256,
+                        layer_id=0,
                     ),
                     CachePDTransferSegment(
                         physical_slot=0,
@@ -383,6 +448,7 @@ def _segmented_layout(
                         page_zero_offset=history_v_offset,
                         page_stride_bytes=256,
                         payload_bytes=256,
+                        layer_id=0,
                     ),
                 ),
             ),
@@ -400,6 +466,7 @@ def _segmented_layout(
                         page_zero_offset=state_offset,
                         page_stride_bytes=512,
                         payload_bytes=384,
+                        layer_id=1,
                     ),
                 ),
             ),
@@ -478,6 +545,68 @@ def test_shared_manager_resolves_lcm_group_segments() -> None:
             ],
             [256, 256, 256, 256, 384],
         )
+    ]
+
+
+def test_shared_manager_transfers_lcm_segments_as_layers_become_ready() -> None:
+    from tokenspeed.runtime.pd.mooncake.prefill import MooncakeKVManagerPrefill
+
+    layout = _segmented_layout(
+        capacity=5,
+        history_k_offset=768,
+        history_v_offset=2816,
+        state_offset=512,
+    )
+    source_manifest = CachePDPageManifest(
+        groups=(
+            CachePDGroupPages("history", (1, 2)),
+            CachePDGroupPages("state", (4,)),
+        ),
+        prefix_len=0,
+        prompt_len=4,
+    )
+    destination_manifest = CachePDPageManifest(
+        groups=(
+            CachePDGroupPages("history", (5, 6)),
+            CachePDGroupPages("state", (3,)),
+        ),
+        prefix_len=0,
+        prompt_len=4,
+    )
+    calls = []
+    manager = object.__new__(MooncakeKVManagerPrefill)
+    manager.layer_num = 2
+    manager.kv_args = SimpleNamespace(
+        cache_layout=layout,
+        kv_data_ptrs=[0x10000],
+        kv_item_lens=[1024],
+        state_type="none",
+    )
+    manager._wait_until_cache_step = lambda step: None
+    manager.engine = SimpleNamespace(
+        batch_transfer_sync=lambda session, src, dst, lengths: (
+            calls.append((session, src, dst, lengths)) or 0
+        )
+    )
+
+    assert (
+        manager.send_kvcache_layerwise(
+            "session",
+            np.asarray([1, 2, 4], dtype=np.int64),
+            [0x20000],
+            np.asarray([5, 6, 3], dtype=np.int64),
+            begin_cache_step=10,
+            interval=1,
+            src_page_manifest=source_manifest,
+            dst_page_manifest=destination_manifest,
+            dst_num_pages_with_null=layout.num_pages_with_null,
+            dst_page_zero_offsets=layout.peer.page_zero_offset_map(),
+        )
+        == 0
+    )
+    assert [lengths for _, _, _, lengths in calls] == [
+        [256, 256, 256, 256],
+        [384],
     ]
 
 

--- a/test/runtime/distributed/test_cache_pd_executors.py
+++ b/test/runtime/distributed/test_cache_pd_executors.py
@@ -169,7 +169,7 @@ def test_cache_decode_destination_seeds_remote_prompt_cache_length(
     assert resets == [([7, 11], [1535, 3073])]
 
 
-def test_cache_factory_exposes_raw_slabs_as_mooncake_layers() -> None:
+def test_cache_factory_keeps_semantic_layers_separate_from_raw_slabs() -> None:
     from tokenspeed.runtime.pd.factory import get_kv_args
 
     layout = _layout()
@@ -180,13 +180,14 @@ def test_cache_factory_exposes_raw_slabs_as_mooncake_layers() -> None:
     )
     pool = SimpleNamespace(
         supports_disaggregation=True,
+        layer_num=43,
         get_pd_cache_contract=lambda: (layout, registrations),
     )
 
     kv_args = get_kv_args(0, 0, "mlx5_0", pool, None)
 
-    assert kv_args.target_layer_num == 2
-    assert kv_args.kv_layer_ids == [0, 1]
+    assert kv_args.target_layer_num == 43
+    assert kv_args.kv_layer_ids == list(range(43))
     assert kv_args.offsets == [(0,), (1,)]
     assert kv_args.kv_item_lens == [16, 16]
     assert kv_args.kv_unit_lens == [16, 16]

--- a/test/runtime/distributed/test_cache_pd_executors.py
+++ b/test/runtime/distributed/test_cache_pd_executors.py
@@ -311,6 +311,34 @@ def test_prefill_submits_typed_manifest_through_layerwise_sender() -> None:
     assert kwargs["destination_page_manifest"] == _destination_manifest()
 
 
+def test_prefill_layerwise_completion_does_not_require_retired_destination() -> None:
+    import tokenspeed.runtime.pd.prefill_executor as prefill_module
+
+    metadata_calls = []
+
+    class _Sender:
+        bootstrap_room = 9
+
+        def has_layerwise_transfer(self):
+            return True
+
+    executor = object.__new__(prefill_module.DisaggPrefillExecutor)
+    executor.cache_layout = _layout()
+    executor.senders = {"request-0": _Sender()}
+    executor.kv_manager = SimpleNamespace(
+        transfer_infos={},
+        set_prefill_metadata=lambda *args: metadata_calls.append(args),
+    )
+    executor._request_token = {"request-0": 42}
+    executor._layerwise_token_published = {"request-0"}
+
+    executor._cache_decode(_op())
+
+    assert metadata_calls == []
+    assert executor._request_token == {}
+    assert executor._layerwise_token_published == set()
+
+
 def test_cache_contract_epd_abort_notifies_decode() -> None:
     import tokenspeed.runtime.pd.prefill_executor as prefill_module
 

--- a/test/runtime/distributed/test_cache_pd_executors.py
+++ b/test/runtime/distributed/test_cache_pd_executors.py
@@ -216,7 +216,7 @@ def test_decode_publishes_manifest_through_legacy_receiver() -> None:
     assert executor._request_pool_indices == {"request-0": 7}
 
 
-def test_decode_publishes_only_extend_rows_from_mixed_batch() -> None:
+def test_decode_rejects_mixed_prefill_decode_batch() -> None:
     import tokenspeed.runtime.pd.decode_executor as decode_module
 
     calls = []
@@ -233,10 +233,11 @@ def test_decode_publishes_only_extend_rows_from_mixed_batch() -> None:
     op.extend_prefix_lens.append(5)
     op.prefill_lengths.append(5)
 
-    executor._cache_prefill(op)
+    with pytest.raises(RuntimeError, match="does not support mixed batches"):
+        executor._cache_prefill(op)
 
-    assert len(calls) == 1
-    assert executor._request_pool_indices == {"request-0": 7}
+    assert calls == []
+    assert executor._request_pool_indices == {}
 
 
 def test_prefill_submits_manifest_through_legacy_sender() -> None:

--- a/test/runtime/distributed/test_cache_pd_manifest.py
+++ b/test/runtime/distributed/test_cache_pd_manifest.py
@@ -31,6 +31,7 @@ from tokenspeed.runtime.pd.cache_protocol import (
     build_cache_page_manifest,
     build_lcm_pd_cache_contract,
     cache_manifest_page_ids,
+    project_cache_destination_manifest,
     validate_cache_manifest_pair,
     validate_cache_peer_layout,
     validate_cache_slab_registrations,
@@ -110,6 +111,63 @@ def test_transfer_policy_is_model_defined_not_inferred_from_family() -> None:
     )
 
     assert manifest.groups[1] == CachePDGroupPages("linear-a", (12, 13, 14))
+
+
+def test_manifest_uses_each_groups_child_page_size() -> None:
+    layout = CachePDLayout(
+        version=CACHE_PD_PROTOCOL_VERSION,
+        layout_fingerprint=_FINGERPRINT,
+        block_size=4,
+        num_pages_with_null=8,
+        physical_buffer_ids=("arena",),
+        physical_page_bytes=128,
+        groups=(
+            CachePDGroup(
+                "history",
+                "history",
+                "full_suffix",
+                (0,),
+                cache_blocks_per_lcm_block=2,
+            ),
+        ),
+    )
+    operation = SimpleNamespace(
+        block_tables_arrays=lambda: {"history": np.asarray([[1, 2, 3]], dtype=np.int32)}
+    )
+
+    manifest = build_cache_page_manifest(
+        operation,
+        layout=layout,
+        request_row=0,
+        prefix_len=0,
+        prompt_len=4,
+    )
+
+    assert manifest.groups == (CachePDGroupPages("history", (1, 2)),)
+
+
+def test_layerwise_destination_projection_selects_chunk_suffix() -> None:
+    full = build_cache_page_manifest(
+        _op(30),
+        layout=_layout(),
+        request_row=0,
+        prefix_len=4,
+        prompt_len=14,
+    )
+
+    chunk = project_cache_destination_manifest(
+        full,
+        layout=_layout(),
+        prefix_len=8,
+        prompt_len=12,
+        num_pages_with_null=_layout().num_pages_with_null,
+    )
+
+    assert chunk.groups == (
+        CachePDGroupPages("attention", (33,)),
+        CachePDGroupPages("linear-a", (44,)),
+        CachePDGroupPages("linear-b", (54,)),
+    )
 
 
 def test_layout_rejects_unbound_physical_slots() -> None:
@@ -355,7 +413,7 @@ def test_lcm_group_capacity_uses_its_cache_blocks_per_parent() -> None:
             ),
         ),
     )
-    tables = {"history": np.array([[5, 6]], dtype=np.int32)}
+    tables = {"history": np.array([[3, 4, 5, 6]], dtype=np.int32)}
     operation = SimpleNamespace(block_tables_arrays=lambda: tables)
 
     build_cache_page_manifest(
@@ -365,7 +423,7 @@ def test_lcm_group_capacity_uses_its_cache_blocks_per_parent() -> None:
         prefix_len=0,
         prompt_len=8,
     )
-    tables["history"][0, 1] = 7
+    tables["history"][0, 3] = 7
     with pytest.raises(CachePDProtocolError, match="invalid page ID"):
         build_cache_page_manifest(
             operation,
@@ -512,6 +570,7 @@ def _two_plane_lcm_plan(num_lcm_blocks: int):
                 field_offset_bytes=0,
                 page_stride_bytes=256,
                 payload_bytes=64,
+                layer_id=0,
             ),
             SimpleNamespace(
                 group_id="history",
@@ -522,6 +581,7 @@ def _two_plane_lcm_plan(num_lcm_blocks: int):
                 field_offset_bytes=0,
                 page_stride_bytes=256,
                 payload_bytes=64,
+                layer_id=0,
             ),
         ),
     )
@@ -569,6 +629,7 @@ def test_lcm_contract_registers_one_arena_and_preserves_group_geometry() -> None
                 field_offset_bytes=0,
                 page_stride_bytes=256,
                 payload_bytes=64,
+                layer_id=0,
             ),
         ),
     )

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -2294,12 +2294,12 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertEqual(
             {group.group_id: group.transfer_policy for group in cache_layout.groups},
             {
-                "v4.swa_kv": "latest_snapshot",
-                "v4.c4a.compressor_state": "latest_snapshot",
+                "v4.swa_kv": "full_suffix",
+                "v4.c4a.compressor_state": "full_suffix",
                 "v4.c4a.compressed_kv": "full_suffix",
-                "v4.c128a.compressor_state": "latest_snapshot",
+                "v4.c128a.compressor_state": "full_suffix",
                 "v4.c128a.compressed_kv": "full_suffix",
-                "v4.c4a.indexer_compressor_state": "latest_snapshot",
+                "v4.c4a.indexer_compressor_state": "full_suffix",
             },
         )
         self.assertEqual(
@@ -2310,6 +2310,37 @@ class TestDeepseekV4Config(unittest.TestCase):
             },
             {field.field_id for field in plan.fields},
         )
+        self.assertTrue(cache_layout.supports_layerwise_transfer)
+        self.assertEqual(
+            {
+                segment.layer_id
+                for group in cache_layout.groups
+                for segment in group.transfer_segments
+            },
+            {0, 1, 2},
+        )
+
+        from tokenspeed_scheduler import Scheduler
+
+        from tokenspeed.runtime.engine.scheduler_utils import (
+            make_config,
+            pool_to_paged_cache_groups,
+        )
+
+        scheduler_config = make_config(
+            num_device_pages=plan.num_lcm_blocks + 1,
+            max_scheduled_tokens=256,
+            max_batch_size=1,
+            page_size=plan.logical_block_tokens,
+            num_host_pages=0,
+            disable_l2_cache=True,
+            enable_l3_storage=False,
+            role="prefill",
+            paged_cache_groups=pool_to_paged_cache_groups(pool),
+            enable_mixed_prefill_decode=True,
+        )
+        scheduler_config.enable_pd_cache = True
+        Scheduler(scheduler_config)
 
     def test_deepseek_v4_kv_pool_rejects_nonpositive_size(self):
         config = SimpleNamespace(

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -4,7 +4,7 @@ import os
 import sys
 import tempfile
 import unittest
-from contextlib import redirect_stderr
+from contextlib import contextmanager, redirect_stderr
 from io import StringIO
 from types import MethodType, SimpleNamespace
 from typing import ClassVar
@@ -98,6 +98,7 @@ from tokenspeed.runtime.layers.layernorm import FusedRMSNorm, RMSNorm
 from tokenspeed.runtime.layers.quantization import QUANTIZATION_METHODS
 from tokenspeed.runtime.models import deepseek_v4 as deepseek_v4_model
 from tokenspeed.runtime.models.deepseek_v4 import (
+    DeepseekV4Attention,
     DeepseekV4Indexer,
     DeepseekV4MLP,
     DeepseekV4Model,
@@ -158,6 +159,7 @@ def _make_planned_deepseek_v4_pool(
     hf_config,
     *,
     num_lcm_blocks: int = 2,
+    pd_disaggregation_enabled: bool = False,
 ):
     fields = build_deepseek_v4_cache_fields(
         layout,
@@ -171,6 +173,7 @@ def _make_planned_deepseek_v4_pool(
         build_v4_cache_specs(
             hf_config,
             layer_ratio=layout.layer_ratio,
+            pd_disaggregation_enabled=pd_disaggregation_enabled,
         )
     )
     pool = HybridDeepseekV4TokenToKVPool(
@@ -467,6 +470,90 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertEqual(
             _deepseek_v4_indexer_token_split(ForwardMode.DECODE, metadata, 5),
             (0, 5),
+        )
+
+    def test_deepseek_v4_prefill_publishes_cache_readiness_after_writes(self):
+        attention = DeepseekV4Attention.__new__(DeepseekV4Attention)
+        torch.nn.Module.__init__(attention)
+        events = []
+        readiness_active = False
+
+        @contextmanager
+        def stream_scope(*, enable):
+            del enable
+
+            class Fork:
+                @contextmanager
+                def branch(self):
+                    yield
+
+            yield Fork()
+
+        @contextmanager
+        def record_pd_cache_step(forward_mode, save_kv_cache, record_kv_cache):
+            nonlocal readiness_active
+            self.assertEqual(forward_mode, ForwardMode.EXTEND)
+            self.assertFalse(save_kv_cache)
+            self.assertIsNone(record_kv_cache)
+            readiness_active = True
+            events.append("readiness-enter")
+            yield
+            events.append("readiness-exit")
+            readiness_active = False
+
+        def prefill_backend(**kwargs):
+            self.assertTrue(readiness_active)
+            events.append("attention")
+            return kwargs["q"]
+
+        q = torch.zeros((1, 1, 4), dtype=torch.bfloat16)
+        attention.stream_fork = SimpleNamespace(scope=stream_scope, aux_stream=None)
+        attention.rotary_emb = SimpleNamespace(
+            cos_sin_cache=torch.zeros((1, 4), dtype=torch.float32)
+        )
+        attention.compressor = None
+        attention.indexer = None
+        attention.attention_kind = "swa"
+        attention.cache_layer_index = 0
+        attention.compress_ratio = 1
+        attention.num_local_heads = 1
+        attention.padded_heads = 1
+        attention.head_dim = 4
+        attention.swa_window = 128
+        attention.scale = 0.5
+        attention.attn_sink = torch.zeros(1, dtype=torch.float32)
+        attention._project_q_kv = lambda _hidden_states: (q, q[:, 0], q[:, 0])
+        attention._insert_swa_cache = lambda **_kwargs: events.append("cache-write")
+        attention._project_attention_output = (
+            lambda output, _positions, _cos_sin_cache: output
+        )
+        backend = SimpleNamespace(
+            forward_metadata=object(),
+            record_pd_cache_step=record_pd_cache_step,
+            forward_deepseek_v4_prefill=prefill_backend,
+        )
+        ctx = SimpleNamespace(
+            dsa_compressor_slot_cache={},
+            dsa_swa_slot_mapping=torch.zeros(1, dtype=torch.int64),
+            token_to_kv_pool=SimpleNamespace(
+                swa_block_size=64,
+                get_swa_kv_buffer=lambda _layer_id: torch.empty(1),
+            ),
+            attn_backend=backend,
+            forward_mode=ForwardMode.EXTEND,
+        )
+
+        actual = attention.forward(
+            positions=torch.zeros(1, dtype=torch.int64),
+            hidden_states=torch.zeros((1, 4), dtype=torch.bfloat16),
+            ctx=ctx,
+            out_cache_loc=torch.zeros(1, dtype=torch.int64),
+        )
+
+        self.assertIs(actual, q)
+        self.assertEqual(
+            events,
+            ["cache-write", "readiness-enter", "attention", "readiness-exit"],
         )
 
     def test_spec_helpers_preserve_non_v4_backend_contracts(self):
@@ -2177,6 +2264,51 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertEqual(
             tuple(pool.get_indexer_kv_buffer_2d(1).shape),
             (plan.group("v4.c4a.compressed_kv").page_count, 64 * 68),
+        )
+
+    def test_deepseek_v4_pd_uses_typed_grouped_cache_contract(self):
+        config = SimpleNamespace(
+            compress_ratios=[1, 4, 128],
+            head_dim=512,
+            qk_rope_head_dim=64,
+            index_head_dim=128,
+            sliding_window=128,
+        )
+        layout = deepseek_v4_cache_layout_from_config(
+            config,
+            page_size=256,
+            use_fp4_indexer_cache=True,
+        )
+        pool, plan = _make_planned_deepseek_v4_pool(
+            layout,
+            config,
+            pd_disaggregation_enabled=True,
+        )
+
+        self.assertTrue(pool.supports_disaggregation)
+        cache_layout, registrations = pool.get_pd_cache_contract()
+        self.assertEqual(cache_layout.block_size, plan.logical_block_tokens)
+        self.assertEqual(cache_layout.physical_buffer_ids, ("lcm_arena",))
+        self.assertEqual(len(registrations), 1)
+        self.assertEqual(registrations[0].base_addr, pool.buffer.data_ptr())
+        self.assertEqual(
+            {group.group_id: group.transfer_policy for group in cache_layout.groups},
+            {
+                "v4.swa_kv": "latest_snapshot",
+                "v4.c4a.compressor_state": "latest_snapshot",
+                "v4.c4a.compressed_kv": "full_suffix",
+                "v4.c128a.compressor_state": "latest_snapshot",
+                "v4.c128a.compressed_kv": "full_suffix",
+                "v4.c4a.indexer_compressor_state": "latest_snapshot",
+            },
+        )
+        self.assertEqual(
+            {
+                segment.field_id
+                for group in cache_layout.groups
+                for segment in group.transfer_segments
+            },
+            {field.field_id for field in plan.fields},
         )
 
     def test_deepseek_v4_kv_pool_rejects_nonpositive_size(self):


### PR DESCRIPTION
## Summary

- preserve DeepSeek V4 group-specific cache layouts and transfer manifests for P/D disaggregation
- publish and transfer typed cache segments as each semantic model layer becomes ready
- keep semantic layer topology independent from the number of physical cache slabs
- reject mixed prefill/decode batches at startup and at decode admission

This reworks and supersedes the closed P/D cache-handoff attempt in #660 against current `main`. The SM120 serving work remains independently scoped in #992.

## Test plan

- `pre-commit run --all-files`
- P/D executor and manifest tests: 35 passed
- clean-main DeepSeek V4 configuration tests: 137 passed, 5 skipped, 2 unrelated SM120 tests deselected
- combined #992 + #997 focused suite: 179 passed, 1 skipped, 13 subtests passed
- InferLab P/D dry-run resolves `enable_mixed_batch=false` for both roles and omits the mixed-batch launch flag
- real four-GPU SM120 DeepSeek V4 Flash TP2/EP2 single-request P/D smoke with #992 applied: default layerwise interval transferred all 43 semantic layers on both TP ranks (86 completions), produced a coherent 16-token completion, and completed verified cleanup
