### PR TITLE
ci: skip unrelated vendor GPU tests based on changed files

### DIFF
--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -65,17 +65,49 @@ jobs:
       )
     runs-on: ubuntu-latest
     outputs:
+      should_run: ${{ steps.changes.outputs.should_run }}
       unit_matrix: ${{ steps.scan.outputs.unit_matrix }}
       unit_has_tasks: ${{ steps.scan.outputs.unit_has_tasks }}
       model_matrix: ${{ steps.scan.outputs.model_matrix }}
       model_has_tasks: ${{ steps.scan.outputs.model_has_tasks }}
       eager_model: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'high priority') }}
-      install_tokenspeed_mla_from_source: ${{ steps.detect_mla.outputs.changed }}
+      install_tokenspeed_mla_from_source: ${{ steps.changes.outputs.install_tokenspeed_mla_from_source }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Classify changed paths
+        id: changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          changed_files="$RUNNER_TEMP/tokenspeed-changed-files.txt"
+          case "${{ github.event_name }}" in
+            pull_request)
+              gh api \
+                "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+                --paginate \
+                -q '.[] | .filename, (.previous_filename // empty)' \
+                > "$changed_files"
+              ;;
+            push)
+              gh api \
+                "/repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.event.after }}" \
+                -q '.files[] | .filename, (.previous_filename // empty)' \
+                > "$changed_files"
+              ;;
+            *)
+              : > "$changed_files"
+              ;;
+          esac
+          python3 test/ci_system/ci_path_filter.py \
+            --runner-group amd \
+            --event-name "${{ github.event_name }}" \
+            "$changed_files" >> "$GITHUB_OUTPUT"
+
       - name: Install scan dependency
+        if: steps.changes.outputs.should_run == 'true'
         # pypi.org occasionally returns "Content-Type: Unknown" for the simple
         # index, which strict pip>=22 refuses to parse. Retry a few times.
         run: |
@@ -88,6 +120,7 @@ jobs:
 
       - name: Build task matrix
         id: scan
+        if: steps.changes.outputs.should_run == 'true'
         env:
           TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS: ${{ vars.TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS }}
         run: |
@@ -105,44 +138,10 @@ jobs:
             printf '%s' "$matrix" | python3 -c "import json, sys; print('${output}_has_tasks=' + ('true' if json.load(sys.stdin).get('include') else 'false'))" >> "$GITHUB_OUTPUT"
           done
 
-      # Compute this once on the hosted runner (where `gh` is pre-installed)
-      # and propagate the result to every matrix job via job output. The
-      # downstream stage jobs read it as an env var and `install_deps.sh`
-      # gates its in-tree `tokenspeed-mla` reinstall on it. Without this
-      # detection, CI would always exercise the pinned PyPI wheel and edits
-      # under `tokenspeed-mla/` would be silently uncovered.
-      - name: Detect tokenspeed-mla source changes
-        id: detect_mla
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          case "${{ github.event_name }}" in
-            pull_request)
-              files=$(gh api \
-                "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-                --paginate -q '.[].filename')
-              ;;
-            push)
-              files=$(gh api \
-                "/repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.event.after }}" \
-                -q '.files[].filename')
-              ;;
-            *)
-              files=""
-              ;;
-          esac
-          if printf '%s\n' "$files" | grep -q '^tokenspeed-mla/'; then
-            echo "tokenspeed-mla touched by this run; in-tree source will be installed."
-            echo "changed=1" >> "$GITHUB_OUTPUT"
-          else
-            echo "tokenspeed-mla untouched; keeping pinned PyPI wheel."
-            echo "changed=0" >> "$GITHUB_OUTPUT"
-          fi
-
   unit-test:
     needs: scan
     if: |
