### PR TITLE
fix(kernel): restore gpt-oss MXFP4 MoE on H100 via Marlin expert bias

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/marlin/mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/marlin/mxfp4.py
@@ -22,10 +22,11 @@
 
 Weight-only 4-bit experts: MXFP4 (E2M1 packed, E8M0 group-32 scales) weights
 are dequantized inside the Marlin grouped GEMM; activations stay bf16, so no
-FP4 tensor cores are required. This is the Hopper path for Kimi-K3, whose
-routed experts use the SiTU gated activation (applied as a fused Triton
-epilogue between the two GEMMs). Routing is precomputed upstream (the K3 gate
-the fused kernels cannot reproduce).
+FP4 tensor cores are required. This is the Hopper path for Kimi-K3 (SiTU
+gated activation, no bias) and gpt-oss (clamped SwiGLU, per-expert bias on
+both projections); the activation runs as a fused Triton epilogue between
+the two GEMMs, and bias is added by the GEMM write-out itself. Routing is
+precomputed upstream.
 
 The kernel and its weight repack use the vendored Marlin MoE; the grouped GEMM
 lives in ``thirdparty/cuda/csrc/marlin_moe`` and is pre-compiled.
@@ -41,6 +42,7 @@ from tokenspeed_kernel.signature import format_signatures
 from tokenspeed_kernel.thirdparty.cuda.marlin import gptq_marlin_repack
 from tokenspeed_kernel.thirdparty.cuda.marlin_moe import (
     marlin_make_workspace,
+    marlin_permute_bias,
     marlin_permute_scales,
     moe_align_block_size,
     moe_wna16_marlin_gemm,
@@ -135,6 +137,17 @@ def marlin_mxfp4_moe_weights(plan: dict, w: torch.nn.Module) -> None:
     w.w2_weight = torch.nn.Parameter(w2_marlin, requires_grad=False)
     w.w13_weight_scale = torch.nn.Parameter(w13_scale_marlin, requires_grad=False)
     w.w2_weight_scale = torch.nn.Parameter(w2_scale_marlin, requires_grad=False)
+
+    # Per-expert output biases (gpt-oss): the kernel adds them at write-out in
+    # the same fragment layout as per-channel scales, in activation dtype.
+    for name in ("w13_weight_bias", "w2_weight_bias"):
+        bias = getattr(w, name, None)
+        if bias is None:
+            continue
+        permuted = torch.stack(
+            [marlin_permute_bias(b) for b in bias.data.to(torch.bfloat16)]
+        )
+        setattr(w, name, torch.nn.Parameter(permuted, requires_grad=False))
     w._marlin_hidden_size = hidden
     w._marlin_ispp = ispp
     w._marlin_repacked = True
@@ -160,7 +173,7 @@ def marlin_mxfp4_moe_weights(plan: dict, w: torch.nn.Module) -> None:
         "supports_all_to_all_ep": frozenset({False}),
         "ispp_alignment": frozenset({MXFP4_BLOCK}),
         "internal_activation_dtype": frozenset({"input"}),
-        "supports_bias": frozenset({False}),
+        "supports_bias": frozenset({False, True}),
     },
     priority=Priority.PORTABLE,
 )
@@ -258,15 +271,24 @@ def marlin_mxfp4_precomputed_moe_apply(
         size_m=num_tokens,
         size_n=gemm1_n,
         size_k=hidden,
+        b_bias=getattr(w, "w13_weight_bias", None),
     ).view(-1, gemm1_n)
 
     beta = float(getattr(w, "activation_situ_beta", 1.0))
     linear_beta = getattr(w, "activation_situ_linear_beta", None)
+    swiglu_arg = getattr(w, "swiglu_arg", None)
     if activation == "situ":
         intermediate2 = situ_and_mul(
             intermediate1,
             beta=beta,
             linear_beta=None if linear_beta is None else float(linear_beta),
+        )
+    elif swiglu_arg is not None:
+        # gpt-oss clamped SwiGLU: gate·sigmoid(alpha·gate)·(up + 1).
+        from tokenspeed_kernel.ops.activation.triton import swiglu_oai
+
+        intermediate2 = swiglu_oai(
+            intermediate1, alpha=swiglu_arg.alpha, limit=swiglu_arg.limit
         )
     else:
         from tokenspeed_kernel.ops.activation.triton import silu_and_mul
