### PR TITLE
perf(multimodal): optimize cross-node feature transport

### DIFF
--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -96,7 +96,7 @@ issue budget, while `--max-total-tokens` controls the global token pool.
 | `--dense-tp-size` | Tensor parallel size for dense layers. Defaults to the attention replica width (attn TP x CP): the full world without DP attention, one replica with it. |
 | `--moe-tp-size` | Tensor parallel size for MoE layers. |
 | `--data-parallel-size` | Number of data-parallel replicas. |
-| `--mm-encoder-tp-mode` | Multimodal encoder parallelism: `weights` shards encoder weights with attention TP; `data` uses TP1 whole-item DP and currently requires aggregate serving, one node, and no attention context parallelism. |
+| `--mm-encoder-tp-mode` | Multimodal encoder parallelism: `weights` shards encoder weights with attention TP; `data` uses TP1 whole-item DP and currently requires aggregate serving and no attention context parallelism. |
 | `--enable-expert-parallel` | Set expert parallelism across the selected world size. |
 | `--expert-parallel-size`, `--ep-size` | Explicit expert parallel size. |
 | `--world-size` | Total worker process count across all nodes. |

--- a/python/tokenspeed/runtime/engine/request_handler.py
+++ b/python/tokenspeed/runtime/engine/request_handler.py
@@ -71,7 +71,7 @@ from tokenspeed.runtime.engine.request_types import FINISH_ABORT
 from tokenspeed.runtime.engine.scheduler_utils import make_spec
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.grammar.grammar_manager import GrammarManager
-from tokenspeed.runtime.multimodal.shm_transport import sync_shm_features
+from tokenspeed.runtime.multimodal.shm_transport import prepare_shm_features
 from tokenspeed.runtime.pd.base.bootstrap import BootstrapInfo
 from tokenspeed.runtime.utils import broadcast_pyobj
 from tokenspeed.runtime.utils.dispatch import TypeBasedDispatcher
@@ -186,7 +186,7 @@ class RequestHandler:
             )
 
         if recv_reqs:
-            sync_shm_features(recv_reqs, self.attn_tp_cpu_group, self.attn_tp_size)
+            prepare_shm_features(recv_reqs, self.attn_tp_cpu_group)
 
         return recv_reqs
 

--- a/python/tokenspeed/runtime/models/minimax_m3.py
+++ b/python/tokenspeed/runtime/models/minimax_m3.py
@@ -1602,7 +1602,7 @@ class MiniMaxM3SparseForConditionalGeneration(MiniMaxM3SparseForCausalLM):
             prefix=add_prefix("patch_merge_mlp", prefix),
             bias=True,
         )
-        self.multimodal_embedder = MultimodalEmbedder()
+        self.multimodal_embedder = MultimodalEmbedder(encoder_mapping=mapping.vision)
         self.image_encoder = self.get_image_feature
         self.video_encoder = self.get_video_feature
 

--- a/python/tokenspeed/runtime/multimodal/embedder.py
+++ b/python/tokenspeed/runtime/multimodal/embedder.py
@@ -32,8 +32,8 @@ Three sequential phases:
      writes each item's output back onto the item itself (``item.encoded`` /
      ``item.encoded_deepstack``). In weight-TP mode every rank encodes the
      full miss list together. In item-DP mode each rank encodes a deterministic
-     subset of whole items and collects the variable-length results with
-     exact-size broadcasts.
+     subset of whole items and collects the variable-length results without
+     padding them to the largest rank output.
 
   3. ``_assemble`` runs the text-token embedding lookup and slices the
      encoder-token ranges into the right positions using the plan's
@@ -55,7 +55,6 @@ request's scatter ranges read from the first item's ``encoded`` tensor.
 from __future__ import annotations
 
 import logging
-import math
 import time
 from collections import defaultdict
 from collections.abc import Callable, Sequence
@@ -68,6 +67,9 @@ from torch import nn
 from tokenspeed.runtime.distributed.mapping import VisionTowerMapping
 from tokenspeed.runtime.distributed.process_group_manager import (
     process_group_manager,
+)
+from tokenspeed.runtime.multimodal.encoder_feature_transport import (
+    EncoderFeatureTransport,
 )
 from tokenspeed.runtime.multimodal.inputs import (
     Modality,
@@ -82,14 +84,6 @@ EncoderWarmupItemsFactory = Callable[[], list[MultimodalDataItem]]
 
 logger = logging.getLogger(__name__)
 LOG_MM_TIMING = envs.TOKENSPEED_LOG_MM_TIMING.get()
-# Small transfers are faster after staging the whole batch; larger transfers
-# benefit from overlapping each H2D enqueue with the next SHM-to-pinned copy.
-_INTERLEAVED_H2D_MIN_AVERAGE_BYTES = 1024 * 1024
-# One rank can stage the input and distribute it faster than every TP rank
-# repeating the host copy once the payload reaches this TP-scaled threshold.
-# Local B200 measurements put the break-even points near 128 MiB for TP2 and
-# 64 MiB for TP4.
-_TP_BROADCAST_BASE_MIN_BYTES = 256 * 1024 * 1024
 
 
 @dataclass
@@ -297,22 +291,7 @@ class MultimodalEmbedder:
         self._encoder_dp_rank = (
             encoder_mapping.dp_rank if encoder_mapping is not None else 0
         )
-        self._h2d_stream: torch.cuda.Stream | None = None
-        vision_tp_group = (
-            encoder_mapping.tp_group if encoder_mapping is not None else None
-        )
-        self._vision_tp_group = vision_tp_group
-        self._vision_tp_process_group = None
-        self._vision_tp_src_rank: int | None = None
-        if (
-            vision_tp_group is not None
-            and len(vision_tp_group) > 1
-            and process_group_manager.has_process_group("nccl", vision_tp_group)
-        ):
-            self._vision_tp_process_group = process_group_manager.get_process_group(
-                "nccl", vision_tp_group
-            )
-            self._vision_tp_src_rank = vision_tp_group[0]
+        self._feature_transport = EncoderFeatureTransport(encoder_mapping)
 
     @property
     def has_encoder_dp(self) -> bool:
@@ -551,7 +530,7 @@ class MultimodalEmbedder:
         spec: EncoderSpec,
         device: torch.device,
     ) -> torch.Tensor:
