### PR TITLE
perf(gfx950): stop using FP32 atomics for the SiTU MoE stage-2 combine

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/situ_grouped.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/situ_grouped.py
@@ -52,11 +52,6 @@ GROUPED_FUSED_ALIGN_MAX_ROUTES = 128
 # not skip the instruction.  A 16-token batch therefore issues 25.7M atomics to
 # perform 0.92M useful ones.
 #
-# Measured on the K3 shape (3584x512, 112 experts, top-k 16), atomics are
-# slower than the scratch buffer from 2 tokens up: 1.2x at 2 tokens, 2.2x at
-# 4, and 2.6-3.0x from 8 through 128.  They only come out ahead at 1 token,
-# and a different kernel handles that batch anyway.  Hence 0.
-#
 # The constant stays instead of deleting the atomic path outright, so the
 # comparison is easy to redo if the padding ever stops dominating.
 GROUPED_ATOMIC_COMBINE_MAX_TOKENS = 0

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/situ_grouped.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/situ_grouped.py
@@ -44,6 +44,22 @@ MXFP4_GROUP_SIZE = 32
 _MXFP4_GROUP_SIZE_GL = gl.constexpr(32)
 GROUPED_BLOCK_M = 64
 GROUPED_FUSED_ALIGN_MAX_ROUTES = 128
+# Atomic combine's cost hardly depends on the batch size at all.  The list of
+# (token, expert) pairs is padded out to a full GROUPED_BLOCK_M-row block per
+# expert, so with 112 experts it is ~7168 rows even for a single token.
+# Every one of those rows issues its atomics, whether or not it holds real work
+# given padding is masked off by pointing the address out of bounds, which does
+# not skip the instruction.  A 16-token batch therefore issues 25.7M atomics to
+# perform 0.92M useful ones.
+#
+# Measured on the K3 shape (3584x512, 112 experts, top-k 16), atomics are
+# slower than the scratch buffer from 2 tokens up: 1.2x at 2 tokens, 2.2x at
+# 4, and 2.6-3.0x from 8 through 128.  They only come out ahead at 1 token,
+# and a different kernel handles that batch anyway.  Hence 0.
+#
+# The constant stays instead of deleting the atomic path outright, so the
+# comparison is easy to redo if the padding ever stops dominating.
+GROUPED_ATOMIC_COMBINE_MAX_TOKENS = 0
 
 
 @gluon.jit
@@ -808,11 +824,7 @@ def gluon_a16w4_situ_grouped_ep_gfx950(
         num_warps=s1_warps,
     )
 
