### PR TITLE
Fix prep tape dependency races

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/metadata/prep_tape.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/metadata/prep_tape.py
@@ -18,21 +18,24 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Declarative one-launch CUDA-graph replay metadata prep.
+"""Declarative CUDA-graph replay metadata prep.
 
 Attention backends refill the captured graph's persistent input buffers
 before every replay. Recorded eagerly that is a chain of tiny fills, copies
 and gathers -- tens of kernel launches for a few kilobytes. A
 :class:`PrepTape` records that chain ONCE against the persistent buffers
 (pointers never change across replays) and then executes it each step with
-one small H2D register upload plus one interpreter-kernel launch.
+one small H2D register upload plus one interpreter launch per stage. Operations
+within a stage run independently; call :meth:`PrepTape.barrier` between
+operations that have a memory dependency.
 
 Usage::
 
     tape = PrepTape(device)
-    tape.fill(buf_a, n=Reg.BS, value=-1)
-    tape.copy(dst_view, src_view, n=Reg.REAL_BS)
+    tape.fill(dst, n=Reg.BS, value=-1)
+    tape.barrier()
     tape.gather(dst, table, idx, n=Reg.REAL_BS, oob_value=-1)
+    tape.copy(dst_view, src_view, n=Reg.REAL_BS)
     tape.filltail(buf_b, live=Reg.REAL_BS, total=Reg.BS, value=0)
     tape.finalize()
     ...
@@ -96,13 +99,17 @@ def _check(t: torch.Tensor, name: str) -> torch.Tensor:
 
 
 class PrepTape:
-    """Records metadata prep ops and replays them in one kernel launch."""
+    """Record metadata operations in explicitly ordered parallel stages.
+
+    Operations within a stage must be independent. Use :meth:`barrier` to start
+    a new stream-ordered stage when operations have a memory dependency.
+    """
 
     def __init__(self, device) -> None:
         self._device = torch.device(device)
-        self._rows: list[list[int]] = []
+        self._stages: list[list[list[int]]] = [[]]
         self._keepalive: list[torch.Tensor] = []
-        self._descs: torch.Tensor | None = None
+        self._descs: torch.Tensor | tuple[torch.Tensor, ...] | None = None
         self._regs_dev = torch.zeros(32, dtype=torch.int64, device=self._device)
         self._regs_pinned = torch.zeros(32, dtype=torch.int64, pin_memory=True)
 
@@ -114,7 +121,7 @@ class PrepTape:
         for t in (dst, src, idx):
             if isinstance(t, torch.Tensor):
                 self._keepalive.append(t)
-        self._rows.append(
+        self._stages[-1].append(
             [
                 op,
                 dst.data_ptr() if isinstance(dst, torch.Tensor) else 0,
@@ -126,6 +133,15 @@ class PrepTape:
                 _ref(scalar),
             ]
         )
+
+    def barrier(self) -> None:
+        """Start a stream-ordered launch stage after the recorded operations.
+
+        Returns ``None``.
+        """
+        if self._descs is not None:
+            raise RuntimeError("tape already finalized")
+        self._stages.append([])
 
     def fill(self, dst: torch.Tensor, n: "int | Reg", value: "int | Reg") -> None:
         """``dst[0:n] = value``."""
@@ -220,7 +236,7 @@ class PrepTape:
         ``state_in[i] = rows[i, clamp((after-2)//P)]`` (0 when no history),
         ``state_out[i] = rows[i, clamp((after-1)//P)]``. ``rows`` and
         ``seq_lens`` are per-step tensors passed via pointer registers."""