-        self._move_features_to_device(items, device)
+        self._feature_transport.move_to_device(items, device)
         return spec.fn(items)
 
     def _encode_data_parallel(
@@ -565,6 +544,9 @@ class MultimodalEmbedder:
         assert self._encoder_dp_group is not None
         per_item_lens = tuple(_item_token_count(item) for item in items)
         assignment = _assign_encoder_items(per_item_lens, len(self._encoder_dp_group))
+        self._feature_transport.route_to_item_owners(
+            items, assignment.item_indices_by_rank
+        )
         local_indices = assignment.item_indices_by_rank[self._encoder_dp_rank]
         local_items = [items[index] for index in local_indices]
         local_rows = assignment.token_counts_by_rank[self._encoder_dp_rank]
@@ -598,6 +580,13 @@ class MultimodalEmbedder:
     def _gather_encoder_outputs(
         self, local_output: torch.Tensor, token_counts_by_rank: Sequence[int]
     ) -> torch.Tensor:
+        """Collect rank-major item-DP outputs directly into their final buffer.
+
+        A lone owner uses one exact-size broadcast. Equal non-empty outputs use
+        NCCL all-gather directly, while uneven outputs use C10d's coalesced
+        exact-size broadcasts through the uneven ``all_gather`` API. None of
+        the paths pads outputs to the largest rank-local row count.
+        """
         assert self._encoder_dp_group is not None
         total_rows = sum(token_counts_by_rank)
         output_width = local_output.shape[-1]
@@ -609,22 +598,49 @@ class MultimodalEmbedder:
         process_group = process_group_manager.get_process_group(
             "nccl", self._encoder_dp_group
         )
-        cursor = 0
-        for owner_rank, rows in enumerate(token_counts_by_rank):
-            if rows == 0:
-                continue
-            rank_output = gathered[cursor : cursor + rows]
+        nonempty_owner_ranks = [
+            rank for rank, rows in enumerate(token_counts_by_rank) if rows > 0
+        ]
+        if not nonempty_owner_ranks:
+            return gathered
+
+        if len(nonempty_owner_ranks) == 1:
+            owner_rank = nonempty_owner_ranks[0]
             if owner_rank == self._encoder_dp_rank:
-                rank_output.copy_(local_output)
-            # A sequence of exact-size broadcasts avoids max-row padding. In
-            # the common single-large-item case this reduces the temporary
-            # DP8 embedding buffer from 8x the result size to exactly 1x.
+                gathered.copy_(local_output)
+            # Avoid issuing one zero-count broadcast per idle rank through the
+            # uneven all-gather fallback. This is the common single-item case.
             torch.distributed.broadcast(
-                rank_output,
+                gathered,
                 src=self._encoder_dp_group[owner_rank],
                 group=process_group,
             )
+            return gathered
+
+        local_output = local_output.contiguous()
+        first_rank_rows = token_counts_by_rank[0]
+        if all(rows == first_rank_rows for rows in token_counts_by_rank):
+            # The flat API writes NCCL's equal-size all-gather directly into
+            # the final contiguous rank-major output buffer.
+            torch.distributed.all_gather_into_tensor(
+                gathered,
+                local_output,
+                group=process_group,
+            )
+            return gathered
+
+        rank_outputs: list[torch.Tensor] = []
+        cursor = 0
+        for rows in token_counts_by_rank:
+            rank_outputs.append(gathered.narrow(0, cursor, rows))
             cursor += rows
+        # PyTorch 2.11 implements uneven NCCL all-gather as one C10d call
+        # containing coalesced exact-size broadcasts, including zero-row views.
+        torch.distributed.all_gather(
+            rank_outputs,
+            local_output,
+            group=process_group,
+        )
         return gathered
 
     @staticmethod
@@ -707,167 +723,7 @@ class MultimodalEmbedder:
 
         return input_embeds, kwargs
 
-    # --- device helpers ----------------------------------------------------
-
-    def _h2d_stream_on(self, device: torch.device) -> torch.cuda.Stream:
-        if self._h2d_stream is None:
-            self._h2d_stream = torch.cuda.Stream(device=device)
-        return self._h2d_stream
-
-    def _move_features_to_device(
-        self, items: list[MultimodalDataItem], device: torch.device
-    ) -> None:
-        """Stage encoder features onto ``device`` on a dedicated H2D stream.
-
-        Inputs that originate from the SHM transport are pinned, so the
-        H2D copy can actually run async with respect to the LM kernels
-        already queued on the current stream. We synchronise the current
-        stream with the H2D stream so the encoder sees the moved tensors,
-        then record that consumer stream for allocator-safe reuse.
-        """
-        pending = [
-            it
-            for it in items
-            if it.feature_shm is not None
-            or (isinstance(it.feature, torch.Tensor) and it.feature.device != device)
-        ]
-        if not pending:
-            return
-
-        if device.type != "cuda":
-            for it in pending:
-                handle = it.feature_shm
-                if handle is not None:
-                    try:
-                        it.feature = handle.consume()
-                    finally:
-                        it.feature_shm = None
-                if isinstance(it.feature, torch.Tensor):
-                    it.feature = it.feature.to(device, non_blocking=True)
-            return
-
-        shm_items = [item for item in pending if item.feature_shm is not None]
-        shm_count = len(shm_items)
-        shm_nbytes = sum(
-            item.feature_shm.nbytes()
-            for item in shm_items
-            if item.feature_shm is not None
-        )
-        use_tp_broadcast = self._should_move_shm_via_tp_broadcast(pending)
-        interleave_h2d = shm_nbytes > shm_count * _INTERLEAVED_H2D_MIN_AVERAGE_BYTES
-        defer_shm_cleanup = shm_count == 1 and interleave_h2d
-        if not use_tp_broadcast and not interleave_h2d:
-            for item in shm_items:
-                handle = item.feature_shm
-                assert handle is not None
-                try:
-                    item.feature = handle.consume()
-                finally:
-                    item.feature_shm = None
-
-        # Keep collectives on the model stream so their ordering matches other
-        # TP collectives queued by the forward pass on every rank.
-        if use_tp_broadcast:
-            self._move_shm_via_tp_broadcast(pending, device)
-            return
-
-        h2d = self._h2d_stream_on(device)
-        current = torch.cuda.current_stream(device)
-        with torch.cuda.stream(h2d):
-            for it in pending:
-                handle = it.feature_shm
-                if handle is not None:
-                    if defer_shm_cleanup:
-                        try:
-                            it.feature = handle.copy_to_pinned()
-                            it.feature = it.feature.to(device, non_blocking=True)
-                        finally:
-                            handle.release()
-                            it.feature_shm = None
-                        continue
-                    try:
-                        it.feature = handle.consume()
-                    finally:
-                        it.feature_shm = None
-                if isinstance(it.feature, torch.Tensor):
-                    it.feature = it.feature.to(device, non_blocking=True)
-        current.wait_stream(h2d)
-        for it in pending:
-            if isinstance(it.feature, torch.Tensor):
-                it.feature.record_stream(current)
-
-    def _should_move_shm_via_tp_broadcast(
-        self, items: list[MultimodalDataItem]
-    ) -> bool:
-        tp_group = self._vision_tp_group
-        if (
-            tp_group is None
-            or self._vision_tp_process_group is None
-            or self._vision_tp_src_rank is None
-            or not items
-            or not all(item.feature_shm is not None for item in items)
-        ):
-            return False
-
-        handles = []
-        for item in items:
-            handle = item.feature_shm
-            assert handle is not None
-            handles.append(handle)
-        dtype = handles[0].dtype
-        if any(handle.dtype != dtype for handle in handles):
-            return False
-        total_nbytes = sum(handle.nbytes() for handle in handles)
-        return total_nbytes >= _TP_BROADCAST_BASE_MIN_BYTES // len(tp_group)
-
-    def _move_shm_via_tp_broadcast(
-        self,
-        items: list[MultimodalDataItem],
-        device: torch.device,
-    ) -> None:
-        tp_group = self._vision_tp_group
-        process_group = self._vision_tp_process_group
-        src_rank = self._vision_tp_src_rank
-        assert tp_group is not None
-        assert process_group is not None
-        assert src_rank is not None
-
-        handles = []
-        for item in items:
-            handle = item.feature_shm
-            assert handle is not None
-            handles.append(handle)
-        dtype = handles[0].dtype
-
-        element_lengths = [math.prod(handle.shape) for handle in handles]
-        base = torch.empty(sum(element_lengths), dtype=dtype, device=device)
-        is_source = torch.distributed.get_rank() == src_rank
-        offset = 0
-        if is_source:
-            for item, handle, length in zip(
-                items, handles, element_lengths, strict=True
-            ):
-                try:
-                    if len(handles) == 1:
-                        handle.copy_into(base.narrow(0, offset, length))
-                    else:
-                        source = handle.consume().reshape(-1)
-                        base.narrow(0, offset, length).copy_(source, non_blocking=True)
-                finally:
-                    item.feature_shm = None
-                offset += length
-        else:
-            for item, handle in zip(items, handles, strict=True):
-                try:
-                    handle.release()
-                finally:
-                    item.feature_shm = None
-
-        torch.distributed.broadcast(base, src=src_rank, group=process_group)
-        offset = 0
-        for item, handle, length in zip(items, handles, element_lengths, strict=True):
-            item.feature = base.narrow(0, offset, length).view(handle.shape)
-            offset += length
+    # --- feature cleanup -------------------------------------------------
 
     @staticmethod
     def _drop_raw_feature(item: MultimodalDataItem) -> bool:

--- a/python/tokenspeed/runtime/multimodal/encoder_feature_transport.py
+++ b/python/tokenspeed/runtime/multimodal/encoder_feature_transport.py
@@ -1,0 +1,459 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Materialize multimodal input features on their encoder devices."""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+import torch
+
+from tokenspeed.runtime.distributed.mapping import VisionTowerMapping
+from tokenspeed.runtime.distributed.process_group_manager import (
+    process_group_manager,
+)
+from tokenspeed.runtime.multimodal.shm_transport import ShmTensorHandle
+from tokenspeed.runtime.utils.env import envs
+
+logger = logging.getLogger(__name__)
+LOG_MM_TIMING = envs.TOKENSPEED_LOG_MM_TIMING.get()
+
+# Small transfers are faster after staging the whole batch; larger transfers
+# benefit from overlapping each H2D enqueue with the next SHM-to-pinned copy.
+_INTERLEAVED_H2D_MIN_AVERAGE_BYTES = 1024 * 1024
+# One rank can stage the input and distribute it faster than every TP rank
+# repeating the host copy once the payload reaches this TP-scaled threshold.
+# Local B200 measurements put the break-even points near 128 MiB for TP2 and
+# 64 MiB for TP4.
+_TP_BROADCAST_BASE_MIN_BYTES = 256 * 1024 * 1024
+
+
+class DeviceFeatureItem(Protocol):
+    """Structural type for a multimodal item materialized before encoding."""
+
+    feature: torch.Tensor | None
+    feature_shm: ShmTensorHandle | None
+
+
+def _packed_layout(
+    handles: Sequence[ShmTensorHandle],
+) -> tuple[list[tuple[ShmTensorHandle, int, int]], int]:
+    """Lay out heterogeneous tensors in one byte buffer with dtype alignment."""
+    layout = []
+    cursor = 0
+    for handle in handles:
+        alignment = torch.empty((), dtype=handle.dtype).element_size()
+        cursor = (cursor + alignment - 1) // alignment * alignment
+        nbytes = handle.nbytes()
+        layout.append((handle, cursor, nbytes))
+        cursor += nbytes
+    return layout, cursor
+
+
+def _build_owner_transfers(
+    items: Sequence[DeviceFeatureItem],
+    item_indices_by_rank: Sequence[Sequence[int]],
+    owner_ranks: tuple[int, ...],
+) -> dict[tuple[int, int], list[ShmTensorHandle]]:
+    if len(item_indices_by_rank) != len(owner_ranks):
+        raise ValueError(
+            "item-DP assignment and owner group sizes differ: "
+            f"{len(item_indices_by_rank)} != {len(owner_ranks)}"
+        )
+
+    transfers: dict[tuple[int, int], list[ShmTensorHandle]] = {}
+    for owner_index, item_indices in enumerate(item_indices_by_rank):
+        owner_rank = owner_ranks[owner_index]
+        for item_index in item_indices:
+            handle = items[item_index].feature_shm
+            if (
+                not isinstance(handle, ShmTensorHandle)
+                or not handle.is_cross_node
+                or handle.is_reachable_from(owner_rank)
+            ):
+                continue
+            source_rank = handle.source_rank
+            if source_rank is None:
+                raise RuntimeError("Cross-node SHM feature has no source rank")
+            if source_rank not in owner_ranks:
+                raise RuntimeError(
+                    f"SHM source rank {source_rank} is outside item-DP group "
+                    f"{owner_ranks}"
+                )
+            transfers.setdefault((source_rank, owner_rank), []).append(handle)
+    return transfers
+
+
+@dataclass(frozen=True)
+class _TpBroadcastEntry:
+    item: DeviceFeatureItem
+    handle: ShmTensorHandle
+    length: int
+
+
+@dataclass(frozen=True)
+class _TpBroadcastBatch:
+    source_rank: int
+    dtype: torch.dtype
+    entries: tuple[_TpBroadcastEntry, ...]
+    stage_via_pinned: bool = False
+
+    @property
+    def numel(self) -> int:
+        return sum(entry.length for entry in self.entries)
+
+    @property
+    def nbytes(self) -> int:
+        return sum(entry.handle.nbytes() for entry in self.entries)
+
+
+class EncoderFeatureTransport:
+    """Own CPU routing, H2D staging, and vision-TP input broadcasts."""
+
+    def __init__(self, encoder_mapping: VisionTowerMapping | None = None) -> None:
+        self._encoder_dp_group = (
+            encoder_mapping.dp_group if encoder_mapping is not None else None
+        )
+        self._h2d_stream: torch.cuda.Stream | None = None
+
+        vision_tp_group = (
+            encoder_mapping.tp_group if encoder_mapping is not None else None
+        )
+        self._vision_tp_group = vision_tp_group
+        self._has_vision_tp = vision_tp_group is not None and len(vision_tp_group) > 1
+        self._vision_tp_process_group = None
+        self._vision_tp_src_rank: int | None = None
+        if (
+            vision_tp_group is not None
+            and len(vision_tp_group) > 1
+            and process_group_manager.has_process_group("nccl", vision_tp_group)
+        ):
+            self._vision_tp_process_group = process_group_manager.get_process_group(
+                "nccl", vision_tp_group
+            )
+            self._vision_tp_src_rank = vision_tp_group[0]
+
+    def route_to_item_owners(
+        self,
+        items: Sequence[DeviceFeatureItem],
+        item_indices_by_rank: Sequence[Sequence[int]],
+    ) -> None:
+        """Pack and send cross-node SHM payloads to their item-DP owners."""
+        if not any(
+            item.feature_shm is not None and item.feature_shm.is_cross_node
+            for item in items
+        ):
+            return
+        if self._encoder_dp_group is None:
+            raise RuntimeError("Item-owner SHM routing has no encoder DP group")
+        owner_ranks = tuple(self._encoder_dp_group)
+        transfers = _build_owner_transfers(
+            items,
+            item_indices_by_rank,
+            owner_ranks,
+        )
+        if not transfers:
+            return
+
+        cpu_group = process_group_manager.get_process_group("gloo", owner_ranks)
+        started = time.perf_counter() if LOG_MM_TIMING else None
+        rank = torch.distributed.get_rank()
+        transferred_handles = 0
+        transferred_bytes = 0
+        for (source_rank, owner_rank), handles in sorted(transfers.items()):
+            layout, packed_nbytes = _packed_layout(handles)
+            transferred_handles += len(layout)
+            transferred_bytes += sum(nbytes for _, _, nbytes in layout)
+            if rank == source_rank:
+                payload = torch.empty(packed_nbytes, dtype=torch.uint8)
+                for handle, offset, nbytes in layout:
+                    handle.copy_bytes_into(payload.narrow(0, offset, nbytes))
+                torch.distributed.send(payload, dst=owner_rank, group=cpu_group)
+            elif rank == owner_rank:
+                payload = torch.empty(packed_nbytes, dtype=torch.uint8, pin_memory=True)
+                torch.distributed.recv(payload, src=source_rank, group=cpu_group)
+                for handle, offset, nbytes in layout:
+                    handle.set_remote(payload.narrow(0, offset, nbytes))
+
+        if LOG_MM_TIMING and started is not None:
+            logger.info(
+                "mm_timing shm_owner_route_ms transfers=%d handles=%d bytes=%d "
+                "elapsed=%.3f",
+                len(transfers),
+                transferred_handles,
+                transferred_bytes,
+                (time.perf_counter() - started) * 1000,
+            )
+
+    def move_to_device(
+        self, items: Sequence[DeviceFeatureItem], device: torch.device
+    ) -> None:
+        """Materialize pending features on ``device`` with bounded host copies."""
+        pending = [
+            item
+            for item in items
+            if item.feature_shm is not None
+            or (
+                isinstance(item.feature, torch.Tensor) and item.feature.device != device
+            )
+        ]
+        if not pending:
+            return
+
+        cross_node_tp_items = [
+            item
+            for item in pending
+            if self._has_vision_tp
+            and item.feature_shm is not None
+            and item.feature_shm.is_cross_node
+        ]
+        if cross_node_tp_items:
+            if device.type != "cuda":
+                raise RuntimeError(
+                    "Cross-node weight-TP SHM transport requires a CUDA device"
+                )
+            batches = self._build_cross_node_tp_batches(cross_node_tp_items)
+            self._execute_tp_broadcasts(batches, device, mode="cross_node")
+            pending = [
+                item
+                for item in pending
+                if item.feature_shm is not None
+                or (
+                    isinstance(item.feature, torch.Tensor)
+                    and item.feature.device != device
+                )
+            ]
+            if not pending:
+                return
+
+        if device.type != "cuda":
+            for item in pending:
+                handle = item.feature_shm
+                if handle is not None:
+                    try:
+                        item.feature = handle.consume()
+                    finally:
+                        item.feature_shm = None
+                if isinstance(item.feature, torch.Tensor):
+                    item.feature = item.feature.to(device, non_blocking=True)
+            return
+
+        shm_items = [item for item in pending if item.feature_shm is not None]
+        shm_count = len(shm_items)
+        shm_nbytes = sum(
+            item.feature_shm.nbytes()
+            for item in shm_items
+            if item.feature_shm is not None
+        )
+        use_tp_broadcast = self._should_use_tp_broadcast(pending)
+        interleave_h2d = shm_nbytes > shm_count * _INTERLEAVED_H2D_MIN_AVERAGE_BYTES
+        defer_shm_cleanup = shm_count == 1 and interleave_h2d
+        if not use_tp_broadcast and not interleave_h2d:
+            for item in shm_items:
+                handle = item.feature_shm
+                assert handle is not None
+                try:
+                    item.feature = handle.consume()
+                finally:
+                    item.feature_shm = None
+
+        # Keep collectives on the model stream so their ordering matches other
+        # TP collectives queued by the forward pass on every rank.
+        if use_tp_broadcast:
+            batch = self._build_local_tp_batch(pending)
+            self._execute_tp_broadcasts((batch,), device, mode="local")
+            return
+
+        h2d = self._h2d_stream_on(device)
+        current = torch.cuda.current_stream(device)
+        with torch.cuda.stream(h2d):
+            for item in pending:
+                handle = item.feature_shm
+                if handle is not None:
+                    if defer_shm_cleanup:
+                        try:
+                            item.feature = handle.copy_to_pinned()
+                            item.feature = item.feature.to(device, non_blocking=True)
+                        finally:
+                            handle.release()
+                            item.feature_shm = None
+                        continue
+                    try:
+                        item.feature = handle.consume()
+                    finally:
+                        item.feature_shm = None
+                if isinstance(item.feature, torch.Tensor):
+                    item.feature = item.feature.to(device, non_blocking=True)
+        current.wait_stream(h2d)
+        for item in pending:
+            if isinstance(item.feature, torch.Tensor):
+                item.feature.record_stream(current)
+
+    def _should_use_tp_broadcast(self, items: Sequence[DeviceFeatureItem]) -> bool:
+        """Return whether a same-host SHM batch should use one TP H2D source."""
+        tp_group = self._vision_tp_group
+        if (
+            tp_group is None
+            or self._vision_tp_process_group is None
+            or self._vision_tp_src_rank is None
+            or not items
+            or not all(item.feature_shm is not None for item in items)
+        ):
+            return False
+
+        handles = []
+        for item in items:
+            handle = item.feature_shm
+            assert handle is not None
+            handles.append(handle)
+        dtype = handles[0].dtype
+        if any(handle.dtype != dtype for handle in handles):
+            return False
+        total_nbytes = sum(handle.nbytes() for handle in handles)
+        return total_nbytes >= _TP_BROADCAST_BASE_MIN_BYTES // len(tp_group)
+
+    def _h2d_stream_on(self, device: torch.device) -> torch.cuda.Stream:
+        if self._h2d_stream is None:
+            self._h2d_stream = torch.cuda.Stream(device=device)
+        return self._h2d_stream
+
+    def _build_local_tp_batch(
+        self, items: Sequence[DeviceFeatureItem]
+    ) -> _TpBroadcastBatch:
+        source_rank = self._vision_tp_src_rank
+        if source_rank is None:
+            raise RuntimeError("Local TP SHM broadcast has no source rank")
+        entries = []
+        for item in items:
+            handle = item.feature_shm
+            if handle is None:
+                raise RuntimeError("Local TP SHM broadcast received an inline feature")
+            entries.append(_TpBroadcastEntry(item, handle, math.prod(handle.shape)))
+        return _TpBroadcastBatch(
+            source_rank=source_rank,
+            dtype=entries[0].handle.dtype,
+            entries=tuple(entries),
+            stage_via_pinned=len(entries) > 1,
+        )
+
+    def _build_cross_node_tp_batches(
+        self, items: Sequence[DeviceFeatureItem]
+    ) -> tuple[_TpBroadcastBatch, ...]:
+        tp_group = self._vision_tp_group
+        if tp_group is None or self._vision_tp_process_group is None:
+            raise RuntimeError(
+                "Cross-node weight-TP SHM transport has no vision TP process group"
+            )
+
+        grouped: dict[
+            tuple[int, torch.dtype],
+            list[_TpBroadcastEntry],
+        ] = {}
+        for item in items:
+            handle = item.feature_shm
+            assert isinstance(handle, ShmTensorHandle)
+            source_rank = handle.source_rank
+            if source_rank is None:
+                raise RuntimeError("Cross-node TP item has no SHM broadcast source")
+            if source_rank not in tp_group:
+                raise RuntimeError(
+                    f"SHM source rank {source_rank} is outside vision TP group "
+                    f"{tp_group}"
+                )
+            grouped.setdefault((source_rank, handle.dtype), []).append(
+                _TpBroadcastEntry(item, handle, math.prod(handle.shape))
+            )
+
+        batches = []
+        for (source_rank, dtype), entries in sorted(
+            grouped.items(), key=lambda pair: (pair[0][0], str(pair[0][1]))
+        ):
+            batches.append(
+                _TpBroadcastBatch(
+                    source_rank=source_rank,
+                    dtype=dtype,
+                    entries=tuple(entries),
+                )
+            )
+        return tuple(batches)
+
+    def _execute_tp_broadcasts(
+        self,
+        batches: Sequence[_TpBroadcastBatch],
+        device: torch.device,
+        *,
+        mode: str,
+    ) -> None:
+        process_group = self._vision_tp_process_group
+        if process_group is None:
+            raise RuntimeError("SHM TP broadcast has no vision TP process group")
+
+        started = time.perf_counter() if LOG_MM_TIMING else None
+        rank = torch.distributed.get_rank()
+        for batch in batches:
+            base = torch.empty(batch.numel, dtype=batch.dtype, device=device)
+            offset = 0
+            if rank == batch.source_rank:
+                for entry in batch.entries:
+                    destination = base.narrow(0, offset, entry.length)
+                    try:
+                        if batch.stage_via_pinned:
+                            source = entry.handle.consume().reshape(-1)
+                            destination.copy_(source, non_blocking=True)
+                        else:
+                            entry.handle.copy_into(destination)
+                    finally:
+                        entry.item.feature_shm = None
+                    offset += entry.length
+            else:
+                for entry in batch.entries:
+                    try:
+                        entry.handle.release()
+                    finally:
+                        entry.item.feature_shm = None
+
+            torch.distributed.broadcast(
+                base,
+                src=batch.source_rank,
+                group=process_group,
+            )
+            offset = 0
+            for entry in batch.entries:
+                entry.item.feature = base.narrow(0, offset, entry.length).view(
+                    entry.handle.shape
+                )
+                offset += entry.length
+
+        if LOG_MM_TIMING and started is not None:
+            logger.info(
+                "mm_timing shm_tp_broadcast_ms mode=%s groups=%d handles=%d "
+                "bytes=%d elapsed=%.3f",
+                mode,
+                len(batches),
+                sum(len(batch.entries) for batch in batches),
+                sum(batch.nbytes for batch in batches),
+                (time.perf_counter() - started) * 1000,
+            )

--- a/python/tokenspeed/runtime/multimodal/inputs.py
+++ b/python/tokenspeed/runtime/multimodal/inputs.py
@@ -265,9 +265,7 @@ class MultimodalInputs(msgspec.Struct, eq=False, kw_only=True, array_like=True):
                 item.feature = None
 
     def attach_shm_features(self) -> None:
-        """Open every pending handle on this rank. Must run before the
-        cross-rank barrier in ``request_handler.recv_reqs``.
-        """
+        """Open every pending handle before peers may consume and unlink it."""
         for item in self.mm_items:
             if item.feature_shm is not None:
                 item.feature_shm.attach()

--- a/python/tokenspeed/runtime/multimodal/shm_transport.py
+++ b/python/tokenspeed/runtime/multimodal/shm_transport.py
@@ -18,20 +18,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""POSIX SHM handle for cross-process multimodal feature tensors.
+"""POSIX SHM representation and reachability for multimodal feature tensors.
 
-The lifecycle keeps the unlink race-free for tensor-parallel ranks while still
-allowing the model-side multimodal planner to deduplicate requests before any
-large payload copy happens:
-
-``publish`` (producer) -> ``attach`` (every rank, before barrier) ->
-``consume`` (only encoder misses) or ``release`` (deduplicated aliases).
+The request path discovers which ranks can open each producer-side SHM segment.
+Later encoder transport stages use that process-local reachability information
+to select a source without coupling this low-level module to encoder ownership
+or device-transfer policy.
 """
 
 from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Sequence
 from multiprocessing import shared_memory
 
 import msgspec
@@ -62,6 +61,10 @@ class ShmTensorHandle(msgspec.Struct, eq=False, dict=True):
     # Payload received over the CPU group when the producer's POSIX segment
     # lives on another host; also non-wire.
     _remote = None
+    # Populated by ``prepare_shm_features`` after every rank has attempted a
+    # local POSIX attach. These are process-local and never serialized.
+    _reachable_ranks = None
+    _group_size = None
 
     @classmethod
     def publish(cls, tensor: torch.Tensor) -> ShmTensorHandle:
@@ -79,9 +82,7 @@ class ShmTensorHandle(msgspec.Struct, eq=False, dict=True):
         return cls(shm_name=name, shape=tuple(tensor.shape), dtype=tensor.dtype)
 
     def attach(self) -> None:
-        """Open the SHM segment on this rank. Must run before the cross-rank
-        barrier so unlink in ``consume()`` cannot race another rank's open.
-        """
+        """Open the segment before peers may consume and unlink it."""
         if self._segment is None:
             self._segment = shared_memory.SharedMemory(name=self.shm_name)
 
@@ -102,10 +103,61 @@ class ShmTensorHandle(msgspec.Struct, eq=False, dict=True):
             n *= d
         return n * torch.empty((), dtype=self.dtype).element_size()
 
-    def peek_bytes(self) -> torch.Tensor:
-        """Copy the attached segment as flat bytes without consuming it."""
-        assert self._segment is not None
-        return torch.frombuffer(self._segment.buf, dtype=torch.uint8).clone()
+    def copy_bytes_into(self, destination: torch.Tensor) -> None:
+        """Copy this attached segment into a flat CPU uint8 destination."""
+        if self._segment is None:
+            raise RuntimeError(
+                f"ShmTensorHandle({self.shm_name!r}) is not attached on the "
+                "selected transport source rank"
+            )
+        if (
+            destination.device.type != "cpu"
+            or destination.dtype != torch.uint8
+            or destination.numel() != self.nbytes()
+        ):
+            raise ValueError(
+                "SHM byte destination must be a flat CPU uint8 tensor with "
+                f"{self.nbytes()} elements"
+            )
+        source = torch.frombuffer(self._segment.buf, dtype=torch.uint8)
+        destination.copy_(source)
+
+    def _set_reachability(
+        self, reachable_ranks: tuple[int, ...], group_size: int
+    ) -> None:
+        """Record process-local SHM reachability after discovery."""
+        if (
+            not reachable_ranks
+            or group_size < len(reachable_ranks)
+            or len(set(reachable_ranks)) != len(reachable_ranks)
+        ):
+            raise ValueError(
+                "Invalid SHM reachability: "
+                f"reachable={reachable_ranks}, group_size={group_size}"
+            )
+        self._reachable_ranks = reachable_ranks
+        self._group_size = group_size
+
+    @property
+    def is_cross_node(self) -> bool:
+        reachable_ranks = self._reachable_ranks
+        group_size = self._group_size
+        return (
+            reachable_ranks is not None
+            and group_size is not None
+            and len(reachable_ranks) != group_size
+        )
+
+    @property
+    def source_rank(self) -> int | None:
+        """Return the selected rank that can directly open this SHM."""
+        reachable_ranks = self._reachable_ranks
+        return reachable_ranks[0] if reachable_ranks else None
+
+    def is_reachable_from(self, rank: int) -> bool:
+        """Return whether ``rank`` can directly open this SHM."""
+        reachable_ranks = self._reachable_ranks
+        return reachable_ranks is not None and rank in reachable_ranks
 
     def set_remote(self, flat_bytes: torch.Tensor) -> None:
         self._remote = flat_bytes
@@ -208,6 +260,11 @@ class ShmTensorHandle(msgspec.Struct, eq=False, dict=True):
         if self._remote is not None:
             self._remote = None
             return
+        # A deferred non-owner on another host never received the payload and
+        # cannot unlink the producer's POSIX segment. Avoid a guaranteed failed
+        # SharedMemory open for every queued/aliased item on every remote rank.
+        if self._reachable_ranks is not None and self._segment is None:
+            return
         segment = self._segment
         self._segment = None
         try:
@@ -236,12 +293,46 @@ class ShmTensorHandle(msgspec.Struct, eq=False, dict=True):
             )
 
 
-def sync_shm_features(reqs, group, group_size: int) -> None:
-    """Attach SHM-backed features in ``reqs`` on every rank.
+def _discover_shm_reachability(handles: Sequence[ShmTensorHandle], group) -> None:
+    """Record which group ranks can attach each producer-side segment."""
+    group_size = torch.distributed.get_world_size(group)
+    attached = [handle.try_attach() for handle in handles]
+    local_flags = torch.tensor(attached, dtype=torch.uint8)
+    if group_size > 1:
+        gathered_flags = [torch.empty_like(local_flags) for _ in range(group_size)]
+        # Each rank contributes H bytes instead of all-reducing a P x H matrix.
+        torch.distributed.all_gather(gathered_flags, local_flags, group=group)
+        flags = torch.stack(gathered_flags)
+    else:
+        flags = local_flags.unsqueeze(0)
 
-    The barrier makes later consume/release unlink race-free in multi-rank
-    setups. Actual materialization is intentionally deferred until the
-    multimodal encoder planner has deduplicated the batch.
+    global_ranks = tuple(
+        torch.distributed.get_global_rank(group, group_rank)
+        for group_rank in range(group_size)
+    )
+    for index, handle in enumerate(handles):
+        local_group_ranks = flags[:, index].nonzero().flatten().tolist()
+        if not local_group_ranks:
+            raise RuntimeError(
+                f"multimodal shm segment {handle.shm_name!r} is not "
+                "reachable from any rank in the group"
+            )
+        reachable_ranks = tuple(global_ranks[int(rank)] for rank in local_group_ranks)
+        handle._set_reachability(reachable_ranks, group_size)
+
+
+def prepare_shm_features(
+    reqs: Sequence[object],
+    group,
+) -> None:
+    """Attach local SHM segments and record their rank reachability.
+
+    Args:
+        reqs: Requests that may carry SHM-backed multimodal features.
+        group: CPU process group whose ranks will later execute the request.
+
+    Returns:
+        None.
     """
     pending = [
         mm
@@ -258,41 +349,23 @@ def sync_shm_features(reqs, group, group_size: int) -> None:
         for item in mm.mm_items
         if item.feature_shm is not None
     ]
-    attached = [h.try_attach() for h in handles]
-    if group_size > 1:
-        # Ship payloads whose POSIX segment lives on another host once over
-        # the CPU group; same-host ranks keep the zero-copy shm path.
-        flags = torch.zeros((group_size, len(handles)), dtype=torch.uint8)
-        flags[torch.distributed.get_rank(group)] = torch.tensor(
-            attached, dtype=torch.uint8
-        )
-        torch.distributed.all_reduce(flags, group=group)
-        for i, handle in enumerate(handles):
-            owners = flags[:, i].nonzero().flatten()
-            if owners.numel() == 0:
-                raise RuntimeError(
-                    f"multimodal shm segment {handle.shm_name!r} is not "
-                    "reachable from any rank in the group"
-                )
-            if owners.numel() == group_size:
-                continue
-            src = torch.distributed.get_global_rank(group, int(owners[0]))
-            if attached[i]:
-                payload = handle.peek_bytes()
-            else:
-                # Pinned: consume() keeps its non_blocking H2D contract.
-                payload = torch.empty(
-                    handle.nbytes(), dtype=torch.uint8, pin_memory=True
-                )
-            torch.distributed.broadcast(payload, src=src, group=group)
-            if not attached[i]:
-                handle.set_remote(payload)
-        torch.distributed.barrier(group)
+    _discover_shm_reachability(handles, group)
+
+    cross_node_handles = 0
+    cross_node_bytes = 0
+    for handle in handles:
+        if handle.is_cross_node:
+            cross_node_handles += 1
+            cross_node_bytes += handle.nbytes()
+
     if LOG_MM_TIMING and started is not None:
         item_count = sum(len(mm.mm_items) for mm in pending)
         logger.info(
-            "mm_timing shm_attach_ms requests=%d items=%d elapsed=%.3f",
+            "mm_timing shm_attach_ms requests=%d items=%d elapsed=%.3f "
+            "cross_node_handles=%d cross_node_bytes=%d",
             len(pending),
             item_count,
             (time.perf_counter() - started) * 1000,
+            cross_node_handles,
+            cross_node_bytes,
         )

--- a/test/runtime/distributed/test_multimodal_encoder_parallelism.py
+++ b/test/runtime/distributed/test_multimodal_encoder_parallelism.py
@@ -156,6 +156,27 @@ def _run_item_dp_case(rank: int, device: torch.device, mapping: Mapping) -> None
     assert idle_calls == (1 if rank == 0 else 0)
     torch.testing.assert_close(idle_item.encoded, _encoded_rows(idle_item, 2, device))
 
+    # Equal rank-local row counts use all_gather_into_tensor directly into the
+    # final rank-major output buffer.
+    equal_items = [_item(50, 2), _item(60, 2)]
+    equal_calls: list[list[int]] = []
+
+    def equal_encoder(batch):
+        equal_calls.append([int(item.hash) for item in batch])
+        return _encoded_rows(batch[0], 2, device)
+
+    embedder._encode(
+        EncodePlan(misses_by_modality={Modality.IMAGE: equal_items}),
+        {Modality.IMAGE: EncoderSpec(equal_encoder)},
+        SimpleNamespace(),
+        device,
+        2,
+        torch.float32,
+    )
+    assert equal_calls == [[50] if rank == 0 else [60]]
+    for item in equal_items:
+        torch.testing.assert_close(item.encoded, _encoded_rows(item, 2, device))
+
 
 def _item_dp_worker(rank: int, world_size: int, port: int) -> None:
     device = torch.device(f"cuda:{rank}")

--- a/test/runtime/distributed/test_multimodal_shm_multinode.py
+++ b/test/runtime/distributed/test_multimodal_shm_multinode.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# SPDX-License-Identifier: MIT
+
+"""Two-node SHM transport coverage, launched once per node with torchrun."""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from tokenspeed.runtime.distributed.mapping import VisionTowerMapping
+from tokenspeed.runtime.distributed.process_group_manager import (
+    process_group_manager,
+)
+from tokenspeed.runtime.multimodal.encoder_feature_transport import (
+    EncoderFeatureTransport,
+)
+from tokenspeed.runtime.multimodal.inputs import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from tokenspeed.runtime.multimodal.shm_transport import (
+    ShmTensorHandle,
+    prepare_shm_features,
+)
+
+
+def _request(items: list[MultimodalDataItem]):
+    return SimpleNamespace(multimodal_inputs=MultimodalInputs(mm_items=items))
+
+
+def _publish_items(rank: int) -> tuple[list[MultimodalDataItem], list[torch.Tensor]]:
+    expected = [
+        torch.tensor([3, 1, 4, 1, 5], dtype=torch.uint8),
+        torch.tensor([2, 7, 1], dtype=torch.uint8),
+        torch.arange(8, dtype=torch.float32).reshape(2, 4),
+    ]
+    metadata = None
+    handles = None
+    if rank == 0:
+        handles = [ShmTensorHandle.publish(tensor) for tensor in expected]
+        metadata = [(handle.shm_name, handle.shape, handle.dtype) for handle in handles]
+
+    objects = [metadata]
+    dist.broadcast_object_list(objects, src=0)
+    if handles is None:
+        handles = [
+            ShmTensorHandle(name, tuple(shape), dtype)
+            for name, shape, dtype in objects[0]
+        ]
+    items = [
+        MultimodalDataItem(
+            modality=Modality.IMAGE,
+            hash=index,
+            offsets=[(0, 0)],
+            feature_shm=handle,
+        )
+        for index, handle in enumerate(handles)
+    ]
+    return items, expected
+
+
+def _release(items: list[MultimodalDataItem]) -> None:
+    for item in items:
+        if item.feature_shm is not None:
+            item.feature_shm.release()
+            item.feature_shm = None
+
+
+def test_multinode_owner_and_tp_transport() -> None:
+    if int(os.environ.get("WORLD_SIZE", "1")) != 2:
+        pytest.skip("launch this test with torchrun --nnodes=2")
+    if not torch.cuda.is_available():
+        pytest.skip("multinode transport coverage requires CUDA")
+
+    rank = int(os.environ["RANK"])
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend="gloo")
+    process_group_manager.register_process_group("gloo", (0, 1), dist.group.WORLD)
+    nccl_group = None
+    owner_items: list[MultimodalDataItem] = []
+    tp_items: list[MultimodalDataItem] = []
+    try:
+        owner_items, expected = _publish_items(rank)
+        prepare_shm_features([_request(owner_items)], dist.group.WORLD)
+        assert all(item.feature_shm.is_cross_node for item in owner_items)
+        owner_transport = EncoderFeatureTransport(
+            VisionTowerMapping(rank=rank, world_size=2, tp_size=1, dp_size=2)
+        )
+        owner_transport.route_to_item_owners(
+            owner_items,
+            ((0,), (1, 2)),
+        )
+        owned_indices = (0,) if rank == 0 else (1, 2)
+        for index in owned_indices:
+            received = owner_items[index].feature_shm.consume()
+            assert received.is_pinned()
+            torch.testing.assert_close(received, expected[index])
+        dist.barrier()
+        _release(owner_items)
+        dist.barrier()
+
+        tp_items, expected = _publish_items(rank)
+        prepare_shm_features([_request(tp_items)], dist.group.WORLD)
+        assert all(item.feature_shm.is_cross_node for item in tp_items)
+
+        tp_group = (0, 1)
+        nccl_group = dist.new_group(ranks=list(tp_group), backend="nccl")
+        process_group_manager.register_process_group("nccl", tp_group, nccl_group)
+        mapping = VisionTowerMapping(rank=rank, world_size=2, tp_size=2, dp_size=1)
+        transport = EncoderFeatureTransport(mapping)
+        device = torch.device("cuda", local_rank)
+        transport.move_to_device(tp_items, device)
+
+        for item, tensor in zip(tp_items, expected, strict=True):
+            assert item.feature_shm is None
+            assert item.feature is not None
+            torch.testing.assert_close(item.feature.cpu(), tensor)
+        dist.barrier()
+    finally:
+        _release(owner_items)
+        _release(tp_items)
+        if nccl_group is not None:
+            dist.destroy_process_group(nccl_group)
+        dist.destroy_process_group()

