### PR TITLE
fix(k3): restore DSpark cache view on unified arena

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/configs/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/mla.py
@@ -40,8 +40,9 @@ def resolve_mla_kv_cache_dtype(
 
     The public K3 DSpark checkpoint has no FP8 KV scales and its reference vLLM
     launch uses the default BF16 cache. TokenSpeed's K3 target currently requires
-    FP8 LCM storage, but the draft owns a separate pool, so keep only that pool
-    in BF16. Other MLA drafts continue to honor the global cache setting.
+    FP8 LCM storage, so the unified arena exposes a separate BF16 compute view
+    for the draft continuation fields. Other MLA drafts continue to honor the
+    global cache setting.
     """
     hf_config = getattr(model_config, "hf_config", None)
     if (

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/factory.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/factory.py
@@ -26,9 +26,12 @@ def create_cache_pool(
     publishes the runtime contract (ModelExecutor fails fast without one).
     """
     if (backing_pool is not None or field_layer_offset) and not (
-        isinstance(config, MHAConfig) and spec.family == "mha"
+        (isinstance(config, MHAConfig) and spec.family == "mha")
+        or (type(config) is MLAConfig and spec.family == "mla")
     ):
-        raise ValueError("backing cache views are only supported by ordinary MHA pools")
+        raise ValueError(
+            "backing cache views are only supported by ordinary MHA or MLA pools"
+        )
     plan = spec.memory_plan
     if spec.family == "deepseek_v4":
         from tokenspeed.runtime.layers.attention.kv_cache.hybrid_deepseek_v4 import (
@@ -201,6 +204,8 @@ def create_cache_pool(
                 paged_cache_group_specs=spec.paged_cache_group_specs,
                 token_capacity=spec.token_capacity,
                 layer_group_ids=spec.layer_group_ids,
+                field_layer_offset=field_layer_offset,
+                backing_pool=backing_pool,
             )
 
         if spec.family != "kimi_k3":

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/mla.py
@@ -67,6 +67,8 @@ class MLATokenToKVPool(CachePool):
         paged_cache_group_specs: tuple[PagedCacheGroupSpec, ...] = (),
         token_capacity: int | None = None,
         layer_group_ids: tuple[str, ...] = (),
+        field_layer_offset: int = 0,
+        backing_pool: CachePool | None = None,
     ):
         super().__init__(
             size,
@@ -77,6 +79,7 @@ class MLATokenToKVPool(CachePool):
             memory_plan,
             paged_cache_group_specs=paged_cache_group_specs,
             token_capacity=token_capacity,
+            backing_pool=backing_pool,
         )
         self.model_dtype = model_dtype
         self.quant_method = quant_method
@@ -84,6 +87,9 @@ class MLATokenToKVPool(CachePool):
         self.kv_lora_rank = kv_lora_rank
         self.qk_rope_head_dim = qk_rope_head_dim
         self.layer_num = layer_num
+        self._field_layer_offset = int(field_layer_offset)
+        if self._field_layer_offset < 0:
+            raise ValueError("field_layer_offset must be non-negative")
         self.kv_cache_dim = kv_lora_rank + qk_rope_head_dim
         # Physical group id per layer, from the cache recipe
         # (CachePoolSpec.layer_group_ids) — the single source the scheduler
@@ -102,6 +108,10 @@ class MLATokenToKVPool(CachePool):
 
         self._create_buffers()
 
+    def _field_layer_id(self, layer_id: int) -> int:
+        """Map this compute view's local layer id into the merged plan."""
+        return self._field_layer_offset + layer_id
+
     def _create_buffers(self) -> None:
         with self.memory_saver_adapter.region(tag="kv_cache", enable_cpu_backup=False):
             # The padded page 0 is used for writing dummy outputs from padded tokens.
@@ -109,22 +119,26 @@ class MLATokenToKVPool(CachePool):
                 self.kv_buffer = [
                     (
                         self.field(
-                            f"layer.{layer_id}.latent_kv", self.store_dtype
+                            f"layer.{self._field_layer_id(layer_id)}.latent_kv",
+                            self.store_dtype,
                         ).view(-1, 1, self.kv_lora_rank),
                         self.field(
-                            f"layer.{layer_id}.latent_scale", torch.float32
+                            f"layer.{self._field_layer_id(layer_id)}.latent_scale",
+                            torch.float32,
                         ).view(-1, 1, 1),
-                        self.field(f"layer.{layer_id}.rope_k", self.model_dtype).view(
-                            -1, 1, self.qk_rope_head_dim
-                        ),
+                        self.field(
+                            f"layer.{self._field_layer_id(layer_id)}.rope_k",
+                            self.model_dtype,
+                        ).view(-1, 1, self.qk_rope_head_dim),
                     )
                     for layer_id in range(self.layer_num)
                 ]
             else:
                 self.kv_buffer = [
-                    self.field(f"layer.{layer_id}.latent_kv", self.store_dtype).view(
-                        -1, 1, self.kv_cache_dim
-                    )
+                    self.field(
+                        f"layer.{self._field_layer_id(layer_id)}.latent_kv",
+                        self.store_dtype,
+                    ).view(-1, 1, self.kv_cache_dim)
                     for layer_id in range(self.layer_num)
                 ]
 

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -82,11 +82,20 @@ def _resolve_heterogeneous_draft_family(
     pd_disaggregation_enabled: bool,
 ) -> CacheModelFamily | None:
     """Validate and return the supported heterogeneous draft family."""
-    if (
-        target_family not in _ORDINARY_CACHE_FAMILIES
-        or draft_family is None
-        or draft_family == target_family
-    ):
+    if draft_family is None:
+        return None
+    if target_family == "kimi_k3":
+        if draft_family != "mla":
+            raise RuntimeError(
+                "Kimi-K3 unified cache currently requires an ordinary MLA draft view"
+            )
+        if pd_disaggregation_enabled:
+            raise RuntimeError(
+                "PD disaggregation does not support heterogeneous target/draft "
+                "cache families"
+            )
+        return draft_family
+    if target_family not in _ORDINARY_CACHE_FAMILIES or draft_family == target_family:
         return None
     if draft_family != "mha":
         raise RuntimeError(

--- a/test/runtime/test_cache_setup.py
+++ b/test/runtime/test_cache_setup.py
@@ -422,10 +422,10 @@ def test_ordinary_recipe_uses_the_draft_attention_family(
             paged_cache_group_specs=target_spec.paged_cache_group_specs,
             backing_pool=target_pool,
         )
-    with pytest.raises(ValueError, match="only supported by ordinary MHA pools"):
+    with pytest.raises(ValueError, match="only supported by ordinary MHA or MLA pools"):
         create_cache_pool(
             target_spec,
-            target_config(),
+            _msa_config(),
             num_layers=2,
             rank=0,
             enable_memory_saver=False,
@@ -489,9 +489,19 @@ def test_heterogeneous_draft_guards_fail_fast() -> None:
         )
         == "mha"
     )
+    assert (
+        _resolve_heterogeneous_draft_family(
+            "kimi_k3", "mla", pd_disaggregation_enabled=False
+        )
+        == "mla"
+    )
     with pytest.raises(RuntimeError, match="require an MHA draft"):
         _resolve_heterogeneous_draft_family(
             "mha", "mla", pd_disaggregation_enabled=False
+        )
+    with pytest.raises(RuntimeError, match="PD disaggregation does not support"):
+        _resolve_heterogeneous_draft_family(
+            "kimi_k3", "mla", pd_disaggregation_enabled=True
         )
     with pytest.raises(RuntimeError, match="PD disaggregation does not support"):
         _resolve_heterogeneous_draft_family(

--- a/test/runtime/test_kimi_k3_cache_pool.py
+++ b/test/runtime/test_kimi_k3_cache_pool.py
@@ -115,3 +115,143 @@ def test_kimi_k3_pool_binds_mla_and_kda_to_one_lcm_backing() -> None:
         == recurrent.untyped_storage().data_ptr()
         == pool.buffer.untyped_storage().data_ptr()
     )
+
+
+def test_kimi_k3_bf16_draft_uses_typed_view_over_fp8_target_arena() -> None:
+    from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
+    from tokenspeed.runtime.layers.attention.kv_cache.factory import create_cache_pool
+    from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
+    from tokenspeed.runtime.layers.attention.kv_cache.recipes.ordinary import (
+        mla_cache_fields,
+    )
+    from tokenspeed.runtime.layers.attention.kv_cache.recipes.setup import CachePoolSpec
+
+    text_config = KimiLinearConfig()
+    target_group_ids = kimi_k3_layer_group_ids(text_config)
+    target_layer_types = tuple(
+        FULL_ATTENTION if group_id == FULL_ATTENTION else LINEAR_ATTENTION
+        for group_id in target_group_ids
+    )
+    num_draft_layers = 5
+    draft_layer_types = (FULL_ATTENTION,) * num_draft_layers
+    draft_fields = mla_cache_fields(
+        layer_group_ids=draft_layer_types,
+        logical_block_tokens=128,
+        latent_width=576,
+        element_size=torch.bfloat16.itemsize,
+    )
+    plan = solve_kimi_k3_cache_layout(
+        text_config,
+        tp_size=8,
+        mla_cache_dtype=torch.float8_e4m3fn,
+        mla_quant_method=None,
+        draft_fields=draft_fields,
+    ).with_num_lcm_blocks(1)
+    merged_layer_types = target_layer_types + draft_layer_types
+    merged_group_ids = target_group_ids + draft_layer_types
+    state_dtypes = {
+        f"layer.{layer_id}.conv_state": torch.bfloat16
+        for layer_id, layer_type in enumerate(target_layer_types)
+        if layer_type == LINEAR_ATTENTION
+    } | {
+        f"layer.{layer_id}.recurrent_state": torch.float32
+        for layer_id, layer_type in enumerate(target_layer_types)
+        if layer_type == LINEAR_ATTENTION
+    }
+    merged_spec = CachePoolSpec(
+        family="kimi_k3",
+        memory_plan=plan,
+        layer_types=merged_layer_types,
+        layer_group_ids=merged_group_ids,
+        paged_cache_group_specs=build_paged_cache_group_specs(
+            layer_types=merged_layer_types,
+            group_ids=merged_group_ids,
+            sliding_window_tokens=None,
+            page_size=plan.logical_block_tokens,
+            pd_disaggregation_enabled=False,
+        ),
+        state_field_dtypes=state_dtypes,
+        token_capacity=128,
+    )
+    target_spec = merged_spec.layer_view(
+        first_layer=0,
+        num_layers=text_config.num_hidden_layers,
+    )
+    draft_spec = merged_spec.layer_view(
+        first_layer=text_config.num_hidden_layers,
+        num_layers=num_draft_layers,
+        family="mla",
+        publish_runtime_contract=False,
+    )
+
+    common_config = dict(
+        device="cpu",
+        backend_name="mla",
+        num_attention_heads=64,
+        num_kv_heads=64,
+        attn_tp_size=8,
+        head_dim=192,
+        dtype=torch.bfloat16,
+        context_len=1024,
+        max_graph_bs=1,
+        max_bs=1,
+        page_size=plan.logical_block_tokens,
+        kv_cache_quant_method="none",
+        kv_lora_rank=512,
+        qk_nope_head_dim=128,
+        qk_rope_head_dim=64,
+        v_head_dim=128,
+        scaling=1.0,
+        kv_cache_dim=576,
+        max_scheduled_tokens=128,
+    )
+    target_config = MLAConfig(
+        kv_cache_dtype=torch.float8_e4m3fn,
+        **common_config,
+    )
+    draft_config = MLAConfig(
+        kv_cache_dtype=torch.bfloat16,
+        is_draft=True,
+        **common_config,
+    )
+    target_pool = create_cache_pool(
+        target_spec,
+        target_config,
+        num_layers=text_config.num_hidden_layers,
+        rank=0,
+        enable_memory_saver=False,
+    )
+    draft_pool = create_cache_pool(
+        draft_spec,
+        draft_config,
+        num_layers=num_draft_layers,
+        rank=0,
+        enable_memory_saver=False,
+        field_layer_offset=text_config.num_hidden_layers,
+        backing_pool=target_pool,
+    )
+
+    assert isinstance(target_pool, HybridKDATokenToKVPool)
+    assert type(draft_pool) is MLATokenToKVPool
+    assert draft_pool.buffer is target_pool.buffer
+    assert draft_pool._fields is target_pool._fields
+    assert draft_pool.runtime_contract is target_pool.runtime_contract
+    target_cache = target_pool.get_key_buffer(text_config.full_attention_layer_ids[0])
+    assert target_cache.dtype == torch.float8_e4m3fn
+    assert draft_pool.get_key_buffer(0).dtype == torch.bfloat16
+    assert (
+        draft_pool.kv_buffer[0].data_ptr()
+        == target_pool.field("layer.93.latent_kv", torch.bfloat16).data_ptr()
+    )
+    assert set(target_pool._fields) == {
+        field.field_id for field in merged_spec.memory_plan.fields
+    }
+
+    target_layer = text_config.full_attention_layer_ids[0]
+    target_before = target_pool.kv_buffer[target_layer].clone()
+    draft_pool.kv_buffer[0][1].fill_(1)
+    assert torch.equal(target_pool.kv_buffer[target_layer], target_before)
+    draft_pool.clear_kv_buffers()
+    assert torch.count_nonzero(draft_pool.kv_buffer[0])
+    target_pool.clear_kv_buffers()
+    assert not torch.count_nonzero(draft_pool.kv_buffer[0])

--- a/test/runtime/test_kimi_k3_cache_spec.py
+++ b/test/runtime/test_kimi_k3_cache_spec.py
@@ -129,7 +129,7 @@ def test_k3_merged_solve_with_draft_shares_page_ids():
         layer_group_ids=("full_attention",),
         logical_block_tokens=128,
         latent_width=576,
-        element_size=1,
+        element_size=torch.bfloat16.itemsize,
     )
     merged = solve_kimi_k3_cache_layout(
         KimiLinearConfig(),
@@ -145,7 +145,9 @@ def test_k3_merged_solve_with_draft_shares_page_ids():
     draft_field = plan.field("layer.93.latent_kv")
     target_field = plan.field("layer.3.latent_kv")
     assert draft_field.group_id == target_field.group_id == "full_attention"
-    assert draft_field.page_stride_bytes == target_field.page_stride_bytes
+    assert draft_field.element_size == 2
+    assert target_field.element_size == 1
+    assert draft_field.page_stride_bytes == 2 * target_field.page_stride_bytes
     # One group -> one page-id space: same page_count by identity.
     assert plan.group("full_attention").page_count == 1 + 7 * 12
 


### PR DESCRIPTION
## Summary
- restore Kimi-K3 + DSpark startup after the unified draft-cache change
- keep one scheduler-owned arena while binding the FP8 target and BF16 MLA draft through separate typed compute views
- cover global continuation mapping, target isolation, shared ownership, and sleep/wake clearing with regression tests

## Root cause

Kimi-K3 stores target MLA KV in FP8, while `Inferact/Kimi-K3-DSpark` requires BF16 KV. After #974, `HybridKDATokenToKVPool` tried to bind all 93 target layers plus five draft continuation layers using the target pool's FP8 dtype. Startup therefore failed on `layer.93.latent_kv` with `dtype itemsize does not match plan`. Treating that field as BF16 inside the target pool is also insufficient because the homogeneous MLA accessors reinterpret it with target FP8 semantics.

This change slices the merged spec into target and draft compute views. The draft view maps local layers 0-4 to merged fields 93-97 and inherits the target's arena and runtime contract without allocating a second buffer.

## Validation

- `180 passed, 36 subtests passed` across cache planning, target/draft wiring, DSpark, and K3 model tests
- Black 26.3.1 and isort 8.0.1 checks pass on all changed files
- 8x MI355X, latest main `0f8a300c`, `Inferact/Kimi-K3-DSpark@cf6b8244`, official AIME26 YAML at `gpu-memory-utilization=0.92`:
  - DSpark: 28/30 (93.33%), eval wall 954.07 s, TTFT 1814.66 ms, TPOT 29.04 ms, 35.62 output tok/s/request, mean output 6437.7 tokens, sampled accept rate 0.26063
  - no-spec control: 21/30 (70.00%), eval wall 469.65 s, TTFT 1785.19 ms, TPOT 63.61 ms, 15.85 output tok/s/request, mean output 3130.2 tokens
  - DSpark improves TPOT by 2.19x and per-request output rate by 2.25x. Aggregate output throughput is effectively flat (~202 vs ~200 tok/s) because this run generated 2.06x more tokens and had a longer tail.

Accuracy caveat: the current AMD AIME YAML selects `--sampling-backend greedy`, which ignores the request's `temperature=1.0` and always uses argmax. The one-pass score difference is therefore a batch/kernel-numerics observation, not evidence that speculation improves model quality; repeated sampling parity should use a stochastic backend.

## Test plan
- [x] focused K3 cache-view tests
- [x] broader cache and DSpark regression suite
- [x] full AIME26 DSpark run on 8x MI355X
- [x] paired no-spec AIME26 control