-        self._rows.append(
+        self._stages[-1].append(
             [
                 _OP_STATE_PAGES,
                 _check(state_in, "state_in").data_ptr(),
@@ -237,19 +253,27 @@ class PrepTape:
     # -- execution ---------------------------------------------------------
 
     def finalize(self) -> None:
-        """Upload the descriptor table; the tape becomes immutable."""
-        self._descs = torch.tensor(
-            self._rows, dtype=torch.int64, device=self._device
-        ).view(-1, _FIELDS)
+        """Upload the explicitly recorded stages; the tape becomes immutable.
+
+        Operations in each stage share a launch. Stages separated by
+        :meth:`barrier` launch in order on the current stream.
+        """
+        stages = tuple(
+            torch.tensor(rows, dtype=torch.int64, device=self._device).view(-1, _FIELDS)
+            for rows in self._stages
+            if rows
+        )
+        # Keep the latency-critical one-stage dispatch path unchanged.
+        self._descs = stages[0] if len(stages) == 1 else stages
 
     def __len__(self) -> int:
-        return len(self._rows)
+        return sum(len(stage) for stage in self._stages)
 
     def run(self, regs: dict) -> None:
         """Execute the tape with this step's register values.
 
-        One pinned write + one async H2D + one kernel launch, regardless of
-        how many ops the tape holds.
+        Uses one pinned write and async H2D upload. Operations in a stage run
+        in one parallel kernel launch; explicit barriers add ordered launches.
         """
         from tokenspeed_kernel.ops.metadata.triton_tape import run_tape
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/metadata/triton_tape.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/metadata/triton_tape.py
@@ -104,7 +104,11 @@ def _prep_tape_kernel(descs_ptr, regs_ptr, BLOCK: tl.constexpr):
 
 
 def run_tape(descs, regs) -> None:
-    """Execute a finalized tape: one launch, one program per descriptor."""
+    """Execute ordered stages, with one parallel program per descriptor."""
+    if isinstance(descs, tuple):
+        for stage in descs:
+            run_tape(stage, regs)
+        return
     n_ops = descs.shape[0]
     if n_ops == 0:
         return

--- a/tokenspeed-kernel/test/ops/metadata/test_prep_tape.py
+++ b/tokenspeed-kernel/test/ops/metadata/test_prep_tape.py
@@ -22,6 +22,7 @@ def test_tape_matches_eager_chain():
 
     tape = PrepTape(dev)
     tape.fill(idxbuf, n=Reg.BS, value=-1)
+    tape.barrier()
     tape.gather(idxbuf, table, gsrc, n=Reg.REAL_BS, oob_value=-7)
     tape.copy(qsl, cached, n=Reg.TOKENS)
     tape.copy2d(twod, srcrows, rows=Reg.BS, src_cols=16, pad_value=-1)
@@ -62,6 +63,28 @@ def test_finalized_tape_rejects_new_ops():
     tape.finalize()
     with pytest.raises(RuntimeError):
         tape.fill(buf, n=8, value=2)
+    with pytest.raises(RuntimeError):
+        tape.barrier()
+
+
+def test_dependent_source_write_precedes_gather_read():
+    """Exercise a cross-program RAW hazard, not only two writes to dst."""
+    dev = "cuda"
+    n = 1 << 18
+    src = torch.zeros(n, dtype=torch.int32, device=dev)
+    idx = torch.tensor([n - 1], dtype=torch.int32, device=dev)
+    dst = torch.zeros(1, dtype=torch.int32, device=dev)
+
+    tape = PrepTape(dev)
+    tape.fill(src, n=n, value=123)
+    tape.barrier()
+    tape.gather(dst, src, idx, n=1)
+    tape.finalize()
+    assert isinstance(tape._descs, tuple) and len(tape._descs) == 2
+
+    tape.run({})
+    torch.cuda.synchronize()
+    assert dst.item() == 123
 
 
 def test_state_pages_matches_reference():
@@ -72,8 +95,8 @@ def test_state_pages_matches_reference():
     seq_lens = torch.tensor(
         [1, 63, 64, 65, 128, 129, 200, 384], dtype=torch.int32, device=dev
     )
-    state_in = torch.zeros(BS, dtype=torch.int32, device=dev)
-    state_out = torch.zeros(BS, dtype=torch.int32, device=dev)
+    state_in = torch.zeros(BS + 4, dtype=torch.int32, device=dev)
+    state_out = torch.zeros(BS + 4, dtype=torch.int32, device=dev)
 
     tape = PrepTape(dev)
     tape.state_pages(
@@ -85,7 +108,10 @@ def test_state_pages_matches_reference():
         max_slots=SLOTS,
         page_size=P,
     )
+    tape.filltail(state_in, live=Reg.BS, total=BS + 4, value=-1)
+    tape.filltail(state_out, live=Reg.BS, total=BS + 4, value=-1)
     tape.finalize()
+    assert isinstance(tape._descs, torch.Tensor)
     tape.run({Reg.BS: BS, Reg.PTR0: rows, Reg.PTR1: seq_lens})
     torch.cuda.synchronize()
 
@@ -98,5 +124,7 @@ def test_state_pages_matches_reference():
     ref_in = rows.gather(1, in_slots.unsqueeze(1)).squeeze(1)
     ref_in = torch.where(before > 0, ref_in, torch.zeros_like(ref_in))
     ref_out = rows.gather(1, out_slots.unsqueeze(1)).squeeze(1)
-    assert torch.equal(state_in, ref_in.int())
-    assert torch.equal(state_out, ref_out.int())
+    assert torch.equal(state_in[:BS], ref_in.int())
+    assert torch.equal(state_out[:BS], ref_out.int())
+    assert (state_in[BS:] == -1).all()
+    assert (state_out[BS:] == -1).all()


### PR DESCRIPTION
## Why this is needed

A prep tape launches one Triton program per recorded operation. Programs in the same launch may run in any order.

The flaky test recorded a fill followed by a gather into the same buffer. Eager execution reads like "fill, then overwrite the live prefix," but the GPU was free to run the fill after the gather. When that happened, the fill occasionally overwrote valid gathered values.

This is an ordering problem rather than a numerical problem: operations that touch independent memory should remain parallel, while genuine dependencies need an explicit boundary.

## Key changes

- Add `PrepTape.barrier()` to start a new stream-ordered launch stage.
- Keep all operations within a stage parallel, preserving the tape's low launch overhead.
- Preserve the existing single-tensor/single-launch path when no barrier is recorded. The production `state_pages + filltail` shape therefore remains one launch.
- Execute multiple stages in order on the current stream.
- Add focused coverage for the original flaky chain, a cross-program read-after-write dependency, and the production single-stage layout.

The intended usage is explicit and mirrors the GPU execution model:

```python
tape.fill(dst, n=Reg.BS, value=-1)
tape.barrier()  # later operations may now depend on the fill
tape.gather(dst, table, idx, n=Reg.REAL_BS, oob_value=-1)
tape.finalize()
```

Independent operations do not need a barrier and continue to share a launch:

```python
tape.state_pages(state_in, state_out, ..., bs=Reg.REAL_BS)
tape.filltail(state_in, live=Reg.REAL_BS, total=max_bs, value=-1)
tape.filltail(state_out, live=Reg.REAL_BS, total=max_bs, value=-1)
tape.finalize()  # one stage, one launch
```

## How the implementation works

### `tokenspeed-kernel/.../metadata/prep_tape.py`

Previously, every descriptor row was appended to one flat list:

```python
self._rows: list[list[int]] = []
...
self._rows.append(descriptor)
```

That flat list was uploaded as one descriptor table, so every operation became an independent Triton program in the same launch. Recording order looked sequential in Python but did not establish GPU execution order.

The tape now stores a list of stages, where each stage is still a list of descriptor rows:

```python
self._stages: list[list[list[int]]] = [[]]
...
self._stages[-1].append(descriptor)
```

Normal recording remains cheap: operations keep appending to the current stage and therefore remain parallel. `barrier()` only starts a new descriptor list:

```python
def barrier(self) -> None:
    if self._descs is not None:
        raise RuntimeError("tape already finalized")
    self._stages.append([])
```

This makes the ordering decision explicit at the call site. There is no runtime alias analysis and no attempt to infer dependencies from pointer values, including pointers supplied through registers.

At finalization, each non-empty stage becomes its own device descriptor tensor:

```python
stages = tuple(
    torch.tensor(rows, dtype=torch.int64, device=self._device).view(-1, _FIELDS)
    for rows in self._stages
    if rows
)
```

The common production case is deliberately kept in its original representation:

```python
self._descs = stages[0] if len(stages) == 1 else stages
```

Therefore:

- No barrier: `_descs` is the same single tensor used before this change.
- One or more barriers: `_descs` is a tuple of tensors, one per ordered stage.
- The register values are still uploaded once per `run()`; only genuinely dependent tapes add launches.

### `tokenspeed-kernel/.../metadata/triton_tape.py`

The Triton interpreter kernel itself is unchanged. It still launches one program per descriptor in a stage:

```python
_prep_tape_kernel[(n_ops,)](descs, regs, BLOCK=128, num_warps=1)
```

Only the Python dispatcher learns how to handle a staged descriptor tuple:

```python
def run_tape(descs, regs) -> None:
    if isinstance(descs, tuple):
        for stage in descs:
            run_tape(stage, regs)
        return

    n_ops = descs.shape[0]
    if n_ops == 0:
        return
    _prep_tape_kernel[(n_ops,)](descs, regs, BLOCK=128, num_warps=1)
```

Each stage launch is submitted to the current PyTorch stream. Stream ordering guarantees that stage N completes before stage N+1 consumes or overwrites its data. Within each stage, descriptors remain separate Triton programs and retain the original parallelism.

For the flaky sequence, execution is now:

```text
stage 0: fill(dst)          # launch 1
          stream ordering
stage 1: gather(dst, ...)   # launch 2
```

For the production state-page sequence, all accesses are independent or disjoint, so it remains:

```text
stage 0: state_pages(group 0..N) + fill tails   # one launch
```

This explicit approach avoids a heavyweight dependency analyzer, which could not reliably reason about tensor pointers supplied through runtime registers anyway.

## Tests

The test changes cover three properties:

1. The original fill-then-gather chain now places a barrier at the real dependency.
2. A large fill followed by a gather from its last element verifies a true cross-program read-after-write dependency.
3. `state_pages` plus disjoint tail fills finalizes to a single descriptor tensor, guarding the production one-launch path.

## Validation

- Focused metadata tests: `5 passed`
- Former flaky chain: `1000/1000` repeated passes
- Production-shaped tape: remains a single descriptor tensor and one launch
- MI350X replay A/B: `28.500 us` staged vs `28.480 us` original (`+0.068%`, within noise)
- `pre-commit run --all-files`: passed
- `git diff --check`: passed

Context: [original flaky Actions job](https://github.com/lightseekorg/tokenspeed/actions/runs/31337925926/job/93310320397), [investigation issue](https://github.com/raikonenfnu/tokenspeed/issues/52).