+      needs.scan.outputs.should_run == 'true' &&
       needs.scan.outputs.unit_has_tasks == 'true' &&
       (github.event_name != 'pull_request' || github.event.action != 'closed') &&
       (
@@ -166,6 +165,7 @@ jobs:
     if: |
       !cancelled() &&
       needs.scan.result == 'success' &&
+      needs.scan.outputs.should_run == 'true' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       needs.scan.outputs.eager_model != 'true' &&
       (
@@ -183,6 +183,7 @@ jobs:
   model-test-eager:
     needs: scan
     if: |
+      needs.scan.outputs.should_run == 'true' &&
       needs.scan.outputs.eager_model == 'true' &&
       github.event.pull_request.draft == false &&
       needs.scan.outputs.model_has_tasks == 'true'

--- a/.github/workflows/pr-test-nvidia-arm.yml
+++ b/.github/workflows/pr-test-nvidia-arm.yml
@@ -65,17 +65,49 @@ jobs:
       )
     runs-on: ubuntu-latest
     outputs:
+      should_run: ${{ steps.changes.outputs.should_run }}
       unit_matrix: ${{ steps.scan.outputs.unit_matrix }}
       unit_has_tasks: ${{ steps.scan.outputs.unit_has_tasks }}
       model_matrix: ${{ steps.scan.outputs.model_matrix }}
       model_has_tasks: ${{ steps.scan.outputs.model_has_tasks }}
       eager_model: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'high priority') }}
-      install_tokenspeed_mla_from_source: ${{ steps.detect_mla.outputs.changed }}
+      install_tokenspeed_mla_from_source: ${{ steps.changes.outputs.install_tokenspeed_mla_from_source }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Classify changed paths
+        id: changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          changed_files="$RUNNER_TEMP/tokenspeed-changed-files.txt"
+          case "${{ github.event_name }}" in
+            pull_request)
+              gh api \
+                "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+                --paginate \
+                -q '.[] | .filename, (.previous_filename // empty)' \
+                > "$changed_files"
+              ;;
+            push)
+              gh api \
+                "/repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.event.after }}" \
+                -q '.files[] | .filename, (.previous_filename // empty)' \
+                > "$changed_files"
+              ;;
+            *)
+              : > "$changed_files"
+              ;;
+          esac
+          python3 test/ci_system/ci_path_filter.py \
+            --runner-group nvidia-arm \
+            --event-name "${{ github.event_name }}" \
+            "$changed_files" >> "$GITHUB_OUTPUT"
+
       - name: Install scan dependency
+        if: steps.changes.outputs.should_run == 'true'
         # pypi.org occasionally returns "Content-Type: Unknown" for the simple
         # index, which strict pip>=22 refuses to parse. Retry a few times.
         run: |
@@ -88,6 +120,7 @@ jobs:
 
       - name: Build task matrix
         id: scan
+        if: steps.changes.outputs.should_run == 'true'
         env:
           TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS: ${{ vars.TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS }}
         run: |
@@ -105,44 +138,10 @@ jobs:
             printf '%s' "$matrix" | python3 -c "import json, sys; print('${output}_has_tasks=' + ('true' if json.load(sys.stdin).get('include') else 'false'))" >> "$GITHUB_OUTPUT"
           done
 
-      # Compute this once on the hosted runner (where `gh` is pre-installed)
-      # and propagate the result to every matrix job via job output. The
-      # downstream stage jobs read it as an env var and `install_deps.sh`
-      # gates its in-tree `tokenspeed-mla` reinstall on it. Without this
-      # detection, CI would always exercise the pinned PyPI wheel and edits
-      # under `tokenspeed-mla/` would be silently uncovered.
-      - name: Detect tokenspeed-mla source changes
-        id: detect_mla
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          case "${{ github.event_name }}" in
-            pull_request)
-              files=$(gh api \
-                "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-                --paginate -q '.[].filename')
-              ;;
-            push)
-              files=$(gh api \
-                "/repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.event.after }}" \
-                -q '.files[].filename')
-              ;;
-            *)
-              files=""
-              ;;
-          esac
-          if printf '%s\n' "$files" | grep -q '^tokenspeed-mla/'; then
-            echo "tokenspeed-mla touched by this run; in-tree source will be installed."
-            echo "changed=1" >> "$GITHUB_OUTPUT"
-          else
-            echo "tokenspeed-mla untouched; keeping pinned PyPI wheel."
-            echo "changed=0" >> "$GITHUB_OUTPUT"
-          fi
-
   unit-test:
     needs: scan
     if: |
