### PR TITLE
refactor(scheduler): simplify event state dispatch

### DIFF
--- a/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
@@ -29,19 +29,17 @@
 
 namespace tokenspeed::fsm {
 
-template <typename State>
-std::variant<PrefillDone, Prefilling> SchedulePrefillFirstChunkEvent::scheduleFirstChunk(State&& state) {
+State SchedulePrefillFirstChunkEvent::scheduleFirstChunk(TokenContainer* token_container, std::int32_t page_size) {
     _assert(coordinator_ != nullptr, "SchedulePrefillFirstChunkEvent requires a cache coordinator");
     _assert(block_tables_.size() == static_cast<std::size_t>(coordinator_->NumGroups()),
             "SchedulePrefillFirstChunkEvent requires one admitted table per cache group");
 
-    TokenContainer* token_container = state.TokenContainerPtr();
     auto req_pool_index = std::make_unique<ReqPoolIndex>(req_pool_allocator_->Allocate());
     TokenContainer::Window window{.begin = hit_tokens_, .size = tokens_this_round_};
     const bool is_last_chunk = window.begin + window.size == token_container->PrefillSize();
     if (is_last_chunk && source_ == PrefillSource::kLocal) {
         return PrefillDone{token_container,
-                           state.PageSize(),
+                           page_size,
                            std::move(req_pool_index),
                            window,
                            reserve_num_tokens_in_next_schedule_event_,
@@ -49,7 +47,7 @@ std::variant<PrefillDone, Prefilling> SchedulePrefillFirstChunkEvent::scheduleFi
                            std::move(cache_progress_)};
     }
     return Prefilling{token_container,
-                      state.PageSize(),
+                      page_size,
                       std::move(req_pool_index),
                       window,
                       reserve_num_tokens_in_next_schedule_event_,
@@ -58,15 +56,15 @@ std::variant<PrefillDone, Prefilling> SchedulePrefillFirstChunkEvent::scheduleFi
                       source_};
 }
 
-std::variant<PrefillDone, Prefilling> SchedulePrefillFirstChunkEvent::operator()(Submitted&& state) {
-    return scheduleFirstChunk(std::move(state));
+State SchedulePrefillFirstChunkEvent::operator()(Submitted&& state) {
+    return scheduleFirstChunk(state.TokenContainerPtr(), state.PageSize());
 }
 
-std::variant<PrefillDone, Prefilling> SchedulePrefillFirstChunkEvent::operator()(Retracted&& state) {
-    return scheduleFirstChunk(std::move(state));
+State SchedulePrefillFirstChunkEvent::operator()(Retracted&& state) {
+    return scheduleFirstChunk(state.TokenContainerPtr(), state.PageSize());
 }
 
-std::variant<PrefillDone, Prefilling> SchedulePrefillEvent::operator()(Prefilling&& state) {
+State SchedulePrefillEvent::operator()(Prefilling&& state) {
     TokenContainer* token_container = state.TokenContainerPtr();
     const std::int32_t page_size = state.PageSize();
     const PrefillSource source = state.Source();

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.cpp
@@ -29,7 +29,8 @@
 
 namespace tokenspeed::fsm {
 
-State SchedulePrefillFirstChunkEvent::scheduleFirstChunk(TokenContainer* token_container, std::int32_t page_size) {
+std::variant<PrefillDone, Prefilling> SchedulePrefillFirstChunkEvent::scheduleFirstChunk(
+    TokenContainer* token_container, std::int32_t page_size) {
     _assert(coordinator_ != nullptr, "SchedulePrefillFirstChunkEvent requires a cache coordinator");
     _assert(block_tables_.size() == static_cast<std::size_t>(coordinator_->NumGroups()),
             "SchedulePrefillFirstChunkEvent requires one admitted table per cache group");
@@ -56,15 +57,15 @@ State SchedulePrefillFirstChunkEvent::scheduleFirstChunk(TokenContainer* token_c
                       source_};
 }
 
-State SchedulePrefillFirstChunkEvent::operator()(Submitted&& state) {
+std::variant<PrefillDone, Prefilling> SchedulePrefillFirstChunkEvent::operator()(Submitted&& state) {
     return scheduleFirstChunk(state.TokenContainerPtr(), state.PageSize());
 }
 
-State SchedulePrefillFirstChunkEvent::operator()(Retracted&& state) {
+std::variant<PrefillDone, Prefilling> SchedulePrefillFirstChunkEvent::operator()(Retracted&& state) {
     return scheduleFirstChunk(state.TokenContainerPtr(), state.PageSize());
 }
 
-State SchedulePrefillEvent::operator()(Prefilling&& state) {
+std::variant<PrefillDone, Prefilling> SchedulePrefillEvent::operator()(Prefilling&& state) {
     TokenContainer* token_container = state.TokenContainerPtr();
     const std::int32_t page_size = state.PageSize();
     const PrefillSource source = state.Source();

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.h
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.h
@@ -25,7 +25,6 @@
 #include <string>
 #include <type_traits>
 #include <utility>
-#include <variant>
 #include <vector>
 
 #include "cache/coordinator/kv_cache_coordinator.h"
@@ -56,14 +55,15 @@ struct SchedulePrefillFirstChunkEvent : InvalidTransitionHandler<SchedulePrefill
           cache_progress_{std::move(cache_progress)},
           load_pairs_{std::move(load_pairs)} {}
 
-    std::variant<PrefillDone, Prefilling> operator()(Submitted&& state);
-    std::variant<PrefillDone, Prefilling> operator()(Retracted&& state);
+    // Multi-target transitions return the canonical state variant so callers
+    // can consume every event result through the same interface.
+    State operator()(Submitted&& state);
+    State operator()(Retracted&& state);
     std::vector<BlockTransfer> TakeLoadPairs() { return std::exchange(load_pairs_, {}); }
     PrefillSource Source() const { return source_; }
 
 private:
-    template <typename State>
-    std::variant<PrefillDone, Prefilling> scheduleFirstChunk(State&& state);
+    State scheduleFirstChunk(TokenContainer* token_container, std::int32_t page_size);
 
     std::int32_t tokens_this_round_{};
     std::int32_t reserve_num_tokens_in_next_schedule_event_{};
@@ -85,7 +85,7 @@ struct SchedulePrefillEvent : InvalidTransitionHandler<SchedulePrefillEvent> {
           reserve_num_tokens_in_next_schedule_event_{reserve_num_tokens_in_next_schedule_event},
           cache_progress_{std::move(cache_progress)} {}
 
-    std::variant<PrefillDone, Prefilling> operator()(Prefilling&& state);
+    State operator()(Prefilling&& state);
 
 private:
     std::int32_t tokens_this_round_{};

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.h
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "cache/coordinator/kv_cache_coordinator.h"
@@ -55,15 +56,14 @@ struct SchedulePrefillFirstChunkEvent : InvalidTransitionHandler<SchedulePrefill
           cache_progress_{std::move(cache_progress)},
           load_pairs_{std::move(load_pairs)} {}
 
-    // Multi-target transitions return the canonical state variant so callers
-    // can consume every event result through the same interface.
-    State operator()(Submitted&& state);
-    State operator()(Retracted&& state);
+    std::variant<PrefillDone, Prefilling> operator()(Submitted&& state);
+    std::variant<PrefillDone, Prefilling> operator()(Retracted&& state);
     std::vector<BlockTransfer> TakeLoadPairs() { return std::exchange(load_pairs_, {}); }
     PrefillSource Source() const { return source_; }
 
 private:
-    State scheduleFirstChunk(TokenContainer* token_container, std::int32_t page_size);
+    std::variant<PrefillDone, Prefilling> scheduleFirstChunk(TokenContainer* token_container,
+                                                            std::int32_t page_size);
 
     std::int32_t tokens_this_round_{};
     std::int32_t reserve_num_tokens_in_next_schedule_event_{};
@@ -85,7 +85,7 @@ struct SchedulePrefillEvent : InvalidTransitionHandler<SchedulePrefillEvent> {
           reserve_num_tokens_in_next_schedule_event_{reserve_num_tokens_in_next_schedule_event},
           cache_progress_{std::move(cache_progress)} {}
 
-    State operator()(Prefilling&& state);
+    std::variant<PrefillDone, Prefilling> operator()(Prefilling&& state);
 
 private:
     std::int32_t tokens_this_round_{};

--- a/tokenspeed-scheduler/csrc/fsm/states.h
+++ b/tokenspeed-scheduler/csrc/fsm/states.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <utility>
 #include <variant>
 
 #include "fsm/forward_states.h"
@@ -29,5 +30,14 @@
 namespace tokenspeed::fsm {
 
 using State = std::variant<Bootstrapping, Submitted, Prefilling, PrefillDone, Decoding, Retracted, Finished>;
+
+inline State ToState(State state) {
+    return state;
+}
+
+template <typename... StateTs>
+State ToState(std::variant<StateTs...>&& state) {
+    return std::visit([](auto&& inner) -> State { return State{std::move(inner)}; }, std::move(state));
+}
 
 }  // namespace tokenspeed::fsm

--- a/tokenspeed-scheduler/csrc/scheduler/execution_event.h
+++ b/tokenspeed-scheduler/csrc/scheduler/execution_event.h
@@ -29,8 +29,7 @@ namespace tokenspeed {
 
 class ExecutionEvent {
 public:
-    template <typename EventType>
-    ExecutionEvent& With(EventType event) {
+    ExecutionEvent& With(Event event) {
         events_.emplace_back(std::move(event));
         return *this;
     }

--- a/tokenspeed-scheduler/csrc/scheduler/outside_events/inc.h
+++ b/tokenspeed-scheduler/csrc/scheduler/outside_events/inc.h
@@ -30,6 +30,11 @@
 
 namespace tokenspeed {
 
-using Event = std::variant<CacheEvent, ForwardEvent, PDEvent>;
+// Keep concrete events grouped by CacheEvent, ForwardEvent, and PDEvent.
+using Event = std::variant<
+    cache::WriteBackDone, cache::LoadBackDone,
+    forward::ExtendResult, forward::Finish, forward::Abort, forward::UpdateReserveNumTokens,
+    pd::BootstrappedEvent, pd::FailedEvent, pd::SucceededEvent, pd::RemotePrefillDoneEvent
+>;
 
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/csrc/scheduler/request.h
+++ b/tokenspeed-scheduler/csrc/scheduler/request.h
@@ -47,7 +47,7 @@ public:
     void Apply(Event&& event) {
         state_ = std::visit(
             [&event](auto&& state) -> fsm::State {
-                return std::forward<Event>(event)(std::move(state));
+                return fsm::ToState(std::forward<Event>(event)(std::move(state)));
             },
             std::move(state_));
     }

--- a/tokenspeed-scheduler/csrc/scheduler/request.h
+++ b/tokenspeed-scheduler/csrc/scheduler/request.h
@@ -25,7 +25,6 @@
 #include <span>
 #include <stdexcept>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -48,14 +47,7 @@ public:
     void Apply(Event&& event) {
         state_ = std::visit(
             [&event](auto&& state) -> fsm::State {
-                auto result = std::forward<Event>(event)(std::move(state));
-                using Result = std::remove_cvref_t<decltype(result)>;
-                if constexpr (std::is_convertible_v<Result, fsm::State>) {
-                    return fsm::State{std::move(result)};
-                } else {
-                    return std::visit([](auto&& inner) -> fsm::State { return fsm::State{std::move(inner)}; },
-                                      std::move(result));
-                }
+                return std::forward<Event>(event)(std::move(state));
             },
             std::move(state_));
     }

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -451,9 +451,8 @@ ExecutionPlan Scheduler::NextExecutionPlan() {
 }
 
 void Scheduler::Advance(const ExecutionEvent& event) {
-    const auto dispatch = [this](const auto& inner) { handleEvent(inner); };
     for (const auto& item : event.Events()) {
-        std::visit([&](const auto& outer) { std::visit(dispatch, outer); }, item);
+        std::visit([this](const auto& inner) { handleEvent(inner); }, item);
     }
 }
 

--- a/tokenspeed-scheduler/tests/cpp/integration_test_helper.h
+++ b/tokenspeed-scheduler/tests/cpp/integration_test_helper.h
@@ -109,27 +109,27 @@ protected:
 
     void SendWriteBackDone(std::uint32_t op_id) {
         ExecutionEvent event;
-        event.With(CacheEvent{cache::WriteBackDone{
+        event.With(cache::WriteBackDone{
             .op_id = op_id,
-        }});
+        });
         scheduler_->Advance(std::move(event));
     }
 
     void SendLoadBackDone(std::uint32_t op_id) {
         ExecutionEvent event;
-        event.With(CacheEvent{cache::LoadBackDone{
+        event.With(cache::LoadBackDone{
             .op_id = op_id,
-        }});
+        });
         scheduler_->Advance(std::move(event));
     }
 
     // Send ExtendResult (new decode tokens) to the scheduler.
     void SendForwardDone(const std::string& request_id, const std::vector<std::int32_t>& tokens) {
         ExecutionEvent event;
-        event.With(ForwardEvent{forward::ExtendResult{
+        event.With(forward::ExtendResult{
             .request_id = request_id,
             .tokens = tokens,
-        }});
+        });
         scheduler_->Advance(std::move(event));
     }
 
@@ -137,15 +137,15 @@ protected:
     // This triggers FinishEvent: Decoding → Draining (or Finished if no writeback needed).
     void SendFinish(const std::string& request_id) {
         ExecutionEvent event;
-        event.With(ForwardEvent{forward::Finish{
+        event.With(forward::Finish{
             .request_id = request_id,
-        }});
+        });
         scheduler_->Advance(std::move(event));
     }
 
     void SendAbortEvent(const std::string& request_id) {
         ExecutionEvent event;
-        event.With(ForwardEvent{forward::Abort{.request_id = request_id}});
+        event.With(forward::Abort{.request_id = request_id});
         scheduler_->Advance(std::move(event));
     }
 

--- a/tokenspeed-scheduler/tests/cpp/test_kv_cache_scenarios.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_kv_cache_scenarios.cpp
@@ -28,6 +28,7 @@
 #include <set>
 #include <sstream>
 #include <stdexcept>
+#include <type_traits>
 #include <utility>
 
 #include <spdlog/sinks/ostream_sink.h>
@@ -40,6 +41,16 @@
 namespace tokenspeed::test {
 
 namespace {
+
+static_assert(std::is_same_v<decltype(std::declval<fsm::SchedulePrefillFirstChunkEvent&>()(
+                                 std::declval<fsm::Submitted&&>())),
+                             fsm::State>);
+static_assert(std::is_same_v<decltype(std::declval<fsm::SchedulePrefillFirstChunkEvent&>()(
+                                 std::declval<fsm::Retracted&&>())),
+                             fsm::State>);
+static_assert(std::is_same_v<decltype(std::declval<fsm::SchedulePrefillEvent&>()(
+                                 std::declval<fsm::Prefilling&&>())),
+                             fsm::State>);
 
 std::pair<bool, std::string> ClearL1CacheWithCapturedLog(Scheduler* scheduler) {
     std::ostringstream output;
@@ -806,7 +817,7 @@ namespace {
 
 void SendAbort(Scheduler& scheduler, const std::string& id) {
     ExecutionEvent event;
-    event.With(ForwardEvent{forward::Abort{.request_id = id}});
+    event.With(forward::Abort{.request_id = id});
     scheduler.Advance(std::move(event));
 }
 

--- a/tokenspeed-scheduler/tests/cpp/test_kv_cache_scenarios.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_kv_cache_scenarios.cpp
@@ -44,13 +44,13 @@ namespace {
 
 static_assert(std::is_same_v<decltype(std::declval<fsm::SchedulePrefillFirstChunkEvent&>()(
                                  std::declval<fsm::Submitted&&>())),
-                             fsm::State>);
+                             std::variant<fsm::PrefillDone, fsm::Prefilling>>);
 static_assert(std::is_same_v<decltype(std::declval<fsm::SchedulePrefillFirstChunkEvent&>()(
                                  std::declval<fsm::Retracted&&>())),
-                             fsm::State>);
+                             std::variant<fsm::PrefillDone, fsm::Prefilling>>);
 static_assert(std::is_same_v<decltype(std::declval<fsm::SchedulePrefillEvent&>()(
                                  std::declval<fsm::Prefilling&&>())),
-                             fsm::State>);
+                             std::variant<fsm::PrefillDone, fsm::Prefilling>>);
 
 std::pair<bool, std::string> ClearL1CacheWithCapturedLog(Scheduler* scheduler) {
     std::ostringstream output;

--- a/tokenspeed-scheduler/tests/cpp/test_outside_event_handler.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_outside_event_handler.cpp
@@ -22,6 +22,18 @@
 
 namespace tokenspeed::test {
 
+TEST(ExecutionEventTest, StoresConcreteEventsInInsertionOrder) {
+    ExecutionEvent event;
+    event.With(cache::WriteBackDone{.op_id = 7})
+        .With(forward::Abort{.request_id = "r0"})
+        .With(pd::BootstrappedEvent{"r1"});
+
+    ASSERT_EQ(event.Events().size(), 3u);
+    EXPECT_TRUE(std::holds_alternative<cache::WriteBackDone>(event.Events()[0]));
+    EXPECT_TRUE(std::holds_alternative<forward::Abort>(event.Events()[1]));
+    EXPECT_TRUE(std::holds_alternative<pd::BootstrappedEvent>(event.Events()[2]));
+}
+
 inline const ForwardBatch* FindForwardBatch(const std::vector<Operation>& operations) {
     for (const auto& operation : operations) {
         if (auto* batch = std::get_if<ForwardBatch>(&operation)) {
@@ -140,13 +152,13 @@ protected:
 
     void SendBootstrapped(const std::string& request_id) {
         ExecutionEvent event;
-        event.With(PDEvent{pd::BootstrappedEvent{request_id}});
+        event.With(pd::BootstrappedEvent{request_id});
         scheduler_->Advance(std::move(event));
     }
 
     void SendRemotePrefillDone(const std::string& request_id, std::int32_t bootstrap_token) {
         ExecutionEvent event;
-        event.With(PDEvent{pd::RemotePrefillDoneEvent{request_id, bootstrap_token}});
+        event.With(pd::RemotePrefillDoneEvent{request_id, bootstrap_token});
         scheduler_->Advance(std::move(event));
     }
 };
@@ -689,7 +701,7 @@ TEST_F(PdSparseDecodeAdmissionTestSuite, MaterializesHistoryAndLatestStateSnapsh
     EXPECT_EQ(decode->block_tables, destination->block_tables);
 
     ExecutionEvent succeeded;
-    succeeded.With(PDEvent{pd::SucceededEvent{"r0"}});
+    succeeded.With(pd::SucceededEvent{"r0"});
     scheduler_->Advance(succeeded);
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), 6);
 }
@@ -717,7 +729,7 @@ TEST_F(PdSparseDecodeAdmissionTestSuite, ReusesHistoryPrefixAndLeavesStatePrefix
     PlanOnce();
 
     ExecutionEvent succeeded;
-    succeeded.With(PDEvent{pd::SucceededEvent{"r0"}});
+    succeeded.With(pd::SucceededEvent{"r0"});
     scheduler_->Advance(succeeded);
 
     Submit({MakeRequestSpec("r1", /*num_pages=*/4, /*start=*/1)});


### PR DESCRIPTION
Return the canonical FSM state from multi-target prefill transitions and flatten scheduler execution events so dispatch needs only one visit.

Kimi k3 model was run for verification.
