### PR TITLE
Pin cuDNN frontend for FlashInfer tactic caches

### DIFF
--- a/tokenspeed-kernel/python/requirements/cuda.txt
+++ b/tokenspeed-kernel/python/requirements/cuda.txt
@@ -13,5 +13,7 @@ tokenspeed-triton>=3.8.10.post20260721
 nvidia-cutlass-dsl[cu13]==4.6.0
 nvidia-cutlass-dsl-libs-cu13==4.6.0
 flashinfer-python==0.6.16
+# FlashInfer tactic-cache metadata includes the frontend version; keep it stable.
+nvidia-cudnn-frontend==1.26.0
 nvidia-ml-py==13.580.82
 nvtx

--- a/tokenspeed-kernel/test/test_setup.py
+++ b/tokenspeed-kernel/test/test_setup.py
@@ -61,6 +61,7 @@ def test_cuda_install_requires_include_runtime_dependencies(monkeypatch) -> None
         "tokenspeed-proton",
         "tokenspeed-triton",
         "flashinfer-python",
+        "nvidia-cudnn-frontend",
         "nvidia-ml-py",
         "nvtx",
         "torch",
@@ -69,6 +70,7 @@ def test_cuda_install_requires_include_runtime_dependencies(monkeypatch) -> None
     assert {"tokenspeed-kernel-amd", "tokenspeed-iris"}.isdisjoint(requirements)
     assert "tokenspeed-triton-kernels" not in requirements
     assert requirements["nvidia-cutlass-dsl"].extras == {"cu13"}
+    assert str(requirements["nvidia-cudnn-frontend"].specifier) == "==1.26.0"
 
 
 def test_cuda_thirdparty_requirements_are_exactly_pinned() -> None:


### PR DESCRIPTION
Pin `nvidia-cudnn-frontend` to 1.26.0 to keep FlashInfer autotune metadata stable and prevent packaged tactic configs from being rejected after dependency resolution upgrades.

Also adds a dependency test to guard the exact version pin.

Test: `pre-commit run --all-files`