+      needs.scan.outputs.should_run == 'true' &&
       needs.scan.outputs.unit_has_tasks == 'true' &&
       (github.event_name != 'pull_request' || github.event.action != 'closed') &&
       (
@@ -166,6 +165,7 @@ jobs:
     if: |
       !cancelled() &&
       needs.scan.result == 'success' &&
+      needs.scan.outputs.should_run == 'true' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       needs.scan.outputs.eager_model != 'true' &&
       (
@@ -185,6 +185,7 @@ jobs:
   model-test-eager:
     needs: scan
     if: |
+      needs.scan.outputs.should_run == 'true' &&
       needs.scan.outputs.eager_model == 'true' &&
       github.event.pull_request.draft == false &&
       needs.scan.outputs.model_has_tasks == 'true'

--- a/.github/workflows/pr-test-nvidia.yml
+++ b/.github/workflows/pr-test-nvidia.yml
@@ -65,17 +65,49 @@ jobs:
       )
     runs-on: ubuntu-latest
     outputs:
+      should_run: ${{ steps.changes.outputs.should_run }}
       unit_matrix: ${{ steps.scan.outputs.unit_matrix }}
       unit_has_tasks: ${{ steps.scan.outputs.unit_has_tasks }}
       model_matrix: ${{ steps.scan.outputs.model_matrix }}
       model_has_tasks: ${{ steps.scan.outputs.model_has_tasks }}
       eager_model: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'high priority') }}
-      install_tokenspeed_mla_from_source: ${{ steps.detect_mla.outputs.changed }}
+      install_tokenspeed_mla_from_source: ${{ steps.changes.outputs.install_tokenspeed_mla_from_source }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Classify changed paths
+        id: changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          changed_files="$RUNNER_TEMP/tokenspeed-changed-files.txt"
+          case "${{ github.event_name }}" in
+            pull_request)
+              gh api \
+                "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+                --paginate \
+                -q '.[] | .filename, (.previous_filename // empty)' \
+                > "$changed_files"
+              ;;
+            push)
+              gh api \
+                "/repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.event.after }}" \
+                -q '.files[] | .filename, (.previous_filename // empty)' \
+                > "$changed_files"
+              ;;
+            *)
+              : > "$changed_files"
+              ;;
+          esac
+          python3 test/ci_system/ci_path_filter.py \
+            --runner-group nvidia-x86 \
+            --event-name "${{ github.event_name }}" \
+            "$changed_files" >> "$GITHUB_OUTPUT"
+
       - name: Install scan dependency
+        if: steps.changes.outputs.should_run == 'true'
         # pypi.org occasionally returns "Content-Type: Unknown" for the simple
         # index, which strict pip>=22 refuses to parse. Retry a few times.
         run: |
@@ -88,6 +120,7 @@ jobs:
 
       - name: Build task matrix
         id: scan
+        if: steps.changes.outputs.should_run == 'true'
         env:
           TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS: h100,b300,${{ vars.TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS }}
         run: |
@@ -105,44 +138,10 @@ jobs:
             printf '%s' "$matrix" | python3 -c "import json, sys; print('${output}_has_tasks=' + ('true' if json.load(sys.stdin).get('include') else 'false'))" >> "$GITHUB_OUTPUT"
           done
 
-      # Compute this once on the hosted runner (where `gh` is pre-installed)
-      # and propagate the result to every matrix job via job output. The
-      # downstream stage jobs read it as an env var and `install_deps.sh`
-      # gates its in-tree `tokenspeed-mla` reinstall on it. Without this
-      # detection, CI would always exercise the pinned PyPI wheel and edits
-      # under `tokenspeed-mla/` would be silently uncovered.
-      - name: Detect tokenspeed-mla source changes
-        id: detect_mla
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          case "${{ github.event_name }}" in
-            pull_request)
-              files=$(gh api \
-                "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-                --paginate -q '.[].filename')
-              ;;
-            push)
-              files=$(gh api \
-                "/repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.event.after }}" \
-                -q '.files[].filename')
-              ;;
-            *)
-              files=""
-              ;;
-          esac
-          if printf '%s\n' "$files" | grep -q '^tokenspeed-mla/'; then
-            echo "tokenspeed-mla touched by this run; in-tree source will be installed."
-            echo "changed=1" >> "$GITHUB_OUTPUT"
-          else
-            echo "tokenspeed-mla untouched; keeping pinned PyPI wheel."
-            echo "changed=0" >> "$GITHUB_OUTPUT"
-          fi
-
   unit-test:
     needs: scan
     if: |
