### PR TITLE
fix(grammar): build the grammar backend under skip_tokenizer_init

### DIFF
--- a/python/tokenspeed/runtime/grammar/grammar_manager.py
+++ b/python/tokenspeed/runtime/grammar/grammar_manager.py
@@ -65,17 +65,16 @@ class GrammarManager:
         self.compile_timeout_secs = float(server_args.grammar_compile_timeout_secs)
         self.compile_max_retries = int(server_args.grammar_compile_max_retries)
 
-        # Backend is None when (a) the user disabled grammar via
-        # --grammar-backend none or (b) tokenizer init is skipped (no tokenizer
-        # → can't build a backend). Either way, requests with grammar fields
-        # get rejected at admission time in process_req_with_grammar.
-        if server_args.skip_tokenizer_init:
-            self.grammar_backend = None
-
-        else:
-            self.grammar_backend = create_grammar_backend(
-                server_args, tokenizer, vocab_size
-            )
+        # Backend is None only when the user disabled grammar via
+        # --grammar-backend none; requests with grammar fields then get
+        # rejected at admission time in process_req_with_grammar. Note
+        # skip_tokenizer_init does NOT disable grammar: it only moves prompt
+        # tokenization to the frontend (e.g. the SMG headless ZMQ drive), and
+        # RequestHandler loads the scheduler-side tokenizer unconditionally,
+        # so the vocab the backend needs is always available here.
+        self.grammar_backend = create_grammar_backend(
+            server_args, tokenizer, vocab_size
+        )
 
         # Grammar admission must be coherent across attention TP ranks: every rank
         # in the group sees the same recv_reqs (broadcast in RequestHandler.recv_reqs),

--- a/test/runtime/test_grammar_manager_headless.py
+++ b/test/runtime/test_grammar_manager_headless.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Regression tests for GrammarManager construction under skip_tokenizer_init.
+
+The headless msgpack launch (``ts serve --headless``, driven by SMG over ZMQ)
+forces ``skip_tokenizer_init=True`` because the frontend passes token ids.
+GrammarManager used to treat that flag as "no tokenizer → no grammar backend"
+and silently discarded ``--grammar-backend xgrammar``, aborting every
+constrained request (json_schema / regex / ebnf / structural_tag) at admission
+with zero tokens. The premise was false: RequestHandler loads the
+scheduler-side tokenizer unconditionally and passes it in, so the backend can
+always be built. These tests pin that contract:
+
+1. ``skip_tokenizer_init=True`` does NOT suppress the grammar backend; the
+   configured backend is built with the tokenizer GrammarManager receives.
+2. ``--grammar-backend none`` remains the one way to get no backend, so the
+   admission-time abort message naming it stays truthful.
+
+Pure CPU; no model, tokenizer, or GPU required.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+# CI registration (AST-parsed, runtime no-op).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=10, suite="runtime-1gpu")
+
+from tokenspeed.runtime.grammar import (  # noqa: E402
+    grammar_manager as grammar_manager_mod,
+)
+from tokenspeed.runtime.grammar.base_grammar_backend import (  # noqa: E402
+    create_grammar_backend,
+)
+from tokenspeed.runtime.grammar.grammar_manager import GrammarManager  # noqa: E402
+
+
+def _server_args(**overrides) -> SimpleNamespace:
+    """The minimal attribute surface GrammarManager.__init__ reads."""
+    args = SimpleNamespace(
+        grammar_backend="xgrammar",
+        grammar_compile_timeout_secs=1.0,
+        grammar_compile_max_retries=1,
+        skip_tokenizer_init=False,
+        disable_any_whitespace=False,
+        # Single-rank attn TP group: the gloo sync-group branch short-circuits.
+        mapping=SimpleNamespace(attn=SimpleNamespace(tp_group=[0])),
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+class TestGrammarManagerHeadless(unittest.TestCase):
+    def test_skip_tokenizer_init_does_not_suppress_backend(self):
+        """The headless flag must not discard a configured grammar backend."""
+        args = _server_args(skip_tokenizer_init=True)
+        tokenizer = object()
+        backend = object()
+
+        with mock.patch.object(
+            grammar_manager_mod, "create_grammar_backend", return_value=backend
+        ) as factory:
+            manager = GrammarManager(args, tokenizer, vocab_size=32)
+
+        factory.assert_called_once_with(args, tokenizer, 32)
+        self.assertIs(manager.grammar_backend, backend)
+
+    def test_backend_none_only_from_explicit_none(self):
+        """--grammar-backend none is the sole path to a missing backend."""
+        args = _server_args(grammar_backend="none", skip_tokenizer_init=True)
+        self.assertIsNone(create_grammar_backend(args, tokenizer=None, vocab_size=32))
+
+        manager = GrammarManager(args, tokenizer=None, vocab_size=32)
+        self.assertIsNone(manager.grammar_backend)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The headless msgpack launch (`ts serve --headless`, driven by SMG over ZMQ) forces `skip_tokenizer_init=True` because the frontend passes token ids (`entrypoints/engine.py`). `GrammarManager.__init__` treats that flag as "no tokenizer → no grammar backend":

```python
if server_args.skip_tokenizer_init:
    self.grammar_backend = None
```

so `--grammar-backend xgrammar` is silently discarded, and every constrained request (`json_schema` / `regex` / `ebnf` / `structural_tag`) is aborted at admission with zero generated tokens. Downstream this surfaces as **empty completions with a 200**, not errors — SMG's ZMQ e2e lane fails 44 constraint tests this way, with nothing in any log (the abort message is also slimmed off the msgpack wire by `BatchTokenIDOutSlim`).

## Why the gate is wrong

Its premise — no tokenizer available — is false in this codebase: `RequestHandler` loads the scheduler-side tokenizer **unconditionally** and passes it into `GrammarManager`. `skip_tokenizer_init` is the only engine-side consumer of the flag besides this gate; it only moves prompt tokenization to the frontend and says nothing about grammar.

This also matches vLLM's architecture: prompt tokenization is always frontend-side there, yet `StructuredOutputManager` keeps an engine-side tokenizer purely for grammar (`vllm/v1/structured_output/__init__.py`).

## Fix

Drop the gate; `create_grammar_backend` alone decides. A `None` backend now happens only for `--grammar-backend none`, which makes the admission-time abort message ("launched with --grammar-backend none") truthful.

## Testing

New `test/runtime/test_grammar_manager_headless.py` (pure CPU, registered in `runtime-1gpu`):
- `skip_tokenizer_init=True` must not suppress a configured backend — **fails on the old code, passes now**
- `--grammar-backend none` remains the sole path to a missing backend

## Follow-ups (separate PRs)

- Append an abort-message column to `BatchTokenIDOutSlim` (wire is append-only) so a frontend that drives the scheduler directly can surface abort reasons instead of empty output.
- Consider rejecting constraints loudly in the gRPC servicer path too when the backend is `none` — today they are silently ignored and answered as freeform text.