@@ -274,7 +296,9 @@ def marlin_mxfp4_precomputed_moe_apply(
         intermediate2 = silu_and_mul(intermediate1)
 
     # GEMM2: fold the route weights in (mul_topk_weights) so finalize is a
-    # plain sum over top_k. EP-masked routes wrote nothing, so zero-init c.
+    # plain sum over top_k. Bias is added before that scaling, so each route
+    # contributes topk_weight * (x @ W2 + b2) and normalized route weights sum
+    # the bias in exactly once. EP-masked routes wrote nothing, so zero-init c.
     intermediate3 = moe_wna16_marlin_gemm(
         intermediate2,
         torch.zeros(num_tokens * top_k, hidden, dtype=x.dtype, device=x.device),
@@ -292,6 +316,7 @@ def marlin_mxfp4_precomputed_moe_apply(
         size_m=num_tokens * top_k,
         size_n=hidden,
         size_k=ispp,
+        b_bias=getattr(w, "w2_weight_bias", None),
     ).view(num_tokens, top_k, hidden)
 
     return intermediate3.sum(dim=1)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/marlin_moe_binding.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/marlin_moe/marlin_moe_binding.cu
@@ -19,7 +19,8 @@
 // SOFTWARE.
 
 // Marlin WNA16 MoE GEMM (vendored), pre-compiled with the specializations
-// tokenspeed needs: bf16 activations, no expert bias.
+// tokenspeed needs: bf16 activations, with and without per-expert bias
+// (gpt-oss carries bias on both expert projections; Kimi-K3 carries none).
 // MXFP4 (E8M0 group-32 scales) is only numerically valid on the bf16
 // activation path, so no fp16 instantiation is exported.
 
@@ -35,6 +36,14 @@ TVM_FFI_DLL_EXPORT_TYPED_FUNC(
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(
     moe_wna16_marlin_gemm_bf16_ep,
     (moe_wna16_marlin_gemm<bf16_t, true, false>));
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    moe_wna16_marlin_gemm_bf16_bias,
+    (moe_wna16_marlin_gemm<bf16_t, false, true>));
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    moe_wna16_marlin_gemm_bf16_ep_bias,
+    (moe_wna16_marlin_gemm<bf16_t, true, true>));
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(
     moe_align_block_size,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/marlin_moe.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/marlin_moe.py
@@ -118,6 +118,18 @@ def marlin_permute_scales(
     return s.reshape((-1, size_n)).contiguous()
 
 
+def marlin_permute_bias(b: torch.Tensor) -> torch.Tensor:
+    """Permute a per-expert bias row ``[size_n]`` into Marlin write-out order.
+
+    The kernel adds bias in the same fragment layout it reads per-channel
+    scales from, so bias uses the single (per-channel) scale permutation.
+    """
+    _, scale_perm_single = _get_scale_perms()
+    origin_shape = b.shape
+    b = b.reshape((-1, len(scale_perm_single)))[:, scale_perm_single]
+    return b.reshape(origin_shape).contiguous()
+
+
 def mxfp4_marlin_process_scales(marlin_scales: torch.Tensor) -> torch.Tensor:
     """Reorder + retype permuted MXFP4 scales for the bf16 Marlin path.
 
@@ -194,6 +206,7 @@ def moe_wna16_marlin_gemm(
     size_n: int,
     size_k: int,
     use_fp32_reduce: bool = True,
+    b_bias: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Run one grouped Marlin W4A16 GEMM over routed expert tokens.
 
@@ -220,6 +233,11 @@ def moe_wna16_marlin_gemm(
         is_ep: Expert-parallel mode; out-of-range expert ids are skipped.
         size_m/size_n/size_k: GEMM problem shape.
         use_fp32_reduce: Reduce partial tiles in fp32 scratch (recommended).
+        b_bias: Optional per-expert output bias ``[E, size_n]`` in the dtype
+            of ``a``, pre-permuted with :func:`marlin_permute_bias`. Added at
+            write-out before any route-weight scaling, so with
+            ``mul_topk_weights`` each route contributes
+            ``topk_weight * (x @ W + bias)``.
 
     Returns:
         ``c`` with dtype of ``a``.
@@ -250,17 +268,21 @@ def moe_wna16_marlin_gemm(
     empty_a = _empty(device, a.dtype)
     empty_i32 = _empty(device, torch.int32)
 
+    # One export per (ep, bias) specialization; shape/layout checks live in
+    # the kernel's RuntimeChecks, not here.
+    has_bias = b_bias is not None
     module = _load_marlin_moe_module()
-    fn = (
-        module.moe_wna16_marlin_gemm_bf16_ep
-        if is_ep
-        else module.moe_wna16_marlin_gemm_bf16
+    fn = getattr(
+        module,
+        "moe_wna16_marlin_gemm_bf16"
+        + ("_ep" if is_ep else "")
+        + ("_bias" if has_bias else ""),
     )
     fn(
         a,
         c,
         b_q_weight,
-        empty_a,  # b_bias
+        b_bias if has_bias else empty_a,
         b_scales,
         empty_a,  # global_scale
         empty_a,  # b_zeros
@@ -282,7 +304,7 @@ def moe_wna16_marlin_gemm(
         size_n,
         size_k,
         False,  # has_act_order
-        False,  # has_bias
+        has_bias,
         True,  # is_k_full
         False,  # has_zp
         num_groups,

--- a/tokenspeed-kernel/test/ops/moe/test_marlin_mxfp4_apply.py
+++ b/tokenspeed-kernel/test/ops/moe/test_marlin_mxfp4_apply.py
@@ -27,9 +27,11 @@ runs the two linear layers with the SiTU epilogue. Runs on SM90+.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 import torch
-from kimi3_reference import a16w4_mxfp4_moe_reference
+from kimi3_reference import a16w4_mxfp4_moe_reference, dequantize_mxfp4
 from tokenspeed_kernel.ops.moe.marlin.mxfp4 import (
     marlin_mxfp4_moe_weights,
     marlin_mxfp4_precomputed_moe_apply,
@@ -112,6 +114,101 @@ def test_marlin_mxfp4_situ_matches_reference(num_tokens: int) -> None:
         linear_beta=linear_beta,
     )
     plan = {"activation": "situ"}
+    marlin_mxfp4_moe_weights(plan, w)
+    actual = marlin_mxfp4_precomputed_moe_apply(
+        plan, x, w, None, topk_weights=topk_weights, topk_ids=topk_ids
+    )
+
+    torch.testing.assert_close(actual.float(), expected.float(), atol=5e-2, rtol=5e-2)
+
+
+def _swiglu_oai_biased_moe_reference(
+    hidden_states: torch.Tensor,
+    raw: dict[str, torch.Tensor],
+    w13_bias: torch.Tensor,
+    w2_bias: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    *,
+    alpha: float,
+    limit: float,
+) -> torch.Tensor:
+    """gpt-oss-shaped reference: biased projections around clamped SwiGLU."""
+    combined = torch.zeros_like(hidden_states, dtype=torch.float32)
+    for expert_id in range(raw["w13_weight"].shape[0]):
+        routes = (topk_ids == expert_id).nonzero(as_tuple=False)
+        if not routes.numel():
+            continue
+        token_ids, slot_ids = routes.unbind(dim=1)
+        x = hidden_states.index_select(0, token_ids).float()
+        w13 = dequantize_mxfp4(
+            raw["w13_weight"][expert_id], raw["w13_scale"][expert_id]
+        )
+        w2 = dequantize_mxfp4(raw["w2_weight"][expert_id], raw["w2_scale"][expert_id])
+        gate_up = x @ w13.T + w13_bias[expert_id].float()
+        gate, up = gate_up.chunk(2, dim=-1)
+        gate = gate.clamp(max=limit)
+        up = up.clamp(-limit, limit)
+        act = gate * torch.sigmoid(alpha * gate) * (up + 1)
+        out = act @ w2.T + w2_bias[expert_id].float()
+        route_weights = topk_weights[token_ids, slot_ids].float().unsqueeze(-1)
+        combined.index_add_(0, token_ids, out * route_weights)
+    return combined.to(hidden_states.dtype)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 64])
+def test_marlin_mxfp4_bias_swiglu_matches_reference(num_tokens: int) -> None:
+    """gpt-oss shape: per-expert bias on both projections + clamped SwiGLU."""
+    _requires_sm90()
+    generator = torch.Generator(device="cuda").manual_seed(17)
+    num_experts, top_k = 8, 2
+    hidden_size, intermediate_size = 256, 128
+    alpha, limit = 1.702, 7.0
+
+    x = (
+        torch.randn(num_tokens, hidden_size, generator=generator, device="cuda") * 0.2
+    ).to(torch.bfloat16)
+    raw = make_mxfp4_moe_weights(
+        num_experts, hidden_size, intermediate_size, generator, device="cuda"
+    )
+    w13_bias = (
+        torch.randn(
+            num_experts, 2 * intermediate_size, generator=generator, device="cuda"
+        )
+        * 0.5
+    ).to(torch.bfloat16)
+    w2_bias = (
+        torch.randn(num_experts, hidden_size, generator=generator, device="cuda") * 0.5
+    ).to(torch.bfloat16)
+    topk_ids = (
+        torch.arange(num_tokens * top_k, device="cuda").reshape(num_tokens, top_k)
+        % num_experts
+    ).to(torch.int32)
+    # Bias correctness relies on normalized route weights (each route adds
+    # topk_weight * bias; they must sum to one bias) — the gpt-oss softmax form.
+    topk_weights = torch.rand(
+        num_tokens, top_k, generator=generator, device="cuda", dtype=torch.float32
+    )
+    topk_weights = topk_weights / topk_weights.sum(-1, keepdim=True)
+
+    expected = _swiglu_oai_biased_moe_reference(
+        x, raw, w13_bias, w2_bias, topk_ids, topk_weights, alpha=alpha, limit=limit
+    )
+
+    w = _Weights(
+        {k: v.clone() for k, v in raw.items()},
+        num_local_experts=num_experts,
+        ep_size=1,
+        ep_rank=0,
+        beta=1.0,
+        linear_beta=None,
+    )
+    w.activation = "swiglu"
+    w.swiglu_arg = SimpleNamespace(alpha=alpha, limit=limit)
+    w.w13_weight_bias = torch.nn.Parameter(w13_bias.clone(), requires_grad=False)
+    w.w2_weight_bias = torch.nn.Parameter(w2_bias.clone(), requires_grad=False)
+
+    plan = {"activation": "swiglu"}
     marlin_mxfp4_moe_weights(plan, w)
     actual = marlin_mxfp4_precomputed_moe_apply(
         plan, x, w, None, topk_weights=topk_weights, topk_ids=topk_ids


### PR DESCRIPTION
Fixes #1036.

## Problem

Since 96f49036 (#914) no kernel covers MXFP4 MoE **with expert bias** on sm 9.0: the triton rewrite dropped the openai `triton_kernels` dependency (and with it bias support), marlin registers `supports_bias=False`, and the flashinfer/gluon paths require arch ≥ 10 / 9.5. gpt-oss therefore dies at model load on H100 with `NoKernelFoundError` (traits: `weight_dtype=mxfp4, activation=swiglu, supports_bias=True`).

## Fix

The vendored Marlin GEMM has implemented bias all along — the `kHasBias` template parameter, write-out epilogue, shared-memory staging, and RuntimeChecks are all present. Only the export layer opted out. This PR un-gates it:

- **binding**: export the `kHasBias=true` specializations (`moe_wna16_marlin_gemm_bf16[_ep]_bias`).
- **wrapper**: optional `b_bias` threading; export selection is name composition over the systematic `[_ep][_bias]` grid. Shape/layout validation stays with the kernel's RuntimeChecks — no duplicate owner in Python.
- **marlin mxfp4 apply**: permute `w13/w2_weight_bias` with the per-channel scale permutation (the fragment layout the write-out reads bias in — same as vLLM's `marlin_permute_bias`, which drives this exact kernel family for gpt-oss on H100 in production), pass them to both GEMMs, and run gpt-oss's clamped SwiGLU (`swiglu_arg` → `swiglu_oai`) instead of falling through to plain `silu_and_mul`. `supports_bias={False, True}`.

## Why bias + `mul_topk_weights` is correct

The kernel adds bias **before** route-weight scaling (bias lands in the shared write-out staging; `topk_weight_score` multiplies on the way to global memory), so each route contributes `topk_weight * (x @ W + b)` and normalized route weights fold the down-projection bias in exactly once across the top-k sum.

## Validation

- New numerical test `test_marlin_mxfp4_bias_swiglu_matches_reference` — gpt-oss shape (per-expert bias on both projections + clamped SwiGLU, 1/8/64 tokens) vs a bf16 dequant reference.
- Existing situ (K3) and EP-masking tests unchanged and passing — no regression to the unbiased path (it still dispatches to the original no-bias exports).
- 7/7 pass on live GPU (sm103 cubin; sm90 compiled in the same build — the H100 instantiation compiles clean).

## Alternatives considered

- Re-adding `triton_kernels` for gpt-oss: reverses #914's dependency removal.
- Adding bias to the new hand-rolled triton kernel: real kernel authoring in a fresh rewrite; better owned by its author if wanted — this PR restores H100 coverage without touching it.
- Lowering gluon's arch floor to 9.0: gated at 9.5 presumably for a reason (H200 work in #995); left to the kernel owners.