+      needs.scan.outputs.should_run == 'true' &&
       needs.scan.outputs.unit_has_tasks == 'true' &&
       (github.event_name != 'pull_request' || github.event.action != 'closed') &&
       (
@@ -166,6 +165,7 @@ jobs:
     if: |
       !cancelled() &&
       needs.scan.result == 'success' &&
+      needs.scan.outputs.should_run == 'true' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       needs.scan.outputs.eager_model != 'true' &&
       (
@@ -183,6 +183,7 @@ jobs:
   model-test-eager:
     needs: scan
     if: |
+      needs.scan.outputs.should_run == 'true' &&
       needs.scan.outputs.eager_model == 'true' &&
       github.event.pull_request.draft == false &&
       needs.scan.outputs.model_has_tasks == 'true'

--- a/test/ci_system/ci_path_filter.py
+++ b/test/ci_system/ci_path_filter.py
@@ -1,0 +1,108 @@
+"""Classify changed files for AMD and NVIDIA GPU CI."""
+
+import argparse
+import sys
+from pathlib import Path
+
+RUNNER_GROUPS = ("amd", "nvidia-arm", "nvidia-x86")
+
+SHARED_DIRECTORIES = (
+    "python",
+    "test",
+    "tokenspeed-kernel",
+    "tokenspeed-scheduler",
+)
+SHARED_FILES = frozenset(
+    {
+        ".github/workflows/run-pr-test-stage.yml",
+    }
+)
+
+VENDOR_DIRECTORIES = {
+    "amd": ("tokenspeed-kernel-amd",),
+    "nvidia-arm": ("tokenspeed-mla",),
+    "nvidia-x86": ("tokenspeed-mla",),
+}
+VENDOR_WORKFLOWS = {
+    "amd": ".github/workflows/pr-test-amd.yml",
+    "nvidia-arm": ".github/workflows/pr-test-nvidia-arm.yml",
+    "nvidia-x86": ".github/workflows/pr-test-nvidia.yml",
+}
+
+
+def is_in_directory(path: str, directory: str) -> bool:
+    return path == directory or path.startswith(f"{directory}/")
+
+
+def touches_directory(paths: set[str], directory: str) -> bool:
+    return any(is_in_directory(path, directory) for path in paths)
+
+
+def should_run(paths: set[str], runner_group: str, event_name: str) -> bool:
+    if event_name == "workflow_dispatch":
+        return True
+
+    if paths & SHARED_FILES:
+        return True
+    if any(touches_directory(paths, directory) for directory in SHARED_DIRECTORIES):
+        return True
+    if VENDOR_WORKFLOWS[runner_group] in paths:
+        return True
+    return any(
+        touches_directory(paths, directory)
+        for directory in VENDOR_DIRECTORIES[runner_group]
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Classify changed files for a vendor PR test workflow."
+    )
+    parser.add_argument(
+        "changed_files",
+        type=Path,
+        help="File containing one repository-relative changed path per line.",
+    )
+    parser.add_argument(
+        "--runner-group",
+        choices=RUNNER_GROUPS,
+        required=True,
+        help="Vendor runner group being considered.",
+    )
+    parser.add_argument(
+        "--event-name",
+        required=True,
+        help="GitHub event name; workflow_dispatch always enables the workflow.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    paths = {
+        line.strip()
+        for line in args.changed_files.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    }
+    run_vendor_tests = should_run(paths, args.runner_group, args.event_name)
+    install_mla = args.runner_group.startswith("nvidia") and touches_directory(
+        paths, "tokenspeed-mla"
+    )
+
+    print(f"should_run={str(run_vendor_tests).lower()}")
+    print(f"install_tokenspeed_mla_from_source={int(install_mla)}")
+
+    if run_vendor_tests:
+        print(
+            f"Changed paths require {args.runner_group} GPU tests.",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"Changed paths do not require {args.runner_group} GPU tests.",
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/ci_system/install_deps.sh
+++ b/test/ci_system/install_deps.sh
@@ -183,8 +183,7 @@ pip_install_with_retry pip3 install -e "./python" \
 # ============================================================
 # Step 7: Optionally override tokenspeed-mla with in-tree source
 # ============================================================
-# Set by `.github/workflows/pr-test-amd.yml` and
-# `.github/workflows/pr-test-nvidia.yml` when the diff touches
+# Set by the NVIDIA PR test workflows when the diff touches
 # `tokenspeed-mla/`. Without this override CI exercises whichever
 # `tokenspeed-mla` version is pinned in
 # `tokenspeed-kernel/python/requirements/cuda-thirdparty.txt` and the


### PR DESCRIPTION
Add file-based trigger to skip NVIDIA CI for AMD-only changes (tokenspeed-kernel-amd) and AMD CI for NVIDIA-only changes (tokenspeed-mla)