-    # Atomic combine wins in decode, where only a handful of local routes
-    # contend.  Prefill retains deterministic BF16 partials + one FP32 masked
-    # reduction; measurements show atomics lose once thousands of tokens hit
-    # the same output surface.
-    fuse_combine = num_tokens <= 16
+    fuse_combine = num_tokens <= GROUPED_ATOMIC_COMBINE_MAX_TOKENS
     if fuse_combine:
         stage2_out = torch.zeros(
             (num_tokens, hidden_dim),

--- a/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx950.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx950.py
@@ -269,6 +269,74 @@ def test_gluon_grouped_a16w4_situ_matches_kimi_k3_shape_gfx950() -> None:
     torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
 
 
+def test_grouped_atomic_combine_matches_partial_reduction_gfx950(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The FP32 atomic stage-2 epilogue must match the default partials path.
+
+    ``GROUPED_ATOMIC_COMBINE_MAX_TOKENS`` is 0 because atomics are slower on
+    every reachable batch, so this is the only coverage the atomic branch gets.
+    Keep it: the constant exists so the crossover can be re-measured, and that
+    is only safe while the branch is known to be correct.
+    """
+    from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4 import situ_grouped
+
+    generator = torch.Generator(device="cuda").manual_seed(20260809)
+    num_tokens = 12
+    num_experts = 8
+    top_k = 4
+    latent_size = 3584
+    intermediate_size = 512
+    raw = make_mxfp4_moe_weights(num_experts, latent_size, intermediate_size, generator)
+    hidden_states = (
+        torch.randn(
+            (num_tokens, latent_size),
+            dtype=torch.bfloat16,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.1
+    )
+    topk_weights, topk_ids = make_round_robin_topk(num_tokens, num_experts, top_k)
+
+    def run() -> torch.Tensor:
+        return situ_grouped.gluon_a16w4_situ_grouped_ep_gfx950(
+            hidden_states,
+            raw["w13_weight"],
+            raw["w13_scale"],
+            raw["w2_weight"],
+            raw["w2_scale"],
+            topk_weights,
+            topk_ids,
+            situ_beta=4.0,
+            situ_linear_beta=25.0,
+            expert_start=0,
+        )
+
+    monkeypatch.setattr(
+        situ_grouped, "GROUPED_ATOMIC_COMBINE_MAX_TOKENS", 0, raising=True
+    )
+    partials = run()
+    monkeypatch.setattr(
+        situ_grouped, "GROUPED_ATOMIC_COMBINE_MAX_TOKENS", num_tokens, raising=True
+    )
+    atomic = run()
+
+    expected = a16w4_mxfp4_moe_reference(
+        hidden_states,
+        raw["w13_weight"],
+        raw["w13_scale"],
+        raw["w2_weight"],
+        raw["w2_scale"],
+        topk_ids,
+        topk_weights,
+        situ_beta=4.0,
+        situ_linear_beta=25.0,
+    )
+    torch.testing.assert_close(partials, expected, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(atomic, expected, atol=2e-2, rtol=2e-2)
+
+
 def _make_local_ep_module(
     raw: dict[str, torch.Tensor],
     *,

--- a/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx950.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx950.py
@@ -158,7 +158,7 @@ def test_ep_decode_matches_kimi_k3_shape_gfx950(
 
     assert actual.shape == (num_tokens, latent_size)
     assert actual.dtype == torch.bfloat16
-    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(actual, expected, atol=2e-4, rtol=2e-2)
 
 
 @pytest.mark.parametrize("num_tokens", [1, 2, 4, 8, 16])
@@ -266,7 +266,7 @@ def test_gluon_grouped_a16w4_situ_matches_kimi_k3_shape_gfx950() -> None:
         situ_beta=4.0,
         situ_linear_beta=25.0,
     )
-    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(actual, expected, atol=2e-4, rtol=2e-2)
 
 
 def test_grouped_atomic_combine_matches_partial_reduction_gfx950(
@@ -333,8 +333,8 @@ def test_grouped_atomic_combine_matches_partial_reduction_gfx950(
         situ_beta=4.0,
         situ_linear_beta=25.0,
     )
-    torch.testing.assert_close(partials, expected, atol=2e-2, rtol=2e-2)
-    torch.testing.assert_close(atomic, expected, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(partials, expected, atol=2e-4, rtol=2e-2)
+    torch.testing.assert_close(atomic, expected, atol=2e-4, rtol=2e-2)
 
 
 def _make_local_ep_module(
@@ -453,7 +453,7 @@ def test_gluon_grouped_device_align_localizes_global_ep_routes_gfx950() -> None:
         situ_linear_beta=25.0,
     )
 
-    torch.testing.assert_close(actual, expected, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(actual, expected, atol=3e-4, rtol=3e-2)
 
 
 @pytest.mark.parametrize("top_k", [1, 4])
@@ -529,7 +529,7 @@ def test_mxfp4_situ_virtual_ep_sum_matches_global_reference_gfx950(
         situ_linear_beta=25.0,
     )
 
-    torch.testing.assert_close(actual, expected, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(actual, expected, atol=3e-4, rtol=3e-2)
 
 
 @pytest.mark.parametrize("num_tokens", [1, 2, 4, 8])
@@ -594,4 +594,4 @@ def test_mxfp4_situ_ep_paths_are_cuda_graph_capturable_gfx950(
         captured = apply()
     graph.replay()
     torch.cuda.synchronize()
-    torch.testing.assert_close(captured, eager, atol=3e-2, rtol=3e-2)
+    torch.testing.assert_close(captured, eager, atol=3e-4, rtol=3e-2)


### PR DESCRIPTION
## Summary

The gfx950 A16W4 SiTU MoE stage-2 combine selected the FP32 atomic epilogue for
`num_tokens <= 16`, on the premise that atomics win when few routes contend.
They don't — the cost tracks the *padded* route list, not the token count, and
under sparse EP the padding is nearly all of it. `GROUPED_ATOMIC_COMBINE_MAX_TOKENS`
moves to 0.

Tightend `atol` for SiTU MoE checks along the way.

## Why atomics lose

The kernel doesn't walk the list of real (token, expert) pairs. It walks a padded
version of that list: `moe_align` rounds every expert up to a whole 64-row block,
so an expert holding a single pair still costs 64 rows. With 112 experts on this
GPU that's ~7168 rows, and it stops growing past 7 tokens — from there on, adding
tokens adds real work but no rows.

That would be harmless if the padding rows were skipped, and on the scratch-buffer
path they are: the store is wrapped in a branch, so a block that's entirely padding
jumps over it. The atomic path can't do that. It hides the padding by pointing the
write at an address the hardware throws away, which means the instruction still
issues on every lane. So the number of atomic adds sent to memory is
`padded rows × output width`, no matter how much of it is real.

At 16 tokens that's 25.7 million atomic adds issued to perform 0.92 million useful
ones — about 4% useful.

## Numbers (Kimi K3 shape, 3584×512, 112 experts, 16 experts per token, MI350X)

End-to-end time, atomics ÷ scratch buffer: **0.89× at 1 token, 1.21× at 2, 2.20×
at 4, and 2.66–3.06× from 8 through 128.** So atomics are behind from 2 tokens up.
They do win at 1 token, but only because the scratch path pays for a second kernel
launch (~28 µs of it exposed), and a separate kernel handles single-token decode
anyway.

Two controlled runs show it's the padding and not the real work. Each varies one
and pins the other (kernel time; scratch = both kernels summed):

| run | real (token, expert) pairs | experts | padded rows | atomics | scratch |
|---|---:|---:|---:|---:|---:|
| **A** — same work, less padding | 256 (16 tok) | 112 | 7168 | 458 µs | 74 µs |
| | 256 (16 tok) | 16 | 1024 | 41 µs | 30 µs |
| | 256 (16 tok) | 4 | 256 | 30 µs | 27 µs |
| **B** — same padding, more work | 112 (7 tok) | 112 | 7168 | 456 µs | 73 µs |
| | 2048 (128 tok) | 112 | 7168 | 503 µs | 112 µs |

Cutting padding 7× with the work unchanged makes atomics 11× faster. Raising the
work 18× with the padding unchanged costs them 10%. The cost is essentially all
padding.

The threshold constant stays instead of deleting the atomic path, so this is easy
to re-measure if the padding ever stops dominating. A new test runs the atomic
path (now unreachable in normal use) against the scratch path and checks they
agree.