--- a/test/runtime/distributed/test_multimodal_shm_multinode.py
+++ b/test/runtime/distributed/test_multimodal_shm_multinode.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import os
+import socket
 from types import SimpleNamespace
 
 import pytest
@@ -88,6 +89,11 @@ def test_multinode_owner_and_tp_transport() -> None:
     owner_items: list[MultimodalDataItem] = []
     tp_items: list[MultimodalDataItem] = []
     try:
+        hostnames: list[str | None] = [None] * dist.get_world_size()
+        dist.all_gather_object(hostnames, socket.gethostname())
+        if len(set(hostnames)) != 2:
+            pytest.skip("multinode transport coverage requires two distinct hosts")
+
         owner_items, expected = _publish_items(rank)
         prepare_shm_features([_request(owner_items)], dist.group.WORLD)
         assert all(item.feature_shm.is_cross_node for item in owner_items)

--- a/test/runtime/test_multimodal_tp_broadcast.py
+++ b/test/runtime/test_multimodal_tp_broadcast.py
@@ -1,7 +1,9 @@
 import pytest
 import torch
 
-from tokenspeed.runtime.multimodal.embedder import VisionEmbedder
+from tokenspeed.runtime.multimodal.encoder_feature_transport import (
+    EncoderFeatureTransport,
+)
 from tokenspeed.runtime.multimodal.inputs import Modality, MultimodalDataItem
 from tokenspeed.runtime.multimodal.shm_transport import ShmTensorHandle
 
