### PR TITLE
perf(kernel): accelerate GLM FP8 DSA attention

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/attention.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/attention.py
@@ -31,6 +31,7 @@ __all__ = [
 ]
 
 _REGISTERED_TOPK_WIDTHS = (512, 1024, 2048)
+_FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
 
 
 @gluon.constexpr_function
@@ -146,73 +147,87 @@ def _dsa_dense_mfma_kv_kernel(
     TILE_K: gl.constexpr,
     D_V: gl.constexpr,
     D_ROPE: gl.constexpr,
+    IS_FP8: gl.constexpr,
+    TRIM_EMPTY_TILES: gl.constexpr,
 ):
+    INSTR_K: gl.constexpr = 32 if IS_FP8 else 16
+    QK_K_WIDTH: gl.constexpr = 16 if IS_FP8 else 8
+    PV_K_WIDTH: gl.constexpr = 8 if IS_FP8 else 4
+    INPUT_VEC: gl.constexpr = 16 if IS_FP8 else 8
+    ROPE_LOAD_VEC: gl.constexpr = 4 if IS_FP8 else 2
+    SHARED_INTERVAL: gl.constexpr = 1024 if IS_FP8 else 512
+    SHARED_PADDING: gl.constexpr = 32 if IS_FP8 else 16
     mfma_s: gl.constexpr = gl.amd.cdna4.AMDMFMALayout(
         version=4,
-        instr_shape=[16, 16, 16],
+        instr_shape=[16, 16, INSTR_K],
         transposed=True,
         warps_per_cta=[4, 1],
     )
     mfma_acc: gl.constexpr = gl.amd.cdna4.AMDMFMALayout(
         version=4,
-        instr_shape=[16, 16, 16],
+        instr_shape=[16, 16, INSTR_K],
         transposed=True,
         warps_per_cta=[4, 1],
     )
 
