### PR TITLE
perf(amd): fold weighted DSA index queries

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/indexing.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/indexing.py
@@ -93,27 +93,28 @@ def _dsa_decode_logits_fp8_kernel(
         + block_offset.to(gl.int64) * num_groups
     )
 
-    scores = gl.zeros([BLOCK_N], gl.float32, layout=row_layout)
+    weighted_q = gl.zeros([BLOCK_D], gl.float32, layout=dim_layout)
     for head in gl.static_range(0, num_heads):
         q_vals = gl.load(
             q + (token * num_heads + head) * head_dim + dims,
             mask=dims < head_dim,
             other=0.0,
         ).to(gl.float32)
-        k_vals = gl.load(
-            index_k_fp8 + fp8_base[:, None] + dims[None, :],
-            mask=valid[:, None] & (dims[None, :] < head_dim),
-            other=0.0,
-        ).to(gl.float32)
-        # Per-row FP32 scales follow each page's FP8 payload.
-        k_scale = gl.load(
-            index_k_scale + scale_base,
-            mask=valid,
-            other=0.0,
-        ).to(gl.float32)
-        head_score = gl.sum(k_vals * k_scale[:, None] * q_vals[None, :], axis=1)
         head_weight = gl.load(weights + token * num_heads + head).to(gl.float32)
-        scores += head_score * head_weight
+        weighted_q += q_vals * head_weight
+
+    k_vals = gl.load(
+        index_k_fp8 + fp8_base[:, None] + dims[None, :],
+        mask=valid[:, None] & (dims[None, :] < head_dim),
+        other=0.0,
+    ).to(gl.float32)
+    # Per-row FP32 scales follow each page's FP8 payload.
+    k_scale = gl.load(
+        index_k_scale + scale_base,
+        mask=valid,
+        other=0.0,
+    ).to(gl.float32)
+    scores = gl.sum(k_vals * k_scale[:, None] * weighted_q[None, :], axis=1)
 
     scores *= softmax_scale
     scores = gl.where(valid, scores, -float("inf"))
@@ -171,26 +172,27 @@ def _dsa_prefill_logits_fp8_kernel(
         + block_offset * num_groups
     )
 
-    scores = gl.zeros([BLOCK_N], gl.float32, layout=row_layout)
+    weighted_q = gl.zeros([BLOCK_D], gl.float32, layout=dim_layout)
     for head in gl.static_range(0, num_heads):
         q_vals = gl.load(
             q + (token * num_heads + head) * head_dim + dims,
             mask=dims < head_dim,
             other=0.0,
         ).to(gl.float32)
-        k_vals = gl.load(
-            index_k_fp8 + fp8_base[:, None] + dims[None, :],
-            mask=valid[:, None] & (dims[None, :] < head_dim),
-            other=0.0,
-        ).to(gl.float32)
-        k_scale = gl.load(
-            index_k_scale + scale_base,
-            mask=valid,
-            other=0.0,
-        ).to(gl.float32)
-        head_score = gl.sum(k_vals * k_scale[:, None] * q_vals[None, :], axis=1)
         head_weight = gl.load(weights + token * num_heads + head).to(gl.float32)
-        scores += head_score * head_weight
+        weighted_q += q_vals * head_weight
+
+    k_vals = gl.load(
+        index_k_fp8 + fp8_base[:, None] + dims[None, :],
+        mask=valid[:, None] & (dims[None, :] < head_dim),
+        other=0.0,
+    ).to(gl.float32)
+    k_scale = gl.load(
+        index_k_scale + scale_base,
+        mask=valid,
+        other=0.0,
+    ).to(gl.float32)
+    scores = gl.sum(k_vals * k_scale[:, None] * weighted_q[None, :], axis=1)
 
     scores *= softmax_scale
     scores = gl.where(valid, scores, -float("inf"))

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/indexing.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/indexing.py
@@ -98,36 +98,36 @@ def _dsa_decode_logits_fp8_kernel(
         layout=row_layout,
     )
 
