### PR TITLE
chore(mla): declare the full_attention cache group at construction

### DIFF
--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -616,10 +616,6 @@ class DeepseekV3AttentionMLA(nn.Module):
         else:
             self.rotary_emb = None
 
-        # MLA is always full attention, so both modules declare that cache
-        # group. A pool publishing several groups -- a hybrid target, or a
-        # draft model sharing the target's unified pool -- rejects an untagged
-        # PagedAttention in validate_paged_cache_group_ids.
         self.attn_mqa = PagedAttention(
             self.num_local_heads,
             self.kv_lora_rank + self.qk_rope_head_dim,

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -85,6 +85,9 @@ from tokenspeed.runtime.execution.context import (
 from tokenspeed.runtime.execution.cuda_graph_wrapper import get_is_capture_mode
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.activation import SiluAndMul
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
+    FULL_ATTENTION,
+)
 from tokenspeed.runtime.layers.dense.nvfp4 import Nvfp4LinearMethod
 from tokenspeed.runtime.layers.layernorm import FusedRMSNorm, RMSNorm
 from tokenspeed.runtime.layers.linear import (
@@ -613,6 +616,10 @@ class DeepseekV3AttentionMLA(nn.Module):
         else:
             self.rotary_emb = None
 
+        # MLA is always full attention, so both modules declare that cache
+        # group. A pool publishing several groups -- a hybrid target, or a
+        # draft model sharing the target's unified pool -- rejects an untagged
+        # PagedAttention in validate_paged_cache_group_ids.
         self.attn_mqa = PagedAttention(
             self.num_local_heads,
             self.kv_lora_rank + self.qk_rope_head_dim,
@@ -620,6 +627,7 @@ class DeepseekV3AttentionMLA(nn.Module):
             num_kv_heads=1,
             layer_id=layer_id,
             v_head_dim=self.kv_lora_rank,
+            group_id=FULL_ATTENTION,
         )
 
         self.attn_mha = PagedAttention(
@@ -629,6 +637,7 @@ class DeepseekV3AttentionMLA(nn.Module):
             num_kv_heads=self.num_local_heads,
             layer_id=layer_id,
             v_head_dim=self.v_head_dim,
+            group_id=FULL_ATTENTION,
         )
 
         self.w_kc = None

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -105,9 +105,6 @@ from tokenspeed.runtime.distributed.comm_ops import (
 from tokenspeed.runtime.distributed.mapping import Mapping
 from tokenspeed.runtime.execution.cuda_graph_wrapper import get_is_capture_mode
 from tokenspeed.runtime.layers.activation import SituAndMul
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-    FULL_ATTENTION,
-)
 from tokenspeed.runtime.layers.layernorm import (
     RMSNorm,
     _get_process_group,
@@ -350,13 +347,6 @@ class KimiLinearMLAAttention(DeepseekV3AttentionMLA):
             alt_stream=alt_stream,
             skip_rope=True,  # K3 MLA is NoPE (mla_use_nope=True)
         )
-        # The MLA layers belong to the Paged cache full_attention cache group. The
-        # inherited attn_mqa/attn_mha PagedAttention modules are
-        # built without a group_id; tag them so validate_paged_cache_group_ids
-        # binds them to the published full_attention table. (KDA layers have no
-        # PagedAttention and resolve their state group via group_id_for_layer.)
-        self.attn_mqa.group_id = FULL_ATTENTION
-        self.attn_mha.group_id = FULL_ATTENTION
         self.use_output_gate = config.mla_use_output_gate
         if self.use_output_gate:
             assert q_lora_rank is not None, "gated MLA assumes the q-lora path"

--- a/python/tokenspeed/runtime/models/kimi_k3_dspark.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_dspark.py
@@ -51,7 +51,6 @@ from tokenspeed.runtime.distributed.comm_ops import all_reduce
 from tokenspeed.runtime.distributed.mapping import Mapping
 from tokenspeed.runtime.execution.context import ForwardContext
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import FULL_ATTENTION
 from tokenspeed.runtime.layers.layernorm import RMSNorm
 from tokenspeed.runtime.layers.linear import ReplicatedLinear
 from tokenspeed.runtime.layers.logits_processor import LogitsProcessorOutput
@@ -200,14 +199,6 @@ class K3DSparkDecoderLayer(nn.Module):
             layer_id=layer_id,
             prefix=add_prefix("self_attn", prefix),
         )
-        # The draft's MLA layers join the target's full_attention paged-cache
-        # group (K3 publishes 4 groups: full_attention + 3 KDA linear). The
-        # inherited attn_mqa/attn_mha are built without a group_id; tag them so
-        # validate_paged_cache_group_ids binds them to the full_attention table
-        # instead of failing on an empty group_id. Mirrors the target
-        # (kimi_k3.py MLA layer construction).
-        self.self_attn.attn_mqa.group_id = FULL_ATTENTION
-        self.self_attn.attn_mha.group_id = FULL_ATTENTION
         self.layer_id = layer_id
         self.post_attention_layernorm = RMSNorm(hidden_size, eps=eps)
         self.mlp = DFlashMLP(

--- a/python/tokenspeed/runtime/models/llama.py
+++ b/python/tokenspeed/runtime/models/llama.py
@@ -265,7 +265,13 @@ class LlamaAttention(nn.Module):
         return create_fused_set_kv_buffer_arg(
             value=v.view(n, self.num_kv_heads, self.head_dim),
             layer=self.attn,
-            out_cache_loc=out_cache_loc,
+            # Cache path: prewrite at this layer's group locations. Identity on
+            # the legacy single-table path; without it a grouped pool would get
+            # the scheduler's locations and the write would miss the pages this
+            # layer reads.
+            out_cache_loc=ctx.attn_backend.select_out_cache_loc(
+                self.attn, out_cache_loc, ctx.forward_mode
+            ),
             token_to_kv_pool=ctx.token_to_kv_pool,
         )
 

--- a/python/tokenspeed/runtime/models/llama.py
+++ b/python/tokenspeed/runtime/models/llama.py
@@ -195,9 +195,6 @@ class LlamaAttention(nn.Module):
             self.head_dim**-0.5,
             num_kv_heads=self.num_kv_heads,
             layer_id=layer_id,
-            # Llama attention is full-history; there is no sliding-window
-            # variant on this path. A model that grows one must thread the
-            # per-layer type through here the way gpt_oss does.
             group_id=FULL_ATTENTION,
         )
 

--- a/python/tokenspeed/runtime/models/llama.py
+++ b/python/tokenspeed/runtime/models/llama.py
@@ -38,6 +38,9 @@ from tokenspeed.runtime.configs.utils import get_rope_theta
 from tokenspeed.runtime.distributed.mapping import Mapping
 from tokenspeed.runtime.execution.context import ForwardContext
 from tokenspeed.runtime.layers.activation import SiluAndMul
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
+    FULL_ATTENTION,
+)
 from tokenspeed.runtime.layers.linear import (
     MergedColumnParallelLinear,
     QKVParallelLinear,
@@ -192,6 +195,10 @@ class LlamaAttention(nn.Module):
             self.head_dim**-0.5,
             num_kv_heads=self.num_kv_heads,
             layer_id=layer_id,
+            # Llama attention is full-history; there is no sliding-window
+            # variant on this path. A model that grows one must thread the
+            # per-layer type through here the way gpt_oss does.
+            group_id=FULL_ATTENTION,
         )
 
     def forward(

--- a/python/tokenspeed/runtime/models/llama_eagle3.py
+++ b/python/tokenspeed/runtime/models/llama_eagle3.py
@@ -39,7 +39,6 @@ from tokenspeed.runtime.execution.context import (
 )
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.activation import SiluAndMul
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import FULL_ATTENTION
 from tokenspeed.runtime.layers.common import concat
 from tokenspeed.runtime.layers.layernorm import FusedRMSNorm, RMSNorm
 from tokenspeed.runtime.layers.linear import (
@@ -81,13 +80,6 @@ class LlamaAttention(BaseLlamaAttention):
     the fallback runs the full N-row attn and post-slices the output.
     Inactive draft steps delegate to base.
     """
-
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        # Llama Eagle3 drafts use full-history attention. Once draft KV layers
-        # share a multi-group target pool, the backend needs this explicit
-        # routing key rather than the single-table fallback.
-        self.attn.group_id = FULL_ATTENTION
 
     def _attn(
         self,

--- a/test/runtime/test_mla_cache_group_id.py
+++ b/test/runtime/test_mla_cache_group_id.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+# CI Registration (parsed via AST, runtime no-op)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=5, suite="runtime-1gpu")
+
+from tokenspeed.runtime.layers.paged_attention import (  # noqa: E402
+    PagedAttention,
+    validate_paged_cache_group_ids,
+)
+
+
+class TestMlaCacheGroupId(unittest.TestCase):
+    """Guards the rule DeepseekV3AttentionMLA now obeys: a PagedAttention that
+    meets a multi-group pool must carry a group id.
+
+    Untagged MLA modules went unnoticed while draft models had their own
+    single-group pool; once the draft began sharing the target's unified pool
+    -- which publishes every group the hybrid target owns -- the validation
+    rejected them and K3 + EAGLE3 refused to start. The wiring itself (that
+    ``DeepseekV3AttentionMLA.__init__`` applies the tag) is covered by serving,
+    not here: constructing it needs distributed init and real weights.
+    """
+
+    def test_validation_rejects_an_untagged_layer(self) -> None:
+        """Guard the other half: the check really fires when a tag is missing,
+        so the test above cannot pass vacuously."""
+        import torch.nn as nn
+
+        from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
+            FULL_ATTENTION,
+        )
+
+        class _Spec:
+            def __init__(self, group_id: str) -> None:
+                self.group_id = group_id
+
+        class _Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.attn = PagedAttention(
+                    8, 576, 1.0, num_kv_heads=1, layer_id=0, v_head_dim=512
+                )
+
+        specs = (_Spec(FULL_ATTENTION), _Spec("linear_attention"))
+        model = _Model()
+        with self.assertRaises(ValueError):
+            validate_paged_cache_group_ids(model, specs)
+        model.attn.group_id = FULL_ATTENTION
+        validate_paged_cache_group_ids(model, specs)  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`DeepseekV3AttentionMLA` left `attn_mqa`/`attn_mha` without a group_id. That went unnoticed while draft models owned a single-group pool, but once the draft shares the target's unified pool — which publishes every group a hybrid target owns — `validate_paged_cache_group_ids` rejects them, and K3 + EAGLE3 refuses to start:

  ValueError: Eagle3DeepseekV2ForCausalLM: attention layer
  'model.midlayer.self_attn.attn_mqa' (layer_id=0) has empty group_id but the
  KV pool publishes 4 paged-cache groups [...]

MLA is always full attention, so tag both modules in the base class rather than per model; K3's own subclass already did exactly this by hand, with a comment explaining why, and that copy now becomes redundant.

The added test guards the validation contract. That `DeepseekV3AttentionMLA.__init__` applies the tag is covered by serving, not by the test: constructing the module needs distributed init and real weights.

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