-    _qlora_tpw_k: gl.constexpr = min(64, D_V // 8)
+    _qlora_tpw_k: gl.constexpr = min(64, D_V // INPUT_VEC)
     _qlora_tpw_m: gl.constexpr = 64 // _qlora_tpw_k
     blk_qlora: gl.constexpr = gl.BlockedLayout(
-        size_per_thread=[1, 8],
+        size_per_thread=[1, INPUT_VEC],
         threads_per_warp=[_qlora_tpw_m, _qlora_tpw_k],
         warps_per_cta=[4, 1],
         order=[1, 0],
     )
-    blk_qrope: gl.constexpr = gl.BlockedLayout(
+    _out_tpw_k: gl.constexpr = min(64, D_V // 8)
+    _out_tpw_m: gl.constexpr = 64 // _out_tpw_k
+    blk_out: gl.constexpr = gl.BlockedLayout(
         size_per_thread=[1, 8],
-        threads_per_warp=[8, 8],
+        threads_per_warp=[_out_tpw_m, _out_tpw_k],
         warps_per_cta=[4, 1],
         order=[1, 0],
     )
-    _klora_tpw_m: gl.constexpr = min(64, D_V // 8)
+    _qrope_tpw_k: gl.constexpr = min(64, D_ROPE // INPUT_VEC)
+    _qrope_tpw_m: gl.constexpr = 64 // _qrope_tpw_k
+    blk_qrope: gl.constexpr = gl.BlockedLayout(
+        size_per_thread=[1, INPUT_VEC],
+        threads_per_warp=[_qrope_tpw_m, _qrope_tpw_k],
+        warps_per_cta=[4, 1],
+        order=[1, 0],
+    )
+    _klora_tpw_m: gl.constexpr = min(64, D_V // INPUT_VEC)
     _klora_tpw_n: gl.constexpr = 64 // _klora_tpw_m
     blk_klora: gl.constexpr = gl.BlockedLayout(
-        size_per_thread=[8, 1],
+        size_per_thread=[INPUT_VEC, 1],
         threads_per_warp=[_klora_tpw_m, _klora_tpw_n],
         warps_per_cta=[1, 4],
         order=[0, 1],
     )
+    _krope_tpw_m: gl.constexpr = min(64, D_ROPE // ROPE_LOAD_VEC)
+    _krope_tpw_n: gl.constexpr = 64 // _krope_tpw_m
     blk_krope: gl.constexpr = gl.BlockedLayout(
-        size_per_thread=[2, 1],
-        threads_per_warp=[32, 2],
+        size_per_thread=[ROPE_LOAD_VEC, 1],
+        threads_per_warp=[_krope_tpw_m, _krope_tpw_n],
         warps_per_cta=[1, 4],
         order=[0, 1],
     )
-    blk_topk: gl.constexpr = gl.BlockedLayout(
-        size_per_thread=[1],
-        threads_per_warp=[64],
-        warps_per_cta=[4],
-        order=[0],
-    )
-
     sh_qlora: gl.constexpr = gl.PaddedSharedLayout.with_identity_for(
-        [[512, 16]],
+        [[SHARED_INTERVAL, SHARED_PADDING]],
         [BLOCK_H, D_V],
         [1, 0],
     )
     sh_qrope: gl.constexpr = gl.SwizzledSharedLayout(
-        vec=8,
+        vec=INPUT_VEC,
         per_phase=2,
         max_phase=8,
         order=[1, 0],
     )
     sh_klora: gl.constexpr = gl.PaddedSharedLayout.with_identity_for(
-        [[512, 16]],
+        [[SHARED_INTERVAL, SHARED_PADDING]],
         [D_V, TILE_K],
         [0, 1],
     )
     sh_krope: gl.constexpr = gl.SwizzledSharedLayout(
-        vec=8,
+        vec=INPUT_VEC,
         per_phase=2,
         max_phase=8,
         order=[0, 1],
@@ -221,32 +236,32 @@ def _dsa_dense_mfma_kv_kernel(
     dot_qlora_a: gl.constexpr = gl.DotOperandLayout(
         operand_index=0,
         parent=mfma_s,
-        k_width=8,
+        k_width=QK_K_WIDTH,
     )
     dot_qrope_a: gl.constexpr = gl.DotOperandLayout(
         operand_index=0,
         parent=mfma_s,
-        k_width=8,
+        k_width=QK_K_WIDTH,
     )
     dot_klora_b: gl.constexpr = gl.DotOperandLayout(
         operand_index=1,
         parent=mfma_s,
-        k_width=8,
+        k_width=QK_K_WIDTH,
     )
     dot_krope_b: gl.constexpr = gl.DotOperandLayout(
         operand_index=1,
         parent=mfma_s,
-        k_width=8,
+        k_width=QK_K_WIDTH,
     )
     dot_p_a: gl.constexpr = gl.DotOperandLayout(
         operand_index=0,
         parent=mfma_acc,
-        k_width=4,
+        k_width=PV_K_WIDTH,
     )
     dot_v_b: gl.constexpr = gl.DotOperandLayout(
         operand_index=1,
         parent=mfma_acc,
-        k_width=4,
+        k_width=PV_K_WIDTH,
     )
 
     token_idx = gl.program_id(axis=0)
@@ -306,6 +321,13 @@ def _dsa_dense_mfma_kv_kernel(
     gl.amd.cdna4.async_copy.commit_group()
 
     NUM_TILES: gl.constexpr = (TOPK + TILE_K - 1) // TILE_K
+    if TRIM_EMPTY_TILES:
+        num_tiles = gl.maximum(
+            gl.cdiv(gl.minimum(gl.maximum(valid_len, 0), TOPK), TILE_K),
+            1,
+        )
+    else:
+        num_tiles: gl.constexpr = NUM_TILES
     topk_base = token_idx.to(tl.int64) * stride_topk_t
 
     offs_tile_klora = gl.arange(0, TILE_K, layout=gl.SliceLayout(0, blk_klora))
@@ -390,7 +412,7 @@ def _dsa_dense_mfma_kv_kernel(
     acc = gl.zeros([BLOCK_H, D_V], dtype=gl.float32, layout=mfma_acc)
 
     cur_buf = 0
-    for tile_idx in range(NUM_TILES - 1):
+    for tile_idx in range(num_tiles - 1):
         next_base = (tile_idx + 1) * TILE_K
         next_offs_klora = next_base + offs_tile_klora
         next_offs_krope = next_base + offs_tile_krope
@@ -517,8 +539,8 @@ def _dsa_dense_mfma_kv_kernel(
     acc = acc / safe_l_i[:, None]
     acc = gl.where(l_i_acc[:, None] > 0.0, acc, 0.0)
 
-    offs_h_o = hg_offset + gl.arange(0, BLOCK_H, layout=gl.SliceLayout(1, blk_qlora))
-    offs_v_o = gl.arange(0, D_V, layout=gl.SliceLayout(0, blk_qlora))
+    offs_h_o = hg_offset + gl.arange(0, BLOCK_H, layout=gl.SliceLayout(1, blk_out))
+    offs_v_o = gl.arange(0, D_V, layout=gl.SliceLayout(0, blk_out))
     mask_h_o = offs_h_o < num_heads
     o_base = token_idx.to(tl.int64) * stride_o_t
     o_offs = (
@@ -526,7 +548,7 @@ def _dsa_dense_mfma_kv_kernel(
         + offs_h_o[:, None].to(tl.int64) * stride_o_h
         + offs_v_o[None, :].to(tl.int64)
     )
-    out_vals = gl.convert_layout(acc.to(out.dtype.element_ty), blk_qlora)
+    out_vals = gl.convert_layout(acc.to(out.dtype.element_ty), blk_out)
     gl.amd.cdna4.buffer_store(
         stored_value=out_vals,
         ptr=out,
@@ -774,7 +796,7 @@ def _check_inputs(
     qk_rope_head_dim: int,
     page_size: int,
 ) -> None:
-    if q.dtype not in (torch.bfloat16, torch.float8_e4m3fn):
+    if q.dtype != torch.bfloat16 and q.dtype not in _FP8_DTYPES:
         raise TypeError(f"Gluon DSA supports BF16/FP8 q, got {q.dtype}")
     if page_size != 64:
         raise ValueError(f"Gluon DSA supports page_size=64, got {page_size}")
@@ -806,7 +828,7 @@ def _check_inputs(
 
 
 def _output_dtype(q: torch.Tensor) -> torch.dtype:
-    return torch.bfloat16 if q.dtype == torch.float8_e4m3fn else q.dtype
+    return torch.bfloat16 if q.dtype in _FP8_DTYPES else q.dtype
 
 
 def _trim_topk_slots_for_context(
@@ -834,13 +856,17 @@ def _run_dense_kv(
     softmax_scale: float,
     kv_lora_rank: int,
     qk_rope_head_dim: int,
+    max_seqlen_k: int,
 ) -> torch.Tensor:
     out = torch.empty(
         (q.shape[0], q.shape[1], kv_lora_rank),
         dtype=_output_dtype(q),
         device=q.device,
     )
-    grid = lambda meta: (q.shape[0], triton.cdiv(q.shape[1], meta["BLOCK_H"]))
+
+    def grid(meta):
+        return q.shape[0], triton.cdiv(q.shape[1], meta["BLOCK_H"])
+
     _dsa_dense_mfma_kv_kernel[grid](
         q,
         kv_cache,
@@ -858,6 +884,8 @@ def _run_dense_kv(
         topk_slots.shape[1],
         D_V=kv_lora_rank,
         D_ROPE=qk_rope_head_dim,
+        IS_FP8=q.dtype in _FP8_DTYPES,
+        TRIM_EMPTY_TILES=int(max_seqlen_k) < int(topk_slots.shape[1]),
         BLOCK_H=16,
         TILE_K=32,
         num_warps=4,
@@ -969,8 +997,9 @@ def _run_dsa(
     topk_lens = topk_lens.contiguous()
     topk_slots = _trim_topk_slots_for_context(topk_slots, max_seqlen_k)
     softmax_scale = float(softmax_scale) * float(k_scale)
-    # The AITER-style tiled kernel maps to dense BF16 KV. TokenSpeed's packed
-    # sparse FP8 rows use a different physical layout and stay on the scalar path.
+    # The tiled kernel maps to dense BF16 or FP8 KV. TokenSpeed's packed sparse
+    # FP8 rows use a different physical layout, so they use the packed sparse
+    # implementation instead of the dense tiled implementation.
     if sparse_kv_cache is not None:
         result = _run_packed_kv(
             q,
@@ -983,11 +1012,12 @@ def _run_dsa(
         )
     elif kv_cache is not None:
         dense_kv = _flatten_dense_kv_cache(kv_cache).contiguous()
-        if (
-            q.dtype == torch.bfloat16
-            and dense_kv.dtype == torch.bfloat16
+        use_tiled_kernel = (
+            q.dtype == dense_kv.dtype
+            and (q.dtype == torch.bfloat16 or q.dtype in _FP8_DTYPES)
             and int(kv_lora_rank) == 512
-        ):
+        )
+        if use_tiled_kernel:
             result = _run_dense_kv(
                 q,
                 dense_kv,
@@ -996,6 +1026,7 @@ def _run_dsa(
                 softmax_scale=softmax_scale,
                 kv_lora_rank=kv_lora_rank,
                 qk_rope_head_dim=qk_rope_head_dim,
+                max_seqlen_k=max_seqlen_k,
             )
         else:
             result = _run_dense_kv_scalar(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
@@ -904,6 +904,7 @@ if current_platform().is_amd:
             {
                 format_signature(q=dense_tensor_format(torch.bfloat16)),
                 format_signature(q=dense_tensor_format(torch.float8_e4m3fn)),
+                format_signature(q=dense_tensor_format(torch.float8_e5m2)),
             }
         ),
         priority=Priority.SPECIALIZED,
@@ -955,6 +956,40 @@ if current_platform().is_amd:
         },
     )
     def gluon_dsa_prefill_gfx950(*args, **kwargs):
+        return _dsa_prefill_impl(*args, **kwargs)
+
+    @register_kernel(
+        "attention",
+        "dsa_prefill",
+        name="gluon_dsa_prefill_fp8_dense_gfx950",
+        solution="gluon",
+        capability=CapabilityRequirement(
+            min_arch_version=ArchVersion(9, 5),
+            max_arch_version=ArchVersion(9, 5),
+            vendors=frozenset({"amd"}),
+        ),
+        signatures=frozenset(
+            {
+                format_signature(q=dense_tensor_format(torch.float8_e4m3fn)),
+                format_signature(q=dense_tensor_format(torch.float8_e5m2)),
+            }
+        ),
+        priority=Priority.SPECIALIZED,
+        traits={
+            "page_size": frozenset({64}),
+            "q_len_per_req": frozenset({1}),
+            "qk_nope_head_dim": frozenset({128, 192}),
+            "kv_lora_rank": frozenset({512}),
+            "qk_rope_head_dim": frozenset({64}),
+            "topk": _DSA_PREFILL_TOPK_WIDTHS,
+            "kv_cache_available": frozenset({True}),
+            "sparse_kv_cache_available": frozenset({False}),
+            "topk_layout": frozenset({"global_slots"}),
+            "support_logit_cap": frozenset({False}),
+            "return_lse": frozenset({False}),
+        },
+    )
+    def gluon_dsa_prefill_fp8_dense_gfx950(*args, **kwargs):
         return _dsa_prefill_impl(*args, **kwargs)
 
     @register_kernel(

--- a/tokenspeed-kernel/test/ops/attention/test_gluon_dsa_amd.py
+++ b/tokenspeed-kernel/test/ops/attention/test_gluon_dsa_amd.py
@@ -948,7 +948,15 @@ def _assert_slots_visible(
     "q_dtype",
     [
         pytest.param(torch.bfloat16, id="q_bf16"),
-        pytest.param(torch.float8_e4m3fn, id="q_fp8"),
+        pytest.param(torch.float8_e4m3fn, id="q_e4m3"),
+        pytest.param(
+            torch.float8_e5m2,
+            id="q_e5m2",
+            marks=pytest.mark.skipif(
+                not is_cdna4(),
+                reason="E5M2 DSA support is specific to gfx950",
+            ),
+        ),
     ],
 )
 def test_dsa_with_sparse_kvcache(mode: str, api, q_dtype: torch.dtype) -> None:
@@ -1016,18 +1024,37 @@ def test_dsa_with_sparse_kvcache(mode: str, api, q_dtype: torch.dtype) -> None:
     "q_dtype",
     [
         pytest.param(torch.bfloat16, id="q_bf16"),
-        pytest.param(torch.float8_e4m3fn, id="q_fp8"),
+        pytest.param(torch.float8_e4m3fn, id="q_e4m3"),
+        pytest.param(
+            torch.float8_e5m2,
+            id="q_e5m2",
+            marks=pytest.mark.skipif(
+                not is_cdna4(),
+                reason="E5M2 DSA support is specific to gfx950",
+            ),
+        ),
     ],
 )
-def test_dsa_dense_kvcache(mode: str, api, q_dtype: torch.dtype) -> None:
+@pytest.mark.parametrize(
+    "kv_lora_rank",
+    [
+        pytest.param(128, id="rank_128"),
+        pytest.param(512, id="rank_512"),
+    ],
+)
+def test_dsa_dense_kvcache(
+    mode: str,
+    api,
+    q_dtype: torch.dtype,
+    kv_lora_rank: int,
+) -> None:
     device = "cuda"
     tokens = 3
     num_heads = 2
     num_slots = 16
     topk = 512
-    kv_lora_rank = 128
     qk_rope_head_dim = 64
-    qk_nope_head_dim = 128
+    qk_nope_head_dim = 192 if kv_lora_rank == 512 else 128
     softmax_scale = 1.0 / math.sqrt(qk_nope_head_dim + qk_rope_head_dim)
     q_bf16 = torch.randn(
         tokens,
@@ -1066,6 +1093,93 @@ def test_dsa_dense_kvcache(mode: str, api, q_dtype: torch.dtype) -> None:
         q,
         dequant_latent,
         dequant_rope,
+        topk_slots,
+        topk_lens,
+        softmax_scale,
+    )
+    assert out.shape == (tokens, num_heads, kv_lora_rank)
+    assert out.dtype == torch.bfloat16
+    torch.testing.assert_close(out.float(), ref.float(), rtol=8e-2, atol=8e-2)
+
+
+@pytest.mark.skipif(
+    not is_cdna4(),
+    reason="dense FP8 specialization is specific to the gfx950 implementation",
+)
+@pytest.mark.parametrize(
+    "api",
+    [
+        pytest.param(gluon_dsa_decode, id="decode"),
+        pytest.param(gluon_dsa_prefill, id="prefill"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("valid_lengths", "max_seqlen_k"),
+    [
+        pytest.param((0, 1, 33, 2048), 2112, id="static-full-width"),
+        pytest.param((0, 1, 31, 33), 33, id="dynamic-short-list"),
+    ],
+)
+@pytest.mark.parametrize(
+    "fp8_dtype",
+    [
+        pytest.param(torch.float8_e4m3fn, id="e4m3"),
+        pytest.param(torch.float8_e5m2, id="e5m2"),
+    ],
+)
+def test_dsa_dense_fp8_glm52_production_shape(
+    api,
+    valid_lengths: tuple[int, ...],
+    max_seqlen_k: int,
+    fp8_dtype: torch.dtype,
+) -> None:
+    device = "cuda"
+    tokens = 4
+    num_heads = 16
+    num_slots = 2112
+    topk = 2048
+    kv_lora_rank = 512
+    qk_rope_head_dim = 64
+    qk_nope_head_dim = 192
+    softmax_scale = 1.0 / math.sqrt(qk_nope_head_dim + qk_rope_head_dim)
+    gen = _generator(device, 401)
+
+    q = _randn_bf16(
+        (tokens, num_heads, kv_lora_rank + qk_rope_head_dim),
+        device=device,
+        generator=gen,
+    ).to(fp8_dtype)
+    kv_cache = _randn_bf16(
+        (num_slots, kv_lora_rank + qk_rope_head_dim),
+        device=device,
+        generator=gen,
+    ).to(fp8_dtype)
+    topk_slots = torch.full((tokens, topk), -1, device=device, dtype=torch.int32)
+    topk_lens = torch.tensor(valid_lengths, device=device, dtype=torch.int32)
+    for token, count in enumerate(topk_lens.tolist()):
+        topk_slots[token, :count] = torch.randperm(
+            max_seqlen_k, device=device, generator=gen, dtype=torch.int32
+        )[:count]
+
+    out = api(
+        q=q,
+        kv_cache=kv_cache,
+        sparse_kv_cache=None,
+        topk_slots=topk_slots,
+        topk_lens=topk_lens,
+        max_seqlen_k=max_seqlen_k,
+        qk_nope_head_dim=qk_nope_head_dim,
+        kv_lora_rank=kv_lora_rank,
+        qk_rope_head_dim=qk_rope_head_dim,
+        softmax_scale=softmax_scale,
+        page_size=64,
+        q_len_per_req=4 if api is gluon_dsa_decode else 1,
+    )
+
+    ref = _dsa_reference(
+        q,
+        kv_cache[:, :kv_lora_rank],
+        kv_cache[:, kv_lora_rank:],
         topk_slots,
         topk_lens,
         softmax_scale,

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -1067,6 +1067,87 @@ def _attention_dsa_decode() -> object:
     )
 
 
+def _attention_dsa_decode_fp8_dense_rank128_q4(
+    dtype: torch.dtype = torch.float8_e4m3fn,
+) -> object:
+    q = torch.empty((2, 4, 8, 192), dtype=dtype)
+    kv_cache = torch.empty((64, 192), dtype=dtype)
+    topk_slots = torch.empty((8, 2048), dtype=torch.int32)
+    topk_lens = torch.empty((8,), dtype=torch.int32)
+    return tokenspeed_kernel.dsa_decode(
+        q=q,
+        kv_cache=kv_cache,
+        sparse_kv_cache=None,
+        topk_slots=topk_slots,
+        topk_lens=topk_lens,
+        max_seqlen_k=64,
+        qk_nope_head_dim=128,
+        kv_lora_rank=128,
+        qk_rope_head_dim=64,
+        softmax_scale=1.0,
+        page_size=64,
+        q_len_per_req=4,
+    )
+
+
+def _attention_dsa_decode_fp8_e5m2_dense_rank128_q4() -> object:
+    return _attention_dsa_decode_fp8_dense_rank128_q4(torch.float8_e5m2)
+
+
+def _attention_dsa_decode_fp8_dense_rank512(
+    dtype: torch.dtype = torch.float8_e4m3fn,
+) -> object:
+    q = torch.empty((2, 4, 8, 576), dtype=dtype)
+    kv_cache = torch.empty((64, 576), dtype=dtype)
+    topk_slots = torch.empty((8, 2048), dtype=torch.int32)
+    topk_lens = torch.empty((8,), dtype=torch.int32)
+    return tokenspeed_kernel.dsa_decode(
+        q=q,
+        kv_cache=kv_cache,
+        sparse_kv_cache=None,
+        topk_slots=topk_slots,
+        topk_lens=topk_lens,
+        max_seqlen_k=64,
+        qk_nope_head_dim=192,
+        kv_lora_rank=512,
+        qk_rope_head_dim=64,
+        softmax_scale=1.0,
+        page_size=64,
+        q_len_per_req=4,
+    )
+
+
+def _attention_dsa_decode_fp8_e5m2_dense_rank512() -> object:
+    return _attention_dsa_decode_fp8_dense_rank512(torch.float8_e5m2)
+
+
+def _attention_dsa_decode_fp8_sparse_rank512(
+    dtype: torch.dtype = torch.float8_e4m3fn,
+) -> object:
+    q = torch.empty((2, 4, 8, 576), dtype=dtype)
+    sparse_kv_cache = torch.empty((64, 656), dtype=torch.uint8)
+    topk_slots = torch.empty((8, 2048), dtype=torch.int32)
+    topk_lens = torch.empty((8,), dtype=torch.int32)
+    return tokenspeed_kernel.dsa_decode(
+        q=q,
+        kv_cache=None,
+        sparse_kv_cache=sparse_kv_cache,
+        topk_slots=topk_slots,
+        topk_lens=topk_lens,
+        max_seqlen_k=64,
+        qk_nope_head_dim=192,
+        kv_lora_rank=512,
+        qk_rope_head_dim=64,
+        softmax_scale=1.0,
+        page_size=64,
+        q_len_per_req=4,
+    )
+
+
+def _attention_dsa_decode_fp8_e5m2_sparse_rank512() -> object:
+    return _attention_dsa_decode_fp8_sparse_rank512(torch.float8_e5m2)
+
+
 def _attention_dsa_prefill() -> object:
     q = torch.empty((2, 8, 576), dtype=torch.bfloat16)
     sparse_kv_cache = torch.empty((64, 656), dtype=torch.uint8)
@@ -1087,9 +1168,11 @@ def _attention_dsa_prefill() -> object:
     )
 
 
-def _attention_dsa_prefill_fp8_dense() -> object:
-    q = torch.empty((2, 8, 576), dtype=torch.float8_e4m3fn)
-    kv_cache = torch.empty((64, 576), dtype=torch.float8_e4m3fn)
+def _attention_dsa_prefill_fp8_dense(
+    dtype: torch.dtype = torch.float8_e4m3fn,
+) -> object:
+    q = torch.empty((2, 8, 576), dtype=dtype)
+    kv_cache = torch.empty((64, 576), dtype=dtype)
     topk_slots = torch.empty((2, 1024), dtype=torch.int32)
     topk_lens = torch.empty((2,), dtype=torch.int32)
     return tokenspeed_kernel.dsa_prefill(
@@ -1105,6 +1188,10 @@ def _attention_dsa_prefill_fp8_dense() -> object:
         softmax_scale=1.0,
         page_size=64,
     )
+
+
+def _attention_dsa_prefill_fp8_e5m2_dense() -> object:
+    return _attention_dsa_prefill_fp8_dense(torch.float8_e5m2)
 
 
 def _attention_dsa_decode_fp8_dense_rank128() -> object:
@@ -2333,6 +2420,54 @@ _CASES = [
         _is_cdna4,
         "cdna4",
         "attention",
+        "dsa_decode_fp8_dense_rank128",
+        "gluon_dsa_decode_gfx950",
+        _attention_dsa_decode_fp8_dense_rank128_q4,
+    ),
+    _case(
+        _is_cdna4,
+        "cdna4",
+        "attention",
+        "dsa_decode_fp8_e5m2_dense_rank128",
+        "gluon_dsa_decode_gfx950",
+        _attention_dsa_decode_fp8_e5m2_dense_rank128_q4,
+    ),
+    _case(
+        _is_cdna4,
+        "cdna4",
+        "attention",
+        "dsa_decode_fp8_dense_rank512",
+        "gluon_dsa_decode_gfx950",
+        _attention_dsa_decode_fp8_dense_rank512,
+    ),
+    _case(
+        _is_cdna4,
+        "cdna4",
+        "attention",
+        "dsa_decode_fp8_e5m2_dense_rank512",
+        "gluon_dsa_decode_gfx950",
+        _attention_dsa_decode_fp8_e5m2_dense_rank512,
+    ),
+    _case(
+        _is_cdna4,
+        "cdna4",
+        "attention",
+        "dsa_decode_fp8_sparse_rank512",
+        "gluon_dsa_decode_gfx950",
+        _attention_dsa_decode_fp8_sparse_rank512,
+    ),
+    _case(
+        _is_cdna4,
+        "cdna4",
+        "attention",
+        "dsa_decode_fp8_e5m2_sparse_rank512",
+        "gluon_dsa_decode_gfx950",
+        _attention_dsa_decode_fp8_e5m2_sparse_rank512,
+    ),
+    _case(
+        _is_cdna4,
+        "cdna4",
+        "attention",
         "dsa_prefill",
         "gluon_dsa_prefill_gfx950",
         _attention_dsa_prefill,
@@ -2341,9 +2476,17 @@ _CASES = [
         _is_cdna4,
         "cdna4",
         "attention",
-        "dsa_prefill",
-        "triton_dsa_prefill",
+        "dsa_prefill_fp8_dense_rank512",
+        "gluon_dsa_prefill_fp8_dense_gfx950",
         _attention_dsa_prefill_fp8_dense,
+    ),
+    _case(
+        _is_cdna4,
+        "cdna4",
+        "attention",
+        "dsa_prefill_fp8_e5m2_dense_rank512",
+        "gluon_dsa_prefill_fp8_dense_gfx950",
+        _attention_dsa_prefill_fp8_e5m2_dense,
     ),
     _case(
         _is_cdna4,


### PR DESCRIPTION
GLM 5.2 uses dense FP8 query and key/value data for selected-key attention. The existing AMD tiled path supported BF16 but did not cover the production FP8, rank-512 shape, leaving long-prompt prefill and decode on a slower generic implementation.

Extend the tiled kernel to FP8 with data-type-specific matrix instruction shapes, vector widths, and shared-memory layouts. Register it only for the supported dense FP8 shape so packed sparse and other layouts retain their existing implementations. Bound the tile loop by the valid-entry count when the visible context is shorter than the fixed-width selection buffer, while retaining one tile so zero-entry rows still produce a defined zero output.

Verification on an AMD Instinct MI355X against ToM:
- Eighteen DSA kernel-selection tests passed, and four production-shape GPU tests passed for decode and prefill.
- Decode comparisons covered 0, 1, 31, 32, 33, and 2,048 valid entries. All outputs were finite, the empty case returned zero, and the worst maximum absolute difference from the upstream implementation was 0.03515625.
- The 8,192-query prefill comparison had maximum absolute difference 0.0234375 and mean absolute difference 0.00115871.

Isolated GPU timing after two warmups:
- Decode with 4 valid entries took 21.240 us median over 50 iterations, versus 69.860 us upstream, a 3.29x speedup.
- Decode with 2,048 valid entries took 120.541 us median over 50 iterations, versus 314.823 us upstream, a 2.61x speedup.
- Prefill with 8,192 queries and 2,048 selected entries took 3.815 ms median over 5 iterations, versus 494.874 ms upstream, a 129.72x speedup.