@@ -17,67 +19,56 @@ def _shm_item(nbytes: int, dtype: torch.dtype = torch.bfloat16):
     )
 
 
-def _embedder(tp_size: int) -> VisionEmbedder:
-    embedder = VisionEmbedder()
-    embedder._vision_tp_group = tuple(range(tp_size))
-    embedder._vision_tp_process_group = object()
-    embedder._vision_tp_src_rank = 0
-    return embedder
+def _transport(tp_size: int) -> EncoderFeatureTransport:
+    transport = EncoderFeatureTransport()
+    transport._vision_tp_group = tuple(range(tp_size))
+    transport._vision_tp_process_group = object()
+    transport._vision_tp_src_rank = 0
+    return transport
 
 
-def test_tp2_broadcasts_at_128_mib():
-    embedder = _embedder(2)
+def test_tp_broadcast_selection():
+    tp2 = _transport(2)
+    assert not tp2._should_use_tp_broadcast([_shm_item(128 * 1024 * 1024 - 2)])
+    assert tp2._should_use_tp_broadcast([_shm_item(128 * 1024 * 1024)])
 
-    assert not embedder._should_move_shm_via_tp_broadcast(
-        [_shm_item(128 * 1024 * 1024 - 2)]
+    tp4 = _transport(4)
+    assert tp4._should_use_tp_broadcast([_shm_item(8 * 1024 * 1024) for _ in range(8)])
+    assert not tp4._should_use_tp_broadcast(
+        [
+            _shm_item(32 * 1024 * 1024, torch.bfloat16),
+            _shm_item(32 * 1024 * 1024, torch.float16),
+        ]
     )
-    assert embedder._should_move_shm_via_tp_broadcast([_shm_item(128 * 1024 * 1024)])
-
-
-def test_tp4_broadcasts_aggregate_64_mib_payload():
-    embedder = _embedder(4)
-    items = [_shm_item(8 * 1024 * 1024) for _ in range(8)]
-
-    assert embedder._should_move_shm_via_tp_broadcast(items)
-
-
-def test_tp_broadcast_requires_uniform_shm_dtype():
-    embedder = _embedder(4)
-    items = [
-        _shm_item(32 * 1024 * 1024, torch.bfloat16),
-        _shm_item(32 * 1024 * 1024, torch.float16),
-    ]
-
-    assert not embedder._should_move_shm_via_tp_broadcast(items)
-
-
-def test_tp_broadcast_rejects_inline_tensors():
-    embedder = _embedder(4)
-    items = [
-        _shm_item(64 * 1024 * 1024),
-        MultimodalDataItem(modality=Modality.IMAGE, feature=torch.empty(1)),
-    ]
-
-    assert not embedder._should_move_shm_via_tp_broadcast(items)
+    assert not tp4._should_use_tp_broadcast(
+        [
+            _shm_item(64 * 1024 * 1024),
+            MultimodalDataItem(modality=Modality.IMAGE, feature=torch.empty(1)),
+        ]
+    )
 
 
 def test_tp_broadcast_stays_on_model_stream(monkeypatch):
-    embedder = _embedder(2)
+    transport = _transport(2)
     items = [_shm_item(128 * 1024 * 1024)]
     moved = []
 
     monkeypatch.setattr(
-        embedder,
-        "_move_shm_via_tp_broadcast",
-        lambda pending, device: moved.append((pending, device)),
+        transport,
+        "_execute_tp_broadcasts",
+        lambda batches, device, *, mode: moved.append((batches, device, mode)),
     )
     monkeypatch.setattr(
-        embedder,
+        transport,
         "_h2d_stream_on",
         lambda _device: pytest.fail("TP broadcast must not use the H2D stream"),
     )
 
     device = torch.device("cuda")
-    embedder._move_features_to_device(items, device)
+    transport.move_to_device(items, device)
 
-    assert moved == [(items, device)]
+    assert len(moved) == 1
+    batches, moved_device, mode = moved[0]
+    assert moved_device == device
+    assert mode == "local"
+    assert [entry.item for entry in batches[0].entries] == items


### PR DESCRIPTION
## Summary

This PR makes multimodal feature transport topology-aware for multi-node deployments.

Previously, cross-node SHM payloads were broadcast to every rank through Gloo. This PR instead:

- Discovers SHM reachability without moving feature payloads during request ingestion.
- Routes item-DP features only to their assigned owner rank.
- Stages weight-TP features on one reachable rank and distributes them through the vision NCCL group.
- Uses optimized output collection for single-owner, equal-sized, and uneven item-DP outputs.
- Separates feature routing and device materialization into `EncoderFeatureTransport`.
- Removes the one-node restriction from multimodal encoder item DP.

## Validation

Tested on 2 nodes × 8 B300 GPUs with three alternating baseline/refactor A/B pairs per model.

| Model | Vision topology | Workload | Baseline | Refactor | Change |
| --- | --- | --- | ---: | ---: | ---: |
| Kimi K2.6 | weights TP16 | 32 concurrent requests, 8 FHD images/request | 0.9811 req/s | 1.1894 req/s | +21.54% |
| Kimi K3 | item-DP16 | 16 concurrent requests, 2 FHD images/request | 0.8312 req/s | 0.9228 req/s | +11.06% |

The first K2.6 baseline run was colder than the other two; using the stable second and third pairs gives a +15.74% paired geometric-mean improvement.

Host-network traffic also decreased:

- Kimi K2.6: approximately 245 GB → 1 GB per run (`-99.6%`).
- Kimi K3: 17.48 GB → 1.37 GB per run (`-92.2%`).

Correctness:

- Kimi K2.6 OCRBench: `0.917`, 1000 samples, no request errors.
- Kimi K3 OCRBench: `0.892`, 1000 samples, no request errors.
- 12/12 performance runs and 6/6 paired input-payload checks passed.
- `pre-commit run --all-files`
- Ruff check and format check
