### PR TITLE
[WIP] fix: initialize AMD hipBLASLt on the CUDA graph capture stream

### DIFF
--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -24,12 +24,13 @@ import bisect
 import gc
 import queue
 from collections.abc import Callable
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from typing import TYPE_CHECKING
 
 import torch
 import torch.distributed as dist
 import tqdm
+from tokenspeed_kernel.platform import current_platform
 
 from tokenspeed.runtime.execution.context import ForwardContext
 from tokenspeed.runtime.execution.forward_batch_info import (
@@ -476,16 +477,23 @@ class CudaGraphWrapper:
         global _is_cuda_graph_phase
         _is_cuda_graph_phase = True
 
-        # Warm up before capture.
-        for _ in range(4):
-            torch.cuda.synchronize()
-            dist.barrier()
-            self._prepare_sampling_capture(bs=bs, variant=variant)
-            # Keep warmup seq_lens >= q_len_per_req so no query row gets an
-            # empty causal span; a stale seq_len of 1 overflows to non-finite KV.
-            self.input_buffers.seq_lens_buf[:bs].fill_(self.max_tokens_per_req)
-            self._init_capture_metadata(bs)
-            run_once()
+        # ROCm hipBLASLt handles are cached per (device, stream). Warm the
+        # capture stream so lazy handle setup cannot occur during capture.
+        warmup_context = (  # noqa: E731
+            (lambda: torch.cuda.stream(self.stream))
+            if current_platform().is_amd
+            else nullcontext
+        )
+        with warmup_context():
+            for _ in range(4):
+                torch.cuda.synchronize()
+                dist.barrier()
+                self._prepare_sampling_capture(bs=bs, variant=variant)
+                # Keep warmup seq_lens >= q_len_per_req so no query row gets an
+                # empty causal span; a stale seq_len of 1 overflows to non-finite KV.
+                self.input_buffers.seq_lens_buf[:bs].fill_(self.max_tokens_per_req)
+                self._init_capture_metadata(bs)
+                run_once()
 
         # Clear any per-pool state that warm-up dirtied at pool row 0,
         # so the graph captures reads against a clean baseline.


### PR DESCRIPTION
## Summary

PyTorch 2.13 caches ROCm hipBLASLt handles per device and stream, but TokenSpeed warmed models on the default stream before capturing on self.stream, allowing lazy handle initialization during capture and causing HIP error 900 and hangs. This change uses the TokenSpeed Kernel platform API to run warmup on the capture stream only for AMD, while preserving existing non-AMD behavior through a shared, non-duplicated context factory.

## Test Plan

Reproduced the failure signature in PyTorch 2.13 Inkling and Qwen 4-GPU CI logs, then verified same-stream BF16 hipBLASLt graph capture and replay remotely on MI350 with PyTorch 2.13.0+rocm7.2.
