### PR TITLE
feat(zmq): data-parallel ranks over the msgpack wire

### DIFF
--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -1077,13 +1077,12 @@ class EventLoop:
         input/output sockets."""
         from tokenspeed.runtime.engine import zmq_msgpack, zmq_wire
 
-        if self.dp_size > 1:
-            # Shared choke point for every launch path: all DP-rank engines
-            # would connect to SMG's ROUTER with the same zmq_engine_index
-            # identity, so their inputs and outputs would collide.
-            raise NotImplementedError(
-                "--zmq-msgpack does not support data-parallel size > 1 yet"
-            )
+        # Each DP rank dials SMG with its own engine identity
+        # (zmq_engine_index + dp_rank): the frontend's grouped worker awaits
+        # dp_size engines on one socket set and tells the ranks apart — and
+        # routes inputs back — by this index. The ready response carries the
+        # true dp rank/size alongside.
+        engine_index = self.server_args.zmq_engine_index + self.dp_rank
         geometry = self._scheduler_cache_geometry
         ready_response = zmq_wire.WireEngineCoreReadyResponse(
             max_model_len=self.model_config.context_len,
@@ -1106,7 +1105,7 @@ class EventLoop:
         return zmq_msgpack.connect_msgpack_engine(
             context,
             self.server_args.zmq_handshake_endpoint(),
-            self.server_args.zmq_engine_index,
+            engine_index,
             ready_response,
             self.model_config.vocab_size,
             enable_output_logprobs=self.server_args.enable_output_logprobs,

--- a/python/tokenspeed/runtime/engine/io_struct.py
+++ b/python/tokenspeed/runtime/engine/io_struct.py
@@ -707,9 +707,16 @@ class BatchTokenIDOutSlim(BaseBatchReq, kw_only=True):
     # non-ragged (always length == len(rids)).
     output_token_logprobs_val: list[list[float]]
     output_token_logprobs_idx: list[list[int]]
+    # Producing DP rank's engine index (the identity it dialed the frontend
+    # with). The output PULL socket carries no routing identity, so under
+    # DP the batch itself names its rank. Appended field: defaults to 0 so
+    # older peers on either side stay compatible.
+    engine_index: int = 0
 
     @classmethod
-    def from_full(cls, out: BatchTokenIDOut) -> "BatchTokenIDOutSlim":
+    def from_full(
+        cls, out: BatchTokenIDOut, engine_index: int = 0
+    ) -> "BatchTokenIDOutSlim":
         # Token source: ``out.output_ids`` — the not-yet-sent slice of each
         # request's generated ids. NOT ``out.decode_ids``: that is the
         # incremental-detokenization window, which starts at the prompt tail
@@ -723,6 +730,7 @@ class BatchTokenIDOutSlim(BaseBatchReq, kw_only=True):
                 "the per-request generated token ids"
             )
         return cls(
+            engine_index=engine_index,
             rids=list(out.rids),
             output_ids=[list(ids) for ids in out.output_ids],
             finished_reasons=[_finish_type(fr) for fr in out.finished_reasons],

--- a/python/tokenspeed/runtime/engine/zmq_msgpack.py
+++ b/python/tokenspeed/runtime/engine/zmq_msgpack.py
@@ -140,13 +140,17 @@ class MsgpackSendSocket:
     and are dropped with a warning rather than crashing the scheduler.
     """
 
-    def __init__(self, socket: zmq.Socket) -> None:
+    def __init__(self, socket: zmq.Socket, engine_index: int = 0) -> None:
         self._socket = socket
+        self._engine_index = engine_index
         self._encoder = MsgpackEncoder()
 
     def send_pyobj(self, obj) -> None:
         if isinstance(obj, BatchTokenIDOut):