-    for head in gl.static_range(0, num_heads):
-        head_weight = gl.load(weights + token * num_heads + head).to(gl.float32)
-        head_score = gl.full(
-            [BLOCK_N],
+    for dim_start in gl.static_range(0, head_dim, BLOCK_D):
+        dims = dim_start + dim_offsets
+        weighted_q = gl.full(
+            [BLOCK_D],
             value=0.0,
             dtype=gl.float32,
-            layout=row_layout,
+            layout=dim_layout,
         )
-        for dim_start in gl.static_range(0, head_dim, BLOCK_D):
-            dims = dim_start + dim_offsets
+        for head in gl.static_range(0, num_heads):
+            head_weight = gl.load(weights + token * num_heads + head).to(gl.float32)
             q_vals = gl.amd.cdna4.buffer_load(
                 ptr=q,
                 offsets=((token * num_heads + head) * head_dim + dims).to(gl.int32),
                 mask=dims < head_dim,
                 other=0.0,
             ).to(gl.float32)
-            k_vals = gl.amd.cdna4.buffer_load(
-                ptr=index_k_fp8,
-                offsets=(fp8_base[:, None] + dims[None, :]).to(gl.int32),
-                mask=valid[:, None] & (dims[None, :] < head_dim),
-                other=0.0,
-            ).to(gl.float32)
-            k_scale = gl.amd.cdna4.buffer_load(
-                ptr=index_k_scale,
-                offsets=(scale_base + dim_start // 128).to(gl.int32),
-                mask=valid,
-                other=0.0,
-            ).to(gl.float32)
-            head_score += gl.sum(k_vals * k_scale[:, None] * q_vals[None, :], axis=1)
-        scores += head_score * head_weight
+            weighted_q += q_vals * head_weight
+        k_vals = gl.amd.cdna4.buffer_load(
+            ptr=index_k_fp8,
+            offsets=(fp8_base[:, None] + dims[None, :]).to(gl.int32),
+            mask=valid[:, None] & (dims[None, :] < head_dim),
+            other=0.0,
+        ).to(gl.float32)
+        k_scale = gl.amd.cdna4.buffer_load(
+            ptr=index_k_scale,
+            offsets=(scale_base + dim_start // 128).to(gl.int32),
+            mask=valid,
+            other=0.0,
+        ).to(gl.float32)
+        scores += gl.sum(k_vals * k_scale[:, None] * weighted_q[None, :], axis=1)
 
     scores *= softmax_scale
     scores = gl.where(valid, scores, -float("inf"))
@@ -191,36 +191,36 @@ def _dsa_prefill_logits_fp8_kernel(
         layout=row_layout,
     )
 
-    for head in gl.static_range(0, num_heads):
-        head_weight = gl.load(weights + token * num_heads + head).to(gl.float32)
-        head_score = gl.full(
-            [BLOCK_N],
+    for dim_start in gl.static_range(0, head_dim, BLOCK_D):
+        dims = dim_start + dim_offsets
+        weighted_q = gl.full(
+            [BLOCK_D],
             value=0.0,
             dtype=gl.float32,
-            layout=row_layout,
+            layout=dim_layout,
         )
-        for dim_start in gl.static_range(0, head_dim, BLOCK_D):
-            dims = dim_start + dim_offsets
+        for head in gl.static_range(0, num_heads):
+            head_weight = gl.load(weights + token * num_heads + head).to(gl.float32)
             q_vals = gl.amd.cdna4.buffer_load(
                 ptr=q,
                 offsets=((token * num_heads + head) * head_dim + dims).to(gl.int32),
                 mask=dims < head_dim,
                 other=0.0,
             ).to(gl.float32)
-            k_vals = gl.amd.cdna4.buffer_load(
-                ptr=index_k_fp8,
-                offsets=(fp8_base[:, None] + dims[None, :]).to(gl.int32),
-                mask=valid[:, None] & (dims[None, :] < head_dim),
-                other=0.0,
-            ).to(gl.float32)
-            k_scale = gl.amd.cdna4.buffer_load(
-                ptr=index_k_scale,
-                offsets=(scale_base + dim_start // 128).to(gl.int32),
-                mask=valid,
-                other=0.0,
-            ).to(gl.float32)
-            head_score += gl.sum(k_vals * k_scale[:, None] * q_vals[None, :], axis=1)
-        scores += head_score * head_weight
+            weighted_q += q_vals * head_weight
+        k_vals = gl.amd.cdna4.buffer_load(
+            ptr=index_k_fp8,
+            offsets=(fp8_base[:, None] + dims[None, :]).to(gl.int32),
+            mask=valid[:, None] & (dims[None, :] < head_dim),
+            other=0.0,
+        ).to(gl.float32)
+        k_scale = gl.amd.cdna4.buffer_load(
+            ptr=index_k_scale,
+            offsets=(scale_base + dim_start // 128).to(gl.int32),
+            mask=valid,
+            other=0.0,
+        ).to(gl.float32)
+        scores += gl.sum(k_vals * k_scale[:, None] * weighted_q[None, :], axis=1)
 
     scores *= softmax_scale
     scores = gl.where(valid, scores, -float("inf"))


### PR DESCRIPTION
Instead of loading and dequantizing index-K once per replicated head, the kernels first compute the weighted query sum and then perform a single index-K dot product. This reduces repeated cache traffic while preserving the mathematically equivalent result.

### MI355x Kernel Performance
All cases use top-k 2048, 32 replicated index heads of dimension 128.
| Decode workload | Baseline (ms) | Folded (ms) | Delta | Speedup |
|---|---:|---:|---:|---:|
| B1 context=1024 | 0.031241 | 0.030880 | -1.16% | 1.012× |
| B8 context=1024 | 0.032201 | 0.031040 | -3.61% | 1.037× |
| B1 context=4096 | 0.033600 | 0.032920 | -2.02% | 1.021× |
| B8 context=4096 | 0.047881 | 0.034120 | -28.74% | 1.403× |

| Prefill workload | Baseline (ms) | Folded (ms) | Delta | Speedup |
|---|---:|---:|---:|---:|
| B1 sequence=1024 | 0.808340 | 0.381889 | -52.76% | 2.117× |
| B8 sequence=1024 | 78.757416 | 22.671728 | -71.21% | 3.474× |
| B1 sequence=4096 | 16.191051 | 5.653631 | -65.08% | 2.864× |
| B8 sequence=4096 | 1466.401611 | 391.844727 | -73.28% | 3.742× |

### MI455x Kernel Performance
All cases use top-k 2048, 32 replicated index heads of dimension 128.
| Decode workload | Baseline (ms) | Folded (ms) | Delta | Speedup |
|---|---:|---:|---:|---:|
| B1 context=1024 | 0.046569 | 0.047711 | +2.45% | 0.976× |
| B8 context=1024 | 0.008252 | 0.007691 | -6.80% | 1.073× |
| B1 context=4096 | 0.021312 | 0.020712 | -2.82% | 1.029× |
| B8 context=4096 | 0.027041 | 0.024837 | -8.15% | 1.089× |

| Prefill workload | Baseline (ms) | Folded (ms) | Delta | Speedup |
|---|---:|---:|---:|---:|
| B1 sequence=1024 | 0.249334 | 0.183956 | -26.22% | 1.355× |
| B8 sequence=1024 | 14.778193 | 10.397066 | -29.65% | 1.421× |
| B1 sequence=4096 | 3.854939 | 2.732657 | -29.11% | 1.411× |
| B8 sequence=4096 | 345.772491 | 221.633453 | -35.90% | 1.560× |