-            slim = BatchTokenIDOutSlim.from_full(obj)
+            # The PULL side carries no routing identity, so the batch itself
+            # names its producing rank; the frontend attributes per-rank
+            # outputs and load by this index under DP.
+            slim = BatchTokenIDOutSlim.from_full(obj, engine_index=self._engine_index)
             self._socket.send_multipart(self._encoder.encode(slim), copy=False)
         else:
             logger.warning(
@@ -250,5 +254,5 @@ def connect_msgpack_engine(
     logger.info("msgpack handshake: complete (engine_index=%s)", engine_index)
     return (
         MsgpackRecvSocket(input_socket, vocab_size, enable_output_logprobs),
-        MsgpackSendSocket(output_socket),
+        MsgpackSendSocket(output_socket, engine_index=engine_index),
     )

--- a/python/tokenspeed/runtime/entrypoints/engine.py
+++ b/python/tokenspeed/runtime/entrypoints/engine.py
@@ -658,8 +658,9 @@ def launch_scheduler_headless(server_args: ServerArgs) -> None:
     """
     server_args.zmq_msgpack = True
     server_args.skip_tokenizer_init = True
-    # DP > 1 is rejected in event_loop._init_msgpack_transport, the choke point
-    # shared with the non-headless --zmq-msgpack launch path.
+    # DP > 1: each rank dials the frontend with its own engine identity
+    # (zmq_engine_index + dp_rank) in event_loop._init_msgpack_transport, the
+    # choke point shared with the non-headless --zmq-msgpack launch path.
 
     configure_logger(server_args)
     _set_envs_and_config(server_args)

--- a/test/runtime/test_zmq_msgpack.py
+++ b/test/runtime/test_zmq_msgpack.py
@@ -250,6 +250,25 @@ def test_slim_out_from_full_roundtrip():
     assert rt.cached_tokens == [1]
     assert rt.output_token_logprobs_val == [[]]
     assert rt.output_token_logprobs_idx == [[]]
+    assert rt.engine_index == 0
+
+
+def test_slim_out_carries_the_producing_engine_index():
+    # The output PULL socket has no routing identity, so under DP the batch
+    # itself names its producing rank; 0 stays the single-engine default.
+    slim = BatchTokenIDOutSlim.from_full(_make_batch_out(), engine_index=3)
+    rt = msgspec.msgpack.Decoder(BatchTokenIDOutSlim).decode(_encode_payload(slim))
+    assert rt.engine_index == 3
+
+
+def test_slim_out_engine_index_defaults_for_older_senders():
+    # Appended field: a 9-element array from an older sender must still decode.
+    slim = BatchTokenIDOutSlim.from_full(_make_batch_out())
+    raw = msgspec.msgpack.decode(_encode_payload(slim))
+    rt = msgspec.msgpack.Decoder(BatchTokenIDOutSlim).decode(
+        msgspec.msgpack.encode(raw[:9])
+    )
+    assert rt.engine_index == 0
 
 
 def test_slim_out_sources_output_ids_not_the_detok_window():
@@ -286,21 +305,22 @@ def test_slim_out_carries_logprob_columns():
 
 
 def test_slim_out_is_tagged_positional_tuple():
-    """The wire form must be a 9-element tagged array (the frontend's codec
-    depends on the tag and column order)."""
+    """The wire form must be a 10-element tagged array (the frontend's codec
+    depends on the tag and column order; engine_index is the appended tail)."""
     out = _make_batch_out(
         output_token_logprobs_val=[[-0.5]], output_token_logprobs_idx=[[10]]
     )
-    slim = BatchTokenIDOutSlim.from_full(out)
+    slim = BatchTokenIDOutSlim.from_full(out, engine_index=1)
     raw = msgspec.msgpack.decode(_encode_payload(slim))
     assert isinstance(raw, list)
     assert raw[0] == "BatchTokenIDOutSlim"
-    assert len(raw) == 9
+    assert len(raw) == 10
     assert raw[1] == ["r1"]  # rids
     assert raw[2] == [[10, 11]]  # output_ids
     assert raw[3] == ["length"]  # finished_reasons
     assert raw[7] == [[pytest.approx(-0.5)]]
     assert raw[8] == [[10]]
+    assert raw[9] == 1  # engine_index (appended)
 
 
 def test_slim_out_finish_reason_none_maps_to_empty():
@@ -634,6 +654,92 @@ def test_connect_and_data_plane_roundtrip():
     finally:
         recv.close()
         send.close()
+        frontend.close()
+        ctx.term()
+        tmp.cleanup()
+
+
+def test_two_dp_ranks_connect_with_distinct_identities():
+    """DP ranks share one frontend socket set: each dials with its own
+    engine-index identity, inputs route to exactly one rank, and outputs name
+    their producing rank in the batch (the PULL side has no identity)."""
+    ctx = zmq.Context()
+    tmp = tempfile.TemporaryDirectory()
+    frontend = _FakeSmgFrontend(ctx, Path(tmp.name))
+
+    engines: dict[int, tuple] = {}
+    errors: dict[int, Exception] = {}
+
+    def _engine(index: int) -> None:
+        try:
+            engines[index] = zmq_msgpack.connect_msgpack_engine(
+                ctx,
+                frontend.handshake_addr,
+                engine_index=index,
+                ready_response=zmq_wire.WireEngineCoreReadyResponse(
+                    max_model_len=4096,
+                    dtype="bfloat16",
+                    vllm_version="tokenspeed-test",
+                    data_parallel_size=2,
+                    data_parallel_rank=index,
+                ),
+                vocab_size=32000,
+            )
+        except Exception as exc:
+            errors[index] = exc
+
+    threads = [threading.Thread(target=_engine, args=(i,)) for i in range(2)]
+    for t in threads:
+        t.start()
+
+    # Phase-tracked handshake: HELLO and READY interleave arbitrarily across
+    # ranks on the one ROUTER, so drive it per-identity rather than in order.
+    init = zmq_wire.WireHandshakeInitMessage(
+        addresses=zmq_wire.WireHandshakeAddresses(
+            inputs=[frontend.input_addr], outputs=[frontend.output_addr]
+        )
+    )
+    inits_sent: set[bytes] = set()
+    ready: set[bytes] = set()
+    while len(ready) < 2:
+        engine_id, _payload = frontend.handshake.recv_multipart()
+        if engine_id not in inits_sent:
+            frontend.handshake.send_multipart([engine_id, zmq_wire.encode(init)])
+            inits_sent.add(engine_id)
+        else:
+            ready.add(engine_id)
+    registered: set[bytes] = set()
+    while len(registered) < 2:
+        reg_id, reg_payload = frontend.input.recv_multipart()
+        assert len(reg_payload) > 0
+        registered.add(reg_id)
+
+    for t in threads:
+        t.join(timeout=15)
+    assert not errors, errors
+    expected_ids = {struct.pack("<H", 0), struct.pack("<H", 1)}
+    assert inits_sent == expected_ids
+    assert registered == expected_ids
+
+    try:
+        # Inputs route by identity: only rank 1 sees a request addressed to it.
+        frames = MsgpackEncoder().encode(_make_request(rid="to-rank-1"))
+        frontend.input.send_multipart(
+            [struct.pack("<H", 1), zmq_wire.REQ_TYPE_ADD, *frames]
+        )
+        io = engines[1][0].recv_pyobj()
+        assert io.rid == "to-rank-1"
+        with pytest.raises(zmq.Again):
+            engines[0][0].recv_pyobj(zmq.NOBLOCK)
+
+        # Outputs name their rank: rank 1's batch arrives tagged engine_index=1.
+        engines[1][1].send_pyobj(_make_batch_out())
+        out = frontend.recv_output()
+        assert out.engine_index == 1
+    finally:
+        for recv, send in engines.values():
+            recv.close()
+            send.close()
         frontend.close()
         ctx.term()
         tmp.cleanup()


### PR DESCRIPTION
## Problem

`--zmq-msgpack` rejects `dp_size > 1`:

```python
# all DP-rank engines would connect to SMG's ROUTER with the same
# zmq_engine_index identity, so their inputs and outputs would collide.
raise NotImplementedError(...)
```

The rejection was correct — but both halves of the collision are fixable with machinery that already exists.

## Solution

**Inputs / handshake**: each rank dials with its own identity, `zmq_engine_index + dp_rank`, at `_init_msgpack_transport` (the choke point shared by the headless and non-headless launch paths). `connect_msgpack_engine` already parameterized the identity, and the ready response already reported the true `data_parallel_rank`/`size` — so a frontend can await all ranks of a group on one socket set and route requests per rank, exactly as it does for vLLM's DP EngineCores.

**Outputs**: the PULL socket carries no routing identity, so under DP a batch must name its producing rank itself. `BatchTokenIDOutSlim` gains an appended `engine_index` tail field (wire stays append-only: older decoders skip the extra element, older senders leave the default 0), threaded through `MsgpackSendSocket` from the rank's dialed index. Without this, a frontend would attribute every rank's outputs — and any per-rank load signal — to rank 0.

DP ranks schedule independently on this wire (no lockstep), so no coordination protocol is needed beyond distinct identities.

## Tests

`test_zmq_msgpack.py` (pure CPU, loopback against the hand-rolled frontend):
- two ranks handshake on one frontend socket set with distinct `<H`-packed identities (phase-tracked handshake — HELLO/READY interleave arbitrarily across ranks);
- an input addressed to rank 1 arrives only at rank 1;
- a batch sent by rank 1 arrives tagged `engine_index=1`;
- slim wire-order test updated to the 10-element form, plus a 9-element decode check pinning older-sender compatibility.

25/25 pass. Frontend counterpart (accepting `engine_count > 1` for tokenspeed and reading the batch's `engine_index`) lands in SMG once this merges.